### PR TITLE
Fix oracle link to market.link on feeds app

### DIFF
--- a/feeds/src/components/networkGraph/SideDrawer.js
+++ b/feeds/src/components/networkGraph/SideDrawer.js
@@ -83,7 +83,7 @@ const NodeDetailsContent = ({ data = {}, jobId, options }) => {
               <a
                 target="_BLANK"
                 rel="noopener noreferrer"
-                href={`https://market.link/search/nodes?&name=${data.name}`}
+                href={`https://market.link/search/nodes?&search=${data.address}`}
               >
                 Market.link
               </a>


### PR DESCRIPTION
Fix oracle link to market.link on feeds app

- changed `?name=oracleName` to `?search=oracleAddress`

[Finishes #171498869]