### PR TITLE
Redact passwords in logs

### DIFF
--- a/web/router.go
+++ b/web/router.go
@@ -299,9 +299,11 @@ func readBody(reader io.Reader) string {
 
 // NOTE: keys must be in lowercase for case insensitive match
 var blacklist = map[string]struct{}{
-	"password":    struct{}{},
-	"newpassword": struct{}{},
-	"oldpassword": struct{}{},
+	"password":             struct{}{},
+	"newpassword":          struct{}{},
+	"oldpassword":          struct{}{},
+	"current_password":     struct{}{},
+	"new_account_password": struct{}{},
 }
 
 func readSanitizedJSON(buf *bytes.Buffer) (string, error) {


### PR DESCRIPTION
```
2019-01-17T14:58:26Z [INFO]  POST /v2/keys web/router.go:255 body={"current_password":"*REDACTED*","new_account_password":"*REDACTED*"} clientIP=127.0.0.1 latency=2.319704581s method=POST path=/v2/keys servedAt=2019-01-17 08:58:26 status=201
```

Could probably do strings.Contains(strings.ToLower(k), "password") and cover the entire blacklist later if we end up having to redact more keys containing password.