### PR TITLE
Don't persist used Nonce unless SendRawTx succeeded

### DIFF
--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -17,33 +17,6 @@ import (
 	null "gopkg.in/guregu/null.v3"
 )
 
-type Transaction struct {
-	Transaction types.Transaction
-	From        common.Address
-	SentAt      uint64
-	SignedRaw   string
-}
-
-func (t *Transaction) Tx() *Tx {
-	ethTx := &t.Transaction
-	return &Tx{
-		From:        t.From,
-		To:          *ethTx.To(),
-		Nonce:       ethTx.Nonce(),
-		Data:        ethTx.Data(),
-		Value:       utils.NewBig(ethTx.Value()),
-		GasLimit:    ethTx.Gas(),
-		GasPrice:    utils.NewBig(ethTx.GasPrice()),
-		Hash:        ethTx.Hash(),
-		SentAt:      t.SentAt,
-		SignedRawTx: t.SignedRaw,
-	}
-}
-
-func (t *Transaction) Hash() common.Hash {
-	return t.Transaction.Hash()
-}
-
 // Tx contains fields necessary for an Ethereum transaction with
 // an additional field for the TxAttempt.
 type Tx struct {

--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -17,6 +17,33 @@ import (
 	null "gopkg.in/guregu/null.v3"
 )
 
+type Transaction struct {
+	Transaction types.Transaction
+	From        common.Address
+	SentAt      uint64
+	SignedRaw   string
+}
+
+func (t *Transaction) Tx() *Tx {
+	ethTx := &t.Transaction
+	return &Tx{
+		From:        t.From,
+		To:          *ethTx.To(),
+		Nonce:       ethTx.Nonce(),
+		Data:        ethTx.Data(),
+		Value:       utils.NewBig(ethTx.Value()),
+		GasLimit:    ethTx.Gas(),
+		GasPrice:    utils.NewBig(ethTx.GasPrice()),
+		Hash:        ethTx.Hash(),
+		SentAt:      t.SentAt,
+		SignedRawTx: t.SignedRaw,
+	}
+}
+
+func (t *Transaction) Hash() common.Hash {
+	return t.Transaction.Hash()
+}
+
 // Tx contains fields necessary for an Ethereum transaction with
 // an additional field for the TxAttempt.
 type Tx struct {

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -1,7 +1,6 @@
 package orm_test
 
 import (
-	"encoding/hex"
 	"io"
 	"math/big"
 	"os"
@@ -18,8 +17,6 @@ import (
 	"chainlink/core/store/orm"
 	"chainlink/core/utils"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -467,41 +464,24 @@ func TestORM_CreateTx(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
-	from := common.HexToAddress("0x2C83ACd90367e7E0D3762eA31aC77F18faecE874")
-	to := common.HexToAddress("0x4A7d17De4B3eC94c59BF07764d9A6e97d92A547A")
-	value := new(big.Int).Exp(big.NewInt(10), big.NewInt(36), nil)
-	nonce := uint64(1232421)
-	gasLimit := uint64(50000)
-	data, err := hex.DecodeString("0987612345abcdef")
-	assert.NoError(t, err)
+	transaction := cltest.NewTransaction(9182731)
 
-	ethTx := types.NewTransaction(
-		nonce,
-		to,
-		value,
-		gasLimit,
-		new(big.Int),
-		data,
-	)
-
-	tx, err := store.CreateTx(null.String{}, ethTx, &from, 0)
+	tx, err := store.CreateTx(transaction, null.String{})
 	require.NoError(t, err)
-
-	// CreateTx should also include an initial attempt
-	assert.Len(t, tx.Attempts, 1)
+	assert.Len(t, tx.Attempts, 0)
 
 	txs := []models.Tx{}
-	assert.NoError(t, store.Where("Nonce", nonce, &txs))
+	assert.NoError(t, store.Where("Nonce", transaction.Transaction.Nonce(), &txs))
 	require.Len(t, txs, 1)
 	ntx := txs[0]
 
 	assert.NotNil(t, ntx.ID)
-	assert.Equal(t, from, ntx.From)
-	assert.Equal(t, to, ntx.To)
-	assert.Equal(t, data, ntx.Data)
-	assert.Equal(t, nonce, ntx.Nonce)
-	assert.Equal(t, value, ntx.Value.ToInt())
-	assert.Equal(t, gasLimit, ntx.GasLimit)
+	assert.NotEmpty(t, ntx.From)
+	assert.NotEmpty(t, ntx.To)
+	assert.NotEmpty(t, ntx.Data)
+	assert.NotEmpty(t, ntx.Nonce)
+	assert.NotEmpty(t, ntx.Value.ToInt())
+	assert.NotEmpty(t, ntx.GasLimit)
 }
 
 func TestORM_CreateTx_WithSurrogateIDIsIdempotent(t *testing.T) {
@@ -509,38 +489,15 @@ func TestORM_CreateTx_WithSurrogateIDIsIdempotent(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
-	from := common.HexToAddress("0x2C83ACd90367e7E0D3762eA31aC77F18faecE874")
-	to := common.HexToAddress("0x4A7d17De4B3eC94c59BF07764d9A6e97d92A547A")
-	value := new(big.Int).Exp(big.NewInt(10), big.NewInt(36), nil)
-	nonce := uint64(1232421)
-	gasLimit := uint64(50000)
-	data, err := hex.DecodeString("0987612345abcdef")
+	transaction := cltest.NewTransaction(0)
+
+	surrogateID := null.StringFrom("9182323")
+	tx1, err := store.CreateTx(transaction, surrogateID)
 	assert.NoError(t, err)
 
-	surrogateID := null.StringFrom("1")
+	transaction = cltest.NewTransaction(1)
 
-	ethTx := types.NewTransaction(
-		nonce,
-		to,
-		value,
-		gasLimit,
-		new(big.Int),
-		data,
-	)
-
-	tx1, err := store.CreateTx(surrogateID, ethTx, &from, 0)
-	assert.NoError(t, err)
-
-	ethTxWithNewNonce := types.NewTransaction(
-		nonce+1,
-		to,
-		value,
-		gasLimit,
-		new(big.Int),
-		data,
-	)
-
-	tx2, err := store.CreateTx(surrogateID, ethTxWithNewNonce, &from, 0)
+	tx2, err := store.CreateTx(transaction, surrogateID)
 	assert.NoError(t, err)
 
 	// IDs should be the same because only record should ever be created
@@ -549,59 +506,8 @@ func TestORM_CreateTx_WithSurrogateIDIsIdempotent(t *testing.T) {
 	// New nonce should be saved
 	assert.NotEqual(t, tx1.Nonce, tx2.Nonce)
 
-	// New nonce should change the signature generated and hash
-	assert.NotEqual(t, tx1.SignedRawTx, tx2.SignedRawTx)
+	// New nonce should change the hash
 	assert.NotEqual(t, tx1.Hash, tx2.Hash)
-}
-
-func TestORM_UpdateTx(t *testing.T) {
-	t.Parallel()
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
-
-	from := common.HexToAddress("0x2C83ACd90367e7E0D3762eA31aC77F18faecE874")
-	to := common.HexToAddress("0x4A7d17De4B3eC94c59BF07764d9A6e97d92A547A")
-	value := new(big.Int).Exp(big.NewInt(10), big.NewInt(36), nil)
-	nonce := uint64(1232421)
-	gasLimit := uint64(50000)
-	data, err := hex.DecodeString("0987612345abcdef")
-	assert.NoError(t, err)
-
-	ethTx := types.NewTransaction(
-		nonce,
-		to,
-		value,
-		gasLimit,
-		new(big.Int),
-		data,
-	)
-
-	tx, err := store.CreateTx(null.String{}, ethTx, &from, 0)
-	assert.NoError(t, err)
-
-	oldNonce := tx.Nonce
-	oldHash := tx.Hash
-	oldSignedRawTx := tx.SignedRawTx
-
-	ethTxWithNewNonce := types.NewTransaction(
-		nonce+1,
-		to,
-		value,
-		gasLimit,
-		new(big.Int),
-		data,
-	)
-
-	err = store.UpdateTx(tx, ethTxWithNewNonce, &from, 0)
-	assert.NoError(t, err)
-
-	// tx fields are updated to match new ethTx
-	assert.NotEqual(t, tx.Nonce, oldNonce)
-	assert.NotEqual(t, tx.SignedRawTx, oldSignedRawTx)
-	assert.NotEqual(t, tx.Hash, oldHash)
-
-	// No additional attempts are created
-	assert.Len(t, tx.Attempts, 1)
 }
 
 func TestORM_AddTxAttempt(t *testing.T) {
@@ -609,40 +515,21 @@ func TestORM_AddTxAttempt(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
-	from := common.HexToAddress("0x2C83ACd90367e7E0D3762eA31aC77F18faecE874")
-	to := common.HexToAddress("0x4A7d17De4B3eC94c59BF07764d9A6e97d92A547A")
-	value := new(big.Int).Exp(big.NewInt(10), big.NewInt(36), nil)
-	nonce := uint64(1232421)
-	gasLimit := uint64(50000)
-	data, err := hex.DecodeString("0987612345abcdef")
+	transaction := cltest.NewTransaction(0)
+
+	tx, err := store.CreateTx(transaction, null.String{})
 	assert.NoError(t, err)
 
-	ethTx := types.NewTransaction(
-		nonce,
-		to,
-		value,
-		gasLimit,
-		new(big.Int),
-		data,
-	)
-
-	tx, err := store.CreateTx(null.String{}, ethTx, &from, 0)
+	txAttempt, err := store.AddTxAttempt(tx, transaction)
 	assert.NoError(t, err)
+	require.Len(t, tx.Attempts, 1)
+	assert.Equal(t, tx.ID, txAttempt.TxID)
+	assert.Equal(t, tx.Attempts[0], txAttempt)
 
-	ethTxWithNewNonce := types.NewTransaction(
-		nonce+1,
-		to,
-		value,
-		gasLimit,
-		new(big.Int),
-		data,
-	)
-
-	// New EthTx generates a new attempt record
-	txAttempt, err := store.AddTxAttempt(tx, ethTxWithNewNonce, 1)
+	transaction = cltest.NewTransaction(1)
+	txAttempt, err = store.AddTxAttempt(tx, transaction)
 	assert.NoError(t, err)
-
-	assert.Len(t, tx.Attempts, 2)
+	require.Len(t, tx.Attempts, 2)
 	assert.Equal(t, tx.ID, txAttempt.TxID)
 	assert.Equal(t, tx.Attempts[1], txAttempt)
 
@@ -651,27 +538,20 @@ func TestORM_AddTxAttempt(t *testing.T) {
 	assert.Equal(t, tx.Hash, txAttempt.Hash)
 
 	// Another attempt with exact same EthTx still generates a new attempt record
-	txAttempt, err = store.AddTxAttempt(tx, ethTxWithNewNonce, 1)
+	txAttempt, err = store.AddTxAttempt(tx, transaction)
 	assert.NoError(t, err)
 
-	assert.Len(t, tx.Attempts, 3)
+	require.Len(t, tx.Attempts, 3)
 	assert.Equal(t, tx.ID, txAttempt.TxID)
 	assert.Equal(t, tx.Attempts[2], txAttempt)
 
-	ethTxWithNewGasLimit := types.NewTransaction(
-		nonce+1,
-		to,
-		value,
-		gasLimit+1,
-		new(big.Int),
-		data,
-	)
+	transaction = cltest.NewTransaction(3)
 
 	// Another attempt with new EthTx updates Tx hash/rawTx etc.
-	txAttempt, err = store.AddTxAttempt(tx, ethTxWithNewGasLimit, 1)
+	txAttempt, err = store.AddTxAttempt(tx, transaction)
 	assert.NoError(t, err)
 
-	assert.Len(t, tx.Attempts, 4)
+	require.Len(t, tx.Attempts, 4)
 	assert.Equal(t, tx.ID, txAttempt.TxID)
 	assert.Equal(t, tx.Attempts[3], txAttempt)
 	assert.Equal(t, tx.Hash, txAttempt.Hash)
@@ -974,12 +854,12 @@ func TestORM_DeleteTransaction(t *testing.T) {
 
 	from := cltest.GetAccountAddress(t, store)
 	tx := cltest.CreateTx(t, store, from, 1)
-	_, err = store.AddTxAttempt(tx, tx.EthTx(big.NewInt(3)), 3)
-	require.NoError(t, err)
+	transaction := cltest.NewTransaction(0)
+	require.NoError(t, utils.JustError(store.AddTxAttempt(tx, transaction)))
 
 	require.NoError(t, store.DeleteTransaction(tx))
 
-	tx, err = store.FindTx(tx.ID)
+	_, err = store.FindTx(tx.ID)
 	require.Error(t, err)
 }
 
@@ -1013,7 +893,7 @@ func TestORM_AllSyncEvents(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Len(t, events, 2)
+	require.Len(t, events, 2)
 	assert.Greater(t, events[1].ID, events[0].ID)
 }
 
@@ -1127,8 +1007,8 @@ func TestORM_FindTxAttempt_PastAttempt(t *testing.T) {
 
 	from := cltest.GetAccountAddress(t, store)
 	tx := cltest.CreateTx(t, store, from, 1)
-	_, err = store.AddTxAttempt(tx, tx.EthTx(big.NewInt(3)), 3)
-	require.NoError(t, err)
+	transaction := cltest.NewTransaction(0)
+	require.NoError(t, utils.JustError(store.AddTxAttempt(tx, transaction)))
 
 	txAttempt, err := store.FindTxAttempt(tx.Attempts[0].Hash)
 	require.NoError(t, err)
@@ -1183,8 +1063,9 @@ func TestORM_FindTxByAttempt_PastAttempt(t *testing.T) {
 	from := cltest.GetAccountAddress(t, store)
 	createdTx := cltest.CreateTx(t, store, from, 1)
 	pastTxAttempt := createdTx.Attempts[0]
-	_, err = store.AddTxAttempt(createdTx, createdTx.EthTx(big.NewInt(3)), 3)
-	require.NoError(t, err)
+
+	transaction := cltest.NewTransaction(0)
+	require.NoError(t, utils.JustError(store.AddTxAttempt(createdTx, transaction)))
 
 	fetchedTx, pastTxAttempt, err := store.FindTxByAttempt(pastTxAttempt.Hash)
 	require.NoError(t, err)
@@ -1250,11 +1131,11 @@ func TestORM_SyncDbKeyStoreToDisk(t *testing.T) {
 
 	dbkeys, err := store.Keys()
 	require.NoError(t, err)
-	assert.Len(t, dbkeys, 1)
+	require.Len(t, dbkeys, 1)
 
 	diskkeys, err := utils.FilesInDir(keysDir)
 	require.NoError(t, err)
-	assert.Len(t, diskkeys, 1)
+	require.Len(t, diskkeys, 1)
 
 	key := dbkeys[0]
 	content, err := utils.FileContents(filepath.Join(keysDir, diskkeys[0]))
@@ -1305,36 +1186,26 @@ func TestORM_UnconfirmedTxAttempts(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
-	// tx #1, 4 attempts
-	{
-		from := common.HexToAddress("0x2C83ACd90367e7E0D3762eA31aC77F18faecE874")
-		to := common.HexToAddress("0x4A7d17De4B3eC94c59BF07764d9A6e97d92A547A")
-		value := new(big.Int).Exp(big.NewInt(10), big.NewInt(36), nil)
-		nonce := uint64(1232421)
-		gasLimit := uint64(50000)
-		data, err := hex.DecodeString("0987612345abcdef")
-		assert.NoError(t, err)
-
-		ethTx := types.NewTransaction(
-			nonce,
-			to,
-			value,
-			gasLimit,
-			new(big.Int),
-			data,
-		)
-
-		tx, err := store.CreateTx(null.String{}, ethTx, &from, 0)
+	t.Run("tx #1, 4 attempts", func(t *testing.T) {
+		transaction := cltest.NewTransaction(0, 0)
+		tx, err := store.CreateTx(transaction, null.StringFrom("0"))
 		require.NoError(t, err)
 
-		_, err = store.AddTxAttempt(tx, ethTx, 1)
+		_, err = store.AddTxAttempt(tx, transaction)
 		require.NoError(t, err)
 
-		_, err = store.AddTxAttempt(tx, ethTx, 2)
+		transaction = cltest.NewTransaction(0, 1)
+		_, err = store.AddTxAttempt(tx, transaction)
 		require.NoError(t, err)
 
-		_, err = store.AddTxAttempt(tx, ethTx, 3)
+		transaction = cltest.NewTransaction(0, 2)
+		_, err = store.AddTxAttempt(tx, transaction)
 		require.NoError(t, err)
+
+		transaction = cltest.NewTransaction(0, 3)
+		_, err = store.AddTxAttempt(tx, transaction)
+		require.NoError(t, err)
+		require.Len(t, tx.Attempts, 4)
 
 		tx.Attempts[0].GasPrice = utils.NewBig(big.NewInt(1111))
 		tx.Attempts[1].GasPrice = utils.NewBig(big.NewInt(2222))
@@ -1345,35 +1216,24 @@ func TestORM_UnconfirmedTxAttempts(t *testing.T) {
 			return db.Save(&tx).Error
 		})
 		require.NoError(t, err)
-	}
+	})
 
-	// tx #2, 3 attempts
-	{
-		from := common.HexToAddress("0x2C83ACd90367e7E0D3762eA31aC77F18faecE874")
-		to := common.HexToAddress("0x4A7d17De4B3eC94c59BF07764d9A6e97d92A547A")
-		value := new(big.Int).Exp(big.NewInt(10), big.NewInt(36), nil)
-		nonce := uint64(33322211)
-		gasLimit := uint64(50000)
-		data, err := hex.DecodeString("0987612345abcdef")
-		assert.NoError(t, err)
-
-		ethTx := types.NewTransaction(
-			nonce,
-			to,
-			value,
-			gasLimit,
-			new(big.Int),
-			data,
-		)
-
-		tx, err := store.CreateTx(null.String{}, ethTx, &from, 0)
+	t.Run("tx #2, 3 attempts", func(t *testing.T) {
+		transaction := cltest.NewTransaction(0)
+		tx, err := store.CreateTx(transaction, null.StringFrom("1"))
 		require.NoError(t, err)
 
-		_, err = store.AddTxAttempt(tx, ethTx, 1)
+		_, err = store.AddTxAttempt(tx, transaction)
 		require.NoError(t, err)
 
-		_, err = store.AddTxAttempt(tx, ethTx, 2)
+		transaction = cltest.NewTransaction(0, 1)
+		_, err = store.AddTxAttempt(tx, transaction)
 		require.NoError(t, err)
+
+		transaction = cltest.NewTransaction(0, 2)
+		_, err = store.AddTxAttempt(tx, transaction)
+		require.NoError(t, err)
+		require.Len(t, tx.Attempts, 3)
 
 		tx.Attempts[0].GasPrice = utils.NewBig(big.NewInt(5555))
 		tx.Attempts[1].GasPrice = utils.NewBig(big.NewInt(6666))
@@ -1383,31 +1243,18 @@ func TestORM_UnconfirmedTxAttempts(t *testing.T) {
 			return db.Save(&tx).Error
 		})
 		require.NoError(t, err)
-	}
+	})
 
-	// tx #3, 2 attempts
-	{
-		from := common.HexToAddress("0x2C83ACd90367e7E0D3762eA31aC77F18faecE874")
-		to := common.HexToAddress("0x4A7d17De4B3eC94c59BF07764d9A6e97d92A547A")
-		value := new(big.Int).Exp(big.NewInt(10), big.NewInt(36), nil)
-		nonce := uint64(432211)
-		gasLimit := uint64(50000)
-		data, err := hex.DecodeString("0987612345abcdef")
-		assert.NoError(t, err)
-
-		ethTx := types.NewTransaction(
-			nonce,
-			to,
-			value,
-			gasLimit,
-			new(big.Int),
-			data,
-		)
-
-		tx, err := store.CreateTx(null.String{}, ethTx, &from, 0)
+	t.Run("tx #2, 2 attempts", func(t *testing.T) {
+		transaction := cltest.NewTransaction(0)
+		tx, err := store.CreateTx(transaction, null.StringFrom("2"))
 		require.NoError(t, err)
 
-		_, err = store.AddTxAttempt(tx, ethTx, 1)
+		_, err = store.AddTxAttempt(tx, transaction)
+		require.NoError(t, err)
+
+		transaction = cltest.NewTransaction(0, 1)
+		_, err = store.AddTxAttempt(tx, transaction)
 		require.NoError(t, err)
 
 		// This tx's attempts should not appear in the results
@@ -1417,7 +1264,7 @@ func TestORM_UnconfirmedTxAttempts(t *testing.T) {
 			return db.Save(&tx).Error
 		})
 		require.NoError(t, err)
-	}
+	})
 
 	attempts, err := store.ORM.UnconfirmedTxAttempts()
 	require.NoError(t, err)

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -42,11 +42,10 @@ func TestTxManager_CreateTx_Success(t *testing.T) {
 
 	from := account.Address
 	to := cltest.NewAddress()
-	data, err := hex.DecodeString("0000abcdef")
+	data := hexutil.MustDecode("0x0000abcdef")
 	nonce := uint64(256)
 
 	manager.Register(keyStore.Accounts())
-	require.NoError(t, err)
 
 	ethClient.On("GetNonce", from).Return(nonce, nil)
 
@@ -187,7 +186,7 @@ func TestTxManager_CreateTx_BreakTxAttemptLimit(t *testing.T) {
 	assert.Len(t, ntx.Attempts, 1)
 
 	manager.OnNewHead(cltest.Head(bumpAt))
-	ethClient.On("GetTxReceipt", mock.Anything).Return(&eth.TxReceipt{}, nil)
+	ethClient.On("GetTxReceipt", mock.Anything).Once().Return(&eth.TxReceipt{}, nil)
 	ethClient.On("SendRawTx", mock.Anything).Return(tx.Attempts[0].Hash, nil)
 
 	receipt, state, err := manager.BumpGasUntilSafe(tx.Attempts[0].Hash)
@@ -196,8 +195,7 @@ func TestTxManager_CreateTx_BreakTxAttemptLimit(t *testing.T) {
 	assert.Equal(t, strpkg.Unconfirmed, state)
 
 	manager.OnNewHead(cltest.Head(bumpAgainAt))
-	ethClient.On("GetTxReceipt", mock.Anything).Return(&eth.TxReceipt{}, nil)
-	ethClient.On("GetTxReceipt", mock.Anything).Return(&eth.TxReceipt{}, nil)
+	ethClient.On("GetTxReceipt", mock.Anything).Twice().Return(&eth.TxReceipt{}, nil)
 
 	receipt, state, err = manager.BumpGasUntilSafe(tx.Attempts[0].Hash)
 	require.NoError(t, err)
@@ -244,12 +242,6 @@ func TestTxManager_CreateTx_AttemptErrorDoesNotIncrementNonce(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, txs, 1)
 
-	txAttempts, _, err := store.TxAttempts(0, 100)
-	assert.NoError(t, err)
-	assert.Len(t, txAttempts, 1)
-
-	assert.Equal(t, txs[0].Hash, txAttempts[0].Hash)
-
 	hash := cltest.NewHash()
 	ethMock.Context("manager.CreateTx#2", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_sendRawTransaction", hash)
@@ -282,39 +274,31 @@ func TestTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
 		{"parity", "Transaction with the same hash was already imported"},
 	}
 
-	for _, test := range tests {
+	for _, tt := range tests {
+		test := tt
 		t.Run(test.name, func(t *testing.T) {
-
-			app, cleanup := cltest.NewApplicationWithKey(t)
+			store, cleanup := cltest.NewStore(t)
 			defer cleanup()
-			store := app.Store
-			manager := store.TxManager
+
+			ethClient := new(mocks.EthClient)
+			config := cltest.NewTestConfig(t)
+			require.NoError(t, utils.JustError(store.KeyStore.NewAccount(cltest.Password)))
+			require.NoError(t, store.KeyStore.Unlock(cltest.Password))
+			manager := strpkg.NewEthTxManager(ethClient, config, store.KeyStore, store.ORM)
+			manager.Register(store.KeyStore.Accounts())
 
 			from := cltest.GetAccountAddress(t, store)
 			to := cltest.NewAddress()
-			data, err := hex.DecodeString("0000abcdef")
-			assert.NoError(t, err)
-			ethMock := app.MockCallerSubscriberClient()
+			data := hexutil.MustDecode("0x0000abcdef")
 
-			nonce1 := uint64(256)
-			ethMock.Context("app.StartAndConnect()", func(ethMock *cltest.EthMock) {
-				ethMock.Register("eth_chainId", store.Config.ChainID())
-				ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce1))
-			})
-			sentAt := uint64(23456)
-			require.NoError(t, app.Store.ORM.CreateHead(cltest.Head(sentAt)))
-			assert.NoError(t, app.StartAndConnect())
+			nonce := uint64(256)
+			ethClient.On("GetNonce", from).Once().Return(nonce, nil)
+			require.NoError(t, manager.Connect(cltest.Head(nonce)))
 
-			ethMock.Context("manager.CreateTx#1", func(ethMock *cltest.EthMock) {
-				ethMock.RegisterError("eth_sendRawTransaction", test.ethClientErrorMsg)
-			})
-
-			hash := cltest.NewHash()
+			ethClient.On("SendRawTx", mock.Anything).Once().Return(nil, errors.New("nonce is too low"))
 			nonce2 := uint64(257)
-			ethMock.Context("manager.CreateTx#2", func(ethMock *cltest.EthMock) {
-				ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce2))
-				ethMock.Register("eth_sendRawTransaction", hash)
-			})
+			ethClient.On("GetNonce", from).Once().Return(nonce2, nil)
+			ethClient.On("SendRawTx", mock.Anything).Once().Return(nil, nil)
 
 			a, err := manager.CreateTx(to, data)
 			require.NoError(t, err)
@@ -326,50 +310,42 @@ func TestTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
 			assert.Equal(t, from, tx.From)
 			assert.Len(t, tx.Attempts, 1)
 
-			ethMock.EventuallyAllCalled(t)
+			ethClient.AssertExpectations(t)
 		})
 	}
 }
 
 func TestTxManager_CreateTx_NonceTooLowReloadLimit(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey(t)
+
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	store := app.Store
-	manager := store.TxManager
+
+	ethClient := new(mocks.EthClient)
+
+	config := cltest.NewTestConfig(t)
+	keyStore := strpkg.NewKeyStore(config.KeysDir())
+	account, err := keyStore.NewAccount(cltest.Password)
+	require.NoError(t, err)
+	require.NoError(t, keyStore.Unlock(cltest.Password))
+	manager := strpkg.NewEthTxManager(ethClient, config, keyStore, store.ORM)
+
+	manager.Register(keyStore.Accounts())
+
+	from := account.Address
+	nonce := uint64(256)
+	ethClient.On("GetNonce", from).Return(nonce, nil)
+	err = manager.Connect(cltest.Head(nonce))
+	require.NoError(t, err)
+
+	ethClient.On("SendRawTx", mock.Anything).Twice().Return(nil, errors.New("nonce is too low"))
 
 	to := cltest.NewAddress()
-	data, err := hex.DecodeString("0000abcdef")
-	assert.NoError(t, err)
-	ethMock := app.MockCallerSubscriberClient()
-
-	nonce1 := uint64(256)
-	ethMock.Context("app.StartAndConnect()", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce1))
-		ethMock.Register("eth_chainId", store.Config.ChainID())
-	})
-	sentAt := uint64(23456)
-	require.NoError(t, app.Store.ORM.CreateHead(cltest.Head(sentAt)))
-	assert.NoError(t, app.StartAndConnect())
-
-	ethMock.Context("manager.CreateTx#1", func(ethMock *cltest.EthMock) {
-		ethMock.RegisterError("eth_sendRawTransaction", "nonce is too low")
-	})
-
-	nonce2 := uint64(257)
-	ethMock.Context("manager.CreateTx#2", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(nonce2))
-		ethMock.RegisterError("eth_sendRawTransaction", "nonce is too low")
-	})
-
+	data := hexutil.MustDecode("0x0000abcdef")
 	_, err = manager.CreateTx(to, data)
-	assert.EqualError(
-		t,
-		err,
-		"Transaction reattempt limit reached for 'nonce is too low' error. Limit: 1",
-	)
+	assert.EqualError(t, err, "Transaction reattempt limit reached for 'nonce is too low' error. Limit: 1")
 
-	ethMock.EventuallyAllCalled(t)
+	ethClient.AssertExpectations(t)
 }
 
 func TestTxManager_CreateTx_ErrPendingConnection(t *testing.T) {
@@ -607,7 +583,9 @@ func TestTxManager_BumpGasUntilSafe_laterConfirmedTx(t *testing.T) {
 	sentAt := uint64(12345)
 
 	tx1 := cltest.CreateTxWithNonce(t, store, from, sentAt, 1)
+	require.Len(t, tx1.Attempts, 1)
 	tx2 := cltest.CreateTxWithNonce(t, store, from, sentAt, 2)
+	require.Len(t, tx2.Attempts, 1)
 
 	etm := txm.(*strpkg.EthTxManager)
 	aa := etm.GetAvailableAccount(from)
@@ -694,9 +672,9 @@ func TestTxManager_BumpGasUntilSafe_erroring(t *testing.T) {
 			store := app.Store
 			txm := store.TxManager
 			from := cltest.GetAccountAddress(t, store)
+
 			tx := cltest.CreateTx(t, store, from, sentAt1)
-			a, err := store.AddTxAttempt(tx, tx.EthTx(big.NewInt(2)), sentAt2)
-			assert.NoError(t, err)
+			a := cltest.AddTxAttempt(t, store, tx, tx.EthTx(big.NewInt(2)), sentAt2)
 
 			ethMock := app.MockCallerSubscriberClient(cltest.Strict)
 			ethMock.ShouldCall(test.mockSetup).During(func() {
@@ -1199,11 +1177,10 @@ func TestTxManager_RebroadcastUnconfirmedTxsOnReconnect(t *testing.T) {
 	manager := strpkg.NewEthTxManager(ethClient, config, keyStore, store.ORM)
 
 	to := cltest.NewAddress()
-	data, err := hex.DecodeString("0000abcdef")
+	data := hexutil.MustDecode("0x0000abcdef")
 	sentAt := uint64(1)
 
 	manager.Register(keyStore.Accounts())
-	require.NoError(t, err)
 
 	ethClient.On("GetNonce", mock.Anything).Times(2).Return(uint64(0), nil)
 
@@ -1221,46 +1198,6 @@ func TestTxManager_RebroadcastUnconfirmedTxsOnReconnect(t *testing.T) {
 	ethClient.On("SendRawTx", mock.Anything).Return(hash, nil)
 	err = manager.Connect(cltest.Head(sentAt))
 	require.NoError(t, err)
-
-	ethClient.AssertExpectations(t)
-}
-
-func TestTxManager_FailOnSendReturnsNonce(t *testing.T) {
-	t.Parallel()
-
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
-
-	keyStore := strpkg.NewKeyStore(store.Config.KeysDir())
-	_, err := keyStore.NewAccount(cltest.Password)
-	require.NoError(t, err)
-	require.NoError(t, keyStore.Unlock(cltest.Password))
-
-	ethClient := new(mocks.EthClient)
-	manager := strpkg.NewEthTxManager(ethClient, store.Config, keyStore, store.ORM)
-
-	to := cltest.NewAddress()
-	data, err := hex.DecodeString("0000abcdef")
-
-	manager.Register(keyStore.Accounts())
-	require.NoError(t, err)
-
-	ethClient.On("GetNonce", mock.Anything).Return(uint64(0), nil)
-
-	err = manager.Connect(cltest.Head(uint64(1)))
-	require.NoError(t, err)
-
-	ethClient.On("SendRawTx", mock.Anything).Once().Return(nil, errors.New("send failed"))
-
-	tx0, err := manager.CreateTx(to, data)
-	require.Error(t, err)
-
-	ethClient.On("SendRawTx", mock.Anything).Once().Return(cltest.NewHash(), nil)
-
-	tx1, err := manager.CreateTx(to, data)
-	require.NoError(t, err)
-
-	assert.NotEqualf(t, tx0.Nonce, tx1.Nonce, "nonce of %d was reused", tx0.Nonce)
 
 	ethClient.AssertExpectations(t)
 }

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -280,7 +280,7 @@ func TestTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
 			store, cleanup := cltest.NewStore(t)
 			defer cleanup()
 
-			ethClient := new(mocks.EthClient)
+			ethClient := new(mocks.Client)
 			config := cltest.NewTestConfig(t)
 			require.NoError(t, utils.JustError(store.KeyStore.NewAccount(cltest.Password)))
 			require.NoError(t, store.KeyStore.Unlock(cltest.Password))
@@ -321,7 +321,7 @@ func TestTxManager_CreateTx_NonceTooLowReloadLimit(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
-	ethClient := new(mocks.EthClient)
+	ethClient := new(mocks.Client)
 
 	config := cltest.NewTestConfig(t)
 	keyStore := strpkg.NewKeyStore(config.KeysDir())

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -3,7 +3,6 @@
 package utils
 
 import (
-	"bytes"
 	"chainlink/core/logger"
 	"crypto/rand"
 	"encoding/base64"
@@ -66,16 +65,6 @@ func HexToUint64(hex string) (uint64, error) {
 // Uint64ToHex converts the given uint64 value to a hex-value string.
 func Uint64ToHex(i uint64) string {
 	return fmt.Sprintf("0x%x", i)
-}
-
-// EncodeTxToHex converts the given Ethereum Transaction type and
-// returns its hex-value string.
-func EncodeTxToHex(tx *types.Transaction) (string, error) {
-	rlp := new(bytes.Buffer)
-	if err := tx.EncodeRLP(rlp); err != nil {
-		return "", err
-	}
-	return hexutil.Encode(rlp.Bytes()), nil
 }
 
 // ISO8601UTC formats given time to ISO8601.

--- a/go.sum
+++ b/go.sum
@@ -407,6 +407,7 @@ go.dedis.ch/protobuf v1.0.5 h1:EbF1czEKICxf5KY8Tm7wMF28hcOQbB6yk4IybIFWTYE=
 go.dedis.ch/protobuf v1.0.5/go.mod h1:eIV4wicvi6JK0q/QnfIEGeSFNG0ZeB24kzut5+HaRLo=
 go.dedis.ch/protobuf v1.0.7 h1:wRUEiq3u0/vBhLjcw9CmAVrol+BnDyq2M0XLukdphyI=
 go.dedis.ch/protobuf v1.0.7/go.mod h1:pv5ysfkDX/EawiPqcW3ikOxsL5t+BqnV6xHSmE79KI4=
+go.dedis.ch/protobuf v1.0.11 h1:FTYVIEzY/bfl37lu3pR4lIj+F9Vp1jE8oh91VmxKgLo=
 go.dedis.ch/protobuf v1.0.11/go.mod h1:97QR256dnkimeNdfmURz0wAMNVbd1VmLXhG1CrTYrJ4=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.opencensus.io v0.20.1/go.mod h1:6WKK9ahsWS3RSO+PY9ZHZUfv2irvY6gN279GOPZjmmk=


### PR DESCRIPTION
If a transaction fails upon sending the raw transaction to the chain, it still persists the nonce to the database. But the global nonce is not incremented.

This means that multiple transactions can record the same nonce.

This PR moves the creation of the TxAttempt to after the Transaction has been sent to the ethereum client. Ensuring that TxAttempts don't record duplicate nonces.