### PR TITLE
Created /v2/stats endpoint that displays high-level job spec data

### DIFF
--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -99,6 +99,7 @@ func NewConfigWithWSServer(wsserver *httptest.Server) *TestConfig {
 			RootDir:                  rootdir,
 			SecretGenerator:          mockSecretGenerator{},
 			SessionTimeout:           store.Duration{MustParseDuration("2m")},
+			StatsParam:               []string{"url"},
 		},
 	}
 	config.SetEthereumServer(wsserver)

--- a/services/job_stats.go
+++ b/services/job_stats.go
@@ -1,0 +1,80 @@
+package services
+
+import (
+	"github.com/smartcontractkit/chainlink/store"
+	"github.com/smartcontractkit/chainlink/store/models"
+	"go.uber.org/multierr"
+)
+
+// AllJobSpecStats returns all Job Spec Stat data for the Job Spec inputs
+func AllJobSpecStats(store *store.Store, jobs []models.JobSpec) (models.JobSpecStats, error) {
+	var merr error
+
+	s := models.JobSpecStats{}
+	if a, err := store.KeyStore.GetAccount(); err != nil {
+		merr = multierr.Append(merr, err)
+	} else {
+		s.Address = a.Address.Hex()
+	}
+
+	for _, j := range jobs {
+		if jobStats, err := jobSpecCounts(store, j); err != nil {
+			merr = multierr.Append(merr, err)
+		} else {
+			s.JobSpecCounts = append(s.JobSpecCounts, jobStats)
+		}
+	}
+	return s, merr
+}
+
+func jobSpecCounts(store *store.Store, job models.JobSpec) (models.JobSpecCounts, error) {
+	jrs, err := store.JobRunsFor(job.ID)
+	if err != nil {
+		return models.JobSpecCounts{}, err
+	}
+
+	rc := make(map[models.RunStatus]int)
+	ac := make(map[models.TaskType]int)
+	pc := make(map[string][]models.ParamCount)
+	for _, jr := range jrs {
+		rc[jr.Status]++
+		if len(jr.TaskRuns) > 0 {
+			countParams(store, jr, pc)
+		}
+	}
+	for _, t := range job.Tasks {
+		ac[t.Type]++
+	}
+	return models.JobSpecCounts{
+		ID:           job.ID,
+		RunCount:     len(jrs),
+		AdaptorCount: ac,
+		StatusCount:  rc,
+		ParamCount:   pc,
+	}, nil
+}
+
+func countParams(store *store.Store, jobRun models.JobRun, paramCount map[string][]models.ParamCount) {
+	tp := store.Config.StatsParam
+
+	for _, p := range tp {
+		trp := jobRun.TaskRuns[0].Task.Params.Get(p)
+		if trp.Exists() {
+			found := false
+			for i := range paramCount[p] {
+				if paramCount[p][i].Value == trp.String() {
+					found = true
+					paramCount[p][i].Count++
+					break
+				}
+			}
+
+			if !found {
+				paramCount[p] = append(paramCount[p], models.ParamCount{
+					Value: trp.String(),
+					Count: 1,
+				})
+			}
+		}
+	}
+}

