### PR TITLE
Specify node version to lts/carbon

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/carbon

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: required
 services:
   - docker
 
-node_js: 8.4
+node_js: lts/carbon
 cache:
   yarn: true
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: required
 services:
   - docker
 
-node_js: lts/carbon
 cache:
   yarn: true
   directories:


### PR DESCRIPTION
This relies on the tool [nvm](https://github.com/creationix/nvm#nvmrc).
Automatic version switching, is not out of the box, but at the very least,
we can merely execute `nvm install` or `nvm use`.

Other options:

1. `nvm use --default`
2. [avn](https://github.com/wbyoung/avn)