### PR TITLE
Throw ServerError on 5xx requests

### DIFF
--- a/gui/src/api.js
+++ b/gui/src/api.js
@@ -1,6 +1,11 @@
 import 'isomorphic-unfetch'
 import formatRequestURI from 'utils/formatRequestURI'
-import { AuthenticationError, BadRequestError, UnknownResponseError } from './errors'
+import {
+  AuthenticationError,
+  BadRequestError,
+  ServerError,
+  UnknownResponseError
+} from './errors'
 import { camelizeKeys } from 'humps'
 
 const formatURI = (path, query = {}) => {
@@ -17,6 +22,8 @@ const parseResponse = response => {
     return response.json().then(json => { throw new BadRequestError(json) })
   } else if (response.status === 401) {
     throw new AuthenticationError(response)
+  } else if (response.status >= 500 && response.status < 600) {
+    throw new ServerError(response)
   } else {
     throw new UnknownResponseError(response)
   }

--- a/gui/src/api.js
+++ b/gui/src/api.js
@@ -22,7 +22,7 @@ const parseResponse = response => {
     return response.json().then(json => { throw new BadRequestError(json) })
   } else if (response.status === 401) {
     throw new AuthenticationError(response)
-  } else if (response.status >= 500 && response.status < 600) {
+  } else if (response.status >= 500) {
     throw new ServerError(response)
   } else {
     throw new UnknownResponseError(response)

--- a/gui/src/errors.js
+++ b/gui/src/errors.js
@@ -9,6 +9,13 @@ export function BadRequestError ({errors}) {
   this.errors = errors
 }
 
+export function ServerError (response) {
+  this.errors = [{
+    status: response.status,
+    detail: response.statusText
+  }]
+}
+
 export function UnknownResponseError (response) {
   this.errors = [{
     status: response.status,


### PR DESCRIPTION
Display status text in error notifications instead of an unhandled JS exception. Ideally we should be handling these correctly on the server and returning a 422 with nice error messages.

Before:
<img width="1421" alt="screen shot 2018-09-12 at 5 51 01 pm" src="https://user-images.githubusercontent.com/680789/45460793-8a921c80-b6b4-11e8-8d94-00d182839d15.png">

After:
<img width="866" alt="screen shot 2018-09-12 at 5 49 01 pm" src="https://user-images.githubusercontent.com/680789/45460791-882fc280-b6b4-11e8-91b0-463b07192fb8.png">

