### PR TITLE
Rewrite job_spec_controller in idiomatic go

### DIFF
--- a/core/web/job_specs_controller.go
+++ b/core/web/job_specs_controller.go
@@ -86,9 +86,6 @@ func (jsc *JobSpecsController) Create(c *gin.Context) {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
 	}
-	// TODO(alx): Roundtrip the presenters.JobSpec through JSON, back to a
-	// JobSpec, and validate it. This will warn developers when there's a
-	// disparity in the presenters logic for the spec.
 	// https://www.pivotaltracker.com/story/show/171169052
 	jsonAPIResponse(c, presenters.JobSpec{JobSpec: js}, "job")
 }


### PR DESCRIPTION
The previous if/then/else/if/then/else chain was a nice trick for appeasing Code
Climate's four-return-per-function rule, but it was difficult to read, and
difficult to insert diagnostic information into. This is much nicer to work
with.