### PR TITLE
Fix old password incorrect error

### DIFF
--- a/cmd/remote_client.go
+++ b/cmd/remote_client.go
@@ -311,7 +311,13 @@ func (cli *Client) ChangePassword(c *clipkg.Context) error {
 	}
 	defer resp.Body.Close()
 
-	fmt.Println("Password updated.")
+	if resp.StatusCode == http.StatusOK {
+		fmt.Println("Password updated.")
+	} else if resp.StatusCode == http.StatusConflict {
+		fmt.Println("Old password did not match.")
+	} else {
+		return cli.printResponseBody(resp)
+	}
 	return nil
 }
 

--- a/web/router.go
+++ b/web/router.go
@@ -283,10 +283,11 @@ func readBody(reader io.Reader) string {
 	return s
 }
 
+// NOTE: keys must be in lowercase for case insensitive match
 var blacklist = map[string]struct{}{
 	"password":    struct{}{},
-	"newPassword": struct{}{},
-	"oldPassword": struct{}{},
+	"newpassword": struct{}{},
+	"oldpassword": struct{}{},
 }
 
 func readSanitizedJSON(buf *bytes.Buffer) (string, error) {

--- a/web/user_controller.go
+++ b/web/user_controller.go
@@ -75,7 +75,7 @@ func (c *UserController) UpdatePassword(ctx *gin.Context) {
 	} else if user, err := c.App.Store.FindUser(); err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, fmt.Errorf("failed to obtain current user record: %+v", err))
 	} else if !utils.CheckPasswordHash(request.OldPassword, user.HashedPassword) {
-		publicError(ctx, http.StatusUnauthorized, errors.New("Old password does not match"))
+		publicError(ctx, http.StatusConflict, errors.New("Old password does not match"))
 	} else if err := c.updateUserPassword(ctx, &user, request.NewPassword); err != nil {
 		ctx.AbortWithError(http.StatusInternalServerError, err)
 	} else if json, err := jsonapi.Marshal(presenters.UserPresenter{User: &user}); err != nil {

--- a/web/user_controller_test.go
+++ b/web/user_controller_test.go
@@ -26,7 +26,7 @@ func TestUserController_UpdatePassword(t *testing.T) {
 		bytes.NewBufferString(`{"oldPassword": "wrong password"}`))
 	defer cleanup()
 	errors = cltest.ParseJSONAPIErrors(resp.Body)
-	assert.Equal(t, 401, resp.StatusCode)
+	assert.Equal(t, 409, resp.StatusCode)
 	assert.Len(t, errors.Errors, 1)
 	assert.Equal(t, "Old password does not match", errors.Errors[0].Detail)
 


### PR DESCRIPTION
 * Use a unique status code for incorrect old password
 * Check response status code to decide what to print in chpass
 * Make sure to match on lowercase passwords in json sanitization