### PR TITLE
Add Pointer contract to LINK token address

### DIFF
--- a/evm/contracts/ChainlinkClient.sol
+++ b/evm/contracts/ChainlinkClient.sol
@@ -5,6 +5,7 @@ import "./ENSResolver.sol";
 import "./interfaces/ENSInterface.sol";
 import "./interfaces/LinkTokenInterface.sol";
 import "./interfaces/ChainlinkRequestInterface.sol";
+import "./interfaces/PointerInterface.sol";
 import "openzeppelin-solidity/contracts/math/SafeMath.sol";
 
 /**
@@ -22,6 +23,7 @@ contract ChainlinkClient {
   uint256 constant private ARGS_VERSION = 1;
   bytes32 constant private ENS_TOKEN_SUBNAME = keccak256("link");
   bytes32 constant private ENS_ORACLE_SUBNAME = keccak256("oracle");
+  address constant private LINK_TOKEN_POINTER = 0xC89bD4E1632D3A43CB03AAAd5262cbe4038Bc571;
 
   ENSInterface private ens;
   bytes32 private ensNode;
@@ -126,6 +128,14 @@ contract ChainlinkClient {
    */
   function setChainlinkToken(address _link) internal {
     link = LinkTokenInterface(_link);
+  }
+
+  /**
+   * @notice Sets the Chainlink token address for the public
+   * network as given by the Pointer contract
+   */
+  function setPublicChainlinkToken() internal {
+    setChainlinkToken(PointerInterface(LINK_TOKEN_POINTER).getAddress());
   }
 
   /**

--- a/evm/contracts/Pointer.sol
+++ b/evm/contracts/Pointer.sol
@@ -1,0 +1,9 @@
+pragma solidity 0.4.24;
+
+contract Pointer {
+  address public getAddress;
+
+  constructor(address _addr) public {
+    getAddress = _addr;
+  }
+}

--- a/evm/contracts/interfaces/PointerInterface.sol
+++ b/evm/contracts/interfaces/PointerInterface.sol
@@ -1,0 +1,5 @@
+pragma solidity 0.4.24;
+
+interface PointerInterface {
+  function getAddress() external view returns (address);
+}

--- a/evm/package.json
+++ b/evm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "chainlink",
-  "version": "0.6.2",
+  "version": "0.6.3",
   "license": "MIT",
   "scripts": {
     "build": "truffle build",

--- a/evm/test/Pointer_test.ts
+++ b/evm/test/Pointer_test.ts
@@ -1,0 +1,22 @@
+import * as h from './support/helpers'
+
+contract('Pointer', () => {
+  const sourcePath = 'Pointer.sol'
+  let contract: any
+  let link: any
+
+  beforeEach(async () => {
+    link = await h.linkContract()
+    contract = await h.deploy(sourcePath, link.address)
+  })
+
+  it('has a limited public interface', () => {
+    h.checkPublicABI(artifacts.require(sourcePath), ['getAddress'])
+  })
+
+  describe('#getAddress', () => {
+    it('returns the LINK token address', async () => {
+      assert.equal(await contract.getAddress(), link.address)
+    })
+  })
+})

--- a/examples/ropsten/contracts/RopstenConsumer.sol
+++ b/examples/ropsten/contracts/RopstenConsumer.sol
@@ -583,6 +583,14 @@ interface ChainlinkRequestInterface {
   ) external;
 }
 
+// File: contracts/interfaces/PointerInterface.sol
+
+pragma solidity 0.4.24;
+
+interface PointerInterface {
+  function getAddress() external view returns (address);
+}
+
 // File: openzeppelin-solidity/contracts/math/SafeMath.sol
 
 pragma solidity ^0.4.24;
@@ -648,6 +656,7 @@ pragma solidity 0.4.24;
 
 
 
+
 /**
  * @title The ChainlinkClient contract
  * @notice Contract writers can inherit this contract in order to create requests for the
@@ -663,6 +672,7 @@ contract ChainlinkClient {
   uint256 constant private ARGS_VERSION = 1;
   bytes32 constant private ENS_TOKEN_SUBNAME = keccak256("link");
   bytes32 constant private ENS_ORACLE_SUBNAME = keccak256("oracle");
+  address constant private LINK_TOKEN_POINTER = 0xC89bD4E1632D3A43CB03AAAd5262cbe4038Bc571;
 
   ENSInterface private ens;
   bytes32 private ensNode;
@@ -767,6 +777,14 @@ contract ChainlinkClient {
    */
   function setChainlinkToken(address _link) internal {
     link = LinkTokenInterface(_link);
+  }
+
+  /**
+   * @notice Sets the Chainlink token address for the public
+   * network as given by the Pointer contract
+   */
+  function setPublicChainlinkToken() internal {
+    setChainlinkToken(PointerInterface(LINK_TOKEN_POINTER).getAddress());
   }
 
   /**


### PR DESCRIPTION
This PR replaces https://github.com/smartcontractkit/chainlink/pull/1157 to only implement the Pointer contract and add the `setPublicChainlinkToken` method to ChainlinkClient.sol.