### PR TITLE
Update docker-compose setup to automatically import default key on node startup

### DIFF
--- a/tools/docker/docker-compose.integration.yaml
+++ b/tools/docker/docker-compose.integration.yaml
@@ -69,7 +69,5 @@ services:
       - EXTERNAL_ADAPTER_PORT=$EXTERNAL_ADAPTER_PORT
 
   node:
-    entrypoint: ''
-    command: /bin/sh -c "chainlink node import /run/secrets/keystore && chainlink node start -d -p /run/secrets/node_password -a /run/secrets/apicredentials"
     environment:
       ALLOW_ORIGINS: http://localhost:3000,http://localhost:6688,http://integration:3000,http://integration:6688,http://node:3000,http://node:6688

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -7,7 +7,8 @@ services:
     build:
       context: ../../
       dockerfile: core/chainlink.Dockerfile
-    command: node start -d -p /run/secrets/node_password -a /run/secrets/apicredentials
+    entrypoint: ''
+    command: /bin/sh -c "chainlink node import /run/secrets/keystore && chainlink node start -d -p /run/secrets/node_password -a /run/secrets/apicredentials"
     restart: always
     environment:
       - ETH_CHAIN_ID


### PR DESCRIPTION
Currently, running `./compose up node` starts the node with a randomly generated ETH key. We have to manually add the default `0x9CA9d2D5E04012C9Ed24C0e513C9bfAa4A2dD77f` key or fund the address the node starts with in order to send txs from the node. This should speed up development and make the node function more like `cldev`.