### PR TITLE
Add meta field to job_runs

### DIFF
--- a/core/adapters/bridge.go
+++ b/core/adapters/bridge.go
@@ -53,7 +53,7 @@ func (ba *Bridge) handleNewRun(input models.RunInput, bridgeResponseURL *url.URL
 		return models.NewRunOutputError(baRunResultError("post to external adapter", err))
 	}
 
-	input = *models.NewRunInput(input.JobRunID(), data, input.Status())
+	input = *models.NewRunInput(input.JobRunID(), data, input.Meta, input.Status())
 	return ba.responseToRunResult(body, input)
 }
 
@@ -72,6 +72,7 @@ func (ba *Bridge) responseToRunResult(body []byte, input models.RunInput) models
 		return models.NewRunOutputPendingBridge()
 	}
 
+	// FIXME: Super weird handling of bridge return result??
 	if brr.Data.IsObject() {
 		data, err := models.Merge(ba.Params, brr.Data)
 		if err != nil {
@@ -90,7 +91,7 @@ func (ba *Bridge) postToExternalAdapter(input models.RunInput, bridgeResponseURL
 		return nil, errors.Wrap(err, "error merging bridge params with input params")
 	}
 
-	outgoing := bridgeOutgoing{JobRunID: input.JobRunID().String(), Data: data}
+	outgoing := bridgeOutgoing{JobRunID: input.JobRunID().String(), Data: data, Meta: input.Meta}
 	if bridgeResponseURL != nil {
 		outgoing.ResponseURL = bridgeResponseURL.String()
 	}
@@ -129,6 +130,7 @@ func baRunResultError(str string, err error) error {
 type bridgeOutgoing struct {
 	JobRunID    string      `json:"id"`
 	Data        models.JSON `json:"data"`
+	Meta        models.JSON `json:"meta"`
 	ResponseURL string      `json:"responseURL,omitempty"`
 }
 

--- a/core/adapters/bridge_test.go
+++ b/core/adapters/bridge_test.go
@@ -55,7 +55,7 @@ func TestBridge_PerformAcceptsNonJsonObjectResponses(t *testing.T) {
 	params := cltest.JSONFromString(t, `{"bodyParam": true}`)
 	ba := &adapters.Bridge{BridgeType: *bt, Params: params}
 
-	input := *models.NewRunInput(jobRunID, cltest.JSONFromString(t, `{"jobRunID": "jobID", "data": 251990120, "statusCode": 200}`), models.RunStatusUnstarted)
+	input := *models.NewRunInput(jobRunID, cltest.JSONFromString(t, `{"jobRunID": "jobID", "data": 251990120, "statusCode": 200}`), cltest.TestMeta(), models.RunStatusUnstarted)
 	result := ba.Perform(input, store)
 	require.NoError(t, result.Error())
 	assert.Equal(t, "251990120", result.Result().String())
@@ -84,7 +84,7 @@ func TestBridge_Perform_transitionsTo(t *testing.T) {
 			_, bt := cltest.NewBridgeType(t, "auctionBidding", mock.URL)
 			ba := &adapters.Bridge{BridgeType: *bt}
 
-			input := *models.NewRunInputWithResult(models.NewID(), "100", test.status)
+			input := *models.NewRunInputWithResult(models.NewID(), "100", cltest.TestMeta(), test.status)
 			result := ba.Perform(input, store)
 
 			assert.Equal(t, test.result, result.Data().String())
@@ -116,7 +116,7 @@ func TestBridge_Perform_startANewRun(t *testing.T) {
 	defer cleanup()
 	store.Config.Set("BRIDGE_RESPONSE_URL", "")
 	runID := models.NewID()
-	wantedBody := fmt.Sprintf(`{"id":"%v","data":{"result":"lot 49"}}`, runID)
+	wantedBody := fmt.Sprintf(`{"id":"%v","data":{"result":"lot 49"},"meta":{"test":true}}`, runID)
 
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
@@ -129,7 +129,7 @@ func TestBridge_Perform_startANewRun(t *testing.T) {
 			_, bt := cltest.NewBridgeType(t, "auctionBidding", mock.URL)
 			eb := &adapters.Bridge{BridgeType: *bt}
 
-			input := *models.NewRunInput(runID, cltest.JSONFromString(t, `{"result": "lot 49"}`), models.RunStatusUnstarted)
+			input := *models.NewRunInput(runID, cltest.JSONFromString(t, `{"result": "lot 49"}`), cltest.TestMeta(), models.RunStatusUnstarted)
 			result := eb.Perform(input, store)
 			val := result.Result()
 			assert.Equal(t, test.want, val.String())
@@ -151,12 +151,12 @@ func TestBridge_Perform_responseURL(t *testing.T) {
 		{
 			name:          "basic URL",
 			configuredURL: cltest.WebURL(t, "https://chain.link"),
-			want:          fmt.Sprintf(`{"id":"%s","data":{"result":"lot 49"},"responseURL":"https://chain.link/v2/runs/%s"}`, input.JobRunID().String(), input.JobRunID().String()),
+			want:          fmt.Sprintf(`{"id":"%s","data":{"result":"lot 49"}, "meta":{"test":true},"responseURL":"https://chain.link/v2/runs/%s"}`, input.JobRunID().String(), input.JobRunID().String()),
 		},
 		{
 			name:          "blank URL",
 			configuredURL: cltest.WebURL(t, ""),
-			want:          fmt.Sprintf(`{"id":"%s","data":{"result":"lot 49"}}`, input.JobRunID().String()),
+			want:          fmt.Sprintf(`{"id":"%s","data":{"result":"lot 49"}, "meta":{"test":true}}`, input.JobRunID().String()),
 		},
 	}
 

--- a/core/adapters/copy.go
+++ b/core/adapters/copy.go
@@ -19,6 +19,6 @@ func (c *Copy) Perform(input models.RunInput, store *store.Store) models.RunOutp
 	}
 
 	jp := JSONParse{Path: c.CopyPath}
-	input = *models.NewRunInput(input.JobRunID(), data, input.Status())
+	input = *models.NewRunInput(input.JobRunID(), data, input.Meta, input.Status())
 	return jp.Perform(input, store)
 }

--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -149,7 +149,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_StillPending(t *testing.T
 
 	adapter := adapters.EthTx{}
 	input := *models.NewRunInputWithResult(
-		models.NewID(), cltest.NewHash(), models.RunStatusPendingConfirmations,
+		models.NewID(), cltest.NewHash(), cltest.TestMeta(), models.RunStatusPendingConfirmations,
 	)
 	output := adapter.Perform(input, store)
 
@@ -174,7 +174,7 @@ func TestEthTxAdapter_Perform_FromPendingConfirmations_Safe(t *testing.T) {
 
 	adapter := adapters.EthTx{}
 	input := *models.NewRunInputWithResult(
-		models.NewID(), cltest.NewHash(), models.RunStatusPendingConfirmations,
+		models.NewID(), cltest.NewHash(), cltest.TestMeta(), models.RunStatusPendingConfirmations,
 	)
 	output := adapter.Perform(input, store)
 
@@ -213,7 +213,7 @@ func TestEthTxAdapter_Perform_AppendingTransactionReceipts(t *testing.T) {
 		"result":"0x3f839aaf5915da8714313a57b9c0a362d1a9a3fac1210190ace5cf3b008d780f"
 	}`)
 	input := *models.NewRunInput(
-		models.NewID(), data, models.RunStatusPendingConfirmations,
+		models.NewID(), data, cltest.TestMeta(), models.RunStatusPendingConfirmations,
 	)
 	output := adapter.Perform(input, store)
 
@@ -264,7 +264,7 @@ func TestEthTxAdapter_Perform_PendingConfirmations_WithFatalErrorInTxManager(t *
 
 	adapter := adapters.EthTx{}
 	input := *models.NewRunInputWithResult(
-		models.NewID(), cltest.NewHash().String(), models.RunStatusPendingConfirmations,
+		models.NewID(), cltest.NewHash().String(), cltest.TestMeta(), models.RunStatusPendingConfirmations,
 	)
 	output := adapter.Perform(input, store)
 
@@ -287,7 +287,7 @@ func TestEthTxAdapter_Perform_PendingConfirmations_WithRecoverableErrorInTxManag
 
 	adapter := adapters.EthTx{}
 	input := *models.NewRunInputWithResult(
-		models.NewID(), cltest.NewHash().String(), models.RunStatusPendingConfirmations,
+		models.NewID(), cltest.NewHash().String(), cltest.TestMeta(), models.RunStatusPendingConfirmations,
 	)
 	output := adapter.Perform(input, store)
 
@@ -308,7 +308,7 @@ func TestEthTxAdapter_Perform_NotConnectedWhenPendingConfirmations(t *testing.T)
 	store.TxManager = txManager
 
 	adapter := adapters.EthTx{}
-	input := *models.NewRunInput(models.NewID(), models.JSON{}, models.RunStatusPendingConfirmations)
+	input := *models.NewRunInput(models.NewID(), models.JSON{}, cltest.TestMeta(), models.RunStatusPendingConfirmations)
 	data := adapter.Perform(input, store)
 
 	require.NoError(t, data.Error())
@@ -423,7 +423,7 @@ func TestEthTxAdapter_Perform_CreateTxWithEmptyResponseErrorTreatsAsPendingConfi
 	txManager.On("Connected").Return(true)
 	txManager.On("BumpGasUntilSafe", mock.Anything).Return(nil, strpkg.Unknown, badResponseErr)
 
-	input := *models.NewRunInput(models.NewID(), output.Data(), output.Status())
+	input := *models.NewRunInput(models.NewID(), output.Data(), cltest.TestMeta(), output.Status())
 	output = adapter.Perform(input, store)
 	require.NoError(t, output.Error())
 	assert.Equal(t, models.RunStatusPendingConfirmations, output.Status())

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -609,16 +609,21 @@ func CreateServiceAgreementViaWeb(
 
 func NewRunInput(value models.JSON) models.RunInput {
 	jobRunID := models.NewID()
-	return *models.NewRunInput(jobRunID, value, models.RunStatusUnstarted)
+	return *models.NewRunInput(jobRunID, value, TestMeta(), models.RunStatusUnstarted)
 }
 
 func NewRunInputWithString(t testing.TB, value string) models.RunInput {
 	jobRunID := models.NewID()
 	data := JSONFromString(t, value)
-	return *models.NewRunInput(jobRunID, data, models.RunStatusUnstarted)
+	return *models.NewRunInput(jobRunID, data, TestMeta(), models.RunStatusUnstarted)
 }
 
 func NewRunInputWithResult(value interface{}) models.RunInput {
 	jobRunID := models.NewID()
-	return *models.NewRunInputWithResult(jobRunID, value, models.RunStatusUnstarted)
+	return *models.NewRunInputWithResult(jobRunID, value, TestMeta(), models.RunStatusUnstarted)
+}
+
+func TestMeta() models.JSON {
+	meta, _ := models.JSON{}.Add("test", true)
+	return meta
 }

--- a/core/internal/mocks/application.go
+++ b/core/internal/mocks/application.go
@@ -85,13 +85,13 @@ func (_m *Application) Cancel(runID *models.ID) (*models.JobRun, error) {
 	return r0, r1
 }
 
-// Create provides a mock function with given fields: jobSpecID, initiator, data, creationHeight, runRequest
-func (_m *Application) Create(jobSpecID *models.ID, initiator *models.Initiator, data *models.JSON, creationHeight *big.Int, runRequest *models.RunRequest) (*models.JobRun, error) {
-	ret := _m.Called(jobSpecID, initiator, data, creationHeight, runRequest)
+// Create provides a mock function with given fields: jobSpecID, initiator, data, meta, creationHeight, runRequest
+func (_m *Application) Create(jobSpecID *models.ID, initiator *models.Initiator, data *models.JSON, meta *models.JSON, creationHeight *big.Int, runRequest *models.RunRequest) (*models.JobRun, error) {
+	ret := _m.Called(jobSpecID, initiator, data, meta, creationHeight, runRequest)
 
 	var r0 *models.JobRun
-	if rf, ok := ret.Get(0).(func(*models.ID, *models.Initiator, *models.JSON, *big.Int, *models.RunRequest) *models.JobRun); ok {
-		r0 = rf(jobSpecID, initiator, data, creationHeight, runRequest)
+	if rf, ok := ret.Get(0).(func(*models.ID, *models.Initiator, *models.JSON, *models.JSON, *big.Int, *models.RunRequest) *models.JobRun); ok {
+		r0 = rf(jobSpecID, initiator, data, meta, creationHeight, runRequest)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.JobRun)
@@ -99,8 +99,8 @@ func (_m *Application) Create(jobSpecID *models.ID, initiator *models.Initiator,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*models.ID, *models.Initiator, *models.JSON, *big.Int, *models.RunRequest) error); ok {
-		r1 = rf(jobSpecID, initiator, data, creationHeight, runRequest)
+	if rf, ok := ret.Get(1).(func(*models.ID, *models.Initiator, *models.JSON, *models.JSON, *big.Int, *models.RunRequest) error); ok {
+		r1 = rf(jobSpecID, initiator, data, meta, creationHeight, runRequest)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/internal/mocks/run_manager.go
+++ b/core/internal/mocks/run_manager.go
@@ -37,13 +37,13 @@ func (_m *RunManager) Cancel(runID *models.ID) (*models.JobRun, error) {
 	return r0, r1
 }
 
-// Create provides a mock function with given fields: jobSpecID, initiator, data, creationHeight, runRequest
-func (_m *RunManager) Create(jobSpecID *models.ID, initiator *models.Initiator, data *models.JSON, creationHeight *big.Int, runRequest *models.RunRequest) (*models.JobRun, error) {
-	ret := _m.Called(jobSpecID, initiator, data, creationHeight, runRequest)
+// Create provides a mock function with given fields: jobSpecID, initiator, data, meta, creationHeight, runRequest
+func (_m *RunManager) Create(jobSpecID *models.ID, initiator *models.Initiator, data *models.JSON, meta *models.JSON, creationHeight *big.Int, runRequest *models.RunRequest) (*models.JobRun, error) {
+	ret := _m.Called(jobSpecID, initiator, data, meta, creationHeight, runRequest)
 
 	var r0 *models.JobRun
-	if rf, ok := ret.Get(0).(func(*models.ID, *models.Initiator, *models.JSON, *big.Int, *models.RunRequest) *models.JobRun); ok {
-		r0 = rf(jobSpecID, initiator, data, creationHeight, runRequest)
+	if rf, ok := ret.Get(0).(func(*models.ID, *models.Initiator, *models.JSON, *models.JSON, *big.Int, *models.RunRequest) *models.JobRun); ok {
+		r0 = rf(jobSpecID, initiator, data, meta, creationHeight, runRequest)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.JobRun)
@@ -51,8 +51,8 @@ func (_m *RunManager) Create(jobSpecID *models.ID, initiator *models.Initiator, 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*models.ID, *models.Initiator, *models.JSON, *big.Int, *models.RunRequest) error); ok {
-		r1 = rf(jobSpecID, initiator, data, creationHeight, runRequest)
+	if rf, ok := ret.Get(1).(func(*models.ID, *models.Initiator, *models.JSON, *models.JSON, *big.Int, *models.RunRequest) error); ok {
+		r1 = rf(jobSpecID, initiator, data, meta, creationHeight, runRequest)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/flux_monitor.go
+++ b/core/services/flux_monitor.go
@@ -467,7 +467,7 @@ func (p *PollingDeviationChecker) createJobRun(nextPrice decimal.Decimal, nextRo
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("unable to start chainlink run with payload %s", payload))
 	}
-	_, err = p.runManager.Create(p.initr.JobSpecID, &p.initr, &runData, nil, models.NewRunRequest())
+	_, err = p.runManager.Create(p.initr.JobSpecID, &p.initr, &runData, &models.JSON{}, nil, models.NewRunRequest())
 	return err
 }
 

--- a/core/services/flux_monitor_test.go
+++ b/core/services/flux_monitor_test.go
@@ -183,7 +183,8 @@ func TestPollingDeviationChecker_PollHappy(t *testing.T) {
 			"dataPrefix": "0x0000000000000000000000000000000000000000000000000000000000000002"
 	}`, initr.InitiatorParams.Address.Hex())))
 	require.NoError(t, err)
-	rm.On("Create", job.ID, &initr, &data, mock.Anything, mock.Anything).
+	meta := models.JSON{}
+	rm.On("Create", job.ID, &initr, &data, &meta, mock.Anything, mock.Anything).
 		Return(&run, nil)
 
 	checker, err := services.NewPollingDeviationChecker(initr, rm, fetcher, time.Second)
@@ -400,7 +401,7 @@ func TestPollingDeviationChecker_RespondToNewRound_Respond(t *testing.T) {
 	// Set up fetcher for 100; even if within deviation, forces the creation of run.
 	fetcher.On("Fetch").Return(decimal.NewFromFloat(100.0), nil).Maybe()
 
-	rm.On("Create", mock.Anything, mock.Anything, &data, mock.Anything, mock.Anything).
+	rm.On("Create", mock.Anything, mock.Anything, &data, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil) // only round 6 triggers run.
 
 	log := cltest.LogFromFixture(t, "testdata/new_round_log.json")

--- a/core/services/run_executor.go
+++ b/core/services/run_executor.go
@@ -119,7 +119,7 @@ func (re *runExecutor) executeTask(run *models.JobRun, taskRun *models.TaskRun) 
 		return models.NewRunOutputError(err)
 	}
 
-	input := *models.NewRunInput(run.ID, data, taskRun.Status)
+	input := *models.NewRunInput(run.ID, data, run.InitialMeta, taskRun.Status)
 	result := adapter.Perform(input, re.store)
 	return result
 }

--- a/core/services/run_manager.go
+++ b/core/services/run_manager.go
@@ -54,6 +54,7 @@ type RunManager interface {
 		jobSpecID *models.ID,
 		initiator *models.Initiator,
 		data *models.JSON,
+		meta *models.JSON,
 		creationHeight *big.Int,
 		runRequest *models.RunRequest) (*models.JobRun, error)
 	CreateErrored(
@@ -105,6 +106,7 @@ func NewRun(
 	job *models.JobSpec,
 	initiator *models.Initiator,
 	data *models.JSON,
+	meta *models.JSON,
 	currentHeight *big.Int,
 	runRequest *models.RunRequest,
 	config orm.ConfigReader,
@@ -121,6 +123,7 @@ func NewRun(
 		TaskRuns:       make([]models.TaskRun, len(job.Tasks)),
 		Status:         models.RunStatusInProgress,
 		Overrides:      *data,
+		InitialMeta:    *meta,
 		CreationHeight: utils.NewBig(currentHeight),
 		ObservedHeight: utils.NewBig(currentHeight),
 		RunRequest:     *runRequest,
@@ -225,6 +228,7 @@ func (rm *runManager) Create(
 	jobSpecID *models.ID,
 	initiator *models.Initiator,
 	data *models.JSON,
+	meta *models.JSON,
 	creationHeight *big.Int,
 	runRequest *models.RunRequest,
 ) (*models.JobRun, error) {
@@ -261,7 +265,7 @@ func (rm *runManager) Create(
 		return nil, fmt.Errorf("invariant for job %s: no tasks to run in NewRun", job.ID)
 	}
 
-	run, adapters := NewRun(&job, initiator, data, creationHeight, runRequest, rm.config, rm.orm, now)
+	run, adapters := NewRun(&job, initiator, data, meta, creationHeight, runRequest, rm.config, rm.orm, now)
 	runCost := runCost(&job, rm.config, adapters)
 	ValidateRun(run, runCost)
 

--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -308,7 +308,8 @@ func TestRunManager_Create(t *testing.T) {
 	rr := models.NewRunRequest()
 	rr.RequestID = &requestID
 	data := cltest.JSONFromString(t, `{"random": "input"}`)
-	jr, err := app.RunManager.Create(job.ID, &initiator, &data, nil, rr)
+	meta := cltest.TestMeta()
+	jr, err := app.RunManager.Create(job.ID, &initiator, &data, &meta, nil, rr)
 	require.NoError(t, err)
 	updatedJR := cltest.WaitForJobRunToComplete(t, store, *jr)
 	assert.Equal(t, rr.RequestID, updatedJR.RunRequest.RequestID)
@@ -331,7 +332,8 @@ func TestRunManager_Create_DoesNotSaveToTaskSpec(t *testing.T) {
 
 	initiator := job.Initiators[0]
 	data := cltest.JSONFromString(t, `{"random": "input"}`)
-	jr, err := app.RunManager.Create(job.ID, &initiator, &data, nil, &models.RunRequest{})
+	meta := cltest.TestMeta()
+	jr, err := app.RunManager.Create(job.ID, &initiator, &data, &meta, nil, &models.RunRequest{})
 	require.NoError(t, err)
 	cltest.WaitForJobRunToComplete(t, store, *jr)
 
@@ -398,7 +400,8 @@ func TestRunManager_Create_fromRunLog_Happy(t *testing.T) {
 			rr.TxHash = &initiatingTxHash
 			rr.BlockHash = &test.logBlockHash
 			data := cltest.JSONFromString(t, `{"random": "input"}`)
-			jr, err := app.RunManager.Create(job.ID, &initiator, &data, creationHeight, rr)
+			meta := cltest.TestMeta()
+			jr, err := app.RunManager.Create(job.ID, &initiator, &data, &meta, creationHeight, rr)
 			require.NoError(t, err)
 
 			run := cltest.WaitForJobRunToPendConfirmations(t, app.Store, *jr)
@@ -646,12 +649,13 @@ func TestRunManager_Create_fromRunLogPayments(t *testing.T) {
 			initiator := job.Initiators[0]
 
 			data := cltest.JSONFromString(t, `{"random": "input"}`)
+			meta := cltest.TestMeta()
 			creationHeight := big.NewInt(1)
 
 			runRequest := models.NewRunRequest()
 			runRequest.Payment = test.inputPayment
 
-			run, err := app.RunManager.Create(job.ID, &initiator, &data, creationHeight, runRequest)
+			run, err := app.RunManager.Create(job.ID, &initiator, &data, &meta, creationHeight, runRequest)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.jobStatus, run.Status)
@@ -691,7 +695,8 @@ func TestRunManager_Create_fromRunLog_ConnectToLaggingEthNode(t *testing.T) {
 	pastCurrentHeight := big.NewInt(1)
 
 	data := cltest.JSONFromString(t, `{"random": "input"}`)
-	jr, err := app.RunManager.Create(job.ID, &initiator, &data, futureCreationHeight, rr)
+	meta := cltest.TestMeta()
+	jr, err := app.RunManager.Create(job.ID, &initiator, &data, &meta, futureCreationHeight, rr)
 	require.NoError(t, err)
 	cltest.WaitForJobRunToPendConfirmations(t, app.Store, *jr)
 

--- a/core/services/scheduler.go
+++ b/core/services/scheduler.go
@@ -131,7 +131,7 @@ func (r *Recurring) AddJob(job models.JobSpec) {
 				return
 			}
 
-			_, err := r.runManager.Create(job.ID, &initr, &models.JSON{}, nil, &models.RunRequest{})
+			_, err := r.runManager.Create(job.ID, &initr, &models.JSON{}, &models.JSON{}, nil, &models.RunRequest{})
 			if err != nil && !ExpectedRecurringScheduleJobError(err) {
 				logger.Errorw(err.Error())
 			}
@@ -181,7 +181,7 @@ func (ot *OneTime) RunJobAt(initiator models.Initiator, job models.JobSpec) {
 			return
 		}
 
-		_, err := ot.RunManager.Create(job.ID, &initiator, &models.JSON{}, nil, &models.RunRequest{})
+		_, err := ot.RunManager.Create(job.ID, &initiator, &models.JSON{}, &models.JSON{}, nil, &models.RunRequest{})
 		if err != nil && !ExpectedRecurringScheduleJobError(err) {
 			logger.Error(err.Error())
 			return

--- a/core/services/scheduler_test.go
+++ b/core/services/scheduler_test.go
@@ -28,7 +28,7 @@ func TestScheduler_Start_LoadingRecurringJobs(t *testing.T) {
 
 	executeJobChannel := make(chan struct{})
 	runManager := new(mocks.RunManager)
-	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).
 		Twice().
 		Run(func(mock.Arguments) {
@@ -51,7 +51,7 @@ func TestScheduler_Start_LoadingRecurringJobs(t *testing.T) {
 func TestRecurring_AddJob(t *testing.T) {
 	executeJobChannel := make(chan struct{}, 1)
 	runManager := new(mocks.RunManager)
-	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).
 		Run(func(mock.Arguments) {
 			executeJobChannel <- struct{}{}
@@ -138,7 +138,7 @@ func TestOneTime_AddJob(t *testing.T) {
 
 	executeJobChannel := make(chan struct{})
 	runManager := new(mocks.RunManager)
-	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).
 		Once().
 		Run(func(mock.Arguments) {

--- a/core/services/subscription.go
+++ b/core/services/subscription.go
@@ -146,11 +146,12 @@ func ReceiveLogRequest(runManager RunManager, le models.LogRequest) {
 		logger.Errorw(err.Error(), le.ForLogger()...)
 		return
 	}
+	initialMeta := le.Meta()
 
-	runJob(runManager, le, data)
+	runJob(runManager, le, data, initialMeta)
 }
 
-func runJob(runManager RunManager, le models.LogRequest, data models.JSON) {
+func runJob(runManager RunManager, le models.LogRequest, data models.JSON, initialMeta models.JSON) {
 	jobSpecID := le.GetJobSpecID()
 	initiator := le.GetInitiator()
 
@@ -171,7 +172,7 @@ func runJob(runManager RunManager, le models.LogRequest, data models.JSON) {
 		return
 	}
 
-	_, err = runManager.Create(jobSpecID, &initiator, &data, le.BlockNumber(), &rr)
+	_, err = runManager.Create(jobSpecID, &initiator, &data, &initialMeta, le.BlockNumber(), &rr)
 	if err != nil {
 		logger.Errorw(err.Error(), le.ForLogger()...)
 	}

--- a/core/services/subscription_test.go
+++ b/core/services/subscription_test.go
@@ -226,7 +226,7 @@ func TestServices_StartJobSubscription(t *testing.T) {
 			executeJobChannel := make(chan struct{})
 
 			runManager := new(mocks.RunManager)
-			runManager.On("Create", job.ID, mock.Anything, mock.Anything, big.NewInt(0), mock.Anything).
+			runManager.On("Create", job.ID, mock.Anything, mock.Anything, mock.Anything, big.NewInt(0), mock.Anything).
 				Return(nil, nil).
 				Run(func(mock.Arguments) {
 					executeJobChannel <- struct{}{}
@@ -361,7 +361,7 @@ func TestServices_NewInitiatorSubscription_EthLog_ReplayFromBlock(t *testing.T) 
 			executeJobChannel := make(chan struct{})
 
 			runManager := new(mocks.RunManager)
-			runManager.On("Create", job.ID, mock.Anything, mock.Anything, big.NewInt(int64(log.BlockNumber)), mock.Anything).
+			runManager.On("Create", job.ID, mock.Anything, mock.Anything, mock.Anything, big.NewInt(int64(log.BlockNumber)), mock.Anything).
 				Return(nil, nil).
 				Run(func(mock.Arguments) {
 					executeJobChannel <- struct{}{}
@@ -424,7 +424,7 @@ func TestServices_NewInitiatorSubscription_RunLog_ReplayFromBlock(t *testing.T) 
 			executeJobChannel := make(chan struct{})
 
 			runManager := new(mocks.RunManager)
-			runManager.On("Create", job.ID, mock.Anything, mock.Anything, big.NewInt(int64(log.BlockNumber)), mock.Anything).
+			runManager.On("Create", job.ID, mock.Anything, mock.Anything, mock.Anything, big.NewInt(int64(log.BlockNumber)), mock.Anything).
 				Return(nil, nil).
 				Run(func(mock.Arguments) {
 					executeJobChannel <- struct{}{}

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -29,6 +29,7 @@ import (
 	"chainlink/core/store/migrations/migration1573812490"
 	"chainlink/core/store/migrations/migration1575036327"
 	"chainlink/core/store/migrations/migration1576022702"
+	"chainlink/core/store/migrations/migration1580290179"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -150,6 +151,10 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "1576022702",
 			Migrate: migration1576022702.Migrate,
+		},
+		{
+			ID:      "1580290179",
+			Migrate: migration1580290179.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration1580290179/migrate.go
+++ b/core/store/migrations/migration1580290179/migrate.go
@@ -1,0 +1,12 @@
+package migration1580290179
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate adds the 'meta' field to the run_results table
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+ALTER TABLE job_runs ADD COLUMN initial_meta text NOT NULL DEFAULT '{}';
+	`).Error
+}

--- a/core/store/models/bridge_run_result.go
+++ b/core/store/models/bridge_run_result.go
@@ -10,6 +10,7 @@ import (
 // BridgeRunResult handles the parsing of RunResults from external adapters.
 type BridgeRunResult struct {
 	Data            JSON        `json:"data"`
+	Meta            JSON        `json:"meta"`
 	Status          RunStatus   `json:"status"`
 	ErrorMessage    null.String `json:"error"`
 	ExternalPending bool        `json:"pending"`

--- a/core/store/models/job_run.go
+++ b/core/store/models/job_run.go
@@ -31,6 +31,7 @@ type JobRun struct {
 	CreationHeight *utils.Big   `json:"creationHeight"`
 	ObservedHeight *utils.Big   `json:"observedHeight"`
 	Overrides      JSON         `json:"overrides"`
+	InitialMeta    JSON         `json:"initialMeta" gorm:"default:'{}'"`
 	DeletedAt      null.Time    `json:"-" gorm:"index"`
 	Payment        *assets.Link `json:"payment,omitempty"`
 }

--- a/core/store/models/log_events.go
+++ b/core/store/models/log_events.go
@@ -146,6 +146,7 @@ type LogRequest interface {
 
 	Validate() bool
 	JSON() (JSON, error)
+	Meta() JSON
 	ToDebug()
 	ForLogger(kvs ...interface{}) []interface{}
 	ValidateRequester() error
@@ -252,6 +253,19 @@ func (le InitiatorLogEvent) JSON() (JSON, error) {
 		return out, err
 	}
 	return out, json.Unmarshal(b, &out)
+}
+
+// Meta returns metadata about the eth log
+func (le InitiatorLogEvent) Meta() JSON {
+	el := le.Log
+	meta := make(map[string]interface{})
+	meta["initiator"] = map[string]interface{}{
+		"transactionHash": el.TxHash,
+	}
+	var out JSON
+	b, _ := json.Marshal(meta)
+	json.Unmarshal(b, &out)
+	return out
 }
 
 // EthLogEvent provides functionality specific to a log event emitted

--- a/core/store/models/log_events_test.go
+++ b/core/store/models/log_events_test.go
@@ -122,6 +122,30 @@ func TestEthLogEvent_JSON(t *testing.T) {
 	}
 }
 
+func TestEthLogEvent_Meta(t *testing.T) {
+	t.Parallel()
+
+	hwLog := cltest.LogFromFixture(t, "testdata/requestLog0original.json")
+	exampleLog := cltest.LogFromFixture(t, "testdata/subscription_logs.json")
+	tests := []struct {
+		name     string
+		el       eth.Log
+		wantMeta models.JSON
+	}{
+		{"example", exampleLog, cltest.JSONFromString(t, `{"initiatorEthLog": {"transactionHash": "0xe044554a0a55067caafd07f8020ab9f2af60bdfe337e395ecd84b4877a3d1ab4"}}`)},
+		{"hello world", hwLog, cltest.JSONFromString(t, `{"initiatorEthLog": {"transactionHash": "0xe05b171038320aca6634ce50de669bd0baa337130269c3ce3594ce4d45fc342a"}}`)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			initr := models.Initiator{Type: models.InitiatorEthLog}
+			le := models.InitiatorLogEvent{Initiator: initr, Log: test.el}.LogRequest()
+			meta := le.Meta()
+			assert.JSONEq(t, strings.ToLower(test.wantMeta.String()), strings.ToLower(meta.String()))
+		})
+	}
+}
+
 func TestRequestLogEvent_Validate(t *testing.T) {
 	t.Parallel()
 

--- a/core/store/models/run_input.go
+++ b/core/store/models/run_input.go
@@ -10,20 +10,22 @@ import (
 type RunInput struct {
 	jobRunID ID
 	data     JSON
+	Meta     JSON
 	status   RunStatus
 }
 
 // NewRunInput creates a new RunInput with arbitrary data
-func NewRunInput(jobRunID *ID, data JSON, status RunStatus) *RunInput {
+func NewRunInput(jobRunID *ID, data JSON, meta JSON, status RunStatus) *RunInput {
 	return &RunInput{
 		jobRunID: *jobRunID,
 		data:     data,
+		Meta:     meta,
 		status:   status,
 	}
 }
 
 // NewRunInputWithResult creates a new RunInput with a value in the "result" field
-func NewRunInputWithResult(jobRunID *ID, value interface{}, status RunStatus) *RunInput {
+func NewRunInputWithResult(jobRunID *ID, value interface{}, meta JSON, status RunStatus) *RunInput {
 	data, err := JSON{}.Add("result", value)
 	if err != nil {
 		panic(fmt.Sprintf("invariant violated, add should not fail on empty JSON %v", err))
@@ -31,6 +33,7 @@ func NewRunInputWithResult(jobRunID *ID, value interface{}, status RunStatus) *R
 	return &RunInput{
 		jobRunID: *jobRunID,
 		data:     data,
+		Meta:     meta,
 		status:   status,
 	}
 }

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -154,8 +154,9 @@ func TestORM_CreateJobRun_CreatesRunRequest(t *testing.T) {
 
 	rr := models.NewRunRequest()
 	data := cltest.JSONFromString(t, `{"random": "input"}`)
+	meta := cltest.TestMeta()
 	currentHeight := big.NewInt(0)
-	run, _ := services.NewRun(&job, &job.Initiators[0], &data, currentHeight, rr, store.Config, store.ORM, time.Now())
+	run, _ := services.NewRun(&job, &job.Initiators[0], &data, &meta, currentHeight, rr, store.Config, store.ORM, time.Now())
 	require.NoError(t, store.CreateJobRun(run))
 
 	requestCount, err := store.ORM.CountOf(&models.RunRequest{})

--- a/core/web/job_runs_controller.go
+++ b/core/web/job_runs_controller.go
@@ -60,13 +60,17 @@ func (jrc *JobRunsController) Create(c *gin.Context) {
 		jsonAPIError(c, http.StatusForbidden, err)
 	} else if data, err := getRunData(c); err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
-	} else if jr, err := jrc.App.Create(j.ID, initiator, &data, nil, &models.RunRequest{}); errors.Cause(err) == orm.ErrorNotFound {
+	} else if jr, err := jrc.App.Create(j.ID, initiator, &data, webInitiatedMeta(), nil, &models.RunRequest{}); errors.Cause(err) == orm.ErrorNotFound {
 		jsonAPIError(c, http.StatusNotFound, errors.New("Job not found"))
 	} else if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 	} else {
 		jsonAPIResponse(c, presenters.JobRun{JobRun: *jr}, "job run")
 	}
+}
+
+func webInitiatedMeta() *models.JSON {
+	return &models.JSON{}
 }
 
 // getInitiator returns the Job Spec's initiator for the given web context.


### PR DESCRIPTION
 This allows us to pass the ethlog txhash through to external adapters.
    
It is extensible and can allow for any arbitrary metadata to be assigned to job runs at initialisation.