### PR TITLE
Move to more procedural run results

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -112,6 +112,7 @@
   packages = [
     ".",
     "accounts",
+    "accounts/abi",
     "accounts/keystore",
     "common",
     "common/hexutil",
@@ -1148,6 +1149,7 @@
     "github.com/bitly/go-simplejson",
     "github.com/ethereum/go-ethereum",
     "github.com/ethereum/go-ethereum/accounts",
+    "github.com/ethereum/go-ethereum/accounts/abi",
     "github.com/ethereum/go-ethereum/accounts/keystore",
     "github.com/ethereum/go-ethereum/common",
     "github.com/ethereum/go-ethereum/common/hexutil",

--- a/adapters/bridge.go
+++ b/adapters/bridge.go
@@ -74,11 +74,7 @@ func responseToRunResult(body []byte, input *models.RunResult) error {
 		return baRunResultError("unmarshaling JSON", err)
 	}
 
-	err = input.Merge(brr.RunResult)
-	if err != nil {
-		return baRunResultError("Unable to merge received payload", err)
-	}
-
+	input.Merge(brr.RunResult)
 	return nil
 }
 

--- a/adapters/bridge.go
+++ b/adapters/bridge.go
@@ -41,14 +41,10 @@ func resumeBridge(input models.RunResult) models.RunResult {
 }
 
 func (ba *Bridge) handleNewRun(input *models.RunResult, bridgeResponseURL *url.URL) {
-	var err error
-	if ba.Params != nil {
-		input.Data, err = input.Data.Merge(*ba.Params)
-		if err != nil {
-			input.SetError(baRunResultError("handling data param", err))
-			return
-		}
+	if ba.Params == nil {
+		ba.Params = new(models.JSON)
 	}
+	input.Data = input.Data.Merge(*ba.Params)
 
 	responseURL := bridgeResponseURL
 	if *responseURL != *zeroURL {

--- a/adapters/bridge.go
+++ b/adapters/bridge.go
@@ -44,7 +44,11 @@ func (ba *Bridge) handleNewRun(input *models.RunResult, bridgeResponseURL *url.U
 	if ba.Params == nil {
 		ba.Params = new(models.JSON)
 	}
-	input.Data = input.Data.Merge(*ba.Params)
+	var err error
+	if input.Data, err = input.Data.Merge(*ba.Params); err != nil {
+		input.SetError(baRunResultError("handling data param", err))
+		return
+	}
 
 	responseURL := bridgeResponseURL
 	if *responseURL != *zeroURL {

--- a/adapters/bridge.go
+++ b/adapters/bridge.go
@@ -45,7 +45,7 @@ func (ba *Bridge) handleNewRun(input *models.RunResult, bridgeResponseURL *url.U
 	if ba.Params != nil {
 		input.Data, err = input.Data.Merge(*ba.Params)
 		if err != nil {
-			input.WithError(baRunResultError("handling data param", err))
+			input.SetError(baRunResultError("handling data param", err))
 			return
 		}
 	}
@@ -56,13 +56,13 @@ func (ba *Bridge) handleNewRun(input *models.RunResult, bridgeResponseURL *url.U
 	}
 	body, err := ba.postToExternalAdapter(input, responseURL)
 	if err != nil {
-		input.WithError(baRunResultError("post to external adapter", err))
+		input.SetError(baRunResultError("post to external adapter", err))
 		return
 	}
 
 	err = responseToRunResult(body, input)
 	if err != nil {
-		input.WithError(baRunResultError("post to external adapter", err))
+		input.SetError(baRunResultError("post to external adapter", err))
 		return
 	}
 }

--- a/adapters/copy.go
+++ b/adapters/copy.go
@@ -17,7 +17,8 @@ func (c *Copy) Perform(input models.RunResult, store *store.Store) models.RunRes
 
 	data, err := input.Data.Add("result", input.Data.String())
 	if err != nil {
-		return input.WithError(err)
+		input.WithError(err)
+		return input
 	}
 	input.Data = data
 

--- a/adapters/copy.go
+++ b/adapters/copy.go
@@ -17,7 +17,7 @@ func (c *Copy) Perform(input models.RunResult, store *store.Store) models.RunRes
 
 	data, err := input.Data.Add("result", input.Data.String())
 	if err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return input
 	}
 	input.Data = data

--- a/adapters/copy_test.go
+++ b/adapters/copy_test.go
@@ -4,8 +4,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"log"
-
 	"github.com/smartcontractkit/chainlink/adapters"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/stretchr/testify/assert"
@@ -45,7 +43,6 @@ func TestCopy_Perform(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
 			input := cltest.RunResultWithData(test.result)
-			log.Print(input)
 			adapter := adapters.Copy{CopyPath: test.copyPath}
 			result := adapter.Perform(input, nil)
 			assert.Equal(t, test.want, result.Data.String())

--- a/adapters/eth_bool.go
+++ b/adapters/eth_bool.go
@@ -20,9 +20,11 @@ type EthBool struct{}
 func (*EthBool) Perform(input models.RunResult, _ *store.Store) models.RunResult {
 	r := input.Result()
 	if boolean(r.Type) {
-		return input.WithResult(evmTrue)
+		input.WithResult(evmTrue)
+		return input
 	}
-	return input.WithResult(evmFalse)
+	input.WithResult(evmFalse)
+	return input
 }
 
 func boolean(t gjson.Type) bool {

--- a/adapters/eth_bool.go
+++ b/adapters/eth_bool.go
@@ -20,10 +20,10 @@ type EthBool struct{}
 func (*EthBool) Perform(input models.RunResult, _ *store.Store) models.RunResult {
 	r := input.Result()
 	if boolean(r.Type) {
-		input.WithResult(evmTrue)
+		input.ApplyResult(evmTrue)
 		return input
 	}
-	input.WithResult(evmFalse)
+	input.ApplyResult(evmFalse)
 	return input
 }
 

--- a/adapters/eth_format.go
+++ b/adapters/eth_format.go
@@ -41,7 +41,7 @@ type EthInt256 struct{}
 func (*EthInt256) Perform(input models.RunResult, _ *store.Store) models.RunResult {
 	value, err := utils.EVMTranscodeInt256(input.Result())
 	if err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return input
 	}
 
@@ -61,7 +61,7 @@ type EthUint256 struct{}
 func (*EthUint256) Perform(input models.RunResult, _ *store.Store) models.RunResult {
 	value, err := utils.EVMTranscodeUint256(input.Result())
 	if err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return input
 	}
 

--- a/adapters/eth_format.go
+++ b/adapters/eth_format.go
@@ -25,7 +25,8 @@ func (*EthBytes32) Perform(input models.RunResult, _ *store.Store) models.RunRes
 	if len(hex) > utils.EVMWordHexLen {
 		hex = hex[:utils.EVMWordHexLen]
 	}
-	return input.WithResult(utils.AddHexPrefix(hex))
+	input.WithResult(utils.AddHexPrefix(hex))
+	return input
 }
 
 // EthInt256 holds no fields
@@ -40,10 +41,12 @@ type EthInt256 struct{}
 func (*EthInt256) Perform(input models.RunResult, _ *store.Store) models.RunResult {
 	value, err := utils.EVMTranscodeInt256(input.Result())
 	if err != nil {
-		return input.WithError(err)
+		input.WithError(err)
+		return input
 	}
 
-	return input.WithResult(hexutil.Encode(value))
+	input.WithResult(hexutil.Encode(value))
+	return input
 }
 
 // EthUint256 holds no fields.
@@ -58,8 +61,10 @@ type EthUint256 struct{}
 func (*EthUint256) Perform(input models.RunResult, _ *store.Store) models.RunResult {
 	value, err := utils.EVMTranscodeUint256(input.Result())
 	if err != nil {
-		return input.WithError(err)
+		input.WithError(err)
+		return input
 	}
 
-	return input.WithResult(hexutil.Encode(value))
+	input.WithResult(hexutil.Encode(value))
+	return input
 }

--- a/adapters/eth_format.go
+++ b/adapters/eth_format.go
@@ -25,7 +25,7 @@ func (*EthBytes32) Perform(input models.RunResult, _ *store.Store) models.RunRes
 	if len(hex) > utils.EVMWordHexLen {
 		hex = hex[:utils.EVMWordHexLen]
 	}
-	input.WithResult(utils.AddHexPrefix(hex))
+	input.ApplyResult(utils.AddHexPrefix(hex))
 	return input
 }
 
@@ -45,7 +45,7 @@ func (*EthInt256) Perform(input models.RunResult, _ *store.Store) models.RunResu
 		return input
 	}
 
-	input.WithResult(hexutil.Encode(value))
+	input.ApplyResult(hexutil.Encode(value))
 	return input
 }
 
@@ -65,6 +65,6 @@ func (*EthUint256) Perform(input models.RunResult, _ *store.Store) models.RunRes
 		return input
 	}
 
-	input.WithResult(hexutil.Encode(value))
+	input.ApplyResult(hexutil.Encode(value))
 	return input
 }

--- a/adapters/eth_tx.go
+++ b/adapters/eth_tx.go
@@ -88,7 +88,7 @@ func createTxRunResult(
 		return
 	}
 
-	input.WithResult(tx.Hash.String())
+	input.ApplyResult(tx.Hash.String())
 	ensureTxRunResult(input, store)
 }
 
@@ -129,5 +129,5 @@ func addReceiptToResult(receipt *store.TxReceipt, in *models.RunResult) {
 
 	receipts = append(receipts, *receipt)
 	in.Add("ethereumReceipts", receipts)
-	in.WithResult(receipt.Hash.String())
+	in.ApplyResult(receipt.Hash.String())
 }

--- a/adapters/eth_tx.go
+++ b/adapters/eth_tx.go
@@ -72,19 +72,19 @@ func createTxRunResult(
 ) {
 	value, err := getTxData(e, input)
 	if err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return
 	}
 
 	data, err := utils.ConcatBytes(e.FunctionSelector.Bytes(), e.DataPrefix, value)
 	if err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return
 	}
 
 	tx, err := store.TxManager.CreateTxWithGas(e.Address, data, e.GasPrice.ToInt(), e.GasLimit)
 	if err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return
 	}
 
