### PR TITLE
Quieter stats pusher

### DIFF
--- a/core/services/synchronization/stats_pusher.go
+++ b/core/services/synchronization/stats_pusher.go
@@ -72,7 +72,6 @@ func (sp *StatsPusher) Start() error {
 	ctx, cancel := context.WithCancel(context.Background())
 	sp.cancel = cancel
 	go sp.eventLoop(ctx)
-	logger.Infow("Started StatsPusher")
 	return nil
 }
 
@@ -121,7 +120,7 @@ func (sp *StatsPusher) eventLoop(parentCtx context.Context) {
 }
 
 func (sp *StatsPusher) pusherLoop(parentCtx context.Context) error {
-	logger.Debugw("Entered StatsPusher push loop")
+	logger.Debugw("Started StatsPusher")
 
 	for {
 		select {

--- a/core/store/orm/log_wrapper.go
+++ b/core/store/orm/log_wrapper.go
@@ -27,6 +27,6 @@ func (l *ormLogWrapper) Print(args ...interface{}) {
 	case "sql":
 		l.Debugw(args[3].(string), "time", args[2], "rows_affected", args[5])
 	default:
-		l.Info(args...)
+		// Don't log these, only seems to be the callback logs which aren't super useful
 	}
 }


### PR DESCRIPTION
When you spend a lot of time reading test output/logs, the StatsPusher stands up as a little noisier than other things.