### PR TITLE
Associate an admin account with each oracle in the PrepaidAggregator.

### DIFF
--- a/evm-contracts/src/v0.6/dev/PrepaidAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/PrepaidAggregator.sol
@@ -150,6 +150,7 @@ contract PrepaidAggregator is AggregatorInterface, Owned {
     onlyUnenabledAddress(_oracle)
   {
     require(oracleCount() < 42, "cannot add more than 42 oracles");
+    require(_admin != address(0), "admin address must not be 0x0");
     require(
       oracles[_oracle].admin == address(0) || oracles[_oracle].admin == _admin,
       "cannot modify previously-set admin address"

--- a/evm-contracts/src/v0.6/dev/PrepaidAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/PrepaidAggregator.sol
@@ -6,7 +6,6 @@ import "./SafeMath128.sol";
 import "./SafeMath64.sol";
 import "./SafeMath32.sol";
 import "../interfaces/LinkTokenInterface.sol";
-import "../interfaces/WithdrawalInterface.sol";
 import "./AggregatorInterface.sol";
 import "../Owned.sol";
 
@@ -18,7 +17,7 @@ import "../Owned.sol";
  * single answer. The latest aggregated answer is exposed as well as historical
  * answers and their updated at timestamp.
  */
-contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
+contract PrepaidAggregator is AggregatorInterface, Owned {
   using SafeMath for uint256;
   using SafeMath128 for uint128;
   using SafeMath64 for uint64;
@@ -48,6 +47,7 @@ contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
     uint32 lastStartedRound;
     int256 latestAnswer;
     uint16 index;
+    address admin;
   }
 
   uint128 public allocatedFunds;
@@ -130,6 +130,8 @@ contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
    * @notice called by the owner to add a new Oracle and update the round
    * related parameters
    * @param _oracle is the address of the new Oracle being added
+   * @param _admin is the admin address of the new oracle. Only this address
+   * is allowed to access the oracle's funds.
    * @param _minAnswers is the new minimum answer count for each round
    * @param _maxAnswers is the new maximum answer count for each round
    * @param _restartDelay is the number of rounds an Oracle has to wait before
@@ -137,6 +139,7 @@ contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
    */
   function addOracle(
     address _oracle,
+    address _admin,
     uint32 _minAnswers,
     uint32 _maxAnswers,
     uint32 _restartDelay
@@ -146,10 +149,15 @@ contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
     onlyUnenabledAddress(_oracle)
   {
     require(oracleCount() < 42, "cannot add more than 42 oracles");
+    require(
+      oracles[_oracle].admin == address(0) || oracles[_oracle].admin == _admin,
+      "cannot modify previously-set admin address"
+    );
     oracles[_oracle].startingRound = getStartingRound(_oracle);
     oracles[_oracle].endingRound = ROUND_MAX;
     oracleAddresses.push(_oracle);
     oracles[_oracle].index = uint16(oracleAddresses.length.sub(1));
+    oracles[_oracle].admin = _admin;
 
     emit OracleAdded(_oracle);
 
@@ -382,29 +390,31 @@ contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
   /**
    * @notice query the available amount of LINK for an oracle to withdraw
    */
-  function withdrawable()
+  function withdrawable(address _oracle)
     external
     view
-    override
     returns (uint256)
   {
-    return oracles[msg.sender].withdrawable;
+    return oracles[_oracle].withdrawable;
   }
 
   /**
-   * @notice transfers the oracle's LINK to another address
+   * @notice transfers the oracle's LINK to another address. Can only be called
+   * by the oracle's admin.
+   * @param _oracle is the oracle whose LINK is transferred
    * @param _recipient is the address to send the LINK to
    * @param _amount is the amount of LINK to send
    */
-  function withdraw(address _recipient, uint256 _amount)
+  function withdraw(address _oracle, address _recipient, uint256 _amount)
     external
-    override
   {
+    require(oracles[_oracle].admin == msg.sender, "Only admin can withdraw");
+
     uint128 amount = uint128(_amount);
-    uint128 available = oracles[msg.sender].withdrawable;
+    uint128 available = oracles[_oracle].withdrawable;
     require(available >= amount, "Insufficient balance");
 
-    oracles[msg.sender].withdrawable = available.sub(amount);
+    oracles[_oracle].withdrawable = available.sub(amount);
     allocatedFunds = allocatedFunds.sub(amount);
 
     assert(LINK.transfer(_recipient, uint256(amount)));
@@ -434,6 +444,30 @@ contract PrepaidAggregator is AggregatorInterface, Owned, WithdrawalInterface {
     returns (int256, uint256)
   {
     return (oracles[_oracle].latestAnswer, oracles[_oracle].lastReportedRound);
+  }
+
+  /**
+   * @notice get the admin address of an oracle
+   * @param _oracle is the address of the oracle whose admin is being queried
+   */
+  function getAdmin(address _oracle)
+    external
+    view
+    returns (address)
+  {
+    return oracles[_oracle].admin;
+  }
+
+  /**
+   * @notice update the admin address for an oracle
+   * @param _oracle is the address of the oracle whose admin is being updated
+   * @param _newAdmin is the new admin address
+   */
+  function updateAdmin(address _oracle, address _newAdmin)
+    external
+  {
+    require(oracles[_oracle].admin == msg.sender, "Only admin can update admin");
+    oracles[_oracle].admin = _newAdmin;
   }
 
   /**

--- a/evm-contracts/src/v0.6/dev/PrepaidAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/PrepaidAggregator.sol
@@ -79,6 +79,7 @@ contract PrepaidAggregator is AggregatorInterface, Owned {
   );
   event OracleAdded(address indexed oracle);
   event OracleRemoved(address indexed oracle);
+  event OracleAdminUpdated(address indexed oracle, address indexed newAdmin);
   event SubmissionReceived(
     int256 indexed answer,
     uint32 indexed round,
@@ -160,6 +161,7 @@ contract PrepaidAggregator is AggregatorInterface, Owned {
     oracles[_oracle].admin = _admin;
 
     emit OracleAdded(_oracle);
+    emit OracleAdminUpdated(_oracle, _admin);
 
     updateFutureRounds(paymentAmount, _minAnswers, _maxAnswers, _restartDelay, timeout);
   }
@@ -468,6 +470,8 @@ contract PrepaidAggregator is AggregatorInterface, Owned {
   {
     require(oracles[_oracle].admin == msg.sender, "Only admin can update admin");
     oracles[_oracle].admin = _newAdmin;
+
+    emit OracleAdminUpdated(_oracle, _newAdmin);
   }
 
   /**

--- a/evm-contracts/test/v0.6/PrepaidAggregator.test.ts
+++ b/evm-contracts/test/v0.6/PrepaidAggregator.test.ts
@@ -727,7 +727,13 @@ describe('PrepaidAggregator', () => {
     beforeEach(async () => {
       await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+        .addOracle(
+          personas.Neil.address,
+          personas.Neil.address,
+          minAns,
+          maxAns,
+          rrDelay,
+        )
 
       for (let i = 0; i < 10; i++) {
         await aggregator.connect(personas.Neil).updateAnswer(nextRound, i)

--- a/evm-contracts/test/v0.6/PrepaidAggregator.test.ts
+++ b/evm-contracts/test/v0.6/PrepaidAggregator.test.ts
@@ -88,6 +88,7 @@ describe('PrepaidAggregator', () => {
       'allocatedFunds',
       'availableFunds',
       'description',
+      'getAdmin',
       'getAnswer',
       'getOracles',
       'getOriginatingRoundOfAnswer',
@@ -109,6 +110,7 @@ describe('PrepaidAggregator', () => {
       'reportingRoundStartedAt',
       'restartDelay',
       'timeout',
+      'updateAdmin',
       'updateAnswer',
       'updateAvailableFunds',
       'updateFutureRounds',
@@ -161,7 +163,13 @@ describe('PrepaidAggregator', () => {
         minMax = i + 1
         await aggregator
           .connect(personas.Carol)
-          .addOracle(oracleAddresses[i].address, minMax, minMax, rrDelay)
+          .addOracle(
+            oracleAddresses[i].address,
+            oracleAddresses[i].address,
+            minMax,
+            minMax,
+            rrDelay,
+          )
       }
     })
 
@@ -211,22 +219,30 @@ describe('PrepaidAggregator', () => {
       it('pays the oracles that have reported', async () => {
         matchers.bigNum(
           0,
-          await aggregator.connect(personas.Neil).withdrawable(),
+          await aggregator
+            .connect(personas.Neil)
+            .withdrawable(personas.Neil.address),
         )
 
         await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
 
         matchers.bigNum(
           paymentAmount,
-          await aggregator.connect(personas.Neil).withdrawable(),
+          await aggregator
+            .connect(personas.Neil)
+            .withdrawable(personas.Neil.address),
         )
         matchers.bigNum(
           0,
-          await aggregator.connect(personas.Ned).withdrawable(),
+          await aggregator
+            .connect(personas.Ned)
+            .withdrawable(personas.Ned.address),
         )
         matchers.bigNum(
           0,
-          await aggregator.connect(personas.Nelly).withdrawable(),
+          await aggregator
+            .connect(personas.Nelly)
+            .withdrawable(personas.Nelly.address),
         )
       })
 
@@ -420,11 +436,15 @@ describe('PrepaidAggregator', () => {
       it('pays the same amount to all oracles per round', async () => {
         matchers.bigNum(
           0,
-          await aggregator.connect(personas.Neil).withdrawable(),
+          await aggregator
+            .connect(personas.Neil)
+            .withdrawable(personas.Neil.address),
         )
         matchers.bigNum(
           0,
-          await aggregator.connect(personas.Nelly).withdrawable(),
+          await aggregator
+            .connect(personas.Nelly)
+            .withdrawable(personas.Nelly.address),
         )
 
         await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
@@ -435,11 +455,15 @@ describe('PrepaidAggregator', () => {
 
         matchers.bigNum(
           paymentAmount,
-          await aggregator.connect(personas.Neil).withdrawable(),
+          await aggregator
+            .connect(personas.Neil)
+            .withdrawable(personas.Neil.address),
         )
         matchers.bigNum(
           paymentAmount,
-          await aggregator.connect(personas.Nelly).withdrawable(),
+          await aggregator
+            .connect(personas.Nelly)
+            .withdrawable(personas.Nelly.address),
         )
       })
     })
@@ -648,7 +672,13 @@ describe('PrepaidAggregator', () => {
     beforeEach(async () => {
       await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+        .addOracle(
+          personas.Neil.address,
+          personas.Neil.address,
+          minAns,
+          maxAns,
+          rrDelay,
+        )
 
       for (const answer of answers) {
         await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
@@ -668,7 +698,13 @@ describe('PrepaidAggregator', () => {
     beforeEach(async () => {
       await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+        .addOracle(
+          personas.Neil.address,
+          personas.Neil.address,
+          minAns,
+          maxAns,
+          rrDelay,
+        )
 
       for (let i = 0; i < 10; i++) {
         await aggregator.connect(personas.Neil).updateAnswer(nextRound, i)
@@ -717,7 +753,13 @@ describe('PrepaidAggregator', () => {
       const pastCount = await aggregator.oracleCount()
       await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+        .addOracle(
+          personas.Neil.address,
+          personas.Neil.address,
+          minAns,
+          maxAns,
+          rrDelay,
+        )
       const currentCount = await aggregator.oracleCount()
 
       matchers.bigNum(currentCount, pastCount + 1)
@@ -726,14 +768,20 @@ describe('PrepaidAggregator', () => {
     it('adds the address in getOracles', async () => {
       await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+        .addOracle(
+          personas.Neil.address,
+          personas.Neil.address,
+          minAns,
+          maxAns,
+          rrDelay,
+        )
       assert.deepEqual([personas.Neil.address], await aggregator.getOracles())
     })
 
     it('updates the round details', async () => {
       await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Neil.address, 0, 1, 0)
+        .addOracle(personas.Neil.address, personas.Neil.address, 0, 1, 0)
 
       matchers.bigNum(ethers.constants.Zero, await aggregator.minAnswerCount())
       matchers.bigNum(
@@ -746,7 +794,13 @@ describe('PrepaidAggregator', () => {
     it('emits a log', async () => {
       const tx = await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+        .addOracle(
+          personas.Neil.address,
+          personas.Neil.address,
+          minAns,
+          maxAns,
+          rrDelay,
+        )
       const receipt = await tx.wait()
 
       const added = h.evmWordToAddress(receipt.logs?.[0].topics[1])
@@ -757,14 +811,26 @@ describe('PrepaidAggregator', () => {
       beforeEach(async () => {
         await aggregator
           .connect(personas.Carol)
-          .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+          .addOracle(
+            personas.Neil.address,
+            personas.Neil.address,
+            minAns,
+            maxAns,
+            rrDelay,
+          )
       })
 
       it('reverts', async () => {
         await matchers.evmRevert(
           aggregator
             .connect(personas.Carol)
-            .addOracle(personas.Neil.address, minAns, maxAns, rrDelay),
+            .addOracle(
+              personas.Neil.address,
+              personas.Neil.address,
+              minAns,
+              maxAns,
+              rrDelay,
+            ),
           'Address is already recorded as an oracle',
         )
       })
@@ -775,7 +841,13 @@ describe('PrepaidAggregator', () => {
         await matchers.evmRevert(
           aggregator
             .connect(personas.Neil)
-            .addOracle(personas.Neil.address, minAns, maxAns, rrDelay),
+            .addOracle(
+              personas.Neil.address,
+              personas.Neil.address,
+              minAns,
+              maxAns,
+              rrDelay,
+            ),
           'Only callable by owner',
         )
       })
@@ -787,14 +859,26 @@ describe('PrepaidAggregator', () => {
         for (let i = 0; i < oracleAddresses.length; i++) {
           await aggregator
             .connect(personas.Carol)
-            .addOracle(oracleAddresses[i].address, i + 1, i + 1, rrDelay)
+            .addOracle(
+              oracleAddresses[i].address,
+              oracleAddresses[i].address,
+              i + 1,
+              i + 1,
+              rrDelay,
+            )
         }
 
         await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
 
         await aggregator
           .connect(personas.Carol)
-          .addOracle(personas.Nelly.address, 3, 3, rrDelay)
+          .addOracle(
+            personas.Nelly.address,
+            personas.Nelly.address,
+            3,
+            3,
+            rrDelay,
+          )
       })
 
       it('does not allow the oracle to update the round', async () => {
@@ -821,7 +905,13 @@ describe('PrepaidAggregator', () => {
         for (let i = 0; i < oracleAddresses.length; i++) {
           await aggregator
             .connect(personas.Carol)
-            .addOracle(oracleAddresses[i].address, i + 1, i + 1, rrDelay)
+            .addOracle(
+              oracleAddresses[i].address,
+              oracleAddresses[i].address,
+              i + 1,
+              i + 1,
+              rrDelay,
+            )
         }
 
         await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
@@ -837,7 +927,13 @@ describe('PrepaidAggregator', () => {
 
         await aggregator
           .connect(personas.Carol)
-          .addOracle(personas.Nelly.address, 1, 1, rrDelay)
+          .addOracle(
+            personas.Nelly.address,
+            personas.Nelly.address,
+            1,
+            1,
+            rrDelay,
+          )
 
         await aggregator.connect(personas.Nelly).updateAnswer(nextRound, answer)
       })
@@ -849,7 +945,53 @@ describe('PrepaidAggregator', () => {
         for (let i = 0; i < oracleAddresses.length; i++) {
           await aggregator
             .connect(personas.Carol)
-            .addOracle(oracleAddresses[i].address, i + 1, i + 1, rrDelay)
+            .addOracle(
+              oracleAddresses[i].address,
+              oracleAddresses[i].address,
+              i + 1,
+              i + 1,
+              rrDelay,
+            )
+        }
+
+        await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
+        await aggregator.connect(personas.Nelly).updateAnswer(nextRound, answer)
+        nextRound++
+
+        await aggregator
+          .connect(personas.Carol)
+          .removeOracle(personas.Nelly.address, 1, 1, rrDelay)
+
+        await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
+        nextRound++
+
+        await aggregator
+          .connect(personas.Carol)
+          .addOracle(
+            personas.Nelly.address,
+            personas.Nelly.address,
+            1,
+            1,
+            rrDelay,
+          )
+
+        await aggregator.connect(personas.Nelly).updateAnswer(nextRound, answer)
+      })
+    })
+
+    describe('when an oracle is re-added with a different admin address', () => {
+      it('reverts', async () => {
+        oracleAddresses = [personas.Neil, personas.Nelly]
+        for (let i = 0; i < oracleAddresses.length; i++) {
+          await aggregator
+            .connect(personas.Carol)
+            .addOracle(
+              oracleAddresses[i].address,
+              oracleAddresses[i].address,
+              i + 1,
+              i + 1,
+              rrDelay,
+            )
         }
 
         await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
@@ -857,11 +999,18 @@ describe('PrepaidAggregator', () => {
         await aggregator
           .connect(personas.Carol)
           .removeOracle(personas.Nelly.address, 1, 1, rrDelay)
-        await aggregator
-          .connect(personas.Carol)
-          .addOracle(personas.Nelly.address, 1, 1, rrDelay)
-
-        await aggregator.connect(personas.Nelly).updateAnswer(nextRound, answer)
+        await matchers.evmRevert(
+          aggregator
+            .connect(personas.Carol)
+            .addOracle(
+              personas.Nelly.address,
+              personas.Carol.address,
+              1,
+              1,
+              rrDelay,
+            ),
+          'cannot modify previously-set admin address',
+        )
       })
     })
 
@@ -874,12 +1023,18 @@ describe('PrepaidAggregator', () => {
 
           await aggregator
             .connect(personas.Carol)
-            .addOracle(fakeAddress, minMax, minMax, rrDelay)
+            .addOracle(fakeAddress, fakeAddress, minMax, minMax, rrDelay)
         }
         await matchers.evmRevert(
           aggregator
             .connect(personas.Carol)
-            .addOracle(personas.Neil.address, limit + 1, limit + 1, rrDelay),
+            .addOracle(
+              personas.Neil.address,
+              personas.Neil.address,
+              limit + 1,
+              limit + 1,
+              rrDelay,
+            ),
           `cannot add more than ${limit} oracles`,
         )
       })
@@ -890,10 +1045,23 @@ describe('PrepaidAggregator', () => {
     beforeEach(async () => {
       await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+        .addOracle(
+          personas.Neil.address,
+          personas.Neil.address,
+          minAns,
+          maxAns,
+          rrDelay,
+        )
       await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Nelly.address, 2, 2, rrDelay, {})
+        .addOracle(
+          personas.Nelly.address,
+          personas.Nelly.address,
+          2,
+          2,
+          rrDelay,
+          {},
+        )
     })
 
     it('decreases the oracle count', async () => {
@@ -1003,14 +1171,26 @@ describe('PrepaidAggregator', () => {
       beforeEach(async () => {
         await aggregator
           .connect(personas.Carol)
-          .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+          .addOracle(
+            personas.Neil.address,
+            personas.Neil.address,
+            minAns,
+            maxAns,
+            rrDelay,
+          )
         assert.deepEqual([personas.Neil.address], await aggregator.getOracles())
       })
 
       it('returns the addresses of added oracles', async () => {
         await aggregator
           .connect(personas.Carol)
-          .addOracle(personas.Ned.address, minAns, maxAns, rrDelay)
+          .addOracle(
+            personas.Ned.address,
+            personas.Ned.address,
+            minAns,
+            maxAns,
+            rrDelay,
+          )
         assert.deepEqual(
           [personas.Neil.address, personas.Ned.address],
           await aggregator.getOracles(),
@@ -1018,7 +1198,13 @@ describe('PrepaidAggregator', () => {
 
         await aggregator
           .connect(personas.Carol)
-          .addOracle(personas.Nelly.address, minAns, maxAns, rrDelay)
+          .addOracle(
+            personas.Nelly.address,
+            personas.Nelly.address,
+            minAns,
+            maxAns,
+            rrDelay,
+          )
         assert.deepEqual(
           [personas.Neil.address, personas.Ned.address, personas.Nelly.address],
           await aggregator.getOracles(),
@@ -1030,13 +1216,31 @@ describe('PrepaidAggregator', () => {
       beforeEach(async () => {
         await aggregator
           .connect(personas.Carol)
-          .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+          .addOracle(
+            personas.Neil.address,
+            personas.Neil.address,
+            minAns,
+            maxAns,
+            rrDelay,
+          )
         await aggregator
           .connect(personas.Carol)
-          .addOracle(personas.Ned.address, minAns, maxAns, rrDelay)
+          .addOracle(
+            personas.Ned.address,
+            personas.Ned.address,
+            minAns,
+            maxAns,
+            rrDelay,
+          )
         await aggregator
           .connect(personas.Carol)
-          .addOracle(personas.Nelly.address, minAns, maxAns, rrDelay)
+          .addOracle(
+            personas.Nelly.address,
+            personas.Nelly.address,
+            minAns,
+            maxAns,
+            rrDelay,
+          )
         assert.deepEqual(
           [personas.Neil.address, personas.Ned.address, personas.Nelly.address],
           await aggregator.getOracles(),
@@ -1103,7 +1307,13 @@ describe('PrepaidAggregator', () => {
         beforeEach(async () => {
           await aggregator
             .connect(personas.Carol)
-            .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+            .addOracle(
+              personas.Neil.address,
+              personas.Neil.address,
+              minAns,
+              maxAns,
+              rrDelay,
+            )
           await aggregator
             .connect(personas.Neil)
             .updateAnswer(nextRound, answer)
@@ -1152,7 +1362,13 @@ describe('PrepaidAggregator', () => {
         const minMax = i + 1
         await aggregator
           .connect(personas.Carol)
-          .addOracle(oracleAddresses[i].address, minMax, minMax, rrDelay)
+          .addOracle(
+            oracleAddresses[i].address,
+            oracleAddresses[i].address,
+            minMax,
+            minMax,
+            rrDelay,
+          )
       }
       minAnswerCount = oracleAddresses.length
       maxAnswerCount = oracleAddresses.length
@@ -1267,7 +1483,13 @@ describe('PrepaidAggregator', () => {
 
       await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+        .addOracle(
+          personas.Neil.address,
+          personas.Neil.address,
+          minAns,
+          maxAns,
+          rrDelay,
+        )
       await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
       await link.transfer(aggregator.address, deposit)
       await aggregator.updateAvailableFunds()
@@ -1303,17 +1525,23 @@ describe('PrepaidAggregator', () => {
     beforeEach(async () => {
       await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+        .addOracle(
+          personas.Neil.address,
+          personas.Neil.address,
+          minAns,
+          maxAns,
+          rrDelay,
+        )
       await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
     })
 
-    it('transfers LINK to the caller', async () => {
+    it('transfers LINK to the recipient', async () => {
       const originalBalance = await link.balanceOf(aggregator.address)
       matchers.bigNum(0, await link.balanceOf(personas.Neil.address))
 
       await aggregator
         .connect(personas.Neil)
-        .withdraw(personas.Neil.address, paymentAmount)
+        .withdraw(personas.Neil.address, personas.Neil.address, paymentAmount)
 
       matchers.bigNum(
         originalBalance.sub(paymentAmount),
@@ -1330,7 +1558,7 @@ describe('PrepaidAggregator', () => {
 
       await aggregator
         .connect(personas.Neil)
-        .withdraw(personas.Neil.address, paymentAmount)
+        .withdraw(personas.Neil.address, personas.Neil.address, paymentAmount)
 
       matchers.bigNum(
         originalAllocation.sub(paymentAmount),
@@ -1345,9 +1573,77 @@ describe('PrepaidAggregator', () => {
             .connect(personas.Neil)
             .withdraw(
               personas.Neil.address,
+              personas.Neil.address,
               paymentAmount.add(ethers.utils.bigNumberify(1)),
             ),
           'Insufficient balance',
+        )
+      })
+    })
+
+    describe('when the caller is not the admin', () => {
+      it('reverts', async () => {
+        await matchers.evmRevert(
+          aggregator
+            .connect(personas.Nelly)
+            .withdraw(
+              personas.Neil.address,
+              personas.Nelly.address,
+              ethers.utils.bigNumberify(1),
+            ),
+          'Only admin can withdraw',
+        )
+      })
+    })
+  })
+
+  describe('#updateAdmin', () => {
+    beforeEach(async () => {
+      await aggregator
+        .connect(personas.Carol)
+        .addOracle(
+          personas.Ned.address,
+          personas.Neil.address,
+          minAns,
+          maxAns,
+          rrDelay,
+        )
+    })
+
+    describe('when the admin tries to update the admin', () => {
+      it('works', async () => {
+        assert.equal(
+          personas.Neil.address,
+          await aggregator.getAdmin(personas.Ned.address),
+        )
+        await aggregator
+          .connect(personas.Neil)
+          .updateAdmin(personas.Ned.address, personas.Nelly.address)
+        assert.equal(
+          personas.Nelly.address,
+          await aggregator.getAdmin(personas.Ned.address),
+        )
+      })
+    })
+
+    describe('when the non-admin owner tries to update the admin', () => {
+      it('reverts', async () => {
+        await matchers.evmRevert(
+          aggregator
+            .connect(personas.Carol)
+            .updateAdmin(personas.Ned.address, personas.Nelly.address),
+          'Only admin can update admin',
+        )
+      })
+    })
+
+    describe('when the non-admin oracle tries to update the admin', () => {
+      it('reverts', async () => {
+        await matchers.evmRevert(
+          aggregator
+            .connect(personas.Ned)
+            .updateAdmin(personas.Ned.address, personas.Nelly.address),
+          'Only admin can update admin',
         )
       })
     })

--- a/evm-contracts/test/v0.6/PrepaidAggregator.test.ts
+++ b/evm-contracts/test/v0.6/PrepaidAggregator.test.ts
@@ -795,7 +795,7 @@ describe('PrepaidAggregator', () => {
       const tx = await aggregator
         .connect(personas.Carol)
         .addOracle(
-          personas.Neil.address,
+          personas.Ned.address,
           personas.Neil.address,
           minAns,
           maxAns,
@@ -803,8 +803,11 @@ describe('PrepaidAggregator', () => {
         )
       const receipt = await tx.wait()
 
-      const added = h.evmWordToAddress(receipt.logs?.[0].topics[1])
-      matchers.bigNum(added, personas.Neil.address)
+      const oracleAddedEvent = h.eventArgs(receipt.events?.[0])
+      assert.equal(oracleAddedEvent.oracle, personas.Ned.address)
+      const oracleAdminUpdatedEvent = h.eventArgs(receipt.events?.[1])
+      assert.equal(oracleAdminUpdatedEvent.oracle, personas.Ned.address)
+      assert.equal(oracleAdminUpdatedEvent.newAdmin, personas.Neil.address)
     })
 
     describe('when the oracle has already been added', () => {
@@ -1616,13 +1619,18 @@ describe('PrepaidAggregator', () => {
           personas.Neil.address,
           await aggregator.getAdmin(personas.Ned.address),
         )
-        await aggregator
+        const tx = await aggregator
           .connect(personas.Neil)
           .updateAdmin(personas.Ned.address, personas.Nelly.address)
+        const receipt = await tx.wait()
         assert.equal(
           personas.Nelly.address,
           await aggregator.getAdmin(personas.Ned.address),
         )
+
+        const event = h.eventArgs(receipt.events?.[0])
+        assert.equal(event.oracle, personas.Ned.address)
+        assert.equal(event.newAdmin, personas.Nelly.address)
       })
     })
 

--- a/evm-contracts/test/v0.6/WhitelistedAggregator.test.ts
+++ b/evm-contracts/test/v0.6/WhitelistedAggregator.test.ts
@@ -31,7 +31,7 @@ describe('WhitelistedAggregator', () => {
   let nextRound: number
   const deployment = setup.snapshot(provider, async () => {
     link = await linkTokenFactory.connect(personas.Default).deploy()
-    aggregator = await aggregatorFactory
+    aggregator = await (aggregatorFactory as any)
       .connect(personas.Carol)
       .deploy(
         link.address,
@@ -39,6 +39,9 @@ describe('WhitelistedAggregator', () => {
         timeout,
         decimals,
         h.toBytes32String(description),
+        // Remove when this PR gets merged:
+        // https://github.com/ethereum-ts/TypeChain/pull/218
+        { gasLimit: 5_500_000 },
       )
     await link.transfer(aggregator.address, deposit)
     await aggregator.updateAvailableFunds()

--- a/evm-contracts/test/v0.6/WhitelistedAggregator.test.ts
+++ b/evm-contracts/test/v0.6/WhitelistedAggregator.test.ts
@@ -57,6 +57,7 @@ describe('WhitelistedAggregator', () => {
       'allocatedFunds',
       'availableFunds',
       'description',
+      'getAdmin',
       'getAnswer',
       'getOracles',
       'getOriginatingRoundOfAnswer',
@@ -79,6 +80,7 @@ describe('WhitelistedAggregator', () => {
       'reportingRoundStartedAt',
       'restartDelay',
       'timeout',
+      'updateAdmin',
       'updateAnswer',
       'updateAvailableFunds',
       'updateFutureRounds',
@@ -118,7 +120,13 @@ describe('WhitelistedAggregator', () => {
     beforeEach(async () => {
       await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+        .addOracle(
+          personas.Neil.address,
+          personas.Neil.address,
+          minAns,
+          maxAns,
+          rrDelay,
+        )
       await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
     })
 
@@ -151,7 +159,13 @@ describe('WhitelistedAggregator', () => {
     beforeEach(async () => {
       await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+        .addOracle(
+          personas.Neil.address,
+          personas.Neil.address,
+          minAns,
+          maxAns,
+          rrDelay,
+        )
       await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
     })
 
@@ -186,7 +200,13 @@ describe('WhitelistedAggregator', () => {
     beforeEach(async () => {
       await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+        .addOracle(
+          personas.Neil.address,
+          personas.Neil.address,
+          minAns,
+          maxAns,
+          rrDelay,
+        )
       await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
     })
 
@@ -217,7 +237,13 @@ describe('WhitelistedAggregator', () => {
     beforeEach(async () => {
       await aggregator
         .connect(personas.Carol)
-        .addOracle(personas.Neil.address, minAns, maxAns, rrDelay)
+        .addOracle(
+          personas.Neil.address,
+          personas.Neil.address,
+          minAns,
+          maxAns,
+          rrDelay,
+        )
       await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
     })
 

--- a/integration-scripts/src/deployV0.6Contracts.ts
+++ b/integration-scripts/src/deployV0.6Contracts.ts
@@ -30,7 +30,13 @@ export async function deployContracts() {
     ethers.utils.formatBytes32String('ETH/USD'),
   )
   const { CHAINLINK_NODE_ADDRESS } = getArgs(['CHAINLINK_NODE_ADDRESS'])
-  await prepaidAggregator.addOracle(CHAINLINK_NODE_ADDRESS, 1, 1, 0)
+  await prepaidAggregator.addOracle(
+    CHAINLINK_NODE_ADDRESS,
+    CHAINLINK_NODE_ADDRESS,
+    1,
+    1,
+    0,
+  )
 
   return {
     linkToken,


### PR DESCRIPTION
Only an oracle's admin may update the admin address, and only an
oracle's admin may withdraw funds belonging to the oracle.

See https://www.pivotaltracker.com/story/show/171010886 for details