### PR TITLE
Reload the account nonce when transaction fails with 'nonce is too low' error

### DIFF
--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -18,6 +18,7 @@ import (
 )
 
 const defaultGasLimit uint64 = 500000
+const nonceReloadLimit uint = 1
 
 // TxManager contains fields for the Ethereum client, the KeyStore,
 // the local Config for the application, and the database.
@@ -31,6 +32,10 @@ type TxManager struct {
 
 // CreateTx signs and sends a transaction to the Ethereum blockchain.
 func (txm *TxManager) CreateTx(to common.Address, data []byte) (*models.Tx, error) {
+	return txm.createTxWithNonceReload(to, data, 0)
+}
+
+func (txm *TxManager) createTxWithNonceReload(to common.Address, data []byte, nrc uint) (*models.Tx, error) {
 	if txm.activeAccount == nil {
 		return nil, errors.New("Must activate an account before creating a transaction")
 	}
@@ -54,6 +59,12 @@ func (txm *TxManager) CreateTx(to common.Address, data []byte) (*models.Tx, erro
 			return err
 		}
 
+		logger.Infow(fmt.Sprintf(
+			"Transaction from: %v, to: %v, attempt #: %v",
+			txm.activeAccount.Address.String(),
+			to.String(),
+			nrc,
+		))
 		gasPrice := txm.config.EthGasPriceDefault
 		var txa *models.TxAttempt
 		txa, err = txm.createAttempt(tx, &gasPrice, blkNum)
@@ -68,13 +79,22 @@ func (txm *TxManager) CreateTx(to common.Address, data []byte) (*models.Tx, erro
 	})
 
 	if err != nil && strings.Contains(err.Error(), "nonce is too low") {
-		logger.Infow("TxManager CreateTx: Reload nonce and reattempt transaction")
+		if nrc >= nonceReloadLimit {
+			err = fmt.Errorf(
+				"Transaction reattempt limit reached for 'nonce is too low' error. Limit: %v, Reattempt: %v",
+				nonceReloadLimit,
+				nrc,
+			)
+			return tx, err
+		}
+
+		logger.Warnw("Transaction nonce is too low. Reloading the nonce from the network and reattempting the transaction.")
 		err = txm.ReloadNonce()
 		if err != nil {
 			return tx, fmt.Errorf("TxManager CreateTX ReloadNonce %v", err)
 		}
 
-		return txm.CreateTx(to, data)
+		return txm.createTxWithNonceReload(to, data, nrc+1)
 	}
 
 	return tx, err


### PR DESCRIPTION
[Fixes #157341003]

It only reloads the nonce once before failing like the current behavior to avoid a possible infinite loop. I'm open to making this configurable, however I feel like if the node requires a value > 1 it may be indicative of a larger problem around wallet management.

New log output:

```bash
2018-09-26T00:39:14Z [INFO]  Starting job                                       services/job_runner.go:233 job=9cc5977649954d1cb5c767be65e7b60e run=d3664d66e1894571939a8372d3ba16cf status=in_progress
2018-09-26T00:39:14Z [INFO]  Transaction from: 0x9CA9d2D5E04012C9Ed24C0e513C9bfAa4A2dD77f, to: 0xa5F108b6d82b9F080325F935F3BAf89e0042CAC8, attempt #: 0 store/tx_manager.go:62
2018-09-26T00:39:14Z [WARN]  Transaction nonce is too low. Reloading the nonce from the network and reattempting the transaction. store/tx_manager.go:91
2018-09-26T00:39:14Z [INFO]  Transaction from: 0x9CA9d2D5E04012C9Ed24C0e513C9bfAa4A2dD77f, to: 0xa5F108b6d82b9F080325F935F3BAf89e0042CAC8, attempt #: 1 store/tx_manager.go:62
2018-09-26T00:39:14Z [DEBUG] Produced task run                                  services/job_runner.go:290 taskRun=TaskRun(12b6fbf92ad64c0598273ff379ff2add,ethtx,pending_confirmations,)
2018-09-26T00:39:14Z [DEBUG] Task ethtx                                         services/job_runner.go:291 taskrun=12b6fbf92ad64c0598273ff379ff2add type=ethtx params={"address":"0xa5f108b6d82b9f080325f935f3baf89e0042cac8","value":"1"} ta$
k=0
2018-09-26T00:39:14Z [INFO]  Finished current job run execution                 services/job_runner.go:264 job=9cc5977649954d1cb5c767be65e7b60e run=d3664d66e1894571939a8372d3ba16cf status=pending_confirmations
```

I'm not entirely happy with the string contains checking for `nonce is too low`. I originally wanted to use `core.ErrNonceTooLow` from [go-ethereum](https://github.com/ethereum/go-ethereum/blob/81080bf8cb7f60f59a68cf48998a29a1a2e10cb9/core/tx_pool.go#L49) but that error doesn't have `is` in the text. I couldn't figure out where `nonce is too low` actually comes from. I tried looking through the `git diff` history of `go-ethereum` but didn't come up with anything.

```bash
git rev-list --all | (     while read revision; do         git grep -F 'nonce is too low' $revision;     done; )
```