### PR TITLE
Add timeout to TriggerClock#trigger

### DIFF
--- a/core/services/synchronization/stats_pusher_test.go
+++ b/core/services/synchronization/stats_pusher_test.go
@@ -55,7 +55,7 @@ func TestStatsPusher_ClockTrigger(t *testing.T) {
 	wsserver, wscleanup := cltest.NewEventWebSocketServer(t)
 	defer wscleanup()
 
-	clock := cltest.NewTriggerClock()
+	clock := cltest.NewTriggerClock(t)
 	pusher := synchronization.NewStatsPusher(store.ORM, wsserver.URL, "", "", clock)
 	pusher.Start()
 	defer pusher.Close()
@@ -79,7 +79,7 @@ func TestStatsPusher_NoAckLeavesEvent(t *testing.T) {
 	wsserver, wscleanup := cltest.NewEventWebSocketServer(t)
 	defer wscleanup()
 
-	clock := cltest.NewTriggerClock()
+	clock := cltest.NewTriggerClock(t)
 	pusher := synchronization.NewStatsPusher(store.ORM, wsserver.URL, "", "", clock)
 	pusher.Start()
 	defer pusher.Close()
@@ -105,7 +105,7 @@ func TestStatsPusher_BadSyncLeavesEvent(t *testing.T) {
 	wsserver, wscleanup := cltest.NewEventWebSocketServer(t)
 	defer wscleanup()
 
-	clock := cltest.NewTriggerClock()
+	clock := cltest.NewTriggerClock(t)
 	pusher := synchronization.NewStatsPusher(store.ORM, wsserver.URL, "", "", clock)
 	pusher.Start()
 	defer pusher.Close()


### PR DESCRIPTION
Without a timeout this maxes the go test timeout (10mins) and only gives
a stack trace. This shortens the timeout and gives a human readable
error.