### PR TITLE
Features/integration test cleanup

### DIFF
--- a/examples/echo_server/create_ethlog_job
+++ b/examples/echo_server/create_ethlog_job
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-curl -u chainlink:twochains -X POST -H 'Content-Type: application/json' \
+curl -sS -u chainlink:twochains -X POST -H 'Content-Type: application/json' \
        -d @./broadcast_logs_job.json http://localhost:6688/v2/specs
 

--- a/examples/echo_server/create_runlog_job
+++ b/examples/echo_server/create_runlog_job
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-curl -u chainlink:twochains -X POST -H 'Content-Type: application/json' \
+curl -sS -u chainlink:twochains -X POST -H 'Content-Type: application/json' \
        -d @./only_jobid_logs_job.json http://localhost:6688/v2/specs

--- a/examples/uptime_sla/create_http_json_x10000_job
+++ b/examples/uptime_sla/create_http_json_x10000_job
@@ -1,4 +1,4 @@
 #!/bin/bash
 
-curl -u chainlink:twochains -X POST -H 'Content-Type: application/json' \
+curl -sS -u chainlink:twochains -X POST -H 'Content-Type: application/json' \
        -d @./http_json_x10000_job.json http://localhost:6688/v2/specs

--- a/internal/bin/gethnet
+++ b/internal/bin/gethnet
@@ -3,7 +3,9 @@
 set -e
 
 cd "$(dirname "$0")"
-./print_account
+
+ACCOUNT=0x9ca9d2d5e04012c9ed24c0e513c9bfaa4a2dd77f
+RPCAPI="eth,net,web3,admin,personal,debug"
 
 # Enable different gethnet subcommands such as clean or console.
 # No subcommand runs the main mining geth.
@@ -16,25 +18,27 @@ case "$1" in
     ;;
   console)
     geth console --dev --mine --networkid 17 --wsorigins "*" --rpc --ws \
-      --rpcapi "eth,net,web3,admin,personal,debug" --rpccorsdomain "null" \
+      --rpcapi "$RPCAPI" --rpccorsdomain "null" \
       --rpcaddr 127.0.0.1 --rpcport 18545 --wsport 18546 --datadir ../gethnet/datadir \
-      --unlock "0x9ca9d2d5e04012c9ed24c0e513c9bfaa4a2dd77f" \
+      --unlock "$ACCOUNT" \
       --password ../gethnet/password.txt
     ;;
   topoff)
     geth console --dev \
-      --unlock "0x9ca9d2d5e04012c9ed24c0e513c9bfaa4a2dd77f" \
+      --unlock "$ACCOUNT" \
       --password ../gethnet/password.txt \
       --datadir ../gethnet/datadir \
       --exec 'loadScript("../gethnet/gethload.js"); topOffAccount();'
     ;;
   *)
+    ./print_account
     ./gethnet topoff
+    sleep 1
     geth --dev --mine --networkid 17 --wsorigins "*" --rpc --ws \
-      --rpcapi "eth,net,web3,admin,personal,debug" --rpccorsdomain "null" \
+      --rpcapi "$RPCAPI" --rpccorsdomain "null" \
       --rpcaddr 127.0.0.1 --dev.period 2 --rpcport 18545 --wsport 18546 \
       --datadir ../gethnet/datadir \
-      --unlock "0x9ca9d2d5e04012c9ed24c0e513c9bfaa4a2dd77f" \
+      --unlock "$ACCOUNT" \
       --password ../gethnet/password.txt
     ;;
 esac

--- a/internal/bin/trace_transaction_parity
+++ b/internal/bin/trace_transaction_parity
@@ -1,6 +1,6 @@
 #!/bin/bash
 
 hash=$1
-curl --data '{"method":"trace_transaction","params":["'$hash'"],"id":1,"jsonrpc":"2.0"}' \
+curl -sS --data '{"method":"trace_transaction","params":["'$hash'"],"id":1,"jsonrpc":"2.0"}' \
   -H "Content-Type: application/json" -X POST localhost:18545
 

--- a/internal/ci/ethereum_test
+++ b/internal/ci/ethereum_test
@@ -12,7 +12,7 @@ time go install github.com/ethereum/go-ethereum/cmd/geth
 echo Running gethnet...
 gethnet &
 ETHEREUMPID=$!
-sleep 1
+sleep 3
 
 # Run CL against ethereum node
 cldev &

--- a/internal/ci/ethereum_test
+++ b/internal/ci/ethereum_test
@@ -1,15 +1,12 @@
 #!/bin/bash
 
-set -e
+set -ex
 
 PATH=./internal/bin:./node_modules/.bin:$PATH
 
 # Run gethnet
-echo Downloading geth...
 time go get -d github.com/ethereum/go-ethereum
-echo Installing geth...
 time go install github.com/ethereum/go-ethereum/cmd/geth
-echo Running gethnet...
 gethnet &
 ETHEREUMPID=$!
 sleep 3

--- a/internal/ci/ethereum_test
+++ b/internal/ci/ethereum_test
@@ -35,7 +35,7 @@ ethjob=`./create_ethlog_job`
 sleep 2
 
 # Check echo count
-count=`curl localhost:6690/count`
+count=`curl -sS localhost:6690/count`
 if [ "$count" -ne "1" ]; then
   echo "Echo count is $count, not 1."
   exit 1

--- a/internal/ci/ethereum_test
+++ b/internal/ci/ethereum_test
@@ -2,18 +2,19 @@
 
 set -ex
 
+# Kill all background processes when this shell script finishes
+trap "kill -- -$$ || true" SIGINT SIGTERM EXIT
+
 PATH=./internal/bin:./node_modules/.bin:$PATH
 
 # Run gethnet
 time go get -d github.com/ethereum/go-ethereum
 time go install github.com/ethereum/go-ethereum/cmd/geth
 gethnet &
-ETHEREUMPID=$!
 sleep 3
 
 # Run CL against ethereum node
 cldev &
-CLDEVPID=$!
 sleep 4
 
 ########################
@@ -24,7 +25,6 @@ cd examples/echo_server
 yarn install
 truffle migrate
 node echo.js &
-ECHOPID=$!
 
 ########################
 ## ethlog
@@ -67,8 +67,3 @@ if [ "$runs" -ne "1" ]; then
 else
   echo "Runs count is correctly $runs."
 fi
-
-# Unfortunately, does not kill off all bg processes
-kill $ECHOPID
-kill $CLDEVPID
-kill $ETHEREUMPID


### PR DESCRIPTION
This is a small ergonomics change to the integration tests in lieu of moving to something like bats:

 1. Actually kill the processes started by the integration test, note that the chainlink node doesn't handle proper `kill` so although it now gets sent the kill signal properly, it'll continue running.
 2. Remove used of `echo` in favor of just using `-x` it's more obvious and less effort to maintain.
 3. Added a slightly longer delay between geth and the node to allow more time for startup on my desktop.
 4. Suppress the curl progress bar output (which is just noise in the integration tests)

I may quickly see if it's worth fixing the signal handling in `node` to make this more complete.