### PR TITLE
Add return value to initiateServiceAgreement and log

### DIFF
--- a/solidity/contracts/Coordinator.sol
+++ b/solidity/contracts/Coordinator.sol
@@ -106,11 +106,11 @@ contract Coordinator {
     bytes32[] _rs,
     bytes32[] _ss,
     bytes32 _requestDigest
-  ) public
+  ) public returns (bytes32 serviceAgreementID)
   {
     require(_oracles.length == _vs.length && _vs.length == _rs.length && _rs.length == _ss.length, "Must pass in as many signatures as oracles");
 
-    bytes32 serviceAgreementID = getId(_payment, _expiration, _oracles, _requestDigest);
+    serviceAgreementID = getId(_payment, _expiration, _oracles, _requestDigest);
 
     for (uint i = 0; i < _oracles.length; i++) {
       address signer = getOracleAddressFromSASignature(serviceAgreementID, _vs[i], _rs[i], _ss[i]);

--- a/solidity/contracts/Coordinator.sol
+++ b/solidity/contracts/Coordinator.sol
@@ -38,6 +38,11 @@ contract Coordinator {
     bytes data
   );
 
+  event NewServiceAgreement(
+    bytes32 indexed said,
+    bytes32 indexed requestDigest
+  );
+
   function onTokenTransfer(
     address _sender,
     uint256 _amount,
@@ -123,6 +128,8 @@ contract Coordinator {
       _oracles,
       _requestDigest
     );
+
+    emit NewServiceAgreement(serviceAgreementID, _requestDigest);
   }
 
   function getOracleAddressFromSASignature(

--- a/solidity/test/Coordinator_test.js
+++ b/solidity/test/Coordinator_test.js
@@ -7,6 +7,7 @@ import {
   deploy,
   executeServiceAgreementBytes,
   functionSelector,
+  getLatestEvent,
   newAddress,
   newHash,
   oracleNode,
@@ -116,6 +117,22 @@ contract('Coordinator', () => {
         )
         const expected = toHex(calculateSAID(payment, expiration, oracles, requestDigest))
         assert.equal(said, expected)
+      })
+
+      it('logs an event', async () => {
+        await coordinator.initiateServiceAgreement(
+          toHex(payment),
+          toHex(expiration),
+          oracles.map(toHex),
+          [oracleSignature.v],
+          [oracleSignature.r].map(toHex),
+          [oracleSignature.s].map(toHex),
+          toHex(requestDigest)
+        )
+        
+        const event = await getLatestEvent(coordinator)
+        const expected = toHex(calculateSAID(payment, expiration, oracles, requestDigest))
+        assert.equal(expected, event.args.said)
       })
     })
 

--- a/solidity/test/Coordinator_test.js
+++ b/solidity/test/Coordinator_test.js
@@ -103,6 +103,20 @@ contract('Coordinator', () => {
         /// /   ['0x70AEc4B9CFFA7b55C0711b82DD719049d615E21d', '0xd26114cd6EE289AccF82350c8d8487fedB8A0C07']
         /// / )
       })
+
+      it('returns the SAID', async () => {
+        const said = await coordinator.initiateServiceAgreement.call(
+          toHex(payment),
+          toHex(expiration),
+          oracles.map(toHex),
+          [oracleSignature.v],
+          [oracleSignature.r].map(toHex),
+          [oracleSignature.s].map(toHex),
+          toHex(requestDigest)
+        )
+        const expected = toHex(calculateSAID(payment, expiration, oracles, requestDigest))
+        assert.equal(said, expected)
+      })
     })
 
     context("with an invalid oracle signatures", () => {


### PR DESCRIPTION
- Caller immediately receives the SAID
- Nodes can watch for service agreements which they have signed to have been initiated on-chain