### PR TITLE
Expose CheckAttempt to TxManager, saves some unnecessary calls

### DIFF
--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -110,11 +110,6 @@ func createTxRunResult(
 		return
 	}
 
-	if receipt == nil || state != strpkg.Safe {
-		input.MarkPendingConfirmations()
-		return
-	}
-
 	logger.Debugw(
 		fmt.Sprintf("Tx #0 is %s", state),
 		"txHash", txAttempt.Hash.String(),
@@ -123,6 +118,11 @@ func createTxRunResult(
 		"currentBlockNumber", tx.SentAt,
 		"receiptHash", receipt.Hash.Hex(),
 	)
+
+	if state != strpkg.Safe {
+		input.MarkPendingConfirmations()
+		return
+	}
 
 	addReceiptToResult(receipt, input)
 }

--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -98,7 +98,7 @@ func createTxRunResult(
 	input.ApplyResult(tx.Hash.String())
 
 	txAttempt := tx.Attempts[0]
-	receipt, state, err := store.TxManager.CheckAttempt(txAttempt, int64(tx.SentAt))
+	receipt, state, err := store.TxManager.CheckAttempt(txAttempt, tx.SentAt)
 	if err != nil {
 		input.SetError(err)
 		return

--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -98,17 +98,18 @@ func createTxRunResult(
 	input.ApplyResult(tx.Hash.String())
 
 	txAttempt := tx.Attempts[0]
-	receipt, state, err := store.TxManager.CheckAttempt(txAttempt, tx.SentAt)
+	receipt, _, err := store.TxManager.CheckAttempt(txAttempt, tx.SentAt)
 	if err != nil {
 		input.SetError(err)
 		return
 	}
 
-	if state == strpkg.Safe || state == strpkg.Confirmed {
-		addReceiptToResult(receipt, input)
-	} else {
+	if receipt == nil {
 		input.MarkPendingConfirmations()
+		return
 	}
+
+	addReceiptToResult(receipt, input)
 }
 
 func ensureTxRunResult(input *models.RunResult, str *strpkg.Store) {

--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -135,7 +135,7 @@ func TestEthTxAdapter_Perform_ConfirmedWithBytes(t *testing.T) {
 	ethMock.EventuallyAllCalled(t)
 }
 
-func TestEthTxAdapter_Perform_ConfirmedWithBytesAndNoDataPrefix(t *testing.T) {
+func TestEthTxAdapter_Perform_SafeWithBytesAndNoDataPrefix(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplicationWithKey(t)
@@ -152,7 +152,7 @@ func TestEthTxAdapter_Perform_ConfirmedWithBytesAndNoDataPrefix(t *testing.T) {
 	require.NoError(t, app.StartAndConnect())
 
 	hash := cltest.NewHash()
-	sentAt := uint64(23456)
+	currentHeight := uint64(23456)
 	ethMock.Register("eth_sendRawTransaction", hash,
 		func(_ interface{}, data ...interface{}) error {
 			rlp := data[0].([]interface{})[0].(string)
@@ -167,8 +167,8 @@ func TestEthTxAdapter_Perform_ConfirmedWithBytesAndNoDataPrefix(t *testing.T) {
 			assert.Equal(t, wantData, hexutil.Encode(tx.Data()))
 			return nil
 		})
-	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(sentAt))
-	safe := sentAt - store.Config.MinOutgoingConfirmations()
+	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(currentHeight))
+	safe := currentHeight - store.Config.MinOutgoingConfirmations()
 	receipt := models.TxReceipt{Hash: hash, BlockNumber: cltest.Int(safe)}
 	ethMock.Register("eth_getTransactionReceipt", receipt)
 

--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/adapters"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
+	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 	"github.com/stretchr/testify/assert"
@@ -453,7 +454,7 @@ func TestEthTxAdapter_DeserializationBytesFormat(t *testing.T) {
 			"000000000000000000000000000000000000000000000000000000000000000b"+
 			"68656c6c6f20776f726c64000000000000000000000000000000000000000000"),
 		gomock.Any(), gomock.Any()).Return(tx, nil)
-	txmMock.EXPECT().CheckAttempt(txAttempt, uint64(0))
+	txmMock.EXPECT().CheckAttempt(txAttempt, uint64(0)).Return(models.TxReceipt{}, strpkg.Unconfirmed, nil)
 
 	task := models.TaskSpec{}
 	err := json.Unmarshal([]byte(`{"type": "EthTx", "params": {"format": "bytes"}}`), &task)

--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -434,7 +434,7 @@ func TestEthTxAdapter_Perform_PendingConfirmations_WithFatalErrorInTxManager(t *
 	ethMock.RegisterError("eth_blockNumber", "Invalid node id")
 	output := adapter.Perform(input, store)
 
-	ethMock.EventuallyAllCalled(t)
+	ethMock.AssertAllCalled()
 
 	assert.Equal(t, models.RunStatusErrored, output.Status)
 	assert.NotNil(t, output.Error())
@@ -465,7 +465,7 @@ func TestEthTxAdapter_Perform_PendingConfirmations_WithRecoverableErrorInTxManag
 	}
 	output := adapter.Perform(input, store)
 
-	ethMock.EventuallyAllCalled(t)
+	ethMock.AssertAllCalled()
 
 	assert.Equal(t, models.RunStatusPendingConfirmations, output.Status)
 	assert.NoError(t, output.GetError())

--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -422,14 +422,16 @@ func TestEthTxAdapter_Perform_PendingConfirmations_WithFatalErrorInTxManager(t *
 
 	store := app.Store
 	ethMock := app.MockEthClient(cltest.Strict)
-	ethMock.Register("eth_getTransactionCount", `0x0100`)
+	ethMock.Register("eth_getTransactionCount", `0x17`)
 	assert.Nil(t, app.Start())
+
+	require.NoError(t, app.WaitForConnection())
 
 	adapter := adapters.EthTx{
 		Address:          cltest.NewAddress(),
 		FunctionSelector: models.HexToFunctionSelector("0xb3f98adc"),
 	}
-	input := cltest.RunResultWithResult("")
+	input := cltest.RunResultWithResult(cltest.NewHash().String())
 	input.Status = models.RunStatusPendingConfirmations
 	ethMock.RegisterError("eth_blockNumber", "Invalid node id")
 	output := adapter.Perform(input, store)
@@ -448,7 +450,7 @@ func TestEthTxAdapter_Perform_PendingConfirmations_WithRecoverableErrorInTxManag
 
 	store := app.Store
 	ethMock := app.MockEthClient(cltest.Strict)
-	ethMock.Register("eth_getTransactionCount", `0x0100`)
+	ethMock.Register("eth_getTransactionCount", `0x12`)
 	assert.Nil(t, app.Start())
 
 	from := cltest.GetAccountAddress(t, store)
@@ -458,6 +460,8 @@ func TestEthTxAdapter_Perform_PendingConfirmations_WithRecoverableErrorInTxManag
 
 	ethMock.Register("eth_blockNumber", "0x100")
 	ethMock.RegisterError("eth_getTransactionReceipt", "Connection reset by peer")
+
+	require.NoError(t, app.WaitForConnection())
 
 	adapter := adapters.EthTx{
 		Address:          cltest.NewAddress(),

--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -451,6 +451,8 @@ func TestEthTxAdapter_DeserializationBytesFormat(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	txmMock := mocks.NewMockTxManager(ctrl)
 	store.TxManager = txmMock
+
+	tx := &models.Tx{Attempts: []*models.TxAttempt{&models.TxAttempt{}}}
 	txmMock.EXPECT().Register(gomock.Any())
 	txmMock.EXPECT().Connected().Return(true).AnyTimes()
 	txmMock.EXPECT().CreateTxWithGas(gomock.Any(), gomock.Any(), hexutil.MustDecode(
@@ -458,7 +460,7 @@ func TestEthTxAdapter_DeserializationBytesFormat(t *testing.T) {
 			"0000000000000000000000000000000000000000000000000000000000000020"+
 			"000000000000000000000000000000000000000000000000000000000000000b"+
 			"68656c6c6f20776f726c64000000000000000000000000000000000000000000"),
-		gomock.Any(), gomock.Any()).Return(&models.Tx{}, nil)
+		gomock.Any(), gomock.Any()).Return(tx, nil)
 	txmMock.EXPECT().BumpGasUntilSafe(gomock.Any())
 
 	task := models.TaskSpec{}

--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -172,6 +172,11 @@ func (mock *EthMock) EventuallyAllCalled(t *testing.T) {
 	g.Eventually(mock.Remaining).Should(gomega.HaveLen(0))
 }
 
+// AssertAllCalled immediately checks that all calls have been made
+func (mock *EthMock) AssertAllCalled() {
+	assert.Empty(mock.t, mock.Remaining())
+}
+
 // Call will call given method and set the result
 func (mock *EthMock) Call(result interface{}, method string, args ...interface{}) error {
 	mock.mutex.Lock()

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -78,7 +78,6 @@ func TestIntegration_HttpRequestWithHeaders(t *testing.T) {
 	eth.Context("ethTx.Perform()#1 at block 23456", func(eth *cltest.EthMock) {
 		eth.Register("eth_blockNumber", utils.Uint64ToHex(sentAt))
 		eth.Register("eth_sendRawTransaction", attempt1Hash) // Initial tx attempt sent
-		eth.Register("eth_blockNumber", utils.Uint64ToHex(sentAt))
 		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
 	})
 	j := cltest.CreateHelloWorldJobViaWeb(t, app, mockServer.URL)
@@ -133,7 +132,6 @@ func TestIntegration_FeeBump(t *testing.T) {
 	eth.Context("ethTx.Perform()#1 at block 23456", func(eth *cltest.EthMock) {
 		eth.Register("eth_blockNumber", utils.Uint64ToHex(sentAt))
 		eth.Register("eth_sendRawTransaction", attempt1Hash) // Initial tx attempt sent
-		eth.Register("eth_blockNumber", utils.Uint64ToHex(sentAt))
 		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
 	})
 	j := cltest.CreateHelloWorldJobViaWeb(t, app, mockServer.URL)

--- a/core/internal/mocks/tx_manager_mocks.go
+++ b/core/internal/mocks/tx_manager_mocks.go
@@ -56,7 +56,7 @@ func (mr *MockTxManagerMockRecorder) BumpGasUntilSafe(arg0 interface{}) *gomock.
 }
 
 // CheckAttempt mocks base method
-func (m *MockTxManager) CheckAttempt(arg0 *models.TxAttempt, arg1 int64) (*models.TxReceipt, store.AttemptState, error) {
+func (m *MockTxManager) CheckAttempt(arg0 *models.TxAttempt, arg1 uint64) (*models.TxReceipt, store.AttemptState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CheckAttempt", arg0, arg1)
 	ret0, _ := ret[0].(*models.TxReceipt)

--- a/core/internal/mocks/tx_manager_mocks.go
+++ b/core/internal/mocks/tx_manager_mocks.go
@@ -41,12 +41,13 @@ func (m *MockTxManager) EXPECT() *MockTxManagerMockRecorder {
 }
 
 // BumpGasUntilSafe mocks base method
-func (m *MockTxManager) BumpGasUntilSafe(arg0 common.Hash) (*models.TxReceipt, error) {
+func (m *MockTxManager) BumpGasUntilSafe(arg0 common.Hash) (*models.TxReceipt, store.AttemptState, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "BumpGasUntilSafe", arg0)
 	ret0, _ := ret[0].(*models.TxReceipt)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
+	ret1, _ := ret[1].(store.AttemptState)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
 // BumpGasUntilSafe indicates an expected call of BumpGasUntilSafe

--- a/core/internal/mocks/tx_manager_mocks.go
+++ b/core/internal/mocks/tx_manager_mocks.go
@@ -55,6 +55,22 @@ func (mr *MockTxManagerMockRecorder) BumpGasUntilSafe(arg0 interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BumpGasUntilSafe", reflect.TypeOf((*MockTxManager)(nil).BumpGasUntilSafe), arg0)
 }
 
+// CheckAttempt mocks base method
+func (m *MockTxManager) CheckAttempt(arg0 *models.TxAttempt, arg1 int64) (*models.TxReceipt, store.AttemptState, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CheckAttempt", arg0, arg1)
+	ret0, _ := ret[0].(*models.TxReceipt)
+	ret1, _ := ret[1].(store.AttemptState)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CheckAttempt indicates an expected call of CheckAttempt
+func (mr *MockTxManagerMockRecorder) CheckAttempt(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CheckAttempt", reflect.TypeOf((*MockTxManager)(nil).CheckAttempt), arg0, arg1)
+}
+
 // Connect mocks base method
 func (m *MockTxManager) Connect(arg0 *models.Head) error {
 	m.ctrl.T.Helper()

--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -535,14 +535,14 @@ func (txm *EthTxManager) processAttempt(
 		return receipt, state, txm.handleSafe(tx, attemptIndex)
 
 	case Confirmed: // nothing to do, need to wait
-		return nil, state, nil
+		return receipt, state, nil
 
 	case Unconfirmed:
 		if isLatestAttempt(tx, txAttempt) && txm.hasTxAttemptMetGasBumpThreshold(tx, attemptIndex, blockHeight) {
-			return nil, state, txm.bumpGas(tx, attemptIndex, blockHeight)
+			err = txm.bumpGas(tx, attemptIndex, blockHeight)
 		}
 
-		return nil, state, nil
+		return receipt, state, err
 	}
 
 	panic("invariant violated, 'Unknown' state returned without error")

--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -252,6 +252,8 @@ func (txm *EthTxManager) sendInitialTx(
 			return errors.Wrap(err, "TxManager#sendInitialTx CreateTx")
 		}
 
+		logger.Debugw(fmt.Sprintf("Adding Tx attempt #%d", 0), "txID", tx.ID)
+
 		_, err = txm.SendRawTx(tx.SignedRawTx)
 		if err != nil {
 			return errors.Wrap(err, "TxManager#sendInitialTx SendRawTx")

--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -455,8 +455,7 @@ func (txm *EthTxManager) CheckAttempt(txAttempt *models.TxAttempt, blockHeight u
 	}
 
 	minimumConfirmations := new(big.Int).SetUint64(txm.config.MinOutgoingConfirmations())
-	confirmedAt := big.NewInt(0).
-		Add(minimumConfirmations, receipt.BlockNumber.ToInt())
+	confirmedAt := new(big.Int).Add(minimumConfirmations, receipt.BlockNumber.ToInt())
 
 	// 0 based indexing since receipt is 1 conf
 	confirmedAt.Sub(confirmedAt, big.NewInt(1))

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -437,7 +437,7 @@ func TestTxManager_BumpGasUntilSafe_confirmed_lessThanGasThreshold(t *testing.T)
 
 	receipt, err := txm.BumpGasUntilSafe(tx.Attempts[0].Hash)
 	assert.NoError(t, err)
-	assert.Nil(t, receipt)
+	assert.NotNil(t, receipt)
 
 	tx, err = store.FindTx(tx.ID)
 	require.NoError(t, err)

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -327,12 +327,10 @@ func TestTxManager_BumpGasUntilSafe_lessThanGasBumpThreshold(t *testing.T) {
 	tx := cltest.CreateTx(t, store, from, sentAt)
 	require.Greater(t, len(tx.Attempts), 0)
 
-	a := tx.Attempts[0]
-
 	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{})
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(gasThreshold-1))
 
-	receipt, err := txm.BumpGasUntilSafe(a.Hash)
+	receipt, err := txm.BumpGasUntilSafe(tx.Attempts[0].Hash)
 	assert.NoError(t, err)
 	assert.Nil(t, receipt)
 
@@ -363,13 +361,11 @@ func TestTxManager_BumpGasUntilSafe_atGasBumpThreshold(t *testing.T) {
 	tx := cltest.CreateTx(t, store, from, sentAt)
 	require.Greater(t, len(tx.Attempts), 0)
 
-	a := tx.Attempts[0]
-
-	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{})
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(gasThreshold))
+	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{})
 	ethMock.Register("eth_sendRawTransaction", cltest.NewHash())
 
-	receipt, err := txm.BumpGasUntilSafe(a.Hash)
+	receipt, err := txm.BumpGasUntilSafe(tx.Attempts[0].Hash)
 	assert.NoError(t, err)
 	assert.Nil(t, receipt)
 
@@ -400,13 +396,11 @@ func TestTxManager_BumpGasUntilSafe_exceedsGasBumpThreshold(t *testing.T) {
 	tx := cltest.CreateTx(t, store, from, sentAt)
 	require.Greater(t, len(tx.Attempts), 0)
 
-	a := tx.Attempts[0]
-
-	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{})
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(gasThreshold+1))
+	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{})
 	ethMock.Register("eth_sendRawTransaction", cltest.NewHash())
 
-	receipt, err := txm.BumpGasUntilSafe(a.Hash)
+	receipt, err := txm.BumpGasUntilSafe(tx.Attempts[0].Hash)
 	assert.NoError(t, err)
 	assert.Nil(t, receipt)
 
@@ -438,12 +432,10 @@ func TestTxManager_BumpGasUntilSafe_confirmed_lessThanGasThreshold(t *testing.T)
 	tx := cltest.CreateTx(t, store, from, sentAt)
 	require.Greater(t, len(tx.Attempts), 0)
 
-	a := tx.Attempts[0]
-
-	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{Hash: cltest.NewHash(), BlockNumber: cltest.Int(gasThreshold)})
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(gasThreshold+minConfs-1))
+	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{Hash: cltest.NewHash(), BlockNumber: cltest.Int(gasThreshold)})
 
-	receipt, err := txm.BumpGasUntilSafe(a.Hash)
+	receipt, err := txm.BumpGasUntilSafe(tx.Attempts[0].Hash)
 	assert.NoError(t, err)
 	assert.Nil(t, receipt)
 
@@ -475,14 +467,12 @@ func TestTxManager_BumpGasUntilSafe_confirmed_atGasBumpThreshold(t *testing.T) {
 	tx := cltest.CreateTx(t, store, from, sentAt)
 	require.Greater(t, len(tx.Attempts), 0)
 
-	a := tx.Attempts[0]
-
-	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{Hash: cltest.NewHash(), BlockNumber: cltest.Int(gasThreshold)})
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(gasThreshold+minConfs))
+	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{Hash: cltest.NewHash(), BlockNumber: cltest.Int(gasThreshold)})
 	ethMock.Register("eth_getBalance", "0x100")
 	ethMock.Register("eth_call", "0x100")
 
-	receipt, err := txm.BumpGasUntilSafe(a.Hash)
+	receipt, err := txm.BumpGasUntilSafe(tx.Attempts[0].Hash)
 	assert.NoError(t, err)
 	assert.NotNil(t, receipt)
 
@@ -514,14 +504,12 @@ func TestTxManager_BumpGasUntilSafe_confirmed_exceedsGasBumpThreshold(t *testing
 	tx := cltest.CreateTx(t, store, from, sentAt)
 	require.Greater(t, len(tx.Attempts), 0)
 
-	a := tx.Attempts[0]
-
-	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{Hash: cltest.NewHash(), BlockNumber: cltest.Int(gasThreshold)})
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(gasThreshold+minConfs+1))
+	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{Hash: cltest.NewHash(), BlockNumber: cltest.Int(gasThreshold)})
 	ethMock.Register("eth_getBalance", "0x100")
 	ethMock.Register("eth_call", "0x100")
 
-	receipt, err := txm.BumpGasUntilSafe(a.Hash)
+	receipt, err := txm.BumpGasUntilSafe(tx.Attempts[0].Hash)
 	assert.NoError(t, err)
 	assert.NotNil(t, receipt)
 
@@ -826,8 +814,7 @@ func TestTxManager_LogsETHAndLINKBalancesAfterSuccessfulTx(t *testing.T) {
 		ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce))
 		ethMock.Register("eth_sendRawTransaction", hash)
 		ethMock.Register("eth_getTransactionReceipt", confirmedReceipt)
-		ethMock.Register("eth_blockNumber", utils.Uint64ToHex(
-			confirmedHeight))
+		ethMock.Register("eth_blockNumber", utils.Uint64ToHex(confirmedHeight))
 		ethMock.Register("eth_getBalance", mockedEthBalance)
 		ethMock.Register("eth_call", mockedLinkBalance)
 	})
@@ -849,7 +836,10 @@ func TestTxManager_LogsETHAndLINKBalancesAfterSuccessfulTx(t *testing.T) {
 		messages = append(messages, log.Message)
 	}
 
-	assert.Contains(t, messages, "Tx #0 checking for minimum of 6 confirmations")
+	assert.Contains(t, messages, "Tx #0 checking on-chain state")
+	assert.Contains(t, messages, "Tx #0 is safe")
+	// This message includes the amounts
+	assert.Contains(t, messages, "Tx #0 got minimum confirmations (6)")
 }
 
 func TestTxManager_CreateTxWithGas(t *testing.T) {


### PR DESCRIPTION
The initial phase of the EthTx adapter creates a transaction, then attempts to do gas bumping on it.

Gas Bumping is never needed on the initial transaction so half of this code is redundant, and because the existing records/information is not pushed into the BumpGasUntilSafe method, which is meant to be used with a freshly retrieved Tx, it creates a lot of redundant work. BumpGasUntilSafe actually needing to do any work in real life is highly unlikely, so I have optimised this path: instead just check for a receipt on the odd chance that the chain was quick to accept.

Full list of changes:
 * CheckAttempt has no side effects, and clearly indicates the states of a TxAttempt, this can now more easily be unit tested.
 * processAttempt (previously checkAttempt) now does all the work of gas bumping retrying etc. The logic of this code is far easier to understand now because the logic for determining state is no peppered in together.
 * BumpGasUntilSafe/CheckAttempt always return a receipt if one was retrieved, this makes them safer to use - the logic for using them can be simplified
 * BumpGasUntilSafe also now returns a state, and always returns a receipt (because it uses CheckAttempt which does the same) which means we can distinguish between fatal errors and just receipt retrieval errors, which we choose to ignore so that attempts can be checked again for the next head