### PR TITLE
Support DEBUG builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,18 +8,17 @@ REPO := smartcontract/chainlink
 COMMIT_SHA ?= $(shell git rev-parse HEAD)
 VERSION = $(shell cat VERSION)
 GO_LDFLAGS := $(shell internal/bin/ldflags)
-GOFLAGS := -ldflags "$(GO_LDFLAGS)"
+GOFLAGS = -ldflags "$(GO_LDFLAGS)"
 DOCKERFILE := Dockerfile
 DOCKER_TAG := $(REPO)
 
 # SGX is disabled by default, but turned on when building from Docker
 SGX_ENABLED ?= no
 SGX_SIMULATION ?= yes
-SGX_TARGET := ./sgx/target/$(ENVIRONMENT)/
 SGX_ENCLAVE := enclave.signed.so
+SGX_TARGET := ./sgx/target/$(ENVIRONMENT)/
 
 ifeq ($(SGX_ENABLED),yes)
-	GO_LDFLAGS += -L $(SGX_TARGET)
 	GOFLAGS += -tags=sgx_enclave
 	SGX_BUILD_ENCLAVE := $(SGX_ENCLAVE)
 	DOCKERFILE := Dockerfile-sgx
@@ -34,8 +33,7 @@ godep: ## Ensure chainlink's go dependencies are installed.
 yarndep: ## Ensure the frontend's dependencies are installed.
 	yarn install
 
-build: godep gui $(SGX_BUILD_ENCLAVE) ## Build chainlink.
-	go build $(GOFLAGS) -o chainlink
+build: godep gui chainlink ## Build chainlink.
 
 install: godep gui ## Install chainlink
 	go install $(GOFLAGS)
@@ -56,9 +54,13 @@ docker: ## Build the docker image.
 dockerpush: ## Push the docker image to dockerhub
 	docker push $(REPO)
 
+chainlink: $(SGX_BUILD_ENCLAVE)
+	go build $(GOFLAGS) -o chainlink
+
 .PHONY: $(SGX_ENCLAVE)
 $(SGX_ENCLAVE):
 	@make -C sgx/
+	@ln -f $(SGX_TARGET)/libadapters.so sgx/target/libadapters.so
 
 help:
 	@echo ""

--- a/adapters/http_sgx.go
+++ b/adapters/http_sgx.go
@@ -3,7 +3,7 @@
 package adapters
 
 /*
-#cgo LDFLAGS: -L../sgx/target/release/ -ladapters
+#cgo LDFLAGS: -L ../sgx/target/ -ladapters
 #include "../sgx/libadapters/adapters.h"
 */
 import "C"

--- a/cmd/enclave_sgx.go
+++ b/cmd/enclave_sgx.go
@@ -3,7 +3,7 @@
 package cmd
 
 /*
-#cgo LDFLAGS: -L../sgx/target/release/ -ladapters
+#cgo LDFLAGS: -L ../sgx/target/ -ladapters
 #include "../sgx/libadapters/adapters.h"
 */
 import "C"

--- a/sgx/Makefile
+++ b/sgx/Makefile
@@ -115,7 +115,7 @@ target/$(ENVIRONMENT)/enclave_t.o: $(TRUSTED_EDL_FILES) $(ENCLAVE) $(RT_PATCH)
 
 $(PATCHED_ENCLAVE): target/$(ENVIRONMENT)/enclave_t.o
 	@printf -- '\nBuilding \e[1;36m$@\e[0m\n\n'
-	@printf -- '\nLinking against simulation libraries: \e[1;91m$(SGX_SIMULATION)\e[0m\n\n'
+	@printf -- 'Linking against simulation libraries: \e[1;91m$(SGX_SIMULATION)\e[0m\n\n'
 	$(CXX) $< -o $@ $(ENCLAVE_RS_LD_FLAGS)
 
 $(SIGNED_ENCLAVE): $(PATCHED_ENCLAVE)


### PR DESCRIPTION
Three changes:

 1. Link libadapters.so into a spot where go build can find it, so you can build debug or release mode
 2. Remove an extra newline before "Linking against simulation libraries..."
 3. Add a chainlink target to build chainlink faster from sgx-env which skips dep/yarn installs.