### PR TITLE
Fix detectable data races

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -297,6 +297,12 @@
   revision = "9637fa0b2f0db13c99d899b91007edb7df4610b7"
 
 [[projects]]
+  branch = "master"
+  name = "github.com/tevino/abool"
+  packages = ["."]
+  revision = "9b9efcf221b50905aab9bbabd3daed56dc10f339"
+
+[[projects]]
   name = "github.com/tidwall/gjson"
   packages = ["."]
   revision = "01f00f129617a6fe98941fb920d6c760241b54d2"
@@ -453,6 +459,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "ee62ef81996e5ffb21669a3a6dde69fad76f21bb1a591af32d20c27877f2bef5"
+  inputs-digest = "6a53c807ad9c94ee4203324f09b2586d79036cc2b588d56139dbe3a01b73b2e4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -121,3 +121,7 @@
 [[constraint]]
   branch = "master"
   name = "github.com/gin-contrib/gzip"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/tevino/abool"

--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -270,11 +270,14 @@ func UseSettableClock(s *store.Store) *SettableClock {
 
 // SettableClock a settable clock
 type SettableClock struct {
-	time time.Time
+	mutex sync.Mutex
+	time  time.Time
 }
 
 // Now get the current time
 func (clock *SettableClock) Now() time.Time {
+	clock.mutex.Lock()
+	defer clock.mutex.Unlock()
 	if clock.time.IsZero() {
 		return time.Now()
 	}
@@ -283,6 +286,8 @@ func (clock *SettableClock) Now() time.Time {
 
 // SetTime set the current time
 func (clock *SettableClock) SetTime(t time.Time) {
+	clock.mutex.Lock()
+	defer clock.mutex.Unlock()
 	clock.time = t
 }
 

--- a/services/application_test.go
+++ b/services/application_test.go
@@ -8,6 +8,7 @@ import (
 
 	. "github.com/onsi/gomega"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
+	"github.com/tevino/abool"
 )
 
 func TestServices_ApplicationSignalShutdown(t *testing.T) {
@@ -15,15 +16,15 @@ func TestServices_ApplicationSignalShutdown(t *testing.T) {
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 
-	var completed bool
+	completed := abool.New()
 	app.Exiter = func(code int) {
-		completed = true
+		completed.Set()
 	}
 
 	app.Start()
 	syscall.Kill(syscall.Getpid(), syscall.SIGTERM)
 
 	Eventually(func() bool {
-		return completed
+		return completed.IsSet()
 	}).Should(BeTrue())
 }

--- a/services/head_tracker_test.go
+++ b/services/head_tracker_test.go
@@ -103,19 +103,19 @@ func TestHeadTracker_HeadTrackableCallbacks(t *testing.T) {
 	eth.RegisterSubscription("newHeads", headers)
 
 	assert.Nil(t, ht.Start())
-	assert.Equal(t, 1, checker.ConnectedCount)
-	assert.Equal(t, 0, checker.DisconnectedCount)
-	assert.Equal(t, 0, checker.OnNewHeadCount)
+	assert.Equal(t, int32(1), checker.ConnectedCount())
+	assert.Equal(t, int32(0), checker.DisconnectedCount())
+	assert.Equal(t, int32(0), checker.OnNewHeadCount())
 
 	headers <- models.BlockHeader{Number: cltest.BigHexInt(1)}
-	g.Eventually(func() int { return checker.OnNewHeadCount }).Should(gomega.Equal(1))
-	assert.Equal(t, 1, checker.ConnectedCount)
-	assert.Equal(t, 0, checker.DisconnectedCount)
+	g.Eventually(func() int32 { return checker.OnNewHeadCount() }).Should(gomega.Equal(int32(1)))
+	assert.Equal(t, int32(1), checker.ConnectedCount())
+	assert.Equal(t, int32(0), checker.DisconnectedCount())
 
 	ht.Stop()
-	assert.Equal(t, 1, checker.DisconnectedCount)
-	assert.Equal(t, 1, checker.ConnectedCount)
-	assert.Equal(t, 1, checker.OnNewHeadCount)
+	assert.Equal(t, int32(1), checker.DisconnectedCount())
+	assert.Equal(t, int32(1), checker.ConnectedCount())
+	assert.Equal(t, int32(1), checker.OnNewHeadCount())
 }
 
 func TestHeadTracker_ReconnectOnError(t *testing.T) {
@@ -136,19 +136,19 @@ func TestHeadTracker_ReconnectOnError(t *testing.T) {
 
 	// connect
 	assert.Nil(t, ht.Start())
-	assert.Equal(t, 1, checker.ConnectedCount)
-	assert.Equal(t, 0, checker.DisconnectedCount)
-	assert.Equal(t, 0, checker.OnNewHeadCount)
+	assert.Equal(t, int32(1), checker.ConnectedCount())
+	assert.Equal(t, int32(0), checker.DisconnectedCount())
+	assert.Equal(t, int32(0), checker.OnNewHeadCount())
 
 	// disconnect
 	firstSub.Errors <- errors.New("Test error to force reconnect")
-	g.Eventually(func() int { return checker.ConnectedCount }).Should(gomega.Equal(2))
-	assert.Equal(t, 1, checker.DisconnectedCount)
-	assert.Equal(t, 0, checker.OnNewHeadCount)
+	g.Eventually(func() int32 { return checker.ConnectedCount() }).Should(gomega.Equal(int32(2)))
+	assert.Equal(t, int32(1), checker.DisconnectedCount())
+	assert.Equal(t, int32(0), checker.OnNewHeadCount())
 
 	// new head
 	headers <- models.BlockHeader{Number: cltest.BigHexInt(1)}
-	g.Eventually(func() int { return checker.OnNewHeadCount }).Should(gomega.Equal(1))
-	assert.Equal(t, 2, checker.ConnectedCount)
-	assert.Equal(t, 1, checker.DisconnectedCount)
+	g.Eventually(func() int32 { return checker.OnNewHeadCount() }).Should(gomega.Equal(int32(1)))
+	assert.Equal(t, int32(2), checker.ConnectedCount())
+	assert.Equal(t, int32(1), checker.DisconnectedCount())
 }


### PR DESCRIPTION
I was using the race detector to make sure that changes to the way JobRuns are handled by the HeadTracker are safe. 

But I found a number of existing races in the code base that I decided to tackle separately to find the signal in the noise.

This is 8 of the more easily fixable races present in the DB, but others will come in a separate PR.