### PR TITLE
Parallel service-agreement tests to those of run-log tests

### DIFF
--- a/internal/cltest/factories.go
+++ b/internal/cltest/factories.go
@@ -89,6 +89,14 @@ func NewJobWithRunLogInitiator() (models.JobSpec, models.Initiator) {
 	return j, j.Initiators[0]
 }
 
+// NewJobWithSALogInitiator creates new JobSpec with the ServiceAgreement
+// initiator
+func NewJobWithSALogInitiator() (models.JobSpec, models.Initiator) {
+	j, initiators := NewJobWithRunLogInitiator()
+	j.Initiators[0].Type = models.InitiatorServiceAgreementExecutionLog
+	return j, initiators
+}
+
 // NewJobWithRunAtInitiator create new Job with RunAt inititaor
 func NewJobWithRunAtInitiator(t time.Time) (models.JobSpec, models.Initiator) {
 	j := NewJob()

--- a/services/subscription.go
+++ b/services/subscription.go
@@ -28,6 +28,14 @@ const (
 	RunLogTopicAmount
 )
 
+// Descriptive indices of a ServiceAgreementExecutionLog's Topic array
+const (
+	ServiceAgreementExecutionLogTopicSignature = iota
+	ServiceAgreementExecutionLogTopicJobID
+	ServiceAgreementExecutionLogTopicRequester
+	ServiceAgreementExecutionLogTopicAmount
+)
+
 // RunLogTopic is the signature for the RunRequest(...) event
 // which Chainlink RunLog initiators watch for.
 // See https://github.com/smartcontractkit/chainlink/blob/master/solidity/contracts/Oracle.sol
@@ -222,7 +230,7 @@ func loggerLogListening(initr models.Initiator, blockNumber *big.Int) {
 // receiveRunOrSALog parses the log and runs the job indicated by a RunLog or
 // ServiceAgreementExecutionLog. (Both log events have the same format.)
 func receiveRunOrSALog(le InitiatorSubscriptionLogEvent) {
-	if !le.ValidateRunLog() {
+	if !le.ValidateRunOrSALog() {
 		return
 	}
 
@@ -388,9 +396,9 @@ func (le InitiatorSubscriptionLogEvent) ToIndexableBlockNumber() *models.Indexab
 	return models.NewIndexableBlockNumber(num, le.Log.BlockHash)
 }
 
-// ValidateRunLog returns whether or not the contained log is a RunLog,
+// ValidateRunOrSALog returns whether or not the contained log is a RunLog,
 // a specific Chainlink event trigger from smart contracts.
-func (le InitiatorSubscriptionLogEvent) ValidateRunLog() bool {
+func (le InitiatorSubscriptionLogEvent) ValidateRunOrSALog() bool {
 	el := le.Log
 	if !isRunLog(el) {
 		logger.Errorw("Skipping; Unable to retrieve runlog parameters from log", le.ForLogger()...)


### PR DESCRIPTION
Addresses story 161963264. Not too interesting, at this stage, because the service-agreement functionality parallels the runlog functionality so closely.