### PR TITLE
Introduce JSON constructor

### DIFF
--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -715,7 +715,7 @@ func (p *PollingDeviationChecker) createJobRun(polledAnswer decimal.Decimal, nex
 		return err
 	}
 
-	payload, err := json.Marshal(jobRunRequest{
+	runData, err := models.NewJSON(jobRunRequest{
 		Result:           polledAnswer,
 		Address:          p.initr.InitiatorParams.Address.Hex(),
 		FunctionSelector: hexutil.Encode(methodID),
@@ -723,10 +723,6 @@ func (p *PollingDeviationChecker) createJobRun(polledAnswer decimal.Decimal, nex
 	})
 	if err != nil {
 		return errors.Wrapf(err, "unable to encode Job Run request in JSON")
-	}
-	runData, err := models.ParseJSON(payload)
-	if err != nil {
-		return errors.Wrap(err, fmt.Sprintf("unable to start chainlink run with payload %s", payload))
 	}
 	runRequest := models.NewRunRequest(runData)
 

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -159,6 +159,16 @@ func ParseJSON(b []byte) (JSON, error) {
 	return j, json.Unmarshal([]byte(str), &j)
 }
 
+// NewJSON returns the JSON encoded object for the given argument.
+func NewJSON(obj interface{}) (JSON, error) {
+	buf, err := json.Marshal(obj)
+	if err != nil {
+		return JSON{}, err
+	}
+	ret := gjson.ParseBytes(buf)
+	return JSON{ret}, nil
+}
+
 // UnmarshalJSON parses the JSON bytes and stores in the *JSON pointer.
 func (j *JSON) UnmarshalJSON(b []byte) error {
 	str := string(b)

--- a/core/store/models/common_test.go
+++ b/core/store/models/common_test.go
@@ -121,6 +121,38 @@ func TestJSON_UnmarshalJSON(t *testing.T) {
 	}
 }
 
+func TestJSON_NewJSON(t *testing.T) {
+	tests := []struct {
+		name        string
+		in          interface{}
+		want        models.JSON
+		wantErrored bool
+	}{
+		{
+			"basic",
+			map[string]interface{}{
+				"num": 100,
+			},
+			cltest.JSONFromString(t, `{"num":100}`),
+			false,
+		},
+		{
+			"invalid argument",
+			make(chan struct{}),
+			models.JSON{},
+			true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			json, err := models.NewJSON(test.in)
+			assert.Equal(t, test.want, json)
+			assert.Equal(t, test.wantErrored, (err != nil))
+		})
+	}
+}
+
 func TestJSON_ParseJSON(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
Add NewJSON(..) to convert JSON marshallable entities into the JSON type.

This replaces some uses of injecting values into hand crafted JSON strings.