### PR TITLE
Revert "Ensure App is fully running and connected before syncing logger"

### DIFF
--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -44,10 +44,9 @@ func TestClient_RunNodeShowsEnv(t *testing.T) {
 	eth.Register("eth_getTransactionCount", `0x1`)
 
 	assert.NoError(t, client.RunNode(c))
-	require.NoError(t, app.WaitForConnection())
 	logger.Sync()
 	logs, err := cltest.ReadLogs(app)
-	require.NoError(t, err)
+	assert.NoError(t, err)
 
 	assert.Contains(t, logs, "LOG_LEVEL: debug\\n")
 	assert.Contains(t, logs, "LOG_TO_DISK: true")

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -221,11 +221,6 @@ func (ta *TestApplication) StartAndConnect() error {
 		return err
 	}
 
-	return ta.WaitForConnection()
-}
-
-// WaitForConnection wait for the StartAndConnect callback to be called
-func (ta *TestApplication) WaitForConnection() error {
 	select {
 	case <-time.After(4 * time.Second):
 		return errors.New("TestApplication#StartAndConnect() timed out")


### PR DESCRIPTION
This reverts commit ddb8a2928ff168440495643d5a38cdfb1f278743.

This commit causes problems for the Windows build.