### PR TITLE
Basic multiword response capability for ethTx adapter

### DIFF
--- a/core/adapters/adapter.go
+++ b/core/adapters/adapter.go
@@ -57,9 +57,9 @@ type BaseAdapter interface {
 	Validate() error
 }
 
-type NoValidationCheckAdapter struct{}
+type NoValidationAdapterMixin struct{}
 
-func (a *NoValidationCheckAdapter) Validate() error { return nil }
+func (a *NoValidationAdapterMixin) Validate() error { return nil }
 
 // PipelineAdapter wraps a BaseAdapter with requirements for execution in the pipeline.
 type PipelineAdapter struct {

--- a/core/adapters/adapter.go
+++ b/core/adapters/adapter.go
@@ -53,7 +53,13 @@ var (
 // adapters have this minimum requirement.
 type BaseAdapter interface {
 	Perform(models.RunInput, *store.Store) models.RunOutput
+	// Validate returns an error if there's something inconsistent about this task
+	Validate() error
 }
+
+type NoValidationCheckAdapter struct{}
+
+func (a *NoValidationCheckAdapter) Validate() error { return nil }
 
 // PipelineAdapter wraps a BaseAdapter with requirements for execution in the pipeline.
 type PipelineAdapter struct {

--- a/core/adapters/bridge.go
+++ b/core/adapters/bridge.go
@@ -18,6 +18,7 @@ import (
 // Bridge adapter is responsible for connecting the task pipeline to external
 // adapters, allowing for custom computations to be executed and included in runs.
 type Bridge struct {
+	*NoValidationCheckAdapter
 	models.BridgeType
 	Params models.JSON
 }

--- a/core/adapters/bridge.go
+++ b/core/adapters/bridge.go
@@ -18,7 +18,7 @@ import (
 // Bridge adapter is responsible for connecting the task pipeline to external
 // adapters, allowing for custom computations to be executed and included in runs.
 type Bridge struct {
-	*NoValidationCheckAdapter
+	*NoValidationAdapterMixin
 	models.BridgeType
 	Params models.JSON
 }

--- a/core/adapters/compare.go
+++ b/core/adapters/compare.go
@@ -11,6 +11,7 @@ import (
 // Compare adapter type takes an Operator and a Value field to
 // compare to the previous task's Result.
 type Compare struct {
+	*NoValidationCheckAdapter
 	Operator string `json:"operator"`
 	Value    string `json:"value"`
 }

--- a/core/adapters/compare.go
+++ b/core/adapters/compare.go
@@ -11,7 +11,7 @@ import (
 // Compare adapter type takes an Operator and a Value field to
 // compare to the previous task's Result.
 type Compare struct {
-	*NoValidationCheckAdapter
+	*NoValidationAdapterMixin
 	Operator string `json:"operator"`
 	Value    string `json:"value"`
 }

--- a/core/adapters/copy.go
+++ b/core/adapters/copy.go
@@ -8,6 +8,7 @@ import (
 // Copy obj keys refers to which value to copy inside `data`,
 // each obj value refers to where to copy the value to inside `data`
 type Copy struct {
+	*NoValidationCheckAdapter
 	CopyPath JSONPath `json:"copyPath"`
 }
 

--- a/core/adapters/copy.go
+++ b/core/adapters/copy.go
@@ -8,7 +8,7 @@ import (
 // Copy obj keys refers to which value to copy inside `data`,
 // each obj value refers to where to copy the value to inside `data`
 type Copy struct {
-	*NoValidationCheckAdapter
+	*NoValidationAdapterMixin
 	CopyPath JSONPath `json:"copyPath"`
 }
 

--- a/core/adapters/eth_bool.go
+++ b/core/adapters/eth_bool.go
@@ -11,7 +11,7 @@ var evmFalse = "0x00000000000000000000000000000000000000000000000000000000000000
 var evmTrue = "0x0000000000000000000000000000000000000000000000000000000000000001"
 
 // EthBool holds no fields
-type EthBool struct{}
+type EthBool struct{ NoValidationCheckAdapter }
 
 // Perform returns the abi encoding for a boolean
 //

--- a/core/adapters/eth_bool.go
+++ b/core/adapters/eth_bool.go
@@ -11,7 +11,7 @@ var evmFalse = "0x00000000000000000000000000000000000000000000000000000000000000
 var evmTrue = "0x0000000000000000000000000000000000000000000000000000000000000001"
 
 // EthBool holds no fields
-type EthBool struct{ NoValidationCheckAdapter }
+type EthBool struct{ NoValidationAdapterMixin }
 
 // Perform returns the abi encoding for a boolean
 //

--- a/core/adapters/eth_format.go
+++ b/core/adapters/eth_format.go
@@ -10,7 +10,7 @@ import (
 )
 
 // EthBytes32 holds no fields.
-type EthBytes32 struct{}
+type EthBytes32 struct{ NoValidationCheckAdapter }
 
 // Perform returns the hex value of the first 32 bytes of a string
 // so that it is in the proper format to be written to the blockchain.
@@ -31,7 +31,7 @@ func (*EthBytes32) Perform(input models.RunInput, _ *store.Store) models.RunOutp
 }
 
 // EthInt256 holds no fields
-type EthInt256 struct{}
+type EthInt256 struct{ NoValidationCheckAdapter }
 
 // Perform returns the hex value of a given string so that it
 // is in the proper format to be written to the blockchain.
@@ -49,7 +49,7 @@ func (*EthInt256) Perform(input models.RunInput, _ *store.Store) models.RunOutpu
 }
 
 // EthUint256 holds no fields.
-type EthUint256 struct{}
+type EthUint256 struct{ NoValidationCheckAdapter }
 
 // Perform returns the hex value of a given string so that it
 // is in the proper format to be written to the blockchain.

--- a/core/adapters/eth_format.go
+++ b/core/adapters/eth_format.go
@@ -10,7 +10,7 @@ import (
 )
 
 // EthBytes32 holds no fields.
-type EthBytes32 struct{ NoValidationCheckAdapter }
+type EthBytes32 struct{ NoValidationAdapterMixin }
 
 // Perform returns the hex value of the first 32 bytes of a string
 // so that it is in the proper format to be written to the blockchain.
@@ -31,7 +31,7 @@ func (*EthBytes32) Perform(input models.RunInput, _ *store.Store) models.RunOutp
 }
 
 // EthInt256 holds no fields
-type EthInt256 struct{ NoValidationCheckAdapter }
+type EthInt256 struct{ NoValidationAdapterMixin }
 
 // Perform returns the hex value of a given string so that it
 // is in the proper format to be written to the blockchain.
@@ -49,7 +49,7 @@ func (*EthInt256) Perform(input models.RunInput, _ *store.Store) models.RunOutpu
 }
 
 // EthUint256 holds no fields.
-type EthUint256 struct{ NoValidationCheckAdapter }
+type EthUint256 struct{ NoValidationAdapterMixin }
 
 // Perform returns the hex value of a given string so that it
 // is in the proper format to be written to the blockchain.

--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -78,7 +78,7 @@ func getTxData(e *EthTx, input models.RunInput) ([]byte, error) {
 	if len(e.DataPrefix) > 0 {
 		payloadOffset = utils.EVMWordUint64(utils.EVMWordByteLen * 2)
 	}
-	output, err = utils.EVMTranscodeJSONWithFormat(result, e.DataFormat)
+	output, err = EVMTranscodeJSONWithFormat(result, e.DataFormat)
 	if err != nil {
 		return []byte{}, err
 	}
@@ -257,12 +257,12 @@ func checkForShortCircuitedFormat(
 	e *EthTx, result gjson.Result, defaultPrefix func(...[]byte) []byte) (
 	shortCircuited bool, output []byte, err error) {
 	switch e.DataFormat {
-	case utils.FormatRawHexWithFuncSelectorAndDataPrefix:
+	case FormatRawHexWithFuncSelectorAndDataPrefix:
 		return true, defaultPrefix(common.HexToHash(result.Str).Bytes()), nil
-	case utils.FormatRawHex:
+	case FormatRawHex:
 		if !utils.HasHexPrefix(result.Str) {
 			return true, nil, fmt.Errorf("%s must be 0x-prefixed, got %s",
-				utils.FormatRawHex, result.Str)
+				FormatRawHex, result.Str)
 		}
 		output, err := hex.DecodeString(utils.RemoveHexPrefix(result.Str))
 		return true, output, err
@@ -273,18 +273,18 @@ func checkForShortCircuitedFormat(
 // Validate returns an error if there's something inconsistent about this task
 func (p *EthTx) Validate() error {
 	switch p.DataFormat {
-	case utils.FormatRawHex:
+	case FormatRawHex:
 		if !bytes.Equal(p.FunctionSelector.Bytes(), eth.FunctionSelector{}.Bytes()) {
 			return fmt.Errorf(
 				"ethTx adapter cannot specify both `%s` format and functionSelector. "+
 					"Prior task must give function selector as the prefix of its output",
-				utils.FormatRawHex)
+				FormatRawHex)
 		}
 		if !bytes.Equal([]byte(p.DataPrefix), []byte{}) {
 			return fmt.Errorf(
 				"ethTx adapter cannot specify both `%s` format and dataPrefix. "+
 					"Prior task must give dataPrefix as the prefix of its output.",
-				utils.FormatRawHex)
+				FormatRawHex)
 		}
 	}
 	return nil

--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -258,7 +258,6 @@ func checkForShortCircuitedFormat(
 	shortCircuited bool, output []byte, err error) {
 	switch e.DataFormat {
 	case utils.FormatRawHexWithFuncSelectorAndDataPrefix:
-		// TODO(alx): Should we enforce 0x-prefix, here? Might break existing jobs...
 		return true, defaultPrefix(common.HexToHash(result.Str).Bytes()), nil
 	case utils.FormatRawHex:
 		if !utils.HasHexPrefix(result.Str) {

--- a/core/adapters/eth_tx_abi_encode.go
+++ b/core/adapters/eth_tx_abi_encode.go
@@ -23,6 +23,7 @@ const evmWordSize = 32
 // EthTxABIEncode holds the Address to send the result to and the FunctionABI
 // to use for encoding arguments.
 type EthTxABIEncode struct {
+	NoValidationCheckAdapter
 	// Ethereum address of the contract this task calls
 	Address common.Address `json:"address"`
 	// ABI of contract function this task calls

--- a/core/adapters/eth_tx_abi_encode.go
+++ b/core/adapters/eth_tx_abi_encode.go
@@ -23,7 +23,7 @@ const evmWordSize = 32
 // EthTxABIEncode holds the Address to send the result to and the FunctionABI
 // to use for encoding arguments.
 type EthTxABIEncode struct {
-	NoValidationCheckAdapter
+	NoValidationAdapterMixin
 	// Ethereum address of the contract this task calls
 	Address common.Address `json:"address"`
 	// ABI of contract function this task calls

--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -43,7 +43,7 @@ func TestEthTxAdapter_Perform(t *testing.T) {
 		{
 			"safe",
 			"0xf7fffff1",
-			"",
+			adapters.FormatRawHexWithFuncSelectorAndDataPrefix,
 			strpkg.Safe,
 			"0x0000000000000000000000000000000000000000000000000000000000000000f7fffff1",
 			models.RunStatusCompleted,
@@ -82,18 +82,18 @@ func TestEthTxAdapter_Perform(t *testing.T) {
 		},
 		{
 			name: fmt.Sprintf("confirmed with %s format",
-				utils.FormatPreformattedHexArguments),
+				adapters.FormatPreformattedHexArguments),
 			input:        "0x" + reallyLongHexString,
-			format:       utils.FormatPreformattedHexArguments,
+			format:       adapters.FormatPreformattedHexArguments,
 			receiptState: strpkg.Confirmed,
 			output: "0x" + strings.Repeat("00", 35) + "20" + // fn selector + offset
 				reallyLongHexString,
 			finalStatus: models.RunStatusPendingConfirmations,
 		},
 		{
-			name:         fmt.Sprintf("confirmed with %s format", utils.FormatRawHex),
+			name:         fmt.Sprintf("confirmed with %s format", adapters.FormatRawHex),
 			input:        "0x" + reallyLongHexString,
-			format:       utils.FormatRawHex,
+			format:       adapters.FormatRawHex,
 			receiptState: strpkg.Confirmed,
 			output:       "0x" + reallyLongHexString,
 			finalStatus:  models.RunStatusPendingConfirmations,

--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"math/big"
 	"strings"
 	"syscall"
@@ -80,13 +81,22 @@ func TestEthTxAdapter_Perform(t *testing.T) {
 			models.RunStatusPendingConfirmations,
 		},
 		{
-			name:         "confirmed with preformatted format",
+			name: fmt.Sprintf("confirmed with %s format",
+				utils.FormatPreformattedHexArguments),
 			input:        "0x" + reallyLongHexString,
-			format:       "preformatted",
+			format:       utils.FormatPreformattedHexArguments,
 			receiptState: strpkg.Confirmed,
 			output: "0x" + strings.Repeat("00", 35) + "20" + // fn selector + offset
 				reallyLongHexString,
 			finalStatus: models.RunStatusPendingConfirmations,
+		},
+		{
+			name:         fmt.Sprintf("confirmed with %s format", utils.FormatRawHex),
+			input:        "0x" + reallyLongHexString,
+			format:       utils.FormatRawHex,
+			receiptState: strpkg.Confirmed,
+			output:       "0x" + reallyLongHexString,
+			finalStatus:  models.RunStatusPendingConfirmations,
 		},
 	}
 

--- a/core/adapters/ethabi.go
+++ b/core/adapters/ethabi.go
@@ -1,0 +1,88 @@
+package adapters
+
+// This file contains functions used to transform an EthTx input to the raw
+// bytes of an ethereum transaction.
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"chainlink/core/utils"
+
+	"github.com/tidwall/gjson"
+)
+
+// The following are options to the "format" argument of the JSON representation
+// for adapters.EthTx. They control how EthTx will transform its input to an
+// ethereum transaction ready to send to an on-chain contract. There are
+// examples of the transformations they effect in TestEthTxAdapter_Perform (see
+// the "format", "input" and "output" fields of the test table called "tests")
+// and TestEVMTranscodeJSONWithFormat, which also uses "format", "input" and
+// "output" fields, but does not include the function selector or initial
+// argument offset, like most of the TestEthTxAdapter_Perform tests.
+const (
+	// FormatRawHexWithFuncSelectorAndDataPrefix is the default format behavior.
+	// Its output is prefixed with the ethTx function selector, followed by the
+	// data prefix
+	FormatRawHexWithFuncSelectorAndDataPrefix = ""
+	// FormatBytes encodes the output as bytes. I.e., the string input will be
+	// cast to bytes, and passed to the on-chain contract method as a solidity
+	// bytes array argument. (No conversion from hex is done; the string input
+	// must be the raw bytes!)
+	FormatBytes = "bytes"
+	// FormatPreformatted encodes the output, assumed to be hex, as bytes and
+	// passes them as arguments. Caller is responsible for all formatting for the
+	// EVM. Input must be 0x-prefixed
+	FormatPreformattedHexArguments = "preformattedHexArguments"
+	// FormatRawHex does no formatting at all. Caller is responsible for
+	// formatting the function selector and offset, in addition to any arguments
+	// to be passed with the transaction. Input must be 0x-prefixed
+	//
+	// Note that this option isn't adressed in EVMTranscodeJSONWithFormat, because
+	// eth_tx.go's getTxData short-circuits, when it encounters this.
+	FormatRawHex = "rawHex"
+	// FormatUint256 encodes the output as bytes containing a uint256
+	FormatUint256 = "uint256"
+	// FormatInt256 encodes the output as bytes containing an int256
+	FormatInt256 = "int256"
+	// FormatBool encodes the output as bytes containing a bool
+	FormatBool = "bool"
+)
+
+// EVMTranscodeJSONWithFormat given a JSON input and a format specifier, encode the
+// value for use by the EVM
+func EVMTranscodeJSONWithFormat(value gjson.Result, format string) ([]byte, error) {
+	switch format {
+	case FormatBytes:
+		return utils.EVMTranscodeBytes(value)
+	case FormatPreformattedHexArguments:
+		if !utils.HasHexPrefix(value.Str) {
+			return nil, fmt.Errorf("%s input must be 0x-prefixed, got %s",
+				FormatPreformattedHexArguments, value.Str)
+		}
+		return hex.DecodeString(utils.RemoveHexPrefix(value.Str))
+	case FormatUint256:
+		data, err := utils.EVMTranscodeUint256(value)
+		if err != nil {
+			return []byte{}, err
+		}
+		return utils.EVMEncodeBytes(data), nil
+
+	case FormatInt256:
+		data, err := utils.EVMTranscodeInt256(value)
+		if err != nil {
+			return []byte{}, err
+		}
+		return utils.EVMEncodeBytes(data), nil
+
+	case FormatBool:
+		data, err := utils.EVMTranscodeBool(value)
+		if err != nil {
+			return []byte{}, err
+		}
+		return utils.EVMEncodeBytes(data), nil
+
+	default:
+		return []byte{}, fmt.Errorf("unsupported format: %s", format)
+	}
+}

--- a/core/adapters/ethabi_test.go
+++ b/core/adapters/ethabi_test.go
@@ -1,0 +1,76 @@
+package adapters
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/gjson"
+)
+
+func TestEVMTranscodeJSONWithFormat(t *testing.T) {
+	reallyLongHexString := "0x" + strings.Repeat("0123456789abcdef", 100)
+	tests := []struct {
+		name   string
+		format string
+		input  string
+		output string
+	}{
+		{
+			"result is string",
+			FormatBytes,
+			`{"result": "hello world"}`,
+			"0x" +
+				"000000000000000000000000000000000000000000000000000000000000000b" +
+				"68656c6c6f20776f726c64000000000000000000000000000000000000000000",
+		},
+		{
+			"result is number",
+			FormatUint256,
+			`{"result": 31223}`,
+			"0x" +
+				"0000000000000000000000000000000000000000000000000000000000000020" +
+				"00000000000000000000000000000000000000000000000000000000000079f7",
+		},
+		{
+			"result is negative number",
+			FormatInt256,
+			`{"result": -123481273.1}`,
+			"0x" +
+				"0000000000000000000000000000000000000000000000000000000000000020" +
+				"fffffffffffffffffffffffffffffffffffffffffffffffffffffffff8a3d347",
+		},
+		{
+			"result is true",
+			FormatBool,
+			`{"result": true}`,
+			"0x" +
+				"0000000000000000000000000000000000000000000000000000000000000020" +
+				"0000000000000000000000000000000000000000000000000000000000000001",
+		},
+		{
+			"result is preformatted",
+			FormatPreformattedHexArguments,
+			fmt.Sprintf(`{"result": "%s"}`, reallyLongHexString),
+			reallyLongHexString,
+		},
+	}
+
+	for _, tt := range tests {
+		test := tt
+		t.Run(test.name, func(t *testing.T) {
+			input := gjson.GetBytes([]byte(test.input), "result")
+			out, err := EVMTranscodeJSONWithFormat(input, test.format)
+			require.NoError(t, err)
+			assert.Equal(t, test.output, hexutil.Encode(out))
+		})
+	}
+}
+
+func TestEVMTranscodeJSONWithFormat_UnsupportedEncoding(t *testing.T) {
+	_, err := EVMTranscodeJSONWithFormat(gjson.Result{}, "burgh")
+	assert.Error(t, err)
+}

--- a/core/adapters/http.go
+++ b/core/adapters/http.go
@@ -19,6 +19,7 @@ import (
 
 // HTTPGet requires a URL which is used for a GET request when the adapter is called.
 type HTTPGet struct {
+	*NoValidationCheckAdapter
 	URL          models.WebURL   `json:"url"`
 	GET          models.WebURL   `json:"get"`
 	Headers      http.Header     `json:"headers"`
@@ -58,6 +59,7 @@ func (hga *HTTPGet) GetRequest() (*http.Request, error) {
 
 // HTTPPost requires a URL which is used for a POST request when the adapter is called.
 type HTTPPost struct {
+	*NoValidationCheckAdapter
 	URL          models.WebURL   `json:"url"`
 	POST         models.WebURL   `json:"post"`
 	Headers      http.Header     `json:"headers"`

--- a/core/adapters/http.go
+++ b/core/adapters/http.go
@@ -19,7 +19,7 @@ import (
 
 // HTTPGet requires a URL which is used for a GET request when the adapter is called.
 type HTTPGet struct {
-	*NoValidationCheckAdapter
+	*NoValidationAdapterMixin
 	URL          models.WebURL   `json:"url"`
 	GET          models.WebURL   `json:"get"`
 	Headers      http.Header     `json:"headers"`
@@ -59,7 +59,7 @@ func (hga *HTTPGet) GetRequest() (*http.Request, error) {
 
 // HTTPPost requires a URL which is used for a POST request when the adapter is called.
 type HTTPPost struct {
-	*NoValidationCheckAdapter
+	*NoValidationAdapterMixin
 	URL          models.WebURL   `json:"url"`
 	POST         models.WebURL   `json:"post"`
 	Headers      http.Header     `json:"headers"`

--- a/core/adapters/json_parse.go
+++ b/core/adapters/json_parse.go
@@ -17,6 +17,7 @@ import (
 // JSONParse holds a path to the desired field in a JSON object,
 // made up of an array of strings.
 type JSONParse struct {
+	NoValidationCheckAdapter
 	Path JSONPath `json:"path"`
 }
 

--- a/core/adapters/json_parse.go
+++ b/core/adapters/json_parse.go
@@ -17,7 +17,7 @@ import (
 // JSONParse holds a path to the desired field in a JSON object,
 // made up of an array of strings.
 type JSONParse struct {
-	NoValidationCheckAdapter
+	NoValidationAdapterMixin
 	Path JSONPath `json:"path"`
 }
 

--- a/core/adapters/multiply.go
+++ b/core/adapters/multiply.go
@@ -9,6 +9,7 @@ import (
 
 // Multiply holds the a number to multiply the given value by.
 type Multiply struct {
+	NoValidationCheckAdapter
 	Times *big.Float `json:"-"`
 }
 

--- a/core/adapters/multiply.go
+++ b/core/adapters/multiply.go
@@ -9,7 +9,7 @@ import (
 
 // Multiply holds the a number to multiply the given value by.
 type Multiply struct {
-	NoValidationCheckAdapter
+	NoValidationAdapterMixin
 	Times *big.Float `json:"-"`
 }
 

--- a/core/adapters/no_op.go
+++ b/core/adapters/no_op.go
@@ -6,7 +6,7 @@ import (
 )
 
 // NoOp adapter type holds no fields
-type NoOp struct{}
+type NoOp struct{ *NoValidationCheckAdapter }
 
 // Perform returns the input
 func (noa *NoOp) Perform(input models.RunInput, _ *store.Store) models.RunOutput {
@@ -15,7 +15,7 @@ func (noa *NoOp) Perform(input models.RunInput, _ *store.Store) models.RunOutput
 }
 
 // NoOpPend adapter type holds no fields
-type NoOpPend struct{}
+type NoOpPend struct{ *NoValidationCheckAdapter }
 
 // Perform on this adapter type returns an empty RunResult with an
 // added field for the status to indicate the task is Pending.

--- a/core/adapters/no_op.go
+++ b/core/adapters/no_op.go
@@ -6,7 +6,7 @@ import (
 )
 
 // NoOp adapter type holds no fields
-type NoOp struct{ *NoValidationCheckAdapter }
+type NoOp struct{ *NoValidationAdapterMixin }
 
 // Perform returns the input
 func (noa *NoOp) Perform(input models.RunInput, _ *store.Store) models.RunOutput {
@@ -15,7 +15,7 @@ func (noa *NoOp) Perform(input models.RunInput, _ *store.Store) models.RunOutput
 }
 
 // NoOpPend adapter type holds no fields
-type NoOpPend struct{ *NoValidationCheckAdapter }
+type NoOpPend struct{ *NoValidationAdapterMixin }
 
 // Perform on this adapter type returns an empty RunResult with an
 // added field for the status to indicate the task is Pending.

--- a/core/adapters/quotient.go
+++ b/core/adapters/quotient.go
@@ -12,6 +12,7 @@ import (
 
 // Quotient holds the Dividend.
 type Quotient struct {
+	*NoValidationCheckAdapter
 	Dividend *big.Float `json:"-"`
 }
 

--- a/core/adapters/quotient.go
+++ b/core/adapters/quotient.go
@@ -12,7 +12,7 @@ import (
 
 // Quotient holds the Dividend.
 type Quotient struct {
-	*NoValidationCheckAdapter
+	*NoValidationAdapterMixin
 	Dividend *big.Float `json:"-"`
 }
 

--- a/core/adapters/random.go
+++ b/core/adapters/random.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Random adapter type holds no fields
-type Random struct{ *NoValidationCheckAdapter }
+type Random struct{ *NoValidationAdapterMixin }
 
 // Perform returns a random uint256 number in 0 | 2**256-1 range
 func (ra *Random) Perform(input models.RunInput, _ *store.Store) models.RunOutput {

--- a/core/adapters/random.go
+++ b/core/adapters/random.go
@@ -9,7 +9,7 @@ import (
 )
 
 // Random adapter type holds no fields
-type Random struct{}
+type Random struct{ *NoValidationCheckAdapter }
 
 // Perform returns a random uint256 number in 0 | 2**256-1 range
 func (ra *Random) Perform(input models.RunInput, _ *store.Store) models.RunOutput {

--- a/core/adapters/sleep.go
+++ b/core/adapters/sleep.go
@@ -11,6 +11,7 @@ import (
 
 // Sleep adapter allows a job to do nothing for some amount of wall time.
 type Sleep struct {
+	*NoValidationCheckAdapter
 	Until models.AnyTime `json:"until"`
 }
 

--- a/core/adapters/sleep.go
+++ b/core/adapters/sleep.go
@@ -11,7 +11,7 @@ import (
 
 // Sleep adapter allows a job to do nothing for some amount of wall time.
 type Sleep struct {
-	*NoValidationCheckAdapter
+	*NoValidationAdapterMixin
 	Until models.AnyTime `json:"until"`
 }
 

--- a/core/adapters/wasm.go
+++ b/core/adapters/wasm.go
@@ -11,6 +11,7 @@ import (
 
 // Wasm represents a wasm binary encoded as base64 or wasm encoded as text (a lisp like language).
 type Wasm struct {
+	*NoValidationCheckAdapter
 	WasmT string `json:"wasmt"`
 }
 

--- a/core/adapters/wasm.go
+++ b/core/adapters/wasm.go
@@ -11,7 +11,7 @@ import (
 
 // Wasm represents a wasm binary encoded as base64 or wasm encoded as text (a lisp like language).
 type Wasm struct {
-	*NoValidationCheckAdapter
+	*NoValidationAdapterMixin
 	WasmT string `json:"wasmt"`
 }
 

--- a/core/adapters/wasm_sgx.go
+++ b/core/adapters/wasm_sgx.go
@@ -22,6 +22,7 @@ import (
 
 // Wasm represents a wasm binary encoded as base64 or wasm encoded as text (a lisp like language).
 type Wasm struct {
+	NoValidationAdapterMixin
 	Wasm string `json:"wasm"`
 }
 

--- a/core/services/testdata/ethtx_inconsistent_params.json
+++ b/core/services/testdata/ethtx_inconsistent_params.json
@@ -1,0 +1,7 @@
+{
+  "initiators": [{"type": "ethLog"}],
+  "tasks": [
+    {"type": "ethtx",
+     "params": {"format": "rawHex", "functionselector": "0x12345678"}}
+  ]
+}

--- a/core/services/validators.go
+++ b/core/services/validators.go
@@ -205,7 +205,10 @@ func validateTask(task models.TaskSpec, store *store.Store) error {
 			return errors.New("EthTxABIEncode Adapter is not implemented yet")
 		}
 	}
-	return err
+	if err != nil {
+		return err
+	}
+	return adapter.Validate()
 }
 
 // ValidateServiceAgreement checks the ServiceAgreement for any application logic errors.

--- a/core/services/validators_test.go
+++ b/core/services/validators_test.go
@@ -70,6 +70,16 @@ func TestValidateJob(t *testing.T) {
 			cltest.MustReadFile(t, "testdata/runlog_2_ethlogs_job.json"),
 			models.NewJSONAPIErrorsWith("Cannot RunLog initiated jobs cannot have more than one EthTx Task"),
 		},
+		{
+			// Basic test that the consistency check is operating correctly. Does not
+			// test all failures.
+			"inconsistent ethtx params",
+			cltest.MustReadFile(t, "testdata/ethtx_inconsistent_params.json"),
+			models.NewJSONAPIErrorsWith(fmt.Sprintf(
+				"ethTx adapter cannot specify both `%s` format and functionSelector. "+
+					"Prior task must give function selector as the prefix of its output",
+				utils.FormatRawHex)),
+		},
 	}
 
 	store, cleanup := cltest.NewStore(t)

--- a/core/utils/ethabi.go
+++ b/core/utils/ethabi.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"bytes"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"math/big"
 	"strconv"
@@ -16,6 +17,9 @@ import (
 const (
 	// FormatBytes encodes the output as bytes
 	FormatBytes = "bytes"
+	// FormatPreformatted encodes the output, assumed to be hex, as bytes. Caller
+	// is responsible for all formatting for the EVM.
+	FormatPreformatted = "preformatted"
 	// FormatUint256 encodes the output as bytes containing a uint256
 	FormatUint256 = "uint256"
 	// FormatInt256 encodes the output as bytes containing an int256
@@ -185,7 +189,8 @@ func EVMTranscodeJSONWithFormat(value gjson.Result, format string) ([]byte, erro
 	switch format {
 	case FormatBytes:
 		return EVMTranscodeBytes(value)
-
+	case FormatPreformatted:
+		return hex.DecodeString(RemoveHexPrefix(value.Str))
 	case FormatUint256:
 		data, err := EVMTranscodeUint256(value)
 		if err != nil {

--- a/core/utils/ethabi.go
+++ b/core/utils/ethabi.go
@@ -30,7 +30,7 @@ const (
 	FormatPreformattedHexArguments = "preformattedHexArguments"
 	// FormatRawHex does no formatting at all. Caller is responsible for
 	// formatting the function selector and offset, in addition to any arguments
-	// to be passed with the transaction.
+	// to be passed with the transaction. Input must be 0x-prefixed
 	FormatRawHex = "rawHex"
 	// FormatUint256 encodes the output as bytes containing a uint256
 	FormatUint256 = "uint256"

--- a/core/utils/ethabi.go
+++ b/core/utils/ethabi.go
@@ -31,6 +31,9 @@ const (
 	// FormatRawHex does no formatting at all. Caller is responsible for
 	// formatting the function selector and offset, in addition to any arguments
 	// to be passed with the transaction. Input must be 0x-prefixed
+	//
+	// Note that this option isn't adressed in EVMTranscodeJSONWithFormat, because
+	// eth_tx.go's getTxData short-circuits, when it encounters this.
 	FormatRawHex = "rawHex"
 	// FormatUint256 encodes the output as bytes containing a uint256
 	FormatUint256 = "uint256"

--- a/core/utils/ethabi_test.go
+++ b/core/utils/ethabi_test.go
@@ -1,15 +1,12 @@
 package utils
 
 import (
-	"fmt"
 	"math"
 	"math/big"
-	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
 
@@ -402,70 +399,6 @@ func TestEVMTranscodeInt256(t *testing.T) {
 	}
 }
 
-func TestEVMTranscodeJSONWithFormat(t *testing.T) {
-	reallyLongHexString := "0x" + strings.Repeat("0123456789abcdef", 100)
-	tests := []struct {
-		name   string
-		format string
-		input  string
-		output string
-	}{
-		{
-			"result is string",
-			FormatBytes,
-			`{"result": "hello world"}`,
-			"0x" +
-				"000000000000000000000000000000000000000000000000000000000000000b" +
-				"68656c6c6f20776f726c64000000000000000000000000000000000000000000",
-		},
-		{
-			"result is number",
-			FormatUint256,
-			`{"result": 31223}`,
-			"0x" +
-				"0000000000000000000000000000000000000000000000000000000000000020" +
-				"00000000000000000000000000000000000000000000000000000000000079f7",
-		},
-		{
-			"result is negative number",
-			FormatInt256,
-			`{"result": -123481273.1}`,
-			"0x" +
-				"0000000000000000000000000000000000000000000000000000000000000020" +
-				"fffffffffffffffffffffffffffffffffffffffffffffffffffffffff8a3d347",
-		},
-		{
-			"result is true",
-			FormatBool,
-			`{"result": true}`,
-			"0x" +
-				"0000000000000000000000000000000000000000000000000000000000000020" +
-				"0000000000000000000000000000000000000000000000000000000000000001",
-		},
-		{
-			"result is preformatted",
-			FormatPreformattedHexArguments,
-			fmt.Sprintf(`{"result": "%s"}`, reallyLongHexString),
-			reallyLongHexString,
-		},
-	}
-
-	for _, tt := range tests {
-		test := tt
-		t.Run(test.name, func(t *testing.T) {
-			input := gjson.GetBytes([]byte(test.input), "result")
-			out, err := EVMTranscodeJSONWithFormat(input, test.format)
-			require.NoError(t, err)
-			assert.Equal(t, test.output, hexutil.Encode(out))
-		})
-	}
-}
-
-func TestEVMTranscodeJSONWithFormat_UnsupportedEncoding(t *testing.T) {
-	_, err := EVMTranscodeJSONWithFormat(gjson.Result{}, "burgh")
-	assert.Error(t, err)
-}
-
 func TestRoundToEVMWordBorder(t *testing.T) {
 	assert.Equal(t, 0, roundToEVMWordBorder(0))
 	assert.Equal(t, 0, roundToEVMWordBorder(32))
@@ -521,4 +454,8 @@ func TestParseDecimalString(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, test.output, out.String())
 	}
+}
+
+func ExampleFormatRawHexWithFuncSelectorAndDataPrefix() {
+
 }

--- a/core/utils/ethabi_test.go
+++ b/core/utils/ethabi_test.go
@@ -444,7 +444,7 @@ func TestEVMTranscodeJSONWithFormat(t *testing.T) {
 		},
 		{
 			"result is preformatted",
-			FormatPreformatted,
+			FormatPreformattedHexArguments,
 			fmt.Sprintf(`{"result": "%s"}`, reallyLongHexString),
 			reallyLongHexString,
 		},

--- a/core/utils/ethabi_test.go
+++ b/core/utils/ethabi_test.go
@@ -1,12 +1,15 @@
 package utils
 
 import (
+	"fmt"
 	"math"
 	"math/big"
+	"strings"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
 
@@ -400,6 +403,7 @@ func TestEVMTranscodeInt256(t *testing.T) {
 }
 
 func TestEVMTranscodeJSONWithFormat(t *testing.T) {
+	reallyLongHexString := "0x" + strings.Repeat("0123456789abcdef", 100)
 	tests := []struct {
 		name   string
 		format string
@@ -438,6 +442,12 @@ func TestEVMTranscodeJSONWithFormat(t *testing.T) {
 				"0000000000000000000000000000000000000000000000000000000000000020" +
 				"0000000000000000000000000000000000000000000000000000000000000001",
 		},
+		{
+			"result is preformatted",
+			FormatPreformatted,
+			fmt.Sprintf(`{"result": "%s"}`, reallyLongHexString),
+			reallyLongHexString,
+		},
 	}
 
 	for _, tt := range tests {
@@ -445,7 +455,7 @@ func TestEVMTranscodeJSONWithFormat(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			input := gjson.GetBytes([]byte(test.input), "result")
 			out, err := EVMTranscodeJSONWithFormat(input, test.format)
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, test.output, hexutil.Encode(out))
 		})
 	}


### PR DESCRIPTION
This is a simple passthrough option for raw bytes, expressed as hex. What
actually ends up being transmitted in the transaction is the ethTx function
selector, followed by 32 as a uint256, followed by the caller's input.