### PR TITLE
Add explorer logging

### DIFF
--- a/explorer/src/server.ts
+++ b/explorer/src/server.ts
@@ -34,6 +34,7 @@ const server = (port: number = DEFAULT_PORT) => {
   }
 
   const app = express()
+  addLogging(app)
 
   app.use(express.static('client/build'))
   app.use('/api/v1', controllers.jobRuns)


### PR DESCRIPTION
Looks like I accidentally omitted the `addLogging` call in start explorer.