### PR TITLE
Add waitForService to TS integration test

### DIFF
--- a/tools/ci-ts/jest.config.js
+++ b/tools/ci-ts/jest.config.js
@@ -1,5 +1,6 @@
 module.exports = {
   preset: 'ts-jest',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
   testEnvironment: 'node',
   testPathIgnorePatterns: ['/node_modules/', 'dist/'],
   testRunner: 'jest-circus/runner',

--- a/tools/ci-ts/jest.setup.ts
+++ b/tools/ci-ts/jest.setup.ts
@@ -1,0 +1,7 @@
+import { getArgs, waitForService } from './test-helpers/common'
+
+const { CHAINLINK_URL } = getArgs(['CHAINLINK_URL'])
+
+beforeAll(async () => {
+  await waitForService(CHAINLINK_URL)
+})

--- a/tools/ci-ts/jest.setup.ts
+++ b/tools/ci-ts/jest.setup.ts
@@ -1,7 +1,11 @@
 import { getArgs, waitForService } from './test-helpers/common'
 
-const { CHAINLINK_URL } = getArgs(['CHAINLINK_URL'])
+const { CHAINLINK_URL, EXTERNAL_ADAPTER_URL } = getArgs([
+  'CHAINLINK_URL',
+  'EXTERNAL_ADAPTER_URL',
+])
 
 beforeAll(async () => {
   await waitForService(CHAINLINK_URL)
+  await waitForService(EXTERNAL_ADAPTER_URL)
 })

--- a/tools/ci-ts/test-helpers/common.ts
+++ b/tools/ci-ts/test-helpers/common.ts
@@ -107,13 +107,18 @@ export async function wait(ms: number) {
   })
 }
 
