### PR TITLE
Oracle.sol emits request cancellation log

### DIFF
--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -53,9 +53,9 @@ contract Chainlinked {
   function cancelChainlinkRequest(bytes32 _requestId)
     internal
   {
-    oracle.cancel(_requestId);
     delete unfulfilledRequests[_requestId];
     emit ChainlinkCancelled(_requestId);
+    oracle.cancel(_requestId);
   }
 
   function LINK(uint256 _amount) internal view returns (uint256) {

--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -41,12 +41,12 @@ contract Chainlinked {
     returns (bytes32)
   {
     _run.requestId = bytes32(requests);
-    _run.close();
-    require(link.transferAndCall(oracle, _amount, _run.encodeForOracle(clArgsVersion)), "unable to transferAndCall to oracle");
-    emit ChainlinkRequested(_run.requestId);
-    unfulfilledRequests[_run.requestId] = oracle;
-
     requests += 1;
+    _run.close();
+    unfulfilledRequests[_run.requestId] = oracle;
+    emit ChainlinkRequested(_run.requestId);
+    require(link.transferAndCall(oracle, _amount, _run.encodeForOracle(clArgsVersion)), "unable to transferAndCall to oracle");
+
     return _run.requestId;
   }
 

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -31,6 +31,10 @@ contract Oracle is Ownable {
     bytes data
   );
 
+  event CancelRequest(
+    uint256 internalId
+  );
+
   constructor(address _link) Ownable() public {
     LINK = LinkToken(_link);
   }
@@ -110,6 +114,7 @@ contract Oracle is Ownable {
     Callback memory cb = callbacks[internalId];
     require(LINK.transfer(cb.addr, cb.amount), "Unable to transfer");
     delete callbacks[internalId];
+    emit CancelRequest(internalId);
   }
 
   // MODIFIERS

--- a/solidity/test/BasicConsumer_test.js
+++ b/solidity/test/BasicConsumer_test.js
@@ -51,7 +51,7 @@ contract('BasicConsumer', () => {
 
       it('triggers a log event in the Oracle contract', async () => {
         let tx = await cc.requestEthereumPrice(currency)
-        let log = tx.receipt.logs[2]
+        let log = tx.receipt.logs[3]
         assert.equal(log.address, oc.address)
 
         let [id, jId, wei, ver, cborData] = decodeRunRequest(log)

--- a/solidity/test/Oracle_test.js
+++ b/solidity/test/Oracle_test.js
@@ -210,7 +210,7 @@ contract('Oracle', () => {
       context('fails during fulfillment', () => {
         beforeEach(async () => {
           const req = await mock.requestData('assertFail(bytes32,bytes32)')
-          internalId = req.receipt.logs[2].topics[1]
+          internalId = req.receipt.logs[3].topics[1]
         })
 
         it('allows the oracle node to receive their payment', async () => {
@@ -235,7 +235,7 @@ contract('Oracle', () => {
       context('calls selfdestruct', () => {
         beforeEach(async () => {
           const req = await mock.requestData('doesNothing(bytes32,bytes32)')
-          internalId = req.receipt.logs[2].topics[1]
+          internalId = req.receipt.logs[3].topics[1]
           await mock.remove()
         })
 
@@ -254,7 +254,7 @@ contract('Oracle', () => {
       context('request is canceled during fulfillment', () => {
         beforeEach(async () => {
           const req = await mock.requestData('cancelRequestOnFulfill(bytes32,bytes32)')
-          internalId = req.receipt.logs[2].topics[1]
+          internalId = req.receipt.logs[3].topics[1]
 
           const mockBalance = await link.balanceOf.call(mock.address)
           assert.isTrue(mockBalance.equals(0))
@@ -285,7 +285,7 @@ contract('Oracle', () => {
       context('requester lies about amount of LINK sent', () => {
         it('the oracle uses the amount of LINK actually paid', async () => {
           const req = await mock.requestData('assertFail(bytes32,bytes32)')
-          const log = req.receipt.logs[2]
+          const log = req.receipt.logs[3]
 
           assert.equal(web3.toWei(1), web3.toDecimal(log.topics[3]))
         })


### PR DESCRIPTION
Also updated the Chainlinked behavior to update all internal state before calling out to external contracts.