### PR TITLE
WIP Refactor HeadTracker reconnection so app.Stop() and reconnectLoop don't deadlock

### DIFF
--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -409,6 +409,6 @@ func (m *MockHeadTrackable) OnNewHead(*models.BlockHeader) { m.OnNewHeadCount +=
 
 type NeverSleeper struct{}
 
-func (ns NeverSleeper) Reset()                  {}
-func (ns NeverSleeper) Sleep()                  {}
-func (ns NeverSleeper) Duration() time.Duration { return 0 * time.Microsecond }
+func (ns NeverSleeper) Reset()                    {}
+func (ns NeverSleeper) Sleep() <-chan (time.Time) { return time.After(ns.Duration()) }
+func (ns NeverSleeper) Duration() time.Duration   { return 0 * time.Nanosecond }

--- a/services/application.go
+++ b/services/application.go
@@ -59,7 +59,7 @@ func (app *ChainlinkApplication) Start() error {
 	go func() {
 		<-sigs
 		app.Stop()
-		app.Exiter(1)
+		app.Exiter(0)
 	}()
 
 	app.attachmentID = app.HeadTracker.Attach(app.EthereumListener)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -254,7 +254,7 @@ func toBlockNumArg(number *big.Int) string {
 // interval, excluding Cron, like reconnecting.
 type Sleeper interface {
 	Reset()
-	Sleep()
+	Sleep() <-chan (time.Time)
 	Duration() time.Duration
 }
 
@@ -273,8 +273,8 @@ func NewBackoffSleeper() BackoffSleeper {
 }
 
 // Sleep waits for the given duration before reattempting.
-func (bs BackoffSleeper) Sleep() {
-	time.Sleep(bs.Backoff.Duration())
+func (bs BackoffSleeper) Sleep() <-chan (time.Time) {
+	return time.After(bs.Backoff.Duration())
 }
 
 // Duration returns the current duration value.


### PR DESCRIPTION
In `internal/ci/ethereum_test`, we kill all processes at the same time. This results in

1. `gethnet` shutting down resulting in CL attempting to reconnect.
2. CL attempting a graceful exit and invoking app.Stop().

The crux of the issue is that `HeadTracker#Stop()` is ambiguously used both by the reconnect loop and the application stop, and must be refactored in order to prevent deadlock, or inability to reconnect.

Currently a WIP.