### PR TITLE
Don't perform build-{chainlink,explorer} on develop/master/release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -419,18 +419,17 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-      - build-chainlink:
+      - prepublish_npm:
           filters:
             tags:
               only: /^v.*/
       - build-explorer:
           filters:
-            tags:
-              only: /^v.*/
-      - prepublish_npm:
-          filters:
-            tags:
-              only: /^v.*/
+            branches:
+              ignore:
+                - develop
+                - /^release\/.*/
+                - master
       - build-publish-explorer:
           requires:
             - explorer
@@ -441,6 +440,13 @@ workflows:
                 - /^release\/.*/
             tags:
               only: /^explorer-v.*/ # handles final versioned releases
+      - build-chainlink:
+          filters:
+            branches:
+              ignore:
+                - develop
+                - /^release\/.*/
+                - master
       - build-publish-chainlink:
           requires:
             - go-sqlite


### PR DESCRIPTION
We don't need to execute `build-chainlink` as well as `build-and-publish-chainlink` on the same branches.