### PR TITLE
add vscode folder to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,7 @@ web/web-packr.go
 build/
 
 # misc
+.vscode/*
 .envrc
 
 # codeship


### PR DESCRIPTION
As Chainlink is open-source and vscode is a popular editor, I think gitignore should include it.