### PR TITLE
support startAt time for jobs

### DIFF
--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -26,7 +26,6 @@ import (
 	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/smartcontractkit/chainlink/web"
 	"github.com/stretchr/testify/assert"
-	null "gopkg.in/guregu/null.v3"
 )
 
 const RootDir = "/tmp/chainlink_test"
@@ -255,8 +254,4 @@ func ParseResponseBody(resp *http.Response) []byte {
 		log.Fatal(err)
 	}
 	return b
-}
-
-func NullableTime(t time.Time) null.Time {
-	return null.Time{Time: t, Valid: true}
 }

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -26,6 +26,7 @@ import (
 	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/smartcontractkit/chainlink/web"
 	"github.com/stretchr/testify/assert"
+	null "gopkg.in/guregu/null.v3"
 )
 
 const RootDir = "/tmp/chainlink_test"
@@ -254,4 +255,8 @@ func ParseResponseBody(resp *http.Response) []byte {
 		log.Fatal(err)
 	}
 	return b
+}
+
+func NullableTime(t time.Time) null.Time {
+	return null.Time{Time: t, Valid: true}
 }

--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -120,20 +120,6 @@ func UseSettableClock(s *store.Store) *SettableClock {
 	return clock
 }
 
-type InstantClock struct{}
-
-func (InstantClock) After(_ time.Duration) <-chan time.Time {
-	c := make(chan time.Time, 100)
-	c <- time.Now()
-	return c
-}
-
-type NeverClock struct{}
-
-func (NeverClock) After(_ time.Duration) <-chan time.Time {
-	return make(chan time.Time)
-}
-
 type SettableClock struct {
 	time time.Time
 }
