### PR TITLE
Standardize size of regional nav buttons in Operator UI

### DIFF
--- a/operator_ui/src/components/Copy.js
+++ b/operator_ui/src/components/Copy.js
@@ -2,9 +2,9 @@ import React from 'react'
 import Button from 'components/Button'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 
-const Copy = ({ data, buttonText }) => (
+const Copy = ({ data, buttonText, className }) => (
   <CopyToClipboard text={data}>
-    <Button>{buttonText}</Button>
+    <Button className={className}>{buttonText}</Button>
   </CopyToClipboard>
 )
 

--- a/operator_ui/src/components/CopyJobSpec.js
+++ b/operator_ui/src/components/CopyJobSpec.js
@@ -1,8 +1,12 @@
 import React from 'react'
 import Copy from 'components/Copy'
 
-const CopyJobSpec = ({ JobSpec }) => (
-  <Copy buttonText="Copy JobSpec" data={JSON.stringify(JobSpec, null, '\t')} />
+const CopyJobSpec = ({ JobSpec, ...props }) => (
+  <Copy
+    buttonText="Copy JobSpec"
+    data={JSON.stringify(JobSpec, null, '\t')}
+    {...props}
+  />
 )
 
 export default CopyJobSpec

--- a/operator_ui/src/containers/Jobs/RegionalNav.tsx
+++ b/operator_ui/src/containers/Jobs/RegionalNav.tsx
@@ -39,7 +39,7 @@ const styles = (theme: Theme) =>
     actions: {
       textAlign: 'right',
     },
-    duplicate: {
+    regionalNavButton: {
       marginLeft: theme.spacing.unit,
       marginRight: theme.spacing.unit,
     },
@@ -237,13 +237,18 @@ const RegionalNav = ({
               </Grid>
               <Grid item xs={5} className={classes.actions}>
                 <Button
-                  className={classes.duplicate}
+                  className={classes.regionalNavButton}
                   onClick={() => setModalOpen(true)}
                 >
                   Archive
                 </Button>
                 {job && isWebInitiator(job.initiators) && (
-                  <Button onClick={handleRun}>Run</Button>
+                  <Button
+                    onClick={handleRun}
+                    className={classes.regionalNavButton}
+                  >
+                    Run
+                  </Button>
                 )}
                 {definition && (
                   <Button
@@ -252,12 +257,17 @@ const RegionalNav = ({
                       state: { definition },
                     }}
                     component={BaseLink}
-                    className={classes.duplicate}
+                    className={classes.regionalNavButton}
                   >
                     Duplicate
                   </Button>
                 )}
-                {definition && <CopyJobSpec JobSpec={definition} />}
+                {definition && (
+                  <CopyJobSpec
+                    JobSpec={definition}
+                    className={classes.regionalNavButton}
+                  />
+                )}
               </Grid>
             </Grid>
           </Grid>

--- a/styleguide/src/theme.ts
+++ b/styleguide/src/theme.ts
@@ -51,14 +51,6 @@ export const theme: ThemeOptions = {
     MuiGrid: {
       spacing: spacing.unit * 3,
     },
-    MuiButton: {
-      style: {
-        paddingTop: spacing.unit,
-        paddingBottom: spacing.unit,
-        paddingLeft: spacing.unit * 5,
-        paddingRight: spacing.unit * 5,
-      },
-    },
   },
   palette: {
     action: {


### PR DESCRIPTION
Addresses [#170752843](https://www.pivotaltracker.com/story/show/170752843)

Removed the `MuiButton` styling from the theme, as those styles take highest precedence and don't allow for overriding. The sizes of other buttons throughout the app are preserved by default materialUI button styles.