### PR TITLE
Use assets.Link instead of big.Int for min payment

### DIFF
--- a/cmd/local_client_test.go
+++ b/cmd/local_client_test.go
@@ -54,7 +54,7 @@ func TestClient_RunNodeShowsEnv(t *testing.T) {
 	assert.Contains(t, logs, "ETH_GAS_BUMP_WEI: 5000000000\\n")
 	assert.Contains(t, logs, "ETH_GAS_PRICE_DEFAULT: 20000000000\\n")
 	assert.Contains(t, logs, "LINK_CONTRACT_ADDRESS: 0x514910771AF9Ca656af840dff83E8264EcF986CA\\n")
-	assert.Contains(t, logs, "MINIMUM_CONTRACT_PAYMENT: 100\\n")
+	assert.Contains(t, logs, "MINIMUM_CONTRACT_PAYMENT: 0.000000000000000100\\n")
 	assert.Contains(t, logs, "ORACLE_CONTRACT_ADDRESS: \\n")
 	assert.Contains(t, logs, "DATABASE_POLL_INTERVAL: 500ms\\n")
 	assert.Contains(t, logs, "ALLOW_ORIGINS: http://localhost:3000,http://localhost:6689\\n")

--- a/cmd/renderer_test.go
+++ b/cmd/renderer_test.go
@@ -108,7 +108,7 @@ func TestRendererTable_ServiceAgreementShow(t *testing.T) {
 	tests := []struct {
 		name, content string
 	}{
-		{"ID", "0xd7b66ba42e97935f456468de5a748990acebf0d9fbc638cf5485196cf7da3b05"},
+		{"ID", "0x8de92e4d6a2b527f1e3c39022ee0f1c177a6d874224fe54f5c4c0d5bcaa57d50"},
 		{"payment amount", "1.000000000000000000 LINK"},
 		{"expiration", "300 seconds"},
 	}

--- a/integration/features_test.go
+++ b/integration/features_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -17,6 +16,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store"
+	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/stretchr/testify/assert"
@@ -543,7 +543,7 @@ func TestIntegration_CreateServiceAgreement(t *testing.T) {
 	assert.NotEqual(t, "", sa.ID)
 	cltest.FindJob(app.Store, sa.JobSpecID)
 
-	assert.Equal(t, big.NewInt(1000000000000000000), sa.Encumbrance.Payment)
+	assert.Equal(t, assets.NewLink(1000000000000000000), sa.Encumbrance.Payment)
 	assert.Equal(t, uint64(300), sa.Encumbrance.Expiration)
-	assert.Equal(t, "0xd7b66ba42e97935f456468de5a748990acebf0d9fbc638cf5485196cf7da3b05", sa.ID)
+	assert.Equal(t, "0x8de92e4d6a2b527f1e3c39022ee0f1c177a6d874224fe54f5c4c0d5bcaa57d50", sa.ID)
 }

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -58,6 +58,8 @@ const (
 
 var storeCounter uint64
 
+var MinimumContractPayment = assets.NewLink(100)
+
 func init() {
 	gin.SetMode(gin.TestMode)
 	gomega.SetDefaultEventuallyTimeout(3 * time.Second)
@@ -92,7 +94,7 @@ func NewConfigWithWSServer(wsserver *httptest.Server) *TestConfig {
 			LogLevel:                 store.LogLevel{Level: zapcore.DebugLevel},
 			MinIncomingConfirmations: 0,
 			MinOutgoingConfirmations: 6,
-			MinimumContractPayment:   *assets.NewLink(100),
+			MinimumContractPayment:   *MinimumContractPayment,
 			MinimumRequestExpiration: 300,
 			RootDir:                  rootdir,
 			SecretGenerator:          mockSecretGenerator{},

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -58,7 +58,7 @@ const (
 
 var storeCounter uint64
 
-var MinimumContractPayment = assets.NewLink(100)
+var minimumContractPayment = assets.NewLink(100)
 
 func init() {
 	gin.SetMode(gin.TestMode)
@@ -94,7 +94,7 @@ func NewConfigWithWSServer(wsserver *httptest.Server) *TestConfig {
 			LogLevel:                 store.LogLevel{Level: zapcore.DebugLevel},
 			MinIncomingConfirmations: 0,
 			MinOutgoingConfirmations: 6,
-			MinimumContractPayment:   *MinimumContractPayment,
+			MinimumContractPayment:   *minimumContractPayment,
 			MinimumRequestExpiration: 300,
 			RootDir:                  rootdir,
 			SecretGenerator:          mockSecretGenerator{},

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -28,6 +28,7 @@ import (
 	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store"
+	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/smartcontractkit/chainlink/web"
@@ -56,8 +57,6 @@ const (
 )
 
 var storeCounter uint64
-
-const MinimumContractPayment = 100
 
 func init() {
 	gin.SetMode(gin.TestMode)
@@ -93,7 +92,7 @@ func NewConfigWithWSServer(wsserver *httptest.Server) *TestConfig {
 			LogLevel:                 store.LogLevel{Level: zapcore.DebugLevel},
 			MinIncomingConfirmations: 0,
 			MinOutgoingConfirmations: 6,
-			MinimumContractPayment:   *big.NewInt(MinimumContractPayment),
+			MinimumContractPayment:   *assets.NewLink(100),
 			MinimumRequestExpiration: 300,
 			RootDir:                  rootdir,
 			SecretGenerator:          mockSecretGenerator{},

--- a/internal/cltest/factories.go
+++ b/internal/cltest/factories.go
@@ -244,7 +244,7 @@ func NewRunLog(jobID string, addr common.Address, blk int, json string) ethtypes
 			services.RunLogTopic,
 			StringToHash("internalID"),
 			StringToHash(jobID),
-			MinimumContractPayment.ToHash(),
+			minimumContractPayment.ToHash(),
 		},
 	}
 }

--- a/internal/cltest/factories.go
+++ b/internal/cltest/factories.go
@@ -236,6 +236,9 @@ func EasyJSONFromString(body string, args ...interface{}) EasyJSON {
 
 // NewRunLog create ethtypes.Log for given jobid, address, block, and json
 func NewRunLog(jobID string, addr common.Address, blk int, json string) ethtypes.Log {
+	config, cleanup := NewConfig()
+	defer cleanup()
+
 	return ethtypes.Log{
 		Address:     addr,
 		BlockNumber: uint64(blk),
@@ -244,7 +247,7 @@ func NewRunLog(jobID string, addr common.Address, blk int, json string) ethtypes
 			services.RunLogTopic,
 			StringToHash("internalID"),
 			StringToHash(jobID),
-			common.BigToHash(big.NewInt(MinimumContractPayment)),
+			config.MinimumContractPayment.ToHash(),
 		},
 	}
 }

--- a/internal/cltest/factories.go
+++ b/internal/cltest/factories.go
@@ -236,9 +236,6 @@ func EasyJSONFromString(body string, args ...interface{}) EasyJSON {
 
 // NewRunLog create ethtypes.Log for given jobid, address, block, and json
 func NewRunLog(jobID string, addr common.Address, blk int, json string) ethtypes.Log {
-	config, cleanup := NewConfig()
-	defer cleanup()
-
 	return ethtypes.Log{
 		Address:     addr,
 		BlockNumber: uint64(blk),
@@ -247,7 +244,7 @@ func NewRunLog(jobID string, addr common.Address, blk int, json string) ethtypes
 			services.RunLogTopic,
 			StringToHash("internalID"),
 			StringToHash(jobID),
-			config.MinimumContractPayment.ToHash(),
+			MinimumContractPayment.ToHash(),
 		},
 	}
 }

--- a/internal/fixtures/web/hello_world_agreement.json
+++ b/internal/fixtures/web/hello_world_agreement.json
@@ -10,6 +10,6 @@
       "functionSelector": "0x609ff1bd"
     }
   ],
-  "payment": 1000000000000000000,
+  "payment": "1000000000000000000",
   "expiration": 300
 }

--- a/services/job_runner_test.go
+++ b/services/job_runner_test.go
@@ -3,7 +3,6 @@ package services_test
 import (
 	"errors"
 	"fmt"
-	"math/big"
 	"net/http"
 	"testing"
 	"time"
@@ -13,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store"
+	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/stretchr/testify/assert"
@@ -451,18 +451,18 @@ func TestJobRunner_ExecuteRun_ErrorsWithNoRuns(t *testing.T) {
 func TestJobRunner_BeginRunWithAmount(t *testing.T) {
 	tests := []struct {
 		name   string
-		amount *big.Int
+		amount *assets.Link
 		status models.RunStatus
 	}{
 		{"job with no amount", nil, models.RunStatusCompleted},
-		{"job with insufficient amount", big.NewInt(9), models.RunStatusErrored},
-		{"job with exact amount", big.NewInt(10), models.RunStatusCompleted},
-		{"job with valid amount", big.NewInt(11), models.RunStatusCompleted},
+		{"job with insufficient amount", assets.NewLink(9), models.RunStatusErrored},
+		{"job with exact amount", assets.NewLink(10), models.RunStatusCompleted},
+		{"job with valid amount", assets.NewLink(11), models.RunStatusCompleted},
 	}
 
 	config, cfgCleanup := cltest.NewConfig()
 	defer cfgCleanup()
-	config.MinimumContractPayment = *big.NewInt(10)
+	config.MinimumContractPayment = *assets.NewLink(10)
 
 	store, cleanup := cltest.NewStoreWithConfig(config)
 	defer cleanup()

--- a/services/subscription.go
+++ b/services/subscription.go
@@ -12,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/store"
+	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 	"github.com/smartcontractkit/chainlink/utils"
@@ -396,12 +397,12 @@ func (le InitiatorSubscriptionLogEvent) EthLogJSON() (models.JSON, error) {
 }
 
 // ContractPayment returns the amount attached to a contract to pay the Oracle upon fulfillment.
-func (le InitiatorSubscriptionLogEvent) ContractPayment() (*big.Int, error) {
+func (le InitiatorSubscriptionLogEvent) ContractPayment() (*assets.Link, error) {
 	if !isRunLog(le.Log) {
 		return nil, nil
 	}
 	encodedAmount := le.Log.Topics[RunLogTopicAmount].Hex()
-	payment, ok := new(big.Int).SetString(encodedAmount, 0)
+	payment, ok := new(assets.Link).SetString(encodedAmount, 0)
 	if !ok {
 		return payment, fmt.Errorf("unable to decoded amount from RunLog: %s", encodedAmount)
 	}

--- a/services/validators_test.go
+++ b/services/validators_test.go
@@ -136,7 +136,7 @@ func TestValidateServiceAgreement(t *testing.T) {
 	}{
 		{"basic", basic, false},
 		{"no payment", basic.Delete("payment"), true},
-		{"less than minimum payment", basic.Add("payment", 1), true},
+		{"less than minimum payment", basic.Add("payment", "1"), true},
 		{"less than minimum expiration", basic.Add("expiration", 1), true},
 	}
 

--- a/store/assets/currencies.go
+++ b/store/assets/currencies.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/willf/pad"
 )
 
@@ -33,10 +34,25 @@ func (l *Link) SetInt64(w int64) *Link {
 	return (*Link)((*big.Int)(l).SetInt64(w))
 }
 
+// ToHash returns a 32 byte representation of this value
+func (l *Link) ToHash() common.Hash {
+	return common.BigToHash((*big.Int)(l))
+}
+
 // SetString delegates to *big.Int.SetString
 func (l *Link) SetString(s string, base int) (*Link, bool) {
 	w, ok := (*big.Int)(l).SetString(s, base)
 	return (*Link)(w), ok
+}
+
+// Cmp defers to big.Int Cmp
+func (l *Link) Cmp(y *Link) int {
+	return (*big.Int)(l).Cmp((*big.Int)(y))
+}
+
+// Text defers to big.Int Text
+func (l *Link) Text(base int) string {
+	return (*big.Int)(l).Text(base)
 }
 
 // MarshalText implements the encoding.TextMarshaler interface.

--- a/store/config.go
+++ b/store/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/gorilla/securecookie"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/smartcontractkit/chainlink/logger"
+	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/utils"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -39,7 +40,7 @@ type Config struct {
 	LogLevel                 LogLevel        `env:"LOG_LEVEL" envDefault:"info"`
 	MinIncomingConfirmations uint64          `env:"MIN_INCOMING_CONFIRMATIONS" envDefault:"0"`
 	MinOutgoingConfirmations uint64          `env:"MIN_OUTGOING_CONFIRMATIONS" envDefault:"12"`
-	MinimumContractPayment   big.Int         `env:"MINIMUM_CONTRACT_PAYMENT" envDefault:"1000000000000000000"`
+	MinimumContractPayment   assets.Link     `env:"MINIMUM_CONTRACT_PAYMENT" envDefault:"1000000000000000000"`
 	MinimumRequestExpiration uint64          `env:"MINIMUM_REQUEST_EXPIRATION" envDefault:"300"`
 	OracleContractAddress    *common.Address `env:"ORACLE_CONTRACT_ADDRESS"`
 	Port                     string          `env:"CHAINLINK_PORT" envDefault:"6688"`
@@ -142,6 +143,7 @@ func parseEnv(cfg interface{}) error {
 	return env.ParseWithFuncs(cfg, env.CustomParsers{
 		reflect.TypeOf(&common.Address{}): addressParser,
 		reflect.TypeOf(big.Int{}):         bigIntParser,
+		reflect.TypeOf(assets.Link{}):     linkParser,
 		reflect.TypeOf(LogLevel{}):        levelParser,
 		reflect.TypeOf(Duration{}):        durationParser,
 	})
@@ -164,6 +166,14 @@ func bigIntParser(str string) (interface{}, error) {
 	i, ok := new(big.Int).SetString(str, 10)
 	if !ok {
 		return i, fmt.Errorf("Unable to parse %v into *big.Int(base 10)", str)
+	}
+	return *i, nil
+}
+
+func linkParser(str string) (interface{}, error) {
+	i, ok := new(assets.Link).SetString(str, 10)
+	if !ok {
+		return i, fmt.Errorf("Unable to parse %v into *assets.Link(base 10)", str)
 	}
 	return *i, nil
 }

--- a/store/config_test.go
+++ b/store/config_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
@@ -21,7 +22,7 @@ func TestStore_ConfigDefaults(t *testing.T) {
 	assert.Equal(t, uint64(0), config.ChainID)
 	assert.Equal(t, *big.NewInt(20000000000), config.EthGasPriceDefault)
 	assert.Equal(t, "0x514910771AF9Ca656af840dff83E8264EcF986CA", common.HexToAddress(config.LinkContractAddress).String())
-	assert.Equal(t, *big.NewInt(1000000000000000000), config.MinimumContractPayment)
+	assert.Equal(t, *assets.NewLink(1000000000000000000), config.MinimumContractPayment)
 	assert.Equal(t, 15*time.Minute, config.SessionTimeout.Duration)
 }
 

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/tidwall/gjson"
 	null "gopkg.in/guregu/null.v3"
 )
@@ -177,11 +178,11 @@ func (tr TaskRun) MarkPendingConfirmations() TaskRun {
 // RunResult keeps track of the outcome of a TaskRun or JobRun. It stores the
 // Data and ErrorMessage, and contains a Pending field to track the status.
 type RunResult struct {
-	JobRunID     string      `json:"jobRunId"`
-	Data         JSON        `json:"data"`
-	Status       RunStatus   `json:"status"`
-	ErrorMessage null.String `json:"error"`
-	Amount       *big.Int    `json:"amount,omitempty"`
+	JobRunID     string       `json:"jobRunId"`
+	Data         JSON         `json:"data"`
+	Status       RunStatus    `json:"status"`
+	ErrorMessage null.String  `json:"error"`
+	Amount       *assets.Link `json:"amount,omitempty"`
 }
 
 // WithValue returns a copy of the RunResult, overriding the "value" field of

--- a/store/models/service_agreement.go
+++ b/store/models/service_agreement.go
@@ -3,10 +3,10 @@ package models
 import (
 	"encoding/json"
 	"fmt"
-	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/utils"
 )
 
@@ -50,16 +50,17 @@ func generateServiceAgreementID(e Encumbrance, digest string) (string, error) {
 
 // Encumbrance connects job specifications with on-chain encumbrances.
 type Encumbrance struct {
-	Payment    *big.Int `json:"payment"`
-	Expiration uint64   `json:"expiration"`
+	Payment    *assets.Link `json:"payment"`
+	Expiration uint64       `json:"expiration"`
 }
 
 // ABI returns the encumbrance ABI encoded as a hex string.
 func (e Encumbrance) ABI() string {
-	if e.Payment == nil {
-		e.Payment = big.NewInt(0)
+	payment := e.Payment
+	if payment == nil {
+		payment = assets.NewLink(0)
 	}
-	return fmt.Sprintf("%064x%064x", e.Payment, e.Expiration)
+	return fmt.Sprintf("%064s%064x", payment.Text(16), e.Expiration)
 }
 
 // ServiceAgreementRequest represents a service agreement as requested over the wire.

--- a/store/presenters/presenters.go
+++ b/store/presenters/presenters.go
@@ -117,7 +117,7 @@ type ConfigWhitelist struct {
 	LogLevel                 store.LogLevel  `json:"logLevel"`
 	MinIncomingConfirmations uint64          `json:"minIncomingConfirmations"`
 	MinOutgoingConfirmations uint64          `json:"minOutgoingConfirmations"`
-	MinimumContractPayment   *big.Int        `json:"minimumContractPayment"`
+	MinimumContractPayment   *assets.Link    `json:"minimumContractPayment"`
 	MinimumRequestExpiration uint64          `json:"minimumRequestExpiration"`
 	OracleContractAddress    *common.Address `json:"oracleContractAddress"`
 	Port                     string          `json:"chainlinkPort"`

--- a/web/config_controller_test.go
+++ b/web/config_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store"
+	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 	"github.com/smartcontractkit/chainlink/web"
 	"github.com/stretchr/testify/assert"
@@ -41,7 +42,7 @@ func TestConfigController_Show(t *testing.T) {
 	assert.Equal(t, big.NewInt(5000000000), cwl.EthGasBumpWei)
 	assert.Equal(t, big.NewInt(20000000000), cwl.EthGasPriceDefault)
 	assert.Equal(t, "", cwl.LinkContractAddress)
-	assert.Equal(t, big.NewInt(cltest.MinimumContractPayment), cwl.MinimumContractPayment)
+	assert.Equal(t, assets.NewLink(100), cwl.MinimumContractPayment)
 	assert.Equal(t, (*common.Address)(nil), cwl.OracleContractAddress)
 	assert.Equal(t, store.Duration{Duration: time.Millisecond * 500}, cwl.DatabaseTimeout)
 }


### PR DESCRIPTION
This will now reject payments input in as float, which could be a source of errors.

Signed-off-by: Alex Kwiatkowski <alex+git@rival-studios.com>
Signed-off-by: John Barker <jebarker@gmail.com>