### PR TITLE
Fix for the random adapter

### DIFF
--- a/core/adapters/random.go
+++ b/core/adapters/random.go
@@ -20,6 +20,6 @@ func (ra *Random) Perform(input models.RunResult, _ *store.Store) models.RunResu
 		return input
 	}
 	ran := new(big.Int).SetBytes(b)
-	input.ApplyResult(ran.String())
+	input.CompleteWithResult(ran.String())
 	return input
 }


### PR DESCRIPTION
For https://www.pivotaltracker.com/story/show/164472932
Were there changes made to the task runner before the PR for random adapter got merged? I'm pretty sure I had ran it and it worked with `ApplyResult` in the past, but I reproduce Thomas' report now. 
cc @dimroc 