### PR TITLE
TestOneTime_AddJob: We want this to block and don't need a timeout

### DIFF
--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -415,6 +415,12 @@ func (t *TriggerClock) Trigger() {
 	}
 }
 
+// TriggerWithoutTimeout is a special case where we know the trigger might
+// block but don't care
+func (t *TriggerClock) TriggerWithoutTimeout() {
+	t.triggers <- time.Now()
+}
+
 // Now returns the current local time
 func (t TriggerClock) Now() time.Time {
 	return time.Now()

--- a/core/services/scheduler_test.go
+++ b/core/services/scheduler_test.go
@@ -166,7 +166,7 @@ func TestOneTime_AddJob(t *testing.T) {
 	}, 3*time.Second)
 
 	// This should block because if OneTime works it won't listen on the channel again
-	go clock.Trigger()
+	go clock.TriggerWithoutTimeout()
 
 	// Sleep for some time to make sure another call isn't made
 	time.Sleep(1 * time.Second)


### PR DESCRIPTION
This test has a special case use of the clock Trigger, where it's making sure that a second tick of a clock doesn't trigger a job to be executed. However, Trigger has a timeout for cases where it can block a test. 

So I've added a special case of Trigger for this case where we are fine with the goroutine just blocking and never returning as it doesn't affect the test.