### PR TITLE
adapter: Instrument adapter completion

### DIFF
--- a/core/adapters/adapter.go
+++ b/core/adapters/adapter.go
@@ -52,6 +52,7 @@ var (
 // BaseAdapter is the minimum interface required to create an adapter. Only core
 // adapters have this minimum requirement.
 type BaseAdapter interface {
+	TaskType() models.TaskType
 	Perform(models.RunInput, *store.Store) models.RunOutput
 }
 

--- a/core/adapters/bridge.go
+++ b/core/adapters/bridge.go
@@ -22,6 +22,11 @@ type Bridge struct {
 	Params models.JSON
 }
 
+// TaskType returns the bridges defined type.
+func (ba *Bridge) TaskType() models.TaskType {
+	return ba.Name
+}
+
 // Perform sends a POST request containing the JSON of the input to the
 // external adapter specified in the BridgeType.
 //

--- a/core/adapters/compare.go
+++ b/core/adapters/compare.go
@@ -22,6 +22,11 @@ var (
 	ErrValueNotSpecified    = errors.New("Value not specified")
 )
 
+// TaskType returns the type of Adapter.
+func (c *Compare) TaskType() models.TaskType {
+	return TaskTypeCompare
+}
+
 // Perform uses the Operator to check the run's result against the
 // specified Value.
 func (c *Compare) Perform(input models.RunInput, _ *store.Store) models.RunOutput {

--- a/core/adapters/copy.go
+++ b/core/adapters/copy.go
@@ -11,6 +11,11 @@ type Copy struct {
 	CopyPath JSONPath `json:"copyPath"`
 }
 
+// TaskType returns the type of Adapter.
+func (c *Copy) TaskType() models.TaskType {
+	return TaskTypeCopy
+}
+
 // Perform returns the copied values from the desired mapping within the `data` JSON object
 func (c *Copy) Perform(input models.RunInput, store *store.Store) models.RunOutput {
 	data, err := models.JSON{}.Add("result", input.Data().String())

--- a/core/adapters/eth_bool.go
+++ b/core/adapters/eth_bool.go
@@ -13,6 +13,11 @@ var evmTrue = "0x000000000000000000000000000000000000000000000000000000000000000
 // EthBool holds no fields
 type EthBool struct{}
 
+// TaskType returns the type of Adapter.
+func (e *EthBool) TaskType() models.TaskType {
+	return TaskTypeEthBool
+}
+
 // Perform returns the abi encoding for a boolean
 //
 // For example, after converting the result false to hex encoded Ethereum

--- a/core/adapters/eth_format.go
+++ b/core/adapters/eth_format.go
@@ -12,6 +12,11 @@ import (
 // EthBytes32 holds no fields.
 type EthBytes32 struct{}
 
+// TaskType returns the type of Adapter.
+func (e *EthBytes32) TaskType() models.TaskType {
+	return TaskTypeEthBytes32
+}
+
 // Perform returns the hex value of the first 32 bytes of a string
 // so that it is in the proper format to be written to the blockchain.
 //
@@ -33,6 +38,11 @@ func (*EthBytes32) Perform(input models.RunInput, _ *store.Store) models.RunOutp
 // EthInt256 holds no fields
 type EthInt256 struct{}
 
+// TaskType returns the type of Adapter.
+func (e *EthInt256) TaskType() models.TaskType {
+	return TaskTypeEthInt256
+}
+
 // Perform returns the hex value of a given string so that it
 // is in the proper format to be written to the blockchain.
 //
@@ -50,6 +60,11 @@ func (*EthInt256) Perform(input models.RunInput, _ *store.Store) models.RunOutpu
 
 // EthUint256 holds no fields.
 type EthUint256 struct{}
+
+// TaskType returns the type of Adapter.
+func (e *EthUint256) TaskType() models.TaskType {
+	return TaskTypeEthUint256
+}
 
 // Perform returns the hex value of a given string so that it
 // is in the proper format to be written to the blockchain.

--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -33,6 +33,11 @@ type EthTx struct {
 	GasLimit         uint64               `json:"gasLimit"`
 }
 
+// TaskType returns the type of Adapter.
+func (e *EthTx) TaskType() models.TaskType {
+	return TaskTypeEthTx
+}
+
 // Perform creates the run result for the transaction if the existing run result
 // is not currently pending. Then it confirms the transaction was confirmed on
 // the blockchain.

--- a/core/adapters/eth_tx_abi_encode.go
+++ b/core/adapters/eth_tx_abi_encode.go
@@ -31,6 +31,11 @@ type EthTxABIEncode struct {
 	GasLimit    uint64     `json:"gasLimit"`
 }
 
+// TaskType returns the type of Adapter.
+func (etx *EthTxABIEncode) TaskType() models.TaskType {
+	return TaskTypeEthTxABIEncode
+}
+
 // UnmarshalJSON for custom JSON unmarshal that is strict, i.e. doesn't
 // accept spurious fields. (In particular, we wan't to ensure that we don't
 // get spurious fields in the FunctionABI, so that users don't get any wrong

--- a/core/adapters/http.go
+++ b/core/adapters/http.go
@@ -37,6 +37,11 @@ type HTTPRequestConfig struct {
 	sizeLimit   int64
 }
 
+// TaskType returns the type of Adapter.
+func (h *HTTPGet) TaskType() models.TaskType {
+	return TaskTypeHTTPGet
+}
+
 // Perform ensures that the adapter's URL responds to a GET request without
 // errors and returns the response body as the "value" field of the result.
 func (hga *HTTPGet) Perform(input models.RunInput, store *store.Store) models.RunOutput {
@@ -76,6 +81,11 @@ type HTTPPost struct {
 	QueryParams  QueryParameters `json:"queryParams"`
 	Body         *string         `json:"body,omitempty"`
 	ExtendedPath ExtendedPath    `json:"extPath"`
+}
+
+// TaskType returns the type of Adapter.
+func (h *HTTPPost) TaskType() models.TaskType {
+	return TaskTypeHTTPPost
 }
 
 // Perform ensures that the adapter's URL responds to a POST request without

--- a/core/adapters/json_parse.go
+++ b/core/adapters/json_parse.go
@@ -20,6 +20,11 @@ type JSONParse struct {
 	Path JSONPath `json:"path"`
 }
 
+// TaskType returns the type of Adapter.
+func (jpa *JSONParse) TaskType() models.TaskType {
+	return TaskTypeJSONParse
+}
+
 // Perform returns the value associated to the desired field for a
 // given JSON object.
 //

--- a/core/adapters/multiply.go
+++ b/core/adapters/multiply.go
@@ -1,10 +1,17 @@
 package adapters
 
 import (
+	"chainlink/core/store/models"
+
 	"github.com/shopspring/decimal"
 )
 
 // Multiply holds the a number to multiply the given value by.
 type Multiply struct {
 	Times *decimal.Decimal `json:"times,omitempty"`
+}
+
+// TaskType returns the type of Adapter.
+func (m *Multiply) TaskType() models.TaskType {
+	return TaskTypeMultiply
 }

--- a/core/adapters/no_op.go
+++ b/core/adapters/no_op.go
@@ -8,6 +8,11 @@ import (
 // NoOp adapter type holds no fields
 type NoOp struct{}
 
+// TaskType returns the type of Adapter.
+func (noa *NoOp) TaskType() models.TaskType {
+	return TaskTypeNoOp
+}
+
 // Perform returns the input
 func (noa *NoOp) Perform(input models.RunInput, _ *store.Store) models.RunOutput {
 	val := input.Result().Value()
@@ -16,6 +21,11 @@ func (noa *NoOp) Perform(input models.RunInput, _ *store.Store) models.RunOutput
 
 // NoOpPend adapter type holds no fields
 type NoOpPend struct{}
+
+// TaskType returns the type of Adapter.
+func (noa *NoOpPend) TaskType() models.TaskType {
+	return TaskTypeNoOpPend
+}
 
 // Perform on this adapter type returns an empty RunResult with an
 // added field for the status to indicate the task is Pending.

--- a/core/adapters/quotient.go
+++ b/core/adapters/quotient.go
@@ -15,6 +15,11 @@ type Quotient struct {
 	Dividend *big.Float `json:"-"`
 }
 
+// TaskType returns the type of Adapter.
+func (q *Quotient) TaskType() models.TaskType {
+	return TaskTypeQuotient
+}
+
 type jsonQuotient struct {
 	Dividend *utils.BigFloat `json:"dividend,omitempty"`
 }

--- a/core/adapters/random.go
+++ b/core/adapters/random.go
@@ -49,6 +49,11 @@ type Random struct {
 	PublicKey string `json:"publicKey"`
 }
 
+// TaskType returns the type of Adapter.
+func (ra *Random) TaskType() models.TaskType {
+	return TaskTypeRandom
+}
+
 // Perform returns the the proof for the VRF output given seed, or an error.
 func (ra *Random) Perform(input models.RunInput, store *store.Store) models.RunOutput {
 	key, err := getKey(ra, input)

--- a/core/adapters/sleep.go
+++ b/core/adapters/sleep.go
@@ -14,6 +14,11 @@ type Sleep struct {
 	Until models.AnyTime `json:"until"`
 }
 
+// TaskType returns the type of Adapter.
+func (adapter *Sleep) TaskType() models.TaskType {
+	return TaskTypeSleep
+}
+
 // Perform returns the input RunResult after waiting for the specified Until parameter.
 func (adapter *Sleep) Perform(input models.RunInput, str *store.Store) models.RunOutput {
 	duration := adapter.Duration()

--- a/core/adapters/wasm.go
+++ b/core/adapters/wasm.go
@@ -14,6 +14,11 @@ type Wasm struct {
 	WasmT string `json:"wasmt"`
 }
 
+// TaskType returns the type of Adapter.
+func (wasm *Wasm) TaskType() models.TaskType {
+	return TaskTypeWasm
+}
+
 // Perform ships the wasm representation to the SGX enclave where it is evaluated.
 func (wasm *Wasm) Perform(input models.RunInput, _ *store.Store) models.RunOutput {
 	err := fmt.Errorf("Wasm is not supported without SGX")

--- a/core/adapters/wasm_sgx.go
+++ b/core/adapters/wasm_sgx.go
@@ -25,6 +25,11 @@ type Wasm struct {
 	Wasm string `json:"wasm"`
 }
 
+// TaskType returns the type of Adapter.
+func (wasm *Wasm) TaskType() models.TaskType {
+	return TaskTypeWasm
+}
+
 // Perform ships the wasm representation to the SGX enclave where it is evaluated.
 func (wasm *Wasm) Perform(input models.RunInput, _ *store.Store) models.RunOutput {
 	adapterJSON, err := json.Marshal(wasm)


### PR DESCRIPTION
Instrument the completion status of the adapters and label them by type.  The
Job Spec ID is included aswell.

Should execution time be added as well?  This would help monitor for long
running or stuck adapters.

Also:

 - adapters: Make TaskType inspectable

   Support logic on the TaskType of the adapter by introducing the method
   TaskType() to the Adapter interface.  This will be usefull for logging and
   metrics.

https://www.pivotaltracker.com/n/projects/2129823/stories/171640595