### PR TITLE
Inline Job Spec Controller function

### DIFF
--- a/core/web/job_specs_controller.go
+++ b/core/web/job_specs_controller.go
@@ -49,33 +49,25 @@ func (jsc *JobSpecsController) requireImplented(js models.JobSpec) error {
 	return nil
 }
 
-// getAndCheckJobSpec(c) returns a validated job spec from c, or errors. On
-// error, a non-zero HTTP status is returned.
-func (jsc *JobSpecsController) getAndCheckJobSpec(
-	c *gin.Context) (js models.JobSpec, httpStatus int, err error) {
-	var jsr models.JobSpecRequest
-	if err := c.ShouldBindJSON(&jsr); err != nil {
-		// TODO(alx): Better parsing and more specific error messages
-		// https://www.pivotaltracker.com/story/show/171164115
-		return models.JobSpec{}, http.StatusBadRequest, err
-	}
-	js = models.NewJobFromRequest(jsr)
-	if err := jsc.requireImplented(js); err != nil {
-		return models.JobSpec{}, http.StatusNotImplemented, err
-	}
-	if err := services.ValidateJob(js, jsc.App.GetStore()); err != nil {
-		return models.JobSpec{}, http.StatusBadRequest, err
-	}
-	return js, 0, nil
-}
-
 // Create adds validates, saves, and starts a new JobSpec.
 // Example:
 //  "<application>/specs"
 func (jsc *JobSpecsController) Create(c *gin.Context) {
-	js, httpStatus, err := jsc.getAndCheckJobSpec(c)
-	if err != nil {
-		jsonAPIError(c, httpStatus, err)
+	var jsr models.JobSpecRequest
+	if err := c.ShouldBindJSON(&jsr); err != nil {
+		// TODO(alx): Better parsing and more specific error messages
+		// https://www.pivotaltracker.com/story/show/171164115
+		jsonAPIError(c, http.StatusBadRequest, err)
+		return
+	}
+
+	js := models.NewJobFromRequest(jsr)
+	if err := jsc.requireImplented(js); err != nil {
+		jsonAPIError(c, http.StatusNotImplemented, err)
+		return
+	}
+	if err := services.ValidateJob(js, jsc.App.GetStore()); err != nil {
+		jsonAPIError(c, http.StatusBadRequest, err)
 		return
 	}
 	if err := NotifyExternalInitiator(js, jsc.App.GetStore()); err != nil {

--- a/core/web/job_specs_controller.go
+++ b/core/web/job_specs_controller.go
@@ -39,7 +39,7 @@ func (jsc *JobSpecsController) Index(c *gin.Context, size, page, offset int) {
 
 // requireImplented verifies if a Job Spec's feature is enabled according to
 // configured policy.
-func (jsc *JobSpecsController) requireImplented(js models.JobSpec) error {
+func (jsc *JobSpecsController) requireImplemented(js models.JobSpec) error {
 	cfg := jsc.App.GetStore().Config
 	if !cfg.Dev() && !cfg.FeatureFluxMonitor() {
 		if intrs := js.InitiatorsFor(models.InitiatorFluxMonitor); len(intrs) > 0 {
@@ -62,7 +62,7 @@ func (jsc *JobSpecsController) Create(c *gin.Context) {
 	}
 
 	js := models.NewJobFromRequest(jsr)
-	if err := jsc.requireImplented(js); err != nil {
+	if err := jsc.requireImplemented(js); err != nil {
 		jsonAPIError(c, http.StatusNotImplemented, err)
 		return
 	}


### PR DESCRIPTION
Improve readibility by inlining a function which is not re-used anywhere.  The change will easily understanding which HTTP status codes are associated with which task.