### PR TITLE
Check the `err` value returned by `convenientTransaction`

### DIFF
--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -527,6 +527,9 @@ func (orm *ORM) CreateTx(
 
 		return dbtx.Save(tx).Error
 	})
+	if err != nil {
+		return nil, err
+	}
 	return tx, nil
 }
 


### PR DESCRIPTION
This ensures that if a transaction can't be saved to the database for some
reason, clients of orm.CreateTx can learn of it.