### PR TITLE
Ensure DB lock is held before each tx/query

### DIFF
--- a/core/gracefulpanic/channel.go
+++ b/core/gracefulpanic/channel.go
@@ -1,0 +1,16 @@
+package gracefulpanic
+
+import "sync"
+
+var ch = make(chan struct{})
+var panicOnce sync.Once
+
+func Panic() {
+	panicOnce.Do(func() {
+		go close(ch)
+	})
+}
+
+func Wait() <-chan struct{} {
+	return ch
+}

--- a/core/services/subscription_test.go
+++ b/core/services/subscription_test.go
@@ -123,8 +123,7 @@ func TestServices_ReceiveLogRequest_IgnoredLogWithRemovedFlag(t *testing.T) {
 		},
 	}
 
-	originalCount := 0
-	err := store.ORM.DB.Model(&models.JobRun{}).Count(&originalCount).Error
+	_, err := store.ORM.CountOf(&models.JobRun{})
 	require.NoError(t, err)
 
 	jm := new(mocks.RunManager)

--- a/core/services/synchronization/stats_pusher_test.go
+++ b/core/services/synchronization/stats_pusher_test.go
@@ -8,6 +8,7 @@ import (
 	"chainlink/core/store/models"
 	"chainlink/core/store/orm"
 
+	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -61,7 +62,9 @@ func TestStatsPusher_ClockTrigger(t *testing.T) {
 	pusher.Start()
 	defer pusher.Close()
 
-	err := store.DB.Save(&models.SyncEvent{Body: string("")}).Error
+	err := store.ORM.RawDB(func(db *gorm.DB) error {
+		return db.Save(&models.SyncEvent{Body: string("")}).Error
+	})
 	require.NoError(t, err)
 
 	clock.Trigger()
@@ -128,7 +131,7 @@ func TestStatsPusher_BadSyncLeavesEvent(t *testing.T) {
 }
 
 func lenSyncEvents(t *testing.T, orm *orm.ORM) int {
-	var count int
-	require.NoError(t, orm.DB.Model(&models.SyncEvent{}).Count(&count).Error)
+	count, err := orm.CountOf(&models.SyncEvent{})
+	require.NoError(t, err)
 	return count
 }

--- a/core/store/migrations/migrate_test.go
+++ b/core/store/migrations/migrate_test.go
@@ -17,6 +17,7 @@ import (
 	"chainlink/core/utils"
 
 	"github.com/gofrs/uuid"
+	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	gormigrate "gopkg.in/gormigrate.v1"
@@ -30,7 +31,7 @@ func bootstrapORM(t *testing.T) (*orm.ORM, func()) {
 	cleanupDB := cltest.PrepareTestDB(tc)
 	orm, err := orm.NewORM(orm.NormalizedDatabaseURL(config), config.DatabaseTimeout())
 	require.NoError(t, err)
-	orm.DB.LogMode(true)
+	orm.SetLogging(true)
 
 	return orm, func() {
 		assert.NoError(t, orm.Close())
@@ -44,273 +45,293 @@ func TestMigrate_Migrations(t *testing.T) {
 	orm, cleanup := bootstrapORM(t)
 	defer cleanup()
 
-	db := orm.DB
+	err := orm.RawDB(func(db *gorm.DB) error {
+		require.NoError(t, migrations.Migrate(db))
 
-	require.NoError(t, migrations.Migrate(db))
-
-	assert.True(t, db.HasTable("bridge_types"))
-	assert.True(t, db.HasTable("encumbrances"))
-	assert.True(t, db.HasTable("external_initiators"))
-	assert.True(t, db.HasTable("heads"))
-	assert.True(t, db.HasTable("job_specs"))
-	assert.True(t, db.HasTable("initiators"))
-	assert.True(t, db.HasTable("job_runs"))
-	assert.True(t, db.HasTable("keys"))
-	assert.True(t, db.HasTable("run_requests"))
-	assert.True(t, db.HasTable("run_results"))
-	assert.True(t, db.HasTable("service_agreements"))
-	assert.True(t, db.HasTable("sessions"))
-	assert.True(t, db.HasTable("task_runs"))
-	assert.True(t, db.HasTable("task_specs"))
-	assert.True(t, db.HasTable("tx_attempts"))
-	assert.True(t, db.HasTable("txes"))
-	assert.True(t, db.HasTable("users"))
+		assert.True(t, db.HasTable("bridge_types"))
+		assert.True(t, db.HasTable("encumbrances"))
+		assert.True(t, db.HasTable("external_initiators"))
+		assert.True(t, db.HasTable("heads"))
+		assert.True(t, db.HasTable("job_specs"))
+		assert.True(t, db.HasTable("initiators"))
+		assert.True(t, db.HasTable("job_runs"))
+		assert.True(t, db.HasTable("keys"))
+		assert.True(t, db.HasTable("run_requests"))
+		assert.True(t, db.HasTable("run_results"))
+		assert.True(t, db.HasTable("service_agreements"))
+		assert.True(t, db.HasTable("sessions"))
+		assert.True(t, db.HasTable("task_runs"))
+		assert.True(t, db.HasTable("task_specs"))
+		assert.True(t, db.HasTable("tx_attempts"))
+		assert.True(t, db.HasTable("txes"))
+		assert.True(t, db.HasTable("users"))
+		return nil
+	})
+	require.NoError(t, err)
 }
 
 func TestMigrate_Migration1560791143(t *testing.T) {
 	orm, cleanup := bootstrapORM(t)
 	defer cleanup()
 
-	db := orm.DB
+	err := orm.RawDB(func(db *gorm.DB) error {
+		require.NoError(t, migrations.MigrateTo(db, "0"))
 
-	require.NoError(t, migrations.MigrateTo(db, "0"))
+		tx := migration0.Tx{
+			ID:       1337,
+			Data:     make([]byte, 10),
+			Value:    models.NewBig(big.NewInt(1)),
+			GasPrice: models.NewBig(big.NewInt(127)),
+		}
+		require.NoError(t, db.Create(&tx).Error)
 
-	tx := migration0.Tx{
-		ID:       1337,
-		Data:     make([]byte, 10),
-		Value:    models.NewBig(big.NewInt(1)),
-		GasPrice: models.NewBig(big.NewInt(127)),
-	}
-	require.NoError(t, db.Create(&tx).Error)
+		require.NoError(t, migrations.MigrateTo(db, "1559081901"))
 
-	require.NoError(t, migrations.MigrateTo(db, "1559081901"))
+		txFound := models.Tx{}
+		require.NoError(t, db.Where("id = ?", tx.ID).Find(&txFound).Error)
 
-	txFound := models.Tx{}
-	require.NoError(t, db.Where("id = ?", tx.ID).Find(&txFound).Error)
+		require.NoError(t, migrations.MigrateTo(db, "1560791143"))
 
-	require.NoError(t, migrations.MigrateTo(db, "1560791143"))
+		txNoID := models.Tx{
+			Data:     make([]byte, 10),
+			Value:    models.NewBig(big.NewInt(2)),
+			GasPrice: models.NewBig(big.NewInt(119)),
+		}
+		require.NoError(t, db.Create(&txNoID).Error)
+		assert.Equal(t, uint64(1338), txNoID.ID)
 
-	txNoID := models.Tx{
-		Data:     make([]byte, 10),
-		Value:    models.NewBig(big.NewInt(2)),
-		GasPrice: models.NewBig(big.NewInt(119)),
-	}
-	require.NoError(t, db.Create(&txNoID).Error)
-	assert.Equal(t, uint64(1338), txNoID.ID)
-
-	noIDTxFound := models.Tx{}
-	require.NoError(t, db.Where("id = ?", tx.ID).Find(&noIDTxFound).Error)
+		noIDTxFound := models.Tx{}
+		require.NoError(t, db.Where("id = ?", tx.ID).Find(&noIDTxFound).Error)
+		return nil
+	})
+	require.NoError(t, err)
 }
 
 func TestMigrate_Migration1560881855(t *testing.T) {
 	orm, cleanup := bootstrapORM(t)
 	defer cleanup()
 
-	db := orm.DB
+	err := orm.RawDB(func(db *gorm.DB) error {
+		require.NoError(t, migrations.MigrateTo(db, "1560924400"))
 
-	require.NoError(t, migrations.MigrateTo(db, "1560924400"))
-
-	befCreation := time.Now()
-	jobSpecID := uuid.Must(uuid.NewV4())
-	jobID := uuid.Must(uuid.NewV4())
-	query := fmt.Sprintf(`
+		befCreation := time.Now()
+		jobSpecID := uuid.Must(uuid.NewV4())
+		jobID := uuid.Must(uuid.NewV4())
+		query := fmt.Sprintf(`
 INSERT INTO run_results (amount) VALUES (2);
 INSERT INTO job_specs (id) VALUES ('%s');
 INSERT INTO job_runs (id, job_spec_id, overrides_id) VALUES ('%s', '%s', (SELECT id from run_results order by id DESC limit 1));
 `, jobSpecID, jobID, jobSpecID)
-	require.NoError(t, db.Exec(query).Error)
-	aftCreation := time.Now()
+		require.NoError(t, db.Exec(query).Error)
+		aftCreation := time.Now()
 
-	// placement of this migration is important, as it makes sure backfilling
-	//  is done if there's already a RunResult with nonzero link reward
-	require.NoError(t, migrations.MigrateTo(db, "1560881855"))
+		// placement of this migration is important, as it makes sure backfilling
+		//  is done if there's already a RunResult with nonzero link reward
+		require.NoError(t, migrations.MigrateTo(db, "1560881855"))
 
-	rowFound := migration1560881855.LinkEarned{}
-	require.NoError(t, db.Table("link_earned").Find(&rowFound).Error)
-	assert.Equal(t, jobSpecID.String(), rowFound.JobSpecID)
-	assert.Equal(t, jobID.String(), rowFound.JobRunID)
-	assert.Equal(t, assets.NewLink(2), rowFound.Earned)
-	assert.True(t, true, rowFound.EarnedAt.After(aftCreation), rowFound.EarnedAt.Before(befCreation))
+		rowFound := migration1560881855.LinkEarned{}
+		require.NoError(t, db.Table("link_earned").Find(&rowFound).Error)
+		assert.Equal(t, jobSpecID.String(), rowFound.JobSpecID)
+		assert.Equal(t, jobID.String(), rowFound.JobRunID)
+		assert.Equal(t, assets.NewLink(2), rowFound.Earned)
+		assert.True(t, true, rowFound.EarnedAt.After(aftCreation), rowFound.EarnedAt.Before(befCreation))
+		return nil
+	})
+	require.NoError(t, err)
 }
 
 func TestMigrate_Migration1560881846(t *testing.T) {
 	orm, cleanup := bootstrapORM(t)
 	defer cleanup()
 
-	db := orm.DB
+	err := orm.RawDB(func(db *gorm.DB) error {
+		require.NoError(t, migrations.MigrateTo(db, "1560881846"))
 
-	require.NoError(t, migrations.MigrateTo(db, "1560881846"))
+		head := migration0.Head{
+			HashRaw: "dad0000000000000000000000000000000000000000000000000000000000b0d",
+			Number:  8616460799,
+		}
+		require.NoError(t, db.Create(&head).Error)
 
-	head := migration0.Head{
-		HashRaw: "dad0000000000000000000000000000000000000000000000000000000000b0d",
-		Number:  8616460799,
-	}
-	require.NoError(t, db.Create(&head).Error)
+		require.NoError(t, migrations.MigrateTo(db, "1560886530"))
 
-	require.NoError(t, migrations.MigrateTo(db, "1560886530"))
-
-	headFound := models.Head{}
-	require.NoError(t, db.Where("id = (SELECT MAX(id) FROM heads)").Find(&headFound).Error)
-	assert.Equal(t, "0xdad0000000000000000000000000000000000000000000000000000000000b0d", headFound.Hash.Hex())
-	assert.Equal(t, int64(8616460799), headFound.Number)
+		headFound := models.Head{}
+		require.NoError(t, db.Where("id = (SELECT MAX(id) FROM heads)").Find(&headFound).Error)
+		assert.Equal(t, "0xdad0000000000000000000000000000000000000000000000000000000000b0d", headFound.Hash.Hex())
+		assert.Equal(t, int64(8616460799), headFound.Number)
+		return nil
+	})
+	require.NoError(t, err)
 }
 
 func TestMigrate_Migration1565139192(t *testing.T) {
 	orm, cleanup := bootstrapORM(t)
 	defer cleanup()
 
-	db := orm.DB
+	err := orm.RawDB(func(db *gorm.DB) error {
+		require.NoError(t, migrations.MigrateTo(db, "1565139192"))
 
-	require.NoError(t, migrations.MigrateTo(db, "1565139192"))
+		specNoPayment := models.NewJobFromRequest(models.JobSpecRequest{})
+		specWithPayment := models.NewJobFromRequest(models.JobSpecRequest{
+			MinPayment: *assets.NewLink(5),
+		})
+		specOneFound := models.JobSpec{}
+		specTwoFound := models.JobSpec{}
 
-	specNoPayment := models.NewJobFromRequest(models.JobSpecRequest{})
-	specWithPayment := models.NewJobFromRequest(models.JobSpecRequest{
-		MinPayment: *assets.NewLink(5),
+		require.NoError(t, db.Create(&specWithPayment).Error)
+		require.NoError(t, db.Create(&specNoPayment).Error)
+		require.NoError(t, db.Where("id = ?", specNoPayment.ID).Find(&specOneFound).Error)
+		require.Equal(t, *assets.NewLink(0), specNoPayment.MinPayment)
+		require.NoError(t, db.Where("id = ?", specWithPayment.ID).Find(&specTwoFound).Error)
+		require.Equal(t, *assets.NewLink(5), specWithPayment.MinPayment)
+		return nil
 	})
-	specOneFound := models.JobSpec{}
-	specTwoFound := models.JobSpec{}
-
-	require.NoError(t, db.Create(&specWithPayment).Error)
-	require.NoError(t, db.Create(&specNoPayment).Error)
-	require.NoError(t, db.Where("id = ?", specNoPayment.ID).Find(&specOneFound).Error)
-	require.Equal(t, *assets.NewLink(0), specNoPayment.MinPayment)
-	require.NoError(t, db.Where("id = ?", specWithPayment.ID).Find(&specTwoFound).Error)
-	require.Equal(t, *assets.NewLink(5), specWithPayment.MinPayment)
+	require.NoError(t, err)
 }
 
 func TestMigrate_Migration1565210496(t *testing.T) {
 	orm, cleanup := bootstrapORM(t)
 	defer cleanup()
 
-	db := orm.DB
+	err := orm.RawDB(func(db *gorm.DB) error {
+		require.NoError(t, migrations.MigrateTo(db, "0"))
 
-	require.NoError(t, migrations.MigrateTo(db, "0"))
+		jobSpec := migration0.JobSpec{
+			ID:        utils.NewBytes32ID(),
+			CreatedAt: time.Now(),
+		}
+		require.NoError(t, db.Create(&jobSpec).Error)
+		jobRun := migration0.JobRun{
+			ID:             utils.NewBytes32ID(),
+			JobSpecID:      jobSpec.ID,
+			ObservedHeight: "115792089237316195423570985008687907853269984665640564039457584007913129639936",
+			CreationHeight: "0",
+		}
+		require.NoError(t, db.Create(&jobRun).Error)
 
-	jobSpec := migration0.JobSpec{
-		ID:        utils.NewBytes32ID(),
-		CreatedAt: time.Now(),
-	}
-	require.NoError(t, db.Create(&jobSpec).Error)
-	jobRun := migration0.JobRun{
-		ID:             utils.NewBytes32ID(),
-		JobSpecID:      jobSpec.ID,
-		ObservedHeight: "115792089237316195423570985008687907853269984665640564039457584007913129639936",
-		CreationHeight: "0",
-	}
-	require.NoError(t, db.Create(&jobRun).Error)
+		require.NoError(t, migrations.MigrateTo(db, "1565210496"))
 
-	require.NoError(t, migrations.MigrateTo(db, "1565210496"))
-
-	jobRunFound := models.JobRun{}
-	require.NoError(t, db.Where("id = ?", jobRun.ID).Find(&jobRunFound).Error)
-	assert.Equal(t, "115792089237316195423570985008687907853269984665640564039457584007913129639936", jobRunFound.ObservedHeight.String())
-	assert.Equal(t, "0", jobRunFound.CreationHeight.String())
+		jobRunFound := models.JobRun{}
+		require.NoError(t, db.Where("id = ?", jobRun.ID).Find(&jobRunFound).Error)
+		assert.Equal(t, "115792089237316195423570985008687907853269984665640564039457584007913129639936", jobRunFound.ObservedHeight.String())
+		assert.Equal(t, "0", jobRunFound.CreationHeight.String())
+		return nil
+	})
+	require.NoError(t, err)
 }
 
 func TestMigrate_Migration1565291711(t *testing.T) {
 	orm, cleanup := bootstrapORM(t)
 	defer cleanup()
 
-	db := orm.DB
+	err := orm.RawDB(func(db *gorm.DB) error {
+		require.NoError(t, migrations.MigrateTo(db, "1560881855"))
 
-	require.NoError(t, migrations.MigrateTo(db, "1560881855"))
+		jobSpec := migration0.JobSpec{
+			ID:        utils.NewBytes32ID(),
+			CreatedAt: time.Now(),
+		}
+		require.NoError(t, db.Create(&jobSpec).Error)
+		jobRun := migration0.JobRun{
+			ID:             utils.NewBytes32ID(),
+			JobSpecID:      jobSpec.ID,
+			CreationHeight: "0",
+			ObservedHeight: "0",
+		}
+		require.NoError(t, db.Create(&jobRun).Error)
 
-	jobSpec := migration0.JobSpec{
-		ID:        utils.NewBytes32ID(),
-		CreatedAt: time.Now(),
-	}
-	require.NoError(t, db.Create(&jobSpec).Error)
-	jobRun := migration0.JobRun{
-		ID:             utils.NewBytes32ID(),
-		JobSpecID:      jobSpec.ID,
-		CreationHeight: "0",
-		ObservedHeight: "0",
-	}
-	require.NoError(t, db.Create(&jobRun).Error)
+		require.NoError(t, migrations.MigrateTo(db, "1565291711"))
 
-	require.NoError(t, migrations.MigrateTo(db, "1565291711"))
-
-	jobRunFound := models.JobRun{}
-	require.NoError(t, db.Where("id = ?", jobRun.ID).Find(&jobRunFound).Error)
-	assert.Equal(t, jobRun.ID, jobRunFound.ID.String())
+		jobRunFound := models.JobRun{}
+		require.NoError(t, db.Where("id = ?", jobRun.ID).Find(&jobRunFound).Error)
+		assert.Equal(t, jobRun.ID, jobRunFound.ID.String())
+		return nil
+	})
+	require.NoError(t, err)
 }
 
 func TestMigrate_Migration1565877314(t *testing.T) {
 	orm, cleanup := bootstrapORM(t)
 	defer cleanup()
 
-	db := orm.DB
+	err := orm.RawDB(func(db *gorm.DB) error {
+		require.NoError(t, migrations.MigrateTo(db, "0"))
 
-	require.NoError(t, migrations.MigrateTo(db, "0"))
+		exi := migration0.ExternalInitiator{
+			AccessKey:    "access_key",
+			Salt:         "salt",
+			HashedSecret: "hashed_secret",
+		}
+		require.NoError(t, db.Create(&exi).Error)
 
-	exi := migration0.ExternalInitiator{
-		AccessKey:    "access_key",
-		Salt:         "salt",
-		HashedSecret: "hashed_secret",
-	}
-	require.NoError(t, db.Create(&exi).Error)
+		require.NoError(t, migrations.MigrateTo(db, "1565877314"))
 
-	require.NoError(t, migrations.MigrateTo(db, "1565877314"))
-
-	exiFound := models.ExternalInitiator{}
-	require.NoError(t, db.Where("id = ?", exi.ID).Find(&exiFound).Error)
-	assert.Equal(t, "access_key", exiFound.Name)
-	assert.Equal(t, "https://unset.url", exiFound.URL.String())
+		exiFound := models.ExternalInitiator{}
+		require.NoError(t, db.Where("id = ?", exi.ID).Find(&exiFound).Error)
+		assert.Equal(t, "access_key", exiFound.Name)
+		assert.Equal(t, "https://unset.url", exiFound.URL.String())
+		return nil
+	})
+	require.NoError(t, err)
 }
 
 func TestMigrate_Migration1570675883(t *testing.T) {
 	orm, cleanup := bootstrapORM(t)
 	defer cleanup()
 
-	db := orm.DB
+	err := orm.RawDB(func(db *gorm.DB) error {
+		require.NoError(t, migrations.MigrateTo(db, "0"))
 
-	require.NoError(t, migrations.MigrateTo(db, "0"))
+		overrides := models.RunResult{
+			Data: cltest.JSONFromString(t, `{"a": "b"}`),
+		}
+		require.NoError(t, db.Create(&overrides).Error)
 
-	overrides := models.RunResult{
-		Data: cltest.JSONFromString(t, `{"a": "b"}`),
-	}
-	require.NoError(t, db.Create(&overrides).Error)
+		jobSpec := migration0.JobSpec{
+			ID:        utils.NewBytes32ID(),
+			CreatedAt: time.Now(),
+		}
+		require.NoError(t, db.Create(&jobSpec).Error)
+		jobRun := migration0.JobRun{
+			ID:             utils.NewBytes32ID(),
+			JobSpecID:      jobSpec.ID,
+			OverridesID:    overrides.ID,
+			CreationHeight: "0",
+			ObservedHeight: "0",
+		}
+		require.NoError(t, db.Create(&jobRun).Error)
 
-	jobSpec := migration0.JobSpec{
-		ID:        utils.NewBytes32ID(),
-		CreatedAt: time.Now(),
-	}
-	require.NoError(t, db.Create(&jobSpec).Error)
-	jobRun := migration0.JobRun{
-		ID:             utils.NewBytes32ID(),
-		JobSpecID:      jobSpec.ID,
-		OverridesID:    overrides.ID,
-		CreationHeight: "0",
-		ObservedHeight: "0",
-	}
-	require.NoError(t, db.Create(&jobRun).Error)
+		require.NoError(t, migrations.MigrateTo(db, "1570675883"))
 
-	require.NoError(t, migrations.MigrateTo(db, "1570675883"))
-
-	jobRunFound := models.JobRun{}
-	require.NoError(t, db.Where("id = ?", jobRun.ID).Find(&jobRunFound).Error)
-	assert.Equal(t, `{"a": "b"}`, jobRunFound.Overrides.String())
-	require.Error(t, db.Where("id = ?", overrides.ID).Find(&overrides).Error)
+		jobRunFound := models.JobRun{}
+		require.NoError(t, db.Where("id = ?", jobRun.ID).Find(&jobRunFound).Error)
+		assert.Equal(t, `{"a": "b"}`, jobRunFound.Overrides.String())
+		require.Error(t, db.Where("id = ?", overrides.ID).Find(&overrides).Error)
+		return nil
+	})
+	require.NoError(t, err)
 }
 
 func TestMigrate_NewerVersionGuard(t *testing.T) {
 	orm, cleanup := bootstrapORM(t)
 	defer cleanup()
 
-	db := orm.DB
+	err := orm.RawDB(func(db *gorm.DB) error {
+		// Do full migrations
+		require.NoError(t, migrations.Migrate(db))
 
-	// Do full migrations
-	require.NoError(t, migrations.Migrate(db))
+		// Add a fictional future migration
+		m := gormigrate.New(db, gormigrate.DefaultOptions, []*gormigrate.Migration{
+			{
+				ID:      "9223372036854775807",
+				Migrate: migration0.Migrate,
+			},
+		})
+		require.NoError(t, m.Migrate())
 
-	// Add a fictional future migration
-	m := gormigrate.New(db, gormigrate.DefaultOptions, []*gormigrate.Migration{
-		{
-			ID:      "9223372036854775807",
-			Migrate: migration0.Migrate,
-		},
+		// Run migrations again, should error
+		require.Error(t, migrations.Migrate(db))
+		return nil
 	})
-	require.NoError(t, m.Migrate())
-
-	// Run migrations again, should error
-	require.Error(t, migrations.Migrate(db))
+	require.NoError(t, err)
 }

--- a/core/store/orm/config_test.go
+++ b/core/store/orm/config_test.go
@@ -12,6 +12,7 @@ import (
 	"chainlink/core/store/migrations/migration1564007745"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/jinzhu/gorm"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -204,7 +205,10 @@ func TestConfig_EthGasPriceDefault(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, orm)
 	orm.SetLogging(true)
-	require.NoError(t, migration1564007745.Migrate(orm.DB))
+	err = orm.RawDB(func(db *gorm.DB) error {
+		return migration1564007745.Migrate(db)
+	})
+	require.NoError(t, err)
 
 	config.SetRuntimeStore(orm)
 

--- a/core/store/orm/helpers_test.go
+++ b/core/store/orm/helpers_test.go
@@ -1,0 +1,9 @@
+package orm
+
+func (o *ORM) LockingStrategyHelperSimulateDisconnect() (error, error) {
+	err1 := o.lockingStrategy.(*PostgresLockingStrategy).conn.Close()
+	err2 := o.lockingStrategy.(*PostgresLockingStrategy).db.Close()
+	o.lockingStrategy.(*PostgresLockingStrategy).conn = nil
+	o.lockingStrategy.(*PostgresLockingStrategy).db = nil
+	return err1, err2
+}

--- a/core/store/orm/locking_strategies.go
+++ b/core/store/orm/locking_strategies.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/gofrs/flock"
+	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 )
 
@@ -29,7 +30,7 @@ func NewLockingStrategy(dialect DialectName, dbpath string) (LockingStrategy, er
 // resource for exclusive access, usually a file or database.
 type LockingStrategy interface {
 	Lock(timeout time.Duration) error
-	Unlock() error
+	Unlock(timeout time.Duration) error
 }
 
 // FileLockingStrategy uses a file lock on disk to ensure exclusive access.
@@ -78,7 +79,7 @@ func normalizedTimeout(timeout time.Duration) <-chan time.Time {
 }
 
 // Unlock is a noop.
-func (s *FileLockingStrategy) Unlock() error {
+func (s *FileLockingStrategy) Unlock(timeout time.Duration) error {
 	s.m.Lock()
 	defer s.m.Unlock()
 	return s.fileLock.Unlock()
@@ -87,10 +88,10 @@ func (s *FileLockingStrategy) Unlock() error {
 // PostgresLockingStrategy uses a postgres advisory lock to ensure exclusive
 // access.
 type PostgresLockingStrategy struct {
-	db     *sql.DB
-	path   string
-	m      *sync.Mutex
-	locked bool
+	db   *sql.DB
+	conn *sql.Conn
+	path string
+	m    *sync.Mutex
 }
 
 // NewPostgresLockingStrategy returns a new instance of the PostgresLockingStrategy.
@@ -109,40 +110,59 @@ func (s *PostgresLockingStrategy) Lock(timeout time.Duration) error {
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	if s.locked {
-		return nil
-	}
-
-	db, err := sql.Open(string(DialectPostgres), s.path)
-	if err != nil {
-		return err
-	}
-	s.db = db
-
 	ctx := context.Background()
 	if timeout != 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)
 		defer cancel()
 	}
-	_, err = s.db.ExecContext(ctx, "SELECT pg_advisory_lock($1)", postgresAdvisoryLockID)
-	if err != nil {
-		return multierr.Append(
-			fmt.Errorf("postgres advisory locking strategy failed, timeout set to %v", displayTimeout(timeout)),
-			err)
+
+	if s.conn == nil {
+		db, err := sql.Open(string(DialectPostgres), s.path)
+		if err != nil {
+			return err
+		}
+		s.db = db
+
+		// `database/sql`.DB does opaque connection pooling, but PG advisory locks are per-connection
+		conn, err := db.Conn(ctx)
+		if err != nil {
+			return err
+		}
+
+		s.conn = conn
 	}
-	s.locked = true
+
+	_, err := s.conn.ExecContext(ctx, "SELECT pg_advisory_lock($1)", postgresAdvisoryLockID)
+	if err != nil {
+		return errors.Wrapf(ErrNoAdvisoryLock, "postgres advisory locking strategy failed on .Lock, timeout set to %v: %v", displayTimeout(timeout), err)
+	}
 	return nil
 }
 
 // Unlock unlocks the locked postgres advisory lock.
-func (s *PostgresLockingStrategy) Unlock() error {
+func (s *PostgresLockingStrategy) Unlock(timeout time.Duration) error {
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	s.locked = false
-	if s.db != nil {
-		return s.db.Close()
+	if s.conn == nil {
+		return nil
 	}
-	return nil
+
+	connErr := s.conn.Close()
+	if connErr == sql.ErrConnDone {
+		connErr = nil
+	}
+	dbErr := s.db.Close()
+	if dbErr == sql.ErrConnDone {
+		dbErr = nil
+	}
+
+	s.db = nil
+	s.conn = nil
+
+	return multierr.Combine(
+		connErr,
+		dbErr,
+	)
 }

--- a/core/store/orm/locking_strategies_test.go
+++ b/core/store/orm/locking_strategies_test.go
@@ -8,7 +8,11 @@ import (
 	"time"
 
 	"chainlink/core/internal/cltest"
+	"chainlink/core/store/models"
 	"chainlink/core/store/orm"
+
+	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/require"
 )
@@ -38,9 +42,9 @@ func TestNewLockingStrategy(t *testing.T) {
 	}
 }
 
-const delay = 10 * time.Millisecond
-
 func TestFileLockingStrategy_Lock(t *testing.T) {
+	const delay = 10 * time.Millisecond
+
 	tc, cleanup := cltest.NewConfig(t)
 	defer cleanup()
 	c := tc.Config
@@ -57,32 +61,120 @@ func TestFileLockingStrategy_Lock(t *testing.T) {
 	require.NoError(t, err)
 	require.Error(t, ls2.Lock(delay), "should not get 2nd exclusive lock")
 
-	require.NoError(t, ls.Unlock())
+	require.NoError(t, ls.Unlock(delay))
 
 	require.NoError(t, ls2.Lock(delay), "allow another to lock after unlock")
-	require.NoError(t, ls2.Unlock())
+	require.NoError(t, ls2.Unlock(delay))
 }
 
 func TestPostgresLockingStrategy_Lock(t *testing.T) {
 	tc, cleanup := cltest.NewConfig(t)
 	defer cleanup()
+
+	cleanupDB := cltest.PrepareTestDB(tc)
+	defer cleanupDB()
+
 	c := tc.Config
 
 	if c.DatabaseURL() == "" {
 		t.Skip("No postgres DatabaseURL set.")
 	}
 
+	delay := c.DatabaseTimeout()
+
 	ls, err := orm.NewPostgresLockingStrategy(c.DatabaseURL())
 	require.NoError(t, err)
 	require.NoError(t, ls.Lock(delay), "should get exclusive lock")
-	require.NoError(t, ls.Lock(delay), "relocking on same instance is noop")
+	require.NoError(t, ls.Lock(delay), "relocking on same instance is reentrant")
 
 	ls2, err := orm.NewPostgresLockingStrategy(c.DatabaseURL())
 	require.NoError(t, err)
 	require.Error(t, ls2.Lock(delay), "should not get 2nd exclusive lock")
-	require.NoError(t, ls2.Unlock())
 
-	require.NoError(t, ls.Unlock())
+	require.NoError(t, ls.Unlock(delay))
+	require.NoError(t, ls.Unlock(delay))
 	require.NoError(t, ls2.Lock(delay), "should get exclusive lock")
-	require.NoError(t, ls2.Unlock())
+	require.NoError(t, ls2.Unlock(delay))
+}
+
+func TestPostgresLockingStrategy_WhenLostIsReacquired(t *testing.T) {
+	t.Parallel()
+	store, cleanup := cltest.NewStore(t)
+	defer cleanup()
+
+	if store.Config.DatabaseURL() == "" {
+		t.Skip("No postgres DatabaseURL set.")
+	}
+
+	delay := store.Config.DatabaseTimeout()
+
+	connErr, dbErr := store.ORM.LockingStrategyHelperSimulateDisconnect()
+	require.NoError(t, connErr)
+	require.NoError(t, dbErr)
+
+	err := store.ORM.RawDB(func(db *gorm.DB) error {
+		return db.Save(&models.JobSpec{ID: models.NewID()}).Error
+	})
+	require.NoError(t, err)
+
+	lock2, err := orm.NewLockingStrategy("postgres", store.Config.DatabaseURL())
+	require.NoError(t, err)
+	err = lock2.Lock(delay)
+	require.Equal(t, errors.Cause(err), orm.ErrNoAdvisoryLock)
+	defer lock2.Unlock(delay)
+}
+
+func TestPostgresLockingStrategy_CanBeReacquiredByNewNodeAfterDisconnect(t *testing.T) {
+	t.Parallel()
+	store, cleanup := cltest.NewStore(t)
+	defer cleanup()
+
+	if store.Config.DatabaseURL() == "" {
+		t.Skip("No postgres DatabaseURL set.")
+	}
+
+	connErr, dbErr := store.ORM.LockingStrategyHelperSimulateDisconnect()
+	require.NoError(t, connErr)
+	require.NoError(t, dbErr)
+
+	orm2, err := orm.NewORM(orm.NormalizedDatabaseURL(store.Config), store.Config.DatabaseTimeout())
+	require.NoError(t, err)
+	defer orm2.Close()
+
+	err = orm2.RawDB(func(db *gorm.DB) error {
+		return db.Save(&models.JobSpec{ID: models.NewID()}).Error
+	})
+	require.NoError(t, err)
+
+	require.Panics(t, func() {
+		_ = store.ORM.RawDB(func(db *gorm.DB) error { return nil })
+	})
+}
+
+func TestPostgresLockingStrategy_WhenReacquiredOriginalNodeErrors(t *testing.T) {
+	t.Parallel()
+	store, cleanup := cltest.NewStore(t)
+	defer cleanup()
+
+	if store.Config.DatabaseURL() == "" {
+		t.Skip("No postgres DatabaseURL set.")
+	}
+
+	delay := store.Config.DatabaseTimeout()
+
+	connErr, dbErr := store.ORM.LockingStrategyHelperSimulateDisconnect()
+	require.NoError(t, connErr)
+	require.NoError(t, dbErr)
+
+	lock, err := orm.NewLockingStrategy("postgres", store.Config.DatabaseURL())
+	require.NoError(t, err)
+	defer lock.Unlock(delay)
+
+	err = lock.Lock(1 * time.Second)
+	require.NoError(t, err)
+	defer lock.Unlock(delay)
+
+	require.Panics(t, func() {
+		_ = store.ORM.RawDB(func(db *gorm.DB) error { return nil })
+	})
 }

--- a/integration/forks/test_helpers
+++ b/integration/forks/test_helpers
@@ -65,7 +65,7 @@ assert_testing_correct_artifact() {
 search_chainlink_logs() {
 	echo "searching for \"$1\" ... "
 	check_count=0;
-	TIMEOUT=30
+	TIMEOUT=60
 	until ( docker-compose logs chainlink | grep "$1" > /dev/null) ; do
     if [ $check_count -gt $TIMEOUT ]; then
       printf "\n"


### PR DESCRIPTION
(edited 11/20/2019)

**Goal of this PR:**

We want a Postgres locking strategy that ensures that only one node in a cluster can access the DB as long as that node stays healthy.  The strategy needs to deal with the node crashing, as well as with network failures.

**General notes on this PR:**

1. All DB access now must be done through the `ORM` itself, rather than accessing the `gorm.DB` struct directly at `orm.DB`.
2. Before every DB interaction, ORM ensures that it has the advisory lock.  If the advisory lock cannot be obtained, the node should shut down to make room for a failover node to take its place.
3. There's currently an `ORM.RawDB()` method which provides the caller with direct access to the `gorm.DB`, but it grabs the advisory lock first.  The reason for this is so that we can put off the work of adding new methods to ORM right away (to be handled in a later PR)
4. Outside of the code in this PR, it's also necessary to configure Postgres's `idle_in_transaction_session_timeout` setting with a reasonably short value to ensure that Postgres doesn't sit around waiting for ages without releasing the lock when a node experiences network trouble. (see: https://www.postgresql.org/docs/9.6/runtime-config-client.html)
5. Panicking inside of `ORM.MustEnsureAdvisoryLock` is not sufficient to signal the node's main goroutine to shutdown gracefully (and to have all of its child goroutines and subsystems shut down).  This is due to how Go panics work -- they unroll the stack in the current goroutine, but not in other goroutines, so `defer` statements in other goroutines are not called.  We need to signal the main goroutine, probably with a channel, so that it can terminate all of its children gracefully.  I've mocked up a simple version of a way we might do this inside of a new package called `gracefulpanic`.  It's a simple channel that the main goroutine listens to, and the ORM closes.

**Notes on Postgres advisory locks:**

1. They're session-scoped, meaning that you can hold them as long as you can hold an open connection to the DB.
2. They have semaphore semantics.  Each call to `pg_advisory_lock(...)` increments a counter.
3. To release the lock, you either have to call `pg_advisory_unlock(...)` once for every time it was locked, or you have to disconnect from the DB and wait for Postgres to notice the broken conn.  See my comment later in this thread for an explanation as to why I chose the disconnect strategy.

**Things we need to think through:**

1. Are all subsystems of the node written in such a way that they clean up gracefully when their parent context/goroutine exits?
    - For example, @j16r mentioned that the `eth_tx` adapter might be worth examining closely:
        > e.g: if the EthTx adapter loads up a Tx, in one transaction, then in another it saves the Tx, what’s it going to do?
        > is there any risk of a double spend?
2. Is it possible for any subsystem to wind up in a bad state if the node is terminated unexpectedly (but gracefully, calling the appropriate `.Close` methods)?
3. Is a Postgres advisory lock the most effective way to achieve the desired functionality?  We need a lock with the following properties:
    - it needs to be reentrant, since the node needs to try to acquire it before every DB interaction
    - it needs to be either node-scoped or connection-scoped (as opposed to transaction-scoped)
    - it needs to be automatically released when the node disconnects/dies or we'll have deadlocked clusters
4. Is it possible for the DB to wind up in a bad state, such that the failover node might get confused when it comes online?
5. Per @j16r's comment, are there other on-chain activities that may wind up in a bad state?
6. Does the `gracefulpanic` solution capture the spirit of how we want to approach shutting down a node?

Paging @se3000 @dimroc @j16r @thodges-gh @felder-cl @jleeh