### PR TITLE
Extract SA build logic into constructor

### DIFF
--- a/internal/cltest/factories.go
+++ b/internal/cltest/factories.go
@@ -341,9 +341,7 @@ func (s MockSigner) Sign(input []byte) (string, error) {
 }
 
 func ServiceAgreementFromString(str string) models.ServiceAgreement {
-	var sar models.ServiceAgreementRequest
-	mustNotErr(json.Unmarshal([]byte(str), &sar))
-	sa, err := models.NewServiceAgreementFromRequest(sar, MockSigner{})
+	sa, err := models.NewServiceAgreementFromRequest(strings.NewReader(str), MockSigner{})
 	mustNotErr(err)
 	return sa
 }

--- a/store/models/job_spec.go
+++ b/store/models/job_spec.go
@@ -17,8 +17,13 @@ import (
 // for a given contract. It contains the Initiators, Tasks (which are the
 // individual steps to be carried out), StartAt, EndAt, and CreatedAt fields.
 type JobSpec struct {
-	ID         string      `json:"id" storm:"id,unique"`
-	CreatedAt  Time        `json:"createdAt" storm:"index"`
+	ID        string `json:"id" storm:"id,unique"`
+	CreatedAt Time   `json:"createdAt" storm:"index"`
+	JobSpecRequest
+}
+
+// JobSpecRequest represents a schema for the incoming job spec request as used by the API.
+type JobSpecRequest struct {
 	Initiators []Initiator `json:"initiators"`
 	Tasks      []TaskSpec  `json:"tasks" storm:"inline"`
 	StartAt    null.Time   `json:"startAt" storm:"index"`

--- a/store/models/service_agreement_test.go
+++ b/store/models/service_agreement_test.go
@@ -2,6 +2,7 @@ package models_test
 
 import (
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/internal/cltest"
@@ -33,10 +34,11 @@ func TestNewServiceAgreementFromRequest(t *testing.T) {
 			var sar models.ServiceAgreementRequest
 			assert.NoError(t, json.Unmarshal([]byte(test.input), &sar))
 
-			sa, err := models.NewServiceAgreementFromRequest(sar, cltest.MockSigner{})
+			sa, err := models.NewServiceAgreementFromRequest(strings.NewReader(test.input), cltest.MockSigner{})
 			assert.NoError(t, err)
 			assert.Equal(t, test.wantDigest, sa.ID)
 			assert.Equal(t, test.wantPayment, sa.Encumbrance.Payment)
+			assert.Equal(t, cltest.NormalizedJSON([]byte(test.input)), sa.RequestBody)
 			assert.NotEqual(t, models.Time{}, sa.CreatedAt)
 		})
 	}
@@ -90,8 +92,7 @@ func TestServiceAgreementRequest_UnmarshalJSON(t *testing.T) {
 			var sar models.ServiceAgreementRequest
 			assert.NoError(t, json.Unmarshal([]byte(test.input), &sar))
 
-			assert.Equal(t, test.wantPayment, sar.Encumbrance.Payment)
-			assert.Equal(t, cltest.NormalizedJSON([]byte(test.input)), sar.NormalizedBody)
+			assert.Equal(t, test.wantPayment, sar.Payment)
 		})
 	}
 }

--- a/store/models/v1.go
+++ b/store/models/v1.go
@@ -108,11 +108,13 @@ func (s AssignmentSpec) ConvertToJobSpec() (JobSpec, error) {
 	initiators = appendCronInitiator(initiators, s)
 
 	j := JobSpec{
-		ID:         utils.NewBytes32ID(),
-		CreatedAt:  Time{Time: time.Now()},
-		Tasks:      tasks,
-		EndAt:      null.TimeFrom(s.Schedule.EndAt.Time),
-		Initiators: initiators,
+		ID:        utils.NewBytes32ID(),
+		CreatedAt: Time{Time: time.Now()},
+		JobSpecRequest: JobSpecRequest{
+			Tasks:      tasks,
+			EndAt:      null.TimeFrom(s.Schedule.EndAt.Time),
+			Initiators: initiators,
+		},
 	}
 	if j.EndAt.Time.IsZero() {
 		j.EndAt.Valid = false

--- a/web/service_agreements_controller.go
+++ b/web/service_agreements_controller.go
@@ -19,12 +19,9 @@ type ServiceAgreementsController struct {
 
 // Create builds and saves a new service agreement record.
 func (sac *ServiceAgreementsController) Create(c *gin.Context) {
-	var sar models.ServiceAgreementRequest
 	if !sac.App.Store.Config.Dev {
 		publicError(c, 500, errors.New("Service Agreements are currently under development and not yet usable outside of development mode"))
-	} else if err := c.ShouldBindJSON(&sar); err != nil {
-		publicError(c, 400, err)
-	} else if sa, err := models.NewServiceAgreementFromRequest(sar, sac.App.Store.KeyStore); err != nil {
+	} else if sa, err := models.NewServiceAgreementFromRequest(c.Request.Body, sac.App.Store.KeyStore); err != nil {
 		publicError(c, 400, err)
 	} else if err = services.ValidateServiceAgreement(sa, sac.App.Store.Config); err != nil {
 		c.AbortWithError(400, err)


### PR DESCRIPTION
Simplify SAR unmarshalling and use it as a schema for accepted
parameters.

I think adding logic to `UnmarshalJSON` other than strictly deserializing is a bit of an anti pattern, so I wanted to avoid it. We've moved all constructor style logic to the constructor. Which now takes a reader so can work with the endpoints more easily.

ServiceAgreementRequest struct is meant to act as a schema for the request, separating this from the ServiceAgreement protects encapsulation. Since UnmarshalJSON can easily violate this and stomp over sensitive fields like ID (which has lead to security flaws in our protocol).

Signed-off-by: John Barker <jebarker@gmail.com>