### PR TITLE
Feature/wasm adapter

### DIFF
--- a/Dockerfile-sgx
+++ b/Dockerfile-sgx
@@ -1,5 +1,5 @@
 # Build Chainlink with SGX
-FROM smartcontract/builder:1.0.2 as builder
+FROM smartcontract/builder:1.0.3 as builder
 
 # Have to reintroduce ENV vars from builder image
 ENV PATH /root/.cargo/bin:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/sgxsdk/bin:/opt/sgxsdk/bin/x64

--- a/adapters/adapter.go
+++ b/adapters/adapter.go
@@ -33,6 +33,8 @@ var (
 	TaskTypeNoOpPend = models.MustNewTaskType("nooppend")
 	// TaskTypeSleep is the identifier for the Sleep adapter.
 	TaskTypeSleep = models.MustNewTaskType("sleep")
+	// TaskTypeWasm is the wasm interpereter adapter
+	TaskTypeWasm = models.MustNewTaskType("wasm")
 )
 
 // Adapter interface applies to all core adapters.
@@ -102,6 +104,9 @@ func For(task models.TaskSpec, store *store.Store) (AdapterWithMinConfs, error) 
 		err = unmarshalParams(task.Params, ac)
 	case TaskTypeSleep:
 		ac = &Sleep{}
+		err = unmarshalParams(task.Params, ac)
+	case TaskTypeWasm:
+		ac = &Wasm{}
 		err = unmarshalParams(task.Params, ac)
 	default:
 		bt, err := store.FindBridge(task.Type.String())

--- a/adapters/wasm.go
+++ b/adapters/wasm.go
@@ -1,0 +1,20 @@
+// +build !sgx_enclave
+
+package adapters
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink/store"
+	"github.com/smartcontractkit/chainlink/store/models"
+)
+
+// Wasm represents a wasm binary encoded as base64 or wasm encoded as text (a lisp like language).
+type Wasm struct {
+	WasmT string `json:"wasmt"`
+}
+
+// Perform ships the wasm representation to the SGX enclave where it is evaluated.
+func (wasm *Wasm) Perform(input models.RunResult, _ *store.Store) models.RunResult {
+	return input.WithError(fmt.Errorf("Wasm is not supported without SGX"))
+}

--- a/adapters/wasm_sgx.go
+++ b/adapters/wasm_sgx.go
@@ -1,0 +1,28 @@
+// +build sgx_enclave
+
+package adapters
+
+/*
+#cgo LDFLAGS: -L../sgx/target/release/ -ladapters
+#include "../sgx/libadapters/adapters.h"
+*/
+import "C"
+
+import (
+	"github.com/smartcontractkit/chainlink/store"
+	"github.com/smartcontractkit/chainlink/store/models"
+)
+
+// Wasm represents a wasm binary encoded as base64 or wasm encoded as text (a lisp like language).
+type Wasm struct {
+	WasmT string `json:"wasmt"`
+}
+
+// Perform ships the wasm representation to the SGX enclave where it is evaluated.
+func (wasm *Wasm) Perform(input models.RunResult, _ *store.Store) models.RunResult {
+	result, err := C.wasm(C.CString(wasm.WasmT))
+	if err != nil {
+		return input.WithError(err)
+	}
+	return input.WithValue(C.GoString(result))
+}

--- a/adapters/wasm_sgx.go
+++ b/adapters/wasm_sgx.go
@@ -3,26 +3,48 @@
 package adapters
 
 /*
-#cgo LDFLAGS: -L../sgx/target/release/ -ladapters
+#cgo LDFLAGS: -L../sgx/target/ -ladapters
 #include "../sgx/libadapters/adapters.h"
+#include "stdlib.h"
 */
 import "C"
 
 import (
+	"fmt"
+	"unsafe"
+
 	"github.com/smartcontractkit/chainlink/store"
 	"github.com/smartcontractkit/chainlink/store/models"
 )
 
 // Wasm represents a wasm binary encoded as base64 or wasm encoded as text (a lisp like language).
 type Wasm struct {
-	WasmT string `json:"wasmt"`
+	Wasm string `json:"wasm"`
 }
 
 // Perform ships the wasm representation to the SGX enclave where it is evaluated.
 func (wasm *Wasm) Perform(input models.RunResult, _ *store.Store) models.RunResult {
-	result, err := C.wasm(C.CString(wasm.WasmT))
+	buffer := make([]byte, 8192)
+	output := (*C.char)(unsafe.Pointer(&buffer[0]))
+	bufferCapacity := C.int(len(buffer))
+	outputLen := C.int(0)
+	outputLenPtr := (*C.int)(unsafe.Pointer(&outputLen))
+
+	fmt.Println("Input", input.JobRunID, input.Data, input.Amount)
+
+	wasmCStr := C.CString(wasm.Wasm)
+	defer C.free(unsafe.Pointer(wasmCStr))
+	valueCStr := C.CString(input.Get("value").String())
+	defer C.free(unsafe.Pointer(valueCStr))
+
+	fmt.Println("value", input.Get("value"), "valueCstr", valueCStr)
+
+	_, err := C.wasm(wasmCStr, valueCStr, output, bufferCapacity, outputLenPtr)
 	if err != nil {
 		return input.WithError(err)
 	}
-	return input.WithValue(C.GoString(result))
+
+	outputStr := C.GoStringN(output, outputLen)
+	fmt.Println("Wasm output", outputLen, outputStr)
+	return input.WithValue(outputStr)
 }

--- a/internal/fixtures/wasm/checketh.wat
+++ b/internal/fixtures/wasm/checketh.wat
@@ -1,0 +1,6 @@
+(module
+  (func $perform (param $value i64) (result i32)
+    (i64.lt_s (i64.const 450) (get_local $value))
+  )
+  (export "perform" (func $perform))
+)

--- a/internal/fixtures/wasm/helloworld.wat
+++ b/internal/fixtures/wasm/helloworld.wat
@@ -1,0 +1,10 @@
+(module
+  ;; Allocate a page of linear memory (64kb). Export it as "memory"
+  (memory (export "memory") 1)
+
+  ;; Write the string at the start of the linear memory.
+  (data (i32.const 0) "Hello, world!") ;; write string at location 0
+
+  ;; Export the position and length of the string.
+  (global (export "length") i32 (i32.const 12))
+  (global (export "position") i32 (i32.const 0)))

--- a/internal/fixtures/web/wasm_hello_world_job.json
+++ b/internal/fixtures/web/wasm_hello_world_job.json
@@ -1,9 +1,11 @@
 {
   "initiators": [{ "type": "web" }],
   "tasks": [
+    { "type": "HttpGet", "url": "https://api.coinmarketcap.com/v2/ticker/1027/?structure=array" },
+    { "type": "JsonParse", "path": ["data", "0", "quotes", "USD", "price"] },
     {
       "type": "Wasm",
-      "wasmt": "(module (type $type0 (func (result i32))) (table 0 anyfunc) (memory 1) (export \"memory\" memory) (export \"hello\" $func0) (func $func0 (result i32) i32.const 16) (data (i32.const 16) \"Hello World\00\"))"
+      "wasm": "AGFzbQEAAAABBgFgAX4BfwMCAQAHCwEHcGVyZm9ybQAACgoBCABCwgMgAFML"
     }
   ]
 }

--- a/internal/fixtures/web/wasm_hello_world_job.json
+++ b/internal/fixtures/web/wasm_hello_world_job.json
@@ -1,0 +1,9 @@
+{
+  "initiators": [{ "type": "web" }],
+  "tasks": [
+    {
+      "type": "Wasm",
+      "wasmt": "(module (type $type0 (func (result i32))) (table 0 anyfunc) (memory 1) (export \"memory\" memory) (export \"hello\" $func0) (func $func0 (result i32) i32.const 16) (data (i32.const 16) \"Hello World\00\"))"
+    }
+  ]
+}

--- a/sgx/enclave/Cargo.lock
+++ b/sgx/enclave/Cargo.lock
@@ -21,11 +21,13 @@ name = "enclave"
 version = "0.1.0"
 dependencies = [
  "lazy_static 0.2.8",
+ "num 0.1.40",
  "serde 1.0.16",
  "serde_json 1.0.17",
  "sgx_tstd 1.0.0",
  "sgx_types 1.0.0",
  "sgxwasm 0.1.0",
+ "wabt-core 0.2.2",
  "wasmi 0.1.1",
 ]
 
