### PR TITLE
standardize "chainlink" as one word

### DIFF
--- a/adapters/doc.go
+++ b/adapters/doc.go
@@ -1,4 +1,4 @@
-// Package adapters contains the core adapters used by the ChainLink node.
+// Package adapters contains the core adapters used by the Chainlink node.
 //
 // HttpGet
 //

--- a/services/application.go
+++ b/services/application.go
@@ -54,7 +54,7 @@ func (app *ChainlinkApplication) Stop() error {
 	return app.Store.Close()
 }
 
-// GetStore returns the pointer to the store for the ChainLinkApplication.
+// GetStore returns the pointer to the store for the ChainlinkApplication.
 func (app *ChainlinkApplication) GetStore() *store.Store {
 	return app.Store
 }

--- a/services/doc.go
+++ b/services/doc.go
@@ -1,11 +1,11 @@
-// Package services contain the key components of the ChainLink
+// Package services contain the key components of the Chainlink
 // node. This includes the Application, JobRunner, LogListener,
 // and Scheduler.
 //
 // Application
 //
 // The Application is the main component used for starting and
-// stopping the ChainLink node.
+// stopping the Chainlink node.
 //
 // JobRunner
 //

--- a/solidity/contracts/Chainlink.sol
+++ b/solidity/contracts/Chainlink.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.4.18;
 
 import "solidity-stringutils/strings.sol";
 
-library ChainLink {
+library Chainlink {
   using strings for *;
 
   struct Run {

--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -1,11 +1,11 @@
 pragma solidity ^0.4.18;
 
 import "./Oracle.sol";
-import "./ChainLink.sol";
+import "./Chainlink.sol";
 
 
-contract ChainLinked {
-  using ChainLink for ChainLink.Run;
+contract Chainlinked {
+  using Chainlink for Chainlink.Run;
 
   Oracle internal oracle;
 
@@ -13,15 +13,15 @@ contract ChainLinked {
     bytes32 _jobId,
     address _cbReceiver,
     string _cbSignature
-  ) internal returns (ChainLink.Run) {
-    ChainLink.Run memory run;
+  ) internal returns (Chainlink.Run) {
+    Chainlink.Run memory run;
     run.jobId = _jobId;
     run.receiver = _cbReceiver;
     run.functionHash = bytes4(keccak256(_cbSignature));
     return run;
   }
 
-  function chainlinkRequest(ChainLink.Run _run) internal returns(uint256) {
+  function chainlinkRequest(Chainlink.Run _run) internal returns(uint256) {
     return oracle.requestData(_run.jobId, _run.receiver, _run.functionHash, _run.close());
   }
 

--- a/solidity/test/Chainlinked_test.js
+++ b/solidity/test/Chainlinked_test.js
@@ -2,11 +2,11 @@
 
 require('./support/helpers.js')
 
-contract('ChainLinked', () => {
+contract('Chainlinked', () => {
   let Oracle = artifacts.require("./contracts/Oracle.sol");
-  let ChainLinked = artifacts.require("./contracts/ChainLinked.sol");
+  let Chainlinked = artifacts.require("./contracts/Chainlinked.sol");
 
   it("has a limited public interface", () => {
-    checkPublicABI(ChainLinked, []);
+    checkPublicABI(Chainlinked, []);
   });
 });

--- a/solidity/test/contracts/DynamicConsumer.sol
+++ b/solidity/test/contracts/DynamicConsumer.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.4.18;
 
-import "../../contracts/ChainLinked.sol";
+import "../../contracts/Chainlinked.sol";
 import "../../contracts/Oracle.sol";
 
-contract DynamicConsumer is ChainLinked {
+contract DynamicConsumer is Chainlinked {
   uint256 private nonce;
   bytes32 public currentPrice;
 
@@ -12,7 +12,7 @@ contract DynamicConsumer is ChainLinked {
   }
 
   function requestEthereumPrice(string _currency) public {
-    ChainLink.Run memory run = newRun("someJobId", this, "fulfill(uint256,bytes32)");
+    Chainlink.Run memory run = newRun("someJobId", this, "fulfill(uint256,bytes32)");
     run.add("url", "https://etherprice.com/api");
     string[] memory path = new string[](2);
     path[0] = "recent";

--- a/solidity/test/contracts/SimpleConsumer.sol
+++ b/solidity/test/contracts/SimpleConsumer.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.4.18;
 
-import "../../contracts/ChainLinked.sol";
+import "../../contracts/Chainlinked.sol";
 import "../../contracts/Oracle.sol";
 
-contract SimpleConsumer is ChainLinked {
+contract SimpleConsumer is Chainlinked {
   uint256 private nonce;
   bytes32 public currentPrice;
 


### PR DESCRIPTION
In marketing can it may be capitalized differently, but in code it should be unambiguously one word.