### PR TITLE
Tx Attempt Limit

### DIFF
--- a/core/store/config.go
+++ b/core/store/config.go
@@ -74,6 +74,7 @@ type ConfigSchema struct {
 	TLSHost                  string         `env:"CHAINLINK_TLS_HOST" `
 	TLSKeyPath               string         `env:"TLS_KEY_PATH" `
 	TLSPort                  uint16         `env:"CHAINLINK_TLS_PORT" default:"6689"`
+	TxAttemptLimit           uint16         `env:"CHAINLINK_TX_ATTEMPT_LIMIT" default:"10"`
 }
 
 var configFileNotFoundError = reflect.TypeOf(viper.ConfigFileNotFoundError{})
@@ -332,6 +333,12 @@ func (c Config) TLSKeyPath() string {
 // TLSPort represents the port Chainlink should listen on for encrypted client requests.
 func (c Config) TLSPort() uint16 {
 	return c.getWithFallback("TLSPort", parsePort).(uint16)
+}
+
+// TxAttemptLimit represents the maximum number of transaction attempts that
+// the TxManager should allow to for a transaction
+func (c Config) TxAttemptLimit() uint16 {
+	return c.getWithFallback("TxAttemptLimit", parsePort).(uint16)
 }
 
 // KeysDir returns the path of the keys directory (used for keystore files).

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -147,6 +147,7 @@ type whitelist struct {
 	SessionTimeout           time.Duration   `json:"sessionTimeout"`
 	TLSHost                  string          `json:"chainlinkTLSHost"`
 	TLSPort                  uint16          `json:"chainlinkTLSPort"`
+	TxAttemptLimit           uint16          `json:"txAttemptLimit"`
 }
 
 // NewConfigWhitelist creates an instance of ConfigWhitelist
@@ -190,6 +191,7 @@ func NewConfigWhitelist(store *store.Store) (ConfigWhitelist, error) {
 			SessionTimeout:           config.SessionTimeout(),
 			TLSHost:                  config.TLSHost(),
 			TLSPort:                  config.TLSPort(),
+			TxAttemptLimit:           config.TxAttemptLimit(),
 		},
 	}, nil
 }

--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -539,6 +539,17 @@ func (txm *EthTxManager) processAttempt(
 		return receipt, state, nil
 
 	case Unconfirmed:
+		attemptLimit := txm.config.TxAttemptLimit()
+		if attemptIndex >= int(attemptLimit) {
+			logger.Warnw(
+				fmt.Sprintf("Tx #%d has met TxAttemptLimit", attemptIndex),
+				"txAttemptLimit", attemptLimit,
+				"txHash", txAttempt.Hash.String(),
+				"txID", txAttempt.TxID,
+			)
+			return receipt, state, nil
+		}
+
 		if isLatestAttempt(tx, attemptIndex) && txm.hasTxAttemptMetGasBumpThreshold(tx, attemptIndex, blockHeight) {
 			logger.Debugw(
 				fmt.Sprintf("Tx #%d has met gas bump threshold, bumping gas", attemptIndex),

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -130,6 +130,64 @@ func TestTxManager_CreateTx_RoundRobinSuccess(t *testing.T) {
 	ethMock.EventuallyAllCalled(t)
 }
 
+func TestTxManager_CreateTx_BreakTxAttemptLimit(t *testing.T) {
+	t.Parallel()
+	app, cleanup := cltest.NewApplicationWithKey(t)
+	defer cleanup()
+	store := app.Store
+	config := store.Config
+	config.Set("CHAINLINK_TX_ATTEMPT_LIMIT", 1)
+	manager := store.TxManager
+
+	to := cltest.NewAddress()
+	data, err := hex.DecodeString("0000abcdef")
+	assert.NoError(t, err)
+	hash := cltest.NewHash()
+	sentAt := uint64(23456)
+	nonce := uint64(256)
+
+	ethMock := app.MockEthClient(cltest.Strict)
+	ethMock.Context("app.StartAndConnect()", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce))
+		ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+	})
+	assert.NoError(t, app.StartAndConnect())
+
+	require.True(t, manager.Connected())
+	ethMock.Context("manager.CreateTx#1", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_sendRawTransaction", hash)
+		ethMock.Register("eth_blockNumber", utils.Uint64ToHex(sentAt))
+		ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{})
+	})
+
+	tx, err := manager.CreateTx(to, data)
+	require.NoError(t, err)
+	require.NotNil(t, tx)
+
+	ethMock.Context("manager.bumpGas#1", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_sendRawTransaction", cltest.NewHash())
+		ethMock.Register("eth_blockNumber", utils.Uint64ToHex(sentAt+config.EthGasBumpThreshold()))
+	})
+
+	receipt, state, err := manager.BumpGasUntilSafe(tx.Attempts[0].Hash)
+	assert.NoError(t, err)
+	assert.Nil(t, receipt)
+	assert.Equal(t, strpkg.Unconfirmed, state)
+
+	ethMock.Context("manager.bumpGas#1", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{})
+		ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{})
+		ethMock.Register("eth_blockNumber", utils.Uint64ToHex(sentAt+2*config.EthGasBumpThreshold()))
+	})
+
+	receipt, state, err = manager.BumpGasUntilSafe(tx.Attempts[0].Hash)
+	assert.NoError(t, err)
+	assert.Nil(t, receipt)
+	assert.Equal(t, strpkg.Unconfirmed, state)
+
+	ethMock.EventuallyAllCalled(t)
+}
+
 func TestTxManager_CreateTx_AttemptErrorDoesNotIncrementNonce(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Add a configurable Tx Attempt Limit which provides a hard ceiling on the number of times gas can be bumped for a transaction .

Defaults to 10.

[Finishes #163962630]