### PR TITLE
Add expiration to cancel requests

### DIFF
--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -78,7 +78,7 @@ contract Oracle is Ownable {
       _currentAmount,
       _callbackAddress,
       _callbackFunctionId,
-      uint64(now.add(1 hours)));
+      uint64(now.add(5 minutes)));
     emit RunRequest(internalId, _specId, _currentAmount, _version, _data);
   }
 

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -14,7 +14,7 @@ contract Oracle is Ownable {
     uint256 amount;
     address addr;
     bytes4 functionId;
-    uint256 cancelExpiration;
+    uint64 cancelExpiration;
   }
 
   // We initialize fields to 1 instead of 0 so that the first invocation
@@ -78,7 +78,7 @@ contract Oracle is Ownable {
       _currentAmount,
       _callbackAddress,
       _callbackFunctionId,
-      now.add(1 hours));
+      uint64(now.add(1 hours)));
     emit RunRequest(internalId, _specId, _currentAmount, _version, _data);
   }
 

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -14,6 +14,7 @@ contract Oracle is Ownable {
     uint256 amount;
     address addr;
     bytes4 functionId;
+    uint256 cancelExpiration;
   }
 
   // We initialize fields to 1 instead of 0 so that the first invocation
@@ -76,7 +77,8 @@ contract Oracle is Ownable {
       _externalId,
       _currentAmount,
       _callbackAddress,
-      _callbackFunctionId);
+      _callbackFunctionId,
+      now.add(1 hours));
     emit RunRequest(internalId, _specId, _currentAmount, _version, _data);
   }
 
