### PR TITLE
Fix TestClient_RunNodeShowsEnv race

### DIFF
--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -44,9 +44,10 @@ func TestClient_RunNodeShowsEnv(t *testing.T) {
 	eth.Register("eth_getTransactionCount", `0x1`)
 
 	assert.NoError(t, client.RunNode(c))
+	require.NoError(t, app.WaitForConnection())
 	logger.Sync()
 	logs, err := cltest.ReadLogs(app)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Contains(t, logs, "LOG_LEVEL: debug\\n")
 	assert.Contains(t, logs, "LOG_TO_DISK: true")

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -221,6 +221,11 @@ func (ta *TestApplication) StartAndConnect() error {
 		return err
 	}
 
+	return ta.WaitForConnection()
+}
+
+// WaitForConnection wait for the StartAndConnect callback to be called
+func (ta *TestApplication) WaitForConnection() error {
 	select {
 	case <-time.After(4 * time.Second):
 		return errors.New("TestApplication#StartAndConnect() timed out")

--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -476,6 +476,17 @@ func (a CallbackAuthenticator) Authenticate(store *store.Store, pwd string) (str
 	return a.Callback(store, pwd)
 }
 
+// BlockedRunner is a Runner that blocks until its channel is posted to
+type BlockedRunner struct {
+	Done chan struct{}
+}
+
+// Run runs the blocked runner, doesn't return until the channel is signalled
+func (r BlockedRunner) Run(app services.Application) error {
+	<-r.Done
+	return nil
+}
+
 // EmptyRunner is an EmptyRunner
 type EmptyRunner struct{}
 


### PR DESCRIPTION
This test occasionally fails, mostly on Windows machines, because the
HeadTracker is still connecting while the Shutdown begins. Preventing the
head tracker from ever connecting.

So we use a goroutine plus a runner with a channel to coordinate when
shutdown happens (via a defer in client.RunNode).

[Fixes #166022398]