--- a/services/job_stats_test.go
+++ b/services/job_stats_test.go
@@ -1,0 +1,60 @@
+package services_test
+
+import (
+	"github.com/smartcontractkit/chainlink/internal/cltest"
+	"github.com/smartcontractkit/chainlink/services"
+	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestJobStats_AllJobSpecStats(t *testing.T) {
+	app, cleanup := cltest.NewApplicationWithKeyStore()
+	defer cleanup()
+
+	j1, _ := cltest.NewJobWithWebInitiator()
+	j1.Initiators[0].Ran = true
+	err := app.Store.SaveJob(&j1)
+	assert.NoError(t, err)
+
+	j2, initr := cltest.NewJobWithWebInitiator()
+	j2.Initiators[0].Ran = true
+	err = app.Store.SaveJob(&j2)
+	assert.NoError(t, err)
+
+	jr := j2.NewRun(initr)
+	jr.ID = "run"
+	jr.Status = "completed"
+	tp, err := jr.TaskRuns[0].Task.Params.Add("url", "https://chain.link")
+	jr.TaskRuns[0].Task.Params = tp
+	assert.NoError(t, err)
+
+	err = app.Store.Save(&jr)
+	assert.NoError(t, err)
+
+	jss, err := services.AllJobSpecStats(app.Store, []models.JobSpec{j1, j2})
+	assert.NoError(t, err)
+
+	assert.Len(t, jss.JobSpecCounts, 2)
+
+	assert.Equal(t, jss.JobSpecCounts[0].ID, j1.ID)
+	assert.Equal(t, jss.JobSpecCounts[0].AdaptorCount["noop"], 1)
+
+	assert.Equal(t, jss.JobSpecCounts[1].ID, j2.ID)
+	assert.Equal(t, jss.JobSpecCounts[1].AdaptorCount["noop"], 1)
+	assert.Equal(t, jss.JobSpecCounts[1].ParamCount["url"][0].Value, "https://chain.link")
+	assert.Equal(t, jss.JobSpecCounts[1].ParamCount["url"][0].Count, 1)
+}
+
+func TestJobStats_NoAccount(t *testing.T) {
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+
+	j, _ := cltest.NewJobWithWebInitiator()
+	j.Initiators[0].Ran = true
+	err := store.SaveJob(&j)
+	assert.NoError(t, err)
+
+	_, err = services.AllJobSpecStats(store, []models.JobSpec{j})
+	assert.Error(t, err)
+}

--- a/store/config.go
+++ b/store/config.go
@@ -16,7 +16,7 @@ import (
 	"github.com/gin-gonic/contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/gorilla/securecookie"
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
 	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/utils"
@@ -45,6 +45,7 @@ type Config struct {
 	OracleContractAddress    *common.Address `env:"ORACLE_CONTRACT_ADDRESS"`
 	Port                     string          `env:"CHAINLINK_PORT" envDefault:"6688"`
 	RootDir                  string          `env:"ROOT" envDefault:"~/.chainlink"`
+	StatsParam               []string        `env:"STATS_PARAM" envDefault:"url"`
 	SecretGenerator          SecretGenerator
 	TLSCertPath              string   `env:"TLS_CERT_PATH" envDefault:""`
 	TLSKeyPath               string   `env:"TLS_KEY_PATH" envDefault:""`

--- a/store/models/job_spec.go
+++ b/store/models/job_spec.go
@@ -293,3 +293,35 @@ func (bt BridgeType) Authenticate(token string) (bool, error) {
 	}
 	return false, fmt.Errorf("Incorrect access token for %s", bt.Name)
 }
+
+// JobSpecStats holds high level data from the store around Job Specs and their Runs
+type JobSpecStats struct {
+	Address       string          `json:"-"`
+	JobSpecCounts []JobSpecCounts `json:"job_spec_stats"`
+}
+
+// JobSpecCounts holds all the data for a single Job Spec and its Runs
+type JobSpecCounts struct {
+	ID           string                  `json:"id"`
+	RunCount     int                     `json:"run_count"`
+	AdaptorCount map[TaskType]int        `json:"adaptor_count"`
+	StatusCount  map[RunStatus]int       `json:"status_count"`
+	ParamCount   map[string][]ParamCount `json:"param_count"`
+}
+
+// ParamCount holds each parameter count in each Job Spec
+type ParamCount struct {
+	Value string `json:"value"`
+	Count int    `json:"count"`
+}
+
+// GetID returns the ID of this structure for jsonapi serialization.
+func (jss JobSpecStats) GetID() string {
+	return jss.Address
+}
+
+// SetID is used to set the ID of this structure when deserializing from jsonapi documents.
+func (jss *JobSpecStats) SetID(value string) error {
+	jss.Address = value
+	return nil
+}

--- a/store/presenters/presenters.go
+++ b/store/presenters/presenters.go
@@ -415,3 +415,29 @@ func (sa ServiceAgreement) FriendlyExpiration() string {
 func (sa ServiceAgreement) FriendlyPayment() string {
 	return fmt.Sprintf("%v LINK", (*assets.Link)(sa.Encumbrance.Payment).String())
 }
+
+// Stats holds high level data from the store around node operation
+type Stats struct {
+	Account      AccountBalance `json:"-"`
+	JobSpecStats []JobSpecStats `json:"job_spec_stats"`
+}
+
+// JobSpecStats holds all the data for a single Job Spec
+type JobSpecStats struct {
+	ID           string                   `json:"id"`
+	RunCount     int                      `json:"run_count"`
+	AdaptorCount map[models.TaskType]int  `json:"adaptor_count"`
+	StatusCount  map[models.RunStatus]int `json:"status_count"`
+	URLCount     map[string]int           `json:"run_url"`
+}
+
+// GetID generates a new ID for jsonapi serialization.
+func (s Stats) GetID() string {
+	return s.Account.Address
+}
+
+// SetID is used to conform to the UnmarshallIdentifier interface for
+// deserializing from jsonapi documents.
+func (s *Stats) SetID(value string) error {
+	return nil
+}

--- a/store/presenters/presenters.go
+++ b/store/presenters/presenters.go
@@ -415,35 +415,3 @@ func (sa ServiceAgreement) FriendlyExpiration() string {
 func (sa ServiceAgreement) FriendlyPayment() string {
 	return fmt.Sprintf("%v LINK", (*assets.Link)(sa.Encumbrance.Payment).String())
 }
-
-// Stats holds high level data from the store around node operation
-type Stats struct {
-	Account      AccountBalance `json:"-"`
-	JobSpecStats []JobSpecStats `json:"job_spec_stats"`
-}
-
-// JobSpecStats holds all the data for a single Job Spec
-type JobSpecStats struct {
-	ID           string                   `json:"id"`
-	RunCount     int                      `json:"run_count"`
-	AdaptorCount map[models.TaskType]int  `json:"adaptor_count"`
-	StatusCount  map[models.RunStatus]int `json:"status_count"`
-	ParamCount   map[string][]ParamCount  `json:"param_count"`
-}
-
-// ParamCount holds each parameter count in each Job Spec
-type ParamCount struct {
-	Value string `json:"value"`
-	Count int    `json:"count"`
-}
-
-// GetID generates a new ID for jsonapi serialization.
-func (s Stats) GetID() string {
-	return s.Account.Address
-}
-
-// SetID is used to conform to the UnmarshallIdentifier interface for
-// deserializing from jsonapi documents.
-func (s *Stats) SetID(value string) error {
-	return nil
-}

--- a/store/presenters/presenters.go
+++ b/store/presenters/presenters.go
@@ -428,7 +428,13 @@ type JobSpecStats struct {
 	RunCount     int                      `json:"run_count"`
 	AdaptorCount map[models.TaskType]int  `json:"adaptor_count"`
 	StatusCount  map[models.RunStatus]int `json:"status_count"`
-	URLCount     map[string]int           `json:"run_url"`
+	ParamCount   map[string][]ParamCount  `json:"param_count"`
+}
+
+// ParamCount holds each parameter count in each Job Spec
+type ParamCount struct {
+	Value string `json:"value"`
+	Count int    `json:"count"`
 }
 
 // GetID generates a new ID for jsonapi serialization.

--- a/web/api.go
+++ b/web/api.go
@@ -51,8 +51,8 @@ func ParsePaginatedRequest(sizeParam, pageParam string) (int, int, int, error) {
 
 func paginationLink(url url.URL, size, page int) jsonapi.Link {
 	query := url.Query()
-	query.Add("size", strconv.Itoa(size))
-	query.Add("page", strconv.Itoa(page))
+	query.Set("size", strconv.Itoa(size))
+	query.Set("page", strconv.Itoa(page))
 	url.RawQuery = query.Encode()
 	return jsonapi.Link{Href: url.String()}
 }

--- a/web/router.go
+++ b/web/router.go
@@ -124,6 +124,9 @@ func v2Routes(app *services.ChainlinkApplication, engine *gin.Engine) {
 
 		cc := ConfigController{app}
 		authv2.GET("/config", cc.Show)
+
+		s := StatsController{app}
+		authv2.GET("/stats", s.Show)
 	}
 }
 

--- a/web/stats_controller.go
+++ b/web/stats_controller.go
@@ -1,0 +1,99 @@
+package web
+
+import (
+	"fmt"
+	"github.com/asdine/storm"
+	"github.com/gin-gonic/gin"
+	"github.com/smartcontractkit/chainlink/services"
+	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/presenters"
+	"go.uber.org/multierr"
+)
+
+// StatsController fetches high-level information about the nodes usage
+type StatsController struct {
+	App *services.ChainlinkApplication
+}
+
+// Show displays Stats, one page at a time
+// Example:
+//  "<application>/stats?size=1&page=2"
+func (sc *StatsController) Show(c *gin.Context) {
+	store := sc.App.Store
+	jobs := []models.JobSpec{}
+
+	size, page, offset, err := ParsePaginatedRequest(c.Query("size"), c.Query("page"))
+	if err != nil {
+		c.AbortWithError(422, err)
+		return
+	}
+
+	skip := storm.Skip(offset)
+	limit := storm.Limit(size)
+
+	if count, err := sc.App.Store.Count(&models.JobSpec{}); err != nil {
+		c.AbortWithError(500, fmt.Errorf("error getting count of JobSpec: %+v", err))
+	} else if err := sc.App.Store.AllByIndex("CreatedAt", &jobs, skip, limit); err != nil {
+		c.AbortWithError(500, fmt.Errorf("error getting Jobs: %+v", err))
+	} else if jss, err := sc.allJobStats(jobs); err != nil {
+		c.AbortWithError(500, fmt.Errorf("error getting job stats: %+v", err))
+	} else if account, err := store.KeyStore.GetAccount(); err != nil {
+		publicError(c, 400, err)
+	} else {
+		a := presenters.AccountBalance{
+			Address: account.Address.Hex(),
+		}
+		s := presenters.Stats{
+			Account:      a,
+			JobSpecStats: jss,
+		}
+
+		buffer, err := NewPaginatedResponse(*c.Request.URL, size, page, count, s)
+		if err != nil {
+			c.AbortWithError(500, fmt.Errorf("failed to marshal document: %+v", err))
+		} else {
+			c.Data(200, MediaType, buffer)
+		}
+	}
+}
+
+func (sc *StatsController) allJobStats(jobs []models.JobSpec) ([]presenters.JobSpecStats, error) {
+	js := []presenters.JobSpecStats{}
+
+	var merr error
+	for _, j := range jobs {
+		if jobStats, err := sc.jobStats(j); err != nil {
+			merr = multierr.Append(merr, err)
+		} else {
+			js = append(js, jobStats)
+		}
+	}
+	return js, merr
+}
+
+func (sc *StatsController) jobStats(job models.JobSpec) (presenters.JobSpecStats, error) {
+	jrs, err := sc.App.Store.JobRunsFor(job.ID)
+	if err != nil {
+		return presenters.JobSpecStats{}, err
+	}
+
+	rc := make(map[models.RunStatus]int)
+	uc := make(map[string]int)
+	ac := make(map[models.TaskType]int)
+	for _, jr := range jrs {
+		rc[jr.Status]++
+		if len(jr.TaskRuns) > 0 && jr.TaskRuns[0].Task.Params.Get("url").Exists() {
+			uc[jr.TaskRuns[0].Task.Params.Get("url").Str]++
+		}
+	}
+	for _, t := range job.Tasks {
+		ac[t.Type]++
+	}
+	return presenters.JobSpecStats{
+		ID:           job.ID,
+		RunCount:     len(jrs),
+		AdaptorCount: ac,
+		StatusCount:  rc,
+		URLCount:     uc,
+	}, nil
+}

--- a/web/stats_controller_test.go
+++ b/web/stats_controller_test.go
@@ -1,0 +1,96 @@
+package web_test
+
+import (
+	"github.com/manyminds/api2go/jsonapi"
+	"github.com/smartcontractkit/chainlink/internal/cltest"
+	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/presenters"
+	"github.com/smartcontractkit/chainlink/web"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/multierr"
+	"testing"
+)
+
+func BenchmarkStatsController_Index(b *testing.B) {
+	app, cleanup := cltest.NewApplicationWithKeyStore()
+	defer cleanup()
+	client := app.NewHTTPClient()
+	setupStatsControllerIndex(app)
+
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		resp, cleanup := client.Get("/v2/stats")
+		defer cleanup()
+		assert.Equal(b, 200, resp.StatusCode, "Response should be successful")
+	}
+}
+
+func TestStatsController_Index(t *testing.T) {
+	t.Parallel()
+
+	app, cleanup := cltest.NewApplicationWithKeyStore()
+	defer cleanup()
+	client := app.NewHTTPClient()
+
+	j1, j2, err := setupStatsControllerIndex(app)
+	assert.NoError(t, err)
+
+	resp, cleanup := client.Get("/v2/stats?size=x")
+	defer cleanup()
+	cltest.AssertServerResponse(t, resp, 422)
+
+	resp, cleanup = client.Get("/v2/stats?size=1")
+	defer cleanup()
+	cltest.AssertServerResponse(t, resp, 200)
+	body := cltest.ParseResponseBody(resp)
+
+	metaCount, err := cltest.ParseJSONAPIResponseMetaCount(body)
+	assert.NoError(t, err)
+	assert.Equal(t, 2, metaCount)
+
+	var links jsonapi.Links
+	stats := presenters.Stats{}
+	err = web.ParsePaginatedResponse(body, &stats, &links)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, links["next"].Href)
+	assert.Empty(t, links["prev"].Href)
+
+	assert.Len(t, stats.JobSpecStats, 1)
+	assert.Equal(t, stats.JobSpecStats[0].AdaptorCount["noop"], 1, "Should have noop as an adaptor")
+	assert.Equal(t, j1.ID, stats.JobSpecStats[0].ID, "should have the same ID")
+
+	resp, cleanup = client.Get(links["next"].Href)
+	defer cleanup()
+	cltest.AssertServerResponse(t, resp, 200)
+
+	stats = presenters.Stats{}
+	err = web.ParsePaginatedResponse(cltest.ParseResponseBody(resp), &stats, &links)
+	assert.NoError(t, err)
+	assert.Empty(t, links["next"])
+	assert.NotEmpty(t, links["prev"])
+
+	assert.Len(t, stats.JobSpecStats, 1)
+	assert.Equal(t, stats.JobSpecStats[0].RunCount, 1, "Should have a single run")
+	assert.Equal(t, stats.JobSpecStats[0].StatusCount["completed"], 1, "Should have a single completed run")
+	assert.Equal(t, stats.JobSpecStats[0].AdaptorCount["noop"], 1, "Should have noop as an adaptor")
+	assert.Equal(t, stats.JobSpecStats[0].URLCount["https://chain.link"], 1, "Should include a url")
+	assert.Equal(t, j2.ID, stats.JobSpecStats[0].ID, "should have the same ID")
+}
+
+func setupStatsControllerIndex(app *cltest.TestApplication) (*models.JobSpec, *models.JobSpec, error) {
+	j1, initr := cltest.NewJobWithWebInitiator()
+	j1.Initiators[0].Ran = true
+	merr := app.Store.SaveJob(&j1)
+	j2, initr := cltest.NewJobWithWebInitiator()
+	j2.Initiators[0].Ran = true
+	merr = multierr.Append(merr, app.Store.SaveJob(&j2))
+
+	jr2 := j2.NewRun(initr)
+	jr2.ID = "runB"
+	jr2.Status = "completed"
+	tp, err := jr2.TaskRuns[0].Task.Params.Add("url", "https://chain.link")
+	merr = multierr.Append(merr, err)
+	jr2.TaskRuns[0].Task.Params = tp
+	merr = multierr.Append(merr, app.Store.Save(&jr2))
+	return &j1, &j2, err
+}

--- a/web/stats_controller_test.go
+++ b/web/stats_controller_test.go
@@ -73,7 +73,8 @@ func TestStatsController_Index(t *testing.T) {
 	assert.Equal(t, stats.JobSpecStats[0].RunCount, 1, "Should have a single run")
 	assert.Equal(t, stats.JobSpecStats[0].StatusCount["completed"], 1, "Should have a single completed run")
 	assert.Equal(t, stats.JobSpecStats[0].AdaptorCount["noop"], 1, "Should have noop as an adaptor")
-	assert.Equal(t, stats.JobSpecStats[0].URLCount["https://chain.link"], 1, "Should include a url")
+	assert.Equal(t, stats.JobSpecStats[0].ParamCount["url"][0].Value, "https://chain.link", "Should include the same URL")
+	assert.Equal(t, stats.JobSpecStats[0].ParamCount["url"][0].Count, 1, "Should include a url")
 	assert.Equal(t, j2.ID, stats.JobSpecStats[0].ID, "should have the same ID")
 }
 

--- a/web/stats_controller_test.go
+++ b/web/stats_controller_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store/models"
-	"github.com/smartcontractkit/chainlink/store/presenters"
 	"github.com/smartcontractkit/chainlink/web"
 	"github.com/stretchr/testify/assert"
 	"go.uber.org/multierr"
@@ -49,37 +48,37 @@ func TestStatsController_Index(t *testing.T) {
 	assert.Equal(t, 2, metaCount)
 
 	var links jsonapi.Links
-	stats := presenters.Stats{}
+	stats := models.JobSpecStats{}
 	err = web.ParsePaginatedResponse(body, &stats, &links)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, links["next"].Href)
 	assert.Empty(t, links["prev"].Href)
 
-	assert.Len(t, stats.JobSpecStats, 1)
-	assert.Equal(t, stats.JobSpecStats[0].AdaptorCount["noop"], 1, "Should have noop as an adaptor")
-	assert.Equal(t, j1.ID, stats.JobSpecStats[0].ID, "should have the same ID")
+	assert.Len(t, stats.JobSpecCounts, 1)
+	assert.Equal(t, stats.JobSpecCounts[0].AdaptorCount["noop"], 1, "Should have noop as an adaptor")
+	assert.Equal(t, j1.ID, stats.JobSpecCounts[0].ID, "should have the same ID")
 
 	resp, cleanup = client.Get(links["next"].Href)
 	defer cleanup()
 	cltest.AssertServerResponse(t, resp, 200)
 
-	stats = presenters.Stats{}
+	stats = models.JobSpecStats{}
 	err = web.ParsePaginatedResponse(cltest.ParseResponseBody(resp), &stats, &links)
 	assert.NoError(t, err)
 	assert.Empty(t, links["next"])
 	assert.NotEmpty(t, links["prev"])
 
-	assert.Len(t, stats.JobSpecStats, 1)
-	assert.Equal(t, stats.JobSpecStats[0].RunCount, 1, "Should have a single run")
-	assert.Equal(t, stats.JobSpecStats[0].StatusCount["completed"], 1, "Should have a single completed run")
-	assert.Equal(t, stats.JobSpecStats[0].AdaptorCount["noop"], 1, "Should have noop as an adaptor")
-	assert.Equal(t, stats.JobSpecStats[0].ParamCount["url"][0].Value, "https://chain.link", "Should include the same URL")
-	assert.Equal(t, stats.JobSpecStats[0].ParamCount["url"][0].Count, 1, "Should include a url")
-	assert.Equal(t, j2.ID, stats.JobSpecStats[0].ID, "should have the same ID")
+	assert.Len(t, stats.JobSpecCounts, 1)
+	assert.Equal(t, stats.JobSpecCounts[0].RunCount, 1, "Should have a single run")
+	assert.Equal(t, stats.JobSpecCounts[0].StatusCount["completed"], 1, "Should have a single completed run")
+	assert.Equal(t, stats.JobSpecCounts[0].AdaptorCount["noop"], 1, "Should have noop as an adaptor")
+	assert.Equal(t, stats.JobSpecCounts[0].ParamCount["url"][0].Value, "https://chain.link", "Should include the same URL")
+	assert.Equal(t, stats.JobSpecCounts[0].ParamCount["url"][0].Count, 1, "Should include a url")
+	assert.Equal(t, j2.ID, stats.JobSpecCounts[0].ID, "should have the same ID")
 }
 
 func setupStatsControllerIndex(app *cltest.TestApplication) (*models.JobSpec, *models.JobSpec, error) {
-	j1, initr := cltest.NewJobWithWebInitiator()
+	j1, _ := cltest.NewJobWithWebInitiator()
 	j1.Initiators[0].Ran = true
 	merr := app.Store.SaveJob(&j1)
 	j2, initr := cltest.NewJobWithWebInitiator()


### PR DESCRIPTION
A new paginated stats endpoint to fetch high-level job spec information, allowing for easy metric gathering. Example response, with `STATS_PARAM` as `url,path`:
```json
{
    "links": {
        "next": "/v2/stats?page=6&size=1",
        "prev": "/v2/stats?page=4&size=1"
    },
    "data": {
        "type": "stats",
        "id": "0x5cd14Cdd14424fF6af88377B3f8c020adcbAb565",
        "attributes": {
            "job_spec_stats": [
                {
                    "id": "f2febf12ce7546d4816c6652da6b02b8",
                    "run_count": 4,
                    "adaptor_count": {
                        "ethtx": 1,
                        "ethuint256": 1,
                        "httpget": 1,
                        "jsonparse": 1,
                        "multiply": 1
                    },
                    "status_count": {
                        "errored": 4
                    },
                    "param_count": {
                        "path": [
                            {
                                "value": "USD",
                                "count": 4
                            }
                        ],
                        "url": [
                            {
                                "value": "https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=USD,EUR,JPY",
                                "count": 4
                            }
                        ]
                    }
                }
            ]
        }
    },
    "meta": {
        "count": 21
    }
}
```

Also as part of this, I've fixed an issue where GET params would be duplicated in the next/prev links when they're specified on the request.

[For #159707176](https://www.pivotaltracker.com/story/show/159707176)