### PR TITLE
Add foreign keys

### DIFF
--- a/cmd/remote_client_test.go
+++ b/cmd/remote_client_test.go
@@ -36,9 +36,9 @@ func TestClient_GetJobSpecs(t *testing.T) {
 	defer cleanup()
 
 	j1 := cltest.NewJob()
-	app.Store.SaveJob(&j1)
+	app.Store.CreateJob(&j1)
 	j2 := cltest.NewJob()
-	app.Store.SaveJob(&j2)
+	app.Store.CreateJob(&j2)
 
 	client, r := app.NewClientAndRenderer()
 
@@ -54,7 +54,7 @@ func TestClient_ShowJobRun_Exists(t *testing.T) {
 	defer cleanup()
 
 	j := cltest.NewJobWithWebInitiator()
-	assert.NoError(t, app.Store.SaveJob(&j))
+	assert.NoError(t, app.Store.CreateJob(&j))
 
 	jr := cltest.CreateJobRunViaWeb(t, app, j, `{"value":"100"}`)
 
@@ -86,7 +86,7 @@ func TestClient_ShowJobSpec_Exists(t *testing.T) {
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 	job := cltest.NewJob()
-	app.Store.SaveJob(&job)
+	app.Store.CreateJob(&job)
 
 	client, r := app.NewClientAndRenderer()
 
@@ -220,7 +220,7 @@ func TestClient_CreateJobRun(t *testing.T) {
 	for _, tt := range tests {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
-			assert.Nil(t, app.Store.SaveJob(&test.jobSpec))
+			assert.Nil(t, app.Store.CreateJob(&test.jobSpec))
 
 			args := make([]string, 1)
 			args[0] = test.jobSpec.ID

--- a/integration/features_test.go
+++ b/integration/features_test.go
@@ -560,7 +560,7 @@ func TestIntegration_BulkDeleteRuns(t *testing.T) {
 	require.NoError(t, err)
 	completedRun := job.NewRun(job.Initiators[0])
 	completedRun.Status = models.RunStatusCompleted
-	err = app.GetStore().SaveJobRun(&completedRun)
+	err = app.GetStore().CreateJobRun(&completedRun)
 	require.NoError(t, err)
 
 	client := app.NewHTTPClient()

--- a/integration/features_test.go
+++ b/integration/features_test.go
@@ -556,7 +556,7 @@ func TestIntegration_BulkDeleteRuns(t *testing.T) {
 	app.Start()
 
 	job := cltest.NewJobWithWebInitiator()
-	err := app.GetStore().SaveJob(&job)
+	err := app.GetStore().CreateJob(&job)
 	require.NoError(t, err)
 	completedRun := job.NewRun(job.Initiators[0])
 	completedRun.Status = models.RunStatusCompleted

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -613,9 +613,18 @@ func CreateJobRunViaWeb(t *testing.T, app *TestApplication, j models.JobSpec, bo
 
 // CreateHelloWorldJobViaWeb creates a HelloWorld JobSpec with the given MockServer Url
 func CreateHelloWorldJobViaWeb(t *testing.T, app *TestApplication, url string) models.JobSpec {
-	j := FixtureCreateJobViaWeb(t, app, "../internal/fixtures/web/hello_world_job.json")
-	j.Tasks[0].Params = JSONFromString(fmt.Sprintf(`{"url":"%v"}`, url))
-	return CreateJobSpecViaWeb(t, app, j)
+	buffer, err := ioutil.ReadFile("../internal/fixtures/web/hello_world_job.json")
+	if err != nil {
+		assert.FailNowf(t, "Unable to read fixture", err.Error())
+	}
+
+	var job models.JobSpec
+	err = json.Unmarshal(buffer, &job)
+	require.NoError(t, err)
+
+	job.ID = utils.NewBytes32ID()
+	job.Tasks[0].Params = JSONFromString(fmt.Sprintf(`{"url":"%v"}`, url))
+	return CreateJobSpecViaWeb(t, app, job)
 }
 
 // CreateMockAssignmentViaWeb creates a JobSpec with the given MockServer Url

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -622,7 +622,7 @@ func CreateHelloWorldJobViaWeb(t *testing.T, app *TestApplication, url string) m
 func CreateMockAssignmentViaWeb(t *testing.T, app *TestApplication, url string) models.JobSpec {
 	j := FixtureCreateJobWithAssignmentViaWeb(t, app, "../internal/fixtures/web/v1_format_job.json")
 	j.Tasks[0].Params = JSONFromString(fmt.Sprintf(`{"url":"%v"}`, url))
-	return CreateJobSpecViaWeb(t, app, j)
+	return j
 }
 
 // UpdateJobRunViaWeb updates jobrun via web using /v2/runs/ID

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -622,7 +622,6 @@ func CreateHelloWorldJobViaWeb(t *testing.T, app *TestApplication, url string) m
 	err = json.Unmarshal(buffer, &job)
 	require.NoError(t, err)
 
-	job.ID = utils.NewBytes32ID()
 	job.Tasks[0].Params = JSONFromString(fmt.Sprintf(`{"url":"%v"}`, url))
 	return CreateJobSpecViaWeb(t, app, job)
 }

--- a/internal/cltest/factories.go
+++ b/internal/cltest/factories.go
@@ -458,6 +458,6 @@ func CreateJobRunWithStatus(store *store.Store, j models.JobSpec, status models.
 	initr := j.Initiators[0]
 	run := j.NewRun(initr)
 	run.Status = status
-	mustNotErr(store.SaveJobRun(&run))
+	mustNotErr(store.CreateJobRun(&run))
 	return run
 }

--- a/services/application.go
+++ b/services/application.go
@@ -138,7 +138,7 @@ func (app *ChainlinkApplication) WakeBulkRunDeleter() {
 // an error from adding the job to the store, the job will not be
 // added to the scheduler.
 func (app *ChainlinkApplication) AddJob(job models.JobSpec) error {
-	err := app.Store.SaveJob(&job)
+	err := app.Store.CreateJob(&job)
 	if err != nil {
 		return err
 	}

--- a/services/application.go
+++ b/services/application.go
@@ -24,6 +24,7 @@ type Application interface {
 	WakeSessionReaper()
 	WakeBulkRunDeleter()
 	AddJob(job models.JobSpec) error
+	AddServiceAgreement(*models.ServiceAgreement) error
 	AddAdapter(bt *models.BridgeType) error
 	RemoveAdapter(bt *models.BridgeType) error
 	NewBox() packr.Box
@@ -145,6 +146,23 @@ func (app *ChainlinkApplication) AddJob(job models.JobSpec) error {
 
 	app.Scheduler.AddJob(job)
 	return app.JobSubscriber.AddJob(job, nil) // nil for latest
+}
+
+// AddServiceAgreement adds a Service Agreement which includes a job that needs
+// to be scheduled.
+func (app *ChainlinkApplication) AddServiceAgreement(sa *models.ServiceAgreement) error {
+	err := app.Store.CreateJob(&sa.JobSpec)
+	if err != nil {
+		return err
+	}
+
+	err = app.Store.CreateServiceAgreement(sa)
+	if err != nil {
+		return err
+	}
+
+	app.Scheduler.AddJob(sa.JobSpec)
+	return app.JobSubscriber.AddJob(sa.JobSpec, nil) // nil for latest
 }
 
 // AddAdapter adds an adapter to the store. If another

--- a/services/application_test.go
+++ b/services/application_test.go
@@ -52,7 +52,7 @@ func TestChainlinkApplication_resumesPendingConnection(t *testing.T) {
 	store := app.Store
 
 	j := cltest.NewJobWithWebInitiator()
-	require.NoError(t, store.SaveJob(&j))
+	require.NoError(t, store.CreateJob(&j))
 
 	jr := cltest.CreateJobRunWithStatus(store, j, models.RunStatusPendingConnection)
 
@@ -72,7 +72,7 @@ func TestPendingConnectionResumer(t *testing.T) {
 	pcr := services.ExportedNewPendingConnectionResumer(store, resumer)
 
 	j := cltest.NewJobWithWebInitiator()
-	require.NoError(t, store.SaveJob(&j))
+	require.NoError(t, store.CreateJob(&j))
 
 	expectedRun := cltest.CreateJobRunWithStatus(store, j, models.RunStatusPendingConnection)
 	_ = cltest.CreateJobRunWithStatus(store, j, models.RunStatusPendingConfirmations)

--- a/services/bulk_run_deleter_test.go
+++ b/services/bulk_run_deleter_test.go
@@ -22,29 +22,29 @@ func TestDeleteJobRuns(t *testing.T) {
 	// matches updated before but none of the statuses
 	oldIncompleteRun := job.NewRun(initiator)
 	oldIncompleteRun.Status = models.RunStatusInProgress
-	err := db.Save(&oldIncompleteRun).Error
-	assert.NoError(t, err)
+	err := db.Create(&oldIncompleteRun).Error
+	require.NoError(t, err)
 	db.Model(&oldIncompleteRun).UpdateColumn("updated_at", cltest.ParseISO8601("2018-01-01T00:00:00Z"))
 
 	// matches one of the statuses and the updated before
 	oldCompletedRun := job.NewRun(initiator)
 	oldCompletedRun.Status = models.RunStatusCompleted
-	err = db.Save(&oldCompletedRun).Error
-	assert.NoError(t, err)
+	err = db.Create(&oldCompletedRun).Error
+	require.NoError(t, err)
 	db.Model(&oldCompletedRun).UpdateColumn("updated_at", cltest.ParseISO8601("2018-01-01T00:00:00Z"))
 
 	// matches one of the statuses but not the updated before
 	newCompletedRun := job.NewRun(initiator)
 	newCompletedRun.Status = models.RunStatusCompleted
-	err = db.Save(&newCompletedRun).Error
-	assert.NoError(t, err)
+	err = db.Create(&newCompletedRun).Error
+	require.NoError(t, err)
 	db.Model(&newCompletedRun).UpdateColumn("updated_at", cltest.ParseISO8601("2018-01-30T00:00:00Z"))
 
 	// matches nothing
 	newIncompleteRun := job.NewRun(initiator)
 	newIncompleteRun.Status = models.RunStatusCompleted
-	err = db.Save(&newIncompleteRun).Error
-	assert.NoError(t, err)
+	err = db.Create(&newIncompleteRun).Error
+	require.NoError(t, err)
 	db.Model(&newIncompleteRun).UpdateColumn("updated_at", cltest.ParseISO8601("2018-01-30T00:00:00Z"))
 
 	err = services.DeleteJobRuns(store.ORM, &models.BulkDeleteRunRequest{

--- a/services/bulk_run_deleter_test.go
+++ b/services/bulk_run_deleter_test.go
@@ -16,7 +16,7 @@ func TestDeleteJobRuns(t *testing.T) {
 
 	db := store.ORM.DB
 	job := cltest.NewJobWithWebInitiator()
-	require.NoError(t, store.ORM.SaveJob(&job))
+	require.NoError(t, store.ORM.CreateJob(&job))
 	initiator := job.Initiators[0]
 
 	// matches updated before but none of the statuses

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -256,7 +256,7 @@ func executeRun(run *models.JobRun, store *store.Store) (*models.JobRun, error) 
 		run = queueNextTask(run, store)
 	}
 
-	if err := saveAndTrigger(run, store); err != nil {
+	if err := updateAndTrigger(run, store); err != nil {
 		return run, err
 	}
 	logger.Infow("Run finished processing", run.ForLogger()...)

--- a/services/job_runner_test.go
+++ b/services/job_runner_test.go
@@ -25,7 +25,7 @@ func TestJobRunner_resumeRunsSinceLastShutdown(t *testing.T) {
 	j.Initiators = []models.Initiator{i}
 	json := fmt.Sprintf(`{"until":"%v"}`, utils.ISO8601UTC(time.Now().Add(time.Second)))
 	j.Tasks = []models.TaskSpec{cltest.NewTask("sleep", json)}
-	assert.NoError(t, store.SaveJob(&j))
+	assert.NoError(t, store.CreateJob(&j))
 
 	sleepingRun := j.NewRun(i)
 	sleepingRun.Status = models.RunStatusPendingSleep
@@ -83,7 +83,7 @@ func TestJobRunner_ChannelForRun_sendAfterClosing(t *testing.T) {
 	assert.NoError(t, rm.Start())
 
 	j := cltest.NewJobWithWebInitiator()
-	assert.NoError(t, s.SaveJob(&j))
+	assert.NoError(t, s.CreateJob(&j))
 	initr := j.Initiators[0]
 	jr := j.NewRun(initr)
 	assert.NoError(t, s.SaveJobRun(&jr))
@@ -111,7 +111,7 @@ func TestJobRunner_ChannelForRun_equalityWithoutClosing(t *testing.T) {
 
 	j := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{cltest.NewTask("nooppend")}
-	assert.NoError(t, s.SaveJob(&j))
+	assert.NoError(t, s.CreateJob(&j))
 	initr := j.Initiators[0]
 	jr := j.NewRun(initr)
 	assert.NoError(t, s.SaveJobRun(&jr))

--- a/services/job_runner_test.go
+++ b/services/job_runner_test.go
@@ -30,11 +30,11 @@ func TestJobRunner_resumeRunsSinceLastShutdown(t *testing.T) {
 	sleepingRun := j.NewRun(i)
 	sleepingRun.Status = models.RunStatusPendingSleep
 	sleepingRun.TaskRuns[0].Status = models.RunStatusPendingSleep
-	assert.NoError(t, store.SaveJobRun(&sleepingRun))
+	assert.NoError(t, store.CreateJobRun(&sleepingRun))
 
 	inProgressRun := j.NewRun(i)
 	inProgressRun.Status = models.RunStatusInProgress
-	assert.NoError(t, store.SaveJobRun(&inProgressRun))
+	assert.NoError(t, store.CreateJobRun(&inProgressRun))
 
 	assert.NoError(t, services.ExportedResumeRunsSinceLastShutdown(rm))
 	messages := []string{}
@@ -86,7 +86,7 @@ func TestJobRunner_ChannelForRun_sendAfterClosing(t *testing.T) {
 	assert.NoError(t, s.CreateJob(&j))
 	initr := j.Initiators[0]
 	jr := j.NewRun(initr)
-	assert.NoError(t, s.SaveJobRun(&jr))
+	assert.NoError(t, s.CreateJobRun(&jr))
 
 	chan1 := services.ExportedChannelForRun(rm, jr.ID)
 	chan1 <- struct{}{}
@@ -114,7 +114,7 @@ func TestJobRunner_ChannelForRun_equalityWithoutClosing(t *testing.T) {
 	assert.NoError(t, s.CreateJob(&j))
 	initr := j.Initiators[0]
 	jr := j.NewRun(initr)
-	assert.NoError(t, s.SaveJobRun(&jr))
+	assert.NoError(t, s.CreateJobRun(&jr))
 
 	chan1 := services.ExportedChannelForRun(rm, jr.ID)
 

--- a/services/job_subscriber_test.go
+++ b/services/job_subscriber_test.go
@@ -24,8 +24,8 @@ func TestJobSubscriber_Connect_WithJobs(t *testing.T) {
 
 	j1 := cltest.NewJobWithLogInitiator()
 	j2 := cltest.NewJobWithLogInitiator()
-	assert.Nil(t, store.SaveJob(&j1))
-	assert.Nil(t, store.SaveJob(&j2))
+	assert.Nil(t, store.CreateJob(&j1))
+	assert.Nil(t, store.CreateJob(&j2))
 	eth.RegisterSubscription("logs")
 	eth.RegisterSubscription("logs")
 
@@ -45,8 +45,8 @@ func TestJobSubscriber_reconnectLoop_Resubscribing(t *testing.T) {
 	eth := cltest.MockEthOnStore(store)
 	j1 := cltest.NewJobWithLogInitiator()
 	j2 := cltest.NewJobWithLogInitiator()
-	assert.Nil(t, store.SaveJob(&j1))
-	assert.Nil(t, store.SaveJob(&j2))
+	assert.Nil(t, store.CreateJob(&j1))
+	assert.Nil(t, store.CreateJob(&j2))
 
 	eth.RegisterSubscription("logs")
 	eth.RegisterSubscription("logs")
@@ -75,8 +75,8 @@ func TestJobSubscriber_AttachedToHeadTracker(t *testing.T) {
 	eth := cltest.MockEthOnStore(store)
 	j1 := cltest.NewJobWithLogInitiator()
 	j2 := cltest.NewJobWithLogInitiator()
-	assert.Nil(t, store.SaveJob(&j1))
-	assert.Nil(t, store.SaveJob(&j2))
+	assert.Nil(t, store.CreateJob(&j1))
+	assert.Nil(t, store.CreateJob(&j2))
 
 	eth.RegisterSubscription("logs")
 	eth.RegisterSubscription("logs")
@@ -178,7 +178,7 @@ func TestJobSubscriber_OnNewHead_OnlyResumePendingConfirmations(t *testing.T) {
 			store.RunChannel = mockRunChannel
 
 			job := cltest.NewJobWithWebInitiator()
-			require.NoError(t, store.SaveJob(&job))
+			require.NoError(t, store.CreateJob(&job))
 			initr := job.Initiators[0]
 			run := job.NewRun(initr)
 			run = run.ApplyResult(models.RunResult{Status: test.status})

--- a/services/job_subscriber_test.go
+++ b/services/job_subscriber_test.go
@@ -182,7 +182,7 @@ func TestJobSubscriber_OnNewHead_OnlyResumePendingConfirmations(t *testing.T) {
 			initr := job.Initiators[0]
 			run := job.NewRun(initr)
 			run = run.ApplyResult(models.RunResult{Status: test.status})
-			assert.Nil(t, store.SaveJobRun(&run))
+			assert.Nil(t, store.CreateJobRun(&run))
 
 			js.OnNewHead(block)
 			if test.wantSend {

--- a/services/runs.go
+++ b/services/runs.go
@@ -319,7 +319,7 @@ func meetsMinimumConfirmations(
 }
 
 func saveAndTrigger(run *models.JobRun, store *store.Store) error {
-	if err := store.SaveJobRun(run); err != nil {
+	if err := store.CreateJobRun(run); err != nil {
 		return err
 	}
 

--- a/services/runs.go
+++ b/services/runs.go
@@ -33,7 +33,7 @@ func ExecuteJob(
 		return nil, err
 	}
 
-	return run, saveAndTrigger(run, store)
+	return run, createAndTrigger(run, store)
 }
 
 // NewRun returns a run from an input job, in an initial state ready for
@@ -159,7 +159,7 @@ func ResumeConfirmingTask(
 		run.Status = models.RunStatusPendingConfirmations
 	}
 
-	return run, saveAndTrigger(run, store)
+	return run, updateAndTrigger(run, store)
 }
 
 // ResumeConnectingTask resumes a run that was left in pending_connection.
@@ -180,7 +180,7 @@ func ResumeConnectingTask(
 	}
 
 	run.Status = models.RunStatusInProgress
-	return run, saveAndTrigger(run, store)
+	return run, updateAndTrigger(run, store)
 }
 
 // ResumePendingTask takes the body provided from an external adapter,
@@ -225,7 +225,7 @@ func ResumePendingTask(
 		*run = run.ApplyResult(input)
 	}
 
-	return run, saveAndTrigger(run, store)
+	return run, updateAndTrigger(run, store)
 }
 
 // QueueSleepingTask creates a go routine which will wake up the job runner
@@ -276,7 +276,7 @@ func performTaskSleep(
 		task.Status = models.RunStatusCompleted
 		run.TaskRuns[currentTaskRunIndex] = *task
 		run.Status = models.RunStatusInProgress
-		return saveAndTrigger(run, store)
+		return updateAndTrigger(run, store)
 	}
 
 	// XXX: This is to eliminate data race that occurs because slices share their
@@ -296,7 +296,7 @@ func performTaskSleep(
 
 		logger.Debugw("Waking job up after sleep", run.ForLogger()...)
 
-		if err := saveAndTrigger(&run, store); err != nil {
+		if err := updateAndTrigger(&run, store); err != nil {
 			logger.Errorw("Error resuming sleeping job:", "error", err)
 		}
 	}(runCopy, *task)
@@ -318,11 +318,21 @@ func meetsMinimumConfirmations(
 	return diff.Cmp(min) >= 0
 }
 
-func saveAndTrigger(run *models.JobRun, store *store.Store) error {
+func updateAndTrigger(run *models.JobRun, store *store.Store) error {
+	if err := store.SaveJobRun(run); err != nil {
+		return err
+	}
+	return triggerIfReady(run, store)
+}
+
+func createAndTrigger(run *models.JobRun, store *store.Store) error {
 	if err := store.CreateJobRun(run); err != nil {
 		return err
 	}
+	return triggerIfReady(run, store)
+}
 
+func triggerIfReady(run *models.JobRun, store *store.Store) error {
 	if run.Status == models.RunStatusInProgress {
 		logger.Debugw(fmt.Sprintf("Executing run originally initiated by %s", run.Initiator.Type), run.ForLogger()...)
 		return store.RunChannel.Send(run.ID)

--- a/services/runs_test.go
+++ b/services/runs_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 	null "gopkg.in/guregu/null.v3"
 )
@@ -235,19 +236,27 @@ func TestResumeConfirmingTask(t *testing.T) {
 	run, err = services.ResumeConfirmingTask(run, store, nil)
 	assert.Error(t, err)
 
+	jobSpec := models.JobSpec{ID: utils.NewBytes32ID()}
+	require.NoError(t, store.ORM.CreateJob(&jobSpec))
+
 	// leave in pending if not enough confirmations have been met yet
 	creationHeight := models.NewBig(big.NewInt(0))
 	run = &models.JobRun{
 		ID:             utils.NewBytes32ID(),
+		JobSpecID:      jobSpec.ID,
 		CreationHeight: creationHeight,
 		Status:         models.RunStatusPendingConfirmations,
 		TaskRuns: []models.TaskRun{models.TaskRun{
 			ID:                   utils.NewBytes32ID(),
 			MinimumConfirmations: 2,
-			TaskSpec:             models.TaskSpec{Type: adapters.TaskTypeNoOp},
+			TaskSpec: models.TaskSpec{
+				JobSpecID: jobSpec.ID,
+				Type:      adapters.TaskTypeNoOp,
+			},
 		}},
 	}
 	hexb := hexutil.Big(*creationHeight.ToInt())
+	require.NoError(t, store.CreateJobRun(run))
 	run, err = services.ResumeConfirmingTask(run, store, &hexb)
 	assert.NoError(t, err)
 	assert.Equal(t, string(models.RunStatusPendingConfirmations), string(run.Status))
@@ -255,15 +264,20 @@ func TestResumeConfirmingTask(t *testing.T) {
 	// input, should go from pending -> in progress and save the input
 	run = &models.JobRun{
 		ID:             utils.NewBytes32ID(),
+		JobSpecID:      jobSpec.ID,
 		CreationHeight: creationHeight,
 		Status:         models.RunStatusPendingConfirmations,
 		TaskRuns: []models.TaskRun{models.TaskRun{
 			ID:                   utils.NewBytes32ID(),
 			MinimumConfirmations: 1,
-			TaskSpec:             models.TaskSpec{Type: adapters.TaskTypeNoOp},
+			TaskSpec: models.TaskSpec{
+				JobSpecID: jobSpec.ID,
+				Type:      adapters.TaskTypeNoOp,
+			},
 		}},
 	}
 	observedHeight := cltest.BigHexInt(1)
+	require.NoError(t, store.CreateJobRun(run))
 	run, err = services.ResumeConfirmingTask(run, store, &observedHeight)
 	assert.NoError(t, err)
 	assert.Equal(t, string(models.RunStatusInProgress), string(run.Status))
@@ -283,16 +297,21 @@ func TestResumeConnectingTask(t *testing.T) {
 	run, err = services.ResumeConnectingTask(run, store)
 	assert.Error(t, err)
 
+	jobSpec := models.JobSpec{ID: utils.NewBytes32ID()}
+	require.NoError(t, store.ORM.CreateJob(&jobSpec))
+
 	taskSpec := models.TaskSpec{Type: adapters.TaskTypeNoOp}
 	// input, should go from pending -> in progress and save the input
 	run = &models.JobRun{
-		ID:     utils.NewBytes32ID(),
-		Status: models.RunStatusPendingConnection,
+		ID:        utils.NewBytes32ID(),
+		JobSpecID: jobSpec.ID,
+		Status:    models.RunStatusPendingConnection,
 		TaskRuns: []models.TaskRun{models.TaskRun{
 			ID:       utils.NewBytes32ID(),
 			TaskSpec: taskSpec,
 		}},
 	}
+	require.NoError(t, store.CreateJobRun(run))
 	run, err = services.ResumeConnectingTask(run, store)
 	assert.NoError(t, err)
 	assert.Equal(t, string(models.RunStatusInProgress), string(run.Status))
@@ -319,23 +338,29 @@ func TestQueueSleepingTask(t *testing.T) {
 	run, err = services.QueueSleepingTask(run, store)
 	assert.Error(t, err)
 
+	jobSpec := models.JobSpec{ID: utils.NewBytes32ID()}
+	require.NoError(t, store.ORM.CreateJob(&jobSpec))
+
 	// reject a run that is sleeping but its task is not
 	run = &models.JobRun{
-		ID:     utils.NewBytes32ID(),
-		Status: models.RunStatusPendingSleep,
+		ID:        utils.NewBytes32ID(),
+		JobSpecID: jobSpec.ID,
+		Status:    models.RunStatusPendingSleep,
 		TaskRuns: []models.TaskRun{models.TaskRun{
 			ID:       utils.NewBytes32ID(),
 			TaskSpec: models.TaskSpec{Type: adapters.TaskTypeSleep},
 		}},
 	}
+	require.NoError(t, store.CreateJobRun(run))
 	run, err = services.QueueSleepingTask(run, store)
 	assert.Error(t, err)
 
 	// error decoding params into adapter
 	inputFromTheFuture := cltest.ParseJSON(bytes.NewBuffer([]byte(`{"until": -1}`)))
 	run = &models.JobRun{
-		ID:     utils.NewBytes32ID(),
-		Status: models.RunStatusPendingSleep,
+		ID:        utils.NewBytes32ID(),
+		JobSpecID: jobSpec.ID,
+		Status:    models.RunStatusPendingSleep,
 		TaskRuns: []models.TaskRun{
 			models.TaskRun{
 				ID:     utils.NewBytes32ID(),
@@ -347,6 +372,7 @@ func TestQueueSleepingTask(t *testing.T) {
 			},
 		},
 	}
+	require.NoError(t, store.CreateJobRun(run))
 	run, err = services.QueueSleepingTask(run, store)
 	assert.NoError(t, err)
 	assert.Equal(t, string(models.RunStatusErrored), string(run.TaskRuns[0].Status))
@@ -354,14 +380,16 @@ func TestQueueSleepingTask(t *testing.T) {
 
 	// mark run as pending, task as completed if duration has already elapsed
 	run = &models.JobRun{
-		ID:     utils.NewBytes32ID(),
-		Status: models.RunStatusPendingSleep,
+		ID:        utils.NewBytes32ID(),
+		JobSpecID: jobSpec.ID,
+		Status:    models.RunStatusPendingSleep,
 		TaskRuns: []models.TaskRun{models.TaskRun{
 			ID:       utils.NewBytes32ID(),
 			Status:   models.RunStatusPendingSleep,
 			TaskSpec: models.TaskSpec{Type: adapters.TaskTypeSleep},
 		}},
 	}
+	require.NoError(t, store.CreateJobRun(run))
 	run, err = services.QueueSleepingTask(run, store)
 	assert.NoError(t, err)
 	assert.Equal(t, string(models.RunStatusCompleted), string(run.TaskRuns[0].Status))
@@ -378,8 +406,9 @@ func TestQueueSleepingTask(t *testing.T) {
 
 	inputFromTheFuture = sleepAdapterParams(60)
 	run = &models.JobRun{
-		ID:     utils.NewBytes32ID(),
-		Status: models.RunStatusPendingSleep,
+		ID:        utils.NewBytes32ID(),
+		JobSpecID: jobSpec.ID,
+		Status:    models.RunStatusPendingSleep,
 		TaskRuns: []models.TaskRun{
 			models.TaskRun{
 				ID:     utils.NewBytes32ID(),
@@ -391,6 +420,7 @@ func TestQueueSleepingTask(t *testing.T) {
 			},
 		},
 	}
+	require.NoError(t, store.CreateJobRun(run))
 	run, err = services.QueueSleepingTask(run, store)
 	assert.NoError(t, err)
 	assert.Equal(t, string(models.RunStatusPendingSleep), string(run.TaskRuns[0].Status))

--- a/services/runs_test.go
+++ b/services/runs_test.go
@@ -161,7 +161,7 @@ func TestNewRun_startAtAndEndAt(t *testing.T) {
 			job := cltest.NewJobWithWebInitiator()
 			job.StartAt = test.startAt
 			job.EndAt = test.endAt
-			assert.Nil(t, store.SaveJob(&job))
+			assert.Nil(t, store.CreateJob(&job))
 
 			_, err := services.NewRun(job, job.Initiators[0], models.RunResult{}, nil, store)
 			if test.errored {

--- a/services/runs_test.go
+++ b/services/runs_test.go
@@ -300,7 +300,7 @@ func TestResumeConnectingTask(t *testing.T) {
 	jobSpec := models.JobSpec{ID: utils.NewBytes32ID()}
 	require.NoError(t, store.ORM.CreateJob(&jobSpec))
 
-	taskSpec := models.TaskSpec{Type: adapters.TaskTypeNoOp}
+	taskSpec := models.TaskSpec{Type: adapters.TaskTypeNoOp, JobSpecID: jobSpec.ID}
 	// input, should go from pending -> in progress and save the input
 	run = &models.JobRun{
 		ID:        utils.NewBytes32ID(),
@@ -348,7 +348,7 @@ func TestQueueSleepingTask(t *testing.T) {
 		Status:    models.RunStatusPendingSleep,
 		TaskRuns: []models.TaskRun{models.TaskRun{
 			ID:       utils.NewBytes32ID(),
-			TaskSpec: models.TaskSpec{Type: adapters.TaskTypeSleep},
+			TaskSpec: models.TaskSpec{Type: adapters.TaskTypeSleep, JobSpecID: jobSpec.ID},
 		}},
 	}
 	require.NoError(t, store.CreateJobRun(run))
@@ -366,8 +366,9 @@ func TestQueueSleepingTask(t *testing.T) {
 				ID:     utils.NewBytes32ID(),
 				Status: models.RunStatusPendingSleep,
 				TaskSpec: models.TaskSpec{
-					Type:   adapters.TaskTypeSleep,
-					Params: inputFromTheFuture,
+					JobSpecID: jobSpec.ID,
+					Type:      adapters.TaskTypeSleep,
+					Params:    inputFromTheFuture,
 				},
 			},
 		},
@@ -386,7 +387,7 @@ func TestQueueSleepingTask(t *testing.T) {
 		TaskRuns: []models.TaskRun{models.TaskRun{
 			ID:       utils.NewBytes32ID(),
 			Status:   models.RunStatusPendingSleep,
-			TaskSpec: models.TaskSpec{Type: adapters.TaskTypeSleep},
+			TaskSpec: models.TaskSpec{Type: adapters.TaskTypeSleep, JobSpecID: jobSpec.ID},
 		}},
 	}
 	require.NoError(t, store.CreateJobRun(run))
@@ -414,8 +415,9 @@ func TestQueueSleepingTask(t *testing.T) {
 				ID:     utils.NewBytes32ID(),
 				Status: models.RunStatusPendingSleep,
 				TaskSpec: models.TaskSpec{
-					Type:   adapters.TaskTypeSleep,
-					Params: inputFromTheFuture,
+					JobSpecID: jobSpec.ID,
+					Type:      adapters.TaskTypeSleep,
+					Params:    inputFromTheFuture,
 				},
 			},
 		},

--- a/services/scheduler_test.go
+++ b/services/scheduler_test.go
@@ -21,9 +21,9 @@ func TestScheduler_Start_LoadingRecurringJobs(t *testing.T) {
 	defer cleanup()
 
 	jobWCron := cltest.NewJobWithSchedule("* * * * * *")
-	assert.Nil(t, store.SaveJob(&jobWCron))
+	assert.Nil(t, store.CreateJob(&jobWCron))
 	jobWoCron := cltest.NewJob()
-	assert.Nil(t, store.SaveJob(&jobWoCron))
+	assert.Nil(t, store.CreateJob(&jobWoCron))
 
 	sched := services.NewScheduler(store)
 	assert.Nil(t, sched.Start())
@@ -42,7 +42,7 @@ func TestScheduler_AddJob_WhenStopped(t *testing.T) {
 	defer sched.Stop()
 
 	j := cltest.NewJobWithSchedule("* * * * *")
-	assert.Nil(t, store.SaveJob(&j))
+	assert.Nil(t, store.CreateJob(&j))
 	sched.AddJob(j)
 
 	cltest.WaitForRuns(t, j, store, 0)
@@ -58,7 +58,7 @@ func TestScheduler_Start_AddingUnstartedJob(t *testing.T) {
 	startAt := cltest.ParseISO8601("3000-01-01T00:00:00.000Z")
 	j := cltest.NewJobWithSchedule("* * * * *")
 	j.StartAt = cltest.NullableTime(startAt)
-	assert.Nil(t, store.SaveJob(&j))
+	assert.Nil(t, store.CreateJob(&j))
 
 	sched := services.NewScheduler(store)
 	defer sched.Stop()
@@ -159,7 +159,7 @@ func TestOneTime_AddJob(t *testing.T) {
 			}
 
 			j := cltest.NewJobWithRunAtInitiator(test.runAt)
-			assert.Nil(t, store.SaveJob(&j))
+			assert.Nil(t, store.CreateJob(&j))
 
 			j.StartAt = test.startAt
 			j.EndAt = test.endAt
@@ -191,7 +191,7 @@ func TestOneTime_RunJobAt_StopJobBeforeExecution(t *testing.T) {
 	}
 	ot.Start()
 	j := cltest.NewJobWithRunAtInitiator(time.Now().Add(time.Hour))
-	assert.Nil(t, store.SaveJob(&j))
+	assert.Nil(t, store.CreateJob(&j))
 	initr := j.Initiators[0]
 
 	finished := abool.New()
@@ -221,7 +221,7 @@ func TestOneTime_RunJobAt_ExecuteLateJob(t *testing.T) {
 		Store: store,
 	}
 	j := cltest.NewJobWithRunAtInitiator(time.Now().Add(time.Hour * -1))
-	assert.Nil(t, store.SaveJob(&j))
+	assert.Nil(t, store.CreateJob(&j))
 	initr := j.Initiators[0]
 	initr.ID = j.Initiators[0].ID
 	initr.JobSpecID = j.ID
@@ -252,7 +252,7 @@ func TestOneTime_RunJobAt_RunTwice(t *testing.T) {
 	}
 
 	j := cltest.NewJobWithRunAtInitiator(time.Now())
-	assert.NoError(t, store.SaveJob(&j))
+	assert.NoError(t, store.CreateJob(&j))
 	ot.RunJobAt(j.Initiators[0], j)
 
 	j2, err := ot.Store.FindJob(j.ID)
@@ -277,7 +277,7 @@ func TestOneTime_RunJobAt_UnstartedRun(t *testing.T) {
 
 	j := cltest.NewJobWithRunAtInitiator(time.Now())
 	j.EndAt = cltest.NullTime("2000-01-01T00:10:00.000Z")
-	assert.NoError(t, store.SaveJob(&j))
+	assert.NoError(t, store.CreateJob(&j))
 
 	ot.RunJobAt(j.Initiators[0], j)
 

--- a/services/scheduler_test.go
+++ b/services/scheduler_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink/services"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tevino/abool"
 	"go.uber.org/zap/zapcore"
 	null "gopkg.in/guregu/null.v3"
@@ -108,16 +109,17 @@ func TestRecurring_AddJob(t *testing.T) {
 			r.Cron = cron
 			defer r.Stop()
 
-			j := cltest.NewJobWithSchedule("* * * * *")
-			j.StartAt = test.startAt
-			j.EndAt = test.endAt
+			job := cltest.NewJobWithSchedule("* * * * *")
+			job.StartAt = test.startAt
+			job.EndAt = test.endAt
 
-			r.AddJob(j)
+			require.NoError(t, store.CreateJob(&job))
+			r.AddJob(job)
 
 			assert.Equal(t, test.wantEntries, len(cron.Entries))
 
 			cron.RunEntries()
-			jobRuns, err := store.JobRunsFor(j.ID)
+			jobRuns, err := store.JobRunsFor(job.ID)
 			assert.NoError(t, err)
 			assert.Equal(t, test.wantRuns, len(jobRuns))
 		})

--- a/store/models/job_spec.go
+++ b/store/models/job_spec.go
@@ -175,7 +175,7 @@ const (
 // to a parent JobID.
 type Initiator struct {
 	ID        uint   `json:"id" gorm:"primary_key;auto_increment"`
-	JobSpecID string `json:"jobSpecId" gorm:"index"`
+	JobSpecID string `json:"jobSpecId" gorm:"index;type:varchar(36) REFERENCES job_specs(id)"`
 	// Type is one of the Initiator* string constants defined just above.
 	Type            string `json:"type" gorm:"index;not null"`
 	InitiatorParams `json:"params,omitempty"`
@@ -217,7 +217,7 @@ func (i Initiator) IsLogInitiated() bool {
 // additional information that adapter would need to operate.
 type TaskSpec struct {
 	gorm.Model
-	JobSpecID     string   `json:"-" gorm:"index"`
+	JobSpecID     string   `json:"-" gorm:"index;type:varchar(36) REFERENCES job_specs(id)"`
 	Type          TaskType `json:"type" gorm:"index;not null"`
 	Confirmations uint64   `json:"confirmations"`
 	Params        JSON     `json:"params" gorm:"type:text"`

--- a/store/models/job_spec.go
+++ b/store/models/job_spec.go
@@ -66,6 +66,9 @@ func NewJob() JobSpec {
 func NewJobFromRequest(jsr JobSpecRequest) JobSpec {
 	jobSpec := NewJob()
 	jobSpec.Initiators = jsr.Initiators
+	for _, initr := range jobSpec.Initiators {
+		initr.JobSpecID = jobSpec.ID
+	}
 	jobSpec.Tasks = jsr.Tasks
 	jobSpec.EndAt = jsr.EndAt
 	jobSpec.StartAt = jsr.StartAt

--- a/store/models/job_spec.go
+++ b/store/models/job_spec.go
@@ -20,7 +20,7 @@ import (
 // for a given contract. It contains the Initiators, Tasks (which are the
 // individual steps to be carried out), StartAt, EndAt, and CreatedAt fields.
 type JobSpec struct {
-	ID         string      `json:"id" gorm:"primary_key;not null"`
+	ID         string      `json:"id,omitempty" gorm:"primary_key;not null"`
 	CreatedAt  Time        `json:"createdAt" gorm:"index"`
 	Initiators []Initiator `json:"initiators"`
 	Tasks      []TaskSpec  `json:"tasks"`

--- a/store/models/job_spec_test.go
+++ b/store/models/job_spec_test.go
@@ -17,7 +17,7 @@ func TestJobSpec_Save(t *testing.T) {
 	defer cleanup()
 
 	j1 := cltest.NewJobWithSchedule("* * * * 7")
-	assert.NoError(t, store.SaveJob(&j1))
+	assert.NoError(t, store.CreateJob(&j1))
 	initr := j1.Initiators[0]
 
 	j2, err := store.FindJob(j1.ID)

--- a/store/models/log_events_test.go
+++ b/store/models/log_events_test.go
@@ -232,7 +232,8 @@ func TestStartRunOrSALogSubscription_ValidateSenders(t *testing.T) {
 			initr := js.Initiators[0]
 			initr.Requesters = []common.Address{requester}
 			_, err := services.NewInitiatorSubscription(initr, js, app.Store, nil, services.ReceiveLogRequest)
-			assert.NoError(t, err)
+			require.NoError(t, err)
+			require.NoError(t, app.Store.CreateJob(&js))
 
 			logs <- test.logFactory(js.ID, cltest.NewAddress(), test.requester, 1, `{}`)
 			eth.EventuallyAllCalled(t)
@@ -240,6 +241,7 @@ func TestStartRunOrSALogSubscription_ValidateSenders(t *testing.T) {
 			gomega.NewGomegaWithT(t).Eventually(func() models.RunStatus {
 				runs, err := app.Store.JobRunsFor(js.ID)
 				require.NoError(t, err)
+				require.Len(t, runs, 1)
 				return runs[0].Status
 			}).Should(gomega.Equal(test.wantStatus))
 		})

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -129,7 +129,7 @@ func (jr JobRun) MarkCompleted() JobRun {
 // Task to be ran.
 type TaskRun struct {
 	ID                   string    `json:"id" gorm:"primary_key;not null"`
-	JobRunID             string    `json:"-" gorm:"index"`
+	JobRunID             string    `json:"-" gorm:"index;not null;type:varchar(36) REFERENCES job_runs(id) ON DELETE CASCADE"`
 	Result               RunResult `json:"result"`
 	ResultID             uint      `json:"-"`
 	Status               RunStatus `json:"status"`

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -14,7 +14,7 @@ import (
 // Result of each Run.
 type JobRun struct {
 	ID             string    `json:"id" gorm:"primary_key;not null"`
-	JobSpecID      string    `json:"jobId" gorm:"index;not null"`
+	JobSpecID      string    `json:"jobId" gorm:"index;not null;type:varchar(36) REFERENCES job_specs(id)"`
 	Result         RunResult `json:"result"`
 	ResultID       uint      `json:"-"`
 	Status         RunStatus `json:"status" gorm:"index"`
@@ -134,7 +134,7 @@ type TaskRun struct {
 	ResultID             uint      `json:"-"`
 	Status               RunStatus `json:"status"`
 	TaskSpec             TaskSpec  `json:"task"`
-	TaskSpecID           uint      `json:"-" gorm:"not null"`
+	TaskSpecID           uint      `json:"-" gorm:"index;not null;type:varchar(36) REFERENCES task_specs(id)"`
 	MinimumConfirmations uint64    `json:"minimumConfirmations"`
 	CreatedAt            time.Time `json:"-" gorm:"index"`
 }

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -23,7 +23,7 @@ func TestJobRuns_RetrievingFromDBWithError(t *testing.T) {
 	job := cltest.NewJobWithWebInitiator()
 	jr := job.NewRun(job.Initiators[0])
 	jr.Result = cltest.RunResultWithError(fmt.Errorf("bad idea"))
-	err := store.SaveJobRun(&jr)
+	err := store.CreateJobRun(&jr)
 	assert.NoError(t, err)
 
 	run, err := store.FindJobRun(jr.ID)
@@ -45,7 +45,7 @@ func TestJobRuns_RetrievingFromDBWithData(t *testing.T) {
 	jr := job.NewRun(initr)
 	data := `{"value":"11850.00"}`
 	jr.Result = cltest.RunResultWithData(data)
-	err = store.SaveJobRun(&jr)
+	err = store.CreateJobRun(&jr)
 	assert.NoError(t, err)
 
 	run, err := store.FindJobRun(jr.ID)
@@ -71,7 +71,7 @@ func TestJobRun_NextTaskRun(t *testing.T) {
 	}
 	assert.NoError(t, store.CreateJob(&job))
 	run := job.NewRun(job.Initiators[0])
-	assert.NoError(t, store.SaveJobRun(&run))
+	assert.NoError(t, store.CreateJobRun(&run))
 	assert.Equal(t, &run.TaskRuns[0], run.NextTaskRun())
 
 	store.RunChannel.Send(run.ID)

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -38,7 +38,7 @@ func TestJobRuns_RetrievingFromDBWithData(t *testing.T) {
 	defer cleanup()
 
 	job := cltest.NewJobWithWebInitiator()
-	err := store.SaveJob(&job)
+	err := store.CreateJob(&job)
 	initr := job.Initiators[0]
 	assert.NoError(t, err)
 
@@ -69,7 +69,7 @@ func TestJobRun_NextTaskRun(t *testing.T) {
 		{Type: adapters.TaskTypeNoOpPend},
 		{Type: adapters.TaskTypeNoOp},
 	}
-	assert.NoError(t, store.SaveJob(&job))
+	assert.NoError(t, store.CreateJob(&job))
 	run := job.NewRun(job.Initiators[0])
 	assert.NoError(t, store.SaveJobRun(&run))
 	assert.Equal(t, &run.TaskRuns[0], run.NextTaskRun())

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 	null "gopkg.in/guregu/null.v3"
 )
@@ -21,10 +22,12 @@ func TestJobRuns_RetrievingFromDBWithError(t *testing.T) {
 	defer cleanup()
 
 	job := cltest.NewJobWithWebInitiator()
+	require.NoError(t, store.CreateJob(&job))
 	jr := job.NewRun(job.Initiators[0])
+	jr.JobSpecID = job.ID
 	jr.Result = cltest.RunResultWithError(fmt.Errorf("bad idea"))
 	err := store.CreateJobRun(&jr)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	run, err := store.FindJobRun(jr.ID)
 	assert.NoError(t, err)

--- a/store/models/service_agreement.go
+++ b/store/models/service_agreement.go
@@ -32,9 +32,8 @@ type ServiceAgreement struct {
 	EncumbranceID uint        `json:"-"`
 	RequestBody   string      `json:"requestBody"`
 	Signature     Signature   `json:"signature"`
-	JobSpec       JobSpec     // JobSpec is used during the initial SA creation.
-	JobSpecID     string      `json:"jobSpecID" gorm:"index"`
-	// If needed later, it can be retrieved from the database with JobSpecID.
+	JobSpec       JobSpec     `gorm:"foreignkey:JobSpecID"`
+	JobSpecID     string      `json:"jobSpecId" gorm:"index;not null;type:varchar(36) REFERENCES job_specs(id)"`
 }
 
 // GetID returns the ID of this structure for jsonapi serialization.

--- a/store/models/v1_test.go
+++ b/store/models/v1_test.go
@@ -57,7 +57,7 @@ func TestAssignmentSpec_ConvertToJobSpec(t *testing.T) {
 
 			j1, err := a.ConvertToJobSpec()
 			assert.NoError(t, err)
-			assert.NoError(t, store.SaveJob(&j1))
+			assert.NoError(t, store.CreateJob(&j1))
 			j2 := cltest.FindJob(store, j1.ID)
 
 			assert.NotEqual(t, "", j2.ID)

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -601,9 +601,9 @@ func (orm *ORM) SaveTx(tx *models.Tx) error {
 	return orm.DB.Save(tx).Error
 }
 
-// SaveInitiator saves the initiator.
-func (orm *ORM) SaveInitiator(initr *models.Initiator) error {
-	return orm.DB.Save(initr).Error
+// CreateInitiator saves the initiator.
+func (orm *ORM) CreateInitiator(initr *models.Initiator) error {
+	return orm.DB.Create(initr).Error
 }
 
 // SaveHead saves the indexable block number related to head tracker.

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -203,11 +203,10 @@ func (orm *ORM) CreateJob(job *models.JobSpec) error {
 	return orm.DB.Save(job).Error
 }
 
-// SaveServiceAgreement saves a service agreement and it's associations to the
+// CreateServiceAgreement saves a service agreement and it's associations to the
 // database.
-func (orm *ORM) SaveServiceAgreement(sa *models.ServiceAgreement) error {
-	merr := orm.DB.Save(sa).Error
-	return merr
+func (orm *ORM) CreateServiceAgreement(sa *models.ServiceAgreement) error {
+	return orm.DB.Create(sa).Error
 }
 
 // JobRunsWithStatus returns the JobRuns which have the passed statuses.

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -190,8 +190,8 @@ func (orm *ORM) Sessions(offset, limit int) ([]models.Session, error) {
 	return sessions, err
 }
 
-// SaveJob saves a job to the database and adds IDs to associated tables.
-func (orm *ORM) SaveJob(job *models.JobSpec) error {
+// CreateJob saves a job to the database and adds IDs to associated tables.
+func (orm *ORM) CreateJob(job *models.JobSpec) error {
 	for i := range job.Initiators {
 		job.Initiators[i].JobSpecID = job.ID
 	}

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -125,6 +125,11 @@ func (orm *ORM) SaveJobRun(run *models.JobRun) error {
 	return orm.DB.Save(run).Error
 }
 
+// CreateJobRun inserts a new JobRun
+func (orm *ORM) CreateJobRun(run *models.JobRun) error {
+	return orm.DB.Create(run).Error
+}
+
 // FindServiceAgreement looks up a ServiceAgreement by its ID.
 func (orm *ORM) FindServiceAgreement(id string) (models.ServiceAgreement, error) {
 	var sa models.ServiceAgreement

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -40,6 +40,7 @@ func initializeDatabase(path string) (*gorm.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to open gorm DB: %+v", err)
 	}
+	db.Exec("PRAGMA foreign_keys = ON")
 	return db, nil
 }
 
@@ -200,7 +201,7 @@ func (orm *ORM) CreateJob(job *models.JobSpec) error {
 	for i := range job.Initiators {
 		job.Initiators[i].JobSpecID = job.ID
 	}
-	return orm.DB.Save(job).Error
+	return orm.DB.Create(job).Error
 }
 
 // CreateServiceAgreement saves a service agreement and it's associations to the

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -103,35 +103,6 @@ func TestORM_JobRunsFor(t *testing.T) {
 	assert.Equal(t, []string{jr2.ID, jr1.ID, jr3.ID}, actual)
 }
 
-func TestORM_SaveServiceAgreement(t *testing.T) {
-	t.Parallel()
-	store, cleanup := cltest.NewStore()
-	defer cleanup()
-
-	tests := []struct {
-		name  string
-		input string
-		want  string
-	}{
-		{"basic",
-			`{"initiators":[{"type":"web"}],"tasks":[{"type":"HttpGet","url":"https://bitstamp.net/api/ticker/"},{"type":"JsonParse","path":["last"]},{"type":"EthBytes32"},{"type":"EthTx"}]}`,
-			"0x57bf5be3447b9a3f8491b6538b01f828bcfcaf2d685ea90375ed4ec2943f4865"},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			sa, err := cltest.ServiceAgreementFromString(test.input)
-			assert.NoError(t, err)
-
-			assert.NoError(t, store.SaveServiceAgreement(&sa))
-
-			sa, err = store.FindServiceAgreement(sa.ID)
-			assert.NoError(t, err)
-			_, err = store.FindJob(sa.JobSpecID)
-			assert.NoError(t, err)
-		})
-	}
-}
-
 func TestORM_JobRunsWithStatus(t *testing.T) {
 	t.Parallel()
 	store, cleanup := cltest.NewStore()

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -335,14 +335,17 @@ func TestORM_MarkRan(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 
+	js := models.NewJob()
+	require.NoError(t, store.CreateJob(&js))
 	initr := models.Initiator{
-		Type: models.InitiatorRunAt,
+		JobSpecID: js.ID,
+		Type:      models.InitiatorRunAt,
 		InitiatorParams: models.InitiatorParams{
 			Time: models.Time{Time: time.Now()},
 		},
 	}
 
-	assert.NoError(t, store.CreateInitiator(&initr))
+	require.NoError(t, store.CreateInitiator(&initr))
 
 	assert.NoError(t, store.MarkRan(&initr, true))
 	ir, err := store.FindInitiator(initr.ID)

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -342,7 +342,7 @@ func TestORM_MarkRan(t *testing.T) {
 		},
 	}
 
-	assert.NoError(t, store.SaveInitiator(&initr))
+	assert.NoError(t, store.CreateInitiator(&initr))
 
 	assert.NoError(t, store.MarkRan(&initr, true))
 	ir, err := store.FindInitiator(initr.ID)

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -45,7 +45,7 @@ func TestORM_SaveJob(t *testing.T) {
 	defer cleanup()
 
 	j1 := cltest.NewJobWithSchedule("* * * * *")
-	store.SaveJob(&j1)
+	store.CreateJob(&j1)
 
 	j2, err := store.FindJob(j1.ID)
 	assert.NoError(t, err)
@@ -61,7 +61,7 @@ func TestORM_SaveJobRun(t *testing.T) {
 	defer cleanup()
 
 	job := cltest.NewJobWithSchedule("* * * * *")
-	require.NoError(t, store.SaveJob(&job))
+	require.NoError(t, store.CreateJob(&job))
 
 	jr1 := job.NewRun(job.Initiators[0])
 	creationHeight := models.NewBig(big.NewInt(0))
@@ -85,7 +85,7 @@ func TestORM_JobRunsFor(t *testing.T) {
 	defer cleanup()
 
 	job := cltest.NewJobWithWebInitiator()
-	require.NoError(t, store.SaveJob(&job))
+	require.NoError(t, store.CreateJob(&job))
 	i := job.Initiators[0]
 	jr1 := job.NewRun(i)
 	jr1.CreatedAt = time.Now().AddDate(0, 0, -1)
@@ -138,7 +138,7 @@ func TestORM_JobRunsWithStatus(t *testing.T) {
 	defer cleanup()
 
 	j := cltest.NewJobWithWebInitiator()
-	assert.NoError(t, store.SaveJob(&j))
+	assert.NoError(t, store.CreateJob(&j))
 	i := j.Initiators[0]
 	npr := j.NewRun(i)
 	assert.NoError(t, store.SaveJobRun(&npr))
@@ -196,7 +196,7 @@ func TestORM_AnyJobWithType(t *testing.T) {
 
 	js := cltest.NewJobWithWebInitiator()
 	js.Tasks = []models.TaskSpec{models.TaskSpec{Type: models.MustNewTaskType("bridgetestname")}}
-	assert.NoError(t, store.SaveJob(&js))
+	assert.NoError(t, store.CreateJob(&js))
 	found, err := store.AnyJobWithType("bridgetestname")
 	assert.NoError(t, err)
 	assert.Equal(t, found, true)
@@ -212,9 +212,9 @@ func TestORM_JobRunsCountFor(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 	job := cltest.NewJobWithWebInitiator()
-	assert.NoError(t, store.SaveJob(&job))
+	assert.NoError(t, store.CreateJob(&job))
 	job2 := cltest.NewJobWithWebInitiator()
-	assert.NoError(t, store.SaveJob(&job2))
+	assert.NoError(t, store.CreateJob(&job2))
 
 	assert.NotEqual(t, job.ID, job2.ID)
 
@@ -309,7 +309,7 @@ func TestORM_PendingBridgeType_alreadyCompleted(t *testing.T) {
 	assert.NoError(t, store.CreateBridgeType(&bt))
 
 	job := cltest.NewJobWithWebInitiator()
-	assert.NoError(t, store.SaveJob(&job))
+	assert.NoError(t, store.CreateJob(&job))
 	initr := job.Initiators[0]
 
 	run := job.NewRun(initr)
@@ -333,7 +333,7 @@ func TestORM_PendingBridgeType_success(t *testing.T) {
 
 	job := cltest.NewJobWithWebInitiator()
 	job.Tasks = []models.TaskSpec{models.TaskSpec{Type: bt.Name}}
-	assert.NoError(t, store.SaveJob(&job))
+	assert.NoError(t, store.CreateJob(&job))
 	initr := job.Initiators[0]
 
 	unfinishedRun := job.NewRun(initr)

--- a/web/bridge_types_controller_test.go
+++ b/web/bridge_types_controller_test.go
@@ -206,7 +206,7 @@ func TestBridgeController_Destroy(t *testing.T) {
 
 	js := cltest.NewJobWithWebInitiator()
 	js.Tasks = []models.TaskSpec{models.TaskSpec{Type: bt.Name}}
-	assert.NoError(t, app.Store.SaveJob(&js))
+	assert.NoError(t, app.Store.CreateJob(&js))
 
 	resp, cleanup = client.Delete("/v2/bridge_types/" + bt.Name.String())
 	defer cleanup()

--- a/web/job_runs_controller_test.go
+++ b/web/job_runs_controller_test.go
@@ -114,17 +114,17 @@ func setupJobRunsControllerIndex(t assert.TestingT, app *cltest.TestApplication)
 	runA := j1.NewRun(j1.Initiators[0])
 	runA.ID = "runA"
 	runA.CreatedAt = now.Add(-2 * time.Second)
-	assert.Nil(t, app.Store.SaveJobRun(&runA))
+	assert.Nil(t, app.Store.CreateJobRun(&runA))
 
 	runB := j1.NewRun(j1.Initiators[0])
 	runB.ID = "runB"
 	runB.CreatedAt = now.Add(-time.Second)
-	assert.Nil(t, app.Store.SaveJobRun(&runB))
+	assert.Nil(t, app.Store.CreateJobRun(&runB))
 
 	runC := j2.NewRun(j2.Initiators[0])
 	runC.ID = "runC"
 	runC.CreatedAt = now
-	assert.Nil(t, app.Store.SaveJobRun(&runC))
+	assert.Nil(t, app.Store.CreateJobRun(&runC))
 
 	return &runA, &runB, &runC
 }
@@ -212,7 +212,7 @@ func TestJobRunsController_Update_Success(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(j.Initiators[0]), 0)
-	assert.Nil(t, app.Store.SaveJobRun(&jr))
+	assert.Nil(t, app.Store.CreateJobRun(&jr))
 
 	body := fmt.Sprintf(`{"id":"%v","data":{"value": "100"}}`, jr.ID)
 	headers := map[string]string{"Authorization": "Bearer " + bt.IncomingToken}
@@ -243,7 +243,7 @@ func TestJobRunsController_Update_WrongAccessToken(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(j.Initiators[0]), 0)
-	assert.Nil(t, app.Store.SaveJobRun(&jr))
+	assert.Nil(t, app.Store.CreateJobRun(&jr))
 
 	body := fmt.Sprintf(`{"id":"%v","data":{"value": "100"}}`, jr.ID)
 	headers := map[string]string{"Authorization": "Bearer " + "wrongaccesstoken"}
@@ -268,7 +268,7 @@ func TestJobRunsController_Update_NotPending(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := j.NewRun(j.Initiators[0])
-	assert.Nil(t, app.Store.SaveJobRun(&jr))
+	assert.Nil(t, app.Store.CreateJobRun(&jr))
 
 	body := fmt.Sprintf(`{"id":"%v","data":{"value": "100"}}`, jr.ID)
 	headers := map[string]string{"Authorization": "Bearer " + bt.IncomingToken}
@@ -290,7 +290,7 @@ func TestJobRunsController_Update_WithError(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(j.Initiators[0]), 0)
-	assert.Nil(t, app.Store.SaveJobRun(&jr))
+	assert.Nil(t, app.Store.CreateJobRun(&jr))
 
 	body := fmt.Sprintf(`{"id":"%v","error":"stack overflow","data":{"value": "0"}}`, jr.ID)
 	headers := map[string]string{"Authorization": "Bearer " + bt.IncomingToken}
@@ -319,7 +319,7 @@ func TestJobRunsController_Update_WithMergeError(t *testing.T) {
 	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(j.Initiators[0]), 0)
 	jr.Overrides = jr.Overrides.WithError(errors.New("Already errored")) // easy way to force Merge error
-	assert.Nil(t, app.Store.SaveJobRun(&jr))
+	assert.Nil(t, app.Store.CreateJobRun(&jr))
 
 	body := fmt.Sprintf(`{"id":"%v","data":{"value": "100"}}`, jr.ID)
 	headers := map[string]string{"Authorization": "Bearer " + bt.IncomingToken}
@@ -348,7 +348,7 @@ func TestJobRunsController_Update_BadInput(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(j.Initiators[0]), 0)
-	assert.Nil(t, app.Store.SaveJobRun(&jr))
+	assert.Nil(t, app.Store.CreateJobRun(&jr))
 
 	body := fmt.Sprint(`{`, jr.ID)
 	resp, cleanup := client.Patch("/v2/runs/"+jr.ID, bytes.NewBufferString(body))
@@ -372,7 +372,7 @@ func TestJobRunsController_Update_NotFound(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(j.Initiators[0]), 0)
-	assert.Nil(t, app.Store.SaveJobRun(&jr))
+	assert.Nil(t, app.Store.CreateJobRun(&jr))
 
 	body := fmt.Sprintf(`{"id":"%v","data":{"value": "100"}}`, jr.ID)
 	resp, cleanup := client.Patch("/v2/runs/"+jr.ID+"1", bytes.NewBufferString(body))
@@ -395,7 +395,7 @@ func TestJobRunsController_Show_Found(t *testing.T) {
 	app.Store.CreateJob(&j)
 
 	jr := j.NewRun(j.Initiators[0])
-	assert.NoError(t, app.Store.SaveJobRun(&jr))
+	assert.NoError(t, app.Store.CreateJobRun(&jr))
 
 	resp, cleanup := client.Get("/v2/runs/" + jr.ID)
 	defer cleanup()

--- a/web/job_runs_controller_test.go
+++ b/web/job_runs_controller_test.go
@@ -104,10 +104,10 @@ func TestJobRunsController_Index(t *testing.T) {
 
 func setupJobRunsControllerIndex(t assert.TestingT, app *cltest.TestApplication) (*models.JobRun, *models.JobRun, *models.JobRun) {
 	j1 := cltest.NewJobWithWebInitiator()
-	assert.Nil(t, app.Store.SaveJob(&j1))
+	assert.Nil(t, app.Store.CreateJob(&j1))
 
 	j2 := cltest.NewJobWithWebInitiator()
-	assert.Nil(t, app.Store.SaveJob(&j2))
+	assert.Nil(t, app.Store.CreateJob(&j2))
 
 	now := time.Now()
 
@@ -136,7 +136,7 @@ func TestJobRunsController_Create_Success(t *testing.T) {
 	defer cleanup()
 
 	j := cltest.NewJobWithWebInitiator()
-	assert.NoError(t, app.Store.SaveJob(&j))
+	assert.NoError(t, app.Store.CreateJob(&j))
 
 	jr := cltest.CreateJobRunViaWeb(t, app, j, `{"value":"100"}`)
 	jr = cltest.WaitForJobRunToComplete(t, app.Store, jr)
@@ -152,7 +152,7 @@ func TestJobRunsController_Create_EmptyBody(t *testing.T) {
 	defer cleanup()
 
 	j := cltest.NewJobWithWebInitiator()
-	assert.Nil(t, app.Store.SaveJob(&j))
+	assert.Nil(t, app.Store.CreateJob(&j))
 
 	jr := cltest.CreateJobRunViaWeb(t, app, j)
 	cltest.WaitForJobRunToComplete(t, app.Store, jr)
@@ -166,7 +166,7 @@ func TestJobRunsController_Create_InvalidBody(t *testing.T) {
 	client := app.NewHTTPClient()
 
 	j := cltest.NewJobWithWebInitiator()
-	assert.Nil(t, app.Store.SaveJob(&j))
+	assert.Nil(t, app.Store.CreateJob(&j))
 
 	resp, cleanup := client.Post("/v2/specs/"+j.ID+"/runs", bytes.NewBufferString(`{`))
 	defer cleanup()
@@ -181,7 +181,7 @@ func TestJobRunsController_Create_WithoutWebInitiator(t *testing.T) {
 	client := app.NewHTTPClient()
 
 	j := cltest.NewJob()
-	assert.Nil(t, app.Store.SaveJob(&j))
+	assert.Nil(t, app.Store.CreateJob(&j))
 
 	resp, cleanup := client.Post("/v2/specs/"+j.ID+"/runs", bytes.NewBuffer([]byte{}))
 	defer cleanup()
@@ -210,7 +210,7 @@ func TestJobRunsController_Update_Success(t *testing.T) {
 	assert.Nil(t, app.Store.CreateBridgeType(&bt))
 	j := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
-	assert.Nil(t, app.Store.SaveJob(&j))
+	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(j.Initiators[0]), 0)
 	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
@@ -241,7 +241,7 @@ func TestJobRunsController_Update_WrongAccessToken(t *testing.T) {
 	assert.Nil(t, app.Store.CreateBridgeType(&bt))
 	j := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
-	assert.Nil(t, app.Store.SaveJob(&j))
+	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(j.Initiators[0]), 0)
 	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
@@ -266,7 +266,7 @@ func TestJobRunsController_Update_NotPending(t *testing.T) {
 	assert.Nil(t, app.Store.CreateBridgeType(&bt))
 	j := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
-	assert.Nil(t, app.Store.SaveJob(&j))
+	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := j.NewRun(j.Initiators[0])
 	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
@@ -288,7 +288,7 @@ func TestJobRunsController_Update_WithError(t *testing.T) {
 	assert.Nil(t, app.Store.CreateBridgeType(&bt))
 	j := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
-	assert.Nil(t, app.Store.SaveJob(&j))
+	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(j.Initiators[0]), 0)
 	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
@@ -316,7 +316,7 @@ func TestJobRunsController_Update_WithMergeError(t *testing.T) {
 	assert.Nil(t, app.Store.CreateBridgeType(&bt))
 	j := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
-	assert.Nil(t, app.Store.SaveJob(&j))
+	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(j.Initiators[0]), 0)
 	jr.Overrides = jr.Overrides.WithError(errors.New("Already errored")) // easy way to force Merge error
 	assert.Nil(t, app.Store.SaveJobRun(&jr))
@@ -346,7 +346,7 @@ func TestJobRunsController_Update_BadInput(t *testing.T) {
 	assert.Nil(t, app.Store.CreateBridgeType(&bt))
 	j := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
-	assert.Nil(t, app.Store.SaveJob(&j))
+	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(j.Initiators[0]), 0)
 	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
@@ -370,7 +370,7 @@ func TestJobRunsController_Update_NotFound(t *testing.T) {
 	assert.Nil(t, app.Store.CreateBridgeType(&bt))
 	j := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
-	assert.Nil(t, app.Store.SaveJob(&j))
+	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(j.Initiators[0]), 0)
 	assert.Nil(t, app.Store.SaveJobRun(&jr))
 
@@ -392,7 +392,7 @@ func TestJobRunsController_Show_Found(t *testing.T) {
 	client := app.NewHTTPClient()
 
 	j := cltest.NewJobWithSchedule("9 9 9 9 6")
-	app.Store.SaveJob(&j)
+	app.Store.CreateJob(&j)
 
 	jr := j.NewRun(j.Initiators[0])
 	assert.NoError(t, app.Store.SaveJobRun(&jr))

--- a/web/job_specs_controller_test.go
+++ b/web/job_specs_controller_test.go
@@ -131,20 +131,20 @@ func TestJobSpecsController_Index_sortCreatedAt(t *testing.T) {
 func setupJobSpecsControllerIndex(app *cltest.TestApplication) (*models.JobSpec, error) {
 	j1 := cltest.NewJobWithSchedule("9 9 9 9 6")
 	j1.CreatedAt = models.Time{Time: time.Now().AddDate(0, 0, -1)}
-	err := app.Store.SaveJob(&j1)
+	err := app.Store.CreateJob(&j1)
 	if err != nil {
 		return nil, err
 	}
 	j2 := cltest.NewJobWithWebInitiator()
 	j2.Initiators[0].Ran = true
-	err = app.Store.SaveJob(&j2)
+	err = app.Store.CreateJob(&j2)
 	return &j1, err
 }
 
 func createJobs(app *cltest.TestApplication, n int) (jobs []*models.JobSpec) {
 	for i := 0; i < n; i++ {
 		j := cltest.NewJobWithWebInitiator()
-		err := app.Store.SaveJob(&j)
+		err := app.Store.CreateJob(&j)
 		if err != nil {
 			panic(fmt.Sprintf("Could not save job: %v", err))
 		}
@@ -343,7 +343,7 @@ func TestJobSpecsController_Show(t *testing.T) {
 
 func setupJobSpecsControllerShow(t assert.TestingT, app *cltest.TestApplication) *models.JobSpec {
 	j := cltest.NewJobWithSchedule("9 9 9 9 6")
-	app.Store.SaveJob(&j)
+	app.Store.CreateJob(&j)
 	initr := j.Initiators[0]
 
 	jr1 := j.NewRun(initr)

--- a/web/job_specs_controller_test.go
+++ b/web/job_specs_controller_test.go
@@ -348,11 +348,11 @@ func setupJobSpecsControllerShow(t assert.TestingT, app *cltest.TestApplication)
 
 	jr1 := j.NewRun(initr)
 	jr1.ID = "2"
-	assert.Nil(t, app.Store.SaveJobRun(&jr1))
+	assert.Nil(t, app.Store.CreateJobRun(&jr1))
 	jr2 := j.NewRun(initr)
 	jr2.ID = "1"
 	jr2.CreatedAt = jr1.CreatedAt.Add(time.Second)
-	assert.Nil(t, app.Store.SaveJobRun(&jr2))
+	assert.Nil(t, app.Store.CreateJobRun(&jr2))
 
 	return &j
 }

--- a/web/service_agreements_controller.go
+++ b/web/service_agreements_controller.go
@@ -40,10 +40,7 @@ func (sac *ServiceAgreementsController) Create(c *gin.Context) {
 		} else if err = services.ValidateServiceAgreement(sa, sac.App.GetStore()); err != nil {
 			publicError(c, 422, err)
 			return
-		} else if err = sac.App.GetStore().CreateServiceAgreement(&sa); err != nil {
-			_ = c.AbortWithError(500, err)
-			return
-		} else if err = sac.App.AddJob(sa.JobSpec); err != nil {
+		} else if err = sac.App.AddServiceAgreement(&sa); err != nil {
 			_ = c.AbortWithError(500, err)
 			return
 		}

--- a/web/service_agreements_controller.go
+++ b/web/service_agreements_controller.go
@@ -40,7 +40,7 @@ func (sac *ServiceAgreementsController) Create(c *gin.Context) {
 		} else if err = services.ValidateServiceAgreement(sa, sac.App.GetStore()); err != nil {
 			publicError(c, 422, err)
 			return
-		} else if err = sac.App.GetStore().SaveServiceAgreement(&sa); err != nil {
+		} else if err = sac.App.GetStore().CreateServiceAgreement(&sa); err != nil {
 			_ = c.AbortWithError(500, err)
 			return
 		} else if err = sac.App.AddJob(sa.JobSpec); err != nil {

--- a/web/service_agreements_controller_test.go
+++ b/web/service_agreements_controller_test.go
@@ -102,7 +102,7 @@ func TestServiceAgreementsController_Show(t *testing.T) {
 	input := cltest.LoadJSON("../internal/fixtures/web/hello_world_agreement.json")
 	sa, err := cltest.ServiceAgreementFromString(string(input))
 	assert.NoError(t, err)
-	assert.NoError(t, app.Store.SaveServiceAgreement(&sa))
+	assert.NoError(t, app.Store.CreateServiceAgreement(&sa))
 
 	resp, cleanup := client.Get("/v2/service_agreements/" + sa.ID)
 	defer cleanup()

--- a/web/service_agreements_controller_test.go
+++ b/web/service_agreements_controller_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestServiceAgreementsController_Create(t *testing.T) {
@@ -101,8 +102,9 @@ func TestServiceAgreementsController_Show(t *testing.T) {
 
 	input := cltest.LoadJSON("../internal/fixtures/web/hello_world_agreement.json")
 	sa, err := cltest.ServiceAgreementFromString(string(input))
-	assert.NoError(t, err)
-	assert.NoError(t, app.Store.CreateServiceAgreement(&sa))
+	require.NoError(t, err)
+	require.NoError(t, app.Store.CreateJob(&sa.JobSpec))
+	require.NoError(t, app.Store.CreateServiceAgreement(&sa))
 
 	resp, cleanup := client.Get("/v2/service_agreements/" + sa.ID)
 	defer cleanup()

--- a/web/snapshots_controller_test.go
+++ b/web/snapshots_controller_test.go
@@ -63,8 +63,7 @@ func TestSnapshotsController_ShowSnapshot_V1_Format(t *testing.T) {
 	t.Parallel()
 
 	tickerResponse := `{"high": "10744.00", "last": "10583.75", "timestamp": "1512156162", "bid": "10555.13", "vwap": "10097.98", "volume": "17861.33960013", "low": "9370.11", "ask": "10583.00", "open": "9927.29"}`
-	mockServer, assertCalled := cltest.NewHTTPMockServer(t, 200, "GET", tickerResponse)
-	defer assertCalled()
+	mockServer, _ := cltest.NewHTTPMockServer(t, 200, "GET", tickerResponse)
 
 	config, _ := cltest.NewConfigWithPrivateKey()
 	app, cleanup := cltest.NewApplicationWithConfigAndUnlockedAccount(config)

--- a/web/snapshots_controller_test.go
+++ b/web/snapshots_controller_test.go
@@ -63,7 +63,8 @@ func TestSnapshotsController_ShowSnapshot_V1_Format(t *testing.T) {
 	t.Parallel()
 
 	tickerResponse := `{"high": "10744.00", "last": "10583.75", "timestamp": "1512156162", "bid": "10555.13", "vwap": "10097.98", "volume": "17861.33960013", "low": "9370.11", "ask": "10583.00", "open": "9927.29"}`
-	mockServer, _ := cltest.NewHTTPMockServer(t, 200, "GET", tickerResponse)
+	mockServer, assertCalled := cltest.NewHTTPMockServer(t, 200, "GET", tickerResponse)
+	defer assertCalled()
 
 	config, _ := cltest.NewConfigWithPrivateKey()
 	app, cleanup := cltest.NewApplicationWithConfigAndUnlockedAccount(config)


### PR DESCRIPTION
Add foreign keys to the suggested models.

Note that in gorm creation/saving has a difference: insert vs update. This difference becomes more important with foreign keys. This change has been made more explicit in the code.

Other changes of note:

  1. Service Agreement and JobSpec get made in one go
  2. Pragma to enable foreign keys, may be ignored on postgres
  3. Fixture methods created two JobSpecs with the same ID, this has been fixed.