@@ -147,4 +133,32 @@ func (clock *SettableClock) Now() time.Time {
 
 func (clock *SettableClock) SetTime(t time.Time) {
 	clock.time = t
+}
+
+func (*SettableClock) After(_ time.Duration) <-chan time.Time {
+	channel := make(chan time.Time, 1)
+	channel <- time.Now()
+	return channel
+}
+
+type InstantClock struct{}
+
+func (InstantClock) Now() time.Time {
+	return time.Now()
+}
+
+func (InstantClock) After(_ time.Duration) <-chan time.Time {
+	c := make(chan time.Time, 100)
+	c <- time.Now()
+	return c
+}
+
+type NeverClock struct{}
+
+func (NeverClock) After(_ time.Duration) <-chan time.Time {
+	return make(chan time.Time)
+}
+
+func (NeverClock) Now() time.Time {
+	return time.Now()
 }

--- a/internal/fixtures/web/start_at_job.json
+++ b/internal/fixtures/web/start_at_job.json
@@ -1,5 +1,5 @@
 {
   "initiators": [ { "type": "web" } ],
   "tasks": [ { "type": "NoOp" } ],
-  "endAt": "3000-01-01T00:00:00.000Z"
+  "startAt": "3000-01-01T00:00:00.000Z"
 }

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -18,8 +18,12 @@ func BeginRun(job *models.Job, store *store.Store) (*models.JobRun, error) {
 }
 
 func BuildRun(job *models.Job, store *store.Store) (*models.JobRun, error) {
-	if job.Ended(store.Clock.Now()) {
-		return nil, fmt.Errorf("NewRun: %v past Job's EndAt(%v)", store.Clock.Now(), job.EndAt)
+	now := store.Clock.Now()
+	if !job.Started(now) {
+		return nil, fmt.Errorf("BeginRun: %v before job's start time(%v)", now, job.StartAt)
+	}
+	if job.Ended(now) {
+		return nil, fmt.Errorf("BeginRun: %v past job's end time(%v)", now, job.EndAt)
 	}
 	return job.NewRun(), nil
 }

--- a/services/job_runner_test.go
+++ b/services/job_runner_test.go
@@ -46,8 +46,8 @@ func TestJobTransitionToPending(t *testing.T) {
 func TestJobRunnerBeginRun(t *testing.T) {
 	t.Parallel()
 
-	pastTime := null.Time{Time: utils.ParseISO8601("2000-01-01T00:00:00.000Z"), Valid: true}
-	futureTime := null.Time{Time: utils.ParseISO8601("3000-01-01T00:00:00.000Z"), Valid: true}
+	pastTime := utils.ParseNullableTime("2000-01-01T00:00:00.000Z")
+	futureTime := utils.ParseNullableTime("3000-01-01T00:00:00.000Z")
 	nullTime := null.Time{Valid: false}
 
 	tests := []struct {
@@ -92,8 +92,8 @@ func TestJobRunnerBeginRun(t *testing.T) {
 func TestJobRunnerBuildRun(t *testing.T) {
 	t.Parallel()
 
-	pastTime := null.Time{Time: utils.ParseISO8601("2000-01-01T00:00:00.000Z"), Valid: true}
-	futureTime := null.Time{Time: utils.ParseISO8601("3000-01-01T00:00:00.000Z"), Valid: true}
+	pastTime := utils.ParseNullableTime("2000-01-01T00:00:00.000Z")
+	futureTime := utils.ParseNullableTime("3000-01-01T00:00:00.000Z")
 	nullTime := null.Time{Valid: false}
 
 	tests := []struct {

--- a/services/scheduler.go
+++ b/services/scheduler.go
@@ -23,7 +23,7 @@ func NewScheduler(store *store.Store) *Scheduler {
 		Recurring: &Recurring{store: store},
 		OneTime: &OneTime{
 			Store: store,
-			Clock: Clock{},
+			Clock: store.Clock,
 		},
 		store: store,
 	}
@@ -113,12 +113,6 @@ func (r *Recurring) addResumer() {
 
 type Afterer interface {
 	After(d time.Duration) <-chan time.Time
-}
-
-type Clock struct{}
-
-func (Clock) After(d time.Duration) <-chan time.Time {
-	return time.After(d)
 }
 
 type OneTime struct {

--- a/services/scheduler_test.go
+++ b/services/scheduler_test.go
@@ -129,7 +129,7 @@ func TestSchedulerAddingUnstartedJob(t *testing.T) {
 
 	startAt := utils.ParseISO8601("3000-01-01T00:00:00.000Z")
 	j := cltest.NewJobWithSchedule("* * * * *")
-	j.StartAt = cltest.NullableTime(startAt)
+	j.StartAt = utils.NullableTime(startAt)
 	assert.Nil(t, store.Save(j))
 
 	sched := services.NewScheduler(store)

--- a/services/scheduler_test.go
+++ b/services/scheduler_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -116,4 +117,36 @@ func TestOneTimeRunJobAt(t *testing.T) {
 	jobRuns := []models.JobRun{}
 	assert.Nil(t, store.Where("JobID", j.ID, &jobRuns))
 	assert.Equal(t, 0, len(jobRuns))
+}
+
+func TestSchedulerAddingUnstartedJob(t *testing.T) {
+	t.Parallel()
+	RegisterTestingT(t)
+
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+	clock := cltest.UseSettableClock(store)
+
+	startAt := utils.ParseISO8601("3000-01-01T00:00:00.000Z")
+	j := cltest.NewJobWithSchedule("* * * * *")
+	j.StartAt = cltest.NullableTime(startAt)
+	assert.Nil(t, store.Save(j))
+
+	sched := services.NewScheduler(store)
+	assert.Nil(t, sched.Start())
+
+	sched.AddJob(j)
+	Consistently(func() int {
+		runs, err := store.JobRunsFor(j)
+		assert.Nil(t, err)
+		return len(runs)
+	}).Should(Equal(0))
+
+	clock.SetTime(startAt)
+
+	Eventually(func() int {
+		runs, err := store.JobRunsFor(j)
+		assert.Nil(t, err)
+		return len(runs)
+	}).Should(Equal(2))
 }

--- a/store/models/job.go
+++ b/store/models/job.go
@@ -65,18 +65,18 @@ func (j *Job) WebAuthorized() bool {
 	return false
 }
 
-func (j *Job) Ended(now time.Time) bool {
+func (j *Job) Ended(t time.Time) bool {
 	if !j.EndAt.Valid {
 		return false
 	}
-	return now.After(j.EndAt.Time)
+	return t.After(j.EndAt.Time)
 }
 
-func (j *Job) Started(now time.Time) bool {
+func (j *Job) Started(t time.Time) bool {
 	if !j.StartAt.Valid {
 		return true
 	}
-	return now.After(j.StartAt.Time) || now.Equal(j.StartAt.Time)
+	return t.After(j.StartAt.Time) || t.Equal(j.StartAt.Time)
 }
 
 type Initiator struct {

--- a/store/models/job.go
+++ b/store/models/job.go
@@ -20,6 +20,7 @@ type Job struct {
 	ID         string      `storm:"id,index,unique"`
 	Initiators []Initiator `json:"initiators"`
 	Tasks      []Task      `json:"tasks" storm:"inline"`
+	StartAt    null.Time   `storm:"index"`
 	EndAt      null.Time   `storm:"index"`
 	CreatedAt  Time        `storm:"index"`
 }
@@ -69,6 +70,13 @@ func (j *Job) Ended(now time.Time) bool {
 		return false
 	}
 	return now.After(j.EndAt.Time)
+}
+
+func (j *Job) Started(now time.Time) bool {
+	if !j.StartAt.Valid {
+		return true
+	}
+	return now.After(j.StartAt.Time) || now.Equal(j.StartAt.Time)
 }
 
 type Initiator struct {

--- a/store/models/job_test.go
+++ b/store/models/job_test.go
@@ -43,8 +43,7 @@ func TestJobNewRun(t *testing.T) {
 func TestJobEnded(t *testing.T) {
 	t.Parallel()
 
-	endAt := utils.ParseISO8601("3000-01-01T00:00:00.000Z")
-	endAtNullable := null.Time{Time: endAt, Valid: true}
+	endAt := utils.ParseNullableTime("3000-01-01T00:00:00.000Z")
 
 	tests := []struct {
 		name    string
@@ -52,10 +51,10 @@ func TestJobEnded(t *testing.T) {
 		current time.Time
 		want    bool
 	}{
-		{"no end at", null.Time{Valid: false}, endAt, false},
-		{"before end at", endAtNullable, endAt.Add(-time.Nanosecond), false},
-		{"at end at", endAtNullable, endAt, false},
-		{"after end at", endAtNullable, endAt.Add(time.Nanosecond), true},
+		{"no end at", null.Time{Valid: false}, endAt.Time, false},
+		{"before end at", endAt, endAt.Time.Add(-time.Nanosecond), false},
+		{"at end at", endAt, endAt.Time, false},
+		{"after end at", endAt, endAt.Time.Add(time.Nanosecond), true},
 	}
 
 	for _, test := range tests {
@@ -71,8 +70,7 @@ func TestJobEnded(t *testing.T) {
 func TestJobStarted(t *testing.T) {
 	t.Parallel()
 
-	startAt := utils.ParseISO8601("3000-01-01T00:00:00.000Z")
-	startAtNullable := null.Time{Time: startAt, Valid: true}
+	startAt := utils.ParseNullableTime("3000-01-01T00:00:00.000Z")
 
 	tests := []struct {
 		name    string
@@ -80,10 +78,10 @@ func TestJobStarted(t *testing.T) {
 		current time.Time
 		want    bool
 	}{
-		{"no start at", null.Time{Valid: false}, startAt, true},
-		{"before start at", startAtNullable, startAt.Add(-time.Nanosecond), false},
-		{"at start at", startAtNullable, startAt, true},
-		{"after start at", startAtNullable, startAt.Add(time.Nanosecond), true},
+		{"no start at", null.Time{Valid: false}, startAt.Time, true},
+		{"before start at", startAt, startAt.Time.Add(-time.Nanosecond), false},
+		{"at start at", startAt, startAt.Time, true},
+		{"after start at", startAt, startAt.Time.Add(time.Nanosecond), true},
 	}
 
 	for _, test := range tests {

--- a/store/models/job_test.go
+++ b/store/models/job_test.go
@@ -67,3 +67,31 @@ func TestJobEnded(t *testing.T) {
 		})
 	}
 }
+
+func TestJobStarted(t *testing.T) {
+	t.Parallel()
+
+	startAt := utils.ParseISO8601("3000-01-01T00:00:00.000Z")
+	startAtNullable := null.Time{Time: startAt, Valid: true}
+
+	tests := []struct {
+		name    string
+		startAt null.Time
+		current time.Time
+		want    bool
+	}{
+		{"no start at", null.Time{Valid: false}, startAt, true},
+		{"before start at", startAtNullable, startAt.Add(-time.Nanosecond), false},
+		{"at start at", startAtNullable, startAt, true},
+		{"after start at", startAtNullable, startAt.Add(time.Nanosecond), true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			job := cltest.NewJob()
+			job.StartAt = test.startAt
+
+			assert.Equal(t, test.want, job.Started(test.current))
+		})
+	}
+}

--- a/store/store.go
+++ b/store/store.go
@@ -14,7 +14,7 @@ import (
 type Store struct {
 	*models.ORM
 	Config    Config
-	Clock     Timer
+	Clock     AfterNower
 	Exiter    func(int)
 	KeyStore  *KeyStore
 	TxManager *TxManager
@@ -58,7 +58,8 @@ func (s *Store) Start() {
 	}()
 }
 
-type Timer interface {
+type AfterNower interface {
+	After(d time.Duration) <-chan time.Time
 	Now() time.Time
 }
 
@@ -66,4 +67,8 @@ type Clock struct{}
 
 func (Clock) Now() time.Time {
 	return time.Now()
+}
+
+func (Clock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
+	null "gopkg.in/guregu/null.v3"
 )
 
 func SenderFromTxHex(value string, chainID uint64) (common.Address, error) {
@@ -106,4 +107,12 @@ func ParseISO8601(s string) time.Time {
 		panic(err)
 	}
 	return t
+}
+
+func NullableTime(t time.Time) null.Time {
+	return null.Time{Time: t, Valid: true}
+}
+
+func ParseNullableTime(s string) null.Time {
+	return NullableTime(ParseISO8601(s))
 }


### PR DESCRIPTION
Adds startAt field to job and constrains it from being run. Also consolidates the scheduler's clock to use the store's clock.