### PR TITLE
Use builder container with go 1.11

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   go:
     working_directory: /go/src/github.com/smartcontractkit/chainlink
     docker:
-      - image: smartcontract/builder:1.0.8
+      - image: smartcontract/builder:1.0.9
     steps:
       - checkout
       - restore_cache:
@@ -19,7 +19,7 @@ jobs:
   geth:
     working_directory: /go/src/github.com/smartcontractkit/chainlink
     docker:
-      - image: smartcontract/builder:1.0.8
+      - image: smartcontract/builder:1.0.9
     steps:
       - checkout
       - restore_cache:
@@ -35,7 +35,7 @@ jobs:
   truffle:
     working_directory: /go/src/github.com/smartcontractkit/chainlink
     docker:
-      - image: smartcontract/builder:1.0.8
+      - image: smartcontract/builder:1.0.9
     steps:
       - checkout
       - restore_cache:
@@ -51,7 +51,7 @@ jobs:
   gui:
     working_directory: /go/src/github.com/smartcontractkit/chainlink
     docker:
-      - image: smartcontract/builder:1.0.8
+      - image: smartcontract/builder:1.0.9
     steps:
       - checkout
       - restore_cache:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Chainlink
-FROM smartcontract/builder:1.0.8 as builder
+FROM smartcontract/builder:1.0.9 as builder
 
 # Have to reintroduce ENV vars from builder image
 ENV PATH /go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/Dockerfile-sgx
+++ b/Dockerfile-sgx
@@ -1,5 +1,5 @@
 # Build Chainlink with SGX
-FROM smartcontract/builder:1.0.8 as builder
+FROM smartcontract/builder:1.0.9 as builder
 
 # Have to reintroduce ENV vars from builder image
 ENV PATH /root/.cargo/bin:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/sgxsdk/bin:/opt/sgxsdk/bin/x64

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,3 @@
-.EXPORT_ALL_VARIABLES:
 .DEFAULT_GOAL := build
 .PHONY: godep yarndep build install gui docker dockerpush
 
@@ -46,9 +45,9 @@ gui: yarndep ## Install GUI
 
 docker: ## Build the docker image.
 	docker build \
-		--build-arg ENVIRONMENT \
-		--build-arg COMMIT_SHA \
-		--build-arg SGX_SIMULATION \
+		--build-arg ENVIRONMENT=$(ENVIRONMENT) \
+		--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+		--build-arg SGX_SIMULATION=$(SGX_SIMULATION) \
 		-t $(TAGGED_REPO) \
 		-f $(DOCKERFILE) \
 		.
@@ -61,7 +60,7 @@ chainlink: $(SGX_BUILD_ENCLAVE)
 
 .PHONY: $(SGX_ENCLAVE)
 $(SGX_ENCLAVE):
-	@make -C sgx/
+	@ENVIRONMENT=$(ENVIRONMENT) SGX_ENABLED=$(SGX_ENABLED) SGX_SIMULATION=$(SGX_SIMULATION) make -C sgx/
 	@ln -f $(SGX_TARGET)/libadapters.so sgx/target/libadapters.so
 
 help:


### PR DESCRIPTION
Fixes an issue with environment variable GOFLAGS leaking into go install command.