### PR TITLE
Add web asset compression

### DIFF
--- a/gui/static.config.js
+++ b/gui/static.config.js
@@ -4,7 +4,7 @@ import JssProvider from 'react-jss/lib/JssProvider'
 import { MuiThemeProvider, createMuiTheme, createGenerateClassName } from '@material-ui/core/styles'
 import theme from './src/theme' // Custom Material UI theme
 import extractBuildInfo from './src/utils/extractBuildInfo'
-
+import BrotliGzipPlugin from 'brotli-gzip-webpack-plugin'
 const buildInfo = extractBuildInfo()
 
 export default {
@@ -30,6 +30,23 @@ export default {
       },
       {is404: true, component: 'src/containers/404'}
     ]
+  },
+  webpack: config => {
+    config.plugins.push(new BrotliGzipPlugin({
+      asset: '[path].br[query]',
+      algorithm: 'brotli',
+      test: /\.(js|css|html|svg)$/,
+      threshold: 10240,
+      minRatio: 0.8
+    })),
+    config.plugins.push(new BrotliGzipPlugin({
+      asset: '[path].gz[query]',
+      algorithm: 'gzip',
+      test: /\.(js|css|html|svg)$/,
+      threshold: 10240,
+      minRatio: 0.8
+  }))
+    return config
   },
   renderToHtml: (render, Comp, meta) => {
     const sheetsRegistry = new SheetsRegistry()

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "babel-plugin-transform-es3-property-literals": "^6.22.0",
     "babel-preset-stage-2": "^6.24.1",
     "bignumber.js": "^7.2.1",
+    "brotli-gzip-webpack-plugin": "^0.5.0",
     "cbor": "^4.0.0",
     "enzyme": "^3.3.0",
     "enzyme-adapter-react-16": "^1.1.1",


### PR DESCRIPTION
Refs [#159078220](https://www.pivotaltracker.com/story/show/159078220) and [#159078405](https://www.pivotaltracker.com/story/show/159078405)

I don't know if we like using [brotli-gzip-webpack-plugin](https://www.npmjs.com/package/brotli-gzip-webpack-plugin) considering that it was last updated 1 year ago. 

@rupurt what do  [#159078220](https://www.pivotaltracker.com/story/show/159078220) and [#159078405](https://www.pivotaltracker.com/story/show/159078405) encompass? adding compression methods only or serving compressed files too?