### PR TITLE
Job Resumption part に

### DIFF
--- a/adapters/sleep.go
+++ b/adapters/sleep.go
@@ -1,7 +1,8 @@
 package adapters
 
 import (
-	"github.com/smartcontractkit/chainlink/logger"
+	"time"
+
 	"github.com/smartcontractkit/chainlink/store"
 	"github.com/smartcontractkit/chainlink/store/models"
 )
@@ -13,19 +14,11 @@ type Sleep struct {
 
 // Perform returns the input RunResult after waiting for the specified Until parameter.
 func (adapter *Sleep) Perform(input models.RunResult, str *store.Store) models.RunResult {
-	duration := adapter.Until.DurationFromNow()
-	if duration <= 0 {
-		input.Status = models.RunStatusCompleted
-		return input
-	}
-
 	input.Status = models.RunStatusPendingSleep
-	go func() {
-		<-str.Clock.After(duration)
-		if err := str.RunChannel.Send(input.JobRunID, nil); err != nil {
-			logger.Error("Sleep Adapter Perform:", err.Error())
-		}
-	}()
-
 	return input
+}
+
+// Duration returns the amount of sleeping this task should be paused for.
+func (adapter *Sleep) Duration() time.Duration {
+	return adapter.Until.DurationFromNow()
 }

--- a/adapters/sleep_test.go
+++ b/adapters/sleep_test.go
@@ -2,9 +2,7 @@ package adapters_test
 
 import (
 	"encoding/json"
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/smartcontractkit/chainlink/adapters"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
@@ -12,58 +10,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func sleepFor(n int) string {
-	d := time.Duration(n)
-	return fmt.Sprintf(`{"until":%v}`, time.Now().Add(d*time.Second).Unix())
-}
-
 func TestSleep_Perform(t *testing.T) {
-	t.Parallel()
-	standardInput := models.RunResult{}
-	sleptInput := models.RunResult{
-		Status: models.RunStatusPendingSleep,
-	}
-
-	tests := []struct {
-		name         string
-		params       string
-		input        models.RunResult
-		wantStatus   models.RunStatus
-		parseErrored bool
-		errored      bool
-	}{
-		{"valid duration", sleepFor(60), standardInput, models.RunStatusPendingSleep, false, false},
-		{"past time", sleepFor(-1), standardInput, models.RunStatusCompleted, false, false},
-		{"json with iso8601", `{"until":"2222-07-20T12:54:49.000Z"}`, standardInput, models.RunStatusPendingSleep, false, false},
-		{"long duration", sleepFor(12592000), standardInput, models.RunStatusPendingSleep, false, false},
-		{"invalid json", `{"until":"1000h"}`, standardInput, models.RunStatusPendingSleep, true, false},
-		{"already slept", sleepFor(1000), sleptInput, models.RunStatusPendingSleep, false, false},
-	}
-
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
-	store.Clock = cltest.InstantClock{}
 
-	for _, tt := range tests {
-		test := tt
-		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
+	adapter := adapters.Sleep{}
+	err := json.Unmarshal([]byte(`{"until": 872835240}`), &adapter)
+	assert.NoError(t, err)
 
-			adapter := adapters.Sleep{}
-			err := json.Unmarshal([]byte(test.params), &adapter)
-			if test.parseErrored {
-				assert.Error(t, err)
-				return
-			}
-			assert.NoError(t, err)
-
-			result := adapter.Perform(test.input, store)
-			assert.Equal(t, test.wantStatus, result.Status)
-			if test.errored {
-				assert.Error(t, result.GetError())
-			} else {
-				assert.NoError(t, result.GetError())
-			}
-		})
-	}
+	result := adapter.Perform(models.RunResult{}, store)
+	assert.Equal(t, string(models.RunStatusPendingSleep), string(result.Status))
 }

