### PR TITLE
improve logging and solve nonce too low issue during stress test

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1178,6 +1178,7 @@
     "github.com/mrwonko/cron",
     "github.com/olekukonko/tablewriter",
     "github.com/onsi/gomega",
+    "github.com/pkg/errors",
     "github.com/satori/go.uuid",
     "github.com/spf13/viper",
     "github.com/stretchr/testify/assert",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -145,3 +145,7 @@
 [[constraint]]
   name = "github.com/gofrs/flock"
   version = "0.7.1"
+
+[[constraint]]
+  name = "github.com/pkg/errors"
+  version = "0.8.1"

--- a/cmd/local_client.go
+++ b/cmd/local_client.go
@@ -88,7 +88,7 @@ func logIfNonceOutOfSync(store *strpkg.Store) {
 		return
 	}
 
-	if localNonceIsNotCurrent(lastNonce, account.GetNonce()) {
+	if localNonceIsNotCurrent(lastNonce, account.Nonce()) {
 		logger.Warn("The account is being used by another wallet and is not safe to use with chainlink")
 	}
 }

--- a/store/models/eth.go
+++ b/store/models/eth.go
@@ -102,14 +102,6 @@ func (tx *Tx) AssignTxAttempt(txat *TxAttempt) {
 	tx.SentAt = txat.SentAt
 }
 
-// IsBumpableAttempt returns true only if the attempt is the last
-// attempt associated meaning it has the highest gas price after subsequent
-// bumps, or if the attempt that has received a TxReceipt,
-// being marked by MarkTxReceipt.
-func (tx *Tx) IsBumpableAttempt(txat *TxAttempt) bool {
-	return tx.Hash == txat.Hash
-}
-
 // TxAttempt is used for keeping track of transactions that
 // have been written to the Ethereum blockchain. This makes
 // it so that if the network is busy, a transaction can be

--- a/store/models/eth.go
+++ b/store/models/eth.go
@@ -102,6 +102,14 @@ func (tx *Tx) AssignTxAttempt(txat *TxAttempt) {
 	tx.SentAt = txat.SentAt
 }
 
+// IsBumpableAttempt returns true only if the attempt is the last
+// attempt associated meaning it has the highest gas price after subsequent
+// bumps, or if the attempt that has received a TxReceipt,
+// being marked by MarkTxReceipt.
+func (tx *Tx) IsBumpableAttempt(txat *TxAttempt) bool {
+	return tx.Hash == txat.Hash
+}
+
 // TxAttempt is used for keeping track of transactions that
 // have been written to the Ethereum blockchain. This makes
 // it so that if the network is busy, a transaction can be

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -420,16 +420,6 @@ func (orm *ORM) CreateTx(
 	return &tx, orm.DB.Save(&tx).Error
 }
 
-// MarkTxReceipt assigns the attempt onto the transaction since its
-// TxReceipt has been confirmed.
-func (orm *ORM) MarkTxReceipt(tx *models.Tx, txat *models.TxAttempt) error {
-	tx.AssignTxAttempt(txat)
-
-	return orm.convenientTransaction(func(dbtx *gorm.DB) error {
-		return dbtx.Save(tx).Error
-	})
-}
-
 // MarkTxSafe updates the database for the given transaction and attempt to
 // show that the transaction has not just been confirmed,
 // but has met the minimum number of outgoing confirmations to be deemed

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -420,9 +420,21 @@ func (orm *ORM) CreateTx(
 	return &tx, orm.DB.Save(&tx).Error
 }
 
