### PR TITLE
Save the Overrides on a job immediately, vs sending in the channel

### DIFF
--- a/adapters/sleep.go
+++ b/adapters/sleep.go
@@ -22,7 +22,7 @@ func (adapter *Sleep) Perform(input models.RunResult, str *store.Store) models.R
 	input.Status = models.RunStatusPendingSleep
 	go func() {
 		<-str.Clock.After(duration)
-		if err := str.RunChannel.Send(input.JobRunID, input, nil); err != nil {
+		if err := str.RunChannel.Send(input.JobRunID, nil); err != nil {
 			logger.Error("Sleep Adapter Perform:", err.Error())
 		}
 	}()

--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -623,8 +623,8 @@ func NewMockRunChannel() *MockRunChannel {
 	}
 }
 
-func (m *MockRunChannel) Send(jobRunID string, rr models.RunResult, ibn *models.IndexableBlockNumber) error {
-	m.Runs = append(m.Runs, rr)
+func (m *MockRunChannel) Send(jobRunID string, ibn *models.IndexableBlockNumber) error {
+	m.Runs = append(m.Runs, models.RunResult{})
 	copy := *ibn
 	m.BlockNumbers = append(m.BlockNumbers, &copy)
 	return nil

--- a/services/export_test.go
+++ b/services/export_test.go
@@ -8,10 +8,9 @@ import (
 func ExportedExecuteRunAtBlock(
 	run models.JobRun,
 	store *store.Store,
-	overrides models.RunResult,
 	blockNumber *models.IndexableBlockNumber,
 ) (models.JobRun, error) {
-	return executeRunAtBlock(run, store, overrides, blockNumber)
+	return executeRunAtBlock(run, store, blockNumber)
 }
 
 func ExportedChannelForRun(jr JobRunner, runID string) chan<- store.RunRequest {

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -86,12 +86,12 @@ func (js *jobSubscriber) Disconnect() {
 func (js *jobSubscriber) OnNewHead(head *models.BlockHeader) {
 	pendingRuns, err := js.store.JobRunsWithStatus(models.RunStatusPendingConfirmations, models.RunStatusInProgress)
 	if err != nil {
-		logger.Error(err.Error())
+		logger.Error("error fetching pending job runs:", err.Error())
 	}
 
 	ibn := head.ToIndexableBlockNumber()
 	for _, jr := range pendingRuns {
-		if err := js.store.RunChannel.Send(jr.ID, jr.Result, ibn); err != nil {
+		if err := js.store.RunChannel.Send(jr.ID, ibn); err != nil {
 			logger.Error("JobSubscriber.OnNewHead: ", err.Error())
 		}
 	}

--- a/services/job_subscriber_test.go
+++ b/services/job_subscriber_test.go
@@ -180,7 +180,6 @@ func TestJobSubscriber_OnNewHead_OnlySendPendingConfirmationsAndInProgress(t *te
 			if test.wantSend {
 				assert.Equal(t, 1, len(mockRunChannel.Runs))
 				assert.Equal(t, block.Number, mockRunChannel.BlockNumbers[0].Number)
-				assert.Equal(t, test.status, mockRunChannel.Runs[0].Status)
 			} else {
 				assert.Equal(t, 0, len(mockRunChannel.Runs))
 			}

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -54,7 +54,7 @@ func TestJobRun_UnfinishedTaskRuns(t *testing.T) {
 	assert.NoError(t, store.Save(&run))
 	assert.Equal(t, run.TaskRuns, run.UnfinishedTaskRuns())
 
-	store.RunChannel.Send(run.ID, models.RunResult{}, nil)
+	store.RunChannel.Send(run.ID, nil)
 	cltest.WaitForJobRunStatus(t, store, run, models.RunStatusPendingConfirmations)
 
 	store.One("ID", run.ID, &run)

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -290,7 +290,7 @@ func TestORM_PendingBridgeType_alreadyCompleted(t *testing.T) {
 	run := job.NewRun(initr)
 	assert.NoError(t, store.Save(&run))
 
-	store.RunChannel.Send(run.ID, models.RunResult{}, nil)
+	store.RunChannel.Send(run.ID, nil)
 	cltest.WaitForJobRunStatus(t, store, run, models.RunStatusCompleted)
 
 	_, err := store.PendingBridgeType(run)

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -57,17 +57,14 @@ func TestStore_Close(t *testing.T) {
 
 	s, cleanup := cltest.NewStore()
 	defer cleanup()
-	want := models.RunResult{}
 
-	s.RunChannel.Send("whatever", want, nil)
-	s.RunChannel.Send("whatever", want, nil)
+	s.RunChannel.Send("whatever", nil)
+	s.RunChannel.Send("whatever", nil)
 
 	rr, open := <-s.RunChannel.Receive()
-	assert.Equal(t, want, rr.Input)
 	assert.True(t, open)
 
 	rr, open = <-s.RunChannel.Receive()
-	assert.Equal(t, want, rr.Input)
 	assert.True(t, open)
 
 	assert.NoError(t, s.Close())
@@ -81,12 +78,10 @@ func TestQueuedRunChannel_Send(t *testing.T) {
 	t.Parallel()
 
 	rq := store.NewQueuedRunChannel()
-	input1 := models.RunResult{}
 	ibn1 := cltest.IndexableBlockNumber(17)
 
-	assert.NoError(t, rq.Send("first", input1, ibn1))
+	assert.NoError(t, rq.Send("first", ibn1))
 	rr1 := <-rq.Receive()
-	assert.Equal(t, input1, rr1.Input)
 	assert.Equal(t, ibn1, rr1.BlockNumber)
 }
 
@@ -94,10 +89,9 @@ func TestQueuedRunChannel_Send_afterClose(t *testing.T) {
 	t.Parallel()
 
 	rq := store.NewQueuedRunChannel()
-	input1 := models.RunResult{JobRunID: "first"}
 	ibn1 := cltest.IndexableBlockNumber(17)
 
 	rq.Close()
 
-	assert.Error(t, rq.Send("first", input1, ibn1))
+	assert.Error(t, rq.Send("first", ibn1))
 }

--- a/web/job_runs_controller_test.go
+++ b/web/job_runs_controller_test.go
@@ -2,6 +2,7 @@ package web_test
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"net/http"
 	"testing"
@@ -277,6 +278,35 @@ func TestJobRunsController_Update_WithError(t *testing.T) {
 	val, err := jr.Result.Value()
 	assert.NoError(t, err)
 	assert.Equal(t, "0", val)
+}
+
+func TestJobRunsController_Update_WithMergeError(t *testing.T) {
+	t.Parallel()
+	app, cleanup := cltest.NewApplication()
+	app.Start()
+	defer cleanup()
+
+	bt := cltest.NewBridgeType()
+	assert.Nil(t, app.Store.Save(&bt))
+	j, initr := cltest.NewJobWithWebInitiator()
+	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
+	assert.Nil(t, app.Store.Save(&j))
+	jr := cltest.MarkJobRunPendingBridge(j.NewRun(initr), 0)
+	jr.Overrides = jr.Overrides.WithError(errors.New("Already errored")) // easy way to force Merge error
+	assert.Nil(t, app.Store.Save(&jr))
+
+	body := fmt.Sprintf(`{"id":"%v","data":{"value": "100"}}`, jr.ID)
+	headers := map[string]string{"Authorization": "Bearer " + bt.IncomingToken}
+	url := app.Config.ClientNodeURL + "/v2/runs/" + jr.ID
+	resp, cleanup := cltest.UnauthenticatedPatch(url, bytes.NewBufferString(body), headers)
+	defer cleanup()
+
+	assert.Equal(t, 200, resp.StatusCode, "Response should be successful")
+	jrID := cltest.ParseCommonJSON(resp.Body).ID
+	assert.Equal(t, jr.ID, jrID)
+
+	jr = cltest.WaitForJobRunStatus(t, app.Store, jr, models.RunStatusErrored)
+	assert.Contains(t, jr.Result.ErrorMessage.String, "Cannot merge")
 }
 
 func TestJobRunsController_Update_BadInput(t *testing.T) {


### PR DESCRIPTION
Partially address #159710789, by saving Overrides directly to the JobRun on creation and in the case of resuming a bridge adapter, saves the input to the TaskRun.