### PR TITLE
controllers: Fix checking errors via ErrorNotFound

### DIFF
--- a/core/web/bridge_types_controller.go
+++ b/core/web/bridge_types_controller.go
@@ -1,11 +1,11 @@
 package web
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/services"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
@@ -44,7 +44,7 @@ func (btc *BridgeTypesController) Show(c *gin.Context) {
 	name := c.Param("BridgeName")
 	if taskType, err := models.NewTaskType(name); err != nil {
 		jsonAPIError(c, http.StatusUnprocessableEntity, err)
-	} else if bt, err := btc.App.GetStore().FindBridge(taskType); err == orm.ErrorNotFound {
+	} else if bt, err := btc.App.GetStore().FindBridge(taskType); errors.Cause(err) == orm.ErrorNotFound {
 		jsonAPIError(c, http.StatusNotFound, errors.New("bridge not found"))
 	} else if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
@@ -60,7 +60,7 @@ func (btc *BridgeTypesController) Update(c *gin.Context) {
 
 	if taskType, err := models.NewTaskType(name); err != nil {
 		jsonAPIError(c, http.StatusUnprocessableEntity, err)
-	} else if bt, err := btc.App.GetStore().FindBridge(taskType); err == orm.ErrorNotFound {
+	} else if bt, err := btc.App.GetStore().FindBridge(taskType); errors.Cause(err) == orm.ErrorNotFound {
 		jsonAPIError(c, http.StatusNotFound, errors.New("bridge not found"))
 	} else if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
@@ -79,7 +79,7 @@ func (btc *BridgeTypesController) Destroy(c *gin.Context) {
 
 	if taskType, err := models.NewTaskType(name); err != nil {
 		jsonAPIError(c, http.StatusUnprocessableEntity, err)
-	} else if bt, err := btc.App.GetStore().FindBridge(taskType); err == orm.ErrorNotFound {
+	} else if bt, err := btc.App.GetStore().FindBridge(taskType); errors.Cause(err) == orm.ErrorNotFound {
 		jsonAPIError(c, http.StatusNotFound, errors.New("bridge not found"))
 	} else if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, fmt.Errorf("Error searching for bridge for BTC Destroy: %+v", err))

--- a/core/web/helpers.go
+++ b/core/web/helpers.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/manyminds/api2go/jsonapi"
+	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
 )
@@ -41,7 +42,7 @@ func paginatedResponse(
 	count int,
 	err error,
 ) {
-	if err == orm.ErrorNotFound {
+	if errors.Cause(err) == orm.ErrorNotFound {
 		err = nil
 	}
 

--- a/core/web/job_runs_controller.go
+++ b/core/web/job_runs_controller.go
@@ -1,11 +1,11 @@
 package web
 
 import (
-	"errors"
 	"io/ioutil"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/services"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
@@ -48,7 +48,7 @@ func (jrc *JobRunsController) Index(c *gin.Context, size, page, offset int) {
 func (jrc *JobRunsController) Create(c *gin.Context) {
 	id := c.Param("SpecID")
 
-	if j, err := jrc.App.GetStore().FindJob(id); err == orm.ErrorNotFound {
+	if j, err := jrc.App.GetStore().FindJob(id); errors.Cause(err) == orm.ErrorNotFound {
 		jsonAPIError(c, http.StatusNotFound, errors.New("Job not found"))
 	} else if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
@@ -76,7 +76,7 @@ func getRunData(c *gin.Context) (models.JSON, error) {
 //  "<application>/runs/:RunID"
 func (jrc *JobRunsController) Show(c *gin.Context) {
 	id := c.Param("RunID")
-	if jr, err := jrc.App.GetStore().FindJobRun(id); err == orm.ErrorNotFound {
+	if jr, err := jrc.App.GetStore().FindJobRun(id); errors.Cause(err) == orm.ErrorNotFound {
 		jsonAPIError(c, http.StatusNotFound, errors.New("Job run not found"))
 	} else if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
@@ -96,7 +96,7 @@ func (jrc *JobRunsController) Update(c *gin.Context) {
 	var brr models.BridgeRunResult
 
 	unscoped := jrc.App.GetStore().Unscoped()
-	if jr, err := unscoped.FindJobRun(id); err == orm.ErrorNotFound {
+	if jr, err := unscoped.FindJobRun(id); errors.Cause(err) == orm.ErrorNotFound {
 		jsonAPIError(c, http.StatusNotFound, errors.New("Job Run not found"))
 	} else if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)

--- a/core/web/job_specs_controller.go
+++ b/core/web/job_specs_controller.go
@@ -1,10 +1,10 @@
 package web
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/services"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
@@ -58,7 +58,7 @@ func (jsc *JobSpecsController) Create(c *gin.Context) {
 //  "<application>/specs/:SpecID"
 func (jsc *JobSpecsController) Show(c *gin.Context) {
 	id := c.Param("SpecID")
-	if j, err := jsc.App.GetStore().FindJob(id); err == orm.ErrorNotFound {
+	if j, err := jsc.App.GetStore().FindJob(id); errors.Cause(err) == orm.ErrorNotFound {
 		jsonAPIError(c, http.StatusNotFound, errors.New("JobSpec not found"))
 	} else if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
@@ -72,7 +72,7 @@ func (jsc *JobSpecsController) Show(c *gin.Context) {
 //  "<application>/specs/:SpecID"
 func (jsc *JobSpecsController) Destroy(c *gin.Context) {
 	id := c.Param("SpecID")
-	if err := jsc.App.ArchiveJob(id); err == orm.ErrorNotFound {
+	if err := jsc.App.ArchiveJob(id); errors.Cause(err) == orm.ErrorNotFound {
 		jsonAPIError(c, http.StatusNotFound, errors.New("JobSpec not found"))
 	} else if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)

--- a/core/web/service_agreements_controller.go
+++ b/core/web/service_agreements_controller.go
@@ -1,11 +1,11 @@
 package web
 
 import (
-	"errors"
 	"net/http"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/services"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
@@ -31,7 +31,7 @@ func (sac *ServiceAgreementsController) Create(c *gin.Context) {
 	}
 
 	sa, err := sac.App.GetStore().FindServiceAgreement(us.ID.String())
-	if err == orm.ErrorNotFound {
+	if errors.Cause(err) == orm.ErrorNotFound {
 		sa, err = models.BuildServiceAgreement(us, sac.App.GetStore().KeyStore)
 		if err != nil {
 			jsonAPIError(c, http.StatusUnprocessableEntity, err)
@@ -52,7 +52,7 @@ func (sac *ServiceAgreementsController) Create(c *gin.Context) {
 //  "<application>/service_agreements/:SAID"
 func (sac *ServiceAgreementsController) Show(c *gin.Context) {
 	id := common.HexToHash(c.Param("SAID"))
-	if sa, err := sac.App.GetStore().FindServiceAgreement(id.String()); err == orm.ErrorNotFound {
+	if sa, err := sac.App.GetStore().FindServiceAgreement(id.String()); errors.Cause(err) == orm.ErrorNotFound {
 		jsonAPIError(c, http.StatusNotFound, errors.New("ServiceAgreement not found"))
 	} else if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)


### PR DESCRIPTION
Use the Cause(..) of the error for checking against the ErrorNotFound value.

This prevents future regressions where the underlying function may Wrap(..) the returned error, causing the condition to fail when it should not.