### PR TITLE
Lock the chainlink-test-helpers version

### DIFF
--- a/evm/box/package.json
+++ b/evm/box/package.json
@@ -14,7 +14,7 @@
   "license": "MIT",
   "dependencies": {
     "chainlink": "0.6.5",
-    "chainlink-test-helpers": "^0.6.0-5",
+    "chainlink-test-helpers": "0.6.0-6",
     "openzeppelin-solidity": "^1.12.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Need this quick while I'm working on the chainlink-test-helpers package.