### PR TITLE
Make Flux Monitor's polling interval configurable

### DIFF
--- a/core/services/validators.go
+++ b/core/services/validators.go
@@ -123,16 +123,21 @@ func ValidateInitiator(i models.Initiator, j models.JobSpec) error {
 func validateFluxMonitor(i models.Initiator, j models.JobSpec) error {
 	fe := models.NewJSONAPIErrors()
 	if i.Address == utils.ZeroAddress {
-		fe.Add("unable to create job config, no address")
+		fe.Add("no address")
 	}
 	if len(i.Feeds) == 0 {
-		fe.Add("unable to create job config, no feeds")
+		fe.Add("no feeds")
 	}
 	if i.Threshold <= 0 {
-		fe.Add("unable to create job config, bad threshold")
+		fe.Add("bad threshold")
 	}
 	if i.RequestData.String() == "" {
-		fe.Add("unable to create job config, no requestdata")
+		fe.Add("no requestdata")
+	}
+	if i.PollingInterval == 0 {
+		fe.Add("no pollingInterval")
+	} else if i.PollingInterval < MinimumPollingInterval {
+		fe.Add("pollingInterval must be equal or greater than " + MinimumPollingInterval.String())
 	}
 
 	return fe.CoerceEmptyToNil()

--- a/core/services/validators_test.go
+++ b/core/services/validators_test.go
@@ -376,7 +376,8 @@ const validInitiator = `{
 			"https://lambda.staging.devnet.tools/cmc/call"
 		],
 		"threshold": 0.5,
-		"precision": 2
+		"precision": 2,
+		"pollingInterval": "1m"
 	}
 }`
 
@@ -399,6 +400,8 @@ func TestValidateInitiator_FluxMonitorErrors(t *testing.T) {
 		{"threshold", cltest.MustJSONDel(t, validInitiator, "params.threshold")},
 		{"threshold", cltest.MustJSONSet(t, validInitiator, "params.threshold", -5)},
 		{"requestdata", cltest.MustJSONDel(t, validInitiator, "params.requestdata")},
+		{"pollingInterval", cltest.MustJSONDel(t, validInitiator, "params.pollingInterval")},
+		{"pollingInterval", cltest.MustJSONSet(t, validInitiator, "params.pollingInterval", "1s")},
 	}
 	for _, test := range tests {
 		t.Run("bad "+test.Field, func(t *testing.T) {

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -29,6 +29,7 @@ import (
 	"chainlink/core/store/migrations/migration1573812490"
 	"chainlink/core/store/migrations/migration1575036327"
 	"chainlink/core/store/migrations/migration1576022702"
+	"chainlink/core/store/migrations/migration1579700934"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -150,6 +151,10 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "1576022702",
 			Migrate: migration1576022702.Migrate,
+		},
+		{
+			ID:      "migration1579700934",
+			Migrate: migration1579700934.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration1579700934/migrate.go
+++ b/core/store/migrations/migration1579700934/migrate.go
@@ -1,0 +1,13 @@
+package migration1579700934
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate adds the polling_interval duration (nanoseconds) to support the Flux Monitor.
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+	  ALTER TABLE initiators ADD COLUMN "polling_interval" BigInt;
+	`).Error
+	return nil
+}

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -401,6 +401,42 @@ func (c Cron) String() string {
 	return string(c)
 }
 
+// Duration is a time duration.
+type Duration time.Duration
+
+// Duration returns the value as the standard time.Duration value.
+func (d Duration) Duration() time.Duration {
+	return time.Duration(d)
+}
+
+// String returns a string representing the duration in the form "72h3m0.5s".
+// Leading zero units are omitted. As a special case, durations less than one
+// second format use a smaller unit (milli-, micro-, or nanoseconds) to ensure
+// that the leading digit is non-zero. The zero duration formats as 0s.
+func (d Duration) String() string {
+	return time.Duration(d).String()
+}
+
+// MarshalJSON implements the json.Marshaler interface.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.String())
+}
+
+// UnmarshalJSON implements the json.Unmarshaler interface.
+func (d *Duration) UnmarshalJSON(input []byte) error {
+	var txt string
+	err := json.Unmarshal(input, &txt)
+	if err != nil {
+		return err
+	}
+	v, err := time.ParseDuration(string(txt))
+	if err != nil {
+		return err
+	}
+	*d = Duration(v)
+	return nil
+}
+
 // WithdrawalRequest request to withdraw LINK.
 type WithdrawalRequest struct {
 	DestinationAddress common.Address `json:"address"`

--- a/core/store/models/common_test.go
+++ b/core/store/models/common_test.go
@@ -348,3 +348,24 @@ func TestAnyTime_MarshalJSON(t *testing.T) {
 		})
 	}
 }
+
+func TestDuration_MarshalJSON(t *testing.T) {
+	tests := []struct {
+		name  string
+		input models.Duration
+		want  string
+	}{
+		{"zero", models.Duration(0), `"0s"`},
+		{"one second", models.Duration(time.Second), `"1s"`},
+		{"one minute", models.Duration(time.Minute), `"1m0s"`},
+		{"one hour", models.Duration(time.Hour), `"1h0m0s"`},
+		{"one hour thirty minutes", models.Duration(time.Hour + 30*time.Minute), `"1h30m0s"`},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			b, err := json.Marshal(&test.input)
+			assert.NoError(t, err)
+			assert.Equal(t, test.want, string(b))
+		})
+	}
+}

--- a/core/store/models/job_spec_test.go
+++ b/core/store/models/job_spec_test.go
@@ -37,6 +37,26 @@ func TestNewInitiatorFromRequest(t *testing.T) {
 				JobSpecID: job.ID,
 			},
 		},
+		{
+			name: models.InitiatorWeb,
+			initrReq: models.InitiatorRequest{
+				Type: models.InitiatorFluxMonitor,
+				InitiatorParams: models.InitiatorParams{
+					Threshold: 5,
+					Precision: 2,
+				},
+			},
+			jobSpec: job,
+			want: models.Initiator{
+				Type:      models.InitiatorFluxMonitor,
+				JobSpecID: job.ID,
+				InitiatorParams: models.InitiatorParams{
+					Threshold:       5,
+					Precision:       2,
+					PollingInterval: models.FluxMonitorDefaultInitiatorParams.PollingInterval,
+				},
+			},
+		},
 	}
 
 	for _, test := range tests {

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -379,12 +379,13 @@ func initiatorParams(i Initiator) (interface{}, error) {
 		}{i.Name}, nil
 	case models.InitiatorFluxMonitor:
 		return struct {
-			Address     common.Address `json:"address"`
-			RequestData models.JSON    `json:"requestData"`
-			Feeds       models.Feeds   `json:"feeds"`
-			Threshold   float32        `json:"threshold"`
-			Precision   int32          `json:"precision"`
-		}{i.Address, i.RequestData, i.Feeds, i.Threshold, i.Precision}, nil
+			Address         common.Address  `json:"address"`
+			RequestData     models.JSON     `json:"requestData"`
+			Feeds           models.Feeds    `json:"feeds"`
+			Threshold       float32         `json:"threshold"`
+			Precision       int32           `json:"precision"`
+			PollingInterval models.Duration `json:"pollingInterval"`
+		}{i.Address, i.RequestData, i.Feeds, i.Threshold, i.Precision, i.PollingInterval}, nil
 	default:
 		return nil, fmt.Errorf("Cannot marshal unsupported initiator type '%v'", i.Type)
 	}

--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/gorilla/sessions v1.2.0
 	github.com/gorilla/websocket v1.4.1
 	github.com/guregu/null v3.4.0+incompatible
+	github.com/imdario/mergo v0.3.8
 	github.com/jinzhu/gorm v1.9.11-0.20190912141731-0c98e7d712e2
 	github.com/jpillora/backoff v0.0.0-20170918002102-8eab2debe79d
 	github.com/leodido/go-urn v1.2.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -245,6 +245,8 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/hpcloud/tail v1.0.0 h1:nfCOvKYfkgYP8hkirhJocXT2+zOD8yUNjXaWfTlyFKI=
 github.com/hpcloud/tail v1.0.0/go.mod h1:ab1qPbhIpdTxEkNHXyeSf5vhxWSCs/tWer42PpOxQnU=
 github.com/huin/goupnp v0.0.0-20161224104101-679507af18f3/go.mod h1:MZ2ZmwcBpvOoJ22IJsc7va19ZwoheaBk43rKg12SKag=
+github.com/imdario/mergo v0.3.8 h1:CGgOkSJeqMRmt0D9XLWExdT4m4F1vd3FV3VPt+0VxkQ=
+github.com/imdario/mergo v0.3.8/go.mod h1:2EnlNZ0deacrJVfApfmtdGgDfMuh/nq6Ok1EcJh5FfA=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/influxdata/influxdb v1.2.3-0.20180221223340-01288bdb0883/go.mod h1:qZna6X/4elxqT3yI9iZYdZrWWdeFOOprn86kgg4+IzY=
 github.com/jackpal/go-nat-pmp v1.0.2-0.20160603034137-1fa385a6f458/go.mod h1:QPH045xvCAeXUZOxsnwmrtiCoxIr9eob+4orBN1SBKc=


### PR DESCRIPTION
Add a new field to the Flux Monitor job spec to set the polling interval
for the Flux Monitor.  Use a default of one minute, and require a
miniumu of 30 seconds for this new field.

Introduce a new dependency, mergo, to declaritively set default values
for its fields.

https://www.pivotaltracker.com/story/show/170521200