@@ -95,13 +95,13 @@ func createTxRunResult(
 func ensureTxRunResult(input *models.RunResult, str *store.Store) {
 	val, err := input.ResultString()
 	if err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return
 	}
 
 	hash := common.HexToHash(val)
 	if err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return
 	}
 

--- a/adapters/eth_tx_test.go
+++ b/adapters/eth_tx_test.go
@@ -228,7 +228,8 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_StillPending(t *testing.T
 	assert.NoError(t, err)
 	adapter := adapters.EthTx{}
 	sentResult := cltest.RunResultWithResult(a.Hash.String())
-	input := sentResult.MarkPendingConfirmations()
+	input := sentResult
+	input.MarkPendingConfirmations()
 
 	output := adapter.Perform(input, store)
 
@@ -268,7 +269,8 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_BumpGas(t *testing.T) {
 	assert.NoError(t, err)
 	adapter := adapters.EthTx{}
 	sentResult := cltest.RunResultWithResult(a.Hash.String())
-	input := sentResult.MarkPendingConfirmations()
+	input := sentResult
+	input.MarkPendingConfirmations()
 
 	output := adapter.Perform(input, store)
 
@@ -309,7 +311,8 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_ConfirmCompletes(t *testi
 	a3, _ := store.AddTxAttempt(tx, tx.EthTx(big.NewInt(3)), sentAt+2)
 	adapter := adapters.EthTx{}
 	sentResult := cltest.RunResultWithResult(a3.Hash.String())
-	input := sentResult.MarkPendingConfirmations()
+	input := sentResult
+	input.MarkPendingConfirmations()
 
 	assert.False(t, tx.Confirmed)
 
@@ -363,9 +366,10 @@ func TestEthTxAdapter_Perform_AppendingTransactionReceipts(t *testing.T) {
 	adapter := adapters.EthTx{}
 	sentResult := cltest.RunResultWithResult(a.Hash.String())
 
-	input := sentResult.MarkPendingConfirmations()
+	input := sentResult
+	input.MarkPendingConfirmations()
 	previousReceipt := strpkg.TxReceipt{Hash: cltest.NewHash(), BlockNumber: cltest.Int(sentAt - 10)}
-	input = input.Add("ethereumReceipts", []strpkg.TxReceipt{previousReceipt})
+	input.Add("ethereumReceipts", []strpkg.TxReceipt{previousReceipt})
 
 	output := adapter.Perform(input, store)
 	assert.True(t, output.Status.Completed())

--- a/adapters/http.go
+++ b/adapters/http.go
@@ -25,7 +25,7 @@ func (hga *HTTPGet) Perform(input models.RunResult, _ *store.Store) models.RunRe
 	client := &http.Client{Transport: tr}
 	response, err := client.Get(hga.GetURL())
 	if err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return input
 	}
 
@@ -34,12 +34,12 @@ func (hga *HTTPGet) Perform(input models.RunResult, _ *store.Store) models.RunRe
 	bytes, err := ioutil.ReadAll(response.Body)
 	body := string(bytes)
 	if err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return input
 	}
 
 	if response.StatusCode >= 400 {
-		input.WithError(fmt.Errorf(body))
+		input.SetError(fmt.Errorf(body))
 		return input
 	}
 
@@ -71,7 +71,7 @@ func (hpa *HTTPPost) Perform(input models.RunResult, _ *store.Store) models.RunR
 	reqBody := bytes.NewBufferString(input.Data.String())
 	response, err := client.Post(hpa.GetURL(), "application/json", reqBody)
 	if err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return input
 	}
 
@@ -80,12 +80,12 @@ func (hpa *HTTPPost) Perform(input models.RunResult, _ *store.Store) models.RunR
 	bytes, err := ioutil.ReadAll(response.Body)
 	body := string(bytes)
 	if err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return input
 	}
 
 	if response.StatusCode >= 400 {
-		input.WithError(fmt.Errorf(body))
+		input.SetError(fmt.Errorf(body))
 		return input
 	}
 

--- a/adapters/http.go
+++ b/adapters/http.go
@@ -25,7 +25,8 @@ func (hga *HTTPGet) Perform(input models.RunResult, _ *store.Store) models.RunRe
 	client := &http.Client{Transport: tr}
 	response, err := client.Get(hga.GetURL())
 	if err != nil {
-		return input.WithError(err)
+		input.WithError(err)
+		return input
 	}
 
 	defer response.Body.Close()
@@ -33,14 +34,17 @@ func (hga *HTTPGet) Perform(input models.RunResult, _ *store.Store) models.RunRe
 	bytes, err := ioutil.ReadAll(response.Body)
 	body := string(bytes)
 	if err != nil {
-		return input.WithError(err)
+		input.WithError(err)
+		return input
 	}
 
 	if response.StatusCode >= 400 {
-		return input.WithError(fmt.Errorf(body))
+		input.WithError(fmt.Errorf(body))
+		return input
 	}
 
-	return input.WithResult(body)
+	input.WithResult(body)
+	return input
 }
 
 // GetURL retrieves the GET field if set otherwise returns the URL field
@@ -67,7 +71,8 @@ func (hpa *HTTPPost) Perform(input models.RunResult, _ *store.Store) models.RunR
 	reqBody := bytes.NewBufferString(input.Data.String())
 	response, err := client.Post(hpa.GetURL(), "application/json", reqBody)
 	if err != nil {
-		return input.WithError(err)
+		input.WithError(err)
+		return input
 	}
 
 	defer response.Body.Close()
@@ -75,14 +80,17 @@ func (hpa *HTTPPost) Perform(input models.RunResult, _ *store.Store) models.RunR
 	bytes, err := ioutil.ReadAll(response.Body)
 	body := string(bytes)
 	if err != nil {
-		return input.WithError(err)
+		input.WithError(err)
+		return input
 	}
 
 	if response.StatusCode >= 400 {
-		return input.WithError(fmt.Errorf(body))
+		input.WithError(fmt.Errorf(body))
+		return input
 	}
 
-	return input.WithResult(body)
+	input.WithResult(body)
+	return input
 }
 
 // GetURL retrieves the POST field if set otherwise returns the URL field

--- a/adapters/http.go
+++ b/adapters/http.go
@@ -2,7 +2,7 @@ package adapters
 
 import (
 	"bytes"
-	"fmt"
+	"errors"
 	"io/ioutil"
 	"net/http"
 
@@ -39,7 +39,7 @@ func (hga *HTTPGet) Perform(input models.RunResult, _ *store.Store) models.RunRe
 	}
 
 	if response.StatusCode >= 400 {
-		input.SetError(fmt.Errorf(body))
+		input.SetError(errors.New(body))
 		return input
 	}
 
@@ -85,7 +85,7 @@ func (hpa *HTTPPost) Perform(input models.RunResult, _ *store.Store) models.RunR
 	}
 
 	if response.StatusCode >= 400 {
-		input.SetError(fmt.Errorf(body))
+		input.SetError(errors.New(body))
 		return input
 	}
 

--- a/adapters/http.go
+++ b/adapters/http.go
@@ -43,7 +43,7 @@ func (hga *HTTPGet) Perform(input models.RunResult, _ *store.Store) models.RunRe
 		return input
 	}
 
-	input.WithResult(body)
+	input.ApplyResult(body)
 	return input
 }
 
@@ -89,7 +89,7 @@ func (hpa *HTTPPost) Perform(input models.RunResult, _ *store.Store) models.RunR
 		return input
 	}
 
-	input.WithResult(body)
+	input.ApplyResult(body)
 	return input
 }
 

--- a/adapters/json_parse.go
+++ b/adapters/json_parse.go
@@ -33,13 +33,13 @@ type JSONParse struct {
 func (jpa *JSONParse) Perform(input models.RunResult, _ *store.Store) models.RunResult {
 	val, err := input.ResultString()
 	if err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return input
 	}
 
 	js, err := simplejson.NewJson([]byte(val))
 	if err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return input
 	}
 
@@ -71,7 +71,7 @@ func dig(js *simplejson.Json, path []string) (*simplejson.Json, error) {
 // i.e. Path = ["errorIfNonExistent", "nullIfNonExistent"]
 func moldErrorOutput(js *simplejson.Json, path []string, input models.RunResult) models.RunResult {
 	if _, err := getEarlyPath(js, path); err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		return input
 	}
 	input.WithNull()

--- a/adapters/json_parse.go
+++ b/adapters/json_parse.go
@@ -74,7 +74,7 @@ func moldErrorOutput(js *simplejson.Json, path []string, input models.RunResult)
 		input.SetError(err)
 		return input
 	}
-	input.WithNull()
+	input.ClearResult()
 	return input
 }
 

--- a/adapters/json_parse.go
+++ b/adapters/json_parse.go
@@ -33,12 +33,14 @@ type JSONParse struct {
 func (jpa *JSONParse) Perform(input models.RunResult, _ *store.Store) models.RunResult {
 	val, err := input.ResultString()
 	if err != nil {
-		return input.WithError(err)
+		input.WithError(err)
+		return input
 	}
 
 	js, err := simplejson.NewJson([]byte(val))
 	if err != nil {
-		return input.WithError(err)
+		input.WithError(err)
+		return input
 	}
 
 	last, err := dig(js, jpa.Path)
@@ -46,7 +48,8 @@ func (jpa *JSONParse) Perform(input models.RunResult, _ *store.Store) models.Run
 		return moldErrorOutput(js, jpa.Path, input)
 	}
 
-	return input.WithResult(last.Interface())
+	input.WithResult(last.Interface())
+	return input
 }
 
 func dig(js *simplejson.Json, path []string) (*simplejson.Json, error) {
@@ -68,9 +71,11 @@ func dig(js *simplejson.Json, path []string) (*simplejson.Json, error) {
 // i.e. Path = ["errorIfNonExistent", "nullIfNonExistent"]
 func moldErrorOutput(js *simplejson.Json, path []string, input models.RunResult) models.RunResult {
 	if _, err := getEarlyPath(js, path); err != nil {
-		return input.WithError(err)
+		input.WithError(err)
+		return input
 	}
-	return input.WithNull()
+	input.WithNull()
+	return input
 }
 
 func getEarlyPath(js *simplejson.Json, path []string) (*simplejson.Json, error) {

--- a/adapters/json_parse.go
+++ b/adapters/json_parse.go
@@ -48,7 +48,7 @@ func (jpa *JSONParse) Perform(input models.RunResult, _ *store.Store) models.Run
 		return moldErrorOutput(js, jpa.Path, input)
 	}
 
-	input.WithResult(last.Interface())
+	input.ApplyResult(last.Interface())
 	return input
 }
 

--- a/adapters/multiply.go
+++ b/adapters/multiply.go
@@ -47,6 +47,6 @@ func (ma *Multiply) Perform(input models.RunResult, _ *store.Store) models.RunRe
 	}
 
 	i.Mul(i, big.NewFloat(float64(ma.Times)))
