### PR TITLE
Use solidity function selectors

### DIFF
--- a/examples/echo_server/contracts/RunLog.sol
+++ b/examples/echo_server/contracts/RunLog.sol
@@ -12,7 +12,7 @@ contract RunLog is Chainlinked {
   }
 
   function request() public {
-    ChainlinkLib.Run memory run = newRun(jobId, this, "fulfill(bytes32,bytes32)");
+    ChainlinkLib.Run memory run = newRun(jobId, this, this.fulfill.selector);
     run.add("msg", "hello_chainlink");
     chainlinkRequest(run, LINK(1));
   }

--- a/examples/uptime_sla/contracts/UptimeSLA.sol
+++ b/examples/uptime_sla/contracts/UptimeSLA.sol
@@ -27,7 +27,7 @@ contract UptimeSLA is Chainlinked {
   }
 
   function updateUptime(string _when) public {
-    ChainlinkLib.Run memory run = newRun(jobId, this, "report(bytes32,uint256)");
+    ChainlinkLib.Run memory run = newRun(jobId, this, this.report.selector);
     run.add("url", "https://status.heroku.com/api/ui/availabilities");
     string[] memory path = new string[](4);
     path[0] = "data";

--- a/integration/contracts/RunLog.sol
+++ b/integration/contracts/RunLog.sol
@@ -10,7 +10,7 @@ contract RunLog is Chainlinked {
   }
 
   function request(bytes32 _jobId) public {
-    ChainlinkLib.Run memory run = newRun(_jobId, this, "fulfill(bytes32,bytes32)");
+    ChainlinkLib.Run memory run = newRun(_jobId, this, this.fulfill.selector);
     run.add("msg", "hello_chainlink");
     chainlinkRequest(run, LINK(1));
   }

--- a/solidity/contracts/ChainlinkLib.sol
+++ b/solidity/contracts/ChainlinkLib.sol
@@ -3,11 +3,6 @@ pragma solidity 0.4.24;
 import "solidity-cborutils/contracts/CBOR.sol";
 
 library ChainlinkLib {
-  bytes internal constant reqSig = "requestData(address,uint256,uint256,bytes32,address,bytes4,bytes32,bytes)";
-  bytes4 internal constant oracleRequestDataFid = bytes4(keccak256(reqSig));
-  bytes internal constant coordSig = "executeServiceAgreement(address,uint256,uint256,bytes32,address,bytes4,bytes32,bytes)";
-  bytes4 internal constant coordinatorRequestDataFid = bytes4(keccak256(coordSig));
-
   using CBOR for Buffer.buffer;
 
   struct Run {
@@ -30,38 +25,6 @@ library ChainlinkLib {
     self.callbackFunctionId = _callbackFunction;
     self.buf.startMap();
     return self;
-  }
-
-  function encodeForOracle(
-    Run memory self,
-    uint256 _clArgsVersion
-  ) internal pure returns (bytes memory) {
-    return abi.encodeWithSelector(
-      oracleRequestDataFid,
-      0, // overridden by onTokenTransfer
-      0, // overridden by onTokenTransfer
-      _clArgsVersion,
-      self.specId,
-      self.callbackAddress,
-      self.callbackFunctionId,
-      self.requestId,
-      self.buf.buf);
-  }
-
-  function encodeForCoordinator(
-    Run memory self,
-    uint256 _clArgsVersion
-  ) internal pure returns (bytes memory) {
-    return abi.encodeWithSelector(
-      coordinatorRequestDataFid, // need to change
-      0, // overridden by onTokenTransfer
-      0, // overridden by onTokenTransfer
-      _clArgsVersion,
-      self.specId,
-      self.callbackAddress,
-      self.callbackFunctionId,
-      self.requestId,
-      self.buf.buf);
   }
 
   function add(Run memory self, string _key, string _value)

--- a/solidity/contracts/ChainlinkLib.sol
+++ b/solidity/contracts/ChainlinkLib.sol
@@ -22,12 +22,12 @@ library ChainlinkLib {
     Run memory self,
     bytes32 _specId,
     address _callbackAddress,
-    string _callbackFunctionSignature
+    bytes4 _callbackFunction
   ) internal pure returns (ChainlinkLib.Run memory) {
     Buffer.init(self.buf, 128);
     self.specId = _specId;
     self.callbackAddress = _callbackAddress;
-    self.callbackFunctionId = bytes4(keccak256(bytes(_callbackFunctionSignature)));
+    self.callbackFunctionId = _callbackFunction;
     self.buf.startMap();
     return self;
   }

--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -31,7 +31,7 @@ contract Chainlinked {
   function newRun(
     bytes32 _specId,
     address _callbackAddress,
-    string _callbackFunctionSignature
+    bytes4 _callbackFunctionSignature
   ) internal pure returns (ChainlinkLib.Run memory) {
     ChainlinkLib.Run memory run;
     return run.initialize(_specId, _callbackAddress, _callbackFunctionSignature);
@@ -110,21 +110,21 @@ contract Chainlinked {
     return oracle;
   }
 
-  function encodeForOracle(ChainlinkLib.Run memory self)
-          internal
-          view
-          returns (bytes memory)
+  function encodeForOracle(ChainlinkLib.Run memory _run)
+    internal
+    view
+    returns (bytes memory)
   {
     return abi.encodeWithSelector(
       oracle.requestData.selector,
       0, // overridden by onTokenTransfer
       0, // overridden by onTokenTransfer
       clArgsVersion,
-      self.specId,
-      self.callbackAddress,
-      self.callbackFunctionId,
-      self.requestId,
-      self.buf.buf);
+      _run.specId,
+      _run.callbackAddress,
+      _run.callbackFunctionId,
+      _run.requestId,
+      _run.buf.buf);
   }
 
   function serviceRequest(ChainlinkLib.Run memory _run, uint256 _amount)

--- a/solidity/contracts/Coordinator.sol
+++ b/solidity/contracts/Coordinator.sol
@@ -2,9 +2,10 @@ pragma solidity 0.4.24;
 
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 import "./interfaces/LinkTokenInterface.sol";
+import "./interfaces/CoordinatorInterface.sol";
 
 // Coordinator handles oracle service aggreements between one or more oracles.
-contract Coordinator {
+contract Coordinator is CoordinatorInterface {
   using SafeMath for uint256;
 
   LinkTokenInterface internal LINK;
@@ -75,7 +76,7 @@ contract Coordinator {
     bytes32 _externalId,
     bytes _data
   )
-    public
+    external
     onlyLINK
     sufficientLINK(_amount, _sAId)
   {
@@ -103,8 +104,10 @@ contract Coordinator {
     uint256 _endAt,
     address[] _oracles,
     bytes32 _requestDigest
-                              )
-    public pure returns (bytes)
+  )
+    public
+    pure
+    returns (bytes)
   {
     return abi.encodePacked(_payment, _expiration, _endAt, _oracles, _requestDigest);
   }
@@ -130,7 +133,10 @@ contract Coordinator {
     bytes32[] _rs,
     bytes32[] _ss,
     bytes32 _requestDigest
-  ) public returns (bytes32 serviceAgreementID) {
+  )
+    public
+    returns (bytes32 serviceAgreementID)
+  {
     require(_oracles.length == _vs.length && _vs.length == _rs.length && _rs.length == _ss.length, "Must pass in as many signatures as oracles"); /* solium-disable-line max-len */
     require(_endAt > block.timestamp, "End of ServiceAgreement must be in the future");
 

--- a/solidity/contracts/examples/ConcreteChainlinked.sol
+++ b/solidity/contracts/examples/ConcreteChainlinked.sol
@@ -22,11 +22,12 @@ contract ConcreteChainlinked is Chainlinked {
   function publicNewRun(
     bytes32 _specId,
     address _address,
-    string _fulfillmentSignature
+    bytes _fulfillmentSignature
   )
     public
   {
-    ChainlinkLib.Run memory run = newRun(_specId, _address, _fulfillmentSignature);
+    ChainlinkLib.Run memory run = newRun(
+      _specId, _address, bytes4(keccak256(_fulfillmentSignature)));
     run.close();
     emit Run(
       run.specId,
@@ -39,12 +40,13 @@ contract ConcreteChainlinked is Chainlinked {
   function publicRequestRun(
     bytes32 _specId,
     address _address,
-    string _fulfillmentSignature,
+    bytes _fulfillmentSignature,
     uint256 _wei
   )
     public
   {
-    ChainlinkLib.Run memory run = newRun(_specId, _address, _fulfillmentSignature);
+    ChainlinkLib.Run memory run = newRun(
+      _specId, _address, bytes4(keccak256(_fulfillmentSignature)));
     chainlinkRequest(run, _wei);
   }
 

--- a/solidity/contracts/examples/Consumer.sol
+++ b/solidity/contracts/examples/Consumer.sol
@@ -12,7 +12,7 @@ contract Consumer is Chainlinked {
   );
 
   function requestEthereumPrice(string _currency) public {
-    ChainlinkLib.Run memory run = newRun(specId, this, "fulfill(bytes32,bytes32)");
+    ChainlinkLib.Run memory run = newRun(specId, this, this.fulfill.selector);
     run.add("url", "https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=USD,EUR,JPY");
     string[] memory path = new string[](1);
     path[0] = _currency;

--- a/solidity/contracts/examples/GetterSetter.sol
+++ b/solidity/contracts/examples/GetterSetter.sol
@@ -18,14 +18,19 @@ contract GetterSetter {
     emit SetBytes32(msg.sender, _value);
   }
 
-  function setBytes(bytes32 _requestID, bytes _value) public {
+  function requestedBytes32(bytes32 _requestId, bytes32 _value) public {
+    requestId = _requestId;
+    setBytes32(_value);
+  }
+
+  function setBytes(bytes _value) public {
     getBytes = _value;
     emit SetBytes(msg.sender, _value);
   }
 
-  function requestedBytes32(bytes32 _requestId, bytes32 _value) public {
+  function requestedBytes(bytes32 _requestId, bytes _value) public {
     requestId = _requestId;
-    setBytes32(_value);
+    setBytes(_value);
   }
 
   function setUint256(uint256 _value) public {

--- a/solidity/contracts/examples/MaliciousChainlinkLib.sol
+++ b/solidity/contracts/examples/MaliciousChainlinkLib.sol
@@ -3,9 +3,6 @@ pragma solidity 0.4.24;
 import "solidity-cborutils/contracts/CBOR.sol";
 
 library MaliciousChainlinkLib {
-  bytes4 internal constant oracleRequestDataFid = bytes4(keccak256("requestData(address,uint256,uint256,bytes32,address,bytes4,bytes32,bytes)"));
-  bytes4 internal constant oracleWithdrawFid = bytes4(keccak256("withdraw(address)"));
-
   using CBOR for Buffer.buffer;
 
   struct Run {
@@ -29,12 +26,12 @@ library MaliciousChainlinkLib {
     Run memory self,
     bytes32 _specId,
     address _callbackAddress,
-    string _callbackFunctionSignature
+    bytes4 _callbackFunction
   ) internal pure returns (MaliciousChainlinkLib.Run memory) {
     Buffer.init(self.buf, 128);
     self.specId = _specId;
     self.callbackAddress = _callbackAddress;
-    self.callbackFunctionId = bytes4(keccak256(bytes(_callbackFunctionSignature)));
+    self.callbackFunctionId = _callbackFunction;
     self.buf.startMap();
     return self;
   }
@@ -43,40 +40,14 @@ library MaliciousChainlinkLib {
     WithdrawRun memory self,
     bytes32 _specId,
     address _callbackAddress,
-    string _callbackFunctionSignature
+    bytes4 _callbackFunction
   ) internal pure returns (MaliciousChainlinkLib.WithdrawRun memory) {
     Buffer.init(self.buf, 128);
     self.specId = _specId;
     self.callbackAddress = _callbackAddress;
-    self.callbackFunctionId = bytes4(keccak256(bytes(_callbackFunctionSignature)));
+    self.callbackFunctionId = _callbackFunction;
     self.buf.startMap();
     return self;
-  }
-
-  function encodeForOracle(
-    Run memory self,
-    uint256 _clArgsVersion
-  ) internal view returns (bytes memory) {
-    return abi.encodeWithSelector(
-      oracleRequestDataFid,
-      address(this), // overridden by onTokenTransfer
-      100 ether,     // overridden by onTokenTransfer
-      _clArgsVersion,
-      self.specId,
-      self.callbackAddress,
-      self.callbackFunctionId,
-      self.requestId,
-      self.buf.buf);
-  }
-
-  function encodeWithdrawForOracle(WithdrawRun memory self, uint256)
-    internal pure returns (bytes memory)
-  {
-    return abi.encodeWithSelector(
-      oracleWithdrawFid,
-      self.callbackAddress,
-      self.amount,
-      self.buf.buf);
   }
 
   function add(Run memory self, string _key, string _value)

--- a/solidity/contracts/examples/MaliciousChainlinked.sol
+++ b/solidity/contracts/examples/MaliciousChainlinked.sol
@@ -23,19 +23,19 @@ contract MaliciousChainlinked {
   function newRun(
     bytes32 _specId,
     address _callbackAddress,
-    string _callbackFunctionSignature
+    bytes4 _callbackFunction
   ) internal pure returns (MaliciousChainlinkLib.Run memory) {
     MaliciousChainlinkLib.Run memory run;
-    return run.initialize(_specId, _callbackAddress, _callbackFunctionSignature);
+    return run.initialize(_specId, _callbackAddress, _callbackFunction);
   }
 
   function newWithdrawRun(
     bytes32 _specId,
     address _callbackAddress,
-    string _callbackFunctionSignature
+    bytes4 _callbackFunction
   ) internal pure returns (MaliciousChainlinkLib.WithdrawRun memory) {
     MaliciousChainlinkLib.WithdrawRun memory run;
-    return run.initializeWithdraw(_specId, _callbackAddress, _callbackFunctionSignature);
+    return run.initializeWithdraw(_specId, _callbackAddress, _callbackFunction);
   }
 
   function chainlinkRequest(MaliciousChainlinkLib.Run memory _run, uint256 _wei)
@@ -45,7 +45,7 @@ contract MaliciousChainlinked {
     requests += 1;
     _run.requestId = bytes32(requests);
     _run.close();
-    require(link.transferAndCall(oracle, _wei, _run.encodeForOracle(clArgsVersion)), "Unable to transferAndCall to oracle");
+    require(link.transferAndCall(oracle, _wei, encodeForOracle(_run)), "Unable to transferAndCall to oracle");
     emit ChainlinkRequested(_run.requestId);
     unfulfilledRequests[_run.requestId] = true;
     return _run.requestId;
@@ -58,7 +58,7 @@ contract MaliciousChainlinked {
     requests += 1;
     _run.requestId = bytes32(requests);
     _run.closeWithdraw();
-    require(link.transferAndCall(oracle, _wei, _run.encodeWithdrawForOracle(clArgsVersion)), "Unable to transferAndCall to oracle");
+    require(link.transferAndCall(oracle, _wei, encodeWithdrawForOracle(_run)), "Unable to transferAndCall to oracle");
     emit ChainlinkRequested(_run.requestId);
     unfulfilledRequests[_run.requestId] = true;
     return _run.requestId;
@@ -74,6 +74,31 @@ contract MaliciousChainlinked {
 
   function setLinkToken(address _link) internal {
     link = LinkTokenInterface(_link);
+  }
+
+  function encodeForOracle(MaliciousChainlinkLib.Run memory _run)
+    internal view returns (bytes memory)
+  {
+    return abi.encodeWithSelector(
+      oracle.requestData.selector,
+      address(this), // overridden by onTokenTransfer
+      100 ether,     // overridden by onTokenTransfer
+      clArgsVersion,
+      _run.specId,
+      _run.callbackAddress,
+      _run.callbackFunctionId,
+      _run.requestId,
+      _run.buf.buf);
+  }
+
+  function encodeWithdrawForOracle(MaliciousChainlinkLib.WithdrawRun memory _run)
+    internal view returns (bytes memory)
+  {
+    return abi.encodeWithSelector(
+      oracle.withdraw.selector,
+      _run.callbackAddress,
+      _run.amount,
+      _run.buf.buf);
   }
 
   modifier checkChainlinkFulfillment(bytes32 _requestId) {

--- a/solidity/contracts/examples/MaliciousConsumer.sol
+++ b/solidity/contracts/examples/MaliciousConsumer.sol
@@ -13,8 +13,8 @@ contract MaliciousConsumer is Chainlinked {
 
   function () public payable {}
 
-  function requestData(string _callbackFunc) public {
-    ChainlinkLib.Run memory run = newRun("specId", this, _callbackFunc);
+  function requestData(bytes _callbackFunc) public {
+    ChainlinkLib.Run memory run = newRun("specId", this, bytes4(keccak256(_callbackFunc)));
     chainlinkRequest(run, LINK(1));
   }
 

--- a/solidity/contracts/examples/MaliciousRequester.sol
+++ b/solidity/contracts/examples/MaliciousRequester.sol
@@ -16,7 +16,8 @@ contract MaliciousRequester is MaliciousChainlinked {
   function maliciousWithdraw()
     public
   {
-    MaliciousChainlinkLib.WithdrawRun memory run = newWithdrawRun("specId", this, "doesNothing(bytes32,bytes32)");
+    MaliciousChainlinkLib.WithdrawRun memory run = newWithdrawRun(
+      "specId", this, this.doesNothing.selector);
     run.amount = link.balanceOf(address(oracle));
     chainlinkWithdrawRequest(run, LINK(1));
   }
@@ -25,7 +26,8 @@ contract MaliciousRequester is MaliciousChainlinked {
     internal
     returns (bytes32 requestId)
   {
-    MaliciousChainlinkLib.Run memory run = newRun("specId", this, "doesNothing(bytes32,bytes32)");
+    MaliciousChainlinkLib.Run memory run = newRun(
+      "specId", this, this.doesNothing.selector);
     requestId = chainlinkRequest(run, LINK(1));
   }
 

--- a/solidity/contracts/examples/ServiceAgreementConsumer.sol
+++ b/solidity/contracts/examples/ServiceAgreementConsumer.sol
@@ -3,8 +3,6 @@ pragma solidity ^0.4.24;
 import "../Chainlinked.sol";
 
 contract ServiceAgreementConsumer is Chainlinked {
-  // NB: `Chainlinked` covers both the single-Oracle and Service-Agreement
-  // frameworks. Some of the terminology there is in terms of a single Oracle.
   bytes32 internal sAId;
   bytes32 public currentPrice;
 
@@ -20,7 +18,7 @@ contract ServiceAgreementConsumer is Chainlinked {
   }
 
   function requestEthereumPrice(string _currency) public {
-    ChainlinkLib.Run memory run = newRun(sAId, this, "fulfill(bytes32,bytes32)");
+    ChainlinkLib.Run memory run = newRun(sAId, this, this.fulfill.selector);
     run.add("url", "https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=USD,EUR,JPY");
     string[] memory path = new string[](1);
     path[0] = _currency;
@@ -32,7 +30,6 @@ contract ServiceAgreementConsumer is Chainlinked {
     public
     checkChainlinkFulfillment(_requestId)
   {
-    // TODO: Example which deals with multiple responses. (Here, or in Coordinator?)
     emit RequestFulfilled(_requestId, _price);
     currentPrice = _price;
   }

--- a/solidity/contracts/interfaces/CoordinatorInterface.sol
+++ b/solidity/contracts/interfaces/CoordinatorInterface.sol
@@ -1,0 +1,14 @@
+pragma solidity 0.4.24;
+
+interface CoordinatorInterface {
+  function executeServiceAgreement(
+    address sender,
+    uint256 amount,
+    uint256 version,
+    bytes32 sAId,
+    address callbackAddress,
+    bytes4 callbackFunctionId,
+    bytes32 externalId,
+    bytes data
+  ) external;
+}

--- a/solidity/contracts/interfaces/OracleInterface.sol
+++ b/solidity/contracts/interfaces/OracleInterface.sol
@@ -13,4 +13,5 @@ interface OracleInterface {
     bytes32 externalId,
     bytes data
   ) external;
+  function withdraw(address recipient, uint256 amount) external;
 }

--- a/solidity/test/ServiceAgreementConsumer_test.js
+++ b/solidity/test/ServiceAgreementConsumer_test.js
@@ -32,7 +32,7 @@ contract('ServiceAgreementConsumer', () => {
     assert.isBelow(rec.gasUsed, 1700000)
   })
 
-  describe('#requestEthereumPrice works', () => {
+  describe('#requestEthereumPrice', () => {
     context('without LINK', () => {
       it('reverts', async () => {
         await assertActionThrows(async () => {
@@ -90,14 +90,6 @@ contract('ServiceAgreementConsumer', () => {
       assert.equal(web3.toUtf8(currentPrice), response)
     })
 
-    it('logs the data given to it by the oracle', async () => {
-      let tx = await coord.fulfillData(internalId, response, { from: oracleNode })
-      assert.equal(2, tx.receipt.logs.length)
-      let log = tx.receipt.logs[0]
-
-      assert.equal(web3.toUtf8(log.topics[2]), response)
-    })
-
     context('when the consumer does not recognize the request ID', () => {
       let otherId
 
@@ -125,22 +117,6 @@ contract('ServiceAgreementConsumer', () => {
         let received = await cc.currentPrice.call()
         assert.equal(web3.toUtf8(received), '')
       })
-    })
-  })
-
-  describe('#withdrawLink', () => {
-    beforeEach(async () => {
-      await link.transfer(cc.address, web3.toWei('1', 'ether'))
-      const balance = await link.balanceOf(cc.address)
-      assert.equal(balance.toString(), web3.toWei('1', 'ether'))
-    })
-
-    it('transfers LINK out of the contract', async () => {
-      await cc.withdrawLink({ from: consumer })
-      const ccBalance = await link.balanceOf(cc.address)
-      const consumerBalance = await link.balanceOf(consumer)
-      assert.equal(ccBalance.toString(), '0')
-      assert.equal(consumerBalance.toString(), web3.toWei('1', 'ether'))
     })
   })
 })


### PR DESCRIPTION
Instead of hashing strings, use Solidity's `selector` primitive. Since this is only available on public functions, availability/presence is checked at compile time.