### PR TITLE
Add Receive with timeout for WebSocketClient

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -835,6 +835,21 @@ func WaitForSyncEventCount(
 	}).Should(gomega.Equal(want))
 }
 
+// AssertSyncEventCountStays ensures that the event sync count stays consistent
+// for a period of time
+func AssertSyncEventCountStays(
+	t *testing.T,
+	orm *orm.ORM,
+	want int,
+) {
+	t.Helper()
+	gomega.NewGomegaWithT(t).Consistently(func() int {
+		var count int
+		assert.NoError(t, orm.DB.Model(&models.SyncEvent{}).Count(&count).Error)
+		return count
+	}).Should(gomega.Equal(want))
+}
+
 // ParseISO8601 given the time string it Must parse the time and return it
 func ParseISO8601(s string) time.Time {
 	t, err := time.Parse(time.RFC3339Nano, s)

--- a/core/internal/cltest/event_websocket_server.go
+++ b/core/internal/cltest/event_websocket_server.go
@@ -7,9 +7,12 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/pkg/errors"
+
 	"github.com/gorilla/websocket"
 )
 
+// EventWebSocketServer is a web socket server designed specifically for testing
 type EventWebSocketServer struct {
 	*httptest.Server
 	mutex       *sync.RWMutex // shared mutex for safe access to arrays/maps.
@@ -20,6 +23,7 @@ type EventWebSocketServer struct {
 	URL         *url.URL
 }
 
+// NewEventWebSocketServer returns a new EventWebSocketServer
 func NewEventWebSocketServer(t *testing.T) (*EventWebSocketServer, func()) {
 	server := &EventWebSocketServer{
 		mutex:     &sync.RWMutex{},
@@ -40,9 +44,44 @@ func NewEventWebSocketServer(t *testing.T) (*EventWebSocketServer, func()) {
 	}
 }
 
-var upgrader = websocket.Upgrader{
-	CheckOrigin: func(r *http.Request) bool { return true },
+// Broadcast sends a message to every web socket client connected to the EventWebSocketServer
+func (wss *EventWebSocketServer) Broadcast(message string) error {
+	wss.mutex.RLock()
+	defer wss.mutex.RUnlock()
+	for _, connection := range wss.connections {
+		err := connection.WriteMessage(websocket.TextMessage, []byte(message))
+		if err != nil {
+			return errors.Wrap(err, "error writing message to connection")
+		}
+	}
+
+	return nil
 }
+
+// WriteCloseMessage tells connected clients to disconnect.
+// Useful to emulate that the websocket server is shutting down without
+// actually shutting down.
+// This overcomes httptest.Server's inability to restart on the same URL:port.
+func (wss *EventWebSocketServer) WriteCloseMessage() {
+	wss.mutex.RLock()
+	for _, connection := range wss.connections {
+		err := connection.WriteMessage(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+		if err != nil {
+			wss.t.Error(err)
+		}
+	}
+	wss.mutex.RUnlock()
+}
+
+var (
+	upgrader = websocket.Upgrader{
+		CheckOrigin: func(r *http.Request) bool { return true },
+	}
+
+	closeCodes = []int{websocket.CloseNormalClosure, websocket.CloseAbnormalClosure}
+)
 
 func (wss *EventWebSocketServer) handler(w http.ResponseWriter, r *http.Request) {
 	var err error
@@ -52,7 +91,6 @@ func (wss *EventWebSocketServer) handler(w http.ResponseWriter, r *http.Request)
 	}
 
 	wss.addConnection(conn)
-	closeCodes := []int{websocket.CloseNormalClosure, websocket.CloseAbnormalClosure}
 	for {
 		_, payload, err := conn.ReadMessage() // we only read
 		if websocket.IsCloseError(err, closeCodes...) {
@@ -90,21 +128,4 @@ func (wss *EventWebSocketServer) removeConnection(conn *websocket.Conn) {
 	}
 	wss.connections = newc
 	wss.mutex.Unlock()
-}
-
-// WriteCloseMessage tells connected clients to disconnect.
-// Useful to emulate that the websocket server is shutting down without
-// actually shutting down.
-// This overcomes httptest.Server's inability to restart on the same URL:port.
-func (wss *EventWebSocketServer) WriteCloseMessage() {
-	wss.mutex.RLock()
-	for _, connection := range wss.connections {
-		err := connection.WriteMessage(
-			websocket.CloseMessage,
-			websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
-		if err != nil {
-			wss.t.Error(err)
-		}
-	}
-	wss.mutex.RUnlock()
 }

--- a/core/services/synchronization/stats_pusher_test.go
+++ b/core/services/synchronization/stats_pusher_test.go
@@ -33,6 +33,8 @@ func TestStatsPusher(t *testing.T) {
 	clock.Trigger()
 	cltest.CallbackOrTimeout(t, "ws server receives jobrun creation", func() {
 		<-wsserver.Received
+		err := wsserver.Broadcast(`{"result": 201}`)
+		assert.NoError(t, err)
 	})
 	cltest.WaitForSyncEventCount(t, store.ORM, 0)
 
@@ -43,8 +45,64 @@ func TestStatsPusher(t *testing.T) {
 	clock.Trigger()
 	cltest.CallbackOrTimeout(t, "ws server receives jobrun update", func() {
 		<-wsserver.Received
+		err := wsserver.Broadcast(`{"result": 201}`)
+		assert.NoError(t, err)
 	})
 	cltest.WaitForSyncEventCount(t, store.ORM, 0)
+}
+
+func TestStatsPusher_NoAckLeavesEvent(t *testing.T) {
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+
+	wsserver, wscleanup := cltest.NewEventWebSocketServer(t)
+	defer wscleanup()
+
+	clock := cltest.NewTriggerClock()
+	pusher := synchronization.NewStatsPusher(store.ORM, wsserver.URL, "", "", clock)
+	pusher.Start()
+	defer pusher.Close()
+
+	j := cltest.NewJobWithWebInitiator()
+	require.NoError(t, store.CreateJob(&j))
+
+	jr := j.NewRun(j.Initiators[0])
+	require.NoError(t, store.CreateJobRun(&jr))
+
+	assert.Equal(t, 1, lenSyncEvents(t, store.ORM), "jobrun sync event should be created")
+	clock.Trigger()
+	cltest.CallbackOrTimeout(t, "ws server receives jobrun creation", func() {
+		<-wsserver.Received
+	})
+	cltest.AssertSyncEventCountStays(t, store.ORM, 1)
+}
+
+func TestStatsPusher_BadSyncLeavesEvent(t *testing.T) {
+	store, cleanup := cltest.NewStore()
+	defer cleanup()
+
+	wsserver, wscleanup := cltest.NewEventWebSocketServer(t)
+	defer wscleanup()
+
+	clock := cltest.NewTriggerClock()
+	pusher := synchronization.NewStatsPusher(store.ORM, wsserver.URL, "", "", clock)
+	pusher.Start()
+	defer pusher.Close()
+
+	j := cltest.NewJobWithWebInitiator()
+	require.NoError(t, store.CreateJob(&j))
+
+	jr := j.NewRun(j.Initiators[0])
+	require.NoError(t, store.CreateJobRun(&jr))
+
+	assert.Equal(t, 1, lenSyncEvents(t, store.ORM), "jobrun sync event should be created")
+	clock.Trigger()
+	cltest.CallbackOrTimeout(t, "ws server receives jobrun creation", func() {
+		<-wsserver.Received
+		err := wsserver.Broadcast(`{"result": 500}`)
+		assert.NoError(t, err)
+	})
+	cltest.AssertSyncEventCountStays(t, store.ORM, 1)
 }
 
 func lenSyncEvents(t *testing.T, orm *orm.ORM) int {

--- a/core/services/synchronization/stats_pusher_test.go
+++ b/core/services/synchronization/stats_pusher_test.go
@@ -33,7 +33,7 @@ func TestStatsPusher(t *testing.T) {
 	clock.Trigger()
 	cltest.CallbackOrTimeout(t, "ws server receives jobrun creation", func() {
 		<-wsserver.Received
-		err := wsserver.Broadcast(`{"result": 201}`)
+		err := wsserver.Broadcast(`{"status": 201}`)
 		assert.NoError(t, err)
 	})
 	cltest.WaitForSyncEventCount(t, store.ORM, 0)
@@ -45,7 +45,7 @@ func TestStatsPusher(t *testing.T) {
 	clock.Trigger()
 	cltest.CallbackOrTimeout(t, "ws server receives jobrun update", func() {
 		<-wsserver.Received
-		err := wsserver.Broadcast(`{"result": 201}`)
+		err := wsserver.Broadcast(`{"status": 201}`)
 		assert.NoError(t, err)
 	})
 	cltest.WaitForSyncEventCount(t, store.ORM, 0)
@@ -99,7 +99,7 @@ func TestStatsPusher_BadSyncLeavesEvent(t *testing.T) {
 	clock.Trigger()
 	cltest.CallbackOrTimeout(t, "ws server receives jobrun creation", func() {
 		<-wsserver.Received
-		err := wsserver.Broadcast(`{"result": 500}`)
+		err := wsserver.Broadcast(`{"status": 500}`)
 		assert.NoError(t, err)
 	})
 	cltest.AssertSyncEventCountStays(t, store.ORM, 1)

--- a/core/store/models/run_test.go
+++ b/core/store/models/run_test.go
@@ -73,8 +73,9 @@ func TestJobRuns_SavesASyncEvent(t *testing.T) {
 	assert.NoError(t, err)
 
 	var events []*models.SyncEvent
-	err = store.AllSyncEvents(func(event *models.SyncEvent) {
+	err = store.AllSyncEvents(func(event *models.SyncEvent) error {
 		events = append(events, event)
+		return nil
 	})
 	require.NoError(t, err)
 	require.Len(t, events, 1)
@@ -113,8 +114,9 @@ func TestJobRuns_SkipsEventSaveIfURLBlank(t *testing.T) {
 	assert.NoError(t, err)
 
 	var events []*models.SyncEvent
-	err = store.AllSyncEvents(func(event *models.SyncEvent) {
+	err = store.AllSyncEvents(func(event *models.SyncEvent) error {
 		events = append(events, event)
+		return nil
 	})
 	require.NoError(t, err)
 	require.Len(t, events, 0)

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -237,7 +237,7 @@ func (orm *ORM) FindJobRun(id string) (models.JobRun, error) {
 }
 
 // AllSyncEvents returns all sync events
-func (orm *ORM) AllSyncEvents(cb func(*models.SyncEvent)) error {
+func (orm *ORM) AllSyncEvents(cb func(*models.SyncEvent) error) error {
 	return Batch(1000, func(offset, limit uint) (uint, error) {
 		var events []models.SyncEvent
 		err := orm.DB.
@@ -249,7 +249,10 @@ func (orm *ORM) AllSyncEvents(cb func(*models.SyncEvent)) error {
 		}
 
 		for _, event := range events {
-			cb(&event)
+			err = cb(&event)
+			if err != nil {
+				return 0, err
+			}
 		}
 
 		return uint(len(events)), err


### PR DESCRIPTION
This PR adds receipt of messages from Explorer and only deletes Events that have been accepted correctly by Explorer.

In the event of an error, the Stats Pusher will back off exponentially for up to a maximum of 5 minutes, reattempting. A bug that prevents syncing will print ERRORs to the log so would be a good source of an alert /cc @jleeh 