### PR TITLE
Cleanup Aggregator contracts

### DIFF
--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -410,7 +410,7 @@ func (txm *EthTxManager) checkAccountForConfirmation(tx *models.Tx) (*eth.TxRece
 		if err := txm.orm.SaveTx(tx); err != nil {
 			return nil, Safe, fmt.Errorf("BumpGasUntilSafe error saving Tx confirmation to the database")
 		}
-		return nil, Safe, fmt.Errorf("BumpGasUntilSafe a version of the Ethereum Transaction from %v with nonce %v", tx.From, tx.Nonce)
+		return nil, Safe, fmt.Errorf("BumpGasUntilSafe a version of the Ethereum Transaction from %v with nonce %v was not recorded in the database", tx.From, tx.Nonce)
 	}
 
 	return nil, Unconfirmed, nil

--- a/evm/contracts/Aggregator.sol
+++ b/evm/contracts/Aggregator.sol
@@ -83,9 +83,10 @@ contract Aggregator is AggregatorInterface, ChainlinkClient, Ownable {
     }
     answers[answerCounter].minimumResponses = minimumResponses;
     answers[answerCounter].maxResponses = uint128(oracles.length);
-    answerCounter = answerCounter.add(1);
 
     emit NewRound(answerCounter, msg.sender);
+
+    answerCounter = answerCounter.add(1);
   }
 
   /**

--- a/evm/contracts/Aggregator.sol
+++ b/evm/contracts/Aggregator.sol
@@ -37,7 +37,7 @@ contract Aggregator is AggregatorInterface, ChainlinkClient, Ownable {
   mapping(uint256 => int256) private currentAnswers;
   mapping(uint256 => uint256) private updatedTimestamps;
 
-  uint256 constant private MAX_ORACLE_COUNT = 45;
+  uint256 constant private MAX_ORACLE_COUNT = 28;
 
   /**
    * @notice Deploy with the address of the LINK token and arrays of matching

--- a/evm/test/Aggregator.test.ts
+++ b/evm/test/Aggregator.test.ts
@@ -96,6 +96,15 @@ describe('Aggregator', () => {
         assertBigNum(ethers.constants.Zero, current)
       })
 
+      it('emits a new round log', async () => {
+        const requestTx = await rate.requestRateUpdate()
+        const receipt = await requestTx.wait()
+
+        const answerId = h.numToBytes32(1)
+        const newRoundLog = receipt.logs![receipt.logs!.length - 1]
+        assert.equal(answerId, newRoundLog.topics[1])
+      })
+
       it('trigger a request to the oracle and accepts a response', async () => {
         const requestTx = await rate.requestRateUpdate()
         const receipt = await requestTx.wait()

--- a/evm/test/Aggregator.test.ts
+++ b/evm/test/Aggregator.test.ts
@@ -432,7 +432,7 @@ describe('Aggregator', () => {
     })
 
     describe('when calling with a large number of oracles', () => {
-      const maxOracleCount = 45
+      const maxOracleCount = 28
 
       beforeEach(() => {
         oracles = []

--- a/evm/v0.5/contracts/dev/Owned.sol
+++ b/evm/v0.5/contracts/dev/Owned.sol
@@ -1,0 +1,20 @@
+pragma solidity 0.5.0;
+
+/**
+ * @title The Owned contract
+ * @notice A contract with helpers for basic contract ownership.
+ */
+contract Owned {
+
+  address public owner;
+
+  constructor() public {
+    owner = msg.sender;
+  }
+
+  modifier onlyOwner() {
+    require(msg.sender == owner, "Only callable by owner");
+    _;
+  }
+
+}

--- a/evm/v0.5/contracts/dev/Owned.sol
+++ b/evm/v0.5/contracts/dev/Owned.sol
@@ -17,9 +17,6 @@ contract Owned {
     address indexed from,
     address indexed to
   );
