### PR TITLE
enable bridges to pass their callback URL

### DIFF
--- a/adapters/http_test.go
+++ b/adapters/http_test.go
@@ -15,8 +15,8 @@ func TestHttpAdapters_NotAUrlError(t *testing.T) {
 		name    string
 		adapter adapters.BaseAdapter
 	}{
-		{"HTTPGet", &adapters.HTTPGet{URL: cltest.MustParseWebURL("NotAURL")}},
-		{"HTTPPost", &adapters.HTTPPost{URL: cltest.MustParseWebURL("NotAURL")}},
+		{"HTTPGet", &adapters.HTTPGet{URL: cltest.WebURL("NotAURL")}},
+		{"HTTPPost", &adapters.HTTPPost{URL: cltest.WebURL("NotAURL")}},
 	}
 
 	for _, tt := range tests {
@@ -54,7 +54,7 @@ func TestHttpGet_Perform(t *testing.T) {
 				func(_ http.Header, body string) { assert.Equal(t, ``, body) })
 			defer cleanup()
 
-			hga := adapters.HTTPGet{URL: cltest.MustParseWebURL(mock.URL)}
+			hga := adapters.HTTPGet{URL: cltest.WebURL(mock.URL)}
 			result := hga.Perform(input, nil)
 
 			val, err := result.Value()
@@ -91,7 +91,7 @@ func TestHttpPost_Perform(t *testing.T) {
 				func(_ http.Header, body string) { assert.Equal(t, wantedBody, body) })
 			defer cleanup()
 
-			hpa := adapters.HTTPPost{URL: cltest.MustParseWebURL(mock.URL)}
+			hpa := adapters.HTTPPost{URL: cltest.WebURL(mock.URL)}
 			result := hpa.Perform(input, nil)
 
 			val := result.Get("value")

--- a/cmd/local_client_test.go
+++ b/cmd/local_client_test.go
@@ -58,6 +58,7 @@ func TestClient_RunNodeShowsEnv(t *testing.T) {
 	assert.Contains(t, logs, "ORACLE_CONTRACT_ADDRESS: \\n")
 	assert.Contains(t, logs, "DATABASE_POLL_INTERVAL: 500ms\\n")
 	assert.Contains(t, logs, "ALLOW_ORIGINS: http://localhost:3000,http://localhost:6689\\n")
+	assert.Contains(t, logs, "BRIDGE_RESPONSE_URL: http://localhost:6688\\n")
 }
 
 func TestClient_RunNodeWithPasswords(t *testing.T) {

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -92,6 +92,7 @@ func NewConfigWithWSServer(wsserver *httptest.Server) *TestConfig {
 	config := TestConfig{
 		Config: store.Config{
 			AllowOrigins:             "http://localhost:3000,http://localhost:6689",
+			BridgeResponseURL:        WebURL("http://localhost:6688"),
 			ChainID:                  3,
 			DatabaseTimeout:          store.Duration{Duration: time.Millisecond * 500},
 			Dev:                      true,
@@ -756,13 +757,6 @@ func WaitForJobs(t *testing.T, store *store.Store, want int) []models.JobSpec {
 		}).Should(gomega.HaveLen(want))
 	}
 	return jobs
-}
-
-// MustParseWebURL must parse the given url and return it
-func MustParseWebURL(str string) models.WebURL {
-	u, err := url.Parse(str)
-	mustNotErr(err)
-	return models.WebURL{URL: u}
 }
 
 // ParseISO8601 given the time string it Must parse the time and return it

--- a/internal/cltest/factories.go
+++ b/internal/cltest/factories.go
@@ -160,7 +160,7 @@ func NewBridgeTypeWithConfirmations(confirmations uint64, info ...string) models
 func WebURL(unparsed string) models.WebURL {
 	parsed, err := url.Parse(unparsed)
 	mustNotErr(err)
-	return models.WebURL{URL: parsed}
+	return models.WebURL(*parsed)
 }
 
 // NullString creates null.String from given value

--- a/services/validators_test.go
+++ b/services/validators_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"net/url"
-
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store/models"
@@ -61,9 +59,7 @@ func TestValidateAdapter(t *testing.T) {
 
 	tt := models.BridgeType{}
 	tt.Name = models.MustNewTaskType("solargridreporting")
-	u, err := url.Parse("https://denergy.eth")
-	assert.NoError(t, err)
-	tt.URL = models.WebURL{URL: u}
+	tt.URL = cltest.WebURL("https://denergy.eth")
 	assert.NoError(t, store.Save(&tt))
 
 	tests := []struct {

--- a/store/config.go
+++ b/store/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/store/assets"
+	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/utils"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -29,6 +30,7 @@ import (
 // by setting environment variables.
 type Config struct {
 	AllowOrigins             string          `env:"ALLOW_ORIGINS" envDefault:"http://localhost:3000,http://localhost:6688"`
+	BridgeResponseURL        models.WebURL   `env:"BRIDGE_RESPONSE_URL" envDefault:""`
 	ChainID                  uint64          `env:"ETH_CHAIN_ID" envDefault:"0"`
 	ClientNodeURL            string          `env:"CLIENT_NODE_URL" envDefault:"http://localhost:6688"`
 	DatabaseTimeout          Duration        `env:"DATABASE_TIMEOUT" envDefault:"500ms"`
@@ -37,6 +39,7 @@ type Config struct {
 	EthGasBumpWei            big.Int         `env:"ETH_GAS_BUMP_WEI" envDefault:"5000000000"`
 	EthGasPriceDefault       big.Int         `env:"ETH_GAS_PRICE_DEFAULT" envDefault:"20000000000"`
 	EthereumURL              string          `env:"ETH_URL" envDefault:"ws://localhost:8546"`
+	JSONStdout               bool            `env:"JSON_STDOUT" envDefault:"false"`
 	LinkContractAddress      string          `env:"LINK_CONTRACT_ADDRESS" envDefault:"0x514910771AF9Ca656af840dff83E8264EcF986CA"`
 	LogLevel                 LogLevel        `env:"LOG_LEVEL" envDefault:"info"`
 	MinIncomingConfirmations uint64          `env:"MIN_INCOMING_CONFIRMATIONS" envDefault:"0"`
@@ -45,15 +48,14 @@ type Config struct {
 	MinimumRequestExpiration uint64          `env:"MINIMUM_REQUEST_EXPIRATION" envDefault:"300"`
 	OracleContractAddress    *common.Address `env:"ORACLE_CONTRACT_ADDRESS"`
 	Port                     uint16          `env:"CHAINLINK_PORT" envDefault:"6688"`
-	TLSPort                  uint16          `env:"CHAINLINK_TLS_PORT" envDefault:"6689"`
-	TLSHost                  string          `env:"CHAINLINK_TLS_HOST" envDefault:""`
+	ReaperExpiration         Duration        `env:"REAPER_EXPIRATION" envDefault:"240h"`
 	RootDir                  string          `env:"ROOT" envDefault:"~/.chainlink"`
-	JSONStdout               bool            `env:"JSON_STDOUT" envDefault:"false"`
+	SessionTimeout           Duration        `env:"SESSION_TIMEOUT" envDefault:"15m"`
+	TLSCertPath              string          `env:"TLS_CERT_PATH" envDefault:""`
+	TLSHost                  string          `env:"CHAINLINK_TLS_HOST" envDefault:""`
+	TLSKeyPath               string          `env:"TLS_KEY_PATH" envDefault:""`
+	TLSPort                  uint16          `env:"CHAINLINK_TLS_PORT" envDefault:"6689"`
 	SecretGenerator          SecretGenerator
-	TLSCertPath              string   `env:"TLS_CERT_PATH" envDefault:""`
-	TLSKeyPath               string   `env:"TLS_KEY_PATH" envDefault:""`
-	SessionTimeout           Duration `env:"SESSION_TIMEOUT" envDefault:"15m"`
-	ReaperExpiration         Duration `env:"REAPER_EXPIRATION" envDefault:"240h"`
 }
 
 // NewConfig returns the config with the environment variables set to their

--- a/store/config_test.go
+++ b/store/config_test.go
@@ -24,6 +24,7 @@ func TestStore_ConfigDefaults(t *testing.T) {
 	assert.Equal(t, "0x514910771AF9Ca656af840dff83E8264EcF986CA", common.HexToAddress(config.LinkContractAddress).String())
 	assert.Equal(t, *assets.NewLink(1000000000000000000), config.MinimumContractPayment)
 	assert.Equal(t, 15*time.Minute, config.SessionTimeout.Duration)
+	assert.Equal(t, "", config.BridgeResponseURL.String())
 }
 
 func TestConfig_sessionSecret(t *testing.T) {

--- a/store/models/common.go
+++ b/store/models/common.go
@@ -217,9 +217,7 @@ func (j JSON) CBOR() ([]byte, error) {
 }
 
 // WebURL contains the URL of the endpoint.
-type WebURL struct {
-	*url.URL
-}
+type WebURL url.URL
 
 // UnmarshalJSON parses the raw URL stored in JSON-encoded
 // data to a URL structure and sets it to the URL field.
@@ -233,21 +231,19 @@ func (w *WebURL) UnmarshalJSON(j []byte) error {
 	if err != nil {
 		return err
 	}
-	w.URL = u
+	*w = WebURL(*u)
 	return nil
 }
 
 // MarshalJSON returns the JSON-encoded string of the given data.
-func (w *WebURL) MarshalJSON() ([]byte, error) {
+func (w WebURL) MarshalJSON() ([]byte, error) {
 	return json.Marshal(w.String())
 }
 
 // String delegates to the wrapped URL struct or an empty string when it is nil
-func (w *WebURL) String() string {
-	if w.URL == nil {
-		return ""
-	}
-	return w.URL.String()
+func (w WebURL) String() string {
+	url := url.URL(w)
+	return url.String()
 }
 
 // Time holds a common field for time.

--- a/store/models/common_test.go
+++ b/store/models/common_test.go
@@ -249,7 +249,7 @@ func TestWebURL_MarshalJSON(t *testing.T) {
 	str := "http://www.duckduckgo.com"
 	parsed, err := url.ParseRequestURI(str)
 	assert.NoError(t, err)
-	wurl := &models.WebURL{URL: parsed}
+	wurl := models.WebURL(*parsed)
 	b, err := json.Marshal(wurl)
 	assert.NoError(t, err)
 	assert.Equal(t, `"`+str+`"`, string(b))
@@ -259,9 +259,7 @@ func TestWebURL_String_HasURL(t *testing.T) {
 	t.Parallel()
 
 	u, _ := url.Parse("http://www.duckduckgo.com")
-	w := models.WebURL{
-		URL: u,
-	}
+	w := models.WebURL(*u)
 
 	assert.Equal(t, "http://www.duckduckgo.com", w.String())
 }

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -3,7 +3,6 @@ package orm_test
 import (
 	"encoding/hex"
 	"math/big"
-	"net/url"
 	"testing"
 	"time"
 
@@ -250,9 +249,7 @@ func TestFindBridge(t *testing.T) {
 
 	tt := models.BridgeType{}
 	tt.Name = models.MustNewTaskType("solargridreporting")
-	u, err := url.Parse("https://denergy.eth")
-	assert.NoError(t, err)
-	tt.URL = models.WebURL{URL: u}
+	tt.URL = cltest.WebURL("https://denergy.eth")
 	assert.NoError(t, store.Save(&tt))
 
 	cases := []struct {

--- a/store/presenters/presenters.go
+++ b/store/presenters/presenters.go
@@ -104,54 +104,56 @@ func (a *AccountBalance) SetID(value string) error {
 // ConfigWhitelist are the non-secret values of the node
 type ConfigWhitelist struct {
 	AllowOrigins             string          `json:"allowOrigins"`
+	BridgeResponseURL        string          `json:"bridgeResponseURL,omitempty"`
 	ChainID                  uint64          `json:"ethChainId"`
 	ChainlinkDev             bool            `json:"chainlinkDev"`
 	ClientNodeURL            string          `json:"clientNodeUrl"`
 	DatabaseTimeout          store.Duration  `json:"databaseTimeout"`
+	EthereumURL              string          `json:"ethUrl"`
 	EthGasBumpThreshold      uint64          `json:"ethGasBumpThreshold"`
 	EthGasBumpWei            *big.Int        `json:"ethGasBumpWei"`
 	EthGasPriceDefault       *big.Int        `json:"ethGasPriceDefault"`
-	EthereumURL              string          `json:"ethUrl"`
 	LinkContractAddress      string          `json:"linkContractAddress"`
 	LogLevel                 store.LogLevel  `json:"logLevel"`
-	MinIncomingConfirmations uint64          `json:"minIncomingConfirmations"`
-	MinOutgoingConfirmations uint64          `json:"minOutgoingConfirmations"`
 	MinimumContractPayment   *assets.Link    `json:"minimumContractPayment"`
 	MinimumRequestExpiration uint64          `json:"minimumRequestExpiration"`
+	MinIncomingConfirmations uint64          `json:"minIncomingConfirmations"`
+	MinOutgoingConfirmations uint64          `json:"minOutgoingConfirmations"`
 	OracleContractAddress    *common.Address `json:"oracleContractAddress"`
 	Port                     uint16          `json:"chainlinkPort"`
-	TLSPort                  uint16          `json:"chainlinkTLSPort"`
-	TLSHost                  string          `json:"chainlinkTLSHost"`
+	ReaperExpiration         store.Duration  `json:"reaperExpiration"`
 	RootDir                  string          `json:"root"`
 	SessionTimeout           store.Duration  `json:"sessionTimeout"`
-	ReaperExpiration         store.Duration  `json:"reaperExpiration"`
+	TLSHost                  string          `json:"chainlinkTLSHost"`
+	TLSPort                  uint16          `json:"chainlinkTLSPort"`
 }
 
 // NewConfigWhitelist creates an instance of ConfigWhitelist
 func NewConfigWhitelist(config store.Config) ConfigWhitelist {
 	return ConfigWhitelist{
 		AllowOrigins:             config.AllowOrigins,
+		BridgeResponseURL:        config.BridgeResponseURL.String(),
 		ChainID:                  config.ChainID,
 		ChainlinkDev:             config.Dev,
 		ClientNodeURL:            config.ClientNodeURL,
 		DatabaseTimeout:          config.DatabaseTimeout,
+		EthereumURL:              config.EthereumURL,
 		EthGasBumpThreshold:      config.EthGasBumpThreshold,
 		EthGasBumpWei:            &config.EthGasBumpWei,
 		EthGasPriceDefault:       &config.EthGasPriceDefault,
-		EthereumURL:              config.EthereumURL,
 		LinkContractAddress:      config.LinkContractAddress,
 		LogLevel:                 config.LogLevel,
-		MinIncomingConfirmations: config.MinIncomingConfirmations,
-		MinOutgoingConfirmations: config.MinOutgoingConfirmations,
 		MinimumContractPayment:   &config.MinimumContractPayment,
 		MinimumRequestExpiration: config.MinimumRequestExpiration,
+		MinIncomingConfirmations: config.MinIncomingConfirmations,
+		MinOutgoingConfirmations: config.MinOutgoingConfirmations,
 		OracleContractAddress:    config.OracleContractAddress,
 		Port:                     config.Port,
-		TLSPort:                  config.TLSPort,
-		TLSHost:                  config.TLSHost,
+		ReaperExpiration:         config.ReaperExpiration,
 		RootDir:                  config.RootDir,
 		SessionTimeout:           config.SessionTimeout,
-		ReaperExpiration:         config.ReaperExpiration,
+		TLSHost:                  config.TLSHost,
+		TLSPort:                  config.TLSPort,
 	}
 }
 
@@ -177,7 +179,8 @@ func (c ConfigWhitelist) String() string {
 		"ALLOW_ORIGINS: %s\n" +
 		"CHAINLINK_DEV: %v\n" +
 		"SESSION_TIMEOUT: %v\n" +
-		"REAPER_EXPIRATION: %v\n"
+		"REAPER_EXPIRATION: %v\n" +
+		"BRIDGE_RESPONSE_URL: %s\n"
 
 	oracleContractAddress := ""
 	if c.OracleContractAddress != nil {
@@ -207,6 +210,7 @@ func (c ConfigWhitelist) String() string {
 		c.ChainlinkDev,
 		c.SessionTimeout,
 		c.ReaperExpiration,
+		c.BridgeResponseURL,
 	)
 }
 

--- a/web/config_controller_test.go
+++ b/web/config_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConfigController_Show(t *testing.T) {
@@ -25,8 +26,7 @@ func TestConfigController_Show(t *testing.T) {
 	cltest.AssertServerResponse(t, resp, 200)
 
 	cwl := presenters.ConfigWhitelist{}
-	err := cltest.ParseJSONAPIResponse(resp, &cwl)
-	assert.NoError(t, err)
+	require.NoError(t, cltest.ParseJSONAPIResponse(resp, &cwl))
 
 	assert.Equal(t, store.LogLevel{Level: -1}, cwl.LogLevel)
 	assert.Contains(t, cwl.RootDir, "/tmp/chainlink_test/")


### PR DESCRIPTION
If the configuration variable `BRIDGE_RESPONSE_URL` is specified, it is passed to the bridge adapter along with the route of the run e.g `v2/runs/89adf09b1367460dabfc39c5d00260ca`. The Bridge adaptor can then respond to this URL. If it is not specified, the bridge adapter is responsible for constructing the URL itself.

Signed-off-by: Steve Ellis <email@steveell.is>
Signed-off-by: John Barker <jebarker@gmail.com>