### PR TITLE
Make minor fixes to the Flux Monitor

### DIFF
--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -670,12 +670,10 @@ func (p *PollingDeviationChecker) loggerFieldsForAnswerUpdated(log *contracts.Lo
 	}
 }
 
-var dec0 = decimal.NewFromInt(0)
-
 // OutsideDeviation checks whether the next price is outside the threshold.
 func OutsideDeviation(curAnswer, nextAnswer decimal.Decimal, threshold float64) bool {
-	if curAnswer.Equal(dec0) {
-		logger.Infow("Current price is 0, deviation automatically met", "answer", dec0)
+	if curAnswer.IsZero() {
+		logger.Infow("Current price is 0, deviation automatically met", "answer", decimal.Zero)
 		return true
 	}
 


### PR DESCRIPTION
Use decimal.Zero, and use a type defined struct for the Job Run payload.  This
will improve safety and clarity in the codebase.