### PR TITLE
Add chainlinkRequestFrom specified oracle

### DIFF
--- a/examples/ropsten/contracts/Oracle.sol
+++ b/examples/ropsten/contracts/Oracle.sol
@@ -274,11 +274,11 @@ contract Oracle is OracleInterface, Ownable {
     hasAvailableFunds(_amount)
   {
     withdrawableWei = withdrawableWei.sub(_amount);
-    LINK.transfer(_recipient, _amount);
+    require(LINK.transfer(_recipient, _amount), "Failed to transfer LINK");
   }
 
   function cancel(bytes32 _externalId)
-    public
+    external
   {
     uint256 internalId = uint256(keccak256(abi.encodePacked(msg.sender, _externalId)));
     require(msg.sender == callbacks[internalId].addr, "Must be called from requester");
@@ -311,15 +311,13 @@ contract Oracle is OracleInterface, Ownable {
     _;
   }
 
-  bytes4 constant private permittedFunc = bytes4(keccak256("requestData(address,uint256,uint256,bytes32,address,bytes4,bytes32,bytes)"));
-
   modifier permittedFunctionsForLINK() {
     bytes4[1] memory funcSelector;
     assembly {
       // solium-disable-next-line security/no-low-level-calls
       calldatacopy(funcSelector, 132, 4) // grab function selector from calldata
     }
-    require(funcSelector[0] == permittedFunc, "Must use whitelisted functions");
+    require(funcSelector[0] == this.requestData.selector, "Must use whitelisted functions");
     _;
   }
 

--- a/examples/ropsten/contracts/RopstenConsumerBase.sol
+++ b/examples/ropsten/contracts/RopstenConsumerBase.sol
@@ -34,7 +34,7 @@ contract ARopstenConsumer is Chainlinked, Ownable {
     public
     onlyOwner
   {
-    ChainlinkLib.Run memory run = newRun(stringToBytes32(_jobId), this, "fulfillEthereumPrice(bytes32,uint256)");
+    ChainlinkLib.Run memory run = newRun(stringToBytes32(_jobId), this, this.fulfillEthereumPrice.selector);
     run.add("url", "https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=USD,EUR,JPY");
     string[] memory path = new string[](1);
     path[0] = _currency;
@@ -47,7 +47,7 @@ contract ARopstenConsumer is Chainlinked, Ownable {
     public
     onlyOwner
   {
-    ChainlinkLib.Run memory run = newRun(stringToBytes32(_jobId), this, "fulfillEthereumChange(bytes32,int256)");
+    ChainlinkLib.Run memory run = newRun(stringToBytes32(_jobId), this, this.fulfillEthereumChange.selector);
     run.add("url", "https://min-api.cryptocompare.com/data/pricemultifull?fsyms=ETH&tsyms=USD,EUR,JPY");
     string[] memory path = new string[](4);
     path[0] = "RAW";
@@ -63,7 +63,7 @@ contract ARopstenConsumer is Chainlinked, Ownable {
     public
     onlyOwner
   {
-    ChainlinkLib.Run memory run = newRun(stringToBytes32(_jobId), this, "fulfillEthereumLastMarket(bytes32,bytes32)");
+    ChainlinkLib.Run memory run = newRun(stringToBytes32(_jobId), this, this.fulfillEthereumLastMarket.selector);
     run.add("url", "https://min-api.cryptocompare.com/data/pricemultifull?fsyms=ETH&tsyms=USD,EUR,JPY");
     string[] memory path = new string[](4);
     path[0] = "RAW";

--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -42,17 +42,10 @@ contract Chainlinked {
     internal
     returns (bytes32)
   {
-    _run.requestId = bytes32(requests);
-    requests += 1;
-    _run.close();
-    unfulfilledRequests[_run.requestId] = oracle;
-    emit ChainlinkRequested(_run.requestId);
-    require(link.transferAndCall(oracle, _amount, encodeForOracle(_run)), "unable to transferAndCall to oracle");
-
-    return _run.requestId;
+    return chainlinkRequestFrom(oracle, _run, _amount);
   }
 
-  function chainlinkRequestTo(address _oracle, ChainlinkLib.Run memory _run, uint256 _amount)
+  function chainlinkRequestFrom(address _oracle, ChainlinkLib.Run memory _run, uint256 _amount)
     internal
     returns (bytes32)
   {

--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -52,6 +52,20 @@ contract Chainlinked {
     return _run.requestId;
   }
 
+  function chainlinkRequestTo(address _oracle, ChainlinkLib.Run memory _run, uint256 _amount)
+    internal
+    returns (bytes32)
+  {
+    _run.requestId = bytes32(requests);
+    requests += 1;
+    _run.close();
+    unfulfilledRequests[_run.requestId] = _oracle;
+    emit ChainlinkRequested(_run.requestId);
+    require(link.transferAndCall(_oracle, _amount, encodeForOracle(_run)), "unable to transferAndCall to oracle");
+
+    return _run.requestId;
+  }
+
   function cancelChainlinkRequest(bytes32 _requestId)
     internal
   {

--- a/solidity/contracts/examples/ConcreteChainlinked.sol
+++ b/solidity/contracts/examples/ConcreteChainlinked.sol
@@ -50,6 +50,19 @@ contract ConcreteChainlinked is Chainlinked {
     chainlinkRequest(run, _wei);
   }
 
+  function publicRequestRunTo(
+    address _oracle,
+    bytes32 _specId,
+    address _address,
+    string _fulfillmentSignature,
+    uint256 _wei
+  )
+    public
+  {
+    ChainlinkLib.Run memory run = newRun(_specId, _address, _fulfillmentSignature);
+    chainlinkRequestTo(_oracle, run, _wei);
+  }
+
   function publicCancelRequest(bytes32 _requestId) public {
     cancelChainlinkRequest(_requestId);
   }
@@ -67,5 +80,9 @@ contract ConcreteChainlinked is Chainlinked {
 
   function publicLINK(uint256 _link) public {
     emit LinkAmount(LINK(_link));
+  }
+
+  function publicOracleAddress() public view returns (address) {
+    return oracleAddress();
   }
 }

--- a/solidity/contracts/examples/ConcreteChainlinked.sol
+++ b/solidity/contracts/examples/ConcreteChainlinked.sol
@@ -50,17 +50,17 @@ contract ConcreteChainlinked is Chainlinked {
     chainlinkRequest(run, _wei);
   }
 
-  function publicRequestRunTo(
+  function publicRequestRunFrom(
     address _oracle,
     bytes32 _specId,
     address _address,
-    string _fulfillmentSignature,
+    bytes _fulfillmentSignature,
     uint256 _wei
   )
     public
   {
-    ChainlinkLib.Run memory run = newRun(_specId, _address, _fulfillmentSignature);
-    chainlinkRequestTo(_oracle, run, _wei);
+    ChainlinkLib.Run memory run = newRun(_specId, _address, bytes4(keccak256(_fulfillmentSignature)));
+    chainlinkRequestFrom(_oracle, run, _wei);
   }
 
   function publicCancelRequest(bytes32 _requestId) public {

--- a/solidity/test/ConcreteChainlinked_test.js
+++ b/solidity/test/ConcreteChainlinked_test.js
@@ -53,9 +53,9 @@ contract('ConcreteChainlinked', () => {
     })
   })
 
-  describe('#chainlinkRequestTo(Run)', () => {
+  describe('#chainlinkRequestFrom(Run)', () => {
     it('emits an event from the contract showing the run ID', async () => {
-      await cc.publicRequestRunTo(newoc.address, specId, cc.address, 'fulfillRequest(bytes32,bytes32)', 0)
+      await cc.publicRequestRunFrom(newoc.address, specId, cc.address, 'fulfillRequest(bytes32,bytes32)', 0)
 
       let events = await getEvents(cc)
       assert.equal(1, events.length)
@@ -64,7 +64,7 @@ contract('ConcreteChainlinked', () => {
     })
 
     it('emits an event on the target oracle contract', async () => {
-      await cc.publicRequestRunTo(newoc.address, specId, cc.address, 'fulfillRequest(bytes32,bytes32)', 0)
+      await cc.publicRequestRunFrom(newoc.address, specId, cc.address, 'fulfillRequest(bytes32,bytes32)', 0)
 
       let events = await getEvents(newoc)
       assert.equal(1, events.length)
@@ -73,7 +73,7 @@ contract('ConcreteChainlinked', () => {
     })
 
     it('does not modify the stored oracle address', async () => {
-      await cc.publicRequestRunTo(newoc.address, specId, cc.address, 'fulfillRequest(bytes32,bytes32)', 0)
+      await cc.publicRequestRunFrom(newoc.address, specId, cc.address, 'fulfillRequest(bytes32,bytes32)', 0)
 
       const actualOracleAddress = await cc.publicOracleAddress()
       assert.equal(oc.address, actualOracleAddress)


### PR DESCRIPTION
Finishes [#162296866](https://www.pivotaltracker.com/story/show/162296866). Allows a requester to send a Chainlink request to a specified oracle without modifying the stored `oracle` of the Chainlinked contract.