### PR TITLE
Use winston logger not console logger in prod explorer setup

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -33,7 +33,7 @@ services:
       - MINIMUM_CONTRACT_PAYMENT=1000000000000
       - RUST_BACKTRACE=1
       - CHAINLINK_DEV=true
-      - EXPLORER_URL=ws://172.16.1.102:8312
+      - EXPLORER_URL=ws://172.16.1.103:8080
     networks:
       devnet:
         ipv4_address: 172.16.1.102
@@ -52,6 +52,8 @@ services:
         ipv4_address: 172.16.1.103
     ports:
       - 8132:8080
+    depends_on:
+      - db
     environment:
       TYPEORM_DATABASE: explorer_dev
       TYPEORM_USERNAME: postgres

--- a/explorer/src/index.ts
+++ b/explorer/src/index.ts
@@ -1,7 +1,9 @@
 import server from './server'
+import { logger } from './logging'
 
 const start = async () => {
+  logger.info(`Starting Explorer Node`)
   server()
 }
 
-start().catch(console.error)
+start().catch(logger.error)

--- a/explorer/src/logging.ts
+++ b/explorer/src/logging.ts
@@ -1,0 +1,43 @@
+import {
+  requestWhitelist,
+  logger as loggerConfig,
+  errorLogger
+} from 'express-winston'
+import * as winston from 'winston'
+import express from 'express'
+
+const LOGGER_WHITELIST = [
+  'url',
+  'method',
+  'httpVersion',
+  'originalUrl',
+  'query'
+]
+requestWhitelist.splice(0, requestWhitelist.length, ...LOGGER_WHITELIST)
+
+export const addRequestLogging = (app: express.Express) => {
+  const consoleTransport = new winston.transports.Console()
+
+  app.use(
+    loggerConfig({
+      expressFormat: true,
+      meta: true,
+      msg: 'HTTP {{req.method}} {{req.url}}',
+      transports: [consoleTransport]
+    })
+  )
+
+  app.use(
+    errorLogger({
+      transports: [consoleTransport]
+    })
+  )
+}
+
+const transports = {
+  console: new winston.transports.Console({ level: 'info' })
+}
+
+export const logger = winston.createLogger({
+  transports: [transports.console]
+})

--- a/explorer/src/server.ts
+++ b/explorer/src/server.ts
@@ -1,6 +1,5 @@
 import * as controllers from './controllers'
-import { requestWhitelist, logger, errorLogger } from 'express-winston'
-import * as winston from 'winston'
+import { addRequestLogging, logger } from './logging'
 import express from 'express'
 import http from 'http'
 import mime from 'mime-types'
@@ -9,34 +8,6 @@ import seed from './seed'
 
 export const DEFAULT_PORT = parseInt(process.env.SERVER_PORT, 10) || 8080
 
-const LOGGER_WHITELIST = [
-  'url',
-  'method',
-  'httpVersion',
-  'originalUrl',
-  'query'
-]
-requestWhitelist.splice(0, requestWhitelist.length, ...LOGGER_WHITELIST)
-
-const addLogging = (app: express.Express) => {
-  const consoleTransport = new winston.transports.Console()
-
-  app.use(
-    logger({
-      expressFormat: true,
-      meta: true,
-      msg: 'HTTP {{req.method}} {{req.url}}',
-      transports: [consoleTransport]
-    })
-  )
-
-  app.use(
-    errorLogger({
-      transports: [consoleTransport]
-    })
-  )
-}
-
 const server = (port: number = DEFAULT_PORT) => {
   if (process.env.NODE_ENV === 'development') {
     seed()
@@ -44,7 +15,7 @@ const server = (port: number = DEFAULT_PORT) => {
 
   const app = express()
   if (process.env.NODE_ENV !== 'test') {
-    addLogging(app)
+    addRequestLogging(app)
   }
 
   app.use(
@@ -66,7 +37,7 @@ const server = (port: number = DEFAULT_PORT) => {
   const server = new http.Server(app)
   bootstrapRealtime(server)
   return server.listen(port, () => {
-    console.log(`server started, listening on port ${port}`)
+    logger.info(`server started, listening on port ${port}`)
   })
 }
 


### PR DESCRIPTION
These console logs are getting dropped when running in `yarn run prod`.

Here they are in docker-compose:

![Screen Shot 2019-07-11 at 15 47 38](https://user-images.githubusercontent.com/344071/61087580-41ede180-a3f3-11e9-9734-59d436597db4.png)
