### PR TITLE
Chore/add context to eth

### DIFF
--- a/core/internal/mocks/client.go
+++ b/core/internal/mocks/client.go
@@ -8,6 +8,8 @@ import (
 
 	common "github.com/ethereum/go-ethereum/common"
 
+	context "context"
+
 	decimal "github.com/shopspring/decimal"
 
 	eth "chainlink/core/eth"
@@ -322,13 +324,13 @@ func (_m *Client) SendRawTx(hex string) (common.Hash, error) {
 	return r0, r1
 }
 
-// SubscribeToLogs provides a mock function with given fields: channel, q
-func (_m *Client) SubscribeToLogs(channel chan<- eth.Log, q ethereum.FilterQuery) (eth.Subscription, error) {
-	ret := _m.Called(channel, q)
+// SubscribeToLogs provides a mock function with given fields: ctx, channel, q
+func (_m *Client) SubscribeToLogs(ctx context.Context, channel chan<- eth.Log, q ethereum.FilterQuery) (eth.Subscription, error) {
+	ret := _m.Called(ctx, channel, q)
 
 	var r0 eth.Subscription
-	if rf, ok := ret.Get(0).(func(chan<- eth.Log, ethereum.FilterQuery) eth.Subscription); ok {
-		r0 = rf(channel, q)
+	if rf, ok := ret.Get(0).(func(context.Context, chan<- eth.Log, ethereum.FilterQuery) eth.Subscription); ok {
+		r0 = rf(ctx, channel, q)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(eth.Subscription)
@@ -336,8 +338,8 @@ func (_m *Client) SubscribeToLogs(channel chan<- eth.Log, q ethereum.FilterQuery
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(chan<- eth.Log, ethereum.FilterQuery) error); ok {
-		r1 = rf(channel, q)
+	if rf, ok := ret.Get(1).(func(context.Context, chan<- eth.Log, ethereum.FilterQuery) error); ok {
+		r1 = rf(ctx, channel, q)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -345,13 +347,13 @@ func (_m *Client) SubscribeToLogs(channel chan<- eth.Log, q ethereum.FilterQuery
 	return r0, r1
 }
 
-// SubscribeToNewHeads provides a mock function with given fields: channel
-func (_m *Client) SubscribeToNewHeads(channel chan<- eth.BlockHeader) (eth.Subscription, error) {
-	ret := _m.Called(channel)
+// SubscribeToNewHeads provides a mock function with given fields: ctx, channel
+func (_m *Client) SubscribeToNewHeads(ctx context.Context, channel chan<- eth.BlockHeader) (eth.Subscription, error) {
+	ret := _m.Called(ctx, channel)
 
 	var r0 eth.Subscription
-	if rf, ok := ret.Get(0).(func(chan<- eth.BlockHeader) eth.Subscription); ok {
-		r0 = rf(channel)
+	if rf, ok := ret.Get(0).(func(context.Context, chan<- eth.BlockHeader) eth.Subscription); ok {
+		r0 = rf(ctx, channel)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(eth.Subscription)
@@ -359,8 +361,8 @@ func (_m *Client) SubscribeToNewHeads(channel chan<- eth.BlockHeader) (eth.Subsc
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(chan<- eth.BlockHeader) error); ok {
-		r1 = rf(channel)
+	if rf, ok := ret.Get(1).(func(context.Context, chan<- eth.BlockHeader) error); ok {
+		r1 = rf(ctx, channel)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/internal/mocks/tx_manager.go
+++ b/core/internal/mocks/tx_manager.go
@@ -11,6 +11,8 @@ import (
 
 	common "github.com/ethereum/go-ethereum/common"
 
+	context "context"
+
 	decimal "github.com/shopspring/decimal"
 
 	eth "chainlink/core/eth"
@@ -563,13 +565,13 @@ func (_m *TxManager) SendRawTx(hex string) (common.Hash, error) {
 	return r0, r1
 }
 
-// SubscribeToLogs provides a mock function with given fields: channel, q
-func (_m *TxManager) SubscribeToLogs(channel chan<- eth.Log, q ethereum.FilterQuery) (eth.Subscription, error) {
-	ret := _m.Called(channel, q)
+// SubscribeToLogs provides a mock function with given fields: ctx, channel, q
+func (_m *TxManager) SubscribeToLogs(ctx context.Context, channel chan<- eth.Log, q ethereum.FilterQuery) (eth.Subscription, error) {
+	ret := _m.Called(ctx, channel, q)
 
 	var r0 eth.Subscription
-	if rf, ok := ret.Get(0).(func(chan<- eth.Log, ethereum.FilterQuery) eth.Subscription); ok {
-		r0 = rf(channel, q)
+	if rf, ok := ret.Get(0).(func(context.Context, chan<- eth.Log, ethereum.FilterQuery) eth.Subscription); ok {
+		r0 = rf(ctx, channel, q)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(eth.Subscription)
@@ -577,8 +579,8 @@ func (_m *TxManager) SubscribeToLogs(channel chan<- eth.Log, q ethereum.FilterQu
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(chan<- eth.Log, ethereum.FilterQuery) error); ok {
-		r1 = rf(channel, q)
+	if rf, ok := ret.Get(1).(func(context.Context, chan<- eth.Log, ethereum.FilterQuery) error); ok {
+		r1 = rf(ctx, channel, q)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -586,13 +588,13 @@ func (_m *TxManager) SubscribeToLogs(channel chan<- eth.Log, q ethereum.FilterQu
 	return r0, r1
 }
 
-// SubscribeToNewHeads provides a mock function with given fields: channel
-func (_m *TxManager) SubscribeToNewHeads(channel chan<- eth.BlockHeader) (eth.Subscription, error) {
-	ret := _m.Called(channel)
+// SubscribeToNewHeads provides a mock function with given fields: ctx, channel
+func (_m *TxManager) SubscribeToNewHeads(ctx context.Context, channel chan<- eth.BlockHeader) (eth.Subscription, error) {
+	ret := _m.Called(ctx, channel)
 
 	var r0 eth.Subscription
-	if rf, ok := ret.Get(0).(func(chan<- eth.BlockHeader) eth.Subscription); ok {
-		r0 = rf(channel)
+	if rf, ok := ret.Get(0).(func(context.Context, chan<- eth.BlockHeader) eth.Subscription); ok {
+		r0 = rf(ctx, channel)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(eth.Subscription)
@@ -600,8 +602,8 @@ func (_m *TxManager) SubscribeToNewHeads(channel chan<- eth.BlockHeader) (eth.Su
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(chan<- eth.BlockHeader) error); ok {
-		r1 = rf(channel)
+	if rf, ok := ret.Get(1).(func(context.Context, chan<- eth.BlockHeader) error); ok {
+		r1 = rf(ctx, channel)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -538,7 +538,8 @@ func (p *PollingDeviationChecker) subscribeToNewRounds(client eth.Client) (eth.S
 		return nil, err
 	}
 
-	subscription, err := client.SubscribeToLogs(p.newRounds, filterQuery)
+	ctx := context.Background()
+	subscription, err := client.SubscribeToLogs(ctx, p.newRounds, filterQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -274,7 +274,7 @@ func TestPollingDeviationChecker_TriggerIdleTimeThreshold(t *testing.T) {
 	ethClient.On("GetAggregatorLatestSubmission", mock.Anything, mock.Anything).
 		Return(big.NewInt(0), big.NewInt(1), nil)
 
-	ethClient.On("SubscribeToLogs", mock.Anything, mock.Anything).
+	ethClient.On("SubscribeToLogs", mock.Anything, mock.Anything, mock.Anything).
 		Return(fakeSubscription(), nil)
 	ethClient.On("GetAggregatorLatestSubmission", mock.Anything, mock.Anything).
 		Return(big.NewInt(0), big.NewInt(0), nil)
@@ -323,7 +323,7 @@ func TestPollingDeviationChecker_StartStop(t *testing.T) {
 		Return(decimal.NewFromInt(100), nil)
 	ethClient.On("GetAggregatorLatestRound", initr.InitiatorParams.Address).
 		Return(big.NewInt(1), nil)
-	ethClient.On("SubscribeToLogs", mock.Anything, mock.Anything).
+	ethClient.On("SubscribeToLogs", mock.Anything, mock.Anything, mock.Anything).
 		Return(fakeSubscription(), nil)
 
 	rm := new(mocks.RunManager)
@@ -381,7 +381,7 @@ func TestPollingDeviationChecker_NoDeviation_CanBeCanceled(t *testing.T) {
 		Return(decimal.NewFromInt(100), nil)
 	ethClient.On("GetAggregatorLatestRound", initr.InitiatorParams.Address).
 		Return(big.NewInt(1), nil)
-	ethClient.On("SubscribeToLogs", mock.Anything, mock.Anything).
+	ethClient.On("SubscribeToLogs", mock.Anything, mock.Anything, mock.Anything).
 		Return(fakeSubscription(), nil)
 	ethClient.On("GetAggregatorLatestSubmission", mock.Anything, mock.Anything).
 		Return(big.NewInt(0), big.NewInt(0), nil)
@@ -665,7 +665,7 @@ func TestPollingDeviationChecker_PollIfEligible(t *testing.T) {
 				Return(test.aggregatorTimedOutStatus, nil)
 			ethClient.On("GetAggregatorLatestSubmission", mock.Anything, mock.Anything).
 				Return(big.NewInt(0), big.NewInt(test.latestRoundAnswered), nil)
-			ethClient.On("SubscribeToLogs", mock.Anything, mock.Anything).
+			ethClient.On("SubscribeToLogs", mock.Anything, mock.Anything, mock.Anything).
 				Return(fakeSubscription(), nil)
 
 			err = deviationChecker.Start(context.Background(), ethClient)

--- a/core/services/head_tracker.go
+++ b/core/services/head_tracker.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"time"
@@ -246,8 +247,9 @@ func (ht *HeadTracker) subscribeToHead() error {
 	ht.headMutex.Lock()
 	defer ht.headMutex.Unlock()
 
+	ctx := context.Background()
 	ht.headers = make(chan eth.BlockHeader)
-	sub, err := ht.store.TxManager.SubscribeToNewHeads(ht.headers)
+	sub, err := ht.store.TxManager.SubscribeToNewHeads(ctx, ht.headers)
 	if err != nil {
 		return errors.Wrap(err, "TxManager#SubscribeToNewHeads")
 	}

--- a/core/services/head_tracker_test.go
+++ b/core/services/head_tracker_test.go
@@ -157,9 +157,9 @@ func TestHeadTracker_ReconnectOnError(t *testing.T) {
 	txManager := new(mocks.TxManager)
 	subscription := cltest.EmptyMockSubscription()
 	txManager.On("GetChainID").Maybe().Return(store.Config.ChainID(), nil)
-	txManager.On("SubscribeToNewHeads", mock.Anything).Return(subscription, nil)
-	txManager.On("SubscribeToNewHeads", mock.Anything).Return(nil, errors.New("cannot reconnect"))
-	txManager.On("SubscribeToNewHeads", mock.Anything).Return(subscription, nil)
+	txManager.On("SubscribeToNewHeads", mock.Anything, mock.Anything, mock.Anything).Return(subscription, nil)
+	txManager.On("SubscribeToNewHeads", mock.Anything, mock.Anything).Return(nil, errors.New("cannot reconnect"))
+	txManager.On("SubscribeToNewHeads", mock.Anything, mock.Anything).Return(subscription, nil)
 	store.TxManager = txManager
 
 	checker := &cltest.MockHeadTrackable{}

--- a/core/services/subscription.go
+++ b/core/services/subscription.go
@@ -1,6 +1,7 @@
 package services
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"time"
@@ -186,8 +187,9 @@ func NewManagedSubscription(
 	filter ethereum.FilterQuery,
 	callback func(eth.Log),
 ) (*ManagedSubscription, error) {
+	ctx := context.Background()
 	logs := make(chan eth.Log)
-	es, err := logSubscriber.SubscribeToLogs(logs, filter)
+	es, err := logSubscriber.SubscribeToLogs(ctx, logs, filter)
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/subscription_test.go
+++ b/core/services/subscription_test.go
@@ -356,7 +356,7 @@ func TestServices_NewInitiatorSubscription_EthLog_ReplayFromBlock(t *testing.T) 
 
 			log := cltest.LogFromFixture(t, "testdata/subscription_logs.json")
 
-			txManager.On("SubscribeToLogs", mock.Anything, expectedQuery).Return(cltest.EmptyMockSubscription(), nil)
+			txManager.On("SubscribeToLogs", mock.Anything, mock.Anything, expectedQuery).Return(cltest.EmptyMockSubscription(), nil)
 			txManager.On("GetLogs", expectedQuery).Return([]ethpkg.Log{log}, nil)
 
 			executeJobChannel := make(chan struct{})
@@ -421,7 +421,7 @@ func TestServices_NewInitiatorSubscription_RunLog_ReplayFromBlock(t *testing.T) 
 			log := receipt.Logs[3]
 			log.Topics[1] = models.IDToTopic(job.ID)
 
-			txmMock.On("SubscribeToLogs", mock.Anything, expectedQuery).Return(cltest.EmptyMockSubscription(), nil)
+			txmMock.On("SubscribeToLogs", mock.Anything, mock.Anything, expectedQuery).Return(cltest.EmptyMockSubscription(), nil)
 			txmMock.On("GetLogs", expectedQuery).Return([]ethpkg.Log{log}, nil)
 
 			executeJobChannel := make(chan struct{})

--- a/core/web/withdrawals_controller_test.go
+++ b/core/web/withdrawals_controller_test.go
@@ -43,7 +43,7 @@ func TestWithdrawalsController_CreateSuccess(t *testing.T) {
 
 	subscription := cltest.EmptyMockSubscription()
 	txManager := new(mocks.TxManager)
-	txManager.On("SubscribeToNewHeads", mock.Anything).Maybe().Return(subscription, nil)
+	txManager.On("SubscribeToNewHeads", mock.Anything, mock.Anything).Maybe().Return(subscription, nil)
 	txManager.On("GetChainID").Maybe().Return(big.NewInt(3), nil)
 	txManager.On("Register", mock.Anything).Return(big.NewInt(3), nil)
 	txManager.On("ContractLINKBalance", wr).Return(*wr.Amount, nil)


### PR DESCRIPTION
Give the caller more control by taking the context as the argument infunctions where the background context was used.