### PR TITLE
Created the copy adaptor for copying bridge values

### DIFF
--- a/adapters/adapter.go
+++ b/adapters/adapter.go
@@ -50,6 +50,9 @@ func For(task models.TaskSpec, store *store.Store) (AdapterWithMinConfs, error) 
 	case "jsonparse":
 		ac = &JSONParse{}
 		err = unmarshalParams(task.Params, ac)
+	case "copy":
+		ac = &Copy{}
+		err = unmarshalParams(task.Params, ac)
 	case "ethbytes32":
 		ac = &EthBytes32{}
 		err = unmarshalParams(task.Params, ac)

--- a/adapters/copy.go
+++ b/adapters/copy.go
@@ -1,0 +1,25 @@
+package adapters
+
+import (
+	"github.com/smartcontractkit/chainlink/store"
+	"github.com/smartcontractkit/chainlink/store/models"
+)
+
+// Copy obj keys refers to which value to copy inside `data`,
+// each obj value refers to where to copy the value to inside `data`
+type Copy struct {
+	CopyPath []string `json:"copyPath"`
+}
+
+// Perform returns the copied values from the desired mapping within the `data` JSON object
+func (c *Copy) Perform(input models.RunResult, store *store.Store) models.RunResult {
+	jp := JSONParse{Path: c.CopyPath}
+
+	data, err := input.Data.Add("value", input.Data.String())
+	if err != nil {
+		return input.WithError(err)
+	}
+	input.Data = data
+
+	return jp.Perform(input, store)
+}

--- a/adapters/copy_test.go
+++ b/adapters/copy_test.go
@@ -1,0 +1,50 @@
+package adapters_test
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink/adapters"
+	"github.com/smartcontractkit/chainlink/internal/cltest"
+	"github.com/stretchr/testify/assert"
+	"log"
+)
+
+func TestCopy_Perform(t *testing.T) {
+	tests := []struct {
+		name            string
+		value           string
+		copyPath        []string
+		want            string
+		wantError       bool
+		wantResultError bool
+	}{
+		{"existing path", `{"high":"11850.00","last":"11779.99"}`, []string{"last"},
+			`{"high":"11850.00","last":"11779.99","value":"11779.99"}`, false, false},
+		{"nonexistent path", `{"high":"11850.00","last":"11779.99"}`, []string{"doesnotexist"},
+			`{"high":"11850.00","last":"11779.99","value":null}`, true, false},
+		{"double nonexistent path", `{"high":"11850.00","last":"11779.99"}`, []string{"no", "really"},
+			`{"high":"11850.00","last":"11779.99","value":"{\"high\":\"11850.00\",\"last\":\"11779.99\"}"}`, true, true},
+		{"array index path", `{"data":[{"availability":"0.99991"}]}`, []string{"data", "0", "availability"},
+			`{"data":[{"availability":"0.99991"}],"value":"0.99991"}`, false, false},
+		{"float value", `{"availability":0.99991}`, []string{"availability"},
+			`{"availability":0.99991,"value":"0.99991"}`, false, false},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			input := cltest.RunResultWithData(test.value)
+			log.Print(input)
+			adapter := adapters.Copy{CopyPath: test.copyPath}
+			result := adapter.Perform(input, nil)
+			assert.Equal(t, test.want, result.Data.String())
+
+			if test.wantResultError {
+				assert.NotNil(t, result.GetError())
+			} else {
+				assert.Nil(t, result.GetError())
+			}
+		})
+	}
+}

--- a/internal/cltest/fixtures.go
+++ b/internal/cltest/fixtures.go
@@ -283,6 +283,15 @@ func RunResultWithValue(val string) models.RunResult {
 	return models.RunResult{Data: data}
 }
 
+// RunResultWithData creates a run result with a given data JSON object
+func RunResultWithData(val string) models.RunResult {
+	data, err := models.ParseJSON([]byte(val))
+	if err != nil {
+		return RunResultWithError(err)
+	}
+	return models.RunResult{Data: data}
+}
+
 // RunResultWithError creates a runresult with given error
 func RunResultWithError(err error) models.RunResult {
 	return models.RunResult{

--- a/internal/fixtures/web/bridge_type_copy_job.json
+++ b/internal/fixtures/web/bridge_type_copy_job.json
@@ -1,0 +1,7 @@
+{
+  "initiators": [{ "type": "web" }],
+  "tasks": [
+    { "type": "assetPrice" },
+    { "type": "copy" }
+  ]
+}


### PR DESCRIPTION
Copy adaptor loops through all the parameters passed in, each parameter key is the from and each value is the to.

When testing the integration, I noticed the type of the adaptor is also passed in which blocks it from returning an error if something invalid was passed in. Instead, it just skips them.

EDIT: For issue #284 