### PR TITLE
TxAttempts get status (confirmed|unconfirmed|retired), only re-check unconfirmed

### DIFF
--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -315,8 +315,8 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_ConfirmCompletes(t *testi
 	require.NoError(t, err)
 	assert.True(t, tx.Confirmed)
 	require.Len(t, tx.Attempts, 2)
-	assert.False(t, tx.Attempts[0].Confirmed)
-	assert.True(t, tx.Attempts[1].Confirmed)
+	assert.False(t, tx.Attempts[0].Confirmed())
+	assert.True(t, tx.Attempts[1].Confirmed())
 
 	receiptsJSON := output.Get("ethereumReceipts").String()
 	var receipts []models.TxReceipt

--- a/core/cmd/renderer.go
+++ b/core/cmd/renderer.go
@@ -269,7 +269,7 @@ func (rt RendererTable) renderTxAttempts(attempts []models.TxAttempt) error {
 			a.Hash.Hex(),
 			fmt.Sprint(a.GasPrice),
 			fmt.Sprint(a.SentAt),
-			fmt.Sprint(a.Confirmed),
+			fmt.Sprint(a.Confirmed()),
 		})
 	}
 

--- a/core/cmd/renderer_test.go
+++ b/core/cmd/renderer_test.go
@@ -156,11 +156,11 @@ func TestRendererTable_Render_TxAttempts(t *testing.T) {
 
 	attempts := []models.TxAttempt{
 		models.TxAttempt{
-			Hash:      cltest.NewHash(),
-			TxID:      1,
-			GasPrice:  models.NewBig(big.NewInt(1)),
-			Confirmed: false,
-			SentAt:    1,
+			Hash:     cltest.NewHash(),
+			TxID:     1,
+			GasPrice: models.NewBig(big.NewInt(1)),
+			Status:   models.TxAttemptStatusUnconfirmed,
+			SentAt:   1,
 		},
 	}
 
@@ -173,7 +173,7 @@ func TestRendererTable_Render_TxAttempts(t *testing.T) {
 	assert.Contains(t, output, attempts[0].Hash.Hex())
 	assert.Contains(t, output, fmt.Sprint(attempts[0].GasPrice))
 	assert.Contains(t, output, fmt.Sprint(attempts[0].SentAt))
-	assert.Contains(t, output, fmt.Sprint(attempts[0].Confirmed))
+	assert.Contains(t, output, fmt.Sprint(attempts[0].Confirmed()))
 }
 
 func TestRendererTable_ServiceAgreementShow(t *testing.T) {

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560881846"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560886530"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560924400"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1562623854"
 	gormigrate "gopkg.in/gormigrate.v1"
 )
 
@@ -52,6 +53,10 @@ func Migrate(db *gorm.DB) error {
 		{
 			ID:      "1560924400",
 			Migrate: migration1560924400.Migrate,
+		},
+		{
+			ID:      "1562623854",
+			Migrate: migration1562623854.Migrate,
 		},
 	})
 

--- a/core/store/migrations/migration1559081901/migrate.go
+++ b/core/store/migrations/migration1559081901/migrate.go
@@ -1,6 +1,9 @@
 package migration1559081901
 
 import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -21,7 +24,7 @@ func Migrate(tx *gorm.DB) error {
 	if err := tx.AutoMigrate(&models.Tx{}).Error; err != nil {
 		return errors.Wrap(err, "failed to auto migrate Tx")
 	}
-	if err := tx.AutoMigrate(&models.TxAttempt{}).Error; err != nil {
+	if err := tx.AutoMigrate(&TxAttempt{}).Error; err != nil {
 		return errors.Wrap(err, "failed to auto migrate TxAttempt")
 	}
 	if err := tx.Exec(
@@ -43,4 +46,16 @@ func Migrate(tx *gorm.DB) error {
 		return errors.Wrap(err, "failed to migrate old Txes, TxAttempts")
 	}
 	return nil
+}
+
+// TxAttempt is a capture of the model TxAttempt before migration1562623854
+type TxAttempt struct {
+	ID          uint64      `gorm:"primary_key;auto_increment"`
+	TxID        uint64      `gorm:"index;type:bigint REFERENCES txes(id) ON DELETE CASCADE"`
+	CreatedAt   time.Time   `gorm:"index;not null"`
+	Hash        common.Hash `gorm:"index;not null"`
+	GasPrice    *models.Big `gorm:"type:varchar(78);not null"`
+	Confirmed   bool        `gorm:"not null"`
+	SentAt      uint64      `gorm:"not null"`
+	SignedRawTx string      `gorm:"type:text;not null"`
 }

--- a/core/store/migrations/migration1562623854/migrate.go
+++ b/core/store/migrations/migration1562623854/migrate.go
@@ -1,0 +1,15 @@
+package migration1562623854
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
+)
+
+func Migrate(tx *gorm.DB) error {
+	if err := tx.Exec(`
+ALTER TABLE tx_attempts ADD COLUMN status varchar(255) NOT NULL DEFAULT 'unconfirmed';
+UPDATE tx_attempts SET status = 'confirmed' WHERE confirmed IS TRUE;`).Error; err != nil {
+		return errors.Wrap(err, "failed to add status column to TxAttempts")
+	}
+	return nil
+}

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -535,6 +535,7 @@ func (orm *ORM) CreateTx(
 				GasPrice:    tx.GasPrice,
 				SentAt:      tx.SentAt,
 				SignedRawTx: tx.SignedRawTx,
+				Status:      models.TxAttemptStatusUnconfirmed,
 			}
 			tx.Attempts = []*models.TxAttempt{&attempt}
 			return dbtx.Create(tx).Error
@@ -578,10 +579,10 @@ func (orm *ORM) UpdateTx(
 // but has met the minimum number of outgoing confirmations to be deemed
 // safely written on the blockchain.
 func (orm *ORM) MarkTxSafe(tx *models.Tx, txAttempt *models.TxAttempt) error {
-	txAttempt.Confirmed = true
+	txAttempt.Status = models.TxAttemptStatusConfirmed
 	tx.Hash = txAttempt.Hash
 	tx.GasPrice = txAttempt.GasPrice
-	tx.Confirmed = txAttempt.Confirmed
+	tx.Confirmed = txAttempt.Confirmed()
 	tx.SentAt = txAttempt.SentAt
 	tx.SignedRawTx = txAttempt.SignedRawTx
 	return orm.DB.Save(tx).Error
@@ -644,7 +645,7 @@ func (orm *ORM) AddTxAttempt(
 	}
 	tx.Hash = txAttempt.Hash
 	tx.GasPrice = txAttempt.GasPrice
-	tx.Confirmed = txAttempt.Confirmed
+	tx.Confirmed = txAttempt.Confirmed()
 	tx.SentAt = txAttempt.SentAt
 	tx.SignedRawTx = txAttempt.SignedRawTx
 	tx.Attempts = append(tx.Attempts, txAttempt)

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -526,7 +526,7 @@ func NewTxFromAttempt(txAttempt models.TxAttempt) Tx {
 	tx := txAttempt.Tx
 	tx.Hash = txAttempt.Hash
 	tx.GasPrice = txAttempt.GasPrice
-	tx.Confirmed = txAttempt.Confirmed
+	tx.Confirmed = txAttempt.Confirmed()
 	tx.SentAt = txAttempt.SentAt
 	tx.SignedRawTx = txAttempt.SignedRawTx
 	return NewTx(tx)


### PR DESCRIPTION
This is an optimization which reduces the number of RPC calls to the Ethereum client by marking TxAttempts as retired when a new transaction attempt with higher gas has been created.