### PR TITLE
Tx Manager Mandelbug fix

### DIFF
--- a/core/services/head_tracker.go
+++ b/core/services/head_tracker.go
@@ -144,10 +144,10 @@ func (ht *HeadTracker) Detach(id string) {
 	ht.headMutex.Lock()
 	defer ht.headMutex.Unlock()
 
-	if !ht.connected {
-		ht.disconnect()
+	t, present := ht.attachments.detach(id)
+	if ht.connected && present {
+		t.Disconnect()
 	}
-	ht.attachments.detach(id)
 }
 
 // Connected returns whether or not this HeadTracker is connected.

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -47,7 +47,7 @@ func TestTxManager_CreateTx_Success(t *testing.T) {
 	})
 
 	tx, err := manager.CreateTx(to, data)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	_, err = store.FindTx(tx.ID)
 	assert.NoError(t, err)
 	assert.Equal(t, nonce, tx.Nonce)


### PR DESCRIPTION
The HeadTracker currently protects access around:

  1. Connection state
  2. "Attachments"

When the connection state is true, and an attachment is added, its Connect callback should be called. However since the connection state has a separate barrier to the attachments, it's possible for connection state to be set to true while an attachment is being added. Here is an example:

  1. Attach handler A
  2. Head Tracker Connects
  3. IsConnected is set to TRUE
  4. Attach handler B
  5. IsConnected is TRUE, so B is immediately executed
  6. Handler A is eventually executed

This PR removes the two separate synchronisation barriers and uses a single barrier to protect both the connection flag and the attachments. Connect is only called on an attachment that has not had its connect callback invoked yet, Disconnect is only called on an attachment that has had Connect called.

NOTE: I have preserved the behaviour of `Disconnect` callbacks being able to "jump in line", this is desired in the `TestJobSubscriber_AttachedToHeadTracker` test.

[Fixes #164499409]
