### PR TITLE
Use a Merge function, to make merging of >2 inputs clearer

### DIFF
--- a/core/adapters/bridge.go
+++ b/core/adapters/bridge.go
@@ -38,7 +38,7 @@ func (ba *Bridge) Perform(input models.RunInput, store *store.Store) models.RunO
 }
 
 func (ba *Bridge) handleNewRun(input models.RunInput, bridgeResponseURL *url.URL) models.RunOutput {
-	data, err := input.Data().Merge(ba.Params)
+	data, err := models.Merge(input.Data(), ba.Params)
 	if err != nil {
 		return models.NewRunOutputError(baRunResultError("handling data param", err))
 	}
@@ -73,7 +73,7 @@ func (ba *Bridge) responseToRunResult(body []byte, input models.RunInput) models
 	}
 
 	if brr.Data.IsObject() {
-		data, err := ba.Params.Merge(brr.Data)
+		data, err := models.Merge(ba.Params, brr.Data)
 		if err != nil {
 			return models.NewRunOutputError(baRunResultError("handling data param", err))
 		}
@@ -85,7 +85,7 @@ func (ba *Bridge) responseToRunResult(body []byte, input models.RunInput) models
 }
 
 func (ba *Bridge) postToExternalAdapter(input models.RunInput, bridgeResponseURL *url.URL) ([]byte, error) {
-	data, err := input.Data().Merge(ba.Params)
+	data, err := models.Merge(input.Data(), ba.Params)
 	if err != nil {
 		return nil, errors.Wrap(err, "error merging bridge params with input params")
 	}

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -635,8 +635,9 @@ func CreateHelloWorldJobViaWeb(t testing.TB, app *TestApplication, url string) m
 	err := json.Unmarshal(buffer, &job)
 	require.NoError(t, err)
 
-	job.Tasks[0].Params, err = job.Tasks[0].Params.Merge(JSONFromString(t, `{"get":"%v"}`, url))
-	assert.NoError(t, err)
+	data, err := models.Merge(job.Tasks[0].Params, JSONFromString(t, `{"get":"%v"}`, url))
+	require.NoError(t, err)
+	job.Tasks[0].Params = data
 	return CreateJobSpecViaWeb(t, app, job)
 }
 

--- a/core/services/run_executor.go
+++ b/core/services/run_executor.go
@@ -102,7 +102,7 @@ func (je *runExecutor) executeTask(run *models.JobRun, taskRun *models.TaskRun) 
 		previousTaskInput = previousTaskRun.Result.Data
 	}
 
-	data, err := models.Merge(previousTaskInput, currentTaskRun.Result.Data, run.Overrides)
+	data, err := models.Merge(run.Overrides, previousTaskInput, taskRun.Result.Data)
 	if err != nil {
 		return models.NewRunOutputError(err)
 	}

