### PR TITLE
Remove duplicate package conflict in chainlinkv0.5

### DIFF
--- a/evm/v0.5/package.json
+++ b/evm/v0.5/package.json
@@ -34,7 +34,6 @@
     "chai": "^4.2.0",
     "depcheck": "^0.8.3",
     "eslint": "^6.3.0",
-    "ethereumjs-abi": "^0.6.5",
     "openzeppelin-test-helpers": "^0.4.1",
     "prettier": "^1.18.2",
     "solc": "0.5.0",


### PR DESCRIPTION
Fixes:

```
warning package.json: "dependencies" has dependency "ethereumjs-abi" with range "^0.6.8" that collides with a dependency in "devDependencies" of the same name with version "^0.6.5"
```