### PR TITLE
make models.Time JSON parsing accept integers

### DIFF
--- a/store/models/common.go
+++ b/store/models/common.go
@@ -237,11 +237,11 @@ type Time struct {
 // UnmarshalJSON parses the raw time stored in JSON-encoded
 // data and stores it to the Time field.
 func (t *Time) UnmarshalJSON(b []byte) error {
-	var s string
-	if err := json.Unmarshal(b, &s); err != nil {
+	var n json.Number
+	if err := json.Unmarshal(b, &n); err != nil {
 		return err
 	}
-	newTime, err := dateparse.ParseAny(s)
+	newTime, err := dateparse.ParseAny(n.String())
 	t.Time = newTime.UTC()
 	return err
 }

--- a/store/models/common_test.go
+++ b/store/models/common_test.go
@@ -249,7 +249,34 @@ func TestWebURL_String_HasNilURL(t *testing.T) {
 	assert.Equal(t, "", w.String())
 }
 
-func TestTimeDurationFromNow(t *testing.T) {
+func TestTime_UnmarshalJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    time.Time
+		errored bool
+	}{
+		{"unix string", `"1529445491"`, time.Unix(1529445491, 0).UTC(), false},
+		{"unix int", `1529445491`, time.Unix(1529445491, 0).UTC(), false},
+		{"iso8601", `"2018-06-19T22:17:19Z"`, time.Unix(1529446639, 0).UTC(), false},
+		{"invalid string", `"1000h"`, time.Now(), true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var actual models.Time
+			err := json.Unmarshal([]byte(test.input), &actual)
+			if test.errored {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, test.want, actual.Time)
+			}
+		})
+	}
+}
+
+func TestTime_DurationFromNow(t *testing.T) {
 	t.Parallel()
 	future := models.Time{Time: time.Now().Add(time.Second)}
 	duration := future.DurationFromNow()

--- a/store/models/common_test.go
+++ b/store/models/common_test.go
@@ -258,7 +258,9 @@ func TestTime_UnmarshalJSON(t *testing.T) {
 	}{
 		{"unix string", `"1529445491"`, time.Unix(1529445491, 0).UTC(), false},
 		{"unix int", `1529445491`, time.Unix(1529445491, 0).UTC(), false},
-		{"iso8601", `"2018-06-19T22:17:19Z"`, time.Unix(1529446639, 0).UTC(), false},
+		{"iso8601 time", `"2018-06-19T22:17:19Z"`, time.Unix(1529446639, 0).UTC(), false},
+		{"iso8601 date", `"2018-06-19"`, time.Unix(1529366400, 0).UTC(), false},
+		{"iso8601 year", `"2018"`, time.Unix(1514764800, 0).UTC(), false},
 		{"invalid string", `"1000h"`, time.Now(), true},
 	}
 


### PR DESCRIPTION
Enables `models.Time` to be specified as an integer in JSON and it will be parsed as a unix timestamp.