### PR TITLE
Improve performance of job runs count query in explorer

### DIFF
--- a/explorer/src/__tests__/queries/Search.test.ts
+++ b/explorer/src/__tests__/queries/Search.test.ts
@@ -3,7 +3,7 @@ import { closeDbConnection, getDb } from '../../database'
 import { Connection } from 'typeorm'
 import { createChainlinkNode } from '../../entity/ChainlinkNode'
 import { fromString } from '../../entity/JobRun'
-import { search } from '../../queries/search'
+import { search, count } from '../../queries/search'
 
 let db: Connection
 
@@ -13,7 +13,7 @@ beforeAll(async () => {
 
 afterAll(async () => closeDbConnection())
 
-describe('search', () => {
+describe('search and count', () => {
   beforeEach(async () => {
     const [chainlinkNode] = await createChainlinkNode(
       db,
@@ -175,5 +175,10 @@ describe('search', () => {
     expect(resultsPrefixedTxHash).toHaveLength(1)
     expect(resultsPrefixedRequester).toHaveLength(1)
     expect(resultsPrefixedRequestId).toHaveLength(1)
+  })
+
+  it('returns the number of results matching the search query', async () => {
+    const countResult = await count(db, { searchQuery: 'runB runC' })
+    expect(countResult).toEqual(2)
   })
 })

--- a/explorer/src/queries/search.ts
+++ b/explorer/src/queries/search.ts
@@ -54,20 +54,25 @@ const searchBuilder = (
   }
 
   return query
-    .leftJoinAndSelect('job_run.chainlinkNode', 'chainlink_node')
-    .orderBy('job_run.createdAt', 'DESC')
 }
 
 export const search = async (
   db: Connection,
   params: SearchParams,
 ): Promise<JobRun[]> => {
-  return searchBuilder(db, params).getMany()
+  return searchBuilder(db, params)
+    .leftJoinAndSelect('job_run.chainlinkNode', 'chainlink_node')
+    .orderBy('job_run.createdAt', 'DESC')
+    .getMany()
 }
 
 export const count = async (
   db: Connection,
   params: SearchParams,
 ): Promise<number> => {
-  return searchBuilder(db, params).getCount()
+  const result = await searchBuilder(db, params)
+    .select('COUNT(*)', 'count')
+    .getRawOne()
+
+  return parseInt(result['count'], 10)
 }


### PR DESCRIPTION
- Don't need to join for the count

In a test database with:

```sql
explorer_dev=# SELECT COUNT(*) FROM job_run;
 count  
--------
 228000
(1 row)

Time: 37.518 ms
```

Old Query:

```sql
explorer_dev=# SELECT COUNT(DISTINCT(job_run.id))
FROM job_run
  LEFT JOIN chainlink_node
  ON chainlink_node.id=job_run."chainlinkNodeId"
WHERE job_run."runId" IN ('0x1597F8CddA5Bc5E579BAdC4d1173d28CbAbD1339')
  OR job_run."jobId" IN ('0x1597F8CddA5Bc5E579BAdC4d1173d28CbAbD1339')
  OR job_run."requester" IN ('0x1597F8CddA5Bc5E579BAdC4d1173d28CbAbD1339')
  OR job_run."requestId" IN ('0x1597F8CddA5Bc5E579BAdC4d1173d28CbAbD1339')
  OR job_run."txHash" IN ('0x1597F8CddA5Bc5E579BAdC4d1173d28CbAbD1339');
 count  
--------
 173113
(1 row)

Time: 3317.278 ms (00:03.317)
```

New Query:

```sql
explorer_dev=# SELECT COUNT(job_run.id)
FROM job_run
WHERE job_run."runId" IN ('0x1597F8CddA5Bc5E579BAdC4d1173d28CbAbD1339')
  OR job_run."jobId" IN ('0x1597F8CddA5Bc5E579BAdC4d1173d28CbAbD1339')
  OR job_run."requester" IN ('0x1597F8CddA5Bc5E579BAdC4d1173d28CbAbD1339')
  OR job_run."requestId" IN ('0x1597F8CddA5Bc5E579BAdC4d1173d28CbAbD1339')
  OR job_run."txHash" IN ('0x1597F8CddA5Bc5E579BAdC4d1173d28CbAbD1339');
 count  
--------
 173113
(1 row)

Time: 383.594 ms
```