### PR TITLE
retry nonce when transaction errors with "Same Hash"

### DIFF
--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -222,8 +222,7 @@ func (txm *EthTxManager) createEthTxWithNonceReload(
 	})
 
 	if err != nil {
-		nonceErr, _ := regexp.MatchString("nonce .*too low", err.Error())
-		if nonceErr {
+		if matchesNonceTooLowError(err) {
 			if nrc >= nonceReloadLimit {
 				err = fmt.Errorf(
 					"Transaction reattempt limit reached for 'nonce is too low' error. Limit: %v, Reattempt: %v",
@@ -244,6 +243,15 @@ func (txm *EthTxManager) createEthTxWithNonceReload(
 	}
 
 	return tx, err
+}
+
+var (
+	nonceTooLowRegex = regexp.MustCompile("nonce .*too low")
+	sameHashRegex    = regexp.MustCompile("same hash was already imported")
+)
+
+func matchesNonceTooLowError(err error) bool {
+	return nonceTooLowRegex.MatchString(err.Error()) || sameHashRegex.MatchString(err.Error())
 }
 
 func (txm *EthTxManager) createTxWithNonceReload(

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -205,6 +205,7 @@ func TestTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
 	}{
 		{"geth", "nonce too low"},
 		{"parity", "Transaction nonce is too low. Try incrementing the nonce"},
+		{"parity", "Transaction with the same hash was already imported"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Actual error msg:
> Transaction with the same hash was already imported.