### PR TITLE
Add OpenLaw as ETH / USD feed sponsor

### DIFF
--- a/feeds/src/feeds.json
+++ b/feeds/src/feeds.json
@@ -11,7 +11,7 @@
     "history": true,
     "decimalPlaces": 3,
     "multiply": "100000000",
-    "sponsored": ["Synthetix", "Loopring"],
+    "sponsored": ["Synthetix", "Loopring", "OpenLaw"],
     "threshold": 0.5
   },
   {


### PR DESCRIPTION
![Screen Shot 2020-02-26 at 5 37 20 PM](https://user-images.githubusercontent.com/680789/75398243-ac8a5980-58be-11ea-9415-6506f0c55f03.png)
