### PR TITLE
[evmv0.5] Enable strict mode additional checks

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -28,6 +28,7 @@ module.exports = {
     '@typescript-eslint/no-empty-interface': 'off',
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/ban-ts-ignore': 'warn',
     '@typescript-eslint/no-use-before-define': [
       'error',
       { functions: false, typedefs: false },

--- a/evm/v0.5/test/support/helpers.ts
+++ b/evm/v0.5/test/support/helpers.ts
@@ -3,6 +3,7 @@ import cbor from 'cbor'
 import * as abi from 'ethereumjs-abi'
 import * as util from 'ethereumjs-util'
 import { FunctionFragment } from 'ethers/utils/abi-coder'
+//@ts-ignore
 import TruffleContract from 'truffle-contract'
 import linkToken from './LinkToken.json'
 import { assertBigNum } from './matchers'
@@ -123,6 +124,7 @@ export const toHexWithoutPrefix = (arg: any): string => {
   if (arg instanceof Buffer || arg instanceof BN) {
     return arg.toString('hex')
   } else if (arg instanceof Uint8Array) {
+    //@ts-ignore
     return Array.prototype.reduce.call(
       arg,
       (a: any, v: any) => a + v.toString('16').padStart(2, '0'),
@@ -355,6 +357,7 @@ export const newUint8ArrayFromStr = (str: string): Uint8Array => {
   const codePoints = Array.prototype.map.call(str, (c: string) =>
     c.charCodeAt(0),
   )
+  //@ts-ignore
   return Uint8Array.from(codePoints)
 }
 

--- a/evm/v0.5/test/support/matchers.ts
+++ b/evm/v0.5/test/support/matchers.ts
@@ -1,6 +1,7 @@
 const bigNum = (num: number) => web3.utils.toBN(num)
 
 // Throws if a and b are not equal, as BN's
+//@ts-ignore
 export const assertBigNum = (a, b, failureMessage) =>
   assert(
     bigNum(a).eq(bigNum(b)),

--- a/evm/v0.5/tsconfig.json
+++ b/evm/v0.5/tsconfig.json
@@ -12,7 +12,12 @@
     "noEmitOnError": false,
     "resolveJsonModule": true,
     "moduleResolution": "node",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
   },
-  "include": ["test", "src", "@types"]
+  "include": ["test", "testv2", "src", "@types"]
 }


### PR DESCRIPTION
All errors in test/support were ignored since they're about to be
replaced by the helper files within src/ anyway.