### PR TITLE
Fix SimplyVC and Validation Capital overlapping on ETH-USD pair

### DIFF
--- a/feeds/src/state/ducks/aggregation/selectors.js
+++ b/feeds/src/state/ducks/aggregation/selectors.js
@@ -16,13 +16,15 @@ const oraclesList = createSelector([oracles], list => {
     names[n.address.toUpperCase()] = n.name
   })
 
-  const result = list.map(a => {
-    return {
-      address: a,
-      name: names[a.toUpperCase()] || 'Unknown',
-      type: 'oracle',
-    }
-  })
+  const result = list
+    .map(a => {
+      return {
+        address: a,
+        name: names[a.toUpperCase()] || 'Unknown',
+        type: 'oracle',
+      }
+    })
+    .sort((a, b) => a.name.localeCompare(b.name))
 
   return result
 })


### PR DESCRIPTION
This one is tricky. Ive decided to sort oracles by name and fortunately this solves the issue with the position of Validation Capital. 

[Finishes #171625869]