### PR TITLE
Allow JSONParse to accept gjson (e.g. from bridge)

### DIFF
--- a/core/adapters/json_parse.go
+++ b/core/adapters/json_parse.go
@@ -11,6 +11,7 @@ import (
 	"chainlink/core/utils"
 
 	simplejson "github.com/bitly/go-simplejson"
+	gjson "github.com/tidwall/gjson"
 )
 
 // JSONParse holds a path to the desired field in a JSON object,
@@ -30,9 +31,18 @@ type JSONParse struct {
 //     ]
 //   }
 //
-// Then ["0","last"] would be the path, and "111" would be the returned value
+// Then ["0","last"] would be the path, and "1111" would be the returned value
 func (jpa *JSONParse) Perform(input models.RunInput, _ *store.Store) models.RunOutput {
-	val, err := input.ResultString()
+	var val string
+	var err error
+
+	if input.Result().Type == gjson.JSON {
+		// Handle case where JSON comes "pre-packaged" as gjson e.g. from bridge (external adapters)
+		val = input.Result().Raw
+	} else {
+		val, err = input.ResultString()
+	}
+
 	if err != nil {
 		return models.NewRunOutputError(err)
 	}

--- a/core/adapters/json_parse_test.go
+++ b/core/adapters/json_parse_test.go
@@ -132,40 +132,17 @@ func TestJsonParse_Perform(t *testing.T) {
 }
 
 func TestJsonParse_Perform_WithPreParsedJSON(t *testing.T) {
-	t.Parallel()
-	tests := []struct {
-		name            string
-		result          string
-		path            []string
-		wantData        string
-		wantStatus      models.RunStatus
-		wantResultError bool
-	}{
-		{"existing path", `{"high":"11850.00","last":"11779.99"}`, []string{"last"},
-			`{"result":"11779.99"}`, models.RunStatusCompleted, false},
-	}
+	var parsed models.JSON
+	err := json.Unmarshal([]byte(`{"high":"11850.00","last":"11779.99"}`), &parsed)
+	assert.NoError(t, err)
 
-	for _, tt := range tests {
-		test := tt
-		t.Run(test.name, func(t *testing.T) {
-			var parsed models.JSON
-			err := json.Unmarshal([]byte(test.result), &parsed)
-			assert.NoError(t, err)
+	input := cltest.NewRunInputWithResult(parsed)
 
-			input := cltest.NewRunInputWithResult(parsed)
-
-			adapter := adapters.JSONParse{Path: test.path}
-			result := adapter.Perform(input, nil)
-			assert.Equal(t, test.wantData, result.Data().String())
-			assert.Equal(t, test.wantStatus, result.Status())
-
-			if test.wantResultError {
-				assert.Error(t, result.Error())
-			} else {
-				assert.NoError(t, result.Error())
-			}
-		})
-	}
+	adapter := adapters.JSONParse{Path: []string{"last"}}
+	result := adapter.Perform(input, nil)
+	assert.Equal(t, `{"result":"11779.99"}`, result.Data().String())
+	assert.Equal(t, models.RunStatusCompleted, result.Status())
+	assert.NoError(t, result.Error())
 }
 
 func TestJSON_UnmarshalJSON(t *testing.T) {


### PR DESCRIPTION
Rationale:

It is not at all clear to our users (or to me) what the difference is
between Copy and JSONParse and when is appropriate to use which.

I propose unifying everything under JSONParse and soft-deprecating Copy.

This PR allows JSONParse to accept gjson as well as string inputs,
making it suitable for use in parsing results from bridges (external
adapters) and making Copy (and copyPath) redundant.