### PR TITLE
StatsPusher pushes EthTx Task tx receipt for Explorer to persist

### DIFF
--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -297,7 +297,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_ConfirmCompletes(t *testi
 	ethMock := app.MockEthClient()
 	ethMock.Register("eth_getTransactionReceipt", strpkg.TxReceipt{})
 	confirmedHash := cltest.NewHash()
-	receipt := strpkg.TxReceipt{Hash: confirmedHash, BlockNumber: cltest.Int(sentAt)}
+	receipt := strpkg.TxReceipt{Hash: confirmedHash, BlockNumber: cltest.Int(sentAt), Status: strpkg.TxReceiptSuccess}
 	ethMock.Register("eth_getTransactionReceipt", receipt)
 	confirmedAt := sentAt + config.MinOutgoingConfirmations() - 1 // confirmations are 0-based idx
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(confirmedAt))
@@ -352,7 +352,7 @@ func TestEthTxAdapter_Perform_AppendingTransactionReceipts(t *testing.T) {
 	sentAt := uint64(23456)
 
 	ethMock := app.MockEthClient()
-	receipt := strpkg.TxReceipt{Hash: cltest.NewHash(), BlockNumber: cltest.Int(sentAt)}
+	receipt := strpkg.TxReceipt{Hash: cltest.NewHash(), BlockNumber: cltest.Int(sentAt), Status: strpkg.TxReceiptSuccess}
 	ethMock.Register("eth_getTransactionReceipt", receipt)
 	confirmedAt := sentAt + config.MinOutgoingConfirmations() - 1 // confirmations are 0-based idx
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(confirmedAt))
@@ -368,7 +368,7 @@ func TestEthTxAdapter_Perform_AppendingTransactionReceipts(t *testing.T) {
 
 	input := sentResult
 	input.MarkPendingConfirmations()
-	previousReceipt := strpkg.TxReceipt{Hash: cltest.NewHash(), BlockNumber: cltest.Int(sentAt - 10)}
+	previousReceipt := strpkg.TxReceipt{Hash: cltest.NewHash(), BlockNumber: cltest.Int(sentAt - 10), Status: strpkg.TxReceiptSuccess}
 	input.Add("ethereumReceipts", []strpkg.TxReceipt{previousReceipt})
 
 	output := adapter.Perform(input, store)

--- a/core/services/synchronization/presenters.go
+++ b/core/services/synchronization/presenters.go
@@ -58,15 +58,27 @@ func (p SyncJobRunPresenter) initiator() syncInitiatorPresenter {
 
 func (p SyncJobRunPresenter) tasks() []syncTaskRunPresenter {
 	tasks := []syncTaskRunPresenter{}
-	for index, task := range p.TaskRuns {
+	for index, tr := range p.TaskRuns {
 		tasks = append(tasks, syncTaskRunPresenter{
 			Index:  index,
-			Type:   string(task.TaskSpec.Type),
-			Status: string(task.Status),
-			Error:  task.Result.ErrorMessage,
+			Type:   string(tr.TaskSpec.Type),
+			Status: string(tr.Status),
+			Error:  tr.Result.ErrorMessage,
+			Result: fetchLastEthereumReceipt(tr),
 		})
 	}
 	return tasks
+}
+
+func fetchLastEthereumReceipt(tr models.TaskRun) interface{} {
+	if tr.TaskSpec.Type == "ethtx" {
+		receipts := tr.Result.Data.Get("ethereumReceipts")
+		if receipts.IsArray() {
+			arr := receipts.Array()
+			return arr[len(arr)-1].Value()
+		}
+	}
+	return nil
 }
 
 type syncInitiatorPresenter struct {
@@ -81,4 +93,5 @@ type syncTaskRunPresenter struct {
 	Type   string      `json:"type"`
 	Status string      `json:"status"`
 	Error  null.String `json:"error"`
+	Result interface{} `json:"result,omitempty"`
 }

--- a/explorer/src/__tests__/entity/JobRun.test.ts
+++ b/explorer/src/__tests__/entity/JobRun.test.ts
@@ -3,6 +3,7 @@ import { Connection } from 'typeorm'
 import { fromString, search } from '../../entity/JobRun'
 import { JOB_RUN_A_ID, JOB_RUN_B_ID } from '../../seed'
 import { createChainlinkNode } from '../../entity/ChainlinkNode'
+import ethtxFixture from '../fixtures/JobRun.ethtx.fixture.json'
 import fixture from '../fixtures/JobRun.fixture.json'
 
 let db: Connection
@@ -46,6 +47,22 @@ describe('fromString', () => {
     expect(r.id).toBeDefined()
     expect(r.type).toEqual('runlog')
     expect(r.taskRuns.length).toEqual(1)
+  })
+
+  it('successfully creates an ethtx tasks with transaction info', async () => {
+    const jr = fromString(JSON.stringify(ethtxFixture))
+
+    expect(jr.taskRuns.length).toEqual(4)
+    const ethtxTask = jr.taskRuns[3]
+    expect(ethtxTask.id).toBeUndefined()
+    expect(ethtxTask.index).toEqual(3)
+    expect(ethtxTask.type).toEqual('ethtx')
+    expect(ethtxTask.status).toEqual('completed')
+    expect(ethtxTask.error).toEqual(null)
+    expect(ethtxTask.transactionHash).toEqual(
+      '0x1111111111111111111111111111111111111111111111111111111111111111'
+    )
+    expect(ethtxTask.transactionStatus).toEqual('0x1')
   })
 
   it('creates when completedAt is null', () => {

--- a/explorer/src/__tests__/fixtures/JobRun.ethtx.fixture.json
+++ b/explorer/src/__tests__/fixtures/JobRun.ethtx.fixture.json
@@ -1,0 +1,27 @@
+{
+  "id": "fe64b0a02e944a6ab411e121a0658117",
+  "jobId": "0d7f0402ce8d44ef80eea4305af7755d",
+  "runId": "fe64b0a02e944a6ab411e121a0658117",
+  "status": "completed",
+  "error": null,
+  "createdAt": "2019-05-03T15:21:35Z",
+  "amount": null,
+  "completedAt": "2019-05-03T11:21:36.01197-04:00",
+  "initiator": { "type": "web" },
+  "tasks": [
+    { "index": 0, "type": "httpget", "status": "completed", "error": null },
+    { "index": 1, "type": "jsonparse", "status": "completed", "error": null },
+    { "index": 2, "type": "ethbytes32", "status": "completed", "error": null },
+    {
+      "index": 3,
+      "type": "ethtx",
+      "status": "completed",
+      "error": null,
+      "result": {
+        "transactionHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
+        "status": "0x1",
+        "blockNumber": "0x6"
+      }
+    }
+  ]
+}

--- a/explorer/src/entity/JobRun.ts
+++ b/explorer/src/entity/JobRun.ts
@@ -81,6 +81,11 @@ export const fromString = (str: string): JobRun => {
     tr.status = trstr.status
     tr.error = trstr.error
 
+    if (trstr.result) {
+      tr.transactionHash = trstr.result.transactionHash
+      tr.transactionStatus = trstr.result.status
+    }
+
     return tr
   })
 
@@ -170,10 +175,14 @@ export const saveJobRunTree = async (db: Connection, jobRun: JobRun) => {
             `("index", "jobRunId") DO UPDATE SET
               "status" = :status
               ,"error" = :error
+              ,"transactionHash" = :transactionHash
+              ,"transactionStatus" = :transactionStatus
               `
           )
           .setParameter('status', tr.status)
           .setParameter('error', tr.error)
+          .setParameter('transactionHash', tr.transactionHash)
+          .setParameter('transactionStatus', tr.transactionStatus)
           .execute()
       })
     )

--- a/explorer/src/entity/TaskRun.ts
+++ b/explorer/src/entity/TaskRun.ts
@@ -1,6 +1,8 @@
 import { Column, Entity, ManyToOne, PrimaryGeneratedColumn } from 'typeorm'
 import { JobRun } from './JobRun'
 
+type TransactionStatus = '0x0' | '0x1'
+
 @Entity()
 export class TaskRun {
   @PrimaryGeneratedColumn()
@@ -20,4 +22,10 @@ export class TaskRun {
 
   @Column({ nullable: true })
   error?: string
+
+  @Column({ nullable: true })
+  transactionHash?: string
+
+  @Column({ nullable: true })
+  transactionStatus?: TransactionStatus
 }

--- a/explorer/src/migration/1556898012528-AddTransactionHashStatusToTaskRun.ts
+++ b/explorer/src/migration/1556898012528-AddTransactionHashStatusToTaskRun.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddTransactionHashStatusToTaskRun1556898012528
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
+      ALTER TABLE "task_run" ADD COLUMN "transactionHash" character varying;
+      ALTER TABLE "task_run" ADD COLUMN "transactionStatus" character varying;
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {}
+}


### PR DESCRIPTION
1. StatsPusher presents tx receipt for ethtx task in run.tasks[].result
2. Explorer migration to store `transactionHash` and `transactionStatus`


explorer GUI updates for compound status task success is for another PR.


Example chainlink payload sent to explorer:

```json
{
  "id": "fe64b0a02e944a6ab411e121a0658117",
  "jobId": "0d7f0402ce8d44ef80eea4305af7755d",
  "runId": "fe64b0a02e944a6ab411e121a0658117",
  "status": "completed",
  "error": null,
  "createdAt": "2019-05-03T15:21:35Z",
  "amount": null,
  "completedAt": "2019-05-03T11:21:36.01197-04:00",
  "initiator": { "type": "web" },
  "tasks": [
    { "index": 0, "type": "httpget", "status": "completed", "error": null },
    { "index": 1, "type": "jsonparse", "status": "completed", "error": null },
    { "index": 2, "type": "ethbytes32", "status": "completed", "error": null },
    {
      "index": 3,
      "type": "ethtx",
      "status": "completed",
      "error": null,
      "result": {
        "transactionHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
        "status": "0x1",
        "blockNumber": "0x6"
      }
    }
  ]
}
```

Went with `result` over `reportedResult` because the reported facet is implied based on it being in a presenter and pushed via statspusher.