### PR TITLE
Add a remote attestation report function to the SGX enclave

### DIFF
--- a/internal/ci/sgx_test
+++ b/internal/ci/sgx_test
@@ -12,6 +12,7 @@ libs="$PWD/sgx/target/$ENVIRONMENT"
 cp ./sgx/target/$ENVIRONMENT/enclave.signed.so $tmpdir/
 
 go test -tags=sgx_enclave -ldflags "-r $libs" ./adapters/ -c -o "$tmpdir/adapters.test"
+go test -tags=sgx_enclave -ldflags "-r $libs" ./services/attestation/ -c -o "$tmpdir/attestation.test"
 
 cd $tmpdir
 if [ -n "$USE_GDB" ] && [ "$ENVIRONMENT" == "debug" ]; then
@@ -19,4 +20,5 @@ if [ -n "$USE_GDB" ] && [ "$ENVIRONMENT" == "debug" ]; then
   /opt/sgxsdk/bin/sgx-gdb -ex run --args ./adapters.test -test.parallel 1 -test.v
 else
   ./adapters.test -test.parallel 2 -test.v $@
+  ./attestation.test -test.parallel 2 -test.v $@
 fi

--- a/internal/ci/sgx_test
+++ b/internal/ci/sgx_test
@@ -11,14 +11,16 @@ trap "rm -rf $tmpdir" EXIT HUP TERM INT
 libs="$PWD/sgx/target/$ENVIRONMENT"
 cp ./sgx/target/$ENVIRONMENT/enclave.signed.so $tmpdir/
 
-go test -tags=sgx_enclave -ldflags "-r $libs" ./adapters/ -c -o "$tmpdir/adapters.test"
-go test -tags=sgx_enclave -ldflags "-r $libs" ./services/attestation/ -c -o "$tmpdir/attestation.test"
+for t in ./adapters/ ./services/attestation/; do
+  executable="$(basename $t)"
+  go test -tags=sgx_enclave -ldflags "-r $libs" $t -c -o "$tmpdir/$executable.test"
 
-cd $tmpdir
-if [ -n "$USE_GDB" ] && [ "$ENVIRONMENT" == "debug" ]; then
-  # XXX: The sgx-gdb wrapper script will actually load the symbol table for the enclave
-  /opt/sgxsdk/bin/sgx-gdb -ex run --args ./adapters.test -test.parallel 1 -test.v
-else
-  ./adapters.test -test.parallel 2 -test.v $@
-  ./attestation.test -test.parallel 2 -test.v $@
-fi
+  pushd $tmpdir >/dev/null
+  if [ -n "$USE_GDB" ] && [ "$ENVIRONMENT" == "debug" ]; then
+    # XXX: The sgx-gdb wrapper script will actually load the symbol table for the enclave
+    /opt/sgxsdk/bin/sgx-gdb -ex run --args ./$executable.test -test.parallel 1 -test.v
+  else
+    ./$executable.test -test.parallel 2 -test.v $@
+  fi
+  popd >/dev/null
+done

--- a/services/attestation/attestation.go
+++ b/services/attestation/attestation.go
@@ -1,0 +1,29 @@
+// +build sgx_enclave
+
+package attestation
+
+/*
+#cgo LDFLAGS: -L../../sgx/target/ -ladapters
+#include <stdlib.h>
+#include "../../sgx/libadapters/adapters.h"
+*/
+import "C"
+import (
+	"fmt"
+	"unsafe"
+)
+
+// Report retrieves an enclave attestation report from the attached enclave
+func Report() (string, error) {
+	buffer := make([]byte, 8192)
+	output := (*C.char)(unsafe.Pointer(&buffer[0]))
+	bufferCapacity := C.int(len(buffer))
+	outputLen := C.int(0)
+	outputLenPtr := (*C.int)(unsafe.Pointer(&outputLen))
+
+	if _, err := C.report(output, bufferCapacity, outputLenPtr); err != nil {
+		return "", fmt.Errorf("SGX report: %v", err)
+	}
+
+	return C.GoStringN(output, outputLen), nil
+}

--- a/services/attestation/attestation_test.go
+++ b/services/attestation/attestation_test.go
@@ -1,0 +1,15 @@
+// +build sgx_enclave
+
+package attestation
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestReport(t *testing.T) {
+	result, err := Report()
+	assert.NoError(t, err)
+	assert.Equal(t, `{"report":{"key_id":[255,0,255,0,255,0,255,0,255,0,255,0,255,0,255,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"mac":[167,99,107,85,185,122,149,93,161,30,126,255,36,101,174,248]}}`, result)
+}

