### PR TITLE
cldev now uses go build so that the binary has debug info

### DIFF
--- a/internal/bin/cldev
+++ b/internal/bin/cldev
@@ -15,6 +15,8 @@ pushd $PROJECT_ROOT >/dev/null
 source internal/bin/clenv
 export ROOT=$PROJECT_ROOT/internal/clroot
 
+set -e
+
 mainexec() {
   mkdir -p tmp
   go build -o tmp/cldevbuild -ldflags "$LDFLAGS" main.go

--- a/internal/bin/cldev
+++ b/internal/bin/cldev
@@ -16,7 +16,9 @@ source internal/bin/clenv
 export ROOT=$PROJECT_ROOT/internal/clroot
 
 mainexec() {
-  go run -ldflags "$LDFLAGS" main.go $@
+  mkdir -p tmp
+  go build -o tmp/cldevbuild -ldflags "$LDFLAGS" main.go
+  tmp/cldevbuild $@
 }
 
 if [ "$#" == 0 ]; then
@@ -38,6 +40,7 @@ case "$1" in
     ;;
   clean)
     rm -f $ROOT/db.bolt $ROOT/log.jsonl
+    rm -f tmp/cldevbuild
     ;;
   migration)
     timestamp=$(date +%s)


### PR DESCRIPTION
Like symbols. Apparently go run is only to be used for code
snippets.