### PR TITLE
Two minor linting adjustments

### DIFF
--- a/adapters/adapter.go
+++ b/adapters/adapter.go
@@ -19,13 +19,13 @@ type Adapter interface {
 func For(task models.Task, store *store.Store) (ac Adapter, err error) {
 	switch strings.ToLower(task.Type) {
 	case "httpget":
-		ac = &HttpGet{}
+		ac = &HTTPGet{}
 		err = unmarshalParams(task.Params, ac)
 	case "httppost":
-		ac = &HttpPost{}
+		ac = &HTTPPost{}
 		err = unmarshalParams(task.Params, ac)
 	case "jsonparse":
-		ac = &JsonParse{}
+		ac = &JSONParse{}
 		err = unmarshalParams(task.Params, ac)
 	case "ethbytes32":
 		ac = &EthBytes32{}

--- a/adapters/doc.go
+++ b/adapters/doc.go
@@ -1,19 +1,19 @@
 // Package adapters contain the core adapters used by the Chainlink node.
 //
-// HttpGet
+// HTTPGet
 //
-// The HttpGet adapter is used to grab the JSON data from the given URL.
-//  { "type": "HttpGet", "url": "https://some-api-example.net/api" }
+// The HTTPGet adapter is used to grab the JSON data from the given URL.
+//  { "type": "HTTPGet", "url": "https://some-api-example.net/api" }
 //
-// HttpPost
+// HTTPPost
 //
 // Sends a POST request to the specified URL and will return the response.
-//  { "type": "HttpPost", "url": "https://weiwatchers.com/api" }
+//  { "type": "HTTPPost", "url": "https://weiwatchers.com/api" }
 //
-// JsonParse
+// JSONParse
 //
-// The JsonParse adapter will obtain the value(s) for the given field(s).
-//  { "type": "JsonParse", "path": ["someField"] }
+// The JSONParse adapter will obtain the value(s) for the given field(s).
+//  { "type": "JSONParse", "path": ["someField"] }
 //
 // EthBytes32
 //

--- a/adapters/http.go
+++ b/adapters/http.go
@@ -10,14 +10,14 @@ import (
 	"github.com/smartcontractkit/chainlink/store/models"
 )
 
-// HttpGet requires a URL which is used for a GET request when the adapter is called.
-type HttpGet struct {
+// HTTPGet requires a URL which is used for a GET request when the adapter is called.
+type HTTPGet struct {
 	URL models.WebURL `json:"url"`
 }
 
 // Perform ensures that the adapter's URL responds to a GET request without
 // errors and returns the response body as the "value" field of the result.
-func (hga *HttpGet) Perform(input models.RunResult, _ *store.Store) models.RunResult {
+func (hga *HTTPGet) Perform(input models.RunResult, _ *store.Store) models.RunResult {
 	response, err := http.Get(hga.URL.String())
 	if err != nil {
 		return input.WithError(err)
@@ -38,14 +38,14 @@ func (hga *HttpGet) Perform(input models.RunResult, _ *store.Store) models.RunRe
 	return input.WithValue(body)
 }
 
-// HttpPost requires a URL which is used for a POST request when the adapter is called.
-type HttpPost struct {
+// HTTPPost requires a URL which is used for a POST request when the adapter is called.
+type HTTPPost struct {
 	URL models.WebURL `json:"url"`
 }
 
 // Perform ensures that the adapter's URL responds to a POST request without
 // errors and returns the response body as the "value" field of the result.
-func (hga *HttpPost) Perform(input models.RunResult, _ *store.Store) models.RunResult {
+func (hga *HTTPPost) Perform(input models.RunResult, _ *store.Store) models.RunResult {
 	reqBody := bytes.NewBufferString(input.Data.String())
 	response, err := http.Post(hga.URL.String(), "application/json", reqBody)
 	if err != nil {

--- a/adapters/http.go
+++ b/adapters/http.go
@@ -45,9 +45,9 @@ type HTTPPost struct {
 
 // Perform ensures that the adapter's URL responds to a POST request without
 // errors and returns the response body as the "value" field of the result.
-func (hga *HTTPPost) Perform(input models.RunResult, _ *store.Store) models.RunResult {
+func (hpa *HTTPPost) Perform(input models.RunResult, _ *store.Store) models.RunResult {
 	reqBody := bytes.NewBufferString(input.Data.String())
-	response, err := http.Post(hga.URL.String(), "application/json", reqBody)
+	response, err := http.Post(hpa.URL.String(), "application/json", reqBody)
 	if err != nil {
 		return input.WithError(err)
 	}

--- a/adapters/http_test.go
+++ b/adapters/http_test.go
@@ -14,8 +14,8 @@ func TestHttpAdapters_NotAUrlError(t *testing.T) {
 		name    string
 		adapter adapters.Adapter
 	}{
-		{"HttpGet", &adapters.HttpGet{URL: cltest.MustParseWebURL("NotAURL")}},
-		{"HttpPost", &adapters.HttpGet{URL: cltest.MustParseWebURL("NotAURL")}},
+		{"HTTPGet", &adapters.HTTPGet{URL: cltest.MustParseWebURL("NotAURL")}},
+		{"HTTPPost", &adapters.HttpGet{URL: cltest.MustParseWebURL("NotAURL")}},
 	}
 
 	for _, tt := range tests {
@@ -53,7 +53,7 @@ func TestHttpGet_Perform(t *testing.T) {
 				func(body string) { assert.Equal(t, ``, body) })
 			defer cleanup()
 
-			hga := adapters.HttpGet{URL: cltest.MustParseWebURL(mock.URL)}
+			hga := adapters.HTTPGet{URL: cltest.MustParseWebURL(mock.URL)}
 			result := hga.Perform(input, nil)
 
 			val, err := result.Value()
@@ -90,7 +90,7 @@ func TestHttpPost_Perform(t *testing.T) {
 				func(body string) { assert.Equal(t, wantedBody, body) })
 			defer cleanup()
 
-			hpa := adapters.HttpPost{URL: cltest.MustParseWebURL(mock.URL)}
+			hpa := adapters.HTTPPost{URL: cltest.MustParseWebURL(mock.URL)}
 			result := hpa.Perform(input, nil)
 
 			val, err := result.Get("value")

--- a/adapters/http_test.go
+++ b/adapters/http_test.go
@@ -15,7 +15,7 @@ func TestHttpAdapters_NotAUrlError(t *testing.T) {
 		adapter adapters.Adapter
 	}{
 		{"HTTPGet", &adapters.HTTPGet{URL: cltest.MustParseWebURL("NotAURL")}},
-		{"HTTPPost", &adapters.HttpGet{URL: cltest.MustParseWebURL("NotAURL")}},
+		{"HTTPPost", &adapters.HTTPPost{URL: cltest.MustParseWebURL("NotAURL")}},
 	}
 
 	for _, tt := range tests {

--- a/adapters/json_parse.go
+++ b/adapters/json_parse.go
@@ -10,9 +10,9 @@ import (
 	"github.com/smartcontractkit/chainlink/store/models"
 )
 
-// JsonParse holds a path to the desired field in a JSON object,
+// JSONParse holds a path to the desired field in a JSON object,
 // made up of an array of strings.
-type JsonParse struct {
+type JSONParse struct {
 	Path []string `json:"path"`
 }
 
@@ -28,7 +28,7 @@ type JsonParse struct {
 //   }
 //
 // Then ["0","last"] would be the path, and "111" would be the returned value
-func (jpa *JsonParse) Perform(input models.RunResult, _ *store.Store) models.RunResult {
+func (jpa *JSONParse) Perform(input models.RunResult, _ *store.Store) models.RunResult {
 	val, err := input.Value()
 	if err != nil {
 		return input.WithError(err)

--- a/adapters/json_parse_test.go
+++ b/adapters/json_parse_test.go
@@ -34,7 +34,7 @@ func TestJsonParse_Perform(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			input := cltest.RunResultWithValue(test.value)
-			adapter := adapters.JsonParse{Path: test.path}
+			adapter := adapters.JSONParse{Path: test.path}
 			result := adapter.Perform(input, nil)
 			assert.Equal(t, test.want, result.Data.String())
 

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -21,7 +21,7 @@ func TestRunNode(t *testing.T) {
 	client := cmd.Client{
 		r,
 		app.Store.Config,
-		cltest.InstanceAppFactory{app},
+		cltest.InstanceAppFactory{App: app},
 		auth,
 		cltest.EmptyRunner{}}
 

--- a/main.go
+++ b/main.go
@@ -66,7 +66,7 @@ func NewProductionClient() *cmd.Client {
 		cmd.RendererTable{os.Stdout},
 		store.NewConfig(),
 		cmd.ChainlinkAppFactory{},
-		cmd.TerminalAuthenticator{cmd.PasswordPrompter{}, os.Exit},
+		cmd.TerminalAuthenticator{Prompter: cmd.PasswordPrompter{}, Exiter: os.Exit},
 		cmd.ChainlinkRunner{},
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -15,7 +15,7 @@ func ExampleRun_Help() {
 		cmd.RendererTable{ioutil.Discard},
 		tc.Config,
 		cmd.ChainlinkAppFactory{},
-		cmd.TerminalAuthenticator{&cltest.MockCountingPrompt{}, os.Exit},
+		cmd.TerminalAuthenticator{Prompter: &cltest.MockCountingPrompt{}, Exiter: os.Exit},
 		cmd.ChainlinkRunner{},
 	}
 

--- a/services/subscription_test.go
+++ b/services/subscription_test.go
@@ -31,7 +31,7 @@ func TestServices_RpcLogEvent_RunLogJSON(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			le := services.RpcLogEvent{Log: test.el}
+			le := services.RPCLogEvent{Log: test.el}
 			output, err := le.RunLogJSON()
 			assert.JSONEq(t, strings.ToLower(test.wantData.String()), strings.ToLower(output.String()))
 			assert.Equal(t, test.wantErrored, (err != nil))
@@ -55,7 +55,7 @@ func TestServices_RpcLogEvent_EthLogJSON(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			le := services.RpcLogEvent{Log: test.el}
+			le := services.RPCLogEvent{Log: test.el}
 			output, err := le.EthLogJSON()
 			assert.JSONEq(t, strings.ToLower(test.wantData.String()), strings.ToLower(output.String()))
 			assert.Equal(t, test.wantErrored, (err != nil))

--- a/web/jobs_controller.go
+++ b/web/jobs_controller.go
@@ -35,18 +35,18 @@ func (jrc *JobsController) Index(c *gin.Context) {
 // Create adds the Jobs to the given context.
 // Example:
 //  "<application>/jobs"
-func (jc *JobsController) Create(c *gin.Context) {
+func (jrc *JobsController) Create(c *gin.Context) {
 	j := models.NewJob()
 
 	if err := c.ShouldBindJSON(&j); err != nil {
 		c.JSON(500, gin.H{
 			"errors": []string{err.Error()},
 		})
-	} else if err = adapters.Validate(j, jc.App.Store); err != nil {
+	} else if err = adapters.Validate(j, jrc.App.Store); err != nil {
 		c.JSON(500, gin.H{
 			"errors": []string{err.Error()},
 		})
-	} else if err = jc.App.AddJob(j); err != nil {
+	} else if err = jrc.App.AddJob(j); err != nil {
 		c.JSON(500, gin.H{
 			"errors": []string{err.Error()},
 		})
@@ -58,9 +58,9 @@ func (jc *JobsController) Create(c *gin.Context) {
 // Show returns the details of a job if it exists.
 // Example:
 //  "<application>/jobs/:JobID"
-func (jc *JobsController) Show(c *gin.Context) {
+func (jrc *JobsController) Show(c *gin.Context) {
 	id := c.Param("JobID")
-	if j, err := jc.App.Store.FindJob(id); err == storm.ErrNotFound {
+	if j, err := jrc.App.Store.FindJob(id); err == storm.ErrNotFound {
 		c.JSON(404, gin.H{
 			"errors": []string{"Job not found."},
 		})
@@ -68,7 +68,7 @@ func (jc *JobsController) Show(c *gin.Context) {
 		c.JSON(500, gin.H{
 			"errors": []string{err.Error()},
 		})
-	} else if runs, err := jc.App.Store.JobRunsFor(j.ID); err != nil {
+	} else if runs, err := jrc.App.Store.JobRunsFor(j.ID); err != nil {
 		c.JSON(500, gin.H{
 			"errors": []string{err.Error()},
 		})

--- a/web/jobs_controller.go
+++ b/web/jobs_controller.go
@@ -17,9 +17,9 @@ type JobsController struct {
 // Index adds the root of the Jobs to the given context.
 // Example:
 //  "<application>/jobs"
-func (jrc *JobsController) Index(c *gin.Context) {
+func (jc *JobsController) Index(c *gin.Context) {
 	var jobs []models.Job
-	if err := jrc.App.Store.AllByIndex("CreatedAt", &jobs); err != nil {
+	if err := jc.App.Store.AllByIndex("CreatedAt", &jobs); err != nil {
 		c.JSON(500, gin.H{
 			"errors": []string{err.Error()},
 		})
@@ -35,18 +35,18 @@ func (jrc *JobsController) Index(c *gin.Context) {
 // Create adds the Jobs to the given context.
 // Example:
 //  "<application>/jobs"
-func (jrc *JobsController) Create(c *gin.Context) {
+func (jc *JobsController) Create(c *gin.Context) {
 	j := models.NewJob()
 
 	if err := c.ShouldBindJSON(&j); err != nil {
 		c.JSON(500, gin.H{
 			"errors": []string{err.Error()},
 		})
-	} else if err = adapters.Validate(j, jrc.App.Store); err != nil {
+	} else if err = adapters.Validate(j, jc.App.Store); err != nil {
 		c.JSON(500, gin.H{
 			"errors": []string{err.Error()},
 		})
-	} else if err = jrc.App.AddJob(j); err != nil {
+	} else if err = jc.App.AddJob(j); err != nil {
 		c.JSON(500, gin.H{
 			"errors": []string{err.Error()},
 		})
@@ -58,9 +58,9 @@ func (jrc *JobsController) Create(c *gin.Context) {
 // Show returns the details of a job if it exists.
 // Example:
 //  "<application>/jobs/:JobID"
-func (jrc *JobsController) Show(c *gin.Context) {
+func (jc *JobsController) Show(c *gin.Context) {
 	id := c.Param("JobID")
-	if j, err := jrc.App.Store.FindJob(id); err == storm.ErrNotFound {
+	if j, err := jc.App.Store.FindJob(id); err == storm.ErrNotFound {
 		c.JSON(404, gin.H{
 			"errors": []string{"Job not found."},
 		})
@@ -68,7 +68,7 @@ func (jrc *JobsController) Show(c *gin.Context) {
 		c.JSON(500, gin.H{
 			"errors": []string{err.Error()},
 		})
-	} else if runs, err := jrc.App.Store.JobRunsFor(j.ID); err != nil {
+	} else if runs, err := jc.App.Store.JobRunsFor(j.ID); err != nil {
 		c.JSON(500, gin.H{
 			"errors": []string{err.Error()},
 		})

--- a/web/jobs_controller_test.go
+++ b/web/jobs_controller_test.go
@@ -44,11 +44,11 @@ func TestJobsController_Create(t *testing.T) {
 	j := cltest.FixtureCreateJobViaWeb(t, app, "../internal/fixtures/web/hello_world_job.json")
 
 	adapter1, _ := adapters.For(j.Tasks[0], app.Store)
-	httpGet := adapter1.(*adapters.HttpGet)
+	httpGet := adapter1.(*adapters.HTTPGet)
 	assert.Equal(t, httpGet.URL.String(), "https://bitstamp.net/api/ticker/")
 
 	adapter2, _ := adapters.For(j.Tasks[1], app.Store)
-	jsonParse := adapter2.(*adapters.JsonParse)
+	jsonParse := adapter2.(*adapters.JSONParse)
 	assert.Equal(t, jsonParse.Path, []string{"last"})
 
 	adapter4, _ := adapters.For(j.Tasks[3], app.Store)
@@ -69,11 +69,11 @@ func TestJobsController_Create_CaseInsensitiveTypes(t *testing.T) {
 	j := cltest.FixtureCreateJobViaWeb(t, app, "../internal/fixtures/web/caseinsensitive_hello_world_job.json")
 
 	adapter1, _ := adapters.For(j.Tasks[0], app.Store)
-	httpGet := adapter1.(*adapters.HttpGet)
+	httpGet := adapter1.(*adapters.HTTPGet)
 	assert.Equal(t, httpGet.URL.String(), "https://bitstamp.net/api/ticker/")
 
 	adapter2, _ := adapters.For(j.Tasks[1], app.Store)
-	jsonParse := adapter2.(*adapters.JsonParse)
+	jsonParse := adapter2.(*adapters.JSONParse)
 	assert.Equal(t, jsonParse.Path, []string{"last"})
 
 	assert.Equal(t, "ethbytes32", j.Tasks[2].Type)


### PR DESCRIPTION
-  `cmd/client_test.go`,  `main.go`, and `main_test.go` had a few instances of unkeyed fields in composite literals. This is a non-issue if the `InstanceAppFactory` and `TerminalAuthenticator` structs are never expanded, but if additional fields are ever added to the structs then unkeyed initilizations may break.
 
- I noticed that the method receivers for `Create(c *gin.Context)` and `Show(c *gin.Context)` in `web/jobs_controller.go` were different from the receiver for `Index(c *gin.Context)`, despite referring to the same `JobsController` struct. I've adjusted these for the sake of consistency.