### PR TITLE
README: Fix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Examples of how to utilize and integrate Chainlinks can be found in the [example
 
 1. [Install Go 1.10+](https://golang.org/doc/install#install), and add your GOPATH's [bin directory to your PATH](https://golang.org/doc/code.html#GOPATH)
 2. Install [NodeJS](https://nodejs.org/en/download/package-manager/) & [Yarn](https://yarnpkg.com/lang/en/docs/install/)
-3. Download Chainlink: `go get -d github.com/smartcontractkit/chainlink && cd $GOPATH/src/github.com/smartcontractkit/chainlink`
+3. Download Chainlink: `go get -d github.com/smartcontractkit/chainlink/... && cd $GOPATH/src/github.com/smartcontractkit/chainlink`
 4. Build and install Chainlink: `make install`
 5. Run the node: `chainlink help`
 


### PR DESCRIPTION
Fix an error in the install instructions by changing to 'go get' command to get all sub-packages.

The 'go get' command was returning an error as there are no '.go' files in the root of the project.