### PR TITLE
Migrate job runs to use run channel

### DIFF
--- a/services/export_test.go
+++ b/services/export_test.go
@@ -1,6 +1,18 @@
 package services
 
-import "github.com/smartcontractkit/chainlink/store"
+import (
+	"github.com/smartcontractkit/chainlink/store"
+	"github.com/smartcontractkit/chainlink/store/models"
+)
+
+func ExportedExecuteRunAtBlock(
+	run models.JobRun,
+	store *store.Store,
+	overrides models.RunResult,
+	blockNumber *models.IndexableBlockNumber,
+) (models.JobRun, error) {
+	return executeRunAtBlock(run, store, overrides, blockNumber)
+}
 
 func ExportedChannelForRun(jr JobRunner, runID string) chan<- store.RunRequest {
 	return jr.channelForRun(runID)

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -139,7 +139,7 @@ func (rm *jobRunner) workerLoop(runID string, workerChannel chan store.RunReques
 			if rr.BlockNumber != nil {
 				logger.Debug("Woke up", jr.ID, "worker to process ", rr.BlockNumber.ToInt())
 			}
-			if jr, err = ExecuteRunAtBlock(jr, rm.store, rr.Input, rr.BlockNumber); err != nil {
+			if jr, err = executeRunAtBlock(jr, rm.store, rr.Input, rr.BlockNumber); err != nil {
 				logger.Errorw(fmt.Sprint("Application Run Channel Executor: error executing run ", runID), jr.ForLogger("error", err)...)
 			}
 
@@ -193,7 +193,7 @@ func BeginRunAtBlock(
 		run = run.ApplyResult(input.WithError(err))
 		return run, multierr.Append(err, store.Save(&run))
 	}
-	return ExecuteRunAtBlock(run, store, input, bn)
+	return executeRunAtBlock(run, store, input, bn)
 }
 
 // BuildRun checks to ensure the given job has not started or ended before
@@ -213,15 +213,15 @@ func BuildRun(job models.JobSpec, i models.Initiator, store *store.Store) (model
 	return job.NewRun(i), nil
 }
 
-// ExecuteRun calls ExecuteRunAtBlock without an IndexableBlockNumber
+// ExecuteRun calls executeRunAtBlock without an IndexableBlockNumber
 func ExecuteRun(jr models.JobRun, store *store.Store, overrides models.RunResult) (models.JobRun, error) {
-	return ExecuteRunAtBlock(jr, store, overrides, nil)
+	return executeRunAtBlock(jr, store, overrides, nil)
 }
 
-// ExecuteRunAtBlock starts the job and executes task runs within that job in the
+// executeRunAtBlock starts the job and executes task runs within that job in the
 // order defined in the run for as long as they do not return errors. Results
 // are saved in the store (db).
-func ExecuteRunAtBlock(
+func executeRunAtBlock(
 	jr models.JobRun,
 	store *store.Store,
 	overrides models.RunResult,

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -213,11 +213,6 @@ func BuildRun(job models.JobSpec, i models.Initiator, store *store.Store) (model
 	return job.NewRun(i), nil
 }
 
-// ExecuteRun calls executeRunAtBlock without an IndexableBlockNumber
-func ExecuteRun(jr models.JobRun, store *store.Store, overrides models.RunResult) (models.JobRun, error) {
-	return executeRunAtBlock(jr, store, overrides, nil)
-}
-
 // executeRunAtBlock starts the job and executes task runs within that job in the
 // order defined in the run for as long as they do not return errors. Results
 // are saved in the store (db).

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -255,7 +255,12 @@ func executeRunAtBlock(
 	return jr, wrapError(jr, store.Save(&jr))
 }
 
-func prepareJobRun(jr models.JobRun, store *store.Store, overrides models.RunResult, bn *models.IndexableBlockNumber) (models.JobRun, error) {
+func prepareJobRun(
+	jr models.JobRun,
+	store *store.Store,
+	overrides models.RunResult,
+	bn *models.IndexableBlockNumber,
+) (models.JobRun, error) {
 	if jr.Status.CanStart() {
 		jr.Status = models.RunStatusInProgress
 	} else {

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -169,12 +169,12 @@ func BuildRun(
 ) (models.JobRun, error) {
 	now := store.Clock.Now()
 	if !job.Started(now) {
-		return models.JobRun{}, JobRunnerError{
+		return models.JobRun{}, RecurringScheduleJobError{
 			msg: fmt.Sprintf("Job runner: Job %v unstarted: %v before job's start time %v", job.ID, now, job.EndAt),
 		}
 	}
 	if job.Ended(now) {
-		return models.JobRun{}, JobRunnerError{
+		return models.JobRun{}, RecurringScheduleJobError{
 			msg: fmt.Sprintf("Job runner: Job %v ended: %v past job's end time %v", job.ID, now, job.EndAt),
 		}
 	}
@@ -326,12 +326,12 @@ func wrapError(run models.JobRun, err error) error {
 	return nil
 }
 
-// JobRunnerError contains the field for the error message.
-type JobRunnerError struct {
+// RecurringScheduleJobError contains the field for the error message.
+type RecurringScheduleJobError struct {
 	msg string
 }
 
 // Error returns the error message for the run.
-func (err JobRunnerError) Error() string {
+func (err RecurringScheduleJobError) Error() string {
 	return err.msg
 }

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -162,7 +162,11 @@ func (rm *jobRunner) workerCount() int {
 
 // BuildRun checks to ensure the given job has not started or ended before
 // creating a new run for the job.
-func BuildRun(job models.JobSpec, i models.Initiator, store *store.Store) (models.JobRun, error) {
+func BuildRun(
+	job models.JobSpec,
+	i models.Initiator,
+	store *store.Store,
+) (models.JobRun, error) {
 	now := store.Clock.Now()
 	if !job.Started(now) {
 		return models.JobRun{}, JobRunnerError{
@@ -177,9 +181,9 @@ func BuildRun(job models.JobSpec, i models.Initiator, store *store.Store) (model
 	return job.NewRun(i), nil
 }
 
-// BuildAndValidateRun builds a new run and validates whether or not the run
-// meets the minimum contract payment.
-func BuildAndValidateRun(
+// BuildRunWithValidPayment builds a new run and validates whether or not the
+// run meets the minimum contract payment.
+func BuildRunWithValidPayment(
 	job models.JobSpec,
 	initr models.Initiator,
 	input models.RunResult,

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -322,7 +322,7 @@ func startTask(
 
 func wrapError(run models.JobRun, err error) error {
 	if err != nil {
-		return fmt.Errorf("ExecuteRun: Job#%v: %v", run.JobID, err)
+		return fmt.Errorf("executeRunAtBlock: Job#%v: %v", run.JobID, err)
 	}
 	return nil
 }

--- a/services/job_runner_test.go
+++ b/services/job_runner_test.go
@@ -139,7 +139,7 @@ func TestJobRunner_Stop(t *testing.T) {
 	}).Should(gomega.Equal(0))
 }
 
-func TestJobRunner_Run(t *testing.T) {
+func TestJobRunner_EnqueueRunWithValidPayment(t *testing.T) {
 	t.Parallel()
 
 	bridgeName := "auctionBidding"
@@ -198,10 +198,9 @@ func TestJobRunner_Run(t *testing.T) {
 			}
 			assert.Nil(t, store.Save(&job))
 
-			run = job.NewRun(initr)
-			assert.NoError(t, store.Save(&run))
 			input := models.RunResult{Data: cltest.JSONFromString(test.input)}
-			store.RunChannel.Send(run.ID, input, nil)
+			run, err := services.EnqueueRunWithValidPayment(job, initr, input, store)
+			assert.NoError(t, err)
 			cltest.WaitForJobRunStatus(t, store, run, test.wantStatus)
 
 			store.One("ID", run.ID, &run)

--- a/services/job_runner_test.go
+++ b/services/job_runner_test.go
@@ -451,7 +451,7 @@ func TestJobRunner_transitionToPending(t *testing.T) {
 	cltest.WaitForJobRunStatus(t, store, run, models.RunStatusPendingConfirmations)
 }
 
-func TestJobRunner_BuildAndValidateRun(t *testing.T) {
+func TestJobRunner_BuildRunWithValidPayment(t *testing.T) {
 	tests := []struct {
 		name    string
 		amount  *assets.Link
@@ -480,7 +480,7 @@ func TestJobRunner_BuildAndValidateRun(t *testing.T) {
 			runResult := models.RunResult{
 				Amount: test.amount,
 			}
-			run, _ := services.BuildAndValidateRun(job, initr, runResult, store)
+			run, _ := services.BuildRunWithValidPayment(job, initr, runResult, store)
 			assert.Equal(t, test.status, run.Status)
 		})
 	}

--- a/services/scheduler.go
+++ b/services/scheduler.go
@@ -132,7 +132,7 @@ func (r *Recurring) AddJob(job models.JobSpec) {
 		if !job.Ended(r.Clock.Now()) {
 			r.Cron.AddFunc(string(initr.Schedule), func() {
 				input := models.RunResult{}
-				run, err := BuildAndValidateRun(job, initr, input, r.store)
+				run, err := BuildRunWithValidPayment(job, initr, input, r.store)
 
 				if err == nil {
 					err = r.store.Save(&run)
@@ -184,7 +184,7 @@ func (ot *OneTime) RunJobAt(initr models.Initiator, job models.JobSpec) {
 			logger.Error(err.Error())
 			return
 		}
-		run, err := BuildAndValidateRun(job, initr, models.RunResult{}, ot.Store)
+		run, err := BuildRunWithValidPayment(job, initr, models.RunResult{}, ot.Store)
 
 		if err == nil {
 			err = ot.Store.Save(&run)

--- a/services/scheduler.go
+++ b/services/scheduler.go
@@ -141,7 +141,7 @@ func (r *Recurring) AddJob(job models.JobSpec) {
 						return
 					}
 					r.store.RunChannel.Send(run.ID, input, nil)
-				} else if !expectedRecurringError(err) {
+				} else if !expectedRecurringScheduleJobError(err) {
 					logger.Errorw(err.Error())
 				}
 			})
@@ -204,9 +204,9 @@ func (ot *OneTime) RunJobAt(initr models.Initiator, job models.JobSpec) {
 	}
 }
 
-func expectedRecurringError(err error) bool {
+func expectedRecurringScheduleJobError(err error) bool {
 	switch err.(type) {
-	case JobRunnerError:
+	case RecurringScheduleJobError:
 		return true
 	default:
 		return false

--- a/services/scheduler_test.go
+++ b/services/scheduler_test.go
@@ -52,6 +52,7 @@ func TestScheduler_Start_AddingUnstartedJob(t *testing.T) {
 	logs := cltest.ObserveLogs()
 
 	store, cleanupStore := cltest.NewStore()
+	defer cleanupStore()
 	clock := cltest.UseSettableClock(store)
 
 	startAt := cltest.ParseISO8601("3000-01-01T00:00:00.000Z")
@@ -60,9 +61,8 @@ func TestScheduler_Start_AddingUnstartedJob(t *testing.T) {
 	assert.Nil(t, store.Save(&j))
 
 	sched := services.NewScheduler(store)
-	assert.Nil(t, sched.Start())
 	defer sched.Stop()
-	defer cleanupStore()
+	assert.Nil(t, sched.Start())
 
 	gomega.NewGomegaWithT(t).Consistently(func() int {
 		runs, err := store.JobRunsFor(j.ID)

--- a/services/scheduler_test.go
+++ b/services/scheduler_test.go
@@ -130,11 +130,11 @@ func TestOneTime_AddJob(t *testing.T) {
 	futureTime := cltest.NullTime("3000-01-01T00:00:00.000Z")
 	pastRunTime := time.Now().Add(time.Hour * -1)
 	tests := []struct {
-		name     string
-		startAt  null.Time
-		endAt    null.Time
-		runAt    time.Time
-		wantRuns bool
+		name          string
+		startAt       null.Time
+		endAt         null.Time
+		runAt         time.Time
+		wantCompleted bool
 	}{
 		{"run at before start at", futureTime, nullTime, pastRunTime, false},
 		{"run at before end at", nullTime, futureTime, pastRunTime, true},
@@ -146,6 +146,10 @@ func TestOneTime_AddJob(t *testing.T) {
 
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
+	jobRunner, cleanup := cltest.NewJobRunner(store)
+	defer cleanup()
+	jobRunner.Start()
+
 	for _, tt := range tests {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
@@ -170,7 +174,7 @@ func TestOneTime_AddJob(t *testing.T) {
 					completed = true
 				}
 				return completed
-			}).Should(gomega.Equal(test.wantRuns))
+			}).Should(gomega.Equal(test.wantCompleted))
 		})
 	}
 }

--- a/services/subscription.go
+++ b/services/subscription.go
@@ -217,7 +217,7 @@ func runJob(le InitiatorSubscriptionLogEvent, data models.JSON, initr models.Ini
 		Amount: payment,
 	}
 
-	run, err := BuildAndValidateRun(le.Job, initr, input, le.store)
+	run, err := BuildRunWithValidPayment(le.Job, initr, input, le.store)
 	if err != nil {
 		logger.Errorw(err.Error(), le.ForLogger()...)
 		return

--- a/services/subscription.go
+++ b/services/subscription.go
@@ -217,18 +217,10 @@ func runJob(le InitiatorSubscriptionLogEvent, data models.JSON, initr models.Ini
 		Amount: payment,
 	}
 
-	run, err := BuildRunWithValidPayment(le.Job, initr, input, le.store)
+	_, err = EnqueueRunAtBlockWithValidPayment(le.Job, initr, input, le.store, le.ToIndexableBlockNumber())
 	if err != nil {
 		logger.Errorw(err.Error(), le.ForLogger()...)
-		return
 	}
-	err = le.store.Save(&run)
-	if err != nil {
-		logger.Errorw(err.Error(), le.ForLogger()...)
-		return
-	}
-
-	le.store.RunChannel.Send(run.ID, input, le.ToIndexableBlockNumber())
 }
 
 // ManagedSubscription encapsulates the connecting, backfilling, and clean up of an

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -176,7 +176,7 @@ func (tr TaskRun) MarkPendingConfirmations() TaskRun {
 }
 
 // RunResult keeps track of the outcome of a TaskRun or JobRun. It stores the
-// Data and ErrorMessage, and contains a Pending field to track the status.
+// Data and ErrorMessage, and contains a field to track the status.
 type RunResult struct {
 	JobRunID     string       `json:"jobRunId"`
 	Data         JSON         `json:"data"`

--- a/web/router.go
+++ b/web/router.go
@@ -136,14 +136,15 @@ func v1Routes(app *services.ChainlinkApplication, engine *gin.Engine) {
 
 func v2Routes(app *services.ChainlinkApplication, engine *gin.Engine) {
 	v2 := engine.Group("/v2")
+
 	jr := JobRunsController{app}
+	v2.PATCH("/runs/:RunID", jr.Update)
 
 	ab := AccountBalanceController{app}
 	v2.GET("/account_balance", ab.Show)
 
 	sa := ServiceAgreementsController{app}
 	v2.POST("/service_agreements", sa.Create)
-	v2.PATCH("/runs/:RunID", jr.Update)
 
 	authv2 := engine.Group("/v2", authRequired(app.Store))
 	{


### PR DESCRIPTION
- [x] Make `services.ExecuteRunAtBlock` private
- [x] Remove services.ExecuteRun
- [x] Figure out new way to test error return value from `services.ExecuteRunAtBlock` e.g. `No unfinished tasks to run`
- [x] Start run in channel without block number `services.BeginRun` (Cron, RunAt)
- [x] Start run in channel with block number `services.BeginRunAtBlock` (RunLog, EthLog)
