### PR TITLE
test env: Use single network for docker compose

### DIFF
--- a/tools/docker/docker-compose.deps.yaml
+++ b/tools/docker/docker-compose.deps.yaml
@@ -7,12 +7,7 @@ services:
       context: .
       dockerfile: wait-postgres.Dockerfile
     command: '-h node-db -p 5432 -U postgres -d $CHAINLINK_DB_NAME --timeout=150'
-    networks:
-      - node-internal
     depends_on:
       - node-db
-networks:
-  node-internal:
-    driver: bridge
 volumes:
   node-db-data:

--- a/tools/docker/docker-compose.gethnet.yaml
+++ b/tools/docker/docker-compose.gethnet.yaml
@@ -2,8 +2,6 @@ version: '3.1'
 
 services:
   node:
-    networks:
-      - ethereum-node
     environment:
       - ETH_CHAIN_ID=1337
     depends_on:
@@ -14,8 +12,3 @@ services:
     image: smartcontract/gethnet
     secrets:
       - node_password
-    networks:
-      - ethereum-node
-networks:
-  ethereum-node:
-    driver: bridge

--- a/tools/docker/docker-compose.integration.yaml
+++ b/tools/docker/docker-compose.integration.yaml
@@ -28,11 +28,6 @@ services:
       - CYPRESS_JOB_SERVER_HOST
       - CYPRESS_EXPLORER_URL
       - CYPRESS_CHAINLINK_URL=$CHAINLINK_URL
-    networks:
-      - explorer-external
-      - node-external
-      - ethereum-node
-      - integration-internal
     secrets:
       - apicredentials
 
@@ -46,8 +41,6 @@ services:
         - SRCROOT
     environment:
       - PORT=$ECHO_SERVER_PORT
-    networks:
-      - integration-internal
 
   cypress-job-server:
     container_name: cypress-job-server
@@ -62,20 +55,9 @@ services:
       - '6692:6692'
     environment:
       - JOB_SERVER_PORT=$CYPRESS_JOB_SERVER_PORT
-    networks:
-      - integration-internal
 
   node:
     entrypoint: ''
     command: /bin/sh -c "chainlink node import /run/secrets/keystore && chainlink node start -d -p /run/secrets/node_password -a /run/secrets/apicredentials"
     environment:
       ALLOW_ORIGINS: http://localhost:3000,http://localhost:6688,http://integration:3000,http://integration:6688,http://node:3000,http://node:6688
-    networks:
-      - node-external
-      - integration-internal # needed this for echo-server, and cypress-job-server
-
-networks:
-  node-external:
-    driver: bridge
-  integration-internal:
-    driver: bridge

--- a/tools/docker/docker-compose.paritynet.yaml
+++ b/tools/docker/docker-compose.paritynet.yaml
@@ -2,15 +2,8 @@ version: '3.1'
 
 services:
   node:
-    networks:
-      - ethereum-node
     depends_on:
       - devnet
   devnet:
     container_name: parity
     image: smartcontract/devnet
-    networks:
-      - ethereum-node
-networks:
-  ethereum-node:
-    driver: bridge

--- a/tools/docker/docker-compose.postgres.yaml
+++ b/tools/docker/docker-compose.postgres.yaml
@@ -4,22 +4,15 @@ services:
   node:
     depends_on:
       - node-db
-    networks:
-      - node-internal
     environment:
       - DATABASE_URL=postgresql://postgres:$CHAINLINK_PGPASSWORD@node-db:5432/$CHAINLINK_DB_NAME?sslmode=disable
   node-db:
     container_name: chainlink-db
     image: circleci/postgres:11-alpine
-    networks:
-      - node-internal
     volumes:
       - node-db-data:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: $CHAINLINK_DB_NAME
       POSTGRES_PASSWORD: $CHAINLINK_PGPASSWORD
-networks:
-  node-internal:
-    driver: bridge
 volumes:
   node-db-data:

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -26,8 +26,6 @@ services:
       - CHAINLINK_TLS_PORT
     env_file:
       - chainlink-variables.env
-    networks:
-      - explorer-external
     ports:
       - 6688:6688
     depends_on:
@@ -45,9 +43,6 @@ services:
       dockerfile: explorer/Dockerfile
     entrypoint: yarn workspace @chainlink/explorer dev:compose
     restart: always
-    networks:
-      - explorer-external
-      - explorer-internal
     ports:
       - 3001:3001
     depends_on:
@@ -62,19 +57,11 @@ services:
   explorer-db:
     container_name: chainlink-explorer-db
     image: postgres:11.5
-    networks:
-      - explorer-internal
     volumes:
       - explorer-db-data:/var/lib/postgresql/data
     environment:
       POSTGRES_DB: $EXPLORER_DB_NAME
       POSTGRES_PASSWORD: $EXPLORER_PGPASSWORD
-
-networks:
-  explorer-external:
-    driver: bridge
-  explorer-internal:
-    driver: bridge
 
 secrets:
   node_password:


### PR DESCRIPTION
By default docker compose uses a single network for the application.
Therefore remove all network setting from configuration.  This should
simplify the environment setup.

From Docker Compose's website:

"By default Compose sets up a single network for your app. Each
container for a service joins the default network and is both reachable
by other containers on that network, and discoverable by them at a
hostname identical to the container name."

https://www.pivotaltracker.com/story/show/170354368