### PR TITLE
Fix/readme test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ $ yarn build
 3. Ready for testing:
 
 ```bash
-$ go test ./...
+$ go test -parallel=1 ./...
 ```
 
 ### Solidity Development

--- a/README.md
+++ b/README.md
@@ -114,6 +114,17 @@ $ ./chainlink
 
 ### Test
 
+1. [Install Yarn](https://yarnpkg.com/lang/en/docs/install)
+
+2. Build contracts:
+
+```bash
+$ cd evm
+$ yarn build
+```
+
+3. Ready for testing:
+
 ```bash
 $ go test ./...
 ```


### PR DESCRIPTION
Update the README instructions for testing to include preparation steps as well as the parallel argument to make tests less likely to fail due to memory consumption.