### PR TITLE
Add explorer connection status

### DIFF
--- a/core/cmd/client.go
+++ b/core/cmd/client.go
@@ -257,7 +257,8 @@ func (t *SessionCookieAuthenticator) Authenticate(sessionRequest models.SessionR
 	if len(cookies) == 0 {
 		return nil, errors.New("Did not receive cookie with session id")
 	}
-	return cookies[0], t.store.Save(cookies[0])
+	sc := web.FindSession(cookies)
+	return sc, t.store.Save(sc)
 }
 
 // CookieStore is a place to store and retrieve cookies.

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -706,7 +706,7 @@ func TestIntegration_SyncJobRuns(t *testing.T) {
 	defer cleanup()
 	app.InstantClock()
 
-	app.Store.StatsPusher.Period = 300 * time.Millisecond
+	app.Store.ExplorerPusher.Period = 300 * time.Millisecond
 
 	app.Start()
 	j := cltest.FixtureCreateJobViaWeb(t, app, "fixtures/web/run_at_job.json")

--- a/core/services/synchronization/explorer_pusher_test.go
+++ b/core/services/synchronization/explorer_pusher_test.go
@@ -11,14 +11,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStatsPusher(t *testing.T) {
+func TestExplorerPusher(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	wsserver, wscleanup := cltest.NewEventWebSocketServer(t)
 	defer wscleanup()
 
-	pusher := synchronization.NewStatsPusher(store.ORM, wsserver.URL, "", "")
+	pusher := synchronization.NewExplorerPusher(store.ORM, wsserver.URL, "", "")
 	pusher.Start()
 	defer pusher.Close()
 
@@ -48,7 +48,7 @@ func TestStatsPusher(t *testing.T) {
 	cltest.WaitForSyncEventCount(t, store.ORM, 0)
 }
 
-func TestStatsPusher_ClockTrigger(t *testing.T) {
+func TestExplorerPusher_ClockTrigger(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
@@ -56,7 +56,7 @@ func TestStatsPusher_ClockTrigger(t *testing.T) {
 	defer wscleanup()
 
 	clock := cltest.NewTriggerClock()
-	pusher := synchronization.NewStatsPusher(store.ORM, wsserver.URL, "", "", clock)
+	pusher := synchronization.NewExplorerPusher(store.ORM, wsserver.URL, "", "", clock)
 	pusher.Start()
 	defer pusher.Close()
 
@@ -72,7 +72,7 @@ func TestStatsPusher_ClockTrigger(t *testing.T) {
 	cltest.WaitForSyncEventCount(t, store.ORM, 0)
 }
 
-func TestStatsPusher_NoAckLeavesEvent(t *testing.T) {
+func TestExplorerPusher_NoAckLeavesEvent(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
@@ -80,7 +80,7 @@ func TestStatsPusher_NoAckLeavesEvent(t *testing.T) {
 	defer wscleanup()
 
 	clock := cltest.NewTriggerClock()
-	pusher := synchronization.NewStatsPusher(store.ORM, wsserver.URL, "", "", clock)
+	pusher := synchronization.NewExplorerPusher(store.ORM, wsserver.URL, "", "", clock)
 	pusher.Start()
 	defer pusher.Close()
 
@@ -98,7 +98,7 @@ func TestStatsPusher_NoAckLeavesEvent(t *testing.T) {
 	cltest.AssertSyncEventCountStays(t, store.ORM, 1)
 }
 
-func TestStatsPusher_BadSyncLeavesEvent(t *testing.T) {
+func TestExplorerPusher_BadSyncLeavesEvent(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
@@ -106,7 +106,7 @@ func TestStatsPusher_BadSyncLeavesEvent(t *testing.T) {
 	defer wscleanup()
 
 	clock := cltest.NewTriggerClock()
-	pusher := synchronization.NewStatsPusher(store.ORM, wsserver.URL, "", "", clock)
+	pusher := synchronization.NewExplorerPusher(store.ORM, wsserver.URL, "", "", clock)
 	pusher.Start()
 	defer pusher.Close()
 

--- a/core/services/synchronization/web_socket_client.go
+++ b/core/services/synchronization/web_socket_client.go
@@ -20,9 +20,22 @@ var (
 	ErrReceiveTimeout = errors.New("timeout waiting for message")
 )
 
+type ConnectionStatus string
+
+const (
+	// ConnectionStatusDisconnected is the default state
+	ConnectionStatusDisconnected = ConnectionStatus("")
+	// ConnectionStatusConnected is used when the client is successfully connected
+	ConnectionStatusConnected = ConnectionStatus("connected")
+	// ConnectionStatusError is used when there is an error
+	ConnectionStatusError = ConnectionStatus("error")
+)
+
 // WebSocketClient encapsulates all the functionality needed to
 // push run information to explorer.
 type WebSocketClient interface {
+	Url() url.URL
+	Status() ConnectionStatus
 	Start() error
 	Close() error
 	Send([]byte)
@@ -31,6 +44,9 @@ type WebSocketClient interface {
 
 type noopWebSocketClient struct{}
 
+func (noopWebSocketClient) Url() url.URL { return url.URL{} }
+
+func (noopWebSocketClient) Status() ConnectionStatus                 { return ConnectionStatusDisconnected }
 func (noopWebSocketClient) Start() error                             { return nil }
 func (noopWebSocketClient) Close() error                             { return nil }
 func (noopWebSocketClient) Send([]byte)                              {}
@@ -44,6 +60,7 @@ type websocketClient struct {
 	receive   chan []byte
 	sleeper   utils.Sleeper
 	started   bool
+	status    ConnectionStatus
 	url       *url.URL
 	accessKey string
 	secret    string
@@ -61,6 +78,16 @@ func NewWebSocketClient(url *url.URL, accessKey, secret string) WebSocketClient 
 		accessKey: accessKey,
 		secret:    secret,
 	}
+}
+
+// Url dereferences the URL the client was initialized with
+func (w *websocketClient) Url() url.URL {
+	return *w.url
+}
+
+// Status returns the private attribute
+func (w *websocketClient) Status() ConnectionStatus {
+	return w.status
 }
 
 // Start starts a write pump over a websocket.
@@ -126,27 +153,40 @@ const (
 // lexical confinement of done chan allows multiple connectAndWritePump routines
 // to clean up independent of itself by reducing shared state. i.e. a passed done, not w.done.
 func (w *websocketClient) connectAndWritePump(parentCtx context.Context, wg *sync.WaitGroup) {
-	wg.Done()
+	doneWaiting := false
 	logger.Infow("Connecting to explorer", "url", w.url)
 
 	for {
 		select {
 		case <-parentCtx.Done():
+			if !doneWaiting {
+				wg.Done()
+			}
 			return
 		case <-time.After(w.sleeper.After()):
 			connectionCtx, cancel := context.WithCancel(parentCtx)
 			defer cancel()
 
 			if err := w.connect(connectionCtx); err != nil {
+				w.status = ConnectionStatusError
+				if !doneWaiting {
+					wg.Done()
+				}
 				logger.Warn("Failed to connect to explorer (", w.url.String(), "): ", err)
 				break
 			}
 
+			w.status = ConnectionStatusConnected
+			if !doneWaiting {
+				wg.Done()
+			}
 			logger.Info("Connected to explorer at ", w.url.String())
 			w.sleeper.Reset()
 			go w.readPump(cancel)
 			w.writePump(connectionCtx)
 		}
+
+		doneWaiting = true
 	}
 }
 
@@ -155,7 +195,7 @@ func (w *websocketClient) writePump(ctx context.Context) {
 	ticker := time.NewTicker(pingPeriod)
 	defer func() {
 		ticker.Stop()
-		wrapConnErrorIf(w.conn.Close()) // exclusive responsibility to close ws conn
+		w.wrapConnErrorIf(w.conn.Close()) // exclusive responsibility to close ws conn
 	}()
 	for {
 		select {
@@ -163,18 +203,18 @@ func (w *websocketClient) writePump(ctx context.Context) {
 			return
 		case message, open := <-w.send:
 			if !open { // channel closed
-				wrapConnErrorIf(w.conn.WriteMessage(websocket.CloseMessage, []byte{}))
+				w.wrapConnErrorIf(w.conn.WriteMessage(websocket.CloseMessage, []byte{}))
 			}
 
 			err := w.writeMessage(message)
 			if err != nil {
-				logger.Error("websocketStatsPusher: ", err)
+				logger.Error("websocketExplorerPusher: ", err)
 				return
 			}
 		case <-ticker.C:
-			wrapConnErrorIf(w.conn.SetWriteDeadline(time.Now().Add(writeWait)))
+			w.wrapConnErrorIf(w.conn.SetWriteDeadline(time.Now().Add(writeWait)))
 			if err := w.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
-				wrapConnErrorIf(err)
+				w.wrapConnErrorIf(err)
 				return
 			}
 		}
@@ -182,7 +222,7 @@ func (w *websocketClient) writePump(ctx context.Context) {
 }
 
 func (w *websocketClient) writeMessage(message []byte) error {
-	wrapConnErrorIf(w.conn.SetWriteDeadline(time.Now().Add(writeWait)))
+	w.wrapConnErrorIf(w.conn.SetWriteDeadline(time.Now().Add(writeWait)))
 	writer, err := w.conn.NextWriter(websocket.TextMessage)
 	if err != nil {
 		return err
@@ -202,7 +242,7 @@ func (w *websocketClient) connect(ctx context.Context) error {
 
 	conn, _, err := websocket.DefaultDialer.DialContext(ctx, w.url.String(), authHeader)
 	if err != nil {
-		return fmt.Errorf("websocketStatsPusher#connect: %v", err)
+		return fmt.Errorf("websocketExplorerPusher#connect: %v", err)
 	}
 
 	w.conn = conn
@@ -243,9 +283,10 @@ func (w *websocketClient) readPump(cancel context.CancelFunc) {
 	}
 }
 
-func wrapConnErrorIf(err error) {
+func (w *websocketClient) wrapConnErrorIf(err error) {
 	if err != nil && websocket.IsUnexpectedCloseError(err, expectedCloseMessages...) {
-		logger.Error(fmt.Sprintf("websocketStatsPusher: %v", err))
+		w.status = ConnectionStatusError
+		logger.Error(fmt.Sprintf("websocketExplorerPusher: %v", err))
 	}
 }
 

--- a/core/services/synchronization/web_socket_client_test.go
+++ b/core/services/synchronization/web_socket_client_test.go
@@ -3,6 +3,7 @@ package synchronization_test
 import (
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 	"time"
 
@@ -64,7 +65,7 @@ func TestWebSocketClient_Send(t *testing.T) {
 	})
 }
 
-func TestWebSocketClient_Authentiation(t *testing.T) {
+func TestWebSocketClient_Authentication(t *testing.T) {
 	headerChannel := make(chan http.Header)
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		headerChannel <- r.Header
@@ -127,4 +128,37 @@ func TestWebSocketClient_SendWithAckTimeout(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, err, synchronization.ErrReceiveTimeout)
 	}, 300*time.Millisecond)
+}
+
+func TestWebSocketClient_Status_ConnectAndServerDisconnect(t *testing.T) {
+	wsserver, cleanup := cltest.NewEventWebSocketServer(t)
+	defer cleanup()
+
+	wsclient := synchronization.NewWebSocketClient(wsserver.URL, "", "")
+	defer wsclient.Close()
+	assert.Equal(t, synchronization.ConnectionStatusDisconnected, wsclient.Status())
+
+	require.NoError(t, wsclient.Start())
+	cltest.CallbackOrTimeout(t, "ws client connects", func() {
+		<-wsserver.Connected
+	})
+	assert.Equal(t, synchronization.ConnectionStatusConnected, wsclient.Status())
+
+	wsserver.WriteCloseMessage()
+	wsserver.Close()
+	time.Sleep(100 * time.Millisecond)
+	assert.Equal(t, synchronization.ConnectionStatusError, wsclient.Status())
+
+}
+
+func TestWebSocketClient_Status_ConnectError(t *testing.T) {
+	badURL, err := url.Parse("http://badhost.com")
+	require.NoError(t, err)
+
+	errorwsclient := synchronization.NewWebSocketClient(badURL, "", "")
+	require.NoError(t, errorwsclient.Start())
+	time.Sleep(100 * time.Millisecond)
+
+	assert.Equal(t, synchronization.ConnectionStatusError, errorwsclient.Status())
+
 }

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -960,7 +960,7 @@ func TestORM_AllSyncEvents(t *testing.T) {
 	defer cleanup()
 
 	orm := store.ORM
-	synchronization.NewStatsPusher(orm, cltest.MustParseURL("http://localhost"), "", "")
+	synchronization.NewExplorerPusher(orm, cltest.MustParseURL("http://localhost"), "", "")
 
 	// Create two events via job run callback
 	job := cltest.NewJobWithWebInitiator()

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -548,3 +548,20 @@ func (t *Tx) SetID(hex string) error {
 	t.Hash = common.HexToHash(hex)
 	return nil
 }
+
+// ExplorerStatus represents the connected server and status of the connection
+type ExplorerStatus struct {
+	Status string `json:"status"`
+	Url    string `json:"url"`
+}
+
+// NewExplorerStatus initializes the struct with the connections endpoint & current status
+func NewExplorerStatus(store *store.Store) ExplorerStatus {
+	client := store.ExplorerPusher.WSClient
+	url := client.Url()
+
+	return ExplorerStatus{
+		Status: string(client.Status()),
+		Url:    url.String(),
+	}
+}

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -24,12 +24,12 @@ import (
 // for keeping the application state in sync with the database.
 type Store struct {
 	*orm.ORM
-	Config      Config
-	Clock       utils.AfterNower
-	KeyStore    *KeyStore
-	RunChannel  RunChannel
-	TxManager   TxManager
-	StatsPusher *synchronization.StatsPusher
+	Config         Config
+	Clock          utils.AfterNower
+	KeyStore       *KeyStore
+	RunChannel     RunChannel
+	TxManager      TxManager
+	ExplorerPusher *synchronization.ExplorerPusher
 }
 
 type lazyRPCWrapper struct {
@@ -132,13 +132,13 @@ func NewStoreWithDialer(config Config, dialer Dialer) *Store {
 	keyStore := NewKeyStore(config.KeysDir())
 
 	store := &Store{
-		Clock:       utils.Clock{},
-		Config:      config,
-		KeyStore:    keyStore,
-		ORM:         orm,
-		RunChannel:  NewQueuedRunChannel(),
-		TxManager:   NewEthTxManager(&EthClient{ethrpc}, config, keyStore, orm),
-		StatsPusher: synchronization.NewStatsPusher(orm, config.ExplorerURL(), config.ExplorerAccessKey(), config.ExplorerSecret()),
+		Clock:          utils.Clock{},
+		Config:         config,
+		KeyStore:       keyStore,
+		ORM:            orm,
+		RunChannel:     NewQueuedRunChannel(),
+		TxManager:      NewEthTxManager(&EthClient{ethrpc}, config, keyStore, orm),
+		ExplorerPusher: synchronization.NewExplorerPusher(orm, config.ExplorerURL(), config.ExplorerAccessKey(), config.ExplorerSecret()),
 	}
 	return store
 }
@@ -148,7 +148,7 @@ func (s *Store) Start() error {
 	s.TxManager.Register(s.KeyStore.Accounts())
 	return multierr.Combine(
 		s.SyncDiskKeyStoreToDB(),
-		s.StatsPusher.Start(),
+		s.ExplorerPusher.Start(),
 	)
 }
 
@@ -157,7 +157,7 @@ func (s *Store) Close() error {
 	s.RunChannel.Close()
 	return multierr.Combine(
 		s.ORM.Close(),
-		s.StatsPusher.Close(),
+		s.ExplorerPusher.Close(),
 	)
 }
 

--- a/core/web/cookies.go
+++ b/core/web/cookies.go
@@ -1,0 +1,16 @@
+package web
+
+import (
+	"net/http"
+)
+
+// FindSession returns the cookie for the chainlink session
+func FindSession(cookies []*http.Cookie) *http.Cookie {
+	for _, c := range cookies {
+		if c.Name == "clsession" {
+			return c
+		}
+	}
+
+	return nil
+}

--- a/core/web/sessions_controller_test.go
+++ b/core/web/sessions_controller_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/chainlink/core/web"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -49,9 +50,12 @@ func TestSessionsController_Create(t *testing.T) {
 
 			if test.wantSession {
 				require.Equal(t, 200, resp.StatusCode)
+
 				cookies := resp.Cookies()
-				require.Equal(t, 1, len(cookies))
-				decrypted, err := cltest.DecodeSessionCookie(cookies[0].Value)
+				sessionCookie := web.FindSession(cookies)
+				require.NotNil(t, sessionCookie)
+
+				decrypted, err := cltest.DecodeSessionCookie(sessionCookie.Value)
 				require.NoError(t, err)
 				user, err := app.Store.AuthorizedUserWithSession(decrypted)
 				assert.NoError(t, err)


### PR DESCRIPTION
*NOTE:* As discussed at IPM. Breaking out the backend from PR #1328 until we resolve how we're going to handle the frontend UX of persistent notifications. Broke out the frontend into a [separate branch](https://github.com/smartcontractkit/chainlink/tree/features/core-cant-connect-explorer-error-notification-frontend)

Adds middleware to set send status via cookie

[#165267699]