### PR TITLE
Fix incorrect handling of error responses in median calculation

### DIFF
--- a/core/services/fluxmonitor/fetchers.go
+++ b/core/services/fluxmonitor/fetchers.go
@@ -134,14 +134,15 @@ func newMedianFetcher(fetchers ...Fetcher) (Fetcher, error) {
 }
 
 func (m *medianFetcher) Fetch() (decimal.Decimal, error) {
-	var err error
-	prices := make([]decimal.Decimal, len(m.fetchers))
+	prices := []decimal.Decimal{}
 	fetchErrors := []error{}
-	for i, fetcher := range m.fetchers {
-		prices[i], err = fetcher.Fetch()
+	for _, fetcher := range m.fetchers {
+		price, err := fetcher.Fetch()
 		if err != nil {
 			logger.Error(err)
 			fetchErrors = append(fetchErrors, err)
+		} else {
+			prices = append(prices, price)
 		}
 	}
 


### PR DESCRIPTION
On an unrelated note, we should probably try a bit harder to test pathological cases in our tests.