### PR TITLE
Parse large float parsed values as string, rather than cast to int64

### DIFF
--- a/utils/ethabi.go
+++ b/utils/ethabi.go
@@ -110,22 +110,30 @@ func EVMTranscodeBool(value gjson.Result) ([]byte, error) {
 	return EVMWordUint64(output), nil
 }
 
+func parseDecimalString(input string) (*big.Int, error) {
+	parseValue, err := strconv.ParseFloat(input, 64)
+	if err != nil {
+		return nil, err
+	}
+	output, ok := big.NewInt(0).SetString(fmt.Sprintf("%.f", parseValue), 10)
+	if !ok {
+		return nil, fmt.Errorf("error parsing decimal %s", input)
+	}
+	return output, nil
+}
+
 func parseNumericString(input string) (*big.Int, error) {
 	if HasHexPrefix(input) {
 		output, ok := big.NewInt(0).SetString(RemoveHexPrefix(input), 16)
 		if !ok {
-			return nil, fmt.Errorf("error parsing %s", input)
+			return nil, fmt.Errorf("error parsing hex %s", input)
 		}
 		return output, nil
 	}
 
 	output, ok := big.NewInt(0).SetString(input, 10)
 	if !ok {
-		parseValue, err := strconv.ParseFloat(input, 64)
-		if err != nil {
-			return nil, err
-		}
-		output = big.NewInt(0).SetInt64(int64(parseValue))
+		return parseDecimalString(input)
 	}
 	return output, nil
 }

--- a/utils/ethabi_test.go
+++ b/utils/ethabi_test.go
@@ -467,13 +467,35 @@ func TestParseNumericString(t *testing.T) {
 		{"0", "0"},
 		{"1", "1"},
 		{"1.0E+0", "1"},
-		{"1E+0", "1"},
-		{"1e+0", "1"},
-		{"0.01e+02", "1"},
 	}
 
 	for _, test := range tests {
 		out, err := parseNumericString(test.input)
+		assert.NoError(t, err)
+		assert.Equal(t, test.output, out.String())
+	}
+}
+
+func TestParseDecimalString(t *testing.T) {
+	tests := []struct {
+		input  string
+		output string
+	}{
+		{"1.0", "1"},
+		{"0", "0"},
+		{"1", "1"},
+		{"1.0E+0", "1"},
+		{"1E+0", "1"},
+		{"1e+0", "1"},
+		{"0.01e+02", "1"},
+		{"12072e-4", "1"},
+		{"1.2072e+20", "120720000000000000000"},
+		{"-1.2072e+20", "-120720000000000000000"},
+		{"1.55555555555555555555e+20", "155555555555555540992"},
+	}
+
+	for _, test := range tests {
+		out, err := parseDecimalString(test.input)
 		assert.NoError(t, err)
 		assert.Equal(t, test.output, out.String())
 	}

--- a/utils/ethabi_test.go
+++ b/utils/ethabi_test.go
@@ -476,6 +476,11 @@ func TestParseNumericString(t *testing.T) {
 	}
 }
 
+func TestParseNumericString_InvalidHex(t *testing.T) {
+	_, err := parseNumericString("0xfZ")
+	assert.Error(t, err)
+}
+
 func TestParseDecimalString(t *testing.T) {
 	tests := []struct {
 		input  string


### PR DESCRIPTION
The cast from 1.2072e+20 to int64 wrapped around to -9223372036854775808, so format the float as a string and get big.Int to parse it via SetString.