### PR TITLE
Accept non-JSON object responses in bridge

### DIFF
--- a/core/adapters/bridge.go
+++ b/core/adapters/bridge.go
@@ -3,7 +3,6 @@ package adapters
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -11,12 +10,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
-)
-
-var (
-	// ErrBridgeResultMustBeJSONObject is returned when a Bridge POSTs a non JSON
-	// object to chainlink
-	ErrBridgeResultMustBeJSONObject = errors.New("Bridge result must be a valid JSON object")
 )
 
 // Bridge adapter is responsible for connecting the task pipeline to external
@@ -82,11 +75,10 @@ func responseToRunResult(body []byte, input *models.RunResult) error {
 	}
 
 	if brr.RunResult.Data.Exists() && !brr.RunResult.Data.IsObject() {
-		return ErrBridgeResultMustBeJSONObject
+		input.ApplyResult(brr.RunResult.Data)
 	}
 
-	input.Merge(brr.RunResult)
-	return nil
+	return input.Merge(brr.RunResult)
 }
 
 func (ba *Bridge) postToExternalAdapter(input *models.RunResult, bridgeResponseURL *url.URL) ([]byte, error) {

--- a/core/adapters/bridge.go
+++ b/core/adapters/bridge.go
@@ -75,7 +75,7 @@ func responseToRunResult(body []byte, input *models.RunResult) error {
 	}
 
 	if brr.RunResult.Data.Exists() && !brr.RunResult.Data.IsObject() {
-		input.ApplyResult(brr.RunResult.Data)
+		input.ApplyResult(brr.RunResult.Data.String())
 	}
 
 	return input.Merge(brr.RunResult)

--- a/core/adapters/bridge_test.go
+++ b/core/adapters/bridge_test.go
@@ -62,7 +62,7 @@ func TestBridge_PerformAcceptsNonJsonObjectResponses(t *testing.T) {
 	}
 	result := ba.Perform(input, store)
 	assert.NoError(t, result.GetError())
-	assert.Equal(t, "251990120", result.Data.Get("result").Raw)
+	assert.Equal(t, "251990120", result.Data.Get("result").String())
 }
 
 func TestBridge_Perform_transitionsTo(t *testing.T) {

--- a/core/adapters/bridge_test.go
+++ b/core/adapters/bridge_test.go
@@ -42,7 +42,7 @@ func TestBridge_PerformEmbedsParamsInData(t *testing.T) {
 	assert.Equal(t, "Bearer "+bt.OutgoingToken, token)
 }
 
-func TestBridge_PerformRejectsNonJsonObjectResponses(t *testing.T) {
+func TestBridge_PerformAcceptsNonJsonObjectResponses(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 	store.Config.Set("BRIDGE_RESPONSE_URL", cltest.WebURL(""))
@@ -61,7 +61,8 @@ func TestBridge_PerformRejectsNonJsonObjectResponses(t *testing.T) {
 		Status: models.RunStatusUnstarted,
 	}
 	result := ba.Perform(input, store)
-	assert.Equal(t, result.GetError(), adapters.ErrBridgeResultMustBeJSONObject)
+	assert.NoError(t, result.GetError())
+	assert.Equal(t, "251990120", result.Data.Get("result").Raw)
 }
 
 func TestBridge_Perform_transitionsTo(t *testing.T) {


### PR DESCRIPTION
[#165129856](https://www.pivotaltracker.com/story/show/165129856)

This is done by directly placing the non-object response in Data.Result.

External adapter non-object responses such as:

```json
{
  "jobRunId": "abc123",
  "data": 123.45
}
```

...would previously not be accepted. Now, store the `"data"` value to the job run's Data.Result, so that the value can be used by the next adapter(s):

```json
{
      "jobRunId": "abc123",
      "taskRunId": "def456",
      "data": {
            "result": 123.45
      },
      "status": "completed",
      "error": null
}
```

Object responses are handled the same way as previously.