### PR TITLE
Clean up secp256k1

### DIFF
--- a/core/services/signatures/ethdss/ethdss.go
+++ b/core/services/signatures/ethdss/ethdss.go
@@ -16,7 +16,7 @@
 //
 // This is mostly copied from the sign/dss package, with minor adjustments for
 // use with ethschnorr.
-package dss
+package ethdss
 
 import (
 	"bytes"
@@ -250,11 +250,7 @@ func (d *DSS) Signature() (ethschnorr.Signature, error) {
 	rv.Signature = secp256k1.ToInt(signature)
 	// commitmentPublicKey corresponds to V in step 4 of section 4.2
 	commitmentPublicKey := d.random.Commitments()[0]
-	rv.CommitmentPublicAddress, err = secp256k1.EthereumAddress(
-		commitmentPublicKey)
-	if err != nil {
-		return nil, err
-	}
+	rv.CommitmentPublicAddress = secp256k1.EthereumAddress(commitmentPublicKey)
 	return rv, nil
 }
 
@@ -263,10 +259,7 @@ func (d *DSS) Signature() (ethschnorr.Signature, error) {
 // has no effect on the correctness or robustness arguments from the paper.)
 func (d *DSS) hashSig() kyber.Scalar {
 	v := d.random.Commitments()[0] // Public-key commitment, in signature from d
-	vAddress, err := secp256k1.EthereumAddress(v)
-	if err != nil {
-		panic(err)
-	}
+	vAddress := secp256k1.EthereumAddress(v)
 	publicKey := d.long.Commitments()[0]
 	rv, err := ethschnorr.ChallengeHash(publicKey, vAddress, d.msg)
 	if err != nil {

--- a/core/services/signatures/ethdss/ethdss_test.go
+++ b/core/services/signatures/ethdss/ethdss_test.go
@@ -1,4 +1,4 @@
-package dss
+package ethdss
 
 import (
 	"crypto/rand"

--- a/core/services/signatures/ethschnorr/ethschnorr.go
+++ b/core/services/signatures/ethschnorr/ethschnorr.go
@@ -96,10 +96,7 @@ func Sign(private kyber.Scalar, msg *big.Int) (Signature, error) {
 	commitmentSecretKey := secp256k1Group.Scalar().Pick(
 		secp256k1Suite.RandomStream())
 	commitmentPublicKey := secp256k1Group.Point().Mul(commitmentSecretKey, nil)
-	commitmentPublicAddress, err := secp256k1.EthereumAddress(commitmentPublicKey)
-	if err != nil {
-		return nil, err
-	}
+	commitmentPublicAddress := secp256k1.EthereumAddress(commitmentPublicKey)
 
 	public := secp256k1Group.Point().Mul(private, nil)
 	challenge, err := ChallengeHash(public, commitmentPublicAddress, msg)
@@ -146,11 +143,7 @@ func Verify(public kyber.Point, msg *big.Int, s Signature) error {
 	maybeCommitmentPublicKey := secp256k1Group.Point().Add(
 		secp256k1Group.Point().Mul(sigScalar, nil),
 		secp256k1Group.Point().Mul(challenge, public))
-	maybeCommitmentPublicAddress, err := secp256k1.EthereumAddress(
-		maybeCommitmentPublicKey)
-	if err != nil {
-		return err
-	}
+	maybeCommitmentPublicAddress := secp256k1.EthereumAddress(maybeCommitmentPublicKey)
 	if !bytes.Equal(s.CommitmentPublicAddress[:],
 		maybeCommitmentPublicAddress[:]) {
 		return fmt.Errorf("signature mismatch")

--- a/core/services/signatures/secp256k1/point_test.go
+++ b/core/services/signatures/secp256k1/point_test.go
@@ -67,6 +67,7 @@ func TestPoint_Embed(t *testing.T) {
 		require.True(t, s256.IsOnCurve(p.X.int(), p.Y.int()),
 			"should embed to a secp256k1 point")
 		output, err := p.Data()
+		require.NoError(t, err)
 		require.True(t, bytes.Equal(data, output),
 			"should get same value back after round-trip "+
 				"embedding, got %v, then %v", data, output)
@@ -200,8 +201,7 @@ func TestPoint_EthereumAddress(t *testing.T) {
 	require.True(t, ok, "failed to parse private key")
 	private := newScalar(pInt)
 	public := newPoint().Mul(private, nil)
-	address, err := EthereumAddress(public)
-	require.Nil(t, err)
+	address := EthereumAddress(public)
 	assert.Equal(t, fmt.Sprintf("%x", address),
 		"c2d7cf95645d33006175b78989035c7c9061d3f9")
 }

--- a/core/services/signatures/secp256k1/scalar.go
+++ b/core/services/signatures/secp256k1/scalar.go
@@ -201,9 +201,9 @@ func (s *secp256k1Scalar) SetBytes(a []byte) kyber.Scalar {
 
 // IsSecp256k1Scalar returns true if p is a secp256k1Scalar
 func IsSecp256k1Scalar(s kyber.Scalar) bool {
-	switch s.(type) {
+	switch s := s.(type) {
 	case *secp256k1Scalar:
-		s.(*secp256k1Scalar).modG()
+		s.modG()
 		return true
 	default:
 		return false

--- a/core/services/vrf/vrf.go
+++ b/core/services/vrf/vrf.go
@@ -271,10 +271,7 @@ func (proof *Proof) Verify() (bool, error) {
 	uPrime := linearCombination(proof.C, proof.PublicKey, proof.S, Generator)
 	// c*secretKey*h + (m - c*secretKey)*h = m*h = v
 	vPrime := linearCombination(proof.C, proof.Gamma, proof.S, h)
-	uWitness, err := secp256k1.EthereumAddress(uPrime)
-	if err != nil {
-		return false, errors.Wrap(err, "vrf.VerifyProof#EthereumAddress")
-	}
+	uWitness := secp256k1.EthereumAddress(uPrime)
 	cPrime := ScalarFromCurvePoints(h, proof.PublicKey, proof.Gamma, uWitness, vPrime)
 	output, err := utils.Keccak256(secp256k1.LongMarshal(proof.Gamma))
 	if err != nil {
@@ -308,10 +305,7 @@ func GenerateProof(secretKey, seed, nonce *big.Int) (*Proof, error) {
 	}
 	sm := secp256k1.IntToScalar(nonce)
 	u := rcurve.Point().Mul(sm, Generator)
-	uWitness, err := secp256k1.EthereumAddress(u)
-	if err != nil {
-		panic(errors.Wrap(err, "while computing Ethereum Address for proof"))
-	}
+	uWitness := secp256k1.EthereumAddress(u)
 	v := rcurve.Point().Mul(sm, h)
 	c := ScalarFromCurvePoints(h, publicKey, gamma, uWitness, v)
 	// s = (m - c*secretKey) % Order

--- a/core/services/vrf/vrf_test.go
+++ b/core/services/vrf/vrf_test.go
@@ -1,7 +1,6 @@
 package vrf
 
 import (
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -79,8 +78,7 @@ func TestVRF_HashToCurve(t *testing.T) {
 
 func TestVRF_ScalarFromCurvePoints(t *testing.T) {
 	g := Generator
-	ga, err := secp256k1.EthereumAddress(g)
-	require.NoError(t, err)
+	ga := secp256k1.EthereumAddress(g)
 	s := ScalarFromCurvePoints(g, g, g, ga, g)
 	eS := "2b1049accb1596a24517f96761b22600a690ee5c6b6cadae3fa522e7d95ba338"
 	// See 'Computes the same hashed scalar from curve points as the golang code' in Curve.js
@@ -99,10 +97,6 @@ func TestVRF_GenerateProof(t *testing.T) {
 	assert.True(t, publicKey.Equal(proof.PublicKey))
 	gammaX, gammaY := CoordsFromPoint(proof.Gamma)
 	// See 'Accepts a valid VRF proof' in VRF.js. These outputs are used there
-	fmt.Printf("cGamma %+v\n", rcurve.Point().Mul(secp256k1.IntToScalar(proof.C), proof.Gamma))
-	h, err := HashToCurve(publicKey, seed)
-	require.NoError(t, err)
-	fmt.Printf("sHash %+v\n", rcurve.Point().Mul(secp256k1.IntToScalar(proof.S), h))
 	gX := "530fddd863609aa12030a07c5fdb323bb392a88343cea123b7f074883d2654c4"
 	gY := "6fd4ee394bf2a3de542c0e5f3c86fc8f75b278a017701a59d69bdf5134dd6b70"
 	assert.Equal(t, bigFromHex(gX), gammaX)


### PR DESCRIPTION
Small improvements to the `secp256k1` API. Basically, `EthereumAddress` panics on error, because the errors it can possibly produce are impossible to handle (e.g., OOM).