### PR TITLE
Update initiateServiceAgreement to use struct parameters

### DIFF
--- a/evm/app/deployer.js
+++ b/evm/app/deployer.js
@@ -49,7 +49,7 @@ module.exports = function Deployer(wallet, utils) {
       const encodedArgs = encodeArgs(contractArgs, compiled.abi)
 
       const txHash = await wallet.send({
-        gas: 2600000,
+        gas: 4000000,
         gasPrice: 10000000000,
         from: wallet.address,
         data: `0x${getBytecode(compiled)}${encodedArgs}`

--- a/evm/contracts/Coordinator.sol
+++ b/evm/contracts/Coordinator.sol
@@ -148,7 +148,7 @@ contract Coordinator is ChainlinkRequestInterface, CoordinatorInterface {
    * @dev Validates that each signer address matches for the given oracles
    * @param _serviceAgreementID Service agreement ID
    * @param _oracles Array of oracle addresses which agreed to the service agreement
-   * @param _signatures A
+   * @param _signatures contains the collected parts(v, r, and s) of each oracle's signature.
    */
   function registerOracleSignatures(
     bytes32 _serviceAgreementID,

--- a/evm/contracts/Coordinator.sol
+++ b/evm/contracts/Coordinator.sol
@@ -280,12 +280,13 @@ contract Coordinator is ChainlinkRequestInterface, CoordinatorInterface {
    */
   function getId(ServiceAgreement memory _agreement) public pure returns (bytes32)
   {
-    return keccak256(abi.encodePacked(
-      _agreement.payment, 
-      _agreement.expiration, 
-      _agreement.endAt, 
-      _agreement.oracles, 
-      _agreement.requestDigest
+    return keccak256(
+      abi.encodePacked(
+        _agreement.payment,
+        _agreement.expiration,
+        _agreement.endAt,
+        _agreement.oracles,
+        _agreement.requestDigest
     ));
   }
 

--- a/evm/contracts/Coordinator.sol
+++ b/evm/contracts/Coordinator.sol
@@ -275,7 +275,7 @@ contract Coordinator is ChainlinkRequestInterface, CoordinatorInterface {
 
   /**
    * @notice Retrieve the Service Agreement ID for the given parameters
-   * @param _agreement A
+      * @param _agreement contains all of the terms of the service agreement that can be verified on-chain.
    * @return The Service Agreement ID, a keccak256 hash of the input params
    */
   function getId(ServiceAgreement memory _agreement) public pure returns (bytes32)

--- a/evm/contracts/interfaces/CoordinatorInterface.sol
+++ b/evm/contracts/interfaces/CoordinatorInterface.sol
@@ -1,15 +1,23 @@
 pragma solidity 0.4.24;
+pragma experimental ABIEncoderV2; // solium-disable-line no-experimental
 
-interface CoordinatorInterface {
-  function initiateServiceAgreement(
-    uint256 payment,
-    uint256 expiration,
-    uint256 endAt,
-    address[] oracles,
-    uint8[] vs,
-    bytes32[] rs,
-    bytes32[] ss,
-    bytes32 requestDigest
-  ) external returns (bytes32);
+contract CoordinatorInterface {
+
+  struct ServiceAgreement {
+    uint256 payment;
+    uint256 expiration;
+    uint256 endAt;
+    address[] oracles;
+    bytes32 requestDigest;
+  }
+
+  struct OracleSignatures {
+    uint8[] vs;
+    bytes32[] rs;
+    bytes32[] ss;
+  }
+
+  function initiateServiceAgreement(ServiceAgreement memory _agreement, OracleSignatures memory _signatures) public returns (bytes32);
+
   function fulfillOracleRequest(bytes32 requestId, bytes32 data) external returns (bool);
 }

--- a/evm/test/BasicConsumer_test.js
+++ b/evm/test/BasicConsumer_test.js
@@ -36,8 +36,8 @@ contract('BasicConsumer', () => {
 
       it('triggers a log event in the Oracle contract', async () => {
         const tx = await cc.requestEthereumPrice(currency)
-        const log = tx.receipt.logs[3]
-        assert.equal(log.address, oc.address)
+        const log = tx.receipt.rawLogs[3]
+        assert.equal(log.address.toLowerCase(), oc.address.toLowerCase())
 
         const request = h.decodeRunRequest(log)
         const expected = {
@@ -48,7 +48,7 @@ contract('BasicConsumer', () => {
 
         assert.equal(h.toHex(specId), request.jobId)
         assertBigNum(h.toWei('1', 'ether'), request.payment)
-        assert.equal(cc.address, request.requester)
+        assert.equal(cc.address.toLowerCase(), request.requester.toLowerCase())
         assert.equal(1, request.dataVersion)
         assert.deepEqual(expected, await cbor.decodeFirst(request.data))
       })
@@ -67,7 +67,7 @@ contract('BasicConsumer', () => {
     beforeEach(async () => {
       await link.transfer(cc.address, h.toWei('1', 'ether'))
       const tx = await cc.requestEthereumPrice(currency)
-      request = h.decodeRunRequest(tx.receipt.logs[3])
+      request = h.decodeRunRequest(tx.receipt.rawLogs[3])
     })
 
     it('records the data given to it by the oracle', async () => {
@@ -83,8 +83,8 @@ contract('BasicConsumer', () => {
       const tx = await h.fulfillOracleRequest(oc, request, response, {
         from: h.oracleNode
       })
-      assert.equal(2, tx.receipt.logs.length)
-      const log = tx.receipt.logs[1]
+      assert.equal(2, tx.receipt.rawLogs.length)
+      const log = tx.receipt.rawLogs[1]
 
       assert.equal(h.toUtf8(log.topics[2]), response)
     })
@@ -102,7 +102,7 @@ contract('BasicConsumer', () => {
           ''
         )
         const tx = await h.requestDataFrom(oc, link, 0, args)
-        otherRequest = h.decodeRunRequest(tx.receipt.logs[2])
+        otherRequest = h.decodeRunRequest(tx.receipt.rawLogs[2])
       })
 
       it('does not accept the data provided', async () => {
@@ -118,7 +118,9 @@ contract('BasicConsumer', () => {
     context('when called by anyone other than the oracle contract', () => {
       it('does not accept the data provided', async () => {
         await h.assertActionThrows(async () => {
-          await cc.fulfill(request.id, response, { from: h.oracleNode })
+          await cc.fulfill(request.id, h.toHex(response), {
+            from: h.oracleNode
+          })
         })
 
         let received = await cc.currentPrice.call()
@@ -134,7 +136,7 @@ contract('BasicConsumer', () => {
     beforeEach(async () => {
       await link.transfer(cc.address, depositAmount)
       const tx = await cc.requestEthereumPrice(currency)
-      request = h.decodeRunRequest(tx.receipt.logs[3])
+      request = h.decodeRunRequest(tx.receipt.rawLogs[3])
     })
 
     context('before 5 minutes', () => {

--- a/evm/test/ConcreteChainlink_test.js
+++ b/evm/test/ConcreteChainlink_test.js
@@ -1,6 +1,11 @@
 import { toBuffer } from 'ethereumjs-util'
 import abi from 'ethereumjs-abi'
-import { checkPublicABI, decodeDietCBOR, deploy } from './support/helpers'
+import {
+  checkPublicABI,
+  decodeDietCBOR,
+  deploy,
+  toHex
+} from './support/helpers'
 
 contract('ConcreteChainlink', () => {
   const sourcePath = 'examples/ConcreteChainlink.sol'
@@ -23,7 +28,7 @@ contract('ConcreteChainlink', () => {
   })
 
   function parseCCLEvent(tx) {
-    const data = toBuffer(tx.receipt.logs[0].data)
+    const data = toBuffer(tx.receipt.rawLogs[0].data)
     return abi.rawDecode(['bytes'], data)
   }
 
@@ -95,7 +100,7 @@ contract('ConcreteChainlink', () => {
     })
 
     it('handles strings', async () => {
-      await ccl.addBytes('first', 'apple')
+      await ccl.addBytes('first', toHex('apple'))
       const tx = await ccl.closeEvent()
       const [payload] = parseCCLEvent(tx)
       const decoded = await decodeDietCBOR(payload)
@@ -152,11 +157,14 @@ contract('ConcreteChainlink', () => {
 
   describe('#addStringArray', () => {
     it('stores and logs keys and values', async () => {
-      await ccl.addStringArray('word', ['seinfeld', '"4"', 'LIFE'])
+      await ccl.addStringArray('word', [
+        toHex('seinfeld'),
+        toHex('"4"'),
+        toHex('LIFE')
+      ])
       const tx = await ccl.closeEvent()
       const [payload] = parseCCLEvent(tx)
       const decoded = await decodeDietCBOR(payload)
-
       assert.deepEqual(decoded, { word: ['seinfeld', '"4"', 'LIFE'] })
     })
   })

--- a/evm/test/ConcreteChainlinked_test.js
+++ b/evm/test/ConcreteChainlinked_test.js
@@ -8,6 +8,7 @@ import {
   getEvents,
   getLatestEvent,
   linkContract,
+  Ox,
   toHexWithoutPrefix,
   toHex
 } from './support/helpers'
@@ -38,10 +39,7 @@ contract('ConcreteChainlinked', () => {
       let [jId, cbAddr, cbFId, cborData] = decodeRunABI(tx.receipt.rawLogs[0])
       let params = await decodeDietCBOR(cborData)
 
-      assert.equal(
-        specId.toLowerCase(),
-        `0x${jId.toString('hex').toLowerCase()}`
-      )
+      assert.equal(specId.toLowerCase(), toHex(jId))
       assert.equal(gs.address.toLowerCase(), `0x${cbAddr.toLowerCase()}`)
       assert.equal('ed53e511', toHexWithoutPrefix(cbFId))
       assert.deepEqual({}, params)

--- a/evm/test/Coordinator_test.js
+++ b/evm/test/Coordinator_test.js
@@ -71,7 +71,6 @@ contract('Coordinator', () => {
     context('with valid oracle signatures', () => {
       it.only('saves a service agreement struct from the parameters', async () => {
         let tx = await h.initiateServiceAgreement(coordinator, agreement)
-        console.log(tx)
         await h.checkServiceAgreementPresent(coordinator, agreement)
       })
 

--- a/evm/test/Coordinator_test.js
+++ b/evm/test/Coordinator_test.js
@@ -69,8 +69,9 @@ contract('Coordinator', () => {
     })
 
     context('with valid oracle signatures', () => {
-      it('saves a service agreement struct from the parameters', async () => {
-        await h.initiateServiceAgreement(coordinator, agreement)
+      it.only('saves a service agreement struct from the parameters', async () => {
+        let tx = await h.initiateServiceAgreement(coordinator, agreement)
+        console.log(tx)
         await h.checkServiceAgreementPresent(coordinator, agreement)
       })
 

--- a/evm/test/GetterSetter_test.js
+++ b/evm/test/GetterSetter_test.js
@@ -1,11 +1,11 @@
-import { deploy, stranger, toUtf8 } from './support/helpers'
+import { deploy, stranger, toHex, toUtf8 } from './support/helpers'
 import { assertBigNum } from './support/matchers'
 
 contract('GetterSetter', () => {
   const sourcePath = 'examples/GetterSetter.sol'
   const requestId =
     '0x3bd198932d9cc01e2950ffc518fd38a303812200000000000000000000000000'
-  const bytes32 = 'Hi Mom!'
+  const bytes32 = toHex('Hi Mom!')
   const uint256 = 645746535432
   let gs
 
@@ -18,15 +18,15 @@ contract('GetterSetter', () => {
       await gs.setBytes32(bytes32, { from: stranger })
 
       let currentBytes32 = await gs.getBytes32.call()
-      assert.equal(toUtf8(currentBytes32), bytes32)
+      assert.equal(toUtf8(currentBytes32), toUtf8(bytes32))
     })
 
     it('logs an event', async () => {
       let tx = await gs.setBytes32(bytes32, { from: stranger })
 
       assert.equal(1, tx.logs.length)
-      assert.equal(stranger.toLowerCase(), tx.logs[0].args.from)
-      assert.equal(bytes32, toUtf8(tx.logs[0].args.value))
+      assert.equal(stranger.toLowerCase(), tx.logs[0].args.from.toLowerCase())
+      assert.equal(toUtf8(bytes32), toUtf8(tx.logs[0].args.value))
     })
   })
 
@@ -38,7 +38,7 @@ contract('GetterSetter', () => {
       assert.equal(currentRequestId, requestId)
 
       let currentBytes32 = await gs.getBytes32.call()
-      assert.equal(toUtf8(currentBytes32), bytes32)
+      assert.equal(toUtf8(currentBytes32), toUtf8(bytes32))
     })
   })
 
@@ -54,7 +54,7 @@ contract('GetterSetter', () => {
       let tx = await gs.setUint256(uint256, { from: stranger })
 
       assert.equal(1, tx.logs.length)
-      assert.equal(stranger.toLowerCase(), tx.logs[0].args.from)
+      assert.equal(stranger.toLowerCase(), tx.logs[0].args.from.toLowerCase())
       assertBigNum(uint256, tx.logs[0].args.value)
     })
   })

--- a/evm/test/OracleDev_test.ts
+++ b/evm/test/OracleDev_test.ts
@@ -5,6 +5,8 @@ contract('OracleDev', () => {
   const priceFeed = 'LinkEx.sol'
   const ethRate = 370160
   const usdRate = 500000
+  const ethSymbol = h.toHex('ETH')
+  const usdSymbol = h.toHex('USD')
   let link: any
   let ocd: any
   let usdFeed: any
@@ -49,20 +51,20 @@ contract('OracleDev', () => {
       await usdFeed.addOracle(h.oracleNode, { from: h.defaultAccount })
       await ethFeed.update(ethRate, { from: h.oracleNode })
       await usdFeed.update(usdRate, { from: h.oracleNode })
-      await ocd.setPriceFeed(ethFeed.address, 'ETH')
-      await ocd.setPriceFeed(usdFeed.address, 'USD')
+      await ocd.setPriceFeed(ethFeed.address, ethSymbol)
+      await ocd.setPriceFeed(usdFeed.address, usdSymbol)
     })
 
     context('when requesting the ETH rate', () => {
       it('returns the current ETH rate', async () => {
-        const currentRate = await ocd.currentRate('ETH')
+        const currentRate = await ocd.currentRate(ethSymbol)
         assert.equal(currentRate.toString(), ethRate.toString())
       })
     })
 
     context('when requesting the USD rate', () => {
       it('returns the current USD rate', async () => {
-        const currentRate = await ocd.currentRate('USD')
+        const currentRate = await ocd.currentRate(usdSymbol)
         assert.equal(currentRate.toString(), usdRate.toString())
       })
     })
@@ -72,30 +74,32 @@ contract('OracleDev', () => {
     context('if a stranger tries setting a price feed', () => {
       it('reverts', async () => {
         await h.assertActionThrows(async () => {
-          await ocd.setPriceFeed(ethFeed.address, 'ETH', { from: h.stranger })
+          await ocd.setPriceFeed(ethFeed.address, ethSymbol, {
+            from: h.stranger
+          })
         })
       })
     })
 
     context('owner setting an ETH price feed', () => {
       beforeEach(async () => {
-        await ocd.setPriceFeed(ethFeed.address, 'ETH', {
+        await ocd.setPriceFeed(ethFeed.address, ethSymbol, {
           from: h.defaultAccount
         })
       })
 
       it('sets the address of a price feed for a given currency', async () => {
-        assert.equal(await ocd.priceFeeds.call('ETH'), ethFeed.address)
+        assert.equal(await ocd.priceFeeds.call(ethSymbol), ethFeed.address)
       })
     })
 
     context('owner setting a USD price feed', () => {
       beforeEach(async () => {
-        await ocd.setPriceFeed(usdFeed.address, 'USD')
+        await ocd.setPriceFeed(usdFeed.address, usdSymbol)
       })
 
       it('sets the address of a price feed for a given currency', async () => {
-        assert.equal(await ocd.priceFeeds.call('USD'), usdFeed.address)
+        assert.equal(await ocd.priceFeeds.call(usdSymbol), usdFeed.address)
       })
     })
   })

--- a/evm/test/Oracle_test.js
+++ b/evm/test/Oracle_test.js
@@ -4,7 +4,8 @@ import { assertBigNum } from './support/matchers'
 contract('Oracle', () => {
   const sourcePath = 'Oracle.sol'
   const fHash = h.functionSelector('requestedBytes32(bytes32,bytes32)')
-  const specId = h.toHex('4c7b7ffb66b344fbaa64995af81e355a')
+  const specId = 
+    '0x4c7b7ffb66b344fbaa64995af81e355a00000000000000000000000000000000'
   const to = '0x80e29acb842498fe6591f020bd82766dce619d43'
   let link, oc, withdraw
 
@@ -131,8 +132,6 @@ contract('Oracle', () => {
       context(
         'if the requester tries to create a requestId for another contract',
         () => {
-          let specId = h.newHash('0x4c7b7ffb66b344fbaa64995af81e355a')
-
           it('the requesters ID will not match with the oracle contract', async () => {
             const tx = await mock.maliciousTargetConsumer(to)
             let events = await h.getEvents(oc)
@@ -146,7 +145,7 @@ contract('Oracle', () => {
               'examples/BasicConsumer.sol',
               link.address,
               oc.address,
-              h.toHex(specId)
+              specId
             )
             await link.transfer(requester.address, paymentAmount)
             await mock.maliciousTargetConsumer(requester.address)
@@ -194,7 +193,7 @@ contract('Oracle', () => {
       it('logs an event', async () => {
         assert.equal(oc.address, log.address)
 
-        assert.equal(h.toUtf8(specId), h.toUtf8(log.topics[1]))
+        assert.equal(specId, log.topics[1])
         const req = h.decodeRunRequest(tx.receipt.rawLogs[2])
         assert.equal(h.defaultAccount.toString().toLowerCase(), req.requester)
         assertBigNum(paid, req.payment)

--- a/evm/test/Oracle_test.js
+++ b/evm/test/Oracle_test.js
@@ -4,7 +4,7 @@ import { assertBigNum } from './support/matchers'
 contract('Oracle', () => {
   const sourcePath = 'Oracle.sol'
   const fHash = h.functionSelector('requestedBytes32(bytes32,bytes32)')
-  const specId = 
+  const specId =
     '0x4c7b7ffb66b344fbaa64995af81e355a00000000000000000000000000000000'
   const to = '0x80e29acb842498fe6591f020bd82766dce619d43'
   let link, oc, withdraw

--- a/evm/test/ServiceAgreementConsumer_test.js
+++ b/evm/test/ServiceAgreementConsumer_test.js
@@ -3,7 +3,7 @@ import { assertBigNum } from './support/matchers'
 
 contract('ServiceAgreementConsumer', () => {
   const sourcePath = 'examples/ServiceAgreementConsumer.sol'
-  const currency = 'USD'
+  const currency = h.toHex('USD')
   let link, coord, cc, agreement
 
   beforeEach(async () => {
@@ -36,14 +36,14 @@ contract('ServiceAgreementConsumer', () => {
 
       it('triggers a log event in the Coordinator contract', async () => {
         let tx = await cc.requestEthereumPrice(currency)
-        let log = tx.receipt.logs[3]
-        assert.equal(log.address, coord.address)
+        let log = tx.receipt.rawLogs[3]
+        assert.equal(log.address.toLowerCase(), coord.address.toLowerCase())
 
         const request = h.decodeRunRequest(log)
         let params = await h.decodeDietCBOR(request.data)
         assert.equal(agreement.id, request.jobId)
         assertBigNum(paymentAmount, h.bigNum(request.payment))
-        assert.equal(cc.address, request.requester)
+        assert.equal(cc.address.toLowerCase(), request.requester.toLowerCase())
         assertBigNum(1, request.dataVersion)
         const url =
           'https://min-api.cryptocompare.com/data/price?fsym=ETH&tsyms=USD,EUR,JPY'
@@ -58,13 +58,13 @@ contract('ServiceAgreementConsumer', () => {
   })
 
   describe('#fulfillOracleRequest', () => {
-    const response = '1,000,000.00'
+    const response = h.toHex('1,000,000.00')
     let request
 
     beforeEach(async () => {
       await link.transfer(cc.address, h.toWei(1, 'ether'))
       const tx = await cc.requestEthereumPrice(currency)
-      request = h.decodeRunRequest(tx.receipt.logs[3])
+      request = h.decodeRunRequest(tx.receipt.rawLogs[3])
     })
 
     it('records the data given to it by the oracle', async () => {
@@ -73,7 +73,7 @@ contract('ServiceAgreementConsumer', () => {
       })
 
       const currentPrice = await cc.currentPrice.call()
-      assert.equal(h.toUtf8(currentPrice), response)
+      assert.equal(h.toUtf8(currentPrice), h.toUtf8(response))
     })
 
     context('when the consumer does not recognize the request ID', () => {
@@ -89,7 +89,7 @@ contract('ServiceAgreementConsumer', () => {
           ''
         )
         const tx = await h.requestDataFrom(coord, link, agreement.payment, args)
-        request2 = h.decodeRunRequest(tx.receipt.logs[2])
+        request2 = h.decodeRunRequest(tx.receipt.rawLogs[2])
       })
 
       it('does not accept the data provided', async () => {

--- a/evm/test/ServiceAgreementConsumer_test.js
+++ b/evm/test/ServiceAgreementConsumer_test.js
@@ -52,7 +52,7 @@ contract('ServiceAgreementConsumer', () => {
 
       it('has a reasonable gas cost', async () => {
         const tx = await cc.requestEthereumPrice(currency)
-        assert.isBelow(tx.receipt.gasUsed, 170000)
+        assert.isBelow(tx.receipt.gasUsed, 172000)
       })
     })
   })

--- a/evm/test/UpdatableConsumer_test.js
+++ b/evm/test/UpdatableConsumer_test.js
@@ -82,8 +82,10 @@ contract('UpdatableConsumer', () => {
 
       it("updates the contract's oracle address", async () => {
         await uc.updateOracle()
-
-        assert.equal(newOracleAddress, await uc.getOracle.call())
+        assert.equal(
+          newOracleAddress.toLowerCase(),
+          (await uc.getOracle.call()).toLowerCase()
+        )
       })
     })
 
@@ -104,8 +106,8 @@ contract('UpdatableConsumer', () => {
 
     beforeEach(async () => {
       await link.transfer(uc.address, paymentAmount)
-      const tx = await uc.requestEthereumPrice(currency)
-      request = h.decodeRunRequest(tx.receipt.logs[3])
+      const tx = await uc.requestEthereumPrice(h.toHex(currency))
+      request = h.decodeRunRequest(tx.receipt.rawLogs[3])
     })
 
     it('records the data given to it by the oracle', async () => {
@@ -125,7 +127,10 @@ contract('UpdatableConsumer', () => {
             from: h.oracleNode
           })
           await uc.updateOracle()
-          assert.equal(newOracleAddress, await uc.getOracle.call())
+          assert.equal(
+            newOracleAddress.toLowerCase(),
+            (await uc.getOracle.call()).toLowerCase()
+          )
         })
 
         it('records the data given to it by the old oracle contract', async () => {
@@ -139,7 +144,9 @@ contract('UpdatableConsumer', () => {
 
         it('does not accept responses from the new oracle for the old requests', async () => {
           await h.assertActionThrows(async () => {
-            await uc.fulfill(request.id, response, { from: h.oracleNode })
+            await uc.fulfill(request.id, h.toHex(response), {
+              from: h.oracleNode
+            })
           })
 
           const currentPrice = await uc.currentPrice.call()

--- a/evm/test/support/helpers.ts
+++ b/evm/test/support/helpers.ts
@@ -557,6 +557,19 @@ export const pad0xHexTo256Bit = (s: string): string =>
 export const padNumTo256Bit = (n: number): string =>
   padHexTo256Bit(n.toString(16))
 
+export const constructStructArgs = (
+  fieldNames: string[],
+  values: any[]
+): any[] => {
+  assert.equal(fieldNames.length, values.length)
+  let args = []
+  for (let i = 0; i < fieldNames.length; i++) {
+    args[i] = values[i]
+    args[fieldNames[i]] = values[i]
+  }
+  return args
+}
+
 export const initiateServiceAgreementArgs = ({
   payment,
   expiration,
@@ -564,16 +577,28 @@ export const initiateServiceAgreementArgs = ({
   oracles,
   oracleSignatures,
   requestDigest
-}: any): any[] => [
-  toHex(newHash(payment.toString())),
-  toHex(newHash(expiration.toString())),
-  toHex(newHash(endAt.toString())),
-  oracles.map(newAddress).map(toHex),
-  oracleSignatures.map((os: any) => os.v),
-  oracleSignatures.map((os: any) => toHex(os.r)),
-  oracleSignatures.map((os: any) => toHex(os.s)),
-  toHex(requestDigest)
-]
+}: any): any[] => {
+  return [
+    constructStructArgs(
+      ['payment', 'expiration', 'endAt', 'oracles', 'requestDigest'],
+      [
+        toHex(newHash(payment.toString())),
+        toHex(newHash(expiration.toString())),
+        toHex(newHash(endAt.toString())),
+        oracles.map(newAddress).map(toHex),
+        toHex(requestDigest)
+      ]
+    ),
+    constructStructArgs(
+      ['vs', 'rs', 'ss'],
+      [
+        oracleSignatures.map((os: any) => os.v),
+        oracleSignatures.map((os: any) => toHex(os.r)),
+        oracleSignatures.map((os: any) => toHex(os.s))
+      ]
+    )
+  ]
+}
 
 // Call coordinator contract to initiate the specified service agreement, and
 // get the return value

--- a/evm/test/support/helpers.ts
+++ b/evm/test/support/helpers.ts
@@ -162,10 +162,9 @@ export const deploy = async (filePath: any, ...args: any[]) =>
 export const getEvents = (contract: any): Promise<any[]> =>
   new Promise((resolve, reject) =>
     contract
-      .allEvents()
-      .get((error: any, events: any) =>
-        error ? reject(error) : resolve(events)
-      )
+      .getPastEvents()
+      .then((events: any) => resolve(events))
+      .catch((error: any) => reject(error))
   )
 
 export const getLatestEvent = async (contract: any): Promise<any[]> => {
@@ -182,7 +181,7 @@ export const requestDataFrom = (
   options: any
 ): any => {
   if (!options) {
-    options = {}
+    options = { value: 0 }
   }
   return link.transferAndCall(oc.address, amount, args, options)
 }
@@ -631,7 +630,9 @@ export const checkServiceAgreementAbsent = async (
   coordinator: any,
   serviceAgreementID: any
 ) => {
-  const sa = await coordinator.serviceAgreements.call(toHex(serviceAgreementID))
+  const sa = await coordinator.serviceAgreements.call(
+    toHex(serviceAgreementID).slice(0, 66)
+  )
   assertBigNum(sa[0], bigNum(0))
   assertBigNum(sa[1], bigNum(0))
   assertBigNum(sa[2], bigNum(0))
@@ -644,7 +645,7 @@ export const checkServiceAgreementAbsent = async (
 export const newServiceAgreement = async (params: any): Promise<any> => {
   const agreement: any = {}
   params = params || {}
-  agreement.payment = params.payment || 1000000000000000000
+  agreement.payment = params.payment || '1000000000000000000'
   agreement.expiration = params.expiration || 300
   agreement.endAt = params.endAt || sixMonthsFromNow()
   agreement.oracles = params.oracles || [oracleNode]
@@ -678,7 +679,7 @@ export const fulfillOracleRequest = async (
   options: any
 ): Promise<any> => {
   if (!options) {
-    options = {}
+    options = { value: 0 }
   }
 
   return oracle.fulfillOracleRequest(
@@ -687,7 +688,7 @@ export const fulfillOracleRequest = async (
     request.callbackAddr,
     request.callbackFunc,
     request.expiration,
-    response,
+    toHex(response),
     options
   )
 }
@@ -698,7 +699,7 @@ export const cancelOracleRequest = async (
   options: any
 ): Promise<any> => {
   if (!options) {
-    options = {}
+    options = { value: 0 }
   }
 
   return oracle.cancelOracleRequest(

--- a/integration/send_runlog_transaction
+++ b/integration/send_runlog_transaction
@@ -8,7 +8,7 @@ const {
   LINK_TOKEN_ADDRESS,
   ORACLE_CONTRACT_ADDRESS
 } = process.env
-const { utils, web3 } = require('../solidity/app/env.js')
+const { utils, web3 } = require('../evm/app/env.js')
 const url = require('url')
 
 process.env.SOLIDITY_INCLUDE = '../evm/contracts'

--- a/integration/send_runlog_transaction
+++ b/integration/send_runlog_transaction
@@ -8,7 +8,7 @@ const {
   LINK_TOKEN_ADDRESS,
   ORACLE_CONTRACT_ADDRESS
 } = process.env
-const { utils } = require('../evm/app/env.js')
+const { utils, web3 } = require('../solidity/app/env.js')
 const url = require('url')
 
 process.env.SOLIDITY_INCLUDE = '../evm/contracts'
@@ -38,7 +38,7 @@ const main = async () => {
     )
     .catch(abort(`Error loading LinkToken at address ${LINK_TOKEN_ADDRESS}`))
 
-  const amount = utils.toWei('1000')
+  const amount = web3.utils.toBN(Number(utils.toWei('1000')).toString(16))
   await LinkToken.transfer(RunLog.address, amount, { gas: 100000 }).catch(
     abort('Error transferring link to RunLog')
   )
@@ -63,7 +63,7 @@ const main = async () => {
     .post(specsUrl, { json: job })
     .catch(abort('Error creating Job'))
 
-  await RunLog.request(Job.data.id, {
+  await RunLog.request(web3.utils.asciiToHex(Job.data.id), {
     from: DEVNET_ADDRESS,
     gas: 2000000
   }).catch(abort('Error making RunLog request'))

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "solium-plugin-zeppelin": "^0.0.2",
     "storybook-addon-material-ui": "^0.9.0-alpha.16",
     "truffle": "^5.0.1",
-    "truffle-contract": "^3.0.6",
+    "truffle-contract": "^4.0.11",
     "truffle-flattener": "^1.3.0",
     "typescript": "^3.4.2",
     "web3": "^1.0.0-beta.35"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2522,6 +2522,11 @@ ansistyles@~0.1.3:
   resolved "https://registry.yarnpkg.com/ansistyles/-/ansistyles-0.1.3.tgz#5de60415bda071bb37127854c864f41b23254539"
   integrity sha1-XeYEFb2gcbs3EnhUyGT0GyMlRTk=
 
+any-promise@1.3.0, any-promise@^1.0.0, any-promise@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/any-promise/-/any-promise-1.3.0.tgz#abc6afeedcea52e809cdc0376aed3ce39635d17f"
+  integrity sha1-q8av7tzqUugJzcA3au0845Y10X8=
+
 any-shell-escape@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/any-shell-escape/-/any-shell-escape-0.1.1.tgz#d55ab972244c71a9a5e1ab0879f30bf110806959"
@@ -3308,6 +3313,11 @@ bignumber.js@^4.0.2:
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
   integrity sha512-eJzYkFYy9L4JzXsbymsFn3p54D+llV27oTQ+ziJG7WFRheJcNZilgVXMG0LoZtlQSKBsJdWtLFqOD0u+U0jZKA==
 
+bignumber.js@^7.2.1:
+  version "7.2.1"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-7.2.1.tgz#80c048759d826800807c4bfd521e50edbba57a5f"
+  integrity sha512-S4XzBk5sMB+Rcb/LNcpzXr57VRTxgAvaAEDAl1AwRx27j00hT84O6OkteE7u8UB3NuaaygCRrEpqox4uDOrbdQ==
+
 bignumber.js@^8.0.1, bignumber.js@^8.0.2:
   version "8.1.1"
   resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-8.1.1.tgz#4b072ae5aea9c20f6730e4e5d529df1271c4d885"
@@ -3371,6 +3381,11 @@ block-stream@*:
   integrity sha1-E+v+d4oDIFz+A3UUgeu0szAMEmo=
   dependencies:
     inherits "~2.0.0"
+
+bluebird@^2.9.34:
+  version "2.11.0"
+  resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-2.11.0.tgz#534b9033c022c9579c56ba3b3e5a5caafbb650e1"
+  integrity sha1-U0uQM8AiyVecVro7Plpcqvu2UOE=
 
 bluebird@^3.3.5, bluebird@^3.5.0, bluebird@^3.5.1, bluebird@^3.5.3:
   version "3.5.3"
@@ -6463,16 +6478,7 @@ eth-ens-namehash@^1.0.2:
     idna-uts46 "^1.0.1"
     js-sha3 "^0.5.7"
 
-eth-lib@0.2.8:
-  version "0.2.8"
-  resolved "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz#b194058bef4b220ad12ea497431d6cb6aa0623c8"
-  integrity sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==
-  dependencies:
-    bn.js "^4.11.6"
-    elliptic "^6.4.0"
-    xhr-request-promise "^0.1.2"
-
-eth-lib@^0.1.26:
+eth-lib@0.1.27, eth-lib@^0.1.26:
   version "0.1.27"
   resolved "https://registry.npmjs.org/eth-lib/-/eth-lib-0.1.27.tgz#f0b0fd144f865d2d6bf8257a40004f2e75ca1dd6"
   integrity sha512-B8czsfkJYzn2UIEMwjc7Mbj+Cy72V+/OXH/tb44LV8jhrjizQJJ325xMOMyk3+ETa6r6oi0jsUY14+om8mQMWA==
@@ -6483,6 +6489,24 @@ eth-lib@^0.1.26:
     nano-json-stream-parser "^0.1.2"
     servify "^0.1.12"
     ws "^3.0.0"
+    xhr-request-promise "^0.1.2"
+
+eth-lib@0.2.7:
+  version "0.2.7"
+  resolved "https://registry.yarnpkg.com/eth-lib/-/eth-lib-0.2.7.tgz#2f93f17b1e23aec3759cd4a3fe20c1286a3fc1ca"
+  integrity sha1-L5Pxex4jrsN1nNSj/iDBKGo/wco=
+  dependencies:
+    bn.js "^4.11.6"
+    elliptic "^6.4.0"
+    xhr-request-promise "^0.1.2"
+
+eth-lib@0.2.8:
+  version "0.2.8"
+  resolved "https://registry.npmjs.org/eth-lib/-/eth-lib-0.2.8.tgz#b194058bef4b220ad12ea497431d6cb6aa0623c8"
+  integrity sha512-ArJ7x1WcWOlSpzdoTBX8vkwlkSQ85CjjifSZtV4co64vWxSV8geWfPI9x4SVYu3DSxnX4yWFVTtGL+j9DUFLNw==
+  dependencies:
+    bn.js "^4.11.6"
+    elliptic "^6.4.0"
     xhr-request-promise "^0.1.2"
 
 ethereum-common@^0.0.18:
@@ -6554,7 +6578,23 @@ ethereumjs-wallet@^0.6.2:
     utf8 "^3.0.0"
     uuid "^3.3.2"
 
-ethers@^4.0.27:
+ethers@4.0.0-beta.1:
+  version "4.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/ethers/-/ethers-4.0.0-beta.1.tgz#0648268b83e0e91a961b1af971c662cdf8cbab6d"
+  integrity sha512-SoYhktEbLxf+fiux5SfCEwdzWENMvgIbMZD90I62s4GZD9nEjgEWy8ZboI3hck193Vs0bDoTohDISx84f2H2tw==
+  dependencies:
+    "@types/node" "^10.3.2"
+    aes-js "3.0.0"
+    bn.js "^4.4.0"
+    elliptic "6.3.3"
+    hash.js "1.1.3"
+    js-sha3 "0.5.7"
+    scrypt-js "2.0.3"
+    setimmediate "1.0.4"
+    uuid "2.0.1"
+    xmlhttprequest "1.8.0"
+
+ethers@^4.0.0-beta.1, ethers@^4.0.27:
   version "4.0.27"
   resolved "https://registry.npmjs.org/ethers/-/ethers-4.0.27.tgz#e570b0da9d805ad65c83d81919abe02b2264c6bf"
   integrity sha512-+DXZLP/tyFnXWxqr2fXLT67KlGUfLuvDkHSOtSC9TUVG9OIj6yrG5JPeXRMYo15xkOYwnjgdMKrXp5V94rtjJA==
@@ -6720,6 +6760,11 @@ event-emitter@~0.3.5:
   dependencies:
     d "1"
     es5-ext "~0.10.14"
+
+eventemitter3@1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-1.1.1.tgz#47786bdaa087caf7b1b75e73abc5c7d540158cd0"
+  integrity sha1-R3hr2qCHyvext15zq8XH1UAVjNA=
 
 eventemitter3@3.1.0, eventemitter3@^3.0.0, eventemitter3@^3.1.0:
   version "3.1.0"
@@ -7415,6 +7460,14 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
+fs-extra@^2.0.0, fs-extra@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-2.1.2.tgz#046c70163cef9aad46b0e4a7fa467fb22d71de35"
+  integrity sha1-BGxwFjzvmq1GsOSn+kZ/si1x3jU=
+  dependencies:
+    graceful-fs "^4.1.2"
+    jsonfile "^2.1.0"
+
 fs-extra@^4.0.2:
   version "4.0.3"
   resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-4.0.3.tgz#0d852122e5bc5beb453fb028e9c0c9bf36340c94"
@@ -7439,6 +7492,16 @@ fs-minipass@^1.2.5:
   integrity sha512-JhBl0skXjUPCFH7x6x61gQxrKyXsxB5gcgePLZCwfyCGGsTISMoIeObbrvVeP6Xmyaudw4TT43qV2Gz+iyd2oQ==
   dependencies:
     minipass "^2.2.1"
+
+fs-promise@^2.0.0:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/fs-promise/-/fs-promise-2.0.3.tgz#f64e4f854bcf689aa8bddcba268916db3db46854"
+  integrity sha1-9k5PhUvPaJqovdy6JokW2z20aFQ=
+  dependencies:
+    any-promise "^1.3.0"
+    fs-extra "^2.0.0"
+    mz "^2.6.0"
+    thenify-all "^1.6.0"
 
 fs-readdir-recursive@^1.1.0:
   version "1.1.0"
@@ -7482,7 +7545,7 @@ fsevents@^1.0.0, fsevents@^1.2.7:
     nan "^2.9.2"
     node-pre-gyp "^0.10.0"
 
-fstream@^1.0.0, fstream@^1.0.2:
+fstream@^1.0.0, fstream@^1.0.2, fstream@^1.0.8:
   version "1.0.11"
   resolved "https://registry.yarnpkg.com/fstream/-/fstream-1.0.11.tgz#5c1fb1f117477114f0632a0eb4b71b3cb0fd3171"
   integrity sha1-XB+x8RdHcRTwYyoOtLcbPLD9MXE=
@@ -7802,24 +7865,7 @@ globby@^8.0.1:
     pify "^3.0.0"
     slash "^1.0.0"
 
-got@^6.3.0, got@^6.7.1:
-  version "6.7.1"
-  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
-  integrity sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=
-  dependencies:
-    create-error-class "^3.0.0"
-    duplexer3 "^0.1.4"
-    get-stream "^3.0.0"
-    is-redirect "^1.0.0"
-    is-retry-allowed "^1.0.0"
-    is-stream "^1.0.0"
-    lowercase-keys "^1.0.0"
-    safe-buffer "^5.0.1"
-    timed-out "^4.0.0"
-    unzip-response "^2.0.1"
-    url-parse-lax "^1.0.0"
-
-got@^7.0.0, got@^7.1.0:
+got@7.1.0, got@^7.0.0, got@^7.1.0:
   version "7.1.0"
   resolved "https://registry.npmjs.org/got/-/got-7.1.0.tgz#05450fd84094e6bbea56f451a43a9c289166385a"
   integrity sha512-Y5WMo7xKKq1muPsxD+KmrR8DH5auG7fBdDVueZwETwV6VytKyU9OX/ddpq2/1hp1vIPvVb4T81dKQz3BivkNLw==
@@ -7838,6 +7884,23 @@ got@^7.0.0, got@^7.1.0:
     timed-out "^4.0.0"
     url-parse-lax "^1.0.0"
     url-to-options "^1.0.1"
+
+got@^6.3.0, got@^6.7.1:
+  version "6.7.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-6.7.1.tgz#240cd05785a9a18e561dc1b44b41c763ef1e8db0"
+  integrity sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=
+  dependencies:
+    create-error-class "^3.0.0"
+    duplexer3 "^0.1.4"
+    get-stream "^3.0.0"
+    is-redirect "^1.0.0"
+    is-retry-allowed "^1.0.0"
+    is-stream "^1.0.0"
+    lowercase-keys "^1.0.0"
+    safe-buffer "^5.0.1"
+    timed-out "^4.0.0"
+    unzip-response "^2.0.1"
+    url-parse-lax "^1.0.0"
 
 graceful-fs@^4.1.10, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.15"
@@ -8249,6 +8312,11 @@ http-errors@1.6.3, http-errors@~1.6.2, http-errors@~1.6.3:
     inherits "2.0.3"
     setprototypeof "1.1.0"
     statuses ">= 1.4.0 < 2"
+
+http-https@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/http-https/-/http-https-1.0.0.tgz#2f908dd5f1db4068c058cd6e6d4ce392c913389b"
+  integrity sha1-L5CN1fHbQGjAWM1ubUzjkskTOJs=
 
 http-parser-js@>=0.4.0:
   version "0.5.0"
@@ -11027,6 +11095,11 @@ moo@^0.4.3:
   resolved "https://registry.npmjs.org/moo/-/moo-0.4.3.tgz#3f847a26f31cf625a956a87f2b10fbc013bfd10e"
   integrity sha512-gFD2xGCl8YFgGHsqJ9NKRVdwlioeW3mI1iqfLNYQOv0+6JRwG58Zk9DIGQgyIaffSYaO1xsKnMaYzzNr1KyIAw==
 
+mout@^0.11.0:
+  version "0.11.1"
+  resolved "https://registry.yarnpkg.com/mout/-/mout-0.11.1.tgz#ba3611df5f0e5b1ffbfd01166b8f02d1f5fa2b99"
+  integrity sha1-ujYR318OWx/7/QEWa48C0fX6K5k=
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -11086,6 +11159,15 @@ mute-stream@~0.0.4:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
+
+mz@^2.6.0:
+  version "2.7.0"
+  resolved "https://registry.yarnpkg.com/mz/-/mz-2.7.0.tgz#95008057a56cafadc2bc63dde7f9ff6955948e32"
+  integrity sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==
+  dependencies:
+    any-promise "^1.0.0"
+    object-assign "^4.0.1"
+    thenify-all "^1.0.0"
 
 nan@2.10.0:
   version "2.10.0"
@@ -11782,6 +11864,13 @@ object.values@^1.0.4, object.values@^1.1.0:
     es-abstract "^1.12.0"
     function-bind "^1.1.1"
     has "^1.0.3"
+
+oboe@2.1.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/oboe/-/oboe-2.1.3.tgz#2b4865dbd46be81225713f4e9bfe4bcf4f680a4f"
+  integrity sha1-K0hl29Rr6BIlcT9Om/5Lz09oCk8=
+  dependencies:
+    http-https "^1.0.0"
 
 obuf@^1.0.0, obuf@^1.1.2:
   version "1.1.2"
@@ -14493,6 +14582,11 @@ scroll-into-view-if-needed@^2.2.16:
   dependencies:
     compute-scroll-into-view "1.0.11"
 
+scrypt-js@2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/scrypt-js/-/scrypt-js-2.0.3.tgz#bb0040be03043da9a012a2cea9fc9f852cfc87d4"
+  integrity sha1-uwBAvgMEPamgEqLOqfyfhSz8h9Q=
+
 scrypt-js@2.0.4:
   version "2.0.4"
   resolved "https://registry.npmjs.org/scrypt-js/-/scrypt-js-2.0.4.tgz#32f8c5149f0797672e551c07e230f834b6af5f16"
@@ -15628,6 +15722,25 @@ swap-case@^1.1.0:
     lower-case "^1.1.1"
     upper-case "^1.1.1"
 
+swarm-js@0.1.37:
+  version "0.1.37"
+  resolved "https://registry.yarnpkg.com/swarm-js/-/swarm-js-0.1.37.tgz#27d485317a340bbeec40292af783cc10acfa4663"
+  integrity sha512-G8gi5fcXP/2upwiuOShJ258sIufBVztekgobr3cVgYXObZwJ5AXLqZn52AI+/ffft29pJexF9WNdUxjlkVehoQ==
+  dependencies:
+    bluebird "^3.5.0"
+    buffer "^5.0.5"
+    decompress "^4.0.0"
+    eth-lib "^0.1.26"
+    fs-extra "^2.1.2"
+    fs-promise "^2.0.0"
+    got "^7.1.0"
+    mime-types "^2.1.16"
+    mkdirp-promise "^5.0.1"
+    mock-fs "^4.1.0"
+    setimmediate "^1.0.5"
+    tar.gz "^1.0.5"
+    xhr-request-promise "^0.1.2"
+
 swarm-js@^0.1.39:
   version "0.1.39"
   resolved "https://registry.npmjs.org/swarm-js/-/swarm-js-0.1.39.tgz#79becb07f291d4b2a178c50fee7aa6e10342c0e8"
@@ -15733,7 +15846,18 @@ tar-stream@^1.1.2, tar-stream@^1.5.2:
     to-buffer "^1.1.1"
     xtend "^4.0.0"
 
-tar@^2.0.0:
+tar.gz@^1.0.5:
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/tar.gz/-/tar.gz-1.0.7.tgz#577ef2c595faaa73452ef0415fed41113212257b"
+  integrity sha512-uhGatJvds/3diZrETqMj4RxBR779LKlIE74SsMcn5JProZsfs9j0QBwWO1RW+IWNJxS2x8Zzra1+AW6OQHWphg==
+  dependencies:
+    bluebird "^2.9.34"
+    commander "^2.8.1"
+    fstream "^1.0.8"
+    mout "^0.11.0"
+    tar "^2.1.1"
+
+tar@^2.0.0, tar@^2.1.1:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/tar/-/tar-2.2.1.tgz#8e4d2a256c0e2185c6b18ad694aec968b83cb1d1"
   integrity sha1-jk0qJWwOIYXGsYrWlK7JaLg8sdE=
@@ -15831,6 +15955,20 @@ theming@^1.3.0:
     is-function "^1.0.1"
     is-plain-object "^2.0.1"
     prop-types "^15.5.8"
+
+thenify-all@^1.0.0, thenify-all@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/thenify-all/-/thenify-all-1.6.0.tgz#1a1918d402d8fc3f98fbf234db0bcc8cc10e9726"
+  integrity sha1-GhkY1ALY/D+Y+/I02wvMjMEOlyY=
+  dependencies:
+    thenify ">= 3.1.0 < 4"
+
+"thenify@>= 3.1.0 < 4":
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/thenify/-/thenify-3.3.0.tgz#e69e38a1babe969b0108207978b9f62b88604839"
+  integrity sha1-5p44obq+lpsBCCB5eLn2K4hgSDk=
+  dependencies:
+    any-promise "^1.0.0"
 
 thread-loader@^1.2.0:
   version "1.2.0"
@@ -16033,6 +16171,11 @@ truffle-blockchain-utils@^0.0.5:
   resolved "https://registry.yarnpkg.com/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.5.tgz#a4e5c064dadd69f782a137f3d276d21095da7a47"
   integrity sha1-pOXAZNrdafeCoTfz0nbSEJXaekc=
 
+truffle-blockchain-utils@^0.0.8:
+  version "0.0.8"
+  resolved "https://registry.yarnpkg.com/truffle-blockchain-utils/-/truffle-blockchain-utils-0.0.8.tgz#09995c36016a54092b337f237c3dc1a3dca12341"
+  integrity sha512-4dbgqd4GrloKNLiaXACiymE3R2PsNFOlbgOh/CGkQVLArtcbgBAl7Fg2l5yVfDV8dtOFWHddj/2UkY25KY1+Dw==
+
 truffle-contract-schema@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/truffle-contract-schema/-/truffle-contract-schema-2.0.2.tgz#9db59e3a5ea85b63dca453a2dba9897c2c3523fd"
@@ -16041,6 +16184,15 @@ truffle-contract-schema@^2.0.2:
     ajv "^5.1.1"
     crypto-js "^3.1.9-1"
     debug "^3.1.0"
+
+truffle-contract-schema@^3.0.6:
+  version "3.0.6"
+  resolved "https://registry.yarnpkg.com/truffle-contract-schema/-/truffle-contract-schema-3.0.6.tgz#d28c43ccbc15524a2be81326ccb8c036332f7371"
+  integrity sha512-oAMPr/ecr06ViJMSatfp1VpbDNul0Q1dSrFkWSF4/6WWK4orhNL90A8uhtEt61doLz5n0Yjf59KWE0p7qToPXw==
+  dependencies:
+    ajv "^5.1.1"
+    crypto-js "^3.1.9-1"
+    debug "^4.1.0"
 
 truffle-contract@^3.0.6:
   version "3.0.7"
@@ -16053,10 +16205,31 @@ truffle-contract@^3.0.6:
     truffle-error "^0.0.3"
     web3 "0.20.6"
 
+truffle-contract@^4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/truffle-contract/-/truffle-contract-4.0.11.tgz#587d0e032c33ad320b7e12f1093eb789c62a8275"
+  integrity sha512-lzKFdLngTSt7MQMOvsUhOEPUjagSbGVkhQm7rSant4Y/VSWIppL3GXqpTOzdcOJMHgL9iYlMEm42+pHXq6DZxg==
+  dependencies:
+    bignumber.js "^7.2.1"
+    ethers "^4.0.0-beta.1"
+    truffle-blockchain-utils "^0.0.8"
+    truffle-contract-schema "^3.0.6"
+    truffle-error "^0.0.4"
+    truffle-interface-adapter "^0.1.2"
+    web3 "1.0.0-beta.37"
+    web3-core-promievent "1.0.0-beta.37"
+    web3-eth-abi "1.0.0-beta.37"
+    web3-utils "1.0.0-beta.37"
+
 truffle-error@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/truffle-error/-/truffle-error-0.0.3.tgz#4bf55242e14deee1c7194932709182deff2c97ca"
   integrity sha1-S/VSQuFN7uHHGUkycJGC3v8sl8o=
+
+truffle-error@^0.0.4:
+  version "0.0.4"
+  resolved "https://registry.yarnpkg.com/truffle-error/-/truffle-error-0.0.4.tgz#c3ff027570c26ae1f20db78637902497857f898f"
+  integrity sha512-hER0TNR4alBIhUp7SNrZRRiZtM/MBx+xBdM9qXP0tC3YASFmhNAxPuOyB8JDHFRNbDx12K7nvaqmyYGsI5c8BQ==
 
 truffle-flattener@^1.3.0:
   version "1.3.0"
@@ -16068,6 +16241,14 @@ truffle-flattener@^1.3.0:
     mkdirp "^0.5.1"
     solidity-parser-antlr "^0.4.0"
     tsort "0.0.1"
+
+truffle-interface-adapter@^0.1.2:
+  version "0.1.2"
+  resolved "https://registry.yarnpkg.com/truffle-interface-adapter/-/truffle-interface-adapter-0.1.2.tgz#b544e726a3a0833911ce6dadb1197cef53ad801b"
+  integrity sha512-1+pZprFU94mN8ydy4wVI2reW4iELDmsUADpa2ti++HwsX/T02yHK5+GxK3wQ9lXglRiI/B694fKFbHcv3t+Vxg==
+  dependencies:
+    bn.js "^4.11.8"
+    web3 "1.0.0-beta.37"
 
 truffle@^4.1.12, truffle@^4.1.15:
   version "4.1.15"
@@ -16265,6 +16446,11 @@ unbzip2-stream@^1.0.9:
   dependencies:
     buffer "^5.2.1"
     through "^2.3.8"
+
+underscore@1.8.3:
+  version "1.8.3"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.8.3.tgz#4f3fb53b106e6097fcf9cb4109f2a5e9bdfa5022"
+  integrity sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=
 
 unfetch@^4.0.0:
   version "4.1.0"
@@ -16695,6 +16881,15 @@ weak-map@^1.0.5:
   resolved "https://registry.npmjs.org/weak-map/-/weak-map-1.0.5.tgz#79691584d98607f5070bd3b70a40e6bb22e401eb"
   integrity sha1-eWkVhNmGB/UHC9O3CkDmuyLkAes=
 
+web3-bzz@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-bzz/-/web3-bzz-1.0.0-beta.37.tgz#59e3e4f5a9d732731008fe9165c3ec8bf85d502f"
+  integrity sha512-E+dho49Nsm/QpQvYWOF35YDsQrMvLB19AApENxhlQsu6HpWQt534DQul0t3Y/aAh8rlKD6Kanxt8LhHDG3vejQ==
+  dependencies:
+    got "7.1.0"
+    swarm-js "0.1.37"
+    underscore "1.8.3"
+
 web3-bzz@1.0.0-beta.50:
   version "1.0.0-beta.50"
   resolved "https://registry.npmjs.org/web3-bzz/-/web3-bzz-1.0.0-beta.50.tgz#5e234eecf427b33f773c78c00e34d370b542f6b0"
@@ -16704,6 +16899,15 @@ web3-bzz@1.0.0-beta.50:
     "@types/node" "^10.12.18"
     lodash "^4.17.11"
     swarm-js "^0.1.39"
+
+web3-core-helpers@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-core-helpers/-/web3-core-helpers-1.0.0-beta.37.tgz#04ec354b7f5c57234c309eea2bda9bf1f2fe68ba"
+  integrity sha512-efaLOzN28RMnbugnyelgLwPWWaSwElQzcAJ/x3PZu+uPloM/lE5x0YuBKvIh7/PoSMlHqtRWj1B8CpuQOUQ5Ew==
+  dependencies:
+    underscore "1.8.3"
+    web3-eth-iban "1.0.0-beta.37"
+    web3-utils "1.0.0-beta.37"
 
 web3-core-helpers@1.0.0-beta.50:
   version "1.0.0-beta.50"
@@ -16715,6 +16919,17 @@ web3-core-helpers@1.0.0-beta.50:
     web3-eth-iban "1.0.0-beta.50"
     web3-utils "1.0.0-beta.50"
 
+web3-core-method@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-core-method/-/web3-core-method-1.0.0-beta.37.tgz#53d148e63f818b23461b26307afdfbdaa9457744"
+  integrity sha512-pKWFUeqnVmzx3VrZg+CseSdrl/Yrk2ioid/HzolNXZE6zdoITZL0uRjnsbqXGEzgRRd1Oe/pFndpTlRsnxXloA==
+  dependencies:
+    underscore "1.8.3"
+    web3-core-helpers "1.0.0-beta.37"
+    web3-core-promievent "1.0.0-beta.37"
+    web3-core-subscriptions "1.0.0-beta.37"
+    web3-utils "1.0.0-beta.37"
+
 web3-core-method@1.0.0-beta.50:
   version "1.0.0-beta.50"
   resolved "https://registry.npmjs.org/web3-core-method/-/web3-core-method-1.0.0-beta.50.tgz#4f9b55699f6e46f49dc8ac6bde204f9ae877b513"
@@ -16724,6 +16939,34 @@ web3-core-method@1.0.0-beta.50:
     eventemitter3 "3.1.0"
     lodash "^4.17.11"
 
+web3-core-promievent@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-core-promievent/-/web3-core-promievent-1.0.0-beta.37.tgz#4e51c469d0a7ac0a969885a4dbcde8504abe5b02"
+  integrity sha512-GTF2r1lP8nJBeA5Gxq5yZpJy9l8Fb9CXGZPfF8jHvaRdQHtm2Z+NDhqYmF833lcdkokRSyfPcXlz1mlWeClFpg==
+  dependencies:
+    any-promise "1.3.0"
+    eventemitter3 "1.1.1"
+
+web3-core-requestmanager@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-core-requestmanager/-/web3-core-requestmanager-1.0.0-beta.37.tgz#721a75df5920621bff42d9d74f7a64413675d56b"
+  integrity sha512-66VUqye5BGp1Zz1r8psCxdNH+GtTjaFwroum2Osx+wbC5oRjAiXkkadiitf6wRb+edodjEMPn49u7B6WGNuewQ==
+  dependencies:
+    underscore "1.8.3"
+    web3-core-helpers "1.0.0-beta.37"
+    web3-providers-http "1.0.0-beta.37"
+    web3-providers-ipc "1.0.0-beta.37"
+    web3-providers-ws "1.0.0-beta.37"
+
+web3-core-subscriptions@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.37.tgz#40de5e2490cc05b15faa8f935c97fd48d670cd9a"
+  integrity sha512-FdXl8so9kwkRRWziuCSpFsAuAdg9KvpXa1fQlT16uoGcYYfxwFO/nkwyBGQzkZt7emShI2IRugcazyPCZDwkOA==
+  dependencies:
+    eventemitter3 "1.1.1"
+    underscore "1.8.3"
+    web3-core-helpers "1.0.0-beta.37"
+
 web3-core-subscriptions@1.0.0-beta.50:
   version "1.0.0-beta.50"
   resolved "https://registry.npmjs.org/web3-core-subscriptions/-/web3-core-subscriptions-1.0.0-beta.50.tgz#73df7143062f915e02b153239af10974e350e20f"
@@ -16732,6 +16975,16 @@ web3-core-subscriptions@1.0.0-beta.50:
     "@babel/runtime" "^7.3.1"
     eventemitter3 "^3.1.0"
     lodash "^4.17.11"
+
+web3-core@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-core/-/web3-core-1.0.0-beta.37.tgz#66c2c7000772c9db36d737ada31607ace09b7e90"
+  integrity sha512-cIwEqCj7OJyefQNauI0HOgW4sSaOQ98V99H2/HEIlnCZylsDzfw7gtQUdwnRFiIyIxjbWy3iWsjwDPoXNPZBYg==
+  dependencies:
+    web3-core-helpers "1.0.0-beta.37"
+    web3-core-method "1.0.0-beta.37"
+    web3-core-requestmanager "1.0.0-beta.37"
+    web3-utils "1.0.0-beta.37"
 
 web3-core@1.0.0-beta.50:
   version "1.0.0-beta.50"
@@ -16743,6 +16996,15 @@ web3-core@1.0.0-beta.50:
     lodash "^4.17.11"
     web3-utils "1.0.0-beta.50"
 
+web3-eth-abi@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.37.tgz#55592fa9cd2427d9f0441d78f3b8d0c1359a2a24"
+  integrity sha512-g9DKZGM2OqwKp/tX3W/yihcj7mQCtJ6CXyZXEIZfuDyRBED/iSEIFfieDOd+yo16sokLMig6FG7ADhhu+19hdA==
+  dependencies:
+    ethers "4.0.0-beta.1"
+    underscore "1.8.3"
+    web3-utils "1.0.0-beta.37"
+
 web3-eth-abi@1.0.0-beta.50:
   version "1.0.0-beta.50"
   resolved "https://registry.npmjs.org/web3-eth-abi/-/web3-eth-abi-1.0.0-beta.50.tgz#52ca509257648c6088aa9d8874d6ea5f249c6de7"
@@ -16752,6 +17014,22 @@ web3-eth-abi@1.0.0-beta.50:
     ethers "^4.0.27"
     lodash "^4.17.11"
     web3-utils "1.0.0-beta.50"
+
+web3-eth-accounts@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-eth-accounts/-/web3-eth-accounts-1.0.0-beta.37.tgz#0a5a9f14a6c3bd285e001c15eb3bb38ffa4b5204"
+  integrity sha512-uvbHL62/zwo4GDmwKdqH9c/EgYd8QVnAfpVw8D3epSISpgbONNY7Hr4MRMSd/CqAP12l2Ls9JVQGLhhC83bW6g==
+  dependencies:
+    any-promise "1.3.0"
+    crypto-browserify "3.12.0"
+    eth-lib "0.2.7"
+    scrypt.js "0.2.0"
+    underscore "1.8.3"
+    uuid "2.0.1"
+    web3-core "1.0.0-beta.37"
+    web3-core-helpers "1.0.0-beta.37"
+    web3-core-method "1.0.0-beta.37"
+    web3-utils "1.0.0-beta.37"
 
 web3-eth-accounts@1.0.0-beta.50:
   version "1.0.0-beta.50"
@@ -16770,6 +17048,20 @@ web3-eth-accounts@1.0.0-beta.50:
     web3-providers "1.0.0-beta.50"
     web3-utils "1.0.0-beta.50"
 
+web3-eth-contract@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.37.tgz#87f93c95ed16f320ba54943b7886890de6766013"
+  integrity sha512-h1B3A8Z/C7BlnTCHkrWbXZQTViDxfR12lKMeTkT8Sqj5phFmxrBlPE4ORy4lf1Dk5b23mZYE0r/IRACx4ThCrQ==
+  dependencies:
+    underscore "1.8.3"
+    web3-core "1.0.0-beta.37"
+    web3-core-helpers "1.0.0-beta.37"
+    web3-core-method "1.0.0-beta.37"
+    web3-core-promievent "1.0.0-beta.37"
+    web3-core-subscriptions "1.0.0-beta.37"
+    web3-eth-abi "1.0.0-beta.37"
+    web3-utils "1.0.0-beta.37"
+
 web3-eth-contract@1.0.0-beta.50:
   version "1.0.0-beta.50"
   resolved "https://registry.npmjs.org/web3-eth-contract/-/web3-eth-contract-1.0.0-beta.50.tgz#bc6d4523347e113c74c5e1c6c78219eeb61d9182"
@@ -16785,6 +17077,20 @@ web3-eth-contract@1.0.0-beta.50:
     web3-eth-accounts "1.0.0-beta.50"
     web3-providers "1.0.0-beta.50"
     web3-utils "1.0.0-beta.50"
+
+web3-eth-ens@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-eth-ens/-/web3-eth-ens-1.0.0-beta.37.tgz#714ecb01eb447ee3eb39b2b20a10ae96edb1f01f"
+  integrity sha512-dR3UkrVzdRrJhfP57xBPx0CMiVnCcYFvh+u2XMkGydrhHgupSUkjqGr89xry/j1T0BkuN9mikpbyhdCVMXqMbg==
+  dependencies:
+    eth-ens-namehash "2.0.8"
+    underscore "1.8.3"
+    web3-core "1.0.0-beta.37"
+    web3-core-helpers "1.0.0-beta.37"
+    web3-core-promievent "1.0.0-beta.37"
+    web3-eth-abi "1.0.0-beta.37"
+    web3-eth-contract "1.0.0-beta.37"
+    web3-utils "1.0.0-beta.37"
 
 web3-eth-ens@1.0.0-beta.50:
   version "1.0.0-beta.50"
@@ -16803,6 +17109,14 @@ web3-eth-ens@1.0.0-beta.50:
     web3-providers "1.0.0-beta.50"
     web3-utils "1.0.0-beta.50"
 
+web3-eth-iban@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.37.tgz#313a3f18ae2ab00ba98678ea1156b09ef32a3655"
+  integrity sha512-WQRniGJFxH/XCbd7miO6+jnUG+6bvuzfeufPIiOtCbeIC1ypp1kSqER8YVBDrTyinU1xnf1U5v0KBZ2yiWBJxQ==
+  dependencies:
+    bn.js "4.11.6"
+    web3-utils "1.0.0-beta.37"
+
 web3-eth-iban@1.0.0-beta.50:
   version "1.0.0-beta.50"
   resolved "https://registry.npmjs.org/web3-eth-iban/-/web3-eth-iban-1.0.0-beta.50.tgz#311ea9422369ecbde6316e10a34de9fb07994cd6"
@@ -16811,6 +17125,17 @@ web3-eth-iban@1.0.0-beta.50:
     "@babel/runtime" "^7.3.1"
     bn.js "4.11.8"
     web3-utils "1.0.0-beta.50"
+
+web3-eth-personal@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-eth-personal/-/web3-eth-personal-1.0.0-beta.37.tgz#187472f51861e2b6d45da43411801bc91a859f9a"
+  integrity sha512-B4dZpGbD+nGnn48i6nJBqrQ+HB7oDmd+Q3wGRKOsHSK5HRWO/KwYeA7wgwamMAElkut50lIsT9EJl4Apfk3G5Q==
+  dependencies:
+    web3-core "1.0.0-beta.37"
+    web3-core-helpers "1.0.0-beta.37"
+    web3-core-method "1.0.0-beta.37"
+    web3-net "1.0.0-beta.37"
+    web3-utils "1.0.0-beta.37"
 
 web3-eth-personal@1.0.0-beta.50:
   version "1.0.0-beta.50"
@@ -16824,6 +17149,25 @@ web3-eth-personal@1.0.0-beta.50:
     web3-net "1.0.0-beta.50"
     web3-providers "1.0.0-beta.50"
     web3-utils "1.0.0-beta.50"
+
+web3-eth@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-eth/-/web3-eth-1.0.0-beta.37.tgz#0e8ffcd857a5f85ae4b5f052ad831ca5c56f4f74"
+  integrity sha512-Eb3aGtkz3G9q+Z9DKgSQNbn/u8RtcZQQ0R4sW9hy5KK47GoT6vab5c6DiD3QWzI0BzitHzR5Ji+3VHf/hPUGgw==
+  dependencies:
+    underscore "1.8.3"
+    web3-core "1.0.0-beta.37"
+    web3-core-helpers "1.0.0-beta.37"
+    web3-core-method "1.0.0-beta.37"
+    web3-core-subscriptions "1.0.0-beta.37"
+    web3-eth-abi "1.0.0-beta.37"
+    web3-eth-accounts "1.0.0-beta.37"
+    web3-eth-contract "1.0.0-beta.37"
+    web3-eth-ens "1.0.0-beta.37"
+    web3-eth-iban "1.0.0-beta.37"
+    web3-eth-personal "1.0.0-beta.37"
+    web3-net "1.0.0-beta.37"
+    web3-utils "1.0.0-beta.37"
 
 web3-eth@1.0.0-beta.50:
   version "1.0.0-beta.50"
@@ -16847,6 +17191,15 @@ web3-eth@1.0.0-beta.50:
     web3-providers "1.0.0-beta.50"
     web3-utils "1.0.0-beta.50"
 
+web3-net@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-net/-/web3-net-1.0.0-beta.37.tgz#b494136043f3c6ba84fe4a47d4c028c2a63c9a8e"
+  integrity sha512-xG/uBtMdDa1UMXw9KjDUgf3fXA/fDEJUYUS0TDn+U9PMgngA+UVECHNNvQTrVVDxEky38V3sahwIDiopNsQdsw==
+  dependencies:
+    web3-core "1.0.0-beta.37"
+    web3-core-method "1.0.0-beta.37"
+    web3-utils "1.0.0-beta.37"
+
 web3-net@1.0.0-beta.50:
   version "1.0.0-beta.50"
   resolved "https://registry.npmjs.org/web3-net/-/web3-net-1.0.0-beta.50.tgz#1ca188b9210da6ae560bbd35a2b6dea1d2e68da7"
@@ -16859,6 +17212,32 @@ web3-net@1.0.0-beta.50:
     web3-core-method "1.0.0-beta.50"
     web3-providers "1.0.0-beta.50"
     web3-utils "1.0.0-beta.50"
+
+web3-providers-http@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-providers-http/-/web3-providers-http-1.0.0-beta.37.tgz#c06efd60e16e329e25bd268d2eefc68d82d13651"
+  integrity sha512-FM/1YDB1jtZuTo78habFj7S9tNHoqt0UipdyoQV29b8LkGKZV9Vs3is8L24hzuj1j/tbwkcAH+ewIseHwu0DTg==
+  dependencies:
+    web3-core-helpers "1.0.0-beta.37"
+    xhr2-cookies "1.1.0"
+
+web3-providers-ipc@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-providers-ipc/-/web3-providers-ipc-1.0.0-beta.37.tgz#55d247e7197257ca0c3e4f4b0fe1561311b9d5b9"
+  integrity sha512-NdRPRxYMIU0C3u18NI8u4bwbhI9pCg5nRgDGYcmSAx5uOBxiYcQy+hb0WkJRRhBoyIXJmy+s26FoH8904+UnPg==
+  dependencies:
+    oboe "2.1.3"
+    underscore "1.8.3"
+    web3-core-helpers "1.0.0-beta.37"
+
+web3-providers-ws@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-providers-ws/-/web3-providers-ws-1.0.0-beta.37.tgz#77c15aebc00b75d760d22d063ac2e415bdbef72f"
+  integrity sha512-8p6ZLv+1JYa5Vs8oBn33Nn3VGFBbF+wVfO+b78RJS1Qf1uIOzjFVDk3XwYDD7rlz9G5BKpxhaQw+6EGQ7L02aw==
+  dependencies:
+    underscore "1.8.3"
+    web3-core-helpers "1.0.0-beta.37"
+    websocket "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
 
 web3-providers@1.0.0-beta.50:
   version "1.0.0-beta.50"
@@ -16873,6 +17252,16 @@ web3-providers@1.0.0-beta.50:
     websocket "git://github.com/frozeman/WebSocket-Node.git#browserifyCompatible"
     xhr2-cookies "1.1.0"
 
+web3-shh@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-shh/-/web3-shh-1.0.0-beta.37.tgz#3246ce5229601b525020828a56ee283307057105"
+  integrity sha512-h5STG/xqZNQWtCLYOu7NiMqwqPea8SfkKQUPUFxXKIPVCFVKpHuQEwW1qcPQRJMLhlQIv17xuoUe1A+RzDNbrw==
+  dependencies:
+    web3-core "1.0.0-beta.37"
+    web3-core-method "1.0.0-beta.37"
+    web3-core-subscriptions "1.0.0-beta.37"
+    web3-net "1.0.0-beta.37"
+
 web3-shh@1.0.0-beta.50:
   version "1.0.0-beta.50"
   resolved "https://registry.npmjs.org/web3-shh/-/web3-shh-1.0.0-beta.50.tgz#e5a4a64b2308267b1635858e4adcc92eeee147f1"
@@ -16886,6 +17275,19 @@ web3-shh@1.0.0-beta.50:
     web3-net "1.0.0-beta.50"
     web3-providers "1.0.0-beta.50"
     web3-utils "1.0.0-beta.50"
+
+web3-utils@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.0.0-beta.37.tgz#ab868a90fe5e649337e38bdaf72133fcbf4d414d"
+  integrity sha512-kA1fyhO8nKgU21wi30oJQ/ssvu+9srMdjOTKbHYbQe4ATPcr5YNwwrxG3Bcpbu1bEwRUVKHCkqi+wTvcAWBdlQ==
+  dependencies:
+    bn.js "4.11.6"
+    eth-lib "0.1.27"
+    ethjs-unit "0.1.6"
+    number-to-bn "1.7.0"
+    randomhex "0.1.5"
+    underscore "1.8.3"
+    utf8 "2.1.1"
 
 web3-utils@1.0.0-beta.50, web3-utils@^1.0.0-beta.31:
   version "1.0.0-beta.50"
@@ -16913,6 +17315,19 @@ web3@0.20.6:
     utf8 "^2.1.1"
     xhr2 "*"
     xmlhttprequest "*"
+
+web3@1.0.0-beta.37:
+  version "1.0.0-beta.37"
+  resolved "https://registry.yarnpkg.com/web3/-/web3-1.0.0-beta.37.tgz#b42c30e67195f816cd19d048fda872f70eca7083"
+  integrity sha512-8XLgUspdzicC/xHG82TLrcF/Fxzj2XYNJ1KTYnepOI77bj5rvpsxxwHYBWQ6/JOjk0HkZqoBfnXWgcIHCDhZhQ==
+  dependencies:
+    web3-bzz "1.0.0-beta.37"
+    web3-core "1.0.0-beta.37"
+    web3-eth "1.0.0-beta.37"
+    web3-eth-personal "1.0.0-beta.37"
+    web3-net "1.0.0-beta.37"
+    web3-shh "1.0.0-beta.37"
+    web3-utils "1.0.0-beta.37"
 
 web3@^0.19.1:
   version "0.19.1"


### PR DESCRIPTION
This pull request updates the `Coordinator.sol` contract's `initiateServiceAgreement` function to use `struct` parameters so that more parameters can be added in the future without being limited by Solidity's stack depth. This change necessitated an update of the truffle-contract dependency to version 4.0.11 so that the tests function correctly. 