### PR TITLE
Don't attempt to use a prompt if not on a tty

### DIFF
--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -381,6 +381,11 @@ func (p *MockCountingPrompt) Prompt(string) string {
 	return p.EnteredStrings[i]
 }
 
+// IsTerminal always returns true in tests
+func (p *MockCountingPrompt) IsTerminal() bool {
+	return true
+}
+
 // NewHTTPMockServer create http test server with passed in parameters
 func NewHTTPMockServer(
 	t *testing.T,


### PR DESCRIPTION
If you run chainlink in a docker container or output to stdout and you forget to supply a password, you'll get a weird `ioctl failed on device` error and it will continue to run.

So when the password is absent, check for a tty before attempting to interactively get a password from the user.

:bowtie: 