### PR TITLE
cldev minor fix for instructions

### DIFF
--- a/tools/bin/cldev
+++ b/tools/bin/cldev
@@ -4,7 +4,7 @@
 # Steps:
 # 1. ./tools/bin/gethnet
 # 2. yarn install
-# 3. cd evm && truffle migrate && cd ..
+# 3. cd evm && truffle migrate --network cldev && cd ..
 # 4. ./tools/bin/cldev
 
 set -e


### PR DESCRIPTION
Suggest running truffle migrate with the cldev ethereum network.