### PR TITLE
Drop ci-ts project dep on @chainlink/contracts

### DIFF
--- a/tools/ci-ts/tsconfig.json
+++ b/tools/ci-ts/tsconfig.json
@@ -6,7 +6,6 @@
   "include": ["tests", "test-helpers", "fixtures"],
   "references": [
     { "path": "../../evm-test-helpers" },
-    { "path": "../../evm-contracts" },
     { "path": "../../operator_ui" }
   ]
 }


### PR DESCRIPTION
This fixes the broken `yarn setup` workspace command