### PR TITLE
Resume in progress job runs on reboot, prevent enqueueing blank job run ids

### DIFF
--- a/adapters/sleep.go
+++ b/adapters/sleep.go
@@ -22,7 +22,7 @@ func (adapter *Sleep) Perform(input models.RunResult, str *store.Store) models.R
 	input.Status = models.RunStatusPendingSleep
 	go func() {
 		<-str.Clock.After(duration)
-		if err := str.RunChannel.Send(input, nil); err != nil {
+		if err := str.RunChannel.Send(input.JobRunID, input, nil); err != nil {
 			logger.Error("Sleep Adapter Perform:", err.Error())
 		}
 	}()

--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -616,7 +616,7 @@ func NewMockRunChannel() *MockRunChannel {
 	}
 }
 
-func (m *MockRunChannel) Send(rr models.RunResult, ibn *models.IndexableBlockNumber) error {
+func (m *MockRunChannel) Send(jobRunID string, rr models.RunResult, ibn *models.IndexableBlockNumber) error {
 	m.Runs = append(m.Runs, rr)
 	copy := *ibn
 	m.BlockNumbers = append(m.BlockNumbers, &copy)

--- a/services/application.go
+++ b/services/application.go
@@ -83,12 +83,14 @@ func (app *ChainlinkApplication) Start() error {
 func (app *ChainlinkApplication) Stop() error {
 	defer logger.Sync()
 	logger.Info("Gracefully exiting...")
+
+	var merr error
 	app.Scheduler.Stop()
-	app.HeadTracker.Stop()
+	merr = multierr.Append(merr, app.HeadTracker.Stop())
 	app.JobRunner.Stop()
-	app.Reaper.Stop()
+	merr = multierr.Append(merr, app.Reaper.Stop())
 	app.HeadTracker.Detach(app.jobSubscriberID)
-	return app.Store.Close()
+	return multierr.Append(merr, app.Store.Close())
 }
 
 // GetStore returns the pointer to the store for the ChainlinkApplication.

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -73,7 +73,7 @@ func (rm *jobRunner) resumeSleepingRuns() error {
 		return err
 	}
 	for _, run := range pendingRuns {
-		rm.store.RunChannel.Send(run.Result, nil)
+		rm.store.RunChannel.Send(run.ID, run.Result, nil)
 	}
 	return nil
 }
@@ -89,7 +89,7 @@ func (rm *jobRunner) demultiplexRuns() {
 				logger.Warn("JobRunner RunChannel closed, demultiplexing of job runs finished")
 				return
 			}
-			rm.channelForRun(rr.Input.JobRunID) <- rr
+			rm.channelForRun(rr.ID) <- rr
 		}
 	}
 }

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -84,7 +84,11 @@ func (rm *jobRunner) demultiplexRuns() {
 		case <-rm.done:
 			logger.Debug("JobRunner demultiplexing of job runs finished")
 			return
-		case rr := <-rm.store.RunChannel.Receive():
+		case rr, ok := <-rm.store.RunChannel.Receive():
+			if !ok {
+				logger.Warn("JobRunner RunChannel closed, demultiplexing of job runs finished")
+				return
+			}
 			rm.channelForRun(rr.Input.JobRunID) <- rr
 		}
 	}
@@ -132,7 +136,7 @@ func (rm *jobRunner) workerLoop(runID string, workerChannel chan store.RunReques
 				return
 			}
 		case <-rm.done:
