### PR TITLE
FluxMonitor: Expose DeviationChecker concurrency

### DIFF
--- a/core/internal/mocks/deviation_checker.go
+++ b/core/internal/mocks/deviation_checker.go
@@ -14,18 +14,23 @@ type DeviationChecker struct {
 	mock.Mock
 }
 
-// Start provides a mock function with given fields: _a0, _a1
-func (_m *DeviationChecker) Start(_a0 context.Context, _a1 eth.Client) error {
-	ret := _m.Called(_a0, _a1)
+// Connect provides a mock function with given fields: _a0
+func (_m *DeviationChecker) Connect(_a0 eth.Client) error {
+	ret := _m.Called(_a0)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, eth.Client) error); ok {
-		r0 = rf(_a0, _a1)
+	if rf, ok := ret.Get(0).(func(eth.Client) error); ok {
+		r0 = rf(_a0)
 	} else {
 		r0 = ret.Error(0)
 	}
 
 	return r0
+}
+
+// Start provides a mock function with given fields: _a0
+func (_m *DeviationChecker) Start(_a0 context.Context) {
+	_m.Called(_a0)
 }
 
 // Stop provides a mock function with given fields:


### PR DESCRIPTION
Give the user of the DeviationChecker control over concurrency by splitting its Start(..) method into one which connects and reports errors, and a second for polling the endpoint metrics.

This is in support avoiding race conditions in upcoming tests.