@@ -111,6 +113,7 @@ contract Oracle is Ownable {
   {
     uint256 internalId = uint256(keccak256(abi.encodePacked(msg.sender, _externalId)));
     require(msg.sender == callbacks[internalId].addr, "Must be called from requester");
+    require(callbacks[internalId].cancelExpiration <= now, "Request is not expired");
     Callback memory cb = callbacks[internalId];
     require(LINK.transfer(cb.addr, cb.amount), "Unable to transfer");
     delete callbacks[internalId];

--- a/solidity/contracts/examples/MaliciousRequester.sol
+++ b/solidity/contracts/examples/MaliciousRequester.sol
@@ -21,5 +21,13 @@ contract MaliciousRequester is MaliciousChainlinked {
     chainlinkWithdrawRequest(run, LINK(1));
   }
 
+  function maliciousRequestCancel()
+    public
+    returns (bytes32 requestId)
+  {
+    MaliciousChainlinkLib.Run memory run = newRun("specId", this, "doesNothing(bytes32,bytes32)");
+    requestId = chainlinkRequest(run, LINK(1));
+  }
+
   function doesNothing(bytes32 _requestId, bytes32 _data) public {}
 }

--- a/solidity/contracts/examples/MaliciousRequester.sol
+++ b/solidity/contracts/examples/MaliciousRequester.sol
@@ -21,12 +21,16 @@ contract MaliciousRequester is MaliciousChainlinked {
     chainlinkWithdrawRequest(run, LINK(1));
   }
 
-  function maliciousRequestCancel()
-    public
+  function request()
+    internal
     returns (bytes32 requestId)
   {
     MaliciousChainlinkLib.Run memory run = newRun("specId", this, "doesNothing(bytes32,bytes32)");
     requestId = chainlinkRequest(run, LINK(1));
+  }
+
+  function maliciousRequestCancel() public {
+    oracle.cancel(request());
   }
 
   function doesNothing(bytes32 _requestId, bytes32 _data) public {}

--- a/solidity/test/BasicConsumer_test.js
+++ b/solidity/test/BasicConsumer_test.js
@@ -15,7 +15,7 @@ import {
   requestDataFrom,
   stranger,
   toHex,
-  increaseTime1Hour
+  increaseTime5Minutes
 } from './support/helpers'
 
 contract('BasicConsumer', () => {
@@ -141,7 +141,7 @@ contract('BasicConsumer', () => {
       requestId = (await getLatestEvent(cc)).args.id
     })
 
-    context("before an hour", () => {
+    context("before 5 minutes", () => {
       it('cant cancel the request', async () => {
         await assertActionThrows(async () => {
           await cc.cancelRequest(requestId, {from: consumer})
@@ -149,9 +149,9 @@ contract('BasicConsumer', () => {
       })
     })
 
-    context("after an hour", () => {
+    context("after 5 minutes", () => {
       it('can cancel the request', async () => {
-        await increaseTime1Hour();
+        await increaseTime5Minutes();
         await cc.cancelRequest(requestId, {from: consumer})
       })
     })

--- a/solidity/test/BasicConsumer_test.js
+++ b/solidity/test/BasicConsumer_test.js
@@ -70,7 +70,7 @@ contract('BasicConsumer', () => {
 
       it('has a reasonable gas cost', async () => {
         let tx = await cc.requestEthereumPrice(currency)
-        assert.isBelow(tx.receipt.gasUsed, 182000)
+        assert.isBelow(tx.receipt.gasUsed, 167000)
       })
     })
   })

--- a/solidity/test/BasicConsumer_test.js
+++ b/solidity/test/BasicConsumer_test.js
@@ -14,7 +14,8 @@ import {
   requestDataBytes,
   requestDataFrom,
   stranger,
-  toHex
+  toHex,
+  increaseTime1Hour
 } from './support/helpers'
 
 contract('BasicConsumer', () => {
@@ -69,7 +70,7 @@ contract('BasicConsumer', () => {
 
       it('has a reasonable gas cost', async () => {
         let tx = await cc.requestEthereumPrice(currency)
-        assert.isBelow(tx.receipt.gasUsed, 165000)
+        assert.isBelow(tx.receipt.gasUsed, 182000)
       })
     })
   })
@@ -140,8 +141,19 @@ contract('BasicConsumer', () => {
       requestId = (await getLatestEvent(cc)).args.id
     })
 
-    it('can cancel the request', async () => {
-      await cc.cancelRequest(requestId, {from: consumer})
+    context("before an hour", () => {
+      it('cant cancel the request', async () => {
+        await assertActionThrows(async () => {
+          await cc.cancelRequest(requestId, {from: consumer})
+        })
+      })
+    })
+
+    context("after an hour", () => {
+      it('can cancel the request', async () => {
+        await increaseTime1Hour();
+        await cc.cancelRequest(requestId, {from: consumer})
+      })
     })
   })
 })

--- a/solidity/test/ConcreteChainlinked_test.js
+++ b/solidity/test/ConcreteChainlinked_test.js
@@ -8,7 +8,7 @@ import {
   getLatestEvent,
   toHexWithoutPrefix,
   toWei,
-  increaseTime1Hour
+  increaseTime5Minutes
 } from './support/helpers'
 
 contract('ConcreteChainlinked', () => {
@@ -61,7 +61,7 @@ contract('ConcreteChainlinked', () => {
     })
 
     it('emits an event from the contract showing the run was cancelled', async () => {
-      await increaseTime1Hour();
+      await increaseTime5Minutes();
       let tx = await cc.publicCancelRequest(requestId)
 
       let events = await getEvents(cc)
@@ -73,7 +73,7 @@ contract('ConcreteChainlinked', () => {
 
     context('when the request ID is no longer unfulfilled', () => {
       beforeEach(async () => {
-        await increaseTime1Hour();
+        await increaseTime5Minutes();
         await cc.publicCancelRequest(requestId)
       })
 

--- a/solidity/test/ConcreteChainlinked_test.js
+++ b/solidity/test/ConcreteChainlinked_test.js
@@ -7,7 +7,8 @@ import {
   getEvents,
   getLatestEvent,
   toHexWithoutPrefix,
-  toWei
+  toWei,
+  increaseTime1Hour
 } from './support/helpers'
 
 contract('ConcreteChainlinked', () => {
@@ -60,6 +61,7 @@ contract('ConcreteChainlinked', () => {
     })
 
     it('emits an event from the contract showing the run was cancelled', async () => {
+      await increaseTime1Hour();
       let tx = await cc.publicCancelRequest(requestId)
 
       let events = await getEvents(cc)
@@ -71,6 +73,7 @@ contract('ConcreteChainlinked', () => {
 
     context('when the request ID is no longer unfulfilled', () => {
       beforeEach(async () => {
+        await increaseTime1Hour();
         await cc.publicCancelRequest(requestId)
       })
 

--- a/solidity/test/Oracle_test.js
+++ b/solidity/test/Oracle_test.js
@@ -381,6 +381,7 @@ contract('Oracle', () => {
   describe('#cancel', () => {
     context('with no pending requests', () => {
       it('fails', async () => {
+        await h.increaseTime1Hour();
         await h.assertActionThrows(async () => {
           await oc.cancel(1337, {from: h.stranger})
         })
@@ -421,12 +422,14 @@ contract('Oracle', () => {
 
       context('from the requester', () => {
         it('refunds the correct amount', async () => {
+          await h.increaseTime1Hour();
           await oc.cancel(requestId, {from: h.consumer})
           let balance = await link.balanceOf(h.consumer)
           assert.equal(startingBalance, balance) // 100
         })
 
         it('triggers a cancellation event', async () => {
+          await h.increaseTime1Hour();
           const tx = await oc.cancel(requestId, {from: h.consumer})
 
           assert.equal(tx.receipt.logs.length, 2)
@@ -435,6 +438,7 @@ contract('Oracle', () => {
 
         context('canceling twice', () => {
           it('fails', async () => {
+            await h.increaseTime1Hour();
             await oc.cancel(requestId, {from: h.consumer})
             await h.assertActionThrows(async () => {
               await oc.cancel(requestId, {from: h.consumer})

--- a/solidity/test/Oracle_test.js
+++ b/solidity/test/Oracle_test.js
@@ -396,7 +396,7 @@ contract('Oracle', () => {
   describe('#cancel', () => {
     context('with no pending requests', () => {
       it('fails', async () => {
-        await h.increaseTime1Hour();
+        await h.increaseTime5Minutes();
         await h.assertActionThrows(async () => {
           await oc.cancel(1337, {from: h.stranger})
         })
@@ -437,14 +437,14 @@ contract('Oracle', () => {
 
       context('from the requester', () => {
         it('refunds the correct amount', async () => {
-          await h.increaseTime1Hour();
+          await h.increaseTime5Minutes();
           await oc.cancel(requestId, {from: h.consumer})
           let balance = await link.balanceOf(h.consumer)
           assert.equal(startingBalance, balance) // 100
         })
 
         it('triggers a cancellation event', async () => {
-          await h.increaseTime1Hour();
+          await h.increaseTime5Minutes();
           const tx = await oc.cancel(requestId, {from: h.consumer})
 
           assert.equal(tx.receipt.logs.length, 2)
@@ -453,7 +453,7 @@ contract('Oracle', () => {
 
         context('canceling twice', () => {
           it('fails', async () => {
-            await h.increaseTime1Hour();
+            await h.increaseTime5Minutes();
             await oc.cancel(requestId, {from: h.consumer})
             await h.assertActionThrows(async () => {
               await oc.cancel(requestId, {from: h.consumer})

--- a/solidity/test/Oracle_test.js
+++ b/solidity/test/Oracle_test.js
@@ -199,7 +199,22 @@ contract('Oracle', () => {
       })
     })
 
-    context('with a malicious consumer/requester', () => {
+    context('with a malicious requester', () => {
+      const paymentAmount = h.toWei(1)
+      
+      beforeEach(async () => {
+        mock = await h.deploy('examples/MaliciousRequester.sol', link.address, oc.address)
+        await link.transfer(mock.address, paymentAmount)
+      })
+
+      it('cannot cancel before the expiration', async () => {
+        await h.assertActionThrows(async () => {
+          await mock.maliciousRequestCancel()
+        })
+      })
+    })
+
+    context('with a malicious consumer', () => {
       const paymentAmount = h.toWei(1)
 
       beforeEach(async () => {

--- a/solidity/test/support/helpers.js
+++ b/solidity/test/support/helpers.js
@@ -239,3 +239,11 @@ export const splitRPCSignature = oracleSignature => {
     s: oracleSignature.slice(32, 64)
   }
 }
+
+export const increaseTime1Hour = async () => {
+  await web3.currentProvider.send({
+    jsonrpc: "2.0", 
+    method: "evm_increaseTime", 
+    params: [3600], id: 0
+  });
+};

--- a/solidity/test/support/helpers.js
+++ b/solidity/test/support/helpers.js
@@ -240,10 +240,10 @@ export const splitRPCSignature = oracleSignature => {
   }
 }
 
-export const increaseTime1Hour = async () => {
+export const increaseTime5Minutes = async () => {
   await web3.currentProvider.send({
     jsonrpc: "2.0", 
     method: "evm_increaseTime", 
-    params: [3600], id: 0
+    params: [300], id: 0
   });
 };


### PR DESCRIPTION
Adds expiration time of 1 hour to the on-chain Callback, which prevents requests from being cancelled before that time has passed.