### PR TITLE
Skip TestServices_ApplicationSignalShutdown on windows:

### DIFF
--- a/services/application_test.go
+++ b/services/application_test.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package services_test
 
 import (


### PR DESCRIPTION
Reliant on os specific syscall.Kill,Getpid().

Fixes https://github.com/smartcontractkit/chainlink/issues/194