### PR TITLE
Reduce truffle warnings

### DIFF
--- a/examples/echo_server/contracts/RunLog.sol
+++ b/examples/echo_server/contracts/RunLog.sol
@@ -5,7 +5,7 @@ import "../../../solidity/contracts/Chainlinked.sol";
 contract RunLog is Chainlinked {
   bytes32 private externalId;
 
-  function RunLog(address _link, address _oracle) public {
+  constructor(address _link, address _oracle) public {
     setLinkToken(_link);
     setOracle(_oracle);
   }

--- a/examples/uptime_sla/contracts/Migrations.sol
+++ b/examples/uptime_sla/contracts/Migrations.sol
@@ -8,7 +8,7 @@ contract Migrations {
     if (msg.sender == owner) _;
   }
 
-  function Migrations() public {
+  constructor() public {
     owner = msg.sender;
   }
 

--- a/examples/uptime_sla/contracts/UptimeSLA.sol
+++ b/examples/uptime_sla/contracts/UptimeSLA.sol
@@ -12,7 +12,7 @@ contract UptimeSLA is Chainlinked {
   bytes32 public externalId;
   uint256 public uptime;
 
-  function UptimeSLA(
+  constructor(
     address _client,
     address _serviceProvider,
     address _link,

--- a/solidity/contracts/ChainlinkLib.sol
+++ b/solidity/contracts/ChainlinkLib.sol
@@ -16,14 +16,14 @@ library ChainlinkLib {
   }
 
   function add(Run memory self, string _key, string _value)
-    internal
+    internal pure
   {
     self.buf.encodeString(_key);
     self.buf.encodeString(_value);
   }
 
   function addStringArray(Run memory self, string _key, string[] memory _values)
-    internal
+    internal pure
   {
     self.buf.encodeString(_key);
     self.buf.startArray();
@@ -34,7 +34,7 @@ library ChainlinkLib {
   }
 
   function close(Run memory self)
-    internal
+    internal pure
     returns (bytes)
   {
      self.buf.endSequence();

--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -22,7 +22,7 @@ contract Chainlinked {
     bytes32 _jobId,
     address _callbackAddress,
     string _callbackFunctionSignature
-  ) internal returns (ChainlinkLib.Run memory) {
+  ) internal pure returns (ChainlinkLib.Run memory) {
     ChainlinkLib.Run memory run;
     Buffer.init(run.buf, 128);
     run.jobId = _jobId;

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -32,7 +32,7 @@ contract Oracle is Ownable {
     bytes data
   );
 
-  function Oracle(address _link) Ownable() public {
+  constructor(address _link) Ownable() public {
     LINK = LinkToken(_link);
   }
 

--- a/solidity/contracts/examples/ConcreteChainlinkLib.sol
+++ b/solidity/contracts/examples/ConcreteChainlinkLib.sol
@@ -11,7 +11,7 @@ contract ConcreteChainlinkLib {
 
   event RunData(bytes payload);
 
-  function ConcreteChainlinkLib() {
+  constructor() public {
     ChainlinkLib.Run memory r2 = run;
     Buffer.init(r2.buf, 128);
     r2.buf.startMap();
@@ -43,7 +43,7 @@ contract ConcreteChainlinkLib {
     run = r2;
   }
 
-  function bytes32ToString(bytes32 x) private returns (string) {
+  function bytes32ToString(bytes32 x) private pure returns (string) {
     bytes memory bytesString = new bytes(32);
     uint charCount = 0;
     for (uint j = 0; j < 32; j++) {

--- a/solidity/contracts/examples/ConcreteChainlinked.sol
+++ b/solidity/contracts/examples/ConcreteChainlinked.sol
@@ -6,7 +6,7 @@ import "../Chainlinked.sol";
 
 contract ConcreteChainlinked is Chainlinked {
 
-  function ConcreteChainlinked(address _link, address _oracle)
+  constructor(address _link, address _oracle)
     public
   {
     setLinkToken(_link);

--- a/solidity/contracts/examples/Consumer.sol
+++ b/solidity/contracts/examples/Consumer.sol
@@ -8,7 +8,7 @@ contract Consumer is Chainlinked, Ownable {
   bytes32 internal jobId;
   bytes32 public currentPrice;
 
-  function Consumer(address _link, address _oracle, bytes32 _jobId) public {
+  constructor(address _link, address _oracle, bytes32 _jobId) public {
     setLinkToken(_link);
     setOracle(_oracle);
     jobId = _jobId;
@@ -24,7 +24,7 @@ contract Consumer is Chainlinked, Ownable {
   }
 
   function stringToBytes32(string memory source)
-    internal
+    internal pure
     returns (bytes32 result) {
       bytes memory tempEmptyStringTest = bytes(source);
       if (tempEmptyStringTest.length == 0) {
@@ -36,9 +36,9 @@ contract Consumer is Chainlinked, Ownable {
     }
   }
 
-  function cancelRequest(uint256 _requestId) 
-    public 
-    onlyOwner 
+  function cancelRequest(uint256 _requestId)
+    public
+    onlyOwner
   {
     oracle.cancel(_requestId);
   }


### PR DESCRIPTION
Use pure where appropriate, mark public, use `constructor` syntax

Less noise!