### PR TITLE
simplify request IDs for consumer contracts

### DIFF
--- a/examples/echo_server/contracts/RunLog.sol
+++ b/examples/echo_server/contracts/RunLog.sol
@@ -20,13 +20,7 @@ contract RunLog is Chainlinked {
 
   function fulfill(bytes32 _externalId, bytes32 _data)
     public
-    onlyOracle
-    checkRequestId(_externalId)
+    checkChainlinkRequest(_externalId)
   {
-  }
-
-  modifier checkRequestId(bytes32 _externalId) {
-    require(externalId == _externalId);
-    _;
   }
 }

--- a/examples/echo_server/contracts/RunLog.sol
+++ b/examples/echo_server/contracts/RunLog.sol
@@ -19,7 +19,7 @@ contract RunLog is Chainlinked {
 
   function fulfill(bytes32 _externalId, bytes32 _data)
     public
-    checkChainlinkRequest(_externalId)
+    checkChainlinkFulfillment(_externalId)
   {
   }
 }

--- a/examples/echo_server/contracts/RunLog.sol
+++ b/examples/echo_server/contracts/RunLog.sol
@@ -3,7 +3,6 @@ pragma solidity ^0.4.23;
 import "../../../solidity/contracts/Chainlinked.sol";
 
 contract RunLog is Chainlinked {
-  bytes32 private externalId;
   bytes32 private jobId;
 
   constructor(address _link, address _oracle, bytes32 _jobId) public {
@@ -15,7 +14,7 @@ contract RunLog is Chainlinked {
   function request() public {
     ChainlinkLib.Run memory run = newRun(jobId, this, "fulfill(bytes32,bytes32)");
     run.add("msg", "hello_chainlink");
-    externalId = chainlinkRequest(run, LINK(1));
+    chainlinkRequest(run, LINK(1));
   }
 
   function fulfill(bytes32 _externalId, bytes32 _data)

--- a/examples/echo_server/contracts/SpecAndRunLog.sol
+++ b/examples/echo_server/contracts/SpecAndRunLog.sol
@@ -33,13 +33,7 @@ contract SpecAndRunLog is Chainlinked, Ownable {
 
   function fulfill(bytes32 _requestId, bytes32 _price)
     public
-    onlyOracle
-    checkRequestId(_requestId)
+    checkChainlinkFulfillment(_requestId)
   {
-  }
-
-  modifier checkRequestId(bytes32 _requestId) {
-    require(requestId == _requestId);
-    _;
   }
 }

--- a/examples/echo_server/test/RunLog_test.js
+++ b/examples/echo_server/test/RunLog_test.js
@@ -15,6 +15,6 @@ contract('RunLog', () => {
 
   it("has a limited public interface", async () => {
     let tx = await logger.request();
-    assert.equal(3, tx.receipt.logs.length);
+    assert.equal(4, tx.receipt.logs.length);
   });
 });

--- a/examples/echo_server/test/SpecAndRunLog_test.js
+++ b/examples/echo_server/test/SpecAndRunLog_test.js
@@ -19,7 +19,7 @@ contract('SpecAndRunLog', () => {
   });
 
   it("emits the correct number of event logs", async () => {
-    assert.equal(3, tx.receipt.logs.length);
+    assert.equal(4, tx.receipt.logs.length);
   });
 
   it("uses the expected event signature from the oracle", () => {

--- a/examples/ropsten/contracts/Chainlinked.sol
+++ b/examples/ropsten/contracts/Chainlinked.sol
@@ -46,9 +46,4 @@ contract Chainlinked {
   function setLinkToken(address _link) internal {
     link = LinkToken(_link);
   }
-
-  modifier onlyOracle() {
-    require(msg.sender == address(oracle));
-    _;
-  }
 }

--- a/examples/ropsten/contracts/ConsumerBytes32.sol
+++ b/examples/ropsten/contracts/ConsumerBytes32.sol
@@ -42,7 +42,7 @@ contract ConsumerBytes32 is Chainlinked, Ownable {
 
   function fulfill(bytes32 _requestId, bytes32 _marketCap)
     public
-    checkChainlinkRequest(_requestId)
+    checkChainlinkFulfillment(_requestId)
   {
     emit RequestFulfilled(_requestId, _marketCap);
     currentMarketCap = _marketCap;

--- a/examples/ropsten/contracts/ConsumerBytes32.sol
+++ b/examples/ropsten/contracts/ConsumerBytes32.sol
@@ -43,16 +43,10 @@ contract ConsumerBytes32 is Chainlinked, Ownable {
 
   function fulfill(bytes32 _requestId, bytes32 _marketCap)
     public
-    onlyOracle
-    checkRequestId(_requestId)
+    checkChainlinkRequest(_requestId)
   {
     emit RequestFulfilled(_requestId, _marketCap);
     currentMarketCap = _marketCap;
-  }
-
-  modifier checkRequestId(bytes32 _requestId) {
-    require(requestId == _requestId);
-    _;
   }
 
 }

--- a/examples/ropsten/contracts/ConsumerBytes32.sol
+++ b/examples/ropsten/contracts/ConsumerBytes32.sol
@@ -4,7 +4,6 @@ import "./Chainlinked.sol";
 import "github.com/OpenZeppelin/openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 contract ConsumerBytes32 is Chainlinked, Ownable {
-  bytes32 internal requestId;
   bytes32 internal jobId;
   bytes32 public currentMarketCap;
 
@@ -31,11 +30,11 @@ contract ConsumerBytes32 is Chainlinked, Ownable {
     path[2] = _currency;
     path[3] = "MKTCAP";
     run.addStringArray("path", path);
-    requestId = chainlinkRequest(run, LINK(1));
+    chainlinkRequest(run, LINK(1));
   }
 
   function cancelRequest(uint256 _requestId) 
-    public 
+    public
     onlyOwner
   {
     oracle.cancel(_requestId);

--- a/examples/ropsten/contracts/ConsumerInt256.sol
+++ b/examples/ropsten/contracts/ConsumerInt256.sol
@@ -4,7 +4,6 @@ import "./Chainlinked.sol";
 import "github.com/OpenZeppelin/openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 contract ConsumerInt256 is Chainlinked, Ownable {
-  bytes32 internal requestId;
   bytes32 internal jobId;
   int256 public changeDay;
 
@@ -31,7 +30,7 @@ contract ConsumerInt256 is Chainlinked, Ownable {
     path[2] = _currency;
     path[3] = "CHANGEPCTDAY";
     run.addStringArray("path", path);
-    requestId = chainlinkRequest(run, LINK(1));
+    chainlinkRequest(run, LINK(1));
   }
 
   function cancelRequest(uint256 _requestId) 

--- a/examples/ropsten/contracts/ConsumerInt256.sol
+++ b/examples/ropsten/contracts/ConsumerInt256.sol
@@ -43,16 +43,10 @@ contract ConsumerInt256 is Chainlinked, Ownable {
 
   function fulfill(bytes32 _requestId, int256 _change)
     public
-    onlyOracle
-    checkRequestId(_requestId)
+    checkChainlinkRequest(_requestId)
   {
     emit RequestFulfilled(_requestId, _change);
     changeDay = _change;
-  }
-
-  modifier checkRequestId(bytes32 _requestId) {
-    require(requestId == _requestId);
-    _;
   }
 
 }

--- a/examples/ropsten/contracts/ConsumerInt256.sol
+++ b/examples/ropsten/contracts/ConsumerInt256.sol
@@ -42,7 +42,7 @@ contract ConsumerInt256 is Chainlinked, Ownable {
 
   function fulfill(bytes32 _requestId, int256 _change)
     public
-    checkChainlinkRequest(_requestId)
+    checkChainlinkFulfillment(_requestId)
   {
     emit RequestFulfilled(_requestId, _change);
     changeDay = _change;

--- a/examples/ropsten/contracts/ConsumerUint256.sol
+++ b/examples/ropsten/contracts/ConsumerUint256.sol
@@ -39,7 +39,7 @@ contract ConsumerUint256 is Chainlinked, Ownable {
 
   function fulfill(bytes32 _requestId, uint256 _price)
     public
-    checkChainlinkRequest(_requestId)
+    checkChainlinkFulfillment(_requestId)
   {
     emit RequestFulfilled(_requestId, _price);
     currentPrice = _price;

--- a/examples/ropsten/contracts/ConsumerUint256.sol
+++ b/examples/ropsten/contracts/ConsumerUint256.sol
@@ -39,17 +39,11 @@ contract ConsumerUint256 is Chainlinked, Ownable {
   }
 
   function fulfill(bytes32 _requestId, uint256 _price)
-  public
-  onlyOracle
-  checkRequestId(_requestId)
+    public
+    checkChainlinkRequest(_requestId)
   {
     emit RequestFulfilled(_requestId, _price);
     currentPrice = _price;
-  }
-
-  modifier checkRequestId(bytes32 _requestId) {
-    require(requestId == _requestId);
-    _;
   }
 
 }

--- a/examples/ropsten/contracts/ConsumerUint256.sol
+++ b/examples/ropsten/contracts/ConsumerUint256.sol
@@ -4,7 +4,6 @@ import "./Chainlinked.sol";
 import "github.com/OpenZeppelin/openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 contract ConsumerUint256 is Chainlinked, Ownable {
-  bytes32 internal requestId;
   bytes32 internal jobId;
   uint256 public currentPrice;
 
@@ -28,7 +27,7 @@ contract ConsumerUint256 is Chainlinked, Ownable {
     string[] memory path = new string[](1);
     path[0] = _currency;
     run.addStringArray("path", path);
-    requestId = chainlinkRequest(run, LINK(1));
+    chainlinkRequest(run, LINK(1));
   }
 
   function cancelRequest(uint256 _requestId) 

--- a/examples/uptime_sla/README.md
+++ b/examples/uptime_sla/README.md
@@ -9,8 +9,7 @@ After the contract is created anyone can request updates from the oracle for the
 ```solidity
 function report(uint256 _requestId, uint256 _rate)
     public
-    onlyOracle
-    checkRequestId(_requestId)
+    checkChainlinkRequest(_requestId)
   {
     if (_rate < uptimeThreshold) {
       client.send(this.balance);

--- a/examples/uptime_sla/README.md
+++ b/examples/uptime_sla/README.md
@@ -9,7 +9,7 @@ After the contract is created anyone can request updates from the oracle for the
 ```solidity
 function report(uint256 _requestId, uint256 _rate)
     public
-    checkChainlinkRequest(_requestId)
+    checkChainlinkFulfillment(_requestId)
   {
     if (_rate < uptimeThreshold) {
       client.send(this.balance);

--- a/examples/uptime_sla/README.md
+++ b/examples/uptime_sla/README.md
@@ -40,7 +40,7 @@ function updateUptime(string _when) public {
    path[2] = "attributes";
    path[3] = "calculation";
    run.add("path", path);
-   requestId = chainlinkRequest(run, LINK(1));
+   chainlinkRequest(run, LINK(1));
 }
 ```
 

--- a/examples/uptime_sla/contracts/UptimeSLA.sol
+++ b/examples/uptime_sla/contracts/UptimeSLA.sol
@@ -9,7 +9,6 @@ contract UptimeSLA is Chainlinked {
   uint256 private endAt;
   address private client;
   address private serviceProvider;
-  bytes32 public externalId;
   uint256 public uptime;
 
   constructor(
@@ -37,7 +36,7 @@ contract UptimeSLA is Chainlinked {
     path[2] = "attributes";
     path[3] = "calculation";
     run.addStringArray("path", path);
-    externalId = chainlinkRequest(run, LINK(1));
+    chainlinkRequest(run, LINK(1));
   }
 
   function report(bytes32 _externalId, uint256 _uptime)

--- a/examples/uptime_sla/contracts/UptimeSLA.sol
+++ b/examples/uptime_sla/contracts/UptimeSLA.sol
@@ -41,7 +41,7 @@ contract UptimeSLA is Chainlinked {
 
   function report(bytes32 _externalId, uint256 _uptime)
     public
-    checkChainlinkRequest(_externalId)
+    checkChainlinkFulfillment(_externalId)
   {
     uptime = _uptime;
     if (_uptime < uptimeThreshold) {

--- a/examples/uptime_sla/contracts/UptimeSLA.sol
+++ b/examples/uptime_sla/contracts/UptimeSLA.sol
@@ -42,8 +42,7 @@ contract UptimeSLA is Chainlinked {
 
   function report(bytes32 _externalId, uint256 _uptime)
     public
-    onlyOracle
-    checkRequestId(_externalId)
+    checkChainlinkRequest(_externalId)
   {
     uptime = _uptime;
     if (_uptime < uptimeThreshold) {
@@ -51,11 +50,6 @@ contract UptimeSLA is Chainlinked {
     } else if (block.timestamp >= endAt) {
       serviceProvider.transfer(this.balance);
     }
-  }
-
-  modifier checkRequestId(bytes32 _externalId) {
-    require(externalId == _externalId);
-    _;
   }
 
 }

--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -19,8 +19,6 @@ contract Chainlinked {
   event ChainlinkFulfilled(bytes32 id);
   event ChainlinkCancelled(bytes32 id);
 
-  event ChainlinkRequest(bytes32 id);
-
   function newRun(
     bytes32 _specId,
     address _callbackAddress,
@@ -47,7 +45,7 @@ contract Chainlinked {
     _run.requestId = bytes32(requests);
     _run.close();
     require(link.transferAndCall(oracle, _wei, _run.encodeForOracle(clArgsVersion)));
-    emit ChainlinkRequest(_run.requestId);
+    emit ChainlinkRequested(_run.requestId);
     unfulfilledRequests[_run.requestId] = true;
     return _run.requestId;
   }
@@ -60,7 +58,7 @@ contract Chainlinked {
     _spec.requestId = bytes32(requests);
     _spec.close();
     require(link.transferAndCall(oracle, _wei, _spec.encodeForOracle(clArgsVersion)));
-    emit ChainlinkRequest(_spec.requestId);
+    emit ChainlinkRequested(_spec.requestId);
     unfulfilledRequests[_spec.requestId] = true;
     return _spec.requestId;
   }

--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -13,6 +13,11 @@ contract Chainlinked {
   LinkToken internal link;
   Oracle internal oracle;
   uint256 internal requests = 1;
+  mapping(bytes32 => bool) internal unfulfilledRequests;
+
+  event ChainlinkRequested(bytes32 id);
+  event ChainlinkFulfilled(bytes32 id);
+  event ChainlinkCancelled(bytes32 id);
 
   event ChainlinkRequest(bytes32 id);
 
@@ -43,6 +48,7 @@ contract Chainlinked {
     _run.close();
     require(link.transferAndCall(oracle, _wei, _run.encodeForOracle(clArgsVersion)));
     emit ChainlinkRequest(_run.requestId);
+    unfulfilledRequests[_run.requestId] = true;
     return _run.requestId;
   }
 
@@ -55,7 +61,16 @@ contract Chainlinked {
     _spec.close();
     require(link.transferAndCall(oracle, _wei, _spec.encodeForOracle(clArgsVersion)));
     emit ChainlinkRequest(_spec.requestId);
+    unfulfilledRequests[_spec.requestId] = true;
     return _spec.requestId;
+  }
+
+  function cancelChainlinkRequest(bytes32 _requestId)
+    internal
+  {
+    oracle.cancel(_requestId);
+    unfulfilledRequests[_requestId] = false;
+    emit ChainlinkCancelled(_requestId);
   }
 
   function LINK(uint256 _amount) internal pure returns (uint256) {
@@ -70,8 +85,10 @@ contract Chainlinked {
     link = LinkToken(_link);
   }
 
-  modifier onlyOracle() {
-    require(msg.sender == address(oracle));
+  modifier checkChainlinkRequest(bytes32 _requestId) {
+    require(msg.sender == address(oracle) && unfulfilledRequests[_requestId]);
     _;
+    unfulfilledRequests[_requestId] = false;
+    emit ChainlinkFulfilled(_requestId);
   }
 }

--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -85,7 +85,7 @@ contract Chainlinked {
     link = LinkToken(_link);
   }
 
-  modifier checkChainlinkRequest(bytes32 _requestId) {
+  modifier checkChainlinkFulfillment(bytes32 _requestId) {
     require(msg.sender == address(oracle) && unfulfilledRequests[_requestId]);
     _;
     unfulfilledRequests[_requestId] = false;

--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -14,6 +14,8 @@ contract Chainlinked {
   Oracle internal oracle;
   uint256 internal requests = 1;
 
+  event ChainlinkRequest(bytes32 id);
+
   function newRun(
     bytes32 _specId,
     address _callbackAddress,
@@ -40,6 +42,7 @@ contract Chainlinked {
     _run.requestId = bytes32(requests);
     _run.close();
     require(link.transferAndCall(oracle, _wei, _run.encodeForOracle(clArgsVersion)));
+    emit ChainlinkRequest(_run.requestId);
     return _run.requestId;
   }
 
@@ -51,6 +54,7 @@ contract Chainlinked {
     _spec.requestId = bytes32(requests);
     _spec.close();
     require(link.transferAndCall(oracle, _wei, _spec.encodeForOracle(clArgsVersion)));
+    emit ChainlinkRequest(_spec.requestId);
     return _spec.requestId;
   }
 

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -118,11 +118,14 @@ contract Oracle is Ownable {
     withdrawableWei = oneForConsistentGasCost;
   }
 
-  function cancel(bytes32 _externalId) public {
+  function cancel(bytes32 _externalId)
+    public
+    returns (bool)
+  {
     uint256 internalId = uint256(keccak256(msg.sender, _externalId));
     require(msg.sender == callbacks[internalId].addr);
     Callback memory cb = callbacks[internalId];
-    LINK.transfer(cb.addr, cb.amount);
+    require(LINK.transfer(cb.addr, cb.amount));
     delete callbacks[internalId];
   }
 

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -120,7 +120,6 @@ contract Oracle is Ownable {
 
   function cancel(bytes32 _externalId)
     public
-    returns (bool)
   {
     uint256 internalId = uint256(keccak256(msg.sender, _externalId));
     require(msg.sender == callbacks[internalId].addr);

--- a/solidity/contracts/examples/ConcreteChainlinked.sol
+++ b/solidity/contracts/examples/ConcreteChainlinked.sol
@@ -1,4 +1,5 @@
 pragma solidity ^0.4.23;
+pragma experimental ABIEncoderV2; //solium-disable-line
 
 
 import "../Chainlinked.sol";
@@ -35,6 +36,30 @@ contract ConcreteChainlinked is Chainlinked {
       run.callbackFunctionId,
       run.buf.buf
     );
+  }
+
+  function publicCLRequestRun(
+    bytes32 _specId,
+    address _address,
+    string _fulfillmentSignature,
+    uint256 _wei
+  )
+    public
+  {
+    ChainlinkLib.Run memory run = newRun(_specId, _address, _fulfillmentSignature);
+    chainlinkRequest(run, _wei);
+  }
+
+  function publicCLRequestSpecAndRun(
+    string[] memory _tasks,
+    address _address,
+    string _fulfillmentSignature,
+    uint256 _wei
+  )
+    public
+  {
+    ChainlinkLib.Spec memory spec = newSpec(_tasks, _address, _fulfillmentSignature);
+    chainlinkRequest(spec, _wei);
   }
 
 }

--- a/solidity/contracts/examples/ConcreteChainlinked.sol
+++ b/solidity/contracts/examples/ConcreteChainlinked.sol
@@ -68,7 +68,7 @@ contract ConcreteChainlinked is Chainlinked {
 
   function fulfillRequest(bytes32 _requestId, bytes32 data)
     public
-    checkChainlinkRequest(_requestId)
+    checkChainlinkFulfillment(_requestId)
   {
   }
 

--- a/solidity/contracts/examples/ConcreteChainlinked.sol
+++ b/solidity/contracts/examples/ConcreteChainlinked.sol
@@ -38,7 +38,7 @@ contract ConcreteChainlinked is Chainlinked {
     );
   }
 
-  function publicCLRequestRun(
+  function publicRequestRun(
     bytes32 _specId,
     address _address,
     string _fulfillmentSignature,
@@ -50,7 +50,7 @@ contract ConcreteChainlinked is Chainlinked {
     chainlinkRequest(run, _wei);
   }
 
-  function publicCLRequestSpecAndRun(
+  function publicRequestSpecAndRun(
     string[] memory _tasks,
     address _address,
     string _fulfillmentSignature,
@@ -60,6 +60,16 @@ contract ConcreteChainlinked is Chainlinked {
   {
     ChainlinkLib.Spec memory spec = newSpec(_tasks, _address, _fulfillmentSignature);
     chainlinkRequest(spec, _wei);
+  }
+
+  function publicCancelRequest(bytes32 _requestId) public {
+    cancelChainlinkRequest(_requestId);
+  }
+
+  function fulfillRequest(bytes32 _requestId, bytes32 data)
+    public
+    checkChainlinkRequest(_requestId)
+  {
   }
 
 }

--- a/solidity/contracts/examples/Consumer.sol
+++ b/solidity/contracts/examples/Consumer.sol
@@ -33,7 +33,7 @@ contract Consumer is Chainlinked, Ownable {
 
   function fulfill(bytes32 _requestId, bytes32 _price)
     public
-    checkChainlinkRequest(_requestId)
+    checkChainlinkFulfillment(_requestId)
   {
     emit RequestFulfilled(_requestId, _price);
     currentPrice = _price;

--- a/solidity/contracts/examples/Consumer.sol
+++ b/solidity/contracts/examples/Consumer.sol
@@ -4,7 +4,6 @@ import "../Chainlinked.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 contract Consumer is Chainlinked, Ownable {
-  bytes32 internal requestId;
   bytes32 internal specId;
   bytes32 public currentPrice;
 
@@ -25,25 +24,19 @@ contract Consumer is Chainlinked, Ownable {
     string[] memory path = new string[](1);
     path[0] = _currency;
     run.addStringArray("path", path);
-    requestId = chainlinkRequest(run, LINK(1));
+    chainlinkRequest(run, LINK(1));
   }
 
-  function cancelRequest() public onlyOwner {
-    oracle.cancel(requestId);
+  function cancelRequest(bytes32 _requestId) public onlyOwner {
+    cancelChainlinkRequest(_requestId);
   }
 
   function fulfill(bytes32 _requestId, bytes32 _price)
     public
-    onlyOracle
-    checkRequestId(_requestId)
+    checkChainlinkRequest(_requestId)
   {
     emit RequestFulfilled(_requestId, _price);
     currentPrice = _price;
-  }
-
-  modifier checkRequestId(bytes32 _requestId) {
-    require(requestId == _requestId);
-    _;
   }
 
 }

--- a/solidity/contracts/examples/SpecAndRunRequester.sol
+++ b/solidity/contracts/examples/SpecAndRunRequester.sol
@@ -37,7 +37,7 @@ contract SpecAndRunRequester is Chainlinked, Ownable {
 
   function fulfill(bytes32 _requestId, bytes32 _price)
     public
-    checkChainlinkRequest(_requestId)
+    checkChainlinkFulfillment(_requestId)
   {
     emit RequestFulfilled(_requestId, _price);
     currentPrice = _price;

--- a/solidity/contracts/examples/SpecAndRunRequester.sol
+++ b/solidity/contracts/examples/SpecAndRunRequester.sol
@@ -4,7 +4,6 @@ import "../Chainlinked.sol";
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 contract SpecAndRunRequester is Chainlinked, Ownable {
-  bytes32 internal requestId;
   bytes32 public currentPrice;
 
   event RequestFulfilled(
@@ -29,24 +28,23 @@ contract SpecAndRunRequester is Chainlinked, Ownable {
     string[] memory path = new string[](1);
     path[0] = _currency;
     spec.addStringArray("path", path);
-    requestId = chainlinkRequest(spec, LINK(1));
+    chainlinkRequest(spec, LINK(1));
   }
 
-  function cancelRequest() public onlyOwner {
-    oracle.cancel(requestId);
+  function cancelRequest(bytes32 _requestId) public onlyOwner {
+    cancelChainlinkRequest(_requestId);
   }
 
   function fulfill(bytes32 _requestId, bytes32 _price)
     public
-    onlyOracle
-    checkRequestId(_requestId)
+    checkChainlinkRequest(_requestId)
   {
     emit RequestFulfilled(_requestId, _price);
     currentPrice = _price;
   }
 
   modifier checkRequestId(bytes32 _requestId) {
-    require(requestId == _requestId);
+    require(_requestId == _requestId);
     _;
   }
 

--- a/solidity/contracts/examples/SpecAndRunRequester.sol
+++ b/solidity/contracts/examples/SpecAndRunRequester.sol
@@ -43,10 +43,5 @@ contract SpecAndRunRequester is Chainlinked, Ownable {
     currentPrice = _price;
   }
 
-  modifier checkRequestId(bytes32 _requestId) {
-    require(_requestId == _requestId);
-    _;
-  }
-
 }
 

--- a/solidity/test/ConcreteChainlinked_test.js
+++ b/solidity/test/ConcreteChainlinked_test.js
@@ -22,7 +22,7 @@ contract('ConcreteChainlinked', () => {
       let tx = await cc.publicNewRun(
         specId,
         gs.address,
-        "requestedBytes32(uint256,bytes32)");
+        "requestedBytes32(bytes32,bytes32)");
 
       assert.equal(1, tx.receipt.logs.length);
       let [jId, cbAddr, cbFId, cborData] = decodeRunABI(tx.receipt.logs[0]);
@@ -30,14 +30,14 @@ contract('ConcreteChainlinked', () => {
 
       assert.equal(specId, jId);
       assert.equal(gs.address, `0x${cbAddr}`);
-      assert.equal("d67ce1e1", toHex(cbFId));
+      assert.equal("ed53e511", toHex(cbFId));
       assert.deepEqual({}, params);
     });
   });
 
   describe("#chainlinkRequest(Run)", () => {
     it("emits an event from the contract showing the run ID", async () => {
-      let tx = await cc.publicCLRequestRun(specId, gs.address, "requestedBytes32(uint256,bytes32)", 0);
+      let tx = await cc.publicRequestRun(specId, cc.address, "fulfillRequest(bytes32,bytes32)", 0);
 
       let events = await getEvents(cc);
       assert.equal(1, events.length);
@@ -48,12 +48,63 @@ contract('ConcreteChainlinked', () => {
 
   describe("#chainlinkRequest(SpecAndRun)", () => {
     it("emits an event from the contract showing the run ID", async () => {
-      let tx = await cc.publicCLRequestSpecAndRun([], gs.address, "requestedBytes32(uint256,bytes32)", 0);
+      let tx = await cc.publicRequestSpecAndRun([], cc.address, "fulfillRequest(bytes32,bytes32)", 0);
 
       let events = await getEvents(cc);
       assert.equal(1, events.length);
       let event = events[0];
       assert.equal(event.event, "ChainlinkRequest");
+    });
+  });
+
+  describe("#cancelChainlinkRequest", () => {
+    let requestId;
+
+    beforeEach(async () => {
+      await cc.publicRequestRun(specId, cc.address, "fulfillRequest(bytes32,bytes32)", 0);
+      requestId = (await getLatestEvent(cc)).args.id;
+    });
+
+    it("emits an event from the contract showing the run was cancelled", async () => {
+      let tx = await cc.publicCancelRequest(requestId);
+
+      let events = await getEvents(cc);
+      assert.equal(1, events.length);
+      let event = events[0];
+      assert.equal(event.event, "ChainlinkCancelled");
+      assert.equal(requestId, event.args.id);
+    });
+
+    context("when the request ID is no longer unfulfilled", () => {
+      beforeEach(async () => {
+        await cc.publicCancelRequest(requestId);
+      });
+
+      it("throws an error", async () => {
+        await assertActionThrows(async () => {
+          await cc.publicCancelRequest(requestId);
+        });
+      });
+    });
+  });
+
+  describe("#checkChainlinkRequest(modifier)", () => {
+    let internalId, requestId;
+
+    beforeEach(async () => {
+      await cc.publicRequestRun(specId, cc.address, "fulfillRequest(bytes32,bytes32)", 0);
+      requestId = (await getLatestEvent(cc)).args.id;
+      internalId = (await getLatestEvent(oc)).args.internalId;
+    });
+
+    it("emits an event marking the request cancelled", async () => {
+      await oc.fulfillData(internalId, "hi mom!");
+
+      let events = await getEvents(cc);
+      assert.equal(1, events.length);
+      let event = events[0];
+      assert.equal(event.event, "ChainlinkFulfilled");
+      assert.equal(requestId, event.args.id);
     });
   });
 });

--- a/solidity/test/ConcreteChainlinked_test.js
+++ b/solidity/test/ConcreteChainlinked_test.js
@@ -34,4 +34,26 @@ contract('ConcreteChainlinked', () => {
       assert.deepEqual({}, params);
     });
   });
+
+  describe("#chainlinkRequest(Run)", () => {
+    it("emits an event from the contract showing the run ID", async () => {
+      let tx = await cc.publicCLRequestRun(specId, gs.address, "requestedBytes32(uint256,bytes32)", 0);
+
+      let events = await getEvents(cc);
+      assert.equal(1, events.length);
+      let event = events[0];
+      assert.equal(event.event, "ChainlinkRequest");
+    });
+  });
+
+  describe("#chainlinkRequest(SpecAndRun)", () => {
+    it("emits an event from the contract showing the run ID", async () => {
+      let tx = await cc.publicCLRequestSpecAndRun([], gs.address, "requestedBytes32(uint256,bytes32)", 0);
+
+      let events = await getEvents(cc);
+      assert.equal(1, events.length);
+      let event = events[0];
+      assert.equal(event.event, "ChainlinkRequest");
+    });
+  });
 });

--- a/solidity/test/ConcreteChainlinked_test.js
+++ b/solidity/test/ConcreteChainlinked_test.js
@@ -88,7 +88,7 @@ contract('ConcreteChainlinked', () => {
     });
   });
 
-  describe("#checkChainlinkRequest(modifier)", () => {
+  describe("#checkChainlinkFulfillment(modifier)", () => {
     let internalId, requestId;
 
     beforeEach(async () => {

--- a/solidity/test/ConcreteChainlinked_test.js
+++ b/solidity/test/ConcreteChainlinked_test.js
@@ -42,7 +42,7 @@ contract('ConcreteChainlinked', () => {
       let events = await getEvents(cc);
       assert.equal(1, events.length);
       let event = events[0];
-      assert.equal(event.event, "ChainlinkRequest");
+      assert.equal(event.event, "ChainlinkRequested");
     });
   });
 
@@ -53,7 +53,7 @@ contract('ConcreteChainlinked', () => {
       let events = await getEvents(cc);
       assert.equal(1, events.length);
       let event = events[0];
-      assert.equal(event.event, "ChainlinkRequest");
+      assert.equal(event.event, "ChainlinkRequested");
     });
   });
 

--- a/solidity/test/Consumer_test.js
+++ b/solidity/test/Consumer_test.js
@@ -80,7 +80,7 @@ contract('Consumer', () => {
 
     it("logs the data given to it by the oracle", async () => {
       let tx = await oc.fulfillData(internalId, response, {from: oracleNode});
-      assert.equal(1, tx.receipt.logs.length);
+      assert.equal(2, tx.receipt.logs.length);
       let log = tx.receipt.logs[0];
 
       assert.equal(web3.toUtf8(log.topics[2]), response);
@@ -125,21 +125,20 @@ contract('Consumer', () => {
     beforeEach(async () => {
       await link.transfer(cc.address, web3.toWei('1', 'ether'));
       await cc.requestEthereumPrice(currency);
-      let event = await getLatestEvent(oc);
-      requestId = event.args.internalId;
+      requestId = (await getLatestEvent(cc)).args.id;
     });
 
     context("when called by a non-owner", () => {
       it("cannot cancel a request", async () => {
         await assertActionThrows(async () => {
-          await cc.cancelRequest({from: stranger});
+          await cc.cancelRequest(requestId, {from: stranger});
         });
       });
     });
 
     context("when called by the owner", () => {
       it("can cancel the request", async () => {
-        await cc.cancelRequest({from: consumer});
+        await cc.cancelRequest(requestId, {from: consumer});
       });
     });
   });

--- a/solidity/test/SpecAndRunRequester_test.js
+++ b/solidity/test/SpecAndRunRequester_test.js
@@ -17,7 +17,7 @@ contract('SpecAndRunRequester', () => {
 
   it("has a predictable gas price", async () => {
     let rec = await eth.getTransactionReceipt(cc.transactionHash);
-    assert.isBelow(rec.gasUsed, 1600000);
+    assert.isBelow(rec.gasUsed, 1650000);
   });
 
   describe("#requestEthereumPrice", () => {


### PR DESCRIPTION
Proposal for a change to hide request IDs from consuming contracts, making it easier to securely make a contract Chainlinked. `checkRequestId` and `onlyOralce` modifiers have been condensed to `checkChainlinkRequest`. I updated the examples to use this pattern, which means that the request ID needs to be passed in, but they could still use the new code and not need the request ID.

The request ID is still returned from `chainlinkRequest`, but it is now completely optional. Instead, 3 new events are emitted by chainlinked contracts: `ChainlinkRequested(bytes32 id)`,  `ChainlinkFulfilled(bytes32 id)`, `ChainlinkCancelled(bytes32 id)`. These raise gas costs a bit, but provide better default visibility into the full lifecycle of a request.

Thoughts?