### PR TITLE
improve oracle contract's current sender & amount parameter passing

### DIFF
--- a/examples/ropsten/contracts/RopstenConsumerBase.sol
+++ b/examples/ropsten/contracts/RopstenConsumerBase.sol
@@ -8,11 +8,11 @@ contract RopstenConsumer is Chainlinked, Ownable {
   bytes32 public lastMarket;
 
   address constant ROPSTEN_LINK_ADDRESS = 0x20fE562d797A42Dcb3399062AE9546cd06f63280;
-  address constant ROPSTEN_ORACLE_ADDRESS = 0xB68145133973411b7B3F2726A625FE3f3808240D;
+  address constant ROPSTEN_ORACLE_ADDRESS = 0x18170370BceC331F31d41B9b83DE772F5Bd47D82;
 
-  bytes32 constant PRICE_SPEC_ID = bytes32("8b05126a278f4f0abe02dd482aa802f8");
-  bytes32 constant CHANGE_SPEC_ID = bytes32("69cf308f8cee429c88eb25644d9f1c1d");
-  bytes32 constant MARKET_SPEC_ID = bytes32("ae18a03a2f5746ca967c403cf53e1318");
+  bytes32 constant PRICE_SPEC_ID = bytes32("3e775111aac649068669b192533490a6");
+  bytes32 constant CHANGE_SPEC_ID = bytes32("fa7d9b1c502f4f9684661679623638fc");
+  bytes32 constant MARKET_SPEC_ID = bytes32("626250ee99b74b68b8e2a27843d6a575");
   
   event RequestEthereumPriceFulfilled(
     bytes32 indexed requestId,

--- a/examples/ropsten/jobs/EthBytes32Job.json
+++ b/examples/ropsten/jobs/EthBytes32Job.json
@@ -2,7 +2,7 @@
   "initiators": [
     {
       "type": "runlog",
-      "address": "0xB68145133973411b7B3F2726A625FE3f3808240D"
+      "address": "0x18170370BceC331F31d41B9b83DE772F5Bd47D82"
     }
   ],
   "tasks": [

--- a/examples/ropsten/jobs/EthInt256Job.json
+++ b/examples/ropsten/jobs/EthInt256Job.json
@@ -2,7 +2,7 @@
   "initiators": [
     {
       "type": "runlog",
-      "address": "0xB68145133973411b7B3F2726A625FE3f3808240D"
+      "address": "0x18170370BceC331F31d41B9b83DE772F5Bd47D82"
     }
   ],
   "tasks": [

--- a/examples/ropsten/jobs/EthUint256Job.json
+++ b/examples/ropsten/jobs/EthUint256Job.json
@@ -2,7 +2,7 @@
   "initiators": [
     {
       "type": "runlog",
-      "address": "0xB68145133973411b7B3F2726A625FE3f3808240D"
+      "address": "0x18170370BceC331F31d41B9b83DE772F5Bd47D82"
     }
   ],
   "tasks": [

--- a/examples/uptime_sla/test/UptimeSLA_test.js
+++ b/examples/uptime_sla/test/UptimeSLA_test.js
@@ -1,109 +1,122 @@
-'use strict';
-
-require('./support/helpers.js')
+import cbor from 'cbor'
+import util from 'ethereumjs-util'
+import {
+  assertActionThrows,
+  days,
+  eth,
+  fastForwardTo,
+  functionSelector,
+  getEvents,
+  getLatestEvent,
+  getLatestTimestamp,
+  newAddress,
+  oracleNode,
+  requestDataBytes,
+  requestDataFrom
+} from './support/helpers'
 
 contract('UptimeSLA', () => {
-  let Link = artifacts.require("../../../solidity/contracts/LinkToken.sol");
-  let Oracle = artifacts.require("../../../solidity/contracts/Oracle.sol");
-  let SLA = artifacts.require("UptimeSLA.sol");
-  let specId = "4c7b7ffb66b344fbaa64995af81e355a";
-  let deposit = 1000000000;
-  let link, oc, sla, client, serviceProvider, startAt;
+  let Link = artifacts.require('../../../solidity/contracts/LinkToken.sol')
+  let Oracle = artifacts.require('../../../solidity/contracts/Oracle.sol')
+  let SLA = artifacts.require('UptimeSLA.sol')
+  let specId = '4c7b7ffb66b344fbaa64995af81e355a'
+  let deposit = 1000000000
+  let link, oc, sla, client, serviceProvider, startAt
 
   beforeEach(async () => {
     client = newAddress()
-    serviceProvider = newAddress();
-    link = await Link.new();
-    oc = await Oracle.new(link.address, {from: oracleNode});
+    serviceProvider = newAddress()
+    link = await Link.new()
+    oc = await Oracle.new(link.address, {from: oracleNode})
     sla = await SLA.new(client, serviceProvider, link.address, oc.address, specId, {
       value: deposit
-    });
-    link.transfer(sla.address, web3.toWei(1, 'ether'));
-    startAt = await getLatestTimestamp();
-  });
+    })
+    link.transfer(sla.address, web3.toWei(1, 'ether'))
+    startAt = await getLatestTimestamp()
+  })
 
   describe("before updates", () => {
     it("does not release money to anyone", async () => {
-      assert.equal(await eth.getBalance(sla.address), deposit);
-      assert.equal(await eth.getBalance(client), 0);
-      assert.equal(await eth.getBalance(serviceProvider), 0);
-    });
-  });
+      assert.equal(await eth.getBalance(sla.address), deposit)
+      assert.equal(await eth.getBalance(client), 0)
+      assert.equal(await eth.getBalance(serviceProvider), 0)
+    })
+  })
 
   describe("#updateUptime", () => {
     it("triggers a log event in the Oracle contract", async () => {
-      let tx = await sla.updateUptime("0");
+      let tx = await sla.updateUptime("0")
 
-      let events = await getEvents(oc);
+      let events = await getEvents(oc)
       assert.equal(1, events.length)
 
       let event = events[0]
-      assert.equal(web3.toUtf8(event.args.specId), specId);
+      assert.equal(web3.toUtf8(event.args.specId), specId)
 
-      let decoded = cbor.decodeFirstSync(util.toBuffer(event.args.data));
+      let decoded = cbor.decodeFirstSync(util.toBuffer(event.args.data))
       assert.deepEqual(
         decoded,
-        {"url":"https://status.heroku.com/api/ui/availabilities","path":["data","0","attributes","calculation"]}
+        {'url': 'https://status.heroku.com/api/ui/availabilities', 'path': ['data', '0', 'attributes', 'calculation']}
       )
-    });
-  });
+    })
+  })
 
