### PR TITLE
Filter headers from explorer logs

### DIFF
--- a/explorer/src/server.ts
+++ b/explorer/src/server.ts
@@ -1,5 +1,5 @@
 import * as controllers from './controllers'
-import * as expressWinston from 'express-winston'
+import { requestWhitelist, logger, errorLogger } from 'express-winston'
 import * as winston from 'winston'
 import express from 'express'
 import http from 'http'
@@ -8,11 +8,20 @@ import seed from './seed'
 
 export const DEFAULT_PORT = parseInt(process.env.SERVER_PORT, 10) || 8080
 
+const LOGGER_WHITELIST = [
+  'url',
+  'method',
+  'httpVersion',
+  'originalUrl',
+  'query'
+]
+requestWhitelist.splice(0, requestWhitelist.length, ...LOGGER_WHITELIST)
+
 const addLogging = (app: express.Express) => {
   const consoleTransport = new winston.transports.Console()
 
   app.use(
-    expressWinston.logger({
+    logger({
       expressFormat: true,
       meta: true,
       msg: 'HTTP {{req.method}} {{req.url}}',
@@ -21,7 +30,7 @@ const addLogging = (app: express.Express) => {
   )
 
   app.use(
-    expressWinston.errorLogger({
+    errorLogger({
       transports: [consoleTransport]
     })
   )

--- a/explorer/src/server.ts
+++ b/explorer/src/server.ts
@@ -4,7 +4,6 @@ import * as winston from 'winston'
 import express from 'express'
 import http from 'http'
 import { bootstrapRealtime } from './realtime'
-import { ChainlinkNode, createChainlinkNode } from './entity/ChainlinkNode'
 import seed from './seed'
 
 export const DEFAULT_PORT = parseInt(process.env.SERVER_PORT, 10) || 8080


### PR DESCRIPTION
[#165229980]

Before:

```
[1] {"level":"info","message":"GET /api/v1/job_runs/a21e139a-7378-4198-8cf8-1afd4ab0d1de 304 53ms","meta":{"res":{"statusCode":304},"req":{"url":"/api/v1/job_runs/a21e139a-7378-4198-8cf8-1afd4ab0d1de","headers":{"x-forwarded-host":"localh
ost:3000","x-forwarded-proto":"http","x-forwarded-port":"3000","x-forwarded-for":"127.0.0.1","if-none-match":"W/\"309-WnsxtaVkItNFF+YaDiPs0fh10Ak\"","cookie":"clsession=MTU1NzQxNjc3MHxEdi1CQkFFQ180SUFBUkFCRUFBQVJ2LUNBQUVHYzNSeWFXNW5EQTRBR
EdOc2MyVnpjMmx2Ymw5cFpBWnpkSEpwYm1jTUlnQWdNMlE1Tm1NeU9EVTFOREZoTkRoalptRTBORGRsTXpBNFpUazVNRGMxTWpVPXzqmArArC0AANaYg5lRrXCzGVAw1GzHaqPKZ3v0s2ep5w==","accept-language":"en-US,en;q=0.9","accept-encoding":"gzip, deflate, br","referer":"http:
//localhost:3000/job-runs/a21e139a-7378-4198-8cf8-1afd4ab0d1de","accept":"*/*","user-agent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_4) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/74.0.3729.131 Safari/537.36","connection":"close","
host":"localhost:8080"},"method":"GET","httpVersion":"1.1","originalUrl":"/api/v1/job_runs/a21e139a-7378-4198-8cf8-1afd4ab0d1de","query":{}},"responseTime":53}}
```

After:

```
[1] {"level":"info","message":"GET /api/v1/job_runs/a21e139a-7378-4198-8cf8-1afd4ab0d1de 200 39ms","meta":{"res":{"statusCode":200},"req":{"url":"/api/v1/job_runs/a21e139a-7378-4198-8cf8-1afd4ab0d1de","method":"GET","httpVersion":"1.1","originalUrl":"/api/v1/job_runs/a21e139a-7378-4198-8cf8-1afd4ab0d1de","query":{}},"responseTime":39}}
```