### PR TITLE
StatsPusher sends RequestID,TxHash,Requester

### DIFF
--- a/services/runs.go
+++ b/services/runs.go
@@ -20,6 +20,25 @@ func ExecuteJob(
 	input models.RunResult,
 	creationHeight *big.Int,
 	store *store.Store) (*models.JobRun, error) {
+	return ExecuteJobWithInitiatorRun(
+		job,
+		initiator,
+		input,
+		creationHeight,
+		store,
+		models.NewInitiatorRun(),
+	)
+}
+
+// ExecuteJobWithInitiatorRun saves and immediately begins executing a run
+// for a specified job, assiging the passed initiator run, if it is ready.
+func ExecuteJobWithInitiatorRun(
+	job models.JobSpec,
+	initiator models.Initiator,
+	input models.RunResult,
+	creationHeight *big.Int,
+	store *store.Store,
+	initiatorRun models.InitiatorRun) (*models.JobRun, error) {
 
 	logger.Debugw(fmt.Sprintf("New run triggered by %s", initiator.Type),
 		"job", job.ID,
@@ -32,6 +51,7 @@ func ExecuteJob(
 		return nil, err
 	}
 
+	run.InitiatorRun = initiatorRun
 	return run, createAndTrigger(run, store)
 }
 

--- a/services/runs.go
+++ b/services/runs.go
@@ -20,25 +20,25 @@ func ExecuteJob(
 	input models.RunResult,
 	creationHeight *big.Int,
 	store *store.Store) (*models.JobRun, error) {
-	return ExecuteJobWithInitiatorRun(
+	return ExecuteJobWithRunRequest(
 		job,
 		initiator,
 		input,
 		creationHeight,
 		store,
-		models.NewInitiatorRun(),
+		models.NewRunRequest(),
 	)
 }
 
-// ExecuteJobWithInitiatorRun saves and immediately begins executing a run
-// for a specified job, assiging the passed initiator run, if it is ready.
-func ExecuteJobWithInitiatorRun(
+// ExecuteJobWithRunRequest saves and immediately begins executing a run
+// for a specified job if it is ready, assiging the passed initiator run.
+func ExecuteJobWithRunRequest(
 	job models.JobSpec,
 	initiator models.Initiator,
 	input models.RunResult,
 	creationHeight *big.Int,
 	store *store.Store,
-	initiatorRun models.InitiatorRun) (*models.JobRun, error) {
+	runRequest models.RunRequest) (*models.JobRun, error) {
 
 	logger.Debugw(fmt.Sprintf("New run triggered by %s", initiator.Type),
 		"job", job.ID,
@@ -51,7 +51,7 @@ func ExecuteJobWithInitiatorRun(
 		return nil, err
 	}
 
-	run.InitiatorRun = initiatorRun
+	run.RunRequest = runRequest
 	return run, createAndTrigger(run, store)
 }
 

--- a/services/runs_test.go
+++ b/services/runs_test.go
@@ -541,10 +541,10 @@ func TestExecuteJobWithRunRequest(t *testing.T) {
 	job.Tasks = []models.TaskSpec{cltest.NewTask(t, "NoOp")} // empty params
 	require.NoError(t, store.CreateJob(&job))
 
-	deadbeef := null.StringFrom("0xdeadbeef")
+	requestID := "RequestID"
 	initr := job.Initiators[0]
 	rr := models.NewRunRequest()
-	rr.RequestID = &deadbeef
+	rr.RequestID = &requestID
 	jr, err := services.ExecuteJobWithRunRequest(
 		job,
 		initr,

--- a/services/runs_test.go
+++ b/services/runs_test.go
@@ -530,7 +530,7 @@ func TestExecuteJob_DoesNotSaveToTaskSpec(t *testing.T) {
 	assert.Equal(t, job.Tasks[0].Params, retrievedJob.Tasks[0].Params)
 }
 
-func TestExecuteJobWithInitiatorRun(t *testing.T) {
+func TestExecuteJobWithRunRequest(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication()
 	defer cleanup()
@@ -543,17 +543,17 @@ func TestExecuteJobWithInitiatorRun(t *testing.T) {
 
 	deadbeef := null.StringFrom("0xdeadbeef")
 	initr := job.Initiators[0]
-	ir := models.NewInitiatorRun()
-	ir.RequestID = &deadbeef
-	jr, err := services.ExecuteJobWithInitiatorRun(
+	rr := models.NewRunRequest()
+	rr.RequestID = &deadbeef
+	jr, err := services.ExecuteJobWithRunRequest(
 		job,
 		initr,
 		cltest.RunResultWithData(`{"random": "input"}`),
 		nil,
 		store,
-		ir,
+		rr,
 	)
 	require.NoError(t, err)
 	updatedJR := cltest.WaitForJobRunToComplete(t, store, *jr)
-	assert.Equal(t, ir.RequestID, updatedJR.InitiatorRun.RequestID)
+	assert.Equal(t, rr.RequestID, updatedJR.RunRequest.RequestID)
 }

--- a/services/runs_test.go
+++ b/services/runs_test.go
@@ -541,9 +541,10 @@ func TestExecuteJobWithInitiatorRun(t *testing.T) {
 	job.Tasks = []models.TaskSpec{cltest.NewTask(t, "NoOp")} // empty params
 	require.NoError(t, store.CreateJob(&job))
 
+	deadbeef := null.StringFrom("0xdeadbeef")
 	initr := job.Initiators[0]
 	ir := models.NewInitiatorRun()
-	ir.RequestID = null.StringFrom("0xdeadbeef")
+	ir.RequestID = &deadbeef
 	jr, err := services.ExecuteJobWithInitiatorRun(
 		job,
 		initr,

--- a/services/subscription.go
+++ b/services/subscription.go
@@ -159,18 +159,18 @@ func runJob(store *strpkg.Store, le models.LogRequest, data models.JSON) {
 		input.SetError(err)
 		logger.Errorw(err.Error(), le.ForLogger()...)
 	}
-	ir, err := le.InitiatorRun()
+	rr, err := le.RunRequest()
 	if err != nil {
 		input.SetError(err)
 		logger.Errorw(err.Error(), le.ForLogger()...)
 	}
-	_, err = ExecuteJobWithInitiatorRun(
+	_, err = ExecuteJobWithRunRequest(
 		le.GetJobSpec(),
 		le.GetInitiator(),
 		input,
 		le.BlockNumber(),
 		store.Unscoped(),
-		ir,
+		rr,
 	)
 	if err != nil {
 		logger.Errorw(err.Error(), le.ForLogger()...)

--- a/services/subscription.go
+++ b/services/subscription.go
@@ -160,7 +160,14 @@ func runJob(store *strpkg.Store, le models.LogRequest, data models.JSON) {
 		logger.Errorw(err.Error(), le.ForLogger()...)
 	}
 
-	_, err = ExecuteJob(le.GetJobSpec(), le.GetInitiator(), input, le.BlockNumber(), store.Unscoped())
+	_, err = ExecuteJobWithInitiatorRun(
+		le.GetJobSpec(),
+		le.GetInitiator(),
+		input,
+		le.BlockNumber(),
+		store.Unscoped(),
+		le.InitiatorRun(),
+	)
 	if err != nil {
 		logger.Errorw(err.Error(), le.ForLogger()...)
 	}

--- a/services/subscription.go
+++ b/services/subscription.go
@@ -159,14 +159,18 @@ func runJob(store *strpkg.Store, le models.LogRequest, data models.JSON) {
 		input.SetError(err)
 		logger.Errorw(err.Error(), le.ForLogger()...)
 	}
-
+	ir, err := le.InitiatorRun()
+	if err != nil {
+		input.SetError(err)
+		logger.Errorw(err.Error(), le.ForLogger()...)
+	}
 	_, err = ExecuteJobWithInitiatorRun(
 		le.GetJobSpec(),
 		le.GetInitiator(),
 		input,
 		le.BlockNumber(),
 		store.Unscoped(),
-		le.InitiatorRun(),
+		ir,
 	)
 	if err != nil {
 		logger.Errorw(err.Error(), le.ForLogger()...)

--- a/services/synchronization/presenters.go
+++ b/services/synchronization/presenters.go
@@ -18,16 +18,16 @@ type SyncJobRunPresenter struct {
 // MarshalJSON returns the JobRun as JSON
 func (p SyncJobRunPresenter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		ID          string                    `json:"id"`
-		JobID       string                    `json:"jobId"`
-		RunID       string                    `json:"runId"`
-		Status      string                    `json:"status"`
-		Error       null.String               `json:"error"`
-		CreatedAt   string                    `json:"createdAt"`
-		Amount      *assets.Link              `json:"amount"`
-		CompletedAt null.Time                 `json:"completedAt"`
-		Initiator   syncInitiatorRunPresenter `json:"initiator"`
-		Tasks       []syncTaskRunPresenter    `json:"tasks"`
+		ID          string                 `json:"id"`
+		JobID       string                 `json:"jobId"`
+		RunID       string                 `json:"runId"`
+		Status      string                 `json:"status"`
+		Error       null.String            `json:"error"`
+		CreatedAt   string                 `json:"createdAt"`
+		Amount      *assets.Link           `json:"amount"`
+		CompletedAt null.Time              `json:"completedAt"`
+		Initiator   syncInitiatorPresenter `json:"initiator"`
+		Tasks       []syncTaskRunPresenter `json:"tasks"`
 	}{
 		ID:          p.ID,
 		RunID:       p.ID,
@@ -42,16 +42,16 @@ func (p SyncJobRunPresenter) MarshalJSON() ([]byte, error) {
 	})
 }
 
-func (p SyncJobRunPresenter) initiator() syncInitiatorRunPresenter {
+func (p SyncJobRunPresenter) initiator() syncInitiatorPresenter {
 	var eip *models.EIP55Address
-	if p.InitiatorRun.Requester != nil {
-		coerced := models.EIP55Address(p.InitiatorRun.Requester.Hex())
+	if p.RunRequest.Requester != nil {
+		coerced := models.EIP55Address(p.RunRequest.Requester.Hex())
 		eip = &coerced
 	}
-	return syncInitiatorRunPresenter{
+	return syncInitiatorPresenter{
 		Type:      p.Initiator.Type,
-		RequestID: p.InitiatorRun.RequestID,
-		TxHash:    p.InitiatorRun.TxHash,
+		RequestID: p.RunRequest.RequestID,
+		TxHash:    p.RunRequest.TxHash,
 		Requester: eip,
 	}
 }
@@ -69,7 +69,7 @@ func (p SyncJobRunPresenter) tasks() []syncTaskRunPresenter {
 	return tasks
 }
 
-type syncInitiatorRunPresenter struct {
+type syncInitiatorPresenter struct {
 	Type      string               `json:"type"`
 	RequestID *null.String         `json:"requestId,omitempty"`
 	TxHash    *common.Hash         `json:"txHash,omitempty"`

--- a/services/synchronization/presenters.go
+++ b/services/synchronization/presenters.go
@@ -18,8 +18,9 @@ type SyncJobRunPresenter struct {
 // MarshalJSON returns the JobRun as JSON
 func (p SyncJobRunPresenter) MarshalJSON() ([]byte, error) {
 	return json.Marshal(&struct {
-		JobID       string                    `json:"jobID"`
-		RunID       string                    `json:"runID"`
+		ID          string                    `json:"id"`
+		JobID       string                    `json:"jobId"`
+		RunID       string                    `json:"runId"`
 		Status      string                    `json:"status"`
 		Error       null.String               `json:"error"`
 		CreatedAt   string                    `json:"createdAt"`
@@ -28,6 +29,7 @@ func (p SyncJobRunPresenter) MarshalJSON() ([]byte, error) {
 		Initiator   syncInitiatorRunPresenter `json:"initiator"`
 		Tasks       []syncTaskRunPresenter    `json:"tasks"`
 	}{
+		ID:          p.ID,
 		RunID:       p.ID,
 		JobID:       p.JobSpecID,
 		Status:      string(p.Status),

--- a/services/synchronization/presenters.go
+++ b/services/synchronization/presenters.go
@@ -43,11 +43,25 @@ func (p SyncJobRunPresenter) MarshalJSON() ([]byte, error) {
 }
 
 func (p SyncJobRunPresenter) initiator() syncInitiatorRunPresenter {
+	if !p.Initiator.IsLogInitiated() {
+		return syncInitiatorRunPresenter{
+			Type: p.Initiator.Type,
+		}
+	}
+
+	if p.Initiator.Type == models.InitiatorEthLog {
+		return syncInitiatorRunPresenter{
+			Type:   p.Initiator.Type,
+			TxHash: &p.InitiatorRun.TxHash,
+		}
+	}
+
+	eip := models.EIP55Address(p.InitiatorRun.Requester.Hex())
 	return syncInitiatorRunPresenter{
 		Type:      p.Initiator.Type,
-		RequestID: p.InitiatorRun.RequestID,
-		TxHash:    p.InitiatorRun.TxHash,
-		Requester: models.EIP55Address(p.InitiatorRun.Requester.Hex()),
+		RequestID: &p.InitiatorRun.RequestID,
+		TxHash:    &p.InitiatorRun.TxHash,
+		Requester: &eip,
 	}
 }
 
@@ -65,10 +79,10 @@ func (p SyncJobRunPresenter) tasks() []syncTaskRunPresenter {
 }
 
 type syncInitiatorRunPresenter struct {
-	Type      string              `json:"type"`
-	RequestID null.String         `json:"requestId"`
-	TxHash    common.Hash         `json:"txHash"`
-	Requester models.EIP55Address `json:"requester"`
+	Type      string               `json:"type"`
+	RequestID *null.String         `json:"requestId,omitempty"`
+	TxHash    *common.Hash         `json:"txHash,omitempty"`
+	Requester *models.EIP55Address `json:"requester,omitempty"`
 }
 
 type syncTaskRunPresenter struct {

--- a/services/synchronization/presenters.go
+++ b/services/synchronization/presenters.go
@@ -43,25 +43,16 @@ func (p SyncJobRunPresenter) MarshalJSON() ([]byte, error) {
 }
 
 func (p SyncJobRunPresenter) initiator() syncInitiatorRunPresenter {
-	if !p.Initiator.IsLogInitiated() {
-		return syncInitiatorRunPresenter{
-			Type: p.Initiator.Type,
-		}
+	var eip *models.EIP55Address
+	if p.InitiatorRun.Requester != nil {
+		coerced := models.EIP55Address(p.InitiatorRun.Requester.Hex())
+		eip = &coerced
 	}
-
-	if p.Initiator.Type == models.InitiatorEthLog {
-		return syncInitiatorRunPresenter{
-			Type:   p.Initiator.Type,
-			TxHash: &p.InitiatorRun.TxHash,
-		}
-	}
-
-	eip := models.EIP55Address(p.InitiatorRun.Requester.Hex())
 	return syncInitiatorRunPresenter{
 		Type:      p.Initiator.Type,
-		RequestID: &p.InitiatorRun.RequestID,
-		TxHash:    &p.InitiatorRun.TxHash,
-		Requester: &eip,
+		RequestID: p.InitiatorRun.RequestID,
+		TxHash:    p.InitiatorRun.TxHash,
+		Requester: eip,
 	}
 }
 

--- a/services/synchronization/presenters.go
+++ b/services/synchronization/presenters.go
@@ -71,7 +71,7 @@ func (p SyncJobRunPresenter) tasks() []syncTaskRunPresenter {
 
 type syncInitiatorPresenter struct {
 	Type      string               `json:"type"`
-	RequestID *null.String         `json:"requestId,omitempty"`
+	RequestID *string              `json:"requestId,omitempty"`
 	TxHash    *common.Hash         `json:"txHash,omitempty"`
 	Requester *models.EIP55Address `json:"requester,omitempty"`
 }

--- a/services/synchronization/presenters_test.go
+++ b/services/synchronization/presenters_test.go
@@ -25,7 +25,7 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 		Initiator: models.Initiator{
 			Type: models.InitiatorRunLog,
 		},
-		InitiatorRun: models.InitiatorRun{
+		RunRequest: models.RunRequest{
 			RequestID: &requestID,
 			TxHash:    &txHash,
 			Requester: &newAddress,
@@ -91,16 +91,16 @@ func TestSyncJobRunPresenter_Initiators(t *testing.T) {
 
 	tests := []struct {
 		initrType string
-		ir        models.InitiatorRun
+		rr        models.RunRequest
 		keyCount  int
 	}{
-		{models.InitiatorWeb, models.InitiatorRun{}, 1},
-		{models.InitiatorCron, models.InitiatorRun{}, 1},
-		{models.InitiatorRunAt, models.InitiatorRun{}, 1},
-		{models.InitiatorEthLog, models.InitiatorRun{TxHash: &txHash}, 2},
+		{models.InitiatorWeb, models.RunRequest{}, 1},
+		{models.InitiatorCron, models.RunRequest{}, 1},
+		{models.InitiatorRunAt, models.RunRequest{}, 1},
+		{models.InitiatorEthLog, models.RunRequest{TxHash: &txHash}, 2},
 		{
 			models.InitiatorRunLog,
-			models.InitiatorRun{
+			models.RunRequest{
 				RequestID: &requestID,
 				TxHash:    &txHash,
 				Requester: &newAddress,
@@ -112,9 +112,9 @@ func TestSyncJobRunPresenter_Initiators(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.initrType, func(t *testing.T) {
 			jobRun := models.JobRun{
-				ID:           "runID-412",
-				Initiator:    models.Initiator{Type: test.initrType},
-				InitiatorRun: test.ir,
+				ID:         "runID-412",
+				Initiator:  models.Initiator{Type: test.initrType},
+				RunRequest: test.rr,
 			}
 
 			p := SyncJobRunPresenter{JobRun: &jobRun}

--- a/services/synchronization/presenters_test.go
+++ b/services/synchronization/presenters_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 	newAddress := common.HexToAddress("0x9FBDa871d559710256a2502A2517b794B482Db40")
-	requestID := null.StringFrom("RequestID")
+	requestID := "RequestID"
 	txHash := common.HexToHash("0xdeadbeef")
 
 	jobRun := models.JobRun{
@@ -86,7 +86,7 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 
 func TestSyncJobRunPresenter_Initiators(t *testing.T) {
 	newAddress := common.HexToAddress("0x9FBDa871d559710256a2502A2517b794B482Db40")
-	requestID := null.StringFrom("RequestID")
+	requestID := "RequestID"
 	txHash := common.HexToHash("0xdeadbeef")
 
 	tests := []struct {

--- a/services/synchronization/presenters_test.go
+++ b/services/synchronization/presenters_test.go
@@ -95,6 +95,8 @@ func TestSyncJobRunPresenter_Initiators(t *testing.T) {
 		keyCount  int
 	}{
 		{models.InitiatorWeb, models.InitiatorRun{}, 1},
+		{models.InitiatorCron, models.InitiatorRun{}, 1},
+		{models.InitiatorRunAt, models.InitiatorRun{}, 1},
 		{models.InitiatorEthLog, models.InitiatorRun{TxHash: &txHash}, 2},
 		{
 			models.InitiatorRunLog,

--- a/services/synchronization/presenters_test.go
+++ b/services/synchronization/presenters_test.go
@@ -14,6 +14,8 @@ import (
 
 func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 	newAddress := common.HexToAddress("0x9FBDa871d559710256a2502A2517b794B482Db40")
+	requestID := null.StringFrom("RequestID")
+	txHash := common.HexToHash("0xdeadbeef")
 
 	jobRun := models.JobRun{
 		ID:        "runID-411",
@@ -24,9 +26,9 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 			Type: models.InitiatorRunLog,
 		},
 		InitiatorRun: models.InitiatorRun{
-			RequestID: null.StringFrom("RequestID"),
-			TxHash:    common.HexToHash("0xdeadbeef"),
-			Requester: newAddress,
+			RequestID: &requestID,
+			TxHash:    &txHash,
+			Requester: &newAddress,
 		},
 		TaskRuns: []models.TaskRun{
 			models.TaskRun{
@@ -83,19 +85,23 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 }
 
 func TestSyncJobRunPresenter_Initiators(t *testing.T) {
+	newAddress := common.HexToAddress("0x9FBDa871d559710256a2502A2517b794B482Db40")
+	requestID := null.StringFrom("RequestID")
+	txHash := common.HexToHash("0xdeadbeef")
+
 	tests := []struct {
 		initrType string
 		ir        models.InitiatorRun
 		keyCount  int
 	}{
 		{models.InitiatorWeb, models.InitiatorRun{}, 1},
-		{models.InitiatorEthLog, models.InitiatorRun{TxHash: common.HexToHash("0xdeadbeef")}, 2},
+		{models.InitiatorEthLog, models.InitiatorRun{TxHash: &txHash}, 2},
 		{
 			models.InitiatorRunLog,
 			models.InitiatorRun{
-				RequestID: null.StringFrom("RequestID"),
-				TxHash:    common.HexToHash("0xdeadbeef"),
-				Requester: common.HexToAddress("0x9FBDa871d559710256a2502A2517b794B482Db40"),
+				RequestID: &requestID,
+				TxHash:    &txHash,
+				Requester: &newAddress,
 			},
 			4,
 		},

--- a/services/synchronization/presenters_test.go
+++ b/services/synchronization/presenters_test.go
@@ -49,8 +49,9 @@ func TestSyncJobRunPresenter(t *testing.T) {
 	err = json.Unmarshal(bytes, &data)
 	require.NoError(t, err)
 
-	assert.Equal(t, data["runID"], "runID-411")
-	assert.Equal(t, data["jobID"], "jobSpecID-312")
+	assert.Equal(t, data["id"], "runID-411")
+	assert.Equal(t, data["runId"], "runID-411")
+	assert.Equal(t, data["jobId"], "jobSpecID-312")
 	assert.Equal(t, data["status"], "in_progress")
 	assert.Contains(t, data, "error")
 	assert.Contains(t, data, "createdAt")

--- a/store/migrations/migrate.go
+++ b/store/migrations/migrate.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink/store/migrations/migration1551895034"
 	"github.com/smartcontractkit/chainlink/store/migrations/migration1552418531"
 	"github.com/smartcontractkit/chainlink/store/migrations/migration1553029703"
+	"github.com/smartcontractkit/chainlink/store/migrations/migration1554131520"
 	gormigrate "gopkg.in/gormigrate.v1"
 )
 
@@ -50,6 +51,10 @@ func Migrate(db *gorm.DB) error {
 		{
 			ID:      "1553029703",
 			Migrate: migration1553029703.Migration{}.Migrate,
+		},
+		{
+			ID:      "1554131520",
+			Migrate: migration1554131520.Migration{}.Migrate,
 		},
 	})
 

--- a/store/migrations/migration1554131520/migrate.go
+++ b/store/migrations/migration1554131520/migrate.go
@@ -1,0 +1,14 @@
+package migration1554131520
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/smartcontractkit/chainlink/store/models"
+)
+
+// Migration is the singleton type for this migration
+type Migration struct{}
+
+// Migrate adds the initiator_runs table
+func (m Migration) Migrate(tx *gorm.DB) error {
+	return tx.AutoMigrate(&models.InitiatorRun{}).Error
+}

--- a/store/migrations/migration1554131520/migrate.go
+++ b/store/migrations/migration1554131520/migrate.go
@@ -1,6 +1,7 @@
 package migration1554131520
 
 import (
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/jinzhu/gorm"
 	"github.com/smartcontractkit/chainlink/store/models"
 )
@@ -10,5 +11,63 @@ type Migration struct{}
 
 // Migrate adds the run request table
 func (m Migration) Migrate(tx *gorm.DB) error {
-	return tx.AutoMigrate(&models.RunRequest{}).Error
+	if err := tx.AutoMigrate(&models.RunRequest{}).Error; err != nil {
+		return err
+	}
+
+	if err := backfillRunRequests(tx, "runat", models.RunRequest{}); err != nil {
+		return err
+	}
+	if err := backfillRunRequests(tx, "cron", models.RunRequest{}); err != nil {
+		return err
+	}
+	if err := backfillRunRequests(tx, "web", models.RunRequest{}); err != nil {
+		return err
+	}
+	txhash := common.HexToHash("0xeeeeeeeeeeeeeeee")
+	if err := backfillRunRequests(tx, "ethlog", models.RunRequest{TxHash: &txhash}); err != nil {
+		return err
+	}
+	requester := common.HexToAddress("0xdeadbeef")
+	requestID := "BACKFILLED_FAKE"
+	runlogrr := models.RunRequest{TxHash: &txhash, Requester: &requester, RequestID: &requestID}
+	if err := backfillRunRequests(tx, "runlog", runlogrr); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func backfillRunRequests(tx *gorm.DB, initrType string, rr models.RunRequest) error {
+	results, err := runIdsFor(tx, initrType)
+	if err != nil {
+		return err
+	}
+	for _, jrid := range results {
+		if err := replaceRunRequest(tx, jrid, rr); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func runIdsFor(tx *gorm.DB, initrType string) ([]string, error) {
+	var results []string
+	err := tx.Unscoped().
+		Table("job_runs").
+		Joins("inner join initiators on job_runs.initiator_id = initiators.id").
+		Where("job_runs.run_request_id IS NULL AND initiators.type = ?", initrType).
+		Pluck("job_runs.id", &results).Error
+	return results, err
+}
+
+func replaceRunRequest(tx *gorm.DB, jrid string, rr models.RunRequest) error {
+	jr := models.JobRun{ID: jrid}
+	if err := tx.Create(&rr).Error; err != nil {
+		return err
+	}
+	if err := tx.Model(&jr).Association("RunRequest").Replace(rr).Error; err != nil {
+		return err
+	}
+	return nil
 }

--- a/store/migrations/migration1554131520/migrate.go
+++ b/store/migrations/migration1554131520/migrate.go
@@ -8,7 +8,7 @@ import (
 // Migration is the singleton type for this migration
 type Migration struct{}
 
-// Migrate adds the initiator_runs table
+// Migrate adds the run request table
 func (m Migration) Migrate(tx *gorm.DB) error {
-	return tx.AutoMigrate(&models.InitiatorRun{}).Error
+	return tx.AutoMigrate(&models.RunRequest{}).Error
 }

--- a/store/models/job_spec.go
+++ b/store/models/job_spec.go
@@ -90,19 +90,19 @@ func (j JobSpec) NewRun(i Initiator) JobRun {
 		}
 	}
 
-	initiatorRun := NewInitiatorRun()
+	runRequest := NewRunRequest()
 	now := time.Now()
 	return JobRun{
-		ID:           jrid,
-		JobSpecID:    j.ID,
-		CreatedAt:    now,
-		UpdatedAt:    now,
-		TaskRuns:     taskRuns,
-		InitiatorRun: initiatorRun,
-		Initiator:    i,
-		InitiatorID:  i.ID,
-		Status:       RunStatusUnstarted,
-		Result:       RunResult{CachedJobRunID: jrid},
+		ID:          jrid,
+		JobSpecID:   j.ID,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		TaskRuns:    taskRuns,
+		RunRequest:  runRequest,
+		Initiator:   i,
+		InitiatorID: i.ID,
+		Status:      RunStatusUnstarted,
+		Result:      RunResult{CachedJobRunID: jrid},
 	}
 }
 

--- a/store/models/job_spec.go
+++ b/store/models/job_spec.go
@@ -90,17 +90,19 @@ func (j JobSpec) NewRun(i Initiator) JobRun {
 		}
 	}
 
+	initiatorRun := NewInitiatorRun()
 	now := time.Now()
 	return JobRun{
-		ID:          jrid,
-		JobSpecID:   j.ID,
-		CreatedAt:   now,
-		UpdatedAt:   now,
-		TaskRuns:    taskRuns,
-		Initiator:   i,
-		InitiatorID: i.ID,
-		Status:      RunStatusUnstarted,
-		Result:      RunResult{CachedJobRunID: jrid},
+		ID:           jrid,
+		JobSpecID:    j.ID,
+		CreatedAt:    now,
+		UpdatedAt:    now,
+		TaskRuns:     taskRuns,
+		InitiatorRun: initiatorRun,
+		Initiator:    i,
+		InitiatorID:  i.ID,
+		Status:       RunStatusUnstarted,
+		Result:       RunResult{CachedJobRunID: jrid},
 	}
 }
 

--- a/store/models/log_events.go
+++ b/store/models/log_events.go
@@ -208,8 +208,9 @@ func (le InitiatorLogEvent) BlockNumber() *big.Int {
 // InitiatorRun returns an initiator run with the transaction hash,
 // present on all log initiated runs.
 func (le InitiatorLogEvent) InitiatorRun() (InitiatorRun, error) {
+	cp := common.BytesToHash(le.Log.TxHash.Bytes())
 	return InitiatorRun{
-		TxHash: le.Log.TxHash,
+		TxHash: &cp,
 	}, nil
 }
 
@@ -328,10 +329,13 @@ func (le RunLogEvent) InitiatorRun() (InitiatorRun, error) {
 		return InitiatorRun{}, err
 	}
 
+	txhash := common.BytesToHash(le.Log.TxHash.Bytes())
+	str := null.StringFrom(parser.parseRequestID(le.Log))
+	requester := le.Requester()
 	return InitiatorRun{
-		RequestID: null.StringFrom(parser.parseRequestID(le.Log)),
-		TxHash:    le.Log.TxHash,
-		Requester: le.Requester(),
+		RequestID: &str,
+		TxHash:    &txhash,
+		Requester: &requester,
 	}, nil
 }
 

--- a/store/models/log_events.go
+++ b/store/models/log_events.go
@@ -9,6 +9,7 @@ import (
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/utils"
@@ -59,16 +60,19 @@ var (
 	OracleFulfillmentFunctionID20190128withoutCast = utils.MustHash("fulfillOracleRequest(bytes32,uint256,address,bytes4,uint256,bytes32)").Hex()[:10]
 )
 
-type logRequestParser func(Log) (JSON, error)
+type logRequestParser interface {
+	parseJSON(Log) (JSON, error)
+	parseRequestID(Log) string
+}
 
 // topicFactoryMap maps the log topic to a factory method that returns an
 // implementation of the interface LogRequest. The concrete implementations
 // are polymorphic and can have difference behaviors for methods like JSON().
 var topicFactoryMap = map[common.Hash]logRequestParser{
-	ServiceAgreementExecutionLogTopic:         parseRunLog0original,
-	RunLogTopic0original:                      parseRunLog0original,
-	RunLogTopic20190123withFullfillmentParams: parseRunLog20190123withFulfillmentParams,
-	RunLogTopic20190207withoutIndexes:         parseRunLog20190207withoutIndexes,
+	ServiceAgreementExecutionLogTopic:         parseRunLog0original{},
+	RunLogTopic0original:                      parseRunLog0original{},
+	RunLogTopic20190123withFullfillmentParams: parseRunLog20190123withFulfillmentParams{},
+	RunLogTopic20190207withoutIndexes:         parseRunLog20190207withoutIndexes{},
 }
 
 // TopicFiltersForRunLog generates the two variations of RunLog IDs that could
@@ -129,7 +133,7 @@ type LogRequest interface {
 	ContractPayment() (*assets.Link, error)
 	ValidateRequester() error
 	BlockNumber() *big.Int
-	InitiatorRun() InitiatorRun
+	InitiatorRun() (InitiatorRun, error)
 }
 
 // InitiatorLogEvent encapsulates all information as a result of a received log from an
@@ -203,10 +207,10 @@ func (le InitiatorLogEvent) BlockNumber() *big.Int {
 
 // InitiatorRun returns an initiator run with the transaction hash,
 // present on all log initiated runs.
-func (le InitiatorLogEvent) InitiatorRun() InitiatorRun {
+func (le InitiatorLogEvent) InitiatorRun() (InitiatorRun, error) {
 	return InitiatorRun{
 		TxHash: le.Log.TxHash,
-	}
+	}, nil
 }
 
 // Validate returns true, no validation on this log event type.
@@ -318,18 +322,17 @@ func (le RunLogEvent) Requester() common.Address {
 
 // InitiatorRun returns an InitiatorRun instance with all parameters
 // from a run log topic, like RequestID.
-func (le RunLogEvent) InitiatorRun() InitiatorRun {
+func (le RunLogEvent) InitiatorRun() (InitiatorRun, error) {
+	parser, err := parserFromLog(le.Log)
+	if err != nil {
+		return InitiatorRun{}, err
+	}
+
 	return InitiatorRun{
-		RequestID: null.StringFrom(le.parseRequestID()),
+		RequestID: null.StringFrom(parser.parseRequestID(le.Log)),
 		TxHash:    le.Log.TxHash,
 		Requester: le.Requester(),
-	}
-}
-
-func (le RunLogEvent) parseRequestID() string {
-	data := le.Log.Data
-	start := requesterSize
-	return common.BytesToHash(data[start : start+idSize]).Hex()
+	}, nil
 }
 
 // JSON decodes the RunLogEvent's data converts it to a JSON object.
@@ -337,22 +340,32 @@ func (le RunLogEvent) JSON() (JSON, error) {
 	return ParseRunLog(le.Log)
 }
 
+func parserFromLog(log Log) (logRequestParser, error) {
+	topic, err := log.getTopic(0)
+	if err != nil {
+		return nil, errors.Wrap(err, "log#getTopic(0)")
+	}
+	parser, ok := topicFactoryMap[topic]
+	if !ok {
+		return nil, fmt.Errorf("No parser for the RunLogEvent topic %v", topic)
+	}
+	return parser, nil
+}
+
 // ParseRunLog decodes the CBOR in the ABI of the log event.
 func ParseRunLog(log Log) (JSON, error) {
-	topic, err := log.getTopic(0)
+	parser, err := parserFromLog(log)
 	if err != nil {
 		return JSON{}, err
 	}
-	parse, ok := topicFactoryMap[topic]
-	if !ok {
-		return JSON{}, fmt.Errorf("No parser for the RunLogEvent topic %v", topic)
-	}
-	return parse(log)
+	return parser.parseJSON(log)
 }
 
 // parseRunLog0original parses the original OracleRequest log format.
 // It responds with only the request ID and data.
-func parseRunLog0original(log Log) (JSON, error) {
+type parseRunLog0original struct{}
+
+func (p parseRunLog0original) parseJSON(log Log) (JSON, error) {
 	data := log.Data
 	start := idSize + versionSize + dataLocationSize + dataLengthSize
 
@@ -373,11 +386,17 @@ func parseRunLog0original(log Log) (JSON, error) {
 	return js.Add("functionSelector", OracleFullfillmentFunctionID0original)
 }
 
+func (parseRunLog0original) parseRequestID(log Log) string {
+	return common.BytesToHash(log.Data[:idSize]).Hex()
+}
+
 // parseRunLog20190123withFulfillmentParams parses the OracleRequest log format
 // which includes the callback, the payment amount, and expiration time
 // The fulfillment also includes the callback, payment amount, and expiration,
 // in addtion to the request ID and data.
-func parseRunLog20190123withFulfillmentParams(log Log) (JSON, error) {
+type parseRunLog20190123withFulfillmentParams struct{}
+
+func (parseRunLog20190123withFulfillmentParams) parseJSON(log Log) (JSON, error) {
 	data := log.Data
 	cborStart := idSize + versionSize + callbackAddrSize + callbackFuncSize + expirationSize + dataLocationSize + dataLengthSize
 
@@ -404,12 +423,18 @@ func parseRunLog20190123withFulfillmentParams(log Log) (JSON, error) {
 	return js.Add("functionSelector", OracleFulfillmentFunctionID20190123withFulfillmentParams)
 }
 
+func (parseRunLog20190123withFulfillmentParams) parseRequestID(log Log) string {
+	return common.BytesToHash(log.Data[:idSize]).Hex()
+}
+
 // parseRunLog20190207withoutIndexes parses the OracleRequest log format after
 // the sender and payment amount indexes were removed.
 // Additionally, the version field for the data payload was moved next to the
 // data that it corresponds to. The fulfillment is made up of the request ID,
 // payment amount, callback, expiration, and data.
-func parseRunLog20190207withoutIndexes(log Log) (JSON, error) {
+type parseRunLog20190207withoutIndexes struct{}
+
+func (parseRunLog20190207withoutIndexes) parseJSON(log Log) (JSON, error) {
 	data := log.Data
 	idStart := requesterSize
 	expirationEnd := idStart + idSize + paymentSize + callbackAddrSize + callbackFuncSize + expirationSize
@@ -430,6 +455,11 @@ func parseRunLog20190207withoutIndexes(log Log) (JSON, error) {
 	}
 
 	return js.Add("functionSelector", OracleFulfillmentFunctionID20190128withoutCast)
+}
+
+func (parseRunLog20190207withoutIndexes) parseRequestID(log Log) string {
+	start := requesterSize
+	return common.BytesToHash(log.Data[start : start+idSize]).Hex()
 }
 
 func bytesToHex(data []byte) string {

--- a/store/models/log_events.go
+++ b/store/models/log_events.go
@@ -133,7 +133,7 @@ type LogRequest interface {
 	ContractPayment() (*assets.Link, error)
 	ValidateRequester() error
 	BlockNumber() *big.Int
-	InitiatorRun() (InitiatorRun, error)
+	RunRequest() (RunRequest, error)
 }
 
 // InitiatorLogEvent encapsulates all information as a result of a received log from an
@@ -205,11 +205,11 @@ func (le InitiatorLogEvent) BlockNumber() *big.Int {
 	return num
 }
 
-// InitiatorRun returns an initiator run with the transaction hash,
+// RunRequest returns a run request instance with the transaction hash,
 // present on all log initiated runs.
-func (le InitiatorLogEvent) InitiatorRun() (InitiatorRun, error) {
+func (le InitiatorLogEvent) RunRequest() (RunRequest, error) {
 	cp := common.BytesToHash(le.Log.TxHash.Bytes())
-	return InitiatorRun{
+	return RunRequest{
 		TxHash: &cp,
 	}, nil
 }
@@ -321,18 +321,18 @@ func (le RunLogEvent) Requester() common.Address {
 	return common.BytesToAddress(le.Log.Data[:requesterSize])
 }
 
-// InitiatorRun returns an InitiatorRun instance with all parameters
+// RunRequest returns an RunRequest instance with all parameters
 // from a run log topic, like RequestID.
-func (le RunLogEvent) InitiatorRun() (InitiatorRun, error) {
+func (le RunLogEvent) RunRequest() (RunRequest, error) {
 	parser, err := parserFromLog(le.Log)
 	if err != nil {
-		return InitiatorRun{}, err
+		return RunRequest{}, err
 	}
 
 	txhash := common.BytesToHash(le.Log.TxHash.Bytes())
 	str := null.StringFrom(parser.parseRequestID(le.Log))
 	requester := le.Requester()
-	return InitiatorRun{
+	return RunRequest{
 		RequestID: &str,
 		TxHash:    &txhash,
 		Requester: &requester,

--- a/store/models/log_events.go
+++ b/store/models/log_events.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smartcontractkit/chainlink/logger"
 	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/smartcontractkit/chainlink/utils"
-	null "gopkg.in/guregu/null.v3"
 )
 
 // Descriptive indices of a RunLog's Topic array
@@ -330,7 +329,7 @@ func (le RunLogEvent) RunRequest() (RunRequest, error) {
 	}
 
 	txhash := common.BytesToHash(le.Log.TxHash.Bytes())
-	str := null.StringFrom(parser.parseRequestID(le.Log))
+	str := parser.parseRequestID(le.Log)
 	requester := le.Requester()
 	return RunRequest{
 		RequestID: &str,

--- a/store/models/log_events_test.go
+++ b/store/models/log_events_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	null "gopkg.in/guregu/null.v3"
 )
 
 func TestParseRunLog(t *testing.T) {
@@ -379,8 +378,7 @@ func TestRunLogEvent_RunRequest(t *testing.T) {
 			rr, err := rle.RunRequest()
 			require.NoError(t, err)
 
-			requestID := null.StringFrom(test.wantRequestID)
-			assert.Equal(t, &requestID, rr.RequestID)
+			assert.Equal(t, &test.wantRequestID, rr.RequestID)
 			assert.Equal(t, test.wantTxHash, rr.TxHash.Hex())
 			assert.Equal(t, &test.wantRequester, rr.Requester)
 		})

--- a/store/models/log_events_test.go
+++ b/store/models/log_events_test.go
@@ -340,7 +340,7 @@ func TestRunLogEvent_Requester(t *testing.T) {
 	}
 }
 
-func TestRunLogEvent_InitiatorRun(t *testing.T) {
+func TestRunLogEvent_RunRequest(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -376,13 +376,13 @@ func TestRunLogEvent_InitiatorRun(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			rle := models.RunLogEvent{models.InitiatorLogEvent{Log: test.log}}
-			ir, err := rle.InitiatorRun()
+			rr, err := rle.RunRequest()
 			require.NoError(t, err)
 
 			requestID := null.StringFrom(test.wantRequestID)
-			assert.Equal(t, &requestID, ir.RequestID)
-			assert.Equal(t, test.wantTxHash, ir.TxHash.Hex())
-			assert.Equal(t, &test.wantRequester, ir.Requester)
+			assert.Equal(t, &requestID, rr.RequestID)
+			assert.Equal(t, test.wantTxHash, rr.TxHash.Hex())
+			assert.Equal(t, &test.wantRequester, rr.Requester)
 		})
 	}
 }

--- a/store/models/log_events_test.go
+++ b/store/models/log_events_test.go
@@ -344,32 +344,32 @@ func TestRunLogEvent_InitiatorRun(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		log       models.Log
-		requester common.Address
-		txhash    string
-		requestID string
+		name          string
+		log           models.Log
+		wantRequestID string
+		wantTxHash    string
+		wantRequester common.Address
 	}{
 		{
-			name:      "old non-commitment",
-			log:       cltest.LogFromFixture(t, "../../internal/fixtures/eth/requestLog0original.json"),
-			requestID: "0x0000000000000000000000000000000000000000000000000000000000000017",
-			txhash:    "0xe05b171038320aca6634ce50de669bd0baa337130269c3ce3594ce4d45fc342a",
-			requester: common.HexToAddress("0xd352677fcded6c358e03c73ea2a8a2832dffc0a4"),
+			name:          "old non-commitment",
+			log:           cltest.LogFromFixture(t, "../../internal/fixtures/eth/requestLog0original.json"),
+			wantRequestID: "0x0000000000000000000000000000000000000000000000000000000000000017",
+			wantTxHash:    "0xe05b171038320aca6634ce50de669bd0baa337130269c3ce3594ce4d45fc342a",
+			wantRequester: common.HexToAddress("0xd352677fcded6c358e03c73ea2a8a2832dffc0a4"),
 		},
 		{
-			name:      "20190123 with fulfillment params",
-			log:       cltest.LogFromFixture(t, "../../internal/fixtures/eth/requestLog20190123withFulfillmentParams.json"),
-			requestID: "0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8",
-			txhash:    "0x04250548cd0b5d03b3bf1331aa83f32b35879440db31a6008d151260a5f3cc76",
-			requester: common.HexToAddress("0x9fbda871d559710256a2502a2517b794b482db41"),
+			name:          "20190123 with fulfillment params",
+			log:           cltest.LogFromFixture(t, "../../internal/fixtures/eth/requestLog20190123withFulfillmentParams.json"),
+			wantRequestID: "0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8",
+			wantTxHash:    "0x04250548cd0b5d03b3bf1331aa83f32b35879440db31a6008d151260a5f3cc76",
+			wantRequester: common.HexToAddress("0x9fbda871d559710256a2502a2517b794b482db41"),
 		},
 		{
-			name:      "20190207 without indexes",
-			log:       cltest.LogFromFixture(t, "../../internal/fixtures/eth/requestLog20190207withoutIndexes.json"),
-			requestID: "0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8",
-			txhash:    "0x04250548cd0b5d03b3bf1331aa83f32b35879440db31a6008d151260a5f3cc76",
-			requester: common.HexToAddress("0x9FBDa871d559710256a2502A2517b794B482Db40"),
+			name:          "20190207 without indexes",
+			log:           cltest.LogFromFixture(t, "../../internal/fixtures/eth/requestLog20190207withoutIndexes.json"),
+			wantRequestID: "0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8",
+			wantTxHash:    "0x04250548cd0b5d03b3bf1331aa83f32b35879440db31a6008d151260a5f3cc76",
+			wantRequester: common.HexToAddress("0x9FBDa871d559710256a2502A2517b794B482Db40"),
 		},
 	}
 
@@ -379,9 +379,10 @@ func TestRunLogEvent_InitiatorRun(t *testing.T) {
 			ir, err := rle.InitiatorRun()
 			require.NoError(t, err)
 
-			assert.Equal(t, null.StringFrom(test.requestID), ir.RequestID)
-			assert.Equal(t, test.txhash, ir.TxHash.Hex())
-			assert.Equal(t, test.requester, ir.Requester)
+			requestID := null.StringFrom(test.wantRequestID)
+			assert.Equal(t, &requestID, ir.RequestID)
+			assert.Equal(t, test.wantTxHash, ir.TxHash.Hex())
+			assert.Equal(t, &test.wantRequester, ir.Requester)
 		})
 	}
 }

--- a/store/models/log_events_test.go
+++ b/store/models/log_events_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/store/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	null "gopkg.in/guregu/null.v3"
 )
 
 func TestParseRunLog(t *testing.T) {
@@ -337,4 +338,14 @@ func TestRunLogEvent_Requester(t *testing.T) {
 			assert.Equal(t, test.want, received)
 		})
 	}
+}
+
+func TestRunLogEvent_InitiatorRun(t *testing.T) {
+	log := cltest.LogFromFixture(t, "../../internal/fixtures/eth/requestLog20190207withoutIndexes.json")
+	rle := models.RunLogEvent{models.InitiatorLogEvent{Log: log}}
+	ir := rle.InitiatorRun()
+
+	assert.Equal(t, null.StringFrom("0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8"), ir.RequestID)
+	assert.Equal(t, "0x04250548cd0b5d03b3bf1331aa83f32b35879440db31a6008d151260a5f3cc76", ir.TxHash.Hex())
+	assert.Equal(t, common.HexToAddress("0x9FBDa871d559710256a2502A2517b794B482Db40"), ir.Requester)
 }

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -15,24 +15,24 @@ import (
 // JobRun tracks the status of a job by holding its TaskRuns and the
 // Result of each Run.
 type JobRun struct {
-	ID             string       `json:"id" gorm:"primary_key;not null"`
-	JobSpecID      string       `json:"jobId" gorm:"index;not null;type:varchar(36) REFERENCES job_specs(id)"`
-	Result         RunResult    `json:"result"`
-	ResultID       uint         `json:"-"`
-	InitiatorRun   InitiatorRun `json:"-"`
-	InitiatorRunID uint         `json:"-"`
-	Status         RunStatus    `json:"status" gorm:"index"`
-	TaskRuns       []TaskRun    `json:"taskRuns"`
-	CreatedAt      time.Time    `json:"createdAt" gorm:"index"`
-	CompletedAt    null.Time    `json:"completedAt"`
-	UpdatedAt      time.Time    `json:"updatedAt"`
-	Initiator      Initiator    `json:"initiator" gorm:"association_autoupdate:false;association_autocreate:false"`
-	InitiatorID    uint         `json:"-"`
-	CreationHeight *Big         `json:"creationHeight" gorm:"type:varchar(255)"`
-	ObservedHeight *Big         `json:"observedHeight" gorm:"type:varchar(255)"`
-	Overrides      RunResult    `json:"overrides"`
-	OverridesID    uint         `json:"-"`
-	DeletedAt      null.Time    `json:"-" gorm:"index"`
+	ID             string     `json:"id" gorm:"primary_key;not null"`
+	JobSpecID      string     `json:"jobId" gorm:"index;not null;type:varchar(36) REFERENCES job_specs(id)"`
+	Result         RunResult  `json:"result"`
+	ResultID       uint       `json:"-"`
+	RunRequest     RunRequest `json:"-"`
+	RunRequestID   uint       `json:"-"`
+	Status         RunStatus  `json:"status" gorm:"index"`
+	TaskRuns       []TaskRun  `json:"taskRuns"`
+	CreatedAt      time.Time  `json:"createdAt" gorm:"index"`
+	CompletedAt    null.Time  `json:"completedAt"`
+	UpdatedAt      time.Time  `json:"updatedAt"`
+	Initiator      Initiator  `json:"initiator" gorm:"association_autoupdate:false;association_autocreate:false"`
+	InitiatorID    uint       `json:"-"`
+	CreationHeight *Big       `json:"creationHeight" gorm:"type:varchar(255)"`
+	ObservedHeight *Big       `json:"observedHeight" gorm:"type:varchar(255)"`
+	Overrides      RunResult  `json:"overrides"`
+	OverridesID    uint       `json:"-"`
+	DeletedAt      null.Time  `json:"-" gorm:"index"`
 }
 
 // GetID returns the ID of this structure for jsonapi serialization.
@@ -145,8 +145,8 @@ func JobRunsWithStatus(runs []JobRun, status RunStatus) []JobRun {
 	return rval
 }
 
-// InitiatorRun stores the fields used to initiate the parent job run.
-type InitiatorRun struct {
+// RunRequest stores the fields used to initiate the parent job run.
+type RunRequest struct {
 	ID        uint `gorm:"primary_key"`
 	RequestID *null.String
 	TxHash    *common.Hash
@@ -154,9 +154,9 @@ type InitiatorRun struct {
 	CreatedAt time.Time
 }
 
-// NewInitiatorRun returns a new InitiatorRun instance.
-func NewInitiatorRun() InitiatorRun {
-	return InitiatorRun{}
+// NewRunRequest returns a new RunRequest instance.
+func NewRunRequest() RunRequest {
+	return RunRequest{}
 }
 
 // TaskRun stores the Task and represents the status of the

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -148,7 +148,7 @@ func JobRunsWithStatus(runs []JobRun, status RunStatus) []JobRun {
 // RunRequest stores the fields used to initiate the parent job run.
 type RunRequest struct {
 	ID        uint `gorm:"primary_key"`
-	RequestID *null.String
+	RequestID *string
 	TxHash    *common.Hash
 	Requester *common.Address
 	CreatedAt time.Time

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -148,9 +148,9 @@ func JobRunsWithStatus(runs []JobRun, status RunStatus) []JobRun {
 // InitiatorRun stores the fields used to initiate the parent job run.
 type InitiatorRun struct {
 	ID        uint `gorm:"primary_key"`
-	RequestID null.String
-	TxHash    common.Hash
-	Requester common.Address
+	RequestID *null.String
+	TxHash    *common.Hash
+	Requester *common.Address
 	CreatedAt time.Time
 }
 

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink/store/assets"
 	"github.com/tidwall/gjson"
 	null "gopkg.in/guregu/null.v3"
@@ -14,22 +15,24 @@ import (
 // JobRun tracks the status of a job by holding its TaskRuns and the
 // Result of each Run.
 type JobRun struct {
-	ID             string    `json:"id" gorm:"primary_key;not null"`
-	JobSpecID      string    `json:"jobId" gorm:"index;not null;type:varchar(36) REFERENCES job_specs(id)"`
-	Result         RunResult `json:"result"`
-	ResultID       uint      `json:"-"`
-	Status         RunStatus `json:"status" gorm:"index"`
-	TaskRuns       []TaskRun `json:"taskRuns"`
-	CreatedAt      time.Time `json:"createdAt" gorm:"index"`
-	CompletedAt    null.Time `json:"completedAt"`
-	UpdatedAt      time.Time `json:"updatedAt"`
-	Initiator      Initiator `json:"initiator" gorm:"association_autoupdate:false;association_autocreate:false"`
-	InitiatorID    uint      `json:"-"`
-	CreationHeight *Big      `json:"creationHeight" gorm:"type:varchar(255)"`
-	ObservedHeight *Big      `json:"observedHeight" gorm:"type:varchar(255)"`
-	Overrides      RunResult `json:"overrides"`
-	OverridesID    uint      `json:"-"`
-	DeletedAt      null.Time `json:"-" gorm:"index"`
+	ID             string       `json:"id" gorm:"primary_key;not null"`
+	JobSpecID      string       `json:"jobId" gorm:"index;not null;type:varchar(36) REFERENCES job_specs(id)"`
+	Result         RunResult    `json:"result"`
+	ResultID       uint         `json:"-"`
+	InitiatorRun   InitiatorRun `json:"-"`
+	InitiatorRunID uint         `json:"-"`
+	Status         RunStatus    `json:"status" gorm:"index"`
+	TaskRuns       []TaskRun    `json:"taskRuns"`
+	CreatedAt      time.Time    `json:"createdAt" gorm:"index"`
+	CompletedAt    null.Time    `json:"completedAt"`
+	UpdatedAt      time.Time    `json:"updatedAt"`
+	Initiator      Initiator    `json:"initiator" gorm:"association_autoupdate:false;association_autocreate:false"`
+	InitiatorID    uint         `json:"-"`
+	CreationHeight *Big         `json:"creationHeight" gorm:"type:varchar(255)"`
+	ObservedHeight *Big         `json:"observedHeight" gorm:"type:varchar(255)"`
+	Overrides      RunResult    `json:"overrides"`
+	OverridesID    uint         `json:"-"`
+	DeletedAt      null.Time    `json:"-" gorm:"index"`
 }
 
 // GetID returns the ID of this structure for jsonapi serialization.
@@ -140,6 +143,15 @@ func JobRunsWithStatus(runs []JobRun, status RunStatus) []JobRun {
 		}
 	}
 	return rval
+}
+
+// InitiatorRun stores the fields used to initiate the parent job run.
+type InitiatorRun struct {
+	ID        uint
+	RequestID null.String
+	TxHash    common.Hash
+	Requester common.Address
+	CreatedAt time.Time
 }
 
 // TaskRun stores the Task and represents the status of the

--- a/store/models/run.go
+++ b/store/models/run.go
@@ -147,11 +147,16 @@ func JobRunsWithStatus(runs []JobRun, status RunStatus) []JobRun {
 
 // InitiatorRun stores the fields used to initiate the parent job run.
 type InitiatorRun struct {
-	ID        uint
+	ID        uint `gorm:"primary_key"`
 	RequestID null.String
 	TxHash    common.Hash
 	Requester common.Address
 	CreatedAt time.Time
+}
+
+// NewInitiatorRun returns a new InitiatorRun instance.
+func NewInitiatorRun() InitiatorRun {
+	return InitiatorRun{}
 }
 
 // TaskRun stores the Task and represents the status of the

--- a/store/models/run_test.go
+++ b/store/models/run_test.go
@@ -88,8 +88,9 @@ func TestJobRuns_SavesASyncEvent(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, jr.Result.Data, recoveredJobRun.Result.Data)
 
-	assert.Contains(t, data, "runID")
-	assert.Contains(t, data, "jobID")
+	assert.Contains(t, data, "id")
+	assert.Contains(t, data, "runId")
+	assert.Contains(t, data, "jobId")
 	assert.Contains(t, data, "status")
 }
 

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -215,6 +215,7 @@ func (orm *ORM) preloadJobRuns() *gorm.DB {
 		Preload("Initiator", func(db *gorm.DB) *gorm.DB {
 			return db.Unscoped()
 		}).
+		Preload("InitiatorRun").
 		Preload("Overrides").
 		Preload("TaskRuns", func(db *gorm.DB) *gorm.DB {
 			return preloadTaskRuns(db).Order("task_spec_id asc")

--- a/store/orm/orm.go
+++ b/store/orm/orm.go
@@ -215,7 +215,7 @@ func (orm *ORM) preloadJobRuns() *gorm.DB {
 		Preload("Initiator", func(db *gorm.DB) *gorm.DB {
 			return db.Unscoped()
 		}).
-		Preload("InitiatorRun").
+		Preload("RunRequest").
 		Preload("Overrides").
 		Preload("TaskRuns", func(db *gorm.DB) *gorm.DB {
 			return preloadTaskRuns(db).Order("task_spec_id asc")


### PR DESCRIPTION
Completes story https://www.pivotaltracker.com/story/show/164707860. Introduces `initiator` key to the json payload sent to linkstats:

```json
{
  "jobID": "jobSpecID-312",
  "runID": "runID-411",
  "status": "in_progress",
  "error": null,
  "createdAt": "0001-01-01T00:00:00Z",
  "amount": "2",
  "completedAt": null,
  "initiator": {
    "type": "runlog",
    "requestId": "RequestID",
    "txHash": "0x00000000000000000000000000000000000000000000000000000000deadbeef",
    "requester": "0x9FBDa871d559710256a2502A2517b794B482Db40"
  },
  "tasks": [
    { "index": 0, "type": "", "status": "pending_confirmations", "error": null },
    { "index": 1, "type": "", "status": "errored", "error": "yikes fam" }
  ]
}
```

Notes and concerns:

1. Includes the introduction of a new model and table `InitiatorRun`, which only holds requested presenter fields: RequestID, TxHash, Requester.
2. Extracts RequestID using logic specific to the RunLog Topic version.
3. `JobRun#Initiator` is still top level and not in `JobRun#InitiatorRun` which is architecturally inconsistent with `JobRun#TaskRuns -> Task`.
4. CreationHeight,ObservedHeight remain where they currently are at top level, and not in InitiatorRun.
5. As is, no backfilling is needed.
6. As is, unblocks `linkstats`.
7. If we do choose to complete the chores above, should it be in this PR or in a subsequent one? 
   - Main pros of merging: Smaller and manageable PR for review, unblocks linkstats
8. Could also use feedback on the json shape above.