### PR TITLE
Fix race in job queue

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -713,6 +713,7 @@ func TestIntegration_SyncJobRuns(t *testing.T) {
 	err := json.Unmarshal([]byte(message), &run)
 	require.NoError(t, err)
 	assert.Equal(t, j.ID, run.JobSpecID)
+	cltest.WaitForJobRunToComplete(t, app.Store, run)
 }
 
 func TestIntegration_SleepAdapter(t *testing.T) {
@@ -792,6 +793,7 @@ func TestIntegration_ExternalInitiator(t *testing.T) {
 	jobRun := cltest.CreateJobRunViaExternalInitiator(t, app, jobSpec, *eia, "")
 	_, err = app.Store.JobRunsFor(jobRun.ID)
 	assert.NoError(t, err)
+	cltest.WaitForJobRunToComplete(t, app.Store, jobRun)
 }
 
 func TestIntegration_ExternalInitiator_WithoutURL(t *testing.T) {

--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -18,6 +18,7 @@ import (
 	"chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -608,10 +609,9 @@ func TestRunManager_Create_fromRunLogPayments(t *testing.T) {
 			config, configCleanup := cltest.NewConfig(t)
 			defer configCleanup()
 			config.Set("MINIMUM_CONTRACT_PAYMENT", test.configMinimumPayment)
-			app, cleanup := cltest.NewApplicationWithConfig(t, config, cltest.EthMockRegisterChainID)
-			defer cleanup()
 
-			app.StartAndConnect()
+			store, storeCleanup := cltest.NewStoreWithConfig(config)
+			defer storeCleanup()
 
 			bt := &models.BridgeType{
 				Name:                   models.MustNewTaskType("expensiveBridge"),
@@ -619,7 +619,7 @@ func TestRunManager_Create_fromRunLogPayments(t *testing.T) {
 				Confirmations:          0,
 				MinimumContractPayment: test.bridgePayment,
 			}
-			require.NoError(t, app.Store.CreateBridgeType(bt))
+			require.NoError(t, store.CreateBridgeType(bt))
 
 			job := cltest.NewJobWithRunLogInitiator()
 			job.MinPayment = test.jobMinimumPayment
@@ -627,7 +627,7 @@ func TestRunManager_Create_fromRunLogPayments(t *testing.T) {
 				cltest.NewTask(t, "NoOp"),
 				cltest.NewTask(t, bt.Name.String()),
 			}
-			require.NoError(t, app.Store.CreateJob(&job))
+			require.NoError(t, store.CreateJob(&job))
 			initiator := job.Initiators[0]
 
 			creationHeight := big.NewInt(1)
@@ -636,10 +636,21 @@ func TestRunManager_Create_fromRunLogPayments(t *testing.T) {
 			runRequest.Payment = test.inputPayment
 			runRequest.RequestParams = cltest.JSONFromString(t, `{"random": "input"}`)
 
-			run, err := app.RunManager.Create(job.ID, &initiator, creationHeight, runRequest)
+			pusher := new(mocks.StatsPusher)
+			pusher.On("PushNow").Return(nil)
+
+			runQueue := new(mocks.RunQueue)
+			runQueue.On("Run", mock.Anything).Return(nil)
+
+			runManager := services.NewRunManager(runQueue, store.Config, store.ORM, pusher, store.TxManager, store.Clock)
+			run, err := runManager.Create(job.ID, &initiator, creationHeight, runRequest)
 			require.NoError(t, err)
 
-			assert.Equal(t, test.jobStatus, run.Status)
+			runManager.ResumeAllConfirming(big.NewInt(3821))
+
+			gomega.NewGomegaWithT(t).Eventually(func() models.RunStatus {
+				return run.Status
+			}).Should(gomega.Equal(test.jobStatus))
 		})
 	}
 }


### PR DESCRIPTION
Uses channels to coordinate between separate goroutines, thereby avoiding any races.