### PR TITLE
Make sure Gas Bumping is only done on the last attempt

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -108,20 +108,37 @@ func TestIntegration_FeeBump(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	config := app.Config
-	eth := app.MockEthClient(cltest.Strict)
+
+	// Put some distance between these two values so we can explore more of the state space
+	config.Set("ETH_GAS_BUMP_THRESHOLD", 10)
+	config.Set("MIN_OUTGOING_CONFIRMATIONS", 20)
+
+	attempt1Hash := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001")
+	attempt2Hash := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002")
+	attempt3Hash := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000003")
+
+	unconfirmedReceipt := models.TxReceipt{}
+
+	// Enumerate the different block heights at which various state changes
+	// happen for the transaction attempts created during this test
+	firstTxSentAt := uint64(23456)
+	firstTxGasBumpAt := firstTxSentAt + config.EthGasBumpThreshold()
+	firstTxRemainsUnconfirmedAt := firstTxGasBumpAt - 1
+
+	secondTxSentAt := firstTxGasBumpAt
+	secondTxGasBumpAt := secondTxSentAt + config.EthGasBumpThreshold()
+	secondTxRemainsUnconfirmedAt := secondTxGasBumpAt - 1
+
+	thirdTxSentAt := secondTxGasBumpAt
+	thirdTxConfirmedAt := thirdTxSentAt + 1
+	thirdTxConfirmedReceipt := models.TxReceipt{
+		Hash:        attempt1Hash,
+		BlockNumber: cltest.Int(thirdTxConfirmedAt),
+	}
+	thirdTxSafeAt := thirdTxSentAt + config.MinOutgoingConfirmations()
 
 	newHeads := make(chan models.BlockHeader)
-	attempt1Hash := common.HexToHash("0xb7862c896a6ba2711bccc0410184e46d793ea83b3e05470f1d359ea276d16bb5")
-	attempt2Hash := common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002")
-	sentAt := uint64(23456)
-	confirmed := sentAt + config.EthGasBumpThreshold() + 1
-	safe := confirmed + config.MinOutgoingConfirmations() - 1
-	unconfirmedReceipt := models.TxReceipt{}
-	confirmedReceipt := models.TxReceipt{
-		Hash:        attempt1Hash,
-		BlockNumber: cltest.Int(confirmed),
-	}
-
+	eth := app.MockEthClient(cltest.Strict)
 	eth.Context("app.Start()", func(eth *cltest.EthMock) {
 		eth.RegisterSubscription("newHeads", newHeads)
 		eth.Register("eth_getTransactionCount", `0x0100`) // TxManager.ActivateAccount()
@@ -129,9 +146,11 @@ func TestIntegration_FeeBump(t *testing.T) {
 	assert.NoError(t, app.Start())
 	eth.EventuallyAllCalled(t)
 
-	eth.Context("ethTx.Perform()#1 at block 23456", func(eth *cltest.EthMock) {
-		eth.Register("eth_blockNumber", utils.Uint64ToHex(sentAt))
-		eth.Register("eth_sendRawTransaction", attempt1Hash) // Initial tx attempt sent
+	// This first run of the EthTx adapter creates an initial transaction which
+	// starts unconfirmed
+	eth.Context("ethTx.Perform()#1", func(eth *cltest.EthMock) {
+		eth.Register("eth_blockNumber", utils.Uint64ToHex(firstTxSentAt))
+		eth.Register("eth_sendRawTransaction", attempt1Hash)
 		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
 	})
 	j := cltest.CreateHelloWorldJobViaWeb(t, app, mockServer.URL)
@@ -139,37 +158,77 @@ func TestIntegration_FeeBump(t *testing.T) {
 	eth.EventuallyAllCalled(t)
 	cltest.WaitForTxAttemptCount(t, app.Store, 1)
 
-	eth.Context("ethTx.Perform()#2 at block 23459", func(eth *cltest.EthMock) {
-		eth.Register("eth_blockNumber", utils.Uint64ToHex(confirmed-1))
+	// At the next head, the transaction is still unconfirmed, but no thresholds
+	// have been met so we just wait...
+	eth.Context("ethTx.Perform()#2", func(eth *cltest.EthMock) {
+		eth.Register("eth_blockNumber", utils.Uint64ToHex(firstTxRemainsUnconfirmedAt))
 		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
-		eth.Register("eth_sendRawTransaction", attempt2Hash) // Gas bumped tx attempt sent
 	})
-	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(confirmed - 1)} // 23459: For Gas Bump
+	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(firstTxRemainsUnconfirmedAt)}
+	eth.EventuallyAllCalled(t)
+	jr = cltest.WaitForJobRunToPendConfirmations(t, app.Store, jr)
+
+	// At the next head, the transaction remains unconfirmed but the gas bump
+	// threshold has been met, so a new transaction is made with a higher amount
+	// of gas ("bumped gas")
+	eth.Context("ethTx.Perform()#3", func(eth *cltest.EthMock) {
+		eth.Register("eth_blockNumber", utils.Uint64ToHex(firstTxGasBumpAt))
+		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
+		eth.Register("eth_sendRawTransaction", attempt2Hash)
+	})
+	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(firstTxGasBumpAt)}
 	eth.EventuallyAllCalled(t)
 	jr = cltest.WaitForJobRunToPendConfirmations(t, app.Store, jr)
 	cltest.WaitForTxAttemptCount(t, app.Store, 2)
 
-	eth.Context("ethTx.Perform()#3 at block 23460", func(eth *cltest.EthMock) {
-		eth.Register("eth_blockNumber", utils.Uint64ToHex(confirmed))
+	// Another head comes in and both transactions are still unconfirmed, more
+	// waiting...
+	eth.Context("ethTx.Perform()#4", func(eth *cltest.EthMock) {
+		eth.Register("eth_blockNumber", utils.Uint64ToHex(secondTxRemainsUnconfirmedAt))
 		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
-		eth.Register("eth_getTransactionReceipt", confirmedReceipt)
+		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
 	})
-	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(confirmed)} // 23460
+	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(secondTxRemainsUnconfirmedAt)}
 	eth.EventuallyAllCalled(t)
 	jr = cltest.WaitForJobRunToPendConfirmations(t, app.Store, jr)
-	cltest.WaitForTxAttemptCount(t, app.Store, 2)
 
-	eth.Context("ethTx.Perform()#4 at block 23465", func(eth *cltest.EthMock) {
-		eth.Register("eth_blockNumber", utils.Uint64ToHex(safe))
+	// Now the second transaction attempt meets the gas bump threshold, so a
+	// final transaction attempt shoud be made
+	eth.Context("ethTx.Perform()#5", func(eth *cltest.EthMock) {
+		eth.Register("eth_blockNumber", utils.Uint64ToHex(secondTxGasBumpAt))
 		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
-		eth.Register("eth_getTransactionReceipt", confirmedReceipt) // confirmed for gas bumped txat
-		eth.Register("eth_getBalance", "0x0100")
-		eth.Register("eth_call", "0x0100")
+		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
+		eth.Register("eth_sendRawTransaction", attempt3Hash)
 	})
-	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(safe)} // 23465
+	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(secondTxGasBumpAt)}
 	eth.EventuallyAllCalled(t)
-	cltest.WaitForTxAttemptCount(t, app.Store, 2)
+	jr = cltest.WaitForJobRunToPendConfirmations(t, app.Store, jr)
+	cltest.WaitForTxAttemptCount(t, app.Store, 3)
 
+	// This third attempt has enough gas and gets confirmed, but has not yet
+	// received sufficient confirmations, so we wait again...
+	eth.Context("ethTx.Perform()#6", func(eth *cltest.EthMock) {
+		eth.Register("eth_blockNumber", utils.Uint64ToHex(thirdTxConfirmedAt))
+		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
+		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
+		eth.Register("eth_getTransactionReceipt", thirdTxConfirmedReceipt)
+	})
+	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(thirdTxConfirmedAt)}
+	eth.EventuallyAllCalled(t)
+	jr = cltest.WaitForJobRunToPendConfirmations(t, app.Store, jr)
+
+	// Finally the third attempt gets to a minimum number of safe confirmations,
+	// the amount remaining in the account is printed (eth_getBalance, eth_call)
+	eth.Context("ethTx.Perform()#7", func(eth *cltest.EthMock) {
+		eth.Register("eth_blockNumber", utils.Uint64ToHex(thirdTxSafeAt))
+		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
+		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
+		eth.Register("eth_getTransactionReceipt", thirdTxConfirmedReceipt)
+		eth.Register("eth_getBalance", "0x100")
+		eth.Register("eth_call", "0x100")
+	})
+	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(thirdTxSafeAt)}
+	eth.EventuallyAllCalled(t)
 	jr = cltest.WaitForJobRunToComplete(t, app.Store, jr)
 
 	val, err := jr.TaskRuns[0].Result.ResultString()
@@ -185,8 +244,6 @@ func TestIntegration_FeeBump(t *testing.T) {
 	assert.Equal(t, attempt1Hash.String(), val)
 	assert.NoError(t, err)
 	assert.Equal(t, jr.Result.CachedJobRunID, jr.ID)
-
-	eth.EventuallyAllCalled(t)
 }
 
 func TestIntegration_RunAt(t *testing.T) {

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -152,25 +152,23 @@ func TestIntegration_FeeBump(t *testing.T) {
 	eth.Context("ethTx.Perform()#3 at block 23460", func(eth *cltest.EthMock) {
 		eth.Register("eth_blockNumber", utils.Uint64ToHex(confirmed))
 		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
-		eth.Register("eth_sendRawTransaction", attempt2Hash)
 		eth.Register("eth_getTransactionReceipt", confirmedReceipt)
 	})
 	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(confirmed)} // 23460
 	eth.EventuallyAllCalled(t)
 	jr = cltest.WaitForJobRunToPendConfirmations(t, app.Store, jr)
-	cltest.WaitForTxAttemptCount(t, app.Store, 3)
+	cltest.WaitForTxAttemptCount(t, app.Store, 2)
 
 	eth.Context("ethTx.Perform()#4 at block 23465", func(eth *cltest.EthMock) {
 		eth.Register("eth_blockNumber", utils.Uint64ToHex(safe))
 		eth.Register("eth_getTransactionReceipt", unconfirmedReceipt)
 		eth.Register("eth_getTransactionReceipt", confirmedReceipt) // confirmed for gas bumped txat
-		eth.Register("eth_sendRawTransaction", attempt2Hash)
 		eth.Register("eth_getBalance", "0x0100")
 		eth.Register("eth_call", "0x0100")
 	})
 	newHeads <- models.BlockHeader{Number: cltest.BigHexInt(safe)} // 23465
 	eth.EventuallyAllCalled(t)
-	cltest.WaitForTxAttemptCount(t, app.Store, 4)
+	cltest.WaitForTxAttemptCount(t, app.Store, 2)
 
 	jr = cltest.WaitForJobRunToComplete(t, app.Store, jr)
 

--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -105,10 +105,11 @@ func (tx *Tx) String() string {
 // for the first time
 func (tx *Tx) AfterCreate(db *gorm.DB) (err error) {
 	attempt := TxAttempt{
-		TxID:     tx.ID,
-		Hash:     tx.Hash,
-		GasPrice: tx.GasPrice,
-		SentAt:   tx.SentAt,
+		TxID:        tx.ID,
+		Hash:        tx.Hash,
+		GasPrice:    tx.GasPrice,
+		SentAt:      tx.SentAt,
+		SignedRawTx: tx.SignedRawTx,
 	}
 	tx.Attempts = []*TxAttempt{&attempt}
 	return db.Create(&attempt).Error
@@ -132,8 +133,11 @@ func (tx Tx) EthTx(gasPriceWei *big.Int) *types.Transaction {
 // it so that if the network is busy, a transaction can be
 // resubmitted with a higher GasPrice.
 type TxAttempt struct {
-	ID        uint64    `gorm:"primary_key;auto_increment"`
-	TxID      uint64    `gorm:"index;type:bigint REFERENCES txes(id) ON DELETE CASCADE"`
+	ID uint64 `gorm:"primary_key;auto_increment"`
+
+	TxID uint64 `gorm:"index;type:bigint REFERENCES txes(id) ON DELETE CASCADE"`
+	Tx   *Tx    `json:"-" gorm:"PRELOAD:false;foreignkey:TxID"`
+
 	CreatedAt time.Time `gorm:"index;not null"`
 
 	Hash        common.Hash `gorm:"index;not null"`

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -511,6 +511,28 @@ func NewTx(tx *models.Tx) Tx {
 	}
 }
 
+// NewTxFromAttempt builds a transaction presenter from a TxAttempt
+//
+// models.Tx represents a transaction in progress, with a series of
+// models.TxAttempts, each one of these represents an ethereum transaction. A
+// TxAttempt only stores the unique details of an ethereum transaction, with
+// the rest of the details on its related Tx.
+//
+// So for presenting a TxAttempt, we take its Hash, GasPrice etc. and get the
+// rest of the details from its Tx.
+//
+// NOTE: We take a copy here as we don't want side effects.
+//
+func NewTxFromAttempt(txAttempt models.TxAttempt) Tx {
+	tx := txAttempt.Tx
+	tx.Hash = txAttempt.Hash
+	tx.GasPrice = txAttempt.GasPrice
+	tx.Confirmed = txAttempt.Confirmed
+	tx.SentAt = txAttempt.SentAt
+	tx.SignedRawTx = txAttempt.SignedRawTx
+	return NewTx(tx)
+}
+
 // GetID returns the jsonapi ID.
 func (t Tx) GetID() string {
 	return t.Hash.String()

--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -363,7 +363,7 @@ func (txm *EthTxManager) BumpGasUntilSafe(hash common.Hash) (*models.TxReceipt, 
 	if err != nil {
 		return nil, Unknown, errors.Wrap(err, "BumpGasUntilSafe getBlockNumber")
 	}
-	tx, err := txm.orm.FindTxByAttempt(hash)
+	tx, _, err := txm.orm.FindTxByAttempt(hash)
 	if err != nil {
 		return nil, Unknown, errors.Wrap(err, "BumpGasUntilSafe FindTxByAttempt")
 	}

--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -539,6 +539,11 @@ func (txm *EthTxManager) processAttempt(
 
 	case Unconfirmed:
 		if isLatestAttempt(tx, attemptIndex) && txm.hasTxAttemptMetGasBumpThreshold(tx, attemptIndex, blockHeight) {
+			logger.Debugw(
+				fmt.Sprintf("Tx #%d has met gas bump threshold, bumping gas", attemptIndex),
+				"txHash", txAttempt.Hash.String(),
+				"txID", txAttempt.TxID,
+			)
 			err = txm.bumpGas(tx, attemptIndex, blockHeight)
 		}
 

--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -538,7 +538,7 @@ func (txm *EthTxManager) processAttempt(
 		return receipt, state, nil
 
 	case Unconfirmed:
-		if isLatestAttempt(tx, txAttempt) && txm.hasTxAttemptMetGasBumpThreshold(tx, attemptIndex, blockHeight) {
+		if isLatestAttempt(tx, attemptIndex) && txm.hasTxAttemptMetGasBumpThreshold(tx, attemptIndex, blockHeight) {
 			err = txm.bumpGas(tx, attemptIndex, blockHeight)
 		}
 
@@ -565,8 +565,8 @@ func (txm *EthTxManager) hasTxAttemptMetGasBumpThreshold(
 // isLatestAttempt returns true only if the attempt is the last
 // attempt associated with the transaction, alluding to the fact that
 // it has the highest gas price after subsequent bumps.
-func isLatestAttempt(tx *models.Tx, txAttempt *models.TxAttempt) bool {
-	return tx.Hash == txAttempt.Hash
+func isLatestAttempt(tx *models.Tx, attemptIndex int) bool {
+	return attemptIndex+1 == len(tx.Attempts)
 }
 
 // handleSafe marks a transaction as safe, no more work needs to be done

--- a/core/web/transactions_controller.go
+++ b/core/web/transactions_controller.go
@@ -1,11 +1,11 @@
 package web
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/services"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
 	"github.com/smartcontractkit/chainlink/core/store/presenters"
@@ -32,11 +32,11 @@ func (tc *TransactionsController) Index(c *gin.Context, size, page, offset int) 
 //  "<application>/transactions/:TxHash"
 func (tc *TransactionsController) Show(c *gin.Context) {
 	hash := common.HexToHash(c.Param("TxHash"))
-	if tx, err := tc.App.GetStore().FindTxByAttempt(hash); err == orm.ErrorNotFound {
+	if txAttempt, err := tc.App.GetStore().FindTxAttempt(hash); errors.Cause(err) == orm.ErrorNotFound {
 		jsonAPIError(c, http.StatusNotFound, errors.New("Transaction not found"))
 	} else if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 	} else {
-		jsonAPIResponse(c, presenters.NewTx(tx), "transaction")
+		jsonAPIResponse(c, presenters.NewTxFromAttempt(*txAttempt), "transaction")
 	}
 }


### PR DESCRIPTION
Both the implementation of `isLatestAttempt` and the ... uncertainty around the FeeBump test have always bothered me, and the recent improvements to the TxManager gave me more clarity. How can Perform()#3 possibly work in the FeeBump test? Couldn't `isLatestAttempt` potentially lie?

Yes to both.

Whenever we resume an EthTx run, we find the transaction it is responsible for by the hash of the initial attempt. `FindByTxAttempt` then puts the values from this attempt onto the `Tx` record. Meaning that the `Tx`'s Hash is always set to the first `TxAttempt`'s Hash.

    func isLatestAttempt(tx *models.Tx, txAttempt *models.TxAttempt) bool {
        return tx.Hash == txAttempt.Hash
    }

This means that the first TxAttempt is always considered the last TxAttempt and in times of network congestion, this could cause more TxAttempts to be made than desired, as the gas bump won't have any affect.

Solutions:

  1. `FindTxByAttempt` no longer saves the details for the `TxAttempt` onto its `Tx`, that logic has been moved into the presenter
  2. `isLatestAttempt` checks the index of the attempt rather than the hash, personally I think this is clearer and is harder to break
  3. The `FeeBump` test now has 7 stages and now accurately reflects the correct number of attempts that should be made.

[Fixes #166562945]