### PR TITLE
Failing forks ci test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -294,7 +294,7 @@ jobs:
           command: yarn install
       - run: ./tools/ci/forks_test
       - store_artifacts:
-          path: ./integration/logs
+          path: ./integration/forks/logs
   build-publish-explorer:
     machine: true
     steps:

--- a/integration/forks/docker-compose.yaml
+++ b/integration/forks/docker-compose.yaml
@@ -3,7 +3,7 @@
 # If you modify this, make sure to make corresponding modifications to the scripts in forks/scripts.
 # Geth is bad about letting you know when it's getting inconsistent inputs, so be careful.
 
-version: '3.7'
+version: "3.7"
 
 services:
   geth:
@@ -26,6 +26,17 @@ services:
       - password
       - "0x9CA9d2D5E04012C9Ed24C0e513C9bfAa4A2dD77f"
 
+  # imports the 0x9CA9d2D5E04012C9Ed24C0e513C9bfAa4A2dD77f key into the CL db
+  chainlink_key_import:
+    image: smartcontract/chainlink
+    command: local import /run/secrets/0x9CA9d2D5E04012C9Ed24C0e513C9bfAa4A2dD77f
+    volumes:
+      - ./tmp/clroot/:/clroot/
+    environment:
+      - ROOT=/clroot
+    secrets:
+      - "0x9CA9d2D5E04012C9Ed24C0e513C9bfAa4A2dD77f"
+
   chainlink:
     image: smartcontract/chainlink
     container_name: forks_chainlink
@@ -44,6 +55,8 @@ services:
     networks:
       gethnet:
         ipv4_address: 172.16.1.102
+    depends_on:
+      - chainlink_key_import
     expose:
       - 6688
     secrets:

--- a/integration/forks/test
+++ b/integration/forks/test
@@ -41,7 +41,7 @@ mkdir -p logs
   # when 2nd chain gets longer, chainlink resumes saving heads
   search_chainlink_logs 'New head resuming run'
   # will wait for head # to be 10 more than block # with contract creation
-  search_chainlink_logs 'Run cannot continue because it lacks sufficient confirmations services'
+  search_chainlink_logs 'Pausing run pending confirmations'
   # should eventually abort running running job
   search_chainlink_logs 'presumably has been uncled'
   # assert job was never run

--- a/integration/forks/test
+++ b/integration/forks/test
@@ -18,7 +18,7 @@ mkdir -p logs
   create_contract
   # wait for chainlink to get notified about transaction
   search_chainlink_logs 'New run triggered by ethlog'
-  search_chainlink_logs 'Run cannot continue because it lacks sufficient confirmations'
+  search_chainlink_logs 'Pausing run pending confirmations'
   # stop mining before sufficient confirmations can be reached
   docker-compose stop
   # assert that nothing has been uncled yet

--- a/integration/forks/test
+++ b/integration/forks/test
@@ -9,39 +9,51 @@ source ./test_helpers
 initial_setup
 mkdir -p logs
 
-# Runs the first chain, where the ethlog contract is deployed
-printf "\nSTARTING CHAIN 1\n"
-# make sure chainlink has actually started receiving blocks from geth
-search_chainlink_logs 'Received new head'
-# broadcast contract creation transaction
-create_contract
-# wait for chainlink to get notified about transaction
-search_chainlink_logs 'New run triggered by ethlog'
-search_chainlink_logs 'Run cannot continue because it lacks sufficient confirmations'
-# save log
-docker-compose logs chainlink > logs/chain_1.log
-docker-compose logs geth > logs/geth.log
-# tear down network before sufficient confirmations can be reached
-docker-compose down
-# assert that nothing has been uncled yet
-assert_not_in_chainlink_logs 'presumably has been uncled'
+# run the first chain, where the ethlog contract is deployed
+{
+  printf "\nSTARTING CHAIN 1\n"
+  # make sure chainlink has actually started receiving blocks from geth
+  search_chainlink_logs 'Received new head'
+  # broadcast contract creation transaction
+  create_contract
+  # wait for chainlink to get notified about transaction
+  search_chainlink_logs 'New run triggered by ethlog'
+  search_chainlink_logs 'Run cannot continue because it lacks sufficient confirmations'
+  # stop mining before sufficient confirmations can be reached
+  docker-compose stop
+  # assert that nothing has been uncled yet
+  assert_not_in_chainlink_logs 'presumably has been uncled'
+  # tear down
+  save_logs 1
+  docker-compose down
+} || {
+  # if error encountered, save logs and exit
+  save_logs 1
+  exit 1
+}
 
 # create 2nd chain that is longer than first chain. Job should be uncled, not run
-printf "\nSTARTING CHAIN 2\n"
-start_network
-# 2nd chain should be younger than first, and so chainlink won't immediately save new heads
-search_chainlink_logs 'Cannot save new head confirmation'
-# when 2nd chain gets longer, chainlink resumes saving heads
-search_chainlink_logs 'New head resuming run'
-# will wait for head # to be 10 more than block # with contract creation
-search_chainlink_logs 'Run cannot continue because it lacks sufficient confirmations services'
-# should eventually abort running running job
-search_chainlink_logs 'presumably has been uncled'
-# save log
-docker-compose logs chainlink > logs/chain_2.log
-docker-compose logs geth >> logs/geth.log
-# tear down
-docker-compose down
-assert_not_in_chainlink_logs 'All tasks complete for run'
+{
+  printf "\nSTARTING CHAIN 2\n"
+  start_network
+  # 2nd chain should be younger than first, and so chainlink won't immediately save new heads
+  search_chainlink_logs 'Cannot save new head confirmation'
+  # when 2nd chain gets longer, chainlink resumes saving heads
+  search_chainlink_logs 'New head resuming run'
+  # will wait for head # to be 10 more than block # with contract creation
+  search_chainlink_logs 'Run cannot continue because it lacks sufficient confirmations services'
+  # should eventually abort running running job
+  search_chainlink_logs 'presumably has been uncled'
+  # assert job was never run
+  docker-compose stop
+  assert_not_in_chainlink_logs 'All tasks complete for run'
+  # tear down
+  save_logs 2
+  docker-compose down
+} || {
+  # if error encountered, save logs and exit
+  save_logs 2
+  exit 1
+}
 
 echo "test passed!"

