### PR TITLE
Disable rebase check for tagged releases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -384,9 +384,9 @@ workflows:
   test:
     jobs:
       - check_if_rebase_needed:
-          filters: # all branches, and /^v../ tags for build-publish...
+          filters: 
             tags:
-              only: /^v.*/
+              ignore: /^v.*/
             branches:
               ignore:
                 - develop


### PR DESCRIPTION
CI always fails due to the fact that tag v0.7.4 is not rebased on develop... which of course it shouldn't be. This check feels like a mistake.