### PR TITLE
tls redirection continued

### DIFF
--- a/internal/bin/clenv
+++ b/internal/bin/clenv
@@ -8,4 +8,6 @@ export ETH_URL=ws://localhost:$ETH_PORT
 export ETH_CHAIN_ID=17
 export TX_MIN_CONFIRMATIONS=2
 export MINIMUM_CONTRACT_PAYMENT=1000000000000
-export CHAINLINK_DEV=${CHAINLINK_DEV:true}
+if [ -z "$CHAINLINK_DEV" ]; then
+  export CHAINLINK_DEV=true
+fi

--- a/store/presenters/presenters.go
+++ b/store/presenters/presenters.go
@@ -160,8 +160,8 @@ func (c ConfigWhitelist) String() string {
 	fmtConfig := "LOG_LEVEL: %v\n" +
 		"ROOT: %s\n" +
 		"CHAINLINK_PORT: %d\n" +
-		"TLS_PORT: %d\n" +
-		"TLS_HOST: %s\n" +
+		"CHAINLINK_TLS_PORT: %d\n" +
+		"CHAINLINK_TLS_HOST: %s\n" +
 		"ETH_URL: %s\n" +
 		"ETH_CHAIN_ID: %d\n" +
 		"CLIENT_NODE_URL: %s\n" +

--- a/web/router.go
+++ b/web/router.go
@@ -94,7 +94,7 @@ func secureMiddleware(config store.Config) gin.HandlerFunc {
 
 			// If there was an error, do not continue.
 			if err != nil {
-				c.AbortWithError(500, err)
+				c.Abort()
 				return
 			}
 

--- a/web/router.go
+++ b/web/router.go
@@ -67,18 +67,16 @@ func secureOptions(config store.Config) secure.Options {
 		SSLRedirect:   config.TLSPort != 0,
 	}
 
-	if config.TLSHost != "" {
-		if config.TLSPort != 0 && config.TLSPort != 443 {
-			options.SSLHost = fmt.Sprintf("%s:%d", config.TLSHost, config.TLSPort)
+	if options.SSLRedirect && !options.IsDevelopment {
+		if config.TLSHost != "" {
+			if config.TLSPort != 443 {
+				options.SSLHost = fmt.Sprintf("%s:%d", config.TLSHost, config.TLSPort)
+			} else {
+				options.SSLHost = config.TLSHost
+			}
 		} else {
-			options.SSLHost = config.TLSHost
+			log.Fatalf("A TLSHost must be configured when TLS redirection is enabled for a non standard port")
 		}
-	} else if options.SSLRedirect && !options.IsDevelopment {
-		if config.TLSPort != 0 && config.TLSPort != 443 {
-			options.SSLHost = fmt.Sprintf("localhost:%d", config.TLSPort)
-		}
-	} else if !options.IsDevelopment {
-		log.Fatalf("A TLSHost must be configured when TLS redirection is enabled for a non standard port")
 	}
 
 	return options


### PR DESCRIPTION
First pass on this was pretty buggy: fixed env var replacement logic in `cldev` script, should now correctly default to `DEV=true`, print out actual env var names in env var output at `chainlink` startup, simplified logic around option checking, removed AbortWithError, this causes endless warnings.

NOTE: this strategy will not work with k8s ingress, best way to do that appears to be to use nginx ingress, will do that in a separate PR.