### PR TITLE
Merge pull request #2195 from smartcontractkit/bug/170752843-inconsistent-button-sizes-in-operatorUI

### DIFF
--- a/explorer/client/src/components/Button.tsx
+++ b/explorer/client/src/components/Button.tsx
@@ -86,6 +86,7 @@ interface Props extends WithStyles<typeof styles> {
   disabled?: boolean
   className?: string
   variant?: ButtonVariant
+  size?: 'small' | 'medium' | 'large'
   // Ideally this would be typed as below. However the MuiButton type annotations
   // don't allow an object to be passed through.
   //
@@ -108,9 +109,10 @@ const Button: React.FC<Props> = ({
   className,
   children,
   onClick,
+  size,
 }) => {
   const curryProps = Object.assign(
-    { component, disabled, href, onClick, type },
+    { component, disabled, href, onClick, type, size },
     muiProps(variant, classes),
   )
   const cn = classNames(classes[variant as keyof typeof classes], className)

--- a/explorer/client/src/components/Cards/Search.tsx
+++ b/explorer/client/src/components/Cards/Search.tsx
@@ -57,7 +57,12 @@ const Search = ({ classes }: Props) => {
                       <SearchBox />
                     </Grid>
                     <Grid item>
-                      <Button variant="contained" color="primary" type="submit">
+                      <Button
+                        variant="contained"
+                        color="primary"
+                        type="submit"
+                        size="large"
+                      >
                         Search
                       </Button>
                     </Grid>

--- a/operator_ui/src/components/Bridges/Form.tsx
+++ b/operator_ui/src/components/Bridges/Form.tsx
@@ -161,6 +161,7 @@ const Form: React.SFC<Props> = props => (
             type="submit"
             className={props.classes.button}
             disabled={props.isSubmitting}
+            size="large"
           >
             {props.actionText}
           </Button>

--- a/operator_ui/src/components/Button.tsx
+++ b/operator_ui/src/components/Button.tsx
@@ -99,6 +99,7 @@ interface Props extends WithStyles<typeof styles> {
   disabled?: boolean
   className?: string
   variant?: ButtonVariant
+  size?: 'small' | 'medium' | 'large'
   // Ideally this would be typed as below. However the MuiButton type annotations
   // don't allow an object to be passed through.
   //
@@ -121,9 +122,10 @@ const Button = ({
   className,
   children,
   onClick,
+  size,
 }: Props) => {
   const curryProps = Object.assign(
-    { component, disabled, href, onClick, type },
+    { component, disabled, href, onClick, type, size },
     muiProps(variant, classes),
   )
   const cn = classNames(classes[variant as keyof typeof classes], className)

--- a/operator_ui/src/components/Copy.js
+++ b/operator_ui/src/components/Copy.js
@@ -2,9 +2,9 @@ import React from 'react'
 import Button from 'components/Button'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
 
-const Copy = ({ data, buttonText }) => (
+const Copy = ({ data, buttonText, ...props }) => (
   <CopyToClipboard text={data}>
-    <Button>{buttonText}</Button>
+    <Button {...props}>{buttonText}</Button>
   </CopyToClipboard>
 )
 

--- a/operator_ui/src/components/CopyJobSpec.js
+++ b/operator_ui/src/components/CopyJobSpec.js
@@ -1,8 +1,12 @@
 import React from 'react'
 import Copy from 'components/Copy'
 
-const CopyJobSpec = ({ JobSpec }) => (
-  <Copy buttonText="Copy JobSpec" data={JSON.stringify(JobSpec, null, '\t')} />
+const CopyJobSpec = ({ JobSpec, ...props }) => (
+  <Copy
+    buttonText="Copy JobSpec"
+    data={JSON.stringify(JobSpec, null, '\t')}
+    {...props}
+  />
 )
 
 export default CopyJobSpec

--- a/operator_ui/src/components/Jobs/Form.tsx
+++ b/operator_ui/src/components/Jobs/Form.tsx
@@ -109,6 +109,7 @@ const Form: React.FC<Props> = props => {
               type="submit"
               disabled={props.isSubmitting}
               className={props.classes.button}
+              size="large"
             >
               {props.actionText}
             </Button>

--- a/operator_ui/src/containers/Jobs/RegionalNav.tsx
+++ b/operator_ui/src/containers/Jobs/RegionalNav.tsx
@@ -39,7 +39,7 @@ const styles = (theme: Theme) =>
     actions: {
       textAlign: 'right',
     },
-    duplicate: {
+    regionalNavButton: {
       marginLeft: theme.spacing.unit,
       marginRight: theme.spacing.unit,
     },
@@ -237,13 +237,18 @@ const RegionalNav = ({
               </Grid>
               <Grid item xs={5} className={classes.actions}>
                 <Button
-                  className={classes.duplicate}
+                  className={classes.regionalNavButton}
                   onClick={() => setModalOpen(true)}
                 >
                   Archive
                 </Button>
                 {job && isWebInitiator(job.initiators) && (
-                  <Button onClick={handleRun}>Run</Button>
+                  <Button
+                    onClick={handleRun}
+                    className={classes.regionalNavButton}
+                  >
+                    Run
+                  </Button>
                 )}
                 {definition && (
                   <Button
@@ -252,12 +257,17 @@ const RegionalNav = ({
                       state: { definition },
                     }}
                     component={BaseLink}
-                    className={classes.duplicate}
+                    className={classes.regionalNavButton}
                   >
                     Duplicate
                   </Button>
                 )}
-                {definition && <CopyJobSpec JobSpec={definition} />}
+                {definition && (
+                  <CopyJobSpec
+                    JobSpec={definition}
+                    className={classes.regionalNavButton}
+                  />
+                )}
               </Grid>
             </Grid>
           </Grid>

--- a/styleguide/src/theme.ts
+++ b/styleguide/src/theme.ts
@@ -51,14 +51,6 @@ export const theme: ThemeOptions = {
     MuiGrid: {
       spacing: spacing.unit * 3,
     },
-    MuiButton: {
-      style: {
-        paddingTop: spacing.unit,
-        paddingBottom: spacing.unit,
-        paddingLeft: spacing.unit * 5,
-        paddingRight: spacing.unit * 5,
-      },
-    },
   },
   palette: {
     action: {
@@ -114,6 +106,19 @@ export const theme: ThemeOptions = {
       root: {
         borderRadius: spacing.unit / 2,
         textTransform: 'none',
+      },
+      sizeLarge: {
+        padding: undefined,
+        fontSize: undefined,
+        paddingTop: spacing.unit,
+        paddingBottom: spacing.unit,
+        paddingLeft: spacing.unit * 5,
+        paddingRight: spacing.unit * 5,
+      },
+    },
+    MuiTableCell: {
+      body: {
+        fontSize: '1rem',
       },
     },
   },


### PR DESCRIPTION
Addresses [#170752843](https://www.pivotaltracker.com/story/show/170752843)

Removes the `MuiButton` styling from the theme, because those styles take highest precedence and don't allow for overriding. The sizes of other buttons throughout the app are preserved by adding custom css where necessary.