### PR TITLE
Improve docker-compose

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,9 +9,9 @@ node_modules/
 vendor/
 tmp/
 
-evm/node_modules/
-evm/build/
-evm/.python-version
+evm/
+examples/
+integration/
 
 internal/gethnet/datadir/geth
 internal/clroot/db.bolt

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,24 @@ ARG COMMIT_SHA
 ARG ENVIRONMENT
 
 WORKDIR /go/src/github.com/smartcontractkit/chainlink
+COPY GNUmakefile VERSION ./
+COPY tools/bin/ldflags ./tools/bin/
+
+# Do dep ensure in a cacheable step
+COPY Gopkg.toml Gopkg.lock ./
+RUN make godep
+
+# And yarn likewise
+COPY yarn.lock package.json ./
+COPY explorer/client/yarn.lock explorer/client/package.json ./explorer/client/
+COPY explorer/yarn.lock explorer/package.json ./explorer/
+COPY operator_ui/package.json ./operator_ui/
+COPY styleguide/package.json ./styleguide/
+RUN make yarndep
+
+# Install chainlink
 ADD . ./
-RUN make install
+RUN make install-chainlink
 
 # Final layer: ubuntu with chainlink binary
 FROM ubuntu:18.04

--- a/core/services/head_tracker.go
+++ b/core/services/head_tracker.go
@@ -1,11 +1,11 @@
 package services
 
 import (
-	"errors"
 	"fmt"
 	"sync"
 	"time"
 
+	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -235,11 +235,11 @@ func (ht *HeadTracker) subscribeToHead() error {
 	ht.headers = make(chan models.BlockHeader)
 	sub, err := ht.store.TxManager.SubscribeToNewHeads(ht.headers)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "TxManager#SubscribeToNewHeads")
 	}
 
 	if err = verifyEthereumChainID(ht); err != nil {
-		return err
+		return errors.Wrap(err, "verifyEthereumChainID")
 	}
 	ht.headSubscription = sub
 	ht.connected = true

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -2,46 +2,64 @@ version: '3.1'
 
 services:
 
-  geth:
-    image: ethereum/client-go
-    restart: on-failure
-    command: --dev --mine --networkid 17 --wsorigins "*" --ws --dev.period 2 --wsaddr 172.16.1.100 --wsport 18546 --datadir /root/gethnet/datadir --unlock "0x9ca9d2d5e04012c9ed24c0e513c9bfaa4a2dd77f" --ipcdisable --password /run/secrets/node_password
-    volumes:
-      - ./tools/gethnet/:/root/gethnet
+  db:
+    image: postgres
     networks:
-      gethnet:
+      devnet:
         ipv4_address: 172.16.1.100
-    ports: []
-    secrets:
-      - node_password
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: explorer_dev
+
+  devnet:
+    image: smartcontract/devnet
+    networks:
+      devnet:
+        ipv4_address: 172.16.1.101
 
   chainlink:
-    image: smartcontract/chainlink-sgx
-    command: node -d -p /run/secrets/node_password -a /run/secrets/apicredentials
+    image: smartcontract/chainlink
+    command: local node -d -p /run/secrets/node_password
     restart: always
     volumes:
       - ./tools/clroot/:/root/clroot
     environment:
+      - ETH_CHAIN_ID=34055
       - LOG_LEVEL=debug
       - ROOT=/root/clroot
-      - ETH_HOST=172.16.1.100
-      - ETH_CHAIN_ID=17
+      - ETH_URL=ws://172.16.1.101:8546
       - MIN_OUTGOING_CONFIRMATIONS=2
       - MINIMUM_CONTRACT_PAYMENT=1000000000000
       - RUST_BACKTRACE=1
       - CHAINLINK_DEV=true
+      - EXPLORER_URL=ws://172.16.1.102:8312
     networks:
-      gethnet:
-        ipv4_address: 172.16.1.101
-    depends_on:
-      - geth
+      devnet:
+        ipv4_address: 172.16.1.102
     ports:
-      - 6688:6688
+      - 8131:6688
+    depends_on:
+      - devnet
     secrets:
       - node_password
 
+  explorer:
+    image: smartcontract/explorer:latest
+    restart: always
+    networks:
+      devnet:
+        ipv4_address: 172.16.1.103
+    ports:
+      - 8132:8080
+    environment:
+      TYPEORM_DATABASE: explorer_dev
+      TYPEORM_USERNAME: postgres
+      TYPEORM_HOST: 172.16.1.100
+      TYPEORM_PORT: 5432
+
 networks:
-  gethnet:
+  devnet:
     driver: bridge
     ipam:
       driver: default
@@ -51,3 +69,7 @@ networks:
 secrets:
   node_password:
     file: ./tools/clroot/password.txt
+
+volumes:
+  db-data:
+    driver: local

--- a/truffle-box.json
+++ b/truffle-box.json
@@ -25,7 +25,7 @@
     "Gopkg.toml",
     "integration",
     "LICENSE",
-    "Makefile",
+    "GNUmakefile",
     "operator_ui",
     "package.json",
     "README.md",


### PR DESCRIPTION
  1. Dep ensure add a -v, this makes it work within docker a bit better
  2. Base dockerfile is now staged for better caching
  3. chainlink/install-chainlink steps broken out to be clearer, and chainlink target is fixed
  4. docker-compose now includes explorer, and changes to devnet