### PR TITLE
Feature/169366221 flux monitor heartbeat

### DIFF
--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -145,11 +145,12 @@ func NewJobWithFluxMonitorInitiator() models.JobSpec {
 		JobSpecID: j.ID,
 		Type:      models.InitiatorFluxMonitor,
 		InitiatorParams: models.InitiatorParams{
-			Address:     NewAddress(),
-			RequestData: models.JSON{gjson.Parse(`{"data":{"coin":"ETH","market":"USD"}}`)},
-			Feeds:       []string{"https://lambda.staging.devnet.tools/bnc/call"},
-			Threshold:   0.5,
-			Precision:   2,
+			Address:       NewAddress(),
+			RequestData:   models.JSON{gjson.Parse(`{"data":{"coin":"ETH","market":"USD"}}`)},
+			Feeds:         []string{"https://lambda.staging.devnet.tools/bnc/call"},
+			IdleThreshold: models.Duration(time.Minute),
+			Threshold:     0.5,
+			Precision:     2,
 		},
 	}}
 	return j

--- a/core/internal/testdata/flux_monitor_job.json
+++ b/core/internal/testdata/flux_monitor_job.json
@@ -7,6 +7,7 @@
         "data":{"coin":"ETH","market":"USD"}
       },
       "feeds": [ "https://lambda.staging.devnet.tools/bnc/call" ],
+      "idleThreshold": "1h",
       "threshold": 0.5,
       "precision": 2
     }

--- a/core/services/flux_monitor.go
+++ b/core/services/flux_monitor.go
@@ -8,6 +8,7 @@ import (
 	"chainlink/core/utils"
 	"context"
 	"fmt"
+	"math"
 	"math/big"
 	"time"
 
@@ -240,18 +241,21 @@ type DeviationChecker interface {
 
 // PollingDeviationChecker polls external price adapters via HTTP to check for price swings.
 type PollingDeviationChecker struct {
-	initr        models.Initiator
-	address      common.Address
-	requestData  models.JSON
-	threshold    float64
-	precision    int32
-	runManager   RunManager
-	currentPrice decimal.Decimal
-	currentRound *big.Int
-	fetcher      Fetcher
-	delay        time.Duration
-	cancel       context.CancelFunc
-	newRounds    chan eth.Log
+	initr         models.Initiator
+	address       common.Address
+	requestData   models.JSON
+	idleThreshold time.Duration
+	threshold     float64
+	precision     int32
+	runManager    RunManager
+	currentPrice  decimal.Decimal
+	currentRound  *big.Int
+	fetcher       Fetcher
+	delay         time.Duration
+	cancel        context.CancelFunc
+	newRounds     chan eth.Log
+
+	waitOnStop chan struct{}
 }
 
 // NewPollingDeviationChecker returns a new instance of PollingDeviationChecker.
@@ -262,17 +266,20 @@ func NewPollingDeviationChecker(
 	delay time.Duration,
 ) (*PollingDeviationChecker, error) {
 	return &PollingDeviationChecker{
-		initr:        initr,
-		address:      initr.InitiatorParams.Address,
-		requestData:  initr.InitiatorParams.RequestData,
-		threshold:    float64(initr.InitiatorParams.Threshold),
-		precision:    initr.InitiatorParams.Precision,
-		runManager:   runManager,
-		currentPrice: decimal.NewFromInt(0),
-		currentRound: big.NewInt(0),
-		fetcher:      fetcher,
-		delay:        delay,
-		newRounds:    make(chan eth.Log),
+		initr:         initr,
+		address:       initr.InitiatorParams.Address,
+		requestData:   initr.InitiatorParams.RequestData,
+		idleThreshold: initr.InitiatorParams.IdleThreshold.Duration(),
+		threshold:     float64(initr.InitiatorParams.Threshold),
+		precision:     initr.InitiatorParams.Precision,
+		runManager:    runManager,
+		currentPrice:  decimal.NewFromInt(0),
+		currentRound:  big.NewInt(0),
+		fetcher:       fetcher,
+		delay:         delay,
+		newRounds:     make(chan eth.Log),
+
+		waitOnStop: make(chan struct{}),
 	}, nil
 }
 
@@ -292,7 +299,7 @@ func (p *PollingDeviationChecker) Start(ctx context.Context, client eth.Client) 
 		return err
 	}
 
-	err = p.poll()
+	err = p.poll(p.threshold)
 	if err != nil {
 		return err
 	}
@@ -302,18 +309,41 @@ func (p *PollingDeviationChecker) Start(ctx context.Context, client eth.Client) 
 	return nil
 }
 