-  event OwnershipRenounced(
-    address indexed by
-  );
 
   constructor() public {
     owner = msg.sender;
@@ -51,19 +48,6 @@ contract Owned {
     pendingOwner = address(0);
 
     emit OwnershipTransfered(oldOwner, msg.sender);
-  }
-
-  /**
-   * @dev Renounces ownership so that no one owns the contract.
-   */
-  function renounceOwnership()
-    external
-    onlyOwner()
-  {
-    address oldOwner = owner;
-    owner = address(0);
-
-    emit OwnershipTransfered(oldOwner, address(0));
   }
 
   /**

--- a/evm/v0.5/contracts/dev/Owned.sol
+++ b/evm/v0.5/contracts/dev/Owned.sol
@@ -7,8 +7,16 @@ pragma solidity 0.5.0;
 contract Owned {
 
   address public owner;
+  address private pendingOwner;
 
-  event OwnershipTransferRequested(address to, address from);
+  event OwnershipTransferRequested(
+    address indexed to,
+    address from
+  );
+  event OwnershipTransfered(
+    address indexed to,
+    address from
+  );
 
   constructor() public {
     owner = msg.sender;
@@ -18,7 +26,21 @@ contract Owned {
     public
     onlyOwner()
   {
+    pendingOwner = _to;
+
     emit OwnershipTransferRequested(_to, owner);
+  }
+
+  function acceptOwnership()
+    public
+  {
+    require(msg.sender == pendingOwner, "Must be requested to accept ownership");
+
+    address oldOwner = owner;
+    owner = msg.sender;
+    pendingOwner = address(0);
+
+    emit OwnershipTransfered(msg.sender, oldOwner);
   }
 
   modifier onlyOwner() {

--- a/evm/v0.5/contracts/dev/Owned.sol
+++ b/evm/v0.5/contracts/dev/Owned.sol
@@ -48,10 +48,4 @@ contract Owned {
     _;
   }
 
-  modifier ifOwner() {
-    if (msg.sender == owner) {
-      _;
-    }
-  }
-
 }

--- a/evm/v0.5/contracts/dev/Owned.sol
+++ b/evm/v0.5/contracts/dev/Owned.sol
@@ -41,7 +41,7 @@ contract Owned {
   function acceptOwnership()
     external
   {
-    require(msg.sender == pendingOwner, "Must be requested to accept ownership");
+    require(msg.sender == pendingOwner, "Must be proposed owner");
 
     address oldOwner = owner;
     owner = msg.sender;

--- a/evm/v0.5/contracts/dev/Owned.sol
+++ b/evm/v0.5/contracts/dev/Owned.sol
@@ -30,7 +30,7 @@ contract Owned {
    * pending.
    */
   function transferOwnership(address _to)
-    public
+    external
     onlyOwner()
   {
     pendingOwner = _to;
@@ -42,7 +42,7 @@ contract Owned {
    * @dev Allows an ownership transfer to be completed by the recipient.
    */
   function acceptOwnership()
-    public
+    external
   {
     require(msg.sender == pendingOwner, "Must be requested to accept ownership");
 
@@ -57,7 +57,7 @@ contract Owned {
    * @dev Renounces ownership so that no one owns the contract.
    */
   function renounceOwnership()
-    public
+    external
     onlyOwner()
   {
     emit OwnershipRenounced(msg.sender);

--- a/evm/v0.5/contracts/dev/Owned.sol
+++ b/evm/v0.5/contracts/dev/Owned.sol
@@ -17,4 +17,10 @@ contract Owned {
     _;
   }
 
+  modifier ifOwner() {
+    if (msg.sender == owner) {
+      _;
+    }
+  }
+
 }

--- a/evm/v0.5/contracts/dev/Owned.sol
+++ b/evm/v0.5/contracts/dev/Owned.sol
@@ -22,6 +22,10 @@ contract Owned {
     owner = msg.sender;
   }
 
+  /**
+   * @dev Allows an owner to begin transferring ownership to a new address,
+   * pending.
+   */
   function transferOwnership(address _to)
     public
     onlyOwner()
@@ -31,6 +35,9 @@ contract Owned {
     emit OwnershipTransferRequested(_to, owner);
   }
 
+  /**
+   * @dev Allows an ownership transfer to be completed by the recipient.
+   */
   function acceptOwnership()
     public
   {
@@ -43,6 +50,9 @@ contract Owned {
     emit OwnershipTransfered(msg.sender, oldOwner);
   }
 
+  /**
+   * @dev Reverts if called by anyone other than the contract owner.
+   */
   modifier onlyOwner() {
     require(msg.sender == owner, "Only callable by owner");
     _;

--- a/evm/v0.5/contracts/dev/Owned.sol
+++ b/evm/v0.5/contracts/dev/Owned.sol
@@ -17,6 +17,9 @@ contract Owned {
     address indexed to,
     address from
   );
+  event OwnershipRenounced(
+    address indexed by
+  );
 
   constructor() public {
     owner = msg.sender;
@@ -48,6 +51,18 @@ contract Owned {
     pendingOwner = address(0);
 
     emit OwnershipTransfered(msg.sender, oldOwner);
+  }
+
+  /**
+   * @dev Renounces ownership so that no one owns the contract.
+   */
+  function renounceOwnership()
+    public
+    onlyOwner()
+  {
+    emit OwnershipRenounced(msg.sender);
+
+    owner = address(0);
   }
 
   /**

--- a/evm/v0.5/contracts/dev/Owned.sol
+++ b/evm/v0.5/contracts/dev/Owned.sol
@@ -60,9 +60,10 @@ contract Owned {
     external
     onlyOwner()
   {
-    emit OwnershipRenounced(msg.sender);
-
+    address oldOwner = owner;
     owner = address(0);
+
+    emit OwnershipTransfered(oldOwner, address(0));
   }
 
   /**

--- a/evm/v0.5/contracts/dev/Owned.sol
+++ b/evm/v0.5/contracts/dev/Owned.sol
@@ -10,12 +10,12 @@ contract Owned {
   address private pendingOwner;
 
   event OwnershipTransferRequested(
-    address indexed to,
-    address from
+    address indexed from,
+    address indexed to
   );
   event OwnershipTransfered(
-    address indexed to,
-    address from
+    address indexed from,
+    address indexed to
   );
   event OwnershipRenounced(
     address indexed by
@@ -35,7 +35,7 @@ contract Owned {
   {
     pendingOwner = _to;
 
-    emit OwnershipTransferRequested(_to, owner);
+    emit OwnershipTransferRequested(owner, _to);
   }
 
   /**
@@ -50,7 +50,7 @@ contract Owned {
     owner = msg.sender;
     pendingOwner = address(0);
 
-    emit OwnershipTransfered(msg.sender, oldOwner);
+    emit OwnershipTransfered(oldOwner, msg.sender);
   }
 
   /**

--- a/evm/v0.5/contracts/dev/Owned.sol
+++ b/evm/v0.5/contracts/dev/Owned.sol
@@ -8,8 +8,17 @@ contract Owned {
 
   address public owner;
 
+  event OwnershipTransferRequested(address to, address from);
+
   constructor() public {
     owner = msg.sender;
+  }
+
+  function transferOwnership(address _to)
+    public
+    onlyOwner()
+  {
+    emit OwnershipTransferRequested(_to, owner);
   }
 
   modifier onlyOwner() {

--- a/evm/v0.5/contracts/dev/PrepaidAggregator.sol
+++ b/evm/v0.5/contracts/dev/PrepaidAggregator.sol
@@ -217,9 +217,14 @@ contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
   function updateAvailableFunds()
     public
   {
+    uint128 pastAvailableFunds = availableFunds;
+
     uint256 available = LINK.balanceOf(address(this)).sub(allocatedFunds);
     availableFunds = uint128(available);
-    emit AvailableFundsUpdated(available);
+
+    if (pastAvailableFunds != available) {
+      emit AvailableFundsUpdated(available);
+    }
   }
 
   /**

--- a/evm/v0.5/contracts/dev/PrepaidAggregator.sol
+++ b/evm/v0.5/contracts/dev/PrepaidAggregator.sol
@@ -1,7 +1,6 @@
 pragma solidity 0.5.0;
 
 import "../Median.sol";
-import "../vendor/Ownable.sol";
 import "../vendor/SafeMath.sol";
 import "./SafeMath128.sol";
 import "./SafeMath64.sol";
@@ -9,6 +8,7 @@ import "./SafeMath32.sol";
 import "../interfaces/LinkTokenInterface.sol";
 import "../interfaces/WithdrawalInterface.sol";
 import "./AggregatorInterface.sol";
+import "./Owned.sol";
 
 /**
  * @title The Prepaid Aggregator contract
@@ -18,7 +18,7 @@ import "./AggregatorInterface.sol";
  * single answer. The latest aggregated answer is exposed as well as historical
  * answers and their updated at timestamp.
  */
-contract PrepaidAggregator is AggregatorInterface, Ownable, WithdrawalInterface {
+contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
   using SafeMath for uint256;
   using SafeMath128 for uint128;
   using SafeMath64 for uint64;

--- a/evm/v0.5/contracts/tests/OwnedTestHelper.sol
+++ b/evm/v0.5/contracts/tests/OwnedTestHelper.sol
@@ -1,0 +1,15 @@
+pragma solidity 0.5.0;
+
+import "../dev/Owned.sol";
+
+contract OwnedTestHelper is Owned {
+
+  event Here();
+
+  function modifierOnlyOwner()
+    public
+    onlyOwner()
+  {
+    emit Here();
+  }
+}

--- a/evm/v0.5/contracts/tests/OwnedTestHelper.sol
+++ b/evm/v0.5/contracts/tests/OwnedTestHelper.sol
@@ -12,4 +12,12 @@ contract OwnedTestHelper is Owned {
   {
     emit Here();
   }
+
+  function modifierIfOwner()
+    public
+    ifOwner()
+  {
+    emit Here();
+  }
+
 }

--- a/evm/v0.5/contracts/tests/OwnedTestHelper.sol
+++ b/evm/v0.5/contracts/tests/OwnedTestHelper.sol
@@ -13,11 +13,4 @@ contract OwnedTestHelper is Owned {
     emit Here();
   }
 
-  function modifierIfOwner()
-    public
-    ifOwner()
-  {
-    emit Here();
-  }
-
 }

--- a/evm/v0.5/test/Owned_test.js
+++ b/evm/v0.5/test/Owned_test.js
@@ -89,7 +89,7 @@ contract('Owned', () => {
       it('does not allow a non-recipient to call it', async () => {
         await expectRevert(
           owned.acceptOwnership({ from: nonOwner }),
-          'Must be requested to accept ownership',
+          'Must be proposed owner',
         )
       })
     })

--- a/evm/v0.5/test/Owned_test.js
+++ b/evm/v0.5/test/Owned_test.js
@@ -15,6 +15,7 @@ contract('Owned', () => {
     checkPublicABI(Owned, [
       'owner',
       // test helper public methods
+      'modifierIfOwner',
       'modifierOnlyOwner',
     ])
   })
@@ -25,7 +26,23 @@ contract('Owned', () => {
     })
   })
 
-  describe('#modifierOnlyOwner', () => {
+  describe('#ifOwner modifier', () => {
+    context('when called by an owner', () => {
+      it('successfully calls the method', async () => {
+        const { logs } = await owned.modifierIfOwner({ from: owner })
+        expectEvent.inLogs(logs, 'Here')
+      })
+    })
+
+    context('when called by anyone but the owner', () => {
+      it('successfully calls the method', async () => {
+        const { logs } = await owned.modifierIfOwner({ from: nonOwner })
+        assert.equal(0, logs.length)
+      })
+    })
+  })
+
+  describe('#onlyOwner modifier', () => {
     context('when called by an owner', () => {
       it('successfully calls the method', async () => {
         const { logs } = await owned.modifierOnlyOwner({ from: owner })
@@ -33,7 +50,7 @@ contract('Owned', () => {
       })
     })
 
-    context('when called by an owner', () => {
+    context('when called by anyone but the owner', () => {
       it('successfully calls the method', async () => {
         expectRevert(
           owned.modifierOnlyOwner({ from: nonOwner }),

--- a/evm/v0.5/test/Owned_test.js
+++ b/evm/v0.5/test/Owned_test.js
@@ -1,0 +1,45 @@
+import { personas, checkPublicABI } from './support/helpers'
+import { expectEvent, expectRevert } from 'openzeppelin-test-helpers'
+
+contract('Owned', () => {
+  const Owned = artifacts.require('OwnedTestHelper.sol')
+  let owned, owner, nonOwner
+
+  beforeEach(async () => {
+    owner = personas.Carol
+    nonOwner = personas.Neil
+    owned = await Owned.new({ from: owner })
+  })
+
+  it('has a limited public interface', () => {
+    checkPublicABI(Owned, [
+      'owner',
+      // test helper public methods
+      'modifierOnlyOwner',
+    ])
+  })
+
+  describe('#constructor', () => {
+    it('assigns ownership to the deployer', async () => {
+      assert.equal(owner, await owned.owner.call())
+    })
+  })
+
+  describe('#modifierOnlyOwner', () => {
+    context('when called by an owner', () => {
+      it('successfully calls the method', async () => {
+        const { logs } = await owned.modifierOnlyOwner({ from: owner })
+        expectEvent.inLogs(logs, 'Here')
+      })
+    })
+
+    context('when called by an owner', () => {
+      it('successfully calls the method', async () => {
+        expectRevert(
+          owned.modifierOnlyOwner({ from: nonOwner }),
+          'Only callable by owner',
+        )
+      })
+    })
+  })
+})

--- a/evm/v0.5/test/Owned_test.js
+++ b/evm/v0.5/test/Owned_test.js
@@ -19,6 +19,7 @@ contract('Owned', () => {
     checkPublicABI(Owned, [
       'acceptOwnership',
       'owner',
+      'renounceOwnership',
       'transferOwnership',
       // test helper public methods
       'modifierOnlyOwner',
@@ -82,6 +83,32 @@ contract('Owned', () => {
         await expectRevert(
           owned.acceptOwnership({ from: nonOwner }),
           'Must be requested to accept ownership',
+        )
+      })
+    })
+  })
+
+  describe('#renounceOwnership', () => {
+    context('when called by an owner', () => {
+      it('emits a log', async () => {
+        const { logs } = await owned.renounceOwnership({ from: owner })
+        expectEvent.inLogs(logs, 'OwnershipRenounced', {by: owner})
+      })
+
+      it('changes the owner to the zero address', async () => {
+        assert.notEqual(0, await owned.owner.call())
+
+        await owned.renounceOwnership({ from: owner })
+
+        assert.equal(0, await owned.owner.call())
+      })
+    })
+
+    context('when called by anyone but the owner', () => {
+      it('successfully calls the method', async () => {
+        await expectRevert(
+          owned.renounceOwnership({ from: nonOwner }),
+          'Only callable by owner',
         )
       })
     })

--- a/evm/v0.5/test/Owned_test.js
+++ b/evm/v0.5/test/Owned_test.js
@@ -35,7 +35,7 @@ contract('Owned', () => {
     })
 
     context('when called by anyone but the owner', () => {
-      it('successfully calls the method', async () => {
+      it('reverts', async () => {
         const { logs } = await owned.modifierIfOwner({ from: nonOwner })
         assert.equal(0, logs.length)
       })
@@ -51,7 +51,7 @@ contract('Owned', () => {
     })
 
     context('when called by anyone but the owner', () => {
-      it('successfully calls the method', async () => {
+      it('reverts', async () => {
         expectRevert(
           owned.modifierOnlyOwner({ from: nonOwner }),
           'Only callable by owner',

--- a/evm/v0.5/test/Owned_test.js
+++ b/evm/v0.5/test/Owned_test.js
@@ -19,7 +19,6 @@ contract('Owned', () => {
     checkPublicABI(Owned, [
       'acceptOwnership',
       'owner',
-      'renounceOwnership',
       'transferOwnership',
       // test helper public methods
       'modifierOnlyOwner',
@@ -91,35 +90,6 @@ contract('Owned', () => {
         await expectRevert(
           owned.acceptOwnership({ from: nonOwner }),
           'Must be requested to accept ownership',
-        )
-      })
-    })
-  })
-
-  describe('#renounceOwnership', () => {
-    context('when called by an owner', () => {
-      it('emits a log', async () => {
-        const { logs } = await owned.renounceOwnership({ from: owner })
-        expectEvent.inLogs(logs, 'OwnershipTransfered', {
-          from: owner,
-          to: '0x0000000000000000000000000000000000000000',
-        })
-      })
-
-      it('changes the owner to the zero address', async () => {
-        assert.notEqual(0, await owned.owner.call())
-
-        await owned.renounceOwnership({ from: owner })
-
-        assert.equal(0, await owned.owner.call())
-      })
-    })
-
-    context('when called by anyone but the owner', () => {
-      it('successfully calls the method', async () => {
-        await expectRevert(
-          owned.renounceOwnership({ from: nonOwner }),
-          'Only callable by owner',
         )
       })
     })

--- a/evm/v0.5/test/Owned_test.js
+++ b/evm/v0.5/test/Owned_test.js
@@ -1,7 +1,7 @@
 import { personas, checkPublicABI } from './support/helpers'
 import { expectEvent, expectRevert } from 'openzeppelin-test-helpers'
 
-contract.only('Owned', () => {
+contract('Owned', () => {
   const Owned = artifacts.require('OwnedTestHelper.sol')
   let owned, owner, nonOwner, newOwner
 
@@ -21,7 +21,6 @@ contract.only('Owned', () => {
       'owner',
       'transferOwnership',
       // test helper public methods
-      'modifierIfOwner',
       'modifierOnlyOwner',
     ])
   })
@@ -29,22 +28,6 @@ contract.only('Owned', () => {
   describe('#constructor', () => {
     it('assigns ownership to the deployer', async () => {
       assert.equal(owner, await owned.owner.call())
-    })
-  })
-
-  describe('#ifOwner modifier', () => {
-    context('when called by an owner', () => {
-      it('successfully calls the method', async () => {
-        const { logs } = await owned.modifierIfOwner({ from: owner })
-        expectEvent.inLogs(logs, 'Here')
-      })
-    })
-
-    context('when called by anyone but the owner', () => {
-      it('reverts', async () => {
-        const { logs } = await owned.modifierIfOwner({ from: nonOwner })
-        assert.equal(0, logs.length)
-      })
     })
   })
 

--- a/evm/v0.5/test/Owned_test.js
+++ b/evm/v0.5/test/Owned_test.js
@@ -53,8 +53,13 @@ contract('Owned', () => {
   describe('#transferOwnership', () => {
     context('when called by an owner', () => {
       it('emits a log', async () => {
-        const { logs } = await owned.transferOwnership(newOwner, { from: owner })
-        expectEvent.inLogs(logs, 'OwnershipTransferRequested', {to: newOwner, from: owner})
+        const { logs } = await owned.transferOwnership(newOwner, {
+          from: owner,
+        })
+        expectEvent.inLogs(logs, 'OwnershipTransferRequested', {
+          to: newOwner,
+          from: owner,
+        })
       })
     })
 
@@ -76,7 +81,10 @@ contract('Owned', () => {
 
       it('allows the recipient to call it', async () => {
         const { logs } = await owned.acceptOwnership({ from: newOwner })
-        expectEvent.inLogs(logs, 'OwnershipTransfered', {to: newOwner, from: owner})
+        expectEvent.inLogs(logs, 'OwnershipTransfered', {
+          to: newOwner,
+          from: owner,
+        })
       })
 
       it('does not allow a non-recipient to call it', async () => {
@@ -92,7 +100,7 @@ contract('Owned', () => {
     context('when called by an owner', () => {
       it('emits a log', async () => {
         const { logs } = await owned.renounceOwnership({ from: owner })
-        expectEvent.inLogs(logs, 'OwnershipRenounced', {by: owner})
+        expectEvent.inLogs(logs, 'OwnershipRenounced', { by: owner })
       })
 
       it('changes the owner to the zero address', async () => {

--- a/evm/v0.5/test/Owned_test.js
+++ b/evm/v0.5/test/Owned_test.js
@@ -100,7 +100,10 @@ contract('Owned', () => {
     context('when called by an owner', () => {
       it('emits a log', async () => {
         const { logs } = await owned.renounceOwnership({ from: owner })
-        expectEvent.inLogs(logs, 'OwnershipRenounced', { by: owner })
+        expectEvent.inLogs(logs, 'OwnershipTransfered', {
+          from: owner,
+          to: '0x0000000000000000000000000000000000000000',
+        })
       })
 
       it('changes the owner to the zero address', async () => {

--- a/evm/v0.5/test/PrepaidAggregator_test.js
+++ b/evm/v0.5/test/PrepaidAggregator_test.js
@@ -92,6 +92,7 @@ contract('PrepaidAggregator', () => {
       // Owned methods:
       'acceptOwnership',
       'owner',
+      'renounceOwnership',
       'transferOwnership',
     ])
   })

--- a/evm/v0.5/test/PrepaidAggregator_test.js
+++ b/evm/v0.5/test/PrepaidAggregator_test.js
@@ -92,7 +92,6 @@ contract('PrepaidAggregator', () => {
       // Owned methods:
       'acceptOwnership',
       'owner',
-      'renounceOwnership',
       'transferOwnership',
     ])
   })

--- a/evm/v0.5/test/PrepaidAggregator_test.js
+++ b/evm/v0.5/test/PrepaidAggregator_test.js
@@ -89,8 +89,8 @@ contract('PrepaidAggregator', () => {
       'withdraw',
       'withdrawFunds',
       'withdrawable',
-      // Ownable methods:
-      'isOwner',
+      // Owned methods:
+      'acceptOwnership',
       'owner',
       'transferOwnership',
     ])
@@ -725,7 +725,7 @@ contract('PrepaidAggregator', () => {
           aggregator.addOracle(personas.Neil, minAns, maxAns, rrDelay, {
             from: personas.Neil,
           }),
-          'Ownable: caller is not the owner',
+          'Only callable by owner',
         )
       })
     })
@@ -935,7 +935,7 @@ contract('PrepaidAggregator', () => {
           aggregator.removeOracle(personas.Neil, 0, 0, rrDelay, {
             from: personas.Ned,
           }),
-          'Ownable: caller is not the owner',
+          'Only callable by owner',
         )
       })
     })
@@ -1024,7 +1024,7 @@ contract('PrepaidAggregator', () => {
           aggregator.withdrawFunds(personas.Carol, deposit, {
             from: personas.Eddy,
           }),
-          'Ownable: caller is not the owner',
+          'Only callable by owner',
         )
 
         assertBigNum(deposit, await aggregator.availableFunds.call())
@@ -1127,7 +1127,7 @@ contract('PrepaidAggregator', () => {
           updateFutureRounds(aggregator, {
             from: personas.Ned,
           }),
-          'caller is not the owner',
+          'Only callable by owner',
         )
       })
     })

--- a/evm/v0.5/test/PrepaidAggregator_test.js
+++ b/evm/v0.5/test/PrepaidAggregator_test.js
@@ -1175,7 +1175,7 @@ contract('PrepaidAggregator', () => {
     })
 
     context('when the available funds have not changed', () => {
-      it('emits a log', async () => {
+      it('does not emit a log', async () => {
         const tx = await aggregator.updateAvailableFunds()
 
         assert.equal(0, tx.receipt.rawLogs.length)

--- a/evm/v0.5/test/PrepaidAggregator_test.js
+++ b/evm/v0.5/test/PrepaidAggregator_test.js
@@ -1174,6 +1174,14 @@ contract('PrepaidAggregator', () => {
       const reportedBalance = h.bigNum(tx.receipt.rawLogs[0].topics[1])
       assertBigNum(await aggregator.availableFunds.call(), reportedBalance)
     })
+
+    context('when the available funds have not changed', () => {
+      it('emits a log', async () => {
+        const tx = await aggregator.updateAvailableFunds()
+
+        assert.equal(0, tx.receipt.rawLogs.length)
+      })
+    })
   })
 
   describe('#withdraw', async () => {


### PR DESCRIPTION
[Fixes #170265616]

- Implements a safer ownership transfer pattern, where the new owner must accept the transfer before it is finalized.
- Fix the round ID reported in the Aggregator to reflect the current round.
- Don't emit a log if nothing has changed when checking current balance.