### PR TITLE
TxManager sends across all available accounts via round robin

### DIFF
--- a/adapters/eth_tx_test.go
+++ b/adapters/eth_tx_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestEthTxAdapter_Perform_Confirmed(t *testing.T) {
@@ -244,6 +245,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_BumpGas(t *testing.T) {
 	config := store.Config
 
 	ethMock := app.MockEthClient()
+	ethMock.Register("eth_getTransactionCount", "0x0")
 	ethMock.Register("eth_getTransactionReceipt", strpkg.TxReceipt{})
 	sentAt := uint64(23456)
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(sentAt+config.EthGasBumpThreshold))
@@ -258,6 +260,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_BumpGas(t *testing.T) {
 	sentResult := cltest.RunResultWithValue(a.Hash.String())
 	input := sentResult.MarkPendingConfirmations()
 
+	require.NoError(t, app.Start())
 	output := adapter.Perform(input, store)
 
 	assert.False(t, output.HasError())
@@ -389,6 +392,7 @@ func TestEthTxAdapter_DeserializationBytesFormat(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	txmMock := mock_store.NewMockTxManager(ctrl)
 	store.TxManager = txmMock
+	txmMock.EXPECT().Start(gomock.Any())
 	txmMock.EXPECT().CreateTx(gomock.Any(), hexutil.MustDecode(
 		"0x00000000"+
 			"0000000000000000000000000000000000000000000000000000000000000020"+

--- a/cmd/local_client.go
+++ b/cmd/local_client.go
@@ -97,11 +97,20 @@ func updateConfig(config strpkg.Config, debug bool) strpkg.Config {
 }
 
 func logNodeBalance(store *strpkg.Store) {
-	kv, err := presenters.ShowEthBalance(store)
+	accounts, err := presenters.ShowEthBalance(store)
 	logger.WarnIf(err)
-	logger.Infow(fmt.Sprint(kv["message"]), "address", kv["address"], "balance", kv["balance"])
-	kv, err = presenters.ShowLinkBalance(store)
+	for _, a := range accounts {
+		logAccountBalance(a)
+	}
+
+	accounts, err = presenters.ShowLinkBalance(store)
 	logger.WarnIf(err)
+	for _, a := range accounts {
+		logAccountBalance(a)
+	}
+}
+
+func logAccountBalance(kv map[string]interface{}) {
 	logger.Infow(fmt.Sprint(kv["message"]), "address", kv["address"], "balance", kv["balance"])
 }
 

--- a/cmd/local_client.go
+++ b/cmd/local_client.go
@@ -69,7 +69,7 @@ func passwordFromFile(pwdFile string) (string, error) {
 }
 
 func logIfNonceOutOfSync(store *strpkg.Store) {
-	account := store.TxManager.GetActiveAccount()
+	account := store.TxManager.NextActiveAccount()
 	lastNonce, err := store.GetLastNonce(account.Address)
 	if err != nil {
 		logger.Error("database error when checking nonce: ", err)

--- a/cmd/remote_client_test.go
+++ b/cmd/remote_client_test.go
@@ -20,8 +20,6 @@ import (
 func TestClient_DisplayAccountBalance(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithKeyStore()
 	defer cleanup()
-	account, err := app.Store.KeyStore.GetAccount()
-	assert.NoError(t, err)
 
 	ethMock := app.MockEthClient()
 	ethMock.Register("eth_getBalance", "0x0100")
@@ -31,7 +29,8 @@ func TestClient_DisplayAccountBalance(t *testing.T) {
 
 	assert.Nil(t, client.DisplayAccountBalance(cltest.EmptyCLIContext()))
 	require.Equal(t, 1, len(r.Renders))
-	assert.Equal(t, account.Address.Hex(), r.Renders[0].(*presenters.AccountBalance).Address)
+	from := cltest.GetAccountAddress(app.GetStore())
+	assert.Equal(t, from.Hex(), r.Renders[0].(*presenters.AccountBalance).Address)
 }
 
 func TestClient_GetJobSpecs(t *testing.T) {
@@ -448,7 +447,7 @@ func TestClient_WithdrawNoArgs(t *testing.T) {
 }
 
 func setupWithdrawalsApplication() (*cltest.TestApplication, func()) {
-	config, _ := cltest.NewConfigWithPrivateKey()
+	config, _ := cltest.NewConfig()
 	oca := common.HexToAddress("0xDEADB3333333F")
 	config.OracleContractAddress = &oca
 	app, cleanup := cltest.NewApplicationWithConfigAndKeyStore(config)

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -538,9 +538,8 @@ func FixtureCreateServiceAgreementViaWeb(
 	client := app.NewHTTPClient()
 
 	agreementWithoutOracle := EasyJSONFromFixture(path)
-	account, err := app.Store.KeyStore.GetAccount()
-	assert.NoError(t, err)
-	agreementWithOracle := agreementWithoutOracle.Add("oracles", []string{account.Address.Hex()})
+	from := GetAccountAddress(app.ChainlinkApplication.GetStore())
+	agreementWithOracle := agreementWithoutOracle.Add("oracles", []string{from.Hex()})
 
 	b, err := json.Marshal(agreementWithOracle)
 	assert.NoError(t, err)
@@ -800,7 +799,7 @@ func mustNotErr(err error) {
 
 // GetAccountAddress returns Address of the account in the keystore of the passed in store
 func GetAccountAddress(store *store.Store) common.Address {
-	account, err := store.KeyStore.GetAccount()
+	account, err := store.KeyStore.GetFirstAccount()
 	mustNotErr(err)
 
 	return account.Address

--- a/services/validators.go
+++ b/services/validators.go
@@ -116,7 +116,7 @@ func ValidateServiceAgreement(sa models.ServiceAgreement, store *store.Store) er
 		fe.Add(fmt.Sprintf("Service agreement encumbrance error: Expiration is below minimum %v", config.MinimumRequestExpiration))
 	}
 
-	account, err := store.KeyStore.GetAccount()
+	account, err := store.KeyStore.GetFirstAccount()
 	if err != nil {
 		return err // 500
 	}

--- a/services/validators_test.go
+++ b/services/validators_test.go
@@ -160,7 +160,7 @@ func TestValidateServiceAgreement(t *testing.T) {
 	assert.NoError(t, err)
 	defer cleanup()
 
-	account, err := store.KeyStore.GetAccount()
+	account, err := store.KeyStore.GetFirstAccount()
 	assert.NoError(t, err)
 
 	oracles := []string{account.Address.Hex()}

--- a/store/assets/currencies.go
+++ b/store/assets/currencies.go
@@ -87,6 +87,17 @@ func (l *Link) UnmarshalText(text []byte) error {
 	return nil
 }
 
+// IsZero returns true when the value is 0 and false otherwise
+func (l *Link) IsZero() bool {
+	zero := big.NewInt(0)
+	return (*big.Int)(l).Cmp(zero) == 0
+}
+
+// Symbol returns LINK
+func (*Link) Symbol() string {
+	return "LINK"
+}
+
 // Eth contains a field to represent the smallest units of ETH
 type Eth big.Int
 
@@ -132,4 +143,9 @@ func (e *Eth) UnmarshalText(text []byte) error {
 func (e *Eth) IsZero() bool {
 	zero := big.NewInt(0)
 	return (*big.Int)(e).Cmp(zero) == 0
+}
+
+// Symbol returns ETH
+func (*Eth) Symbol() string {
+	return "ETH"
 }

--- a/store/key_store.go
+++ b/store/key_store.go
@@ -52,12 +52,7 @@ func (ks *KeyStore) Unlock(phrase string) error {
 }
 
 // SignTx uses the unlocked account to sign the given transaction.
-func (ks *KeyStore) SignTx(tx *types.Transaction, chainID uint64) (*types.Transaction, error) {
-	account, err := ks.GetAccount()
-	if err != nil {
-		return nil, err
-	}
-
+func (ks *KeyStore) SignTx(account accounts.Account, tx *types.Transaction, chainID uint64) (*types.Transaction, error) {
 	return ks.KeyStore.SignTx(
 		account,
 		tx,
@@ -67,7 +62,7 @@ func (ks *KeyStore) SignTx(tx *types.Transaction, chainID uint64) (*types.Transa
 
 // Sign creates an HMAC from some input data using the account's private key
 func (ks *KeyStore) Sign(input []byte) (models.Signature, error) {
-	account, err := ks.GetAccount()
+	account, err := ks.GetFirstAccount()
 	if err != nil {
 		return models.Signature{}, err
 	}
@@ -85,9 +80,9 @@ func (ks *KeyStore) Sign(input []byte) (models.Signature, error) {
 	return signature, nil
 }
 
-// GetAccount returns the unlocked account in the KeyStore object. The client
+// GetFirstAccount returns the unlocked account in the KeyStore object. The client
 // ensures that an account exists during authentication.
-func (ks *KeyStore) GetAccount() (accounts.Account, error) {
+func (ks *KeyStore) GetFirstAccount() (accounts.Account, error) {
 	if len(ks.Accounts()) == 0 {
 		return accounts.Account{}, errors.New("No Ethereum Accounts configured")
 	}

--- a/store/mock_store/mocks.go
+++ b/store/mock_store/mocks.go
@@ -102,16 +102,16 @@ func (mr *MockTxManagerMockRecorder) GetLinkBalance(address interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLinkBalance", reflect.TypeOf((*MockTxManager)(nil).GetLinkBalance), address)
 }
 
-// GetActiveAccount mocks base method
-func (m *MockTxManager) GetActiveAccount() *store.ManagedAccount {
-	ret := m.ctrl.Call(m, "GetActiveAccount")
+// NextActiveAccount mocks base method
+func (m *MockTxManager) NextActiveAccount() *store.ManagedAccount {
+	ret := m.ctrl.Call(m, "NextActiveAccount")
 	ret0, _ := ret[0].(*store.ManagedAccount)
 	return ret0
 }
 
-// GetActiveAccount indicates an expected call of GetActiveAccount
-func (mr *MockTxManagerMockRecorder) GetActiveAccount() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetActiveAccount", reflect.TypeOf((*MockTxManager)(nil).GetActiveAccount))
+// NextActiveAccount indicates an expected call of NextActiveAccount
+func (mr *MockTxManagerMockRecorder) NextActiveAccount() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NextActiveAccount", reflect.TypeOf((*MockTxManager)(nil).NextActiveAccount))
 }
 
 // GetEthBalance mocks base method

--- a/store/mock_store/mocks.go
+++ b/store/mock_store/mocks.go
@@ -38,6 +38,18 @@ func (m *MockTxManager) EXPECT() *MockTxManagerMockRecorder {
 	return m.recorder
 }
 
+// Start mocks base method
+func (m *MockTxManager) Start(accounts []accounts.Account) error {
+	ret := m.ctrl.Call(m, "Start", accounts)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Start indicates an expected call of Start
+func (mr *MockTxManagerMockRecorder) Start(accounts interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Start", reflect.TypeOf((*MockTxManager)(nil).Start), accounts)
+}
+
 // CreateTx mocks base method
 func (m *MockTxManager) CreateTx(to common.Address, data []byte) (*models.Tx, error) {
 	ret := m.ctrl.Call(m, "CreateTx", to, data)
@@ -49,18 +61,6 @@ func (m *MockTxManager) CreateTx(to common.Address, data []byte) (*models.Tx, er
 // CreateTx indicates an expected call of CreateTx
 func (mr *MockTxManagerMockRecorder) CreateTx(to, data interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTx", reflect.TypeOf((*MockTxManager)(nil).CreateTx), to, data)
-}
-
-// ActivateAccount mocks base method
-func (m *MockTxManager) ActivateAccount(account accounts.Account) error {
-	ret := m.ctrl.Call(m, "ActivateAccount", account)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// ActivateAccount indicates an expected call of ActivateAccount
-func (mr *MockTxManagerMockRecorder) ActivateAccount(account interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ActivateAccount", reflect.TypeOf((*MockTxManager)(nil).ActivateAccount), account)
 }
 
 // MeetsMinConfirmations mocks base method

--- a/store/presenters/presenters_test.go
+++ b/store/presenters/presenters_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
-	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 	"github.com/stretchr/testify/assert"
@@ -88,13 +87,14 @@ func TestPresenterShowEthBalance_WithAccount(t *testing.T) {
 
 	assert.True(t, app.Store.KeyStore.HasAccounts())
 
-	kv, err := presenters.ShowEthBalance(app.Store)
+	kvs, err := presenters.ShowEthBalance(app.Store)
 	assert.NoError(t, err)
+	kv := kvs[0]
 	addr := cltest.GetAccountAddress(app.Store).Hex()
 	want := fmt.Sprintf("ETH Balance for %v: 0.000000000000000256", addr)
 	assert.Equal(t, want, kv["message"].(string))
 	assert.Equal(t, kv["address"].(common.Address).String(), addr)
-	assert.Equal(t, kv["balance"].(*assets.Eth).String(), "0.000000000000000256")
+	assert.Equal(t, kv["balance"].(string), "0.000000000000000256")
 }
 
 func TestPresenterShowLinkBalance_NoAccount(t *testing.T) {
@@ -119,11 +119,12 @@ func TestPresenterShowLinkBalance_WithAccount(t *testing.T) {
 
 	assert.True(t, app.Store.KeyStore.HasAccounts())
 
-	kv, err := presenters.ShowLinkBalance(app.Store)
+	kvs, err := presenters.ShowLinkBalance(app.Store)
 	assert.NoError(t, err)
 
+	kv := kvs[0]
 	addr := cltest.GetAccountAddress(app.Store).Hex()
-	want := fmt.Sprintf("Link Balance for %v: 0.000000000000000256", addr)
+	want := fmt.Sprintf("LINK Balance for %v: 0.000000000000000256", addr)
 	assert.Equal(t, want, kv["message"].(string))
 	assert.Equal(t, kv["address"].(common.Address).String(), addr)
 	assert.Equal(t, kv["balance"], "0.000000000000000256")

--- a/store/store.go
+++ b/store/store.go
@@ -94,12 +94,7 @@ func NewStoreWithDialer(config Config, dialer Dialer) *Store {
 
 // Start initiates all of Store's dependencies including the TxManager.
 func (s *Store) Start() error {
-	acc, err := s.KeyStore.GetAccount()
-	if err != nil {
-		return err
-	}
-
-	return s.TxManager.ActivateAccount(acc)
+	return s.TxManager.Start(s.KeyStore.Accounts())
 }
 
 // Close shuts down all of the working parts of the store.

--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -24,8 +24,8 @@ const nonceReloadLimit uint = 1
 
 // TxManager represents an interface for interacting with the blockchain
 type TxManager interface {
+	Start(accounts []accounts.Account) error
 	CreateTx(to common.Address, data []byte) (*models.Tx, error)
-	ActivateAccount(account accounts.Account) error
 	MeetsMinConfirmations(hash common.Hash) (bool, error)
 	WithdrawLink(wr models.WithdrawalRequest) (common.Hash, error)
 	GetLinkBalance(address common.Address) (*assets.Link, error)
@@ -42,31 +42,33 @@ type TxManager interface {
 // the local Config for the application, and the database.
 type EthTxManager struct {
 	*EthClient
-	keyStore      *KeyStore
-	config        Config
-	orm           *orm.ORM
-	activeAccount *ManagedAccount
+	keyStore            *KeyStore
+	config              Config
+	orm                 *orm.ORM
+	availableAccounts   []*ManagedAccount
+	availableAccountIdx int
 }
 
 // CreateTx signs and sends a transaction to the Ethereum blockchain.
 func (txm *EthTxManager) CreateTx(to common.Address, data []byte) (*models.Tx, error) {
-	return txm.createTxWithNonceReload(to, data, 0)
-}
-
-func (txm *EthTxManager) createTxWithNonceReload(to common.Address, data []byte, nrc uint) (*models.Tx, error) {
-	if txm.activeAccount == nil {
+	ma := txm.GetActiveAccount()
+	if ma == nil {
 		return nil, errors.New("Must activate an account before creating a transaction")
 	}
 
+	return txm.createTxWithNonceReload(ma, to, data, 0)
+}
+
+func (txm *EthTxManager) createTxWithNonceReload(ma *ManagedAccount, to common.Address, data []byte, nrc uint) (*models.Tx, error) {
 	blkNum, err := txm.GetBlockNumber()
 	if err != nil {
 		return nil, err
 	}
 
 	var tx *models.Tx
-	err = txm.activeAccount.GetAndIncrementNonce(func(nonce uint64) error {
+	err = ma.GetAndIncrementNonce(func(nonce uint64) error {
 		tx, err = txm.orm.CreateTx(
-			txm.activeAccount.Address,
+			ma.Address,
 			nonce,
 			to,
 			data,
@@ -77,7 +79,7 @@ func (txm *EthTxManager) createTxWithNonceReload(to common.Address, data []byte,
 			return err
 		}
 
-		logger.Infow(fmt.Sprintf("Created ETH transaction, attempt #: %v", nrc), "from", txm.activeAccount.Address.String(), "to", to.String())
+		logger.Infow(fmt.Sprintf("Created ETH transaction, attempt #: %v", nrc), "from", ma.Address.String(), "to", to.String())
 		gasPrice := txm.config.EthGasPriceDefault
 		var txa *models.TxAttempt
 		txa, err = txm.createAttempt(tx, &gasPrice, blkNum)
@@ -104,12 +106,12 @@ func (txm *EthTxManager) createTxWithNonceReload(to common.Address, data []byte,
 			}
 
 			logger.Warnw("Transaction nonce is too low. Reloading the nonce from the network and reattempting the transaction.")
-			err = txm.ReloadNonce()
+			err = txm.ReloadNonce(ma)
 			if err != nil {
 				return tx, fmt.Errorf("TxManager CreateTX ReloadNonce %v", err)
 			}
 
-			return txm.createTxWithNonceReload(to, data, nrc+1)
+			return txm.createTxWithNonceReload(ma, to, data, nrc+1)
 		}
 	}
 
@@ -183,8 +185,12 @@ func (txm *EthTxManager) createAttempt(
 	gasPrice *big.Int,
 	blkNum uint64,
 ) (*models.TxAttempt, error) {
+	ma := txm.getAccount(tx.From)
+	if ma == nil {
+		return nil, fmt.Errorf("Unable to locate %v as an available account in EthTxManager. Has TxManager been started or has the address been removed?", tx.From.Hex())
+	}
 	etx := tx.EthTx(gasPrice)
-	etx, err := txm.keyStore.SignTx(etx, txm.config.ChainID)
+	etx, err := txm.keyStore.SignTx(ma.Account, etx, txm.config.ChainID)
 	if err != nil {
 		return nil, err
 	}
@@ -239,11 +245,12 @@ func (txm *EthTxManager) checkAttempt(
 // the latest ETH and LINK balances for the active account on the txm, or an
 // error on failure.
 func (txm *EthTxManager) GetETHAndLINKBalances() (*big.Int, *assets.Link, error) {
-	if txm.activeAccount == nil {
+	ma := txm.GetActiveAccount()
+	if ma == nil {
 		return big.NewInt(0), assets.NewLink(0), fmt.Errorf(
 			"Could not find activeAccount for which to report new balances")
 	}
-	address := txm.activeAccount.Account.Address
+	address := ma.Account.Address
 	linkBalance, linkErr := txm.GetLinkBalance(address)
 	ethBalance, ethErr := txm.EthClient.GetWeiBalance(address)
 	merr := multierr.Append(linkErr, ethErr)
@@ -314,41 +321,68 @@ func (txm *EthTxManager) bumpGas(txat *models.TxAttempt, blkNum uint64) error {
 	}
 	gasPrice := new(big.Int).Add(txat.GasPrice, &txm.config.EthGasBumpWei)
 	txat, err := txm.createAttempt(tx, gasPrice, blkNum)
+	if err != nil {
+		return err
+	}
 	logger.Infow(fmt.Sprintf("Bumping gas to %v for transaction %v", gasPrice, txat.Hash.String()), "txat", txat)
-	return err
+	return nil
 }
 
-// GetActiveAccount returns a copy of the TxManager's active nonce managed
-// account.
+// GetActiveAccount uses round robing to select a managed account
+// from the list of available accounts as defined in Start(...)
 func (txm *EthTxManager) GetActiveAccount() *ManagedAccount {
-	if txm.activeAccount == nil {
+	if len(txm.availableAccounts) == 0 {
 		return nil
 	}
-	return &ManagedAccount{
-		Account: txm.activeAccount.Account,
-		nonce:   txm.activeAccount.nonce,
+
+	current := txm.availableAccountIdx
+	txm.availableAccountIdx++
+	if txm.availableAccountIdx >= len(txm.availableAccounts) {
+		txm.availableAccountIdx = 0
 	}
+	return txm.availableAccounts[current]
+}
+
+func (txm *EthTxManager) getAccount(from common.Address) *ManagedAccount {
+	for _, a := range txm.availableAccounts {
+		if a.Address == from {
+			return a
+		}
+	}
+
+	return nil
+}
+
+// Start activates accounts for outgoing transactions and client side
+// nonce management.
+func (txm *EthTxManager) Start(accounts []accounts.Account) error {
+	var merr error
+	for _, a := range accounts {
+		merr = multierr.Append(merr, txm.activateAccount(a))
+	}
+
+	return merr
 }
 
 // ActivateAccount retrieves an account's nonce from the blockchain for client
 // side management in ManagedAccount.
-func (txm *EthTxManager) ActivateAccount(account accounts.Account) error {
+func (txm *EthTxManager) activateAccount(account accounts.Account) error {
 	nonce, err := txm.GetNonce(account.Address)
 	if err != nil {
 		return err
 	}
 
-	txm.activeAccount = &ManagedAccount{Account: account, nonce: nonce}
+	txm.availableAccounts = append(txm.availableAccounts, NewManagedAccount(account, nonce))
 	return nil
 }
 
 // ReloadNonce fetch and update the current nonce via eth_getTransactionCount
-func (txm *EthTxManager) ReloadNonce() error {
-	nonce, err := txm.GetNonce(txm.activeAccount.Address)
+func (txm *EthTxManager) ReloadNonce(ma *ManagedAccount) error {
+	nonce, err := txm.GetNonce(ma.Address)
 	if err != nil {
 		return fmt.Errorf("TxManager ReloadNonce: %v", err)
 	}
-	txm.activeAccount.nonce = nonce
+	ma.nonce = nonce
 	return nil
 }
 
@@ -357,7 +391,13 @@ func (txm *EthTxManager) ReloadNonce() error {
 type ManagedAccount struct {
 	accounts.Account
 	nonce uint64
-	mutex sync.Mutex
+	mutex *sync.Mutex
+}
+
+// NewManagedAccount creates a managed account that handles nonce increments
+// locally.
+func NewManagedAccount(a accounts.Account, nonce uint64) *ManagedAccount {
+	return &ManagedAccount{Account: a, nonce: nonce, mutex: &sync.Mutex{}}
 }
 
 // GetNonce returns the client side managed nonce.

--- a/web/user_controller.go
+++ b/web/user_controller.go
@@ -92,7 +92,7 @@ func (c *UserController) AccountBalances(ctx *gin.Context) {
 	store := c.App.GetStore()
 	txm := store.TxManager
 
-	if account, err := store.KeyStore.GetAccount(); err != nil {
+	if account, err := store.KeyStore.GetFirstAccount(); err != nil {
 		publicError(ctx, 400, err)
 	} else if ethBalance, err := txm.GetEthBalance(account.Address); err != nil {
 		ctx.AbortWithError(500, err)

--- a/web/user_controller_test.go
+++ b/web/user_controller_test.go
@@ -69,7 +69,7 @@ func TestUserController_AccountBalances_Success(t *testing.T) {
 	defer cleanup()
 	assert.Equal(t, 200, resp.StatusCode)
 
-	account, err := appWithAccount.Store.KeyStore.GetAccount()
+	account, err := appWithAccount.Store.KeyStore.GetFirstAccount()
 	assert.NoError(t, err)
 
 	ab := presenters.AccountBalance{}

--- a/web/withdrawals_controller.go
+++ b/web/withdrawals_controller.go
@@ -32,7 +32,7 @@ func (abc *WithdrawalsController) Create(c *gin.Context) {
 		publicError(c, 400, fmt.Errorf("Must withdraw at least %v LINK", naz.String()))
 	} else if wr.Address == utils.ZeroAddress { // address is unmarshalled to ZeroAddres if invalid
 		publicError(c, 400, errors.New("Invalid withdrawal address"))
-	} else if account, err := store.KeyStore.GetAccount(); err != nil {
+	} else if account, err := store.KeyStore.GetFirstAccount(); err != nil {
 		c.AbortWithError(500, err)
 	} else if linkBalance, err := txm.GetLinkBalance(account.Address); err != nil {
 		c.AbortWithError(500, err)

--- a/web/withdrawals_controller_test.go
+++ b/web/withdrawals_controller_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestWithdrawalsController_CreateSuccess(t *testing.T) {
-	config, _ := cltest.NewConfigWithPrivateKey()
+	config, _ := cltest.NewConfig()
 	oca := common.HexToAddress("0xDEADB3333333F")
 	config.OracleContractAddress = &oca
 	app, cleanup := cltest.NewApplicationWithConfigAndKeyStore(config)


### PR DESCRIPTION
This is preliminary support for Chainlink Node to use all accounts in its keys/ folder for outgoing ethereum transactions.

https://www.pivotaltracker.com/story/show/162201560

Withdrawal, Service Agreement signing and Account Balances still only support the first address.