### PR TITLE
 ensure that runAt initiators cannot be run twice

### DIFF
--- a/services/scheduler.go
+++ b/services/scheduler.go
@@ -159,6 +159,12 @@ func (ot *OneTime) RunJobAt(initr models.Initiator, job models.JobSpec) {
 	select {
 	case <-ot.done:
 	case <-ot.Clock.After(initr.Time.DurationFromNow()):
+		if initr.Ran {
+			logger.Error((fmt.Errorf("Job runner: Initiator: %v cannot be run more than once", initr.ID)))
+			return
+		}
+
+		initr.Ran = true
 		_, err := BeginRun(job, initr, models.RunResult{}, ot.Store)
 		if err != nil {
 			logger.Error(err.Error())

--- a/services/scheduler.go
+++ b/services/scheduler.go
@@ -159,14 +159,11 @@ func (ot *OneTime) RunJobAt(initr models.Initiator, job models.JobSpec) {
 	select {
 	case <-ot.done:
 	case <-ot.Clock.After(initr.Time.DurationFromNow()):
-		if initr.Ran {
-			logger.Error((fmt.Errorf("Job runner: Initiator: %v cannot be run more than once", initr.ID)))
+		if err := ot.Store.MarkRan(&initr); err != nil {
+			logger.Error(err.Error())
 			return
 		}
-
-		initr.Ran = true
-		_, err := BeginRun(job, initr, models.RunResult{}, ot.Store)
-		if err != nil {
+		if _, err := BeginRun(job, initr, models.RunResult{}, ot.Store); err != nil {
 			logger.Error(err.Error())
 		}
 	}

--- a/services/scheduler.go
+++ b/services/scheduler.go
@@ -163,8 +163,15 @@ func (ot *OneTime) RunJobAt(initr models.Initiator, job models.JobSpec) {
 			logger.Error(err.Error())
 			return
 		}
-		if _, err := BeginRun(job, initr, models.RunResult{}, ot.Store); err != nil {
+		jr, err := BeginRun(job, initr, models.RunResult{}, ot.Store)
+		if err != nil {
 			logger.Error(err.Error())
+		}
+		if jr.Status == models.RunStatusUnstarted {
+			initr.Ran = false
+			if err := ot.Store.Save(&initr); err != nil {
+				logger.Error(err.Error())
+			}
 		}
 	}
 }

--- a/services/scheduler_test.go
+++ b/services/scheduler_test.go
@@ -216,6 +216,8 @@ func TestOneTime_RunJobAt_ExecuteLateJob(t *testing.T) {
 	}
 	j, initr := cltest.NewJobWithRunAtInitiator(time.Now().Add(time.Hour * -1))
 	assert.Nil(t, store.SaveJob(&j))
+	initr.ID = j.Initiators[0].ID
+	initr.JobID = j.ID
 
 	var finished bool
 	go func() {

--- a/store/models/orm.go
+++ b/store/models/orm.go
@@ -242,14 +242,12 @@ func (orm *ORM) MarkRan(i *Initiator) error {
 		return err
 	}
 
-	if !ir.Ran {
-		ir.Ran = true
-	} else {
+	if ir.Ran {
 		return fmt.Errorf("Job runner: Initiator: %v cannot run more than once", ir.ID)
 	}
 
-	ir.Ran = true
-	if err := dbtx.Save(&ir); err != nil {
+	i.Ran = true
+	if err := dbtx.Save(i); err != nil {
 		return err
 	}
 	return dbtx.Commit()

--- a/store/models/orm.go
+++ b/store/models/orm.go
@@ -228,6 +228,20 @@ func (orm *ORM) BridgeTypeFor(name string) (BridgeType, error) {
 	return tt, err
 }
 
+// MarkRan will set Ran to true for a given initiator
+func (orm *ORM) MarkRan(i *Initiator) error {
+	dbtx, err := orm.Begin(true)
+	if err != nil {
+		return err
+	}
+	defer dbtx.Rollback()
+	i.Ran = true
+	if err := dbtx.Save(i); err != nil {
+		return err
+	}
+	return dbtx.Commit()
+}
+
 // DatabaseAccessError is an error that occurs during database access.
 type DatabaseAccessError struct {
 	msg string

--- a/store/models/orm.go
+++ b/store/models/orm.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"fmt"
 	"log"
 	"math/big"
 	"reflect"
@@ -235,8 +236,20 @@ func (orm *ORM) MarkRan(i *Initiator) error {
 		return err
 	}
 	defer dbtx.Rollback()
-	i.Ran = true
-	if err := dbtx.Save(i); err != nil {
+
+	var ir Initiator
+	if err := orm.One("ID", i.ID, &ir); err != nil {
+		return err
+	}
+
+	if !ir.Ran {
+		ir.Ran = true
+	} else {
+		return fmt.Errorf("Job runner: Initiator: %v cannot run more than once", ir.ID)
+	}
+
+	ir.Ran = true
+	if err := dbtx.Save(&ir); err != nil {
 		return err
 	}
 	return dbtx.Commit()

--- a/store/models/orm_test.go
+++ b/store/models/orm_test.go
@@ -217,10 +217,10 @@ func TestMarkRan(t *testing.T) {
 	defer cleanup()
 
 	_, initr := cltest.NewJobWithRunAtInitiator(time.Now())
+	assert.Nil(t, store.Save(&initr))
 
 	assert.Nil(t, store.MarkRan(&initr))
 	var ir models.Initiator
 	assert.Nil(t, store.One("ID", initr.ID, &ir))
 	assert.True(t, ir.Ran)
-
 }

--- a/store/models/orm_test.go
+++ b/store/models/orm_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -207,4 +208,19 @@ func TestORM_SaveCreationHeight(t *testing.T) {
 			assert.Equal(t, test.wantHeight, jr.CreationHeight.ToInt())
 		})
 	}
+}
+
+func TestMarkRan(t *testing.T) {
+	t.Parallel()
+
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+
+	_, initr := cltest.NewJobWithRunAtInitiator(time.Now())
+
+	assert.Nil(t, store.MarkRan(&initr))
+	var ir models.Initiator
+	assert.Nil(t, store.One("ID", initr.ID, &ir))
+	assert.True(t, ir.Ran)
+
 }


### PR DESCRIPTION
I was a little concerned about initr not having an ID you can see this in schduler_test.go L#217. Because MarkRan Reloads an initiator to check if has already run. I got the ID from jobspec for it to pass. Not sure if that is correctly done. 