### PR TITLE
Add unit tests to enclave code

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Chainlink
-FROM smartcontract/builder:1.0.3 as builder
+FROM smartcontract/builder:1.0.4 as builder
 
 # Have to reintroduce ENV vars from builder image
 ENV PATH /go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/Dockerfile-sgx
+++ b/Dockerfile-sgx
@@ -1,5 +1,5 @@
 # Build Chainlink with SGX
-FROM smartcontract/builder:1.0.3 as builder
+FROM smartcontract/builder:1.0.4 as builder
 
 # Have to reintroduce ENV vars from builder image
 ENV PATH /root/.cargo/bin:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/sgxsdk/bin:/opt/sgxsdk/bin/x64

--- a/codeship-steps.yml
+++ b/codeship-steps.yml
@@ -4,6 +4,9 @@
   - name: Go Unit Tests
     service: ci
     command: ./internal/ci/go_test
+  - name: Rust Unit Tests
+    service: ci
+    command: ./internal/ci/rust_test
   - name: Solidity Contract Tests
     service: ci
     command: ./internal/ci/truffle_test

--- a/internal/ci/Dockerfile
+++ b/internal/ci/Dockerfile
@@ -1,14 +1,4 @@
-FROM smartcontract/builder:1.0.1
-
-# The integration tests need jq
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y jq
-
-# Install goverage to capture go test coverage
-RUN go get -u github.com/haya14busa/goverage
-RUN curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 \
-      > "/usr/local/bin/cc-test-reporter" \
-      && chmod +x "/usr/local/bin/cc-test-reporter"
+FROM smartcontract/builder:1.0.4
 
 # Create the project working directory in the full GOPATH
 RUN mkdir -p /go/src/github.com/smartcontractkit/chainlink/

--- a/internal/ci/go_test
+++ b/internal/ci/go_test
@@ -3,7 +3,7 @@
 set -e
 
 cc-test-reporter before-build
-go test -v --tags=test -coverprofile=c.out ./...
+go test -v -parallel 2 --tags=test -coverprofile=c.out ./...
 result=$?
 if [ -n "$CC_TEST_REPORTER_ID"  ]; then
   cc-test-reporter after-build -t gocov --exit-code $result

--- a/internal/ci/rust_test
+++ b/internal/ci/rust_test
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+set -e
+
+pushd sgx/utils 2>/dev/null
+cargo test
+popd 2>/dev/null

--- a/internal/ci/rust_test
+++ b/internal/ci/rust_test
@@ -3,5 +3,5 @@
 set -e
 
 pushd sgx/utils 2>/dev/null
-cargo test
+cargo tarpaulin
 popd 2>/dev/null

--- a/internal/ci/rust_test
+++ b/internal/ci/rust_test
@@ -3,5 +3,5 @@
 set -e
 
 pushd sgx/utils 2>/dev/null
-cargo tarpaulin
+cargo test
 popd 2>/dev/null

--- a/sgx/enclave/Cargo.lock
+++ b/sgx/enclave/Cargo.lock
@@ -37,6 +37,7 @@ dependencies = [
  "serde_json 1.0.17",
  "sgx_tstd 1.0.0",
  "sgx_types 1.0.0",
+ "utils 0.1.0",
  "wabt-core 0.2.2",
  "wasmi 0.1.1",
 ]
