### PR TITLE
Clean up Job Runs *and* related Run Results and Task Runs in Bulk Deletion

### DIFF
--- a/store/migrations/migration0/migrate.go
+++ b/store/migrations/migration0/migrate.go
@@ -2,7 +2,6 @@ package migration0
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/store/orm"
@@ -18,7 +17,6 @@ func (m Migration) Timestamp() string {
 func (m Migration) Migrate(orm *orm.ORM) error {
 	return multierr.Combine(
 		setTimezone(orm),
-		setForeignKeysOn(orm),
 		migrationHelper(orm, &models.JobSpec{}),
 		migrationHelper(orm, &models.TaskSpec{}),
 		migrationHelper(orm, &models.JobRun{}),
@@ -38,13 +36,6 @@ func (m Migration) Migrate(orm *orm.ORM) error {
 func setTimezone(orm *orm.ORM) error {
 	if orm.DB.Dialect().GetName() == "postgres" {
 		return orm.DB.Exec(`SET TIME ZONE 'UTC';`).Error
-	}
-	return nil
-}
-
-func setForeignKeysOn(orm *orm.ORM) error {
-	if strings.HasPrefix(orm.DB.Dialect().GetName(), "sqlite") {
-		return orm.DB.Exec("PRAGMA foreign_keys = ON").Error
 	}
 	return nil
 }

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -82,6 +82,7 @@ func initializeDatabase(dialect, path string) (*gorm.DB, error) {
 	if err != nil {
 		return nil, fmt.Errorf("unable to open %s for gorm DB: %+v", path, err)
 	}
+	db.Exec("PRAGMA foreign_keys = ON")
 	return db, nil
 }
 

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -703,7 +703,12 @@ func (orm *ORM) DeleteStaleSessions(before time.Time) error {
 	return orm.DB.Where("last_used < ?", before).Delete(models.Session{}).Error
 }
 
-// BulkDeleteRuns removes runs given a query.
+// BulkDeleteRuns removes JobRuns and their related records: TaskRuns and
+// RunResults.
+//
+// TaskRuns are removed by ON DELETE CASCADE when the JobRuns are
+// deleted, but RunResults are not using foreign keys because multiple foreign
+// keys on a record creates an ambiguity with gorm.
 func (orm *ORM) BulkDeleteRuns(bulkQuery *models.BulkDeleteRunRequest) error {
 	tx := orm.DB.Begin()
 	if tx.Error != nil {

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -706,32 +706,46 @@ func (orm *ORM) DeleteStaleSessions(before time.Time) error {
 // BulkDeleteRuns removes runs given a query.
 func (orm *ORM) BulkDeleteRuns(bulkQuery *models.BulkDeleteRunRequest) error {
 	tx := orm.DB.Begin()
-	err := orm.DB.Exec(`DELETE
+	if tx.Error != nil {
+		return tx.Error
+	}
+
+	// NOTE: SQLite doesn't support compound delete statements, so delete run
+	// results for job_runs ...
+	err := tx.Exec(`
+		DELETE
 		FROM run_results
 		WHERE run_results.id IN (SELECT result_id
-													  FROM job_runs
-														WHERE status IN (?) AND updated_at < ?)`,
+													   FROM job_runs
+														 WHERE status IN (?) AND updated_at < ?)`,
 		bulkQuery.Status.ToStrings(), bulkQuery.UpdatedBefore).Error
 	if err != nil {
-		return err
+		tx.Rollback()
+		return fmt.Errorf("error deleting JobRun's RunResults: %v", err)
 	}
-	err = orm.DB.Exec(`DELETE
+
+	// and then task runs using a join in the subquery
+	err = tx.Exec(`
+		DELETE
 		FROM run_results
 		WHERE run_results.id IN (SELECT task_runs.result_id
-													  FROM task_runs
-														INNER JOIN job_runs ON
-															task_runs.job_run_id = job_runs.id
-														WHERE job_runs.status IN (?) AND job_runs.updated_at < ?)`,
+													   FROM task_runs
+														 INNER JOIN job_runs ON
+															 task_runs.job_run_id = job_runs.id
+														 WHERE job_runs.status IN (?) AND job_runs.updated_at < ?)`,
 		bulkQuery.Status.ToStrings(), bulkQuery.UpdatedBefore).Error
 	if err != nil {
-		return err
+		tx.Rollback()
+		return fmt.Errorf("error deleting TaskRuns's RunResults: %v", err)
 	}
-	err = orm.DB.
+
+	err = tx.
 		Where("status IN (?)", bulkQuery.Status.ToStrings()).
 		Where("updated_at < ?", bulkQuery.UpdatedBefore).
 		Delete(&[]models.JobRun{}).
 		Error
 	if err != nil {
+		tx.Rollback()
 		return err
 	}
 	return tx.Commit().Error

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -2,7 +2,6 @@ package orm_test
 
 import (
 	"encoding/hex"
-	"fmt"
 	"math/big"
 	"testing"
 	"time"
@@ -542,7 +541,6 @@ func TestBulkDeleteRuns(t *testing.T) {
 	// matches updated before but none of the statuses
 	oldIncompleteRun := job.NewRun(initiator)
 	oldIncompleteRun.Status = models.RunStatusInProgress
-	fmt.Println("oldIncompleteRun", oldIncompleteRun)
 	err := orm.CreateJobRun(&oldIncompleteRun)
 	require.NoError(t, err)
 	db.Model(&oldIncompleteRun).UpdateColumn("updated_at", cltest.ParseISO8601("2018-01-01T00:00:00Z"))


### PR DESCRIPTION
This has to be done in multiple statements due to our inverse child->parent relationship on RunResults -> {JobRuns, TaskRuns}.

Sqlite also doesn't support joins on DELETEs so we have to use two subqueries.

NOTE: Sqlite needs the foreign keys pragma to be set on every connection, setting it on the migration is not sufficient. See https://www.techonthenet.com/sql_server/foreign_keys/foreign_delete.php