### PR TITLE
Log Link balance on startup

### DIFF
--- a/adapters/eth_format.go
+++ b/adapters/eth_format.go
@@ -13,9 +13,6 @@ import (
 // EthBytes32 holds no fields.
 type EthBytes32 struct{}
 
-const evmWordByteLen = 32
-const evmWordHexLen = evmWordByteLen * 2
-
 // Perform returns the hex value of the first 32 bytes of a string
 // so that it is in the proper format to be written to the blockchain.
 //
@@ -28,11 +25,11 @@ func (*EthBytes32) Perform(input models.RunResult, _ *store.Store) models.RunRes
 		return input.WithError(err)
 	}
 
-	value := common.RightPadBytes([]byte(result.String()), evmWordByteLen)
+	value := common.RightPadBytes([]byte(result.String()), utils.EVMWordByteLen)
 	hex := utils.RemoveHexPrefix(common.ToHex(value))
 
-	if len(hex) > evmWordHexLen {
-		hex = hex[:evmWordHexLen]
+	if len(hex) > utils.EVMWordHexLen {
+		hex = hex[:utils.EVMWordHexLen]
 	}
 	return input.WithValue(utils.AddHexPrefix(hex))
 }
@@ -61,7 +58,7 @@ func (*EthUint256) Perform(input models.RunResult, _ *store.Store) models.RunRes
 	if err != nil {
 		return input.WithError(err)
 	}
-	padded := common.LeftPadBytes(b, evmWordByteLen)
+	padded := common.LeftPadBytes(b, utils.EVMWordByteLen)
 
 	return input.WithValue(common.ToHex(padded))
 }
@@ -75,8 +72,8 @@ func bigToUintHex(f *big.Float) string {
 	if len(hex)%2 != 0 {
 		hex = "0" + hex
 	}
-	if len(hex) > evmWordHexLen {
-		hex = hex[len(hex)-evmWordHexLen:]
+	if len(hex) > utils.EVMWordHexLen {
+		hex = hex[len(hex)-utils.EVMWordHexLen:]
 	}
 	return hex
 }

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -50,6 +50,9 @@ func logNodeBalance(store *strpkg.Store) {
 	balance, err := presenters.ShowEthBalance(store)
 	logger.WarnIf(err)
 	logger.Infow(balance)
+	balance, err = presenters.ShowLinkBalance(store)
+	logger.WarnIf(err)
+	logger.Infow(balance)
 }
 
 // ShowJobSpec returns the status of the given JobID.

--- a/store/config.go
+++ b/store/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	EthGasBumpThreshold uint64   `env:"ETH_GAS_BUMP_THRESHOLD" envDefault:"12"`
 	EthGasBumpWei       big.Int  `env:"ETH_GAS_BUMP_WEI" envDefault:"5000000000"`
 	EthGasPriceDefault  big.Int  `env:"ETH_GAS_PRICE_DEFAULT" envDefault:"20000000000"`
+	LinkContractAddress string   `env:"LINK_CONTRACT_ADDRESS" envDefault:"0x514910771AF9Ca656af840dff83E8264EcF986CA"`
 }
 
 // NewConfig returns the config with the environment variables set to their

--- a/store/config_test.go
+++ b/store/config_test.go
@@ -4,6 +4,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common"
 	strpkg "github.com/smartcontractkit/chainlink/store"
 	"github.com/stretchr/testify/assert"
 )
@@ -12,4 +13,5 @@ func TestStore_ConfigDefaults(t *testing.T) {
 	config := strpkg.NewConfig()
 	assert.Equal(t, uint64(0), config.ChainID)
 	assert.Equal(t, *big.NewInt(20000000000), config.EthGasPriceDefault)
+	assert.Equal(t, "0x514910771AF9Ca656af840dff83E8264EcF986CA", common.HexToAddress(config.LinkContractAddress).String())
 }

--- a/store/eth_client.go
+++ b/store/eth_client.go
@@ -54,6 +54,30 @@ func (eth *EthClient) GetEthBalance(address common.Address) (float64, error) {
 	return utils.WeiToEth(numWei), nil
 }
 
