### PR TITLE
Use testing.TB in App/EthMock instead of panics

### DIFF
--- a/core/adapters/adapter_test.go
+++ b/core/adapters/adapter_test.go
@@ -13,7 +13,7 @@ import (
 
 func TestCreatingAdapterWithConfig(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	task := models.TaskSpec{Type: adapters.TaskTypeNoOp}
@@ -24,7 +24,7 @@ func TestCreatingAdapterWithConfig(t *testing.T) {
 
 func TestAdapterFor(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	_, bt := cltest.NewBridgeType("rideShare", "https://dUber.eth")

--- a/core/adapters/bridge_test.go
+++ b/core/adapters/bridge_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestBridge_PerformEmbedsParamsInData(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	store.Config.Set("BRIDGE_RESPONSE_URL", cltest.WebURL(""))
 
@@ -43,7 +43,7 @@ func TestBridge_PerformEmbedsParamsInData(t *testing.T) {
 }
 
 func TestBridge_PerformAcceptsNonJsonObjectResponses(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	store.Config.Set("BRIDGE_RESPONSE_URL", cltest.WebURL(""))
 
@@ -79,7 +79,7 @@ func TestBridge_Perform_transitionsTo(t *testing.T) {
 		{"from completed", models.RunStatusCompleted, models.RunStatusCompleted},
 	}
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	store.Config.Set("BRIDGE_RESPONSE_URL", "")
 
@@ -124,7 +124,7 @@ func TestBridge_Perform_startANewRun(t *testing.T) {
 		{"unsetting result", 200, "", false, false, `{"data":{"result":null}}`},
 	}
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	store.Config.Set("BRIDGE_RESPONSE_URL", "")
 	runID := utils.NewBytes32ID()
@@ -176,7 +176,7 @@ func TestBridge_Perform_responseURL(t *testing.T) {
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			store, cleanup := cltest.NewStore()
+			store, cleanup := cltest.NewStore(t)
 			defer cleanup()
 			store.Config.Set("BRIDGE_RESPONSE_URL", test.configuredURL)
 

--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -20,7 +20,7 @@ import (
 func TestEthTxAdapter_Perform_Confirmed(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	store := app.Store
 	config := store.Config
@@ -80,7 +80,7 @@ func TestEthTxAdapter_Perform_Confirmed(t *testing.T) {
 func TestEthTxAdapter_Perform_ConfirmedWithBytes(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	store := app.Store
 	config := store.Config
@@ -143,7 +143,7 @@ func TestEthTxAdapter_Perform_ConfirmedWithBytes(t *testing.T) {
 func TestEthTxAdapter_Perform_ConfirmedWithBytesAndNoDataPrefix(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	store := app.Store
 	config := store.Config
@@ -208,7 +208,7 @@ func TestEthTxAdapter_Perform_ConfirmedWithBytesAndNoDataPrefix(t *testing.T) {
 func TestEthTxAdapter_Perform_FromPendingConfirmations_StillPending(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	store := app.Store
 	config := store.Config
@@ -245,7 +245,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_StillPending(t *testing.T
 func TestEthTxAdapter_Perform_FromPendingConfirmations_BumpGas(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	store := app.Store
 	config := store.Config
@@ -286,7 +286,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_BumpGas(t *testing.T) {
 func TestEthTxAdapter_Perform_FromPendingConfirmations_ConfirmCompletes(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	store := app.Store
@@ -343,7 +343,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_ConfirmCompletes(t *testi
 func TestEthTxAdapter_Perform_AppendingTransactionReceipts(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	store := app.Store
@@ -383,7 +383,7 @@ func TestEthTxAdapter_Perform_AppendingTransactionReceipts(t *testing.T) {
 func TestEthTxAdapter_Perform_WithError(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	store := app.Store
@@ -406,7 +406,7 @@ func TestEthTxAdapter_Perform_WithError(t *testing.T) {
 func TestEthTxAdapter_Perform_WithErrorInvalidInput(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	store := app.Store
@@ -429,7 +429,7 @@ func TestEthTxAdapter_Perform_WithErrorInvalidInput(t *testing.T) {
 func TestEthTxAdapter_Perform_PendingConfirmations_WithErrorInTxManager(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	store := app.Store
@@ -450,7 +450,7 @@ func TestEthTxAdapter_Perform_PendingConfirmations_WithErrorInTxManager(t *testi
 }
 
 func TestEthTxAdapter_DeserializationBytesFormat(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	ctrl := gomock.NewController(t)
 	txmMock := mocks.NewMockTxManager(ctrl)
@@ -488,7 +488,7 @@ func TestEthTxAdapter_DeserializationBytesFormat(t *testing.T) {
 func TestEthTxAdapter_Perform_CustomGas(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	gasPrice := big.NewInt(187)
@@ -526,7 +526,7 @@ func TestEthTxAdapter_Perform_CustomGas(t *testing.T) {
 func TestEthTxAdapter_Perform_NotConnected(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	store := app.Store
 

--- a/core/adapters/sleep_test.go
+++ b/core/adapters/sleep_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestSleep_Perform(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	adapter := adapters.Sleep{}

--- a/core/cmd/client_test.go
+++ b/core/cmd/client_test.go
@@ -23,7 +23,7 @@ func TestTerminalCookieAuthenticator_AuthenticateWithoutSession(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			app, cleanup := cltest.NewApplication()
+			app, cleanup := cltest.NewApplication(t)
 			defer cleanup()
 
 			sr := models.SessionRequest{Email: test.email, Password: test.pwd}
@@ -43,7 +43,7 @@ func TestTerminalCookieAuthenticator_AuthenticateWithoutSession(t *testing.T) {
 func TestTerminalCookieAuthenticator_AuthenticateWithSession(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	app.MustSeedUserSession()
 
@@ -85,7 +85,7 @@ func TestTerminalCookieAuthenticator_AuthenticateWithSession(t *testing.T) {
 func TestDiskCookieStore_Retrieve(t *testing.T) {
 	t.Parallel()
 
-	tc, cleanup := cltest.NewConfig()
+	tc, cleanup := cltest.NewConfig(t)
 	defer cleanup()
 	config := tc.Config
 
@@ -129,7 +129,7 @@ func TestTerminalAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			store, cleanup := cltest.NewStore()
+			store, cleanup := cltest.NewStore(t)
 			defer cleanup()
 
 			mock := &cltest.MockCountingPrompter{EnteredStrings: test.enteredStrings, NotTerminal: !test.isTerminal}
@@ -155,7 +155,7 @@ func TestTerminalAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 func TestTerminalAPIInitializer_InitializeWithExistingAPIUser(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	initialUser := cltest.MustUser(cltest.APIEmail, cltest.Password)
@@ -184,7 +184,7 @@ func TestFileAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			store, cleanup := cltest.NewStore()
+			store, cleanup := cltest.NewStore(t)
 			defer cleanup()
 
 			tfi := cmd.NewFileAPIInitializer(test.file)
@@ -205,7 +205,7 @@ func TestFileAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 func TestFileAPIInitializer_InitializeWithExistingAPIUser(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	initialUser := cltest.MustUser(cltest.APIEmail, cltest.Password)

--- a/core/cmd/key_store_authenticator_test.go
+++ b/core/cmd/key_store_authenticator_test.go
@@ -11,7 +11,7 @@ import (
 func TestTerminalKeyStoreAuthenticator_WithNoAcctNoPwdCreatesAccount(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
 	prompt := &cltest.MockCountingPrompter{EnteredStrings: []string{
@@ -29,7 +29,7 @@ func TestTerminalKeyStoreAuthenticator_WithNoAcctNoPwdCreatesAccount(t *testing.
 func TestTerminalKeyStoreAuthenticator_WithNoAcctWithInitialPwdCreatesAcct(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
 	auth := cmd.TerminalKeyStoreAuthenticator{Prompter: &cltest.MockCountingPrompter{}}
@@ -44,7 +44,7 @@ func TestTerminalKeyStoreAuthenticator_WithNoAcctWithInitialPwdCreatesAcct(t *te
 func TestTerminalKeyStoreAuthenticator_WithAcctNoInitialPwdPromptLoop(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	// prompt loop tries all in array
@@ -61,7 +61,7 @@ func TestTerminalKeyStoreAuthenticator_WithAcctNoInitialPwdPromptLoop(t *testing
 func TestTerminalKeyStoreAuthenticator_WithAcctAndPwd(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	tests := []struct {

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -19,12 +19,12 @@ import (
 func TestClient_RunNodeShowsEnv(t *testing.T) {
 	t.Parallel()
 
-	config, configCleanup := cltest.NewConfig()
+	config, configCleanup := cltest.NewConfig(t)
 	defer configCleanup()
 	config.Set("LINK_CONTRACT_ADDRESS", "0x514910771AF9Ca656af840dff83E8264EcF986CA")
 	config.Set("CHAINLINK_PORT", 6688)
 
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
 	auth := cltest.CallbackAuthenticator{Callback: func(*store.Store, string) (string, error) { return "", nil }}
@@ -94,7 +94,7 @@ func TestClient_RunNodeWithPasswords(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			app, cleanup := cltest.NewApplication()
+			app, cleanup := cltest.NewApplication(t)
 			defer cleanup()
 			_, err := app.Store.KeyStore.NewAccount("password") // matches correct_password.txt
 			assert.NoError(t, err)
@@ -151,7 +151,7 @@ func TestClient_RunNodeWithAPICredentialsFile(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			app, cleanup := cltest.NewApplicationWithKey()
+			app, cleanup := cltest.NewApplicationWithKey(t)
 			defer cleanup()
 
 			noauth := cltest.CallbackAuthenticator{Callback: func(*store.Store, string) (string, error) { return "", nil }}
@@ -184,7 +184,7 @@ func TestClient_RunNodeWithAPICredentialsFile(t *testing.T) {
 func TestClient_ImportKey(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client, _ := app.NewClientAndRenderer()
 
@@ -218,7 +218,7 @@ func TestClient_LogToDiskOptionDisablesAsExpected(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			config, configCleanup := cltest.NewConfig()
+			config, configCleanup := cltest.NewConfig(t)
 			defer configCleanup()
 			config.Set("CHAINLINK_DEV", true)
 			config.Set("LOG_TO_DISK", tt.logToDiskValue)

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -17,7 +17,7 @@ import (
 func TestClient_DisplayAccountBalance(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	ethMock := app.MockEthClient()
@@ -36,7 +36,7 @@ func TestClient_DisplayAccountBalance(t *testing.T) {
 func TestClient_GetJobSpecs(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
 	j1 := cltest.NewJob()
@@ -55,7 +55,7 @@ func TestClient_GetJobSpecs(t *testing.T) {
 func TestClient_ShowJobRun_Exists(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
 	j := cltest.NewJobWithWebInitiator()
@@ -76,7 +76,7 @@ func TestClient_ShowJobRun_Exists(t *testing.T) {
 func TestClient_ShowJobRun_NotFound(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
 	client, r := app.NewClientAndRenderer()
@@ -91,7 +91,7 @@ func TestClient_ShowJobRun_NotFound(t *testing.T) {
 func TestClient_ShowJobSpec_Exists(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	job := cltest.NewJob()
 	app.Store.CreateJob(&job)
@@ -109,7 +109,7 @@ func TestClient_ShowJobSpec_Exists(t *testing.T) {
 func TestClient_ShowJobSpec_NotFound(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
 	client, r := app.NewClientAndRenderer()
@@ -124,7 +124,7 @@ func TestClient_ShowJobSpec_NotFound(t *testing.T) {
 func TestClient_CreateServiceAgreement(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	client, _ := app.NewClientAndRenderer()
 
@@ -166,7 +166,7 @@ func TestClient_CreateServiceAgreement(t *testing.T) {
 func TestClient_CreateJobSpec(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client, _ := app.NewClientAndRenderer()
 
@@ -200,7 +200,7 @@ func TestClient_CreateJobSpec(t *testing.T) {
 func TestClient_ArchiveJobSpec(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
 	job := cltest.NewJob()
@@ -221,7 +221,7 @@ func TestClient_ArchiveJobSpec(t *testing.T) {
 func TestClient_CreateJobSpec_JSONAPIErrors(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client, _ := app.NewClientAndRenderer()
 
@@ -237,7 +237,7 @@ func TestClient_CreateJobSpec_JSONAPIErrors(t *testing.T) {
 func TestClient_CreateJobRun(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client, _ := app.NewClientAndRenderer()
 
@@ -284,7 +284,7 @@ func TestClient_CreateJobRun(t *testing.T) {
 func TestClient_AddBridge(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client, _ := app.NewClientAndRenderer()
 
@@ -320,7 +320,7 @@ func TestClient_AddBridge(t *testing.T) {
 func TestClient_GetBridges(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	bt1 := &models.BridgeType{
 		Name:          models.MustNewTaskType("testingbridges1"),
@@ -349,7 +349,7 @@ func TestClient_GetBridges(t *testing.T) {
 func TestClient_ShowBridge(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	bt := &models.BridgeType{
 		Name:          models.MustNewTaskType("testingbridges1"),
@@ -371,7 +371,7 @@ func TestClient_ShowBridge(t *testing.T) {
 func TestClient_RemoveBridge(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	bt := &models.BridgeType{
 		Name:          models.MustNewTaskType("testingbridges1"),
@@ -394,7 +394,7 @@ func TestClient_RemoveBridge(t *testing.T) {
 func TestClient_RemoteLogin(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	app.Start()
 
@@ -432,7 +432,7 @@ func TestClient_RemoteLogin(t *testing.T) {
 func TestClient_WithdrawSuccess(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup, _ := setupWithdrawalsApplication()
+	app, cleanup, _ := setupWithdrawalsApplication(t)
 	defer cleanup()
 
 	assert.NoError(t, app.StartAndConnect())
@@ -449,7 +449,7 @@ func TestClient_WithdrawSuccess(t *testing.T) {
 func TestClient_WithdrawNoArgs(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup, _ := setupWithdrawalsApplication()
+	app, cleanup, _ := setupWithdrawalsApplication(t)
 	defer cleanup()
 
 	assert.NoError(t, app.StartAndConnect())
@@ -470,7 +470,7 @@ func TestClient_WithdrawNoArgs(t *testing.T) {
 func TestClient_WithdrawFromSpecifiedContractAddress(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup, ethMockCheck := setupWithdrawalsApplication()
+	app, cleanup, ethMockCheck := setupWithdrawalsApplication(t)
 	defer cleanup()
 
 	assert.NoError(t, app.StartAndConnect())
@@ -485,11 +485,11 @@ func TestClient_WithdrawFromSpecifiedContractAddress(t *testing.T) {
 	ethMockCheck(t)
 }
 
-func setupWithdrawalsApplication() (*cltest.TestApplication, func(), func(*testing.T)) {
-	config, _ := cltest.NewConfig()
+func setupWithdrawalsApplication(t *testing.T) (*cltest.TestApplication, func(), func(*testing.T)) {
+	config, _ := cltest.NewConfig(t)
 	oca := common.HexToAddress("0xDEADB3333333F")
 	config.Set("ORACLE_CONTRACT_ADDRESS", &oca)
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 
 	hash := cltest.NewHash()
 	sentAt := "0x5BA0"
@@ -512,7 +512,7 @@ func setupWithdrawalsApplication() (*cltest.TestApplication, func(), func(*testi
 func TestClient_SendEther(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup, _ := setupWithdrawalsApplication()
+	app, cleanup, _ := setupWithdrawalsApplication(t)
 	defer cleanup()
 
 	assert.NoError(t, app.StartAndConnect())
@@ -529,7 +529,7 @@ func TestClient_SendEther(t *testing.T) {
 func TestClient_SendEther_From(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup, _ := setupWithdrawalsApplication()
+	app, cleanup, _ := setupWithdrawalsApplication(t)
 	defer cleanup()
 
 	assert.NoError(t, app.StartAndConnect())
@@ -548,7 +548,7 @@ func TestClient_SendEther_From(t *testing.T) {
 func TestClient_ChangePassword(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	app.Start()
 
@@ -585,7 +585,7 @@ func TestClient_ChangePassword(t *testing.T) {
 func TestClient_GetTransactions(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	store := app.GetStore()
@@ -619,7 +619,7 @@ func TestClient_GetTransactions(t *testing.T) {
 func TestClient_GetTxAttempts(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	store := app.GetStore()
@@ -655,7 +655,7 @@ func TestClient_GetTxAttempts(t *testing.T) {
 func TestClient_CreateExtraKey(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	app.Start()
 

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -225,12 +225,12 @@ func NullTime(val interface{}) null.Time {
 }
 
 // JSONFromString create JSON from given body and arguments
-func JSONFromString(t *testing.T, body string, args ...interface{}) models.JSON {
+func JSONFromString(t testing.TB, body string, args ...interface{}) models.JSON {
 	return JSONFromBytes(t, []byte(fmt.Sprintf(body, args...)))
 }
 
 // JSONFromBytes creates JSON from a given byte array
-func JSONFromBytes(t *testing.T, body []byte) models.JSON {
+func JSONFromBytes(t testing.TB, body []byte) models.JSON {
 	j, err := models.ParseJSON(body)
 	require.NoError(t, err)
 	return j

--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"reflect"
+	"runtime/debug"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -35,12 +36,12 @@ func (ta *TestApplication) MockEthClient(flags ...string) *EthMock {
 	if ta.ChainlinkApplication.HeadTracker.Connected() {
 		logger.Panic("Cannot mock eth client after being connected")
 	}
-	return MockEthOnStore(ta.Store, flags...)
+	return MockEthOnStore(ta.t, ta.Store, flags...)
 }
 
 // MockEthOnStore given store return new EthMock Client
-func MockEthOnStore(s *store.Store, flags ...string) *EthMock {
-	mock := &EthMock{}
+func MockEthOnStore(t testing.TB, s *store.Store, flags ...string) *EthMock {
+	mock := &EthMock{t: t}
 	for _, flag := range flags {
 		if flag == Strict {
 			mock.strict = true
@@ -64,6 +65,7 @@ type EthMock struct {
 	mutex          sync.RWMutex
 	context        string
 	strict         bool
+	t              testing.TB
 }
 
 // Dial mock dial
@@ -78,15 +80,18 @@ func (mock *EthMock) Context(context string, callback func(*EthMock)) {
 	mock.context = ""
 }
 
-func (mock *EthMock) ShouldCall(t *testing.T, setup func(mock *EthMock)) ethMockDuring {
-	assert.True(t, mock.AllCalled())
+func (mock *EthMock) ShouldCall(setup func(mock *EthMock)) ethMockDuring {
+	if !mock.AllCalled() {
+		mock.t.Errorf("Remaining ethMockCalls: %v", mock.Remaining())
+		mock.t.Fail()
+	}
 	setup(mock)
-	return ethMockDuring{t: t, mock: mock}
+	return ethMockDuring{mock: mock}
 }
 
 type ethMockDuring struct {
 	mock *EthMock
-	t    *testing.T
+	t    testing.TB
 }
 
 func (emd ethMockDuring) During(action func()) {
@@ -182,9 +187,9 @@ func (mock *EthMock) Call(result interface{}, method string, args ...interface{}
 
 	err := fmt.Errorf("EthMock: Method %v not registered", method)
 	if mock.strict {
-		logger.Panic(err)
+		mock.t.Errorf("%s\n%s", err, debug.Stack())
 	} else {
-		logger.Error(err)
+		mock.t.Logf("%s\n%s", err, debug.Stack())
 	}
 	return err
 }

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -25,7 +25,7 @@ import (
 func TestIntegration_Scheduler(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	app.Start()
 
@@ -52,7 +52,7 @@ func TestIntegration_HttpRequestWithHeaders(t *testing.T) {
 		})
 	defer assertCalled()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	config := app.Config
 	eth := app.MockEthClient(cltest.Strict)
@@ -106,7 +106,7 @@ func TestIntegration_FeeBump(t *testing.T) {
 	mockServer, assertCalled := cltest.NewHTTPMockServer(t, 200, "GET", tickerResponse)
 	defer assertCalled()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	config := app.Config
 	eth := app.MockEthClient(cltest.Strict)
@@ -195,7 +195,7 @@ func TestIntegration_FeeBump(t *testing.T) {
 
 func TestIntegration_RunAt(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	app.InstantClock()
 
@@ -212,7 +212,7 @@ func TestIntegration_RunAt(t *testing.T) {
 
 func TestIntegration_EthLog(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
 	eth := app.MockEthClient()
@@ -234,10 +234,10 @@ func TestIntegration_EthLog(t *testing.T) {
 }
 
 func TestIntegration_RunLog(t *testing.T) {
-	config, cfgCleanup := cltest.NewConfig()
+	config, cfgCleanup := cltest.NewConfig(t)
 	defer cfgCleanup()
 	config.Set("MIN_INCOMING_CONFIRMATIONS", 6)
-	app, cleanup := cltest.NewApplicationWithConfig(config)
+	app, cleanup := cltest.NewApplicationWithConfig(t, config)
 	defer cleanup()
 
 	eth := app.MockEthClient()
@@ -277,7 +277,7 @@ func TestIntegration_RunLog(t *testing.T) {
 func TestIntegration_EndAt(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	clock := cltest.UseSettableClock(app.Store)
 	app.Start()
@@ -304,7 +304,7 @@ func TestIntegration_EndAt(t *testing.T) {
 func TestIntegration_StartAt(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	clock := cltest.UseSettableClock(app.Store)
 	app.Start()
@@ -327,7 +327,7 @@ func TestIntegration_StartAt(t *testing.T) {
 func TestIntegration_ExternalAdapter_RunLogInitiated(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
 	eth := app.MockEthClient()
@@ -374,7 +374,7 @@ func TestIntegration_ExternalAdapter_RunLogInitiated(t *testing.T) {
 func TestIntegration_ExternalAdapter_Copy(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	bridgeURL := cltest.WebURL("https://test.chain.link/always")
 	app.Store.Config.Set("BRIDGE_RESPONSE_URL", bridgeURL)
@@ -427,7 +427,7 @@ func TestIntegration_ExternalAdapter_Copy(t *testing.T) {
 func TestIntegration_ExternalAdapter_Pending(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	app.Start()
 
@@ -476,7 +476,7 @@ func TestIntegration_ExternalAdapter_Pending(t *testing.T) {
 func TestIntegration_WeiWatchers(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
 	eth := app.MockEthClient()
@@ -510,7 +510,7 @@ func TestIntegration_WeiWatchers(t *testing.T) {
 }
 
 func TestIntegration_MultiplierInt256(t *testing.T) {
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	app.Start()
 
@@ -524,7 +524,7 @@ func TestIntegration_MultiplierInt256(t *testing.T) {
 }
 
 func TestIntegration_MultiplierUint256(t *testing.T) {
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	app.Start()
 
@@ -540,7 +540,7 @@ func TestIntegration_MultiplierUint256(t *testing.T) {
 func TestIntegration_NonceManagement_firstRunWithExistingTXs(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	j := cltest.FixtureCreateJobViaWeb(t, app, "fixtures/web/web_initiated_eth_tx_job.json")
@@ -581,7 +581,7 @@ func TestIntegration_NonceManagement_firstRunWithExistingTXs(t *testing.T) {
 func TestIntegration_CreateServiceAgreement(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	eth := app.MockEthClient()
@@ -623,9 +623,9 @@ func TestIntegration_SyncJobRuns(t *testing.T) {
 	wsserver, wsserverCleanup := cltest.NewEventWebSocketServer(t)
 	defer wsserverCleanup()
 
-	config, _ := cltest.NewConfig()
+	config, _ := cltest.NewConfig(t)
 	config.Set("EXPLORER_URL", wsserver.URL.String())
-	app, cleanup := cltest.NewApplicationWithConfig(config)
+	app, cleanup := cltest.NewApplicationWithConfig(t, config)
 	defer cleanup()
 	app.InstantClock()
 

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -4,13 +4,14 @@ package main
 
 import (
 	"io/ioutil"
+	"testing"
 
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 )
 
 func ExampleRun() {
-	tc, cleanup := cltest.NewConfig()
+	tc, cleanup := cltest.NewConfig(&testing.T{})
 	defer cltest.WipePostgresDatabase(tc.Config)
 	defer cleanup()
 	tc.Config.Set("CHAINLINK_DEV", false)
@@ -66,7 +67,7 @@ func ExampleRun() {
 }
 
 func ExampleVersion() {
-	tc, cleanup := cltest.NewConfig()
+	tc, cleanup := cltest.NewConfig(&testing.T{})
 	defer cltest.WipePostgresDatabase(tc.Config)
 	defer cleanup()
 	testClient := &cmd.Client{

--- a/core/services/application_test.go
+++ b/core/services/application_test.go
@@ -19,9 +19,9 @@ import (
 )
 
 func TestChainlinkApplication_SignalShutdown(t *testing.T) {
-	config, cleanup := cltest.NewConfig()
+	config, cleanup := cltest.NewConfig(t)
 	defer cleanup()
-	app, appCleanUp := cltest.NewApplicationWithConfig(config)
+	app, appCleanUp := cltest.NewApplicationWithConfig(t, config)
 	defer appCleanUp()
 
 	completed := abool.New()
@@ -38,7 +38,7 @@ func TestChainlinkApplication_SignalShutdown(t *testing.T) {
 }
 
 func TestChainlinkApplication_AddJob(t *testing.T) {
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	ctrl := gomock.NewController(t)
 	jobSubscriberMock := mock_services.NewMockJobSubscriber(ctrl)
@@ -48,7 +48,7 @@ func TestChainlinkApplication_AddJob(t *testing.T) {
 }
 
 func TestChainlinkApplication_resumesPendingConnection_Happy(t *testing.T) {
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	store := app.Store
 
@@ -62,7 +62,7 @@ func TestChainlinkApplication_resumesPendingConnection_Happy(t *testing.T) {
 }
 
 func TestChainlinkApplication_resumesPendingConnection_Archived(t *testing.T) {
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	store := app.Store
 
@@ -78,7 +78,7 @@ func TestChainlinkApplication_resumesPendingConnection_Archived(t *testing.T) {
 }
 
 func TestPendingConnectionResumer(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	resumedRuns := []string{}

--- a/core/services/head_tracker_test.go
+++ b/core/services/head_tracker_test.go
@@ -19,10 +19,10 @@ import (
 func TestHeadTracker_New(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
-	cltest.MockEthOnStore(store)
+	cltest.MockEthOnStore(t, store)
 	assert.Nil(t, store.SaveHead(cltest.Head(1)))
 	last := cltest.Head(16)
 	assert.Nil(t, store.SaveHead(last))
@@ -54,10 +54,10 @@ func TestHeadTracker_Get(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			store, cleanup := cltest.NewStore()
+			store, cleanup := cltest.NewStore(t)
 			defer cleanup()
 
-			cltest.MockEthOnStore(store)
+			cltest.MockEthOnStore(t, store)
 			if test.initial != nil {
 				assert.Nil(t, store.SaveHead(test.initial))
 			}
@@ -81,9 +81,9 @@ func TestHeadTracker_Get(t *testing.T) {
 func TestHeadTracker_Start_NewHeads(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	eth := cltest.MockEthOnStore(store)
+	eth := cltest.MockEthOnStore(t, store)
 	ht := services.NewHeadTracker(store, []strpkg.HeadTrackable{})
 	defer ht.Stop()
 
@@ -97,9 +97,9 @@ func TestHeadTracker_HeadTrackableCallbacks(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewGomegaWithT(t)
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	eth := cltest.MockEthOnStore(store)
+	eth := cltest.MockEthOnStore(t, store)
 
 	checker := &cltest.MockHeadTrackable{}
 	ht := services.NewHeadTracker(store, []strpkg.HeadTrackable{checker}, cltest.NeverSleeper{})
@@ -127,9 +127,9 @@ func TestHeadTracker_ReconnectOnError(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewGomegaWithT(t)
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	eth := cltest.MockEthOnStore(store)
+	eth := cltest.MockEthOnStore(t, store)
 
 	checker := &cltest.MockHeadTrackable{}
 	ht := services.NewHeadTracker(store, []strpkg.HeadTrackable{checker}, cltest.NeverSleeper{})
@@ -161,9 +161,9 @@ func TestHeadTracker_ReconnectAndStopDoesntDeadlock(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewGomegaWithT(t)
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	eth := cltest.MockEthOnStore(store)
+	eth := cltest.MockEthOnStore(t, store)
 	eth.NoMagic()
 
 	checker := &cltest.MockHeadTrackable{}
@@ -191,9 +191,9 @@ func TestHeadTracker_StartConnectsFromLastSavedHeader(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewGomegaWithT(t)
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	eth := cltest.MockEthOnStore(store)
+	eth := cltest.MockEthOnStore(t, store)
 	headers := make(chan models.BlockHeader)
 	eth.RegisterSubscription("newHeads", headers)
 

--- a/core/services/job_runner_test.go
+++ b/core/services/job_runner_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestJobRunner_resumeRunsSinceLastShutdown(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	rm, cleanup := cltest.NewJobRunner(store)
 	defer cleanup()
@@ -52,7 +52,7 @@ func TestJobRunner_resumeRunsSinceLastShutdown(t *testing.T) {
 }
 
 func TestJobRunner_executeRun_correctlyPopulatesFinishedAt(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	j := models.NewJob()
@@ -79,7 +79,7 @@ func TestJobRunner_executeRun_correctlyPopulatesFinishedAt(t *testing.T) {
 func TestJobRunner_ChannelForRun_equalityBetweenRuns(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	rm, cleanup := cltest.NewJobRunner(store)
 	defer cleanup()
@@ -101,7 +101,7 @@ func TestJobRunner_ChannelForRun_equalityBetweenRuns(t *testing.T) {
 func TestJobRunner_ChannelForRun_sendAfterClosing(t *testing.T) {
 	t.Parallel()
 
-	s, cleanup := cltest.NewStore()
+	s, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	rm, cleanup := cltest.NewJobRunner(s)
 	defer cleanup()
@@ -128,7 +128,7 @@ func TestJobRunner_ChannelForRun_sendAfterClosing(t *testing.T) {
 func TestJobRunner_ChannelForRun_equalityWithoutClosing(t *testing.T) {
 	t.Parallel()
 
-	s, cleanup := cltest.NewStore()
+	s, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	rm, cleanup := cltest.NewJobRunner(s)
 	defer cleanup()
@@ -153,7 +153,7 @@ func TestJobRunner_ChannelForRun_equalityWithoutClosing(t *testing.T) {
 func TestJobRunner_Stop(t *testing.T) {
 	t.Parallel()
 
-	s, cleanup := cltest.NewStore()
+	s, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	rm, cleanup := cltest.NewJobRunner(s)
 	defer cleanup()

--- a/core/services/job_subscriber_test.go
+++ b/core/services/job_subscriber_test.go
@@ -19,9 +19,9 @@ import (
 func TestJobSubscriber_Connect_WithJobs(t *testing.T) {
 	t.Parallel()
 
-	store, el, cleanup := cltest.NewJobSubscriber()
+	store, el, cleanup := cltest.NewJobSubscriber(t)
 	defer cleanup()
-	eth := cltest.MockEthOnStore(store)
+	eth := cltest.MockEthOnStore(t, store)
 
 	j1 := cltest.NewJobWithLogInitiator()
 	j2 := cltest.NewJobWithLogInitiator()
@@ -41,9 +41,9 @@ func newAddr() common.Address {
 func TestJobSubscriber_reconnectLoop_Resubscribing(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	eth := cltest.MockEthOnStore(store)
+	eth := cltest.MockEthOnStore(t, store)
 	j1 := cltest.NewJobWithLogInitiator()
 	j2 := cltest.NewJobWithLogInitiator()
 	assert.Nil(t, store.CreateJob(&j1))
@@ -71,9 +71,9 @@ func TestJobSubscriber_AttachedToHeadTracker(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewGomegaWithT(t)
 
-	store, el, cleanup := cltest.NewJobSubscriber()
+	store, el, cleanup := cltest.NewJobSubscriber(t)
 	defer cleanup()
-	eth := cltest.MockEthOnStore(store)
+	eth := cltest.MockEthOnStore(t, store)
 	j1 := cltest.NewJobWithLogInitiator()
 	j2 := cltest.NewJobWithLogInitiator()
 	assert.Nil(t, store.CreateJob(&j1))
@@ -115,10 +115,10 @@ func TestJobSubscriber_AddJob_Listening(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			store, el, cleanup := cltest.NewJobSubscriber()
+			store, el, cleanup := cltest.NewJobSubscriber(t)
 			defer cleanup()
 
-			eth := cltest.MockEthOnStore(store)
+			eth := cltest.MockEthOnStore(t, store)
 			logChan := make(chan models.Log, 1)
 			eth.RegisterSubscription("logs", logChan)
 
@@ -162,10 +162,10 @@ func TestJobSubscriber_RemoveJob(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.initType, func(t *testing.T) {
-			store, el, cleanup := cltest.NewJobSubscriber()
+			store, el, cleanup := cltest.NewJobSubscriber(t)
 			defer cleanup()
 
-			eth := cltest.MockEthOnStore(store)
+			eth := cltest.MockEthOnStore(t, store)
 			logChan := make(chan models.Log, 1)
 			eth.RegisterSubscription("logs", logChan)
 
@@ -236,7 +236,7 @@ func TestJobSubscriber_OnNewHead_OnlyResumePendingConfirmations(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(prettyLabel(test.archived, test.status), func(t *testing.T) {
-			store, js, cleanup := cltest.NewJobSubscriber()
+			store, js, cleanup := cltest.NewJobSubscriber(t)
 			defer cleanup()
 
 			mockRunChannel := cltest.NewMockRunChannel()

--- a/core/services/reaper_test.go
+++ b/core/services/reaper_test.go
@@ -15,7 +15,7 @@ import (
 func TestStoreReaper_ReapSessions(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	r := services.NewStoreReaper(store)

--- a/core/services/runs_test.go
+++ b/core/services/runs_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func TestNewRun(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	input := models.JSON{Result: gjson.Parse(`{"address":"0xdfcfc2b9200dbb10952c2b7cce60fc7260e03c6f"}`)}
@@ -49,7 +49,7 @@ func TestNewRun(t *testing.T) {
 }
 
 func TestNewRun_requiredPayment(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	input := models.JSON{Result: gjson.Parse(`{"address":"0xdfcfc2b9200dbb10952c2b7cce60fc7260e03c6f"}`)}
@@ -94,7 +94,7 @@ func TestNewRun_requiredPayment(t *testing.T) {
 }
 
 func TestNewRun_minimumConfirmations(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	input := models.JSON{Result: gjson.Parse(`{"address":"0xdfcfc2b9200dbb10952c2b7cce60fc7260e03c6f"}`)}
@@ -150,7 +150,7 @@ func TestNewRun_startAtAndEndAt(t *testing.T) {
 		{"job ended", nullTime, pastTime, true},
 	}
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	clock := cltest.UseSettableClock(store)
 	clock.SetTime(time.Now())
@@ -174,7 +174,7 @@ func TestNewRun_startAtAndEndAt(t *testing.T) {
 }
 
 func TestNewRun_noTasksErrorsInsteadOfPanic(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	job := cltest.NewJobWithWebInitiator()
@@ -188,7 +188,7 @@ func TestNewRun_noTasksErrorsInsteadOfPanic(t *testing.T) {
 }
 
 func TestResumePendingTask(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	// reject a run with an invalid state
@@ -238,7 +238,7 @@ func TestResumePendingTask(t *testing.T) {
 }
 
 func TestResumeConfirmingTask(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	// reject a run with an invalid state
@@ -298,7 +298,7 @@ func TestResumeConfirmingTask(t *testing.T) {
 }
 
 func TestResumeConnectingTask(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	// reject a run with an invalid state
@@ -338,7 +338,7 @@ func sleepAdapterParams(n int) models.JSON {
 }
 
 func TestQueueSleepingTask(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	store.Clock = cltest.NeverClock{}
 
@@ -417,7 +417,7 @@ func TestQueueSleepingTask(t *testing.T) {
 }
 
 func TestQueueSleepingTaskA_CompletesSleepingTaskAfterDurationElapsed_Happy(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	store.Clock = cltest.NeverClock{}
 
@@ -465,7 +465,7 @@ func TestQueueSleepingTaskA_CompletesSleepingTaskAfterDurationElapsed_Happy(t *t
 }
 
 func TestQueueSleepingTaskA_CompletesSleepingTaskAfterDurationElapsed_Archived(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	store.Clock = cltest.NeverClock{}
 
@@ -519,7 +519,7 @@ func TestQueueSleepingTaskA_CompletesSleepingTaskAfterDurationElapsed_Archived(t
 
 func TestExecuteJob_DoesNotSaveToTaskSpec(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	app.Start()
 	store := app.Store
@@ -548,7 +548,7 @@ func TestExecuteJob_DoesNotSaveToTaskSpec(t *testing.T) {
 
 func TestExecuteJobWithRunRequest(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	app.Start()
 	store := app.Store

--- a/core/services/scheduler_test.go
+++ b/core/services/scheduler_test.go
@@ -18,7 +18,7 @@ import (
 func TestScheduler_Start_LoadingRecurringJobs(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	jobWCron := cltest.NewJobWithSchedule("* * * * * *")
@@ -37,7 +37,7 @@ func TestScheduler_Start_LoadingRecurringJobs(t *testing.T) {
 func TestScheduler_AddJob_WhenStopped(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	sched := services.NewScheduler(store)
 	defer sched.Stop()
@@ -52,7 +52,7 @@ func TestScheduler_AddJob_WhenStopped(t *testing.T) {
 func TestScheduler_Start_AddingUnstartedJob(t *testing.T) {
 	logs := cltest.ObserveLogs()
 
-	store, cleanupStore := cltest.NewStore()
+	store, cleanupStore := cltest.NewStore(t)
 	defer cleanupStore()
 	clock := cltest.UseSettableClock(store)
 
@@ -99,7 +99,7 @@ func TestRecurring_AddJob(t *testing.T) {
 		{"start at after end at", futureTime, pastTime, 0, 0},
 	}
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	for _, tt := range tests {
 		test := tt
@@ -127,7 +127,7 @@ func TestRecurring_AddJob(t *testing.T) {
 }
 
 func TestRecurring_AddJob_Archived(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	r := services.NewRecurring(store)
 	cron := cltest.NewMockCron()
@@ -171,7 +171,7 @@ func TestOneTime_AddJob(t *testing.T) {
 		{"start at after end at", futureTime, pastTime, pastRunTime, false},
 	}
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	jobRunner, cleanup := cltest.NewJobRunner(store)
 	defer cleanup()
@@ -218,7 +218,7 @@ func TestOneTime_AddJob(t *testing.T) {
 func TestOneTime_RunJobAt_StopJobBeforeExecution(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	ot := services.OneTime{
@@ -249,7 +249,7 @@ func TestOneTime_RunJobAt_StopJobBeforeExecution(t *testing.T) {
 func TestOneTime_RunJobAt_ExecuteLateJob(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	ot := services.OneTime{
@@ -279,7 +279,7 @@ func TestOneTime_RunJobAt_ExecuteLateJob(t *testing.T) {
 func TestOneTime_RunJobAt_RunTwice(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	ot := services.OneTime{
@@ -304,7 +304,7 @@ func TestOneTime_RunJobAt_RunTwice(t *testing.T) {
 func TestOneTime_RunJobAt_UnstartedRun(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	ot := services.OneTime{
@@ -327,7 +327,7 @@ func TestOneTime_RunJobAt_UnstartedRun(t *testing.T) {
 func TestOneTime_RunJobAt_ArchivedRun(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	ot := services.OneTime{

--- a/core/services/subscription_test.go
+++ b/core/services/subscription_test.go
@@ -15,9 +15,9 @@ import (
 func TestServices_NewInitiatorSubscription_BackfillLogs(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	eth := cltest.MockEthOnStore(store)
+	eth := cltest.MockEthOnStore(t, store)
 
 	job := cltest.NewJobWithLogInitiator()
 	initr := job.Initiators[0]
@@ -42,9 +42,9 @@ func TestServices_NewInitiatorSubscription_BackfillLogs(t *testing.T) {
 func TestServices_NewInitiatorSubscription_BackfillLogs_WithNoHead(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	eth := cltest.MockEthOnStore(store)
+	eth := cltest.MockEthOnStore(t, store)
 
 	job := cltest.NewJobWithLogInitiator()
 	initr := job.Initiators[0]
@@ -63,9 +63,9 @@ func TestServices_NewInitiatorSubscription_BackfillLogs_WithNoHead(t *testing.T)
 func TestServices_NewInitiatorSubscription_PreventsDoubleDispatch(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	eth := cltest.MockEthOnStore(store)
+	eth := cltest.MockEthOnStore(t, store)
 
 	job := cltest.NewJobWithLogInitiator()
 	initr := job.Initiators[0]

--- a/core/services/synchronization/stats_pusher_test.go
+++ b/core/services/synchronization/stats_pusher_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestStatsPusher(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	wsserver, wscleanup := cltest.NewEventWebSocketServer(t)
@@ -52,7 +52,7 @@ func TestStatsPusher(t *testing.T) {
 }
 
 func TestStatsPusher_NoAckLeavesEvent(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	wsserver, wscleanup := cltest.NewEventWebSocketServer(t)
@@ -78,7 +78,7 @@ func TestStatsPusher_NoAckLeavesEvent(t *testing.T) {
 }
 
 func TestStatsPusher_BadSyncLeavesEvent(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	wsserver, wscleanup := cltest.NewEventWebSocketServer(t)

--- a/core/services/validators_test.go
+++ b/core/services/validators_test.go
@@ -55,7 +55,7 @@ func TestValidateJob(t *testing.T) {
 		},
 	}
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	for _, test := range tests {
@@ -69,7 +69,7 @@ func TestValidateJob(t *testing.T) {
 }
 
 func TestValidateJob_DevRejectsSleepAdapter(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	sleepingJob := cltest.NewJobWithWebInitiator()
@@ -85,7 +85,7 @@ func TestValidateJob_DevRejectsSleepAdapter(t *testing.T) {
 func TestValidateAdapter(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	// Create a duplicate
@@ -169,7 +169,7 @@ func TestValidateInitiator(t *testing.T) {
 func TestValidateServiceAgreement(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	_, err := store.KeyStore.NewAccount("password") // matches correct_password.txt
 	assert.NoError(t, err)
 	err = store.KeyStore.Unlock("password")

--- a/core/store/eth_client_test.go
+++ b/core/store/eth_client_test.go
@@ -18,7 +18,7 @@ func TestEthClient_GetTxReceipt(t *testing.T) {
 	response := cltest.MustReadFile(t, "../internal/fixtures/eth/getTransactionReceipt.json")
 	mockServer, wsCleanup := cltest.NewWSServer(string(response))
 	defer wsCleanup()
-	config := cltest.NewConfigWithWSServer(mockServer)
+	config := cltest.NewConfigWithWSServer(t, mockServer)
 	store, cleanup := cltest.NewStoreWithConfig(config)
 	defer cleanup()
 
@@ -75,7 +75,7 @@ func TestTxReceipt_FulfilledRunlog(t *testing.T) {
 
 func TestEthClient_GetNonce(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	ethMock := app.MockEthClient()
 	ethClientObject := app.Store.TxManager.(*strpkg.EthTxManager).EthClient
@@ -88,7 +88,7 @@ func TestEthClient_GetNonce(t *testing.T) {
 
 func TestEthClient_GetBlockNumber(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	ethMock := app.MockEthClient()
 	ethClientObject := app.Store.TxManager.(*strpkg.EthTxManager).EthClient
@@ -101,7 +101,7 @@ func TestEthClient_GetBlockNumber(t *testing.T) {
 
 func TestEthClient_SendRawTx(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	ethMock := app.MockEthClient()
 	ethClientObject := app.Store.TxManager.(*strpkg.EthTxManager).EthClient
@@ -113,7 +113,7 @@ func TestEthClient_SendRawTx(t *testing.T) {
 
 func TestEthClient_GetEthBalance(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	tests := []struct {
@@ -140,7 +140,7 @@ func TestEthClient_GetEthBalance(t *testing.T) {
 
 func TestEthClient_GetERC20Balance(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	ethMock := app.MockEthClient()

--- a/core/store/key_store_test.go
+++ b/core/store/key_store_test.go
@@ -12,7 +12,7 @@ const correctPassphrase = "p@ssword"
 
 func TestCreateEthereumAccount(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	_, err := store.KeyStore.NewAccount(correctPassphrase)
@@ -24,7 +24,7 @@ func TestCreateEthereumAccount(t *testing.T) {
 
 func TestUnlockKey_SingleAddress(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	store.KeyStore.NewAccount(correctPassphrase)
@@ -48,7 +48,7 @@ func TestUnlockKey_MultipleAddresses(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			store, cleanup := cltest.NewStore()
+			store, cleanup := cltest.NewStore(t)
 			defer cleanup()
 
 			store.KeyStore.NewAccount(test.passphrase1)
@@ -66,7 +66,7 @@ func TestUnlockKey_MultipleAddresses(t *testing.T) {
 func TestKeyStore_SignSuccess(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	_, err := store.KeyStore.NewAccount(correctPassphrase)
@@ -81,7 +81,7 @@ func TestKeyStore_SignSuccess(t *testing.T) {
 func TestKeyStore_SignAccountLocked(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	account, err := store.KeyStore.NewAccount(correctPassphrase)

--- a/core/store/migrations/migrate_test.go
+++ b/core/store/migrations/migrate_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func bootstrapORM(t *testing.T) (*orm.ORM, func()) {
-	tc, cleanup := cltest.NewConfig()
+	tc, cleanup := cltest.NewConfig(t)
 	config := tc.Config
 
 	require.NoError(t, os.MkdirAll(config.RootDir(), 0700))

--- a/core/store/models/job_spec_test.go
+++ b/core/store/models/job_spec_test.go
@@ -14,7 +14,7 @@ import (
 
 func TestNewJobFromRequest(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	j1 := cltest.NewJobWithSchedule("* * * * 7")
@@ -43,7 +43,7 @@ func TestNewJobFromRequest(t *testing.T) {
 
 func TestJobSpec_Save(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	j1 := cltest.NewJobWithSchedule("* * * * 7")
@@ -58,7 +58,7 @@ func TestJobSpec_Save(t *testing.T) {
 
 func TestJobSpec_NewRun(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	job := cltest.NewJobWithSchedule("1 * * * *")

--- a/core/store/models/log_events_test.go
+++ b/core/store/models/log_events_test.go
@@ -194,7 +194,7 @@ func TestStartRunOrSALogSubscription_ValidateSenders(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			app, cleanup := cltest.NewApplicationWithKey()
+			app, cleanup := cltest.NewApplicationWithKey(t)
 			defer cleanup()
 
 			eth := app.MockEthClient()

--- a/core/store/models/run_test.go
+++ b/core/store/models/run_test.go
@@ -17,7 +17,7 @@ import (
 
 func TestJobRuns_RetrievingFromDBWithError(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	job := cltest.NewJobWithWebInitiator()
@@ -36,7 +36,7 @@ func TestJobRuns_RetrievingFromDBWithError(t *testing.T) {
 
 func TestJobRuns_RetrievingFromDBWithData(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	job := cltest.NewJobWithWebInitiator()
@@ -58,7 +58,7 @@ func TestJobRuns_RetrievingFromDBWithData(t *testing.T) {
 
 func TestJobRuns_SavesASyncEvent(t *testing.T) {
 	t.Parallel()
-	config, _ := cltest.NewConfig()
+	config, _ := cltest.NewConfig(t)
 	config.Set("EXPLORER_URL", "http://localhost:4201")
 	store, cleanup := cltest.NewStoreWithConfig(config)
 	defer cleanup()
@@ -97,7 +97,7 @@ func TestJobRuns_SavesASyncEvent(t *testing.T) {
 
 func TestJobRuns_SkipsEventSaveIfURLBlank(t *testing.T) {
 	t.Parallel()
-	config, _ := cltest.NewConfig()
+	config, _ := cltest.NewConfig(t)
 	config.Set("EXPLORER_URL", "")
 	store, cleanup := cltest.NewStoreWithConfig(config)
 	defer cleanup()
@@ -125,7 +125,7 @@ func TestJobRuns_SkipsEventSaveIfURLBlank(t *testing.T) {
 func TestJobRun_NextTaskRun(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	jobRunner, cleanup := cltest.NewJobRunner(store)
 	defer cleanup()

--- a/core/store/orm/locking_strategies_test.go
+++ b/core/store/orm/locking_strategies_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestNewLockingStrategy(t *testing.T) {
-	tc, cleanup := cltest.NewConfig()
+	tc, cleanup := cltest.NewConfig(t)
 	defer cleanup()
 	c := tc.Config
 
@@ -40,7 +40,7 @@ func TestNewLockingStrategy(t *testing.T) {
 const delay = 10 * time.Millisecond
 
 func TestFileLockingStrategy_Lock(t *testing.T) {
-	tc, cleanup := cltest.NewConfig()
+	tc, cleanup := cltest.NewConfig(t)
 	defer cleanup()
 	c := tc.Config
 
@@ -63,7 +63,7 @@ func TestFileLockingStrategy_Lock(t *testing.T) {
 }
 
 func TestPostgresLockingStrategy_Lock(t *testing.T) {
-	tc, cleanup := cltest.NewConfig()
+	tc, cleanup := cltest.NewConfig(t)
 	defer cleanup()
 	c := tc.Config
 

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestORM_WhereNotFound(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	j1 := models.NewJob()
@@ -35,7 +35,7 @@ func TestORM_WhereNotFound(t *testing.T) {
 
 func TestORM_AllNotFound(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	var jobs []models.JobSpec
@@ -46,7 +46,7 @@ func TestORM_AllNotFound(t *testing.T) {
 
 func TestORM_CreateJob(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	j1 := cltest.NewJobWithSchedule("* * * * *")
@@ -63,7 +63,7 @@ func TestORM_CreateJob(t *testing.T) {
 
 func TestORM_Unscoped(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	orm := store.ORM
@@ -77,7 +77,7 @@ func TestORM_Unscoped(t *testing.T) {
 
 func TestORM_ArchiveJob(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	job := cltest.NewJobWithSchedule("* * * * *")
@@ -99,7 +99,7 @@ func TestORM_ArchiveJob(t *testing.T) {
 
 func TestORM_CreateJobRun_ArchivesRunIfJobArchived(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	job := cltest.NewJobWithWebInitiator()
@@ -116,7 +116,7 @@ func TestORM_CreateJobRun_ArchivesRunIfJobArchived(t *testing.T) {
 
 func TestORM_CreateJobRun_CreatesRunRequest(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	job := cltest.NewJobWithWebInitiator()
@@ -133,7 +133,7 @@ func TestORM_CreateJobRun_CreatesRunRequest(t *testing.T) {
 
 func TestORM_SaveJobRun_DoesNotSaveTaskSpec(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	job := cltest.NewJobWithSchedule("* * * * *")
@@ -159,7 +159,7 @@ func TestORM_SaveJobRun_DoesNotSaveTaskSpec(t *testing.T) {
 
 func TestORM_SaveJobRun_ArchivedDoesNotRevertDeletedAt(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	job := cltest.NewJobWithWebInitiator()
@@ -187,7 +187,7 @@ func coercedJSON(v string) string {
 func TestORM_JobRunsFor(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	job := cltest.NewJobWithWebInitiator()
@@ -212,7 +212,7 @@ func TestORM_JobRunsFor(t *testing.T) {
 func TestORM_JobRunsSortedFor(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	includedJob := cltest.NewJobWithWebInitiator()
@@ -242,7 +242,7 @@ func TestORM_JobRunsSortedFor(t *testing.T) {
 
 func TestORM_UnscopedJobRunsWithStatus_Happy(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	j := cltest.NewJobWithWebInitiator()
@@ -297,7 +297,7 @@ func TestORM_UnscopedJobRunsWithStatus_Happy(t *testing.T) {
 
 func TestORM_UnscopedJobRunsWithStatus_Deleted(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	j := cltest.NewJobWithWebInitiator()
@@ -355,7 +355,7 @@ func TestORM_UnscopedJobRunsWithStatus_Deleted(t *testing.T) {
 
 func TestORM_UnscopedJobRunsWithStatus_OrdersByCreatedAt(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	j := cltest.NewJobWithWebInitiator()
@@ -381,7 +381,7 @@ func TestORM_UnscopedJobRunsWithStatus_OrdersByCreatedAt(t *testing.T) {
 func TestORM_AnyJobWithType(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	js := cltest.NewJobWithWebInitiator()
@@ -399,7 +399,7 @@ func TestORM_AnyJobWithType(t *testing.T) {
 func TestORM_JobRunsCountFor(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	job := cltest.NewJobWithWebInitiator()
 	require.NoError(t, store.CreateJob(&job))
@@ -427,7 +427,7 @@ func TestORM_JobRunsCountFor(t *testing.T) {
 
 func TestORM_CreatingTx(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	from := common.HexToAddress("0x2C83ACd90367e7E0D3762eA31aC77F18faecE874")
@@ -458,7 +458,7 @@ func TestORM_CreatingTx(t *testing.T) {
 func TestORM_FindBridge(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	bt := models.BridgeType{}
@@ -489,7 +489,7 @@ func TestORM_FindBridge(t *testing.T) {
 func TestORM_PendingBridgeType_alreadyCompleted(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	jobRunner, cleanup := cltest.NewJobRunner(store)
 	defer cleanup()
@@ -515,7 +515,7 @@ func TestORM_PendingBridgeType_alreadyCompleted(t *testing.T) {
 func TestORM_PendingBridgeType_success(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	_, bt := cltest.NewBridgeType()
@@ -534,7 +534,7 @@ func TestORM_PendingBridgeType_success(t *testing.T) {
 
 func TestORM_GetLastNonce_StormNotFound(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	store := app.Store
 
@@ -547,7 +547,7 @@ func TestORM_GetLastNonce_StormNotFound(t *testing.T) {
 
 func TestORM_GetLastNonce_Valid(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	store := app.Store
 	manager := store.TxManager
@@ -574,7 +574,7 @@ func TestORM_GetLastNonce_Valid(t *testing.T) {
 func TestORM_MarkRan(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	js := models.NewJob()
@@ -600,7 +600,7 @@ func TestORM_MarkRan(t *testing.T) {
 func TestORM_FindUser(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	user1 := cltest.MustUser("test1@email1.net", "password1")
 	user2 := cltest.MustUser("test2@email2.net", "password2")
@@ -618,7 +618,7 @@ func TestORM_FindUser(t *testing.T) {
 func TestORM_AuthorizedUserWithSession(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	user := cltest.MustUser("have@email", "password")
@@ -662,7 +662,7 @@ func TestORM_AuthorizedUserWithSession(t *testing.T) {
 func TestORM_DeleteUser(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	user := cltest.MustUser("test1@email1.net", "password1")
 	require.NoError(t, store.SaveUser(&user))
@@ -677,7 +677,7 @@ func TestORM_DeleteUser(t *testing.T) {
 func TestORM_DeleteUserSession(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	user := cltest.MustUser("test1@email1.net", "password1")
 	require.NoError(t, store.SaveUser(&user))
@@ -699,7 +699,7 @@ func TestORM_DeleteUserSession(t *testing.T) {
 func TestORM_CreateSession(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	initial := cltest.MustUser(cltest.APIEmail, cltest.Password)
@@ -737,7 +737,7 @@ func TestORM_CreateSession(t *testing.T) {
 }
 
 func TestORM_DeleteTransaction(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	_, err := store.KeyStore.NewAccount(cltest.Password)
 	require.NoError(t, err)
 	defer cleanup()
@@ -757,7 +757,7 @@ func TestORM_DeleteTransaction(t *testing.T) {
 }
 
 func TestORM_AllSyncEvents(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	orm := store.ORM
@@ -791,7 +791,7 @@ func TestORM_AllSyncEvents(t *testing.T) {
 }
 
 func TestBulkDeleteRuns(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	orm := store.ORM
@@ -860,7 +860,7 @@ func TestBulkDeleteRuns(t *testing.T) {
 func TestORM_FindTxByAttempt_CurrentAttempt(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	_, err := store.KeyStore.NewAccount(cltest.Password)
 	require.NoError(t, err)
 	defer cleanup()
@@ -887,7 +887,7 @@ func TestORM_FindTxByAttempt_CurrentAttempt(t *testing.T) {
 func TestORM_FindTxByAttempt_PastAttempt(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	_, err := store.KeyStore.NewAccount(cltest.Password)
 	require.NoError(t, err)
 	defer cleanup()
@@ -955,7 +955,7 @@ func TestORM_DeduceDialect(t *testing.T) {
 }
 
 func TestORM_SyncDbKeyStoreToDisk(t *testing.T) {
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
 	store := app.GetStore()
@@ -984,7 +984,7 @@ func TestORM_SyncDbKeyStoreToDisk(t *testing.T) {
 }
 
 func TestORM_UpdateBridgeType(t *testing.T) {
-	store, cleanup := cltest.NewStore()
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	firstBridge := &models.BridgeType{

--- a/core/store/store_test.go
+++ b/core/store/store_test.go
@@ -19,7 +19,7 @@ import (
 func TestStore_Start(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	store := app.Store
@@ -33,7 +33,7 @@ func TestStore_Start(t *testing.T) {
 func TestStore_Close(t *testing.T) {
 	t.Parallel()
 
-	s, cleanup := cltest.NewStore()
+	s, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	s.RunChannel.Send("whatever")
@@ -55,7 +55,7 @@ func TestStore_Close(t *testing.T) {
 func TestStore_SyncDiskKeyStoreToDB_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	store := app.GetStore()
 
@@ -88,7 +88,7 @@ func TestStore_SyncDiskKeyStoreToDB_HappyPath(t *testing.T) {
 func TestStore_SyncDiskKeyStoreToDB_MultipleKeys(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	app.AddUnlockedKey() // second account
 	defer cleanup()
 
@@ -136,7 +136,7 @@ func TestStore_SyncDiskKeyStoreToDB_MultipleKeys(t *testing.T) {
 func TestStore_SyncDiskKeyStoreToDB_DBKeyAlreadyExists(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	require.NoError(t, app.StartAndConnect())
 	store := app.GetStore()

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -22,7 +22,7 @@ import (
 
 func TestTxManager_CreateTx_Success(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	store := app.Store
 	manager := store.TxManager
@@ -64,7 +64,7 @@ func TestTxManager_CreateTx_Success(t *testing.T) {
 
 func TestTxManager_CreateTx_RoundRobinSuccess(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	app.AddUnlockedKey() // second account
 	config := app.Config
@@ -135,10 +135,10 @@ func TestTxManager_CreateTx_RoundRobinSuccess(t *testing.T) {
 func TestTxManager_CreateTx_AttemptErrorDeletesTxAndDoesNotIncrementNonce(t *testing.T) {
 	t.Parallel()
 
-	config, configCleanup := cltest.NewConfig()
+	config, configCleanup := cltest.NewConfig(t)
 	defer configCleanup()
 
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
 	store := app.Store
@@ -210,7 +210,7 @@ func TestTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 
-			app, cleanup := cltest.NewApplicationWithKey()
+			app, cleanup := cltest.NewApplicationWithKey(t)
 			defer cleanup()
 			store := app.Store
 			manager := store.TxManager
@@ -264,7 +264,7 @@ func TestTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
 
 func TestTxManager_CreateTx_NonceTooLowReloadLimit(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	store := app.Store
 	manager := store.TxManager
@@ -305,7 +305,7 @@ func TestTxManager_CreateTx_NonceTooLowReloadLimit(t *testing.T) {
 
 func TestTxManager_CreateTx_ErrPendingConnection(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	store := app.Store
 	manager := store.TxManager
@@ -321,7 +321,7 @@ func TestTxManager_CreateTx_ErrPendingConnection(t *testing.T) {
 func TestTxManager_BumpGasUntilSafe(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	ethMock := app.MockEthClient()
 	ethMock.Register("eth_getTransactionCount", "0x0")
@@ -380,7 +380,7 @@ func TestTxManager_BumpGasUntilSafe(t *testing.T) {
 func TestTxManager_BumpGasUntilSafe_erroring(t *testing.T) {
 	t.Parallel()
 
-	config, cleanup := cltest.NewConfig()
+	config, cleanup := cltest.NewConfig(t)
 	defer cleanup()
 
 	sentAt1 := uint64(23456)
@@ -437,7 +437,7 @@ func TestTxManager_BumpGasUntilSafe_erroring(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+			app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 			defer cleanup()
 
 			store := app.Store
@@ -448,7 +448,7 @@ func TestTxManager_BumpGasUntilSafe_erroring(t *testing.T) {
 			assert.NoError(t, err)
 
 			ethMock := app.MockEthClient(cltest.Strict)
-			ethMock.ShouldCall(t, test.mockSetup).During(func() {
+			ethMock.ShouldCall(test.mockSetup).During(func() {
 				ethMock.Register("eth_blockNumber", utils.Uint64ToHex(test.blockHeight))
 				require.NoError(t, app.StartAndConnect())
 				receipt, err := txm.BumpGasUntilSafe(a.Hash)
@@ -542,11 +542,11 @@ func TestTxManager_ReloadNonce(t *testing.T) {
 
 func TestTxManager_WithdrawLink(t *testing.T) {
 	t.Parallel()
-	config, configCleanup := cltest.NewConfig()
+	config, configCleanup := cltest.NewConfig(t)
 	defer configCleanup()
 	oca := common.HexToAddress("0xDEADB3333333F")
 	config.Set("ORACLE_CONTRACT_ADDRESS", &oca)
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
 	txm := app.Store.TxManager
@@ -585,7 +585,7 @@ func TestTxManager_WithdrawLink(t *testing.T) {
 
 func TestTxManager_WithdrawLink_Unconfigured_Oracle(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	nonce := uint64(256)
@@ -643,12 +643,12 @@ func TestTxManager_LogsETHAndLINKBalancesAfterSuccessfulTx(t *testing.T) {
 
 	logsToCheckForBalance := cltest.ObserveLogs()
 
-	config, configCleanup := cltest.NewConfig()
+	config, configCleanup := cltest.NewConfig(t)
 	defer configCleanup()
 	oracleAddress := "0xDEADB3333333F"
 	oca := common.HexToAddress(oracleAddress)
 	config.Set("ORACLE_CONTRACT_ADDRESS", &oca)
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
 	manager := app.Store.TxManager
@@ -706,7 +706,7 @@ func TestTxManager_LogsETHAndLINKBalancesAfterSuccessfulTx(t *testing.T) {
 func TestTxManager_CreateTxWithGas(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	store := app.Store
 	manager := store.TxManager

--- a/core/web/bridge_types_controller_test.go
+++ b/core/web/bridge_types_controller_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func BenchmarkBridgeTypesController_Index(b *testing.B) {
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(b)
 	defer cleanup()
 	setupJobSpecsControllerIndex(app)
 	client := app.NewHTTPClient()
@@ -31,7 +31,7 @@ func BenchmarkBridgeTypesController_Index(b *testing.B) {
 func TestBridgeTypesController_Index(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -98,7 +98,7 @@ func setupBridgeControllerIndex(app *cltest.TestApplication) ([]*models.BridgeTy
 func TestBridgeTypesController_Create_Success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -126,7 +126,7 @@ func TestBridgeTypesController_Create_Success(t *testing.T) {
 func TestBridgeTypesController_Update_Success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -149,7 +149,7 @@ func TestBridgeTypesController_Update_Success(t *testing.T) {
 func TestBridgeController_Show(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -178,7 +178,7 @@ func TestBridgeController_Show(t *testing.T) {
 func TestBridgeController_Destroy(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 	resp, cleanup := client.Delete("/v2/bridge_types/testingbridges1")
@@ -213,7 +213,7 @@ func TestBridgeController_Destroy(t *testing.T) {
 func TestBridgeTypesController_Create_AdapterExistsError(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -228,7 +228,7 @@ func TestBridgeTypesController_Create_AdapterExistsError(t *testing.T) {
 func TestBridgeTypesController_Create_BindJSONError(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -243,7 +243,7 @@ func TestBridgeTypesController_Create_BindJSONError(t *testing.T) {
 func TestBridgeTypesController_Create_DatabaseError(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 

--- a/core/web/config_controller_test.go
+++ b/core/web/config_controller_test.go
@@ -17,7 +17,7 @@ import (
 func TestConfigController_Show(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 

--- a/core/web/cors_test.go
+++ b/core/web/cors_test.go
@@ -9,9 +9,9 @@ import (
 func TestCors_DefaultOrigins(t *testing.T) {
 	t.Parallel()
 
-	config, _ := cltest.NewConfig()
+	config, _ := cltest.NewConfig(t)
 	config.Set("ALLOW_ORIGINS", "http://localhost:3000,http://localhost:6689")
-	app, appCleanup := cltest.NewApplicationWithConfigAndKey(config)
+	app, appCleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer appCleanup()
 	client := app.NewHTTPClient()
 
@@ -50,9 +50,9 @@ func TestCors_OverrideOrigins(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.origin, func(t *testing.T) {
-			config, _ := cltest.NewConfig()
+			config, _ := cltest.NewConfig(t)
 			config.Set("ALLOW_ORIGINS", test.allow)
-			app, appCleanup := cltest.NewApplicationWithConfigAndKey(config)
+			app, appCleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 			defer appCleanup()
 			client := app.NewHTTPClient()
 

--- a/core/web/external_initiators_controller_test.go
+++ b/core/web/external_initiators_controller_test.go
@@ -12,7 +12,7 @@ import (
 func TestExternalInitiatorsController_Create(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	client := app.NewHTTPClient()
@@ -25,7 +25,7 @@ func TestExternalInitiatorsController_Create(t *testing.T) {
 func TestExternalInitiatorsController_Delete(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	client := app.NewHTTPClient()
@@ -38,7 +38,7 @@ func TestExternalInitiatorsController_Delete(t *testing.T) {
 func TestExternalInitiatorsController_DeleteNotFound(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	err := app.GetStore().CreateExternalInitiator(&models.ExternalInitiator{
 		AccessKey: "abracadabra",

--- a/core/web/gui_assets_test.go
+++ b/core/web/gui_assets_test.go
@@ -11,7 +11,7 @@ import (
 func TestGuiAssets_WildcardIndexHtml(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := &http.Client{}
 
@@ -51,7 +51,7 @@ func TestGuiAssets_WildcardIndexHtml(t *testing.T) {
 func TestGuiAssets_WildcardRouteInfo(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := &http.Client{}
 
@@ -75,7 +75,7 @@ func TestGuiAssets_WildcardRouteInfo(t *testing.T) {
 func TestGuiAssets_Exact(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := &http.Client{}
 

--- a/core/web/job_runs_controller_test.go
+++ b/core/web/job_runs_controller_test.go
@@ -17,7 +17,7 @@ import (
 )
 
 func BenchmarkJobRunsController_Index(b *testing.B) {
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(b)
 	defer cleanup()
 	app.Start()
 	run1, _, _ := setupJobRunsControllerIndex(b, app)
@@ -34,7 +34,7 @@ func BenchmarkJobRunsController_Index(b *testing.B) {
 func TestJobRunsController_Index(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -122,7 +122,7 @@ func setupJobRunsControllerIndex(t assert.TestingT, app *cltest.TestApplication)
 
 func TestJobRunsController_Create_Success(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 
@@ -138,7 +138,7 @@ func TestJobRunsController_Create_Success(t *testing.T) {
 
 func TestJobRunsController_Create_Archived(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 
@@ -154,7 +154,7 @@ func TestJobRunsController_Create_Archived(t *testing.T) {
 
 func TestJobRunsController_Create_EmptyBody(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 
@@ -167,7 +167,7 @@ func TestJobRunsController_Create_EmptyBody(t *testing.T) {
 
 func TestJobRunsController_Create_InvalidBody(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -182,7 +182,7 @@ func TestJobRunsController_Create_InvalidBody(t *testing.T) {
 
 func TestJobRunsController_Create_WithoutWebInitiator(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -197,7 +197,7 @@ func TestJobRunsController_Create_WithoutWebInitiator(t *testing.T) {
 
 func TestJobRunsController_Create_NotFound(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -209,7 +209,7 @@ func TestJobRunsController_Create_NotFound(t *testing.T) {
 
 func TestJobRunsController_Update_Success(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 
@@ -257,7 +257,7 @@ func TestJobRunsController_Update_Success(t *testing.T) {
 
 func TestJobRunsController_Update_WrongAccessToken(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -282,7 +282,7 @@ func TestJobRunsController_Update_WrongAccessToken(t *testing.T) {
 
 func TestJobRunsController_Update_NotPending(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -304,7 +304,7 @@ func TestJobRunsController_Update_NotPending(t *testing.T) {
 
 func TestJobRunsController_Update_WithError(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -334,7 +334,7 @@ func TestJobRunsController_Update_WithError(t *testing.T) {
 
 func TestJobRunsController_Update_BadInput(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -358,7 +358,7 @@ func TestJobRunsController_Update_BadInput(t *testing.T) {
 
 func TestJobRunsController_Update_NotFound(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -383,7 +383,7 @@ func TestJobRunsController_Update_NotFound(t *testing.T) {
 func TestJobRunsController_Show_Found(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -406,7 +406,7 @@ func TestJobRunsController_Show_Found(t *testing.T) {
 
 func TestJobRunsController_Show_NotFound(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -418,7 +418,7 @@ func TestJobRunsController_Show_NotFound(t *testing.T) {
 
 func TestJobRunsController_Show_Unauthenticated(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	defer cleanup()
 

--- a/core/web/job_specs_controller_test.go
+++ b/core/web/job_specs_controller_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func BenchmarkJobSpecsController_Index(b *testing.B) {
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(b)
 	defer cleanup()
 	client := app.NewHTTPClient()
 	setupJobSpecsControllerIndex(app)
@@ -34,7 +34,7 @@ func BenchmarkJobSpecsController_Index(b *testing.B) {
 func TestJobSpecsController_Index_noSort(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -82,7 +82,7 @@ func TestJobSpecsController_Index_noSort(t *testing.T) {
 func TestJobSpecsController_Index_sortCreatedAt(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -156,7 +156,7 @@ func setupJobSpecsControllerIndex(app *cltest.TestApplication) (*models.JobSpec,
 func TestJobSpecsController_Create_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -200,7 +200,7 @@ func TestJobSpecsController_Create_HappyPath(t *testing.T) {
 
 func TestJobSpecsController_Create_CaseInsensitiveTypes(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
 	j := cltest.FixtureCreateJobViaWeb(t, app, "testdata/caseinsensitive_hello_world_job.json")
@@ -226,7 +226,7 @@ func TestJobSpecsController_Create_CaseInsensitiveTypes(t *testing.T) {
 
 func TestJobSpecsController_Create_NonExistentTaskJob(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -242,7 +242,7 @@ func TestJobSpecsController_Create_NonExistentTaskJob(t *testing.T) {
 
 func TestJobSpecsController_Create_InvalidJob(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -258,7 +258,7 @@ func TestJobSpecsController_Create_InvalidJob(t *testing.T) {
 
 func TestJobSpecsController_Create_InvalidCron(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -274,7 +274,7 @@ func TestJobSpecsController_Create_InvalidCron(t *testing.T) {
 
 func TestJobSpecsController_Create_Initiator_Only(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -290,7 +290,7 @@ func TestJobSpecsController_Create_Initiator_Only(t *testing.T) {
 
 func TestJobSpecsController_Create_Task_Only(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -305,7 +305,7 @@ func TestJobSpecsController_Create_Task_Only(t *testing.T) {
 }
 
 func BenchmarkJobSpecsController_Show(b *testing.B) {
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(b)
 	defer cleanup()
 	client := app.NewHTTPClient()
 	j := setupJobSpecsControllerShow(b, app)
@@ -320,7 +320,7 @@ func BenchmarkJobSpecsController_Show(b *testing.B) {
 func TestJobSpecsController_Show(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -360,7 +360,7 @@ func setupJobSpecsControllerShow(t assert.TestingT, app *cltest.TestApplication)
 
 func TestJobSpecsController_Show_NotFound(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 
@@ -371,7 +371,7 @@ func TestJobSpecsController_Show_NotFound(t *testing.T) {
 
 func TestJobSpecsController_Show_Unauthenticated(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
 	resp, err := http.Get(app.Server.URL + "/v2/specs/" + "garbage")
@@ -381,7 +381,7 @@ func TestJobSpecsController_Show_Unauthenticated(t *testing.T) {
 
 func TestJobSpecsController_Destroy(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 	job := cltest.NewJobWithLogInitiator()

--- a/core/web/keys_controller_test.go
+++ b/core/web/keys_controller_test.go
@@ -13,8 +13,8 @@ import (
 func TestKeysController_CreateSuccess(t *testing.T) {
 	t.Parallel()
 
-	config, _ := cltest.NewConfig()
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+	config, _ := cltest.NewConfig(t)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
 	ethMock := app.MockEthClient()
@@ -45,8 +45,8 @@ func TestKeysController_CreateSuccess(t *testing.T) {
 func TestKeysController_InvalidPassword(t *testing.T) {
 	t.Parallel()
 
-	config, _ := cltest.NewConfig()
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+	config, _ := cltest.NewConfig(t)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
 	ethMock := app.MockEthClient()
@@ -77,8 +77,8 @@ func TestKeysController_InvalidPassword(t *testing.T) {
 func TestKeysController_JSONBindingError(t *testing.T) {
 	t.Parallel()
 
-	config, _ := cltest.NewConfig()
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+	config, _ := cltest.NewConfig(t)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
 	ethMock := app.MockEthClient()

--- a/core/web/router_test.go
+++ b/core/web/router_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestTokenAuthRequired_NoCredentials(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	router := web.Router(app)
@@ -28,7 +28,7 @@ func TestTokenAuthRequired_NoCredentials(t *testing.T) {
 }
 
 func TestTokenAuthRequired_SessionCredentials(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	router := web.Router(app)
@@ -43,7 +43,7 @@ func TestTokenAuthRequired_SessionCredentials(t *testing.T) {
 }
 
 func TestTokenAuthRequired_TokenCredentials(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	router := web.Router(app)
@@ -70,7 +70,7 @@ func TestTokenAuthRequired_TokenCredentials(t *testing.T) {
 }
 
 func TestTokenAuthRequired_BadTokenCredentials(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	router := web.Router(app)
@@ -97,7 +97,7 @@ func TestTokenAuthRequired_BadTokenCredentials(t *testing.T) {
 }
 
 func TestSessions_RateLimited(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	router := web.Router(app)
@@ -125,7 +125,7 @@ func TestSessions_RateLimited(t *testing.T) {
 }
 
 func TestRouter_LargePOSTBody(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	router := web.Router(app)

--- a/core/web/service_agreements_controller_test.go
+++ b/core/web/service_agreements_controller_test.go
@@ -15,9 +15,9 @@ import (
 func TestServiceAgreementsController_Create(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
-	eth := cltest.MockEthOnStore(app.GetStore())
+	eth := cltest.MockEthOnStore(t, app.GetStore())
 	eth.RegisterSubscription("logs")
 
 	client := app.NewHTTPClient()
@@ -66,9 +66,9 @@ func TestServiceAgreementsController_Create(t *testing.T) {
 func TestServiceAgreementsController_Create_isIdempotent(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
-	eth := cltest.MockEthOnStore(app.GetStore())
+	eth := cltest.MockEthOnStore(t, app.GetStore())
 	eth.RegisterSubscription("logs")
 
 	client := app.NewHTTPClient()
@@ -94,7 +94,7 @@ func TestServiceAgreementsController_Create_isIdempotent(t *testing.T) {
 
 func TestServiceAgreementsController_Show(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := app.NewHTTPClient()
 

--- a/core/web/sessions_controller_test.go
+++ b/core/web/sessions_controller_test.go
@@ -19,7 +19,7 @@ func TestSessionsController_Create(t *testing.T) {
 	t.Parallel()
 
 	user := cltest.MustUser("email@test.net", "password123")
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	err := app.Store.SaveUser(&user)
 	assert.NoError(t, err)
@@ -74,7 +74,7 @@ func TestSessionsController_Create_ReapSessions(t *testing.T) {
 	t.Parallel()
 
 	user := cltest.MustUser("email@test.net", "password123")
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	err := app.Store.SaveUser(&user)
 	assert.NoError(t, err)
@@ -101,7 +101,7 @@ func TestSessionsController_Destroy(t *testing.T) {
 	t.Parallel()
 
 	seedUser := cltest.MustUser("email@test.net", "password123")
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	app.Start()
 	err := app.Store.SaveUser(&seedUser)
 	assert.NoError(t, err)
@@ -146,7 +146,7 @@ func TestSessionsController_Destroy_ReapSessions(t *testing.T) {
 
 	client := http.Client{}
 	user := cltest.MustUser("email@test.net", "password123")
-	app, cleanup := cltest.NewApplication()
+	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
 	app.Start()

--- a/core/web/transactions_controller_test.go
+++ b/core/web/transactions_controller_test.go
@@ -16,7 +16,7 @@ import (
 func TestTransactionsController_Index_Success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	ethMock := app.MockEthClient()
@@ -57,7 +57,7 @@ func TestTransactionsController_Index_Success(t *testing.T) {
 func TestTransactionsController_Index_Error(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	ethMock := app.MockEthClient()
 	ethMock.Register("eth_getTransactionCount", "0x100")
@@ -72,7 +72,7 @@ func TestTransactionsController_Index_Error(t *testing.T) {
 func TestTransactionsController_Show_Success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	ethMock := app.MockEthClient()
@@ -117,7 +117,7 @@ func TestTransactionsController_Show_Success(t *testing.T) {
 func TestTransactionsController_Show_NotFound(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	ethMock := app.MockEthClient()

--- a/core/web/transfer_controller_test.go
+++ b/core/web/transfer_controller_test.go
@@ -17,8 +17,8 @@ import (
 func TestTransfersController_CreateSuccess(t *testing.T) {
 	t.Parallel()
 
-	config, _ := cltest.NewConfig()
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+	config, _ := cltest.NewConfig(t)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
 	ethMock := app.MockEthClient()
@@ -54,8 +54,8 @@ func TestTransfersController_CreateSuccess(t *testing.T) {
 func TestTransfersController_CreateSuccess_From(t *testing.T) {
 	t.Parallel()
 
-	config, _ := cltest.NewConfig()
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+	config, _ := cltest.NewConfig(t)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
 	ethMock := app.MockEthClient()
@@ -92,8 +92,8 @@ func TestTransfersController_CreateSuccess_From(t *testing.T) {
 func TestTransfersController_TransferError(t *testing.T) {
 	t.Parallel()
 
-	config, _ := cltest.NewConfig()
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+	config, _ := cltest.NewConfig(t)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
 	ethMock := app.MockEthClient()
@@ -127,8 +127,8 @@ func TestTransfersController_TransferError(t *testing.T) {
 func TestTransfersController_JSONBindingError(t *testing.T) {
 	t.Parallel()
 
-	config, _ := cltest.NewConfig()
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+	config, _ := cltest.NewConfig(t)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
 	ethMock := app.MockEthClient()

--- a/core/web/tx_attempts_controller_test.go
+++ b/core/web/tx_attempts_controller_test.go
@@ -15,7 +15,7 @@ import (
 func TestTxAttemptsController_Index_Success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
 	ethMock := app.MockEthClient()
@@ -53,7 +53,7 @@ func TestTxAttemptsController_Index_Success(t *testing.T) {
 func TestTxAttemptsController_Index_Error(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey()
+	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	ethMock := app.MockEthClient()
 	ethMock.Register("eth_getTransactionCount", "0x100")

--- a/core/web/user_controller_test.go
+++ b/core/web/user_controller_test.go
@@ -13,7 +13,7 @@ import (
 func TestUserController_UpdatePassword(t *testing.T) {
 	t.Parallel()
 
-	appWithUser, cleanup := cltest.NewApplicationWithKey()
+	appWithUser, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	client := appWithUser.NewHTTPClient()
 
@@ -47,7 +47,7 @@ func TestUserController_UpdatePassword(t *testing.T) {
 func TestUserController_AccountBalances_NoAccounts(t *testing.T) {
 	t.Parallel()
 
-	appWithoutAccount, cleanup := cltest.NewApplication()
+	appWithoutAccount, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 	client := appWithoutAccount.NewHTTPClient()
 
@@ -65,7 +65,7 @@ func TestUserController_AccountBalances_NoAccounts(t *testing.T) {
 func TestUserController_AccountBalances_Success(t *testing.T) {
 	t.Parallel()
 
-	appWithAccount, cleanup := cltest.NewApplicationWithKey()
+	appWithAccount, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	appWithAccount.AddUnlockedKey()
 	client := appWithAccount.NewHTTPClient()

--- a/core/web/withdrawals_controller_test.go
+++ b/core/web/withdrawals_controller_test.go
@@ -26,10 +26,10 @@ func verifyLinkBalanceCheck(address common.Address, t *testing.T) func(interface
 func TestWithdrawalsController_CreateSuccess(t *testing.T) {
 	t.Parallel()
 
-	config, _ := cltest.NewConfig()
+	config, _ := cltest.NewConfig(t)
 	oca := common.HexToAddress("0xDEADB3333333F")
 	config.Set("ORACLE_CONTRACT_ADDRESS", &oca)
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 	hash := cltest.NewHash()
 	client := app.NewHTTPClient()
@@ -71,10 +71,10 @@ func TestWithdrawalsController_CreateSuccess(t *testing.T) {
 func TestWithdrawalsController_BalanceTooLow(t *testing.T) {
 	t.Parallel()
 
-	config, _ := cltest.NewConfig()
+	config, _ := cltest.NewConfig(t)
 	oca := common.HexToAddress("0xDEADB3333333F")
 	config.Set("ORACLE_CONTRACT_ADDRESS", &oca)
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(config)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 	client := app.NewHTTPClient()
 


### PR DESCRIPTION
An example of failing output:

```
--- FAIL: TestIntegration_FeeBump (6.06s)
    mocks.go:190: EthMock: Method eth_blockNumber not registered
        goroutine 41 [running]:
        runtime/debug.Stack(0x4ca3ff2, 0x21, 0xc020b2c8c8)
        	/Users/john/.asdf/installs/golang/1.11.4/go/src/runtime/debug/stack.go:24 +0xa7
        github.com/smartcontractkit/chainlink/core/internal/cltest.(*EthMock).Call(0xc0002b2080, 0x4adec20, 0xc020ccac30, 0x4c922da, 0xf, 0x0, 0x0, 0x0, 0x0, 0x0)
        	/Users/john/go/src/github.com/smartcontractkit/chainlink/core/internal/cltest/mocks.go:190 +0x20c
        github.com/smartcontractkit/chainlink/core/store.(*EthClient).GetBlockNumber(0xc0001bac90, 0x0, 0x40, 0xc000ac0ac0)
        	/Users/john/go/src/github.com/smartcontractkit/chainlink/core/store/eth_client.go:116 +0x88
        github.com/smartcontractkit/chainlink/core/store.(*EthTxManager).getBlockNumber(0xc000423900, 0x20, 0x40, 0x0)
        	/Users/john/go/src/github.com/smartcontractkit/chainlink/core/store/tx_manager.go:626 +0x3d
        github.com/smartcontractkit/chainlink/core/store.(*EthTxManager).BumpGasUntilSafe(0xc000423900, 0x71a26b6a892c86b7, 0x6de4840141c0cc1b, 0xf47053e3ba83e79, 0xb56bd176a29e351d, 0xb56bd176a29e351d, 0x0, 0x0)
        	/Users/john/go/src/github.com/smartcontractkit/chainlink/core/store/tx_manager.go:279 +0x43
        github.com/smartcontractkit/chainlink/core/adapters.ensureTxRunResult(0xc020b2cd60, 0xc000351560)
        	/Users/john/go/src/github.com/smartcontractkit/chainlink/core/adapters/eth_tx.go:108 +0xad
        github.com/smartcontractkit/chainlink/core/adapters.createTxRunResult(0xc0007f54f0, 0xc020b2cd60, 0xc000351560)
        	/Users/john/go/src/github.com/smartcontractkit/chainlink/core/adapters/eth_tx.go:92 +0x285
        github.com/smartcontractkit/chainlink/core/adapters.(*EthTx).Perform(0xc0007f54f0, 0x6, 0xc020c90ae0, 0x20, 0xc020c90b00, 0x20, 0x5, 0xc020ba7bd0, 0x4f, 0x0, ...)
        	/Users/john/go/src/github.com/smartcontractkit/chainlink/core/adapters/eth_tx.go:42 +0xf5
        github.com/smartcontractkit/chainlink/core/services.executeTask(0xc020bdac00, 0xc020bf32b0, 0xc000351560, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
        	/Users/john/go/src/github.com/smartcontractkit/chainlink/core/services/job_runner.go:227 +0x4b0
        github.com/smartcontractkit/chainlink/core/services.executeRun(0xc020bdac00, 0xc000351560, 0x20, 0xc020c90340)
        	/Users/john/go/src/github.com/smartcontractkit/chainlink/core/services/job_runner.go:250 +0x149
        github.com/smartcontractkit/chainlink/core/services.(*jobRunner).workerLoop(0xc0003515c0, 0xc0001fee40, 0x20, 0xc000804c00)
        	/Users/john/go/src/github.com/smartcontractkit/chainlink/core/services/job_runner.go:163 +0x1e8
        github.com/smartcontractkit/chainlink/core/services.(*jobRunner).channelForRun.func1(0xc0003515c0, 0xc0001fee40, 0x20, 0xc000804c00)
        	/Users/john/go/src/github.com/smartcontractkit/chainlink/core/services/job_runner.go:141 +0x50
        created by github.com/smartcontractkit/chainlink/core/services.(*jobRunner).channelForRun
        	/Users/john/go/src/github.com/smartcontractkit/chainlink/core/services/job_runner.go:140 +0x18e
```