### PR TITLE
Add a strict flag to EthMock

### DIFF
--- a/integration/features_test.go
+++ b/integration/features_test.go
@@ -47,7 +47,7 @@ func TestIntegration_HelloWorld(t *testing.T) {
 	config, _ := cltest.NewConfigWithPrivateKey()
 	app, cleanup := cltest.NewApplicationWithConfigAndUnlockedAccount(config)
 	defer cleanup()
-	eth := app.MockEthClient()
+	eth := app.MockEthClient(cltest.Strict)
 
 	newHeads := make(chan models.BlockHeader)
 	attempt1Hash := common.HexToHash("0xb7862c896a6ba2711bccc0410184e46d793ea83b3e05470f1d359ea276d16bb5")

--- a/integration/features_test.go
+++ b/integration/features_test.go
@@ -63,6 +63,7 @@ func TestIntegration_HelloWorld(t *testing.T) {
 
 	eth.Context("app.Start()", func(eth *cltest.EthMock) {
 		eth.RegisterSubscription("newHeads", newHeads)
+		eth.Register("eth_getBlockByNumber", models.BlockHeader{})
 		eth.Register("eth_getTransactionCount", `0x0100`) // TxManager.ActivateAccount()
 	})
 	assert.NoError(t, app.Start())

--- a/integration/features_test.go
+++ b/integration/features_test.go
@@ -63,7 +63,6 @@ func TestIntegration_HelloWorld(t *testing.T) {
 
 	eth.Context("app.Start()", func(eth *cltest.EthMock) {
 		eth.RegisterSubscription("newHeads", newHeads)
-		eth.Register("eth_getBlockByNumber", models.BlockHeader{})
 		eth.Register("eth_getTransactionCount", `0x0100`) // TxManager.ActivateAccount()
 	})
 	assert.NoError(t, app.Start())
@@ -101,6 +100,8 @@ func TestIntegration_HelloWorld(t *testing.T) {
 		eth.Register("eth_blockNumber", utils.Uint64ToHex(safe))
 		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
 		eth.Register("eth_getTransactionReceipt", confirmedReceipt) // confirmed for gas bumped txat
+		eth.Register("eth_getBalance", "0x0100")
+		eth.Register("eth_call", "0x0100")
 	})
 	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(safe)} // 23465
 	eth.EventuallyAllCalled(t)

--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -146,6 +146,7 @@ func (mock *EthMock) Call(result interface{}, method string, args ...interface{}
 			return nil
 		}
 	}
+
 	err := fmt.Errorf("EthMock: Method %v not registered", method)
 	if mock.strict {
 		log.Fatal(err)

--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -26,17 +26,25 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Strict flag makes the mock eth client panic if an unexpected call is made
+const Strict = "strict"
+
 // MockEthClient create new EthMock Client
-func (ta *TestApplication) MockEthClient() *EthMock {
+func (ta *TestApplication) MockEthClient(flags ...string) *EthMock {
 	if ta.ChainlinkApplication.HeadTracker.Connected() {
 		logger.Panic("Cannot mock eth client after being connected")
 	}
-	return MockEthOnStore(ta.Store)
+	return MockEthOnStore(ta.Store, flags...)
 }
 
 // MockEthOnStore given store return new EthMock Client
-func MockEthOnStore(s *store.Store) *EthMock {
+func MockEthOnStore(s *store.Store, flags ...string) *EthMock {
 	mock := &EthMock{}
+	for _, flag := range flags {
+		if flag == Strict {
+			mock.strict = true
+		}
+	}
 	eth := &store.EthClient{CallerSubscriber: mock}
 	if txm, ok := s.TxManager.(*store.EthTxManager); ok {
 		txm.EthClient = eth
@@ -54,6 +62,7 @@ type EthMock struct {
 	logsCalled     bool
 	mutex          sync.RWMutex
 	context        string
+	strict         bool
 }
 
 // Dial mock dial
@@ -137,7 +146,11 @@ func (mock *EthMock) Call(result interface{}, method string, args ...interface{}
 			return nil
 		}
 	}
-	return fmt.Errorf("EthMock: Method %v not registered", method)
+	err := fmt.Errorf("EthMock: Method %v not registered", method)
+	if mock.strict {
+		log.Fatal(err)
+	}
+	return err
 }
 
 // RegisterSubscription register a mock subscription to the given name and channels


### PR DESCRIPTION
Given the nature of the HelloWorld test, it's easy to break things, but this test is painful to fix because diagnosis is so challenging.

One thing that hurts diagnosis is that the mocks are not enforced, so they tend to drift over time. The mocks have changed several times recently, and now look to be incorrect again.

Added a strict flag to make sure this doesn't happen anymore.