### PR TITLE
Scheduler integration test is more forgiving of multiple runs

### DIFF
--- a/integration/features_test.go
+++ b/integration/features_test.go
@@ -32,7 +32,7 @@ func TestIntegration_Scheduler(t *testing.T) {
 
 	j := cltest.FixtureCreateJobViaWeb(t, app, "../internal/fixtures/web/scheduler_job.json")
 
-	cltest.WaitForRuns(t, j, app.Store, 1)
+	cltest.WaitForRunsAtLeast(t, j, app.Store, 1)
 
 	initr := j.Initiators[0]
 	assert.Equal(t, models.InitiatorCron, initr.Type)

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -760,6 +760,22 @@ func WaitForRuns(t *testing.T, j models.JobSpec, store *strpkg.Store, want int) 
 	return jrs
 }
 
+// WaitForRunsAtLeast waits for at least the passed number of runs to start.
+func WaitForRunsAtLeast(t *testing.T, j models.JobSpec, store *strpkg.Store, want int) {
+	t.Helper()
+	g := gomega.NewGomegaWithT(t)
+
+	if want == 0 {
+		t.Fatal("must want more than 0 runs when waiting")
+	} else {
+		g.Eventually(func() int {
+			jrs, err := store.JobRunsFor(j.ID)
+			require.NoError(t, err)
+			return len(jrs)
+		}).Should(gomega.BeNumerically(">=", want))
+	}
+}
+
 func WaitForTxAttemptCount(t *testing.T, store *strpkg.Store, want int) []models.TxAttempt {
 	t.Helper()
 	g := gomega.NewGomegaWithT(t)


### PR DESCRIPTION
TestIntegration_Scheduler asserts that at least one run has executed with a cron of `* * * * *` rather than enforcing exactly one.