@@ -250,6 +251,13 @@ dependencies = [
 name = "unicode-xid"
 version = "0.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "utils"
+version = "0.1.0"
+dependencies = [
+ "sgx_tstd 1.0.0",
+]
 
 [[package]]
 name = "wabt-core"

--- a/sgx/enclave/Cargo.lock
+++ b/sgx/enclave/Cargo.lock
@@ -4,14 +4,14 @@ version = "0.7.0"
 dependencies = [
  "byteorder 1.2.1",
  "safemem 0.2.0",
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]
 name = "byteorder"
 version = "1.2.1"
 dependencies = [
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]
@@ -22,7 +22,7 @@ version = "0.1.2"
 name = "dtoa"
 version = "0.4.2"
 dependencies = [
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]
@@ -35,8 +35,8 @@ dependencies = [
  "serde 1.0.16",
  "serde_derive 1.0.16",
  "serde_json 1.0.17",
- "sgx_tstd 1.0.0",
- "sgx_types 1.0.0",
+ "sgx_tstd 1.0.1",
+ "sgx_types 1.0.1",
  "utils 0.1.0",
  "wabt-core 0.2.2",
  "wasmi 0.1.1",
@@ -44,16 +44,16 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "0.3.4"
+version = "0.4.1"
 dependencies = [
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]
 name = "lazy_static"
 version = "0.2.8"
 dependencies = [
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]
@@ -61,7 +61,7 @@ name = "log"
 version = "0.3.8"
 dependencies = [
  "cfg-if 0.1.2",
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]
@@ -76,7 +76,7 @@ dependencies = [
  "num-derive 0.1.41",
  "num-integer 0.1.35",
  "num-iter 0.1.34",
- "num-traits 0.1.40",
+ "num-traits 0.2.5",
 ]
 
 [[package]]
@@ -91,8 +91,8 @@ dependencies = [
 name = "num-integer"
 version = "0.1.35"
 dependencies = [
- "num-traits 0.1.40",
- "sgx_tstd 1.0.0",
+ "num-traits 0.2.5",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]
@@ -100,15 +100,15 @@ name = "num-iter"
 version = "0.1.34"
 dependencies = [
  "num-integer 0.1.35",
- "num-traits 0.1.40",
- "sgx_tstd 1.0.0",
+ "num-traits 0.2.5",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]
 name = "num-traits"
-version = "0.1.40"
+version = "0.2.5"
 dependencies = [
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]
@@ -117,7 +117,7 @@ version = "0.27.5"
 dependencies = [
  "byteorder 1.2.1",
  "log 0.3.8",
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]
@@ -134,14 +134,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "safemem"
 version = "0.2.0"
 dependencies = [
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]
 name = "serde"
 version = "1.0.16"
 dependencies = [
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]
@@ -166,17 +166,17 @@ name = "serde_json"
 version = "1.0.17"
 dependencies = [
  "dtoa 0.4.2",
- "itoa 0.3.4",
- "num-traits 0.1.40",
+ "itoa 0.4.1",
+ "num-traits 0.2.5",
  "serde 1.0.16",
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]
 name = "sgx_alloc"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
- "sgx_trts 1.0.0",
+ "sgx_trts 1.0.1",
 ]
 
 [[package]]
@@ -185,40 +185,40 @@ version = "0.1.0"
 
 [[package]]
 name = "sgx_tprotected_fs"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
- "sgx_trts 1.0.0",
- "sgx_types 1.0.0",
+ "sgx_trts 1.0.1",
+ "sgx_types 1.0.1",
 ]
 
 [[package]]
 name = "sgx_trts"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
- "sgx_types 1.0.0",
+ "sgx_types 1.0.1",
 ]
 
 [[package]]
 name = "sgx_tstd"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
- "sgx_alloc 1.0.0",
+ "sgx_alloc 1.0.1",
  "sgx_build_helper 0.1.0",
- "sgx_tprotected_fs 1.0.0",
- "sgx_trts 1.0.0",
- "sgx_types 1.0.0",
- "sgx_unwind 0.0.0",
+ "sgx_tprotected_fs 1.0.1",
+ "sgx_trts 1.0.1",
+ "sgx_types 1.0.1",
+ "sgx_unwind 0.0.1",
 ]
 
 [[package]]
 name = "sgx_types"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "sgx_unwind"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
- "sgx_trts 1.0.0",
+ "sgx_trts 1.0.1",
 ]
 
 [[package]]
@@ -256,7 +256,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "utils"
 version = "0.1.0"
 dependencies = [
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]
@@ -266,8 +266,8 @@ dependencies = [
  "serde 1.0.16",
  "serde_derive 1.0.16",
  "serde_json 1.0.17",
- "sgx_tstd 1.0.0",
- "sgx_types 1.0.0",
+ "sgx_tstd 1.0.1",
+ "sgx_types 1.0.1",
 ]
 
 [[package]]
