### PR TITLE
Add preliminary linting and fix lint errors

### DIFF
--- a/evm/box/package.json
+++ b/evm/box/package.json
@@ -8,6 +8,7 @@
     "console:live": "npx truffle console --network live",
     "migrate:dev": "npx truffle migrate --reset --network cldev",
     "migrate:live": "npx truffle migrate --network live",
+    "lint": "echo \"No linter configured for evm-box project\" &&  exit 0",
     "test": "npx truffle test"
   },
   "license": "MIT",

--- a/evm/package.json
+++ b/evm/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "truffle build",
     "test": "truffle test",
+    "lint": "echo \"No linter configured for evm project\" &&  exit 0",
     "flatten": "../tools/bin/flatten-testnet"
   },
   "dependencies": {

--- a/examples/echo_server/package.json
+++ b/examples/echo_server/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "test": "truffle test"
+    "test": "truffle test",
+    "lint": "echo \"No linter configured for examples/echo_server\" && exit 0"
   },
   "devDependencies": {
     "body-parser": "^1.18.3",

--- a/examples/testnet/package.json
+++ b/examples/testnet/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.6.0",
   "license": "MIT",
+  "scripts": {
+    "lint": "echo \"No linter configured for examples/testnet\" && exit 0"
+  },
   "devDependencies": {
     "truffle": "^5.0.25"
   }

--- a/examples/twilio_sms/package.json
+++ b/examples/twilio_sms/package.json
@@ -4,7 +4,8 @@
   "version": "0.6.0",
   "license": "MIT",
   "scripts": {
-    "test": "truffle test"
+    "test": "truffle test",
+    "lint": "echo \"No linter configured for examples/twilio_sms\" && exit 0"
   },
   "devDependencies": {
     "body-parser": "^1.18.3",

--- a/examples/uptime_sla/package.json
+++ b/examples/uptime_sla/package.json
@@ -4,7 +4,8 @@
   "license": "MIT",
   "private": true,
   "scripts": {
-    "test": "truffle test"
+    "test": "truffle test",
+    "lint": "echo \"No linter configured for uptime_sla\" && exit 0"
   },
   "devDependencies": {
     "bignumber.js": "^8.0.1",

--- a/integration/package.json
+++ b/integration/package.json
@@ -5,7 +5,8 @@
   "license": "MIT",
   "scripts": {
     "test": "cross-env NODE_ENV=test jest",
-    "test:nocache": "cross-env NODE_ENV=test jest --no-cache"
+    "test:nocache": "cross-env NODE_ENV=test jest --no-cache",
+    "lint": "echo \"No linter configured for integration\" && exit 0"
   },
   "dependencies": {
     "chainlink": "0.6.1"

--- a/operator_ui/package.json
+++ b/operator_ui/package.json
@@ -29,14 +29,6 @@
     "@chainlink/styleguide": "0.0.0",
     "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^3.0.1",
-    "@types/classnames": "^2.2.8",
-    "@types/lodash": "^4.14.135",
-    "@types/node": "^11.9.5",
-    "@types/react": "^16.7.0",
-    "@types/react-dom": "^16.7.0",
-    "@types/react-redux": "~6.0.0",
-    "@types/react-resize-detector": "^4.0.1",
-    "@types/react-router-dom": "^4.3.4",
     "axios": "^0.18.0",
     "babel-jest": "^24.1.0",
     "bignumber.js": "^8.0.1",
@@ -87,5 +79,17 @@
     "use-react-hooks": "^1.0.7",
     "uuid": "^3.3.2"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@types/enzyme": "^3.10.3",
+    "@types/fetch-mock": "^7.3.1",
+    "@types/jest": "^24.0.16",
+    "@types/classnames": "^2.2.8",
+    "@types/lodash": "^4.14.135",
+    "@types/node": "^11.9.5",
+    "@types/react": "^16.7.0",
+    "@types/react-dom": "^16.7.0",
+    "@types/react-redux": "~6.0.0",
+    "@types/react-resize-detector": "^4.0.1",
+    "@types/react-router-dom": "^4.3.4"
+  }
 }

--- a/operator_ui/package.json
+++ b/operator_ui/package.json
@@ -9,6 +9,7 @@
     "serve": "serve dist -p 3000",
     "test": "cross-env NODE_ENV=test jest",
     "test:nocache": "cross-env NODE_ENV=test jest --no-cache",
+    "lint": "tsc --noEmit",
     "watch": "cross-env NODE_ENV=test jest --watchAll --notify"
   },
   "dependencies": {

--- a/operator_ui/src/components/JobRuns/TaskExpansionPanel.tsx
+++ b/operator_ui/src/components/JobRuns/TaskExpansionPanel.tsx
@@ -1,9 +1,9 @@
-import React from 'react'
 import { createStyles } from '@material-ui/core'
-import { withStyles, WithStyles } from '@material-ui/core/styles'
 import Grid from '@material-ui/core/Grid'
+import { withStyles, WithStyles } from '@material-ui/core/styles'
 import capitalize from 'lodash/capitalize'
-import { ITaskRun, IJobRun } from '../../../@types/operator_ui'
+import React from 'react'
+import { IJobRun, ITaskRun } from '../../../@types/operator_ui'
 import StatusItem from './StatusItem'
 import { stringify } from "javascript-stringify";
 
@@ -26,7 +26,7 @@ interface IItemProps extends WithStyles<typeof fontStyles> {
   colATitle: string
   colAValue: string
   colBTitle: string
-  colBValue?: string
+  colBValue: string | null
 }
 
 const Item = withStyles(fontStyles)(

--- a/operator_ui/src/components/JobRuns/TaskExpansionPanel.tsx
+++ b/operator_ui/src/components/JobRuns/TaskExpansionPanel.tsx
@@ -1,11 +1,11 @@
-import { createStyles } from '@material-ui/core'
-import Grid from '@material-ui/core/Grid'
-import { withStyles, WithStyles } from '@material-ui/core/styles'
-import capitalize from 'lodash/capitalize'
-import React from 'react'
-import { IJobRun, ITaskRun } from '../../../@types/operator_ui'
-import StatusItem from './StatusItem'
+import { createStyles } from '@material-ui/core';
+import Grid from '@material-ui/core/Grid';
+import { withStyles, WithStyles } from '@material-ui/core/styles';
 import { stringify } from "javascript-stringify";
+import capitalize from 'lodash/capitalize';
+import React from 'react';
+import { IJobRun, ITaskRun } from '../../../@types/operator_ui';
+import StatusItem from './StatusItem';
 
 const fontStyles = () =>
   createStyles({
@@ -26,7 +26,7 @@ interface IItemProps extends WithStyles<typeof fontStyles> {
   colATitle: string
   colAValue: string
   colBTitle: string
-  colBValue: string | null
+  colBValue?: string 
 }
 
 const Item = withStyles(fontStyles)(

--- a/operator_ui/tsconfig.json
+++ b/operator_ui/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "paths": {
+      "*": ["*", "src/*", "support/*"]
+    },
     "declaration": true,
     "target": "es2015",
     "module": "esnext",
@@ -16,12 +19,8 @@
     "strict": true,
     "esModuleInterop": true
   },
-  "include": [
-    "src/**/*"
-  ],
-  "references": [
-    { "path": "../styleguide" }
-  ],
+  "include": ["src"],
+  "references": [{ "path": "../styleguide" }],
   "files": [
     "@types/json-api-normalizer.d.ts",
     "@types/redux-object.d.ts",

--- a/operator_ui/tsconfig.json
+++ b/operator_ui/tsconfig.json
@@ -7,7 +7,7 @@
     "declaration": true,
     "target": "es2015",
     "module": "esnext",
-    "lib": ["es2015", "dom"],
+    "lib": ["dom"],
     "moduleResolution": "node",
     "skipLibCheck": true,
     "isolatedModules": false,
@@ -19,11 +19,6 @@
     "strict": true,
     "esModuleInterop": true
   },
-  "include": ["src"],
-  "references": [{ "path": "../styleguide" }],
-  "files": [
-    "@types/json-api-normalizer.d.ts",
-    "@types/redux-object.d.ts",
-    "@types/use-react-hooks.d.ts"
-  ]
+  "include": ["src", "@types"],
+  "references": [{ "path": "../styleguide" }]
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "examples/*"
   ],
   "scripts": {
+    "lint:all": "yarn workspaces run lint",
     "lint:fix": "eslint --fix --color --ext .js --ext .jsx --ext .ts --ext .tsx .",
     "lint:styleguide": "eslint --color --ext .js --ext .jsx --ext .ts --ext .tsx ./styleguide",
     "lint:operator-ui": "eslint --color --ext .js --ext .jsx --ext .ts --ext .tsx ./operator_ui",

--- a/styleguide/package.json
+++ b/styleguide/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "start": "start-storybook -p 9001",
     "build-storybook": "build-storybook",
-    "build": "tsc -b"
+    "build": "tsc -b",
+    "lint": "tsc --noEmit"
   },
   "dependencies": {
     "@babel/core": "^7.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2523,10 +2523,30 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cheerio@*":
+  version "0.22.12"
+  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.12.tgz#93c050401d4935a5376e8b352965f7458bed5340"
+  integrity sha512-aczowyAJNfrkBV+HS8DyAA87OnvkqGrrOmm5s7V6Jbgimzv/1ZoAy91cLJX8GQrUS60KufD7EIzA2LbK8HV4hg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/classnames@^2.2.8":
   version "2.2.9"
   resolved "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.9.tgz#d868b6febb02666330410fe7f58f3c4b8258be7b"
   integrity sha512-MNl+rT5UmZeilaPxAVs6YaPC2m6aA8rofviZbhbxpPpl61uKodfdQVsBtgJGTqGizEf02oW3tsVe7FYB8kK14A==
+
+"@types/enzyme@^3.10.3":
+  version "3.10.3"
+  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.3.tgz#02b6c5ac7d0472005944a652e79045e2f6c66804"
+  integrity sha512-f/Kcb84sZOSZiBPCkr4He9/cpuSLcKRyQaEE20Q30Prx0Dn6wcyMAWI0yofL6yvd9Ht9G7EVkQeRqK0n5w8ILw==
+  dependencies:
+    "@types/cheerio" "*"
+    "@types/react" "*"
+
+"@types/fetch-mock@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@types/fetch-mock/-/fetch-mock-7.3.1.tgz#df7421e8bcb351b430bfbfa5c52bb353826ac94f"
+  integrity sha512-2U4vZWHNbsbK7TRmizgr/pbKe0FKopcxu+hNDtIBDiM1wvrKRItybaYj7VQ6w/hZJStU/JxRiNi5ww4YDEvKbA==
 
 "@types/history@*":
   version "4.7.2"
@@ -2537,6 +2557,18 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#2cc2ca41051498382b43157c8227fea60363f94a"
   integrity sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==
+
+"@types/jest-diff@*":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
+  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
+
+"@types/jest@^24.0.16":
+  version "24.0.16"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.16.tgz#8d3e406ec0f0dc1688d6711af3062ff9bd428066"
+  integrity sha512-JrAiyV+PPGKZzw6uxbI761cHZ0G7QMOHXPhtSpcl08rZH6CswXaaejckn3goFKmF7M3nzEoJ0lwYCbqLMmjziQ==
+  dependencies:
+    "@types/jest-diff" "*"
 
 "@types/jss@^9.5.6":
   version "9.5.8"


### PR DESCRIPTION
This adds typescript type compilation checking where needed so we can quickly check for project-wide type errors. 

Once #1497 is merged, I can rebase this against master if needed.

## Future work
Opens up the possibility to integrate per-package `eslint` so we can remove it from the root workspace.
Opens up the possibility to run per-package formatting with `prettier` 

- Adds root workspace command `lint:all` which will run the configured linter per project.