### PR TITLE
Clean up log_events.go

### DIFF
--- a/core/services/subscription.go
+++ b/core/services/subscription.go
@@ -35,11 +35,7 @@ func StartJobSubscription(job models.JobSpec, head *models.Head, store *strpkg.S
 	var merr error
 	var unsubscribers []Unsubscriber
 
-	initrs := job.InitiatorsFor(
-		models.InitiatorEthLog,
-		models.InitiatorRunLog,
-		models.InitiatorServiceAgreementExecutionLog,
-	)
+	initrs := job.InitiatorsFor(models.LogBasedChainlinkJobInitiators...)
 
 	nextHead := head.NextInt() // Exclude current block from subscription
 	if replayFromBlock := store.Config.ReplayFromBlock(); replayFromBlock >= 0 {
@@ -128,10 +124,11 @@ func loggerLogListening(initr models.Initiator, blockNumber *big.Int) {
 	logger.Infow(msg, "address", utils.LogListeningAddress(initr.Address), "jobID", initr.JobSpecID.String())
 }
 
-// ReceiveLogRequest parses the log and runs the job indicated by a RunLog or
-// ServiceAgreementExecutionLog. (Both log events have the same format.)
+// ReceiveLogRequest parses the log and runs the job it indicated by its
+// GetJobSpecID method
 func ReceiveLogRequest(runManager RunManager, le models.LogRequest) {
 	if !le.Validate() {
+		logger.Debugw("discarding INVALID EVENT LOG", "log", le.GetLog())
 		return
 	}
 

--- a/core/services/subscription_test.go
+++ b/core/services/subscription_test.go
@@ -411,7 +411,9 @@ func TestServices_NewInitiatorSubscription_RunLog_ReplayFromBlock(t *testing.T) 
 			expectedQuery := ethereum.FilterQuery{
 				FromBlock: test.wantFromBlock,
 				Addresses: []common.Address{initr.InitiatorParams.Address},
-				Topics:    models.TopicFiltersForRunLog([]common.Hash{models.RunLogTopic20190207withoutIndexes, models.RunLogTopic20190123withFullfillmentParams, models.RunLogTopic0original}, initr.JobSpecID),
+				Topics: [][]common.Hash{
+					models.TopicsForInitiatorsWhichRequireJobSpecIDTopic[models.InitiatorRunLog],
+					{models.IDToTopic(initr.JobSpecID), models.IDToHexTopic(initr.JobSpecID)}},
 			}
 
 			receipt := cltest.TxReceiptFromFixture(t, "../eth/testdata/runlogReceipt.json")

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -198,8 +198,8 @@ func (j JSON) AsMap() (map[string]interface{}, error) {
 	return output, nil
 }
 
-// mapToJSON returns m as a JSON object, or errors
-func mapToJSON(m map[string]interface{}) (JSON, error) {
+// NewJSONFromMap returns m as a JSON object, or errors
+func NewJSONFromMap(m map[string]interface{}) (JSON, error) {
 	bytes, err := json.Marshal(m)
 	if err != nil {
 		return JSON{}, err
@@ -207,27 +207,25 @@ func mapToJSON(m map[string]interface{}) (JSON, error) {
 	return JSON{Result: gjson.ParseBytes(bytes)}, nil
 }
 
+// jsonObject is used to pass multiple key/value pairs to JSON
+// object-manipulation utilities
+type jsonObject map[string]interface{}
+
 // Add returns a new instance of JSON with the new value added.
 func (j JSON) Add(insertKey string, insertValue interface{}) (JSON, error) {
-	return j.MultiAdd([]KV{{insertKey, insertValue}})
-}
-
-// KV represents a key/value pair to be added to a JSON object
-type KV struct {
-	Key   string
-	Value interface{}
+	return j.MultiAdd(jsonObject{insertKey: insertValue})
 }
 
 // MultiAdd returns a new instance of j with the new values added.
-func (j JSON) MultiAdd(keyValues []KV) (JSON, error) {
+func (j JSON) MultiAdd(keyValues jsonObject) (JSON, error) {
 	output, err := j.AsMap()
 	if err != nil {
 		return JSON{}, err
 	}
-	for _, kv := range keyValues {
-		output[kv.Key] = kv.Value
+	for key, value := range keyValues {
+		output[key] = value
 	}
-	return mapToJSON(output)
+	return NewJSONFromMap(output)
 }
 
 // Delete returns a new instance of JSON with the specified key removed.

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -183,30 +183,51 @@ func (j JSON) Bytes() []byte {
 	return []byte(j.String())
 }
 
-// Add returns a new instance of JSON with the new value added.
-func (j JSON) Add(insertKey string, insertValue interface{}) (JSON, error) {
+// AsMap returns j as a map
+func (j JSON) AsMap() (map[string]interface{}, error) {
 	output := make(map[string]interface{})
-
 	switch v := j.Result.Value().(type) {
 	case map[string]interface{}:
 		for key, value := range v {
-			if key != insertKey {
-				output[key] = value
-			}
+			output[key] = value
 		}
-		output[insertKey] = insertValue
 	case nil:
-		output[insertKey] = insertValue
 	default:
-		return JSON{}, errors.New("can only add to JSON objects or null")
+		return nil, errors.New("can only add to JSON objects or null")
 	}
+	return output, nil
+}
 
-	bytes, err := json.Marshal(output)
+// mapToJSON returns m as a JSON object, or errors
+func mapToJSON(m map[string]interface{}) (JSON, error) {
+	bytes, err := json.Marshal(m)
 	if err != nil {
 		return JSON{}, err
 	}
-
 	return JSON{Result: gjson.ParseBytes(bytes)}, nil
+}
+
+// Add returns a new instance of JSON with the new value added.
+func (j JSON) Add(insertKey string, insertValue interface{}) (JSON, error) {
+	return j.MultiAdd([]KV{{insertKey, insertValue}})
+}
+
+// KV represents a key/value pair to be added to a JSON object
+type KV struct {
+	Key   string
+	Value interface{}
+}
+
+// MultiAdd returns a new instance of j with the new values added.
+func (j JSON) MultiAdd(keyValues []KV) (JSON, error) {
+	output, err := j.AsMap()
+	if err != nil {
+		return JSON{}, err
+	}
+	for _, kv := range keyValues {
+		output[kv.Key] = kv.Value
+	}
+	return mapToJSON(output)
 }
 
 // Delete returns a new instance of JSON with the specified key removed.
@@ -227,7 +248,7 @@ func (j JSON) CBOR() ([]byte, error) {
 	case map[string]interface{}, []interface{}, nil:
 		return b, cbor.Encode(v)
 	default:
-		return b, fmt.Errorf("Unable to coerce JSON to CBOR for type %T", v)
+		return b, fmt.Errorf("unable to coerce JSON to CBOR for type %T", v)
 	}
 }
 

--- a/core/store/models/log_events.go
+++ b/core/store/models/log_events.go
@@ -90,16 +90,22 @@ var topicFactoryMap = map[common.Hash]logRequestParser{
 // chainlink job when an appropriate ethereum log is received.
 // (InitiatorFluxMonitor kicks off a job when a log is emitted, but the JobID is
 // not taken from the log)
-var LogBasedChainlinkJobInitiators = []string{InitiatorRunLog, InitiatorEthLog,
-	InitiatorServiceAgreementExecutionLog}
+var LogBasedChainlinkJobInitiators = []string{
+	InitiatorRunLog,
+	InitiatorEthLog,
+	InitiatorServiceAgreementExecutionLog,
+}
 
-// topicsForInitiatorsWhichRequireJobSpecTopic are the log topics which kick off
+// TopicsForInitiatorsWhichRequireJobSpecTopic are the log topics which kick off
 // a user job with the given type of initiator. If chainlink has any jobs with
 // these initiators, it subscribes on startup to logs which match both these
 // topics and some representation of the job spec ID.
 var TopicsForInitiatorsWhichRequireJobSpecIDTopic = map[string][]common.Hash{
-	InitiatorRunLog: {RunLogTopic20190207withoutIndexes,
-		RunLogTopic20190123withFullfillmentParams, RunLogTopic0original},
+	InitiatorRunLog: {
+		RunLogTopic20190207withoutIndexes,
+		RunLogTopic20190123withFullfillmentParams,
+		RunLogTopic0original,
+	},
 	InitiatorServiceAgreementExecutionLog: {ServiceAgreementExecutionLogTopic},
 }
 

--- a/core/store/models/log_events.go
+++ b/core/store/models/log_events.go
@@ -13,6 +13,7 @@ import (
 
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 )
 
@@ -85,55 +86,74 @@ var topicFactoryMap = map[common.Hash]logRequestParser{
 	RunLogTopic20190207withoutIndexes:         parseRunLog20190207withoutIndexes{},
 }
 
-// TopicFiltersForRunLog generates the two variations of RunLog IDs that could
-// possibly be entered on a RunLog or a ServiceAgreementExecutionLog. There is the ID,
-// hex encoded and the ID zero padded.
-func TopicFiltersForRunLog(logTopics []common.Hash, jobID *ID) [][]common.Hash {
-	return [][]common.Hash{logTopics, {IDToTopic(jobID), IDToHexTopic(jobID)}}
+// LogBasedChainlinkJobInitiators are initiators which kick off a user-specified
+// chainlink job when an appropriate ethereum log is received.
+// (InitiatorFluxMonitor kicks off work, but not a user-specified job.)
+var LogBasedChainlinkJobInitiators = []string{InitiatorRunLog, InitiatorEthLog,
+	InitiatorServiceAgreementExecutionLog}
+
+// topicsForInitiatorsWhichRequireJobSpecTopic are the log topics which kick off
+// a user job with the given type of initiator. If chainlink has any jobs with
+// these initiators, it subscribes on startup to logs which match both these
+// topics and some representation of the job spec ID.
+var TopicsForInitiatorsWhichRequireJobSpecIDTopic = map[string][]common.Hash{
+	InitiatorRunLog: {RunLogTopic20190207withoutIndexes,
+		RunLogTopic20190123withFullfillmentParams, RunLogTopic0original},
+	InitiatorServiceAgreementExecutionLog: {ServiceAgreementExecutionLogTopic},
+}
+
+// initiationRequiresJobSpecId is true if jobs initiated by the given
+// initiatiatorType require that their initiating logs match their JobSpecIDs.
+func initiationRequiresJobSpecID(initiatorType string) bool {
+	_, ok := TopicsForInitiatorsWhichRequireJobSpecIDTopic[initiatorType]
+	return ok
+}
+
+// jobSpecIDTopics lists the ways jsID could be represented as a log topic. This
+// allows log subscriptions to respond to all possible representations.
+func JobSpecIDTopics(jsID *ID) []common.Hash {
+	return []common.Hash{
+		// The job to be initiated can be encoded in a log topic in two ways:
+		IDToTopic(jsID),    // 16 full-range bytes, left padded to 32 bytes,
+		IDToHexTopic(jsID), // 32 ASCII hex chars representing the 16 bytes
+	}
 }
 
 // FilterQueryFactory returns the ethereum FilterQuery for this initiator.
-func FilterQueryFactory(i Initiator, from *big.Int) (ethereum.FilterQuery, error) {
-	q := ethereum.FilterQuery{
-		FromBlock: from,
-		Addresses: utils.WithoutZeroAddresses([]common.Address{i.Address}),
-	}
+func FilterQueryFactory(i Initiator, from *big.Int) (q ethereum.FilterQuery, err error) {
+	q.FromBlock = from
+	q.Addresses = utils.WithoutZeroAddresses([]common.Address{i.Address})
 
-	switch i.Type {
-	case InitiatorEthLog:
+	switch {
+	case i.Type == InitiatorEthLog:
 		if from == nil {
 			q.FromBlock = i.InitiatorParams.FromBlock.ToInt()
-		} else if from != nil && i.InitiatorParams.FromBlock != nil {
+		} else if i.InitiatorParams.FromBlock != nil {
 			q.FromBlock = utils.MaxBigs(from, i.InitiatorParams.FromBlock.ToInt())
 		}
 		q.ToBlock = i.InitiatorParams.ToBlock.ToInt()
 
 		if q.FromBlock != nil && q.ToBlock != nil && q.FromBlock.Cmp(q.ToBlock) >= 0 {
-			return q, fmt.Errorf("cannot generate a FilterQuery with fromBlock >= toBlock")
+			return ethereum.FilterQuery{}, fmt.Errorf(
+				"cannot generate a FilterQuery with fromBlock >= toBlock")
 		}
 
+		// Copying the topics across (instead of coercing i.Topics to a
+		// [][]common.Hash) clarifies their type for reflect.DeepEqual
 		q.Topics = make([][]common.Hash, len(i.Topics))
-		copy(q.Topics, i.Topics) // Simply coercing i.Topics to the underlying type confuses reflect.DeepEqual
-
-		return q, nil
-
-	case InitiatorRunLog:
-		topics := []common.Hash{RunLogTopic20190207withoutIndexes, RunLogTopic20190123withFullfillmentParams, RunLogTopic0original}
-		q.Topics = TopicFiltersForRunLog(topics, i.JobSpecID)
-		return q, nil
-
-	case InitiatorServiceAgreementExecutionLog:
-		topics := []common.Hash{ServiceAgreementExecutionLogTopic}
-		q.Topics = TopicFiltersForRunLog(topics, i.JobSpecID)
-		return q, nil
-
-	case InitiatorFluxMonitor:
+		copy(q.Topics, i.Topics)
+	case i.Type == InitiatorFluxMonitor:
 		q.Topics = [][]common.Hash{{AggregatorNewRoundLogTopic20191220}}
-		return q, nil
-
+	case initiationRequiresJobSpecID(i.Type):
+		q.Topics = [][]common.Hash{
+			TopicsForInitiatorsWhichRequireJobSpecIDTopic[i.Type],
+			JobSpecIDTopics(i.JobSpecID),
+		}
 	default:
-		return ethereum.FilterQuery{}, fmt.Errorf("Cannot generate a FilterQuery for initiator of type %T", i)
+		return ethereum.FilterQuery{},
+			fmt.Errorf("cannot generate a FilterQuery for initiator of type %T", i)
 	}
+	return q, nil
 }
 
 // LogRequest is the interface to allow polymorphic functionality of different
@@ -154,11 +174,13 @@ type LogRequest interface {
 }
 
 // InitiatorLogEvent encapsulates all information as a result of a received log from an
-// InitiatorSubscription.
+// InitiatorSubscription, and acts as a base struct for other log-initiated events
 type InitiatorLogEvent struct {
 	Log       eth.Log
 	Initiator Initiator
 }
+
+var _ LogRequest = InitiatorLogEvent{} // InitiatorLogEvent implements LogRequest
 
 // LogRequest is a factory method that coerces this log event to the correct
 // type based on Initiator.Type, exposed by the LogRequest interface.
@@ -166,9 +188,7 @@ func (le InitiatorLogEvent) LogRequest() LogRequest {
 	switch le.Initiator.Type {
 	case InitiatorEthLog:
 		return EthLogEvent{InitiatorLogEvent: le}
-	case InitiatorServiceAgreementExecutionLog:
-		fallthrough
-	case InitiatorRunLog:
+	case InitiatorRunLog, InitiatorServiceAgreementExecutionLog:
 		return RunLogEvent{le}
 	}
 	logger.Warnw("LogRequest: Unable to discern initiator type for log request", le.ForLogger()...)
@@ -216,20 +236,13 @@ func (le InitiatorLogEvent) ToDebug() {
 
 // BlockNumber returns the block number for the given InitiatorSubscriptionLogEvent.
 func (le InitiatorLogEvent) BlockNumber() *big.Int {
-	num := new(big.Int)
-	num.SetUint64(le.Log.BlockNumber)
-	return num
+	return new(big.Int).SetUint64(le.Log.BlockNumber)
 }
 
 // RunRequest returns a run request instance with the transaction hash,
 // present on all log initiated runs.
 func (le InitiatorLogEvent) RunRequest() (RunRequest, error) {
-	txHash := common.BytesToHash(le.Log.TxHash.Bytes())
-	blockHash := common.BytesToHash(le.Log.BlockHash.Bytes())
-	return RunRequest{
-		BlockHash: &blockHash,
-		TxHash:    &txHash,
-	}, nil
+	return RunRequest{BlockHash: &le.Log.BlockHash, TxHash: &le.Log.TxHash}, nil
 }
 
 // Validate returns true, no validation on this log event type.
@@ -283,7 +296,7 @@ func (le RunLogEvent) Validate() bool {
 func contractPayment(log eth.Log) (*assets.Link, error) {
 	version, err := log.GetTopic(0)
 	if err != nil {
-		return nil, fmt.Errorf("Missing RunLogEvent Topic#0: %v", err)
+		return nil, fmt.Errorf("missing RunLogEvent Topic#0: %v", err)
 	}
 
 	var encodedAmount common.Hash
@@ -318,7 +331,7 @@ func (le RunLogEvent) ValidateRequester() error {
 			return nil
 		}
 	}
-	return fmt.Errorf("Run Log didn't have have a valid requester: %v", le.Requester().Hex())
+	return fmt.Errorf("run Log didn't have have a valid requester: %v", le.Requester().Hex())
 }
 
 // Requester pulls the requesting address out of the LogEvent's topics.
@@ -347,14 +360,12 @@ func (le RunLogEvent) RunRequest() (RunRequest, error) {
 		return RunRequest{}, err
 	}
 
-	txHash := common.BytesToHash(le.Log.TxHash.Bytes())
-	blockHash := common.BytesToHash(le.Log.BlockHash.Bytes())
-	str := parser.parseRequestID(le.Log)
+	requestID := parser.parseRequestID(le.Log)
 	requester := le.Requester()
 	return RunRequest{
-		RequestID: &str,
-		TxHash:    &txHash,
-		BlockHash: &blockHash,
+		RequestID: &requestID,
+		TxHash:    &le.Log.TxHash,
+		BlockHash: &le.Log.BlockHash,
 		Requester: &requester,
 		Payment:   payment,
 	}, nil
@@ -372,7 +383,7 @@ func parserFromLog(log eth.Log) (logRequestParser, error) {
 	}
 	parser, ok := topicFactoryMap[topic]
 	if !ok {
-		return nil, fmt.Errorf("No parser for the RunLogEvent topic %s", topic.String())
+		return nil, fmt.Errorf("no parser for the RunLogEvent topic %s", topic.String())
 	}
 	return parser, nil
 }
@@ -398,21 +409,15 @@ func (p parseRunLog0original) parseJSON(log eth.Log) (JSON, error) {
 	if err != nil {
 		return js, err
 	}
-	js, err = js.Add("address", log.Address.String())
-	if err != nil {
-		return js, err
-	}
-
-	js, err = js.Add("dataPrefix", bytesToHex(data[:idSize]))
-	if err != nil {
-		return js, err
-	}
-
-	return js.Add("functionSelector", OracleFullfillmentFunctionID0original)
+	return js.MultiAdd([]KV{
+		{"address", log.Address.String()},
+		{"dataPrefix", bytesToHex(data[:idSize])},
+		{"functionSelector", OracleFullfillmentFunctionID0original},
+	})
 }
 
 func (parseRunLog0original) parseRequestID(log eth.Log) string {
-	return common.BytesToHash(log.Data[:idSize]).Hex()
+	return hexutil.Encode(log.Data[:idSize])
 }
 
 // parseRunLog20190123withFulfillmentParams parses the OracleRequest log format
@@ -429,23 +434,16 @@ func (parseRunLog20190123withFulfillmentParams) parseJSON(log eth.Log) (JSON, er
 	if err != nil {
 		return js, err
 	}
-
-	js, err = js.Add("address", log.Address.String())
-	if err != nil {
-		return js, err
-	}
-
 	callbackAndExpStart := idSize + versionSize
 	callbackAndExpEnd := callbackAndExpStart + callbackAddrSize + callbackFuncSize + expirationSize
 	dataPrefix := bytesToHex(append(append(data[:idSize],
 		log.Topics[RequestLogTopicPayment].Bytes()...),
 		data[callbackAndExpStart:callbackAndExpEnd]...))
-	js, err = js.Add("dataPrefix", dataPrefix)
-	if err != nil {
-		return js, err
-	}
-
-	return js.Add("functionSelector", OracleFulfillmentFunctionID20190123withFulfillmentParams)
+	return js.MultiAdd([]KV{
+		{"address", log.Address.String()},
+		{"dataPrefix", dataPrefix},
+		{"functionSelector", OracleFulfillmentFunctionID20190123withFulfillmentParams},
+	})
 }
 
 func (parseRunLog20190123withFulfillmentParams) parseRequestID(log eth.Log) string {
@@ -468,18 +466,11 @@ func (parseRunLog20190207withoutIndexes) parseJSON(log eth.Log) (JSON, error) {
 	if err != nil {
 		return js, fmt.Errorf("Error parsing CBOR: %v", err)
 	}
-
-	js, err = js.Add("address", log.Address.String())
-	if err != nil {
-		return js, err
-	}
-
-	js, err = js.Add("dataPrefix", bytesToHex(data[idStart:expirationEnd]))
-	if err != nil {
-		return js, err
-	}
-
-	return js.Add("functionSelector", OracleFulfillmentFunctionID20190128withoutCast)
+	return js.MultiAdd([]KV{
+		{"address", log.Address.String()},
+		{"dataPrefix", bytesToHex(data[idStart:expirationEnd])},
+		{"functionSelector", OracleFulfillmentFunctionID20190128withoutCast},
+	})
 }
 
 func (parseRunLog20190207withoutIndexes) parseRequestID(log eth.Log) string {

--- a/core/store/models/log_events.go
+++ b/core/store/models/log_events.go
@@ -410,10 +410,10 @@ func (p parseRunLog0original) parseJSON(log eth.Log) (JSON, error) {
 	if err != nil {
 		return js, err
 	}
-	return js.MultiAdd([]KV{
-		{"address", log.Address.String()},
-		{"dataPrefix", bytesToHex(data[:idSize])},
-		{"functionSelector", OracleFullfillmentFunctionID0original},
+	return js.MultiAdd(jsonObject{
+		"address":          log.Address.String(),
+		"dataPrefix":       bytesToHex(data[:idSize]),
+		"functionSelector": OracleFullfillmentFunctionID0original,
 	})
 }
 
@@ -440,10 +440,10 @@ func (parseRunLog20190123withFulfillmentParams) parseJSON(log eth.Log) (JSON, er
 	dataPrefix := bytesToHex(append(append(data[:idSize],
 		log.Topics[RequestLogTopicPayment].Bytes()...),
 		data[callbackAndExpStart:callbackAndExpEnd]...))
-	return js.MultiAdd([]KV{
-		{"address", log.Address.String()},
-		{"dataPrefix", dataPrefix},
-		{"functionSelector", OracleFulfillmentFunctionID20190123withFulfillmentParams},
+	return js.MultiAdd(jsonObject{
+		"address":          log.Address.String(),
+		"dataPrefix":       dataPrefix,
+		"functionSelector": OracleFulfillmentFunctionID20190123withFulfillmentParams,
 	})
 }
 
@@ -467,10 +467,10 @@ func (parseRunLog20190207withoutIndexes) parseJSON(log eth.Log) (JSON, error) {
 	if err != nil {
 		return js, fmt.Errorf("Error parsing CBOR: %v", err)
 	}
-	return js.MultiAdd([]KV{
-		{"address", log.Address.String()},
-		{"dataPrefix", bytesToHex(data[idStart:expirationEnd])},
-		{"functionSelector", OracleFulfillmentFunctionID20190128withoutCast},
+	return js.MultiAdd(jsonObject{
+		"address":          log.Address.String(),
+		"dataPrefix":       bytesToHex(data[idStart:expirationEnd]),
+		"functionSelector": OracleFulfillmentFunctionID20190128withoutCast,
 	})
 }
 

--- a/core/store/models/log_events.go
+++ b/core/store/models/log_events.go
@@ -86,9 +86,10 @@ var topicFactoryMap = map[common.Hash]logRequestParser{
 	RunLogTopic20190207withoutIndexes:         parseRunLog20190207withoutIndexes{},
 }
 
-// LogBasedChainlinkJobInitiators are initiators which kick off a user-specified
+// LogBasedChainlinkJobInitiators are initiators which kick off a log-specified
 // chainlink job when an appropriate ethereum log is received.
-// (InitiatorFluxMonitor kicks off work, but not a user-specified job.)
+// (InitiatorFluxMonitor kicks off a job when a log is emitted, but the JobID is
+// not taken from the log)
 var LogBasedChainlinkJobInitiators = []string{InitiatorRunLog, InitiatorEthLog,
 	InitiatorServiceAgreementExecutionLog}
 

--- a/core/store/models/topics_test.go
+++ b/core/store/models/topics_test.go
@@ -10,18 +10,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTopicFiltersForRunLog(t *testing.T) {
+func TestJobSpecIDTopics(t *testing.T) {
 	t.Parallel()
 
 	jobID, err := models.NewIDFromString("4a1eb0e8df314cb894024a38991cff0f")
 	require.NoError(t, err)
 
-	topics := models.TopicFiltersForRunLog([]common.Hash{models.RunLogTopic0original}, jobID)
+	topics := models.JobSpecIDTopics(jobID)
 	assert.Equal(t, 2, len(topics))
-	assert.Equal(
-		t,
-		[]common.Hash{models.RunLogTopic0original},
-		topics[models.RequestLogTopicSignature])
 
 	assert.Equal(
 		t,
@@ -29,7 +25,7 @@ func TestTopicFiltersForRunLog(t *testing.T) {
 			common.HexToHash("0x4a1eb0e8df314cb894024a38991cff0f00000000000000000000000000000000"),
 			common.HexToHash("0x3461316562306538646633313463623839343032346133383939316366663066"),
 		},
-		topics[1])
+		topics)
 }
 
 func TestRunLogTopic0original(t *testing.T) {


### PR DESCRIPTION
I keep finding this code hard to follow, whenever I come back to it. The goal of
this PR is to document the role of log_events.go's logic and data, and to
re-organize it a bit so its knowledge is a bit more centralized.