### PR TITLE
Chainlink Core negative block diffs are floored at 0

### DIFF
--- a/core/services/runs.go
+++ b/core/services/runs.go
@@ -389,7 +389,11 @@ func meetsMinimumConfirmations(
 
 func blockConfirmations(currentHeight, creationHeight *models.Big) *big.Int {
 	bigDiff := new(big.Int).Sub(currentHeight.ToInt(), creationHeight.ToInt())
-	return bigDiff.Add(bigDiff, big.NewInt(1)) // creation of runlog alone warrants 1 confirmation
+	confs := bigDiff.Add(bigDiff, big.NewInt(1)) // creation of runlog alone warrants 1 confirmation
+	if confs.Cmp(big.NewInt(0)) < 0 {            // negative, so floor at 0
+		confs.SetUint64(0)
+	}
+	return confs
 }
 
 func updateAndTrigger(run *models.JobRun, store *store.Store) error {


### PR DESCRIPTION
on connection to second, lagging eth node, do not let
a current block height that's behind creation height
skew confirmations