### PR TITLE
Small change to head tracker to make inserts cheaper and save some disk

### DIFF
--- a/core/services/head_tracker.go
+++ b/core/services/head_tracker.go
@@ -64,7 +64,7 @@ func (ht *HeadTracker) Start() error {
 	}
 	number := ht.head
 	if number != nil {
-		logger.Debug("Tracking logs from last block ", presenters.FriendlyBigInt(number.ToInt()), " with hash ", number.Hash().Hex())
+		logger.Debug("Tracking logs from last block ", presenters.FriendlyBigInt(number.ToInt()), " with hash ", number.Hash.Hex())
 	}
 
 	ht.done = make(chan struct{})
@@ -113,10 +113,10 @@ func (ht *HeadTracker) Save(n *models.Head) error {
 		ht.headMutex.Unlock()
 	} else {
 		ht.headMutex.Unlock()
-		msg := fmt.Sprintf("Cannot save new head confirmation %v because it's equal to or less than current head %v with hash %s", n, ht.head, n.Hash().Hex())
+		msg := fmt.Sprintf("Cannot save new head confirmation %v because it's equal to or less than current head %v with hash %s", n, ht.head, n.Hash.Hex())
 		return errBlockNotLater{msg}
 	}
-	return ht.store.SaveHead(n)
+	return ht.store.CreateHead(n)
 }
 
 // Head returns the latest block header being tracked, or nil.
@@ -209,7 +209,7 @@ func (ht *HeadTracker) receiveHeaders() error {
 				fmt.Sprintf("Received new head %v", presenters.FriendlyBigInt(head.ToInt())),
 				"blockHeight", head.ToInt(),
 				"blockHash", block.Hash(),
-				"hash", head.Hash())
+				"hash", head.Hash)
 			if err := ht.Save(head); err != nil {
 				switch err.(type) {
 				case errBlockNotLater:

--- a/core/services/head_tracker_test.go
+++ b/core/services/head_tracker_test.go
@@ -23,10 +23,10 @@ func TestHeadTracker_New(t *testing.T) {
 	defer cleanup()
 
 	cltest.MockEthOnStore(t, store)
-	assert.Nil(t, store.SaveHead(cltest.Head(1)))
+	assert.Nil(t, store.CreateHead(cltest.Head(1)))
 	last := cltest.Head(16)
-	assert.Nil(t, store.SaveHead(last))
-	assert.Nil(t, store.SaveHead(cltest.Head(10)))
+	assert.Nil(t, store.CreateHead(last))
+	assert.Nil(t, store.CreateHead(cltest.Head(10)))
 
 	ht := services.NewHeadTracker(store, []strpkg.HeadTrackable{})
 	assert.Nil(t, ht.Start())
@@ -59,7 +59,7 @@ func TestHeadTracker_Get(t *testing.T) {
 
 			cltest.MockEthOnStore(t, store)
 			if test.initial != nil {
-				assert.Nil(t, store.SaveHead(test.initial))
+				assert.Nil(t, store.CreateHead(test.initial))
 			}
 
 			ht := services.NewHeadTracker(store, []strpkg.HeadTrackable{})

--- a/core/services/synchronization/stats_pusher.go
+++ b/core/services/synchronization/stats_pusher.go
@@ -72,6 +72,7 @@ func (sp *StatsPusher) Start() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	sp.cancel = cancel
 	go sp.eventLoop(ctx)
+	logger.Infow("Started StatsPusher")
 	return nil
 }
 

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560433987"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560791143"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560881846"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560886530"
 	gormigrate "gopkg.in/gormigrate.v1"
 )
 
@@ -42,6 +43,10 @@ func Migrate(db *gorm.DB) error {
 		{
 			ID:      "1560881846",
 			Migrate: migration1560881846.Migrate,
+		},
+		{
+			ID:      "1560886530",
+			Migrate: migration1560886530.Migrate,
 		},
 	})
 

--- a/core/store/migrations/migrate_test.go
+++ b/core/store/migrations/migrate_test.go
@@ -8,7 +8,11 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration0"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1559081901"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1559767166"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560433987"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560791143"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560881846"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560886530"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
 	"github.com/stretchr/testify/assert"
@@ -93,4 +97,31 @@ func TestMigrate_Migration1560791143(t *testing.T) {
 
 	noIDTxFound := models.Tx{}
 	require.NoError(t, db.Where("id = ?", tx.ID).Find(&noIDTxFound).Error)
+}
+
+func TestMigrate_Migration1560881846(t *testing.T) {
+	orm, cleanup := bootstrapORM(t)
+	defer cleanup()
+
+	db := orm.DB
+
+	require.NoError(t, migration0.Migrate(db))
+	require.NoError(t, migration1559081901.Migrate(db))
+	require.NoError(t, migration1559767166.Migrate(db))
+	require.NoError(t, migration1560433987.Migrate(db))
+	require.NoError(t, migration1560791143.Migrate(db))
+	require.NoError(t, migration1560881846.Migrate(db))
+
+	head := migration0.Head{
+		HashRaw: "dad0000000000000000000000000000000000000000000000000000000000b0d",
+		Number:  8616460799,
+	}
+	require.NoError(t, db.Create(&head).Error)
+
+	require.NoError(t, migration1560886530.Migrate(db))
+
+	headFound := models.Head{}
+	require.NoError(t, db.Where("id = (SELECT MAX(id) FROM heads)").Find(&headFound).Error)
+	assert.Equal(t, "0xdad0000000000000000000000000000000000000000000000000000000000b0d", headFound.Hash.Hex())
+	assert.Equal(t, int64(8616460799), headFound.Number)
 }

--- a/core/store/migrations/migration0/migrate.go
+++ b/core/store/migrations/migration0/migrate.go
@@ -105,3 +105,9 @@ type TaskRun struct {
 	MinimumConfirmations uint64    `json:"minimumConfirmations"`
 	CreatedAt            time.Time `json:"-" gorm:"index"`
 }
+
+// Head is a capture of the model representing Head before migration1560881846
+type Head struct {
+	HashRaw string `gorm:"primary_key;type:varchar;column:hash"`
+	Number  int64  `gorm:"index;type:bigint;not null"`
+}

--- a/core/store/migrations/migration1560886530/migrate.go
+++ b/core/store/migrations/migration1560886530/migrate.go
@@ -1,0 +1,62 @@
+package migration1560886530
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/store/dbutil"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration0"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/chainlink/core/store/orm"
+)
+
+// Migrate converts the heads table to use a surrogate ID and binary hash
+func Migrate(tx *gorm.DB) error {
+	if err := tx.Exec(`
+DROP INDEX IF EXISTS idx_heads_number;
+DROP INDEX IF EXISTS idx_heads_hash;
+ALTER TABLE heads RENAME TO heads_archive;`).Error; err != nil {
+		return errors.Wrap(err, "failed to drop heads")
+	}
+
+	if err := tx.AutoMigrate(&models.Head{}).Error; err != nil {
+		return errors.Wrap(err, "failed to auto migrate Head")
+	}
+
+	var err error
+	if dbutil.IsPostgres(tx) {
+		err = tx.Exec(`
+INSERT INTO heads ("hash", "number")
+SELECT decode(convert_from("hash", 'utf-8'), 'hex'), "number"
+FROM heads_archive;
+DROP TABLE heads_archive;`).Error
+	} else {
+		// SQLite doesn't support decoding at the SQL level
+		err = orm.Batch(1000, func(offset, limit uint) (uint, error) {
+			var heads []migration0.Head
+			err := tx.
+				Table("heads_archive").
+				Limit(limit).
+				Offset(offset).
+				Order("number").
+				Find(&heads).Error
+			if err != nil {
+				return 0, err
+			}
+
+			for _, head := range heads {
+				migratedHead := models.Head{
+					Hash:   common.HexToHash(head.HashRaw),
+					Number: head.Number,
+				}
+				err = tx.Create(&migratedHead).Error
+				if err != nil {
+					return 0, err
+				}
+			}
+
+			return uint(len(heads)), err
+		})
+	}
+	return errors.Wrap(err, "failed to migrate old Heads")
+}

