### PR TITLE
Make external initiator specs forwar compat.

### DIFF
--- a/core/internal/testdata/external_initiator_job.json
+++ b/core/internal/testdata/external_initiator_job.json
@@ -1,4 +1,18 @@
 {
-  "initiators": [{ "type": "external", "name": "somecoin", "params":{"foo":"bar"}}],
-  "tasks": [{"type": "NoOp"}]
+  "initiators": [
+    {
+      "type": "external",
+      "params": {
+        "name": "somecoin",
+        "body": {
+          "foo": "bar"
+        }
+      }
+    }
+  ],
+  "tasks": [
+    {
+      "type": "NoOp"
+    }
+  ]
 }

--- a/core/store/models/job_spec_test.go
+++ b/core/store/models/job_spec_test.go
@@ -1,7 +1,6 @@
 package models_test
 
 import (
-	"encoding/json"
 	"testing"
 	"time"
 
@@ -26,21 +25,6 @@ func TestNewInitiatorFromRequest(t *testing.T) {
 		want     models.Initiator
 	}{
 		{
-			name: models.InitiatorExternal,
-			initrReq: models.InitiatorRequest{
-				Type: models.InitiatorExternal,
-				Name: "somecoin",
-			},
-			jobSpec: job,
-			want: models.Initiator{
-				Type:      models.InitiatorExternal,
-				JobSpecID: job.ID,
-				InitiatorParams: models.InitiatorParams{
-					Name: "somecoin",
-				},
-			},
-		},
-		{
 			name: models.InitiatorWeb,
 			initrReq: models.InitiatorRequest{
 				Type: models.InitiatorWeb,
@@ -60,61 +44,6 @@ func TestNewInitiatorFromRequest(t *testing.T) {
 				test.jobSpec,
 			)
 			assert.Equal(t, test.want, res)
-		})
-	}
-}
-
-func TestUnmarshalInitiatorRequest(t *testing.T) {
-	tests := []struct {
-		Name   string
-		JSON   map[string]interface{}
-		Expect models.InitiatorRequest
-	}{
-		{
-			Name: "ExternalInitiator",
-			JSON: map[string]interface{}{
-				"type": "external",
-				"name": "somecoin",
-				"params": map[string]string{
-					"foo":  "bar",
-					"name": "bitcoin",
-				},
-			},
-			Expect: models.InitiatorRequest{
-				Type: models.InitiatorExternal,
-				Name: "somecoin",
-				InitiatorParams: models.InitiatorParams{
-					Name:   "bitcoin",
-					Params: `{"foo":"bar","name":"bitcoin"}`,
-				},
-			},
-		},
-		{
-			Name: "CronInitiator",
-			JSON: map[string]interface{}{
-				"type": "cron",
-				"params": map[string]string{
-					"schedule": "* * * * *",
-				},
-			},
-			Expect: models.InitiatorRequest{
-				Type: models.InitiatorCron,
-				InitiatorParams: models.InitiatorParams{
-					Schedule: "* * * * *",
-				},
-			},
-		},
-	}
-	for _, test := range tests {
-		t.Run(test.Name, func(t *testing.T) {
-			buf, err := json.Marshal(test.JSON)
-			require.NoError(t, err)
-
-			var i models.InitiatorRequest
-			err = json.Unmarshal(buf, &i)
-			require.NoError(t, err)
-
-			assert.Equal(t, test.Expect, i)
 		})
 	}
 }

--- a/core/web/external_initiators.go
+++ b/core/web/external_initiators.go
@@ -21,14 +21,13 @@ type JobSpecNotice struct {
 
 // NewJobSpecNotice returns a new JobSpec.
 func NewJobSpecNotice(initiator models.Initiator, js models.JobSpec) (*JobSpecNotice, error) {
-	params, err := models.ParseJSON([]byte(initiator.Params))
-	if err != nil {
-		return nil, errors.Wrap(err, "external initiator params")
+	if initiator.Body == nil {
+		return nil, errors.New("body must be defined")
 	}
 	return &JobSpecNotice{
 		JobID:  js.ID,
 		Type:   initiator.Type,
-		Params: params,
+		Params: *initiator.Body,
 	}, nil
 }
 

--- a/core/web/external_initiators_test.go
+++ b/core/web/external_initiators_test.go
@@ -14,6 +14,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func JSONFromString(t *testing.T, arg string) *models.JSON {
+	if arg == "" {
+		return nil
+	}
+	ret := cltest.JSONFromString(t, arg)
+	return &ret
+}
+
 func TestNotifyExternalInitiator_Notified(t *testing.T) {
 	tests := []struct {
 		Name          string
@@ -32,8 +40,8 @@ func TestNotifyExternalInitiator_Notified(t *testing.T) {
 					models.Initiator{
 						Type: models.InitiatorExternal,
 						InitiatorParams: models.InitiatorParams{
-							Name:   "somecoin",
-							Params: `{"foo":"bar"}`,
+							Name: "somecoin",
+							Body: JSONFromString(t, `{"foo":"bar"}`),
 						},
 					},
 				},
@@ -60,15 +68,15 @@ func TestNotifyExternalInitiator_Notified(t *testing.T) {
 					models.Initiator{
 						Type: models.InitiatorExternal,
 						InitiatorParams: models.InitiatorParams{
-							Name:   "somecoin",
-							Params: `{"foo":"bar"}`,
+							Name: "somecoin",
+							Body: JSONFromString(t, `{"foo":"bar"}`),
 						},
 					},
 				},
 			},
 			web.JobSpecNotice{
 				Type:   models.InitiatorExternal,
-				Params: cltest.JSONFromString(t, `{"foo":"bar"}`),
+				Params: *JSONFromString(t, `{"foo":"bar"}`),
 			},
 		},
 	}

--- a/core/web/testdata/external_initiator_job.json
+++ b/core/web/testdata/external_initiator_job.json
@@ -1,4 +1,18 @@
 {
-  "initiators": [{ "type": "external", "name": "somecoin", "params": {"foo":"bar"}}],
-  "tasks": [{"type":"NoOp"}]
+  "initiators": [
+    {
+      "type": "external",
+      "params": {
+        "name": "somecoin",
+        "body": {
+          "foo": "bar"
+        }
+      }
+    }
+  ],
+  "tasks": [
+    {
+      "type": "NoOp"
+    }
+  ]
 }


### PR DESCRIPTION
In order to improve forward compatibility, make the JSON request for creating external initiators generic.  To do this move the name into the params object, and make the 'body' to be posted to the external
initiator a subfield.

So
```
  {
    "type": "external",
    "name": "foo",
    "params": {
      "abc": 123
    }
  }
```

becomes
```
  {
    "type": "external",
    "params": {
      "name": "foo",
      "body": {
        "abc": 123,
      }
    }
  }
```

In order to avoid writing a migration, the database name for Initiator.Params has been preserved.

https://www.pivotaltracker.com/n/projects/2129823/stories/169221781