### PR TITLE
Bugfix/scheduler error scheduled after started edge case

### DIFF
--- a/core/services/scheduler.go
+++ b/core/services/scheduler.go
@@ -132,7 +132,7 @@ func (r *Recurring) AddJob(job models.JobSpec) {
 			}
 
 			_, err := r.runManager.Create(job.ID, &initr, &models.JSON{}, nil, &models.RunRequest{})
-			if err != nil && !expectedRecurringScheduleJobError(err) {
+			if err != nil && !ExpectedRecurringScheduleJobError(err) {
 				logger.Errorw(err.Error())
 			}
 		})
@@ -182,7 +182,7 @@ func (ot *OneTime) RunJobAt(initiator models.Initiator, job models.JobSpec) {
 		}
 
 		_, err := ot.RunManager.Create(job.ID, &initiator, &models.JSON{}, nil, &models.RunRequest{})
-		if err != nil && !expectedRecurringScheduleJobError(err) {
+		if err != nil && !ExpectedRecurringScheduleJobError(err) {
 			logger.Error(err.Error())
 			return
 		}
@@ -193,9 +193,9 @@ func (ot *OneTime) RunJobAt(initiator models.Initiator, job models.JobSpec) {
 	}
 }
 
-func expectedRecurringScheduleJobError(err error) bool {
+func ExpectedRecurringScheduleJobError(err error) bool {
 	switch errors.Cause(err).(type) {
-	case *RecurringScheduleJobError:
+	case RecurringScheduleJobError:
 		return true
 	default:
 		return false

--- a/core/services/scheduler.go
+++ b/core/services/scheduler.go
@@ -1,7 +1,6 @@
 package services
 
 import (
-	"errors"
 	"sync"
 	"time"
 
@@ -11,6 +10,7 @@ import (
 	"chainlink/core/utils"
 
 	"github.com/mrwonko/cron"
+	"github.com/pkg/errors"
 )
 
 // Scheduler contains fields for Recurring and OneTime for occurrences,
@@ -194,8 +194,8 @@ func (ot *OneTime) RunJobAt(initiator models.Initiator, job models.JobSpec) {
 }
 
 func expectedRecurringScheduleJobError(err error) bool {
-	switch err.(type) {
-	case RecurringScheduleJobError:
+	switch errors.Cause(err).(type) {
+	case *RecurringScheduleJobError:
 		return true
 	default:
 		return false

--- a/core/services/scheduler_test.go
+++ b/core/services/scheduler_test.go
@@ -8,6 +8,8 @@ import (
 	"chainlink/core/internal/mocks"
 	"chainlink/core/services"
 
+	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v3"
@@ -234,4 +236,11 @@ func TestOneTime_AddJob_BeforeStart(t *testing.T) {
 	ot.Stop()
 
 	runManager.AssertExpectations(t)
+}
+
+func TestExpectedRecurringScheduleJobError(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, services.ExpectedRecurringScheduleJobError(services.RecurringScheduleJobError{}))
+	assert.False(t, services.ExpectedRecurringScheduleJobError(errors.New("recurring scheduler job error, but wrong type")))
 }


### PR DESCRIPTION
Still a very small but finite chance that the RunManager guard could be hit when scheduling, so fixed the `expectedRecurringScheduleJobError` function to match properly.