### PR TITLE
Multiplier adapter accepts strings

### DIFF
--- a/adapters/multiply.go
+++ b/adapters/multiply.go
@@ -30,21 +30,31 @@ func (ma *Multiply) Perform(input models.RunResult, _ *store.Store) models.RunRe
 		return input.WithError(fmt.Errorf("cannot parse into big.Float: %v", val.String()))
 	}
 
+	times, err := ma.timesToFloat()
+	if err != nil {
+		return input.WithError(err)
+	}
+
+	res := i.Mul(i, big.NewFloat(times))
+	return input.WithValue(res.String())
+}
+
+// timesToFloat returns `Times` field value as float64
+func (ma *Multiply) timesToFloat() (float64, error) {
 	switch times := ma.Times.(type) {
 	case int:
-		res := i.Mul(i, big.NewFloat(float64(times)))
-		return input.WithValue(res.String())
-
+		return float64(times), nil
+	case int64:
+		return float64(times), nil
+	case float64:
+		return times, nil
 	case string:
 		timesInt, err := strconv.Atoi(times)
 		if err != nil {
-			return input.WithError(fmt.Errorf("cannot parse into int: %v", times))
+			return 0, fmt.Errorf("cannot parse into int: %v", times)
 		}
-
-		res := i.Mul(i, big.NewFloat(float64(timesInt)))
-		return input.WithValue(res.String())
-
+		return float64(timesInt), nil
 	default:
-		return input.WithError(fmt.Errorf("wrong type of the multiplier: %v", times))
+		return 0, fmt.Errorf("wrong type of the multiplier: %v", times)
 	}
 }

