### PR TITLE
Add ExtendedPath to HTTP adapters

### DIFF
--- a/core/adapters/http.go
+++ b/core/adapters/http.go
@@ -100,9 +100,7 @@ func (hpa *HTTPPost) GetRequest(body string) (*http.Request, error) {
 }
 
 func appendExtendedPath(request *http.Request, extPath ExtendedPath) {
-	for _, element := range extPath {
-		request.URL.Path = path.Join(request.URL.Path, element)
-	}
+	request.URL.Path = path.Join(append([]string{request.URL.Path}, []string(extPath)...)...)
 }
 
 func appendQueryParams(request *http.Request, queryParams QueryParameters) {

--- a/core/adapters/http.go
+++ b/core/adapters/http.go
@@ -19,11 +19,11 @@ import (
 
 // HTTPGet requires a URL which is used for a GET request when the adapter is called.
 type HTTPGet struct {
-	URL         models.WebURL   `json:"url"`
-	GET         models.WebURL   `json:"get"`
-	Headers     http.Header     `json:"headers"`
-	QueryParams QueryParameters `json:"queryParams"`
-	ExtPath     ExtendedPath    `json:"extPath"`
+	URL          models.WebURL   `json:"url"`
+	GET          models.WebURL   `json:"get"`
+	Headers      http.Header     `json:"headers"`
+	QueryParams  QueryParameters `json:"queryParams"`
+	ExtendedPath ExtendedPath    `json:"extPath"`
 }
 
 // Perform ensures that the adapter's URL responds to a GET request without
@@ -51,7 +51,7 @@ func (hga *HTTPGet) GetRequest() (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	appendExtendedPath(request, hga.ExtPath)
+	appendExtendedPath(request, hga.ExtendedPath)
 	appendQueryParams(request, hga.QueryParams)
 	setHeaders(request, hga.Headers, "")
 	return request, nil
@@ -59,11 +59,11 @@ func (hga *HTTPGet) GetRequest() (*http.Request, error) {
 
 // HTTPPost requires a URL which is used for a POST request when the adapter is called.
 type HTTPPost struct {
-	URL         models.WebURL   `json:"url"`
-	POST        models.WebURL   `json:"post"`
-	Headers     http.Header     `json:"headers"`
-	QueryParams QueryParameters `json:"queryParams"`
-	ExtPath     ExtendedPath    `json:"extPath"`
+	URL          models.WebURL   `json:"url"`
+	POST         models.WebURL   `json:"post"`
+	Headers      http.Header     `json:"headers"`
+	QueryParams  QueryParameters `json:"queryParams"`
+	ExtendedPath ExtendedPath    `json:"extPath"`
 }
 
 // Perform ensures that the adapter's URL responds to a POST request without
@@ -93,7 +93,7 @@ func (hpa *HTTPPost) GetRequest(body string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	appendExtendedPath(request, hpa.ExtPath)
+	appendExtendedPath(request, hpa.ExtendedPath)
 	appendQueryParams(request, hpa.QueryParams)
 	setHeaders(request, hpa.Headers, "application/json")
 	return request, nil

--- a/core/adapters/http_test.go
+++ b/core/adapters/http_test.go
@@ -410,28 +410,28 @@ func TestExtendedPath(t *testing.T) {
 			ep := adapters.ExtendedPath{}
 			err := json.Unmarshal([]byte(test.path), &ep)
 			hga := adapters.HTTPGet{
-				URL:     cltest.WebURL(t, test.startingUrl),
-				ExtPath: ep,
+				URL:          cltest.WebURL(t, test.startingUrl),
+				ExtendedPath: ep,
 			}
 			hpa := adapters.HTTPPost{
-				URL:     cltest.WebURL(t, test.startingUrl),
-				ExtPath: ep,
+				URL:          cltest.WebURL(t, test.startingUrl),
+				ExtendedPath: ep,
 			}
 			if test.wantErrored {
 				requestGET, _ := hga.GetRequest()
 				assert.Equal(t, test.expectedURL, requestGET.URL.String())
-				assert.Equal(t, test.expectedPath, hga.ExtPath)
+				assert.Equal(t, test.expectedPath, hga.ExtendedPath)
 				requestPOST, _ := hpa.GetRequest("")
 				assert.Equal(t, test.expectedURL, requestPOST.URL.String())
-				assert.Equal(t, test.expectedPath, hpa.ExtPath)
+				assert.Equal(t, test.expectedPath, hpa.ExtendedPath)
 				assert.NotNil(t, err)
 			} else {
 				requestGET, _ := hga.GetRequest()
 				assert.Equal(t, test.expectedURL, requestGET.URL.String())
-				assert.Equal(t, test.expectedPath, hga.ExtPath)
+				assert.Equal(t, test.expectedPath, hga.ExtendedPath)
 				requestPOST, _ := hpa.GetRequest("")
 				assert.Equal(t, test.expectedURL, requestPOST.URL.String())
-				assert.Equal(t, test.expectedPath, hpa.ExtPath)
+				assert.Equal(t, test.expectedPath, hpa.ExtendedPath)
 				assert.Nil(t, err)
 			}
 		})
@@ -509,14 +509,14 @@ func TestHTTP_BuildingURL(t *testing.T) {
 			err := json.Unmarshal([]byte(test.path), &ep)
 			err = json.Unmarshal([]byte(test.queryParams), &qp)
 			hga := adapters.HTTPGet{
-				URL:         cltest.WebURL(t, test.startingUrl),
-				QueryParams: qp,
-				ExtPath:     ep,
+				URL:          cltest.WebURL(t, test.startingUrl),
+				QueryParams:  qp,
+				ExtendedPath: ep,
 			}
 			hpa := adapters.HTTPPost{
-				URL:         cltest.WebURL(t, test.startingUrl),
-				QueryParams: qp,
-				ExtPath:     ep,
+				URL:          cltest.WebURL(t, test.startingUrl),
+				QueryParams:  qp,
+				ExtendedPath: ep,
 			}
 			requestGET, _ := hga.GetRequest()
 			assert.Equal(t, test.expectedURL, requestGET.URL.String())

--- a/core/adapters/http_test.go
+++ b/core/adapters/http_test.go
@@ -28,8 +28,7 @@ func TestHttpAdapters_NotAUrlError(t *testing.T) {
 		{"HTTPPost", &adapters.HTTPPost{URL: cltest.WebURL(t, "NotAURL")}},
 	}
 
-	for _, tt := range tests {
-		test := tt
+	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			result := test.adapter.Perform(models.RunResult{}, store)
 			assert.Equal(t, models.JSON{}, result.Data)
@@ -68,8 +67,7 @@ func TestHTTPGet_Perform(t *testing.T) {
 			}},
 	}
 
-	for _, tt := range cases {
-		test := tt
+	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			input := cltest.RunResultWithResult("inputValue")
 			mock, cleanup := cltest.NewHTTPMockServer(t, test.status, "GET", test.response,
@@ -157,8 +155,7 @@ func TestHttpPost_Perform(t *testing.T) {
 			}},
 	}
 
-	for _, tt := range cases {
-		test := tt
+	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			input := cltest.RunResultWithResult("inputVal")
 			wantedBody := `{"result":"inputVal"}`
@@ -249,8 +246,7 @@ func TestQueryParameters_Success(t *testing.T) {
 		},
 	}
 
-	for _, tt := range cases {
-		test := tt
+	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			qp := adapters.QueryParameters{}
 			err := json.Unmarshal([]byte(test.queryParams), &qp)
@@ -301,8 +297,7 @@ func TestQueryParameters_Error(t *testing.T) {
 		},
 	}
 
-	for _, tt := range cases {
-		test := tt
+	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			qp := adapters.QueryParameters{}
 			err := json.Unmarshal([]byte(test.queryParams), &qp)
@@ -408,8 +403,7 @@ func TestExtendedPath_Success(t *testing.T) {
 		},
 	}
 
-	for _, tt := range cases {
-		test := tt
+	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			ep := adapters.ExtendedPath{}
 			err := json.Unmarshal([]byte(test.path), &ep)
@@ -453,8 +447,7 @@ func TestExtendedPath_Error(t *testing.T) {
 		},
 	}
 
-	for _, tt := range cases {
-		test := tt
+	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			ep := adapters.ExtendedPath{}
 			err := json.Unmarshal([]byte(test.path), &ep)
@@ -541,8 +534,7 @@ func TestHTTP_BuildingURL(t *testing.T) {
 		},
 	}
 
-	for _, tt := range cases {
-		test := tt
+	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
 			ep := adapters.ExtendedPath{}
 			qp := adapters.QueryParameters{}


### PR DESCRIPTION
Should make [discussion](https://www.pivotaltracker.com/story/show/166675824) a bit easier. Built out of necessity.