### PR TITLE
Denormalized overrides

### DIFF
--- a/core/services/job_runner.go
+++ b/core/services/job_runner.go
@@ -190,7 +190,7 @@ func prepareTaskInput(run *models.JobRun, input models.JSON) (models.JSON, error
 		return models.JSON{}, err
 	}
 
-	if input, err = run.Overrides.Data.Merge(input); err != nil {
+	if input, err = run.Overrides.Merge(input); err != nil {
 		return models.JSON{}, err
 	}
 	return input, nil
@@ -200,7 +200,7 @@ func executeTask(run *models.JobRun, currentTaskRun *models.TaskRun, store *stor
 	taskCopy := currentTaskRun.TaskSpec // deliberately copied to keep mutations local
 
 	var err error
-	if taskCopy.Params, err = taskCopy.Params.Merge(run.Overrides.Data); err != nil {
+	if taskCopy.Params, err = taskCopy.Params.Merge(run.Overrides); err != nil {
 		currentTaskRun.Result.SetError(err)
 		return currentTaskRun.Result
 	}

--- a/core/services/runs.go
+++ b/core/services/runs.go
@@ -94,7 +94,7 @@ func NewRun(
 
 	run := job.NewRun(initiator)
 
-	run.Overrides = input
+	run.Overrides = input.Data
 	run.ApplyResult(input)
 	run.CreationHeight = models.NewBig(currentHeight)
 	run.ObservedHeight = models.NewBig(currentHeight)
@@ -245,7 +245,7 @@ func ResumePendingTask(
 		return fmt.Errorf("Attempting to resume pending run with no remaining tasks %s", run.ID.String())
 	}
 
-	run.Overrides.Merge(input)
+	run.Overrides.Merge(input.Data)
 
 	currentTaskRun.ApplyResult(input)
 	if currentTaskRun.Status.Finished() && run.TasksRemain() {
@@ -295,7 +295,7 @@ func QueueSleepingTask(
 		return fmt.Errorf("Attempting to resume sleeping run with non sleeping task %s", run.ID.String())
 	}
 
-	adapter, err := prepareAdapter(currentTaskRun, run.Overrides.Data, store)
+	adapter, err := prepareAdapter(currentTaskRun, run.Overrides, store)
 	if err != nil {
 		currentTaskRun.SetError(err)
 		run.SetError(err)

--- a/core/services/runs_test.go
+++ b/core/services/runs_test.go
@@ -47,7 +47,7 @@ func TestNewRun(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, string(models.RunStatusInProgress), string(run.Status))
 	assert.Len(t, run.TaskRuns, 1)
-	assert.Equal(t, input, run.Overrides.Data)
+	assert.Equal(t, input, run.Overrides)
 	assert.False(t, run.TaskRuns[0].Confirmations.Valid)
 }
 

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -25,6 +25,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1568280052"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1568833756"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1570087128"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1570675883"
 	gormigrate "gopkg.in/gormigrate.v1"
 )
 
@@ -114,6 +115,10 @@ func Migrate(db *gorm.DB) error {
 		{
 			ID:      "1570087128",
 			Migrate: migration1570087128.Migrate,
+		},
+		{
+			ID:      "1570675883",
+			Migrate: migration1570675883.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -32,6 +32,11 @@ import (
 // Migrate iterates through available migrations, running and tracking
 // migrations that have not been run.
 func Migrate(db *gorm.DB) error {
+	return MigrateTo(db, "")
+}
+
+// MigrateTo runs all migrations up to and including the specified migration ID
+func MigrateTo(db *gorm.DB, migrationID string) error {
 	options := *gormigrate.DefaultOptions
 	options.UseTransaction = true
 
@@ -134,7 +139,11 @@ func Migrate(db *gorm.DB) error {
 		return errors.New("database is newer than current chainlink version")
 	}
 
-	err = m.Migrate()
+	if migrationID == "" {
+		migrationID = migrations[len(migrations)-1].ID
+	}
+
+	err = m.MigrateTo(migrationID)
 	if err != nil {
 		return errors.Wrap(err, "error running migrations")
 	}

--- a/core/store/migrations/migrate_test.go
+++ b/core/store/migrations/migrate_test.go
@@ -12,18 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/assets"
 	"github.com/smartcontractkit/chainlink/core/store/migrations"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration0"
-	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1559081901"
-	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1559767166"
-	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560433987"
-	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560791143"
-	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560881846"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560881855"
-	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560886530"
-	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560924400"
-	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565139192"
-	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565210496"
-	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565291711"
-	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565877314"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
 	"github.com/smartcontractkit/chainlink/core/utils"
@@ -56,8 +45,7 @@ func TestMigrate_Migrations(t *testing.T) {
 
 	db := orm.DB
 
-	require.NoError(t, migration0.Migrate(db))
-	require.NoError(t, migration1559081901.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "1559081901"))
 
 	assert.True(t, db.HasTable("bridge_types"))
 	assert.True(t, db.HasTable("encumbrances"))
@@ -84,7 +72,7 @@ func TestMigrate_Migration1560791143(t *testing.T) {
 
 	db := orm.DB
 
-	require.NoError(t, migration0.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "0"))
 
 	tx := migration0.Tx{
 		ID:       1337,
@@ -94,12 +82,12 @@ func TestMigrate_Migration1560791143(t *testing.T) {
 	}
 	require.NoError(t, db.Create(&tx).Error)
 
-	require.NoError(t, migration1559081901.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "1559081901"))
 
 	txFound := models.Tx{}
 	require.NoError(t, db.Where("id = ?", tx.ID).Find(&txFound).Error)
 
-	require.NoError(t, migration1560791143.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "1560791143"))
 
 	txNoID := models.Tx{
 		Data:     make([]byte, 10),
@@ -119,15 +107,7 @@ func TestMigrate_Migration1560881855(t *testing.T) {
 
 	db := orm.DB
 
-	require.NoError(t, migration0.Migrate(db))
-	require.NoError(t, migration1559081901.Migrate(db))
-	require.NoError(t, migration1559767166.Migrate(db))
-	require.NoError(t, migration1560433987.Migrate(db))
-	require.NoError(t, migration1560791143.Migrate(db))
-	require.NoError(t, migration1560881846.Migrate(db))
-	require.NoError(t, migration1560886530.Migrate(db))
-	require.NoError(t, migration1560924400.Migrate(db))
-	require.NoError(t, migration1565139192.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "1560924400"))
 
 	befCreation := time.Now()
 	jobSpecID := uuid.Must(uuid.NewV4())
@@ -142,7 +122,7 @@ INSERT INTO job_runs (id, job_spec_id, overrides_id) VALUES ('%s', '%s', (SELECT
 
 	// placement of this migration is important, as it makes sure backfilling
 	//  is done if there's already a RunResult with nonzero link reward
-	require.NoError(t, migration1560881855.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "1560881855"))
 
 	rowFound := migration1560881855.LinkEarned{}
 	require.NoError(t, db.Table("link_earned").Find(&rowFound).Error)
@@ -158,12 +138,7 @@ func TestMigrate_Migration1560881846(t *testing.T) {
 
 	db := orm.DB
 
-	require.NoError(t, migration0.Migrate(db))
-	require.NoError(t, migration1559081901.Migrate(db))
-	require.NoError(t, migration1559767166.Migrate(db))
-	require.NoError(t, migration1560433987.Migrate(db))
-	require.NoError(t, migration1560791143.Migrate(db))
-	require.NoError(t, migration1560881846.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "1560881846"))
 
 	head := migration0.Head{
 		HashRaw: "dad0000000000000000000000000000000000000000000000000000000000b0d",
@@ -171,7 +146,7 @@ func TestMigrate_Migration1560881846(t *testing.T) {
 	}
 	require.NoError(t, db.Create(&head).Error)
 
-	require.NoError(t, migration1560886530.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "1560886530"))
 
 	headFound := models.Head{}
 	require.NoError(t, db.Where("id = (SELECT MAX(id) FROM heads)").Find(&headFound).Error)
@@ -185,8 +160,8 @@ func TestMigrate_Migration1565139192(t *testing.T) {
 
 	db := orm.DB
 
-	require.NoError(t, migration0.Migrate(db))
-	require.NoError(t, migration1565139192.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "1565139192"))
+
 	specNoPayment := models.NewJobFromRequest(models.JobSpecRequest{})
 	specWithPayment := models.NewJobFromRequest(models.JobSpecRequest{
 		MinPayment: assets.NewLink(5),
@@ -208,7 +183,7 @@ func TestMigrate_Migration1565210496(t *testing.T) {
 
 	db := orm.DB
 
-	require.NoError(t, migration0.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "0"))
 
 	jobSpec := migration0.JobSpec{
 		ID:        utils.NewBytes32ID(),
@@ -223,7 +198,7 @@ func TestMigrate_Migration1565210496(t *testing.T) {
 	}
 	require.NoError(t, db.Create(&jobRun).Error)
 
-	require.NoError(t, migration1565210496.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "1565210496"))
 
 	jobRunFound := models.JobRun{}
 	require.NoError(t, db.Where("id = ?", jobRun.ID).Find(&jobRunFound).Error)
@@ -237,8 +212,7 @@ func TestMigrate_Migration1565291711(t *testing.T) {
 
 	db := orm.DB
 
-	require.NoError(t, migration0.Migrate(db))
-	require.NoError(t, migration1560881855.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "1560881855"))
 
 	jobSpec := migration0.JobSpec{
 		ID:        utils.NewBytes32ID(),
@@ -253,7 +227,7 @@ func TestMigrate_Migration1565291711(t *testing.T) {
 	}
 	require.NoError(t, db.Create(&jobRun).Error)
 
-	require.NoError(t, migration1565291711.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "1565291711"))
 
 	jobRunFound := models.JobRun{}
 	require.NoError(t, db.Where("id = ?", jobRun.ID).Find(&jobRunFound).Error)
@@ -266,7 +240,7 @@ func TestMigrate_Migration1565877314(t *testing.T) {
 
 	db := orm.DB
 
-	require.NoError(t, migration0.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "0"))
 
 	exi := migration0.ExternalInitiator{
 		AccessKey:    "access_key",
@@ -275,11 +249,9 @@ func TestMigrate_Migration1565877314(t *testing.T) {
 	}
 	require.NoError(t, db.Create(&exi).Error)
 
-	require.NoError(t, migration1565210496.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "1565877314"))
 
-	require.NoError(t, migration1565877314.Migrate(db))
-
-	exiFound := migration1565877314.ExternalInitiator{}
+	exiFound := models.ExternalInitiator{}
 	require.NoError(t, db.Where("id = ?", exi.ID).Find(&exiFound).Error)
 	assert.Equal(t, "access_key", exiFound.Name)
 	assert.Equal(t, "https://unset.url", exiFound.URL.String())
@@ -291,7 +263,7 @@ func TestMigrate_Migration1570675883(t *testing.T) {
 
 	db := orm.DB
 
-	require.NoError(t, migration0.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "0"))
 
 	overrides := models.RunResult{
 		Data: cltest.JSONFromString(t, `{"a": "b"}`),

--- a/core/store/migrations/migrate_test.go
+++ b/core/store/migrations/migrate_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565210496"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565291711"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1565877314"
-	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1570675883"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
 	"github.com/smartcontractkit/chainlink/core/utils"
@@ -313,7 +312,7 @@ func TestMigrate_Migration1570675883(t *testing.T) {
 	}
 	require.NoError(t, db.Create(&jobRun).Error)
 
-	require.NoError(t, migration1570675883.Migrate(db))
+	require.NoError(t, migrations.MigrateTo(db, "1570675883"))
 
 	jobRunFound := models.JobRun{}
 	require.NoError(t, db.Where("id = ?", jobRun.ID).Find(&jobRunFound).Error)

--- a/core/store/migrations/migration1570675883/migrate.go
+++ b/core/store/migrations/migration1570675883/migrate.go
@@ -1,0 +1,21 @@
+package migration1570675883
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+ALTER TABLE job_runs ADD COLUMN "overrides" text;
+UPDATE job_runs
+SET "overrides" = (
+	SELECT data
+	FROM run_results
+	WHERE overrides_id = run_results.id
+);
+DELETE FROM run_results
+WHERE id IN (
+	SELECT overrides_id
+	FROM job_runs
+);`).Error
+}

--- a/core/store/models/job_run.go
+++ b/core/store/models/job_run.go
@@ -31,8 +31,7 @@ type JobRun struct {
 	InitiatorID    uint         `json:"-"`
 	CreationHeight *Big         `json:"creationHeight"`
 	ObservedHeight *Big         `json:"observedHeight"`
-	Overrides      RunResult    `json:"overrides"`
-	OverridesID    uint         `json:"-"`
+	Overrides      JSON         `json:"overrides"`
 	DeletedAt      null.Time    `json:"-" gorm:"index"`
 	Payment        *assets.Link `json:"payment,omitempty"`
 }

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -226,7 +226,6 @@ func (orm *ORM) preloadJobRuns() *gorm.DB {
 			return db.Unscoped()
 		}).
 		Preload("RunRequest").
-		Preload("Overrides").
 		Preload("TaskRuns", func(db *gorm.DB) *gorm.DB {
 			return preloadTaskRuns(db).Order("task_spec_id asc")
 		}).


### PR DESCRIPTION
Overrides are stored as RunResults but they don't use most of the RunResult interface or data, so we can store them as a string field on JobRuns and save a bunch.

Didn't remove the overrides_id column to avoid downtime.