+/**
+ * Makes a simple get request to an endpoint and ensures the service responds.
+ * Status code doesn't matter - just ensures the service is running.
+ * @param endpoint the url of the service
+ * @param timeout the time to wait before erroring
+ */
 export async function waitForService(endpoint: string, timeout = 20000) {
   await assertAsync(
-    async () => {
-      return fetch(endpoint)
+    async () =>
+      fetch(endpoint)
         .then(() => true)
-        .catch(() => false)
-    },
+        .catch(() => false),
     `${endpoint} is unreachable after ${timeout}ms`,
     timeout,
   )

--- a/tools/ci-ts/test-helpers/common.ts
+++ b/tools/ci-ts/test-helpers/common.ts
@@ -103,8 +103,20 @@ export async function deployContract<T extends DeployFactory>(
 
 export async function wait(ms: number) {
   return new Promise(res => {
-    setTimeout(() => res(), ms)
+    setTimeout(res, ms)
   })
+}
+
+export async function waitForService(endpoint: string, timeout = 20000) {
+  await assertAsync(
+    async () => {
+      return fetch(endpoint)
+        .then(() => true)
+        .catch(() => false)
+    },
+    `${endpoint} is unreachable after ${timeout}ms`,
+    timeout,
+  )
 }
 
 /**

--- a/tools/ci-ts/test-helpers/common.ts
+++ b/tools/ci-ts/test-helpers/common.ts
@@ -111,7 +111,7 @@ export async function wait(ms: number) {
  * Makes a simple get request to an endpoint and ensures the service responds.
  * Status code doesn't matter - just ensures the service is running.
  * @param endpoint the url of the service
- * @param timeout the time to wait before erroring
+ * @param timeout the time in milliseconds to wait before erroring
  */
 export async function waitForService(endpoint: string, timeout = 20000) {
   await assertAsync(

--- a/tools/ci-ts/tests/flux-monitor.test.ts
+++ b/tools/ci-ts/tests/flux-monitor.test.ts
@@ -6,6 +6,7 @@ import {
   wait,
   createProvider,
   fundAddress,
+  waitForService,
 } from '../test-helpers/common'
 import * as clClient from '../test-helpers/chainlink-cli'
 import { contract, helpers as h, matchers } from '@chainlink/test-helpers'
@@ -14,11 +15,15 @@ import { JobSpec } from '../../../operator_ui/@types/operator_ui'
 import 'isomorphic-unfetch'
 import { ethers } from 'ethers'
 
+const { EXTERNAL_ADAPTER_URL, CHAINLINK_URL } = getArgs([
+  'EXTERNAL_ADAPTER_URL',
+  'CHAINLINK_URL',
+])
+
 const provider = createProvider()
 const carol = ethers.Wallet.createRandom().connect(provider)
 const linkTokenFactory = new contract.LinkTokenFactory(carol)
 const fluxAggregatorFactory = new FluxAggregatorFactory(carol)
-const { EXTERNAL_ADAPTER_URL } = getArgs(['EXTERNAL_ADAPTER_URL'])
 const adapterURL = new URL('result', EXTERNAL_ADAPTER_URL).href
 const deposit = h.toWei('1000')
 
@@ -56,6 +61,7 @@ describe('flux monitor eth client integration', () => {
   let node1Address: string
 
   beforeAll(async () => {
+    await waitForService(CHAINLINK_URL)
     clClient.login()
     node1Address = clClient.getAdminInfo()[0].address
     await fundAddress(carol.address)

--- a/tools/ci-ts/tests/flux-monitor.test.ts
+++ b/tools/ci-ts/tests/flux-monitor.test.ts
@@ -6,7 +6,6 @@ import {
   wait,
   createProvider,
   fundAddress,
-  waitForService,
 } from '../test-helpers/common'
 import * as clClient from '../test-helpers/chainlink-cli'
 import { contract, helpers as h, matchers } from '@chainlink/test-helpers'
@@ -15,10 +14,7 @@ import { JobSpec } from '../../../operator_ui/@types/operator_ui'
 import 'isomorphic-unfetch'
 import { ethers } from 'ethers'
 
-const { EXTERNAL_ADAPTER_URL, CHAINLINK_URL } = getArgs([
-  'EXTERNAL_ADAPTER_URL',
-  'CHAINLINK_URL',
-])
+const { EXTERNAL_ADAPTER_URL } = getArgs(['EXTERNAL_ADAPTER_URL'])
 
 const provider = createProvider()
 const carol = ethers.Wallet.createRandom().connect(provider)
@@ -61,7 +57,6 @@ describe('flux monitor eth client integration', () => {
   let node1Address: string
 
   beforeAll(async () => {
-    await waitForService(CHAINLINK_URL)
     clClient.login()
     node1Address = clClient.getAdminInfo()[0].address
     await fundAddress(carol.address)

--- a/tools/docker/compose
+++ b/tools/docker/compose
@@ -47,8 +47,8 @@ Commands:
     dev:integration | di  Run docker-compose with dev config for integration tests
     dev                   Run docker-compose with dev config for the core node and operator-ui
 
-    eth:clean             Reset blockchain data to genesis state
-    cl:clean              Reset chainlink database
+    eth:restart             Reset blockchain data to genesis state
+    cl:restart              Reset chainlink database
 
     *                     Run docker-compose with base config"
 

--- a/tools/docker/docker-compose.ts-integration.yaml
+++ b/tools/docker/docker-compose.ts-integration.yaml
@@ -41,4 +41,4 @@ services:
     entrypoint: ''
     command: chainlink node start -d -p /run/secrets/node_password -a /run/secrets/apicredentials
     environment:
-      ALLOW_ORIGINS: http://localhost:3000,http://localhost:6688,http://integration:3000,http://integration:6688,http://node:3000,http://node:6688
+      ALLOW_ORIGINS: http://localhost:3000,http://localhost:6688,http://ts-integration:3000,http://ts-integration:6688,http://node:3000,http://node:6688

--- a/tools/docker/docker-compose.ts-integration.yaml
+++ b/tools/docker/docker-compose.ts-integration.yaml
@@ -41,4 +41,4 @@ services:
     entrypoint: ''
     command: chainlink node start -d -p /run/secrets/node_password -a /run/secrets/apicredentials
     environment:
-      ALLOW_ORIGINS: http://localhost:3000,http://localhost:6688,http://ts-integration:3000,http://ts-integration:6688,http://node:3000,http://node:6688
+      ALLOW_ORIGINS: http://localhost:3000,http://localhost:6688,http://integration-ts:3000,http://integration-ts:6688,http://node:3000,http://node:6688


### PR DESCRIPTION
Fixes race condition in TS integration test by waiting for CL node before initiating test suit.

Waiting for https://github.com/smartcontractkit/chainlink/pull/2476