### PR TITLE
Remove version- prefix from docker tags

### DIFF
--- a/tools/bin/branch2tag
+++ b/tools/bin/branch2tag
@@ -10,7 +10,7 @@ elif [ "${branch}" = "master" ]; then
 elif [[ "${branch}" =~ ^hotfix\/([a-zA-Z0-9.]+) ]]; then
   echo hotfix-${BASH_REMATCH[1]}
 elif [[ "${branch}" =~ ^release\/([a-zA-Z0-9.]+) ]]; then
-  echo version-${BASH_REMATCH[1]}
+  echo "${BASH_REMATCH[1]}"
 else
   echo unable to deduce docker tag from ${branch}
   exit 1


### PR DESCRIPTION
Around version 0.6 we introduced `version-` to our docker tags, I'd like to revert this to the way it was.