### PR TITLE
Ensure we always bump gas above geth's minimum required limit

### DIFF
--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -222,21 +222,22 @@ func CreateTx(
 	from common.Address,
 	sentAt uint64,
 ) *models.Tx {
-	return CreateTxWithNonce(t, store, from, sentAt, 0)
+	return CreateTxWithNonceAndGasPrice(t, store, from, sentAt, 0, 1)
 }
 
-// CreateTxWithNonce creates a Tx from a specified address, sentAt, and nonce
-func CreateTxWithNonce(
+// CreateTxWithNonceAndGasPrice creates a Tx from a specified address, sentAt, nonce and gas price
+func CreateTxWithNonceAndGasPrice(
 	t testing.TB,
 	store *strpkg.Store,
 	from common.Address,
 	sentAt uint64,
 	nonce uint64,
+	gasPrice int64,
 ) *models.Tx {
 	data := make([]byte, 36)
 	binary.LittleEndian.PutUint64(data, sentAt)
 
-	transaction := types.NewTransaction(nonce, common.Address{}, big.NewInt(0), 250000, big.NewInt(1), data)
+	transaction := types.NewTransaction(nonce, common.Address{}, big.NewInt(0), 250000, big.NewInt(gasPrice), data)
 	tx := &models.Tx{
 		From:        from,
 		SentAt:      sentAt,

--- a/core/store/orm/config_reader.go
+++ b/core/store/orm/config_reader.go
@@ -26,9 +26,11 @@ type ConfigReader interface {
 	FeatureFluxMonitor() bool
 	MaximumServiceDuration() time.Duration
 	MinimumServiceDuration() time.Duration
+	EthGasBumpPercent() uint16
 	EthGasBumpThreshold() uint64
 	EthGasBumpWei() *big.Int
 	EthGasPriceDefault() *big.Int
+	EthMaxGasPriceWei() *big.Int
 	SetEthGasPriceDefault(value *big.Int) error
 	EthereumURL() string
 	JSONConsole() bool

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -28,7 +28,9 @@ type ConfigSchema struct {
 	MinimumServiceDuration    time.Duration  `env:"MINIMUM_SERVICE_DURATION" default:"0s" `
 	EthGasBumpThreshold       uint64         `env:"ETH_GAS_BUMP_THRESHOLD" default:"12" `
 	EthGasBumpWei             big.Int        `env:"ETH_GAS_BUMP_WEI" default:"5000000000"`
+	EthGasBumpPercent         uint16         `env:"ETH_GAS_BUMP_PERCENT" default:"10"`
 	EthGasPriceDefault        big.Int        `env:"ETH_GAS_PRICE_DEFAULT" default:"20000000000"`
+	EthMaxGasPriceWei         uint64         `env:"ETH_MAX_GAS_PRICE_WEI" default:"500000000000"`
 	EthereumURL               string         `env:"ETH_URL" default:"ws://localhost:8546"`
 	JSONConsole               bool           `env:"JSON_CONSOLE" default:"false"`
 	LinkContractAddress       string         `env:"LINK_CONTRACT_ADDRESS" default:"0x514910771AF9Ca656af840dff83E8264EcF986CA"`

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -436,6 +436,100 @@ func TestTxManager_BumpGasUntilSafe_atGasBumpThreshold(t *testing.T) {
 	ethMock.EventuallyAllCalled(t)
 }
 
+func TestTxManager_BumpGasUntilSafe_atGasBumpThreshold_bumpsGasMoreInCaseOfUnderpricedTransaction(t *testing.T) {
+	t.Parallel()
+
+	app, cleanup := cltest.NewApplicationWithKey(t)
+	defer cleanup()
+
+	store := app.Store
+	config := store.Config
+
+	txm := store.TxManager
+	from := cltest.GetAccountAddress(t, store)
+	sentAt := uint64(23456)
+	gasThreshold := sentAt + config.EthGasBumpThreshold()
+	ethMock := app.EthMock
+	ethMock.Register("eth_getTransactionCount", "0x0")
+	ethMock.Register("eth_chainId", config.ChainID())
+	require.NoError(t, app.Store.ORM.CreateHead(cltest.Head(gasThreshold)))
+	require.NoError(t, app.StartAndConnect())
+
+	tx := cltest.CreateTxWithNonceAndGasPrice(t, store, from, sentAt, 0, 48000000000)
+	require.Greater(t, len(tx.Attempts), 0)
+
+	ethMock.Register("eth_getTransactionReceipt", eth.TxReceipt{})
+
+	// Simulate two bumps that receive `replacement transaction underpriced`
+	// and the third and final one successful
+	ethMock.RegisterError("eth_sendRawTransaction", "replacement transaction underpriced")
+	ethMock.RegisterError("eth_sendRawTransaction", "replacement transaction underpriced")
+	ethMock.Register("eth_sendRawTransaction", cltest.NewHash())
+
+	receipt, state, err := txm.BumpGasUntilSafe(tx.Attempts[0].Hash)
+	assert.NoError(t, err)
+	assert.Nil(t, receipt)
+	assert.Equal(t, strpkg.Unconfirmed, state)
+
+	tx, err = store.FindTx(tx.ID)
+	require.NoError(t, err)
+	assert.Len(t, tx.Attempts, 2)
+
+	latestAttempt := tx.Attempts[1]
+	gasPrice, err := latestAttempt.GasPrice.Value()
+	require.NoError(t, err)
+
+	// Initial gas price is 48Gwei
+	// Bump to 53Gwei and fail
+	// Bump to 58.3Gwei and fail
+	// Bump to 64.13Gwei and pass
+	assert.Equal(t, "64130000000", gasPrice)
+
+	ethMock.EventuallyAllCalled(t)
+}
+
+func TestTxManager_BumpGasUntilSafe_atGasBumpThreshold_returnsErrorIfMaxGasPriceIsReached(t *testing.T) {
+	t.Parallel()
+
+	app, cleanup := cltest.NewApplicationWithKey(t)
+	defer cleanup()
+
+	store := app.Store
+	config := store.Config
+
+	txm := store.TxManager
+	from := cltest.GetAccountAddress(t, store)
+	sentAt := uint64(23456)
+	gasThreshold := sentAt + config.EthGasBumpThreshold()
+	ethMock := app.EthMock
+	ethMock.Register("eth_getTransactionCount", "0x0")
+	ethMock.Register("eth_chainId", config.ChainID())
+	require.NoError(t, app.Store.ORM.CreateHead(cltest.Head(gasThreshold)))
+	require.NoError(t, app.StartAndConnect())
+
+	tx := cltest.CreateTxWithNonceAndGasPrice(t, store, from, sentAt, 0, 499000000000)
+	store.SaveTx(tx)
+	require.Greater(t, len(tx.Attempts), 0)
+
+	ethMock.Register("eth_getTransactionReceipt", eth.TxReceipt{})
+
+	receipt, state, err := txm.BumpGasUntilSafe(tx.Attempts[0].Hash)
+	assert.EqualError(t, err, "bumped gas price of 548900000000 would exceed maximum configured limit of 500000000000, set by ETH_GAS_PRICE_WEI")
+	assert.Nil(t, receipt)
+	assert.Equal(t, strpkg.Unconfirmed, state)
+
+	tx, err = store.FindTx(tx.ID)
+	require.NoError(t, err)
+	assert.Len(t, tx.Attempts, 1)
+
+	latestAttempt := tx.Attempts[0]
+	gasPrice, err := latestAttempt.GasPrice.Value()
+	require.NoError(t, err)
+	assert.Equal(t, "499000000000", gasPrice)
+
+	ethMock.EventuallyAllCalled(t)
+}
+
 func TestTxManager_BumpGasUntilSafe_exceedsGasBumpThreshold(t *testing.T) {
 	t.Parallel()
 
@@ -495,7 +589,7 @@ func TestTxManager_BumpGasUntilSafe_confirmed(t *testing.T) {
 	txm := store.TxManager
 	from := cltest.GetAccountAddress(t, store)
 
-	tx := cltest.CreateTxWithNonce(t, store, from, sentAt, nonce)
+	tx := cltest.CreateTxWithNonceAndGasPrice(t, store, from, sentAt, nonce, 1)
 	require.Greater(t, len(tx.Attempts), 0)
 
 	app.EthMock.Register("eth_getTransactionReceipt", eth.TxReceipt{Hash: cltest.NewHash(), BlockNumber: cltest.Int(gasThreshold)})
@@ -550,7 +644,7 @@ func TestTxManager_BumpGasUntilSafe_safe(t *testing.T) {
 			txm := store.TxManager
 			from := cltest.GetAccountAddress(t, store)
 
-			tx := cltest.CreateTxWithNonce(t, store, from, sentAt, nonce)
+			tx := cltest.CreateTxWithNonceAndGasPrice(t, store, from, sentAt, nonce, 1)
 			require.Greater(t, len(tx.Attempts), 0)
 
 			app.EthMock.Register("eth_getTransactionReceipt", eth.TxReceipt{Hash: cltest.NewHash(), BlockNumber: cltest.Int(gasThreshold)})
@@ -592,9 +686,9 @@ func TestTxManager_BumpGasUntilSafe_laterConfirmedTx(t *testing.T) {
 	from := cltest.GetAccountAddress(t, store)
 	sentAt := uint64(12345)
 
-	tx1 := cltest.CreateTxWithNonce(t, store, from, sentAt, 1)
+	tx1 := cltest.CreateTxWithNonceAndGasPrice(t, store, from, sentAt, 1, 1)
 	require.Len(t, tx1.Attempts, 1)
-	tx2 := cltest.CreateTxWithNonce(t, store, from, sentAt, 2)
+	tx2 := cltest.CreateTxWithNonceAndGasPrice(t, store, from, sentAt, 2, 1)
 	require.Len(t, tx2.Attempts, 1)
 
 	etm := txm.(*strpkg.EthTxManager)
@@ -1140,4 +1234,34 @@ func TestTxManager_RebroadcastUnconfirmedTxsOnReconnect(t *testing.T) {
 	require.NoError(t, err)
 
 	ethClient.AssertExpectations(t)
+}
+
+func TestTxManager_BumpGasByIncrement(t *testing.T) {
+	t.Parallel()
+
+	store, cleanup := cltest.NewStore(t)
+	defer cleanup()
+
+	ethClient := new(mocks.Client)
+
+	config := cltest.NewTestConfig(t)
+	config.Set("CHAINLINK_TX_ATTEMPT_LIMIT", 1)
+	keyStore := strpkg.NewKeyStore(config.KeysDir())
+	txm := strpkg.NewEthTxManager(ethClient, config, keyStore, store.ORM)
+
+	tests := []struct {
+		name                   string
+		originalGasPrice       *big.Int
+		expectedBumpedGasPrice *big.Int
+	}{
+		{"bumping gas from 5Gwei to 10Gwei", big.NewInt(5000000000), big.NewInt(10000000000)},
+		{"bumping gas from 100Gwei to 110Gwei", big.NewInt(100000000000), big.NewInt(110000000000)},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			actual := txm.BumpGasByIncrement(test.originalGasPrice)
+			assert.Equal(t, test.expectedBumpedGasPrice.String(), actual.String())
+		})
+	}
 }


### PR DESCRIPTION
- Avoids transactions getting permanently stuck at a gas "ceiling"

https://www.pivotaltracker.com/story/show/171824840