### PR TITLE
use new RunChannel for JobRunsController

### DIFF
--- a/adapters/sleep.go
+++ b/adapters/sleep.go
@@ -23,7 +23,7 @@ func (adapter *Sleep) Perform(input models.RunResult, str *store.Store) models.R
 	go func() {
 		<-str.Clock.After(duration)
 		if err := str.RunChannel.Send(input, nil); err != nil {
-			logger.Warn("Sleep Adapter Perform:", err.Error())
+			logger.Error("Sleep Adapter Perform:", err.Error())
 		}
 	}()
 

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -84,7 +84,7 @@ func logIfNonceOutOfSync(store *strpkg.Store) {
 	account := store.TxManager.GetActiveAccount()
 	lastNonce, err := store.GetLastNonce(account.Address)
 	if err != nil {
-		logger.Warn("database error when checking nonce: ", err)
+		logger.Error("database error when checking nonce: ", err)
 		return
 	}
 

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -724,8 +724,3 @@ func AssertServerResponse(t *testing.T, resp *http.Response, expectedStatusCode 
 		assert.FailNowf(t, "Unexpected response", "Expected %d response, got %d", expectedStatusCode, resp.StatusCode)
 	}
 }
-
-func NewJobRunner(s *store.Store) (services.JobRunner, func()) {
-	rm := services.NewJobRunner(s)
-	return rm, func() { rm.Stop() }
-}

--- a/internal/cltest/factories.go
+++ b/internal/cltest/factories.go
@@ -308,3 +308,8 @@ func MarkJobRunPendingBridge(jr models.JobRun, i int) models.JobRun {
 	jr.TaskRuns[i].Result.Status = models.RunStatusPendingBridge
 	return jr
 }
+
+func NewJobRunner(s *store.Store) (services.JobRunner, func()) {
+	rm := services.NewJobRunner(s)
+	return rm, func() { rm.Stop() }
+}

--- a/services/export_test.go
+++ b/services/export_test.go
@@ -1,0 +1,15 @@
+package services
+
+import "github.com/smartcontractkit/chainlink/store"
+
+func ExportedChannelForRun(jr JobRunner, runID string) chan<- store.RunRequest {
+	return jr.channelForRun(runID)
+}
+
+func ExportedResumeSleepingRuns(jr JobRunner) error {
+	return jr.resumeSleepingRuns()
+}
+
+func ExportedWorkerCount(jr JobRunner) int {
+	return jr.workerCount()
+}

