### PR TITLE
Transaction confirmation checks whether the blocknumber is set

### DIFF
--- a/store/eth_client.go
+++ b/store/eth_client.go
@@ -161,5 +161,5 @@ var emptyHash = common.Hash{}
 
 // Unconfirmed returns true if the transaction is not confirmed.
 func (txr *TxReceipt) Unconfirmed() bool {
-	return txr.Hash == emptyHash
+	return txr.Hash == emptyHash || txr.BlockNumber == nil
 }


### PR DESCRIPTION
For issue #478.

After the original fix I was seeing runtime panics as posted in the issue. Upon investigation, Parity (v1.10.0) was returning this for the tx receipt:
```json
{
  "blockNumber":null,
  "transactionHash":"0xfa9578e4e3e7efce85af1bc88049b3b8c55d4553f55c557dab8b4156af553852"
}
```
Since the tx hash was set, the node was thinking it was confirmed which then cause it to bomb out when trying to handle it.

Just added a check that the blocknumber is set before thinking the tx is confirmed.

Seems this is known and differs between Geth/Parity: https://github.com/paritytech/parity-ethereum/issues/3569