### PR TITLE
Enable 404 page

### DIFF
--- a/core/web/router.go
+++ b/core/web/router.go
@@ -344,9 +344,8 @@ func guiAssetRoutes(box packr.Box, engine *gin.Engine) {
 			if err == os.ErrNotExist {
 				c.AbortWithStatus(http.StatusNotFound)
 			} else {
-				err := fmt.Errorf("failed to open static file '%s': %+v", path, err)
-				logger.Error(err.Error())
-				jsonAPIError(c, http.StatusInternalServerError, err)
+				logger.Errorf("failed to open static file '%s': %+v", path, err)
+				c.AbortWithStatus(http.StatusInternalServerError)
 			}
 			return
 		}

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -335,22 +335,24 @@ func guiAssetRoutes(box packr.Box, engine *gin.Engine) {
 			}
 		}
 
-		if matchedBoxPath != "" {
-			file, err := box.Open(matchedBoxPath)
-			if err != nil {
-				if err == os.ErrNotExist {
-					c.AbortWithStatus(http.StatusNotFound)
-				} else {
-					err := fmt.Errorf("failed to open static file '%s': %+v", path, err)
-					logger.Error(err.Error())
-					jsonAPIError(c, http.StatusInternalServerError, err)
-				}
-				return
-			}
-			defer file.Close()
-
-			http.ServeContent(c.Writer, c.Request, path, time.Time{}, file)
+		if matchedBoxPath == "" {
+			matchedBoxPath = "404.html"
 		}
+
+		file, err := box.Open(matchedBoxPath)
+		if err != nil {
+			if err == os.ErrNotExist {
+				c.AbortWithStatus(http.StatusNotFound)
+			} else {
+				err := fmt.Errorf("failed to open static file '%s': %+v", path, err)
+				logger.Error(err.Error())
+				jsonAPIError(c, http.StatusInternalServerError, err)
+			}
+			return
+		}
+		defer file.Close()
+
+		http.ServeContent(c.Writer, c.Request, path, time.Time{}, file)
 	})
 }
 

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -335,8 +335,10 @@ func guiAssetRoutes(box packr.Box, engine *gin.Engine) {
 			}
 		}
 
+		var is404 bool
 		if matchedBoxPath == "" {
 			matchedBoxPath = "404.html"
+			is404 = true
 		}
 
 		file, err := box.Open(matchedBoxPath)
@@ -351,7 +353,12 @@ func guiAssetRoutes(box packr.Box, engine *gin.Engine) {
 		}
 		defer file.Close()
 
-		http.ServeContent(c.Writer, c.Request, path, time.Time{}, file)
+		if is404 {
+			c.Writer.WriteHeader(http.StatusNotFound)
+			io.Copy(c.Writer, file)
+		} else {
+			http.ServeContent(c.Writer, c.Request, path, time.Time{}, file)
+		}
 	})
 }
 

--- a/operator_ui/src/Private.js
+++ b/operator_ui/src/Private.js
@@ -49,6 +49,7 @@ const TransactionsShow = universal(
   uniOpts
 )
 const Configuration = universal(import('./containers/Configuration'), uniOpts)
+const NotFound = universal(import('./containers/NotFound'), uniOpts)
 
 const styles = theme => {
   return {
@@ -205,6 +206,7 @@ class Private extends React.Component {
                   component={TransactionsShow}
                 />
                 <PrivateRoute exact path="/config" component={Configuration} />
+                <PrivateRoute component={NotFound} />
               </Switch>
             </div>
           </main>

--- a/operator_ui/src/containers/NotFound.js
+++ b/operator_ui/src/containers/NotFound.js
@@ -1,0 +1,20 @@
+import React from 'react'
+import NotFoundSVG from 'images/four-oh-four.js'
+import { withStyles } from '@material-ui/core/styles'
+
+const styles = () => ({
+  logo: {
+    top: '30%',
+    left: '50%',
+    transform: 'translate(-50%, -30%)',
+    position: 'absolute'
+  }
+})
+
+const Logo = ({ classes }) => (
+  <div className={classes.logo}>
+    <NotFoundSVG />
+  </div>
+)
+
+export default withStyles(styles)(Logo)

--- a/operator_ui/static.config.js
+++ b/operator_ui/static.config.js
@@ -14,7 +14,7 @@ export default {
     title: 'Chainlink'
   }),
   getRoutes: async () => {
-    return [{ path: '404', component: 'src/containers/404' }]
+    return [{ path: '404', component: 'src/containers/NotFound.js' }]
   },
   beforeRenderToElement: (render, Comp) => render(Comp),
   plugins: [


### PR DESCRIPTION
`react-static` complicated this a bit.  It doesn't seem to be correctly building the 404.js page into 404.html (the 404 page triggers on bad URLs, but was always blank).  To fix this, I had to add a default catch-all route to the end of the Private collection of routes that renders the NotFound component.