### PR TITLE
Titlecase job run status card

### DIFF
--- a/gui/__tests__/components/JobRuns/StatusCard.test.js
+++ b/gui/__tests__/components/JobRuns/StatusCard.test.js
@@ -1,0 +1,10 @@
+import React from 'react'
+import StatusCard from 'components/JobRuns/StatusCard'
+import mountWithTheme from 'test-helpers/mountWithTheme'
+
+describe('components/JobRuns/StatusCard', () => {
+  it('can display a title', () => {
+    let withTitle = mountWithTheme(<StatusCard>pending_confirmations</StatusCard>)
+    expect(withTitle.text()).toContain('Pending Confirmations')
+  })
+})

--- a/gui/__tests__/containers/JobRuns/Show.test.js
+++ b/gui/__tests__/containers/JobRuns/Show.test.js
@@ -52,6 +52,6 @@ describe('containers/JobRuns/Show', () => {
     await syncFetch(wrapper)
     expect(wrapper.text()).toContain('Web')
     expect(wrapper.text()).toContain('Noop')
-    expect(wrapper.text()).toContain('completed')
+    expect(wrapper.text()).toContain('Completed')
   })
 })

--- a/gui/src/components/JobRuns/StatusCard.js
+++ b/gui/src/components/JobRuns/StatusCard.js
@@ -4,6 +4,7 @@ import PaddedCard from 'components/PaddedCard'
 import StatusIcon from 'components/JobRuns/StatusIcon'
 import Typography from '@material-ui/core/Typography'
 import classNames from 'classnames'
+import { titleCase } from 'change-case'
 
 const styles = theme => ({
   completed: {
@@ -39,7 +40,7 @@ const StatusCard = ({ classes, children }) => {
         {children}
       </StatusIcon>
       <Typography className={classes.statusText} variant='h5' color='inherit'>
-        {children}
+        {titleCase(children)}
       </Typography>
     </PaddedCard>
   )


### PR DESCRIPTION
Before:
![screen shot 2019-02-26 at 4 11 09 pm](https://user-images.githubusercontent.com/680789/53456056-b0507b00-39e1-11e9-8bb6-d45f716ce6cb.png)

After:
![screen shot 2019-02-26 at 4 15 26 pm](https://user-images.githubusercontent.com/680789/53456072-c100f100-39e1-11e9-9046-115146e29558.png)
