### PR TITLE
Migration logging can be enabled independently of all sql logging

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -98,6 +98,8 @@ func NewConfigWithWSServer(t testing.TB, wsserver *httptest.Server) *TestConfig 
 	rawConfig.Set("CHAINLINK_DEV", true)
 	rawConfig.Set("ETH_GAS_BUMP_THRESHOLD", 3)
 	rawConfig.Set("LOG_LEVEL", orm.LogLevel{Level: zapcore.DebugLevel})
+	rawConfig.Set("LOG_SQL", false)
+	rawConfig.Set("LOG_SQL_MIGRATIONS", false)
 	rawConfig.Set("MINIMUM_SERVICE_DURATION", "24h")
 	rawConfig.Set("MIN_INCOMING_CONFIRMATIONS", 1)
 	rawConfig.Set("MIN_OUTGOING_CONFIRMATIONS", 6)

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -82,7 +82,6 @@ func Migrate(db *gorm.DB) error {
 		},
 	}
 
-	db.LogMode(true)
 	m := gormigrate.New(db, &options, migrations)
 
 	var count int

--- a/core/store/migrations/migrate_test.go
+++ b/core/store/migrations/migrate_test.go
@@ -40,6 +40,7 @@ func bootstrapORM(t *testing.T) (*orm.ORM, func()) {
 
 	orm, err := orm.NewORM(orm.NormalizedDatabaseURL(config), config.DatabaseTimeout())
 	require.NoError(t, err)
+	orm.DB.LogMode(true)
 
 	return orm, func() {
 		assert.NoError(t, orm.Close())
@@ -185,6 +186,7 @@ func TestMigrate_Migration1560881846(t *testing.T) {
 func TestMigrate_Migration1565139192(t *testing.T) {
 	orm, cleanup := bootstrapORM(t)
 	defer cleanup()
+
 	db := orm.DB
 
 	require.NoError(t, migration0.Migrate(db))
@@ -209,7 +211,6 @@ func TestMigrate_Migration1565210496(t *testing.T) {
 	defer cleanup()
 
 	db := orm.DB
-	db.LogMode(true)
 
 	require.NoError(t, migration0.Migrate(db))
 
@@ -239,7 +240,6 @@ func TestMigrate_Migration1565291711(t *testing.T) {
 	defer cleanup()
 
 	db := orm.DB
-	db.LogMode(true)
 
 	require.NoError(t, migration0.Migrate(db))
 	require.NoError(t, migration1560881855.Migrate(db))

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -244,6 +244,11 @@ func (c Config) LogSQLStatements() bool {
 	return c.viper.GetBool(EnvVarName("LogSQLStatements"))
 }
 
+// LogSQLMigrations tells chainlink to log all SQL migrations made using the default logger
+func (c Config) LogSQLMigrations() bool {
+	return c.viper.GetBool(EnvVarName("LogSQLMigrations"))
+}
+
 // MinIncomingConfirmations represents the minimum number of block
 // confirmations that need to be recorded since a job run started before a task
 // can proceed.

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -35,6 +35,7 @@ type ConfigSchema struct {
 	LogLevel                 LogLevel       `env:"LOG_LEVEL" default:"info"`
 	LogToDisk                bool           `env:"LOG_TO_DISK" default:"true"`
 	LogSQLStatements         bool           `env:"LOG_SQL" default:"false"`
+	LogSQLMigrations         bool           `env:"LOG_SQL_MIGRATIONS" default:"true"`
 	MinIncomingConfirmations uint32         `env:"MIN_INCOMING_CONFIRMATIONS" default:"3"`
 	MinOutgoingConfirmations uint64         `env:"MIN_OUTGOING_CONFIRMATIONS" default:"12"`
 	MinimumContractPayment   assets.Link    `env:"MINIMUM_CONTRACT_PAYMENT" default:"1000000000000000000"`

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -126,16 +126,18 @@ type whitelist struct {
 	BridgeResponseURL        string          `json:"bridgeResponseURL,omitempty"`
 	ChainID                  *big.Int        `json:"ethChainId"`
 	ClientNodeURL            string          `json:"clientNodeUrl"`
-	Dev                      bool            `json:"chainlinkDev"`
 	DatabaseTimeout          time.Duration   `json:"databaseTimeout"`
+	Dev                      bool            `json:"chainlinkDev"`
 	EthereumURL              string          `json:"ethUrl"`
 	EthGasBumpThreshold      uint64          `json:"ethGasBumpThreshold"`
 	EthGasBumpWei            *big.Int        `json:"ethGasBumpWei"`
 	EthGasPriceDefault       *big.Int        `json:"ethGasPriceDefault"`
+	ExplorerURL              string          `json:"explorerUrl"`
 	JSONConsole              bool            `json:"jsonConsole"`
 	LinkContractAddress      string          `json:"linkContractAddress"`
-	ExplorerURL              string          `json:"explorerUrl"`
 	LogLevel                 orm.LogLevel    `json:"logLevel"`
+	LogSQLMigrations         bool            `json:"logSqlMigrations"`
+	LogSQLStatements         bool            `json:"logSqlStatements"`
 	LogToDisk                bool            `json:"logToDisk"`
 	MinimumContractPayment   *assets.Link    `json:"minimumContractPayment"`
 	MinimumRequestExpiration uint64          `json:"minimumRequestExpiration"`
@@ -182,6 +184,8 @@ func NewConfigWhitelist(store *store.Store) (ConfigWhitelist, error) {
 			ExplorerURL:              explorerURL,
 			LogLevel:                 config.LogLevel(),
 			LogToDisk:                config.LogToDisk(),
+			LogSQLStatements:         config.LogSQLStatements(),
+			LogSQLMigrations:         config.LogSQLMigrations(),
 			MinimumContractPayment:   config.MinimumContractPayment(),
 			MinimumRequestExpiration: config.MinimumRequestExpiration(),
 			MinIncomingConfirmations: config.MinIncomingConfirmations(),

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -204,6 +204,7 @@ func initializeORM(config *orm.Config) (*orm.ORM, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "initializeORM#NewORM")
 	}
+	orm.SetLogging(config.LogSQLStatements() || config.LogSQLMigrations())
 	if err = migrations.Migrate(orm.DB); err != nil {
 		return nil, errors.Wrap(err, "initializeORM#Migrate")
 	}


### PR DESCRIPTION
SQL logging implies migration logging, migration logging is a "subset". This should make the tests a lot less verbose.