### PR TITLE
Added benchmark tests for the job specs controller and job runs controller

### DIFF
--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -276,7 +276,7 @@ func ObserveLogs() *observer.ObservedLogs {
 	return observed
 }
 
-func FixtureCreateJobViaWeb(t *testing.T, app *TestApplication, path string) models.JobSpec {
+func FixtureCreateJobViaWeb(t assert.TestingT, app *TestApplication, path string) models.JobSpec {
 	resp := BasicAuthPost(
 		app.Server.URL+"/v2/specs",
 		"application/json",
@@ -377,7 +377,7 @@ func NewClientAndRenderer(config store.Config) (*cmd.Client, *RendererMock) {
 	return client, r
 }
 
-func CheckStatusCode(t *testing.T, resp *http.Response, expected int) {
+func CheckStatusCode(t assert.TestingT, resp *http.Response, expected int) {
 	assert.Equal(t, expected, resp.StatusCode)
 	if resp.StatusCode != expected {
 		buf, err := ioutil.ReadAll(resp.Body)

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -276,7 +276,7 @@ func ObserveLogs() *observer.ObservedLogs {
 	return observed
 }
 
-func FixtureCreateJobViaWeb(t assert.TestingT, app *TestApplication, path string) models.JobSpec {
+func FixtureCreateJobViaWeb(t *testing.T, app *TestApplication, path string) models.JobSpec {
 	resp := BasicAuthPost(
 		app.Server.URL+"/v2/specs",
 		"application/json",
@@ -377,7 +377,7 @@ func NewClientAndRenderer(config store.Config) (*cmd.Client, *RendererMock) {
 	return client, r
 }
 
-func CheckStatusCode(t assert.TestingT, resp *http.Response, expected int) {
+func CheckStatusCode(t *testing.T, resp *http.Response, expected int) {
 	assert.Equal(t, expected, resp.StatusCode)
 	if resp.StatusCode != expected {
 		buf, err := ioutil.ReadAll(resp.Body)

--- a/web/job_runs_controller_test.go
+++ b/web/job_runs_controller_test.go
@@ -20,8 +20,16 @@ type JobRun struct {
 	ID string `json:"id"`
 }
 
+func BenchmarkJobRunsController_Index(b *testing.B) {
+	testJobRunsControllerIndex(b)
+}
+
 func TestJobRunsController_Index(t *testing.T) {
 	t.Parallel()
+	testJobRunsControllerIndex(t)
+}
+
+func testJobRunsControllerIndex(t assert.TestingT) {
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 

--- a/web/job_specs_controller_test.go
+++ b/web/job_specs_controller_test.go
@@ -14,8 +14,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func BenchmarkJobSpecsController_Index(b *testing.B) {
+	testJobSpecsControllerIndex(b)
+}
+
 func TestJobSpecsController_Index(t *testing.T) {
 	t.Parallel()
+	testJobSpecsControllerIndex(t)
+}
+
+func testJobSpecsControllerIndex(t assert.TestingT) {
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 
@@ -36,8 +44,16 @@ func TestJobSpecsController_Index(t *testing.T) {
 	assert.NotEqual(t, true, jobs[1].Initiators[0].Ran, "should ignore fields for other initiators")
 }
 
+func BenchmarkJobSpecsController_Create(b *testing.B) {
+	testJobSpecsControllerCreate(b)
+}
+
 func TestJobSpecsController_Create(t *testing.T) {
 	t.Parallel()
+	testJobSpecsControllerCreate(t)
+}
+
+func testJobSpecsControllerCreate(t assert.TestingT) {
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 
@@ -141,8 +157,16 @@ func TestJobSpecsController_Create_InvalidCron(t *testing.T) {
 	assert.Equal(t, expected, string(cltest.ParseResponseBody(resp)))
 }
 
+func BenchmarkJobSpecsController_Show(b *testing.B) {
+	testJobSpecsControllerShow(b)
+}
+
 func TestJobSpecsController_Show(t *testing.T) {
 	t.Parallel()
+	testJobSpecsControllerShow(t)
+}
+
+func testJobSpecsControllerShow(t assert.TestingT) {
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 


### PR DESCRIPTION
With adding the benchmark tests, I wanted as little code duplication as possible so I've used the assert.TestingT interface to be able to share the common methods between test and benchmarks.

An issue is with refactor is that it doesn't benchmark the completion of job runs due to using the assert.TestingT interface and the helper methods. Although, then I suppose the biggest factor of the performance of that benchmark would be the API used in the task, which then could result in false negatives.

Also, I'm not sure if not using pointers to pass the assert.TestingT interface would cause any noticeable degragation.

A lot less code for a similar result!