--- a/adapters/multiply_test.go
+++ b/adapters/multiply_test.go
@@ -27,6 +27,7 @@ func TestMultiply_Perform(t *testing.T) {
 		{"string_object", "100", `{"value":{"foo":"bar"}}`, "", true},
 		{"rubbish_string", "123aaa123", `{"value":"1.23"}`, "", true},
 		{"slice_string", []int{1, 2, 3}, `{"value":"1.23"}`, "", true},
+		{"float_string", 100.0, `{"value":"1.23"}`, "123", false},
 	}
 
 	for _, tt := range tests {

--- a/adapters/multiply_test.go
+++ b/adapters/multiply_test.go
@@ -23,6 +23,8 @@ func TestMultiply_Perform(t *testing.T) {
 		{"integer", `{"times":100}`, `{"value":123}`, "12300", false, false},
 		{"float", `{"times":100}`, `{"value":1.23}`, "123", false, false},
 		{"object", `{"times":100}`, `{"value":{"foo":"bar"}}`, "", true, false},
+		{"zero_integer_string", `{"times":0}`, `{"value":"1.23"}`, "0", false, false},
+		{"negative_integer_string", `{"times":-5}`, `{"value":"1.23"}`, "-6.15", false, false},
 
 		{"string_string", `{"times":"100"}`, `{"value":"1.23"}`, "123", false, false},
 		{"string_integer", `{"times":"100"}`, `{"value":123}`, "12300", false, false},
@@ -30,6 +32,8 @@ func TestMultiply_Perform(t *testing.T) {
 		{"string_object", `{"times":"100"}`, `{"value":{"foo":"bar"}}`, "", true, false},
 		{"array_string", `{"times":[1, 2, 3]}`, `{"value":"1.23"}`, "", false, true},
 		{"rubbish_string", `{"times":"123aaa123"}`, `{"value":"1.23"}`, "", false, true},
+		{"zero_string_string", `{"times":"0"}`, `{"value":"1.23"}`, "0", false, false},
+		{"negative_string_string", `{"times":"-5"}`, `{"value":"1.23"}`, "-6.15", false, false},
 	}
 
 	for _, tt := range tests {

--- a/adapters/multiply_test.go
+++ b/adapters/multiply_test.go
@@ -1,6 +1,7 @@
 package adapters_test
 
 import (
+	"encoding/json"
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/adapters"
@@ -11,23 +12,24 @@ import (
 
 func TestMultiply_Perform(t *testing.T) {
 	tests := []struct {
-		name    string
-		times   interface{}
-		json    string
-		want    string
-		errored bool
+		name      string
+		params    string
+		json      string
+		want      string
+		errored   bool
+		jsonError bool
 	}{
-		{"string", 100, `{"value":"1.23"}`, "123", false},
-		{"integer", 100, `{"value":123}`, "12300", false},
-		{"float", 100, `{"value":1.23}`, "123", false},
-		{"object", 100, `{"value":{"foo":"bar"}}`, "", true},
-		{"string_string", "100", `{"value":"1.23"}`, "123", false},
-		{"string_integer", "100", `{"value":123}`, "12300", false},
-		{"string_float", "100", `{"value":1.23}`, "123", false},
-		{"string_object", "100", `{"value":{"foo":"bar"}}`, "", true},
-		{"rubbish_string", "123aaa123", `{"value":"1.23"}`, "", true},
-		{"slice_string", []int{1, 2, 3}, `{"value":"1.23"}`, "", true},
-		{"float_string", 100.0, `{"value":"1.23"}`, "123", false},
+		{"string", `{"times":100}`, `{"value":"1.23"}`, "123", false, false},
+		{"integer", `{"times":100}`, `{"value":123}`, "12300", false, false},
+		{"float", `{"times":100}`, `{"value":1.23}`, "123", false, false},
+		{"object", `{"times":100}`, `{"value":{"foo":"bar"}}`, "", true, false},
+
+		{"string_string", `{"times":"100"}`, `{"value":"1.23"}`, "123", false, false},
+		{"string_integer", `{"times":"100"}`, `{"value":123}`, "12300", false, false},
+		{"string_float", `{"times":"100"}`, `{"value":1.23}`, "123", false, false},
+		{"string_object", `{"times":"100"}`, `{"value":{"foo":"bar"}}`, "", true, false},
+		{"array_string", `{"times":[1, 2, 3]}`, `{"value":"1.23"}`, "", false, true},
+		{"rubbish_string", `{"times":"123aaa123"}`, `{"value":"1.23"}`, "", false, true},
 	}
 
 	for _, tt := range tests {
@@ -37,16 +39,21 @@ func TestMultiply_Perform(t *testing.T) {
 			input := models.RunResult{
 				Data: cltest.JSONFromString(test.json),
 			}
-			adapter := adapters.Multiply{Times: test.times}
+			adapter := adapters.Multiply{}
+			jsonErr := json.Unmarshal([]byte(test.params), &adapter)
 			result := adapter.Perform(input, nil)
 
-			if test.errored {
+			if test.jsonError {
+				assert.NotNil(t, jsonErr)
+			} else if test.errored {
 				assert.NotNil(t, result.GetError())
+				assert.Nil(t, jsonErr)
 			} else {
 				val, err := result.Value()
 				assert.Nil(t, err)
 				assert.Equal(t, test.want, val)
 				assert.Nil(t, result.GetError())
+				assert.Nil(t, jsonErr)
 			}
 		})
 	}

--- a/adapters/multiply_test.go
+++ b/adapters/multiply_test.go
@@ -12,7 +12,7 @@ import (
 func TestMultiply_Perform(t *testing.T) {
 	tests := []struct {
 		name    string
-		times   int64
+		times   interface{}
 		json    string
 		want    string
 		errored bool
@@ -21,6 +21,12 @@ func TestMultiply_Perform(t *testing.T) {
 		{"integer", 100, `{"value":123}`, "12300", false},
 		{"float", 100, `{"value":1.23}`, "123", false},
 		{"object", 100, `{"value":{"foo":"bar"}}`, "", true},
+		{"string_string", "100", `{"value":"1.23"}`, "123", false},
+		{"string_integer", "100", `{"value":123}`, "12300", false},
+		{"string_float", "100", `{"value":1.23}`, "123", false},
+		{"string_object", "100", `{"value":{"foo":"bar"}}`, "", true},
+		{"rubbish_string", "123aaa123", `{"value":"1.23"}`, "", true},
+		{"slice_string", []int{1, 2, 3}, `{"value":"1.23"}`, "", true},
 	}
 
 	for _, tt := range tests {

--- a/internal/fixtures/web/uint256_string_times_job.json
+++ b/internal/fixtures/web/uint256_string_times_job.json
@@ -1,0 +1,9 @@
+{
+  "initiators": [{ "type": "web" }],
+  "tasks": [
+    { "type": "HttpGet", "url": "https://bitstamp.net/api/ticker/" },
+    { "type": "JsonParse", "path": ["last"] },
+    { "type": "Multiply", "times": "100" },
+    { "type": "EthUint256" }
+  ]
+}

--- a/web/integration_test.go
+++ b/web/integration_test.go
@@ -345,3 +345,25 @@ func TestIntegration_MultiplierUint256(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, "0x00000000000000000000000000000000000000000000000000000000000f98b2", val)
 }
+
+func TestIntegration_MultiplierUint256String(t *testing.T) {
+	gock.EnableNetworking()
+	defer cltest.CloseGock(t)
+
+	app, cleanup := cltest.NewApplication()
+	defer cleanup()
+	app.Start()
+
+	gock.New("https://bitstamp.net").
+		Get("/api/ticker").
+		Reply(200).
+		JSON(`{"last": "10221.30"}`)
+
+	j := cltest.FixtureCreateJobViaWeb(t, app, "../internal/fixtures/web/uint256_string_times_job.json")
+	jr := cltest.CreateJobRunViaWeb(t, app, j)
+	jr = cltest.WaitForJobRunToComplete(t, app.Store, jr)
+
+	val, err := jr.Result.Value()
+	assert.Nil(t, err)
+	assert.Equal(t, "0x00000000000000000000000000000000000000000000000000000000000f98b2", val)
+}


### PR DESCRIPTION
Resolves #139

Not sure if a case for `int64` is also necessary.