### PR TITLE
Migrate to use http.StatusCode const.

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -652,7 +652,7 @@ func CreateSpecViaWeb(t testing.TB, app *TestApplication, spec string) models.Jo
 	client := app.NewHTTPClient()
 	resp, cleanup := client.Post("/v2/specs", bytes.NewBufferString(spec))
 	defer cleanup()
-	AssertServerResponse(t, resp, 200)
+	AssertServerResponse(t, resp, http.StatusOK)
 
 	var createdJob models.JobSpec
 	err := ParseJSONAPIResponse(t, resp, &createdJob)
@@ -671,7 +671,7 @@ func CreateJobRunViaWeb(t testing.TB, app *TestApplication, j models.JobSpec, bo
 	client := app.NewHTTPClient()
 	resp, cleanup := client.Post("/v2/specs/"+j.ID.String()+"/runs", bodyBuffer)
 	defer cleanup()
-	AssertServerResponse(t, resp, 200)
+	AssertServerResponse(t, resp, http.StatusOK)
 	var jr models.JobRun
 	err := ParseJSONAPIResponse(t, resp, &jr)
 	require.NoError(t, err)
@@ -710,7 +710,7 @@ func UpdateJobRunViaWeb(
 	resp, cleanup := client.Patch("/v2/runs/"+jr.ID.String(), bytes.NewBufferString(body), headers)
 	defer cleanup()
 
-	AssertServerResponse(t, resp, 200)
+	AssertServerResponse(t, resp, http.StatusOK)
 	var respJobRun presenters.JobRun
 	assert.NoError(t, ParseJSONAPIResponse(t, resp, &respJobRun))
 	assert.Equal(t, jr.ID, respJobRun.ID)
@@ -732,7 +732,7 @@ func CreateBridgeTypeViaWeb(
 		bytes.NewBufferString(payload),
 	)
 	defer cleanup()
-	AssertServerResponse(t, resp, 200)
+	AssertServerResponse(t, resp, http.StatusOK)
 	bt := &models.BridgeTypeAuthentication{}
 	err := ParseJSONAPIResponse(t, resp, bt)
 	require.NoError(t, err)
@@ -754,7 +754,7 @@ func CreateExternalInitiatorViaWeb(
 		bytes.NewBufferString(payload),
 	)
 	defer cleanup()
-	AssertServerResponse(t, resp, 201)
+	AssertServerResponse(t, resp, http.StatusCreated)
 	ei := &presenters.ExternalInitiatorAuthentication{}
 	err := ParseJSONAPIResponse(t, resp, ei)
 	require.NoError(t, err)

--- a/core/internal/cltest/fixtures.go
+++ b/core/internal/cltest/fixtures.go
@@ -3,6 +3,7 @@ package cltest
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -34,7 +35,7 @@ func FixtureCreateServiceAgreementViaWeb(
 	resp, cleanup := client.Post("/v2/service_agreements", bytes.NewBufferString(agreementWithOracle))
 	defer cleanup()
 
-	AssertServerResponse(t, resp, 200)
+	AssertServerResponse(t, resp, http.StatusOK)
 	responseSA := models.ServiceAgreement{}
 	err := ParseJSONAPIResponse(t, resp, &responseSA)
 	require.NoError(t, err)

--- a/core/web/config_controller_test.go
+++ b/core/web/config_controller_test.go
@@ -2,6 +2,7 @@ package web_test
 
 import (
 	"math/big"
+	"net/http"
 	"testing"
 	"time"
 
@@ -23,7 +24,7 @@ func TestConfigController_Show(t *testing.T) {
 
 	resp, cleanup := client.Get("/v2/config")
 	defer cleanup()
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 
 	cwl := presenters.ConfigWhitelist{}
 	require.NoError(t, cltest.ParseJSONAPIResponse(t, resp, &cwl))

--- a/core/web/cors_test.go
+++ b/core/web/cors_test.go
@@ -1,6 +1,7 @@
 package web_test
 
 import (
+	"net/http"
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
@@ -19,9 +20,9 @@ func TestCors_DefaultOrigins(t *testing.T) {
 		origin     string
 		statusCode int
 	}{
-		{"http://localhost:3000", 200},
-		{"http://localhost:6689", 200},
-		{"http://localhost:1234", 403},
+		{"http://localhost:3000", http.StatusOK},
+		{"http://localhost:6689", http.StatusOK},
+		{"http://localhost:1234", http.StatusForbidden},
 	}
 
 	for _, test := range tests {
@@ -42,10 +43,10 @@ func TestCors_OverrideOrigins(t *testing.T) {
 		origin     string
 		statusCode int
 	}{
-		{"http://chainlink.com", "http://chainlink.com", 200},
-		{"http://chainlink.com", "http://localhost:3000", 403},
-		{"*", "http://chainlink.com", 200},
-		{"*", "http://localhost:3000", 200},
+		{"http://chainlink.com", "http://chainlink.com", http.StatusOK},
+		{"http://chainlink.com", "http://localhost:3000", http.StatusForbidden},
+		{"*", "http://chainlink.com", http.StatusOK},
+		{"*", "http://localhost:3000", http.StatusOK},
 	}
 
 	for _, test := range tests {

--- a/core/web/gui_assets_test.go
+++ b/core/web/gui_assets_test.go
@@ -17,35 +17,35 @@ func TestGuiAssets_WildcardIndexHtml(t *testing.T) {
 
 	resp, err := client.Get(app.Server.URL + "/")
 	require.NoError(t, err)
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 
 	resp, err = client.Get(app.Server.URL + "/not_found")
 	require.NoError(t, err)
-	cltest.AssertServerResponse(t, resp, 404)
+	cltest.AssertServerResponse(t, resp, http.StatusNotFound)
 
 	resp, err = client.Get(app.Server.URL + "/job_specs/abc123")
 	require.NoError(t, err)
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 
 	resp, err = client.Get(app.Server.URL + "/jjob_specs/abc123")
 	require.NoError(t, err)
-	cltest.AssertServerResponse(t, resp, 404)
+	cltest.AssertServerResponse(t, resp, http.StatusNotFound)
 
 	resp, err = client.Get(app.Server.URL + "/job_specs/abc123/runs")
 	require.NoError(t, err)
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 
 	resp, err = client.Get(app.Server.URL + "/job_specs/abc123/rruns")
 	require.NoError(t, err)
-	cltest.AssertServerResponse(t, resp, 404)
+	cltest.AssertServerResponse(t, resp, http.StatusNotFound)
 
 	resp, err = client.Get(app.Server.URL + "/job_specs/abc123/runs/abc123")
 	require.NoError(t, err)
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 
 	resp, err = client.Get(app.Server.URL + "/job_specs/abc123/rruns/abc123")
 	require.NoError(t, err)
-	cltest.AssertServerResponse(t, resp, 404)
+	cltest.AssertServerResponse(t, resp, http.StatusNotFound)
 }
 
 func TestGuiAssets_WildcardRouteInfo(t *testing.T) {
@@ -57,19 +57,19 @@ func TestGuiAssets_WildcardRouteInfo(t *testing.T) {
 
 	resp, err := client.Get(app.Server.URL + "/job_specs/abc123/routeInfo.json")
 	require.NoError(t, err)
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 
 	resp, err = client.Get(app.Server.URL + "/job_specs/abc123/rrouteInfo.json")
 	require.NoError(t, err)
-	cltest.AssertServerResponse(t, resp, 404)
+	cltest.AssertServerResponse(t, resp, http.StatusNotFound)
 
 	resp, err = client.Get(app.Server.URL + "/job_specs/abc123/runs/routeInfo.json")
 	require.NoError(t, err)
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 
 	resp, err = client.Get(app.Server.URL + "/job_specs/abc123/runs/rrouteInfo.json")
 	require.NoError(t, err)
-	cltest.AssertServerResponse(t, resp, 404)
+	cltest.AssertServerResponse(t, resp, http.StatusNotFound)
 }
 
 func TestGuiAssets_Exact(t *testing.T) {
@@ -81,9 +81,9 @@ func TestGuiAssets_Exact(t *testing.T) {
 
 	resp, err := client.Get(app.Server.URL + "/main.js")
 	require.NoError(t, err)
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 
 	resp, err = client.Get(app.Server.URL + "/mmain.js")
 	require.NoError(t, err)
-	cltest.AssertServerResponse(t, resp, 404)
+	cltest.AssertServerResponse(t, resp, http.StatusNotFound)
 }

--- a/core/web/ping_controller_test.go
+++ b/core/web/ping_controller_test.go
@@ -20,7 +20,7 @@ func TestPingController_Show_APICredentials(t *testing.T) {
 
 	resp, cleanup := client.Get("/v2/ping")
 	defer cleanup()
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 	require.Equal(t, `{"message":"pong"}`, string(cltest.ParseResponseBody(t, resp)))
 }
 
@@ -56,7 +56,7 @@ func TestPingController_Show_ExternalInitiatorCredentials(t *testing.T) {
 	require.NoError(t, err)
 	defer resp.Body.Close()
 
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 	require.Equal(t, `{"message":"pong"}`, string(cltest.ParseResponseBody(t, resp)))
 }
 

--- a/core/web/service_agreements_controller_test.go
+++ b/core/web/service_agreements_controller_test.go
@@ -3,6 +3,7 @@ package web_test
 import (
 	"bytes"
 	"io/ioutil"
+	"net/http"
 	"testing"
 	"time"
 
@@ -28,9 +29,9 @@ func TestServiceAgreementsController_Create(t *testing.T) {
 		input    string
 		wantCode int
 	}{
-		{"success", base, 200},
-		{"fails validation", cltest.MustJSONDel(t, base, "payment"), 422},
-		{"invalid JSON", "{", 422},
+		{"success", base, http.StatusOK},
+		{"fails validation", cltest.MustJSONDel(t, base, "payment"), http.StatusUnprocessableEntity},
+		{"invalid JSON", "{", http.StatusUnprocessableEntity},
 	}
 
 	for _, test := range tests {
@@ -39,7 +40,7 @@ func TestServiceAgreementsController_Create(t *testing.T) {
 			defer cleanup()
 
 			cltest.AssertServerResponse(t, resp, test.wantCode)
-			if test.wantCode == 200 {
+			if test.wantCode == http.StatusOK {
 				responseSA := models.ServiceAgreement{}
 
 				err := cltest.ParseJSONAPIResponse(t, resp, &responseSA)
@@ -76,14 +77,14 @@ func TestServiceAgreementsController_Create_isIdempotent(t *testing.T) {
 	reader := bytes.NewBuffer(cltest.MustReadFile(t, "testdata/hello_world_agreement.json"))
 	resp, cleanup := client.Post("/v2/service_agreements", reader)
 	defer cleanup()
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 	response1 := models.ServiceAgreement{}
 	assert.NoError(t, cltest.ParseJSONAPIResponse(t, resp, &response1))
 
 	reader = bytes.NewBuffer(cltest.MustReadFile(t, "testdata/hello_world_agreement.json"))
 	resp, cleanup = client.Post("/v2/service_agreements", reader)
 	defer cleanup()
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 	response2 := models.ServiceAgreement{}
 	assert.NoError(t, cltest.ParseJSONAPIResponse(t, resp, &response2))
 
@@ -105,7 +106,7 @@ func TestServiceAgreementsController_Show(t *testing.T) {
 
 	resp, cleanup := client.Get("/v2/service_agreements/" + sa.ID)
 	defer cleanup()
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 
 	b, err := ioutil.ReadAll(resp.Body)
 	assert.NoError(t, err)

--- a/core/web/transactions_controller_test.go
+++ b/core/web/transactions_controller_test.go
@@ -2,6 +2,7 @@ package web_test
 
 import (
 	"math/big"
+	"net/http"
 	"testing"
 
 	"github.com/manyminds/api2go/jsonapi"
@@ -40,7 +41,7 @@ func TestTransactionsController_Index_Success(t *testing.T) {
 
 	resp, cleanup := client.Get("/v2/transactions?size=2")
 	defer cleanup()
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 
 	var links jsonapi.Links
 	var txs []presenters.Tx
@@ -103,7 +104,7 @@ func TestTransactionsController_Show_Success(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			resp, cleanup := client.Get("/v2/transactions/" + test.hash)
 			defer cleanup()
-			cltest.AssertServerResponse(t, resp, 200)
+			cltest.AssertServerResponse(t, resp, http.StatusOK)
 
 			ptx := presenters.Tx{}
 			require.NoError(t, cltest.ParseJSONAPIResponse(t, resp, &ptx))
@@ -141,5 +142,5 @@ func TestTransactionsController_Show_NotFound(t *testing.T) {
 
 	resp, cleanup := client.Get("/v2/transactions/" + (tx.Hash.String() + "1"))
 	defer cleanup()
-	cltest.AssertServerResponse(t, resp, 404)
+	cltest.AssertServerResponse(t, resp, http.StatusNotFound)
 }

--- a/core/web/tx_attempts_controller_test.go
+++ b/core/web/tx_attempts_controller_test.go
@@ -2,6 +2,7 @@ package web_test
 
 import (
 	"math/big"
+	"net/http"
 	"testing"
 
 	"github.com/manyminds/api2go/jsonapi"
@@ -36,7 +37,7 @@ func TestTxAttemptsController_Index_Success(t *testing.T) {
 
 	resp, cleanup := client.Get("/v2/tx_attempts?size=2")
 	defer cleanup()
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 
 	var links jsonapi.Links
 	var attempts []models.TxAttempt

--- a/core/web/withdrawals_controller_test.go
+++ b/core/web/withdrawals_controller_test.go
@@ -3,6 +3,7 @@ package web_test
 import (
 	"bytes"
 	"encoding/json"
+	"net/http"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -62,7 +63,7 @@ func TestWithdrawalsController_CreateSuccess(t *testing.T) {
 	resp, cleanup := client.Post("/v2/withdrawals", bytes.NewBuffer(body))
 	defer cleanup()
 
-	cltest.AssertServerResponse(t, resp, 200)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 
 	assert.True(t, ethMock.AllCalled(), "Not Called")
 }
@@ -105,6 +106,6 @@ func TestWithdrawalsController_BalanceTooLow(t *testing.T) {
 	resp, cleanup := client.Post("/v2/withdrawals", bytes.NewBuffer(body))
 	defer cleanup()
 
-	cltest.AssertServerResponse(t, resp, 400)
+	cltest.AssertServerResponse(t, resp, http.StatusBadRequest)
 	assert.True(t, ethMock.AllCalled(), ethMock.Remaining())
 }


### PR DESCRIPTION
To improve clarity, continue migrating code to use the http packages constants for status codes.