### PR TITLE
Rate throttling for ethereum

### DIFF
--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -137,6 +137,11 @@ func (c Config) Dev() bool {
 	return c.viper.GetBool(EnvVarName("Dev"))
 }
 
+// MaxRPCCallsPerSecond returns the rate at which RPC calls can be fired
+func (c Config) MaxRPCCallsPerSecond() uint64 {
+	return c.viper.GetUint64(EnvVarName("MaxRPCCallsPerSecond"))
+}
+
 // MaximumServiceDuration is the maximum time that a service agreement can run
 // from after the time it is created. Default 1 year = 365 * 24h = 8760h
 func (c Config) MaximumServiceDuration() time.Duration {

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -39,7 +39,8 @@ type ConfigSchema struct {
 	MinIncomingConfirmations uint32         `env:"MIN_INCOMING_CONFIRMATIONS" default:"3"`
 	MinOutgoingConfirmations uint64         `env:"MIN_OUTGOING_CONFIRMATIONS" default:"12"`
 	MinimumContractPayment   assets.Link    `env:"MINIMUM_CONTRACT_PAYMENT" default:"1000000000000000000"`
-	MinimumRequestExpiration uint64         `env:"MINIMUM_REQUEST_EXPIRATION" default:"300" `
+	MinimumRequestExpiration uint64         `env:"MINIMUM_REQUEST_EXPIRATION" default:"300"`
+	MaxRPCCallsPerSecond     uint64         `env:"MAX_RPC_CALLS_PER_SECOND" default:"500"`
 	OracleContractAddress    common.Address `env:"ORACLE_CONTRACT_ADDRESS"`
 	Port                     uint16         `env:"CHAINLINK_PORT" default:"6688"`
 	ReaperExpiration         time.Duration  `env:"REAPER_EXPIRATION" default:"240h"`

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -139,6 +139,7 @@ type whitelist struct {
 	LogSQLMigrations         bool            `json:"logSqlMigrations"`
 	LogSQLStatements         bool            `json:"logSqlStatements"`
 	LogToDisk                bool            `json:"logToDisk"`
+	MaxRPCCallsPerSecond     uint64          `json:"maxRPCCallsPerSecond"`
 	MinimumContractPayment   *assets.Link    `json:"minimumContractPayment"`
 	MinimumRequestExpiration uint64          `json:"minimumRequestExpiration"`
 	MinIncomingConfirmations uint32          `json:"minIncomingConfirmations"`
@@ -186,6 +187,7 @@ func NewConfigWhitelist(store *store.Store) (ConfigWhitelist, error) {
 			LogToDisk:                config.LogToDisk(),
 			LogSQLStatements:         config.LogSQLStatements(),
 			LogSQLMigrations:         config.LogSQLMigrations(),
+			MaxRPCCallsPerSecond:     config.MaxRPCCallsPerSecond(),
 			MinimumContractPayment:   config.MinimumContractPayment(),
 			MinimumRequestExpiration: config.MinimumRequestExpiration(),
 			MinIncomingConfirmations: config.MinIncomingConfirmations(),

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	golang.org/x/crypto v0.0.0-20190701094942-4def268fd1a4
 	golang.org/x/sync v0.0.0-20190423024810-112230192c58
 	golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2
+	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 	gopkg.in/gormigrate.v1 v1.6.0
 	gopkg.in/guregu/null.v2 v2.1.2 // indirect
 	gopkg.in/guregu/null.v3 v3.4.0

--- a/go.sum
+++ b/go.sum
@@ -407,6 +407,7 @@ golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2 h1:z99zHgr7hKfrUcX/KsoJk5FJfjTceCKIp96+biqP4To=
 golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
+golang.org/x/time v0.0.0-20190308202827-9d24e82272b4 h1:SvFZT6jyqRaOeXpc5h/JSfZenJ2O330aBsf7JfSUXmQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180221164845-07fd8470d635/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=


### PR DESCRIPTION
This adds a rate limiter to ethereum calls, `Wait` will block and sleep till a window has opened where the threshold won't be exceeded. Note that we use a timeout so that after 30 seconds of waiting, the call will fail.

Configurable using `MAX_RPC_CALLS_PER_SECOND`.