### PR TITLE
Use require in a bunch of tests that panic due to later asserts

### DIFF
--- a/cmd/remote_client_test.go
+++ b/cmd/remote_client_test.go
@@ -46,7 +46,7 @@ func TestClient_GetJobSpecs(t *testing.T) {
 
 	client, r := app.NewClientAndRenderer()
 
-	assert.Nil(t, client.GetJobSpecs(cltest.EmptyCLIContext()))
+	require.Nil(t, client.GetJobSpecs(cltest.EmptyCLIContext()))
 	jobs := *r.Renders[0].(*[]models.JobSpec)
 	assert.Equal(t, 2, len(jobs))
 	assert.Equal(t, j1.ID, jobs[0].ID)
@@ -97,8 +97,8 @@ func TestClient_ShowJobSpec_Exists(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Parse([]string{job.ID})
 	c := cli.NewContext(nil, set, nil)
-	assert.Nil(t, client.ShowJobSpec(c))
-	assert.Equal(t, 1, len(r.Renders))
+	require.Nil(t, client.ShowJobSpec(c))
+	require.Equal(t, 1, len(r.Renders))
 	assert.Equal(t, job.ID, r.Renders[0].(*presenters.JobSpec).ID)
 }
 
@@ -302,9 +302,9 @@ func TestClient_GetBridges(t *testing.T) {
 
 	client, r := app.NewClientAndRenderer()
 
-	assert.Nil(t, client.GetBridges(cltest.EmptyCLIContext()))
+	require.Nil(t, client.GetBridges(cltest.EmptyCLIContext()))
 	bridges := *r.Renders[0].(*[]models.BridgeType)
-	assert.Equal(t, 2, len(bridges))
+	require.Equal(t, 2, len(bridges))
 	assert.Equal(t, bt1.Name, bridges[0].Name)
 }
 
@@ -323,8 +323,8 @@ func TestClient_ShowBridge(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Parse([]string{bt.Name.String()})
 	c := cli.NewContext(nil, set, nil)
-	assert.Nil(t, client.ShowBridge(c))
-	assert.Equal(t, 1, len(r.Renders))
+	require.Nil(t, client.ShowBridge(c))
+	require.Equal(t, 1, len(r.Renders))
 	assert.Equal(t, bt.Name, r.Renders[0].(*models.BridgeType).Name)
 }
 
@@ -343,8 +343,8 @@ func TestClient_RemoveBridge(t *testing.T) {
 	set := flag.NewFlagSet("test", 0)
 	set.Parse([]string{bt.Name.String()})
 	c := cli.NewContext(nil, set, nil)
-	assert.Nil(t, client.RemoveBridge(c))
-	assert.Equal(t, 1, len(r.Renders))
+	require.Nil(t, client.RemoveBridge(c))
+	require.Equal(t, 1, len(r.Renders))
 	assert.Equal(t, bt.Name, r.Renders[0].(*models.BridgeType).Name)
 }
 

--- a/store/config_test.go
+++ b/store/config_test.go
@@ -166,9 +166,9 @@ func TestStore_urlParser(t *testing.T) {
 			if test.wantError {
 				assert.Error(t, err)
 			} else {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				w, ok := i.(models.WebURL)
-				assert.True(t, ok)
+				require.True(t, ok)
 				assert.Equal(t, test.input, w.String())
 			}
 		})

--- a/web/job_runs_controller_test.go
+++ b/web/job_runs_controller_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink/store/presenters"
 	"github.com/smartcontractkit/chainlink/web"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type JobRunsJSON struct {
@@ -396,7 +397,7 @@ func TestJobRunsController_Show_Found(t *testing.T) {
 
 	resp, cleanup := client.Get("/v2/runs/" + jr.ID)
 	defer cleanup()
-	assert.Equal(t, 200, resp.StatusCode, "Response should be successful")
+	require.Equal(t, 200, resp.StatusCode, "Response should be successful")
 
 	var respJobRun presenters.JobRun
 	assert.NoError(t, cltest.ParseJSONAPIResponse(resp, &respJobRun))

--- a/web/sessions_controller_test.go
+++ b/web/sessions_controller_test.go
@@ -48,9 +48,9 @@ func TestSessionsController_Create(t *testing.T) {
 			defer resp.Body.Close()
 
 			if test.wantSession {
-				assert.Equal(t, 200, resp.StatusCode)
+				require.Equal(t, 200, resp.StatusCode)
 				cookies := resp.Cookies()
-				assert.Equal(t, 1, len(cookies))
+				require.Equal(t, 1, len(cookies))
 				decrypted, err := cltest.DecodeSessionCookie(cookies[0].Value)
 				require.NoError(t, err)
 				user, err := app.Store.AuthorizedUserWithSession(decrypted)
@@ -61,7 +61,7 @@ func TestSessionsController_Create(t *testing.T) {
 				assert.NoError(t, err)
 				assert.Equal(t, `{"authenticated":true}`, string(b))
 			} else {
-				assert.True(t, resp.StatusCode >= 400, "Should not be able to create session")
+				require.True(t, resp.StatusCode >= 400, "Should not be able to create session")
 				var sessions []models.Session
 				err = app.Store.All(&sessions)
 				assert.NoError(t, err)

--- a/web/user_controller_test.go
+++ b/web/user_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestUserController_UpdatePassword(t *testing.T) {
@@ -18,7 +19,7 @@ func TestUserController_UpdatePassword(t *testing.T) {
 	resp, cleanup := client.Patch("/v2/user/password", bytes.NewBufferString(""))
 	defer cleanup()
 	errors := cltest.ParseJSONAPIErrors(resp.Body)
-	assert.Equal(t, 422, resp.StatusCode)
+	require.Equal(t, 422, resp.StatusCode)
 	assert.Len(t, errors.Errors, 1)
 
 	// Old password is wrong
@@ -27,7 +28,7 @@ func TestUserController_UpdatePassword(t *testing.T) {
 		bytes.NewBufferString(`{"oldPassword": "wrong password"}`))
 	defer cleanup()
 	errors = cltest.ParseJSONAPIErrors(resp.Body)
-	assert.Equal(t, 409, resp.StatusCode)
+	require.Equal(t, 409, resp.StatusCode)
 	assert.Len(t, errors.Errors, 1)
 	assert.Equal(t, "Old password does not match", errors.Errors[0].Detail)
 
@@ -78,7 +79,7 @@ func TestUserController_AccountBalances_Success(t *testing.T) {
 
 	resp, cleanup := client.Get("/v2/user/balances")
 	defer cleanup()
-	assert.Equal(t, 200, resp.StatusCode)
+	require.Equal(t, 200, resp.StatusCode)
 
 	expectedAccounts := appWithAccount.Store.KeyStore.Accounts()
 	actualBalances := []presenters.AccountBalance{}


### PR DESCRIPTION
While testing configuration changes, a bunch of these tests would panic due to array out of bounds and other invalid assertions. `require` in appropriate places fixes this.