### PR TITLE
Created int256 adaptor for Ethereum

### DIFF
--- a/adapters/adapter.go
+++ b/adapters/adapter.go
@@ -53,6 +53,9 @@ func For(task models.TaskSpec, store *store.Store) (AdapterWithMinConfs, error) 
 	case "ethbytes32":
 		ac = &EthBytes32{}
 		err = unmarshalParams(task.Params, ac)
+	case "ethint256":
+		ac = &EthInt256{}
+		err = unmarshalParams(task.Params, ac)
 	case "ethuint256":
 		ac = &EthUint256{}
 		err = unmarshalParams(task.Params, ac)

--- a/adapters/eth_format_test.go
+++ b/adapters/eth_format_test.go
@@ -47,6 +47,66 @@ func TestEthBytes32_Perform(t *testing.T) {
 	}
 }
 
+func TestEthInt256_Perform(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name    string
+		json    string
+		want    string
+		errored bool
+	}{
+		{"string", `{"value":"123"}`, utils.EVMHexNumber(123), false},
+		{"integer", `{"value":123}`, utils.EVMHexNumber(123), false},
+		{"integer", `{"value":"18446744073709551615"}`,
+			"0x000000000000000000000000000000000000000000000000ffffffffffffffff", false},
+		{"integer", `{"value":"170141183460469231731687303715884105728"}`,
+			"0x0000000000000000000000000000000080000000000000000000000000000000", false},
+		{"minus integer", `{"value":"-170141183460469231731687303715884105729"}`,
+			"0x-000000000000000000000000000000080000000000000000000000000000001", false},
+		{"integer", `{"value":"170141183460469231731687303715884105729"}`,
+			"0x0000000000000000000000000000000080000000000000000000000000000001", false},
+		{"2^128", `{"value":"340282366920938463463374607431768211456"}`,
+			"0x0000000000000000000000000000000100000000000000000000000000000000", false},
+		{"2^128 * -1", `{"value":"-340282366920938463463374607431768211456"}`,
+			"0x-000000000000000000000000000000100000000000000000000000000000000", false},
+		{"large float precision", `{"value":"115792089237316195423570985008687907853269984665640564039457584007913129639934"}`,
+			"", true},
+		{"2^256 - 1", `{"value":"115792089237316195423570985008687907853269984665640564039457584007913129639935"}`,
+			"", true},
+		{"2^256", `{"value":"115792089237316195423570985008687907853269984665640564039457584007913129639936"}`,
+			"", true},
+		{"2^252 - 1", `{"value":"7237005577332262213973186563042994240829374041602535252466099000494570602495"}`,
+			"0x0fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", false},
+		{"(2^252 - 1) * -1", `{"value":"-7237005577332262213973186563042994240829374041602535252466099000494570602495"}`,
+			"0x-fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff", false},
+		{"float", `{"value":123.0}`, utils.EVMHexNumber(123), false},
+		{"rounded float", `{"value":123.99}`, utils.EVMHexNumber(123), false},
+		{"negative string", `{"value":"-123"}`, "0x-00000000000000000000000000000000000000000000000000000000000007b", false},
+		{"negative float", `{"value":-123.99}`, "0x-00000000000000000000000000000000000000000000000000000000000007b", false},
+		{"object", `{"value":{"a": "b"}}`, "", true},
+		{"odd length result", `{"value":"1234"}`, utils.EVMHexNumber(1234), false},
+	}
+
+	adapter := adapters.EthInt256{}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			input := models.RunResult{
+				Data: cltest.JSONFromString(test.json),
+			}
+			result := adapter.Perform(input, nil)
+
+			if test.errored {
+				assert.NotNil(t, result.GetError())
+			} else {
+				val, err := result.Value()
+				assert.Nil(t, result.GetError())
+				assert.Nil(t, err)
+				assert.Equal(t, test.want, val)
+			}
+		})
+	}
+}
+
 func TestEthUint256_Perform(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
For pivotal tracker ticket #155879139.

My only concern with this is the hex formatting of minus integers, so say for -123 it would output it signed with a minus:
`0x-00000000000000000000000000000000000000000000000000000000000007b`

Whereas I would of expected it to be in a two's compliment format:
`0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff85`