-  describe("#fulfillData", () => {
-    let response = "0x00000000000000000000000000000000000000000000000000000000000f8c4c";
-    let requestId;
+  describe('#fulfillData', () => {
+    let response = '0x00000000000000000000000000000000000000000000000000000000000f8c4c'
+    let requestId
 
     beforeEach(async () => {
-      await sla.updateUptime("0");
-      let event = await getLatestEvent(oc);
+      await sla.updateUptime('0')
+      let event = await getLatestEvent(oc)
       requestId = event.args.internalId
-    });
+    })
 
     context("when the value is below 9999", async () => {
-      let response = "0x000000000000000000000000000000000000000000000000000000000000270e";
+      let response = "0x000000000000000000000000000000000000000000000000000000000000270e"
 
-      it("sends the deposit to the client", async () => {
+      it('sends the deposit to the client', async () => {
         await oc.fulfillData(requestId, response, {from: oracleNode})
 
-        assert.equal(await eth.getBalance(sla.address), 0);
-        assert.equal(await eth.getBalance(client), deposit);
-        assert.equal(await eth.getBalance(serviceProvider), 0);
-      });
-    });
+        assert.equal(await eth.getBalance(sla.address), 0)
+        assert.equal(await eth.getBalance(client), deposit)
+        assert.equal(await eth.getBalance(serviceProvider), 0)
+      })
+    })
 
     context("when the value is 9999 or above", () => {
-      let response = "0x000000000000000000000000000000000000000000000000000000000000270f";
+      let response = "0x000000000000000000000000000000000000000000000000000000000000270f"
 
-      it("does not move the money", async () => {
+      it('does not move the money', async () => {
         await oc.fulfillData(requestId, response, {from: oracleNode})
 
-        assert.equal(await eth.getBalance(sla.address), deposit);
-        assert.equal(await eth.getBalance(client), 0);
-        assert.equal(await eth.getBalance(serviceProvider), 0);
-      });
+        assert.equal(await eth.getBalance(sla.address), deposit)
+        assert.equal(await eth.getBalance(client), 0)
+        assert.equal(await eth.getBalance(serviceProvider), 0)
+      })
 
-      context("and a month has passed", () => {
+      context('and a month has passed', () => {
         beforeEach(async () => {
-          await fastForwardTo(startAt + days(30));
-        });
+          await fastForwardTo(startAt + days(30))
+        })
 
-        it("gives the money back to the service provider", async () => {
+        it('gives the money back to the service provider', async () => {
           await oc.fulfillData(requestId, response, {from: oracleNode})
 
-          assert.equal(await eth.getBalance(sla.address), 0);
-          assert.equal(await eth.getBalance(client), 0);
-          assert.equal(await eth.getBalance(serviceProvider), deposit);
-        });
-      });
-    });
+          assert.equal(await eth.getBalance(sla.address), 0)
+          assert.equal(await eth.getBalance(client), 0)
+          assert.equal(await eth.getBalance(serviceProvider), deposit)
+        })
+      })
+    })
 
-    context("when the consumer does not recognize the request ID", () => {
+    context('when the consumer does not recognize the request ID', () => {
       beforeEach(async () => {
-        let fid = functionSelector("report(uint256,bytes32)");
-        let args = requestDataBytes(specId, sla.address, fid, "xid", "");
-        await requestDataFrom(oc, link, 0, args);
-        let event = await getLatestEvent(oc);
-        requestId = event.args.internalId;
-      });
+        let fid = functionSelector("report(uint256,bytes32)")
+        let args = requestDataBytes(specId, sla.address, fid, "xid", "")
+        await requestDataFrom(oc, link, 0, args)
+        let event = await getLatestEvent(oc)
+        requestId = event.args.internalId
+      })
 
       it("does not accept the data provided", async () => {
         let originalUptime = await sla.uptime()
@@ -111,15 +124,15 @@ contract('UptimeSLA', () => {
         let newUptime = await sla.uptime()
 
         assert.isTrue(originalUptime.equals(newUptime))
-      });
-    });
+      })
+    })
 
-    context("when called by anyone other than the oracle contract", () => {
-      it("does not accept the data provided", async () => {
+    context('when called by anyone other than the oracle contract', () => {
+      it('does not accept the data provided', async () => {
         await assertActionThrows(async () => {
           await sla.report(requestId, response, {from: oracleNode})
-        });
-      });
-    });
-  });
-});
+        })
+      })
+    })
+  })
+})

