### PR TITLE
Replace assert.Nil w assert.NoError, mitigate TestEthClient_GetTxReceipt flakiness

### DIFF
--- a/adapters/adapter_test.go
+++ b/adapters/adapter_test.go
@@ -19,7 +19,7 @@ func TestCreatingAdapterWithConfig(t *testing.T) {
 	task := models.TaskSpec{Type: "NoOp"}
 	adapter, err := adapters.For(task, store)
 	adapter.Perform(models.RunResult{}, nil)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestAdapterFor(t *testing.T) {
@@ -47,9 +47,9 @@ func TestAdapterFor(t *testing.T) {
 			task := models.TaskSpec{Type: test.bridgeName}
 			adapter, err := adapters.For(task, store)
 			if test.errored {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				wa, ok := adapter.(adapters.MinConfsWrappedAdapter)
 				if ok {
 					assert.Equal(t, test.want, reflect.TypeOf(wa.Adapter).String())

--- a/adapters/eth_format_test.go
+++ b/adapters/eth_format_test.go
@@ -41,8 +41,8 @@ func TestEthBytes32_Perform(t *testing.T) {
 
 			val, err := result.Value()
 			assert.Equal(t, test.expected, val)
-			assert.Nil(t, err)
-			assert.Nil(t, result.GetError())
+			assert.NoError(t, err)
+			assert.NoError(t, result.GetError())
 		})
 	}
 }
@@ -98,11 +98,11 @@ func TestEthInt256_Perform(t *testing.T) {
 			result := adapter.Perform(input, nil)
 
 			if test.errored {
-				assert.NotNil(t, result.GetError())
+				assert.Error(t, result.GetError())
 			} else {
 				val, err := result.Value()
-				assert.Nil(t, result.GetError())
-				assert.Nil(t, err)
+				assert.NoError(t, result.GetError())
+				assert.NoError(t, err)
 				assert.Equal(t, test.want, val)
 			}
 		})
@@ -153,11 +153,11 @@ func TestEthUint256_Perform(t *testing.T) {
 			result := adapter.Perform(input, nil)
 
 			if test.errored {
-				assert.NotNil(t, result.GetError())
+				assert.Error(t, result.GetError())
 			} else {
 				val, err := result.Value()
-				assert.Nil(t, result.GetError())
-				assert.Nil(t, err)
+				assert.NoError(t, result.GetError())
+				assert.NoError(t, err)
 				assert.Equal(t, test.want, val)
 			}
 		})

--- a/adapters/eth_tx_test.go
+++ b/adapters/eth_tx_test.go
@@ -38,7 +38,7 @@ func TestEthTxAdapter_Perform_Confirmed(t *testing.T) {
 		func(_ interface{}, data ...interface{}) error {
 			rlp := data[0].([]interface{})[0].(string)
 			tx, err := utils.DecodeEthereumTx(rlp)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, address.String(), tx.To().String())
 			wantData := utils.HexConcat(fHash.String(), dataPrefix.String(), inputValue)
 			assert.Equal(t, wantData, hexutil.Encode(tx.Data()))
@@ -86,7 +86,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_StillPending(t *testing.T
 	tx := cltest.NewTx(from, sentAt)
 	assert.Nil(t, store.Save(tx))
 	a, err := store.AddAttempt(tx, tx.EthTx(big.NewInt(1)), sentAt)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	adapter := adapters.EthTx{}
 	sentResult := cltest.RunResultWithValue(a.Hash.String())
 	input := sentResult.MarkPendingConfirmations()
@@ -120,7 +120,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_BumpGas(t *testing.T) {
 	tx := cltest.NewTx(from, sentAt)
 	assert.Nil(t, store.Save(tx))
 	a, err := store.AddAttempt(tx, tx.EthTx(big.NewInt(1)), 1)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	adapter := adapters.EthTx{}
 	sentResult := cltest.RunResultWithValue(a.Hash.String())
 	input := sentResult.MarkPendingConfirmations()

--- a/adapters/http_test.go
+++ b/adapters/http_test.go
@@ -24,7 +24,7 @@ func TestHttpAdapters_NotAUrlError(t *testing.T) {
 			t.Parallel()
 			result := test.adapter.Perform(models.RunResult{}, nil)
 			assert.Equal(t, models.JSON{}, result.Data)
-			assert.NotNil(t, result.Error)
+			assert.True(t, result.HasError())
 		})
 	}
 }
@@ -57,7 +57,7 @@ func TestHttpGet_Perform(t *testing.T) {
 			result := hga.Perform(input, nil)
 
 			val, err := result.Value()
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, test.want, val)
 			assert.Equal(t, test.wantErrored, result.HasError())
 			assert.Equal(t, false, result.Status.PendingBridge())
@@ -94,7 +94,7 @@ func TestHttpPost_Perform(t *testing.T) {
 			result := hpa.Perform(input, nil)
 
 			val, err := result.Get("value")
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, test.want, val.String())
 			assert.Equal(t, true, val.Exists())
 			assert.Equal(t, test.wantErrored, result.HasError())

--- a/adapters/json_parse_test.go
+++ b/adapters/json_parse_test.go
@@ -39,9 +39,9 @@ func TestJsonParse_Perform(t *testing.T) {
 			assert.Equal(t, test.want, result.Data.String())
 
 			if test.wantResultError {
-				assert.NotNil(t, result.GetError())
+				assert.Error(t, result.GetError())
 			} else {
-				assert.Nil(t, result.GetError())
+				assert.NoError(t, result.GetError())
 			}
 		})
 	}

--- a/adapters/multiply_test.go
+++ b/adapters/multiply_test.go
@@ -48,16 +48,16 @@ func TestMultiply_Perform(t *testing.T) {
 			result := adapter.Perform(input, nil)
 
 			if test.jsonError {
-				assert.NotNil(t, jsonErr)
+				assert.Error(t, jsonErr)
 			} else if test.errored {
-				assert.NotNil(t, result.GetError())
-				assert.Nil(t, jsonErr)
+				assert.Error(t, result.GetError())
+				assert.NoError(t, jsonErr)
 			} else {
 				val, err := result.Value()
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 				assert.Equal(t, test.want, val)
-				assert.Nil(t, result.GetError())
-				assert.Nil(t, jsonErr)
+				assert.NoError(t, result.GetError())
+				assert.NoError(t, jsonErr)
 			}
 		})
 	}

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -80,7 +80,7 @@ func TestClient_ShowJobSpec_NotFound(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Parse([]string{"bogus-ID"})
 	c := cli.NewContext(nil, set, nil)
-	assert.NotNil(t, client.ShowJobSpec(c))
+	assert.Error(t, client.ShowJobSpec(c))
 	assert.Empty(t, r.Renders)
 }
 
