### PR TITLE
(?) 404 for requests that query for unavailable pages 

### DIFF
--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -816,6 +816,9 @@ func (orm *ORM) JobsSorted(sort SortType, offset int, limit int) ([]models.JobSp
 	var jobs []models.JobSpec
 	order := fmt.Sprintf("created_at %s", sort.String())
 	err = orm.getRecords(&jobs, order, offset, limit)
+	if len(jobs) == 0 && count != 0 {
+		return jobs, count, gorm.ErrRecordNotFound
+	}
 	return jobs, count, err
 }
 

--- a/core/web/helpers.go
+++ b/core/web/helpers.go
@@ -42,7 +42,7 @@ func paginatedResponse(
 	err error,
 ) {
 	if err == orm.ErrorNotFound {
-		err = nil
+		jsonAPIError(c, http.StatusNotFound, fmt.Errorf("Page not found"))
 	}
 
 	if err != nil {


### PR DESCRIPTION
This doesn't address any story (not that I'm aware of), but it's something I observed when using operator ui. If there are only [11,19] jobs created (2 pages), then heading to page 3 should not be returning a 200, I think. To reproduce, query for available pages + 1 or something bogus like 129312938 in `http://localhost:3000/jobs/page/HERE` and note that 200 is returned. This makes operator ui think that there are no availabe jobs and offers you to create some. This isn't limited only to jobspecs, but other endpoints too, however before proceeding further I'd like to hear if this is by design. (also there might be better ways to check for this condition without calling `getRecords`, but the changes i made are for demonstrational purposes)