### PR TITLE
Chainlink Core tracks and pushes task run confirmation counts:

### DIFF
--- a/core/services/runs.go
+++ b/core/services/runs.go
@@ -321,8 +321,7 @@ func updateTaskRunConfirmations(currentHeight *models.Big, jr *models.JobRun, ta
 	if jr.CreationHeight == nil || currentHeight == nil {
 		return
 	}
-	diff := new(big.Int).Sub(currentHeight.ToInt(), jr.CreationHeight.ToInt())
-	taskRun.Confirmations = diff.Uint64() + 1 // creation alone warrants one confirmation
+	taskRun.Confirmations = blockNumberDifference(currentHeight, jr.CreationHeight)
 	if taskRun.Confirmations > taskRun.MinimumConfirmations {
 		taskRun.Confirmations = taskRun.MinimumConfirmations
 	}
@@ -356,10 +355,13 @@ func meetsMinimumConfirmations(
 		return true
 	}
 
-	diff := new(big.Int).Sub(currentHeight.ToInt(), run.CreationHeight.ToInt())
-	min := new(big.Int).SetUint64(taskRun.MinimumConfirmations)
-	min = min.Sub(min, big.NewInt(1))
-	return diff.Cmp(min) >= 0
+	diff := blockNumberDifference(currentHeight, run.CreationHeight)
+	return diff >= taskRun.MinimumConfirmations
+}
+
+func blockNumberDifference(currentHeight, creationHeight *models.Big) uint64 {
+	diff := new(big.Int).Sub(currentHeight.ToInt(), creationHeight.ToInt())
+	return diff.Uint64() + 1 // creation of runlog alone warrants 1 confirmation
 }
 
 func updateAndTrigger(run *models.JobRun, store *store.Store) error {

--- a/core/services/synchronization/presenters.go
+++ b/core/services/synchronization/presenters.go
@@ -69,11 +69,13 @@ func (p SyncJobRunPresenter) tasks() ([]syncTaskRunPresenter, error) {
 			return []syncTaskRunPresenter{}, err
 		}
 		tasks = append(tasks, syncTaskRunPresenter{
-			Index:  index,
-			Type:   string(tr.TaskSpec.Type),
-			Status: string(tr.Status),
-			Error:  tr.Result.ErrorMessage,
-			Result: erp,
+			Index:                index,
+			Type:                 string(tr.TaskSpec.Type),
+			Status:               string(tr.Status),
+			Error:                tr.Result.ErrorMessage,
+			Result:               erp,
+			Confirmations:        tr.Confirmations,
+			MinimumConfirmations: tr.MinimumConfirmations,
 		})
 	}
 	return tasks, nil
@@ -134,9 +136,11 @@ type syncInitiatorPresenter struct {
 }
 
 type syncTaskRunPresenter struct {
-	Index  int         `json:"index"`
-	Type   string      `json:"type"`
-	Status string      `json:"status"`
-	Error  null.String `json:"error"`
-	Result interface{} `json:"result,omitempty"`
+	Index                int         `json:"index"`
+	Type                 string      `json:"type"`
+	Status               string      `json:"status"`
+	Error                null.String `json:"error"`
+	Result               interface{} `json:"result,omitempty"`
+	Confirmations        uint64      `json:"confirmations"`
+	MinimumConfirmations uint64      `json:"minimumConfirmations"`
 }

--- a/core/services/synchronization/presenters_test.go
+++ b/core/services/synchronization/presenters_test.go
@@ -34,8 +34,10 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 		},
 		TaskRuns: []models.TaskRun{
 			models.TaskRun{
-				ID:     "task0RunID-938",
-				Status: models.RunStatusPendingConfirmations,
+				ID:                   "task0RunID-938",
+				Status:               models.RunStatusPendingConfirmations,
+				Confirmations:        1,
+				MinimumConfirmations: 3,
 			},
 			models.TaskRun{
 				ID:     "task1RunID-17",
@@ -78,6 +80,8 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 	assert.Contains(t, task0, "type")
 	assert.Equal(t, task0["status"], "pending_confirmations")
 	assert.Equal(t, task0["error"], nil)
+	assert.Equal(t, float64(1), task0["confirmations"])
+	assert.Equal(t, float64(3), task0["minimumConfirmations"])
 	task1, ok := tasks[1].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, task1["index"], float64(1))

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -5,6 +5,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration0"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1559081901"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1559767166"
 	gormigrate "gopkg.in/gormigrate.v1"
 )
 
