### PR TITLE
Deploy feeds_ui to Heroku via Docker build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ operator_ui/artifacts
 *-packr.go
 
 # Feeds UI
-feeds_ui/build
+feeds/build
 
 # SQLite
 tools/clroot/db.sqlite3-shm

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ operator_ui/dist
 operator_ui/artifacts
 *-packr.go
 
+# Feeds UI
+feeds_ui/build
+
 # SQLite
 tools/clroot/db.sqlite3-shm
 tools/clroot/db.sqlite3-wal

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -5,7 +5,7 @@ ADD . .
 
 ARG REACT_APP_INFURA_KEY
 RUN yarn install
-RUN yarn workspace @chainlink/heartbeat run build
+RUN yarn workspace @chainlink/feeds run build
 
 FROM node:10.16.3-alpine
 
@@ -14,14 +14,14 @@ WORKDIR /app
 COPY --from=builder /app/package.json package.json
 COPY --from=builder /app/yarn.lock yarn.lock
 COPY --from=builder /app/node_modules node_modules
-COPY --from=builder /app/feeds_ui/node_modules feeds_ui/node_modules
-COPY --from=builder /app/feeds_ui/package.json feeds_ui/package.json
-COPY --from=builder /app/feeds_ui/server.js feeds_ui/server.js
-COPY --from=builder /app/feeds_ui/src feeds_ui/src
-COPY --from=builder /app/feeds_ui/src/feeds.json feeds_ui/build/feeds.json
-COPY --from=builder /app/feeds_ui/src/nodes.json feeds_ui/build/nodes.json
-COPY --from=builder /app/feeds_ui/public feeds_ui/public
-COPY --from=builder /app/feeds_ui/build feeds_ui/build
+COPY --from=builder /app/feeds/node_modules feeds/node_modules
+COPY --from=builder /app/feeds/package.json feeds/package.json
+COPY --from=builder /app/feeds/server.js feeds/server.js
+COPY --from=builder /app/feeds/src feeds/src
+COPY --from=builder /app/feeds/src/feeds.json feeds/build/feeds.json
+COPY --from=builder /app/feeds/src/nodes.json feeds/build/nodes.json
+COPY --from=builder /app/feeds/public feeds/public
+COPY --from=builder /app/feeds/build feeds/build
 
 ENV NODE_ENV production
-ENTRYPOINT [ "yarn", "workspace", "@chainlink/heartbeat", "run", "start" ]
+ENTRYPOINT [ "yarn", "workspace", "@chainlink/feeds", "run", "start" ]

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -1,0 +1,27 @@
+FROM node:10.16.3 as builder
+
+WORKDIR /app
+ADD . .
+
+ARG REACT_APP_INFURA_KEY
+RUN yarn install
+RUN yarn workspace @chainlink/heartbeat run build
+
+FROM node:10.16.3-alpine
+
+WORKDIR /app
+
+COPY --from=builder /app/package.json package.json
+COPY --from=builder /app/yarn.lock yarn.lock
+COPY --from=builder /app/node_modules node_modules
+COPY --from=builder /app/feeds_ui/node_modules feeds_ui/node_modules
+COPY --from=builder /app/feeds_ui/package.json feeds_ui/package.json
+COPY --from=builder /app/feeds_ui/server.js feeds_ui/server.js
+COPY --from=builder /app/feeds_ui/src feeds_ui/src
+COPY --from=builder /app/feeds_ui/src/feeds.json feeds_ui/build/feeds.json
+COPY --from=builder /app/feeds_ui/src/nodes.json feeds_ui/build/nodes.json
+COPY --from=builder /app/feeds_ui/public feeds_ui/public
+COPY --from=builder /app/feeds_ui/build feeds_ui/build
+
+ENV NODE_ENV production
+ENTRYPOINT [ "yarn", "workspace", "@chainlink/heartbeat", "run", "start" ]

--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -4,6 +4,7 @@ WORKDIR /app
 ADD . .
 
 ARG REACT_APP_INFURA_KEY
+ARG REACT_APP_GA_ID
 RUN yarn install
 RUN yarn workspace @chainlink/feeds run build
 

--- a/feeds/README.md
+++ b/feeds/README.md
@@ -55,9 +55,18 @@ $ heroku container:login
 
 ```
 
-Deploy new changes from the root of the monorepo
+Build and push a new image from the root of the monorepo
 
 ```
 $ heroku container:push --recursive --arg REACT_APP_INFURA_KEY=abc123,REACT_APP_GA_ID=abc123 -a the-app-name