--- a/services/head_tracker.go
+++ b/services/head_tracker.go
@@ -183,7 +183,7 @@ func (ht *HeadTracker) subscribeToNewHeads(headers chan models.BlockHeader) (mod
 	go func() {
 		err := <-sub.Err()
 		if err != nil {
-			logger.Warnw("Error in new head subscription, disconnected", "err", err)
+			logger.Errorw("Error in new head subscription, disconnected", "err", err)
 			ht.reconnectLoop()
 		}
 	}()
@@ -193,7 +193,7 @@ func (ht *HeadTracker) subscribeToNewHeads(headers chan models.BlockHeader) (mod
 func (ht *HeadTracker) updateBlockHeader() {
 	header, err := ht.store.TxManager.GetBlockByNumber("latest")
 	if err != nil {
-		logger.Warn("Unable to update latest block header", "err", err)
+		logger.Errorw("Unable to update latest block header", "err", err)
 		return
 	}
 
@@ -238,7 +238,7 @@ func (ht *HeadTracker) reconnectLoop() {
 		ht.sleeper.Sleep()
 		err := ht.Start()
 		if err != nil {
-			logger.Warnw(fmt.Sprintf("Error reconnecting to %v", ht.store.Config.EthereumURL), "err", err)
+			logger.Errorw(fmt.Sprintf("Error reconnecting to %v", ht.store.Config.EthereumURL), "err", err)
 		} else {
 			logger.Info("Reconnected to node ", ht.store.Config.EthereumURL)
 			break

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -97,13 +97,13 @@ func (rm *jobRunner) workerLoop(runID string, workerChannel chan store.RunReques
 		case rr := <-workerChannel:
 			jr, err := rm.store.FindJobRun(runID)
 			if err != nil {
-				logger.Warnw("Application Run Channel Executor: error finding run", jr.ForLogger("error", err)...)
+				logger.Errorw("Application Run Channel Executor: error finding run", jr.ForLogger("error", err)...)
 			}
 			if rr.BlockNumber != nil {
 				logger.Debug("Woke up", jr.ID, "worker to process ", rr.BlockNumber.ToInt())
 			}
 			if jr, err = ExecuteRunAtBlock(jr, rm.store, rr.Input, rr.BlockNumber); err != nil {
-				logger.Warnw("Application Run Channel Executor: error executing run", jr.ForLogger("error", err)...)
+				logger.Errorw("Application Run Channel Executor: error executing run", jr.ForLogger("error", err)...)
 			}
 
 			if jr.Status.Finished() {

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -92,7 +92,7 @@ func (js *jobSubscriber) OnNewHead(head *models.BlockHeader) {
 	ibn := head.ToIndexableBlockNumber()
 	for _, jr := range pendingRuns {
 		if err := js.store.RunChannel.Send(jr.Result, ibn); err != nil {
-			logger.Warn("JobSubscriber.OnNewHead: ", err.Error())
+			logger.Error("JobSubscriber.OnNewHead: ", err.Error())
 		}
 	}
 }

--- a/web/job_runs_controller_test.go
+++ b/web/job_runs_controller_test.go
@@ -26,6 +26,7 @@ type JobRun struct {
 
 func BenchmarkJobRunsController_Index(b *testing.B) {
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 	j := setupJobRunsControllerIndex(b, app)
 
@@ -40,6 +41,7 @@ func TestJobRunsController_Index(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 
 	j := setupJobRunsControllerIndex(t, app)
@@ -99,6 +101,7 @@ func setupJobRunsControllerIndex(t assert.TestingT, app *cltest.TestApplication)
 func TestJobRunsController_Create_Success(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 
 	j, _ := cltest.NewJobWithWebInitiator()
@@ -114,6 +117,7 @@ func TestJobRunsController_Create_Success(t *testing.T) {
 func TestJobRunsController_Create_EmptyBody(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 
 	j, _ := cltest.NewJobWithWebInitiator()
@@ -126,6 +130,7 @@ func TestJobRunsController_Create_EmptyBody(t *testing.T) {
 func TestJobRunsController_Create_InvalidBody(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 
 	j, _ := cltest.NewJobWithWebInitiator()
@@ -140,6 +145,7 @@ func TestJobRunsController_Create_InvalidBody(t *testing.T) {
 func TestJobRunsController_Create_WithoutWebInitiator(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 
 	j := cltest.NewJob()
@@ -153,6 +159,7 @@ func TestJobRunsController_Create_WithoutWebInitiator(t *testing.T) {
 func TestJobRunsController_Create_NotFound(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 
 	url := app.Server.URL + "/v2/specs/garbageID/runs"
@@ -163,6 +170,7 @@ func TestJobRunsController_Create_NotFound(t *testing.T) {
 func TestJobRunsController_Update_Success(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 
 	bt := cltest.NewBridgeType()
@@ -189,6 +197,7 @@ func TestJobRunsController_Update_Success(t *testing.T) {
 func TestJobRunsController_Update_NotPending(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 
 	bt := cltest.NewBridgeType()
@@ -208,6 +217,7 @@ func TestJobRunsController_Update_NotPending(t *testing.T) {
 func TestJobRunsController_Update_WithError(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 
 	bt := cltest.NewBridgeType()
@@ -234,6 +244,7 @@ func TestJobRunsController_Update_WithError(t *testing.T) {
 func TestJobRunsController_Update_BadInput(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 
 	bt := cltest.NewBridgeType()
@@ -255,6 +266,7 @@ func TestJobRunsController_Update_BadInput(t *testing.T) {
 func TestJobRunsController_Update_NotFound(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 
 	bt := cltest.NewBridgeType()
@@ -277,6 +289,7 @@ func TestJobRunsController_Show_Found(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 
 	j, initr := cltest.NewJobWithSchedule("9 9 9 9 6")
@@ -301,6 +314,7 @@ func TestJobRunsController_Show_Found(t *testing.T) {
 func TestJobRunsController_Show_NotFound(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 
 	resp := cltest.BasicAuthGet(app.Server.URL + "/v2/runs/garbage")
@@ -310,6 +324,7 @@ func TestJobRunsController_Show_NotFound(t *testing.T) {
 func TestJobRunsController_Show_Unauthenticated(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication()
+	app.Start()
 	defer cleanup()
 
 	resp, err := http.Get(app.Server.URL + "/v2/runs/notauthorized")

--- a/web/router.go
+++ b/web/router.go
@@ -97,7 +97,7 @@ func guiEngine(app *services.ChainlinkApplication) *gin.Engine {
 		if filepath.Ext(c.Request.URL.Path) == "" {
 			index, err := box.Open("index.html")
 			if err != nil {
-				logger.Warn(err)
+				logger.Error(err)
 			}
 
 			buf := new(bytes.Buffer)
@@ -115,7 +115,7 @@ func loggerFunc() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		buf, err := ioutil.ReadAll(c.Request.Body)
 		if err != nil {
-			logger.Warn("Web request log error: ", err.Error())
+			logger.Error("Web request log error: ", err.Error())
 			c.Next()
 			return
 		}


### PR DESCRIPTION
- uses RunChannel to kick off new JobRuns
- mark JobRunner methods as unexported
- updates logger.Warn to logger.Error where errors are raised