### PR TITLE
eth: Properly handle zero hex values

### DIFF
--- a/core/eth/client.go
+++ b/core/eth/client.go
@@ -148,9 +148,13 @@ func (client *CallerSubscriberClient) GetAggregatorPrice(address common.Address,
 
 func parseHexOrDecimal(input string) (decimal.Decimal, error) {
 	if utils.HasHexPrefix(input) {
-		if value, ok := (&big.Int{}).SetString(input[2:], 16); ok {
+		if len([]rune(input)) == 2 {
+			input = "0x0"
+		}
+		if value, ok := (&big.Int{}).SetString(input, 0); ok {
 			return decimal.NewFromString(value.Text(10))
 		}
+
 	}
 	return decimal.NewFromString(input)
 }

--- a/core/eth/client_test.go
+++ b/core/eth/client_test.go
@@ -178,6 +178,7 @@ func TestCallerSubscriberClient_GetAggregatorPrice(t *testing.T) {
 		precision      int32
 		expectation    decimal.Decimal
 	}{
+		{"hex - Zero", "0x", 2, decimal.NewFromFloat(0)},
 		{"hex", "0x0100", 2, decimal.NewFromFloat(2.56)},
 		{"decimal", "10000000000000", 11, decimal.NewFromInt(100)},
 		{"large decimal", "52050000000000000000", 11, decimal.RequireFromString("520500000")},


### PR DESCRIPTION
The value of '0x' should be counted as a legal zero.

https://www.pivotaltracker.com/story/show/170651351