### PR TITLE
Build dependencies on starting operator-ui

### DIFF
--- a/operator_ui/package.json
+++ b/operator_ui/package.json
@@ -7,7 +7,7 @@
     "node": "10.16.3"
   },
   "scripts": {
-    "start": "react-static start",
+    "start": "yarn build:tsc && react-static start",
     "build": "yarn build:tsc && react-static build",
     "build:tsc": "tsc -b",
     "build:tsc:clean": "tsc -b --clean",

--- a/tools/docker/docker-compose.dev.yaml
+++ b/tools/docker/docker-compose.dev.yaml
@@ -19,13 +19,13 @@ services:
       dockerfile: tools/docker/operatorui.Dockerfile
       args:
         - SRCROOT
-    entrypoint: /bin/sh -c 'yarn && yarn setup && yarn workspace @chainlink/operator-ui start'
-    environment: 
+    entrypoint: /bin/sh -c 'yarn && yarn workspace @chainlink/operator-ui start'
+    environment:
       - CHAINLINK_PORT
     ports:
       - 3000:3000
       - 4000:4000
-    volumes: 
+    volumes:
       - ../..:$SRCROOT
     depends_on:
       - node


### PR DESCRIPTION
This allows us to skip building other dependencies that we don't need
in order to run operator-ui