### PR TITLE
SPIKE on using postgres as a backing store

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -322,6 +322,25 @@
   revision = "4f4301a06e153ff90e17793577ab6bf79f8dc5c5"
 
 [[projects]]
+  digest = "1:7d4958827c8f2d9d31e24d9a3a52194eb179f77d854692e57954c516ecf76748"
+  name = "github.com/jinzhu/gorm"
+  packages = [
+    ".",
+    "dialects/postgres",
+  ]
+  pruneopts = ""
+  revision = "472c70caa40267cb89fd8facb07fe6454b578626"
+  version = "v1.9.2"
+
+[[projects]]
+  branch = "master"
+  digest = "1:d9a7385b84d8187fd94e0357045c6fa1147ca94caa56fdd539336c7c102fc728"
+  name = "github.com/jinzhu/inflection"
+  packages = ["."]
+  pruneopts = ""
+  revision = "04140366298a54a039076d798123ffa108fff46c"
+
+[[projects]]
   digest = "1:ef0f9731bc6c3c59396adc50f36da36ca98c704812c449794f9326f7bc64b5f1"
   name = "github.com/jpillora/backoff"
   packages = ["."]
@@ -336,6 +355,18 @@
   pruneopts = ""
   revision = "ca39e5af3ece67bbcda3d0f4f56a8e24d9f2dad4"
   version = "1.1.3"
+
+[[projects]]
+  digest = "1:29145d7af4adafd72a79df5e41456ac9e232d5a28c1cd4dacf3ff008a217fc10"
+  name = "github.com/lib/pq"
+  packages = [
+    ".",
+    "hstore",
+    "oid",
+  ]
+  pruneopts = ""
+  revision = "4ded0e9383f75c197b3a2aaa6d590ac52df6fd79"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -850,7 +881,11 @@
     "github.com/gorilla/securecookie",
     "github.com/gorilla/sessions",
     "github.com/gorilla/websocket",
+    "github.com/jinzhu/gorm",
+    "github.com/jinzhu/gorm/dialects/postgres",
     "github.com/jpillora/backoff",
+    "github.com/lib/pq",
+    "github.com/lib/pq/hstore",
     "github.com/manyminds/api2go/jsonapi",
     "github.com/mitchellh/go-homedir",
     "github.com/mrwonko/cron",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -137,3 +137,11 @@
 [[constraint]]
   name = "github.com/golang/mock"
   version = "1.2.0"
+
+[[constraint]]
+  name = "github.com/jinzhu/gorm"
+  version = "1.9.2"
+
+[[constraint]]
+  name = "github.com/lib/pq"
+  version = "1.0.0"

