### PR TITLE
Remove required logIndex and transactionIndex for light client support

### DIFF
--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -36,11 +36,11 @@ type Log struct {
 	// hash of the transaction
 	TxHash common.Hash `json:"transactionHash"`
 	// index of the transaction in the block
-	TxIndex uint `json:"transactionIndex" gencodec:"required"`
+	TxIndex uint `json:"transactionIndex"`
 	// hash of the block in which the transaction was included
 	BlockHash common.Hash `json:"blockHash"`
 	// index of the log in the receipt
-	Index uint `json:"logIndex" gencodec:"required"`
+	Index uint `json:"logIndex"`
 
 	// The Removed field is true if this log was reverted due to a chain reorganisation.
 	// You must pay attention to this field if you receive logs through a filter query.

--- a/core/store/models/gen_log_json.go
+++ b/core/store/models/gen_log_json.go
@@ -20,9 +20,9 @@ func (l Log) MarshalJSON() ([]byte, error) {
 		Data        hexutil.Bytes  `json:"data" gencodec:"required"`
 		BlockNumber hexutil.Uint64 `json:"blockNumber"`
 		TxHash      common.Hash    `json:"transactionHash"`
-		TxIndex     hexutil.Uint   `json:"transactionIndex" gencodec:"required"`
+		TxIndex     hexutil.Uint   `json:"transactionIndex"`
 		BlockHash   common.Hash    `json:"blockHash"`
-		Index       hexutil.Uint   `json:"logIndex" gencodec:"required"`
+		Index       hexutil.Uint   `json:"logIndex"`
 		Removed     bool           `json:"removed"`
 	}
 	var enc Log
@@ -46,9 +46,9 @@ func (l *Log) UnmarshalJSON(input []byte) error {
 		Data        *hexutil.Bytes  `json:"data" gencodec:"required"`
 		BlockNumber *hexutil.Uint64 `json:"blockNumber"`
 		TxHash      *common.Hash    `json:"transactionHash"`
-		TxIndex     *hexutil.Uint   `json:"transactionIndex" gencodec:"required"`
+		TxIndex     *hexutil.Uint   `json:"transactionIndex"`
 		BlockHash   *common.Hash    `json:"blockHash"`
-		Index       *hexutil.Uint   `json:"logIndex" gencodec:"required"`
+		Index       *hexutil.Uint   `json:"logIndex"`
 		Removed     *bool           `json:"removed"`
 	}
 	var dec Log
@@ -73,17 +73,15 @@ func (l *Log) UnmarshalJSON(input []byte) error {
 	if dec.TxHash != nil {
 		l.TxHash = *dec.TxHash
 	}
-	if dec.TxIndex == nil {
-		return errors.New("missing required field 'transactionIndex' for Log")
+	if dec.TxIndex != nil {
+		l.TxIndex = uint(*dec.TxIndex)
 	}
-	l.TxIndex = uint(*dec.TxIndex)
 	if dec.BlockHash != nil {
 		l.BlockHash = *dec.BlockHash
 	}
-	if dec.Index == nil {
-		return errors.New("missing required field 'logIndex' for Log")
+	if dec.Index != nil {
+		l.Index = uint(*dec.Index)
 	}
-	l.Index = uint(*dec.Index)
 	if dec.Removed != nil {
 		l.Removed = *dec.Removed
 	}


### PR DESCRIPTION
Example transaction receipt from light clients for a fulfillment tx:
```
{
    "jsonrpc": "2.0",
    "result": {
        "blockHash": "0x6c0deace15b5fed0fc3c66d2e1089bbe523960a01a258c5c97bb31c0baad15e7",
        "blockNumber": "0x56c820",
        "contractAddress": null,
        "cumulativeGasUsed": "0x10a30",
        "from": null,
        "gasUsed": null,
        "logs": [
            {
                "address": "0xec8ea88b10717ad268e30bbbf3f3659c44d49256",
                "blockHash": null,
                "blockNumber": null,
                "data": "0x",
                "logIndex": null,
                "removed": false,
                "topics": [
                    "0x7cc135e0cebb02c3480ae5d74d377283180a2601f8f644edf7987b009316c63a",
                    "0x177deec7b77150208732595dafba8fb087c07f87bf2ee095a8566cdf87831afe"
                ],
                "transactionHash": null,
                "transactionIndex": null,
                "transactionLogIndex": null,
                "type": "pending"
            },
            {
                "address": "0xec8ea88b10717ad268e30bbbf3f3659c44d49256",
                "blockHash": null,
                "blockNumber": null,
                "data": "0x",
                "logIndex": null,
                "removed": false,
                "topics": [
                    "0x794eb9e29f6750ede99e05248d997a9ab9fa23c4a7eaff8afa729080eb7c6428",
                    "0x177deec7b77150208732595dafba8fb087c07f87bf2ee095a8566cdf87831afe",
                    "0x0000000000000000000000000000000000000000000000000000000000006941"
                ],
                "transactionHash": null,
                "transactionIndex": null,
                "transactionLogIndex": null,
                "type": "pending"
            }
        ],
        "logsBloom": "0x00000000000000000000020000000000000000000000000000000000000000000000100000000000000000000000000000800000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000000000000000000000100000000000000000000000800000000000000000000100000000000000040000000000000000000000000000000000000000000000000000004000000000000000000102008000000000000000000000000000000000000000000000000000000000000002000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000000",
        "root": null,
        "status": "0x1",
        "to": null,
        "transactionHash": "0x2f6dafc0e47bfbf98a9d402e901e7b1d13ba04abe0411a5073b6f7aef379873d",
        "transactionIndex": "0x1"
    },
    "id": 1
}
```

On finding usages for `transactionIndex` and `logIndex` in `models.Eth`, the only use was it being printed in the logger in debug mode:
https://github.com/smartcontractkit/chainlink/blob/master/core/services/subscription.go#L109