### PR TITLE
Switch use of orm.All to use AllInBatches for better memory consumption

### DIFF
--- a/cmd/remote_client_test.go
+++ b/cmd/remote_client_test.go
@@ -113,7 +113,7 @@ func TestClient_CreateServiceAgreement(t *testing.T) {
 			err := client.CreateServiceAgreement(c)
 
 			cltest.AssertError(t, test.errored, err)
-			jobs, _ := app.Store.Jobs()
+			jobs := cltest.AllJobs(app.Store)
 			if test.jobsCreated {
 				assert.True(t, len(jobs) > 0)
 			} else {
@@ -138,7 +138,7 @@ func TestClient_CreateServiceAgreementMultipleTimes(t *testing.T) {
 	err := client.CreateServiceAgreement(c)
 
 	assert.NoError(t, err)
-	numberOfJobs, _ := app.Store.Jobs()
+	numberOfJobs := cltest.AllJobs(app.Store)
 	assert.Equal(t, 1, len(numberOfJobs))
 
 	set.Parse([]string{sa.String()})
@@ -149,7 +149,7 @@ func TestClient_CreateServiceAgreementMultipleTimes(t *testing.T) {
 	err = client.CreateServiceAgreement(c)
 
 	assert.NoError(t, err)
-	numberOfJobs, _ = app.Store.Jobs()
+	numberOfJobs = cltest.AllJobs(app.Store)
 	assert.Equal(t, 2, len(numberOfJobs))
 }
 
@@ -179,7 +179,7 @@ func TestClient_CreateJobSpec(t *testing.T) {
 			err := client.CreateJobSpec(c)
 			cltest.AssertError(t, test.errored, err)
 
-			numberOfJobs, _ := app.Store.Jobs()
+			numberOfJobs := cltest.AllJobs(app.Store)
 			assert.Equal(t, test.nJobs, len(numberOfJobs))
 		})
 	}

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -742,17 +742,14 @@ func WaitForJobs(t *testing.T, store *store.Store, want int) []models.JobSpec {
 	g := gomega.NewGomegaWithT(t)
 
 	var jobs []models.JobSpec
-	var err error
 	if want == 0 {
 		g.Consistently(func() []models.JobSpec {
-			jobs, err = store.Jobs()
-			assert.NoError(t, err)
+			jobs = AllJobs(store)
 			return jobs
 		}).Should(gomega.HaveLen(want))
 	} else {
 		g.Eventually(func() []models.JobSpec {
-			jobs, err = store.Jobs()
-			assert.NoError(t, err)
+			jobs = AllJobs(store)
 			return jobs
 		}).Should(gomega.HaveLen(want))
 	}
@@ -950,4 +947,15 @@ func HexToBytes(in string) []byte {
 	b, err := utils.HexToBytes(in)
 	mustNotErr(err)
 	return b
+}
+
+func AllJobs(store *store.Store) []models.JobSpec {
+	var bucket []models.JobSpec
+	var all []models.JobSpec
+	err := store.AllInBatches(&bucket, func(j models.JobSpec) bool {
+		all = append(all, j)
+		return true
+	})
+	mustNotErr(err)
+	return all
 }

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -61,14 +61,12 @@ func (js *jobSubscriber) addSubscription(sub JobSubscription) {
 
 // Connect connects the jobs to the ethereum node by creating corresponding subscriptions.
 func (js *jobSubscriber) Connect(bn *models.IndexableBlockNumber) error {
-	jobs, err := js.store.Jobs()
-	if err != nil {
-		return err
-	}
-	for _, j := range jobs {
-		err = multierr.Append(err, js.AddJob(j, bn))
-	}
-	return err
+	var merr error
+	err := js.store.Jobs(func(j models.JobSpec) bool {
+		merr = multierr.Append(merr, js.AddJob(j, bn))
+		return true
+	})
+	return multierr.Append(merr, err)
 }
 
 // Disconnect disconnects all subscriptions associated with jobs belonging to

--- a/services/scheduler.go
+++ b/services/scheduler.go
@@ -2,7 +2,6 @@ package services
 
 import (
 	"errors"
-	"fmt"
 	"sync"
 	"time"
 
@@ -54,16 +53,10 @@ func (s *Scheduler) Start() error {
 	}
 	s.started = true
 
-	jobs, err := s.store.Jobs()
-	if err != nil {
-		return fmt.Errorf("Scheduler: %v", err)
-	}
-
-	for _, job := range jobs {
-		s.addJob(job)
-	}
-
-	return nil
+	return s.store.Jobs(func(j models.JobSpec) bool {
+		s.addJob(j)
+		return true
+	})
 }
 
 // Stop is the governing function for both Recurring and OneTime

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -110,10 +110,11 @@ func (orm *ORM) InitBucket(model interface{}) error {
 }
 
 // Jobs fetches all jobs.
-func (orm *ORM) Jobs() ([]models.JobSpec, error) {
-	var jobs []models.JobSpec
-	err := orm.All(&jobs)
-	return jobs, err
+func (orm *ORM) Jobs(cb func(models.JobSpec) bool) error {
+	var bucket []models.JobSpec
+	return orm.AllInBatches(&bucket, func(j models.JobSpec) bool {
+		return cb(j)
+	})
 }
 
 // JobRunsFor fetches all JobRuns with a given Job ID,

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -17,6 +17,13 @@ import (
 	"github.com/smartcontractkit/chainlink/utils"
 )
 
+var (
+	// ErrorInvalidCallbackSignature is returned in AllInBatches if the incorrect function signature is passed.
+	ErrorInvalidCallbackSignature = errors.New("AllInBatches callback has incorrect function signature, must return bool")
+	// ErrorInvalidCallbackModel is returned in AllInBatches if the model and bucket do not match types.
+	ErrorInvalidCallbackModel = errors.New("AllInBatches callback has incorrect model, must match bucket")
+)
+
 // ORM contains the database object used by Chainlink.
 type ORM struct {
 	*storm.DB
@@ -469,11 +476,11 @@ func (orm *ORM) AllInBatches(bucket interface{}, callback interface{}, optionalB
 	vcallback := reflect.ValueOf(callback)
 	tcallback := reflect.TypeOf(callback)
 	if tcallback.NumOut() != 1 || tcallback.Out(0).Kind() != reflect.Bool {
-		return errors.New("AllInBatches callback has incorrect function signature, must return bool")
+		return ErrorInvalidCallbackSignature
 	}
 
 	if tcallback.NumIn() != 1 || tcallback.In(0) != underlyingBucketType(bucket) {
-		return errors.New("AllInBatches callback has incorrect model, must match bucket")
+		return ErrorInvalidCallbackModel
 	}
 
 	for {

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -217,23 +217,23 @@ func (orm *ORM) JobRunsWithStatus(statuses ...models.RunStatus) ([]models.JobRun
 // AnyJobWithType returns true if there is at least one job associated with
 // the type name specified and false otherwise
 func (orm *ORM) AnyJobWithType(taskTypeName string) (bool, error) {
-	jobs := []models.JobSpec{}
-	err := orm.All(&jobs)
-	if err != nil {
-		return false, err
-	}
 	ts, err := models.NewTaskType(taskTypeName)
 	if err != nil {
 		return false, err
 	}
-	for i := range jobs {
-		for j := range jobs[i].Tasks {
-			if jobs[i].Tasks[j].Type == ts {
-				return true, nil
+
+	var found bool
+	err = orm.Jobs(func(j models.JobSpec) bool {
+		for _, t := range j.Tasks {
+			if t.Type == ts {
+				found = true
+				return false
 			}
 		}
-	}
-	return false, nil
+		return true
+	})
+
+	return found, err
 }
 
 // CreateTx saves the properties of an Ethereum transaction to the database.

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/orm"
 	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -644,15 +645,16 @@ func TestORM_AllInBatches_IncorrectCallback(t *testing.T) {
 	tests := []struct {
 		name     string
 		callback interface{}
+		err      error
 	}{
-		{"missing bool", func(models.JobSpec) {}},
-		{"wrong rval", func(models.JobSpec) int { return 0 }},
-		{"mismatched bucket and model", func(models.BridgeType) bool { return true }},
+		{"missing bool", func(models.JobSpec) {}, orm.ErrorInvalidCallbackSignature},
+		{"wrong rval", func(models.JobSpec) int { return 0 }, orm.ErrorInvalidCallbackSignature},
+		{"mismatched bucket and model", func(models.BridgeType) bool { return true }, orm.ErrorInvalidCallbackModel},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			err := store.AllInBatches(&bucket, test.callback)
-			require.Error(t, err)
+			require.Equal(t, test.err, err)
 		})
 	}
 }


### PR DESCRIPTION
Stream instances into memory in batches, rather than holding the entire bucket in memory.

https://www.pivotaltracker.com/story/show/160762751