### PR TITLE
fix authentication for job creation API

### DIFF
--- a/core/web/router.go
+++ b/core/web/router.go
@@ -263,6 +263,7 @@ func v2Routes(app services.Application, r *gin.RouterGroup) {
 		authv2.POST("/external_initiators", eia.Create)
 		authv2.DELETE("/external_initiators/:AccessKey", eia.Destroy)
 
+		authv2.POST("/specs", j.Create)
 		authv2.GET("/specs", paginatedRequest(j.Index))
 		authv2.GET("/specs/:SpecID", j.Show)
 		authv2.DELETE("/specs/:SpecID", j.Destroy)
@@ -308,7 +309,6 @@ func v2Routes(app services.Application, r *gin.RouterGroup) {
 	ping := PingController{app}
 	tokAuthv2 := r.Group("/v2", tokenAuthRequired(app.GetStore()))
 	tokAuthv2.POST("/specs/:SpecID/runs", jr.Create)
-	tokAuthv2.POST("/specs", j.Create)
 	tokAuthv2.GET("/ping", ping.Show)
 }
 

--- a/core/web/router_test.go
+++ b/core/web/router_test.go
@@ -60,7 +60,7 @@ func TestTokenAuthRequired_TokenCredentials(t *testing.T) {
 	err = app.GetStore().CreateExternalInitiator(ea)
 	require.NoError(t, err)
 
-	request, err := http.NewRequest("POST", ts.URL+"/v2/specs/", bytes.NewBufferString("{}"))
+	request, err := http.NewRequest("GET", ts.URL+"/v2/ping/", bytes.NewBufferString("{}"))
 	require.NoError(t, err)
 	request.Header.Set("Content-Type", web.MediaType)
 	request.Header.Set("X-Chainlink-EA-AccessKey", eia.AccessKey)
@@ -70,7 +70,7 @@ func TestTokenAuthRequired_TokenCredentials(t *testing.T) {
 	resp, err := client.Do(request)
 	require.NoError(t, err)
 
-	assert.Equal(t, 400, resp.StatusCode)
+	assert.Equal(t, 200, resp.StatusCode)
 }
 
 func TestTokenAuthRequired_BadTokenCredentials(t *testing.T) {
@@ -91,7 +91,7 @@ func TestTokenAuthRequired_BadTokenCredentials(t *testing.T) {
 	err = app.GetStore().CreateExternalInitiator(ea)
 	require.NoError(t, err)
 
-	request, err := http.NewRequest("POST", ts.URL+"/v2/specs/", bytes.NewBufferString("{}"))
+	request, err := http.NewRequest("GET", ts.URL+"/v2/ping/", bytes.NewBufferString("{}"))
 	require.NoError(t, err)
 	request.Header.Set("Content-Type", web.MediaType)
 	request.Header.Set("X-Chainlink-EA-AccessKey", eia.AccessKey)


### PR DESCRIPTION
Job Spec creation should not be possible via an External Initiator, only Run creation.