--- a/examples/uptime_sla/test/UptimeSLA_test.js
+++ b/examples/uptime_sla/test/UptimeSLA_test.js
@@ -1,19 +1,21 @@
 import cbor from 'cbor'
 import util from 'ethereumjs-util'
 import {
-  assertActionThrows,
   days,
-  eth,
   fastForwardTo,
+  getLatestTimestamp,
+  newAddress
+} from './support/helpers'
+import {
+  assertActionThrows,
+  eth,
   functionSelector,
   getEvents,
   getLatestEvent,
-  getLatestTimestamp,
-  newAddress,
   oracleNode,
   requestDataBytes,
   requestDataFrom
-} from './support/helpers'
+} from '../../../solidity/test/support/helpers'
 
 contract('UptimeSLA', () => {
   let Link = artifacts.require('../../../solidity/contracts/LinkToken.sol')

--- a/examples/uptime_sla/test/support/helpers.js
+++ b/examples/uptime_sla/test/support/helpers.js
@@ -1,16 +1,16 @@
+import {
+  eth,
+  functionSelector,
+  getEvents
+} from '../../../../solidity/test/support/helpers'
+
 const BigNumber = require('bignumber.js')
 const abi = require('ethereumjs-abi')
 const cbor = require('cbor')
 const moment = require('moment')
 const util = require('ethereumjs-util')
 
-let eth,
-  Eth,
-  accounts,
-  Accounts,
-  oracleNode,
-  stranger,
-  consumer,
+let Eth,
   emptyAddress,
   sealBlock,
   sendTransaction,
@@ -31,33 +31,16 @@ let eth,
   getLatestBlock,
   getLatestTimestamp,
   fastForwardTo,
-  getEvents,
   eventsOfType,
   getEventsOfType,
-  getLatestEvent,
-  assertActionThrows,
   encodeUint256,
   encodeAddress,
   encodeBytes,
   checkPublicABI,
-  functionSelector,
   randomHex,
-  newAddress,
-  requestDataBytes,
-  requestDataFrom
+  newAddress
 
 (() => {
-  eth = web3.eth
-
-  before(async function () {
-    accounts = await eth.accounts
-    Accounts = accounts.slice(1)
-
-    oracleNode = Accounts[0]
-    stranger = Accounts[1]
-    consumer = Accounts[2]
-  })
-
   Eth = function sendEth (method, params) {
     params = params || []
 
@@ -161,18 +144,6 @@ let eth,
     await sealBlock()
   }
 
-  getEvents = function (contract) {
-    return new Promise((resolve, reject) => {
-      contract.allEvents().get((error, events) => {
-        if (error) {
-          reject(error)
-        } else {
-          resolve(events)
-        };
-      })
-    })
-  }
-
   eventsOfType = function (events, type) {
     let filteredEvents = []
     for (event of events) {
@@ -183,28 +154,6 @@ let eth,
 
   getEventsOfType = async function (contract, type) {
     return eventsOfType(await getEvents(contract), type)
-  }
-
-  getLatestEvent = async function (contract) {
-    let events = await getEvents(contract)
-    return events[events.length - 1]
-  }
-
-  assertActionThrows = function (action) {
-    return Promise.resolve().then(action)
-      .catch(error => {
-        assert(error, 'Expected an error to be raised')
-        assert(error.message, 'Expected an error to be raised')
-        return error.message
-      })
-      .then(errorMessage => {
-        assert(errorMessage, 'Expected an error to be raised')
-        const invalidOpcode = errorMessage.includes('invalid opcode')
-        const reverted = errorMessage.includes('VM Exception while processing transaction: revert')
-        assert.isTrue(invalidOpcode || reverted, 'expected error message to include "invalid JUMP" or "revert"')
-        // see https://github.com/ethereumjs/testrpc/issues/39
-        // for why the "invalid JUMP" is the throw related error when using TestRPC
-      })
   }
 
   encodeUint256 = function (int) {
@@ -241,10 +190,6 @@ let eth,
     }
   }
 
-  functionSelector = function (signature) {
-    return '0x' + web3.sha3(signature).slice(2).slice(0, 8)
-  }
-
   // https://codepen.io/code_monk/pen/FvpfI
   randomHex = function (len) {
     var maxlen = 8
@@ -261,42 +206,22 @@ let eth,
   newAddress = () => {
     return '0x' + randomHex(40)
   }
-
-  requestDataBytes = function requestDataBytes (jobId, to, fHash, runId, data) {
-    let types = ['address', 'uint256', 'uint256', 'bytes32', 'address', 'bytes4', 'bytes32', 'bytes']
-    let values = [0, 0, 1, jobId, to, fHash, runId, data]
-    let funcSelector = functionSelector('requestData(address,uint256,uint256,bytes32,address,bytes4,bytes32,bytes)')
-    let encoded = abi.rawEncode(types, values)
-    return funcSelector + encoded.toString('hex')
-  }
-
-  requestDataFrom = function requestDataFrom (oc, link, amount, args) {
-    return link.transferAndCall(oc.address, amount, args)
-  }
 })()
 
 export {
-  Accounts,
   Eth,
-  accounts,
-  assertActionThrows,
   bigNum,
   checkPublicABI,
-  consumer,
   days,
   emptyAddress,
   encodeAddress,
   encodeBytes,
   encodeUint256,
-  eth,
   eventsOfType,
   fastForwardTo,
-  functionSelector,
   getBalance,
-  getEvents,
   getEventsOfType,
   getLatestBlock,
-  getLatestEvent,
   getLatestTimestamp,
   hexToAddress,
   hexToInt,
@@ -306,14 +231,10 @@ export {
   logTopic,
   minutes,
   newAddress,
-  oracleNode,
   randomHex,
-  requestDataBytes,
-  requestDataFrom,
   sealBlock,
   seconds,
   sendTransaction,
-  stranger,
   toWei,
   tokens,
   unixTime

--- a/examples/uptime_sla/test/support/helpers.js
+++ b/examples/uptime_sla/test/support/helpers.js
@@ -1,241 +1,49 @@
-import {
-  eth,
-  functionSelector,
-  getEvents
-} from '../../../../solidity/test/support/helpers'
+import { eth } from '../../../../solidity/test/support/helpers'
 
-const BigNumber = require('bignumber.js')
-const abi = require('ethereumjs-abi')
-const cbor = require('cbor')
-const moment = require('moment')
-const util = require('ethereumjs-util')
+// https://codepen.io/code_monk/pen/FvpfI
+const randomHex = len => {
+  const maxlen = 8
+  const min = Math.pow(16, Math.min(len, maxlen) - 1)
+  const max = Math.pow(16, Math.min(len, maxlen)) - 1
+  const n = Math.floor(Math.random() * (max - min + 1)) + min
+  let r = n.toString(16)
+  while (r.length < len) {
+    r = r + randomHex(len - maxlen)
+  }
+  return r
+}
 
-let Eth,
-  emptyAddress,
-  sealBlock,
-  sendTransaction,
-  getBalance,
-  bigNum,
-  toWei,
-  tokens,
-  intToHex,
-  hexToInt,
-  hexToAddress,
-  unixTime,
-  seconds,
-  minutes,
-  hours,
-  days,
-  keccak256,
-  logTopic,
-  getLatestBlock,
-  getLatestTimestamp,
-  fastForwardTo,
-  eventsOfType,
-  getEventsOfType,
-  encodeUint256,
-  encodeAddress,
-  encodeBytes,
-  checkPublicABI,
-  randomHex,
-  newAddress
+export const newAddress = () => ('0x' + randomHex(40))
 
-(() => {
-  Eth = function sendEth (method, params) {
-    params = params || []
+export const getLatestTimestamp = async () => {
+  const latestBlock = await eth.getBlock('latest', false)
+  return web3.toDecimal(latestBlock.timestamp)
+}
 
-    return new Promise((resolve, reject) => {
-      web3.currentProvider.sendAsync({
+const sendEth = (method, params) => (
+  new Promise((resolve, reject) => {
+    web3.currentProvider.sendAsync(
+      {
         jsonrpc: '2.0',
         method: method,
         params: params || [],
         id: new Date().getTime()
-      }, function sendEthResponse (error, response) {
-        if (error) {
-          reject(error)
-        } else {
-          resolve(response.result)
-        };
-      }, () => {}, () => {})
-    })
-  }
+      },
+      (error, response) => (error ? reject(error) : resolve(response.result)),
+      () => {},
+      () => {}
+    )
+  })
+)
 
-  emptyAddress = '0x0000000000000000000000000000000000000000'
-
-  sealBlock = async function () {
-    return Eth('evm_mine')
-  }
-
-  sendTransaction = async function (params) {
-    return await eth.sendTransaction(params)
-  }
-
-  getBalance = async function (account) {
-    return bigNum(await eth.getBalance(account))
-  }
-
-  bigNum = function (number) {
-    return new BigNumber(number)
-  }
-
-  toWei = function (number) {
-    return web3.toWei(number)
-  }
-
-  tokens = function (number) {
-    return bigNum(number * 10 ** 18)
-  }
-
-  intToHex = function (number) {
-    return '0x' + bigNum(number).toString(16)
-  }
-
-  hexToInt = function (string) {
-    return web3.toBigNumber(string)
-  }
-
-  hexToAddress = function (string) {
-    return '0x' + string.slice(string.length - 40)
-  }
-
-  unixTime = function (time) {
-    return moment(time).unix()
-  }
-
-  seconds = function (number) {
-    return number
-  }
-
-  minutes = function (number) {
-    return number * 60
-  }
-
-  hours = function (number) {
-    return number * minutes(60)
-  }
-
-  days = function (number) {
-    return number * hours(24)
-  }
-
-  keccak256 = function (string) {
-    return web3.sha3(string)
-  }
-
-  logTopic = function (string) {
-    let hash = keccak256(string)
-    return '0x' + hash.slice(26)
-  }
-
-  getLatestBlock = async function () {
-    return await eth.getBlock('latest', false)
-  }
-
-  getLatestTimestamp = async function () {
-    let latestBlock = await getLatestBlock()
-    return web3.toDecimal(latestBlock.timestamp)
-  }
-
-  fastForwardTo = async function (target) {
-    let now = await getLatestTimestamp()
-    assert.isAbove(target, now, 'Cannot fast forward to the past')
-    let difference = target - now
-    await Eth('evm_increaseTime', [difference])
-    await sealBlock()
-  }
-
-  eventsOfType = function (events, type) {
-    let filteredEvents = []
-    for (event of events) {
-      if (event.event === type) filteredEvents.push(event)
-    }
-    return filteredEvents
-  }
-
-  getEventsOfType = async function (contract, type) {
-    return eventsOfType(await getEvents(contract), type)
-  }
-
-  encodeUint256 = function (int) {
-    let zeros = '0000000000000000000000000000000000000000000000000000000000000000'
-    let payload = int.toString(16)
-    return (zeros + payload).slice(payload.length)
-  }
-
-  encodeAddress = function (address) {
-    return '000000000000000000000000' + address.slice(2)
-  }
-
-  encodeBytes = function (bytes) {
-    let zeros = '0000000000000000000000000000000000000000000000000000000000000000'
-    let padded = bytes.padEnd(64, 0)
-    let length = encodeUint256(bytes.length / 2)
-    return length + padded
-  }
-
-  checkPublicABI = function (contract, expectedPublic) {
-    let actualPublic = []
-    for (method of contract.abi) {
-      if (method.type == 'function') actualPublic.push(method.name)
-    };
-
-    for (method of actualPublic) {
-      let index = expectedPublic.indexOf(method)
-      assert.isAtLeast(index, 0, (`#${method} is NOT expected to be public`))
-    }
-
-    for (method of expectedPublic) {
-      let index = actualPublic.indexOf(method)
-      assert.isAtLeast(index, 0, (`#${method} is expected to be public`))
-    }
-  }
-
-  // https://codepen.io/code_monk/pen/FvpfI
-  randomHex = function (len) {
-    var maxlen = 8
-    var min = Math.pow(16, Math.min(len, maxlen) - 1)
-    var max = Math.pow(16, Math.min(len, maxlen)) - 1
-    var n = Math.floor(Math.random() * (max - min + 1)) + min
-    var r = n.toString(16)
-    while (r.length < len) {
-      r = r + randomHex(len - maxlen)
-    }
-    return r
-  }
-
-  newAddress = () => {
-    return '0x' + randomHex(40)
-  }
-})()
-
-export {
-  Eth,
-  bigNum,
-  checkPublicABI,
-  days,
-  emptyAddress,
-  encodeAddress,
-  encodeBytes,
-  encodeUint256,
-  eventsOfType,
-  fastForwardTo,
-  getBalance,
-  getEventsOfType,
-  getLatestBlock,
-  getLatestTimestamp,
-  hexToAddress,
-  hexToInt,
-  hours,
-  intToHex,
-  keccak256,
-  logTopic,
-  minutes,
-  newAddress,
-  randomHex,
-  sealBlock,
-  seconds,
-  sendTransaction,
-  toWei,
-  tokens,
-  unixTime
+export const fastForwardTo = async target => {
+  const now = await getLatestTimestamp()
+  assert.isAbove(target, now, 'Cannot fast forward to the past')
+  const difference = target - now
+  await sendEth('evm_increaseTime', [difference])
+  await sendEth('evm_mine')
 }
+
+const minutes = number => number * 60
+const hours = number => (number * minutes(60))
+export const days = number => (number * hours(24))

--- a/examples/uptime_sla/test/support/helpers.js
+++ b/examples/uptime_sla/test/support/helpers.js
@@ -217,9 +217,9 @@ util = require('ethereumjs-util');
   };
 
   requestDataBytes = function requestDataBytes(jobId, to, fHash, runId, data) {
-    let types = ["uint256", "bytes32", "address", "bytes4", "bytes32", "bytes"];
-    let values = [1, jobId, to, fHash, runId, data];
-    let funcSelector = functionSelector("requestData(uint256,bytes32,address,bytes4,bytes32,bytes)");
+    let types = ["address", "uint256", "uint256", "bytes32", "address", "bytes4", "bytes32", "bytes"];
+    let values = [0, 0 ,1, jobId, to, fHash, runId, data];
+    let funcSelector = functionSelector("requestData(address,uint256,uint256,bytes32,address,bytes4,bytes32,bytes)");
     let encoded = abi.rawEncode(types, values);
     return funcSelector + encoded.toString("hex");
   };

--- a/examples/uptime_sla/test/support/helpers.js
+++ b/examples/uptime_sla/test/support/helpers.js
@@ -1,231 +1,320 @@
-BigNumber = require('bignumber.js');
-abi = require('ethereumjs-abi');
-cbor = require("cbor");
-moment = require('moment');
-util = require('ethereumjs-util');
+const BigNumber = require('bignumber.js')
+const abi = require('ethereumjs-abi')
+const cbor = require('cbor')
+const moment = require('moment')
+const util = require('ethereumjs-util')
+
+let eth,
+  Eth,
+  accounts,
+  Accounts,
+  oracleNode,
+  stranger,
+  consumer,
+  emptyAddress,
+  sealBlock,
+  sendTransaction,
+  getBalance,
+  bigNum,
+  toWei,
+  tokens,
+  intToHex,
+  hexToInt,
+  hexToAddress,
+  unixTime,
+  seconds,
+  minutes,
+  hours,
+  days,
+  keccak256,
+  logTopic,
+  getLatestBlock,
+  getLatestTimestamp,
+  fastForwardTo,
+  getEvents,
+  eventsOfType,
+  getEventsOfType,
+  getLatestEvent,
+  assertActionThrows,
+  encodeUint256,
+  encodeAddress,
+  encodeBytes,
+  checkPublicABI,
+  functionSelector,
+  randomHex,
+  newAddress,
+  requestDataBytes,
+  requestDataFrom
 
 (() => {
-  eth = web3.eth;
+  eth = web3.eth
 
   before(async function () {
-    accounts = await eth.accounts;
-    Accounts = accounts.slice(1);
+    accounts = await eth.accounts
+    Accounts = accounts.slice(1)
 
-    oracleNode = Accounts[0];
-    stranger = Accounts[1];
-    consumer = Accounts[2];
-  });
+    oracleNode = Accounts[0]
+    stranger = Accounts[1]
+    consumer = Accounts[2]
+  })
 
-  Eth = function sendEth(method, params) {
-    params = params || [];
+  Eth = function sendEth (method, params) {
+    params = params || []
 
     return new Promise((resolve, reject) => {
       web3.currentProvider.sendAsync({
-        jsonrpc: "2.0",
+        jsonrpc: '2.0',
         method: method,
         params: params || [],
         id: new Date().getTime()
-      }, function sendEthResponse(error, response) {
+      }, function sendEthResponse (error, response) {
         if (error) {
-          reject(error);
+          reject(error)
         } else {
-          resolve(response.result);
+          resolve(response.result)
         };
-      }, () => {}, () => {});
-    });
-  };
-
-  emptyAddress = '0x0000000000000000000000000000000000000000';
-
-  sealBlock = async function sealBlock() {
-    return Eth('evm_mine');
-  };
-
-  sendTransaction = async function sendTransaction(params) {
-    return await eth.sendTransaction(params);
+      }, () => {}, () => {})
+    })
   }
 
-  getBalance = async function getBalance(account) {
-    return bigNum(await eth.getBalance(account));
+  emptyAddress = '0x0000000000000000000000000000000000000000'
+
+  sealBlock = async function () {
+    return Eth('evm_mine')
   }
 
-  bigNum = function bigNum(number) {
-    return new BigNumber(number);
+  sendTransaction = async function (params) {
+    return await eth.sendTransaction(params)
   }
 
-  toWei = function toWei(number) {
-    return web3.toWei(number);
+  getBalance = async function (account) {
+    return bigNum(await eth.getBalance(account))
   }
 
-  tokens = function tokens(number) {
-    return bigNum(number * 10**18);
+  bigNum = function (number) {
+    return new BigNumber(number)
   }
 
-  intToHex = function intToHex(number) {
-    return '0x' + bigNum(number).toString(16);
+  toWei = function (number) {
+    return web3.toWei(number)
   }
 
-  hexToAddress = function hexToAddress(string) {
-    return '0x' + string.slice(string.length - 40);
+  tokens = function (number) {
+    return bigNum(number * 10 ** 18)
   }
 
-  unixTime = function unixTime(time) {
-    return moment(time).unix();
+  intToHex = function (number) {
+    return '0x' + bigNum(number).toString(16)
   }
 
-  seconds = function seconds(number) {
-    return number;
-  };
-
-  minutes = function minutes(number) {
-    return number * 60;
-  };
-
-  hours = function hours(number) {
-    return number * minutes(60);
-  };
-
-  days = function days(number) {
-    return number * hours(24);
-  };
-
-  keccak256 = function keccak256(string) {
-    return web3.sha3(string);
+  hexToInt = function (string) {
+    return web3.toBigNumber(string)
   }
 
-  logTopic = function logTopic(string) {
-    let hash = keccak256(string);
-    return '0x' + hash.slice(26);
+  hexToAddress = function (string) {
+    return '0x' + string.slice(string.length - 40)
   }
 
-  getLatestBlock = async function getLatestBlock() {
-    return await eth.getBlock('latest', false);
-  };
+  unixTime = function (time) {
+    return moment(time).unix()
+  }
 
-  getLatestTimestamp = async function getLatestTimestamp () {
+  seconds = function (number) {
+    return number
+  }
+
+  minutes = function (number) {
+    return number * 60
+  }
+
+  hours = function (number) {
+    return number * minutes(60)
+  }
+
+  days = function (number) {
+    return number * hours(24)
+  }
+
+  keccak256 = function (string) {
+    return web3.sha3(string)
+  }
+
+  logTopic = function (string) {
+    let hash = keccak256(string)
+    return '0x' + hash.slice(26)
+  }
+
+  getLatestBlock = async function () {
+    return await eth.getBlock('latest', false)
+  }
+
+  getLatestTimestamp = async function () {
     let latestBlock = await getLatestBlock()
-    return web3.toDecimal(latestBlock.timestamp);
-  };
+    return web3.toDecimal(latestBlock.timestamp)
+  }
 
-  fastForwardTo = async function fastForwardTo(target) {
-    let now = await getLatestTimestamp();
-    assert.isAbove(target, now, "Cannot fast forward to the past");
-    let difference = target - now;
-    await Eth("evm_increaseTime", [difference]);
-    await sealBlock();
-  };
+  fastForwardTo = async function (target) {
+    let now = await getLatestTimestamp()
+    assert.isAbove(target, now, 'Cannot fast forward to the past')
+    let difference = target - now
+    await Eth('evm_increaseTime', [difference])
+    await sealBlock()
+  }
 
-  getEvents = function getEvents(contract) {
+  getEvents = function (contract) {
     return new Promise((resolve, reject) => {
       contract.allEvents().get((error, events) => {
         if (error) {
-          reject(error);
+          reject(error)
         } else {
-          resolve(events);
+          resolve(events)
         };
-      });
-    });
-  };
+      })
+    })
+  }
 
-  eventsOfType = function eventsOfType(events, type) {
-    let filteredEvents = [];
+  eventsOfType = function (events, type) {
+    let filteredEvents = []
     for (event of events) {
-      if (event.event === type) filteredEvents.push(event);
+      if (event.event === type) filteredEvents.push(event)
     }
-    return filteredEvents;
-  };
+    return filteredEvents
+  }
 
-  getEventsOfType = async function getEventsOfType(contract, type) {
-    return eventsOfType(await getEvents(contract), type);
-  };
+  getEventsOfType = async function (contract, type) {
+    return eventsOfType(await getEvents(contract), type)
+  }
 
-  getLatestEvent = async function getLatestEvent(contract) {
-    let events = await getEvents(contract);
-    return events[events.length - 1];
-  };
+  getLatestEvent = async function (contract) {
+    let events = await getEvents(contract)
+    return events[events.length - 1]
+  }
 
-  assertActionThrows = function assertActionThrows(action) {
+  assertActionThrows = function (action) {
     return Promise.resolve().then(action)
       .catch(error => {
-        assert(error, "Expected an error to be raised");
-        assert(error.message, "Expected an error to be raised");
-        return error.message;
+        assert(error, 'Expected an error to be raised')
+        assert(error.message, 'Expected an error to be raised')
+        return error.message
       })
       .then(errorMessage => {
-        assert(errorMessage, "Expected an error to be raised");
-        invalidOpcode = errorMessage.includes("invalid opcode")
-        reverted = errorMessage.includes("VM Exception while processing transaction: revert")
-        assert.isTrue(invalidOpcode || reverted, 'expected error message to include "invalid JUMP" or "revert"');
+        assert(errorMessage, 'Expected an error to be raised')
+        const invalidOpcode = errorMessage.includes('invalid opcode')
+        const reverted = errorMessage.includes('VM Exception while processing transaction: revert')
+        assert.isTrue(invalidOpcode || reverted, 'expected error message to include "invalid JUMP" or "revert"')
         // see https://github.com/ethereumjs/testrpc/issues/39
         // for why the "invalid JUMP" is the throw related error when using TestRPC
       })
-  };
-
-  encodeUint256 = function encodeUint256(int) {
-    let zeros = "0000000000000000000000000000000000000000000000000000000000000000";
-    let payload = int.toString(16);
-    return (zeros + payload).slice(payload.length);
   }
 
-  encodeAddress = function encodeAddress(address) {
-    return '000000000000000000000000' + address.slice(2);
+  encodeUint256 = function (int) {
+    let zeros = '0000000000000000000000000000000000000000000000000000000000000000'
+    let payload = int.toString(16)
+    return (zeros + payload).slice(payload.length)
   }
 
-  encodeBytes = function encodeBytes(bytes) {
-    let zeros = "0000000000000000000000000000000000000000000000000000000000000000";
-    let padded = bytes.padEnd(64, 0);
-    let length = encodeUint256(bytes.length / 2);
-    return length + padded;
+  encodeAddress = function (address) {
+    return '000000000000000000000000' + address.slice(2)
   }
 
-  checkPublicABI = function checkPublicABI(contract, expectedPublic) {
-    let actualPublic = [];
+  encodeBytes = function (bytes) {
+    let zeros = '0000000000000000000000000000000000000000000000000000000000000000'
+    let padded = bytes.padEnd(64, 0)
+    let length = encodeUint256(bytes.length / 2)
+    return length + padded
+  }
+
+  checkPublicABI = function (contract, expectedPublic) {
+    let actualPublic = []
     for (method of contract.abi) {
-      if (method.type == 'function') actualPublic.push(method.name);
+      if (method.type == 'function') actualPublic.push(method.name)
     };
 
     for (method of actualPublic) {
-      let index = expectedPublic.indexOf(method);
+      let index = expectedPublic.indexOf(method)
       assert.isAtLeast(index, 0, (`#${method} is NOT expected to be public`))
     }
 
     for (method of expectedPublic) {
-      let index = actualPublic.indexOf(method);
+      let index = actualPublic.indexOf(method)
       assert.isAtLeast(index, 0, (`#${method} is expected to be public`))
     }
-  };
+  }
 
-  functionSelector = function functionSelector(signature) {
-    return "0x" + web3.sha3(signature).slice(2).slice(0, 8);
-  };
+  functionSelector = function (signature) {
+    return '0x' + web3.sha3(signature).slice(2).slice(0, 8)
+  }
 
   // https://codepen.io/code_monk/pen/FvpfI
-  randomHex = function randomHex(len) {
-    var maxlen = 8;
-    var min = Math.pow(16,Math.min(len,maxlen)-1);
-    var max = Math.pow(16,Math.min(len,maxlen)) - 1;
-    var n   = Math.floor( Math.random() * (max-min+1) ) + min;
-    var r   = n.toString(16);
-    while ( r.length < len ) {
-      r = r + randomHex(len - maxlen);
+  randomHex = function (len) {
+    var maxlen = 8
+    var min = Math.pow(16, Math.min(len, maxlen) - 1)
+    var max = Math.pow(16, Math.min(len, maxlen)) - 1
+    var n = Math.floor(Math.random() * (max - min + 1)) + min
+    var r = n.toString(16)
+    while (r.length < len) {
+      r = r + randomHex(len - maxlen)
     }
-    return r;
-  };
+    return r
+  }
 
-  newAddress = function newAddress() {
-    return "0x" + randomHex(40);
-  };
+  newAddress = () => {
+    return '0x' + randomHex(40)
+  }
 
-  requestDataBytes = function requestDataBytes(jobId, to, fHash, runId, data) {
-    let types = ["address", "uint256", "uint256", "bytes32", "address", "bytes4", "bytes32", "bytes"];
-    let values = [0, 0 ,1, jobId, to, fHash, runId, data];
-    let funcSelector = functionSelector("requestData(address,uint256,uint256,bytes32,address,bytes4,bytes32,bytes)");
-    let encoded = abi.rawEncode(types, values);
-    return funcSelector + encoded.toString("hex");
-  };
+  requestDataBytes = function requestDataBytes (jobId, to, fHash, runId, data) {
+    let types = ['address', 'uint256', 'uint256', 'bytes32', 'address', 'bytes4', 'bytes32', 'bytes']
+    let values = [0, 0, 1, jobId, to, fHash, runId, data]
+    let funcSelector = functionSelector('requestData(address,uint256,uint256,bytes32,address,bytes4,bytes32,bytes)')
+    let encoded = abi.rawEncode(types, values)
+    return funcSelector + encoded.toString('hex')
+  }
 
-  requestDataFrom = function requestDataFrom(oc, link, amount, args) {
-    return link.transferAndCall(oc.address, amount, args);
-  };
+  requestDataFrom = function requestDataFrom (oc, link, amount, args) {
+    return link.transferAndCall(oc.address, amount, args)
+  }
+})()
 
-})();
+export {
+  Accounts,
+  Eth,
+  accounts,
+  assertActionThrows,
+  bigNum,
+  checkPublicABI,
+  consumer,
+  days,
+  emptyAddress,
+  encodeAddress,
+  encodeBytes,
+  encodeUint256,
+  eth,
+  eventsOfType,
+  fastForwardTo,
+  functionSelector,
+  getBalance,
+  getEvents,
+  getEventsOfType,
+  getLatestBlock,
+  getLatestEvent,
+  getLatestTimestamp,
+  hexToAddress,
+  hexToInt,
+  hours,
+  intToHex,
+  keccak256,
+  logTopic,
+  minutes,
+  newAddress,
+  oracleNode,
+  randomHex,
+  requestDataBytes,
+  requestDataFrom,
+  sealBlock,
+  seconds,
+  sendTransaction,
+  stranger,
+  toWei,
+  tokens,
+  unixTime
+}

--- a/examples/uptime_sla/test/support/helpers.js
+++ b/examples/uptime_sla/test/support/helpers.js
@@ -1,20 +1,5 @@
 import { eth } from '../../../../solidity/test/support/helpers'
 
-// https://codepen.io/code_monk/pen/FvpfI
-const randomHex = len => {
-  const maxlen = 8
-  const min = Math.pow(16, Math.min(len, maxlen) - 1)
-  const max = Math.pow(16, Math.min(len, maxlen)) - 1
-  const n = Math.floor(Math.random() * (max - min + 1)) + min
-  let r = n.toString(16)
-  while (r.length < len) {
-    r = r + randomHex(len - maxlen)
-  }
-  return r
-}
-
-export const newAddress = () => ('0x' + randomHex(40))
-
 export const getLatestTimestamp = async () => {
   const latestBlock = await eth.getBlock('latest', false)
   return web3.toDecimal(latestBlock.timestamp)

--- a/examples/uptime_sla/truffle.js
+++ b/examples/uptime_sla/truffle.js
@@ -1,11 +1,14 @@
+require('babel-register')
+require('babel-polyfill')
+
 module.exports = {
-  network: "test",
+  network: 'test',
   networks: {
     development: {
-      host: "127.0.0.1",
+      host: '127.0.0.1',
       port: 18545,
-      network_id: "*",
+      network_id: '*',
       gas: 4700000
     }
   }
-};
+}

--- a/solidity/contracts/ChainlinkLib.sol
+++ b/solidity/contracts/ChainlinkLib.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.24;
 import "solidity-cborutils/contracts/CBOR.sol";
 
 library ChainlinkLib {
-  bytes4 internal constant oracleRequestDataFid = bytes4(keccak256("requestData(uint256,bytes32,address,bytes4,bytes32,bytes)"));
+  bytes4 internal constant oracleRequestDataFid = bytes4(keccak256("requestData(address,uint256,uint256,bytes32,address,bytes4,bytes32,bytes)"));
 
   using CBOR for Buffer.buffer;
 
@@ -35,6 +35,8 @@ library ChainlinkLib {
   ) internal pure returns (bytes memory) {
     return abi.encodeWithSelector(
       oracleRequestDataFid,
+      0, // overridden by onTokenTransfer
+      0, // overridden by onTokenTransfer
       _clArgsVersion,
       self.specId,
       self.callbackAddress,
@@ -63,7 +65,7 @@ library ChainlinkLib {
     self.buf.encodeString(_key);
     self.buf.encodeInt(_value);
   }
-  
+
   function addUint(Run memory self, string _key, uint256 _value)
     internal pure
   {

--- a/solidity/contracts/Coordinator.sol
+++ b/solidity/contracts/Coordinator.sol
@@ -33,7 +33,9 @@ contract Coordinator {
     bytes32 _requestDigest
   ) public
   {
-    require((_oracles.length == _vs.length) && (_vs.length == _rs.length) && (_rs.length == _ss.length), "Must pass in as many signatures as oracles");
+    require((_oracles.length == _vs.length) &&
+            (_vs.length == _rs.length) &&
+            (_rs.length == _ss.length), "Must pass in as many signatures as oracles");
 
     bytes32 serviceAgreementID = getId(_payment, _expiration, _oracles, _requestDigest);
 

--- a/solidity/contracts/Coordinator.sol
+++ b/solidity/contracts/Coordinator.sol
@@ -33,9 +33,7 @@ contract Coordinator {
     bytes32 _requestDigest
   ) public
   {
-    require((_oracles.length == _vs.length) &&
-            (_vs.length == _rs.length) &&
-            (_rs.length == _ss.length), "Must pass in as many signatures as oracles");
+    require(_oracles.length == _vs.length && _vs.length == _rs.length && _rs.length == _ss.length, "Must pass in as many signatures as oracles");
 
     bytes32 serviceAgreementID = getId(_payment, _expiration, _oracles, _requestDigest);
 

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -42,8 +42,12 @@ contract Oracle is Ownable {
     public
     onlyLINK
   {
-    // solium-disable-next-line security/no-low-level-calls
-    assembly { calldatacopy(add(_data, 36), 4, 64) } // ensures correct sender and amount are passed
+    assembly {
+      // solium-disable security/no-low-level-calls
+      mstore(add(_data, 36), _sender) // ensure correct sender is passed
+      // solium-disable security/no-low-level-calls
+      mstore(add(_data, 68), _wei)    // ensure correct amount is passed
+    }
     // solium-disable-next-line security/no-low-level-calls
     require(address(this).delegatecall(_data), "Unable to create request"); // calls requestData
   }

--- a/solidity/contracts/examples/MaliciousChainlinkLib.sol
+++ b/solidity/contracts/examples/MaliciousChainlinkLib.sol
@@ -60,7 +60,7 @@ library MaliciousChainlinkLib {
     return abi.encodeWithSelector(
       oracleRequestDataFid,
       address(this), // overridden by onTokenTransfer
-      1 ether,       // overridden by onTokenTransfer
+      100 ether,     // overridden by onTokenTransfer
       _clArgsVersion,
       self.specId,
       self.callbackAddress,

--- a/solidity/contracts/examples/MaliciousChainlinkLib.sol
+++ b/solidity/contracts/examples/MaliciousChainlinkLib.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.4.24;
 import "solidity-cborutils/contracts/CBOR.sol";
 
 library MaliciousChainlinkLib {
-  bytes4 internal constant oracleRequestDataFid = bytes4(keccak256("requestData(uint256,bytes32,address,bytes4,bytes32,bytes)"));
+  bytes4 internal constant oracleRequestDataFid = bytes4(keccak256("requestData(address,uint256,uint256,bytes32,address,bytes4,bytes32,bytes)"));
   bytes4 internal constant oracleWithdrawFid = bytes4(keccak256("withdraw(address)"));
 
   using CBOR for Buffer.buffer;
@@ -56,9 +56,11 @@ library MaliciousChainlinkLib {
   function encodeForOracle(
     Run memory self,
     uint256 _clArgsVersion
-  ) internal pure returns (bytes memory) {
+  ) internal view returns (bytes memory) {
     return abi.encodeWithSelector(
       oracleRequestDataFid,
+      address(this), // overridden by onTokenTransfer
+      1 ether,       // overridden by onTokenTransfer
       _clArgsVersion,
       self.specId,
       self.callbackAddress,
@@ -98,7 +100,7 @@ library MaliciousChainlinkLib {
     self.buf.encodeString(_key);
     self.buf.encodeInt(_value);
   }
-  
+
   function addUint(Run memory self, string _key, uint256 _value)
     internal pure
   {

--- a/solidity/test/Consumer_test.js
+++ b/solidity/test/Consumer_test.js
@@ -70,7 +70,7 @@ contract('Consumer', () => {
 
       it('has a reasonable gas cost', async () => {
         let tx = await cc.requestEthereumPrice(currency)
-        assert.isBelow(tx.receipt.gasUsed, 190000)
+        assert.isBelow(tx.receipt.gasUsed, 165000)
       })
     })
   })

--- a/solidity/test/Oracle_test.js
+++ b/solidity/test/Oracle_test.js
@@ -184,7 +184,7 @@ contract('Oracle', () => {
       })
     })
 
-    context('malicious consumer', () => {
+    context('with a malicious consumer/requester', () => {
       const paymentAmount = h.toWei(1)
 
       beforeEach(async () => {
@@ -267,8 +267,8 @@ contract('Oracle', () => {
         })
       })
 
-      context('lies about amount sent', () => {
-        it('reports the correct amount of LINK paid', async () => {
+      context('requester lies about amount of LINK sent', () => {
+        it('the oracle uses the amount of LINK actually paid', async () => {
           const req = await mock.requestData('assertFail(bytes32,bytes32)')
           const log = req.receipt.logs[2]
 

--- a/solidity/test/support/helpers.js
+++ b/solidity/test/support/helpers.js
@@ -159,10 +159,10 @@ export const decodeRunRequest = log => {
 }
 
 export const requestDataBytes = (specId, to, fHash, runId, data) => {
-  let types = ['uint256', 'bytes32', 'address', 'bytes4', 'bytes32', 'bytes']
-  let values = [1, specId, to, fHash, runId, data]
+  let types = ['address', 'uint256', 'uint256', 'bytes32', 'address', 'bytes4', 'bytes32', 'bytes']
+  let values = [0, 0, 1, specId, to, fHash, runId, data]
   let encoded = abi.rawEncode(types, values)
-  let funcSelector = functionSelector('requestData(uint256,bytes32,address,bytes4,bytes32,bytes)')
+  let funcSelector = functionSelector('requestData(address,uint256,uint256,bytes32,address,bytes4,bytes32,bytes)')
   return funcSelector + encoded.toString('hex')
 }
 


### PR DESCRIPTION
The oracle contract now assumes that all methods called through
onTokenTransfer have the first two parameters of currentSender and
currentAmount. Before passing data onto the designated method, it
overwrites those parameters to make sure that they are the correct
values.