### PR TITLE
Add ES6 support for truffle tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "babel-plugin-transform-es3-member-expression-literals": "^6.22.0",
     "babel-plugin-transform-es3-property-literals": "^6.22.0",
     "babel-preset-stage-2": "^6.24.1",
+    "babel-register": "^6.26.0",
     "bignumber.js": "^7.2.1",
     "cbor": "^4.0.0",
     "enzyme": "^3.3.0",

--- a/solidity/test/Chainlinked_test.js
+++ b/solidity/test/Chainlinked_test.js
@@ -1,6 +1,4 @@
-'use strict'
-
-require('./support/helpers.js')
+import { checkPublicABI } from './support/helpers'
 
 contract('Chainlinked', () => {
   const sourcePath = 'Chainlinked.sol'

--- a/solidity/test/ConcreteChainlinkLib_test.js
+++ b/solidity/test/ConcreteChainlinkLib_test.js
@@ -1,6 +1,10 @@
-'use strict'
-
-require('./support/helpers.js')
+import cbor from 'cbor'
+import util from 'ethereumjs-util'
+import abi from 'ethereumjs-abi'
+import {
+  checkPublicABI,
+  deploy
+} from './support/helpers.js'
 
 contract('ConcreteChainlinkLib', () => {
   const sourcePath = 'examples/ConcreteChainlinkLib.sol'

--- a/solidity/test/ConcreteChainlinked_test.js
+++ b/solidity/test/ConcreteChainlinked_test.js
@@ -1,6 +1,14 @@
-'use strict'
-
-require('./support/helpers.js')
+import cbor from 'cbor'
+import {
+  assertActionThrows,
+  bigNum,
+  decodeRunABI,
+  deploy,
+  getEvents,
+  getLatestEvent,
+  toHex,
+  toWei
+} from './support/helpers'
 
 contract('ConcreteChainlinked', () => {
   const sourcePath = 'examples/ConcreteChainlinked.sol'

--- a/solidity/test/Consumer_test.js
+++ b/solidity/test/Consumer_test.js
@@ -1,6 +1,21 @@
-'use strict'
-
-require('./support/helpers.js')
+import cbor from 'cbor'
+import {
+  assertActionThrows,
+  consumer,
+  decodeRunRequest,
+  defaultAccount,
+  deploy,
+  eth,
+  functionSelector,
+  getLatestEvent,
+  hexToInt,
+  oracleNode,
+  rPad,
+  requestDataBytes,
+  requestDataFrom,
+  stranger,
+  toHex
+} from './support/helpers'
 
 contract('Consumer', () => {
   const sourcePath = 'examples/Consumer.sol'

--- a/solidity/test/Coordinator_test.js
+++ b/solidity/test/Coordinator_test.js
@@ -1,7 +1,5 @@
-'use strict'
-
-const { assertBigNum } = require('./support/matchers.js')
-require('./support/helpers.js')
+import { deploy, checkPublicABI, bigNum } from './support/helpers'
+import { assertBigNum } from './support/matchers'
 
 contract('Coordinator', () => {
   const sourcePath = 'Coordinator.sol'

--- a/solidity/test/GetterSetter_test.js
+++ b/solidity/test/GetterSetter_test.js
@@ -1,6 +1,4 @@
-'use strict'
-
-require('./support/helpers.js')
+import { _0x, rPad, deploy, stranger } from './support/helpers'
 
 contract('GetterSetter', () => {
   const sourcePath = 'examples/GetterSetter.sol'

--- a/solidity/test/Oracle_test.js
+++ b/solidity/test/Oracle_test.js
@@ -1,6 +1,16 @@
-'use strict'
-
-require('./support/helpers.js')
+import {
+  consumer,
+  defaultAccount,
+  deploy,
+  functionSelector,
+  oracleNode,
+  stranger,
+  toWei,
+  requestDataBytes,
+  checkPublicABI,
+  assertActionThrows,
+  requestDataFrom
+} from './support/helpers'
 
 contract('Oracle', () => {
   const sourcePath = 'Oracle.sol'

--- a/solidity/test/support/helpers.js
+++ b/solidity/test/support/helpers.js
@@ -1,16 +1,38 @@
-const Wallet = require('../../app/wallet.js');
-const Utils = require('../../app/utils.js');
-const Deployer = require('../../app/deployer.js');
+const Wallet = require('../../app/wallet.js')
+const Utils = require('../../app/utils.js')
+const Deployer = require('../../app/deployer.js')
 
-BigNumber = require('bignumber.js');
-moment = require('moment');
-abi = require('ethereumjs-abi');
-util = require('ethereumjs-util');
-cbor = require('cbor');
+const BigNumber = require('bignumber.js')
+const moment = require('moment')
+const abi = require('ethereumjs-abi')
+const util = require('ethereumjs-util')
+
+let _0x,
+  assertActionThrows,
+  bigNum,
+  checkPublicABI,
+  consumer,
+  decodeRunRequest,
+  decodeRunABI,
+  defaultAccount,
+  deploy,
+  eth,
+  functionSelector,
+  getEvents,
+  getLatestEvent,
+  hexToInt,
+  lPad,
+  oracleNode,
+  rPad,
+  requestDataBytes,
+  requestDataFrom,
+  stranger,
+  toHex,
+  toWei
 
 (() => {
   let utils, wallet, deployer
-  eth = web3.eth;
+  eth = web3.eth
 
   process.env.SOLIDITY_INCLUDE = '../../solidity/contracts/:../../solidity/contracts/examples/:../../contracts/:../../contracts/lib/:../../node_modules/:../../node_modules/linkToken/contracts'
 
@@ -45,7 +67,7 @@ cbor = require('cbor');
     // ==================
     // Mnemonic:      candy maple cake sugar pudding cream honey rich smooth crumble sweet treat
     // Base HD Path:  m/44'/60'/0'/0/{account_index}
-    accounts = eth.accounts
+    const accounts = eth.accounts
 
     defaultAccount = accounts[0]
     oracleNode = accounts[1]
@@ -56,262 +78,286 @@ cbor = require('cbor');
     utils = Utils(web3.currentProvider)
     wallet = Wallet(privateKey, utils)
     deployer = Deployer(wallet, utils)
-  });
+  })
 
   deploy = (filePath, ...args) => {
     return deployer.perform(filePath, ...args)
   }
 
-  Eth = function sendEth(method, params) {
+  const Eth = function sendEth (method, params) {
     params = params || []
 
     return new Promise((resolve, reject) => {
       web3.currentProvider.sendAsync({
-        jsonrpc: "2.0",
+        jsonrpc: '2.0',
         method: method,
         params: params || [],
         id: new Date().getTime()
-      }, function sendEthResponse(error, response) {
+      }, function sendEthResponse (error, response) {
         if (error) {
-          reject(error);
+          reject(error)
         } else {
-          resolve(response.result);
+          resolve(response.result)
         };
-      }, () => {}, () => {});
-    });
-  };
-
-  emptyAddress = '0x0000000000000000000000000000000000000000';
-
-  sealBlock = async function sealBlock() {
-    return Eth('evm_mine');
-  };
-
-  sendTransaction = async function sendTransaction(params) {
-    return await eth.sendTransaction(params);
+      }, () => {}, () => {})
+    })
   }
 
-  getBalance = async function getBalance(account) {
-    return bigNum(await eth.getBalance(account));
+  const emptyAddress = '0x0000000000000000000000000000000000000000'
+
+  const sealBlock = async function sealBlock () {
+    return Eth('evm_mine')
   }
 
-  bigNum = function bigNum(number) {
-    return web3.toBigNumber(number);
+  const sendTransaction = async function sendTransaction (params) {
+    return await eth.sendTransaction(params)
   }
 
-  toWei = function toWei(number) {
-    return bigNum(web3.toWei(number));
+  const getBalance = async function getBalance (account) {
+    return bigNum(await eth.getBalance(account))
   }
 
-  tokens = function tokens(number) {
-    return bigNum(number * 10**18);
+  bigNum = function bigNum (number) {
+    return web3.toBigNumber(number)
   }
 
-  intToHex = function intToHex(number) {
-    return '0x' + bigNum(number).toString(16);
+  toWei = number => {
+    return bigNum(web3.toWei(number))
   }
 
-  intToHexNoPrefix = function intToHex(number) {
-    return bigNum(number).toString(16);
+  const tokens = function tokens (number) {
+    return bigNum(number * 10 ** 18)
   }
 
-  hexToInt = function hexToInt(string) {
-    return web3.toBigNumber(string);
+  const intToHex = function intToHex (number) {
+    return '0x' + bigNum(number).toString(16)
   }
 
-  hexToAddress = function hexToAddress(string) {
-    return '0x' + string.slice(string.length - 40);
+  const intToHexNoPrefix = function intToHex (number) {
+    return bigNum(number).toString(16)
   }
 
-  unixTime = function unixTime(time) {
-    return moment(time).unix();
+  hexToInt = string => {
+    return web3.toBigNumber(string)
   }
 
-  seconds = function seconds(number) {
-    return number;
-  };
-
-  minutes = function minutes(number) {
-    return number * 60;
-  };
-
-  hours = function hours(number) {
-    return number * minutes(60);
-  };
-
-  days = function days(number) {
-    return number * hours(24);
-  };
-
-  keccak256 = function keccak256(string) {
-    return web3.sha3(string);
+  const hexToAddress = function hexToAddress (string) {
+    return '0x' + string.slice(string.length - 40)
   }
 
-  logTopic = function logTopic(string) {
-    let hash = keccak256(string);
-    return '0x' + hash.slice(26);
+  const unixTime = function unixTime (time) {
+    return moment(time).unix()
   }
 
-  getLatestBlock = async function getLatestBlock() {
-    return await eth.getBlock('latest', false);
-  };
+  const seconds = function seconds (number) {
+    return number
+  }
 
-  getLatestTimestamp = async function getLatestTimestamp () {
+  const minutes = function minutes (number) {
+    return number * 60
+  }
+
+  const hours = function hours (number) {
+    return number * minutes(60)
+  }
+
+  const days = function days (number) {
+    return number * hours(24)
+  }
+
+  const keccak256 = function keccak256 (string) {
+    return web3.sha3(string)
+  }
+
+  const logTopic = function logTopic (string) {
+    let hash = keccak256(string)
+    return '0x' + hash.slice(26)
+  }
+
+  const getLatestBlock = async function getLatestBlock () {
+    return await eth.getBlock('latest', false)
+  }
+
+  const getLatestTimestamp = async function getLatestTimestamp () {
     let latestBlock = await getLatestBlock()
-    return web3.toDecimal(latestBlock.timestamp);
-  };
+    return web3.toDecimal(latestBlock.timestamp)
+  }
 
-  fastForwardTo = async function fastForwardTo(target) {
-    let now = await getLatestTimestamp();
-    assert.isAbove(target, now, "Cannot fast forward to the past");
-    let difference = target - now;
-    await Eth("evm_increaseTime", [difference]);
-    await sealBlock();
-  };
+  const fastForwardTo = async function fastForwardTo (target) {
+    let now = await getLatestTimestamp()
+    assert.isAbove(target, now, 'Cannot fast forward to the past')
+    let difference = target - now
+    await Eth('evm_increaseTime', [difference])
+    await sealBlock()
+  }
 
-  getEvents = function getEvents(contract) {
+  getEvents = contract => {
     return new Promise((resolve, reject) => {
       contract.allEvents().get((error, events) => {
         if (error) {
-          reject(error);
+          reject(error)
         } else {
-          resolve(events);
+          resolve(events)
         };
-      });
-    });
-  };
+      })
+    })
+  }
 
-  eventsOfType = function eventsOfType(events, type) {
-    let filteredEvents = [];
+  const eventsOfType = function eventsOfType (events, type) {
+    let filteredEvents = []
     for (event of events) {
-      if (event.event === type) filteredEvents.push(event);
+      if (event.event === type) filteredEvents.push(event)
     }
-    return filteredEvents;
-  };
+    return filteredEvents
+  }
 
-  getEventsOfType = async function getEventsOfType(contract, type) {
-    return eventsOfType(await getEvents(contract), type);
-  };
+  const getEventsOfType = async function getEventsOfType (contract, type) {
+    return eventsOfType(await getEvents(contract), type)
+  }
 
-  getLatestEvent = async function getLatestEvent(contract) {
-    let events = await getEvents(contract);
-    return events[events.length - 1];
-  };
+  getLatestEvent = async (contract) => {
+    let events = await getEvents(contract)
+    return events[events.length - 1]
+  }
 
-  assertActionThrows = function assertActionThrows(action) {
+  assertActionThrows = action => {
     return Promise.resolve().then(action)
       .catch(error => {
-        assert(error, "Expected an error to be raised");
-        assert(error.message, "Expected an error to be raised");
-        return error.message;
+        assert(error, 'Expected an error to be raised')
+        assert(error.message, 'Expected an error to be raised')
+        return error.message
       })
       .then(errorMessage => {
-        assert(errorMessage, "Expected an error to be raised");
-        invalidOpcode = errorMessage.includes("invalid opcode")
-        reverted = errorMessage.includes("VM Exception while processing transaction: revert")
-        assert.isTrue(invalidOpcode || reverted, 'expected error message to include "invalid JUMP" or "revert"');
+        assert(errorMessage, 'Expected an error to be raised')
+        const invalidOpcode = errorMessage.includes('invalid opcode')
+        const reverted = errorMessage.includes('VM Exception while processing transaction: revert')
+        assert.isTrue(invalidOpcode || reverted, 'expected error message to include "invalid JUMP" or "revert"')
         // see https://github.com/ethereumjs/testrpc/issues/39
         // for why the "invalid JUMP" is the throw related error when using TestRPC
       })
-  };
-
-  encodeUint256 = function encodeUint256(int) {
-    let zeros = "0000000000000000000000000000000000000000000000000000000000000000";
-    let payload = int.toString(16);
-    return (zeros + payload).slice(payload.length);
   }
 
-  encodeAddress = function encodeAddress(address) {
-    return '000000000000000000000000' + address.slice(2);
+  const encodeUint256 = function encodeUint256 (int) {
+    let zeros = '0000000000000000000000000000000000000000000000000000000000000000'
+    let payload = int.toString(16)
+    return (zeros + payload).slice(payload.length)
   }
 
-  encodeBytes = function encodeBytes(bytes) {
-    let zeros = "0000000000000000000000000000000000000000000000000000000000000000";
-    let padded = bytes.padEnd(64, 0);
-    let length = encodeUint256(bytes.length / 2);
-    return length + padded;
+  const encodeAddress = function encodeAddress (address) {
+    return '000000000000000000000000' + address.slice(2)
   }
 
-  checkPublicABI = function checkPublicABI(contract, expectedPublic) {
-    let actualPublic = [];
-    for (method of contract.abi) {
-      if (method.type == 'function') actualPublic.push(method.name);
+  const encodeBytes = function encodeBytes (bytes) {
+    let zeros = '0000000000000000000000000000000000000000000000000000000000000000'
+    let padded = bytes.padEnd(64, 0)
+    let length = encodeUint256(bytes.length / 2)
+    return length + padded
+  }
+
+  checkPublicABI = function checkPublicABI (contract, expectedPublic) {
+    let actualPublic = []
+    for (const method of contract.abi) {
+      if (method.type === 'function') actualPublic.push(method.name)
     };
 
-    for (method of actualPublic) {
-      let index = expectedPublic.indexOf(method);
+    for (const method of actualPublic) {
+      let index = expectedPublic.indexOf(method)
       assert.isAtLeast(index, 0, (`#${method} is NOT expected to be public`))
     }
 
-    for (method of expectedPublic) {
-      let index = actualPublic.indexOf(method);
+    for (const method of expectedPublic) {
+      let index = actualPublic.indexOf(method)
       assert.isAtLeast(index, 0, (`#${method} is expected to be public`))
     }
-  };
+  }
 
-  functionSelector = function functionSelector(signature) {
-    return "0x" + web3.sha3(signature).slice(2).slice(0, 8);
-  };
+  functionSelector = (signature) => {
+    return '0x' + web3.sha3(signature).slice(2).slice(0, 8)
+  }
 
-  rPad = function rPad(string) {
-    let wordLen = parseInt((string.length + 31) / 32) * 32;
+  rPad = (string) => {
+    let wordLen = parseInt((string.length + 31) / 32) * 32
     for (let i = string.length; i < wordLen; i++) {
-      string = string + "\x00";
+      string = string + '\x00'
     }
     return string
-  };
+  }
 
-  lPad = function lPad(string) {
-    let wordLen = parseInt((string.length + 31) / 32) * 32;
+  lPad = (string) => {
+    let wordLen = parseInt((string.length + 31) / 32) * 32
     for (let i = string.length; i < wordLen; i++) {
-      string = "\x00" + string;
+      string = '\x00' + string
     }
     return string
-  };
+  }
 
-  lPadHex = function lPadHex(string) {
-    let wordLen = parseInt((string.length + 63) / 64) * 64;
+  const lPadHex = function lPadHex (string) {
+    let wordLen = parseInt((string.length + 63) / 64) * 64
     for (let i = string.length; i < wordLen; i++) {
-      string = "0" + string;
+      string = '0' + string
     }
     return string
-  };
+  }
 
-  toHex = function toHex(arg) {
+  toHex = arg => {
     if (arg instanceof Buffer) {
-      return arg.toString("hex");
+      return arg.toString('hex')
     } else {
-      return Buffer.from(arg, "ascii").toString("hex");
+      return Buffer.from(arg, 'ascii').toString('hex')
     }
-  };
+  }
 
-  decodeRunABI = function decodeRunABI(log) {
-    let runABI = util.toBuffer(log.data);
-    let types = ["bytes32", "address", "bytes4", "bytes"];
-    return abi.rawDecode(types, runABI);
-  };
+  decodeRunABI = log => {
+    let runABI = util.toBuffer(log.data)
+    let types = ['bytes32', 'address', 'bytes4', 'bytes']
+    return abi.rawDecode(types, runABI)
+  }
 
-  decodeRunRequest = function decodeRunRequest(log) {
-    let runABI = util.toBuffer(log.data);
-    let types = ["uint256", "bytes"];
-    let [version, data] = abi.rawDecode(types, runABI);
-    return [log.topics[1], log.topics[2], log.topics[3], version, data];
-  };
+  decodeRunRequest = log => {
+    let runABI = util.toBuffer(log.data)
+    let types = ['uint256', 'bytes']
+    let [version, data] = abi.rawDecode(types, runABI)
+    return [log.topics[1], log.topics[2], log.topics[3], version, data]
+  }
 
-  requestDataBytes = function requestDataBytes(specId, to, fHash, runId, data) {
-    let types = ["uint256", "bytes32", "address", "bytes4", "bytes32", "bytes"];
-    let values = [1, specId, to, fHash, runId, data];
-    let encoded = abi.rawEncode(types, values);
-    let funcSelector = functionSelector("requestData(uint256,bytes32,address,bytes4,bytes32,bytes)");
-    return funcSelector + encoded.toString("hex");
-  };
+  requestDataBytes = (specId, to, fHash, runId, data) => {
+    let types = ['uint256', 'bytes32', 'address', 'bytes4', 'bytes32', 'bytes']
+    let values = [1, specId, to, fHash, runId, data]
+    let encoded = abi.rawEncode(types, values)
+    let funcSelector = functionSelector('requestData(uint256,bytes32,address,bytes4,bytes32,bytes)')
+    return funcSelector + encoded.toString('hex')
+  }
 
-  requestDataFrom = function requestDataFrom(oc, link, amount, args) {
-    return link.transferAndCall(oc.address, amount, args);
-  };
+  requestDataFrom = (oc, link, amount, args) => {
+    return link.transferAndCall(oc.address, amount, args)
+  }
 
   _0x = (val) => {
     return `0x${toHex(val)}`
   }
+})()
 
-})();
+export {
+  _0x,
+  assertActionThrows,
+  bigNum,
+  checkPublicABI,
+  consumer,
+  decodeRunABI,
+  decodeRunRequest,
+  defaultAccount,
+  deploy,
+  eth,
+  functionSelector,
+  getEvents,
+  getLatestEvent,
+  hexToInt,
+  lPad,
+  oracleNode,
+  rPad,
+  requestDataBytes,
+  requestDataFrom,
+  stranger,
+  toHex,
+  toWei
+}

--- a/solidity/test/support/helpers.js
+++ b/solidity/test/support/helpers.js
@@ -2,8 +2,6 @@ const Wallet = require('../../app/wallet.js')
 const Utils = require('../../app/utils.js')
 const Deployer = require('../../app/deployer.js')
 
-const BigNumber = require('bignumber.js')
-const moment = require('moment')
 const abi = require('ethereumjs-abi')
 const util = require('ethereumjs-util')
 

--- a/solidity/test/support/helpers.js
+++ b/solidity/test/support/helpers.js
@@ -84,39 +84,6 @@ let _0x,
     return deployer.perform(filePath, ...args)
   }
 
-  const Eth = function sendEth (method, params) {
-    params = params || []
-
-    return new Promise((resolve, reject) => {
-      web3.currentProvider.sendAsync({
-        jsonrpc: '2.0',
-        method: method,
-        params: params || [],
-        id: new Date().getTime()
-      }, function sendEthResponse (error, response) {
-        if (error) {
-          reject(error)
-        } else {
-          resolve(response.result)
-        };
-      }, () => {}, () => {})
-    })
-  }
-
-  const emptyAddress = '0x0000000000000000000000000000000000000000'
-
-  const sealBlock = async function sealBlock () {
-    return Eth('evm_mine')
-  }
-
-  const sendTransaction = async function sendTransaction (params) {
-    return await eth.sendTransaction(params)
-  }
-
-  const getBalance = async function getBalance (account) {
-    return bigNum(await eth.getBalance(account))
-  }
-
   bigNum = function bigNum (number) {
     return web3.toBigNumber(number)
   }
@@ -125,70 +92,8 @@ let _0x,
     return bigNum(web3.toWei(number))
   }
 
-  const tokens = function tokens (number) {
-    return bigNum(number * 10 ** 18)
-  }
-
-  const intToHex = function intToHex (number) {
-    return '0x' + bigNum(number).toString(16)
-  }
-
-  const intToHexNoPrefix = function intToHex (number) {
-    return bigNum(number).toString(16)
-  }
-
   hexToInt = string => {
     return web3.toBigNumber(string)
-  }
-
-  const hexToAddress = function hexToAddress (string) {
-    return '0x' + string.slice(string.length - 40)
-  }
-
-  const unixTime = function unixTime (time) {
-    return moment(time).unix()
-  }
-
-  const seconds = function seconds (number) {
-    return number
-  }
-
-  const minutes = function minutes (number) {
-    return number * 60
-  }
-
-  const hours = function hours (number) {
-    return number * minutes(60)
-  }
-
-  const days = function days (number) {
-    return number * hours(24)
-  }
-
-  const keccak256 = function keccak256 (string) {
-    return web3.sha3(string)
-  }
-
-  const logTopic = function logTopic (string) {
-    let hash = keccak256(string)
-    return '0x' + hash.slice(26)
-  }
-
-  const getLatestBlock = async function getLatestBlock () {
-    return await eth.getBlock('latest', false)
-  }
-
-  const getLatestTimestamp = async function getLatestTimestamp () {
-    let latestBlock = await getLatestBlock()
-    return web3.toDecimal(latestBlock.timestamp)
-  }
-
-  const fastForwardTo = async function fastForwardTo (target) {
-    let now = await getLatestTimestamp()
-    assert.isAbove(target, now, 'Cannot fast forward to the past')
-    let difference = target - now
-    await Eth('evm_increaseTime', [difference])
-    await sealBlock()
   }
 
   getEvents = contract => {
@@ -201,18 +106,6 @@ let _0x,
         };
       })
     })
-  }
-
-  const eventsOfType = function eventsOfType (events, type) {
-    let filteredEvents = []
-    for (event of events) {
-      if (event.event === type) filteredEvents.push(event)
-    }
-    return filteredEvents
-  }
-
-  const getEventsOfType = async function getEventsOfType (contract, type) {
-    return eventsOfType(await getEvents(contract), type)
   }
 
   getLatestEvent = async (contract) => {
@@ -241,17 +134,6 @@ let _0x,
     let zeros = '0000000000000000000000000000000000000000000000000000000000000000'
     let payload = int.toString(16)
     return (zeros + payload).slice(payload.length)
-  }
-
-  const encodeAddress = function encodeAddress (address) {
-    return '000000000000000000000000' + address.slice(2)
-  }
-
-  const encodeBytes = function encodeBytes (bytes) {
-    let zeros = '0000000000000000000000000000000000000000000000000000000000000000'
-    let padded = bytes.padEnd(64, 0)
-    let length = encodeUint256(bytes.length / 2)
-    return length + padded
   }
 
   checkPublicABI = function checkPublicABI (contract, expectedPublic) {
@@ -287,14 +169,6 @@ let _0x,
     let wordLen = parseInt((string.length + 31) / 32) * 32
     for (let i = string.length; i < wordLen; i++) {
       string = '\x00' + string
-    }
-    return string
-  }
-
-  const lPadHex = function lPadHex (string) {
-    let wordLen = parseInt((string.length + 63) / 64) * 64
-    for (let i = string.length; i < wordLen; i++) {
-      string = '0' + string
     }
     return string
   }

--- a/solidity/test/support/matchers.js
+++ b/solidity/test/support/matchers.js
@@ -1,6 +1,4 @@
-module.exports = {
-  assertBigNum: (a, b) => assert(
-    a.equals(b),
-    `payment ${a} is not ${b}`
-  )
-}
+export const assertBigNum = (a, b) => assert(
+  a.equals(b),
+  `payment ${a} is not ${b}`
+)

--- a/solidity/truffle.js
+++ b/solidity/truffle.js
@@ -1,3 +1,6 @@
+require('babel-register');
+require('babel-polyfill');
+
 global.h = require('./helpers');
 
 module.exports = {


### PR DESCRIPTION
`support/helpers` has a bunch of pure functions that we can extract out of the closure if we would like. This PR just gets us up and running with modern syntax.