### PR TITLE
External Initiator: Add Name and URL params

### DIFF
--- a/core/cmd/remote_client.go
+++ b/core/cmd/remote_client.go
@@ -67,7 +67,25 @@ func (cli *Client) CreateServiceAgreement(c *clipkg.Context) error {
 
 // CreateExternalInitiator adds an external initiator
 func (cli *Client) CreateExternalInitiator(c *clipkg.Context) error {
-	resp, err := cli.HTTP.Post("/v2/external_initiators", nil)
+	if c.NArg() != 2 {
+		return cli.errorOut(errors.New("create expects two arguments: a name and a url"))
+	}
+
+	var request models.ExternalInitiatorRequest
+	request.Name = c.Args().Get(0)
+	if url, err := models.NewWebURL(c.Args().Get(1)); err == nil {
+		request.URL = url
+	} else {
+		return cli.errorOut(err)
+	}
+
+	requestData, err := json.Marshal(request)
+	if err != nil {
+		return cli.errorOut(err)
+	}
+
+	buf := bytes.NewBuffer(requestData)
+	resp, err := cli.HTTP.Post("/v2/external_initiators", buf)
 	if err != nil {
 		return cli.errorOut(err)
 	}

--- a/core/cmd/remote_client.go
+++ b/core/cmd/remote_client.go
@@ -66,6 +66,9 @@ func (cli *Client) CreateServiceAgreement(c *clipkg.Context) error {
 }
 
 // CreateExternalInitiator adds an external initiator
+//
+// TODO: Investigate reducing the number of return statements
+// TODO: Increase code coverage
 func (cli *Client) CreateExternalInitiator(c *clipkg.Context) error {
 	if c.NArg() != 2 {
 		return cli.errorOut(errors.New("create expects two arguments: a name and a url"))

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -188,7 +188,7 @@ func TestClient_CreateServiceAgreement(t *testing.T) {
 	}
 }
 
-func testClient_CreateExternalInitiator(t *testing.T) {
+func TestClient_CreateExternalInitiator(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplicationWithKey(t)
@@ -216,9 +216,6 @@ func testClient_CreateExternalInitiator(t *testing.T) {
 			c := cli.NewContext(nil, set, nil)
 
 			err := client.CreateExternalInitiator(c)
-			// TODO: Error
-			//parseResponse error: 500 Internal Server Error; table
-			//external_initiators has no column named created_at
 
 			cltest.AssertError(t, test.errored, err)
 			exis := cltest.AllExternalInitiators(t, app.Store)

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -1148,6 +1148,15 @@ func NewSession(optionalSessionID ...string) models.Session {
 	return session
 }
 
+func AllExternalInitiators(t testing.TB, store *strpkg.Store) []models.ExternalInitiator {
+	t.Helper()
+
+	var all []models.ExternalInitiator
+	err := store.ORM.DB.Find(&all).Error
+	require.NoError(t, err)
+	return all
+}
+
 func AllJobs(t testing.TB, store *strpkg.Store) []models.JobSpec {
 	t.Helper()
 

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1564007745"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565139192"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565210496"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565877314"
 	gormigrate "gopkg.in/gormigrate.v1"
 )
 
@@ -74,6 +75,10 @@ func Migrate(db *gorm.DB) error {
 		{
 			ID:      "1565210496",
 			Migrate: migration1565210496.Migrate,
+		},
+		{
+			ID:      "1565877314",
+			Migrate: migration1565877314.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration0/migrate.go
+++ b/core/store/migrations/migration0/migrate.go
@@ -17,7 +17,7 @@ func Migrate(tx *gorm.DB) error {
 	if err := tx.AutoMigrate(&models.Encumbrance{}).Error; err != nil {
 		return errors.Wrap(err, "failed to auto migrate Encumbrance")
 	}
-	if err := tx.AutoMigrate(&models.ExternalInitiator{}).Error; err != nil {
+	if err := tx.AutoMigrate(&ExternalInitiator{}).Error; err != nil {
 		return errors.Wrap(err, "failed to auto migrate ExternalInitiator")
 	}
 	if err := tx.AutoMigrate(&Head{}).Error; err != nil {
@@ -105,6 +105,14 @@ type TaskRun struct {
 	TaskSpecID           uint      `json:"-" gorm:"index;not null REFERENCES task_specs(id)"`
 	MinimumConfirmations uint64    `json:"minimumConfirmations"`
 	CreatedAt            time.Time `json:"-" gorm:"index"`
+}
+
+// ExternalInitiator represents a user that can initiate runs remotely
+type ExternalInitiator struct {
+	*gorm.Model
+	AccessKey    string
+	Salt         string
+	HashedSecret string
 }
 
 // Head is a capture of the model representing Head before migration1560881846

--- a/core/store/migrations/migration1565877314/migrate.go
+++ b/core/store/migrations/migration1565877314/migrate.go
@@ -1,0 +1,67 @@
+package migration1565877314
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+)
+
+type ExternalInitiatorOld struct {
+	*gorm.Model
+	AccessKey    string
+	Salt         string
+	HashedSecret string
+}
+
+func (ExternalInitiatorOld) TableName() string {
+	return "external_initiators"
+}
+
+type ExternalInitiator struct {
+	*gorm.Model
+	Name         string        `gorm:"not null,unique"`
+	URL          models.WebURL `gorm:"not null"`
+	AccessKey    string
+	Salt         string
+	HashedSecret string
+}
+
+// newExternalInitiator creates a new row, setting the Name to the AccessKey
+func newExternalInitiator(arg ExternalInitiatorOld) ExternalInitiator {
+	url, _ := models.NewWebURL("https://unset.url")
+	return ExternalInitiator{
+		Model: arg.Model,
+
+		Name:         arg.AccessKey,
+		URL:          url,
+		AccessKey:    arg.AccessKey,
+		Salt:         arg.Salt,
+		HashedSecret: arg.HashedSecret,
+	}
+}
+
+// Migrate adds External Initiator Name and URL fields.
+func Migrate(tx *gorm.DB) error {
+	var exis []ExternalInitiatorOld
+	if err := tx.Find(&exis).Error; err != nil {
+		return errors.Wrap(err, "could not load all External Intitiators")
+	}
+
+	// Make new table
+	if err := tx.DropTable(ExternalInitiatorOld{}).Error; err != nil {
+		return errors.Wrap(err, "could not drop old External Intitiator table")
+	}
+	if err := tx.AutoMigrate(&ExternalInitiator{}).Error; err != nil {
+		return errors.Wrap(err, "could not create new External Intitiator table")
+	}
+
+	// Copy
+	for _, old := range exis {
+		exi := newExternalInitiator(old)
+		if err := tx.Save(exi).Error; err != nil {
+			return errors.Wrap(err, "could not save migrated version of External Initiator")
+		}
+	}
+
+	return nil
+}

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -251,6 +251,15 @@ func (j JSON) CBOR() ([]byte, error) {
 // WebURL contains the URL of the endpoint.
 type WebURL url.URL
 
+// NewWebURL creates a new WebURL.
+func NewWebURL(arg string) (WebURL, error) {
+	u, err := url.ParseRequestURI(arg)
+	if err != nil {
+		return WebURL{}, err
+	}
+	return WebURL(*u), nil
+}
+
 // UnmarshalJSON parses the raw URL stored in JSON-encoded
 // data to a URL structure and sets it to the URL field.
 func (w *WebURL) UnmarshalJSON(j []byte) error {

--- a/core/store/models/external_initiator.go
+++ b/core/store/models/external_initiator.go
@@ -11,9 +11,17 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+// ExternalInitiatorRequest is the incoming record used to create an ExternalInitiator.
+type ExternalInitiatorRequest struct {
+	Name string `json:"name"`
+	URL  WebURL `json:"url"`
+}
+
 // ExternalInitiator represents a user that can initiate runs remotely
 type ExternalInitiator struct {
 	*gorm.Model
+	Name         string
+	URL          WebURL
 	AccessKey    string
 	Salt         string
 	HashedSecret string
@@ -21,7 +29,10 @@ type ExternalInitiator struct {
 
 // NewExternalInitiator generates an ExternalInitiator from an
 // ExternalInitiatorAuthentication, hashing the password for storage
-func NewExternalInitiator(eia *ExternalInitiatorAuthentication) (*ExternalInitiator, error) {
+func NewExternalInitiator(
+	eia *ExternalInitiatorAuthentication,
+	eir *ExternalInitiatorRequest,
+) (*ExternalInitiator, error) {
 	salt := utils.NewSecret(48)
 	hashedSecret, err := HashedSecret(eia, salt)
 	if err != nil {
@@ -29,6 +40,8 @@ func NewExternalInitiator(eia *ExternalInitiatorAuthentication) (*ExternalInitia
 	}
 
 	return &ExternalInitiator{
+		Name:         eir.Name,
+		URL:          eir.URL,
 		AccessKey:    eia.AccessKey,
 		HashedSecret: hashedSecret,
 		Salt:         salt,

--- a/core/store/models/external_initiator_test.go
+++ b/core/store/models/external_initiator_test.go
@@ -1,17 +1,23 @@
-package models
+package models_test
 
 import (
 	"testing"
 
+	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestNewExternalInitiator(t *testing.T) {
-	eia := NewExternalInitiatorAuthentication()
+	eia := models.NewExternalInitiatorAuthentication()
 	assert.Len(t, eia.AccessKey, 32)
 	assert.Len(t, eia.Secret, 64)
 
-	ei, err := NewExternalInitiator(eia)
+	eir := &models.ExternalInitiatorRequest{
+		Name: "bitcoin",
+		URL:  cltest.WebURL(t, "http://localhost:8888"),
+	}
+	ei, err := models.NewExternalInitiator(eia, eir)
 	assert.NoError(t, err)
 	assert.NotEqual(t, ei.HashedSecret, eia.Secret)
 	assert.Equal(t, ei.AccessKey, eia.AccessKey)

--- a/core/web/external_initiators_controller.go
+++ b/core/web/external_initiators_controller.go
@@ -15,6 +15,8 @@ type ExternalInitiatorsController struct {
 }
 
 // Create builds and saves a new service agreement record.
+//
+// TODO: Validate name does not already exist
 func (eic *ExternalInitiatorsController) Create(c *gin.Context) {
 	eir := &models.ExternalInitiatorRequest{}
 	if !eic.App.GetStore().Config.Dev() {

--- a/core/web/external_initiators_controller.go
+++ b/core/web/external_initiators_controller.go
@@ -16,13 +16,16 @@ type ExternalInitiatorsController struct {
 
 // Create builds and saves a new service agreement record.
 func (eic *ExternalInitiatorsController) Create(c *gin.Context) {
+	eir := &models.ExternalInitiatorRequest{}
 	if !eic.App.GetStore().Config.Dev() {
 		jsonAPIError(c, http.StatusMethodNotAllowed, errors.New("External Initiators are currently under development and not yet usable outside of development mode"))
 		return
 	}
 
 	eia := models.NewExternalInitiatorAuthentication()
-	if ea, err := models.NewExternalInitiator(eia); err != nil {
+	if err := c.ShouldBindJSON(eir); err != nil {
+		jsonAPIError(c, http.StatusUnprocessableEntity, err)
+	} else if ea, err := models.NewExternalInitiator(eia, eir); err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 	} else if err := eic.App.GetStore().CreateExternalInitiator(ea); err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)

--- a/core/web/external_initiators_controller_test.go
+++ b/core/web/external_initiators_controller_test.go
@@ -1,6 +1,7 @@
 package web_test
 
 import (
+	"bytes"
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
@@ -17,7 +18,9 @@ func TestExternalInitiatorsController_Create(t *testing.T) {
 
 	client := app.NewHTTPClient()
 
-	resp, cleanup := client.Post("/v2/external_initiators", nil)
+	resp, cleanup := client.Post("/v2/external_initiators",
+		bytes.NewBufferString(`{"name":"bitcoin","url":"http://without.a.name"}`),
+	)
 	defer cleanup()
 	cltest.AssertServerResponse(t, resp, 201)
 }

--- a/core/web/ping_controller_test.go
+++ b/core/web/ping_controller_test.go
@@ -34,8 +34,12 @@ func TestPingController_Show_ExternalInitiatorCredentials(t *testing.T) {
 		AccessKey: "abracadabra",
 		Secret:    "opensesame",
 	}
+	eir := &models.ExternalInitiatorRequest{
+		Name: "bitcoin",
+		URL:  cltest.WebURL(t, "http://localhost:8888"),
+	}
 
-	ei, err := models.NewExternalInitiator(eia)
+	ei, err := models.NewExternalInitiator(eia, eir)
 	require.NoError(t, err)
 	err = app.GetStore().CreateExternalInitiator(ei)
 	require.NoError(t, err)

--- a/core/web/router_test.go
+++ b/core/web/router_test.go
@@ -51,7 +51,11 @@ func TestTokenAuthRequired_TokenCredentials(t *testing.T) {
 	defer ts.Close()
 
 	eia := models.NewExternalInitiatorAuthentication()
-	ea, err := models.NewExternalInitiator(eia)
+	eir := &models.ExternalInitiatorRequest{
+		Name: "bitcoin",
+		URL:  cltest.WebURL(t, "http://localhost:8888"),
+	}
+	ea, err := models.NewExternalInitiator(eia, eir)
 	require.NoError(t, err)
 	err = app.GetStore().CreateExternalInitiator(ea)
 	require.NoError(t, err)
@@ -78,7 +82,11 @@ func TestTokenAuthRequired_BadTokenCredentials(t *testing.T) {
 	defer ts.Close()
 
 	eia := models.NewExternalInitiatorAuthentication()
-	ea, err := models.NewExternalInitiator(eia)
+	eir := &models.ExternalInitiatorRequest{
+		Name: "bitcoin",
+		URL:  cltest.WebURL(t, "http://localhost:8888"),
+	}
+	ea, err := models.NewExternalInitiator(eia, eir)
 	require.NoError(t, err)
 	err = app.GetStore().CreateExternalInitiator(ea)
 	require.NoError(t, err)


### PR DESCRIPTION
Make the 'chainlink exi create' command take two arguments 'Name' and 'URL'

 - add NewWebURL(..) to models pkg
 - add ExternalInitiatorRequest to models
 - update external_intiator_controller