### PR TITLE
move contract interactions before modifier's yield

### DIFF
--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -161,8 +161,8 @@ contract Chainlinked {
 
   modifier checkChainlinkFulfillment(bytes32 _requestId) {
     require(msg.sender == unfulfilledRequests[_requestId], "source must be the oracle of the request");
-    _;
     delete unfulfilledRequests[_requestId];
     emit ChainlinkFulfilled(_requestId);
+    _;
   }
 }

--- a/solidity/test/BasicConsumer_test.js
+++ b/solidity/test/BasicConsumer_test.js
@@ -96,7 +96,7 @@ contract('BasicConsumer', () => {
     it('logs the data given to it by the oracle', async () => {
       let tx = await oc.fulfillData(internalId, response, {from: oracleNode})
       assert.equal(2, tx.receipt.logs.length)
-      let log = tx.receipt.logs[0]
+      let log = tx.receipt.logs[1]
 
       assert.equal(web3.toUtf8(log.topics[2]), response)
     })


### PR DESCRIPTION
Allows the contract to conform with the standard [checks, effects,
 interactions pattern](https://solidity.readthedocs.io/en/develop/security-considerations.html#use-the-checks-effects-interactions-pattern).