### PR TITLE
Put a mutex around the SgxEnclave

### DIFF
--- a/sgx/libadapters/Cargo.lock
+++ b/sgx/libadapters/Cargo.lock
@@ -3,6 +3,7 @@ name = "adapters"
 version = "0.1.0"
 dependencies = [
  "errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)",
  "sgx_trts 1.0.4",
  "sgx_types 1.0.4",
@@ -32,6 +33,11 @@ dependencies = [
 [[package]]
 name = "gcc"
 version = "0.3.55"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lazy_static"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -126,6 +132,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum errno 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c2a071601ed01b988f896ab14b95e67335d1eeb50190932a1320f7fe3cadc84e"
 "checksum errno-dragonfly 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "14ca354e36190500e1e1fb267c647932382b54053c50b14970856c0b00a35067"
 "checksum gcc 0.3.55 (registry+https://github.com/rust-lang/crates.io-index)" = "8f5f3913fa0bfe7ee1fd8248b6b9f42a5af4b9d65ec2dd2c3c26132b950ecfc2"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.43 (registry+https://github.com/rust-lang/crates.io-index)" = "76e3a3ef172f1a0b9a9ff0dd1491ae5e6c948b94479a3021819ba7d860c8645d"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"

--- a/sgx/libadapters/Cargo.toml
+++ b/sgx/libadapters/Cargo.toml
@@ -17,6 +17,7 @@ global_exit = []
 
 [dependencies]
 errno = "0.2.3"
+lazy_static = "1.0.0"
 libc = "*"
 utils = { path = "../utils" }
 

--- a/sgx/libadapters/src/multiply.rs
+++ b/sgx/libadapters/src/multiply.rs
@@ -3,7 +3,7 @@ use libc;
 use sgx_types::*;
 use utils::cstr_len;
 
-use get_enclave;
+use use_enclave;
 
 extern "C" {
     fn sgx_multiply(
@@ -27,42 +27,36 @@ pub extern "C" fn multiply(
     result_capacity: usize,
     result_len: *mut usize,
 ) {
-    let enclave_id = match get_enclave() {
-        Ok(e) => e,
-        Err(err) => {
-            set_errno(Errno(err as i32));
-            return;
-        }
-    };
+    use_enclave(|enclave_id| {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+        let result = unsafe {
+            sgx_multiply(
+                enclave_id,
+                &mut retval,
+                adapter as *const u8,
+                cstr_len(adapter),
+                input as *const u8,
+                cstr_len(input),
+                result_ptr as *mut u8,
+                result_capacity,
+                result_len as *mut usize,
+            )
+        };
 
-    let mut retval = sgx_status_t::SGX_SUCCESS;
-    let result = unsafe {
-        sgx_multiply(
-            enclave_id,
-            &mut retval,
-            adapter as *const u8,
-            cstr_len(adapter),
-            input as *const u8,
-            cstr_len(input),
-            result_ptr as *mut u8,
-            result_capacity,
-            result_len as *mut usize,
-        )
-    };
-
-    set_errno(Errno(0));
-    match result {
-        sgx_status_t::SGX_SUCCESS => {}
-        _ => {
-            set_errno(Errno(result as i32));
-            return;
+        set_errno(Errno(0));
+        match result {
+            sgx_status_t::SGX_SUCCESS => {}
+            _ => {
+                set_errno(Errno(result as i32));
+                return;
+            }
         }
-    }
 
-    match retval {
-        sgx_status_t::SGX_SUCCESS => {}
-        _ => {
-            set_errno(Errno(result as i32));
+        match retval {
+            sgx_status_t::SGX_SUCCESS => {}
+            _ => {
+                set_errno(Errno(result as i32));
+            }
         }
-    }
+    });
 }


### PR DESCRIPTION
This returns to the lazy_static method for keeping a single SgxEnclave around but wraps it in a Mutex to synchronize calls to the enclave.

For now this means all calls to the enclave are effectively sequential.