### PR TITLE
Fix "too many SQL variables" issue

### DIFF
--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -1009,6 +1009,16 @@ func AllJobs(store *strpkg.Store) []models.JobSpec {
 	return all
 }
 
+func MustAllJobsWithStatus(t *testing.T, store *strpkg.Store, statuses ...models.RunStatus) []*models.JobRun {
+	var runs []*models.JobRun
+	err := store.UnscopedJobRunsWithStatus(func(jr *models.JobRun) error {
+		runs = append(runs, jr)
+		return nil
+	}, statuses...)
+	require.NoError(t, err)
+	return runs
+}
+
 func GetLastTxAttempt(t *testing.T, store *strpkg.Store) models.TxAttempt {
 	var attempt models.TxAttempt
 	var count int

--- a/internal/cltest/cltest.go
+++ b/internal/cltest/cltest.go
@@ -1011,9 +1011,8 @@ func AllJobs(store *strpkg.Store) []models.JobSpec {
 
 func MustAllJobsWithStatus(t *testing.T, store *strpkg.Store, statuses ...models.RunStatus) []*models.JobRun {
 	var runs []*models.JobRun
-	err := store.UnscopedJobRunsWithStatus(func(jr *models.JobRun) error {
+	err := store.UnscopedJobRunsWithStatus(func(jr *models.JobRun) {
 		runs = append(runs, jr)
-		return nil
 	}, statuses...)
 	require.NoError(t, err)
 	return runs

--- a/services/application.go
+++ b/services/application.go
@@ -236,18 +236,19 @@ func newPendingConnectionResumer(store *store.Store) *pendingConnectionResumer {
 }
 
 func (p *pendingConnectionResumer) Connect(head *models.Head) error {
-	pendingRuns, err := p.store.UnscopedJobRunsWithStatus(models.RunStatusPendingConnection)
+	var merr error
+	err := p.store.UnscopedJobRunsWithStatus(func(run *models.JobRun) error {
+		err := p.resumer(run, p.store.Unscoped())
+		if err != nil {
+			merr = multierr.Append(merr, err)
+		}
+		return nil
+	}, models.RunStatusPendingConnection)
+
 	if err != nil {
 		return multierr.Append(errors.New("error resuming pending connections"), err)
 	}
 
-	var merr error
-	for _, jr := range pendingRuns {
-		err := p.resumer(&jr, p.store.Unscoped())
-		if err != nil {
-			merr = multierr.Append(merr, err)
-		}
-	}
 	return merr
 }
 

--- a/services/application.go
+++ b/services/application.go
@@ -237,12 +237,11 @@ func newPendingConnectionResumer(store *store.Store) *pendingConnectionResumer {
 
 func (p *pendingConnectionResumer) Connect(head *models.Head) error {
 	var merr error
-	err := p.store.UnscopedJobRunsWithStatus(func(run *models.JobRun) error {
+	err := p.store.UnscopedJobRunsWithStatus(func(run *models.JobRun) {
 		err := p.resumer(run, p.store.Unscoped())
 		if err != nil {
 			merr = multierr.Append(merr, err)
 		}
-		return nil
 	}, models.RunStatusPendingConnection)
 
 	if err != nil {

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -89,7 +89,7 @@ func (rm *jobRunner) resumeRunsSinceLastShutdown() error {
 	// runs in progress and asleep, to prevent the following race condition:
 	// 1. resume sleep, 2. awake from sleep, 3. in progress, 4. resume in progress (double enqueued).
 	var merr error
-	err := rm.store.UnscopedJobRunsWithStatusCB(func(run *models.JobRun) error {
+	err := rm.store.UnscopedJobRunsWithStatus(func(run *models.JobRun) error {
 
 		if run.Result.Status == models.RunStatusPendingSleep {
 			if err := QueueSleepingTask(run, rm.store.Unscoped()); err != nil {

--- a/services/job_runner.go
+++ b/services/job_runner.go
@@ -89,7 +89,7 @@ func (rm *jobRunner) resumeRunsSinceLastShutdown() error {
 	// runs in progress and asleep, to prevent the following race condition:
 	// 1. resume sleep, 2. awake from sleep, 3. in progress, 4. resume in progress (double enqueued).
 	var merr error
-	err := rm.store.UnscopedJobRunsWithStatus(func(run *models.JobRun) error {
+	err := rm.store.UnscopedJobRunsWithStatus(func(run *models.JobRun) {
 
 		if run.Result.Status == models.RunStatusPendingSleep {
 			if err := QueueSleepingTask(run, rm.store.Unscoped()); err != nil {
@@ -98,8 +98,6 @@ func (rm *jobRunner) resumeRunsSinceLastShutdown() error {
 		} else {
 			merr = multierr.Append(merr, rm.store.RunChannel.Send(run.ID))
 		}
-
-		return nil
 
 	}, models.RunStatusInProgress, models.RunStatusPendingSleep)
 

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -106,13 +106,12 @@ func (js *jobSubscriber) OnNewHead(head *models.Head) {
 	height := head.ToInt()
 	logger.Debugw("Received new head", "current_height", height)
 
-	err := js.store.UnscopedJobRunsWithStatus(func(run *models.JobRun) error {
+	err := js.store.UnscopedJobRunsWithStatus(func(run *models.JobRun) {
 		err := ResumeConfirmingTask(run, js.store.Unscoped(), height)
 		if err != nil {
 			logger.Errorf("JobSubscriber.OnNewHead: %v", err)
 		}
 
-		return nil
 	}, models.RunStatusPendingConfirmations)
 
 	if err != nil {

--- a/services/job_subscriber.go
+++ b/services/job_subscriber.go
@@ -103,20 +103,19 @@ func (js *jobSubscriber) Disconnect() {
 
 // OnNewHead resumes all pending job runs based on the new head activity.
 func (js *jobSubscriber) OnNewHead(head *models.Head) {
-	pendingRuns, err := js.store.UnscopedJobRunsWithStatus(models.RunStatusPendingConfirmations)
-	if err != nil {
-		logger.Error("error fetching pending job runs:", err.Error())
-	}
-
 	height := head.ToInt()
-	logger.Debugw("Received new head",
-		"current_height", height,
-		"pending_run_count", len(pendingRuns),
-	)
-	for _, jr := range pendingRuns {
-		err := ResumeConfirmingTask(&jr, js.store.Unscoped(), height)
+	logger.Debugw("Received new head", "current_height", height)
+
+	err := js.store.UnscopedJobRunsWithStatus(func(run *models.JobRun) error {
+		err := ResumeConfirmingTask(run, js.store.Unscoped(), height)
 		if err != nil {
-			logger.Error("JobSubscriber.OnNewHead: ", err.Error())
+			logger.Errorf("JobSubscriber.OnNewHead: %v", err)
 		}
+
+		return nil
+	}, models.RunStatusPendingConfirmations)
+
+	if err != nil {
+		logger.Errorf("error fetching pending job runs: %v", err)
 	}
 }

--- a/services/runs_test.go
+++ b/services/runs_test.go
@@ -525,6 +525,7 @@ func TestExecuteJob_DoesNotSaveToTaskSpec(t *testing.T) {
 
 	retrievedJob, err := store.FindJob(job.ID)
 	require.NoError(t, err)
-
+	require.Len(t, job.Tasks, 1)
+	require.Len(t, retrievedJob.Tasks, 1)
 	assert.Equal(t, job.Tasks[0].Params, retrievedJob.Tasks[0].Params)
 }

--- a/services/scheduler_test.go
+++ b/services/scheduler_test.go
@@ -292,7 +292,8 @@ func TestOneTime_RunJobAt_RunTwice(t *testing.T) {
 	ot.RunJobAt(j.Initiators[0], j)
 
 	j2, err := ot.Store.FindJob(j.ID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.Len(t, j2.Initiators, 1)
 	ot.RunJobAt(j2.Initiators[0], j2)
 
 	jobRuns, err := store.JobRunsFor(j.ID)
@@ -318,7 +319,8 @@ func TestOneTime_RunJobAt_UnstartedRun(t *testing.T) {
 	ot.RunJobAt(j.Initiators[0], j)
 
 	j2, err := store.FindJob(j.ID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.Len(t, j2.Initiators, 1)
 	assert.Equal(t, false, j2.Initiators[0].Ran)
 }
 
@@ -342,7 +344,8 @@ func TestOneTime_RunJobAt_ArchivedRun(t *testing.T) {
 
 	unscoped := store.Unscoped()
 	j2, err := unscoped.FindJob(j.ID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.Len(t, j2.Initiators, 1)
 	assert.Equal(t, false, j2.Initiators[0].Ran)
 	count, err := unscoped.JobRunsCountFor(j.ID)
 	require.NoError(t, err)

--- a/store/models/job_spec_test.go
+++ b/store/models/job_spec_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink/internal/cltest"
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	null "gopkg.in/guregu/null.v3"
 )
 
@@ -21,7 +22,8 @@ func TestJobSpec_Save(t *testing.T) {
 	initr := j1.Initiators[0]
 
 	j2, err := store.FindJob(j1.ID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.Len(t, j2.Initiators, 1)
 	assert.Equal(t, initr.Schedule, j2.Initiators[0].Schedule)
 }
 

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -366,7 +366,7 @@ func (orm *ORM) CreateServiceAgreement(sa *models.ServiceAgreement) error {
 
 // UnscopedJobRunsWithStatus passes all JobRuns to a callback, one by one,
 // including those that were soft deleted.
-func (orm *ORM) UnscopedJobRunsWithStatus(cb func(*models.JobRun) error, statuses ...models.RunStatus) error {
+func (orm *ORM) UnscopedJobRunsWithStatus(cb func(*models.JobRun), statuses ...models.RunStatus) error {
 	var runIDs []string
 	err := orm.DB.Unscoped().
 		Table("job_runs").
@@ -384,10 +384,7 @@ func (orm *ORM) UnscopedJobRunsWithStatus(cb func(*models.JobRun) error, statuse
 			return fmt.Errorf("error finding job run %v", err)
 		}
 
-		err = cb(&run)
-		if err != nil {
-			return fmt.Errorf("error returned by UnscopedJobRunsWithStatus callback %v", err)
-		}
+		cb(&run)
 	}
 
 	return nil

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -199,10 +199,10 @@ func (orm *ORM) preloadJobRuns() *gorm.DB {
 			return db.Unscoped()
 		}).
 		Preload("Overrides").
-		Preload("Result").
 		Preload("TaskRuns", func(db *gorm.DB) *gorm.DB {
 			return preloadTaskRuns(db).Order("task_spec_id asc")
-		})
+		}).
+		Preload("Result")
 }
 
 // FindJobRun looks up a JobRun by its ID.

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -371,7 +371,7 @@ func (orm *ORM) UnscopedJobRunsWithStatus(cb func(*models.JobRun) error, statuse
 	err := orm.DB.Unscoped().
 		Table("job_runs").
 		Where("status IN (?)", statuses).
-		Order("status desc, created_at asc").
+		Order("created_at asc").
 		Pluck("ID", &runIDs).Error
 	if err != nil {
 		return fmt.Errorf("error finding job ids %v", err)

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -369,17 +369,9 @@ func (orm *ORM) CreateServiceAgreement(sa *models.ServiceAgreement) error {
 	return orm.DB.Create(sa).Error
 }
 
-// UnscopedJobRunsWithStatus returns all JobRuns, including ones that have been
-// soft deleted, which have the passed statuses.
-func (orm *ORM) UnscopedJobRunsWithStatus(statuses ...models.RunStatus) ([]models.JobRun, error) {
-	runs := []models.JobRun{}
-	err := orm.Unscoped().preloadJobRuns().Where("status IN (?)", statuses).Find(&runs).Error
-	return runs, err
-}
-
-// UnscopedJobRunsWithStatusCB passes all JobRuns to a callback, one by one,
-// including soft deleted ones.
-func (orm *ORM) UnscopedJobRunsWithStatusCB(cb func(*models.JobRun) error, statuses ...models.RunStatus) error {
+// UnscopedJobRunsWithStatus passes all JobRuns to a callback, one by one,
+// including those that were soft deleted.
+func (orm *ORM) UnscopedJobRunsWithStatus(cb func(*models.JobRun) error, statuses ...models.RunStatus) error {
 	var runIDs []string
 	err := orm.DB.Unscoped().Table("job_runs").Where("status IN (?)", statuses).Order("status desc").Pluck("ID", &runIDs).Error
 	if err != nil {

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -267,7 +267,11 @@ func TestORM_UnscopedJobRunsWithStatus_Happy(t *testing.T) {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
 
-			pending, err := store.UnscopedJobRunsWithStatus(test.statuses...)
+			var pending []*models.JobRun
+			err := store.UnscopedJobRunsWithStatus(func(jr *models.JobRun) error {
+				pending = append(pending, jr)
+				return nil
+			}, test.statuses...)
 			assert.NoError(t, err)
 
 			pendingIDs := []string{}
@@ -327,7 +331,11 @@ func TestORM_UnscopedJobRunsWithStatus_Deleted(t *testing.T) {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
 
-			pending, err := store.UnscopedJobRunsWithStatus(test.statuses...)
+			var pending []*models.JobRun
+			err := store.UnscopedJobRunsWithStatus(func(jr *models.JobRun) error {
+				pending = append(pending, jr)
+				return nil
+			}, test.statuses...)
 			assert.NoError(t, err)
 
 			pendingIDs := []string{}

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -52,7 +52,8 @@ func TestORM_CreateJob(t *testing.T) {
 	store.CreateJob(&j1)
 
 	j2, err := store.FindJob(j1.ID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+	require.Len(t, j2.Initiators, 1)
 	j1.Initiators[0].CreatedAt = j2.Initiators[0].CreatedAt
 	assert.Equal(t, j1.ID, j2.ID)
 	assert.Equal(t, j1.Initiators[0], j2.Initiators[0])
@@ -130,6 +131,8 @@ func TestORM_SaveJobRun_DoesNotSaveTaskSpec(t *testing.T) {
 
 	retrievedJob, err := store.FindJob(job.ID)
 	require.NoError(t, err)
+	require.Len(t, job.Tasks, 1)
+	require.Len(t, retrievedJob.Tasks, 1)
 	assert.JSONEq(
 		t,
 		coercedJSON(job.Tasks[0].Params.String()),

--- a/store/orm/orm_test.go
+++ b/store/orm/orm_test.go
@@ -266,13 +266,7 @@ func TestORM_UnscopedJobRunsWithStatus_Happy(t *testing.T) {
 	for _, tt := range tests {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
-
-			var pending []*models.JobRun
-			err := store.UnscopedJobRunsWithStatus(func(jr *models.JobRun) error {
-				pending = append(pending, jr)
-				return nil
-			}, test.statuses...)
-			assert.NoError(t, err)
+			pending := cltest.MustAllJobsWithStatus(t, store, test.statuses...)
 
 			pendingIDs := []string{}
 			for _, jr := range pending {
@@ -330,13 +324,7 @@ func TestORM_UnscopedJobRunsWithStatus_Deleted(t *testing.T) {
 	for _, tt := range tests {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
-
-			var pending []*models.JobRun
-			err := store.UnscopedJobRunsWithStatus(func(jr *models.JobRun) error {
-				pending = append(pending, jr)
-				return nil
-			}, test.statuses...)
-			assert.NoError(t, err)
+			pending := cltest.MustAllJobsWithStatus(t, store, test.statuses...)
 
 			pendingIDs := []string{}
 			for _, jr := range pending {
@@ -366,12 +354,7 @@ func TestORM_UnscopedJobRunsWithStatus_OrdersByCreatedAt(t *testing.T) {
 	oldPending.CreatedAt = time.Now()
 	require.NoError(t, store.CreateJobRun(&oldPending))
 
-	var runs []*models.JobRun
-	err := store.UnscopedJobRunsWithStatus(func(jr *models.JobRun) error {
-		runs = append(runs, jr)
-		return nil
-	}, models.RunStatusInProgress, models.RunStatusPendingSleep)
-	require.NoError(t, err)
+	runs := cltest.MustAllJobsWithStatus(t, store, models.RunStatusInProgress, models.RunStatusPendingSleep)
 	require.Len(t, runs, 2)
 	assert.Equal(t, runs[0].ID, oldPending.ID)
 	assert.Equal(t, runs[1].ID, newPending.ID)

--- a/web/job_specs_controller_test.go
+++ b/web/job_specs_controller_test.go
@@ -189,8 +189,8 @@ func TestJobSpecsController_Create_HappyPath(t *testing.T) {
 	// Check ORM
 	orm := app.GetStore().ORM
 	j, err = orm.FindJob(j.ID)
-	assert.NoError(t, err)
-	assert.Len(t, j.Initiators, 1)
+	require.NoError(t, err)
+	require.Len(t, j.Initiators, 1)
 	assert.Equal(t, models.InitiatorWeb, j.Initiators[0].Type)
 
 	adapter1, _ = adapters.For(j.Tasks[0], app.Store)
@@ -334,7 +334,9 @@ func TestJobSpecsController_Show(t *testing.T) {
 	cltest.AssertServerResponse(t, resp, 200)
 
 	var respJob presenters.JobSpec
-	assert.NoError(t, cltest.ParseJSONAPIResponse(resp, &respJob))
+	require.NoError(t, cltest.ParseJSONAPIResponse(resp, &respJob))
+	require.Len(t, j.Initiators, 1)
+	require.Len(t, respJob.Initiators, 1)
 	assert.Equal(t, j.Initiators[0].Schedule, respJob.Initiators[0].Schedule, "should have the same schedule")
 	assert.Equal(t, jr[0].ID, respJob.Runs[0].ID, "should have job runs ordered by created at(descending)")
 	assert.Equal(t, jr[1].ID, respJob.Runs[1].ID, "should have job runs ordered by created at(descending)")


### PR DESCRIPTION
GORM combined with preloading tends to produce very large `IN(?)` expressions, which hit a hard limit of 1000 variables in a statement.

This PR changes UnscopedJobRunsWithStatus to first get all job run IDs, which should be relatively cheap. Then inflates each run before passing it to a callback. In theory this should mean that only one JobRun is inflated into memory at a time and the queries shouldn't hit the limit.

There may be an opportunity to improve this by batching the load of JobRuns into larger chunks, though this may be tricky due to the complicated shape of a JobRun and all its associated records. We should likely explore https://www.pivotaltracker.com/n/projects/2129823/stories/164807802 first, then consider optimising.