### PR TITLE
add filepath support for create command

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -7,6 +7,9 @@ import (
 	"io/ioutil"
 	"net/http"
 
+	"github.com/mitchellh/go-homedir"
+	"github.com/tidwall/gjson"
+
 	"github.com/gin-gonic/gin"
 	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/services"
@@ -92,17 +95,22 @@ func (cli *Client) GetJobSpecs(c *clipkg.Context) error {
 func (cli *Client) CreateJobSpec(c *clipkg.Context) error {
 	cfg := cli.Config
 	if !c.Args().Present() {
-		return cli.errorOut(errors.New("Must pass in JSON/filepath"))
+		return cli.errorOut(errors.New("Must pass in JSON or filepath"))
 	}
+	arg := c.Args().First()
 	var buf *bytes.Buffer
-	if c.Args().First()[0] != '{' {
-		file, err := ioutil.ReadFile(c.Args().First())
+	if gjson.Valid(arg) {
+		buf = bytes.NewBufferString(arg)
+	} else {
+		dir, err := homedir.Expand(arg)
+		if err != nil {
+			return cli.errorOut(err)
+		}
+		file, err := ioutil.ReadFile(dir)
 		if err != nil {
 			return cli.errorOut(err)
 		}
 		buf = bytes.NewBuffer(file)
-	} else {
-		buf = bytes.NewBufferString(c.Args().First())
 	}
 	resp, err := utils.BasicAuthPost(
 		cfg.BasicAuthUsername,

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -92,14 +92,24 @@ func (cli *Client) GetJobSpecs(c *clipkg.Context) error {
 func (cli *Client) CreateJobSpec(c *clipkg.Context) error {
 	cfg := cli.Config
 	if !c.Args().Present() {
-		return cli.errorOut(errors.New("Must pass in job JSON"))
+		return cli.errorOut(errors.New("Must pass in JSON/filepath"))
+	}
+	var buf *bytes.Buffer
+	if c.Args().First()[0] != '{' {
+		file, err := ioutil.ReadFile(c.Args().First())
+		if err != nil {
+			return cli.errorOut(err)
+		}
+		buf = bytes.NewBuffer(file)
+	} else {
+		buf = bytes.NewBufferString(c.Args().First())
 	}
 	resp, err := utils.BasicAuthPost(
 		cfg.BasicAuthUsername,
 		cfg.BasicAuthPassword,
 		cfg.ClientNodeURL+"/v2/specs",
 		"application/json",
-		bytes.NewBufferString(c.Args().First()),
+		buf,
 	)
 	if err != nil {
 		return cli.errorOut(err)

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -91,9 +91,9 @@ func TestClient_CreateJobSpec(t *testing.T) {
 	}{
 		{"{bad json}", 0, true},
 		{"bad/filepath/", 0, true},
-		{"{\"initiators\":[{\"type\":\"web\"}], \"tasks\":[{\"type\": \"NoOp\"}]}", 1, false},
-		{"{\"initiators\":[{\"type\":\"ethLog\", \"address\": \"0x3cCad4715152693fE3BC4460591e3D3Fbd071b42\"}],\"tasks\": [ { \"type\": \"NoOp\" } ]}", 2, false},
-		{"../internal/fixtures/web/eth_log_job.json", 3, false},
+		{`{"initiators":[{"type":"web"}],"tasks":[{"type":"NoOp"}]}`, 1, false},
+		{`{"initiators":[{"type":"runAt","time":"2018-01-08T18:12:01.103Z"}],"tasks":[{"type":"NoOp"}]}`, 2, false},
+		{"../internal/fixtures/web/end_at_job.json", 3, false},
 		{"~/go/src/github.com/smartcontractkit/chainlink/internal/fixtures/web/hello_world_job.json", 4, false},
 		{"~/go/src/github.com/smartcontractkit/chainlink/internal/fixtures/web/invalid_cron.json", 4, true},
 	}
@@ -110,6 +110,6 @@ func TestClient_CreateJobSpec(t *testing.T) {
 			assert.Nil(t, client.CreateJobSpec(c))
 		}
 		numberOfJobs, _ := app.Store.Jobs()
-		assert.Equal(t, len(numberOfJobs), test.nJobs)
+		assert.Equal(t, test.nJobs, len(numberOfJobs))
 	}
 }

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -89,13 +89,11 @@ func TestClient_CreateJobSpec(t *testing.T) {
 		nJobs   int
 		errored bool
 	}{
-		{"{bad json}", 0, true},
+		{"{bad son}", 0, true},
 		{"bad/filepath/", 0, true},
 		{`{"initiators":[{"type":"web"}],"tasks":[{"type":"NoOp"}]}`, 1, false},
 		{`{"initiators":[{"type":"runAt","time":"2018-01-08T18:12:01.103Z"}],"tasks":[{"type":"NoOp"}]}`, 2, false},
 		{"../internal/fixtures/web/end_at_job.json", 3, false},
-		{"~/go/src/github.com/smartcontractkit/chainlink/internal/fixtures/web/hello_world_job.json", 4, false},
-		{"~/go/src/github.com/smartcontractkit/chainlink/internal/fixtures/web/invalid_cron.json", 4, true},
 	}
 
 	for _, tt := range tests {

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -89,9 +89,13 @@ func TestClient_CreateJobSpec(t *testing.T) {
 		nJobs   int
 		errored bool
 	}{
-		{"bad input", 0, true},
-		{`{"initiators":[{"type":"web"}],"tasks":[{"type":"NoOp"}]}`, 1, false},
-		{`{"initiators":[{"type":"runAt","time":"2018-01-08T18:12:01.103Z"}],"tasks":[{"type":"NoOp"}]}`, 2, false},
+		{"{bad json}", 0, true},
+		{"bad/filepath/", 0, true},
+		{"{\"initiators\":[{\"type\":\"web\"}], \"tasks\":[{\"type\": \"NoOp\"}]}", 1, false},
+		{"{\"initiators\":[{\"type\":\"ethLog\", \"address\": \"0x3cCad4715152693fE3BC4460591e3D3Fbd071b42\"}],\"tasks\": [ { \"type\": \"NoOp\" } ]}", 2, false},
+		{"../internal/fixtures/web/eth_log_job.json", 3, false},
+		{"~/go/src/github.com/smartcontractkit/chainlink/internal/fixtures/web/hello_world_job.json", 4, false},
+		{"~/go/src/github.com/smartcontractkit/chainlink/internal/fixtures/web/invalid_cron.json", 4, true},
 	}
 
 	for _, tt := range tests {

--- a/web/job_specs_controller.go
+++ b/web/job_specs_controller.go
@@ -50,7 +50,7 @@ func (jsc *JobSpecsController) Create(c *gin.Context) {
 			"errors": []string{err.Error()},
 		})
 	} else {
-		c.JSON(200, gin.H{"id": j.ID})
+		c.JSON(200, presenters.JobSpec{JobSpec: j})
 	}
 }
 


### PR DESCRIPTION
I dont think you can add $HOME as a hard coded test because shell expansion usually gives you the absolute path.
 I did however test chainlink create with ~  / $HOME / $GOPATH they all create jobs.

