### PR TITLE
Fix uptime calculations for sessions

### DIFF
--- a/explorer/src/entity/ChainlinkNode.ts
+++ b/explorer/src/entity/ChainlinkNode.ts
@@ -175,40 +175,30 @@ export async function uptime(db: Connection, node: ChainlinkNode | number) {
 
 // uptime from completed sessions
 async function historicUptime(db: Connection, id: number): Promise<number> {
-  const { seconds } = await db
+  const { seconds } = (await db
     .createQueryBuilder()
     .select(
-      `FLOOR(SUM(
-        (31536000 * DATE_PART('year', session.finishedAt - session.createdAt)) +
-        (86400 * DATE_PART('day', session.finishedAt - session.createdAt)) +
-        (3600 * DATE_PART('hour', session.finishedAt - session.createdAt)) +
-        (60 * DATE_PART('minute', session.finishedAt - session.createdAt)) +
-        (DATE_PART('second', session.finishedAt - session.createdAt))
-      )) as seconds`,
+      `EXTRACT(EPOCH FROM session."finishedAt" - session."createdAt") as seconds`,
     )
     .from(Session, 'session')
     .where({ chainlinkNodeId: id })
     .andWhere('session.finishedAt is not null')
-    .getRawOne()
-  return parseInt(seconds) || 0
+    // NOTE: If there are no sessions, SELECT EXTRACT... returns null
+    .getRawOne()) || { seconds: 0 }
+  return Math.max(0, seconds)
 }
 
 // uptime from current open session
 async function currentUptime(db: Connection, id: number): Promise<number> {
-  const { seconds } = await db
+  const { seconds } = (await db
     .createQueryBuilder()
     .select(
-      `FLOOR(SUM(
-        (31536000 * DATE_PART('year', now() - session.createdAt)) +
-        (86400 * DATE_PART('day', now() - session.createdAt)) +
-        (3600 * DATE_PART('hour', now() - session.createdAt)) +
-        (60 * DATE_PART('minute', now() - session.createdAt)) +
-        (DATE_PART('second', now() - session.createdAt))
-      )) as seconds`,
+      `FLOOR(EXTRACT(EPOCH FROM (now() - session."createdAt"))) as seconds`,
     )
     .from(Session, 'session')
     .where({ chainlinkNodeId: id })
-    .andWhere('session.finishedAt is null')
-    .getRawOne()
-  return parseInt(seconds) || 0
+    .andWhere('session."finishedAt" is null')
+    // NOTE: If there are no sessions, SELECT EXTRACT... returns null
+    .getRawOne()) || { seconds: 0 }
+  return Math.max(0, seconds)
 }

--- a/explorer/src/entity/ChainlinkNode.ts
+++ b/explorer/src/entity/ChainlinkNode.ts
@@ -175,7 +175,7 @@ export async function uptime(db: Connection, node: ChainlinkNode | number) {
 
 // uptime from completed sessions
 async function historicUptime(db: Connection, id: number): Promise<number> {
-  const { seconds } = (await db
+  const queryResult = await db
     .createQueryBuilder()
     .select(
       `EXTRACT(EPOCH FROM session."finishedAt" - session."createdAt") as seconds`,
@@ -183,14 +183,15 @@ async function historicUptime(db: Connection, id: number): Promise<number> {
     .from(Session, 'session')
     .where({ chainlinkNodeId: id })
     .andWhere('session.finishedAt is not null')
-    // NOTE: If there are no sessions, SELECT EXTRACT... returns null
-    .getRawOne()) || { seconds: 0 }
+    .getRawOne()
+  // NOTE: If there are no sessions, SELECT EXTRACT... returns null
+  const seconds = queryResult?.seconds ?? 0
   return Math.max(0, seconds)
 }
 
 // uptime from current open session
 async function currentUptime(db: Connection, id: number): Promise<number> {
-  const { seconds } = (await db
+  const queryResult = await db
     .createQueryBuilder()
     .select(
       `FLOOR(EXTRACT(EPOCH FROM (now() - session."createdAt"))) as seconds`,
@@ -198,7 +199,8 @@ async function currentUptime(db: Connection, id: number): Promise<number> {
     .from(Session, 'session')
     .where({ chainlinkNodeId: id })
     .andWhere('session."finishedAt" is null')
-    // NOTE: If there are no sessions, SELECT EXTRACT... returns null
-    .getRawOne()) || { seconds: 0 }
+    .getRawOne()
+  // NOTE: If there are no sessions, SELECT EXTRACT... returns null
+  const seconds = queryResult?.seconds ?? 0
   return Math.max(0, seconds)
 }

--- a/explorer/src/entity/Session.ts
+++ b/explorer/src/entity/Session.ts
@@ -33,11 +33,10 @@ export async function createSession(
   db: Connection,
   node: ChainlinkNode,
 ): Promise<Session> {
-  const now = new Date()
   await db.manager
     .createQueryBuilder()
     .update(Session)
-    .set({ finishedAt: now })
+    .set({ finishedAt: () => 'now()' })
     .where({ chainlinkNodeId: node.id, finishedAt: null })
     .execute()
   const session = new Session()
@@ -61,7 +60,7 @@ export async function closeSession(
   return db.manager
     .createQueryBuilder()
     .update(Session)
-    .set({ finishedAt: new Date() })
+    .set({ finishedAt: () => 'now()' })
     .where({ sessionId: session.id })
     .execute()
 }


### PR DESCRIPTION
Use native postgres function which should account for leap years (like this one!). Make sure typeorm doesn't try do to an erroneous UTC conversion on the session finishedAt. Use max on seconds calculation in case of imprecise timestamp or clock drift issue.