### PR TITLE
Fix method chain id not registered #170925095

### DIFF
--- a/core/adapters/bridge_test.go
+++ b/core/adapters/bridge_test.go
@@ -46,7 +46,7 @@ func TestBridge_PerformEmbedsParamsInData(t *testing.T) {
 }
 
 func setupJobRunAndStore(t *testing.T, txHash []byte, blockHash []byte) (*store.Store, *models.ID, func()) {
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.Lenient)
 	require.NoError(t, app.Start())
 	store := app.Store
 	jr := app.MustCreateJobRun(txHash, blockHash)

--- a/core/cmd/client_test.go
+++ b/core/cmd/client_test.go
@@ -44,7 +44,7 @@ func TestTerminalCookieAuthenticator_AuthenticateWithoutSession(t *testing.T) {
 func TestTerminalCookieAuthenticator_AuthenticateWithSession(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 	app.MustSeedUserSession()

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -209,7 +209,7 @@ func TestClient_RunNodeWithAPICredentialsFile(t *testing.T) {
 func TestClient_ImportKey(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -14,7 +14,6 @@ import (
 	"chainlink/core/internal/cltest"
 	"chainlink/core/store/models"
 	"chainlink/core/store/presenters"
-	"chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
@@ -25,13 +24,12 @@ import (
 func TestClient_DisplayAccountBalance(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
-	require.NoError(t, app.Start())
+	app.EthMock.Register("eth_getBalance", "0x0100")
+	app.EthMock.Register("eth_call", "0x0100")
 
-	ethMock := app.MockCallerSubscriberClient()
-	ethMock.Register("eth_getBalance", "0x0100")
-	ethMock.Register("eth_call", "0x0100")
+	require.NoError(t, app.Start())
 
 	client, r := app.NewClientAndRenderer()
 
@@ -45,7 +43,7 @@ func TestClient_DisplayAccountBalance(t *testing.T) {
 func TestClient_IndexJobSpecs(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -65,7 +63,7 @@ func TestClient_IndexJobSpecs(t *testing.T) {
 func TestClient_ShowJobRun_Exists(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -87,7 +85,7 @@ func TestClient_ShowJobRun_Exists(t *testing.T) {
 func TestClient_ShowJobRun_NotFound(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -103,7 +101,7 @@ func TestClient_ShowJobRun_NotFound(t *testing.T) {
 func TestClient_IndexJobRuns(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -131,7 +129,7 @@ func TestClient_IndexJobRuns(t *testing.T) {
 func TestClient_ShowJobSpec_Exists(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -151,7 +149,7 @@ func TestClient_ShowJobSpec_Exists(t *testing.T) {
 func TestClient_ShowJobSpec_NotFound(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -169,7 +167,7 @@ var EndAt = time.Now().AddDate(0, 10, 0).Round(time.Second).UTC()
 func TestClient_CreateServiceAgreement(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -231,7 +229,7 @@ func TestClient_CreateExternalInitiator(t *testing.T) {
 	for _, tt := range tests {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
-			app, cleanup := cltest.NewApplicationWithKey(t)
+			app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 			defer cleanup()
 			require.NoError(t, app.Start())
 
@@ -270,7 +268,7 @@ func TestClient_CreateExternalInitiator_Errors(t *testing.T) {
 	for _, tt := range tests {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
-			app, cleanup := cltest.NewApplicationWithKey(t)
+			app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 			defer cleanup()
 			require.NoError(t, app.Start())
 
@@ -292,7 +290,7 @@ func TestClient_CreateExternalInitiator_Errors(t *testing.T) {
 func TestClient_DestroyExternalInitiator(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -316,7 +314,7 @@ func TestClient_DestroyExternalInitiator(t *testing.T) {
 func TestClient_DestroyExternalInitiator_NotFound(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -332,7 +330,7 @@ func TestClient_DestroyExternalInitiator_NotFound(t *testing.T) {
 func TestClient_CreateJobSpec(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -368,7 +366,7 @@ func TestClient_CreateJobSpec(t *testing.T) {
 func TestClient_ArchiveJobSpec(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -390,7 +388,7 @@ func TestClient_ArchiveJobSpec(t *testing.T) {
 func TestClient_CreateJobSpec_JSONAPIErrors(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -408,7 +406,7 @@ func TestClient_CreateJobSpec_JSONAPIErrors(t *testing.T) {
 func TestClient_CreateJobRun(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -457,7 +455,7 @@ func TestClient_CreateJobRun(t *testing.T) {
 func TestClient_CreateBridge(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -495,7 +493,7 @@ func TestClient_CreateBridge(t *testing.T) {
 func TestClient_IndexBridges(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -526,7 +524,7 @@ func TestClient_IndexBridges(t *testing.T) {
 func TestClient_ShowBridge(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -550,7 +548,7 @@ func TestClient_ShowBridge(t *testing.T) {
 func TestClient_RemoveBridge(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -575,7 +573,7 @@ func TestClient_RemoveBridge(t *testing.T) {
 func TestClient_RemoteLogin(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -613,7 +611,7 @@ func TestClient_RemoteLogin(t *testing.T) {
 func TestClient_WithdrawSuccess(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup, _ := setupWithdrawalsApplication(t)
+	app, cleanup := setupWithdrawalsApplication(t)
 	defer cleanup()
 	require.NoError(t, app.StartAndConnect())
 
@@ -623,16 +621,20 @@ func TestClient_WithdrawSuccess(t *testing.T) {
 
 	c := cli.NewContext(nil, set, nil)
 
+	app.EthMock.Context("manager.CreateTx#1", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_call", "0xDE0B6B3A7640000")
+		ethMock.Register("eth_sendRawTransaction", cltest.NewHash())
+	})
 	assert.Nil(t, client.Withdraw(c))
 }
 
 func TestClient_WithdrawNoArgs(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup, _ := setupWithdrawalsApplication(t)
+	app, cleanup := setupWithdrawalsApplication(t)
 	defer cleanup()
 
-	assert.NoError(t, utils.JustError(app.MockStartAndConnect()))
+	require.NoError(t, app.StartAndConnect())
 
 	client, _ := app.NewClientAndRenderer()
 	set := flag.NewFlagSet("admin withdraw", 0)
@@ -650,50 +652,47 @@ func TestClient_WithdrawNoArgs(t *testing.T) {
 func TestClient_WithdrawFromSpecifiedContractAddress(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup, ethMockCheck := setupWithdrawalsApplication(t)
+	app, cleanup := setupWithdrawalsApplication(t)
 	defer cleanup()
 	require.NoError(t, app.StartAndConnect())
 
 	client, _ := app.NewClientAndRenderer()
 	cliParserRouter := cmd.NewApp(client)
+
+	app.EthMock.Context("manager.CreateTx#1", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_call", "0xDE0B6B3A7640000")
+		ethMock.Register("eth_sendRawTransaction", cltest.NewHash())
+	})
 	assert.Nil(t, cliParserRouter.Run([]string{
 		"chainlink", "admin", "withdraw",
 		"0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF", "1234",
 		"--from=" +
 			"0x3141592653589793238462643383279502884197"}))
-	ethMockCheck(t)
 }
 
-func setupWithdrawalsApplication(t *testing.T) (*cltest.TestApplication, func(), func(*testing.T)) {
+func setupWithdrawalsApplication(t *testing.T) (*cltest.TestApplication, func()) {
 	config, _ := cltest.NewConfig(t)
 	oca := common.HexToAddress("0xDEADB3333333F")
 	config.Set("ORACLE_CONTRACT_ADDRESS", &oca)
 	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 
-	hash := cltest.NewHash()
 	nonce := "0x100"
-	ethMock := app.MockCallerSubscriberClient()
 
-	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
+	app.EthMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", nonce)
 		ethMock.Register("eth_chainId", config.ChainID())
 	})
 
-	ethMock.Context("manager.CreateTx#1", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_call", "0xDE0B6B3A7640000")
-		ethMock.Register("eth_sendRawTransaction", hash)
-	})
-
-	return app, cleanup, ethMock.EventuallyAllCalled
+	return app, cleanup
 }
 
 func TestClient_SendEther(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup, _ := setupWithdrawalsApplication(t)
+	app, cleanup := setupWithdrawalsApplication(t)
 	defer cleanup()
 
-	assert.NoError(t, app.StartAndConnect())
+	require.NoError(t, app.StartAndConnect())
 
 	client, _ := app.NewClientAndRenderer()
 	set := flag.NewFlagSet("sendether", 0)
@@ -701,21 +700,28 @@ func TestClient_SendEther(t *testing.T) {
 
 	c := cli.NewContext(nil, set, nil)
 
+	app.EthMock.Context("manager.CreateTx#1", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_sendRawTransaction", cltest.NewHash())
+	})
 	assert.NoError(t, client.SendEther(c))
 }
 
 func TestClient_SendEther_From(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup, _ := setupWithdrawalsApplication(t)
+	app, cleanup := setupWithdrawalsApplication(t)
 	defer cleanup()
 
-	assert.NoError(t, app.StartAndConnect())
+	require.NoError(t, app.StartAndConnect())
 
 	client, _ := app.NewClientAndRenderer()
 	set := flag.NewFlagSet("sendether", 0)
 	set.String("from", app.Store.TxManager.NextActiveAccount().Address.String(), "")
 	set.Parse([]string{"100", "0x342156c8d3bA54Abc67920d35ba1d1e67201aC9C"})
+
+	app.EthMock.Context("manager.CreateTx#1", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_sendRawTransaction", cltest.NewHash())
+	})
 
 	cliapp := cli.NewApp()
 	c := cli.NewContext(cliapp, set, nil)
@@ -726,7 +732,7 @@ func TestClient_SendEther_From(t *testing.T) {
 func TestClient_ChangePassword(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -763,7 +769,7 @@ func TestClient_ChangePassword(t *testing.T) {
 func TestClient_IndexTransactions(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -798,7 +804,7 @@ func TestClient_IndexTransactions(t *testing.T) {
 func TestClient_ShowTransaction(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -820,7 +826,7 @@ func TestClient_ShowTransaction(t *testing.T) {
 func TestClient_IndexTxAttempts(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -855,7 +861,7 @@ func TestClient_IndexTxAttempts(t *testing.T) {
 func TestClient_CreateExtraKey(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -875,7 +881,7 @@ func TestClient_CreateExtraKey(t *testing.T) {
 func TestClient_SetMinimumGasPrice(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup, _ := setupWithdrawalsApplication(t)
+	app, cleanup := setupWithdrawalsApplication(t)
 	defer cleanup()
 	require.NoError(t, app.StartAndConnect())
 
@@ -885,6 +891,7 @@ func TestClient_SetMinimumGasPrice(t *testing.T) {
 
 	c := cli.NewContext(nil, set, nil)
 
+	// app.EthMock.Register("eth_call", "0xDE0B6B3A7640000")
 	assert.NoError(t, client.SetMinimumGasPrice(c))
 	assert.Equal(t, big.NewInt(8616460799), app.Store.Config.EthGasPriceDefault())
 
@@ -902,7 +909,7 @@ func TestClient_SetMinimumGasPrice(t *testing.T) {
 func TestClient_GetConfiguration(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -927,13 +934,8 @@ func TestClient_GetConfiguration(t *testing.T) {
 func TestClient_CancelJobRun(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
-	ethMock := app.MockCallerSubscriberClient()
-	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_getTransactionCount", 0)
-		ethMock.Register("eth_chainId", app.Config.ChainID())
-	})
 	require.NoError(t, app.Start())
 
 	job := cltest.NewJobWithWebInitiator()

--- a/core/cmd/renderer_test.go
+++ b/core/cmd/renderer_test.go
@@ -38,7 +38,7 @@ func TestRendererTable_RenderJobs(t *testing.T) {
 func TestRendererTable_RenderConfiguration(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -148,6 +148,7 @@ type TestApplication struct {
 	wsServer         *httptest.Server
 	connectedChannel chan struct{}
 	Started          bool
+	EthMock          *EthMock
 }
 
 func newWSServer() (*httptest.Server, func()) {
@@ -182,11 +183,11 @@ func NewWSServer(msg string) (*httptest.Server, func()) {
 }
 
 // NewApplication creates a New TestApplication along with a NewConfig
-func NewApplication(t testing.TB) (*TestApplication, func()) {
+func NewApplication(t testing.TB, flags ...string) (*TestApplication, func()) {
 	t.Helper()
 
 	c, cfgCleanup := NewConfig(t)
-	app, cleanup := NewApplicationWithConfig(t, c)
+	app, cleanup := NewApplicationWithConfig(t, c, flags...)
 	return app, func() {
 		cleanup()
 		cfgCleanup()
@@ -194,11 +195,11 @@ func NewApplication(t testing.TB) (*TestApplication, func()) {
 }
 
 // NewApplicationWithKey creates a new TestApplication along with a new config
-func NewApplicationWithKey(t testing.TB) (*TestApplication, func()) {
+func NewApplicationWithKey(t testing.TB, flags ...string) (*TestApplication, func()) {
 	t.Helper()
 
 	config, cfgCleanup := NewConfig(t)
-	app, cleanup := NewApplicationWithConfigAndKey(t, config)
+	app, cleanup := NewApplicationWithConfigAndKey(t, config, flags...)
 	return app, func() {
 		cleanup()
 		cfgCleanup()
@@ -207,16 +208,16 @@ func NewApplicationWithKey(t testing.TB) (*TestApplication, func()) {
 
 // NewApplicationWithConfigAndKey creates a new TestApplication with the given testconfig
 // it will also provide an unlocked account on the keystore
-func NewApplicationWithConfigAndKey(t testing.TB, tc *TestConfig) (*TestApplication, func()) {
+func NewApplicationWithConfigAndKey(t testing.TB, tc *TestConfig, flags ...string) (*TestApplication, func()) {
 	t.Helper()
 
-	app, cleanup := NewApplicationWithConfig(t, tc)
+	app, cleanup := NewApplicationWithConfig(t, tc, flags...)
 	app.ImportKey(key3cb8e3fd9d27e39a5e9e6852b0e96160061fd4ea)
 	return app, cleanup
 }
 
 // NewApplicationWithConfig creates a New TestApplication with specified test config
-func NewApplicationWithConfig(t testing.TB, tc *TestConfig) (*TestApplication, func()) {
+func NewApplicationWithConfig(t testing.TB, tc *TestConfig, flags ...string) (*TestApplication, func()) {
 	t.Helper()
 
 	cleanupDB := PrepareTestDB(tc)
@@ -226,7 +227,7 @@ func NewApplicationWithConfig(t testing.TB, tc *TestConfig) (*TestApplication, f
 		ta.connectedChannel <- struct{}{}
 	}).(*services.ChainlinkApplication)
 	ta.ChainlinkApplication = app
-	ethMock := MockEthOnStore(t, app.Store)
+	ta.EthMock = MockEthOnStore(t, app.Store, flags...)
 
 	server := newServer(ta)
 	tc.Config.Set("CLIENT_NODE_URL", server.URL)
@@ -238,7 +239,7 @@ func NewApplicationWithConfig(t testing.TB, tc *TestConfig) (*TestApplication, f
 	return ta, func() {
 		require.NoError(t, ta.Stop())
 		cleanupDB()
-		require.True(t, ethMock.AllCalled(), ethMock.Remaining())
+		require.True(t, ta.EthMock.AllCalled(), ta.EthMock.Remaining())
 	}
 }
 
@@ -268,11 +269,11 @@ func (ta *TestApplication) StartAndConnect() error {
 		return err
 	}
 
-	return ta.WaitForConnection()
+	return ta.waitForConnection()
 }
 
-// WaitForConnection wait for the StartAndConnect callback to be called
-func (ta *TestApplication) WaitForConnection() error {
+// waitForConnection wait for the StartAndConnect callback to be called
+func (ta *TestApplication) waitForConnection() error {
 	select {
 	case <-time.After(4 * time.Second):
 		return errors.New("TestApplication#StartAndConnect() timed out")
@@ -281,20 +282,21 @@ func (ta *TestApplication) WaitForConnection() error {
 	}
 }
 
-func (ta *TestApplication) MockStartAndConnect() (*EthMock, error) {
-	ethMock := ta.MockCallerSubscriberClient()
-	ethMock.Context("TestApplication#MockStartAndConnect()", func(ethMock *EthMock) {
-		ethMock.Register("eth_chainId", ta.Config.ChainID())
-		ethMock.Register("eth_getTransactionCount", `0x0`)
-	})
+// TODO: DELETE THIS
+// func (ta *TestApplication) MockStartAndConnect() (*EthMock, error) {
+//     ethMock := ta.MockCallerSubscriberClient()
+//     ethMock.Context("TestApplication#MockStartAndConnect()", func(ethMock *EthMock) {
+//         ethMock.Register("eth_chainId", ta.Config.ChainID())
+//         ethMock.Register("eth_getTransactionCount", `0x0`)
+//     })
 
-	err := ta.Start()
-	if err != nil {
-		return ethMock, err
-	}
+//     err := ta.Start()
+//     if err != nil {
+//         return ethMock, err
+//     }
 
-	return ethMock, ta.WaitForConnection()
-}
+//     return ethMock, ta.WaitForConnection()
+// }
 
 // Stop will stop the test application and perform cleanup
 func (ta *TestApplication) Stop() error {

--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -32,8 +32,12 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Strict flag makes the mock eth client panic if an unexpected call is made
-const Strict = "strict"
+// Lenient flag prevents the mock eth client from panicking if an unexpected call is made
+const Lenient = "lenient"
+
+// EthMockRegisterChainID registers the common case of calling eth_chainId
+// and returns the store.config.ChainID
+const EthMockRegisterChainID = "eth_mock_register_chain_id"
 
 // MockCallerSubscriberClient create new EthMock Client
 func (ta *TestApplication) MockCallerSubscriberClient(flags ...string) *EthMock {
@@ -45,10 +49,12 @@ func (ta *TestApplication) MockCallerSubscriberClient(flags ...string) *EthMock 
 
 // MockEthOnStore given store return new EthMock Client
 func MockEthOnStore(t testing.TB, s *store.Store, flags ...string) *EthMock {
-	mock := &EthMock{t: t}
+	mock := &EthMock{t: t, strict: true}
 	for _, flag := range flags {
-		if flag == Strict {
-			mock.strict = true
+		if flag == Lenient {
+			mock.strict = false
+		} else if flag == EthMockRegisterChainID {
+			mock.Register("eth_chainId", s.Config.ChainID())
 		}
 	}
 	eth := &eth.CallerSubscriberClient{CallerSubscriber: mock}
@@ -199,8 +205,6 @@ func (mock *EthMock) Call(result interface{}, method string, args ...interface{}
 	err := fmt.Errorf("EthMock: Method %v not registered", method)
 	if mock.strict {
 		mock.t.Errorf("%s\n%s", err, debug.Stack())
-	} else {
-		mock.t.Logf("%s\n%s", err, debug.Stack())
 	}
 	return err
 }

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -28,10 +28,8 @@ import (
 func TestIntegration_Scheduler(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
-	eth.Register("eth_chainId", app.Store.Config.ChainID())
 	app.Start()
 
 	j := cltest.FixtureCreateJobViaWeb(t, app, "fixtures/web/scheduler_job.json")
@@ -60,7 +58,7 @@ func TestIntegration_HttpRequestWithHeaders(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	config := app.Config
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
+	eth := app.EthMock
 
 	newHeads := make(chan ethpkg.BlockHeader)
 	attempt1Hash := common.HexToHash("0xb7862c896a6ba2711bccc0410184e46d793ea83b3e05470f1d359ea276d16bb5")
@@ -145,7 +143,7 @@ func TestIntegration_FeeBump(t *testing.T) {
 	thirdTxSafeAt := thirdTxSentAt + config.MinOutgoingConfirmations()
 
 	newHeads := make(chan ethpkg.BlockHeader)
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
+	eth := app.EthMock
 	eth.Context("app.Start()", func(eth *cltest.EthMock) {
 		eth.RegisterSubscription("newHeads", newHeads)
 		eth.Register("eth_chainId", config.ChainID())
@@ -242,10 +240,8 @@ func TestIntegration_FeeBump(t *testing.T) {
 
 func TestIntegration_RunAt(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
-	eth.Register("eth_chainId", app.Store.Config.ChainID())
 	app.InstantClock()
 
 	require.NoError(t, app.Start())
@@ -260,10 +256,10 @@ func TestIntegration_RunAt(t *testing.T) {
 
 func TestIntegration_EthLog(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.Lenient)
 	defer cleanup()
 
-	eth := app.MockCallerSubscriberClient()
+	eth := app.EthMock
 	logs := make(chan ethpkg.Log, 1)
 	eth.Context("app.Start()", func(eth *cltest.EthMock) {
 		eth.Register("eth_chainId", app.Store.Config.ChainID())
@@ -311,10 +307,10 @@ func TestIntegration_RunLog(t *testing.T) {
 			config, cfgCleanup := cltest.NewConfig(t)
 			defer cfgCleanup()
 			config.Set("MIN_INCOMING_CONFIRMATIONS", 6)
-			app, cleanup := cltest.NewApplicationWithConfig(t, config)
+			app, cleanup := cltest.NewApplicationWithConfig(t, config, cltest.Lenient)
 			defer cleanup()
 
-			eth := app.MockCallerSubscriberClient()
+			eth := app.EthMock
 			logs := make(chan ethpkg.Log, 1)
 			newHeads := eth.RegisterNewHeads()
 			eth.Context("app.Start()", func(eth *cltest.EthMock) {
@@ -373,7 +369,7 @@ func TestIntegration_StartAt(t *testing.T) {
 
 	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
+	eth := app.EthMock
 	eth.Register("eth_chainId", app.Store.Config.ChainID())
 	require.NoError(t, app.Start())
 
@@ -390,7 +386,7 @@ func TestIntegration_ExternalAdapter_RunLogInitiated(t *testing.T) {
 	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
 
-	eth := app.MockCallerSubscriberClient()
+	eth := app.EthMock
 	eth.Register("eth_chainId", app.Store.Config.ChainID())
 	logs := make(chan ethpkg.Log, 1)
 	newHeads := make(chan ethpkg.BlockHeader, 10)
@@ -446,10 +442,8 @@ func TestIntegration_ExternalAdapter_RunLogInitiated(t *testing.T) {
 func TestIntegration_ExternalAdapter_Copy(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
-	eth.Register("eth_chainId", app.Store.Config.ChainID())
 	bridgeURL := cltest.WebURL(t, "https://test.chain.link/always")
 	app.Store.Config.Set("BRIDGE_RESPONSE_URL", bridgeURL)
 	require.NoError(t, app.Start())
@@ -498,10 +492,8 @@ func TestIntegration_ExternalAdapter_Copy(t *testing.T) {
 func TestIntegration_ExternalAdapter_Pending(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
-	eth.Register("eth_chainId", app.Store.Config.ChainID())
 	require.NoError(t, app.Start())
 
 	bta := &models.BridgeTypeAuthentication{}
@@ -547,10 +539,10 @@ func TestIntegration_ExternalAdapter_Pending(t *testing.T) {
 func TestIntegration_WeiWatchers(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.Lenient)
 	defer cleanup()
 
-	eth := app.MockCallerSubscriberClient()
+	eth := app.EthMock
 	eth.RegisterNewHead(1)
 	logs := make(chan ethpkg.Log, 1)
 	eth.Context("app.Start()", func(eth *cltest.EthMock) {
@@ -582,10 +574,8 @@ func TestIntegration_WeiWatchers(t *testing.T) {
 }
 
 func TestIntegration_MultiplierInt256(t *testing.T) {
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
-	eth.Register("eth_chainId", app.Store.Config.ChainID())
 	require.NoError(t, app.Start())
 
 	j := cltest.FixtureCreateJobViaWeb(t, app, "fixtures/web/int256_job.json")
@@ -597,10 +587,8 @@ func TestIntegration_MultiplierInt256(t *testing.T) {
 }
 
 func TestIntegration_MultiplierUint256(t *testing.T) {
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
-	eth.Register("eth_chainId", app.Store.Config.ChainID())
 	require.NoError(t, app.Start())
 
 	j := cltest.FixtureCreateJobViaWeb(t, app, "fixtures/web/uint256_job.json")
@@ -614,18 +602,14 @@ func TestIntegration_MultiplierUint256(t *testing.T) {
 func TestIntegration_NonceManagement_firstRunWithExistingTxs(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 
-	config, configCleanup := cltest.NewConfig(t)
-	defer configCleanup()
-
-	eth := app.MockCallerSubscriberClient()
+	eth := app.EthMock
 	newHeads := make(chan ethpkg.BlockHeader)
 	eth.Context("app.Start()", func(eth *cltest.EthMock) {
 		eth.RegisterSubscription("newHeads", newHeads)
 		eth.Register("eth_getTransactionCount", `0x100`) // activate account nonce
-		eth.Register("eth_chainId", config.ChainID())
 	})
 	require.NoError(t, app.Store.ORM.CreateHead(cltest.Head(100)))
 	require.NoError(t, app.StartAndConnect())
@@ -665,7 +649,7 @@ func TestIntegration_CreateServiceAgreement(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
-	eth := app.MockCallerSubscriberClient()
+	eth := app.EthMock
 	logs := make(chan ethpkg.Log, 1)
 	eth.Context("app.Start()", func(eth *cltest.EthMock) {
 		eth.RegisterSubscription("logs", logs)
@@ -708,10 +692,8 @@ func TestIntegration_SyncJobRuns(t *testing.T) {
 
 	config, _ := cltest.NewConfig(t)
 	config.Set("EXPLORER_URL", wsserver.URL.String())
-	app, cleanup := cltest.NewApplicationWithConfig(t, config)
+	app, cleanup := cltest.NewApplicationWithConfig(t, config, cltest.EthMockRegisterChainID)
 	defer cleanup()
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
-	eth.Register("eth_chainId", config.ChainID())
 
 	app.InstantClock()
 	require.NoError(t, app.Start())
@@ -737,10 +719,8 @@ func TestIntegration_SleepAdapter(t *testing.T) {
 	t.Parallel()
 
 	sleepSeconds := 4
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
-	eth.Register("eth_chainId", app.Store.Config.ChainID())
 	require.NoError(t, app.Start())
 
 	j := cltest.FixtureCreateJobViaWeb(t, app, "./testdata/sleep_job.json")
@@ -756,10 +736,8 @@ func TestIntegration_SleepAdapter(t *testing.T) {
 func TestIntegration_ExternalInitiator(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
-	eth.Register("eth_chainId", app.Store.Config.ChainID())
 	require.NoError(t, app.Start())
 
 	exInitr := struct {
@@ -819,10 +797,8 @@ func TestIntegration_ExternalInitiator(t *testing.T) {
 func TestIntegration_ExternalInitiator_WithoutURL(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
-	eth.Register("eth_chainId", app.Store.Config.ChainID())
 	require.NoError(t, app.Start())
 
 	eiCreate := map[string]string{
@@ -851,11 +827,9 @@ func TestIntegration_ExternalInitiator_WithoutURL(t *testing.T) {
 }
 
 func TestIntegration_AuthToken(t *testing.T) {
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
-	eth.Register("eth_chainId", app.Store.Config.ChainID())
 	require.NoError(t, app.Start())
 
 	// set up user
@@ -878,7 +852,7 @@ func TestIntegration_FluxMonitor_Deviation(t *testing.T) {
 
 	// Start, connect, and initialize node
 	newHeads := make(chan ethpkg.BlockHeader)
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
+	eth := app.EthMock
 	eth.Context("app.Start()", func(eth *cltest.EthMock) {
 		eth.RegisterSubscription("newHeads", newHeads)
 		eth.Register("eth_getTransactionCount", `0x0100`) // TxManager.ActivateAccount()
@@ -952,7 +926,7 @@ func TestIntegration_FluxMonitor_NewRound(t *testing.T) {
 	defer cleanup()
 
 	// Start, connect, and initialize node
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
+	eth := app.EthMock
 	eth.Context("app.StartAndConnect()", func(eth *cltest.EthMock) {
 		eth.Register("eth_getTransactionCount", `0x0100`) // TxManager.ActivateAccount()
 		eth.Register("eth_chainId", app.Store.Config.ChainID())

--- a/core/services/application_test.go
+++ b/core/services/application_test.go
@@ -8,7 +8,6 @@ import (
 
 	"chainlink/core/internal/cltest"
 	"chainlink/core/store/models"
-	"chainlink/core/utils"
 
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
@@ -18,10 +17,8 @@ import (
 func TestChainlinkApplication_SignalShutdown(t *testing.T) {
 	config, cleanup := cltest.NewConfig(t)
 	defer cleanup()
-	app, appCleanUp := cltest.NewApplicationWithConfig(t, config)
+	app, appCleanUp := cltest.NewApplicationWithConfig(t, config, cltest.EthMockRegisterChainID)
 	defer appCleanUp()
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
-	eth.Register("eth_chainId", app.Store.Config.ChainID())
 
 	completed := abool.New()
 	app.Exiter = func(code int) {
@@ -39,6 +36,9 @@ func TestChainlinkApplication_SignalShutdown(t *testing.T) {
 func TestChainlinkApplication_resumesPendingConnection_Happy(t *testing.T) {
 	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
+	app.EthMock.Context("app.Start()", func(meth *cltest.EthMock) {
+		meth.Register("eth_chainId", app.Store.Config.ChainID())
+	})
 	store := app.Store
 
 	j := cltest.NewJobWithWebInitiator()
@@ -46,13 +46,16 @@ func TestChainlinkApplication_resumesPendingConnection_Happy(t *testing.T) {
 
 	jr := cltest.CreateJobRunWithStatus(t, store, j, models.RunStatusPendingConnection)
 
-	require.NoError(t, utils.JustError(app.MockStartAndConnect()))
+	require.NoError(t, app.StartAndConnect())
 	_ = cltest.WaitForJobRunToComplete(t, store, jr)
 }
 
 func TestChainlinkApplication_resumesPendingConnection_Archived(t *testing.T) {
 	app, cleanup := cltest.NewApplication(t)
 	defer cleanup()
+	app.EthMock.Context("app.Start()", func(meth *cltest.EthMock) {
+		meth.Register("eth_chainId", app.Store.Config.ChainID())
+	})
 	store := app.Store
 
 	j := cltest.NewJobWithWebInitiator()
@@ -62,6 +65,6 @@ func TestChainlinkApplication_resumesPendingConnection_Archived(t *testing.T) {
 
 	require.NoError(t, store.ArchiveJob(j.ID))
 
-	require.NoError(t, utils.JustError(app.MockStartAndConnect()))
+	require.NoError(t, app.StartAndConnect())
 	_ = cltest.WaitForJobRunToComplete(t, store, jr)
 }

--- a/core/services/head_tracker_test.go
+++ b/core/services/head_tracker_test.go
@@ -25,9 +25,7 @@ func TestHeadTracker_New(t *testing.T) {
 
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-
-	eth := cltest.MockEthOnStore(t, store)
-	eth.Register("eth_chainId", store.Config.ChainID())
+	cltest.MockEthOnStore(t, store, cltest.EthMockRegisterChainID)
 
 	assert.Nil(t, store.CreateHead(cltest.Head(1)))
 	last := cltest.Head(16)
@@ -45,8 +43,7 @@ func TestHeadTracker_New_Limit_At_100(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
-	eth := cltest.MockEthOnStore(t, store)
-	eth.Register("eth_chainId", store.Config.ChainID())
+	cltest.MockEthOnStore(t, store, cltest.EthMockRegisterChainID)
 
 	for idx := 0; idx <= 200; idx++ {
 		assert.Nil(t, store.CreateHead(cltest.Head(idx)))
@@ -83,8 +80,7 @@ func TestHeadTracker_Get(t *testing.T) {
 			store, cleanup := cltest.NewStore(t)
 			defer cleanup()
 
-			eth := cltest.MockEthOnStore(t, store)
-			eth.Register("eth_chainId", store.Config.ChainID())
+			cltest.MockEthOnStore(t, store, cltest.EthMockRegisterChainID)
 			if test.initial != nil {
 				assert.Nil(t, store.CreateHead(test.initial))
 			}
@@ -110,11 +106,10 @@ func TestHeadTracker_Start_NewHeads(t *testing.T) {
 
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	eth := cltest.MockEthOnStore(t, store)
+	eth := cltest.MockEthOnStore(t, store, cltest.EthMockRegisterChainID)
 	ht := services.NewHeadTracker(store, []strpkg.HeadTrackable{})
 	defer ht.Stop()
 
-	eth.Register("eth_chainId", store.Config.ChainID())
 	eth.RegisterSubscription("newHeads")
 
 	assert.Nil(t, ht.Start())
@@ -127,7 +122,7 @@ func TestHeadTracker_HeadTrackableCallbacks(t *testing.T) {
 
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	mocketh := cltest.MockEthOnStore(t, store)
+	mocketh := cltest.MockEthOnStore(t, store, cltest.EthMockRegisterChainID)
 
 	checker := &cltest.MockHeadTrackable{}
 	ht := services.NewHeadTracker(store, []strpkg.HeadTrackable{checker}, cltest.NeverSleeper{})
@@ -193,10 +188,9 @@ func TestHeadTracker_StartConnectsFromLastSavedHeader(t *testing.T) {
 
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	mocketh := cltest.MockEthOnStore(t, store)
+	mocketh := cltest.MockEthOnStore(t, store, cltest.EthMockRegisterChainID)
 	headers := make(chan eth.BlockHeader)
 	mocketh.RegisterSubscription("newHeads", headers)
-	mocketh.Register("eth_chainId", store.Config.ChainID())
 
 	lastSavedBN := big.NewInt(1)
 	currentBN := big.NewInt(2)

--- a/core/services/job_subscriber_test.go
+++ b/core/services/job_subscriber_test.go
@@ -82,7 +82,7 @@ func TestJobSubscriber_AddJob_RemoveJob(t *testing.T) {
 
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
-	cltest.MockEthOnStore(t, store)
+	cltest.MockEthOnStore(t, store, cltest.Lenient)
 
 	runManager := new(mocks.RunManager)
 	jobSubscriber := services.NewJobSubscriber(store, runManager)

--- a/core/store/models/log_events_test.go
+++ b/core/store/models/log_events_test.go
@@ -238,7 +238,7 @@ func TestStartRunOrSALogSubscription_ValidateSenders(t *testing.T) {
 			app, cleanup := cltest.NewApplicationWithKey(t)
 			defer cleanup()
 
-			ethMock := app.MockCallerSubscriberClient()
+			ethMock := app.EthMock
 			logs := make(chan eth.Log, 1)
 			ethMock.Context("app.Start()", func(meth *cltest.EthMock) {
 				meth.Register("eth_getTransactionCount", "0x1")

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -678,7 +678,7 @@ func TestORM_PendingBridgeType_success(t *testing.T) {
 func TestORM_GetLastNonce_StormNotFound(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 	store := app.Store
@@ -696,7 +696,7 @@ func TestORM_GetLastNonce_Valid(t *testing.T) {
 	defer cleanup()
 	store := app.Store
 	manager := store.TxManager
-	ethMock := app.MockCallerSubscriberClient()
+	ethMock := app.EthMock
 	one := uint64(1)
 
 	ethMock.Register("eth_getTransactionCount", utils.Uint64ToHex(one))

--- a/core/store/store_test.go
+++ b/core/store/store_test.go
@@ -44,7 +44,7 @@ func TestStore_Close(t *testing.T) {
 func TestStore_SyncDiskKeyStoreToDB_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 	store := app.GetStore()
@@ -78,7 +78,7 @@ func TestStore_SyncDiskKeyStoreToDB_HappyPath(t *testing.T) {
 func TestStore_SyncDiskKeyStoreToDB_MultipleKeys(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	app.AddUnlockedKey() // second account
 	defer cleanup()
 	require.NoError(t, app.Start())
@@ -129,7 +129,11 @@ func TestStore_SyncDiskKeyStoreToDB_DBKeyAlreadyExists(t *testing.T) {
 
 	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
-	require.NoError(t, utils.JustError(app.MockStartAndConnect()))
+	app.EthMock.Context("app.Start()", func(meth *cltest.EthMock) {
+		meth.Register("eth_getTransactionCount", "0x1")
+		meth.Register("eth_chainId", app.Store.Config.ChainID())
+	})
+	require.NoError(t, app.StartAndConnect())
 	store := app.GetStore()
 
 	// assert sync worked on NewApplication

--- a/core/web/authentication_test.go
+++ b/core/web/authentication_test.go
@@ -28,7 +28,7 @@ func authSuccess(*store.Store, *gin.Context) error {
 }
 
 func TestAuthenticateByToken_Success(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 	app.Start()
@@ -53,7 +53,7 @@ func TestAuthenticateByToken_Success(t *testing.T) {
 }
 
 func TestAuthenticateByToken_AuthFailed(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 	app.Start()

--- a/core/web/bridge_types_controller_test.go
+++ b/core/web/bridge_types_controller_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func BenchmarkBridgeTypesController_Index(b *testing.B) {
-	app, cleanup := cltest.NewApplication(b)
+	app, cleanup := cltest.NewApplication(b, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	setupJobSpecsControllerIndex(app)
 	client := app.NewHTTPClient()
@@ -34,7 +34,7 @@ func BenchmarkBridgeTypesController_Index(b *testing.B) {
 func TestBridgeTypesController_Index(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
@@ -102,7 +102,7 @@ func setupBridgeControllerIndex(t testing.TB, store *store.Store) ([]*models.Bri
 func TestBridgeTypesController_Create_Success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
@@ -131,7 +131,7 @@ func TestBridgeTypesController_Create_Success(t *testing.T) {
 func TestBridgeTypesController_Update_Success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
@@ -155,7 +155,7 @@ func TestBridgeTypesController_Update_Success(t *testing.T) {
 func TestBridgeController_Show(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
@@ -185,7 +185,7 @@ func TestBridgeController_Show(t *testing.T) {
 func TestBridgeController_Destroy(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -222,7 +222,7 @@ func TestBridgeController_Destroy(t *testing.T) {
 func TestBridgeTypesController_Create_AdapterExistsError(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -239,7 +239,7 @@ func TestBridgeTypesController_Create_AdapterExistsError(t *testing.T) {
 func TestBridgeTypesController_Create_BindJSONError(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -256,7 +256,7 @@ func TestBridgeTypesController_Create_BindJSONError(t *testing.T) {
 func TestBridgeTypesController_Create_DatabaseError(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 

--- a/core/web/config_controller_test.go
+++ b/core/web/config_controller_test.go
@@ -19,7 +19,7 @@ import (
 func TestConfigController_Show(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()

--- a/core/web/cors_test.go
+++ b/core/web/cors_test.go
@@ -14,7 +14,7 @@ func TestCors_DefaultOrigins(t *testing.T) {
 
 	config, _ := cltest.NewConfig(t)
 	config.Set("ALLOW_ORIGINS", "http://localhost:3000,http://localhost:6689")
-	app, appCleanup := cltest.NewApplicationWithConfigAndKey(t, config)
+	app, appCleanup := cltest.NewApplicationWithConfigAndKey(t, config, cltest.Lenient)
 	defer appCleanup()
 	require.NoError(t, app.Start())
 
@@ -58,7 +58,7 @@ func TestCors_OverrideOrigins(t *testing.T) {
 			config, _ := cltest.NewConfig(t)
 			config.Set("ALLOW_ORIGINS", test.allow)
 
-			app, appCleanup := cltest.NewApplicationWithConfigAndKey(t, config)
+			app, appCleanup := cltest.NewApplicationWithConfigAndKey(t, config, cltest.Lenient)
 			defer appCleanup()
 			require.NoError(t, app.Start())
 

--- a/core/web/external_initiators_controller_test.go
+++ b/core/web/external_initiators_controller_test.go
@@ -16,7 +16,7 @@ import (
 func TestExternalInitiatorsController_Create_success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -42,7 +42,7 @@ func TestExternalInitiatorsController_Create_success(t *testing.T) {
 func TestExternalInitiatorsController_Create_without_URL(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -68,7 +68,7 @@ func TestExternalInitiatorsController_Create_without_URL(t *testing.T) {
 func TestExternalInitiatorsController_Create_invalid(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -84,7 +84,7 @@ func TestExternalInitiatorsController_Create_invalid(t *testing.T) {
 func TestExternalInitiatorsController_Delete(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -104,7 +104,7 @@ func TestExternalInitiatorsController_Delete(t *testing.T) {
 func TestExternalInitiatorsController_DeleteNotFound(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 

--- a/core/web/gui_assets_test.go
+++ b/core/web/gui_assets_test.go
@@ -12,7 +12,7 @@ import (
 func TestGuiAssets_WildcardIndexHtml(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -54,7 +54,7 @@ func TestGuiAssets_WildcardIndexHtml(t *testing.T) {
 func TestGuiAssets_WildcardRouteInfo(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -80,7 +80,7 @@ func TestGuiAssets_WildcardRouteInfo(t *testing.T) {
 func TestGuiAssets_Exact(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 

--- a/core/web/job_runs_controller_test.go
+++ b/core/web/job_runs_controller_test.go
@@ -19,7 +19,7 @@ import (
 )
 
 func BenchmarkJobRunsController_Index(b *testing.B) {
-	app, cleanup := cltest.NewApplication(b)
+	app, cleanup := cltest.NewApplication(b, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	app.Start()
 	run1, _, _ := setupJobRunsControllerIndex(b, app)
@@ -36,7 +36,7 @@ func BenchmarkJobRunsController_Index(b *testing.B) {
 func TestJobRunsController_Index(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -124,7 +124,7 @@ func setupJobRunsControllerIndex(t assert.TestingT, app *cltest.TestApplication)
 
 func TestJobRunsController_Create_Success(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 
@@ -139,7 +139,7 @@ func TestJobRunsController_Create_Success(t *testing.T) {
 
 func TestJobRunsController_Create_Wrong_ExternalInitiator(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 
@@ -180,7 +180,7 @@ func TestJobRunsController_Create_Wrong_ExternalInitiator(t *testing.T) {
 
 func TestJobRunsController_Create_ExternalInitiator_Success(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 
@@ -208,7 +208,7 @@ func TestJobRunsController_Create_ExternalInitiator_Success(t *testing.T) {
 
 func TestJobRunsController_Create_Archived(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 
@@ -224,7 +224,7 @@ func TestJobRunsController_Create_Archived(t *testing.T) {
 
 func TestJobRunsController_Create_EmptyBody(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 
@@ -237,7 +237,7 @@ func TestJobRunsController_Create_EmptyBody(t *testing.T) {
 
 func TestJobRunsController_Create_InvalidBody(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -252,7 +252,7 @@ func TestJobRunsController_Create_InvalidBody(t *testing.T) {
 
 func TestJobRunsController_Create_WithoutWebInitiator(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -267,7 +267,7 @@ func TestJobRunsController_Create_WithoutWebInitiator(t *testing.T) {
 
 func TestJobRunsController_Create_NotFound(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -279,7 +279,7 @@ func TestJobRunsController_Create_NotFound(t *testing.T) {
 
 func TestJobRunsController_Create_InvalidID(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -291,9 +291,8 @@ func TestJobRunsController_Create_InvalidID(t *testing.T) {
 
 func TestJobRunsController_Update_Success(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
-	eth := app.MockCallerSubscriberClient()
-	eth.Register("eth_chainId", app.Store.Config.ChainID())
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
+
 	app.Start()
 	defer cleanup()
 
@@ -340,7 +339,7 @@ func TestJobRunsController_Update_Success(t *testing.T) {
 
 func TestJobRunsController_Update_WrongAccessToken(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -365,7 +364,7 @@ func TestJobRunsController_Update_WrongAccessToken(t *testing.T) {
 
 func TestJobRunsController_Update_NotPending(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -387,7 +386,7 @@ func TestJobRunsController_Update_NotPending(t *testing.T) {
 
 func TestJobRunsController_Update_WithError(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -416,7 +415,7 @@ func TestJobRunsController_Update_WithError(t *testing.T) {
 
 func TestJobRunsController_Update_BadInput(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -440,7 +439,7 @@ func TestJobRunsController_Update_BadInput(t *testing.T) {
 
 func TestJobRunsController_Update_NotFound(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -465,7 +464,7 @@ func TestJobRunsController_Update_NotFound(t *testing.T) {
 func TestJobRunsController_Show_Found(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -488,7 +487,7 @@ func TestJobRunsController_Show_Found(t *testing.T) {
 
 func TestJobRunsController_Show_NotFound(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -500,7 +499,7 @@ func TestJobRunsController_Show_NotFound(t *testing.T) {
 
 func TestJobRunsController_Show_InvalidID(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 	client := app.NewHTTPClient()
@@ -512,7 +511,7 @@ func TestJobRunsController_Show_InvalidID(t *testing.T) {
 
 func TestJobRunsController_Show_Unauthenticated(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 
@@ -523,7 +522,7 @@ func TestJobRunsController_Show_Unauthenticated(t *testing.T) {
 
 func TestJobRunsController_Cancel(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	defer cleanup()
 

--- a/core/web/job_specs_controller_test.go
+++ b/core/web/job_specs_controller_test.go
@@ -38,7 +38,7 @@ func BenchmarkJobSpecsController_Index(b *testing.B) {
 func TestJobSpecsController_Index_noSort(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
@@ -87,7 +87,7 @@ func TestJobSpecsController_Index_noSort(t *testing.T) {
 func TestJobSpecsController_Index_sortCreatedAt(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -163,7 +163,7 @@ func setupJobSpecsControllerIndex(app *cltest.TestApplication) (*models.JobSpec,
 func TestJobSpecsController_Create_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -219,10 +219,8 @@ func TestJobSpecsController_CreateExternalInitiator_Success(t *testing.T) {
 	)
 	defer assertCalled()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
-	eth := app.MockCallerSubscriberClient(cltest.Strict)
-	eth.Register("eth_chainId", app.Store.Config.ChainID())
 	app.Start()
 
 	url := cltest.WebURL(t, eiMockServer.URL)
@@ -251,7 +249,7 @@ func TestJobSpecsController_CreateExternalInitiator_Success(t *testing.T) {
 
 func TestJobSpecsController_Create_CaseInsensitiveTypes(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -278,7 +276,7 @@ func TestJobSpecsController_Create_CaseInsensitiveTypes(t *testing.T) {
 
 func TestJobSpecsController_Create_NonExistentTaskJob(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -300,7 +298,7 @@ func TestJobSpecsController_Create_FluxMonitor_disabled(t *testing.T) {
 	config.Set("CHAINLINK_DEV", "FALSE")
 	config.Set("FEATURE_FLUX_MONITOR", "FALSE")
 
-	app, cleanup := cltest.NewApplicationWithConfig(t, config)
+	app, cleanup := cltest.NewApplicationWithConfig(t, config, cltest.EthMockRegisterChainID)
 	defer cleanup()
 
 	require.NoError(t, app.Start())
@@ -322,7 +320,7 @@ func TestJobSpecsController_Create_FluxMonitor_enabled(t *testing.T) {
 	config.Set("CHAINLINK_DEV", "FALSE")
 	config.Set("FEATURE_FLUX_MONITOR", "TRUE")
 
-	app, cleanup := cltest.NewApplicationWithConfig(t, config)
+	app, cleanup := cltest.NewApplicationWithConfig(t, config, cltest.Lenient)
 	defer cleanup()
 
 	require.NoError(t, app.Start())
@@ -338,7 +336,7 @@ func TestJobSpecsController_Create_FluxMonitor_enabled(t *testing.T) {
 
 func TestJobSpecsController_Create_InvalidJob(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -357,7 +355,7 @@ func TestJobSpecsController_Create_InvalidJob(t *testing.T) {
 
 func TestJobSpecsController_Create_InvalidCron(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -376,7 +374,7 @@ func TestJobSpecsController_Create_InvalidCron(t *testing.T) {
 
 func TestJobSpecsController_Create_Initiator_Only(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -395,7 +393,7 @@ func TestJobSpecsController_Create_Initiator_Only(t *testing.T) {
 
 func TestJobSpecsController_Create_Task_Only(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -430,7 +428,7 @@ func BenchmarkJobSpecsController_Show(b *testing.B) {
 func TestJobSpecsController_Show(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -464,7 +462,7 @@ func setupJobSpecsControllerShow(t assert.TestingT, app *cltest.TestApplication)
 
 func TestJobSpecsController_Show_NotFound(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -477,7 +475,7 @@ func TestJobSpecsController_Show_NotFound(t *testing.T) {
 
 func TestJobSpecsController_Show_InvalidUuid(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -490,7 +488,7 @@ func TestJobSpecsController_Show_InvalidUuid(t *testing.T) {
 
 func TestJobSpecsController_Show_Unauthenticated(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	require.NoError(t, app.Start())
 
 	defer cleanup()
@@ -502,7 +500,7 @@ func TestJobSpecsController_Show_Unauthenticated(t *testing.T) {
 
 func TestJobSpecsController_Destroy(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 

--- a/core/web/keys_controller_test.go
+++ b/core/web/keys_controller_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"testing"
 
-	"chainlink/core/eth"
 	"chainlink/core/internal/cltest"
 	"chainlink/core/store/models"
 
@@ -19,10 +18,9 @@ func TestKeysController_CreateSuccess(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
-	ethMock := app.MockCallerSubscriberClient()
+	ethMock := app.EthMock
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", "0x100")
-		ethMock.Register("eth_getBlockByNumber", eth.BlockHeader{})
 		ethMock.Register("eth_chainId", config.ChainID())
 	})
 
@@ -52,10 +50,9 @@ func TestKeysController_InvalidPassword(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
-	ethMock := app.MockCallerSubscriberClient()
+	ethMock := app.EthMock
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", "0x100")
-		ethMock.Register("eth_getBlockByNumber", eth.BlockHeader{})
 		ethMock.Register("eth_chainId", config.ChainID())
 	})
 
@@ -85,10 +82,9 @@ func TestKeysController_JSONBindingError(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
-	ethMock := app.MockCallerSubscriberClient()
+	ethMock := app.EthMock
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", "0x100")
-		ethMock.Register("eth_getBlockByNumber", eth.BlockHeader{})
 		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
 	})
 

--- a/core/web/ping_controller_test.go
+++ b/core/web/ping_controller_test.go
@@ -16,7 +16,7 @@ import (
 func TestPingController_Show_APICredentials(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -32,7 +32,7 @@ func TestPingController_Show_APICredentials(t *testing.T) {
 func TestPingController_Show_ExternalInitiatorCredentials(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -71,7 +71,7 @@ func TestPingController_Show_ExternalInitiatorCredentials(t *testing.T) {
 func TestPingController_Show_NoCredentials(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 

--- a/core/web/router_test.go
+++ b/core/web/router_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestTokenAuthRequired_NoCredentials(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -31,7 +31,7 @@ func TestTokenAuthRequired_NoCredentials(t *testing.T) {
 }
 
 func TestTokenAuthRequired_SessionCredentials(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -47,7 +47,7 @@ func TestTokenAuthRequired_SessionCredentials(t *testing.T) {
 }
 
 func TestTokenAuthRequired_TokenCredentials(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -80,7 +80,7 @@ func TestTokenAuthRequired_TokenCredentials(t *testing.T) {
 }
 
 func TestTokenAuthRequired_BadTokenCredentials(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -113,7 +113,7 @@ func TestTokenAuthRequired_BadTokenCredentials(t *testing.T) {
 }
 
 func TestSessions_RateLimited(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -142,7 +142,7 @@ func TestSessions_RateLimited(t *testing.T) {
 }
 
 func TestRouter_LargePOSTBody(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -162,7 +162,7 @@ func TestRouter_LargePOSTBody(t *testing.T) {
 }
 
 func TestRouter_GinHelmetHeaders(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 

--- a/core/web/service_agreements_controller_test.go
+++ b/core/web/service_agreements_controller_test.go
@@ -21,12 +21,11 @@ var endAtISO8601 = endAt.Format(time.RFC3339)
 func TestServiceAgreementsController_Create(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
-	require.NoError(t, app.Start())
+	app.EthMock.RegisterSubscription("logs")
 
-	eth := cltest.MockEthOnStore(t, app.GetStore())
-	eth.RegisterSubscription("logs")
+	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
 	base := string(cltest.MustReadFile(t, "testdata/hello_world_agreement.json"))
@@ -65,7 +64,7 @@ func TestServiceAgreementsController_Create(t *testing.T) {
 					jobids = append(jobids, j.ID)
 				}
 				assert.Contains(t, jobids, createdSA.JobSpec.ID)
-				eth.EventuallyAllCalled(t)
+				app.EthMock.EventuallyAllCalled(t)
 			}
 		})
 	}
@@ -74,12 +73,11 @@ func TestServiceAgreementsController_Create(t *testing.T) {
 func TestServiceAgreementsController_Create_isIdempotent(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
-	require.NoError(t, app.Start())
+	app.EthMock.RegisterSubscription("logs")
 
-	eth := cltest.MockEthOnStore(t, app.GetStore())
-	eth.RegisterSubscription("logs")
+	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
 
@@ -102,12 +100,12 @@ func TestServiceAgreementsController_Create_isIdempotent(t *testing.T) {
 
 	assert.Equal(t, response1.ID, response2.ID)
 	assert.Equal(t, response1.JobSpec.ID, response2.JobSpec.ID)
-	eth.EventuallyAllCalled(t)
+	app.EthMock.EventuallyAllCalled(t)
 }
 
 func TestServiceAgreementsController_Show(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 

--- a/core/web/sessions_controller_test.go
+++ b/core/web/sessions_controller_test.go
@@ -21,7 +21,7 @@ func TestSessionsController_Create(t *testing.T) {
 	t.Parallel()
 
 	user := cltest.MustUser("email@test.net", "password123")
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	err := app.Store.SaveUser(&user)
 	assert.NoError(t, err)
@@ -79,7 +79,7 @@ func TestSessionsController_Create_ReapSessions(t *testing.T) {
 	t.Parallel()
 
 	user := cltest.MustUser("email@test.net", "password123")
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	err := app.Store.SaveUser(&user)
 	assert.NoError(t, err)
@@ -106,7 +106,7 @@ func TestSessionsController_Destroy(t *testing.T) {
 	t.Parallel()
 
 	seedUser := cltest.MustUser("email@test.net", "password123")
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	app.Start()
 	err := app.Store.SaveUser(&seedUser)
 	assert.NoError(t, err)
@@ -151,7 +151,7 @@ func TestSessionsController_Destroy_ReapSessions(t *testing.T) {
 
 	client := http.Client{}
 	user := cltest.MustUser("email@test.net", "password123")
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 
 	app.Start()

--- a/core/web/transactions_controller_test.go
+++ b/core/web/transactions_controller_test.go
@@ -21,8 +21,9 @@ func TestTransactionsController_Index_Success(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
-	ethMock := app.MockCallerSubscriberClient()
+	ethMock := app.EthMock
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
 		ethMock.Register("eth_getTransactionCount", "0x100")
 	})
 
@@ -61,8 +62,11 @@ func TestTransactionsController_Index_Error(t *testing.T) {
 
 	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
-	ethMock := app.MockCallerSubscriberClient()
-	ethMock.Register("eth_getTransactionCount", "0x100")
+	ethMock := app.EthMock
+	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
+		ethMock.Register("eth_getTransactionCount", "0x100")
+	})
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -74,10 +78,10 @@ func TestTransactionsController_Index_Error(t *testing.T) {
 func TestTransactionsController_Show_Success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 
-	ethMock := app.MockCallerSubscriberClient()
+	ethMock := app.EthMock
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
 		ethMock.Register("eth_getTransactionCount", "0x100")
@@ -133,8 +137,9 @@ func TestTransactionsController_Show_NotFound(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
-	ethMock := app.MockCallerSubscriberClient()
+	ethMock := app.EthMock
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
+		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
 		ethMock.Register("eth_getTransactionCount", "0x100")
 	})
 

--- a/core/web/transfer_controller_test.go
+++ b/core/web/transfer_controller_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 
 	"chainlink/core/assets"
-	"chainlink/core/eth"
 	"chainlink/core/internal/cltest"
 	"chainlink/core/store/models"
 
@@ -23,10 +22,9 @@ func TestTransfersController_CreateSuccess(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
-	ethMock := app.MockCallerSubscriberClient()
+	ethMock := app.EthMock
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", "0x100")
-		ethMock.Register("eth_getBlockByNumber", eth.BlockHeader{})
 		ethMock.Register("eth_chainId", config.ChainID())
 		ethMock.Register("eth_sendRawTransaction", cltest.NewHash())
 	})
@@ -60,10 +58,9 @@ func TestTransfersController_CreateSuccess_From(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
-	ethMock := app.MockCallerSubscriberClient()
+	ethMock := app.EthMock
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", "0x100")
-		ethMock.Register("eth_getBlockByNumber", eth.BlockHeader{})
 		ethMock.Register("eth_sendRawTransaction", cltest.NewHash())
 		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
 	})
@@ -98,10 +95,9 @@ func TestTransfersController_TransferError(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
-	ethMock := app.MockCallerSubscriberClient()
+	ethMock := app.EthMock
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", "0x100")
-		ethMock.Register("eth_getBlockByNumber", eth.BlockHeader{})
 		ethMock.Register("eth_chainId", config.ChainID())
 		ethMock.RegisterError("eth_sendRawTransaction", "No dice")
 	})
@@ -133,10 +129,9 @@ func TestTransfersController_JSONBindingError(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config)
 	defer cleanup()
 
-	ethMock := app.MockCallerSubscriberClient()
+	ethMock := app.EthMock
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", "0x100")
-		ethMock.Register("eth_getBlockByNumber", eth.BlockHeader{})
 		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
 	})
 

--- a/core/web/tx_attempts_controller_test.go
+++ b/core/web/tx_attempts_controller_test.go
@@ -20,7 +20,7 @@ func TestTxAttemptsController_Index_Success(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 
-	ethMock := app.MockCallerSubscriberClient()
+	ethMock := app.EthMock
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_chainId", app.Config.ChainID())
 		ethMock.Register("eth_getTransactionCount", "0x100")
@@ -58,8 +58,10 @@ func TestTxAttemptsController_Index_Error(t *testing.T) {
 
 	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
-	ethMock := app.MockCallerSubscriberClient()
-	ethMock.Register("eth_getTransactionCount", "0x100")
+	app.EthMock.Context("app.Start()", func(meth *cltest.EthMock) {
+		meth.Register("eth_getTransactionCount", "0x1")
+		meth.Register("eth_chainId", app.Store.Config.ChainID())
+	})
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()

--- a/core/web/user_controller_test.go
+++ b/core/web/user_controller_test.go
@@ -18,7 +18,7 @@ import (
 func TestUserController_UpdatePassword(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
@@ -53,7 +53,7 @@ func TestUserController_UpdatePassword(t *testing.T) {
 func TestUserController_AccountBalances_NoAccounts(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
+	app, cleanup := cltest.NewApplication(t, cltest.EthMockRegisterChainID)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
@@ -73,14 +73,14 @@ func TestUserController_AccountBalances_NoAccounts(t *testing.T) {
 func TestUserController_AccountBalances_Success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
 
 	app.AddUnlockedKey()
 	client := app.NewHTTPClient()
 
-	ethMock := app.MockCallerSubscriberClient()
+	ethMock := app.EthMock
 	ethMock.Context("first wallet", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getBalance", "0x0100")
 		ethMock.Register("eth_call", "0x0100")
@@ -113,13 +113,9 @@ func TestUserController_AccountBalances_Success(t *testing.T) {
 func TestUserController_NewAPIToken(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
-	ethMock := app.MockCallerSubscriberClient()
-	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
-	})
 
 	client := app.NewHTTPClient()
 	req, err := json.Marshal(models.ChangeAuthTokenRequest{
@@ -140,13 +136,9 @@ func TestUserController_NewAPIToken(t *testing.T) {
 func TestUserController_NewAPIToken_unauthorized(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
-	ethMock := app.MockCallerSubscriberClient()
-	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
-	})
 
 	client := app.NewHTTPClient()
 	req, err := json.Marshal(models.ChangeAuthTokenRequest{
@@ -161,13 +153,9 @@ func TestUserController_NewAPIToken_unauthorized(t *testing.T) {
 func TestUserController_DeleteAPIKey(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
-	ethMock := app.MockCallerSubscriberClient()
-	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
-	})
 
 	client := app.NewHTTPClient()
 	req, err := json.Marshal(models.ChangeAuthTokenRequest{
@@ -183,13 +171,9 @@ func TestUserController_DeleteAPIKey(t *testing.T) {
 func TestUserController_DeleteAPIKey_unauthorized(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
+	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
-	ethMock := app.MockCallerSubscriberClient()
-	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
-	})
 
 	client := app.NewHTTPClient()
 	req, err := json.Marshal(models.ChangeAuthTokenRequest{

--- a/core/web/withdrawals_controller_test.go
+++ b/core/web/withdrawals_controller_test.go
@@ -84,7 +84,7 @@ func TestWithdrawalsController_BalanceTooLow(t *testing.T) {
 		Amount:             assets.NewLink(1000000000000000000),
 	}
 
-	ethMock := app.MockCallerSubscriberClient()
+	ethMock := app.EthMock
 
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_getTransactionCount", "0x100")


### PR DESCRIPTION
Fixes https://www.pivotaltracker.com/n/projects/2129823/stories/170925095

This forces all uses of ethmock to be strict by default, unless the `cltest.Lenient` flag is explicitly passed.

This cleans up a ton of useless errors from logs when tests are run with `-v` and forces new uses to be explicit about either mocking or not.