### PR TITLE
README: remove references to GOPATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ $ ./chainlink
 ### Test
 
 ```bash
-$ cd $GOPATH/src/github.com/smartcontractkit/chainlink
 $ go test ./...
 ```
 
@@ -103,7 +102,7 @@ $ go test ./...
 1. [Install Yarn](https://yarnpkg.com/lang/en/docs/install)
 2. Install the dependencies:
 ```bash
-$ cd $GOPATH/src/github.com/smartcontractkit/chainlink/evm
+$ cd evm
 $ yarn install
 ```
 3. Run tests:


### PR DESCRIPTION
Remove references to the GOPATH in the README (except re: command PATH) as the project should no longer reside in this location.