### PR TITLE
Log a warning if a task fails in RunExecutor

### DIFF
--- a/core/services/run_executor.go
+++ b/core/services/run_executor.go
@@ -79,7 +79,11 @@ func (je *runExecutor) Execute(runID *models.ID) error {
 	}
 
 	if run.Status.Finished() {
-		logger.Debugw("All tasks complete for run", run.ForLogger()...)
+		if run.Status.Errored() {
+			logger.Warnw("Task failed", run.ForLogger()...)
+		} else {
+			logger.Debugw("All tasks complete for run", run.ForLogger()...)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
If a task fails, instead of logging `All tasks complete for run` log `Task failed` at warning level.