### PR TITLE
Slight improvement to router logging

### DIFF
--- a/web/router.go
+++ b/web/router.go
@@ -235,7 +235,7 @@ func loggerFunc() gin.HandlerFunc {
 		c.Next()
 		end := time.Now()
 
-		logger.Infow("Web request",
+		logger.Infow(fmt.Sprintf("%s %s", c.Request.Method, c.Request.URL.Path),
 			"method", c.Request.Method,
 			"status", c.Writer.Status(),
 			"path", c.Request.URL.Path,
@@ -243,7 +243,7 @@ func loggerFunc() gin.HandlerFunc {
 			"body", readBody(rdr),
 			"clientIP", c.ClientIP(),
 			"errors", c.Errors.String(),
-			"servedAt", end.Format("2006/01/02 - 15:04:05"),
+			"servedAt", end.Format("2006-01-02 15:04:05"),
 			"latency", fmt.Sprintf("%v", end.Sub(start)),
 		)
 	}


### PR DESCRIPTION
This makes the router log output a bit closer to nginx logs so it's easier to scan the output (also use a more standard date format).

![screen shot 2018-10-17 at 10 38 13](https://user-images.githubusercontent.com/344071/47094228-cc087100-d1f8-11e8-8b5c-cb42f040869d.png)
