### PR TITLE
Fix yarn.lock file regeneration

### DIFF
--- a/tools/eslint-config/package.json
+++ b/tools/eslint-config/package.json
@@ -15,7 +15,6 @@
   },
   "peerDependencies": {
     "@chainlink/prettier-config": "0.0.1",
-    "eslint": "^6.3.0",
     "prettier": "^1.18.2",
     "typescript": "^3.6.3"
   },


### PR DESCRIPTION
Fixes

```
error An unexpected error occurred: "could not find a copy of eslint to link in /Users/alex/workspace/go/src/github.com/smartcontractkit/chainlink/node_modules/@chainlink/eslint-config/node_modules"
```