### PR TITLE
web: Fix delete external initiator endpoint

### DIFF
--- a/core/web/external_initiators_controller.go
+++ b/core/web/external_initiators_controller.go
@@ -7,6 +7,7 @@ import (
 	"chainlink/core/auth"
 	"chainlink/core/services"
 	"chainlink/core/store/models"
+	"chainlink/core/store/orm"
 	"chainlink/core/store/presenters"
 
 	"github.com/gin-gonic/gin"
@@ -50,8 +51,10 @@ func (eic *ExternalInitiatorsController) Destroy(c *gin.Context) {
 		return
 	}
 
-	id := c.Param("AccessKey")
-	if err := eic.App.GetStore().DeleteExternalInitiator(id); err != nil {
+	name := c.Param("Name")
+	if exi, err := eic.App.GetStore().FindExternalInitiatorByName(name); err == orm.ErrorNotFound {
+		jsonAPIError(c, http.StatusNotFound, err)
+	} else if err := eic.App.GetStore().DeleteExternalInitiator(exi.Name); err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 	} else {
 		jsonAPIResponseWithStatus(c, nil, "external initiator", http.StatusNoContent)

--- a/core/web/external_initiators_controller_test.go
+++ b/core/web/external_initiators_controller_test.go
@@ -110,7 +110,24 @@ func TestExternalInitiatorsController_DeleteNotFound(t *testing.T) {
 
 	client := app.NewHTTPClient()
 
-	resp, cleanup := client.Delete("/v2/external_initiators")
-	defer cleanup()
-	assert.Equal(t, http.StatusText(http.StatusNotFound), http.StatusText(resp.StatusCode))
+	tests := []struct {
+		Name string
+		URL  string
+	}{
+		{
+			Name: "No external initiator specified",
+			URL:  "/v2/external_initiators",
+		},
+		{
+			Name: "Unknown initiator",
+			URL:  "/v2/external_initiators/not-exist",
+		},
+	}
+
+	for _, test := range tests {
+		t.Log(test.Name)
+		resp, cleanup := client.Delete(test.URL)
+		defer cleanup()
+		assert.Equal(t, http.StatusText(http.StatusNotFound), http.StatusText(resp.StatusCode))
+	}
 }


### PR DESCRIPTION
Return a 'Not Found' error when the external initiator to be deleted
does not exist.

Also correct an important issue where the wrong endpoint key is being
set in the router.

https://www.pivotaltracker.com/story/show/170400051