### PR TITLE
Parse optional oracle contract during command-line withdrawal

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/smartcontractkit/chainlink/store"
+	"github.com/urfave/cli"
+	"os"
+)
+
+// NewApp returns the command-line parser/function-router for the given client
+func NewApp(client *Client) *cli.App {
+	app := cli.NewApp()
+	app.Usage = "CLI for Chainlink"
+	app.Version = fmt.Sprintf("%v@%v", store.Version, store.Sha)
+	app.Flags = []cli.Flag{
+		cli.BoolFlag{
+			Name:  "json, j",
+			Usage: "json output as opposed to table",
+		},
+	}
+	app.Before = func(c *cli.Context) error {
+		if c.Bool("json") {
+			client.Renderer = RendererJSON{Writer: os.Stdout}
+		}
+		return nil
+	}
+	app.Commands = []cli.Command{
+		{
+			Name:    "node",
+			Aliases: []string{"n"},
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "api, a",
+					Usage: "text file holding the API email and password, each on a line",
+				},
+				cli.StringFlag{
+					Name:  "password, p",
+					Usage: "text file holding the password for the node's account",
+				},
+				cli.BoolFlag{
+					Name:  "debug, d",
+					Usage: "set logger level to debug",
+				},
+			},
+			Usage:  "Run the chainlink node",
+			Action: client.RunNode,
+		},
+		{
+			Name:   "deleteuser",
+			Usage:  "Erase the *local node's* user and corresponding session to force recreation on next node launch. Does not work remotely over API.",
+			Action: client.DeleteUser,
+		},
+		{
+			Name:   "login",
+			Usage:  "Login to remote client by creating a session cookie",
+			Action: client.RemoteLogin,
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "file, f",
+					Usage: "text file holding the API email and password needed to create a session cookie",
+				},
+			},
+		},
+		{
+			Name:    "account",
+			Aliases: []string{"a"},
+			Usage:   "Display the account address with its ETH & LINK balances",
+			Action:  client.DisplayAccountBalance,
+		},
+		{
+			Name:    "jobspecs",
+			Aliases: []string{"jobs", "j", "specs"},
+			Usage:   "Get all jobs",
+			Action:  client.GetJobSpecs,
+			Flags: []cli.Flag{
+				cli.IntFlag{
+					Name:  "page",
+					Usage: "page of results to display",
+				},
+			},
+		},
+		{
+			Name:    "show",
+			Aliases: []string{"s"},
+			Usage:   "Show a specific job",
+			Action:  client.ShowJobSpec,
+		},
+		{
+			Name:    "create",
+			Aliases: []string{"c"},
+			Usage:   "Create job spec from JSON",
+			Action:  client.CreateJobSpec,
+		},
+		{
+			Name:    "run",
+			Aliases: []string{"r"},
+			Usage:   "Begin job run for specid",
+			Action:  client.CreateJobRun,
+		},
+		{
+			Name:    "showrun",
+			Aliases: []string{"sr"},
+			Usage:   "Show a job run for a RunID",
+			Action:  client.ShowJobRun,
+		},
+		{
+			Name:   "backup",
+			Usage:  "Backup the database of the running node",
+			Action: client.BackupDatabase,
+		},
+		{
+			Name:    "import",
+			Aliases: []string{"i"},
+			Usage:   "Import a key file to use with the node",
+			Action:  client.ImportKey,
+		},
+		{
+			Name:   "bridge",
+			Usage:  "Add a new bridge to the node",
+			Action: client.AddBridge,
+		},
+		{
+			Name:   "getbridges",
+			Usage:  "List all bridges added to the node",
+			Action: client.GetBridges,
+			Flags: []cli.Flag{
+				cli.IntFlag{
+					Name:  "page",
+					Usage: "page of results to display",
+				},
+			},
+		},
+		{
+			Name:   "showbridge",
+			Usage:  "Show a specific bridge",
+			Action: client.ShowBridge,
+		},
+		{
+			Name:   "removebridge",
+			Usage:  "Removes a specific bridge",
+			Action: client.RemoveBridge,
+		},
+		{
+			Name:    "agree",
+			Aliases: []string{"createsa"},
+			Usage:   "Creates a service agreement",
+			Action:  client.CreateServiceAgreement,
+		},
+		{
+			Name:    "withdraw",
+			Aliases: []string{"w"},
+			Usage:   "Withdraw, to an authorized Ethereum <address>, <amount> units of LINK. Withdraws from the configured oracle contract by default, or from contract optionally specified by a third command-line argument --from-oracle-contract-address=<contract address>. Address inputs must be in EIP55-compliant capitalization.",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "from-oracle-contract-address",
+					Usage: "address of Oracle contract to withdraw from (will use node default if unspecified)",
+				},
+			},
+
+			Action: client.Withdraw,
+		},
+		{
+			Name:   "chpass",
+			Usage:  "Change your password",
+			Action: client.ChangePassword,
+		},
+		{
+			Name:   "txattempts",
+			Usage:  "List the transaction attempts in descending order",
+			Action: client.GetTxAttempts,
+			Flags: []cli.Flag{
+				cli.IntFlag{
+					Name:  "page",
+					Usage: "page of results to display",
+				},
+			},
+		},
+	}
+	return app
+}

