### PR TITLE
Expose TxHash in metadata for external adapters

### DIFF
--- a/core/adapters/bridge.go
+++ b/core/adapters/bridge.go
@@ -12,6 +12,7 @@ import (
 	"chainlink/core/store/models"
 
 	"github.com/pkg/errors"
+	"github.com/tidwall/gjson"
 )
 
 // Bridge adapter is responsible for connecting the task pipeline to external
@@ -34,10 +35,18 @@ func (ba *Bridge) Perform(input models.RunInput, store *store.Store) models.RunO
 	} else if input.Status().PendingBridge() {
 		return models.NewRunOutputInProgress(input.Data())
 	}
-	return ba.handleNewRun(input, store.Config.BridgeResponseURL())
+	jobRun, err := store.ORM.FindJobRun(input.JobRunID())
+	var meta models.JSON
+	if err == nil && jobRun.ID != nil {
+		json := fmt.Sprintf(`{"initiator":{"transactionHash":"%s"}}`, jobRun.RunRequest.TxHash.Hex())
+		meta = models.JSON{gjson.Parse(json)}
+	} else {
+		meta = models.JSON{}
+	}
+	return ba.handleNewRun(input, meta, store.Config.BridgeResponseURL())
 }
 
-func (ba *Bridge) handleNewRun(input models.RunInput, bridgeResponseURL *url.URL) models.RunOutput {
+func (ba *Bridge) handleNewRun(input models.RunInput, meta models.JSON, bridgeResponseURL *url.URL) models.RunOutput {
 	data, err := models.Merge(input.Data(), ba.Params)
 	if err != nil {
 		return models.NewRunOutputError(baRunResultError("handling data param", err))
@@ -48,7 +57,7 @@ func (ba *Bridge) handleNewRun(input models.RunInput, bridgeResponseURL *url.URL
 		responseURL.Path += fmt.Sprintf("/v2/runs/%s", input.JobRunID().String())
 	}
 
-	body, err := ba.postToExternalAdapter(input, responseURL)
+	body, err := ba.postToExternalAdapter(input, meta, responseURL)
 	if err != nil {
 		return models.NewRunOutputError(baRunResultError("post to external adapter", err))
 	}
@@ -84,13 +93,13 @@ func (ba *Bridge) responseToRunResult(body []byte, input models.RunInput) models
 	return models.NewRunOutputCompleteWithResult(brr.Data.String())
 }
 
-func (ba *Bridge) postToExternalAdapter(input models.RunInput, bridgeResponseURL *url.URL) ([]byte, error) {
+func (ba *Bridge) postToExternalAdapter(input models.RunInput, meta models.JSON, bridgeResponseURL *url.URL) ([]byte, error) {
 	data, err := models.Merge(input.Data(), ba.Params)
 	if err != nil {
 		return nil, errors.Wrap(err, "error merging bridge params with input params")
 	}
 
-	outgoing := bridgeOutgoing{JobRunID: input.JobRunID().String(), Data: data}
+	outgoing := bridgeOutgoing{JobRunID: input.JobRunID().String(), Data: data, Meta: meta}
 	if bridgeResponseURL != nil {
 		outgoing.ResponseURL = bridgeResponseURL.String()
 	}
@@ -129,6 +138,7 @@ func baRunResultError(str string, err error) error {
 type bridgeOutgoing struct {
 	JobRunID    string      `json:"id"`
 	Data        models.JSON `json:"data"`
+	Meta        models.JSON `json:"meta"`
 	ResponseURL string      `json:"responseURL,omitempty"`
 }
 

--- a/core/adapters/bridge.go
+++ b/core/adapters/bridge.go
@@ -41,20 +41,22 @@ func (ba *Bridge) Perform(input models.RunInput, store *store.Store) models.RunO
 
 func getMeta(store *store.Store, jobRunID *models.ID) *models.JSON {
 	jobRun, err := store.ORM.FindJobRun(jobRunID)
-	if err == nil && jobRun.ID != nil && jobRun.RunRequest.TxHash != nil && jobRun.RunRequest.BlockHash != nil {
-		json := fmt.Sprintf(`
-				{
-					"initiator": {
-						"transactionHash": "%s",
-						"blockHash": "%s"
-					}
-				}`,
-			jobRun.RunRequest.TxHash.Hex(),
-			jobRun.RunRequest.BlockHash.Hex(),
-		)
-		return &models.JSON{gjson.Parse(json)}
+	if err != nil {
+		return nil
+	} else if jobRun.RunRequest.TxHash == nil || jobRun.RunRequest.BlockHash == nil {
+		return nil
 	}
-	return nil
+	meta := fmt.Sprintf(`
+		{
+			"initiator": {
+				"transactionHash": "%s",
+				"blockHash": "%s"
+			}
+		}`,
+		jobRun.RunRequest.TxHash.Hex(),
+		jobRun.RunRequest.BlockHash.Hex(),
+	)
+	return &models.JSON{gjson.Parse(meta)}
 }
 
 func (ba *Bridge) handleNewRun(input models.RunInput, meta *models.JSON, bridgeResponseURL *url.URL) models.RunOutput {

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -398,6 +398,21 @@ func (ta *TestApplication) NewAuthenticatingClient(prompter cmd.Prompter) *cmd.C
 	return client
 }
 
+func (ta *TestApplication) MustCreateJobRun(txHash []byte) *models.JobRun {
+	job := NewJobWithWebInitiator()
+	err := ta.Store.CreateJob(&job)
+	require.NoError(ta.t, err)
+
+	jr := NewJobRun(job)
+	hash := common.BytesToHash(txHash)
+	jr.RunRequest.TxHash = &hash
+	err = ta.Store.CreateJobRun(&jr)
+	// panic("Does the above insert the TxHash?")
+	require.NoError(ta.t, err)
+
+	return &jr
+}
+
 // NewStoreWithConfig creates a new store with given config
 func NewStoreWithConfig(config *TestConfig) (*strpkg.Store, func()) {
 	cleanupDB := PrepareTestDB(config)

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -398,16 +398,18 @@ func (ta *TestApplication) NewAuthenticatingClient(prompter cmd.Prompter) *cmd.C
 	return client
 }
 
-func (ta *TestApplication) MustCreateJobRun(txHash []byte) *models.JobRun {
+func (ta *TestApplication) MustCreateJobRun(txHashBytes []byte, blockHashBytes []byte) *models.JobRun {
 	job := NewJobWithWebInitiator()
 	err := ta.Store.CreateJob(&job)
 	require.NoError(ta.t, err)
 
 	jr := NewJobRun(job)
-	hash := common.BytesToHash(txHash)
-	jr.RunRequest.TxHash = &hash
+	txHash := common.BytesToHash(txHashBytes)
+	jr.RunRequest.TxHash = &txHash
+	blockHash := common.BytesToHash(blockHashBytes)
+	jr.RunRequest.BlockHash = &blockHash
+
 	err = ta.Store.CreateJobRun(&jr)
-	// panic("Does the above insert the TxHash?")
 	require.NoError(ta.t, err)
 
 	return &jr

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -622,3 +622,7 @@ func NewRunInputWithResult(value interface{}) models.RunInput {
 	jobRunID := models.NewID()
 	return *models.NewRunInputWithResult(jobRunID, value, models.RunStatusUnstarted)
 }
+
+func NewRunInputWithResultAndJobRunID(value interface{}, jobRunID *models.ID) models.RunInput {
+	return *models.NewRunInputWithResult(jobRunID, value, models.RunStatusUnstarted)
+}

--- a/go.sum
+++ b/go.sum
@@ -402,6 +402,7 @@ github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.1.0 h1:ElTg5tNp4DqfV7UQjDqv2+RJlNzsDtvNAWccbItceIE=
 github.com/prometheus/client_model v0.1.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.0.0-20181120120127-aeab699e26f4/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
@@ -411,6 +412,7 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.7.0 h1:L+1lyG48J1zAQXA3RBX/nG/B3gjlHq0zTt2tlbJLyCY=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
+github.com/prometheus/common v0.9.1 h1:KOMtN28tlbam3/7ZKEYKHhKoJZYYj3gMH4uc62x7X7U=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -632,6 +634,7 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f h1:68K/z8GLUxV76xGSqwTWw2gyk/jwn79LUL43rES2g8o=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -660,6 +663,7 @@ golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 h1:hKsoRgsbwY1NafxrwTs+k64
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=


### PR DESCRIPTION
This allows us to pass the ethlog txhash through to external adapters.

An alternative approach to #2246.

Story is: https://www.pivotaltracker.com/story/show/170969490

This is required for the multi-node lock deposit external adapter since we
must write the transaction hash into the foreign chain.