### PR TITLE
Prompt only appears when needed

### DIFF
--- a/gui/src/components/Bridges/Form.js
+++ b/gui/src/components/Bridges/Form.js
@@ -23,20 +23,12 @@ const styles = theme => ({
   }
 })
 
-const isDirty = ({
-  values,
-  name,
-  url,
-  minimumContractPayment,
-  confirmations,
-  submitCount
-}) => {
+const isDirty = ({ values, submitCount }) => {
   return (
-    (values.name !== name ||
-      values.url !== url ||
-      values.minimumContractPayment.toString() !==
-        minimumContractPayment.toString() ||
-      values.confirmations !== confirmations) &&
+    (values.name !== '' ||
+      values.url !== '' ||
+      (values.minimumContractPayment.toString() !== '0' &&
+        values.confirmations !== '0')) &&
     submitCount === 0
   )
 }


### PR DESCRIPTION
Since Minimum Contract Payment & Confirmations are prefilled for the user, they should be discarded in shouldPromptAppear conditional.

this
<p align="center">
  <img src="https://i.imgur.com/7byvj1D.gif">
</p>
vs
<p align="center">
  <img src="https://i.imgur.com/JqmzOQX.gif">
</p>