-// ConfirmTx updates the database for the given transaction to
-// show that the transaction has been confirmed on the blockchain.
-func (orm *ORM) ConfirmTx(tx *models.Tx, txat *models.TxAttempt) error {
+// MarkTxReceipt assigns the attempt onto the transaction since its
+// TxReceipt has been confirmed.
+func (orm *ORM) MarkTxReceipt(tx *models.Tx, txat *models.TxAttempt) error {
+	tx.AssignTxAttempt(txat)
+
+	return orm.convenientTransaction(func(dbtx *gorm.DB) error {
+		return dbtx.Save(tx).Error
+	})
+}
+
+// MarkTxSafe updates the database for the given transaction and attempt to
+// show that the transaction has not just been confirmed,
+// but has met the minimum number of outgoing confirmations to be deemed
+// safely written on the blockchain.
+func (orm *ORM) MarkTxSafe(tx *models.Tx, txat *models.TxAttempt) error {
 	txat.Confirmed = true
 	tx.AssignTxAttempt(txat)
 

--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -457,10 +457,6 @@ func (txm *EthTxManager) handleConfirmed(
 		"confirmedAt", confirmedAt,
 	)
 
-	if err := txm.orm.MarkTxReceipt(tx, txat); err != nil {
-		return nil, confirmed, err
-	}
-
 	if big.NewInt(int64(blkNum)).Cmp(confirmedAt) == -1 {
 		return nil, confirmed, nil
 	}

--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -289,8 +289,8 @@ func (txm *EthTxManager) BumpGasUntilSafe(hash common.Hash) (*TxReceipt, error) 
 	for _, txat := range attempts {
 		receipt, err := txm.checkAttempt(tx, &txat, blkNum)
 		merr = multierr.Append(merr, err)
-		if receipt != nil {
-			return receipt, merr
+		if receipt != nil { // success, so all prior errors can be ignored.
+			return receipt, nil
 		}
 	}
 	return nil, merr
@@ -516,7 +516,7 @@ func (txm *EthTxManager) bumpGas(txat *models.TxAttempt, blkNum uint64) error {
 	if err != nil {
 		return errors.Wrap(err, "bumpGas")
 	}
-	logger.Infow(fmt.Sprintf("Bumping gas to %v for transaction %v", gasPrice, bumpedTxAt.Hash.String()), "txat", bumpedTxAt)
+	logger.Infow(fmt.Sprintf("Bumping gas to %v for transaction %v", gasPrice, bumpedTxAt.Hash.String()), "txat", bumpedTxAt, "nonce", tx.Nonce)
 	return nil
 }
 

--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -572,8 +572,8 @@ func NewManagedAccount(a accounts.Account, nonce uint64) *ManagedAccount {
 	return &ManagedAccount{Account: a, nonce: nonce, mutex: &sync.Mutex{}}
 }
 
-// GetNonce returns the client side managed nonce.
-func (a *ManagedAccount) GetNonce() uint64 {
+// Nonce returns the client side managed nonce.
+func (a *ManagedAccount) Nonce() uint64 {
 	return a.nonce
 }
 

--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -437,6 +437,7 @@ func (txm *EthTxManager) handleConfirmed(
 		fmt.Sprintf("Confirmed TX: %d attempt %s waiting on %v confirmations", txat.TxID, txat.Hash.Hex(), minConfs),
 		"txHash", txat.Hash.String(),
 		"txid", txat.TxID,
+		"nonce", tx.Nonce,
 		"gasPrice", txat.GasPrice.String(),
 		"from", tx.From.Hex(),
 		"receiptBlockNumber", rcpt.BlockNumber.ToInt(),
@@ -457,6 +458,8 @@ func (txm *EthTxManager) handleConfirmed(
 	logger.Infow(
 		fmt.Sprintf("Confirmed TX %d: %s", txat.TxID, txat.Hash.String()),
 		"txHash", txat.Hash.String(),
+		"txid", txat.TxID,
+		"nonce", tx.Nonce,
 		"ethBalance", ethBalance,
 		"linkBalance", linkBalance,
 		"receipt", rcpt,
@@ -479,6 +482,7 @@ func (txm *EthTxManager) handleUnconfirmed(
 	logParams := []interface{}{
 		"txHash", txAttempt.Hash.String(),
 		"txid", txAttempt.TxID,
+		"nonce", latestTx.Nonce,
 		"gasPrice", txAttempt.GasPrice.String(),
 		"from", latestTx.From.Hex(),
 		"blkNum", blkNum,

--- a/store/tx_manager.go
+++ b/store/tx_manager.go
@@ -380,9 +380,6 @@ func (txm *EthTxManager) createAttempt(
 	if err != nil {
 		return nil, err
 	}
-	// race condition part 2: this can legitimately fail if the tx is confirmed
-	// on the eth node since the receipt was retrieved, since the start of the window
-	// in part 1. small window but possible nonetheless.
 	return a, txm.sendTransaction(etx)
 }
 
@@ -410,7 +407,7 @@ func (txm *EthTxManager) checkAttempt(
 	txat *models.TxAttempt,
 	blkNum uint64,
 ) (*TxReceipt, attemptState, error) {
-	receipt, err := txm.GetTxReceipt(txat.Hash) // race condition? part 1: start of window. see part 2
+	receipt, err := txm.GetTxReceipt(txat.Hash)
 	if err != nil {
 		return nil, unconfirmed, errors.Wrap(err, "checkAttempt GetTxReceipt")
 	}

--- a/store/tx_manager_test.go
+++ b/store/tx_manager_test.go
@@ -469,7 +469,7 @@ func TestTxManager_Register(t *testing.T) {
 
 	aa := txm.NextActiveAccount()
 	assert.Equal(t, account.Address, aa.Address)
-	assert.Equal(t, uint64(0x2d0), aa.GetNonce())
+	assert.Equal(t, uint64(0x2d0), aa.Nonce())
 }
 
 func TestTxManager_NextActiveAccount_RoundRobin(t *testing.T) {
@@ -497,11 +497,11 @@ func TestTxManager_NextActiveAccount_RoundRobin(t *testing.T) {
 
 	a0 := txm.NextActiveAccount()
 	assert.Equal(t, accounts[0].Address, a0.Address)
-	assert.Equal(t, uint64(0x1d0), a0.GetNonce())
+	assert.Equal(t, uint64(0x1d0), a0.Nonce())
 
 	a1 := txm.NextActiveAccount()
 	assert.Equal(t, accounts[1].Address, a1.Address)
-	assert.Equal(t, uint64(0x2d0), a1.GetNonce())
+	assert.Equal(t, uint64(0x2d0), a1.Nonce())
 
 	a2 := txm.NextActiveAccount()
 	assert.Equal(t, a0, a2)
@@ -526,7 +526,7 @@ func TestTxManager_ReloadNonce(t *testing.T) {
 	ethMock.EventuallyAllCalled(t)
 
 	assert.Equal(t, account.Address, ma.Address)
-	assert.Equal(t, uint64(0x2d1), ma.GetNonce())
+	assert.Equal(t, uint64(0x2d1), ma.Nonce())
 }
 
 func TestTxManager_WithdrawLink(t *testing.T) {
@@ -601,13 +601,13 @@ func TestManagedAccount_GetAndIncrementNonce_YieldsCurrentNonceAndIncrements(t *
 		assert.Equal(t, uint64(0), y)
 		return nil
 	})
-	assert.Equal(t, uint64(1), managedAccount.GetNonce())
+	assert.Equal(t, uint64(1), managedAccount.Nonce())
 
 	managedAccount.GetAndIncrementNonce(func(y uint64) error {
 		assert.Equal(t, uint64(1), y)
 		return nil
 	})
-	assert.Equal(t, uint64(2), managedAccount.GetNonce())
+	assert.Equal(t, uint64(2), managedAccount.Nonce())
 }
 
 func TestManagedAccount_GetAndIncrementNonce_DoesNotIncrementWhenCallbackThrowsException(t *testing.T) {
@@ -624,7 +624,7 @@ func TestManagedAccount_GetAndIncrementNonce_DoesNotIncrementWhenCallbackThrowsE
 		return errors.New("Should not increment again")
 	})
 	assert.Error(t, err)
-	assert.Equal(t, uint64(0), managedAccount.GetNonce())
+	assert.Equal(t, uint64(0), managedAccount.Nonce())
 }
 
 func TestTxManager_LogsETHAndLINKBalancesAfterSuccessfulTx(t *testing.T) {

--- a/store/tx_manager_test.go
+++ b/store/tx_manager_test.go
@@ -421,7 +421,7 @@ func TestTxManager_BumpGasUntilSafe_erroring(t *testing.T) {
 		{"later conf, early error", (safeAt + 1), func(ethMock *cltest.EthMock) {
 			ethMock.RegisterError("eth_getTransactionReceipt", "FUBAR")
 			ethMock.Register("eth_getTransactionReceipt", confedReceipt)
-		}, true, true},
+		}, true, false},
 	}
 
 	for _, test := range tests {

--- a/store/tx_manager_test.go
+++ b/store/tx_manager_test.go
@@ -315,7 +315,7 @@ func TestTxManager_CreateTx_ErrPendingConnection(t *testing.T) {
 	assert.NoError(t, err)
 
 	_, err = manager.CreateTx(to, data)
-	assert.Equal(t, strpkg.ErrPendingConnection, err)
+	assert.Contains(t, err.Error(), strpkg.ErrPendingConnection.Error())
 }
 
 func TestTxManager_BumpGasUntilSafe(t *testing.T) {


### PR DESCRIPTION
Fixes a bug where a confirmed but not safe (reached min confirmations, say 12) TxReceipt still allowed other txattempts to be gas bumped.

While a larger refactor of `TxManager` is necessary, this fix will be a stopgap until that point. One of the goals in this PR is to push the vocabulary `safe` to disambiguate between a transaction with one confirmation and a transaction with the minimum number of confirmations (default 12).

Vocab:

Confirmed: Has 1 confirmation.
Safe: Has minimum confirmations.