### PR TITLE
Only display completedAt when the status is completed

### DIFF
--- a/core/cmd/renderer.go
+++ b/core/cmd/renderer.go
@@ -212,7 +212,7 @@ func (rt RendererTable) renderJobRuns(runs []presenters.JobRun) error {
 			jr.ID,
 			string(jr.Status),
 			utils.ISO8601UTC(jr.CreatedAt),
-			utils.NullISO8601UTC(jr.CompletedAt),
+			utils.NullISO8601UTC(jr.FinishedAt),
 			jr.Result.Data.String(),
 			jr.Result.ErrorMessage.String,
 		})

--- a/core/internal/fixtures/migrations/1537223654_jobrun_without_initiator_params.json
+++ b/core/internal/fixtures/migrations/1537223654_jobrun_without_initiator_params.json
@@ -26,7 +26,7 @@
     }
   ],
   "createdAt": "2018-08-02T09:40:00.000466903-05:00",
-  "completedAt": null,
+  "finishedAt": null,
   "initiator": {
     "id": 23,
     "jobId": "1e25ad32c0f14e10b8e0da192e4023a5",

--- a/core/services/export_test.go
+++ b/core/services/export_test.go
@@ -5,10 +5,9 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/models"
 )
 
-func ExportedExecuteRunAtBlock(
+func ExportedExecuteRun(
 	run *models.JobRun,
 	store *store.Store,
-	input models.RunResult,
 ) error {
 	return executeRun(run, store)
 }

--- a/core/services/job_runner.go
+++ b/core/services/job_runner.go
@@ -166,6 +166,7 @@ func (rm *jobRunner) workerLoop(runID string, workerChannel chan struct{}) {
 			}
 
 			if run.Status.Finished() {
+				run.MarkCompleted()
 				logger.Debugw("All tasks complete for run", "run", run.ID)
 				return
 			}

--- a/core/services/job_runner.go
+++ b/core/services/job_runner.go
@@ -166,7 +166,7 @@ func (rm *jobRunner) workerLoop(runID string, workerChannel chan struct{}) {
 			}
 
 			if run.Status.Finished() {
-				run.MarkCompleted()
+				run.SetFinishedAt()
 				logger.Debugw("All tasks complete for run", "run", run.ID)
 				return
 			}

--- a/core/services/job_runner_test.go
+++ b/core/services/job_runner_test.go
@@ -51,7 +51,7 @@ func TestJobRunner_resumeRunsSinceLastShutdown(t *testing.T) {
 	assert.ElementsMatch(t, expectedMessages, messages)
 }
 
-func TestJobRunner_executeRun_correctlyPopulatesCompletedAt(t *testing.T) {
+func TestJobRunner_executeRun_correctlyPopulatesFinishedAt(t *testing.T) {
 	store, cleanup := cltest.NewStore()
 	defer cleanup()
 
@@ -68,11 +68,11 @@ func TestJobRunner_executeRun_correctlyPopulatesCompletedAt(t *testing.T) {
 	require.NoError(t, store.CreateJobRun(&run))
 
 	require.NoError(t, services.ExportedExecuteRun(&run, store))
-	assert.False(t, run.CompletedAt.Valid)
+	assert.False(t, run.FinishedAt.Valid)
 	assert.Equal(t, models.RunStatusInProgress, run.Status)
 
 	require.NoError(t, services.ExportedExecuteRun(&run, store))
-	assert.False(t, run.CompletedAt.Valid)
+	assert.False(t, run.FinishedAt.Valid)
 	assert.Equal(t, models.RunStatusPendingConfirmations, run.Status)
 }
 

--- a/core/services/runs.go
+++ b/core/services/runs.go
@@ -229,7 +229,7 @@ func ResumePendingTask(
 		run.Status = models.RunStatusInProgress
 	} else if currentTaskRun.Status.Finished() {
 		run.ApplyResult(input)
-		run.MarkCompleted()
+		run.SetFinishedAt()
 	} else {
 		run.ApplyResult(input)
 	}

--- a/core/services/runs.go
+++ b/core/services/runs.go
@@ -227,6 +227,9 @@ func ResumePendingTask(
 	currentTaskRun.ApplyResult(input)
 	if currentTaskRun.Status.Finished() && run.TasksRemain() {
 		run.Status = models.RunStatusInProgress
+	} else if currentTaskRun.Status.Finished() {
+		run.ApplyResult(input)
+		run.MarkCompleted()
 	} else {
 		run.ApplyResult(input)
 	}

--- a/core/services/runs_test.go
+++ b/core/services/runs_test.go
@@ -216,7 +216,7 @@ func TestResumePendingTask(t *testing.T) {
 	err = services.ResumePendingTask(run, store, models.RunResult{Data: input, Status: models.RunStatusCompleted})
 	assert.Error(t, err)
 	assert.Equal(t, string(models.RunStatusCompleted), string(run.Status))
-	assert.True(t, run.CompletedAt.Valid)
+	assert.True(t, run.FinishedAt.Valid)
 	assert.Len(t, run.TaskRuns, 1)
 	assert.Equal(t, run.ID, run.TaskRuns[0].Result.CachedJobRunID)
 	assert.Equal(t, string(models.RunStatusCompleted), string(run.TaskRuns[0].Result.Status))

--- a/core/services/runs_test.go
+++ b/core/services/runs_test.go
@@ -216,6 +216,7 @@ func TestResumePendingTask(t *testing.T) {
 	err = services.ResumePendingTask(run, store, models.RunResult{Data: input, Status: models.RunStatusCompleted})
 	assert.Error(t, err)
 	assert.Equal(t, string(models.RunStatusCompleted), string(run.Status))
+	assert.True(t, run.CompletedAt.Valid)
 	assert.Len(t, run.TaskRuns, 1)
 	assert.Equal(t, run.ID, run.TaskRuns[0].Result.CachedJobRunID)
 	assert.Equal(t, string(models.RunStatusCompleted), string(run.TaskRuns[0].Result.Status))

--- a/core/services/synchronization/presenters.go
+++ b/core/services/synchronization/presenters.go
@@ -23,27 +23,27 @@ func (p SyncJobRunPresenter) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(&struct {
-		ID          string                 `json:"id"`
-		JobID       string                 `json:"jobId"`
-		RunID       string                 `json:"runId"`
-		Status      string                 `json:"status"`
-		Error       null.String            `json:"error"`
-		CreatedAt   string                 `json:"createdAt"`
-		Amount      *assets.Link           `json:"amount"`
-		CompletedAt null.Time              `json:"completedAt"`
-		Initiator   syncInitiatorPresenter `json:"initiator"`
-		Tasks       []syncTaskRunPresenter `json:"tasks"`
+		ID         string                 `json:"id"`
+		JobID      string                 `json:"jobId"`
+		RunID      string                 `json:"runId"`
+		Status     string                 `json:"status"`
+		Error      null.String            `json:"error"`
+		CreatedAt  string                 `json:"createdAt"`
+		Amount     *assets.Link           `json:"amount"`
+		FinishedAt null.Time              `json:"finishedAt"`
+		Initiator  syncInitiatorPresenter `json:"initiator"`
+		Tasks      []syncTaskRunPresenter `json:"tasks"`
 	}{
-		ID:          p.ID,
-		RunID:       p.ID,
-		JobID:       p.JobSpecID,
-		Status:      string(p.Status),
-		Error:       p.Result.ErrorMessage,
-		CreatedAt:   utils.ISO8601UTC(p.CreatedAt),
-		Amount:      p.Result.Amount,
-		CompletedAt: p.CompletedAt,
-		Initiator:   p.initiator(),
-		Tasks:       tasks,
+		ID:         p.ID,
+		RunID:      p.ID,
+		JobID:      p.JobSpecID,
+		Status:     string(p.Status),
+		Error:      p.Result.ErrorMessage,
+		CreatedAt:  utils.ISO8601UTC(p.CreatedAt),
+		Amount:     p.Result.Amount,
+		FinishedAt: p.FinishedAt,
+		Initiator:  p.initiator(),
+		Tasks:      tasks,
 	})
 }
 

--- a/core/services/synchronization/presenters_test.go
+++ b/core/services/synchronization/presenters_test.go
@@ -59,7 +59,7 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 	assert.Contains(t, data, "error")
 	assert.Contains(t, data, "createdAt")
 	assert.Equal(t, data["amount"], "2")
-	assert.Equal(t, data["completedAt"], nil)
+	assert.Equal(t, data["finishedAt"], nil)
 	assert.Contains(t, data, "tasks")
 
 	initiator, ok := data["initiator"].(map[string]interface{})

--- a/core/store/models/run.go
+++ b/core/store/models/run.go
@@ -24,7 +24,7 @@ type JobRun struct {
 	Status         RunStatus  `json:"status" gorm:"index"`
 	TaskRuns       []TaskRun  `json:"taskRuns"`
 	CreatedAt      time.Time  `json:"createdAt" gorm:"index"`
-	CompletedAt    null.Time  `json:"completedAt"`
+	FinishedAt     null.Time  `json:"finishedAt"`
 	UpdatedAt      time.Time  `json:"updatedAt"`
 	Initiator      Initiator  `json:"initiator" gorm:"association_autoupdate:false;association_autocreate:false"`
 	InitiatorID    uint       `json:"-"`
@@ -122,11 +122,9 @@ func (jr *JobRun) ApplyResult(result RunResult) {
 	jr.Status = result.Status
 }
 
-// MarkCompleted sets the JobRun's completed at time.
-func (jr *JobRun) MarkCompleted() {
-	if jr.Status.Completed() {
-		jr.CompletedAt = null.Time{Time: time.Now(), Valid: true}
-	}
+// SetFinishedAt sets the JobRun's finished at time to now.
+func (jr *JobRun) SetFinishedAt() {
+	jr.FinishedAt = null.TimeFrom(time.Now())
 }
 
 // JobRunsWithStatus filters passed job runs returning those that have

--- a/core/store/models/run.go
+++ b/core/store/models/run.go
@@ -120,6 +120,10 @@ func (jr *JobRun) SetError(err error) {
 func (jr *JobRun) ApplyResult(result RunResult) {
 	jr.Result = result
 	jr.Status = result.Status
+}
+
+// MarkCompleted sets the JobRun's completed at time.
+func (jr *JobRun) MarkCompleted() {
 	if jr.Status.Completed() {
 		jr.CompletedAt = null.Time{Time: time.Now(), Valid: true}
 	}

--- a/core/store/models/run.go
+++ b/core/store/models/run.go
@@ -125,14 +125,6 @@ func (jr *JobRun) ApplyResult(result RunResult) {
 	}
 }
 
-// MarkCompleted sets the JobRun's status to completed and records the
-// completed at time.
-func (jr *JobRun) MarkCompleted() {
-	jr.Status = RunStatusCompleted
-	jr.Result.Status = RunStatusCompleted
-	jr.CompletedAt = null.Time{Time: time.Now(), Valid: true}
-}
-
 // JobRunsWithStatus filters passed job runs returning those that have
 // the desired status, entirely in memory.
 func JobRunsWithStatus(runs []JobRun, status RunStatus) []JobRun {
@@ -205,12 +197,6 @@ func (tr *TaskRun) SetError(err error) {
 func (tr *TaskRun) ApplyResult(result RunResult) {
 	tr.Result = result
 	tr.Status = result.Status
-}
-
-// MarkCompleted marks the task's status as completed.
-func (tr *TaskRun) MarkCompleted() {
-	tr.Status = RunStatusCompleted
-	tr.Result.Status = RunStatusCompleted
 }
 
 // MarkPendingConfirmations marks the task's status as blocked.

--- a/explorer/client/@types/link-stats/index.d.ts
+++ b/explorer/client/@types/link-stats/index.d.ts
@@ -13,7 +13,7 @@ interface IJobRun {
   txHash: string
   error?: string
   createdAt: string
-  completedAt?: string
+  finishedAt?: string
   chainlinkNode: IChainlinkNode
   taskRuns: ITaskRun[]
 }

--- a/explorer/client/src/__tests__/components/JobRuns/Details.test.tsx
+++ b/explorer/client/src/__tests__/components/JobRuns/Details.test.tsx
@@ -1,5 +1,5 @@
-import React from 'react'
 import { mount } from 'enzyme'
+import React from 'react'
 import Details from '../../../components/JobRuns/Details'
 
 describe('components/JobRuns/Details', () => {

--- a/explorer/client/src/components/JobRuns/Details.tsx
+++ b/explorer/client/src/components/JobRuns/Details.tsx
@@ -98,7 +98,7 @@ const Details = ({ classes, jobRun }: IProps) => {
         </TableRow>
         <TableRow>
           <KeyCol>Completed At</KeyCol>
-          <Col>{jobRun.completedAt && moment(jobRun.completedAt).format()}</Col>
+          <Col>{jobRun.finishedAt && moment(jobRun.finishedAt).format()}</Col>
         </TableRow>
         {jobRun.error && (
           <TableRow>

--- a/explorer/client/src/models.ts
+++ b/explorer/client/src/models.ts
@@ -1,6 +1,6 @@
 export interface IJobRun {
   chainlinkNode: any
-  completedAt: string
+  finishedAt: string
   createdAt: string
   error?: string
   id: string

--- a/explorer/src/__tests__/entity/JobRun.test.ts
+++ b/explorer/src/__tests__/entity/JobRun.test.ts
@@ -21,7 +21,7 @@ describe('fromString', () => {
     expect(jr.jobId).toEqual('aeb2861d306645b1ba012079aeb2e53a')
     expect(jr.createdAt).toEqual(new Date('2019-04-01T22:07:04Z'))
     expect(jr.status).toEqual('in_progress')
-    expect(jr.completedAt).toEqual(new Date('2018-04-01T22:07:04Z'))
+    expect(jr.finishedAt).toEqual(new Date('2018-04-01T22:07:04Z'))
 
     expect(jr.type).toEqual('runlog')
     expect(jr.requestId).toEqual('RequestID')
@@ -64,13 +64,13 @@ describe('fromString', () => {
     expect(ethtxTask.transactionStatus).toEqual('fulfilledRunLog')
   })
 
-  it('creates when completedAt is null', () => {
-    const fixtureWithoutCompletedAt = Object.assign({}, fixture, {
-      completedAt: null
+  it('creates when finishedAt is null', () => {
+    const fixtureWithoutFinishedAt = Object.assign({}, fixture, {
+      finishedAt: null
     })
-    const jr = fromString(JSON.stringify(fixtureWithoutCompletedAt))
+    const jr = fromString(JSON.stringify(fixtureWithoutFinishedAt))
     expect(jr.runId).toEqual('f1xtureAaaaaaaaaaaaaaaaaaaaaaaaa')
-    expect(jr.completedAt).toEqual(null)
+    expect(jr.finishedAt).toEqual(null)
   })
 
   it('errors on a malformed string', async () => {

--- a/explorer/src/__tests__/fixtures/JobRun.ethtx.fixture.json
+++ b/explorer/src/__tests__/fixtures/JobRun.ethtx.fixture.json
@@ -6,7 +6,7 @@
   "error": null,
   "createdAt": "2019-05-03T15:21:35Z",
   "amount": null,
-  "completedAt": "2019-05-03T11:21:36.01197-04:00",
+  "finishedAt": "2019-05-03T11:21:36.01197-04:00",
   "initiator": { "type": "web" },
   "tasks": [
     { "index": 0, "type": "httpget", "status": "completed", "error": null },

--- a/explorer/src/__tests__/fixtures/JobRun.fixture.json
+++ b/explorer/src/__tests__/fixtures/JobRun.fixture.json
@@ -5,7 +5,7 @@
   "error": null,
   "createdAt": "2019-04-01T22:07:04Z",
   "amount": null,
-  "completedAt": "2018-04-01T22:07:04Z",
+  "finishedAt": "2018-04-01T22:07:04Z",
   "initiator": {
     "type": "runlog",
     "requestId": "RequestID",

--- a/explorer/src/__tests__/fixtures/JobRunUpdate.fixture.json
+++ b/explorer/src/__tests__/fixtures/JobRunUpdate.fixture.json
@@ -5,7 +5,7 @@
   "error": null,
   "createdAt": "2019-04-01T22:07:04Z",
   "amount": null,
-  "completedAt": "2018-04-01T22:07:04Z",
+  "finishedAt": "2018-04-01T22:07:04Z",
   "initiator": {
     "type": "runlog",
     "requestId": "RequestID",

--- a/explorer/src/entity/JobRun.ts
+++ b/explorer/src/entity/JobRun.ts
@@ -46,7 +46,7 @@ export class JobRun {
   createdAt: Date
 
   @Column({ nullable: true })
-  completedAt: Date
+  finishedAt: Date
 
   @OneToMany(type => TaskRun, taskRun => taskRun.jobRun, {
     eager: true,
@@ -67,7 +67,7 @@ export const fromString = (str: string): JobRun => {
   jr.jobId = json.jobId
   jr.status = json.status
   jr.createdAt = new Date(json.createdAt)
-  jr.completedAt = json.completedAt && new Date(json.completedAt)
+  jr.finishedAt = json.finishedAt && new Date(json.finishedAt)
 
   jr.type = json.initiator.type
   jr.requestId = json.initiator.requestId
@@ -154,12 +154,12 @@ export const saveJobRunTree = async (db: Connection, jobRun: JobRun) => {
         `("runId", "chainlinkNodeId") DO UPDATE SET
         "status" = :status
         ,"error" = :error
-        ,"completedAt" = :completedAt
+        ,"finishedAt" = :finishedAt
       `
       )
       .setParameter('status', jobRun.status)
       .setParameter('error', jobRun.error)
-      .setParameter('completedAt', jobRun.completedAt)
+      .setParameter('finishedAt', jobRun.finishedAt)
       .execute()
 
     await Promise.all(

--- a/explorer/src/migration/1557261237896-InitialMigration.ts
+++ b/explorer/src/migration/1557261237896-InitialMigration.ts
@@ -33,7 +33,7 @@ CREATE TABLE job_run (
   "status" character varying NOT NULL,
   "error" character varying,
   "createdAt" timestamp without time zone DEFAULT now() NOT NULL,
-  "completedAt" timestamp without time zone,
+  "finishedAt" timestamp without time zone,
   "type" character varying NOT NULL,
   "requestId" citext,
   "txHash" citext,

--- a/explorer/src/serializers/jobRunSerializer.ts
+++ b/explorer/src/serializers/jobRunSerializer.ts
@@ -15,7 +15,7 @@ export const BASE_ATTRIBUTES = [
   'requester',
   'error',
   'createdAt',
-  'completedAt'
+  'finishedAt'
 ]
 
 export const chainlinkNode = {

--- a/operator_ui/support/factories/jsonApiJobSpecRuns.js
+++ b/operator_ui/support/factories/jsonApiJobSpecRuns.js
@@ -27,7 +27,7 @@ export default (jobs, jobSpecId, count) => {
           },
           status: 'completed',
           createdAt: '2018-06-18T15:49:33.015913563-04:00',
-          completedAt: '2018-06-18T15:49:33.023078819-04:00'
+          finishedAt: '2018-06-18T15:49:33.023078819-04:00'
         }
       }
     })


### PR DESCRIPTION
[Fixes #165950912]

---
Dimitri:
1. When code reviewing, please look at https://github.com/smartcontractkit/chainlink/commit/5719fc9f23f09838438037a3f922d60d239b26c1
1. This has been modified by Dimitri in the core side to not erroneously push a CompletedAt when not completed.
1. We have renamed CompletedAt to FinishedAt, and also track when errored runs end.

More details in comments below.

