### PR TITLE
When Parity light client response with EmptyResponse, we can retry

### DIFF
--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net"
+	"regexp"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -114,6 +115,9 @@ func createTxRunResult(
 	if IsClientRetriable(err) {
 		input.MarkPendingConnection()
 		return
+	} else if IsClientEmptyError(err) {
+		input.MarkPendingConfirmations()
+		return
 	} else if err != nil {
 		input.SetError(err)
 		return
@@ -212,4 +216,15 @@ func IsClientRetriable(err error) bool {
 	}
 
 	return false
+}
+
+var (
+	parityEmptyResponseRegex = regexp.MustCompile("Error cause was EmptyResponse")
+)
+
+// Parity light clients can return an EmptyResponse error when they don't have
+// access to the transaction in the mempool. If we wait long enough it should
+// eventually return a transaction receipt.
+func IsClientEmptyError(err error) bool {
+	return err != nil && parityEmptyResponseRegex.MatchString(err.Error())
 }

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -274,10 +274,10 @@ func (orm *ORM) convenientTransaction(callback func(*gorm.DB) error) error {
 	if dbtx.Error != nil {
 		return dbtx.Error
 	}
+	defer dbtx.Rollback()
 
 	err := callback(dbtx)
 	if err != nil {
-		dbtx.Rollback()
 		return err
 	}
 


### PR DESCRIPTION
[Fixes #166627069]