### PR TITLE
Fix the parameters to make gui's go run gui/main.go

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -47,7 +47,7 @@ bootstrap: dependencies install
 
 gui: yarndep ## Install GUI
 	CHAINLINK_VERSION="$(VERSION)@$(COMMIT_SHA)" yarn build
-	CGO_ENABLED=0 go run gui/main.go $(foreach $(shell pwd),"/services")
+	CGO_ENABLED=0 go run gui/main.go "${CURDIR}/services"
 
 docker: ## Build the docker image.
 	docker build \


### PR DESCRIPTION
This command invokes packr to place static assets in
go code, to ultimately end up in the binary.

Fixes https://github.com/smartcontractkit/chainlink/issues/687