### PR TITLE
Add quotient adapter

### DIFF
--- a/core/adapters/adapter.go
+++ b/core/adapters/adapter.go
@@ -45,6 +45,8 @@ var (
 	TaskTypeRandom = models.MustNewTaskType("random")
 	// TaskTypeCompare is the identifier for the Compare adapter.
 	TaskTypeCompare = models.MustNewTaskType("compare")
+	// TaskTypeQuotient is the identifier for the Quotient adapter.
+	TaskTypeQuotient = models.MustNewTaskType("quotient")
 )
 
 // BaseAdapter is the minimum interface required to create an adapter. Only core
@@ -128,6 +130,9 @@ func For(task models.TaskSpec, config orm.ConfigReader, orm *orm.ORM) (*Pipeline
 		err = unmarshalParams(task.Params, ba)
 	case TaskTypeCompare:
 		ba = &Compare{}
+		err = unmarshalParams(task.Params, ba)
+	case TaskTypeQuotient:
+		ba = &Quotient{}
 		err = unmarshalParams(task.Params, ba)
 	default:
 		bt, err := orm.FindBridge(task.Type)

--- a/core/adapters/doc.go
+++ b/core/adapters/doc.go
@@ -70,6 +70,17 @@
 // value.
 //   { "type": "Multiply", "params": {"times": 100 }}
 //
+// Quotient
+//
+// The Quotient adapter gives the result of x / y where x is a specified value (dividend)
+// and y is the input value (result).
+// This can be useful for inverting outputs, e.g. if you have a USD/ETH conversion
+// rate and you want to flip it to ETH/USD you can use this adapter with a dividend of 1 to get
+// 1 / result.
+//
+// value.
+//   { "type": "Quotient", "params": {"dividend": 1 }}
+//
 // Random
 //
 // Random adapter generates a number between 0 and 2**256-1

--- a/core/adapters/quotient.go
+++ b/core/adapters/quotient.go
@@ -37,7 +37,6 @@ type Quotient struct {
 // For example, if input value is "2.5", and the adapter's "dividend" value
 // is "1", the result's value will be "0.4".
 func (q *Quotient) Perform(input models.RunInput, _ *store.Store) models.RunOutput {
-	fmt.Println(q.Dividend)
 	val := input.Result()
 	i, ok := (&big.Float{}).SetString(val.String())
 	if !ok {

--- a/core/adapters/quotient.go
+++ b/core/adapters/quotient.go
@@ -1,0 +1,53 @@
+package adapters
+
+import (
+	"fmt"
+	"math/big"
+	"strconv"
+
+	"chainlink/core/store"
+	"chainlink/core/store/models"
+	"chainlink/core/utils"
+)
+
+// Dividend represents x where x / y.
+type Dividend float64
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (n *Dividend) UnmarshalJSON(input []byte) error {
+	input = utils.RemoveQuotes(input)
+	dividend, err := strconv.ParseFloat(string(input), 64)
+	if err != nil {
+		return fmt.Errorf("cannot parse into float: %s", input)
+	}
+
+	*n = Dividend(dividend)
+
+	return nil
+}
+
+// Quotient holds the Dividend.
+type Quotient struct {
+	Dividend *Dividend `json:"dividend"`
+}
+
+// Perform returns result of dividend / divisor were divisor is
+// the input's "result" field.
+//
+// For example, if input value is "2.5", and the adapter's "dividend" value
+// is "1", the result's value will be "0.4".
+func (q *Quotient) Perform(input models.RunInput, _ *store.Store) models.RunOutput {
+	fmt.Println(q.Dividend)
+	val := input.Result()
+	i, ok := (&big.Float{}).SetString(val.String())
+	if !ok {
+		return models.NewRunOutputError(fmt.Errorf("cannot parse into big.Float: %v", val.String()))
+	}
+	if i.Cmp(big.NewFloat(0)) == 0 {
+		return models.NewRunOutputError(fmt.Errorf("cannot divide by zero"))
+	}
+	if q.Dividend != nil {
+		i = new(big.Float).Quo(big.NewFloat(float64(*q.Dividend)), i)
+	}
+	return models.NewRunOutputCompleteWithResult(i.String())
+}

--- a/core/adapters/quotient_test.go
+++ b/core/adapters/quotient_test.go
@@ -42,10 +42,11 @@ func TestQuotient_Perform_Success(t *testing.T) {
 			t.Parallel()
 			input := cltest.NewRunInputWithString(t, test.json)
 			adapter := adapters.Quotient{}
-			json.Unmarshal([]byte(test.params), &adapter)
+			jsonErr := json.Unmarshal([]byte(test.params), &adapter)
 			result := adapter.Perform(input, nil)
 
 			require.NoError(t, result.Error())
+			require.NoError(t, jsonErr)
 			assert.Equal(t, test.want, result.Result().String())
 		})
 	}
@@ -56,12 +57,11 @@ func TestQuotient_Perform_Error(t *testing.T) {
 		name   string
 		params string
 		json   string
-		want   string
 	}{
-		{"string zero integer", `{"dividend":"1"}`, `{"result":0}`, "0"},
-		{"zero string zero float", `{"dividend":"0"}`, `{"result":"0"}`, "0"},
-		{"object", `{"dividend":100}`, `{"result":{"foo":"bar"}}`, ""},
-		{"string object", `{"dividend":"100"}`, `{"result":{"foo":"bar"}}`, ""},
+		{"string zero integer", `{"dividend":"1"}`, `{"result":0}`},
+		{"zero string zero float", `{"dividend":"0"}`, `{"result":"0"}`},
+		{"object", `{"dividend":100}`, `{"result":{"foo":"bar"}}`},
+		{"string object", `{"dividend":"100"}`, `{"result":{"foo":"bar"}}`},
 	}
 
 	for _, test := range tests {
@@ -72,8 +72,8 @@ func TestQuotient_Perform_Error(t *testing.T) {
 			jsonErr := json.Unmarshal([]byte(test.params), &adapter)
 			result := adapter.Perform(input, nil)
 
-			require.Error(t, result.Error())
-			assert.NoError(t, jsonErr)
+			require.NoError(t, jsonErr)
+			assert.Error(t, result.Error())
 		})
 	}
 }
