### PR TITLE
Rename 'Overrides' to 'InitialParams'

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -934,17 +934,17 @@ func TestIntegration_FluxMonitor_Deviation(t *testing.T) {
 	// Check the FM price on completed run output
 	jr := cltest.WaitForJobRunToComplete(t, app.GetStore(), jrs[0])
 
-	overrides := jr.Overrides
-	assert.Equal(t, "102", overrides.Get("result").String())
+	initialParams := jr.InitialParams
+	assert.Equal(t, "102", initialParams.Get("result").String())
 	assert.Equal(
 		t,
 		"0x3cCad4715152693fE3BC4460591e3D3Fbd071b42", // from testdata/flux_monitor_job.json
-		overrides.Get("address").String())
-	assert.Equal(t, "0xe6330cf7", overrides.Get("functionSelector").String())
+		initialParams.Get("address").String())
+	assert.Equal(t, "0xe6330cf7", initialParams.Get("functionSelector").String())
 	assert.Equal(
 		t,
 		"0x0000000000000000000000000000000000000000000000000000000000000002",
-		overrides.Get("dataPrefix").String())
+		initialParams.Get("dataPrefix").String())
 }
 
 func TestIntegration_FluxMonitor_NewRound(t *testing.T) {

--- a/core/internal/fixtures/migrations/1537223654_jobrun_without_initiator_params.json
+++ b/core/internal/fixtures/migrations/1537223654_jobrun_without_initiator_params.json
@@ -3,7 +3,9 @@
   "jobId": "1e25ad32c0f14e10b8e0da192e4023a5",
   "result": {
     "jobRunId": "0e6d6a32bb244134a074a7ec7037b049",
-    "data": { "value": "0xfd7a471722265c62bbe2eb1d61f113e0832685dc0f7f55377edc168aa823722a" },
+    "data": {
+      "value": "0xfd7a471722265c62bbe2eb1d61f113e0832685dc0f7f55377edc168aa823722a"
+    },
     "status": "completed",
     "error": null
   },
@@ -13,7 +15,9 @@
       "id": "c724da146957405983fb1c779713a21a",
       "result": {
         "jobRunId": "0e6d6a32bb244134a074a7ec7037b049",
-        "data": { "value": "{\"USD\":411.52}" },
+        "data": {
+          "value": "{\"USD\":411.52}"
+        },
         "status": "completed",
         "error": null
       },
@@ -36,5 +40,10 @@
     "address": "0x0000000000000000000000000000000000000000"
   },
   "creationHeight": "0x395b26",
-  "overrides": { "jobRunId": "", "data": { }, "status": "", "error": null }
+  "initialParams": {
+    "jobRunId": "",
+    "data": {},
+    "status": "",
+    "error": null
+  }
 }

--- a/core/services/run_executor.go
+++ b/core/services/run_executor.go
@@ -96,7 +96,7 @@ func (re *runExecutor) Execute(runID *models.ID) error {
 func (re *runExecutor) executeTask(run *models.JobRun, taskRun *models.TaskRun) models.RunOutput {
 	taskCopy := taskRun.TaskSpec // deliberately copied to keep mutations local
 
-	params, err := models.Merge(run.Overrides, taskCopy.Params)
+	params, err := models.Merge(run.InitialParams, taskCopy.Params)
 	if err != nil {
 		return models.NewRunOutputError(err)
 	}
@@ -114,7 +114,7 @@ func (re *runExecutor) executeTask(run *models.JobRun, taskRun *models.TaskRun) 
 		previousTaskInput = previousTaskRun.Result.Data
 	}
 
-	data, err := models.Merge(run.Overrides, previousTaskInput, taskRun.Result.Data)
+	data, err := models.Merge(run.InitialParams, previousTaskInput, taskRun.Result.Data)
 	if err != nil {
 		return models.NewRunOutputError(err)
 	}

--- a/core/services/run_executor_test.go
+++ b/core/services/run_executor_test.go
@@ -212,7 +212,7 @@ func TestJobRunner_prioritizeSpecParamsOverRequestParams(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: adapters.TaskTypeMultiply, Params: taskParams}}
 	assert.NoError(t, store.CreateJob(&j))
 	run := cltest.NewJobRun(j)
