### PR TITLE
Use an insecure store in testing with fewer iterations for mega speed…

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -401,7 +401,7 @@ func (ta *TestApplication) NewAuthenticatingClient(prompter cmd.Prompter) *cmd.C
 // NewStoreWithConfig creates a new store with given config
 func NewStoreWithConfig(config *TestConfig) (*strpkg.Store, func()) {
 	cleanupDB := PrepareTestDB(config)
-	s := strpkg.NewStore(config.Config)
+	s := strpkg.NewInsecureStore(config.Config)
 	return s, func() {
 		cleanUpStore(config.t, s)
 		cleanupDB()

--- a/core/store/key_store.go
+++ b/core/store/key_store.go
@@ -28,12 +28,14 @@ type KeyStore struct {
 
 // NewKeyStore creates a keystore for the given directory.
 func NewKeyStore(keyDir string) *KeyStore {
-	ks := keystore.NewKeyStore(
-		keyDir,
-		keystore.StandardScryptN,
-		keystore.StandardScryptP,
-	)
+	ks := keystore.NewKeyStore(keyDir, keystore.StandardScryptN, keystore.StandardScryptP)
+	return &KeyStore{ks}
+}
 
+// NewInsecureKeyStore creates an *INSECURE* keystore for the given directory.
+// NOTE: Should only be used for testing!
+func NewInsecureKeyStore(keyDir string) *KeyStore {
+	ks := keystore.NewKeyStore(keyDir, keystore.LightScryptN, keystore.LightScryptP)
 	return &KeyStore{ks}
 }
 


### PR DESCRIPTION
I was doing some performance profiling on the go tests recently, and noticed that the keystore takes up around 99% of test speed.

When I mentioned this today, @coventry mentioned that this is likely due to the difficulty/iterations in the key store unlocking function. So I tuned it down to see what difference it would make to the overall test speed...