### PR TITLE
StatsPusher pushes on JobRun update as well as create

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -820,6 +820,21 @@ func WaitForJobs(t *testing.T, store *strpkg.Store, want int) []models.JobSpec {
 	return jobs
 }
 
+// WaitForSyncEventCount checks if the sync event count eventually reaches
+// the amound specified in parameter want.
+func WaitForSyncEventCount(
+	t *testing.T,
+	orm *orm.ORM,
+	want int,
+) {
+	t.Helper()
+	gomega.NewGomegaWithT(t).Eventually(func() int {
+		var count int
+		assert.NoError(t, orm.DB.Model(&models.SyncEvent{}).Count(&count).Error)
+		return count
+	}).Should(gomega.Equal(want))
+}
+
 // ParseISO8601 given the time string it Must parse the time and return it
 func ParseISO8601(s string) time.Time {
 	t, err := time.Parse(time.RFC3339Nano, s)

--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -392,6 +392,30 @@ func (InstantClock) After(_ time.Duration) <-chan time.Time {
 	return c
 }
 
+// TriggerClock implements the AfterNower interface, but must be manually triggered
+// to resume computation on After.
+type TriggerClock struct {
+	triggers chan time.Time
+}
+
+// NewTriggerClock returns a new TriggerClock, that a test can manually fire
+// to continue processing in a Clock dependency.
+func NewTriggerClock() *TriggerClock {
+	return &TriggerClock{
+		triggers: make(chan time.Time),
+	}
+}
+
+// Trigger sends a time to unblock the After call.
+func (t *TriggerClock) Trigger() {
+	t.triggers <- time.Now()
+}
+
+// After waits on a manual trigger.
+func (t *TriggerClock) After(_ time.Duration) <-chan time.Time {
+	return t.triggers
+}
+
 // NeverClock a never clock
 type NeverClock struct{}
 

--- a/core/services/scheduler.go
+++ b/core/services/scheduler.go
@@ -3,7 +3,6 @@ package services
 import (
 	"errors"
 	"sync"
-	"time"
 
 	"github.com/mrwonko/cron"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -93,7 +92,7 @@ func (s *Scheduler) AddJob(job models.JobSpec) {
 // Instances of Recurring must be initialized using NewRecurring().
 type Recurring struct {
 	Cron  Cron
-	Clock Nower
+	Clock utils.Nower
 	store *store.Store
 }
 
@@ -142,7 +141,7 @@ func (r *Recurring) AddJob(job models.JobSpec) {
 // OneTime represents runs that are to be executed only once.
 type OneTime struct {
 	Store *store.Store
-	Clock Afterer
+	Clock utils.Afterer
 	done  chan struct{}
 }
 
@@ -220,16 +219,4 @@ func newChainlinkCron() *chainlinkCron {
 func (cc *chainlinkCron) Stop() {
 	cc.Cron.Stop()
 	cc.Cron.Wait()
-}
-
-// Nower is an interface that fulfills the Now method,
-// following the behavior of time.Now.
-type Nower interface {
-	Now() time.Time
-}
-
-// Afterer is an interface that fulfills the After method,
-// following the behavior of time.After.
-type Afterer interface {
-	After(d time.Duration) <-chan time.Time
 }

--- a/core/services/synchronization/stats_pusher_test.go
+++ b/core/services/synchronization/stats_pusher_test.go
@@ -1,0 +1,38 @@
+package synchronization_test
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/services/synchronization"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/chainlink/core/store/orm"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStatsPusher(t *testing.T) {
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+
+	wsserver, wscleanup := cltest.NewEventWebSocketServer(t)
+	defer wscleanup()
+
+	pusher := synchronization.NewStatsPusher(store.ORM, wsserver.URL)
+	pusher.Start()
+	defer pusher.Close()
+
+	j := cltest.NewJobWithWebInitiator()
+	require.NoError(t, store.CreateJob(&j))
+
+	jr := j.NewRun(j.Initiators[0])
+	require.NoError(t, store.CreateJobRun(&jr))
+
+	assert.Equal(t, 1, lenSyncEvents(t, store.ORM))
+}
+
+func lenSyncEvents(t *testing.T, orm *orm.ORM) int {
+	var count int
+	require.NoError(t, orm.DB.Model(&models.SyncEvent{}).Count(&count).Error)
+	return count
+}

--- a/core/services/synchronization/stats_pusher_test.go
+++ b/core/services/synchronization/stats_pusher_test.go
@@ -34,7 +34,7 @@ func TestStatsPusher(t *testing.T) {
 	cltest.CallbackOrTimeout(t, "ws server receives jobrun creation", func() {
 		<-wsserver.Received
 	})
-	assert.Equal(t, 0, lenSyncEvents(t, store.ORM))
+	cltest.WaitForSyncEventCount(t, store.ORM, 0)
 
 	jr.ApplyResult(models.RunResult{Status: models.RunStatusCompleted})
 	require.NoError(t, store.SaveJobRun(&jr))
@@ -44,7 +44,7 @@ func TestStatsPusher(t *testing.T) {
 	cltest.CallbackOrTimeout(t, "ws server receives jobrun update", func() {
 		<-wsserver.Received
 	})
-	assert.Equal(t, 0, lenSyncEvents(t, store.ORM))
+	cltest.WaitForSyncEventCount(t, store.ORM, 0)
 }
 
 func lenSyncEvents(t *testing.T, orm *orm.ORM) int {

--- a/core/services/synchronization/web_socket_client_test.go
+++ b/core/services/synchronization/web_socket_client_test.go
@@ -9,53 +9,53 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestWebSocketStatsPusher_StartCloseStart(t *testing.T) {
+func TestWebSocketClient_StartCloseStart(t *testing.T) {
 	wsserver, cleanup := cltest.NewEventWebSocketServer(t)
 	defer cleanup()
 
-	pusher := synchronization.NewWebSocketClient(wsserver.URL)
-	require.NoError(t, pusher.Start())
-	cltest.CallbackOrTimeout(t, "stats pusher connects", func() {
+	wsclient := synchronization.NewWebSocketClient(wsserver.URL)
+	require.NoError(t, wsclient.Start())
+	cltest.CallbackOrTimeout(t, "ws client connects", func() {
 		<-wsserver.Connected
 	})
-	require.NoError(t, pusher.Close())
+	require.NoError(t, wsclient.Close())
 
 	// restart after client disconnect
-	require.NoError(t, pusher.Start())
-	cltest.CallbackOrTimeout(t, "stats pusher restarts", func() {
+	require.NoError(t, wsclient.Start())
+	cltest.CallbackOrTimeout(t, "ws client restarts", func() {
 		<-wsserver.Connected
 	}, 3*time.Second)
-	require.NoError(t, pusher.Close())
+	require.NoError(t, wsclient.Close())
 }
 
-func TestWebSocketStatsPusher_ReconnectLoop(t *testing.T) {
+func TestWebSocketClient_ReconnectLoop(t *testing.T) {
 	wsserver, cleanup := cltest.NewEventWebSocketServer(t)
 	defer cleanup()
 
-	pusher := synchronization.NewWebSocketClient(wsserver.URL)
-	require.NoError(t, pusher.Start())
-	cltest.CallbackOrTimeout(t, "stats pusher connects", func() {
+	wsclient := synchronization.NewWebSocketClient(wsserver.URL)
+	require.NoError(t, wsclient.Start())
+	cltest.CallbackOrTimeout(t, "ws client connects", func() {
 		<-wsserver.Connected
 	})
 
 	// reconnect after server disconnect
 	wsserver.WriteCloseMessage()
-	cltest.CallbackOrTimeout(t, "stats pusher reconnects", func() {
+	cltest.CallbackOrTimeout(t, "ws client reconnects", func() {
 		<-wsserver.Connected
 	}, 3*time.Second)
-	require.NoError(t, pusher.Close())
+	require.NoError(t, wsclient.Close())
 }
 
-func TestWebSocketStatsPusher_Send(t *testing.T) {
+func TestWebSocketClient_Send(t *testing.T) {
 	wsserver, cleanup := cltest.NewEventWebSocketServer(t)
 	defer cleanup()
 
-	pusher := synchronization.NewWebSocketClient(wsserver.URL)
-	require.NoError(t, pusher.Start())
-	defer pusher.Close()
+	wsclient := synchronization.NewWebSocketClient(wsserver.URL)
+	require.NoError(t, wsclient.Start())
+	defer wsclient.Close()
 
 	expectation := `{"hello": "world"}`
-	pusher.Send([]byte(expectation))
+	wsclient.Send([]byte(expectation))
 	cltest.CallbackOrTimeout(t, "receive stats", func() {
 		require.Equal(t, expectation, <-wsserver.Received)
 	})

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -26,7 +25,7 @@ import (
 type Store struct {
 	*orm.ORM
 	Config      Config
-	Clock       AfterNower
+	Clock       utils.AfterNower
 	KeyStore    *KeyStore
 	RunChannel  RunChannel
 	TxManager   TxManager
@@ -133,7 +132,7 @@ func NewStoreWithDialer(config Config, dialer Dialer) *Store {
 	keyStore := NewKeyStore(config.KeysDir())
 
 	store := &Store{
-		Clock:       Clock{},
+		Clock:       utils.Clock{},
 		Config:      config,
 		KeyStore:    keyStore,
 		ORM:         orm,
@@ -198,26 +197,6 @@ func (s *Store) SyncDiskKeyStoreToDB() error {
 		}
 	}
 	return merr
-}
-
-// AfterNower is an interface that fulfills the `After()` and `Now()`
-// methods.
-type AfterNower interface {
-	After(d time.Duration) <-chan time.Time
-	Now() time.Time
-}
-
-// Clock is a basic type for scheduling events in the application.
-type Clock struct{}
-
-// Now returns the current time.
-func (Clock) Now() time.Time {
-	return time.Now()
-}
-
-// After returns the current time if the given duration has elapsed.
-func (Clock) After(d time.Duration) <-chan time.Time {
-	return time.After(d)
 }
 
 func initializeORM(config Config) (*orm.ORM, error) {

--- a/core/utils/interfaces.go
+++ b/core/utils/interfaces.go
@@ -1,0 +1,35 @@
+package utils
+
+import "time"
+
+// Nower is an interface that fulfills the Now method,
+// following the behavior of time.Now.
+type Nower interface {
+	Now() time.Time
+}
+
+// Afterer is an interface that fulfills the After method,
+// following the behavior of time.After.
+type Afterer interface {
+	After(d time.Duration) <-chan time.Time
+}
+
+// AfterNower is an interface that fulfills the `After()` and `Now()`
+// methods.
+type AfterNower interface {
+	After(d time.Duration) <-chan time.Time
+	Now() time.Time
+}
+
+// Clock is a basic type for scheduling events in the application.
+type Clock struct{}
+
+// Now returns the current time.
+func (Clock) Now() time.Time {
+	return time.Now()
+}
+
+// After returns the current time if the given duration has elapsed.
+func (Clock) After(d time.Duration) <-chan time.Time {
+	return time.After(d)
+}


### PR DESCRIPTION
For tracker story https://www.pivotaltracker.com/story/show/165295640

CL already pushes new JobRuns, this PR pushes updates to said JobRuns.

This is consumed by linkstats in PR https://github.com/smartcontractkit/linkstats/pull/68