### PR TITLE
Update README install instructions back to go get.

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Examples of how to utilize and integrate Chainlinks can be found in our [Hello C
 
 1. [Install Go 1.9+](https://golang.org/doc/install#install), and add your GOPATH's [bin directory to your PATH](https://golang.org/doc/code.html#GOPATH)
 2. Install [dep](https://github.com/golang/dep#installation): `$ brew install dep` <br> or `$ go get -u github.com/golang/dep/cmd/dep`
-3. Install ChainLink: `$ go get github.com/smartcontractkit/chainlink`
-4. Install dependencies: `$ make install` in the `chainlink/` folder
+3. Download ChainLink: `$ go get -d github.com/smartcontractkit/chainlink`
+4. Install: `$ make install` in the `chainlink/` folder
 5. Run the node: `$ chainlink help`
 
 ### Ethereum Node Requirements

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Examples of how to utilize and integrate Chainlinks can be found in our [Hello C
 
 1. [Install Go 1.9+](https://golang.org/doc/install#install), and add your GOPATH's [bin directory to your PATH](https://golang.org/doc/code.html#GOPATH)
 2. Install [dep](https://github.com/golang/dep#installation): `$ brew install dep` <br> or `$ go get -u github.com/golang/dep/cmd/dep`
-3. Download ChainLink: `$ go get -d github.com/smartcontractkit/chainlink`
-4. Install: `$ make install` in the `chainlink/` folder
+3. Download ChainLink: `$ go get -d github.com/smartcontractkit/chainlink && cd $GOPATH/src/github.com/smartcontractkit/chainlink`
+4. Install: `$ make install`
 5. Run the node: `$ chainlink help`
 
 ### Ethereum Node Requirements

--- a/README.md
+++ b/README.md
@@ -15,8 +15,8 @@ Examples of how to utilize and integrate Chainlinks can be found in our [Hello C
 
 1. [Install Go 1.9+](https://golang.org/doc/install#install), and add your GOPATH's [bin directory to your PATH](https://golang.org/doc/code.html#GOPATH)
 2. Install [dep](https://github.com/golang/dep#installation): `$ brew install dep` <br> or `$ go get -u github.com/golang/dep/cmd/dep`
-3. Clone ChainLink: `$ git clone https://github.com/smartcontractkit/chainlink.git`
-4. Install the project: `$ make install`
+3. Install ChainLink: `$ go get github.com/smartcontractkit/chainlink`
+4. Install dependencies: `$ make install` in the `chainlink/` folder
 5. Run the node: `$ chainlink help`
 
 ### Ethereum Node Requirements


### PR DESCRIPTION
Tested on a fresh build, we can install using `go get`. One caveat is the machine will need `gcc` installed in order for go-ethereum/crypto/secp256k1 to build. I think I'll gather all the required dependencies for a development environment and put it in the Developer Tips wiki page.