### PR TITLE
mark transactions as confirmed even if the version is unknown

### DIFF
--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -156,9 +156,20 @@ func CreateTx(
 	from common.Address,
 	sentAt uint64,
 ) *models.Tx {
+	return CreateTxWithNonce(t, store, from, sentAt, 0)
+}
+
+// CreateTxWithNonce creates a Tx from a specified address, sentAt, and nonce
+func CreateTxWithNonce(
+	t testing.TB,
+	store *strpkg.Store,
+	from common.Address,
+	sentAt uint64,
+	nonce uint64,
+) *models.Tx {
 	data := make([]byte, 36)
 	binary.LittleEndian.PutUint64(data, sentAt)
-	ethTx := types.NewTransaction(0, common.Address{}, big.NewInt(0), 250000, big.NewInt(1), data)
+	ethTx := types.NewTransaction(nonce, common.Address{}, big.NewInt(0), 250000, big.NewInt(1), data)
 	tx, err := store.CreateTx(null.String{}, ethTx, &from, sentAt)
 	require.NoError(t, err)
 	return tx

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -611,6 +611,17 @@ func (orm *ORM) UpdateTx(
 	return orm.DB.Save(tx).Error
 }
 
+// FindLaterConfirmedTx finds the earliest confirmed Ethereum transaction
+// that has the same sender and a higher nonce.
+func (orm *ORM) FindLaterConfirmedTx(tx *models.Tx) (*models.Tx, error) {
+	later := models.Tx{}
+	rval := orm.DB.Order("nonce asc").
+		Where("\"confirmed\" = true AND \"from\" = ? AND \"nonce\" > ?", tx.From, tx.Nonce).
+		First(&later)
+
+	return &later, ignoreRecordNotFound(rval)
+}
+
 // MarkTxSafe updates the database for the given transaction and attempt to
 // show that the transaction has not just been confirmed,
 // but has met the minimum number of outgoing confirmations to be deemed

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -620,22 +620,6 @@ func (orm *ORM) UpdateTx(
 	return orm.DB.Save(tx).Error
 }
 
-// FindLaterConfirmedTx finds the earliest confirmed Ethereum transaction
-// that has the same sender and a higher nonce.
-func (orm *ORM) FindLaterConfirmedTx(tx *models.Tx) (*models.Tx, error) {
-	later := models.Tx{}
-	rval := orm.DB.Order("nonce asc").
-		Where(`"confirmed" = true AND "from" = ? AND "nonce" > ?`, tx.From, tx.Nonce).
-		First(&later)
-
-	removed, err := removeRecordNotFound(rval)
-	if removed {
-		return nil, err
-	}
-
-	return &later, err
-}
-
 // MarkTxSafe updates the database for the given transaction and attempt to
 // show that the transaction has not just been confirmed,
 // but has met the minimum number of outgoing confirmations to be deemed

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -214,7 +214,7 @@ func (orm *ORM) FindInitiator(ID uint) (models.Initiator, error) {
 func (orm *ORM) preloadJobs() *gorm.DB {
 	return orm.DB.
 		Preload("Initiators", func(db *gorm.DB) *gorm.DB {
-			return db.Unscoped().Order("\"id\" asc")
+			return db.Unscoped().Order(`"id" asc`)
 		}).
 		Preload("Tasks", func(db *gorm.DB) *gorm.DB {
 			return db.Unscoped().Order("id asc")
@@ -625,7 +625,7 @@ func (orm *ORM) UpdateTx(
 func (orm *ORM) FindLaterConfirmedTx(tx *models.Tx) (*models.Tx, error) {
 	later := models.Tx{}
 	rval := orm.DB.Order("nonce asc").
-		Where("\"confirmed\" = true AND \"from\" = ? AND \"nonce\" > ?", tx.From, tx.Nonce).
+		Where(`"confirmed" = true AND "from" = ? AND "nonce" > ?`, tx.From, tx.Nonce).
 		First(&later)
 
 	removed, err := removeRecordNotFound(rval)
@@ -721,7 +721,7 @@ func (orm *ORM) AddTxAttempt(
 // GetLastNonce retrieves the last known nonce in the database for an account
 func (orm *ORM) GetLastNonce(address common.Address) (uint64, error) {
 	var transaction models.Tx
-	rval := orm.DB.Order("nonce desc").Where("\"from\" = ?", address).First(&transaction)
+	rval := orm.DB.Order("nonce desc").Where(`"from" = ?`, address).First(&transaction)
 	return transaction.Nonce, ignoreRecordNotFound(rval)
 }
 

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -141,7 +141,7 @@ func removeRecordNotFound(db *gorm.DB) (bool, error) {
 	var merr error
 	removed := false
 	for _, err := range db.GetErrors() {
-		if err == gorm.ErrRecordNotFound {
+		if errors.Cause(err) == gorm.ErrRecordNotFound {
 			removed = true
 		} else {
 			merr = multierr.Append(merr, err)

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -133,22 +133,13 @@ func DeduceDialect(path string) (DialectName, error) {
 }
 
 func ignoreRecordNotFound(db *gorm.DB) error {
-	_, err := removeRecordNotFound(db)
-	return err
-}
-
-func removeRecordNotFound(db *gorm.DB) (bool, error) {
 	var merr error
-	removed := false
-	for _, err := range db.GetErrors() {
-		if errors.Cause(err) == gorm.ErrRecordNotFound {
-			removed = true
-		} else {
-			merr = multierr.Append(merr, err)
+	for _, e := range db.GetErrors() {
+		if e != gorm.ErrRecordNotFound {
+			merr = multierr.Append(merr, e)
 		}
 	}
-
-	return removed, merr
+	return merr
 }
 
 func (orm *ORM) DialectName() DialectName {

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -978,6 +978,11 @@ func (orm *ORM) SaveSession(session *models.Session) error {
 	return orm.DB.Save(session).Error
 }
 
+// SaveTx saves the Ethereum Transaction.
+func (orm *ORM) SaveTx(tx *models.Tx) error {
+	return orm.DB.Save(tx).Error
+}
+
 // CreateBridgeType saves the bridge type.
 func (orm *ORM) CreateBridgeType(bt *models.BridgeType) error {
 	return orm.DB.Create(bt).Error

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -672,51 +672,6 @@ func TestORM_AddTxAttempt(t *testing.T) {
 	assert.Equal(t, tx.Hash, txAttempt.Hash)
 }
 
-func TestORM_FindLaterConfirmedTx_success(t *testing.T) {
-	t.Parallel()
-
-	app, cleanup := cltest.NewApplicationWithKey(t)
-	defer cleanup()
-	store := app.Store
-	orm := store.ORM
-
-	from := cltest.GetAccountAddress(t, store)
-	sentAt := uint64(23456)
-	tx1 := cltest.CreateTxWithNonce(t, store, from, sentAt, 1)
-	tx2 := cltest.CreateTxWithNonce(t, store, from, sentAt, 2)
-	tx3 := cltest.CreateTxWithNonce(t, store, from, sentAt, 3)
-
-	tx2a := tx2.Attempts[0]
-	tx2a.Confirmed = true
-	assert.NoError(t, store.MarkTxSafe(tx2, tx2a))
-	tx3a := tx3.Attempts[0]
-	tx3a.Confirmed = true
-	assert.NoError(t, store.MarkTxSafe(tx3, tx3a))
-
-	found, err := orm.FindLaterConfirmedTx(tx1)
-	assert.NoError(t, err)
-	assert.Equal(t, tx2.ID, found.ID)
-}
-
-func TestORM_FindLaterConfirmedTx_failed(t *testing.T) {
-	t.Parallel()
-
-	app, cleanup := cltest.NewApplicationWithKey(t)
-	defer cleanup()
-	store := app.Store
-	orm := store.ORM
-
-	from := cltest.GetAccountAddress(t, store)
-	sentAt := uint64(23456)
-	tx1 := cltest.CreateTxWithNonce(t, store, from, sentAt, 1)
-	cltest.CreateTxWithNonce(t, store, from, sentAt, 2)
-	cltest.CreateTxWithNonce(t, store, from, sentAt, 3)
-
-	found, err := orm.FindLaterConfirmedTx(tx1)
-	assert.NoError(t, err)
-	assert.Nil(t, found)
-}
-
 func TestORM_FindBridge(t *testing.T) {
 	t.Parallel()
 

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -672,7 +672,7 @@ func TestORM_AddTxAttempt(t *testing.T) {
 	assert.Equal(t, tx.Hash, txAttempt.Hash)
 }
 
-func TestORM_FindLaterConfirmedTx(t *testing.T) {
+func TestORM_FindLaterConfirmedTx_success(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplicationWithKey(t)
@@ -696,6 +696,25 @@ func TestORM_FindLaterConfirmedTx(t *testing.T) {
 	found, err := orm.FindLaterConfirmedTx(tx1)
 	assert.NoError(t, err)
 	assert.Equal(t, tx2.ID, found.ID)
+}
+
+func TestORM_FindLaterConfirmedTx_failed(t *testing.T) {
+	t.Parallel()
+
+	app, cleanup := cltest.NewApplicationWithKey(t)
+	defer cleanup()
+	store := app.Store
+	orm := store.ORM
+
+	from := cltest.GetAccountAddress(t, store)
+	sentAt := uint64(23456)
+	tx1 := cltest.CreateTxWithNonce(t, store, from, sentAt, 1)
+	cltest.CreateTxWithNonce(t, store, from, sentAt, 2)
+	cltest.CreateTxWithNonce(t, store, from, sentAt, 3)
+
+	found, err := orm.FindLaterConfirmedTx(tx1)
+	assert.NoError(t, err)
+	assert.Nil(t, found)
 }
 
 func TestORM_FindBridge(t *testing.T) {

--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -769,7 +769,6 @@ func (a *ManagedAccount) ReloadNonce(txm *EthTxManager) error {
 		return fmt.Errorf("TxManager ReloadNonce: %v", err)
 	}
 	a.nonce = nonce
-	a.updateLastSafeNonce(nonce)
 	return nil
 }
 

--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -754,6 +754,7 @@ func (a *ManagedAccount) ReloadNonce(txm *EthTxManager) error {
 		return fmt.Errorf("TxManager ReloadNonce: %v", err)
 	}
 	a.nonce = nonce
+	a.updateLastConfirmedNonce(nonce)
 	return nil
 }
 

--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -729,8 +729,9 @@ func (txm *EthTxManager) activateAccount(account accounts.Account) (*ManagedAcco
 // to coordinate outgoing transactions.
 type ManagedAccount struct {
 	accounts.Account
-	nonce uint64
-	mutex *sync.Mutex
+	nonce              uint64
+	lastConfirmedNonce uint64
+	mutex              *sync.Mutex
 }
 
 // NewManagedAccount creates a managed account that handles nonce increments
@@ -768,6 +769,12 @@ func (a *ManagedAccount) GetAndIncrementNonce(callback func(uint64) error) error
 	}
 
 	return err
+}
+
+func (a *ManagedAccount) updateLastConfirmedNonce(latest uint64) {
+	if latest > a.lastConfirmedNonce {
+		a.lastConfirmedNonce = latest
+	}
 }
 
 // Contract holds the solidity contract's parsed ABI

--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -392,7 +392,7 @@ func (txm *EthTxManager) checkChainForConfirmation(tx *models.Tx) (*models.TxRec
 func (txm *EthTxManager) checkDBForConfirmation(tx *models.Tx) (*models.TxReceipt, AttemptState, error) {
 	later, err := txm.orm.FindLaterConfirmedTx(tx)
 	if err != nil {
-		return nil, Unknown, errors.Wrap(err, "BumpGasUntilSafe checkDBForConfrimation")
+		return nil, Unknown, errors.Wrap(err, "BumpGasUntilSafe checkDBForConfirmation")
 	} else if later == nil {
 		return nil, Unconfirmed, nil
 	}

--- a/core/store/tx_manager_internal_test.go
+++ b/core/store/tx_manager_internal_test.go
@@ -9,15 +9,15 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func (a *ManagedAccount) PublicLastConfirmedNonce() uint64 {
-	return a.lastConfirmedNonce
+func (a *ManagedAccount) PublicLastSafeNonce() uint64 {
+	return a.lastSafeNonce
 }
 
-func (a *ManagedAccount) SetLastConfirmedNonce(n uint64) {
-	a.lastConfirmedNonce = n
+func (a *ManagedAccount) SetLastSafeNonce(n uint64) {
+	a.lastSafeNonce = n
 }
 
-func TestManagedAccount_updateLastConfirmedNonce(t *testing.T) {
+func TestManagedAccount_updateLastSafeNonce(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -33,15 +33,15 @@ func TestManagedAccount_updateLastConfirmedNonce(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			ma := &ManagedAccount{lastConfirmedNonce: test.last}
-			ma.updateLastConfirmedNonce(test.submitted)
+			ma := &ManagedAccount{lastSafeNonce: test.last}
+			ma.updateLastSafeNonce(test.submitted)
 
-			assert.Equal(t, test.want, ma.lastConfirmedNonce)
+			assert.Equal(t, test.want, ma.lastSafeNonce)
 		})
 	}
 }
 
-func TestTxManager_updateLastConfirmedTx_success(t *testing.T) {
+func TestTxManager_updateLastSafeNonce_success(t *testing.T) {
 	t.Parallel()
 
 	from := common.HexToAddress("0xbf4ed7b27f1d666546e30d74d50d173d20bca754")
@@ -51,12 +51,12 @@ func TestTxManager_updateLastConfirmedTx_success(t *testing.T) {
 	txm := &EthTxManager{availableAccounts: []*ManagedAccount{ma}}
 	tx := &models.Tx{From: from, Nonce: nonce}
 
-	txm.updateManagedAccounts(tx)
+	txm.updateLastSafeNonce(tx)
 
-	assert.Equal(t, nonce, ma.lastConfirmedNonce)
+	assert.Equal(t, nonce, ma.lastSafeNonce)
 }
 
-func TestTxManager_updateLastConfirmedTx_noMatchingAccount(t *testing.T) {
+func TestTxManager_updateLastSafeNonce_noMatchingAccount(t *testing.T) {
 	t.Parallel()
 
 	from := common.HexToAddress("0xbf4ed7b27f1d666546e30d74d50d173d20bca754")
@@ -66,7 +66,7 @@ func TestTxManager_updateLastConfirmedTx_noMatchingAccount(t *testing.T) {
 	txm := &EthTxManager{availableAccounts: []*ManagedAccount{ma}}
 	tx := &models.Tx{From: from, Nonce: nonce}
 
-	txm.updateManagedAccounts(tx)
+	txm.updateLastSafeNonce(tx)
 
-	assert.NotEqual(t, nonce, ma.lastConfirmedNonce)
+	assert.NotEqual(t, nonce, ma.lastSafeNonce)
 }

--- a/core/store/tx_manager_internal_test.go
+++ b/core/store/tx_manager_internal_test.go
@@ -13,13 +13,8 @@ func (a *ManagedAccount) PublicLastConfirmedNonce() uint64 {
 	return a.lastConfirmedNonce
 }
 
-func (txm *EthTxManager) GetAvailableAccount(from common.Address) *ManagedAccount {
-	for _, a := range txm.availableAccounts {
-		if a.Address == from {
-			return a
-		}
-	}
-	return nil
+func (a *ManagedAccount) SetLastConfirmedNonce(n uint64) {
+	a.lastConfirmedNonce = n
 }
 
 func TestManagedAccount_updateLastConfirmedNonce(t *testing.T) {

--- a/core/store/tx_manager_internal_test.go
+++ b/core/store/tx_manager_internal_test.go
@@ -6,6 +6,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func (a *ManagedAccount) PublicLastConfirmedNonce() uint64 {
+	return a.lastConfirmedNonce
+}
+
 func TestTxManager_updateLastConfirmedNonce(t *testing.T) {
 	t.Parallel()
 

--- a/core/store/tx_manager_internal_test.go
+++ b/core/store/tx_manager_internal_test.go
@@ -1,0 +1,31 @@
+package store
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTxManager_updateLastConfirmedNonce(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		last      uint64
+		submitted uint64
+		want      uint64
+	}{
+		{"greater", 100, 101, 101},
+		{"less", 100, 99, 100},
+		{"equal", 100, 100, 100},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			ma := &ManagedAccount{lastConfirmedNonce: test.last}
+			ma.updateLastConfirmedNonce(test.submitted)
+
+			assert.Equal(t, test.want, ma.lastConfirmedNonce)
+		})
+	}
+}

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -881,7 +881,6 @@ func TestTxManager_ReloadNonce(t *testing.T) {
 
 	assert.Equal(t, account.Address, ma.Address)
 	assert.Equal(t, nonce, ma.Nonce())
-	assert.Equal(t, nonce, ma.PublicLastSafeNonce())
 }
 
 func TestTxManager_WithdrawLink_HappyPath(t *testing.T) {

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -639,6 +639,12 @@ func TestTxManager_BumpGasUntilSafe_laterConfirmedTx(t *testing.T) {
 	assert.Equal(t, strpkg.Confirmed, state)
 	assert.Error(t, err)
 
+	tx, err := store.FindTx(tx1.ID)
+	require.NoError(t, err)
+	assert.True(t, tx.Confirmed)
+	assert.Equal(t, tx.Hash.Hex(), "0x0000000000000000000000000000000000000000000000000000000000000000")
+	assert.Len(t, tx.Attempts, 1)
+
 	ethMock.EventuallyAllCalled(t)
 }
 

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -609,9 +609,10 @@ func TestTxManager_BumpGasUntilSafe_laterConfirmedTx(t *testing.T) {
 
 	tx1 := cltest.CreateTxWithNonce(t, store, from, sentAt, 1)
 	tx2 := cltest.CreateTxWithNonce(t, store, from, sentAt, 2)
-	tx2a := tx2.Attempts[0]
-	tx2a.Confirmed = true
-	assert.NoError(t, store.MarkTxSafe(tx2, tx2a))
+
+	etm := txm.(*strpkg.EthTxManager)
+	aa := etm.GetAvailableAccount(from)
+	aa.SetLastConfirmedNonce(tx2.Nonce)
 
 	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{})
 

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -532,7 +532,7 @@ func TestTxManager_BumpGasUntilSafe_confirmed(t *testing.T) {
 
 	etm := txm.(*strpkg.EthTxManager)
 	aa := etm.GetAvailableAccount(from)
-	assert.Equal(t, tx.Nonce, aa.PublicLastConfirmedNonce())
+	assert.NotEqual(t, tx.Nonce, aa.PublicLastSafeNonce())
 
 	ethMock.EventuallyAllCalled(t)
 }
@@ -586,7 +586,7 @@ func TestTxManager_BumpGasUntilSafe_safe(t *testing.T) {
 
 			etm := txm.(*strpkg.EthTxManager)
 			aa := etm.GetAvailableAccount(from)
-			assert.Equal(t, tx.Nonce, aa.PublicLastConfirmedNonce())
+			assert.Equal(t, tx.Nonce, aa.PublicLastSafeNonce())
 
 			ethMock.EventuallyAllCalled(t)
 		})
@@ -612,7 +612,7 @@ func TestTxManager_BumpGasUntilSafe_laterConfirmedTx(t *testing.T) {
 
 	etm := txm.(*strpkg.EthTxManager)
 	aa := etm.GetAvailableAccount(from)
-	aa.SetLastConfirmedNonce(tx2.Nonce)
+	aa.SetLastSafeNonce(tx2.Nonce)
 
 	ethMock.Register("eth_getTransactionReceipt", models.TxReceipt{})
 
@@ -881,7 +881,7 @@ func TestTxManager_ReloadNonce(t *testing.T) {
 
 	assert.Equal(t, account.Address, ma.Address)
 	assert.Equal(t, nonce, ma.Nonce())
-	assert.Equal(t, nonce, ma.PublicLastConfirmedNonce())
+	assert.Equal(t, nonce, ma.PublicLastSafeNonce())
 }
 
 func TestTxManager_WithdrawLink_HappyPath(t *testing.T) {

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -45,7 +45,7 @@ const (
 // 0x0000000000000000000000000000000000000000
 var ZeroAddress = common.Address{}
 
-// ZeroHash is a hash of all zeroes, otherwise in Ethereum as
+// EmptyHash is a hash of all zeroes, otherwise in Ethereum as
 // 0x0000000000000000000000000000000000000000000000000000000000000000
 var EmptyHash = common.Hash{}
 

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -104,9 +104,6 @@ func FormatJSON(v interface{}) ([]byte, error) {
 	return json.MarshalIndent(v, "", "  ")
 }
 
-// NewBytes32Length holds the length of bytes needed for Bytes32ID.
-const NewBytes32Length = 32
-
 // NewBytes32ID returns a randomly generated UUID that conforms to
 // Ethereum bytes32.
 func NewBytes32ID() string {

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -41,9 +41,12 @@ const (
 	EVMWordHexLen = EVMWordByteLen * 2
 )
 
-// ZeroAddress is an empty address, otherwise in Ethereum as
+// ZeroAddress is an address of all zeroes, otherwise in Ethereum as
 // 0x0000000000000000000000000000000000000000
 var ZeroAddress = common.Address{}
+
+// ZeroHash is a hash of all zeroes, otherwise in Ethereum as
+// 0x0000000000000000000000000000000000000000000000000000000000000000
 var EmptyHash = common.Hash{}
 
 // WithoutZeroAddresses returns a list of addresses excluding the zero address.

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -44,6 +44,7 @@ const (
 // ZeroAddress is an empty address, otherwise in Ethereum as
 // 0x0000000000000000000000000000000000000000
 var ZeroAddress = common.Address{}
+var EmptyHash = common.Hash{}
 
 // WithoutZeroAddresses returns a list of addresses excluding the zero address.
 func WithoutZeroAddresses(addresses []common.Address) []common.Address {

--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aristanetworks/goarista v0.0.0-20190204200901-2166578f3448 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
 	github.com/bitly/go-simplejson v0.5.0
-	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/boj/redistore v0.0.0-20160128113310-fc113767cd6b // indirect
 	github.com/btcsuite/btcd v0.0.0-20190115013929-ed77733ec07d
 	github.com/cespare/cp v1.1.1 // indirect


### PR DESCRIPTION
Occasionally a transaction can get broadcast to Ethereum but then fails to save to the database, for example if an error was returned or connection was dropped from the Ethereum node. In these cases, we do not have the transaction ID to look it up, and can continue waiting for that transaction confirmation indefinitely.

This PR checks the DB for later confirmed transactions, after first querying the blockchain. If a transaction with a higher nonce from the same account is found, then the earlier transaction is marked as confirmed so we stop querying for it.