### PR TITLE
Fix typescript configuration for operator_ui

### DIFF
--- a/operator_ui/package.json
+++ b/operator_ui/package.json
@@ -29,14 +29,6 @@
     "@chainlink/styleguide": "0.0.0",
     "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^3.0.1",
-    "@types/classnames": "^2.2.8",
-    "@types/lodash": "^4.14.135",
-    "@types/react-resize-detector": "^4.0.1",
-    "@types/react-router-dom": "^4.3.4",
-    "@types/node": "^11.9.5",
-    "@types/react": "^16.7.0",
-    "@types/react-dom": "^16.7.0",
-    "@types/react-redux": "~6.0.0",
     "axios": "^0.18.0",
     "babel-jest": "^24.1.0",
     "bignumber.js": "^8.0.1",
@@ -81,10 +73,22 @@
     "redux-object": "^0.5.6",
     "redux-thunk": "^2.3.0",
     "serve": "^10.0.0",
+    "typescript": "^3.5.0",
     "url": "^0.11.0",
     "use-react-hooks": "^1.0.7",
-    "uuid": "^3.3.2",
-    "typescript": "^3.5.0"
+    "uuid": "^3.3.2"
   },
-  "devDependencies": {}
+  "devDependencies": {
+    "@types/enzyme": "^3.10.3",
+    "@types/fetch-mock": "^7.3.1",
+    "@types/jest": "^24.0.16",
+    "@types/classnames": "^2.2.8",
+    "@types/lodash": "^4.14.135",
+    "@types/node": "^11.9.5",
+    "@types/react": "^16.7.0",
+    "@types/react-dom": "^16.7.0",
+    "@types/react-redux": "~6.0.0",
+    "@types/react-resize-detector": "^4.0.1",
+    "@types/react-router-dom": "^4.3.4"
+  }
 }

--- a/operator_ui/tsconfig.json
+++ b/operator_ui/tsconfig.json
@@ -1,6 +1,9 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
+    "paths": {
+      "*": ["*", "src/*", "support/*"]
+    },
     "declaration": true,
     "target": "es2015",
     "module": "esnext",
@@ -16,12 +19,8 @@
     "strict": true,
     "esModuleInterop": true
   },
-  "include": [
-    "src/**/*"
-  ],
-  "references": [
-    { "path": "../styleguide" }
-  ],
+  "include": ["src"],
+  "references": [{ "path": "../styleguide" }],
   "files": [
     "@types/json-api-normalizer.d.ts",
     "@types/redux-object.d.ts",

--- a/operator_ui/tsconfig.json
+++ b/operator_ui/tsconfig.json
@@ -7,7 +7,7 @@
     "declaration": true,
     "target": "es2015",
     "module": "esnext",
-    "lib": ["es2015", "dom"],
+    "lib": ["dom"],
     "moduleResolution": "node",
     "skipLibCheck": true,
     "isolatedModules": false,
@@ -19,11 +19,6 @@
     "strict": true,
     "esModuleInterop": true
   },
-  "include": ["src"],
-  "references": [{ "path": "../styleguide" }],
-  "files": [
-    "@types/json-api-normalizer.d.ts",
-    "@types/redux-object.d.ts",
-    "@types/use-react-hooks.d.ts"
-  ]
+  "include": ["src", "@types"],
+  "references": [{ "path": "../styleguide" }]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2523,10 +2523,30 @@
   dependencies:
     "@types/node" "*"
 
+"@types/cheerio@*":
+  version "0.22.12"
+  resolved "https://registry.yarnpkg.com/@types/cheerio/-/cheerio-0.22.12.tgz#93c050401d4935a5376e8b352965f7458bed5340"
+  integrity sha512-aczowyAJNfrkBV+HS8DyAA87OnvkqGrrOmm5s7V6Jbgimzv/1ZoAy91cLJX8GQrUS60KufD7EIzA2LbK8HV4hg==
+  dependencies:
+    "@types/node" "*"
+
 "@types/classnames@^2.2.8":
   version "2.2.9"
   resolved "https://registry.npmjs.org/@types/classnames/-/classnames-2.2.9.tgz#d868b6febb02666330410fe7f58f3c4b8258be7b"
   integrity sha512-MNl+rT5UmZeilaPxAVs6YaPC2m6aA8rofviZbhbxpPpl61uKodfdQVsBtgJGTqGizEf02oW3tsVe7FYB8kK14A==
+
+"@types/enzyme@^3.10.3":
+  version "3.10.3"
+  resolved "https://registry.yarnpkg.com/@types/enzyme/-/enzyme-3.10.3.tgz#02b6c5ac7d0472005944a652e79045e2f6c66804"
+  integrity sha512-f/Kcb84sZOSZiBPCkr4He9/cpuSLcKRyQaEE20Q30Prx0Dn6wcyMAWI0yofL6yvd9Ht9G7EVkQeRqK0n5w8ILw==
+  dependencies:
+    "@types/cheerio" "*"
+    "@types/react" "*"
+
+"@types/fetch-mock@^7.3.1":
+  version "7.3.1"
+  resolved "https://registry.yarnpkg.com/@types/fetch-mock/-/fetch-mock-7.3.1.tgz#df7421e8bcb351b430bfbfa5c52bb353826ac94f"
+  integrity sha512-2U4vZWHNbsbK7TRmizgr/pbKe0FKopcxu+hNDtIBDiM1wvrKRItybaYj7VQ6w/hZJStU/JxRiNi5ww4YDEvKbA==
 
 "@types/history@*":
   version "4.7.2"
@@ -2537,6 +2557,18 @@
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-1.1.0.tgz#2cc2ca41051498382b43157c8227fea60363f94a"
   integrity sha512-ohkhb9LehJy+PA40rDtGAji61NCgdtKLAlFoYp4cnuuQEswwdK3vz9SOIkkyc3wrk8dzjphQApNs56yyXLStaQ==
+
+"@types/jest-diff@*":
+  version "20.0.1"
+  resolved "https://registry.yarnpkg.com/@types/jest-diff/-/jest-diff-20.0.1.tgz#35cc15b9c4f30a18ef21852e255fdb02f6d59b89"
+  integrity sha512-yALhelO3i0hqZwhjtcr6dYyaLoCHbAMshwtj6cGxTvHZAKXHsYGdff6E8EPw3xLKY0ELUTQ69Q1rQiJENnccMA==
+
+"@types/jest@^24.0.16":
+  version "24.0.16"
+  resolved "https://registry.yarnpkg.com/@types/jest/-/jest-24.0.16.tgz#8d3e406ec0f0dc1688d6711af3062ff9bd428066"
+  integrity sha512-JrAiyV+PPGKZzw6uxbI761cHZ0G7QMOHXPhtSpcl08rZH6CswXaaejckn3goFKmF7M3nzEoJ0lwYCbqLMmjziQ==
+  dependencies:
+    "@types/jest-diff" "*"
 
 "@types/jss@^9.5.6":
   version "9.5.8"


### PR DESCRIPTION
- Started using the `devDependencies` field for separation of concerns between what we need for the actual app vs dev tooling / testing
- Fixed path resolution within `tsconfig` to match the path resolution we use for jest + react-static
- Cleaned up some redundant tsconfig settings