+
+# If the config vars are stored in Heroku, you can capture the output in a subshell
+$ heroku container:push --recursive --arg REACT_APP_INFURA_KEY=$(heroku config:get REACT_APP_INFURA_KEY -a feeds-ui-ak),REACT_APP_GA_ID=$(heroku config:get REACT_APP_GA_ID -a feeds-ui-ak) -a feeds-ui-ak
+```
+
+
+Deploy the newly built image by releasing the container from the root of the monorepo
+
+```
 $ heroku container:release web -a the-app-name
 ```

--- a/feeds/README.md
+++ b/feeds/README.md
@@ -33,8 +33,31 @@ See the section about [deployment](https://facebook.github.io/create-react-app/d
 
 Launches the expressjs server that serve the `/build` folder
 
-## Env variables
+## **DEPRECATED** Original non-monorepo Heroku env variables
 
 ```
 REACT_APP_INFURA_KEY="yourkey"
+```
+
+## Deploy Monorepo to Heroku
+
+Enable Docker container builds on the application
+
+```
+$ heroku stack:set container -a the-app-name
+
+```
+
+Login to the Heroku Docker container registry
+
+```
+$ heroku container:login
+
+```
+
+Deploy new changes from the root of the monorepo
+
+```
+$ heroku container:push --recursive --arg REACT_APP_INFURA_KEY=the-infura-key -a the-app-name
+$ heroku container:release web -a the-app-name
 ```

--- a/feeds/README.md
+++ b/feeds/README.md
@@ -58,6 +58,6 @@ $ heroku container:login
 Deploy new changes from the root of the monorepo
 
 ```
-$ heroku container:push --recursive --arg REACT_APP_INFURA_KEY=the-infura-key -a the-app-name
+$ heroku container:push --recursive --arg REACT_APP_INFURA_KEY=abc123,REACT_APP_GA_ID=abc123 -a the-app-name
 $ heroku container:release web -a the-app-name
 ```

--- a/feeds/README.md
+++ b/feeds/README.md
@@ -39,7 +39,7 @@ Launches the expressjs server that serve the `/build` folder
 REACT_APP_INFURA_KEY="yourkey"
 ```
 
-## Deploy Monorepo to Heroku
+## Deploy to Heroku
 
 Enable Docker container builds on the application
 

--- a/feeds/package.json
+++ b/feeds/package.json
@@ -15,7 +15,8 @@
     ]
   },
   "engines": {
-    "node": "~10.16"
+    "node": "~10.16",
+    "yarn": "1.x"
   },
   "scripts": {
     "start": "npm run server",

--- a/feeds/src/contracts/utils.js
+++ b/feeds/src/contracts/utils.js
@@ -5,11 +5,11 @@ export function createContract(address, provider, abi) {
   return new ethers.Contract(address, abi, provider)
 }
 
+const REACT_APP_INFURA_KEY = process.env.REACT_APP_INFURA_KEY
+
 export function createInfuraProvider(networkId = MAINNET_ID) {
   const provider = new ethers.providers.JsonRpcProvider(
-    `https://${networkName(networkId)}.infura.io/v3/${
-      process.env.REACT_APP_INFURA_KEY
-    }`,
+    `https://${networkName(networkId)}.infura.io/v3/${REACT_APP_INFURA_KEY}`,
   )
   provider.pollingInterval = 8000
 

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,5 @@
+build:
+  docker:
+    web: Dockerfile.web
+  config:
+    REACT_APP_INFURA_KEY:

--- a/heroku.yml
+++ b/heroku.yml
@@ -3,3 +3,4 @@ build:
     web: Dockerfile.web
   config:
     REACT_APP_INFURA_KEY:
+    REACT_APP_GA_ID:


### PR DESCRIPTION
https://feeds-ui-ak.herokuapp.com/

To switch over to the heroku app from this monorepo I was thinking we could use the following plan:

- Create a new production heroku app `feeds-ui-monorepo`
- Deploy using steps in `feeds_ui/README.md`
- Assign domain `http://feeds.chain.link/` to new `feeds-ui-monorepo` heroku application
- Update DNS to point to monorepo app

After we've confirmed that everything is running correctly on the monorepo app:

- Delete old single repo heroku application
- Delete old repo https://github.com/smartcontractkit/feeds-ui/