-	input.WithResult(i.String())
+	input.ApplyResult(i.String())
 	return input
 }

--- a/adapters/multiply.go
+++ b/adapters/multiply.go
@@ -42,9 +42,11 @@ func (ma *Multiply) Perform(input models.RunResult, _ *store.Store) models.RunRe
 	val := input.Result()
 	i, ok := (&big.Float{}).SetString(val.String())
 	if !ok {
-		return input.WithError(fmt.Errorf("cannot parse into big.Float: %v", val.String()))
+		input.WithError(fmt.Errorf("cannot parse into big.Float: %v", val.String()))
+		return input
 	}
 
-	res := i.Mul(i, big.NewFloat(float64(ma.Times)))
-	return input.WithResult(res.String())
+	i.Mul(i, big.NewFloat(float64(ma.Times)))
+	input.WithResult(i.String())
+	return input
 }

--- a/adapters/multiply.go
+++ b/adapters/multiply.go
@@ -42,7 +42,7 @@ func (ma *Multiply) Perform(input models.RunResult, _ *store.Store) models.RunRe
 	val := input.Result()
 	i, ok := (&big.Float{}).SetString(val.String())
 	if !ok {
-		input.WithError(fmt.Errorf("cannot parse into big.Float: %v", val.String()))
+		input.SetError(fmt.Errorf("cannot parse into big.Float: %v", val.String()))
 		return input
 	}
 

--- a/adapters/no_op.go
+++ b/adapters/no_op.go
@@ -20,5 +20,6 @@ type NoOpPend struct{}
 // Perform on this adapter type returns an empty RunResult with an
 // added field for the status to indicate the task is Pending.
 func (noa *NoOpPend) Perform(input models.RunResult, _ *store.Store) models.RunResult {
-	return input.MarkPendingConfirmations()
+	input.MarkPendingConfirmations()
+	return input
 }