@@ -108,7 +108,7 @@ func TestClient_CreateJobSpec(t *testing.T) {
 		set.Parse([]string{test.input})
 		c := cli.NewContext(nil, set, nil)
 		if test.errored {
-			assert.NotNil(t, client.CreateJobSpec(c))
+			assert.Error(t, client.CreateJobSpec(c))
 		} else {
 			assert.Nil(t, client.CreateJobSpec(c))
 		}
@@ -155,7 +155,7 @@ func TestClient_CreateJobRun(t *testing.T) {
 			set.Parse(args)
 			c := cli.NewContext(nil, set, nil)
 			if test.errored {
-				assert.NotNil(t, client.CreateJobRun(c))
+				assert.Error(t, client.CreateJobRun(c))
 			} else {
 				assert.Nil(t, client.CreateJobRun(c))
 			}
@@ -190,7 +190,7 @@ func TestClient_AddBridge(t *testing.T) {
 			set.Parse([]string{test.param})
 			c := cli.NewContext(nil, set, nil)
 			if test.errored {
-				assert.NotNil(t, client.AddBridge(c))
+				assert.Error(t, client.AddBridge(c))
 			} else {
 				assert.Nil(t, client.AddBridge(c))
 			}
@@ -253,14 +253,14 @@ func TestClient_BackupDatabase(t *testing.T) {
 	c := cli.NewContext(nil, set, nil)
 
 	err := client.BackupDatabase(c)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	restored := models.NewORM(path)
 	restoredJob, err := restored.FindJob(job.ID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	reloaded, err := app.Store.FindJob(job.ID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, reloaded, restoredJob)
 }
 
@@ -277,7 +277,7 @@ func TestClient_ImportKey(t *testing.T) {
 	set.Parse([]string{"../internal/fixtures/keys/3cb8e3fd9d27e39a5e9e6852b0e96160061fd4ea.json"})
 	c := cli.NewContext(nil, set, nil)
 	assert.Nil(t, client.ImportKey(c))
-	assert.NotNil(t, client.ImportKey(c))
+	assert.Error(t, client.ImportKey(c))
 }
 
 func first(a models.JobSpec, b interface{}) models.JobSpec {

--- a/cmd/renderer_test.go
+++ b/cmd/renderer_test.go
@@ -60,5 +60,5 @@ func TestRendererTableRenderBridge(t *testing.T) {
 func TestRendererTableRenderUnknown(t *testing.T) {
 	r := cmd.RendererTable{Writer: ioutil.Discard}
 	anon := struct{ Name string }{"Romeo"}
-	assert.NotNil(t, r.Render(&anon))
+	assert.Error(t, r.Render(&anon))
 }

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -359,7 +359,7 @@ func FixtureCreateJobWithAssignmentViaWeb(t *testing.T, app *TestApplication, pa
 // CreateJobSpecViaWeb creates a jobspec via web using /v2/specs
 func CreateJobSpecViaWeb(t *testing.T, app *TestApplication, job models.JobSpec) models.JobSpec {
 	marshaled, err := json.Marshal(&job)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	resp := BasicAuthPost(
 		app.Server.URL+"/v2/specs",
 		"application/json",
@@ -536,13 +536,13 @@ func WaitForRuns(t *testing.T, j models.JobSpec, store *store.Store, want int) [
 	if want == 0 {
 		g.Consistently(func() []models.JobRun {
 			jrs, err = store.JobRunsFor(j.ID)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			return jrs
 		}).Should(gomega.HaveLen(want))
 	} else {
 		g.Eventually(func() []models.JobRun {
 			jrs, err = store.JobRunsFor(j.ID)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			return jrs
 		}).Should(gomega.HaveLen(want))
 	}

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -113,7 +113,8 @@ func NewWSServer(msg string) *httptest.Server {
 	}
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		conn, _ := upgrader.Upgrade(w, r, nil)
+		conn, err := upgrader.Upgrade(w, r, nil)
+		logger.PanicIf(err)
 		conn.WriteMessage(websocket.BinaryMessage, []byte(msg))
 	})
 	server := httptest.NewServer(handler)

--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -397,7 +397,7 @@ func NewHTTPMockServer(
 	called := false
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, err := ioutil.ReadAll(r.Body)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, wantMethod, r.Method)
 		if len(callback) > 0 {
 			callback[0](string(b))

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -131,6 +131,13 @@ func WarnIf(err error) {
 	}
 }
 
+//PanicIf logs the error if present.
+func PanicIf(err error) {
+	if err != nil {
+		logger.Panic(err)
+	}
+}
+
 // Fatal logs a fatal message then exits the application using Sprint.
 func Fatal(args ...interface{}) {
 	logger.Fatal(args...)

--- a/logger/prettyconsole_test.go
+++ b/logger/prettyconsole_test.go
@@ -44,7 +44,7 @@ func TestPrettyConsole_Write(t *testing.T) {
 			_, err := pc.Write([]byte(tt.input))
 
 			if tt.wantError {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
 				assert.Equal(t, tt.want, tr.Written)
 			}

--- a/services/head_tracker_test.go
+++ b/services/head_tracker_test.go
@@ -62,9 +62,9 @@ func TestHeadTracker_Get(t *testing.T) {
 
 			err := ht.Save(test.toSave)
 			if test.wantError {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 
 			assert.Equal(t, test.want, ht.LastRecord().ToInt())

--- a/services/job_runner_test.go
+++ b/services/job_runner_test.go
@@ -60,7 +60,7 @@ func TestJobRunner_ExecuteRun(t *testing.T) {
 			run = job.NewRun(initr)
 			input := models.RunResult{Data: cltest.JSONFromString(test.input)}
 			run, err := services.ExecuteRun(run, store, input)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			store.One("ID", run.ID, &run)
 			assert.Equal(t, test.wantStatus, run.Status)
@@ -173,18 +173,18 @@ func TestExecuteRun_TransitionToPendingConfirmations_WithBridgeTask(t *testing.T
 			assert.Nil(t, store.Save(&bt))
 
 			run, err := store.SaveCreationHeight(run, cltest.IndexableBlockNumber(creationHeight))
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			early := cltest.IndexableBlockNumber(creationHeight + test.triggeringConf - 2)
 			run, err = services.ExecuteRunAtBlock(run, store, models.RunResult{}, early)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			store.One("ID", run.ID, &run)
 			assert.Equal(t, models.RunStatusPendingConfirmations, run.Status)
 
 			trigger := cltest.IndexableBlockNumber(creationHeight + test.triggeringConf - 1)
 			run, err = services.ExecuteRunAtBlock(run, store, models.RunResult{}, trigger)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, models.RunStatusCompleted, run.Status)
 		})
 	}
@@ -200,7 +200,7 @@ func TestJobRunner_ExecuteRun_TransitionToPending(t *testing.T) {
 
 	run := job.NewRun(initr)
 	run, err := services.ExecuteRun(run, store, models.RunResult{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	store.One("ID", run.ID, &run)
 	assert.Equal(t, models.RunStatusPendingConfirmations, run.Status)
@@ -215,7 +215,7 @@ func TestJobRunner_ExecuteRun_ErrorsWithNoRuns(t *testing.T) {
 	job.Tasks = []models.TaskSpec{}
 	run := job.NewRun(initr)
 	run, err := services.ExecuteRun(run, store, models.RunResult{})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestJobRunner_BeginRunWithAmount(t *testing.T) {
@@ -284,12 +284,12 @@ func TestJobRunner_BeginRun(t *testing.T) {
 			_, err := services.BeginRun(job, initr, models.RunResult{}, store)
 
 			if test.errored {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 			jrs, err := store.JobRunsFor(job.ID)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, test.runCount, len(jrs))
 		})
 	}
@@ -328,9 +328,9 @@ func TestJobRunner_BuildRun(t *testing.T) {
 			_, err := services.BuildRun(job, initr, store)
 
 			if test.errored {
-				assert.NotNil(t, err)
+				assert.Error(t, err)
 			} else {
-				assert.Nil(t, err)
+				assert.NoError(t, err)
 			}
 		})
 	}

--- a/services/job_subscriber_test.go
+++ b/services/job_subscriber_test.go
@@ -175,7 +175,7 @@ func TestJobSubscriber_OnNewHead_OnlyRunPendingConfirmations(t *testing.T) {
 			el.OnNewHead(cltest.NewBlockHeader(10))
 
 			refreshed, err := store.FindJobRun(run.ID)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, test.wantStatus, refreshed.Status)
 		})
 	}

--- a/services/scheduler_test.go
+++ b/services/scheduler_test.go
@@ -65,7 +65,7 @@ func TestScheduler_Start_AddingUnstartedJob(t *testing.T) {
 
 	gomega.NewGomegaWithT(t).Consistently(func() int {
 		runs, err := store.JobRunsFor(j.ID)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		return len(runs)
 	}, (2 * time.Second)).Should(gomega.Equal(0))
 
@@ -252,7 +252,7 @@ func TestOneTime_RunJobAt_RunTwice(t *testing.T) {
 
 	ot.RunJobAt(initrs[0], j)
 	j2, err := ot.Store.FindJob(j.ID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	var initrs2 []models.Initiator
 	store.Where("JobID", j.ID, &initrs2)

--- a/services/subscription_test.go
+++ b/services/subscription_test.go
@@ -32,7 +32,7 @@ func TestInitiatorSubscriptionLogEvent_RunLogJSON(t *testing.T) {
 			le := services.InitiatorSubscriptionLogEvent{Log: test.el}
 			output, err := le.RunLogJSON()
 			assert.JSONEq(t, strings.ToLower(test.wantData.String()), strings.ToLower(output.String()))
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, test.wantErrored, (err != nil))
 		})
 	}
@@ -79,7 +79,7 @@ func TestServices_NewInitiatorSubscription_BackfillLogs(t *testing.T) {
 	head := cltest.IndexableBlockNumber(0)
 	subscriber := services.NewRPCLogSubscriber(initr, head, nil, callback)
 	sub, err := services.NewInitiatorSubscription(initr, job, store, subscriber)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer sub.Unsubscribe()
 
 	eth.EventuallyAllCalled(t)
@@ -100,7 +100,7 @@ func TestServices_NewInitiatorSubscription_BackfillLogs_WithNoHead(t *testing.T)
 	callback := func(services.InitiatorSubscriptionLogEvent) { count += 1 }
 	subscriber := services.NewRPCLogSubscriber(initr, nil, nil, callback)
 	sub, err := services.NewInitiatorSubscription(initr, job, store, subscriber)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer sub.Unsubscribe()
 
 	eth.EventuallyAllCalled(t)
@@ -126,7 +126,7 @@ func TestServices_NewInitiatorSubscription_PreventsDoubleDispatch(t *testing.T) 
 	head := cltest.IndexableBlockNumber(0)
 	subscriber := services.NewRPCLogSubscriber(initr, head, nil, callback)
 	sub, err := services.NewInitiatorSubscription(initr, job, store, subscriber)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer sub.Unsubscribe()
 
 	eth.EventuallyAllCalled(t)

--- a/services/validators_test.go
+++ b/services/validators_test.go
@@ -38,7 +38,7 @@ func TestValidateJob(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var j models.JobSpec
-			assert.Nil(t, json.Unmarshal(test.input, &j))
+			assert.NoError(t, json.Unmarshal(test.input, &j))
 			result := services.ValidateJob(j, store)
 			assert.Equal(t, test.want, result)
 		})
@@ -54,9 +54,9 @@ func TestValidateAdapter(t *testing.T) {
 	tt := models.BridgeType{}
 	tt.Name = "solargridreporting"
 	u, err := url.Parse("https://denergy.eth")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tt.URL = models.WebURL{URL: u}
-	assert.Nil(t, store.Save(&tt))
+	assert.NoError(t, store.Save(&tt))
 
 	tests := []struct {
 		description string
@@ -110,12 +110,12 @@ func TestValidateInitiator(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var initr models.Initiator
-			assert.Nil(t, json.Unmarshal([]byte(test.input), &initr))
+			assert.NoError(t, json.Unmarshal([]byte(test.input), &initr))
 			result := services.ValidateInitiator(initr, job)
 			if test.wantError {
-				assert.NotNil(t, result)
+				assert.Error(t, result)
 			} else {
-				assert.Nil(t, result)
+				assert.NoError(t, result)
 			}
 		})
 	}

--- a/store/eth_client_test.go
+++ b/store/eth_client_test.go
@@ -23,7 +23,7 @@ func TestEthClient_GetTxReceipt(t *testing.T) {
 
 	hash := common.HexToHash("0xb903239f8543d04b5dc1ba6579132b143087c68db1b2168786408fcbce568238")
 	receipt, err := ec.GetTxReceipt(hash)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, hash, receipt.Hash)
 	assert.Equal(t, cltest.BigHexInt(uint64(11)), receipt.BlockNumber)
 }
@@ -36,7 +36,7 @@ func TestEthClient_GetNonce(t *testing.T) {
 	ethClientObject := app.Store.TxManager.EthClient
 	ethMock.Register("eth_getTransactionCount", "0x0100")
 	result, err := ethClientObject.GetNonce(cltest.NewAddress())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	var expected uint64 = 256
 	assert.Equal(t, result, expected)
 }
@@ -49,7 +49,7 @@ func TestEthClient_GetBlockNumber(t *testing.T) {
 	ethClientObject := app.Store.TxManager.EthClient
 	ethMock.Register("eth_blockNumber", "0x0100")
 	result, err := ethClientObject.GetBlockNumber()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	var expected uint64 = 256
 	assert.Equal(t, result, expected)
 }
@@ -62,7 +62,7 @@ func TestEthClient_SendRawTx(t *testing.T) {
 	ethClientObject := app.Store.TxManager.EthClient
 	ethMock.Register("eth_sendRawTransaction", common.Hash{1})
 	result, err := ethClientObject.SendRawTx("test")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, result, common.Hash{1})
 }
 
@@ -95,7 +95,7 @@ func TestEthClient_GetEthBalance(t *testing.T) {
 
 			ethMock.Register("eth_getBalance", test.input)
 			result, err := ethClientObject.GetEthBalance(cltest.NewAddress())
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, test.expected, result)
 		})
 	}
@@ -111,15 +111,15 @@ func TestEthClient_GetERC20Balance(t *testing.T) {
 
 	ethMock.Register("eth_call", "0x0100") // 256
 	result, err := ethClientObject.GetERC20Balance(cltest.NewAddress(), cltest.NewAddress())
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	expected := big.NewInt(256)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, result)
 
 	ethMock.Register("eth_call", "0x4b3b4ca85a86c47a098a224000000000") // 1e38
 	result, err = ethClientObject.GetERC20Balance(cltest.NewAddress(), cltest.NewAddress())
 	expected = big.NewInt(0)
 	expected.SetString("100000000000000000000000000000000000000", 10)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, expected, result)
 }

--- a/store/eth_client_test.go
+++ b/store/eth_client_test.go
@@ -11,7 +11,6 @@ import (
 )
 
 func TestEthClient_GetTxReceipt(t *testing.T) {
-	t.Parallel()
 	response := cltest.LoadJSON("../internal/fixtures/eth/getTransactionReceipt.json")
 	mockServer := cltest.NewWSServer(string(response))
 	defer mockServer.Close()

--- a/store/key_store_test.go
+++ b/store/key_store_test.go
@@ -16,7 +16,7 @@ func TestCreateEthereumAccount(t *testing.T) {
 	defer cleanup()
 
 	_, err := store.KeyStore.NewAccount(passphrase)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	files, _ := ioutil.ReadDir(store.Config.KeysDir())
 	assert.Equal(t, 1, len(files))
@@ -29,6 +29,6 @@ func TestUnlockKey(t *testing.T) {
 
 	store.KeyStore.NewAccount(passphrase)
 
-	assert.NotNil(t, store.KeyStore.Unlock("wrong phrase"))
-	assert.Nil(t, store.KeyStore.Unlock(passphrase))
+	assert.Error(t, store.KeyStore.Unlock("wrong phrase"))
+	assert.NoError(t, store.KeyStore.Unlock(passphrase))
 }

--- a/store/models/common_test.go
+++ b/store/models/common_test.go
@@ -39,7 +39,7 @@ func Test_ParseCBOR(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			b, err := utils.HexToBytes(test.in)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			json, err := models.ParseCBOR(b)
 			assert.Equal(t, test.want, json)
@@ -175,11 +175,11 @@ func TestJSON_CBOR(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			encoded, err := test.in.CBOR()
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			var decoded interface{}
 			cbor := codec.NewDecoderBytes(encoded, new(codec.CborHandle))
-			assert.Nil(t, cbor.Decode(&decoded))
+			assert.NoError(t, cbor.Decode(&decoded))
 
 			decoded = coerceInterfaceMapToStringMap(decoded)
 
@@ -212,7 +212,7 @@ func TestWebURL_UnmarshalJSON_Error(t *testing.T) {
 	j := []byte(`"NotAUrl"`)
 	wurl := &models.WebURL{}
 	err := json.Unmarshal(j, wurl)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestWebURL_UnmarshalJSON(t *testing.T) {
@@ -220,7 +220,7 @@ func TestWebURL_UnmarshalJSON(t *testing.T) {
 	j := []byte(`"http://www.duckduckgo.com"`)
 	wurl := &models.WebURL{}
 	err := json.Unmarshal(j, wurl)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 }
 
 func TestWebURL_MarshalJSON(t *testing.T) {
@@ -228,10 +228,10 @@ func TestWebURL_MarshalJSON(t *testing.T) {
 
 	str := "http://www.duckduckgo.com"
 	parsed, err := url.ParseRequestURI(str)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	wurl := &models.WebURL{URL: parsed}
 	b, err := json.Marshal(wurl)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, `"`+str+`"`, string(b))
 }
 

--- a/store/models/eth_test.go
+++ b/store/models/eth_test.go
@@ -30,7 +30,7 @@ func TestModels_FunctionSelectorUnmarshalJSON(t *testing.T) {
 	bytes := []byte(`"0xb3f98adc"`)
 	var fid models.FunctionSelector
 	err := json.Unmarshal(bytes, &fid)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "0xb3f98adc", fid.String())
 }
 
@@ -39,7 +39,7 @@ func TestModels_FunctionSelectorUnmarshalJSONError(t *testing.T) {
 	bytes := []byte(`"0xb3f98adc123456"`)
 	var fid models.FunctionSelector
 	err := json.Unmarshal(bytes, &fid)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestModels_Header_UnmarshalJSON(t *testing.T) {
@@ -70,7 +70,7 @@ func TestModels_Header_UnmarshalJSON(t *testing.T) {
 
 			data := cltest.LoadJSON(test.path)
 			value := gjson.Get(string(data), "params.result")
-			assert.Nil(t, json.Unmarshal([]byte(value.String()), &header))
+			assert.NoError(t, json.Unmarshal([]byte(value.String()), &header))
 
 			assert.Equal(t, test.wantNumber, header.Number)
 			assert.Equal(t, test.wantHash, header.Hash().String())

--- a/store/models/job_spec_test.go
+++ b/store/models/job_spec_test.go
@@ -18,11 +18,11 @@ func TestJobSpec_Save(t *testing.T) {
 	defer cleanup()
 
 	j1, initr := cltest.NewJobWithSchedule("* * * * 7")
-	assert.Nil(t, store.SaveJob(&j1))
+	assert.NoError(t, store.SaveJob(&j1))
 
 	store.Save(j1)
 	j2, err := store.FindJob(j1.ID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, initr.Schedule, j2.Initiators[0].Schedule)
 }
 
@@ -122,15 +122,15 @@ func TestTask_UnmarshalJSON(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			var task models.TaskSpec
 			err := json.Unmarshal([]byte(test.json), &task)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, test.confirmations, task.Confirmations)
 
 			assert.Equal(t, test.taskType, task.Type)
 			_, err = adapters.For(task, store)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			s, err := json.Marshal(task)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, test.json, string(s))
 		})
 	}

--- a/store/models/orm_test.go
+++ b/store/models/orm_test.go
@@ -23,7 +23,7 @@ func TestWhereNotFound(t *testing.T) {
 	jobs := []models.JobSpec{j1}
 
 	err := store.Where("ID", "bogus", &jobs)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, len(jobs), "Queried array should be empty")
 }
 
@@ -34,7 +34,7 @@ func TestAllNotFound(t *testing.T) {
 
 	var jobs []models.JobSpec
 	err := store.All(&jobs)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, len(jobs), "Queried array should be empty")
 }
 
@@ -51,7 +51,7 @@ func TestORMSaveJob(t *testing.T) {
 	assert.NotEqual(t, 0, j2.Initiators[0])
 	assert.Equal(t, j2.Initiators[0].ID, j1.Initiators[0].ID)
 	assert.Equal(t, j2.ID, j2.Initiators[0].JobID)
-	assert.Nil(t, store.One("JobID", j1.ID, &initr))
+	assert.NoError(t, store.One("JobID", j1.ID, &initr))
 	assert.Equal(t, models.Cron("* * * * *"), initr.Schedule)
 }
 
@@ -61,9 +61,9 @@ func TestJobRunsWithStatus(t *testing.T) {
 	defer cleanup()
 
 	j, i := cltest.NewJobWithWebInitiator()
-	assert.Nil(t, store.SaveJob(&j))
+	assert.NoError(t, store.SaveJob(&j))
 	npr := j.NewRun(i)
-	assert.Nil(t, store.Save(&npr))
+	assert.NoError(t, store.Save(&npr))
 
 	statuses := []models.RunStatus{
 		models.RunStatusPendingBridge,
@@ -73,7 +73,7 @@ func TestJobRunsWithStatus(t *testing.T) {
 	for _, status := range statuses {
 		run := j.NewRun(i)
 		run.Status = status
-		assert.Nil(t, store.Save(&run))
+		assert.NoError(t, store.Save(&run))
 		seedIds = append(seedIds, run.ID)
 	}
 
@@ -99,7 +99,7 @@ func TestJobRunsWithStatus(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 
 			pending, err := store.JobRunsWithStatus(test.statuses...)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			pendingIDs := []string{}
 			for _, jr := range pending {
@@ -121,13 +121,13 @@ func TestCreatingTx(t *testing.T) {
 	nonce := uint64(1232421)
 	gasLimit := uint64(50000)
 	data, err := hex.DecodeString("0987612345abcdef")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	_, err = store.CreateTx(from, nonce, to, data, value, gasLimit)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	txs := []models.Tx{}
-	assert.Nil(t, store.Where("Nonce", nonce, &txs))
+	assert.NoError(t, store.Where("Nonce", nonce, &txs))
 	assert.Equal(t, 1, len(txs))
 	tx := txs[0]
 
@@ -149,9 +149,9 @@ func TestBridgeTypeFor(t *testing.T) {
 	tt := models.BridgeType{}
 	tt.Name = "solargridreporting"
 	u, err := url.Parse("https://denergy.eth")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tt.URL = models.WebURL{URL: u}
-	assert.Nil(t, store.Save(&tt))
+	assert.NoError(t, store.Save(&tt))
 
 	cases := []struct {
 		description string
@@ -197,14 +197,14 @@ func TestORM_SaveCreationHeight(t *testing.T) {
 				ch := hexutil.Big(*test.creationHeight)
 				jr.CreationHeight = &ch
 			}
-			assert.Nil(t, store.Save(&jr))
+			assert.NoError(t, store.Save(&jr))
 
 			bn := cltest.IndexableBlockNumber(test.parameterHeight)
 			result, err := store.SaveCreationHeight(jr, bn)
 
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, test.wantHeight, result.CreationHeight.ToInt())
-			assert.Nil(t, store.One("ID", jr.ID, &jr))
+			assert.NoError(t, store.One("ID", jr.ID, &jr))
 			assert.Equal(t, test.wantHeight, jr.CreationHeight.ToInt())
 		})
 	}
@@ -217,10 +217,10 @@ func TestMarkRan(t *testing.T) {
 	defer cleanup()
 
 	_, initr := cltest.NewJobWithRunAtInitiator(time.Now())
-	assert.Nil(t, store.Save(&initr))
+	assert.NoError(t, store.Save(&initr))
 
-	assert.Nil(t, store.MarkRan(&initr))
+	assert.NoError(t, store.MarkRan(&initr))
 	var ir models.Initiator
-	assert.Nil(t, store.One("ID", initr.ID, &ir))
+	assert.NoError(t, store.One("ID", initr.ID, &ir))
 	assert.True(t, ir.Ran)
 }

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -25,11 +25,11 @@ func TestJobRuns_RetrievingFromDBWithError(t *testing.T) {
 	jr := job.NewRun(initr)
 	jr.Result = cltest.RunResultWithError(fmt.Errorf("bad idea"))
 	err := store.Save(&jr)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	run := &models.JobRun{}
 	err = store.One("ID", jr.ID, run)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.True(t, run.Result.HasError())
 	assert.Equal(t, "bad idea", run.Result.Error())
 }
@@ -45,12 +45,12 @@ func TestJobRun_UnfinishedTaskRuns(t *testing.T) {
 		{Type: "NoOpPend"},
 		{Type: "NoOp"},
 	}
-	assert.Nil(t, store.SaveJob(&j))
+	assert.NoError(t, store.SaveJob(&j))
 	jr := j.NewRun(i)
 	assert.Equal(t, jr.TaskRuns, jr.UnfinishedTaskRuns())
 
 	jr, err := services.ExecuteRun(jr, store, models.RunResult{})
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, jr.TaskRuns[1:], jr.UnfinishedTaskRuns())
 }
 
@@ -142,7 +142,7 @@ func TestRunResult_Value(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var data models.JSON
-			assert.Nil(t, json.Unmarshal([]byte(test.json), &data))
+			assert.NoError(t, json.Unmarshal([]byte(test.json), &data))
 			rr := models.RunResult{Data: data}
 
 			val, err := rr.Value()

--- a/store/models/v1_test.go
+++ b/store/models/v1_test.go
@@ -53,16 +53,16 @@ func TestAssignmentSpec_ConvertToJobSpec(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var a models.AssignmentSpec
-			assert.Nil(t, json.Unmarshal([]byte(test.input), &a))
+			assert.NoError(t, json.Unmarshal([]byte(test.input), &a))
 
 			j1, err := a.ConvertToJobSpec()
-			assert.Nil(t, err)
-			assert.Nil(t, store.SaveJob(&j1))
+			assert.NoError(t, err)
+			assert.NoError(t, store.SaveJob(&j1))
 			j2 := cltest.FindJob(store, j1.ID)
 
 			assert.NotEqual(t, "", j2.ID)
 			var want models.JobSpec
-			assert.Nil(t, json.Unmarshal([]byte(test.want), &want))
+			assert.NoError(t, json.Unmarshal([]byte(test.want), &want))
 			assert.Equal(t, want.EndAt, j2.EndAt)
 
 			for i, wantTask := range want.Tasks {
@@ -126,13 +126,13 @@ func TestAssignmentSpec_ConvertToAssignment(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var js1 models.JobSpec
-			assert.Nil(t, json.Unmarshal([]byte(test.input), &js1))
+			assert.NoError(t, json.Unmarshal([]byte(test.input), &js1))
 
 			a1, err := models.ConvertToAssignment(js1)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			a2 := models.AssignmentSpec{}
-			assert.Nil(t, json.Unmarshal([]byte(test.want), &a2))
+			assert.NoError(t, json.Unmarshal([]byte(test.want), &a2))
 
 			for i, wantTask := range a2.Assignment.Subtasks {
 				actualTask := a1.Assignment.Subtasks[i]
@@ -175,12 +175,12 @@ func TestAssignmentSpec_ConvertToSnapshot(t *testing.T) {
 
 	for _, test := range tests {
 		var rr models.RunResult
-		assert.Nil(t, json.Unmarshal([]byte(test.input), &rr))
+		assert.NoError(t, json.Unmarshal([]byte(test.input), &rr))
 
 		ss1 := models.ConvertToSnapshot(rr)
 
 		var ss2 models.Snapshot
-		assert.Nil(t, json.Unmarshal([]byte(test.want), &ss2))
+		assert.NoError(t, json.Unmarshal([]byte(test.want), &ss2))
 
 		assert.Equal(t, ss2.Details, ss1.Details)
 		assert.Equal(t, ss2.ID, ss1.ID)

--- a/store/presenters/presenters_test.go
+++ b/store/presenters/presenters_test.go
@@ -37,11 +37,11 @@ func TestPresenterInitiatorHasCorrectKeys(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.i.Type, func(t *testing.T) {
 			j, err := json.Marshal(presenters.Initiator{Initiator: test.i})
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			var value map[string]interface{}
 			err = json.Unmarshal(j, &value)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 
 			keys := utils.GetStringKeys(value)
 			sort.Strings(keys)
@@ -68,7 +68,7 @@ func TestPresenterShowEthBalance_WithEmptyAccount(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithKeyStore()
 	defer cleanup()
 	_, err := presenters.ShowEthBalance(app.Store)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 }
 
 func TestPresenterShowEthBalance_WithAccount(t *testing.T) {
@@ -82,7 +82,7 @@ func TestPresenterShowEthBalance_WithAccount(t *testing.T) {
 	assert.True(t, app.Store.KeyStore.HasAccounts())
 
 	output, err := presenters.ShowEthBalance(app.Store)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	addr := cltest.GetAccountAddress(app.Store).Hex()
 	want := fmt.Sprintf("ETH Balance for %v: 0.000000000000000256", addr)
 	assert.Equal(t, want, output)
@@ -111,7 +111,7 @@ func TestPresenterShowLinkBalance_WithAccount(t *testing.T) {
 	assert.True(t, app.Store.KeyStore.HasAccounts())
 
 	output, err := presenters.ShowLinkBalance(app.Store)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	addr := cltest.GetAccountAddress(app.Store).Hex()
 	want := fmt.Sprintf("Link Balance for %v: 0.000000000000000256", addr)
@@ -145,6 +145,6 @@ func TestBridgeTypeMarshalJSON(t *testing.T) {
 	expected := []byte("{\"name\":\"hapax\",\"url\":\"http://hap.ax\",\"defaultConfirmations\":0}")
 	bt := presenters.BridgeType{BridgeType: input}
 	output, err := bt.MarshalJSON()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, output, expected)
 }

--- a/store/tx_manager_test.go
+++ b/store/tx_manager_test.go
@@ -23,7 +23,7 @@ func TestTxManager_CreateTx_Success(t *testing.T) {
 
 	to := cltest.NewAddress()
 	data, err := hex.DecodeString("0000abcdef")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	hash := cltest.NewHash()
 	sentAt := uint64(23456)
 	nonce := uint64(256)
@@ -31,21 +31,21 @@ func TestTxManager_CreateTx_Success(t *testing.T) {
 	ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce))
 	ethMock.Register("eth_sendRawTransaction", hash)
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(sentAt))
-	assert.Nil(t, app.Start())
+	assert.NoError(t, app.Start())
 
 	a, err := manager.CreateTx(to, data)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tx := models.Tx{}
-	assert.Nil(t, store.One("ID", a.TxID, &tx))
-	assert.Nil(t, err)
+	assert.NoError(t, store.One("ID", a.TxID, &tx))
+	assert.NoError(t, err)
 	assert.Equal(t, nonce, tx.Nonce)
 	assert.Equal(t, data, tx.Data)
 	assert.Equal(t, to, tx.To)
 
-	assert.Nil(t, store.One("From", tx.From, &tx))
+	assert.NoError(t, store.One("From", tx.From, &tx))
 	assert.Equal(t, nonce, tx.Nonce)
 	attempts, err := store.AttemptsFor(tx.ID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(attempts))
 
 	ethMock.EventuallyAllCalled(t)
@@ -65,17 +65,17 @@ func TestTxManager_CreateTx_AttemptErrorDeletesTxAndDoesNotIncrementNonce(t *tes
 
 	to := cltest.NewAddress()
 	data, err := hex.DecodeString("0000abcdef")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	sentAt := uint64(23456)
 	nonce := uint64(256)
 	ethMock := app.MockEthClient()
 	ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce))
 	ethMock.Register("eth_sendRawTransaction", "invalid")
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(sentAt))
-	assert.Nil(t, app.Start())
+	assert.NoError(t, app.Start())
 
 	_, err = manager.CreateTx(to, data)
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 
 	var txs []models.Tx
 	err = store.ORM.All(&txs)
@@ -90,18 +90,18 @@ func TestTxManager_CreateTx_AttemptErrorDeletesTxAndDoesNotIncrementNonce(t *tes
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(sentAt))
 
 	a, err := manager.CreateTx(to, data)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	tx := models.Tx{}
-	assert.Nil(t, store.One("ID", a.TxID, &tx))
-	assert.Nil(t, err)
+	assert.NoError(t, store.One("ID", a.TxID, &tx))
+	assert.NoError(t, err)
 	assert.Equal(t, nonce, tx.Nonce)
 	assert.Equal(t, data, tx.Data)
 	assert.Equal(t, to, tx.To)
 
-	assert.Nil(t, store.One("From", tx.From, &tx))
+	assert.NoError(t, store.One("From", tx.From, &tx))
 	assert.Equal(t, nonce, tx.Nonce)
 	attempts, err := store.AttemptsFor(tx.ID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(attempts))
 
 	ethMock.EventuallyAllCalled(t)
@@ -125,15 +125,15 @@ func TestTxManager_MeetsMinConfirmations_BeforeThreshold(t *testing.T) {
 
 	tx := cltest.CreateTxAndAttempt(store, from, sentAt)
 	attempts, err := store.AttemptsFor(tx.ID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	a := attempts[0]
 
 	confirmed, err := txm.MeetsMinConfirmations(a.Hash)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, confirmed)
-	assert.Nil(t, store.One("ID", tx.ID, tx))
+	assert.NoError(t, store.One("ID", tx.ID, tx))
 	attempts, err = store.AttemptsFor(tx.ID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(attempts))
 
 	ethMock.EventuallyAllCalled(t)
@@ -157,15 +157,15 @@ func TestTxManager_MeetsMinConfirmations_AtThreshold(t *testing.T) {
 
 	tx := cltest.CreateTxAndAttempt(store, from, sentAt)
 	attempts, err := store.AttemptsFor(tx.ID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	a := attempts[0]
 
 	confirmed, err := txm.MeetsMinConfirmations(a.Hash)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.False(t, confirmed)
-	assert.Nil(t, store.One("ID", tx.ID, tx))
+	assert.NoError(t, store.One("ID", tx.ID, tx))
 	attempts, err = store.AttemptsFor(tx.ID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 2, len(attempts))
 
 	ethMock.EventuallyAllCalled(t)
@@ -213,11 +213,11 @@ func TestTxManager_MeetsMinConfirmations_confirmed(t *testing.T) {
 			a := tx.TxAttempt
 
 			actual, err := txm.MeetsMinConfirmations(a.Hash)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, test.want, actual)
 
 			attempts, err := store.AttemptsFor(tx.ID)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.Equal(t, 1, len(attempts))
 
 			ethMock.EventuallyAllCalled(t)
@@ -235,7 +235,7 @@ func TestTxManager_ActivateAccount(t *testing.T) {
 	account := accounts.Account{Address: common.HexToAddress("0xbf4ed7b27f1d666546e30d74d50d173d20bca754")}
 
 	ethMock.Register("eth_getTransactionCount", `0x2D0`)
-	assert.Nil(t, txm.ActivateAccount(account))
+	assert.NoError(t, txm.ActivateAccount(account))
 	ethMock.EventuallyAllCalled(t)
 
 	aa := txm.GetActiveAccount()
@@ -272,11 +272,11 @@ func TestActiveAccount_GetAndIncrementNonce_DoesNotIncrementWhenCallbackThrowsEx
 		assert.Equal(t, uint64(0), y)
 		return errors.New("Should not increment")
 	})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	err = activeAccount.GetAndIncrementNonce(func(y uint64) error {
 		assert.Equal(t, uint64(0), y)
 		return errors.New("Should not increment again")
 	})
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, uint64(0), activeAccount.GetNonce())
 }

--- a/web/assignments_controller_test.go
+++ b/web/assignments_controller_test.go
@@ -20,21 +20,21 @@ func TestAssignmentsController_Create_V1_Format(t *testing.T) {
 	j := cltest.FixtureCreateJobWithAssignmentViaWeb(t, app, "../internal/fixtures/web/v1_format_job.json")
 
 	adapter1, err := adapters.For(j.Tasks[0], app.Store)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	httpGet := cltest.UnwrapAdapter(adapter1).(*adapters.HTTPGet)
 	assert.Equal(t, httpGet.URL.String(), "https://bitstamp.net/api/ticker/")
 
 	adapter2, err := adapters.For(j.Tasks[1], app.Store)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	jsonParse := cltest.UnwrapAdapter(adapter2).(*adapters.JSONParse)
 	assert.Equal(t, jsonParse.Path, []string{"last"})
 
 	adapter3, err := adapters.For(j.Tasks[2], app.Store)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "*adapters.EthBytes32", reflect.TypeOf(cltest.UnwrapAdapter(adapter3)).String())
 
 	adapter4, err := adapters.For(j.Tasks[3], app.Store)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	ethTx := cltest.UnwrapAdapter(adapter4).(*adapters.EthTx)
 	assert.Equal(t, ethTx.Address, common.HexToAddress("0x9CA9d2D5E04012C9Ed24C0e513C9bfAa4A2dD77f"))
 }
@@ -46,7 +46,7 @@ func TestAssignmentsController_Show_V1_Format(t *testing.T) {
 
 	j := cltest.FixtureCreateJobWithAssignmentViaWeb(t, app, "../internal/fixtures/web/v1_format_job_with_schedule.json")
 	a1, err := models.ConvertToAssignment(j)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	resp := cltest.BasicAuthGet(app.Server.URL + "/v1/assignments/" + j.ID)
 	assert.Equal(t, 200, resp.StatusCode, "Response should be successful")

--- a/web/integration_test.go
+++ b/web/integration_test.go
@@ -59,7 +59,7 @@ func TestIntegration_HelloWorld(t *testing.T) {
 	eth.Register("eth_getTransactionReceipt", store.TxReceipt{})
 
 	err := app.Start()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	defer cleanup()
 
 	j := cltest.CreateHelloWorldJobViaWeb(t, app, mockServer.URL)
@@ -88,17 +88,17 @@ func TestIntegration_HelloWorld(t *testing.T) {
 	jr = cltest.WaitForJobRunToComplete(t, app.Store, jr)
 
 	val, err := jr.TaskRuns[0].Result.Value()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, tickerResponse, val)
 	val, err = jr.TaskRuns[1].Result.Value()
 	assert.Equal(t, "10583.75", val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	val, err = jr.TaskRuns[3].Result.Value()
 	assert.Equal(t, hash.String(), val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	val, err = jr.Result.Value()
 	assert.Equal(t, hash.String(), val)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, jr.Result.JobRunID, jr.ID)
 
 	eth.EventuallyAllCalled(t)
@@ -169,7 +169,7 @@ func TestIntegration_RunLog(t *testing.T) {
 	cltest.WaitForRuns(t, j, app.Store, 1)
 
 	runs, err := app.Store.JobRunsFor(j.ID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	jr := runs[0]
 	cltest.WaitForJobRunToPendConfirmations(t, app.Store, jr)
 
@@ -204,7 +204,7 @@ func TestIntegration_EndAt(t *testing.T) {
 	assert.Equal(t, 500, resp.StatusCode)
 	gomega.NewGomegaWithT(t).Consistently(func() []models.JobRun {
 		jobRuns, err := app.Store.JobRunsFor(j.ID)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		return jobRuns
 	}).Should(gomega.HaveLen(1))
 }
@@ -268,10 +268,10 @@ func TestIntegration_ExternalAdapter_RunLogInitiated(t *testing.T) {
 	tr := jr.TaskRuns[0]
 	assert.Equal(t, "randomnumber", tr.Task.Type)
 	val, err := tr.Result.Value()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, eaValue, val)
 	res, err := tr.Result.Get("extra")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, eaExtra, res.String())
 }
 
@@ -296,10 +296,10 @@ func TestIntegration_ExternalAdapter_WebInitiated(t *testing.T) {
 	tr := jr.TaskRuns[0]
 	assert.Equal(t, "randomnumber", tr.Task.Type)
 	val, err := tr.Result.Value()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, eaValue, val)
 	res, err := tr.Result.Get("extra")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, eaExtra, res.String())
 }
 
@@ -328,7 +328,7 @@ func TestIntegration_ExternalAdapter_Pending(t *testing.T) {
 	tr := jr.TaskRuns[0]
 	assert.Equal(t, models.RunStatusPendingBridge, tr.Status)
 	val, err := tr.Result.Value()
-	assert.NotNil(t, err)
+	assert.Error(t, err)
 	assert.Equal(t, "", val)
 
 	jr = cltest.UpdateJobRunViaWeb(t, app, jr, `{"data":{"value":"100"}}`)
@@ -336,7 +336,7 @@ func TestIntegration_ExternalAdapter_Pending(t *testing.T) {
 	tr = jr.TaskRuns[0]
 	assert.Equal(t, models.RunStatusCompleted, tr.Status)
 	val, err = tr.Result.Value()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "100", val)
 }
 
@@ -355,7 +355,7 @@ func TestIntegration_WeiWatchers(t *testing.T) {
 	mockServer, cleanup := cltest.NewHTTPMockServer(t, 200, "POST", `{"pending":true}`,
 		func(body string) {
 			marshaledLog, err := json.Marshal(&log)
-			assert.Nil(t, err)
+			assert.NoError(t, err)
 			assert.JSONEq(t, string(marshaledLog), body)
 		})
 	defer cleanup()
@@ -384,7 +384,7 @@ func TestIntegration_MultiplierInt256(t *testing.T) {
 	jr = cltest.WaitForJobRunToComplete(t, app.Store, jr)
 
 	val, err := jr.Result.Value()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "0xfffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0674e", val)
 }
 
@@ -398,7 +398,7 @@ func TestIntegration_MultiplierUint256(t *testing.T) {
 	jr = cltest.WaitForJobRunToComplete(t, app.Store, jr)
 
 	val, err := jr.Result.Value()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "0x00000000000000000000000000000000000000000000000000000000000f98b2", val)
 }
 
@@ -431,13 +431,13 @@ func TestIntegration_NonceManagement_firstRunWithExistingTXs(t *testing.T) {
 
 		txHashString, err := jr.Result.Value()
 		txHash := common.HexToHash(txHashString)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		attempt := &models.TxAttempt{}
 		err = app.Store.One("Hash", txHash, attempt)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		var tx models.Tx
 		err = app.Store.One("ID", attempt.TxID, &tx)
-		assert.Nil(t, err)
+		assert.NoError(t, err)
 		assert.Equal(t, expectedNonce, tx.Nonce)
 	}
 

--- a/web/job_runs_controller_test.go
+++ b/web/job_runs_controller_test.go
@@ -41,7 +41,7 @@ func TestJobRunsController_Index(t *testing.T) {
 
 	j := setupJobRunsControllerIndex(t, app)
 	jr, err := app.Store.JobRunsFor(j.ID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	resp := cltest.BasicAuthGet(app.Server.URL + "/v2/specs/" + j.ID + "/runs?size=x")
 	cltest.AssertServerResponse(t, resp, 422)
@@ -98,7 +98,7 @@ func TestJobRunsController_Create_Success(t *testing.T) {
 	jr := cltest.CreateJobRunViaWeb(t, app, j, `{"value":"100"}`)
 	jr = cltest.WaitForJobRunToComplete(t, app.Store, jr)
 	val, err := jr.Result.Value()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "100", val)
 }
 
@@ -173,7 +173,7 @@ func TestJobRunsController_Update_Success(t *testing.T) {
 
 	jr = cltest.WaitForJobRunToComplete(t, app.Store, jr)
 	val, err := jr.Result.Value()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "100", val)
 }
 
@@ -218,7 +218,7 @@ func TestJobRunsController_Update_WithError(t *testing.T) {
 
 	jr = cltest.WaitForJobRunStatus(t, app.Store, jr, models.RunStatusErrored)
 	val, err := jr.Result.Value()
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, "0", val)
 }
 

--- a/web/job_specs_controller_test.go
+++ b/web/job_specs_controller_test.go
@@ -244,7 +244,7 @@ func TestJobSpecsController_Show(t *testing.T) {
 	j := setupJobSpecsControllerShow(t, app)
 
 	jr, err := app.Store.JobRunsFor(j.ID)
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 
 	resp := cltest.BasicAuthGet(app.Server.URL + "/v2/specs/" + j.ID)
 	assert.Equal(t, 200, resp.StatusCode, "Response should be successful")
@@ -286,6 +286,6 @@ func TestJobSpecsController_Show_Unauthenticated(t *testing.T) {
 	defer cleanup()
 
 	resp, err := http.Get(app.Server.URL + "/v2/specs/" + "garbage")
-	assert.Nil(t, err)
+	assert.NoError(t, err)
 	assert.Equal(t, 401, resp.StatusCode, "Response should be forbidden")
 }

--- a/web/snapshots_controller_test.go
+++ b/web/snapshots_controller_test.go
@@ -3,11 +3,12 @@ package web_test
 import (
 	"bytes"
 	"encoding/json"
+	"testing"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink/store"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/utils"
-	"testing"
 
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
[Fixes #157325281]

1. Does a `s/assert.Nil/assert.NoError` where applicable
2. Does a `s/assert.NotNil/assert.Error` where applicable
3. panics if cltest NewWSServer fails to upgrade connection
4. Removes `t.Parallel()` from the troublesome `TestEthClient_GetTxReceipt`