### PR TITLE
parallelize cmd tests. add from flag to sendether

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -161,8 +161,14 @@ func NewApp(client *Client) *cli.App {
 			Action: client.Withdraw,
 		},
 		{
-			Name:   "sendether",
-			Usage:  "Send <amount> ETH from the node's ETH account to an <address>.",
+			Name:  "sendether",
+			Usage: "Send <amount> ETH from the node's ETH account to an <address>.",
+			Flags: []cli.Flag{
+				cli.StringFlag{
+					Name:  "from, f",
+					Usage: "optional flag to specify which address should send the transaction",
+				},
+			},
 			Action: client.SendEther,
 		},
 		{

--- a/cmd/client_test.go
+++ b/cmd/client_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestTerminalCookieAuthenticator_AuthenticateWithoutSession(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name, email, pwd string
 	}{
@@ -39,6 +41,8 @@ func TestTerminalCookieAuthenticator_AuthenticateWithoutSession(t *testing.T) {
 }
 
 func TestTerminalCookieAuthenticator_AuthenticateWithSession(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 	app.MustSeedUserSession()
@@ -79,6 +83,8 @@ func TestTerminalCookieAuthenticator_AuthenticateWithSession(t *testing.T) {
 }
 
 func TestDiskCookieStore_Retrieve(t *testing.T) {
+	t.Parallel()
+
 	tc, cleanup := cltest.NewConfig()
 	defer cleanup()
 	config := tc.Config
@@ -108,6 +114,8 @@ func TestDiskCookieStore_Retrieve(t *testing.T) {
 }
 
 func TestTerminalAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name           string
 		enteredStrings []string
@@ -145,6 +153,8 @@ func TestTerminalAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 }
 
 func TestTerminalAPIInitializer_InitializeWithExistingAPIUser(t *testing.T) {
+	t.Parallel()
+
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 
@@ -193,6 +203,8 @@ func TestFileAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 }
 
 func TestFileAPIInitializer_InitializeWithExistingAPIUser(t *testing.T) {
+	t.Parallel()
+
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 

--- a/cmd/local_client_test.go
+++ b/cmd/local_client_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestClient_RunNodeShowsEnv(t *testing.T) {
+	t.Parallel()
+
 	config, configCleanup := cltest.NewConfig()
 	defer configCleanup()
 	config.Set("LINK_CONTRACT_ADDRESS", "0x514910771AF9Ca656af840dff83E8264EcF986CA")
@@ -66,6 +68,8 @@ func TestClient_RunNodeShowsEnv(t *testing.T) {
 }
 
 func TestClient_RunNodeWithPasswords(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name         string
 		pwdfile      string
@@ -120,6 +124,8 @@ func TestClient_RunNodeWithPasswords(t *testing.T) {
 }
 
 func TestClient_RunNodeWithAPICredentialsFile(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name       string
 		apiFile    string

--- a/cmd/remote_client.go
+++ b/cmd/remote_client.go
@@ -338,8 +338,20 @@ func (cli *Client) SendEther(c *clipkg.Context) error {
 				unparsedDestinationAddress), err))
 	}
 
+	unparsedFromAddress := c.String("from")
+	fromAddress := common.Address{}
+	if unparsedFromAddress != "" {
+		fromAddress, err = utils.ParseEthereumAddress(unparsedFromAddress)
+		if err != nil {
+			return cli.errorOut(multierr.Combine(
+				fmt.Errorf("while parsing withdrawal from address %v",
+					unparsedFromAddress), err))
+		}
+	}
+
 	request := models.SendEtherRequest{
 		DestinationAddress: destinationAddress,
+		FromAddress:        fromAddress,
 		Amount:             assets.NewEth(amount),
 	}
 

--- a/cmd/remote_client_test.go
+++ b/cmd/remote_client_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestClient_DisplayAccountBalance(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup := cltest.NewApplicationWithKeyStore()
 	defer cleanup()
 
@@ -36,6 +38,8 @@ func TestClient_DisplayAccountBalance(t *testing.T) {
 }
 
 func TestClient_GetJobSpecs(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 
@@ -54,6 +58,7 @@ func TestClient_GetJobSpecs(t *testing.T) {
 
 func TestClient_ShowJobRun_Exists(t *testing.T) {
 	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 
@@ -74,6 +79,7 @@ func TestClient_ShowJobRun_Exists(t *testing.T) {
 
 func TestClient_ShowJobRun_NotFound(t *testing.T) {
 	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 
@@ -87,6 +93,8 @@ func TestClient_ShowJobRun_NotFound(t *testing.T) {
 }
 
 func TestClient_ShowJobSpec_Exists(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 	job := cltest.NewJob()
@@ -103,6 +111,8 @@ func TestClient_ShowJobSpec_Exists(t *testing.T) {
 }
 
 func TestClient_ShowJobSpec_NotFound(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 
@@ -116,6 +126,8 @@ func TestClient_ShowJobSpec_NotFound(t *testing.T) {
 }
 
 func TestClient_CreateServiceAgreement(t *testing.T) {
+	t.Parallel()
+
 	config, _ := cltest.NewConfigWithPrivateKey()
 	app, cleanup := cltest.NewApplicationWithConfigAndUnlockedAccount(config)
 	defer cleanup()
@@ -157,6 +169,8 @@ func TestClient_CreateServiceAgreement(t *testing.T) {
 }
 
 func TestClient_CreateJobSpec(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 	client, _ := app.NewClientAndRenderer()
@@ -189,6 +203,8 @@ func TestClient_CreateJobSpec(t *testing.T) {
 }
 
 func TestClient_CreateJobSpec_JSONAPIErrors(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 	client, _ := app.NewClientAndRenderer()
@@ -204,6 +220,7 @@ func TestClient_CreateJobSpec_JSONAPIErrors(t *testing.T) {
 
 func TestClient_CreateJobRun(t *testing.T) {
 	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 	client, _ := app.NewClientAndRenderer()
@@ -250,6 +267,7 @@ func TestClient_CreateJobRun(t *testing.T) {
 
 func TestClient_AddBridge(t *testing.T) {
 	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 	client, _ := app.NewClientAndRenderer()
@@ -284,6 +302,8 @@ func TestClient_AddBridge(t *testing.T) {
 }
 
 func TestClient_GetBridges(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 	bt1 := &models.BridgeType{
@@ -309,6 +329,8 @@ func TestClient_GetBridges(t *testing.T) {
 }
 
 func TestClient_ShowBridge(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 	bt := &models.BridgeType{
@@ -329,6 +351,8 @@ func TestClient_ShowBridge(t *testing.T) {
 }
 
 func TestClient_RemoveBridge(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 	bt := &models.BridgeType{
@@ -417,6 +441,8 @@ func TestClient_RemoteLogin(t *testing.T) {
 }
 
 func TestClient_WithdrawSuccess(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup, _ := setupWithdrawalsApplication()
 	defer cleanup()
 
@@ -432,6 +458,8 @@ func TestClient_WithdrawSuccess(t *testing.T) {
 }
 
 func TestClient_WithdrawNoArgs(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup, _ := setupWithdrawalsApplication()
 	defer cleanup()
 
@@ -451,6 +479,8 @@ func TestClient_WithdrawNoArgs(t *testing.T) {
 }
 
 func TestClient_WithdrawFromSpecifiedContractAddress(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup, ethMockCheck := setupWithdrawalsApplication()
 	defer cleanup()
 
@@ -495,6 +525,8 @@ func first(a models.JobSpec, b interface{}) models.JobSpec {
 }
 
 func TestClient_SendEther(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup, _ := setupWithdrawalsApplication()
 	defer cleanup()
 
@@ -506,10 +538,31 @@ func TestClient_SendEther(t *testing.T) {
 
 	c := cli.NewContext(nil, set, nil)
 
-	assert.Nil(t, client.SendEther(c))
+	assert.NoError(t, client.SendEther(c))
+}
+
+func TestClient_SendEther_From(t *testing.T) {
+	t.Parallel()
+
+	app, cleanup, _ := setupWithdrawalsApplication()
+	defer cleanup()
+
+	assert.NoError(t, app.StartAndConnect())
+
+	client, _ := app.NewClientAndRenderer()
+	set := flag.NewFlagSet("sendether", 0)
+	set.String("from", "0x534E10734271342d8dC78B8B009E40ef06659c0d", "")
+	set.Parse([]string{"100", "0x342156c8d3bA54Abc67920d35ba1d1e67201aC9C"})
+
+	cliapp := cli.NewApp()
+	c := cli.NewContext(cliapp, set, nil)
+
+	assert.NoError(t, client.SendEther(c))
 }
 
 func TestClient_ChangePassword(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 	app.Start()
@@ -545,6 +598,8 @@ func TestClient_ChangePassword(t *testing.T) {
 }
 
 func TestClient_GetTxAttempts(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup := cltest.NewApplicationWithKeyStore()
 	defer cleanup()
 
@@ -579,6 +634,8 @@ func TestClient_GetTxAttempts(t *testing.T) {
 }
 
 func TestClient_CreateExtraKey(t *testing.T) {
+	t.Parallel()
+
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 	app.Start()

--- a/store/models/common.go
+++ b/store/models/common.go
@@ -302,6 +302,7 @@ type WithdrawalRequest struct {
 // SendEtherRequest represents a request to transfer ETH.
 type SendEtherRequest struct {
 	DestinationAddress common.Address `json:"address"`
+	FromAddress        common.Address `json:"from"`
 	Amount             *assets.Eth    `json:"amount"`
 }
 


### PR DESCRIPTION
ive added a flag to accept an optional from address. I also noticed the tests for cmd were slow. So I added the parallel flag to all the tests that did not have it.

result

```
ok  	github.com/smartcontractkit/chainlink/cmd	48.817s
ok  	github.com/smartcontractkit/chainlink/cmd	15.731s
```