### PR TITLE
Enforce color encoding regardless of terminal

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path"
 
+	"github.com/fatih/color"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -57,8 +58,10 @@ func CreateProductionLogger(dir string, lvl zapcore.Level) *zap.Logger {
 	return zl
 }
 
-// CreateTestLogger creates a logger that directs output to PrettyConsole.
+// CreateTestLogger creates a logger that directs output to PrettyConsole
+// configured for test output.
 func CreateTestLogger() *zap.Logger {
+	color.NoColor = false
 	config := zap.NewProductionConfig()
 	config.Level.SetLevel(zapcore.DebugLevel)
 	config.OutputPaths = []string{"pretty"}

--- a/logger/prettyconsole_test.go
+++ b/logger/prettyconsole_test.go
@@ -3,11 +3,12 @@ package logger
 import (
 	"testing"
 
+	"github.com/fatih/color"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestPrettyConsole_Write(t *testing.T) {
-	t.Parallel()
+	color.NoColor = false
 
 	tests := []struct {
 		name      string
@@ -18,19 +19,19 @@ func TestPrettyConsole_Write(t *testing.T) {
 		{
 			"headline",
 			`{"ts":1523537728.7260377, "level":"info", "msg":"top level"}`,
-			"2018-04-12T12:55:28Z [INFO]  top level  \n",
+			"2018-04-12T12:55:28Z \x1b[37m[INFO]  \x1b[0mtop level \x1b[34m\x1b[0m \n",
 			false,
 		},
 		{
 			"details",
 			`{"ts":1523537728, "level":"debug", "msg":"top level", "details":"nuances"}`,
-			"2018-04-12T12:55:28Z [DEBUG] top level  \ndetails=nuances \n",
+			"2018-04-12T12:55:28Z \x1b[32m[DEBUG] \x1b[0mtop level \x1b[34m\x1b[0m \ndetails=nuances \n",
 			false,
 		},
 		{
 			"blacklist",
 			`{"ts":1523537728, "level":"warn", "msg":"top level", "hash":"nuances"}`,
-			"2018-04-12T12:55:28Z [WARN]  top level  \n",
+			"2018-04-12T12:55:28Z \x1b[33m[WARN]  \x1b[0mtop level \x1b[34m\x1b[0m \n",
 			false,
 		},
 		{"error", `{"broken":}`, `{}`, true},


### PR DESCRIPTION
Fixes travis CI go 1.9 errors in https://github.com/smartcontractkit/chainlink/pull/233 and https://github.com/smartcontractkit/chainlink/pull/232