### PR TITLE
Make Ropsten example a Yarn workspace with Truffle

### DIFF
--- a/examples/ropsten/RopstenConsumerBase.sol
+++ b/examples/ropsten/RopstenConsumerBase.sol
@@ -1,7 +1,7 @@
 pragma solidity 0.4.24;
 
-import "../../../evm/contracts/ChainlinkClient.sol";
-import "../../../node_modules/openzeppelin-solidity/contracts/ownership/Ownable.sol";
+import "../../evm/contracts/ChainlinkClient.sol";
+import "../../node_modules/openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 contract ARopstenConsumer is ChainlinkClient, Ownable {
   uint256 constant private ORACLE_PAYMENT = 1 * LINK; // solium-disable-line zeppelin/no-arithmetic-operations

--- a/examples/ropsten/contracts/RopstenConsumer.sol
+++ b/examples/ropsten/contracts/RopstenConsumer.sol
@@ -959,7 +959,7 @@ contract Ownable {
   }
 }
 
-// File: ../examples/ropsten/contracts/RopstenConsumerBase.sol
+// File: ../examples/ropsten/RopstenConsumerBase.sol
 
 pragma solidity 0.4.24;
 

--- a/examples/ropsten/package.json
+++ b/examples/ropsten/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "chainlink-ropsten",
+  "private": true,
+  "version": "0.6.0",
+  "license": "MIT",
+  "dependencies": {
+    "truffle": "^5.0.1"
+  }
+}

--- a/examples/ropsten/truffle.js
+++ b/examples/ropsten/truffle.js
@@ -1,0 +1,7 @@
+module.exports = {
+  compilers: {
+    solc: {
+      version: '0.4.24'
+    }
+  }
+}

--- a/tools/bin/flatten-ropsten
+++ b/tools/bin/flatten-ropsten
@@ -2,5 +2,5 @@
 
 rm -f ../examples/ropsten/contracts/RopstenConsumer.sol
 rm -f ../examples/ropsten/contracts/Oracle.sol
-yarn truffle-flattener ../examples/ropsten/contracts/RopstenConsumerBase.sol --output ../examples/ropsten/contracts/RopstenConsumer.sol
+yarn truffle-flattener ../examples/ropsten/RopstenConsumerBase.sol --output ../examples/ropsten/contracts/RopstenConsumer.sol
 yarn truffle-flattener ../evm/contracts/Oracle.sol --output ../examples/ropsten/contracts/Oracle.sol

--- a/tools/ci/truffle_test
+++ b/tools/ci/truffle_test
@@ -9,3 +9,5 @@ yarn lint:evm && yarn lint:examples
 yarn workspace chainlink truffle test
 yarn workspace chainlink-uptime-sla truffle test --network test
 yarn workspace chainlink-echo-server truffle test --network test
+yarn workspace chainlink flatten
+yarn workspace chainlink-ropsten truffle build


### PR DESCRIPTION
Instead of manually having to run `yarn flatten` in the evm directory any time you make a change to a contract, the Ropsten example contracts will automatically be flattened and ensured that they compile for you as part of `./tools/ci/truffle_test`.