@@ -82,20 +82,15 @@ func TestQuotient_Perform_JSONParseError(t *testing.T) {
 	tests := []struct {
 		name   string
 		params string
-		json   string
-		want   string
 	}{
-		{"array string", `{"dividend":[1, 2, 3]}`, `{"result":"1.23"}`, ""},
-		{"rubbish string", `{"dividend":"123aaa123"}`, `{"result":"1.23"}`, ""},
+		{"array string", `{"dividend":[1, 2, 3]}`},
+		{"rubbish string", `{"dividend":"123aaa123"}`},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			t.Parallel()
-			input := cltest.NewRunInputWithString(t, test.json)
 			adapter := adapters.Quotient{}
 			jsonErr := json.Unmarshal([]byte(test.params), &adapter)
-			adapter.Perform(input, nil)
-
 			assert.Error(t, jsonErr)
 		})
 	}

--- a/core/adapters/quotient_test.go
+++ b/core/adapters/quotient_test.go
@@ -39,7 +39,6 @@ func TestQuotient_Perform_Success(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			input := cltest.NewRunInputWithString(t, test.json)
 			adapter := adapters.Quotient{}
 			jsonErr := json.Unmarshal([]byte(test.params), &adapter)
@@ -66,7 +65,6 @@ func TestQuotient_Perform_Error(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			input := cltest.NewRunInputWithString(t, test.json)
 			adapter := adapters.Quotient{}
 			jsonErr := json.Unmarshal([]byte(test.params), &adapter)
@@ -88,7 +86,6 @@ func TestQuotient_Perform_JSONParseError(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Parallel()
 			adapter := adapters.Quotient{}
 			jsonErr := json.Unmarshal([]byte(test.params), &adapter)
 			assert.Error(t, jsonErr)

--- a/core/adapters/quotient_test.go
+++ b/core/adapters/quotient_test.go
@@ -1,0 +1,102 @@
+package adapters_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"chainlink/core/adapters"
+	"chainlink/core/internal/cltest"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestQuotient_Perform_Success(t *testing.T) {
+	tests := []struct {
+		name   string
+		params string
+		json   string
+		want   string
+	}{
+		{"string", `{"dividend":100}`, `{"result":"1.23"}`, "81.30081301"},
+		{"integer", `{"dividend":100}`, `{"result":123}`, "0.8130081301"},
+		{"float", `{"dividend":100}`, `{"result":1.23}`, "81.30081301"},
+		{"zero integer string", `{"dividend":0}`, `{"result":"1.23"}`, "0"},
+		{"zero float string", `{"dividend":0.0}`, `{"result":"1.23"}`, "0"},
+		{"negative integer string", `{"dividend":-5}`, `{"result":"1.23"}`, "-4.06504065"},
+		{"negative integer string", `{"dividend":-5}`, `{"result":"1.23"}`, "-4.06504065"},
+
+		{"no dividend parameter", `{}`, `{"result":"3.14"}`, "3.14"},
+
+		{"string string", `{"dividend":"100"}`, `{"result":"1.23"}`, "81.30081301"},
+		{"string integer", `{"dividend":"100"}`, `{"result":123}`, "0.8130081301"},
+		{"string float", `{"dividend":"100"}`, `{"result":1.23}`, "81.30081301"},
+
+		{"zero string string", `{"dividend":"0"}`, `{"result":"1.23"}`, "0"},
+		{"negative string string", `{"dividend":"-5"}`, `{"result":"1.23"}`, "-4.06504065"},
+		{"string", `{"dividend":"1"}`, `{"result":"1.23"}`, "0.8130081301"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			input := cltest.NewRunInputWithString(t, test.json)
+			adapter := adapters.Quotient{}
+			json.Unmarshal([]byte(test.params), &adapter)
+			result := adapter.Perform(input, nil)
+
+			require.NoError(t, result.Error())
+			assert.Equal(t, test.want, result.Result().String())
+		})
+	}
+}
+
+func TestQuotient_Perform_Error(t *testing.T) {
+	tests := []struct {
+		name   string
+		params string
+		json   string
+		want   string
+	}{
+		{"string zero integer", `{"dividend":"1"}`, `{"result":0}`, "0"},
+		{"zero string zero float", `{"dividend":"0"}`, `{"result":"0"}`, "0"},
+		{"object", `{"dividend":100}`, `{"result":{"foo":"bar"}}`, ""},
+		{"string object", `{"dividend":"100"}`, `{"result":{"foo":"bar"}}`, ""},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			input := cltest.NewRunInputWithString(t, test.json)
+			adapter := adapters.Quotient{}
+			jsonErr := json.Unmarshal([]byte(test.params), &adapter)
+			result := adapter.Perform(input, nil)
+
+			require.Error(t, result.Error())
+			assert.NoError(t, jsonErr)
+		})
+	}
+}
+
+func TestQuotient_Perform_JSONParseError(t *testing.T) {
+	tests := []struct {
+		name   string
+		params string
+		json   string
+		want   string
+	}{
+		{"array string", `{"dividend":[1, 2, 3]}`, `{"result":"1.23"}`, ""},
+		{"rubbish string", `{"dividend":"123aaa123"}`, `{"result":"1.23"}`, ""},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			input := cltest.NewRunInputWithString(t, test.json)
+			adapter := adapters.Quotient{}
+			jsonErr := json.Unmarshal([]byte(test.params), &adapter)
+			adapter.Perform(input, nil)
+
+			assert.Error(t, jsonErr)
+		})
+	}
+}


### PR DESCRIPTION
In some cases we have an endpoint that only returns one direction of conversion e.g. ETH/USD (but we need USD/ETH).

This adapter allows us to invert the output so we can get the correct exchange rate.