--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -255,8 +255,9 @@ func (h BlockHeader) ToHead() *Head {
 
 // Head represents a BlockNumber, BlockHash.
 type Head struct {
-	HashRaw string `gorm:"primary_key;type:varchar;column:hash"`
-	Number  int64  `gorm:"index;type:bigint;not null"`
+	ID     uint64      `gorm:"primary_key;auto_increment"`
+	Hash   common.Hash `gorm:"not null"`
+	Number int64       `gorm:"index;not null"`
 }
 
 // NewHead returns a Head instance with a BlockNumber and BlockHash.
@@ -266,14 +267,9 @@ func NewHead(bigint *big.Int, hash common.Hash) *Head {
 	}
 
 	return &Head{
-		Number:  bigint.Int64(),
-		HashRaw: hash.Hex()[2:], // remove 0x
+		Number: bigint.Int64(),
+		Hash:   hash,
 	}
-}
-
-// Hash returns the Hash instance related to this block height.
-func (l *Head) Hash() common.Hash {
-	return common.HexToHash(l.HashRaw)
 }
 
 // String returns a string representation of this number.

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -936,9 +936,9 @@ func (orm *ORM) CreateInitiator(initr *models.Initiator) error {
 	return orm.DB.Create(initr).Error
 }
 
-// SaveHead saves the indexable block number related to head tracker.
-func (orm *ORM) SaveHead(n *models.Head) error {
-	return orm.DB.Save(n).Error
+// CreateHead creates a head record that tracks which block heads we've observed in the HeadTracker
+func (orm *ORM) CreateHead(n *models.Head) error {
+	return orm.DB.Create(n).Error
 }
 
 // LastHead returns the most recently persisted head entry.


### PR DESCRIPTION
Removed the index from Hash, I don't believe it's being used.
Store hash as BLOB/bytea.
Use BIGSERIAL as primary key, this makes inserts a bit cheaper.