### PR TITLE
WIP: Paginating updates jobs url

### DIFF
--- a/gui/src/Layout.js
+++ b/gui/src/Layout.js
@@ -183,7 +183,7 @@ class Layout extends Component {
                   <PrivateRoute exact path='/bridges' component={Bridges} />
                   <PrivateRoute exact path='/bridges/:bridgeName' component={BridgeSpec} />
                   <PrivateRoute exact path='/' component={Jobs} />
-                  <PrivateRoute exact path='/jobs/page/:page' component={Jobs} />
+                  <PrivateRoute exact path='/jobs/page/:jobPage' component={Jobs} />
                   <Routes />
                 </Switch>
               </div>

--- a/gui/src/Layout.js
+++ b/gui/src/Layout.js
@@ -183,6 +183,7 @@ class Layout extends Component {
                   <PrivateRoute exact path='/bridges' component={Bridges} />
                   <PrivateRoute exact path='/bridges/:bridgeName' component={BridgeSpec} />
                   <PrivateRoute exact path='/' component={Jobs} />
+                  <PrivateRoute exact path='/jobs/page/:page' component={Jobs} />
                   <Routes />
                 </Switch>
               </div>

--- a/gui/src/components/Footer.js
+++ b/gui/src/components/Footer.js
@@ -2,7 +2,7 @@ import React from 'react'
 import { withStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import Card from '@material-ui/core/Card'
-import extractBuildInfo from 'utils/extractBuildInfo';
+import extractBuildInfo from 'utils/extractBuildInfo'
 
 const styles = theme => ({
   style: {
@@ -17,7 +17,7 @@ const styles = theme => ({
 
 const {version, sha} = extractBuildInfo()
 
-const Footnote = ({ classes}) => {
+const Footnote = ({classes}) => {
   return (
     <Card className={classes.style}>
       <Typography>

--- a/gui/src/components/Footer.js
+++ b/gui/src/components/Footer.js
@@ -1,8 +1,8 @@
 import React from 'react'
 import { withStyles } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
-import { withRouteData } from 'react-static'
 import Card from '@material-ui/core/Card'
+import extractBuildInfo from 'utils/extractBuildInfo';
 
 const styles = theme => ({
   style: {
@@ -15,7 +15,9 @@ const styles = theme => ({
   }
 })
 
-const Footnote = ({ classes, version, sha }) => {
+const {version, sha} = extractBuildInfo()
+
+const Footnote = ({ classes}) => {
   return (
     <Card className={classes.style}>
       <Typography>
@@ -25,4 +27,4 @@ const Footnote = ({ classes, version, sha }) => {
   )
 }
 
-export default withRouteData(withStyles(styles)(Footnote))
+export default withStyles(styles)(Footnote)

--- a/gui/src/components/JobList.js
+++ b/gui/src/components/JobList.js
@@ -62,14 +62,9 @@ export class JobList extends Component {
   componentDidMount () {
     const { pageSize, fetchJobs } = this.props
     const firstPage = 1
-    if (this.props.match.params.page) {
-      const queryPage = this.props.match.params.page
-      this.setState({ page: queryPage })
-      fetchJobs(queryPage, pageSize)
-    } else {
-      this.setState({ page: firstPage })
-      fetchJobs(firstPage, pageSize)
-    }
+    const queryPage = this.props.match ? (parseInt(this.props.match.params.page) || firstPage) : firstPage
+    this.setState({ page: queryPage })
+    fetchJobs(queryPage, pageSize)
   }
 
   handleChangePage (e, page) {

--- a/gui/src/components/JobList.js
+++ b/gui/src/components/JobList.js
@@ -62,7 +62,7 @@ export class JobList extends Component {
   componentDidMount () {
     const { pageSize, fetchJobs } = this.props
     const firstPage = 1
-    const queryPage = this.props.match ? (parseInt(this.props.match.params.page) || firstPage) : firstPage
+    const queryPage = this.props.match ? (parseInt(this.props.match.params.jobPage) || firstPage) : firstPage
     this.setState({ page: queryPage })
     fetchJobs(queryPage, pageSize)
   }

--- a/gui/src/components/JobList.js
+++ b/gui/src/components/JobList.js
@@ -10,7 +10,7 @@ import TableRow from '@material-ui/core/TableRow'
 import TablePagination from '@material-ui/core/TablePagination'
 import Typography from '@material-ui/core/Typography'
 import formatInitiators from 'utils/formatInitiators'
-import TableButtons from 'components/TableButtons'
+import TableButtons, { FIRST_PAGE } from 'components/TableButtons'
 
 const renderFetching = () => (
   <TableRow>
@@ -61,8 +61,7 @@ export class JobList extends Component {
 
   componentDidMount () {
     const { pageSize, fetchJobs } = this.props
-    const firstPage = 1
-    const queryPage = this.props.match ? (parseInt(this.props.match.params.jobPage) || firstPage) : firstPage
+    const queryPage = this.props.match ? (parseInt(this.props.match.params.jobPage, 10) || FIRST_PAGE) : FIRST_PAGE
     this.setState({ page: queryPage })
     fetchJobs(queryPage, pageSize)
   }

--- a/gui/src/components/JobList.js
+++ b/gui/src/components/JobList.js
@@ -10,6 +10,7 @@ import TableRow from '@material-ui/core/TableRow'
 import TablePagination from '@material-ui/core/TablePagination'
 import Typography from '@material-ui/core/Typography'
 import formatInitiators from 'utils/formatInitiators'
+import TableButtons from 'components/TableButtons'
 
 const renderFetching = () => (
   <TableRow>
@@ -54,21 +55,41 @@ const renderBody = (jobs, fetching, error) => {
 export class JobList extends Component {
   constructor (props) {
     super(props)
-    this.state = {
-      page: 0
-    }
+    this.state = { page: 1 }
     this.handleChangePage = this.handleChangePage.bind(this)
+  }
+
+  componentDidMount () {
+    const { pageSize, fetchJobs } = this.props
+    const firstPage = 1
+    if (this.props.match.params.page) {
+      const queryPage = this.props.match.params.page
+      this.setState({ page: queryPage })
+      fetchJobs(queryPage, pageSize)
+    } else {
+      this.setState({ page: firstPage })
+      fetchJobs(firstPage, pageSize)
+    }
   }
 
   handleChangePage (e, page) {
     const {fetchJobs, pageSize} = this.props
-
-    fetchJobs(page + 1, pageSize)
-    this.setState({page})
+    fetchJobs(page, pageSize)
+    this.setState({ page })
   }
 
   render () {
     const {jobs, jobCount, pageSize, fetching, error} = this.props
+    const TableButtonsWithProps = () => (
+      <TableButtons
+        {...this.props}
+        count={jobCount}
+        onChangePage={this.handleChangePage}
+        rowsPerPage={pageSize}
+        page={this.state.page}
+        replaceWith={`/jobs/page`}
+      />
+    )
 
     return (
       <Card>
@@ -95,11 +116,10 @@ export class JobList extends Component {
           count={jobCount}
           rowsPerPage={pageSize}
           rowsPerPageOptions={[pageSize]}
-          page={this.state.page}
-          backIconButtonProps={{'aria-label': 'Previous Page'}}
-          nextIconButtonProps={{'aria-label': 'Next Page'}}
-          onChangePage={this.handleChangePage}
+          page={this.state.page - 1}
+          onChangePage={() => {} /* handler required by component, so make it a no-op */}
           onChangeRowsPerPage={() => {} /* handler required by component, so make it a no-op */}
+          ActionsComponent={TableButtonsWithProps}
         />
       </Card>
     )

--- a/gui/src/components/TableButtons.js
+++ b/gui/src/components/TableButtons.js
@@ -14,9 +14,9 @@ const styles = theme => ({
 })
 
 const TableButtons = props => {
-  const lastPage = Math.ceil(props.count / props.rowsPerPage)
   const firstPage = 1
   const currentPage = props.page
+  const lastPage = Math.ceil(props.count / props.rowsPerPage)
   const handlePage = page => e => {
     page = Math.min(page, lastPage)
     page = Math.max(page, firstPage)

--- a/gui/src/components/TableButtons.js
+++ b/gui/src/components/TableButtons.js
@@ -1,0 +1,45 @@
+import { IconButton, withStyles } from '@material-ui/core'
+import FirstPageIcon from '@material-ui/icons/FirstPage'
+import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft'
+import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight'
+import LastPageIcon from '@material-ui/icons/LastPage'
+import React from 'react'
+
+const styles = theme => ({
+  customButtons: {
+    flexShrink: 0,
+    color: theme.palette.text.secondary,
+    marginLeft: theme.spacing.unit * 2.5
+  }
+})
+
+const TableButtons = props => {
+  const lastPage = Math.ceil(props.count / props.rowsPerPage)
+  const firstPage = 1
+  const currentPage = props.page
+  const handlePage = page => e => {
+    page = Math.min(page, lastPage)
+    page = Math.max(page, firstPage)
+    if (props.history) props.history.replace(`${props.replaceWith}/${page}`)
+    props.onChangePage(e, page)
+  }
+
+  return (
+    <div className={props.classes.customButtons}>
+      <IconButton onClick={handlePage(firstPage)} disabled={currentPage <= firstPage} aria-label='First Page'>
+        <FirstPageIcon />
+      </IconButton>
+      <IconButton onClick={handlePage(currentPage - 1)} disabled={currentPage <= firstPage} aria-label='Previous Page'>
+        <KeyboardArrowLeft />
+      </IconButton>
+      <IconButton onClick={handlePage(currentPage + 1)} disabled={currentPage >= lastPage} aria-label='Next Page'>
+        <KeyboardArrowRight />
+      </IconButton>
+      <IconButton onClick={handlePage(lastPage)} disabled={currentPage >= lastPage} aria-label='Last Page'>
+        <LastPageIcon />
+      </IconButton>
+    </div>
+  )
+}
+
+export default withStyles(styles)(TableButtons)

--- a/gui/src/components/TableButtons.js
+++ b/gui/src/components/TableButtons.js
@@ -42,4 +42,5 @@ const TableButtons = props => {
   )
 }
 
+export const FIRST_PAGE = 1
 export default withStyles(styles)(TableButtons)

--- a/gui/src/containers/JobSpecRuns.js
+++ b/gui/src/containers/JobSpecRuns.js
@@ -36,7 +36,7 @@ export class JobSpecRuns extends Component {
   componentDidMount () {
     const { jobSpecId, pageSize, fetchJobSpecRuns } = this.props
     const firstPage = 1
-    const queryPage = this.props.match ? (parseInt(this.props.match.params.page) || firstPage) : firstPage
+    const queryPage = this.props.match ? (parseInt(this.props.match.params.jobRunsPage) || firstPage) : firstPage
     this.setState({ page: queryPage })
     fetchJobSpecRuns(jobSpecId, queryPage, pageSize)
   }

--- a/gui/src/containers/JobSpecRuns.js
+++ b/gui/src/containers/JobSpecRuns.js
@@ -6,16 +6,12 @@ import React, { Component } from 'react'
 import Typography from '@material-ui/core/Typography'
 import TablePagination from '@material-ui/core/TablePagination'
 import Card from '@material-ui/core/Card'
-import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft'
-import KeyboardArrowRight from '@material-ui/icons/KeyboardArrowRight'
-import FirstPageIcon from '@material-ui/icons/FirstPage'
-import LastPageIcon from '@material-ui/icons/LastPage'
 import matchRouteAndMapDispatchToProps from 'utils/matchRouteAndMapDispatchToProps'
 import { connect } from 'react-redux'
 import { fetchJobSpecRuns } from 'actions'
 import { withStyles } from '@material-ui/core/styles'
 import { jobRunsCountSelector, jobRunsSelector } from 'selectors'
-import { IconButton } from '@material-ui/core'
+import TableButtons from 'components/TableButtons'
 
 const styles = theme => ({
   breadcrumb: {
@@ -25,41 +21,8 @@ const styles = theme => ({
   title: {
     marginTop: theme.spacing.unit * 5,
     marginBottom: theme.spacing.unit * 5
-  },
-  customButtons: {
-    flexShrink: 0,
-    color: theme.palette.text.secondary,
-    marginLeft: theme.spacing.unit * 2.5
   }
 })
-
-const TableButtons = props => {
-  const lastPage = Math.ceil(props.count / props.rowsPerPage)
-  const firstPage = 1
-  const currentPage = props.page
-  const handlePage = page => e => {
-    page = Math.min(page, lastPage)
-    page = Math.max(page, firstPage)
-    if (props.history) { props.history.replace(`/job_specs/${props.specID}/runs/page/${page}`) }
-    props.onChangePage(e, page)
-  }
-  return (
-    <div className={props.classes.customButtons}>
-      <IconButton onClick={handlePage(firstPage)} disabled={currentPage === firstPage} aria-label='First Page'>
-        <FirstPageIcon />
-      </IconButton>
-      <IconButton onClick={handlePage(currentPage - 1)} disabled={currentPage === firstPage} aria-label='Previous Page'>
-        <KeyboardArrowLeft />
-      </IconButton>
-      <IconButton onClick={handlePage(currentPage + 1)} disabled={currentPage >= lastPage} aria-label='Next Page'>
-        <KeyboardArrowRight />
-      </IconButton>
-      <IconButton onClick={handlePage(lastPage)} disabled={currentPage >= lastPage} aria-label='Last Page'>
-        <LastPageIcon />
-      </IconButton>
-    </div>
-  )
-}
 
 export class JobSpecRuns extends Component {
   constructor (props) {
@@ -120,6 +83,7 @@ const renderLatestRuns = (props, state, handleChangePage) => {
       page={state.page}
       specID={jobSpecId}
       rowsPerPage={pageSize}
+      replaceWith={`/job_specs/${jobSpecId}/runs/page`}
     />
   )
   return (
@@ -133,7 +97,7 @@ const renderLatestRuns = (props, state, handleChangePage) => {
         page={state.page - 1}
         onChangePage={() => {} /* handler required by component, so make it a no-op */}
         onChangeRowsPerPage={() => {} /* handler required by component, so make it a no-op */}
-        ActionsComponent={withStyles(styles)(TableButtonsWithProps)}
+        ActionsComponent={TableButtonsWithProps}
       />
     </Card>
   )

--- a/gui/src/containers/JobSpecRuns.js
+++ b/gui/src/containers/JobSpecRuns.js
@@ -36,7 +36,7 @@ export class JobSpecRuns extends Component {
   componentDidMount () {
     const { jobSpecId, pageSize, fetchJobSpecRuns } = this.props
     const firstPage = 1
-    const queryPage = this.props.match ? (parseInt(this.props.match.params.jobRunsPage) || firstPage) : firstPage
+    const queryPage = this.props.match ? (parseInt(this.props.match.params.jobRunsPage, 10) || firstPage) : firstPage
     this.setState({ page: queryPage })
     fetchJobSpecRuns(jobSpecId, queryPage, pageSize)
   }

--- a/gui/src/containers/JobSpecRuns.js
+++ b/gui/src/containers/JobSpecRuns.js
@@ -36,14 +36,9 @@ export class JobSpecRuns extends Component {
   componentDidMount () {
     const { jobSpecId, pageSize, fetchJobSpecRuns } = this.props
     const firstPage = 1
-    if (this.props.match.params.jobRunsPage) {
-      const START_PAGE = this.props.match.params.jobRunsPage
-      this.setState({ page: START_PAGE })
-      fetchJobSpecRuns(jobSpecId, START_PAGE, pageSize)
-    } else {
-      this.setState({ page: firstPage })
-      fetchJobSpecRuns(jobSpecId, firstPage, pageSize)
-    }
+    const queryPage = this.props.match ? (parseInt(this.props.match.params.page) || firstPage) : firstPage
+    this.setState({ page: queryPage })
+    fetchJobSpecRuns(jobSpecId, queryPage, pageSize)
   }
 
   handleChangePage (e, page) {

--- a/gui/src/containers/Jobs.js
+++ b/gui/src/containers/Jobs.js
@@ -137,4 +137,3 @@ export const ConnectedJobs = connect(
 )(Jobs)
 
 export default withStyles(styles)(ConnectedJobs)
-

--- a/gui/src/containers/Jobs.js
+++ b/gui/src/containers/Jobs.js
@@ -7,7 +7,6 @@ import TokenBalance from 'components/TokenBalance'
 import MetaInfo from 'components/MetaInfo'
 import Footer from 'components/Footer'
 import matchRouteAndMapDispatchToProps from 'utils/matchRouteAndMapDispatchToProps'
-import { withSiteData } from 'react-static'
 import { withStyles } from '@material-ui/core/styles'
 import { connect } from 'react-redux'
 import { fetchJobs, fetchAccountBalance } from 'actions'
@@ -137,6 +136,5 @@ export const ConnectedJobs = connect(
   matchRouteAndMapDispatchToProps({fetchAccountBalance, fetchJobs})
 )(Jobs)
 
-export default withSiteData(
-  withStyles(styles)(ConnectedJobs)
-)
+export default withStyles(styles)(ConnectedJobs)
+

--- a/gui/src/containers/Jobs.js
+++ b/gui/src/containers/Jobs.js
@@ -20,16 +20,21 @@ const styles = theme => ({
   }
 })
 
-const renderJobsList = ({jobs, jobCount, pageSize, jobsFetching, jobsError, fetchJobs}) => (
-  <JobList
-    jobs={jobs}
-    jobCount={jobCount}
-    pageSize={pageSize}
-    fetching={jobsFetching}
-    error={jobsError}
-    fetchJobs={fetchJobs}
-  />
-)
+const renderJobsList = (props) => {
+  const {jobs, jobCount, pageSize, jobsFetching, jobsError, fetchJobs, history, match} = props
+  return (
+    <JobList
+      jobs={jobs}
+      jobCount={jobCount}
+      pageSize={pageSize}
+      fetching={jobsFetching}
+      error={jobsError}
+      fetchJobs={fetchJobs}
+      history={history}
+      match={match}
+    />
+  )
+}
 
 const renderSidebar = ({
   ethBalance,
@@ -63,13 +68,11 @@ const renderSidebar = ({
 
 export class Jobs extends Component {
   componentDidMount () {
-    this.props.fetchJobs(1, this.props.pageSize)
     this.props.fetchAccountBalance()
   }
 
   render () {
     const { classes } = this.props
-
     return (
       <div>
         <Typography variant='display2' color='inherit' className={classes.title}>

--- a/gui/static.config.js
+++ b/gui/static.config.js
@@ -13,16 +13,8 @@ export default {
   }),
   getRoutes: async () => {
     return [
-      {
-        path: '/',
-        component: 'src/containers/Jobs',
-        getData: () => buildInfo
-      },
-      {
-        path: '/jobs/page/_jobPage_',
-        component: 'src/containers/Jobs',
-        getData: () => buildInfo
-      },
+      {path: '/',},
+      {path: '/jobs/page/_jobPage_',},
       {path: '/job_specs/_jobSpecId_'},
       {path: '/job_specs/_jobSpecId_/runs'},
       {path: '/job_specs/_jobSpecId_/runs/page/_jobRunsPage_'},

--- a/gui/static.config.js
+++ b/gui/static.config.js
@@ -13,8 +13,8 @@ export default {
   }),
   getRoutes: async () => {
     return [
-      {path: '/',},
-      {path: '/jobs/page/_jobPage_',},
+      {path: '/'},
+      {path: '/jobs/page/_jobPage_'},
       {path: '/job_specs/_jobSpecId_'},
       {path: '/job_specs/_jobSpecId_/runs'},
       {path: '/job_specs/_jobSpecId_/runs/page/_jobRunsPage_'},

--- a/gui/static.config.js
+++ b/gui/static.config.js
@@ -18,6 +18,7 @@ export default {
         component: 'src/containers/Jobs',
         getData: () => buildInfo
       },
+      {path: '/jobs/page/_jobPage_'},
       {path: '/job_specs/_jobSpecId_'},
       {path: '/job_specs/_jobSpecId_/runs'},
       {path: '/job_specs/_jobSpecId_/runs/page/_jobRunsPage_'},

--- a/gui/static.config.js
+++ b/gui/static.config.js
@@ -18,7 +18,11 @@ export default {
         component: 'src/containers/Jobs',
         getData: () => buildInfo
       },
-      {path: '/jobs/page/_jobPage_'},
+      {
+        path: '/jobs/page/_jobPage_',
+        component: 'src/containers/Jobs',
+        getData: () => buildInfo
+      },
       {path: '/job_specs/_jobSpecId_'},
       {path: '/job_specs/_jobSpecId_/runs'},
       {path: '/job_specs/_jobSpecId_/runs/page/_jobRunsPage_'},


### PR DESCRIPTION
[Refs #159413341](https://www.pivotaltracker.com/story/show/159413341)

Since I already used first & last page table buttons for jobspecs and I had to use them here too I refactored it into TableButtons component. 

@rupurt I haven't added test cases for the updated job urls yet. I noticed however that this PR brings a regression when you land on a `localhost/jobs/page/X` page. Going to the next page goes to `localhost/jobs/page/X+1`, but coming back to the X'th page still stays at `localhost/jobs/page/X+1` instead of `/page/X`. I'm not too sure why this is happening, maybe duplicate history entries? If so, does react-static provide some tools to manipulate the url more flexibly? Or should I make the buttons Link components to change the url?