### PR TITLE
Directly alter confirmations type to bigint in explorer db:

### DIFF
--- a/explorer/client/@types/link-stats/index.d.ts
+++ b/explorer/client/@types/link-stats/index.d.ts
@@ -25,8 +25,8 @@ interface ITaskRun {
   status: string
   transactionHash?: string
   transactionStatus?: string
-  confirmations?: number
-  minimumConfirmations?: number
+  confirmations?: string
+  minimumConfirmations?: string
   error?: string
 }
 

--- a/explorer/client/package.json
+++ b/explorer/client/package.json
@@ -61,6 +61,7 @@
     "eslint-plugin-react": "^7.12.4",
     "eslint-plugin-standard": "^4.0.0",
     "javascript-time-ago": "^2.0.1",
+    "jsbi": "^3.0.0",
     "json-api-normalizer": "^0.4.14",
     "module-to-cdn": "^3.1.2",
     "prettier": "^1.16.4",

--- a/explorer/client/src/__tests__/components/JobRuns/TaskRuns.test.tsx
+++ b/explorer/client/src/__tests__/components/JobRuns/TaskRuns.test.tsx
@@ -23,9 +23,9 @@ describe('components/JobRuns/TaskRuns', () => {
   it('displays incoming pending confirmations with 0/3 pending confirmations', () => {
     const taskRuns = [
       {
-        confirmations: 0,
+        confirmations: '0',
         id: 1,
-        minimumConfirmations: 3,
+        minimumConfirmations: '3',
         status: 'completed',
         type: 'httpget'
       } as ITaskRun
@@ -42,9 +42,9 @@ describe('components/JobRuns/TaskRuns', () => {
   it('displays incoming pending confirmations with 1/3 pending confirmations', () => {
     const taskRuns = [
       {
-        confirmations: 1,
+        confirmations: '1',
         id: 1,
-        minimumConfirmations: 3,
+        minimumConfirmations: '3',
         status: 'completed',
         type: 'httpget'
       } as ITaskRun
@@ -61,16 +61,16 @@ describe('components/JobRuns/TaskRuns', () => {
   it('does not display repeated pending confirmations', () => {
     const taskRuns = [
       {
-        confirmations: 3,
+        confirmations: '3',
         id: 1,
-        minimumConfirmations: 3,
+        minimumConfirmations: '3',
         status: 'completed',
         type: 'httpget'
       } as ITaskRun,
       {
-        confirmations: 3,
+        confirmations: '3',
         id: 2,
-        minimumConfirmations: 3,
+        minimumConfirmations: '3',
         status: 'completed',
         type: 'jsonparse'
       } as ITaskRun
@@ -86,16 +86,16 @@ describe('components/JobRuns/TaskRuns', () => {
   it('does display increasing pending confirmations', () => {
     const taskRuns = [
       {
-        confirmations: 3,
+        confirmations: '3',
         id: 1,
-        minimumConfirmations: 3,
+        minimumConfirmations: '3',
         status: 'completed',
         type: 'httpget'
       } as ITaskRun,
       {
-        confirmations: 4,
+        confirmations: '4',
         id: 2,
-        minimumConfirmations: 5,
+        minimumConfirmations: '5',
         status: 'completed',
         type: 'jsonparse'
       } as ITaskRun

--- a/explorer/client/src/components/JobRuns/TaskRuns.tsx
+++ b/explorer/client/src/components/JobRuns/TaskRuns.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import JSBI from 'jsbi'
 import Typography from '@material-ui/core/Typography'
 import {
   createStyles,
@@ -52,10 +53,10 @@ interface IProps extends WithStyles<typeof styles> {
 
 const renderConfirmations = (
   { confirmations, minimumConfirmations }: ITaskRun,
-  prevConfs: number,
+  prevConfs: string,
   classes: any
 ) => {
-  if (minimumConfirmations && minimumConfirmations > prevConfs) {
+  if (minimumConfirmations && JSBI.GT(minimumConfirmations, prevConfs)) {
     return (
       <Typography
         variant="subtitle2"
@@ -68,12 +69,12 @@ const renderConfirmations = (
   return null
 }
 
-const calculatePrevConfs = (taskRuns: ITaskRun[] | undefined): number[] => {
+const calculatePrevConfs = (taskRuns: ITaskRun[] | undefined): string[] => {
   if (taskRuns) {
     const prevMinConfs = taskRuns.map(
       taskRun => taskRun.minimumConfirmations
-    ) as number[]
-    prevMinConfs.unshift(0)
+    ) as string[]
+    prevMinConfs.unshift('0')
     return prevMinConfs
   }
   return []

--- a/explorer/client/yarn.lock
+++ b/explorer/client/yarn.lock
@@ -6402,6 +6402,11 @@ js-yaml@^3.12.0, js-yaml@^3.13.0, js-yaml@^3.7.0, js-yaml@^3.9.0:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+jsbi@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/jsbi/-/jsbi-3.0.0.tgz#c3e8a08713736e57231c210d93393df86d20747e"
+  integrity sha512-3gj+H13urlMGogSVM5rZvvgrhFwLmLisVQKRoxPU7KunFHpeJk+Jfjkp2E/79QSMyUa45aDDNG8yHnKD6Gro6Q==
+
 jsbn@~0.1.0:
   version "0.1.1"
   resolved "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"

--- a/explorer/src/__tests__/entity/JobRun.test.ts
+++ b/explorer/src/__tests__/entity/JobRun.test.ts
@@ -122,9 +122,9 @@ describe('entity/jobRun/saveJobRunTree', () => {
     await saveJobRunTree(db, jr)
 
     const modifications = {
-      confirmations: 2,
+      confirmations: '2',
       error: 'something bad happened',
-      minimumConfirmations: 3,
+      minimumConfirmations: '3',
       status: 'errored',
       transactionHash:
         '0x2222222222222222222222222222222222222222222222222222222222222222',

--- a/explorer/src/__tests__/entity/JobRun.test.ts
+++ b/explorer/src/__tests__/entity/JobRun.test.ts
@@ -36,8 +36,8 @@ describe('entity/jobRun/fromString', () => {
     expect(jr.taskRuns[0].index).toEqual(0)
     expect(jr.taskRuns[0].type).toEqual('httpget')
     expect(jr.taskRuns[0].status).toEqual('')
-    expect(jr.taskRuns[0].confirmations).toEqual(0)
-    expect(jr.taskRuns[0].minimumConfirmations).toEqual(3)
+    expect(jr.taskRuns[0].confirmations).toEqual('0')
+    expect(jr.taskRuns[0].minimumConfirmations).toEqual('3')
     expect(jr.taskRuns[0].error).toEqual(null)
 
     const [chainlinkNode, _] = await createChainlinkNode(

--- a/explorer/src/__tests__/entity/TaskRun.test.ts
+++ b/explorer/src/__tests__/entity/TaskRun.test.ts
@@ -1,0 +1,74 @@
+import { Connection } from 'typeorm'
+import { closeDbConnection, getDb } from '../../database'
+import { createChainlinkNode } from '../../entity/ChainlinkNode'
+import { fromString, JobRun, saveJobRunTree } from '../../entity/JobRun'
+import fixture from '../fixtures/JobRun.fixture.json'
+
+let db: Connection
+
+beforeAll(async () => {
+  db = await getDb()
+})
+
+afterAll(async () => closeDbConnection())
+
+describe('entity/taskRun', () => {
+  it('copies old confirmations to new column on INSERT', async () => {
+    const [chainlinkNode, _] = await createChainlinkNode(
+      db,
+      'testOverwriteJobRunsErrorOnConflict'
+    )
+
+    const jr = fromString(JSON.stringify(fixture))
+    jr.chainlinkNodeId = chainlinkNode.id
+    await saveJobRunTree(db, jr)
+    expect(jr.id).toBeDefined()
+
+    // insert into old columns
+    await db.manager.query(
+      `
+      INSERT INTO task_run("jobRunId", index, type, status, confirmations, "minimumConfirmations")
+      VALUES ($1, 1, 'randomtask', 'in_progress', 1, 2);
+    `,
+      [jr.id]
+    )
+
+    const retrieved = await db.manager.findOne(JobRun, jr.id)
+    const task = retrieved.taskRuns[1]
+
+    expect(task.confirmationsOld).toEqual(1)
+    expect(task.minimumConfirmationsOld).toEqual(2)
+    expect(task.confirmations).toEqual('1')
+    expect(task.minimumConfirmations).toEqual('2')
+  })
+
+  it('copies old confirmations to new column on UPDATE', async () => {
+    const [chainlinkNode, _] = await createChainlinkNode(
+      db,
+      'testOverwriteJobRunsErrorOnConflict'
+    )
+
+    const jr = fromString(JSON.stringify(fixture))
+    jr.chainlinkNodeId = chainlinkNode.id
+    await saveJobRunTree(db, jr)
+    expect(jr.id).toBeDefined()
+    const tr = jr.taskRuns[0]
+
+    // update old columns
+    await db.manager.query(
+      `
+      UPDATE task_run SET confirmations = 9, "minimumConfirmations" = 10
+      WHERE id = $1;
+    `,
+      [tr.id]
+    )
+
+    const retrieved = await db.manager.findOne(JobRun, jr.id)
+    const task = retrieved.taskRuns[0]
+
+    expect(task.confirmationsOld).toEqual(9)
+    expect(task.minimumConfirmationsOld).toEqual(10)
+    expect(task.confirmations).toEqual('9')
+    expect(task.minimumConfirmations).toEqual('10')
+  })
+})

--- a/explorer/src/__tests__/fixtures/JobRun.ethtx.fixture.json
+++ b/explorer/src/__tests__/fixtures/JobRun.ethtx.fixture.json
@@ -13,8 +13,8 @@
       "index": 0,
       "type": "httpget",
       "status": "completed",
-      "confirmations": 3,
-      "minimumConfirmations": 3,
+      "confirmations": "3",
+      "minimumConfirmations": "3",
       "error": null
     },
     { "index": 1, "type": "jsonparse", "status": "completed", "error": null },

--- a/explorer/src/__tests__/fixtures/JobRun.fixture.json
+++ b/explorer/src/__tests__/fixtures/JobRun.fixture.json
@@ -17,8 +17,8 @@
       "index": 0,
       "type": "httpget",
       "status": "",
-      "confirmations": 0,
-      "minimumConfirmations": 3,
+      "confirmations": "0",
+      "minimumConfirmations": "3",
       "error": null
     }
   ]

--- a/explorer/src/__tests__/fixtures/JobRunUpdate.fixture.json
+++ b/explorer/src/__tests__/fixtures/JobRunUpdate.fixture.json
@@ -17,8 +17,8 @@
       "index": 0,
       "type": "httpget",
       "status": "completed",
-      "confirmations": 3,
-      "minimumConfirmations": 3,
+      "confirmations": "3",
+      "minimumConfirmations": "3",
       "error": null
     }
   ]

--- a/explorer/src/bin/migrator.ts
+++ b/explorer/src/bin/migrator.ts
@@ -6,7 +6,7 @@ const migrate = async () => {
   return bootstrap(async (db: Connection) => {
     console.log(`Migrating [\x1b[32m${db.options.database}\x1b[0m]...`)
 
-    const pendingMigrations = await db.runMigrations({ transaction: false })
+    const pendingMigrations = await db.runMigrations()
     for (let m of pendingMigrations) {
       console.log('ran', m)
     }

--- a/explorer/src/bin/migrator.ts
+++ b/explorer/src/bin/migrator.ts
@@ -6,7 +6,7 @@ const migrate = async () => {
   return bootstrap(async (db: Connection) => {
     console.log(`Migrating [\x1b[32m${db.options.database}\x1b[0m]...`)
 
-    const pendingMigrations = await db.runMigrations()
+    const pendingMigrations = await db.runMigrations({ transaction: false })
     for (let m of pendingMigrations) {
       console.log('ran', m)
     }

--- a/explorer/src/entity/JobRun.ts
+++ b/explorer/src/entity/JobRun.ts
@@ -128,8 +128,8 @@ export const saveJobRunTree = async (db: Connection, jobRun: JobRun) => {
               ,"error" = :error
               ,"transactionHash" = :transactionHash
               ,"transactionStatus" = :transactionStatus
-              ,"confirmations" = :confirmations
-              ,"minimumConfirmations" = :minimumConfirmations
+              ,"confirmations_new1562419039813" = :confirmations
+              ,"minimumConfirmations_new1562419039813" = :minimumConfirmations
               `
           )
           .setParameter('status', tr.status)

--- a/explorer/src/entity/TaskRun.ts
+++ b/explorer/src/entity/TaskRun.ts
@@ -29,9 +29,18 @@ export class TaskRun {
   @Column({ nullable: true })
   transactionStatus?: TransactionStatus
 
-  @Column({ nullable: true })
-  minimumConfirmations?: number
+  @Column({ nullable: true, name: 'minimumConfirmations_new1562419039813' })
+  minimumConfirmations?: string
 
-  @Column({ nullable: true })
-  confirmations?: number
+  @Column({ nullable: true, name: 'confirmations_new1562419039813' })
+  confirmations?: string
+
+  //
+  // TODO: Old columns will be deleted once node operators have migrated to this or
+  // later version.
+  @Column({ nullable: true, name: 'minimumConfirmations' })
+  minimumConfirmationsOld?: number
+
+  @Column({ nullable: true, name: 'confirmations' })
+  confirmationsOld?: number
 }

--- a/explorer/src/factories.ts
+++ b/explorer/src/factories.ts
@@ -25,8 +25,8 @@ export const createJobRun = async (
   tr.index = 0
   tr.status = 'in_progress'
   tr.type = 'httpget'
-  tr.confirmations = 1
-  tr.minimumConfirmations = 3
+  tr.confirmations = '1'
+  tr.minimumConfirmations = '3'
   await db.manager.save(tr)
 
   return jobRun

--- a/explorer/src/migration/1562419039813-ConvertTaskRunConfirmationsToBigInt.ts
+++ b/explorer/src/migration/1562419039813-ConvertTaskRunConfirmationsToBigInt.ts
@@ -1,12 +1,50 @@
 import { MigrationInterface, QueryRunner } from 'typeorm'
+import { TaskRun } from '../entity/TaskRun'
 
 export class ConvertTaskRunConfirmationsToBigInt1562419039813
   implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<any> {
+    const max = await queryRunner.manager.count(TaskRun)
+
     await queryRunner.query(`
-      ALTER TABLE "task_run" ALTER COLUMN "confirmations" SET DATA TYPE bigint;
-      ALTER TABLE "task_run" ALTER COLUMN "minimumConfirmations" SET DATA TYPE bigint;
+      ALTER TABLE "task_run" ADD COLUMN "confirmations_new1562419039813" bigint NULL;
+      ALTER TABLE "task_run" ADD COLUMN "minimumConfirmations_new1562419039813" bigint NULL;
     `)
+
+    const batchSize = 1000
+    for (let windowmin = 0; windowmin < max; windowmin += batchSize) {
+      const windowmax = windowmin + batchSize
+      await queryRunner.query(
+        `
+        UPDATE "task_run" SET
+          "confirmations_new1562419039813" = confirmations,
+          "minimumConfirmations_new1562419039813" = "minimumConfirmations"
+          WHERE id >= $1 AND id < $2;
+      `,
+        [windowmin, windowmax]
+      )
+    }
+
+    await queryRunner.startTransaction()
+    await queryRunner.query(`
+      ALTER TABLE "task_run" RENAME COLUMN "confirmations" TO "confirmations_old1562419039813";
+      ALTER TABLE "task_run" RENAME COLUMN "confirmations_new1562419039813" TO "confirmations";
+
+      ALTER TABLE "task_run" RENAME COLUMN "minimumConfirmations" TO "minimumConfirmations_old1562419039813";
+      ALTER TABLE "task_run" RENAME COLUMN "minimumConfirmations_new1562419039813" TO "minimumConfirmations";
+    `)
+
+    await queryRunner.query(
+      `
+      UPDATE "task_run" SET
+        "confirmations" = "confirmations_old1562419039813",
+        "minimumConfirmations" = "minimumConfirmations_old1562419039813"
+        WHERE id >= $1;
+    `,
+      [max]
+    )
+
+    await queryRunner.commitTransaction()
   }
 
   public async down(queryRunner: QueryRunner): Promise<any> {}

--- a/explorer/src/migration/1562419039813-ConvertTaskRunConfirmationsToBigInt.ts
+++ b/explorer/src/migration/1562419039813-ConvertTaskRunConfirmationsToBigInt.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class ConvertTaskRunConfirmationsToBigInt1562419039813
+  implements MigrationInterface {
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
+      ALTER TABLE "task_run" ALTER COLUMN "confirmations" SET DATA TYPE bigint;
+      ALTER TABLE "task_run" ALTER COLUMN "minimumConfirmations" SET DATA TYPE bigint;
+    `)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<any> {}
+}

--- a/explorer/src/migration/1562419039813-ConvertTaskRunConfirmationsToBigInt.ts
+++ b/explorer/src/migration/1562419039813-ConvertTaskRunConfirmationsToBigInt.ts
@@ -4,47 +4,32 @@ import { TaskRun } from '../entity/TaskRun'
 export class ConvertTaskRunConfirmationsToBigInt1562419039813
   implements MigrationInterface {
   public async up(queryRunner: QueryRunner): Promise<any> {
-    const max = await queryRunner.manager.count(TaskRun)
-
     await queryRunner.query(`
       ALTER TABLE "task_run" ADD COLUMN "confirmations_new1562419039813" bigint NULL;
       ALTER TABLE "task_run" ADD COLUMN "minimumConfirmations_new1562419039813" bigint NULL;
     `)
 
-    const batchSize = 1000
-    for (let windowmin = 0; windowmin < max; windowmin += batchSize) {
-      const windowmax = windowmin + batchSize
-      await queryRunner.query(
-        `
-        UPDATE "task_run" SET
-          "confirmations_new1562419039813" = confirmations,
-          "minimumConfirmations_new1562419039813" = "minimumConfirmations"
-          WHERE id >= $1 AND id < $2;
-      `,
-        [windowmin, windowmax]
-      )
-    }
-
-    await queryRunner.startTransaction()
     await queryRunner.query(`
-      ALTER TABLE "task_run" RENAME COLUMN "confirmations" TO "confirmations_old1562419039813";
-      ALTER TABLE "task_run" RENAME COLUMN "confirmations_new1562419039813" TO "confirmations";
+      CREATE FUNCTION copy_task_run_confirmations() RETURNS TRIGGER AS $$
+        BEGIN
+          NEW.confirmations_new1562419039813 = NEW.confirmations;
+          NEW."minimumConfirmations_new1562419039813" = NEW."minimumConfirmations";
+          RETURN NEW;
+        END;
+      $$ LANGUAGE plpgsql;
 
-      ALTER TABLE "task_run" RENAME COLUMN "minimumConfirmations" TO "minimumConfirmations_old1562419039813";
-      ALTER TABLE "task_run" RENAME COLUMN "minimumConfirmations_new1562419039813" TO "minimumConfirmations";
+      CREATE TRIGGER check_task_run_confirmations
+      BEFORE UPDATE OR INSERT on "task_run"
+      FOR EACH ROW
+      WHEN (NEW.confirmations IS NOT NULL OR NEW."minimumConfirmations" IS NOT NULL)
+      execute procedure copy_task_run_confirmations();
     `)
 
-    await queryRunner.query(
-      `
+    await queryRunner.query(`
       UPDATE "task_run" SET
-        "confirmations" = "confirmations_old1562419039813",
-        "minimumConfirmations" = "minimumConfirmations_old1562419039813"
-        WHERE id >= $1;
-    `,
-      [max]
-    )
-
-    await queryRunner.commitTransaction()
+        "confirmations_new1562419039813" = confirmations,
+        "minimumConfirmations_new1562419039813" = "minimumConfirmations"
+    `)
   }
 
   public async down(queryRunner: QueryRunner): Promise<any> {}


### PR DESCRIPTION
Tracker: https://www.pivotaltracker.com/story/show/167151102

1. This brings parity between the core type and the explorer type, which is `bigint`.
2. `bigint`s in JS and TypeORM are strings. We therefore need a bigint string handler, JSBI fits that bill: https://github.com/GoogleChromeLabs/jsbi