+func (eth *EthClient) GetERC20Balance(address common.Address, contractAddress common.Address) (*big.Int, error) {
+	type callArgs struct {
+		To common.Address `json:"to"`
+		Data hexutil.Bytes `json:"data"`
+	}
+	result := ""
+	numLinkBigInt := new(big.Int)
+	functionSelector := models.HexToFunctionSelector("0x70a08231") // balanceOf(address)
+	data, err := utils.HexToBytes(functionSelector.String(), common.ToHex(common.LeftPadBytes(address.Bytes(), utils.EVMWordByteLen)))
+	if err != nil {
+		return nil, err
+	}
+	args := callArgs {
+		To:   contractAddress,
+		Data: data,
+	}
+	err = eth.Call(&result, "eth_call", args, "latest")
+	if err != nil {
+		return numLinkBigInt, err
+	}
+	numLinkBigInt.SetString(result, 0)
+	return numLinkBigInt, nil
+}
+
 // SendRawTx sends a signed transaction to the transaction pool.
 func (eth *EthClient) SendRawTx(hex string) (common.Hash, error) {
 	result := common.Hash{}

--- a/store/eth_client.go
+++ b/store/eth_client.go
@@ -56,8 +56,8 @@ func (eth *EthClient) GetEthBalance(address common.Address) (float64, error) {
 
 func (eth *EthClient) GetERC20Balance(address common.Address, contractAddress common.Address) (*big.Int, error) {
 	type callArgs struct {
-		To common.Address `json:"to"`
-		Data hexutil.Bytes `json:"data"`
+		To   common.Address `json:"to"`
+		Data hexutil.Bytes  `json:"data"`
 	}
 	result := ""
 	numLinkBigInt := new(big.Int)
@@ -66,7 +66,7 @@ func (eth *EthClient) GetERC20Balance(address common.Address, contractAddress co
 	if err != nil {
 		return nil, err
 	}
-	args := callArgs {
+	args := callArgs{
 		To:   contractAddress,
 		Data: data,
 	}

--- a/store/eth_client_test.go
+++ b/store/eth_client_test.go
@@ -3,6 +3,8 @@ package store_test
 import (
 	"testing"
 
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/stretchr/testify/assert"
@@ -59,7 +61,7 @@ func TestEthClient_SendRawTx(t *testing.T) {
 	assert.Equal(t, result, common.Hash{1})
 }
 
-func TestEthGetBalance(t *testing.T) {
+func TestEthClient_GetEthBalance(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithKeyStore()
 	defer cleanup()
 
@@ -73,9 +75,31 @@ func TestEthGetBalance(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expected, result)
 
-	ethMock.Register("eth_getBalance", "0x4b3b4ca85a86c4000000000000000000") // 1e38
+	ethMock.Register("eth_getBalance", "0x4b3b4ca85a86c47a098a224000000000") // 1e38
 	result, err = ethClientObject.GetEthBalance(cltest.NewAddress())
 	expected = 1e20
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+}
+
+func TestEthClient_GetERC20Balance(t *testing.T) {
+	app, cleanup := cltest.NewApplicationWithKeyStore()
+	defer cleanup()
+
+	ethMock := app.MockEthClient()
+	ethClientObject := app.Store.TxManager.EthClient
+
+	ethMock.Register("eth_call", "0x0100") // 256
+	result, err := ethClientObject.GetERC20Balance(cltest.NewAddress(), cltest.NewAddress())
+	assert.Nil(t, err)
+	expected := big.NewInt(256)
+	assert.Nil(t, err)
+	assert.Equal(t, expected, result)
+
+	ethMock.Register("eth_call", "0x4b3b4ca85a86c47a098a224000000000") // 1e38
+	result, err = ethClientObject.GetERC20Balance(cltest.NewAddress(), cltest.NewAddress())
+	expected = big.NewInt(0)
+	expected.SetString("100000000000000000000000000000000000000", 10)
 	assert.Nil(t, err)
 	assert.Equal(t, expected, result)
 }

--- a/store/presenters/presenters.go
+++ b/store/presenters/presenters.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"math/big"
 	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -35,7 +36,26 @@ func ShowEthBalance(store *store.Store) (string, error) {
 	}
 	result := fmt.Sprintf("ETH Balance for %v: %v", address.Hex(), balance)
 	if balance == 0 {
-		return result, errors.New("0 Balance. Chainlink node not fully functional, please deposit eth into your address: " + address.Hex())
+		return result, errors.New("0 Balance. Chainlink node not fully functional, please deposit ETH into your address: " + address.Hex())
+	}
+	return result, nil
+}
+
+func ShowLinkBalance(store *store.Store) (string, error) {
+	if !store.KeyStore.HasAccounts() {
+		logger.Panic("KeyStore must have an account in order to show balance")
+	}
+	address := store.KeyStore.GetAccount().Address
+	linkContractAddress := common.HexToAddress(store.Config.LinkContractAddress)
+	balance, err := store.TxManager.GetERC20Balance(address, linkContractAddress)
+	if err != nil {
+		return "", err
+	}
+	// Because Eth and Link both use 1e18 precision, we can correct using the same facility
+	linkBalance := utils.WeiToEth(balance)
+	result := fmt.Sprintf("Link Balance for %v: %v", address.Hex(), linkBalance)
+	if balance == big.NewInt(0) {
+		return result, errors.New("0 Balance. Chainlink node not fully functional, please deposit LINK into your address: " + address.Hex())
 	}
 	return result, nil
 }

--- a/store/presenters/presenters_test.go
+++ b/store/presenters/presenters_test.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 	"testing"
 	"time"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
@@ -67,4 +68,55 @@ func TestPresenterShowEthBalance_WithEmptyAccount(t *testing.T) {
 	defer cleanup()
 	_, err := presenters.ShowEthBalance(app.Store)
 	assert.NotNil(t, err)
+}
+
+func TestPresenterShowEthBalance_WithAccount(t *testing.T) {
+	t.Parallel()
+	app, cleanup := cltest.NewApplicationWithKeyStore()
+	defer cleanup()
+
+	ethMock := app.MockEthClient()
+	ethMock.Register("eth_getBalance", "0x0100") // 256
+
+	assert.True(t, app.Store.KeyStore.HasAccounts())
+
+	output, err := presenters.ShowEthBalance(app.Store)
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("ETH Balance for %v: 2.56e-16", app.Store.KeyStore.GetAccount().Address.Hex()), output)
+}
+
+func TestPresenterShowLinkBalance_NoAccount(t *testing.T) {
+	t.Parallel()
+	store, cleanup := cltest.NewStore()
+	defer func() {
+		if r := recover(); r == nil {
+			t.Errorf("The code should have panicked")
+		}
+	}()
+	defer cleanup()
+	presenters.ShowLinkBalance(store)
+}
+
+func TestPresenterShowLinkBalance_WithEmptyAccount(t *testing.T) {
+	t.Parallel()
+	app, cleanup := cltest.NewApplicationWithKeyStore()
+	defer cleanup()
+	_, err := presenters.ShowLinkBalance(app.Store)
+	fmt.Println(err)
+	assert.NotNil(t, err)
+}
+
+func TestPresenterShowLinkBalance_WithAccount(t *testing.T) {
+	t.Parallel()
+	app, cleanup := cltest.NewApplicationWithKeyStore()
+	defer cleanup()
+
+	ethMock := app.MockEthClient()
+	ethMock.Register("eth_call", "0x0100") // 256
+
+	assert.True(t, app.Store.KeyStore.HasAccounts())
+
+	output, err := presenters.ShowLinkBalance(app.Store)
+	assert.Nil(t, err)
+	assert.Equal(t, fmt.Sprintf("Link Balance for %v: 2.56e-16", app.Store.KeyStore.GetAccount().Address.Hex()), output)
 }

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -29,6 +29,8 @@ import (
 const (
 	HUMAN_TIME_FORMAT = "2006-01-02 15:04:05 MST"
 	weiPerEth         = 1e18
+	EVMWordByteLen    = 32
+	EVMWordHexLen     = EVMWordByteLen * 2
 )
 
 // ZeroAddress is an empty address, otherwise in Ethereum as


### PR DESCRIPTION
This adds a `ShowLinkBalance` call to startup, which loads the Link balances from the `LINK_CONTRACT_ADDRESS` contract and displays that value.

A few notes:
* I haven't tested this against a proper node, just via the unit tests herein, so there is the possibility of bugs, particularly in the eth_call interaction.
* I removed the Config type coercion for common.Address, because I ran into trouble with it - "Type is not supported" from `env`.
* I reused `utils.WeiToEth` to convert the link balance, because the number of decimals is the same as ether - I figure this should be renamed at least.

[#155879128]