-	run.Overrides = cltest.JSONFromString(t, fmt.Sprintf(`{"times":%v, "result": %v}`, requestParameter, requestBase))
+	run.InitialParams = cltest.JSONFromString(t, fmt.Sprintf(`{"times":%v, "result": %v}`, requestParameter, requestBase))
 	assert.NoError(t, store.CreateJobRun(&run))
 
 	require.NoError(t, runExecutor.Execute(run.ID))

--- a/core/services/run_manager.go
+++ b/core/services/run_manager.go
@@ -120,7 +120,7 @@ func NewRun(
 		InitiatorID:    initiator.ID,
 		TaskRuns:       make([]models.TaskRun, len(job.Tasks)),
 		Status:         models.RunStatusInProgress,
-		Overrides:      *data,
+		InitialParams:  *data,
 		CreationHeight: utils.NewBig(currentHeight),
 		ObservedHeight: utils.NewBig(currentHeight),
 		RunRequest:     *runRequest,
@@ -345,11 +345,11 @@ func (rm *runManager) ResumePending(
 		return rm.updateWithError(&run, "Attempting to resume pending run with no remaining tasks %s", run.ID)
 	}
 
-	data, err := models.Merge(run.Overrides, input.Data)
+	data, err := models.Merge(run.InitialParams, input.Data)
 	if err != nil {
-		return rm.updateWithError(&run, "Error while merging onto overrides for run %s", run.ID)
+		return rm.updateWithError(&run, "Error while merging onto initialParams for run %s", run.ID)
 	}
-	run.Overrides = data
+	run.InitialParams = data
 
 	currentTaskRun.ApplyBridgeRunResult(input)
 	run.ApplyBridgeRunResult(input)

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -30,6 +30,7 @@ import (
 	"chainlink/core/store/migrations/migration1575036327"
 	"chainlink/core/store/migrations/migration1576022702"
 	"chainlink/core/store/migrations/migration1579700934"
+	"chainlink/core/store/migrations/migration1580827546"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -153,8 +154,12 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 			Migrate: migration1576022702.Migrate,
 		},
 		{
-			ID:      "migration1579700934",
+			ID:      "1579700934",
 			Migrate: migration1579700934.Migrate,
+		},
+		{
+			ID:      "1580827546",
+			Migrate: migration1580827546.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migrate_test.go
+++ b/core/store/migrations/migrate_test.go
@@ -304,7 +304,7 @@ func TestMigrate_Migration1570675883(t *testing.T) {
 
 		jobRunFound := models.JobRun{}
 		require.NoError(t, db.Where("id = ?", jobRun.ID).Find(&jobRunFound).Error)
-		assert.Equal(t, `{"a": "b"}`, jobRunFound.Overrides.String())
+		assert.Equal(t, `{"a": "b"}`, jobRunFound.InitialParams.String())
 		require.Error(t, db.Where("id = ?", overrides.ID).Find(&overrides).Error)
 		return nil
 	})

--- a/core/store/migrations/migration1580827546/migrate.go
+++ b/core/store/migrations/migration1580827546/migrate.go
@@ -1,0 +1,13 @@
+package migration1580827546
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate adds the polling_interval duration (nanoseconds) to support the Flux Monitor.
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+	  ALTER TABLE job_runs RENAME COLUMN overrides TO initial_params;
+	`).Error
+	return nil
+}

--- a/core/store/models/job_run.go
+++ b/core/store/models/job_run.go
@@ -30,7 +30,7 @@ type JobRun struct {
 	InitiatorID    uint         `json:"-"`
 	CreationHeight *utils.Big   `json:"creationHeight"`
 	ObservedHeight *utils.Big   `json:"observedHeight"`
-	Overrides      JSON         `json:"overrides"`
+	InitialParams  JSON         `json:"initialParams"`
 	DeletedAt      null.Time    `json:"-" gorm:"index"`
 	Payment        *assets.Link `json:"payment,omitempty"`
 }


### PR DESCRIPTION
At some point the meaning of 'Overrides' has changed.

It may once have referred to parameters that overrode results, but now
it means precisely the opposite of its name, i.e. parameters that are
overriden by everything else.

This name change should help to avoid future confusion for people new to the
codebase.

Story: https://www.pivotaltracker.com/story/show/170976420