### PR TITLE
Chore/streamline logging

### DIFF
--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -578,15 +578,6 @@ func (txm *EthTxManager) processAttempt(
 
 	switch state {
 	case Safe:
-		logger.Debugw(
-			fmt.Sprintf("Tx #%d is %s", attemptIndex, state),
-			"txHash", txAttempt.Hash.String(),
-			"txID", txAttempt.TxID,
-			"receiptBlockNumber", receipt.BlockNumber.ToInt(),
-			"currentBlockNumber", blockHeight,
-			"receiptHash", receipt.Hash.Hex(),
-		)
-
 		txm.updateLastSafeNonce(tx)
 		return receipt, state, txm.handleSafe(tx, attemptIndex)
 
@@ -686,7 +677,8 @@ func (txm *EthTxManager) handleSafe(
 	ethBalance, linkBalance, balanceErr := txm.GetETHAndLINKBalances(tx.From)
 
 	logger.Infow(
-		fmt.Sprintf("Tx #%d got minimum confirmations (%d)", attemptIndex, minimumConfirmations),
+		fmt.Sprintf("Tx #%d is safe", attemptIndex),
+		"minimumConfirmations", minimumConfirmations,
 		"txHash", txAttempt.Hash.String(),
 		"txID", txAttempt.TxID,
 		"ethBalance", ethBalance,


### PR DESCRIPTION
While watching 0.7.0 run, I noticed some logging improvements that could be made.

 a) Only one log message to indicate that a transaction is safe (used to be two)
 b) Don't print the result.Data() it is often massive and prevents the log system from allowing us to read the log message