### PR TITLE
Don't build images & report test coverage on CircleCI when any jobs fail

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -281,6 +281,16 @@ workflows:
       - rust
       - explorer
       - build-explorer-image:
+          requires:
+            - go-sqlite
+            - go-sqlite-race
+            - go-postgres
+            - truffle
+            - geth-postgres
+            - parity-postgres
+            - operator-ui
+            - rust
+            - explorer
           filters:
             branches:
               ignore: master
@@ -304,6 +314,14 @@ workflows:
                 - /^release\/.*/
       - aws-ecr/build_and_push_image:
           requires:
+            - go-sqlite
+            - go-sqlite-race
+            - go-postgres
+            - truffle
+            - geth-postgres
+            - parity-postgres
+            - operator-ui
+            - rust
             - explorer
           filters:
             branches:
@@ -314,4 +332,11 @@ workflows:
       - reportcoverage:
           requires:
             - go-sqlite
+            - go-sqlite-race
+            - go-postgres
+            - truffle
+            - geth-postgres
+            - parity-postgres
             - operator-ui
+            - rust
+            - explorer


### PR DESCRIPTION
Failed jobs can't be re-run on CircleCI until all jobs without dependencies have failed. Our build image job is the slowest on CI and takes ~15 mins.

This PR will result in a longer overall build time, but faster time to retry in the result of a failure.

It should also help with queuing, as a long running job to build an image that won't be deployed, won't be taking up time & resources.

Current:

![Screen Shot 2019-09-12 at 4 33 51 PM](https://user-images.githubusercontent.com/680789/64827893-2762f080-d57b-11e9-8b2d-3bdfe19b1410.png)

New:

![Screen Shot 2019-09-12 at 4 35 49 PM](https://user-images.githubusercontent.com/680789/64827962-698c3200-d57b-11e9-915c-9572dc4ac666.png)


