### PR TITLE
Format log output with more visible distinctions betwen components

### DIFF
--- a/logger/prettyconsole.go
+++ b/logger/prettyconsole.go
@@ -25,6 +25,7 @@ var levelColors = map[string]func(...interface{}) string{
 }
 
 var blue = color.New(color.FgBlue).SprintFunc()
+var green = color.New(color.FgGreen).SprintFunc()
 
 // PrettyConsole wraps a Sink (Writer, Syncer, Closer), usually stdout, and
 // formats the incoming json bytes with colors and white space for readability
@@ -53,9 +54,9 @@ func generateHeadline(js models.JSON) string {
 		utils.ISO8601UTC(time.Unix(int64(sec), int64(dec*(1e9)))),
 		" ",
 		coloredLevel(js.Get("level")),
-		js.Get("msg"),
+		fmt.Sprintf("%-50s", js.Get("msg")),
 		" ",
-		blue(js.Get("caller")),
+		fmt.Sprintf("%-32s", blue(js.Get("caller"))),
 	}
 	return fmt.Sprint(headline...)
 }
@@ -76,11 +77,7 @@ func generateDetails(js models.JSON) string {
 		if detailsBlacklist[k] || len(v.String()) == 0 {
 			continue
 		}
-		details += fmt.Sprintf("%s=%v ", k, v)
-	}
-
-	if len(details) > 0 {
-		details = fmt.Sprint("\n", details)
+		details += fmt.Sprintf("%s=%v ", green(k), v)
 	}
 	return details
 }

--- a/logger/prettyconsole_test.go
+++ b/logger/prettyconsole_test.go
@@ -19,19 +19,19 @@ func TestPrettyConsole_Write(t *testing.T) {
 		{
 			"headline",
 			`{"ts":1523537728.7260377, "level":"info", "msg":"top level"}`,
-			"2018-04-12T12:55:28Z \x1b[37m[INFO]  \x1b[0mtop level \x1b[34m\x1b[0m \n",
+			"2018-04-12T12:55:28Z \x1b[37m[INFO]  \x1b[0mtop level                                          \x1b[34m\x1b[0m                        \n",
 			false,
 		},
 		{
 			"details",
 			`{"ts":1523537728, "level":"debug", "msg":"top level", "details":"nuances"}`,
-			"2018-04-12T12:55:28Z \x1b[32m[DEBUG] \x1b[0mtop level \x1b[34m\x1b[0m \ndetails=nuances \n",
+			"2018-04-12T12:55:28Z \x1b[32m[DEBUG] \x1b[0mtop level                                          \x1b[34m\x1b[0m                        \x1b[32mdetails\x1b[0m=nuances \n",
 			false,
 		},
 		{
 			"blacklist",
 			`{"ts":1523537728, "level":"warn", "msg":"top level", "hash":"nuances"}`,
-			"2018-04-12T12:55:28Z \x1b[33m[WARN]  \x1b[0mtop level \x1b[34m\x1b[0m \n",
+			"2018-04-12T12:55:28Z \x1b[33m[WARN]  \x1b[0mtop level                                          \x1b[34m\x1b[0m                        \n",
 			false,
 		},
 		{"error", `{"broken":}`, `{}`, true},


### PR DESCRIPTION
I find the logging output quite hard to follow, especially the newline after the source code line (my terminal already wraps long lines automatically so this has weird results). So here is a small attempt to make it a bit more legible. See example screenshot:

![screen shot 2018-05-02 at 15 49 52](https://user-images.githubusercontent.com/344071/39546125-4dc57d8e-4e21-11e8-876f-2edc1f46da29.png)
