### PR TITLE
Improve BoltDB encapsulation inside orm package

### DIFF
--- a/adapters/adapter_test.go
+++ b/adapters/adapter_test.go
@@ -29,7 +29,7 @@ func TestAdapterFor(t *testing.T) {
 
 	bt := cltest.NewBridgeType("rideShare", "https://dUber.eth")
 	bt.MinimumContractPayment = *assets.NewLink(10)
-	assert.Nil(t, store.Save(&bt))
+	assert.Nil(t, store.SaveBridgeType(&bt))
 
 	cases := []struct {
 		name                   string

--- a/adapters/eth_tx_test.go
+++ b/adapters/eth_tx_test.go
@@ -224,7 +224,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_StillPending(t *testing.T
 
 	from := cltest.GetAccountAddress(store)
 	tx := cltest.NewTx(from, sentAt)
-	assert.Nil(t, store.Save(tx))
+	assert.Nil(t, store.SaveTx(tx))
 	a, err := store.AddAttempt(tx, tx.EthTx(big.NewInt(1)), sentAt)
 	assert.NoError(t, err)
 	adapter := adapters.EthTx{}
@@ -263,7 +263,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_BumpGas(t *testing.T) {
 
 	from := cltest.GetAccountAddress(store)
 	tx := cltest.NewTx(from, sentAt)
-	assert.Nil(t, store.Save(tx))
+	assert.Nil(t, store.SaveTx(tx))
 	a, err := store.AddAttempt(tx, tx.EthTx(big.NewInt(1)), 1)
 	assert.NoError(t, err)
 	adapter := adapters.EthTx{}
@@ -303,7 +303,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_ConfirmCompletes(t *testi
 	require.NoError(t, app.StartAndConnect())
 
 	tx := cltest.NewTx(cltest.NewAddress(), sentAt)
-	assert.Nil(t, store.Save(tx))
+	assert.Nil(t, store.SaveTx(tx))
 	store.AddAttempt(tx, tx.EthTx(big.NewInt(1)), sentAt)
 	store.AddAttempt(tx, tx.EthTx(big.NewInt(2)), sentAt+1)
 	a3, _ := store.AddAttempt(tx, tx.EthTx(big.NewInt(3)), sentAt+2)

--- a/adapters/eth_tx_test.go
+++ b/adapters/eth_tx_test.go
@@ -72,7 +72,7 @@ func TestEthTxAdapter_Perform_Confirmed(t *testing.T) {
 	txs, err := store.TxFrom(from)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(txs))
-	attempts, _ := store.AttemptsFor(txs[0].ID)
+	attempts, _ := store.TxAttemptsFor(txs[0].ID)
 	assert.Equal(t, 1, len(attempts))
 
 	ethMock.EventuallyAllCalled(t)
@@ -137,7 +137,7 @@ func TestEthTxAdapter_Perform_ConfirmedWithBytes(t *testing.T) {
 	txs, err := store.TxFrom(from)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(txs))
-	attempts, _ := store.AttemptsFor(txs[0].ID)
+	attempts, _ := store.TxAttemptsFor(txs[0].ID)
 	assert.Equal(t, 1, len(attempts))
 
 	ethMock.EventuallyAllCalled(t)
@@ -203,7 +203,7 @@ func TestEthTxAdapter_Perform_ConfirmedWithBytesAndNoDataPrefix(t *testing.T) {
 		assert.NoError(t, err)
 		return txs
 	}).Should(gomega.HaveLen(1))
-	attempts, _ := store.AttemptsFor(txs[0].ID)
+	attempts, _ := store.TxAttemptsFor(txs[0].ID)
 	assert.Equal(t, 1, len(attempts))
 
 	ethMock.EventuallyAllCalled(t)
@@ -227,7 +227,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_StillPending(t *testing.T
 	from := cltest.GetAccountAddress(store)
 	tx := cltest.NewTx(from, sentAt)
 	assert.Nil(t, store.SaveTx(tx))
-	a, err := store.AddAttempt(tx, tx.EthTx(big.NewInt(1)), sentAt)
+	a, err := store.AddTxAttempt(tx, tx.EthTx(big.NewInt(1)), sentAt)
 	assert.NoError(t, err)
 	adapter := adapters.EthTx{}
 	sentResult := cltest.RunResultWithValue(a.Hash.String())
@@ -237,8 +237,9 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_StillPending(t *testing.T
 
 	assert.False(t, output.HasError())
 	assert.True(t, output.Status.PendingConfirmations())
-	assert.Nil(t, store.One("ID", tx.ID, tx))
-	attempts, _ := store.AttemptsFor(tx.ID)
+	_, err = store.FindTx(tx.ID)
+	assert.NoError(t, err)
+	attempts, _ := store.TxAttemptsFor(tx.ID)
 	assert.Equal(t, 1, len(attempts))
 
 	ethMock.EventuallyAllCalled(t)
@@ -266,7 +267,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_BumpGas(t *testing.T) {
 	from := cltest.GetAccountAddress(store)
 	tx := cltest.NewTx(from, sentAt)
 	assert.Nil(t, store.SaveTx(tx))
-	a, err := store.AddAttempt(tx, tx.EthTx(big.NewInt(1)), 1)
+	a, err := store.AddTxAttempt(tx, tx.EthTx(big.NewInt(1)), 1)
 	assert.NoError(t, err)
 	adapter := adapters.EthTx{}
 	sentResult := cltest.RunResultWithValue(a.Hash.String())
@@ -276,8 +277,9 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_BumpGas(t *testing.T) {
 
 	assert.False(t, output.HasError())
 	assert.True(t, output.Status.PendingConfirmations())
-	assert.Nil(t, store.One("ID", tx.ID, tx))
-	attempts, _ := store.AttemptsFor(tx.ID)
+	_, err = store.FindTx(tx.ID)
+	assert.NoError(t, err)
+	attempts, _ := store.TxAttemptsFor(tx.ID)
 	assert.Equal(t, 2, len(attempts))
 
 	ethMock.EventuallyAllCalled(t)
@@ -306,9 +308,9 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_ConfirmCompletes(t *testi
 
 	tx := cltest.NewTx(cltest.NewAddress(), sentAt)
 	assert.Nil(t, store.SaveTx(tx))
-	store.AddAttempt(tx, tx.EthTx(big.NewInt(1)), sentAt)
-	store.AddAttempt(tx, tx.EthTx(big.NewInt(2)), sentAt+1)
-	a3, _ := store.AddAttempt(tx, tx.EthTx(big.NewInt(3)), sentAt+2)
+	store.AddTxAttempt(tx, tx.EthTx(big.NewInt(1)), sentAt)
+	store.AddTxAttempt(tx, tx.EthTx(big.NewInt(2)), sentAt+1)
+	a3, _ := store.AddTxAttempt(tx, tx.EthTx(big.NewInt(3)), sentAt+2)
 	adapter := adapters.EthTx{}
 	sentResult := cltest.RunResultWithValue(a3.Hash.String())
 	input := sentResult.MarkPendingConfirmations()
@@ -320,9 +322,10 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_ConfirmCompletes(t *testi
 	assert.True(t, output.Status.Completed())
 	assert.False(t, output.HasError())
 
-	assert.Nil(t, store.One("ID", tx.ID, tx))
+	tx, err := store.FindTx(tx.ID)
+	assert.NoError(t, err)
 	assert.True(t, tx.Confirmed)
-	attempts, _ := store.AttemptsFor(tx.ID)
+	attempts, _ := store.TxAttemptsFor(tx.ID)
 	assert.False(t, attempts[0].Confirmed)
 	assert.True(t, attempts[1].Confirmed)
 	assert.False(t, attempts[2].Confirmed)

--- a/adapters/eth_tx_test.go
+++ b/adapters/eth_tx_test.go
@@ -69,8 +69,8 @@ func TestEthTxAdapter_Perform_Confirmed(t *testing.T) {
 	assert.False(t, data.HasError())
 
 	from := cltest.GetAccountAddress(store)
-	txs := []models.Tx{}
-	assert.Nil(t, store.Where("From", from, &txs))
+	txs, err := store.TxFrom(from)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(txs))
 	attempts, _ := store.AttemptsFor(txs[0].ID)
 	assert.Equal(t, 1, len(attempts))
@@ -134,8 +134,8 @@ func TestEthTxAdapter_Perform_ConfirmedWithBytes(t *testing.T) {
 	assert.False(t, data.HasError())
 
 	from := cltest.GetAccountAddress(store)
-	txs := []models.Tx{}
-	assert.Nil(t, store.Where("From", from, &txs))
+	txs, err := store.TxFrom(from)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(txs))
 	attempts, _ := store.AttemptsFor(txs[0].ID)
 	assert.Equal(t, 1, len(attempts))
@@ -196,9 +196,11 @@ func TestEthTxAdapter_Perform_ConfirmedWithBytesAndNoDataPrefix(t *testing.T) {
 	assert.Equal(t, models.RunStatusCompleted, data.Status)
 
 	from := cltest.GetAccountAddress(store)
-	txs := []models.Tx{}
+	var txs []models.Tx
 	gomega.NewGomegaWithT(t).Eventually(func() []models.Tx {
-		assert.Nil(t, store.Where("From", from, &txs))
+		var err error
+		txs, err = store.TxFrom(from)
+		assert.NoError(t, err)
 		return txs
 	}).Should(gomega.HaveLen(1))
 	attempts, _ := store.AttemptsFor(txs[0].ID)

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -348,7 +348,7 @@ func (t *promptingAPIInitializer) Initialize(store *store.Store) (models.User, e
 			fmt.Println("Error creating API user: ", err)
 			continue
 		}
-		if err = store.Save(&user); err != nil {
+		if err = store.SaveUser(&user); err != nil {
 			fmt.Println("Error creating API user: ", err)
 		}
 		return user, err
@@ -379,7 +379,7 @@ func (f fileAPIInitializer) Initialize(store *store.Store) (models.User, error) 
 	if err != nil {
 		return user, err
 	}
-	return user, store.Save(&user)
+	return user, store.SaveUser(&user)
 }
 
 var errNoCredentialFile = errors.New("No API user credential file was passed")

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -149,7 +149,7 @@ func TestTerminalAPIInitializer_InitializeWithExistingAPIUser(t *testing.T) {
 	defer cleanup()
 
 	initialUser := cltest.MustUser(cltest.APIEmail, cltest.Password)
-	require.NoError(t, store.Save(&initialUser))
+	require.NoError(t, store.SaveUser(&initialUser))
 
 	mock := &cltest.MockCountingPrompter{}
 	tai := cmd.NewPromptingAPIInitializer(mock)
@@ -197,7 +197,7 @@ func TestFileAPIInitializer_InitializeWithExistingAPIUser(t *testing.T) {
 	defer cleanup()
 
 	initialUser := cltest.MustUser(cltest.APIEmail, cltest.Password)
-	require.NoError(t, store.Save(&initialUser))
+	require.NoError(t, store.SaveUser(&initialUser))
 
 	tests := []struct {
 		name      string

--- a/cmd/prompter.go
+++ b/cmd/prompter.go
@@ -37,7 +37,7 @@ func (tp terminalPrompter) Prompt(prompt string) string {
 		logger.Fatal(err)
 	}
 	clearLine()
-	return strings.TrimSpace(string(line))
+	return strings.TrimSpace(line)
 }
 
 // PasswordPrompt displays the prompt for the user to enter the password and

--- a/cmd/remote_client_test.go
+++ b/cmd/remote_client_test.go
@@ -557,5 +557,8 @@ func TestClient_GetTxAttempts(t *testing.T) {
 	set.Int("page", 2, "doc")
 	c = cli.NewContext(nil, set, nil)
 	require.Equal(t, 2, c.Int("page"))
-	assert.Error(t, client.GetTxAttempts(c))
+	assert.NoError(t, client.GetTxAttempts(c))
+
+	renderedAttempts = *r.Renders[1].(*[]models.TxAttempt)
+	assert.Equal(t, 0, len(renderedAttempts))
 }

--- a/cmd/remote_client_test.go
+++ b/cmd/remote_client_test.go
@@ -536,7 +536,7 @@ func TestClient_GetTxAttempts(t *testing.T) {
 	store := app.GetStore()
 	from := cltest.GetAccountAddress(store)
 	tx := cltest.CreateTxAndAttempt(store, from, 1)
-	attempts, err := store.AttemptsFor(tx.ID)
+	attempts, err := store.TxAttemptsFor(tx.ID)
 	require.NoError(t, err)
 
 	client, r := app.NewClientAndRenderer()

--- a/integration/features_test.go
+++ b/integration/features_test.go
@@ -597,7 +597,7 @@ func TestIntegration_BulkDeleteRuns(t *testing.T) {
 		return task.Status == "completed"
 	}).Should(gomega.BeTrue())
 
-	runCount, err := app.Store.Count(&models.JobRun{})
+	runCount, err := app.Store.JobRunsCount()
 	assert.NoError(t, err)
 	assert.Equal(t, 0, runCount)
 }

--- a/integration/features_test.go
+++ b/integration/features_test.go
@@ -573,7 +573,7 @@ func TestIntegration_BulkDeleteRuns(t *testing.T) {
 	completedRun := job.NewRun(initiator)
 	completedRun.Status = models.RunStatusCompleted
 	completedRun.UpdatedAt = cltest.ParseISO8601("2018-11-02T10:14:18Z")
-	err := app.GetStore().ORM.Save(&completedRun)
+	err := app.GetStore().ORM.DB.Save(&completedRun)
 	assert.NoError(t, err)
 
 	client := app.NewHTTPClient()

--- a/integration/features_test.go
+++ b/integration/features_test.go
@@ -34,8 +34,7 @@ func TestIntegration_Scheduler(t *testing.T) {
 
 	cltest.WaitForRuns(t, j, app.Store, 1)
 
-	var initr models.Initiator
-	app.Store.One("JobID", j.ID, &initr)
+	initr := j.Initiators[0]
 	assert.Equal(t, models.InitiatorCron, initr.Type)
 	assert.Equal(t, "* * * * *", string(initr.Schedule), "Wrong cron schedule saved")
 }
@@ -133,8 +132,7 @@ func TestIntegration_RunAt(t *testing.T) {
 
 	j := cltest.FixtureCreateJobViaWeb(t, app, "../internal/fixtures/web/run_at_job.json")
 
-	var initr models.Initiator
-	app.Store.One("JobID", j.ID, &initr)
+	initr := j.Initiators[0]
 	assert.Equal(t, models.InitiatorRunAt, initr.Type)
 	assert.Equal(t, "2018-01-08T18:12:01Z", initr.Time.ISO8601())
 
@@ -158,8 +156,7 @@ func TestIntegration_EthLog(t *testing.T) {
 	j := cltest.FixtureCreateJobViaWeb(t, app, "../internal/fixtures/web/eth_log_job.json")
 	address := common.HexToAddress("0x3cCad4715152693fE3BC4460591e3D3Fbd071b42")
 
-	var initr models.Initiator
-	app.Store.One("JobID", j.ID, &initr)
+	initr := j.Initiators[0]
 	assert.Equal(t, models.InitiatorEthLog, initr.Type)
 	assert.Equal(t, address, initr.Address)
 
@@ -185,8 +182,7 @@ func TestIntegration_RunLog(t *testing.T) {
 	j := cltest.FixtureCreateJobViaWeb(t, app, "../internal/fixtures/web/runlog_noop_job.json")
 	requiredConfs := 100
 
-	var initr models.Initiator
-	app.Store.One("JobID", j.ID, &initr)
+	initr := j.Initiators[0]
 	assert.Equal(t, models.InitiatorRunLog, initr.Type)
 
 	logBlockNumber := 1
@@ -292,7 +288,7 @@ func TestIntegration_ExternalAdapter_RunLogInitiated(t *testing.T) {
 	cltest.WaitForJobRunToPendConfirmations(t, app.Store, jr)
 
 	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(logBlockNumber + 9)}
-	cltest.WaitForJobRunToComplete(t, app.Store, jr)
+	jr = cltest.WaitForJobRunToComplete(t, app.Store, jr)
 
 	tr := jr.TaskRuns[0]
 	assert.Equal(t, "randomnumber", tr.Task.Type.String())
@@ -505,11 +501,9 @@ func TestIntegration_NonceManagement_firstRunWithExistingTXs(t *testing.T) {
 		txHashString, err := jr.Result.Value()
 		txHash := common.HexToHash(txHashString)
 		assert.NoError(t, err)
-		attempt := &models.TxAttempt{}
-		err = app.Store.One("Hash", txHash, attempt)
+		attempt, err := app.Store.FindTxAttempt(txHash)
 		assert.NoError(t, err)
-		var tx models.Tx
-		err = app.Store.One("ID", attempt.TxID, &tx)
+		tx, err := app.Store.FindTx(attempt.TxID)
 		assert.NoError(t, err)
 		assert.Equal(t, expectedNonce, tx.Nonce)
 	}

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -261,9 +261,9 @@ func (ta *TestApplication) Stop() error {
 
 func (ta *TestApplication) MustSeedUserSession() models.User {
 	mockUser := MustUser(APIEmail, Password)
-	mustNotErr(ta.Store.Save(&mockUser))
+	mustNotErr(ta.Store.SaveUser(&mockUser))
 	session := NewSession(APISessionID)
-	mustNotErr(ta.Store.Save(&session))
+	mustNotErr(ta.Store.SaveSession(&session))
 	return mockUser
 }
 

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -642,7 +642,8 @@ func UpdateJobRunViaWeb(
 
 	AssertServerResponse(t, resp, 200)
 	jrID := ParseCommonJSON(resp.Body).ID
-	assert.Nil(t, app.Store.One("ID", jrID, &jr))
+	jr, err = app.Store.FindJobRun(jrID)
+	assert.NoError(t, err)
 	return jr
 }
 
@@ -701,8 +702,10 @@ func WaitForJobRunStatus(
 	status models.RunStatus,
 ) models.JobRun {
 	t.Helper()
+	var err error
 	gomega.NewGomegaWithT(t).Eventually(func() models.RunStatus {
-		assert.Nil(t, store.One("ID", jr.ID, &jr))
+		jr, err = store.FindJobRun(jr.ID)
+		assert.NoError(t, err)
 		return jr.Status
 	}).Should(gomega.Equal(status))
 	return jr
@@ -716,8 +719,10 @@ func JobRunStays(
 	status models.RunStatus,
 ) models.JobRun {
 	t.Helper()
+	var err error
 	gomega.NewGomegaWithT(t).Consistently(func() models.RunStatus {
-		assert.Nil(t, store.One("ID", jr.ID, &jr))
+		jr, err = store.FindJobRun(jr.ID)
+		assert.NoError(t, err)
 		return jr.Status
 	}).Should(gomega.Equal(status))
 	return jr

--- a/internal/cltest/factories.go
+++ b/internal/cltest/factories.go
@@ -128,7 +128,7 @@ func CreateTxAndAttempt(
 	sentAt uint64,
 ) *models.Tx {
 	tx := NewTx(from, sentAt)
-	mustNotErr(store.Save(tx))
+	mustNotErr(store.SaveTx(tx))
 	_, err := store.AddAttempt(tx, tx.EthTx(big.NewInt(1)), sentAt)
 	mustNotErr(err)
 	return tx

--- a/internal/cltest/factories.go
+++ b/internal/cltest/factories.go
@@ -129,7 +129,7 @@ func CreateTxAndAttempt(
 ) *models.Tx {
 	tx := NewTx(from, sentAt)
 	mustNotErr(store.SaveTx(tx))
-	_, err := store.AddAttempt(tx, tx.EthTx(big.NewInt(1)), sentAt)
+	_, err := store.AddTxAttempt(tx, tx.EthTx(big.NewInt(1)), sentAt)
 	mustNotErr(err)
 	return tx
 }

--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -569,7 +569,7 @@ func (m *MockAPIInitializer) Initialize(store *store.Store) (models.User, error)
 	}
 	m.Count += 1
 	user := MustUser(APIEmail, Password)
-	return user, store.Save(&user)
+	return user, store.SaveUser(&user)
 }
 
 func NewMockAuthenticatedHTTPClient(cfg store.Config) cmd.HTTPClient {

--- a/services/application.go
+++ b/services/application.go
@@ -163,7 +163,7 @@ func (app *ChainlinkApplication) AddAdapter(bt *models.BridgeType) error {
 		return models.NewValidationError(err.Error())
 	}
 
-	if err := store.Save(bt); err != nil {
+	if err := store.SaveBridgeType(bt); err != nil {
 		return models.NewDatabaseAccessError(err.Error())
 	}
 

--- a/services/bulk_run_deleter.go
+++ b/services/bulk_run_deleter.go
@@ -51,7 +51,7 @@ func RunPendingTask(orm *orm.ORM, task *models.BulkDeleteRunTask) error {
 	} else {
 		task.Status = models.BulkTaskStatusCompleted
 	}
-	return orm.Save(task)
+	return orm.DB.Save(task)
 }
 
 // DeleteJobRuns removes runs that match a query

--- a/services/bulk_run_deleter.go
+++ b/services/bulk_run_deleter.go
@@ -3,7 +3,6 @@ package services
 import (
 	"fmt"
 
-	"github.com/asdine/storm"
 	"github.com/asdine/storm/q"
 	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/store"
@@ -38,7 +37,7 @@ func (btr *bulkRunDeleter) Work() {
 		}
 		return err
 	})
-	if err != nil && err != storm.ErrNotFound {
+	if err != nil && err != orm.ErrorNotFound {
 		logger.Errorw("Error querying bulk tasks", "error", err)
 	}
 }

--- a/services/bulk_run_deleter.go
+++ b/services/bulk_run_deleter.go
@@ -22,7 +22,7 @@ type bulkRunDeleter struct {
 }
 
 func (btr *bulkRunDeleter) Work() {
-	query := btr.store.Select(q.Eq("Status", models.BulkTaskStatusInProgress)).OrderBy("CreatedAt")
+	query := btr.store.ORM.DB.Select(q.Eq("Status", models.BulkTaskStatusInProgress)).OrderBy("CreatedAt")
 	err := query.Each(&models.BulkDeleteRunTask{}, func(r interface{}) error {
 		task := r.(*models.BulkDeleteRunTask)
 		logger.Infow("Processing bulk run delete task",
@@ -56,7 +56,7 @@ func RunPendingTask(orm *orm.ORM, task *models.BulkDeleteRunTask) error {
 
 // DeleteJobRuns removes runs that match a query
 func DeleteJobRuns(orm *orm.ORM, bulkQuery *models.BulkDeleteRunRequest) error {
-	query := orm.Select(
+	query := orm.DB.Select(
 		q.And(
 			q.In("Status", bulkQuery.Status),
 			q.Lt("UpdatedAt", bulkQuery.UpdatedBefore),

--- a/services/bulk_run_deleter_test.go
+++ b/services/bulk_run_deleter_test.go
@@ -19,28 +19,28 @@ func TestDeleteJobRuns(t *testing.T) {
 	oldIncompleteRun := job.NewRun(initiator)
 	oldIncompleteRun.Status = models.RunStatusInProgress
 	oldIncompleteRun.UpdatedAt = cltest.ParseISO8601("2018-01-01T00:00:00Z")
-	err := store.Save(&oldIncompleteRun)
+	err := store.ORM.DB.Save(&oldIncompleteRun)
 	assert.NoError(t, err)
 
 	// matches one of the statuses and the updated before
 	oldCompletedRun := job.NewRun(initiator)
 	oldCompletedRun.Status = models.RunStatusCompleted
 	oldCompletedRun.UpdatedAt = cltest.ParseISO8601("2018-01-01T00:00:00Z")
-	err = store.Save(&oldCompletedRun)
+	err = store.ORM.DB.Save(&oldCompletedRun)
 	assert.NoError(t, err)
 
 	// matches one of the statuses but not the updated before
 	newCompletedRun := job.NewRun(initiator)
 	newCompletedRun.Status = models.RunStatusCompleted
 	newCompletedRun.UpdatedAt = cltest.ParseISO8601("2018-01-30T00:00:00Z")
-	err = store.ORM.Save(&newCompletedRun)
+	err = store.ORM.DB.Save(&newCompletedRun)
 	assert.NoError(t, err)
 
 	// matches nothing
 	newIncompleteRun := job.NewRun(initiator)
 	newIncompleteRun.Status = models.RunStatusCompleted
 	newIncompleteRun.UpdatedAt = cltest.ParseISO8601("2018-01-30T00:00:00Z")
-	err = store.ORM.Save(&newIncompleteRun)
+	err = store.ORM.DB.Save(&newIncompleteRun)
 	assert.NoError(t, err)
 
 	err = services.DeleteJobRuns(store.ORM, &models.BulkDeleteRunRequest{
@@ -48,7 +48,7 @@ func TestDeleteJobRuns(t *testing.T) {
 		UpdatedBefore: cltest.ParseISO8601("2018-01-15T00:00:00Z"),
 	})
 
-	runCount, err := store.Count(&models.JobRun{})
+	runCount, err := store.ORM.DB.Count(&models.JobRun{})
 	assert.NoError(t, err)
 	assert.Equal(t, 3, runCount)
 }

--- a/services/head_tracker.go
+++ b/services/head_tracker.go
@@ -112,7 +112,7 @@ func (ht *HeadTracker) Save(n *models.IndexableBlockNumber) error {
 		ht.head = &copy
 	}
 	ht.headMutex.Unlock()
-	return ht.store.Save(n)
+	return ht.store.SaveHead(n)
 }
 
 // Head returns the latest block header being tracked, or nil.

--- a/services/head_tracker.go
+++ b/services/head_tracker.go
@@ -6,12 +6,12 @@ import (
 	"sync"
 	"time"
 
-	"github.com/asdine/storm"
 	uuid "github.com/satori/go.uuid"
 	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/store"
 	strpkg "github.com/smartcontractkit/chainlink/store"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/orm"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/tevino/abool"
@@ -267,7 +267,7 @@ func (ht *HeadTracker) fastForwardHeadFromEth() {
 func (ht *HeadTracker) updateHeadFromDb() error {
 	numbers := []models.IndexableBlockNumber{}
 	err := ht.store.Select().OrderBy("Digits", "Number").Limit(1).Reverse().Find(&numbers)
-	if err != nil && err != storm.ErrNotFound {
+	if err != nil && err != orm.ErrorNotFound {
 		return err
 	}
 	if len(numbers) > 0 {

--- a/services/head_tracker.go
+++ b/services/head_tracker.go
@@ -11,7 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink/store"
 	strpkg "github.com/smartcontractkit/chainlink/store"
 	"github.com/smartcontractkit/chainlink/store/models"
-	"github.com/smartcontractkit/chainlink/store/orm"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/tevino/abool"
@@ -265,16 +264,13 @@ func (ht *HeadTracker) fastForwardHeadFromEth() {
 }
 
 func (ht *HeadTracker) updateHeadFromDb() error {
-	numbers := []models.IndexableBlockNumber{}
-	err := ht.store.Select().OrderBy("Digits", "Number").Limit(1).Reverse().Find(&numbers)
-	if err != nil && err != orm.ErrorNotFound {
+	number, err := ht.store.LastHead()
+	if err != nil {
 		return err
 	}
-	if len(numbers) > 0 {
-		ht.headMutex.Lock()
-		ht.head = &numbers[0]
-		ht.headMutex.Unlock()
-	}
+	ht.headMutex.Lock()
+	ht.head = number
+	ht.headMutex.Unlock()
 	return nil
 }
 

--- a/services/head_tracker_test.go
+++ b/services/head_tracker_test.go
@@ -21,10 +21,10 @@ func TestHeadTracker_New(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 	cltest.MockEthOnStore(store)
-	assert.Nil(t, store.Save(cltest.IndexableBlockNumber(1)))
+	assert.Nil(t, store.SaveHead(cltest.IndexableBlockNumber(1)))
 	last := cltest.IndexableBlockNumber(16)
-	assert.Nil(t, store.Save(last))
-	assert.Nil(t, store.Save(cltest.IndexableBlockNumber(10)))
+	assert.Nil(t, store.SaveHead(last))
+	assert.Nil(t, store.SaveHead(cltest.IndexableBlockNumber(10)))
 
 	ht := services.NewHeadTracker(store)
 	assert.Nil(t, ht.Start())
@@ -56,7 +56,7 @@ func TestHeadTracker_Get(t *testing.T) {
 			defer cleanup()
 			cltest.MockEthOnStore(store)
 			if test.initial != nil {
-				assert.Nil(t, store.Save(test.initial))
+				assert.Nil(t, store.SaveHead(test.initial))
 			}
 
 			ht := services.NewHeadTracker(store)

--- a/services/job_runner_test.go
+++ b/services/job_runner_test.go
@@ -25,7 +25,7 @@ func TestJobRunner_resumeRunsSinceLastShutdown(t *testing.T) {
 	j.Initiators = []models.Initiator{i}
 	json := fmt.Sprintf(`{"until":"%v"}`, utils.ISO8601UTC(time.Now().Add(time.Second)))
 	j.Tasks = []models.TaskSpec{cltest.NewTask("sleep", json)}
-	assert.NoError(t, store.Save(&j))
+	assert.NoError(t, store.SaveJob(&j))
 
 	sleepingRun := j.NewRun(i)
 	sleepingRun.Status = models.RunStatusPendingSleep

--- a/services/job_runner_test.go
+++ b/services/job_runner_test.go
@@ -30,11 +30,11 @@ func TestJobRunner_resumeRunsSinceLastShutdown(t *testing.T) {
 	sleepingRun := j.NewRun(i)
 	sleepingRun.Status = models.RunStatusPendingSleep
 	sleepingRun.TaskRuns[0].Status = models.RunStatusPendingSleep
-	assert.NoError(t, store.Save(&sleepingRun))
+	assert.NoError(t, store.SaveJobRun(&sleepingRun))
 
 	inProgressRun := j.NewRun(i)
 	inProgressRun.Status = models.RunStatusInProgress
-	assert.NoError(t, store.Save(&inProgressRun))
+	assert.NoError(t, store.SaveJobRun(&inProgressRun))
 
 	assert.NoError(t, services.ExportedResumeRunsSinceLastShutdown(rm))
 	messages := []string{}
@@ -84,7 +84,7 @@ func TestJobRunner_ChannelForRun_sendAfterClosing(t *testing.T) {
 	j, initr := cltest.NewJobWithWebInitiator()
 	assert.NoError(t, s.SaveJob(&j))
 	jr := j.NewRun(initr)
-	assert.NoError(t, s.Save(&jr))
+	assert.NoError(t, s.SaveJobRun(&jr))
 
 	chan1 := services.ExportedChannelForRun(rm, jr.ID)
 	chan1 <- struct{}{}
@@ -111,7 +111,7 @@ func TestJobRunner_ChannelForRun_equalityWithoutClosing(t *testing.T) {
 	j.Tasks = []models.TaskSpec{cltest.NewTask("nooppend")}
 	assert.NoError(t, s.SaveJob(&j))
 	jr := j.NewRun(initr)
-	assert.NoError(t, s.Save(&jr))
+	assert.NoError(t, s.SaveJobRun(&jr))
 
 	chan1 := services.ExportedChannelForRun(rm, jr.ID)
 

--- a/services/job_subscriber_test.go
+++ b/services/job_subscriber_test.go
@@ -176,7 +176,7 @@ func TestJobSubscriber_OnNewHead_OnlyResumePendingConfirmations(t *testing.T) {
 			job, initr := cltest.NewJobWithWebInitiator()
 			run := job.NewRun(initr)
 			run = run.ApplyResult(models.RunResult{Status: test.status})
-			assert.Nil(t, store.Save(&run))
+			assert.Nil(t, store.SaveJobRun(&run))
 
 			js.OnNewHead(block)
 			if test.wantSend {

--- a/services/reaper.go
+++ b/services/reaper.go
@@ -3,10 +3,10 @@ package services
 import (
 	"time"
 
-	"github.com/asdine/storm"
 	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/store"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/orm"
 )
 
 type storeReaper struct {
@@ -27,7 +27,7 @@ func (sr *storeReaper) Work() {
 	offset := time.Now().Add(-sr.config.ReaperExpiration()).Add(-sr.config.SessionTimeout())
 	stale := models.Time{offset}
 	err := sr.store.Range("LastUsed", models.Time{}, stale, &sessions)
-	if err != nil && err != storm.ErrNotFound {
+	if err != nil && err != orm.ErrorNotFound {
 		logger.Error("unable to reap stale sessions: ", err)
 		return
 	}

--- a/services/reaper.go
+++ b/services/reaper.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/store"
-	"github.com/smartcontractkit/chainlink/store/models"
-	"github.com/smartcontractkit/chainlink/store/orm"
 )
 
 type storeReaper struct {
@@ -23,19 +21,9 @@ func NewStoreReaper(store *store.Store) SleeperTask {
 }
 
 func (sr *storeReaper) Work() {
-	var sessions []models.Session
 	offset := time.Now().Add(-sr.config.ReaperExpiration()).Add(-sr.config.SessionTimeout())
-	stale := models.Time{offset}
-	err := sr.store.Range("LastUsed", models.Time{}, stale, &sessions)
-	if err != nil && err != orm.ErrorNotFound {
+	err := sr.store.DeleteStaleSessions(offset)
+	if err != nil {
 		logger.Error("unable to reap stale sessions: ", err)
-		return
-	}
-
-	for _, s := range sessions {
-		err := sr.store.DeleteStruct(&s)
-		if err != nil {
-			logger.Error("unable to delete stale session: ", err)
-		}
 	}
 }

--- a/services/reaper_test.go
+++ b/services/reaper_test.go
@@ -39,7 +39,7 @@ func TestStoreReaper_ReapSessions(t *testing.T) {
 
 			session := cltest.NewSession(test.name)
 			session.LastUsed = models.Time{test.lastUsed}
-			require.NoError(t, store.Save(&session))
+			require.NoError(t, store.SaveSession(&session))
 
 			r.WakeUp()
 

--- a/services/reaper_test.go
+++ b/services/reaper_test.go
@@ -45,14 +45,14 @@ func TestStoreReaper_ReapSessions(t *testing.T) {
 
 			if test.wantReap {
 				gomega.NewGomegaWithT(t).Eventually(func() []models.Session {
-					sessions := []models.Session{}
-					assert.Nil(t, store.All(&sessions))
+					sessions, err := store.Sessions(0, 10)
+					assert.NoError(t, err)
 					return sessions
 				}).Should(gomega.HaveLen(0))
 			} else {
 				gomega.NewGomegaWithT(t).Consistently(func() []models.Session {
-					sessions := []models.Session{}
-					assert.Nil(t, store.All(&sessions))
+					sessions, err := store.Sessions(0, 10)
+					assert.NoError(t, err)
 					return sessions
 				}).Should(gomega.HaveLen(1))
 			}

--- a/services/runs_test.go
+++ b/services/runs_test.go
@@ -26,7 +26,7 @@ func TestNewRun(t *testing.T) {
 
 	bt := cltest.NewBridgeType("timecube", "http://http://timecube.2enp.com/")
 	bt.MinimumContractPayment = *assets.NewLink(10)
-	assert.Nil(t, store.Save(&bt))
+	assert.Nil(t, store.SaveBridgeType(&bt))
 
 	creationHeight := cltest.BigHexInt(1000)
 
@@ -54,7 +54,7 @@ func TestNewRun_requiredPayment(t *testing.T) {
 
 	bt := cltest.NewBridgeType("timecube", "http://http://timecube.2enp.com/")
 	bt.MinimumContractPayment = *assets.NewLink(10)
-	assert.Nil(t, store.Save(&bt))
+	assert.Nil(t, store.SaveBridgeType(&bt))
 
 	tests := []struct {
 		name           string

--- a/services/scheduler.go
+++ b/services/scheduler.go
@@ -172,7 +172,7 @@ func (ot *OneTime) RunJobAt(initr models.Initiator, job models.JobSpec) {
 		if err != nil {
 			logger.Error(err.Error())
 			initr.Ran = false
-			if err := ot.Store.Save(&initr); err != nil {
+			if err := ot.Store.SaveInitiator(&initr); err != nil {
 				logger.Error(err.Error())
 			}
 		}

--- a/services/scheduler_test.go
+++ b/services/scheduler_test.go
@@ -58,7 +58,7 @@ func TestScheduler_Start_AddingUnstartedJob(t *testing.T) {
 	startAt := cltest.ParseISO8601("3000-01-01T00:00:00.000Z")
 	j, _ := cltest.NewJobWithSchedule("* * * * *")
 	j.StartAt = cltest.NullableTime(startAt)
-	assert.Nil(t, store.Save(&j))
+	assert.Nil(t, store.SaveJob(&j))
 
 	sched := services.NewScheduler(store)
 	defer sched.Stop()

--- a/services/scheduler_test.go
+++ b/services/scheduler_test.go
@@ -250,19 +250,12 @@ func TestOneTime_RunJobAt_RunTwice(t *testing.T) {
 	}
 
 	j, _ := cltest.NewJobWithRunAtInitiator(time.Now())
-	assert.Nil(t, store.SaveJob(&j))
+	assert.NoError(t, store.SaveJob(&j))
+	ot.RunJobAt(j.Initiators[0], j)
 
-	var initrs []models.Initiator
-	store.Where("JobID", j.ID, &initrs)
-
-	ot.RunJobAt(initrs[0], j)
 	j2, err := ot.Store.FindJob(j.ID)
 	assert.NoError(t, err)
-
-	var initrs2 []models.Initiator
-	store.Where("JobID", j.ID, &initrs2)
-
-	ot.RunJobAt(initrs2[0], j2)
+	ot.RunJobAt(j2.Initiators[0], j2)
 
 	jobRuns, err := store.JobRunsFor(j.ID)
 	assert.NoError(t, err)
@@ -282,12 +275,11 @@ func TestOneTime_RunJobAt_UnstartedRun(t *testing.T) {
 
 	j, _ := cltest.NewJobWithRunAtInitiator(time.Now())
 	j.EndAt = cltest.NullTime("2000-01-01T00:10:00.000Z")
-	assert.Nil(t, store.SaveJob(&j))
+	assert.NoError(t, store.SaveJob(&j))
 
 	ot.RunJobAt(j.Initiators[0], j)
 
-	var initrs2 []models.Initiator
-	store.Where("JobID", j.ID, &initrs2)
-
-	assert.Equal(t, false, initrs2[0].Ran)
+	j2, err := store.FindJob(j.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, false, j2.Initiators[0].Ran)
 }

--- a/services/scheduler_test.go
+++ b/services/scheduler_test.go
@@ -117,8 +117,8 @@ func TestRecurring_AddJob(t *testing.T) {
 			assert.Equal(t, test.wantEntries, len(cron.Entries))
 
 			cron.RunEntries()
-			jobRuns := []models.JobRun{}
-			assert.Nil(t, store.Where("JobID", j.ID, &jobRuns))
+			jobRuns, err := store.JobRunsFor(j.ID)
+			assert.NoError(t, err)
 			assert.Equal(t, test.wantRuns, len(jobRuns))
 		})
 	}
@@ -167,9 +167,9 @@ func TestOneTime_AddJob(t *testing.T) {
 			ot.AddJob(j)
 
 			gomega.NewGomegaWithT(t).Eventually(func() bool {
-				jobRuns := []models.JobRun{}
 				completed := false
-				assert.Nil(t, store.Where("JobID", j.ID, &jobRuns))
+				jobRuns, err := store.JobRunsFor(j.ID)
+				assert.NoError(t, err)
 				if (len(jobRuns) > 0) && (jobRuns[0].Status == models.RunStatusCompleted) {
 					completed = true
 				}
@@ -204,8 +204,8 @@ func TestOneTime_RunJobAt_StopJobBeforeExecution(t *testing.T) {
 	gomega.NewGomegaWithT(t).Eventually(func() bool {
 		return finished.IsSet()
 	}).Should(gomega.Equal(true))
-	jobRuns := []models.JobRun{}
-	assert.Nil(t, store.Where("JobID", j.ID, &jobRuns))
+	jobRuns, err := store.JobRunsFor(j.ID)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, len(jobRuns))
 }
 
@@ -233,8 +233,8 @@ func TestOneTime_RunJobAt_ExecuteLateJob(t *testing.T) {
 	gomega.NewGomegaWithT(t).Eventually(func() bool {
 		return finished.IsSet()
 	}).Should(gomega.Equal(true))
-	jobRuns := []models.JobRun{}
-	assert.Nil(t, store.Where("JobID", j.ID, &jobRuns))
+	jobRuns, err := store.JobRunsFor(j.ID)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(jobRuns))
 }
 
@@ -264,8 +264,8 @@ func TestOneTime_RunJobAt_RunTwice(t *testing.T) {
 
 	ot.RunJobAt(initrs2[0], j2)
 
-	jobRuns := []models.JobRun{}
-	assert.Nil(t, store.Where("JobID", j.ID, &jobRuns))
+	jobRuns, err := store.JobRunsFor(j.ID)
+	assert.NoError(t, err)
 	assert.Equal(t, 1, len(jobRuns))
 }
 

--- a/services/subscription_test.go
+++ b/services/subscription_test.go
@@ -12,6 +12,7 @@ import (
 	strpkg "github.com/smartcontractkit/chainlink/store"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestInitiatorSubscriptionLogEvent_RunLogJSON(t *testing.T) {
@@ -326,9 +327,9 @@ func TestStartRunOrSALogSubscription_ValidateSenders(t *testing.T) {
 				eth.EventuallyAllCalled(t)
 
 				gomega.NewGomegaWithT(t).Eventually(func() models.RunStatus {
-					var run models.JobRun
-					app.Store.One("JobID", js.ID, &run)
-					return run.Status
+					runs, err := app.Store.JobRunsFor(js.ID)
+					require.NoError(t, err)
+					return runs[0].Status
 				}).Should(gomega.Equal(test.status))
 			})
 		}

--- a/services/validators_test.go
+++ b/services/validators_test.go
@@ -73,10 +73,10 @@ func TestValidateAdapter(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 
-	tt := models.BridgeType{}
-	tt.Name = models.MustNewTaskType("solargridreporting")
-	tt.URL = cltest.WebURL("https://denergy.eth")
-	assert.NoError(t, store.Save(&tt))
+	bt := models.BridgeType{}
+	bt.Name = models.MustNewTaskType("solargridreporting")
+	bt.URL = cltest.WebURL("https://denergy.eth")
+	assert.NoError(t, store.SaveBridgeType(&bt))
 
 	tests := []struct {
 		description string

--- a/store/forms/update_bridge_type.go
+++ b/store/forms/update_bridge_type.go
@@ -45,7 +45,7 @@ func (ubt UpdateBridgeType) Save() error {
 	bt.URL = ubt.URL
 	bt.Confirmations = ubt.Confirmations
 	bt.MinimumContractPayment = ubt.MinimumContractPayment
-	return ubt.store.Save(&bt)
+	return ubt.store.SaveBridgeType(&bt)
 }
 
 // Marshal encodes the bridge with the JSON-API presenter

--- a/store/forms/update_bridge_type_test.go
+++ b/store/forms/update_bridge_type_test.go
@@ -3,10 +3,10 @@ package forms_test
 import (
 	"testing"
 
-	"github.com/asdine/storm"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/store/forms"
+	"github.com/smartcontractkit/chainlink/store/orm"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -20,7 +20,7 @@ func TestFormsNewUpdateBridgeType(t *testing.T) {
 	assert.Nil(t, s.Save(&bt))
 
 	_, err := forms.NewUpdateBridgeType(s, "idontexist")
-	assert.Equal(t, err, storm.ErrNotFound)
+	assert.Equal(t, err, orm.ErrorNotFound)
 
 	_, err = forms.NewUpdateBridgeType(s, "bridgea")
 	assert.NoError(t, err)

--- a/store/forms/update_bridge_type_test.go
+++ b/store/forms/update_bridge_type_test.go
@@ -17,7 +17,7 @@ func TestFormsNewUpdateBridgeType(t *testing.T) {
 	defer cleanup()
 
 	bt := cltest.NewBridgeType("bridgea")
-	assert.Nil(t, s.Save(&bt))
+	assert.Nil(t, s.SaveBridgeType(&bt))
 
 	_, err := forms.NewUpdateBridgeType(s, "idontexist")
 	assert.Equal(t, err, orm.ErrorNotFound)
@@ -33,7 +33,7 @@ func TestFormsUpdateBridgeType_Save(t *testing.T) {
 	defer cleanup()
 
 	bt := cltest.NewBridgeType("bridgea", "http://bridge")
-	assert.Nil(t, s.Save(&bt))
+	assert.Nil(t, s.SaveBridgeType(&bt))
 
 	form, err := forms.NewUpdateBridgeType(s, "bridgea")
 	assert.NoError(t, err)

--- a/store/migrations/migrate.go
+++ b/store/migrations/migrate.go
@@ -57,7 +57,7 @@ func Migrate(orm *orm.ORM) error {
 			if err != nil {
 				return err
 			}
-			err = orm.Save(&MigrationTimestamp{ts})
+			err = orm.DB.Save(&MigrationTimestamp{ts})
 			if err != nil {
 				return err
 			}

--- a/store/migrations/migration1536696950/migrate_test.go
+++ b/store/migrations/migration1536696950/migrate_test.go
@@ -31,7 +31,7 @@ func TestMigrate1536696950_MigrateRunResultAmount1536521223(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 
-	require.NoError(t, store.Save(&jr))
+	require.NoError(t, store.ORM.DB.Save(&jr))
 
 	migration := migration1536696950.Migration{}
 	require.NoError(t, migration.Migrate(store.ORM))
@@ -50,7 +50,7 @@ func TestMigrate1536696950_MigrateRunResultAmount1536521223_asString(t *testing.
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 
-	require.NoError(t, store.Save(&jr))
+	require.NoError(t, store.ORM.DB.Save(&jr))
 
 	migration := migration1536696950.Migration{}
 	require.NoError(t, migration.Migrate(store.ORM))

--- a/store/migrations/migration1536764911/migrate_test.go
+++ b/store/migrations/migration1536764911/migrate_test.go
@@ -35,7 +35,7 @@ func TestMigrate1536764911_JobRun(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 
-	require.NoError(t, store.Save(&jr))
+	require.NoError(t, store.ORM.DB.Save(&jr))
 
 	migration := migration1536764911.Migration{}
 	require.NoError(t, migration.Migrate(store.ORM))

--- a/store/migrations/migration1537223654/migrate_test.go
+++ b/store/migrations/migration1537223654/migrate_test.go
@@ -20,7 +20,7 @@ func TestMigrate1537223654_updatesJobSpecsBucket(t *testing.T) {
 	input := cltest.LoadJSON("../../../internal/fixtures/migrations/1537223654_job_without_initiator_params.json")
 	var js1 old.JobSpec
 	require.NoError(t, json.Unmarshal(input, &js1))
-	require.NoError(t, store.Save(&js1))
+	require.NoError(t, store.ORM.DB.Save(&js1))
 
 	migration := migration1537223654.Migration{}
 	require.NoError(t, migration.Migrate(store.ORM))
@@ -40,7 +40,7 @@ func TestMigrate1537223654_updatesInitiatorsBucket(t *testing.T) {
 	input := cltest.LoadJSON("../../../internal/fixtures/migrations/1537223654_initiator_without_params.json")
 	var i1 old.Initiator
 	require.NoError(t, json.Unmarshal(input, &i1))
-	require.NoError(t, store.Save(&i1))
+	require.NoError(t, store.ORM.DB.Save(&i1))
 
 	migration := migration1537223654.Migration{}
 	require.NoError(t, migration.Migrate(store.ORM))
@@ -61,7 +61,7 @@ func TestMigrate1537223654_updatesJobRunsBucket(t *testing.T) {
 	input := cltest.LoadJSON("../../../internal/fixtures/migrations/1537223654_jobrun_without_initiator_params.json")
 	var jr1 old.JobRun
 	require.NoError(t, json.Unmarshal(input, &jr1))
-	require.NoError(t, store.Save(&jr1))
+	require.NoError(t, store.ORM.DB.Save(&jr1))
 
 	migration := migration1537223654.Migration{}
 	require.NoError(t, migration.Migrate(store.ORM))

--- a/store/models/address.go
+++ b/store/models/address.go
@@ -60,5 +60,5 @@ func (a *EIP55Address) UnmarshalText(input []byte) error {
 // UnmarshalJSON parses a hash from a JSON string
 func (a *EIP55Address) UnmarshalJSON(input []byte) error {
 	input = utils.RemoveQuotes(input)
-	return a.UnmarshalText([]byte(input))
+	return a.UnmarshalText(input)
 }

--- a/store/models/eth.go
+++ b/store/models/eth.go
@@ -106,7 +106,7 @@ func (f *FunctionSelector) UnmarshalJSON(input []byte) error {
 		return err
 	}
 
-	if utils.HasHexPrefix(string(s)) {
+	if utils.HasHexPrefix(s) {
 		bytes := common.FromHex(s)
 		if len(bytes) != FunctionSelectorLength {
 			return errors.New("Function ID must be 4 bytes in length")

--- a/store/models/job_spec_test.go
+++ b/store/models/job_spec_test.go
@@ -19,7 +19,6 @@ func TestJobSpec_Save(t *testing.T) {
 	j1, initr := cltest.NewJobWithSchedule("* * * * 7")
 	assert.NoError(t, store.SaveJob(&j1))
 
-	store.Save(j1)
 	j2, err := store.FindJob(j1.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, initr.Schedule, j2.Initiators[0].Schedule)

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -23,7 +23,7 @@ func TestJobRuns_RetrievingFromDBWithError(t *testing.T) {
 	job, initr := cltest.NewJobWithWebInitiator()
 	jr := job.NewRun(initr)
 	jr.Result = cltest.RunResultWithError(fmt.Errorf("bad idea"))
-	err := store.Save(&jr)
+	err := store.SaveJobRun(&jr)
 	assert.NoError(t, err)
 
 	run := &models.JobRun{}
@@ -50,7 +50,7 @@ func TestJobRun_NextTaskRun(t *testing.T) {
 	}
 	assert.NoError(t, store.SaveJob(&job))
 	run := job.NewRun(initiator)
-	assert.NoError(t, store.Save(&run))
+	assert.NoError(t, store.SaveJobRun(&run))
 	assert.Equal(t, &run.TaskRuns[0], run.NextTaskRun())
 
 	store.RunChannel.Send(run.ID)

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -26,8 +26,7 @@ func TestJobRuns_RetrievingFromDBWithError(t *testing.T) {
 	err := store.SaveJobRun(&jr)
 	assert.NoError(t, err)
 
-	run := &models.JobRun{}
-	err = store.One("ID", jr.ID, run)
+	run, err := store.FindJobRun(jr.ID)
 	assert.NoError(t, err)
 	assert.True(t, run.Result.HasError())
 	assert.Equal(t, "bad idea", run.Result.Error())
@@ -56,7 +55,8 @@ func TestJobRun_NextTaskRun(t *testing.T) {
 	store.RunChannel.Send(run.ID)
 	cltest.WaitForJobRunStatus(t, store, run, models.RunStatusPendingConfirmations)
 
-	store.One("ID", run.ID, &run)
+	run, err := store.FindJobRun(run.ID)
+	assert.NoError(t, err)
 	assert.Equal(t, &run.TaskRuns[1], run.NextTaskRun())
 }
 

--- a/store/models/signature.go
+++ b/store/models/signature.go
@@ -75,7 +75,7 @@ func (s Signature) MarshalText() ([]byte, error) {
 // UnmarshalJSON parses a signature from a JSON string
 func (s *Signature) UnmarshalJSON(input []byte) error {
 	input = utils.RemoveQuotes(input)
-	return s.UnmarshalText([]byte(input))
+	return s.UnmarshalText(input)
 }
 
 // MarshalJSON prints the signature as a hexadecimal encoded string

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -638,3 +638,8 @@ func (orm *ORM) SaveUser(user *models.User) error {
 func (orm *ORM) SaveSession(session *models.Session) error {
 	return orm.Save(session)
 }
+
+// SaveBridgeType saves the bridge type.
+func (orm *ORM) SaveBridgeType(bt *models.BridgeType) error {
+	return orm.Save(bt)
+}

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -520,3 +520,20 @@ func underlyingBucketType(bucket interface{}) reflect.Type {
 	elemType := sliceType.Elem()
 	return elemType
 }
+
+func (orm *ORM) ClearNonCurrentSessions(sessionID string) error {
+	var sessions []models.Session
+	err := orm.Select(q.Not(q.Eq("ID", sessionID))).Find(&sessions)
+	if err != nil && err != ErrorNotFound {
+		return err
+	}
+
+	for _, s := range sessions {
+		err := orm.DeleteStruct(&s)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -582,9 +582,14 @@ func (orm *ORM) GetTxAttempts(offset int, limit int) ([]models.TxAttempt, int, e
 	return attempts, count, err
 }
 
+// JobRunsCount returns the total number of job runs
+func (orm *ORM) JobRunsCount() (int, error) {
+	return orm.Count(&models.JobRun{})
+}
+
 // SortedJobRuns returns job runs ordered and filtered by the passed params.
 func (orm *ORM) SortedJobRuns(order SortType, offset int, limit int) ([]models.JobRun, int, error) {
-	count, err := orm.Count(&models.JobRun{})
+	count, err := orm.JobRunsCount()
 	if err != nil {
 		return nil, 0, err
 	}

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -565,3 +565,15 @@ func (orm *ORM) SortedJobs(order SortType, offset int, limit int) ([]models.JobS
 	err := orm.AllByIndex("CreatedAt", &jobs, stormOrder, stormOffset, stormLimit)
 	return jobs, err
 }
+
+// GetTxAttempts returns the last tx attempts sorted by sent at descending.
+func (orm *ORM) GetTxAttempts(offset int, limit int) ([]models.TxAttempt, int, error) {
+	var attempts []models.TxAttempt
+	count, err := orm.Count(&models.TxAttempt{})
+	if err != nil {
+		return nil, 0, err
+	}
+	query := orm.Select().OrderBy("SentAt").Reverse().Limit(limit).Skip(offset)
+	err = query.Find(&attempts)
+	return attempts, count, err
+}

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -559,9 +559,9 @@ func stormOrder(st SortType) func(*index.Options) {
 	return so
 }
 
-// SortedJobs returns many JobSpecs sorted by CreatedAt from the store adhering
+// JobsSorted returns many JobSpecs sorted by CreatedAt from the store adhering
 // to the passed parameters.
-func (orm *ORM) SortedJobs(order SortType, offset int, limit int) ([]models.JobSpec, error) {
+func (orm *ORM) JobsSorted(order SortType, offset int, limit int) ([]models.JobSpec, error) {
 	stormOffset := storm.Skip(offset)
 	stormLimit := storm.Limit(limit)
 
@@ -570,8 +570,8 @@ func (orm *ORM) SortedJobs(order SortType, offset int, limit int) ([]models.JobS
 	return jobs, err
 }
 
-// GetTxAttempts returns the last tx attempts sorted by sent at descending.
-func (orm *ORM) GetTxAttempts(offset int, limit int) ([]models.TxAttempt, int, error) {
+// TxAttempts returns the last tx attempts sorted by sent at descending.
+func (orm *ORM) TxAttempts(offset int, limit int) ([]models.TxAttempt, int, error) {
 	var attempts []models.TxAttempt
 	count, err := orm.Count(&models.TxAttempt{})
 	if err != nil {
@@ -587,8 +587,8 @@ func (orm *ORM) JobRunsCount() (int, error) {
 	return orm.Count(&models.JobRun{})
 }
 
-// SortedJobRuns returns job runs ordered and filtered by the passed params.
-func (orm *ORM) SortedJobRuns(order SortType, offset int, limit int) ([]models.JobRun, int, error) {
+// JobRunsSorted returns job runs ordered and filtered by the passed params.
+func (orm *ORM) JobRunsSorted(order SortType, offset int, limit int) ([]models.JobRun, int, error) {
 	count, err := orm.JobRunsCount()
 	if err != nil {
 		return nil, 0, err
@@ -604,9 +604,9 @@ func (orm *ORM) SortedJobRuns(order SortType, offset int, limit int) ([]models.J
 	return runs, count, err
 }
 
-// SortedJobRunsFor returns job runs for a specific job spec ordered and
+// JobRunsSortedFor returns job runs for a specific job spec ordered and
 // filtered by the passed params.
-func (orm *ORM) SortedJobRunsFor(id string, order SortType, offset int, limit int) ([]models.JobRun, int, error) {
+func (orm *ORM) JobRunsSortedFor(id string, order SortType, offset int, limit int) ([]models.JobRun, int, error) {
 	count, err := orm.JobRunsCountFor(id)
 	if err != nil {
 		return nil, 0, err

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -628,3 +628,13 @@ func (orm *ORM) BridgeTypes(offset int, limit int) ([]models.BridgeType, int, er
 	err = orm.AllByIndex("Name", &bridges, storm.Skip(offset), storm.Limit(limit))
 	return bridges, count, err
 }
+
+// SaveUser saves the user.
+func (orm *ORM) SaveUser(user *models.User) error {
+	return orm.Save(user)
+}
+
+// SaveSession saves the session.
+func (orm *ORM) SaveSession(session *models.Session) error {
+	return orm.Save(session)
+}

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -653,3 +653,8 @@ func (orm *ORM) SaveTx(tx *models.Tx) error {
 func (orm *ORM) SaveInitiator(initr *models.Initiator) error {
 	return orm.Save(initr)
 }
+
+// SaveHead saves the indexable block number related to head tracker.
+func (orm *ORM) SaveHead(n *models.IndexableBlockNumber) error {
+	return orm.Save(n)
+}

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -643,3 +643,8 @@ func (orm *ORM) SaveSession(session *models.Session) error {
 func (orm *ORM) SaveBridgeType(bt *models.BridgeType) error {
 	return orm.Save(bt)
 }
+
+// SaveTx saves the transaction.
+func (orm *ORM) SaveTx(tx *models.Tx) error {
+	return orm.Save(tx)
+}

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -648,3 +648,8 @@ func (orm *ORM) SaveBridgeType(bt *models.BridgeType) error {
 func (orm *ORM) SaveTx(tx *models.Tx) error {
 	return orm.Save(tx)
 }
+
+// SaveInitiator saves the initiator.
+func (orm *ORM) SaveInitiator(initr *models.Initiator) error {
+	return orm.Save(initr)
+}

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -615,3 +615,16 @@ func (orm *ORM) SortedJobRunsFor(id string, order SortType, offset int, limit in
 	err = query.Find(&runs)
 	return runs, count, err
 }
+
+// BridgeTypes returns bridge types ordered by name filtered limited by the
+// passed params.
+func (orm *ORM) BridgeTypes(offset int, limit int) ([]models.BridgeType, int, error) {
+	count, err := orm.Count(&models.BridgeType{})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	var bridges []models.BridgeType
+	err = orm.AllByIndex("Name", &bridges, storm.Skip(offset), storm.Limit(limit))
+	return bridges, count, err
+}

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -677,3 +677,16 @@ func (orm *ORM) Save(data interface{}) error {
 	logger.Panic("Direct saves are not allowed, use orm's model specific save")
 	return nil
 }
+
+// LastHead returns the last ordered IndexableBlockNumber.
+func (orm *ORM) LastHead() (*models.IndexableBlockNumber, error) {
+	numbers := []models.IndexableBlockNumber{}
+	err := orm.Select().OrderBy("Digits", "Number").Limit(1).Reverse().Find(&numbers)
+	if err == storm.ErrNotFound {
+		return nil, nil
+	}
+	if err == nil {
+		return &numbers[0], nil
+	}
+	return nil, err
+}

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -162,6 +162,13 @@ func (orm *ORM) JobRunsCountFor(jobID string) (int, error) {
 	return query.Count(&models.JobRun{})
 }
 
+// Sessions returns all sessions limited by the parameters.
+func (orm *ORM) Sessions(offset, limit int) ([]models.Session, error) {
+	var sessions []models.Session
+	err := orm.All(&sessions)
+	return sessions, err
+}
+
 // SaveJob saves a job to the database and adds IDs to associated tables.
 func (orm *ORM) SaveJob(job *models.JobSpec) error {
 	tx, err := orm.Begin(true)
@@ -578,8 +585,15 @@ func (orm *ORM) TxFrom(from common.Address) ([]models.Tx, error) {
 	return txs, err
 }
 
+// Transactions returns all transactions limited by passed parameters.
+func (orm *ORM) Transactions(offset, limit int) ([]models.Tx, error) {
+	var txs []models.Tx
+	err := orm.All(&txs)
+	return txs, err
+}
+
 // TxAttempts returns the last tx attempts sorted by sent at descending.
-func (orm *ORM) TxAttempts(offset int, limit int) ([]models.TxAttempt, int, error) {
+func (orm *ORM) TxAttempts(offset, limit int) ([]models.TxAttempt, int, error) {
 	var attempts []models.TxAttempt
 	count, err := orm.Count(&models.TxAttempt{})
 	if err != nil {
@@ -587,6 +601,9 @@ func (orm *ORM) TxAttempts(offset int, limit int) ([]models.TxAttempt, int, erro
 	}
 	query := orm.Select().OrderBy("SentAt").Reverse().Limit(limit).Skip(offset)
 	err = query.Find(&attempts)
+	if err == storm.ErrNotFound {
+		err = nil
+	}
 	return attempts, count, err
 }
 
@@ -609,6 +626,9 @@ func (orm *ORM) JobRunsSorted(order SortType, offset int, limit int) ([]models.J
 
 	var runs []models.JobRun
 	err = query.Find(&runs)
+	if err == storm.ErrNotFound {
+		err = nil
+	}
 	return runs, count, err
 }
 
@@ -627,6 +647,9 @@ func (orm *ORM) JobRunsSortedFor(id string, order SortType, offset int, limit in
 
 	var runs []models.JobRun
 	err = query.Find(&runs)
+	if err == storm.ErrNotFound {
+		err = nil
+	}
 	return runs, count, err
 }
 

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -104,6 +104,20 @@ func (orm *ORM) FindJob(id string) (models.JobSpec, error) {
 	return job, err
 }
 
+// FindInitiator returns the single initiator defined by the passed ID.
+func (orm *ORM) FindInitiator(ID int) (models.Initiator, error) {
+	initr := models.Initiator{}
+	err := orm.One("ID", ID, &initr)
+	return initr, err
+}
+
+// FindInitiatorsForJob returns all initiators for a specific job.
+func (orm *ORM) FindInitiatorsForJob(jobID string) ([]models.Initiator, error) {
+	initrs := []models.Initiator{}
+	err := orm.Where("JobID", jobID, &initrs)
+	return initrs, err
+}
+
 // FindJobRun looks up a JobRun by its ID.
 func (orm *ORM) FindJobRun(id string) (models.JobRun, error) {
 	var jr models.JobRun
@@ -290,9 +304,23 @@ func (orm *ORM) ConfirmTx(tx *models.Tx, txat *models.TxAttempt) error {
 	return dbtx.Commit()
 }
 
-// AttemptsFor returns the Transaction Attempts (TxAttempt) for a
+// FindTx returns the specific transaction for the passed ID.
+func (orm *ORM) FindTx(ID uint64) (*models.Tx, error) {
+	tx := &models.Tx{}
+	err := orm.One("ID", ID, tx)
+	return tx, err
+}
+
+// FindTxAttempt returns the specific transaction attempt with the hash.
+func (orm *ORM) FindTxAttempt(hash common.Hash) (*models.TxAttempt, error) {
+	txat := &models.TxAttempt{}
+	err := orm.One("Hash", hash, txat)
+	return txat, err
+}
+
+// TxAttemptsFor returns the Transaction Attempts (TxAttempt) for a
 // given Transaction ID (TxID).
-func (orm *ORM) AttemptsFor(id uint64) ([]models.TxAttempt, error) {
+func (orm *ORM) TxAttemptsFor(id uint64) ([]models.TxAttempt, error) {
 	attempts := []models.TxAttempt{}
 	if err := orm.Where("TxID", id, &attempts); err != nil {
 		return attempts, err
@@ -300,9 +328,9 @@ func (orm *ORM) AttemptsFor(id uint64) ([]models.TxAttempt, error) {
 	return attempts, nil
 }
 
-// AddAttempt creates a new transaction attempt and stores it
+// AddTxAttempt creates a new transaction attempt and stores it
 // in the database.
-func (orm *ORM) AddAttempt(
+func (orm *ORM) AddTxAttempt(
 	tx *models.Tx,
 	etx *types.Transaction,
 	blkNum uint64,

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -570,6 +570,13 @@ func (orm *ORM) JobsSorted(order SortType, offset int, limit int) ([]models.JobS
 	return jobs, err
 }
 
+// TxFrom returns all transactions from a particular address.
+func (orm *ORM) TxFrom(from common.Address) ([]models.Tx, error) {
+	txs := []models.Tx{}
+	err := orm.Where("From", from, &txs)
+	return txs, err
+}
+
 // TxAttempts returns the last tx attempts sorted by sent at descending.
 func (orm *ORM) TxAttempts(offset int, limit int) ([]models.TxAttempt, int, error) {
 	var attempts []models.TxAttempt

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -61,7 +61,7 @@ func (orm *ORM) GetBolt() *bolt.DB {
 // Where fetches multiple objects with "Find" in Storm.
 func (orm *ORM) Where(field string, value interface{}, instance interface{}) error {
 	err := orm.Find(field, value, instance)
-	if err == ErrorNotFound {
+	if err == storm.ErrNotFound {
 		emptySlice(instance)
 		return nil
 	}
@@ -141,7 +141,7 @@ func (orm *ORM) Jobs(cb func(models.JobSpec) bool) error {
 func (orm *ORM) JobRunsFor(jobID string) ([]models.JobRun, error) {
 	runs := []models.JobRun{}
 	err := orm.Find("JobID", jobID, &runs) // Use Find to leverage db index
-	if err == ErrorNotFound {
+	if err == storm.ErrNotFound {
 		return []models.JobRun{}, nil
 	}
 	sort.Sort(jobRunSorterAscending(runs))
@@ -221,7 +221,7 @@ func (orm *ORM) SaveServiceAgreement(sa *models.ServiceAgreement) error {
 func (orm *ORM) JobRunsWithStatus(statuses ...models.RunStatus) ([]models.JobRun, error) {
 	runs := []models.JobRun{}
 	err := orm.Select(q.In("Status", statuses)).Find(&runs)
-	if err == ErrorNotFound {
+	if err == storm.ErrNotFound {
 		return []models.JobRun{}, nil
 	}
 
@@ -340,7 +340,7 @@ func (orm *ORM) AddAttempt(
 func (orm *ORM) GetLastNonce(address common.Address) (uint64, error) {
 	var transactions []models.Tx
 	query := orm.Select(q.Eq("From", address))
-	if err := query.Limit(1).OrderBy("Nonce").Reverse().Find(&transactions); err == ErrorNotFound {
+	if err := query.Limit(1).OrderBy("Nonce").Reverse().Find(&transactions); err == storm.ErrNotFound {
 		return 0, nil
 	} else if err != nil {
 		return 0, err
@@ -535,7 +535,7 @@ func underlyingBucketType(bucket interface{}) reflect.Type {
 func (orm *ORM) ClearNonCurrentSessions(sessionID string) error {
 	var sessions []models.Session
 	err := orm.Select(q.Not(q.Eq("ID", sessionID))).Find(&sessions)
-	if err != nil && err != ErrorNotFound {
+	if err != nil && err != storm.ErrNotFound {
 		return err
 	}
 

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -67,13 +67,13 @@ func TestJobRunsFor(t *testing.T) {
 	require.NoError(t, store.SaveJob(&job))
 	jr1 := job.NewRun(i)
 	jr1.CreatedAt = time.Now().AddDate(0, 0, -1)
-	require.NoError(t, store.Save(&jr1))
+	require.NoError(t, store.SaveJobRun(&jr1))
 	jr2 := job.NewRun(i)
 	jr2.CreatedAt = time.Now().AddDate(0, 0, 1)
-	require.NoError(t, store.Save(&jr2))
+	require.NoError(t, store.SaveJobRun(&jr2))
 	jr3 := job.NewRun(i)
 	jr3.CreatedAt = time.Now().AddDate(0, 0, -9)
-	require.NoError(t, store.Save(&jr3))
+	require.NoError(t, store.SaveJobRun(&jr3))
 
 	runs, err := store.JobRunsFor(job.ID)
 	assert.NoError(t, err)
@@ -118,7 +118,7 @@ func TestJobRunsWithStatus(t *testing.T) {
 	j, i := cltest.NewJobWithWebInitiator()
 	assert.NoError(t, store.SaveJob(&j))
 	npr := j.NewRun(i)
-	assert.NoError(t, store.Save(&npr))
+	assert.NoError(t, store.SaveJobRun(&npr))
 
 	statuses := []models.RunStatus{
 		models.RunStatusPendingBridge,
@@ -128,7 +128,7 @@ func TestJobRunsWithStatus(t *testing.T) {
 	for _, status := range statuses {
 		run := j.NewRun(i)
 		run.Status = status
-		assert.NoError(t, store.Save(&run))
+		assert.NoError(t, store.SaveJobRun(&run))
 		seedIds = append(seedIds, run.ID)
 	}
 
@@ -199,9 +199,9 @@ func TestJobRunsCountFor(t *testing.T) {
 	run2 := job.NewRun(initr)
 	run3 := job2.NewRun(initr)
 
-	assert.NoError(t, store.Save(&completedRun))
-	assert.NoError(t, store.Save(&run2))
-	assert.NoError(t, store.Save(&run3))
+	assert.NoError(t, store.SaveJobRun(&completedRun))
+	assert.NoError(t, store.SaveJobRun(&run2))
+	assert.NoError(t, store.SaveJobRun(&run3))
 
 	count, err := store.JobRunsCountFor(job.ID)
 	assert.NoError(t, err)
@@ -289,7 +289,7 @@ func TestORM_PendingBridgeType_alreadyCompleted(t *testing.T) {
 	assert.NoError(t, store.SaveJob(&job))
 
 	run := job.NewRun(initr)
-	assert.NoError(t, store.Save(&run))
+	assert.NoError(t, store.SaveJobRun(&run))
 
 	store.RunChannel.Send(run.ID)
 	cltest.WaitForJobRunStatus(t, store, run, models.RunStatusCompleted)

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -380,8 +380,8 @@ func TestORM_FindUser(t *testing.T) {
 	user2 := cltest.MustUser("test2@email2.net", "password2")
 	user2.CreatedAt = models.Time{time.Now().Add(-24 * time.Hour)}
 
-	require.NoError(t, store.Save(&user1))
-	require.NoError(t, store.Save(&user2))
+	require.NoError(t, store.SaveUser(&user1))
+	require.NoError(t, store.SaveUser(&user2))
 
 	actual, err := store.FindUser()
 	require.NoError(t, err)
@@ -396,7 +396,7 @@ func TestORM_AuthorizedUserWithSession(t *testing.T) {
 	defer cleanup()
 
 	user := cltest.MustUser("have@email", "password")
-	require.NoError(t, store.Save(&user))
+	require.NoError(t, store.SaveUser(&user))
 
 	tests := []struct {
 		name            string
@@ -415,7 +415,7 @@ func TestORM_AuthorizedUserWithSession(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			prevSession := cltest.NewSession("correctID")
 			prevSession.LastUsed = models.Time{time.Now().Add(-cltest.MustParseDuration("2m"))}
-			require.NoError(t, store.Save(&prevSession))
+			require.NoError(t, store.SaveSession(&prevSession))
 
 			expectedTime := models.Time{time.Now()}.HumanString()
 			actual, err := store.ORM.AuthorizedUserWithSession(test.sessionID, test.sessionDuration)
@@ -439,7 +439,7 @@ func TestORM_DeleteUser(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 	user := cltest.MustUser("test1@email1.net", "password1")
-	require.NoError(t, store.Save(&user))
+	require.NoError(t, store.SaveUser(&user))
 
 	_, err := store.DeleteUser()
 	require.NoError(t, err)
@@ -454,10 +454,10 @@ func TestORM_DeleteUserSession(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 	user := cltest.MustUser("test1@email1.net", "password1")
-	require.NoError(t, store.Save(&user))
+	require.NoError(t, store.SaveUser(&user))
 
 	session := models.NewSession()
-	require.NoError(t, store.Save(&session))
+	require.NoError(t, store.SaveSession(&session))
 
 	err := store.DeleteUserSession(session.ID)
 	require.NoError(t, err)
@@ -478,7 +478,7 @@ func TestORM_CreateSession(t *testing.T) {
 	defer cleanup()
 
 	initial := cltest.MustUser(cltest.APIEmail, cltest.Password)
-	require.NoError(t, store.Save(&initial))
+	require.NoError(t, store.SaveUser(&initial))
 
 	tests := []struct {
 		name        string

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -248,10 +248,10 @@ func TestFindBridge(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 
-	tt := models.BridgeType{}
-	tt.Name = models.MustNewTaskType("solargridreporting")
-	tt.URL = cltest.WebURL("https://denergy.eth")
-	assert.NoError(t, store.Save(&tt))
+	bt := models.BridgeType{}
+	bt.Name = models.MustNewTaskType("solargridreporting")
+	bt.URL = cltest.WebURL("https://denergy.eth")
+	assert.NoError(t, store.SaveBridgeType(&bt))
 
 	cases := []struct {
 		description string
@@ -259,7 +259,7 @@ func TestFindBridge(t *testing.T) {
 		want        models.BridgeType
 		errored     bool
 	}{
-		{"actual external adapter", tt.Name.String(), tt, false},
+		{"actual external adapter", bt.Name.String(), bt, false},
 		{"core adapter", "ethtx", models.BridgeType{}, true},
 		{"non-existent adapter", "nonExistent", models.BridgeType{}, true},
 	}
@@ -283,7 +283,7 @@ func TestORM_PendingBridgeType_alreadyCompleted(t *testing.T) {
 	jobRunner.Start()
 
 	bt := cltest.NewBridgeType()
-	assert.NoError(t, store.Save(&bt))
+	assert.NoError(t, store.SaveBridgeType(&bt))
 
 	job, initr := cltest.NewJobWithWebInitiator()
 	assert.NoError(t, store.SaveJob(&job))
@@ -305,7 +305,7 @@ func TestORM_PendingBridgeType_success(t *testing.T) {
 	defer cleanup()
 
 	bt := cltest.NewBridgeType()
-	assert.NoError(t, store.Save(&bt))
+	assert.NoError(t, store.SaveBridgeType(&bt))
 
 	job, initr := cltest.NewJobWithWebInitiator()
 	job.Tasks = []models.TaskSpec{models.TaskSpec{Type: bt.Name}}

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -173,7 +173,7 @@ func TestAnyJobWithType(t *testing.T) {
 
 	js, _ := cltest.NewJobWithWebInitiator()
 	js.Tasks = []models.TaskSpec{models.TaskSpec{Type: models.MustNewTaskType("bridgetestname")}}
-	assert.NoError(t, store.Save(&js))
+	assert.NoError(t, store.SaveJob(&js))
 	found, err := store.AnyJobWithType("bridgetestname")
 	assert.NoError(t, err)
 	assert.Equal(t, found, true)

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -363,7 +363,7 @@ func TestORM_MarkRan(t *testing.T) {
 	defer cleanup()
 
 	_, initr := cltest.NewJobWithRunAtInitiator(time.Now())
-	assert.NoError(t, store.Save(&initr))
+	assert.NoError(t, store.SaveInitiator(&initr))
 
 	assert.NoError(t, store.MarkRan(&initr))
 	var ir models.Initiator

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -465,9 +465,8 @@ func TestORM_DeleteUserSession(t *testing.T) {
 	user, err = store.FindUser()
 	require.NoError(t, err)
 
-	var sessions []models.Session
-	err = store.All(&sessions)
-	require.NoError(t, err)
+	sessions, err := store.Sessions(0, 10)
+	assert.NoError(t, err)
 	require.Empty(t, sessions)
 }
 

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -45,7 +45,7 @@ func TestORM_SaveJob(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 
-	j1, initr := cltest.NewJobWithSchedule("* * * * *")
+	j1, _ := cltest.NewJobWithSchedule("* * * * *")
 	store.SaveJob(&j1)
 
 	j2, _ := store.FindJob(j1.ID)
@@ -53,8 +53,9 @@ func TestORM_SaveJob(t *testing.T) {
 	assert.Equal(t, j1.Initiators[0], j2.Initiators[0])
 	assert.Equal(t, j2.ID, j2.Initiators[0].JobID)
 
-	assert.NoError(t, store.One("JobID", j1.ID, &initr))
-	assert.Equal(t, models.Cron("* * * * *"), initr.Schedule)
+	initiators, err := store.FindInitiatorsForJob(j1.ID)
+	assert.NoError(t, err)
+	assert.Equal(t, models.Cron("* * * * *"), initiators[0].Schedule)
 }
 
 func TestJobRunsFor(t *testing.T) {
@@ -366,8 +367,8 @@ func TestORM_MarkRan(t *testing.T) {
 	assert.NoError(t, store.SaveInitiator(&initr))
 
 	assert.NoError(t, store.MarkRan(&initr))
-	var ir models.Initiator
-	assert.NoError(t, store.One("ID", initr.ID, &ir))
+	ir, err := store.FindInitiator(initr.ID)
+	assert.NoError(t, err)
 	assert.True(t, ir.Ran)
 }
 

--- a/store/presenters/presenters.go
+++ b/store/presenters/presenters.go
@@ -373,8 +373,6 @@ func (i Initiator) FriendlyRunAt() string {
 	return ""
 }
 
-var emptyAddress = common.Address{}.String()
-
 // FriendlyAddress returns the Ethereum address if present, and a blank
 // string if not.
 func (i Initiator) FriendlyAddress() string {

--- a/store/tx_manager_test.go
+++ b/store/tx_manager_test.go
@@ -162,12 +162,12 @@ func TestTxManager_CreateTx_AttemptErrorDeletesTxAndDoesNotIncrementNonce(t *tes
 	_, err = manager.CreateTx(to, data)
 	assert.Error(t, err)
 
-	var txs []models.Tx
-	err = store.ORM.All(&txs)
+	txs, err := store.Transactions(0, 10)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, len(txs))
 
-	var txAttempts []models.TxAttempt
-	err = store.ORM.All(&txAttempts)
+	txAttempts, _, err := store.TxAttempts(0, 100)
+	assert.NoError(t, err)
 	assert.Equal(t, 0, len(txAttempts))
 
 	hash := cltest.NewHash()

--- a/store/tx_manager_test.go
+++ b/store/tx_manager_test.go
@@ -27,6 +27,7 @@ func TestTxManager_CreateTx_Success(t *testing.T) {
 	store := app.Store
 	manager := store.TxManager
 
+	from := cltest.GetAccountAddress(app.GetStore())
 	to := cltest.NewAddress()
 	data, err := hex.DecodeString("0000abcdef")
 	assert.NoError(t, err)
@@ -45,17 +46,16 @@ func TestTxManager_CreateTx_Success(t *testing.T) {
 		ethMock.Register("eth_blockNumber", utils.Uint64ToHex(sentAt))
 	})
 
-	a, err := manager.CreateTx(to, data)
+	tx, err := manager.CreateTx(to, data)
 	assert.NoError(t, err)
-	tx := models.Tx{}
-	assert.NoError(t, store.One("ID", a.TxID, &tx))
+	_, err = store.FindTx(tx.ID)
+	assert.NoError(t, err)
 	assert.Equal(t, nonce, tx.Nonce)
 	assert.Equal(t, data, tx.Data)
 	assert.Equal(t, to, tx.To)
-
-	assert.NoError(t, store.One("From", tx.From, &tx))
+	assert.Equal(t, from, tx.From)
 	assert.Equal(t, nonce, tx.Nonce)
-	attempts, err := store.AttemptsFor(tx.ID)
+	attempts, err := store.TxAttemptsFor(tx.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(attempts))
 
@@ -90,7 +90,7 @@ func TestTxManager_CreateTx_RoundRobinSuccess(t *testing.T) {
 	createdTx1, err := manager.CreateTx(to, data)
 	require.NoError(t, err)
 
-	attempts, err := store.AttemptsFor(createdTx1.ID)
+	attempts, err := store.TxAttemptsFor(createdTx1.ID)
 	require.NoError(t, err)
 	require.Len(t, attempts, 1)
 
@@ -105,7 +105,7 @@ func TestTxManager_CreateTx_RoundRobinSuccess(t *testing.T) {
 	require.NoError(t, err)
 
 	// retrieve new gas bumped second attempt
-	attempts, err = store.AttemptsFor(createdTx1.ID)
+	attempts, err = store.TxAttemptsFor(createdTx1.ID)
 	require.NoError(t, err)
 	require.Len(t, attempts, 2)
 	a2 := attempts[1]
@@ -143,6 +143,7 @@ func TestTxManager_CreateTx_AttemptErrorDeletesTxAndDoesNotIncrementNonce(t *tes
 	store := app.Store
 	manager := store.TxManager
 
+	from := cltest.GetAccountAddress(app.GetStore())
 	to := cltest.NewAddress()
 	data, err := hex.DecodeString("0000abcdef")
 	assert.NoError(t, err)
@@ -176,18 +177,18 @@ func TestTxManager_CreateTx_AttemptErrorDeletesTxAndDoesNotIncrementNonce(t *tes
 		ethMock.Register("eth_blockNumber", utils.Uint64ToHex(sentAt))
 	})
 
-	a, err := manager.CreateTx(to, data)
+	tx, err := manager.CreateTx(to, data)
 	assert.NoError(t, err)
-	tx := models.Tx{}
-	assert.NoError(t, store.One("ID", a.TxID, &tx))
+	_, err = store.FindTx(tx.ID)
+	assert.NoError(t, err)
 	assert.NoError(t, err)
 	assert.Equal(t, nonce, tx.Nonce)
 	assert.Equal(t, data, tx.Data)
 	assert.Equal(t, to, tx.To)
+	assert.Equal(t, from, tx.From)
 
-	assert.NoError(t, store.One("From", tx.From, &tx))
 	assert.Equal(t, nonce, tx.Nonce)
-	attempts, err := store.AttemptsFor(tx.ID)
+	attempts, err := store.TxAttemptsFor(tx.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, 1, len(attempts))
 
@@ -213,6 +214,7 @@ func TestTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
 			store := app.Store
 			manager := store.TxManager
 
+			from := cltest.GetAccountAddress(store)
 			to := cltest.NewAddress()
 			data, err := hex.DecodeString("0000abcdef")
 			assert.NoError(t, err)
@@ -240,16 +242,16 @@ func TestTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
 
 			a, err := manager.CreateTx(to, data)
 			assert.NoError(t, err)
-			tx := models.Tx{}
-			assert.NoError(t, store.One("ID", a.TxID, &tx))
+			tx, err := store.FindTx(a.TxID)
+			require.NoError(t, err)
 			assert.NoError(t, err)
 			assert.Equal(t, nonce2, tx.Nonce)
 			assert.Equal(t, data, tx.Data)
 			assert.Equal(t, to, tx.To)
 
-			assert.NoError(t, store.One("From", tx.From, &tx))
+			assert.Equal(t, from, tx.From)
 			assert.Equal(t, nonce2, tx.Nonce)
-			attempts, err := store.AttemptsFor(tx.ID)
+			attempts, err := store.TxAttemptsFor(tx.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(attempts))
 
@@ -353,7 +355,7 @@ func TestTxManager_MeetsMinConfirmations(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			tx := cltest.CreateTxAndAttempt(store, from, sentAt)
-			attempts, err := store.AttemptsFor(tx.ID)
+			attempts, err := store.TxAttemptsFor(tx.ID)
 			assert.NoError(t, err)
 			a := attempts[0]
 
@@ -366,8 +368,7 @@ func TestTxManager_MeetsMinConfirmations(t *testing.T) {
 			confirmed, err := txm.MeetsMinConfirmations(a.Hash)
 			assert.NoError(t, err)
 			assert.Equal(t, test.wantConfirmed, confirmed)
-			assert.NoError(t, store.One("ID", tx.ID, tx))
-			attempts, err = store.AttemptsFor(tx.ID)
+			attempts, err = store.TxAttemptsFor(tx.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, test.wantLength, len(attempts))
 
@@ -436,7 +437,7 @@ func TestTxManager_MeetsMinConfirmations_erroring(t *testing.T) {
 			txm := store.TxManager
 			from := cltest.GetAccountAddress(store)
 			tx := cltest.CreateTxAndAttempt(store, from, sentAt1)
-			a, err := store.AddAttempt(tx, tx.EthTx(big.NewInt(2)), sentAt2)
+			a, err := store.AddTxAttempt(tx, tx.EthTx(big.NewInt(2)), sentAt2)
 			assert.NoError(t, err)
 
 			ethMock := app.MockEthClient()
@@ -541,6 +542,7 @@ func TestTxManager_WithdrawLink(t *testing.T) {
 
 	txm := app.Store.TxManager
 
+	from := cltest.GetAccountAddress(app.GetStore())
 	to := cltest.NewAddress()
 	hash := cltest.NewHash()
 	sentAt := uint64(23456)
@@ -565,10 +567,11 @@ func TestTxManager_WithdrawLink(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, ethMock.AllCalled(), "Not Called")
 
-	var tx models.Tx
-
-	assert.NoError(t, app.Store.One("Nonce", nonce, &tx))
+	transactions, err := app.Store.TxFrom(from)
+	require.NoError(t, err)
+	tx := transactions[0]
 	assert.Equal(t, hash, tx.Hash)
+	assert.Equal(t, nonce, tx.Nonce)
 }
 
 func TestTxManager_WithdrawLink_Unconfigured_Oracle(t *testing.T) {
@@ -668,7 +671,7 @@ func TestTxManager_LogsETHAndLINKBalancesAfterSuccessfulTx(t *testing.T) {
 
 	confirmedTx, err := manager.CreateTx(to, data)
 	assert.NoError(t, err)
-	txTransmissionAttempts, err := app.Store.AttemptsFor(confirmedTx.ID)
+	txTransmissionAttempts, err := app.Store.TxAttemptsFor(confirmedTx.ID)
 	assert.NoError(t, err)
 	initialSuccessfulAttempt := txTransmissionAttempts[0]
 
@@ -737,7 +740,7 @@ func TestTxManager_CreateTxWithGas(t *testing.T) {
 			assert.NoError(t, err)
 			assert.Equal(t, test.expectedGasLimit, tx.GasLimit)
 
-			attempts, err := store.AttemptsFor(tx.ID)
+			attempts, err := store.TxAttemptsFor(tx.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, 1, len(attempts))
 			assert.Equal(t, test.expectedGasPrice, attempts[0].GasPrice)

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -34,8 +34,6 @@ const (
 	EVMWordHexLen = EVMWordByteLen * 2
 )
 
-var weiPerEth = big.NewInt(1e18)
-
 // ZeroAddress is an empty address, otherwise in Ethereum as
 // 0x0000000000000000000000000000000000000000
 var ZeroAddress = common.Address{}

--- a/web/assignments_controller.go
+++ b/web/assignments_controller.go
@@ -3,10 +3,10 @@ package web
 import (
 	"errors"
 
-	"github.com/asdine/storm"
 	"github.com/gin-gonic/gin"
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/orm"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 )
 
@@ -40,7 +40,7 @@ func (ac *AssignmentsController) Create(c *gin.Context) {
 func (ac *AssignmentsController) Show(c *gin.Context) {
 	id := c.Param("ID")
 
-	if j, err := ac.App.GetStore().FindJob(id); err == storm.ErrNotFound {
+	if j, err := ac.App.GetStore().FindJob(id); err == orm.ErrorNotFound {
 		publicError(c, 404, errors.New("ID not found"))
 	} else if err != nil {
 		c.AbortWithError(500, err)

--- a/web/bridge_types_controller.go
+++ b/web/bridge_types_controller.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/asdine/storm"
 	"github.com/gin-gonic/gin"
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/smartcontractkit/chainlink/services"
@@ -42,18 +41,9 @@ func (btc *BridgeTypesController) Index(c *gin.Context) {
 		return
 	}
 
-	skip := storm.Skip(offset)
-	limit := storm.Limit(size)
-
-	var bridges []models.BridgeType
-
-	count, err := btc.App.GetStore().Count(&models.BridgeType{})
+	bridges, count, err := btc.App.GetStore().BridgeTypes(offset, size)
 	if err != nil {
-		c.AbortWithError(500, fmt.Errorf("error getting count of bridges: %+v", err))
-		return
-	}
-	if err := btc.App.GetStore().AllByIndex("Name", &bridges, skip, limit); err != nil {
-		c.AbortWithError(500, fmt.Errorf("error fetching all bridges: %+v", err))
+		c.AbortWithError(500, fmt.Errorf("error getting bridges: %+v", err))
 		return
 	}
 	pbt := make([]presenters.BridgeType, len(bridges))

--- a/web/bridge_types_controller.go
+++ b/web/bridge_types_controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store/forms"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/orm"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 )
 
@@ -70,7 +71,7 @@ func (btc *BridgeTypesController) Index(c *gin.Context) {
 // Show returns the details of a specific Bridge.
 func (btc *BridgeTypesController) Show(c *gin.Context) {
 	name := c.Param("BridgeName")
-	if bt, err := btc.App.GetStore().FindBridge(name); err == storm.ErrNotFound {
+	if bt, err := btc.App.GetStore().FindBridge(name); err == orm.ErrorNotFound {
 		publicError(c, 404, errors.New("bridge name not found"))
 	} else if err != nil {
 		c.AbortWithError(500, err)
@@ -86,7 +87,7 @@ func (btc *BridgeTypesController) Update(c *gin.Context) {
 	bn := c.Param("BridgeName")
 	form, err := forms.NewUpdateBridgeType(btc.App.GetStore(), bn)
 
-	if err == storm.ErrNotFound {
+	if err == orm.ErrorNotFound {
 		publicError(c, 404, errors.New("bridge name not found"))
 		return
 	}
@@ -110,7 +111,7 @@ func (btc *BridgeTypesController) Update(c *gin.Context) {
 // Destroy removes a specific Bridge.
 func (btc *BridgeTypesController) Destroy(c *gin.Context) {
 	name := c.Param("BridgeName")
-	if bt, err := btc.App.GetStore().FindBridge(name); err == storm.ErrNotFound {
+	if bt, err := btc.App.GetStore().FindBridge(name); err == orm.ErrorNotFound {
 		publicError(c, 404, errors.New("bridge name not found"))
 	} else if err != nil {
 		c.AbortWithError(500, fmt.Errorf("Error searching for bridge for BTC Destroy: %+v", err))

--- a/web/bulk_deletes_controller.go
+++ b/web/bulk_deletes_controller.go
@@ -3,11 +3,11 @@ package web
 import (
 	"errors"
 
-	"github.com/asdine/storm"
 	"github.com/gin-gonic/gin"
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/orm"
 )
 
 // BulkDeletesController manages background tasks that delete resources given a query
@@ -41,7 +41,7 @@ func (c *BulkDeletesController) Show(ctx *gin.Context) {
 	id := ctx.Param("taskID")
 	task := models.BulkDeleteRunTask{}
 
-	if err := c.App.GetStore().One("ID", id, &task); err == storm.ErrNotFound {
+	if err := c.App.GetStore().One("ID", id, &task); err == orm.ErrorNotFound {
 		ctx.AbortWithError(404, errors.New("Bulk delete task not found"))
 	} else if err != nil {
 		ctx.AbortWithError(500, err)

--- a/web/bulk_deletes_controller.go
+++ b/web/bulk_deletes_controller.go
@@ -41,7 +41,7 @@ func (c *BulkDeletesController) Show(ctx *gin.Context) {
 	id := ctx.Param("taskID")
 	task := models.BulkDeleteRunTask{}
 
-	if err := c.App.GetStore().One("ID", id, &task); err == orm.ErrorNotFound {
+	if err := c.App.GetStore().ORM.DB.One("ID", id, &task); err == orm.ErrorNotFound {
 		ctx.AbortWithError(404, errors.New("Bulk delete task not found"))
 	} else if err != nil {
 		ctx.AbortWithError(500, err)

--- a/web/bulk_deletes_controller.go
+++ b/web/bulk_deletes_controller.go
@@ -24,7 +24,7 @@ func (c *BulkDeletesController) Create(ctx *gin.Context) {
 		ctx.AbortWithError(422, err)
 	} else if task, err := models.NewBulkDeleteRunTask(request); err != nil {
 		ctx.AbortWithError(422, err)
-	} else if err := c.App.GetStore().Save(task); err != nil {
+	} else if err := c.App.GetStore().ORM.DB.Save(task); err != nil {
 		ctx.AbortWithError(500, err)
 	} else if doc, err := jsonapi.Marshal(task); err != nil {
 		ctx.AbortWithError(500, err)

--- a/web/job_runs_controller.go
+++ b/web/job_runs_controller.go
@@ -40,9 +40,9 @@ func (jrc *JobRunsController) Index(c *gin.Context) {
 	var runs []models.JobRun
 	var count int
 	if id == "" {
-		runs, count, err = store.SortedJobRuns(order, offset, size)
+		runs, count, err = store.JobRunsSorted(order, offset, size)
 	} else {
-		runs, count, err = store.SortedJobRunsFor(id, order, offset, size)
+		runs, count, err = store.JobRunsSortedFor(id, order, offset, size)
 	}
 
 	if err == orm.ErrorNotFound {

--- a/web/job_runs_controller.go
+++ b/web/job_runs_controller.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/orm"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 	"github.com/smartcontractkit/chainlink/utils"
 )
@@ -49,7 +50,7 @@ func (jrc *JobRunsController) Index(c *gin.Context) {
 	var runs []models.JobRun
 	if countErr != nil {
 		c.AbortWithError(500, fmt.Errorf("error getting count of JobRuns: %+v", err))
-	} else if err := query.Find(&runs); err == storm.ErrNotFound {
+	} else if err := query.Find(&runs); err == orm.ErrorNotFound {
 		c.Data(404, MediaType, emptyJSON)
 	} else if err != nil {
 		c.AbortWithError(500, fmt.Errorf("error getting paged JobRuns: %+v", err))
@@ -80,7 +81,7 @@ func runsForJob(jobID string, store *store.Store, size int, offset int) (query s
 func (jrc *JobRunsController) Create(c *gin.Context) {
 	id := c.Param("SpecID")
 
-	if j, err := jrc.App.GetStore().FindJob(id); err == storm.ErrNotFound {
+	if j, err := jrc.App.GetStore().FindJob(id); err == orm.ErrorNotFound {
 		c.AbortWithError(404, errors.New("Job not found"))
 	} else if err != nil {
 		c.AbortWithError(500, err)
@@ -110,7 +111,7 @@ func getRunData(c *gin.Context) (models.JSON, error) {
 //  "<application>/runs/:RunID"
 func (jrc *JobRunsController) Show(c *gin.Context) {
 	id := c.Param("RunID")
-	if jr, err := jrc.App.GetStore().FindJobRun(id); err == storm.ErrNotFound {
+	if jr, err := jrc.App.GetStore().FindJobRun(id); err == orm.ErrorNotFound {
 		c.AbortWithError(404, errors.New("Job Run not found"))
 	} else if err != nil {
 		c.AbortWithError(500, err)
@@ -128,7 +129,7 @@ func (jrc *JobRunsController) Show(c *gin.Context) {
 func (jrc *JobRunsController) Update(c *gin.Context) {
 	id := c.Param("RunID")
 	var brr models.BridgeRunResult
-	if jr, err := jrc.App.GetStore().FindJobRun(id); err == storm.ErrNotFound {
+	if jr, err := jrc.App.GetStore().FindJobRun(id); err == orm.ErrorNotFound {
 		c.AbortWithError(404, errors.New("Job Run not found"))
 	} else if err != nil {
 		c.AbortWithError(500, err)

--- a/web/job_runs_controller_test.go
+++ b/web/job_runs_controller_test.go
@@ -207,7 +207,7 @@ func TestJobRunsController_Update_Success(t *testing.T) {
 	defer cleanup()
 
 	bt := cltest.NewBridgeType()
-	assert.Nil(t, app.Store.Save(&bt))
+	assert.Nil(t, app.Store.SaveBridgeType(&bt))
 	j, initr := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.SaveJob(&j))
@@ -238,7 +238,7 @@ func TestJobRunsController_Update_WrongAccessToken(t *testing.T) {
 	client := app.NewHTTPClient()
 
 	bt := cltest.NewBridgeType()
-	assert.Nil(t, app.Store.Save(&bt))
+	assert.Nil(t, app.Store.SaveBridgeType(&bt))
 	j, initr := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.SaveJob(&j))
@@ -262,7 +262,7 @@ func TestJobRunsController_Update_NotPending(t *testing.T) {
 	client := app.NewHTTPClient()
 
 	bt := cltest.NewBridgeType()
-	assert.Nil(t, app.Store.Save(&bt))
+	assert.Nil(t, app.Store.SaveBridgeType(&bt))
 	j, initr := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.SaveJob(&j))
@@ -284,7 +284,7 @@ func TestJobRunsController_Update_WithError(t *testing.T) {
 	client := app.NewHTTPClient()
 
 	bt := cltest.NewBridgeType()
-	assert.Nil(t, app.Store.Save(&bt))
+	assert.Nil(t, app.Store.SaveBridgeType(&bt))
 	j, initr := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.SaveJob(&j))
@@ -312,7 +312,7 @@ func TestJobRunsController_Update_WithMergeError(t *testing.T) {
 	defer cleanup()
 
 	bt := cltest.NewBridgeType()
-	assert.Nil(t, app.Store.Save(&bt))
+	assert.Nil(t, app.Store.SaveBridgeType(&bt))
 	j, initr := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.SaveJob(&j))
@@ -342,7 +342,7 @@ func TestJobRunsController_Update_BadInput(t *testing.T) {
 	client := app.NewHTTPClient()
 
 	bt := cltest.NewBridgeType()
-	assert.Nil(t, app.Store.Save(&bt))
+	assert.Nil(t, app.Store.SaveBridgeType(&bt))
 	j, initr := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.SaveJob(&j))
@@ -365,7 +365,7 @@ func TestJobRunsController_Update_NotFound(t *testing.T) {
 	client := app.NewHTTPClient()
 
 	bt := cltest.NewBridgeType()
-	assert.Nil(t, app.Store.Save(&bt))
+	assert.Nil(t, app.Store.SaveBridgeType(&bt))
 	j, initr := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.SaveJob(&j))

--- a/web/job_runs_controller_test.go
+++ b/web/job_runs_controller_test.go
@@ -114,17 +114,17 @@ func setupJobRunsControllerIndex(t assert.TestingT, app *cltest.TestApplication)
 	runA := j1.NewRun(initr)
 	runA.ID = "runA"
 	runA.CreatedAt = now.Add(-2 * time.Second)
-	assert.Nil(t, app.Store.Save(&runA))
+	assert.Nil(t, app.Store.SaveJobRun(&runA))
 
 	runB := j1.NewRun(initr)
 	runB.ID = "runB"
 	runB.CreatedAt = now.Add(-time.Second)
-	assert.Nil(t, app.Store.Save(&runB))
+	assert.Nil(t, app.Store.SaveJobRun(&runB))
 
 	runC := j2.NewRun(initr)
 	runC.ID = "runC"
 	runC.CreatedAt = now
-	assert.Nil(t, app.Store.Save(&runC))
+	assert.Nil(t, app.Store.SaveJobRun(&runC))
 
 	return &runA, &runB, &runC
 }
@@ -212,7 +212,7 @@ func TestJobRunsController_Update_Success(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.Save(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(initr), 0)
-	assert.Nil(t, app.Store.Save(&jr))
+	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
 	body := fmt.Sprintf(`{"id":"%v","data":{"value": "100"}}`, jr.ID)
 	headers := map[string]string{"Authorization": "Bearer " + bt.IncomingToken}
@@ -243,7 +243,7 @@ func TestJobRunsController_Update_WrongAccessToken(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.Save(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(initr), 0)
-	assert.Nil(t, app.Store.Save(&jr))
+	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
 	body := fmt.Sprintf(`{"id":"%v","data":{"value": "100"}}`, jr.ID)
 	headers := map[string]string{"Authorization": "Bearer " + "wrongaccesstoken"}
@@ -267,7 +267,7 @@ func TestJobRunsController_Update_NotPending(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.Save(&j))
 	jr := j.NewRun(initr)
-	assert.Nil(t, app.Store.Save(&jr))
+	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
 	body := fmt.Sprintf(`{"id":"%v","data":{"value": "100"}}`, jr.ID)
 	headers := map[string]string{"Authorization": "Bearer " + bt.IncomingToken}
@@ -289,7 +289,7 @@ func TestJobRunsController_Update_WithError(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.Save(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(initr), 0)
-	assert.Nil(t, app.Store.Save(&jr))
+	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
 	body := fmt.Sprintf(`{"id":"%v","error":"stack overflow","data":{"value": "0"}}`, jr.ID)
 	headers := map[string]string{"Authorization": "Bearer " + bt.IncomingToken}
@@ -318,7 +318,7 @@ func TestJobRunsController_Update_WithMergeError(t *testing.T) {
 	assert.Nil(t, app.Store.Save(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(initr), 0)
 	jr.Overrides = jr.Overrides.WithError(errors.New("Already errored")) // easy way to force Merge error
-	assert.Nil(t, app.Store.Save(&jr))
+	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
 	body := fmt.Sprintf(`{"id":"%v","data":{"value": "100"}}`, jr.ID)
 	headers := map[string]string{"Authorization": "Bearer " + bt.IncomingToken}
@@ -347,7 +347,7 @@ func TestJobRunsController_Update_BadInput(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.Save(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(initr), 0)
-	assert.Nil(t, app.Store.Save(&jr))
+	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
 	body := fmt.Sprint(`{`, jr.ID)
 	resp, cleanup := client.Patch("/v2/runs/"+jr.ID, bytes.NewBufferString(body))
@@ -370,7 +370,7 @@ func TestJobRunsController_Update_NotFound(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.Save(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(initr), 0)
-	assert.Nil(t, app.Store.Save(&jr))
+	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
 	body := fmt.Sprintf(`{"id":"%v","data":{"value": "100"}}`, jr.ID)
 	resp, cleanup := client.Patch("/v2/runs/"+jr.ID+"1", bytes.NewBufferString(body))
@@ -393,7 +393,7 @@ func TestJobRunsController_Show_Found(t *testing.T) {
 
 	jr := j.NewRun(initr)
 	jr.ID = "jobrun1"
-	assert.Nil(t, app.Store.Save(&jr))
+	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
 	resp, cleanup := client.Get("/v2/runs/" + jr.ID)
 	defer cleanup()

--- a/web/job_runs_controller_test.go
+++ b/web/job_runs_controller_test.go
@@ -210,7 +210,7 @@ func TestJobRunsController_Update_Success(t *testing.T) {
 	assert.Nil(t, app.Store.Save(&bt))
 	j, initr := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
-	assert.Nil(t, app.Store.Save(&j))
+	assert.Nil(t, app.Store.SaveJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(initr), 0)
 	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
@@ -241,7 +241,7 @@ func TestJobRunsController_Update_WrongAccessToken(t *testing.T) {
 	assert.Nil(t, app.Store.Save(&bt))
 	j, initr := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
-	assert.Nil(t, app.Store.Save(&j))
+	assert.Nil(t, app.Store.SaveJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(initr), 0)
 	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
@@ -265,7 +265,7 @@ func TestJobRunsController_Update_NotPending(t *testing.T) {
 	assert.Nil(t, app.Store.Save(&bt))
 	j, initr := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
-	assert.Nil(t, app.Store.Save(&j))
+	assert.Nil(t, app.Store.SaveJob(&j))
 	jr := j.NewRun(initr)
 	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
@@ -287,7 +287,7 @@ func TestJobRunsController_Update_WithError(t *testing.T) {
 	assert.Nil(t, app.Store.Save(&bt))
 	j, initr := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
-	assert.Nil(t, app.Store.Save(&j))
+	assert.Nil(t, app.Store.SaveJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(initr), 0)
 	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
@@ -315,7 +315,7 @@ func TestJobRunsController_Update_WithMergeError(t *testing.T) {
 	assert.Nil(t, app.Store.Save(&bt))
 	j, initr := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
-	assert.Nil(t, app.Store.Save(&j))
+	assert.Nil(t, app.Store.SaveJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(initr), 0)
 	jr.Overrides = jr.Overrides.WithError(errors.New("Already errored")) // easy way to force Merge error
 	assert.Nil(t, app.Store.SaveJobRun(&jr))
@@ -345,7 +345,7 @@ func TestJobRunsController_Update_BadInput(t *testing.T) {
 	assert.Nil(t, app.Store.Save(&bt))
 	j, initr := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
-	assert.Nil(t, app.Store.Save(&j))
+	assert.Nil(t, app.Store.SaveJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(initr), 0)
 	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
@@ -368,7 +368,7 @@ func TestJobRunsController_Update_NotFound(t *testing.T) {
 	assert.Nil(t, app.Store.Save(&bt))
 	j, initr := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
-	assert.Nil(t, app.Store.Save(&j))
+	assert.Nil(t, app.Store.SaveJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(initr), 0)
 	assert.Nil(t, app.Store.SaveJobRun(&jr))
 

--- a/web/job_runs_controller_test.go
+++ b/web/job_runs_controller_test.go
@@ -250,7 +250,8 @@ func TestJobRunsController_Update_WrongAccessToken(t *testing.T) {
 	resp, cleanup := client.Patch("/v2/runs/"+jr.ID, bytes.NewBufferString(body), headers)
 	defer cleanup()
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode, "Response should be unauthorized")
-	assert.Nil(t, app.Store.One("ID", jr.ID, &jr))
+	jr, err := app.Store.FindJobRun(jr.ID)
+	assert.NoError(t, err)
 	assert.Equal(t, models.RunStatusPendingBridge, jr.Status)
 }
 
@@ -353,7 +354,8 @@ func TestJobRunsController_Update_BadInput(t *testing.T) {
 	resp, cleanup := client.Patch("/v2/runs/"+jr.ID, bytes.NewBufferString(body))
 	defer cleanup()
 	assert.Equal(t, 500, resp.StatusCode, "Response should be successful")
-	assert.Nil(t, app.Store.One("ID", jr.ID, &jr))
+	jr, err := app.Store.FindJobRun(jr.ID)
+	assert.NoError(t, err)
 	assert.Equal(t, models.RunStatusPendingBridge, jr.Status)
 }
 
@@ -376,7 +378,8 @@ func TestJobRunsController_Update_NotFound(t *testing.T) {
 	resp, cleanup := client.Patch("/v2/runs/"+jr.ID+"1", bytes.NewBufferString(body))
 	defer cleanup()
 	assert.Equal(t, 404, resp.StatusCode, "Response should be successful")
-	assert.Nil(t, app.Store.One("ID", jr.ID, &jr))
+	jr, err := app.Store.FindJobRun(jr.ID)
+	assert.NoError(t, err)
 	assert.Equal(t, models.RunStatusPendingBridge, jr.Status)
 }
 

--- a/web/job_specs_controller.go
+++ b/web/job_specs_controller.go
@@ -36,7 +36,7 @@ func (jsc *JobSpecsController) Index(c *gin.Context) {
 
 	if count, err := jsc.App.GetStore().Count(&models.JobSpec{}); err != nil {
 		c.AbortWithError(500, fmt.Errorf("error getting count of JobSpec: %+v", err))
-	} else if jobs, err := jsc.App.GetStore().SortedJobs(order, offset, size); err != nil {
+	} else if jobs, err := jsc.App.GetStore().JobsSorted(order, offset, size); err != nil {
 		c.AbortWithError(500, fmt.Errorf("erorr fetching All JobSpecs: %+v", err))
 	} else {
 		pjs := make([]presenters.JobSpec, len(jobs))

--- a/web/job_specs_controller.go
+++ b/web/job_specs_controller.go
@@ -4,8 +4,6 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/asdine/storm"
-	"github.com/asdine/storm/index"
 	"github.com/gin-gonic/gin"
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/smartcontractkit/chainlink/services"
@@ -29,20 +27,16 @@ func (jsc *JobSpecsController) Index(c *gin.Context) {
 		return
 	}
 
-	var order func(opts *index.Options)
+	var order orm.SortType
 	if c.Query("sort") == "-createdAt" {
-		order = storm.Reverse()
+		order = orm.Descending
 	} else {
-		order = func(opts *index.Options) {}
+		order = orm.Ascending
 	}
 
-	skip := storm.Skip(offset)
-	limit := storm.Limit(size)
-
-	var jobs []models.JobSpec
 	if count, err := jsc.App.GetStore().Count(&models.JobSpec{}); err != nil {
 		c.AbortWithError(500, fmt.Errorf("error getting count of JobSpec: %+v", err))
-	} else if err := jsc.App.GetStore().AllByIndex("CreatedAt", &jobs, order, skip, limit); err != nil {
+	} else if jobs, err := jsc.App.GetStore().SortedJobs(order, offset, size); err != nil {
 		c.AbortWithError(500, fmt.Errorf("erorr fetching All JobSpecs: %+v", err))
 	} else {
 		pjs := make([]presenters.JobSpec, len(jobs))

--- a/web/job_specs_controller.go
+++ b/web/job_specs_controller.go
@@ -10,6 +10,7 @@ import (
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/orm"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 )
 
@@ -81,7 +82,7 @@ func (jsc *JobSpecsController) Create(c *gin.Context) {
 //  "<application>/specs/:SpecID"
 func (jsc *JobSpecsController) Show(c *gin.Context) {
 	id := c.Param("SpecID")
-	if j, err := jsc.App.GetStore().FindJob(id); err == storm.ErrNotFound {
+	if j, err := jsc.App.GetStore().FindJob(id); err == orm.ErrorNotFound {
 		publicError(c, 404, errors.New("JobSpec not found"))
 	} else if err != nil {
 		c.AbortWithError(500, err)

--- a/web/job_specs_controller_test.go
+++ b/web/job_specs_controller_test.go
@@ -336,11 +336,11 @@ func setupJobSpecsControllerShow(t assert.TestingT, app *cltest.TestApplication)
 
 	jr1 := j.NewRun(initr)
 	jr1.ID = "2"
-	assert.Nil(t, app.Store.Save(&jr1))
+	assert.Nil(t, app.Store.SaveJobRun(&jr1))
 	jr2 := j.NewRun(initr)
 	jr2.ID = "1"
 	jr2.CreatedAt = jr1.CreatedAt.Add(time.Second)
-	assert.Nil(t, app.Store.Save(&jr2))
+	assert.Nil(t, app.Store.SaveJobRun(&jr2))
 
 	return &j
 }

--- a/web/job_specs_controller_test.go
+++ b/web/job_specs_controller_test.go
@@ -182,8 +182,7 @@ func TestJobSpecsController_Create(t *testing.T) {
 	assert.Equal(t, "0x356a04bCe728ba4c62A30294A55E6A8600a320B3", signTx.Address.String())
 	assert.Equal(t, "0x609ff1bd", signTx.FunctionSelector.String())
 
-	var initr models.Initiator
-	app.Store.One("JobID", j.ID, &initr)
+	initr := j.Initiators[0]
 	assert.Equal(t, models.InitiatorWeb, initr.Type)
 	assert.NotEqual(t, models.Time{}, j.CreatedAt)
 }

--- a/web/service_agreements_controller.go
+++ b/web/service_agreements_controller.go
@@ -4,12 +4,12 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/asdine/storm"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin"
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/orm"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 )
 
@@ -32,7 +32,7 @@ func (sac *ServiceAgreementsController) Create(c *gin.Context) {
 	}
 
 	sa, err := sac.App.GetStore().FindServiceAgreement(us.ID.String())
-	if err == storm.ErrNotFound {
+	if err == orm.ErrorNotFound {
 		sa, err = models.BuildServiceAgreement(us, sac.App.GetStore().KeyStore)
 		if err != nil {
 			publicError(c, 422, err)
@@ -60,7 +60,7 @@ func (sac *ServiceAgreementsController) Create(c *gin.Context) {
 //  "<application>/service_agreements/:SAID"
 func (sac *ServiceAgreementsController) Show(c *gin.Context) {
 	id := common.HexToHash(c.Param("SAID"))
-	if sa, err := sac.App.GetStore().FindServiceAgreement(id.String()); err == storm.ErrNotFound {
+	if sa, err := sac.App.GetStore().FindServiceAgreement(id.String()); err == orm.ErrorNotFound {
 		publicError(c, 404, errors.New("ServiceAgreement not found"))
 	} else if err != nil {
 		_ = c.AbortWithError(500, err)

--- a/web/sessions_controller_test.go
+++ b/web/sessions_controller_test.go
@@ -62,8 +62,7 @@ func TestSessionsController_Create(t *testing.T) {
 				assert.Equal(t, `{"authenticated":true}`, string(b))
 			} else {
 				require.True(t, resp.StatusCode >= 400, "Should not be able to create session")
-				var sessions []models.Session
-				err = app.Store.All(&sessions)
+				sessions, err := app.Store.Sessions(0, 1)
 				assert.NoError(t, err)
 				assert.Empty(t, sessions)
 			}
@@ -92,8 +91,8 @@ func TestSessionsController_Create_ReapSessions(t *testing.T) {
 
 	assert.Equal(t, 200, resp.StatusCode)
 	gomega.NewGomegaWithT(t).Eventually(func() []models.Session {
-		sessions := []models.Session{}
-		assert.Nil(t, app.Store.All(&sessions))
+		sessions, err := app.Store.Sessions(0, 10)
+		assert.NoError(t, err)
 		return sessions
 	}).Should(gomega.HaveLen(1))
 }
@@ -171,8 +170,8 @@ func TestSessionsController_Destroy_ReapSessions(t *testing.T) {
 
 	assert.Equal(t, 200, resp.StatusCode)
 	gomega.NewGomegaWithT(t).Eventually(func() []models.Session {
-		sessions := []models.Session{}
-		assert.Nil(t, app.Store.All(&sessions))
+		sessions, err := app.Store.Sessions(0, 10)
+		assert.NoError(t, err)
 		return sessions
 	}).Should(gomega.HaveLen(0))
 }

--- a/web/sessions_controller_test.go
+++ b/web/sessions_controller_test.go
@@ -21,7 +21,7 @@ func TestSessionsController_Create(t *testing.T) {
 	user := cltest.MustUser("email@test.net", "password123")
 	app, cleanup := cltest.NewApplication()
 	app.Start()
-	err := app.Store.Save(&user)
+	err := app.Store.SaveUser(&user)
 	assert.NoError(t, err)
 	defer cleanup()
 
@@ -77,13 +77,13 @@ func TestSessionsController_Create_ReapSessions(t *testing.T) {
 	user := cltest.MustUser("email@test.net", "password123")
 	app, cleanup := cltest.NewApplication()
 	app.Start()
-	err := app.Store.Save(&user)
+	err := app.Store.SaveUser(&user)
 	assert.NoError(t, err)
 	defer cleanup()
 
 	staleSession := cltest.NewSession()
 	staleSession.LastUsed = models.Time{time.Now().Add(-cltest.MustParseDuration("241h"))}
-	require.NoError(t, app.Store.Save(&staleSession))
+	require.NoError(t, app.Store.SaveSession(&staleSession))
 
 	body := fmt.Sprintf(`{"email":"%s","password":"%s"}`, "email@test.net", "password123")
 	resp, err := http.Post(app.Config.ClientNodeURL()+"/sessions", "application/json", bytes.NewBufferString(body))
@@ -104,11 +104,11 @@ func TestSessionsController_Destroy(t *testing.T) {
 	seedUser := cltest.MustUser("email@test.net", "password123")
 	app, cleanup := cltest.NewApplication()
 	app.Start()
-	err := app.Store.Save(&seedUser)
+	err := app.Store.SaveUser(&seedUser)
 	assert.NoError(t, err)
 
 	correctSession := models.NewSession()
-	require.NoError(t, app.Store.Save(&correctSession))
+	require.NoError(t, app.Store.SaveSession(&correctSession))
 	defer cleanup()
 
 	config := app.Store.Config
@@ -151,16 +151,16 @@ func TestSessionsController_Destroy_ReapSessions(t *testing.T) {
 	defer cleanup()
 
 	app.Start()
-	err := app.Store.Save(&user)
+	err := app.Store.SaveUser(&user)
 	assert.NoError(t, err)
 
 	correctSession := models.NewSession()
-	require.NoError(t, app.Store.Save(&correctSession))
+	require.NoError(t, app.Store.SaveSession(&correctSession))
 	cookie := cltest.MustGenerateSessionCookie(correctSession.ID)
 
 	staleSession := cltest.NewSession()
 	staleSession.LastUsed = models.Time{time.Now().Add(-cltest.MustParseDuration("241h"))}
-	require.NoError(t, app.Store.Save(&staleSession))
+	require.NoError(t, app.Store.SaveSession(&staleSession))
 
 	request, err := http.NewRequest("DELETE", app.Config.ClientNodeURL()+"/sessions", nil)
 	assert.NoError(t, err)

--- a/web/snapshots_controller.go
+++ b/web/snapshots_controller.go
@@ -3,10 +3,10 @@ package web
 import (
 	"errors"
 
-	"github.com/asdine/storm"
 	"github.com/gin-gonic/gin"
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/orm"
 )
 
 // SnapshotsController manages Snapshot requests.
@@ -20,7 +20,7 @@ type SnapshotsController struct {
 func (sc *SnapshotsController) CreateSnapshot(c *gin.Context) {
 	id := c.Param("AID")
 
-	if j, err := sc.App.GetStore().FindJob(id); err == storm.ErrNotFound {
+	if j, err := sc.App.GetStore().FindJob(id); err == orm.ErrorNotFound {
 		publicError(c, 404, errors.New("Job not found"))
 	} else if err != nil {
 		c.AbortWithError(500, err)
@@ -37,7 +37,7 @@ func (sc *SnapshotsController) CreateSnapshot(c *gin.Context) {
 func (sc *SnapshotsController) ShowSnapshot(c *gin.Context) {
 	id := c.Param("ID")
 
-	if jr, err := sc.App.GetStore().FindJobRun(id); err == storm.ErrNotFound {
+	if jr, err := sc.App.GetStore().FindJobRun(id); err == orm.ErrorNotFound {
 		publicError(c, 404, errors.New("Job not found"))
 	} else if err != nil {
 		c.AbortWithError(500, err)

--- a/web/tx_attempts_controller.go
+++ b/web/tx_attempts_controller.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/orm"
 )
 
 // TxAttemptsController lists TxAttempts requests.
@@ -24,10 +25,10 @@ func (tac *TxAttemptsController) Index(c *gin.Context) {
 	}
 
 	var attempts []models.TxAttempt
-	query, count, countErr := getTxAttempts(tac.App.GetStore(), size, offset)
-	if countErr != nil {
+	query, count, err := getTxAttempts(tac.App.GetStore(), size, offset)
+	if err != nil {
 		c.AbortWithError(500, err)
-	} else if err := query.Find(&attempts); err == storm.ErrNotFound {
+	} else if err := query.Find(&attempts); err == orm.ErrorNotFound {
 		c.Data(404, MediaType, emptyJSON)
 	} else if err != nil {
 		c.AbortWithError(500, fmt.Errorf("error getting paged TxAttempts: %+v", err))
@@ -39,7 +40,7 @@ func (tac *TxAttemptsController) Index(c *gin.Context) {
 }
 
 func getTxAttempts(store *store.Store, size int, offset int) (storm.Query, int, error) {
-	count, countErr := store.Count(&models.TxAttempt{})
+	count, err := store.Count(&models.TxAttempt{})
 	query := store.Select().OrderBy("SentAt").Reverse().Limit(size).Skip(offset)
-	return query, count, countErr
+	return query, count, err
 }

--- a/web/tx_attempts_controller.go
+++ b/web/tx_attempts_controller.go
@@ -21,7 +21,7 @@ func (tac *TxAttemptsController) Index(c *gin.Context) {
 		return
 	}
 
-	attempts, count, err := tac.App.GetStore().GetTxAttempts(offset, size)
+	attempts, count, err := tac.App.GetStore().TxAttempts(offset, size)
 	if err == orm.ErrorNotFound {
 		c.Data(404, MediaType, emptyJSON)
 	} else if err != nil {

--- a/web/tx_attempts_controller.go
+++ b/web/tx_attempts_controller.go
@@ -3,11 +3,8 @@ package web
 import (
 	"fmt"
 
-	"github.com/asdine/storm"
 	"github.com/gin-gonic/gin"
 	"github.com/smartcontractkit/chainlink/services"
-	"github.com/smartcontractkit/chainlink/store"
-	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/store/orm"
 )
 
@@ -24,11 +21,8 @@ func (tac *TxAttemptsController) Index(c *gin.Context) {
 		return
 	}
 
-	var attempts []models.TxAttempt
-	query, count, err := getTxAttempts(tac.App.GetStore(), size, offset)
-	if err != nil {
-		c.AbortWithError(500, err)
-	} else if err := query.Find(&attempts); err == orm.ErrorNotFound {
+	attempts, count, err := tac.App.GetStore().GetTxAttempts(offset, size)
+	if err == orm.ErrorNotFound {
 		c.Data(404, MediaType, emptyJSON)
 	} else if err != nil {
 		c.AbortWithError(500, fmt.Errorf("error getting paged TxAttempts: %+v", err))
@@ -37,10 +31,4 @@ func (tac *TxAttemptsController) Index(c *gin.Context) {
 	} else {
 		c.Data(200, MediaType, buffer)
 	}
-}
-
-func getTxAttempts(store *store.Store, size int, offset int) (storm.Query, int, error) {
-	count, err := store.Count(&models.TxAttempt{})
-	query := store.Select().OrderBy("SentAt").Reverse().Limit(size).Skip(offset)
-	return query, count, err
 }

--- a/web/tx_attempts_controller_test.go
+++ b/web/tx_attempts_controller_test.go
@@ -29,9 +29,9 @@ func TestTxAttemptsController_Index_Success(t *testing.T) {
 
 	from := cltest.GetAccountAddress(store)
 	tx := cltest.CreateTxAndAttempt(store, from, 1)
-	_, err := store.AddAttempt(tx, tx.EthTx(big.NewInt(2)), 2)
+	_, err := store.AddTxAttempt(tx, tx.EthTx(big.NewInt(2)), 2)
 	require.NoError(t, err)
-	_, err = store.AddAttempt(tx, tx.EthTx(big.NewInt(3)), 3)
+	_, err = store.AddTxAttempt(tx, tx.EthTx(big.NewInt(3)), 3)
 	require.NoError(t, err)
 
 	resp, cleanup := client.Get("/v2/txattempts?size=2")

--- a/web/user_controller.go
+++ b/web/user_controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/asdine/storm/q"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/gin-gonic/contrib/sessions"
 	"github.com/gin-gonic/gin"
@@ -13,7 +12,6 @@ import (
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store"
 	"github.com/smartcontractkit/chainlink/store/models"
-	"github.com/smartcontractkit/chainlink/store/orm"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 	"github.com/smartcontractkit/chainlink/utils"
 )
@@ -32,23 +30,6 @@ func (c *UserController) getCurrentSessionID(ctx *gin.Context) (string, error) {
 	return sessionID, nil
 }
 
-func (c *UserController) clearNonCurrentSessions(sessionID string) error {
-	var sessions []models.Session
-	err := c.App.GetStore().Select(q.Not(q.Eq("ID", sessionID))).Find(&sessions)
-	if err != nil && err != orm.ErrorNotFound {
-		return err
-	}
-
-	for _, s := range sessions {
-		err := c.App.GetStore().DeleteStruct(&s)
-		if err != nil {
-			return err
-		}
-	}
-
-	return nil
-}
-
 func (c *UserController) saveNewPassword(user *models.User, newPassword string) error {
 	hashedPassword, err := utils.HashPassword(newPassword)
 	if err != nil {
@@ -61,7 +42,7 @@ func (c *UserController) saveNewPassword(user *models.User, newPassword string) 
 func (c *UserController) updateUserPassword(ctx *gin.Context, user *models.User, newPassword string) error {
 	if sessionID, err := c.getCurrentSessionID(ctx); err != nil {
 		return err
-	} else if err := c.clearNonCurrentSessions(sessionID); err != nil {
+	} else if err := c.App.GetStore().ClearNonCurrentSessions(sessionID); err != nil {
 		return fmt.Errorf("failed to clear non current user sessions: %+v", err)
 	} else if err := c.saveNewPassword(user, newPassword); err != nil {
 		return fmt.Errorf("failed to update current user password: %+v", err)

--- a/web/user_controller.go
+++ b/web/user_controller.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/asdine/storm"
 	"github.com/asdine/storm/q"
 	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/gin-gonic/contrib/sessions"
@@ -14,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/store/orm"
 	"github.com/smartcontractkit/chainlink/store/presenters"
 	"github.com/smartcontractkit/chainlink/utils"
 )
@@ -35,7 +35,7 @@ func (c *UserController) getCurrentSessionID(ctx *gin.Context) (string, error) {
 func (c *UserController) clearNonCurrentSessions(sessionID string) error {
 	var sessions []models.Session
 	err := c.App.GetStore().Select(q.Not(q.Eq("ID", sessionID))).Find(&sessions)
-	if err != nil && err != storm.ErrNotFound {
+	if err != nil && err != orm.ErrorNotFound {
 		return err
 	}
 

--- a/web/user_controller.go
+++ b/web/user_controller.go
@@ -36,7 +36,7 @@ func (c *UserController) saveNewPassword(user *models.User, newPassword string) 
 		return err
 	}
 	user.HashedPassword = hashedPassword
-	return c.App.GetStore().Save(user)
+	return c.App.GetStore().SaveUser(user)
 }
 
 func (c *UserController) updateUserPassword(ctx *gin.Context, user *models.User, newPassword string) error {


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/162865488

There are some notable exceptions to the encapsulation:

1. A select few `Save(...)` inside of tests that deliberately want to bypass normal logic. These have been explicitly marked with `ORM.DB.Save(...)`
2. services/bulk_run_deleter.go
3. store/migrations/**/*
4. web/backup_controller.go

`bulk_run_deleter.go`, `backup_controller.go`, and `migrations` of these will be gutted if not outright deleted which is why effort wasn't spent in encapsulating them into `orm`. What's also notable is that because of our typing inside migrations, we in effect have multiple models for many types. i.e.: `migration0.JobRun`, `migration1537223654.JobRun`, `migration1536696950.JobRun`, etc. This further reinforces the decision to skip the encapsulation effort in `migrations`.
