### PR TITLE
fix go vet's errors #183

### DIFF
--- a/main.go
+++ b/main.go
@@ -24,7 +24,7 @@ func Run(client *cmd.Client, args ...string) {
 	}
 	app.Before = func(c *cli.Context) error {
 		if c.Bool("json") {
-			client.Renderer = cmd.RendererJSON{os.Stdout}
+			client.Renderer = cmd.RendererJSON{Writer: os.Stdout}
 		}
 		return nil
 	}
@@ -75,10 +75,10 @@ func Run(client *cmd.Client, args ...string) {
 
 func NewProductionClient() *cmd.Client {
 	return &cmd.Client{
-		cmd.RendererTable{os.Stdout},
-		store.NewConfig(),
-		cmd.ChainlinkAppFactory{},
-		cmd.TerminalAuthenticator{Prompter: cmd.PasswordPrompter{}, Exiter: os.Exit},
-		cmd.ChainlinkRunner{},
+		Renderer: cmd.RendererTable{Writer: os.Stdout},
+		Config: store.NewConfig(),
+		AppFactory: cmd.ChainlinkAppFactory{},
+		Auth: cmd.TerminalAuthenticator{Prompter: cmd.PasswordPrompter{}, Exiter: os.Exit},
+		Runner: cmd.ChainlinkRunner{},
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -12,11 +12,11 @@ func ExampleRun_Help() {
 	tc, cleanup := cltest.NewConfig()
 	defer cleanup()
 	testClient := &cmd.Client{
-		cmd.RendererTable{ioutil.Discard},
-		tc.Config,
-		cmd.ChainlinkAppFactory{},
-		cmd.TerminalAuthenticator{Prompter: &cltest.MockCountingPrompt{}, Exiter: os.Exit},
-		cmd.ChainlinkRunner{},
+		Renderer: cmd.RendererTable{Writer: ioutil.Discard},
+		Config: tc.Config,
+		AppFactory: cmd.ChainlinkAppFactory{},
+		Auth: cmd.TerminalAuthenticator{Prompter: &cltest.MockCountingPrompt{}, Exiter: os.Exit},
+		Runner: cmd.ChainlinkRunner{},
 	}
 
 	Run(testClient, "chainlink.test --help")


### PR DESCRIPTION
Fixes the `go vet`'s `composite literal uses unkeyed fields` errors.
One error left in `main_test.go`:  `/main_test.go:11: ExampleRun_Help refers to unknown field or method: Run.Help` 
Will try to fix it next.
