### PR TITLE
Add SGX integration test to CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ jobs:
   go:
     working_directory: /go/src/github.com/smartcontractkit/chainlink
     docker:
-      - image: smartcontract/builder:1.0.11
+      - image: smartcontract/builder:1.0.12
     steps:
       - checkout
       - restore_cache:
@@ -20,7 +20,7 @@ jobs:
   gorace:
     working_directory: /go/src/github.com/smartcontractkit/chainlink
     docker:
-      - image: smartcontract/builder:1.0.11
+      - image: smartcontract/builder:1.0.12
     steps:
       - checkout
       - restore_cache:
@@ -36,7 +36,7 @@ jobs:
   rust:
     working_directory: /go/src/github.com/smartcontractkit/chainlink
     docker:
-      - image: smartcontract/builder:1.0.11
+      - image: smartcontract/builder:1.0.12
     steps:
       - checkout
       - restore_cache:
@@ -55,10 +55,39 @@ jobs:
           paths:
               - ~/.cargo
       - run: ./internal/ci/rust_test
+  sgx:
+    working_directory: /go/src/github.com/smartcontractkit/chainlink
+    docker:
+      - image: smartcontract/builder:1.0.12
+    environment:
+      SGX_ENABLED: yes
+      # XXX: These are set in the base image but circleci seems to wipe them out
+      PATH: "/root/.cargo/bin:/go/bin:/usr/local/go/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/opt/sgxsdk/bin:/opt/sgxsdk/bin/x64"
+      LD_LIBRARY_PATH: "/opt/sgxsdk/sdk_libs"
+      SGX_SDK: "/opt/sgxsdk"
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore Go Vendor Cache
+          key: v1-go-vendor-{{ checksum "Gopkg.lock" }}
+      - restore_cache:
+          key: cargo-cache
+      - run: dep ensure -vendor-only
+      - save_cache:
+          name: Save Go Vendor Cache
+          key: v1-go-vendor-{{ checksum "Gopkg.lock" }}
+          paths:
+            - ./vendor
+      - save_cache:
+          key: cargo-cache
+          paths:
+              - ~/.cargo
+      - run: make chainlink
+      - run: ./internal/ci/sgx_test
   geth:
     working_directory: /go/src/github.com/smartcontractkit/chainlink
     docker:
-      - image: smartcontract/builder:1.0.11
+      - image: smartcontract/builder:1.0.12
     steps:
       - checkout
       - restore_cache:
@@ -74,7 +103,7 @@ jobs:
   truffle:
     working_directory: /go/src/github.com/smartcontractkit/chainlink
     docker:
-      - image: smartcontract/builder:1.0.11
+      - image: smartcontract/builder:1.0.12
     steps:
       - checkout
       - restore_cache:
@@ -90,7 +119,7 @@ jobs:
   gui:
     working_directory: /go/src/github.com/smartcontractkit/chainlink
     docker:
-      - image: smartcontract/builder:1.0.11
+      - image: smartcontract/builder:1.0.12
     steps:
       - checkout
       - restore_cache:
@@ -106,7 +135,7 @@ jobs:
       - run: ./internal/ci/gui_test
   reportcoverage:
     docker:
-      - image: smartcontract/builder:1.0.11
+      - image: smartcontract/builder:1.0.12
     steps:
       - checkout
       - run: ./internal/ci/init_gcloud
@@ -141,6 +170,7 @@ workflows:
       - geth
       - gui
       - rust
+      - sgx
       - reportcoverage:
           requires:
             - go

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,18 +42,12 @@ jobs:
       - restore_cache:
           name: Restore Go Vendor Cache
           key: v1-go-vendor-{{ checksum "Gopkg.lock" }}
-      - restore_cache:
-          key: cargo-cache
       - run: dep ensure -vendor-only
       - save_cache:
           name: Save Go Vendor Cache
           key: v1-go-vendor-{{ checksum "Gopkg.lock" }}
           paths:
             - ./vendor
-      - save_cache:
-          key: cargo-cache
-          paths:
-              - ~/.cargo
       - run: ./internal/ci/rust_test
   sgx:
     working_directory: /go/src/github.com/smartcontractkit/chainlink
@@ -70,18 +64,12 @@ jobs:
       - restore_cache:
           name: Restore Go Vendor Cache
           key: v1-go-vendor-{{ checksum "Gopkg.lock" }}
-      - restore_cache:
-          key: cargo-cache
       - run: dep ensure -vendor-only
       - save_cache:
           name: Save Go Vendor Cache
           key: v1-go-vendor-{{ checksum "Gopkg.lock" }}
           paths:
             - ./vendor
-      - save_cache:
-          key: cargo-cache
-          paths:
-              - ~/.cargo
       - run: make chainlink
       - run: ./internal/ci/sgx_test
   geth:

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ SGX_SIMULATION ?= yes
 SGX_ENCLAVE := enclave.signed.so
 SGX_TARGET := ./sgx/target/$(ENVIRONMENT)/
 
-ifeq ($(SGX_ENABLED),yes)
+ifneq (,$(filter yes true,$(SGX_ENABLED)))
 	GOFLAGS += -tags=sgx_enclave
 	SGX_BUILD_ENCLAVE := $(SGX_ENCLAVE)
 	DOCKERFILE := Dockerfile-sgx