@@ -22,6 +23,10 @@ func Migrate(db *gorm.DB) error {
 		{
 			ID:      "1559081901",
 			Migrate: migration1559081901.Migrate,
+		},
+		{
+			ID:      "1559767166",
+			Migrate: migration1559767166.Migrate,
 		},
 	})
 

--- a/core/store/migrations/migration0/migrate.go
+++ b/core/store/migrations/migration0/migrate.go
@@ -49,7 +49,7 @@ func Migrate(tx *gorm.DB) error {
 	if err := tx.AutoMigrate(&models.SyncEvent{}).Error; err != nil {
 		return errors.Wrap(err, "failed to auto migrate SyncEvent")
 	}
-	if err := tx.AutoMigrate(&models.TaskRun{}).Error; err != nil {
+	if err := tx.AutoMigrate(&TaskRun{}).Error; err != nil {
 		return errors.Wrap(err, "failed to auto migrate TaskRun")
 	}
 	if err := tx.AutoMigrate(&models.TaskSpec{}).Error; err != nil {
@@ -92,4 +92,16 @@ type TxAttempt struct {
 	Hex       string `gorm:"type:text"`
 	SentAt    uint64
 	CreatedAt time.Time `gorm:"index"`
+}
+
+// TaskRun stores the Task and represents the status of the
+// Task to be ran.
+type TaskRun struct {
+	ID                   string    `json:"id" gorm:"primary_key;not null"`
+	JobRunID             string    `json:"-" gorm:"index;not null;type:varchar(36) REFERENCES job_runs(id) ON DELETE CASCADE"`
+	ResultID             uint      `json:"-"`
+	Status               string    `json:"status"`
+	TaskSpecID           uint      `json:"-" gorm:"index;not null REFERENCES task_specs(id)"`
+	MinimumConfirmations uint64    `json:"minimumConfirmations"`
+	CreatedAt            time.Time `json:"-" gorm:"index"`
 }

--- a/core/store/migrations/migration1559767166/migrate.go
+++ b/core/store/migrations/migration1559767166/migrate.go
@@ -1,0 +1,14 @@
+package migration1559767166
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+)
+
+func Migrate(tx *gorm.DB) error {
+	if err := tx.AutoMigrate(&models.TaskRun{}).Error; err != nil {
+		return errors.Wrap(err, "failed to auto migrate TaskRun")
+	}
+	return nil
+}

--- a/core/store/models/run.go
+++ b/core/store/models/run.go
@@ -164,6 +164,7 @@ type TaskRun struct {
 	TaskSpec             TaskSpec  `json:"task" gorm:"association_autoupdate:false;association_autocreate:false"`
 	TaskSpecID           uint      `json:"-" gorm:"index;not null REFERENCES task_specs(id)"`
 	MinimumConfirmations uint64    `json:"minimumConfirmations"`
+	Confirmations        uint64    `json:"confirmations" gorm:"not null"`
 	CreatedAt            time.Time `json:"-" gorm:"index"`
 }
 

--- a/core/store/models/run.go
+++ b/core/store/models/run.go
@@ -164,7 +164,7 @@ type TaskRun struct {
 	TaskSpec             TaskSpec  `json:"task" gorm:"association_autoupdate:false;association_autocreate:false"`
 	TaskSpecID           uint      `json:"-" gorm:"index;not null REFERENCES task_specs(id)"`
 	MinimumConfirmations uint64    `json:"minimumConfirmations"`
-	Confirmations        uint64    `json:"confirmations" gorm:"not null"`
+	Confirmations        uint64    `json:"confirmations" gorm:"default: 0;not null"`
 	CreatedAt            time.Time `json:"-" gorm:"index"`
 }
 


### PR DESCRIPTION
Pushes it specifically to the Explorer. This is solely for the core (golang) side of the implementation. Explorer nodejs and react changes will happen in a separate PR.