### PR TITLE
 Add Link address helper to Chainlinked contract 

### DIFF
--- a/examples/ropsten/contracts/RopstenConsumer.sol
+++ b/examples/ropsten/contracts/RopstenConsumer.sol
@@ -754,6 +754,10 @@ contract Oracle is Ownable {
     bytes data
   );
 
+  event CancelRequest(
+    uint256 internalId
+  );
+
   constructor(address _link) Ownable() public {
     LINK = LinkToken(_link);
   }
@@ -833,6 +837,7 @@ contract Oracle is Ownable {
     Callback memory cb = callbacks[internalId];
     require(LINK.transfer(cb.addr, cb.amount), "Unable to transfer");
     delete callbacks[internalId];
+    emit CancelRequest(internalId);
   }
 
   // MODIFIERS
@@ -930,21 +935,21 @@ contract Chainlinked {
     returns (bytes32)
   {
     _run.requestId = bytes32(requests);
-    _run.close();
-    require(link.transferAndCall(oracle, _amount, _run.encodeForOracle(clArgsVersion)), "unable to transferAndCall to oracle");
-    emit ChainlinkRequested(_run.requestId);
-    unfulfilledRequests[_run.requestId] = oracle;
-
     requests += 1;
+    _run.close();
+    unfulfilledRequests[_run.requestId] = oracle;
+    emit ChainlinkRequested(_run.requestId);
+    require(link.transferAndCall(oracle, _amount, _run.encodeForOracle(clArgsVersion)), "unable to transferAndCall to oracle");
+
     return _run.requestId;
   }
 
   function cancelChainlinkRequest(bytes32 _requestId)
     internal
   {
-    oracle.cancel(_requestId);
     delete unfulfilledRequests[_requestId];
     emit ChainlinkCancelled(_requestId);
+    oracle.cancel(_requestId);
   }
 
   function LINK(uint256 _amount) internal view returns (uint256) {
@@ -957,6 +962,14 @@ contract Chainlinked {
 
   function setLinkToken(address _link) internal {
     link = LinkToken(_link);
+  }
+
+  function getLinkToken()
+    internal
+    view
+    returns (address)
+  {
+    return address(link);
   }
 
   function newChainlinkWithENS(address _ens, bytes32 _node)
@@ -1089,6 +1102,11 @@ contract RopstenConsumer is Chainlinked, Ownable {
   {
     emit RequestEthereumLastMarket(_requestId, _market);
     lastMarket = _market;
+  }
+
+  function withdrawLink() public onlyOwner {
+    LinkToken link = LinkToken(getLinkToken());
+    require(link.transfer(msg.sender, link.balanceOf(address(this))), "Unable to transfer");
   }
 
 }

--- a/examples/ropsten/contracts/RopstenConsumerBase.sol
+++ b/examples/ropsten/contracts/RopstenConsumerBase.sol
@@ -102,4 +102,9 @@ contract RopstenConsumer is Chainlinked, Ownable {
     lastMarket = _market;
   }
 
+  function withdrawLink() public onlyOwner {
+    LinkToken link = LinkToken(getLinkToken());
+    require(link.transfer(msg.sender, link.balanceOf(address(this))), "Unable to transfer");
+  }
+
 }

--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -70,6 +70,14 @@ contract Chainlinked {
     link = LinkToken(_link);
   }
 
+  function getLinkToken()
+    internal
+    view
+    returns (address)
+  {
+    return address(link);
+  }
+
   function newChainlinkWithENS(address _ens, bytes32 _node)
     internal
     returns (address, address)

--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -70,7 +70,7 @@ contract Chainlinked {
     link = LinkToken(_link);
   }
 
-  function getLinkToken()
+  function chainlinkToken()
     internal
     view
     returns (address)

--- a/solidity/contracts/examples/ConcreteChainlinked.sol
+++ b/solidity/contracts/examples/ConcreteChainlinked.sol
@@ -54,8 +54,8 @@ contract ConcreteChainlinked is Chainlinked {
     cancelChainlinkRequest(_requestId);
   }
 
-  function publicGetLinkToken() public returns (address) {
-    return getLinkToken();
+  function publicChainlinkToken() public returns (address) {
+    return chainlinkToken();
   }
 
   function fulfillRequest(bytes32 _requestId, bytes32 _)

--- a/solidity/contracts/examples/ConcreteChainlinked.sol
+++ b/solidity/contracts/examples/ConcreteChainlinked.sol
@@ -54,6 +54,10 @@ contract ConcreteChainlinked is Chainlinked {
     cancelChainlinkRequest(_requestId);
   }
 
+  function publicGetLinkToken() public returns (address) {
+    return getLinkToken();
+  }
+
   function fulfillRequest(bytes32 _requestId, bytes32 _)
     public
     checkChainlinkFulfillment(_requestId)

--- a/solidity/contracts/examples/Consumer.sol
+++ b/solidity/contracts/examples/Consumer.sol
@@ -24,6 +24,11 @@ contract Consumer is Chainlinked {
     cancelChainlinkRequest(_requestId);
   }
 
+  function withdrawLink() public {
+    LinkToken link = LinkToken(getLinkToken());
+    require(link.transfer(msg.sender, link.balanceOf(address(this))), "Unable to transfer");
+  }
+
   function fulfill(bytes32 _requestId, bytes32 _price)
     public
     checkChainlinkFulfillment(_requestId)

--- a/solidity/contracts/examples/Consumer.sol
+++ b/solidity/contracts/examples/Consumer.sol
@@ -25,7 +25,7 @@ contract Consumer is Chainlinked {
   }
 
   function withdrawLink() public {
-    LinkToken link = LinkToken(getLinkToken());
+    LinkToken link = LinkToken(chainlinkToken());
     require(link.transfer(msg.sender, link.balanceOf(address(this))), "Unable to transfer");
   }
 

--- a/solidity/test/BasicConsumer_test.js
+++ b/solidity/test/BasicConsumer_test.js
@@ -144,4 +144,20 @@ contract('BasicConsumer', () => {
       await cc.cancelRequest(requestId, {from: consumer})
     })
   })
+
+  describe('#withdrawLink', () => {
+    beforeEach(async () => {
+      await link.transfer(cc.address, web3.toWei('1', 'ether'))
+      const balance = await link.balanceOf(cc.address);
+      assert.equal(balance.toString(), web3.toWei('1', 'ether'));
+    })
+
+    it('transfers LINK out of the contract', async () => {
+      await cc.withdrawLink({from: consumer});
+      const ccBalance = await link.balanceOf(cc.address);
+      const consumerBalance = await link.balanceOf(consumer);
+      assert.equal(ccBalance.toString(), '0');
+      assert.equal(consumerBalance.toString(), web3.toWei('1', 'ether'));
+    })
+  })
 })

--- a/solidity/test/ConcreteChainlinked_test.js
+++ b/solidity/test/ConcreteChainlinked_test.js
@@ -102,9 +102,9 @@ contract('ConcreteChainlinked', () => {
     })
   })
 
-  describe('#getLinkToken', () => {
+  describe('#chainlinkToken', () => {
     it('returns the Link Token address', async () => {
-      const addr = await cc.publicGetLinkToken.call();
+      const addr = await cc.publicChainlinkToken.call();
       assert.equal(addr, link.address)
     })
   })

--- a/solidity/test/ConcreteChainlinked_test.js
+++ b/solidity/test/ConcreteChainlinked_test.js
@@ -102,6 +102,13 @@ contract('ConcreteChainlinked', () => {
     })
   })
 
+  describe('#getLinkToken', () => {
+    it('returns the Link Token address', async () => {
+      const addr = await cc.publicGetLinkToken.call();
+      assert.equal(addr, link.address)
+    })
+  })
+
   describe('#LINK', () => {
     it('multiplies the value by a trillion', async () => {
       await cc.publicLINK(1)


### PR DESCRIPTION
Allows the consuming contract writer to access the LinkToken address without exposing the private variable.