### PR TITLE
CLI command to give node's ETH away

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -161,6 +161,11 @@ func NewApp(client *Client) *cli.App {
 			Action: client.Withdraw,
 		},
 		{
+			Name:   "sendether",
+			Usage:  "Send <amount> ETH from the node's ETH account to an <address>.",
+			Action: client.SendEther,
+		},
+		{
 			Name:   "chpass",
 			Usage:  "Change your password",
 			Action: client.ChangePassword,

--- a/cmd/remote_client.go
+++ b/cmd/remote_client.go
@@ -318,6 +318,47 @@ func (cli *Client) Withdraw(c *clipkg.Context) error {
 	return cli.printResponseBody(resp)
 }
 
+// SendEther transfers ETH from the node's account to a specified address.
+func (cli *Client) SendEther(c *clipkg.Context) error {
+	if c.NArg() != 2 {
+		return cli.errorOut(errors.New("sendether expects two arguments: an amount and an address"))
+	}
+
+	amount, err := strconv.ParseInt(c.Args().Get(1), 10, 64)
+	if err != nil {
+		return cli.errorOut(multierr.Combine(
+			errors.New("while parsing ETH transfer amount"), err))
+	}
+
+	unparsedDestinationAddress := c.Args().Get(1)
+	destinationAddress, err := utils.ParseEthereumAddress(unparsedDestinationAddress)
+	if err != nil {
+		return cli.errorOut(multierr.Combine(
+			fmt.Errorf("while parsing withdrawal destination address %v",
+				unparsedDestinationAddress), err))
+	}
+
+	request := models.SendEtherRequest{
+		DestinationAddress: destinationAddress,
+		Amount:             assets.NewEth(amount),
+	}
+
+	requestData, err := json.Marshal(request)
+	if err != nil {
+		return cli.errorOut(err)
+	}
+
+	buf := bytes.NewBuffer(requestData)
+
+	resp, err := cli.HTTP.Post("/v2/ethtransfers", buf)
+	if err != nil {
+		return cli.errorOut(err)
+	}
+	defer resp.Body.Close()
+
+	return cli.printResponseBody(resp)
+}
+
 // ChangePassword prompts the user for the old password and a new one, then
 // posts it to Chainlink to change the password.
 func (cli *Client) ChangePassword(c *clipkg.Context) error {

--- a/cmd/remote_client.go
+++ b/cmd/remote_client.go
@@ -324,7 +324,7 @@ func (cli *Client) SendEther(c *clipkg.Context) error {
 		return cli.errorOut(errors.New("sendether expects two arguments: an amount and an address"))
 	}
 
-	amount, err := strconv.ParseInt(c.Args().Get(1), 10, 64)
+	amount, err := strconv.ParseInt(c.Args().Get(0), 10, 64)
 	if err != nil {
 		return cli.errorOut(multierr.Combine(
 			errors.New("while parsing ETH transfer amount"), err))
@@ -350,7 +350,7 @@ func (cli *Client) SendEther(c *clipkg.Context) error {
 
 	buf := bytes.NewBuffer(requestData)
 
-	resp, err := cli.HTTP.Post("/v2/ethtransfers", buf)
+	resp, err := cli.HTTP.Post("/v2/transfers", buf)
 	if err != nil {
 		return cli.errorOut(err)
 	}

--- a/cmd/remote_client_test.go
+++ b/cmd/remote_client_test.go
@@ -494,6 +494,21 @@ func first(a models.JobSpec, b interface{}) models.JobSpec {
 	return a
 }
 
+func TestClient_SendEther(t *testing.T) {
+	app, cleanup, _ := setupWithdrawalsApplication()
+	defer cleanup()
+
+	assert.NoError(t, app.StartAndConnect())
+
+	client, _ := app.NewClientAndRenderer()
+	set := flag.NewFlagSet("sendether", 0)
+	set.Parse([]string{"100", "0x342156c8d3bA54Abc67920d35ba1d1e67201aC9C"})
+
+	c := cli.NewContext(nil, set, nil)
+
+	assert.Nil(t, client.SendEther(c))
+}
+
 func TestClient_ChangePassword(t *testing.T) {
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -881,10 +881,15 @@ func AssertServerResponse(t *testing.T, resp *http.Response, expectedStatusCode 
 	}
 
 	if resp.StatusCode >= 300 && resp.StatusCode < 600 {
-		var result map[string][]string
-		err := json.Unmarshal(ParseResponseBody(resp), &result)
+		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {
-			assert.FailNowf(t, "Unable to unmarshal json", err.Error())
+			assert.FailNowf(t, "Unable to read body", err.Error())
+		}
+
+		var result map[string][]string
+		err = json.Unmarshal(b, &result)
+		if err != nil {
+			assert.FailNowf(t, fmt.Sprintf("Unable to unmarshal json from body '%s'", string(b)), err.Error())
 		}
 
 		assert.FailNowf(t, "Request failed", "Expected %d response, got %d with errors: %s", expectedStatusCode, resp.StatusCode, result["errors"])

--- a/main_test.go
+++ b/main_test.go
@@ -53,6 +53,7 @@ func ExampleRun() {
 	//      removebridge              Removes a specific bridge
 	//      agree, createsa           Creates a service agreement
 	//      withdraw, w               Withdraw, to an authorized Ethereum <address>, <amount> units of LINK. Withdraws from the configured oracle contract by default, or from contract optionally specified by a third command-line argument --from-oracle-contract-address=<contract address>. Address inputs must be in EIP55-compliant capitalization.
+	//      sendether                 Send <amount> ETH from the node's ETH account to an <address>.
 	//      chpass                    Change your password
 	//      txattempts                List the transaction attempts in descending order
 	//      help, h                   Shows a list of commands or help for one command

--- a/store/mock_store/mocks.go
+++ b/store/mock_store/mocks.go
@@ -41,6 +41,7 @@ func (m *MockTxManager) EXPECT() *MockTxManagerMockRecorder {
 
 // Connect mocks base method
 func (m *MockTxManager) Connect(arg0 *models.IndexableBlockNumber) error {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Connect", arg0)
 	ret0, _ := ret[0].(error)
 	return ret0
@@ -48,11 +49,13 @@ func (m *MockTxManager) Connect(arg0 *models.IndexableBlockNumber) error {
 
 // Connect indicates an expected call of Connect
 func (mr *MockTxManagerMockRecorder) Connect(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connect", reflect.TypeOf((*MockTxManager)(nil).Connect), arg0)
 }
 
 // Connected mocks base method
 func (m *MockTxManager) Connected() bool {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Connected")
 	ret0, _ := ret[0].(bool)
 	return ret0
@@ -60,11 +63,13 @@ func (m *MockTxManager) Connected() bool {
 
 // Connected indicates an expected call of Connected
 func (mr *MockTxManagerMockRecorder) Connected() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Connected", reflect.TypeOf((*MockTxManager)(nil).Connected))
 }
 
 // ContractLINKBalance mocks base method
 func (m *MockTxManager) ContractLINKBalance(arg0 models.WithdrawalRequest) (assets.Link, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ContractLINKBalance", arg0)
 	ret0, _ := ret[0].(assets.Link)
 	ret1, _ := ret[1].(error)
@@ -73,11 +78,13 @@ func (m *MockTxManager) ContractLINKBalance(arg0 models.WithdrawalRequest) (asse
 
 // ContractLINKBalance indicates an expected call of ContractLINKBalance
 func (mr *MockTxManagerMockRecorder) ContractLINKBalance(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ContractLINKBalance", reflect.TypeOf((*MockTxManager)(nil).ContractLINKBalance), arg0)
 }
 
 // CreateTx mocks base method
 func (m *MockTxManager) CreateTx(arg0 common.Address, arg1 []byte) (*models.Tx, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTx", arg0, arg1)
 	ret0, _ := ret[0].(*models.Tx)
 	ret1, _ := ret[1].(error)
@@ -86,11 +93,28 @@ func (m *MockTxManager) CreateTx(arg0 common.Address, arg1 []byte) (*models.Tx, 
 
 // CreateTx indicates an expected call of CreateTx
 func (mr *MockTxManagerMockRecorder) CreateTx(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTx", reflect.TypeOf((*MockTxManager)(nil).CreateTx), arg0, arg1)
+}
+
+// CreateTxWithEth mocks base method
+func (m *MockTxManager) CreateTxWithEth(arg0 common.Address, arg1 *assets.Eth) (*models.Tx, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateTxWithEth", arg0, arg1)
+	ret0, _ := ret[0].(*models.Tx)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateTxWithEth indicates an expected call of CreateTxWithEth
+func (mr *MockTxManagerMockRecorder) CreateTxWithEth(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTxWithEth", reflect.TypeOf((*MockTxManager)(nil).CreateTxWithEth), arg0, arg1)
 }
 
 // CreateTxWithGas mocks base method
 func (m *MockTxManager) CreateTxWithGas(arg0 common.Address, arg1 []byte, arg2 *big.Int, arg3 uint64) (*models.Tx, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateTxWithGas", arg0, arg1, arg2, arg3)
 	ret0, _ := ret[0].(*models.Tx)
 	ret1, _ := ret[1].(error)
@@ -99,21 +123,25 @@ func (m *MockTxManager) CreateTxWithGas(arg0 common.Address, arg1 []byte, arg2 *
 
 // CreateTxWithGas indicates an expected call of CreateTxWithGas
 func (mr *MockTxManagerMockRecorder) CreateTxWithGas(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTxWithGas", reflect.TypeOf((*MockTxManager)(nil).CreateTxWithGas), arg0, arg1, arg2, arg3)
 }
 
 // Disconnect mocks base method
 func (m *MockTxManager) Disconnect() {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Disconnect")
 }
 
 // Disconnect indicates an expected call of Disconnect
 func (mr *MockTxManagerMockRecorder) Disconnect() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Disconnect", reflect.TypeOf((*MockTxManager)(nil).Disconnect))
 }
 
 // GetBlockByNumber mocks base method
 func (m *MockTxManager) GetBlockByNumber(arg0 string) (models.BlockHeader, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBlockByNumber", arg0)
 	ret0, _ := ret[0].(models.BlockHeader)
 	ret1, _ := ret[1].(error)
@@ -122,11 +150,13 @@ func (m *MockTxManager) GetBlockByNumber(arg0 string) (models.BlockHeader, error
 
 // GetBlockByNumber indicates an expected call of GetBlockByNumber
 func (mr *MockTxManagerMockRecorder) GetBlockByNumber(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlockByNumber", reflect.TypeOf((*MockTxManager)(nil).GetBlockByNumber), arg0)
 }
 
 // GetEthBalance mocks base method
 func (m *MockTxManager) GetEthBalance(arg0 common.Address) (*assets.Eth, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetEthBalance", arg0)
 	ret0, _ := ret[0].(*assets.Eth)
 	ret1, _ := ret[1].(error)
@@ -135,11 +165,13 @@ func (m *MockTxManager) GetEthBalance(arg0 common.Address) (*assets.Eth, error) 
 
 // GetEthBalance indicates an expected call of GetEthBalance
 func (mr *MockTxManagerMockRecorder) GetEthBalance(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetEthBalance", reflect.TypeOf((*MockTxManager)(nil).GetEthBalance), arg0)
 }
 
 // GetLINKBalance mocks base method
 func (m *MockTxManager) GetLINKBalance(arg0 common.Address) (*assets.Link, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLINKBalance", arg0)
 	ret0, _ := ret[0].(*assets.Link)
 	ret1, _ := ret[1].(error)
@@ -148,11 +180,13 @@ func (m *MockTxManager) GetLINKBalance(arg0 common.Address) (*assets.Link, error
 
 // GetLINKBalance indicates an expected call of GetLINKBalance
 func (mr *MockTxManagerMockRecorder) GetLINKBalance(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLINKBalance", reflect.TypeOf((*MockTxManager)(nil).GetLINKBalance), arg0)
 }
 
 // GetLogs mocks base method
 func (m *MockTxManager) GetLogs(arg0 go_ethereum.FilterQuery) ([]store.Log, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetLogs", arg0)
 	ret0, _ := ret[0].([]store.Log)
 	ret1, _ := ret[1].(error)
@@ -161,11 +195,13 @@ func (m *MockTxManager) GetLogs(arg0 go_ethereum.FilterQuery) ([]store.Log, erro
 
 // GetLogs indicates an expected call of GetLogs
 func (mr *MockTxManagerMockRecorder) GetLogs(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetLogs", reflect.TypeOf((*MockTxManager)(nil).GetLogs), arg0)
 }
 
 // MeetsMinConfirmations mocks base method
 func (m *MockTxManager) MeetsMinConfirmations(arg0 common.Hash) (bool, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "MeetsMinConfirmations", arg0)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
@@ -174,11 +210,13 @@ func (m *MockTxManager) MeetsMinConfirmations(arg0 common.Hash) (bool, error) {
 
 // MeetsMinConfirmations indicates an expected call of MeetsMinConfirmations
 func (mr *MockTxManagerMockRecorder) MeetsMinConfirmations(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "MeetsMinConfirmations", reflect.TypeOf((*MockTxManager)(nil).MeetsMinConfirmations), arg0)
 }
 
 // NextActiveAccount mocks base method
 func (m *MockTxManager) NextActiveAccount() *store.ManagedAccount {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NextActiveAccount")
 	ret0, _ := ret[0].(*store.ManagedAccount)
 	return ret0
@@ -186,31 +224,37 @@ func (m *MockTxManager) NextActiveAccount() *store.ManagedAccount {
 
 // NextActiveAccount indicates an expected call of NextActiveAccount
 func (mr *MockTxManagerMockRecorder) NextActiveAccount() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NextActiveAccount", reflect.TypeOf((*MockTxManager)(nil).NextActiveAccount))
 }
 
 // OnNewHead mocks base method
 func (m *MockTxManager) OnNewHead(arg0 *models.BlockHeader) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "OnNewHead", arg0)
 }
 
 // OnNewHead indicates an expected call of OnNewHead
 func (mr *MockTxManagerMockRecorder) OnNewHead(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNewHead", reflect.TypeOf((*MockTxManager)(nil).OnNewHead), arg0)
 }
 
 // Register mocks base method
 func (m *MockTxManager) Register(arg0 []accounts.Account) {
+	m.ctrl.T.Helper()
 	m.ctrl.Call(m, "Register", arg0)
 }
 
 // Register indicates an expected call of Register
 func (mr *MockTxManagerMockRecorder) Register(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Register", reflect.TypeOf((*MockTxManager)(nil).Register), arg0)
 }
 
 // SubscribeToLogs mocks base method
 func (m *MockTxManager) SubscribeToLogs(arg0 chan<- store.Log, arg1 go_ethereum.FilterQuery) (models.EthSubscription, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubscribeToLogs", arg0, arg1)
 	ret0, _ := ret[0].(models.EthSubscription)
 	ret1, _ := ret[1].(error)
@@ -219,11 +263,13 @@ func (m *MockTxManager) SubscribeToLogs(arg0 chan<- store.Log, arg1 go_ethereum.
 
 // SubscribeToLogs indicates an expected call of SubscribeToLogs
 func (mr *MockTxManagerMockRecorder) SubscribeToLogs(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeToLogs", reflect.TypeOf((*MockTxManager)(nil).SubscribeToLogs), arg0, arg1)
 }
 
 // SubscribeToNewHeads mocks base method
 func (m *MockTxManager) SubscribeToNewHeads(arg0 chan<- models.BlockHeader) (models.EthSubscription, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SubscribeToNewHeads", arg0)
 	ret0, _ := ret[0].(models.EthSubscription)
 	ret1, _ := ret[1].(error)
@@ -232,11 +278,13 @@ func (m *MockTxManager) SubscribeToNewHeads(arg0 chan<- models.BlockHeader) (mod
 
 // SubscribeToNewHeads indicates an expected call of SubscribeToNewHeads
 func (mr *MockTxManagerMockRecorder) SubscribeToNewHeads(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SubscribeToNewHeads", reflect.TypeOf((*MockTxManager)(nil).SubscribeToNewHeads), arg0)
 }
 
 // WithdrawLINK mocks base method
 func (m *MockTxManager) WithdrawLINK(arg0 models.WithdrawalRequest) (common.Hash, error) {
+	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "WithdrawLINK", arg0)
 	ret0, _ := ret[0].(common.Hash)
 	ret1, _ := ret[1].(error)
@@ -245,5 +293,6 @@ func (m *MockTxManager) WithdrawLINK(arg0 models.WithdrawalRequest) (common.Hash
 
 // WithdrawLINK indicates an expected call of WithdrawLINK
 func (mr *MockTxManagerMockRecorder) WithdrawLINK(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WithdrawLINK", reflect.TypeOf((*MockTxManager)(nil).WithdrawLINK), arg0)
 }

--- a/store/models/common.go
+++ b/store/models/common.go
@@ -323,6 +323,12 @@ type WithdrawalRequest struct {
 	Amount             *assets.Link   `json:"amount"`
 }
 
+// SendEtherRequest represents a request to transfer ETH.
+type SendEtherRequest struct {
+	DestinationAddress common.Address `json:"address"`
+	Amount             *assets.Eth    `json:"amount"`
+}
+
 // Int stores large integers and can deserialize a variety of inputs.
 type Int big.Int
 

--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -156,12 +156,13 @@ func normalize(gasPriceWei *big.Int, gasLimit uint64, config Config) (*big.Int, 
 	return gasPriceWei, gasLimit
 }
 
-func (txm *EthTxManager) createTxWithNonceReload(
+func (txm *EthTxManager) createEthTxWithNonceReload(
 	ma *ManagedAccount,
 	to common.Address,
 	data []byte,
 	gasPriceWei *big.Int,
 	gasLimit uint64,
+	value *assets.Eth,
 	nrc uint) (*models.Tx, error) {
 	blkNum, err := txm.GetBlockNumber()
 	if err != nil {
@@ -175,7 +176,7 @@ func (txm *EthTxManager) createTxWithNonceReload(
 			nonce,
 			to,
 			data,
-			big.NewInt(0),
+			value.ToInt(),
 			gasLimit,
 		)
 		if err != nil {
@@ -218,6 +219,23 @@ func (txm *EthTxManager) createTxWithNonceReload(
 	}
 
 	return tx, err
+}
+
+func (txm *EthTxManager) createTxWithNonceReload(
+	ma *ManagedAccount,
+	to common.Address,
+	data []byte,
+	gasPriceWei *big.Int,
+	gasLimit uint64,
+	nrc uint) (*models.Tx, error) {
+	return createEthTxWithNonceReload(
+		ma,
+		to,
+		data,
+		gasPriceWei,
+		gasLimit,
+		assets.NewETH(0),
+		nrc)
 }
 
 // GetLINKBalance returns the balance of LINK at the given address

--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -1,3 +1,4 @@
+//go:generate mockgen -package=mock_store -destination=mock_store/mocks.go github.com/smartcontractkit/chainlink/store TxManager
 package store
 
 import (

--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -1,4 +1,3 @@
-//go:generate mockgen -package=mock_store -destination=mock_store/mocks.go github.com/smartcontractkit/chainlink/store TxManager
 package store
 
 import (
@@ -50,6 +49,8 @@ type TxManager interface {
 	SubscribeToLogs(channel chan<- Log, q ethereum.FilterQuery) (models.EthSubscription, error)
 	GetLogs(q ethereum.FilterQuery) ([]Log, error)
 }
+
+//go:generate mockgen -package=mock_store -destination=mock_store/mocks.go github.com/smartcontractkit/chainlink/store TxManager
 
 // EthTxManager contains fields for the Ethereum client, the KeyStore,
 // the local Config for the application, and the database.

--- a/web/router.go
+++ b/web/router.go
@@ -172,6 +172,9 @@ func v2Routes(app services.Application, engine *gin.Engine) {
 		w := WithdrawalsController{app}
 		authv2.POST("/withdrawals", w.Create)
 
+		ts := TransfersController{app}
+		authv2.POST("/transfers", ts.Create)
+
 		backup := BackupController{app}
 		authv2.GET("/backup", backup.Show)
 

--- a/web/transfer_controller.go
+++ b/web/transfer_controller.go
@@ -24,7 +24,7 @@ func (tc *TransfersController) Create(c *gin.Context) {
 	if err := c.ShouldBindJSON(&tr); err != nil {
 		publicError(c, 400, err)
 		return
-	} else if tx, err := store.TxManager.CreateTx(tr.DestinationAddress, []byte{}); err != nil {
+	} else if tx, err := store.TxManager.CreateTxWithEth(tr.DestinationAddress, tr.Amount); err != nil {
 		publicError(c, 400, fmt.Errorf("Transaction failed: %v", err))
 	} else {
 		c.JSON(200, tx)

--- a/web/transfer_controller.go
+++ b/web/transfer_controller.go
@@ -23,7 +23,6 @@ func (tc *TransfersController) Create(c *gin.Context) {
 
 	if err := c.ShouldBindJSON(&tr); err != nil {
 		publicError(c, 400, err)
-		return
 	} else if tx, err := store.TxManager.CreateTxWithEth(tr.DestinationAddress, tr.Amount); err != nil {
 		publicError(c, 400, fmt.Errorf("Transaction failed: %v", err))
 	} else {

--- a/web/transfer_controller.go
+++ b/web/transfer_controller.go
@@ -1,0 +1,32 @@
+package web
+
+import (
+	"fmt"
+
+	"github.com/gin-gonic/gin"
+	"github.com/smartcontractkit/chainlink/services"
+	"github.com/smartcontractkit/chainlink/store/models"
+)
+
+// TransfersController can send LINK tokens to another address
+type TransfersController struct {
+	App services.Application
+}
+
+// Create sends ETH from the Chainlink's account to a specified address.
+//
+// Example: "<application>/withdrawals"
+func (tc *TransfersController) Create(c *gin.Context) {
+	var tr models.SendEtherRequest
+
+	store := tc.App.GetStore()
+
+	if err := c.ShouldBindJSON(&tr); err != nil {
+		publicError(c, 400, err)
+		return
+	} else if tx, err := store.TxManager.CreateTx(tr.DestinationAddress, []byte{}); err != nil {
+		publicError(c, 400, fmt.Errorf("Transaction failed: %v", err))
+	} else {
+		c.JSON(200, tx)
+	}
+}

--- a/web/transfer_controller_test.go
+++ b/web/transfer_controller_test.go
@@ -1,0 +1,36 @@
+package web_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink/internal/cltest"
+	"github.com/smartcontractkit/chainlink/store/assets"
+	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTransfersController_CreateSuccess(t *testing.T) {
+	config, _ := cltest.NewConfig()
+	app, cleanup := cltest.NewApplicationWithConfigAndKeyStore(config)
+	defer cleanup()
+
+	client := app.NewHTTPClient()
+
+	assert.NoError(t, app.StartAndConnect())
+
+	request := models.SendEtherRequest{
+		DestinationAddress: common.HexToAddress("0xFA01FA015C8A5332987319823728982379128371"),
+		Amount:             assets.NewEth(100),
+	}
+
+	body, err := json.Marshal(&request)
+	assert.NoError(t, err)
+
+	resp, cleanup := client.Post("/v2/transfers", bytes.NewBuffer(body))
+	defer cleanup()
+
+	cltest.AssertServerResponse(t, resp, 200)
+}

--- a/web/transfer_controller_test.go
+++ b/web/transfer_controller_test.go
@@ -95,7 +95,7 @@ func TestTransfersController_JSONBindingError(t *testing.T) {
 
 	assert.NoError(t, app.StartAndConnect())
 
-	resp, cleanup := client.Post("/v2/transfers", bytes.NewBuffer([]byte("{}")))
+	resp, cleanup := client.Post("/v2/transfers", bytes.NewBuffer([]byte(`{"address":""}`)))
 	defer cleanup()
 
 	cltest.AssertServerResponse(t, resp, 400)

--- a/web/transfer_controller_test.go
+++ b/web/transfer_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/store/models"
+	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -16,6 +17,14 @@ func TestTransfersController_CreateSuccess(t *testing.T) {
 	config, _ := cltest.NewConfig()
 	app, cleanup := cltest.NewApplicationWithConfigAndKeyStore(config)
 	defer cleanup()
+
+	ethMock := app.MockEthClient()
+	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_getTransactionCount", "0x100")
+		ethMock.Register("eth_getBlockByNumber", models.BlockHeader{})
+		ethMock.Register("eth_blockNumber", utils.Uint64ToHex(0))
+		ethMock.Register("eth_sendRawTransaction", cltest.NewHash())
+	})
 
 	client := app.NewHTTPClient()
 


### PR DESCRIPTION
Adds the sendether cli command for sending ETH to a specified account.

[Finishes #162149295]

<img width="955" alt="screen shot 2019-01-07 at 15 08 16" src="https://user-images.githubusercontent.com/344071/50796235-26601d80-128e-11e9-8fb2-7fd0d668f2d5.png">
