### PR TITLE
Prevent data race when stopping run queue

### DIFF
--- a/core/services/run_queue.go
+++ b/core/services/run_queue.go
@@ -34,9 +34,10 @@ type RunQueue interface {
 }
 
 type runQueue struct {
-	workersMutex sync.RWMutex
-	workers      map[string]int
-	workersWg    sync.WaitGroup
+	workersMutex  sync.RWMutex
+	workers       map[string]int
+	workersWg     sync.WaitGroup
+	stopRequested bool
 
 	runExecutor RunExecutor
 }
@@ -56,24 +57,27 @@ func (rq *runQueue) Start() error {
 
 // Stop closes all open worker channels.
 func (rq *runQueue) Stop() {
+	rq.workersMutex.Lock()
+	rq.stopRequested = true
+	rq.workersMutex.Unlock()
 	rq.workersWg.Wait()
 }
 
 // Run tells the job runner to start executing a job
 func (rq *runQueue) Run(run *models.JobRun) {
-	runID := run.ID.String()
-
-	defer numberRunsQueued.Inc()
-
 	rq.workersMutex.Lock()
+	if rq.stopRequested {
+		return
+	}
+
+	runID := run.ID.String()
+	defer numberRunsQueued.Inc()
 	if queueCount, present := rq.workers[runID]; present {
 		rq.workers[runID] = queueCount + 1
-		rq.workersMutex.Unlock()
 		return
 	}
 	rq.workers[runID] = 1
 	numberRunQueueWorkers.Set(float64(len(rq.workers)))
-	rq.workersMutex.Unlock()
 
 	rq.workersWg.Add(1)
 	go func() {
@@ -96,6 +100,7 @@ func (rq *runQueue) Run(run *models.JobRun) {
 
 		rq.workersWg.Done()
 	}()
+	rq.workersMutex.Unlock()
 }
 
 // WorkerCount returns the number of workers currently processing a job run

--- a/core/services/run_queue.go
+++ b/core/services/run_queue.go
@@ -66,6 +66,7 @@ func (rq *runQueue) Stop() {
 // Run tells the job runner to start executing a job
 func (rq *runQueue) Run(run *models.JobRun) {
 	rq.workersMutex.Lock()
+	defer rq.workersMutex.Unlock()
 	if rq.stopRequested {
 		return
 	}
@@ -100,7 +101,6 @@ func (rq *runQueue) Run(run *models.JobRun) {
 
 		rq.workersWg.Done()
 	}()
-	rq.workersMutex.Unlock()
 }
 
 // WorkerCount returns the number of workers currently processing a job run


### PR DESCRIPTION
Data race occurs because you are not suppose to access a waitlock from
different goroutines.

Solution is to synchronise access to the waitlock using a mutex and
only allow addition of workers if we aren't waiting for it to close.