### PR TITLE
Bulk deletion of runs

### DIFF
--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -389,7 +389,8 @@ type EmptyApplication struct{}
 func (*EmptyApplication) Start() error                              { return nil }
 func (*EmptyApplication) Stop() error                               { return nil }
 func (*EmptyApplication) GetStore() *store.Store                    { return nil }
-func (*EmptyApplication) GetReaper() services.Reaper                { return nil }
+func (*EmptyApplication) WakeSessionReaper()                        {}
+func (*EmptyApplication) WakeBulkRunDeleter()                       {}
 func (*EmptyApplication) AddJob(job models.JobSpec) error           { return nil }
 func (*EmptyApplication) AddAdapter(bt *models.BridgeType) error    { return nil }
 func (*EmptyApplication) RemoveAdapter(bt *models.BridgeType) error { return nil }

--- a/services/bulk_run_deleter.go
+++ b/services/bulk_run_deleter.go
@@ -1,0 +1,75 @@
+package services
+
+import (
+	"fmt"
+
+	"github.com/asdine/storm/q"
+	"github.com/smartcontractkit/chainlink/logger"
+	"github.com/smartcontractkit/chainlink/store"
+	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/orm"
+)
+
+// NewBulkRunDeleter creates a task runner that is responsible for executing bulk tasks.
+func NewBulkRunDeleter(store *store.Store) SleeperTask {
+	return NewSleeperTask(&bulkRunDeleter{
+		store: store,
+	})
+}
+
+type bulkRunDeleter struct {
+	store *store.Store
+}
+
+func (btr *bulkRunDeleter) Work() {
+	query := btr.store.Select(q.Eq("Status", models.BulkTaskStatusInProgress)).OrderBy("CreatedAt")
+	err := query.Each(&models.BulkDeleteRunTask{}, func(r interface{}) error {
+		task := r.(*models.BulkDeleteRunTask)
+		logger.Infow("Processing bulk run delete task",
+			"task_id", task.ID,
+			"statuses", task.Query.Status,
+			"updated_before", task.Query.UpdatedBefore,
+		)
+
+		err := RunPendingTask(btr.store.ORM, task)
+		if err != nil {
+			logger.Errorw("Error deleting runs for bulk task", "task_id", task.ID, "error", err)
+		}
+		return err
+	})
+	if err != nil {
+		logger.Errorw("Error querying bulk tasks", "error", err)
+	}
+}
+
+// RunPendingTask executes bulk run tasks
+func RunPendingTask(orm *orm.ORM, task *models.BulkDeleteRunTask) error {
+	err := DeleteJobRuns(orm, &task.Query)
+	if err != nil {
+		task.Error = err
+		task.Status = models.BulkTaskStatusErrored
+	} else {
+		task.Status = models.BulkTaskStatusCompleted
+	}
+	return orm.Save(task)
+}
+
+// DeleteJobRuns removes runs that match a query
+func DeleteJobRuns(orm *orm.ORM, bulkQuery *models.BulkDeleteRunRequest) error {
+	query := orm.Select(
+		q.And(
+			q.In("Status", bulkQuery.Status),
+			q.Lt("UpdatedAt", bulkQuery.UpdatedBefore),
+		),
+	).OrderBy("CompletedAt")
+
+	return query.Each(&models.JobRun{}, func(r interface{}) error {
+		run := r.(*models.JobRun)
+		logger.Debugw("Deleting run", "run_id", run.ID, "status", run.Status, "updated_at", run.UpdatedAt)
+		err := orm.DeleteStruct(run)
+		if err != nil {
+			return fmt.Errorf("error deleting run %s: %+v", run.ID, err)
+		}
+		return nil
+	})
+}

