### PR TITLE
cltest: elaborate on failed HTTP Mock error

### DIFF
--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -595,7 +595,7 @@ func NewHTTPMockServer(
 	server := httptest.NewServer(handler)
 	return server, func() {
 		server.Close()
-		assert.True(t, called)
+		assert.True(t, called, "expected call Mock HTTP endpoint '%s'", server.URL)
 	}
 }
 


### PR DESCRIPTION
To clarify the error case on failed tests, elaborate on the failed assertion when the HTTP Mock endpoint was not called.