--- a/integration/forks/test
+++ b/integration/forks/test
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# save logs if script errors and exits early
+chain_number=1
+function on_exit {
+  save_logs $chain_number
+}
+trap on_exit EXIT
+
 # set this directory as working directory
 cd "$(dirname "$0")"
 # import test helpers
@@ -10,50 +17,39 @@ initial_setup
 mkdir -p logs
 
 # run the first chain, where the ethlog contract is deployed
-{
-  printf "\nSTARTING CHAIN 1\n"
-  # make sure chainlink has actually started receiving blocks from geth
-  search_chainlink_logs 'Received new head'
-  # broadcast contract creation transaction
-  create_contract
-  # wait for chainlink to get notified about transaction
-  search_chainlink_logs 'New run triggered by ethlog'
-  search_chainlink_logs 'Pausing run pending confirmations'
-  # stop mining before sufficient confirmations can be reached
-  docker-compose stop
-  # assert that nothing has been uncled yet
-  assert_not_in_chainlink_logs 'presumably has been uncled'
-  # tear down
-  save_logs 1
-  docker-compose down
-} || {
-  # if error encountered, save logs and exit
-  save_logs 1
-  exit 1
-}
+printf "\nSTARTING CHAIN 1\n"
+# make sure chainlink has actually started receiving blocks from geth
+search_chainlink_logs 'Received new head'
+# broadcast contract creation transaction
+create_contract
+# wait for chainlink to get notified about transaction
+search_chainlink_logs 'New run triggered by ethlog'
+search_chainlink_logs 'Pausing run pending confirmations'
+# stop mining before sufficient confirmations can be reached
+docker-compose stop
+# assert that nothing has been uncled yet
+assert_not_in_chainlink_logs 'presumably has been uncled'
+# tear down
+save_logs 1
+docker-compose down
 
 # create 2nd chain that is longer than first chain. Job should be uncled, not run
-{
-  printf "\nSTARTING CHAIN 2\n"
-  start_network
-  # 2nd chain should be younger than first, and so chainlink won't immediately save new heads
-  search_chainlink_logs 'Cannot save new head confirmation'
-  # when 2nd chain gets longer, chainlink resumes saving heads
-  search_chainlink_logs 'New head resuming run'
-  # will wait for head # to be 10 more than block # with contract creation
-  search_chainlink_logs 'Pausing run pending confirmations'
-  # should eventually abort running running job
-  search_chainlink_logs 'presumably has been uncled'
-  # assert job was never run
-  docker-compose stop
-  assert_not_in_chainlink_logs 'All tasks complete for run'
-  # tear down
-  save_logs 2
-  docker-compose down
-} || {
-  # if error encountered, save logs and exit
-  save_logs 2
-  exit 1
-}
+printf "\nSTARTING CHAIN 2\n"
+chain_number=2
+start_network
+# 2nd chain should be younger than first, and so chainlink won't immediately save new heads
+search_chainlink_logs 'Cannot save new head confirmation'
+# when 2nd chain gets longer, chainlink resumes saving heads
+search_chainlink_logs 'New connection resuming run'
+# will wait for head # to be 10 more than block # with contract creation
+search_chainlink_logs 'Cannot save new head confirmation'
+# should eventually abort running running job
+search_chainlink_logs 'presumably has been uncled'
+# assert job was never run
+docker-compose stop
+assert_not_in_chainlink_logs 'All tasks complete for run'
+# tear down
+save_logs 2
+docker-compose down
 
 echo "test passed!"

--- a/integration/forks/test_helpers
+++ b/integration/forks/test_helpers
@@ -70,3 +70,9 @@ search_chainlink_logs() {
     sleep 1;
 	done
 }
+
+save_logs() {
+  echo "saving logs for chain $1"
+  docker-compose logs chainlink > "logs/chain_$1.log"
+  docker-compose logs geth >> "logs/geth_$1.log"
+}

--- a/tools/ci/forks_test
+++ b/tools/ci/forks_test
@@ -6,7 +6,7 @@ source ./integration/common
 
 heading 'Forks Test'
 
-yarn workspace @chainlink/integration test:forks
+./integration/forks/test
 
 title 'All tests passed.'
 


### PR DESCRIPTION
This PR introduces these changes to the forks CI test:

1. updates the test to search for verbiage consistent with that of the CL node.
eg: `Run cannot continue because it lacks sufficient confirmations` &rarr; `Pausing run pending confirmations`

1. Imports the local key `0x9CA9d2D5E04012C9Ed24C0e513C9bfAa4A2dD77f` before starting chainlink. This was already present in an [earlier PR](https://github.com/smartcontractkit/chainlink/pull/1791) but was accidentally removed.

1. Adds logs to the CircleCI artifacts

1. Ensures logs are saved, even when the test errors out