### PR TITLE
Start and connect app before ResumeAllConnections, causes a race

### DIFF
--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -373,7 +373,7 @@ func TestRunManager_Create_fromRunLog_Happy(t *testing.T) {
 			mocketh.Context("app.Start()", func(meth *cltest.EthMock) {
 				meth.Register("eth_chainId", store.Config.ChainID())
 			})
-			app.Start()
+			app.StartAndConnect()
 
 			job := cltest.NewJobWithRunLogInitiator()
 			job.Tasks = []models.TaskSpec{cltest.NewTask(t, "NoOp")}

--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -286,7 +286,7 @@ func TestRunManager_Create(t *testing.T) {
 	eth := cltest.MockEthOnStore(t, store)
 	eth.Register("eth_chainId", store.Config.ChainID())
 
-	app.Start()
+	app.StartAndConnect()
 
 	job := cltest.NewJobWithRunLogInitiator()
 	job.Tasks = []models.TaskSpec{cltest.NewTask(t, "NoOp")} // empty params
@@ -312,7 +312,7 @@ func TestRunManager_Create_DoesNotSaveToTaskSpec(t *testing.T) {
 	mocketh := cltest.MockEthOnStore(t, store)
 	mocketh.Register("eth_chainId", store.Config.ChainID())
 
-	app.Start()
+	app.StartAndConnect()
 
 	job := cltest.NewJobWithWebInitiator()
 	job.Tasks = []models.TaskSpec{cltest.NewTask(t, "NoOp")} // empty params
@@ -615,7 +615,7 @@ func TestRunManager_Create_fromRunLogPayments(t *testing.T) {
 			mocketh.Context("app.Start()", func(meth *cltest.EthMock) {
 				meth.Register("eth_chainId", store.Config.ChainID())
 			})
-			app.Start()
+			app.StartAndConnect()
 
 			bt := &models.BridgeType{
 				Name:                   models.MustNewTaskType("expensiveBridge"),

--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -258,7 +258,7 @@ func TestRunManager_ResumeAllConnecting_NotEnoughConfirmations(t *testing.T) {
 	eth := cltest.MockEthOnStore(t, store)
 	eth.Register("eth_chainId", store.Config.ChainID())
 
-	app.Start()
+	app.StartAndConnect()
 
 	job := cltest.NewJobWithRunLogInitiator()
 	job.Tasks = []models.TaskSpec{cltest.NewTask(t, "NoOp")}


### PR DESCRIPTION
If the app connects after ResumeAllConnections, it may wake the run up again and since the mocks are not setup for that, it will error out. Make sure the connection happens first.

[Fixes #170322338]
[Fixes #170370573]