### PR TITLE
chainlink-launcher adds Eth crt to CA if it exists, now used in vanilla Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build Chainlink
-FROM smartcontract/builder:1.0.9 as builder
+FROM smartcontract/builder:1.0.11 as builder
 
 # Have to reintroduce ENV vars from builder image
 ENV PATH /go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,10 +17,18 @@ FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y ca-certificates
 
+WORKDIR /root
+
 COPY --from=builder \
   /go/src/github.com/smartcontractkit/chainlink/chainlink \
   /usr/local/bin/
 
+COPY --from=builder \
+  /go/src/github.com/smartcontractkit/chainlink/chainlink-launcher.sh \
+  /root/
+
+RUN chmod +x ./chainlink-launcher.sh
+
 EXPOSE 6688
-ENTRYPOINT ["chainlink"]
+ENTRYPOINT ["./chainlink-launcher.sh"]
 CMD ["node"]

--- a/Dockerfile-sgx
+++ b/Dockerfile-sgx
@@ -1,5 +1,5 @@
 # Build Chainlink with SGX
-FROM smartcontract/builder:1.0.9 as builder
+FROM smartcontract/builder:1.0.11 as builder
 
 # Have to reintroduce ENV vars from builder image
 ENV PATH /root/.cargo/bin:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/sgxsdk/bin:/opt/sgxsdk/bin/x64

--- a/Dockerfile-sgx
+++ b/Dockerfile-sgx
@@ -43,7 +43,7 @@ COPY --from=builder /opt/intel/ /opt/intel/
 # Copy chainlink enclave+stub from build image
 ARG ENVIRONMENT
 COPY --from=builder \
-  /go/src/github.com/smartcontractkit/chainlink/chainlink /root/
+  /go/src/github.com/smartcontractkit/chainlink/chainlink /usr/local/bin/
 COPY --from=builder \
   /go/src/github.com/smartcontractkit/chainlink/sgx/target/$ENVIRONMENT/libadapters.so \
   /usr/lib/

--- a/chainlink-launcher.sh
+++ b/chainlink-launcher.sh
@@ -1,22 +1,28 @@
 #!/bin/bash -e
 
+ETHEREUM_CRT="${ETHEREUM_CRT:-/secrets/ethereum/tls.crt}"
+if [ -f $ETHEREUM_CRT ]; then
+  cp $ETHEREUM_CRT /usr/local/share/ca-certificates/eth.crt
+  update-ca-certificates
+fi
+
 command=`echo $1 | tr A-Z a-z`
 if [ "$command" != "n" ] && [ "$command" != "node" ]; then
-  ./chainlink "$@"
+  chainlink "$@"
   exit 0
 fi
 
 trap "kill -- -$$ 2>/dev/null || true" SIGINT SIGTERM EXIT
 
-if [ "$SGX_SIMULATION" != yes ]; then
+if [ "$SGXENABLED" = "yes" ] && [ "$SGX_SIMULATION" != "yes" ]; then
   /opt/intel/sgxpsw/aesm/aesm_service &
   aesm_pid=$!
 fi
 
-./chainlink "$@" | cat &
+chainlink "$@" | cat &
 chainlink_pid=$!
 
-if [ "$SGX_SIMULATION" != yes ]; then
+if [ "$SGXENABLED" = "yes" ] && [ "$SGX_SIMULATION" != "yes" ]; then
   while sleep 10; do
     kill -0 $aesm_pid 2>/dev/null
     kill -0 $chainlink_pid 2>/dev/null


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/635121/47121213-d437cf00-d23f-11e8-94e6-4e84cf2b10c8.png)


Associated with https://github.com/smartcontractkit/infrastructure/pull/34