### PR TITLE
Tag builder image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Chainlink with SGX
-FROM smartcontract/builder as builder
+FROM smartcontract/builder:1.0.0 as builder
 
 # Have to reintroduce ENV vars from Baidu's SGX SDK image
 ENV PATH /root/.cargo/bin:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/sgxsdk/bin:/opt/sgxsdk/bin/x64

--- a/builder/GNUmakefile
+++ b/builder/GNUmakefile
@@ -1,3 +1,3 @@
 .PHONY: all
 all:
-	docker build -t smartcontract/builder .
+	docker build -t smartcontract/builder:1.0.0 .


### PR DESCRIPTION
Tag the image used so that building the Dockerfile still works even while I push newer build images.