### PR TITLE
Features/ethbool core adapter

### DIFF
--- a/adapters/adapter.go
+++ b/adapters/adapter.go
@@ -11,6 +11,8 @@ import (
 var (
 	// TaskTypeCopy is the identifier for the Copy adapter.
 	TaskTypeCopy = models.MustNewTaskType("copy")
+	// TaskTypeEthBool is the identifier for the EthBool adapter.
+	TaskTypeEthBool = models.MustNewTaskType("ethbool")
 	// TaskTypeEthBytes32 is the identifier for the EthBytes32 adapter.
 	TaskTypeEthBytes32 = models.MustNewTaskType("ethbytes32")
 	// TaskTypeEthInt256 is the identifier for the EthInt256 adapter.
@@ -63,6 +65,9 @@ func For(task models.TaskSpec, store *store.Store) (*PipelineAdapter, error) {
 	switch task.Type {
 	case TaskTypeCopy:
 		ba = &Copy{}
+		err = unmarshalParams(task.Params, ba)
+	case TaskTypeEthBool:
+		ba = &EthBool{}
 		err = unmarshalParams(task.Params, ba)
 	case TaskTypeEthBytes32:
 		ba = &EthBytes32{}

--- a/adapters/doc.go
+++ b/adapters/doc.go
@@ -15,6 +15,12 @@
 // The JSONParse adapter will obtain the value(s) for the given field(s).
 //  { "type": "JSONParse", "path": ["someField"] }
 //
+// EthBool
+//
+// The EthBool adapter will take the given values and format them for
+// the Ethereum blockhain in boolean value.
+//  { "type": "EthBool" }
+//
 // EthBytes32
 //
 // The EthBytes32 adapter will take the given values and format them for

--- a/adapters/eth_bool.go
+++ b/adapters/eth_bool.go
@@ -1,0 +1,35 @@
+package adapters
+
+import (
+	"github.com/smartcontractkit/chainlink/store"
+	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/tidwall/gjson"
+)
+
+var evmFalse = "0x0000000000000000000000000000000000000000000000000000000000000000"
+var evmTrue = "0x0000000000000000000000000000000000000000000000000000000000000001"
+
+// EthBool holds no fields
+type EthBool struct{}
+
+// Perform returns the abi encoding for a boolean
+//
+// For example, after converting the value false to hex encoded Ethereum
+// ABI, it would be:
+// "0x0000000000000000000000000000000000000000000000000000000000000000"
+func (*EthBool) Perform(input models.RunResult, _ *store.Store) models.RunResult {
+	r := input.Get("value")
+	if boolean(r.Type) {
+		return input.WithValue(evmTrue)
+	}
+	return input.WithValue(evmFalse)
+}
+
+func boolean(t gjson.Type) bool {
+	switch t {
+	case gjson.False:
+		return false
+	default:
+		return true
+	}
+}

--- a/adapters/eth_bool_test.go
+++ b/adapters/eth_bool_test.go
@@ -1,0 +1,45 @@
+package adapters_test
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink/adapters"
+	"github.com/smartcontractkit/chainlink/internal/cltest"
+	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/stretchr/testify/assert"
+)
+
+var evmFalse = "0x0000000000000000000000000000000000000000000000000000000000000000"
+var evmTrue = "0x0000000000000000000000000000000000000000000000000000000000000001"
+
+func TestEthBool_Perform(t *testing.T) {
+	tests := []struct {
+		name     string
+		json     string
+		expected string
+	}{
+		{"bool false", `{"value":false}`, evmFalse},
+		{"bool true", `{"value":true}`, evmTrue},
+		{"true string", `{"value":"true"}`, evmTrue},
+		{"false string", `{"value":"false"}`, evmTrue},
+		{"number 5", `{"value":5}`, evmTrue},
+		{"number 0", `{"value":0}`, evmTrue},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			past := models.RunResult{
+				Data: cltest.JSONFromString(test.json),
+			}
+			adapter := adapters.EthBool{}
+			result := adapter.Perform(past, nil)
+
+			val, err := result.Value()
+			assert.Equal(t, test.expected, val)
+			assert.NoError(t, err)
+			assert.NoError(t, result.GetError())
+		})
+	}
+}


### PR DESCRIPTION
Add a new core adapter EthBool

Created a custom boolean case statement since the gjson library bool check does not match the story criteria.

```go
// Bool returns an boolean representation.
func (t Result) Bool() bool {
	switch t.Type {
	default:
		return false
	case True:
		return true
	case String:
		return t.Str != "" && t.Str != "0" && t.Str != "false"
	case Number:
		return t.Num != 0
	}
}
```