### PR TITLE
Remove unused and incorrect lazy_static dependency

### DIFF
--- a/sgx/enclave/Cargo.toml
+++ b/sgx/enclave/Cargo.toml
@@ -13,7 +13,6 @@ default = []
 [dependencies]
 utils = { path = "../utils", default-features = false }
 num = { path = "/opt/rust-sgx-sdk/third_party/num" }
-lazy_static = { path = "/opt/rust-sgx-sdk/third_party/lazy-static.rs" }
 serde = { path = "/opt/rust-sgx-sdk/third_party/serde-rs/serde/serde" }
 serde_derive = { path = "/opt/rust-sgx-sdk/third_party/serde-rs/serde/serde_derive" }
 serde_json = { path = "/opt/rust-sgx-sdk/third_party/serde-rs/json"}


### PR DESCRIPTION
Not sure how this got in there, looks like a weird copy and paste bug.