### PR TITLE
On strict, Panic for stacktrace, otherwise Error, in EthMock#Call

### DIFF
--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -182,7 +182,9 @@ func (mock *EthMock) Call(result interface{}, method string, args ...interface{}
 
 	err := fmt.Errorf("EthMock: Method %v not registered", method)
 	if mock.strict {
-		log.Fatal(err)
+		logger.Panic(err)
+	} else {
+		logger.Error(err)
 	}
 	return err
 }


### PR DESCRIPTION
This is a small change to improve the UX of the EthMock when Calls fail.