### PR TITLE
limit rebase check to branches that need it

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -376,6 +376,11 @@ workflows:
           filters: # all branches, and /^v../ tags for build-publish...
             tags:
               only: /^v.*/
+            branches:
+              ignore:
+                - develop
+                - /^release\/.*/
+                - master
       - go-sqlite:
           filters: # all branches, and /^v../ tags for build-publish...
             tags:


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/171092714

We know `develop` is up to date and expect `master` and `release*` to be behind.