--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/gobuffalo/packr"
 	"github.com/onsi/gomega"
 	"github.com/smartcontractkit/chainlink/cmd"
@@ -23,6 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink/store"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // MockEthClient create new EthMock Client
@@ -637,3 +639,16 @@ func (m *MockRunChannel) Receive() <-chan store.RunRequest {
 }
 
 func (m *MockRunChannel) Close() {}
+
+// ExtractTargetAddressFromERC20EthEthCallMock extracts the contract address and the
+// method data, for checking in a test.
+func ExtractTargetAddressFromERC20EthEthCallMock(
+	t *testing.T, arg ...interface{}) common.Address {
+	ethMockCallArgs, ethMockCallArgsOk := (arg[0]).([]interface{})
+	require.True(t, ethMockCallArgsOk)
+	actualCallArgs, actualCallArgsOk := (ethMockCallArgs[0]).([]interface{})
+	require.True(t, actualCallArgsOk)
+	address, ok := store.ExtractERC20BalanceTargetAddress(actualCallArgs[0])
+	require.True(t, ok)
+	return address
+}

--- a/main.go
+++ b/main.go
@@ -1,14 +1,12 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"time"
 
 	"github.com/smartcontractkit/chainlink/cmd"
 	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/store"
-	"github.com/urfave/cli"
 )
 
 func init() {
@@ -21,166 +19,7 @@ func main() {
 
 // Run runs the CLI, providing further command instructions by default.
 func Run(client *cmd.Client, args ...string) {
-	app := cli.NewApp()
-	app.Usage = "CLI for Chainlink"
-	app.Version = fmt.Sprintf("%v@%v", store.Version, store.Sha)
-	app.Flags = []cli.Flag{
-		cli.BoolFlag{
-			Name:  "json, j",
-			Usage: "json output as opposed to table",
-		},
-	}
-	app.Before = func(c *cli.Context) error {
-		if c.Bool("json") {
-			client.Renderer = cmd.RendererJSON{Writer: os.Stdout}
-		}
-		return nil
-	}
-	app.Commands = []cli.Command{
-		{
-			Name:    "node",
-			Aliases: []string{"n"},
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  "api, a",
-					Usage: "text file holding the API email and password, each on a line",
-				},
-				cli.StringFlag{
-					Name:  "password, p",
-					Usage: "text file holding the password for the node's account",
-				},
-				cli.BoolFlag{
-					Name:  "debug, d",
-					Usage: "set logger level to debug",
-				},
-			},
-			Usage:  "Run the chainlink node",
-			Action: client.RunNode,
-		},
-		{
-			Name:   "deleteuser",
-			Usage:  "Erase the *local node's* user and corresponding session to force recreation on next node launch. Does not work remotely over API.",
-			Action: client.DeleteUser,
-		},
-		{
-			Name:   "login",
-			Usage:  "Login to remote client by creating a session cookie",
-			Action: client.RemoteLogin,
-			Flags: []cli.Flag{
-				cli.StringFlag{
-					Name:  "file, f",
-					Usage: "text file holding the API email and password needed to create a session cookie",
-				},
-			},
-		},
-		{
-			Name:    "account",
-			Aliases: []string{"a"},
-			Usage:   "Display the account address with its ETH & LINK balances",
-			Action:  client.DisplayAccountBalance,
-		},
-		{
-			Name:    "jobspecs",
-			Aliases: []string{"jobs", "j", "specs"},
-			Usage:   "Get all jobs",
-			Action:  client.GetJobSpecs,
-			Flags: []cli.Flag{
-				cli.IntFlag{
-					Name:  "page",
-					Usage: "page of results to display",
-				},
-			},
-		},
-		{
-			Name:    "show",
-			Aliases: []string{"s"},
-			Usage:   "Show a specific job",
-			Action:  client.ShowJobSpec,
-		},
-		{
-			Name:    "create",
-			Aliases: []string{"c"},
-			Usage:   "Create job spec from JSON",
-			Action:  client.CreateJobSpec,
-		},
-		{
-			Name:    "run",
-			Aliases: []string{"r"},
-			Usage:   "Begin job run for specid",
-			Action:  client.CreateJobRun,
-		},
-		{
-			Name:    "showrun",
-			Aliases: []string{"sr"},
-			Usage:   "Show a job run for a RunID",
-			Action:  client.ShowJobRun,
-		},
-		{
-			Name:   "backup",
-			Usage:  "Backup the database of the running node",
-			Action: client.BackupDatabase,
-		},
-		{
-			Name:    "import",
-			Aliases: []string{"i"},
-			Usage:   "Import a key file to use with the node",
-			Action:  client.ImportKey,
-		},
-		{
-			Name:   "bridge",
-			Usage:  "Add a new bridge to the node",
-			Action: client.AddBridge,
-		},
-		{
-			Name:   "getbridges",
-			Usage:  "List all bridges added to the node",
-			Action: client.GetBridges,
-			Flags: []cli.Flag{
-				cli.IntFlag{
-					Name:  "page",
-					Usage: "page of results to display",
-				},
-			},
-		},
-		{
-			Name:   "showbridge",
-			Usage:  "Show a specific bridge",
-			Action: client.ShowBridge,
-		},
-		{
-			Name:   "removebridge",
-			Usage:  "Removes a specific bridge",
-			Action: client.RemoveBridge,
-		},
-		{
-			Name:    "agree",
-			Aliases: []string{"createsa"},
-			Usage:   "Creates a service agreement",
-			Action:  client.CreateServiceAgreement,
-		},
-		{
-			Name:    "withdraw",
-			Aliases: []string{"w"},
-			Usage:   "Withdraw LINK to an authorized address",
-			Action:  client.Withdraw,
-		},
-		{
-			Name:   "chpass",
-			Usage:  "Change your password",
-			Action: client.ChangePassword,
-		},
-		{
-			Name:   "txattempts",
-			Usage:  "List the transaction attempts in descending order",
-			Action: client.GetTxAttempts,
-			Flags: []cli.Flag{
-				cli.IntFlag{
-					Name:  "page",
-					Usage: "page of results to display",
-				},
-			},
-		},
-	}
+	app := cmd.NewApp(client)
 	logger.WarnIf(app.Run(args))
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -51,7 +51,7 @@ func ExampleRun() {
 	//      showbridge                Show a specific bridge
 	//      removebridge              Removes a specific bridge
 	//      agree, createsa           Creates a service agreement
-	//      withdraw, w               Withdraw LINK to an authorized address
+	//      withdraw, w               Withdraw, to an authorized Ethereum <address>, <amount> units of LINK. Withdraws from the configured oracle contract by default, or from contract optionally specified by a third command-line argument --from-oracle-contract-address=<contract address>. Address inputs must be in EIP55-compliant capitalization.
 	//      chpass                    Change your password
 	//      txattempts                List the transaction attempts in descending order
 	//      help, h                   Shows a list of commands or help for one command

--- a/store/mock_store/mocks.go
+++ b/store/mock_store/mocks.go
@@ -76,8 +76,17 @@ func (mr *MockTxManagerMockRecorder) MeetsMinConfirmations(hash interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MeetsMinConfirmations", reflect.TypeOf((*MockTxManager)(nil).MeetsMinConfirmations), hash)
 }
 
-// WithdrawLink mocks base method
-func (m *MockTxManager) WithdrawLink(wr models.WithdrawalRequest) (common.Hash, error) {
+// ContractLINKBalance wraps base method
+func (m *MockTxManager) ContractLINKBalance(
+	wr models.WithdrawalRequest) (assets.Link, error) {
+	ret := m.ctrl.Call(m, "ContractLINKBalance", wr)
+	ret0, _ := ret[0].(assets.Link)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// WithdrawLINK mocks base method
+func (m *MockTxManager) WithdrawLINK(wr models.WithdrawalRequest) (common.Hash, error) {
 	ret := m.ctrl.Call(m, "WithdrawLink", wr)
 	ret0, _ := ret[0].(common.Hash)
 	ret1, _ := ret[1].(error)
@@ -86,20 +95,20 @@ func (m *MockTxManager) WithdrawLink(wr models.WithdrawalRequest) (common.Hash, 
 
 // WithdrawLink indicates an expected call of WithdrawLink
 func (mr *MockTxManagerMockRecorder) WithdrawLink(wr interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithdrawLink", reflect.TypeOf((*MockTxManager)(nil).WithdrawLink), wr)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithdrawLINK", reflect.TypeOf((*MockTxManager)(nil).WithdrawLINK), wr)
 }
 
-// GetLinkBalance mocks base method
-func (m *MockTxManager) GetLinkBalance(address common.Address) (*assets.Link, error) {
-	ret := m.ctrl.Call(m, "GetLinkBalance", address)
+// GetLINKBalance mocks base method
+func (m *MockTxManager) GetLINKBalance(address common.Address) (*assets.Link, error) {
+	ret := m.ctrl.Call(m, "GetLINKBalance", address)
 	ret0, _ := ret[0].(*assets.Link)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetLinkBalance indicates an expected call of GetLinkBalance
-func (mr *MockTxManagerMockRecorder) GetLinkBalance(address interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLinkBalance", reflect.TypeOf((*MockTxManager)(nil).GetLinkBalance), address)
+// GetLINKBalance indicates an expected call of GetLINKBalance
+func (mr *MockTxManagerMockRecorder) GetLINKBalance(address interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLINKBalance", reflect.TypeOf((*MockTxManager)(nil).GetLINKBalance), address)
 }
 
 // NextActiveAccount mocks base method

--- a/store/models/common.go
+++ b/store/models/common.go
@@ -311,8 +311,9 @@ func (c Cron) String() string {
 
 // WithdrawalRequest request to withdraw LINK.
 type WithdrawalRequest struct {
-	Address common.Address `json:"address"`
-	Amount  *assets.Link   `json:"amount"`
+	DestinationAddress common.Address `json:"address"`
+	ContractAddress    common.Address `json:"contractAddress"`
+	Amount             *assets.Link   `json:"amount"`
 }
 
 // Int stores large integers and can deserialize a variety of inputs.

--- a/store/presenters/presenters.go
+++ b/store/presenters/presenters.go
@@ -83,7 +83,7 @@ func getBalance(store *store.Store, account accounts.Account, balanceType reques
 	case ethRequest:
 		return store.TxManager.GetEthBalance(account.Address)
 	case linkRequest:
-		return store.TxManager.GetLinkBalance(account.Address)
+		return store.TxManager.GetLINKBalance(account.Address)
 	}
 	return nil, fmt.Errorf("Impossible to get balance for %T with value %v", balanceType, balanceType)
 }
@@ -181,12 +181,12 @@ func NewConfigWhitelist(config store.Config) ConfigWhitelist {
 		MinIncomingConfirmations: config.MinIncomingConfirmations,
 		MinOutgoingConfirmations: config.MinOutgoingConfirmations,
 		OracleContractAddress:    config.OracleContractAddress,
-		Port:                     config.Port,
-		ReaperExpiration:         config.ReaperExpiration,
-		RootDir:                  config.RootDir,
-		SessionTimeout:           config.SessionTimeout,
-		TLSHost:                  config.TLSHost,
-		TLSPort:                  config.TLSPort,
+		Port:             config.Port,
+		ReaperExpiration: config.ReaperExpiration,
+		RootDir:          config.RootDir,
+		SessionTimeout:   config.SessionTimeout,
+		TLSHost:          config.TLSHost,
+		TLSPort:          config.TLSPort,
 	}
 }
 

--- a/store/tx_manager_test.go
+++ b/store/tx_manager_test.go
@@ -523,11 +523,11 @@ func TestTxManager_WithdrawLink(t *testing.T) {
 	})
 
 	wr := models.WithdrawalRequest{
-		Address: to,
-		Amount:  assets.NewLink(10),
+		DestinationAddress: to,
+		Amount:             assets.NewLink(10),
 	}
 
-	hash, err := txm.WithdrawLink(wr)
+	hash, err := txm.WithdrawLINK(wr)
 	assert.NoError(t, err)
 	assert.True(t, ethMock.AllCalled(), "Not Called")
 
@@ -550,12 +550,12 @@ func TestTxManager_WithdrawLink_Unconfigured_Oracle(t *testing.T) {
 	assert.NoError(t, app.Start())
 
 	wr := models.WithdrawalRequest{
-		Address: cltest.NewAddress(),
-		Amount:  assets.NewLink(10),
+		DestinationAddress: cltest.NewAddress(),
+		Amount:             assets.NewLink(10),
 	}
 
-	_, err := app.Store.TxManager.WithdrawLink(wr)
-	assert.EqualError(t, err, "OracleContractAddress not set can not withdraw")
+	_, err := app.Store.TxManager.WithdrawLINK(wr)
+	assert.EqualError(t, err, "OracleContractAddress not set; cannot withdraw")
 }
 
 func TestManagedAccount_GetAndIncrementNonce_YieldsCurrentNonceAndIncrements(t *testing.T) {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -357,3 +357,31 @@ func RemoveQuotes(input []byte) []byte {
 	}
 	return input
 }
+
+// EIP55CapitalizedAddress returns true iff possibleAddressString has the correct
+// capitalization for an Ethereum address, per EIP 55
+func EIP55CapitalizedAddress(possibleAddressString string) bool {
+	if !HasHexPrefix(possibleAddressString) {
+		possibleAddressString = "0x" + possibleAddressString
+	}
+	EIP55Capitalized := common.HexToAddress(possibleAddressString).Hex()
+	return possibleAddressString == EIP55Capitalized
+}
+
+// ParseEthereumAddress returns addressString as a go-ethereum Address, or an
+// error if it's invalid, e.g. if EIP 55 capitalization check fails
+func ParseEthereumAddress(addressString string) (common.Address, error) {
+	if !common.IsHexAddress(addressString) {
+		return common.Address{}, fmt.Errorf(
+			"not a valid Ethereum address: %s", addressString)
+	}
+	address := common.HexToAddress(addressString)
+	if !EIP55CapitalizedAddress(addressString) {
+		return common.Address{}, fmt.Errorf(
+			"%s treated as Ethereum address, but it has an invalid capitalization! "+
+				"The correctly-capitalized address would be %s, but "+
+				"check carefully before copying and pasting! ",
+			addressString, address.Hex())
+	}
+	return address, nil
+}

--- a/web/user_controller.go
+++ b/web/user_controller.go
@@ -113,7 +113,7 @@ func getAccountBalanceFor(ctx *gin.Context, store *store.Store, account accounts
 	txm := store.TxManager
 	if ethBalance, err := txm.GetEthBalance(account.Address); err != nil {
 		ctx.AbortWithError(500, err)
-	} else if linkBalance, err := txm.GetLinkBalance(account.Address); err != nil {
+	} else if linkBalance, err := txm.GetLINKBalance(account.Address); err != nil {
 		ctx.AbortWithError(500, err)
 	} else {
 		return presenters.AccountBalance{

--- a/web/withdrawals_controller.go
+++ b/web/withdrawals_controller.go
@@ -19,8 +19,10 @@ type WithdrawalsController struct {
 var naz = assets.NewLink(1)
 
 // Create sends LINK from the configured oracle contract to the given address
-// Example:
-//  "<application>/withdrawals"
+// See models.WithdrawalRequest for expected inputs. ContractAddress field is
+// optional.
+//
+// Example: "<application>/withdrawals"
 func (abc *WithdrawalsController) Create(c *gin.Context) {
 	store := abc.App.GetStore()
 	txm := store.TxManager
@@ -28,18 +30,29 @@ func (abc *WithdrawalsController) Create(c *gin.Context) {
 
 	if err := c.ShouldBindJSON(&wr); err != nil {
 		publicError(c, 400, err)
-	} else if wr.Amount.Cmp(naz) < 0 {
-		publicError(c, 400, fmt.Errorf("Must withdraw at least %v LINK", naz.String()))
-	} else if wr.Address == utils.ZeroAddress { // address is unmarshalled to ZeroAddres if invalid
+		return
+	}
+
+	addressWasNotSpecifiedInRequest := utils.ZeroAddress
+
+	if wr.Amount.Cmp(naz) < 0 {
+		publicError(c, 400, fmt.Errorf(
+			"Must withdraw at least %v LINK", naz.String()))
+	} else if wr.DestinationAddress == addressWasNotSpecifiedInRequest {
 		publicError(c, 400, errors.New("Invalid withdrawal address"))
-	} else if account, err := store.KeyStore.GetFirstAccount(); err != nil {
-		c.AbortWithError(500, err)
-	} else if linkBalance, err := txm.GetLinkBalance(account.Address); err != nil {
-		c.AbortWithError(500, err)
+	} else if linkBalance, err := txm.ContractLINKBalance(wr); err != nil {
+		_ = c.AbortWithError(500, err)
 	} else if linkBalance.Cmp(wr.Amount) < 0 {
-		publicError(c, 400, fmt.Errorf("Insufficient link balance. Withdrawal Amount: %v Link Balance: %v", wr.Amount.String(), linkBalance.String()))
-	} else if hash, err := txm.WithdrawLink(wr); err != nil {
-		c.AbortWithError(500, err)
+		publicError(c, 400, fmt.Errorf(
+			"Insufficient link balance. Withdrawal Amount: %v "+
+				"Link Balance: %v",
+			wr.Amount.String(), linkBalance.String()))
+		return
+	}
+
+	hash, err := txm.WithdrawLINK(wr)
+	if err != nil {
+		_ = c.AbortWithError(500, err)
 	} else {
 		c.JSON(200, hash)
 	}


### PR DESCRIPTION
Takes an optional third argument of the form `--from-oracle-contract-address=<address>`. Not sure where to document this -- for now it's a huge string in the `Usage` field in `main.go`. 

It seems like it might be easier and more flexible to parse if we made more use of go's `flag` library in `context.go`.

There seem to be no integration tests for withdrawal at the moment. I broke as much as I could into unit tests, and extended the `withdrawal_controller_test.go` test to include a custom contract address.

We may want to record authorized withdrawal-destination addresses on a per-contract basis.

Addresses tracker story #162198879