### PR TITLE
Add prepush hook requiring branch to be rebased on origin/develop

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+# Don't push unless the local branch contains the head of the remote
+# origin/develop branch.
+
+set -e
+
+# Get the head of the branch being pushed.
+#
+# Local SHAs are passed to stdin, in the second column. See pre-push.sample
+read _ local_sha _ _ 
+
+# Make sure we have the latest version of develop, locally
+git remote update > /dev/null
+
+# Check that pushee branch contains develop head SHA
+remote_develop_head=`git rev-list origin/develop | head -1`
+if [ -z "`git log $local_sha | grep $remote_develop_head | head -1`" ] ; then
+    echo "↘↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↙"
+    echo "→ Please rebase on origin/develop before pushing ←"
+    echo "↗↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↑↖"
+    exit 1
+fi

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -13,7 +13,7 @@ read _ local_sha _ _
 # Make sure we have the latest version of develop, locally
 git remote update > /dev/null
 
-# Check that pushee branch contains develop head SHA
+# Check that branch to be pushed contains develop head SHA
 remote_develop_head=`git rev-list origin/develop | head -1`
 if [ -z "`git log $local_sha | grep $remote_develop_head | head -1`" ] ; then
     echo "↘↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↓↙"

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -30,6 +30,7 @@ TAGGED_REPO := $(REPO):$(DOCKER_TAG)
 
 .PHONY: install
 install: operator-ui-autoinstall install-chainlink-autoinstall ## Install chainlink and all its dependencies.
+	git config core.hooksPath .githooks
 
 .PHONY: install-chainlink-autoinstall
 install-chainlink-autoinstall: | gomod install-chainlink

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -30,6 +30,9 @@ TAGGED_REPO := $(REPO):$(DOCKER_TAG)
 
 .PHONY: install
 install: operator-ui-autoinstall install-chainlink-autoinstall ## Install chainlink and all its dependencies.
+
+.PHONY: install-git-hooks
+install-git-hooks:
 	git config core.hooksPath .githooks
 
 .PHONY: install-chainlink-autoinstall


### PR DESCRIPTION
Adds a command to the `make install` logic which points git's config at
`chainlink/.githooks`, which contains `pre-push`. It runs before each git push,
and does the following

1. Extracts the head SHA of the branch to be pushed, which git passes to the
   command via stdin.
2. Updates all remotes, to ensure origin/develop is up to date.
3. Extracts the head SHA of origin develop, and searches the parent SHAs of the
   pushee branch head.
4. Fails with an error message, if develop's head SHA is not present in the
   history of the pushee branch.
5. Otherwise, continues without error, allowing the push to continue.