### PR TITLE
Feature/flux monitor prometheus integration

### DIFF
--- a/core/services/flux_monitor_fetchers.go
+++ b/core/services/flux_monitor_fetchers.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/guregu/null"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/shopspring/decimal"
 	"go.uber.org/multierr"
 )
@@ -41,8 +42,12 @@ func newHTTPFetcher(
 		return nil, err
 	}
 
+	client := &http.Client{Timeout: timeout, Transport: http.DefaultTransport}
+	client.Transport = promhttp.InstrumentRoundTripperDuration(promFMResponseTime, client.Transport)
+	client.Transport = instrumentRoundTripperReponseSize(promFMResponseSize, client.Transport)
+
 	return &httpFetcher{
-		client:      &http.Client{Timeout: timeout},
+		client:      client,
 		url:         u,
 		requestData: requestData,
 	}, err

--- a/core/services/flux_monitor_prometheus.go
+++ b/core/services/flux_monitor_prometheus.go
@@ -1,0 +1,79 @@
+package services
+
+import (
+	"math/big"
+	"net/http"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/shopspring/decimal"
+)
+
+var (
+	promFMReportedValue = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flux_monitor_reported_value",
+			Help: "Flux monitor's last reported price",
+		},
+		[]string{"job_spec_id"},
+	)
+	promFMSeenValue = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flux_monitor_seen_value",
+			Help: "Flux monitor's last observed value from target",
+		},
+		[]string{"job_spec_id"},
+	)
+	promFMReportedRound = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flux_monitor_reported_round",
+			Help: "Flux monitor's last reported round",
+		},
+		[]string{"job_spec_id"},
+	)
+	promFMSeenRound = promauto.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "flux_monitor_seen_round",
+			Help: "Last seen round by other node operators",
+		},
+		[]string{"job_spec_id"},
+	)
+	promFMResponseTime = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "flux_monitor_request_duration_seconds",
+			Help:    "Flux monitor's histogram of request latencies",
+			Buckets: prometheus.DefBuckets,
+		},
+		[]string{},
+	)
+	promFMResponseSize = promauto.NewHistogram(
+		prometheus.HistogramOpts{
+			Name:    "flux_monitor_response_size_bytes",
+			Help:    "Flux monitor's last response body size",
+			Buckets: prometheus.DefBuckets,
+		},
+	)
+)
+
+func promSetDecimal(gauge prometheus.Gauge, arg decimal.Decimal) {
+	val, _ := arg.Float64()
+	gauge.Set(val)
+}
+
+func promSetBigInt(gauge prometheus.Gauge, arg *big.Int) {
+	gauge.Set(float64(arg.Int64()))
+}
+
+func instrumentRoundTripperReponseSize(
+	obs prometheus.Observer,
+	next http.RoundTripper,
+) promhttp.RoundTripperFunc {
+	return promhttp.RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		resp, err := next.RoundTrip(r)
+		if err == nil && resp.ContentLength >= 0 {
+			obs.Observe(float64(resp.ContentLength))
+		}
+		return resp, err
+	})
+}

--- a/go.mod
+++ b/go.mod
@@ -48,6 +48,7 @@ require (
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.3.0
+	github.com/prometheus/tsdb v0.7.1 // indirect
 	github.com/rjeczalik/notify v0.9.2 // indirect
 	github.com/rs/cors v1.6.0 // indirect
 	github.com/satori/go.uuid v1.2.0


### PR DESCRIPTION
Use prometheus to monitor:

 - Last reported and seen prices (w/ JobSpecID as label)
 - Last reported and seen rounds (w/ JobSpecID as label)
 - HTTP request times
 - HTTP response size

Attempt to isolate prometheus code to improve clarity by defining metric values and helper functions into a separate file called 'flux_monitor_prometheus.go'.

https://www.pivotaltracker.com/story/show/169484307