### PR TITLE
Add API index all bridge adapters

### DIFF
--- a/cmd/client.go
+++ b/cmd/client.go
@@ -97,28 +97,6 @@ func (cli *Client) ShowJobSpec(c *clipkg.Context) error {
 	return cli.renderResponse(resp, &job)
 }
 
-func (cli *Client) getPageOfJobSpecs(requestURI string, page int, jobs *[]models.JobSpec, links *jsonapi.Links) error {
-	cfg := cli.Config
-
-	uri, err := url.Parse(requestURI)
-	if err != nil {
-		return err
-	}
-	q := uri.Query()
-	if page > 0 {
-		q.Set("page", strconv.Itoa(page))
-	}
-	uri.RawQuery = q.Encode()
-
-	resp, err := utils.BasicAuthGet(cfg.BasicAuthUsername, cfg.BasicAuthPassword, uri.String())
-	if err != nil {
-		return cli.errorOut(err)
-	}
-	defer resp.Body.Close()
-
-	return cli.deserializeAPIResponse(resp, jobs, links)
-}
-
 // GetJobSpecs returns all job specs.
 func (cli *Client) GetJobSpecs(c *clipkg.Context) error {
 	cfg := cli.Config
@@ -131,7 +109,7 @@ func (cli *Client) GetJobSpecs(c *clipkg.Context) error {
 
 	var links jsonapi.Links
 	var jobs []models.JobSpec
-	err := cli.getPageOfJobSpecs(requestURI, page, &jobs, &links)
+	err := cli.getPage(requestURI, page, &jobs, &links)
 	if err != nil {
 		return err
 	}
@@ -277,14 +255,14 @@ func (cli *Client) GetBridges(c *clipkg.Context) error {
 
 	var links jsonapi.Links
 	var bridges []models.BridgeType
-	err := cli.getPageOfBridges(requestURI, page, &bridges, &links)
+	err := cli.getPage(requestURI, page, &bridges, &links)
 	if err != nil {
 		return err
 	}
 	return cli.errorOut(cli.Render(&bridges))
 }
 
-func (cli *Client) getPageOfBridges(requestURI string, page int, bridges *[]models.BridgeType, links *jsonapi.Links) error {
+func (cli *Client) getPage(requestURI string, page int, model interface{}, links *jsonapi.Links) error {
 	cfg := cli.Config
 
 	uri, err := url.Parse(requestURI)
@@ -303,7 +281,7 @@ func (cli *Client) getPageOfBridges(requestURI string, page int, bridges *[]mode
 	}
 	defer resp.Body.Close()
 
-	return cli.deserializeAPIResponse(resp, bridges, links)
+	return cli.deserializeAPIResponse(resp, model, links)
 }
 
 // ShowBridge returns the info for the given Bridge name.

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -197,6 +197,27 @@ func TestClient_AddBridge(t *testing.T) {
 	}
 }
 
+func TestClient_GetBridges(t *testing.T) {
+	app, cleanup := cltest.NewApplication()
+	defer cleanup()
+	bt1 := &models.BridgeType{Name: "testingbridges1",
+		URL:                  cltest.WebURL("https://testing.com/bridges"),
+		DefaultConfirmations: 0}
+	app.AddAdapter(bt1)
+
+	bt2 := &models.BridgeType{Name: "testingbridges2",
+		URL:                  cltest.WebURL("https://testing.com/bridges"),
+		DefaultConfirmations: 0}
+	app.AddAdapter(bt2)
+
+	client, r := cltest.NewClientAndRenderer(app.Store.Config)
+
+	assert.Nil(t, client.GetBridges(nil))
+	bridges := *r.Renders[0].(*[]models.BridgeType)
+	assert.Equal(t, 2, len(bridges))
+	assert.Equal(t, bt1.Name, bridges[0].Name)
+}
+
 func TestClient_ShowBridge(t *testing.T) {
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -203,7 +203,7 @@ func TestClient_ShowBridge(t *testing.T) {
 	bt := &models.BridgeType{Name: "testingbridges1",
 		URL:                  cltest.WebURL("https://testing.com/bridges"),
 		DefaultConfirmations: 0}
-	app.AddAdapter(&bt)
+	app.AddAdapter(bt)
 
 	client, r := cltest.NewClientAndRenderer(app.Store.Config)
 

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -18,8 +18,8 @@ import (
 func TestClient_RunNode(t *testing.T) {
 	app, _ := cltest.NewApplicationWithKeyStore() // cleanup invoked in client.RunNode
 	eth := app.MockEthClient()
-	eth.Register("eth_getTransactionCount", `0x1`)	
-	
+	eth.Register("eth_getTransactionCount", `0x1`)
+
 	r := &cltest.RendererMock{}
 	var called bool
 	auth := cltest.CallbackAuthenticator{Callback: func(*store.Store, string) { called = true }}
@@ -195,6 +195,24 @@ func TestClient_AddBridge(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestClient_ShowBridge(t *testing.T) {
+	app, cleanup := cltest.NewApplication()
+	defer cleanup()
+	bt := &models.BridgeType{Name: "testingbridges1",
+		URL:                  cltest.WebURL("https://testing.com/bridges"),
+		DefaultConfirmations: 0}
+	app.AddAdapter(&bt)
+
+	client, r := cltest.NewClientAndRenderer(app.Store.Config)
+
+	set := flag.NewFlagSet("test", 0)
+	set.Parse([]string{bt.Name})
+	c := cli.NewContext(nil, set, nil)
+	assert.Nil(t, client.ShowBridge(c))
+	assert.Equal(t, 1, len(r.Renders))
+	assert.Equal(t, bt.Name, r.Renders[0].(*presenters.BridgeType).Name)
 }
 
 func TestClient_BackupDatabase(t *testing.T) {

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -177,6 +177,7 @@ func TestClient_AddBridge(t *testing.T) {
 		{"EmptyString", "", true},
 		{"ValidString", `{ "name": "TestBridge", "url": "http://localhost:3000/randomNumber" }`, false},
 		{"InvalidString", `{ "noname": "", "nourl": "" }`, true},
+		{"InvalidChar", `{ "badname": "path/bridge", "nourl": "" }`, true},
 		{"ValidPath", "../internal/fixtures/web/create_random_number_bridge_type.json", false},
 		{"InvalidPath", "bad/filepath/", true},
 	}

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -212,7 +212,7 @@ func TestClient_ShowBridge(t *testing.T) {
 	c := cli.NewContext(nil, set, nil)
 	assert.Nil(t, client.ShowBridge(c))
 	assert.Equal(t, 1, len(r.Renders))
-	assert.Equal(t, bt.Name, r.Renders[0].(*presenters.BridgeType).Name)
+	assert.Equal(t, bt.Name, r.Renders[0].(*models.BridgeType).Name)
 }
 
 func TestClient_BackupDatabase(t *testing.T) {

--- a/cmd/renderer.go
+++ b/cmd/renderer.go
@@ -48,6 +48,8 @@ func (rt RendererTable) Render(v interface{}) error {
 		rt.renderJob(*typed)
 	case *models.BridgeType:
 		rt.renderBridge(*typed)
+	case *[]models.BridgeType:
+		rt.renderBridges(*typed)
 	default:
 		return fmt.Errorf("Unable to render object: %v", typed)
 	}
@@ -84,6 +86,25 @@ func jobRowToStrings(job models.JobSpec) []string {
 		p.FriendlyInitiators(),
 		p.FriendlyTasks(),
 	}
+}
+
+func bridgeRowToStrings(bridge models.BridgeType) []string {
+	return []string{
+		bridge.Name,
+		bridge.URL.String(),
+		strconv.FormatUint(bridge.DefaultConfirmations, 10),
+	}
+}
+
+func (rt RendererTable) renderBridges(bridges []models.BridgeType) error {
+	table := tablewriter.NewWriter(rt)
+	table.SetHeader([]string{"Name", "URL", "DefaultConfirmations"})
+	for _, v := range bridges {
+		table.Append(bridgeRowToStrings(v))
+	}
+
+	render("Bridges", table)
+	return nil
 }
 
 func (rt RendererTable) renderBridge(bridge models.BridgeType) error {

--- a/main.go
+++ b/main.go
@@ -92,6 +92,22 @@ func Run(client *cmd.Client, args ...string) {
 			Usage:  "Add a new bridge to the node",
 			Action: client.AddBridge,
 		},
+		{
+			Name:   "getbridges",
+			Usage:  "List all bridges added to the node",
+			Action: client.GetBridges,
+			Flags: []cli.Flag{
+				cli.IntFlag{
+					Name:  "page",
+					Usage: "page of results to display",
+				},
+			},
+		},
+		{
+			Name:   "showbridge",
+			Usage:  "Show a specific bridge",
+			Action: client.ShowBridge,
+		},
 	}
 	app.Run(args)
 }

--- a/main_test.go
+++ b/main_test.go
@@ -41,8 +41,8 @@ func ExampleRun() {
 	//      backup                    Backup the database of the running node
 	//      import, i                 Import a key file to use with the node
 	//      bridge                    Add a new bridge to the node
-	//	getbridges		  List all bridges added to the node
-	//	showbridge		  Show a specific bridge
+	//      getbridges                List all bridges added to the node
+	//      showbridge                Show a specific bridge
 	//      help, h                   Shows a list of commands or help for one command
 	//
 	// GLOBAL OPTIONS:

--- a/main_test.go
+++ b/main_test.go
@@ -41,6 +41,8 @@ func ExampleRun() {
 	//      backup                    Backup the database of the running node
 	//      import, i                 Import a key file to use with the node
 	//      bridge                    Add a new bridge to the node
+	//	getbridges		  List all bridges added to the node
+	//	showbridge		  Show a specific bridge
 	//      help, h                   Shows a list of commands or help for one command
 	//
 	// GLOBAL OPTIONS:

--- a/services/validators.go
+++ b/services/validators.go
@@ -35,8 +35,12 @@ func ValidateJob(j models.JobSpec, store *store.Store) error {
 	return merr
 }
 
-// ValidateAdapter checks that the bridge type doesn't have a duplicate name
+// ValidateAdapter checks that the bridge type doesn't have a duplicate or invalid name
 func ValidateAdapter(bt *models.BridgeType, store *store.Store) (err error) {
+
+	if len(bt.Name) < 1 {
+		err = fmt.Errorf("adapter validation: no name specified")
+	}
 	re := regexp.MustCompile("^[a-zA-Z0-9-_]*$")
 	if !re.MatchString(bt.Name) {
 		err = fmt.Errorf("adapter validation: name %v contains invalid characters", bt.Name)

--- a/services/validators.go
+++ b/services/validators.go
@@ -3,6 +3,7 @@ package services
 import (
 	"errors"
 	"fmt"
+	"regexp"
 	"strings"
 
 	"github.com/smartcontractkit/chainlink/adapters"
@@ -36,6 +37,10 @@ func ValidateJob(j models.JobSpec, store *store.Store) error {
 
 // ValidateAdapter checks that the bridge type doesn't have a duplicate name
 func ValidateAdapter(bt *models.BridgeType, store *store.Store) (err error) {
+	re := regexp.MustCompile("^[a-zA-Z0-9-_]*$")
+	if !re.MatchString(bt.Name) {
+		err = fmt.Errorf("adapter validation: name %v contains invalid characters", bt.Name)
+	}
 	ts := models.TaskSpec{Type: bt.Name}
 	if a, _ := adapters.For(ts, store); a != nil {
 		err = fmt.Errorf("adapter validation: adapter %v exists", bt.Name)

--- a/services/validators_test.go
+++ b/services/validators_test.go
@@ -67,6 +67,8 @@ func TestValidateAdapter(t *testing.T) {
 			errors.New("adapter validation: adapter solargridreporting exists")},
 		{"existing core adapter", "ethtx",
 			errors.New("adapter validation: adapter ethtx exists")},
+		{"no adapter name", "",
+			errors.New("adapter validation: no name specified")},
 		{"invalid adapter name", "invalid/adapter",
 			errors.New("adapter validation: name invalid/adapter contains invalid characters")},
 		{"new external adapter", "gdaxprice", nil},

--- a/services/validators_test.go
+++ b/services/validators_test.go
@@ -67,6 +67,8 @@ func TestValidateAdapter(t *testing.T) {
 			errors.New("adapter validation: adapter solargridreporting exists")},
 		{"existing core adapter", "ethtx",
 			errors.New("adapter validation: adapter ethtx exists")},
+		{"invalid adapter name", "invalid/adapter",
+			errors.New("adapter validation: name invalid/adapter contains invalid characters")},
 		{"new external adapter", "gdaxprice", nil},
 	}
 

--- a/store/models/job_spec.go
+++ b/store/models/job_spec.go
@@ -208,6 +208,22 @@ type BridgeType struct {
 	DefaultConfirmations uint64 `json:"defaultConfirmations"`
 }
 
+// GetID returns the ID of this structure for jsonapi serialization.
+func (bt BridgeType) GetID() string {
+	return bt.Name
+}
+
+// GetName returns the pluralized "type" of this structure for jsonapi serialization.
+func (bt BridgeType) GetName() string {
+	return "bridges"
+}
+
+// SetID is used to set the ID of this structure when deserializing from jsonapi documents.
+func (bt *BridgeType) SetID(value string) error {
+	bt.Name = value
+	return nil
+}
+
 // UnmarshalJSON parses the given input and updates the BridgeType
 // Name and URL.
 func (bt *BridgeType) UnmarshalJSON(input []byte) error {

--- a/store/models/orm.go
+++ b/store/models/orm.go
@@ -56,6 +56,13 @@ func emptySlice(to interface{}) {
 	reflect.Indirect(ref).Set(results)
 }
 
+// FindBridge looks up a Bridge by its Name.
+func (orm *ORM) FindBridge(name string) (BridgeType, error) {
+	var bt BridgeType
+	err := orm.One("Name", name, &bt)
+	return bt, err
+}
+
 // FindJob looks up a Job by its ID.
 func (orm *ORM) FindJob(id string) (JobSpec, error) {
 	var job JobSpec

--- a/store/presenters/presenters.go
+++ b/store/presenters/presenters.go
@@ -65,6 +65,21 @@ func ShowLinkBalance(store *store.Store) (string, error) {
 	return result, nil
 }
 
+// BridgeType holds a bridge.
+type BridgeType struct {
+	models.BridgeType
+}
+
+// MarshalJSON returns the JSON data of the Bridge.
+func (bt BridgeType) MarshalJSON() ([]byte, error) {
+	type Alias BridgeType
+	return json.Marshal(&struct {
+		Alias
+	}{
+		Alias(bt),
+	})
+}
+
 // JobSpec holds the JobSpec definition and each run associated with that Job.
 type JobSpec struct {
 	models.JobSpec

--- a/store/presenters/presenters_test.go
+++ b/store/presenters/presenters_test.go
@@ -136,3 +136,15 @@ func TestPresenter_FriendlyBigInt(t *testing.T) {
 		})
 	}
 }
+
+func TestBridgeTypeMarshalJSON(t *testing.T) {
+	t.Parallel()
+	input := models.BridgeType{Name: "hapax",
+		URL:                  cltest.WebURL("http://hap.ax"),
+		DefaultConfirmations: 0}
+	expected := []byte("{\"name\":\"hapax\",\"url\":\"http://hap.ax\",\"defaultConfirmations\":0}")
+	bt := presenters.BridgeType{BridgeType: input}
+	output, err := bt.MarshalJSON()
+	assert.Nil(t, err)
+	assert.Equal(t, output, expected)
+}

--- a/web/bridge_types_controller.go
+++ b/web/bridge_types_controller.go
@@ -33,7 +33,6 @@ func (btc *BridgeTypesController) Create(c *gin.Context) {
 }
 
 // Index lists Bridges, one page at a time.
-
 func (btc *BridgeTypesController) Index(c *gin.Context) {
 	size, page, offset, err := ParsePaginatedRequest(c.Query("size"), c.Query("page"))
 	if err != nil {
@@ -75,7 +74,6 @@ func (btc *BridgeTypesController) Index(c *gin.Context) {
 }
 
 // Show returns the details of a specific Bridge.
-
 func (btc *BridgeTypesController) Show(c *gin.Context) {
 	name := c.Param("BridgeName")
 	if bt, err := btc.App.Store.FindBridge(name); err == storm.ErrNotFound {

--- a/web/bridge_types_controller.go
+++ b/web/bridge_types_controller.go
@@ -70,3 +70,20 @@ func (btc *BridgeTypesController) Index(c *gin.Context) {
 		}
 	}
 }
+
+// Show returns the details of a specific Bridge.
+
+func (btc *BridgeTypesController) Show(c *gin.Context) {
+	name := c.Param("BridgeName")
+	if bt, err := btc.App.Store.FindBridge(name); err == storm.ErrNotFound {
+		c.JSON(404, gin.H{
+			"errors": []string{"Bridge Name not found."},
+		})
+	} else if err != nil {
+		c.JSON(500, gin.H{
+			"errors": []string{err.Error()},
+		})
+	} else {
+		c.JSON(200, presenters.BridgeType{BridgeType: bt})
+	}
+}

--- a/web/bridge_types_controller.go
+++ b/web/bridge_types_controller.go
@@ -1,6 +1,8 @@
 package web
 
 import (
+	"fmt"
+
 	"github.com/asdine/storm"
 	"github.com/gin-gonic/gin"
 	"github.com/smartcontractkit/chainlink/services"

--- a/web/bridge_types_controller_test.go
+++ b/web/bridge_types_controller_test.go
@@ -104,6 +104,28 @@ func TestBridgeTypesController_Create(t *testing.T) {
 	assert.Equal(t, "https://example.com/randomNumber", bt.URL.String())
 }
 
+func TestBridgeController_Show(t *testing.T) {
+	t.Parallel()
+
+	app, cleanup := cltest.NewApplication()
+	defer cleanup()
+
+	bt := &models.BridgeType{Name: "testingbridges1",
+		URL:                  cltest.WebURL("https://testing.com/bridges"),
+		DefaultConfirmations: 0}
+	err := app.AddAdapter(bt)
+	assert.NoError(t, err)
+
+	resp := cltest.BasicAuthGet(app.Server.URL + "/v2/bridge_types/" + bt.Name)
+	assert.Equal(t, 200, resp.StatusCode, "Response should be successful")
+
+	var respBridge presenters.BridgeType
+	json.Unmarshal(cltest.ParseResponseBody(resp), &respBridge)
+	assert.Equal(t, respBridge.Name, bt.Name, "should have the same schedule")
+	assert.Equal(t, respBridge.URL.String(), bt.URL.String(), "should have the same URL")
+	assert.Equal(t, respBridge.DefaultConfirmations, bt.DefaultConfirmations, "should have the same DefaultConfirmations")
+}
+
 func TestBridgeTypesController_Create_AdapterExistsError(t *testing.T) {
 	t.Parallel()
 

--- a/web/bridge_types_controller_test.go
+++ b/web/bridge_types_controller_test.go
@@ -126,6 +126,9 @@ func TestBridgeController_Show(t *testing.T) {
 	assert.Equal(t, respBridge.Name, bt.Name, "should have the same schedule")
 	assert.Equal(t, respBridge.URL.String(), bt.URL.String(), "should have the same URL")
 	assert.Equal(t, respBridge.DefaultConfirmations, bt.DefaultConfirmations, "should have the same DefaultConfirmations")
+
+	resp = cltest.BasicAuthGet(app.Server.URL + "/v2/bridge_types/nosuchbridge")
+	assert.Equal(t, 404, resp.StatusCode, "Response should be 404")
 }
 
 func TestBridgeTypesController_Create_AdapterExistsError(t *testing.T) {

--- a/web/bridge_types_controller_test.go
+++ b/web/bridge_types_controller_test.go
@@ -2,11 +2,13 @@ package web_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"testing"
 
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/presenters"
 	"github.com/smartcontractkit/chainlink/web"
 	"github.com/stretchr/testify/assert"
 )

--- a/web/bridge_types_controller_test.go
+++ b/web/bridge_types_controller_test.go
@@ -167,5 +167,5 @@ func TestBridgeTypesController_Create_DatabaseError(t *testing.T) {
 		"application/json",
 		bytes.NewBufferString(`{"url":"http://without.a.name"}`),
 	)
-	cltest.AssertServerResponse(t, resp, 500)
+	cltest.AssertServerResponse(t, resp, 400)
 }

--- a/web/bridge_types_controller_test.go
+++ b/web/bridge_types_controller_test.go
@@ -4,10 +4,84 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/manyminds/api2go/jsonapi"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/web"
 	"github.com/stretchr/testify/assert"
 )
+
+func BenchmarkBridgeTypesController_Index(b *testing.B) {
+	app, cleanup := cltest.NewApplication()
+	defer cleanup()
+	setupJobSpecsControllerIndex(app)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		resp := cltest.BasicAuthGet(app.Server.URL + "/v2/specs")
+		assert.Equal(b, 200, resp.StatusCode, "Response should be successful")
+	}
+}
+
+func TestBridgeTypesController_Index(t *testing.T) {
+	t.Parallel()
+
+	app, cleanup := cltest.NewApplication()
+	defer cleanup()
+
+	bt, err := setupBridgeControllerIndex(app)
+	assert.NoError(t, err)
+
+	resp := cltest.BasicAuthGet(app.Server.URL + "/v2/specs?size=x")
+	cltest.AssertServerResponse(t, resp, 422)
+
+	resp = cltest.BasicAuthGet(app.Server.URL + "/v2/bridge_types?size=1")
+	cltest.AssertServerResponse(t, resp, 200)
+
+	var links jsonapi.Links
+	bridges := []models.BridgeType{}
+
+	err = web.ParsePaginatedResponse(cltest.ParseResponseBody(resp), &bridges, &links)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, links["next"].Href)
+	assert.Empty(t, links["prev"].Href)
+
+	assert.Len(t, bridges, 1)
+	assert.Equal(t, bt[0].Name, bridges[0].Name, "should have the same Name")
+	assert.Equal(t, bt[0].URL.String(), bridges[0].URL.String(), "should have the same URL")
+	assert.Equal(t, bt[0].DefaultConfirmations, bridges[0].DefaultConfirmations, "should have the same DefaultConfirmations")
+
+	resp = cltest.BasicAuthGet(app.Server.URL + links["next"].Href)
+	cltest.AssertServerResponse(t, resp, 200)
+
+	bridges = []models.BridgeType{}
+	err = web.ParsePaginatedResponse(cltest.ParseResponseBody(resp), &bridges, &links)
+	assert.NoError(t, err)
+	assert.Empty(t, links["next"])
+	assert.NotEmpty(t, links["prev"])
+	assert.Len(t, bridges, 1)
+	assert.Equal(t, bt[1].Name, bridges[0].Name, "should have the same Name")
+	assert.Equal(t, bt[1].URL.String(), bridges[0].URL.String(), "should have the same URL")
+	assert.Equal(t, bt[1].DefaultConfirmations, bridges[0].DefaultConfirmations, "should have the same DefaultConfirmations")
+}
+
+func setupBridgeControllerIndex(app *cltest.TestApplication) ([]*models.BridgeType, error) {
+
+	bt1 := &models.BridgeType{Name: "testingbridges1",
+		URL:                  cltest.WebURL("https://testing.com/bridges"),
+		DefaultConfirmations: 0}
+	err := app.AddAdapter(bt1)
+	if err != nil {
+		return nil, err
+	}
+
+	bt2 := &models.BridgeType{Name: "testingbridges2",
+		URL:                  cltest.WebURL("https://testing.com/tari"),
+		DefaultConfirmations: 0}
+	err = app.AddAdapter(bt2)
+
+	return []*models.BridgeType{bt1, bt2}, err
+}
 
 func TestBridgeTypesController_Create(t *testing.T) {
 	t.Parallel()

--- a/web/router.go
+++ b/web/router.go
@@ -39,7 +39,9 @@ func Router(app *services.ChainlinkApplication) *gin.Engine {
 		v2.PATCH("/runs/:RunID", jr.Update)
 
 		tt := BridgeTypesController{app}
+		v2.GET("/bridge_types", tt.Index)
 		v2.POST("/bridge_types", tt.Create)
+		//v2.GET("/bridge_types/:BridgeName", tt.Show)
 
 		backup := BackupController{app}
 		v2.GET("/backup", backup.Show)

--- a/web/router.go
+++ b/web/router.go
@@ -41,7 +41,7 @@ func Router(app *services.ChainlinkApplication) *gin.Engine {
 		tt := BridgeTypesController{app}
 		v2.GET("/bridge_types", tt.Index)
 		v2.POST("/bridge_types", tt.Create)
-		//v2.GET("/bridge_types/:BridgeName", tt.Show)
+		v2.GET("/bridge_types/:BridgeName", tt.Show)
 
 		backup := BackupController{app}
 		v2.GET("/backup", backup.Show)


### PR DESCRIPTION
#262 
https://www.pivotaltracker.com/n/projects/2129823/stories/157213214

For the sake of consistency with the API for `Jobs` I've added separate CLI commands for listing the bridges or showing a specific one by its name. It might be better to just have them as arguments for the general `bridge` command, so let me know if you'd prefer that.

I've added a validation check to prevent `Bridge` names from having non-alphanumerical characters besides hyphens and underscores. This is to prevent bugs with the API if a bridge with a name like `br/idge` is added. 