### PR TITLE
Move Overrides to RunRequest.RequestParams

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -934,17 +934,17 @@ func TestIntegration_FluxMonitor_Deviation(t *testing.T) {
 	// Check the FM price on completed run output
 	jr := cltest.WaitForJobRunToComplete(t, app.GetStore(), jrs[0])
 
-	overrides := jr.Overrides
-	assert.Equal(t, "102", overrides.Get("result").String())
+	requestParams := jr.RunRequest.RequestParams
+	assert.Equal(t, "102", requestParams.Get("result").String())
 	assert.Equal(
 		t,
 		"0x3cCad4715152693fE3BC4460591e3D3Fbd071b42", // from testdata/flux_monitor_job.json
-		overrides.Get("address").String())
-	assert.Equal(t, "0xe6330cf7", overrides.Get("functionSelector").String())
+		requestParams.Get("address").String())
+	assert.Equal(t, "0xe6330cf7", requestParams.Get("functionSelector").String())
 	assert.Equal(
 		t,
 		"0x0000000000000000000000000000000000000000000000000000000000000002",
-		overrides.Get("dataPrefix").String())
+		requestParams.Get("dataPrefix").String())
 }
 
 func TestIntegration_FluxMonitor_NewRound(t *testing.T) {

--- a/core/internal/mocks/application.go
+++ b/core/internal/mocks/application.go
@@ -85,13 +85,13 @@ func (_m *Application) Cancel(runID *models.ID) (*models.JobRun, error) {
 	return r0, r1
 }
 
-// Create provides a mock function with given fields: jobSpecID, initiator, data, creationHeight, runRequest
-func (_m *Application) Create(jobSpecID *models.ID, initiator *models.Initiator, data *models.JSON, creationHeight *big.Int, runRequest *models.RunRequest) (*models.JobRun, error) {
-	ret := _m.Called(jobSpecID, initiator, data, creationHeight, runRequest)
+// Create provides a mock function with given fields: jobSpecID, initiator, creationHeight, runRequest
+func (_m *Application) Create(jobSpecID *models.ID, initiator *models.Initiator, creationHeight *big.Int, runRequest *models.RunRequest) (*models.JobRun, error) {
+	ret := _m.Called(jobSpecID, initiator, creationHeight, runRequest)
 
 	var r0 *models.JobRun
-	if rf, ok := ret.Get(0).(func(*models.ID, *models.Initiator, *models.JSON, *big.Int, *models.RunRequest) *models.JobRun); ok {
-		r0 = rf(jobSpecID, initiator, data, creationHeight, runRequest)
+	if rf, ok := ret.Get(0).(func(*models.ID, *models.Initiator, *big.Int, *models.RunRequest) *models.JobRun); ok {
+		r0 = rf(jobSpecID, initiator, creationHeight, runRequest)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.JobRun)
@@ -99,8 +99,8 @@ func (_m *Application) Create(jobSpecID *models.ID, initiator *models.Initiator,
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*models.ID, *models.Initiator, *models.JSON, *big.Int, *models.RunRequest) error); ok {
-		r1 = rf(jobSpecID, initiator, data, creationHeight, runRequest)
+	if rf, ok := ret.Get(1).(func(*models.ID, *models.Initiator, *big.Int, *models.RunRequest) error); ok {
+		r1 = rf(jobSpecID, initiator, creationHeight, runRequest)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/internal/mocks/job_subscriber.go
+++ b/core/internal/mocks/job_subscriber.go
@@ -81,6 +81,20 @@ func (_m *JobSubscriber) RemoveJob(ID *models.ID) error {
 	return r0
 }
 
+// Start provides a mock function with given fields:
+func (_m *JobSubscriber) Start() error {
+	ret := _m.Called()
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Stop provides a mock function with given fields:
 func (_m *JobSubscriber) Stop() error {
 	ret := _m.Called()

--- a/core/internal/mocks/run_manager.go
+++ b/core/internal/mocks/run_manager.go
@@ -37,13 +37,13 @@ func (_m *RunManager) Cancel(runID *models.ID) (*models.JobRun, error) {
 	return r0, r1
 }
 
-// Create provides a mock function with given fields: jobSpecID, initiator, data, creationHeight, runRequest
-func (_m *RunManager) Create(jobSpecID *models.ID, initiator *models.Initiator, data *models.JSON, creationHeight *big.Int, runRequest *models.RunRequest) (*models.JobRun, error) {
-	ret := _m.Called(jobSpecID, initiator, data, creationHeight, runRequest)
+// Create provides a mock function with given fields: jobSpecID, initiator, creationHeight, runRequest
+func (_m *RunManager) Create(jobSpecID *models.ID, initiator *models.Initiator, creationHeight *big.Int, runRequest *models.RunRequest) (*models.JobRun, error) {
+	ret := _m.Called(jobSpecID, initiator, creationHeight, runRequest)
 
 	var r0 *models.JobRun
-	if rf, ok := ret.Get(0).(func(*models.ID, *models.Initiator, *models.JSON, *big.Int, *models.RunRequest) *models.JobRun); ok {
-		r0 = rf(jobSpecID, initiator, data, creationHeight, runRequest)
+	if rf, ok := ret.Get(0).(func(*models.ID, *models.Initiator, *big.Int, *models.RunRequest) *models.JobRun); ok {
+		r0 = rf(jobSpecID, initiator, creationHeight, runRequest)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*models.JobRun)
@@ -51,8 +51,8 @@ func (_m *RunManager) Create(jobSpecID *models.ID, initiator *models.Initiator, 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(*models.ID, *models.Initiator, *models.JSON, *big.Int, *models.RunRequest) error); ok {
-		r1 = rf(jobSpecID, initiator, data, creationHeight, runRequest)
+	if rf, ok := ret.Get(1).(func(*models.ID, *models.Initiator, *big.Int, *models.RunRequest) error); ok {
+		r1 = rf(jobSpecID, initiator, creationHeight, runRequest)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/flux_monitor.go
+++ b/core/services/flux_monitor.go
@@ -476,8 +476,7 @@ func (p *PollingDeviationChecker) createJobRun(nextPrice decimal.Decimal, nextRo
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("unable to start chainlink run with payload %s", payload))
 	}
-	runRequest := models.NewRunRequest()
-	runRequest.RequestParams = runData
+	runRequest := models.NewRunRequest(runData)
 
 	_, err = p.runManager.Create(p.initr.JobSpecID, &p.initr, nil, runRequest)
 	return err

--- a/core/services/flux_monitor.go
+++ b/core/services/flux_monitor.go
@@ -476,7 +476,10 @@ func (p *PollingDeviationChecker) createJobRun(nextPrice decimal.Decimal, nextRo
 	if err != nil {
 		return errors.Wrap(err, fmt.Sprintf("unable to start chainlink run with payload %s", payload))
 	}
-	_, err = p.runManager.Create(p.initr.JobSpecID, &p.initr, &runData, nil, models.NewRunRequest())
+	runRequest := models.NewRunRequest()
+	runRequest.RequestParams = runData
+
+	_, err = p.runManager.Create(p.initr.JobSpecID, &p.initr, nil, runRequest)
 	return err
 }
 

--- a/core/services/run_executor.go
+++ b/core/services/run_executor.go
@@ -96,7 +96,7 @@ func (re *runExecutor) Execute(runID *models.ID) error {
 func (re *runExecutor) executeTask(run *models.JobRun, taskRun *models.TaskRun) models.RunOutput {
 	taskCopy := taskRun.TaskSpec // deliberately copied to keep mutations local
 
-	params, err := models.Merge(run.Overrides, taskCopy.Params)
+	params, err := models.Merge(run.RunRequest.RequestParams, taskCopy.Params)
 	if err != nil {
 		return models.NewRunOutputError(err)
 	}
@@ -114,7 +114,7 @@ func (re *runExecutor) executeTask(run *models.JobRun, taskRun *models.TaskRun) 
 		previousTaskInput = previousTaskRun.Result.Data
 	}
 
-	data, err := models.Merge(run.Overrides, previousTaskInput, taskRun.Result.Data)
+	data, err := models.Merge(run.RunRequest.RequestParams, previousTaskInput, taskRun.Result.Data)
 	if err != nil {
 		return models.NewRunOutputError(err)
 	}

--- a/core/services/run_executor_test.go
+++ b/core/services/run_executor_test.go
@@ -212,7 +212,7 @@ func TestJobRunner_prioritizeSpecParamsOverRequestParams(t *testing.T) {
 	j.Tasks = []models.TaskSpec{{Type: adapters.TaskTypeMultiply, Params: taskParams}}
 	assert.NoError(t, store.CreateJob(&j))
 	run := cltest.NewJobRun(j)
-	run.Overrides = cltest.JSONFromString(t, fmt.Sprintf(`{"times":%v, "result": %v}`, requestParameter, requestBase))
+	run.RunRequest.RequestParams = cltest.JSONFromString(t, fmt.Sprintf(`{"times":%v, "result": %v}`, requestParameter, requestBase))
 	assert.NoError(t, store.CreateJobRun(&run))
 
 	require.NoError(t, runExecutor.Execute(run.ID))

--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -307,8 +307,8 @@ func TestRunManager_Create(t *testing.T) {
 	initiator := job.Initiators[0]
 	rr := models.NewRunRequest()
 	rr.RequestID = &requestID
-	data := cltest.JSONFromString(t, `{"random": "input"}`)
-	jr, err := app.RunManager.Create(job.ID, &initiator, &data, nil, rr)
+	rr.RequestParams = cltest.JSONFromString(t, `{"random": "input"}`)
+	jr, err := app.RunManager.Create(job.ID, &initiator, nil, rr)
 	require.NoError(t, err)
 	updatedJR := cltest.WaitForJobRunToComplete(t, store, *jr)
 	assert.Equal(t, rr.RequestID, updatedJR.RunRequest.RequestID)
@@ -331,7 +331,8 @@ func TestRunManager_Create_DoesNotSaveToTaskSpec(t *testing.T) {
 
 	initiator := job.Initiators[0]
 	data := cltest.JSONFromString(t, `{"random": "input"}`)
-	jr, err := app.RunManager.Create(job.ID, &initiator, &data, nil, &models.RunRequest{})
+	rr := &models.RunRequest{RequestParams: data}
+	jr, err := app.RunManager.Create(job.ID, &initiator, nil, rr)
 	require.NoError(t, err)
 	cltest.WaitForJobRunToComplete(t, store, *jr)
 
@@ -397,8 +398,8 @@ func TestRunManager_Create_fromRunLog_Happy(t *testing.T) {
 			rr.RequestID = &requestID
 			rr.TxHash = &initiatingTxHash
 			rr.BlockHash = &test.logBlockHash
-			data := cltest.JSONFromString(t, `{"random": "input"}`)
-			jr, err := app.RunManager.Create(job.ID, &initiator, &data, creationHeight, rr)
+			rr.RequestParams = cltest.JSONFromString(t, `{"random": "input"}`)
+			jr, err := app.RunManager.Create(job.ID, &initiator, creationHeight, rr)
 			require.NoError(t, err)
 
 			run := cltest.WaitForJobRunToPendConfirmations(t, app.Store, *jr)
@@ -645,13 +646,13 @@ func TestRunManager_Create_fromRunLogPayments(t *testing.T) {
 			require.NoError(t, store.CreateJob(&job))
 			initiator := job.Initiators[0]
 
-			data := cltest.JSONFromString(t, `{"random": "input"}`)
 			creationHeight := big.NewInt(1)
 
 			runRequest := models.NewRunRequest()
 			runRequest.Payment = test.inputPayment
+			runRequest.RequestParams = cltest.JSONFromString(t, `{"random": "input"}`)
 
-			run, err := app.RunManager.Create(job.ID, &initiator, &data, creationHeight, runRequest)
+			run, err := app.RunManager.Create(job.ID, &initiator, creationHeight, runRequest)
 			require.NoError(t, err)
 
 			assert.Equal(t, test.jobStatus, run.Status)
@@ -690,8 +691,8 @@ func TestRunManager_Create_fromRunLog_ConnectToLaggingEthNode(t *testing.T) {
 	futureCreationHeight := big.NewInt(9)
 	pastCurrentHeight := big.NewInt(1)
 
-	data := cltest.JSONFromString(t, `{"random": "input"}`)
-	jr, err := app.RunManager.Create(job.ID, &initiator, &data, futureCreationHeight, rr)
+	rr.RequestParams = cltest.JSONFromString(t, `{"random": "input"}`)
+	jr, err := app.RunManager.Create(job.ID, &initiator, futureCreationHeight, rr)
 	require.NoError(t, err)
 	cltest.WaitForJobRunToPendConfirmations(t, app.Store, *jr)
 

--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -305,7 +305,7 @@ func TestRunManager_Create(t *testing.T) {
 
 	requestID := "RequestID"
 	initiator := job.Initiators[0]
-	rr := models.NewRunRequest()
+	rr := models.NewRunRequest(models.JSON{})
 	rr.RequestID = &requestID
 	rr.RequestParams = cltest.JSONFromString(t, `{"random": "input"}`)
 	jr, err := app.RunManager.Create(job.ID, &initiator, nil, rr)
@@ -394,7 +394,7 @@ func TestRunManager_Create_fromRunLog_Happy(t *testing.T) {
 			creationHeight := big.NewInt(1)
 			requestID := "RequestID"
 			initiator := job.Initiators[0]
-			rr := models.NewRunRequest()
+			rr := models.NewRunRequest(models.JSON{})
 			rr.RequestID = &requestID
 			rr.TxHash = &initiatingTxHash
 			rr.BlockHash = &test.logBlockHash
@@ -648,7 +648,7 @@ func TestRunManager_Create_fromRunLogPayments(t *testing.T) {
 
 			creationHeight := big.NewInt(1)
 
-			runRequest := models.NewRunRequest()
+			runRequest := models.NewRunRequest(models.JSON{})
 			runRequest.Payment = test.inputPayment
 			runRequest.RequestParams = cltest.JSONFromString(t, `{"random": "input"}`)
 
@@ -683,7 +683,7 @@ func TestRunManager_Create_fromRunLog_ConnectToLaggingEthNode(t *testing.T) {
 
 	requestID := "RequestID"
 	initiator := job.Initiators[0]
-	rr := models.NewRunRequest()
+	rr := models.NewRunRequest(models.JSON{})
 	rr.RequestID = &requestID
 	rr.TxHash = &initiatingTxHash
 	rr.BlockHash = &triggeringBlockHash

--- a/core/services/scheduler.go
+++ b/core/services/scheduler.go
@@ -131,7 +131,7 @@ func (r *Recurring) AddJob(job models.JobSpec) {
 				return
 			}
 
-			_, err := r.runManager.Create(job.ID, &initr, &models.JSON{}, nil, &models.RunRequest{})
+			_, err := r.runManager.Create(job.ID, &initr, nil, &models.RunRequest{})
 			if err != nil && !ExpectedRecurringScheduleJobError(err) {
 				logger.Errorw(err.Error())
 			}
@@ -181,7 +181,7 @@ func (ot *OneTime) RunJobAt(initiator models.Initiator, job models.JobSpec) {
 			return
 		}
 
-		_, err := ot.RunManager.Create(job.ID, &initiator, &models.JSON{}, nil, &models.RunRequest{})
+		_, err := ot.RunManager.Create(job.ID, &initiator, nil, &models.RunRequest{})
 		if err != nil && !ExpectedRecurringScheduleJobError(err) {
 			logger.Error(err.Error())
 			return

--- a/core/services/scheduler_test.go
+++ b/core/services/scheduler_test.go
@@ -28,7 +28,7 @@ func TestScheduler_Start_LoadingRecurringJobs(t *testing.T) {
 
 	executeJobChannel := make(chan struct{})
 	runManager := new(mocks.RunManager)
-	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).
 		Twice().
 		Run(func(mock.Arguments) {
@@ -51,7 +51,7 @@ func TestScheduler_Start_LoadingRecurringJobs(t *testing.T) {
 func TestRecurring_AddJob(t *testing.T) {
 	executeJobChannel := make(chan struct{}, 1)
 	runManager := new(mocks.RunManager)
-	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).
 		Run(func(mock.Arguments) {
 			executeJobChannel <- struct{}{}
@@ -138,7 +138,7 @@ func TestOneTime_AddJob(t *testing.T) {
 
 	executeJobChannel := make(chan struct{})
 	runManager := new(mocks.RunManager)
-	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+	runManager.On("Create", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
 		Return(nil, nil).
 		Once().
 		Run(func(mock.Arguments) {

--- a/core/services/subscription.go
+++ b/core/services/subscription.go
@@ -141,16 +141,12 @@ func ReceiveLogRequest(runManager RunManager, le models.LogRequest) {
 	}
 
 	le.ToDebug()
-	data, err := le.JSON()
-	if err != nil {
-		logger.Errorw(err.Error(), le.ForLogger()...)
-		return
-	}
 
-	runJob(runManager, le, data)
+	runJob(runManager, le)
+
 }
 
-func runJob(runManager RunManager, le models.LogRequest, data models.JSON) {
+func runJob(runManager RunManager, le models.LogRequest) {
 	jobSpecID := le.GetJobSpecID()
 	initiator := le.GetInitiator()
 
@@ -171,7 +167,7 @@ func runJob(runManager RunManager, le models.LogRequest, data models.JSON) {
 		return
 	}
 
-	_, err = runManager.Create(jobSpecID, &initiator, &data, le.BlockNumber(), &rr)
+	_, err = runManager.Create(jobSpecID, &initiator, le.BlockNumber(), &rr)
 	if err != nil {
 		logger.Errorw(err.Error(), le.ForLogger()...)
 	}

--- a/core/services/subscription_test.go
+++ b/core/services/subscription_test.go
@@ -226,7 +226,7 @@ func TestServices_StartJobSubscription(t *testing.T) {
 			executeJobChannel := make(chan struct{})
 
 			runManager := new(mocks.RunManager)
-			runManager.On("Create", job.ID, mock.Anything, mock.Anything, big.NewInt(0), mock.Anything).
+			runManager.On("Create", job.ID, mock.Anything, big.NewInt(0), mock.Anything).
 				Return(nil, nil).
 				Run(func(mock.Arguments) {
 					executeJobChannel <- struct{}{}
@@ -292,6 +292,8 @@ func TestServices_StartJobSubscription_RunlogNoTopicMatch(t *testing.T) {
 			require.NoError(t, store.CreateJob(&job))
 
 			runManager := new(mocks.RunManager)
+			runManager.On("CreateErrored", mock.Anything, mock.Anything, mock.Anything).
+				Return(nil, nil)
 
 			subscription, err := services.StartJobSubscription(job, cltest.Head(91), store, runManager)
 			require.NoError(t, err)
@@ -308,7 +310,6 @@ func TestServices_StartJobSubscription_RunlogNoTopicMatch(t *testing.T) {
 				},
 			}
 
-			runManager.AssertExpectations(t)
 			eth.EventuallyAllCalled(t)
 		})
 	}
@@ -361,7 +362,7 @@ func TestServices_NewInitiatorSubscription_EthLog_ReplayFromBlock(t *testing.T) 
 			executeJobChannel := make(chan struct{})
 
 			runManager := new(mocks.RunManager)
-			runManager.On("Create", job.ID, mock.Anything, mock.Anything, big.NewInt(int64(log.BlockNumber)), mock.Anything).
+			runManager.On("Create", job.ID, mock.Anything, big.NewInt(int64(log.BlockNumber)), mock.Anything).
 				Return(nil, nil).
 				Run(func(mock.Arguments) {
 					executeJobChannel <- struct{}{}
@@ -424,7 +425,7 @@ func TestServices_NewInitiatorSubscription_RunLog_ReplayFromBlock(t *testing.T) 
 			executeJobChannel := make(chan struct{})
 
 			runManager := new(mocks.RunManager)
-			runManager.On("Create", job.ID, mock.Anything, mock.Anything, big.NewInt(int64(log.BlockNumber)), mock.Anything).
+			runManager.On("Create", job.ID, mock.Anything, big.NewInt(int64(log.BlockNumber)), mock.Anything).
 				Return(nil, nil).
 				Run(func(mock.Arguments) {
 					executeJobChannel <- struct{}{}

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -30,6 +30,7 @@ import (
 	"chainlink/core/store/migrations/migration1575036327"
 	"chainlink/core/store/migrations/migration1576022702"
 	"chainlink/core/store/migrations/migration1579700934"
+	"chainlink/core/store/migrations/migration1581240419"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -155,6 +156,10 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "1579700934",
 			Migrate: migration1579700934.Migrate,
+		},
+		{
+			ID:      "1581240419",
+			Migrate: migration1581240419.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migrate_test.go
+++ b/core/store/migrations/migrate_test.go
@@ -12,6 +12,7 @@ import (
 	"chainlink/core/store/migrations"
 	"chainlink/core/store/migrations/migration0"
 	"chainlink/core/store/migrations/migration1560881855"
+	"chainlink/core/store/migrations/migration1570675883"
 	"chainlink/core/store/models"
 	"chainlink/core/store/orm"
 	"chainlink/core/utils"
@@ -302,7 +303,7 @@ func TestMigrate_Migration1570675883(t *testing.T) {
 
 		require.NoError(t, migrations.MigrateTo(db, "1570675883"))
 
-		jobRunFound := models.JobRun{}
+		jobRunFound := migration1570675883.JobRun{}
 		require.NoError(t, db.Where("id = ?", jobRun.ID).Find(&jobRunFound).Error)
 		assert.Equal(t, `{"a": "b"}`, jobRunFound.Overrides.String())
 		require.Error(t, db.Where("id = ?", overrides.ID).Find(&overrides).Error)

--- a/core/store/migrations/migration1570675883/migrate.go
+++ b/core/store/migrations/migration1570675883/migrate.go
@@ -2,7 +2,17 @@ package migration1570675883
 
 import (
 	"github.com/jinzhu/gorm"
+	"chainlink/core/store/models"
 )
+
+type JobRun struct {
+	models.JobRun
+	Overrides models.JSON
+}
+
+func (JobRun) TableName() string {
+	return "job_runs"
+}
 
 func Migrate(tx *gorm.DB) error {
 	return tx.Exec(`

--- a/core/store/migrations/migration1581240419/migrate.go
+++ b/core/store/migrations/migration1581240419/migrate.go
@@ -1,0 +1,39 @@
+package migration1581240419
+
+import (
+	"chainlink/core/store/dbutil"
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate moves job_runs.overrides to run_requets.request_params
+func Migrate(tx *gorm.DB) error {
+	err := tx.Exec(`ALTER TABLE run_requests ADD request_params text NOT NULL DEFAULT '{}'`).Error
+	if err != nil {
+		return err
+	}
+	if dbutil.IsPostgres(tx) {
+		err = tx.Exec(`
+			UPDATE run_requests
+			SET request_params = job_runs.overrides
+			FROM job_runs
+			WHERE job_runs.run_request_id = run_requests.id AND job_runs.overrides IS NOT NULL
+		`).Error
+	} else {
+		// WARNING: This is slow on Sqlite since there is no index on job_runs.run_request_id
+		err = tx.Exec(`
+			UPDATE run_requests
+			SET request_params = COALESCE((
+				SELECT overrides
+				FROM job_runs
+				WHERE run_request_id = run_requests.id
+			), '{}')
+		`).Error
+	}
+	if err != nil {
+		return err
+	}
+	if dbutil.IsPostgres(tx) {
+		return tx.Exec(`ALTER TABLE job_runs DROP COLUMN IF EXISTS overrides`).Error
+	}
+	return nil
+}

--- a/core/store/migrations/migration1581240419/migrate.go
+++ b/core/store/migrations/migration1581240419/migrate.go
@@ -5,7 +5,7 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
-// Migrate moves job_runs.overrides to run_requets.request_params
+// Migrate moves job_runs.overrides to run_requests.request_params
 func Migrate(tx *gorm.DB) error {
 	err := tx.Exec(`ALTER TABLE run_requests ADD request_params text NOT NULL DEFAULT '{}'`).Error
 	if err != nil {

--- a/core/store/models/job_run.go
+++ b/core/store/models/job_run.go
@@ -30,7 +30,6 @@ type JobRun struct {
 	InitiatorID    uint         `json:"-"`
 	CreationHeight *utils.Big   `json:"creationHeight"`
 	ObservedHeight *utils.Big   `json:"observedHeight"`
-	Overrides      JSON         `json:"overrides"`
 	DeletedAt      null.Time    `json:"-" gorm:"index"`
 	Payment        *assets.Link `json:"payment,omitempty"`
 }
@@ -173,13 +172,14 @@ func (jr *JobRun) ErrorString() string {
 
 // RunRequest stores the fields used to initiate the parent job run.
 type RunRequest struct {
-	ID        uint `gorm:"primary_key"`
-	RequestID *string
-	TxHash    *common.Hash
-	BlockHash *common.Hash
-	Requester *common.Address
-	CreatedAt time.Time
-	Payment   *assets.Link
+	ID            uint `gorm:"primary_key"`
+	RequestID     *string
+	TxHash        *common.Hash
+	BlockHash     *common.Hash
+	Requester     *common.Address
+	CreatedAt     time.Time
+	Payment       *assets.Link
+	RequestParams JSON `gorm:"default: '{}';not null"`
 }
 
 // NewRunRequest returns a new RunRequest instance.

--- a/core/store/models/job_run.go
+++ b/core/store/models/job_run.go
@@ -183,8 +183,8 @@ type RunRequest struct {
 }
 
 // NewRunRequest returns a new RunRequest instance.
-func NewRunRequest() *RunRequest {
-	return &RunRequest{CreatedAt: time.Now()}
+func NewRunRequest(requestParams JSON) *RunRequest {
+	return &RunRequest{CreatedAt: time.Now(), RequestParams: requestParams}
 }
 
 // TaskRun stores the Task and represents the status of the

--- a/core/store/models/log_events.go
+++ b/core/store/models/log_events.go
@@ -227,9 +227,15 @@ func (le InitiatorLogEvent) BlockNumber() *big.Int {
 func (le InitiatorLogEvent) RunRequest() (RunRequest, error) {
 	txHash := common.BytesToHash(le.Log.TxHash.Bytes())
 	blockHash := common.BytesToHash(le.Log.BlockHash.Bytes())
+
+	requestParams, err := le.JSON()
+	if err != nil {
+		return RunRequest{}, err
+	}
 	return RunRequest{
-		BlockHash: &blockHash,
-		TxHash:    &txHash,
+		BlockHash:     &blockHash,
+		TxHash:        &txHash,
+		RequestParams: requestParams,
 	}, nil
 }
 
@@ -338,6 +344,12 @@ func (le RunLogEvent) Requester() common.Address {
 // RunRequest returns an RunRequest instance with all parameters
 // from a run log topic, like RequestID.
 func (le RunLogEvent) RunRequest() (RunRequest, error) {
+	requestParams, err := le.JSON()
+	if err != nil {
+		logger.Errorw(err.Error(), le.ForLogger()...)
+		return RunRequest{}, err
+	}
+
 	parser, err := parserFromLog(le.Log)
 	if err != nil {
 		return RunRequest{}, err
@@ -352,12 +364,14 @@ func (le RunLogEvent) RunRequest() (RunRequest, error) {
 	blockHash := common.BytesToHash(le.Log.BlockHash.Bytes())
 	str := parser.parseRequestID(le.Log)
 	requester := le.Requester()
+
 	return RunRequest{
-		RequestID: &str,
-		TxHash:    &txHash,
-		BlockHash: &blockHash,
-		Requester: &requester,
-		Payment:   payment,
+		RequestID:     &str,
+		TxHash:        &txHash,
+		BlockHash:     &blockHash,
+		Requester:     &requester,
+		Payment:       payment,
+		RequestParams: requestParams,
 	}, nil
 }
 

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -153,9 +153,8 @@ func TestORM_CreateJobRun_CreatesRunRequest(t *testing.T) {
 	require.NoError(t, store.CreateJob(&job))
 
 	rr := models.NewRunRequest()
-	data := cltest.JSONFromString(t, `{"random": "input"}`)
 	currentHeight := big.NewInt(0)
-	run, _ := services.NewRun(&job, &job.Initiators[0], &data, currentHeight, rr, store.Config, store.ORM, time.Now())
+	run, _ := services.NewRun(&job, &job.Initiators[0], currentHeight, rr, store.Config, store.ORM, time.Now())
 	require.NoError(t, store.CreateJobRun(run))
 
 	requestCount, err := store.ORM.CountOf(&models.RunRequest{})

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -152,7 +152,7 @@ func TestORM_CreateJobRun_CreatesRunRequest(t *testing.T) {
 	job := cltest.NewJobWithWebInitiator()
 	require.NoError(t, store.CreateJob(&job))
 
-	rr := models.NewRunRequest()
+	rr := models.NewRunRequest(models.JSON{})
 	currentHeight := big.NewInt(0)
 	run, _ := services.NewRun(&job, &job.Initiators[0], currentHeight, rr, store.Config, store.ORM, time.Now())
 	require.NoError(t, store.CreateJobRun(run))

--- a/core/web/job_runs_controller.go
+++ b/core/web/job_runs_controller.go
@@ -82,7 +82,7 @@ func (jrc *JobRunsController) Create(c *gin.Context) {
 		return
 	}
 
-	jr, err := jrc.App.Create(j.ID, initiator, &data, nil, &models.RunRequest{})
+	jr, err := jrc.App.Create(j.ID, initiator, nil, &models.RunRequest{RequestParams: data})
 	if errors.Cause(err) == orm.ErrorNotFound {
 		jsonAPIError(c, http.StatusNotFound, errors.New("Job not found"))
 		return


### PR DESCRIPTION
At some point the meaning of 'Overrides' has changed.

It may once have referred to parameters that overrode results, but now
it means precisely the opposite of its name, i.e. parameters that are
overriden by everything else.

This name change should help to avoid future confusion for people new to the
codebase.

In addition, Steve made the suggestion that it makes more sense for this data to live on `run_requests`.

Story: https://www.pivotaltracker.com/story/show/170976420