### PR TITLE
config: Add feature flag for Flux Monitor

### DIFF
--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -143,6 +143,11 @@ func (c Config) FeatureExternalInitiators() bool {
 	return c.viper.GetBool(EnvVarName("FeatureExternalInitiators"))
 }
 
+// FeatureFluxMonitor enables the Flux Monitor feature.
+func (c Config) FeatureFluxMonitor() bool {
+	return c.viper.GetBool(EnvVarName("FeatureFluxMonitor"))
+}
+
 // MaxRPCCallsPerSecond returns the rate at which RPC calls can be fired
 func (c Config) MaxRPCCallsPerSecond() uint64 {
 	return c.viper.GetUint64(EnvVarName("MaxRPCCallsPerSecond"))

--- a/core/store/orm/config_reader.go
+++ b/core/store/orm/config_reader.go
@@ -23,6 +23,7 @@ type ConfigReader interface {
 	DefaultHTTPLimit() int64
 	Dev() bool
 	FeatureExternalInitiators() bool
+	FeatureFluxMonitor() bool
 	MaximumServiceDuration() time.Duration
 	MinimumServiceDuration() time.Duration
 	EthGasBumpThreshold() uint64

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -23,6 +23,7 @@ type ConfigSchema struct {
 	DefaultHTTPLimit          int64          `env:"DEFAULT_HTTP_LIMIT" default:"32768"`
 	Dev                       bool           `env:"CHAINLINK_DEV" default:"false"`
 	FeatureExternalInitiators bool           `env:"FEATURE_EXTERNAL_INITIATORS" default:"false"`
+	FeatureFluxMonitor        bool           `env:"FEATURE_FLUX_MONITOR" default:"false"`
 	MaximumServiceDuration    time.Duration  `env:"MAXIMUM_SERVICE_DURATION" default:"8760h" `
 	MinimumServiceDuration    time.Duration  `env:"MINIMUM_SERVICE_DURATION" default:"0s" `
 	EthGasBumpThreshold       uint64         `env:"ETH_GAS_BUMP_THRESHOLD" default:"12" `

--- a/core/web/testdata/flux_monitor_job.json
+++ b/core/web/testdata/flux_monitor_job.json
@@ -1,0 +1,19 @@
+{
+  "initiators": [{
+    "type": "fluxmonitor",
+    "params": {
+      "address": "0x3cCad4715152693fE3BC4460591e3D3Fbd071b42",
+      "requestdata": {
+        "data":{"coin":"ETH","market":"USD"}
+      },
+      "feeds": [ "https://lambda.staging.devnet.tools/bnc/call" ],
+      "threshold": 0.5,
+      "precision": 2
+    }
+  }],
+  "tasks": [
+    {
+      "type": "NoOp"
+    }
+  ]
+}


### PR DESCRIPTION
Allow users to configure Flux Monitor support using the environment
variable 'FEATURE_FLUX_MONITOR'.  The feature is also enabled by default
when Chainlink is running in dev mode via 'CHAINLINK_DEV'.

https://www.pivotaltracker.com/story/show/170648724