### PR TITLE
SpecAndRunRequester has correct params for fulfillment

### DIFF
--- a/services/subscription.go
+++ b/services/subscription.go
@@ -347,11 +347,6 @@ func (le InitiatorSubscriptionLogEvent) ValidateRunLog() bool {
 	return true
 }
 
-// fulfillDataFunctionID is the signature for the fulfillData(uint256,bytes32) function located in Oracle.sol
-// fulfillDataFunctionID is calculated in the following way: bytes4(keccak256("fulfillData(uint256,bytes32)"))
-// See https://github.com/smartcontractkit/chainlink/blob/master/solidity/contracts/Oracle.sol
-var fulfillDataFunctionID = "76005c26"
-
 // RunLogJSON extracts data from the log's topics and data specific to the format defined
 // by RunLogs.
 func (le InitiatorSubscriptionLogEvent) RunLogJSON() (models.JSON, error) {
@@ -381,7 +376,7 @@ func fulfillmentToJSON(le InitiatorSubscriptionLogEvent) (models.JSON, error) {
 		return js, err
 	}
 
-	return js.Add("functionSelector", fulfillDataFunctionID)
+	return js.Add("functionSelector", OracleFulfillmentFunctionID)
 }
 
 // EthLogJSON reformats the log as JSON.

--- a/services/subscription_test.go
+++ b/services/subscription_test.go
@@ -15,7 +15,7 @@ import (
 func TestInitiatorSubscriptionLogEvent_RunLogJSON(t *testing.T) {
 	t.Parallel()
 
-	clData := cltest.JSONFromString(`{"url":"https://etherprice.com/api","path":["recent","usd"],"address":"0x3cCad4715152693fE3BC4460591e3D3Fbd071b42","dataPrefix":"0x0000000000000000000000000000000000000000000000000000000000000001","functionSelector":"76005c26"}`)
+	clData := cltest.JSONFromString(`{"url":"https://etherprice.com/api","path":["recent","usd"],"address":"0x3cCad4715152693fE3BC4460591e3D3Fbd071b42","dataPrefix":"0x0000000000000000000000000000000000000000000000000000000000000001","functionSelector":"0x76005c26"}`)
 
 	hwLog := cltest.LogFromFixture("../internal/fixtures/eth/subscription_logs_hello_world.json")
 	tests := []struct {


### PR DESCRIPTION
Related to https://www.pivotaltracker.com/story/show/156360786

The on-chain job spec did not specify the address and functionSelector for the EthTx adapter. Now, the `SpecAndRunSubscriber` will have sane defaults for `EthTx`:

1. The `EthTx#Address` will default to the sender of the log.
2. The FunctionSelector will be hardcoded to the fixed `bytes4(keccak256(fulfillment(uint256,bytes32)))` defined in `Oracle.sol`.