### PR TITLE
Change default cypress job server host

### DIFF
--- a/integration/cypress/support/commands.ts
+++ b/integration/cypress/support/commands.ts
@@ -36,7 +36,7 @@ Cypress.Commands.add(
 
 Cypress.Commands.add('getJobJson', () => {
   cy.fixture('job').then(job => {
-    const host = Cypress.env('JOB_SERVER_HOST') || 'localhost'
+    const host = Cypress.env('JOB_SERVER_HOST') || 'cypress-job-server'
     const port = Cypress.env('JOB_SERVER_PORT') || '6692'
     job.tasks[0].params.get = `http://${host}:${port}`
     cy.wrap(JSON.stringify(job, null, 4))


### PR DESCRIPTION
The default for the job server host has been changed so that it works
correctly by default when running it locally against docker infra.