--- a/services/scheduler.go
+++ b/services/scheduler.go
@@ -172,7 +172,7 @@ func (ot *OneTime) RunJobAt(initr models.Initiator, job models.JobSpec) {
 		if err != nil {
 			logger.Error(err.Error())
 			initr.Ran = false
-			if err := ot.Store.Save(&initr); err != nil {
+			if err := ot.Store.UpdateInitiator(&initr); err != nil {
 				logger.Error(err.Error())
 			}
 		}

--- a/services/scheduler_test.go
+++ b/services/scheduler_test.go
@@ -252,20 +252,20 @@ func TestOneTime_RunJobAt_RunTwice(t *testing.T) {
 	j, _ := cltest.NewJobWithRunAtInitiator(time.Now())
 	assert.Nil(t, store.SaveJob(&j))
 
-	var initrs []models.Initiator
-	store.Where("JobID", j.ID, &initrs)
-
-	ot.RunJobAt(initrs[0], j)
-	j2, err := ot.Store.FindJob(j.ID)
+	initrs, err := store.FindInitiatorsByJobID(j.ID)
 	assert.NoError(t, err)
 
-	var initrs2 []models.Initiator
-	store.Where("JobID", j.ID, &initrs2)
+	ot.RunJobAt(initrs[0], j)
+	j2, err := store.FindJob(j.ID)
+	assert.NoError(t, err)
+
+	initrs2, err := store.FindInitiatorsByJobID(j.ID)
+	assert.NoError(t, err)
 
 	ot.RunJobAt(initrs2[0], j2)
 
-	jobRuns := []models.JobRun{}
-	assert.Nil(t, store.Where("JobID", j.ID, &jobRuns))
+	jobRuns, err := store.FindJobRuns(j.ID)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(jobRuns))
 }
 

--- a/services/subscription.go
+++ b/services/subscription.go
@@ -415,10 +415,10 @@ func (le InitiatorSubscriptionLogEvent) ValidateRunOrSALog() bool {
 }
 
 func (le InitiatorSubscriptionLogEvent) validRequester() bool {
-	if len(le.Initiator.Requesters) == 0 {
+	if len(le.Initiator.Requesters.Addresses) == 0 {
 		return true
 	}
-	for _, r := range le.Initiator.Requesters {
+	for _, r := range le.Initiator.Requesters.Addresses {
 		if le.Requester() == r {
 			return true
 		}

--- a/services/subscription_test.go
+++ b/services/subscription_test.go
@@ -266,7 +266,7 @@ func TestInitiatorSubscriptionLogEvent_ValidateRunOrSALog(t *testing.T) {
 					Log: log,
 					Initiator: models.Initiator{
 						InitiatorParams: models.InitiatorParams{
-							Requesters: test.initiatorRequesters,
+							Requesters: &models.AddressList{Addresses: test.initiatorRequesters},
 						},
 					},
 				}
@@ -318,7 +318,7 @@ func TestStartRunOrSALogSubscription_ValidateSenders(t *testing.T) {
 				assert.NoError(t, app.Start())
 
 				js, initr := logFuncs.jobConstructor()
-				initr.Requesters = []common.Address{requester}
+				initr.Requesters.Addresses = []common.Address{requester}
 				_, err := logFuncs.subscriber(initr, js, nil, app.Store)
 				assert.NoError(t, err)
 

--- a/store/migrations/migrate.go
+++ b/store/migrations/migrate.go
@@ -4,7 +4,6 @@ import (
 	"sort"
 	"sync"
 
-	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/store/migrations/migration0"
 	"github.com/smartcontractkit/chainlink/store/migrations/migration1536696950"
 	"github.com/smartcontractkit/chainlink/store/migrations/migration1536764911"

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -18,7 +18,7 @@ type JobRun struct {
 	JobID          string       `json:"jobId" storm:"index"`
 	Result         RunResult    `json:"result" storm:"inline"`
 	Status         RunStatus    `json:"status" storm:"index"`
-	TaskRuns       []TaskRun    `json:"taskRuns" storm:"inline"`
+	TaskRuns       []TaskRun    `json:"taskRuns" storm:"inline" gorm:"foreignkey:JobRunID"`
 	CreatedAt      time.Time    `json:"createdAt" storm:"index"`
 	CompletedAt    null.Time    `json:"completedAt"`
 	UpdatedAt      time.Time    `json:"updatedAt"`
@@ -120,7 +120,8 @@ func (jr JobRun) MarkCompleted() JobRun {
 // TaskRun stores the Task and represents the status of the
 // Task to be ran.
 type TaskRun struct {
-	ID                   string    `json:"id" storm:"id,unique"`
+	ID                   string `json:"id" storm:"id,unique" gorm:"primary_key;varchar(100)"`
+	JobRunID             string
 	Result               RunResult `json:"result"`
 	Status               RunStatus `json:"status"`
 	Task                 TaskSpec  `json:"task"`


### PR DESCRIPTION
I chose a test that uses some core models, then added a `usePG` flag to
the store, which enables postgres ORM mode.

Run the test as below:

go test -v ./services/ -run TestOneTime_RunJobAt_RunTwice

Changing usePG to false should also still pass.

This is a proof of concept for some of the changes that would need to be
made to adapt postgres under the hood, while still supporting boltDB.