### PR TITLE
Use a macro to reduce the From<Error> trait boilerplate

### DIFF
--- a/sgx/enclave/src/lib.rs
+++ b/sgx/enclave/src/lib.rs
@@ -9,11 +9,10 @@ extern crate serde;
 extern crate serde_json;
 extern crate sgx_types;
 #[cfg(not(target_env = "sgx"))]
-#[macro_use]
-extern crate sgx_tstd as std;
+#[macro_use] extern crate sgx_tstd as std;
 extern crate wasmi;
 
-mod util;
+#[macro_use] mod util;
 mod wasm;
 
 use sgx_types::*;
@@ -70,28 +69,14 @@ pub extern "C" fn sgx_wasm(
 
 enum WasmError {
     FromUtf8Error(std::string::FromUtf8Error),
-    WasmError(wasm::Error),
+    ExecError(wasm::Error),
     OutputCStrError(util::OutputCStrError),
     UnexpectedOutputError,
 }
 
-impl From<std::string::FromUtf8Error> for WasmError {
-    fn from(e: std::string::FromUtf8Error) -> Self {
-        WasmError::FromUtf8Error(e)
-    }
-}
-
-impl From<wasm::Error> for WasmError {
-    fn from(e: wasm::Error) -> Self {
-        WasmError::WasmError(e)
-    }
-}
-
-impl From<util::OutputCStrError> for WasmError {
-    fn from(e: util::OutputCStrError) -> Self {
-        WasmError::OutputCStrError(e)
-    }
-}
+impl_from_error!(std::string::FromUtf8Error, WasmError::FromUtf8Error);
+impl_from_error!(wasm::Error, WasmError::ExecError);
+impl_from_error!(util::OutputCStrError, WasmError::OutputCStrError);
 
 fn wasm(
     wasmt_ptr: *const u8,

--- a/sgx/enclave/src/util.rs
+++ b/sgx/enclave/src/util.rs
@@ -48,3 +48,13 @@ pub fn copy_string_to_cstr_ptr(
 
     Ok(())
 }
+
+macro_rules! impl_from_error {
+    ($from:path, $to:tt::$ctor:tt) => {
+        impl From<$from> for $to {
+            fn from(e: $from) -> Self {
+                $to::$ctor(e)
+            }
+        }
+    };
+}

--- a/sgx/enclave/src/wasm.rs
+++ b/sgx/enclave/src/wasm.rs
@@ -14,35 +14,11 @@ pub enum Error {
     WasmTrap(wasmi::Trap),
 }
 
-impl From<base64::DecodeError> for Error {
-    fn from(e: base64::DecodeError) -> Self {
-        Error::Base64DecoderError(e)
-    }
-}
-
-impl From<num::ParseIntError> for Error {
-    fn from(e: num::ParseIntError) -> Self {
-        Error::ParseIntError(e)
-    }
-}
-
-impl From<traits::ParseFloatError> for Error {
-    fn from(e: traits::ParseFloatError) -> Self {
-        Error::ParseFloatError(e)
-    }
-}
-
-impl From<wasmi::Error> for Error {
-    fn from(e: wasmi::Error) -> Self {
-        Error::WasmError(e)
-    }
-}
-
-impl From<wasmi::Trap> for Error {
-    fn from(e: wasmi::Trap) -> Self {
-        Error::WasmTrap(e)
-    }
-}
+impl_from_error!(base64::DecodeError, Error::Base64DecoderError);
+impl_from_error!(num::ParseIntError, Error::ParseIntError);
+impl_from_error!(traits::ParseFloatError, Error::ParseFloatError);
+impl_from_error!(wasmi::Error, Error::WasmError);
+impl_from_error!(wasmi::Trap, Error::WasmTrap);
 
 pub fn exec(encoded_program: &str, arguments: &str) -> Result<wasmi::RuntimeValue, Error> {
     let data = base64::decode(encoded_program)?;

--- a/sgx/libadapters/src/lib.rs
+++ b/sgx/libadapters/src/lib.rs
@@ -5,8 +5,7 @@ extern crate errno;
 extern crate sgx_types;
 extern crate sgx_urts;
 
-#[macro_use]
-extern crate lazy_static;
+#[macro_use] extern crate lazy_static;
 
 use std::panic;
 


### PR DESCRIPTION
This is just a little one! 

A small macro that generates a `From` trait implementation for a straightforward error mapping pattern. 

I considered using https://github.com/withoutboats/failure instead of rolling my own, but it needs alloc, and is a little more involved and sort of meshes all errors into a single big tool chain error bucket. Not sure how I feel about this yet! Also with `no_std` the most interesting parts don't work!

:bowtie: 