### PR TITLE
(@chainlink/contracts) Recompile assets after tests

### DIFF
--- a/evm-box/package.json
+++ b/evm-box/package.json
@@ -15,7 +15,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "@chainlink/contracts": "^0.0.1",
+    "@chainlink/contracts": "^0.0.2",
     "@chainlink/test-helpers": "0.0.2",
     "openzeppelin-solidity": "1.12.0"
   },

--- a/evm-contracts/package.json
+++ b/evm-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/contracts",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Smart contracts and their language abstractions for chainlink",
   "repository": "https://github.com/smartcontractkit/chainlink",
   "author": "Chainlink devs",
@@ -12,7 +12,7 @@
     "clean": "tsc -b --clean tsconfig.test.json tsconfig.ethers.json && rm -rf abi ethers truffle",
     "pretest": "tsc -b --clean tsconfig.ethers.json",
     "test": "jest --testTimeout 80000 --forceExit",
-    "prepublishOnly": "yarn clean && yarn setup && yarn test"
+    "prepublishOnly": "yarn clean && yarn setup && yarn test && yarn setup"
   },
   "devDependencies": {
     "@chainlink/belt": "0.0.1",

--- a/integration-scripts/package.json
+++ b/integration-scripts/package.json
@@ -27,7 +27,7 @@
     "@0x/sol-compiler": "^4.0.3",
     "@0x/sol-trace": "^3.0.7",
     "@chainlink/test-helpers": "0.0.2",
-    "@chainlink/contracts": "0.0.1",
+    "@chainlink/contracts": "0.0.2",
     "chalk": "^2.4.2",
     "ethers": "^4.0.44",
     "link_token": "^1.0.6",


### PR DESCRIPTION
The "pretest" hook deletes any javascript assets after tests. When the order
of commands in the "prepublishOnly" script is executed, the published assets
are missing their transpiled javascript components for the "ethers" directory.
This change re-builds any missing files after tests.