### PR TITLE
Flux Monitor: fix block on startup with > 2 jobs

### DIFF
--- a/core/services/flux_monitor_test.go
+++ b/core/services/flux_monitor_test.go
@@ -138,7 +138,7 @@ func TestConcreteFluxMonitor_ConnectStartsExistingJobs(t *testing.T) {
 
 	checkerFactory := new(mocks.DeviationCheckerFactory)
 
-	for i := 0; i < 100; i++ {
+	for i := 0; i < 3; i++ {
 		job := cltest.NewJobWithFluxMonitorInitiator()
 		require.NoError(t, store.CreateJob(&job))
 		job, err := store.FindJob(job.ID)

--- a/core/services/flux_monitor_test.go
+++ b/core/services/flux_monitor_test.go
@@ -128,12 +128,6 @@ func TestConcreteFluxMonitor_ConnectStartsExistingJobs(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
-	job := cltest.NewJobWithFluxMonitorInitiator()
-	require.NoError(t, store.CreateJob(&job))
-
-	job, err := store.FindJob(job.ID) // Update job from db to get matching coerced time values (UpdatedAt)
-	require.NoError(t, err)
-
 	runManager := new(mocks.RunManager)
 	started := make(chan struct{})
 
@@ -143,11 +137,21 @@ func TestConcreteFluxMonitor_ConnectStartsExistingJobs(t *testing.T) {
 	})
 
 	checkerFactory := new(mocks.DeviationCheckerFactory)
-	checkerFactory.On("New", job.Initiators[0], runManager).Return(dc, nil)
+
+	for i := 0; i < 100; i++ {
+		job := cltest.NewJobWithFluxMonitorInitiator()
+		require.NoError(t, store.CreateJob(&job))
+		job, err := store.FindJob(job.ID)
+		require.NoError(t, err)
+		checkerFactory.On("New", job.Initiators[0], runManager).Return(dc, nil)
+	}
+
 	fm := services.NewFluxMonitor(store, runManager)
 	services.ExportedSetCheckerFactory(fm, checkerFactory)
-	require.NoError(t, fm.Start())
+	err := fm.Start()
+	require.NoError(t, err)
 	defer fm.Stop()
+
 	require.NoError(t, fm.Connect(nil))
 	cltest.CallbackOrTimeout(t, "deviation checker started", func() {
 		<-started


### PR DESCRIPTION
Fix an issue in FluxMonitor.Start() where it would block if more than 2
Jobs were added.

Make the process of starting (adding) the pre-existing jobs sequential.
The CSP consumer can only handle one action at a time.  Adding more than
one job without draining the error channel causes it to block.

This may cause a significant slow down on Start.