### PR TITLE
explorer correctly uses fulfilledRunLog,CL pushes txStatus key

### DIFF
--- a/core/services/synchronization/presenters.go
+++ b/core/services/synchronization/presenters.go
@@ -104,7 +104,7 @@ func formatEthereumReceipt(str string) (*syncReceiptPresenter, error) {
 
 type syncReceiptPresenter struct {
 	Hash   common.Hash `json:"transactionHash"`
-	Status TxStatus    `json:"status"`
+	Status TxStatus    `json:"transactionStatus"`
 }
 
 // TxStatus indicates if a transaction is fulfiled or not

--- a/core/services/synchronization/presenters_test.go
+++ b/core/services/synchronization/presenters_test.go
@@ -204,7 +204,7 @@ func TestSyncJobRunPresenter_EthTxTask(t *testing.T) {
 			assert.Equal(t, task0["error"].Type, gjson.Null)
 
 			txresult := task0["result"].Map()
-			assert.Equal(t, test.want, txresult["status"].String())
+			assert.Equal(t, test.want, txresult["transactionStatus"].String())
 			assert.Equal(t, fulfillmentTxHash, txresult["transactionHash"].String())
 		})
 	}

--- a/explorer/client/src/__tests__/utils/status.test.ts
+++ b/explorer/client/src/__tests__/utils/status.test.ts
@@ -8,7 +8,7 @@ const COMPLETED_ETHTX_WITHOUT_STATUS = {
 const COMPLETED_ETHTX_WITH_STATUS = {
   type: 'ethtx',
   status: 'completed',
-  transactionStatus: '0x1'
+  transactionStatus: 'fulfilledRunLog'
 } as ITaskRun
 
 describe('utils/status', () => {

--- a/explorer/client/src/utils/status.ts
+++ b/explorer/client/src/utils/status.ts
@@ -5,7 +5,7 @@ const hasUnfulfilledEthTx = (jobRun: IJobRun) => {
     return (
       tr.type === 'ethtx' &&
       tr.status === 'completed' &&
-      tr.transactionStatus !== '0x1'
+      tr.transactionStatus !== 'fulfilledRunLog'
     )
   })
 }

--- a/explorer/src/__tests__/fixtures/JobRun.ethtx.fixture.json
+++ b/explorer/src/__tests__/fixtures/JobRun.ethtx.fixture.json
@@ -19,7 +19,7 @@
       "error": null,
       "result": {
         "transactionHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
-        "status": "fulfilledRunLog",
+        "transactionStatus": "fulfilledRunLog",
         "blockNumber": "0x6"
       }
     }

--- a/explorer/src/entity/JobRun.ts
+++ b/explorer/src/entity/JobRun.ts
@@ -82,7 +82,7 @@ export const fromString = (str: string): JobRun => {
 
     if (trstr.result) {
       tr.transactionHash = trstr.result.transactionHash
-      tr.transactionStatus = trstr.result.status
+      tr.transactionStatus = trstr.result.transactionStatus
     }
 
     return tr


### PR DESCRIPTION
Besides bug fixing, there has been one notable change.

1. Chainlink Core pushes the receipt as 
```
result: { transactionHash: 0x123, transactionStatus: fulfilledRunLog }
```

used to be
```
result: { transactionHash: 0x123, status: 0x1 }
```

1. Explorer was still using the old `0x1` in some places. `tasks[].result.status` has been renamed to `tasks[].result.transactionStatus` to prevent confusion with `status` and `tasks[].status`.

```
{
  "id": "fe64b0a02e944a6ab411e121a0658117",
  "jobId": "0d7f0402ce8d44ef80eea4305af7755d",
  "runId": "fe64b0a02e944a6ab411e121a0658117",
  "status": "completed",
  "error": null,
  "createdAt": "2019-05-03T15:21:35Z",
  "amount": null,
  "finishedAt": "2019-05-03T11:21:36.01197-04:00",
  "initiator": { "type": "web" },
  "tasks": [
    { "index": 0, "type": "httpget", "status": "completed", "error": null },
    { "index": 1, "type": "jsonparse", "status": "completed", "error": null },
    { "index": 2, "type": "ethbytes32", "status": "completed", "error": null },
    {
      "index": 3,
      "type": "ethtx",
      "status": "completed",
      "error": null,
      "result": {
        "transactionHash": "0x1111111111111111111111111111111111111111111111111111111111111111",
        "transactionStatus": "fulfilledRunLog",
        "blockNumber": "0x6"
      }
    }
  ]
}
```