### PR TITLE
Limit parallelization of sgx tests

### DIFF
--- a/internal/ci/sgx_test
+++ b/internal/ci/sgx_test
@@ -18,5 +18,5 @@ if [ -n "$USE_GDB" ] && [ "$ENVIRONMENT" == "debug" ]; then
   # XXX: The sgx-gdb wrapper script will actually load the symbol table for the enclave
   /opt/sgxsdk/bin/sgx-gdb -ex run --args ./adapters.test -test.parallel 1 -test.v
 else
-  ./adapters.test -test.v $@
+  ./adapters.test -test.parallel 2 -test.v $@
 fi


### PR DESCRIPTION
Been spending some time using valgrind to look at memory usage of chainlink, and nothing on the SGX side really pops out. 

My suspicion is that we're just using a lot of memory when testing because a lot of our tests fire up an entire application. OOM was also a problem for the race detector. SGX just likely adds enough memory pressure to hit the ceiling in our CircleCI containers. 

[Fixes #161970240]