### PR TITLE
Remove `transaction rolled back` spam and unify GORM logging

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -402,7 +402,8 @@
   version = "v1.0"
 
 [[projects]]
-  digest = "1:7d4958827c8f2d9d31e24d9a3a52194eb179f77d854692e57954c516ecf76748"
+  branch = "feature/on_defer_rollback_should_not_print_error_message"
+  digest = "1:c561ed4278be7f4199bda4cf400e4d9878e3fb120eae96ea57734f2f338368a1"
   name = "github.com/jinzhu/gorm"
   packages = [
     ".",
@@ -410,8 +411,8 @@
     "dialects/sqlite",
   ]
   pruneopts = ""
-  revision = "472c70caa40267cb89fd8facb07fe6454b578626"
-  version = "v1.9.2"
+  revision = "9f02beef1cddd6516e7eb234a8cd3826bedbb349"
+  source = "github.com/smartcontractkit/gorm"
 
 [[projects]]
   branch = "master"

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -166,6 +166,7 @@ func TestIntegration_FeeBump(t *testing.T) {
 		eth.Register("eth_blockNumber", utils.Uint64ToHex(safe))
 		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
 		eth.Register("eth_getTransactionReceipt", confirmedReceipt) // confirmed for gas bumped txat
+		eth.Register("eth_sendRawTransaction", attempt2Hash)
 		eth.Register("eth_getBalance", "0x0100")
 		eth.Register("eth_call", "0x0100")
 	})

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -32,6 +32,10 @@ func init() {
 	SetLogger(zl)
 }
 
+func GetLogger() *Logger {
+	return logger
+}
+
 func prettyConsoleSink(s zap.Sink) func(*url.URL) (zap.Sink, error) {
 	return func(*url.URL) (zap.Sink, error) {
 		return PrettyConsole{s}, nil

--- a/core/store/orm/log_wrapper.go
+++ b/core/store/orm/log_wrapper.go
@@ -1,0 +1,11 @@
+package orm
+
+import "github.com/smartcontractkit/chainlink/core/logger"
+
+type ormLogWrapper struct {
+	*logger.Logger
+}
+
+func (l ormLogWrapper) Print(args ...interface{}) {
+	logger.Info("", args)
+}

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -91,6 +91,8 @@ func initializeDatabase(dialect, path string) (*gorm.DB, error) {
 		return nil, fmt.Errorf("unable to open %s for gorm DB: %+v", path, err)
 	}
 
+	db.SetLogger(ormLogWrapper{logger.GetLogger()})
+
 	if err := dbutil.SetTimezone(db); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This uses a fork of gorm which makes a very subtle change to logging: it does not log a "sql: transaction has already been committed or rolled back"  message anymore in the case when a `rollback` defer is called after a successful `commit`.

It also sets the gorm logger to use our own, so the log filtering is unified - though the output is pretty heinous.