### PR TITLE
Combine externalId and internalId to requestId

### DIFF
--- a/examples/ropsten/contracts/Oracle.sol
+++ b/examples/ropsten/contracts/Oracle.sol
@@ -120,7 +120,7 @@ library SafeMath {
 
 interface OracleInterface {
   function cancel(bytes32 externalId) external;
-  function fulfillData(uint256 internalId, bytes32 data) external returns (bool);
+  function fulfillData(bytes32 requestId, bytes32 data) external returns (bool);
   function getAuthorizationStatus(address node) external view returns (bool);
   function requestData(
     address sender,
@@ -129,7 +129,7 @@ interface OracleInterface {
     bytes32 specId,
     address callbackAddress,
     bytes4 callbackFunctionId,
-    bytes32 externalId,
+    uint256 nonce,
     bytes data
   ) external;
   function setFulfillmentPermission(address node, bool allowed) external;
@@ -162,7 +162,6 @@ contract Oracle is OracleInterface, Ownable {
   LinkTokenInterface internal LINK;
 
   struct Callback {
-    bytes32 externalId;
     uint256 amount;
     address addr;
     bytes4 functionId;
@@ -174,20 +173,20 @@ contract Oracle is OracleInterface, Ownable {
   uint256 constant private oneForConsistentGasCost = 1;
   uint256 private withdrawableWei = oneForConsistentGasCost;
 
-  mapping(uint256 => Callback) private callbacks;
+  mapping(bytes32 => Callback) private callbacks;
   mapping(address => bool) private authorizedNodes;
 
   event RunRequest(
     bytes32 indexed specId,
     address indexed requester,
     uint256 indexed amount,
-    uint256 internalId,
+    bytes32 requestId,
     uint256 version,
     bytes data
   );
 
   event CancelRequest(
-    uint256 internalId
+    bytes32 requestId
   );
 
   constructor(address _link) Ownable() public {
@@ -220,17 +219,16 @@ contract Oracle is OracleInterface, Ownable {
     bytes32 _specId,
     address _callbackAddress,
     bytes4 _callbackFunctionId,
-    bytes32 _externalId,
+    uint256 _nonce,
     bytes _data
   )
     external
     onlyLINK
     checkCallbackAddress(_callbackAddress)
   {
-    uint256 internalId = uint256(keccak256(abi.encodePacked(_sender, _externalId)));
-    require(callbacks[internalId].externalId != _externalId, "Must use a unique ID");
-    callbacks[internalId] = Callback(
-      _externalId,
+    bytes32 requestId = keccak256(abi.encodePacked(_sender, _nonce));
+    require(callbacks[requestId].cancelExpiration == 0, "Must use a unique ID");
+    callbacks[requestId] = Callback(
       _amount,
       _callbackAddress,
       _callbackFunctionId,
@@ -239,27 +237,27 @@ contract Oracle is OracleInterface, Ownable {
       _specId,
       _sender,
       _amount,
-      internalId,
+      requestId,
       _version,
       _data);
   }
 
   function fulfillData(
-    uint256 _internalId,
+    bytes32 _requestId,
     bytes32 _data
   )
     external
     onlyAuthorizedNode
-    hasInternalId(_internalId)
+    isValidRequest(_requestId)
     returns (bool)
   {
-    Callback memory callback = callbacks[_internalId];
+    Callback memory callback = callbacks[_requestId];
     withdrawableWei = withdrawableWei.add(callback.amount);
-    delete callbacks[_internalId];
+    delete callbacks[_requestId];
     // All updates to the oracle's fulfillment should come before calling the
     // callback(addr+functionId) as it is untrusted.
     // See: https://solidity.readthedocs.io/en/develop/security-considerations.html#use-the-checks-effects-interactions-pattern
-    return callback.addr.call(callback.functionId, callback.externalId, _data); // solium-disable-line security/no-low-level-calls
+    return callback.addr.call(callback.functionId, _requestId, _data); // solium-disable-line security/no-low-level-calls
   }
 
   function getAuthorizationStatus(address _node) external view returns (bool) {
@@ -286,13 +284,12 @@ contract Oracle is OracleInterface, Ownable {
   function cancel(bytes32 _externalId)
     external
   {
-    uint256 internalId = uint256(keccak256(abi.encodePacked(msg.sender, _externalId)));
-    require(msg.sender == callbacks[internalId].addr, "Must be called from requester");
-    require(callbacks[internalId].cancelExpiration <= now, "Request is not expired");
-    Callback memory cb = callbacks[internalId];
+    require(msg.sender == callbacks[_requestId].addr, "Must be called from requester");
+    require(callbacks[_requestId].cancelExpiration <= now, "Request is not expired");
+    Callback memory cb = callbacks[_requestId];
     require(LINK.transfer(cb.addr, cb.amount), "Unable to transfer");
-    delete callbacks[internalId];
-    emit CancelRequest(internalId);
+    delete callbacks[_requestId];
+    emit CancelRequest(_requestId);
   }
 
   // MODIFIERS
@@ -302,8 +299,8 @@ contract Oracle is OracleInterface, Ownable {
     _;
   }
 
-  modifier hasInternalId(uint256 _internalId) {
-    require(callbacks[_internalId].addr != address(0), "Must have a valid internalId");
+  modifier isValidRequest(bytes32 _requestId) {
+    require(callbacks[_requestId].addr != address(0), "Must have a valid requestId");
     _;
   }
 

--- a/examples/ropsten/contracts/RopstenConsumer.sol
+++ b/examples/ropsten/contracts/RopstenConsumer.sol
@@ -331,7 +331,7 @@ interface LinkTokenInterface {
 
 interface OracleInterface {
   function cancel(bytes32 externalId) external;
-  function fulfillData(bytes32 requestId, bytes32 data) external returns (bool);
+  function fulfillData(uint256 requestId, bytes32 data) external returns (bool);
   function getAuthorizationStatus(address node) external view returns (bool);
   function requestData(
     address sender,

--- a/examples/uptime_sla/test/UptimeSLA_test.js
+++ b/examples/uptime_sla/test/UptimeSLA_test.js
@@ -70,7 +70,7 @@ contract('UptimeSLA', () => {
     beforeEach(async () => {
       await sla.updateUptime('0')
       const event = await getLatestEvent(oc)
-      requestId = event.args.internalId
+      requestId = event.args.requestId
     })
 
     context("when the value is below 9999", async () => {
@@ -122,7 +122,7 @@ contract('UptimeSLA', () => {
         let args = requestDataBytes(specId, sla.address, fid, "xid", "")
         await requestDataFrom(oc, link, 0, args)
         let event = await getLatestEvent(oc)
-        requestId = event.args.internalId
+        requestId = event.args.requestId
       })
 
       it("does not accept the data provided", async () => {

--- a/solidity/contracts/ChainlinkLib.sol
+++ b/solidity/contracts/ChainlinkLib.sol
@@ -11,7 +11,7 @@ library ChainlinkLib {
     bytes32 specId;
     address callbackAddress;
     bytes4 callbackFunctionId;
-    bytes32 requestId;
+    uint256 nonce;
     Buffer.buffer buf;
   }
 

--- a/solidity/contracts/Coordinator.sol
+++ b/solidity/contracts/Coordinator.sol
@@ -36,7 +36,7 @@ contract Coordinator is CoordinatorInterface {
     bytes32 indexed sAId,
     address indexed requester,
     uint256 indexed amount,
-    bytes32 requestId,
+    uint256 requestId,
     uint256 version,
     bytes data
   );
@@ -90,7 +90,7 @@ contract Coordinator is CoordinatorInterface {
       _sAId,
       _sender,
       _amount,
-      requestId,
+      uint256(requestId),
       _version,
       _data);
   }
@@ -189,21 +189,22 @@ contract Coordinator is CoordinatorInterface {
     _;
   }
 
-  modifier hasInternalId(bytes32 _requestId) {
-    require(callbacks[_requestId].addr != address(0), "Must have a valid internalId");
+  modifier hasInternalId(uint256 _requestId) {
+    require(callbacks[bytes32(_requestId)].addr != address(0), "Must have a valid internalId");
     _;
   }
 
   function fulfillData(
-    bytes32 _requestId,
+    uint256 _requestId,
     bytes32 _data
   )
     public
     hasInternalId(_requestId)
     returns (bool)
   {
-    Callback memory callback = callbacks[_requestId];
-    delete callbacks[_requestId];
+    bytes32 requestId = bytes32(_requestId);
+    Callback memory callback = callbacks[requestId];
+    delete callbacks[requestId];
     // All updates to the oracle's fulfillment should come before calling the
     // callback(addr+functionId) as it is untrusted. See:
     // https://solidity.readthedocs.io/en/develop/security-considerations.html#use-the-checks-effects-interactions-pattern

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -29,7 +29,7 @@ contract Oracle is OracleInterface, Ownable {
     bytes32 indexed specId,
     address indexed requester,
     uint256 indexed amount,
-    bytes32 requestId,
+    uint256 requestId,
     uint256 version,
     bytes data
   );
@@ -86,13 +86,13 @@ contract Oracle is OracleInterface, Ownable {
       _specId,
       _sender,
       _amount,
-      requestId,
+      uint256(requestId),
       _version,
       _data);
   }
 
   function fulfillData(
-    bytes32 _requestId,
+    uint256 _requestId,
     bytes32 _data
   )
     external
@@ -100,13 +100,14 @@ contract Oracle is OracleInterface, Ownable {
     isValidRequest(_requestId)
     returns (bool)
   {
-    Callback memory callback = callbacks[_requestId];
+    bytes32 requestId = bytes32(_requestId);
+    Callback memory callback = callbacks[requestId];
     withdrawableWei = withdrawableWei.add(callback.amount);
-    delete callbacks[_requestId];
+    delete callbacks[requestId];
     // All updates to the oracle's fulfillment should come before calling the
     // callback(addr+functionId) as it is untrusted.
     // See: https://solidity.readthedocs.io/en/develop/security-considerations.html#use-the-checks-effects-interactions-pattern
-    return callback.addr.call(callback.functionId, _requestId, _data); // solium-disable-line security/no-low-level-calls
+    return callback.addr.call(callback.functionId, requestId, _data); // solium-disable-line security/no-low-level-calls
   }
 
   function getAuthorizationStatus(address _node) external view returns (bool) {
@@ -130,7 +131,7 @@ contract Oracle is OracleInterface, Ownable {
     return withdrawableWei.sub(oneForConsistentGasCost);
   }
 
-  function cancel(bytes32 _externalId)
+  function cancel(bytes32 _requestId)
     external
   {
     require(msg.sender == callbacks[_requestId].addr, "Must be called from requester");
@@ -148,8 +149,8 @@ contract Oracle is OracleInterface, Ownable {
     _;
   }
 
-  modifier isValidRequest(bytes32 _requestId) {
-    require(callbacks[_requestId].addr != address(0), "Must have a valid requestId");
+  modifier isValidRequest(uint256 _requestId) {
+    require(callbacks[bytes32(_requestId)].addr != address(0), "Must have a valid requestId");
     _;
   }
 

--- a/solidity/contracts/examples/EmptyOracle.sol
+++ b/solidity/contracts/examples/EmptyOracle.sol
@@ -5,10 +5,10 @@ import "../interfaces/OracleInterface.sol";
 contract EmptyOracle is OracleInterface {
 
   function cancel(bytes32) external {}
-  function fulfillData(uint256, bytes32) external returns (bool) {}
+  function fulfillData(bytes32, bytes32) external returns (bool) {}
   function getAuthorizationStatus(address) external view returns (bool) { return false; }
   function onTokenTransfer(address, uint256, bytes) external pure {}
-  function requestData(address, uint256, uint256, bytes32, address, bytes4, bytes32, bytes) external {}
+  function requestData(address, uint256, uint256, bytes32, address, bytes4, uint256, bytes) external {}
   function setFulfillmentPermission(address, bool) external {}
   function withdraw(address, uint256) external {}
   function withdrawable() external view returns (uint256) {}

--- a/solidity/contracts/examples/EmptyOracle.sol
+++ b/solidity/contracts/examples/EmptyOracle.sol
@@ -5,7 +5,7 @@ import "../interfaces/OracleInterface.sol";
 contract EmptyOracle is OracleInterface {
 
   function cancel(bytes32) external {}
-  function fulfillData(bytes32, bytes32) external returns (bool) {}
+  function fulfillData(uint256, bytes32) external returns (bool) {}
   function getAuthorizationStatus(address) external view returns (bool) { return false; }
   function onTokenTransfer(address, uint256, bytes) external pure {}
   function requestData(address, uint256, uint256, bytes32, address, bytes4, uint256, bytes) external {}

--- a/solidity/contracts/examples/MaliciousChainlinkLib.sol
+++ b/solidity/contracts/examples/MaliciousChainlinkLib.sol
@@ -9,7 +9,7 @@ library MaliciousChainlinkLib {
     bytes32 specId;
     address callbackAddress;
     bytes4 callbackFunctionId;
-    bytes32 requestId;
+    uint256 nonce;
     Buffer.buffer buf;
   }
 
@@ -17,8 +17,7 @@ library MaliciousChainlinkLib {
     bytes32 specId;
     address callbackAddress;
     bytes4 callbackFunctionId;
-    bytes32 requestId;
-    uint256 amount;
+    uint256 nonce;
     Buffer.buffer buf;
   }
 

--- a/solidity/contracts/examples/MaliciousChainlinked.sol
+++ b/solidity/contracts/examples/MaliciousChainlinked.sol
@@ -70,6 +70,21 @@ contract MaliciousChainlinked {
     return requestId;
   }
 
+  function chainlinkTargetRequest(address _target, MaliciousChainlinkLib.Run memory _run, uint256 _amount)
+    internal
+    returns(bytes32 requestId)
+  {
+    requestId = keccak256(abi.encodePacked(_target, requests));
+    _run.nonce = requests;
+    _run.close();
+    unfulfilledRequests[requestId] = oracle;
+    emit ChainlinkRequested(requestId);
+    require(link.transferAndCall(oracle, _amount, encodeForOracle(_run)), "Unable to transferAndCall to oracle");
+    requests += 1;
+
+    return requestId;
+  }
+
   function chainlinkWithdrawRequest(MaliciousChainlinkLib.WithdrawRun memory _run, uint256 _wei)
     internal
     returns(bytes32 requestId)

--- a/solidity/contracts/examples/MaliciousChainlinked.sol
+++ b/solidity/contracts/examples/MaliciousChainlinked.sol
@@ -1,8 +1,11 @@
 pragma solidity 0.4.24;
 
 import "./MaliciousChainlinkLib.sol";
-import "../interfaces/OracleInterface.sol";
+import "../ENSResolver.sol";
+import "../interfaces/ENSInterface.sol";
 import "../interfaces/LinkTokenInterface.sol";
+import "../interfaces/OracleInterface.sol";
+import "../interfaces/CoordinatorInterface.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 contract MaliciousChainlinked {
@@ -10,15 +13,22 @@ contract MaliciousChainlinked {
   using MaliciousChainlinkLib for MaliciousChainlinkLib.WithdrawRun;
   using SafeMath for uint256;
 
-  uint256 constant clArgsVersion = 1;
+  uint256 constant private clArgsVersion = 1;
+  uint256 constant private linkDivisibility = 10**18;
 
-  LinkTokenInterface internal link;
-  OracleInterface internal oracle;
-  uint256 internal requests = 1;
-  mapping(bytes32 => bool) internal unfulfilledRequests;
+  LinkTokenInterface private link;
+  OracleInterface private oracle;
+  uint256 private requests = 1;
+  mapping(bytes32 => address) private unfulfilledRequests;
+
+  ENSInterface private ens;
+  bytes32 private ensNode;
+  bytes32 constant private ensTokenSubname = keccak256("link");
+  bytes32 constant private ensOracleSubname = keccak256("oracle");
 
   event ChainlinkRequested(bytes32 id);
   event ChainlinkFulfilled(bytes32 id);
+  event ChainlinkCancelled(bytes32 id);
 
   function newRun(
     bytes32 _specId,
@@ -38,34 +48,53 @@ contract MaliciousChainlinked {
     return run.initializeWithdraw(_specId, _callbackAddress, _callbackFunction);
   }
 
-  function chainlinkRequest(MaliciousChainlinkLib.Run memory _run, uint256 _wei)
+  function chainlinkRequest(MaliciousChainlinkLib.Run memory _run, uint256 _amount)
     internal
-    returns(bytes32)
+    returns (bytes32)
   {
-    requests += 1;
-    _run.requestId = bytes32(requests);
+    return chainlinkRequestFrom(oracle, _run, _amount);
+  }
+
+  function chainlinkRequestFrom(address _oracle, MaliciousChainlinkLib.Run memory _run, uint256 _amount)
+    internal
+    returns (bytes32 requestId)
+  {
+    requestId = keccak256(abi.encodePacked(this, requests));
+    _run.nonce = requests;
     _run.close();
-    require(link.transferAndCall(oracle, _wei, encodeForOracle(_run)), "Unable to transferAndCall to oracle");
-    emit ChainlinkRequested(_run.requestId);
-    unfulfilledRequests[_run.requestId] = true;
-    return _run.requestId;
+    unfulfilledRequests[requestId] = _oracle;
+    emit ChainlinkRequested(requestId);
+    require(link.transferAndCall(_oracle, _amount, encodeForOracle(_run)), "unable to transferAndCall to oracle");
+    requests += 1;
+
+    return requestId;
   }
 
   function chainlinkWithdrawRequest(MaliciousChainlinkLib.WithdrawRun memory _run, uint256 _wei)
     internal
-    returns(bytes32)
+    returns(bytes32 requestId)
   {
-    requests += 1;
-    _run.requestId = bytes32(requests);
+    requestId = keccak256(abi.encodePacked(this, requests));
+    _run.nonce = requests;
     _run.closeWithdraw();
+    unfulfilledRequests[requestId] = oracle;
+    emit ChainlinkRequested(requestId);
     require(link.transferAndCall(oracle, _wei, encodeWithdrawForOracle(_run)), "Unable to transferAndCall to oracle");
-    emit ChainlinkRequested(_run.requestId);
-    unfulfilledRequests[_run.requestId] = true;
-    return _run.requestId;
+    requests += 1;
+    return requestId;
+  }
+
+  function cancelChainlinkRequest(bytes32 _requestId)
+    internal
+  {
+    OracleInterface requested = OracleInterface(unfulfilledRequests[_requestId]);
+    delete unfulfilledRequests[_requestId];
+    emit ChainlinkCancelled(_requestId);
+    requested.cancel(_requestId);
   }
 
   function LINK(uint256 _amount) internal pure returns (uint256) {
-    return _amount.mul(10**18);
+    return _amount.mul(linkDivisibility);
   }
 
   function setOracle(address _oracle) internal {
@@ -76,18 +105,56 @@ contract MaliciousChainlinked {
     link = LinkTokenInterface(_link);
   }
 
+  function chainlinkToken()
+    internal
+    view
+    returns (address)
+  {
+    return address(link);
+  }
+
+  function oracleAddress()
+    internal
+    view
+    returns (address)
+  {
+    return address(oracle);
+  }
+
+  function newChainlinkWithENS(address _ens, bytes32 _node)
+    internal
+    returns (address, address)
+  {
+    ens = ENSInterface(_ens);
+    ensNode = _node;
+    ENSResolver resolver = ENSResolver(ens.resolver(ensNode));
+    bytes32 linkSubnode = keccak256(abi.encodePacked(ensNode, ensTokenSubname));
+    setLinkToken(resolver.addr(linkSubnode));
+    return (link, updateOracleWithENS());
+  }
+
+  function updateOracleWithENS()
+    internal
+    returns (address)
+  {
+    ENSResolver resolver = ENSResolver(ens.resolver(ensNode));
+    bytes32 oracleSubnode = keccak256(abi.encodePacked(ensNode, ensOracleSubname));
+    setOracle(resolver.addr(oracleSubnode));
+    return oracle;
+  }
+
   function encodeForOracle(MaliciousChainlinkLib.Run memory _run)
     internal view returns (bytes memory)
   {
     return abi.encodeWithSelector(
       oracle.requestData.selector,
-      address(this), // overridden by onTokenTransfer
-      100 ether,     // overridden by onTokenTransfer
+      0, // overridden by onTokenTransfer
+      0, // overridden by onTokenTransfer
       clArgsVersion,
       _run.specId,
       _run.callbackAddress,
       _run.callbackFunctionId,
-      _run.requestId,
+      _run.nonce,
       _run.buf.buf);
   }
 
@@ -96,15 +163,47 @@ contract MaliciousChainlinked {
   {
     return abi.encodeWithSelector(
       oracle.withdraw.selector,
-      _run.callbackAddress,
-      _run.amount,
+      0,
+      0,
       _run.buf.buf);
   }
 
+  function encodeForCoordinator(MaliciousChainlinkLib.Run memory _run)
+    internal
+    view
+    returns (bytes memory)
+  {
+    return abi.encodeWithSelector(
+      CoordinatorInterface(oracle).executeServiceAgreement.selector,
+      0, // overridden by onTokenTransfer
+      0, // overridden by onTokenTransfer
+      clArgsVersion,
+      _run.specId,
+      _run.callbackAddress,
+      _run.callbackFunctionId,
+      _run.nonce,
+      _run.buf.buf);
+  }
+
+  function serviceRequest(MaliciousChainlinkLib.Run memory _run, uint256 _amount)
+    internal
+    returns (bytes32 requestId)
+  {
+    requestId = keccak256(abi.encodePacked(this, requests));
+    _run.nonce = requests;
+    _run.close();
+    unfulfilledRequests[requestId] = oracle;
+    emit ChainlinkRequested(requestId);
+    require(link.transferAndCall(oracle, _amount, encodeForCoordinator(_run)), "unable to transferAndCall to oracle");
+    requests += 1;
+
+    return requestId;
+  }
+
   modifier checkChainlinkFulfillment(bytes32 _requestId) {
-    require(msg.sender == address(oracle) && unfulfilledRequests[_requestId], "Source must be oracle with a valid requestId");
-    _;
-    unfulfilledRequests[_requestId] = false;
+    require(msg.sender == unfulfilledRequests[_requestId], "source must be the oracle of the request");
+    delete unfulfilledRequests[_requestId];
     emit ChainlinkFulfilled(_requestId);
+    _;
   }
 }

--- a/solidity/contracts/examples/MaliciousRequester.sol
+++ b/solidity/contracts/examples/MaliciousRequester.sol
@@ -25,9 +25,13 @@ contract MaliciousRequester is MaliciousChainlinked {
     internal
     returns (bytes32 requestId)
   {
-    MaliciousChainlinkLib.Run memory run = newRun(
-      "specId", this, this.doesNothing.selector);
+    MaliciousChainlinkLib.Run memory run = newRun("specId", this, this.doesNothing.selector);
     requestId = chainlinkRequest(run, LINK(1));
+  }
+
+  function maliciousTargetConsumer(address _target) public returns (bytes32 requestId) {
+    MaliciousChainlinkLib.Run memory run = newRun("specId", _target, bytes4(keccak256("fulfill(bytes32,bytes32)")));
+    requestId = chainlinkTargetRequest(_target, run, LINK(1));
   }
 
   function maliciousRequestCancel() public {

--- a/solidity/contracts/examples/MaliciousRequester.sol
+++ b/solidity/contracts/examples/MaliciousRequester.sol
@@ -18,7 +18,6 @@ contract MaliciousRequester is MaliciousChainlinked {
   {
     MaliciousChainlinkLib.WithdrawRun memory run = newWithdrawRun(
       "specId", this, this.doesNothing.selector);
-    run.amount = link.balanceOf(address(oracle));
     chainlinkWithdrawRequest(run, LINK(1));
   }
 
@@ -32,6 +31,7 @@ contract MaliciousRequester is MaliciousChainlinked {
   }
 
   function maliciousRequestCancel() public {
+    OracleInterface oracle = OracleInterface(oracleAddress());
     oracle.cancel(request());
   }
 

--- a/solidity/contracts/interfaces/CoordinatorInterface.sol
+++ b/solidity/contracts/interfaces/CoordinatorInterface.sol
@@ -8,7 +8,7 @@ interface CoordinatorInterface {
     bytes32 sAId,
     address callbackAddress,
     bytes4 callbackFunctionId,
-    bytes32 externalId,
+    uint256 nonce,
     bytes data
   ) external;
 }

--- a/solidity/contracts/interfaces/OracleInterface.sol
+++ b/solidity/contracts/interfaces/OracleInterface.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.24;
 
 interface OracleInterface {
   function cancel(bytes32 externalId) external;
-  function fulfillData(bytes32 requestId, bytes32 data) external returns (bool);
+  function fulfillData(uint256 requestId, bytes32 data) external returns (bool);
   function getAuthorizationStatus(address node) external view returns (bool);
   function requestData(
     address sender,

--- a/solidity/contracts/interfaces/OracleInterface.sol
+++ b/solidity/contracts/interfaces/OracleInterface.sol
@@ -2,7 +2,7 @@ pragma solidity 0.4.24;
 
 interface OracleInterface {
   function cancel(bytes32 externalId) external;
-  function fulfillData(uint256 internalId, bytes32 data) external returns (bool);
+  function fulfillData(bytes32 requestId, bytes32 data) external returns (bool);
   function getAuthorizationStatus(address node) external view returns (bool);
   function requestData(
     address sender,
@@ -11,7 +11,7 @@ interface OracleInterface {
     bytes32 specId,
     address callbackAddress,
     bytes4 callbackFunctionId,
-    bytes32 externalId,
+    uint256 nonce,
     bytes data
   ) external;
   function setFulfillmentPermission(address node, bool allowed) external;

--- a/solidity/test/BasicConsumer_test.js
+++ b/solidity/test/BasicConsumer_test.js
@@ -77,24 +77,24 @@ contract('BasicConsumer', () => {
 
   describe('#fulfillData', () => {
     let response = '1,000,000.00'
-    let internalId
+    let requestId
 
     beforeEach(async () => {
       await link.transfer(cc.address, web3.toWei('1', 'ether'))
       await cc.requestEthereumPrice(currency)
       let event = await getLatestEvent(oc)
-      internalId = event.args.internalId
+      requestId = event.args.requestId
     })
 
     it('records the data given to it by the oracle', async () => {
-      await oc.fulfillData(internalId, response, {from: oracleNode})
+      await oc.fulfillData(requestId, response, {from: oracleNode})
 
       let currentPrice = await cc.currentPrice.call()
       assert.equal(web3.toUtf8(currentPrice), response)
     })
 
     it('logs the data given to it by the oracle', async () => {
-      let tx = await oc.fulfillData(internalId, response, {from: oracleNode})
+      let tx = await oc.fulfillData(requestId, response, {from: oracleNode})
       assert.equal(2, tx.receipt.logs.length)
       let log = tx.receipt.logs[1]
 
@@ -106,10 +106,10 @@ contract('BasicConsumer', () => {
 
       beforeEach(async () => {
         let funcSig = functionSelector('fulfill(bytes32,bytes32)')
-        let args = requestDataBytes(toHex(specId), cc.address, funcSig, 42, '')
+        let args = requestDataBytes(toHex(specId), cc.address, funcSig, 43, '')
         await requestDataFrom(oc, link, 0, args)
         let event = await getLatestEvent(oc)
-        otherId = event.args.internalId
+        otherId = event.args.requestId
       })
 
       it('does not accept the data provided', async () => {
@@ -123,7 +123,7 @@ contract('BasicConsumer', () => {
     context('when called by anyone other than the oracle contract', () => {
       it('does not accept the data provided', async () => {
         await assertActionThrows(async () => {
-          await cc.fulfill(internalId, response, {from: oracleNode})
+          await cc.fulfill(requestId, response, {from: oracleNode})
         })
 
         let received = await cc.currentPrice.call()
@@ -138,7 +138,8 @@ contract('BasicConsumer', () => {
     beforeEach(async () => {
       await link.transfer(cc.address, web3.toWei('1', 'ether'))
       await cc.requestEthereumPrice(currency)
-      requestId = (await getLatestEvent(cc)).args.id
+      let event = await getLatestEvent(oc)
+      requestId = event.args.requestId
     })
 
     context("before 5 minutes", () => {

--- a/solidity/test/ConcreteChainlinked_test.js
+++ b/solidity/test/ConcreteChainlinked_test.js
@@ -114,7 +114,7 @@ contract('ConcreteChainlinked', () => {
     beforeEach(async () => {
       await cc.publicRequestRun(specId, cc.address, 'fulfillRequest(bytes32,bytes32)', 0)
       requestId = (await getLatestEvent(cc)).args.id
-      internalId = (await getLatestEvent(oc)).args.internalId
+      internalId = (await getLatestEvent(oc)).args.requestId
     })
 
     it('emits an event marking the request cancelled', async () => {

--- a/solidity/test/Coordinator_test.js
+++ b/solidity/test/Coordinator_test.js
@@ -158,7 +158,7 @@ contract('Coordinator', () => {
 
         // If updating this test, be sure to update services.ServiceAgreementExecutionLogTopic.
         // (Which see for the calculation of this hash.)
-        let eventSignature = '0x6d6db1f8fe19d95b1d0fa6a4bce7bb24fbf84597b35a33ff95521fac453c1529'
+        let eventSignature = '0x162abc71bbcd0462b6e89c346f395cff0446e018d1b6edeb6621a9c8d1be7029'
         assert.equal(eventSignature, log.topics[0])
 
         assert.equal(agreement.id, log.topics[1])
@@ -183,7 +183,7 @@ contract('Coordinator', () => {
     context('when not called through the LINK token', () => {
       it('reverts', async () => {
         await assertActionThrows(async () => {
-          await coordinator.executeServiceAgreement(0, 0, 1, agreement.id, to, fHash, 'id', '', { from: consumer })
+          await coordinator.executeServiceAgreement(0, 0, 1, agreement.id, to, fHash, 1, '', { from: consumer })
         })
       })
     })
@@ -191,7 +191,6 @@ contract('Coordinator', () => {
 
   describe('#fulfillData', () => {
     const agreement = newServiceAgreement({oracles: [oracleNode]})
-    const externalId = '17'
 
     let mock, internalId
 
@@ -201,7 +200,7 @@ contract('Coordinator', () => {
       mock = await deploy('examples/GetterSetter.sol')
       const fHash = functionSelector('requestedBytes32(bytes32,bytes32)')
 
-      const payload = executeServiceAgreementBytes(agreement.id, mock.address, fHash, externalId, '')
+      const payload = executeServiceAgreementBytes(agreement.id, mock.address, fHash, 1, '')
       const tx = await link.transferAndCall(coordinator.address, agreement.payment, payload)
       internalId = runRequestId(tx.receipt.logs[2])
     })
@@ -226,7 +225,7 @@ contract('Coordinator', () => {
           await coordinator.fulfillData(internalId, 'Hello World!', { from: oracleNode })
 
           const mockRequestId = await mock.requestId.call()
-          assert.equal(externalId, web3.toUtf8(mockRequestId))
+          assert.equal(internalId, mockRequestId)
 
           const currentValue = await mock.getBytes32.call()
           assert.equal('Hello World!', web3.toUtf8(currentValue))

--- a/solidity/test/Coordinator_test.js
+++ b/solidity/test/Coordinator_test.js
@@ -158,7 +158,7 @@ contract('Coordinator', () => {
 
         // If updating this test, be sure to update services.ServiceAgreementExecutionLogTopic.
         // (Which see for the calculation of this hash.)
-        let eventSignature = '0x162abc71bbcd0462b6e89c346f395cff0446e018d1b6edeb6621a9c8d1be7029'
+        let eventSignature = '0x6d6db1f8fe19d95b1d0fa6a4bce7bb24fbf84597b35a33ff95521fac453c1529'
         assert.equal(eventSignature, log.topics[0])
 
         assert.equal(agreement.id, log.topics[1])

--- a/solidity/test/Oracle_test.js
+++ b/solidity/test/Oracle_test.js
@@ -86,7 +86,7 @@ contract('Oracle', () => {
 
     context('malicious requester', () => {
       let mock
-      const paymentAmount = 1
+      const paymentAmount = web3.toWei('1', 'ether')
 
       beforeEach(async () => {
         mock = await h.deploy('examples/MaliciousRequester.sol', link.address, oc.address)

--- a/solidity/test/Oracle_test.js
+++ b/solidity/test/Oracle_test.js
@@ -168,7 +168,7 @@ contract('Oracle', () => {
 
       it('uses the expected event signature', async () => {
         // If updating this test, be sure to update services.RunLogTopic.
-        let eventSignature = '0x162abc71bbcd0462b6e89c346f395cff0446e018d1b6edeb6621a9c8d1be7029'
+        let eventSignature = '0x6d6db1f8fe19d95b1d0fa6a4bce7bb24fbf84597b35a33ff95521fac453c1529'
         assert.equal(eventSignature, log.topics[0])
       })
 

--- a/solidity/test/ServiceAgreementConsumer_test.js
+++ b/solidity/test/ServiceAgreementConsumer_test.js
@@ -78,7 +78,7 @@ contract('ServiceAgreementConsumer', () => {
       await link.transfer(cc.address, web3.toWei('1', 'ether'))
       await cc.requestEthereumPrice(currency)
       let event = await getLatestEvent(coord)
-      internalId = event.args.internalId
+      internalId = event.args.requestId
     })
 
     it('records the data given to it by the oracle', async () => {
@@ -93,10 +93,10 @@ contract('ServiceAgreementConsumer', () => {
 
       beforeEach(async () => {
         let funcSig = functionSelector('fulfill(bytes32,bytes32)')
-        let args = executeServiceAgreementBytes(agreement.id, cc.address, funcSig, 42, '')
+        let args = executeServiceAgreementBytes(agreement.id, cc.address, funcSig, 1, '')
         await requestDataFrom(coord, link, 0, args)
         let event = await getLatestEvent(coord)
-        otherId = event.args.internalId
+        otherId = event.args.requestId
       })
 
       it('does not accept the data provided', async () => {

--- a/solidity/test/ServiceAgreementConsumer_test.js
+++ b/solidity/test/ServiceAgreementConsumer_test.js
@@ -72,17 +72,17 @@ contract('ServiceAgreementConsumer', () => {
 
   describe('#fulfillData', () => {
     let response = '1,000,000.00'
-    let internalId
+    let requestId
 
     beforeEach(async () => {
       await link.transfer(cc.address, web3.toWei('1', 'ether'))
       await cc.requestEthereumPrice(currency)
       let event = await getLatestEvent(coord)
-      internalId = event.args.requestId
+      requestId = event.args.requestId
     })
 
     it('records the data given to it by the oracle', async () => {
-      await coord.fulfillData(internalId, response, { from: oracleNode })
+      await coord.fulfillData(requestId, response, { from: oracleNode })
 
       let currentPrice = await cc.currentPrice.call()
       assert.equal(web3.toUtf8(currentPrice), response)
@@ -110,7 +110,7 @@ contract('ServiceAgreementConsumer', () => {
     context('when called by anyone other than the oracle contract', () => {
       it('does not accept the data provided', async () => {
         await assertActionThrows(async () => {
-          await cc.fulfill(internalId, response, { from: oracleNode })
+          await cc.fulfill(requestId, response, { from: oracleNode })
         })
         let received = await cc.currentPrice.call()
         assert.equal(web3.toUtf8(received), '')

--- a/solidity/test/UpdatableConsumer_test.js
+++ b/solidity/test/UpdatableConsumer_test.js
@@ -91,7 +91,7 @@ contract('UpdatableConsumer', () => {
       await link.transfer(uc.address, web3.toWei('1', 'ether'))
       await uc.requestEthereumPrice(currency)
       const event = await getLatestEvent(oc)
-      internalId = event.args.internalId
+      internalId = event.args.requestId
 
       const event2 = await getLatestEvent(uc)
       requestId = event2.args.id

--- a/solidity/test/support/helpers.js
+++ b/solidity/test/support/helpers.js
@@ -145,13 +145,13 @@ export const decodeRunABI = log => {
 export const decodeRunRequest = log => {
   let runABI = util.toBuffer(log.data)
   let types = ['uint256', 'uint256', 'bytes']
-  let [internalId, version, data] = abi.rawDecode(types, runABI)
-  return [log.topics[1], log.topics[2], log.topics[3], toHex(internalId), version, data]
+  let [requestId, version, data] = abi.rawDecode(types, runABI)
+  return [log.topics[1], log.topics[2], log.topics[3], toHex(requestId), version, data]
 }
 
 export const runRequestId = log => {
-  var [_, _, _, internalId, _, _] = decodeRunRequest(log) // eslint-disable-line no-unused-vars, no-redeclare
-  return internalId
+  var [_, _, _, requestId, _, _] = decodeRunRequest(log) // eslint-disable-line no-unused-vars, no-redeclare
+  return requestId
 }
 
 export const requestDataBytes = (specId, to, fHash, nonce, data) => {

--- a/solidity/test/support/helpers.js
+++ b/solidity/test/support/helpers.js
@@ -154,11 +154,11 @@ export const runRequestId = log => {
   return internalId
 }
 
-export const requestDataBytes = (specId, to, fHash, runId, data) => {
-  let types = ['address', 'uint256', 'uint256', 'bytes32', 'address', 'bytes4', 'bytes32', 'bytes']
-  let values = [0, 0, 1, specId, to, fHash, runId, data]
+export const requestDataBytes = (specId, to, fHash, nonce, data) => {
+  let types = ['address', 'uint256', 'uint256', 'bytes32', 'address', 'bytes4', 'uint256', 'bytes']
+  let values = [0, 0, 1, specId, to, fHash, nonce, data]
   let encoded = abiEncode(types, values)
-  let funcSelector = functionSelector('requestData(address,uint256,uint256,bytes32,address,bytes4,bytes32,bytes)')
+  let funcSelector = functionSelector('requestData(address,uint256,uint256,bytes32,address,bytes4,uint256,bytes)')
   return funcSelector + encoded
 }
 
@@ -282,11 +282,11 @@ export const personalSign = (account, message) => {
   )
 }
 
-export const executeServiceAgreementBytes = (sAID, to, fHash, runId, data) => {
-  let types = ['address', 'uint256', 'uint256', 'bytes32', 'address', 'bytes4', 'bytes32', 'bytes']
-  let values = [0, 0, 1, sAID, to, fHash, runId, data]
+export const executeServiceAgreementBytes = (sAID, to, fHash, nonce, data) => {
+  let types = ['address', 'uint256', 'uint256', 'bytes32', 'address', 'bytes4', 'uint256', 'bytes']
+  let values = [0, 0, 1, sAID, to, fHash, nonce, data]
   let encoded = abiEncode(types, values)
-  let funcSelector = functionSelector('executeServiceAgreement(address,uint256,uint256,bytes32,address,bytes4,bytes32,bytes)')
+  let funcSelector = functionSelector('executeServiceAgreement(address,uint256,uint256,bytes32,address,bytes4,uint256,bytes)')
   return funcSelector + encoded
 }
 


### PR DESCRIPTION
Merges `uint256 internalId` and `bytes32 externalId` into a single `bytes32 requestId` based on the sender's address and a nonce.

Requester generates `requestId` in Chainlinked by:

```
requestId = keccak256(abi.encodePacked(this, requests));
```

They then pass in the nonce (instead of the externalId) they used (`requests`) to the oracle contract, which stores the Callback as:

```
bytes32 requestId = keccak256(abi.encodePacked(_sender, _nonce));
```

~~Todo~~: done!
- ~~Clean up references to internalId and externalId in tests and be consistent with requestId~~
- ~~Update MaliciousChainlinked/MaliciousChainlinkLib contracts~~
- ~~Update contracts and tests in examples/echo_server and examples/uptime_sla~~
- ~~Chainlink node responds with `bytes32` for requestId instead of `uint256`~~

Invalidates https://github.com/smartcontractkit/chainlink/pull/814