### PR TITLE
Use the system allocater for libadapters to reduce mem pressure

### DIFF
--- a/sgx/libadapters/src/lib.rs
+++ b/sgx/libadapters/src/lib.rs
@@ -1,5 +1,8 @@
 #![feature(libc)]
 
+#![feature(alloc_system)]
+extern crate alloc_system;
+
 extern crate errno;
 extern crate libc;
 extern crate sgx_types;


### PR DESCRIPTION
This is just a small toggle on the SGX shim to see if it'll reduce memory pressure.
This option is on by default in Rust > 1.30 so can be removed if we upgrade the rust compiler.
This also allows easier analysis with valgrind.