### PR TITLE
bump minimum timeouts for solidity tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 # dependencies
 node_modules/
-vendor/
-.vendor-new/
 tmp/
 
 /chainlink

--- a/evm/package.json
+++ b/evm/package.json
@@ -15,7 +15,7 @@
     "slither": "truffle compile --quiet && slither .",
     "pretest": "yarn build",
     "test:v1": "tsc && truffle test ./dist/test/*",
-    "test:v2": "jest --testTimeout 10000",
+    "test:v2": "jest --testTimeout 20000",
     "test": "yarn test:v1 && yarn test:v2",
     "format": "prettier --write \"**/*\"",
     "prepublishOnly": "yarn build && yarn lint && yarn test",

--- a/evm/testv2/UpdatableConsumer.test.ts
+++ b/evm/testv2/UpdatableConsumer.test.ts
@@ -100,7 +100,7 @@ describe('UpdatableConsumer', () => {
     uc = await updatableConsumerFactory
       .connect(roles.defaultAccount)
       .deploy(specId, ens.address, domainNode)
-  }, 10000)
+  })
 
   describe('constructor', () => {
     it('pulls the token contract address from the resolver', async () => {


### PR DESCRIPTION
Don't love having to increase this. Ideally'd make it overridable per machine.