### PR TITLE
Ensure only one explorer connection per credentials

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "tslint.packageManager": "yarn"
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "tslint.packageManager": "yarn"
-}

--- a/explorer/src/__tests__/realtime.test.ts
+++ b/explorer/src/__tests__/realtime.test.ts
@@ -197,13 +197,11 @@ describe('realtime', () => {
   it('rejects multiple connections from single node', async done => {
     expect.assertions(8)
 
+    // eslint-disable-next-line prefer-const
     let ws1: WebSocket, ws2: WebSocket, ws3: WebSocket
 
-    ws1 = await newChainlinkNode(
-      ENDPOINT,
-      chainlinkNode.accessKey,
-      secret,
-    )
+    // eslint-disable-next-line prefer-const
+    ws1 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
 
     ws1.addEventListener('close', (event: WebSocket.CloseEvent) => {
       expect(ws1.readyState).toBe(WebSocket.CLOSED)
@@ -212,11 +210,7 @@ describe('realtime', () => {
       expect(event.reason).toEqual('Duplicate connection opened')
     })
 
-    ws2 = await newChainlinkNode(
-      ENDPOINT,
-      chainlinkNode.accessKey,
-      secret,
-    )
+    ws2 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
 
     ws2.addEventListener('close', (event: WebSocket.CloseEvent) => {
       expect(ws2.readyState).toBe(WebSocket.CLOSED)
@@ -227,10 +221,6 @@ describe('realtime', () => {
       done()
     })
 
-    ws3 = await newChainlinkNode(
-      ENDPOINT,
-      chainlinkNode.accessKey,
-      secret,
-    )
+    ws3 = await newChainlinkNode(ENDPOINT, chainlinkNode.accessKey, secret)
   })
 })

--- a/explorer/src/__tests__/realtime.test.ts
+++ b/explorer/src/__tests__/realtime.test.ts
@@ -195,14 +195,11 @@ describe('realtime', () => {
   })
 
   it('rejects multiple connections from single node', async done => {
-    expect.assertions(4)
+    expect.assertions(8)
 
-    const ws1: WebSocket = await newChainlinkNode(
-      ENDPOINT,
-      chainlinkNode.accessKey,
-      secret,
-    )
-    const ws2: WebSocket = await newChainlinkNode(
+    let ws1: WebSocket, ws2: WebSocket, ws3: WebSocket
+
+    ws1 = await newChainlinkNode(
       ENDPOINT,
       chainlinkNode.accessKey,
       secret,
@@ -213,8 +210,27 @@ describe('realtime', () => {
       expect(ws2.readyState).toBe(WebSocket.OPEN)
       expect(event.code).toBe(NORMAL_CLOSE)
       expect(event.reason).toEqual('Duplicate connection opened')
-      ws2.close()
+    })
+
+    ws2 = await newChainlinkNode(
+      ENDPOINT,
+      chainlinkNode.accessKey,
+      secret,
+    )
+
+    ws2.addEventListener('close', (event: WebSocket.CloseEvent) => {
+      expect(ws2.readyState).toBe(WebSocket.CLOSED)
+      expect(ws3.readyState).toBe(WebSocket.OPEN)
+      expect(event.code).toBe(NORMAL_CLOSE)
+      expect(event.reason).toEqual('Duplicate connection opened')
+      ws3.close()
       done()
     })
+
+    ws3 = await newChainlinkNode(
+      ENDPOINT,
+      chainlinkNode.accessKey,
+      secret,
+    )
   })
 })


### PR DESCRIPTION
Addresses [#168004826](https://www.pivotaltracker.com/story/show/168004826).
Also a reiteration after PR #1622 was rejected.

Ensures one connection per credentials to explorer.

This story is also partly addressed by [John's PR](github.com/smartcontractkit/chainlink/commit/aeea28e5e8dc0f18933b89e4c187a3b5d5a31795), which adds the session record in the first place

John's PR ensures that session metrics are tracked fairly and that opening a 2nd connection will update the `finishedAt` column of the 1st connection in the DB.

This PR actually closes the socket of the first connection after the second is opened.

These changes produce the side effects that when two nodes are both trying to connect, they "slinky" back and forth between connecting and then getting disconnected by the other. This should be addressed in the future to avoid creating unnecessary session records. Created a story for that [here](https://www.pivotaltracker.com/story/show/168841848).