### PR TITLE
adapters: isolate Multiplier sgx function

### DIFF
--- a/core/adapters/multiply.go
+++ b/core/adapters/multiply.go
@@ -1,14 +1,9 @@
-// +build !sgx_enclave
-
 package adapters
 
 import (
 	"fmt"
-	"math/big"
 	"strconv"
 
-	"chainlink/core/store"
-	"chainlink/core/store/models"
 	"chainlink/core/utils"
 )
 
@@ -31,22 +26,4 @@ func (m *Multiplier) UnmarshalJSON(input []byte) error {
 // Multiply holds the a number to multiply the given value by.
 type Multiply struct {
 	Times *Multiplier `json:"times"`
-}
-
-// Perform returns the input's "result" field, multiplied times the adapter's
-// "times" field.
-//
-// For example, if input value is "99.994" and the adapter's "times" is
-// set to "100", the result's value will be "9999.4".
-func (ma *Multiply) Perform(input models.RunInput, _ *store.Store) models.RunOutput {
-	val := input.Result()
-	i, ok := (&big.Float{}).SetString(val.String())
-	if !ok {
-		return models.NewRunOutputError(fmt.Errorf("cannot parse into big.Float: %v", val.String()))
-	}
-
-	if ma.Times != nil {
-		i.Mul(i, big.NewFloat(float64(*ma.Times)))
-	}
-	return models.NewRunOutputCompleteWithResult(i.String())
 }

--- a/core/adapters/multiply_perform.go
+++ b/core/adapters/multiply_perform.go
@@ -1,0 +1,28 @@
+// +build !sgx_enclave
+
+package adapters
+
+import (
+	"chainlink/core/store"
+	"chainlink/core/store/models"
+	"fmt"
+	"math/big"
+)
+
+// Perform returns the input's "result" field, multiplied times the adapter's
+// "times" field.
+//
+// For example, if input value is "99.994" and the adapter's "times" is
+// set to "100", the result's value will be "9999.4".
+func (ma *Multiply) Perform(input models.RunInput, _ *store.Store) models.RunOutput {
+	val := input.Result()
+	i, ok := (&big.Float{}).SetString(val.String())
+	if !ok {
+		return models.NewRunOutputError(fmt.Errorf("cannot parse into big.Float: %v", val.String()))
+	}
+
+	if ma.Times != nil {
+		i.Mul(i, big.NewFloat(float64(*ma.Times)))
+	}
+	return models.NewRunOutputCompleteWithResult(i.String())
+}

--- a/core/adapters/multiply_perform_sgx.go
+++ b/core/adapters/multiply_perform_sgx.go
@@ -10,38 +10,14 @@ package adapters
 import "C"
 
 import (
-	"encoding/json"
-	"fmt"
-	"strconv"
-	"unsafe"
-
 	"chainlink/core/store"
 	"chainlink/core/store/models"
-	"chainlink/core/utils"
+	"encoding/json"
+	"fmt"
+	"unsafe"
 
 	"github.com/pkg/errors"
 )
-
-// Multiplier represents the number to multiply by in Multiply adapter.
-type Multiplier float64
-
-// UnmarshalJSON implements json.Unmarshaler.
-func (m *Multiplier) UnmarshalJSON(input []byte) error {
-	input = utils.RemoveQuotes(input)
-	times, err := strconv.ParseFloat(string(input), 64)
-	if err != nil {
-		return fmt.Errorf("cannot parse into float: %s", input)
-	}
-
-	*m = Multiplier(times)
-
-	return nil
-}
-
-// Multiply holds the a number to multiply the given value by.
-type Multiply struct {
-	Times Multiplier `json:"times"`
-}
 
 // Perform returns the input's "result" field, multiplied times the adapter's
 // "times" field.


### PR DESCRIPTION
Consolidate type declaration into its one file by moving the perform method into its own file.  This produces more files, but less repeated code and may be easier to maintain.