### PR TITLE
Don't set and enforce secure cookie if TLS disabled

### DIFF
--- a/core/store/config.go
+++ b/core/store/config.go
@@ -367,11 +367,11 @@ func (c Config) SessionSecret() ([]byte, error) {
 	return c.SecretGenerator.Generate(c)
 }
 
-// SessionOptions returns the sesssions.Options struct used to configure
+// SessionOptions returns the sessions.Options struct used to configure
 // the session store.
 func (c Config) SessionOptions() sessions.Options {
 	return sessions.Options{
-		Secure:   !c.Dev(),
+		Secure:   !c.Dev() && c.TLSPort() != 0,
 		HttpOnly: true,
 		MaxAge:   86400 * 30,
 	}

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -77,8 +77,10 @@ func Router(app services.Application) *gin.Engine {
 		loggerFunc(),
 		gin.Recovery(),
 		cors,
-		secureMiddleware(config),
 	)
+	if config.TLSPort() != 0 {
+		engine.Use(secureMiddleware(config))
+	}
 
 	api := engine.Group(
 		"/",


### PR DESCRIPTION
* Disables secure middleware when TLS completely disabled
* Don't set secure cookie when TLS completely disabled