### PR TITLE
rename and reorganize solidity

### DIFF
--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -14,16 +14,15 @@ contract Chainlinked {
 
   uint256 constant private ARGS_VERSION = 1;
   uint256 constant private LINK_DIVISIBILITY = 10**18;
+  bytes32 constant private ENS_TOKEN_SUBNAME = keccak256("link");
+  bytes32 constant private ENS_ORACLE_SUBNAME = keccak256("oracle");
 
+  ENSInterface private ens;
+  bytes32 private ensNode;
   LinkTokenInterface private link;
   OracleInterface private oracle;
   uint256 private requests = 1;
   mapping(bytes32 => address) private unfulfilledRequests;
-
-  ENSInterface private ens;
-  bytes32 private ensNode;
-  bytes32 constant private ENS_TOKEN_SUBNAME = keccak256("link");
-  bytes32 constant private ENS_ORACLE_SUBNAME = keccak256("oracle");
 
   event ChainlinkRequested(bytes32 id);
   event ChainlinkFulfilled(bytes32 id);

--- a/solidity/contracts/Chainlinked.sol
+++ b/solidity/contracts/Chainlinked.sol
@@ -12,8 +12,8 @@ contract Chainlinked {
   using ChainlinkLib for ChainlinkLib.Run;
   using SafeMath for uint256;
 
-  uint256 constant private clArgsVersion = 1;
-  uint256 constant private linkDivisibility = 10**18;
+  uint256 constant private ARGS_VERSION = 1;
+  uint256 constant private LINK_DIVISIBILITY = 10**18;
 
   LinkTokenInterface private link;
   OracleInterface private oracle;
@@ -22,8 +22,8 @@ contract Chainlinked {
 
   ENSInterface private ens;
   bytes32 private ensNode;
-  bytes32 constant private ensTokenSubname = keccak256("link");
-  bytes32 constant private ensOracleSubname = keccak256("oracle");
+  bytes32 constant private ENS_TOKEN_SUBNAME = keccak256("link");
+  bytes32 constant private ENS_ORACLE_SUBNAME = keccak256("oracle");
 
   event ChainlinkRequested(bytes32 id);
   event ChainlinkFulfilled(bytes32 id);
@@ -70,7 +70,7 @@ contract Chainlinked {
   }
 
   function LINK(uint256 _amount) internal pure returns (uint256) {
-    return _amount.mul(linkDivisibility);
+    return _amount.mul(LINK_DIVISIBILITY);
   }
 
   function setOracle(address _oracle) internal {
@@ -111,7 +111,7 @@ contract Chainlinked {
     ens = ENSInterface(_ens);
     ensNode = _node;
     ENSResolver resolver = ENSResolver(ens.resolver(ensNode));
-    bytes32 linkSubnode = keccak256(abi.encodePacked(ensNode, ensTokenSubname));
+    bytes32 linkSubnode = keccak256(abi.encodePacked(ensNode, ENS_TOKEN_SUBNAME));
     setLinkToken(resolver.addr(linkSubnode));
     return (link, updateOracleWithENS());
   }
@@ -121,7 +121,7 @@ contract Chainlinked {
     returns (address)
   {
     ENSResolver resolver = ENSResolver(ens.resolver(ensNode));
-    bytes32 oracleSubnode = keccak256(abi.encodePacked(ensNode, ensOracleSubname));
+    bytes32 oracleSubnode = keccak256(abi.encodePacked(ensNode, ENS_ORACLE_SUBNAME));
     setOracle(resolver.addr(oracleSubnode));
     return oracle;
   }
@@ -135,7 +135,7 @@ contract Chainlinked {
       oracle.requestData.selector,
       0, // overridden by onTokenTransfer
       0, // overridden by onTokenTransfer
-      clArgsVersion,
+      ARGS_VERSION,
       _run.specId,
       _run.callbackAddress,
       _run.callbackFunctionId,
@@ -152,7 +152,7 @@ contract Chainlinked {
       CoordinatorInterface(oracle).executeServiceAgreement.selector,
       0, // overridden by onTokenTransfer
       0, // overridden by onTokenTransfer
-      clArgsVersion,
+      ARGS_VERSION,
       _run.specId,
       _run.callbackAddress,
       _run.callbackFunctionId,

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -21,6 +21,7 @@ contract Oracle is OracleInterface, Ownable {
   // does not cost more gas.
   uint256 constant private ONE_FOR_CONSISTENT_GAS_COST = 1;
   uint256 constant private MINIMUM_CONSUMER_GAS_LIMIT = 400000;
+  uint256 constant public EXPIRY_TIME = 5 minutes;
   uint256 private withdrawableTokens = ONE_FOR_CONSISTENT_GAS_COST;
 
   mapping(bytes32 => Callback) private callbacks;
@@ -82,7 +83,7 @@ contract Oracle is OracleInterface, Ownable {
       _amount,
       _callbackAddress,
       _callbackFunctionId,
-      uint64(now.add(5 minutes)));
+      uint64(now.add(EXPIRY_TIME)));
     emit RunRequest(
       _specId,
       _sender,

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -105,7 +105,7 @@ contract Oracle is OracleInterface, Ownable {
     Callback memory callback = callbacks[requestId];
     withdrawableWei = withdrawableWei.add(callback.amount);
     delete callbacks[requestId];
-    require(gasleft() >= minimumConsumerGasLimit);
+    require(gasleft() >= minimumConsumerGasLimit, "Must provide consumer enough gas");
     // All updates to the oracle's fulfillment should come before calling the
     // callback(addr+functionId) as it is untrusted.
     // See: https://solidity.readthedocs.io/en/develop/security-considerations.html#use-the-checks-effects-interactions-pattern

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -8,7 +8,11 @@ import "./interfaces/LinkTokenInterface.sol";
 contract Oracle is OracleInterface, Ownable {
   using SafeMath for uint256;
 
-  LinkTokenInterface internal LINK;
+  uint256 constant public EXPIRY_TIME = 5 minutes;
+  uint256 constant private MINIMUM_CONSUMER_GAS_LIMIT = 400000;
+  // We initialize fields to 1 instead of 0 so that the first invocation
+  // does not cost more gas.
+  uint256 constant private ONE_FOR_CONSISTENT_GAS_COST = 1;
 
   struct Callback {
     uint256 amount;
@@ -17,15 +21,10 @@ contract Oracle is OracleInterface, Ownable {
     uint64 cancelExpiration;
   }
 
-  // We initialize fields to 1 instead of 0 so that the first invocation
-  // does not cost more gas.
-  uint256 constant private ONE_FOR_CONSISTENT_GAS_COST = 1;
-  uint256 constant private MINIMUM_CONSUMER_GAS_LIMIT = 400000;
-  uint256 constant public EXPIRY_TIME = 5 minutes;
-  uint256 private withdrawableTokens = ONE_FOR_CONSISTENT_GAS_COST;
-
+  LinkTokenInterface internal LINK;
   mapping(bytes32 => Callback) private callbacks;
   mapping(address => bool) private authorizedNodes;
+  uint256 private withdrawableTokens = ONE_FOR_CONSISTENT_GAS_COST;
 
   event RunRequest(
     bytes32 indexed specId,

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -21,7 +21,7 @@ contract Oracle is OracleInterface, Ownable {
   // does not cost more gas.
   uint256 constant private oneForConsistentGasCost = 1;
   uint256 constant private minimumConsumerGasLimit = 400000;
-  uint256 private withdrawableWei = oneForConsistentGasCost;
+  uint256 private withdrawableTokens = oneForConsistentGasCost;
 
   mapping(bytes32 => Callback) private callbacks;
   mapping(address => bool) private authorizedNodes;
@@ -103,7 +103,7 @@ contract Oracle is OracleInterface, Ownable {
   {
     bytes32 requestId = bytes32(_requestId);
     Callback memory callback = callbacks[requestId];
-    withdrawableWei = withdrawableWei.add(callback.amount);
+    withdrawableTokens = withdrawableTokens.add(callback.amount);
     delete callbacks[requestId];
     require(gasleft() >= minimumConsumerGasLimit, "Must provide consumer enough gas");
     // All updates to the oracle's fulfillment should come before calling the
@@ -125,12 +125,12 @@ contract Oracle is OracleInterface, Ownable {
     onlyOwner
     hasAvailableFunds(_amount)
   {
-    withdrawableWei = withdrawableWei.sub(_amount);
+    withdrawableTokens = withdrawableTokens.sub(_amount);
     require(LINK.transfer(_recipient, _amount), "Failed to transfer LINK");
   }
 
   function withdrawable() external view onlyOwner returns (uint256) {
-    return withdrawableWei.sub(oneForConsistentGasCost);
+    return withdrawableTokens.sub(oneForConsistentGasCost);
   }
 
   function cancel(bytes32 _requestId)
@@ -147,7 +147,7 @@ contract Oracle is OracleInterface, Ownable {
   // MODIFIERS
 
   modifier hasAvailableFunds(uint256 _amount) {
-    require(withdrawableWei >= _amount.add(oneForConsistentGasCost), "Amount requested is greater than withdrawable balance");
+    require(withdrawableTokens >= _amount.add(oneForConsistentGasCost), "Amount requested is greater than withdrawable balance");
     _;
   }
 

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -50,7 +50,7 @@ contract Oracle is OracleInterface, Ownable {
   )
     public
     onlyLINK
-    permittedFunctionsForLINK
+    permittedFunctionsForLINK(_data)
   {
     assembly {
       // solium-disable-next-line security/no-low-level-calls
@@ -166,13 +166,13 @@ contract Oracle is OracleInterface, Ownable {
     _;
   }
 
-  modifier permittedFunctionsForLINK() {
-    bytes4[1] memory funcSelector;
+  modifier permittedFunctionsForLINK(bytes _data) {
+    bytes4 funcSelector;
     assembly {
       // solium-disable-next-line security/no-low-level-calls
-      calldatacopy(funcSelector, 132, 4) // grab function selector from calldata
+      funcSelector := mload(add(_data, 32))
     }
-    require(funcSelector[0] == this.requestData.selector, "Must use whitelisted functions");
+    require(funcSelector == this.requestData.selector, "Must use whitelisted functions");
     _;
   }
 

--- a/solidity/contracts/Oracle.sol
+++ b/solidity/contracts/Oracle.sol
@@ -19,9 +19,9 @@ contract Oracle is OracleInterface, Ownable {
 
   // We initialize fields to 1 instead of 0 so that the first invocation
   // does not cost more gas.
-  uint256 constant private oneForConsistentGasCost = 1;
-  uint256 constant private minimumConsumerGasLimit = 400000;
-  uint256 private withdrawableTokens = oneForConsistentGasCost;
+  uint256 constant private ONE_FOR_CONSISTENT_GAS_COST = 1;
+  uint256 constant private MINIMUM_CONSUMER_GAS_LIMIT = 400000;
+  uint256 private withdrawableTokens = ONE_FOR_CONSISTENT_GAS_COST;
 
   mapping(bytes32 => Callback) private callbacks;
   mapping(address => bool) private authorizedNodes;
@@ -105,7 +105,7 @@ contract Oracle is OracleInterface, Ownable {
     Callback memory callback = callbacks[requestId];
     withdrawableTokens = withdrawableTokens.add(callback.amount);
     delete callbacks[requestId];
-    require(gasleft() >= minimumConsumerGasLimit, "Must provide consumer enough gas");
+    require(gasleft() >= MINIMUM_CONSUMER_GAS_LIMIT, "Must provide consumer enough gas");
     // All updates to the oracle's fulfillment should come before calling the
     // callback(addr+functionId) as it is untrusted.
     // See: https://solidity.readthedocs.io/en/develop/security-considerations.html#use-the-checks-effects-interactions-pattern
@@ -130,7 +130,7 @@ contract Oracle is OracleInterface, Ownable {
   }
 
   function withdrawable() external view onlyOwner returns (uint256) {
-    return withdrawableTokens.sub(oneForConsistentGasCost);
+    return withdrawableTokens.sub(ONE_FOR_CONSISTENT_GAS_COST);
   }
 
   function cancel(bytes32 _requestId)
@@ -147,7 +147,7 @@ contract Oracle is OracleInterface, Ownable {
   // MODIFIERS
 
   modifier hasAvailableFunds(uint256 _amount) {
-    require(withdrawableTokens >= _amount.add(oneForConsistentGasCost), "Amount requested is greater than withdrawable balance");
+    require(withdrawableTokens >= _amount.add(ONE_FOR_CONSISTENT_GAS_COST), "Amount requested is greater than withdrawable balance");
     _;
   }
 

--- a/solidity/test/Oracle_test.js
+++ b/solidity/test/Oracle_test.js
@@ -16,6 +16,7 @@ contract('Oracle', () => {
 
   it('has a limited public interface', () => {
     h.checkPublicABI(artifacts.require(sourcePath), [
+      'EXPIRY_TIME',
       'cancel',
       'fulfillData',
       'getAuthorizationStatus',


### PR DESCRIPTION
Follows best practices for variable naming, groups like variables together, tighten up gas usage.