### PR TITLE
change name on bridge types to be a primary key:

### DIFF
--- a/store/migrations/migrate.go
+++ b/store/migrations/migrate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/store/migrations/migration0"
 	"github.com/smartcontractkit/chainlink/store/migrations/migration1549496047"
+	"github.com/smartcontractkit/chainlink/store/migrations/migration1551816486"
 	"github.com/smartcontractkit/chainlink/store/orm"
 	"go.uber.org/multierr"
 )
@@ -16,6 +17,7 @@ import (
 func init() {
 	registerMigration(migration0.Migration{})
 	registerMigration(migration1549496047.Migration{})
+	registerMigration(migration1551816486.Migration{})
 }
 
 type migration interface {

--- a/store/migrations/migration1551816486/migrate.go
+++ b/store/migrations/migration1551816486/migrate.go
@@ -1,0 +1,29 @@
+package migration1551816486
+
+import (
+	"github.com/smartcontractkit/chainlink/store/orm"
+)
+
+type Migration struct{}
+
+func (m Migration) Timestamp() string {
+	return "1551816486"
+}
+
+// Migrate creates a new bridge_types table with the correct primary key
+// because sqlite does not allow you to modify the primary key
+// after table creation.
+func (m Migration) Migrate(orm *orm.ORM) error {
+	tx := orm.DB.Begin()
+	err := tx.Exec(`
+		CREATE TABLE "bridge_types_with_pk" ("name" varchar(255),"url" varchar(255),"confirmations" bigint,"incoming_token" varchar(255),"outgoing_token" varchar(255),"minimum_contract_payment" varchar(255) , PRIMARY KEY ("name"));
+		INSERT INTO "bridge_types_with_pk" SELECT * FROM "bridge_types";
+		DROP TABLE "bridge_types";
+		ALTER TABLE "bridge_types_with_pk" RENAME TO "bridge_types";
+	`).Error
+	if err != nil {
+		tx.Rollback()
+		return err
+	}
+	return tx.Commit().Error
+}

--- a/store/models/job_spec.go
+++ b/store/models/job_spec.go
@@ -287,7 +287,7 @@ func (t *TaskType) Scan(value interface{}) error {
 // BridgeType is used for external adapters and has fields for
 // the name of the adapter and its URL.
 type BridgeType struct {
-	Name                   TaskType    `json:"name" gorm:"unique_index"`
+	Name                   TaskType    `json:"name" gorm:"primary_key"`
 	URL                    WebURL      `json:"url"`
 	Confirmations          uint64      `json:"confirmations"`
 	IncomingToken          string      `json:"incomingToken"`

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -748,6 +748,29 @@ func TestORM_SyncDbKeyStoreToDisk(t *testing.T) {
 	assert.Equal(t, key.JSON.String(), content)
 }
 
+func TestORM_UpdateBridgeType(t *testing.T) {
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+
+	firstBridge := &models.BridgeType{
+		Name: "UniqueName",
+		URL:  cltest.WebURL("http:/oneurl.com"),
+	}
+
+	require.NoError(t, store.CreateBridgeType(firstBridge))
+
+	updateBridge := models.BridgeType{
+		Name: "UniqueName",
+		URL:  cltest.WebURL("http:/updatedurl.com"),
+	}
+
+	require.NoError(t, store.UpdateBridgeType(&updateBridge))
+
+	foundbridge, err := store.FindBridge("UniqueName")
+	require.NoError(t, err)
+	require.Equal(t, updateBridge, foundbridge)
+}
+
 func isDirEmpty(t *testing.T, dir string) bool {
 	f, err := os.Open(dir)
 	if err != nil {

--- a/web/bridge_types_controller.go
+++ b/web/bridge_types_controller.go
@@ -68,7 +68,11 @@ func (btc *BridgeTypesController) Update(c *gin.Context) {
 		return
 	}
 
-	c.BindJSON(&form)
+	if err = c.BindJSON(&form); err != nil {
+		publicError(c, 400, fmt.Errorf("unable to parse JSON: %v", err))
+		return
+	}
+
 	err = form.Save()
 	if err != nil {
 		c.AbortWithError(500, err)


### PR DESCRIPTION
Added new column to bridge_types instead of modifying existing name column
because sqlite does not allow you to add primary key after the fact.

Fixes https://www.pivotaltracker.com/story/show/164343428