### PR TITLE
Change required node version to lts/dubnium

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,1 +1,1 @@
-lts/carbon
+lts/dubnium


### PR DESCRIPTION
We currently require minimum v10 in `operator_ui` for a `yarn` install to succeed, the `.nvmrc` file does not meet this requirement