--- a/services/bulk_run_deleter_test.go
+++ b/services/bulk_run_deleter_test.go
@@ -1,0 +1,78 @@
+package services_test
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink/internal/cltest"
+	"github.com/smartcontractkit/chainlink/services"
+	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDeleteJobRuns(t *testing.T) {
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+
+	job, initiator := cltest.NewJobWithWebInitiator()
+
+	// matches updated before but none of the statuses
+	oldIncompleteRun := job.NewRun(initiator)
+	oldIncompleteRun.Status = models.RunStatusInProgress
+	oldIncompleteRun.UpdatedAt = cltest.ParseISO8601("2018-01-01T00:00:00Z")
+	err := store.Save(&oldIncompleteRun)
+	assert.NoError(t, err)
+
+	// matches one of the statuses and the updated before
+	oldCompletedRun := job.NewRun(initiator)
+	oldCompletedRun.Status = models.RunStatusCompleted
+	oldCompletedRun.UpdatedAt = cltest.ParseISO8601("2018-01-01T00:00:00Z")
+	err = store.Save(&oldCompletedRun)
+	assert.NoError(t, err)
+
+	// matches one of the statuses but not the updated before
+	newCompletedRun := job.NewRun(initiator)
+	newCompletedRun.Status = models.RunStatusCompleted
+	newCompletedRun.UpdatedAt = cltest.ParseISO8601("2018-01-30T00:00:00Z")
+	err = store.ORM.Save(&newCompletedRun)
+	assert.NoError(t, err)
+
+	// matches nothing
+	newIncompleteRun := job.NewRun(initiator)
+	newIncompleteRun.Status = models.RunStatusCompleted
+	newIncompleteRun.UpdatedAt = cltest.ParseISO8601("2018-01-30T00:00:00Z")
+	err = store.ORM.Save(&newIncompleteRun)
+	assert.NoError(t, err)
+
+	err = services.DeleteJobRuns(store.ORM, &models.BulkDeleteRunRequest{
+		Status:        []models.RunStatus{models.RunStatusCompleted},
+		UpdatedBefore: cltest.ParseISO8601("2018-01-15T00:00:00Z"),
+	})
+
+	runCount, err := store.Count(&models.JobRun{})
+	assert.NoError(t, err)
+	assert.Equal(t, 3, runCount)
+}
+
+func TestRunPendingTask(t *testing.T) {
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+
+	task, err := models.NewBulkDeleteRunTask(models.BulkDeleteRunRequest{})
+	assert.NoError(t, err)
+	err = services.RunPendingTask(store.ORM, task)
+	assert.NoError(t, err)
+	assert.Equal(t, string(models.BulkTaskStatusCompleted), string(task.Status))
+}
+
+func TestRunPendingTask_Error(t *testing.T) {
+	store, cleanup := cltest.NewStore()
+	// Close store immediately to trigger error
+	cleanup()
+
+	task, err := models.NewBulkDeleteRunTask(models.BulkDeleteRunRequest{})
+	assert.NoError(t, err)
+	err = services.RunPendingTask(store.ORM, task)
+	assert.Error(t, err)
+	assert.Equal(t, string(models.BulkTaskStatusErrored), string(task.Status))
+	assert.NotNil(t, task.Error)
+}

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -151,7 +151,7 @@ func (rm *jobRunner) workerLoop(runID string, workerChannel chan struct{}) {
 			}
 
 			if run.Status.Finished() {
-				logger.Debugw("All tasks complete for run", []interface{}{"run", run.ID}...)
+				logger.Debugw("All tasks complete for run", "run", run.ID)
 				return
 			}
 

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -88,9 +88,9 @@ func (js *jobSubscriber) OnNewHead(head *models.BlockHeader) {
 	}
 
 	ibn := head.ToIndexableBlockNumber().Number
