### PR TITLE
Map InitiatorRequest.Name -> Initiator.Params.Name

### DIFF
--- a/core/internal/testdata/external_initiator_job.json
+++ b/core/internal/testdata/external_initiator_job.json
@@ -1,5 +1,5 @@
 {
-  "initiators": [{ "type": "external", "params": {"name": "someCoin"}}],
+  "initiators": [{ "type": "external", "name": "someCoin"}],
   "tasks": [
     { "type": "HttpGet", "params": {
         "get": "https://bitstamp.net/api/ticker/",

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -27,6 +27,7 @@ type JobSpecRequest struct {
 // InitiatorRequest represents a schema for incoming initiator requests as used by the API.
 type InitiatorRequest struct {
 	Type            string `json:"type"`
+	Name            string `json:"name,omitempty"`
 	InitiatorParams `json:"params,omitempty"`
 }
 
@@ -248,7 +249,7 @@ func NewInitiatorFromRequest(
 	initr InitiatorRequest,
 	jobSpec JobSpec,
 ) Initiator {
-	return Initiator{
+	ret := Initiator{
 		JobSpecID: jobSpec.ID,
 		// Type must be downcast to comply with Initiator
 		// deserialization logic. Ideally, Initiator.Type should be its
@@ -257,6 +258,8 @@ func NewInitiatorFromRequest(
 		Type:            strings.ToLower(initr.Type),
 		InitiatorParams: initr.InitiatorParams,
 	}
+	ret.InitiatorParams.Name = initr.Name
+	return ret
 }
 
 // UnmarshalJSON parses the raw initiator data and updates the

--- a/core/store/models/job_spec_test.go
+++ b/core/store/models/job_spec_test.go
@@ -13,6 +13,55 @@ import (
 	null "gopkg.in/guregu/null.v3"
 )
 
+func TestNewInitiatorFromRequest(t *testing.T) {
+	t.Parallel()
+
+	job := cltest.NewJob()
+	tests := []struct {
+		name     string
+		initrReq models.InitiatorRequest
+		jobSpec  models.JobSpec
+		want     models.Initiator
+	}{
+		{
+			name: models.InitiatorExternal,
+			initrReq: models.InitiatorRequest{
+				Type: models.InitiatorExternal,
+				Name: "somecoin",
+			},
+			jobSpec: job,
+			want: models.Initiator{
+				Type:      models.InitiatorExternal,
+				JobSpecID: job.ID,
+				InitiatorParams: models.InitiatorParams{
+					Name: "somecoin",
+				},
+			},
+		},
+		{
+			name: models.InitiatorWeb,
+			initrReq: models.InitiatorRequest{
+				Type: models.InitiatorWeb,
+			},
+			jobSpec: job,
+			want: models.Initiator{
+				Type:      models.InitiatorWeb,
+				JobSpecID: job.ID,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			res := models.NewInitiatorFromRequest(
+				test.initrReq,
+				test.jobSpec,
+			)
+			assert.Equal(t, test.want, res)
+		})
+	}
+}
+
 func TestNewJobFromRequest(t *testing.T) {
 	t.Parallel()
 	store, cleanup := cltest.NewStore(t)


### PR DESCRIPTION
To better support business case of ExternalInitiators, move the 'name' field to the root of the initiator request.

Old Initiator Request
   {"type":"external", "params": {"name": "somecoin", "foo": "bar"}}
New Initiator Request
   {"type":"external", "name": "somecoin", "params": {"foo": "bar"}}