### PR TITLE
Feature/sgx multiple thread support

### DIFF
--- a/adapters/multiply_test.go
+++ b/adapters/multiply_test.go
@@ -23,17 +23,17 @@ func TestMultiply_Perform(t *testing.T) {
 		{"integer", `{"times":100}`, `{"value":123}`, "12300", false, false},
 		{"float", `{"times":100}`, `{"value":1.23}`, "123", false, false},
 		{"object", `{"times":100}`, `{"value":{"foo":"bar"}}`, "", true, false},
-		{"zero_integer_string", `{"times":0}`, `{"value":"1.23"}`, "0", false, false},
-		{"negative_integer_string", `{"times":-5}`, `{"value":"1.23"}`, "-6.15", false, false},
+		{"zero integer string", `{"times":0}`, `{"value":"1.23"}`, "0", false, false},
+		{"negative integer string", `{"times":-5}`, `{"value":"1.23"}`, "-6.15", false, false},
 
-		{"string_string", `{"times":"100"}`, `{"value":"1.23"}`, "123", false, false},
-		{"string_integer", `{"times":"100"}`, `{"value":123}`, "12300", false, false},
-		{"string_float", `{"times":"100"}`, `{"value":1.23}`, "123", false, false},
-		{"string_object", `{"times":"100"}`, `{"value":{"foo":"bar"}}`, "", true, false},
-		{"array_string", `{"times":[1, 2, 3]}`, `{"value":"1.23"}`, "", false, true},
-		{"rubbish_string", `{"times":"123aaa123"}`, `{"value":"1.23"}`, "", false, true},
-		{"zero_string_string", `{"times":"0"}`, `{"value":"1.23"}`, "0", false, false},
-		{"negative_string_string", `{"times":"-5"}`, `{"value":"1.23"}`, "-6.15", false, false},
+		{"string string", `{"times":"100"}`, `{"value":"1.23"}`, "123", false, false},
+		{"string integer", `{"times":"100"}`, `{"value":123}`, "12300", false, false},
+		{"string float", `{"times":"100"}`, `{"value":1.23}`, "123", false, false},
+		{"string object", `{"times":"100"}`, `{"value":{"foo":"bar"}}`, "", true, false},
+		{"array string", `{"times":[1, 2, 3]}`, `{"value":"1.23"}`, "", false, true},
+		{"rubbish string", `{"times":"123aaa123"}`, `{"value":"1.23"}`, "", false, true},
+		{"zero string string", `{"times":"0"}`, `{"value":"1.23"}`, "0", false, false},
+		{"negative string string", `{"times":"-5"}`, `{"value":"1.23"}`, "-6.15", false, false},
 	}
 
 	for _, tt := range tests {

--- a/adapters/wasm_test.go
+++ b/adapters/wasm_test.go
@@ -61,7 +61,7 @@ func TestWasm_Perform(t *testing.T) {
 			false,
 		},
 		{
-			"invalid input ",
+			"invalid input",
 			fmt.Sprintf(`{"wasm":"%s"}`, CheckEthProgram),
 			`{"value": null}`,
 			"",

--- a/cmd/enclave_sgx.go
+++ b/cmd/enclave_sgx.go
@@ -2,23 +2,10 @@
 
 package cmd
 
-/*
-#cgo LDFLAGS: -L ../sgx/target/ -ladapters
-#include "../sgx/libadapters/adapters.h"
-*/
-import "C"
-import (
-	"fmt"
-
-	"github.com/smartcontractkit/chainlink/logger"
-)
+import "github.com/smartcontractkit/chainlink/logger"
 
 // InitEnclave initialized the SGX enclave for use by adapters
 func InitEnclave() error {
-	_, err := C.init_enclave()
-	if err != nil {
-		return fmt.Errorf("error initializing SGX enclave: %+v", err)
-	}
 	logger.Infow("SGX Enclave Loaded")
 	return nil
 }

--- a/internal/bin/sgx-env
+++ b/internal/bin/sgx-env
@@ -2,4 +2,9 @@
 
 workdir="/go/src/github.com/smartcontractkit/chainlink"
 image_tag=`cat Dockerfile-sgx | grep FROM | grep builder | awk '{print$2}'`
-docker run --volume "$PWD:$workdir" --workdir="$workdir" --env "SGX_ENABLED=yes" -ti $image_tag
+docker run \
+  --volume "$PWD:$workdir" \
+  --workdir="$workdir" \
+  --env "SGX_ENABLED=yes" \
+  --env "RUST_BACKTRACE=1" \
+  -ti $image_tag

--- a/internal/ci/sgx_test
+++ b/internal/ci/sgx_test
@@ -18,6 +18,5 @@ if [ -n "$USE_GDB" ] && [ "$ENVIRONMENT" == "debug" ]; then
   # XXX: The sgx-gdb wrapper script will actually load the symbol table for the enclave
   /opt/sgxsdk/bin/sgx-gdb -ex run --args ./adapters.test -test.parallel 1 -test.v
 else
-  # FIXME: Get a TCS exhausted error if go tries to run SGX performs from multiple threads/cpus
-  GOMAXPROCS=1 ./adapters.test -test.parallel 1 -test.v -test.run TestWasm_Perform
+  ./adapters.test -test.v $@
 fi

--- a/sgx/libadapters/Cargo.lock
+++ b/sgx/libadapters/Cargo.lock
@@ -3,7 +3,6 @@ name = "adapters"
 version = "0.1.0"
 dependencies = [
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
- "lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "sgx_trts 1.0.4",
  "sgx_types 1.0.4",
@@ -34,14 +33,6 @@ dependencies = [
 name = "gcc"
 version = "0.3.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
-name = "lazy_static"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-dependencies = [
- "version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)",
-]
 
 [[package]]
 name = "libc"
@@ -113,11 +104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "version_check"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-
-[[package]]
 name = "winapi"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,9 +126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
-"checksum lazy_static 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ca488b89a5657b0a2ecd45b95609b3e848cf1755da332a0da46e2b2b1cb371a7"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
-"checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"

--- a/sgx/libadapters/Cargo.toml
+++ b/sgx/libadapters/Cargo.toml
@@ -17,7 +17,6 @@ global_exit = []
 
 [dependencies]
 errno = "0.2.3"
-lazy_static = "1.0.0"
 libc = "*"
 utils = { path = "../utils" }
 

--- a/sgx/libadapters/adapters.h
+++ b/sgx/libadapters/adapters.h
@@ -1,3 +1,2 @@
-void init_enclave();
 void multiply(char *adapter, char *input, char *result, int result_capacity, int *result_len);
 void wasm(char *wasm, char *arguments, char *result, int result_capacity, int *result_len);

--- a/sgx/libadapters/src/lib.rs
+++ b/sgx/libadapters/src/lib.rs
@@ -1,49 +1,22 @@
 #![feature(libc)]
-extern crate libc;
 
 extern crate errno;
+extern crate libc;
 extern crate sgx_types;
 extern crate sgx_urts;
 extern crate utils;
 
-#[macro_use]
-extern crate lazy_static;
-
-use std::panic;
-
-use errno::{set_errno, Errno};
 use sgx_types::*;
 use sgx_urts::SgxEnclave;
+use std::cell::RefCell;
 
 pub mod multiply;
 pub mod wasm;
 
-static ENCLAVE_FILE: &'static str = "enclave.signed.so";
+static ENCLAVE_FILE: &str = "enclave.signed.so";
+thread_local!(static ENCLAVE: RefCell<Option<SgxEnclave>> = RefCell::new(None));
 
-// lazy_static allows us to setup a global value to persist the enclave in, so that we don't have
-// to pass the SgxEnclave into go territory and then back again.
-lazy_static! {
-    static ref ENCLAVE: SgxEnclave = {
-        perform_enclave_init().unwrap_or_else(|err| {
-            panic!("Failed to initialize the enclave: {}", err);
-        })
-    };
-}
-
-#[no_mangle]
-pub extern "C" fn init_enclave() {
-    // lazy_statics don't have a way to return an error, so setup a panic handler.
-    let result = panic::catch_unwind(|| {
-        lazy_static::initialize(&ENCLAVE);
-    });
-    set_errno(Errno(0));
-    if result.is_err() {
-        // Go uses the C _errno variable to get errors from C
-        set_errno(Errno(1));
-    }
-}
-
-fn perform_enclave_init() -> SgxResult<SgxEnclave> {
+fn enclave_init() -> SgxResult<SgxEnclave> {
     let mut launch_token: sgx_launch_token_t = [0; 1024];
     let mut launch_token_updated: i32 = 0;
     let debug = 1;
@@ -58,4 +31,19 @@ fn perform_enclave_init() -> SgxResult<SgxEnclave> {
         &mut launch_token_updated,
         &mut misc_attr,
     )
+}
+
+// get_enclave lazily initializes a thread local enclave context and returns its ID for use in
+// ECALL/OCALLs
+pub fn get_enclave() -> SgxResult<u64> {
+    ENCLAVE.with(|e| {
+        if let Some(ref e) = *e.borrow() {
+            return Ok(e.geteid());
+        }
+
+        let enclave = enclave_init()?;
+        let enclave_id = enclave.geteid();
+        *e.borrow_mut() = Some(enclave);
+        Ok(enclave_id)
+    })
 }

--- a/sgx/libadapters/src/multiply.rs
+++ b/sgx/libadapters/src/multiply.rs
@@ -3,7 +3,7 @@ use libc;
 use sgx_types::*;
 use utils::cstr_len;
 
-use ENCLAVE;
+use get_enclave;
 
 extern "C" {
     fn sgx_multiply(
@@ -27,10 +27,18 @@ pub extern "C" fn multiply(
     result_capacity: usize,
     result_len: *mut usize,
 ) {
+    let enclave_id = match get_enclave() {
+        Ok(e) => e,
+        Err(err) => {
+            set_errno(Errno(err as i32));
+            return;
+        }
+    };
+
     let mut retval = sgx_status_t::SGX_SUCCESS;
     let result = unsafe {
         sgx_multiply(
-            ENCLAVE.geteid(),
+            enclave_id,
             &mut retval,
             adapter as *const u8,
             cstr_len(adapter),

--- a/sgx/libadapters/src/wasm.rs
+++ b/sgx/libadapters/src/wasm.rs
@@ -3,7 +3,7 @@ use libc;
 use sgx_types::*;
 use utils::cstr_len;
 
-use ENCLAVE;
+use get_enclave;
 
 extern "C" {
     fn sgx_wasm(
@@ -27,10 +27,18 @@ pub extern "C" fn wasm(
     result_capacity: usize,
     result_len: *mut usize,
 ) {
+    let enclave_id = match get_enclave() {
+        Ok(e) => e,
+        Err(err) => {
+            set_errno(Errno(err as i32));
+            return;
+        }
+    };
+
     let mut retval = sgx_status_t::SGX_SUCCESS;
     let result = unsafe {
         sgx_wasm(
-            ENCLAVE.geteid(),
+            enclave_id,
             &mut retval,
             adapter as *const u8,
             cstr_len(adapter),


### PR DESCRIPTION
Put the enclave context into a thread local so that each Go thread gets its own context. Uses a thread local rather than a lazy_static and lazy initialises the context when doing the adapter perform. Nice side effect is that this takes out the panic on startup if SGX initialisation fails.

[Finishes #161512009]