### PR TITLE
Return "" instead of nil pointer panic in WebURL#String

### DIFF
--- a/store/models/common.go
+++ b/store/models/common.go
@@ -167,6 +167,14 @@ func (w *WebURL) MarshalJSON() ([]byte, error) {
 	return json.Marshal(w.String())
 }
 
+// String delegates to the wrapped URL struct or an empty string when it is nil
+func (w *WebURL) String() string {
+	if w.URL == nil {
+		return ""
+	}
+	return w.URL.String()
+}
+
 // Time holds a common field for time.
 type Time struct {
 	time.Time

--- a/store/models/common_test.go
+++ b/store/models/common_test.go
@@ -144,6 +144,25 @@ func TestWebURL_MarshalJSON(t *testing.T) {
 	assert.Equal(t, `"`+str+`"`, string(b))
 }
 
+func TestWebURL_String_HasURL(t *testing.T) {
+	t.Parallel()
+
+	u, _ := url.Parse("http://www.duckduckgo.com")
+	w := models.WebURL{
+		URL: u,
+	}
+
+	assert.Equal(t, "http://www.duckduckgo.com", w.String())
+}
+
+func TestWebURL_String_HasNilURL(t *testing.T) {
+	t.Parallel()
+
+	w := models.WebURL{}
+
+	assert.Equal(t, "", w.String())
+}
+
 func TestTimeDurationFromNow(t *testing.T) {
 	t.Parallel()
 	future := models.Time{Time: time.Now().Add(time.Second)}


### PR DESCRIPTION
This is the same behavior as `URL#String` from `net/url`