### PR TITLE
exclude jobspec internal fields from operator_ui definition

### DIFF
--- a/operator_ui/__tests__/utils/jobSpecDefinition.test.js
+++ b/operator_ui/__tests__/utils/jobSpecDefinition.test.js
@@ -1,0 +1,39 @@
+import jobSpecDefinition from 'utils/jobSpecDefinition'
+
+const input = `{
+  "initiators": [
+    {
+      "type": "web",
+      "params": {
+      }
+    }
+  ],
+  "tasks": [
+    {
+      "ID": 1,
+      "CreatedAt": "2019-05-27T11:31:27.81655-04:00",
+      "UpdatedAt": "2019-05-27T11:31:27.81655-04:00",
+      "DeletedAt": null,
+      "type": "httpget",
+      "confirmations": 0,
+      "params": {
+        "ID": "KeepMeBecauseIAmUserDefined",
+        "get": "https://dimroc-public.s3.amazonaws.com/etl-language-comparison/tweets20140416.tar.gz"
+      }
+    }
+  ],
+  "startAt": null,
+  "endAt": null
+}`
+
+describe('utils/jobSpecDefinition', () => {
+  it('scrubs unwanted keys', () => {
+    const output = jobSpecDefinition(JSON.parse(input))
+    expect(output.tasks).toHaveLength(1)
+    expect(output.tasks[0].ID).toBeUndefined()
+    expect(output.tasks[0].CreatedAt).toBeUndefined()
+    expect(output.tasks[0].DeletedAt).toBeUndefined()
+    expect(output.tasks[0].UpdatedAt).toBeUndefined()
+    expect(output.tasks[0].params.ID).toEqual('KeepMeBecauseIAmUserDefined')
+  })
+})

--- a/operator_ui/src/utils/jobSpecDefinition.js
+++ b/operator_ui/src/utils/jobSpecDefinition.js
@@ -1,4 +1,19 @@
 const DEFINITION_KEYS = ['initiators', 'tasks', 'startAt', 'endAt']
+const SCRUBBED_KEYS = ['ID', 'CreatedAt', 'DeletedAt', 'UpdatedAt']
+
+const scrub = payload => {
+  if (Array.isArray(payload)) {
+    return payload.map(p => scrub(p))
+  }
+  if (typeof payload !== 'object' || payload === null) {
+    return payload
+  }
+  const keepers = Object.keys(payload).filter(k => !SCRUBBED_KEYS.includes(k))
+  return keepers.reduce((obj, key) => ({ ...obj, [key]: payload[key] }), {})
+}
 
 export default jobSpec =>
-  DEFINITION_KEYS.reduce((obj, key) => ({ ...obj, [key]: jobSpec[key] }), {})
+  DEFINITION_KEYS.reduce(
+    (obj, key) => ({ ...obj, [key]: scrub(jobSpec[key]) }),
+    {}
+  )


### PR DESCRIPTION
No longer has ID, CreatedAt, DeletedAt, UpdatedAt:

![image](https://user-images.githubusercontent.com/635121/58643946-4b513d80-82ce-11e9-8a57-7507b5f36145.png)
