### PR TITLE
Connect to linkstats via StatsPusher

### DIFF
--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -1021,3 +1021,24 @@ func GetLastTxAttempt(t *testing.T, store *strpkg.Store) models.TxAttempt {
 func JustError(_ interface{}, err error) error {
 	return err
 }
+
+func CallbackOrTimeout(t *testing.T, msg string, callback func(), durationParams ...time.Duration) {
+	t.Helper()
+
+	duration := 100 * time.Millisecond
+	if len(durationParams) > 0 {
+		duration = durationParams[0]
+	}
+
+	done := make(chan struct{})
+	go func() {
+		callback()
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(duration):
+		t.Fatal(fmt.Sprintf("CallbackOrTimeout: %s timed out", msg))
+	}
+}

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -1018,10 +1018,6 @@ func GetLastTxAttempt(t *testing.T, store *strpkg.Store) models.TxAttempt {
 	return attempt
 }
 
-func JustError(_ interface{}, err error) error {
-	return err
-}
-
 func CallbackOrTimeout(t *testing.T, msg string, callback func(), durationParams ...time.Duration) {
 	t.Helper()
 

--- a/internal/cltest/event_websocket_server.go
+++ b/internal/cltest/event_websocket_server.go
@@ -1,0 +1,110 @@
+package cltest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync"
+	"testing"
+
+	"github.com/gorilla/websocket"
+)
+
+type EventWebsocketServer struct {
+	*httptest.Server
+	mutex       *sync.RWMutex // shared mutex for safe access to arrays/maps.
+	t           *testing.T
+	connections []*websocket.Conn
+	Connected   chan struct{}
+	Received    chan string
+	URL         *url.URL
+}
+
+func NewEventWebsocketServer(t *testing.T) (*EventWebsocketServer, func()) {
+	server := &EventWebsocketServer{
+		mutex:     &sync.RWMutex{},
+		t:         t,
+		Connected: make(chan struct{}, 1), // have buffer of one for easier assertions after the event
+		Received:  make(chan string, 100),
+	}
+
+	server.Server = httptest.NewServer(http.HandlerFunc(server.handler))
+	u, err := url.Parse(server.Server.URL)
+	if err != nil {
+		t.Fatal("EventWebsocketServer: ", err)
+	}
+	u.Scheme = "ws"
+	server.URL = u
+	return server, func() {
+		server.Close()
+	}
+}
+
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool { return true },
+}
+
+func (wss *EventWebsocketServer) handler(w http.ResponseWriter, r *http.Request) {
+	var err error
+	conn, err := upgrader.Upgrade(w, r, nil)
+	if err != nil {
+		wss.t.Fatal("EventWebsocketServer Upgrade: ", err)
+	}
+
+	wss.addConnection(conn)
+	closeCodes := []int{websocket.CloseNormalClosure, websocket.CloseAbnormalClosure}
+	for {
+		_, payload, err := conn.ReadMessage() // we only read
+		if websocket.IsCloseError(err, closeCodes...) {
+			wss.removeConnection(conn)
+			return
+		}
+		if err != nil {
+			wss.t.Fatal("EventWebsocketServer ReadMessage: ", err)
+		}
+
+		select {
+		case wss.Received <- string(payload):
+		default:
+		}
+	}
+}
+
+func (wss *EventWebsocketServer) addConnection(conn *websocket.Conn) {
+	wss.mutex.Lock()
+	wss.connections = append(wss.connections, conn)
+	wss.mutex.Unlock()
+	select { // broadcast connected event
+	case wss.Connected <- struct{}{}:
+	default:
+	}
+}
+
+func (wss *EventWebsocketServer) removeConnection(conn *websocket.Conn) {
+	newc := []*websocket.Conn{}
+	wss.mutex.Lock()
+	for _, connection := range wss.connections {
+		if connection != conn {
+			newc = append(newc, connection)
+		}
+	}
+	wss.connections = newc
+	wss.mutex.Unlock()
+}
+
+// WriteCloseMessage tells connected clients to disconnect.
+// Useful to emulate that the websocket server is shutting down without
+// actually shutting down.
+// This overcomes httptest.Server's inability to restart on the same URL:port.
+func (wss *EventWebsocketServer) WriteCloseMessage() {
+	wss.mutex.RLock()
+	for _, connection := range wss.connections {
+		err := connection.WriteMessage(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		if err != nil {
+			wss.t.Error(err)
+		}
+	}
+	wss.mutex.RUnlock()
+}

--- a/internal/cltest/mocks.go
+++ b/internal/cltest/mocks.go
@@ -9,7 +9,6 @@ import (
 	"log"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"reflect"
 	"strings"
 	"sync"
@@ -18,7 +17,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/gorilla/websocket"
 	"github.com/onsi/gomega"
 	"github.com/smartcontractkit/chainlink/cmd"
 	"github.com/smartcontractkit/chainlink/logger"
@@ -714,103 +712,4 @@ type MockPasswordPrompter struct {
 
 func (m MockPasswordPrompter) Prompt() string {
 	return m.Password
-}
-
-type EventWebsocketServer struct {
-	*httptest.Server
-	mutex       *sync.RWMutex // shared mutex for safe access to arrays/maps.
-	t           *testing.T
-	connections []*websocket.Conn
-	Connected   chan struct{}
-	Received    chan string
-	URL         *url.URL
-}
-
-func NewEventWebsocketServer(t *testing.T) (*EventWebsocketServer, func()) {
-	server := &EventWebsocketServer{
-		mutex:     &sync.RWMutex{},
-		t:         t,
-		Connected: make(chan struct{}, 1), // have buffer of one for easier assertions after the event
-		Received:  make(chan string, 100),
-	}
-
-	server.Server = httptest.NewServer(http.HandlerFunc(server.handler))
-	u, err := url.Parse(server.Server.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	u.Scheme = "ws"
-	server.URL = u
-	return server, func() {
-		server.Close()
-	}
-}
-
-var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
-}
-
-func (wss *EventWebsocketServer) handler(w http.ResponseWriter, r *http.Request) {
-	var err error
-	conn, err := upgrader.Upgrade(w, r, nil)
-	if err != nil {
-		wss.t.Fatal(err)
-	}
-
-	wss.addConnection(conn)
-	closeCodes := []int{websocket.CloseNormalClosure, websocket.CloseAbnormalClosure}
-	for {
-		_, payload, err := conn.ReadMessage() // we only read
-		if websocket.IsCloseError(err, closeCodes...) {
-			wss.removeConnection(conn)
-			return
-		}
-		if err != nil {
-			wss.t.Fatal(err)
-		}
-
-		select {
-		case wss.Received <- string(payload):
-		default:
-		}
-	}
-}
-
-func (wss *EventWebsocketServer) addConnection(conn *websocket.Conn) {
-	wss.mutex.Lock()
-	wss.connections = append(wss.connections, conn)
-	wss.mutex.Unlock()
-	select { // broadcast connected event
-	case wss.Connected <- struct{}{}:
-	default:
-	}
-}
-
-func (wss *EventWebsocketServer) removeConnection(conn *websocket.Conn) {
-	newc := []*websocket.Conn{}
-	wss.mutex.Lock()
-	for _, connection := range wss.connections {
-		if connection != conn {
-			newc = append(newc, connection)
-		}
-	}
-	wss.connections = newc
-	wss.mutex.Unlock()
-}
-
-// WriteCloseMessage tells connected clients to disconnect.
-// Useful to emulate that the websocket server is shutting down without
-// actually shutting down.
-// This overcomes httptest.Server's inability to restart on the same URL:port.
-func (wss *EventWebsocketServer) WriteCloseMessage() {
-	wss.mutex.RLock()
-	for _, connection := range wss.connections {
-		err := connection.WriteMessage(
-			websocket.CloseMessage,
-			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
-		if err != nil {
-			wss.t.Error(err)
-		}
-	}
-	wss.mutex.RUnlock()
 }

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -155,14 +155,21 @@ func Error(args ...interface{}) {
 	logger.Error(args...)
 }
 
-//WarnIf logs the error if present.
+// WarnIf logs the error if present.
 func WarnIf(err error) {
 	if err != nil {
 		logger.Warn(err)
 	}
 }
 
-//PanicIf logs the error if present.
+// ErrorIf logs the error if present.
+func ErrorIf(err error) {
+	if err != nil {
+		logger.Error(err)
+	}
+}
+
+// PanicIf logs the error if present.
 func PanicIf(err error) {
 	if err != nil {
 		logger.Panic(err)

--- a/services/head_tracker.go
+++ b/services/head_tracker.go
@@ -195,9 +195,9 @@ func (ht *HeadTracker) subscribe() bool {
 		case <-time.After(ht.sleeper.After()):
 			err := ht.subscribeToHead()
 			if err != nil {
-				logger.Warnw(fmt.Sprintf("Failed to connect to %v", ht.store.Config.EthereumURL()), "err", err)
+				logger.Warnw(fmt.Sprintf("Failed to connect to ethereum node %v", ht.store.Config.EthereumURL()), "err", err)
 			} else {
-				logger.Info("Connected to node ", ht.store.Config.EthereumURL())
+				logger.Info("Connected to ethereum node ", ht.store.Config.EthereumURL())
 				return true
 			}
 		}

--- a/services/runs_test.go
+++ b/services/runs_test.go
@@ -493,7 +493,7 @@ func TestQueueSleepingTaskA_CompletesSleepingTaskAfterDurationElapsed_Archived(t
 	assert.True(t, open)
 	assert.Equal(t, run.ID, runRequest.ID)
 
-	require.Error(t, cltest.JustError(store.FindJobRun(run.ID)), "archived runs should not be visible to normal store")
+	require.Error(t, utils.JustError(store.FindJobRun(run.ID)), "archived runs should not be visible to normal store")
 
 	*run, err = unscoped.FindJobRun(run.ID)
 	assert.NoError(t, err)

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -141,7 +141,6 @@ func TestORM_SaveJobRun_ArchivedDoesNotRevertDeletedAt(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 
-	store.ORM.DB.LogMode(true)
 	job := cltest.NewJobWithWebInitiator()
 	require.NoError(t, store.CreateJob(&job))
 

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -87,12 +87,12 @@ func TestORM_ArchiveJob(t *testing.T) {
 
 	require.NoError(t, store.ArchiveJob(job.ID))
 
-	require.Error(t, cltest.JustError(store.FindJob(job.ID)))
-	require.Error(t, cltest.JustError(store.FindJobRun(run.ID)))
+	require.Error(t, utils.JustError(store.FindJob(job.ID)))
+	require.Error(t, utils.JustError(store.FindJobRun(run.ID)))
 
 	orm := store.ORM.Unscoped()
-	require.NoError(t, cltest.JustError(orm.FindJob(job.ID)))
-	require.NoError(t, cltest.JustError(orm.FindJobRun(run.ID)))
+	require.NoError(t, utils.JustError(orm.FindJob(job.ID)))
+	require.NoError(t, utils.JustError(orm.FindJobRun(run.ID)))
 }
 
 func TestORM_CreateJobRun_ArchivesRunIfJobArchived(t *testing.T) {
@@ -108,8 +108,8 @@ func TestORM_CreateJobRun_ArchivesRunIfJobArchived(t *testing.T) {
 	jr := job.NewRun(job.Initiators[0])
 	require.NoError(t, store.CreateJobRun(&jr))
 
-	require.Error(t, cltest.JustError(store.FindJobRun(jr.ID)))
-	require.NoError(t, cltest.JustError(store.Unscoped().FindJobRun(jr.ID)))
+	require.Error(t, utils.JustError(store.FindJobRun(jr.ID)))
+	require.NoError(t, utils.JustError(store.Unscoped().FindJobRun(jr.ID)))
 }
 
 func TestORM_SaveJobRun_DoesNotSaveTaskSpec(t *testing.T) {
@@ -152,8 +152,8 @@ func TestORM_SaveJobRun_ArchivedDoesNotRevertDeletedAt(t *testing.T) {
 	jr.Status = models.RunStatusInProgress
 	require.NoError(t, store.SaveJobRun(&jr))
 
-	require.Error(t, cltest.JustError(store.FindJobRun(jr.ID)))
-	require.NoError(t, cltest.JustError(store.Unscoped().FindJobRun(jr.ID)))
+	require.Error(t, utils.JustError(store.FindJobRun(jr.ID)))
+	require.NoError(t, utils.JustError(store.Unscoped().FindJobRun(jr.ID)))
 }
 
 func coercedJSON(v string) string {

--- a/store/presenters/presenters.go
+++ b/store/presenters/presenters.go
@@ -148,6 +148,7 @@ type whitelist struct {
 	EthGasPriceDefault       *big.Int        `json:"ethGasPriceDefault"`
 	JSONConsole              bool            `json:"jsonConsole"`
 	LinkContractAddress      string          `json:"linkContractAddress"`
+	LinkstatsURL             string          `json:"linkstatsUrl"`
 	LogLevel                 store.LogLevel  `json:"logLevel"`
 	LogToDisk                bool            `json:"logToDisk"`
 	MinimumContractPayment   *assets.Link    `json:"minimumContractPayment"`
@@ -171,6 +172,10 @@ func NewConfigWhitelist(store *store.Store) (ConfigWhitelist, error) {
 		return ConfigWhitelist{}, err
 	}
 
+	linkstatsURL := ""
+	if config.LinkstatsURL() != nil {
+		linkstatsURL = config.LinkstatsURL().String()
+	}
 	return ConfigWhitelist{
 		AccountAddress: account.Address.Hex(),
 		whitelist: whitelist{
@@ -186,6 +191,7 @@ func NewConfigWhitelist(store *store.Store) (ConfigWhitelist, error) {
 			EthGasPriceDefault:       config.EthGasPriceDefault(),
 			JSONConsole:              config.JSONConsole(),
 			LinkContractAddress:      config.LinkContractAddress(),
+			LinkstatsURL:             linkstatsURL,
 			LogLevel:                 config.LogLevel(),
 			LogToDisk:                config.LogToDisk(),
 			MinimumContractPayment:   config.MinimumContractPayment(),

--- a/store/stats_pusher.go
+++ b/store/stats_pusher.go
@@ -1,0 +1,150 @@
+package store
+
+import (
+	"fmt"
+	"net/url"
+	"sync"
+	"time"
+
+	"github.com/gorilla/websocket"
+	"github.com/smartcontractkit/chainlink/logger"
+)
+
+// StatsPusher encapsulates all the functionality needed to
+// push run information to linkstats.
+type StatsPusher interface {
+	Start() error
+	Close() error
+}
+
+// NewStatsPusher returns a functioning instance depending on the
+// URL passed: nil is a noop instance, url assumes a websocket instance.
+// No support for http.
+func NewStatsPusher(url *url.URL) StatsPusher {
+	if url != nil {
+		return NewWebsocketStatsPusher(url)
+	}
+	return noopStatsPusher{}
+}
+
+type noopStatsPusher struct{}
+
+func (noopStatsPusher) Start() error { return nil }
+func (noopStatsPusher) Close() error { return nil }
+
+type websocketStatsPusher struct {
+	url     url.URL
+	conn    *websocket.Conn
+	send    chan []byte
+	boot    *sync.Mutex
+	started bool
+}
+
+// NewWebsocketStatsPusher returns a stats pusher using a websocket for
+// delivery.
+func NewWebsocketStatsPusher(url *url.URL) StatsPusher {
+	return &websocketStatsPusher{
+		url:  *url,
+		send: make(chan []byte),
+		boot: &sync.Mutex{},
+	}
+}
+
+// Start starts a write pump over a websocket.
+func (w *websocketStatsPusher) Start() error {
+	w.boot.Lock()
+	defer w.boot.Unlock()
+
+	if w.started {
+		return nil
+	}
+
+	conn, _, err := websocket.DefaultDialer.Dial(w.url.String(), nil)
+	if err != nil {
+		return fmt.Errorf("websocketStatsPusher#Start(): %v", err)
+	}
+
+	w.conn = conn
+	go w.writePump()
+	w.started = true
+	return nil
+}
+
+const (
+	// Time allowed to write a message to the peer.
+	writeWait = 10 * time.Second
+
+	// Time allowed to read the next pong message from the peer.
+	pongWait = 60 * time.Second
+
+	// Send pings to peer with this period. Must be less than pongWait.
+	pingPeriod = (pongWait * 9) / 10
+)
+
+// Inspired by https://github.com/gorilla/websocket/blob/master/examples/chat/client.go
+func (w *websocketStatsPusher) writePump() {
+	ticker := time.NewTicker(pingPeriod)
+	defer func() {
+		ticker.Stop()
+		wrapLoggerErrorIf(w.conn.Close())
+	}()
+	for {
+		select {
+		case message, open := <-w.send:
+			if !open { // channel closed
+				wrapLoggerErrorIf(w.conn.WriteMessage(websocket.CloseMessage, []byte{}))
+				return
+			}
+
+			wrapLoggerErrorIf(w.conn.SetWriteDeadline(time.Now().Add(writeWait)))
+			writer, err := w.conn.NextWriter(websocket.TextMessage)
+			if err != nil {
+				logger.Error(err)
+				return
+			}
+			_, err = writer.Write(message)
+			wrapLoggerErrorIf(err)
+
+			// Add queued messages to the current websocket message,
+			// batching sending for efficiency.
+			n := len(w.send)
+			for i := 0; i < n; i++ {
+				additionalMsg, open := <-w.send
+				if !open {
+					break
+				}
+				_, err = writer.Write(additionalMsg)
+				wrapLoggerErrorIf(err)
+			}
+
+			if err := writer.Close(); err != nil {
+				logger.Error(err)
+				return
+			}
+		case <-ticker.C:
+			wrapLoggerErrorIf(w.conn.SetWriteDeadline(time.Now().Add(writeWait)))
+			if err := w.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
+				wrapLoggerErrorIf(err)
+				return
+			}
+		}
+	}
+}
+
+func wrapLoggerErrorIf(err error) {
+	if err != nil && !websocket.IsCloseError(err) {
+		logger.Error(fmt.Sprintf("websocketStatsPusher: %v", err))
+	}
+}
+
+func (w *websocketStatsPusher) Close() error {
+	w.boot.Lock()
+	defer w.boot.Unlock()
+
+	if w.send != nil {
+		close(w.send)
+		w.send = nil
+	}
+	w.started = false
+	return nil
+}

--- a/store/stats_pusher.go
+++ b/store/stats_pusher.go
@@ -1,6 +1,7 @@
 package store
 
 import (
+	"context"
 	"fmt"
 	"net/url"
 	"sync"
@@ -39,7 +40,7 @@ func (noopStatsPusher) Send([]byte)  {}
 type websocketStatsPusher struct {
 	boot    *sync.Mutex
 	conn    *websocket.Conn
-	done    chan struct{}
+	cancel  context.CancelFunc
 	send    chan []byte
 	sleeper utils.Sleeper
 	started bool
@@ -66,10 +67,11 @@ func (w *websocketStatsPusher) Start() error {
 		return nil
 	}
 
-	w.done = make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	w.cancel = cancel
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	go w.connectAndWritePump(wg, w.done)
+	go w.connectAndWritePump(ctx, wg)
 	wg.Wait()
 	w.started = true
 	return nil
@@ -92,25 +94,27 @@ const (
 // Inspired by https://github.com/gorilla/websocket/blob/master/examples/chat/client.go
 // lexical confinement of done chan allows multiple connectAndWritePump routines
 // to clean up independent of itself by reducing shared state. i.e. a passed done, not w.done.
-func (w *websocketStatsPusher) connectAndWritePump(wg *sync.WaitGroup, done chan struct{}) {
+func (w *websocketStatsPusher) connectAndWritePump(parentCtx context.Context, wg *sync.WaitGroup) {
 	wg.Done()
+	logger.Info("Connecting to linkstats at ", w.url.String())
 
 	for {
 		select {
-		case <-done:
+		case <-parentCtx.Done():
 			return
 		case <-time.After(w.sleeper.After()):
-			if err := w.connect(); err != nil {
+			connectionCtx, cancel := context.WithCancel(parentCtx)
+			defer cancel()
+
+			if err := w.connect(connectionCtx); err != nil {
 				logger.Warn("Failed to connect to linkstats (", w.url.String(), "): ", err)
 				break
 			}
 
 			logger.Info("Connected to linkstats at ", w.url.String())
 			w.sleeper.Reset()
-
-			serverDone := make(chan struct{})
-			go w.readPumpForControlMessages(serverDone)
-			w.writePump(done, serverDone)
+			go w.readPumpForControlMessages(cancel)
+			w.writePump(connectionCtx)
 		}
 	}
 }
@@ -120,7 +124,7 @@ var (
 )
 
 // Inspired by https://github.com/gorilla/websocket/blob/master/examples/chat/client.go#L82
-func (w *websocketStatsPusher) writePump(done chan struct{}, serverDone chan struct{}) {
+func (w *websocketStatsPusher) writePump(ctx context.Context) {
 	ticker := time.NewTicker(pingPeriod)
 	defer func() {
 		ticker.Stop()
@@ -128,9 +132,7 @@ func (w *websocketStatsPusher) writePump(done chan struct{}, serverDone chan str
 	}()
 	for {
 		select {
-		case <-done:
-			return
-		case <-serverDone:
+		case <-ctx.Done():
 			return
 		case message, open := <-w.send:
 			if !open { // channel closed
@@ -176,8 +178,8 @@ func (w *websocketStatsPusher) writePump(done chan struct{}, serverDone chan str
 	}
 }
 
-func (w *websocketStatsPusher) connect() error {
-	conn, _, err := websocket.DefaultDialer.Dial(w.url.String(), nil)
+func (w *websocketStatsPusher) connect(ctx context.Context) error {
+	conn, _, err := websocket.DefaultDialer.DialContext(ctx, w.url.String(), nil)
 	if err != nil {
 		return fmt.Errorf("websocketStatsPusher#connect: %v", err)
 	}
@@ -192,7 +194,9 @@ var expectedCloseMessages = []int{websocket.CloseGoingAway, websocket.CloseAbnor
 // intention of handling control messages, like server disconnect.
 // https://stackoverflow.com/a/48181794/639773
 // https://github.com/gorilla/websocket/blob/master/examples/chat/client.go#L56
-func (w *websocketStatsPusher) readPumpForControlMessages(serverDone chan struct{}) {
+func (w *websocketStatsPusher) readPumpForControlMessages(cancel context.CancelFunc) {
+	defer cancel()
+
 	w.conn.SetReadLimit(maxMessageSize)
 	_ = w.conn.SetReadDeadline(time.Now().Add(pongWait))
 	w.conn.SetPongHandler(func(string) error {
@@ -206,8 +210,7 @@ func (w *websocketStatsPusher) readPumpForControlMessages(serverDone chan struct
 			if websocket.IsUnexpectedCloseError(err, expectedCloseMessages...) {
 				logger.Warn(fmt.Sprintf("readPumpForControlMessages: %v", err))
 			}
-			close(serverDone)
-			break
+			return
 		}
 	}
 }
@@ -222,9 +225,8 @@ func (w *websocketStatsPusher) Close() error {
 	w.boot.Lock()
 	defer w.boot.Unlock()
 
-	if w.done != nil {
-		close(w.done)
-		w.done = nil
+	if w.started {
+		w.cancel()
 	}
 	w.started = false
 	return nil

--- a/store/stats_pusher.go
+++ b/store/stats_pusher.go
@@ -101,10 +101,11 @@ func (w *websocketStatsPusher) connectAndWritePump(wg *sync.WaitGroup, done chan
 			return
 		case <-time.After(w.sleeper.After()):
 			if err := w.connect(); err != nil {
-				logger.Warn("Inability to connect to linkstats: ", err)
+				logger.Warn("Failed to connect to linkstats (", w.url.String(), "): ", err)
 				break
 			}
 
+			logger.Info("Connected to linkstats at ", w.url.String())
 			w.sleeper.Reset()
 
 			serverDone := make(chan struct{})

--- a/store/stats_pusher_test.go
+++ b/store/stats_pusher_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestWebsocketStatsPusher_StartCloseStart(t *testing.T) {
-	wsserver, cleanup := cltest.NewCountingWebsocketServer(t)
+	wsserver, cleanup := cltest.NewEventWebsocketServer(t)
 	defer cleanup()
 
 	pusher := store.NewWebsocketStatsPusher(wsserver.URL)
@@ -29,7 +29,7 @@ func TestWebsocketStatsPusher_StartCloseStart(t *testing.T) {
 }
 
 func TestWebsocketStatsPusher_ReconnectLoop(t *testing.T) {
-	wsserver, cleanup := cltest.NewCountingWebsocketServer(t)
+	wsserver, cleanup := cltest.NewEventWebsocketServer(t)
 	defer cleanup()
 
 	pusher := store.NewWebsocketStatsPusher(wsserver.URL)
@@ -47,7 +47,7 @@ func TestWebsocketStatsPusher_ReconnectLoop(t *testing.T) {
 }
 
 func TestWebsocketStatsPusher_Send(t *testing.T) {
-	wsserver, cleanup := cltest.NewCountingWebsocketServer(t)
+	wsserver, cleanup := cltest.NewEventWebsocketServer(t)
 	defer cleanup()
 
 	pusher := store.NewWebsocketStatsPusher(wsserver.URL)

--- a/store/stats_pusher_test.go
+++ b/store/stats_pusher_test.go
@@ -1,0 +1,21 @@
+package store_test
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink/internal/cltest"
+	"github.com/smartcontractkit/chainlink/store"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWebsocketStatsPusher_New(t *testing.T) {
+	wsserver, cleanup := cltest.NewCountingWebsocketServer(t)
+	defer cleanup()
+
+	pusher := store.NewWebsocketStatsPusher(wsserver.URL)
+	require.NoError(t, pusher.Start())
+	cltest.CallbackOrTimeout(t, "stats pusher connects", func() {
+		<-wsserver.Connected
+	})
+	require.NoError(t, pusher.Close())
+}

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -475,3 +475,8 @@ func FileContents(path string) (string, error) {
 	}
 	return string(dat), nil
 }
+
+// JustError takes a tuple and returns the last entry, the error.
+func JustError(_ interface{}, err error) error {
+	return err
+}

--- a/web/job_specs_controller_test.go
+++ b/web/job_specs_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/smartcontractkit/chainlink/store/presenters"
+	"github.com/smartcontractkit/chainlink/utils"
 	"github.com/smartcontractkit/chainlink/web"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -387,6 +388,6 @@ func TestJobSpecsController_Destroy(t *testing.T) {
 	resp, cleanup := client.Delete("/v2/specs/" + job.ID)
 	defer cleanup()
 	assert.Equal(t, 204, resp.StatusCode)
-	assert.Error(t, cltest.JustError(app.Store.FindJob(job.ID)))
+	assert.Error(t, utils.JustError(app.Store.FindJob(job.ID)))
 	assert.Equal(t, 0, len(app.ChainlinkApplication.JobSubscriber.Jobs()))
 }


### PR DESCRIPTION
Ability for the chainlink node to connect to linkstats via websockets. A bulk of the code falls into three categories:

1. Automatic reconnections
2. `cltest.NewEventWebsocketServer` for easier testability
3. Boilerplate gorilla websocket code.

Highlights:

1. Works with `linkstats` via `LINKSTATS_URL=ws://localhost:8080/clnode/\?transport=websocket cldev node`
2. Automatically reconnects with BackoffSleeper
3. Has a `readPumpForControlMessages` exclusively to handle websocket connection state.
4. Has basic `Send` functionality for completeness.
5. Inspired by Gorilla websockets example: https://github.com/gorilla/websocket/blob/master/examples/chat/client.go
6. Modified `store.Config` to be able to parse out `*url.Url` or `nil` as opposed to a zero object `url.Url`. It was awkward comparing a *url.URL to a zerod object (url.URL{}) instead of nil.
7. Particularly proud of the tests in `stats_pusher_test.go`
8. Move `cltest.JustError` to `utils.JustError`
9. Used `context.Context` instead of `done` channels to cleanup goroutines.