### PR TITLE
Added format directives for Errorf lines.

### DIFF
--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -90,7 +90,7 @@ func (mock *EthMock) Call(result interface{}, method string, args ...interface{}
 				reflect.Indirect(ref).Set(reflect.ValueOf(resp.response))
 				if resp.callback != nil {
 					if err := resp.callback(result, args); err != nil {
-						return fmt.Errorf("ethMock Error:", err)
+						return fmt.Errorf("ethMock Error: %v", err)
 					}
 				}
 				return nil

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -182,7 +182,7 @@ func (rr RunResult) SetError(err error) {
 // GetError returns the error of a RunResult if it is present.
 func (rr RunResult) GetError() error {
 	if rr.HasError() {
-		return fmt.Errorf("Run Result: ", rr.Error())
+		return fmt.Errorf("Run Result: %v", rr.Error())
 	} else {
 		return nil
 	}


### PR DESCRIPTION
Reported on Gitter by Ahmad:
```
/run.go:185: Errorf call has arguments but no formatting directives
```
Also found another instance of the same issue in mocks.go.