### PR TITLE
Fix postgres advisory locking tests

### DIFF
--- a/core/store/orm/locking_strategies_test.go
+++ b/core/store/orm/locking_strategies_test.go
@@ -7,11 +7,13 @@ import (
 	"testing"
 	"time"
 
+	"chainlink/core/gracefulpanic"
 	"chainlink/core/internal/cltest"
 	"chainlink/core/store/models"
 	"chainlink/core/store/orm"
 
 	"github.com/jinzhu/gorm"
+	"github.com/onsi/gomega"
 	"github.com/pkg/errors"
 
 	"github.com/stretchr/testify/require"
@@ -144,9 +146,8 @@ func TestPostgresLockingStrategy_CanBeReacquiredByNewNodeAfterDisconnect(t *test
 	})
 	require.NoError(t, err)
 
-	require.Panics(t, func() {
-		_ = store.ORM.RawDB(func(db *gorm.DB) error { return nil })
-	})
+	_ = store.ORM.RawDB(func(db *gorm.DB) error { return nil })
+	gomega.NewGomegaWithT(t).Eventually(gracefulpanic.Wait()).Should(gomega.BeClosed())
 }
 
 func TestPostgresLockingStrategy_WhenReacquiredOriginalNodeErrors(t *testing.T) {
@@ -171,7 +172,6 @@ func TestPostgresLockingStrategy_WhenReacquiredOriginalNodeErrors(t *testing.T) 
 	require.NoError(t, err)
 	defer lock.Unlock(delay)
 
-	require.Panics(t, func() {
-		_ = store.ORM.RawDB(func(db *gorm.DB) error { return nil })
-	})
+	_ = store.ORM.RawDB(func(db *gorm.DB) error { return nil })
+	gomega.NewGomegaWithT(t).Eventually(gracefulpanic.Wait()).Should(gomega.BeClosed())
 }


### PR DESCRIPTION
Wait for gracefulpanic channel close instead of real panic... because
`MustEnsureAdvisoryLock` never actually panics.

I have no idea how this test ever passed.

Story: https://www.pivotaltracker.com/n/projects/2129823

@spooktheducks in addition to this fix, what do you think about renaming `gracefulpanic` to `gracefulexit`?

I find it to be confusingly named, because it doesn't actually panic.
