### PR TITLE
Update flatten-ropsten and add npm command

### DIFF
--- a/internal/bin/flatten-ropsten
+++ b/internal/bin/flatten-ropsten
@@ -2,4 +2,4 @@
 
 cd solidity
 rm -f ../examples/ropsten/contracts/RopstenConsumer.sol
-truffle-flattener ../examples/ropsten/contracts/RopstenConsumerBase.sol > ../examples/ropsten/contracts/RopstenConsumer.sol
+./node_modules/.bin/truffle-flattener ../examples/ropsten/contracts/RopstenConsumerBase.sol > ../examples/ropsten/contracts/RopstenConsumer.sol

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint-ci": "standard --verbose | snazzy",
     "test": "NODE_ENV=test jest",
     "test-ci": "NODE_ENV=test yarn jest -i --reporters jest-silent-reporter",
-    "watch": "NODE_ENV=test jest --watchAll --notify"
+    "watch": "NODE_ENV=test jest --watchAll --notify",
+    "flatten": "./internal/bin/flatten-ropsten"
   },
   "dependencies": {
     "change-case": "^3.0.2",


### PR DESCRIPTION
I noticed we may have different versions of `truffle-flattener` on our machines, so this ensures we're all on the same version.