### PR TITLE
Add Zeppelin plugin for Solium

### DIFF
--- a/.soliumrc.json
+++ b/.soliumrc.json
@@ -1,12 +1,33 @@
 {
   "extends": "solium:recommended",
-  "plugins": ["security"],
+  "plugins": ["security", "zeppelin"],
   "rules": {
     "indentation": ["error", 2],
     "no-experimental": "error",
     "quotes": ["error", "double"],
     "security/no-block-members": "off",
     "security/no-inline-assembly": "off",
-    "security/no-low-level-calls": "error"
+    "security/no-low-level-calls": "error",
+    "zeppelin/constant-candidates": [
+      "warning"
+    ],
+    "zeppelin/highlight-comments": [
+      "warning"
+    ],
+    "zeppelin/missing-natspec-comments": [
+      "off"
+    ],
+    "zeppelin/no-arithmetic-operations": [
+      "error"
+    ],
+    "zeppelin/no-state-variable-shadowing": [
+      "warning"
+    ],
+    "zeppelin/no-unchecked-send": [
+      "error"
+    ],
+    "zeppelin/no-unused-imports": [
+      "error"
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "snazzy": "^7.1.1",
     "solc": "^0.4.24",
     "solium": "^1.1.8",
+    "solium-plugin-zeppelin": "^0.0.2",
     "standard": "^11.0.1",
     "truffle": "^4.1.14",
     "truffle-contract": "^3.0.6",

--- a/solidity/contracts/examples/ConcreteChainlinkLib.sol
+++ b/solidity/contracts/examples/ConcreteChainlinkLib.sol
@@ -65,7 +65,7 @@ contract ConcreteChainlinkLib {
     bytes memory bytesString = new bytes(32);
     uint charCount = 0;
     for (uint j = 0; j < 32; j++) {
-      byte char = byte(bytes32(uint(x) * 2 ** (8 * j)));
+      byte char = byte(bytes32(uint(x) * 2 ** (8 * j))); //solium-disable-line
       if (char != 0) {
         bytesString[charCount] = char;
         charCount++;


### PR DESCRIPTION
I think it's a good time that we add the [Zeppelin plugin for Solium](https://github.com/OpenZeppelin/solium-plugin-zeppelin) to our project. Very glad to see we only had one problem, but it was in our ConcreteChainlinkLib.sol contract, which is only used for tests. So I added an ignore line specifically for that.