### PR TITLE
Renames contract variables so that there is a consistent naming convention among several contracts

### DIFF
--- a/solidity/contracts/Chainlink.sol
+++ b/solidity/contracts/Chainlink.sol
@@ -8,8 +8,8 @@ library Chainlink {
   struct Run {
     string payload;
     bytes32 jobId;
-    address receiver;
-    bytes4 functionSelector;
+    address callbackAddress;
+    bytes4 callbackFunctionId;
   }
 
   function add(Run self, string _key, string _value) internal {

--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -11,19 +11,19 @@ contract Chainlinked {
 
   function newRun(
     bytes32 _jobId,
-    address _cbReceiver,
-    string _cbSignature
+    address _callbackAddress,
+    string _callbackFunctionSignature
   ) internal returns (Chainlink.Run) {
     Chainlink.Run memory run;
     run.jobId = _jobId;
-    run.receiver = _cbReceiver;
-    run.functionSelector = bytes4(keccak256(_cbSignature));
+    run.callbackAddress = _callbackAddress;
+    run.callbackFunctionId = bytes4(keccak256(_callbackFunctionSignature));
     return run;
   }
 
   function chainlinkRequest(Chainlink.Run _run) internal returns(uint256) {
     return oracle.requestData(
-      _run.jobId, _run.receiver, _run.functionSelector, _run.close());
+      _run.jobId, _run.callbackAddress, _run.callbackFunctionId, _run.close());
   }
 
   function setOracle(address _oracle) internal {

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -6,7 +6,7 @@ contract Oracle is Ownable {
 
   struct Callback {
     address addr;
-    bytes4 fid;
+    bytes4 functionId;
   }
 
   uint256 private requestId;
@@ -21,15 +21,15 @@ contract Oracle is Ownable {
   function requestData(
     bytes32 _jobId,
     address _callbackAddress,
-    bytes4 _callbackFID,
+    bytes4 _callbackFunctionId,
     string _data
   )
     public
     returns (uint256)
   {
     requestId += 1;
-    Callback memory cb = Callback(_callbackAddress, _callbackFID);
-    callbacks[requestId] = cb;
+    Callback memory callback = Callback(_callbackAddress, _callbackFunctionId);
+    callbacks[requestId] = callback;
     Request(requestId, _jobId, _data);
     return requestId;
   }
@@ -39,8 +39,8 @@ contract Oracle is Ownable {
     onlyOwner
     hasRequestId(_requestId)
   {
-    Callback memory cb = callbacks[_requestId];
-    require(cb.addr.call(cb.fid, _requestId, _data));
+    Callback memory callback = callbacks[_requestId];
+    require(callback.addr.call(callback.functionId, _requestId, _data));
     delete callbacks[_requestId];
   }
 

--- a/solidity/contracts/examples/SimpleConsumer.sol
+++ b/solidity/contracts/examples/SimpleConsumer.sol
@@ -11,9 +11,9 @@ contract SimpleConsumer is Chainlinked {
   }
 
   function requestEthereumPrice() public {
-    var fid = bytes4(keccak256("fulfill(uint256,bytes32)"));
+    var functionId = bytes4(keccak256("fulfill(uint256,bytes32)"));
     var data = '{"url":"https://etherprice.com/api","path":["recent","usd"]}';
-    requestId = oracle.requestData("someJobId", this, fid, data);
+    requestId = oracle.requestData("someJobId", this, functionId, data);
   }
 
   function fulfill(uint256 _requestId, bytes32 _data)


### PR DESCRIPTION
The status quo is that several variable names allude to exactly the same thing:

    ex: _cbReceiver, reciever, _callbackAddress  -> callback address
    ex: functionSelector, _callbackFID  -> callback function id

This commit:
1. Duplicates variable names among several contracts for callback address and callback function id, so that there is consistency amongst contracts
2. Renames FID to functionId since FID is not descriptive enough
3. Renames cb -> callback since cb is not descriptive enough