### PR TITLE
Use cargo config to share target, rather than copy in place

### DIFF
--- a/sgx/.cargo/config
+++ b/sgx/.cargo/config
@@ -1,0 +1,2 @@
+[build]
+target-dir = "../sgx/target"

--- a/sgx/Makefile
+++ b/sgx/Makefile
@@ -93,7 +93,6 @@ $(ENCLAVE_STUB): target/$(ENVIRONMENT)/enclave_u.o
 $(LIBADAPTERS): libadapters/Cargo.toml $(wildcard libadapters/src/*.rs) $(ENCLAVE_STUB)
 	@printf -- '\nBuilding \e[1;36m$@\e[0m\n\n'
 	SGX_SIMULATION=$(SGX_SIMULATION) ENVIRONMENT=$(ENVIRONMENT) SGX_SDK=$(SGX_SDK) $(CARGO) build $(RUST_FLAGS) --manifest-path $<
-	cp libadapters/$(LIBADAPTERS) $@
 
 # Enclave ---------------
 
@@ -104,8 +103,7 @@ $(RT_PATCH):
 
 $(ENCLAVE): enclave/Cargo.toml $(wildcard enclave/src/*.rs)
 	@printf -- '\nBuilding \e[1;36m$@\e[0m\n\n'
-	ENVIRONMENT=$(ENVIRONMENT) SGX_SDK=$(SGX_SDK) $(CARGO) build $(RUST_FLAGS) --manifest-path $<
-	cp enclave/$(ENCLAVE) $@
+	SGX_SIMULATION=$(SGX_SIMULATION) ENVIRONMENT=$(ENVIRONMENT) SGX_SDK=$(SGX_SDK) $(CARGO) build $(RUST_FLAGS) --manifest-path $<
 
 $(TRUSTED_EDL_FILES): $(SGX_EDGER8R) enclave/enclave.edl
 	@printf -- '\nBuilding \e[1;36m$@\e[0m\n\n'


### PR DESCRIPTION
If you cargo compile from libadapters or enclave, it'll make rust targets that get loaded into your Docker image, which might not have been built with the same SGX_SIMULATION setting. This could create inconsistencies between the untrusted and trusted side of the enclave and cause an SGX_ERROR.

This puts everything in the same target directory.

Also be explicit with SGX_SIMULATION variable in enclave build target.