### PR TITLE
resumeRunsSinceLastShutdown does not query db queue after awaking jobs

### DIFF
--- a/store/models/run.go
+++ b/store/models/run.go
@@ -128,6 +128,18 @@ func (jr *JobRun) MarkCompleted() {
 	jr.CompletedAt = null.Time{Time: time.Now(), Valid: true}
 }
 
+// JobRunsWithStatus filters passed job runs returning those that have
+// the desired status, entirely in memory.
+func JobRunsWithStatus(runs []JobRun, status RunStatus) []JobRun {
+	rval := []JobRun{}
+	for _, r := range runs {
+		if r.Status == status {
+			rval = append(rval, r)
+		}
+	}
+	return rval
+}
+
 // TaskRun stores the Task and represents the status of the
 // Task to be ran.
 type TaskRun struct {


### PR DESCRIPTION
This prevents the following race condition from happening

0. Have a job run that's sleeping but past its time to wake up.
1. Run `resumeRunsSinceLastShutdown`
2. Query with `rm.store.JobRunsWithStatus(models.RunStatusPendingSleep)`
3. Leads to the queuing of said run with QueueSleepingTask
4. Asynchronously place run from `pending_sleep` to `in_progress`
5. Query again w rm.store.JobRunsWithStatus(models.RunStatusInProgress)
6. Finds already enqueued run because it is now `in_progress` and re-enqueues it (double enqueue)