### PR TITLE
A batch of improvements to the Ethtx changes

### DIFF
--- a/core/store/models/eth_test.go
+++ b/core/store/models/eth_test.go
@@ -202,8 +202,6 @@ func TestTx_PresenterMatchesHex(t *testing.T) {
 	signedHex, err := utils.EncodeTxToHex(signed)
 	assert.NoError(t, err)
 
-	ptx, err := presenters.NewTx(createdTx)
-	assert.NoError(t, err)
-
+	ptx := presenters.NewTx(createdTx)
 	assert.Equal(t, signedHex, ptx.Hex)
 }

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -495,7 +495,7 @@ type Tx struct {
 }
 
 // NewTx builds a transaction presenter.
-func NewTx(tx *models.Tx) (Tx, error) {
+func NewTx(tx *models.Tx) Tx {
 	return Tx{
 		Confirmed: tx.Confirmed,
 		Data:      hexutil.Bytes(tx.Data),
@@ -508,7 +508,7 @@ func NewTx(tx *models.Tx) (Tx, error) {
 		SentAt:    strconv.FormatUint(tx.SentAt, 10),
 		To:        &tx.To,
 		Value:     tx.Value.String(),
-	}, nil
+	}
 }
 
 // GetID returns the jsonapi ID.

--- a/core/store/presenters/presenters_test.go
+++ b/core/store/presenters/presenters_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_NewTx(t *testing.T) {
@@ -19,9 +18,7 @@ func Test_NewTx(t *testing.T) {
 		Nonce:    uint64(100),
 		SentAt:   uint64(300),
 	}
-	ptx, err := NewTx(&tx)
-	require.NoError(t, err)
-
+	ptx := NewTx(&tx)
 	assert.Equal(t, "5000", ptx.GasLimit)
 	assert.Equal(t, "100", ptx.Nonce)
 	assert.Equal(t, "300", ptx.SentAt)

--- a/core/web/transactions_controller.go
+++ b/core/web/transactions_controller.go
@@ -21,11 +21,7 @@ func (tc *TransactionsController) Index(c *gin.Context, size, page, offset int) 
 	txs, count, err := tc.App.GetStore().Transactions(offset, size)
 	ptxs := make([]presenters.Tx, len(txs))
 	for i, tx := range txs {
-		txp, err := presenters.NewTx(&tx)
-		if err != nil {
-			jsonAPIError(c, http.StatusInternalServerError, err)
-			return
-		}
+		txp := presenters.NewTx(&tx)
 		ptxs[i] = txp
 	}
 	paginatedResponse(c, "Transactions", size, page, ptxs, count, err)
@@ -40,7 +36,7 @@ func (tc *TransactionsController) Show(c *gin.Context) {
 		jsonAPIError(c, http.StatusNotFound, errors.New("Transaction not found"))
 	} else if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
-	} else if txp, err := presenters.NewTx(tx); err != nil {
+	} else if txp := presenters.NewTx(tx); false {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 	} else {
 		jsonAPIResponse(c, txp, "transaction")

--- a/core/web/transactions_controller_test.go
+++ b/core/web/transactions_controller_test.go
@@ -108,8 +108,7 @@ func TestTransactionsController_Show_Success(t *testing.T) {
 			ptx := presenters.Tx{}
 			require.NoError(t, cltest.ParseJSONAPIResponse(t, resp, &ptx))
 
-			txp, err := presenters.NewTx(&test.want)
-			require.NoError(t, err)
+			txp := presenters.NewTx(&test.want)
 			assert.Equal(t, txp.Confirmed, ptx.Confirmed)
 			assert.Equal(t, txp.Data, ptx.Data)
 			assert.Equal(t, txp.GasLimit, ptx.GasLimit)

--- a/core/web/transfer_controller.go
+++ b/core/web/transfer_controller.go
@@ -33,7 +33,7 @@ func (tc *TransfersController) Create(c *gin.Context) {
 		jsonAPIError(c, http.StatusBadRequest, err)
 	} else if tx, err := store.TxManager.CreateTxWithEth(from, tr.DestinationAddress, tr.Amount); err != nil {
 		jsonAPIError(c, http.StatusBadRequest, fmt.Errorf("Transaction failed: %v", err))
-	} else if txp, err := presenters.NewTx(tx); err != nil {
+	} else if txp := presenters.NewTx(tx); false {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 	} else {
 		jsonAPIResponse(c, txp, "transaction")

--- a/core/web/withdrawals_controller.go
+++ b/core/web/withdrawals_controller.go
@@ -55,7 +55,7 @@ func (abc *WithdrawalsController) Create(c *gin.Context) {
 	hash, err := txm.WithdrawLINK(wr)
 	if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
-	} else if txp, err := presenters.NewTx(&models.Tx{Hash: hash}); err != nil {
+	} else if txp := presenters.NewTx(&models.Tx{Hash: hash}); false {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 	} else {
 		jsonAPIResponse(c, txp, "transaction")


### PR DESCRIPTION
Some small improvements after the EthTx adapter changes:

  1. Remove unused err from presenters.NewTx
  2. Mark obselete TxAttempts as such so that their receipts don't need to be retrieved