-			logger.Debug("JobRunner worker loop", runID, "finished")
+			logger.Debug("JobRunner worker loop for ", runID, " finished")
 			return
 		}
 	}

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -119,13 +119,13 @@ func (rm *jobRunner) workerLoop(runID string, workerChannel chan store.RunReques
 		case rr := <-workerChannel:
 			jr, err := rm.store.FindJobRun(runID)
 			if err != nil {
-				logger.Errorw("Application Run Channel Executor: error finding run", jr.ForLogger("error", err)...)
+				logger.Errorw(fmt.Sprint("Application Run Channel Executor: error finding run ", runID), jr.ForLogger("error", err)...)
 			}
 			if rr.BlockNumber != nil {
 				logger.Debug("Woke up", jr.ID, "worker to process ", rr.BlockNumber.ToInt())
 			}
 			if jr, err = ExecuteRunAtBlock(jr, rm.store, rr.Input, rr.BlockNumber); err != nil {
-				logger.Errorw("Application Run Channel Executor: error executing run", jr.ForLogger("error", err)...)
+				logger.Errorw(fmt.Sprint("Application Run Channel Executor: error executing run ", runID), jr.ForLogger("error", err)...)
 			}
 
 			if jr.Status.Finished() {

--- a/services/job_runner_test.go
+++ b/services/job_runner_test.go
@@ -41,6 +41,7 @@ func TestJobRunner_resumeSleepingRuns(t *testing.T) {
 
 	assert.NoError(t, services.ExportedResumeSleepingRuns(rm))
 	rr, open := <-store.RunChannel.Receive()
+	assert.Equal(t, jr.ID, rr.ID)
 	assert.Equal(t, jr.Result, rr.Input)
 	assert.True(t, open)
 }

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -91,7 +91,7 @@ func (js *jobSubscriber) OnNewHead(head *models.BlockHeader) {
 
 	ibn := head.ToIndexableBlockNumber()
 	for _, jr := range pendingRuns {
-		if err := js.store.RunChannel.Send(jr.Result, ibn); err != nil {
+		if err := js.store.RunChannel.Send(jr.ID, jr.Result, ibn); err != nil {
 			logger.Error("JobSubscriber.OnNewHead: ", err.Error())
 		}
 	}

--- a/store/models/job_spec.go
+++ b/store/models/job_spec.go
@@ -74,6 +74,7 @@ func (j JobSpec) NewRun(i Initiator) JobRun {
 		TaskRuns:  taskRuns,
 		Initiator: i,
 		Status:    RunStatusUnstarted,
+		Result:    RunResult{JobRunID: jrid},
 	}
 }
 

--- a/store/store.go
+++ b/store/store.go
@@ -133,8 +133,7 @@ func (s *Store) recoverInProgress() ([]models.JobRun, error) {
 
 func (s *Store) resumeInProgress(runs []models.JobRun) error {
 	for _, run := range runs {
-		rr := models.RunResult{JobRunID: run.ID}
-		if err := s.RunChannel.Send(rr, nil); err != nil {
+		if err := s.RunChannel.Send(run.ID, run.Result, nil); err != nil {
 			return err
 		}
 	}
@@ -196,13 +195,14 @@ func friendlyDuration(duration time.Duration) string {
 // RunRequest is the type that the RunChannel uses to package all the necessary
 // pieces to execute a Job Run.
 type RunRequest struct {
+	ID          string
 	Input       models.RunResult
 	BlockNumber *models.IndexableBlockNumber
 }
 
 // RunChannel manages and dispatches incoming runs.
 type RunChannel interface {
-	Send(rr models.RunResult, ibn *models.IndexableBlockNumber) error
+	Send(jobRunID string, rr models.RunResult, ibn *models.IndexableBlockNumber) error
 	Receive() <-chan RunRequest
 	Close()
 }
@@ -223,7 +223,7 @@ func NewQueuedRunChannel() RunChannel {
 }
 
 // Send adds another entry to the queue of runs.
-func (rq *QueuedRunChannel) Send(rr models.RunResult, ibn *models.IndexableBlockNumber) error {
+func (rq *QueuedRunChannel) Send(jobRunID string, rr models.RunResult, ibn *models.IndexableBlockNumber) error {
 	rq.mutex.Lock()
 	defer rq.mutex.Unlock()
 
@@ -231,7 +231,12 @@ func (rq *QueuedRunChannel) Send(rr models.RunResult, ibn *models.IndexableBlock
 		return errors.New("QueuedRunChannel.Add: cannot add to a closed QueuedRunChannel")
 	}
 
+	if jobRunID == "" {
+		return errors.New("QueuedRunChannel.Add: cannot add an empty jobRunID")
+	}
+
 	rq.queue <- RunRequest{
+		ID:          jobRunID,
 		Input:       rr,
 		BlockNumber: ibn,
 	}

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/smartcontractkit/chainlink/store"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStore_Start(t *testing.T) {
@@ -21,6 +22,34 @@ func TestStore_Start(t *testing.T) {
 	ethMock.Register("eth_getTransactionCount", `0x2D0`)
 	assert.Nil(t, store.Start())
 	ethMock.EventuallyAllCalled(t)
+}
+
+func TestStore_Start_CleansupPrematureShutdown(t *testing.T) {
+	t.Parallel()
+
+	app, cleanup := cltest.NewApplicationWithKeyStore()
+	defer cleanup()
+
+	ethMock := app.MockEthClient()
+	ethMock.Register("eth_getTransactionCount", `0x2D0`)
+
+	s := app.Store
+	job, init := cltest.NewJobWithWebInitiator()
+	require.NoError(t, s.SaveJob(&job))
+
+	jr := job.NewRun(init)
+	jr.Status = models.RunStatusInProgress
+	require.NoError(t, s.Save(&jr))
+
+	require.NoError(t, s.Start())
+	var cleanedJr models.JobRun
+	require.NoError(t, s.One("ID", jr.ID, &cleanedJr))
+
+	assert.Equal(t, jr.ID, cleanedJr.ID)
+	assert.Equal(t, string(models.RunStatusUnstarted), string(cleanedJr.Status))
+
+	require.NoError(t, app.JobRunner.Start())
+	cltest.WaitForJobRunToComplete(t, s, cleanedJr)
 }
 
 func TestStore_Close(t *testing.T) {

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -57,10 +57,10 @@ func TestStore_Close(t *testing.T) {
 
 	s, cleanup := cltest.NewStore()
 	defer cleanup()
-	want := models.RunResult{JobRunID: "whatever"}
+	want := models.RunResult{}
 
-	s.RunChannel.Send(want, nil)
-	s.RunChannel.Send(want, nil)
+	s.RunChannel.Send("whatever", want, nil)
+	s.RunChannel.Send("whatever", want, nil)
 
 	rr, open := <-s.RunChannel.Receive()
 	assert.Equal(t, want, rr.Input)
@@ -81,10 +81,10 @@ func TestQueuedRunChannel_Send(t *testing.T) {
 	t.Parallel()
 
 	rq := store.NewQueuedRunChannel()
-	input1 := models.RunResult{JobRunID: "first"}
+	input1 := models.RunResult{}
 	ibn1 := cltest.IndexableBlockNumber(17)
 
-	assert.NoError(t, rq.Send(input1, ibn1))
+	assert.NoError(t, rq.Send("first", input1, ibn1))
 	rr1 := <-rq.Receive()
 	assert.Equal(t, input1, rr1.Input)
 	assert.Equal(t, ibn1, rr1.BlockNumber)
@@ -99,5 +99,5 @@ func TestQueuedRunChannel_Send_afterClose(t *testing.T) {
 
 	rq.Close()
 
-	assert.Error(t, rq.Send(input1, ibn1))
+	assert.Error(t, rq.Send("first", input1, ibn1))
 }

--- a/store/tx_manager_test.go
+++ b/store/tx_manager_test.go
@@ -245,11 +245,7 @@ func TestTxManager_MeetsMinConfirmations_erroring(t *testing.T) {
 
 			confirmed, err := txm.MeetsMinConfirmations(a.Hash)
 			assert.Equal(t, test.wantConfirmed, confirmed)
-			if test.wantErrored {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
+			cltest.AssertError(t, test.wantErrored, err)
 		})
 	}
 }

--- a/web/job_runs_controller.go
+++ b/web/job_runs_controller.go
@@ -131,8 +131,7 @@ func startJob(j models.JobSpec, s *store.Store, body models.JSON) (models.JobRun
 
 func executeRun(jr models.JobRun, s *store.Store, rr models.RunResult) {
 	go func() {
-		rr.JobRunID = jr.ID
-		if err := s.RunChannel.Send(rr, nil); err != nil {
+		if err := s.RunChannel.Send(jr.ID, rr, nil); err != nil {
 			logger.Error("Web initiator: ", err.Error())
 		}
 	}()


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/160604356
https://www.pivotaltracker.com/story/show/160687845


Fixes https://github.com/smartcontractkit/chainlink/issues/577 and https://github.com/smartcontractkit/chainlink/issues/576.