--- a/core/services/run_executor.go
+++ b/core/services/run_executor.go
@@ -84,10 +84,11 @@ func (je *runExecutor) Execute(runID *models.ID) error {
 func (je *runExecutor) executeTask(run *models.JobRun, taskRun *models.TaskRun) models.RunOutput {
 	taskCopy := taskRun.TaskSpec // deliberately copied to keep mutations local
 
-	var err error
-	if taskCopy.Params, err = taskCopy.Params.Merge(run.Overrides); err != nil {
+	params, err := models.Merge(taskCopy.Params, run.Overrides)
+	if err != nil {
 		return models.NewRunOutputError(err)
 	}
+	taskCopy.Params = params
 
 	adapter, err := adapters.For(taskCopy, je.store.Config, je.store.ORM)
 	if err != nil {
@@ -96,14 +97,13 @@ func (je *runExecutor) executeTask(run *models.JobRun, taskRun *models.TaskRun) 
 
 	previousTaskRun := run.PreviousTaskRun()
 
-	data := models.JSON{}
+	previousTaskInput := models.JSON{}
 	if previousTaskRun != nil {
-		if data, err = previousTaskRun.Result.Data.Merge(taskRun.Result.Data); err != nil {
-			return models.NewRunOutputError(err)
-		}
+		previousTaskInput = previousTaskRun.Result.Data
 	}
 
-	if data, err = run.Overrides.Merge(data); err != nil {
+	data, err := models.Merge(previousTaskInput, currentTaskRun.Result.Data, run.Overrides)
+	if err != nil {
 		return models.NewRunOutputError(err)
 	}
 

--- a/core/services/run_manager.go
+++ b/core/services/run_manager.go
@@ -300,7 +300,11 @@ func (jm *runManager) ResumePending(
 		return jm.updateWithError(&run, "Attempting to resume pending run with no remaining tasks %s", run.ID)
 	}
 
-	run.Overrides.Merge(input.Data)
+	data, err := models.Merge(run.Overrides, input.Data)
+	if err != nil {
+		return jm.updateWithError(&run, "Error while merging onto overrides for run %s", run.ID)
+	}
+	run.Overrides = data
 
 	currentTaskRun.ApplyBridgeRunResult(input)
 	run.ApplyBridgeRunResult(input)

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -21,12 +21,6 @@ import (
 	"github.com/ugorji/go/codec"
 )
 
-var (
-	// ErrorCannotMergeNonObject is returned if a Merge was attempted on a string
-	// or array JSON value
-	ErrorCannotMergeNonObject = errors.New("Cannot merge, expected object '{}'")
-)
-
 // RunStatus is a string that represents the run status
 type RunStatus string
 

--- a/core/store/models/common_test.go
+++ b/core/store/models/common_test.go
@@ -82,7 +82,7 @@ func TestJSON_Merge(t *testing.T) {
 			j1 := cltest.JSONFromString(t, test.original)
 			j2 := cltest.JSONFromString(t, test.input)
 
-			merged, err := j1.Merge(j2)
+			merged, err := models.Merge(j1, j2)
 			if test.wantError {
 				require.Error(t, err)
 			} else {
@@ -95,7 +95,7 @@ func TestJSON_Merge(t *testing.T) {
 }
 
 func TestJSON_MergeNull(t *testing.T) {
-	merged, err := models.JSON{}.Merge(models.JSON{})
+	merged, err := models.Merge(models.JSON{}, models.JSON{})
 	require.NoError(t, err)
 	assert.Equal(t, `{}`, merged.String())
 }

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -166,13 +166,6 @@ func TestORM_SaveJobRun_Cancelled(t *testing.T) {
 	assert.Equal(t, orm.OptimisticUpdateConflictError, store.SaveJobRun(&jr))
 }
 
-func coercedJSON(v string) string {
-	if v == "" {
-		return "{}"
-	}
-	return v
-}
-
 func TestORM_JobRunsFor(t *testing.T) {
 	t.Parallel()
 

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -119,32 +119,6 @@ func TestORM_CreateJobRun_CreatesRunRequest(t *testing.T) {
 	assert.Equal(t, 1, requestCount)
 }
 
-func TestORM_SaveJobRun_DoesNotSaveTaskSpec(t *testing.T) {
-	t.Parallel()
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
-
-	job := cltest.NewJobWithSchedule("* * * * *")
-	require.NoError(t, store.CreateJob(&job))
-
-	jr := job.NewRun(job.Initiators[0])
-	require.NoError(t, store.CreateJobRun(&jr))
-
-	var err error
-	jr.TaskRuns[0].TaskSpec.Params, err = jr.TaskRuns[0].TaskSpec.Params.Merge(cltest.JSONFromString(t, `{"random": "input"}`))
-	require.NoError(t, err)
-	require.NoError(t, store.SaveJobRun(&jr))
-
-	retrievedJob, err := store.FindJob(job.ID)
-	require.NoError(t, err)
-	require.Len(t, job.Tasks, 1)
-	require.Len(t, retrievedJob.Tasks, 1)
-	assert.JSONEq(
-		t,
-		coercedJSON(job.Tasks[0].Params.String()),
-		retrievedJob.Tasks[0].Params.String())
-}
-
 func TestORM_SaveJobRun_ArchivedDoesNotRevertDeletedAt(t *testing.T) {
 	t.Parallel()
 	store, cleanup := cltest.NewStore(t)


### PR DESCRIPTION
This is a small change to JSON#Merge which lifts it out into a function, rationale: 

  1. As an isolated function it's clearer (to me) that this returns a copy and doesn't mutate anything
  2. The original used Map() which potentially returns a the underlying data structure of the object, which could mean Merge actually mutates the caller if a resize happens.
  3. Merge is now variadic, so merging in the RunManager becomes a bit clearer: `models.Merge(previousTaskInput, currentTaskRun.Result.Data, run.Overrides)` which makes it more obvious what is happening.
  4. Reduced error checking, only turning the result back into gjson encounters an error signature, which only needs to happen once for any number of merge operations.