### PR TITLE
cmd: fix error reporting when ext. init. not found

### DIFF
--- a/core/cmd/remote_client.go
+++ b/core/cmd/remote_client.go
@@ -111,10 +111,8 @@ func (cli *Client) DeleteExternalInitiator(c *clipkg.Context) error {
 		return cli.errorOut(err)
 	}
 	defer resp.Body.Close()
-	if resp.StatusCode >= 400 && resp.StatusCode < 500 {
-		cli.renderAPIResponse(resp, nil)
-	}
-	return nil
+	_, err = cli.parseResponse(resp)
+	return err
 }
 
 // ShowJobRun returns the status of the given Jobrun.


### PR DESCRIPTION
Use parseResponse(..) to correctly report an error to a command line user when trying to detroy a non-existent External Initiator.

Fixes #1255453b22473f97cde96d4acb5d4412d925a047

https://www.pivotaltracker.com/story/show/170400051