-	logger.Debugw("Received new head", []interface{}{
+	logger.Debugw("Received new head",
 		"current_height", ibn,
-		"pending_run_count", len(pendingRuns)}...,
+		"pending_run_count", len(pendingRuns),
 	)
 	for _, jr := range pendingRuns {
 		_, err := ResumeConfirmingTask(&jr, js.store, &ibn)

--- a/services/reaper.go
+++ b/services/reaper.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"sync"
 	"time"
 
 	"github.com/asdine/storm"
@@ -10,67 +9,20 @@ import (
 	"github.com/smartcontractkit/chainlink/store/models"
 )
 
-// Reaper interface defines the methods used to reap stale objects such as sessions.
-type Reaper interface {
-	Start() error
-	Stop() error
-	ReapSessions()
-}
-
 type storeReaper struct {
-	store   *store.Store
-	config  store.Config
-	cond    *sync.Cond
-	started bool
+	store  *store.Store
+	config store.Config
 }
 
 // NewStoreReaper creates a reaper that cleans stale objects from the store.
-func NewStoreReaper(store *store.Store) Reaper {
-	var m sync.Mutex
-	return &storeReaper{
+func NewStoreReaper(store *store.Store) SleeperTask {
+	return NewSleeperTask(&storeReaper{
 		store:  store,
 		config: store.Config,
-		cond:   sync.NewCond(&m),
-	}
+	})
 }
 
-// Start starts the reaper instance so that it can listen for cleanup asynchronously.
-func (sr *storeReaper) Start() error {
-	sr.cond.L.Lock()
-	sr.started = true
-	sr.cond.L.Unlock()
-	go sr.listenForReaps()
-	return nil
-}
-
-// Stop stops the reaper from listening to clean up messages asynchronously.
-func (sr *storeReaper) Stop() error {
-	sr.cond.L.Lock()
-	sr.started = false
-	sr.cond.Signal()
-	sr.cond.L.Unlock()
-	return nil
-}
-
-// ReapSessions signals the reaper to clean up sessions asynchronously.
-func (sr *storeReaper) ReapSessions() {
-	sr.cond.Signal()
-}
-
-func (sr *storeReaper) listenForReaps() {
-	for {
-		sr.cond.L.Lock()
-		sr.cond.Wait()
-		if sr.started == false {
-			sr.cond.L.Unlock()
-			return
-		}
-		sr.deleteStaleSessions()
-		sr.cond.L.Unlock()
-	}
-}
-
-func (sr *storeReaper) deleteStaleSessions() {
+func (sr *storeReaper) Work() {
 	var sessions []models.Session
 	offset := time.Now().Add(-sr.config.ReaperExpiration.Duration).Add(-sr.config.SessionTimeout.Duration)
 	stale := models.Time{offset}

--- a/services/reaper_test.go
+++ b/services/reaper_test.go
@@ -41,7 +41,7 @@ func TestStoreReaper_ReapSessions(t *testing.T) {
 			session.LastUsed = models.Time{test.lastUsed}
 			require.NoError(t, store.Save(&session))
 
-			r.ReapSessions()
+			r.WakeUp()
 
 			if test.wantReap {
 				gomega.NewGomegaWithT(t).Eventually(func() []models.Session {

--- a/services/runs.go
+++ b/services/runs.go
@@ -22,11 +22,11 @@ func ExecuteJob(
 	creationHeight *hexutil.Big,
 	store *store.Store) (*models.JobRun, error) {
 
-	logger.Debugw(fmt.Sprintf("New run triggered by %s", initiator.Type), []interface{}{
+	logger.Debugw(fmt.Sprintf("New run triggered by %s", initiator.Type),
 		"job", job.ID,
 		"input_status", input.Status,
 		"creation_height", creationHeight.ToInt(),
-	}...)
+	)
 
 	run, err := NewRun(job, initiator, input, creationHeight, store)
 	if err != nil {
@@ -193,7 +193,7 @@ func ResumePendingTask(
 	if run.Overrides, err = run.Overrides.Merge(input); err != nil {
 		run.TaskRuns[currentTaskRunIndex] = currentTaskRun.ApplyResult(input.WithError(err))
 		*run = run.ApplyResult(input.WithError(err))
-		return run, store.Save(run)
+		return run, store.SaveJobRun(run)
 	}
 
 	currentTaskRun = currentTaskRun.ApplyResult(input)
@@ -232,7 +232,7 @@ func QueueSleepingTask(
 	if err != nil {
 		run.TaskRuns[currentTaskRunIndex] = currentTaskRun.ApplyResult(run.Result.WithError(err))
 		*run = run.ApplyResult(run.Result.WithError(err))
-		return run, store.Save(run)
+		return run, store.SaveJobRun(run)
 	}
 
 	if sleepAdapter, ok := adapter.BaseAdapter.(*adapters.Sleep); ok {
@@ -298,7 +298,7 @@ func meetsMinimumConfirmations(
 }
 
 func saveAndTrigger(run *models.JobRun, store *store.Store) error {
-	if err := store.Save(run); err != nil {
+	if err := store.SaveJobRun(run); err != nil {
 		return err
 	}
 

--- a/services/sleeper_task.go
+++ b/services/sleeper_task.go
@@ -1,0 +1,73 @@
+package services
+
+import (
+	"sync"
+
+	"github.com/smartcontractkit/chainlink/store"
+)
+
+// SleeperTask represents a task that waits in the background to process some work.
+type SleeperTask interface {
+	Start() error
+	Stop() error
+	WakeUp()
+}
+
+// Worker is a simple interface that represents some work to do repeatedly
+type Worker interface {
+	Work()
+}
+
+type sleeperTask struct {
+	worker  Worker
+	store   *store.Store
+	cond    *sync.Cond
+	started bool
+}
+
+// NewSleeperTask takes a worker and retruns a SleeperTask
+func NewSleeperTask(worker Worker) SleeperTask {
+	var m sync.Mutex
+	return &sleeperTask{
+		worker: worker,
+		cond:   sync.NewCond(&m),
+	}
+}
+
+// Start begins the SleeperTask
+func (s *sleeperTask) Start() error {
+	s.cond.L.Lock()
+	s.started = true
+	s.cond.L.Unlock()
+	go s.workerLoop()
+	return nil
+}
+
+// Stop stops the SleeperTask
+func (s *sleeperTask) Stop() error {
+	s.cond.L.Lock()
+	s.started = false
+	s.cond.Signal()
+	s.cond.L.Unlock()
+	return nil
+}
+
+// WakeUp wakes up the sleeper task, asking it to execute its Worker.
+func (s *sleeperTask) WakeUp() {
+	go s.cond.Signal()
+}
+
+// workerLoop is the goroutine behind the sleeper task that waits for a signal
+// before kicking off the worker
+func (s *sleeperTask) workerLoop() {
+	for {
+		s.cond.L.Lock()
+		s.cond.Wait()
+		if s.started == false {
+			s.cond.L.Unlock()
+			return
+		}
+		s.worker.Work()
+		s.cond.L.Unlock()
+	}
+}

--- a/services/sleeper_task_test.go
+++ b/services/sleeper_task_test.go
@@ -1,0 +1,39 @@
+package services
+
+import (
+	"sync/atomic"
+	"testing"
+
+	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/assert"
+)
+
+type TestWorker struct {
+	counter uint64
+}
+
+func (t *TestWorker) Work() {
+	atomic.AddUint64(&t.counter, 1)
+}
+
+func (t *TestWorker) Counter() uint64 {
+	return atomic.LoadUint64(&t.counter)
+}
+
+func TestSleeperTask(t *testing.T) {
+	worker := TestWorker{}
+	sleeper := NewSleeperTask(&worker)
+
+	assert.Equal(t, uint64(0), worker.Counter())
+	sleeper.Start()
+
+	assert.Equal(t, uint64(0), worker.Counter())
+
+	sleeper.WakeUp()
+	gomega.NewGomegaWithT(t).Eventually(func() bool {
+		return worker.Counter() == 1
+	}).Should(gomega.Equal(true))
+
+	sleeper.Stop()
+	assert.Equal(t, uint64(1), worker.Counter())
+}

--- a/store/models/bulk.go
+++ b/store/models/bulk.go
@@ -1,0 +1,64 @@
+package models
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/smartcontractkit/chainlink/utils"
+)
+
+// BulkTaskStatus indicates what a bulk task is doing.
+type BulkTaskStatus string
+
+const (
+	// BulkTaskStatusInProgress is the default state of any run status.
+	BulkTaskStatusInProgress = BulkTaskStatus("")
+	// BulkTaskStatusErrored means a bulk task stopped because it encountered an error.
+	BulkTaskStatusErrored = BulkTaskStatus("errored")
+	// BulkTaskStatusCompleted means a bulk task finished.
+	BulkTaskStatusCompleted = BulkTaskStatus("completed")
+)
+
+// BulkDeleteRunRequest describes the query for deletion of runs
+type BulkDeleteRunRequest struct {
+	Status        []RunStatus `json:"status"`
+	UpdatedBefore time.Time   `json:"updatedBefore"`
+}
+
+// BulkDeleteRunTask represents a task that is working to delete runs with a query
+type BulkDeleteRunTask struct {
+	ID     string               `json:"id" storm:"id,unique"`
+	Query  BulkDeleteRunRequest `json:"query"`
+	Status BulkTaskStatus       `json:"status"`
+	Error  error                `json:"error"`
+}
+
+// NewBulkDeleteRunTask returns a task from a request to make a task
+func NewBulkDeleteRunTask(request BulkDeleteRunRequest) (*BulkDeleteRunTask, error) {
+	for _, status := range request.Status {
+		if status != RunStatusCompleted && status != RunStatusErrored {
+			return nil, fmt.Errorf("cannot delete Runs with status %s", status)
+		}
+	}
+
+	return &BulkDeleteRunTask{
+		ID:    utils.NewBytes32ID(),
+		Query: request,
+	}, nil
+}
+
+// GetID returns the ID of this structure for jsonapi serialization.
+func (t BulkDeleteRunTask) GetID() string {
+	return t.ID
+}
+
+// GetName returns the pluralized "type" of this structure for jsonapi serialization.
+func (t BulkDeleteRunTask) GetName() string {
+	return "bulk_delete_runs_tasks"
+}
+
+// SetID is used to set the ID of this structure when deserializing from jsonapi documents.
+func (t *BulkDeleteRunTask) SetID(value string) error {
+	t.ID = value
+	return nil
+}

--- a/store/models/bulk_test.go
+++ b/store/models/bulk_test.go
@@ -1,0 +1,22 @@
+package models
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewBulkDeleteRunTask(t *testing.T) {
+	task, err := NewBulkDeleteRunTask(BulkDeleteRunRequest{})
+	assert.NoError(t, err)
+	assert.NotEmpty(t, task.ID)
+
+	task, err = NewBulkDeleteRunTask(BulkDeleteRunRequest{Status: []RunStatus{RunStatusCompleted}})
+	assert.NoError(t, err)
+
+	task, err = NewBulkDeleteRunTask(BulkDeleteRunRequest{Status: []RunStatus{""}})
+	assert.Error(t, err)
+
+	task, err = NewBulkDeleteRunTask(BulkDeleteRunRequest{Status: []RunStatus{RunStatusInProgress}})
+	assert.Error(t, err)
+}

--- a/store/models/job_spec.go
+++ b/store/models/job_spec.go
@@ -80,10 +80,12 @@ func (j JobSpec) NewRun(i Initiator) JobRun {
 		}
 	}
 
+	now := time.Now()
 	return JobRun{
 		ID:        jrid,
 		JobID:     j.ID,
-		CreatedAt: time.Now(),
+		CreatedAt: now,
+		UpdatedAt: now,
 		TaskRuns:  taskRuns,
 		Initiator: i,
 		Status:    RunStatusUnstarted,

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -21,6 +21,7 @@ type JobRun struct {
 	TaskRuns       []TaskRun    `json:"taskRuns" storm:"inline"`
 	CreatedAt      time.Time    `json:"createdAt" storm:"index"`
 	CompletedAt    null.Time    `json:"completedAt"`
+	UpdatedAt      time.Time    `json:"updatedAt"`
 	Initiator      Initiator    `json:"initiator"`
 	CreationHeight *hexutil.Big `json:"creationHeight"`
 	ObservedHeight *hexutil.Big `json:"observedHeight"`

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -106,6 +106,12 @@ func (orm *ORM) FindJobRun(id string) (models.JobRun, error) {
 	return jr, err
 }
 
+// SaveJobRun updates UpdatedAt for a JobRun and saves it
+func (orm *ORM) SaveJobRun(run *models.JobRun) error {
+	run.UpdatedAt = time.Now()
+	return orm.Save(run)
+}
+
 // FindServiceAgreement looks up a ServiceAgreement by its ID.
 func (orm *ORM) FindServiceAgreement(id string) (models.ServiceAgreement, error) {
 	var sa models.ServiceAgreement

--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -77,7 +77,7 @@ func (txm *EthTxManager) createTxWithNonceReload(to common.Address, data []byte,
 			return err
 		}
 
-		logger.Infow(fmt.Sprintf("Created ETH transaction, attempt #: %v", nrc), []interface{}{"from", txm.activeAccount.Address.String(), "to", to.String()}...)
+		logger.Infow(fmt.Sprintf("Created ETH transaction, attempt #: %v", nrc), "from", txm.activeAccount.Address.String(), "to", to.String())
 		gasPrice := txm.config.EthGasPriceDefault
 		var txa *models.TxAttempt
 		txa, err = txm.createAttempt(tx, &gasPrice, blkNum)

--- a/web/bulk_deletes_controller.go
+++ b/web/bulk_deletes_controller.go
@@ -1,0 +1,53 @@
+package web
+
+import (
+	"errors"
+
+	"github.com/asdine/storm"
+	"github.com/gin-gonic/gin"
+	"github.com/manyminds/api2go/jsonapi"
+	"github.com/smartcontractkit/chainlink/services"
+	"github.com/smartcontractkit/chainlink/store/models"
+)
+
+// BulkDeletesController manages background tasks that delete resources given a query
+type BulkDeletesController struct {
+	App services.Application
+}
+
+// Create queues a task to delete runs based on a query
+// Example:
+//  "<application>/bulk_delete_runs"
+func (c *BulkDeletesController) Create(ctx *gin.Context) {
+	request := models.BulkDeleteRunRequest{}
+	if err := ctx.ShouldBindJSON(&request); err != nil {
+		ctx.AbortWithError(422, err)
+	} else if task, err := models.NewBulkDeleteRunTask(request); err != nil {
+		ctx.AbortWithError(422, err)
+	} else if err := c.App.GetStore().Save(task); err != nil {
+		ctx.AbortWithError(500, err)
+	} else if doc, err := jsonapi.Marshal(task); err != nil {
+		ctx.AbortWithError(500, err)
+	} else {
+		c.App.WakeBulkRunDeleter()
+		ctx.Data(201, MediaType, doc)
+	}
+}
+
+// Show returns the details of a BulkDeleteTask.
+// Example:
+//  "<application>/bulk_delete_runs/:RunID"
+func (c *BulkDeletesController) Show(ctx *gin.Context) {
+	id := ctx.Param("taskID")
+	task := models.BulkDeleteRunTask{}
+
+	if err := c.App.GetStore().One("ID", id, &task); err == storm.ErrNotFound {
+		ctx.AbortWithError(404, errors.New("Bulk delete task not found"))
+	} else if err != nil {
+		ctx.AbortWithError(500, err)
+	} else if doc, err := jsonapi.Marshal(&task); err != nil {
+		ctx.AbortWithError(500, err)
+	} else {
+		ctx.Data(200, MediaType, doc)
+	}
+}

--- a/web/router.go
+++ b/web/router.go
@@ -180,6 +180,10 @@ func v2Routes(app services.Application, engine *gin.Engine) {
 
 		txs := TxAttemptsController{app}
 		authv2.GET("/txattempts", txs.Index)
+
+		bdc := BulkDeletesController{app}
+		authv2.POST("/bulk_delete_runs", bdc.Create)
+		authv2.GET("/bulk_delete_runs/:taskID", bdc.Show)
 	}
 }
 

--- a/web/sessions_controller.go
+++ b/web/sessions_controller.go
@@ -19,7 +19,7 @@ type SessionsController struct {
 // Create creates a session ID for the given user credentials, and returns it
 // in a cookie.
 func (sc *SessionsController) Create(c *gin.Context) {
-	defer sc.App.GetReaper().ReapSessions()
+	defer sc.App.WakeSessionReaper()
 
 	session := sessions.Default(c)
 	var sr models.SessionRequest
@@ -36,7 +36,7 @@ func (sc *SessionsController) Create(c *gin.Context) {
 
 // Destroy erases the session ID for the sole API user.
 func (sc *SessionsController) Destroy(c *gin.Context) {
-	defer sc.App.GetReaper().ReapSessions()
+	defer sc.App.WakeSessionReaper()
 
 	session := sessions.Default(c)
 	defer session.Clear()


### PR DESCRIPTION
Add a BulkTaskRunner for deleting of TaskRuns, abstract the sleeping task pattern into a separate interface that takes a Worker. A task can be created by an endpoint with a POST, then it can be GET'ed to see how it progresses.