### PR TITLE
Check for overly permissive file permissions

### DIFF
--- a/core/cmd/client.go
+++ b/core/cmd/client.go
@@ -298,7 +298,7 @@ type DiskCookieStore struct {
 
 // Save stores a cookie.
 func (d DiskCookieStore) Save(cookie *http.Cookie) error {
-	return ioutil.WriteFile(d.cookiePath(), []byte(cookie.String()), 0660)
+	return ioutil.WriteFile(d.cookiePath(), []byte(cookie.String()), 0600)
 }
 
 // Retrieve returns any Saved cookies.

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -13,6 +13,9 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// this permission grants read / write accccess to file owners only
+const readWritePerms = os.FileMode(0600)
+
 var logger *Logger
 
 func init() {
@@ -67,11 +70,11 @@ func SetLogger(zl *zap.Logger) {
 func CreateProductionLogger(
 	dir string, jsonConsole bool, lvl zapcore.Level, toDisk bool) *zap.Logger {
 	config := zap.NewProductionConfig()
+	destination := logFileURI(dir)
 	if !jsonConsole {
 		config.OutputPaths = []string{"pretty://console"}
 	}
 	if toDisk {
-		destination := logFileURI(dir)
 		config.OutputPaths = append(config.OutputPaths, destination)
 		config.ErrorOutputPaths = append(config.ErrorOutputPaths, destination)
 	}
@@ -81,6 +84,13 @@ func CreateProductionLogger(
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	if toDisk {
+		if err := os.Chmod(destination, readWritePerms); err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	return zl
 }
 

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -28,6 +28,9 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// this permission grants read / write accccess to file owners only
+const readWritePerms = os.FileMode(0600)
+
 // Config holds parameters used by the application which can be overridden by
 // setting environment variables.
 //
@@ -447,7 +450,7 @@ func (f filePersistedSecretGenerator) Generate(c Config) ([]byte, error) {
 	}
 	key := securecookie.GenerateRandomKey(32)
 	str := base64.StdEncoding.EncodeToString(key)
-	return key, ioutil.WriteFile(sessionPath, []byte(str), 0644)
+	return key, ioutil.WriteFile(sessionPath, []byte(str), readWritePerms)
 }
 
 func parseAddress(str string) (interface{}, error) {


### PR DESCRIPTION
Addresses [#171337992](https://www.pivotaltracker.com/story/show/171337992)

This PR scraps the [old plan](https://github.com/smartcontractkit/chainlink/pull/2402) of using ACLs because of their incompatibility with windows, docker, etc. The golang library only supports linux.