### PR TITLE
Handle when Parity returns a TxReceipt with no blockHash

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -354,7 +354,7 @@ func TestIntegration_RunLog(t *testing.T) {
 			newHeads <- models.BlockHeader{Number: cltest.BigHexInt(safeNumber)}
 			confirmedReceipt := models.TxReceipt{
 				Hash:        runlog.TxHash,
-				BlockHash:   test.receiptBlockHash,
+				BlockHash:   &test.receiptBlockHash,
 				BlockNumber: cltest.Int(creationHeight),
 			}
 			eth.Context("validateOnMainChain", func(ethMock *cltest.EthMock) {
@@ -460,7 +460,7 @@ func TestIntegration_ExternalAdapter_RunLogInitiated(t *testing.T) {
 
 	confirmedReceipt := models.TxReceipt{
 		Hash:        runlog.TxHash,
-		BlockHash:   runlog.BlockHash,
+		BlockHash:   &runlog.BlockHash,
 		BlockNumber: cltest.Int(logBlockNumber),
 	}
 	eth.Context("validateOnMainChain", func(ethMock *cltest.EthMock) {

--- a/core/services/runs.go
+++ b/core/services/runs.go
@@ -401,7 +401,7 @@ func validateOnMainChain(jr *models.JobRun, taskRun *models.TaskRun, store *stor
 
 func invalidRequest(request models.RunRequest, receipt *models.TxReceipt) bool {
 	return receipt.Unconfirmed() ||
-		(request.BlockHash != nil && *request.BlockHash != receipt.BlockHash)
+		(request.BlockHash != nil && *request.BlockHash != *receipt.BlockHash)
 }
 
 func meetsMinimumConfirmations(

--- a/core/services/runs_test.go
+++ b/core/services/runs_test.go
@@ -689,7 +689,7 @@ func TestExecuteJobWithRunRequest_fromRunLog_Happy(t *testing.T) {
 
 			confirmedReceipt := models.TxReceipt{
 				Hash:        initiatingTxHash,
-				BlockHash:   test.receiptBlockHash,
+				BlockHash:   &test.receiptBlockHash,
 				BlockNumber: cltest.Int(3),
 			}
 			eth.Context("validateOnMainChain", func(ethMock *cltest.EthMock) {

--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -398,10 +398,10 @@ func (k *Key) WriteToDisk(path string) error {
 // TxReceipt holds the block number and the transaction hash of a signed
 // transaction that has been written to the blockchain.
 type TxReceipt struct {
-	BlockNumber *Big        `json:"blockNumber"`
-	BlockHash   common.Hash `json:"blockHash"`
-	Hash        common.Hash `json:"transactionHash"`
-	Logs        []Log       `json:"logs"`
+	BlockNumber *Big         `json:"blockNumber"`
+	BlockHash   *common.Hash `json:"blockHash"`
+	Hash        common.Hash  `json:"transactionHash"`
+	Logs        []Log        `json:"logs"`
 }
 
 // Unconfirmed returns true if the transaction is not confirmed.

--- a/core/store/models/eth_test.go
+++ b/core/store/models/eth_test.go
@@ -37,6 +37,20 @@ func TestLog_UnmarshalEmptyTxHash(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestReceipt_UnmarshalEmptyBlockHash(t *testing.T) {
+	t.Parallel()
+
+	input := `{
+		"transactionHash": "0x444172bef57ad978655171a8af2cfd89baa02a97fcb773067aef7794d6913374",
+		"blockNumber": "0x8bf99b",
+		"blockHash": null
+	}`
+
+	var receipt models.TxReceipt
+	err := json.Unmarshal([]byte(input), &receipt)
+	require.NoError(t, err)
+}
+
 func TestModels_HexToFunctionSelector(t *testing.T) {
 	t.Parallel()
 	fid := models.HexToFunctionSelector("0xb3f98adc")


### PR DESCRIPTION
Parity defines `block_hash` as optional, see `transaction.rs` : `block_hash: Option<H256>`.