### PR TITLE
Adjust Drawer Item Width

### DIFF
--- a/gui/src/Layout.js
+++ b/gui/src/Layout.js
@@ -53,6 +53,7 @@ const styles = theme => {
       paddingTop: theme.spacing.unit * 2,
       paddingBottom: theme.spacing.unit * 2,
       display: 'inline-block',
+      width: 'inherit',
       textDecoration: 'none'
     },
     drawerPaper: {


### PR DESCRIPTION
I think this shouldn't be per design. 
![Preview](https://thumbs.gfycat.com/ReadyWhoppingBarbet-size_restricted.gif)
Clicking menu items outside the text was not working earlier. It should work now.