### PR TITLE
fix hanging integration tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -94,7 +94,7 @@ jobs:
     working_directory: ~/chainlink
     steps:
       - checkout
-      - run: cd ./tools/docker && ./compose test
+      - run: cd ./tools/docker && timeout --foreground 1200s ./compose test
   parity-postgres:
     resource_class: 2xlarge
     machine:
@@ -103,7 +103,7 @@ jobs:
     working_directory: ~/chainlink
     steps:
       - checkout
-      - run: cd ./tools/docker && ./compose test
+      - run: cd ./tools/docker && timeout --foreground 1200s ./compose test
   solidity:
     resource_class: xlarge
     docker:

--- a/tools/docker/docker-compose.deps.yaml
+++ b/tools/docker/docker-compose.deps.yaml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.5'
 
 services:
   wait-db:

--- a/tools/docker/docker-compose.dev-integration.yaml
+++ b/tools/docker/docker-compose.dev-integration.yaml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.5'
 
 services:
   integration:

--- a/tools/docker/docker-compose.dev.yaml
+++ b/tools/docker/docker-compose.dev.yaml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.5'
 services:
   node:
     entrypoint: '/bin/sh -c "while sleep 1000; do :; done"'

--- a/tools/docker/docker-compose.gethnet.yaml
+++ b/tools/docker/docker-compose.gethnet.yaml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.5'
 
 services:
   node:

--- a/tools/docker/docker-compose.integration.yaml
+++ b/tools/docker/docker-compose.integration.yaml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.5'
 
 services:
   integration:

--- a/tools/docker/docker-compose.integration.yaml
+++ b/tools/docker/docker-compose.integration.yaml
@@ -9,7 +9,8 @@ services:
       dockerfile: tools/docker/integration.Dockerfile
       args:
         - SRCROOT
-    shm_size: '128m' # https://stackoverflow.com/questions/30210362/how-to-increase-the-size-of-the-dev-shm-in-docker-container/49667456#49667456
+      shm_size: '256mb' # https://stackoverflow.com/questions/30210362/how-to-increase-the-size-of-the-dev-shm-in-docker-container/49667456#49667456
+    shm_size: '256mb' # https://stackoverflow.com/questions/30210362/how-to-increase-the-size-of-the-dev-shm-in-docker-container/49667456#49667456
     volumes:
       # Forwards the local Docker socket to the container.
       - /var/run/docker.sock:/var/run/docker.sock

--- a/tools/docker/docker-compose.integration.yaml
+++ b/tools/docker/docker-compose.integration.yaml
@@ -9,8 +9,8 @@ services:
       dockerfile: tools/docker/integration.Dockerfile
       args:
         - SRCROOT
-      shm_size: '256mb' # https://stackoverflow.com/questions/30210362/how-to-increase-the-size-of-the-dev-shm-in-docker-container/49667456#49667456
-    shm_size: '256mb' # https://stackoverflow.com/questions/30210362/how-to-increase-the-size-of-the-dev-shm-in-docker-container/49667456#49667456
+      shm_size: '512mb' # https://stackoverflow.com/questions/30210362/how-to-increase-the-size-of-the-dev-shm-in-docker-container/49667456#49667456
+    shm_size: '512mb' # https://stackoverflow.com/questions/30210362/how-to-increase-the-size-of-the-dev-shm-in-docker-container/49667456#49667456
     volumes:
       # Forwards the local Docker socket to the container.
       - /var/run/docker.sock:/var/run/docker.sock

--- a/tools/docker/docker-compose.integration.yaml
+++ b/tools/docker/docker-compose.integration.yaml
@@ -9,6 +9,7 @@ services:
       dockerfile: tools/docker/integration.Dockerfile
       args:
         - SRCROOT
+    shm_size: '128m' # https://stackoverflow.com/questions/30210362/how-to-increase-the-size-of-the-dev-shm-in-docker-container/49667456#49667456
     volumes:
       # Forwards the local Docker socket to the container.
       - /var/run/docker.sock:/var/run/docker.sock

--- a/tools/docker/docker-compose.paritynet.yaml
+++ b/tools/docker/docker-compose.paritynet.yaml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.5'
 
 services:
   node:

--- a/tools/docker/docker-compose.postgres.yaml
+++ b/tools/docker/docker-compose.postgres.yaml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.5'
 
 services:
   node:

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -1,4 +1,4 @@
-version: '3.1'
+version: '3.5'
 
 services:
   node:


### PR DESCRIPTION
[Bump the shm size](https://stackoverflow.com/questions/30210362/how-to-increase-the-size-of-the-dev-shm-in-docker-container/49667456#49667456) in docker [to prevent cypress from crashing](https://github.com/cypress-io/cypress/issues/4434).

Along the way, bump to docker-compose version 3.5 and add a max timeout to the integration tests.