### PR TITLE
Run go-postgres tests on CircleCI with verbose output

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
           paths:
             - '/go/pkg/mod'
       - run: yarn setup:contracts
-      - run: go test -p 3 -parallel 2 ./...
+      - run: go test -v -p 3 -parallel 2 ./...
   rust:
     docker:
       - image: smartcontract/builder:1.0.25


### PR DESCRIPTION
This makes it easier to debug test failures on CI 