### PR TITLE
Add VSCode workspace file

### DIFF
--- a/chainlink.code-workspace
+++ b/chainlink.code-workspace
@@ -1,0 +1,37 @@
+{
+  "folders": [
+    {
+      "path": "."
+    },
+    { "path": "core" },
+    { "path": "examples" },
+    {
+      "path": "evm"
+    },
+    {
+      "path": "explorer"
+    },
+    {
+      "path": "integration"
+    },
+    {
+      "path": "styleguide"
+    },
+    {
+      "path": "operator_ui"
+    }
+  ],
+
+  "settings": {
+    "editor.codeActionsOnSave": {
+      "source.organizeImports": true
+    },
+    "editor.formatOnSave": true,
+
+    "typescript.preferences.importModuleSpecifier": "auto",
+    "javascript.preferences.importModuleSpecifier": "auto"
+  },
+  "extensions": {
+    "recommendations": ["esbenp.prettier-vscode"]
+  }
+}


### PR DESCRIPTION
This adds a workspace for people using VSCode or a fork of it. If deemed not needed, I can instead add this to `.gitignore`.


Includes:
- Recommendation to install `prettier` plugin
- Format on save
- Sort and remove unused imports
- Workspaces used