### PR TITLE
Git-ignore .envrc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ tmp/
 internal/devnet/db.bolt
 internal/devnet/log.jsonl
 /chainlink
+.envrc


### PR DESCRIPTION
This file is recommended for development here:
https://github.com/smartcontractkit/chainlink/wiki/Development-Tips#direnv

But its particulars can be system-specific, so we can ignore it in the repo to
avoid improper inclusion.