### PR TITLE
Avoid int64 overflow in utils.EVMTranscodeBytes, error on overflow in conversion to int256

### DIFF
--- a/core/utils/ethabi.go
+++ b/core/utils/ethabi.go
@@ -3,10 +3,11 @@ package utils
 import (
 	"bytes"
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"math/big"
 	"strconv"
+
+	"github.com/pkg/errors"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
@@ -41,13 +42,13 @@ func EVMTranscodeBytes(value gjson.Result) ([]byte, error) {
 		return EVMEncodeBytes(EVMWordUint64(1)), nil
 
 	case gjson.Number:
-		word, err := EVMWordSignedBigInt(big.NewInt(int64(value.Num)))
+		v := big.NewFloat(value.Num)
+		vInt, _ := v.Int(big.NewInt(0))
+		word, err := EVMWordSignedBigInt(vInt)
 		if err != nil {
-			return []byte{}, nil
+			return nil, errors.Wrap(err, "while converting float to int256")
 		}
-
 		return EVMEncodeBytes(word), nil
-
 	default:
 		return []byte{}, fmt.Errorf("unsupported encoding for value: %s", value.Type)
 	}

--- a/core/utils/ethabi.go
+++ b/core/utils/ethabi.go
@@ -43,7 +43,7 @@ func EVMTranscodeBytes(value gjson.Result) ([]byte, error) {
 
 	case gjson.Number:
 		v := big.NewFloat(value.Num)
-		vInt, _ := v.Int(big.NewInt(0))
+		vInt, _ := v.Int(nil)
 		word, err := EVMWordSignedBigInt(vInt)
 		if err != nil {
 			return nil, errors.Wrap(err, "while converting float to int256")

--- a/core/utils/ethabi_test.go
+++ b/core/utils/ethabi_test.go
@@ -127,7 +127,7 @@ func TestEVMTranscodeBytes(t *testing.T) {
 				"0000000000000000000000000000000000000000000000000000000000000013",
 			false,
 		},
-		{"value won't fit in int256", `1e300`, "", true},
+		{"value won't fit in int256", `1e300`, "0x", true},
 	}
 	for _, tt := range tests {
 		test := tt
@@ -135,9 +135,7 @@ func TestEVMTranscodeBytes(t *testing.T) {
 			input := gjson.Parse(test.input)
 			out, err := EVMTranscodeBytes(input)
 			assert.Equal(t, tt.errs, err != nil, "unexpected error value")
-			if !tt.errs {
-				assert.Equal(t, test.output, hexutil.Encode(out))
-			}
+			assert.Equal(t, test.output, hexutil.Encode(out))
 		})
 	}
 }


### PR DESCRIPTION
Convert JSON number to a `big.Float` instead of an `int64`, to avoid silent overflow. It's now possible for the conversion to `int256` to overflow.

It's probably undesirable for `EthTx` (which relies on this code) to silently truncate floats to integers, but fixing that is going to be some effort. [Tracker story on the subject](https://www.pivotaltracker.com/story/show/167473125).