### PR TITLE
Fix external initiator deletion

### DIFF
--- a/core/store/models/external_initiator.go
+++ b/core/store/models/external_initiator.go
@@ -3,11 +3,11 @@ package models
 import (
 	"crypto/subtle"
 	"strings"
+	"time"
 
 	"chainlink/core/auth"
 	"chainlink/core/utils"
 
-	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 )
 
@@ -19,7 +19,6 @@ type ExternalInitiatorRequest struct {
 
 // ExternalInitiator represents a user that can initiate runs remotely
 type ExternalInitiator struct {
-	*gorm.Model
 	Name           string  `gorm:"not null;unique"`
 	URL            *WebURL `gorm:"url,omitempty"`
 	AccessKey      string  `gorm:"not null"`
@@ -27,6 +26,9 @@ type ExternalInitiator struct {
 	HashedSecret   string  `gorm:"not null"`
 	OutgoingSecret string  `gorm:"not null"`
 	OutgoingToken  string  `gorm:"not null"`
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // NewExternalInitiator generates an ExternalInitiator from an

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -370,8 +370,7 @@ func (orm *ORM) CreateExternalInitiator(externalInitiator *models.ExternalInitia
 func (orm *ORM) DeleteExternalInitiator(accessKey string) error {
 	orm.MustEnsureAdvisoryLock()
 	return orm.db.
-		Where("access_key = ?", accessKey).
-		Delete(&models.ExternalInitiator{}).
+		Delete(&models.ExternalInitiator{}, "access_key = ?", accessKey).
 		Error
 }
 

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -370,7 +370,8 @@ func (orm *ORM) CreateExternalInitiator(externalInitiator *models.ExternalInitia
 func (orm *ORM) DeleteExternalInitiator(accessKey string) error {
 	orm.MustEnsureAdvisoryLock()
 	return orm.db.
-		Delete(&models.ExternalInitiator{}, "access_key = ?", accessKey).
+		Where("access_key = ?", accessKey).
+		Delete(&models.ExternalInitiator{}).
 		Error
 }
 

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -10,6 +10,7 @@ import (
 
 	"chainlink/core/adapters"
 	"chainlink/core/assets"
+	"chainlink/core/auth"
 	"chainlink/core/internal/cltest"
 	"chainlink/core/services"
 	"chainlink/core/services/synchronization"
@@ -81,6 +82,30 @@ func TestORM_Unscoped(t *testing.T) {
 		return nil
 	})
 	require.NoError(t, err)
+}
+
+func TestORM_DeleteExternalInitiator(t *testing.T) {
+	store, cleanup := cltest.NewStore(t)
+	defer cleanup()
+
+	token := auth.NewToken()
+	req := models.ExternalInitiatorRequest{
+		Name: "externalinitiator",
+	}
+	exi, err := models.NewExternalInitiator(token, &req)
+	require.NoError(t, err)
+	require.NoError(t, store.CreateExternalInitiator(exi))
+
+	_, err = store.FindExternalInitiator(token)
+	require.NoError(t, err)
+
+	err = store.DeleteExternalInitiator(exi.AccessKey)
+	require.NoError(t, err)
+
+	_, err = store.FindExternalInitiator(token)
+	require.Error(t, err)
+
+	require.NoError(t, store.CreateExternalInitiator(exi))
 }
 
 func TestORM_ArchiveJob(t *testing.T) {


### PR DESCRIPTION
Hard delete external initiators from the database by removing the 'DeleteAt' field.  Remove also the redudant ID parameter as the Name field functions as the entity's unique ID.

The Gorm package uses the 'DeleteAt' field to hint a record was deleted, but this conflicts with the databases UNIQUE constraint on the name field.

https://www.pivotaltracker.com/n/projects/2129823/stories/169932466