### PR TITLE
Update jobs command to jobspecs in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ By default this will start on port 6688, where it exposes a [REST API](https://g
 
 Once your node has started, you can view your current jobs with:
 ```bash
-$ chainlink jobs
+$ chainlink jobspecs
 ````
 View details of a specific job with:
 ```bash


### PR DESCRIPTION
Not sure if this is needed but I couldn't get `chainlink jobs` to work on `22ef4b41049c99728500577db9abff7fa6a8aabb` and it doesn't appear in the help output:

```bash
COMMANDS:
     node, n             Run the chainlink node
     jobspecs, j, specs  Get all jobs
     show, s             Show a specific job
     create, c           Create job spec from JSON
     help, h             Shows a list of commands or help for one command
```