### PR TITLE
Fix multiply adapter: correct EDL to match ECALL

### DIFF
--- a/sgx/enclave/enclave.edl
+++ b/sgx/enclave/enclave.edl
@@ -18,6 +18,7 @@ enclave {
     public sgx_status_t sgx_multiply(
       [in, size=adapter_len] const uint8_t* adapter, size_t adapter_len,
       [in, size=input_len] const uint8_t* input, size_t input_len,
-      [out, size=output_len] uint8_t* output, size_t output_len);
+      [out, size=result_capacity] uint8_t* result_ptr, size_t result_capacity,
+      [out] size_t *result_len);
   };
 };

--- a/sgx/enclave/src/lib.rs
+++ b/sgx/enclave/src/lib.rs
@@ -161,7 +161,7 @@ fn multiply(
     let multiplicand = get_json_string(&input.data, "value")?;
     let result = parse_and_multiply(&multiplicand, &multiplier)?;
 
-    input.status = Some("completed".to_string());
+    input.status = "completed".to_string();
     input.add("value", serde_json::Value::String(result));
 
     let rr_json = serde_json::to_string(&input)?;
@@ -192,7 +192,7 @@ fn parse_and_multiply(
 struct RunResult {
     job_run_id: String,
     data: serde_json::Value,
-    status: Option<String>,
+    status: String,
     error_message: Option<String>,
     amount: Option<u64>,
 }

--- a/sgx/utils/src/lib.rs
+++ b/sgx/utils/src/lib.rs
@@ -56,7 +56,7 @@ pub fn copy_string_to_cstr_ptr(
     }
 
     unsafe {
-        from_raw_parts_mut(output_ptr, input_size).copy_from_slice(input_slice);
+        ptr::copy_nonoverlapping(input_slice.as_ptr(), output_ptr, input_size);
         ptr::copy(&input_size, output_len, 1);
     }
 


### PR DESCRIPTION
  * status in result is not an Option
  * use copy_nonoverlapping in utils

The EDL definition of sgx_multiply was missing the final parameter result_len, so we were smashing the stack in the ECALL wrapper.

SGX edg8r creates a wrapper library of c functions around all trusted calls in the enclave, and since it was informed incorrectly of the argument count, the ABI was all messed up, resulting in a panic.

