### PR TITLE
Use data returned from FindBridge in gui link creation

### DIFF
--- a/core/adapters/adapter.go
+++ b/core/adapters/adapter.go
@@ -115,7 +115,7 @@ func For(task models.TaskSpec, store *store.Store) (*PipelineAdapter, error) {
 		ba = &Wasm{}
 		err = unmarshalParams(task.Params, ba)
 	default:
-		bt, err := store.FindBridge(task.Type.String())
+		bt, err := store.FindBridge(task.Type)
 		if err != nil {
 			return nil, fmt.Errorf("%s is not a supported adapter type", task.Type)
 		}

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -915,6 +915,8 @@ func AssertServerResponse(t *testing.T, resp *http.Response, expectedStatusCode 
 		return
 	}
 
+	t.Logf("expected status code %d got %d", expectedStatusCode, resp.StatusCode)
+
 	if resp.StatusCode >= 300 && resp.StatusCode < 600 {
 		b, err := ioutil.ReadAll(resp.Body)
 		if err != nil {

--- a/core/store/models/bridge_type.go
+++ b/core/store/models/bridge_type.go
@@ -63,11 +63,11 @@ func (bt *BridgeTypeAuthentication) SetID(value string) error {
 // BridgeType is used for external adapters and has fields for
 // the name of the adapter and its URL.
 type BridgeType struct {
-	Name                   TaskType `json:"name" gorm:"primary_key"`
-	URL                    WebURL   `json:"url"`
-	Confirmations          uint64   `json:"confirmations"`
-	IncomingTokenHash      string
-	Salt                   string
+	Name                   TaskType     `json:"name" gorm:"primary_key"`
+	URL                    WebURL       `json:"url"`
+	Confirmations          uint64       `json:"confirmations"`
+	IncomingTokenHash      string       `json:"-"`
+	Salt                   string       `json:"-"`
 	OutgoingToken          string       `json:"outgoingToken"`
 	MinimumContractPayment *assets.Link `json:"minimumContractPayment" gorm:"type:varchar(255)"`
 }

--- a/core/store/models/bridge_type.go
+++ b/core/store/models/bridge_type.go
@@ -68,7 +68,7 @@ type BridgeType struct {
 	Confirmations          uint64   `json:"confirmations"`
 	IncomingTokenHash      string
 	Salt                   string
-	OutgoingToken          string
+	OutgoingToken          string       `json:"outgoingToken"`
 	MinimumContractPayment *assets.Link `json:"minimumContractPayment" gorm:"type:varchar(255)"`
 }
 

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -169,9 +169,9 @@ func (orm *ORM) Where(field string, value interface{}, instance interface{}) err
 }
 
 // FindBridge looks up a Bridge by its Name.
-func (orm *ORM) FindBridge(name string) (models.BridgeType, error) {
+func (orm *ORM) FindBridge(name models.TaskType) (models.BridgeType, error) {
 	var bt models.BridgeType
-	return bt, orm.DB.First(&bt, "name = ?", name).Error
+	return bt, orm.DB.First(&bt, "name = ?", name.String()).Error
 }
 
 // PendingBridgeType returns the bridge type of the current pending task,
@@ -181,7 +181,7 @@ func (orm *ORM) PendingBridgeType(jr models.JobRun) (models.BridgeType, error) {
 	if nextTask == nil {
 		return models.BridgeType{}, errors.New("Cannot find the pending bridge type of a job run with no unfinished tasks")
 	}
-	return orm.FindBridge(nextTask.TaskSpec.Type.String())
+	return orm.FindBridge(nextTask.TaskSpec.Type)
 }
 
 // FindJob looks up a Job by its ID.

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -467,11 +467,11 @@ func TestORM_FindBridge(t *testing.T) {
 
 	cases := []struct {
 		description string
-		name        string
+		name        models.TaskType
 		want        models.BridgeType
 		errored     bool
 	}{
-		{"actual external adapter", bt.Name.String(), bt, false},
+		{"actual external adapter", bt.Name, bt, false},
 		{"core adapter", "ethtx", models.BridgeType{}, true},
 		{"non-existent adapter", "nonExistent", models.BridgeType{}, true},
 	}

--- a/core/web/bridge_types_controller.go
+++ b/core/web/bridge_types_controller.go
@@ -21,7 +21,7 @@ func (btc *BridgeTypesController) Create(c *gin.Context) {
 	btr := &models.BridgeTypeRequest{}
 
 	if err := c.ShouldBindJSON(btr); err != nil {
-		c.AbortWithError(http.StatusInternalServerError, err)
+		publicError(c, http.StatusUnprocessableEntity, err)
 	} else if bta, bt, err := models.NewBridgeType(btr); err != nil {
 		publicError(c, StatusCodeForError(err), err)
 	} else if err := services.ValidateBridgeType(btr, btc.App.GetStore()); err != nil {
@@ -65,7 +65,7 @@ func (btc *BridgeTypesController) Update(c *gin.Context) {
 	} else if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 	} else if err := c.ShouldBindJSON(btr); err != nil {
-		c.AbortWithError(http.StatusInternalServerError, err)
+		publicError(c, http.StatusUnprocessableEntity, err)
 	} else if err := btc.App.GetStore().UpdateBridgeType(&bt, btr); err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
 	} else {

--- a/core/web/bridge_types_controller.go
+++ b/core/web/bridge_types_controller.go
@@ -42,7 +42,9 @@ func (btc *BridgeTypesController) Index(c *gin.Context, size, page, offset int) 
 // Show returns the details of a specific Bridge.
 func (btc *BridgeTypesController) Show(c *gin.Context) {
 	name := c.Param("BridgeName")
-	if bt, err := btc.App.GetStore().FindBridge(name); err == orm.ErrorNotFound {
+	if taskType, err := models.NewTaskType(name); err != nil {
+		publicError(c, http.StatusUnprocessableEntity, err)
+	} else if bt, err := btc.App.GetStore().FindBridge(taskType); err == orm.ErrorNotFound {
 		publicError(c, http.StatusNotFound, errors.New("bridge not found"))
 	} else if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
@@ -56,7 +58,9 @@ func (btc *BridgeTypesController) Update(c *gin.Context) {
 	name := c.Param("BridgeName")
 	btr := &models.BridgeTypeRequest{}
 
-	if bt, err := btc.App.GetStore().FindBridge(name); err == orm.ErrorNotFound {
+	if taskType, err := models.NewTaskType(name); err != nil {
+		publicError(c, http.StatusUnprocessableEntity, err)
+	} else if bt, err := btc.App.GetStore().FindBridge(taskType); err == orm.ErrorNotFound {
 		publicError(c, http.StatusNotFound, errors.New("bridge not found"))
 	} else if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, err)
@@ -72,7 +76,10 @@ func (btc *BridgeTypesController) Update(c *gin.Context) {
 // Destroy removes a specific Bridge.
 func (btc *BridgeTypesController) Destroy(c *gin.Context) {
 	name := c.Param("BridgeName")
-	if bt, err := btc.App.GetStore().FindBridge(name); err == orm.ErrorNotFound {
+
+	if taskType, err := models.NewTaskType(name); err != nil {
+		publicError(c, http.StatusUnprocessableEntity, err)
+	} else if bt, err := btc.App.GetStore().FindBridge(taskType); err == orm.ErrorNotFound {
 		publicError(c, http.StatusNotFound, errors.New("bridge not found"))
 	} else if err != nil {
 		c.AbortWithError(http.StatusInternalServerError, fmt.Errorf("Error searching for bridge for BTC Destroy: %+v", err))

--- a/core/web/bridge_types_controller_test.go
+++ b/core/web/bridge_types_controller_test.go
@@ -114,7 +114,7 @@ func TestBridgeTypesController_Create_Success(t *testing.T) {
 	assert.NotEmpty(t, respJSON.Get("data.attributes.incomingToken").String())
 	assert.NotEmpty(t, respJSON.Get("data.attributes.outgoingToken").String())
 
-	bt, err := app.Store.FindBridge(btName)
+	bt, err := app.Store.FindBridge(models.MustNewTaskType(btName))
 	assert.NoError(t, err)
 	assert.Equal(t, "randomnumber", bt.Name.String())
 	assert.Equal(t, uint64(10), bt.Confirmations)
@@ -131,7 +131,7 @@ func TestBridgeTypesController_Update_Success(t *testing.T) {
 	client := app.NewHTTPClient()
 
 	bt := &models.BridgeType{
-		Name: models.MustNewTaskType("bridgea"),
+		Name: models.MustNewTaskType("BRidgea"),
 		URL:  cltest.WebURL("http://mybridge"),
 	}
 	require.NoError(t, app.GetStore().CreateBridgeType(bt))
@@ -141,7 +141,7 @@ func TestBridgeTypesController_Update_Success(t *testing.T) {
 	defer cleanup()
 	cltest.AssertServerResponse(t, resp, 200)
 
-	ubt, err := app.Store.FindBridge(bt.Name.String())
+	ubt, err := app.Store.FindBridge(bt.Name)
 	assert.NoError(t, err)
 	assert.Equal(t, cltest.WebURL("http://yourbridge"), ubt.URL)
 }

--- a/core/web/bridge_types_controller_test.go
+++ b/core/web/bridge_types_controller_test.go
@@ -237,7 +237,7 @@ func TestBridgeTypesController_Create_BindJSONError(t *testing.T) {
 		bytes.NewBufferString("}"),
 	)
 	defer cleanup()
-	cltest.AssertServerResponse(t, resp, 500)
+	cltest.AssertServerResponse(t, resp, 422)
 }
 
 func TestBridgeTypesController_Create_DatabaseError(t *testing.T) {

--- a/operator_ui/__tests__/containers/Bridges/Show.test.js
+++ b/operator_ui/__tests__/containers/Bridges/Show.test.js
@@ -18,7 +18,7 @@ const mountShow = props =>
 
 describe('containers/Bridges/Show', () => {
   it('renders the details of the bridge spec', async () => {
-    expect.assertions(6)
+    expect.assertions(5)
     const response = {
       data: {
         id: 'tallbridge',
@@ -27,7 +27,6 @@ describe('containers/Bridges/Show', () => {
           name: 'Tall Bridge',
           url: 'https://localhost.com:712/endpoint',
           confirmations: 9,
-          incomingToken: 'incomingToken',
           outgoingToken: 'outgoingToken'
         }
       }
@@ -42,7 +41,6 @@ describe('containers/Bridges/Show', () => {
     expect(wrapper.text()).toContain('Tall Bridge')
     expect(wrapper.text()).toContain('Confirmations')
     expect(wrapper.text()).toContain('https://localhost.com:712/endpoint')
-    expect(wrapper.text()).toContain('incomingToken')
     expect(wrapper.text()).toContain('outgoingToken')
     expect(wrapper.text()).toContain('9')
   })

--- a/operator_ui/src/actions.js
+++ b/operator_ui/src/actions.js
@@ -235,8 +235,8 @@ export const updateBridge = (data, successCallback, errorCallback) => {
     return api
       .updateBridge(data)
       .then(res => {
-        dispatch(receiveUpdateSuccess(res))
-        dispatch(notifySuccess(successCallback, data))
+        dispatch(receiveUpdateSuccess(res.data))
+        dispatch(notifySuccess(successCallback, res.data))
       })
       .catch(error => {
         curryErrorHandler(dispatch, RECEIVE_UPDATE_ERROR)(error)

--- a/operator_ui/src/actions.js
+++ b/operator_ui/src/actions.js
@@ -220,7 +220,7 @@ export const createBridge = (data, successCallback, errorCallback) => {
       .createBridge(data)
       .then(res => {
         dispatch(receiveCreateSuccess(res))
-        dispatch(notifySuccess(successCallback, data))
+        dispatch(notifySuccess(successCallback, res.data))
       })
       .catch(error => {
         curryErrorHandler(dispatch, RECEIVE_CREATE_ERROR)(error)

--- a/operator_ui/src/components/Bridges/Form.js
+++ b/operator_ui/src/components/Bridges/Form.js
@@ -142,7 +142,11 @@ const formikOpts = {
   },
 
   handleSubmit(values, { props, setSubmitting }) {
-    values.url = normalizeUrl(values.url)
+    try {
+      values.url = normalizeUrl(values.url)
+    } catch(exception) {
+      values.url = ''
+    }
     props.onSubmit(values, props.onSuccess, props.onError)
     set('persistBridge', values)
     setTimeout(() => {

--- a/operator_ui/src/containers/Bridges/Edit.js
+++ b/operator_ui/src/containers/Bridges/Edit.js
@@ -1,6 +1,6 @@
 import React from 'react'
 import PropTypes from 'prop-types'
-import { Link } from 'react-static'
+import { Link } from 'react-router-dom'
 import { connect } from 'react-redux'
 import Grid from '@material-ui/core/Grid'
 import Typography from '@material-ui/core/Typography'
@@ -17,11 +17,13 @@ import ReactStaticLinkComponent from 'components/ReactStaticLinkComponent'
 import Content from 'components/Content'
 import { useHooks, useEffect } from 'use-react-hooks'
 
-const SuccessNotification = ({ name }) => (
-  <React.Fragment>
-    Successfully updated <Link to={`/bridges/${name}`}>{name}</Link>
-  </React.Fragment>
-)
+const SuccessNotification = ({ id }) => {
+  return (
+    <React.Fragment>
+      Successfully updated <Link to={`/bridges/${id}`}>{id}</Link>
+    </React.Fragment>
+  )
+}
 
 export const Edit = useHooks(props => {
   useEffect(() => {

--- a/operator_ui/src/containers/Bridges/New.js
+++ b/operator_ui/src/containers/Bridges/New.js
@@ -12,11 +12,13 @@ import Content from 'components/Content'
 import { createBridge } from 'actions'
 import matchRouteAndMapDispatchToProps from 'utils/matchRouteAndMapDispatchToProps'
 
-const SuccessNotification = ({ name }) => (
-  <React.Fragment>
-    Successfully created bridge <Link to={`/bridges/${name}`}>{name}</Link>
-  </React.Fragment>
-)
+const SuccessNotification = ({ id }) => {
+  return (
+    <React.Fragment>
+      Successfully created bridge <Link to={`/bridges/${id}`}>{id}</Link>
+    </React.Fragment>
+  )
+}
 
 const New = props => {
   document.title = 'New Bridge'

--- a/operator_ui/src/containers/Bridges/Show.js
+++ b/operator_ui/src/containers/Bridges/Show.js
@@ -47,13 +47,6 @@ const renderLoaded = props => (
     </Typography>
 
     <Typography variant="subtitle1" color="textSecondary">
-      Incoming Token
-    </Typography>
-    <Typography variant="body1" color="inherit">
-      {props.bridge.incomingToken}
-    </Typography>
-
-    <Typography variant="subtitle1" color="textSecondary">
       Outgoing Token
     </Typography>
     <Typography variant="body1" color="inherit">


### PR DESCRIPTION
 - [x] Always find bridges by TaskType rather than raw string, so that invalid task types cannot be searched with
 - [x] Display returned record in BridgeType header, rather than submitted, should handle downcased name
 - [x] URL submission breaks if URL is invalid
 - [x] Updating a URL produces a 500
 - [x] Bridge show endpoint leaks secrets
 - [x] Spot for incoming token in GUI is no longer needed