### PR TITLE
Disable following redirects by default in HTTP requests

### DIFF
--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -32,6 +32,7 @@ import (
 	"chainlink/core/store/migrations/migration1579700934"
 	"chainlink/core/store/migrations/migration1580904019"
 	"chainlink/core/store/migrations/migration1581240419"
+	"chainlink/core/store/migrations/migration1583337770"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -165,6 +166,10 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "1581240419",
 			Migrate: migration1581240419.Migrate,
+		},
+		{
+			ID:      "1583337770",
+			Migrate: migration1583337770.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration1583337770/migrate.go
+++ b/core/store/migrations/migration1583337770/migrate.go
@@ -1,0 +1,23 @@
+package migration1583337770
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate converts task_specs.params into JSONB and grandfathers in
+// the legacy followRedirect behaviour
+// NOTE: Re-typing columns is fairly expensive, but even very large task_spec
+// tables are unlikely to exceed a few thousand rows, so migration time is
+// acceptable.
+func Migrate(tx *gorm.DB) error {
+	err := tx.Exec(`ALTER TABLE task_specs ALTER COLUMN params TYPE jsonb USING params::jsonb`).Error
+	if err != nil {
+		return err
+	}
+
+	return tx.Exec(`
+		UPDATE task_specs
+		SET params = params || jsonb '{"followRedirects": true}'
+		WHERE type IN ('httpget', 'httppost') AND NOT params ? 'followRedirects'
+	`).Error
+}


### PR DESCRIPTION
- Add a `followRedirects` option to the HTTPGet and HTTPPost specs that allows
node operators to manually override if necessary
- Old task specs have this set automatically to preserve backwards
compatibility