### PR TITLE
Handle eth non fatal errors more appropriately in eth tx initial phase

### DIFF
--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -7,7 +7,9 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/store"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
@@ -197,6 +199,10 @@ var (
 	clientRetryableErrorRegex = regexp.MustCompile("connection timed out")
 )
 
+// isClientRetriable does its best effort to see if an error indicates one that
+// might have a different outcome if we retried the operation
 func isClientRetriable(err error) bool {
-	return err != nil && clientRetryableErrorRegex.MatchString(err.Error())
+	return err != nil &&
+		(errors.Cause(err) == store.ErrPendingConnection ||
+			clientRetryableErrorRegex.MatchString(err.Error()))
 }

--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -111,7 +111,10 @@ func createTxRunResult(
 	)
 
 	receipt, state, err := store.TxManager.CheckAttempt(txAttempt, tx.SentAt)
-	if err != nil {
+	if isClientRetriable(err) {
+		input.MarkPendingConnection()
+		return
+	} else if err != nil {
 		input.SetError(err)
 		return
 	}
@@ -196,7 +199,7 @@ func addReceiptToResult(receipt *models.TxReceipt, in *models.RunResult) {
 }
 
 var (
-	clientRetryableErrorRegex = regexp.MustCompile("connection timed out")
+	clientRetryableErrorRegex = regexp.MustCompile("(connection timed out|connection reset by peer)")
 )
 
 // isClientRetriable does its best effort to see if an error indicates one that

--- a/core/services/job_subscriber.go
+++ b/core/services/job_subscriber.go
@@ -111,7 +111,7 @@ func (js *jobSubscriber) OnNewHead(head *models.Head) {
 			logger.Errorf("JobSubscriber.OnNewHead: %v", err)
 		}
 
-	}, models.RunStatusPendingConfirmations)
+	}, models.RunStatusPendingConnection, models.RunStatusPendingConfirmations)
 
 	if err != nil {
 		logger.Errorf("error fetching pending job runs: %v", err)

--- a/core/services/job_subscriber_test.go
+++ b/core/services/job_subscriber_test.go
@@ -206,7 +206,7 @@ func sendingOnClosedChannel(callback func()) (rval bool) {
 	return false
 }
 
-func TestJobSubscriber_OnNewHead_OnlyResumePendingConfirmations(t *testing.T) {
+func TestJobSubscriber_OnNewHead_ResumePendingConfirmationsAndPendingConnections(t *testing.T) {
 	t.Parallel()
 
 	block := cltest.NewBlockHeader(10)
@@ -222,6 +222,8 @@ func TestJobSubscriber_OnNewHead_OnlyResumePendingConfirmations(t *testing.T) {
 		archived bool
 		wantSend bool
 	}{
+		{models.RunStatusPendingConnection, false, true},
+		{models.RunStatusPendingConnection, true, true},
 		{models.RunStatusPendingConfirmations, false, true},
 		{models.RunStatusPendingConfirmations, true, true},
 		{models.RunStatusInProgress, false, false},

--- a/core/services/runs.go
+++ b/core/services/runs.go
@@ -148,7 +148,7 @@ func ResumeConfirmingTask(
 
 	logger.Debugw("New head resuming run", run.ForLogger()...)
 
-	if !run.Status.PendingConfirmations() {
+	if !run.Status.PendingConfirmations() && !run.Status.PendingConnection() {
 		return fmt.Errorf("Attempt to resume non confirming task")
 	}
 


### PR DESCRIPTION
In the initial phase of the EthTx adapter, we perform a number of RPC calls to our ethereum client, that could fail, that we might not want to consider terminal, e.g:

  * Connection timed out
  * Connection reset by peer

We should attempt to detect these and instead of marking the task run as failed, mark is as "retriable". This might mean "pending_connection" or otherwise...