@@ -279,7 +279,7 @@ dependencies = [
  "parity-wasm 0.27.5",
  "serde 1.0.16",
  "serde_derive 1.0.16",
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 
 [metadata]

--- a/sgx/enclave/Cargo.toml
+++ b/sgx/enclave/Cargo.toml
@@ -11,7 +11,7 @@ crate-type = ["staticlib"]
 default = []
 
 [dependencies]
-utils = { path = "../utils" }
+utils = { path = "../utils", default-features = false }
 num = { path = "/opt/rust-sgx-sdk/third_party/num" }
 lazy_static = { path = "/opt/rust-sgx-sdk/third_party/lazy-static.rs" }
 serde = { path = "/opt/rust-sgx-sdk/third_party/serde-rs/serde/serde" }

--- a/sgx/enclave/Cargo.toml
+++ b/sgx/enclave/Cargo.toml
@@ -11,6 +11,7 @@ crate-type = ["staticlib"]
 default = []
 
 [dependencies]
+utils = { path = "../utils" }
 num = { path = "/opt/rust-sgx-sdk/third_party/num" }
 lazy_static = { path = "/opt/rust-sgx-sdk/third_party/lazy-static.rs" }
 serde = { path = "/opt/rust-sgx-sdk/third_party/serde-rs/serde/serde" }

--- a/sgx/enclave/src/lib.rs
+++ b/sgx/enclave/src/lib.rs
@@ -13,15 +13,15 @@ extern crate serde_json;
 #[cfg(not(target_env = "sgx"))]
 #[macro_use] extern crate sgx_tstd as std;
 extern crate sgx_types;
+#[macro_use] extern crate utils;
 extern crate wasmi;
 
-#[macro_use] mod util;
 mod wasm;
 
 use sgx_types::*;
-use util::{copy_string_to_cstr_ptr, string_from_cstr_with_len};
 use std::string::String;
 use std::string::ToString;
+use utils::{copy_string_to_cstr_ptr, string_from_cstr_with_len};
 
 #[no_mangle]
 pub extern "C" fn sgx_http_get(url_ptr: *const u8, url_len: usize) -> sgx_status_t {
@@ -75,13 +75,13 @@ pub extern "C" fn sgx_wasm(
 enum WasmError {
     FromUtf8Error(std::string::FromUtf8Error),
     ExecError(wasm::Error),
-    OutputCStrError(util::OutputCStrError),
+    OutputCStrError(utils::OutputCStrError),
     UnexpectedOutputError,
 }
 
 impl_from_error!(std::string::FromUtf8Error, WasmError::FromUtf8Error);
 impl_from_error!(wasm::Error, WasmError::ExecError);
-impl_from_error!(util::OutputCStrError, WasmError::OutputCStrError);
+impl_from_error!(utils::OutputCStrError, WasmError::OutputCStrError);
 
 fn wasm(
     wasmt_ptr: *const u8,

--- a/sgx/enclave/src/lib.rs
+++ b/sgx/enclave/src/lib.rs
@@ -94,13 +94,8 @@ fn wasm(
 ) -> Result<(), WasmError> {
 
     let wasmt = string_from_cstr_with_len(wasmt_ptr, wasmt_len)?;
-    println!("wasmt: {:?}", wasmt);
-
     let arguments = string_from_cstr_with_len(arguments_ptr, arguments_len)?;
-    println!("arguments: {:?}", arguments);
-
     let output = wasm::exec(&wasmt, &arguments)?;
-    println!("output: {:?}", output);
 
     let value = match output {
         wasmi::RuntimeValue::I32(v) => format!("{}", v),
@@ -135,6 +130,19 @@ pub extern "C" fn sgx_multiply(
     }
 }
 
+enum MultiplyError {
+    ParseIntError(core::num::ParseIntError),
+    OutputCStrError(utils::OutputCStrError),
+    FromUtf8Error(std::string::FromUtf8Error),
+    JsonError(serde_json::Error),
+    InvalidArgumentError,
+}
+
+impl_from_error!(core::num::ParseIntError, MultiplyError::ParseIntError);
+impl_from_error!(utils::OutputCStrError, MultiplyError::OutputCStrError);
+impl_from_error!(std::string::FromUtf8Error, MultiplyError::FromUtf8Error);
+impl_from_error!(serde_json::Error, MultiplyError::JsonError);
+
 fn multiply(
     adapter_str_ptr: *const u8,
     adapter_str_len: usize,
@@ -143,60 +151,39 @@ fn multiply(
     result_ptr: *mut u8,
     result_capacity: usize,
     result_len: *mut usize,
-) -> Result<(), sgx_status_t> {
-    let adapter_str = string_from_cstr_with_len(adapter_str_ptr, adapter_str_len).unwrap();
-    let adapter: serde_json::Value = match serde_json::from_str(&adapter_str) {
-        Ok(result) => result,
-        Err(_err) => return Err(sgx_status_t::SGX_ERROR_INVALID_PARAMETER),
-    };
-    let input_str = string_from_cstr_with_len(input_str_ptr, input_str_len).unwrap();
-    let mut input = parse_run_result_json(&input_str)?;
-    let multiplier = get_json_string(&adapter, "times".to_string())?;
-    let multiplicand = get_json_string(&input.data, "value".to_string())?;
+) -> Result<(), MultiplyError> {
+    let adapter_str = string_from_cstr_with_len(adapter_str_ptr, adapter_str_len)?;
+    let adapter = serde_json::from_str(&adapter_str)?;
+    let input_str = string_from_cstr_with_len(input_str_ptr, input_str_len)?;
+    let mut input : RunResult = serde_json::from_str(&input_str)?;
+    let multiplier = get_json_string(&adapter, "times")?;
+    let multiplicand = get_json_string(&input.data, "value")?;
     let result = parse_and_multiply(&multiplicand, &multiplier)?;
 
     input.status = Some("completed".to_string());
-    input.add("value".to_string(), serde_json::Value::String(result));
-    let rr_json = match serde_json::to_string(&input) {
-        Ok(v) => v,
-        _ => return Err(sgx_status_t::SGX_ERROR_INVALID_PARAMETER),
-    };
+    input.add("value", serde_json::Value::String(result));
 
-    match copy_string_to_cstr_ptr(&rr_json, result_ptr, result_capacity, result_len) {
-        Err(_) => Err(sgx_status_t::SGX_ERROR_INVALID_PARAMETER),
-        _ => Ok(())
-    }
+    let rr_json = serde_json::to_string(&input)?;
+    copy_string_to_cstr_ptr(&rr_json, result_ptr, result_capacity, result_len)?;
+    Ok(())
 }
 
-fn get_json_string(object: &serde_json::Value, key: String) -> Result<String, sgx_status_t> {
+fn get_json_string(object: &serde_json::Value, key: &str) -> Result<String, MultiplyError> {
     match &object[key] {
         serde_json::Value::String(v) => Ok(v.clone()),
         serde_json::Value::Number(v) => Ok(format!("{}", v)),
-        _ => return Err(sgx_status_t::SGX_ERROR_INVALID_PARAMETER),
+        _ => return Err(MultiplyError::InvalidArgumentError),
     }
 }
 
 fn parse_and_multiply(
     multiplicand_str: &str,
     multiplier_str: &str,
-) -> Result<String, sgx_status_t> {
-    let multiplicand = match i128::from_str_radix(multiplicand_str, 10) {
-        Ok(result) => result,
-        _ => return Err(sgx_status_t::SGX_ERROR_INVALID_PARAMETER),
-    };
-    let multiplier = match i128::from_str_radix(multiplier_str, 10) {
-        Ok(result) => result,
-        _ => return Err(sgx_status_t::SGX_ERROR_INVALID_PARAMETER),
-    };
-
-    Ok(format!("{:?}", multiplicand * multiplier))
-}
-
-fn parse_run_result_json(input: &str) -> Result<RunResult, sgx_status_t> {
-    match serde_json::from_str(input) {
-        Ok(rr) => Ok(rr),
-        _ => return Err(sgx_status_t::SGX_ERROR_INVALID_PARAMETER),
-    }
+) -> Result<String, MultiplyError> {
+    let multiplicand = i128::from_str_radix(multiplicand_str, 10)?;
+    let multiplier = i128::from_str_radix(multiplier_str, 10)?;
+    let result = multiplicand * multiplier;
+    Ok(format!("{}", result))
 }
 
 #[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
@@ -210,7 +197,7 @@ struct RunResult {
 }
 
 impl RunResult {
-    fn add(&mut self, key: String, value: serde_json::Value) {
+    fn add(&mut self, key: &str, value: serde_json::Value) {
         self.data[key] = value;
     }
 }

--- a/sgx/enclave/src/lib.rs
+++ b/sgx/enclave/src/lib.rs
@@ -156,6 +156,7 @@ fn multiply(
     let adapter = serde_json::from_str(&adapter_str)?;
     let input_str = string_from_cstr_with_len(input_str_ptr, input_str_len)?;
     let mut input : RunResult = serde_json::from_str(&input_str)?;
+
     let multiplier = get_json_string(&adapter, "times")?;
     let multiplicand = get_json_string(&input.data, "value")?;
     let result = parse_and_multiply(&multiplicand, &multiplier)?;

--- a/sgx/libadapters/Cargo.lock
+++ b/sgx/libadapters/Cargo.lock
@@ -5,9 +5,9 @@ dependencies = [
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_trts 1.0.0",
- "sgx_types 1.0.0",
- "sgx_urts 1.0.0",
+ "sgx_trts 1.0.1",
+ "sgx_types 1.0.1",
+ "sgx_urts 1.0.1",
  "utils 0.1.0",
 ]
 
@@ -47,9 +47,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "sgx_alloc"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
- "sgx_trts 1.0.0",
+ "sgx_trts 1.0.1",
 ]
 
 [[package]]
@@ -58,55 +58,55 @@ version = "0.1.0"
 
 [[package]]
 name = "sgx_tprotected_fs"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
- "sgx_trts 1.0.0",
- "sgx_types 1.0.0",
+ "sgx_trts 1.0.1",
+ "sgx_types 1.0.1",
 ]
 
 [[package]]
 name = "sgx_trts"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
- "sgx_types 1.0.0",
+ "sgx_types 1.0.1",
 ]
 
 [[package]]
 name = "sgx_tstd"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
- "sgx_alloc 1.0.0",
+ "sgx_alloc 1.0.1",
  "sgx_build_helper 0.1.0",
- "sgx_tprotected_fs 1.0.0",
- "sgx_trts 1.0.0",
- "sgx_types 1.0.0",
- "sgx_unwind 0.0.0",
+ "sgx_tprotected_fs 1.0.1",
+ "sgx_trts 1.0.1",
+ "sgx_types 1.0.1",
+ "sgx_unwind 0.0.1",
 ]
 
 [[package]]
 name = "sgx_types"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "sgx_unwind"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
- "sgx_trts 1.0.0",
+ "sgx_trts 1.0.1",
 ]
 
 [[package]]
 name = "sgx_urts"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_types 1.0.0",
+ "sgx_types 1.0.1",
 ]
 
 [[package]]
 name = "utils"
 version = "0.1.0"
 dependencies = [
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 
 [[package]]

--- a/sgx/libadapters/Cargo.lock
+++ b/sgx/libadapters/Cargo.lock
@@ -2,82 +2,138 @@
 name = "adapters"
 version = "0.1.0"
 dependencies = [
- "errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_trts 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_urts 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_trts 1.0.0",
+ "sgx_types 1.0.0",
+ "sgx_urts 1.0.0",
+ "utils 0.1.0",
 ]
 
 [[package]]
 name = "errno"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
-name = "kernel32-sys"
-version = "0.2.2"
+name = "errno-dragonfly"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "gcc"
+version = "0.3.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "lazy_static"
-version = "1.0.0"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
-version = "0.2.40"
+version = "0.2.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sgx_alloc"
+version = "1.0.0"
+dependencies = [
+ "sgx_trts 1.0.0",
+]
+
+[[package]]
+name = "sgx_build_helper"
+version = "0.1.0"
+
+[[package]]
+name = "sgx_tprotected_fs"
+version = "1.0.0"
+dependencies = [
+ "sgx_trts 1.0.0",
+ "sgx_types 1.0.0",
+]
 
 [[package]]
 name = "sgx_trts"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "sgx_types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_types 1.0.0",
+]
+
+[[package]]
+name = "sgx_tstd"
+version = "1.0.0"
+dependencies = [
+ "sgx_alloc 1.0.0",
+ "sgx_build_helper 0.1.0",
+ "sgx_tprotected_fs 1.0.0",
+ "sgx_trts 1.0.0",
+ "sgx_types 1.0.0",
+ "sgx_unwind 0.0.0",
 ]
 
 [[package]]
 name = "sgx_types"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "sgx_unwind"
+version = "0.0.0"
+dependencies = [
+ "sgx_trts 1.0.0",
+]
 
 [[package]]
 name = "sgx_urts"
 version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)",
- "sgx_types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)",
+ "sgx_types 1.0.0",
+]
+
+[[package]]
+name = "utils"
+version = "0.1.0"
+dependencies = [
+ "sgx_tstd 1.0.0",
 ]
 
 [[package]]
 name = "winapi"
-version = "0.2.8"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
-name = "winapi-build"
-version = "0.1.1"
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [metadata]
-"checksum errno 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "b2c858c42ac0b88532f48fca88b0ed947cad4f1f64d904bcd6c9f138f7b95d70"
-"checksum kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "7507624b29483431c0ba2d82aece8ca6cdba9382bff4ddd0f7490560c056098d"
-"checksum lazy_static 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "c8f31047daa365f19be14b47c29df4f7c3b581832407daabe6ae77397619237d"
-"checksum libc 0.2.40 (registry+https://github.com/rust-lang/crates.io-index)" = "6fd41f331ac7c5b8ac259b8bf82c75c0fb2e469bbf37d2becbba9a6a2221965b"
-"checksum sgx_trts 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5c3f481502aaa72062b44ff5b3bbdd48b711e547cd4518cee7da832dc5e1037d"
-"checksum sgx_types 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "856c6648b731660db14bca279ffefeca4093de8ebb9e5eebc98406b9d97dcd41"
-"checksum sgx_urts 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "89e8311ae4f049cd2ebe4822006f62bd2964643c17c67a5425d4859abb2d31a6"
-"checksum winapi 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)" = "167dc9d6949a9b857f3451275e911c3f44255842c1f7a76f33c55103a909087a"
-"checksum winapi-build 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "2d315eee3b34aca4797b2da6b13ed88266e6d612562a0c46390af8299fc699bc"
+"checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
+"checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
+"checksum gcc 0.3.54 (registry+https://github.com/rust-lang/crates.io-index)" = "5e33ec290da0d127825013597dbdfc28bee4964690c7ce1166cbc2a7bd08b1bb"
+"checksum lazy_static 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "fb497c35d362b6a331cfd94956a07fc2c78a4604cdbee844a81170386b996dd3"
+"checksum libc 0.2.42 (registry+https://github.com/rust-lang/crates.io-index)" = "b685088df2b950fccadf07a7187c8ef846a959c142338a48f9dc0b94517eb5f1"
+"checksum winapi 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)" = "773ef9dcc5f24b7d850d0ff101e542ff24c3b090a9768e03ff889fdef41f00fd"
+"checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/sgx/libadapters/Cargo.toml
+++ b/sgx/libadapters/Cargo.toml
@@ -19,6 +19,9 @@ global_exit = []
 errno = "0.2.3"
 lazy_static = "1.0.0"
 libc = "*"
-sgx_trts = "=1.0.0"
-sgx_types = "=1.0.0"
-sgx_urts = "=1.0.0"
+utils = { path = "../utils" }
+
+[target.'cfg(not(target_env = "sgx"))'.dependencies]
+sgx_trts = { path = "/opt/rust-sgx-sdk/sgx_trts" }
+sgx_types = { path = "/opt/rust-sgx-sdk/sgx_types" }
+sgx_urts = { path = "/opt/rust-sgx-sdk/sgx_urts" }

--- a/sgx/libadapters/build.rs
+++ b/sgx/libadapters/build.rs
@@ -39,8 +39,7 @@ fn main() {
 
     if env::var("SGX_SIMULATION")
         .unwrap_or_default()
-        .contains("yes")
-    {
+        .contains("yes") {
         println!("cargo:rustc-link-lib=dylib=sgx_urts_sim");
         println!("cargo:rustc-link-lib=dylib=crypto");
     } else {

--- a/sgx/libadapters/src/http.rs
+++ b/sgx/libadapters/src/http.rs
@@ -1,7 +1,7 @@
 use libc;
 use sgx_types::*;
 use std::ptr;
-use util::cstr_len;
+use utils::cstr_len;
 
 use ENCLAVE;
 

--- a/sgx/libadapters/src/lib.rs
+++ b/sgx/libadapters/src/lib.rs
@@ -4,6 +4,7 @@ extern crate libc;
 extern crate errno;
 extern crate sgx_types;
 extern crate sgx_urts;
+extern crate utils;
 
 #[macro_use] extern crate lazy_static;
 
@@ -16,7 +17,6 @@ use sgx_urts::SgxEnclave;
 pub mod http;
 pub mod wasm;
 pub mod multiply;
-mod util;
 
 static ENCLAVE_FILE: &'static str = "enclave.signed.so";
 

--- a/sgx/libadapters/src/multiply.rs
+++ b/sgx/libadapters/src/multiply.rs
@@ -1,7 +1,7 @@
 use errno::{set_errno, Errno};
 use libc;
 use sgx_types::*;
-use util::cstr_len;
+use utils::cstr_len;
 
 use ENCLAVE;
 

--- a/sgx/libadapters/src/util.rs
+++ b/sgx/libadapters/src/util.rs
@@ -1,7 +1,0 @@
-use libc;
-use std::ffi::CStr;
-
-pub fn cstr_len(string: *const libc::c_char) -> usize {
-    let buffer = unsafe { CStr::from_ptr(string).to_bytes() };
-    buffer.len()
-}

--- a/sgx/libadapters/src/wasm.rs
+++ b/sgx/libadapters/src/wasm.rs
@@ -1,7 +1,7 @@
 use errno::{set_errno, Errno};
 use libc;
 use sgx_types::*;
-use util::cstr_len;
+use utils::cstr_len;
 
 use ENCLAVE;
 

--- a/sgx/utils/Cargo.lock
+++ b/sgx/utils/Cargo.lock
@@ -1,0 +1,56 @@
+[[package]]
+name = "sgx_alloc"
+version = "1.0.0"
+dependencies = [
+ "sgx_trts 1.0.0",
+]
+
+[[package]]
+name = "sgx_build_helper"
+version = "0.1.0"
+
+[[package]]
+name = "sgx_tprotected_fs"
+version = "1.0.0"
+dependencies = [
+ "sgx_trts 1.0.0",
+ "sgx_types 1.0.0",
+]
+
+[[package]]
+name = "sgx_trts"
+version = "1.0.0"
+dependencies = [
+ "sgx_types 1.0.0",
+]
+
+[[package]]
+name = "sgx_tstd"
+version = "1.0.0"
+dependencies = [
+ "sgx_alloc 1.0.0",
+ "sgx_build_helper 0.1.0",
+ "sgx_tprotected_fs 1.0.0",
+ "sgx_trts 1.0.0",
+ "sgx_types 1.0.0",
+ "sgx_unwind 0.0.0",
+]
+
+[[package]]
+name = "sgx_types"
+version = "1.0.0"
+
+[[package]]
+name = "sgx_unwind"
+version = "0.0.0"
+dependencies = [
+ "sgx_trts 1.0.0",
+]
+
+[[package]]
+name = "utils"
+version = "0.1.0"
+dependencies = [
+ "sgx_tstd 1.0.0",
+]
+

--- a/sgx/utils/Cargo.lock
+++ b/sgx/utils/Cargo.lock
@@ -1,8 +1,8 @@
 [[package]]
 name = "sgx_alloc"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
- "sgx_trts 1.0.0",
+ "sgx_trts 1.0.1",
 ]
 
 [[package]]
@@ -11,46 +11,46 @@ version = "0.1.0"
 
 [[package]]
 name = "sgx_tprotected_fs"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
- "sgx_trts 1.0.0",
- "sgx_types 1.0.0",
+ "sgx_trts 1.0.1",
+ "sgx_types 1.0.1",
 ]
 
 [[package]]
 name = "sgx_trts"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
- "sgx_types 1.0.0",
+ "sgx_types 1.0.1",
 ]
 
 [[package]]
 name = "sgx_tstd"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
- "sgx_alloc 1.0.0",
+ "sgx_alloc 1.0.1",
  "sgx_build_helper 0.1.0",
- "sgx_tprotected_fs 1.0.0",
- "sgx_trts 1.0.0",
- "sgx_types 1.0.0",
- "sgx_unwind 0.0.0",
+ "sgx_tprotected_fs 1.0.1",
+ "sgx_trts 1.0.1",
+ "sgx_types 1.0.1",
+ "sgx_unwind 0.0.1",
 ]
 
 [[package]]
 name = "sgx_types"
