### PR TITLE
HeadTracker#Start does not block until connection:

### DIFF
--- a/services/head_tracker_test.go
+++ b/services/head_tracker_test.go
@@ -105,7 +105,7 @@ func TestHeadTracker_HeadTrackableCallbacks(t *testing.T) {
 	eth.RegisterSubscription("newHeads", headers)
 
 	assert.Nil(t, ht.Start())
-	assert.Equal(t, int32(1), checker.ConnectedCount())
+	g.Eventually(func() int32 { return checker.ConnectedCount() }).Should(gomega.Equal(int32(1)))
 	assert.Equal(t, int32(0), checker.DisconnectedCount())
 	assert.Equal(t, int32(0), checker.OnNewHeadCount())
 
@@ -138,7 +138,7 @@ func TestHeadTracker_ReconnectOnError(t *testing.T) {
 
 	// connect
 	assert.Nil(t, ht.Start())
-	assert.Equal(t, int32(1), checker.ConnectedCount())
+	g.Eventually(func() int32 { return checker.ConnectedCount() }).Should(gomega.Equal(int32(1)))
 	assert.Equal(t, int32(0), checker.DisconnectedCount())
 	assert.Equal(t, int32(0), checker.OnNewHeadCount())
 
@@ -171,7 +171,7 @@ func TestHeadTracker_ReconnectAndStopDoesntDeadlock(t *testing.T) {
 
 	// connect
 	assert.Nil(t, ht.Start())
-	assert.Equal(t, int32(1), checker.ConnectedCount())
+	g.Eventually(func() int32 { return checker.ConnectedCount() }).Should(gomega.Equal(int32(1)))
 	assert.Equal(t, int32(0), checker.DisconnectedCount())
 	assert.Equal(t, int32(0), checker.OnNewHeadCount())
 
@@ -187,6 +187,7 @@ func TestHeadTracker_ReconnectAndStopDoesntDeadlock(t *testing.T) {
 
 func TestHeadTracker_StartConnectsFromLastSavedHeader(t *testing.T) {
 	t.Parallel()
+	g := gomega.NewGomegaWithT(t)
 
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
@@ -206,7 +207,7 @@ func TestHeadTracker_StartConnectsFromLastSavedHeader(t *testing.T) {
 	ht.Attach(checker)
 
 	assert.Nil(t, ht.Start())
-	assert.Equal(t, int32(1), checker.ConnectedCount())
+	g.Eventually(func() int32 { return checker.ConnectedCount() }).Should(gomega.Equal(int32(1)))
 	assert.Equal(t, lastSavedBN, connectedBN)
 	assert.Equal(t, currentBN, ht.Head().ToInt())
 	assert.NoError(t, ht.Stop())

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -21,7 +21,7 @@ type JobSubscriber interface {
 type jobSubscriber struct {
 	store            *store.Store
 	jobSubscriptions []JobSubscription
-	jobsMutex        sync.Mutex
+	jobsMutex        sync.RWMutex
 }
 
 // NewJobSubscriber returns a new job subscriber.
@@ -46,6 +46,8 @@ func (js *jobSubscriber) AddJob(job models.JobSpec, bn *models.IndexableBlockNum
 
 // Jobs returns the jobs being listened to.
 func (js *jobSubscriber) Jobs() []models.JobSpec {
+	js.jobsMutex.RLock()
+	defer js.jobsMutex.RUnlock()
 	var jobs []models.JobSpec
 	for _, js := range js.jobSubscriptions {
 		jobs = append(jobs, js.Job)

--- a/services/job_subscriber_test.go
+++ b/services/job_subscriber_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/onsi/gomega"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/services"
 	strpkg "github.com/smartcontractkit/chainlink/store"
@@ -67,6 +68,7 @@ func TestJobSubscriber_reconnectLoop_Resubscribing(t *testing.T) {
 
 func TestJobSubscriber_AttachedToHeadTracker(t *testing.T) {
 	t.Parallel()
+	g := gomega.NewGomegaWithT(t)
 
 	store, el, cleanup := cltest.NewJobSubscriber()
 	defer cleanup()
@@ -82,7 +84,7 @@ func TestJobSubscriber_AttachedToHeadTracker(t *testing.T) {
 	ht := services.NewHeadTracker(store)
 	assert.Nil(t, ht.Start())
 	id := ht.Attach(el)
-	assert.Equal(t, 2, len(el.Jobs()))
+	g.Eventually(func() int { return len(el.Jobs()) }).Should(gomega.Equal(2))
 	eth.EventuallyAllCalled(t)
 
 	ht.Detach(id)


### PR DESCRIPTION
also fast forward on every reconnect
[Fixes #162323947]

Fixes https://github.com/smartcontractkit/chainlink/issues/731