### PR TITLE
turn off yarn caching in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,5 @@
 sudo: required
 
-cache:
-  yarn: true
-  directories:
-    - vendor
-
 env:
   global:
     - DEP_VERSION="0.4.1"


### PR DESCRIPTION
Now that our yarn packages are changing more frequently, this is causing regular failures on CI. Turn off caching for now.