### PR TITLE
Remove virtual keyword from v6 AggregatorInterface

### DIFF
--- a/evm-contracts/src/v0.6/dev/AggregatorInterface.sol
+++ b/evm-contracts/src/v0.6/dev/AggregatorInterface.sol
@@ -1,11 +1,11 @@
 pragma solidity ^0.6.0;
 
 interface AggregatorInterface {
-  function latestAnswer() external view virtual returns (int256);
-  function latestTimestamp() external view virtual returns (uint256);
-  function latestRound() external view virtual returns (uint256);
-  function getAnswer(uint256 roundId) external view virtual returns (int256);
-  function getTimestamp(uint256 roundId) external view virtual returns (uint256);
+  function latestAnswer() external view returns (int256);
+  function latestTimestamp() external view returns (uint256);
+  function latestRound() external view returns (uint256);
+  function getAnswer(uint256 roundId) external view returns (int256);
+  function getTimestamp(uint256 roundId) external view returns (uint256);
 
   event AnswerUpdated(int256 indexed current, uint256 indexed roundId, uint256 timestamp);
   event NewRound(uint256 indexed roundId, address indexed startedBy);


### PR DESCRIPTION
@se3000 I didn't catch this with the update PR. The `virtual` keyword is already implied in Solidity 6 with interfaces.