### PR TITLE
Style the default loading text when asynchronously downloading routes

### DIFF
--- a/gui/src/Layout.js
+++ b/gui/src/Layout.js
@@ -13,6 +13,7 @@ import MenuIcon from '@material-ui/icons/Menu'
 import Flash from 'components/Flash'
 import PrivateRoute from './PrivateRoute'
 import Logo from 'components/Logo'
+import Loading from 'components/Loading'
 import universal from 'react-universal-component'
 import { Link, Router, Route, Switch } from 'react-static'
 import { hot } from 'react-hot-loader'
@@ -22,16 +23,18 @@ import { bindActionCreators } from 'redux'
 import { submitSignOut } from 'actions'
 import { isFetchingSelector } from 'selectors'
 
-// Use universal-react-component for code-splitting non-static routes
-const Bridges = universal(import('./containers/Bridges'))
-const BridgeSpec = universal(import('./containers/BridgeSpec'))
-const Configuration = universal(import('./containers/Configuration'))
-const About = universal(import('./containers/About'))
-const Jobs = universal(import('./containers/Jobs'))
-const JobSpec = universal(import('./containers/JobSpec'))
-const JobSpecRuns = universal(import('./containers/JobSpecRuns'))
-const JobSpecRun = universal(import('./containers/JobSpecRun'))
-const SignIn = universal(import('./containers/SignIn'))
+// Asynchronously load routes that are chunked via code-splitting
+// 'import' as a function must take a string. It can't take a variable.
+const uniOpts = {loading: Loading}
+const Bridges = universal(import('./containers/Bridges'), uniOpts)
+const BridgeSpec = universal(import('./containers/BridgeSpec'), uniOpts)
+const Configuration = universal(import('./containers/Configuration'), uniOpts)
+const About = universal(import('./containers/About'), uniOpts)
+const Jobs = universal(import('./containers/Jobs'), uniOpts)
+const JobSpec = universal(import('./containers/JobSpec'), uniOpts)
+const JobSpecRuns = universal(import('./containers/JobSpecRuns'), uniOpts)
+const JobSpecRun = universal(import('./containers/JobSpecRun'), uniOpts)
+const SignIn = universal(import('./containers/SignIn'), uniOpts)
 
 const appBarHeight = 70
 const drawerWidth = 240

--- a/gui/src/components/Loading.js
+++ b/gui/src/components/Loading.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import Grid from '@material-ui/core/Grid'
+import Typography from '@material-ui/core/Typography'
+import { withStyles } from '@material-ui/core/styles'
+
+const styles = theme => ({
+  wrapper: {
+    marginTop: theme.spacing.unit * 5
+  },
+  text: {
+    textAlign: 'center'
+  }
+})
+
+const Loading = ({classes}) => (
+  <Grid container alignItems='center'>
+    <Grid item xs={12} className={classes.wrapper}>
+      <Typography variant='headline' className={classes.text}>
+        Loading...
+      </Typography>
+    </Grid>
+  </Grid>
+)
+
+export default withStyles(styles)(Loading)


### PR DESCRIPTION
It's only really noticeable on a slower connection. Difficult to notice locally in development.

Old:

<img width="1010" alt="old-route-loading" src="https://user-images.githubusercontent.com/680789/43928373-866bb27c-9be5-11e8-8f90-9dbe0d5d5b0e.png">

New:

<img width="1348" alt="new-route-loading" src="https://user-images.githubusercontent.com/680789/43928377-8a75df28-9be5-11e8-95cd-bf448ed40939.png">
