### PR TITLE
Fix MUI Warnings

### DIFF
--- a/gui/src/components/BridgeList.js
+++ b/gui/src/components/BridgeList.js
@@ -75,7 +75,7 @@ export const BridgeList = useHooks(props => {
   } = props
   const TableButtonsWithProps = () => (
     <TableButtons
-      {...props}
+      history={props.history}
       count={bridgeCount}
       onChangePage={handleChangePage}
       rowsPerPage={pageSize}

--- a/gui/src/components/KeyValueList.js
+++ b/gui/src/components/KeyValueList.js
@@ -44,7 +44,9 @@ const ErrorRow = ({ children }) => <SpanRow>{children}</SpanRow>
 
 const Col = ({ children }) => (
   <TableCell>
-    <Typography variant="body1">{children}</Typography>
+    <Typography variant="body1">
+      <span>{children}</span>
+    </Typography>
   </TableCell>
 )
 

--- a/gui/src/containers/JobRuns/Index.js
+++ b/gui/src/containers/JobRuns/Index.js
@@ -27,7 +27,7 @@ const renderLatestRuns = (props, state, handleChangePage) => {
   const { jobSpecId, latestJobRuns, jobRunsCount, pageSize } = props
   const TableButtonsWithProps = () => (
     <TableButtons
-      {...props}
+      history={props.history}
       count={jobRunsCount}
       onChangePage={handleChangePage}
       page={state.page}


### PR DESCRIPTION
Fixes in `http://localhost:3000/config`
```
Warning: Failed prop type: Invalid prop `children` supplied to `Typography`, expected a ReactNode.
    in Typography (created by WithStyles(Typography))
    in WithStyles(Typography) (at KeyValueList.js:47)
    in td (created by Context.Consumer)
    in TableCell (created by WithStyles(TableCell))
    in WithStyles(TableCell) (at KeyValueList.js:46)
    in Col (at KeyValueList.js:19)
    in tr (created by Context.Consumer)
    in TableRow (created by WithStyles(TableRow))
    in WithStyles(TableRow) (at KeyValueList.js:17)
    in tbody (created by TableBody)
    in TableBody (created by WithStyles(TableBody))
    in WithStyles(TableBody) (at KeyValueList.js:72)
    in table (created by Table)
    in Table (created by WithStyles(Table))
    in WithStyles(Table) (at KeyValueList.js:63)
    in div (created by Paper)
    in Paper (created by WithStyles(Paper))
    in WithStyles(Paper) (created by Card)
    in Card (created by WithStyles(Card))
    in WithStyles(Card) (at KeyValueList.js:60)
    in KeyValueList (at Configuration.js:27)
    in div (created by Grid)
    in Grid (created by WithStyles(Grid))
    in WithStyles(Grid) (at Configuration.js:26)
    in div (created by Grid)
    in Grid (created by WithStyles(Grid))
    in WithStyles(Grid) (at Configuration.js:25)
    in div (at Content.js:11)
    in Content (created by WithStyles(Content))
    in WithStyles(Content) (at Configuration.js:24)
    in HookComponent (created by HookWrapper)
    in HookWrapper (created by Connect(HookWrapper))
    in Connect(HookWrapper) (created by UniversalComponent)
    in UniversalComponent (created by PrivateRoute)
    in PrivateRoute (created by Connect(PrivateRoute))
    in Connect(PrivateRoute) (at Private.js:162)
    in Switch (at Private.js:82)
    in div (at Private.js:81)
    in main (at Private.js:73)
    in div (created by Grid)
    in Grid (created by WithStyles(Grid))
    in WithStyles(Grid) (at Private.js:68)
    in div (created by Grid)
    in Grid (created by WithStyles(Grid))
    in WithStyles(Grid) (at Private.js:67)
    in Private (created by WithStyles(Private))
    in WithStyles(Private) (created by HotExportedWithStyles(Private))
    in AppContainer (created by HotExportedWithStyles(Private))
    in HotExportedWithStyles(Private) (created by Route)
    in Route (at Layout.js:38)
    in Switch (at Layout.js:34)
    in Router (created by BrowserRouter)
    in BrowserRouter
    in Unknown (at Root.js:111)
    in RouterScroller (at Root.js:104)
    in Wrapper (at Root.js:110)
    in ErrorBoundary (at Root.js:109)
    in Root (at StaticInfo.js:17)
    in StaticInfo
    in Component (at Layout.js:31)
    in Layout (created by Connect(Layout))
    in Connect(Layout) (created by App)
    in Provider (at App.tsx:26)
    in App (at src/index.js:27)
    in MuiThemeProviderOld
    in AppContainer (at src/index.js:25)
```

Also fixes in `http://localhost:3000/jobs/5e1a984565274e9f84f4422b4fdef4ff/runs`
```
index.js:1449 Warning: Material-UI: the key `breadcrumb` provided to the classes property is not implemented in TableButtons.
You can only override one of the following: customButtons.
```