-version = "1.0.0"
+version = "1.0.1"
 
 [[package]]
 name = "sgx_unwind"
-version = "0.0.0"
+version = "0.0.1"
 dependencies = [
- "sgx_trts 1.0.0",
+ "sgx_trts 1.0.1",
 ]
 
 [[package]]
 name = "utils"
 version = "0.1.0"
 dependencies = [
- "sgx_tstd 1.0.0",
+ "sgx_tstd 1.0.1",
 ]
 

--- a/sgx/utils/Cargo.toml
+++ b/sgx/utils/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "utils"
+version = "0.1.0"
+authors = ["John Barker <jebarker@gmail.com>"]
+
+[target.'cfg(not(target_env = "sgx"))'.dependencies]
+sgx_tstd = { path = "/opt/rust-sgx-sdk/sgx_tstd" }

--- a/sgx/utils/Cargo.toml
+++ b/sgx/utils/Cargo.toml
@@ -3,5 +3,9 @@ name = "utils"
 version = "0.1.0"
 authors = ["John Barker <jebarker@gmail.com>"]
 
+[features]
+default = ["std"]
+std = []
+
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
 sgx_tstd = { path = "/opt/rust-sgx-sdk/sgx_tstd" }

--- a/sgx/utils/src/lib.rs
+++ b/sgx/utils/src/lib.rs
@@ -1,10 +1,14 @@
 // Util functions, primarily for passing data between Go / Rust / SGX enclaves
 
