### PR TITLE
Fix status in job runner when bridge doesn't exist

### DIFF
--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -138,7 +138,7 @@ func startTask(
 	adapter, err := adapters.For(tr.Task, store)
 
 	if err != nil {
-		return tr.ApplyResult(tr.Result.SetError(err))
+		return tr.ApplyResult(tr.Result.WithError(err))
 	}
 
 	return tr.ApplyResult(adapter.Perform(input, store))

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -138,9 +138,7 @@ func startTask(
 	adapter, err := adapters.For(tr.Task, store)
 
 	if err != nil {
-		tr.Status = models.RunStatusErrored
-		tr.Result.SetError(err)
-		return tr
+		return tr.ApplyResult(tr.Result.SetError(err))
 	}
 
 	return tr.ApplyResult(adapter.Perform(input, store))

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -229,13 +229,6 @@ func (rr RunResult) Error() string {
 	return rr.ErrorMessage.String
 }
 
-// SetError stores the given error in the ErrorMessage field.
-func (rr RunResult) SetError(err error) RunResult {
-	rr.Status = RunStatusErrored
-	rr.ErrorMessage = null.StringFrom(err.Error())
-	return rr
-}
-
 // GetError returns the error of a RunResult if it is present.
 func (rr RunResult) GetError() error {
 	if rr.HasError() {

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -230,8 +230,10 @@ func (rr RunResult) Error() string {
 }
 
 // SetError stores the given error in the ErrorMessage field.
-func (rr RunResult) SetError(err error) {
+func (rr RunResult) SetError(err error) RunResult {
+	rr.Status = RunStatusErrored
 	rr.ErrorMessage = null.StringFrom(err.Error())
+	return rr
 }
 
 // GetError returns the error of a RunResult if it is present.

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -150,14 +150,14 @@ func TestRunResult_Value(t *testing.T) {
 	}
 }
 
-func TestRunResult_SetError(t *testing.T) {
+func TestRunResult_WithError(t *testing.T) {
 	t.Parallel()
 
 	rr := models.RunResult{}
 
 	assert.Equal(t, models.RunStatusUnstarted, rr.Status)
 
-	rr = rr.SetError(errors.New("this blew up"))
+	rr = rr.WithError(errors.New("this blew up"))
 
 	assert.Equal(t, models.RunStatusErrored, rr.Status)
 	assert.Equal(t, cltest.NullString("this blew up"), rr.ErrorMessage)

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"testing"
 
@@ -147,6 +148,19 @@ func TestRunResult_Value(t *testing.T) {
 			assert.Equal(t, test.wantErrored, (err != nil))
 		})
 	}
+}
+
+func TestRunResult_SetError(t *testing.T) {
+	t.Parallel()
+
+	rr := models.RunResult{}
+
+	assert.Equal(t, models.RunStatusUnstarted, rr.Status)
+
+	rr = rr.SetError(errors.New("this blew up"))
+
+	assert.Equal(t, models.RunStatusErrored, rr.Status)
+	assert.Equal(t, cltest.NullString("this blew up"), rr.ErrorMessage)
 }
 
 func TestRunResult_Merge(t *testing.T) {


### PR DESCRIPTION
- Set status & message in RunResult#SetError
- Add test coverage for RunResult#SetError

Signed-off-by: Steve Ellis <email@steveell.is>
Signed-off-by: Alex Kwiatkowski <alex+git@rival-studios.com>