+// stopTimer stops and clears the timer as suggested by the documentation.
+func stopTimer(arg *time.Timer) {
+	if !arg.Stop() && len(arg.C) > 0 {
+		// Residual events are the timer's channel and need to be cleared.
+		//
+		// Refer to timer.Stop's documentation or
+		// https://developpaper.com/detailed-explanation-of-the-trap-of-timer-in-golang/
+		<-arg.C
+	}
+}
+
 func (p *PollingDeviationChecker) consume(ctx context.Context, roundSubscription eth.Subscription) {
 	defer roundSubscription.Unsubscribe()
+
+	idleThreshold := time.NewTimer(math.MaxInt64)
+	defer stopTimer(idleThreshold)
+
 	for {
+		if p.idleThreshold > 0 {
+			stopTimer(idleThreshold) // Reset expects stopped or expired timer.
+			idleThreshold.Reset(p.idleThreshold)
+		}
+
 		select {
 		case <-ctx.Done():
+			close(p.waitOnStop)
 			return
 		case err := <-roundSubscription.Err():
 			logger.Error(errors.Wrap(err, "checker lost subscription to NewRound log events"))
 		case log := <-p.newRounds:
 			logger.ErrorIf(p.respondToNewRound(log), "checker unable to respond to new round")
 		case <-time.After(p.delay):
-			logger.ErrorIf(p.poll(), "checker unable to poll")
+			logger.ErrorIf(p.poll(p.threshold), "checker unable to poll")
+		case <-idleThreshold.C:
+			logger.ErrorIf(p.poll(0), "checker unable to poll")
 		}
 	}
 }