+#![cfg_attr(not(test), no_std)]
+
+#[cfg(not(test))]
+extern crate sgx_tstd as std;
+
 use std::ffi::{CString, NulError};
-use std::ptr;
-use std::slice;
-use std::slice::from_raw_parts_mut;
+use std::slice::{self, from_raw_parts_mut};
 use std::string::{FromUtf8Error, String};
+use std::ptr;
 
 // string_from_cstr_with_len creates a rust String from a string pointer with a specific length.
 pub fn string_from_cstr_with_len(ptr: *const u8, len: usize) -> Result<String, FromUtf8Error> {
@@ -49,6 +53,7 @@ pub fn copy_string_to_cstr_ptr(
     Ok(())
 }
 
+#[macro_export]
 macro_rules! impl_from_error {
     ($from:path, $to:tt::$ctor:tt) => {
         impl From<$from> for $to {
@@ -57,4 +62,39 @@ macro_rules! impl_from_error {
             }
         }
     };
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{string_from_cstr_with_len, copy_string_to_cstr_ptr};
+
+    #[test]
+    fn test_string_from_cstr_with_len() {
+        let cstr = b"hello world!";
+        let result = string_from_cstr_with_len(cstr as *const u8, 12);
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "hello world!");
+    }
+
+    #[test]
+    fn test_copy_string_to_cstr_ptr() {
+        let mut buffer: [u8; 64] = [0; 64];
+        let mut size : usize = 0;
+
+        let result = copy_string_to_cstr_ptr("hello world!".into(), &mut buffer[0], buffer.len(), &mut size);
+
+        assert!(result.is_ok());
+        assert_eq!(size, 12);
+        assert_eq!(String::from_utf8_lossy(&buffer[..size]), "hello world!".to_string());
+    }
+
+    #[test]
+    fn test_copy_string_to_cstr_ptr_insufficient_capacity() {
+        let mut buffer: [u8; 10] = [0; 10];
+        let mut size : usize = 0;
+
+        let result = copy_string_to_cstr_ptr("hello world!".into(), &mut buffer[0], buffer.len(), &mut size);
+        assert!(result.is_err());
+    }
 }

--- a/sgx/utils/src/lib.rs
+++ b/sgx/utils/src/lib.rs
@@ -1,4 +1,8 @@
 // Util functions, primarily for passing data between Go / Rust / SGX enclaves
+//
+// NOTE: This library is intended to be unit tested, in test mode it uses the std rust library as
+// this is needed for Rust's testing framework. Take care not to introduce a dependency on anything
+// in std which is not also in sgx_tstd.
 
 #![cfg_attr(all(not(test), not(feature = "std")), no_std)]
 


### PR DESCRIPTION
Moved some common code between the untrusted and trusted side of the enclave to a new crate called utils. Utils has a std feature flag for working with/without the std library and can be unit tested.

Added a unit test option to the codeship steps.

NOTE: I had consistent problems with running the go tests on codeship that didn't seem to point to any assertion failure, just a go routine panicking. Tuning down the parallelism in the tests seems to have alleviated this, without affecting the duration of the tests.

:bowtie: 