### PR TITLE
Denormalize amount and link_earned onto a run

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -352,6 +352,7 @@ func TestIntegration_RunLog(t *testing.T) {
 			assert.NoError(t, err)
 			jr := runs[0]
 			cltest.WaitForJobRunToPendConfirmations(t, app.Store, jr)
+			require.Len(t, jr.TaskRuns, 1)
 			assert.False(t, jr.TaskRuns[0].Confirmations.Valid)
 
 			blockIncrease := app.Store.Config.MinIncomingConfirmations()

--- a/core/services/job_runner.go
+++ b/core/services/job_runner.go
@@ -268,14 +268,6 @@ func executeRun(run *models.JobRun, store *store.Store) error {
 
 	if run.Status.Finished() {
 		run.SetFinishedAt()
-		reward := run.Overrides.Amount
-		if reward != nil {
-			earn := models.NewLinkEarned(run.ID, run.Overrides.Amount)
-			if err := store.AddLinkEarned(&earn); err != nil {
-				return err
-			}
-		}
-
 	}
 
 	if err := updateAndTrigger(run, store); err != nil {

--- a/core/services/job_runner_test.go
+++ b/core/services/job_runner_test.go
@@ -90,10 +90,12 @@ func TestJobRunner_executeRun_correctlyAddsLinkEarnings(t *testing.T) {
 	}
 	assert.NoError(t, store.CreateJob(&j))
 	run := j.NewRun(i)
+	run.Payment = assets.NewLink(1)
 	require.NoError(t, store.CreateJobRun(&run))
-	run.Overrides.Amount = assets.NewLink(1)
 	require.NoError(t, services.ExportedExecuteRun(&run, store))
-	actual, _ := store.LinkEarnedFor(&j)
+
+	actual, err := store.LinkEarnedFor(&j)
+	require.NoError(t, err)
 	assert.Equal(t, assets.NewLink(1), actual)
 }
 

--- a/core/services/runs.go
+++ b/core/services/runs.go
@@ -48,7 +48,7 @@ func ExecuteJobWithRunRequest(
 		"creation_height", creationHeight,
 	)
 
-	run, err := NewRun(job, initiator, input, creationHeight, store)
+	run, err := NewRun(job, initiator, input, creationHeight, store, runRequest.Payment)
 	if err != nil {
 		return nil, errors.Wrap(err, "NewRun failed")
 	}
@@ -62,7 +62,7 @@ func ExecuteJobWithRunRequest(
 func MeetsMinimumPayment(
 	expectedMinJobPayment *assets.Link,
 	actualRunPayment *assets.Link) bool {
-	// input.Amount is always present for runs triggered by ethlogs
+	// input.Payment is always present for runs triggered by ethlogs
 	if actualRunPayment == nil || expectedMinJobPayment == nil || expectedMinJobPayment.IsZero() {
 		return true
 	}
@@ -76,7 +76,8 @@ func NewRun(
 	initiator models.Initiator,
 	input models.RunResult,
 	currentHeight *big.Int,
-	store *store.Store) (*models.JobRun, error) {
+	store *store.Store,
+	payment *assets.Link) (*models.JobRun, error) {
 
 	now := store.Clock.Now()
 	if !job.Started(now) {
@@ -98,18 +99,18 @@ func NewRun(
 	run.CreationHeight = models.NewBig(currentHeight)
 	run.ObservedHeight = models.NewBig(currentHeight)
 
-	if !MeetsMinimumPayment(job.MinPayment, input.Amount) {
+	if !MeetsMinimumPayment(job.MinPayment, payment) {
 		logger.Infow("Rejecting run with insufficient payment", []interface{}{
 			"run", run.ID,
 			"job", run.JobSpecID,
-			"input_amount", input.Amount,
-			"required_amount", job.MinPayment,
+			"input_payment", payment,
+			"required_payment", job.MinPayment,
 		}...)
 
 		err := fmt.Errorf(
 			"Rejecting job %s with payment %s below job-specific-minimum threshold (%s)",
 			job.ID,
-			input.Amount,
+			payment,
 			job.MinPayment.Text(10))
 		run.SetError(err)
 	}
@@ -138,20 +139,20 @@ func NewRun(
 		}
 	}
 
-	// input.Amount is always present for runs triggered by ethlogs
-	if input.Amount != nil {
-		if cost.Cmp(input.Amount) > 0 {
+	// payment is always present for runs triggered by ethlogs
+	if payment != nil {
+		if cost.Cmp(payment) > 0 {
 			logger.Debugw("Rejecting run with insufficient payment", []interface{}{
 				"run", run.ID,
 				"job", run.JobSpecID,
-				"input_amount", input.Amount,
-				"required_amount", cost,
+				"input_payment", payment,
+				"required_payment", cost,
 			}...)
 
 			err := fmt.Errorf(
 				"Rejecting job %s with payment %s below minimum threshold (%s)",
 				job.ID,
-				input.Amount,
+				payment,
 				store.Config.MinimumContractPayment().Text(10))
 			run.SetError(err)
 		}

--- a/core/services/runs_test.go
+++ b/core/services/runs_test.go
@@ -43,7 +43,7 @@ func TestNewRun(t *testing.T) {
 	}}
 
 	inputResult := models.RunResult{Data: input}
-	run, err := services.NewRun(jobSpec, jobSpec.Initiators[0], inputResult, creationHeight, store)
+	run, err := services.NewRun(jobSpec, jobSpec.Initiators[0], inputResult, creationHeight, store, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, string(models.RunStatusInProgress), string(run.Status))
 	assert.Len(t, run.TaskRuns, 1)
@@ -114,9 +114,9 @@ func TestNewRun_requiredPayment(t *testing.T) {
 			}}
 			jobSpec.MinPayment = test.minimumJobSpecPayment
 
-			inputResult := models.RunResult{Data: input, Amount: test.payment}
+			inputResult := models.RunResult{Data: input}
 
-			run, err := services.NewRun(jobSpec, jobSpec.Initiators[0], inputResult, nil, store)
+			run, err := services.NewRun(jobSpec, jobSpec.Initiators[0], inputResult, nil, store, test.payment)
 			assert.NoError(t, err)
 			assert.Equal(t, string(test.expectedStatus), string(run.Status))
 		})
@@ -156,7 +156,8 @@ func TestNewRun_minimumConfirmations(t *testing.T) {
 				jobSpec.Initiators[0],
 				inputResult,
 				creationHeight,
-				store)
+				store,
+				nil)
 			assert.NoError(t, err)
 			assert.Equal(t, string(test.expectedStatus), string(run.Status))
 			require.Len(t, run.TaskRuns, 1)
@@ -196,7 +197,7 @@ func TestNewRun_startAtAndEndAt(t *testing.T) {
 			job.EndAt = test.endAt
 			assert.Nil(t, store.CreateJob(&job))
 
-			_, err := services.NewRun(job, job.Initiators[0], models.RunResult{}, nil, store)
+			_, err := services.NewRun(job, job.Initiators[0], models.RunResult{}, nil, store, nil)
 			if test.errored {
 				assert.Error(t, err)
 			} else {
@@ -214,7 +215,7 @@ func TestNewRun_noTasksErrorsInsteadOfPanic(t *testing.T) {
 	job.Tasks = []models.TaskSpec{}
 	require.NoError(t, store.CreateJob(&job))
 
-	jr, err := services.NewRun(job, job.Initiators[0], models.RunResult{}, nil, store)
+	jr, err := services.NewRun(job, job.Initiators[0], models.RunResult{}, nil, store, nil)
 	assert.NoError(t, err)
 	assert.True(t, jr.Status.Errored())
 	assert.True(t, jr.Result.HasError())

--- a/core/services/subscription.go
+++ b/core/services/subscription.go
@@ -150,16 +150,7 @@ func ReceiveLogRequest(store *strpkg.Store, le models.LogRequest) {
 }
 
 func runJob(store *strpkg.Store, le models.LogRequest, data models.JSON) {
-	payment, err := le.ContractPayment()
-	if err != nil {
-		logger.Errorw(err.Error(), le.ForLogger()...)
-		return
-	}
-
-	input := models.RunResult{
-		Data:   data,
-		Amount: payment,
-	}
+	input := models.RunResult{Data: data}
 	if err := le.ValidateRequester(); err != nil {
 		input.SetError(err)
 		logger.Errorw(err.Error(), le.ForLogger()...)

--- a/core/services/synchronization/presenters.go
+++ b/core/services/synchronization/presenters.go
@@ -30,7 +30,7 @@ func (p SyncJobRunPresenter) MarshalJSON() ([]byte, error) {
 		Status     string                 `json:"status"`
 		Error      null.String            `json:"error"`
 		CreatedAt  string                 `json:"createdAt"`
-		Amount     *assets.Link           `json:"amount"`
+		Payment    *assets.Link           `json:"payment"`
 		FinishedAt null.Time              `json:"finishedAt"`
 		Initiator  syncInitiatorPresenter `json:"initiator"`
 		Tasks      []syncTaskRunPresenter `json:"tasks"`
@@ -41,7 +41,7 @@ func (p SyncJobRunPresenter) MarshalJSON() ([]byte, error) {
 		Status:     string(p.Status),
 		Error:      p.Result.ErrorMessage,
 		CreatedAt:  utils.ISO8601UTC(p.CreatedAt),
-		Amount:     p.Result.Amount,
+		Payment:    p.Payment,
 		FinishedAt: p.FinishedAt,
 		Initiator:  p.initiator(),
 		Tasks:      tasks,

--- a/core/services/synchronization/presenters_test.go
+++ b/core/services/synchronization/presenters_test.go
@@ -28,7 +28,8 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 		ID:        runID,
 		JobSpecID: specID,
 		Status:    models.RunStatusInProgress,
-		Result:    models.RunResult{Amount: assets.NewLink(2)},
+		Result:    models.RunResult{},
+		Payment:   assets.NewLink(2),
 		Initiator: models.Initiator{
 			Type: models.InitiatorRunLog,
 		},
@@ -65,7 +66,7 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 	assert.Equal(t, data["status"], "in_progress")
 	assert.Contains(t, data, "error")
 	assert.Contains(t, data, "createdAt")
-	assert.Equal(t, data["amount"], "2")
+	assert.Equal(t, data["payment"], "2")
 	assert.Equal(t, data["finishedAt"], nil)
 	assert.Contains(t, data, "tasks")
 
@@ -180,7 +181,8 @@ func TestSyncJobRunPresenter_EthTxTask(t *testing.T) {
 				ID:        models.NewID(),
 				JobSpecID: models.NewID(),
 				Status:    models.RunStatusCompleted,
-				Result:    models.RunResult{Amount: assets.NewLink(2)},
+				Result:    models.RunResult{},
+				Payment:   assets.NewLink(2),
 				Initiator: models.Initiator{
 					Type: models.InitiatorRunLog,
 				},

--- a/core/store/assets/currencies.go
+++ b/core/store/assets/currencies.go
@@ -110,18 +110,27 @@ func (l Link) Value() (driver.Value, error) {
 
 // Scan reads the database value and returns an instance.
 func (l *Link) Scan(value interface{}) error {
-	switch temp := value.(type) {
+	switch v := value.(type) {
 	case string:
-		_, ok := l.SetString(temp, 10)
+		decoded, ok := l.SetString(v, 10)
 		if !ok {
-			return fmt.Errorf("Unable to scan Link string from %s", temp)
+			return fmt.Errorf("Unable to set string %v of %T to base 10 big.Int for Link", value, value)
 		}
-		return nil
+		*l = *decoded
+	case []uint8:
+		// The SQL library returns numeric() types as []uint8 of the string representation
+		decoded, ok := l.SetString(string(v), 10)
+		if !ok {
+			return fmt.Errorf("Unable to set string %v of %T to base 10 big.Int for Link", value, value)
+		}
+		*l = *decoded
 	case int64:
 		return fmt.Errorf("Unable to convert %v of %T to Link, is the sql type set to varchar?", value, value)
 	default:
 		return fmt.Errorf("Unable to convert %v of %T to Link", value, value)
 	}
+
+	return nil
 }
 
 // Eth contains a field to represent the smallest units of ETH

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565291711"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565877314"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1566498796"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1567029116"
 	gormigrate "gopkg.in/gormigrate.v1"
 )
 
@@ -89,6 +90,10 @@ func Migrate(db *gorm.DB) error {
 		{
 			ID:      "1565877314",
 			Migrate: migration1565877314.Migrate,
+		},
+		{
+			ID:      "1567029116",
+			Migrate: migration1567029116.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration0/migrate.go
+++ b/core/store/migrations/migration0/migrate.go
@@ -7,6 +7,7 @@ import (
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 	clnull "github.com/smartcontractkit/chainlink/core/null"
+	"github.com/smartcontractkit/chainlink/core/store/assets"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"gopkg.in/guregu/null.v3"
 )
@@ -40,7 +41,7 @@ func Migrate(tx *gorm.DB) error {
 	if err := tx.AutoMigrate(&RunRequest{}).Error; err != nil {
 		return errors.Wrap(err, "failed to auto migrate RunRequest")
 	}
-	if err := tx.AutoMigrate(&models.RunResult{}).Error; err != nil {
+	if err := tx.AutoMigrate(&RunResult{}).Error; err != nil {
 		return errors.Wrap(err, "failed to auto migrate RunResult")
 	}
 	if err := tx.AutoMigrate(&ServiceAgreement{}).Error; err != nil {
@@ -189,4 +190,13 @@ type TaskSpec struct {
 	Type          string `gorm:"index;not null"`
 	Confirmations clnull.Uint32
 	Params        string `gorm:"type:text"`
+}
+
+// RunResult is a capture of the model before migration1567029116
+type RunResult struct {
+	ID           uint   `gorm:"primary_key;auto_increment"`
+	Data         string `gorm:"type:text"`
+	Status       string
+	ErrorMessage string
+	Amount       *assets.Link `gorm:"type:varchar(255)"`
 }

--- a/core/store/migrations/migration1567029116/migrate.go
+++ b/core/store/migrations/migration1567029116/migrate.go
@@ -1,0 +1,43 @@
+package migration1567029116
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/smartcontractkit/chainlink/core/store/dbutil"
+)
+
+// Migrate optimizes the JobRuns table to reduce the cost of IDs
+func Migrate(tx *gorm.DB) error {
+	if dbutil.IsPostgres(tx) {
+		return tx.Exec(`
+ALTER TABLE run_requests ADD COLUMN "payment" numeric(78, 0);
+ALTER TABLE job_runs ADD COLUMN "payment" numeric(78, 0);
+UPDATE job_runs
+SET "payment" = CAST("earned" AS numeric)
+FROM link_earned
+WHERE job_run_id = job_runs.id;
+DROP TABLE "link_earned";
+ALTER TABLE run_results DROP COLUMN "amount";
+`).Error
+	}
+
+	return tx.Exec(`
+ALTER TABLE run_requests ADD COLUMN "payment" varchar(255);
+ALTER TABLE job_runs ADD COLUMN "payment" varchar(255);
+UPDATE job_runs
+SET "payment" = (
+	SELECT earned
+	FROM link_earned
+	WHERE job_run_id = job_runs.id
+);
+DROP TABLE "link_earned";
+CREATE TABLE "run_results_new" (
+	"id" integer primary key autoincrement,
+	"data" text,
+	"status" varchar(255),
+	"error_message" varchar(255)
+);
+INSERT INTO "run_results_new" SELECT "id", "data", "status", "error_message" FROM "run_results";
+DROP TABLE "run_results";
+ALTER TABLE "run_results_new" RENAME TO "run_results";
+	`).Error
+}

--- a/core/store/models/log_events_test.go
+++ b/core/store/models/log_events_test.go
@@ -292,10 +292,10 @@ func TestRunLogEvent_ContractPayment(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			rle := models.RunLogEvent{models.InitiatorLogEvent{Log: test.log}}
 
-			received, err := rle.ContractPayment()
+			request, err := rle.RunRequest()
 
 			cltest.AssertError(t, test.wantErrored, err)
-			assert.Equal(t, test.want, received)
+			assert.Equal(t, test.want, request.Payment)
 		})
 	}
 }

--- a/core/store/models/run_test.go
+++ b/core/store/models/run_test.go
@@ -136,7 +136,7 @@ func TestForLogger(t *testing.T) {
 	linkReward := assets.NewLink(5)
 
 	jr.Result = cltest.RunResultWithData(`{"result":"11850.00"}`)
-	jr.Overrides.Amount = linkReward
+	jr.Payment = linkReward
 	logsBeforeCompletion := jr.ForLogger()
 	require.Len(t, logsBeforeCompletion, 6)
 	assert.Equal(t, logsBeforeCompletion[0], "job")

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -215,29 +215,25 @@ func TestORM_LinkEarnedFor(t *testing.T) {
 	require.NoError(t, store.CreateJob(&job))
 
 	initr := job.Initiators[0]
-	data := `{"result":"921.02"}`
 	jr1 := job.NewRun(initr)
-	jr1.Result = cltest.RunResultWithData(data)
-	jr2 := job.NewRun(initr)
-	jr2.Result = cltest.RunResultWithData(data)
-	jr3 := job.NewRun(initr)
-	jr3.Result = cltest.RunResultWithData(data)
+	jr1.Payment = assets.NewLink(2)
+	jr1.FinishedAt = null.TimeFrom(time.Now())
 	require.NoError(t, store.CreateJobRun(&jr1))
+	jr2 := job.NewRun(initr)
+	jr2.Payment = assets.NewLink(3)
+	jr2.FinishedAt = null.TimeFrom(time.Now())
 	require.NoError(t, store.CreateJobRun(&jr2))
+	jr3 := job.NewRun(initr)
+	jr3.Payment = assets.NewLink(5)
+	jr3.FinishedAt = null.TimeFrom(time.Now())
 	require.NoError(t, store.CreateJobRun(&jr3))
-
-	earning1 := cltest.FakeLinkEarned(&jr1, assets.NewLink(2))
-	require.NoError(t, store.AddLinkEarned(&earning1))
-	earning2 := cltest.FakeLinkEarned(&jr2, assets.NewLink(3))
-	require.NoError(t, store.AddLinkEarned(&earning2))
-	earning3 := cltest.FakeLinkEarned(&jr3, assets.NewLink(5))
-	require.NoError(t, store.AddLinkEarned(&earning3))
+	jr4 := job.NewRun(initr)
+	jr4.Payment = assets.NewLink(5)
+	require.NoError(t, store.CreateJobRun(&jr4))
 
 	totalEarned, err := store.LinkEarnedFor(&job)
-	assert.NoError(t, err)
-	actualEarned := assets.NewLink(10)
-	assert.Equal(t, totalEarned, actualEarned)
-
+	require.NoError(t, err)
+	assert.Equal(t, assets.NewLink(10), totalEarned)
 }
 
 func TestORM_JobRunsSortedFor(t *testing.T) {

--- a/explorer/src/__tests__/fixtures/JobRun.ethtx.fixture.json
+++ b/explorer/src/__tests__/fixtures/JobRun.ethtx.fixture.json
@@ -5,7 +5,7 @@
   "status": "completed",
   "error": null,
   "createdAt": "2019-05-03T15:21:35Z",
-  "amount": null,
+  "payment": null,
   "finishedAt": "2019-05-03T11:21:36.01197-04:00",
   "initiator": { "type": "web" },
   "tasks": [

--- a/explorer/src/__tests__/fixtures/JobRun.fixture.json
+++ b/explorer/src/__tests__/fixtures/JobRun.fixture.json
@@ -4,7 +4,7 @@
   "status": "in_progress",
   "error": null,
   "createdAt": "2019-04-01T22:07:04Z",
-  "amount": null,
+  "payment": null,
   "finishedAt": null,
   "initiator": {
     "type": "runlog",

--- a/explorer/src/__tests__/fixtures/JobRunUpdate.fixture.json
+++ b/explorer/src/__tests__/fixtures/JobRunUpdate.fixture.json
@@ -4,7 +4,7 @@
   "status": "completed",
   "error": null,
   "createdAt": "2019-04-01T22:07:04Z",
-  "amount": null,
+  "payment": null,
   "finishedAt": "2018-04-01T22:07:04Z",
   "initiator": {
     "type": "runlog",

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/gin-gonic/gin v1.4.0
 	github.com/gobuffalo/packr v1.30.1
 	github.com/gofrs/flock v0.7.1
+	github.com/gofrs/uuid v3.2.0+incompatible
 	github.com/golang/mock v1.3.1
 	github.com/google/uuid v1.1.0 // indirect
 	github.com/gorilla/securecookie v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -117,6 +117,7 @@ github.com/gobuffalo/packr/v2 v2.5.1 h1:TFOeY2VoGamPjQLiNDT3mn//ytzk236VMO2j7iHx
 github.com/gobuffalo/packr/v2 v2.5.1/go.mod h1:8f9c96ITobJlPzI44jj+4tHnEKNt0xXWSVlXRN9X1Iw=
 github.com/gofrs/flock v0.7.1 h1:DP+LD/t0njgoPBvT5MJLeliUIVQR03hiKR6vezdwHlc=
 github.com/gofrs/flock v0.7.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
+github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
 github.com/gogo/protobuf v1.2.0/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=

--- a/operator_ui/@types/core/store/models.d.ts
+++ b/operator_ui/@types/core/store/models.d.ts
@@ -148,6 +148,7 @@ declare module 'core/store/models' {
     createdHeight: Pointer<Big>
     observedHeight: Pointer<Big>
     overrides: RunResult
+    payment: Pointer<assets.Link>
   }
 
   /**
@@ -173,7 +174,6 @@ declare module 'core/store/models' {
     data: JSONValue
     status: RunStatus
     error: nullable.String
-    amount?: assets.Link
   }
 
   /**

--- a/operator_ui/@types/operator_ui.d.ts
+++ b/operator_ui/@types/operator_ui.d.ts
@@ -7,7 +7,6 @@ interface RunResult {
   jobRunId: string
   taskRunId: string
   status: status
-  amount?: number
 }
 
 export interface IBridgeType
@@ -40,6 +39,7 @@ export interface IJobRun
   createdAt: string
   finishedAt: string
   status: string
+  payment: number
 }
 
 export interface IJobSpec extends dbTypes.JobSpec {

--- a/operator_ui/__tests__/components/JobRuns/StatusCard.test.js
+++ b/operator_ui/__tests__/components/JobRuns/StatusCard.test.js
@@ -14,9 +14,9 @@ describe('components/JobRuns/StatusCard', () => {
   const completedRun = {
     id: 'runA',
     status: 'completed',
-    overrides: { amount: 2000000000000000000 },
     createdAt: TWO_MINUTES_MS,
-    finishedAt: MINUTE_MS
+    finishedAt: MINUTE_MS,
+    payment: 2000000000000000000
   }
   const erroredRun = {
     id: 'runA',

--- a/operator_ui/src/components/JobRuns/StatusCard.tsx
+++ b/operator_ui/src/components/JobRuns/StatusCard.tsx
@@ -63,7 +63,7 @@ const EarnedLink = ({
   jobRun?: IJobRun
   classes: WithStyles<typeof styles>['classes']
 }) => {
-  const linkEarned = jobRun && jobRun.overrides && jobRun.overrides.amount
+  const linkEarned = jobRun && jobRun.payment
   return (
     <Typography className={classes.earnedLink} variant="h6">
       +{linkEarned ? selectLink(linkEarned) : 0} Link


### PR DESCRIPTION
Link earned only applies to a single amount attached to a Run after it has been completed, we can use this knowledge to get rid of the link_earned table (which ran a risk of double counting) attaching the payment to the run itself and the run_request. RunResults no longer need the amount column, which simplifies the model and also reduces disk usage.

 * Drop link_earned table, the finishedAt date and finished status of a
   run denote earned link
 * Save the amount as payment on the run
 * Add payment to RunRequest

[Fixes #168094582]