### PR TITLE
Optimize dockerfiles for SGX make workflow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,16 @@ ENV PATH /go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr
 ARG COMMIT_SHA
 ARG ENVIRONMENT
 
-ADD . /go/src/github.com/smartcontractkit/chainlink
+# Do dependency installs first, since these will change less than the full
+# source tree and can get cached
 WORKDIR /go/src/github.com/smartcontractkit/chainlink
-RUN make build
+ADD Gopkg.* /go/src/github.com/smartcontractkit/chainlink/
+RUN dep ensure -vendor-only
+ADD package.json yarn.lock /go/src/github.com/smartcontractkit/chainlink/
+RUN yarn install
+
+ADD . /go/src/github.com/smartcontractkit/chainlink
+RUN make chainlink
 
 # Final layer: ubuntu with chainlink binary
 FROM ubuntu:16.04

--- a/Dockerfile-sgx
+++ b/Dockerfile-sgx
@@ -10,10 +10,18 @@ ARG COMMIT_SHA
 ARG ENVIRONMENT
 ENV SGX_ENABLED yes
 ARG SGX_SIMULATION
+ENV SGX_SIMULATION $SGX_SIMULATION
+
+# Do dependency installs first, since these will change less than the full
+# source tree and can get cached
+WORKDIR /go/src/github.com/smartcontractkit/chainlink
+ADD Gopkg.* /go/src/github.com/smartcontractkit/chainlink/
+RUN dep ensure -vendor-only
+ADD package.json yarn.lock /go/src/github.com/smartcontractkit/chainlink/
+RUN yarn install
 
 ADD . /go/src/github.com/smartcontractkit/chainlink
-WORKDIR /go/src/github.com/smartcontractkit/chainlink
-RUN make build
+RUN make chainlink
 
 # Final layer: ubuntu with aesm and chainlink binaries (executable + enclave)
 FROM ubuntu:16.04

--- a/Makefile
+++ b/Makefile
@@ -30,14 +30,13 @@ godep: ## Ensure chainlink's go dependencies are installed.
 yarndep: ## Ensure the frontend's dependencies are installed.
 	yarn install
 
-build: godep gui $(SGX_BUILD_ENCLAVE) ## Build chainlink.
-	go build $(GOFLAGS) -o chainlink
+build: yarndep godep chainlink ## Build chainlink.
 
 install: godep gui ## Install chainlink
 	go install $(GOFLAGS)
 
-gui: yarndep ## Install GUI
-	CHAINLINK_VERSION="$(VERSION)@$(COMMIT_SHA)" yarn build
+gui: ## Install GUI
+	yarn build
 	go generate ./...
 
 docker: ## Build the docker image.
@@ -50,6 +49,9 @@ docker: ## Build the docker image.
 
 dockerpush: ## Push the docker image to dockerhub
 	docker push $(REPO)
+
+chainlink: gui $(SGX_BUILD_ENCLAVE)
+	go build $(GOFLAGS) -o chainlink
 
 .PHONY: $(SGX_ENCLAVE)
 $(SGX_ENCLAVE):

--- a/Makefile
+++ b/Makefile
@@ -6,9 +6,12 @@ ENVIRONMENT ?= release
 
 REPO := smartcontract/chainlink
 COMMIT_SHA ?= $(shell git rev-parse HEAD)
-VERSION = $(shell cat VERSION)
+VERSION ?= $(shell cat VERSION)
 GO_LDFLAGS := $(shell internal/bin/ldflags)
 GOFLAGS := -ldflags "$(GO_LDFLAGS)"
+DOCKERFILE := Dockerfile
+DOCKER_TAG := $(REPO)
+CHAINLINK_VERSION := "$(VERSION)@$(COMMIT_SHA)"
 
 # SGX is disabled by default, but turned on when building from Docker
 SGX_ENABLED ?= no
@@ -20,6 +23,8 @@ ifeq ($(SGX_ENABLED),yes)
 	GO_LDFLAGS += -L $(SGX_TARGET)
 	GOFLAGS += -tags=sgx_enclave
 	SGX_BUILD_ENCLAVE := $(SGX_ENCLAVE)
+	DOCKERFILE := Dockerfile-sgx
+	DOCKER_TAG := $(REPO)-sgx
 else
 	SGX_BUILD_ENCLAVE :=
 endif
@@ -43,9 +48,8 @@ docker: ## Build the docker image.
 	docker build \
 		--build-arg ENVIRONMENT \
 		--build-arg COMMIT_SHA \
-		--build-arg SGX_ENABLED \
 		--build-arg SGX_SIMULATION \
-		-t $(REPO) .
+		-t $(DOCKER_TAG) -f $(DOCKERFILE) .
 
 dockerpush: ## Push the docker image to dockerhub
 	docker push $(REPO)

--- a/store/store.go
+++ b/store/store.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path"
 	"sync"
@@ -63,12 +64,12 @@ func NewStore(config Config) *Store {
 func NewStoreWithDialer(config Config, dialer Dialer) *Store {
 	err := os.MkdirAll(config.RootDir, os.FileMode(0700))
 	if err != nil {
-		logger.Fatal("Unable to create project root dir: %+v", err)
+		logger.Fatal(fmt.Sprintf("Unable to create project root dir: %+v", err))
 	}
 	orm := initializeORM(config)
 	ethrpc, err := dialer.Dial(config.EthereumURL)
 	if err != nil {
-		logger.Fatal("Unable to dial ETH RPC port: %+v", err)
+		logger.Fatal(fmt.Sprintf("Unable to dial ETH RPC port: %+v", err))
 	}
 	keyStore := NewKeyStore(config.KeysDir())
 


### PR DESCRIPTION
Working with SGX code right now is a little painful because you basically have to build via docker, and any change to any source code builds the WHOLE image from the beginning, including yarn install (60s) and dep (5-10s).

This is an attempt to make that process faster by doing the dep and install commands in their own layers, which means they should be cached if the package manifests haven't changed. 