### PR TITLE
Remove unneeded import in Chainlinked contract

### DIFF
--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -3,11 +3,9 @@ pragma solidity ^0.4.23;
 import "./ChainlinkLib.sol";
 import "./Oracle.sol";
 import "linkToken/contracts/LinkToken.sol";
-import "solidity-cborutils/contracts/CBOR.sol";
 
 contract Chainlinked {
   using ChainlinkLib for ChainlinkLib.Run;
-  using CBOR for Buffer.buffer;
 
   uint256 constant clArgsVersion = 1;
 


### PR DESCRIPTION
CBOR is only used in ChainlinkLib, where it's also imported.