### PR TITLE
Feature/notify external initiator

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -814,7 +814,7 @@ func TestIntegration_ExternalInitiator(t *testing.T) {
 
 	exInitr := struct {
 		Header http.Header
-		Body   models.JobSpecNotice
+		Body   web.JobSpecNotice
 	}{}
 	eiMockServer, assertCalled := cltest.NewHTTPMockServer(t, http.StatusOK, "POST", "",
 		func(header http.Header, body string) {
@@ -854,7 +854,7 @@ func TestIntegration_ExternalInitiator(t *testing.T) {
 		eip.OutgoingSecret,
 		exInitr.Header.Get(web.ExternalInitiatorSecretHeader),
 	)
-	expected := models.JobSpecNotice{
+	expected := web.JobSpecNotice{
 		JobID:  jobSpec.ID,
 		Type:   models.InitiatorExternal,
 		Params: cltest.JSONFromString(t, `{"foo":"bar"}`),

--- a/core/internal/testdata/external_initiator_job.json
+++ b/core/internal/testdata/external_initiator_job.json
@@ -1,21 +1,4 @@
 {
-  "initiators": [{ "type": "external", "name": "someCoin"}],
-  "tasks": [
-    { "type": "HttpGet", "params": {
-        "get": "https://bitstamp.net/api/ticker/",
-        "headers": {
-          "Key1": ["value"],
-          "Key2": ["value", "value"]
-        }
-      }
-    },
-    { "type": "JsonParse", "params": { "path": ["last"] }},
-    { "type": "EthBytes32" },
-    {
-      "type": "EthTx", "params": {
-        "address": "0x356a04bce728ba4c62a30294a55e6a8600a320b3",
-        "functionSelector": "0x609ff1bd"
-      }
-    }
-  ]
+  "initiators": [{ "type": "external", "name": "somecoin", "params":{"foo":"bar"}}],
+  "tasks": [{"type": "NoOp"}]
 }

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1566915476"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1567029116"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1568280052"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1568833756"
 	gormigrate "gopkg.in/gormigrate.v1"
 )
 
@@ -104,6 +105,10 @@ func Migrate(db *gorm.DB) error {
 		{
 			ID:      "1568280052",
 			Migrate: migration1568280052.Migrate,
+		},
+		{
+			ID:      "1568833756",
+			Migrate: migration1568833756.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration1568833756/migrate.go
+++ b/core/store/migrations/migration1568833756/migrate.go
@@ -1,0 +1,45 @@
+package migration1568833756
+
+import (
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+	"gopkg.in/guregu/null.v3"
+)
+
+// InitiatorParams is a collection of the possible parameters that different
+// Initiators may require.
+type InitiatorParams struct {
+	Schedule   models.Cron              `json:"schedule,omitempty"`
+	Time       models.AnyTime           `json:"time,omitempty"`
+	Ran        bool                     `json:"ran,omitempty"`
+	Address    common.Address           `json:"address,omitempty" gorm:"index"`
+	Requesters models.AddressCollection `json:"requesters,omitempty" gorm:"type:text"`
+	Name       string                   `json:"name,omitempty"`
+	Params     string                   `json:"-"`
+}
+
+// Initiator could be thought of as a trigger, defines how a Job can be
+// started, or rather, how a JobRun can be created from a Job.
+// Initiators will have their own unique ID, but will be associated
+// to a parent JobID.
+type Initiator struct {
+	ID              uint       `json:"id" gorm:"primary_key;auto_increment"`
+	JobSpecID       *models.ID `json:"jobSpecId" gorm:"index;type:varchar(36) REFERENCES job_specs(id)"`
+	Type            string     `json:"type" gorm:"index;not null"`
+	CreatedAt       time.Time  `gorm:"index"`
+	InitiatorParams `json:"params,omitempty"`
+	DeletedAt       null.Time `json:"-" gorm:"index"`
+}
+
+// Migrate Initiator parameter 'Text' to support External Initaitor generic
+// JSON parameters.
+func Migrate(tx *gorm.DB) error {
+	if err := tx.AutoMigrate(&Initiator{}).Error; err != nil {
+		return errors.Wrap(err, "could not add 'text' field to Initiator table")
+	}
+	return nil
+}

--- a/core/store/migrations/migration1568833756/migrate.go
+++ b/core/store/migrations/migration1568833756/migrate.go
@@ -39,7 +39,7 @@ type Initiator struct {
 // JSON parameters.
 func Migrate(tx *gorm.DB) error {
 	if err := tx.AutoMigrate(&Initiator{}).Error; err != nil {
-		return errors.Wrap(err, "could not add 'text' field to Initiator table")
+		return errors.Wrap(err, "could not add fields 'names' and 'params' to the Initiator table")
 	}
 	return nil
 }

--- a/core/store/migrations/migration1568833756/migrate.go
+++ b/core/store/migrations/migration1568833756/migrate.go
@@ -10,9 +10,15 @@ import (
 	"gopkg.in/guregu/null.v3"
 )
 
-// InitiatorParams is a collection of the possible parameters that different
-// Initiators may require.
-type InitiatorParams struct {
+// Initiator could be thought of as a trigger, defines how a Job can be
+// started, or rather, how a JobRun can be created from a Job.
+// Initiators will have their own unique ID, but will be associated
+// to a parent JobID.
+type Initiator struct {
+	ID         uint       `gorm:"primary_key;auto_increment"`
+	JobSpecID  *models.ID `gorm:"index;type:varchar(36) REFERENCES job_specs(id)"`
+	Type       string     `gorm:"index;not null"`
+	CreatedAt  time.Time  `gorm:"index"`
 	Schedule   models.Cron
 	Time       models.AnyTime
 	Ran        bool
@@ -20,19 +26,7 @@ type InitiatorParams struct {
 	Requesters models.AddressCollection `gorm:"type:text"`
 	Name       string
 	Params     string
-}
-
-// Initiator could be thought of as a trigger, defines how a Job can be
-// started, or rather, how a JobRun can be created from a Job.
-// Initiators will have their own unique ID, but will be associated
-// to a parent JobID.
-type Initiator struct {
-	ID        uint       `gorm:"primary_key;auto_increment"`
-	JobSpecID *models.ID `gorm:"index;type:varchar(36) REFERENCES job_specs(id)"`
-	Type      string     `gorm:"index;not null"`
-	CreatedAt time.Time  `gorm:"index"`
-	InitiatorParams
-	DeletedAt null.Time `gorm:"index"`
+	DeletedAt  null.Time `gorm:"index"`
 }
 
 // Migrate Initiator parameter 'Text' to support External Initaitor generic

--- a/core/store/migrations/migration1568833756/migrate.go
+++ b/core/store/migrations/migration1568833756/migrate.go
@@ -13,13 +13,13 @@ import (
 // InitiatorParams is a collection of the possible parameters that different
 // Initiators may require.
 type InitiatorParams struct {
-	Schedule   models.Cron              `json:"schedule,omitempty"`
-	Time       models.AnyTime           `json:"time,omitempty"`
-	Ran        bool                     `json:"ran,omitempty"`
-	Address    common.Address           `json:"address,omitempty" gorm:"index"`
-	Requesters models.AddressCollection `json:"requesters,omitempty" gorm:"type:text"`
-	Name       string                   `json:"name,omitempty"`
-	Params     string                   `json:"-"`
+	Schedule   models.Cron
+	Time       models.AnyTime
+	Ran        bool
+	Address    common.Address           `gorm:"index"`
+	Requesters models.AddressCollection `gorm:"type:text"`
+	Name       string
+	Params     string
 }
 
 // Initiator could be thought of as a trigger, defines how a Job can be
@@ -27,12 +27,12 @@ type InitiatorParams struct {
 // Initiators will have their own unique ID, but will be associated
 // to a parent JobID.
 type Initiator struct {
-	ID              uint       `json:"id" gorm:"primary_key;auto_increment"`
-	JobSpecID       *models.ID `json:"jobSpecId" gorm:"index;type:varchar(36) REFERENCES job_specs(id)"`
-	Type            string     `json:"type" gorm:"index;not null"`
-	CreatedAt       time.Time  `gorm:"index"`
-	InitiatorParams `json:"params,omitempty"`
-	DeletedAt       null.Time `json:"-" gorm:"index"`
+	ID        uint       `gorm:"primary_key;auto_increment"`
+	JobSpecID *models.ID `gorm:"index;type:varchar(36) REFERENCES job_specs(id)"`
+	Type      string     `gorm:"index;not null"`
+	CreatedAt time.Time  `gorm:"index"`
+	InitiatorParams
+	DeletedAt null.Time `gorm:"index"`
 }
 
 // Migrate Initiator parameter 'Text' to support External Initaitor generic

--- a/core/store/models/external_initiator.go
+++ b/core/store/models/external_initiator.go
@@ -12,26 +12,6 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-// JobSpecNotice is sent to the External Initiator when JobSpecs are created.
-type JobSpecNotice struct {
-	JobID  *ID    `json:"jobId"`
-	Type   string `json:"type"`
-	Params JSON   `json:"params,omitempty"`
-}
-
-// NewJobSpecNotice returns a new JobSpec.
-func NewJobSpecNotice(initiator Initiator, js JobSpec) (*JobSpecNotice, error) {
-	params, err := ParseJSON([]byte(initiator.Params))
-	if err != nil {
-		return nil, errors.Wrap(err, "external initiator params")
-	}
-	return &JobSpecNotice{
-		JobID:  js.ID,
-		Type:   initiator.Type,
-		Params: params,
-	}, nil
-}
-
 // ExternalInitiatorRequest is the incoming record used to create an ExternalInitiator.
 type ExternalInitiatorRequest struct {
 	Name string `json:"name"`

--- a/core/store/models/external_initiator.go
+++ b/core/store/models/external_initiator.go
@@ -12,6 +12,26 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
+// JobSpecNotice is sent to the External Initiator when JobSpecs are created.
+type JobSpecNotice struct {
+	JobID  *ID    `json:"jobId"`
+	Type   string `json:"type"`
+	Params JSON   `json:"params,omitempty"`
+}
+
+// NewJobSpecNotice returns a new JobSpec.
+func NewJobSpecNotice(initiator Initiator, js JobSpec) (*JobSpecNotice, error) {
+	params, err := ParseJSON([]byte(initiator.Params))
+	if err != nil {
+		return nil, errors.Wrap(err, "external initiator params")
+	}
+	return &JobSpecNotice{
+		JobID:  js.ID,
+		Type:   initiator.Type,
+		Params: params,
+	}, nil
+}
+
 // ExternalInitiatorRequest is the incoming record used to create an ExternalInitiator.
 type ExternalInitiatorRequest struct {
 	Name string `json:"name"`

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -31,7 +31,7 @@ type InitiatorRequest struct {
 	InitiatorParams `json:"params,omitempty"`
 }
 
-// UnmarshalJSON ...
+// UnmarshalJSON implements the json.Unmarshaler interface.
 func (i *InitiatorRequest) UnmarshalJSON(buf []byte) error {
 	type Alias InitiatorRequest
 	temp := struct {

--- a/core/store/models/job_spec_test.go
+++ b/core/store/models/job_spec_test.go
@@ -1,6 +1,7 @@
 package models_test
 
 import (
+	"encoding/json"
 	"testing"
 	"time"
 
@@ -58,6 +59,61 @@ func TestNewInitiatorFromRequest(t *testing.T) {
 				test.jobSpec,
 			)
 			assert.Equal(t, test.want, res)
+		})
+	}
+}
+
+func TestUnmarshalInitiatorRequest(t *testing.T) {
+	tests := []struct {
+		Name   string
+		JSON   map[string]interface{}
+		Expect models.InitiatorRequest
+	}{
+		{
+			Name: "ExternalInitiator",
+			JSON: map[string]interface{}{
+				"type": "external",
+				"name": "somecoin",
+				"params": map[string]string{
+					"foo":  "bar",
+					"name": "bitcoin",
+				},
+			},
+			Expect: models.InitiatorRequest{
+				Type: models.InitiatorExternal,
+				Name: "somecoin",
+				InitiatorParams: models.InitiatorParams{
+					Name:   "bitcoin",
+					Params: `{"foo":"bar","name":"bitcoin"}`,
+				},
+			},
+		},
+		{
+			Name: "CronInitiator",
+			JSON: map[string]interface{}{
+				"type": "cron",
+				"params": map[string]string{
+					"schedule": "* * * * *",
+				},
+			},
+			Expect: models.InitiatorRequest{
+				Type: models.InitiatorCron,
+				InitiatorParams: models.InitiatorParams{
+					Schedule: "* * * * *",
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			buf, err := json.Marshal(test.JSON)
+			require.NoError(t, err)
+
+			var i models.InitiatorRequest
+			err = json.Unmarshal(buf, &i)
+			require.NoError(t, err)
+
+			assert.Equal(t, test.Expect, i)
 		})
 	}
 }

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -343,9 +343,9 @@ func (orm *ORM) FindExternalInitiator(eia *models.ExternalInitiatorAuthenticatio
 }
 
 // FindExternalInitiatorByName finds an external initiator given an authentication request
-func (orm *ORM) FindExternalInitiatorByName(name string) (models.ExternalInitiator, error) {
+func (orm *ORM) FindExternalInitiatorByName(iname string) (models.ExternalInitiator, error) {
 	var exi models.ExternalInitiator
-	return exi, orm.DB.First(&exi, "name = ?", name).Error
+	return exi, orm.DB.First(&exi, "lower(name) = lower(?)", iname).Error
 }
 
 // FindServiceAgreement looks up a ServiceAgreement by its ID.

--- a/core/web/external_initiators.go
+++ b/core/web/external_initiators.go
@@ -1,0 +1,85 @@
+package web
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/store"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+)
+
+// JobSpecNotice is sent to the External Initiator when JobSpecs are created.
+type JobSpecNotice struct {
+	JobID  *models.ID  `json:"jobId"`
+	Type   string      `json:"type"`
+	Params models.JSON `json:"params,omitempty"`
+}
+
+// NewJobSpecNotice returns a new JobSpec.
+func NewJobSpecNotice(initiator models.Initiator, js models.JobSpec) (*JobSpecNotice, error) {
+	params, err := models.ParseJSON([]byte(initiator.Params))
+	if err != nil {
+		return nil, errors.Wrap(err, "external initiator params")
+	}
+	return &JobSpecNotice{
+		JobID:  js.ID,
+		Type:   initiator.Type,
+		Params: params,
+	}, nil
+}
+
+func newNotifyHTTPRequest(jsn JobSpecNotice, ei models.ExternalInitiator) (*http.Request, error) {
+	buf, err := json.Marshal(jsn)
+	if err != nil {
+		return nil, errors.Wrap(err, "new Job Spec notification")
+	}
+	req, err := http.NewRequest(http.MethodPost, ei.URL.String(), bytes.NewBuffer(buf))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set(ExternalInitiatorAccessKeyHeader, ei.OutgoingToken)
+	req.Header.Set(ExternalInitiatorSecretHeader, ei.OutgoingSecret)
+	return req, nil
+}
+
+// NotifyExternalInitiator sends a POST notification to the External Initiator
+// responsible for initiating the Job Spec.
+func NotifyExternalInitiator(
+	js models.JobSpec,
+	store *store.Store,
+) error {
+	initrs := js.InitiatorsFor(models.InitiatorExternal)
+	if len(initrs) > 1 {
+		return errors.New("must have one or less External Initiators")
+	}
+	if len(initrs) == 0 {
+		return nil
+	}
+	initr := initrs[0]
+
+	ei, err := store.FindExternalInitiatorByName(initr.Name)
+	if err != nil {
+		return errors.Wrap(err, "external initiator")
+	}
+	notice, err := NewJobSpecNotice(initr, js)
+	if err != nil {
+		return errors.Wrap(err, "new Job Spec notification")
+	}
+
+	req, err := newNotifyHTTPRequest(*notice, ei)
+	if err != nil {
+		return errors.Wrap(err, "creating notify HTTP request")
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return errors.Wrap(err, "could not notify '%s' (%s)")
+	}
+	if !(resp.StatusCode >= 200 && resp.StatusCode < 300) {
+		return fmt.Errorf(" notify '%s' (%s) received bad response '%s'", ei.Name, ei.URL, resp.Status)
+	}
+	return nil
+}

--- a/core/web/external_initiators_test.go
+++ b/core/web/external_initiators_test.go
@@ -1,0 +1,179 @@
+package web_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/chainlink/core/web"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNotifyExternalInitiator_Notified(t *testing.T) {
+	tests := []struct {
+		Name          string
+		ExInitr       models.ExternalInitiatorRequest
+		JobSpec       models.JobSpec
+		JobSpecNotice web.JobSpecNotice
+	}{
+		{
+			"Job Spec w/ External Initiator",
+			models.ExternalInitiatorRequest{
+				Name: "somecoin",
+			},
+			models.JobSpec{
+				ID: models.NewID(),
+				Initiators: []models.Initiator{
+					models.Initiator{
+						Type: models.InitiatorExternal,
+						InitiatorParams: models.InitiatorParams{
+							Name:   "somecoin",
+							Params: `{"foo":"bar"}`,
+						},
+					},
+				},
+			},
+			web.JobSpecNotice{
+				Type:   models.InitiatorExternal,
+				Params: cltest.JSONFromString(t, `{"foo":"bar"}`),
+			},
+		},
+		{
+			"Job Spec w/ multiple initiators",
+			models.ExternalInitiatorRequest{
+				Name: "somecoin",
+			},
+			models.JobSpec{
+				ID: models.NewID(),
+				Initiators: []models.Initiator{
+					models.Initiator{
+						Type: models.InitiatorCron,
+					},
+					models.Initiator{
+						Type: models.InitiatorWeb,
+					},
+					models.Initiator{
+						Type: models.InitiatorExternal,
+						InitiatorParams: models.InitiatorParams{
+							Name:   "somecoin",
+							Params: `{"foo":"bar"}`,
+						},
+					},
+				},
+			},
+			web.JobSpecNotice{
+				Type:   models.InitiatorExternal,
+				Params: cltest.JSONFromString(t, `{"foo":"bar"}`),
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			app, cleanup := cltest.NewApplicationWithKey(t)
+			defer cleanup()
+			exInitr := struct {
+				Header http.Header
+				Body   web.JobSpecNotice
+			}{}
+			eiMockServer, assertCalled := cltest.NewHTTPMockServer(t, http.StatusOK, "POST", "",
+				func(header http.Header, body string) {
+					exInitr.Header = header
+					err := json.Unmarshal([]byte(body), &exInitr.Body)
+					require.NoError(t, err)
+				},
+			)
+			defer assertCalled()
+
+			test.ExInitr.URL = cltest.WebURL(t, eiMockServer.URL)
+			eia := models.NewExternalInitiatorAuthentication()
+			ei, err := models.NewExternalInitiator(eia, &test.ExInitr)
+			require.NoError(t, err)
+			err = app.GetStore().CreateExternalInitiator(ei)
+			require.NoError(t, err)
+
+			err = app.GetStore().CreateJob(&test.JobSpec)
+			require.NoError(t, err)
+
+			err = web.NotifyExternalInitiator(test.JobSpec, app.GetStore())
+			require.NoError(t, err)
+			assert.Equal(t,
+				ei.OutgoingToken,
+				exInitr.Header.Get(web.ExternalInitiatorAccessKeyHeader),
+			)
+			assert.Equal(t,
+				ei.OutgoingSecret,
+				exInitr.Header.Get(web.ExternalInitiatorSecretHeader),
+			)
+			test.JobSpecNotice.JobID = test.JobSpec.ID
+			assert.Equal(t, test.JobSpecNotice, exInitr.Body)
+		})
+	}
+}
+
+func TestNotifyExternalInitiator_NotNotified(t *testing.T) {
+	tests := []struct {
+		Name    string
+		ExInitr models.ExternalInitiatorRequest
+		JobSpec models.JobSpec
+	}{
+		{
+			"Job Spec w/ no Initiators",
+			models.ExternalInitiatorRequest{
+				Name: "somecoin",
+			},
+			models.JobSpec{
+				ID:         models.NewID(),
+				Initiators: []models.Initiator{},
+			},
+		},
+		{
+			"Job Spec w/ multiple initiators",
+			models.ExternalInitiatorRequest{
+				Name: "somecoin",
+			},
+			models.JobSpec{
+				ID: models.NewID(),
+				Initiators: []models.Initiator{
+					models.Initiator{
+						Type: models.InitiatorCron,
+					},
+					models.Initiator{
+						Type: models.InitiatorWeb,
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			app, cleanup := cltest.NewApplicationWithKey(t)
+			defer cleanup()
+
+			var remoteNotified bool
+			eiMockServer, _ := cltest.NewHTTPMockServer(t, http.StatusOK, "POST", "",
+				func(header http.Header, body string) {
+					remoteNotified = true
+				},
+			)
+			defer eiMockServer.Close()
+
+			test.ExInitr.URL = cltest.WebURL(t, eiMockServer.URL)
+			eia := models.NewExternalInitiatorAuthentication()
+			ei, err := models.NewExternalInitiator(eia, &test.ExInitr)
+			require.NoError(t, err)
+			err = app.GetStore().CreateExternalInitiator(ei)
+			require.NoError(t, err)
+
+			err = app.GetStore().CreateJob(&test.JobSpec)
+			require.NoError(t, err)
+
+			err = web.NotifyExternalInitiator(test.JobSpec, app.GetStore())
+			require.NoError(t, err)
+
+			require.False(t, remoteNotified)
+		})
+	}
+}

--- a/core/web/job_specs_controller.go
+++ b/core/web/job_specs_controller.go
@@ -73,7 +73,7 @@ func notifyExternalInitiator(
 
 	ei, err := store.FindExternalInitiatorByName(initr.Name)
 	if err != nil {
-		return err
+		return errors.Wrap(err, "external initiator")
 	}
 	notice, err := models.NewJobSpecNotice(initr, js)
 	if err != nil {

--- a/core/web/job_specs_controller.go
+++ b/core/web/job_specs_controller.go
@@ -41,7 +41,7 @@ func (jsc *JobSpecsController) Index(c *gin.Context, size, page, offset int) {
 }
 
 // notifyExternalInitiator sends a POST notification to the External Initiator
-// responsible for initiating the JobRun.
+// responsible for initiating the Job Spec.
 func notifyExternalInitiator(
 	c *gin.Context,
 	js models.JobSpec,

--- a/core/web/job_specs_controller_test.go
+++ b/core/web/job_specs_controller_test.go
@@ -202,7 +202,7 @@ func TestJobSpecsController_Create_HappyPath(t *testing.T) {
 func TestJobSpecsController_CreateExternalInitiator_Success(t *testing.T) {
 	t.Parallel()
 
-	var eiReceived *models.JobSpecNotice
+	var eiReceived web.JobSpecNotice
 	eiMockServer, assertCalled := cltest.NewHTTPMockServer(t, http.StatusOK, "POST", "",
 		func(header http.Header, body string) {
 			err := json.Unmarshal([]byte(body), &eiReceived)
@@ -228,7 +228,7 @@ func TestJobSpecsController_CreateExternalInitiator_Success(t *testing.T) {
 	require.NoError(t, err)
 
 	jobSpec := cltest.FixtureCreateJobViaWeb(t, app, "./testdata/external_initiator_job.json")
-	expected := &models.JobSpecNotice{
+	expected := web.JobSpecNotice{
 		JobID:  jobSpec.ID,
 		Type:   models.InitiatorExternal,
 		Params: cltest.JSONFromString(t, `{"foo":"bar"}`),

--- a/core/web/testdata/external_initiator_job.json
+++ b/core/web/testdata/external_initiator_job.json
@@ -1,0 +1,4 @@
+{
+  "initiators": [{ "type": "external", "name": "somecoin", "params": {}}],
+  "tasks": [{"type":"NoOp"}]
+}

--- a/core/web/testdata/external_initiator_job.json
+++ b/core/web/testdata/external_initiator_job.json
@@ -1,4 +1,4 @@
 {
-  "initiators": [{ "type": "external", "name": "somecoin", "params": {}}],
+  "initiators": [{ "type": "external", "name": "somecoin", "params": {"foo":"bar"}}],
   "tasks": [{"type":"NoOp"}]
 }


### PR DESCRIPTION
Notify the External Initiator by 'POST'ing to their URL information about the Job Spec and information defined by the Node Operator.

 - Add InitiatorParams field 'Params' to capture Node Operator generic
   parameters for External (remote) Initiators on new Job Specs.  For
   simplicity and leniency, a 'string' type is used.
 - Define models.JobSpecNotice to encapsulate information POST'ed to
   E.I..