### PR TITLE
Make sleeper task Stop() function synchronous

### DIFF
--- a/core/web/authentication_test.go
+++ b/core/web/authentication_test.go
@@ -31,7 +31,6 @@ func TestAuthenticateByToken_Success(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	require.NoError(t, app.Start())
-	app.Start()
 	app.MustSeedUserAPIKey()
 
 	called := false
@@ -56,7 +55,6 @@ func TestAuthenticateByToken_AuthFailed(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithKey(t)
 	defer cleanup()
 	require.NoError(t, app.Start())
-	app.Start()
 	app.MustSeedUserAPIKey()
 
 	called := false


### PR DESCRIPTION
- Ensures the worker completes before returning
- Prevents race condition in tests