### PR TITLE
Add GUI to make install and Docker container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go/src/github.com/smartcontractkit/chainlink/chainlink /usr/local/bin/
-COPY --from=builder /go/src/github.com/smartcontractkit/chainlink /go/src/github.com/smartcontractkit/chainlink
+COPY --from=builder /go/src/github.com/smartcontractkit/chainlink/gui/dist /go/src/github.com/smartcontractkit/chainlink/gui/dist
+
 
 EXPOSE 6688
 EXPOSE 6689

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Build Chainlink
 FROM golang:1.10-alpine as builder
 
-RUN apk add --no-cache make curl git gcc musl-dev linux-headers
+RUN apk add --no-cache make curl git gcc g++ musl-dev linux-headers yarn python
 RUN curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
 
 ADD . /go/src/github.com/smartcontractkit/chainlink
@@ -12,6 +12,8 @@ FROM alpine:latest
 
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /go/src/github.com/smartcontractkit/chainlink/chainlink /usr/local/bin/
+COPY --from=builder /go/src/github.com/smartcontractkit/chainlink /go/src/github.com/smartcontractkit/chainlink
 
 EXPOSE 6688
+EXPOSE 6689
 ENTRYPOINT ["chainlink"]

--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ LDFLAGS=-ldflags "-X github.com/smartcontractkit/chainlink/store.Sha=`git rev-pa
 dep: ## Ensure chainlink's go dependencies are installed.
 	@dep ensure
 
-build: dep ## Build chainlink.
+build: dep gui ## Build chainlink.
 	@go build $(LDFLAGS) -o chainlink
 
-install: dep ## Install chainlink
+install: dep gui ## Install chainlink
 	@go install $(LDFLAGS)
 
 gui: ## Install GUI 


### PR DESCRIPTION
I think ideally we'd want the GUI to be built into the `chainlink` binary. However, this allows for the GUI to be built as part of `make install` and with the Docker container.