### PR TITLE
Features/ability to archive jobs

### DIFF
--- a/cmd/app.go
+++ b/cmd/app.go
@@ -93,6 +93,11 @@ func NewApp(client *Client) *cli.App {
 			Action:  client.CreateJobSpec,
 		},
 		{
+			Name:   "archivejob",
+			Usage:  "Archive job and all associated runs",
+			Action: client.ArchiveJobSpec,
+		},
+		{
 			Name:    "run",
 			Aliases: []string{"r"},
 			Usage:   "Begin job run for specid",

--- a/cmd/local_client_test.go
+++ b/cmd/local_client_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/smartcontractkit/chainlink/cmd"
 	"github.com/smartcontractkit/chainlink/internal/cltest"
@@ -44,6 +45,7 @@ func TestClient_RunNodeShowsEnv(t *testing.T) {
 	eth.Register("eth_getTransactionCount", `0x1`)
 
 	assert.NoError(t, client.RunNode(c))
+	<-time.After(time.Second) // wait for client.RunNode to connect
 	logger.Sync()
 	logs, err := cltest.ReadLogs(app)
 	assert.NoError(t, err)

--- a/cmd/remote_client.go
+++ b/cmd/remote_client.go
@@ -119,6 +119,22 @@ func (cli *Client) CreateJobSpec(c *clipkg.Context) error {
 	return cli.renderAPIResponse(resp, &js)
 }
 
+// ArchiveJobSpec soft deletes a job and its associated runs.
+func (cli *Client) ArchiveJobSpec(c *clipkg.Context) error {
+	if !c.Args().Present() {
+		return cli.errorOut(errors.New("Must pass the job id to be archived"))
+	}
+	resp, err := cli.HTTP.Delete("/v2/specs/" + c.Args().First())
+	if err != nil {
+		return cli.errorOut(err)
+	}
+	_, err = cli.parseResponse(resp)
+	if err != nil {
+		return cli.errorOut(err)
+	}
+	return nil
+}
+
 // CreateJobRun creates job run based on SpecID and optional JSON
 func (cli *Client) CreateJobRun(c *clipkg.Context) error {
 	if !c.Args().Present() {

--- a/cmd/remote_client_test.go
+++ b/cmd/remote_client_test.go
@@ -197,6 +197,27 @@ func TestClient_CreateJobSpec(t *testing.T) {
 	}
 }
 
+func TestClient_ArchiveJobSpec(t *testing.T) {
+	t.Parallel()
+
+	app, cleanup := cltest.NewApplication()
+	defer cleanup()
+
+	job := cltest.NewJob()
+	require.NoError(t, app.Store.CreateJob(&job))
+
+	client, _ := app.NewClientAndRenderer()
+
+	set := flag.NewFlagSet("archive", 0)
+	set.Parse([]string{job.ID})
+	c := cli.NewContext(nil, set, nil)
+
+	require.NoError(t, client.ArchiveJobSpec(c))
+
+	jobs := cltest.AllJobs(app.Store)
+	require.Len(t, jobs, 0)
+}
+
 func TestClient_CreateJobSpec_JSONAPIErrors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -1017,3 +1017,7 @@ func GetLastTxAttempt(t *testing.T, store *strpkg.Store) models.TxAttempt {
 	require.NotEqual(t, 0, count)
 	return attempt
 }
+
+func JustError(_ interface{}, err error) error {
+	return err
+}

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -704,7 +704,7 @@ func WaitForJobRunStatus(
 	t.Helper()
 	var err error
 	gomega.NewGomegaWithT(t).Eventually(func() models.RunStatus {
-		jr, err = store.FindJobRun(jr.ID)
+		jr, err = store.Unscoped().FindJobRun(jr.ID)
 		assert.NoError(t, err)
 		return jr.Status
 	}).Should(gomega.Equal(status))

--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -553,6 +553,39 @@ type MockCronEntry struct {
 	Function func()
 }
 
+// ControlledCron holds a list of funcs, which a developer can then
+// manually trigger.
+type ControlledCron struct {
+	funcs []func()
+}
+
+// NewControlledCron returns an instance of a developer controlled cron.
+func NewControlledCron() *ControlledCron {
+	return &ControlledCron{
+		funcs: []func(){},
+	}
+}
+
+// Start is a noop.
+func (*ControlledCron) Start() {}
+
+// Stop is a noop.
+func (*ControlledCron) Stop() {}
+
+// AddFunc adds the function to the list of functions to run
+// when manually triggered.
+func (c *ControlledCron) AddFunc(schd string, fn func()) error {
+	c.funcs = append(c.funcs, fn)
+	return nil
+}
+
+// RunFuncs will manually invoke the functions added to this Cron.
+func (c *ControlledCron) RunFuncs() {
+	for _, f := range c.funcs {
+		f()
+	}
+}
+
 // MockHeadTrackable allows you to mock HeadTrackable
 type MockHeadTrackable struct {
 	connectedCount    int32

--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -553,39 +553,6 @@ type MockCronEntry struct {
 	Function func()
 }
 
-// ControlledCron holds a list of funcs, which a developer can then
-// manually trigger.
-type ControlledCron struct {
-	funcs []func()
-}
-
-// NewControlledCron returns an instance of a developer controlled cron.
-func NewControlledCron() *ControlledCron {
-	return &ControlledCron{
-		funcs: []func(){},
-	}
-}
-
-// Start is a noop.
-func (*ControlledCron) Start() {}
-
-// Stop is a noop.
-func (*ControlledCron) Stop() {}
-
-// AddFunc adds the function to the list of functions to run
-// when manually triggered.
-func (c *ControlledCron) AddFunc(schd string, fn func()) error {
-	c.funcs = append(c.funcs, fn)
-	return nil
-}
-
-// RunFuncs will manually invoke the functions added to this Cron.
-func (c *ControlledCron) RunFuncs() {
-	for _, f := range c.funcs {
-		f()
-	}
-}
-
 // MockHeadTrackable allows you to mock HeadTrackable
 type MockHeadTrackable struct {
 	connectedCount    int32

--- a/main_test.go
+++ b/main_test.go
@@ -44,6 +44,7 @@ func ExampleRun() {
 	//      jobspecs, jobs, j, specs  Get all jobs
 	//      show, s                   Show a specific job
 	//      create, c                 Create job spec from JSON
+	//      archivejob                Archive job and all associated runs
 	//      run, r                    Begin job run for specid
 	//      showrun, sr               Show a job run for a RunID
 	//      import, i                 Import a key file to use with the node

--- a/services/application.go
+++ b/services/application.go
@@ -23,6 +23,7 @@ type Application interface {
 	GetStore() *store.Store
 	WakeSessionReaper()
 	AddJob(job models.JobSpec) error
+	ArchiveJob(ID string) error
 	AddServiceAgreement(*models.ServiceAgreement) error
 	AddAdapter(bt *models.BridgeType) error
 	RemoveAdapter(bt *models.BridgeType) error
@@ -136,6 +137,12 @@ func (app *ChainlinkApplication) AddJob(job models.JobSpec) error {
 
 	app.Scheduler.AddJob(job)
 	return app.JobSubscriber.AddJob(job, nil) // nil for latest
+}
+
+// ArchiveJob silences the job from the system, preventing future job runs.
+func (app *ChainlinkApplication) ArchiveJob(ID string) error {
+	_ = app.JobSubscriber.RemoveJob(ID)
+	return app.Store.ArchiveJob(ID)
 }
 
 // AddServiceAgreement adds a Service Agreement which includes a job that needs

--- a/services/application.go
+++ b/services/application.go
@@ -229,7 +229,7 @@ func newPendingConnectionResumer(store *store.Store) *pendingConnectionResumer {
 }
 
 func (p *pendingConnectionResumer) Connect(head *models.Head) error {
-	pendingRuns, err := p.store.JobRunsWithStatus(models.RunStatusPendingConnection)
+	pendingRuns, err := p.store.UnscopedJobRunsWithStatus(models.RunStatusPendingConnection)
 	if err != nil {
 		return multierr.Append(errors.New("error resuming pending connections"), err)
 	}

--- a/services/application.go
+++ b/services/application.go
@@ -236,7 +236,7 @@ func (p *pendingConnectionResumer) Connect(head *models.Head) error {
 
 	var merr error
 	for _, jr := range pendingRuns {
-		err := p.resumer(&jr, p.store)
+		err := p.resumer(&jr, p.store.Unscoped())
 		if err != nil {
 			merr = multierr.Append(merr, err)
 		}

--- a/services/application_test.go
+++ b/services/application_test.go
@@ -47,7 +47,7 @@ func TestChainlinkApplication_AddJob(t *testing.T) {
 	app.AddJob(cltest.NewJob())
 }
 
-func TestChainlinkApplication_resumesPendingConnection(t *testing.T) {
+func TestChainlinkApplication_resumesPendingConnection_Happy(t *testing.T) {
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 	store := app.Store
@@ -57,7 +57,23 @@ func TestChainlinkApplication_resumesPendingConnection(t *testing.T) {
 
 	jr := cltest.CreateJobRunWithStatus(store, j, models.RunStatusPendingConnection)
 
-	require.NoError(t, app.Start())
+	require.NoError(t, app.StartAndConnect())
+	_ = cltest.WaitForJobRunToComplete(t, store, jr)
+}
+
+func TestChainlinkApplication_resumesPendingConnection_Archived(t *testing.T) {
+	app, cleanup := cltest.NewApplication()
+	defer cleanup()
+	store := app.Store
+
+	j := cltest.NewJobWithWebInitiator()
+	require.NoError(t, store.CreateJob(&j))
+
+	jr := cltest.CreateJobRunWithStatus(store, j, models.RunStatusPendingConnection)
+
+	require.NoError(t, store.ArchiveJob(j.ID))
+
+	require.NoError(t, app.StartAndConnect())
 	_ = cltest.WaitForJobRunToComplete(t, store, jr)
 }
 

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -87,7 +87,7 @@ func (rm *jobRunner) resumeRunsSinceLastShutdown() error {
 	// Do all querying of run statuses since last shutdown before enqueuing
 	// runs in progress and asleep, to prevent the following race condition:
 	// 1. resume sleep, 2. awake from sleep, 3. in progress, 4. resume in progress (double enqueued).
-	resumableRuns, err := rm.store.JobRunsWithStatus(models.RunStatusInProgress, models.RunStatusPendingSleep)
+	resumableRuns, err := rm.store.UnscopedJobRunsWithStatus(models.RunStatusInProgress, models.RunStatusPendingSleep)
 	if err != nil {
 		return err
 	}

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -94,7 +94,7 @@ func (rm *jobRunner) resumeRunsSinceLastShutdown() error {
 	}
 
 	for _, run := range models.JobRunsWithStatus(resumableRuns, models.RunStatusPendingSleep) {
-		if err := QueueSleepingTask(&run, rm.store); err != nil {
+		if err := QueueSleepingTask(&run, rm.store.Unscoped()); err != nil {
 			logger.Errorw("Error resuming sleeping job", "error", err)
 		}
 	}

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -35,7 +35,8 @@ type jobRunner struct {
 // NewJobRunner initializes a JobRunner.
 func NewJobRunner(str *store.Store) JobRunner {
 	return &jobRunner{
-		store:   str,
+		// Unscoped allows the processing of runs that are soft deleted asynchronously
+		store:   str.Unscoped(),
 		workers: make(map[string]chan struct{}),
 	}
 }

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"fmt"
 	"sync"
 
 	"github.com/smartcontractkit/chainlink/logger"
@@ -14,19 +15,24 @@ import (
 type JobSubscriber interface {
 	store.HeadTrackable
 	AddJob(job models.JobSpec, bn *models.Head) error
+	RemoveJob(ID string) error
 	Jobs() []models.JobSpec
 }
 
 // jobSubscriber implementation
 type jobSubscriber struct {
 	store            *store.Store
-	jobSubscriptions []JobSubscription
-	jobsMutex        sync.RWMutex
+	jobSubscriptions map[string]JobSubscription
+	jobsMutex        *sync.RWMutex
 }
 
 // NewJobSubscriber returns a new job subscriber.
 func NewJobSubscriber(store *store.Store) JobSubscriber {
-	return &jobSubscriber{store: store}
+	return &jobSubscriber{
+		store:            store,
+		jobSubscriptions: map[string]JobSubscription{},
+		jobsMutex:        &sync.RWMutex{},
+	}
 }
 
 // AddJob subscribes to ethereum log events for each "runlog" and "ethlog"
@@ -44,13 +50,26 @@ func (js *jobSubscriber) AddJob(job models.JobSpec, bn *models.Head) error {
 	return nil
 }
 
+// RemoveJob unsubscribes the job from a log subscription to trigger runs.
+func (js *jobSubscriber) RemoveJob(ID string) error {
+	js.jobsMutex.Lock()
+	sub, ok := js.jobSubscriptions[ID]
+	delete(js.jobSubscriptions, ID)
+	js.jobsMutex.Unlock()
+	if !ok {
+		return fmt.Errorf("JobSubscriber#RemoveJob: job %s not found", ID)
+	}
+	sub.Unsubscribe()
+	return nil
+}
+
 // Jobs returns the jobs being listened to.
 func (js *jobSubscriber) Jobs() []models.JobSpec {
 	js.jobsMutex.RLock()
 	defer js.jobsMutex.RUnlock()
 	var jobs []models.JobSpec
-	for _, js := range js.jobSubscriptions {
-		jobs = append(jobs, js.Job)
+	for _, sub := range js.jobSubscriptions {
+		jobs = append(jobs, sub.Job)
 	}
 	return jobs
 }
@@ -58,7 +77,7 @@ func (js *jobSubscriber) Jobs() []models.JobSpec {
 func (js *jobSubscriber) addSubscription(sub JobSubscription) {
 	js.jobsMutex.Lock()
 	defer js.jobsMutex.Unlock()
-	js.jobSubscriptions = append(js.jobSubscriptions, sub)
+	js.jobSubscriptions[sub.Job.ID] = sub
 }
 
 // Connect connects the jobs to the ethereum node by creating corresponding subscriptions.
@@ -79,7 +98,7 @@ func (js *jobSubscriber) Disconnect() {
 	for _, sub := range js.jobSubscriptions {
 		sub.Unsubscribe()
 	}
-	js.jobSubscriptions = []JobSubscription{}
+	js.jobSubscriptions = map[string]JobSubscription{}
 }
 
 // OnNewHead resumes all pending job runs based on the new head activity.

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -84,7 +84,7 @@ func (js *jobSubscriber) Disconnect() {
 
 // OnNewHead resumes all pending job runs based on the new head activity.
 func (js *jobSubscriber) OnNewHead(head *models.Head) {
-	pendingRuns, err := js.store.JobRunsWithStatus(models.RunStatusPendingConfirmations)
+	pendingRuns, err := js.store.UnscopedJobRunsWithStatus(models.RunStatusPendingConfirmations)
 	if err != nil {
 		logger.Error("error fetching pending job runs:", err.Error())
 	}

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -95,7 +95,7 @@ func (js *jobSubscriber) OnNewHead(head *models.Head) {
 		"pending_run_count", len(pendingRuns),
 	)
 	for _, jr := range pendingRuns {
-		err := ResumeConfirmingTask(&jr, js.store, height)
+		err := ResumeConfirmingTask(&jr, js.store.Unscoped(), height)
 		if err != nil {
 			logger.Error("JobSubscriber.OnNewHead: ", err.Error())
 		}

--- a/services/job_subscriber_test.go
+++ b/services/job_subscriber_test.go
@@ -1,6 +1,7 @@
 package services_test
 
 import (
+	"fmt"
 	"math/big"
 	"testing"
 
@@ -158,20 +159,32 @@ func TestJobSubscriber_OnNewHead_OnlyResumePendingConfirmations(t *testing.T) {
 	t.Parallel()
 
 	block := cltest.NewBlockHeader(10)
+	prettyLabel := func(archived bool, rs models.RunStatus) string {
+		if archived {
+			return fmt.Sprintf("archived:%s", string(rs))
+		}
+		return string(rs)
+	}
 
 	tests := []struct {
 		status   models.RunStatus
+		archived bool
 		wantSend bool
 	}{
-		{models.RunStatusPendingConfirmations, true},
-		{models.RunStatusInProgress, false},
-		{models.RunStatusPendingBridge, false},
-		{models.RunStatusPendingSleep, false},
-		{models.RunStatusCompleted, false},
+		{models.RunStatusPendingConfirmations, false, true},
+		{models.RunStatusPendingConfirmations, true, true},
+		{models.RunStatusInProgress, false, false},
+		{models.RunStatusInProgress, true, false},
+		{models.RunStatusPendingBridge, false, false},
+		{models.RunStatusPendingBridge, true, false},
+		{models.RunStatusPendingSleep, false, false},
+		{models.RunStatusPendingSleep, true, false},
+		{models.RunStatusCompleted, false, false},
+		{models.RunStatusCompleted, true, false},
 	}
 
 	for _, test := range tests {
-		t.Run(string(test.status), func(t *testing.T) {
+		t.Run(prettyLabel(test.archived, test.status), func(t *testing.T) {
 			store, js, cleanup := cltest.NewJobSubscriber()
 			defer cleanup()
 
@@ -183,7 +196,11 @@ func TestJobSubscriber_OnNewHead_OnlyResumePendingConfirmations(t *testing.T) {
 			initr := job.Initiators[0]
 			run := job.NewRun(initr)
 			run.ApplyResult(models.RunResult{Status: test.status})
-			assert.Nil(t, store.CreateJobRun(&run))
+			require.NoError(t, store.CreateJobRun(&run))
+
+			if test.archived {
+				require.NoError(t, store.ArchiveJob(job.ID))
+			}
 
 			js.OnNewHead(block.ToHead())
 			if test.wantSend {

--- a/services/mock_services/job_subscriber.go
+++ b/services/mock_services/job_subscriber.go
@@ -89,3 +89,15 @@ func (m *MockJobSubscriber) OnNewHead(arg0 *models.Head) {
 func (mr *MockJobSubscriberMockRecorder) OnNewHead(arg0 interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "OnNewHead", reflect.TypeOf((*MockJobSubscriber)(nil).OnNewHead), arg0)
 }
+
+// RemoveJob mocks base method
+func (m *MockJobSubscriber) RemoveJob(arg0 string) error {
+	ret := m.ctrl.Call(m, "RemoveJob", arg0)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveJob indicates an expected call of RemoveJob
+func (mr *MockJobSubscriberMockRecorder) RemoveJob(arg0 interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveJob", reflect.TypeOf((*MockJobSubscriber)(nil).RemoveJob), arg0)
+}

--- a/services/scheduler_test.go
+++ b/services/scheduler_test.go
@@ -130,7 +130,7 @@ func TestRecurring_AddJob_Archived(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 	r := services.NewRecurring(store)
-	cron := cltest.NewControlledCron()
+	cron := cltest.NewMockCron()
 	r.Cron = cron
 	defer r.Stop()
 
@@ -138,13 +138,13 @@ func TestRecurring_AddJob_Archived(t *testing.T) {
 	require.NoError(t, store.CreateJob(&job))
 	r.AddJob(job)
 
-	cron.RunFuncs()
+	cron.RunEntries()
 	count, err := store.Unscoped().JobRunsCountFor(job.ID)
 	require.NoError(t, err)
 	assert.Equal(t, 1, count)
 
 	require.NoError(t, store.ArchiveJob(job.ID))
-	cron.RunFuncs()
+	cron.RunEntries()
 
 	count, err = store.Unscoped().JobRunsCountFor(job.ID)
 	require.NoError(t, err)

--- a/services/subscription.go
+++ b/services/subscription.go
@@ -160,7 +160,7 @@ func runJob(store *strpkg.Store, le models.LogRequest, data models.JSON) {
 		logger.Errorw(err.Error(), le.ForLogger()...)
 	}
 
-	_, err = ExecuteJob(le.GetJobSpec(), le.GetInitiator(), input, le.BlockNumber(), store)
+	_, err = ExecuteJob(le.GetJobSpec(), le.GetInitiator(), input, le.BlockNumber(), store.Unscoped())
 	if err != nil {
 		logger.Errorw(err.Error(), le.ForLogger()...)
 	}

--- a/store/migrations/migrate.go
+++ b/store/migrations/migrate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink/store/migrations/migration1549496047"
 	"github.com/smartcontractkit/chainlink/store/migrations/migration1551816486"
 	"github.com/smartcontractkit/chainlink/store/migrations/migration1551895034"
+	"github.com/smartcontractkit/chainlink/store/migrations/migration1552418531"
 	"github.com/smartcontractkit/chainlink/store/orm"
 	"go.uber.org/multierr"
 )
@@ -19,6 +20,7 @@ func init() {
 	registerMigration(migration1549496047.Migration{})
 	registerMigration(migration1551816486.Migration{})
 	registerMigration(migration1551895034.Migration{})
+	registerMigration(migration1552418531.Migration{})
 }
 
 type migration interface {

--- a/store/migrations/migrate_test.go
+++ b/store/migrations/migrate_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink/store/migrations/migration1551816486"
 	"github.com/smartcontractkit/chainlink/store/migrations/migration1551895034"
 	"github.com/smartcontractkit/chainlink/store/migrations/migration1551895034/old"
+	"github.com/smartcontractkit/chainlink/store/migrations/migration1552418531"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/store/orm"
 	"github.com/stretchr/testify/assert"
@@ -209,4 +210,38 @@ func TestMigrate1551895034(t *testing.T) {
 		t,
 		hash.String(),
 		retrieved.Hash().Hex())
+}
+
+func TestMigrate1552418531(t *testing.T) {
+	migrations.ExportedClearRegisteredMigrations()
+
+	orm, cleanup := bootstrapORM(t)
+	defer cleanup()
+
+	// seed w old schema
+	err := orm.DB.Exec(`
+		CREATE TABLE "job_specs" ("id" varchar(255) NOT NULL,"created_at" datetime,"start_at" datetime,"end_at" datetime, PRIMARY KEY ("id"));
+		INSERT INTO "job_specs" VALUES ("testjobspec", CURRENT_TIMESTAMP, NULL, NULL);
+	`).Error
+	require.NoError(t, err)
+
+	// migrate
+	tm := &migration1552418531.Migration{}
+	migrations.ExportedRegisterMigration(tm)
+
+	require.NoError(t, migrations.Migrate(orm))
+
+	retrieved := models.JobSpec{}
+	err = orm.DB.First(&retrieved).Error
+	require.NoError(t, err)
+
+	require.Equal(t, false, retrieved.DeletedAt.Valid)
+
+	err = orm.DB.Delete(&retrieved).Error
+	require.NoError(t, err)
+	err = orm.DB.First(&retrieved).Error
+	require.Error(t, err)
+	err = orm.DB.Unscoped().First(&retrieved).Error
+	require.NoError(t, err)
+	require.Equal(t, true, retrieved.DeletedAt.Valid)
 }

--- a/store/migrations/migrate_test.go
+++ b/store/migrations/migrate_test.go
@@ -220,8 +220,8 @@ func TestMigrate1552418531(t *testing.T) {
 
 	// seed w old schema
 	err := orm.DB.Exec(`
-		CREATE TABLE "job_specs" ("id" varchar(255) NOT NULL,"created_at" datetime,"start_at" datetime,"end_at" datetime, PRIMARY KEY ("id"));
-		INSERT INTO "job_specs" VALUES ("testjobspec", CURRENT_TIMESTAMP, NULL, NULL);
+		CREATE TABLE "job_specs" ("id" varchar(255) NOT NULL,"created_at" timestamp,"start_at" timestamp,"end_at" timestamp, PRIMARY KEY ("id"));
+		INSERT INTO "job_specs" VALUES ('testjobspec', CURRENT_TIMESTAMP, NULL, NULL);
 	`).Error
 	require.NoError(t, err)
 

--- a/store/migrations/migration1552418531/migrate.go
+++ b/store/migrations/migration1552418531/migrate.go
@@ -1,0 +1,39 @@
+package migration1552418531
+
+import (
+	"github.com/smartcontractkit/chainlink/store/orm"
+	"go.uber.org/multierr"
+	"gopkg.in/guregu/null.v3"
+)
+
+type Migration struct{}
+
+func (m Migration) Timestamp() string {
+	return "1552418531"
+}
+
+// Migrate creates a new bridge_types table with the correct primary key
+// because sqlite does not allow you to modify the primary key
+// after table creation.
+func (m Migration) Migrate(orm *orm.ORM) error {
+	return multierr.Combine(
+		orm.DB.AutoMigrate(&initiator{}).Error,
+		orm.DB.AutoMigrate(&jobSpec{}).Error,
+		orm.DB.AutoMigrate(&jobRun{}).Error,
+	)
+}
+
+type jobSpec struct {
+	ID        string    `json:"id,omitempty" gorm:"primary_key;not null"`
+	DeletedAt null.Time `json:"-" gorm:"index"`
+}
+
+type jobRun struct {
+	ID        string    `json:"id" gorm:"primary_key;not null"`
+	DeletedAt null.Time `json:"-" gorm:"index"`
+}
+
+type initiator struct {
+	ID        uint      `json:"id" gorm:"primary_key;auto_increment"`
+	DeletedAt null.Time `json:"=" gorm:"index"`
+}

--- a/store/models/job_spec.go
+++ b/store/models/job_spec.go
@@ -26,6 +26,7 @@ type JobSpec struct {
 	Tasks      []TaskSpec  `json:"tasks"`
 	StartAt    null.Time   `json:"startAt" gorm:"index"`
 	EndAt      null.Time   `json:"endAt" gorm:"index"`
+	DeletedAt  null.Time   `json:"-" gorm:"index"`
 }
 
 // JobSpecRequest represents a schema for the incoming job spec request as used by the API.
@@ -182,6 +183,7 @@ type Initiator struct {
 	Type            string    `json:"type" gorm:"index;not null"`
 	CreatedAt       time.Time `gorm:"index"`
 	InitiatorParams `json:"params,omitempty"`
+	DeletedAt       null.Time `json:"-" gorm:"index"`
 }
 
 // InitiatorParams is a collection of the possible parameters that different

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -29,6 +29,7 @@ type JobRun struct {
 	ObservedHeight *Big      `json:"observedHeight" gorm:"type:varchar(255)"`
 	Overrides      RunResult `json:"overrides"`
 	OverridesID    uint      `json:"-"`
+	DeletedAt      null.Time `json:"-" gorm:"index"`
 }
 
 // GetID returns the ID of this structure for jsonapi serialization.

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -232,7 +232,7 @@ func (orm *ORM) convenientTransaction(callback func(*gorm.DB) error) error {
 // SaveJobRun updates UpdatedAt for a JobRun and saves it
 func (orm *ORM) SaveJobRun(run *models.JobRun) error {
 	return orm.convenientTransaction(func(dbtx *gorm.DB) error {
-		return dbtx.Save(run).Error
+		return dbtx.Unscoped().Omit("deleted_at").Save(run).Error
 	})
 }
 

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -815,6 +815,7 @@ func (orm *ORM) BulkDeleteRuns(bulkQuery *models.BulkDeleteRunRequest) error {
 	err = tx.
 		Where("status IN (?)", bulkQuery.Status.ToStrings()).
 		Where("updated_at < ?", bulkQuery.UpdatedBefore).
+		Unscoped().
 		Delete(&[]models.JobRun{}).
 		Error
 	if err != nil {

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -180,13 +180,23 @@ func (orm *ORM) preloadJobs() *gorm.DB {
 		})
 }
 
+func preloadTaskRuns(db *gorm.DB) *gorm.DB {
+	return db.
+		Preload("Result").
+		Preload("TaskSpec", func(db *gorm.DB) *gorm.DB {
+			return db.Unscoped()
+		})
+}
+
 func (orm *ORM) preloadJobRuns() *gorm.DB {
 	return orm.DB.
-		Preload("Initiator").
+		Preload("Initiator", func(db *gorm.DB) *gorm.DB {
+			return db.Unscoped()
+		}).
 		Preload("Overrides").
 		Preload("Result").
 		Preload("TaskRuns", func(db *gorm.DB) *gorm.DB {
-			return db.Set("gorm:auto_preload", true).Order("task_spec_id asc")
+			return preloadTaskRuns(db).Order("task_spec_id asc")
 		})
 }
 

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -332,10 +332,11 @@ func (orm *ORM) CreateServiceAgreement(sa *models.ServiceAgreement) error {
 	return orm.DB.Create(sa).Error
 }
 
-// JobRunsWithStatus returns the JobRuns which have the passed statuses.
-func (orm *ORM) JobRunsWithStatus(statuses ...models.RunStatus) ([]models.JobRun, error) {
+// UnscopedJobRunsWithStatus returns all JobRuns, including ones that have been
+// soft deleted, which have the passed statuses.
+func (orm *ORM) UnscopedJobRunsWithStatus(statuses ...models.RunStatus) ([]models.JobRun, error) {
 	runs := []models.JobRun{}
-	err := orm.preloadJobRuns().Where("status IN (?)", statuses).Find(&runs).Error
+	err := orm.preloadJobRuns().Unscoped().Where("status IN (?)", statuses).Find(&runs).Error
 	return runs, err
 }
 

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -346,7 +346,7 @@ func (orm *ORM) CreateServiceAgreement(sa *models.ServiceAgreement) error {
 // soft deleted, which have the passed statuses.
 func (orm *ORM) UnscopedJobRunsWithStatus(statuses ...models.RunStatus) ([]models.JobRun, error) {
 	runs := []models.JobRun{}
-	err := orm.preloadJobRuns().Unscoped().Where("status IN (?)", statuses).Find(&runs).Error
+	err := orm.Unscoped().preloadJobRuns().Where("status IN (?)", statuses).Find(&runs).Error
 	return runs, err
 }
 

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -95,6 +95,23 @@ func TestORM_ArchiveJob(t *testing.T) {
 	require.NoError(t, cltest.JustError(orm.FindJobRun(run.ID)))
 }
 
+func TestORM_CreateJobRun_ArchivesRunIfJobArchived(t *testing.T) {
+	t.Parallel()
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+
+	job := cltest.NewJobWithWebInitiator()
+	require.NoError(t, store.CreateJob(&job))
+
+	require.NoError(t, store.ArchiveJob(job.ID))
+
+	jr := job.NewRun(job.Initiators[0])
+	require.NoError(t, store.CreateJobRun(&jr))
+
+	require.Error(t, cltest.JustError(store.FindJobRun(jr.ID)))
+	require.NoError(t, cltest.JustError(store.Unscoped().FindJobRun(jr.ID)))
+}
+
 func TestORM_SaveJobRun_DoesNotSaveTaskSpec(t *testing.T) {
 	t.Parallel()
 	store, cleanup := cltest.NewStore()

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -59,10 +59,6 @@ func TestORM_CreateJob(t *testing.T) {
 	assert.Equal(t, j2.ID, j2.Initiators[0].JobSpecID)
 }
 
-func first(_ interface{}, err error) error {
-	return err
-}
-
 func TestORM_Unscoped(t *testing.T) {
 	t.Parallel()
 	store, cleanup := cltest.NewStore()
@@ -91,12 +87,12 @@ func TestORM_ArchiveJob(t *testing.T) {
 
 	require.NoError(t, store.ArchiveJob(job.ID))
 
-	require.Error(t, first(store.FindJob(job.ID)))
-	require.Error(t, first(store.FindJobRun(run.ID)))
+	require.Error(t, cltest.JustError(store.FindJob(job.ID)))
+	require.Error(t, cltest.JustError(store.FindJobRun(run.ID)))
 
 	orm := store.ORM.Unscoped()
-	require.NoError(t, first(orm.FindJob(job.ID)))
-	require.NoError(t, first(orm.FindJobRun(run.ID)))
+	require.NoError(t, cltest.JustError(orm.FindJob(job.ID)))
+	require.NoError(t, cltest.JustError(orm.FindJobRun(run.ID)))
 }
 
 func TestORM_SaveJobRun_DoesNotSaveTaskSpec(t *testing.T) {

--- a/store/store.go
+++ b/store/store.go
@@ -153,6 +153,14 @@ func (s *Store) Close() error {
 	return s.ORM.Close()
 }
 
+// Unscoped returns a shallow copy of the store, with an unscoped ORM allowing
+// one to work with soft deleted records.
+func (s *Store) Unscoped() *Store {
+	cpy := *s
+	cpy.ORM = cpy.ORM.Unscoped()
+	return &cpy
+}
+
 // AuthorizedUserWithSession will return the one API user if the Session ID exists
 // and hasn't expired, and update session's LastUsed field.
 func (s *Store) AuthorizedUserWithSession(sessionID string) (models.User, error) {

--- a/web/job_runs_controller_test.go
+++ b/web/job_runs_controller_test.go
@@ -144,6 +144,22 @@ func TestJobRunsController_Create_Success(t *testing.T) {
 	assert.Equal(t, "100", val)
 }
 
+func TestJobRunsController_Create_Archived(t *testing.T) {
+	t.Parallel()
+	app, cleanup := cltest.NewApplication()
+	app.Start()
+	defer cleanup()
+
+	j := cltest.NewJobWithWebInitiator()
+	require.NoError(t, app.Store.CreateJob(&j))
+	require.NoError(t, app.Store.ArchiveJob(j.ID))
+
+	client := app.NewHTTPClient()
+	resp, cleanup := client.Post("/v2/specs/"+j.ID+"/runs", bytes.NewBufferString(`{"result":"100"}`))
+	defer cleanup()
+	cltest.AssertServerResponse(t, resp, 404)
+}
+
 func TestJobRunsController_Create_EmptyBody(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication()

--- a/web/job_specs_controller.go
+++ b/web/job_specs_controller.go
@@ -88,7 +88,7 @@ func marshalSpecFromJSONAPI(j models.JobSpec, runs []models.JobRun) (*jsonapi.Do
 //  "<application>/specs/:SpecID"
 func (jsc *JobSpecsController) Destroy(c *gin.Context) {
 	id := c.Param("SpecID")
-	if err := jsc.App.GetStore().ArchiveJob(id); err == orm.ErrorNotFound {
+	if err := jsc.App.ArchiveJob(id); err == orm.ErrorNotFound {
 		publicError(c, http.StatusNotFound, errors.New("JobSpec not found"))
 	} else if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)

--- a/web/job_specs_controller.go
+++ b/web/job_specs_controller.go
@@ -82,3 +82,17 @@ func marshalSpecFromJSONAPI(j models.JobSpec, runs []models.JobRun) (*jsonapi.Do
 	doc, err := jsonapi.MarshalToStruct(p, nil)
 	return doc, err
 }
+
+// Destroy soft deletes a job spec.
+// Example:
+//  "<application>/specs/:SpecID"
+func (jsc *JobSpecsController) Destroy(c *gin.Context) {
+	id := c.Param("SpecID")
+	if err := jsc.App.GetStore().ArchiveJob(id); err == orm.ErrorNotFound {
+		publicError(c, http.StatusNotFound, errors.New("JobSpec not found"))
+	} else if err != nil {
+		c.AbortWithError(http.StatusInternalServerError, err)
+	} else {
+		c.JSON(http.StatusNoContent, nil)
+	}
+}

--- a/web/job_specs_controller_test.go
+++ b/web/job_specs_controller_test.go
@@ -377,3 +377,17 @@ func TestJobSpecsController_Show_Unauthenticated(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, 401, resp.StatusCode, "Response should be forbidden")
 }
+
+func TestJobSpecsController_Destroy(t *testing.T) {
+	t.Parallel()
+	app, cleanup := cltest.NewApplication()
+	defer cleanup()
+	client := app.NewHTTPClient()
+	job := cltest.NewJob()
+	require.NoError(t, app.Store.CreateJob(&job))
+
+	resp, cleanup := client.Delete("/v2/specs/" + job.ID)
+	defer cleanup()
+	assert.Equal(t, 204, resp.StatusCode)
+	assert.Error(t, cltest.JustError(app.Store.FindJob(job.ID)))
+}

--- a/web/job_specs_controller_test.go
+++ b/web/job_specs_controller_test.go
@@ -383,11 +383,12 @@ func TestJobSpecsController_Destroy(t *testing.T) {
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
 	client := app.NewHTTPClient()
-	job := cltest.NewJob()
+	job := cltest.NewJobWithLogInitiator()
 	require.NoError(t, app.Store.CreateJob(&job))
 
 	resp, cleanup := client.Delete("/v2/specs/" + job.ID)
 	defer cleanup()
 	assert.Equal(t, 204, resp.StatusCode)
 	assert.Error(t, cltest.JustError(app.Store.FindJob(job.ID)))
+	assert.Equal(t, 0, len(app.ChainlinkApplication.JobSubscriber.Jobs()))
 }

--- a/web/router.go
+++ b/web/router.go
@@ -141,6 +141,7 @@ func v2Routes(app services.Application, engine *gin.Engine) {
 		authv2.GET("/specs", paginatedRequest(j.Index))
 		authv2.POST("/specs", j.Create)
 		authv2.GET("/specs/:SpecID", j.Show)
+		authv2.DELETE("/specs/:SpecID", j.Destroy)
 
 		authv2.GET("/runs", paginatedRequest(jr.Index))
 		authv2.POST("/specs/:SpecID/runs", jr.Create)


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/155159173

This story was more challenging than anticipated. Here are some highlights:

* The philosophy is that existing runs of archived jobs continue uninterrupted, but new runs are prevented.
* Archiving a job utilizes `gorm`'s soft delete, which sets `deleted_at` in SQL.
* Created the CLI command `chainlink archivejob abc123`, that soft deletes the job and all associated runs, initiators, task specs.
* Archiving a job has a very high chance of being performed asynchronous to a run starting or already in progress from a variety of initiator types, including web, cron, runAt, logs. Extra care must be taken.
* in_progress jobs continue to run until completion.
* Runs could be paused as a result of a `pending_*` status. They are archived, but allowed to continue until completion. This is reflected in the method rename `UnscopedJobRunsWithStatus`, which is only used to find pending or in progress runs.
* No new runs can be created from an archived job.

#### Pending
* pending_sleep, pending_confirmations, pending_connection, pending_bridge can be resumed and run to completion, but are still archived and therefore removed from the operator GUI and CLI get commands.

#### Initiators
* web: Simplest case, standard SQL queries have soft deleted jobs hidden automatically.
* cron: Inability to remove cron jobs at runtime forced an implementation that checks if `orm.Archived(...)` right before continuing the job, much like EndAt.
* runAt: Similar but simpler implementation to `cron` above.
* logs: Application will unsubscribe job specific subscriptions.

In addition to the initiator scenarios above, there are edge cases as a result of race conditions we are now testing and compliant with:

1. After archiving a job, a run already in progress must become and continue to be archived. Future saves of run should not flip back the deleted at and unarchive.
2. Runs that are inadvertently created after an archive, due to a race condition, must also be archived but allowed to execute. i.e. A runlog is received from an ethereum node as a job is being archived. The small window where a run is created, it should still be archived.