### PR TITLE
Add a memory-based log sink to test logger

### DIFF
--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -86,12 +86,13 @@ func CreateProductionLogger(
 }
 
 // CreateTestLogger creates a logger that directs output to PrettyConsole
-// configured for test output.
+// configured for test output, and to the buffer testMemoryLog.
 func CreateTestLogger(lvl zapcore.Level) *zap.Logger {
+	var _ *MemorySink = TestMemoryLog() // Make sure memory log is created
 	color.NoColor = false
 	config := zap.NewProductionConfig()
 	config.Level.SetLevel(lvl)
-	config.OutputPaths = []string{"pretty://console"}
+	config.OutputPaths = []string{"pretty://console", "memory://"}
 	zl, err := config.Build(zap.AddCallerSkip(1))
 	if err != nil {
 		log.Fatal(err)

--- a/core/logger/logger_test.go
+++ b/core/logger/logger_test.go
@@ -1,0 +1,15 @@
+package logger
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestTestLogger(t *testing.T) {
+	logger := CreateTestLogger(zapcore.DebugLevel)
+	msg := "this is a test of the logging system"
+	logger.Debug(msg)
+	require.Contains(t, TestMemoryLog().String(), msg)
+}

--- a/core/logger/memory_sink.go
+++ b/core/logger/memory_sink.go
@@ -1,0 +1,38 @@
+package logger
+
+// Based on https://stackoverflow.com/a/52737940
+
+import (
+	"bytes"
+	"sync"
+
+	"go.uber.org/zap"
+)
+
+// MemorySink implements zap.Sink by writing all messages to a buffer.
+type MemorySink struct {
+	*bytes.Buffer
+}
+
+var _ zap.Sink = &MemorySink{}
+
+// Close is a dummy method to satisfy the zap.Sink interface
+func (s *MemorySink) Close() error { return nil }
+
+// Sync is a dummy method to satisfy the zap.Sink interface
+func (s *MemorySink) Sync() error { return nil }
+
+var testMemoryLog *MemorySink
+var createSinkOnce sync.Once
+
+func registerMemorySink() {
+	testMemoryLog = &MemorySink{new(bytes.Buffer)}
+	if err := zap.RegisterSink("memory", prettyConsoleSink(testMemoryLog)); err != nil {
+		panic(err)
+	}
+}
+
+func TestMemoryLog() *MemorySink {
+	createSinkOnce.Do(registerMemorySink)
+	return testMemoryLog
+}


### PR DESCRIPTION
This makes it easy to assert on log events, in tests.