### PR TITLE
Fix unauthorized error msg in Sign In

### DIFF
--- a/gui/__tests__/connectors/reducers/notifications.test.js
+++ b/gui/__tests__/connectors/reducers/notifications.test.js
@@ -50,7 +50,11 @@ describe('connectors/reducers/notifications', () => {
 
     expect(state.notifications).toEqual({
       errors: [
-        { detail: 'Your email or password is incorrect. Please try again' }
+        {
+          props: {
+            msg: 'Your email or password is incorrect. Please try again'
+          }
+        }
       ],
       successes: [],
       currentUrl: null

--- a/gui/__tests__/containers/SignIn.test.js
+++ b/gui/__tests__/containers/SignIn.test.js
@@ -58,7 +58,11 @@ describe('containers/SignIn', () => {
     const newState = store.getState()
     expect(newState.notifications).toEqual({
       errors: [
-        { detail: 'Your email or password is incorrect. Please try again' }
+        {
+          props: {
+            msg: 'Your email or password is incorrect. Please try again'
+          }
+        }
       ],
       successes: [],
       currentUrl: '/signin'

--- a/gui/src/connectors/redux/reducers/notifications.js
+++ b/gui/src/connectors/redux/reducers/notifications.js
@@ -30,7 +30,7 @@ export default (state = initialState, action = {}) => {
     case RECEIVE_SIGNIN_FAIL: {
       return Object.assign({}, state, {
         successes: [],
-        errors: [{ detail: SIGN_IN_FAIL_MSG }]
+        errors: [{ props: { msg: SIGN_IN_FAIL_MSG } }]
       })
     }
     case NOTIFY_SUCCESS: {
@@ -48,28 +48,28 @@ export default (state = initialState, action = {}) => {
     }
     case NOTIFY_ERROR: {
       const { component, error } = action
-      let notifications
+      let errorNotifications
 
       if (error.errors) {
-        notifications = error.errors.map(e => ({
+        errorNotifications = error.errors.map(e => ({
           component: component,
           props: { msg: e.detail }
         }))
       } else if (error.message) {
-        notifications = [
+        errorNotifications = [
           {
             component: component,
             props: { msg: error.message }
           }
         ]
       } else {
-        notifications = [error]
+        errorNotifications = [error]
       }
       if (error instanceof BadRequestError) set('persistBridge', {})
 
       return Object.assign({}, state, {
         successes: [],
-        errors: notifications
+        errors: errorNotifications
       })
     }
     default:

--- a/gui/src/containers/SignIn.js
+++ b/gui/src/containers/SignIn.js
@@ -81,7 +81,7 @@ export const SignIn = useHooks(props => {
                 </Grid>
 
                 {errors.length > 0 &&
-                  errors.map(({ detail }, idx) => {
+                  errors.map(({ props }, idx) => {
                     return (
                       <Grid item xs={12} key={idx}>
                         <Card raised={false} className={classes.error}>
@@ -90,7 +90,7 @@ export const SignIn = useHooks(props => {
                               variant="body1"
                               className={classes.errorText}
                             >
-                              {detail}
+                              {props.msg}
                             </Typography>
                           </CardContent>
                         </Card>


### PR DESCRIPTION
Just a quickfix. 
To reproduce fill bridge/spec from, wait out before you are unauthorized and click Create. Error message isn't shown. Pics for clarity:
Before:
![image](https://user-images.githubusercontent.com/40662484/53915037-13b75a00-402d-11e9-8ca5-bf479f41cb11.png)

After:
![image](https://user-images.githubusercontent.com/40662484/53914987-ed91ba00-402c-11e9-989b-3ae5a99ba046.png)