--- a/adapters/multiply_sgx.go
+++ b/adapters/multiply_sgx.go
@@ -70,6 +70,7 @@ func (ma *Multiply) Perform(input models.RunResult, _ *store.Store) models.RunRe
 	if _, err = C.multiply(cAdapter, cInput, output, bufferCapacity, outputLenPtr); err != nil {
 		return input.WithError(fmt.Errorf("SGX multiply: %v", err))
 	}
+
 	sgxResult := C.GoStringN(output, outputLen)
 	var result models.RunResult
 	if err := json.Unmarshal([]byte(sgxResult), &result); err != nil {

--- a/adapters/wasm_test.go
+++ b/adapters/wasm_test.go
@@ -14,12 +14,9 @@ import (
 )
 
 const (
-	// HelloWorldProgram was compiled then base64ed from internal/fixtures/wasm/helloworld.wat
-	// This program prints hello world then sets two globals (length, position)
-	HelloWorldProgram = "AGFzbQEAAAABBgFgAX4BfwMCAQAHCwEHcGVyZm9ybQAACgoBCABCwgMgAFML"
-	// CheckEthProgram was compiled then base64ed from internal/fixtures/wasm/checketh.wat
+	// CheckEthProgram was compiled then base64ed from internal/fixtures/wasm/checkethf.wat
 	// This program compares the input value to 450 using i64.lt_s
-	CheckEthProgram = "AGFzbQEAAAABBgFgAX4BfwMCAQAHCwEHcGVyZm9ybQAACgoBCABCwgMgAFML"
+	CheckEthProgram = "AGFzbQEAAAABBgFgAXwBfwMCAQAHCwEHcGVyZm9ybQAAChABDgBEAAAAAAAgfEAgAGML"
 )
 
 func TestWasm_Perform(t *testing.T) {
@@ -32,26 +29,26 @@ func TestWasm_Perform(t *testing.T) {
 		jsonError bool
 	}{
 		{
-			"hello world",
-			fmt.Sprintf(`{"wasm":"%s"}`, HelloWorldProgram),
-			`{"value": 0}`,
-			"",
+			"check eth less than 450",
+			fmt.Sprintf(`{"wasm":"%s"}`, CheckEthProgram),
+			`{"value": 449.9}`,
+			"0",
+			false,
+			false,
+		},
+		{
+			"check eth equals 450",
+			fmt.Sprintf(`{"wasm":"%s"}`, CheckEthProgram),
+			`{"value": 450.0}`,
+			"0",
 			false,
 			false,
 		},
 		{
 			"check eth greater than 450",
 			fmt.Sprintf(`{"wasm":"%s"}`, CheckEthProgram),
-			`{"value":"451"}`,
+			`{"value": 450.1}`,
 			"1",
-			false,
-			false,
-		},
-		{
-			"check eth less than 450",
-			fmt.Sprintf(`{"wasm":"%s"}`, CheckEthProgram),
-			`{"value":"449"}`,
-			"-1",
 			false,
 			false,
 		},

--- a/adapters/wasm_test.go
+++ b/adapters/wasm_test.go
@@ -1,0 +1,86 @@
+// +build sgx_enclave
+
+package adapters_test
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink/adapters"
+	"github.com/smartcontractkit/chainlink/internal/cltest"
+	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	// HelloWorldProgram was compiled then base64ed from internal/fixtures/wasm/helloworld.wat
+	// This program prints hello world then sets two globals (length, position)
+	HelloWorldProgram = "AGFzbQEAAAABBgFgAX4BfwMCAQAHCwEHcGVyZm9ybQAACgoBCABCwgMgAFML"
+	// CheckEthProgram was compiled then base64ed from internal/fixtures/wasm/checketh.wat
+	// This program compares the input value to 450 using i64.lt_s
+	CheckEthProgram = "AGFzbQEAAAABBgFgAX4BfwMCAQAHCwEHcGVyZm9ybQAACgoBCABCwgMgAFML"
+)
+
+func TestWasm_Perform(t *testing.T) {
+	tests := []struct {
+		name      string
+		params    string
+		json      string
+		want      string
+		errored   bool
+		jsonError bool
+	}{
+		{
+			"hello world",
+			fmt.Sprintf(`{"wasm":"%s"}`, HelloWorldProgram),
+			`{"value": 0}`,
+			"",
+			false,
+			false,
+		},
+		{
+			"check eth greater than 450",
+			fmt.Sprintf(`{"wasm":"%s"}`, CheckEthProgram),
+			`{"value":"451"}`,
+			"1",
+			false,
+			false,
+		},
+		{
+			"check eth less than 450",
+			fmt.Sprintf(`{"wasm":"%s"}`, CheckEthProgram),
+			`{"value":"449"}`,
+			"-1",
+			false,
+			false,
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			input := models.RunResult{
+				Data: cltest.JSONFromString(test.json),
+			}
+			adapter := adapters.Wasm{}
+			jsonErr := json.Unmarshal([]byte(test.params), &adapter)
+			result := adapter.Perform(input, nil)
+
+			if test.jsonError {
+				assert.Error(t, jsonErr)
+			} else if test.errored {
+				assert.Error(t, result.GetError())
+				assert.NoError(t, jsonErr)
+			} else {
+				val, err := result.Value()
+				assert.NoError(t, err)
+				assert.Equal(t, test.want, val)
+				assert.NoError(t, result.GetError())
+				assert.NoError(t, jsonErr)
+			}
+		})
+	}
+}

--- a/adapters/wasm_test.go
+++ b/adapters/wasm_test.go
@@ -52,6 +52,22 @@ func TestWasm_Perform(t *testing.T) {
 			false,
 			false,
 		},
+		{
+			"invalid wasm in adapter",
+			`{"wasm":"123is"}`,
+			"",
+			"",
+			true,
+			false,
+		},
+		{
+			"invalid input ",
+			fmt.Sprintf(`{"wasm":"%s"}`, CheckEthProgram),
+			`{"value": null}`,
+			"",
+			true,
+			false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,9 +16,9 @@ services:
       - node_password
 
   chainlink:
-    image: smartcontract/chainlink
-    command: node -d -p /run/secrets/node_password
-    restart: on-failure
+    image: smartcontract/chainlink-sgx
+    command: node -d -p /run/secrets/node_password -a /run/secrets/apicredentials
+    restart: always
     volumes:
       - ./internal/clroot/:/root/clroot
     environment:

--- a/internal/bin/sgx-env
+++ b/internal/bin/sgx-env
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 workdir="/go/src/github.com/smartcontractkit/chainlink"
 image_tag=`cat Dockerfile-sgx | grep FROM | grep builder | awk '{print$2}'`

--- a/internal/ci/sgx_test
+++ b/internal/ci/sgx_test
@@ -1,0 +1,13 @@
+#!/bin/bash -e
+
+set -x
+
+export ENVIRONMENT=${ENVIRONMENT:-release}
+
+tmpdir=$(mktemp -d)
+trap "rm -rf $tmpdir" EXIT HUP TERM INT
+libs="$PWD/sgx/target/$ENVIRONMENT"
+cp ./sgx/target/$ENVIRONMENT/enclave.signed.so $tmpdir/
+go test -tags=sgx_enclave -ldflags "-r $libs" ./adapters/ -c -o "$tmpdir/adapters.test"
+cd $tmpdir
+./adapters.test -test.parallel 1 -test.v

--- a/internal/ci/sgx_test
+++ b/internal/ci/sgx_test
@@ -6,8 +6,17 @@ export ENVIRONMENT=${ENVIRONMENT:-release}
 
 tmpdir=$(mktemp -d)
 trap "rm -rf $tmpdir" EXIT HUP TERM INT
+
 libs="$PWD/sgx/target/$ENVIRONMENT"
 cp ./sgx/target/$ENVIRONMENT/enclave.signed.so $tmpdir/
+
 go test -tags=sgx_enclave -ldflags "-r $libs" ./adapters/ -c -o "$tmpdir/adapters.test"
+
 cd $tmpdir
-./adapters.test -test.parallel 1 -test.v
+if [ -n "$USE_GDB" ] && [ "$ENVIRONMENT" == "debug" ]; then
+  # XXX: The sgx-gdb wrapper script will actually load the symbol table for the enclave
+  /opt/sgxsdk/bin/sgx-gdb -ex run --args ./adapters.test -test.parallel 1 -test.v
+else
+  # FIXME: Get a TCS exhausted error if go tries to run SGX performs from multiple threads/cpus
+  GOMAXPROCS=1 ./adapters.test -test.parallel 1 -test.v -test.run TestWasm_Perform
+fi

--- a/internal/ci/sgx_test
+++ b/internal/ci/sgx_test
@@ -7,6 +7,7 @@ export ENVIRONMENT=${ENVIRONMENT:-release}
 tmpdir=$(mktemp -d)
 trap "rm -rf $tmpdir" EXIT HUP TERM INT
 
+# Put the enclave alongside the test binary so libadapters.so can find it
 libs="$PWD/sgx/target/$ENVIRONMENT"
 cp ./sgx/target/$ENVIRONMENT/enclave.signed.so $tmpdir/
 

--- a/internal/fixtures/wasm/checkethf.wat
+++ b/internal/fixtures/wasm/checkethf.wat
@@ -1,0 +1,6 @@
+(module
+  (func $perform (param $value f64) (result i32)
+    (f64.lt (f64.const 450.0) (get_local $value))
+  )
+  (export "perform" (func $perform))
+)

--- a/sgx/Makefile
+++ b/sgx/Makefile
@@ -22,17 +22,16 @@ SGX_ENCLAVE_SIGNER := $(SGX_BIN)/sgx_sign
 SGX_LIBRARY_PATH := $(SGX_SDK)/lib64
 SGX_COMMON_CFLAGS := -m64
 
-RUST_FLAGS :=
-ifeq ($(ENVIRONMENT), debug)
-	SGX_COMMON_CFLAGS += -O0 -g
-else
+ifneq (,$(filter release,$(ENVIRONMENT)))
 	SGX_COMMON_CFLAGS += -O2
 	RUST_FLAGS := --release
+else
+	SGX_COMMON_CFLAGS += -O0 -g
 endif
 
 TRTS_LIB := sgx_trts
 SERVICE_LIB := sgx_tservice
-ifeq ($(SGX_SIMULATION),yes)
+ifneq (,$(filter yes true,$(SGX_SIMULATION)))
 	TRTS_LIB := sgx_trts_sim
 	SERVICE_LIB := sgx_tservice_sim
 endif

--- a/sgx/enclave/Cargo.toml
+++ b/sgx/enclave/Cargo.toml
@@ -11,14 +11,14 @@ crate-type = ["staticlib"]
 default = []
 
 [dependencies]
-utils = { path = "../utils", default-features = false }
+base64 = { path = "/opt/rust-sgx-sdk/third_party/rust-base64" }
 num = { path = "/opt/rust-sgx-sdk/third_party/num" }
 serde = { path = "/opt/rust-sgx-sdk/third_party/serde-rs/serde/serde" }
 serde_derive = { path = "/opt/rust-sgx-sdk/third_party/serde-rs/serde/serde_derive" }
 serde_json = { path = "/opt/rust-sgx-sdk/third_party/serde-rs/json"}
+utils = { path = "../utils", default-features = false }
 wabt-core = { path = "/opt/rust-sgx-sdk/third_party/wabt-rs-core" }
 wasmi = { path = "/opt/rust-sgx-sdk/third_party/wasmi" }
-base64 = { path = "/opt/rust-sgx-sdk/third_party/rust-base64" }
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
 sgx_tstd = { path = "/opt/rust-sgx-sdk/sgx_tstd" }

--- a/sgx/enclave/enclave.config.xml
+++ b/sgx/enclave/enclave.config.xml
@@ -2,7 +2,7 @@
   <ProdID>0</ProdID>
   <ISVSVN>0</ISVSVN>
   <StackMaxSize>0x40000</StackMaxSize>
-  <HeapMaxSize>0x100000</HeapMaxSize>
+  <HeapMaxSize>0x1000000</HeapMaxSize>
   <TCSNum>1</TCSNum>
   <TCSPolicy>1</TCSPolicy>
   <DisableDebug>0</DisableDebug>

--- a/sgx/enclave/enclave.edl
+++ b/sgx/enclave/enclave.edl
@@ -6,8 +6,8 @@ enclave {
 
   trusted {
     public sgx_status_t sgx_wasm(
-      [in, size=wasmt_len] const uint8_t* wasmt_ptr, size_t wasmt_len,
-      [in, size=arguments_len] const uint8_t* arguments_ptr, size_t arguments_len,
+      [in, size=adapter_len] const uint8_t* adapter, size_t adapter_len,
+      [in, size=input_len] const uint8_t* input, size_t input_len,
       [out, size=result_capacity] uint8_t* result_ptr, size_t result_capacity,
       [out] size_t *result_len);
     public sgx_status_t sgx_multiply(

--- a/sgx/enclave/src/lib.rs
+++ b/sgx/enclave/src/lib.rs
@@ -1,6 +1,5 @@
 #![crate_name = "enclave"]
 #![crate_type = "staticlib"]
-
 #![cfg_attr(not(target_env = "sgx"), no_std)]
 #![cfg_attr(target_env = "sgx", feature(rustc_private))]
 #![feature(alloc)]
@@ -8,22 +7,26 @@
 extern crate base64;
 extern crate num;
 extern crate serde;
-#[macro_use] extern crate serde_derive;
-#[macro_use] extern crate serde_json;
+#[macro_use]
+extern crate serde_derive;
+#[macro_use]
+extern crate serde_json;
 #[cfg(not(target_env = "sgx"))]
-#[macro_use] extern crate sgx_tstd as std;
+#[macro_use]
+extern crate sgx_tstd as std;
 extern crate sgx_types;
-#[macro_use] extern crate utils;
+#[macro_use]
+extern crate utils;
 extern crate wasmi;
 
-mod wasm;
 mod multiply;
+mod wasm;
 
 mod result;
 
+use result::RunResult;
 use sgx_types::*;
 use utils::{copy_string_to_cstr_ptr, string_from_cstr_with_len};
-use result::RunResult;
 
 #[derive(Debug)]
 enum ShimError {
@@ -69,14 +72,15 @@ fn wasm_shim(
     result_capacity: usize,
     result_len: *mut usize,
 ) -> Result<(), ShimError> {
-
     let adapter_str = string_from_cstr_with_len(adapter_str_ptr, adapter_str_len)?;
     let adapter = serde_json::from_str(&adapter_str)?;
     let input_str = string_from_cstr_with_len(input_str_ptr, input_str_len)?;
-    let input : RunResult = serde_json::from_str(&input_str)?;
+    let input: RunResult = serde_json::from_str(&input_str)?;
 
     let result = match wasm::perform(&adapter, &input) {
-        Ok(value) => result::new(&input).with_data(&value).with_status("completed"),
+        Ok(value) => result::new(&input)
+            .with_data(&value)
+            .with_status("completed"),
         Err(err) => result::new(&input).with_error(&format!("{:?}", err)),
     };
 
@@ -121,10 +125,12 @@ fn multiply_shim(
     let adapter_str = string_from_cstr_with_len(adapter_str_ptr, adapter_str_len)?;
     let adapter = serde_json::from_str(&adapter_str)?;
     let input_str = string_from_cstr_with_len(input_str_ptr, input_str_len)?;
-    let input : RunResult = serde_json::from_str(&input_str)?;
+    let input: RunResult = serde_json::from_str(&input_str)?;
 
     let result = match multiply::perform(&adapter, &input) {
-        Ok(value) => result::new(&input).with_data(&value).with_status("completed"),
+        Ok(value) => result::new(&input)
+            .with_data(&value)
+            .with_status("completed"),
         Err(err) => result::new(&input).with_error(&format!("{:?}", err)),
     };
 

--- a/sgx/enclave/src/multiply.rs
+++ b/sgx/enclave/src/multiply.rs
@@ -1,0 +1,26 @@
+use std::string::ToString;
+use result::{self, RunResult, get_value};
+
+#[derive(Debug)]
+pub enum MultiplyError {
+    ParseFloatError(core::num::ParseFloatError),
+    ResultError(result::Error),
+}
+
+impl_from_error!(core::num::ParseFloatError, MultiplyError::ParseFloatError);
+impl_from_error!(result::Error, MultiplyError::ResultError);
+
+pub type MultiplyResult = Result<serde_json::Value, MultiplyError>;
+
+pub fn perform(adapter: &serde_json::Value, input: &RunResult) -> MultiplyResult {
+    let multiplier_str = get_value(&adapter, "times")?;
+    let multiplicand_str = get_value(&input.data, "value")?;
+
+    let multiplicand = multiplicand_str.parse::<f64>()?;
+    let multiplier = multiplier_str.parse::<f64>()?;
+
+    let result = multiplicand * multiplier;
+
+    Ok(json!({"value": result.to_string()}))
+}
+

--- a/sgx/enclave/src/multiply.rs
+++ b/sgx/enclave/src/multiply.rs
@@ -1,5 +1,5 @@
+use result::{self, get_value, RunResult};
 use std::string::ToString;
-use result::{self, RunResult, get_value};
 
 #[derive(Debug)]
 pub enum MultiplyError {
@@ -23,4 +23,3 @@ pub fn perform(adapter: &serde_json::Value, input: &RunResult) -> MultiplyResult
 
     Ok(json!({"value": result.to_string()}))
 }
-

--- a/sgx/enclave/src/result.rs
+++ b/sgx/enclave/src/result.rs
@@ -1,4 +1,4 @@
-use std::string::{ToString, String};
+use std::string::{String, ToString};
 
 #[derive(Debug)]
 pub enum Error {
@@ -14,7 +14,7 @@ pub fn get_value(object: &serde_json::Value, key: &str) -> Result<String, Error>
 }
 
 pub fn new(result: &RunResult) -> RunResult {
-    RunResult{
+    RunResult {
         job_run_id: result.job_run_id.clone(),
         amount: result.amount,
         ..Default::default()
@@ -33,7 +33,7 @@ pub struct RunResult {
 
 impl RunResult {
     pub fn with_data(&self, data: &serde_json::Value) -> RunResult {
-        RunResult{
+        RunResult {
             job_run_id: self.job_run_id.clone(),
             data: data.clone(),
             status: self.status.clone(),
@@ -43,7 +43,7 @@ impl RunResult {
     }
 
     pub fn with_error(&self, error: &str) -> RunResult {
-        RunResult{
+        RunResult {
             job_run_id: self.job_run_id.clone(),
             data: self.data.clone(),
             status: "errored".to_string(),
@@ -53,7 +53,7 @@ impl RunResult {
     }
 
     pub fn with_status(&self, status: &str) -> RunResult {
-        RunResult{
+        RunResult {
             job_run_id: self.job_run_id.clone(),
             data: self.data.clone(),
             status: status.to_string(),

--- a/sgx/enclave/src/result.rs
+++ b/sgx/enclave/src/result.rs
@@ -1,0 +1,64 @@
+use std::string::{ToString, String};
+
+#[derive(Debug)]
+pub enum Error {
+    InvalidEncoding,
+}
+
+pub fn get_value(object: &serde_json::Value, key: &str) -> Result<String, Error> {
+    match &object[key] {
+        serde_json::Value::String(v) => Ok(v.clone()),
+        serde_json::Value::Number(v) => Ok(format!("{}", v)),
+        _ => return Err(Error::InvalidEncoding),
+    }
+}
+
+pub fn new(result: &RunResult) -> RunResult {
+    RunResult{
+        job_run_id: result.job_run_id.clone(),
+        amount: result.amount,
+        ..Default::default()
+    }
+}
+
+#[derive(Serialize, Deserialize, Default, Debug, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct RunResult {
+    pub job_run_id: String,
+    pub data: serde_json::Value,
+    pub status: String,
+    pub error: Option<String>,
+    pub amount: Option<u64>,
+}
+
+impl RunResult {
+    pub fn with_data(&self, data: &serde_json::Value) -> RunResult {
+        RunResult{
+            job_run_id: self.job_run_id.clone(),
+            data: data.clone(),
+            status: self.status.clone(),
+            error: self.error.clone(),
+            amount: self.amount.clone(),
+        }
+    }
+
+    pub fn with_error(&self, error: &str) -> RunResult {
+        RunResult{
+            job_run_id: self.job_run_id.clone(),
+            data: self.data.clone(),
+            status: "errored".to_string(),
+            error: Some(error.to_string()),
+            amount: self.amount.clone(),
+        }
+    }
+
+    pub fn with_status(&self, status: &str) -> RunResult {
+        RunResult{
+            job_run_id: self.job_run_id.clone(),
+            data: self.data.clone(),
+            status: status.to_string(),
+            error: self.error.clone(),
+            amount: self.amount.clone(),
+        }
+    }
+}

--- a/sgx/enclave/src/wasm.rs
+++ b/sgx/enclave/src/wasm.rs
@@ -1,37 +1,74 @@
 use base64;
-use num::Num;
-use num::traits;
-use std::num;
+use std::{num, vec::Vec};
 use wasmi::{self, ImportsBuilder, ModuleInstance, NopExternals};
 
+use result::{self, RunResult, get_value};
+
 #[derive(Debug)]
-pub enum Error {
+pub enum WasmError {
+    ArgumentTypeNotImplementedYet,
     Base64DecoderError(base64::DecodeError),
     EmptyResultError,
     ParseIntError(num::ParseIntError),
-    ParseFloatError(traits::ParseFloatError),
+    ParseFloatError(num::ParseFloatError),
+    ResultError(result::Error),
     WasmError(wasmi::Error),
     WasmTrap(wasmi::Trap),
 }
 
-impl_from_error!(base64::DecodeError, Error::Base64DecoderError);
-impl_from_error!(num::ParseIntError, Error::ParseIntError);
-impl_from_error!(traits::ParseFloatError, Error::ParseFloatError);
-impl_from_error!(wasmi::Error, Error::WasmError);
-impl_from_error!(wasmi::Trap, Error::WasmTrap);
+impl_from_error!(base64::DecodeError, WasmError::Base64DecoderError);
+impl_from_error!(num::ParseIntError, WasmError::ParseIntError);
+impl_from_error!(num::ParseFloatError, WasmError::ParseFloatError);
+impl_from_error!(result::Error, WasmError::ResultError);
+impl_from_error!(wasmi::Error, WasmError::WasmError);
+impl_from_error!(wasmi::Trap, WasmError::WasmTrap);
 
-pub fn exec(encoded_program: &str, arguments: &str) -> Result<wasmi::RuntimeValue, Error> {
-    let data = base64::decode(encoded_program)?;
+pub type WasmResult = Result<serde_json::Value, WasmError>;
+
+pub fn perform(adapter: &serde_json::Value, input: &RunResult) -> WasmResult {
+    let encoded_program = get_value(&adapter, "wasm")?;
+    let data = base64::decode(&encoded_program)?;
     let module = wasmi::Module::from_buffer(data)?;
     let module_ref = ModuleInstance::new(&module, &ImportsBuilder::default())?;
     let instance = module_ref.run_start(&mut NopExternals)?;
 
-    // FIXME: assumes a single value argument that is a float
-    let value = <f64 as Num>::from_str_radix(arguments, 10)?;
+    let arguments = json_as_wasm_arguments(&input.data["value"])?;
+    match instance.invoke_export("perform", &arguments.as_slice(), &mut NopExternals)? {
+        Some(v) => Ok(json!({"value": wasm_as_json(&v)?})),
+        _ => Err(WasmError::EmptyResultError),
+    }
+}
 
-    let arguments = &[wasmi::RuntimeValue::I64(value as i64)];
-    match instance.invoke_export("perform", arguments, &mut NopExternals)? {
-        Some(v) => Ok(v),
-        _ => Err(Error::EmptyResultError),
+fn wasm_as_json(input: &wasmi::RuntimeValue) -> Result<serde_json::Value, WasmError> {
+    match input {
+        // RunResult in chainlink only supports string values
+        wasmi::RuntimeValue::I32(v) => Ok(serde_json::Value::String(format!("{}", v))),
+        _ => Err(WasmError::ArgumentTypeNotImplementedYet),
+    }
+}
+
+fn json_as_wasm_arguments(input: &serde_json::Value) -> Result<Vec<wasmi::RuntimeValue>, WasmError> {
+    match input {
+        serde_json::Value::Array(vec) => vec.into_iter().map(json_to_wasm).collect(),
+
+        // No value was specified in the input RunResult
+        serde_json::Value::Null => Ok(vec![]),
+
+        _ => Ok(vec![json_to_wasm(input)?]),
+    }
+}
+
+fn json_to_wasm(input: &serde_json::Value) -> Result<wasmi::RuntimeValue, WasmError> {
+    match input {
+        serde_json::Value::Number(num) => {
+            if input.is_f64()  {
+                Ok(wasmi::RuntimeValue::F64(num.as_f64().unwrap().into()))
+            } else if input.is_i64() {
+                Ok(wasmi::RuntimeValue::F64((num.as_i64().unwrap() as f64).into()))
+            } else {
+                Err(WasmError::ArgumentTypeNotImplementedYet)
+            }
+        },
+        _ => Err(WasmError::ArgumentTypeNotImplementedYet)
     }
 }

--- a/sgx/enclave/src/wasm.rs
+++ b/sgx/enclave/src/wasm.rs
@@ -2,7 +2,7 @@ use base64;
 use std::{num, vec::Vec};
 use wasmi::{self, ImportsBuilder, ModuleInstance, NopExternals};
 
-use result::{self, RunResult, get_value};
+use result::{self, get_value, RunResult};
 
 #[derive(Debug)]
 pub enum WasmError {
@@ -47,7 +47,9 @@ fn wasm_as_json(input: &wasmi::RuntimeValue) -> Result<serde_json::Value, WasmEr
     }
 }
 
-fn json_as_wasm_arguments(input: &serde_json::Value) -> Result<Vec<wasmi::RuntimeValue>, WasmError> {
+fn json_as_wasm_arguments(
+    input: &serde_json::Value,
+) -> Result<Vec<wasmi::RuntimeValue>, WasmError> {
     match input {
         serde_json::Value::Array(vec) => vec.into_iter().map(json_to_wasm).collect(),
 
@@ -61,14 +63,16 @@ fn json_as_wasm_arguments(input: &serde_json::Value) -> Result<Vec<wasmi::Runtim
 fn json_to_wasm(input: &serde_json::Value) -> Result<wasmi::RuntimeValue, WasmError> {
     match input {
         serde_json::Value::Number(num) => {
-            if input.is_f64()  {
+            if input.is_f64() {
                 Ok(wasmi::RuntimeValue::F64(num.as_f64().unwrap().into()))
             } else if input.is_i64() {
-                Ok(wasmi::RuntimeValue::F64((num.as_i64().unwrap() as f64).into()))
+                Ok(wasmi::RuntimeValue::F64(
+                    (num.as_i64().unwrap() as f64).into(),
+                ))
             } else {
                 Err(WasmError::ArgumentTypeNotImplementedYet)
             }
-        },
-        _ => Err(WasmError::ArgumentTypeNotImplementedYet)
+        }
+        _ => Err(WasmError::ArgumentTypeNotImplementedYet),
     }
 }

--- a/sgx/libadapters/build.rs
+++ b/sgx/libadapters/build.rs
@@ -39,7 +39,8 @@ fn main() {
 
     if env::var("SGX_SIMULATION")
         .unwrap_or_default()
-        .contains("yes") {
+        .contains("yes")
+    {
         println!("cargo:rustc-link-lib=dylib=sgx_urts_sim");
         println!("cargo:rustc-link-lib=dylib=crypto");
     } else {

--- a/sgx/libadapters/src/lib.rs
+++ b/sgx/libadapters/src/lib.rs
@@ -6,7 +6,8 @@ extern crate sgx_types;
 extern crate sgx_urts;
 extern crate utils;
 
-#[macro_use] extern crate lazy_static;
+#[macro_use]
+extern crate lazy_static;
 
 use std::panic;
 
@@ -14,8 +15,8 @@ use errno::{set_errno, Errno};
 use sgx_types::*;
 use sgx_urts::SgxEnclave;
 
-pub mod wasm;
 pub mod multiply;
+pub mod wasm;
 
 static ENCLAVE_FILE: &'static str = "enclave.signed.so";
 

--- a/sgx/libadapters/src/multiply.rs
+++ b/sgx/libadapters/src/multiply.rs
@@ -42,22 +42,19 @@ pub extern "C" fn multiply(
         )
     };
 
+    set_errno(Errno(0));
     match result {
-        sgx_status_t::SGX_SUCCESS => {}
+        sgx_status_t::SGX_SUCCESS => {},
         _ => {
-            println!("Call into Enclave multiplier failed: {}", result.as_str());
+            set_errno(Errno(result as i32));
+            return;
         }
     }
 
     match retval {
-        sgx_status_t::SGX_SUCCESS => {
-            println!("multiply call succeeded");
-            set_errno(Errno(0));
-        }
+        sgx_status_t::SGX_SUCCESS => {},
         _ => {
-            println!("multiply returned error: {}", retval.as_str());
             set_errno(Errno(result as i32));
-            return;
         }
     }
 }

--- a/sgx/libadapters/src/multiply.rs
+++ b/sgx/libadapters/src/multiply.rs
@@ -44,7 +44,7 @@ pub extern "C" fn multiply(
 
     set_errno(Errno(0));
     match result {
-        sgx_status_t::SGX_SUCCESS => {},
+        sgx_status_t::SGX_SUCCESS => {}
         _ => {
             set_errno(Errno(result as i32));
             return;
@@ -52,7 +52,7 @@ pub extern "C" fn multiply(
     }
 
     match retval {
-        sgx_status_t::SGX_SUCCESS => {},
+        sgx_status_t::SGX_SUCCESS => {}
         _ => {
             set_errno(Errno(result as i32));
         }

--- a/sgx/libadapters/src/wasm.rs
+++ b/sgx/libadapters/src/wasm.rs
@@ -9,10 +9,10 @@ extern "C" {
     fn sgx_wasm(
         eid: sgx_enclave_id_t,
         retval: *mut sgx_status_t,
-        wasmt_ptr: *const u8,
-        wasmt_len: usize,
-        arguments_ptr: *const u8,
-        arguments_len: usize,
+        adapter: *const u8,
+        adapter_len: usize,
+        input: *const u8,
+        input_len: usize,
         result_ptr: *mut u8,
         result_capacity: usize,
         result_len: *mut usize,
@@ -21,8 +21,8 @@ extern "C" {
 
 #[no_mangle]
 pub extern "C" fn wasm(
-    wasm: *const libc::c_char,
-    arguments: *const libc::c_char,
+    adapter: *const libc::c_char,
+    input: *const libc::c_char,
     result_ptr: *mut libc::c_char,
     result_capacity: usize,
     result_len: *mut usize,
@@ -32,37 +32,29 @@ pub extern "C" fn wasm(
         sgx_wasm(
             ENCLAVE.geteid(),
             &mut retval,
-            wasm as *const u8,
-            cstr_len(wasm),
-            arguments as *const u8,
-            cstr_len(arguments),
+            adapter as *const u8,
+            cstr_len(adapter),
+            input as *const u8,
+            cstr_len(input),
             result_ptr as *mut u8,
             result_capacity,
             result_len as *mut usize,
         )
     };
 
+    set_errno(Errno(0));
     match result {
-        sgx_status_t::SGX_SUCCESS => {
-            println!("Call into enclave succeded");
-            set_errno(Errno(0));
-        }
+        sgx_status_t::SGX_SUCCESS => {},
         _ => {
-            println!("Call into Enclave wasm failed: {}", result.as_str());
             set_errno(Errno(result as i32));
             return;
         }
     }
 
     match retval {
-        sgx_status_t::SGX_SUCCESS => {
-            println!("wasm call succeeded");
-            set_errno(Errno(0));
-        }
+        sgx_status_t::SGX_SUCCESS => {},
         _ => {
-            println!("wasm returned error: {}", retval.as_str());
             set_errno(Errno(result as i32));
-            return;
         }
     }
 }

--- a/sgx/libadapters/src/wasm.rs
+++ b/sgx/libadapters/src/wasm.rs
@@ -44,7 +44,7 @@ pub extern "C" fn wasm(
 
     set_errno(Errno(0));
     match result {
-        sgx_status_t::SGX_SUCCESS => {},
+        sgx_status_t::SGX_SUCCESS => {}
         _ => {
             set_errno(Errno(result as i32));
             return;
@@ -52,7 +52,7 @@ pub extern "C" fn wasm(
     }
 
     match retval {
-        sgx_status_t::SGX_SUCCESS => {},
+        sgx_status_t::SGX_SUCCESS => {}
         _ => {
             set_errno(Errno(result as i32));
         }

--- a/sgx/utils/src/lib.rs
+++ b/sgx/utils/src/lib.rs
@@ -10,9 +10,9 @@
 extern crate sgx_tstd as std;
 
 use std::ffi::{CStr, CString, NulError};
-use std::slice::{self, from_raw_parts_mut};
-use std::string::{FromUtf8Error, String};
 use std::ptr;
+use std::slice;
+use std::string::{FromUtf8Error, String};
 
 // cstr_len gets the length of a cstring pointer, not including the null terminator
 pub fn cstr_len(string: *const i8) -> usize {

--- a/sgx/utils/src/lib.rs
+++ b/sgx/utils/src/lib.rs
@@ -46,7 +46,6 @@ pub fn copy_string_to_cstr_ptr(
     output_capacity: usize,
     output_len: *mut usize,
 ) -> Result<(), OutputCStrError> {
-
     let input_cstring = CString::new(input)?;
     let input_slice = input_cstring.to_bytes();
     let input_size = input_slice.len();
@@ -76,8 +75,8 @@ macro_rules! impl_from_error {
 
 #[cfg(test)]
 mod tests {
+    use super::{copy_string_to_cstr_ptr, cstr_len, string_from_cstr_with_len};
     use std::ffi::CString;
-    use super::{string_from_cstr_with_len, copy_string_to_cstr_ptr, cstr_len};
 
     #[test]
     fn test_string_from_cstr_with_len() {
@@ -91,21 +90,34 @@ mod tests {
     #[test]
     fn test_copy_string_to_cstr_ptr() {
         let mut buffer: [u8; 64] = [0; 64];
-        let mut size : usize = 0;
+        let mut size: usize = 0;
 
-        let result = copy_string_to_cstr_ptr("hello world!".into(), &mut buffer[0], buffer.len(), &mut size);
+        let result = copy_string_to_cstr_ptr(
+            "hello world!".into(),
+            &mut buffer[0],
+            buffer.len(),
+            &mut size,
+        );
 
         assert!(result.is_ok());
         assert_eq!(size, 12);
-        assert_eq!(String::from_utf8_lossy(&buffer[..size]), "hello world!".to_string());
+        assert_eq!(
+            String::from_utf8_lossy(&buffer[..size]),
+            "hello world!".to_string()
+        );
     }
 
     #[test]
     fn test_copy_string_to_cstr_ptr_insufficient_capacity() {
         let mut buffer: [u8; 10] = [0; 10];
-        let mut size : usize = 0;
+        let mut size: usize = 0;
 
-        let result = copy_string_to_cstr_ptr("hello world!".into(), &mut buffer[0], buffer.len(), &mut size);
+        let result = copy_string_to_cstr_ptr(
+            "hello world!".into(),
+            &mut buffer[0],
+            buffer.len(),
+            &mut size,
+        );
         assert!(result.is_err());
     }
 


### PR DESCRIPTION
Adds tests that cover the SGX adapters via the go code, which should rinse through the layers of the adapter library, the enclave, the SGX edgr8r shims etc. As part of this made the wasm and multiple adapters more uniform.

One caveat: since the go runtime can execute multiple tests in different threads, the SGX enclave will tend to fail on multiple invocations with SGX_ERROR_OUT_OF_TCS. As a short term fix I've just forced the number of procs to 1 and turned off parallelism.

We should look into using thread local storage for the SGX context to resolve this. https://crates.io/crates/ref_thread_local could be an option.

[Finishes #159322272]