### PR TITLE
Persist UI State across unauthenticated requests

### DIFF
--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -3,7 +3,7 @@ import { Provider } from 'react-redux'
 import createStore from './connectors/redux'
 import Layout from './Layout'
 import './index.css'
-import { set } from './utils/storage';
+import { set } from './utils/storage'
 
 const store = createStore()
 

--- a/gui/src/App.tsx
+++ b/gui/src/App.tsx
@@ -3,6 +3,14 @@ import { Provider } from 'react-redux'
 import createStore from './connectors/redux'
 import Layout from './Layout'
 import './index.css'
+import { set } from './utils/storage';
+
+const store = createStore()
+
+store.subscribe(() => {
+  const prevURL = store.getState().notifications.currentUrl
+  if(prevURL !== '/signin') set("persistURL", prevURL)
+})
 
 class App extends PureComponent {
   // Remove the server-side injected CSS.
@@ -15,7 +23,7 @@ class App extends PureComponent {
 
   render (): JSX.Element {
     return (
-      <Provider store={createStore()}>
+      <Provider store={store}>
         <Layout />
       </Provider>
     )

--- a/gui/src/components/Bridges/Form.js
+++ b/gui/src/components/Bridges/Form.js
@@ -136,9 +136,9 @@ Form.propTypes = {
 
 const formikOpts = {
   mapPropsToValues({ name, url, minimumContractPayment, confirmations }) {
-    const shouldPersist = Object.keys(get('saveBridgeJSON')).length !== 0
-    let persistedJSON = shouldPersist && get('saveBridgeJSON')
-    if (shouldPersist) set('saveBridgeJSON', {})
+    const shouldPersist = Object.keys(get('persistBridge')).length !== 0
+    let persistedJSON = shouldPersist && get('persistBridge')
+    if (shouldPersist) set('persistBridge', {})
     const json = {
       name: name || '',
       url: url || '',
@@ -150,7 +150,7 @@ const formikOpts = {
 
   handleSubmit(values, { props, setSubmitting }) {
     props.onSubmit(values, props.onSuccess, props.onError)
-    set('saveBridgeJSON', values)
+    set('persistBridge', values)
     setTimeout(() => {
       setSubmitting(false)
     }, 1000)

--- a/gui/src/components/Bridges/Form.js
+++ b/gui/src/components/Bridges/Form.js
@@ -5,6 +5,7 @@ import * as formik from 'formik'
 import { withStyles } from '@material-ui/core/styles'
 import { TextField, Grid } from '@material-ui/core'
 import Button from 'components/Button'
+import { set, get } from 'utils/storage'
 
 const styles = theme => ({
   textfield: {
@@ -135,16 +136,21 @@ Form.propTypes = {
 
 const formikOpts = {
   mapPropsToValues({ name, url, minimumContractPayment, confirmations }) {
-    return {
+    const shouldPersist = Object.keys(get('saveBridgeJSON')).length !== 0
+    let persistedJSON = shouldPersist && get('saveBridgeJSON')
+    if (shouldPersist) set('saveBridgeJSON', {})
+    const json = {
       name: name || '',
       url: url || '',
       minimumContractPayment: minimumContractPayment || 0,
       confirmations: confirmations || 0
     }
+    return (shouldPersist && persistedJSON) || json
   },
 
   handleSubmit(values, { props, setSubmitting }) {
     props.onSubmit(values, props.onSuccess, props.onError)
+    set('saveBridgeJSON', values)
     setTimeout(() => {
       setSubmitting(false)
     }, 1000)

--- a/gui/src/components/Jobs/Form.js
+++ b/gui/src/components/Jobs/Form.js
@@ -81,9 +81,9 @@ Form.propTypes = {
 
 const formikOpts = {
   mapPropsToValues({ definition }) {
-    const shouldPersist = Object.keys(get('saveSpecJSON')).length !== 0
-    let persistedJSON = shouldPersist && get('saveSpecJSON')
-    if (shouldPersist) set('saveSpecJSON', {})
+    const shouldPersist = Object.keys(get('persistSpec')).length !== 0
+    let persistedJSON = shouldPersist && get('persistSpec')
+    if (shouldPersist) set('persistSpec', {})
     const json =
       JSON.stringify(definition, null, '\t') ||
       (shouldPersist && persistedJSON) ||
@@ -105,7 +105,7 @@ const formikOpts = {
 
   handleSubmit(values, { props, setSubmitting }) {
     const definition = JSON.parse(values.json)
-    set('saveSpecJSON', values.json)
+    set('persistSpec', values.json)
     props.onSubmit(definition, props.onSuccess, props.onError)
     setTimeout(() => {
       setSubmitting(false)

--- a/gui/src/components/Jobs/Form.js
+++ b/gui/src/components/Jobs/Form.js
@@ -5,6 +5,7 @@ import { withStyles } from '@material-ui/core/styles'
 import Button from 'components/Button'
 import { TextField, Grid } from '@material-ui/core'
 import { Prompt } from 'react-router-dom'
+import { set, get } from 'utils/storage'
 
 const styles = theme => ({
   card: {
@@ -80,7 +81,13 @@ Form.propTypes = {
 
 const formikOpts = {
   mapPropsToValues({ definition }) {
-    const json = JSON.stringify(definition, null, '\t') || ''
+    const shouldPersist = Object.keys(get('saveSpecJSON')).length !== 0
+    let persistedJSON = shouldPersist && get('saveSpecJSON')
+    if (shouldPersist) set('saveSpecJSON', {})
+    const json =
+      JSON.stringify(definition, null, '\t') ||
+      (shouldPersist && persistedJSON) ||
+      ''
     return { json }
   },
 
@@ -98,6 +105,7 @@ const formikOpts = {
 
   handleSubmit(values, { props, setSubmitting }) {
     const definition = JSON.parse(values.json)
+    set('saveSpecJSON', values.json)
     props.onSubmit(definition, props.onSuccess, props.onError)
     setTimeout(() => {
       setSubmitting(false)

--- a/gui/src/connectors/redux/reducers/notifications.js
+++ b/gui/src/connectors/redux/reducers/notifications.js
@@ -4,6 +4,8 @@ import {
   NOTIFY_SUCCESS,
   NOTIFY_ERROR
 } from 'actions'
+import { set } from 'utils/storage'
+import { BadRequestError } from 'errors'
 
 const initialState = {
   errors: [],
@@ -36,7 +38,9 @@ export default (state = initialState, action = {}) => {
         component: action.component,
         props: action.props
       }
-
+      if (success.props.data && success.props.data.type === 'specs')
+        set('persistSpec', {})
+      else if (typeof success.props.url === 'string') set('persistBridge', {})
       return Object.assign({}, state, {
         successes: [success],
         errors: []
@@ -61,6 +65,7 @@ export default (state = initialState, action = {}) => {
       } else {
         notifications = [error]
       }
+      if (error instanceof BadRequestError) set('persistBridge', {})
 
       return Object.assign({}, state, {
         successes: [],

--- a/gui/src/containers/SignIn.js
+++ b/gui/src/containers/SignIn.js
@@ -13,6 +13,7 @@ import { hot } from 'react-hot-loader'
 import { submitSignIn } from 'actions'
 import HexagonLogo from 'components/Logos/Hexagon'
 import matchRouteAndMapDispatchToProps from 'utils/matchRouteAndMapDispatchToProps'
+import { get } from 'utils/storage'
 
 const styles = theme => ({
   container: {
@@ -51,7 +52,9 @@ export const SignIn = useHooks(props => {
   }
   const { classes, fetching, authenticated, errors } = props
 
-  if (authenticated) return <Redirect to="/" />
+  const hasPrevState = Object.keys(get('persistURL')).length !== 0
+  if (authenticated)
+    return <Redirect to={(hasPrevState && get('persistURL')) || '/'} />
   return (
     <Grid
       container


### PR DESCRIPTION
Now this could've been done in many ways, but I think this sketch is the least expensive approach (perhaps it's better to lift persisting routes to redux and not rely on local storage). It seems to work too, but I couldn't test thoroughly, so let me know if anything's going wrong.

cc @se3000, iirc you were interested to see this (addresses persisting both forms & routes)