### PR TITLE
Add started friendly timestamp to operator job run regional nav

### DIFF
--- a/operator_ui/src/components/JobRuns/RegionalNav.js
+++ b/operator_ui/src/components/JobRuns/RegionalNav.js
@@ -9,6 +9,7 @@ import List from '@material-ui/core/List'
 import ListItem from '@material-ui/core/ListItem'
 import { fetchJob, createJobRun } from 'actions'
 import Link from 'components/Link'
+import TimeAgo from 'components/TimeAgo'
 
 const styles = theme => {
   return {
@@ -42,23 +43,32 @@ const styles = theme => {
   }
 }
 
-const RegionalNav = ({ classes, jobSpecId, jobRunId }) => {
+const RegionalNav = ({ classes, jobSpecId, jobRunId, jobRun }) => {
   return (
     <Card className={classes.container}>
       <Grid container spacing={0}>
         <Grid item xs={12}>
+          <Typography variant="subtitle2" color="secondary" gutterBottom>
+            Job Run Detail
+          </Typography>
           <Link to={`/jobs/${jobSpecId}`}>
             <Typography variant="subtitle1" color="primary">
               {jobSpecId}
             </Typography>
           </Link>
-          <Typography variant="h3" color="secondary">
-            Job Run Detail
+        </Grid>
+        <Grid item xs={12}>
+          <Typography variant="h3" color="secondary" gutterBottom>
+            {jobRunId}
           </Typography>
         </Grid>
         <Grid item xs={12}>
-          <Typography variant="subtitle1" color="textSecondary">
-            #{jobRunId}
+          <Typography variant="subtitle2" color="textSecondary">
+            {jobRun && (
+              <React.Fragment>
+                Started <TimeAgo>{jobRun.createdAt}</TimeAgo>
+              </React.Fragment>
+            )}
           </Typography>
         </Grid>
         <Grid item xs={12}>


### PR DESCRIPTION
Before:
![Screen Shot 2019-05-30 at 6 09 11 PM](https://user-images.githubusercontent.com/680789/58674753-13fe8300-8306-11e9-83fe-7e160403c3c6.png)

---------------------------------------------------------------

After:
![Screen Shot 2019-05-31 at 9 41 03 AM](https://user-images.githubusercontent.com/680789/58720888-405ae380-8388-11e9-9d3b-e4b69012dcb2.png)


---------------------------------------------------------------

Also makes it closer to the same structure as `Jobs#Show`:
![Screen Shot 2019-05-31 at 8 06 26 AM](https://user-images.githubusercontent.com/680789/58715132-1818b800-837b-11e9-828d-c0cd1da35b99.png)

