### PR TITLE
docker: Notify docker not a requirement

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -1,5 +1,8 @@
 # Using docker-compose for local development
+
 The docker-compose configuration present in this directory allows for a user to quickly setup all of chainlink's services to perform actions like integration tests, acceptance tests, and development across multiple services.
+
+Docker specific scripts can be found in [bin](./bin).
 
 # Requirements
 - [docker-compose](https://docs.docker.com/compose/install/)


### PR DESCRIPTION
Set a policy of not requiring docker as a development tool by giving
notice in the docker tool's README.

Docker's abstracts away a lot of effort when dealing with the
dependencies on a project.  The problem is when the project -relies- on
Docker, it adds an additional layer of abstraction and significant
resources to support it.