### PR TITLE
Add sol-trace support to v0.5 tests

### DIFF
--- a/evm/v0.5/package.json
+++ b/evm/v0.5/package.json
@@ -17,7 +17,8 @@
     "prepublishOnly": "yarn setup && yarn lint && yarn test",
     "test": "yarn test:v1 && yarn test:v2",
     "test:v1": "tsc && truffle test ./dist/test/*_test.js",
-    "test:v2": "jest --testTimeout 80000",
+    "_comment_:test:v2": "# we force exit because the subprovider holds onto resources and doesn't release them",
+    "test:v2": "jest --testTimeout 80000 --detectOpenHandles --forceExit",
     "tsc": "tsc"
   },
   "dependencies": {
@@ -31,6 +32,7 @@
   },
   "devDependencies": {
     "@0x/sol-compiler": "^4.0.3",
+    "@0x/sol-trace": "^3.0.3",
     "@types/bn.js": "^4.11.5",
     "@types/cbor": "^2.0.0",
     "@types/chai": "^4.2.7",

--- a/evm/v0.5/src/provider.ts
+++ b/evm/v0.5/src/provider.ts
@@ -1,9 +1,35 @@
 import { ethers } from 'ethers'
-import ganache from 'ganache-core'
+import {
+  SolCompilerArtifactAdapter,
+  Web3ProviderEngine,
+  RevertTraceSubprovider,
+} from '@0x/sol-trace'
+import {
+  FakeGasEstimateSubprovider,
+  GanacheSubprovider,
+} from '@0x/subproviders'
+import * as path from 'path'
 
 /**
  * Create a test provider which uses an in-memory, in-process chain
  */
 export function makeTestProvider(): ethers.providers.JsonRpcProvider {
-  return new ethers.providers.Web3Provider(ganache.provider() as any)
+  const defaultFromAddress = ''
+  const artifactAdapter = new SolCompilerArtifactAdapter(
+    path.resolve('dist/artifacts'),
+    path.resolve('contracts'),
+  )
+  const revertTraceSubprovider = new RevertTraceSubprovider(
+    artifactAdapter,
+    defaultFromAddress,
+    true,
+  )
+
+  const providerEngine = new Web3ProviderEngine()
+  providerEngine.addProvider(new FakeGasEstimateSubprovider(4 * 10 ** 6)) // Ganache does a poor job of estimating gas, so just crank it up for testing.
+  providerEngine.addProvider(revertTraceSubprovider)
+  providerEngine.addProvider(new GanacheSubprovider({}))
+  providerEngine.start()
+
+  return new ethers.providers.Web3Provider(providerEngine)
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,6 +39,25 @@
     ethereum-types "^2.1.6"
     lodash "^4.17.11"
 
+"@0x/dev-utils@^3.1.0":
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/@0x/dev-utils/-/dev-utils-3.1.0.tgz#a343f36aa819b2e748fe9946645fd959ebff843c"
+  integrity sha512-Xy2ub6gxsIu5MsWdmFpxsMaIg5o33lRwzeZshdfPLqGKx6GVM2Kk4GTWUiBrukpoUA8LvyV5nW8vzOrZm0UJfA==
+  dependencies:
+    "@0x/subproviders" "^6.0.3"
+    "@0x/types" "^3.1.1"
+    "@0x/typescript-typings" "^5.0.1"
+    "@0x/utils" "^5.1.2"
+    "@0x/web3-wrapper" "^7.0.3"
+    "@types/web3-provider-engine" "^14.0.0"
+    chai "^4.0.1"
+    chai-as-promised "^7.1.0"
+    chai-bignumber "^3.0.0"
+    dirty-chai "^2.0.1"
+    ethereum-types "^3.0.0"
+    lodash "^4.17.11"
+    web3-provider-engine "14.0.6"
+
 "@0x/json-schemas@^4.0.2":
   version "4.0.2"
   resolved "https://registry.npmjs.org/@0x/json-schemas/-/json-schemas-4.0.2.tgz#6f7c1dcde04d3acc3e8ca2f24177b9705c10e772"
@@ -146,6 +165,21 @@
     loglevel "^1.6.1"
     web3-provider-engine "14.0.6"
 
+"@0x/sol-trace@^3.0.3":
+  version "3.0.3"
+  resolved "https://registry.npmjs.org/@0x/sol-trace/-/sol-trace-3.0.3.tgz#97405e3c35eddd3505effaff0aca3abacd757a24"
+  integrity sha512-pEAAqfRyNAUSrIMFZuSOB+ZwkU7FkAsiu56t7CAU0U5P+fyQShyZ5aDf0qgg1vt3u+69dz0B2NifC5bcsCVTog==
+  dependencies:
+    "@0x/sol-tracing-utils" "^7.0.3"
+    "@0x/subproviders" "^6.0.3"
+    "@0x/typescript-typings" "^5.0.1"
+    chalk "^2.3.0"
+    ethereum-types "^3.0.0"
+    ethereumjs-util "^5.1.1"
+    lodash "^4.17.11"
+    loglevel "^1.6.1"
+    web3-provider-engine "14.0.6"
+
 "@0x/sol-tracing-utils@^6.0.19":
   version "6.0.19"
   resolved "https://registry.npmjs.org/@0x/sol-tracing-utils/-/sol-tracing-utils-6.0.19.tgz#3c119c7e5b6d2bd1c94663985b7641aec85ef625"
@@ -161,6 +195,33 @@
     "@types/solidity-parser-antlr" "^0.2.3"
     chalk "^2.3.0"
     ethereum-types "^2.1.6"
+    ethereumjs-util "^5.1.1"
+    ethers "~4.0.4"
+    glob "^7.1.2"
+    istanbul "^0.4.5"
+    lodash "^4.17.11"
+    loglevel "^1.6.1"
+    mkdirp "^0.5.1"
+    rimraf "^2.6.2"
+    semaphore-async-await "^1.5.1"
+    solc "^0.5.5"
+    solidity-parser-antlr "^0.4.2"
+
+"@0x/sol-tracing-utils@^7.0.3":
+  version "7.0.3"
+  resolved "https://registry.npmjs.org/@0x/sol-tracing-utils/-/sol-tracing-utils-7.0.3.tgz#33de0c07466b1faed2e7b3c9ffdf7fe3fd24315a"
+  integrity sha512-7LLAb+7EYIuT92xb84Ta560vbSs7EnbomgWztDeKK9HvQ13rRo0XPeu+TlsTsVbgPxVDba1rw30Ax0r9vmLdJw==
+  dependencies:
+    "@0x/dev-utils" "^3.1.0"
+    "@0x/sol-compiler" "^4.0.3"
+    "@0x/sol-resolver" "^3.0.2"
+    "@0x/subproviders" "^6.0.3"
+    "@0x/typescript-typings" "^5.0.1"
+    "@0x/utils" "^5.1.2"
+    "@0x/web3-wrapper" "^7.0.3"
+    "@types/solidity-parser-antlr" "^0.2.3"
+    chalk "^2.3.0"
+    ethereum-types "^3.0.0"
     ethereumjs-util "^5.1.1"
     ethers "~4.0.4"
     glob "^7.1.2"
@@ -190,6 +251,34 @@
     bip39 "^2.5.0"
     bn.js "^4.11.8"
     ethereum-types "^2.1.6"
+    ethereumjs-tx "^1.3.5"
+    ethereumjs-util "^5.1.1"
+    ganache-core "^2.6.0"
+    hdkey "^0.7.1"
+    json-rpc-error "2.0.0"
+    lodash "^4.17.11"
+    semaphore-async-await "^1.5.1"
+    web3-provider-engine "14.0.6"
+  optionalDependencies:
+    "@ledgerhq/hw-transport-node-hid" "^4.3.0"
+
+"@0x/subproviders@^6.0.3":
+  version "6.0.3"
+  resolved "https://registry.npmjs.org/@0x/subproviders/-/subproviders-6.0.3.tgz#5d88dc15efab2df6463de5e48706396645c2b5ed"
+  integrity sha512-sPw9I1rv/JMXxkf6c7xZVbwSMB0RizsuqG45NSHaIwPoWPh3/+IkmIgRv4M9nWignDu/q+F8v0D1ww3aIGMX0Q==
+  dependencies:
+    "@0x/assert" "^3.0.3"
+    "@0x/types" "^3.1.1"
+    "@0x/typescript-typings" "^5.0.1"
+    "@0x/utils" "^5.1.2"
+    "@0x/web3-wrapper" "^7.0.3"
+    "@ledgerhq/hw-app-eth" "^4.3.0"
+    "@ledgerhq/hw-transport-u2f" "4.24.0"
+    "@types/hdkey" "^0.7.0"
+    "@types/web3-provider-engine" "^14.0.0"
+    bip39 "^2.5.0"
+    bn.js "^4.11.8"
+    ethereum-types "^3.0.0"
     ethereumjs-tx "^1.3.5"
     ethereumjs-util "^5.1.1"
     ganache-core "^2.6.0"
@@ -5667,14 +5756,6 @@ buffer-xor@^1.0.3:
   resolved "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz#26e61ed1422fb70dd42e6e36729ed51d855fe8d9"
   integrity sha1-JuYe0UIvtw3ULm42cp7VHYVf6Nk=
 
-buffer@5.4.3, buffer@^5.0.5, buffer@^5.2.1:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.3.tgz#3fbc9c69eb713d323e3fc1a895eee0710c072115"
-  integrity sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
-
 buffer@^4.3.0:
   version "4.9.2"
   resolved "https://registry.npmjs.org/buffer/-/buffer-4.9.2.tgz#230ead344002988644841ab0244af8c44bbe3ef8"
@@ -5683,6 +5764,14 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
+
+buffer@^5.0.5, buffer@^5.2.1:
+  version "5.4.3"
+  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.3.tgz#3fbc9c69eb713d323e3fc1a895eee0710c072115"
+  integrity sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==
+  dependencies:
+    base64-js "^1.0.2"
+    ieee754 "^1.1.4"
 
 buffer@^5.1.0:
   version "5.4.0"
@@ -5994,6 +6083,18 @@ center-align@^0.1.1:
   dependencies:
     align-text "^0.1.3"
     lazy-cache "^1.0.3"
+
+chai-as-promised@^7.1.0:
+  version "7.1.1"
+  resolved "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz#08645d825deb8696ee61725dbf590c012eb00ca0"
+  integrity sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==
+  dependencies:
+    check-error "^1.0.2"
+
+chai-bignumber@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.npmjs.org/chai-bignumber/-/chai-bignumber-3.0.0.tgz#e90cf1f468355bbb11a9acd051222586cd2648a9"
+  integrity sha512-SubOtaSI2AILWTWe2j0c6i2yFT/f9J6UBjeVGDuwDiPLkF/U5+/eTWUE3sbCZ1KgcPF6UJsDVYbIxaYA097MQA==
 
 chai-bn@^0.1.1:
   version "0.1.1"
@@ -7905,6 +8006,11 @@ dir-glob@^2.0.0:
   integrity sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==
   dependencies:
     path-type "^3.0.0"
+
+dirty-chai@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/dirty-chai/-/dirty-chai-2.0.1.tgz#6b2162ef17f7943589da840abc96e75bda01aff3"
+  integrity sha512-ys79pWKvDMowIDEPC6Fig8d5THiC0DJ2gmTeGzVAoEH18J8OzLud0Jh7I9IWg3NSk8x2UocznUuFmfHCXYZx9w==
 
 discontinuous-range@1.0.0:
   version "1.0.0"
@@ -19578,12 +19684,12 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-sha3@^1.2.2, sha3@^2.0.7:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/sha3/-/sha3-2.1.1.tgz#488c0f978a73ea540cc4f4a2235a77aed095c031"
-  integrity sha512-hj6dCLbWByenZarg2gb2VFD9zoY5kr/FMriDcbtVDLJ5geOWGOJCI0jQUjAzoY/ZHlkt8BSEbh9KJEDT8AGuJQ==
+sha3@^1.2.2:
+  version "1.2.6"
+  resolved "https://registry.npmjs.org/sha3/-/sha3-1.2.6.tgz#102aa3e47dc793e2357902c3cce8760822f9e905"
+  integrity sha512-KgLGmJGrmNB4JWVsAV11Yk6KbvsAiygWJc7t5IebWva/0NukNrjJqhtKhzy3Eiv2AKuGvhZZt7dt1mDo7HkoiQ==
   dependencies:
-    buffer "5.4.3"
+    nan "2.13.2"
 
 shallow-clone@^0.1.2:
   version "0.1.2"


### PR DESCRIPTION
This was driven out by a need of debugging a failed test conversion in https://www.pivotaltracker.com/story/show/170605187.

This adds solidity stack trace + source map support for reverts during test failures. You can see an example revert message below with this PR.

![image](https://user-images.githubusercontent.com/6404866/72012802-918a5a00-322a-11ea-929b-f0f0d7b094f0.png)
