### PR TITLE
Use JSON-API errors when returned from the server in json-api-client package

### DIFF
--- a/operator_ui/__tests__/containers/SignIn.test.js
+++ b/operator_ui/__tests__/containers/SignIn.test.js
@@ -47,6 +47,8 @@ describe('containers/SignIn', () => {
     await syncFetch(wrapper)
     const newState = store.getState()
     expect(newState.authentication.allowed).toEqual(true)
+
+    await syncFetch(wrapper)
     expect(wrapper.text()).toContain('Behind authentication')
   })
 

--- a/tools/json-api-client/src/errors.ts
+++ b/tools/json-api-client/src/errors.ts
@@ -1,6 +1,6 @@
 import { JsonApiResponse } from 'json-api-normalizer'
 
-interface Error {
+export interface ErrorItem {
   status: number
   detail: any
 }
@@ -10,7 +10,7 @@ export interface DocumentWithErrors {
 }
 
 export class AuthenticationError extends Error {
-  errors: Error[]
+  errors: ErrorItem[]
 
   constructor(response: Response) {
     super(`AuthenticationError(${response.statusText})`)
@@ -33,21 +33,16 @@ export class BadRequestError extends Error {
 }
 
 export class ServerError extends Error {
-  errors: Error[]
+  errors: ErrorItem[]
 
-  constructor(response: Response) {
-    super(`ServerError(${response.statusText})`)
-    this.errors = [
-      {
-        status: response.status,
-        detail: response.statusText,
-      },
-    ]
+  constructor(errors: ErrorItem[]) {
+    super('ServerError')
+    this.errors = errors
   }
 }
 
 export class UnknownResponseError extends Error {
-  errors: Error[]
+  errors: ErrorItem[]
 
   constructor(response: Response) {
     super(`UnknownResponseError(${response.statusText})`)

--- a/tools/json-api-client/src/transport/json.ts
+++ b/tools/json-api-client/src/transport/json.ts
@@ -127,7 +127,7 @@ type ResponseType<TParams, T> = TParams extends PaginatedRequestParams
 
 async function parseResponse<T>(response: Response): Promise<T> {
   if (response.status === 204) {
-    return new Promise(resolve => resolve({} as T))
+    return {} as T
   } else if (response.status >= 200 && response.status < 300) {
     return response.json()
   } else if (response.status === 400) {

--- a/tools/json-api-client/src/transport/json.ts
+++ b/tools/json-api-client/src/transport/json.ts
@@ -141,7 +141,7 @@ async function parseResponse<T>(response: Response): Promise<T> {
     let errors: ErrorItem[]
 
     if (json.errors) {
-      errors = json.errors.map((e: any) => ({
+      errors = json.errors.map((e: ErrorsObject) => ({
         status: response.status,
         detail: e.detail,
       }))

--- a/tools/json-api-client/src/transport/json.ts
+++ b/tools/json-api-client/src/transport/json.ts
@@ -137,25 +137,27 @@ async function parseResponse<T>(response: Response): Promise<T> {
   } else if (response.status === 401) {
     throw new AuthenticationError(response)
   } else if (response.status >= 500) {
-    const json = await response.json()
-    let errors: ErrorItem[]
-
-    if (json.errors) {
-      errors = json.errors.map((e: ErrorsObject) => ({
-        status: response.status,
-        detail: e.detail,
-      }))
-    } else {
-      errors = [
-        {
-          status: response.status,
-          detail: response.statusText,
-        },
-      ]
-    }
-
+    const errors = await errorItems(response)
     throw new ServerError(errors)
   } else {
     throw new UnknownResponseError(response)
   }
+}
+
+async function errorItems(response: Response): Promise<ErrorItem[]> {
+  const json = await response.json()
+
+  if (json.errors) {
+    return json.errors.map((e: ErrorsObject) => ({
+      status: response.status,
+      detail: e.detail,
+    }))
+  }
+
+  return [
+    {
+      status: response.status,
+      detail: response.statusText,
+    },
+  ]
 }


### PR DESCRIPTION
[Fixes #169546399]