### PR TITLE
README: Use 'yarn install' in prep for Golang testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,8 +119,8 @@ $ ./chainlink
 2. Build contracts:
 
 ```bash
-$ cd evm
-$ yarn build
+$ yarn
+$ make contracts
 ```
 
 3. Ready for testing:


### PR DESCRIPTION
Fix an issue in the README testin instructions which results in the error 'sol-compiler: command not found'.

Edit: Updated to use 'make contracts' instead