### PR TITLE
MinPayment null is not usefully distinct from nil

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -677,7 +677,7 @@ func TestIntegration_CreateServiceAgreement(t *testing.T) {
 	assert.NotEqual(t, "", sa.ID)
 	j := cltest.FindJob(t, app.Store, sa.JobSpecID)
 
-	assert.Equal(t, cltest.NewLink(t, "1000000000000000000"), sa.Encumbrance.Payment)
+	assert.Equal(t, *cltest.NewLink(t, "1000000000000000000"), sa.Encumbrance.Payment)
 	assert.Equal(t, uint64(300), sa.Encumbrance.Expiration)
 
 	assert.Equal(t, endAt, sa.Encumbrance.EndAt.Time)

--- a/core/services/run_manager.go
+++ b/core/services/run_manager.go
@@ -89,7 +89,7 @@ func newRun(
 	run.CreationHeight = models.NewBig(currentHeight)
 	run.ObservedHeight = models.NewBig(currentHeight)
 
-	if !MeetsMinimumPayment(job.MinPayment, payment) {
+	if !MeetsMinimumPayment(&job.MinPayment, payment) {
 		logger.Infow("Rejecting run with insufficient payment",
 			run.ForLogger(
 				"input_payment", payment,
@@ -104,7 +104,7 @@ func newRun(
 	}
 
 	cost := &assets.Link{}
-	cost.Set(job.MinPayment)
+	cost.Set(&job.MinPayment)
 	for i, taskRun := range run.TaskRuns {
 		adapter, err := adapters.For(taskRun.TaskSpec, config, orm)
 
@@ -321,7 +321,6 @@ func (jm *runManager) ResumePending(
 //
 // To recap: This must run before anything else writes job run status to the db,
 // ie. tries to run a job.
-// https://chainlink/pull/807
 func (jm *runManager) ResumeAllInProgress() error {
 	return jm.orm.UnscopedJobRunsWithStatus(jm.runQueue.Run, models.RunStatusInProgress, models.RunStatusPendingSleep)
 }

--- a/core/services/runs.go
+++ b/core/services/runs.go
@@ -18,7 +18,7 @@ func MeetsMinimumPayment(
 	expectedMinJobPayment *assets.Link,
 	actualRunPayment *assets.Link) bool {
 	// input.Payment is always present for runs triggered by ethlogs
-	if actualRunPayment == nil || expectedMinJobPayment == nil || expectedMinJobPayment.IsZero() {
+	if actualRunPayment == nil || expectedMinJobPayment.IsZero() {
 		return true
 	}
 	return expectedMinJobPayment.Cmp(actualRunPayment) < 1

--- a/core/services/validators.go
+++ b/core/services/validators.go
@@ -155,7 +155,7 @@ func ValidateServiceAgreement(sa models.ServiceAgreement, store *store.Store) er
 	fe := models.NewJSONAPIErrors()
 	config := store.Config
 
-	if sa.Encumbrance.Payment == nil {
+	if sa.Encumbrance.Payment.IsZero() {
 		fe.Add("Service agreement encumbrance error: No payment amount set")
 	} else if sa.Encumbrance.Payment.Cmp(config.MinimumContractPayment()) == -1 {
 		fe.Add(fmt.Sprintf("Service agreement encumbrance error: Payment amount is below minimum %v", config.MinimumContractPayment().String()))

--- a/core/store/assets/currencies_test.go
+++ b/core/store/assets/currencies_test.go
@@ -57,11 +57,11 @@ func TestAssets_Link_UnmarshalJsonError(t *testing.T) {
 
 	link := assets.Link{}
 
-	err := json.Unmarshal([]byte(`"a"`), &link)
-	assert.EqualError(t, err, "assets: cannot unmarshal \"a\" into a *assets.Link")
+	err := json.Unmarshal([]byte(`"x"`), &link)
+	assert.EqualError(t, err, "assets: cannot unmarshal \"x\" into a *assets.Link")
 
 	err = json.Unmarshal([]byte(`1`), &link)
-	assert.EqualError(t, err, "json: cannot unmarshal number into Go value of type *assets.Link")
+	assert.Equal(t, assets.ErrNoQuotesForCurrency, err)
 }
 
 func TestAssets_NewEthAndString(t *testing.T) {
@@ -119,9 +119,9 @@ func TestAssets_Eth_UnmarshalJsonError(t *testing.T) {
 
 	eth := assets.Eth{}
 
-	err := json.Unmarshal([]byte(`"a"`), &eth)
-	assert.EqualError(t, err, "assets: cannot unmarshal \"a\" into a *assets.Eth")
+	err := json.Unmarshal([]byte(`"x"`), &eth)
+	assert.EqualError(t, err, "assets: cannot unmarshal \"x\" into a *assets.Eth")
 
 	err = json.Unmarshal([]byte(`1`), &eth)
-	assert.EqualError(t, err, "json: cannot unmarshal number into Go value of type *assets.Eth")
+	assert.Equal(t, assets.ErrNoQuotesForCurrency, err)
 }

--- a/core/store/migrations/migrate_test.go
+++ b/core/store/migrations/migrate_test.go
@@ -165,7 +165,7 @@ func TestMigrate_Migration1565139192(t *testing.T) {
 
 	specNoPayment := models.NewJobFromRequest(models.JobSpecRequest{})
 	specWithPayment := models.NewJobFromRequest(models.JobSpecRequest{
-		MinPayment: assets.NewLink(5),
+		MinPayment: *assets.NewLink(5),
 	})
 	specOneFound := models.JobSpec{}
 	specTwoFound := models.JobSpec{}
@@ -173,9 +173,9 @@ func TestMigrate_Migration1565139192(t *testing.T) {
 	require.NoError(t, db.Create(&specWithPayment).Error)
 	require.NoError(t, db.Create(&specNoPayment).Error)
 	require.NoError(t, db.Where("id = ?", specNoPayment.ID).Find(&specOneFound).Error)
-	require.Equal(t, assets.NewLink(0), specNoPayment.MinPayment)
+	require.Equal(t, *assets.NewLink(0), specNoPayment.MinPayment)
 	require.NoError(t, db.Where("id = ?", specWithPayment.ID).Find(&specTwoFound).Error)
-	require.Equal(t, assets.NewLink(5), specWithPayment.MinPayment)
+	require.Equal(t, *assets.NewLink(5), specWithPayment.MinPayment)
 }
 
 func TestMigrate_Migration1565210496(t *testing.T) {

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -23,7 +23,7 @@ type JobSpecRequest struct {
 	Tasks      []TaskSpecRequest  `json:"tasks"`
 	StartAt    null.Time          `json:"startAt"`
 	EndAt      null.Time          `json:"endAt"`
-	MinPayment *assets.Link       `json:"minPayment"`
+	MinPayment assets.Link        `json:"minPayment"`
 }
 
 // InitiatorRequest represents a schema for incoming initiator requests as used by the API.
@@ -65,14 +65,14 @@ type TaskSpecRequest struct {
 // for a given contract. It contains the Initiators, Tasks (which are the
 // individual steps to be carried out), StartAt, EndAt, and CreatedAt fields.
 type JobSpec struct {
-	ID         *ID          `json:"id,omitempty" gorm:"primary_key;not null"`
-	CreatedAt  time.Time    `json:"createdAt" gorm:"index"`
-	Initiators []Initiator  `json:"initiators"`
-	MinPayment *assets.Link `json:"minPayment" gorm:"type:varchar(255)"`
-	Tasks      []TaskSpec   `json:"tasks"`
-	StartAt    null.Time    `json:"startAt" gorm:"index"`
-	EndAt      null.Time    `json:"endAt" gorm:"index"`
-	DeletedAt  null.Time    `json:"-" gorm:"index"`
+	ID         *ID         `json:"id,omitempty" gorm:"primary_key;not null"`
+	CreatedAt  time.Time   `json:"createdAt" gorm:"index"`
+	Initiators []Initiator `json:"initiators"`
+	MinPayment assets.Link `json:"minPayment" gorm:"type:varchar(255)"`
+	Tasks      []TaskSpec  `json:"tasks"`
+	StartAt    null.Time   `json:"startAt" gorm:"index"`
+	EndAt      null.Time   `json:"endAt" gorm:"index"`
+	DeletedAt  null.Time   `json:"-" gorm:"index"`
 }
 
 // GetID returns the ID of this structure for jsonapi serialization.
@@ -96,7 +96,7 @@ func NewJob() JobSpec {
 	return JobSpec{
 		ID:         NewID(),
 		CreatedAt:  time.Now(),
-		MinPayment: assets.NewLink(0),
+		MinPayment: *assets.NewLink(0),
 	}
 }
 
@@ -119,9 +119,7 @@ func NewJobFromRequest(jsr JobSpecRequest) JobSpec {
 
 	jobSpec.EndAt = jsr.EndAt
 	jobSpec.StartAt = jsr.StartAt
-	if jsr.MinPayment != nil {
-		jobSpec.MinPayment = jsr.MinPayment
-	}
+	jobSpec.MinPayment = jsr.MinPayment
 	return jobSpec
 }
 

--- a/core/store/models/job_spec_test.go
+++ b/core/store/models/job_spec_test.go
@@ -132,7 +132,7 @@ func TestNewJobFromRequest(t *testing.T) {
 		Tasks:      cltest.BuildTaskRequests(t, j1.Tasks),
 		StartAt:    j1.StartAt,
 		EndAt:      j1.EndAt,
-		MinPayment: assets.NewLink(5),
+		MinPayment: *assets.NewLink(5),
 	}
 
 	j2 := models.NewJobFromRequest(jsr)
@@ -142,13 +142,13 @@ func TestNewJobFromRequest(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, fetched1.Initiators, 1)
 	assert.Len(t, fetched1.Tasks, 1)
-	assert.Equal(t, fetched1.MinPayment, assets.NewLink(0))
+	assert.Equal(t, fetched1.MinPayment, *assets.NewLink(0))
 
 	fetched2, err := store.FindJob(j2.ID)
 	assert.NoError(t, err)
 	assert.Len(t, fetched2.Initiators, 1)
 	assert.Len(t, fetched2.Tasks, 1)
-	assert.Equal(t, fetched2.MinPayment, assets.NewLink(5))
+	assert.Equal(t, fetched2.MinPayment, *assets.NewLink(5))
 }
 
 func TestJobSpec_Save(t *testing.T) {

--- a/core/store/models/service_agreement.go
+++ b/core/store/models/service_agreement.go
@@ -21,7 +21,7 @@ type Encumbrance struct {
 	// Corresponds to requestDigest in solidity ServiceAgreement struct
 	ID uint `json:"-" gorm:"primary_key;auto_increment"`
 	// Price to request a report based on this agreement
-	Payment *assets.Link `json:"payment" gorm:"type:varchar(255)"`
+	Payment assets.Link `json:"payment" gorm:"type:varchar(255)"`
 	// Expiration is the amount of time an oracle has to answer a request
 	Expiration uint64 `json:"expiration"`
 	// Agreement is valid until this time
@@ -60,7 +60,7 @@ type ServiceAgreement struct {
 type ServiceAgreementRequest struct {
 	Initiators             []InitiatorRequest     `json:"initiators"`
 	Tasks                  []TaskSpecRequest      `json:"tasks"`
-	Payment                *assets.Link           `json:"payment"`
+	Payment                assets.Link            `json:"payment"`
 	Expiration             uint64                 `json:"expiration"`
 	EndAt                  AnyTime                `json:"endAt"`
 	Oracles                EIP55AddressCollection `json:"oracles"`
@@ -186,7 +186,7 @@ func generateSAID(e Encumbrance, digest common.Hash) (common.Hash, error) {
 func (e Encumbrance) ABI(digest common.Hash) ([]byte, error) {
 	buffer := bytes.Buffer{}
 	var paymentHash common.Hash
-	if e.Payment != nil {
+	if !e.Payment.IsZero() {
 		paymentHash = e.Payment.ToHash()
 	}
 	_, err := buffer.Write(paymentHash.Bytes())

--- a/core/store/models/service_agreement_test.go
+++ b/core/store/models/service_agreement_test.go
@@ -21,7 +21,7 @@ func TestNewUnsignedServiceAgreementFromRequest(t *testing.T) {
 		name        string
 		input       string
 		wantDigest  string
-		wantPayment *assets.Link
+		wantPayment assets.Link
 	}{
 		{
 			"basic",
@@ -35,7 +35,7 @@ func TestNewUnsignedServiceAgreementFromRequest(t *testing.T) {
 				`"aggFulfillSelector":"0x87654321"` +
 				`}`,
 			"0xad12826461f2259eac07e762d9f1d32dd6af2e4ed0797b08cb3d8a8c3c4dd61d",
-			assets.NewLink(1),
+			*assets.NewLink(1),
 		},
 	}
 	for _, test := range tests {
@@ -58,7 +58,7 @@ func TestBuildServiceAgreement(t *testing.T) {
 		name        string
 		input       string
 		wantDigest  string
-		wantPayment *assets.Link
+		wantPayment assets.Link
 	}{
 		{
 			"basic",
@@ -72,7 +72,7 @@ func TestBuildServiceAgreement(t *testing.T) {
 				`"aggFulfillSelector":"0x87654321"` +
 				`}`,
 			"0xad12826461f2259eac07e762d9f1d32dd6af2e4ed0797b08cb3d8a8c3c4dd61d",
-			assets.NewLink(1),
+			*assets.NewLink(1),
 		},
 	}
 	for _, test := range tests {
@@ -102,7 +102,7 @@ func TestEncumbrance_ABI(t *testing.T) {
 
 	tests := []struct {
 		name                   string
-		payment                *assets.Link
+		payment                assets.Link
 		expiration             int
 		endAt                  models.AnyTime
 		oracles                []models.EIP55Address
@@ -111,7 +111,7 @@ func TestEncumbrance_ABI(t *testing.T) {
 		aggFulfillSelector     string
 		want                   string
 	}{
-		{"basic", assets.NewLink(1), 2, models.AnyTime{}, nil,
+		{"basic", *assets.NewLink(1), 2, models.AnyTime{}, nil,
 			"0x0000000000000000000000000000000000000000000000000000000000000000", "0x00000000", "0x00000000",
 			"0x" +
 				"0000000000000000000000000000000000000000000000000000000000000001" + // Payment
@@ -121,7 +121,7 @@ func TestEncumbrance_ABI(t *testing.T) {
 				"0000000000000000000000000000000000000000" + // Aggregator address
 				"00000000" + "00000000", // Function selectors
 		},
-		{"basic dead beef payment", assets.NewLink(3735928559), 2, models.AnyTime{}, nil,
+		{"basic dead beef payment", *assets.NewLink(3735928559), 2, models.AnyTime{}, nil,
 			"0x0000000000000000000000000000000000000000000000000000000000000000", "0x00000000", "0x00000000",
 			"0x" +
 				"00000000000000000000000000000000000000000000000000000000deadbeef" + // Payment
@@ -131,7 +131,7 @@ func TestEncumbrance_ABI(t *testing.T) {
 				"0000000000000000000000000000000000000000" + // Aggregator address
 				"00000000" + "00000000", // Function selectors
 		},
-		{"empty", nil, 0, models.AnyTime{}, nil,
+		{"empty", *assets.NewLink(0), 0, models.AnyTime{}, nil,
 			"0x0000000000000000000000000000000000000000000000000000000000000000", "0x00000000", "0x00000000",
 			"0x" +
 				"0000000000000000000000000000000000000000000000000000000000000000" + // Payment
@@ -141,7 +141,7 @@ func TestEncumbrance_ABI(t *testing.T) {
 				"0000000000000000000000000000000000000000" + // Aggregator address
 				"00000000" + "00000000", // Function selectors
 		},
-		{"oracle address", nil, 0, models.AnyTime{},
+		{"oracle address", *assets.NewLink(0), 0, models.AnyTime{},
 			[]models.EIP55Address{models.EIP55Address("0xa0788FC17B1dEe36f057c42B6F373A34B014687e")},
 			"0x0000000000000000000000000000000000000000000000000000000000000000", "0x00000000", "0x00000000",
 			"0x" +
@@ -153,7 +153,7 @@ func TestEncumbrance_ABI(t *testing.T) {
 				"0000000000000000000000000000000000000000" + // Aggregator address
 				"00000000" + "00000000", // Function selectors
 		},
-		{"different endAt", nil, 0, models.NewAnyTime(endAt),
+		{"different endAt", *assets.NewLink(0), 0, models.NewAnyTime(endAt),
 			[]models.EIP55Address{models.EIP55Address("0xa0788FC17B1dEe36f057c42B6F373A34B014687e")},
 			"0x0000000000000000000000000000000000000000000000000000000000000000", "0x00000000", "0x00000000",
 			"0x" +
@@ -165,7 +165,7 @@ func TestEncumbrance_ABI(t *testing.T) {
 				"0000000000000000000000000000000000000000" + // Aggregator address
 				"00000000" + "00000000", // Function selectors
 		},
-		{name: "aggregator info", payment: nil, expiration: 0, endAt: models.NewAnyTime(endAt),
+		{name: "aggregator info", expiration: 0, endAt: models.NewAnyTime(endAt),
 			oracles: []models.EIP55Address{
 				models.EIP55Address("0xa0788FC17B1dEe36f057c42B6F373A34B014687e"),
 			},
@@ -210,7 +210,7 @@ func TestServiceAgreementRequest_UnmarshalJSON(t *testing.T) {
 		name        string
 		input       string
 		wantDigest  string
-		wantPayment *assets.Link
+		wantPayment assets.Link
 	}{
 		{
 			"basic",
@@ -225,7 +225,7 @@ func TestServiceAgreementRequest_UnmarshalJSON(t *testing.T) {
 				`"endAt":"2018-06-19T22:17:19Z"}` +
 				`}`,
 			"0x57bf5be3447b9a3f8491b6538b01f828bcfcaf2d685ea90375ed4ec2943f4865",
-			assets.NewLink(1),
+			*assets.NewLink(1),
 		},
 	}
 	for _, test := range tests {

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -196,15 +196,15 @@ func NewConfigWhitelist(store *store.Store) (ConfigWhitelist, error) {
 			MinIncomingConfirmations: config.MinIncomingConfirmations(),
 			MinOutgoingConfirmations: config.MinOutgoingConfirmations(),
 			OracleContractAddress:    config.OracleContractAddress(),
-			Port:             config.Port(),
-			ReaperExpiration: config.ReaperExpiration(),
-			ReplayFromBlock:  config.ReplayFromBlock(),
-			RootDir:          config.RootDir(),
-			SessionTimeout:   config.SessionTimeout(),
-			TLSHost:          config.TLSHost(),
-			TLSPort:          config.TLSPort(),
-			TLSRedirect:      config.TLSRedirect(),
-			TxAttemptLimit:   config.TxAttemptLimit(),
+			Port:                     config.Port(),
+			ReaperExpiration:         config.ReaperExpiration(),
+			ReplayFromBlock:          config.ReplayFromBlock(),
+			RootDir:                  config.RootDir(),
+			SessionTimeout:           config.SessionTimeout(),
+			TLSHost:                  config.TLSHost(),
+			TLSPort:                  config.TLSPort(),
+			TLSRedirect:              config.TLSRedirect(),
+			TxAttemptLimit:           config.TxAttemptLimit(),
 		},
 	}, nil
 }
@@ -308,9 +308,6 @@ func (job JobSpec) FriendlyEndAt() string {
 // FriendlyMinPayment returns a formatted string of the Job's
 // Minimum Link Payment threshold
 func (job JobSpec) FriendlyMinPayment() string {
-	if job.MinPayment == nil {
-		return assets.NewLink(0).Text(10)
-	}
 	return job.MinPayment.Text(10)
 }
 


### PR DESCRIPTION
We keep a pointer Link in a bunch of structs, but a pointer on a struct takes up more space and nil is not usefully distinct from a 0 value in this case.

So just remove the pointer usage for assets.Link and no more null pointer exceptions!