@@ -322,6 +352,7 @@ func (p *PollingDeviationChecker) consume(ctx context.Context, roundSubscription
 func (p *PollingDeviationChecker) Stop() {
 	if p.cancel != nil {
 		p.cancel()
+		<-p.waitOnStop
 	}
 }
 
@@ -409,7 +440,7 @@ func (p *PollingDeviationChecker) respondToNewRound(log eth.Log) error {
 // poll walks through the steps to check for a deviation, early exiting if deviation
 // is not met, or triggering a new job run if deviation is met.
 // Only invoked by the CSP consumer on the single goroutine for thread safety.
-func (p *PollingDeviationChecker) poll() error {
+func (p *PollingDeviationChecker) poll(threshold float64) error {
 	jobSpecID := p.initr.JobSpecID.String()
 
 	nextPrice, err := p.fetchPrices()
@@ -418,7 +449,7 @@ func (p *PollingDeviationChecker) poll() error {
 	}
 	promSetDecimal(promFMSeenValue.WithLabelValues(jobSpecID), nextPrice)
 
-	if !OutsideDeviation(p.currentPrice, nextPrice, p.threshold) {
+	if !OutsideDeviation(p.currentPrice, nextPrice, threshold) {
 		return nil // early exit since deviation criteria not met.
 	}
 

--- a/core/services/flux_monitor_helpers_test.go
+++ b/core/services/flux_monitor_helpers_test.go
@@ -29,7 +29,7 @@ func (p *PollingDeviationChecker) ExportedRespondToNewRound(log eth.Log) error {
 }
 
 func (p *PollingDeviationChecker) ExportedPoll() error {
-	return p.poll()
+	return p.poll(p.threshold)
 }
 
 // ExportedCurrentPrice returns the private current price for assertions;

--- a/core/services/flux_monitor_helpers_test.go
+++ b/core/services/flux_monitor_helpers_test.go
@@ -28,7 +28,7 @@ func (p *PollingDeviationChecker) ExportedRespondToNewRound(log eth.Log) error {
 	return p.respondToNewRound(log)
 }
 
-func (p *PollingDeviationChecker) ExportedPoll() error {
+func (p *PollingDeviationChecker) ExportedPoll() (bool, error) {
 	return p.poll(p.threshold)
 }
 

--- a/core/services/flux_monitor_test.go
+++ b/core/services/flux_monitor_test.go
@@ -211,7 +211,8 @@ func TestPollingDeviationChecker_PollHappy(t *testing.T) {
 	assert.Equal(t, decimal.NewFromInt(100), checker.ExportedCurrentPrice())
 	assert.Equal(t, big.NewInt(1), checker.ExportedCurrentRound())
 
-	require.NoError(t, checker.ExportedPoll()) // main entry point
+	_, err = checker.ExportedPoll()
+	require.NoError(t, err) // main entry point
 
 	fetcher.AssertExpectations(t)
 	rm.AssertExpectations(t)
@@ -223,7 +224,7 @@ func TestPollingDeviationChecker_TriggerIdleTimeThreshold(t *testing.T) {
 	job := cltest.NewJobWithFluxMonitorInitiator()
 	initr := job.Initiators[0]
 	initr.ID = 1
-	initr.PollingInterval = models.Duration(24 * time.Hour)
+	initr.PollingInterval = models.Duration(5 * time.Millisecond)
 	initr.IdleThreshold = models.Duration(10 * time.Millisecond)
 
 	jobRun := cltest.NewJobRun(job)

--- a/core/services/validators.go
+++ b/core/services/validators.go
@@ -122,6 +122,9 @@ func validateFluxMonitor(i models.Initiator, j models.JobSpec) error {
 	if len(i.Feeds) == 0 {
 		fe.Add("no feeds")
 	}
+	if i.IdleThreshold != 0 && i.IdleThreshold < i.PollingInterval {
+		fe.Add("idleThreshold must be equal or greater than the pollingInterval")
+	}
 	if i.Threshold <= 0 {
 		fe.Add("bad threshold")
 	}

--- a/core/services/validators_test.go
+++ b/core/services/validators_test.go
@@ -375,6 +375,7 @@ const validInitiator = `{
 			"https://lambda.staging.devnet.tools/cc/call",
 			"https://lambda.staging.devnet.tools/cmc/call"
 		],
+		"idleThreshold": "1m",
 		"threshold": 0.5,
 		"precision": 2,
 		"pollingInterval": "1m"
@@ -402,6 +403,7 @@ func TestValidateInitiator_FluxMonitorErrors(t *testing.T) {
 		{"requestdata", cltest.MustJSONDel(t, validInitiator, "params.requestdata")},
 		{"pollingInterval", cltest.MustJSONDel(t, validInitiator, "params.pollingInterval")},
 		{"pollingInterval", cltest.MustJSONSet(t, validInitiator, "params.pollingInterval", "1s")},
+		{"idleThreshold", cltest.MustJSONSet(t, validInitiator, "params.idleThreshold", "30s")},
 	}
 	for _, test := range tests {
 		t.Run("bad "+test.Field, func(t *testing.T) {

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -30,6 +30,7 @@ import (
 	"chainlink/core/store/migrations/migration1575036327"
 	"chainlink/core/store/migrations/migration1576022702"
 	"chainlink/core/store/migrations/migration1579700934"
+	"chainlink/core/store/migrations/migration1580904019"
 	"chainlink/core/store/migrations/migration1581240419"
 
 	"github.com/jinzhu/gorm"
@@ -156,6 +157,10 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "1579700934",
 			Migrate: migration1579700934.Migrate,
+		},
+		{
+			ID:      "1580904019",
+			Migrate: migration1580904019.Migrate,
 		},
 		{
 			ID:      "1581240419",

--- a/core/store/migrations/migration1580904019/migrate.go
+++ b/core/store/migrations/migration1580904019/migrate.go
@@ -1,0 +1,13 @@
+package migration1580904019
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate adds the InitiatorParams.IdleThreshold duration (nanoseconds) to support the Flux Monitor.
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+	  ALTER TABLE initiators ADD COLUMN "idle_threshold" BigInt;
+	`).Error
+	return nil
+}

--- a/core/store/migrations/migration1580904019/migrate.go
+++ b/core/store/migrations/migration1580904019/migrate.go
@@ -9,5 +9,4 @@ func Migrate(tx *gorm.DB) error {
 	return tx.Exec(`
 	  ALTER TABLE initiators ADD COLUMN "idle_threshold" BigInt;
 	`).Error
-	return nil
 }

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -217,6 +217,7 @@ type InitiatorParams struct {
 
 	RequestData     JSON     `json:"requestData,omitempty" gorm:"type:text"`
 	Feeds           Feeds    `json:"feeds,omitempty" gorm:"type:text"`
+	IdleThreshold   Duration `json:"idleThreshold,omitempty"`
 	Threshold       float32  `json:"threshold,omitempty" gorm:"type:float"`
 	Precision       int32    `json:"precision,omitempty" gorm:"type:smallint"`
 	PollingInterval Duration `json:"pollingInterval,omitempty"`

--- a/core/store/models/job_spec_test.go
+++ b/core/store/models/job_spec_test.go
@@ -42,8 +42,9 @@ func TestNewInitiatorFromRequest(t *testing.T) {
 			initrReq: models.InitiatorRequest{
 				Type: models.InitiatorFluxMonitor,
 				InitiatorParams: models.InitiatorParams{
-					Threshold: 5,
-					Precision: 2,
+					IdleThreshold: models.Duration(5 * time.Second),
+					Precision:     2,
+					Threshold:     5,
 				},
 			},
 			jobSpec: job,
@@ -51,9 +52,10 @@ func TestNewInitiatorFromRequest(t *testing.T) {
 				Type:      models.InitiatorFluxMonitor,
 				JobSpecID: job.ID,
 				InitiatorParams: models.InitiatorParams{
-					Threshold:       5,
-					Precision:       2,
+					IdleThreshold:   models.Duration(5 * time.Second),
 					PollingInterval: models.FluxMonitorDefaultInitiatorParams.PollingInterval,
+					Precision:       2,
+					Threshold:       5,
 				},
 			},
 		},

--- a/core/web/job_specs_controller_test.go
+++ b/core/web/job_specs_controller_test.go
@@ -3,6 +3,7 @@ package web_test
 import (
 	"bytes"
 	"encoding/json"
+	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -333,7 +334,11 @@ func TestJobSpecsController_Create_FluxMonitor_enabled(t *testing.T) {
 	resp, cleanup := client.Post("/v2/specs", bytes.NewBuffer(jsonStr))
 	defer cleanup()
 
-	require.Equal(t, http.StatusText(http.StatusOK), http.StatusText(resp.StatusCode))
+	body, _ := ioutil.ReadAll(resp.Body)
+	require.Equal(
+		t, http.StatusText(http.StatusOK), http.StatusText(resp.StatusCode),
+		string(body),
+	)
 }
 
 func TestJobSpecsController_Create_InvalidJob(t *testing.T) {

--- a/core/web/job_specs_controller_test.go
+++ b/core/web/job_specs_controller_test.go
@@ -3,7 +3,6 @@ package web_test
 import (
 	"bytes"
 	"encoding/json"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
@@ -334,11 +333,7 @@ func TestJobSpecsController_Create_FluxMonitor_enabled(t *testing.T) {
 	resp, cleanup := client.Post("/v2/specs", bytes.NewBuffer(jsonStr))
 	defer cleanup()
 
-	body, _ := ioutil.ReadAll(resp.Body)
-	require.Equal(
-		t, http.StatusText(http.StatusOK), http.StatusText(resp.StatusCode),
-		string(body),
-	)
+	cltest.AssertServerResponse(t, resp, http.StatusOK)
 }
 
 func TestJobSpecsController_Create_InvalidJob(t *testing.T) {

--- a/integration/flux_monitor_test
+++ b/integration/flux_monitor_test
@@ -14,13 +14,13 @@ flux_monitor_test() {
   local log=$LOG_PATH/flux_monitor.log
 
   # add flux monitor job to CL node
-  FLUX_MONITOR_JOB="$(
+  local flux_monitor_job="$(
      cat flux_monitor/fixtures/job.json \
        | jq --arg address $PREPAID_AGGREGATOR_ADDRESS '.initiators[0].params.address = $address' \
        | jq --arg url $EXTERNAL_ADAPTER_URL '.initiators[0].params.feeds[0] = $url' \
        | jq --arg dur $pollingInterval '.initiators[0].params.pollingInterval = $dur'
   )"
-  chainlink jobs create "$FLUX_MONITOR_JOB"
+  flux_monitor_job=(chainlink -j jobs create "$flux_monitor_job")
 
   # Check job counts
   assert "Jobs count" "chainlink -j jobs list | jq length" $expected_job_count
@@ -49,6 +49,8 @@ flux_monitor_test() {
 
   # Assert job ran
   assert "Flux Monitor Runs count" "chainlink -j runs list | jq length" $second_job_run_count
+
+  chainlink -j jobs archive $(jq .id "$flux_monitor_job")
 }
 
 flux_monitor_test

--- a/integration/flux_monitor_test
+++ b/integration/flux_monitor_test
@@ -37,7 +37,7 @@ flux_monitor_test() {
     --data '{"result":101}' \
     "$EXTERNAL_ADAPTER_URL/result"
 
-  sleep "$pollingDuration"
+  sleep "$pollingInterval"
 
   # Assert no jobs ran after nominal update
   assert "Flux Monitor Runs count" "chainlink -j runs list | jq length" $first_job_run_count

--- a/integration/flux_monitor_test
+++ b/integration/flux_monitor_test
@@ -5,22 +5,24 @@ source $SRCROOT/integration/common
 title 'Flux Monitor test.'
 
 flux_monitor_test() {
+  local log=$LOG_PATH/flux_monitor.log
+  local expected_job_count=$(expr $(chainlink -j jobs list | jq length) + 1)
+
   local pollingInterval="5s"
 
-  local expected_job_count=$(expr $(chainlink -j jobs list | jq length) + 1)
   local initial_job_run_count=$(expr $(chainlink -j runs list | jq length))
   local first_job_run_count=$((initial_job_run_count + 1))
   local second_job_run_count=$((first_job_run_count + 1))
-  local log=$LOG_PATH/flux_monitor.log
+  local third_job_run_count=$((second_job_run_count + 1))
+
 
   # add flux monitor job to CL node
   local flux_monitor_job="$(
      cat flux_monitor/fixtures/job.json \
        | jq --arg address $PREPAID_AGGREGATOR_ADDRESS '.initiators[0].params.address = $address' \
-       | jq --arg url $EXTERNAL_ADAPTER_URL '.initiators[0].params.feeds[0] = $url' \
-       | jq --arg dur $pollingInterval '.initiators[0].params.pollingInterval = $dur'
+       | jq --arg url $EXTERNAL_ADAPTER_URL '.initiators[0].params.feeds[0] = $url'
   )"
-  flux_monitor_job=(chainlink -j jobs create "$flux_monitor_job")
+  flux_monitor_job="$(chainlink -j jobs create "$flux_monitor_job")"
 
   # Check job counts
   assert "Jobs count" "chainlink -j jobs list | jq length" $expected_job_count
@@ -50,7 +52,8 @@ flux_monitor_test() {
   # Assert job ran
   assert "Flux Monitor Runs count" "chainlink -j runs list | jq length" $second_job_run_count
 
-  chainlink -j jobs archive $(jq .id "$flux_monitor_job")
+  # Stop the job from affecting other tests
+  chainlink jobs archive $(echo "$flux_monitor_job" | jq .id)
 }
 
 flux_monitor_test

--- a/integration/flux_monitor_test
+++ b/integration/flux_monitor_test
@@ -52,7 +52,7 @@ flux_monitor_test() {
   # Assert job ran
   assert "Flux Monitor Runs count" "chainlink -j runs list | jq length" $second_job_run_count
 
-  # Stop the job from affecting other tests
+  echo "archiving job to prevent it affecting other tests"
   chainlink jobs archive $(echo "$flux_monitor_job" | jq .id)
 }
 


### PR DESCRIPTION
Allow chainlink operators to configure the Flux Monitor to trigger a Job Run if it has exceeded a specified 'idle time'.  The 'idle time' is the time for which no Job Run has been started.

The behavior is disabled if no idle time is defined.

https://www.pivotaltracker.com/story/show/169366221
