### PR TITLE
Features/explorer accepts one connection at a time

### DIFF
--- a/explorer/.prettierignore
+++ b/explorer/.prettierignore
@@ -7,3 +7,4 @@ Dockerfile
 src/public
 .migrations*
 .env
+*.md5

--- a/explorer/src/__tests__/realtime.test.ts
+++ b/explorer/src/__tests__/realtime.test.ts
@@ -172,7 +172,7 @@ describe('realtime', () => {
     })
   })
 
-  it('reject invalid authentication', async (done: any) => {
+  it('rejects invalid authentication', async (done: any) => {
     expect.assertions(1)
 
     newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, 'lol-no').catch(
@@ -181,5 +181,17 @@ describe('realtime', () => {
         done()
       },
     )
+  })
+
+  it.only('rejects multiple connections from single node', async () => {
+    // expect.assertions(3)
+
+    const ws1 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
+    expect(ws1.readyState).toBe(1) // connection open
+    const ws2 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
+    expect(ws2.readyState).toBe(1) // connection open
+    expect(ws1.readyState).toBe(3) // connection closed
+    ws1.close()
+    ws2.close()
   })
 })

--- a/explorer/src/__tests__/realtime.test.ts
+++ b/explorer/src/__tests__/realtime.test.ts
@@ -193,20 +193,24 @@ describe('realtime', () => {
   it('rejects multiple connections from single node', async done => {
     expect.assertions(4)
 
-    let ws1: WebSocket
-    let ws2: WebSocket
+    const ws1: WebSocket = await newChainlinkNode(
+      ENDPOINT,
+      chainlinkNode.accessKey,
+      secret,
+    )
+    const ws2: WebSocket = await newChainlinkNode(
+      ENDPOINT,
+      chainlinkNode.accessKey,
+      secret,
+    )
 
-    const onCloseCallback = (event: WebSocket.CloseEvent) => {
+    ws1.addEventListener('close', (event: WebSocket.CloseEvent) => {
       expect(ws1.readyState).toBe(CLOSED_CONNECTION)
       expect(ws2.readyState).toBe(OPEN_CONNECTION)
       expect(event.code).toBe(NORMAL_CLOSE)
       expect(event.reason).toEqual('Duplicate connection opened')
       ws2.close()
       done()
-    }
-
-    ws1 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
-    ws1.addEventListener('close', onCloseCallback)
-    ws2 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
+    })
   })
 })

