### PR TITLE
Jobs list should be sorted most recent first

### DIFF
--- a/core/web/job_specs_controller.go
+++ b/core/web/job_specs_controller.go
@@ -22,9 +22,9 @@ type JobSpecsController struct {
 func (jsc *JobSpecsController) Index(c *gin.Context, size, page, offset int) {
 	var order orm.SortType
 	if c.Query("sort") == "-createdAt" {
-		order = orm.Descending
-	} else {
 		order = orm.Ascending
+	} else {
+		order = orm.Descending
 	}
 
 	jobs, count, err := jsc.App.GetStore().JobsSorted(order, offset, size)


### PR DESCRIPTION
For [#166096276](https://www.pivotaltracker.com/story/show/166096276)

I mean seeing that its displaying last to first now, can just `.reverse()` and be done with it, but I guess sorting by`createdAt`is better