### PR TITLE
Generate SAID in Coordinator contract

### DIFF
--- a/examples/uptime_sla/test/support/helpers.js
+++ b/examples/uptime_sla/test/support/helpers.js
@@ -65,10 +65,6 @@ util = require('ethereumjs-util');
     return '0x' + bigNum(number).toString(16);
   }
 
-  hexToInt = function hexToInt(string) {
-    return web3.toBigNumber(string);
-  }
-
   hexToAddress = function hexToAddress(string) {
     return '0x' + string.slice(string.length - 40);
   }

--- a/integration/features_test.go
+++ b/integration/features_test.go
@@ -543,5 +543,5 @@ func TestIntegration_CreateServiceAgreement(t *testing.T) {
 
 	assert.Equal(t, assets.NewLink(1000000000000000000), sa.Encumbrance.Payment)
 	assert.Equal(t, uint64(300), sa.Encumbrance.Expiration)
-	cltest.AssertValidHash(t, 32, sa.ID)
+	assert.NotEqual(t, "", sa.ID)
 }

--- a/internal/cltest/factories.go
+++ b/internal/cltest/factories.go
@@ -336,8 +336,8 @@ func NewJobRunner(s *store.Store) (services.JobRunner, func()) {
 
 type MockSigner struct{}
 
-func (s MockSigner) Sign(input []byte) (string, error) {
-	return "0xc7106c5877b5bd321e5aac3842cd6ae68faf21e7e6ee45556b13f7b386104381", nil
+func (s MockSigner) Sign(input []byte) (models.Signature, error) {
+	return models.NewSignature("0xb7a987222fc36c4c8ed1b91264867a422769998aadbeeb1c697586a04fa2b616025b5ca936ec5bdb150999e298b6ecf09251d3c4dd1306dedec0692e7037584800")
 }
 
 func ServiceAgreementFromString(str string) (models.ServiceAgreement, error) {

--- a/solidity/app/deployer.js
+++ b/solidity/app/deployer.js
@@ -11,7 +11,7 @@ module.exports = function Deployer (wallet, utils) {
     contract.setProvider(utils.provider)
     contract.defaults({
       from: wallet.address,
-      gas: 2500000,
+      gas: 3500000,
       gasPrice: 10000000000
     })
     return contract.at(address)

--- a/solidity/contracts/Coordinator.sol
+++ b/solidity/contracts/Coordinator.sol
@@ -3,7 +3,6 @@ pragma experimental ABIEncoderV2; //solium-disable-line
 
 // Coordinator handles oracle service aggreements between one or more oracles.
 contract Coordinator {
-
   struct ServiceAgreement {
     uint256 payment;
     uint256 expiration;
@@ -28,16 +27,38 @@ contract Coordinator {
     uint256 _payment,
     uint256 _expiration,
     address[] _oracles,
+    uint8[] _vs,
+    bytes32[] _rs,
+    bytes32[] _ss,
     bytes32 _requestDigest
   ) public
   {
-    bytes32 id = getId(_payment, _expiration, _oracles, _requestDigest);
+    require((_oracles.length == _vs.length) && (_vs.length == _rs.length) && (_rs.length == _ss.length), "Must pass in as many signatures as oracles");
 
-    serviceAgreements[id] = ServiceAgreement(
+    bytes32 serviceAgreementID = getId(_payment, _expiration, _oracles, _requestDigest);
+
+    for (uint i = 0; i < _oracles.length; i++) {
+      address signer = getOracleAddressFromSASignature(serviceAgreementID, _vs[i], _rs[i], _ss[i]);
+      require(_oracles[i] == signer, "Invalid oracle signature specified in SA");
+    }
+
+    serviceAgreements[serviceAgreementID] = ServiceAgreement(
       _payment,
       _expiration,
       _oracles,
       _requestDigest
     );
+  }
+
+  function getOracleAddressFromSASignature(
+    bytes32 _serviceAgreementID,
+    uint8 _v,
+    bytes32 _r,
+    bytes32 _s
+  )
+    private pure returns (address)
+  {
+    bytes32 prefixedHash = keccak256(abi.encodePacked("\x19Ethereum Signed Message:\n32", _serviceAgreementID));
+    return ecrecover(prefixedHash, _v, _r, _s);
   }
 }

--- a/solidity/test/ConcreteChainlinked_test.js
+++ b/solidity/test/ConcreteChainlinked_test.js
@@ -6,7 +6,7 @@ import {
   deploy,
   getEvents,
   getLatestEvent,
-  toHex,
+  toHexWithoutPrefix,
   toWei
 } from './support/helpers'
 
@@ -35,7 +35,7 @@ contract('ConcreteChainlinked', () => {
 
       assert.equal(specId, jId)
       assert.equal(gs.address, `0x${cbAddr}`)
-      assert.equal('ed53e511', toHex(cbFId))
+      assert.equal('ed53e511', toHexWithoutPrefix(cbFId))
       assert.deepEqual({}, params)
     })
   })

--- a/solidity/test/Consumer_test.js
+++ b/solidity/test/Consumer_test.js
@@ -1,29 +1,45 @@
 import cbor from 'cbor'
-import * as h from './support/helpers'
+import {
+  assertActionThrows,
+  consumer,
+  decodeRunRequest,
+  defaultAccount,
+  deploy,
+  eth,
+  functionSelector,
+  getLatestEvent,
+  hexToInt,
+  newHash,
+  oracleNode,
+  requestDataBytes,
+  requestDataFrom,
+  stranger,
+  toHex
+} from './support/helpers'
 
 contract('Consumer', () => {
   const sourcePath = 'examples/Consumer.sol'
-  let specId = '4c7b7ffb66b344fbaa64995af81e355a'
+  let specId = newHash('0x4c7b7ffb66b344fbaa64995af81e355a')
   let currency = 'USD'
   let link, oc, cc
 
   beforeEach(async () => {
-    link = await h.deploy('LinkToken.sol')
-    oc = await h.deploy('Oracle.sol', link.address)
-    await oc.transferOwnership(h.oracleNode, {from: h.defaultAccount})
-    cc = await h.deploy(sourcePath, link.address, oc.address, specId)
-    await cc.transferOwnership(h.consumer, {from: h.defaultAccount})
+    link = await deploy('LinkToken.sol')
+    oc = await deploy('Oracle.sol', link.address)
+    await oc.transferOwnership(oracleNode, {from: defaultAccount})
+    cc = await deploy(sourcePath, link.address, oc.address, toHex(specId))
+    await cc.transferOwnership(consumer, {from: defaultAccount})
   })
 
   it('has a predictable gas price', async () => {
-    const rec = await h.eth.getTransactionReceipt(cc.transactionHash)
+    const rec = await eth.getTransactionReceipt(cc.transactionHash)
     assert.isBelow(rec.gasUsed, 1600000)
   })
 
   describe('#requestEthereumPrice', () => {
     context('without LINK', () => {
       it('reverts', async () => {
-        await h.assertActionThrows(async () => {
+        await assertActionThrows(async () => {
           await cc.requestEthereumPrice(currency)
         })
       })
@@ -39,15 +55,15 @@ contract('Consumer', () => {
         let log = tx.receipt.logs[2]
         assert.equal(log.address, oc.address)
 
-        let [id, jId, wei, ver, cborData] = h.decodeRunRequest(log)
+        let [id, jId, wei, ver, cborData] = decodeRunRequest(log)
         let params = await cbor.decodeFirst(cborData)
         let expected = {
           'path': ['USD'],
           'url': 'https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=USD,EUR,JPY'
         }
 
-        assert.equal(`0x${h.toHex(h.rPad(specId))}`, jId)
-        assert.equal(web3.toWei('1', 'ether'), h.hexToInt(wei))
+        assert.equal(toHex(specId), jId)
+        assert.equal(web3.toWei('1', 'ether'), hexToInt(wei))
         assert.equal(1, ver)
         assert.deepEqual(expected, params)
       })
@@ -66,19 +82,19 @@ contract('Consumer', () => {
     beforeEach(async () => {
       await link.transfer(cc.address, web3.toWei('1', 'ether'))
       await cc.requestEthereumPrice(currency)
-      let event = await h.getLatestEvent(oc)
+      let event = await getLatestEvent(oc)
       internalId = event.args.internalId
     })
 
     it('records the data given to it by the oracle', async () => {
-      await oc.fulfillData(internalId, response, {from: h.oracleNode})
+      await oc.fulfillData(internalId, response, {from: oracleNode})
 
       let currentPrice = await cc.currentPrice.call()
       assert.equal(web3.toUtf8(currentPrice), response)
     })
 
     it('logs the data given to it by the oracle', async () => {
-      let tx = await oc.fulfillData(internalId, response, {from: h.oracleNode})
+      let tx = await oc.fulfillData(internalId, response, {from: oracleNode})
       assert.equal(2, tx.receipt.logs.length)
       let log = tx.receipt.logs[0]
 
@@ -89,15 +105,15 @@ contract('Consumer', () => {
       let otherId
 
       beforeEach(async () => {
-        let funcSig = h.functionSelector('fulfill(bytes32,bytes32)')
-        let args = h.requestDataBytes(specId, cc.address, funcSig, 42, '')
-        await h.requestDataFrom(oc, link, 0, args)
-        let event = await h.getLatestEvent(oc)
+        let funcSig = functionSelector('fulfill(bytes32,bytes32)')
+        let args = requestDataBytes(toHex(specId), cc.address, funcSig, 42, '')
+        await requestDataFrom(oc, link, 0, args)
+        let event = await getLatestEvent(oc)
         otherId = event.args.internalId
       })
 
       it('does not accept the data provided', async () => {
-        await oc.fulfillData(otherId, response, {from: h.oracleNode})
+        await oc.fulfillData(otherId, response, {from: oracleNode})
 
         let received = await cc.currentPrice.call()
         assert.equal(web3.toUtf8(received), '')
@@ -106,8 +122,8 @@ contract('Consumer', () => {
 
     context('when called by anyone other than the oracle contract', () => {
       it('does not accept the data provided', async () => {
-        await h.assertActionThrows(async () => {
-          await cc.fulfill(internalId, response, {from: h.oracleNode})
+        await assertActionThrows(async () => {
+          await cc.fulfill(internalId, response, {from: oracleNode})
         })
 
         let received = await cc.currentPrice.call()
@@ -122,20 +138,20 @@ contract('Consumer', () => {
     beforeEach(async () => {
       await link.transfer(cc.address, web3.toWei('1', 'ether'))
       await cc.requestEthereumPrice(currency)
-      requestId = (await h.getLatestEvent(cc)).args.id
+      requestId = (await getLatestEvent(cc)).args.id
     })
 
     context('when called by a non-owner', () => {
       it('cannot cancel a request', async () => {
-        await h.assertActionThrows(async () => {
-          await cc.cancelRequest(requestId, {from: h.stranger})
+        await assertActionThrows(async () => {
+          await cc.cancelRequest(requestId, {from: stranger})
         })
       })
     })
 
     context('when called by the owner', () => {
       it('can cancel the request', async () => {
-        await cc.cancelRequest(requestId, {from: h.consumer})
+        await cc.cancelRequest(requestId, {from: consumer})
       })
     })
   })

--- a/solidity/test/GetterSetter_test.js
+++ b/solidity/test/GetterSetter_test.js
@@ -1,8 +1,8 @@
-import { _0x, rPad, deploy, stranger } from './support/helpers'
+import { deploy, stranger } from './support/helpers'
 
 contract('GetterSetter', () => {
   const sourcePath = 'examples/GetterSetter.sol'
-  const requestId = _0x(rPad('5432'))
+  const requestId = '0x3bd198932d9cc01e2950ffc518fd38a303812200000000000000000000000000'
   const bytes32 = 'Hi Mom!'
   const uint256 = 645746535432
   let gs

--- a/store/key_store.go
+++ b/store/key_store.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/accounts/keystore"
-	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/utils"
 )
 
@@ -61,22 +61,23 @@ func (ks *KeyStore) SignTx(tx *types.Transaction, chainID uint64) (*types.Transa
 }
 
 // Sign creates an HMAC from some input data using the account's private key
-func (ks *KeyStore) Sign(input []byte) (string, error) {
+func (ks *KeyStore) Sign(input []byte) (models.Signature, error) {
 	account, err := ks.GetAccount()
 	if err != nil {
-		return "", err
+		return models.Signature{}, err
 	}
 	hash, err := utils.Keccak256(input)
 	if err != nil {
-		return "", err
+		return models.Signature{}, err
 	}
 
 	output, err := ks.KeyStore.SignHash(account, hash)
-
 	if err != nil {
-		return "", err
+		return models.Signature{}, err
 	}
-	return common.ToHex(output), nil
+	var signature models.Signature
+	signature.SetBytes(output)
+	return signature, nil
 }
 
 // GetAccount returns the unlocked account in the KeyStore object. The client

--- a/store/models/orm_test.go
+++ b/store/models/orm_test.go
@@ -102,8 +102,11 @@ func TestORM_SaveServiceAgreement(t *testing.T) {
 			assert.NoError(t, err)
 
 			assert.NoError(t, store.SaveServiceAgreement(&sa))
-			sa = cltest.FindServiceAgreement(store, sa.ID)
-			cltest.FindJob(store, sa.JobSpecID)
+
+			sa, err = store.FindServiceAgreement(sa.ID)
+			assert.NoError(t, err)
+			_, err = store.FindJob(sa.JobSpecID)
+			assert.NoError(t, err)
 		})
 	}
 }

--- a/store/models/service_agreement.go
+++ b/store/models/service_agreement.go
@@ -1,10 +1,11 @@
 package models
 
 import (
+	"bytes"
 	"encoding/json"
-	"fmt"
 	"io"
 	"io/ioutil"
+	"math/big"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -19,7 +20,7 @@ type ServiceAgreement struct {
 	ID          string      `json:"id" storm:"id,unique"`
 	JobSpecID   string      `json:"jobSpecID"`
 	RequestBody string      `json:"requestBody"`
-	Signature   string      `json:"signature"`
+	Signature   Signature   `json:"signature"`
 	JobSpec     JobSpec     // JobSpec is used during the initial SA creation.
 	// If needed later, it can be retrieved from the database with JobSpecID.
 }
@@ -36,13 +37,14 @@ func (sa ServiceAgreement) GetName() string {
 
 // SetID is used to set the ID of this structure when deserializing from jsonapi documents.
 func (sa *ServiceAgreement) SetID(value string) error {
+	//sa.ID.SetString(value)
 	sa.ID = value
 	return nil
 }
 
 // Signer is used to produce a HMAC signature from an input digest
 type Signer interface {
-	Sign(input []byte) (string, error)
+	Sign(input []byte) (Signature, error)
 }
 
 // NewServiceAgreementFromRequest builds a new ServiceAgreement.
@@ -64,7 +66,6 @@ func NewServiceAgreementFromRequest(reader io.Reader, signer Signer) (ServiceAgr
 	}
 
 	requestDigest, err := utils.Keccak256([]byte(normalized))
-	digest := common.ToHex(requestDigest)
 
 	encumbrance := Encumbrance{
 		Payment:    sar.Payment,
@@ -72,12 +73,12 @@ func NewServiceAgreementFromRequest(reader io.Reader, signer Signer) (ServiceAgr
 		Oracles:    sar.Oracles,
 	}
 
-	id, err := generateServiceAgreementID(encumbrance, digest)
+	id, err := generateServiceAgreementID(encumbrance, common.BytesToHash(requestDigest))
 	if err != nil {
 		return ServiceAgreement{}, err
 	}
 
-	signature, err := signer.Sign([]byte(id))
+	signature, err := signer.Sign(id.Bytes())
 	if err != nil {
 		return ServiceAgreement{}, err
 	}
@@ -89,7 +90,7 @@ func NewServiceAgreementFromRequest(reader io.Reader, signer Signer) (ServiceAgr
 	jobSpec.StartAt = sar.StartAt
 
 	return ServiceAgreement{
-		ID:          id,
+		ID:          id.String(),
 		CreatedAt:   Time{time.Now()},
 		Encumbrance: encumbrance,
 		JobSpec:     jobSpec,
@@ -98,13 +99,33 @@ func NewServiceAgreementFromRequest(reader io.Reader, signer Signer) (ServiceAgr
 	}, nil
 }
 
-func generateServiceAgreementID(e Encumbrance, digest string) (string, error) {
-	b, err := utils.HexToBytes(e.ABI(), digest)
+func generateServiceAgreementID(e Encumbrance, digest common.Hash) (common.Hash, error) {
+	buffer, err := serviceAgreementIDInputBuffer(e, digest)
 	if err != nil {
-		return "", err
+		return common.Hash{}, nil
 	}
-	bytesID, err := utils.Keccak256(b)
-	return common.ToHex(bytesID), err
+
+	bytes, err := utils.Keccak256(buffer.Bytes())
+	return common.BytesToHash(bytes), err
+}
+
+func serviceAgreementIDInputBuffer(encumbrance Encumbrance, digest common.Hash) (bytes.Buffer, error) {
+	buffer := bytes.Buffer{}
+
+	encumberanceBytes, err := encumbrance.ABI()
+	if err != nil {
+		return bytes.Buffer{}, err
+	}
+	_, err = buffer.Write(encumberanceBytes)
+	if err != nil {
+		return bytes.Buffer{}, err
+	}
+
+	_, err = buffer.Write(digest.Bytes())
+	if err != nil {
+		return bytes.Buffer{}, err
+	}
+	return buffer, nil
 }
 
 // Encumbrance connects job specifications with on-chain encumbrances.
@@ -114,13 +135,42 @@ type Encumbrance struct {
 	Oracles    []EIP55Address `json:"oracles"`
 }
 
-// ABI returns the encumbrance ABI encoded as a hex string.
-func (e Encumbrance) ABI() string {
-	payment := e.Payment
-	if payment == nil {
-		payment = assets.NewLink(0)
+// ABI packs the encumberance as a byte array using the same technique as
+// abi.encodePacked, meaning that addresses are padded with left 0s to match
+// hashes in the oracle list
+func (e Encumbrance) ABI() ([]byte, error) {
+	buffer := bytes.Buffer{}
+	var paymentHash common.Hash
+	if e.Payment != nil {
+		paymentHash = e.Payment.ToHash()
 	}
-	return fmt.Sprintf("%064s%064x", payment.Text(16), e.Expiration)
+	_, err := buffer.Write(paymentHash.Bytes())
+	if err != nil {
+		return []byte{}, err
+	}
+	expirationHash := common.BigToHash((*big.Int)(new(big.Int).SetUint64(e.Expiration)))
+	_, err = buffer.Write(expirationHash.Bytes())
+	if err != nil {
+		return []byte{}, err
+	}
+
+	err = encodeOracles(&buffer, e.Oracles)
+	if err != nil {
+		return []byte{}, err
+	}
+	return buffer.Bytes(), nil
+}
+
+func encodeOracles(buffer *bytes.Buffer, oracles []EIP55Address) error {
+	for _, o := range oracles {
+		// XXX: Solidity packs addresses as hashes when doing abi.encodePacking, so mirror here
+		oracleAddressHash := common.BytesToHash(o.Bytes())
+		_, err := buffer.Write(oracleAddressHash.Bytes())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // ServiceAgreementRequest represents a service agreement as requested over the wire.

--- a/store/models/signature.go
+++ b/store/models/signature.go
@@ -1,0 +1,86 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+)
+
+const (
+	// SignatureLength is the length of the signature in bytes: v = 1, r = 32, s
+	// = 32; v + r + s = 65
+	SignatureLength = 65
+)
+
+// Signature is a byte array fixed to the size of a signature
+type Signature [SignatureLength]byte
+
+// NewSignature returns a new Signature
+func NewSignature(s string) (Signature, error) {
+	bytes := common.FromHex(s)
+	return BytesToSignature(bytes), nil
+}
+
+// BytesToSignature converts an arbitrary length byte array to a Signature
+func BytesToSignature(b []byte) Signature {
+	var s Signature
+	s.SetBytes(b)
+	return s
+}
+
+// Bytes returns the raw bytes
+func (s Signature) Bytes() []byte { return s[:] }
+
+// Big returns a big.Int representation
+func (s Signature) Big() *big.Int { return new(big.Int).SetBytes(s[:]) }
+
+// Hex returns a hexadecimal string
+func (s Signature) Hex() string { return hexutil.Encode(s[:]) }
+
+// String implements the stringer interface and is used also by the logger.
+func (s Signature) String() string {
+	return s.Hex()
+}
+
+// Format implements fmt.Formatter
+func (s Signature) Format(state fmt.State, c rune) {
+	fmt.Fprintf(state, "%"+string(c), s.String())
+}
+
+// SetBytes assigns the byte array to the signature
+func (s *Signature) SetBytes(b []byte) {
+	if len(b) > len(s) {
+		b = b[len(b)-SignatureLength:]
+	}
+
+	copy(s[SignatureLength-len(b):], b)
+}
+
+// UnmarshalText parses the signature from a hexadecimal representation
+func (s *Signature) UnmarshalText(input []byte) error {
+	var err error
+	*s, err = NewSignature(string(input))
+	return err
+}
+
+// MarshalText encodes the signature in hexadecimal
+func (s Signature) MarshalText() ([]byte, error) {
+	return []byte(s.String()), nil
+}
+
+// UnmarshalJSON parses a signature from a JSON string
+func (s *Signature) UnmarshalJSON(input []byte) error {
+	if isString(input) {
+		input = input[1 : len(input)-1]
+	}
+
+	return s.UnmarshalText([]byte(input))
+}
+
+// MarshalJSON prints the signature as a hexadecimal encoded string
+func (s Signature) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}

--- a/store/models/signature_test.go
+++ b/store/models/signature_test.go
@@ -1,0 +1,42 @@
+package models
+
+import (
+	"encoding/json"
+	"fmt"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSignature(t *testing.T) {
+	str := "0xb7a987222fc36c4c8ed1b91264867a422769998aadbeeb1c697586a04fa2b616025b5ca936ec5bdb150999e298b6ecf09251d3c4dd1306dedec0692e7037584800"
+	signature, err := NewSignature(str)
+	assert.NoError(t, err)
+
+	assert.Equal(t, []byte{
+		0xb7, 0xa9, 0x87, 0x22, 0x2f, 0xc3, 0x6c, 0x4c, 0x8e, 0xd1, 0xb9, 0x12,
+		0x64, 0x86, 0x7a, 0x42, 0x27, 0x69, 0x99, 0x8a, 0xad, 0xbe, 0xeb, 0x1c,
+		0x69, 0x75, 0x86, 0xa0, 0x4f, 0xa2, 0xb6, 0x16, 0x02, 0x5b, 0x5c, 0xa9,
+		0x36, 0xec, 0x5b, 0xdb, 0x15, 0x09, 0x99, 0xe2, 0x98, 0xb6, 0xec, 0xf0,
+		0x92, 0x51, 0xd3, 0xc4, 0xdd, 0x13, 0x06, 0xde, 0xde, 0xc0, 0x69, 0x2e,
+		0x70, 0x37, 0x58, 0x48, 0x00,
+	}, signature.Bytes())
+
+	bi, _ := (new(big.Int)).SetString("b7a987222fc36c4c8ed1b91264867a422769998aadbeeb1c697586a04fa2b616025b5ca936ec5bdb150999e298b6ecf09251d3c4dd1306dedec0692e7037584800", 16)
+	assert.Equal(t, bi, signature.Big())
+
+	assert.Equal(t, str, signature.String())
+
+	assert.Equal(t, str, fmt.Sprintf("%s", signature))
+
+	zerosignature := Signature{}
+	err = json.Unmarshal([]byte(`"0xb7a987222fc36c4c8ed1b91264867a422769998aadbeeb1c697586a04fa2b616025b5ca936ec5bdb150999e298b6ecf09251d3c4dd1306dedec0692e7037584800"`), &zerosignature)
+	assert.NoError(t, err)
+	assert.Equal(t, str, zerosignature.String())
+
+	zerosignature = Signature{}
+	err = zerosignature.UnmarshalText([]byte(str))
+	assert.NoError(t, err)
+	assert.Equal(t, str, zerosignature.String())
+}

--- a/web/service_agreements_controller.go
+++ b/web/service_agreements_controller.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/asdine/storm"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin"
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/smartcontractkit/chainlink/services"
@@ -38,8 +39,8 @@ func (sac *ServiceAgreementsController) Create(c *gin.Context) {
 // Example:
 //  "<application>/service_agreements/:SAID"
 func (sac *ServiceAgreementsController) Show(c *gin.Context) {
-	id := c.Param("SAID")
-	if sa, err := sac.App.Store.FindServiceAgreement(id); err == storm.ErrNotFound {
+	id := common.HexToHash(c.Param("SAID"))
+	if sa, err := sac.App.Store.FindServiceAgreement(id.String()); err == storm.ErrNotFound {
 		publicError(c, 404, errors.New("ServiceAgreement not found"))
 	} else if err != nil {
 		c.AbortWithError(500, err)

--- a/web/service_agreements_controller_test.go
+++ b/web/service_agreements_controller_test.go
@@ -43,12 +43,12 @@ func TestServiceAgreementsController_Create(t *testing.T) {
 				body := cltest.ParseResponseBody(resp)
 				err := web.ParseJSONAPIResponse(body, &responseSA)
 				assert.NoError(t, err)
-				cltest.AssertValidHash(t, 32, responseSA.ID)
-				cltest.AssertValidHash(t, 65, responseSA.Signature)
+				assert.NotEqual(t, "", responseSA.ID)
+				assert.NotEqual(t, "", responseSA.Signature.String())
 
 				createdSA := cltest.FindServiceAgreement(app.Store, responseSA.ID)
-				cltest.AssertValidHash(t, 32, createdSA.ID)
-				cltest.AssertValidHash(t, 65, createdSA.Signature)
+				assert.NotEqual(t, "", createdSA.ID)
+				assert.NotEqual(t, "", createdSA.Signature.String())
 			}
 		})
 	}


### PR DESCRIPTION
The coordinator contract now generates the SAID from the input parameters (encumbrance + digest), the ABI for the encumbrance now returns a buffer, rather than string, and that is signed. Some small cleanups to solidity tests to make hex/hexWithoutPrefix/buffers more explicit.