### PR TITLE
Bump Ubuntu image version for Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /go/src/github.com/smartcontractkit/chainlink
 RUN make build
 
 # Final layer: ubuntu with chainlink binary
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y ca-certificates

--- a/Dockerfile-sgx
+++ b/Dockerfile-sgx
@@ -16,7 +16,7 @@ WORKDIR /go/src/github.com/smartcontractkit/chainlink
 RUN make build
 
 # Final layer: ubuntu with aesm and chainlink binaries (executable + enclave)
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 # Install AESM
 ENV DEBIAN_FRONTEND noninteractive


### PR DESCRIPTION
The image `ubuntu:18.04` is the new [Ubuntu minimal image](https://blog.ubuntu.com/2018/07/09/minimal-ubuntu-released). Works with and without SGX.