### PR TITLE
shorten the time check for sleeping

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -663,6 +663,6 @@ func TestIntegration_SleepAdapter(t *testing.T) {
 	jr := cltest.CreateJobRunViaWeb(t, app, j, runInput)
 
 	cltest.WaitForJobRunToPendSleep(t, app.Store, jr)
-	cltest.JobRunStays(t, app.Store, jr, models.RunStatusPendingSleep, time.Second*2)
+	cltest.JobRunStays(t, app.Store, jr, models.RunStatusPendingSleep, time.Second)
 	cltest.WaitForJobRunToComplete(t, app.Store, jr)
 }


### PR DESCRIPTION
- makes the test a little more lenient if run in a slow environment