### PR TITLE
Add metadata to jobrun table and expose in bridge adapters

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -398,6 +398,19 @@ func (ta *TestApplication) NewAuthenticatingClient(prompter cmd.Prompter) *cmd.C
 	return client
 }
 
+func (ta *TestApplication) MustCreateJobRun(initialMeta models.JSON) *models.JobRun {
+	job := NewJobWithWebInitiator()
+	err := ta.Store.CreateJob(&job)
+	require.NoError(ta.t, err)
+
+	jr := NewJobRun(job)
+	jr.InitialMeta = initialMeta
+	err = ta.Store.CreateJobRun(&jr)
+	require.NoError(ta.t, err)
+
+	return &jr
+}
+
 // NewStoreWithConfig creates a new store with given config
 func NewStoreWithConfig(config *TestConfig) (*strpkg.Store, func()) {
 	cleanupDB := PrepareTestDB(config)

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -622,3 +622,7 @@ func NewRunInputWithResult(value interface{}) models.RunInput {
 	jobRunID := models.NewID()
 	return *models.NewRunInputWithResult(jobRunID, value, models.RunStatusUnstarted)
 }
+
+func NewRunInputWithResultAndJobRunID(value interface{}, jobRunID *models.ID) models.RunInput {
+	return *models.NewRunInputWithResult(jobRunID, value, models.RunStatusUnstarted)
+}

--- a/core/internal/mocks/application.go
+++ b/core/internal/mocks/application.go
@@ -85,13 +85,13 @@ func (_m *Application) Cancel(runID *models.ID) (*models.JobRun, error) {
 	return r0, r1
 }
 
-// Create provides a mock function with given fields: jobSpecID, initiator, data, creationHeight, runRequest
-func (_m *Application) Create(jobSpecID *models.ID, initiator *models.Initiator, data *models.JSON, creationHeight *big.Int, runRequest *models.RunRequest) (*models.JobRun, error) {
-	ret := _m.Called(jobSpecID, initiator, data, creationHeight, runRequest)
+// Create provides a mock function with given fields: jobSpecID, initiator, data, meta, creationHeight, runRequest
+func (_m *Application) Create(jobSpecID *models.ID, initiator *models.Initiator, data *models.JSON, meta *models.JSON, creationHeight *big.Int, runRequest *models.RunRequest) (*models.JobRun, error) {
+	ret := _m.Called(jobSpecID, initiator, data, meta, creationHeight, runRequest)
 
 	var r0 *models.JobRun
-	if rf, ok := ret.Get(0).(func(*models.ID, *models.Initiator, *models.JSON, *big.Int, *models.RunRequest) *models.JobRun); ok {
-		r0 = rf(jobSpecID, initiator, data, creationHeight, runRequest)
+	if rf, ok := ret.Get(0).(func(*models.ID, *models.Initiator, *models.JSON, *models.JSON, *big.Int, *models.RunRequest) *models.JobRun); ok {
+		r0 = rf(jobSpecID, initiator, data, meta, creationHeight, runRequest)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.JobRun)
@@ -99,8 +99,8 @@ func (_m *Application) Create(jobSpecID *models.ID, initiator *models.Initiator,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*models.ID, *models.Initiator, *models.JSON, *big.Int, *models.RunRequest) error); ok {
-		r1 = rf(jobSpecID, initiator, data, creationHeight, runRequest)
+	if rf, ok := ret.Get(1).(func(*models.ID, *models.Initiator, *models.JSON, *models.JSON, *big.Int, *models.RunRequest) error); ok {
+		r1 = rf(jobSpecID, initiator, data, meta, creationHeight, runRequest)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/internal/mocks/run_manager.go
+++ b/core/internal/mocks/run_manager.go
@@ -37,13 +37,13 @@ func (_m *RunManager) Cancel(runID *models.ID) (*models.JobRun, error) {
 	return r0, r1
 }
 
-// Create provides a mock function with given fields: jobSpecID, initiator, data, creationHeight, runRequest
-func (_m *RunManager) Create(jobSpecID *models.ID, initiator *models.Initiator, data *models.JSON, creationHeight *big.Int, runRequest *models.RunRequest) (*models.JobRun, error) {
-	ret := _m.Called(jobSpecID, initiator, data, creationHeight, runRequest)
+// Create provides a mock function with given fields: jobSpecID, initiator, data, meta, creationHeight, runRequest
+func (_m *RunManager) Create(jobSpecID *models.ID, initiator *models.Initiator, data *models.JSON, meta *models.JSON, creationHeight *big.Int, runRequest *models.RunRequest) (*models.JobRun, error) {
+	ret := _m.Called(jobSpecID, initiator, data, meta, creationHeight, runRequest)
 
 	var r0 *models.JobRun
-	if rf, ok := ret.Get(0).(func(*models.ID, *models.Initiator, *models.JSON, *big.Int, *models.RunRequest) *models.JobRun); ok {
-		r0 = rf(jobSpecID, initiator, data, creationHeight, runRequest)
+	if rf, ok := ret.Get(0).(func(*models.ID, *models.Initiator, *models.JSON, *models.JSON, *big.Int, *models.RunRequest) *models.JobRun); ok {
+		r0 = rf(jobSpecID, initiator, data, meta, creationHeight, runRequest)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.JobRun)
@@ -51,8 +51,8 @@ func (_m *RunManager) Create(jobSpecID *models.ID, initiator *models.Initiator, 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*models.ID, *models.Initiator, *models.JSON, *big.Int, *models.RunRequest) error); ok {
-		r1 = rf(jobSpecID, initiator, data, creationHeight, runRequest)
+	if rf, ok := ret.Get(1).(func(*models.ID, *models.Initiator, *models.JSON, *models.JSON, *big.Int, *models.RunRequest) error); ok {
+		r1 = rf(jobSpecID, initiator, data, meta, creationHeight, runRequest)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/flux_monitor.go
+++ b/core/services/flux_monitor.go
@@ -483,7 +483,7 @@ func (p *PollingDeviationChecker) createJobRun(nextPrice decimal.Decimal, nextRo
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("unable to start chainlink run with payload %s", payload))
 	}
-	_, err = p.runManager.Create(p.initr.JobSpecID, &p.initr, &runData, nil, models.NewRunRequest())
+	_, err = p.runManager.Create(p.initr.JobSpecID, &p.initr, &runData, &models.JSON{}, nil, models.NewRunRequest())
 	return err
 }
 

--- a/core/services/flux_monitor_test.go
+++ b/core/services/flux_monitor_test.go
@@ -183,7 +183,7 @@ func TestPollingDeviationChecker_PollHappy(t *testing.T) {
 			"dataPrefix": "0x0000000000000000000000000000000000000000000000000000000000000002"
 	}`, initr.InitiatorParams.Address.Hex())))
 	require.NoError(t, err)
-	rm.On("Create", job.ID, &initr, &data, mock.Anything, mock.Anything).
+	rm.On("Create", job.ID, &initr, &data, mock.Anything, mock.Anything, mock.Anything).
 		Return(&run, nil)
 
 	checker, err := services.NewPollingDeviationChecker(initr, rm, fetcher, time.Second)
@@ -400,7 +400,7 @@ func TestPollingDeviationChecker_RespondToNewRound_Respond(t *testing.T) {
 	// Set up fetcher for 100; even if within deviation, forces the creation of run.
 	fetcher.On("Fetch").Return(decimal.NewFromFloat(100.0), nil).Maybe()
 
-	rm.On("Create", mock.Anything, mock.Anything, &data, mock.Anything, mock.Anything).
+	rm.On("Create", mock.Anything, mock.Anything, &data, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil) // only round 6 triggers run.
 
 	log := cltest.LogFromFixture(t, "testdata/new_round_log.json")

--- a/core/services/run_manager.go
+++ b/core/services/run_manager.go
@@ -54,6 +54,7 @@ type RunManager interface {
 		jobSpecID *models.ID,
 		initiator *models.Initiator,
 		data *models.JSON,
+		meta *models.JSON,
 		creationHeight *big.Int,
 		runRequest *models.RunRequest) (*models.JobRun, error)
 	CreateErrored(
@@ -105,6 +106,7 @@ func NewRun(
 	job *models.JobSpec,
 	initiator *models.Initiator,
 	data *models.JSON,
+	meta *models.JSON,
 	currentHeight *big.Int,
 	runRequest *models.RunRequest,
 	config orm.ConfigReader,
@@ -121,6 +123,7 @@ func NewRun(
 		TaskRuns:       make([]models.TaskRun, len(job.Tasks)),
 		Status:         models.RunStatusInProgress,
 		Overrides:      *data,
+		InitialMeta:    *meta,
 		CreationHeight: utils.NewBig(currentHeight),
 		ObservedHeight: utils.NewBig(currentHeight),
 		RunRequest:     *runRequest,
@@ -225,6 +228,7 @@ func (rm *runManager) Create(
 	jobSpecID *models.ID,
 	initiator *models.Initiator,
 	data *models.JSON,
+	meta *models.JSON,
 	creationHeight *big.Int,
 	runRequest *models.RunRequest,
 ) (*models.JobRun, error) {
@@ -261,7 +265,7 @@ func (rm *runManager) Create(
 		return nil, fmt.Errorf("invariant for job %s: no tasks to run in NewRun", job.ID)
 	}
 
-	run, adapters := NewRun(&job, initiator, data, creationHeight, runRequest, rm.config, rm.orm, now)
+	run, adapters := NewRun(&job, initiator, data, meta, creationHeight, runRequest, rm.config, rm.orm, now)
 	runCost := runCost(&job, rm.config, adapters)
 	ValidateRun(run, runCost)
 

--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -308,7 +308,8 @@ func TestRunManager_Create(t *testing.T) {
 	rr := models.NewRunRequest()
 	rr.RequestID = &requestID
 	data := cltest.JSONFromString(t, `{"random": "input"}`)
-	jr, err := app.RunManager.Create(job.ID, &initiator, &data, nil, rr)
+	meta := cltest.JSONFromString(t, `{"random": "meta"}`)
+	jr, err := app.RunManager.Create(job.ID, &initiator, &data, &meta, nil, rr)
 	require.NoError(t, err)
 	updatedJR := cltest.WaitForJobRunToComplete(t, store, *jr)
 	assert.Equal(t, rr.RequestID, updatedJR.RunRequest.RequestID)
@@ -331,7 +332,8 @@ func TestRunManager_Create_DoesNotSaveToTaskSpec(t *testing.T) {
 
 	initiator := job.Initiators[0]
 	data := cltest.JSONFromString(t, `{"random": "input"}`)
-	jr, err := app.RunManager.Create(job.ID, &initiator, &data, nil, &models.RunRequest{})
+	meta := cltest.JSONFromString(t, `{"random": "meta"}`)
+	jr, err := app.RunManager.Create(job.ID, &initiator, &data, &meta, nil, &models.RunRequest{})
 	require.NoError(t, err)
 	cltest.WaitForJobRunToComplete(t, store, *jr)
 
@@ -398,7 +400,8 @@ func TestRunManager_Create_fromRunLog_Happy(t *testing.T) {
 			rr.TxHash = &initiatingTxHash
 			rr.BlockHash = &test.logBlockHash
 			data := cltest.JSONFromString(t, `{"random": "input"}`)
-			jr, err := app.RunManager.Create(job.ID, &initiator, &data, creationHeight, rr)
+			meta := cltest.JSONFromString(t, `{"random": "meta"}`)
+			jr, err := app.RunManager.Create(job.ID, &initiator, &data, &meta, creationHeight, rr)
 			require.NoError(t, err)
 
 			run := cltest.WaitForJobRunToPendConfirmations(t, app.Store, *jr)
@@ -646,12 +649,13 @@ func TestRunManager_Create_fromRunLogPayments(t *testing.T) {
 			initiator := job.Initiators[0]
 
 			data := cltest.JSONFromString(t, `{"random": "input"}`)
+			meta := cltest.JSONFromString(t, `{"random": "meta"}`)
 			creationHeight := big.NewInt(1)
 
 			runRequest := models.NewRunRequest()
 			runRequest.Payment = test.inputPayment
 
-			run, err := app.RunManager.Create(job.ID, &initiator, &data, creationHeight, runRequest)
+			run, err := app.RunManager.Create(job.ID, &initiator, &data, &meta, creationHeight, runRequest)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.jobStatus, run.Status)
@@ -691,7 +695,8 @@ func TestRunManager_Create_fromRunLog_ConnectToLaggingEthNode(t *testing.T) {
 	pastCurrentHeight := big.NewInt(1)
 
 	data := cltest.JSONFromString(t, `{"random": "input"}`)
-	jr, err := app.RunManager.Create(job.ID, &initiator, &data, futureCreationHeight, rr)
+	meta := cltest.JSONFromString(t, `{"random": "meta"}`)
+	jr, err := app.RunManager.Create(job.ID, &initiator, &data, &meta, futureCreationHeight, rr)
 	require.NoError(t, err)
 	cltest.WaitForJobRunToPendConfirmations(t, app.Store, *jr)
 

--- a/core/services/scheduler.go
+++ b/core/services/scheduler.go
@@ -131,7 +131,7 @@ func (r *Recurring) AddJob(job models.JobSpec) {
 				return
 			}
 
-			_, err := r.runManager.Create(job.ID, &initr, &models.JSON{}, nil, &models.RunRequest{})
+			_, err := r.runManager.Create(job.ID, &initr, &models.JSON{}, &models.JSON{}, nil, &models.RunRequest{})
 			if err != nil && !ExpectedRecurringScheduleJobError(err) {
 				logger.Errorw(err.Error())
 			}
@@ -181,7 +181,7 @@ func (ot *OneTime) RunJobAt(initiator models.Initiator, job models.JobSpec) {
 			return
 		}
 
-		_, err := ot.RunManager.Create(job.ID, &initiator, &models.JSON{}, nil, &models.RunRequest{})
+		_, err := ot.RunManager.Create(job.ID, &initiator, &models.JSON{}, &models.JSON{}, nil, &models.RunRequest{})
 		if err != nil && !ExpectedRecurringScheduleJobError(err) {
 			logger.Error(err.Error())
 			return

--- a/core/services/scheduler_test.go
+++ b/core/services/scheduler_test.go
@@ -28,7 +28,7 @@ func TestScheduler_Start_LoadingRecurringJobs(t *testing.T) {
 
 	executeJobChannel := make(chan struct{})
 	runManager := new(mocks.RunManager)
-	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).
 		Twice().
 		Run(func(mock.Arguments) {
@@ -51,7 +51,7 @@ func TestScheduler_Start_LoadingRecurringJobs(t *testing.T) {
 func TestRecurring_AddJob(t *testing.T) {
 	executeJobChannel := make(chan struct{}, 1)
 	runManager := new(mocks.RunManager)
-	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).
 		Run(func(mock.Arguments) {
 			executeJobChannel <- struct{}{}
@@ -138,7 +138,7 @@ func TestOneTime_AddJob(t *testing.T) {
 
 	executeJobChannel := make(chan struct{})
 	runManager := new(mocks.RunManager)
-	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).
 		Once().
 		Run(func(mock.Arguments) {

--- a/core/services/subscription.go
+++ b/core/services/subscription.go
@@ -146,11 +146,12 @@ func ReceiveLogRequest(runManager RunManager, le models.LogRequest) {
 		logger.Errorw(err.Error(), le.ForLogger()...)
 		return
 	}
+	initialMeta := le.Meta()
 
-	runJob(runManager, le, data)
+	runJob(runManager, le, data, initialMeta)
 }
 
-func runJob(runManager RunManager, le models.LogRequest, data models.JSON) {
+func runJob(runManager RunManager, le models.LogRequest, data models.JSON, initialMeta models.JSON) {
 	jobSpecID := le.GetJobSpecID()
 	initiator := le.GetInitiator()
 
@@ -171,7 +172,7 @@ func runJob(runManager RunManager, le models.LogRequest, data models.JSON) {
 		return
 	}
 
-	_, err = runManager.Create(jobSpecID, &initiator, &data, le.BlockNumber(), &rr)
+	_, err = runManager.Create(jobSpecID, &initiator, &data, &initialMeta, le.BlockNumber(), &rr)
 	if err != nil {
 		logger.Errorw(err.Error(), le.ForLogger()...)
 	}

--- a/core/services/subscription_test.go
+++ b/core/services/subscription_test.go
@@ -226,7 +226,7 @@ func TestServices_StartJobSubscription(t *testing.T) {
 			executeJobChannel := make(chan struct{})
 
 			runManager := new(mocks.RunManager)
-			runManager.On("Create", job.ID, mock.Anything, mock.Anything, big.NewInt(0), mock.Anything).
+			runManager.On("Create", job.ID, mock.Anything, mock.Anything, mock.Anything, big.NewInt(0), mock.Anything).
 				Return(nil, nil).
 				Run(func(mock.Arguments) {
 					executeJobChannel <- struct{}{}
@@ -361,7 +361,7 @@ func TestServices_NewInitiatorSubscription_EthLog_ReplayFromBlock(t *testing.T) 
 			executeJobChannel := make(chan struct{})
 
 			runManager := new(mocks.RunManager)
-			runManager.On("Create", job.ID, mock.Anything, mock.Anything, big.NewInt(int64(log.BlockNumber)), mock.Anything).
+			runManager.On("Create", job.ID, mock.Anything, mock.Anything, mock.Anything, big.NewInt(int64(log.BlockNumber)), mock.Anything).
 				Return(nil, nil).
 				Run(func(mock.Arguments) {
 					executeJobChannel <- struct{}{}
@@ -424,7 +424,7 @@ func TestServices_NewInitiatorSubscription_RunLog_ReplayFromBlock(t *testing.T) 
 			executeJobChannel := make(chan struct{})
 
 			runManager := new(mocks.RunManager)
-			runManager.On("Create", job.ID, mock.Anything, mock.Anything, big.NewInt(int64(log.BlockNumber)), mock.Anything).
+			runManager.On("Create", job.ID, mock.Anything, mock.Anything, mock.Anything, big.NewInt(int64(log.BlockNumber)), mock.Anything).
 				Return(nil, nil).
 				Run(func(mock.Arguments) {
 					executeJobChannel <- struct{}{}

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -30,6 +30,7 @@ import (
 	"chainlink/core/store/migrations/migration1575036327"
 	"chainlink/core/store/migrations/migration1576022702"
 	"chainlink/core/store/migrations/migration1579700934"
+	"chainlink/core/store/migrations/migration1580290179"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -155,6 +156,10 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "migration1579700934",
 			Migrate: migration1579700934.Migrate,
+		},
+		{
+			ID:      "1580290179",
+			Migrate: migration1580290179.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration1580290179/migrate.go
+++ b/core/store/migrations/migration1580290179/migrate.go
@@ -1,0 +1,12 @@
+package migration1580290179
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate adds the 'meta' field to the run_results table
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+ALTER TABLE job_runs ADD COLUMN initial_meta text NOT NULL DEFAULT '{}';
+	`).Error
+}

--- a/core/store/models/job_run.go
+++ b/core/store/models/job_run.go
@@ -31,6 +31,7 @@ type JobRun struct {
 	CreationHeight *utils.Big   `json:"creationHeight"`
 	ObservedHeight *utils.Big   `json:"observedHeight"`
 	Overrides      JSON         `json:"overrides"`
+	InitialMeta    JSON         `json:"initialMeta" gorm:"default:'{}'"`
 	DeletedAt      null.Time    `json:"-" gorm:"index"`
 	Payment        *assets.Link `json:"payment,omitempty"`
 }

--- a/core/store/models/log_events.go
+++ b/core/store/models/log_events.go
@@ -146,6 +146,7 @@ type LogRequest interface {
 
 	Validate() bool
 	JSON() (JSON, error)
+	Meta() JSON
 	ToDebug()
 	ForLogger(kvs ...interface{}) []interface{}
 	ValidateRequester() error
@@ -252,6 +253,19 @@ func (le InitiatorLogEvent) JSON() (JSON, error) {
 		return out, err
 	}
 	return out, json.Unmarshal(b, &out)
+}
+
+// Meta returns metadata about the ethereum log event
+func (le InitiatorLogEvent) Meta() JSON {
+	el := le.Log
+	meta := make(map[string]interface{})
+	meta["initiator"] = map[string]interface{}{
+		"transactionHash": el.TxHash,
+	}
+	var out JSON
+	b, _ := json.Marshal(meta)
+	json.Unmarshal(b, &out)
+	return out
 }
 
 // EthLogEvent provides functionality specific to a log event emitted

--- a/core/store/models/log_events_test.go
+++ b/core/store/models/log_events_test.go
@@ -122,6 +122,30 @@ func TestEthLogEvent_JSON(t *testing.T) {
 	}
 }
 
+func TestEthLogEvent_Meta(t *testing.T) {
+	t.Parallel()
+
+	hwLog := cltest.LogFromFixture(t, "testdata/requestLog0original.json")
+	exampleLog := cltest.LogFromFixture(t, "testdata/subscription_logs.json")
+	tests := []struct {
+		name     string
+		el       eth.Log
+		wantMeta models.JSON
+	}{
+		{"example", exampleLog, cltest.JSONFromString(t, `{"initiator": {"transactionHash": "0xe044554a0a55067caafd07f8020ab9f2af60bdfe337e395ecd84b4877a3d1ab4"}}`)},
+		{"hello world", hwLog, cltest.JSONFromString(t, `{"initiator": {"transactionHash": "0xe05b171038320aca6634ce50de669bd0baa337130269c3ce3594ce4d45fc342a"}}`)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			initr := models.Initiator{Type: models.InitiatorEthLog}
+			le := models.InitiatorLogEvent{Initiator: initr, Log: test.el}.LogRequest()
+			meta := le.Meta()
+			assert.JSONEq(t, strings.ToLower(test.wantMeta.String()), strings.ToLower(meta.String()))
+		})
+	}
+}
+
 func TestRequestLogEvent_Validate(t *testing.T) {
 	t.Parallel()
 

--- a/core/store/models/log_events_test.go
+++ b/core/store/models/log_events_test.go
@@ -141,7 +141,7 @@ func TestEthLogEvent_Meta(t *testing.T) {
 			initr := models.Initiator{Type: models.InitiatorEthLog}
 			le := models.InitiatorLogEvent{Initiator: initr, Log: test.el}.LogRequest()
 			meta := le.Meta()
-			assert.JSONEq(t, strings.ToLower(test.wantMeta.String()), strings.ToLower(meta.String()))
+			assert.JSONEq(t, test.wantMeta.String(), meta.String())
 		})
 	}
 }

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -154,8 +154,9 @@ func TestORM_CreateJobRun_CreatesRunRequest(t *testing.T) {
 
 	rr := models.NewRunRequest()
 	data := cltest.JSONFromString(t, `{"random": "input"}`)
+	meta := cltest.JSONFromString(t, `{"random": "meta"}`)
 	currentHeight := big.NewInt(0)
-	run, _ := services.NewRun(&job, &job.Initiators[0], &data, currentHeight, rr, store.Config, store.ORM, time.Now())
+	run, _ := services.NewRun(&job, &job.Initiators[0], &data, &meta, currentHeight, rr, store.Config, store.ORM, time.Now())
 	require.NoError(t, store.CreateJobRun(run))
 
 	requestCount, err := store.ORM.CountOf(&models.RunRequest{})

--- a/core/web/job_runs_controller.go
+++ b/core/web/job_runs_controller.go
@@ -60,7 +60,7 @@ func (jrc *JobRunsController) Create(c *gin.Context) {
 		jsonAPIError(c, http.StatusForbidden, err)
 	} else if data, err := getRunData(c); err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
-	} else if jr, err := jrc.App.Create(j.ID, initiator, &data, nil, &models.RunRequest{}); errors.Cause(err) == orm.ErrorNotFound {
+	} else if jr, err := jrc.App.Create(j.ID, initiator, &data, &models.JSON{}, nil, &models.RunRequest{}); errors.Cause(err) == orm.ErrorNotFound {
 		jsonAPIError(c, http.StatusNotFound, errors.New("Job not found"))
 	} else if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)

