### PR TITLE
Add error message to start().catch

### DIFF
--- a/explorer/src/index.ts
+++ b/explorer/src/index.ts
@@ -14,4 +14,9 @@ const start = async () => {
   server()
 }
 
-start().catch(logger.error)
+start().catch(e => {
+  logger.error({
+    message: `Exception during startup: ${e.message}`,
+    stack: e.stack,
+  })
+})


### PR DESCRIPTION
If an exception happens during explorer setup, this used to print a
blank error.