### PR TITLE
Native ChainID type is big.Int, don't truncate to uint64

### DIFF
--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -203,13 +203,12 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_StillPending(t *testing.T
 	defer cleanup()
 	store := app.Store
 	config := store.Config
-	chainID := cltest.Int(config.ChainID())
 	ethMock := app.MockEthClient()
 
 	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{})
 	sentAt := uint64(23456)
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(sentAt+config.EthGasBumpThreshold()-1))
-	ethMock.Register("eth_chainId", *chainID)
+	ethMock.Register("eth_chainId", config.ChainID())
 
 	require.NoError(t, app.StartAndConnect())
 
@@ -282,7 +281,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_ConfirmCompletes(t *testi
 	ethMock.Register("eth_call", "0x1")
 	ethMock.Register("eth_getBalance", "0x100")
 
-	ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+	ethMock.Register("eth_chainId", store.Config.ChainID())
 	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{})
 	confirmedHash := cltest.NewHash()
 	receipt := models.TxReceipt{Hash: confirmedHash, BlockNumber: cltest.Int(sentAt)}
@@ -341,12 +340,11 @@ func TestEthTxAdapter_Perform_AppendingTransactionReceipts(t *testing.T) {
 	sentAt := uint64(23456)
 
 	ethMock := app.MockEthClient()
-	chainID := cltest.Int(config.ChainID())
 	receipt := models.TxReceipt{Hash: cltest.NewHash(), BlockNumber: cltest.Int(sentAt)}
 	ethMock.Register("eth_getTransactionReceipt", receipt)
 	confirmedAt := sentAt + config.MinOutgoingConfirmations() - 1 // confirmations are 0-based idx
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(confirmedAt))
-	ethMock.Register("eth_chainId", *chainID)
+	ethMock.Register("eth_chainId", config.ChainID())
 
 	require.NoError(t, app.StartAndConnect())
 
