### PR TITLE
Fix createdAt on CLI job creation

### DIFF
--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -69,7 +69,8 @@ func (j *JobSpec) SetID(value string) error {
 // the CreatedAt field to the time of invokation.
 func NewJob() JobSpec {
 	return JobSpec{
-		ID: utils.NewBytes32ID(),
+		ID:        utils.NewBytes32ID(),
+		CreatedAt: time.Now(),
 	}
 }
 

--- a/core/store/models/job_spec_test.go
+++ b/core/store/models/job_spec_test.go
@@ -49,16 +49,12 @@ func TestJobSpec_Save(t *testing.T) {
 	befCreation := time.Now()
 	j1 := cltest.NewJobWithSchedule("* * * * 7")
 	aftCreation := time.Now()
-
 	assert.True(t, true, j1.CreatedAt.After(aftCreation), j1.CreatedAt.Before(befCreation))
-	tBef := j1.CreatedAt
+	assert.False(t, false, j1.CreatedAt.IsZero())
 
 	befInsertion := time.Now()
 	assert.NoError(t, store.CreateJob(&j1))
 	aftInsertion := time.Now()
-
-	tAft := j1.CreatedAt
-	assert.Equal(t, tBef, tAft)
 	assert.True(t, true, j1.CreatedAt.After(aftInsertion), j1.CreatedAt.Before(befInsertion))
 
 	initr := j1.Initiators[0]

--- a/core/store/models/job_spec_test.go
+++ b/core/store/models/job_spec_test.go
@@ -46,8 +46,21 @@ func TestJobSpec_Save(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
+	befCreation := time.Now()
 	j1 := cltest.NewJobWithSchedule("* * * * 7")
+	aftCreation := time.Now()
+
+	assert.True(t, true, j1.CreatedAt.After(aftCreation), j1.CreatedAt.Before(befCreation))
+	tBef := j1.CreatedAt
+
+	befInsertion := time.Now()
 	assert.NoError(t, store.CreateJob(&j1))
+	aftInsertion := time.Now()
+
+	tAft := j1.CreatedAt
+	assert.Equal(t, tBef, tAft)
+	assert.True(t, true, j1.CreatedAt.After(aftInsertion), j1.CreatedAt.Before(befInsertion))
+
 	initr := j1.Initiators[0]
 
 	j2, err := store.FindJob(j1.ID)


### PR DESCRIPTION
For [#166771657](https://www.pivotaltracker.com/story/show/166771657)

@dimroc this was removed in https://github.com/smartcontractkit/chainlink/commit/3ed7eb690373986ba21d7794ed996265e3bf46ac#diff-44139d287260a9d300b778f3296c7c4aL60 
was it an intentional change?
I mean the function doc says 
```
// NewJob initializes a new job by generating a unique ID and setting
// the CreatedAt field to the time of invokation.
```
but clearly `CreatedAt` is not modified
