### PR TITLE
update PrepaidAggregator to use Solidity v0.6

### DIFF
--- a/core/eth/client.go
+++ b/core/eth/client.go
@@ -145,7 +145,7 @@ func newDecimalFromString(arg string) (decimal.Decimal, error) {
 
 // GetAggregatorPrice returns the current price at the given address.
 func (client *CallerSubscriberClient) GetAggregatorPrice(address common.Address, precision int32) (decimal.Decimal, error) {
-	aggregator, err := GetV5Contract(PrepaidAggregatorName)
+	aggregator, err := GetV6Contract(PrepaidAggregatorName)
 	if err != nil {
 		return decimal.Decimal{}, errors.Wrap(err, "unable to get contract "+PrepaidAggregatorName)
 	}
@@ -173,7 +173,7 @@ func (client *CallerSubscriberClient) GetAggregatorPrice(address common.Address,
 
 // GetAggregatorRound returns the latest round at the given address.
 func (client *CallerSubscriberClient) GetAggregatorRound(address common.Address) (*big.Int, error) {
-	aggregator, err := GetV5Contract(PrepaidAggregatorName)
+	aggregator, err := GetV6Contract(PrepaidAggregatorName)
 	if err != nil {
 		return nil, errors.Wrap(err, "unable to get contract "+PrepaidAggregatorName)
 	}

--- a/core/eth/contracts.go
+++ b/core/eth/contracts.go
@@ -43,14 +43,14 @@ func GetContract(name string) (*Contract, error) {
 	return getContract(name, box)
 }
 
-// GetAdvancedContract loads the contract JSON file from ../../evm-contracts/abi/v0.5
+// GetV6Contract loads the contract JSON file from ../../evm-contracts/abi/v0.6
 // and parses the ABI JSON contents into an abi.ABI object
 //
 // NB: These contracts can be built by running
 //    yarn setup:contracts
 // in the base project directory.
-func GetV5Contract(name string) (*Contract, error) {
-	box := packr.NewBox("../../evm-contracts/abi/v0.5")
+func GetV6Contract(name string) (*Contract, error) {
+	box := packr.NewBox("../../evm-contracts/abi/v0.6")
 	return getContract(name, box)
 }
 
@@ -78,10 +78,10 @@ func (contract *Contract) GetMethodID(method string) ([]byte, error) {
 	return mabi.ID(), nil
 }
 
-// MustGetV5ContractEventID finds the event for the given contract by searching
+// MustGetV6ContractEventID finds the event for the given contract by searching
 // embedded contract assets from evm/, or panics if not found.
-func MustGetV5ContractEventID(name, eventName string) common.Hash {
-	contract, err := GetV5Contract(name)
+func MustGetV6ContractEventID(name, eventName string) common.Hash {
+	contract, err := GetV6Contract(name)
 	if err != nil {
 		logger.Panic(fmt.Errorf("unable to find contract %s", name))
 	}

--- a/core/services/flux_monitor.go
+++ b/core/services/flux_monitor.go
@@ -455,7 +455,7 @@ func (p *PollingDeviationChecker) fetchPrices() (decimal.Decimal, error) {
 }
 
 func (p *PollingDeviationChecker) createJobRun(nextPrice decimal.Decimal, nextRound *big.Int) error {
-	aggregatorContract, err := eth.GetV5Contract(eth.PrepaidAggregatorName)
+	aggregatorContract, err := eth.GetV6Contract(eth.PrepaidAggregatorName)
 	if err != nil {
 		return err
 	}

--- a/core/store/models/log_events.go
+++ b/core/store/models/log_events.go
@@ -67,7 +67,7 @@ var (
 	OracleFulfillmentFunctionID20190128withoutCast = utils.MustHash("fulfillOracleRequest(bytes32,uint256,address,bytes4,uint256,bytes32)").Hex()[:10]
 	// AggregatorNewRoundLogTopic20191220 is the NewRound filter topic for
 	// the PrepaidAggregator as of Dec. 20th 2019. Eagerly fails if not found.
-	AggregatorNewRoundLogTopic20191220 = eth.MustGetV5ContractEventID("PrepaidAggregator", "NewRound")
+	AggregatorNewRoundLogTopic20191220 = eth.MustGetV6ContractEventID("PrepaidAggregator", "NewRound")
 )
 
 type logRequestParser interface {

--- a/evm-contracts/src/v0.6/Median.sol
+++ b/evm-contracts/src/v0.6/Median.sol
@@ -1,0 +1,108 @@
+pragma solidity ^0.6.2;
+
+import "./vendor/SafeMath.sol";
+import "./vendor/SignedSafeMath.sol";
+
+library Median {
+  using SafeMath for uint256;
+  using SignedSafeMath for int256;
+
+  /**
+   * @dev Returns the sorted middle, or the average of the two middle indexed 
+   * items if the array has an even number of elements
+   * @param _list The list of elements to compare
+   */
+  function calculate(int256[] memory _list)
+    internal
+    pure
+    returns (int256)
+  {
+    uint256 answerLength = _list.length;
+    uint256 middleIndex = answerLength.div(2);
+    if (answerLength % 2 == 0) {
+      int256 median1 = quickselect(copy(_list), middleIndex);
+      int256 median2 = quickselect(_list, middleIndex.add(1)); // quickselect is 1 indexed
+      int256 remainder = (median1 % 2 + median2 % 2) / 2;
+      return (median1 / 2).add(median2 / 2).add(remainder); // signed integers are not supported by SafeMath
+    } else {
+      return quickselect(_list, middleIndex.add(1)); // quickselect is 1 indexed
+    }
+  }
+
+  /**
+   * @dev Returns the kth value of the ordered array
+   * See: http://www.cs.yale.edu/homes/aspnes/pinewiki/QuickSelect.html
+   * @param _a The list of elements to pull from
+   * @param _k The index, 1 based, of the elements you want to pull from when ordered
+   */
+  function quickselect(int256[] memory _a, uint256 _k)
+    private
+    pure
+    returns (int256)
+  {
+    int256[] memory a = _a;
+    uint256 k = _k;
+    uint256 aLen = a.length;
+    int256[] memory a1 = new int256[](aLen);
+    int256[] memory a2 = new int256[](aLen);
+    uint256 a1Len;
+    uint256 a2Len;
+    int256 pivot;
+    uint256 i;
+
+    while (true) {
+      pivot = a[aLen.div(2)];
+      a1Len = 0;
+      a2Len = 0;
+      for (i = 0; i < aLen; i++) {
+        if (a[i] < pivot) {
+          a1[a1Len] = a[i];
+          a1Len++;
+        } else if (a[i] > pivot) {
+          a2[a2Len] = a[i];
+          a2Len++;
+        }
+      }
+      if (k <= a1Len) {
+        aLen = a1Len;
+        (a, a1) = swap(a, a1);
+      } else if (k > (aLen.sub(a2Len))) {
+        k = k.sub(aLen.sub(a2Len));
+        aLen = a2Len;
+        (a, a2) = swap(a, a2);
+      } else {
+        return pivot;
+      }
+    }
+  }
+
+  /**
+   * @dev Swaps the pointers to two uint256 arrays in memory
+   * @param _a The pointer to the first in memory array
+   * @param _b The pointer to the second in memory array
+   */
+  function swap(int256[] memory _a, int256[] memory _b)
+    private
+    pure
+    returns(int256[] memory, int256[] memory)
+  {
+    return (_b, _a);
+  }
+
+  /**
+   * @dev Makes an in memory copy of the array passed in
+   * @param _list The pointer to the array to be copied
+   */
+  function copy(int256[] memory _list)
+    private
+    pure
+    returns(int256[] memory)
+  {
+    int256[] memory list2 = new int256[](_list.length);
+    for (uint256 i = 0; i < _list.length; i++) {
+      list2[i] = _list[i];
+    }
+    return list2;
+  }
+
+}

--- a/evm-contracts/src/v0.6/Median.sol
+++ b/evm-contracts/src/v0.6/Median.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.0;
 
 import "./vendor/SafeMath.sol";
 import "./vendor/SignedSafeMath.sol";

--- a/evm-contracts/src/v0.6/dev/AggregatorInterface.sol
+++ b/evm-contracts/src/v0.6/dev/AggregatorInterface.sol
@@ -1,0 +1,12 @@
+pragma solidity ^0.6.2;
+
+interface AggregatorInterface {
+  function latestAnswer() external view virtual returns (int256);
+  function latestTimestamp() external view virtual returns (uint256);
+  function latestRound() external view virtual returns (uint256);
+  function getAnswer(uint256 roundId) external view virtual returns (int256);
+  function getTimestamp(uint256 roundId) external view virtual returns (uint256);
+
+  event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 timestamp);
+  event NewRound(uint256 indexed roundId, address indexed startedBy);
+}

--- a/evm-contracts/src/v0.6/dev/AggregatorInterface.sol
+++ b/evm-contracts/src/v0.6/dev/AggregatorInterface.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.0;
 
 interface AggregatorInterface {
   function latestAnswer() external view virtual returns (int256);

--- a/evm-contracts/src/v0.6/dev/Owned.sol
+++ b/evm-contracts/src/v0.6/dev/Owned.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.6.2;
 
 /**
  * @title The Owned contract

--- a/evm-contracts/src/v0.6/dev/Owned.sol
+++ b/evm-contracts/src/v0.6/dev/Owned.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.2;
+pragma solidity ^0.6.0;
 
 /**
  * @title The Owned contract

--- a/evm-contracts/src/v0.6/dev/PrepaidAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/PrepaidAggregator.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.6.2;
 
 import "../Median.sol";
 import "../vendor/SafeMath.sol";
@@ -254,22 +254,13 @@ contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
   }
 
   /**
-   * @notice query the available amount of LINK for an oracle to withdraw
-   */
-  function withdrawable()
-    external
-    view
-    returns (uint256)
-  {
-    return oracles[msg.sender].withdrawable;
-  }
-
-  /**
    * @notice get the most recently reported answer
    */
   function latestAnswer()
     external
     view
+    virtual
+    override
     returns (int256)
   {
     return _latestAnswer();
@@ -281,6 +272,8 @@ contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
   function latestTimestamp()
     external
     view
+    virtual
+    override
     returns (uint256)
   {
     return _latestTimestamp();
@@ -292,6 +285,7 @@ contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
   function latestRound()
     external
     view
+    override
     returns (uint256)
   {
     return latestRoundId;
@@ -315,6 +309,8 @@ contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
   function getAnswer(uint256 _roundId)
     external
     view
+    virtual
+    override
     returns (int256)
   {
     return _getAnswer(_roundId);
@@ -327,6 +323,8 @@ contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
   function getTimestamp(uint256 _roundId)
     external
     view
+    virtual
+    override
     returns (uint256)
   {
     return _getTimestamp(_roundId);
@@ -359,12 +357,25 @@ contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
   }
 
   /**
+   * @notice query the available amount of LINK for an oracle to withdraw
+   */
+  function withdrawable()
+    external
+    view
+    override
+    returns (uint256)
+  {
+    return oracles[msg.sender].withdrawable;
+  }
+
+  /**
    * @notice transfers the oracle's LINK to another address
    * @param _recipient is the address to send the LINK to
    * @param _amount is the amount of LINK to send
    */
   function withdraw(address _recipient, uint256 _amount)
     external
+    override
   {
     uint128 amount = uint128(_amount);
     uint128 available = oracles[msg.sender].withdrawable;

--- a/evm-contracts/src/v0.6/dev/SafeMath128.sol
+++ b/evm-contracts/src/v0.6/dev/SafeMath128.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.0;
 
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow

--- a/evm-contracts/src/v0.6/dev/SafeMath128.sol
+++ b/evm-contracts/src/v0.6/dev/SafeMath128.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.6.2;
 
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow
@@ -14,9 +14,9 @@ pragma solidity ^0.5.0;
  * class of bugs, so it's recommended to use it always.
  *
  * This library is a version of Open Zeppelin's SafeMath, modified to support
- * unsigned 64 bit integers.
+ * unsigned 128 bit integers.
  */
-library SafeMath64 {
+library SafeMath128 {
   /**
     * @dev Returns the addition of two unsigned integers, reverting on
     * overflow.
@@ -26,8 +26,8 @@ library SafeMath64 {
     * Requirements:
     * - Addition cannot overflow.
     */
-  function add(uint64 a, uint64 b) internal pure returns (uint64) {
-    uint64 c = a + b;
+  function add(uint128 a, uint128 b) internal pure returns (uint128) {
+    uint128 c = a + b;
     require(c >= a, "SafeMath: addition overflow");
 
     return c;
@@ -42,9 +42,9 @@ library SafeMath64 {
     * Requirements:
     * - Subtraction cannot overflow.
     */
-  function sub(uint64 a, uint64 b) internal pure returns (uint64) {
+  function sub(uint128 a, uint128 b) internal pure returns (uint128) {
     require(b <= a, "SafeMath: subtraction overflow");
-    uint64 c = a - b;
+    uint128 c = a - b;
 
     return c;
   }
@@ -58,7 +58,7 @@ library SafeMath64 {
     * Requirements:
     * - Multiplication cannot overflow.
     */
-  function mul(uint64 a, uint64 b) internal pure returns (uint64) {
+  function mul(uint128 a, uint128 b) internal pure returns (uint128) {
     // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
     // benefit is lost if 'b' is also tested.
     // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
@@ -66,7 +66,7 @@ library SafeMath64 {
       return 0;
     }
 
-    uint64 c = a * b;
+    uint128 c = a * b;
     require(c / a == b, "SafeMath: multiplication overflow");
 
     return c;
@@ -83,10 +83,10 @@ library SafeMath64 {
     * Requirements:
     * - The divisor cannot be zero.
     */
-  function div(uint64 a, uint64 b) internal pure returns (uint64) {
+  function div(uint128 a, uint128 b) internal pure returns (uint128) {
     // Solidity only automatically asserts when dividing by 0
     require(b > 0, "SafeMath: division by zero");
-    uint64 c = a / b;
+    uint128 c = a / b;
     // assert(a == b * c + a % b); // There is no case in which this doesn't hold
 
     return c;
@@ -103,7 +103,7 @@ library SafeMath64 {
     * Requirements:
     * - The divisor cannot be zero.
     */
-  function mod(uint64 a, uint64 b) internal pure returns (uint64) {
+  function mod(uint128 a, uint128 b) internal pure returns (uint128) {
     require(b != 0, "SafeMath: modulo by zero");
     return a % b;
   }

--- a/evm-contracts/src/v0.6/dev/SafeMath32.sol
+++ b/evm-contracts/src/v0.6/dev/SafeMath32.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.0;
 
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow

--- a/evm-contracts/src/v0.6/dev/SafeMath32.sol
+++ b/evm-contracts/src/v0.6/dev/SafeMath32.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.6.2;
 
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow

--- a/evm-contracts/src/v0.6/dev/SafeMath64.sol
+++ b/evm-contracts/src/v0.6/dev/SafeMath64.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.0;
 
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow

--- a/evm-contracts/src/v0.6/dev/SafeMath64.sol
+++ b/evm-contracts/src/v0.6/dev/SafeMath64.sol
@@ -1,0 +1,110 @@
+pragma solidity ^0.6.2;
+
+/**
+ * @dev Wrappers over Solidity's arithmetic operations with added overflow
+ * checks.
+ *
+ * Arithmetic operations in Solidity wrap on overflow. This can easily result
+ * in bugs, because programmers usually assume that an overflow raises an
+ * error, which is the standard behavior in high level programming languages.
+ * `SafeMath` restores this intuition by reverting the transaction when an
+ * operation overflows.
+ *
+ * Using this library instead of the unchecked operations eliminates an entire
+ * class of bugs, so it's recommended to use it always.
+ *
+ * This library is a version of Open Zeppelin's SafeMath, modified to support
+ * unsigned 64 bit integers.
+ */
+library SafeMath64 {
+  /**
+    * @dev Returns the addition of two unsigned integers, reverting on
+    * overflow.
+    *
+    * Counterpart to Solidity's `+` operator.
+    *
+    * Requirements:
+    * - Addition cannot overflow.
+    */
+  function add(uint64 a, uint64 b) internal pure returns (uint64) {
+    uint64 c = a + b;
+    require(c >= a, "SafeMath: addition overflow");
+
+    return c;
+  }
+
+  /**
+    * @dev Returns the subtraction of two unsigned integers, reverting on
+    * overflow (when the result is negative).
+    *
+    * Counterpart to Solidity's `-` operator.
+    *
+    * Requirements:
+    * - Subtraction cannot overflow.
+    */
+  function sub(uint64 a, uint64 b) internal pure returns (uint64) {
+    require(b <= a, "SafeMath: subtraction overflow");
+    uint64 c = a - b;
+
+    return c;
+  }
+
+  /**
+    * @dev Returns the multiplication of two unsigned integers, reverting on
+    * overflow.
+    *
+    * Counterpart to Solidity's `*` operator.
+    *
+    * Requirements:
+    * - Multiplication cannot overflow.
+    */
+  function mul(uint64 a, uint64 b) internal pure returns (uint64) {
+    // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
+    // benefit is lost if 'b' is also tested.
+    // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
+    if (a == 0) {
+      return 0;
+    }
+
+    uint64 c = a * b;
+    require(c / a == b, "SafeMath: multiplication overflow");
+
+    return c;
+  }
+
+  /**
+    * @dev Returns the integer division of two unsigned integers. Reverts on
+    * division by zero. The result is rounded towards zero.
+    *
+    * Counterpart to Solidity's `/` operator. Note: this function uses a
+    * `revert` opcode (which leaves remaining gas untouched) while Solidity
+    * uses an invalid opcode to revert (consuming all remaining gas).
+    *
+    * Requirements:
+    * - The divisor cannot be zero.
+    */
+  function div(uint64 a, uint64 b) internal pure returns (uint64) {
+    // Solidity only automatically asserts when dividing by 0
+    require(b > 0, "SafeMath: division by zero");
+    uint64 c = a / b;
+    // assert(a == b * c + a % b); // There is no case in which this doesn't hold
+
+    return c;
+  }
+
+  /**
+    * @dev Returns the remainder of dividing two unsigned integers. (unsigned integer modulo),
+    * Reverts when dividing by zero.
+    *
+    * Counterpart to Solidity's `%` operator. This function uses a `revert`
+    * opcode (which leaves remaining gas untouched) while Solidity uses an
+    * invalid opcode to revert (consuming all remaining gas).
+    *
+    * Requirements:
+    * - The divisor cannot be zero.
+    */
+  function mod(uint64 a, uint64 b) internal pure returns (uint64) {
+    require(b != 0, "SafeMath: modulo by zero");
+    return a % b;
+  }
+}

--- a/evm-contracts/src/v0.6/dev/Whitelisted.sol
+++ b/evm-contracts/src/v0.6/dev/Whitelisted.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.6.2;
 
 import "./Owned.sol";
 

--- a/evm-contracts/src/v0.6/dev/Whitelisted.sol
+++ b/evm-contracts/src/v0.6/dev/Whitelisted.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.2;
+pragma solidity ^0.6.0;
 
 import "./Owned.sol";
 

--- a/evm-contracts/src/v0.6/dev/WhitelistedAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/WhitelistedAggregator.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.6.2;
 
 import "./PrepaidAggregator.sol";
 import "./Whitelisted.sol";
@@ -30,8 +30,9 @@ contract WhitelistedAggregator is PrepaidAggregator, Whitelisted {
    */
   function latestAnswer()
     external
-    isWhitelisted()
     view
+    override
+    isWhitelisted()
     returns (int256)
   {
     return _latestAnswer();
@@ -44,6 +45,7 @@ contract WhitelistedAggregator is PrepaidAggregator, Whitelisted {
   function latestTimestamp()
     external
     view
+    override
     isWhitelisted()
     returns (uint256)
   {
@@ -58,6 +60,7 @@ contract WhitelistedAggregator is PrepaidAggregator, Whitelisted {
   function getAnswer(uint256 _roundId)
     external
     view
+    override
     isWhitelisted()
     returns (int256)
   {
@@ -71,8 +74,9 @@ contract WhitelistedAggregator is PrepaidAggregator, Whitelisted {
    */
   function getTimestamp(uint256 _roundId)
     external
-    isWhitelisted()
     view
+    override
+    isWhitelisted()
     returns (uint256)
   {
     return _getTimestamp(_roundId);

--- a/evm-contracts/src/v0.6/dev/vendor/SafeMath.sol
+++ b/evm-contracts/src/v0.6/dev/vendor/SafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.5.0;
+pragma solidity ^0.6.0;
 
 /**
  * @dev Wrappers over Solidity's arithmetic operations with added overflow
@@ -12,11 +12,8 @@ pragma solidity ^0.5.0;
  *
  * Using this library instead of the unchecked operations eliminates an entire
  * class of bugs, so it's recommended to use it always.
- *
- * This library is a version of Open Zeppelin's SafeMath, modified to support
- * unsigned 128 bit integers.
  */
-library SafeMath128 {
+library SafeMath {
   /**
     * @dev Returns the addition of two unsigned integers, reverting on
     * overflow.
@@ -26,8 +23,8 @@ library SafeMath128 {
     * Requirements:
     * - Addition cannot overflow.
     */
-  function add(uint128 a, uint128 b) internal pure returns (uint128) {
-    uint128 c = a + b;
+  function add(uint256 a, uint256 b) internal pure returns (uint256) {
+    uint256 c = a + b;
     require(c >= a, "SafeMath: addition overflow");
 
     return c;
@@ -42,9 +39,9 @@ library SafeMath128 {
     * Requirements:
     * - Subtraction cannot overflow.
     */
-  function sub(uint128 a, uint128 b) internal pure returns (uint128) {
+  function sub(uint256 a, uint256 b) internal pure returns (uint256) {
     require(b <= a, "SafeMath: subtraction overflow");
-    uint128 c = a - b;
+    uint256 c = a - b;
 
     return c;
   }
@@ -58,7 +55,7 @@ library SafeMath128 {
     * Requirements:
     * - Multiplication cannot overflow.
     */
-  function mul(uint128 a, uint128 b) internal pure returns (uint128) {
+  function mul(uint256 a, uint256 b) internal pure returns (uint256) {
     // Gas optimization: this is cheaper than requiring 'a' not being zero, but the
     // benefit is lost if 'b' is also tested.
     // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
@@ -66,7 +63,7 @@ library SafeMath128 {
       return 0;
     }
 
-    uint128 c = a * b;
+    uint256 c = a * b;
     require(c / a == b, "SafeMath: multiplication overflow");
 
     return c;
@@ -83,10 +80,10 @@ library SafeMath128 {
     * Requirements:
     * - The divisor cannot be zero.
     */
-  function div(uint128 a, uint128 b) internal pure returns (uint128) {
+  function div(uint256 a, uint256 b) internal pure returns (uint256) {
     // Solidity only automatically asserts when dividing by 0
     require(b > 0, "SafeMath: division by zero");
-    uint128 c = a / b;
+    uint256 c = a / b;
     // assert(a == b * c + a % b); // There is no case in which this doesn't hold
 
     return c;
@@ -103,7 +100,7 @@ library SafeMath128 {
     * Requirements:
     * - The divisor cannot be zero.
     */
-  function mod(uint128 a, uint128 b) internal pure returns (uint128) {
+  function mod(uint256 a, uint256 b) internal pure returns (uint256) {
     require(b != 0, "SafeMath: modulo by zero");
     return a % b;
   }

--- a/evm-contracts/src/v0.6/tests/MedianTestHelper.sol
+++ b/evm-contracts/src/v0.6/tests/MedianTestHelper.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.0;
 
 import "../Median.sol";
 

--- a/evm-contracts/src/v0.6/tests/MedianTestHelper.sol
+++ b/evm-contracts/src/v0.6/tests/MedianTestHelper.sol
@@ -1,0 +1,15 @@
+pragma solidity ^0.6.2;
+
+import "../Median.sol";
+
+contract MedianTestHelper {
+
+  function publicGet(int256[] memory _list)
+    public
+    pure
+    returns (int256)
+  {
+    return Median.calculate(_list);
+  }
+
+}

--- a/evm-contracts/src/v0.6/tests/OwnedTestHelper.sol
+++ b/evm-contracts/src/v0.6/tests/OwnedTestHelper.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.5.0;
+pragma solidity 0.6.2;
 
 import "../dev/Owned.sol";
 

--- a/evm-contracts/src/v0.6/tests/OwnedTestHelper.sol
+++ b/evm-contracts/src/v0.6/tests/OwnedTestHelper.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.2;
+pragma solidity ^0.6.0;
 
 import "../dev/Owned.sol";
 

--- a/evm-contracts/src/v0.6/vendor/SignedSafeMath.sol
+++ b/evm-contracts/src/v0.6/vendor/SignedSafeMath.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.6.2;
+pragma solidity ^0.6.0;
 
 library SignedSafeMath {
 

--- a/evm-contracts/src/v0.6/vendor/SignedSafeMath.sol
+++ b/evm-contracts/src/v0.6/vendor/SignedSafeMath.sol
@@ -1,0 +1,22 @@
+pragma solidity ^0.6.2;
+
+library SignedSafeMath {
+
+  /**
+   * @dev Adds two int256s and makes sure the result doesn't overflow. Signed
+   * integers aren't supported by the SafeMath library, thus this method
+   * @param _a The first number to be added
+   * @param _a The second number to be added
+   */
+  function add(int256 _a, int256 _b)
+    internal
+    pure
+    returns (int256)
+  {
+    // solium-disable-next-line zeppelin/no-arithmetic-operations
+    int256 c = _a + _b;
+    require((_b >= 0 && c >= _a) || (_b < 0 && c < _a), "SignedSafeMath: addition overflow");
+
+    return c;
+  }
+}

--- a/evm-contracts/test/v0.4/AggregatorProxy.test.ts
+++ b/evm-contracts/test/v0.4/AggregatorProxy.test.ts
@@ -133,7 +133,7 @@ describe('AggregatorProxy', () => {
       assert.notEqual('0', height.toString())
     })
 
-    it('pulls the height from the aggregator', async () => {
+    it('pulls the timestamp from the aggregator', async () => {
       matchers.bigNum(
         await aggregator.latestTimestamp(),
         await proxy.latestTimestamp(),
@@ -175,7 +175,7 @@ describe('AggregatorProxy', () => {
         await proxy.setAggregator(aggregator2.address)
       })
 
-      it('pulls the height from the new aggregator', async () => {
+      it('pulls the timestamp from the new aggregator', async () => {
         matchers.bigNum(
           await aggregator2.latestTimestamp(),
           await proxy.latestTimestamp(),

--- a/evm-contracts/test/v0.6/Median.test.ts
+++ b/evm-contracts/test/v0.6/Median.test.ts
@@ -1,0 +1,109 @@
+import { contract, matchers, setup } from '@chainlink/test-helpers'
+import { ethers } from 'ethers'
+import { MedianTestHelperFactory } from '../../ethers/v0.6/MedianTestHelperFactory'
+
+const medianTestHelperFactory = new MedianTestHelperFactory()
+const provider = setup.provider()
+
+let defaultAccount: ethers.Wallet
+beforeAll(async () => {
+  const users = await setup.users(provider)
+  defaultAccount = users.roles.defaultAccount
+})
+
+describe('Median', () => {
+  let median: contract.Instance<MedianTestHelperFactory>
+
+  beforeEach(async () => {
+    median = await medianTestHelperFactory.connect(defaultAccount).deploy()
+  })
+
+  describe('testing various lists', () => {
+    const tests = [
+      {
+        name: 'ordered ascending',
+        responses: [0, 1, 2, 3, 4, 5, 6, 7],
+        want: 3,
+      },
+      {
+        name: 'ordered descending',
+        responses: [7, 6, 5, 4, 3, 2, 1, 0],
+        want: 3,
+      },
+      {
+        name: 'unordered 1',
+        responses: [1001, 1, 101, 10, 11, 0, 111],
+        want: 11,
+      },
+      {
+        name: 'unordered 2',
+        responses: [8, 8, 4, 5, 5, 7, 9, 5, 9],
+        want: 7,
+      },
+      {
+        name: 'unordered 3',
+        responses: [33, 44, 89, 101, 67, 7, 23, 55, 88, 324, 0, 88],
+        want: 61, // 67 + 55 / 2
+      },
+      {
+        name: 'long unordered',
+        responses: [
+          333121,
+          323453,
+          337654,
+          345363,
+          345363,
+          333456,
+          335477,
+          333323,
+          332352,
+          354648,
+          983260,
+          333856,
+          335468,
+          376987,
+          333253,
+          388867,
+          337879,
+          333324,
+          338678,
+        ],
+        want: 335477,
+      },
+      {
+        name: 'overflowing numbers',
+        responses: [
+          ethers.utils.bigNumberify(
+            '57896044618658097711785492504343953926634992332820282019728792003956564819967',
+          ),
+          ethers.utils.bigNumberify(
+            '57896044618658097711785492504343953926634992332820282019728792003956564819967',
+          ),
+        ],
+        want: ethers.utils.bigNumberify(
+          '57896044618658097711785492504343953926634992332820282019728792003956564819967',
+        ),
+      },
+      {
+        name: 'overflowing numbers',
+        responses: [
+          ethers.utils.bigNumberify(
+            '57896044618658097711785492504343953926634992332820282019728792003956564819967',
+          ),
+          ethers.utils.bigNumberify(
+            '57896044618658097711785492504343953926634992332820282019728792003956564819966',
+          ),
+        ],
+        want: ethers.utils.bigNumberify(
+          '57896044618658097711785492504343953926634992332820282019728792003956564819966',
+        ),
+      },
+    ]
+
+    for (const test of tests) {
+      it(test.name, async () => {
+        matchers.bigNum(test.want, await median.publicGet(test.responses))
+      })
+    }
+  })
+})

--- a/evm-contracts/test/v0.6/Owned.test.ts
+++ b/evm-contracts/test/v0.6/Owned.test.ts
@@ -6,7 +6,7 @@ import {
 } from '@chainlink/test-helpers'
 import { assert } from 'chai'
 import { ethers } from 'ethers'
-import { OwnedTestHelperFactory } from '../../ethers/v0.5/OwnedTestHelperFactory'
+import { OwnedTestHelperFactory } from '../../ethers/v0.6/OwnedTestHelperFactory'
 
 const ownedTestHelperFactory = new OwnedTestHelperFactory()
 const provider = setup.provider()

--- a/evm-contracts/test/v0.6/PrepaidAggregator.test.ts
+++ b/evm-contracts/test/v0.6/PrepaidAggregator.test.ts
@@ -7,7 +7,7 @@ import {
 import { assert } from 'chai'
 import { randomBytes } from 'crypto'
 import { ethers } from 'ethers'
-import { PrepaidAggregatorFactory } from '../../ethers/v0.5/PrepaidAggregatorFactory'
+import { PrepaidAggregatorFactory } from '../../ethers/v0.6/PrepaidAggregatorFactory'
 
 let personas: setup.Personas
 const provider = setup.provider()

--- a/evm-contracts/test/v0.6/Whitelisted.test.ts
+++ b/evm-contracts/test/v0.6/Whitelisted.test.ts
@@ -1,6 +1,6 @@
 import { contract, helpers, matchers, setup } from '@chainlink/test-helpers'
 import { assert } from 'chai'
-import { WhitelistedFactory } from '../../ethers/v0.5/WhitelistedFactory'
+import { WhitelistedFactory } from '../../ethers/v0.6/WhitelistedFactory'
 
 const whitelistedFactory = new WhitelistedFactory()
 const provider = setup.provider()

--- a/evm-contracts/test/v0.6/WhitelistedAggregator.test.ts
+++ b/evm-contracts/test/v0.6/WhitelistedAggregator.test.ts
@@ -5,7 +5,7 @@ import {
   setup,
 } from '@chainlink/test-helpers'
 import { assert } from 'chai'
-import { WhitelistedAggregatorFactory } from '../../ethers/v0.5/WhitelistedAggregatorFactory'
+import { WhitelistedAggregatorFactory } from '../../ethers/v0.6/WhitelistedAggregatorFactory'
 
 const aggregatorFactory = new WhitelistedAggregatorFactory()
 const linkTokenFactory = new contract.LinkTokenFactory()

--- a/integration-scripts/package.json
+++ b/integration-scripts/package.json
@@ -19,6 +19,7 @@
     "deploy-link-token-contract": "node ./dist/src/deployLinkTokenContract",
     "deploy-contracts": "node ./dist/src/deployContracts",
     "deploy-v0.5-contracts": "node ./dist/src/deployV0.5Contracts",
+    "deploy-v0.6-contracts": "node ./dist/src/deployV0.6Contracts",
     "initiate-service-agreement": "node ./dist/src/initiateServiceAgreement",
     "start-echo-server": "node ./dist/src/echoServer"
   },

--- a/integration-scripts/src/deployV0.6Contracts.ts
+++ b/integration-scripts/src/deployV0.6Contracts.ts
@@ -1,9 +1,10 @@
-import { CoordinatorFactory } from '@chainlink/contracts/ethers/v0.5/CoordinatorFactory'
-import { MeanAggregatorFactory } from '@chainlink/contracts/ethers/v0.5/MeanAggregatorFactory'
+import { PrepaidAggregatorFactory } from '@chainlink/contracts/ethers/v0.6/PrepaidAggregatorFactory'
+import { ethers } from 'ethers'
 import {
   createProvider,
   deployContract,
   DEVNET_ADDRESS,
+  getArgs,
   registerPromiseHandler,
 } from './common'
 import { deployLinkTokenContract } from './deployLinkTokenContract'
@@ -20,20 +21,19 @@ export async function deployContracts() {
 
   const linkToken = await deployLinkTokenContract()
 
-  const coordinator = await deployContract(
-    { Factory: CoordinatorFactory, signer, name: 'Coordinator' },
+  const prepaidAggregator = await deployContract(
+    { Factory: PrepaidAggregatorFactory, signer, name: 'PrepaidAggregator' },
     linkToken.address,
+    1,
+    3,
+    1,
+    ethers.utils.formatBytes32String('ETH/USD'),
   )
-
-  const meanAggregator = await deployContract({
-    Factory: MeanAggregatorFactory,
-    signer,
-    name: 'MeanAggregator',
-  })
+  const { CHAINLINK_NODE_ADDRESS } = getArgs(['CHAINLINK_NODE_ADDRESS'])
+  await prepaidAggregator.addOracle(CHAINLINK_NODE_ADDRESS, 1, 1, 0)
 
   return {
     linkToken,
-    coordinator,
-    meanAggregator,
+    prepaidAggregator,
   }
 }

--- a/integration/common
+++ b/integration/common
@@ -80,6 +80,13 @@ deploy_v05_contracts() {
   export LINK_TOKEN_ADDRESS=`cat log | grep 'Deployed LinkToken at:' | awk '{print$4}'`
   export COORDINATOR_ADDRESS=`cat log | grep 'Deployed Coordinator at:' | awk '{print$4}'`
   export MEAN_AGGREGATOR_ADDRESS=`cat log | grep 'Deployed MeanAggregator at:' | awk '{print$4}'`
+}
+
+deploy_v06_contracts() {
+  title "Migrating v0.6 contracts..."
+  local log=$LOG_PATH/deployv0.5.log
+  yarn workspace @chainlink/integration-scripts deploy-v0.6-contracts | tee log
+  export LINK_TOKEN_ADDRESS=`cat log | grep 'Deployed LinkToken at:' | awk '{print$4}'`
   export PREPAID_AGGREGATOR_ADDRESS=`cat log | grep 'Deployed PrepaidAggregator at:' | awk '{print$4}'`
 }
 

--- a/integration/common
+++ b/integration/common
@@ -84,7 +84,7 @@ deploy_v05_contracts() {
 
 deploy_v06_contracts() {
   title "Migrating v0.6 contracts..."
-  local log=$LOG_PATH/deployv0.5.log
+  local log=$LOG_PATH/deployv0.6.log
   yarn workspace @chainlink/integration-scripts deploy-v0.6-contracts | tee log
   export LINK_TOKEN_ADDRESS=`cat log | grep 'Deployed LinkToken at:' | awk '{print$4}'`
   export PREPAID_AGGREGATOR_ADDRESS=`cat log | grep 'Deployed PrepaidAggregator at:' | awk '{print$4}'`

--- a/tools/ci/ethereum_test
+++ b/tools/ci/ethereum_test
@@ -26,6 +26,8 @@ cd $SRCROOT/integration
 ./ethlog_test
 deploy_v05_contracts
 ./service_agreement_test
+
+deploy_v06_contracts
 ./flux_monitor_test
 
 title 'End to end tests.'

--- a/tools/docker/docker-compose.paritynet.yaml
+++ b/tools/docker/docker-compose.paritynet.yaml
@@ -6,7 +6,7 @@ services:
       - devnet
   devnet:
     container_name: parity
-    image: smartcontract/devnet
+    image: smartcontract/devnet:st-peters
     user: root
     command: --config /devnet/miner.toml --db-path /devnet/database
     ports:


### PR DESCRIPTION
Moves all related contracts over when possible, and if solidity is used by other v0.5 contracts then I copied it over instead.