--- a/integration/features_test.go
+++ b/integration/features_test.go
@@ -50,7 +50,7 @@ func TestIntegration_HelloWorld(t *testing.T) {
 	defer cleanup()
 	eth := app.MockEthClient()
 
-	newHeads := make(chan models.BlockHeader, 10)
+	newHeads := make(chan models.BlockHeader)
 	attempt1Hash := common.HexToHash("0xb7862c896a6ba2711bccc0410184e46d793ea83b3e05470f1d359ea276d16bb5")
 	attempt2Hash := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002")
 	sentAt := uint64(23456)
@@ -304,6 +304,8 @@ func TestIntegration_ExternalAdapter_RunLogInitiated(t *testing.T) {
 	assert.Equal(t, eaExtra, res.String())
 }
 
+// This test ensures that the response body of an external adapter are supplied
+// as params to the successive task
 func TestIntegration_ExternalAdapter_Copy(t *testing.T) {
 	t.Parallel()
 
@@ -354,6 +356,9 @@ func TestIntegration_ExternalAdapter_Copy(t *testing.T) {
 	assert.Equal(t, eaQuote, res.String())
 }
 
+// This test ensures that an bridge adapter task is resumed from pending after
+// sending out a request to an external adapter and waiting to receive a
+// request back
 func TestIntegration_ExternalAdapter_Pending(t *testing.T) {
 	t.Parallel()
 

--- a/integration/send_runlog_transaction
+++ b/integration/send_runlog_transaction
@@ -7,8 +7,8 @@ const web3 = require('web3')
 
 process.env.SOLIDITY_INCLUDE = '../solidity/contracts'
 
-function futureOffset(seconds) {
-  return parseInt((new Date).getTime() / 1000) + seconds
+function futureOffset (seconds) {
+  return parseInt((new Date()).getTime() / 1000) + seconds
 }
 
 const main = async () => {
@@ -30,9 +30,10 @@ const main = async () => {
 
   const job = {
     '_comment': 'A runlog has a jobid baked into the contract so chainlink knows which job to run.',
-    'initiators': [{ 'type': 'runlog' , 'params': {"requesters": [RunLog.address]}}],
+    'initiators': [{'type': 'runlog', 'params': {'requesters': [RunLog.address]}}],
     'tasks': [
-      { 'type': 'Sleep', 'params': { 'until': futureOffset(3) } },
+      // 10 seconds to ensure the time has not elapsed by the time the run is triggered
+      { 'type': 'Sleep', 'params': { 'until': futureOffset(10) } },
       { 'type': 'HttpPost', 'params': { 'url': 'http://localhost:6690' } }
     ]
   }

--- a/internal/ci/ethereum_test
+++ b/internal/ci/ethereum_test
@@ -10,7 +10,7 @@ set -e
 assert ()
 {
   sleepCount=0
-  while [ "$sleepCount" -le "10" ] && output=`eval $2`; do
+  while [ "$sleepCount" -le "30" ] && output=`eval $2`; do
     if [ "$output" == "$3" ]; then
       printf -- "\033[32mTest passed!\033[0m $1: got expected value $3.\n"
       return

--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -613,7 +613,6 @@ func (m mockSecretGenerator) Generate(store.Config) ([]byte, error) {
 
 type MockRunChannel struct {
 	Runs               []models.RunResult
-	BlockNumbers       []*models.IndexableBlockNumber
 	neverReturningChan chan store.RunRequest
 }
 
@@ -623,10 +622,8 @@ func NewMockRunChannel() *MockRunChannel {
 	}
 }
 
-func (m *MockRunChannel) Send(jobRunID string, ibn *models.IndexableBlockNumber) error {
+func (m *MockRunChannel) Send(jobRunID string) error {
 	m.Runs = append(m.Runs, models.RunResult{})
-	copy := *ibn
-	m.BlockNumbers = append(m.BlockNumbers, &copy)
 	return nil
 }
 

--- a/services/export_test.go
+++ b/services/export_test.go
@@ -9,7 +9,7 @@ func ExportedExecuteRunAtBlock(
 	run *models.JobRun,
 	store *store.Store,
 	input models.RunResult,
-) error {
+) (*models.JobRun, error) {
 	return executeRun(run, store)
 }
 

--- a/services/export_test.go
+++ b/services/export_test.go
@@ -6,19 +6,19 @@ import (
 )
 
 func ExportedExecuteRunAtBlock(
-	run models.JobRun,
+	run *models.JobRun,
 	store *store.Store,
-	blockNumber *models.IndexableBlockNumber,
-) (models.JobRun, error) {
-	return executeRunAtBlock(run, store, blockNumber)
+	input models.RunResult,
+) error {
+	return executeRun(run, store)
 }
 
-func ExportedChannelForRun(jr JobRunner, runID string) chan<- store.RunRequest {
+func ExportedChannelForRun(jr JobRunner, runID string) chan<- struct{} {
 	return jr.channelForRun(runID)
 }
 
-func ExportedResumeSleepingRuns(jr JobRunner) error {
-	return jr.resumeSleepingRuns()
+func ExportedResumeRuns(jr JobRunner) error {
+	return jr.resumeRuns()
 }
 
 func ExportedWorkerCount(jr JobRunner) int {

--- a/services/job_runner_test.go
+++ b/services/job_runner_test.go
@@ -2,25 +2,19 @@ package services_test
 
 import (
 	"fmt"
-	"net/http"
 	"testing"
 	"time"
 
 	"github.com/onsi/gomega"
-	"github.com/smartcontractkit/chainlink/adapters"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/services"
-	"github.com/smartcontractkit/chainlink/store"
-	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tidwall/gjson"
-	null "gopkg.in/guregu/null.v3"
 )
 
-func TestJobRunner_resumeSleepingRuns(t *testing.T) {
+func TestJobRunner_resumeRuns(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 	rm, cleanup := cltest.NewJobRunner(store)
@@ -33,15 +27,28 @@ func TestJobRunner_resumeSleepingRuns(t *testing.T) {
 	j.Tasks = []models.TaskSpec{cltest.NewTask("sleep", json)}
 	assert.NoError(t, store.Save(&j))
 
-	jr := j.NewRun(i)
-	jr.Status = models.RunStatusPendingSleep
-	jr.Result.Data = cltest.JSONFromString(`{"foo":"bar"}`)
-	assert.NoError(t, store.Save(&jr))
+	sleepingRun := j.NewRun(i)
+	sleepingRun.Status = models.RunStatusPendingSleep
+	sleepingRun.TaskRuns[0].Status = models.RunStatusPendingSleep
+	assert.NoError(t, store.Save(&sleepingRun))
 
-	assert.NoError(t, services.ExportedResumeSleepingRuns(rm))
+	inProgressRun := j.NewRun(i)
+	inProgressRun.Status = models.RunStatusInProgress
+	assert.NoError(t, store.Save(&inProgressRun))
+
+	assert.NoError(t, services.ExportedResumeRuns(rm))
+	messages := []string{}
+
 	rr, open := <-store.RunChannel.Receive()
-	assert.Equal(t, jr.ID, rr.ID)
 	assert.True(t, open)
+	messages = append(messages, rr.ID)
+
+	rr, open = <-store.RunChannel.Receive()
+	assert.True(t, open)
+	messages = append(messages, rr.ID)
+
+	expectedMessages := []string{sleepingRun.ID, inProgressRun.ID}
+	assert.ElementsMatch(t, expectedMessages, messages)
 }
 
 func TestJobRunner_ChannelForRun_equalityBetweenRuns(t *testing.T) {
@@ -80,15 +87,15 @@ func TestJobRunner_ChannelForRun_sendAfterClosing(t *testing.T) {
 	assert.NoError(t, s.Save(&jr))
 
 	chan1 := services.ExportedChannelForRun(rm, jr.ID)
-	chan1 <- store.RunRequest{}
+	chan1 <- struct{}{}
 	cltest.WaitForJobRunToComplete(t, s, jr)
 
-	gomega.NewGomegaWithT(t).Eventually(func() chan<- store.RunRequest {
+	gomega.NewGomegaWithT(t).Eventually(func() chan<- struct{} {
 		return services.ExportedChannelForRun(rm, jr.ID)
 	}).Should(gomega.Not(gomega.Equal(chan1))) // eventually deletes the channel
 
 	chan2 := services.ExportedChannelForRun(rm, jr.ID)
-	chan2 <- store.RunRequest{} // does not panic
+	chan2 <- struct{}{} // does not panic
 }
 
 func TestJobRunner_ChannelForRun_equalityWithoutClosing(t *testing.T) {
@@ -108,7 +115,7 @@ func TestJobRunner_ChannelForRun_equalityWithoutClosing(t *testing.T) {
 
 	chan1 := services.ExportedChannelForRun(rm, jr.ID)
 
-	chan1 <- store.RunRequest{}
+	chan1 <- struct{}{}
 	cltest.WaitForJobRunToPendConfirmations(t, s, jr)
 
 	chan2 := services.ExportedChannelForRun(rm, jr.ID)
@@ -135,370 +142,4 @@ func TestJobRunner_Stop(t *testing.T) {
 	gomega.NewGomegaWithT(t).Eventually(func() int {
 		return services.ExportedWorkerCount(rm)
 	}).Should(gomega.Equal(0))
-}
-
-func TestJobRunner_EnqueueRunWithValidPayment(t *testing.T) {
-	t.Parallel()
-
-	bridgeName := "auctionBidding"
-	tests := []struct {
-		name       string
-		bridgeType string
-		input      string
-		runResult  string
-		wantStatus models.RunStatus
-		wantData   string
-		postBody   string
-	}{
-		{"success", bridgeName, `{}`, `{"data":{"value":"100"}}`, models.RunStatusCompleted, `{"value":"100","type":"auctionBidding"}`, `{"type":"auctionBidding"}`},
-		{"errored", bridgeName, `{}`, `{"error":"too much"}`, models.RunStatusErrored, `{"type":"auctionBidding"}`, `{"type":"auctionBidding"}`},
-		{"errored with a value", bridgeName, `{}`, `{"error":"too much", "data":{"value":"99"}}`, models.RunStatusErrored, `{"value":"99","type":"auctionBidding"}`, `{"type":"auctionBidding"}`},
-		{"overriding bridge type params", bridgeName, `{"url":"hack"}`, `{"data":{"value":"100"}}`, models.RunStatusCompleted, `{"value":"100","url":"hack","type":"auctionBidding"}`, `{"type":"auctionBidding","url":"hack"}`},
-		{"type parameter does not override", bridgeName, `{"type":"0"}`, `{"data":{"value":"100"}}`, models.RunStatusCompleted, `{"value":"100","type":"auctionBidding"}`, `{"type":"auctionBidding"}`},
-		{"non-existent bridge type", "non-existent", `{}`, `{}`, models.RunStatusErrored, `{}`, `{}`},
-	}
-
-	store, cleanup := cltest.NewStore()
-	defer cleanup()
-	jobRunner, cleanup := cltest.NewJobRunner(store)
-	defer cleanup()
-	jobRunner.Start()
-
-	for _, tt := range tests {
-		test := tt
-		t.Run(test.name, func(t *testing.T) {
-
-			var bt models.BridgeType
-			var run models.JobRun
-			mockServer, _ := cltest.NewHTTPMockServer(t, 200, "POST", test.runResult,
-				func(h http.Header, b string) {
-					token := utils.StripBearer(h.Get("Authorization"))
-					assert.Equal(t, bt.OutgoingToken, token)
-
-					body := cltest.JSONFromString(b)
-
-					id := body.Get("id")
-					assert.True(t, id.Exists())
-					assert.Equal(t, run.ID, id.String())
-
-					data := body.Get("data")
-					assert.True(t, data.Exists())
-
-					assert.JSONEq(t, test.postBody, data.String())
-				})
-			bt = cltest.NewBridgeType(bridgeName, mockServer.URL)
-			assert.Nil(t, store.Save(&bt))
-
-			job, initr := cltest.NewJobWithWebInitiator()
-			job.Tasks = []models.TaskSpec{
-				cltest.NewTask(test.bridgeType),
-				cltest.NewTask("noop"),
-			}
-			assert.Nil(t, store.Save(&job))
-
-			input := models.RunResult{Data: cltest.JSONFromString(test.input)}
-			run, err := services.EnqueueRunWithValidPayment(job, initr, input, store)
-			assert.NoError(t, err)
-			cltest.WaitForJobRunStatus(t, store, run, test.wantStatus)
-
-			store.One("ID", run.ID, &run)
-			assert.Equal(t, test.wantStatus, run.Status)
-			assert.JSONEq(t, test.wantData, run.Result.Data.String())
-			assert.Equal(t, input, run.Overrides)
-
-			tr1 := run.TaskRuns[0]
-			assert.Equal(t, test.wantStatus, tr1.Status)
-			assert.Equal(t, test.wantStatus, tr1.Result.Status)
-			assert.JSONEq(t, test.wantData, tr1.Result.Data.String())
-
-			if test.wantStatus == models.RunStatusCompleted {
-				tr2 := run.TaskRuns[1]
-				assert.JSONEq(t, test.wantData, tr2.Result.Data.String())
-				assert.True(t, run.CompletedAt.Valid)
-			}
-		})
-	}
-}
-
-func TestJobRunner_ExecuteRunAtBlock_startingStatus(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		status    models.RunStatus
-		wantError bool
-	}{
-		{models.RunStatusUnstarted, false},
-		{models.RunStatusInProgress, true},
-		{models.RunStatusPendingConfirmations, false},
-		{models.RunStatusPendingSleep, false},
-		{models.RunStatusPendingBridge, false},
-		{models.RunStatusErrored, true},
-		{models.RunStatusCompleted, true},
-	}
-
-	store, cleanup := cltest.NewStore()
-	defer cleanup()
-
-	for _, test := range tests {
-		t.Run(string(test.status), func(t *testing.T) {
-			job, initr := cltest.NewJobWithWebInitiator()
-			run := job.NewRun(initr)
-
-			run.Status = test.status
-
-			run, err := services.ExportedExecuteRunAtBlock(run, store, nil)
-			if test.wantError {
-				require.Error(t, err)
-				assert.Contains(t, err.Error(), "Unable to start with status")
-			} else {
-				require.NoError(t, err)
-			}
-		})
-	}
-}
-
-func TestJobRunner_savesOverridesOnError(t *testing.T) {
-	t.Parallel()
-
-	store, cleanup := cltest.NewStore()
-	defer cleanup()
-	jobRunner, cleanup := cltest.NewJobRunner(store)
-	defer cleanup()
-	jobRunner.Start()
-
-	job, initr := cltest.NewJobWithLogInitiator()
-	job.Tasks = []models.TaskSpec{} // reason for error
-	run := job.NewRun(initr)
-	initialData := models.JSON{Result: gjson.Parse(`{"key":"shouldBeHere"}`)}
-	run.Overrides = models.RunResult{Data: initialData}
-	assert.NoError(t, store.Save(&run))
-
-	run, err := services.ExportedExecuteRunAtBlock(run, store, nil)
-	assert.Error(t, err)
-
-	assert.NoError(t, store.One("ID", run.ID, &run))
-	assert.Equal(t, initialData, run.Overrides.Data)
-}
-
-func TestJobRunner_transitionToPendingConfirmations(t *testing.T) {
-	t.Parallel()
-
-	config, cfgCleanup := cltest.NewConfig()
-	defer cfgCleanup()
-	config.MinIncomingConfirmations = 10
-
-	store, cleanup := cltest.NewStoreWithConfig(config)
-	defer cleanup()
-	jobRunner, cleanup := cltest.NewJobRunner(store)
-	defer cleanup()
-	jobRunner.Start()
-
-	creationHeight := 1000
-	configMin := int(store.Config.MinIncomingConfirmations)
-
-	tests := []struct {
-		name           string
-		confirmations  int
-		triggeringConf int
-	}{
-		{"not defined in task spec", 0, configMin},
-		{"task spec > global min confs", configMin + 1, configMin + 1},
-		{"task spec == global min confs", configMin, configMin},
-		{"task spec < global min confs", configMin - 1, configMin},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			job, initr := cltest.NewJobWithLogInitiator()
-			job.Tasks = []models.TaskSpec{
-				{
-					Type:          adapters.TaskTypeNoOp,
-					Confirmations: uint64(test.confirmations),
-				},
-			}
-
-			initialData := models.JSON{Result: gjson.Parse(`{"address":"0xdfcfc2b9200dbb10952c2b7cce60fc7260e03c6f"}`)}
-			run := job.NewRun(initr)
-			run.Overrides = models.RunResult{Data: initialData}
-			run, err := store.SaveCreationHeight(run, cltest.IndexableBlockNumber(creationHeight))
-			assert.NoError(t, err)
-
-			early := cltest.IndexableBlockNumber(creationHeight + test.triggeringConf - 2)
-			store.RunChannel.Send(run.ID, early)
-
-			cltest.WaitForJobRunStatus(t, store, run, models.RunStatusPendingConfirmations)
-			store.One("ID", run.ID, &run)
-			assert.Equal(t, initialData, run.Result.Data)
-
-			trigger := cltest.IndexableBlockNumber(creationHeight + test.triggeringConf - 1)
-			store.RunChannel.Send(run.ID, trigger)
-			cltest.WaitForJobRunStatus(t, store, run, models.RunStatusCompleted)
-			store.One("ID", run.ID, &run)
-			assert.Equal(t, initialData, run.Result.Data)
-		})
-	}
-}
-
-func TestJobRunner_transitionToPendingConfirmationsWithBridgeTask(t *testing.T) {
-	t.Parallel()
-
-	config, cfgCleanup := cltest.NewConfig()
-	defer cfgCleanup()
-	config.MinIncomingConfirmations = 10
-	store, cleanup := cltest.NewStoreWithConfig(config)
-	defer cleanup()
-	jobRunner, cleanup := cltest.NewJobRunner(store)
-	defer cleanup()
-	jobRunner.Start()
-	creationHeight := 1000
-	configMin := int(store.Config.MinIncomingConfirmations)
-
-	tests := []struct {
-		name                    string
-		bridgeTypeConfirmations int
-		taskSpecConfirmations   int
-		triggeringConf          int
-	}{
-		{"not defined in task spec or bridge type", 0, 0, configMin},
-		{"bridge type confirmations > task spec confirmations", configMin + 1, configMin, configMin + 1},
-		{"bridge type confirmations = task spec confirmations", configMin, configMin, configMin},
-		{"bridge type confirmations < task spec confirmations", configMin - 2, configMin - 1, configMin},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			job, initr := cltest.NewJobWithLogInitiator()
-			job.Tasks = []models.TaskSpec{
-				{
-					Type:          models.MustNewTaskType("randomNumber"),
-					Confirmations: uint64(test.taskSpecConfirmations),
-				},
-			}
-
-			run := job.NewRun(initr)
-			mockServer, _ := cltest.NewHTTPMockServer(t, 200, "POST", "{\"todo\": \"todo\"}",
-				func(_ http.Header, b string) {
-					body := cltest.JSONFromString(b)
-
-					id := body.Get("id")
-					assert.True(t, id.Exists())
-					assert.Equal(t, run.ID, id.String())
-
-					data := body.Get("data")
-					assert.True(t, data.Exists())
-					assert.Equal(t, data.Type, gjson.JSON)
-				})
-			bt := cltest.NewBridgeTypeWithConfirmations(uint64(test.bridgeTypeConfirmations), "randomNumber", mockServer.URL)
-			assert.Nil(t, store.Save(&bt))
-
-			run, err := store.SaveCreationHeight(run, cltest.IndexableBlockNumber(creationHeight))
-			assert.NoError(t, err)
-
-			early := cltest.IndexableBlockNumber(creationHeight + test.triggeringConf - 2)
-			store.RunChannel.Send(run.ID, early)
-			cltest.WaitForJobRunStatus(t, store, run, models.RunStatusPendingConfirmations)
-
-			trigger := cltest.IndexableBlockNumber(creationHeight + test.triggeringConf - 1)
-			store.RunChannel.Send(run.ID, trigger)
-			cltest.WaitForJobRunStatus(t, store, run, models.RunStatusCompleted)
-		})
-	}
-}
-
-func TestJobRunner_transitionToPending(t *testing.T) {
-	t.Parallel()
-
-	store, cleanup := cltest.NewStore()
-	defer cleanup()
-	jobRunner, cleanup := cltest.NewJobRunner(store)
-	defer cleanup()
-	jobRunner.Start()
-
-	job, initr := cltest.NewJobWithWebInitiator()
-	job.Tasks = []models.TaskSpec{cltest.NewTask("NoOpPend")}
-
-	run := job.NewRun(initr)
-	assert.NoError(t, store.Save(&run))
-
-	store.RunChannel.Send(run.ID, nil)
-	cltest.WaitForJobRunStatus(t, store, run, models.RunStatusPendingConfirmations)
-}
-
-func TestJobRunner_BuildRunWithValidPayment(t *testing.T) {
-	config, cfgCleanup := cltest.NewConfig()
-	defer cfgCleanup()
-	config.MinimumContractPayment = *assets.NewLink(10)
-
-	store, cleanup := cltest.NewStoreWithConfig(config)
-	defer cleanup()
-
-	tests := []struct {
-		name       string
-		amount     *assets.Link
-		invalid    bool
-		wantStatus models.RunStatus
-	}{
-		{"job with insufficient amount", assets.NewLink(9), true, models.RunStatusErrored},
-		{"job with no amount", nil, false, models.RunStatusUnstarted},
-		{"job with exact amount", assets.NewLink(10), false, models.RunStatusUnstarted},
-		{"job with valid amount", assets.NewLink(11), false, models.RunStatusUnstarted},
-	}
-
-	for _, tt := range tests {
-		test := tt
-		t.Run(test.name, func(t *testing.T) {
-			job, initr := cltest.NewJobWithWebInitiator()
-			job.Tasks = []models.TaskSpec{
-				cltest.NewTask("ethtx"),
-			}
-			assert.Nil(t, store.SaveJob(&job))
-
-			runResult := models.RunResult{
-				Amount: test.amount,
-			}
-			run, _ := services.BuildRunWithValidPayment(job, initr, runResult, store)
-			assert.Equal(t, test.wantStatus, run.Status)
-		})
-	}
-}
-
-func TestJobRunner_BuildRun(t *testing.T) {
-	pastTime := cltest.ParseNullableTime("2000-01-01T00:00:00.000Z")
-	futureTime := cltest.ParseNullableTime("3000-01-01T00:00:00.000Z")
-	nullTime := null.Time{Valid: false}
-
-	tests := []struct {
-		name    string
-		startAt null.Time
-		endAt   null.Time
-		errored bool
-	}{
-		{"job not started", futureTime, nullTime, true},
-		{"job started", pastTime, futureTime, false},
-		{"job with no time range", nullTime, nullTime, false},
-		{"job ended", nullTime, pastTime, true},
-	}
-
-	store, cleanup := cltest.NewStore()
-	defer cleanup()
-	clock := cltest.UseSettableClock(store)
-	clock.SetTime(time.Now())
-
-	for _, tt := range tests {
-		test := tt
-		t.Run(test.name, func(t *testing.T) {
-			job, initr := cltest.NewJobWithWebInitiator()
-			job.StartAt = test.startAt
-			job.EndAt = test.endAt
-			assert.Nil(t, store.SaveJob(&job))
-
-			_, err := services.BuildRun(job, initr, store, models.RunResult{})
-
-			if test.errored {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-			}
-		})
-	}
 }

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -93,7 +93,7 @@ func (js *jobSubscriber) OnNewHead(head *models.BlockHeader) {
 		"pending_run_count", len(pendingRuns)}...,
 	)
 	for _, jr := range pendingRuns {
-		err := ResumeConfirmingTask(&jr, js.store, ibn)
+		_, err := ResumeConfirmingTask(&jr, js.store, ibn)
 		if err != nil {
 			logger.Error("JobSubscriber.OnNewHead: ", err.Error())
 		}

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -87,13 +87,13 @@ func (js *jobSubscriber) OnNewHead(head *models.BlockHeader) {
 		logger.Error("error fetching pending job runs:", err.Error())
 	}
 
-	ibn := head.ToIndexableBlockNumber().Number.ToInt()
+	ibn := head.ToIndexableBlockNumber().Number
 	logger.Debugw("Received new head", []interface{}{
 		"current_height", ibn,
 		"pending_run_count", len(pendingRuns)}...,
 	)
 	for _, jr := range pendingRuns {
-		_, err := ResumeConfirmingTask(&jr, js.store, ibn)
+		_, err := ResumeConfirmingTask(&jr, js.store, &ibn)
 		if err != nil {
 			logger.Error("JobSubscriber.OnNewHead: ", err.Error())
 		}

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -82,14 +82,19 @@ func (js *jobSubscriber) Disconnect() {
 
 // OnNewHead resumes all pending job runs based on the new head activity.
 func (js *jobSubscriber) OnNewHead(head *models.BlockHeader) {
-	pendingRuns, err := js.store.JobRunsWithStatus(models.RunStatusPendingConfirmations, models.RunStatusInProgress)
+	pendingRuns, err := js.store.JobRunsWithStatus(models.RunStatusPendingConfirmations)
 	if err != nil {
 		logger.Error("error fetching pending job runs:", err.Error())
 	}
 
-	ibn := head.ToIndexableBlockNumber()
+	ibn := head.ToIndexableBlockNumber().Number.ToInt()
+	logger.Debugw("Received new head", []interface{}{
+		"current_height", ibn,
+		"pending_run_count", len(pendingRuns)}...,
+	)
 	for _, jr := range pendingRuns {
-		if err := js.store.RunChannel.Send(jr.ID, ibn); err != nil {
+		err := ResumeConfirmingTask(&jr, js.store, ibn)
+		if err != nil {
 			logger.Error("JobSubscriber.OnNewHead: ", err.Error())
 		}
 	}

--- a/services/job_subscriber_test.go
+++ b/services/job_subscriber_test.go
@@ -173,7 +173,7 @@ func TestJobSubscriber_OnNewHead_OnlyResumePendingConfirmations(t *testing.T) {
 
 			job, initr := cltest.NewJobWithWebInitiator()
 			run := job.NewRun(initr)
-			run.ApplyResult(models.RunResult{Status: test.status})
+			run = run.ApplyResult(models.RunResult{Status: test.status})
 			assert.Nil(t, store.Save(&run))
 
 			js.OnNewHead(block)

--- a/services/runs.go
+++ b/services/runs.go
@@ -134,6 +134,10 @@ func ResumeConfirmingTask(
 		return run, fmt.Errorf("Attempting to resume confirming run with no remaining tasks %s", run.ID)
 	}
 
+	if currentBlockHeight == nil {
+		return run, fmt.Errorf("Attempting to resume confirming run with no currentBlockHeight %s", run.ID)
+	}
+
 	run.ObservedHeight = currentBlockHeight
 
 	if meetsMinimumConfirmations(run, currentTaskRun, run.ObservedHeight) {

--- a/services/runs.go
+++ b/services/runs.go
@@ -256,19 +256,10 @@ func performTaskSleep(
 		return saveAndTrigger(run, store)
 	}
 
-	runCopy := models.JobRun{
-		ID:             run.ID,
-		JobID:          run.JobID,
-		Result:         run.Result,
-		Status:         run.Status,
-		TaskRuns:       make([]models.TaskRun, len(run.TaskRuns)),
-		CreatedAt:      run.CreatedAt,
-		CompletedAt:    run.CompletedAt,
-		Initiator:      run.Initiator,
-		CreationHeight: run.CreationHeight,
-		ObservedHeight: run.ObservedHeight,
-		Overrides:      run.Overrides,
-	}
+	// XXX: This is to eliminate data race that occurs because slices share their
+	// underlying array even in copies
+	runCopy := *run
+	runCopy.TaskRuns = make([]models.TaskRun, len(run.TaskRuns))
 	copy(runCopy.TaskRuns, run.TaskRuns)
 
 	go func(run models.JobRun, task models.TaskRun) {

--- a/services/runs.go
+++ b/services/runs.go
@@ -1,0 +1,307 @@
+package services
+
+import (
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/smartcontractkit/chainlink/adapters"
+	"github.com/smartcontractkit/chainlink/logger"
+	"github.com/smartcontractkit/chainlink/store"
+	"github.com/smartcontractkit/chainlink/store/assets"
+	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/utils"
+)
+
+// ExecuteJob saves and immediately begins executing a run for a specified job
+// if it is ready.
+func ExecuteJob(
+	job models.JobSpec,
+	initiator models.Initiator,
+	input models.RunResult,
+	creationHeight *big.Int,
+	store *store.Store) (models.JobRun, error) {
+
+	logger.Debugw(fmt.Sprintf("New run triggered by %s", initiator.Type), []interface{}{
+		"job", job.ID,
+		"input_status", input.Status,
+		"creation_height", creationHeight,
+	}...)
+
+	run, err := NewRun(job, initiator, input, creationHeight, store)
+	if err != nil {
+		return models.JobRun{}, err
+	}
+
+	return run, saveAndTrigger(&run, store)
+}
+
+// NewRun returns a run from an input job, in an initial state ready for
+// processing by the job runner system
+func NewRun(
+	job models.JobSpec,
+	initiator models.Initiator,
+	input models.RunResult,
+	currentHeight *big.Int,
+	store *store.Store) (models.JobRun, error) {
+
+	now := store.Clock.Now()
+	if !job.Started(now) {
+		return models.JobRun{}, RecurringScheduleJobError{
+			msg: fmt.Sprintf("Job runner: Job %v unstarted: %v before job's start time %v", job.ID, now, job.EndAt),
+		}
+	}
+
+	if job.Ended(now) {
+		return models.JobRun{}, RecurringScheduleJobError{
+			msg: fmt.Sprintf("Job runner: Job %v ended: %v past job's end time %v", job.ID, now, job.EndAt),
+		}
+	}
+
+	run := job.NewRun(initiator)
+
+	run.Overrides = input
+	run.ApplyResult(input)
+
+	if currentHeight != nil {
+		creationHeightHex := hexutil.Big(*currentHeight)
+		run.CreationHeight = &creationHeightHex
+		run.ObservedHeight = &creationHeightHex
+	}
+
+	cost := assets.NewLink(0)
+	for i, taskRun := range run.TaskRuns {
+		adapter, err := adapters.For(taskRun.Task, store)
+
+		if err != nil {
+			run.ApplyResult(run.Result.WithError(err))
+			return run, nil
+		}
+
+		mp := adapter.MinContractPayment()
+		cost.Add(cost, &mp)
+
+		if currentHeight != nil {
+			run.TaskRuns[i].MinimumConfirmations = utils.MaxUint64(
+				store.Config.MinIncomingConfirmations,
+				taskRun.Task.Confirmations,
+				adapter.MinConfs())
+		}
+	}
+
+	// input.Amount is always present for runs triggered by ethlogs
+	if input.Amount != nil {
+		if cost.Cmp(input.Amount) > 0 {
+			logger.Debugw("Rejecting run with insufficient paymen", []interface{}{
+				"run", run.ID,
+				"job", run.JobID,
+				"input_amount", input.Amount,
+				"required_amount", cost,
+			}...)
+
+			err := fmt.Errorf(
+				"Rejecting job %s with payment %s below minimum threshold (%s)",
+				job.ID,
+				input.Amount,
+				store.Config.MinimumContractPayment.Text(10))
+			run.ApplyResult(input.WithError(err))
+			return run, nil
+		}
+	}
+
+	initialTask := run.TaskRuns[0]
+	if meetsMinimumConfirmations(&run, &initialTask, run.CreationHeight) {
+		run.Status = models.RunStatusInProgress
+	} else {
+		logger.Debugw("Insufficient confirmations to begin job", run.ForLogger()...)
+		run.Status = models.RunStatusPendingConfirmations
+	}
+
+	return run, nil
+}
+
+// ResumeConfirmingTask resumes a confirming run if the minimum confirmations have been met
+func ResumeConfirmingTask(
+	run *models.JobRun,
+	store *store.Store,
+	currentBlockHeight *big.Int,
+) error {
+
+	logger.Debugw("New head resuming run", run.ForLogger()...)
+
+	if !run.Status.PendingConfirmations() {
+		return fmt.Errorf("Attempt to resume non confirming task")
+	}
+
+	currentTaskRun := run.NextTaskRun()
+	if currentTaskRun == nil {
+		return fmt.Errorf("Attempting to resume confirming run with no remaining tasks %s", run.ID)
+	}
+
+	observedHeight := hexutil.Big(*currentBlockHeight)
+	run.ObservedHeight = &observedHeight
+
+	if meetsMinimumConfirmations(run, currentTaskRun, run.ObservedHeight) {
+		logger.Debugw("Minimum confirmations met, resuming job", []interface{}{
+			"run", run.ID,
+			"job", run.JobID,
+			"observed_height", currentBlockHeight,
+		}...)
+		run.Status = models.RunStatusInProgress
+	} else {
+		logger.Debugw("Insufficient confirmations to wake job", []interface{}{
+			"run", run.ID,
+			"job", run.JobID,
+			"observed_height", currentBlockHeight,
+		}...)
+		run.Status = models.RunStatusPendingConfirmations
+	}
+
+	return saveAndTrigger(run, store)
+}
+
+// ResumePendingTask takes the body provided from an external adapter,
+// saves it for the next task to process, then tells the job runner to execute
+// it
+func ResumePendingTask(
+	run *models.JobRun,
+	store *store.Store,
+	input models.RunResult,
+) error {
+
+	logger.Debugw("External adapter resuming job", []interface{}{
+		"run", run.ID,
+		"job", run.JobID,
+		"status", run.Status,
+		"input_data", input.Data,
+		"input_result", input.Status,
+	}...)
+
+	if !run.Status.PendingBridge() {
+		return fmt.Errorf("Attempting to resume non pending run %s", run.ID)
+	}
+
+	currentTaskRun := run.NextTaskRun()
+	if currentTaskRun == nil {
+		return fmt.Errorf("Attempting to resume pending run with no remaining tasks %s", run.ID)
+	}
+
+	var err error
+	if run.Overrides, err = run.Overrides.Merge(input); err != nil {
+		currentTaskRun.ApplyResult(input.WithError(err))
+		run.ApplyResult(input.WithError(err))
+		return store.Save(run)
+	}
+
+	currentTaskRun.ApplyResult(input)
+	if currentTaskRun.Status.Finished() && run.TasksRemain() {
+		run.Status = models.RunStatusInProgress
+	} else {
+		run.ApplyResult(input)
+	}
+
+	return saveAndTrigger(run, store)
+}
+
+// QueueSleepingTask creates a go routine which will wake up the job runner
+// once the sleep's time has elapsed
+func QueueSleepingTask(
+	run *models.JobRun,
+	store *store.Store,
+) error {
+	if !run.Status.PendingSleep() {
+		return fmt.Errorf("Attempting to resume non sleeping run %s", run.ID)
+	}
+	currentTaskRun := run.NextTaskRun()
+	if currentTaskRun == nil {
+		return fmt.Errorf("Attempting to resume sleeping run with no remaining tasks %s", run.ID)
+	}
+
+	if !currentTaskRun.Status.PendingSleep() {
+		return fmt.Errorf("Attempting to resume sleeping run with non sleeping task %s", run.ID)
+	}
+
+	adapter, err := adapters.For(currentTaskRun.Task, store)
+
+	if err != nil {
+		currentTaskRun.ApplyResult(run.Result.WithError(err))
+		run.ApplyResult(run.Result.WithError(err))
+		return store.Save(run)
+	}
+
+	if sleepAdapter, ok := adapter.BaseAdapter.(*adapters.Sleep); ok {
+		return performTaskSleep(run, currentTaskRun, sleepAdapter, store)
+	}
+
+	return fmt.Errorf("Attempting to resume non sleeping task for run %s (%s)", run.ID, currentTaskRun.Task.Type)
+}
+
+func performTaskSleep(
+	run *models.JobRun,
+	task *models.TaskRun,
+	adapter *adapters.Sleep,
+	store *store.Store) error {
+
+	duration := adapter.Duration()
+	if duration <= 0 {
+		logger.Debugw("Sleep duration has already elapsed, completing task", run.ForLogger()...)
+		task.Status = models.RunStatusCompleted
+		run.Status = models.RunStatusInProgress
+		return saveAndTrigger(run, store)
+	}
+
+	go func() {
+		logger.Debugw("Task sleeping...", run.ForLogger()...)
+
+		<-store.Clock.After(duration)
+
+		task.Status = models.RunStatusCompleted
+		run.Status = models.RunStatusInProgress
+
+		logger.Debugw("Waking job up after sleep", run.ForLogger()...)
+
+		if err := saveAndTrigger(run, store); err != nil {
+			logger.Errorw("Error resuming sleeping job:", "error", err)
+		}
+	}()
+
+	return nil
+}
+
+func meetsMinimumConfirmations(
+	run *models.JobRun,
+	taskRun *models.TaskRun,
+	currentHeight *hexutil.Big) bool {
+	if run.CreationHeight == nil {
+		return true
+	}
+
+	diff := new(big.Int).Sub(currentHeight.ToInt(), run.CreationHeight.ToInt())
+	min := new(big.Int).SetUint64(taskRun.MinimumConfirmations)
+	min = min.Sub(min, big.NewInt(1))
+	return diff.Cmp(min) >= 0
+}
+
+func saveAndTrigger(run *models.JobRun, store *store.Store) error {
+	if err := store.Save(run); err != nil {
+		return err
+	}
+
+	if run.Status == models.RunStatusInProgress {
+		logger.Debugw(fmt.Sprintf("Executing new run initiated by %s", run.Initiator.Type), run.ForLogger()...)
+		return store.RunChannel.Send(run.ID)
+	}
+
+	logger.Debugw(fmt.Sprintf("Queueing run initiated by %s", run.Initiator.Type), run.ForLogger()...)
+	return nil
+}
+
+// RecurringScheduleJobError contains the field for the error message.
+type RecurringScheduleJobError struct {
+	msg string
+}
+
+// Error returns the error message for the run.
+func (err RecurringScheduleJobError) Error() string {
+	return err.msg
+}

--- a/services/runs.go
+++ b/services/runs.go
@@ -197,10 +197,8 @@ func ResumePendingTask(
 	currentTaskRun = currentTaskRun.ApplyResult(input)
 	run.TaskRuns[currentTaskRunIndex] = currentTaskRun
 	if currentTaskRun.Status.Finished() && run.TasksRemain() {
-		fmt.Println("setting status to in progress")
 		run.Status = models.RunStatusInProgress
 	} else {
-		fmt.Println("applying result", input.Status)
 		*run = run.ApplyResult(input)
 	}
 

--- a/services/runs_test.go
+++ b/services/runs_test.go
@@ -1,0 +1,356 @@
+package services_test
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/smartcontractkit/chainlink/adapters"
+	"github.com/smartcontractkit/chainlink/internal/cltest"
+	"github.com/smartcontractkit/chainlink/services"
+	"github.com/smartcontractkit/chainlink/store/assets"
+	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/tidwall/gjson"
+	null "gopkg.in/guregu/null.v3"
+)
+
+func TestNewRun(t *testing.T) {
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+
+	input := models.JSON{Result: gjson.Parse(`{"address":"0xdfcfc2b9200dbb10952c2b7cce60fc7260e03c6f"}`)}
+
+	bt := cltest.NewBridgeType("timecube", "http://http://timecube.2enp.com/")
+	bt.MinimumContractPayment = *assets.NewLink(10)
+	assert.Nil(t, store.Save(&bt))
+
+	creationHeight := big.NewInt(1000)
+
+	jobSpec := models.NewJob()
+	jobSpec.Tasks = []models.TaskSpec{{
+		Type: "timecube",
+	}}
+	jobSpec.Initiators = []models.Initiator{{
+		Type: models.InitiatorEthLog,
+	}}
+
+	inputResult := models.RunResult{Data: input}
+	run, err := services.NewRun(jobSpec, jobSpec.Initiators[0], inputResult, creationHeight, store)
+	assert.NoError(t, err)
+	assert.Equal(t, string(models.RunStatusInProgress), string(run.Status))
+	assert.Len(t, run.TaskRuns, 1)
+	assert.Equal(t, input, run.Overrides.Data)
+}
+
+func TestNewRun_requiredPayment(t *testing.T) {
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+
+	input := models.JSON{Result: gjson.Parse(`{"address":"0xdfcfc2b9200dbb10952c2b7cce60fc7260e03c6f"}`)}
+
+	bt := cltest.NewBridgeType("timecube", "http://http://timecube.2enp.com/")
+	bt.MinimumContractPayment = *assets.NewLink(10)
+	assert.Nil(t, store.Save(&bt))
+
+	tests := []struct {
+		name           string
+		payment        *assets.Link
+		minimumPayment assets.Link
+		expectedStatus models.RunStatus
+	}{
+		{"creates runnable job", nil, *assets.NewLink(0), models.RunStatusInProgress},
+		{"insufficient payment as specified by config", assets.NewLink(9), *assets.NewLink(10), models.RunStatusErrored},
+		{"sufficient payment as specified by config", assets.NewLink(10), *assets.NewLink(10), models.RunStatusInProgress},
+		{"insufficient payment as specified by adapter", assets.NewLink(9), *assets.NewLink(0), models.RunStatusErrored},
+		{"sufficient payment as specified by adapter", assets.NewLink(10), *assets.NewLink(0), models.RunStatusInProgress},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			store.Config.MinimumContractPayment = test.minimumPayment
+
+			jobSpec := models.NewJob()
+			jobSpec.Tasks = []models.TaskSpec{{
+				Type: "timecube",
+			}}
+			jobSpec.Initiators = []models.Initiator{{
+				Type: models.InitiatorEthLog,
+			}}
+
+			inputResult := models.RunResult{Data: input, Amount: test.payment}
+
+			run, err := services.NewRun(jobSpec, jobSpec.Initiators[0], inputResult, nil, store)
+			assert.NoError(t, err)
+			assert.Equal(t, string(test.expectedStatus), string(run.Status))
+		})
+	}
+}
+
+func TestNewRun_minimumConfirmations(t *testing.T) {
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+
+	input := models.JSON{Result: gjson.Parse(`{"address":"0xdfcfc2b9200dbb10952c2b7cce60fc7260e03c6f"}`)}
+	inputResult := models.RunResult{Data: input}
+
+	creationHeight := big.NewInt(1000)
+
+	tests := []struct {
+		name                string
+		configConfirmations uint64
+		taskConfirmations   uint64
+		expectedStatus      models.RunStatus
+	}{
+		{"creates runnable job", 0, 0, models.RunStatusInProgress},
+		{"requires minimum task confirmations", 2, 0, models.RunStatusPendingConfirmations},
+		{"requires minimum config confirmations", 0, 2, models.RunStatusPendingConfirmations},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			store.Config.MinIncomingConfirmations = test.configConfirmations
+
+			jobSpec, initiator := cltest.NewJobWithLogInitiator()
+			jobSpec.Tasks[0].Confirmations = test.taskConfirmations
+
+			run, err := services.NewRun(jobSpec, initiator, inputResult, creationHeight, store)
+			assert.NoError(t, err)
+			assert.Equal(t, string(test.expectedStatus), string(run.Status))
+		})
+	}
+}
+
+func TestNewRun_startAtAndEndAt(t *testing.T) {
+	pastTime := cltest.ParseNullableTime("2000-01-01T00:00:00.000Z")
+	futureTime := cltest.ParseNullableTime("3000-01-01T00:00:00.000Z")
+	nullTime := null.Time{Valid: false}
+
+	tests := []struct {
+		name    string
+		startAt null.Time
+		endAt   null.Time
+		errored bool
+	}{
+		{"job not started", futureTime, nullTime, true},
+		{"job started", pastTime, futureTime, false},
+		{"job with no time range", nullTime, nullTime, false},
+		{"job ended", nullTime, pastTime, true},
+	}
+
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+	clock := cltest.UseSettableClock(store)
+	clock.SetTime(time.Now())
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			job, initr := cltest.NewJobWithWebInitiator()
+			job.StartAt = test.startAt
+			job.EndAt = test.endAt
+			assert.Nil(t, store.SaveJob(&job))
+
+			_, err := services.NewRun(job, initr, models.RunResult{}, nil, store)
+			if test.errored {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestResumePendingTask(t *testing.T) {
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+
+	// reject a run with an invalid state
+	run := models.JobRun{}
+	err := services.ResumePendingTask(&run, store, models.RunResult{})
+	assert.Error(t, err)
+
+	// reject a run with no tasks
+	run = models.JobRun{Status: models.RunStatusPendingBridge}
+	err = services.ResumePendingTask(&run, store, models.RunResult{})
+	assert.Error(t, err)
+
+	// input with error errors run
+	run = models.JobRun{
+		Status:   models.RunStatusPendingBridge,
+		TaskRuns: []models.TaskRun{models.TaskRun{}},
+	}
+	err = services.ResumePendingTask(&run, store, models.RunResult{Status: models.RunStatusErrored})
+	assert.Error(t, err)
+
+	// completed input with remaining tasks should put task into pending
+	run = models.JobRun{
+		Status:   models.RunStatusPendingBridge,
+		TaskRuns: []models.TaskRun{models.TaskRun{}, models.TaskRun{}},
+	}
+	input := models.JSON{Result: gjson.Parse(`{"address":"0xdfcfc2b9200dbb10952c2b7cce60fc7260e03c6f"}`)}
+	err = services.ResumePendingTask(&run, store, models.RunResult{Data: input, Status: models.RunStatusCompleted})
+	assert.Error(t, err)
+	assert.Equal(t, string(models.RunStatusInProgress), string(run.Status))
+	assert.Len(t, run.TaskRuns, 2)
+	assert.Equal(t, run.ID, run.TaskRuns[0].Result.JobRunID)
+	assert.Equal(t, string(models.RunStatusCompleted), string(run.TaskRuns[0].Result.Status))
+
+	// completed input with no remaining tasks should get marked as complete
+	run = models.JobRun{
+		Status:   models.RunStatusPendingBridge,
+		TaskRuns: []models.TaskRun{models.TaskRun{}},
+	}
+	err = services.ResumePendingTask(&run, store, models.RunResult{Data: input, Status: models.RunStatusCompleted})
+	assert.Error(t, err)
+	assert.Equal(t, string(models.RunStatusCompleted), string(run.Status))
+	assert.Len(t, run.TaskRuns, 1)
+	assert.Equal(t, run.ID, run.TaskRuns[0].Result.JobRunID)
+	assert.Equal(t, string(models.RunStatusCompleted), string(run.TaskRuns[0].Result.Status))
+}
+
+func TestResumeConfirmingTask(t *testing.T) {
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+
+	// reject a run with an invalid state
+	run := models.JobRun{}
+	err := services.ResumeConfirmingTask(&run, store, big.NewInt(0))
+	assert.Error(t, err)
+
+	// reject a run with no tasks
+	run = models.JobRun{Status: models.RunStatusPendingConfirmations}
+	err = services.ResumeConfirmingTask(&run, store, big.NewInt(0))
+	assert.Error(t, err)
+
+	// leave in pending if not enough confirmations have been met yet
+	creationHeight := cltest.BigHexInt(0)
+	run = models.JobRun{
+		ID:             utils.NewBytes32ID(),
+		CreationHeight: &creationHeight,
+		Status:         models.RunStatusPendingConfirmations,
+		TaskRuns:       []models.TaskRun{models.TaskRun{MinimumConfirmations: 2, Task: models.TaskSpec{Type: adapters.TaskTypeNoOp}}},
+	}
+	err = services.ResumeConfirmingTask(&run, store, big.NewInt(0))
+	assert.NoError(t, err)
+	assert.Equal(t, string(models.RunStatusPendingConfirmations), string(run.Status))
+
+	// input, should go from pending -> in progress and save the input
+	creationHeight = cltest.BigHexInt(0)
+	run = models.JobRun{
+		ID:             utils.NewBytes32ID(),
+		CreationHeight: &creationHeight,
+		Status:         models.RunStatusPendingConfirmations,
+		TaskRuns:       []models.TaskRun{models.TaskRun{MinimumConfirmations: 1, Task: models.TaskSpec{Type: adapters.TaskTypeNoOp}}},
+	}
+	err = services.ResumeConfirmingTask(&run, store, big.NewInt(1))
+	assert.NoError(t, err)
+	assert.Equal(t, string(models.RunStatusInProgress), string(run.Status))
+}
+
+func sleepAdapterParams(n int) models.JSON {
+	d := time.Duration(n)
+	json := []byte(fmt.Sprintf(`{"until":%v}`, time.Now().Add(d*time.Second).Unix()))
+	return cltest.ParseJSON(bytes.NewBuffer(json))
+}
+
+func TestQueueSleepingTask(t *testing.T) {
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+	store.Clock = cltest.NeverClock{}
+
+	// reject a run with an invalid state
+	run := models.JobRun{}
+	err := services.QueueSleepingTask(&run, store)
+	assert.Error(t, err)
+
+	// reject a run with no tasks
+	run = models.JobRun{Status: models.RunStatusPendingSleep}
+	err = services.QueueSleepingTask(&run, store)
+	assert.Error(t, err)
+
+	// reject a run that is sleeping but its task is not
+	run = models.JobRun{
+		ID:       utils.NewBytes32ID(),
+		Status:   models.RunStatusPendingSleep,
+		TaskRuns: []models.TaskRun{models.TaskRun{Task: models.TaskSpec{Type: adapters.TaskTypeSleep}}},
+	}
+	err = services.QueueSleepingTask(&run, store)
+	assert.Error(t, err)
+
+	// error decoding params into adapter
+	inputFromTheFuture := cltest.ParseJSON(bytes.NewBuffer([]byte(`{"until": -1}`)))
+	run = models.JobRun{
+		ID:     utils.NewBytes32ID(),
+		Status: models.RunStatusPendingSleep,
+		TaskRuns: []models.TaskRun{
+			models.TaskRun{
+				Status: models.RunStatusPendingSleep,
+				Task: models.TaskSpec{
+					Type:   adapters.TaskTypeSleep,
+					Params: inputFromTheFuture,
+				},
+			},
+		},
+	}
+	err = services.QueueSleepingTask(&run, store)
+	assert.NoError(t, err)
+	assert.Equal(t, string(models.RunStatusErrored), string(run.TaskRuns[0].Status))
+	assert.Equal(t, string(models.RunStatusErrored), string(run.Status))
+
+	// mark run as pending, task as completed if duration has already elapsed
+	run = models.JobRun{
+		ID:       utils.NewBytes32ID(),
+		Status:   models.RunStatusPendingSleep,
+		TaskRuns: []models.TaskRun{models.TaskRun{Status: models.RunStatusPendingSleep, Task: models.TaskSpec{Type: adapters.TaskTypeSleep}}},
+	}
+	err = services.QueueSleepingTask(&run, store)
+	assert.NoError(t, err)
+	assert.Equal(t, string(models.RunStatusCompleted), string(run.TaskRuns[0].Status))
+	assert.Equal(t, string(models.RunStatusInProgress), string(run.Status))
+
+	runRequest, open := <-store.RunChannel.Receive()
+	assert.True(t, open)
+	assert.Equal(t, run.ID, runRequest.ID)
+
+	// queue up next run if duration has not elapsed yet
+	clock := cltest.UseSettableClock(store)
+	store.Clock = clock
+	clock.SetTime(time.Time{})
+
+	inputFromTheFuture = sleepAdapterParams(60)
+	run = models.JobRun{
+		ID:     utils.NewBytes32ID(),
+		Status: models.RunStatusPendingSleep,
+		TaskRuns: []models.TaskRun{
+			models.TaskRun{
+				Status: models.RunStatusPendingSleep,
+				Task: models.TaskSpec{
+					Type:   adapters.TaskTypeSleep,
+					Params: inputFromTheFuture,
+				},
+			},
+		},
+	}
+	err = services.QueueSleepingTask(&run, store)
+	assert.NoError(t, err)
+	assert.Equal(t, string(models.RunStatusPendingSleep), string(run.TaskRuns[0].Status))
+	assert.Equal(t, string(models.RunStatusPendingSleep), string(run.Status))
+
+	// force the duration elapse
+	clock.SetTime((time.Time{}).Add(math.MaxInt64))
+	runRequest, open = <-store.RunChannel.Receive()
+	assert.True(t, open)
+	assert.Equal(t, run.ID, runRequest.ID)
+
+	run, err = store.ORM.FindJobRun(run.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, string(models.RunStatusCompleted), string(run.TaskRuns[0].Status))
+	assert.Equal(t, string(models.RunStatusInProgress), string(run.Status))
+}

--- a/services/scheduler.go
+++ b/services/scheduler.go
@@ -124,8 +124,7 @@ func (r *Recurring) AddJob(job models.JobSpec) {
 		initr := i
 		if !job.Ended(r.Clock.Now()) {
 			r.Cron.AddFunc(string(initr.Schedule), func() {
-				input := models.RunResult{}
-				_, err := EnqueueRunWithValidPayment(job, initr, input, r.store)
+				_, err := ExecuteJob(job, initr, models.RunResult{}, nil, r.store)
 				if err != nil && !expectedRecurringScheduleJobError(err) {
 					logger.Errorw(err.Error())
 				}
@@ -169,7 +168,7 @@ func (ot *OneTime) RunJobAt(initr models.Initiator, job models.JobSpec) {
 			logger.Error(err.Error())
 			return
 		}
-		_, err := EnqueueRunWithValidPayment(job, initr, models.RunResult{}, ot.Store)
+		_, err := ExecuteJob(job, initr, models.RunResult{}, nil, ot.Store)
 		if err != nil {
 			logger.Error(err.Error())
 			initr.Ran = false

--- a/services/subscription.go
+++ b/services/subscription.go
@@ -219,8 +219,8 @@ func runJob(le InitiatorSubscriptionLogEvent, data models.JSON, initr models.Ini
 		Amount: payment,
 	}
 
-	currentHead := le.ToIndexableBlockNumber().Number.ToInt()
-	_, err = ExecuteJob(le.Job, initr, input, currentHead, le.store)
+	currentHead := le.ToIndexableBlockNumber().Number
+	_, err = ExecuteJob(le.Job, initr, input, &currentHead, le.store)
 	if err != nil {
 		logger.Errorw(err.Error(), le.ForLogger()...)
 	}

--- a/services/subscription.go
+++ b/services/subscription.go
@@ -219,7 +219,8 @@ func runJob(le InitiatorSubscriptionLogEvent, data models.JSON, initr models.Ini
 		Amount: payment,
 	}
 
-	_, err = EnqueueRunAtBlockWithValidPayment(le.Job, initr, input, le.store, le.ToIndexableBlockNumber())
+	currentHead := le.ToIndexableBlockNumber().Number.ToInt()
+	_, err = ExecuteJob(le.Job, initr, input, currentHead, le.store)
 	if err != nil {
 		logger.Errorw(err.Error(), le.ForLogger()...)
 	}
@@ -315,8 +316,8 @@ type InitiatorSubscriptionLogEvent struct {
 // ForLogger formats the InitiatorSubscriptionLogEvent for easy common formatting in logs (trace statements, not ethereum events).
 func (le InitiatorSubscriptionLogEvent) ForLogger(kvs ...interface{}) []interface{} {
 	output := []interface{}{
-		"job", le.Job,
-		"log", le.Log,
+		"job", le.Job.ID,
+		"log", le.Log.BlockNumber,
 		"initiator", le.Initiator,
 	}
 

--- a/services/validators.go
+++ b/services/validators.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink/adapters"
 	"github.com/smartcontractkit/chainlink/store"
-	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/store/models"
 )
 
@@ -47,27 +46,6 @@ func ValidateAdapter(bt *models.BridgeType, store *store.Store) (err error) {
 		fe.Add(fmt.Sprintf("Adapter %v already exists", bt.Name))
 	}
 	return fe.CoerceEmptyToNil()
-}
-
-// ValidateMinimumContractPayment returns true when the amount is >= the cost of
-// every adapter used in the job
-func ValidateMinimumContractPayment(
-	s *store.Store,
-	job models.JobSpec,
-	amount assets.Link,
-) (bool, error) {
-	cost := assets.NewLink(0)
-
-	for _, task := range job.Tasks {
-		a, err := adapters.For(task, s)
-		if err != nil {
-			return false, fmt.Errorf("policies.MinimumContractPaymentValid: %v", err)
-		}
-		mp := a.MinContractPayment()
-		cost.Add(cost, &mp)
-	}
-
-	return cost.Cmp(&amount) <= 0, nil
 }
 
 // ValidateInitiator checks the Initiator for any application logic errors.

--- a/services/validators_test.go
+++ b/services/validators_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/services"
-	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/stretchr/testify/assert"
@@ -175,70 +174,4 @@ func TestValidateServiceAgreement(t *testing.T) {
 			cltest.AssertError(t, test.wantError, result)
 		})
 	}
-}
-
-func TestValidateMinimumContractPayment_tasksExist(t *testing.T) {
-	t.Parallel()
-
-	config, cleanup := cltest.NewConfig()
-	defer cleanup()
-	config.MinimumContractPayment = *assets.NewLink(1)
-
-	s, cleanup := cltest.NewStoreWithConfig(config)
-	defer cleanup()
-
-	bta := cltest.NewBridgeType("bridgeA")
-	bta.MinimumContractPayment = *assets.NewLink(2)
-	assert.NoError(t, s.Save(&bta))
-
-	btb := cltest.NewBridgeType("bridgeB")
-	btb.MinimumContractPayment = *assets.NewLink(3)
-	assert.NoError(t, s.Save(&btb))
-
-	job := models.NewJob()
-	job.Tasks = []models.TaskSpec{
-		cltest.NewTask("ethtx"),
-		cltest.NewTask("bridgea"),
-		cltest.NewTask("bridgeb"),
-	}
-	assert.NoError(t, s.Save(&job))
-
-	tests := []struct {
-		name      string
-		amount    assets.Link
-		wantValid bool
-	}{
-		{"less than", *assets.NewLink(5), false},
-		{"equal", *assets.NewLink(6), true},
-		{"greater than", *assets.NewLink(7), true},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			valid, err := services.ValidateMinimumContractPayment(s, job, test.amount)
-			assert.NoError(t, err)
-			assert.Equal(t, test.wantValid, valid)
-		})
-	}
-}
-
-func TestValidateMinimumContractPayment_taskDoesNotExist(t *testing.T) {
-	t.Parallel()
-
-	config, cleanup := cltest.NewConfig()
-	defer cleanup()
-	config.MinimumContractPayment = *assets.NewLink(1)
-
-	s, cleanup := cltest.NewStoreWithConfig(config)
-	defer cleanup()
-
-	job := models.NewJob()
-	job.Tasks = []models.TaskSpec{
-		cltest.NewTask("idontexist"),
-	}
-	assert.NoError(t, s.Save(&job))
-
-	valid, err := services.ValidateMinimumContractPayment(s, job, *assets.NewLink(1))
-	assert.Error(t, err)
-	assert.Equal(t, false, valid)
 }

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/smartcontractkit/chainlink/adapters"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store/models"
@@ -34,7 +33,7 @@ func TestJobRuns_RetrievingFromDBWithError(t *testing.T) {
 	assert.Equal(t, "bad idea", run.Result.Error())
 }
 
-func TestJobRun_UnfinishedTaskRuns(t *testing.T) {
+func TestJobRun_NextTaskRun(t *testing.T) {
 	t.Parallel()
 
 	store, cleanup := cltest.NewStore()
@@ -52,83 +51,13 @@ func TestJobRun_UnfinishedTaskRuns(t *testing.T) {
 	assert.NoError(t, store.SaveJob(&job))
 	run := job.NewRun(initiator)
 	assert.NoError(t, store.Save(&run))
-	assert.Equal(t, run.TaskRuns, run.UnfinishedTaskRuns())
+	assert.Equal(t, &run.TaskRuns[0], run.NextTaskRun())
 
-	store.RunChannel.Send(run.ID, nil)
+	store.RunChannel.Send(run.ID)
 	cltest.WaitForJobRunStatus(t, store, run, models.RunStatusPendingConfirmations)
 
 	store.One("ID", run.ID, &run)
-	assert.Equal(t, run.TaskRuns[1:], run.UnfinishedTaskRuns())
-}
-
-func TestTaskRun_Runnable(t *testing.T) {
-	t.Parallel()
-
-	job, initr := cltest.NewJobWithLogInitiator()
-	tests := []struct {
-		name                 string
-		creationHeight       *hexutil.Big
-		currentHeight        *models.IndexableBlockNumber
-		minimumConfirmations uint64
-		want                 bool
-	}{
-		{"creation nil current nil minconfs 0", nil, nil, 0, true},
-		{"creation 1 current nil minconfs 0", cltest.NewBigHexInt(1), nil, 0, true},
-		{"creation 1 current 1 minconfs 0", cltest.NewBigHexInt(1), cltest.IndexableBlockNumber(1), 0, true},
-		{"creation 1 current 1 minconfs 1", cltest.NewBigHexInt(1), cltest.IndexableBlockNumber(1), 1, true},
-		{"creation 1 current 2 minconfs 1", cltest.NewBigHexInt(1), cltest.IndexableBlockNumber(2), 1, true},
-		{"creation 1 current 2 minconfs 2", cltest.NewBigHexInt(1), cltest.IndexableBlockNumber(2), 2, true},
-		{"creation 1 current 2 minconfs 3", cltest.NewBigHexInt(1), cltest.IndexableBlockNumber(2), 3, false},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			jr := job.NewRun(initr)
-			if test.creationHeight != nil {
-				jr.CreationHeight = test.creationHeight
-			}
-
-			assert.Equal(t, test.want, jr.Runnable(test.currentHeight, test.minimumConfirmations))
-		})
-	}
-}
-
-func TestTaskRun_Merge(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{"preserves task field",
-			`{"url":"https://NEW.example.com/api"}`,
-			`{"url":"https://OLD.example.com/api"}`},
-		{"add field",
-			`{"extra":1}`,
-			`{"url":"https://OLD.example.com/api","extra":1}`},
-		{"preserves task field and adds new field",
-			`{"url":"https://NEW.example.com/api","extra":1}`,
-			`{"url":"https://OLD.example.com/api","extra":1}`},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			orig := `{"url":"https://OLD.example.com/api"}`
-			tr := models.TaskRun{
-				Task: models.TaskSpec{
-					Params: models.JSON{Result: gjson.Parse(orig)},
-					Type:   adapters.TaskTypeHTTPGet,
-				},
-			}
-			input := cltest.JSONFromString(test.input)
-
-			merged, err := tr.MergeTaskParams(input)
-			assert.NoError(t, err)
-			assert.JSONEq(t, test.want, merged.Task.Params.String())
-			assert.JSONEq(t, orig, tr.Task.Params.String())
-		})
-	}
+	assert.Equal(t, &run.TaskRuns[1], run.NextTaskRun())
 }
 
 func TestRunResult_Value(t *testing.T) {

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -85,11 +85,11 @@ func (orm *ORM) FindBridge(name string) (models.BridgeType, error) {
 // PendingBridgeType returns the bridge type of the current pending task,
 // or error if not pending bridge.
 func (orm *ORM) PendingBridgeType(jr models.JobRun) (models.BridgeType, error) {
-	unfinished := jr.UnfinishedTaskRuns()
-	if len(unfinished) == 0 {
+	nextTask := jr.NextTaskRun()
+	if nextTask == nil {
 		return models.BridgeType{}, errors.New("Cannot find the pending bridge type of a job run with no unfinished tasks")
 	}
-	return orm.FindBridge(unfinished[0].Task.Type.String())
+	return orm.FindBridge(nextTask.Task.Type.String())
 }
 
 // FindJob looks up a Job by its ID.
@@ -197,18 +197,6 @@ func (orm *ORM) SaveServiceAgreement(sa *models.ServiceAgreement) error {
 	}
 
 	return tx.Commit()
-}
-
-// SaveCreationHeight stores the JobRun in the database with the given
-// block number.
-func (orm *ORM) SaveCreationHeight(jr models.JobRun, bn *models.IndexableBlockNumber) (models.JobRun, error) {
-	if jr.CreationHeight != nil || bn == nil {
-		return jr, nil
-	}
-
-	dup := bn.Number
-	jr.CreationHeight = &dup
-	return jr, orm.Save(&jr)
 }
 
 // JobRunsWithStatus returns the JobRuns which have the passed statuses.

--- a/store/store_test.go
+++ b/store/store_test.go
@@ -5,9 +5,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store"
-	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestStore_Start(t *testing.T) {
@@ -24,42 +22,14 @@ func TestStore_Start(t *testing.T) {
 	ethMock.EventuallyAllCalled(t)
 }
 
-func TestStore_Start_CleansupPrematureShutdown(t *testing.T) {
-	t.Parallel()
-
-	app, cleanup := cltest.NewApplicationWithKeyStore()
-	defer cleanup()
-
-	ethMock := app.MockEthClient()
-	ethMock.Register("eth_getTransactionCount", `0x2D0`)
-
-	s := app.Store
-	job, init := cltest.NewJobWithWebInitiator()
-	require.NoError(t, s.SaveJob(&job))
-
-	jr := job.NewRun(init)
-	jr.Status = models.RunStatusInProgress
-	require.NoError(t, s.Save(&jr))
-
-	require.NoError(t, s.Start())
-	var cleanedJr models.JobRun
-	require.NoError(t, s.One("ID", jr.ID, &cleanedJr))
-
-	assert.Equal(t, jr.ID, cleanedJr.ID)
-	assert.Equal(t, string(models.RunStatusUnstarted), string(cleanedJr.Status))
-
-	require.NoError(t, app.JobRunner.Start())
-	cltest.WaitForJobRunToComplete(t, s, cleanedJr)
-}
-
 func TestStore_Close(t *testing.T) {
 	t.Parallel()
 
 	s, cleanup := cltest.NewStore()
 	defer cleanup()
 
-	s.RunChannel.Send("whatever", nil)
-	s.RunChannel.Send("whatever", nil)
+	s.RunChannel.Send("whatever")
+	s.RunChannel.Send("whatever")
 
 	rr, open := <-s.RunChannel.Receive()
 	assert.True(t, open)
@@ -78,20 +48,17 @@ func TestQueuedRunChannel_Send(t *testing.T) {
 	t.Parallel()
 
 	rq := store.NewQueuedRunChannel()
-	ibn1 := cltest.IndexableBlockNumber(17)
 
-	assert.NoError(t, rq.Send("first", ibn1))
+	assert.NoError(t, rq.Send("first"))
 	rr1 := <-rq.Receive()
-	assert.Equal(t, ibn1, rr1.BlockNumber)
+	assert.NotNil(t, rr1)
 }
 
 func TestQueuedRunChannel_Send_afterClose(t *testing.T) {
 	t.Parallel()
 
 	rq := store.NewQueuedRunChannel()
-	ibn1 := cltest.IndexableBlockNumber(17)
-
 	rq.Close()
 
-	assert.Error(t, rq.Send("first", ibn1))
+	assert.Error(t, rq.Send("first"))
 }

--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -59,12 +59,7 @@ func (txm *TxManager) createTxWithNonceReload(to common.Address, data []byte, nr
 			return err
 		}
 
-		logger.Infow(fmt.Sprintf(
-			"Transaction from: %v, to: %v, attempt #: %v",
-			txm.activeAccount.Address.String(),
-			to.String(),
-			nrc,
-		))
+		logger.Infow(fmt.Sprintf("Created ETH transaction, attempt #: %v", nrc), []interface{}{"from", txm.activeAccount.Address.String(), "to", to.String()}...)
 		gasPrice := txm.config.EthGasPriceDefault
 		var txa *models.TxAttempt
 		txa, err = txm.createAttempt(tx, &gasPrice, blkNum)

--- a/web/job_runs_controller.go
+++ b/web/job_runs_controller.go
@@ -58,7 +58,7 @@ func (jrc *JobRunsController) Create(c *gin.Context) {
 		c.AbortWithError(500, err)
 	} else if jr, err := services.ExecuteJob(j, j.InitiatorsFor(models.InitiatorWeb)[0], models.RunResult{Data: data}, nil, jrc.App.Store); err != nil {
 		c.AbortWithError(500, err)
-	} else if doc, err := jsonapi.Marshal(presenters.JobRun{jr}); err != nil {
+	} else if doc, err := jsonapi.Marshal(presenters.JobRun{JobRun: *jr}); err != nil {
 		c.AbortWithError(500, err)
 	} else {
 		c.Data(200, MediaType, doc)
@@ -82,7 +82,7 @@ func (jrc *JobRunsController) Show(c *gin.Context) {
 		c.AbortWithError(404, errors.New("Job Run not found"))
 	} else if err != nil {
 		c.AbortWithError(500, err)
-	} else if doc, err := jsonapi.Marshal(presenters.JobRun{jr}); err != nil {
+	} else if doc, err := jsonapi.Marshal(presenters.JobRun{JobRun: jr}); err != nil {
 		c.AbortWithError(500, err)
 	} else {
 		c.Data(200, MediaType, doc)
@@ -108,7 +108,7 @@ func (jrc *JobRunsController) Update(c *gin.Context) {
 		c.AbortWithError(500, err)
 	} else if _, err := bt.Authenticate(utils.StripBearer(c.Request.Header.Get("Authorization"))); err != nil {
 		publicError(c, http.StatusUnauthorized, err)
-	} else if err = services.ResumePendingTask(&jr, jrc.App.Store, brr.RunResult); err != nil {
+	} else if _, err = services.ResumePendingTask(&jr, jrc.App.Store, brr.RunResult); err != nil {
 		c.AbortWithError(500, err)
 	} else {
 		c.JSON(200, gin.H{"id": jr.ID})

--- a/web/job_runs_controller.go
+++ b/web/job_runs_controller.go
@@ -9,9 +9,7 @@ import (
 	"github.com/asdine/storm"
 	"github.com/gin-gonic/gin"
 	"github.com/manyminds/api2go/jsonapi"
-	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/services"
-	"github.com/smartcontractkit/chainlink/store"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 	"github.com/smartcontractkit/chainlink/utils"
@@ -58,7 +56,7 @@ func (jrc *JobRunsController) Create(c *gin.Context) {
 		c.AbortWithError(403, errors.New("Job not available on web API, recreate with web initiator"))
 	} else if data, err := getRunData(c); err != nil {
 		c.AbortWithError(500, err)
-	} else if jr, err := startJob(j, jrc.App.Store, data); err != nil {
+	} else if jr, err := services.ExecuteJob(j, j.InitiatorsFor(models.InitiatorWeb)[0], models.RunResult{Data: data}, nil, jrc.App.Store); err != nil {
 		c.AbortWithError(500, err)
 	} else if doc, err := jsonapi.Marshal(presenters.JobRun{jr}); err != nil {
 		c.AbortWithError(500, err)
@@ -110,52 +108,9 @@ func (jrc *JobRunsController) Update(c *gin.Context) {
 		c.AbortWithError(500, err)
 	} else if _, err := bt.Authenticate(utils.StripBearer(c.Request.Header.Get("Authorization"))); err != nil {
 		publicError(c, http.StatusUnauthorized, err)
-	} else if err = resumeJob(&jr, brr.RunResult, jrc.App.Store); err != nil {
+	} else if err = services.ResumePendingTask(&jr, jrc.App.Store, brr.RunResult); err != nil {
 		c.AbortWithError(500, err)
 	} else {
 		c.JSON(200, gin.H{"id": jr.ID})
 	}
-}
-
-func resumeJob(jr *models.JobRun, input models.RunResult, store *store.Store) error {
-	var err error
-	if input.Status.Errored() {
-		*jr = jr.ApplyResult(input)
-		return store.Save(jr)
-	}
-
-	jr.Overrides, err = jr.Overrides.Merge(input)
-	if err != nil {
-		*jr = jr.ApplyResult(jr.Result.WithError(err))
-		return store.Save(jr)
-	}
-
-	if err := store.Save(jr); err != nil {
-		return err
-	}
-	executeRun(*jr, store)
-	return nil
-}
-
-func startJob(j models.JobSpec, s *store.Store, body models.JSON) (models.JobRun, error) {
-	i := j.InitiatorsFor(models.InitiatorWeb)[0]
-	jr, err := services.BuildRun(j, i, s, models.RunResult{Data: body})
-	if err != nil {
-		return jr, err
-	}
-
-	if s.Save(&jr); err != nil {
-		return jr, err
-	}
-
-	executeRun(jr, s)
-	return jr, nil
-}
-
-func executeRun(jr models.JobRun, s *store.Store) {
-	go func() {
-		if err := s.RunChannel.Send(jr.ID, nil); err != nil {
-			logger.Error("Web initiator: ", err.Error())
-		}
-	}()
 }

--- a/web/snapshots_controller.go
+++ b/web/snapshots_controller.go
@@ -24,7 +24,7 @@ func (sc *SnapshotsController) CreateSnapshot(c *gin.Context) {
 		publicError(c, 404, errors.New("Job not found"))
 	} else if err != nil {
 		c.AbortWithError(500, err)
-	} else if jr, err := startJob(j, sc.App.Store, models.JSON{}); err != nil {
+	} else if jr, err := services.ExecuteJob(j, j.InitiatorsFor(models.InitiatorWeb)[0], models.RunResult{}, nil, sc.App.Store); err != nil {
 		c.AbortWithError(500, err)
 	} else {
 		c.JSON(200, gin.H{"id": jr.ID})


### PR DESCRIPTION
Remove block height from run channel, simplify job runner

This is a BFC, highlights:

 1. The run channel no longer contains any state, i.e. block height has
 been removed from the run channel
 2. The job runner works on one task at a time
 3. All logic for whether a task should run has been moved into the
 initiator side, preventing data races with long held job runs in the
 job runner
 4. Specialized logic for various initiators has been moved into New*
 factory methods so they can be tested independently of the job runner.

This paves the way for the ability to recover job runner state at
startup, since all state is captured in storage, rather than in the run
channel.