--- a/adapters/wasm.go
+++ b/adapters/wasm.go
@@ -16,6 +16,6 @@ type Wasm struct {
 
 // Perform ships the wasm representation to the SGX enclave where it is evaluated.
 func (wasm *Wasm) Perform(input models.RunResult, _ *store.Store) models.RunResult {
-	input.WithError(fmt.Errorf("Wasm is not supported without SGX"))
+	input.SetError(fmt.Errorf("Wasm is not supported without SGX"))
 	return input
 }

--- a/adapters/wasm.go
+++ b/adapters/wasm.go
@@ -16,5 +16,6 @@ type Wasm struct {
 
 // Perform ships the wasm representation to the SGX enclave where it is evaluated.
 func (wasm *Wasm) Perform(input models.RunResult, _ *store.Store) models.RunResult {
-	return input.WithError(fmt.Errorf("Wasm is not supported without SGX"))
+	input.WithError(fmt.Errorf("Wasm is not supported without SGX"))
+	return input
 }

--- a/services/application.go
+++ b/services/application.go
@@ -221,7 +221,7 @@ func (c *headTrackableCallback) OnNewHead(*models.BlockHeader) {}
 
 type pendingConnectionResumer struct {
 	store   *store.Store
-	resumer func(*models.JobRun, *store.Store) (*models.JobRun, error)
+	resumer func(*models.JobRun, *store.Store) error
 }
 
 func newPendingConnectionResumer(store *store.Store) *pendingConnectionResumer {
@@ -236,7 +236,7 @@ func (p *pendingConnectionResumer) Connect(head *models.IndexableBlockNumber) er
 
 	var merr error
 	for _, jr := range pendingRuns {
-		_, err := p.resumer(&jr, p.store)
+		err := p.resumer(&jr, p.store)
 		if err != nil {
 			merr = multierr.Append(merr, err)
 		}

--- a/services/application_test.go
+++ b/services/application_test.go
@@ -66,9 +66,9 @@ func TestPendingConnectionResumer(t *testing.T) {
 	defer cleanup()
 
 	resumedRuns := []string{}
-	resumer := func(run *models.JobRun, store *strpkg.Store) (*models.JobRun, error) {
+	resumer := func(run *models.JobRun, store *strpkg.Store) error {
 		resumedRuns = append(resumedRuns, run.ID)
-		return nil, nil
+		return nil
 	}
 	pcr := services.ExportedNewPendingConnectionResumer(store, resumer)
 

--- a/services/export_test.go
+++ b/services/export_test.go
@@ -9,7 +9,7 @@ func ExportedExecuteRunAtBlock(
 	run *models.JobRun,
 	store *store.Store,
 	input models.RunResult,
-) (*models.JobRun, error) {
+) error {
 	return executeRun(run, store)
 }
 
@@ -27,7 +27,7 @@ func ExportedWorkerCount(jr JobRunner) int {
 
 func ExportedNewPendingConnectionResumer(
 	store *store.Store,
-	resumer func(*models.JobRun, *store.Store) (*models.JobRun, error),
+	resumer func(*models.JobRun, *store.Store) error,
 ) store.HeadTrackable {
 	return &pendingConnectionResumer{
 		store:   store,

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -244,7 +244,7 @@ func executeRun(run *models.JobRun, store *store.Store) (*models.JobRun, error) 
 	result := executeTask(run, currentTaskRun, store)
 
 	currentTaskRun.ApplyResult(result)
-	*run = run.ApplyResult(result)
+	run.ApplyResult(result)
 
 	if currentTaskRun.Status.PendingSleep() {
 		logger.Debugw("Task is sleeping", []interface{}{"run", run.ID}...)

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -183,26 +183,17 @@ func prepareTaskInput(run *models.JobRun, currentTaskRun *models.TaskRun) (model
 	input := currentTaskRun.Result
 	previousTaskRun := run.PreviousTaskRun()
 
-	var err error
 	if previousTaskRun != nil {
-		if input.Data, err = previousTaskRun.Result.Data.Merge(input.Data); err != nil {
-			return models.RunResult{}, err
-		}
+		input.Data = previousTaskRun.Result.Data.Merge(input.Data)
 	}
 
-	if input.Data, err = run.Overrides.Data.Merge(input.Data); err != nil {
-		return models.RunResult{}, err
-	}
+	input.Data = run.Overrides.Data.Merge(input.Data)
 	return input, nil
 }
 
 func executeTask(run *models.JobRun, currentTaskRun *models.TaskRun, store *store.Store) models.RunResult {
 	taskCopy := currentTaskRun.TaskSpec // deliberately copied to keep mutations local
-	var err error
-	if taskCopy.Params, err = taskCopy.Params.Merge(run.Overrides.Data); err != nil {
-		currentTaskRun.Result.SetError(err)
-		return currentTaskRun.Result
-	}
+	taskCopy.Params = taskCopy.Params.Merge(run.Overrides.Data)
 
 	adapter, err := adapters.For(taskCopy, store)
 	if err != nil {

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -200,19 +200,22 @@ func executeTask(run *models.JobRun, currentTaskRun *models.TaskRun, store *stor
 	taskCopy := currentTaskRun.TaskSpec // deliberately copied to keep mutations local
 	var err error
 	if taskCopy.Params, err = taskCopy.Params.Merge(run.Overrides.Data); err != nil {
-		return currentTaskRun.Result.WithError(err)
+		currentTaskRun.Result.WithError(err)
+		return currentTaskRun.Result
 	}
 
 	adapter, err := adapters.For(taskCopy, store)
 	if err != nil {
-		return currentTaskRun.Result.WithError(err)
+		currentTaskRun.Result.WithError(err)
+		return currentTaskRun.Result
 	}
 
 	logger.Infow(fmt.Sprintf("Processing task %s", taskCopy.Type), []interface{}{"task", currentTaskRun.ID}...)
 
 	input, err := prepareTaskInput(run, currentTaskRun)
 	if err != nil {
-		return currentTaskRun.Result.WithError(err)
+		currentTaskRun.Result.WithError(err)
+		return currentTaskRun.Result
 	}
 
 	result := adapter.Perform(input, store)

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -200,13 +200,13 @@ func executeTask(run *models.JobRun, currentTaskRun *models.TaskRun, store *stor
 	taskCopy := currentTaskRun.TaskSpec // deliberately copied to keep mutations local
 	var err error
 	if taskCopy.Params, err = taskCopy.Params.Merge(run.Overrides.Data); err != nil {
-		currentTaskRun.Result.WithError(err)
+		currentTaskRun.Result.SetError(err)
 		return currentTaskRun.Result
 	}
 
 	adapter, err := adapters.For(taskCopy, store)
 	if err != nil {
-		currentTaskRun.Result.WithError(err)
+		currentTaskRun.Result.SetError(err)
 		return currentTaskRun.Result
 	}
 
@@ -214,7 +214,7 @@ func executeTask(run *models.JobRun, currentTaskRun *models.TaskRun, store *stor
 
 	input, err := prepareTaskInput(run, currentTaskRun)
 	if err != nil {
-		currentTaskRun.Result.WithError(err)
+		currentTaskRun.Result.SetError(err)
 		return currentTaskRun.Result
 	}
 

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -231,7 +231,6 @@ func executeTask(run *models.JobRun, currentTaskRun *models.TaskRun, store *stor
 
 func executeRun(run *models.JobRun, store *store.Store) error {
 	logger.Infow("Processing run", run.ForLogger()...)
-	logger.Debug(fmt.Sprintf("TaskRuns %s", run.TaskRuns))
 
 	if !run.Status.Runnable() {
 		return fmt.Errorf("Run triggered in non runnable state %s", run.Status)
@@ -244,13 +243,8 @@ func executeRun(run *models.JobRun, store *store.Store) error {
 
 	result := executeTask(run, currentTaskRun, store)
 
-	logger.Debug(fmt.Sprintf("Result %v", result))
 	currentTaskRun.ApplyResult(result)
 	run.ApplyResult(result)
-
-	logger.Debug(fmt.Sprintf("TaskRuns %s", run.TaskRuns))
-	logger.Debug(fmt.Sprintf("CurrentTaskRun %s", currentTaskRun))
-	logger.Debug(fmt.Sprintf("FutureTaskRun %s", run.NextTaskRun()))
 
 	if currentTaskRun.Status.PendingSleep() {
 		logger.Debugw("Task is sleeping", []interface{}{"run", run.ID}...)

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -95,7 +95,7 @@ func (js *jobSubscriber) OnNewHead(head *models.BlockHeader) {
 		"pending_run_count", len(pendingRuns),
 	)
 	for _, jr := range pendingRuns {
-		_, err := ResumeConfirmingTask(&jr, js.store, ibn)
+		err := ResumeConfirmingTask(&jr, js.store, ibn)
 		if err != nil {
 			logger.Error("JobSubscriber.OnNewHead: ", err.Error())
 		}

--- a/services/job_subscriber_test.go
+++ b/services/job_subscriber_test.go
@@ -182,7 +182,7 @@ func TestJobSubscriber_OnNewHead_OnlyResumePendingConfirmations(t *testing.T) {
 			require.NoError(t, store.CreateJob(&job))
 			initr := job.Initiators[0]
 			run := job.NewRun(initr)
-			run = run.ApplyResult(models.RunResult{Status: test.status})
+			run.ApplyResult(models.RunResult{Status: test.status})
 			assert.Nil(t, store.CreateJobRun(&run))
 
 			js.OnNewHead(block)

--- a/services/runs.go
+++ b/services/runs.go
@@ -271,11 +271,12 @@ func performTaskSleep(
 	runCopy.TaskRuns = make([]models.TaskRun, len(run.TaskRuns))
 	copy(runCopy.TaskRuns, run.TaskRuns)
 
-	go func(run models.JobRun, task models.TaskRun) {
+	go func(run models.JobRun) {
 		logger.Debugw("Task sleeping...", run.ForLogger()...)
 
 		<-store.Clock.After(duration)
 
+		task := run.NextTaskRun()
 		task.Status = models.RunStatusCompleted
 		run.Status = models.RunStatusInProgress
 
@@ -284,7 +285,7 @@ func performTaskSleep(
 		if err := updateAndTrigger(&run, store); err != nil {
 			logger.Errorw("Error resuming sleeping job:", "error", err)
 		}
-	}(runCopy, *task)
+	}(runCopy)
 
 	return nil
 }

--- a/services/runs.go
+++ b/services/runs.go
@@ -201,11 +201,7 @@ func ResumePendingTask(
 		return fmt.Errorf("Attempting to resume pending run with no remaining tasks %s", run.ID)
 	}
 
-	if err := run.Overrides.Merge(input); err != nil {
-		currentTaskRun.SetError(err)
-		run.SetError(err)
-		return store.SaveJobRun(run)
-	}
+	run.Overrides.Merge(input)
 
 	currentTaskRun.ApplyResult(input)
 	if currentTaskRun.Status.Finished() && run.TasksRemain() {

--- a/services/runs.go
+++ b/services/runs.go
@@ -61,7 +61,7 @@ func NewRun(
 	run := job.NewRun(initiator)
 
 	run.Overrides = input
-	run = run.ApplyResult(input)
+	run.ApplyResult(input)
 	run.CreationHeight = models.NewBig(currentHeight.ToInt())
 	run.ObservedHeight = models.NewBig(currentHeight.ToInt())
 
@@ -211,7 +211,7 @@ func ResumePendingTask(
 	if currentTaskRun.Status.Finished() && run.TasksRemain() {
 		run.Status = models.RunStatusInProgress
 	} else {
-		*run = run.ApplyResult(input)
+		run.ApplyResult(input)
 	}
 
 	return run, updateAndTrigger(run, store)

--- a/services/runs.go
+++ b/services/runs.go
@@ -243,6 +243,7 @@ func QueueSleepingTask(
 
 	if err != nil {
 		currentTaskRun.SetError(err)
+		run.TaskRuns[currentTaskRunIndex] = currentTaskRun
 		run.SetError(err)
 		return run, store.SaveJobRun(run)
 	}

--- a/services/runs_test.go
+++ b/services/runs_test.go
@@ -180,12 +180,12 @@ func TestResumePendingTask(t *testing.T) {
 
 	// reject a run with an invalid state
 	run := &models.JobRun{}
-	run, err := services.ResumePendingTask(run, store, models.RunResult{})
+	err := services.ResumePendingTask(run, store, models.RunResult{})
 	assert.Error(t, err)
 
 	// reject a run with no tasks
 	run = &models.JobRun{Status: models.RunStatusPendingBridge}
-	run, err = services.ResumePendingTask(run, store, models.RunResult{})
+	err = services.ResumePendingTask(run, store, models.RunResult{})
 	assert.Error(t, err)
 
 	// input with error errors run
@@ -193,7 +193,7 @@ func TestResumePendingTask(t *testing.T) {
 		Status:   models.RunStatusPendingBridge,
 		TaskRuns: []models.TaskRun{models.TaskRun{}},
 	}
-	run, err = services.ResumePendingTask(run, store, models.RunResult{Status: models.RunStatusErrored})
+	err = services.ResumePendingTask(run, store, models.RunResult{Status: models.RunStatusErrored})
 	assert.Error(t, err)
 
 	// completed input with remaining tasks should put task into pending
@@ -202,7 +202,7 @@ func TestResumePendingTask(t *testing.T) {
 		TaskRuns: []models.TaskRun{models.TaskRun{}, models.TaskRun{}},
 	}
 	input := models.JSON{Result: gjson.Parse(`{"address":"0xdfcfc2b9200dbb10952c2b7cce60fc7260e03c6f"}`)}
-	run, err = services.ResumePendingTask(run, store, models.RunResult{Data: input, Status: models.RunStatusCompleted})
+	err = services.ResumePendingTask(run, store, models.RunResult{Data: input, Status: models.RunStatusCompleted})
 	assert.Error(t, err)
 	assert.Equal(t, string(models.RunStatusInProgress), string(run.Status))
 	assert.Len(t, run.TaskRuns, 2)
@@ -214,7 +214,7 @@ func TestResumePendingTask(t *testing.T) {
 		Status:   models.RunStatusPendingBridge,
 		TaskRuns: []models.TaskRun{models.TaskRun{}},
 	}
-	run, err = services.ResumePendingTask(run, store, models.RunResult{Data: input, Status: models.RunStatusCompleted})
+	err = services.ResumePendingTask(run, store, models.RunResult{Data: input, Status: models.RunStatusCompleted})
 	assert.Error(t, err)
 	assert.Equal(t, string(models.RunStatusCompleted), string(run.Status))
 	assert.Len(t, run.TaskRuns, 1)
@@ -228,12 +228,12 @@ func TestResumeConfirmingTask(t *testing.T) {
 
 	// reject a run with an invalid state
 	run := &models.JobRun{}
-	run, err := services.ResumeConfirmingTask(run, store, nil)
+	err := services.ResumeConfirmingTask(run, store, nil)
 	assert.Error(t, err)
 
 	// reject a run with no tasks
 	run = &models.JobRun{Status: models.RunStatusPendingConfirmations}
-	run, err = services.ResumeConfirmingTask(run, store, nil)
+	err = services.ResumeConfirmingTask(run, store, nil)
 	assert.Error(t, err)
 
 	jobSpec := models.JobSpec{ID: utils.NewBytes32ID()}
@@ -257,7 +257,7 @@ func TestResumeConfirmingTask(t *testing.T) {
 	}
 	hexb := hexutil.Big(*creationHeight.ToInt())
 	require.NoError(t, store.CreateJobRun(run))
-	run, err = services.ResumeConfirmingTask(run, store, &hexb)
+	err = services.ResumeConfirmingTask(run, store, &hexb)
 	assert.NoError(t, err)
 	assert.Equal(t, string(models.RunStatusPendingConfirmations), string(run.Status))
 
@@ -278,7 +278,7 @@ func TestResumeConfirmingTask(t *testing.T) {
 	}
 	observedHeight := cltest.BigHexInt(1)
 	require.NoError(t, store.CreateJobRun(run))
-	run, err = services.ResumeConfirmingTask(run, store, &observedHeight)
+	err = services.ResumeConfirmingTask(run, store, &observedHeight)
 	assert.NoError(t, err)
 	assert.Equal(t, string(models.RunStatusInProgress), string(run.Status))
 }
@@ -289,12 +289,12 @@ func TestResumeConnectingTask(t *testing.T) {
 
 	// reject a run with an invalid state
 	run := &models.JobRun{}
-	run, err := services.ResumeConnectingTask(run, store)
+	err := services.ResumeConnectingTask(run, store)
 	assert.Error(t, err)
 
 	// reject a run with no tasks
 	run = &models.JobRun{Status: models.RunStatusPendingConnection}
-	run, err = services.ResumeConnectingTask(run, store)
+	err = services.ResumeConnectingTask(run, store)
 	assert.Error(t, err)
 
 	jobSpec := models.JobSpec{ID: utils.NewBytes32ID()}
@@ -312,7 +312,7 @@ func TestResumeConnectingTask(t *testing.T) {
 		}},
 	}
 	require.NoError(t, store.CreateJobRun(run))
-	run, err = services.ResumeConnectingTask(run, store)
+	err = services.ResumeConnectingTask(run, store)
 	assert.NoError(t, err)
 	assert.Equal(t, string(models.RunStatusInProgress), string(run.Status))
 }

--- a/services/runs_test.go
+++ b/services/runs_test.go
@@ -330,12 +330,12 @@ func TestQueueSleepingTask(t *testing.T) {
 
 	// reject a run with an invalid state
 	run := &models.JobRun{}
-	run, err := services.QueueSleepingTask(run, store)
+	err := services.QueueSleepingTask(run, store)
 	assert.Error(t, err)
 
 	// reject a run with no tasks
 	run = &models.JobRun{Status: models.RunStatusPendingSleep}
-	run, err = services.QueueSleepingTask(run, store)
+	err = services.QueueSleepingTask(run, store)
 	assert.Error(t, err)
 
 	jobSpec := models.JobSpec{ID: utils.NewBytes32ID()}
@@ -352,7 +352,7 @@ func TestQueueSleepingTask(t *testing.T) {
 		}},
 	}
 	require.NoError(t, store.CreateJobRun(run))
-	run, err = services.QueueSleepingTask(run, store)
+	err = services.QueueSleepingTask(run, store)
 	assert.Error(t, err)
 
 	// error decoding params into adapter
@@ -374,7 +374,7 @@ func TestQueueSleepingTask(t *testing.T) {
 		},
 	}
 	require.NoError(t, store.CreateJobRun(run))
-	run, err = services.QueueSleepingTask(run, store)
+	err = services.QueueSleepingTask(run, store)
 	assert.NoError(t, err)
 	assert.Equal(t, string(models.RunStatusErrored), string(run.TaskRuns[0].Status))
 	assert.Equal(t, string(models.RunStatusErrored), string(run.Status))
@@ -391,7 +391,7 @@ func TestQueueSleepingTask(t *testing.T) {
 		}},
 	}
 	require.NoError(t, store.CreateJobRun(run))
-	run, err = services.QueueSleepingTask(run, store)
+	err = services.QueueSleepingTask(run, store)
 	assert.NoError(t, err)
 	assert.Equal(t, string(models.RunStatusCompleted), string(run.TaskRuns[0].Status))
 	assert.Equal(t, string(models.RunStatusInProgress), string(run.Status))
@@ -423,7 +423,7 @@ func TestQueueSleepingTask(t *testing.T) {
 		},
 	}
 	require.NoError(t, store.CreateJobRun(run))
-	run, err = services.QueueSleepingTask(run, store)
+	err = services.QueueSleepingTask(run, store)
 	assert.NoError(t, err)
 	assert.Equal(t, string(models.RunStatusPendingSleep), string(run.TaskRuns[0].Status))
 	assert.Equal(t, string(models.RunStatusPendingSleep), string(run.Status))

--- a/services/subscription.go
+++ b/services/subscription.go
@@ -156,7 +156,7 @@ func runJob(store *strpkg.Store, le models.LogRequest, data models.JSON) {
 		Amount: payment,
 	}
 	if err := le.ValidateRequester(); err != nil {
-		input.WithError(err)
+		input.SetError(err)
 		logger.Errorw(err.Error(), le.ForLogger()...)
 	}
 

--- a/services/subscription.go
+++ b/services/subscription.go
@@ -156,7 +156,7 @@ func runJob(store *strpkg.Store, le models.LogRequest, data models.JSON) {
 		Amount: payment,
 	}
 	if err := le.ValidateRequester(); err != nil {
-		input = input.WithError(err)
+		input.WithError(err)
 		logger.Errorw(err.Error(), le.ForLogger()...)
 	}
 

--- a/store/models/address.go
+++ b/store/models/address.go
@@ -49,7 +49,7 @@ func (a EIP55Address) String() string {
 
 // Format implements fmt.Formatter
 func (a EIP55Address) Format(s fmt.State, c rune) {
-	fmt.Fprintf(s, a.String())
+	fmt.Fprint(s, a.String())
 }
 
 // UnmarshalText parses a hash from plain text

--- a/store/models/common.go
+++ b/store/models/common.go
@@ -182,7 +182,7 @@ func (j JSON) MarshalJSON() ([]byte, error) {
 // Merge combines the given JSON with the existing JSON.
 func (j JSON) Merge(j2 JSON) (JSON, error) {
 	body := j.Map()
-	if body == nil || j.Type != gjson.JSON {
+	if body == nil || (j.Type != gjson.JSON && j.Type != gjson.Null) {
 		return JSON{}, ErrorCannotMergeNonObject
 	}
 

--- a/store/models/common.go
+++ b/store/models/common.go
@@ -173,7 +173,7 @@ func (j JSON) MarshalJSON() ([]byte, error) {
 }
 
 // Merge combines the given JSON with the existing JSON.
-func (j JSON) Merge(j2 JSON) (JSON, error) {
+func (j JSON) Merge(j2 JSON) JSON {
 	body := j.Map()
 	for key, value := range j2.Map() {
 		body[key] = value
@@ -184,13 +184,10 @@ func (j JSON) Merge(j2 JSON) (JSON, error) {
 		cleaned[k] = v.Value()
 	}
 
-	b, err := json.Marshal(cleaned)
-	if err != nil {
-		return JSON{}, err
-	}
-
+	b, _ := json.Marshal(cleaned)
 	var rval JSON
-	return rval, gjson.Unmarshal(b, &rval)
+	gjson.Unmarshal(b, &rval)
+	return rval
 }
 
 // Empty returns true if the JSON does not exist.
@@ -214,7 +211,8 @@ func (j JSON) Add(key string, val interface{}) (JSON, error) {
 	if err = json.Unmarshal([]byte(str), &j2); err != nil {
 		return j2, err
 	}
-	return j.Merge(j2)
+	j = j.Merge(j2)
+	return j, nil
 }
 
 // Delete returns a new instance of JSON with the specified key removed.

--- a/store/models/common_test.go
+++ b/store/models/common_test.go
@@ -19,21 +19,20 @@ func TestJSON_Merge(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name        string
-		input       string
-		want        string
-		wantErrored bool
+		name  string
+		input string
+		want  string
 	}{
 		{"new field", `{"extra":"fields"}`,
-			`{"value":"OLD","other":1,"extra":"fields"}`, false},
+			`{"value":"OLD","other":1,"extra":"fields"}`},
 		{"overwritting fields", `{"value":["new","new"],"extra":2}`,
-			`{"value":["new","new"],"other":1,"extra":2}`, false},
+			`{"value":["new","new"],"other":1,"extra":2}`},
 		{"nested JSON", `{"extra":{"fields": ["more", 1]}}`,
-			`{"value":"OLD","other":1,"extra":{"fields":["more",1]}}`, false},
+			`{"value":"OLD","other":1,"extra":{"fields":["more",1]}}`},
 		{"empty JSON", `{}`,
-			`{"value":"OLD","other":1}`, false},
+			`{"value":"OLD","other":1}`},
 		{"null values", `{"value":null}`,
-			`{"value":null,"other":1}`, false},
+			`{"value":null,"other":1}`},
 	}
 
 	for _, test := range tests {
@@ -42,8 +41,7 @@ func TestJSON_Merge(t *testing.T) {
 			j1 := cltest.JSONFromString(t, orig)
 			j2 := cltest.JSONFromString(t, test.input)
 
-			merged, err := j1.Merge(j2)
-			assert.Equal(t, test.wantErrored, (err != nil))
+			merged := j1.Merge(j2)
 			assert.JSONEq(t, test.want, merged.String())
 			assert.JSONEq(t, orig, j1.String())
 		})

--- a/store/models/common_test.go
+++ b/store/models/common_test.go
@@ -62,14 +62,14 @@ func TestJSON_Merge(t *testing.T) {
 			false,
 		},
 		{
-			"string value",
+			"string",
 			`"string"`,
 			`{}`,
 			"",
 			true,
 		},
 		{
-			"array value",
+			"array",
 			`["a1"]`,
 			`{"value": null}`,
 			"",
@@ -92,6 +92,12 @@ func TestJSON_Merge(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestJSON_MergeNull(t *testing.T) {
+	merged, err := models.JSON{}.Merge(models.JSON{})
+	require.NoError(t, err)
+	assert.Equal(t, `{}`, merged.String())
 }
 
 func TestJSON_UnmarshalJSON(t *testing.T) {

--- a/store/models/common_test.go
+++ b/store/models/common_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/ugorji/go/codec"
 )
 
@@ -19,31 +20,76 @@ func TestJSON_Merge(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		input string
-		want  string
+		name      string
+		original  string
+		input     string
+		want      string
+		wantError bool
 	}{
-		{"new field", `{"extra":"fields"}`,
-			`{"value":"OLD","other":1,"extra":"fields"}`},
-		{"overwritting fields", `{"value":["new","new"],"extra":2}`,
-			`{"value":["new","new"],"other":1,"extra":2}`},
-		{"nested JSON", `{"extra":{"fields": ["more", 1]}}`,
-			`{"value":"OLD","other":1,"extra":{"fields":["more",1]}}`},
-		{"empty JSON", `{}`,
-			`{"value":"OLD","other":1}`},
-		{"null values", `{"value":null}`,
-			`{"value":null,"other":1}`},
+		{
+			"new field",
+			`{"value":"OLD","other":1}`,
+			`{"extra":"fields"}`,
+			`{"value":"OLD","other":1,"extra":"fields"}`,
+			false,
+		},
+		{
+			"overwritting fields",
+			`{"value":"OLD","other":1}`,
+			`{"value":["new","new"],"extra":2}`,
+			`{"value":["new","new"],"other":1,"extra":2}`,
+			false,
+		},
+		{
+			"nested JSON",
+			`{"value":"OLD","other":1}`,
+			`{"extra":{"fields": ["more", 1]}}`,
+			`{"value":"OLD","other":1,"extra":{"fields":["more",1]}}`,
+			false,
+		},
+		{
+			"empty JSON",
+			`{"value":"OLD","other":1}`,
+			`{}`,
+			`{"value":"OLD","other":1}`,
+			false,
+		},
+		{
+			"null values",
+			`{"value":"OLD","other":1}`,
+			`{"value":null}`,
+			`{"value":null,"other":1}`,
+			false,
+		},
+		{
+			"string value",
+			`"string"`,
+			`{}`,
+			"",
+			true,
+		},
+		{
+			"array value",
+			`["a1"]`,
+			`{"value": null}`,
+			"",
+			true,
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			orig := `{"value":"OLD","other":1}`
-			j1 := cltest.JSONFromString(t, orig)
+			j1 := cltest.JSONFromString(t, test.original)
 			j2 := cltest.JSONFromString(t, test.input)
 
-			merged := j1.Merge(j2)
-			assert.JSONEq(t, test.want, merged.String())
-			assert.JSONEq(t, orig, j1.String())
+			merged, err := j1.Merge(j2)
+			if test.wantError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				assert.JSONEq(t, test.want, merged.String())
+				assert.JSONEq(t, test.original, j1.String())
+			}
 		})
 	}
 }

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -200,8 +200,7 @@ type RunResult struct {
 	Amount          *assets.Link `json:"amount,omitempty" gorm:"type:varchar(255)"`
 }
 
-// ApplyResult returns a copy of the RunResult, overriding the "result" field of
-// Data and setting the status to completed.
+// ApplyResult saves a value to a RunResult and marks it as completed
 func (rr *RunResult) ApplyResult(val interface{}) {
 	rr.Status = RunStatusCompleted
 	rr.Add("result", val)
@@ -217,8 +216,7 @@ func (rr *RunResult) Add(key string, result interface{}) {
 	rr.Data = data
 }
 
-// ClearResult returns a copy of the RunResult, overriding the "result" field of
-// Data to null.
+// ClearResult sets the "result" field to null
 func (rr *RunResult) ClearResult() {
 	data, err := rr.Data.Add("result", nil)
 	if err != nil {
@@ -228,24 +226,23 @@ func (rr *RunResult) ClearResult() {
 	rr.Data = data
 }
 
-// SetError returns a copy of the RunResult, setting the error field
-// and setting the status to in progress.
+// SetError marks the result as errored and saves the specified error message
 func (rr *RunResult) SetError(err error) {
 	rr.ErrorMessage = null.StringFrom(err.Error())
 	rr.Status = RunStatusErrored
 }
 
-// MarkPendingBridge returns a copy of RunResult but with status set to pending_bridge.
+// MarkPendingBridge sets the status to pending_bridge
 func (rr *RunResult) MarkPendingBridge() {
 	rr.Status = RunStatusPendingBridge
 }
 
-// MarkPendingConfirmations returns a copy of RunResult but with status set to pending_confirmations.
+// MarkPendingConfirmations sets the status to pending_confirmations.
 func (rr *RunResult) MarkPendingConfirmations() {
 	rr.Status = RunStatusPendingConfirmations
 }
 
-// MarkPendingConnection returns a copy of RunResult but with status set to pending_connection.
+// MarkPendingConnection sets the status to pending_connection.
 func (rr *RunResult) MarkPendingConnection() {
 	rr.Status = RunStatusPendingConnection
 }

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -284,40 +284,13 @@ func (rr *RunResult) GetError() error {
 	return nil
 }
 
-// Merge returns a copy which is the result of joining the input RunResult
-// with the instance it is called on, preferring the RunResult results passed in,
-// but using the existing results if the input RunResult results are of their
-// respective zero value.
-//
-// Returns an error if called on a RunResult that already has an error.
-func (rr *RunResult) Merge(in RunResult) error {
-	if rr.HasError() {
-		return fmt.Errorf("Cannot merge onto a RunResult with error: %v", rr.Error())
-	}
-
-	var err error
-	rr.Data, err = rr.Data.Merge(in.Data)
-	if err != nil {
-		return fmt.Errorf("TaskRun#Merge merging JSON: %v", err.Error())
-	}
-
-	rr.ID = in.ID
-	rr.CachedTaskRunID = in.CachedTaskRunID
+// Merge saves the specified result's data onto the receiving RunResult. The
+// input result's data takes preference over the receivers'.
+func (rr *RunResult) Merge(in RunResult) {
+	rr.Data, _ = rr.Data.Merge(in.Data)
 	rr.ErrorMessage = in.ErrorMessage
 	rr.Amount = in.Amount
-
-	if len(in.CachedJobRunID) != 0 {
-		rr.CachedJobRunID = in.CachedJobRunID
-	}
-	if in.Status.Errored() || rr.Status.Errored() {
-		rr.Status = RunStatusErrored
-	} else if in.Status.PendingBridge() || rr.Status.PendingBridge() {
-		rr.MarkPendingBridge()
-	} else {
-		rr.Status = in.Status
-	}
-
-	return nil
+	rr.Status = in.Status
 }
 
 // BridgeRunResult handles the parsing of RunResults from external adapters.

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -104,6 +104,13 @@ func (jr JobRun) TasksRemain() bool {
 	return runnable
 }
 
+// SetError sets this job run to failed and saves the error message
+func (jr *JobRun) SetError(err error) {
+	jr.Result.ErrorMessage = null.StringFrom(err.Error())
+	jr.Result.Status = RunStatusErrored
+	jr.Status = jr.Result.Status
+}
+
 // ApplyResult updates the JobRun's Result and Status
 func (jr JobRun) ApplyResult(result RunResult) JobRun {
 	id := jr.Result.ID
@@ -162,6 +169,13 @@ func (tr TaskRun) ForLogger(kvs ...interface{}) []interface{} {
 	}
 
 	return append(kvs, output...)
+}
+
+// SetError sets this task run to failed and saves the error message
+func (tr *TaskRun) SetError(err error) {
+	tr.Result.ErrorMessage = null.StringFrom(err.Error())
+	tr.Result.Status = RunStatusErrored
+	tr.Status = tr.Result.Status
 }
 
 // ApplyResult updates the TaskRun's Result and Status
@@ -295,11 +309,11 @@ func (rr *RunResult) Merge(in RunResult) error {
 		return fmt.Errorf("Cannot merge onto a RunResult with error: %v", rr.Error())
 	}
 
-	merged, err := rr.Data.Merge(in.Data)
+	var err error
+	rr.Data, err = rr.Data.Merge(in.Data)
 	if err != nil {
 		return fmt.Errorf("TaskRun#Merge merging JSON: %v", err.Error())
 	}
-	rr.Data = merged
 	if len(in.CachedJobRunID) == 0 {
 		rr.CachedJobRunID = in.CachedJobRunID
 	}

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -314,7 +314,13 @@ func (rr *RunResult) Merge(in RunResult) error {
 	if err != nil {
 		return fmt.Errorf("TaskRun#Merge merging JSON: %v", err.Error())
 	}
-	if len(in.CachedJobRunID) == 0 {
+
+	rr.ID = in.ID
+	rr.CachedTaskRunID = in.CachedTaskRunID
+	rr.ErrorMessage = in.ErrorMessage
+	rr.Amount = in.Amount
+
+	if len(in.CachedJobRunID) != 0 {
 		rr.CachedJobRunID = in.CachedJobRunID
 	}
 	if in.Status.Errored() || rr.Status.Errored() {

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -323,7 +323,10 @@ func (rr *RunResult) Merge(in RunResult) error {
 		rr.Status = RunStatusErrored
 	} else if in.Status.PendingBridge() || rr.Status.PendingBridge() {
 		rr.MarkPendingBridge()
+	} else {
+		rr.Status = in.Status
 	}
+
 	return nil
 }
 

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -286,11 +286,16 @@ func (rr *RunResult) GetError() error {
 
 // Merge saves the specified result's data onto the receiving RunResult. The
 // input result's data takes preference over the receivers'.
-func (rr *RunResult) Merge(in RunResult) {
-	rr.Data = rr.Data.Merge(in.Data)
+func (rr *RunResult) Merge(in RunResult) error {
+	var err error
+	rr.Data, err = rr.Data.Merge(in.Data)
+	if err != nil {
+		return err
+	}
 	rr.ErrorMessage = in.ErrorMessage
 	rr.Amount = in.Amount
 	rr.Status = in.Status
+	return nil
 }
 
 // BridgeRunResult handles the parsing of RunResults from external adapters.

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -218,7 +218,7 @@ func (rr *RunResult) WithResult(val interface{}) {
 func (rr *RunResult) Add(key string, result interface{}) {
 	data, err := rr.Data.Add(key, result)
 	if err != nil {
-		rr.WithError(err)
+		rr.SetError(err)
 		return
 	}
 	rr.Data = data
@@ -229,15 +229,15 @@ func (rr *RunResult) Add(key string, result interface{}) {
 func (rr *RunResult) WithNull() {
 	data, err := rr.Data.Add("result", nil)
 	if err != nil {
-		rr.WithError(err)
+		rr.SetError(err)
 		return
 	}
 	rr.Data = data
 }
 
-// WithError returns a copy of the RunResult, setting the error field
+// SetError returns a copy of the RunResult, setting the error field
 // and setting the status to in progress.
-func (rr *RunResult) WithError(err error) {
+func (rr *RunResult) SetError(err error) {
 	rr.ErrorMessage = null.StringFrom(err.Error())
 	rr.Status = RunStatusErrored
 }

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -151,12 +151,12 @@ type TaskRun struct {
 }
 
 // String returns info on the TaskRun as "ID,Type,Status,Result".
-func (tr TaskRun) String() string {
+func (tr *TaskRun) String() string {
 	return fmt.Sprintf("TaskRun(%v,%v,%v,%v)", tr.ID, tr.TaskSpec.Type, tr.Status, tr.Result)
 }
 
 // ForLogger formats the TaskRun info for a common formatting in the log.
-func (tr TaskRun) ForLogger(kvs ...interface{}) []interface{} {
+func (tr *TaskRun) ForLogger(kvs ...interface{}) []interface{} {
 	output := []interface{}{
 		"type", tr.TaskSpec.Type,
 		"params", tr.TaskSpec.Params,
@@ -185,17 +185,15 @@ func (tr *TaskRun) ApplyResult(result RunResult) {
 }
 
 // MarkCompleted marks the task's status as completed.
-func (tr TaskRun) MarkCompleted() TaskRun {
+func (tr *TaskRun) MarkCompleted() {
 	tr.Status = RunStatusCompleted
 	tr.Result.Status = RunStatusCompleted
-	return tr
 }
 
 // MarkPendingConfirmations marks the task's status as blocked.
-func (tr TaskRun) MarkPendingConfirmations() TaskRun {
+func (tr *TaskRun) MarkPendingConfirmations() {
 	tr.Status = RunStatusPendingConfirmations
 	tr.Result.Status = RunStatusPendingConfirmations
-	return tr
 }
 
 // RunResult keeps track of the outcome of a TaskRun or JobRun. It stores the

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -72,7 +72,6 @@ func (jr JobRun) ForLogger(kvs ...interface{}) []interface{} {
 // NextTaskRunIndex returns the position of the next unfinished task
 func (jr *JobRun) NextTaskRunIndex() (int, bool) {
 	for index, tr := range jr.TaskRuns {
-		fmt.Println("tr", tr, "tr.Status.Unstarted()", tr.Status.Unstarted())
 		if tr.Status.CanStart() {
 			return index, true
 		}

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -200,9 +200,9 @@ type RunResult struct {
 	Amount          *assets.Link `json:"amount,omitempty" gorm:"type:varchar(255)"`
 }
 
-// WithResult returns a copy of the RunResult, overriding the "result" field of
+// ApplyResult returns a copy of the RunResult, overriding the "result" field of
 // Data and setting the status to completed.
-func (rr *RunResult) WithResult(val interface{}) {
+func (rr *RunResult) ApplyResult(val interface{}) {
 	rr.Status = RunStatusCompleted
 	rr.Add("result", val)
 }

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -31,12 +31,12 @@ type JobRun struct {
 }
 
 // GetID returns the ID of this structure for jsonapi serialization.
-func (jr JobRun) GetID() string {
+func (jr *JobRun) GetID() string {
 	return jr.ID
 }
 
 // GetName returns the pluralized "type" of this structure for jsonapi serialization.
-func (jr JobRun) GetName() string {
+func (jr *JobRun) GetName() string {
 	return "runs"
 }
 
@@ -47,7 +47,7 @@ func (jr *JobRun) SetID(value string) error {
 }
 
 // ForLogger formats the JobRun for a common formatting in the log.
-func (jr JobRun) ForLogger(kvs ...interface{}) []interface{} {
+func (jr *JobRun) ForLogger(kvs ...interface{}) []interface{} {
 	output := []interface{}{
 		"job", jr.JobSpecID,
 		"run", jr.ID,
@@ -70,7 +70,7 @@ func (jr JobRun) ForLogger(kvs ...interface{}) []interface{} {
 }
 
 // NextTaskRunIndex returns the position of the next unfinished task
-func (jr JobRun) NextTaskRunIndex() (int, bool) {
+func (jr *JobRun) NextTaskRunIndex() (int, bool) {
 	for index, tr := range jr.TaskRuns {
 		if !(tr.Status.Completed() || tr.Status.Errored()) {
 			return index, true
@@ -81,7 +81,7 @@ func (jr JobRun) NextTaskRunIndex() (int, bool) {
 
 // NextTaskRun returns the next immediate TaskRun in the list
 // of unfinished TaskRuns.
-func (jr JobRun) NextTaskRun() *TaskRun {
+func (jr *JobRun) NextTaskRun() *TaskRun {
 	for _, tr := range jr.TaskRuns {
 		if !(tr.Status.Completed() || tr.Status.Errored()) {
 			return &tr
@@ -91,7 +91,7 @@ func (jr JobRun) NextTaskRun() *TaskRun {
 }
 
 // PreviousTaskRun returns the last task to be processed, if it exists
-func (jr JobRun) PreviousTaskRun() *TaskRun {
+func (jr *JobRun) PreviousTaskRun() *TaskRun {
 	index, runnable := jr.NextTaskRunIndex()
 	if runnable && index > 0 {
 		return &jr.TaskRuns[index-1]
@@ -100,7 +100,7 @@ func (jr JobRun) PreviousTaskRun() *TaskRun {
 }
 
 // TasksRemain returns true if there are unfinished tasks left for this job run
-func (jr JobRun) TasksRemain() bool {
+func (jr *JobRun) TasksRemain() bool {
 	_, runnable := jr.NextTaskRunIndex()
 	return runnable
 }
@@ -129,11 +129,10 @@ func (jr *JobRun) ApplyResult(result RunResult) {
 
 // MarkCompleted sets the JobRun's status to completed and records the
 // completed at time.
-func (jr JobRun) MarkCompleted() JobRun {
+func (jr *JobRun) MarkCompleted() {
 	jr.Status = RunStatusCompleted
 	jr.Result.Status = RunStatusCompleted
 	jr.CompletedAt = null.Time{Time: time.Now(), Valid: true}
-	return jr
 }
 
 // TaskRun stores the Task and represents the status of the

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -287,7 +287,7 @@ func (rr *RunResult) GetError() error {
 // Merge saves the specified result's data onto the receiving RunResult. The
 // input result's data takes preference over the receivers'.
 func (rr *RunResult) Merge(in RunResult) {
-	rr.Data, _ = rr.Data.Merge(in.Data)
+	rr.Data = rr.Data.Merge(in.Data)
 	rr.ErrorMessage = in.ErrorMessage
 	rr.Amount = in.Amount
 	rr.Status = in.Status

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -72,7 +72,9 @@ func (jr JobRun) ForLogger(kvs ...interface{}) []interface{} {
 // NextTaskRunIndex returns the position of the next unfinished task
 func (jr *JobRun) NextTaskRunIndex() (int, bool) {
 	for index, tr := range jr.TaskRuns {
-		if tr.Status.Runnable() {
+		fmt.Println("tr", tr, "tr.Status.Unstarted()", tr.Status.Unstarted())
+		if tr.Status.Unstarted() {
+			//if !(tr.Status.Pending() || tr.Status.Errored()) {
 			return index, true
 		}
 	}

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -113,13 +113,7 @@ func (jr *JobRun) SetError(err error) {
 
 // ApplyResult updates the JobRun's Result and Status
 func (jr *JobRun) ApplyResult(result RunResult) {
-	id := jr.Result.ID
-
 	jr.Result = result
-	jr.Result.ID = id
-	jr.Result.CachedJobRunID = jr.ID
-	jr.Result.CachedTaskRunID = ""
-
 	jr.Status = result.Status
 	if jr.Status.Completed() {
 		jr.CompletedAt = null.Time{Time: time.Now(), Valid: true}

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -224,9 +224,9 @@ func (rr *RunResult) Add(key string, result interface{}) {
 	rr.Data = data
 }
 
-// WithNull returns a copy of the RunResult, overriding the "result" field of
+// ClearResult returns a copy of the RunResult, overriding the "result" field of
 // Data to null.
-func (rr *RunResult) WithNull() {
+func (rr *RunResult) ClearResult() {
 	data, err := rr.Data.Add("result", nil)
 	if err != nil {
 		rr.SetError(err)

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -113,7 +113,7 @@ func (jr *JobRun) SetError(err error) {
 }
 
 // ApplyResult updates the JobRun's Result and Status
-func (jr JobRun) ApplyResult(result RunResult) JobRun {
+func (jr *JobRun) ApplyResult(result RunResult) {
 	id := jr.Result.ID
 
 	jr.Result = result
@@ -125,7 +125,6 @@ func (jr JobRun) ApplyResult(result RunResult) JobRun {
 	if jr.Status.Completed() {
 		jr.CompletedAt = null.Time{Time: time.Now(), Valid: true}
 	}
-	return jr
 }
 
 // MarkCompleted sets the JobRun's status to completed and records the

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -73,8 +73,7 @@ func (jr JobRun) ForLogger(kvs ...interface{}) []interface{} {
 func (jr *JobRun) NextTaskRunIndex() (int, bool) {
 	for index, tr := range jr.TaskRuns {
 		fmt.Println("tr", tr, "tr.Status.Unstarted()", tr.Status.Unstarted())
-		if tr.Status.Unstarted() {
-			//if !(tr.Status.Pending() || tr.Status.Errored()) {
+		if tr.Status.CanStart() {
 			return index, true
 		}
 	}

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -82,9 +82,10 @@ func (jr JobRun) NextTaskRunIndex() (int, bool) {
 // NextTaskRun returns the next immediate TaskRun in the list
 // of unfinished TaskRuns.
 func (jr JobRun) NextTaskRun() *TaskRun {
-	nextTaskIndex, runnable := jr.NextTaskRunIndex()
-	if runnable {
-		return &jr.TaskRuns[nextTaskIndex]
+	for _, tr := range jr.TaskRuns {
+		if !(tr.Status.Completed() || tr.Status.Errored()) {
+			return &tr
+		}
 	}
 	return nil
 }
@@ -179,10 +180,9 @@ func (tr *TaskRun) SetError(err error) {
 }
 
 // ApplyResult updates the TaskRun's Result and Status
-func (tr TaskRun) ApplyResult(result RunResult) TaskRun {
+func (tr *TaskRun) ApplyResult(result RunResult) {
 	tr.Result = result
 	tr.Status = result.Status
-	return tr
 }
 
 // MarkCompleted marks the task's status as completed.

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -161,6 +161,7 @@ func TestRunResult_Merge(t *testing.T) {
 	inProgress := models.RunStatusInProgress
 	pending := models.RunStatusPendingBridge
 	errored := models.RunStatusErrored
+	completed := models.RunStatusCompleted
 
 	nullString := cltest.NullString(nil)
 	jrID := utils.NewBytes32ID()
@@ -184,6 +185,10 @@ func TestRunResult_Merge(t *testing.T) {
 			`{"result":"old&busted","unique":"1"}`, nullString, inProgress, jrID,
 			`{"result":"newHotness","and":"!"}`, nullString, inProgress, jrID,
 			`{"result":"newHotness","unique":"1","and":"!"}`, nullString, inProgress, jrID, false},
+		{"completed result",
+			`{"result":"old"}`, nullString, inProgress, jrID,
+			`{}`, nullString, completed, jrID,
+			`{"result":"old"}`, nullString, completed, jrID, false},
 		{"original error throws",
 			`{"result":"old"}`, cltest.NullString("old problem"), errored, jrID,
 			`{}`, nullString, inProgress, jrID,

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -149,7 +149,7 @@ func TestRunResult_WithError(t *testing.T) {
 
 	assert.Equal(t, models.RunStatusUnstarted, rr.Status)
 
-	rr.WithError(errors.New("this blew up"))
+	rr.SetError(errors.New("this blew up"))
 
 	assert.Equal(t, models.RunStatusErrored, rr.Status)
 	assert.Equal(t, cltest.NullString("this blew up"), rr.ErrorMessage)

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -135,7 +135,7 @@ func TestRunResult_Add(t *testing.T) {
 			assert.NoError(t, json.Unmarshal([]byte(test.json), &data))
 			rr := models.RunResult{Data: data}
 
-			rr = rr.Add(test.key, test.value)
+			rr.Add(test.key, test.value)
 
 			assert.JSONEq(t, test.want, rr.Data.String())
 		})
@@ -149,7 +149,7 @@ func TestRunResult_WithError(t *testing.T) {
 
 	assert.Equal(t, models.RunStatusUnstarted, rr.Status)
 
-	rr = rr.WithError(errors.New("this blew up"))
+	rr.WithError(errors.New("this blew up"))
 
 	assert.Equal(t, models.RunStatusErrored, rr.Status)
 	assert.Equal(t, cltest.NullString("this blew up"), rr.ErrorMessage)
@@ -224,8 +224,13 @@ func TestRunResult_Merge(t *testing.T) {
 				CachedJobRunID: test.inJRID,
 				Status:         test.inStatus,
 			}
-			merged, err := original.Merge(in)
-			assert.Equal(t, test.wantErrored, err != nil)
+			merged := original
+			err := merged.Merge(in)
+			if test.wantErrored {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 
 			assert.JSONEq(t, test.originalData, original.Data.String())
 			assert.Equal(t, test.originalError, original.ErrorMessage)

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/smartcontractkit/chainlink/adapters"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store/models"
-	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -164,92 +163,61 @@ func TestRunResult_Merge(t *testing.T) {
 	completed := models.RunStatusCompleted
 
 	nullString := cltest.NullString(nil)
-	jrID := utils.NewBytes32ID()
 	tests := []struct {
 		name             string
 		originalData     string
 		originalError    null.String
 		originalStatus   models.RunStatus
-		originalJRID     string
 		inData           string
 		inError          null.String
 		inStatus         models.RunStatus
-		inJRID           string
 		wantData         string
 		wantErrorMessage null.String
 		wantStatus       models.RunStatus
-		wantJRID         string
-		wantErrored      bool
 	}{
 		{"merging data",
-			`{"result":"old&busted","unique":"1"}`, nullString, inProgress, jrID,
-			`{"result":"newHotness","and":"!"}`, nullString, inProgress, jrID,
-			`{"result":"newHotness","unique":"1","and":"!"}`, nullString, inProgress, jrID, false},
+			`{"result":"old&busted","unique":"1"}`, nullString, inProgress,
+			`{"result":"newHotness","and":"!"}`, nullString, inProgress,
+			`{"result":"newHotness","unique":"1","and":"!"}`, nullString, inProgress},
 		{"completed result",
-			`{"result":"old"}`, nullString, inProgress, jrID,
-			`{}`, nullString, completed, jrID,
-			`{"result":"old"}`, nullString, completed, jrID, false},
-		{"original error throws",
-			`{"result":"old"}`, cltest.NullString("old problem"), errored, jrID,
-			`{}`, nullString, inProgress, jrID,
-			`{"result":"old"}`, cltest.NullString("old problem"), errored, jrID, true},
+			`{"result":"old"}`, nullString, inProgress,
+			`{}`, nullString, completed,
+			`{"result":"old"}`, nullString, completed},
 		{"error override",
-			`{"result":"old"}`, nullString, inProgress, jrID,
-			`{}`, cltest.NullString("new problem"), errored, jrID,
-			`{"result":"old"}`, cltest.NullString("new problem"), errored, jrID, false},
-		{"original job run ID",
-			`{"result":"old"}`, nullString, inProgress, jrID,
-			`{}`, nullString, inProgress, "",
-			`{"result":"old"}`, nullString, inProgress, jrID, false},
-		{"job run ID override",
-			`{"result":"old"}`, nullString, inProgress, utils.NewBytes32ID(),
-			`{}`, nullString, inProgress, jrID,
-			`{"result":"old"}`, nullString, inProgress, jrID, false},
-		{"original pending",
-			`{"result":"old"}`, nullString, pending, jrID,
-			`{}`, nullString, inProgress, jrID,
-			`{"result":"old"}`, nullString, pending, jrID, false},
+			`{"result":"old"}`, nullString, inProgress,
+			`{}`, cltest.NullString("new problem"), errored,
+			`{"result":"old"}`, cltest.NullString("new problem"), errored},
 		{"pending override",
-			`{"result":"old"}`, nullString, inProgress, jrID,
-			`{}`, nullString, pending, jrID,
-			`{"result":"old"}`, nullString, pending, jrID, false},
+			`{"result":"old"}`, nullString, inProgress,
+			`{}`, nullString, pending,
+			`{"result":"old"}`, nullString, pending},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			original := models.RunResult{
-				Data:           models.JSON{Result: gjson.Parse(test.originalData)},
-				ErrorMessage:   test.originalError,
-				CachedJobRunID: test.originalJRID,
-				Status:         test.originalStatus,
+				Data:         models.JSON{Result: gjson.Parse(test.originalData)},
+				ErrorMessage: test.originalError,
+				Status:       test.originalStatus,
 			}
 			in := models.RunResult{
-				Data:           cltest.JSONFromString(t, test.inData),
-				ErrorMessage:   test.inError,
-				CachedJobRunID: test.inJRID,
-				Status:         test.inStatus,
+				Data:         cltest.JSONFromString(t, test.inData),
+				ErrorMessage: test.inError,
+				Status:       test.inStatus,
 			}
 			merged := original
-			err := merged.Merge(in)
-			if test.wantErrored {
-				require.Error(t, err)
-			} else {
-				require.NoError(t, err)
-			}
+			merged.Merge(in)
 
 			assert.JSONEq(t, test.originalData, original.Data.String())
 			assert.Equal(t, test.originalError, original.ErrorMessage)
-			assert.Equal(t, test.originalJRID, original.CachedJobRunID)
 			assert.Equal(t, test.originalStatus, original.Status)
 
 			assert.JSONEq(t, test.inData, in.Data.String())
 			assert.Equal(t, test.inError, in.ErrorMessage)
-			assert.Equal(t, test.inJRID, in.CachedJobRunID)
 			assert.Equal(t, test.inStatus, in.Status)
 
 			assert.JSONEq(t, test.wantData, merged.Data.String())
 			assert.Equal(t, test.wantErrorMessage, merged.ErrorMessage)
-			assert.Equal(t, test.wantJRID, merged.CachedJobRunID)
 			assert.Equal(t, test.wantStatus, merged.Status)
 		})
 	}

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -71,8 +71,7 @@ func TestORM_SaveJobRun_DoesNotSaveTaskSpec(t *testing.T) {
 	require.NoError(t, store.CreateJobRun(&jr))
 
 	var err error
-	jr.TaskRuns[0].TaskSpec.Params, err =
-		jr.TaskRuns[0].TaskSpec.Params.Merge(cltest.JSONFromString(t, `{"random": "input"}`))
+	jr.TaskRuns[0].TaskSpec.Params = jr.TaskRuns[0].TaskSpec.Params.Merge(cltest.JSONFromString(t, `{"random": "input"}`))
 	require.NoError(t, err)
 	require.NoError(t, store.SaveJobRun(&jr))
 

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -71,7 +71,7 @@ func TestORM_SaveJobRun_DoesNotSaveTaskSpec(t *testing.T) {
 	require.NoError(t, store.CreateJobRun(&jr))
 
 	var err error
-	jr.TaskRuns[0].TaskSpec.Params = jr.TaskRuns[0].TaskSpec.Params.Merge(cltest.JSONFromString(t, `{"random": "input"}`))
+	jr.TaskRuns[0].TaskSpec.Params, err = jr.TaskRuns[0].TaskSpec.Params.Merge(cltest.JSONFromString(t, `{"random": "input"}`))
 	require.NoError(t, err)
 	require.NoError(t, store.SaveJobRun(&jr))
 

--- a/store/tx_manager_test.go
+++ b/store/tx_manager_test.go
@@ -242,7 +242,7 @@ func TestTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
 			})
 
 			a, err := manager.CreateTx(to, data)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			tx, err := store.FindTx(a.ID)
 			require.NoError(t, err)
 			assert.NoError(t, err)

--- a/web/job_runs_controller.go
+++ b/web/job_runs_controller.go
@@ -109,7 +109,7 @@ func (jrc *JobRunsController) Update(c *gin.Context) {
 		c.AbortWithError(500, err)
 	} else if _, err := bt.Authenticate(utils.StripBearer(c.Request.Header.Get("Authorization"))); err != nil {
 		publicError(c, http.StatusUnauthorized, err)
-	} else if _, err = services.ResumePendingTask(&jr, jrc.App.GetStore(), brr.RunResult); err != nil {
+	} else if err = services.ResumePendingTask(&jr, jrc.App.GetStore(), brr.RunResult); err != nil {
 		c.AbortWithError(500, err)
 	} else {
 		c.JSON(200, gin.H{"id": jr.ID})

--- a/web/job_runs_controller_test.go
+++ b/web/job_runs_controller_test.go
@@ -318,7 +318,7 @@ func TestJobRunsController_Update_WithMergeError(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(j.Initiators[0]), 0)
-	jr.Overrides = jr.Overrides.WithError(errors.New("Already errored")) // easy way to force Merge error
+	jr.Overrides.WithError(errors.New("Already errored")) // easy way to force Merge error
 	assert.Nil(t, app.Store.CreateJobRun(&jr))
 
 	body := fmt.Sprintf(`{"id":"%v","data":{"result": "100"}}`, jr.ID)

--- a/web/job_runs_controller_test.go
+++ b/web/job_runs_controller_test.go
@@ -318,7 +318,7 @@ func TestJobRunsController_Update_WithMergeError(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.Nil(t, app.Store.CreateJob(&j))
 	jr := cltest.MarkJobRunPendingBridge(j.NewRun(j.Initiators[0]), 0)
-	jr.Overrides.WithError(errors.New("Already errored")) // easy way to force Merge error
+	jr.Overrides.SetError(errors.New("Already errored")) // easy way to force Merge error
 	assert.Nil(t, app.Store.CreateJobRun(&jr))
 
 	body := fmt.Sprintf(`{"id":"%v","data":{"result": "100"}}`, jr.ID)


### PR DESCRIPTION
This marks a departure from the pseudo-functional pattern of having methods on RunResult/JobRun and TaskRun that return copies.

The motivation here is:
  1. Moving around copies is inefficient in go
  2. Managing copies means also managing indexes into the collection of TaskRuns on JobRun, since you can't modify them directly, this provides more room for error
  3. Because of go's lack of functional programming, the functional style ends up being quite complex

I've also split SetError out from ApplyResult, since the type is always consistent at the call site and this is more "confident".
