### PR TITLE
Fix readme install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Examples of how to utilize and integrate Chainlinks can be found in the [example
 
 1. [Install Go 1.10+](https://golang.org/doc/install#install), and add your GOPATH's [bin directory to your PATH](https://golang.org/doc/code.html#GOPATH)
 2. Install [NodeJS](https://nodejs.org/en/download/package-manager/) & [Yarn](https://yarnpkg.com/lang/en/docs/install/)
-3. Download Chainlink: `go get -d github.com/smartcontractkit/chainlink && cd $GOPATH/src/github.com/smartcontractkit/chainlink`
+3. Download Chainlink: `go get -d github.com/smartcontractkit/chainlink/... && cd $GOPATH/src/github.com/smartcontractkit/chainlink`
 4. Build and install Chainlink: `make install`
 5. Run the node: `chainlink help`
 


### PR DESCRIPTION
I accidentally merged this to master, instead of develop. Alternatively, I could rebase develop on top of master. Open to other solutions for getting this over.