### PR TITLE
Use `make install` for getting started installation step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
 .DEFAULT_GOAL := build
-.PHONY: build
+.PHONY: dep build install
 
 LDFLAGS=-ldflags "-X github.com/smartcontractkit/chainlink/store.Sha=`git rev-parse HEAD`"
 
-build:
+dep:
 	@dep ensure
+
+build: dep
 	@go build $(LDFLAGS) -o chainlink
+
+install: dep
+	@go install $(LDFLAGS)

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Examples of how to utilize and integrate Chainlinks can be found in our [Hello C
 1. [Install Go 1.9+](https://golang.org/doc/install#install), and add your GOPATH's [bin directory to your PATH](https://golang.org/doc/code.html#GOPATH)
 2. Install [dep](https://github.com/golang/dep#installation): `$ brew install dep` <br> or `$ go get -u github.com/golang/dep/cmd/dep`
 3. Clone ChainLink: `$ git clone https://github.com/smartcontractkit/chainlink.git`
-4. Build the project: `$ make`
-5. Run the node: `$ ./chainlink help`
+4. Install the project: `$ make install`
+5. Run the node: `$ chainlink help`
 
 ### Ethereum Node Requirements
 


### PR DESCRIPTION
This will place the `chainlink` binary in $GOPATH/bin rather than in the repo directory. Makes the installation step more convenient for non dev use.

@thodges-gh please take a pass and let me know what you think. Merge away if it's good.