### PR TITLE
Trigger Job Runs via an External Initiator

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -680,6 +680,32 @@ func CreateJobRunViaWeb(t testing.TB, app *TestApplication, j models.JobSpec, bo
 	return jr
 }
 
+func CreateJobRunViaExternalInitiator(
+	t testing.TB,
+	app *TestApplication,
+	j models.JobSpec,
+	eia models.ExternalInitiatorAuthentication,
+	body string,
+) models.JobRun {
+	t.Helper()
+
+	headers := make(map[string]string)
+	headers[web.ExternalInitiatorAccessKeyHeader] = eia.AccessKey
+	headers[web.ExternalInitiatorSecretHeader] = eia.Secret
+
+	url := app.Config.ClientNodeURL() + "/v2/specs/" + j.ID.String() + "/runs"
+	bodyBuf := bytes.NewBufferString(body)
+	resp, cleanup := UnauthenticatedPost(t, url, bodyBuf, headers)
+	defer cleanup()
+	AssertServerResponse(t, resp, 200)
+	var jr models.JobRun
+	err := ParseJSONAPIResponse(t, resp, &jr)
+	require.NoError(t, err)
+
+	assert.Equal(t, j.ID, jr.JobSpecID)
+	return jr
+}
+
 // CreateHelloWorldJobViaWeb creates a HelloWorld JobSpec with the given MockServer Url
 func CreateHelloWorldJobViaWeb(t testing.TB, app *TestApplication, url string) models.JobSpec {
 	t.Helper()
@@ -1146,6 +1172,21 @@ func AssertError(t testing.TB, want bool, err error) {
 	} else {
 		assert.NoError(t, err)
 	}
+}
+
+func UnauthenticatedPost(t testing.TB, url string, body io.Reader, headers map[string]string) (*http.Response, func()) {
+	t.Helper()
+
+	client := http.Client{}
+	request, err := http.NewRequest("POST", url, body)
+	require.NoError(t, err)
+	request.Header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		request.Header.Add(key, value)
+	}
+	resp, err := client.Do(request)
+	require.NoError(t, err)
+	return resp, func() { resp.Body.Close() }
 }
 
 func UnauthenticatedPatch(t testing.TB, url string, body io.Reader, headers map[string]string) (*http.Response, func()) {

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -52,6 +52,19 @@ func NewTask(t *testing.T, taskType string, json ...string) models.TaskSpec {
 	}
 }
 
