### PR TITLE
Added Routable Navigation

### DIFF
--- a/gui/src/components/JobList.js
+++ b/gui/src/components/JobList.js
@@ -58,6 +58,16 @@ export class JobList extends Component {
     fetchJobs(queryPage, pageSize)
   }
 
+  componentDidUpdate (prevProps) {
+    const prevJobPage = prevProps.match.params.jobPage
+    const currentJobPage = this.props.match.params.jobPage
+
+    if (prevJobPage !== currentJobPage) {
+      const { pageSize, fetchJobs } = this.props
+      fetchJobs(currentJobPage, pageSize)
+    }
+  }
+
   handleChangePage (e, page) {
     const {fetchJobs, pageSize} = this.props
     fetchJobs(page, pageSize)

--- a/gui/src/components/JobList.js
+++ b/gui/src/components/JobList.js
@@ -59,12 +59,14 @@ export class JobList extends Component {
   }
 
   componentDidUpdate (prevProps) {
-    const prevJobPage = prevProps.match.params.jobPage
-    const currentJobPage = this.props.match.params.jobPage
-
-    if (prevJobPage !== currentJobPage) {
-      const { pageSize, fetchJobs } = this.props
-      fetchJobs(currentJobPage, pageSize)
+    if(prevProps.match && this.props.match){
+      const prevJobPage = prevProps.match.params.jobPage
+      const currentJobPage = this.props.match.params.jobPage
+  
+      if (prevJobPage !== currentJobPage) {
+        const { pageSize, fetchJobs } = this.props
+        fetchJobs(currentJobPage, pageSize)
+      }
     }
   }
 

--- a/gui/src/components/TableButtons.js
+++ b/gui/src/components/TableButtons.js
@@ -20,7 +20,7 @@ const TableButtons = props => {
   const handlePage = page => e => {
     page = Math.min(page, lastPage)
     page = Math.max(page, firstPage)
-    if (props.history) props.history.replace(`${props.replaceWith}/${page}`)
+    if (props.history) props.history.push(`${props.replaceWith}/${page}`)
     props.onChangePage(e, page)
   }
 

--- a/gui/src/containers/JobSpecRuns.js
+++ b/gui/src/containers/JobSpecRuns.js
@@ -36,9 +36,19 @@ export class JobSpecRuns extends Component {
   componentDidMount () {
     const { jobSpecId, pageSize, fetchJobSpecRuns } = this.props
     const firstPage = 1
-    const queryPage = this.props.match ? (parseInt(this.props.match.params.jobRunsPage, 10) || firstPage) : firstPage
+    const queryPage = this.props.match ? parseInt(this.props.match.params.jobRunsPage, 10) || firstPage : firstPage
     this.setState({ page: queryPage })
     fetchJobSpecRuns(jobSpecId, queryPage, pageSize)
+  }
+
+  componentDidUpdate (prevProps) {
+    const prevJobRunsPage = prevProps.match.params.jobRunsPage
+    const currentJobRunsPage = this.props.match.params.jobRunsPage
+
+    if (prevJobRunsPage !== currentJobRunsPage) {
+      const { pageSize, fetchJobs } = this.props
+      fetchJobs(currentJobRunsPage, pageSize)
+    }
   }
 
   handleChangePage (e, page) {
@@ -132,9 +142,8 @@ const mapStateToProps = (state, ownProps) => {
   }
 }
 
-export const ConnectedJobSpecRuns = connect(
-  mapStateToProps,
-  matchRouteAndMapDispatchToProps({fetchJobSpecRuns})
-)(JobSpecRuns)
+export const ConnectedJobSpecRuns = connect(mapStateToProps, matchRouteAndMapDispatchToProps({ fetchJobSpecRuns }))(
+  JobSpecRuns
+)
 
 export default withStyles(styles)(ConnectedJobSpecRuns)


### PR DESCRIPTION
This fix propagates navigation to the history stack, however going back and forward doesn't call `fetchJobs()` in `<JobList />`. FetchJobs is called in ComponentDidMount [here](https://github.com/smartcontractkit/chainlink/blob/master/gui/src/components/JobList.js#L58), but back and forward buttons do not trigger `componentDidMount`. 