### PR TITLE
Fix ValidateRun to show consistent amounts

### DIFF
--- a/core/services/run_manager.go
+++ b/core/services/run_manager.go
@@ -167,7 +167,7 @@ func ValidateRun(run *models.JobRun, contractCost *assets.Link) {
 		err := fmt.Errorf(
 			"Rejecting job %s with payment %s below minimum threshold (%s)",
 			run.JobSpecID,
-			run.Payment,
+			run.Payment.Text(10),
 			contractCost.Text(10))
 		run.SetError(err)
 		return


### PR DESCRIPTION
This fixes inconsistent magnitude in errors.

BEFORE

<img width="707" alt="Screenshot 2020-01-03 at 16 53 17" src="https://user-images.githubusercontent.com/4147639/71717125-9ecdd000-2e49-11ea-9aa4-18c688cc044b.png">

AFTER

<img width="760" alt="Screenshot 2020-01-03 at 17 05 34" src="https://user-images.githubusercontent.com/4147639/71717650-4c8dae80-2e4b-11ea-87b9-60014e004bf9.png">
