### PR TITLE
services: Instrument Job Run status updates

### DIFF
--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -265,7 +265,7 @@ func (cli *Client) RebroadcastTransactions(c *clipkg.Context) error {
 				taskRun.Status = models.RunStatusErrored
 			}
 		}
-		jobRun.Status = models.RunStatusErrored
+		jobRun.SetStatus(models.RunStatusErrored)
 
 		err = store.ORM.SaveJobRun(&jobRun)
 		if err != nil {

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -953,6 +953,6 @@ func TestClient_CancelJobRun(t *testing.T) {
 
 	runs := cltest.MustAllJobsWithStatus(t, app.Store, models.RunStatusCancelled)
 	require.Len(t, runs, 1)
-	assert.Equal(t, models.RunStatusCancelled, runs[0].Status)
+	assert.Equal(t, models.RunStatusCancelled, runs[0].GetStatus())
 	assert.NotNil(t, runs[0].FinishedAt)
 }

--- a/core/cmd/renderer.go
+++ b/core/cmd/renderer.go
@@ -263,7 +263,7 @@ func (rt RendererTable) renderJobRuns(runs []presenters.JobRun) error {
 	for _, jr := range runs {
 		table.Append([]string{
 			jr.ID.String(),
-			string(jr.Status),
+			string(jr.GetStatus()),
 			utils.ISO8601UTC(jr.CreatedAt),
 			utils.NullISO8601UTC(jr.FinishedAt),
 			jr.Result.Data.String(),

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -790,7 +790,7 @@ func WaitForJobRunStatus(
 	gomega.NewGomegaWithT(t).Eventually(func() models.RunStatus {
 		jr, err = store.Unscoped().FindJobRun(jr.ID)
 		assert.NoError(t, err)
-		return jr.Status
+		return jr.GetStatus()
 	}).Should(gomega.Equal(status))
 	return jr
 }
@@ -814,7 +814,7 @@ func JobRunStays(
 	gomega.NewGomegaWithT(t).Consistently(func() models.RunStatus {
 		jr, err = store.FindJobRun(jr.ID)
 		assert.NoError(t, err)
-		return jr.Status
+		return jr.GetStatus()
 	}, duration).Should(gomega.Equal(status))
 	return jr
 }

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -595,30 +595,14 @@ func EmptyCLIContext() *cli.Context {
 func NewJobRun(job models.JobSpec) models.JobRun {
 	initiator := job.Initiators[0]
 	now := time.Now()
-	run := models.JobRun{
-		ID:          models.NewID(),
-		JobSpecID:   job.ID,
-		CreatedAt:   now,
-		UpdatedAt:   now,
-		Initiator:   initiator,
-		InitiatorID: initiator.ID,
-		Status:      models.RunStatusInProgress,
-		TaskRuns:    make([]models.TaskRun, len(job.Tasks)),
-	}
-	for i, task := range job.Tasks {
-		run.TaskRuns[i] = models.TaskRun{
-			ID:       models.NewID(),
-			JobRunID: run.ID,
-			TaskSpec: task,
-		}
-	}
+	run := models.MakeJobRun(&job, now, &initiator, nil, &models.RunRequest{})
 	return run
 }
 
 // NewJobRunPendingBridge returns a new job run in the pending bridge state
 func NewJobRunPendingBridge(job models.JobSpec) models.JobRun {
 	run := NewJobRun(job)
-	run.Status = models.RunStatusPendingBridge
+	run.SetStatus(models.RunStatusPendingBridge)
 	run.TaskRuns[0].Status = models.RunStatusPendingBridge
 	return run
 }
@@ -626,7 +610,7 @@ func NewJobRunPendingBridge(job models.JobSpec) models.JobRun {
 // CreateJobRunWithStatus returns a new job run with the specified status that has been persisted
 func CreateJobRunWithStatus(t testing.TB, store *store.Store, job models.JobSpec, status models.RunStatus) models.JobRun {
 	run := NewJobRun(job)
-	run.Status = status
+	run.SetStatus(status)
 	require.NoError(t, store.CreateJobRun(&run))
 	return run
 }

--- a/core/services/run_executor.go
+++ b/core/services/run_executor.go
@@ -54,7 +54,7 @@ func (re *runExecutor) Execute(runID *models.ID) error {
 
 	for taskIndex := range run.TaskRuns {
 		taskRun := &run.TaskRuns[taskIndex]
-		if !run.Status.Runnable() {
+		if !run.GetStatus().Runnable() {
 			logger.Debugw("Run execution blocked", run.ForLogger("task", taskRun.ID.String())...)
 			break
 		}
@@ -94,8 +94,8 @@ func (re *runExecutor) Execute(runID *models.ID) error {
 		re.statsPusher.PushNow()
 	}
 
-	if run.Status.Finished() {
-		if run.Status.Errored() {
+	if run.GetStatus().Finished() {
+		if run.GetStatus().Errored() {
 			logger.Warnw("Task failed", run.ForLogger()...)
 		} else {
 			logger.Debugw("All tasks complete for run", run.ForLogger()...)

--- a/core/services/run_executor.go
+++ b/core/services/run_executor.go
@@ -80,7 +80,7 @@ func (re *runExecutor) Execute(runID *models.ID) error {
 				run.ForLogger("required_height", taskRun.MinimumConfirmations)...,
 			)
 			taskRun.Status = models.RunStatusPendingConfirmations
-			run.Status = models.RunStatusPendingConfirmations
+			run.SetStatus(models.RunStatusPendingConfirmations)
 
 		}
 

--- a/core/services/run_executor_test.go
+++ b/core/services/run_executor_test.go
@@ -48,7 +48,7 @@ func TestRunExecutor_Execute(t *testing.T) {
 
 	run, err = store.FindJobRun(run.ID)
 	require.NoError(t, err)
-	assert.Equal(t, models.RunStatusCompleted, run.Status)
+	assert.Equal(t, models.RunStatusCompleted, run.GetStatus())
 	require.Len(t, run.TaskRuns, 1)
 	assert.Equal(t, models.RunStatusCompleted, run.TaskRuns[0].Status)
 
@@ -85,7 +85,7 @@ func TestRunExecutor_Execute_Pending(t *testing.T) {
 
 	run, err = store.FindJobRun(run.ID)
 	require.NoError(t, err)
-	assert.Equal(t, models.RunStatusPendingConfirmations, run.Status)
+	assert.Equal(t, models.RunStatusPendingConfirmations, run.GetStatus())
 	require.Len(t, run.TaskRuns, 2)
 	assert.Equal(t, models.RunStatusCompleted, run.TaskRuns[0].Status)
 	assert.Equal(t, models.RunStatusPendingConfirmations, run.TaskRuns[1].Status)
@@ -152,7 +152,7 @@ func TestRunExecutor_Execute_CancelActivelyRunningTask(t *testing.T) {
 
 	run, err := store.FindJobRun(run.ID)
 	require.NoError(t, err)
-	assert.Equal(t, models.RunStatusCancelled, run.Status)
+	assert.Equal(t, models.RunStatusCancelled, run.GetStatus())
 
 	require.Len(t, run.TaskRuns, 2)
 	assert.Equal(t, models.RunStatusCancelled, run.TaskRuns[0].Status)
@@ -189,7 +189,7 @@ func TestRunExecutor_InitialTaskLacksConfirmations(t *testing.T) {
 
 	run, err := store.FindJobRun(run.ID)
 	require.NoError(t, err)
-	assert.Equal(t, models.RunStatusPendingConfirmations, run.Status)
+	assert.Equal(t, models.RunStatusPendingConfirmations, run.GetStatus())
 	require.Len(t, run.TaskRuns, 1)
 	assert.Equal(t, models.RunStatusPendingConfirmations, run.TaskRuns[0].Status)
 }

--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -883,17 +883,25 @@ func TestRunManager_NewRun(t *testing.T) {
 
 	t.Run("creates a run with a block height and all adapters", func(t *testing.T) {
 		run, adapters := services.NewRun(&job, &job.Initiators[0], big.NewInt(0), &models.RunRequest{}, store.Config, store.ORM, now)
+		assert.NotNil(t, run.ID)
+		assert.NotNil(t, run.JobSpecID)
 		assert.Equal(t, run.GetStatus(), models.RunStatusInProgress)
 		assert.Equal(t, utils.NewBig(big.NewInt(0)), run.CreationHeight)
 		assert.Equal(t, utils.NewBig(big.NewInt(0)), run.ObservedHeight)
+		require.Len(t, run.TaskRuns, 1)
+		assert.NotNil(t, run.TaskRuns[0].ID)
 		assert.Len(t, adapters, 1)
 	})
 
 	t.Run("with no block height creates a run with all adapters", func(t *testing.T) {
 		run, adapters := services.NewRun(&job, &job.Initiators[0], nil, &models.RunRequest{}, store.Config, store.ORM, now)
+		assert.NotNil(t, run.ID)
+		assert.NotNil(t, run.JobSpecID)
 		assert.Equal(t, run.GetStatus(), models.RunStatusInProgress)
 		assert.Nil(t, run.CreationHeight)
 		assert.Nil(t, run.ObservedHeight)
+		require.Len(t, run.TaskRuns, 1)
+		assert.NotNil(t, run.TaskRuns[0].ID)
 		assert.Len(t, adapters, 1)
 	})
 }

--- a/core/services/runs.go
+++ b/core/services/runs.go
@@ -21,7 +21,7 @@ func validateMinimumConfirmations(run *models.JobRun, taskRun *models.TaskRun, c
 		)
 
 		taskRun.Status = models.RunStatusPendingConfirmations
-		run.Status = models.RunStatusPendingConfirmations
+		run.SetStatus(models.RunStatusPendingConfirmations)
 
 	} else if err := validateOnMainChain(run, taskRun, txManager); err != nil {
 		logger.Warnw("Failure while trying to validate chain",
@@ -32,7 +32,7 @@ func validateMinimumConfirmations(run *models.JobRun, taskRun *models.TaskRun, c
 		run.SetError(err)
 
 	} else {
-		run.Status = models.RunStatusInProgress
+		run.SetStatus(models.RunStatusInProgress)
 	}
 }
 

--- a/core/services/synchronization/presenters.go
+++ b/core/services/synchronization/presenters.go
@@ -40,7 +40,7 @@ func (p SyncJobRunPresenter) MarshalJSON() ([]byte, error) {
 		ID:         p.ID.String(),
 		RunID:      p.ID.String(),
 		JobID:      p.JobSpecID.String(),
-		Status:     string(p.Status),
+		Status:     string(p.GetStatus()),
 		Error:      p.Result.ErrorMessage,
 		CreatedAt:  utils.ISO8601UTC(p.CreatedAt),
 		Payment:    p.Payment,

--- a/core/services/synchronization/presenters_test.go
+++ b/core/services/synchronization/presenters_test.go
@@ -3,7 +3,9 @@ package synchronization
 import (
 	"encoding/json"
 	"io/ioutil"
+	"math/big"
 	"testing"
+	"time"
 
 	"chainlink/core/assets"
 	clnull "chainlink/core/null"
@@ -21,39 +23,31 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 	requestID := "RequestID"
 	txHash := common.HexToHash("0xdeadbeef")
 
-	runID := models.NewID()
-	specID := models.NewID()
 	task0RunID := models.NewID()
 	task1RunID := models.NewID()
-	jobRun := models.JobRun{
-		ID:        runID,
-		JobSpecID: specID,
-		Status:    models.RunStatusInProgress,
-		Result:    models.RunResult{},
+
+	job := models.JobSpec{ID: models.NewID()}
+	runRequest := models.RunRequest{
 		Payment:   assets.NewLink(2),
-		Initiator: models.Initiator{
-			Type: models.InitiatorRunLog,
+		RequestID: &requestID,
+		TxHash:    &txHash,
+		Requester: &newAddress,
+	}
+	run := models.MakeJobRun(&job, time.Now(), &models.Initiator{Type: models.InitiatorRunLog}, big.NewInt(0), &runRequest)
+	run.TaskRuns = []models.TaskRun{
+		models.TaskRun{
+			ID:                   task0RunID,
+			Status:               models.RunStatusPendingConfirmations,
+			Confirmations:        clnull.Uint32From(1),
+			MinimumConfirmations: clnull.Uint32From(3),
 		},
-		RunRequest: models.RunRequest{
-			RequestID: &requestID,
-			TxHash:    &txHash,
-			Requester: &newAddress,
-		},
-		TaskRuns: []models.TaskRun{
-			models.TaskRun{
-				ID:                   task0RunID,
-				Status:               models.RunStatusPendingConfirmations,
-				Confirmations:        clnull.Uint32From(1),
-				MinimumConfirmations: clnull.Uint32From(3),
-			},
-			models.TaskRun{
-				ID:     task1RunID,
-				Status: models.RunStatusErrored,
-				Result: models.RunResult{ErrorMessage: null.StringFrom("yikes fam")},
-			},
+		models.TaskRun{
+			ID:     task1RunID,
+			Status: models.RunStatusErrored,
+			Result: models.RunResult{ErrorMessage: null.StringFrom("yikes fam")},
 		},
 	}
-	p := SyncJobRunPresenter{JobRun: &jobRun}
+	p := SyncJobRunPresenter{JobRun: &run}
 
 	bytes, err := p.MarshalJSON()
 	require.NoError(t, err)
@@ -62,8 +56,8 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 	err = json.Unmarshal(bytes, &data)
 	require.NoError(t, err)
 
-	assert.Equal(t, data["runId"], runID.String())
-	assert.Equal(t, data["jobId"], specID.String())
+	assert.Equal(t, data["runId"], run.ID.String())
+	assert.Equal(t, data["jobId"], job.ID.String())
 	assert.Equal(t, data["status"], "in_progress")
 	assert.Contains(t, data, "error")
 	assert.Contains(t, data, "createdAt")
@@ -177,31 +171,23 @@ func TestSyncJobRunPresenter_EthTxTask(t *testing.T) {
 			taskSpec := models.TaskSpec{
 				Type: "ethtx",
 			}
-
-			jobRun := models.JobRun{
-				ID:        models.NewID(),
-				JobSpecID: models.NewID(),
-				Status:    models.RunStatusCompleted,
-				Result:    models.RunResult{},
-				Payment:   assets.NewLink(2),
-				Initiator: models.Initiator{
-					Type: models.InitiatorRunLog,
-				},
-				RunRequest: models.RunRequest{
-					RequestID: &requestID,
-					TxHash:    &requestTxHash,
-					Requester: &newAddress,
-				},
-				TaskRuns: []models.TaskRun{
-					models.TaskRun{
-						ID:       models.NewID(),
-						TaskSpec: taskSpec,
-						Status:   models.RunStatusPendingConfirmations,
-						Result:   models.RunResult{Data: dataJSON},
-					},
+			job := models.JobSpec{ID: models.NewID()}
+			runRequest := models.RunRequest{
+				RequestID: &requestID,
+				TxHash:    &requestTxHash,
+				Requester: &newAddress,
+			}
+			run := models.MakeJobRun(&job, time.Now(), &models.Initiator{Type: models.InitiatorRunLog}, big.NewInt(0), &runRequest)
+			run.SetStatus(models.RunStatusCompleted)
+			run.TaskRuns = []models.TaskRun{
+				models.TaskRun{
+					ID:       models.NewID(),
+					TaskSpec: taskSpec,
+					Status:   models.RunStatusPendingConfirmations,
+					Result:   models.RunResult{Data: dataJSON},
 				},
 			}
-			p := SyncJobRunPresenter{JobRun: &jobRun}
+			p := SyncJobRunPresenter{JobRun: &run}
 
 			bytes, err := p.MarshalJSON()
 			require.NoError(t, err)

--- a/core/store/models/job_run_test.go
+++ b/core/store/models/job_run_test.go
@@ -127,10 +127,10 @@ func TestJobRun_ForLogger(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
-	job := cltest.NewJobWithWebInitiator()
+	job := models.NewJob()
+	job.Initiators = []models.Initiator{{JobSpecID: job.ID, Type: models.InitiatorWeb}}
 	require.NoError(t, store.CreateJob(&job))
 	jr := cltest.NewJobRun(job)
-	jr.JobSpecID = job.ID
 	linkReward := assets.NewLink(5)
 
 	jr.Result = models.RunResult{Data: cltest.JSONFromString(t, `{"result":"11850.00"}`)}
@@ -142,13 +142,13 @@ func TestJobRun_ForLogger(t *testing.T) {
 	assert.Equal(t, logsBeforeCompletion[2], "run")
 	assert.Equal(t, logsBeforeCompletion[3], jr.ID.String())
 	assert.Equal(t, logsBeforeCompletion[4], "status")
-	assert.Equal(t, logsBeforeCompletion[5], jr.Status)
+	assert.Equal(t, logsBeforeCompletion[5], jr.GetStatus())
 
-	jr.Status = "completed"
+	jr.SetStatus("completed")
 	logsAfterCompletion := jr.ForLogger()
 	require.Len(t, logsAfterCompletion, 8)
 	assert.Equal(t, logsAfterCompletion[4], "status")
-	assert.Equal(t, logsAfterCompletion[5], jr.Status)
+	assert.Equal(t, logsAfterCompletion[5], jr.GetStatus())
 	assert.Equal(t, logsAfterCompletion[6], "link_earned")
 	assert.Equal(t, logsAfterCompletion[7], linkReward)
 
@@ -162,7 +162,7 @@ func TestJobRun_ForLogger(t *testing.T) {
 	assert.Equal(t, logsWithBlockHeights[9], big.NewInt(10))
 
 	run := cltest.NewJobRun(job)
-	run.Status = models.RunStatusErrored
+	run.SetStatus(models.RunStatusErrored)
 	run.Result.ErrorMessage = null.StringFrom("bad idea")
 	logsWithErr := run.ForLogger()
 	require.Len(t, logsWithErr, 10)
@@ -192,7 +192,7 @@ func TestJobRun_ApplyOutput_CompletedWithTasksRemaining(t *testing.T) {
 	result := models.NewRunOutputComplete(models.JSON{})
 	jobRun.ApplyOutput(result)
 	assert.False(t, jobRun.FinishedAt.Valid)
-	assert.Equal(t, jobRun.Status, models.RunStatusInProgress)
+	assert.Equal(t, jobRun.GetStatus(), models.RunStatusInProgress)
 }
 
 func TestJobRun_ApplyOutput_ErrorSetsFinishedAt(t *testing.T) {
@@ -200,7 +200,7 @@ func TestJobRun_ApplyOutput_ErrorSetsFinishedAt(t *testing.T) {
 
 	job := cltest.NewJobWithWebInitiator()
 	jobRun := cltest.NewJobRun(job)
-	jobRun.Status = models.RunStatusErrored
+	jobRun.SetStatus(models.RunStatusErrored)
 
 	result := models.NewRunOutputError(errors.New("oh futz"))
 	jobRun.ApplyOutput(result)

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -195,9 +195,10 @@ const (
 type Initiator struct {
 	ID        uint `json:"id" gorm:"primary_key;auto_increment"`
 	JobSpecID *ID  `json:"jobSpecId" gorm:"index;type:varchar(36) REFERENCES job_specs(id)"`
+
 	// Type is one of the Initiator* string constants defined just above.
 	Type            string    `json:"type" gorm:"index;not null"`
-	CreatedAt       time.Time `gorm:"index"`
+	CreatedAt       time.Time `json:"createdAt" gorm:"index"`
 	InitiatorParams `json:"params,omitempty"`
 	DeletedAt       null.Time `json:"-" gorm:"index"`
 }

--- a/core/store/models/log_events_test.go
+++ b/core/store/models/log_events_test.go
@@ -239,7 +239,7 @@ func TestStartRunOrSALogSubscription_ValidateSenders(t *testing.T) {
 			gomega.NewGomegaWithT(t).Eventually(func() models.RunStatus {
 				runs, err := app.Store.JobRunsFor(js.ID)
 				require.NoError(t, err)
-				return runs[0].Status
+				return runs[0].GetStatus()
 			}).Should(gomega.Equal(test.wantStatus))
 		})
 	}

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -175,7 +175,7 @@ func TestORM_SaveJobRun_ArchivedDoesNotRevertDeletedAt(t *testing.T) {
 
 	require.NoError(t, store.ArchiveJob(job.ID))
 
-	jr.Status = models.RunStatusInProgress
+	jr.SetStatus(models.RunStatusInProgress)
 	require.NoError(t, store.SaveJobRun(&jr))
 
 	require.Error(t, utils.JustError(store.FindJobRun(jr.ID)))
@@ -194,18 +194,18 @@ func TestORM_SaveJobRun_Cancelled(t *testing.T) {
 	jr := cltest.NewJobRun(job)
 	require.NoError(t, store.CreateJobRun(&jr))
 
-	jr.Status = models.RunStatusInProgress
+	jr.SetStatus(models.RunStatusInProgress)
 	require.NoError(t, store.SaveJobRun(&jr))
 
 	// Save the updated at before saving with cancelled
 	updatedAt := jr.UpdatedAt
 
-	jr.Status = models.RunStatusCancelled
+	jr.SetStatus(models.RunStatusCancelled)
 	require.NoError(t, store.SaveJobRun(&jr))
 
 	// Restore the previous updated at to simulate a conflict
 	jr.UpdatedAt = updatedAt
-	jr.Status = models.RunStatusInProgress
+	jr.SetStatus(models.RunStatusInProgress)
 	assert.Equal(t, orm.OptimisticUpdateConflictError, store.SaveJobRun(&jr))
 }
 
@@ -253,28 +253,34 @@ func TestORM_LinkEarnedFor(t *testing.T) {
 	require.NoError(t, store.CreateJob(&job))
 
 	jr1 := cltest.NewJobRun(job)
-	jr1.Status = models.RunStatusCompleted
+	jr1.TaskRuns[0].Status = models.RunStatusCompleted
+	jr1.SetStatus(models.RunStatusCompleted)
 	jr1.Payment = assets.NewLink(2)
-	jr1.FinishedAt = null.TimeFrom(time.Now())
 	require.NoError(t, store.CreateJobRun(&jr1))
+
 	jr2 := cltest.NewJobRun(job)
-	jr2.Status = models.RunStatusCompleted
+	jr2.TaskRuns[0].Status = models.RunStatusCompleted
+	jr2.SetStatus(models.RunStatusCompleted)
 	jr2.Payment = assets.NewLink(3)
-	jr2.FinishedAt = null.TimeFrom(time.Now())
 	require.NoError(t, store.CreateJobRun(&jr2))
+
 	jr3 := cltest.NewJobRun(job)
-	jr3.Status = models.RunStatusCompleted
+	jr3.TaskRuns[0].Status = models.RunStatusCompleted
+	jr3.SetStatus(models.RunStatusCompleted)
 	jr3.Payment = assets.NewLink(5)
 	jr3.FinishedAt = null.TimeFrom(time.Now())
 	require.NoError(t, store.CreateJobRun(&jr3))
+
 	jr4 := cltest.NewJobRun(job)
-	jr4.Status = models.RunStatusCompleted
+	jr4.TaskRuns[0].Status = models.RunStatusCompleted
+	jr4.SetStatus(models.RunStatusCompleted)
 	jr4.Payment = assets.NewLink(5)
+	jr4.FinishedAt = null.Time{}
 	require.NoError(t, store.CreateJobRun(&jr4))
+
 	jr5 := cltest.NewJobRun(job)
-	jr5.Status = models.RunStatusCancelled
+	jr5.SetStatus(models.RunStatusCancelled)
 	jr5.Payment = assets.NewLink(5)
-	jr5.FinishedAt = null.TimeFrom(time.Now())
 	require.NoError(t, store.CreateJobRun(&jr5))
 
 	totalEarned, err := store.LinkEarnedFor(&job)
@@ -330,7 +336,7 @@ func TestORM_UnscopedJobRunsWithStatus_Happy(t *testing.T) {
 	var seedIds []*models.ID
 	for _, status := range statuses {
 		run := cltest.NewJobRun(j)
-		run.Status = status
+		run.SetStatus(status)
 		require.NoError(t, store.CreateJobRun(&run))
 		seedIds = append(seedIds, run.ID)
 	}
@@ -385,7 +391,7 @@ func TestORM_UnscopedJobRunsWithStatus_Deleted(t *testing.T) {
 	var seedIds []*models.ID
 	for _, status := range statuses {
 		run := cltest.NewJobRun(j)
-		run.Status = status
+		run.SetStatus(status)
 		require.NoError(t, store.CreateJobRun(&run))
 		seedIds = append(seedIds, run.ID)
 	}
@@ -432,12 +438,12 @@ func TestORM_UnscopedJobRunsWithStatus_OrdersByCreatedAt(t *testing.T) {
 	assert.NoError(t, store.CreateJob(&j))
 
 	newPending := cltest.NewJobRun(j)
-	newPending.Status = models.RunStatusPendingSleep
+	newPending.SetStatus(models.RunStatusPendingSleep)
 	newPending.CreatedAt = time.Now().Add(10 * time.Second)
 	require.NoError(t, store.CreateJobRun(&newPending))
 
 	oldPending := cltest.NewJobRun(j)
-	oldPending.Status = models.RunStatusPendingSleep
+	oldPending.SetStatus(models.RunStatusPendingSleep)
 	oldPending.CreatedAt = time.Now()
 	require.NoError(t, store.CreateJobRun(&oldPending))
 
@@ -952,12 +958,12 @@ func TestORM_AllSyncEvents(t *testing.T) {
 	require.NoError(t, store.ORM.CreateJob(&job))
 
 	oldIncompleteRun := cltest.NewJobRun(job)
-	oldIncompleteRun.Status = models.RunStatusInProgress
+	oldIncompleteRun.SetStatus(models.RunStatusInProgress)
 	err := orm.CreateJobRun(&oldIncompleteRun)
 	require.NoError(t, err)
 
 	newCompletedRun := cltest.NewJobRun(job)
-	newCompletedRun.Status = models.RunStatusCompleted
+	newCompletedRun.SetStatus(models.RunStatusCompleted)
 	err = orm.CreateJobRun(&newCompletedRun)
 	require.NoError(t, err)
 
@@ -976,18 +982,19 @@ func TestBulkDeleteRuns(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
+	var resultCount int
+	var taskCount int
+	var runCount int
 	orm := store.ORM
 
 	err := orm.RawDB(func(db *gorm.DB) error {
 		job := cltest.NewJobWithWebInitiator()
-		job.Tasks = []models.TaskSpec{{Type: adapters.TaskTypeNoOp}}
 		require.NoError(t, store.ORM.CreateJob(&job))
 
 		// bulk delete should not delete these because they match the updated before
 		// but none of the statuses
 		oldIncompleteRun := cltest.NewJobRun(job)
 		oldIncompleteRun.Result = models.RunResult{Data: cltest.JSONFromString(t, `{"result": 17}`)}
-		oldIncompleteRun.Status = models.RunStatusInProgress
 		err := orm.CreateJobRun(&oldIncompleteRun)
 		require.NoError(t, err)
 		db.Model(&oldIncompleteRun).UpdateColumn("updated_at", cltest.ParseISO8601(t, "2018-01-01T00:00:00Z"))
@@ -995,8 +1002,9 @@ func TestBulkDeleteRuns(t *testing.T) {
 		// bulk delete *SHOULD* delete these because they match one of the statuses
 		// and the updated before
 		oldCompletedRun := cltest.NewJobRun(job)
+		oldCompletedRun.TaskRuns[0].Status = models.RunStatusCompleted
 		oldCompletedRun.Result = models.RunResult{Data: cltest.JSONFromString(t, `{"result": 19}`)}
-		oldCompletedRun.Status = models.RunStatusCompleted
+		oldCompletedRun.SetStatus(models.RunStatusCompleted)
 		err = orm.CreateJobRun(&oldCompletedRun)
 		require.NoError(t, err)
 		db.Model(&oldCompletedRun).UpdateColumn("updated_at", cltest.ParseISO8601(t, "2018-01-01T00:00:00Z"))
@@ -1005,7 +1013,7 @@ func TestBulkDeleteRuns(t *testing.T) {
 		// statuses but not the updated before
 		newCompletedRun := cltest.NewJobRun(job)
 		newCompletedRun.Result = models.RunResult{Data: cltest.JSONFromString(t, `{"result": 23}`)}
-		newCompletedRun.Status = models.RunStatusCompleted
+		newCompletedRun.SetStatus(models.RunStatusCompleted)
 		err = orm.CreateJobRun(&newCompletedRun)
 		require.NoError(t, err)
 		db.Model(&newCompletedRun).UpdateColumn("updated_at", cltest.ParseISO8601(t, "2018-01-30T00:00:00Z"))
@@ -1013,7 +1021,7 @@ func TestBulkDeleteRuns(t *testing.T) {
 		// bulk delete should not delete these because none of their attributes match
 		newIncompleteRun := cltest.NewJobRun(job)
 		newIncompleteRun.Result = models.RunResult{Data: cltest.JSONFromString(t, `{"result": 71}`)}
-		newIncompleteRun.Status = models.RunStatusCompleted
+		newIncompleteRun.SetStatus(models.RunStatusCompleted)
 		err = orm.CreateJobRun(&newIncompleteRun)
 		require.NoError(t, err)
 		db.Model(&newIncompleteRun).UpdateColumn("updated_at", cltest.ParseISO8601(t, "2018-01-30T00:00:00Z"))
@@ -1022,20 +1030,16 @@ func TestBulkDeleteRuns(t *testing.T) {
 			Status:        []models.RunStatus{models.RunStatusCompleted},
 			UpdatedBefore: cltest.ParseISO8601(t, "2018-01-15T00:00:00Z"),
 		})
-
 		require.NoError(t, err)
 
-		var runCount int
 		err = db.Model(&models.JobRun{}).Count(&runCount).Error
 		assert.NoError(t, err)
 		assert.Equal(t, 3, runCount)
 
-		var taskCount int
 		err = db.Model(&models.TaskRun{}).Count(&taskCount).Error
 		assert.NoError(t, err)
 		assert.Equal(t, 3, taskCount)
 
-		var resultCount int
 		err = db.Model(&models.RunResult{}).Count(&resultCount).Error
 		assert.NoError(t, err)
 		assert.Equal(t, 3, resultCount)

--- a/core/web/job_runs_controller.go
+++ b/core/web/job_runs_controller.go
@@ -168,7 +168,7 @@ func (jrc *JobRunsController) Update(c *gin.Context) {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
 	}
-	if !jr.Status.PendingBridge() {
+	if !jr.GetStatus().PendingBridge() {
 		jsonAPIError(c, http.StatusMethodNotAllowed, errors.New("Cannot resume a job run that isn't pending"))
 		return
 	}

--- a/core/web/job_runs_controller_test.go
+++ b/core/web/job_runs_controller_test.go
@@ -359,7 +359,7 @@ func TestJobRunsController_Update_WrongAccessToken(t *testing.T) {
 	assert.Equal(t, http.StatusUnauthorized, resp.StatusCode, "Response should be unauthorized")
 	jr, err := app.Store.FindJobRun(jr.ID)
 	assert.NoError(t, err)
-	assert.Equal(t, models.RunStatusPendingBridge, jr.Status)
+	assert.Equal(t, models.RunStatusPendingBridge, jr.GetStatus())
 }
 
 func TestJobRunsController_Update_NotPending(t *testing.T) {
@@ -434,7 +434,7 @@ func TestJobRunsController_Update_BadInput(t *testing.T) {
 	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode, "Response should be successful")
 	jr, err := app.Store.FindJobRun(jr.ID)
 	assert.NoError(t, err)
-	assert.Equal(t, models.RunStatusPendingBridge, jr.Status)
+	assert.Equal(t, models.RunStatusPendingBridge, jr.GetStatus())
 }
 
 func TestJobRunsController_Update_NotFound(t *testing.T) {
@@ -458,7 +458,7 @@ func TestJobRunsController_Update_NotFound(t *testing.T) {
 	assert.Equal(t, http.StatusNotFound, resp.StatusCode, "Response should be not found")
 	jr, err := app.Store.FindJobRun(jr.ID)
 	assert.NoError(t, err)
-	assert.Equal(t, models.RunStatusPendingBridge, jr.Status)
+	assert.Equal(t, models.RunStatusPendingBridge, jr.GetStatus())
 }
 
 func TestJobRunsController_Show_Found(t *testing.T) {
@@ -552,6 +552,6 @@ func TestJobRunsController_Cancel(t *testing.T) {
 
 		run, err := app.Store.FindJobRun(run.ID)
 		assert.NoError(t, err)
-		assert.Equal(t, models.RunStatusCancelled, run.Status)
+		assert.Equal(t, models.RunStatusCancelled, run.GetStatus())
 	})
 }


### PR DESCRIPTION
Replace prometheus instrumentation with a labelled metric counter
tracking all state updates by the Run Manager service (and its
components).

https://www.pivotaltracker.com/n/projects/2129823/stories/171640595

I opted for using counters as that was what was already in place, but since the task required a more general metric, the older metrics were replaced with a single one to track status updates w/ labels.