### PR TITLE
migration: Fix incorrect naming of migration

### DIFF
--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -153,7 +153,7 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 			Migrate: migration1576022702.Migrate,
 		},
 		{
-			ID:      "migration1579700934",
+			ID:      "1579700934",
 			Migrate: migration1579700934.Migrate,
 		},
 	}


### PR DESCRIPTION
A migration ID was not labelled correctly, causing the migrations to be out of order.