### PR TITLE
Add go generate step to gui target

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,6 @@ RUN mv /tmp/chainlink /root/ && \
   mv /tmp/enclave.signed.so /root/ 2>/dev/null || true && \
   mv /tmp/libadapters.so /usr/lib/ 2>/dev/null || true && \
   rm -f /tmp/*.so
-COPY --from=builder /go/src/github.com/smartcontractkit/chainlink/gui/dist /go/src/github.com/smartcontractkit/chainlink/gui/dist
 
 # Launch chainlink via a small script that watches AESM + Chainlink
 ARG SGX_SIMULATION

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,8 @@ gui: ## Install GUI
 	@cd gui
 	@yarn install
 	@cd ..
-	@yarn build
+	yarn build
+	go generate ./...
 
 docker: ## Build the docker image.
 	docker build \


### PR DESCRIPTION
Add the go generate command so gui assets get embedded in chainlink binary and docker file.