### PR TITLE
Optimise height columns on JobRuns

### DIFF
--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560924400"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1564007745"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565139192"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565210496"
 	gormigrate "gopkg.in/gormigrate.v1"
 )
 
@@ -69,6 +70,10 @@ func Migrate(db *gorm.DB) error {
 		{
 			ID:      "1564007745",
 			Migrate: migration1564007745.Migrate,
+		},
+		{
+			ID:      "1565210496",
+			Migrate: migration1565210496.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migrate_test.go
+++ b/core/store/migrations/migrate_test.go
@@ -212,7 +212,7 @@ func TestMigrate_Migration1565210496(t *testing.T) {
 
 	require.NoError(t, migration0.Migrate(db))
 
-	jobSpec := models.JobSpec{
+	jobSpec := migration0.JobSpec{
 		ID:        utils.NewBytes32ID(),
 		CreatedAt: time.Now(),
 	}

--- a/core/store/migrations/migrate_test.go
+++ b/core/store/migrations/migrate_test.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560924400"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565210496"
+	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/smartcontractkit/chainlink/core/store/assets"
 
@@ -199,6 +201,36 @@ func TestMigrate_Migration1565139192(t *testing.T) {
 	require.Equal(t, assets.NewLink(0), specNoPayment.MinPayment)
 	require.NoError(t, db.Where("id = ?", specWithPayment.ID).Find(&specTwoFound).Error)
 	require.Equal(t, assets.NewLink(5), specWithPayment.MinPayment)
+}
+
+func TestMigrate_Migration1565210496(t *testing.T) {
+	orm, cleanup := bootstrapORM(t)
+	defer cleanup()
+
+	db := orm.DB
+	db.LogMode(true)
+
+	require.NoError(t, migration0.Migrate(db))
+
+	jobSpec := models.JobSpec{
+		ID:        utils.NewBytes32ID(),
+		CreatedAt: time.Now(),
+	}
+	require.NoError(t, db.Create(&jobSpec).Error)
+	jobRun := migration0.JobRun{
+		ID:             utils.NewBytes32ID(),
+		JobSpecID:      jobSpec.ID,
+		ObservedHeight: "115792089237316195423570985008687907853269984665640564039457584007913129639936",
+		CreationHeight: "0",
+	}
+	require.NoError(t, db.Create(&jobRun).Error)
+
+	require.NoError(t, migration1565210496.Migrate(db))
+
+	jobRunFound := models.JobRun{}
+	require.NoError(t, db.Where("id = ?", jobRun.ID).Find(&jobRunFound).Error)
+	assert.Equal(t, "115792089237316195423570985008687907853269984665640564039457584007913129639936", jobRunFound.ObservedHeight.String())
+	assert.Equal(t, "0", jobRunFound.CreationHeight.String())
 }
 
 func TestMigrate_NewerVersionGuard(t *testing.T) {

--- a/core/store/migrations/migration0/migrate.go
+++ b/core/store/migrations/migration0/migrate.go
@@ -29,7 +29,7 @@ func Migrate(tx *gorm.DB) error {
 	if err := tx.AutoMigrate(&models.Initiator{}).Error; err != nil {
 		return errors.Wrap(err, "failed to auto migrate Initiator")
 	}
-	if err := tx.AutoMigrate(&models.JobRun{}).Error; err != nil {
+	if err := tx.AutoMigrate(&JobRun{}).Error; err != nil {
 		return errors.Wrap(err, "failed to auto migrate JobRun")
 	}
 	if err := tx.AutoMigrate(&models.Key{}).Error; err != nil {
@@ -131,4 +131,21 @@ type JobSpec struct {
 	StartAt    null.Time          `json:"startAt" gorm:"index"`
 	EndAt      null.Time          `json:"endAt" gorm:"index"`
 	DeletedAt  null.Time          `json:"-" gorm:"index"`
+}
+
+// JobRun is a capture of the model representing Head before migration1565210496
+type JobRun struct {
+	ID             string    `json:"id" gorm:"primary_key;not null"`
+	JobSpecID      string    `json:"jobId" gorm:"index;not null;type:varchar(36) REFERENCES job_specs(id)"`
+	ResultID       uint      `json:"-"`
+	RunRequestID   uint      `json:"-"`
+	Status         string    `json:"status" gorm:"index"`
+	CreatedAt      time.Time `json:"createdAt" gorm:"index"`
+	FinishedAt     null.Time `json:"finishedAt"`
+	UpdatedAt      time.Time `json:"updatedAt"`
+	InitiatorID    uint      `json:"-"`
+	CreationHeight string    `json:"creationHeight" gorm:"type:varchar(255)"`
+	ObservedHeight string    `json:"observedHeight" gorm:"type:varchar(255)"`
+	OverridesID    uint      `json:"-"`
+	DeletedAt      null.Time `json:"-" gorm:"index"`
 }

--- a/core/store/migrations/migration1565210496/migrate.go
+++ b/core/store/migrations/migration1565210496/migrate.go
@@ -1,0 +1,28 @@
+package migration1565210496
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/store/dbutil"
+)
+
+// Migrate optimizes the JobRuns table for reduced on disk footprint
+func Migrate(tx *gorm.DB) error {
+	if dbutil.IsPostgres(tx) {
+		if err := tx.Exec(`
+ALTER TABLE job_runs ADD COLUMN "creation_height_numeric" numeric(78, 0);
+ALTER TABLE job_runs ADD COLUMN "observed_height_numeric" numeric(78, 0);
+INSERT INTO job_runs ("creation_height_numeric", "observed_height_numeric")
+SELECT CAST("creation_height" as numeric), CAST("observed_height" as numeric)
+FROM job_runs;
+ALTER TABLE job_runs DROP COLUMN "creation_height";
+ALTER TABLE job_runs DROP COLUMN "observed_height";
+ALTER TABLE job_runs RENAME COLUMN "creation_height_numeric" TO "creation_height";
+ALTER TABLE job_runs RENAME COLUMN "observed_height_numeric" TO "observed_height";
+	`).Error; err != nil {
+			return errors.Wrap(err, "failed to change height columns on job_runs")
+		}
+	}
+
+	return nil
+}

--- a/core/store/migrations/migration1565210496/migrate.go
+++ b/core/store/migrations/migration1565210496/migrate.go
@@ -12,9 +12,10 @@ func Migrate(tx *gorm.DB) error {
 		if err := tx.Exec(`
 ALTER TABLE job_runs ADD COLUMN "creation_height_numeric" numeric(78, 0);
 ALTER TABLE job_runs ADD COLUMN "observed_height_numeric" numeric(78, 0);
-INSERT INTO job_runs ("creation_height_numeric", "observed_height_numeric")
-SELECT CAST("creation_height" as numeric), CAST("observed_height" as numeric)
-FROM job_runs;
+UPDATE job_runs
+SET
+	"creation_height_numeric" = CAST("creation_height" as numeric),
+	"observed_height_numeric" = CAST("observed_height" as numeric);
 ALTER TABLE job_runs DROP COLUMN "creation_height";
 ALTER TABLE job_runs DROP COLUMN "observed_height";
 ALTER TABLE job_runs RENAME COLUMN "creation_height_numeric" TO "creation_height";

--- a/core/store/models/big.go
+++ b/core/store/models/big.go
@@ -1,0 +1,110 @@
+package models
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"math/big"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/smartcontractkit/chainlink/core/utils"
+)
+
+// Big stores large integers and can deserialize a variety of inputs.
+type Big big.Int
+
+// NewBig constructs a Big from *big.Int.
+func NewBig(i *big.Int) *Big {
+	if i != nil {
+		b := Big(*i)
+		return &b
+	}
+	return nil
+}
+
+// MarshalText marshals this instance to base 10 number as string.
+func (b *Big) MarshalText() ([]byte, error) {
+	return []byte((*big.Int)(b).Text(10)), nil
+}
+
+// MarshalJSON marshals this instance to base 10 number as string.
+func (b *Big) MarshalJSON() ([]byte, error) {
+	return b.MarshalText()
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+func (b *Big) UnmarshalText(input []byte) error {
+	input = utils.RemoveQuotes(input)
+	str := string(input)
+	if utils.HasHexPrefix(str) {
+		decoded, err := hexutil.DecodeBig(str)
+		if err != nil {
+			return err
+		}
+		*b = Big(*decoded)
+		return nil
+	}
+
+	_, ok := b.setString(str, 10)
+	if !ok {
+		return fmt.Errorf("Unable to convert %s to Big", str)
+	}
+	return nil
+}
+
+func (b *Big) setBytes(value []uint8) *Big {
+	w := (*big.Int)(b).SetBytes(value)
+	return (*Big)(w)
+}
+
+func (b *Big) setString(s string, base int) (*Big, bool) {
+	w, ok := (*big.Int)(b).SetString(s, base)
+	return (*Big)(w), ok
+}
+
+// UnmarshalJSON implements encoding.JSONUnmarshaler.
+func (b *Big) UnmarshalJSON(input []byte) error {
+	return b.UnmarshalText(input)
+}
+
+// Value returns this instance serialized for database storage.
+func (b Big) Value() (driver.Value, error) {
+	return b.String(), nil
+}
+
+// Scan reads the database value and returns an instance.
+func (b *Big) Scan(value interface{}) error {
+	switch v := value.(type) {
+	case string:
+		decoded, ok := b.setString(v, 10)
+		if !ok {
+			return fmt.Errorf("Unable to set string %v of %T to base 10 big.Int for Big", value, value)
+		}
+		*b = *decoded
+	case []uint8:
+		// The SQL library returns numeric() types as []uint8 of the string representation
+		decoded, ok := b.setString(string(v), 10)
+		if !ok {
+			return fmt.Errorf("Unable to set string %v of %T to base 10 big.Int for Big", value, value)
+		}
+		*b = *decoded
+	default:
+		return fmt.Errorf("Unable to convert %v of %T to Big", value, value)
+	}
+
+	return nil
+}
+
+// ToInt converts b to a big.Int.
+func (b *Big) ToInt() *big.Int {
+	return (*big.Int)(b)
+}
+
+// String returns the base 10 encoding of b.
+func (b *Big) String() string {
+	return b.ToInt().Text(10)
+}
+
+// Hex returns the hex encoding of b.
+func (b *Big) Hex() string {
+	return hexutil.EncodeBig(b.ToInt())
+}

--- a/core/store/models/big_test.go
+++ b/core/store/models/big_test.go
@@ -1,0 +1,138 @@
+package models
+
+import (
+	"encoding/json"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBig_UnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	i := &Big{}
+	tests := []struct {
+		name  string
+		input string
+		want  *big.Int
+	}{
+		{"number", `1234`, big.NewInt(1234)},
+		{"string", `"1234"`, big.NewInt(1234)},
+		{"hex number", `0x1234`, big.NewInt(4660)},
+		{"hex string", `"0x1234"`, big.NewInt(4660)},
+		{"single quoted", `'1234'`, big.NewInt(1234)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := i.UnmarshalText([]byte(test.input))
+			require.NoError(t, err)
+			assert.Equal(t, test.want, i.ToInt())
+		})
+	}
+}
+
+func TestBig_UnmarshalTextErrors(t *testing.T) {
+	t.Parallel()
+
+	i := &Big{}
+	tests := []struct {
+		name  string
+		input string
+		want  *big.Int
+	}{
+		{"quoted word", `"word"`, big.NewInt(0)},
+		{"word", `word`, big.NewInt(0)},
+		{"empty", ``, big.NewInt(0)},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			err := i.UnmarshalText([]byte(test.input))
+			require.Error(t, err)
+		})
+	}
+}
+
+func TestBig_MarshalJSON(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input *big.Int
+		want  string
+	}{
+		{"number", big.NewInt(1234), `1234`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			i := (*Big)(test.input)
+			b, err := json.Marshal(&i)
+			assert.NoError(t, err)
+			assert.Equal(t, test.want, string(b))
+		})
+	}
+}
+
+func TestBig_Scan(t *testing.T) {
+	t.Parallel()
+
+	uint256Max, ok := new(big.Int).SetString("115792089237316195423570985008687907853269984665640564039457584007913129639935", 10)
+	require.True(t, ok)
+
+	tests := []struct {
+		name  string
+		input interface{}
+		want  *Big
+	}{
+		{"zero string", "0", NewBig(big.NewInt(0))},
+		{"one string", "1", NewBig(big.NewInt(1))},
+		{
+			"large string",
+			"115792089237316195423570985008687907853269984665640564039457584007913129639935",
+			NewBig(uint256Max),
+		},
+		{"zero as bytes", []uint8{48}, NewBig(big.NewInt(0))},
+		{"small number as bytes", []uint8{49, 52}, NewBig(big.NewInt(14))},
+		{
+			"max number as bytes",
+			[]uint8{
+				49, 49, 53, 55, 57, 50, 48, 56, 57, 50, 51, 55, 51, 49, 54, 49, 57, 53,
+				52, 50, 51, 53, 55, 48, 57, 56, 53, 48, 48, 56, 54, 56, 55, 57, 48, 55,
+				56, 53, 51, 50, 54, 57, 57, 56, 52, 54, 54, 53, 54, 52, 48, 53, 54, 52,
+				48, 51, 57, 52, 53, 55, 53, 56, 52, 48, 48, 55, 57, 49, 51, 49, 50, 57,
+				54, 51, 57, 57, 51, 53,
+			},
+			NewBig(uint256Max),
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			big := &Big{}
+			err := big.Scan(test.input)
+			require.NoError(t, err)
+			assert.Equal(t, test.want, big)
+		})
+	}
+}
+
+func TestBig_ScanErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		input interface{}
+	}{
+		{"zero integer", 0},
+		{"one integer", 1},
+		{"zero wrapped string", `"0"`},
+		{"one wrapped string", `"1"`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			big := &Big{}
+			err := big.Scan(test.input)
+			require.Error(t, err)
+		})
+	}
+}

--- a/core/store/models/common_test.go
+++ b/core/store/models/common_test.go
@@ -2,7 +2,6 @@ package models_test
 
 import (
 	"encoding/json"
-	"math/big"
 	"net/url"
 	"reflect"
 	"testing"
@@ -343,54 +342,6 @@ func TestAnyTime_MarshalJSON(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			b, err := json.Marshal(&test.input)
-			assert.NoError(t, err)
-			assert.Equal(t, test.want, string(b))
-		})
-	}
-}
-
-func TestBig_UnmarshalText(t *testing.T) {
-	t.Parallel()
-
-	i := &models.Big{}
-	tests := []struct {
-		name      string
-		input     string
-		wantError bool
-		want      *big.Int
-	}{
-		{"number", `1234`, false, big.NewInt(1234)},
-		{"string", `"1234"`, false, big.NewInt(1234)},
-		{"hex number", `0x1234`, false, big.NewInt(4660)},
-		{"hex string", `"0x1234"`, false, big.NewInt(4660)},
-		{"single quoted", `'1234'`, false, big.NewInt(1234)},
-		{"quoted word", `"word"`, true, big.NewInt(0)},
-		{"word", `word`, true, big.NewInt(0)},
-		{"empty", ``, true, big.NewInt(0)},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			err := i.UnmarshalText([]byte(test.input))
-			cltest.AssertError(t, test.wantError, err)
-			assert.Equal(t, test.want, i.ToInt())
-		})
-	}
-}
-
-func TestBig_MarshalJSON(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name  string
-		input *big.Int
-		want  string
-	}{
-		{"number", big.NewInt(1234), `1234`},
-	}
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			i := (*models.Big)(test.input)
-			b, err := json.Marshal(&i)
 			assert.NoError(t, err)
 			assert.Equal(t, test.want, string(b))
 		})


### PR DESCRIPTION
Use numeric column for storing created at block height and observed block heights, 50% reduction in storage vs text.

Note that using a plugin to store uint256s could introduce a further 20% savings but would require installing a custom plugin + openssl.

Also since the go SQL drivers are text based and not binary, there is no saving in traffic to the database which you would expect.