### PR TITLE
stop job runner before nuking DB

### DIFF
--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -219,9 +219,9 @@ func NewStoreWithConfig(config *TestConfig) (*store.Store, func()) {
 // NewStore creates a new store
 func NewStore() (*store.Store, func()) {
 	c, cleanup := NewConfig()
-	store, storecleanup := NewStoreWithConfig(c)
+	store, storeCleanup := NewStoreWithConfig(c)
 	return store, func() {
-		storecleanup()
+		storeCleanup()
 		cleanup()
 	}
 }

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -210,7 +210,7 @@ func NewStore() (*store.Store, func()) {
 
 func cleanUpStore(store *store.Store) {
 	logger.Sync()
-	store.Close()
+	store.Stop()
 	go func() {
 		if err := os.RemoveAll(store.Config.RootDir); err != nil {
 			log.Println(err)

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -210,7 +210,7 @@ func NewStore() (*store.Store, func()) {
 
 func cleanUpStore(store *store.Store) {
 	logger.Sync()
-	store.Stop()
+	store.Close()
 	go func() {
 		if err := os.RemoveAll(store.Config.RootDir); err != nil {
 			log.Println(err)

--- a/services/application.go
+++ b/services/application.go
@@ -86,7 +86,7 @@ func (app *ChainlinkApplication) Stop() error {
 	app.JobRunner.Stop()
 	app.HeadTracker.Detach(app.jobSubscriberID)
 	app.HeadTracker.Detach(app.specSubscriberID)
-	return app.Store.Stop()
+	return app.Store.Close()
 }
 
 // GetStore returns the pointer to the store for the ChainlinkApplication.

--- a/services/job_runner_test.go
+++ b/services/job_runner_test.go
@@ -20,7 +20,8 @@ import (
 func TestJobRunner_resumeSleepingRuns(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
-	rm := services.NewJobRunner(store)
+	rm, cleanup := cltest.NewJobRunner(store)
+	defer cleanup()
 
 	j := models.NewJob()
 	i := models.Initiator{Type: models.InitiatorWeb}
@@ -45,7 +46,8 @@ func TestJobRunner_ChannelForRun_equalityBetweenRuns(t *testing.T) {
 
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
-	rm := services.NewJobRunner(store)
+	rm, cleanup := cltest.NewJobRunner(store)
+	defer cleanup()
 
 	job, initr := cltest.NewJobWithWebInitiator()
 	run1 := job.NewRun(initr)
@@ -56,7 +58,7 @@ func TestJobRunner_ChannelForRun_equalityBetweenRuns(t *testing.T) {
 	chan1b := services.ExportedChannelForRun(rm, run1.ID)
 
 	assert.NotEqual(t, chan1a, chan2)
-	assert.Equal(t, chan1a, chan1a)
+	assert.Equal(t, chan1a, chan1b)
 	assert.NotEqual(t, chan2, chan1b)
 }
 
@@ -65,7 +67,8 @@ func TestJobRunner_ChannelForRun_sendAfterClosing(t *testing.T) {
 
 	s, cleanup := cltest.NewStore()
 	defer cleanup()
-	rm := services.NewJobRunner(s)
+	rm, cleanup := cltest.NewJobRunner(s)
+	defer cleanup()
 	assert.NoError(t, rm.Start())
 
 	j, initr := cltest.NewJobWithWebInitiator()
@@ -90,7 +93,8 @@ func TestJobRunner_ChannelForRun_equalityWithoutClosing(t *testing.T) {
 
 	s, cleanup := cltest.NewStore()
 	defer cleanup()
-	rm := services.NewJobRunner(s)
+	rm, cleanup := cltest.NewJobRunner(s)
+	defer cleanup()
 	assert.NoError(t, rm.Start())
 
 	j, initr := cltest.NewJobWithWebInitiator()
@@ -113,7 +117,8 @@ func TestJobRunner_Stop(t *testing.T) {
 
 	s, cleanup := cltest.NewStore()
 	defer cleanup()
-	rm := services.NewJobRunner(s)
+	rm, cleanup := cltest.NewJobRunner(s)
+	defer cleanup()
 	j, initr := cltest.NewJobWithWebInitiator()
 	jr := j.NewRun(initr)
 

--- a/services/subscription_test.go
+++ b/services/subscription_test.go
@@ -85,7 +85,10 @@ func TestServices_NewInitiatorSubscription_BackfillLogs(t *testing.T) {
 	defer sub.Unsubscribe()
 
 	eth.EventuallyAllCalled(t)
-	assert.Equal(t, int32(1), atomic.LoadInt32(&count))
+
+	gomega.NewGomegaWithT(t).Eventually(func() int32 {
+		return atomic.LoadInt32(&count)
+	}).Should(gomega.Equal(int32(1)))
 }
 
 func TestServices_NewInitiatorSubscription_BackfillLogs_WithNoHead(t *testing.T) {

--- a/store/eth_client_test.go
+++ b/store/eth_client_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestEthClient_GetTxReceipt(t *testing.T) {
 	response := cltest.LoadJSON("../internal/fixtures/eth/getTransactionReceipt.json")
-	mockServer := cltest.NewWSServer(string(response))
-	defer mockServer.Close()
+	mockServer, wscleanup := cltest.NewWSServer(string(response))
+	defer wscleanup()
 	config := cltest.NewConfigWithWSServer(mockServer)
 	store, cleanup := cltest.NewStoreWithConfig(config)
 	defer cleanup()

--- a/store/eth_client_test.go
+++ b/store/eth_client_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestEthClient_GetTxReceipt(t *testing.T) {
 	response := cltest.LoadJSON("../internal/fixtures/eth/getTransactionReceipt.json")
-	mockServer, wscleanup := cltest.NewWSServer(string(response))
-	defer wscleanup()
+	mockServer, wsCleanup := cltest.NewWSServer(string(response))
+	defer wsCleanup()
 	config := cltest.NewConfigWithWSServer(mockServer)
 	store, cleanup := cltest.NewStoreWithConfig(config)
 	defer cleanup()

--- a/store/store.go
+++ b/store/store.go
@@ -97,10 +97,10 @@ func (s *Store) Start() error {
 	return s.TxManager.ActivateAccount(acc)
 }
 
-// Stop shuts down all of the working parts of the store.
-func (s *Store) Stop() error {
+// Close shuts down all of the working parts of the store.
+func (s *Store) Close() error {
 	s.RunChannel.Close()
-	return s.Close()
+	return s.ORM.Close()
 }
 
 // AfterNower is an interface that fulfills the `After()` and `Now()`

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewStore_Start(t *testing.T) {
+func TestStore_Start(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplicationWithKeyStore()
@@ -23,7 +23,7 @@ func TestNewStore_Start(t *testing.T) {
 	ethMock.EventuallyAllCalled(t)
 }
 
-func TestNewStore_Stop(t *testing.T) {
+func TestStore_Close(t *testing.T) {
 	t.Parallel()
 
 	s, cleanup := cltest.NewStore()
@@ -41,7 +41,7 @@ func TestNewStore_Stop(t *testing.T) {
 	assert.Equal(t, want, rr.Input)
 	assert.True(t, open)
 
-	assert.NoError(t, s.Stop())
+	assert.NoError(t, s.Close())
 
 	rr, open = <-s.RunChannel.Receive()
 	assert.Equal(t, store.RunRequest{}, rr)


### PR DESCRIPTION
- prevent deadlock by stopping job runner in tests
- prevent race condition in backfill test

Signed-off-by: Dimitri Roche <dimroc@gmail.com>