### PR TITLE
Convert uint64 to big.Int correctly in cltest.BigHexInt

### DIFF
--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -456,12 +456,12 @@ func StringToVersionedLogData20190207withoutIndexes(
 // BigHexInt create hexutil.Big value from given value
 func BigHexInt(val interface{}) hexutil.Big {
 	switch x := val.(type) {
-	case int:
+	case int: // Single case allows compiler to narrow x's type.
 		return hexutil.Big(*big.NewInt(int64(x)))
 	case uint32:
 		return hexutil.Big(*big.NewInt(int64(x)))
 	case uint64:
-		return hexutil.Big(*big.NewInt(int64(x)))
+		return hexutil.Big(*big.NewInt(0).SetUint64(x))
 	case int64:
 		return hexutil.Big(*big.NewInt(x))
 	default:

--- a/core/internal/cltest/factories_test.go
+++ b/core/internal/cltest/factories_test.go
@@ -1,0 +1,17 @@
+package cltest
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func i(x int64) *big.Int { return big.NewInt(x) }
+
+func TestBigHexInt(t *testing.T) {
+	asBig := i(0).Sub(i(0).Exp(i(2), i(64), big.NewInt(0)), i(1)) // 2**64-1
+	x := asBig.Uint64()
+	newBig := BigHexInt(x)
+	assert.Equal(t, (*big.Int)(&newBig).Uint64(), x)
+}


### PR DESCRIPTION
The previous code would convert uint64(2**64-1) to big.NewInt(1), and generally
be inaccurate for any uint64 greater than 2**63. See test for demonstration.