--- a/sgx/Makefile
+++ b/sgx/Makefile
@@ -43,7 +43,7 @@ ENCLAVE_RS_INCLUDE := -I$(SGX_SDK)/include -I$(SGX_SDK)/include/tlibc -I$(SGX_SD
 ENCLAVE_RS_LIBS := -L./target/$(ENVIRONMENT) -lcompiler-rt-patch -lenclave
 ENCLAVE_RS_FLAGS := $(SGX_COMMON_CFLAGS) -nostdinc -fvisibility=hidden -fpie -fstack-protector $(ENCLAVE_RS_INCLUDE)
 ENCLAVE_RS_LD_FLAGS := $(SGX_COMMON_CFLAGS) -Wl,--no-undefined -nostdlib -nodefaultlibs -nostartfiles -L$(SGX_LIBRARY_PATH) \
-	-Wl,--whole-archive -l$(TRTS_LIB) -Wl,--no-whole-archive \
+	-Wl,--whole-archive -l$(TRTS_LIB) -l$(SERVICE_LIB) -Wl,--no-whole-archive \
 	-Wl,--start-group -lsgx_tstdc -lsgx_tstdcxx -lsgx_tcrypto $(ENCLAVE_RS_LIBS) -Wl,--end-group \
 	-Wl,-Bstatic -Wl,-Bsymbolic -Wl,--no-undefined \
 	-Wl,-pie,-eenclave_entry -Wl,--export-dynamic \

--- a/sgx/enclave/Cargo.lock
+++ b/sgx/enclave/Cargo.lock
@@ -48,6 +48,7 @@ dependencies = [
  "serde 1.0.71",
  "serde_derive 1.0.71",
  "serde_json 1.0.24",
+ "sgx_tse 1.0.4",
  "sgx_tstd 1.0.4",
  "sgx_types 1.0.4",
  "utils 0.1.0",
@@ -210,6 +211,13 @@ dependencies = [
 
 [[package]]
 name = "sgx_trts"
+version = "1.0.4"
+dependencies = [
+ "sgx_types 1.0.4",
+]
+
+[[package]]
+name = "sgx_tse"
 version = "1.0.4"
 dependencies = [
  "sgx_types 1.0.4",

--- a/sgx/enclave/Cargo.toml
+++ b/sgx/enclave/Cargo.toml
@@ -22,5 +22,6 @@ wabt-core = { path = "/opt/rust-sgx-sdk/third_party/wabt-rs-core" }
 wasmi = { path = "/opt/rust-sgx-sdk/third_party/wasmi" }
 
 [target.'cfg(not(target_env = "sgx"))'.dependencies]
+sgx_tse = { path = "/opt/rust-sgx-sdk/sgx_tse" }
 sgx_tstd = { path = "/opt/rust-sgx-sdk/sgx_tstd" }
 sgx_types = { path = "/opt/rust-sgx-sdk/sgx_types" }

--- a/sgx/enclave/enclave.edl
+++ b/sgx/enclave/enclave.edl
@@ -15,5 +15,8 @@ enclave {
       [in, size=input_len] const uint8_t* input, size_t input_len,
       [out, size=result_capacity] uint8_t* result_ptr, size_t result_capacity,
       [out] size_t *result_len);
+    public sgx_status_t sgx_report(
+      [out, size=result_capacity] uint8_t* result_ptr, size_t result_capacity,
+      [out] size_t *result_len);
   };
 };

--- a/sgx/enclave/src/attestation.rs
+++ b/sgx/enclave/src/attestation.rs
@@ -1,0 +1,9 @@
+use tse;
+use sgx_types::*;
+
+pub fn report() -> Result<sgx_report_t, sgx_status_t> {
+    let target_info = sgx_target_info_t::default();
+    let report_data = sgx_report_data_t::default();
+
+    tse::rsgx_create_report(&target_info, &report_data)
+}

--- a/sgx/libadapters/adapters.h
+++ b/sgx/libadapters/adapters.h
@@ -1,2 +1,3 @@
 void multiply(char *adapter, char *input, char *result, int result_capacity, int *result_len);
 void wasm(char *wasm, char *arguments, char *result, int result_capacity, int *result_len);
+void report(char *result, int result_capacity, int *result_len);

--- a/sgx/libadapters/src/attestation.rs
+++ b/sgx/libadapters/src/attestation.rs
@@ -1,0 +1,51 @@
+use errno::{set_errno, Errno};
+use libc;
+use sgx_types::*;
+
+use use_enclave;
+
+extern "C" {
+    fn sgx_report(
+        eid: sgx_enclave_id_t,
+        retval: *mut sgx_status_t,
+        result_ptr: *mut u8,
+        result_capacity: usize,
+        result_len: *mut usize,
+    ) -> sgx_status_t;
+}
+
+#[no_mangle]
+pub extern "C" fn report(
+    result_ptr: *mut libc::c_char,
+    result_capacity: usize,
+    result_len: *mut usize,
+) {
+    use_enclave(|enclave_id| {
+        let mut retval = sgx_status_t::SGX_SUCCESS;
+        let result = unsafe {
+            sgx_report(
+                enclave_id,
+                &mut retval,
+                result_ptr as *mut u8,
+                result_capacity,
+                result_len as *mut usize,
+            )
+        };
+
+        set_errno(Errno(0));
+        match result {
+            sgx_status_t::SGX_SUCCESS => {}
+            _ => {
+                set_errno(Errno(result as i32));
+                return;
+            }
+        }
+
+        match retval {
+            sgx_status_t::SGX_SUCCESS => {}
+            _ => {
+                set_errno(Errno(result as i32));
+            }
+        }
+    });
+}

--- a/sgx/libadapters/src/lib.rs
+++ b/sgx/libadapters/src/lib.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, Mutex};
 
 pub mod multiply;
 pub mod wasm;
+pub mod attestation;
 
 static ENCLAVE_FILE: &str = "enclave.signed.so";
 


### PR DESCRIPTION
This is just a small part of the puzzle towards remote attestation of the SGX enclave, generating the enclave report to be submitted to the quoting enclave. Nothing is wired up just a small unit test to ensure the call works.