### PR TITLE
Make minor Flux Monitor improvements

### DIFF
--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -95,7 +95,7 @@ func New(
 func (fm *concreteFluxMonitor) Start() error {
 	fm.logBroadcaster.Start()
 
-	go fm.processAddRemoveJobRequests()
+	go fm.serveInternalRequests()
 
 	var wg sync.WaitGroup
 	err := fm.store.Jobs(func(j *models.JobSpec) bool {
@@ -129,9 +129,10 @@ func (fm *concreteFluxMonitor) Stop() {
 	<-fm.chDone
 }
 
-// actionConsumer is the CSP consumer. It's run on a single goroutine to
-// coordinate the collection of DeviationCheckers in a thread-safe fashion.
-func (fm *concreteFluxMonitor) processAddRemoveJobRequests() {
+// serveInternalRequests handles internal requests for state change via
+// channels.  Inspired by the ideas of Communicating Sequential Processes, or
+// CSP.
+func (fm *concreteFluxMonitor) serveInternalRequests() {
 	defer close(fm.chDone)
 
 	jobMap := map[models.ID][]DeviationChecker{}

--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -141,7 +141,7 @@ func (fm *concreteFluxMonitor) serveInternalRequests() {
 		select {
 		case entry := <-fm.chAdd:
 			if _, ok := jobMap[entry.jobID]; ok {
-				logger.Errorf("job %s has already been added to flux monitor", entry.jobID)
+				logger.Errorf("job '%s' has already been added to flux monitor", entry.jobID)
 				return
 			}
 			for _, checker := range entry.checkers {
@@ -150,7 +150,12 @@ func (fm *concreteFluxMonitor) serveInternalRequests() {
 			jobMap[entry.jobID] = entry.checkers
 
 		case jobID := <-fm.chRemove:
-			for _, checker := range jobMap[jobID] {
+			checkers, ok := jobMap[jobID]
+			if !ok {
+				logger.Errorf("job '%s' is missing from the flux monitor", jobID)
+				return
+			}
+			for _, checker := range checkers {
 				checker.Stop()
 			}
 			delete(jobMap, jobID)

--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -441,7 +441,6 @@ func (p *PollingDeviationChecker) consume() {
 		p.idleTicker = time.After(p.idleThreshold)
 	}
 
-Loop:
 	for {
 		select {
 		case <-p.chStop:
@@ -450,7 +449,7 @@ Loop:
 		case maybeLog := <-p.chMaybeLogs:
 			if maybeLog.Err != nil {
 				logger.Errorf("error received from log broadcaster: %v", maybeLog.Err)
-				continue Loop
+				continue
 			}
 			p.respondToLog(maybeLog.Log)
 


### PR DESCRIPTION
 (felder-cl, 3 hours ago)
   FluxMonitor: Log error on removing ghost Jobs

   Consider deleting a non-existent Job as an error to help surface potential
   flaws in the code base.

   It can be considered removing an non-existent entity a logical error in the
   program flow.

(felder-cl, 4 hours ago)
   FluxMonitor: Rename and doc. CSP consumer

   Fix the badly named documentation and update the methods name to reflect
   its purpose.

 (felder-cl, 4 hours ago)
   fluxmonitor: Cleanup useless label

   'continue' automatically continues the inner-most for-loop making the
   'Loop' label a NoOp.