### PR TITLE
Wait for geth rather than using an arbitrary sleep

### DIFF
--- a/internal/ci/ethereum_test
+++ b/internal/ci/ethereum_test
@@ -11,7 +11,9 @@ PATH=./internal/bin:./node_modules/.bin:$PATH
 time go get -d github.com/ethereum/go-ethereum
 time go install github.com/ethereum/go-ethereum/cmd/geth
 gethnet &
-sleep 3
+while ! curl -s http://127.0.0.1:18545; do
+    sleep 1
+done
 
 # Run CL against ethereum node
 cldev &


### PR DESCRIPTION
This seems to fail quite frequently for me, geth startup time does not appear to be very consistent. So I put in an actual polling loop to make sure geth is running before continuing.