### PR TITLE
Use workspace commands for explorer job in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -198,7 +198,7 @@ jobs:
       - run: ./tools/ci/init_gcloud
       - run: ./tools/ci/operator_ui_test
   explorer:
-    working_directory: ~/chainlink/explorer
+    working_directory: ~/chainlink
     docker:
       - image: circleci/node:10-browsers
         environment:
@@ -210,31 +210,31 @@ jobs:
     steps:
       - checkout:
           path: ~/chainlink
+      - run: echo $CACHE_VERSION > cache.version
       - restore_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}-{{checksum "client/yarn.lock" }}
+          name: Restore Yarn Package Cache
+          key: v{{ checksum "cache.version" }}-yarn-vendor-{{ checksum "yarn.lock" }}-node:10-browsers
       - run:
-          name: Install Server Packages
+          name: Install New Packages
           command: yarn install
-      - run:
-          name: Install Client Packages
-          command: cd client && yarn install
       - save_cache:
-          key: dependency-cache-{{ checksum "yarn.lock" }}-{{checksum "client/yarn.lock" }}
+          name: Save Yarn Package Cache
+          key: v{{ checksum "cache.version" }}-yarn-vendor-{{ checksum "yarn.lock" }}-node:10-browsers
           paths:
             - ~/.cache/yarn
             - /usr/local/share/.cache/yarn
       - run:
           name: Run Lint
-          command: yarn lint
+          command: yarn workspace @chainlink/explorer run lint
       - run:
           name: Run Server Tests
-          command: yarn test-ci:silent
+          command: yarn workspace @chainlink/explorer run test-ci:silent
       - run:
           name: Run Client Tests
-          command: cd client && yarn test-ci:silent
+          command: yarn workspace @chainlink/explorer-client run test-ci:silent
       - run:
           name: Run E2E Tests
-          command: cd client && yarn build && cd .. && yarn test-ci:e2e:silent
+          command: yarn workspace @chainlink/explorer-client run build && yarn workspace @chainlink/explorer run test-ci:e2e:silent
   build-explorer-image:
     machine: true
     steps:


### PR DESCRIPTION
Need new cache key because docker image has different permissions to builder https://support.circleci.com/hc/en-us/articles/360004250693-Restoring-cache-fails-with-Permission-Denied-