### PR TITLE
remove cached packr file when running cldev

### DIFF
--- a/tools/bin/cldev
+++ b/tools/bin/cldev
@@ -20,6 +20,7 @@ DEFAULT_KEY_PATH=$ROOT/keys/UTC--2017-01-05T20-42-24.637Z--9ca9d2d5e04012c9ed24c
 
 mainexec() {
   mkdir -p tmp
+  rm -f core/services/*-packr.go
   go build -o tmp/cldevbuild -ldflags "$LDFLAGS" ./core/main.go
   tmp/cldevbuild $@
 }


### PR DESCRIPTION
The operator UI appears to be getting cached in the packr.go files.
Remove those when running cldev.

Signed-off-by: Ryan Hall <hall.ryan.r@gmail.com>