--- a/go.sum
+++ b/go.sum
@@ -402,6 +402,7 @@ github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.1.0 h1:ElTg5tNp4DqfV7UQjDqv2+RJlNzsDtvNAWccbItceIE=
 github.com/prometheus/client_model v0.1.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.0.0-20181120120127-aeab699e26f4/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
@@ -411,6 +412,7 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.7.0 h1:L+1lyG48J1zAQXA3RBX/nG/B3gjlHq0zTt2tlbJLyCY=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
+github.com/prometheus/common v0.9.1 h1:KOMtN28tlbam3/7ZKEYKHhKoJZYYj3gMH4uc62x7X7U=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -632,6 +634,7 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f h1:68K/z8GLUxV76xGSqwTWw2gyk/jwn79LUL43rES2g8o=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -660,6 +663,7 @@ golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 h1:hKsoRgsbwY1NafxrwTs+k64
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=


### PR DESCRIPTION
This allows us to pass the ethlog txhash through to external adapters.

It is extensible and can allow for any arbitrary metadata to be assigned to job runs at initialisation.

An alternative approach to #2230 using a DB lookup instead of passing parameter everywhere.

Story is: https://www.pivotaltracker.com/story/show/170969490

This is required for the multi-node lock deposit external adapter since we must write the transaction hash into the foreign chain.