### PR TITLE
fix parameter merging priority

### DIFF
--- a/core/services/job_runner.go
+++ b/core/services/job_runner.go
@@ -200,7 +200,7 @@ func executeTask(run *models.JobRun, currentTaskRun *models.TaskRun, store *stor
 	taskCopy := currentTaskRun.TaskSpec // deliberately copied to keep mutations local
 
 	var err error
-	if taskCopy.Params, err = taskCopy.Params.Merge(run.Overrides); err != nil {
+	if taskCopy.Params, err = run.Overrides.Merge(taskCopy.Params); err != nil {
 		currentTaskRun.Result.SetError(err)
 		return currentTaskRun.Result
 	}

--- a/integration-scripts/src/sendRunlogTransaction.ts
+++ b/integration-scripts/src/sendRunlogTransaction.ts
@@ -106,10 +106,7 @@ async function createJob(
       // 10 seconds to ensure the time has not elapsed by the time the run is triggered
       { type: 'Sleep', params: { until: futureOffsetSeconds(10) } },
       { type: 'HttpPost', params: { url: echoServerUrl } },
-      {
-        type: 'EthTx',
-        params: { functionSelector: 'fulfillOracleRequest(uint256,bytes32)' },
-      },
+      { type: 'EthTx' },
     ],
   }
 


### PR DESCRIPTION
Job Spec parameters should take precedence over Run Request parameters.

Added a commit to simplify the test and avoid spinning up HTTP servers.