### PR TITLE
models: Create new IntiatorExternal type

### DIFF
--- a/core/services/validators.go
+++ b/core/services/validators.go
@@ -85,6 +85,8 @@ func ValidateInitiator(i models.Initiator, j models.JobSpec) error {
 		return validateRunAtInitiator(i, j)
 	case models.InitiatorCron:
 		return validateCronInitiator(i)
+	case models.InitiatorExternal:
+		return validateExternalInitiator(i)
 	case models.InitiatorServiceAgreementExecutionLog:
 		return validateServiceAgreementInitiator(i, j)
 	case models.InitiatorWeb:
@@ -113,6 +115,13 @@ func validateRunAtInitiator(i models.Initiator, j models.JobSpec) error {
 func validateCronInitiator(i models.Initiator) error {
 	if i.Schedule == "" {
 		return models.NewJSONAPIErrorsWith("Schedule must have a cron")
+	}
+	return nil
+}
+
+func validateExternalInitiator(i models.Initiator) error {
+	if len([]rune(i.Name)) == 0 {
+		return models.NewJSONAPIErrorsWith("External must have a name")
 	}
 	return nil
 }

--- a/core/services/validators_test.go
+++ b/core/services/validators_test.go
@@ -192,6 +192,7 @@ func TestValidateInitiator(t *testing.T) {
 	}{
 		{"web", `{"type":"web"}`, false},
 		{"ethlog", `{"type":"ethlog"}`, false},
+		{"external", `{"type":"external","params":{"name":"bitcoin"}}`, false},
 		{"runlog", `{"type":"runlog"}`, false},
 		{"runat", fmt.Sprintf(`{"type":"runat","params": {"time":"%v"}}`, utils.ISO8601UTC(startAt)), false},
 		{"runat w/o time", `{"type":"runat"}`, true},
@@ -199,6 +200,7 @@ func TestValidateInitiator(t *testing.T) {
 		{"runat w time after end at", fmt.Sprintf(`{"type":"runat","params": {"time":"%v"}}`, endAt.Add(time.Second).Unix()), true},
 		{"cron", `{"type":"cron","params": {"schedule":"* * * * * *"}}`, false},
 		{"cron w/o schedule", `{"type":"cron"}`, true},
+		{"external w/o name", `{"type":"external"}`, true},
 		{"non-existent initiator", `{"type":"doesntExist"}`, true},
 	}
 

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565291711"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565877314"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1566498796"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1566915476"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1567029116"
 	gormigrate "gopkg.in/gormigrate.v1"
 )
@@ -90,6 +91,10 @@ func Migrate(db *gorm.DB) error {
 		{
 			ID:      "1565877314",
 			Migrate: migration1565877314.Migrate,
+		},
+		{
+			ID:      "1566915476",
+			Migrate: migration1566915476.Migrate,
 		},
 		{
 			ID:      "1567029116",

--- a/core/store/migrations/migration1566915476/migrate.go
+++ b/core/store/migrations/migration1566915476/migrate.go
@@ -1,0 +1,15 @@
+package migration1566915476
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
+)
+
+// Migrate adds the name parameter in support of the new JobSpec's intiator
+// 'external'.
+func Migrate(tx *gorm.DB) error {
+	if err := tx.Exec(`ALTER TABLE initiators ADD name varchar(255)`).Error; err != nil {
+		return errors.Wrap(err, "failed to add name to Initiator")
+	}
+	return nil
+}

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -204,6 +204,8 @@ const (
 	// InitiatorServiceAgreementExecutionLog for tasks in a job to watch a
 	// Solidity Coordinator contract and expect a payload from a log event.
 	InitiatorServiceAgreementExecutionLog = "execagreement"
+	// InitiatorExternal for tasks in a job to be trigger by an external party.
+	InitiatorExternal = "external"
 )
 
 // Initiator could be thought of as a trigger, defines how a Job can be
@@ -228,6 +230,7 @@ type InitiatorParams struct {
 	Ran        bool              `json:"ran,omitempty"`
 	Address    common.Address    `json:"address,omitempty" gorm:"index"`
 	Requesters AddressCollection `json:"requesters,omitempty" gorm:"type:text"`
+	Name       string            `json:"name,omitempty"`
 }
 
 // UnmarshalJSON parses the raw initiator data and updates the

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -366,8 +366,12 @@ func initiatorParams(i Initiator) (interface{}, error) {
 		return struct {
 			Address common.Address `json:"address"`
 		}{i.Address}, nil
+	case models.InitiatorExternal:
+		return struct {
+			Name string `json:"name"`
+		}{i.Name}, nil
 	default:
-		return nil, fmt.Errorf("Cannot marshal unsupported initiator type %v", i.Type)
+		return nil, fmt.Errorf("Cannot marshal unsupported initiator type '%v'", i.Type)
 	}
 }
 


### PR DESCRIPTION
Create a new initiator type to Job Specs.  This new type represents jobs started by new entities called ExternalInitiators as represented by the models.ExternalInitiator type.