### PR TITLE
Fix coverage profile and numbers for CI go_test

### DIFF
--- a/integration/features.go
+++ b/integration/features.go
@@ -1,0 +1,1 @@
+package integration

--- a/internal/ci/go_test
+++ b/internal/ci/go_test
@@ -2,7 +2,8 @@
 
 set -e
 
-packages=`go list -f '{{.ImportPath}},' ./... | tr -d '\n' | sed 's/,$//'`
+packages=`go list -f '{{.ImportPath}},' ./... | grep -v "internal\|gui\|tmp" \
+  | tr -d '\n' | sed 's/,$//'`
 
 cc-test-reporter before-build
 go test -v -parallel 2 --tags=test -coverprofile=c.out -coverpkg=$packages ./...

--- a/internal/ci/go_test
+++ b/internal/ci/go_test
@@ -2,11 +2,10 @@
 
 set -e
 
-packages=`go list -f '{{.ImportPath}},' ./... | grep -v "internal\|gui\|tmp" \
-  | tr -d '\n' | sed 's/,$//'`
+go get -u github.com/smartcontractkit/goverage
 
 cc-test-reporter before-build
-go test -v -parallel 2 --tags=test -coverprofile=c.out -coverpkg=$packages ./...
+goverage -v -parallel 2 --tags=test -coverprofile=c.out ./...
 result=$?
 if [ -n "$CC_TEST_REPORTER_ID"  ]; then
   cc-test-reporter after-build -t gocov --exit-code $result

--- a/internal/ci/go_test
+++ b/internal/ci/go_test
@@ -2,8 +2,10 @@
 
 set -e
 
+packages=`go list -f '{{.ImportPath}},' ./... | tr -d '\n' | sed 's/,$//'`
+
 cc-test-reporter before-build
-go test -v -parallel 2 --tags=test -coverprofile=c.out -coverpkg=./... ./...
+go test -v -parallel 2 --tags=test -coverprofile=c.out -coverpkg=$packages ./...
 result=$?
 if [ -n "$CC_TEST_REPORTER_ID"  ]; then
   cc-test-reporter after-build -t gocov --exit-code $result

--- a/internal/ci/go_test
+++ b/internal/ci/go_test
@@ -3,7 +3,7 @@
 set -e
 
 cc-test-reporter before-build
-go test -v -parallel 2 --tags=test -coverprofile=c.out ./...
+go test -v -parallel 2 --tags=test -coverprofile=c.out -coverpkg=./... ./...
 result=$?
 if [ -n "$CC_TEST_REPORTER_ID"  ]; then
   cc-test-reporter after-build -t gocov --exit-code $result


### PR DESCRIPTION
## TL;DR
Before, if the coverage didn't come directly from the corresponding test package, it didn't count. Now it does. The change as a result of this PR is illustrated below where we don't have a `logger_test.go` but we do have coverage from other `*_test.go` packages.

![image](https://user-images.githubusercontent.com/635121/43205715-f6ab0d76-8ff1-11e8-8a27-b000d2c01650.png)

---

## Details
Our coverage numbers are off with the switch to go1.10 coverprofile. `packageB_test` will not contribute to `packageA` coverage, only `packageA_test` will. This is shown here:

![image 6](https://user-images.githubusercontent.com/635121/43205236-ed4727de-8ff0-11e8-8dd1-a2b6bb4e0dcd.png)

Where `AddAdapter` clearly has coverage from https://github.com/smartcontractkit/chainlink/blob/10b14d18f20932be8efa25013e7cf6e66355b485/cmd/remote_client_test.go#L228

The answer involves using `-coverpkg=<listOfPackages>` but that then results in erroneous coverage percentages. More information https://github.com/haya14busa/goverage/issues/9#issuecomment-407760156