### PR TITLE
add logs command to docker-compose tool

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -201,6 +201,17 @@ echo "ALLOW_ORIGINS=http://localhost:1337" > chainlink-variables.env
 ./compose acceptance
 ```
 
+# Following logs
+
+The `logs` command will allow you to follow the logs of any running service. For example:
+
+```bash
+./compose up node # starts the node service and all it's dependencies, including devnet, explorer, the DB...
+./compose logs devnet # shows the blockchain logs
+# ^C to exit
+./compose logs # shows the combined logs of all running services
+```
+
 # FAQs
 
 ## My storage space is full! How do I clean up docker's disk usage?

--- a/tools/docker/compose
+++ b/tools/docker/compose
@@ -29,6 +29,7 @@ usage="compose -- A helper script for running common docker-compose commands\
 Commands:
     help                  Displays this help menu
     clean                 Remove any containers and volumes related to compose files
+    logs                  Display the logs of any service(s) by name
 
     cld                   Runs the chainlink node container in dev mode
     cldo                  cld in addition to operator-ui in dev mode
@@ -57,6 +58,9 @@ case "$1" in
     $test down -v
     $deps down -v
     $dev_integration down -v
+    ;;
+  logs)
+    $base logs -f ${@:2}
     ;;
 
   cld)


### PR DESCRIPTION
This helps the developer selectively choose which logs to display while deving. Especially convenient for geth / parity, since their compose files have to be merged in.