### PR TITLE
add timeouts to core http server to prevent DOS attacks

### DIFF
--- a/core/web/router.go
+++ b/core/web/router.go
@@ -27,6 +27,14 @@ import (
 	"github.com/unrolled/secure"
 )
 
+func init() {
+	gin.DebugPrintRouteFunc = printRoutes
+}
+
+func printRoutes(httpMethod, absolutePath, handlerName string, nuHandlers int) {
+	logger.Debugf("%-6s %-25s --> %s (%d handlers)", httpMethod, absolutePath, handlerName, nuHandlers)
+}
+
 const (
 	// SessionName is the session name
 	SessionName = "clsession"


### PR DESCRIPTION
1. Adds the following timeouts:
```go
	ReadTimeout:  5 * time.Second,
	WriteTimeout: 10 * time.Second,
	IdleTimeout:  60 * time.Second,
```

Opted against removing KeepAlives (`s.SetKeepAlivesEnabled(false)`) entirely due to the improved performance with legitimate use as described here in "persistent connections" https://developer.mozilla.org/en-US/docs/Web/HTTP/Connection_management_in_HTTP_1.x

2. Routes gin route logging through CL logger, which means it will also be in our log files.

![image](https://user-images.githubusercontent.com/635121/57651158-8fd49d80-759a-11e9-9838-f4348fd66a4f.png)