@@ -403,7 +401,7 @@ func TestEthTxAdapter_Perform_WithErrorInvalidInput(t *testing.T) {
 
 	store := app.Store
 	ethMock := app.MockEthClient()
-	ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+	ethMock.Register("eth_chainId", store.Config.ChainID())
 	ethMock.Register("eth_getTransactionCount", `0x0100`)
 	require.NoError(t, app.StartAndConnect())
 
@@ -427,9 +425,8 @@ func TestEthTxAdapter_Perform_PendingConfirmations_WithFatalErrorInTxManager(t *
 
 	store := app.Store
 	ethMock := app.MockEthClient(cltest.Strict)
-	chainID := cltest.Int(store.Config.ChainID())
 	ethMock.Register("eth_getTransactionCount", `0x17`)
-	ethMock.Register("eth_chainId", *chainID)
+	ethMock.Register("eth_chainId", store.Config.ChainID())
 	assert.Nil(t, app.Start())
 
 	require.NoError(t, app.WaitForConnection())
@@ -458,7 +455,7 @@ func TestEthTxAdapter_Perform_PendingConfirmations_WithRecoverableErrorInTxManag
 	store := app.Store
 	ethMock := app.MockEthClient(cltest.Strict)
 	ethMock.Register("eth_getTransactionCount", `0x12`)
-	ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+	ethMock.Register("eth_chainId", store.Config.ChainID())
 	assert.Nil(t, app.Start())
 
 	from := cltest.GetAccountAddress(t, store)
@@ -688,7 +685,7 @@ func TestEthTxAdapter_Perform_NoDoubleSpendOnSendTransactionFail(t *testing.T) {
 	store := app.Store
 	ethMock := app.MockEthClient(cltest.Strict)
 	ethMock.Register("eth_getTransactionCount", `0x1`)
-	ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+	ethMock.Register("eth_chainId", store.Config.ChainID())
 
 	address := cltest.NewAddress()
 	fHash := models.HexToFunctionSelector("b3f98adc")
@@ -763,7 +760,7 @@ func TestEthTxAdapter_Perform_NoDoubleSpendOnSendTransactionFailAndNonceChange(t
 	ethMock := app.MockEthClient(cltest.Strict)
 	ethMock.Register("eth_getTransactionCount", `0x1`)
 	ethMock.Register("eth_getTransactionCount", `0x2`)
-	ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+	ethMock.Register("eth_chainId", store.Config.ChainID())
 	app.AddUnlockedKey()
 
 	addresses := cltest.GetAccountAddresses(store)

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -41,7 +41,7 @@ func TestClient_RunNodeShowsEnv(t *testing.T) {
 
 	eth := app.MockEthClient()
 	eth.Register("eth_getTransactionCount", `0x1`)
-	eth.Register("eth_chainId", *cltest.Int(config.ChainID()))
+	eth.Register("eth_chainId", config.ChainID())
 
 	// Start RunNode in a goroutine, it will block until we resume the runner
 	go func() {

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -523,7 +523,7 @@ func setupWithdrawalsApplication(t *testing.T) (*cltest.TestApplication, func(),
 
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", nonce)
-		ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+		ethMock.Register("eth_chainId", config.ChainID())
 	})
 
 	ethMock.Context("manager.CreateTx#1", func(ethMock *cltest.EthMock) {

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -254,10 +254,9 @@ func (ta *TestApplication) WaitForConnection() error {
 }
 
 func (ta *TestApplication) MockStartAndConnect() (*EthMock, error) {
-	chainID := Int(ta.Config.ChainID())
 	ethMock := ta.MockEthClient()
 	ethMock.Context("TestApplication#MockStartAndConnect()", func(ethMock *EthMock) {
-		ethMock.Register("eth_chainId", *chainID)
+		ethMock.Register("eth_chainId", ta.Config.ChainID())
 		ethMock.Register("eth_getTransactionCount", `0x0`)
 	})
 

--- a/core/internal/mocks/tx_manager_mocks.go
+++ b/core/internal/mocks/tx_manager_mocks.go
@@ -188,10 +188,10 @@ func (mr *MockTxManagerMockRecorder) GetBlockByNumber(arg0 interface{}) *gomock.
 }
 
 // GetChainID mocks base method
-func (m *MockTxManager) GetChainID() (uint64, error) {
+func (m *MockTxManager) GetChainID() (*big.Int, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetChainID")
-	ret0, _ := ret[0].(uint64)
+	ret0, _ := ret[0].(*big.Int)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/core/services/application_test.go
+++ b/core/services/application_test.go
@@ -24,6 +24,8 @@ func TestChainlinkApplication_SignalShutdown(t *testing.T) {
 	defer cleanup()
 	app, appCleanUp := cltest.NewApplicationWithConfig(t, config)
 	defer appCleanUp()
+	eth := app.MockEthClient(cltest.Strict)
+	eth.Register("eth_chainId", app.Store.Config.ChainID())
 
 	completed := abool.New()
 	app.Exiter = func(code int) {

--- a/core/services/head_tracker.go
+++ b/core/services/head_tracker.go
@@ -238,9 +238,10 @@ func (ht *HeadTracker) subscribeToHead() error {
 		return errors.Wrap(err, "TxManager#SubscribeToNewHeads")
 	}
 
-	if err = verifyEthereumChainID(ht); err != nil {
+	if err := verifyEthereumChainID(ht); err != nil {
 		return errors.Wrap(err, "verifyEthereumChainID")
 	}
+
 	ht.headSubscription = sub
 	ht.connected = true
 	ht.connect(ht.head)
@@ -284,12 +285,11 @@ func (e errBlockNotLater) Error() string {
 // matches the ChainID reported by the ETH node connected to this Chainlink node.
 func verifyEthereumChainID(ht *HeadTracker) error {
 	ethereumChainID, err := ht.store.TxManager.GetChainID()
-
 	if err != nil {
 		return err
 	}
 
-	if ht.store.Config.ChainID() != ethereumChainID {
+	if ethereumChainID.Cmp(ht.store.Config.ChainID()) != 0 {
 		return fmt.Errorf(
 			"Ethereum ChainID doesn't match chainlink config.ChainID: config ID=%d, eth RPC ID=%d",
 			ht.store.Config.ChainID(),

--- a/core/services/head_tracker_test.go
+++ b/core/services/head_tracker_test.go
@@ -7,8 +7,10 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/golang/mock/gomock"
 	"github.com/onsi/gomega"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/internal/mocks"
 	"github.com/smartcontractkit/chainlink/core/services"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -22,7 +24,9 @@ func TestHeadTracker_New(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
-	cltest.MockEthOnStore(t, store)
+	eth := cltest.MockEthOnStore(t, store)
+	eth.Register("eth_chainId", store.Config.ChainID())
+
 	assert.Nil(t, store.CreateHead(cltest.Head(1)))
 	last := cltest.Head(16)
 	assert.Nil(t, store.CreateHead(last))
@@ -35,9 +39,13 @@ func TestHeadTracker_New(t *testing.T) {
 
 func TestHeadTracker_New_Limit_At_100(t *testing.T) {
 	t.Parallel()
+
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	cltest.MockEthOnStore(t, store)
+
+	eth := cltest.MockEthOnStore(t, store)
+	eth.Register("eth_chainId", store.Config.ChainID())
+
 	for idx := 0; idx <= 200; idx++ {
 		assert.Nil(t, store.CreateHead(cltest.Head(idx)))
 	}
@@ -73,7 +81,8 @@ func TestHeadTracker_Get(t *testing.T) {
 			store, cleanup := cltest.NewStore(t)
 			defer cleanup()
 
-			cltest.MockEthOnStore(t, store)
+			eth := cltest.MockEthOnStore(t, store)
+			eth.Register("eth_chainId", store.Config.ChainID())
 			if test.initial != nil {
 				assert.Nil(t, store.CreateHead(test.initial))
 			}
@@ -103,6 +112,7 @@ func TestHeadTracker_Start_NewHeads(t *testing.T) {
 	ht := services.NewHeadTracker(store, []strpkg.HeadTrackable{})
 	defer ht.Stop()
 
+	eth.Register("eth_chainId", store.Config.ChainID())
 	eth.RegisterSubscription("newHeads")
 
 	assert.Nil(t, ht.Start())
@@ -113,20 +123,16 @@ func TestHeadTracker_HeadTrackableCallbacks(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewGomegaWithT(t)
 
-	config, configCleanup := cltest.NewConfig(t)
-	defer configCleanup()
-
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	eth := cltest.MockEthOnStore(t, store)
-	chainId := cltest.Int(config.ChainID())
 
 	checker := &cltest.MockHeadTrackable{}
 	ht := services.NewHeadTracker(store, []strpkg.HeadTrackable{checker}, cltest.NeverSleeper{})
 
 	headers := make(chan models.BlockHeader)
 	eth.RegisterSubscription("newHeads", headers)
-	eth.Register("eth_chainId", *chainId)
+	eth.Register("eth_chainId", store.Config.ChainID())
 
 	assert.Nil(t, ht.Start())
 	g.Eventually(func() int32 { return checker.ConnectedCount() }).Should(gomega.Equal(int32(1)))
@@ -150,68 +156,36 @@ func TestHeadTracker_ReconnectOnError(t *testing.T) {
 
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	chainID := cltest.Int(store.Config.ChainID())
-	eth := cltest.MockEthOnStore(t, store)
+
+	ctrl := gomock.NewController(t)
+	txmMock := mocks.NewMockTxManager(ctrl)
+	store.TxManager = txmMock
 
 	checker := &cltest.MockHeadTrackable{}
 	ht := services.NewHeadTracker(store, []strpkg.HeadTrackable{checker}, cltest.NeverSleeper{})
 
-	firstSub := eth.RegisterSubscription("newHeads")
-	headers := make(chan models.BlockHeader)
-	eth.RegisterSubscription("newHeads", headers)
-	eth.Register("eth_chainId", *chainID)
+	subscription := cltest.EmptyMockSubscription()
+	txmMock.EXPECT().GetChainID().Return(store.Config.ChainID(), nil).AnyTimes()
+	txmMock.EXPECT().SubscribeToNewHeads(gomock.Any()).Return(subscription, nil)
+	txmMock.EXPECT().SubscribeToNewHeads(gomock.Any()).Return(nil, errors.New("cannot reconnect"))
+	txmMock.EXPECT().SubscribeToNewHeads(gomock.Any()).Return(subscription, nil)
 
 	// connect
-	assert.Nil(t, ht.Start())
-	g.Eventually(func() int32 { return checker.ConnectedCount() }).Should(gomega.Equal(int32(1)))
-	assert.Equal(t, int32(0), checker.DisconnectedCount())
-	assert.Equal(t, int32(0), checker.OnNewHeadCount())
-
-	// disconnect, to trigger an automatic reconnect
-	eth.Register("eth_chainId", *chainID)
-	firstSub.Errors <- errors.New("Test error to force reconnect")
-	g.Eventually(func() int32 { return checker.ConnectedCount() }).Should(gomega.Equal(int32(2)))
-	assert.Equal(t, int32(1), checker.DisconnectedCount())
-	assert.Equal(t, int32(0), checker.OnNewHeadCount())
-
-	// new head
-	headers <- models.BlockHeader{Number: cltest.BigHexInt(1)}
-	g.Eventually(func() int32 { return checker.OnNewHeadCount() }).Should(gomega.Equal(int32(1)))
-	assert.Equal(t, int32(2), checker.ConnectedCount())
-	assert.Equal(t, int32(1), checker.DisconnectedCount())
-}
-
-func TestHeadTracker_ReconnectAndStopDoesntDeadlock(t *testing.T) {
-	t.Parallel()
-	g := gomega.NewGomegaWithT(t)
-
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
-	chainID := cltest.Int(store.Config.ChainID())
-	eth := cltest.MockEthOnStore(t, store)
-	eth.NoMagic()
-
-	checker := &cltest.MockHeadTrackable{}
-	ht := services.NewHeadTracker(store, []strpkg.HeadTrackable{checker}, cltest.NeverSleeper{})
-
-	firstConnection := eth.RegisterSubscription("newHeads")
-
-	// connect
-	eth.Register("eth_chainId", *chainID)
 	assert.Nil(t, ht.Start())
 	g.Eventually(func() int32 { return checker.ConnectedCount() }).Should(gomega.Equal(int32(1)))
 	assert.Equal(t, int32(0), checker.DisconnectedCount())
 	assert.Equal(t, int32(0), checker.OnNewHeadCount())
 
 	// trigger reconnect loop
-	eth.Register("eth_chainId", *chainID)
-	firstConnection.Errors <- errors.New("Test error to force reconnect")
-	g.Consistently(func() int32 { return checker.ConnectedCount() }).Should(gomega.Equal(int32(1)))
+	subscription.Errors <- errors.New("Test error to force reconnect")
+	g.Eventually(func() int32 { return checker.ConnectedCount() }).Should(gomega.Equal(int32(2)))
+	g.Consistently(func() int32 { return checker.ConnectedCount() }).Should(gomega.Equal(int32(2)))
 	assert.Equal(t, int32(1), checker.DisconnectedCount())
 	assert.Equal(t, int32(0), checker.OnNewHeadCount())
 
 	// stop
 	assert.NoError(t, ht.Stop())
+	ctrl.Finish()
 }
 
 func TestHeadTracker_StartConnectsFromLastSavedHeader(t *testing.T) {
@@ -220,11 +194,10 @@ func TestHeadTracker_StartConnectsFromLastSavedHeader(t *testing.T) {
 
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	chainID := cltest.Int(store.Config.ChainID())
 	eth := cltest.MockEthOnStore(t, store)
 	headers := make(chan models.BlockHeader)
 	eth.RegisterSubscription("newHeads", headers)
-	eth.Register("eth_chainId", *chainID)
+	eth.Register("eth_chainId", store.Config.ChainID())
 
 	lastSavedBN := big.NewInt(1)
 	currentBN := big.NewInt(2)

--- a/core/services/job_subscriber_test.go
+++ b/core/services/job_subscriber_test.go
@@ -75,7 +75,6 @@ func TestJobSubscriber_AttachedToHeadTracker(t *testing.T) {
 	defer cleanup()
 
 	eth := cltest.MockEthOnStore(t, store)
-	chainId := cltest.Int(store.Config.ChainID())
 	j1 := cltest.NewJobWithLogInitiator()
 	j2 := cltest.NewJobWithLogInitiator()
 	assert.Nil(t, store.CreateJob(&j1))
@@ -83,7 +82,7 @@ func TestJobSubscriber_AttachedToHeadTracker(t *testing.T) {
 
 	eth.RegisterSubscription("logs")
 	eth.RegisterSubscription("logs")
-	eth.Register("eth_chainId", *chainId)
+	eth.Register("eth_chainId", store.Config.ChainID())
 
 	ht := services.NewHeadTracker(store, []strpkg.HeadTrackable{el})
 	assert.Nil(t, ht.Start())
@@ -122,6 +121,8 @@ func TestJobSubscriber_AddJob_Listening(t *testing.T) {
 			defer cleanup()
 
 			eth := cltest.MockEthOnStore(t, store)
+			eth.Register("eth_getLogs", []models.Log{})
+			eth.Register("eth_chainId", store.Config.ChainID())
 			logChan := make(chan models.Log, 1)
 			eth.RegisterSubscription("logs", logChan)
 

--- a/core/services/runs_test.go
+++ b/core/services/runs_test.go
@@ -555,8 +555,12 @@ func TestExecuteJob_DoesNotSaveToTaskSpec(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
-	app.Start()
+
 	store := app.Store
+	eth := cltest.MockEthOnStore(t, store)
+	eth.Register("eth_chainId", store.Config.ChainID())
+
+	app.Start()
 
 	job := cltest.NewJobWithWebInitiator()
 	job.Tasks = []models.TaskSpec{cltest.NewTask(t, "NoOp")} // empty params
@@ -584,8 +588,12 @@ func TestExecuteJobWithRunRequest(t *testing.T) {
 	t.Parallel()
 	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
-	app.Start()
+
 	store := app.Store
+	eth := cltest.MockEthOnStore(t, store)
+	eth.Register("eth_chainId", store.Config.ChainID())
+
+	app.Start()
 
 	job := cltest.NewJobWithRunLogInitiator()
 	job.Tasks = []models.TaskSpec{cltest.NewTask(t, "NoOp")} // empty params

--- a/core/store/eth_client.go
+++ b/core/store/eth_client.go
@@ -131,10 +131,10 @@ func (eth *EthClient) GetLogs(q ethereum.FilterQuery) ([]models.Log, error) {
 }
 
 // GetChainID returns the ethereum ChainID.
-func (eth *EthClient) GetChainID() (uint64, error) {
-	var intermediary models.Big
-	err := eth.Call(&intermediary, "eth_chainId")
-	return intermediary.ToInt().Uint64(), err
+func (eth *EthClient) GetChainID() (*big.Int, error) {
+	value := new(models.Big)
+	err := eth.Call(value, "eth_chainId")
+	return value.ToInt(), err
 }
 
 // SubscribeToLogs registers a subscription for push notifications of logs

--- a/core/store/key_store.go
+++ b/core/store/key_store.go
@@ -67,12 +67,8 @@ func (ks *KeyStore) NewAccount(passphrase string) (accounts.Account, error) {
 }
 
 // SignTx uses the unlocked account to sign the given transaction.
-func (ks *KeyStore) SignTx(account accounts.Account, tx *types.Transaction, chainID uint64) (*types.Transaction, error) {
-	return ks.KeyStore.SignTx(
-		account,
-		tx,
-		big.NewInt(int64(chainID)),
-	)
+func (ks *KeyStore) SignTx(account accounts.Account, tx *types.Transaction, chainID *big.Int) (*types.Transaction, error) {
+	return ks.KeyStore.SignTx(account, tx, chainID)
 }
 
 // Sign creates an HMAC from some input data using the account's private key

--- a/core/store/models/eth_test.go
+++ b/core/store/models/eth_test.go
@@ -183,7 +183,7 @@ func TestTx_PresenterMatchesHex(t *testing.T) {
 	ethMock.Context("app.StartAndConnect()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", "0x00")
 		ethMock.Register("eth_getTransactionCount", "0x10")
-		ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+		ethMock.Register("eth_chainId", store.Config.ChainID())
 	})
 
 	require.NoError(t, app.StartAndConnect())

--- a/core/store/models/log_events_test.go
+++ b/core/store/models/log_events_test.go
@@ -202,7 +202,7 @@ func TestStartRunOrSALogSubscription_ValidateSenders(t *testing.T) {
 			eth.Context("app.Start()", func(eth *cltest.EthMock) {
 				eth.Register("eth_getTransactionCount", "0x1")
 				eth.RegisterSubscription("logs", logs)
-				eth.Register("eth_chainId", *cltest.Int(app.Store.Config.ChainID()))
+				eth.Register("eth_chainId", app.Store.Config.ChainID())
 			})
 			assert.NoError(t, app.StartAndConnect())
 

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -106,8 +106,8 @@ func (c Config) BridgeResponseURL() *url.URL {
 }
 
 // ChainID represents the chain ID to use for transactions.
-func (c Config) ChainID() uint64 {
-	return c.viper.GetUint64(EnvVarName("ChainID"))
+func (c Config) ChainID() *big.Int {
+	return c.getWithFallback("ChainID", parseBigInt).(*big.Int)
 }
 
 // ClientNodeURL is the URL of the Ethereum node this Chainlink node should connect to.

--- a/core/store/orm/config_reader.go
+++ b/core/store/orm/config_reader.go
@@ -15,7 +15,7 @@ import (
 type ConfigReader interface {
 	AllowOrigins() string
 	BridgeResponseURL() *url.URL
-	ChainID() uint64
+	ChainID() *big.Int
 	ClientNodeURL() string
 	DatabaseTimeout() time.Duration
 	DatabaseURL() string

--- a/core/store/orm/config_test.go
+++ b/core/store/orm/config_test.go
@@ -20,7 +20,7 @@ import (
 func TestStore_ConfigDefaults(t *testing.T) {
 	t.Parallel()
 	config := NewConfig()
-	assert.Equal(t, uint64(0), config.ChainID())
+	assert.Equal(t, big.NewInt(0), config.ChainID())
 	assert.Equal(t, big.NewInt(20000000000), config.EthGasPriceDefault())
 	assert.Equal(t, "0x514910771AF9Ca656af840dff83E8264EcF986CA", common.HexToAddress(config.LinkContractAddress()).String())
 	assert.Equal(t, assets.NewLink(1000000000000000000), config.MinimumContractPayment())

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -808,7 +808,7 @@ func TestORM_GetLastNonce_Valid(t *testing.T) {
 	ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(one))
 	ethMock.Register("eth_blockNumber", utils.Uint64ToHex(one))
 	ethMock.Register("eth_sendRawTransaction", cltest.NewHash())
-	ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+	ethMock.Register("eth_chainId", store.Config.ChainID())
 
 	assert.NoError(t, app.StartAndConnect())
 

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -15,7 +15,7 @@ import (
 type ConfigSchema struct {
 	AllowOrigins             string         `env:"ALLOW_ORIGINS" default:"http://localhost:3000,http://localhost:6688"`
 	BridgeResponseURL        url.URL        `env:"BRIDGE_RESPONSE_URL"`
-	ChainID                  uint64         `env:"ETH_CHAIN_ID" default:"0"`
+	ChainID                  big.Int        `env:"ETH_CHAIN_ID" default:"0"`
 	ClientNodeURL            string         `env:"CLIENT_NODE_URL" default:"http://localhost:6688"`
 	DatabaseTimeout          time.Duration  `env:"DATABASE_TIMEOUT" default:"500ms"`
 	DatabaseURL              string         `env:"DATABASE_URL"`

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -124,7 +124,7 @@ type ConfigWhitelist struct {
 type whitelist struct {
 	AllowOrigins             string          `json:"allowOrigins"`
 	BridgeResponseURL        string          `json:"bridgeResponseURL,omitempty"`
-	ChainID                  uint64          `json:"ethChainId"`
+	ChainID                  *big.Int        `json:"ethChainId"`
 	ClientNodeURL            string          `json:"clientNodeUrl"`
 	Dev                      bool            `json:"chainlinkDev"`
 	DatabaseTimeout          time.Duration   `json:"databaseTimeout"`

--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -58,7 +58,7 @@ type TxManager interface {
 	SubscribeToLogs(channel chan<- models.Log, q ethereum.FilterQuery) (models.EthSubscription, error)
 	GetLogs(q ethereum.FilterQuery) ([]models.Log, error)
 	GetTxReceipt(common.Hash) (*models.TxReceipt, error)
-	GetChainID() (uint64, error)
+	GetChainID() (*big.Int, error)
 }
 
 //go:generate mockgen -package=mocks -destination=../internal/mocks/tx_manager_mocks.go github.com/smartcontractkit/chainlink/core/store TxManager

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -37,7 +37,7 @@ func TestTxManager_CreateTx_Success(t *testing.T) {
 	ethMock := app.MockEthClient()
 	ethMock.Context("app.StartAndConnect()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce))
-		ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+		ethMock.Register("eth_chainId", store.Config.ChainID())
 	})
 	assert.NoError(t, app.StartAndConnect())
 
@@ -80,7 +80,7 @@ func TestTxManager_CreateTx_RoundRobinSuccess(t *testing.T) {
 	ethMock.Context("app.StartAndConnect()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", "0x00")
 		ethMock.Register("eth_getTransactionCount", "0x10")
-		ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+		ethMock.Register("eth_chainId", config.ChainID())
 	})
 	assert.NoError(t, app.StartAndConnect())
 
@@ -150,7 +150,7 @@ func TestTxManager_CreateTx_BreakTxAttemptLimit(t *testing.T) {
 	ethMock := app.MockEthClient(cltest.Strict)
 	ethMock.Context("app.StartAndConnect()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce))
-		ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+		ethMock.Register("eth_chainId", store.Config.ChainID())
 	})
 	assert.NoError(t, app.StartAndConnect())
 
@@ -210,7 +210,7 @@ func TestTxManager_CreateTx_AttemptErrorDoesNotIncrementNonce(t *testing.T) {
 	ethMock := app.MockEthClient()
 	ethMock.Context("app.StartAndConnect()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce))
-		ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+		ethMock.Register("eth_chainId", store.Config.ChainID())
 	})
 	assert.NoError(t, app.StartAndConnect())
 
@@ -281,7 +281,7 @@ func TestTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
 
 			nonce1 := uint64(256)
 			ethMock.Context("app.StartAndConnect()", func(ethMock *cltest.EthMock) {
-				ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+				ethMock.Register("eth_chainId", store.Config.ChainID())
 				ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce1))
 			})
 			assert.NoError(t, app.StartAndConnect())
@@ -330,7 +330,7 @@ func TestTxManager_CreateTx_NonceTooLowReloadLimit(t *testing.T) {
 	nonce1 := uint64(256)
 	ethMock.Context("app.StartAndConnect()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce1))
-		ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+		ethMock.Register("eth_chainId", store.Config.ChainID())
 	})
 	assert.NoError(t, app.StartAndConnect())
 
@@ -383,7 +383,7 @@ func TestTxManager_BumpGasUntilSafe_lessThanGasBumpThreshold(t *testing.T) {
 
 	ethMock := app.MockEthClient(cltest.Strict)
 	ethMock.Register("eth_getTransactionCount", "0x0")
-	ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+	ethMock.Register("eth_chainId", config.ChainID())
 	require.NoError(t, app.StartAndConnect())
 
 	txm := store.TxManager
@@ -420,7 +420,7 @@ func TestTxManager_BumpGasUntilSafe_atGasBumpThreshold(t *testing.T) {
 
 	ethMock := app.MockEthClient(cltest.Strict)
 	ethMock.Register("eth_getTransactionCount", "0x0")
-	ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+	ethMock.Register("eth_chainId", config.ChainID())
 	require.NoError(t, app.StartAndConnect())
 
 	txm := store.TxManager
@@ -458,7 +458,7 @@ func TestTxManager_BumpGasUntilSafe_exceedsGasBumpThreshold(t *testing.T) {
 
 	ethMock := app.MockEthClient(cltest.Strict)
 	ethMock.Register("eth_getTransactionCount", "0x0")
-	ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+	ethMock.Register("eth_chainId", config.ChainID())
 	require.NoError(t, app.StartAndConnect())
 
 	txm := store.TxManager
@@ -496,7 +496,7 @@ func TestTxManager_BumpGasUntilSafe_confirmed_lessThanGasThreshold(t *testing.T)
 
 	ethMock := app.MockEthClient(cltest.Strict)
 	ethMock.Register("eth_getTransactionCount", "0x0")
-	ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+	ethMock.Register("eth_chainId", config.ChainID())
 	require.NoError(t, app.StartAndConnect())
 
 	txm := store.TxManager
@@ -534,7 +534,7 @@ func TestTxManager_BumpGasUntilSafe_confirmed_atGasBumpThreshold(t *testing.T) {
 
 	ethMock := app.MockEthClient(cltest.Strict)
 	ethMock.Register("eth_getTransactionCount", "0x0")
-	ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+	ethMock.Register("eth_chainId", config.ChainID())
 	require.NoError(t, app.StartAndConnect())
 
 	txm := store.TxManager
@@ -673,7 +673,7 @@ func TestTxManager_BumpGasUntilSafe_erroring(t *testing.T) {
 			ethMock := app.MockEthClient(cltest.Strict)
 			ethMock.ShouldCall(test.mockSetup).During(func() {
 				ethMock.Register("eth_blockNumber", utils.Uint64ToHex(test.blockHeight))
-				ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+				ethMock.Register("eth_chainId", store.Config.ChainID())
 				require.NoError(t, app.StartAndConnect())
 				receipt, _, err := txm.BumpGasUntilSafe(a.Hash)
 
@@ -696,7 +696,7 @@ func TestTxManager_CheckAttempt(t *testing.T) {
 
 	ethMock := app.MockEthClient(cltest.Strict)
 	ethMock.Register("eth_getTransactionCount", "0x0")
-	ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+	ethMock.Register("eth_chainId", config.ChainID())
 	require.NoError(t, app.StartAndConnect())
 
 	txm := store.TxManager
@@ -751,7 +751,7 @@ func TestTxManager_CheckAttempt_error(t *testing.T) {
 	store := app.Store
 	ethMock := app.MockEthClient(cltest.Strict)
 	ethMock.Register("eth_getTransactionCount", "0x0")
-	ethMock.Register("eth_chainId", *cltest.Int(store.Config.ChainID()))
+	ethMock.Register("eth_chainId", store.Config.ChainID())
 	require.NoError(t, app.StartAndConnect())
 
 	txm := store.TxManager
@@ -865,11 +865,10 @@ func TestTxManager_WithdrawLink_HappyPath(t *testing.T) {
 	hash := cltest.NewHash()
 	sentAt := uint64(23456)
 	nonce := uint64(256)
-	chainId := cltest.Int(config.ChainID())
 	ethMock := app.MockEthClient()
 	ethMock.Context("app.StartAndConnect()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce))
-		ethMock.Register("eth_chainId", *chainId)
+		ethMock.Register("eth_chainId", config.ChainID())
 	})
 	assert.NoError(t, app.StartAndConnect())
 
@@ -903,7 +902,7 @@ func TestTxManager_WithdrawLink_Unconfigured_Oracle(t *testing.T) {
 	ethMock := app.MockEthClient()
 	ethMock.Context("app.StartAndConnect()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce))
-		ethMock.Register("eth_chainId", *cltest.Int(app.Store.Config.ChainID()))
+		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
 	})
 	assert.NoError(t, app.StartAndConnect())
 
@@ -985,7 +984,7 @@ func TestTxManager_LogsETHAndLINKBalancesAfterSuccessfulTx(t *testing.T) {
 		ethMock.Register("eth_blockNumber", utils.Uint64ToHex(confirmedHeight))
 		ethMock.Register("eth_getBalance", mockedEthBalance)
 		ethMock.Register("eth_call", mockedLinkBalance)
-		ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+		ethMock.Register("eth_chainId", config.ChainID())
 	})
 	assert.NoError(t, app.StartAndConnect())
 
@@ -1027,7 +1026,7 @@ func TestTxManager_CreateTxWithGas(t *testing.T) {
 	ethMock := app.MockEthClient()
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce))
-		ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+		ethMock.Register("eth_chainId", config.ChainID())
 	})
 	assert.NoError(t, app.StartAndConnect())
 

--- a/core/web/config_controller_test.go
+++ b/core/web/config_controller_test.go
@@ -34,7 +34,7 @@ func TestConfigController_Show(t *testing.T) {
 	assert.Equal(t, uint16(6689), cwl.TLSPort)
 	assert.Equal(t, "", cwl.TLSHost)
 	assert.Contains(t, cwl.EthereumURL, "ws://127.0.0.1:")
-	assert.Equal(t, uint64(3), cwl.ChainID)
+	assert.Equal(t, big.NewInt(3), cwl.ChainID)
 	assert.Contains(t, cwl.ClientNodeURL, "http://127.0.0.1:")
 	assert.Equal(t, uint64(6), cwl.MinOutgoingConfirmations)
 	assert.Equal(t, uint32(1), cwl.MinIncomingConfirmations)

--- a/core/web/keys_controller_test.go
+++ b/core/web/keys_controller_test.go
@@ -21,7 +21,7 @@ func TestKeysController_CreateSuccess(t *testing.T) {
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", "0x100")
 		ethMock.Register("eth_getBlockByNumber", models.BlockHeader{})
-		ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+		ethMock.Register("eth_chainId", config.ChainID())
 	})
 
 	client := app.NewHTTPClient()
@@ -50,12 +50,11 @@ func TestKeysController_InvalidPassword(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
-	chainId := cltest.Int(config.ChainID())
 	ethMock := app.MockEthClient()
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", "0x100")
 		ethMock.Register("eth_getBlockByNumber", models.BlockHeader{})
-		ethMock.Register("eth_chainId", *chainId)
+		ethMock.Register("eth_chainId", config.ChainID())
 	})
 
 	client := app.NewHTTPClient()
@@ -88,7 +87,7 @@ func TestKeysController_JSONBindingError(t *testing.T) {
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", "0x100")
 		ethMock.Register("eth_getBlockByNumber", models.BlockHeader{})
-		ethMock.Register("eth_chainId", *cltest.Int(app.Store.Config.ChainID()))
+		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
 	})
 
 	client := app.NewHTTPClient()

--- a/core/web/transfer_controller_test.go
+++ b/core/web/transfer_controller_test.go
@@ -26,7 +26,7 @@ func TestTransfersController_CreateSuccess(t *testing.T) {
 		ethMock.Register("eth_getTransactionCount", "0x100")
 		ethMock.Register("eth_getBlockByNumber", models.BlockHeader{})
 		ethMock.Register("eth_blockNumber", utils.Uint64ToHex(0))
-		ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+		ethMock.Register("eth_chainId", config.ChainID())
 		ethMock.Register("eth_sendRawTransaction", cltest.NewHash())
 	})
 
@@ -65,7 +65,7 @@ func TestTransfersController_CreateSuccess_From(t *testing.T) {
 		ethMock.Register("eth_getBlockByNumber", models.BlockHeader{})
 		ethMock.Register("eth_blockNumber", utils.Uint64ToHex(0))
 		ethMock.Register("eth_sendRawTransaction", cltest.NewHash())
-		ethMock.Register("eth_chainId", *cltest.Int(app.Store.Config.ChainID()))
+		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
 	})
 
 	client := app.NewHTTPClient()
@@ -103,7 +103,7 @@ func TestTransfersController_TransferError(t *testing.T) {
 		ethMock.Register("eth_getTransactionCount", "0x100")
 		ethMock.Register("eth_getBlockByNumber", models.BlockHeader{})
 		ethMock.Register("eth_blockNumber", utils.Uint64ToHex(0))
-		ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+		ethMock.Register("eth_chainId", config.ChainID())
 		ethMock.RegisterError("eth_sendRawTransaction", "No dice")
 	})
 
@@ -139,7 +139,7 @@ func TestTransfersController_JSONBindingError(t *testing.T) {
 		ethMock.Register("eth_getTransactionCount", "0x100")
 		ethMock.Register("eth_getBlockByNumber", models.BlockHeader{})
 		ethMock.Register("eth_blockNumber", utils.Uint64ToHex(0))
-		ethMock.Register("eth_chainId", *cltest.Int(app.Store.Config.ChainID()))
+		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
 	})
 
 	client := app.NewHTTPClient()

--- a/core/web/withdrawals_controller_test.go
+++ b/core/web/withdrawals_controller_test.go
@@ -48,7 +48,7 @@ func TestWithdrawalsController_CreateSuccess(t *testing.T) {
 			verifyLinkBalanceCheck(oca, t))
 		ethMock.Register("eth_sendRawTransaction", hash)
 		ethMock.Register("eth_blockNumber", sentAt)
-		ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+		ethMock.Register("eth_chainId", config.ChainID())
 	})
 
 	assert.NoError(t, app.StartAndConnect())
@@ -92,7 +92,7 @@ func TestWithdrawalsController_BalanceTooLow(t *testing.T) {
 
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", "0x100")
-		ethMock.Register("eth_chainId", *cltest.Int(config.ChainID()))
+		ethMock.Register("eth_chainId", config.ChainID())
 	})
 	ethMock.Context("manager.CreateTx#1", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_call", "0x0",


### PR DESCRIPTION
This code used to trigger the race detector but using the encoding interface creates a copy.