### PR TITLE
cmd: improve file permissions check

### DIFF
--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -98,10 +98,9 @@ func checkFilePermissions(directory string) error {
 			if err != nil {
 				return err
 			}
-			fileMode := info.Mode()
-			// bitwise &^ used to check if file has any invalid permissions
+			fileMode := info.Mode().Perm()
 			if fileMode&^ownerPermsMask != 0 && !fileMode.IsDir() {
-				return fmt.Errorf("%s has overly permissive file permissions, %s", path, fileMode.String())
+				return fmt.Errorf("%s has overly permissive file permissions, should be atleast %s", path, ownerPermsMask)
 			}
 			return nil
 		})


### PR DESCRIPTION
Follow up on PR #2424

  - '%s' defaults to String()
  - remove redundant comment.  The code is pretty clear about whats
  happening.
  - Communicate to user what the permissions should be.  User has access
  to what it is.