### PR TITLE
Fix the spurious test TestClient_RunNodeShowsEnv:

### DIFF
--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -17,8 +17,6 @@ import (
 )
 
 func TestClient_RunNodeShowsEnv(t *testing.T) {
-	t.Parallel()
-
 	config, configCleanup := cltest.NewConfig(t)
 	defer configCleanup()
 	config.Set("LINK_CONTRACT_ADDRESS", "0x514910771AF9Ca656af840dff83E8264EcF986CA")
@@ -207,8 +205,6 @@ func TestClient_ImportKey(t *testing.T) {
 }
 
 func TestClient_LogToDiskOptionDisablesAsExpected(t *testing.T) {
-	t.Parallel()
-
 	tests := []struct {
 		name            string
 		logToDiskValue  bool

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -222,7 +222,9 @@ func TestClient_LogToDiskOptionDisablesAsExpected(t *testing.T) {
 			require.NoError(t, os.MkdirAll(config.KeysDir(), os.FileMode(0700)))
 			defer os.RemoveAll(config.RootDir())
 
+			previousLogger := logger.GetLogger().Desugar()
 			logger.SetLogger(config.CreateProductionLogger())
+			defer logger.SetLogger(previousLogger)
 			filepath := filepath.Join(config.RootDir(), "log.jsonl")
 			_, err := os.Stat(filepath)
 			assert.Equal(t, os.IsNotExist(err), !tt.fileShouldExist)

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -582,10 +582,13 @@ func ParseJSONAPIResponseMetaCount(input []byte) (int, error) {
 }
 
 // ObserveLogs returns the observed logs
-func ObserveLogs() *observer.ObservedLogs {
+func ObserveLogs() (*observer.ObservedLogs, func()) {
+	previousLogger := logger.GetLogger()
 	core, observed := observer.New(zapcore.DebugLevel)
 	logger.SetLogger(zap.New(core))
-	return observed
+	return observed, func() {
+		logger.SetLogger(previousLogger.Desugar())
+	}
 }
 
 // ReadLogs returns the contents of the applications log file as a string

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -892,9 +892,8 @@ func TestManagedAccount_GetAndIncrementNonce_DoesNotIncrementWhenCallbackThrowsE
 }
 
 func TestTxManager_LogsETHAndLINKBalancesAfterSuccessfulTx(t *testing.T) {
-	t.Parallel()
-
-	logsToCheckForBalance := cltest.ObserveLogs()
+	logsToCheckForBalance, cleanup := cltest.ObserveLogs()
+	defer cleanup()
 
 	config, configCleanup := cltest.NewConfig(t)
 	defer configCleanup()


### PR DESCRIPTION
1. Finally fixes https://www.pivotaltracker.com/story/show/164683119 by having tests that manipulate the `logger` global NOT run in parallel.
2. Adds clean up of logger in tests.