### PR TITLE
Stop JobSubscriber in tests

### DIFF
--- a/core/services/job_subscriber_test.go
+++ b/core/services/job_subscriber_test.go
@@ -24,6 +24,7 @@ func TestJobSubscriber_OnNewHead(t *testing.T) {
 
 	runManager := new(mocks.RunManager)
 	jobSubscriber := services.NewJobSubscriber(store, runManager)
+	defer jobSubscriber.Stop()
 
 	wg := sync.WaitGroup{}
 	wg.Add(1)
@@ -84,6 +85,7 @@ func TestJobSubscriber_AddJob_RemoveJob(t *testing.T) {
 
 	runManager := new(mocks.RunManager)
 	jobSubscriber := services.NewJobSubscriber(store, runManager)
+	defer jobSubscriber.Stop()
 
 	jobSpec := cltest.NewJobWithLogInitiator()
 	err := jobSubscriber.AddJob(jobSpec, cltest.Head(321))
@@ -107,6 +109,7 @@ func TestJobSubscriber_AddJob_NotLogInitiatedError(t *testing.T) {
 
 	runManager := new(mocks.RunManager)
 	jobSubscriber := services.NewJobSubscriber(store, runManager)
+	defer jobSubscriber.Stop()
 
 	job := models.JobSpec{}
 	err := jobSubscriber.AddJob(job, cltest.Head(1))
@@ -121,6 +124,7 @@ func TestJobSubscriber_RemoveJob_NotFoundError(t *testing.T) {
 
 	runManager := new(mocks.RunManager)
 	jobSubscriber := services.NewJobSubscriber(store, runManager)
+	defer jobSubscriber.Stop()
 
 	err := jobSubscriber.RemoveJob(models.NewID())
 	require.Error(t, err)
@@ -134,6 +138,7 @@ func TestJobSubscriber_Connect_Disconnect(t *testing.T) {
 
 	runManager := new(mocks.RunManager)
 	jobSubscriber := services.NewJobSubscriber(store, runManager)
+	defer jobSubscriber.Stop()
 
 	eth := cltest.MockEthOnStore(t, store)
 	eth.Register("eth_getLogs", []ethpkg.Log{})


### PR DESCRIPTION
- Fixes some DB cleanup lock errors in test suite