### PR TITLE
Fix External Initiator 'gorm' tag

### DIFF
--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -21,6 +21,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1566498796"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1566915476"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1567029116"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1568280052"
 	gormigrate "gopkg.in/gormigrate.v1"
 )
 
@@ -99,6 +100,10 @@ func Migrate(db *gorm.DB) error {
 		{
 			ID:      "1567029116",
 			Migrate: migration1567029116.Migrate,
+		},
+		{
+			ID:      "1568280052",
+			Migrate: migration1568280052.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration1568280052/migrate.go
+++ b/core/store/migrations/migration1568280052/migrate.go
@@ -1,0 +1,59 @@
+package migration1568280052
+
+import (
+	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565877314"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+)
+
+type ExternalInitiator struct {
+	*gorm.Model
+	Name           string        `gorm:"not null;unique"`
+	URL            models.WebURL `gorm:"not null"`
+	AccessKey      string        `gorm:"not null"`
+	Salt           string        `gorm:"not null"`
+	HashedSecret   string        `gorm:"not null"`
+	OutgoingSecret string        `gorm:"not null"`
+	OutgoingToken  string        `gorm:"not null"`
+}
+
+// newExternalInitiator returns a copy of the old struct with the fields untouched.
+func newExternalInitiator(arg migration1565877314.ExternalInitiator) ExternalInitiator {
+	return ExternalInitiator{
+		Model:          arg.Model,
+		Name:           arg.AccessKey,
+		URL:            arg.URL,
+		AccessKey:      arg.AccessKey,
+		Salt:           arg.Salt,
+		HashedSecret:   arg.HashedSecret,
+		OutgoingSecret: arg.OutgoingSecret,
+		OutgoingToken:  arg.OutgoingToken,
+	}
+}
+
+// Migrate adds External Initiator Name and URL fields.
+func Migrate(tx *gorm.DB) error {
+	var exis []migration1565877314.ExternalInitiator
+	if err := tx.Find(&exis).Error; err != nil {
+		return errors.Wrap(err, "could not load all External Intitiators")
+	}
+
+	// Make new table
+	if err := tx.DropTable(migration1565877314.ExternalInitiator{}).Error; err != nil {
+		return errors.Wrap(err, "could not drop old External Intitiator table")
+	}
+	if err := tx.AutoMigrate(&ExternalInitiator{}).Error; err != nil {
+		return errors.Wrap(err, "could not create new External Intitiator table")
+	}
+
+	// Copy
+	for _, old := range exis {
+		exi := newExternalInitiator(old)
+		if err := tx.Save(exi).Error; err != nil {
+			return errors.Wrap(err, "could not save migrated version of External Initiator")
+		}
+	}
+
+	return nil
+}

--- a/core/store/models/external_initiator.go
+++ b/core/store/models/external_initiator.go
@@ -21,7 +21,7 @@ type ExternalInitiatorRequest struct {
 // ExternalInitiator represents a user that can initiate runs remotely
 type ExternalInitiator struct {
 	*gorm.Model
-	Name           string `gorm:"not null,unique"`
+	Name           string `gorm:"not null;unique"`
 	URL            WebURL `gorm:"not null"`
 	AccessKey      string `gorm:"not null"`
 	Salt           string `gorm:"not null"`


### PR DESCRIPTION
Make the External Initiator's 'name' column unique by correcting the tag used for the struct's field.  It should be ';' instead of ','.