### PR TITLE
Use config to set Log Level

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -66,7 +66,16 @@ var minimumContractPayment = assets.NewLink(100)
 func init() {
 	gin.SetMode(gin.TestMode)
 	gomega.SetDefaultEventuallyTimeout(3 * time.Second)
-	logger.SetLogger(logger.CreateTestLogger())
+	lvl := logLevelFromEnv()
+	logger.SetLogger(logger.CreateTestLogger(lvl))
+}
+
+func logLevelFromEnv() zapcore.Level {
+	lvl := zapcore.ErrorLevel
+	if env := os.Getenv("LOG_LEVEL"); env != "" {
+		_ = lvl.Set(env)
+	}
+	return lvl
 }
 
 // TestConfig struct with test store and wsServer

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -86,10 +86,10 @@ func CreateProductionLogger(
 
 // CreateTestLogger creates a logger that directs output to PrettyConsole
 // configured for test output.
-func CreateTestLogger() *zap.Logger {
+func CreateTestLogger(lvl zapcore.Level) *zap.Logger {
 	color.NoColor = false
 	config := zap.NewProductionConfig()
-	config.Level.SetLevel(zapcore.DebugLevel)
+	config.Level.SetLevel(lvl)
 	config.OutputPaths = []string{"pretty://console"}
 	zl, err := config.Build(zap.AddCallerSkip(1))
 	if err != nil {


### PR DESCRIPTION
To make the log level configurable, source the log level through application's default settings.

Warning: this changes the default Log Level to 'INFO' from 'DEBUG'.