### PR TITLE
Refactor aggregateAndPay to protect from overflows

### DIFF
--- a/solidity/app/deployer.js
+++ b/solidity/app/deployer.js
@@ -49,7 +49,7 @@ module.exports = function Deployer(wallet, utils) {
       const encodedArgs = encodeArgs(contractArgs, compiled.abi)
 
       const txHash = await wallet.send({
-        gas: 2500000,
+        gas: 2600000,
         gasPrice: 10000000000,
         from: wallet.address,
         data: `0x${getBytecode(compiled)}${encodedArgs}`


### PR DESCRIPTION
I changed the way in which responses from oracles are aggregated to divide by the number of responses. This method reduces the likelihood of integer overflows during aggregation, but it also reduces the precision of the final answer. To account for this inaccuracy, the items to aggregate are multiplied by a `precision` constant before being divided by the number of responses. 