### PR TITLE
Outgoing confirmations include 1st confirmation:

### DIFF
--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -150,6 +150,7 @@ func (txm *TxManager) handleConfirmed(
 	minConfs := big.NewInt(int64(txm.Config.TxMinConfirmations))
 	rcptBlkNum := big.Int(rcpt.BlockNumber)
 	safeAt := minConfs.Add(&rcptBlkNum, minConfs)
+	safeAt.Sub(safeAt, big.NewInt(1)) // 0 based indexing since rcpt is 1 conf
 	if big.NewInt(int64(blkNum)).Cmp(safeAt) == -1 {
 		return false, nil
 	}

--- a/store/tx_manager_test.go
+++ b/store/tx_manager_test.go
@@ -118,7 +118,7 @@ func TestTxManager_MeetsMinConfirmations_confirmed(t *testing.T) {
 	defer configCleanup()
 
 	sentAt := uint64(1)
-	confirmedAt := uint64(2)
+	receiptAt := uint64(2)
 	config.TxMinConfirmations = 2
 
 	app, cleanup := cltest.NewApplicationWithConfigAndKeyStore(config)
@@ -133,10 +133,10 @@ func TestTxManager_MeetsMinConfirmations_confirmed(t *testing.T) {
 		currentHeight uint64
 		want          bool
 	}{
-		{"less than min confs", 3, false},
-		{"equal min confs", 4, true},
-		{"1 greater than min confs", 5, true},
-		{"2 greater than min confs", 6, true},
+		{"less than min confs", 2, false},
+		{"equal min confs", 3, true},
+		{"1 greater than min confs", 4, true},
+		{"2 greater than min confs", 5, true},
 	}
 
 	for _, test := range tests {
@@ -144,7 +144,7 @@ func TestTxManager_MeetsMinConfirmations_confirmed(t *testing.T) {
 			ethMock := app.MockEthClient()
 			confirmationReceipt := strpkg.TxReceipt{
 				Hash:        cltest.NewHash(),
-				BlockNumber: cltest.BigHexInt(confirmedAt),
+				BlockNumber: cltest.BigHexInt(receiptAt),
 			}
 			ethMock.Register("eth_getTransactionReceipt", confirmationReceipt)
 			ethMock.Register("eth_blockNumber", utils.Uint64ToHex(test.currentHeight))

--- a/web/integration_test.go
+++ b/web/integration_test.go
@@ -57,7 +57,7 @@ func TestIntegration_HelloWorld(t *testing.T) {
 	hash := common.HexToHash("0xb7862c896a6ba2711bccc0410184e46d793ea83b3e05470f1d359ea276d16bb5")
 	sentAt := uint64(23456)
 	confirmed := sentAt + config.EthGasBumpThreshold + 1
-	safe := confirmed + config.TxMinConfirmations
+	safe := confirmed + config.TxMinConfirmations - 1
 
 	eth.Register("eth_blockNumber", utils.Uint64ToHex(sentAt))
 	eth.Register("eth_sendRawTransaction", hash)
@@ -88,7 +88,7 @@ func TestIntegration_HelloWorld(t *testing.T) {
 		Hash:        hash,
 		BlockNumber: cltest.BigHexInt(confirmed),
 	})
-	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(safe)} // 23466
+	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(safe)} // 23465
 
 	jr = cltest.WaitForJobRunToComplete(t, app.Store, jr)
 


### PR DESCRIPTION
Fixes off by 1 confirmation error.
i.e. Sent At 1, will now be confirmed at 10, if
minimum confirmations are 10. Was 11.