### PR TITLE
Silence error output from tsc

### DIFF
--- a/evm/v0.5/package.json
+++ b/evm/v0.5/package.json
@@ -8,7 +8,7 @@
     "generate-typings": "typechain --target ethers --outDir src/generated \"{test/support/LinkToken*,dist/artifacts/*}\"",
     "postgenerate-typings": "yarn workspace chainlink export-typings v0.5/src/generated v0.5/dist/src/generated",
     "build:windows": "truffle.cmd build && yarn generate-typings && (tsc || true)",
-    "build": "sol-compiler && yarn generate-typings && (tsc || true)",
+    "build": "sol-compiler && yarn generate-typings && (tsc &> /dev/null || true)",
     "depcheck": "echo \"chainlinkv0.5\" && depcheck --ignore-dirs=build/contracts || true",
     "eslint": "eslint --ext .ts,.js test",
     "solhint": "solhint ./contracts/**/*.sol",


### PR DESCRIPTION
While we're still converting the package to typescript, the error
output isn't needed and instead causes confusion in script and ci
output.