### PR TITLE
WIP: Add verbose logging of eth logs before routing to subscriptions to track down serialization issue.

### DIFF
--- a/store/eth_client.go
+++ b/store/eth_client.go
@@ -132,7 +132,7 @@ func (eth *EthClient) GetLogs(q ethereum.FilterQuery) ([]types.Log, error) {
 // SubscribeToLogs registers a subscription for push notifications of logs
 // from a given address.
 func (eth *EthClient) SubscribeToLogs(
-	channel chan<- types.Log,
+	channel chan<- map[string]interface{},
 	q ethereum.FilterQuery,
 ) (models.EthSubscription, error) {
 	// https://github.com/ethereum/go-ethereum/blob/762f3a48a00da02fe58063cb6ce8dc2d08821f15/ethclient/ethclient.go#L359


### PR DESCRIPTION
Log ethereum logs before unmarshaling and routing them to subscriptions