### PR TITLE
Hex or hex-assumed jobID topic filtering:

### DIFF
--- a/internal/cltest/fixtures.go
+++ b/internal/cltest/fixtures.go
@@ -198,7 +198,7 @@ func NewRunLog(jobID string, addr common.Address, blk int, json string) ethtypes
 		Data:        StringToRunLogData(json),
 		Topics: []common.Hash{
 			services.RunLogTopic,
-			StringToHash("requestID"),
+			StringToHash("internalID"),
 			StringToHash(jobID),
 			common.BigToHash(big.NewInt(0)),
 		},


### PR DESCRIPTION
Handles correct hex encoded job ID and the scenario where user passes in
incorrect 0xJOBID, mistakenly assuming it’s already a hex encoded value.

Geth graciously corrects mistakenly assumed hex encoded values, while
parity strictly adheres to what’s passed in, resulting in different topics
depending on the running node if inputing 0xJOBID and not 0xHEXJOBID.