### PR TITLE
Silence console in explorer tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -240,7 +240,7 @@ jobs:
           command: yarn test-ci:silent
       - run:
           name: Run Client Tests
-          command: cd client && yarn test-ci
+          command: cd client && yarn test-ci:silent
       - run:
           name: Run E2E Tests
           command: cd client && yarn build && cd .. && yarn test-ci:e2e:silent

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -237,13 +237,13 @@ jobs:
           command: yarn lint
       - run:
           name: Run Server Tests
-          command: yarn test-ci
+          command: yarn test-ci:silent
       - run:
           name: Run Client Tests
           command: cd client && yarn test-ci
       - run:
           name: Run E2E Tests
-          command: cd client && yarn build && cd .. && yarn test-ci:e2e
+          command: cd client && yarn build && cd .. && yarn test-ci:e2e:silent
   build-explorer-image:
     machine: true
     steps:

--- a/explorer/client/package.json
+++ b/explorer/client/package.json
@@ -19,6 +19,7 @@
     "lint": "eslint . --color",
     "test": "react-scripts test",
     "test-ci": "CI=true react-scripts test",
+    "test-ci:silent": "yarn test-ci --silent",
     "autoinstall": "md5sum -c .yarn.lock.md5 || yarn install && md5sum yarn.lock > .yarn.lock.md5"
   },
   "main": "app.js",

--- a/explorer/client/src/__tests__/components/Table.test.tsx
+++ b/explorer/client/src/__tests__/components/Table.test.tsx
@@ -6,7 +6,7 @@ const HEADERS = ['First Name', 'Last Name']
 
 describe('components/Table', () => {
   it('renders table headers', () => {
-    const wrapper = mount(<Table headers={HEADERS} />)
+    const wrapper = mount(<Table headers={HEADERS} onChangePage={() => {}} />)
 
     expect(wrapper.text()).toContain('First Name')
     expect(wrapper.text()).toContain('Last Name')
@@ -17,7 +17,9 @@ describe('components/Table', () => {
       [{ type: 'text', text: 'Michael' }, { type: 'text', text: 'Jordan' }],
       [{ type: 'text', text: 'Charles' }, { type: 'text', text: 'Barkley' }]
     ]
-    const wrapper = mount(<Table headers={HEADERS} rows={rows} />)
+    const wrapper = mount(
+      <Table headers={HEADERS} rows={rows} onChangePage={() => {}} />
+    )
 
     expect(wrapper.text()).toContain('Michael')
     expect(wrapper.text()).toContain('Jordan')
@@ -26,14 +28,21 @@ describe('components/Table', () => {
   })
 
   it('renders a default loading message when rows are undefined', () => {
-    const wrapper = mount(<Table headers={HEADERS} rows={undefined} />)
+    const wrapper = mount(
+      <Table headers={HEADERS} rows={undefined} onChangePage={() => {}} />
+    )
 
     expect(wrapper.text()).toContain('Loading...')
   })
 
   it('can override the default loading message', () => {
     const wrapper = mount(
-      <Table headers={HEADERS} rows={undefined} loadingMsg="LOADING" />
+      <Table
+        headers={HEADERS}
+        rows={undefined}
+        loadingMsg="LOADING"
+        onChangePage={() => {}}
+      />
     )
 
     expect(wrapper.text()).not.toContain('Loading...')
@@ -41,14 +50,21 @@ describe('components/Table', () => {
   })
 
   it('renders a default empty message when there are no rows', () => {
-    const wrapper = mount(<Table headers={HEADERS} rows={[]} />)
+    const wrapper = mount(
+      <Table headers={HEADERS} rows={[]} onChangePage={() => {}} />
+    )
 
     expect(wrapper.text()).toContain('No results')
   })
 
   it('can override the default empty message', () => {
     const wrapper = mount(
-      <Table headers={HEADERS} rows={[]} emptyMsg="EMPTY" />
+      <Table
+        headers={HEADERS}
+        rows={[]}
+        emptyMsg="EMPTY"
+        onChangePage={() => {}}
+      />
     )
 
     expect(wrapper.text()).not.toContain('No results')

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -16,6 +16,8 @@
     "test-ci": "yarn autosetup && yarn jest src/__tests__ --runInBand --detectOpenHandles",
     "test-ci:e2e": "yarn autosetup && yarn build && yarn test-ci:e2e:no-build",
     "test-ci:e2e:no-build": "yarn autosetup && yarn jest e2e/ --runInBand --detectOpenHandles",
+    "test-ci:silent": "yarn test-ci --silent",
+    "test-ci:e2e:silent": "yarn test-ci:e2e --silent",
     "lint": "eslint --color --ext .js --ext .jsx --ext .ts --ext .tsx .",
     "lint:fix": "eslint --fix --color --ext .js --ext .jsx --ext .ts --ext .tsx .",
     "migration:run": "ts-node ./src/bin/migrator.ts migrate",

--- a/explorer/src/server.ts
+++ b/explorer/src/server.ts
@@ -43,7 +43,9 @@ const server = (port: number = DEFAULT_PORT) => {
   }
 
   const app = express()
-  addLogging(app)
+  if (process.env.NODE_ENV !== 'test') {
+    addLogging(app)
+  }
 
   app.use(
     express.static('client/build', {


### PR DESCRIPTION
For [#165300808](https://www.pivotaltracker.com/story/show/165300808)

Thoughts about this approach? (verbose isn't necessary, but it helps displaying all subtests)