### PR TITLE
Fix Add bridge in GUI bug

### DIFF
--- a/integration/.eslintrc.js
+++ b/integration/.eslintrc.js
@@ -1,5 +1,9 @@
 module.exports = {
   root: true,
+  env: {
+    browser: true,
+    node: true,
+  },
   extends: [
     // TODO: might need to clean this up since truffle uses mocha and we're also using jest here
     '@chainlink/eslint-config/node',

--- a/integration/addBridge.test.js
+++ b/integration/addBridge.test.js
@@ -1,15 +1,15 @@
-const puppeteer = require('puppeteer')
-const pupExpect = require('expect-puppeteer')
-const puppeteerConfig = require('./puppeteer.config.js')
-const {
+import puppeteer from 'puppeteer'
+import pupExpect from 'expect-puppeteer'
+import puppeteerConfig from './puppeteer.config.js'
+import {
   signIn,
   consoleLogger,
   clickButton,
   clickLink,
-} = require('./support/helpers.js')
+} from './support/helpers.js'
 
 describe('End to end', () => {
-  let browser, page, server
+  let browser, page
   beforeAll(async () => {
     jest.setTimeout(30000)
     pupExpect.setDefaultOptions({ timeout: 3000 })
@@ -51,7 +51,7 @@ describe('End to end', () => {
     await new Promise(resolve => setTimeout(resolve, 2000)) // FIXME timeout until we can reload again
     const newBridgeLink = await flashMessage[0].$('a')
     await newBridgeLink.click()
-    const pathName = await page.evaluate(() => location.pathname)
+    const pathName = await page.evaluate(() => window.location.pathname)
     expect(pathName).toEqual('/bridges/new_bridge')
   })
 })

--- a/integration/addBridge.test.js
+++ b/integration/addBridge.test.js
@@ -1,0 +1,56 @@
+const puppeteer = require('puppeteer')
+const pupExpect = require('expect-puppeteer')
+const puppeteerConfig = require('./puppeteer.config.js')
+const {
+  signIn,
+  clickBridgesTab,
+  clickNewBridgeButton,
+} = require('./support/helpers.js')
+
+describe('End to end', () => {
+  let browser, page, server
+  beforeAll(async () => {
+    jest.setTimeout(30000)
+    pupExpect.setDefaultOptions({ timeout: 3000 })
+    browser = await puppeteer.launch(puppeteerConfig)
+    page = await browser.newPage()
+    page.on('console', msg => {
+      console.log(`PAGE LOG url: ${page.url()} | msg: ${msg.text()}`)
+    })
+  })
+
+  afterAll(async () => {
+    return browser.close()
+  })
+
+  it('adds a bridge', async () => {
+    // Navigate to Operator UI
+    await page.goto('http://localhost:6688')
+    await pupExpect(page).toMatch('Chainlink')
+
+    // Login
+    await signIn(page, 'notreal@fakeemail.ch', 'twochains')
+    await pupExpect(page).toMatch('Jobs')
+
+    // Add Bridge
+    await clickBridgesTab(page)
+    await pupExpect(page).toMatchElement('h4', { text: 'Bridges' })
+    await clickNewBridgeButton(page)
+    await pupExpect(page).toFillForm('form', {
+      name: 'new_bridge',
+      url: 'http://example.com',
+      minimumContractPayment: '123',
+      confirmations: '5',
+    })
+    await pupExpect(page).toClick('button', { text: 'Create Bridge' })
+
+    // Navigate to bridge show page
+    const flashMessage = await page.$x(
+      "//p[contains(text(), 'Successfully created bridge')]",
+    )
+    const jobRunLink = await flashMessage[0].$('a')
+    await jobRunLink.click()
+    const pathName = await page.evaluate(() => location.pathname)
+    expect(pathName).toEqual('/bridges/new_bridge')
+  })
+})

--- a/integration/addBridge.test.js
+++ b/integration/addBridge.test.js
@@ -4,8 +4,8 @@ const puppeteerConfig = require('./puppeteer.config.js')
 const {
   signIn,
   consoleLogger,
-  clickBridgesTab,
-  clickNewBridgeButton,
+  clickButton,
+  clickLink,
 } = require('./support/helpers.js')
 
 describe('End to end', () => {
@@ -32,24 +32,25 @@ describe('End to end', () => {
     await pupExpect(page).toMatch('Jobs')
 
     // Add Bridge
-    await clickBridgesTab(page)
+    await clickLink(page, 'Bridges')
     await pupExpect(page).toMatchElement('h4', { text: 'Bridges' })
-    await clickNewBridgeButton(page)
+    await clickLink(page, 'New Bridge')
     await pupExpect(page).toFillForm('form', {
       name: 'new_bridge',
       url: 'http://example.com',
       minimumContractPayment: '123',
       confirmations: '5',
     })
-    await pupExpect(page).toClick('button', { text: 'Create Bridge' })
+    await clickButton(page, 'Create Bridge')
+    await pupExpect(page).toMatch(/success.+?bridge/i)
 
     // Navigate to bridge show page
     const flashMessage = await page.$x(
       "//p[contains(text(), 'Successfully created bridge')]",
     )
     await new Promise(resolve => setTimeout(resolve, 2000)) // FIXME timeout until we can reload again
-    const jobRunLink = await flashMessage[0].$('a')
-    await jobRunLink.click()
+    const newBridgeLink = await flashMessage[0].$('a')
+    await newBridgeLink.click()
     const pathName = await page.evaluate(() => location.pathname)
     expect(pathName).toEqual('/bridges/new_bridge')
   })

--- a/integration/addBridge.test.js
+++ b/integration/addBridge.test.js
@@ -15,7 +15,7 @@ describe('End to end', () => {
     pupExpect.setDefaultOptions({ timeout: 3000 })
     browser = await puppeteer.launch(puppeteerConfig)
     page = await browser.newPage()
-    page.on('console', consoleLogger)
+    page.on('console', consoleLogger(page))
   })
 
   afterAll(async () => {

--- a/integration/addBridge.test.js
+++ b/integration/addBridge.test.js
@@ -1,12 +1,14 @@
-import puppeteer from 'puppeteer'
-import pupExpect from 'expect-puppeteer'
-import puppeteerConfig from './puppeteer.config.js'
-import {
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const puppeteer = require('puppeteer')
+const pupExpect = require('expect-puppeteer')
+const puppeteerConfig = require('./puppeteer.config.js')
+const {
   signIn,
   consoleLogger,
   clickButton,
   clickLink,
-} from './support/helpers.js'
+} = require('./support/helpers.js')
 
 describe('End to end', () => {
   let browser, page

--- a/integration/addBridge.test.js
+++ b/integration/addBridge.test.js
@@ -47,6 +47,7 @@ describe('End to end', () => {
     const flashMessage = await page.$x(
       "//p[contains(text(), 'Successfully created bridge')]",
     )
+    await new Promise(resolve => setTimeout(resolve, 2000)) // FIXME timeout until we can reload again
     const jobRunLink = await flashMessage[0].$('a')
     await jobRunLink.click()
     const pathName = await page.evaluate(() => location.pathname)

--- a/integration/addBridge.test.js
+++ b/integration/addBridge.test.js
@@ -3,6 +3,7 @@ const pupExpect = require('expect-puppeteer')
 const puppeteerConfig = require('./puppeteer.config.js')
 const {
   signIn,
+  consoleLogger,
   clickBridgesTab,
   clickNewBridgeButton,
 } = require('./support/helpers.js')
@@ -14,9 +15,7 @@ describe('End to end', () => {
     pupExpect.setDefaultOptions({ timeout: 3000 })
     browser = await puppeteer.launch(puppeteerConfig)
     page = await browser.newPage()
-    page.on('console', msg => {
-      console.log(`PAGE LOG url: ${page.url()} | msg: ${msg.text()}`)
-    })
+    page.on('console', consoleLogger)
   })
 
   afterAll(async () => {

--- a/integration/createAndRunJob.test.js
+++ b/integration/createAndRunJob.test.js
@@ -4,31 +4,21 @@ const puppeteer = require('puppeteer')
 const pupExpect = require('expect-puppeteer')
 const { newServer } = require('./support/server.js')
 const { scrape } = require('./support/scrape.js')
+const puppeteerConfig = require('./puppeteer.config.js')
 const {
   signIn,
   clickNewJobButton,
   clickTransactionsMenuItem,
 } = require('./support/helpers.js')
 
-const AVERAGE_CLIENT_WIDTH = 1366
-const AVERAGE_CLIENT_HEIGHT = 768
-
 describe('End to end', () => {
   let browser, page, server
   beforeAll(async () => {
     jest.setTimeout(30000)
     pupExpect.setDefaultOptions({ timeout: 3000 })
-    browser = await puppeteer.launch({
-      devtools: false,
-      headless: true,
-      args: ['--no-sandbox'],
-    })
-    page = await browser.newPage()
-    await page.setViewport({
-      width: AVERAGE_CLIENT_WIDTH,
-      height: AVERAGE_CLIENT_HEIGHT,
-    })
     server = await newServer(`{"last": "3843.95"}`)
+    browser = await puppeteer.launch(puppeteerConfig)
+    page = await browser.newPage()
     page.on('console', msg => {
       console.log(`PAGE LOG url: ${page.url()} | msg: ${msg.text()}`)
     })

--- a/integration/createAndRunJob.test.js
+++ b/integration/createAndRunJob.test.js
@@ -7,6 +7,7 @@ const { scrape } = require('./support/scrape.js')
 const puppeteerConfig = require('./puppeteer.config.js')
 const {
   signIn,
+  consoleLogger,
   clickNewJobButton,
   clickTransactionsMenuItem,
 } = require('./support/helpers.js')
@@ -19,9 +20,7 @@ describe('End to end', () => {
     server = await newServer(`{"last": "3843.95"}`)
     browser = await puppeteer.launch(puppeteerConfig)
     page = await browser.newPage()
-    page.on('console', msg => {
-      console.log(`PAGE LOG url: ${page.url()} | msg: ${msg.text()}`)
-    })
+    page.on('console', consoleLogger)
   })
 
   afterAll(async () => {

--- a/integration/createAndRunJob.test.js
+++ b/integration/createAndRunJob.test.js
@@ -20,7 +20,7 @@ describe('End to end', () => {
     server = await newServer(`{"last": "3843.95"}`)
     browser = await puppeteer.launch(puppeteerConfig)
     page = await browser.newPage()
-    page.on('console', consoleLogger)
+    page.on('console', consoleLogger(page))
   })
 
   afterAll(async () => {

--- a/integration/createAndRunJob.test.js
+++ b/integration/createAndRunJob.test.js
@@ -8,8 +8,8 @@ const puppeteerConfig = require('./puppeteer.config.js')
 const {
   signIn,
   consoleLogger,
-  clickNewJobButton,
   clickTransactionsMenuItem,
+  clickLink,
 } = require('./support/helpers.js')
 
 describe('End to end', () => {
@@ -36,7 +36,7 @@ describe('End to end', () => {
     await pupExpect(page).toMatch('Jobs')
 
     // Create Job
-    await clickNewJobButton(page)
+    await clickLink(page, 'New Job')
     await pupExpect(page).toMatchElement('h5', { text: 'New Job' })
 
     // prettier-ignore

--- a/integration/puppeteer.config.js
+++ b/integration/puppeteer.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  devtools: false,
+  headless: true,
+  args: ['--no-sandbox'],
+  defaultViewport: {
+    width: 1366,
+    height: 768,
+  },
+}

--- a/integration/support/helpers.js
+++ b/integration/support/helpers.js
@@ -1,4 +1,6 @@
-import pupExpect from 'expect-puppeteer'
+/* eslint-disable @typescript-eslint/no-var-requires */
+
+const puppeteer = require('puppeteer')
 
 const clickNavigationTag = tagName => async (page, text) => {
   // XXX: Some buttons/links don't do anything if you click them too quickly,

--- a/integration/support/helpers.js
+++ b/integration/support/helpers.js
@@ -10,7 +10,7 @@ module.exports = {
 
   consoleLogger: msg => {
     console.log(`PAGE LOG url: ${page.url()} | msg: ${msg.text()}`)
-  }
+  },
 
   clickNewJobButton: async page => clickLink(page, 'New Job'),
 

--- a/integration/support/helpers.js
+++ b/integration/support/helpers.js
@@ -8,6 +8,10 @@ const clickLink = async (page, title) => {
 module.exports = {
   clickLink: clickLink,
 
+  consoleLogger: msg => {
+    console.log(`PAGE LOG url: ${page.url()} | msg: ${msg.text()}`)
+  }
+
   clickNewJobButton: async page => clickLink(page, 'New Job'),
 
   clickBridgesTab: async page => clickLink(page, 'Bridges'),

--- a/integration/support/helpers.js
+++ b/integration/support/helpers.js
@@ -1,4 +1,4 @@
-const pupExpect = require('expect-puppeteer')
+import pupExpect from 'expect-puppeteer'
 
 const clickNavigationTag = tagName => async (page, text) => {
   // XXX: Some buttons/links don't do anything if you click them too quickly,

--- a/integration/support/helpers.js
+++ b/integration/support/helpers.js
@@ -1,4 +1,7 @@
 const clickLink = async (page, title) => {
+  // XXX: This buttons don't do anything if you click them too quickly, so for
+  // now, add a small delay
+  await page.waitFor(500)
   await expect(page).toClick('a', { text: title })
   await page.waitForNavigation({
     waitUntil: 'networkidle0',

--- a/integration/support/helpers.js
+++ b/integration/support/helpers.js
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-var-requires */
 
-const puppeteer = require('puppeteer')
+const pupExpect = require('expect-puppeteer')
 
 const clickNavigationTag = tagName => async (page, text) => {
   // XXX: Some buttons/links don't do anything if you click them too quickly,

--- a/integration/support/helpers.js
+++ b/integration/support/helpers.js
@@ -1,16 +1,18 @@
 const clickLink = async (page, title) => {
-  return expect(page).toClick('a', { text: title })
+  await expect(page).toClick('a', { text: title })
+  await page.waitForNavigation({
+    waitUntil: 'networkidle0',
+  })
 }
 
 module.exports = {
   clickLink: clickLink,
 
-  clickNewJobButton: async page => {
-    // XXX: This button doesn't do anything if you click it too quickly, so for
-    // now, add a small delay
-    await page.waitFor(500)
-    return clickLink(page, 'New Job')
-  },
+  clickNewJobButton: async page => clickLink(page, 'New Job'),
+
+  clickBridgesTab: async page => clickLink(page, 'Bridges'),
+
+  clickNewBridgeButton: async page => clickLink(page, 'New Bridge'),
 
   clickTransactionsMenuItem: async page => {
     return expect(page).toClick('li > a', { text: 'Transactions' })

--- a/integration/support/helpers.js
+++ b/integration/support/helpers.js
@@ -1,8 +1,10 @@
+const pupExpect = require('expect-puppeteer')
+
 const clickLink = async (page, title) => {
-  // XXX: This buttons don't do anything if you click them too quickly, so for
-  // now, add a small delay
+  // XXX: Some buttons don't do anything if you click them too quickly,
+  // so for, now, add a small delay
   await page.waitFor(500)
-  await expect(page).toClick('a', { text: title })
+  await pupExpect(page).toClick('a', { text: title })
   await page.waitForNavigation({
     waitUntil: 'networkidle0',
   })
@@ -22,12 +24,12 @@ module.exports = {
   clickNewBridgeButton: async page => clickLink(page, 'New Bridge'),
 
   clickTransactionsMenuItem: async page => {
-    return expect(page).toClick('li > a', { text: 'Transactions' })
+    return pupExpect(page).toClick('li > a', { text: 'Transactions' })
   },
 
-  signIn: async (page, email) => {
-    await expect(page).toFill('form input[id=email]', email)
-    await expect(page).toFill('form input[id=password]', 'twochains')
-    return expect(page).toClick('form button')
+  signIn: async (page, email, password) => {
+    await pupExpect(page).toFill('form input[id=email]', email)
+    await pupExpect(page).toFill('form input[id=password]', 'twochains')
+    return pupExpect(page).toClick('form button')
   },
 }

--- a/integration/support/helpers.js
+++ b/integration/support/helpers.js
@@ -8,7 +8,7 @@ const clickLink = async (page, title) => {
 module.exports = {
   clickLink: clickLink,
 
-  consoleLogger: msg => {
+  consoleLogger: page => msg => {
     console.log(`PAGE LOG url: ${page.url()} | msg: ${msg.text()}`)
   },
 

--- a/integration/support/helpers.js
+++ b/integration/support/helpers.js
@@ -1,27 +1,19 @@
 const pupExpect = require('expect-puppeteer')
 
-const clickLink = async (page, title) => {
-  // XXX: Some buttons don't do anything if you click them too quickly,
+const clickNavigationTag = tagName => async (page, text) => {
+  // XXX: Some buttons/links don't do anything if you click them too quickly,
   // so for, now, add a small delay
   await page.waitFor(500)
-  await pupExpect(page).toClick('a', { text: title })
-  await page.waitForNavigation({
-    waitUntil: 'networkidle0',
-  })
+  await pupExpect(page).toClick(tagName, { text })
 }
 
 module.exports = {
-  clickLink: clickLink,
+  clickLink: clickNavigationTag('a'),
+  clickButton: clickNavigationTag('button'),
 
   consoleLogger: page => msg => {
     console.log(`PAGE LOG url: ${page.url()} | msg: ${msg.text()}`)
   },
-
-  clickNewJobButton: async page => clickLink(page, 'New Job'),
-
-  clickBridgesTab: async page => clickLink(page, 'Bridges'),
-
-  clickNewBridgeButton: async page => clickLink(page, 'New Bridge'),
 
   clickTransactionsMenuItem: async page => {
     return pupExpect(page).toClick('li > a', { text: 'Transactions' })

--- a/operator_ui/src/components/Bridges/Form.tsx
+++ b/operator_ui/src/components/Bridges/Form.tsx
@@ -97,7 +97,6 @@ const Form: React.SFC<Props> = props => (
                 name="minimumContractPayment"
                 placeholder="0"
                 value={props.values.minimumContractPayment}
-                type="number"
                 inputProps={{ min: 0 }}
                 onChange={props.handleChange}
                 className={props.classes.textfield}
@@ -143,10 +142,10 @@ const WithFormikForm = withFormik<OwnProps, FormValues>({
     const shouldPersist = Object.keys(get('persistBridge')).length !== 0
     const persistedJSON = shouldPersist && get('persistBridge')
     if (shouldPersist) set('persistBridge', {})
-    const json = {
+    const json: FormValues = {
       name: name || '',
       url: url || '',
-      minimumContractPayment: minimumContractPayment || 0,
+      minimumContractPayment: minimumContractPayment || '0',
       confirmations: confirmations || 0,
     }
     return (shouldPersist && persistedJSON) || json


### PR DESCRIPTION
Addresses [this story](https://www.pivotaltracker.com/story/show/168341643)

Bug fix is simply to require `minimumContractPayment` inputs as strings instead of numbers (which I think makes sense anyway since a valid input could be larger than `Number.MAX_SAFE_INTEGER`.)

Also wrote a new integration test for adding a bridge through the GUI and refactored the reusable puppeteer and testing code into `puppeteer.config.js` and `helpers.js`