### PR TITLE
Only log to disk when running node, not tests

### DIFF
--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -286,7 +286,7 @@ func ParseResponseBody(resp *http.Response) []byte {
 
 func ObserveLogs() *observer.ObservedLogs {
 	core, observed := observer.New(zapcore.DebugLevel)
-	logger.SetLogger(logger.NewLogger(zap.New(core)))
+	logger.SetLogger(zap.New(core))
 	return observed
 }
 

--- a/services/application.go
+++ b/services/application.go
@@ -36,7 +36,6 @@ type ChainlinkApplication struct {
 // be used by the node.
 func NewApplication(config store.Config) Application {
 	store := store.NewStore(config)
-	logger.Reconfigure(config.RootDir, config.LogLevel.Level)
 	ht := NewHeadTracker(store)
 	return &ChainlinkApplication{
 		HeadTracker:      ht,

--- a/store/config.go
+++ b/store/config.go
@@ -11,6 +11,8 @@ import (
 	"github.com/caarlos0/env"
 	"github.com/gin-gonic/gin"
 	homedir "github.com/mitchellh/go-homedir"
+	"github.com/smartcontractkit/chainlink/logger"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -54,6 +56,12 @@ func NewConfig() Config {
 // KeysDir returns the path of the keys directory (used for keystore files).
 func (c Config) KeysDir() string {
 	return path.Join(c.RootDir, "keys")
+}
+
+// CreateDiskLogger returns a logger for the config's root directory
+// and LogLevel.
+func (c Config) CreateDiskLogger() *zap.Logger {
+	return logger.CreateDiskLogger(c.RootDir, c.LogLevel.Level)
 }
 
 func parseEnv(cfg interface{}) error {


### PR DESCRIPTION
Will reduce cleanup but not having to remove `log.jsonl`.