### PR TITLE
README.md - Fixed different URLs in examples.

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,11 +154,3 @@ And the node will log the following:
 ```shell
 {"level":"info","ts":1518531822.179224,"caller":"web/router.go:50","msg":"Web request","method":"POST","status":200,"path":"/v2/bridge_types","query":"","body":"{\"name\":\"randomNumber\",\"url\":\"http://localhost:3000/randomNumber\"}","clientIP":"127.0.0.1","comment":"","servedAt":"2018/02/13 - 14:23:42","latency":"1.623398ms"}
 ```
-
-### Running Geth
-
-Replace 172.31.27.77 with the IP address for Geth to listen on.
-
-```shell
-geth --fast --ws --wsaddr 172.31.27.77 --wsport 8546 --wsorigins "*"
-```


### PR DESCRIPTION
Needed to make a quick change for the example URLs I provided in the External Adapter section ~~and added a small section giving an example of how to run the Geth node with websockets enabled~~.

I'm not sure if I want to have the example for Geth show everything on localhost or not. Ideally a proper setup should have the Geth instance running on a separate machine. Would like your opinions on this.