### PR TITLE
Make SleeperTask.Stop() synchronous

### DIFF
--- a/core/services/application_test.go
+++ b/core/services/application_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
 	"github.com/tevino/abool"
+	"time"
 )
 
 func TestChainlinkApplication_SignalShutdown(t *testing.T) {
@@ -30,7 +31,7 @@ func TestChainlinkApplication_SignalShutdown(t *testing.T) {
 
 	gomega.NewGomegaWithT(t).Eventually(func() bool {
 		return completed.IsSet()
-	}).Should(gomega.BeTrue())
+	}, 10*time.Second).Should(gomega.BeTrue())
 }
 
 func TestChainlinkApplication_resumesPendingConnection_Happy(t *testing.T) {

--- a/core/services/sleeper_task.go
+++ b/core/services/sleeper_task.go
@@ -20,7 +20,7 @@ const (
 type SleeperTask interface {
 	Start() error
 	Stop() error
-	WakeUp() error
+	WakeUp()
 }
 
 // Worker is a simple interface that represents some work to do repeatedly
@@ -101,18 +101,15 @@ func (s *sleeperTask) Stop() error {
 
 // WakeUp wakes up the sleeper task, asking it to execute its Worker.
 // Idempotent, can be called multiple times but will only wake the worker once (until the worker finishes again)
-func (s *sleeperTask) WakeUp() error {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
+func (s *sleeperTask) WakeUp() {
 	if s.state == stopped {
-		return errors.New("cannot wake up stopped sleeper task")
+		panic("cannot wake up stopped sleeper task")
 	}
 
 	select {
 	case s.waker <- struct{}{}:
 	default:
 	}
-	return nil
 }
 
 // workerLoop is the goroutine behind the sleeper task that waits for a signal

--- a/core/services/sleeper_task.go
+++ b/core/services/sleeper_task.go
@@ -1,10 +1,21 @@
 package services
 
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const (
+	stopWaitTime = 5 * time.Second
+)
+
 // SleeperTask represents a task that waits in the background to process some work.
 type SleeperTask interface {
 	Start() error
 	Stop() error
-	WakeUp()
+	WakeUp() error
 }
 
 // Worker is a simple interface that represents some work to do repeatedly
@@ -13,9 +24,13 @@ type Worker interface {
 }
 
 type sleeperTask struct {
-	worker Worker
-	waker  chan struct{}
-	closer chan struct{}
+	worker  Worker
+	waker   chan struct{}
+	closer  chan struct{}
+	closed  chan struct{}
+	started bool
+	stopped bool
+	mutex   sync.Mutex
 }
 
 // NewSleeperTask takes a worker and returns a SleeperTask.
@@ -29,30 +44,72 @@ type sleeperTask struct {
 //
 func NewSleeperTask(worker Worker) SleeperTask {
 	return &sleeperTask{
-		worker: worker,
-		waker:  make(chan struct{}, 1),
-		closer: make(chan struct{}, 1),
+		worker:  worker,
+		waker:   make(chan struct{}, 1),
+		closer:  make(chan struct{}, 1),
+		closed:  make(chan struct{}, 1),
+		started: false,
+		stopped: false,
+		mutex:   sync.Mutex{},
 	}
 }
 
 // Start begins the SleeperTask
+// Calling start on a started task will return an error
 func (s *sleeperTask) Start() error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+	if s.stopped {
+		return errors.New("cannot start a sleeper task that has been stopped")
+	} else if s.started {
+		return errors.New("sleeper task is already started")
+	}
+	s.started = true
 	go s.workerLoop()
 	return nil
 }
 
 // Stop stops the SleeperTask
+// It can only be called once
+// It will block until all tasks have completed, or the timeout is reached
+// Stopped tasks cannot be restarted
 func (s *sleeperTask) Stop() error {
+	s.mutex.Lock()
+	if s.stopped {
+		s.mutex.Unlock()
+		return errors.New("sleeper task is already stopped")
+	}
+	s.stopped = true
+	s.mutex.Unlock()
+
 	s.closer <- struct{}{}
-	return nil
+	// NOTE: Closing the channels will cause the rogue task to panic if it does eventually complete
+	defer close(s.waker)
+	defer close(s.closer)
+	defer close(s.closed)
+	select {
+	case <-s.closed:
+		return nil
+	case <-time.After(stopWaitTime):
+		return fmt.Errorf("task did not complete within %s", stopWaitTime.String())
+	}
 }
 
 // WakeUp wakes up the sleeper task, asking it to execute its Worker.
-func (s *sleeperTask) WakeUp() {
+// Idempotent, can be called multiple times but will only wake the worker once (until the worker finishes again)
+func (s *sleeperTask) WakeUp() error {
+	s.mutex.Lock()
+	if s.stopped {
+		s.mutex.Unlock()
+		return errors.New("cannot wake up stopped sleeper task")
+	}
+	s.mutex.Unlock()
+
 	select {
 	case s.waker <- struct{}{}:
 	default:
 	}
+	return nil
 }
 
 // workerLoop is the goroutine behind the sleeper task that waits for a signal
@@ -63,6 +120,7 @@ func (s *sleeperTask) workerLoop() {
 		case <-s.waker:
 			s.worker.Work()
 		case <-s.closer:
+			s.closed <- struct{}{}
 			return
 		}
 	}

--- a/core/services/sleeper_task_test.go
+++ b/core/services/sleeper_task_test.go
@@ -68,16 +68,14 @@ func TestSleeperTask_WakeupAfterStarted(t *testing.T) {
 	sleeper.Stop()
 }
 
-func TestSleeperTask_WakeupAfterStopped(t *testing.T) {
+func TestSleeperTask_WakeupAfterStoppedPanics(t *testing.T) {
 	worker := testWorker{output: make(chan struct{})}
 	sleeper := services.NewSleeperTask(&worker)
 
 	sleeper.Start()
 	sleeper.Stop()
 
-	err := sleeper.WakeUp()
-
-	assert.Error(t, err)
+	assert.Panics(t, sleeper.WakeUp, "expected sleeper.WakeUp() to panic on stopped sleeper, but it didn't")
 }
 
 func TestSleeperTask_WakeupNotBlockedWhileWorking(t *testing.T) {

--- a/core/services/sleeper_task_test.go
+++ b/core/services/sleeper_task_test.go
@@ -94,8 +94,7 @@ func TestSleeperTask_WakeupNotBlockedWhileWorking(t *testing.T) {
 	sleeper.Stop()
 }
 
-// TODO: Do we really need to support restarting? It doesnt't appear to be used anywhere
-func TestSleeperTask_Restart(t *testing.T) {
+func TestSleeperTask_StartAfterStoppedReturnsError(t *testing.T) {
 	worker := testWorker{output: make(chan struct{})}
 	sleeper := services.NewSleeperTask(&worker)
 
@@ -106,12 +105,7 @@ func TestSleeperTask_Restart(t *testing.T) {
 
 	sleeper.Stop()
 
-	sleeper.Start()
-	sleeper.WakeUp()
-
-	gomega.NewGomegaWithT(t).Eventually(worker.output).Should(gomega.Receive(&struct{}{}))
-
-	sleeper.Stop()
+	assert.Error(t, sleeper.Stop())
 }
 
 func TestSleeperTask_StopWaitsUntilWorkFinishes(t *testing.T) {

--- a/core/web/authentication_test.go
+++ b/core/web/authentication_test.go
@@ -31,7 +31,6 @@ func TestAuthenticateByToken_Success(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
-	app.Start()
 	app.MustSeedUserAPIKey()
 
 	called := false
@@ -56,7 +55,6 @@ func TestAuthenticateByToken_AuthFailed(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithKey(t, cltest.Lenient)
 	defer cleanup()
 	require.NoError(t, app.Start())
-	app.Start()
 	app.MustSeedUserAPIKey()
 
 	called := false

--- a/go.mod
+++ b/go.mod
@@ -49,7 +49,6 @@ require (
 	github.com/pborman/uuid v0.0.0-20180906182336-adf5a7427709 // indirect
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.4.1
-	github.com/prometheus/tsdb v0.7.1 // indirect
 	github.com/rjeczalik/notify v0.9.2 // indirect
 	github.com/rs/cors v1.6.0 // indirect
 	github.com/satori/go.uuid v1.2.0

--- a/go.sum
+++ b/go.sum
@@ -406,6 +406,7 @@ github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90 h1:S/YWwWx
 github.com/prometheus/client_model v0.0.0-20190129233127-fd36f4220a90/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/client_model v0.1.0 h1:ElTg5tNp4DqfV7UQjDqv2+RJlNzsDtvNAWccbItceIE=
 github.com/prometheus/client_model v0.1.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
+github.com/prometheus/client_model v0.2.0 h1:uq5h0d+GuxiXLJLNABMgp2qUWDPiLvgCzz2dUR+/W/M=
 github.com/prometheus/client_model v0.2.0/go.mod h1:xMI15A0UPsDsEKsMN9yxemIoYk6Tm2C1GtYGdfGttqA=
 github.com/prometheus/common v0.0.0-20181113130724-41aa239b4cce/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
 github.com/prometheus/common v0.0.0-20181120120127-aeab699e26f4/go.mod h1:daVV7qP5qjZbuso7PdcryaAu0sAZbrN9i7WWcTMWvro=
@@ -415,6 +416,7 @@ github.com/prometheus/common v0.4.0/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y8
 github.com/prometheus/common v0.4.1/go.mod h1:TNfzLD0ON7rHzMJeJkieUDPYmFC7Snx/y86RQel1bk4=
 github.com/prometheus/common v0.7.0 h1:L+1lyG48J1zAQXA3RBX/nG/B3gjlHq0zTt2tlbJLyCY=
 github.com/prometheus/common v0.7.0/go.mod h1:DjGbpBbp5NYNiECxcL/VnbXCCaQpKd3tt26CguLLsqA=
+github.com/prometheus/common v0.9.1 h1:KOMtN28tlbam3/7ZKEYKHhKoJZYYj3gMH4uc62x7X7U=
 github.com/prometheus/common v0.9.1/go.mod h1:yhUN8i9wzaXS3w1O07YhxHEBxD+W35wd8bs7vj7HSQ4=
 github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
 github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1/go.mod h1:c3At6R/oaqEKCNdg8wHV1ftS6bRYblBhIjjI8uT2IGk=
@@ -638,6 +640,7 @@ golang.org/x/sys v0.0.0-20190813064441-fde4db37ae7a/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20191026070338-33540a1f6037/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f h1:68K/z8GLUxV76xGSqwTWw2gyk/jwn79LUL43rES2g8o=
 golang.org/x/sys v0.0.0-20191220142924-d4481acd189f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200122134326-e047566fdf82 h1:ywK/j/KkyTHcdyYSZNXGjMwgmDSfjglYZ3vStQ/gSCU=
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -666,6 +669,7 @@ golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5 h1:hKsoRgsbwY1NafxrwTs+k64
 golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7 h1:9zdDQZ7Thm29KFXgAX/+yaf3eVbP7djjWp/dXAppNCc=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/api v0.3.1/go.mod h1:6wY9I6uQWHQ8EM57III9mq/AjF+i8G65rmVagqKMtkk=
 google.golang.org/appengine v1.1.0/go.mod h1:EbEs0AVv82hx2wNQdGPgUI5lhzA/G0D9YwlJXL52JkM=


### PR DESCRIPTION
This is a rewrite of #2301

- Fixes postgres "database still in use" test errors

NOTE: One question still remains.

@j16r @se3000 The tests indicate that we ought to support restarting sleeper tasks, but AFAICT this is not actually used anywhere in the code. It's significantly simpler if we don't support restarts and remove that test. What do you think?

P.s. thanks for your patience with this everyone.