+// NewJobWithExternalInitiator creates new Job with external inititaor
+func NewJobWithExternalInitiator(ei *models.ExternalInitiator) models.JobSpec {
+	j := NewJob()
+	j.Initiators = []models.Initiator{{
+		JobSpecID: j.ID,
+		Type:      models.InitiatorExternal,
+		InitiatorParams: models.InitiatorParams{
+			Name: ei.Name,
+		},
+	}}
+	return j
+}
+
 // NewJobWithSchedule create new job with the given schedule
 func NewJobWithSchedule(sched string) models.JobSpec {
 	j := NewJob()

--- a/core/internal/testdata/external_initiator_job.json
+++ b/core/internal/testdata/external_initiator_job.json
@@ -1,0 +1,21 @@
+{
+  "initiators": [{ "type": "external", "params": {"name": "someCoin"}}],
+  "tasks": [
+    { "type": "HttpGet", "params": {
+        "get": "https://bitstamp.net/api/ticker/",
+        "headers": {
+          "Key1": ["value"],
+          "Key2": ["value", "value"]
+        }
+      }
+    },
+    { "type": "JsonParse", "params": { "path": ["last"] }},
+    { "type": "EthBytes32" },
+    {
+      "type": "EthTx", "params": {
+        "address": "0x356a04bce728ba4c62a30294a55e6a8600a320b3",
+        "functionSelector": "0x609ff1bd"
+      }
+    }
+  ]
+}

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -152,6 +152,21 @@ func (j JobSpec) InitiatorsFor(types ...string) []Initiator {
 	return list
 }
 
+// InitiatorExternal finds the Job Spec's Initiator field associated with the
+// External Initiator's name using a case insensitive search.
+//
+// Returns nil if not found.
+func (j JobSpec) InitiatorExternal(name string) *Initiator {
+	var found *Initiator
+	for _, i := range j.InitiatorsFor(InitiatorExternal) {
+		if strings.ToLower(i.Name) == strings.ToLower(name) {
+			found = &i
+			break
+		}
+	}
+	return found
+}
+
 // WebAuthorized returns true if the "web" initiator is present.
 func (j JobSpec) WebAuthorized() bool {
 	for _, initr := range j.Initiators {

--- a/core/web/job_runs_controller.go
+++ b/core/web/job_runs_controller.go
@@ -87,9 +87,8 @@ func getAuthenticatedInitiator(c *gin.Context, js models.JobSpec) (*models.Initi
 			return nil, fmt.Errorf("Job not available via External Initiator '%s'", ei.Name)
 		}
 		return initiator, nil
-	} else {
-		return nil, errors.New("authentication required")
 	}
+	return nil, errors.New("authentication required")
 }
 
 func getRunData(c *gin.Context) (models.JSON, error) {

--- a/core/web/job_runs_controller.go
+++ b/core/web/job_runs_controller.go
@@ -76,7 +76,6 @@ func getAuthenticatedInitiator(c *gin.Context, js models.JobSpec) (*models.Initi
 		}
 		return &webInitiators[0], nil
 	} else if ei, ok := authenticatedEI(c); ok {
-		// TODO(felder-cl): Add test case for external initiator created Job
 		var initiator *models.Initiator
 		for _, i := range js.InitiatorsFor(models.InitiatorExternal) {
 			if strings.ToLower(i.Name) == ei.Name {

--- a/core/web/job_runs_controller.go
+++ b/core/web/job_runs_controller.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"strings"
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
@@ -76,13 +75,7 @@ func getAuthenticatedInitiator(c *gin.Context, js models.JobSpec) (*models.Initi
 		}
 		return &webInitiators[0], nil
 	} else if ei, ok := authenticatedEI(c); ok {
-		var initiator *models.Initiator
-		for _, i := range js.InitiatorsFor(models.InitiatorExternal) {
-			if strings.ToLower(i.Name) == ei.Name {
-				initiator = &i
-				break
-			}
-		}
+		initiator := js.InitiatorExternal(ei.Name)
 		if initiator == nil {
 			return nil, fmt.Errorf("Job not available via External Initiator '%s'", ei.Name)
 		}

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -150,8 +150,20 @@ func sessionAuth(store *store.Store, c *gin.Context) error {
 		return ErrorAuthFailed
 	}
 
-	_, err := store.AuthorizedUserWithSession(sessionID)
-	return err
+	user, err := store.AuthorizedUserWithSession(sessionID)
+	if err != nil {
+		return err
+	}
+	c.Set("user", &user)
+	return nil
+}
+
+func authenticatedUser(c *gin.Context) (*models.User, bool) {
+	obj, ok := c.Get("user")
+	if !ok {
+		return nil, false
+	}
+	return obj.(*models.User), ok
 }
 
 func tokenAuth(store *store.Store, c *gin.Context) error {
@@ -173,8 +185,17 @@ func tokenAuth(store *store.Store, c *gin.Context) error {
 	if !ok {
 		return ErrorAuthFailed
 	}
+	c.Set("external_initiator", ei)
 
 	return nil
+}
+
+func authenticatedEI(c *gin.Context) (*models.ExternalInitiator, bool) {
+	obj, ok := c.Get("external_initiator")
+	if !ok {
+		return nil, false
+	}
+	return obj.(*models.ExternalInitiator), ok
 }
 
 func sessionAuthRequired(store *store.Store) gin.HandlerFunc {

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -47,6 +47,10 @@ const (
 	SessionName = "clsession"
 	// SessionIDKey is the session ID key in the session map
 	SessionIDKey = "clsession_id"
+	// SessionUserKey is the User key in the session map
+	SessionUserKey = "user"
+	// SessionExternalInitiator is the Externale Initiator key in the session map
+	SessionExternalInitiatorKey = "external_initiator"
 	// ExternalInitiatorAccessKeyHeader is the header name for the access key
 	// used by external initiators to authenticate
 	ExternalInitiatorAccessKeyHeader = "X-Chainlink-EA-AccessKey"
@@ -154,12 +158,12 @@ func sessionAuth(store *store.Store, c *gin.Context) error {
 	if err != nil {
 		return err
 	}
-	c.Set("user", &user)
+	c.Set(SessionUserKey, &user)
 	return nil
 }
 
 func authenticatedUser(c *gin.Context) (*models.User, bool) {
-	obj, ok := c.Get("user")
+	obj, ok := c.Get(SessionUserKey)
 	if !ok {
 		return nil, false
 	}
@@ -185,13 +189,13 @@ func tokenAuth(store *store.Store, c *gin.Context) error {
 	if !ok {
 		return ErrorAuthFailed
 	}
-	c.Set("external_initiator", ei)
+	c.Set(SessionExternalInitiatorKey, ei)
 
 	return nil
 }
 
 func authenticatedEI(c *gin.Context) (*models.ExternalInitiator, bool) {
-	obj, ok := c.Get("external_initiator")
+	obj, ok := c.Get(SessionExternalInitiatorKey)
 	if !ok {
 		return nil, false
 	}


### PR DESCRIPTION
Allow triggering of Job Runs by 'POST'ing to the Job Spec controller as an External Initiator.

Also:
 - Store authenticated entities in the web(Gin's) context. 