### PR TITLE
prevent pending connection from submitting 2nd tx

### DIFF
--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -41,7 +41,7 @@ type EthTx struct {
 // the blockchain.
 func (etx *EthTx) Perform(input models.RunInput, store *strpkg.Store) models.RunOutput {
 	if !store.TxManager.Connected() {
-		return models.NewRunOutputPendingConnection()
+		return pendingConfirmationsOrConnection(input)
 	}
 
 	if input.Status().PendingConfirmations() {
@@ -229,4 +229,13 @@ var (
 // eventually return a transaction receipt.
 func IsClientEmptyError(err error) bool {
 	return err != nil && parityEmptyResponseRegex.MatchString(err.Error())
+}
+
+func pendingConfirmationsOrConnection(input models.RunInput) models.RunOutput {
+	// If the input is not pending confirmations next time it may, then it may
+	// submit a new transaction.
+	if input.Status().PendingConfirmations() {
+		return models.NewRunOutputPendingConfirmations()
+	}
+	return models.NewRunOutputPendingConnection()
 }

--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -297,6 +297,26 @@ func TestEthTxAdapter_Perform_PendingConfirmations_WithRecoverableErrorInTxManag
 	txManager.AssertExpectations(t)
 }
 
+func TestEthTxAdapter_Perform_NotConnectedWhenPendingConfirmations(t *testing.T) {
+	t.Parallel()
+
+	store, cleanup := cltest.NewStore(t)
+	defer cleanup()
+
+	txManager := new(mocks.TxManager)
+	txManager.On("Connected").Return(false)
+	store.TxManager = txManager
+
+	adapter := adapters.EthTx{}
+	input := *models.NewRunInput(models.NewID(), models.JSON{}, models.RunStatusPendingConfirmations)
+	data := adapter.Perform(input, store)
+
+	require.NoError(t, data.Error())
+	assert.Equal(t, models.RunStatusPendingConfirmations, data.Status())
+
+	txManager.AssertExpectations(t)
+}
+
 func TestEthTxAdapter_Perform_NotConnected(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
- If a node is not connected, it may create a second transaction instead
of worst case just creating a new attempt, which will subsequently throw off
the behavior of the first transaction and attempt.