### PR TITLE
cltest: display http status in string form

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -958,7 +958,7 @@ func AssertServerResponse(t testing.TB, resp *http.Response, expectedStatusCode 
 		return
 	}
 
-	t.Logf("expected status code %d got %d", expectedStatusCode, resp.StatusCode)
+	t.Logf("expected status code %s got %s", http.StatusText(expectedStatusCode), http.StatusText(resp.StatusCode))
 
 	if resp.StatusCode >= 300 && resp.StatusCode < 600 {
 		b, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Improve user experience for testing by using human readable HTTP status codes.