### PR TITLE
cmd: Fix printing of External Init. Auth.

### DIFF
--- a/core/cmd/renderer.go
+++ b/core/cmd/renderer.go
@@ -67,7 +67,7 @@ func (rt RendererTable) Render(v interface{}) error {
 		return rt.renderTxs(*typed)
 	case *presenters.Tx:
 		return rt.renderTx(*typed)
-	case *models.ExternalInitiatorAuthentication:
+	case *presenters.ExternalInitiatorAuthentication:
 		return rt.renderExternalInitiatorAuthentication(*typed)
 	case *web.ConfigPatchResponse:
 		return rt.renderConfigPatchResponse(typed)
@@ -251,15 +251,17 @@ func (rt RendererTable) renderServiceAgreement(sa presenters.ServiceAgreement) e
 	return nil
 }
 
-func (rt RendererTable) renderExternalInitiatorAuthentication(eia models.ExternalInitiatorAuthentication) error {
-	table := rt.newTable([]string{"ID", "Value"})
+func (rt RendererTable) renderExternalInitiatorAuthentication(eia presenters.ExternalInitiatorAuthentication) error {
+	table := rt.newTable([]string{"Name", "URL", "AccessKey", "Secret", "OutgoingToken", "OutgoingSecret"})
 	table.Append([]string{
-		"AccessKey",
+		eia.Name,
+		eia.URL.String(),
 		eia.AccessKey,
-		"Secret",
 		eia.Secret,
+		eia.OutgoingToken,
+		eia.OutgoingSecret,
 	})
-	render("External Initiator Credentials", table)
+	render("External Initiator Credentials:", table)
 	return nil
 }
 

--- a/core/cmd/renderer_test.go
+++ b/core/cmd/renderer_test.go
@@ -152,6 +152,39 @@ func TestRendererTable_RenderBridgeList(t *testing.T) {
 	}
 }
 
+func TestRendererTable_RenderExternalInitiatorAuthentication(t *testing.T) {
+	t.Parallel()
+
+	eia := presenters.ExternalInitiatorAuthentication{
+		Name:           "bitcoin",
+		URL:            cltest.WebURL(t, "http://localhost:8888"),
+		AccessKey:      "accesskey",
+		Secret:         "secret",
+		OutgoingToken:  "outgoingToken",
+		OutgoingSecret: "outgoingSecret",
+	}
+	tests := []struct {
+		name, content string
+	}{
+		{"Name", eia.Name},
+		{"URL", eia.URL.String()},
+		{"AccessKey", eia.AccessKey},
+		{"Secret", eia.Secret},
+		{"OutgoingToken", eia.OutgoingToken},
+		{"OutgoingSecret", eia.OutgoingSecret},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tw := &testWriter{test.content, t, false}
+			r := cmd.RendererTable{Writer: tw}
+
+			assert.Nil(t, r.Render(&eia))
+			assert.True(t, tw.found)
+		})
+	}
+}
+
 func TestRendererTable_Render_TxAttempts(t *testing.T) {
 	t.Parallel()
 

--- a/core/cmd/renderer_test.go
+++ b/core/cmd/renderer_test.go
@@ -179,7 +179,7 @@ func TestRendererTable_RenderExternalInitiatorAuthentication(t *testing.T) {
 			tw := &testWriter{test.content, t, false}
 			r := cmd.RendererTable{Writer: tw}
 
-			assert.Nil(t, r.Render(&eia))
+			assert.NoError(t, r.Render(&eia))
 			assert.True(t, tw.found)
 		})
 	}


### PR DESCRIPTION
Add rendering logic for the External Initiator Authentication object returned on creation of an external initiator.

This fixes a previous commit where rendering logic was written for the model instead of the presenter.