--- a/explorer/src/__tests__/realtime.test.ts
+++ b/explorer/src/__tests__/realtime.test.ts
@@ -189,7 +189,7 @@ describe('realtime', () => {
     let ws1: WebSocket
     let ws2: WebSocket
 
-    const onCloseCallback = event => {
+    const onCloseCallback = (event: WebSocket.CloseEvent) => {
       expect(ws1.readyState).toBe(3) // connection closed
       expect(ws2.readyState).toBe(1) // connection open
       expect(event.code).toBe(1000)

--- a/explorer/src/__tests__/realtime.test.ts
+++ b/explorer/src/__tests__/realtime.test.ts
@@ -183,7 +183,7 @@ describe('realtime', () => {
     )
   })
 
-  it.only('rejects multiple connections from single node', async done => {
+  it('rejects multiple connections from single node', async done => {
     expect.assertions(4)
 
     const ws1 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)

--- a/explorer/src/__tests__/realtime.test.ts
+++ b/explorer/src/__tests__/realtime.test.ts
@@ -183,15 +183,20 @@ describe('realtime', () => {
     )
   })
 
-  it.only('rejects multiple connections from single node', async () => {
-    // expect.assertions(3)
+  it.only('rejects multiple connections from single node', async (done) => {
+    expect.assertions(5)
 
     const ws1 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
     expect(ws1.readyState).toBe(1) // connection open
     const ws2 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
-    expect(ws2.readyState).toBe(1) // connection open
-    expect(ws1.readyState).toBe(3) // connection closed
-    ws1.close()
-    ws2.close()
+
+    ws1.addEventListener('close', event => {
+      expect(ws2.readyState).toBe(1) // connection open
+      expect(ws1.readyState).toBe(3) // connection closed
+      expect(event.code).toBe(1000)
+      expect(event.reason).toEqual('Duplicate connection opened')
+      ws2.close()
+      done()
+    })
   })
 })

--- a/explorer/src/__tests__/realtime.test.ts
+++ b/explorer/src/__tests__/realtime.test.ts
@@ -183,16 +183,15 @@ describe('realtime', () => {
     )
   })
 
-  it.only('rejects multiple connections from single node', async (done) => {
-    expect.assertions(5)
+  it.only('rejects multiple connections from single node', async done => {
+    expect.assertions(4)
 
     const ws1 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
-    expect(ws1.readyState).toBe(1) // connection open
     const ws2 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
 
     ws1.addEventListener('close', event => {
-      expect(ws2.readyState).toBe(1) // connection open
       expect(ws1.readyState).toBe(3) // connection closed
+      expect(ws2.readyState).toBe(1) // connection open
       expect(event.code).toBe(1000)
       expect(event.reason).toEqual('Duplicate connection opened')
       ws2.close()

--- a/explorer/src/__tests__/realtime.test.ts
+++ b/explorer/src/__tests__/realtime.test.ts
@@ -13,12 +13,16 @@ import { clearDb } from './testdatabase'
 
 const ENDPOINT = `ws://localhost:${DEFAULT_TEST_PORT}`
 
-const newChainlinkNode = (url: string, accessKey: string, secret: string): Promise<WebSocket> => {
+const newChainlinkNode = (
+  url: string,
+  accessKey: string,
+  secret: string,
+): Promise<WebSocket> => {
   const ws = new WebSocket(ENDPOINT, {
     headers: {
       'X-Explore-Chainlink-AccessKey': accessKey,
-      'X-Explore-Chainlink-Secret': secret
-    }
+      'X-Explore-Chainlink-Secret': secret,
+    },
   })
 
   return new Promise((resolve: (arg0: WebSocket) => void, reject) => {
@@ -43,7 +47,10 @@ describe('realtime', () => {
 
   beforeEach(async () => {
     clearDb()
-    ;[chainlinkNode, secret] = await createChainlinkNode(db, 'explore realtime test chainlinkNode')
+    ;[chainlinkNode, secret] = await createChainlinkNode(
+      db,
+      'explore realtime test chainlinkNode',
+    )
   })
 
   afterAll(async () => {
@@ -139,7 +146,9 @@ describe('realtime', () => {
 
     const tr = jr.taskRuns[3]
     expect(tr.status).toEqual('completed')
-    expect(tr.transactionHash).toEqual('0x1111111111111111111111111111111111111111111111111111111111111111')
+    expect(tr.transactionHash).toEqual(
+      '0x1111111111111111111111111111111111111111111111111111111111111111',
+    )
     expect(tr.transactionStatus).toEqual('fulfilledRunLog')
     ws.close()
   })
@@ -166,17 +175,27 @@ describe('realtime', () => {
   it('rejects invalid authentication', async (done: any) => {
     expect.assertions(1)
 
-    newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, 'lol-no').catch(error => {
-      expect(error).toBeDefined()
-      done()
-    })
+    newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, 'lol-no').catch(
+      error => {
+        expect(error).toBeDefined()
+        done()
+      },
+    )
   })
 
   it('rejects multiple connections from single node', async done => {
     expect.assertions(4)
 
-    const ws1 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
-    const ws2 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
+    const ws1 = await newChainlinkNode(
+      ENDPOINT,
+      chainlinkNode.accessKey,
+      secret,
+    )
+    const ws2 = await newChainlinkNode(
+      ENDPOINT,
+      chainlinkNode.accessKey,
+      secret,
+    )
 
     ws1.addEventListener('close', event => {
       expect(ws1.readyState).toBe(3) // connection closed

--- a/explorer/src/__tests__/realtime.test.ts
+++ b/explorer/src/__tests__/realtime.test.ts
@@ -12,9 +12,7 @@ import { ChainlinkNode, createChainlinkNode } from '../entity/ChainlinkNode'
 import { clearDb } from './testdatabase'
 import {
   ACCESS_KEY_HEADER,
-  CLOSED_CONNECTION,
   NORMAL_CLOSE,
-  OPEN_CONNECTION,
   SECRET_HEADER,
 } from '../utils/constants'
 
@@ -205,8 +203,8 @@ describe('realtime', () => {
     )
 
     ws1.addEventListener('close', (event: WebSocket.CloseEvent) => {
-      expect(ws1.readyState).toBe(CLOSED_CONNECTION)
-      expect(ws2.readyState).toBe(OPEN_CONNECTION)
+      expect(ws1.readyState).toBe(WebSocket.CLOSED)
+      expect(ws2.readyState).toBe(WebSocket.OPEN)
       expect(event.code).toBe(NORMAL_CLOSE)
       expect(event.reason).toEqual('Duplicate connection opened')
       ws2.close()

--- a/explorer/src/__tests__/realtime.test.ts
+++ b/explorer/src/__tests__/realtime.test.ts
@@ -186,8 +186,16 @@ describe('realtime', () => {
   it('rejects multiple connections from single node', async done => {
     expect.assertions(4)
 
-    const ws1 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
-    const ws2 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
+    const ws1 = await newChainlinkNode(
+      ENDPOINT,
+      chainlinkNode.accessKey,
+      secret
+    )
+    const ws2 = await newChainlinkNode(
+      ENDPOINT,
+      chainlinkNode.accessKey,
+      secret
+    )
 
     ws1.addEventListener('close', event => {
       expect(ws1.readyState).toBe(3) // connection closed

--- a/explorer/src/__tests__/realtime.test.ts
+++ b/explorer/src/__tests__/realtime.test.ts
@@ -10,6 +10,13 @@ import { JobRun } from '../entity/JobRun'
 import { TaskRun } from '../entity/TaskRun'
 import { ChainlinkNode, createChainlinkNode } from '../entity/ChainlinkNode'
 import { clearDb } from './testdatabase'
+import {
+  ACCESS_KEY_HEADER,
+  CLOSED_CONNECTION,
+  NORMAL_CLOSE,
+  OPEN_CONNECTION,
+  SECRET_HEADER,
+} from '../utils/constants'
 
 const ENDPOINT = `ws://localhost:${DEFAULT_TEST_PORT}`
 
@@ -20,8 +27,8 @@ const newChainlinkNode = (
 ): Promise<WebSocket> => {
   const ws = new WebSocket(ENDPOINT, {
     headers: {
-      'X-Explore-Chainlink-AccessKey': accessKey,
-      'X-Explore-Chainlink-Secret': secret,
+      [ACCESS_KEY_HEADER]: accessKey,
+      [SECRET_HEADER]: secret,
     },
   })
 
@@ -190,9 +197,9 @@ describe('realtime', () => {
     let ws2: WebSocket
 
     const onCloseCallback = (event: WebSocket.CloseEvent) => {
-      expect(ws1.readyState).toBe(3) // connection closed
-      expect(ws2.readyState).toBe(1) // connection open
-      expect(event.code).toBe(1000)
+      expect(ws1.readyState).toBe(CLOSED_CONNECTION)
+      expect(ws2.readyState).toBe(OPEN_CONNECTION)
+      expect(event.code).toBe(NORMAL_CLOSE)
       expect(event.reason).toEqual('Duplicate connection opened')
       ws2.close()
       done()

--- a/explorer/src/__tests__/realtime.test.ts
+++ b/explorer/src/__tests__/realtime.test.ts
@@ -186,24 +186,20 @@ describe('realtime', () => {
   it('rejects multiple connections from single node', async done => {
     expect.assertions(4)
 
-    const ws1 = await newChainlinkNode(
-      ENDPOINT,
-      chainlinkNode.accessKey,
-      secret,
-    )
-    const ws2 = await newChainlinkNode(
-      ENDPOINT,
-      chainlinkNode.accessKey,
-      secret,
-    )
+    let ws1: WebSocket
+    let ws2: WebSocket
 
-    ws1.addEventListener('close', event => {
+    const onCloseCallback = event => {
       expect(ws1.readyState).toBe(3) // connection closed
       expect(ws2.readyState).toBe(1) // connection open
       expect(event.code).toBe(1000)
       expect(event.reason).toEqual('Duplicate connection opened')
       ws2.close()
       done()
-    })
+    }
+
+    ws1 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
+    ws1.addEventListener('close', onCloseCallback)
+    ws2 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
   })
 })

--- a/explorer/src/__tests__/realtime.test.ts
+++ b/explorer/src/__tests__/realtime.test.ts
@@ -13,16 +13,12 @@ import { clearDb } from './testdatabase'
 
 const ENDPOINT = `ws://localhost:${DEFAULT_TEST_PORT}`
 
-const newChainlinkNode = (
-  url: string,
-  accessKey: string,
-  secret: string,
-): Promise<WebSocket> => {
+const newChainlinkNode = (url: string, accessKey: string, secret: string): Promise<WebSocket> => {
   const ws = new WebSocket(ENDPOINT, {
     headers: {
       'X-Explore-Chainlink-AccessKey': accessKey,
-      'X-Explore-Chainlink-Secret': secret,
-    },
+      'X-Explore-Chainlink-Secret': secret
+    }
   })
 
   return new Promise((resolve: (arg0: WebSocket) => void, reject) => {
@@ -47,10 +43,7 @@ describe('realtime', () => {
 
   beforeEach(async () => {
     clearDb()
-    ;[chainlinkNode, secret] = await createChainlinkNode(
-      db,
-      'explore realtime test chainlinkNode',
-    )
+    ;[chainlinkNode, secret] = await createChainlinkNode(db, 'explore realtime test chainlinkNode')
   })
 
   afterAll(async () => {
@@ -146,9 +139,7 @@ describe('realtime', () => {
 
     const tr = jr.taskRuns[3]
     expect(tr.status).toEqual('completed')
-    expect(tr.transactionHash).toEqual(
-      '0x1111111111111111111111111111111111111111111111111111111111111111',
-    )
+    expect(tr.transactionHash).toEqual('0x1111111111111111111111111111111111111111111111111111111111111111')
     expect(tr.transactionStatus).toEqual('fulfilledRunLog')
     ws.close()
   })
@@ -175,27 +166,17 @@ describe('realtime', () => {
   it('rejects invalid authentication', async (done: any) => {
     expect.assertions(1)
 
-    newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, 'lol-no').catch(
-      error => {
-        expect(error).toBeDefined()
-        done()
-      },
-    )
+    newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, 'lol-no').catch(error => {
+      expect(error).toBeDefined()
+      done()
+    })
   })
 
   it('rejects multiple connections from single node', async done => {
     expect.assertions(4)
 
-    const ws1 = await newChainlinkNode(
-      ENDPOINT,
-      chainlinkNode.accessKey,
-      secret
-    )
-    const ws2 = await newChainlinkNode(
-      ENDPOINT,
-      chainlinkNode.accessKey,
-      secret
-    )
+    const ws1 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
+    const ws2 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
 
     ws1.addEventListener('close', event => {
       expect(ws1.readyState).toBe(3) // connection closed

--- a/explorer/src/realtime.ts
+++ b/explorer/src/realtime.ts
@@ -72,7 +72,9 @@ export const bootstrapRealtime = async (server: http.Server) => {
 
   wss.on('connection', (ws: WebSocket, request: http.IncomingMessage) => {
     // accessKey type already validated in verifyClient()
-    const accessKey = request.headers['x-explore-chainlink-accesskey'].toString()
+    const accessKey = request.headers[
+      'x-explore-chainlink-accesskey'
+    ].toString()
 
     const existingConnection = connections.get(accessKey)
     if (existingConnection) {

--- a/explorer/src/realtime.ts
+++ b/explorer/src/realtime.ts
@@ -107,6 +107,7 @@ export const bootstrapRealtime = async (server: http.Server) => {
       if (session != null) {
         closeSession(db, session)
         sessions.delete(accessKey)
+        connections.delete(accessKey)
       }
 
       clnodeCount = clnodeCount - 1

--- a/explorer/src/utils/constants.ts
+++ b/explorer/src/utils/constants.ts
@@ -1,5 +1,5 @@
 export const OPEN_CONNECTION: number = 1
 export const CLOSED_CONNECTION: number = 3
 export const NORMAL_CLOSE: number = 1000
-export const ACCESS_KEY_HEADER: string = 'X-Explore-Chainlink-AccessKey'
-export const SECRET_HEADER: string = 'X-Explore-Chainlink-Secret'
+export const ACCESS_KEY_HEADER: string = 'x-explore-chainlink-accesskey'
+export const SECRET_HEADER: string = 'x-explore-chainlink-secret'

--- a/explorer/src/utils/constants.ts
+++ b/explorer/src/utils/constants.ts
@@ -1,5 +1,3 @@
-export const OPEN_CONNECTION = 1
-export const CLOSED_CONNECTION = 3
 export const NORMAL_CLOSE = 1000
 export const ACCESS_KEY_HEADER = 'x-explore-chainlink-accesskey'
 export const SECRET_HEADER = 'x-explore-chainlink-secret'

--- a/explorer/src/utils/constants.ts
+++ b/explorer/src/utils/constants.ts
@@ -1,0 +1,5 @@
+export const OPEN_CONNECTION: number = 1
+export const CLOSED_CONNECTION: number = 3
+export const NORMAL_CLOSE: number = 1000
+export const ACCESS_KEY_HEADER: string = 'X-Explore-Chainlink-AccessKey'
+export const SECRET_HEADER: string = 'X-Explore-Chainlink-Secret'

--- a/explorer/src/utils/constants.ts
+++ b/explorer/src/utils/constants.ts
@@ -1,5 +1,5 @@
-export const OPEN_CONNECTION: number = 1
-export const CLOSED_CONNECTION: number = 3
-export const NORMAL_CLOSE: number = 1000
-export const ACCESS_KEY_HEADER: string = 'x-explore-chainlink-accesskey'
-export const SECRET_HEADER: string = 'x-explore-chainlink-secret'
+export const OPEN_CONNECTION = 1
+export const CLOSED_CONNECTION = 3
+export const NORMAL_CLOSE = 1000
+export const ACCESS_KEY_HEADER = 'x-explore-chainlink-accesskey'
+export const SECRET_HEADER = 'x-explore-chainlink-secret'


### PR DESCRIPTION
Addresses [#168004826](https://www.pivotaltracker.com/n/projects/2129823/stories/168004826)

This story is also partly addressed by [John's PR](github.com/smartcontractkit/chainlink/commit/aeea28e5e8dc0f18933b89e4c187a3b5d5a31795), which adds the session record in the first place

John's PR ensures that session metrics are tracked fairly and that opening a 2nd connection will update the `finishedAt` column of the 1st connection in the DB.

This PR actually closes the socket of the first connection after the second is opened.