### PR TITLE
Feature/chainlink api key

### DIFF
--- a/core/auth/auth.go
+++ b/core/auth/auth.go
@@ -1,0 +1,62 @@
+package auth
+
+import (
+	"chainlink/core/utils"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"golang.org/x/crypto/sha3"
+)
+
+var (
+	// ErrorAuthFailed is a generic authentication failed - but not because of
+	// some system failure on our behalf (i.e. HTTP 5xx), more detail is not
+	// given
+	ErrorAuthFailed = errors.New("Authentication failed")
+)
+
+// Token is used for API authentication.
+type Token struct {
+	AccessKey string `json:"accessKey"`
+	Secret    string `json:"secret"`
+}
+
+// GetID returns the ID of this structure for jsonapi serialization.
+func (ta *Token) GetID() string {
+	return ta.AccessKey
+}
+
+// GetName returns the pluralized "type" of this structure for jsonapi serialization.
+func (ta *Token) GetName() string {
+	return "auth_tokens"
+}
+
+// SetID returns the ID of this structure for jsonapi serialization.
+func (ta *Token) SetID(id string) error {
+	ta.AccessKey = id
+	return nil
+}
+
+// NewToken returns a new Authentication Token.
+func NewToken() *Token {
+	return &Token{
+		AccessKey: utils.NewBytes32ID(),
+		Secret:    utils.NewSecret(utils.DefaultSecretSize),
+	}
+}
+
+func hashInput(ta *Token, salt string) []byte {
+	return []byte(fmt.Sprintf("v0-%s-%s-%s", ta.AccessKey, ta.Secret, salt))
+}
+
+// HashedSecret generates a hashed password for an external initiator
+// authentication
+func HashedSecret(ta *Token, salt string) (string, error) {
+	hasher := sha3.New256()
+	_, err := hasher.Write(hashInput(ta, salt))
+	if err != nil {
+		return "", errors.Wrap(err, "error writing external initiator authentication to hasher")
+	}
+	return hex.EncodeToString(hasher.Sum(nil)), nil
+}

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -17,6 +17,7 @@ import (
 	"testing"
 	"time"
 
+	"chainlink/core/auth"
 	"chainlink/core/cmd"
 	"chainlink/core/logger"
 	"chainlink/core/services"
@@ -604,7 +605,7 @@ func CreateJobRunViaExternalInitiator(
 	t testing.TB,
 	app *TestApplication,
 	j models.JobSpec,
-	eia models.ExternalInitiatorAuthentication,
+	eia auth.Token,
 	body string,
 ) models.JobRun {
 	t.Helper()

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -50,6 +50,10 @@ const (
 	RootDir = "/tmp/chainlink_test"
 	// APIEmail of the API user
 	APIEmail = "email@test.net"
+	// APIKey of the API user
+	APIKey = "2d25e62eaf9143e993acaf48691564b2"
+	// APISecret of the API user.
+	APISecret = "1eCP/w0llVkchejFaoBpfIGaLRxZK54lTXBCT22YLW+pdzE4Fafy/XO5LoJ2uwHi"
 	// Password the password
 	Password = "password"
 	// APISessionID ID for API user
@@ -319,6 +323,16 @@ func (ta *TestApplication) MustSeedUserSession() models.User {
 	require.NoError(ta.t, ta.Store.SaveUser(&mockUser))
 	session := NewSession(APISessionID)
 	require.NoError(ta.t, ta.Store.SaveSession(&session))
+	return mockUser
+}
+
+// MustSeedUserAPIKey creates and returns a User with their API Token Key and
+// Secret generated.
+func (ta *TestApplication) MustSeedUserAPIKey() models.User {
+	mockUser := MustUser(APIEmail, Password)
+	apiToken := auth.Token{APIKey, APISecret}
+	require.NoError(ta.t, mockUser.SetAuthToken(&apiToken))
+	require.NoError(ta.t, ta.Store.SaveUser(&mockUser))
 	return mockUser
 }
 

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"chainlink/core/auth"
 	"chainlink/core/internal/cltest"
 	"chainlink/core/store/models"
 	"chainlink/core/utils"
@@ -782,7 +783,7 @@ func TestIntegration_ExternalInitiator(t *testing.T) {
 	require.NoError(t, err)
 	eip := cltest.CreateExternalInitiatorViaWeb(t, app, string(eiCreateJSON))
 
-	eia := &models.ExternalInitiatorAuthentication{
+	eia := &auth.Token{
 		AccessKey: eip.AccessKey,
 		Secret:    eip.Secret,
 	}
@@ -831,7 +832,7 @@ func TestIntegration_ExternalInitiator_WithoutURL(t *testing.T) {
 	require.NoError(t, err)
 	eip := cltest.CreateExternalInitiatorViaWeb(t, app, string(eiCreateJSON))
 
-	eia := &models.ExternalInitiatorAuthentication{
+	eia := &auth.Token{
 		AccessKey: eip.AccessKey,
 		Secret:    eip.Secret,
 	}

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -26,6 +26,7 @@ import (
 	"chainlink/core/store/migrations/migration1570087128"
 	"chainlink/core/store/migrations/migration1570675883"
 	"chainlink/core/store/migrations/migration1573667511"
+	"chainlink/core/store/migrations/migration1573812490"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -135,6 +136,10 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "1573667511",
 			Migrate: migration1573667511.Migrate,
+		},
+		{
+			ID:      "1573812490",
+			Migrate: migration1573812490.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration1573812490/migrate.go
+++ b/core/store/migrations/migration1573812490/migrate.go
@@ -1,0 +1,24 @@
+package migration1573812490
+
+import (
+	"time"
+
+	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
+)
+
+type user struct {
+	Email          string    `json:"email" gorm:"primary_key"`
+	HashedPassword string    `json:"hashedPassword"`
+	CreatedAt      time.Time `json:"createdAt" gorm:"index"`
+	TokenKey       string    `json:"tokenKey"`
+	TokenSecret    string    `json:"tokenSecret"`
+}
+
+// Migrate adds fields 'TokenKey' and 'TokenSecret' to support Token Authentication of a user.
+func Migrate(tx *gorm.DB) error {
+	if err := tx.AutoMigrate(&user{}).Error; err != nil {
+		return errors.Wrap(err, "could not add fields 'TokenKey' and 'TokenSecreet' to table")
+	}
+	return nil
+}

--- a/core/store/models/external_initiator.go
+++ b/core/store/models/external_initiator.go
@@ -2,15 +2,13 @@ package models
 
 import (
 	"crypto/subtle"
-	"encoding/hex"
-	"fmt"
 	"strings"
 
+	"chainlink/core/auth"
 	"chainlink/core/utils"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
-	"golang.org/x/crypto/sha3"
 )
 
 // ExternalInitiatorRequest is the incoming record used to create an ExternalInitiator.
@@ -32,13 +30,13 @@ type ExternalInitiator struct {
 }
 
 // NewExternalInitiator generates an ExternalInitiator from an
-// ExternalInitiatorAuthentication, hashing the password for storage
+// auth.Token, hashing the password for storage
 func NewExternalInitiator(
-	eia *ExternalInitiatorAuthentication,
+	eia *auth.Token,
 	eir *ExternalInitiatorRequest,
 ) (*ExternalInitiator, error) {
 	salt := utils.NewSecret(utils.DefaultSecretSize)
-	hashedSecret, err := HashedSecret(eia, salt)
+	hashedSecret, err := auth.HashedSecret(eia, salt)
 	if err != nil {
 		return nil, errors.Wrap(err, "error hashing secret for external initiator")
 	}
@@ -56,59 +54,10 @@ func NewExternalInitiator(
 
 // AuthenticateExternalInitiator compares an auth against an initiator and
 // returns true if the password hashes match
-func AuthenticateExternalInitiator(eia *ExternalInitiatorAuthentication, ea *ExternalInitiator) (bool, error) {
-	hashedSecret, err := HashedSecret(eia, ea.Salt)
+func AuthenticateExternalInitiator(eia *auth.Token, ea *ExternalInitiator) (bool, error) {
+	hashedSecret, err := auth.HashedSecret(eia, ea.Salt)
 	if err != nil {
 		return false, err
 	}
 	return subtle.ConstantTimeCompare([]byte(hashedSecret), []byte(ea.HashedSecret)) == 1, nil
-}
-
-// NewExternalInitiatorAuthentication returns a new
-// ExternalInitiatorAuthentication with a freshly generated access key and
-// secret, this is intended to be supplied to the user and saved, as it cannot
-// be regenerated in the future.
-func NewExternalInitiatorAuthentication() *ExternalInitiatorAuthentication {
-	return &ExternalInitiatorAuthentication{
-		AccessKey: utils.NewBytes32ID(),
-		Secret:    utils.NewSecret(utils.DefaultSecretSize),
-	}
-}
-
-func hashInput(eia *ExternalInitiatorAuthentication, salt string) []byte {
-	return []byte(fmt.Sprintf("v0-%s-%s-%s", eia.AccessKey, eia.Secret, salt))
-}
-
-// HashedSecret generates a hashed password for an external initiator
-// authentication
-func HashedSecret(eia *ExternalInitiatorAuthentication, salt string) (string, error) {
-	hasher := sha3.New256()
-	_, err := hasher.Write(hashInput(eia, salt))
-	if err != nil {
-		return "", errors.Wrap(err, "error writing external initiator authentication to hasher")
-	}
-	return hex.EncodeToString(hasher.Sum(nil)), nil
-}
-
-// ExternalInitiatorAuthentication represents the credentials needed to
-// authenticate as an external initiator
-type ExternalInitiatorAuthentication struct {
-	AccessKey string
-	Secret    string
-}
-
-// GetID returns the ID of this structure for jsonapi serialization.
-func (eia *ExternalInitiatorAuthentication) GetID() string {
-	return eia.AccessKey
-}
-
-// GetName returns the pluralized "type" of this structure for jsonapi serialization.
-func (eia *ExternalInitiatorAuthentication) GetName() string {
-	return "external_initiators"
-}
-
-// SetID returns the ID of this structure for jsonapi serialization.
-func (eia *ExternalInitiatorAuthentication) SetID(id string) error {
-	eia.AccessKey = id
-	return nil
 }

--- a/core/store/models/external_initiator_test.go
+++ b/core/store/models/external_initiator_test.go
@@ -3,6 +3,7 @@ package models_test
 import (
 	"testing"
 
+	"chainlink/core/auth"
 	"chainlink/core/internal/cltest"
 	"chainlink/core/store/models"
 
@@ -10,7 +11,7 @@ import (
 )
 
 func TestNewExternalInitiator(t *testing.T) {
-	eia := models.NewExternalInitiatorAuthentication()
+	eia := auth.NewToken()
 	assert.Len(t, eia.AccessKey, 32)
 	assert.Len(t, eia.Secret, 64)
 

--- a/core/store/models/user.go
+++ b/core/store/models/user.go
@@ -13,6 +13,8 @@ type User struct {
 	Email          string    `json:"email" gorm:"primary_key"`
 	HashedPassword string    `json:"hashedPassword"`
 	CreatedAt      time.Time `json:"createdAt" gorm:"index"`
+	TokenKey       string    `json:"tokenKey"`
+	TokenSecret    string    `json:"tokenSecret"`
 }
 
 // https://davidcel.is/posts/stop-validating-email-addresses-with-regex/

--- a/core/store/models/user.go
+++ b/core/store/models/user.go
@@ -1,20 +1,24 @@
 package models
 
 import (
-	"errors"
+	"crypto/subtle"
 	"regexp"
 	"time"
 
+	"chainlink/core/auth"
 	"chainlink/core/utils"
+
+	"github.com/pkg/errors"
 )
 
 // User holds the credentials for API user.
 type User struct {
-	Email          string    `json:"email" gorm:"primary_key"`
-	HashedPassword string    `json:"hashedPassword"`
-	CreatedAt      time.Time `json:"createdAt" gorm:"index"`
-	TokenKey       string    `json:"tokenKey"`
-	TokenSecret    string    `json:"tokenSecret"`
+	Email             string    `json:"email" gorm:"primary_key"`
+	HashedPassword    string    `json:"hashedPassword"`
+	CreatedAt         time.Time `json:"createdAt" gorm:"index"`
+	TokenKey          string    `json:"tokenKey"`
+	TokenSalt         string    `json:"-"`
+	TokenHashedSecret string    `json:"-"`
 }
 
 // https://davidcel.is/posts/stop-validating-email-addresses-with-regex/
@@ -72,4 +76,46 @@ func NewSession() Session {
 type ChangePasswordRequest struct {
 	OldPassword string `json:"oldPassword"`
 	NewPassword string `json:"newPassword"`
+}
+
+// Changeauth.TokenRequest is sent when updating a User's authentication token.
+type ChangeAuthTokenRequest struct {
+	Password string `json:"password"`
+}
+
+// GenerateAuthToken randomly generates and sets the users Authentication
+// Token.
+func (u *User) GenerateAuthToken() (*auth.Token, error) {
+	token := auth.NewToken()
+	return token, u.SetAuthToken(token)
+}
+
+// DeleteAuthToken clears and disables the users Authentication Token.
+func (u *User) DeleteAuthToken() {
+	u.TokenKey = ""
+	u.TokenSalt = ""
+	u.TokenHashedSecret = ""
+}
+
+// SetAuthToken updates the user to use the given Authentication Token.
+func (u *User) SetAuthToken(token *auth.Token) error {
+	salt := utils.NewSecret(utils.DefaultSecretSize)
+	hashedSecret, err := auth.HashedSecret(token, salt)
+	if err != nil {
+		return errors.Wrap(err, "user")
+	}
+	u.TokenSalt = salt
+	u.TokenKey = token.AccessKey
+	u.TokenHashedSecret = hashedSecret
+	return nil
+}
+
+// AuthenticateUserByToken returns true on successful authentication of the
+// user against the given Authentication Token.
+func AuthenticateUserByToken(token *auth.Token, user *User) (bool, error) {
+	hashedSecret, err := auth.HashedSecret(token, user.TokenSalt)
+	if err != nil {
+		return false, err
+	}
+	return subtle.ConstantTimeCompare([]byte(hashedSecret), []byte(user.TokenHashedSecret)) == 1, nil
 }

--- a/core/store/models/user_test.go
+++ b/core/store/models/user_test.go
@@ -7,6 +7,7 @@ import (
 	"chainlink/core/utils"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNewUser(t *testing.T) {
@@ -38,4 +39,26 @@ func TestNewUser(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestUserGenerateAuthToken(t *testing.T) {
+	var user models.User
+	token, err := user.GenerateAuthToken()
+	require.NoError(t, err)
+	assert.Equal(t, token.AccessKey, user.TokenKey)
+	assert.NotEqual(t, token.Secret, user.TokenHashedSecret)
+}
+
+func TestAuthenticateUserByToken(t *testing.T) {
+	var user models.User
+
+	token, err := user.GenerateAuthToken()
+	ok, err := models.AuthenticateUserByToken(token, &user)
+	require.NoError(t, err)
+	assert.True(t, ok, "authentication must be successful")
+
+	_, err = user.GenerateAuthToken()
+	ok, err = models.AuthenticateUserByToken(token, &user)
+	require.NoError(t, err)
+	assert.False(t, ok, "authentication must fail with past token")
 }

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -818,6 +818,11 @@ func (orm *ORM) AuthorizedUserWithSession(sessionID string, sessionDuration time
 	return orm.FindUser()
 }
 
+// AuthorizedUserWithToken ...
+func (orm *ORM) AuthorizedUserWithToken(tokenSecret string) (models.User, error) {
+	return models.User{}, errors.New("not implemented")
+}
+
 // DeleteUser will delete the API User in the db.
 func (orm *ORM) DeleteUser() (models.User, error) {
 	orm.MustEnsureAdvisoryLock()

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -818,11 +818,6 @@ func (orm *ORM) AuthorizedUserWithSession(sessionID string, sessionDuration time
 	return orm.FindUser()
 }
 
-// AuthorizedUserWithToken ...
-func (orm *ORM) AuthorizedUserWithToken(tokenSecret string) (models.User, error) {
-	return models.User{}, errors.New("not implemented")
-}
-
 // DeleteUser will delete the API User in the db.
 func (orm *ORM) DeleteUser() (models.User, error) {
 	orm.MustEnsureAdvisoryLock()

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"chainlink/core/auth"
 	"chainlink/core/gracefulpanic"
 	"chainlink/core/logger"
 	"chainlink/core/store/assets"
@@ -377,7 +378,9 @@ func (orm *ORM) DeleteExternalInitiator(accessKey string) error {
 }
 
 // FindExternalInitiator finds an external initiator given an authentication request
-func (orm *ORM) FindExternalInitiator(eia *models.ExternalInitiatorAuthentication) (*models.ExternalInitiator, error) {
+func (orm *ORM) FindExternalInitiator(
+	eia *auth.Token,
+) (*models.ExternalInitiator, error) {
 	orm.MustEnsureAdvisoryLock()
 	initiator := &models.ExternalInitiator{}
 	err := orm.db.Where("access_key = ?", eia.AccessKey).Find(initiator).Error

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"time"
 
+	"chainlink/core/auth"
 	"chainlink/core/logger"
 	"chainlink/core/store"
 	"chainlink/core/store/assets"
@@ -633,7 +634,7 @@ type ExternalInitiatorAuthentication struct {
 // NewExternalInitiatorAuthentication creates an instance of ExternalInitiatorAuthentication.
 func NewExternalInitiatorAuthentication(
 	ei models.ExternalInitiator,
-	eia models.ExternalInitiatorAuthentication,
+	eia auth.Token,
 ) *ExternalInitiatorAuthentication {
 	var result = &ExternalInitiatorAuthentication{
 		Name:           ei.Name,

--- a/core/web/authentication.go
+++ b/core/web/authentication.go
@@ -1,0 +1,106 @@
+package web
+
+import (
+	"chainlink/core/auth"
+	"chainlink/core/store"
+	"chainlink/core/store/models"
+	"chainlink/core/store/orm"
+	"net/http"
+
+	"github.com/gin-gonic/contrib/sessions"
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+)
+
+const (
+	// APIKey is the header name for the API token identifier for user authentication.
+	APIKey = "X-API-KEY"
+	// APISecret is the header name for the API token secret for user authentication.
+	APISecret = "X-API-SECRET"
+	// ExternalInitiatorAccessKeyHeader is the header name for the access key
+	// used by external initiators to authenticate
+	ExternalInitiatorAccessKeyHeader = "X-Chainlink-EA-AccessKey"
+	// ExternalInitiatorSecretHeader is the header name for the secret used by
+	// external initiators to authenticate
+	ExternalInitiatorSecretHeader = "X-Chainlink-EA-Secret"
+)
+
+type authType func(store *store.Store, ctx *gin.Context) error
+
+func authenticatedUser(c *gin.Context) (*models.User, bool) {
+	obj, ok := c.Get(SessionUserKey)
+	if !ok {
+		return nil, false
+	}
+	return obj.(*models.User), ok
+}
+
+func AuthenticateExternalInitiator(store *store.Store, c *gin.Context) error {
+	eia := &auth.Token{
+		AccessKey: c.GetHeader(ExternalInitiatorAccessKeyHeader),
+		Secret:    c.GetHeader(ExternalInitiatorSecretHeader),
+	}
+
+	ei, err := store.FindExternalInitiator(eia)
+	if errors.Cause(err) == orm.ErrorNotFound {
+		return auth.ErrorAuthFailed
+	} else if err != nil {
+		return errors.Wrap(err, "finding external intiator")
+	}
+
+	ok, err := models.AuthenticateExternalInitiator(eia, ei)
+	if err != nil {
+		return err
+	}
+
+	if !ok {
+		return auth.ErrorAuthFailed
+	}
+	c.Set(SessionExternalInitiatorKey, ei)
+
+	return nil
+}
+
+var _ authType = AuthenticateExternalInitiator
+
+func authenticatedEI(c *gin.Context) (*models.ExternalInitiator, bool) {
+	obj, ok := c.Get(SessionExternalInitiatorKey)
+	if !ok {
+		return nil, false
+	}
+	return obj.(*models.ExternalInitiator), ok
+}
+
+func AuthenticateBySession(store *store.Store, c *gin.Context) error {
+	session := sessions.Default(c)
+	sessionID, ok := session.Get(SessionIDKey).(string)
+	if !ok {
+		return auth.ErrorAuthFailed
+	}
+
+	user, err := store.AuthorizedUserWithSession(sessionID)
+	if err != nil {
+		return err
+	}
+	c.Set(SessionUserKey, &user)
+	return nil
+}
+
+var _ authType = AuthenticateBySession
+
+func RequireAuth(store *store.Store, methods ...authType) gin.HandlerFunc {
+	return func(c *gin.Context) {
+		var err error
+		for _, method := range methods {
+			err = method(store, c)
+			if err != auth.ErrorAuthFailed {
+				break
+			}
+		}
+		if err != nil {
+			c.AbortWithStatus(http.StatusUnauthorized)
+		} else {
+			c.Next()
+		}
+	}
+}

--- a/core/web/authentication_test.go
+++ b/core/web/authentication_test.go
@@ -1,0 +1,98 @@
+package web_test
+
+import (
+	"chainlink/core/auth"
+	"chainlink/core/store"
+	"chainlink/core/web"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+func authError(_ *store.Store, _ *gin.Context) error {
+	return errors.New("random error")
+}
+
+func authFailure(_ *store.Store, _ *gin.Context) error {
+	return auth.ErrorAuthFailed
+}
+
+func authSuccess(_ *store.Store, _ *gin.Context) error {
+	return nil
+}
+
+func TestRequireAuth_NoneRequired(t *testing.T) {
+	called := false
+	var store *store.Store
+	router := gin.New()
+	router.Use(web.RequireAuth(store))
+	router.GET("/", func(c *gin.Context) {
+		called = true
+		c.String(http.StatusOK, "")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	router.ServeHTTP(w, req)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusText(http.StatusOK), http.StatusText(w.Code))
+}
+
+func TestRequireAuth_AuthFailed(t *testing.T) {
+	called := false
+	var store *store.Store
+	router := gin.New()
+	router.Use(web.RequireAuth(store, authFailure))
+	router.GET("/", func(c *gin.Context) {
+		called = true
+		c.String(http.StatusOK, "")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	router.ServeHTTP(w, req)
+
+	assert.False(t, called)
+	assert.Equal(t, http.StatusText(http.StatusUnauthorized), http.StatusText(w.Code))
+}
+
+func TestRequireAuth_LastAuthSuccess(t *testing.T) {
+	called := false
+	var store *store.Store
+	router := gin.New()
+	router.Use(web.RequireAuth(store, authFailure, authSuccess))
+	router.GET("/", func(c *gin.Context) {
+		called = true
+		c.String(http.StatusOK, "")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	router.ServeHTTP(w, req)
+
+	assert.True(t, called)
+	assert.Equal(t, http.StatusText(http.StatusOK), http.StatusText(w.Code))
+}
+
+func TestRequireAuth_Error(t *testing.T) {
+	called := false
+	var store *store.Store
+	router := gin.New()
+	router.Use(web.RequireAuth(store, authError, authSuccess))
+	router.GET("/", func(c *gin.Context) {
+		called = true
+		c.String(http.StatusOK, "")
+	})
+
+	w := httptest.NewRecorder()
+	req, _ := http.NewRequest("GET", "/", nil)
+	router.ServeHTTP(w, req)
+
+	assert.False(t, called)
+	assert.Equal(t, http.StatusText(http.StatusUnauthorized), http.StatusText(w.Code))
+}

--- a/core/web/authentication_test.go
+++ b/core/web/authentication_test.go
@@ -15,15 +15,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func authError(_ *store.Store, _ *gin.Context) error {
+func authError(*store.Store, *gin.Context) error {
 	return errors.New("random error")
 }
 
-func authFailure(_ *store.Store, _ *gin.Context) error {
+func authFailure(*store.Store, *gin.Context) error {
 	return auth.ErrorAuthFailed
 }
 
-func authSuccess(_ *store.Store, _ *gin.Context) error {
+func authSuccess(*store.Store, *gin.Context) error {
 	return nil
 }
 

--- a/core/web/external_initiators_controller.go
+++ b/core/web/external_initiators_controller.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"net/http"
 
+	"chainlink/core/auth"
 	"chainlink/core/services"
 	"chainlink/core/store/models"
 	"chainlink/core/store/presenters"
@@ -24,7 +25,7 @@ func (eic *ExternalInitiatorsController) Create(c *gin.Context) {
 		return
 	}
 
-	eia := models.NewExternalInitiatorAuthentication()
+	eia := auth.NewToken()
 	if err := c.ShouldBindJSON(eir); err != nil {
 		jsonAPIError(c, http.StatusUnprocessableEntity, err)
 	} else if ei, err := models.NewExternalInitiator(eia, eir); err != nil {

--- a/core/web/external_initiators_test.go
+++ b/core/web/external_initiators_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"testing"
 
+	"chainlink/core/auth"
 	"chainlink/core/internal/cltest"
 	"chainlink/core/store/models"
 	"chainlink/core/web"
@@ -91,7 +92,7 @@ func TestNotifyExternalInitiator_Notified(t *testing.T) {
 
 			url := cltest.WebURL(t, eiMockServer.URL)
 			test.ExInitr.URL = &url
-			eia := models.NewExternalInitiatorAuthentication()
+			eia := auth.NewToken()
 			ei, err := models.NewExternalInitiator(eia, &test.ExInitr)
 			require.NoError(t, err)
 			err = store.CreateExternalInitiator(ei)
@@ -165,7 +166,7 @@ func TestNotifyExternalInitiator_NotNotified(t *testing.T) {
 
 			url := cltest.WebURL(t, eiMockServer.URL)
 			test.ExInitr.URL = &url
-			eia := models.NewExternalInitiatorAuthentication()
+			eia := auth.NewToken()
 			ei, err := models.NewExternalInitiator(eia, &test.ExInitr)
 			require.NoError(t, err)
 			err = store.CreateExternalInitiator(ei)

--- a/core/web/job_runs_controller_test.go
+++ b/core/web/job_runs_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"chainlink/core/auth"
 	"chainlink/core/internal/cltest"
 	"chainlink/core/store/models"
 	"chainlink/core/store/presenters"
@@ -148,7 +149,7 @@ func TestJobRunsController_Create_Wrong_ExternalInitiator(t *testing.T) {
 		Name: "bitcoin",
 		URL:  &eir_url,
 	}
-	eia := models.NewExternalInitiatorAuthentication()
+	eia := auth.NewToken()
 	ei, err := models.NewExternalInitiator(eia, eir)
 	require.NoError(t, err)
 	assert.NoError(t, app.Store.CreateExternalInitiator(ei))
@@ -160,7 +161,7 @@ func TestJobRunsController_Create_Wrong_ExternalInitiator(t *testing.T) {
 		Name: "someCoin",
 		URL:  &eir_url,
 	}
-	wrongEIA := models.NewExternalInitiatorAuthentication()
+	wrongEIA := auth.NewToken()
 	wrongEI, err := models.NewExternalInitiator(wrongEIA, wrongEIR)
 	require.NoError(t, err)
 	assert.NoError(t, app.Store.CreateExternalInitiator(wrongEI))
@@ -184,8 +185,7 @@ func TestJobRunsController_Create_ExternalInitiator_Success(t *testing.T) {
 	defer cleanup()
 
 	url := cltest.WebURL(t, "http://localhost:8888")
-
-	eia := models.NewExternalInitiatorAuthentication()
+	eia := auth.NewToken()
 	eir := &models.ExternalInitiatorRequest{
 		Name: "bitcoin",
 		URL:  &url,

--- a/core/web/job_specs_controller_test.go
+++ b/core/web/job_specs_controller_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"chainlink/core/adapters"
+	"chainlink/core/auth"
 	"chainlink/core/internal/cltest"
 	"chainlink/core/store/models"
 	"chainlink/core/store/presenters"
@@ -228,7 +229,7 @@ func TestJobSpecsController_CreateExternalInitiator_Success(t *testing.T) {
 		Name: "someCoin",
 		URL:  &url,
 	}
-	eia := models.NewExternalInitiatorAuthentication()
+	eia := auth.NewToken()
 	ei, err := models.NewExternalInitiator(eia, &eir)
 	require.NoError(t, err)
 	err = app.GetStore().CreateExternalInitiator(ei)

--- a/core/web/ping_controller_test.go
+++ b/core/web/ping_controller_test.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 	"testing"
 
+	"chainlink/core/auth"
 	"chainlink/core/internal/cltest"
 	"chainlink/core/store/models"
 	"chainlink/core/web"
@@ -33,7 +34,7 @@ func TestPingController_Show_ExternalInitiatorCredentials(t *testing.T) {
 	defer cleanup()
 	require.NoError(t, app.Start())
 
-	eia := &models.ExternalInitiatorAuthentication{
+	eia := &auth.Token{
 		AccessKey: "abracadabra",
 		Secret:    "opensesame",
 	}

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -47,7 +47,7 @@ const (
 	SessionIDKey = "clsession_id"
 	// SessionUserKey is the User key in the session map
 	SessionUserKey = "user"
-	// SessionExternalInitiator is the Externale Initiator key in the session map
+	// SessionExternalInitiatorKey is the Externale Initiator key in the session map
 	SessionExternalInitiatorKey = "external_initiator"
 )
 

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -47,7 +47,7 @@ const (
 	SessionIDKey = "clsession_id"
 	// SessionUserKey is the User key in the session map
 	SessionUserKey = "user"
-	// SessionExternalInitiatorKey is the Externale Initiator key in the session map
+	// SessionExternalInitiatorKey is the External Initiator key in the session map
 	SessionExternalInitiatorKey = "external_initiator"
 )
 

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -17,8 +17,6 @@ import (
 
 	"chainlink/core/logger"
 	"chainlink/core/services"
-	"chainlink/core/store"
-	"chainlink/core/store/models"
 	"chainlink/core/store/orm"
 
 	helmet "github.com/danielkov/gin-helmet"
@@ -28,7 +26,6 @@ import (
 	"github.com/gin-gonic/contrib/sessions"
 	"github.com/gin-gonic/gin"
 	"github.com/gobuffalo/packr"
-	"github.com/pkg/errors"
 	"github.com/ulule/limiter"
 	mgin "github.com/ulule/limiter/drivers/middleware/gin"
 	"github.com/ulule/limiter/drivers/store/memory"
@@ -52,19 +49,6 @@ const (
 	SessionUserKey = "user"
 	// SessionExternalInitiator is the Externale Initiator key in the session map
 	SessionExternalInitiatorKey = "external_initiator"
-	// ExternalInitiatorAccessKeyHeader is the header name for the access key
-	// used by external initiators to authenticate
-	ExternalInitiatorAccessKeyHeader = "X-Chainlink-EA-AccessKey"
-	// ExternalInitiatorSecretHeader is the header name for the secret used by
-	// external initiators to authenticate
-	ExternalInitiatorSecretHeader = "X-Chainlink-EA-Secret"
-)
-
-var (
-	// ErrorAuthFailed is a generic authentication failed - but not because of
-	// some system failure on our behalf (i.e. HTTP 5xx), more detail is not
-	// given
-	ErrorAuthFailed = errors.New("Authentication failed")
 )
 
 // Router listens and responds to requests to the node for valid paths.
@@ -147,94 +131,8 @@ func secureMiddleware(config orm.ConfigReader) gin.HandlerFunc {
 
 	return secureFunc
 }
-
-func sessionAuth(store *store.Store, c *gin.Context) error {
-	session := sessions.Default(c)
-	sessionID, ok := session.Get(SessionIDKey).(string)
-	if !ok {
-		return ErrorAuthFailed
-	}
-
-	user, err := store.AuthorizedUserWithSession(sessionID)
-	if err != nil {
-		return err
-	}
-	c.Set(SessionUserKey, &user)
-	return nil
-}
-
-func authenticatedUser(c *gin.Context) (*models.User, bool) {
-	obj, ok := c.Get(SessionUserKey)
-	if !ok {
-		return nil, false
-	}
-	return obj.(*models.User), ok
-}
-
-func tokenAuth(store *store.Store, c *gin.Context) error {
-	eia := &models.ExternalInitiatorAuthentication{
-		AccessKey: c.GetHeader(ExternalInitiatorAccessKeyHeader),
-		Secret:    c.GetHeader(ExternalInitiatorSecretHeader),
-	}
-
-	ei, err := store.FindExternalInitiator(eia)
-	if errors.Cause(err) == orm.ErrorNotFound {
-		return ErrorAuthFailed
-	} else if err != nil {
-		return errors.Wrap(err, "finding external intiator")
-	}
-
-	ok, err := models.AuthenticateExternalInitiator(eia, ei)
-	if err != nil {
-		return err
-	}
-
-	if !ok {
-		return ErrorAuthFailed
-	}
-	c.Set(SessionExternalInitiatorKey, ei)
-
-	return nil
-}
-
-func authenticatedEI(c *gin.Context) (*models.ExternalInitiator, bool) {
-	obj, ok := c.Get(SessionExternalInitiatorKey)
-	if !ok {
-		return nil, false
-	}
-	return obj.(*models.ExternalInitiator), ok
-}
-
-func sessionAuthRequired(store *store.Store) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		err := sessionAuth(store, c)
-		if err != nil {
-			c.AbortWithStatus(http.StatusUnauthorized)
-		} else {
-			c.Next()
-		}
-	}
-}
-
-// sessionOrTokenAuthRequired first tries session authentication, then falls back to
-// token authentication, strictly for External Initiators
-func sessionOrTokenAuthRequired(store *store.Store) gin.HandlerFunc {
-	return func(c *gin.Context) {
-		err := sessionAuth(store, c)
-		if err == ErrorAuthFailed {
-			err = tokenAuth(store, c)
-		}
-
-		if err != nil {
-			c.AbortWithStatus(http.StatusUnauthorized)
-		} else {
-			c.Next()
-		}
-	}
-}
-
 func metricRoutes(app services.Application, r *gin.RouterGroup) {
-	group := r.Group("/debug", sessionAuthRequired(app.GetStore()))
+	group := r.Group("/debug", RequireAuth(app.GetStore(), AuthenticateBySession))
 	group.GET("/vars", expvar.Handler())
 
 	if app.GetStore().Config.Dev() {
@@ -266,7 +164,7 @@ func sessionRoutes(app services.Application, r *gin.RouterGroup) {
 	unauth := r.Group("/", rateLimiter(20*time.Second, 5))
 	sc := SessionsController{app}
 	unauth.POST("/sessions", sc.Create)
-	auth := r.Group("/", sessionAuthRequired(app.GetStore()))
+	auth := r.Group("/", RequireAuth(app.GetStore(), AuthenticateBySession))
 	auth.DELETE("/sessions", sc.Destroy)
 }
 
@@ -281,7 +179,7 @@ func v2Routes(app services.Application, r *gin.RouterGroup) {
 
 	j := JobSpecsController{app}
 
-	authv2 := r.Group("/v2", sessionAuthRequired(app.GetStore()))
+	authv2 := r.Group("/v2", RequireAuth(app.GetStore(), AuthenticateBySession))
 	{
 		uc := UserController{app}
 		authv2.PATCH("/user/password", uc.UpdatePassword)
@@ -336,7 +234,10 @@ func v2Routes(app services.Application, r *gin.RouterGroup) {
 	}
 
 	ping := PingController{app}
-	sotAuth := r.Group("/v2", sessionOrTokenAuthRequired(app.GetStore()))
+	sotAuth := r.Group("/v2", RequireAuth(app.GetStore(),
+		AuthenticateExternalInitiator,
+		AuthenticateBySession,
+	))
 	sotAuth.POST("/specs/:SpecID/runs", jr.Create)
 	sotAuth.GET("/ping", ping.Show)
 }

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -179,11 +179,13 @@ func v2Routes(app services.Application, r *gin.RouterGroup) {
 
 	j := JobSpecsController{app}
 
-	authv2 := r.Group("/v2", RequireAuth(app.GetStore(), AuthenticateBySession))
+	authv2 := r.Group("/v2", RequireAuth(app.GetStore(), AuthenticateByToken, AuthenticateBySession))
 	{
 		uc := UserController{app}
 		authv2.PATCH("/user/password", uc.UpdatePassword)
 		authv2.GET("/user/balances", uc.AccountBalances)
+		authv2.POST("/user/token", uc.NewAPIToken)
+		authv2.POST("/user/token/delete", uc.DeleteAPIToken)
 
 		eia := ExternalInitiatorsController{app}
 		authv2.POST("/external_initiators", eia.Create)
@@ -234,12 +236,13 @@ func v2Routes(app services.Application, r *gin.RouterGroup) {
 	}
 
 	ping := PingController{app}
-	sotAuth := r.Group("/v2", RequireAuth(app.GetStore(),
+	userOrEI := r.Group("/v2", RequireAuth(app.GetStore(),
 		AuthenticateExternalInitiator,
+		AuthenticateByToken,
 		AuthenticateBySession,
 	))
-	sotAuth.POST("/specs/:SpecID/runs", jr.Create)
-	sotAuth.GET("/ping", ping.Show)
+	userOrEI.POST("/specs/:SpecID/runs", jr.Create)
+	userOrEI.GET("/ping", ping.Show)
 }
 
 func guiAssetRoutes(box packr.Box, engine *gin.Engine) {

--- a/core/web/router_test.go
+++ b/core/web/router_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"chainlink/core/auth"
 	"chainlink/core/internal/cltest"
 	"chainlink/core/store/models"
 	"chainlink/core/web"
@@ -54,7 +55,7 @@ func TestTokenAuthRequired_TokenCredentials(t *testing.T) {
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
-	eia := models.NewExternalInitiatorAuthentication()
+	eia := auth.NewToken()
 	url := cltest.WebURL(t, "http://localhost:8888")
 	eir := &models.ExternalInitiatorRequest{
 		Name: "bitcoin",
@@ -87,7 +88,7 @@ func TestTokenAuthRequired_BadTokenCredentials(t *testing.T) {
 	ts := httptest.NewServer(router)
 	defer ts.Close()
 
-	eia := models.NewExternalInitiatorAuthentication()
+	eia := auth.NewToken()
 	url := cltest.WebURL(t, "http://localhost:8888")
 	eir := &models.ExternalInitiatorRequest{
 		Name: "bitcoin",

--- a/core/web/user_controller_test.go
+++ b/core/web/user_controller_test.go
@@ -2,10 +2,13 @@ package web_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"net/http"
 	"testing"
 
+	"chainlink/core/auth"
 	"chainlink/core/internal/cltest"
+	"chainlink/core/store/models"
 	"chainlink/core/store/presenters"
 
 	"github.com/stretchr/testify/assert"
@@ -105,4 +108,96 @@ func TestUserController_AccountBalances_Success(t *testing.T) {
 	assert.Equal(t, expectedAccounts[1].Address.Hex(), second.Address)
 	assert.Equal(t, "0.000000000000000001", second.EthBalance.String())
 	assert.Equal(t, "0.000000000000000001", second.LinkBalance.String())
+}
+
+func TestUserController_NewAPIToken(t *testing.T) {
+	t.Parallel()
+
+	app, cleanup := cltest.NewApplicationWithKey(t)
+	defer cleanup()
+	require.NoError(t, app.Start())
+	ethMock := app.MockEthCallerSubscriber()
+	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
+	})
+
+	client := app.NewHTTPClient()
+	req, err := json.Marshal(models.ChangeAuthTokenRequest{
+		Password: cltest.Password,
+	})
+	require.NoError(t, err)
+	resp, cleanup := client.Post("/v2/user/token", bytes.NewBuffer(req))
+	defer cleanup()
+
+	require.Equal(t, http.StatusCreated, resp.StatusCode)
+	var authToken auth.Token
+	err = cltest.ParseJSONAPIResponse(t, resp, &authToken)
+	require.NoError(t, err)
+	assert.NotEmpty(t, authToken.AccessKey)
+	assert.NotEmpty(t, authToken.Secret)
+}
+
+func TestUserController_NewAPIToken_unauthorized(t *testing.T) {
+	t.Parallel()
+
+	app, cleanup := cltest.NewApplicationWithKey(t)
+	defer cleanup()
+	require.NoError(t, app.Start())
+	ethMock := app.MockEthCallerSubscriber()
+	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
+	})
+
+	client := app.NewHTTPClient()
+	req, err := json.Marshal(models.ChangeAuthTokenRequest{
+		Password: "wrong-password",
+	})
+	require.NoError(t, err)
+	resp, cleanup := client.Post("/v2/user/token", bytes.NewBuffer(req))
+	defer cleanup()
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
+}
+
+func TestUserController_DeleteAPIKey(t *testing.T) {
+	t.Parallel()
+
+	app, cleanup := cltest.NewApplicationWithKey(t)
+	defer cleanup()
+	require.NoError(t, app.Start())
+	ethMock := app.MockEthCallerSubscriber()
+	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
+	})
+
+	client := app.NewHTTPClient()
+	req, err := json.Marshal(models.ChangeAuthTokenRequest{
+		Password: cltest.Password,
+	})
+	require.NoError(t, err)
+	resp, cleanup := client.Post("/v2/user/token/delete", bytes.NewBuffer(req))
+	defer cleanup()
+
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+}
+
+func TestUserController_DeleteAPIKey_unauthorized(t *testing.T) {
+	t.Parallel()
+
+	app, cleanup := cltest.NewApplicationWithKey(t)
+	defer cleanup()
+	require.NoError(t, app.Start())
+	ethMock := app.MockEthCallerSubscriber()
+	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
+	})
+
+	client := app.NewHTTPClient()
+	req, err := json.Marshal(models.ChangeAuthTokenRequest{
+		Password: "wrong-password",
+	})
+	require.NoError(t, err)
+	resp, cleanup := client.Post("/v2/user/token/delete", bytes.NewBuffer(req))
+	defer cleanup()
+
+	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 }


### PR DESCRIPTION
Allow use of user API keys with Chainlink.

A new type AuthToken is defined to represent these tokens, and supporting logic is introduced into the user's model.  By default a user starts without a generated API token and must do it manually requiring their password.

Please refer to the commit messages for more info.

https://www.pivotaltracker.com/n/projects/2129823/stories/168516871

Can I get an OK on the general approach?  After I'll iron out the details.