### PR TITLE
Expose devnet ports

### DIFF
--- a/tools/docker/docker-compose.gethnet.yaml
+++ b/tools/docker/docker-compose.gethnet.yaml
@@ -10,5 +10,7 @@ services:
     build: ../gethnet
     container_name: geth
     image: smartcontract/gethnet
+    ports:
+      - 8545:8545
     secrets:
       - node_password

--- a/tools/docker/docker-compose.paritynet.yaml
+++ b/tools/docker/docker-compose.paritynet.yaml
@@ -7,3 +7,5 @@ services:
   devnet:
     container_name: parity
     image: smartcontract/devnet
+    ports:
+      - 8545:8545


### PR DESCRIPTION
Exposing the port to the eth nodes will allow us to interact with it via rpc, which is essential to initially funding addresses on geth