### PR TITLE
Limit ci/gorace_test parallelism to 1

### DIFF
--- a/internal/ci/gorace_test
+++ b/internal/ci/gorace_test
@@ -3,5 +3,5 @@
 set -e
 
 # Split up each test run to mitigate memory consumption
-go test -race -cpu 2 github.com/smartcontractkit/chainlink/integration && \
-  go test -race -cpu 2 github.com/smartcontractkit/chainlink/services
+go test -race -cpu 2 -parallel 1 github.com/smartcontractkit/chainlink/integration && \
+  go test -race -cpu 2 -parallel 1 github.com/smartcontractkit/chainlink/services


### PR DESCRIPTION
Confirmed through local use that `-parallel 1` reduces memory use.