### PR TITLE
 Account for undefined jobSpecInitiator

### DIFF
--- a/gui/src/utils/jobSpecInitiators.js
+++ b/gui/src/utils/jobSpecInitiators.js
@@ -1,5 +1,5 @@
 export const isWebInitiator = (initiators) => (
-  initiators.find(initiator => initiator.type === 'web')
+  (initiators || []).find(initiator => initiator.type === 'web')
 )
 
 export const formatInitiators = (initiators) => (


### PR DESCRIPTION
I was testing in the dev-server. Fixes a minor bug that is reproduced like:
1. Enter the Job Spec page: `http://localhost:3000/job_specs/JOBSPECID`
2. Click Show More
3. Click The `Job ID: JOBSPECID` hyperlink in breadcrumbs. ![image](https://user-images.githubusercontent.com/40662484/47743536-ab5b0500-dc55-11e8-8ee3-10e1c001a539.png)

4. Error
