### PR TITLE
Return similar outputs for CLI and API

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -339,7 +339,11 @@ func (cli *Client) deserializeAPIResponse(resp *http.Response, dst interface{}, 
 
 func (cli *Client) deserializeResponse(resp *http.Response, dst interface{}) error {
 	if resp.StatusCode >= 400 {
-		return cli.errorOut(errors.New(resp.Status))
+		b, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return cli.errorOut(errors.New(resp.Status))
+		}
+		return cli.errorOut(errors.New(string(b)))
 	}
 	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
As noted by Thomas [here](https://www.pivotaltracker.com/n/projects/2129823/stories/156575315)
This simply attempts to return the response body in case of an error 400+ for CLI commands so that one would get the same error message when using CLI or `curl`