### PR TITLE
168728559 external initiator optional url

### DIFF
--- a/core/web/external_initiators.go
+++ b/core/web/external_initiators.go
@@ -66,6 +66,9 @@ func NotifyExternalInitiator(
 	if err != nil {
 		return errors.Wrap(err, "external initiator")
 	}
+	if ei.URL == nil {
+		return nil
+	}
 	notice, err := NewJobSpecNotice(initr, js)
 	if err != nil {
 		return errors.Wrap(err, "new Job Spec notification")


### PR DESCRIPTION
Addresses rejected story [#168728559](https://www.pivotaltracker.com/story/show/168728559)

In conjunction with [PR #1940](https://github.com/smartcontractkit/chainlink/pull/1940)

Story was rejected because jobs run with EI were still trying to POST to the EI endpoint even if none existed. This PR fixes that issue.