### PR TITLE
Validate blank URL's on bridge create

### DIFF
--- a/core/services/validators.go
+++ b/core/services/validators.go
@@ -49,7 +49,11 @@ func ValidateBridgeType(bt *models.BridgeTypeRequest, store *store.Store) error 
 	if _, err := models.NewTaskType(bt.Name.String()); err != nil {
 		fe.Merge(err)
 	}
-	if _, err := url.Parse(bt.URL.String()); err != nil {
+	u := bt.URL.String()
+	if len(strings.TrimSpace(u)) == 0 {
+		fe.Add("URL must be present")
+	}
+	if _, err := url.Parse(u); err != nil {
 		fe.Add("Invalid URL format")
 		fe.Merge(err)
 	}

--- a/core/services/validators_test.go
+++ b/core/services/validators_test.go
@@ -141,6 +141,12 @@ func TestValidateAdapter(t *testing.T) {
 			models.NewJSONAPIErrorsWith("Task Type validation: name invalid/adapter contains invalid characters"),
 		},
 		{
+			"invalid with blank url",
+			"validadaptername",
+			cltest.WebURL(t, ""),
+			models.NewJSONAPIErrorsWith("URL must be present"),
+		},
+		{
 			"valid url",
 			"adapterwithvalidurl",
 			cltest.WebURL(t, "//denergy"),


### PR DESCRIPTION
[Fixes #169956626]

Blank URL's are currently allowed which causes an error when returning the `bridge#index` data

![Screen Shot 2019-11-25 at 8 42 15 AM](https://user-images.githubusercontent.com/680789/69560132-21689300-0f60-11ea-81b4-d40ce56046f8.png)
