### PR TITLE
Remove redundant URL validation in EI creation

### DIFF
--- a/core/services/validators.go
+++ b/core/services/validators.go
@@ -87,12 +87,6 @@ func ValidateExternalInitiator(
 	} else if err != orm.ErrorNotFound {
 		return errors.Wrap(err, "validating external initiator")
 	}
-	// only validate URL if present
-	if exi.URL != nil {
-		if isURL := govalidator.IsURL((*exi.URL).String()); !isURL {
-			fe.Add("Invalid URL format")
-		}
-	}
 	return fe.CoerceEmptyToNil()
 }
 

--- a/core/services/validators_test.go
+++ b/core/services/validators_test.go
@@ -248,8 +248,8 @@ func TestValidateExternalInitiator(t *testing.T) {
 	}{
 		{"basic", `{"name":"bitcoin","url":"https://test.url"}`, false},
 		{"basic w/ underscore", `{"name":"bit_coin","url":"https://test.url"}`, false},
+		{"basic w/ underscore in url", `{"name":"bitcoin","url":"https://chainlink_bit-coin_1.url"}`, false},
 		{"missing url", `{"name":"missing_url"}`, false},
-		{"bad url", `{"name":"bitcoin","url":"//test.url"}`, true},
 		{"duplicate name", `{"name":"duplicate","url":"https://test.url"}`, true},
 		{"invalid name characters", `{"name":"<invalid>","url":"https://test.url"}`, true},
 		{"missing name", `{"url":"https://test.url"}`, true},


### PR DESCRIPTION
URL parsing is already done in an earlier step, and the validation that is made here is too strict for our usage.