### PR TITLE
Fix racy test

### DIFF
--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -606,10 +606,10 @@ func TestRunManager_Create_fromRunLogPayments(t *testing.T) {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
 			config, configCleanup := cltest.NewConfig(t)
-			defer configCleanup()
 			config.Set("MINIMUM_CONTRACT_PAYMENT", test.configMinimumPayment)
 			app, cleanup := cltest.NewApplicationWithConfig(t, config, cltest.EthMockRegisterChainID)
 			defer cleanup()
+			defer configCleanup()
 
 			app.StartAndConnect()
 


### PR DESCRIPTION
Attempt to fix: https://www.pivotaltracker.com/story/show/171494227

We must clean up config BEFORE the app exits, so that all connections
are closed first before we tear down the database.