### PR TITLE
Fix error saving new head confirmations on first run (2)

### DIFF
--- a/adapters/eth_tx_test.go
+++ b/adapters/eth_tx_test.go
@@ -93,7 +93,6 @@ func TestEthTxAdapter_Perform_ConfirmedWithBytes(t *testing.T) {
 	inputValue := "cönfirmed" // contains diacritic acute to check bytes counted for length not chars
 
 	ethMock := app.MockEthClient()
-	ethMock.Register("eth_getBlockByNumber", models.BlockHeader{})
 	ethMock.Register("eth_getTransactionCount", `0x0100`)
 	require.NoError(t, app.StartAndConnect())
 
@@ -156,7 +155,6 @@ func TestEthTxAdapter_Perform_ConfirmedWithBytesAndNoDataPrefix(t *testing.T) {
 	inputValue := "cönfirmed"
 
 	ethMock := app.MockEthClient()
-	ethMock.Register("eth_getBlockByNumber", models.BlockHeader{})
 	ethMock.Register("eth_getTransactionCount", `0x0100`)
 	require.NoError(t, app.StartAndConnect())
 

--- a/integration/features_test.go
+++ b/integration/features_test.go
@@ -517,7 +517,6 @@ func TestIntegration_CreateServiceAgreement(t *testing.T) {
 	logs := make(chan models.Log, 1)
 	eth.Context("app.Start()", func(eth *cltest.EthMock) {
 		eth.RegisterSubscription("logs", logs)
-		eth.Register("eth_getBlockByNumber", models.BlockHeader{}) // services.(*HeadTracker).fastForwardHeadFromEth
 		eth.Register("eth_getTransactionCount", `0x100`)
 	})
 	assert.NoError(t, app.Start())
@@ -552,10 +551,6 @@ func TestIntegration_BulkDeleteRuns(t *testing.T) {
 
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
-	eth := app.MockEthClient()
-	eth.Context("app.Start()", func(eth *cltest.EthMock) {
-		eth.Register("eth_getBlockByNumber", models.BlockHeader{})
-	})
 	app.Start()
 
 	job := cltest.NewJobWithWebInitiator()

--- a/store/models/log_events_test.go
+++ b/store/models/log_events_test.go
@@ -204,7 +204,6 @@ func TestStartRunOrSALogSubscription_ValidateSenders(t *testing.T) {
 			eth := app.MockEthClient()
 			logs := make(chan models.Log, 1)
 			eth.Context("app.Start()", func(eth *cltest.EthMock) {
-				eth.Register("eth_getBlockByNumber", models.BlockHeader{})
 				eth.Register("eth_getTransactionCount", "0x1")
 				eth.RegisterSubscription("logs", logs)
 			})


### PR DESCRIPTION
Prevent double dispatch of first block confirmation,
warn on non later blocks.

https://www.pivotaltracker.com/story/show/163421657