### PR TITLE
Respect JobSpec#MinPayment

### DIFF
--- a/core/services/runs.go
+++ b/core/services/runs.go
@@ -119,7 +119,8 @@ func NewRun(
 		run.SetError(err)
 	}
 
-	cost := assets.NewLink(0)
+	cost := &assets.Link{}
+	cost.Set(job.MinPayment)
 	for i, taskRun := range run.TaskRuns {
 		adapter, err := adapters.For(taskRun.TaskSpec, store)
 
@@ -128,9 +129,11 @@ func NewRun(
 			return &run, nil
 		}
 
-		mp := adapter.MinContractPayment()
-		if mp != nil {
-			cost.Add(cost, mp)
+		if job.MinPayment.IsZero() {
+			mp := adapter.MinContractPayment()
+			if mp != nil {
+				cost.Add(cost, mp)
+			}
 		}
 
 		if currentHeight != nil {

--- a/core/services/runs_test.go
+++ b/core/services/runs_test.go
@@ -74,45 +74,85 @@ func TestNewRun_MeetsMinimumPayment(t *testing.T) {
 	}
 }
 
-func TestNewRun_requiredPayment(t *testing.T) {
+func TestNewRun_jobSpecMinPayment(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	input := models.JSON{Result: gjson.Parse(`{"address":"0xdfcfc2b9200dbb10952c2b7cce60fc7260e03c6f"}`)}
 
-	_, bt := cltest.NewBridgeType(t, "timecube", "http://http://timecube.2enp.com/")
-	bt.MinimumContractPayment = assets.NewLink(10)
-	require.NoError(t, store.CreateBridgeType(bt))
-
 	tests := []struct {
-		name                  string
-		payment               *assets.Link
-		minimumConfigPayment  *assets.Link
-		minimumJobSpecPayment *assets.Link
-		expectedStatus        models.RunStatus
+		name           string
+		payment        *assets.Link
+		minPayment     *assets.Link
+		expectedStatus models.RunStatus
 	}{
-		{"creates runnable job", nil, assets.NewLink(0), assets.NewLink(0), models.RunStatusInProgress},
-		{"insufficient payment as specified by config", assets.NewLink(9), assets.NewLink(10), assets.NewLink(0), models.RunStatusErrored},
-		{"sufficient payment as specified by config", assets.NewLink(10), assets.NewLink(10), assets.NewLink(0), models.RunStatusInProgress},
-		{"insufficient payment as specified by adapter", assets.NewLink(9), assets.NewLink(0), assets.NewLink(0), models.RunStatusErrored},
-		{"sufficient payment as specified by adapter", assets.NewLink(10), assets.NewLink(0), assets.NewLink(0), models.RunStatusInProgress},
-		{"insufficient payment as specified by jobSpec MinPayment", assets.NewLink(9), assets.NewLink(0), assets.NewLink(10), models.RunStatusErrored},
-		{"sufficient payment as specified by jobSpec MinPayment", assets.NewLink(10), assets.NewLink(0), assets.NewLink(10), models.RunStatusInProgress},
+		{"payment < min payment", assets.NewLink(9), assets.NewLink(10), models.RunStatusErrored},
+		{"payment = min payment", assets.NewLink(10), assets.NewLink(10), models.RunStatusInProgress},
+		{"payment > min payment", assets.NewLink(11), assets.NewLink(10), models.RunStatusInProgress},
+		{"payment is nil", nil, assets.NewLink(10), models.RunStatusInProgress},
 	}
 
 	for _, tt := range tests {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
-			store.Config.Set("MINIMUM_CONTRACT_PAYMENT", test.minimumConfigPayment)
-
 			jobSpec := models.NewJob()
 			jobSpec.Tasks = []models.TaskSpec{{
-				Type: "timecube",
+				Type: "noop",
 			}}
 			jobSpec.Initiators = []models.Initiator{{
 				Type: models.InitiatorEthLog,
 			}}
-			jobSpec.MinPayment = test.minimumJobSpecPayment
+			jobSpec.MinPayment = test.minPayment
+
+			inputResult := models.RunResult{Data: input}
+
+			run, err := services.NewRun(jobSpec, jobSpec.Initiators[0], inputResult, nil, store, test.payment)
+			assert.NoError(t, err)
+			assert.Equal(t, string(test.expectedStatus), string(run.Status))
+		})
+	}
+}
+
+func TestNewRun_taskSumPayment(t *testing.T) {
+	store, cleanup := cltest.NewStore(t)
+	defer cleanup()
+
+	_, bta := cltest.NewBridgeType(t, "timecube_a", "http://http://timecube.2enp.com/")
+	bta.MinimumContractPayment = assets.NewLink(8)
+	require.NoError(t, store.CreateBridgeType(bta))
+
+	_, btb := cltest.NewBridgeType(t, "timecube_b", "http://http://timecube.2enp.com/")
+	btb.MinimumContractPayment = assets.NewLink(7)
+	require.NoError(t, store.CreateBridgeType(btb))
+
+	store.Config.Set("MINIMUM_CONTRACT_PAYMENT", "1")
+
+	input := models.JSON{Result: gjson.Parse(`{"address":"0xdfcfc2b9200dbb10952c2b7cce60fc7260e03c6f"}`)}
+
+	tests := []struct {
+		name           string
+		payment        *assets.Link
+		expectedStatus models.RunStatus
+	}{
+		{"payment < min payment", assets.NewLink(15), models.RunStatusErrored},
+		{"payment = min payment", assets.NewLink(16), models.RunStatusInProgress},
+		{"payment > min payment", assets.NewLink(17), models.RunStatusInProgress},
+		{"payment is nil", nil, models.RunStatusInProgress},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			jobSpec := models.NewJob()
+			jobSpec.Tasks = []models.TaskSpec{
+				{Type: "timecube_a"},
+				{Type: "timecube_b"},
+				{Type: "ethtx"},
+				{Type: "noop"},
+			}
+			jobSpec.Initiators = []models.Initiator{{
+				Type: models.InitiatorEthLog,
+			}}
 
 			inputResult := models.RunResult{Data: input}
 

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -268,7 +268,7 @@ func (c Config) MinOutgoingConfirmations() uint64 {
 	return c.viper.GetUint64(EnvVarName("MinOutgoingConfirmations"))
 }
 
-// MinimumContractPayment represents the minimum amount of ETH that must be
+// MinimumContractPayment represents the minimum amount of LINK that must be
 // supplied for a contract to be considered.
 func (c Config) MinimumContractPayment() *assets.Link {
 	return c.getWithFallback("MinimumContractPayment", parseLink).(*assets.Link)


### PR DESCRIPTION
[Fixes #164214281]

I re-wrote the tests to better capture how payment is checked. The cost is:

- `JobSpec#MinPayment` when > 0
- Sum of task adapters `MinContractPayment` when `JobSpec#MinPayment = 0`

The previous test data only had a single task and ignored the `MINIMUM_CONTRACT_PAYMENT` in config. 

```
# was not used by a task and was falling back to the default value of 1000000000000000000
store.Config.Set("MINIMUM_CONTRACT_PAYMENT", test.minimumConfigPayment)
```