### PR TITLE
Configure truffle env as development

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -18,7 +18,7 @@ Each example requires the development environment, set up as follows:
 3. Run truffle migrations for the Chainlink contracts:
   1. `cd ../solidity`
   2. `yarn install`
-  3. `./node_modules/.bin/truffle migrate --network devnet`
+  3. `./node_modules/.bin/truffle migrate`
 4. Run `./internal/bin/cldev` in top level repo folder
 
 Go to our [development wiki](https://github.com/smartcontractkit/chainlink/wiki/Development-Tips) to read more.

--- a/examples/uptime_sla/deploy
+++ b/examples/uptime_sla/deploy
@@ -1,3 +1,3 @@
 #!/usr/bin/env bash
 
-./node_modules/.bin/truffle migrate --compile-all --reset --network devnet
+./node_modules/.bin/truffle migrate --compile-all --reset

--- a/examples/uptime_sla/truffle.js
+++ b/examples/uptime_sla/truffle.js
@@ -1,6 +1,6 @@
 module.exports = {
   networks: {
-    devnet: {
+    development: {
       host: "127.0.0.1",
       port: 18545,
       network_id: "*",

--- a/internal/bin/cldev
+++ b/internal/bin/cldev
@@ -4,7 +4,7 @@
 # Steps:
 # 0. Have docker installed and configured
 # 1. ./internal/bin/devnet
-# 2. cd solidity && truffle migrate --network devnet && cd ..
+# 2. cd solidity && truffle migrate && cd ..
 # 3. ./internal/bin/cldev
 
 export LOG_LEVEL=debug

--- a/internal/ci/truffle_test
+++ b/internal/ci/truffle_test
@@ -3,8 +3,8 @@
 set -e
 
 cd solidity
-./node_modules/.bin/truffle test
+./node_modules/.bin/truffle test --network test
 
 cd ../examples/uptime_sla
 yarn install
-./node_modules/.bin/truffle test
+./node_modules/.bin/truffle test --network test

--- a/solidity/truffle.js
+++ b/solidity/truffle.js
@@ -2,7 +2,7 @@ global.h = require('./helpers');
 
 module.exports = {
   networks: {
-    devnet: {
+    development: {
       host: "127.0.0.1",
       port: 18545,
       network_id: "*",


### PR DESCRIPTION
This allows us to avoid the `--network devnet` switch

`examples/twillio_sms` & `examples/echo_server` are already configured as `development` and don't need the switch.