### PR TITLE
ORM: use errors.Wrap where possible

### DIFF
--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -80,7 +80,7 @@ func NewORM(uri string, timeout time.Duration) (*ORM, error) {
 
 	lockingStrategy, err := NewLockingStrategy(dialect, uri)
 	if err != nil {
-		return nil, fmt.Errorf("unable to create ORM lock: %+v", err)
+		return nil, errors.Wrap(err, "unable to create ORM lock")
 	}
 
 	logger.Infof("Locking %v for exclusive access with %v timeout", dialect, displayTimeout(timeout))
@@ -94,7 +94,7 @@ func NewORM(uri string, timeout time.Duration) (*ORM, error) {
 
 	db, err := initializeDatabase(string(dialect), uri)
 	if err != nil {
-		return nil, fmt.Errorf("unable to init DB: %+v", err)
+		return nil, errors.Wrap(err, "unable to init DB")
 	}
 
 	orm.db = db
@@ -123,7 +123,7 @@ func displayTimeout(timeout time.Duration) string {
 func initializeDatabase(dialect, path string) (*gorm.DB, error) {
 	db, err := gorm.Open(dialect, path)
 	if err != nil {
-		return nil, fmt.Errorf("unable to open %s for gorm DB: %+v", path, err)
+		return nil, errors.Wrapf(err, "unable to open %s for gorm DB", path)
 	}
 
 	db.SetLogger(newOrmLogWrapper(logger.GetLogger()))
@@ -581,7 +581,7 @@ func (orm *ORM) UnscopedJobRunsWithStatus(cb func(*models.JobRun), statuses ...m
 		Order("created_at asc").
 		Pluck("ID", &runIDs).Error
 	if err != nil {
-		return fmt.Errorf("error finding job ids %v", err)
+		return errors.Wrap(err, "finding job ids")
 	}
 
 	return Batch(100, func(offset, limit uint) (uint, error) {
@@ -592,7 +592,7 @@ func (orm *ORM) UnscopedJobRunsWithStatus(cb func(*models.JobRun), statuses ...m
 			Order("job_runs.created_at asc").
 			Find(&runs, "job_runs.id IN (?)", batchIDs).Error
 		if err != nil {
-			return 0, fmt.Errorf("error fetching job run batch: %v", err)
+			return 0, errors.Wrap(err, "error fetching job run batch")
 		}
 
 		for _, run := range runs {


### PR DESCRIPTION
Make the original errors visible to callers by using errors.Wrap(..).