### PR TITLE
fix parameter precedence

### DIFF
--- a/core/services/job_runner.go
+++ b/core/services/job_runner.go
@@ -200,7 +200,7 @@ func executeTask(run *models.JobRun, currentTaskRun *models.TaskRun, store *stor
 	taskCopy := currentTaskRun.TaskSpec // deliberately copied to keep mutations local
 
 	var err error
-	if taskCopy.Params, err = taskCopy.Params.Merge(run.Overrides); err != nil {
+	if taskCopy.Params, err = run.Overrides.Merge(taskCopy.Params); err != nil {
 		currentTaskRun.Result.SetError(err)
 		return currentTaskRun.Result
 	}


### PR DESCRIPTION
Job Spec parameters should take precedence over Run Request parameters