@@ -57,6 +59,41 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "num"
+version = "0.1.40"
+dependencies = [
+ "num-derive 0.1.41",
+ "num-integer 0.1.35",
+ "num-iter 0.1.34",
+ "num-traits 0.1.40",
+]
+
+[[package]]
+name = "num-derive"
+version = "0.1.41"
+dependencies = [
+ "quote 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syn 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.35"
+dependencies = [
+ "num-traits 0.1.40",
+ "sgx_tstd 1.0.0",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.34"
+dependencies = [
+ "num-integer 0.1.35",
+ "num-traits 0.1.40",
+ "sgx_tstd 1.0.0",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.1.40"
 dependencies = [
@@ -71,6 +108,11 @@ dependencies = [
  "log 0.3.8",
  "sgx_tstd 1.0.0",
 ]
+
+[[package]]
+name = "quote"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "quote"
@@ -176,6 +218,14 @@ dependencies = [
 
 [[package]]
 name = "syn"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quote 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "syn"
 version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
@@ -222,7 +272,9 @@ dependencies = [
 
 [metadata]
 "checksum memory_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
+"checksum quote 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "b0f1847d90ff21d41b08f7f9f8e82dff613c3e2c5ebc9f8a10aeee1a0c4d7d17"
 "checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
 "checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum syn 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d25c61533bd33b0badb0b96178731a19407586f8a2547753095109c142e5242"
 "checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
 "checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"

--- a/sgx/enclave/Cargo.lock
+++ b/sgx/enclave/Cargo.lock
@@ -1,104 +1,228 @@
 [[package]]
+name = "byteorder"
+version = "1.2.1"
+dependencies = [
+ "sgx_tstd 1.0.0",
+]
+
+[[package]]
 name = "cfg-if"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "0.1.2"
+
+[[package]]
+name = "dtoa"
+version = "0.4.2"
+dependencies = [
+ "sgx_tstd 1.0.0",
+]
 
 [[package]]
 name = "enclave"
 version = "0.1.0"
 dependencies = [
- "sgx_tstd 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_types 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 0.2.8",
+ "serde 1.0.16",
+ "serde_json 1.0.17",
+ "sgx_tstd 1.0.0",
+ "sgx_types 1.0.0",
+ "sgxwasm 0.1.0",
+ "wasmi 0.1.1",
 ]
 
 [[package]]
-name = "filetime"
-version = "0.1.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+name = "itoa"
+version = "0.3.4"
 dependencies = [
- "cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_tstd 1.0.0",
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.40"
+name = "lazy_static"
+version = "0.2.8"
+dependencies = [
+ "sgx_tstd 1.0.0",
+]
+
+[[package]]
+name = "log"
+version = "0.3.8"
+dependencies = [
+ "cfg-if 0.1.2",
+ "sgx_tstd 1.0.0",
+]
+
+[[package]]
+name = "memory_units"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "redox_syscall"
-version = "0.1.37"
+name = "num-traits"
+version = "0.1.40"
+dependencies = [
+ "sgx_tstd 1.0.0",
+]
+
+[[package]]
+name = "parity-wasm"
+version = "0.27.5"
+dependencies = [
+ "byteorder 1.2.1",
+ "log 0.3.8",
+ "sgx_tstd 1.0.0",
+]
+
+[[package]]
+name = "quote"
+version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "serde"
+version = "1.0.16"
+dependencies = [
+ "sgx_tstd 1.0.0",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.16"
+dependencies = [
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_derive_internals 0.16.0",
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.16.0"
+dependencies = [
+ "syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.17"
+dependencies = [
+ "dtoa 0.4.2",
+ "itoa 0.3.4",
+ "num-traits 0.1.40",
+ "serde 1.0.16",
+ "sgx_tstd 1.0.0",
+]
 
 [[package]]
 name = "sgx_alloc"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "1.0.0"
 dependencies = [
- "sgx_trts 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_trts 1.0.0",
 ]
 
 [[package]]
 name = "sgx_build_helper"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "sgx_tprotected_fs"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "1.0.0"
 dependencies = [
- "sgx_trts 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_types 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_trts 1.0.0",
+ "sgx_types 1.0.0",
 ]
 
 [[package]]
 name = "sgx_trts"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "1.0.0"
 dependencies = [
- "sgx_types 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_types 1.0.0",
 ]
 
 [[package]]
 name = "sgx_tstd"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "1.0.0"
 dependencies = [
- "sgx_alloc 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_build_helper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_tprotected_fs 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_trts 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_types 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_unwind 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_alloc 1.0.0",
+ "sgx_build_helper 0.1.0",
+ "sgx_tprotected_fs 1.0.0",
+ "sgx_trts 1.0.0",
+ "sgx_types 1.0.0",
+ "sgx_unwind 0.0.0",
 ]
 
 [[package]]
 name = "sgx_types"
-version = "0.9.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+version = "1.0.0"
 
 [[package]]
 name = "sgx_unwind"
 version = "0.0.0"
+dependencies = [
+ "sgx_trts 1.0.0",
+]
+
+[[package]]
+name = "sgxwasm"
+version = "0.1.0"
+dependencies = [
+ "serde 1.0.16",
+ "serde_derive 1.0.16",
+ "serde_json 1.0.17",
+ "sgx_tstd 1.0.0",
+ "sgx_types 1.0.0",
+ "wabt-core 0.2.2",
+ "wasmi 0.1.1",
+]
+
+[[package]]
+name = "syn"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "sgx_trts 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
+ "synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "synom"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "unicode-xid"
+version = "0.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "wabt-core"
+version = "0.2.2"
+dependencies = [
+ "serde 1.0.16",
+ "serde_derive 1.0.16",
+ "serde_json 1.0.17",
+ "sgx_tstd 1.0.0",
+ "sgx_types 1.0.0",
+]
+
+[[package]]
+name = "wasmi"
+version = "0.1.1"
+dependencies = [
+ "byteorder 1.2.1",
+ "memory_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "parity-wasm 0.27.5",
+ "serde 1.0.16",
+ "serde_derive 1.0.16",
+ "sgx_tstd 1.0.0",
 ]
 
 [metadata]
-"checksum cfg-if 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "405216fd8fe65f718daa7102ea808a946b6ce40c742998fbfd3463645552de18"
-"checksum filetime 0.1.15 (registry+https://github.com/rust-lang/crates.io-index)" = "714653f3e34871534de23771ac7b26e999651a0a228f47beb324dfdf1dd4b10f"
-"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
-"checksum redox_syscall 0.1.37 (registry+https://github.com/rust-lang/crates.io-index)" = "0d92eecebad22b767915e4d529f89f28ee96dbbf5a4810d2b844373f136417fd"
-"checksum sgx_alloc 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)" = "2f8528f6c72e037e9a300960cccf2e35935b22e358b9bab033fb14e16c579dcd"
-"checksum sgx_build_helper 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ee53e3b297178bf5a3b6275015020875149e12424d7d2ec01a2f0cfcc475b878"
-"checksum sgx_tprotected_fs 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)" = "01c5ff3ff4da51894151381aa70f94b0f9c422ede7836b431d73352d1afba1ff"
-"checksum sgx_trts 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1293a490ceb58471411c704f0163b716970bf53133ce9fdf2c163f46930603ea"
-"checksum sgx_tstd 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)" = "f3a99559870bfbb939f5baf0e7fc438e8d629c987da4af4f4d0b3a0a24a224a1"
-"checksum sgx_types 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dae9217f41cde70a81a3adfab96d78bcab678fd97ad4eedee004a3f0f6bb21a9"
-"checksum sgx_unwind 0.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "36947158619ad13e5c7841a6546f715b6da41181933994df4cc7e1e5d6665a24"
+"checksum memory_units 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "8452105ba047068f40ff7093dd1d9da90898e63dd61736462e9cdda6a90ad3c3"
+"checksum quote 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)" = "7a6e920b65c65f10b2ae65c831a81a073a89edd28c7cce89475bff467ab4167a"
+"checksum syn 0.11.11 (registry+https://github.com/rust-lang/crates.io-index)" = "d3b891b9015c88c576343b9b3e41c2c11a51c219ef067b264bd9c8aa9b441dad"
+"checksum synom 0.11.3 (registry+https://github.com/rust-lang/crates.io-index)" = "a393066ed9010ebaed60b9eafa373d4b1baac186dd7e008555b0f702b51945b6"
+"checksum unicode-xid 0.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "8c1f860d7d29cf02cb2f3f359fd35991af3d30bac52c57d265a3c461074cb4dc"

--- a/sgx/enclave/Cargo.lock
+++ b/sgx/enclave/Cargo.lock
@@ -1,4 +1,13 @@
 [[package]]
+name = "base64"
+version = "0.7.0"
+dependencies = [
+ "byteorder 1.2.1",
+ "safemem 0.2.0",
+ "sgx_tstd 1.0.0",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.2.1"
 dependencies = [
@@ -20,6 +29,7 @@ dependencies = [
 name = "enclave"
 version = "0.1.0"
 dependencies = [
+ "base64 0.7.0",
  "lazy_static 0.2.8",
  "num 0.1.40",
  "serde 1.0.16",
@@ -118,6 +128,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "quote"
 version = "0.3.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "safemem"
+version = "0.2.0"
+dependencies = [
+ "sgx_tstd 1.0.0",
+]
 
 [[package]]
 name = "serde"

--- a/sgx/enclave/Cargo.toml
+++ b/sgx/enclave/Cargo.toml
@@ -11,10 +11,12 @@ crate-type = ["staticlib"]
 default = []
 
 [dependencies]
+num = { path = "/opt/rust-sgx-sdk/third_party/num" }
 lazy_static = { path = "/opt/rust-sgx-sdk/third_party/lazy-static.rs" }
 serde = { path = "/opt/rust-sgx-sdk/third_party/serde-rs/serde/serde" }
 serde_json = { path = "/opt/rust-sgx-sdk/third_party/serde-rs/json"}
 sgxwasm = { path = "sgxwasm" }
+wabt-core = { path = "/opt/rust-sgx-sdk/third_party/wabt-rs-core" }
 wasmi = { path = "/opt/rust-sgx-sdk/third_party/wasmi" }
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]

--- a/sgx/enclave/Cargo.toml
+++ b/sgx/enclave/Cargo.toml
@@ -18,6 +18,7 @@ serde_json = { path = "/opt/rust-sgx-sdk/third_party/serde-rs/json"}
 sgxwasm = { path = "sgxwasm" }
 wabt-core = { path = "/opt/rust-sgx-sdk/third_party/wabt-rs-core" }
 wasmi = { path = "/opt/rust-sgx-sdk/third_party/wasmi" }
+base64 = { path = "/opt/rust-sgx-sdk/third_party/rust-base64" }
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
 sgx_tstd = { path = "/opt/rust-sgx-sdk/sgx_tstd" }

--- a/sgx/enclave/enclave.edl
+++ b/sgx/enclave/enclave.edl
@@ -5,8 +5,15 @@ enclave {
   from "sgx_tstdc.edl" import *;
 
   trusted {
-    public sgx_status_t sgx_http_get([in, size=url_len] const uint8_t* url, size_t url_len);
-    public sgx_status_t sgx_http_post([in, size=url_len] const uint8_t* url, size_t url_len, [in, size=body_len] const uint8_t* body, size_t body_len);
-    public sgx_status_t sgx_wasm([in, size=wasmt_len] const uint8_t* wasmt_ptr, size_t wasmt_len);
+    public sgx_status_t sgx_http_get(
+      [in, size=url_len] const uint8_t* url, size_t url_len);
+    public sgx_status_t sgx_http_post(
+      [in, size=url_len] const uint8_t* url, size_t url_len,
+      [in, size=body_len] const uint8_t* body, size_t body_len);
+    public sgx_status_t sgx_wasm(
+      [in, size=wasmt_len] const uint8_t* wasmt_ptr, size_t wasmt_len,
+      [in, size=arguments_len] const uint8_t* arguments_ptr, size_t arguments_len,
+      [out, size=result_capacity] uint8_t* result_ptr, size_t result_capacity,
+      [out] size_t *result_len);
   };
 };

--- a/sgx/enclave/enclave.edl
+++ b/sgx/enclave/enclave.edl
@@ -7,5 +7,6 @@ enclave {
   trusted {
     public sgx_status_t sgx_http_get([in, size=url_len] const uint8_t* url, size_t url_len);
     public sgx_status_t sgx_http_post([in, size=url_len] const uint8_t* url, size_t url_len, [in, size=body_len] const uint8_t* body, size_t body_len);
+    public sgx_status_t sgx_wasm([in, size=wasmt_len] const uint8_t* wasmt_ptr, size_t wasmt_len);
   };
 };

--- a/sgx/enclave/sgxwasm/Cargo.toml
+++ b/sgx/enclave/sgxwasm/Cargo.toml
@@ -1,20 +1,13 @@
 [package]
-name = "enclave"
+name = "sgxwasm"
 version = "0.1.0"
-authors = ["John Barker <john@smartcontract.com>"]
-
-[lib]
-name = "enclave"
-crate-type = ["staticlib"]
-
-[features]
-default = []
+authors = ["Baidu"]
 
 [dependencies]
-lazy_static = { path = "/opt/rust-sgx-sdk/third_party/lazy-static.rs" }
 serde = { path = "/opt/rust-sgx-sdk/third_party/serde-rs/serde/serde" }
+serde_derive = { path = "/opt/rust-sgx-sdk/third_party/serde-rs/serde/serde_derive"}
 serde_json = { path = "/opt/rust-sgx-sdk/third_party/serde-rs/json"}
-sgxwasm = { path = "sgxwasm" }
+wabt-core = { path = "/opt/rust-sgx-sdk/third_party/wabt-rs-core" }
 wasmi = { path = "/opt/rust-sgx-sdk/third_party/wasmi" }
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]

--- a/sgx/enclave/sgxwasm/src/lib.rs
+++ b/sgx/enclave/sgxwasm/src/lib.rs
@@ -1,0 +1,419 @@
+// Copyright (C) 2017-2018 Baidu, Inc. All Rights Reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in
+//    the documentation and/or other materials provided with the
+//    distribution.
+//  * Neither the name of Baidu, Inc., nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#![crate_name = "sgxwasm"]
+#![crate_type = "staticlib"]
+
+#![cfg_attr(not(target_env = "sgx"), no_std)]
+#![cfg_attr(target_env = "sgx", feature(rustc_private))]
+
+extern crate sgx_types;
+#[cfg(not(target_env = "sgx"))]
+#[macro_use]
+extern crate sgx_tstd as std;
+extern crate wasmi;
+extern crate wabt_core;
+
+use std::{i32, i64, u32, u64, f32};
+use std::prelude::v1::*;
+use std::collections::HashMap;
+use wasmi::memory_units::Pages;
+
+pub use wasmi::Error as InterpreterError;
+use wasmi::{ModuleInstance,
+            ImportsBuilder,
+            RuntimeValue,
+//          NopExternals,
+            MemoryInstance,
+            GlobalInstance,
+            GlobalRef,
+            TableRef,
+            MemoryRef,
+            TableInstance,
+            Trap,
+            Externals,
+            RuntimeArgs,
+            FuncRef,
+            Signature,
+            FuncInstance,
+            ModuleImportResolver,
+            TableDescriptor,
+            MemoryDescriptor,
+            GlobalDescriptor,
+            ModuleRef,
+            ImportResolver,
+            Module,
+};
+
+use wabt_core::script;
+use wabt_core::script::{Value};
+
+extern crate serde;
+#[macro_use]
+extern crate serde_derive;
+//use serde::{Serialize, Serializer, Deserialize, Deserializer};
+#[derive(Debug, Serialize, Deserialize)]
+pub enum SgxWasmAction {
+    Invoke {
+        module: Option<String>,
+        field: String,
+        args: Vec<BoundaryValue>
+    },
+    Get {
+        module: Option<String>,
+        field: String,
+    },
+    LoadModule {
+        name: Option<String>,
+        module: Vec<u8>,
+    },
+    TryLoad {
+        module: Vec<u8>,
+    },
+    Register {
+        name: Option<String>,
+        as_name: String,
+    },
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum BoundaryValue {
+    I32(i32),
+    I64(i64),
+    F32(u32),
+    F64(u64),
+}
+
+pub fn runtime_value_to_boundary_value(rv: RuntimeValue) -> BoundaryValue {
+    match rv {
+        RuntimeValue::I32(rv) => BoundaryValue::I32(rv),
+        RuntimeValue::I64(rv) => BoundaryValue::I64(rv),
+        RuntimeValue::F32(rv) => BoundaryValue::F32(rv.to_bits()),
+        RuntimeValue::F64(rv) => BoundaryValue::F64(rv.to_bits()),
+    }
+}
+
+pub fn boundary_value_to_runtime_value(rv: BoundaryValue) -> RuntimeValue {
+    match rv {
+        BoundaryValue::I32(bv) => RuntimeValue::I32(bv),
+        BoundaryValue::I64(bv) => RuntimeValue::I64(bv),
+        BoundaryValue::F32(bv) => RuntimeValue::F32(f32::from_bits(bv)),
+        BoundaryValue::F64(bv) => RuntimeValue::F64(f64::from_bits(bv)),
+    }
+}
+
+pub fn result_covert(res : Result<Option<RuntimeValue>, InterpreterError>)
+                     -> Result<Option<BoundaryValue>, InterpreterError>
+{
+    match res {
+        Ok(None) => Ok(None),
+        Ok(Some(rv)) => Ok(Some(runtime_value_to_boundary_value(rv))),
+        Err(x) => Err(x),
+    }
+}
+
+pub struct SpecModule {
+    table: TableRef,
+    memory: MemoryRef,
+    global_i32: GlobalRef,
+    global_f32: GlobalRef,
+    global_f64: GlobalRef,
+}
+
+impl SpecModule {
+    pub fn new() -> Self {
+        SpecModule {
+            table: TableInstance::alloc(10, Some(20)).unwrap(),
+            memory: MemoryInstance::alloc(Pages(1), Some(Pages(2))).unwrap(),
+            global_i32: GlobalInstance::alloc(RuntimeValue::I32(666), false),
+            global_f32: GlobalInstance::alloc(RuntimeValue::F32(666.0), false),
+            global_f64: GlobalInstance::alloc(RuntimeValue::F64(666.0), false),
+        }
+    }
+}
+
+pub fn spec_to_runtime_value(value: Value) -> RuntimeValue {
+    match value {
+        Value::I32(v) => RuntimeValue::I32(v),
+        Value::I64(v) => RuntimeValue::I64(v),
+        Value::F32(v) => RuntimeValue::F32(v),
+        Value::F64(v) => RuntimeValue::F64(v),
+    }
+}
+
+#[derive(Debug)]
+pub enum Error {
+    Load(String),
+    Start(Trap),
+    Script(script::Error),
+    Interpreter(InterpreterError),
+}
+
+impl From<InterpreterError> for Error {
+    fn from(e: InterpreterError) -> Error {
+        Error::Interpreter(e)
+    }
+}
+
+impl From<script::Error> for Error {
+    fn from(e: script::Error) -> Error {
+        Error::Script(e)
+    }
+}
+
+const PRINT_FUNC_INDEX: usize = 0;
+
+impl Externals for SpecModule {
+    fn invoke_index(
+        &mut self,
+        index: usize,
+        args: RuntimeArgs,
+    ) -> Result<Option<RuntimeValue>, Trap> {
+        match index {
+            PRINT_FUNC_INDEX => {
+                println!("print: {:?}", args);
+                Ok(None)
+            }
+            _ => panic!("SpecModule doesn't provide function at index {}", index),
+        }
+    }
+}
+
+impl ModuleImportResolver for SpecModule {
+    fn resolve_func(
+        &self,
+        field_name: &str,
+        func_type: &Signature,
+    ) -> Result<FuncRef, InterpreterError> {
+        let index = match field_name {
+            "print" => PRINT_FUNC_INDEX,
+            "print_i32" => PRINT_FUNC_INDEX,
+            "print_i32_f32" => PRINT_FUNC_INDEX,
+            "print_f64_f64" => PRINT_FUNC_INDEX,
+            "print_f32" => PRINT_FUNC_INDEX,
+            "print_f64" => PRINT_FUNC_INDEX,
+            _ => {
+                return Err(InterpreterError::Instantiation(format!(
+                    "Unknown host func import {}",
+                    field_name
+                )));
+            }
+        };
+
+        if func_type.return_type().is_some() {
+            return Err(InterpreterError::Instantiation(
+                "Function `print_` have unit return type".into(),
+            ));
+        }
+
+        let func = FuncInstance::alloc_host(func_type.clone(), index);
+        return Ok(func);
+    }
+    fn resolve_global(
+        &self,
+        field_name: &str,
+        _global_type: &GlobalDescriptor,
+    ) -> Result<GlobalRef, InterpreterError> {
+        match field_name {
+            "global_i32" => Ok(self.global_i32.clone()),
+            "global_f32" => Ok(self.global_f32.clone()),
+            "global_f64" => Ok(self.global_f64.clone()),
+            _ => Err(InterpreterError::Instantiation(format!(
+                "Unknown host global import {}",
+                field_name
+            )))
+        }
+    }
+
+    fn resolve_memory(
+        &self,
+        field_name: &str,
+        _memory_type: &MemoryDescriptor,
+    ) -> Result<MemoryRef, InterpreterError> {
+        if field_name == "memory" {
+            return Ok(self.memory.clone());
+        }
+
+        Err(InterpreterError::Instantiation(format!(
+            "Unknown host memory import {}",
+            field_name
+        )))
+    }
+
+    fn resolve_table(
+        &self,
+        field_name: &str,
+        _table_type: &TableDescriptor,
+    ) -> Result<TableRef, InterpreterError> {
+        if field_name == "table" {
+            return Ok(self.table.clone());
+        }
+
+        Err(InterpreterError::Instantiation(format!(
+            "Unknown host table import {}",
+            field_name
+        )))
+    }
+}
+
+pub struct SpecDriver {
+    spec_module: SpecModule,
+    instances: HashMap<String, ModuleRef>,
+    last_module: Option<ModuleRef>,
+}
+
+impl SpecDriver {
+    pub fn new() -> SpecDriver {
+        SpecDriver {
+            spec_module: SpecModule::new(),
+            instances: HashMap::new(),
+            last_module: None,
+        }
+    }
+
+    pub fn spec_module(&mut self) -> &mut SpecModule {
+        &mut self.spec_module
+    }
+
+    pub fn add_module(&mut self, name: Option<String>, module: ModuleRef) {
+        self.last_module = Some(module.clone());
+        if let Some(name) = name {
+            self.instances.insert(name, module);
+        }
+    }
+
+    pub fn module(&self, name: &str) -> Result<ModuleRef, InterpreterError> {
+        self.instances.get(name).cloned().ok_or_else(|| {
+            InterpreterError::Instantiation(format!("Module not registered {}", name))
+        })
+    }
+
+    pub fn module_or_last(&self, name: Option<&str>) -> Result<ModuleRef, InterpreterError> {
+        match name {
+            Some(name) => self.module(name),
+            None => self.last_module
+                .clone()
+                .ok_or_else(|| InterpreterError::Instantiation("No modules registered".into())),
+        }
+    }
+
+    pub fn register(&mut self, name : &Option<String>,
+                    as_name : String) -> Result<(), InterpreterError> {
+        let module = match self.module_or_last(name.as_ref().map(|x| x.as_ref())) {
+            Ok(module) => module,
+            Err(_) => return Err(InterpreterError::Instantiation("No such modules registered".into())),
+        };
+        self.add_module(Some(as_name), module);
+        Ok(())
+    }
+}
+
+impl ImportResolver for SpecDriver {
+    fn resolve_func(
+        &self,
+        module_name: &str,
+        field_name: &str,
+        func_type: &Signature,
+    ) -> Result<FuncRef, InterpreterError> {
+        if module_name == "spectest" {
+            self.spec_module.resolve_func(field_name, func_type)
+        } else {
+            self.module(module_name)?
+                .resolve_func(field_name, func_type)
+        }
+    }
+
+    fn resolve_global(
+        &self,
+        module_name: &str,
+        field_name: &str,
+        global_type: &GlobalDescriptor,
+    ) -> Result<GlobalRef, InterpreterError> {
+        if module_name == "spectest" {
+            self.spec_module.resolve_global(field_name, global_type)
+        } else {
+            self.module(module_name)?
+                .resolve_global(field_name, global_type)
+        }
+    }
+
+    fn resolve_memory(
+        &self,
+        module_name: &str,
+        field_name: &str,
+        memory_type: &MemoryDescriptor,
+    ) -> Result<MemoryRef, InterpreterError> {
+        if module_name == "spectest" {
+            self.spec_module.resolve_memory(field_name, memory_type)
+        } else {
+            self.module(module_name)?
+                .resolve_memory(field_name, memory_type)
+        }
+    }
+
+    fn resolve_table(
+        &self,
+        module_name: &str,
+        field_name: &str,
+        table_type: &TableDescriptor,
+    ) -> Result<TableRef, InterpreterError> {
+        if module_name == "spectest" {
+            self.spec_module.resolve_table(field_name, table_type)
+        } else {
+            self.module(module_name)?
+                .resolve_table(field_name, table_type)
+        }
+    }
+}
+
+pub fn try_load_module(wasm: &[u8]) -> Result<Module, Error> {
+    Module::from_buffer(wasm).map_err(|e| Error::Load(e.to_string()))
+}
+
+pub fn try_load(wasm: &[u8], spec_driver: &mut SpecDriver) -> Result<(), Error> {
+    let module = try_load_module(wasm)?;
+    let instance = ModuleInstance::new(&module, &ImportsBuilder::default())?;
+    instance
+        .run_start(spec_driver.spec_module())
+        .map_err(|trap| Error::Start(trap))?;
+    Ok(())
+}
+
+pub fn load_module(wasm: &[u8], name: &Option<String>, spec_driver: &mut SpecDriver) -> Result<ModuleRef, Error> {
+    let module = try_load_module(wasm)?;
+    let instance = ModuleInstance::new(&module, spec_driver)
+        .map_err(|e| Error::Load(e.to_string()))?
+        .run_start(spec_driver.spec_module())
+        .map_err(|trap| Error::Start(trap))?;
+
+    let module_name = name.clone();
+    spec_driver.add_module(module_name, instance.clone());
+
+    Ok(instance)
+}
+

--- a/sgx/enclave/src/lib.rs
+++ b/sgx/enclave/src/lib.rs
@@ -1,65 +1,124 @@
 #![crate_name = "enclave"]
 #![crate_type = "staticlib"]
-
 #![cfg_attr(not(target_env = "sgx"), no_std)]
 #![cfg_attr(target_env = "sgx", feature(rustc_private))]
 
-#[macro_use]
-extern crate lazy_static;
+extern crate base64;
 extern crate num;
 extern crate serde;
 extern crate serde_json;
 extern crate sgx_types;
+#[cfg(not(target_env = "sgx"))]
 #[macro_use]
 extern crate sgx_tstd as std;
 extern crate sgxwasm;
 extern crate wasmi;
 
+mod util;
 mod wasm;
 
 use sgx_types::*;
-use std::string::String;
-use std::slice;
+use util::{copy_string_to_cstr_ptr, string_from_cstr_with_len};
 
 #[no_mangle]
 pub extern "C" fn sgx_http_get(url_ptr: *const u8, url_len: usize) -> sgx_status_t {
-    let url_slice = unsafe { slice::from_raw_parts(url_ptr, url_len) };
-    let url = String::from_utf8(url_slice.to_vec()).unwrap();
+    let url = string_from_cstr_with_len(url_ptr, url_len).unwrap();
 
     println!("Performing HTTP GET from within enclave with {:?}", url);
     sgx_status_t::SGX_SUCCESS
 }
 
 #[no_mangle]
-pub extern "C" fn sgx_http_post(url_ptr: *const u8, url_len: usize, body_ptr: *const u8, body_len: usize) -> sgx_status_t {
-    let url_slice = unsafe { slice::from_raw_parts(url_ptr, url_len) };
-    let url = String::from_utf8(url_slice.to_vec()).unwrap();
+pub extern "C" fn sgx_http_post(
+    url_ptr: *const u8,
+    url_len: usize,
+    body_ptr: *const u8,
+    body_len: usize,
+) -> sgx_status_t {
+    let url = string_from_cstr_with_len(url_ptr, url_len).unwrap();
+    let body = string_from_cstr_with_len(body_ptr, body_len).unwrap();
 
-    let body_slice = unsafe { slice::from_raw_parts(body_ptr, body_len) };
-    let body = String::from_utf8(body_slice.to_vec()).unwrap();
-
-    println!("Performing HTTP POST from within enclave with {:?}: {:?}", url, body);
+    println!(
+        "Performing HTTP POST from within enclave with {:?}: {:?}",
+        url, body
+    );
     sgx_status_t::SGX_SUCCESS
 }
 
 #[no_mangle]
-pub extern "C" fn sgx_wasm(wasmt_ptr: *const u8, wasmt_len: usize) -> sgx_status_t {
-    let wasmt_slice = unsafe { slice::from_raw_parts(wasmt_ptr, wasmt_len) };
-    let wasmt = String::from_utf8(wasmt_slice.to_vec()).unwrap();
+pub extern "C" fn sgx_wasm(
+    wasmt_ptr: *const u8,
+    wasmt_len: usize,
+    arguments_ptr: *const u8,
+    arguments_len: usize,
+    result_ptr: *mut u8,
+    result_capacity: usize,
+    result_len: *mut usize,
+) -> sgx_status_t {
+    match wasm(
+        wasmt_ptr,
+        wasmt_len,
+        arguments_ptr,
+        arguments_len,
+        result_ptr,
+        result_capacity,
+        result_len,
+    ) {
+        Ok(_) => sgx_status_t::SGX_SUCCESS,
+        _ => sgx_status_t::SGX_ERROR_UNEXPECTED,
+    }
+}
 
-    let data = &[
-        0, 97, 115, 109, // \0ASM - magic
-        1, 0, 0, 0       //  0x01 - version
-    ];
+enum WasmError {
+    FromUtf8Error(std::string::FromUtf8Error),
+    WasmError(wasm::Error),
+    OutputCStrError(util::OutputCStrError),
+}
 
-    match wasmi::Module::from_buffer(data) {
-        Ok(r) => {
-            //println!("module: {:?}", r);
-            return sgx_status_t::SGX_SUCCESS
-        },
-        Err(err) => {
-            println!("Error executing wasm: {:?}", err);
-            return sgx_status_t::SGX_ERROR_WASM_INTERPRETER_ERROR;
-        },
-    };
+impl From<std::string::FromUtf8Error> for WasmError {
+    fn from(e: std::string::FromUtf8Error) -> Self {
+        WasmError::FromUtf8Error(e)
+    }
+}
+
+impl From<wasm::Error> for WasmError {
+    fn from(e: wasm::Error) -> Self {
+        WasmError::WasmError(e)
+    }
+}
+
+impl From<util::OutputCStrError> for WasmError {
+    fn from(e: util::OutputCStrError) -> Self {
+        WasmError::OutputCStrError(e)
+    }
+}
+
+fn wasm(
+    wasmt_ptr: *const u8,
+    wasmt_len: usize,
+    arguments_ptr: *const u8,
+    arguments_len: usize,
+    result_ptr: *mut u8,
+    result_capacity: usize,
+    result_len: *mut usize,
+) -> Result<(), WasmError> {
+
+    let wasmt = string_from_cstr_with_len(wasmt_ptr, wasmt_len)?;
+    println!("wasmt: {:?}", wasmt);
+
+    let arguments = string_from_cstr_with_len(arguments_ptr, arguments_len)?;
+    println!("arguments: {:?}", arguments);
+
+    let output = wasm::exec(&wasmt, &arguments)?;
+    println!("output: {:?}", output);
+
+    // FIXME: This prints the value as I32(1) which is not super useful right now
+    copy_string_to_cstr_ptr(
+        &format!("{:?}", output),
+        result_ptr,
+        result_capacity,
+        result_len,
+    )?;
+
+    Ok(())
 }

--- a/sgx/enclave/src/lib.rs
+++ b/sgx/enclave/src/lib.rs
@@ -4,9 +4,20 @@
 #![cfg_attr(not(target_env = "sgx"), no_std)]
 #![cfg_attr(target_env = "sgx", feature(rustc_private))]
 
+#[macro_use]
+extern crate lazy_static;
+
+extern crate serde;
+extern crate serde_json;
+
 extern crate sgx_types;
 #[macro_use]
 extern crate sgx_tstd as std;
+
+extern crate sgxwasm;
+extern crate wasmi;
+
+mod wasm;
 
 use sgx_types::*;
 use std::string::String;
@@ -30,5 +41,10 @@ pub extern "C" fn sgx_http_post(url_ptr: *const u8, url_len: usize, body_ptr: *c
     let body = String::from_utf8(body_slice.to_vec()).unwrap();
 
     println!("Performing HTTP POST from within enclave with {:?}: {:?}", url, body);
+    sgx_status_t::SGX_SUCCESS
+}
+
+#[no_mangle]
+pub extern "C" fn sgx_wasm(wasmt_ptr: *const u8, wasmt_len: usize) -> sgx_status_t {
     sgx_status_t::SGX_SUCCESS
 }

--- a/sgx/enclave/src/util.rs
+++ b/sgx/enclave/src/util.rs
@@ -1,0 +1,50 @@
+// Util functions, primarily for passing data between Go / Rust / SGX enclaves
+
+use std::ffi::{CString, NulError};
+use std::ptr;
+use std::slice;
+use std::slice::from_raw_parts_mut;
+use std::string::{FromUtf8Error, String};
+
+// string_from_cstr_with_len creates a rust String from a string pointer with a specific length.
+pub fn string_from_cstr_with_len(ptr: *const u8, len: usize) -> Result<String, FromUtf8Error> {
+    let slice = unsafe { slice::from_raw_parts(ptr, len) };
+    String::from_utf8(slice.to_vec())
+}
+
+#[derive(Debug)]
+pub enum OutputCStrError {
+    NulError,
+    CapacityError,
+}
+
+impl From<NulError> for OutputCStrError {
+    fn from(_: NulError) -> Self {
+        OutputCStrError::NulError
+    }
+}
+
+// copy_string_to_cstr_ptr takes in input rust String, and copies it to an output pointer
+// with a specific capacity, storing the input string length in output_len.
+pub fn copy_string_to_cstr_ptr(
+    input: &str,
+    output_ptr: *mut u8,
+    output_capacity: usize,
+    output_len: *mut usize,
+) -> Result<(), OutputCStrError> {
+
+    let input_cstring = CString::new(input)?;
+    let input_slice = input_cstring.to_bytes();
+    let input_size = input_slice.len();
+
+    if output_capacity < input_size {
+        return Err(OutputCStrError::CapacityError);
+    }
+
+    unsafe {
+        from_raw_parts_mut(output_ptr, input_size).copy_from_slice(input_slice);
+        ptr::copy(&input_size, output_len, 1);
+    }
+
+    Ok(())
+}

--- a/sgx/enclave/src/wasm.rs
+++ b/sgx/enclave/src/wasm.rs
@@ -1,222 +1,77 @@
-// Copyright (C) 2017-2018 Baidu, Inc. All Rights Reserved.
-//
-// Redistribution and use in source and binary forms, with or without
-// modification, are permitted provided that the following conditions
-// are met:
-//
-//  * Redistributions of source code must retain the above copyright
-//    notice, this list of conditions and the following disclaimer.
-//  * Redistributions in binary form must reproduce the above copyright
-//    notice, this list of conditions and the following disclaimer in
-//    the documentation and/or other materials provided with the
-//    distribution.
-//  * Neither the name of Baidu, Inc., nor the names of its
-//    contributors may be used to endorse or promote products derived
-//    from this software without specific prior written permission.
-//
-// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+use base64;
+use num::traits;
+use num::Num;
+use sgxwasm;
+use std::num;
+use wasmi::{self, ImportsBuilder, ModuleInstance, NopExternals};
 
-use std::prelude::v1::*;
-use std::sync::SgxMutex;
-use std::ptr;
-
-use serde_json;
-
-use sgxwasm::{self, SpecDriver, boundary_value_to_runtime_value, result_covert};
-
-use sgx_types::*;
-use std::slice;
-
-use wasmi::{self, ModuleInstance, ImportsBuilder, RuntimeValue, Error as InterpreterError, Module};
-
-lazy_static!{
-    static ref SPECDRIVER: SgxMutex<SpecDriver> = SgxMutex::new(SpecDriver::new());
+#[derive(Debug)]
+pub enum Error {
+    Base64DecoderError(base64::DecodeError),
+    EmptyResultError,
+    ParseIntError(num::ParseIntError),
+    ParseFloatError(traits::ParseFloatError),
+    WasmError(sgxwasm::Error),
+    WasmTrap(wasmi::Trap),
 }
 
-#[no_mangle]
-pub extern "C"
-fn sgxwasm_init() -> sgx_status_t {
-    let mut sd = SPECDRIVER.lock().unwrap();
-    *sd = SpecDriver::new();
-    sgx_status_t::SGX_SUCCESS
-}
-
-fn wasm_invoke(module : Option<String>, field : String, args : Vec<RuntimeValue>)
-              -> Result<Option<RuntimeValue>, InterpreterError> {
-    let mut program = SPECDRIVER.lock().unwrap();
-    let module = program.module_or_last(module.as_ref().map(|x| x.as_ref()))
-                        .expect(&format!("Expected program to have loaded module {:?}", module));
-    module.invoke_export(&field, &args, program.spec_module())
-}
-
-fn wasm_get(module : Option<String>, field : String)
-            -> Result<Option<RuntimeValue>, InterpreterError> {
-    let program = SPECDRIVER.lock().unwrap();
-    let module = match module {
-        None => {
-                 program
-                 .module_or_last(None)
-                 .expect(&format!("Expected program to have loaded module {:?}",
-                        "None"
-                 ))
-        },
-        Some(str) => {
-                 program
-                 .module_or_last(Some(&str))
-                 .expect(&format!("Expected program to have loaded module {:?}",
-                         str
-                 ))
-        }
-    };
-
-    let global = module.export_by_name(&field)
-                       .ok_or_else(|| {
-                           InterpreterError::Global(format!("Expected to have export with name {}", field))
-                       })?
-                       .as_global()
-                       .cloned()
-                       .ok_or_else(|| {
-                           InterpreterError::Global(format!("Expected export {} to be a global", field))
-                       })?;
-     Ok(Some(global.get()))
-}
-
-fn try_load_module(wasm: &[u8]) -> Result<Module, InterpreterError> {
-    wasmi::Module::from_buffer(wasm).map_err(|e| InterpreterError::Instantiation(format!("Module::from_buffer error {:?}", e)))
-}
-
-fn wasm_try_load(wasm: Vec<u8>) -> Result<(), InterpreterError> {
-    let ref mut spec_driver = SPECDRIVER.lock().unwrap();
-    let module = try_load_module(&wasm[..])?;
-    let instance = ModuleInstance::new(&module, &ImportsBuilder::default())?;
-    instance
-        .run_start(spec_driver.spec_module())
-        .map_err(|trap| InterpreterError::Instantiation(format!("ModuleInstance::run_start error on {:?}", trap)))?;
-    Ok(())
-}
-
-fn wasm_load_module(name: Option<String>, module: Vec<u8>)
-                    -> Result<(), InterpreterError> {
-    let ref mut spec_driver = SPECDRIVER.lock().unwrap();
-    let module = try_load_module(&module[..])?;
-    let instance = ModuleInstance::new(&module, &**spec_driver)
-        .map_err(|e| InterpreterError::Instantiation(format!("ModuleInstance::new error on {:?}", e)))?
-        .run_start(spec_driver.spec_module())
-        .map_err(|trap| InterpreterError::Instantiation(format!("ModuleInstance::run_start error on {:?}", trap)))?;
-
-    spec_driver.add_module(name, instance.clone());
-
-    Ok(())
-}
-
-fn wasm_register(name: &Option<String>, as_name: String)
-                    -> Result<(), InterpreterError> {
-    let ref mut spec_driver = SPECDRIVER.lock().unwrap();
-    spec_driver.register(name, as_name)
-}
-
-#[no_mangle]
-pub extern "C"
-fn sgxwasm_run_action(req_bin : *const u8, req_length: usize,
-                      result_bin : *mut u8, result_max_len: usize) -> sgx_status_t {
-
-    let req_slice = unsafe { slice::from_raw_parts(req_bin, req_length) };
-    let action_req: sgxwasm::SgxWasmAction = serde_json::from_slice(req_slice).unwrap();
-
-    let response;
-    let return_status;
-
-    match action_req {
-        sgxwasm::SgxWasmAction::Invoke{module,field,args}=> {
-            let args = args.into_iter()
-                           .map(|x| boundary_value_to_runtime_value(x))
-                           .collect::<Vec<RuntimeValue>>();
-            let r = wasm_invoke(module, field, args);
-            let r = result_covert(r);
-            response = serde_json::to_string(&r).unwrap();
-            match r {
-                Ok(_) => {
-                    return_status = sgx_status_t::SGX_SUCCESS;
-                },
-                Err(_) => {
-                    return_status = sgx_status_t::SGX_ERROR_WASM_INTERPRETER_ERROR;
-               }
-            }
-        },
-        sgxwasm::SgxWasmAction::Get{module,field} => {
-            let r = wasm_get(module, field);
-            let r = result_covert(r);
-            response = serde_json::to_string(&r).unwrap();
-            match r {
-                Ok(_v) => {
-                    return_status = sgx_status_t::SGX_SUCCESS;
-                },
-                Err(_x) => {
-                    return_status = sgx_status_t::SGX_ERROR_WASM_INTERPRETER_ERROR;
-                }
-            }
-        },
-        sgxwasm::SgxWasmAction::LoadModule{name,module} => {
-            let r = wasm_load_module(name.clone(), module);
-            response = serde_json::to_string(&r).unwrap();
-            match r {
-                Ok(_) => {
-                    return_status = sgx_status_t::SGX_SUCCESS;
-                },
-                Err(_x) => {
-                    return_status = sgx_status_t::SGX_ERROR_WASM_LOAD_MODULE_ERROR;
-                }
-            }
-        },
-        sgxwasm::SgxWasmAction::TryLoad{module} => {
-            let r = wasm_try_load(module);
-            response = serde_json::to_string(&r).unwrap();
-            match r {
-                Ok(()) => {
-                    return_status = sgx_status_t::SGX_SUCCESS;
-                },
-                Err(_x) => {
-                    return_status = sgx_status_t::SGX_ERROR_WASM_TRY_LOAD_ERROR;
-                }
-            }
-        },
-        sgxwasm::SgxWasmAction::Register{name, as_name} => {
-            let r = wasm_register(&name, as_name.clone());
-            response = serde_json::to_string(&r).unwrap();
-            match r {
-                Ok(()) => {
-                    return_status = sgx_status_t::SGX_SUCCESS;
-                },
-                Err(_x) => {
-                    return_status = sgx_status_t::SGX_ERROR_WASM_REGISTER_ERROR;
-                }
-            }
-        }
-    }
-
-    //println!("len = {}, Response = {:?}", response.len(), response);
-
-    if response.len() < result_max_len {
-        unsafe {
-            ptr::copy_nonoverlapping(response.as_ptr(),
-                                     result_bin,
-                                     response.len());
-        }
-        return return_status;
-    }
-    else{
-        //println!("Result len = {} > buf size = {}", response.len(), result_max_len);
-        return sgx_status_t::SGX_ERROR_WASM_BUFFER_TOO_SHORT;
+impl From<base64::DecodeError> for Error {
+    fn from(e: base64::DecodeError) -> Self {
+        Error::Base64DecoderError(e)
     }
 }
 
+impl From<sgxwasm::Error> for Error {
+    fn from(e: sgxwasm::Error) -> Self {
+        Error::WasmError(e)
+    }
+}
+
+impl From<wasmi::Trap> for Error {
+    fn from(e: wasmi::Trap) -> Self {
+        Error::WasmTrap(e)
+    }
+}
+
+impl From<num::ParseIntError> for Error {
+    fn from(e: num::ParseIntError) -> Self {
+        Error::ParseIntError(e)
+    }
+}
+
+impl From<traits::ParseFloatError> for Error {
+    fn from(e: traits::ParseFloatError) -> Self {
+        Error::ParseFloatError(e)
+    }
+}
+
+pub fn exec(encoded_program: &str, arguments: &str) -> Result<wasmi::RuntimeValue, Error> {
+    println!("exec: {:?}", encoded_program);
+    let data = base64::decode(encoded_program)?;
+    println!("data: {:?}", data);
+    // FIXME: Compiler can't find the From trait for the below?
+    let module = wasmi::Module::from_buffer(data) //?;
+        .expect("module error");
+    println!("module loaded");
+    let module_ref = ModuleInstance::new(&module, &ImportsBuilder::default()) //?;
+        .expect("module_ref error");
+    println!("module_ref loaded");
+    let instance = module_ref.run_start(&mut NopExternals) //?;
+        .expect("run_start error");
+
+    println!("instance loaded");
+    // FIXME: assumes a single value argument that is a float
+    let value = <f64 as Num>::from_str_radix(arguments, 10)?;
+
+    println!("value loaded {:?}", value);
+    let arguments = [wasmi::RuntimeValue::I64(value as i64)];
+
+    println!("loading permission: {:?}", instance);
+    match instance
+        .invoke_export("perform", &arguments, &mut NopExternals)
+        .expect("invoke_export")
+    {
+        Some(v) => Ok(v),
+        _ => Err(Error::EmptyResultError),
+    }
+}

--- a/sgx/enclave/src/wasm.rs
+++ b/sgx/enclave/src/wasm.rs
@@ -1,0 +1,222 @@
+// Copyright (C) 2017-2018 Baidu, Inc. All Rights Reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in
+//    the documentation and/or other materials provided with the
+//    distribution.
+//  * Neither the name of Baidu, Inc., nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+use std::prelude::v1::*;
+use std::sync::SgxMutex;
+use std::ptr;
+
+use serde_json;
+
+use sgxwasm::{self, SpecDriver, boundary_value_to_runtime_value, result_covert};
+
+use sgx_types::*;
+use std::slice;
+
+use wasmi::{self, ModuleInstance, ImportsBuilder, RuntimeValue, Error as InterpreterError, Module};
+
+lazy_static!{
+    static ref SPECDRIVER: SgxMutex<SpecDriver> = SgxMutex::new(SpecDriver::new());
+}
+
+#[no_mangle]
+pub extern "C"
+fn sgxwasm_init() -> sgx_status_t {
+    let mut sd = SPECDRIVER.lock().unwrap();
+    *sd = SpecDriver::new();
+    sgx_status_t::SGX_SUCCESS
+}
+
+fn wasm_invoke(module : Option<String>, field : String, args : Vec<RuntimeValue>)
+              -> Result<Option<RuntimeValue>, InterpreterError> {
+    let mut program = SPECDRIVER.lock().unwrap();
+    let module = program.module_or_last(module.as_ref().map(|x| x.as_ref()))
+                        .expect(&format!("Expected program to have loaded module {:?}", module));
+    module.invoke_export(&field, &args, program.spec_module())
+}
+
+fn wasm_get(module : Option<String>, field : String)
+            -> Result<Option<RuntimeValue>, InterpreterError> {
+    let program = SPECDRIVER.lock().unwrap();
+    let module = match module {
+        None => {
+                 program
+                 .module_or_last(None)
+                 .expect(&format!("Expected program to have loaded module {:?}",
+                        "None"
+                 ))
+        },
+        Some(str) => {
+                 program
+                 .module_or_last(Some(&str))
+                 .expect(&format!("Expected program to have loaded module {:?}",
+                         str
+                 ))
+        }
+    };
+
+    let global = module.export_by_name(&field)
+                       .ok_or_else(|| {
+                           InterpreterError::Global(format!("Expected to have export with name {}", field))
+                       })?
+                       .as_global()
+                       .cloned()
+                       .ok_or_else(|| {
+                           InterpreterError::Global(format!("Expected export {} to be a global", field))
+                       })?;
+     Ok(Some(global.get()))
+}
+
+fn try_load_module(wasm: &[u8]) -> Result<Module, InterpreterError> {
+    wasmi::Module::from_buffer(wasm).map_err(|e| InterpreterError::Instantiation(format!("Module::from_buffer error {:?}", e)))
+}
+
+fn wasm_try_load(wasm: Vec<u8>) -> Result<(), InterpreterError> {
+    let ref mut spec_driver = SPECDRIVER.lock().unwrap();
+    let module = try_load_module(&wasm[..])?;
+    let instance = ModuleInstance::new(&module, &ImportsBuilder::default())?;
+    instance
+        .run_start(spec_driver.spec_module())
+        .map_err(|trap| InterpreterError::Instantiation(format!("ModuleInstance::run_start error on {:?}", trap)))?;
+    Ok(())
+}
+
+fn wasm_load_module(name: Option<String>, module: Vec<u8>)
+                    -> Result<(), InterpreterError> {
+    let ref mut spec_driver = SPECDRIVER.lock().unwrap();
+    let module = try_load_module(&module[..])?;
+    let instance = ModuleInstance::new(&module, &**spec_driver)
+        .map_err(|e| InterpreterError::Instantiation(format!("ModuleInstance::new error on {:?}", e)))?
+        .run_start(spec_driver.spec_module())
+        .map_err(|trap| InterpreterError::Instantiation(format!("ModuleInstance::run_start error on {:?}", trap)))?;
+
+    spec_driver.add_module(name, instance.clone());
+
+    Ok(())
+}
+
+fn wasm_register(name: &Option<String>, as_name: String)
+                    -> Result<(), InterpreterError> {
+    let ref mut spec_driver = SPECDRIVER.lock().unwrap();
+    spec_driver.register(name, as_name)
+}
+
+#[no_mangle]
+pub extern "C"
+fn sgxwasm_run_action(req_bin : *const u8, req_length: usize,
+                      result_bin : *mut u8, result_max_len: usize) -> sgx_status_t {
+
+    let req_slice = unsafe { slice::from_raw_parts(req_bin, req_length) };
+    let action_req: sgxwasm::SgxWasmAction = serde_json::from_slice(req_slice).unwrap();
+
+    let response;
+    let return_status;
+
+    match action_req {
+        sgxwasm::SgxWasmAction::Invoke{module,field,args}=> {
+            let args = args.into_iter()
+                           .map(|x| boundary_value_to_runtime_value(x))
+                           .collect::<Vec<RuntimeValue>>();
+            let r = wasm_invoke(module, field, args);
+            let r = result_covert(r);
+            response = serde_json::to_string(&r).unwrap();
+            match r {
+                Ok(_) => {
+                    return_status = sgx_status_t::SGX_SUCCESS;
+                },
+                Err(_) => {
+                    return_status = sgx_status_t::SGX_ERROR_WASM_INTERPRETER_ERROR;
+               }
+            }
+        },
+        sgxwasm::SgxWasmAction::Get{module,field} => {
+            let r = wasm_get(module, field);
+            let r = result_covert(r);
+            response = serde_json::to_string(&r).unwrap();
+            match r {
+                Ok(_v) => {
+                    return_status = sgx_status_t::SGX_SUCCESS;
+                },
+                Err(_x) => {
+                    return_status = sgx_status_t::SGX_ERROR_WASM_INTERPRETER_ERROR;
+                }
+            }
+        },
+        sgxwasm::SgxWasmAction::LoadModule{name,module} => {
+            let r = wasm_load_module(name.clone(), module);
+            response = serde_json::to_string(&r).unwrap();
+            match r {
+                Ok(_) => {
+                    return_status = sgx_status_t::SGX_SUCCESS;
+                },
+                Err(_x) => {
+                    return_status = sgx_status_t::SGX_ERROR_WASM_LOAD_MODULE_ERROR;
+                }
+            }
+        },
+        sgxwasm::SgxWasmAction::TryLoad{module} => {
+            let r = wasm_try_load(module);
+            response = serde_json::to_string(&r).unwrap();
+            match r {
+                Ok(()) => {
+                    return_status = sgx_status_t::SGX_SUCCESS;
+                },
+                Err(_x) => {
+                    return_status = sgx_status_t::SGX_ERROR_WASM_TRY_LOAD_ERROR;
+                }
+            }
+        },
+        sgxwasm::SgxWasmAction::Register{name, as_name} => {
+            let r = wasm_register(&name, as_name.clone());
+            response = serde_json::to_string(&r).unwrap();
+            match r {
+                Ok(()) => {
+                    return_status = sgx_status_t::SGX_SUCCESS;
+                },
+                Err(_x) => {
+                    return_status = sgx_status_t::SGX_ERROR_WASM_REGISTER_ERROR;
+                }
+            }
+        }
+    }
+
+    //println!("len = {}, Response = {:?}", response.len(), response);
+
+    if response.len() < result_max_len {
+        unsafe {
+            ptr::copy_nonoverlapping(response.as_ptr(),
+                                     result_bin,
+                                     response.len());
+        }
+        return return_status;
+    }
+    else{
+        //println!("Result len = {} > buf size = {}", response.len(), result_max_len);
+        return sgx_status_t::SGX_ERROR_WASM_BUFFER_TOO_SHORT;
+    }
+}
+

--- a/sgx/libadapters/Cargo.lock
+++ b/sgx/libadapters/Cargo.lock
@@ -5,9 +5,9 @@ dependencies = [
  "errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_trts 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_types 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_urts 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_trts 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_urts 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -41,24 +41,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sgx_trts"
-version = "0.9.8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "sgx_types 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "sgx_types"
-version = "0.9.8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sgx_urts"
-version = "0.9.8"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_types 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -76,8 +76,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
 "checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
 "checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
-"checksum sgx_trts 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)" = "1293a490ceb58471411c704f0163b716970bf53133ce9fdf2c163f46930603ea"
-"checksum sgx_types 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)" = "dae9217f41cde70a81a3adfab96d78bcab678fd97ad4eedee004a3f0f6bb21a9"
-"checksum sgx_urts 0.9.8 (registry+https://github.com/rust-lang/crates.io-index)" = "77309e3cb70d9a2312dc7cf3d95e9c4ad4b908e7a970306b5d87e3daa8eb6e4d"
+"checksum sgx_trts 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c3f481502aaa72062b44ff5b3bbdd48b711e547cd4518cee7da832dc5e1037d"
+"checksum sgx_types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "856c6648b731660db14bca279ffefeca4093de8ebb9e5eebc98406b9d97dcd41"
+"checksum sgx_urts 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89e8311ae4f049cd2ebe4822006f62bd2964643c17c67a5425d4859abb2d31a6"
 "checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
 "checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"

--- a/sgx/libadapters/adapters.h
+++ b/sgx/libadapters/adapters.h
@@ -1,4 +1,4 @@
 void init_enclave();
 char * http_get(char *url);
 char * http_post(char *url, char *body);
-char * wasm(char *wasm);
+void wasm(char *wasm, char *arguments, char *result, int result_capacity, int *result_len);

--- a/sgx/libadapters/adapters.h
+++ b/sgx/libadapters/adapters.h
@@ -1,3 +1,4 @@
 void init_enclave();
 char * http_get(char *url);
 char * http_post(char *url, char *body);
+char * wasm(char *wasm);

--- a/sgx/libadapters/src/lib.rs
+++ b/sgx/libadapters/src/lib.rs
@@ -15,6 +15,7 @@ use sgx_types::*;
 use sgx_urts::SgxEnclave;
 
 pub mod http;
+pub mod wasm;
 
 static ENCLAVE_FILE: &'static str = "enclave.signed.so";
 

--- a/sgx/libadapters/src/wasm.rs
+++ b/sgx/libadapters/src/wasm.rs
@@ -1,0 +1,40 @@
+use libc;
+use sgx_types::*;
+use std::ffi::CStr;
+use std::ptr;
+
+use ENCLAVE;
+
+extern "C" {
+    fn sgx_wasm(
+        eid: sgx_enclave_id_t,
+        retval: *mut sgx_status_t,
+        wasmt: *const u8,
+        wasmt_len: usize,
+    ) -> sgx_status_t;
+}
+
+fn cstr_len(string: *const libc::c_char) -> usize {
+    let buffer = unsafe { CStr::from_ptr(string).to_bytes() };
+    buffer.len()
+}
+
+#[no_mangle]
+pub extern "C" fn wasm(wasmt: *const libc::c_char) -> *const libc::c_char {
+    let mut retval = sgx_status_t::SGX_SUCCESS;
+    let result = unsafe {
+        sgx_wasm(
+            ENCLAVE.geteid(),
+            &mut retval,
+            wasmt as *const u8,
+            cstr_len(wasmt),
+        )
+    };
+    match result {
+        sgx_status_t::SGX_SUCCESS => {}
+        _ => {
+            println!("Call into Enclave wasm failed: {}", result.as_str());
+        }
+    }
+    ptr::null()
+}

--- a/sgx/libadapters/src/wasm.rs
+++ b/sgx/libadapters/src/wasm.rs
@@ -1,7 +1,7 @@
+use errno::{set_errno, Errno};
 use libc;
 use sgx_types::*;
 use std::ffi::CStr;
-use std::ptr;
 
 use ENCLAVE;
 
@@ -9,8 +9,13 @@ extern "C" {
     fn sgx_wasm(
         eid: sgx_enclave_id_t,
         retval: *mut sgx_status_t,
-        wasmt: *const u8,
+        wasmt_ptr: *const u8,
         wasmt_len: usize,
+        arguments_ptr: *const u8,
+        arguments_len: usize,
+        result_ptr: *mut u8,
+        result_capacity: usize,
+        result_len: *mut usize,
     ) -> sgx_status_t;
 }
 
@@ -20,21 +25,49 @@ fn cstr_len(string: *const libc::c_char) -> usize {
 }
 
 #[no_mangle]
-pub extern "C" fn wasm(wasmt: *const libc::c_char) -> *const libc::c_char {
+pub extern "C" fn wasm(
+    wasm: *const libc::c_char,
+    arguments: *const libc::c_char,
+    result_ptr: *mut libc::c_char,
+    result_capacity: usize,
+    result_len: *mut usize,
+) {
     let mut retval = sgx_status_t::SGX_SUCCESS;
     let result = unsafe {
         sgx_wasm(
             ENCLAVE.geteid(),
             &mut retval,
-            wasmt as *const u8,
-            cstr_len(wasmt),
+            wasm as *const u8,
+            cstr_len(wasm),
+            arguments as *const u8,
+            cstr_len(arguments),
+            result_ptr as *mut u8,
+            result_capacity,
+            result_len as *mut usize,
         )
     };
+
     match result {
-        sgx_status_t::SGX_SUCCESS => {}
+        sgx_status_t::SGX_SUCCESS => {
+            println!("Call into enclave succeded");
+            set_errno(Errno(0));
+        }
         _ => {
             println!("Call into Enclave wasm failed: {}", result.as_str());
+            set_errno(Errno(result as i32));
+            return;
         }
     }
-    ptr::null()
+
+    match retval {
+        sgx_status_t::SGX_SUCCESS => {
+            println!("wasm call succeeded");
+            set_errno(Errno(0));
+        }
+        _ => {
+            println!("wasm returned error: {}", retval.as_str());
+            set_errno(Errno(result as i32));
+            return;
+        }
+    }
 }


### PR DESCRIPTION
Add an experimental WASM adapter that can run arbitrary wasm bytes encoded as base64. Takes a single float64 value, returns the output printed in debug mode.

e.g: output value of `10` will be printed `I32(10)`