### PR TITLE
Add retry and timeout to http adapter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
 	github.com/aristanetworks/goarista v0.0.0-20190204200901-2166578f3448 // indirect
 	github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a
+	github.com/avast/retry-go v2.6.0+incompatible
 	github.com/bitly/go-simplejson v0.5.0
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/boj/redistore v0.0.0-20160128113310-fc113767cd6b // indirect

--- a/go.sum
+++ b/go.sum
@@ -45,6 +45,8 @@ github.com/aristanetworks/goarista v0.0.0-20190204200901-2166578f3448/go.mod h1:
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a h1:idn718Q4B6AGu/h5Sxe66HYVdqdGu2l9Iebqhi/AEoA=
 github.com/asaskevich/govalidator v0.0.0-20190424111038-f61b66f89f4a/go.mod h1:lB+ZfQJz7igIIfQNfa7Ml4HSf2uFQQRzpGGRXenZAgY=
+github.com/avast/retry-go v2.6.0+incompatible h1:FelcMrm7Bxacr1/RM8+/eqkDkmVN7tjlsy51dOzB3LI=
+github.com/avast/retry-go v2.6.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/171605831

Timeout is set to 15s.

Using these options for retry:

DefaultAttempts      = uint(5)

Library default options are:

DefaultDelay         = 100 * time.Millisecond
DefaultMaxJitter     = 100 * time.Millisecond
DefaultOnRetry       = func(n uint, err error) {}
DefaultRetryIf       = IsRecoverable
DefaultDelayType     = CombineDelay(BackOffDelay, RandomDelay)
DefaultLastErrorOnly = false

So this will retry http requests up to 5 times with a linear backoff of 100
milliseconds and jitter of between 0 and 100ms.

The worst case scenario is 5 retries with max backoff and max jitter on a request that times out i.e.

5 * 15 + 200 * 5 = 76 seconds

This is better than the previous worst case of infinity seconds, since there was no timeout at all before.