### PR TITLE
add a log to Consumer.sol's fulfill function

### DIFF
--- a/solidity/contracts/examples/Consumer.sol
+++ b/solidity/contracts/examples/Consumer.sol
@@ -8,6 +8,11 @@ contract Consumer is Chainlinked, Ownable {
   bytes32 internal jobId;
   bytes32 public currentPrice;
 
+  event RequestFulfilled(
+    bytes32 indexed requestId,
+    bytes32 indexed price
+  );
+
   constructor(address _link, address _oracle, bytes32 _jobId) public {
     setLinkToken(_link);
     setOracle(_oracle);
@@ -43,12 +48,13 @@ contract Consumer is Chainlinked, Ownable {
     oracle.cancel(_requestId);
   }
 
-  function fulfill(bytes32 _requestId, bytes32 _data)
+  function fulfill(bytes32 _requestId, bytes32 _price)
     public
     onlyOracle
     checkRequestId(_requestId)
   {
-    currentPrice = _data;
+    emit RequestFulfilled(_requestId, _price);
+    currentPrice = _price;
   }
 
   modifier checkRequestId(bytes32 _requestId) {

--- a/solidity/test/Consumer_test.js
+++ b/solidity/test/Consumer_test.js
@@ -72,10 +72,18 @@ contract('Consumer', () => {
     });
 
     it("records the data given to it by the oracle", async () => {
-      await oc.fulfillData(requestId, response, {from: oracleNode})
+      await oc.fulfillData(requestId, response, {from: oracleNode});
 
       let currentPrice = await cc.currentPrice.call();
       assert.equal(web3.toUtf8(currentPrice), response);
+    });
+
+    it("logs the data given to it by the oracle", async () => {
+      let tx = await oc.fulfillData(requestId, response, {from: oracleNode});
+      assert.equal(1, tx.receipt.logs.length);
+      let log = tx.receipt.logs[0];
+
+      assert.equal(web3.toUtf8(log.topics[2]), response);
     });
 
     context("when the consumer does not recognize the request ID", () => {
@@ -120,7 +128,7 @@ contract('Consumer', () => {
       let event = await getLatestEvent(oc);
       requestId = event.args.id;
     });
-    
+
     context("when called by a non-owner", () => {
       it("cannot cancel a request", async () => {
         await assertActionThrows(async () => {


### PR DESCRIPTION
- makes it easier to recognize the changes made to Consumer's `fulfill` method.