### PR TITLE
Improve clarity of TxManager MeetsMinConfirmations:

### DIFF
--- a/adapters/eth_tx.go
+++ b/adapters/eth_tx.go
@@ -62,7 +62,7 @@ func ensureTxRunResult(input models.RunResult, store *store.Store) models.RunRes
 		return input.WithError(err)
 	}
 
-	confirmed, err := store.TxManager.EnsureTxConfirmed(hash)
+	confirmed, err := store.TxManager.MeetsMinConfirmations(hash)
 
 	if err != nil {
 		return input.WithError(err)

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -110,8 +110,12 @@ func NewWSServer(msg string) *httptest.Server {
 }
 
 func NewApplication() (*TestApplication, func()) {
-	c, _ := NewConfig()
-	return NewApplicationWithConfig(c)
+	c, cfgCleanup := NewConfig()
+	app, cleanup := NewApplicationWithConfig(c)
+	return app, func() {
+		cleanup()
+		cfgCleanup()
+	}
 }
 
 func NewApplicationWithConfig(tc *TestConfig) (*TestApplication, func()) {

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -134,7 +134,16 @@ func NewApplicationWithConfig(tc *TestConfig) (*TestApplication, func()) {
 }
 
 func NewApplicationWithKeyStore() (*TestApplication, func()) {
-	app, cleanup := NewApplication()
+	config, cfgCleanup := NewConfig()
+	app, cleanup := NewApplicationWithConfigAndKeyStore(config)
+	return app, func() {
+		cleanup()
+		cfgCleanup()
+	}
+}
+
+func NewApplicationWithConfigAndKeyStore(tc *TestConfig) (*TestApplication, func()) {
+	app, cleanup := NewApplicationWithConfig(tc)
 	_, err := app.Store.KeyStore.NewAccount(Password)
 	mustNotErr(err)
 	mustNotErr(app.Store.KeyStore.Unlock(Password))

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -65,12 +65,12 @@ func (jr JobRun) NextTaskRun() TaskRun {
 // Runnable checks that the number of confirmations have passed since the
 // job's creation height to determine if the JobRun can be started. Returns
 // true for non-EthereumListener (runlog & ethlog) initiators.
-func (jr JobRun) Runnable(bn *IndexableBlockNumber, minConfs uint64) bool {
-	if jr.CreationHeight == nil || bn == nil {
+func (jr JobRun) Runnable(currentHeight *IndexableBlockNumber, minConfs uint64) bool {
+	if jr.CreationHeight == nil || currentHeight == nil {
 		return true
 	}
 
-	diff := new(big.Int).Sub(bn.ToInt(), jr.CreationHeight.ToInt())
+	diff := new(big.Int).Sub(currentHeight.ToInt(), jr.CreationHeight.ToInt())
 	min := new(big.Int).SetUint64(minConfs)
 	return diff.Cmp(min) >= 0
 }

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -60,15 +60,15 @@ func TestJobRun_Runnable(t *testing.T) {
 	tests := []struct {
 		name                 string
 		creationHeight       *hexutil.Big
-		blockNumber          *models.IndexableBlockNumber
+		currentHeight        *models.IndexableBlockNumber
 		minimumConfirmations uint64
 		want                 bool
 	}{
 		{"unset nil 0", nil, nil, 0, true},
 		{"1 nil 0", cltest.NewBigHexInt(1), nil, 0, true},
-		{"1 1 diff 0", cltest.NewBigHexInt(1), cltest.IndexableBlockNumber(1), 0, true},
-		{"1 1 diff 1", cltest.NewBigHexInt(1), cltest.IndexableBlockNumber(1), 1, false},
-		{"1 2 diff 1", cltest.NewBigHexInt(1), cltest.IndexableBlockNumber(2), 1, true},
+		{"1 1 minconf 0", cltest.NewBigHexInt(1), cltest.IndexableBlockNumber(1), 0, true},
+		{"1 1 minconf 1", cltest.NewBigHexInt(1), cltest.IndexableBlockNumber(1), 1, false},
+		{"1 2 minconf 1", cltest.NewBigHexInt(1), cltest.IndexableBlockNumber(2), 1, true},
 	}
 
 	for _, test := range tests {
@@ -78,7 +78,7 @@ func TestJobRun_Runnable(t *testing.T) {
 				jr.CreationHeight = test.creationHeight
 			}
 
-			assert.Equal(t, test.want, jr.Runnable(test.blockNumber, test.minimumConfirmations))
+			assert.Equal(t, test.want, jr.Runnable(test.currentHeight, test.minimumConfirmations))
 		})
 	}
 }

--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -54,9 +54,9 @@ func (txm *TxManager) CreateTx(to common.Address, data []byte) (*models.Tx, erro
 	return tx, nil
 }
 
-// EnsureTxConfirmed returns true if the given transaction hash has been
+// MeetsMinConfirmations returns true if the given transaction hash has been
 // confirmed on the blockchain.
-func (txm *TxManager) EnsureTxConfirmed(hash common.Hash) (bool, error) {
+func (txm *TxManager) MeetsMinConfirmations(hash common.Hash) (bool, error) {
 	blkNum, err := txm.GetBlockNumber()
 	if err != nil {
 		return false, err


### PR DESCRIPTION
Ensures that we are not off by one when checking
minimum EthTx confirmations.

Signed-off-by: Dimitri Roche <dimroc@gmail.com>