### PR TITLE
Fix status card

### DIFF
--- a/operator_ui/__tests__/components/JobRuns/StatusCard.test.js
+++ b/operator_ui/__tests__/components/JobRuns/StatusCard.test.js
@@ -14,7 +14,7 @@ describe('components/JobRuns/StatusCard', () => {
   const completedRun = {
     id: 'runA',
     status: 'completed',
-    result: { amount: 2000000000000000000 },
+    overrides: { amount: 2000000000000000000 },
     createdAt: TWO_MINUTES_MS,
     finishedAt: MINUTE_MS
   }

--- a/operator_ui/__tests__/components/JobRuns/StatusCard.test.js
+++ b/operator_ui/__tests__/components/JobRuns/StatusCard.test.js
@@ -39,22 +39,14 @@ describe('components/JobRuns/StatusCard', () => {
     expect(withChildren.text()).toContain('I am a child')
   })
 
-  it('can display the elapsed time for completed and errored jobs', () => {
-    let erroredStatus = mountWithTheme(
-      <StatusCard title="errored" jobRun={erroredRun} />
-    )
-    let completedStatus = mountWithTheme(
-      <StatusCard title="completed" jobRun={completedRun} />
-    )
+  it('can display the elapsed time for jobruns', () => {
+    let erroredStatus = mountWithTheme(<StatusCard title="errored" jobRun={erroredRun} />)
+    let completedStatus = mountWithTheme(<StatusCard title="completed" jobRun={completedRun} />)
+    let pendingStatus = mountWithTheme(<StatusCard title="pending" jobRun={pendingRun} />)
+
     expect(erroredStatus.text()).toContain('1m')
     expect(completedStatus.text()).toContain('1m')
-  })
-
-  it('will not display the elapsed time for pending jobs', () => {
-    let pendingStatus = mountWithTheme(
-      <StatusCard title="pending_confirmations" jobRun={pendingRun} />
-    )
-    expect(pendingStatus.text()).not.toContain('1m')
+    expect(pendingStatus.html()).toContain('id="elapsedTime"')
   })
 
   it('can display link earned for completed jobs', () => {

--- a/operator_ui/src/components/ElapsedTime.tsx
+++ b/operator_ui/src/components/ElapsedTime.tsx
@@ -8,9 +8,10 @@ interface IProps {
   className: string
 }
 
-const ElapsedTime = ({ start, end, className }: IProps) => {
+const ElapsedTime =
+({ start, end, className }: IProps) => {
   return (
-    <Typography variant="h6" className={className}>
+    <Typography id='elapsedTime' variant="h6" className={className}>
       {elapsedTimeHHMMSS(start, end)}
     </Typography>
   )

--- a/operator_ui/src/components/JobRuns/StatusCard.tsx
+++ b/operator_ui/src/components/JobRuns/StatusCard.tsx
@@ -67,7 +67,7 @@ const EarnedLink = ({
   jobRun?: IJobRun
   classes: WithStyles<typeof styles>['classes']
 }) => {
-  const linkEarned = jobRun && jobRun.result && jobRun.result.amount
+  const linkEarned = jobRun && jobRun.overrides && jobRun.overrides.amount
   return (
     <Typography className={classes.earnedLink} variant="h6">
       +{linkEarned ? selectLink(linkEarned) : 0} Link
@@ -93,7 +93,7 @@ const StatusCard = ({ title, classes, children, jobRun }: IProps) => {
             <Typography className={classes.statusText} variant="h5">
               {titleCase(title)}
             </Typography>
-            {status !== 'pending' && (
+            {(status === 'completed' || status === 'errored') && (
               <ElapsedTime
                 start={createdAt}
                 end={finishedAt}


### PR DESCRIPTION
For reasons unbeknownst to me, Chainlink presenter presents the link earned amount in the overrides field. Previously, I thought that this information was available in the result field, but now that I've tested the StatusCard with the real runs, I observed that this is not the case. Also, there are other statuses such as `pending_sleep` `pending_bridge` that need to avoid displaying ElapsedTime, so I've adjusted the card to show elapsed time only on `Completed` and `Errored` jobs.

Here is a real Run json that shows where `amount` is located. 
```
{"data":{"type":"runs","id":"1b9ebaf057fb4ab68c77beac0288e5f1","attributes":{"id":"1b9ebaf057fb4ab68c77beac0288e5f1","jobId":"4d7223be487643f1b3116213dc7ded70","result":{"jobRunId":"1b9ebaf057fb4ab68c77beac0288e5f1","taskRunId":"00df0abc3e6c42169dace6302a0a9bb6","data":{"address":"0x029a9500e3962a8aEA7678B317AcabBf2433eA58","dataPrefix":"0x34b8614a618b7743f1cc493138a0818afed91fcb8807719271a692742e0b563d0000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000046257ccea1de8158d85fa0733b8ae2e6b4fcacb592cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005d3821fb","ethereumReceipts":[{"blockHash":"0xe79aa1f840abe3644cd4ca108b180f2b20a2b0444db47885e8414134c80e08fe","blockNumber":6051875,"logs":[{"address":"0x46257ccea1de8158d85fa0733b8ae2e6b4fcacb5","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x0","data":"0x","logIndex":"0x0","removed":false,"topics":["0x7cc135e0cebb02c3480ae5d74d377283180a2601f8f644edf7987b009316c63a","0x34b8614a618b7743f1cc493138a0818afed91fcb8807719271a692742e0b563d"],"transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x0"},{"address":"0x46257ccea1de8158d85fa0733b8ae2e6b4fcacb5","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x0","data":"0x","logIndex":"0x0","removed":false,"topics":["0x794eb9e29f6750ede99e05248d997a9ab9fa23c4a7eaff8afa729080eb7c6428","0x34b8614a618b7743f1cc493138a0818afed91fcb8807719271a692742e0b563d","0x3230372e35320000000000000000000000000000000000000000000000000000"],"transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x0"}],"transactionHash":"0x4f634a03084c8de5888f13e51c52abd09340b514846cfd0850b8b3aeebed0256"}],"functionSelector":"0x4ab0d190","latestOutgoingTxHash":"0x4f634a03084c8de5888f13e51c52abd09340b514846cfd0850b8b3aeebed0256","path":"USD","result":"0x4f634a03084c8de5888f13e51c52abd09340b514846cfd0850b8b3aeebed0256","times":100,"url":"https://min-api.cryptocompare.com/data/price?fsym=ETH\u0026tsyms=USD"},"status":"completed","error":null},"status":"completed","taskRuns":[{"id":"a786ee0aacf845c09d48876fcce39ccd","result":{"jobRunId":"1b9ebaf057fb4ab68c77beac0288e5f1","taskRunId":"a786ee0aacf845c09d48876fcce39ccd","data":{"address":"0x029a9500e3962a8aEA7678B317AcabBf2433eA58","dataPrefix":"0x34b8614a618b7743f1cc493138a0818afed91fcb8807719271a692742e0b563d0000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000046257ccea1de8158d85fa0733b8ae2e6b4fcacb592cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005d3821fb","functionSelector":"0x4ab0d190","path":"USD","result":"{\"USD\":207.52}","times":100,"url":"https://min-api.cryptocompare.com/data/price?fsym=ETH\u0026tsyms=USD"},"status":"completed","error":null},"status":"completed","task":{"ID":20,"CreatedAt":"2019-07-24T06:12:44.515439737-04:00","UpdatedAt":"2019-07-24T06:12:44.515439737-04:00","DeletedAt":null,"type":"httpget","confirmations":null,"params":{}},"minimumConfirmations":3,"confirmations":3},{"id":"48b6026db6d740619c2d980fce040d4b","result":{"jobRunId":"1b9ebaf057fb4ab68c77beac0288e5f1","taskRunId":"48b6026db6d740619c2d980fce040d4b","data":{"address":"0x029a9500e3962a8aEA7678B317AcabBf2433eA58","dataPrefix":"0x34b8614a618b7743f1cc493138a0818afed91fcb8807719271a692742e0b563d0000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000046257ccea1de8158d85fa0733b8ae2e6b4fcacb592cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005d3821fb","functionSelector":"0x4ab0d190","path":"USD","result":207.52,"times":100,"url":"https://min-api.cryptocompare.com/data/price?fsym=ETH\u0026tsyms=USD"},"status":"completed","error":null},"status":"completed","task":{"ID":21,"CreatedAt":"2019-07-24T06:12:44.515547174-04:00","UpdatedAt":"2019-07-24T06:12:44.515547174-04:00","DeletedAt":null,"type":"jsonparse","confirmations":null,"params":{}},"minimumConfirmations":3,"confirmations":3},{"id":"d3653c04cd2a48ad8c0c29d3de29860d","result":{"jobRunId":"1b9ebaf057fb4ab68c77beac0288e5f1","taskRunId":"d3653c04cd2a48ad8c0c29d3de29860d","data":{"address":"0x029a9500e3962a8aEA7678B317AcabBf2433eA58","dataPrefix":"0x34b8614a618b7743f1cc493138a0818afed91fcb8807719271a692742e0b563d0000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000046257ccea1de8158d85fa0733b8ae2e6b4fcacb592cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005d3821fb","functionSelector":"0x4ab0d190","path":"USD","result":"0x3230372e35320000000000000000000000000000000000000000000000000000","times":100,"url":"https://min-api.cryptocompare.com/data/price?fsym=ETH\u0026tsyms=USD"},"status":"completed","error":null},"status":"completed","task":{"ID":22,"CreatedAt":"2019-07-24T06:12:44.515653919-04:00","UpdatedAt":"2019-07-24T06:12:44.515653919-04:00","DeletedAt":null,"type":"ethbytes32","confirmations":null,"params":{}},"minimumConfirmations":3,"confirmations":3},{"id":"00df0abc3e6c42169dace6302a0a9bb6","result":{"jobRunId":"1b9ebaf057fb4ab68c77beac0288e5f1","taskRunId":"00df0abc3e6c42169dace6302a0a9bb6","data":{"address":"0x029a9500e3962a8aEA7678B317AcabBf2433eA58","dataPrefix":"0x34b8614a618b7743f1cc493138a0818afed91fcb8807719271a692742e0b563d0000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000046257ccea1de8158d85fa0733b8ae2e6b4fcacb592cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005d3821fb","ethereumReceipts":[{"blockHash":"0xe79aa1f840abe3644cd4ca108b180f2b20a2b0444db47885e8414134c80e08fe","blockNumber":6051875,"logs":[{"address":"0x46257ccea1de8158d85fa0733b8ae2e6b4fcacb5","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x0","data":"0x","logIndex":"0x0","removed":false,"topics":["0x7cc135e0cebb02c3480ae5d74d377283180a2601f8f644edf7987b009316c63a","0x34b8614a618b7743f1cc493138a0818afed91fcb8807719271a692742e0b563d"],"transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x0"},{"address":"0x46257ccea1de8158d85fa0733b8ae2e6b4fcacb5","blockHash":"0x0000000000000000000000000000000000000000000000000000000000000000","blockNumber":"0x0","data":"0x","logIndex":"0x0","removed":false,"topics":["0x794eb9e29f6750ede99e05248d997a9ab9fa23c4a7eaff8afa729080eb7c6428","0x34b8614a618b7743f1cc493138a0818afed91fcb8807719271a692742e0b563d","0x3230372e35320000000000000000000000000000000000000000000000000000"],"transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x0"}],"transactionHash":"0x4f634a03084c8de5888f13e51c52abd09340b514846cfd0850b8b3aeebed0256"}],"functionSelector":"0x4ab0d190","latestOutgoingTxHash":"0x4f634a03084c8de5888f13e51c52abd09340b514846cfd0850b8b3aeebed0256","path":"USD","result":"0x4f634a03084c8de5888f13e51c52abd09340b514846cfd0850b8b3aeebed0256","times":100,"url":"https://min-api.cryptocompare.com/data/price?fsym=ETH\u0026tsyms=USD"},"status":"completed","error":null},"status":"completed","task":{"ID":23,"CreatedAt":"2019-07-24T06:12:44.515755332-04:00","UpdatedAt":"2019-07-24T06:12:44.515755332-04:00","DeletedAt":null,"type":"ethtx","confirmations":null,"params":{}},"minimumConfirmations":3,"confirmations":3}],"createdAt":"2019-07-24T06:14:17.460452024-04:00","finishedAt":"2019-07-24T06:17:01.013668984-04:00","updatedAt":"2019-07-24T06:17:01.014297405-04:00","creationHeight":6051870,"observedHeight":6051885,"overrides":{"jobRunId":"","taskRunId":"","data":{"address":"0x029a9500e3962a8aEA7678B317AcabBf2433eA58","dataPrefix":"0x34b8614a618b7743f1cc493138a0818afed91fcb8807719271a692742e0b563d0000000000000000000000000000000000000000000000000de0b6b3a764000000000000000000000000000046257ccea1de8158d85fa0733b8ae2e6b4fcacb592cdaaf300000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000005d3821fb","functionSelector":"0x4ab0d190","path":"USD","times":100,"url":"https://min-api.cryptocompare.com/data/price?fsym=ETH\u0026tsyms=USD"},"status":"","error":null,"amount":"1000000000000000000"},"initiator":{"type":"runlog","params":{"address":"0x029a9500e3962a8aea7678b317acabbf2433ea58"}}}}}
``` 