### PR TITLE
End to End test for Transactions

### DIFF
--- a/e2e/createAndRunJob.test.js
+++ b/e2e/createAndRunJob.test.js
@@ -3,6 +3,7 @@ const expect = require('expect-puppeteer')
 const { newServer } = require('./support/server.js')
 const { scrape } = require('./support/scrape.js')
 const {
+  signIn,
   clickNewJobButton,
   clickTransactionsMenuItem
 } = require('./support/helpers.js')
@@ -35,9 +36,7 @@ describe('End to end', () => {
     await expect(page).toMatch('Chainlink')
 
     // Login
-    await expect(page).toFill('form input[id=email]', 'notreal@fakeemail.ch')
-    await expect(page).toFill('form input[id=password]', 'twochains')
-    await expect(page).toClick('form button')
+    await signIn(page, 'notreal@fakeemail.ch', 'twochains')
     await expect(page).toMatch('Jobs')
 
     // Create Job

--- a/e2e/createAndRunJob.test.js
+++ b/e2e/createAndRunJob.test.js
@@ -6,7 +6,7 @@ const { scrape } = require('./support/scrape.js')
 describe('End to end', () => {
   let browser, page, server
   beforeAll(async () => {
-    jest.setTimeout(30000)
+    jest.setTimeout(60000)
 
     browser = await puppeteer.launch({
       devtools: false,

--- a/e2e/createAndRunJob.test.js
+++ b/e2e/createAndRunJob.test.js
@@ -37,7 +37,7 @@ describe('End to end', () => {
     await expect(page).toMatch('Jobs')
 
     // Create Job
-    await expect(page).toClick('a', { text: 'New Job' })
+    await expect(page).toClick('a > span', { text: 'New Job' })
     await expect(page).toMatch('New Job')
 
     const jobJson = `{
@@ -60,12 +60,8 @@ describe('End to end', () => {
     const txHash = match[1]
 
     // Navigate to transactions page
-    await expect(page).toClick('button', { 'aria-label': 'open drawer' })
-    await expect(page).toClick('span', { text: 'Transactions', timeout: 30000 })
-    await expect(page).toMatchElement('h4', {
-      text: 'Transactions',
-      timeout: 30000
-    })
+    await expect(page).toClick('li > a', { text: 'Transactions' })
+    await expect(page).toMatchElement('h4', { text: 'Transactions' })
     await expect(page).toMatchElement('p', { text: txHash })
 
     // Navigate to transaction page and check for the transaction

--- a/e2e/createAndRunJob.test.js
+++ b/e2e/createAndRunJob.test.js
@@ -38,7 +38,7 @@ describe('End to end', () => {
 
     // Create Job
     await expect(page).toClick('a > span', { text: 'New Job' })
-    await expect(page).toMatch('New Job')
+    await expect(page).toMatchElement('h5', { text: 'New Job' })
 
     const jobJson = `{
       "initiators": [{"type": "web"}],

--- a/e2e/createAndRunJob.test.js
+++ b/e2e/createAndRunJob.test.js
@@ -1,15 +1,23 @@
 const puppeteer = require('puppeteer')
 const expect = require('expect-puppeteer')
+const { newServer } = require('./support/server.js')
+const { scrape } = require('./support/scrape.js')
 
 describe('End to end', () => {
   let browser, page
   beforeAll(async () => {
     browser = await puppeteer.launch({
       devtools: false,
-      headless: true,
+      headless: false,
       args: ['--no-sandbox']
     })
     page = await browser.newPage()
+<<<<<<< HEAD
+=======
+    server = await newServer(`{"last": "3843.95"}`)
+
+    page.on('console', msg => console.log('PAGE LOG:', msg.text()))
+>>>>>>> Add scrape command for pulling up matches, add console
   })
 
   afterAll(async () => {
@@ -42,6 +50,25 @@ describe('End to end', () => {
     await expect(page).toClick('#created-job')
     await expect(page).toMatch('Job Spec Detail')
     await expect(page).toClick('button', { text: 'Run' })
+<<<<<<< HEAD
     await expect(page).toMatch(/success.+run/i)
+=======
+    await expect(page).toMatch(/success.+?run/i)
+
+    // Transaction ID should eventually be coded on page like so:
+    //    {"result":"0x6736ad06da823692cc66c5a51032c4aed83bfca9778eb1a7ad24de67f3f472fc"}
+    const match = await scrape(page, /"result":"(0x[0-9a-f]{64})"/)
+    const txHash = match[1]
+
+    // Navigate to transactions page
+    await expect(page).toClick('button', { 'aria-label': 'open drawer' })
+    await expect(page).toClick('span', { text: 'Transactions' })
+    await expect(page).toMatchElement('h4', { text: 'Transactions' })
+    await expect(page).toMatchElement('p', { text: txHash })
+
+    // Navigate to transaction page and check for the transaction
+    await expect(page).toClick('a', { text: txHash })
+    await scrape(page, txHash)
+>>>>>>> Add scrape command for pulling up matches, add console
   })
 })

--- a/e2e/createAndRunJob.test.js
+++ b/e2e/createAndRunJob.test.js
@@ -2,6 +2,10 @@ const puppeteer = require('puppeteer')
 const expect = require('expect-puppeteer')
 const { newServer } = require('./support/server.js')
 const { scrape } = require('./support/scrape.js')
+const {
+  clickNewJobButton,
+  clickTransactionsMenuItem
+} = require('./support/helpers.js')
 
 describe('End to end', () => {
   let browser, page, server
@@ -37,8 +41,7 @@ describe('End to end', () => {
     await expect(page).toMatch('Jobs')
 
     // Create Job
-    await page.waitFor(500)
-    await expect(page).toClick('a > span', { text: 'New Job' })
+    await clickNewJobButton(page)
     await expect(page).toMatchElement('h5', { text: 'New Job' })
 
     const jobJson = `{
@@ -61,7 +64,7 @@ describe('End to end', () => {
     const txHash = match[1]
 
     // Navigate to transactions page
-    await expect(page).toClick('li > a', { text: 'Transactions' })
+    await clickTransactionsMenuItem(page)
     await expect(page).toMatchElement('h4', { text: 'Transactions' })
     await expect(page).toMatchElement('p', { text: txHash })
 

--- a/e2e/createAndRunJob.test.js
+++ b/e2e/createAndRunJob.test.js
@@ -4,24 +4,23 @@ const { newServer } = require('./support/server.js')
 const { scrape } = require('./support/scrape.js')
 
 describe('End to end', () => {
-  let browser, page
+  let browser, page, server
   beforeAll(async () => {
+    jest.setTimeout(30000)
+
     browser = await puppeteer.launch({
       devtools: false,
       headless: true,
       args: ['--no-sandbox']
     })
     page = await browser.newPage()
-<<<<<<< HEAD
-=======
     server = await newServer(`{"last": "3843.95"}`)
 
     page.on('console', msg => console.log('PAGE LOG:', msg.text()))
->>>>>>> Add scrape command for pulling up matches, add console
   })
 
   afterAll(async () => {
-    await browser.close()
+    return Promise.all([browser.close(), server.close()])
   })
 
   it('creates a job that runs', async () => {
@@ -50,9 +49,6 @@ describe('End to end', () => {
     await expect(page).toClick('#created-job')
     await expect(page).toMatch('Job Spec Detail')
     await expect(page).toClick('button', { text: 'Run' })
-<<<<<<< HEAD
-    await expect(page).toMatch(/success.+run/i)
-=======
     await expect(page).toMatch(/success.+?run/i)
 
     // Transaction ID should eventually be coded on page like so:
@@ -62,13 +58,15 @@ describe('End to end', () => {
 
     // Navigate to transactions page
     await expect(page).toClick('button', { 'aria-label': 'open drawer' })
-    await expect(page).toClick('span', { text: 'Transactions' })
-    await expect(page).toMatchElement('h4', { text: 'Transactions' })
+    await expect(page).toClick('span', { text: 'Transactions', timeout: 30000 })
+    await expect(page).toMatchElement('h4', {
+      text: 'Transactions',
+      timeout: 30000
+    })
     await expect(page).toMatchElement('p', { text: txHash })
 
     // Navigate to transaction page and check for the transaction
     await expect(page).toClick('a', { text: txHash })
     await scrape(page, txHash)
->>>>>>> Add scrape command for pulling up matches, add console
   })
 })

--- a/e2e/createAndRunJob.test.js
+++ b/e2e/createAndRunJob.test.js
@@ -8,7 +8,7 @@ describe('End to end', () => {
   beforeAll(async () => {
     browser = await puppeteer.launch({
       devtools: false,
-      headless: false,
+      headless: true,
       args: ['--no-sandbox']
     })
     page = await browser.newPage()

--- a/e2e/createAndRunJob.test.js
+++ b/e2e/createAndRunJob.test.js
@@ -6,7 +6,8 @@ const { scrape } = require('./support/scrape.js')
 describe('End to end', () => {
   let browser, page, server
   beforeAll(async () => {
-    jest.setTimeout(60000)
+    jest.setTimeout(30000)
+    expect.setDefaultOptions({ timeout: 3000 })
 
     browser = await puppeteer.launch({
       devtools: false,

--- a/e2e/createAndRunJob.test.js
+++ b/e2e/createAndRunJob.test.js
@@ -8,6 +8,9 @@ const {
   clickTransactionsMenuItem
 } = require('./support/helpers.js')
 
+const AVERAGE_CLIENT_WIDTH = 1366
+const AVERAGE_CLIENT_HEIGHT = 768
+
 describe('End to end', () => {
   let browser, page, server
   beforeAll(async () => {
@@ -20,7 +23,10 @@ describe('End to end', () => {
       args: ['--no-sandbox']
     })
     page = await browser.newPage()
-    await page.setViewport({ width: 1366, height: 768 })
+    await page.setViewport({
+      width: AVERAGE_CLIENT_WIDTH,
+      height: AVERAGE_CLIENT_HEIGHT
+    })
 
     server = await newServer(`{"last": "3843.95"}`)
 

--- a/e2e/createAndRunJob.test.js
+++ b/e2e/createAndRunJob.test.js
@@ -37,6 +37,7 @@ describe('End to end', () => {
     await expect(page).toMatch('Jobs')
 
     // Create Job
+    await page.waitFor(500)
     await expect(page).toClick('a > span', { text: 'New Job' })
     await expect(page).toMatchElement('h5', { text: 'New Job' })
 

--- a/e2e/createAndRunJob.test.js
+++ b/e2e/createAndRunJob.test.js
@@ -15,6 +15,8 @@ describe('End to end', () => {
       args: ['--no-sandbox']
     })
     page = await browser.newPage()
+    await page.setViewport({ width: 1366, height: 768 })
+
     server = await newServer(`{"last": "3843.95"}`)
 
     page.on('console', msg => console.log('PAGE LOG:', msg.text()))

--- a/e2e/createAndRunJob.test.js
+++ b/e2e/createAndRunJob.test.js
@@ -49,10 +49,23 @@ describe('End to end', () => {
     await clickNewJobButton(page)
     await expect(page).toMatchElement('h5', { text: 'New Job' })
 
+    // prettier-ignore
     const jobJson = `{
       "initiators": [{"type": "web"}],
-      "tasks": [{"type": "NoOp"}]
+	    "tasks": [
+        {"type": "httpget", "params": {"get": "http://localhost:${server.port}"}},
+        {"type": "jsonparse", "params": {"path": ["last"]}},
+        {
+          "type": "ethtx",
+          "confirmations": 0,
+          "params": {
+            "address": "0xaa664fa2fdc390c662de1dbacf1218ac6e066ae6",
+            "functionSelector": "setBytes(bytes32,bytes)"
+          }
+        }
+      ]
     }`
+
     await expect(page).toFill('form textarea', jobJson)
     await expect(page).toClick('button', { text: 'Create Job' })
     await expect(page).toMatch(/success.+job/i)

--- a/e2e/support/helpers.js
+++ b/e2e/support/helpers.js
@@ -1,7 +1,11 @@
 module.exports = {
+  clickLink: async (page, title) => {
+    return expect(page).toClick('a', { text: title })
+  },
+
   clickNewJobButton: async page => {
     await page.waitFor(500)
-    return expect(page).toClick('a', { text: 'New Job' })
+    return this.clickLink(page, 'New Job')
   },
 
   clickTransactionsMenuItem: async page => {

--- a/e2e/support/helpers.js
+++ b/e2e/support/helpers.js
@@ -1,0 +1,16 @@
+module.exports = {
+  clickNewJobButton: async page => {
+    await page.waitFor(500)
+    return expect(page).toClick('a', { text: 'New Job' })
+  },
+
+  clickTransactionsMenuItem: async page => {
+    return expect(page).toClick('li > a', { text: 'Transactions' })
+  },
+
+  signIn: async (page, email, password) => {
+    await expect(page).toFill('form input[id=email]', email)
+    await expect(page).toFill('form input[id=password]', 'twochains')
+    return expect(page).toClick('form button')
+  }
+}

--- a/e2e/support/helpers.js
+++ b/e2e/support/helpers.js
@@ -1,13 +1,15 @@
+const clickLink = async (page, title) => {
+  return expect(page).toClick('a', { text: title })
+}
+
 module.exports = {
-  clickLink: async (page, title) => {
-    return expect(page).toClick('a', { text: title })
-  },
+  clickLink: clickLink,
 
   clickNewJobButton: async page => {
     // XXX: This button doesn't do anything if you click it too quickly, so for
     // now, add a small delay
     await page.waitFor(500)
-    return this.clickLink(page, 'New Job')
+    return clickLink(page, 'New Job')
   },
 
   clickTransactionsMenuItem: async page => {

--- a/e2e/support/helpers.js
+++ b/e2e/support/helpers.js
@@ -4,6 +4,8 @@ module.exports = {
   },
 
   clickNewJobButton: async page => {
+    // XXX: This button doesn't do anything if you click it too quickly, so for
+    // now, add a small delay
     await page.waitFor(500)
     return this.clickLink(page, 'New Job')
   },

--- a/e2e/support/scrape.js
+++ b/e2e/support/scrape.js
@@ -1,6 +1,7 @@
 const pollUntilTimeout = (interval, cb, ...args) => {
   return new Promise((resolve, reject) => {
     const timer = setInterval(async () => {
+      /* eslint-disable standard/no-callback-literal */
       const result = await cb(...args)
       if (result !== false) {
         clearInterval(timer)

--- a/e2e/support/scrape.js
+++ b/e2e/support/scrape.js
@@ -1,0 +1,36 @@
+const pollUntilTimeout = (interval, cb, ...args) => {
+  return new Promise((resolve, reject) => {
+    const timer = setInterval(async () => {
+      const result = await cb(...args)
+      if (result !== false) {
+        clearInterval(timer)
+        resolve(result)
+      }
+    }, interval)
+  })
+}
+
+module.exports = {
+  // Scrape matches against the page content and returns the match groups found
+  // if any, it will refresh the page until the match is found or timeout
+  // occurs.
+  scrape: async (page, regex) => {
+    let match = await pollUntilTimeout(
+      3000,
+      async page => {
+        const content = await page.content()
+        let match = content
+          .replace(/\s+/g, ' ')
+          .trim()
+          .match(regex)
+        if (match !== null) {
+          return match
+        }
+        page.reload()
+        return false
+      },
+      page
+    )
+    return match
+  }
+}

--- a/e2e/support/server.js
+++ b/e2e/support/server.js
@@ -1,0 +1,26 @@
+const net = require('net')
+
+module.exports = {
+  newServer: async response => {
+    const server = new net.Server(socket => {
+      socket.on('data', () => {
+        socket.write(`HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: ${response.length}
+
+${response}`)
+      })
+    })
+    server.on('close', () => {
+      server.unref()
+    })
+
+    const endpoint = await server.listen()
+    return {
+      port: endpoint.address().port,
+      close: () => {
+        return Promise.all([endpoint.close(), server.close()])
+      }
+    }
+  }
+}

--- a/e2e/support/server.js
+++ b/e2e/support/server.js
@@ -9,6 +9,7 @@ Content-Type: application/json
 Content-Length: ${response.length}
 
 ${response}`)
+        socket.end()
       })
     })
     server.on('close', () => {

--- a/integration/common
+++ b/integration/common
@@ -161,16 +161,20 @@ launch_echo_server() {
   title "Echo server is running."
 }
 
+print_logs() {
+  for log in $(find "$SRCROOT/integration" -maxdepth 1 -type f -iname '*.log'); do
+    heading "$log"
+    cat $log
+  done
+}
+
 exit_handler() {
   errno=$?
   # Print all the logs if the test fails
   if [ $errno -ne 0 ]; then
     title "ABORTING TEST"
     printf -- "Exited with code $errno\n"
-    for log in $(find "$SRCROOT/integration" -maxdepth 1 -type f -iname '*.log'); do
-      heading "$log"
-      cat $log
-    done
+    print_logs
   fi
   exit $errno
 }

--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -492,7 +492,7 @@ func (txm *EthTxManager) handleUnconfirmed(
 		return nil, txm.bumpGas(txAttempt, blkNum)
 	}
 	logger.Infow(
-		fmt.Sprintf("Unconfirmed TX %d has not yet met gas bump threshold", txAttempt.TxID),
+		fmt.Sprintf("Unconfirmed TX %d has not met gas bump threshold", txAttempt.TxID),
 		logParams...,
 	)
 	return nil, nil


### PR DESCRIPTION
Added a test to click through to the transactions page and assert that a transaction ID associated with the triggered job is shown.

  * Adds a server that responds like a bridge would to the test
  * Adds a scraping command which matches on a page, reloading and returns the match group
  * Adds printing of console errors to output as part of test, hopefully to motivate us to remove or fix console errors in our app

Note: I haven't been able to figure out a workaround for the delay, which accounts for some "delay" before the click handler is mounted. If I click on "New Job" too quickly, it does nothing.