### PR TITLE
Add dashboard labels for Jobs and Runs

### DIFF
--- a/operator_ui/src/components/Dashboards/RecentActivity.js
+++ b/operator_ui/src/components/Dashboards/RecentActivity.js
@@ -108,7 +108,7 @@ const RecentActivity = ({ classes, runs }) => {
                             color="primary"
                             component="span"
                           >
-                            {r.jobId}
+                            Job: {r.jobId}
                           </Typography>
                         </Link>
                       </Grid>
@@ -119,7 +119,7 @@ const RecentActivity = ({ classes, runs }) => {
                             color="textSecondary"
                             component="span"
                           >
-                            {r.id}
+                            Run: {r.id}
                           </Typography>
                         </Link>
                       </Grid>


### PR DESCRIPTION
For [#165973996](https://www.pivotaltracker.com/story/show/165973996)

![image](https://user-images.githubusercontent.com/40662484/57753323-dbca3400-76b9-11e9-9f9a-17d6fc0f0815.png)

@se3000 Did the story intend to add labels for the Recently Created Jobs card too (highlight)? I didn't prefix it, as there's not enough width and might be redundant as well