### PR TITLE
prevent double setting of headers when request body size too big

### DIFF
--- a/core/web/router.go
+++ b/core/web/router.go
@@ -331,7 +331,14 @@ func loggerFunc() gin.HandlerFunc {
 		buf, err := ioutil.ReadAll(c.Request.Body)
 		if err != nil {
 			logger.Error("Web request log error: ", err.Error())
-			c.AbortWithStatus(http.StatusBadRequest)
+			// Implicitly relies on limits.RequestSizeLimiter
+			// overriding of c.Request.Body to abort gin's Context
+			// inside ioutil.ReadAll.
+			// Functions as we would like, but horrible from an architecture
+			// and design pattern perspective.
+			if !c.IsAborted() {
+				c.AbortWithStatus(http.StatusBadRequest)
+			}
 			return
 		}
 		rdr := bytes.NewBuffer(buf)


### PR DESCRIPTION
Clumsily prevent double setting of headers when request body size too big:


----
## WAS:

Immediately checks Request Body size and eagerly aborts, unlike https://github.com/gin-contrib/size that wraps `ctx.Request.Body` with a lazy size checker, leading to an implicit c.Abort as a side effect of `ioutil.ReadAll(ctx.Request.Body)`.

Code in question: https://github.com/gin-contrib/size/blob/161dc59b048fd26f83f74cc3227f36fe77d790a8/size.go#L36-L38

```golang
func (mbr *maxBytesReader) Read(p []byte) (n int, err error) {
	toRead := mbr.remaining
	if mbr.remaining == 0 {
		if mbr.sawEOF {
			return mbr.tooLarge()
		}
```

By overriding `Read` and mutating a reference to context, they implicitly abort inside `ioutil.ReadAll(...)`.

---

The current commit (https://github.com/smartcontractkit/chainlink/pull/1203/commits/37d6d94b68b5819764e13fde04fe7da8d131794b) does get us past the issue, but without the comment, it would be difficult to discover that implicit functionality.