### PR TITLE
Use clenv vars in gethnet so that they are the same

### DIFF
--- a/internal/bin/cldev
+++ b/internal/bin/cldev
@@ -7,6 +7,8 @@
 # 3. cd solidity && truffle migrate && cd ..
 # 4. ./internal/bin/cldev
 
+set -e
+
 GIT_ROOT=`git rev-parse --show-toplevel`
 PROJECT_ROOT=${TRAVIS_BUILD_DIR:-$GIT_ROOT}
 LDFLAGS=`$PROJECT_ROOT/internal/bin/ldflags`
@@ -14,8 +16,6 @@ LDFLAGS=`$PROJECT_ROOT/internal/bin/ldflags`
 pushd $PROJECT_ROOT >/dev/null
 source internal/bin/clenv
 export ROOT=$PROJECT_ROOT/internal/clroot
-
-set -e
 
 mainexec() {
   mkdir -p tmp

--- a/internal/bin/cldocker
+++ b/internal/bin/cldocker
@@ -25,7 +25,7 @@ DOCKER="docker run -ti \
     $REPO:$TAG"
 
 source $PROJECT_ROOT/internal/bin/clenv
-export ETH_URL="ws://docker.for.mac.localhost:$ETH_PORT"
+export ETH_URL="ws://docker.for.mac.localhost:$ETH_WS_PORT"
 if [ "$#" == 0 ]; then
   $DOCKER node -d -p /root/.chainlink/password.txt -a /root/.chainlink/apicredentials
 elif [ "$1" == "node" ]; then

--- a/internal/bin/clenv
+++ b/internal/bin/clenv
@@ -3,8 +3,9 @@
 # Environment variables for running chainlink in development mode
 
 export LOG_LEVEL=debug
-export ETH_PORT=18546
-export ETH_URL=ws://localhost:$ETH_PORT
+export ETH_WS_PORT=18546
+export ETH_RPC_PORT=18545
+export ETH_URL=ws://localhost:$ETH_WS_PORT
 export ETH_CHAIN_ID=17
 export TX_MIN_CONFIRMATIONS=2
 export MINIMUM_CONTRACT_PAYMENT=1000000000000

--- a/internal/bin/gethnet
+++ b/internal/bin/gethnet
@@ -2,47 +2,50 @@
 
 set -e
 
-cd "$(dirname "$0")"
+GIT_ROOT=`git rev-parse --show-toplevel`
+PROJECT_ROOT=${TRAVIS_BUILD_DIR:-$GIT_ROOT}
+
+pushd $PROJECT_ROOT >/dev/null
+source internal/bin/clenv
+popd >/dev/null
 
 ACCOUNT=0x9ca9d2d5e04012c9ed24c0e513c9bfaa4a2dd77f
 RPCAPI="eth,net,web3,admin,personal,debug"
+GETH_ARGS="--dev --mine
+  --datadir ../gethnet/datadir
+  --password ../clroot/password.txt
+  --networkid $ETH_CHAIN_ID
+  --unlock "$ACCOUNT"
+  --ipcdisable"
+
+pushd "$(dirname "$0")" >/dev/null
 
 # Enable different gethnet subcommands such as clean or console.
 # No subcommand runs the main mining geth.
 case "$1" in
   attach)
-    geth attach ws://localhost:18546
+    geth attach $ETH_URL
     ;;
   clean)
     rm -rf ../gethnet/datadir/geth
     ;;
   console)
-    geth console --dev --mine --networkid 17 --wsorigins "*" --rpc --ws \
-      --rpcapi "$RPCAPI" --rpccorsdomain "null" \
-      --rpcaddr 127.0.0.1 --rpcport 18545 --wsport 18546 --datadir ../gethnet/datadir \
-      --unlock "$ACCOUNT" \
-      --ipcdisable \
-      --password ../clroot/password.txt
+    geth console $GETH_ARGS
     ;;
   topoff)
-    geth console --dev \
-      --unlock "$ACCOUNT" \
-      --password ../clroot/password.txt \
-      --datadir ../gethnet/datadir \
-      --ipcdisable \
-      --exec 'loadScript("../gethnet/gethload.js"); confirm(topOffAccount());'
+    printf "Topping off account...\n"
+    geth console $GETH_ARGS --exec 'loadScript("../gethnet/gethload.js"); confirm(topOffAccount());'
     ;;
   *)
     ./print_account
     ./gethnet topoff
     sleep 1
-    geth --dev --mine --networkid 17 --wsorigins "*" --rpc --ws \
-      --rpcapi "$RPCAPI" --rpccorsdomain "null" \
-      --rpcaddr 127.0.0.1 --dev.period 2 --rpcport 18545 --wsport 18546 \
-      --datadir ../gethnet/datadir \
-      --unlock "$ACCOUNT" \
-      --ipcdisable \
-      --password ../clroot/password.txt \
-      --verbosity 1
+    printf "\n\nStarting node...\n"
+    geth $GETH_ARGS \
+      --ws --wsorigins "*" --wsport $ETH_WS_PORT \
+      --rpc --rpcapi "$RPCAPI" --rpccorsdomain "null" --rpcaddr 127.0.0.1 --rpcport $ETH_RPC_PORT \
+      --dev.period 2
     ;;
 esac
+
+popd >/dev/null


### PR DESCRIPTION
Also put common gethnet args into an env var to ensure consistency,
topoff was using slightly different vars which was concerning.