### PR TITLE
FluxMonitor: Require available funds for operation

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -874,10 +874,12 @@ func TestIntegration_FluxMonitor_Deviation(t *testing.T) {
 	// Configure fake Eth Node to return 10,000 cents when FM initiates price.
 	eth.Context("Flux Monitor initializes price", func(mock *cltest.EthMock) {
 		var data []byte
-		data = append(data, utils.EVMWordUint64(2)...)     // RoundID
-		data = append(data, utils.EVMWordUint64(1)...)     // Eligible
-		data = append(data, utils.EVMWordUint64(10000)...) // LatestAnswer
-		data = append(data, utils.EVMWordUint64(0)...)     // TimesOutAt
+		data = append(data, utils.EVMWordUint64(2)...)                                                          // RoundID
+		data = append(data, utils.EVMWordUint64(1)...)                                                          // Eligible
+		data = append(data, utils.EVMWordUint64(10000)...)                                                      // LatestAnswer
+		data = append(data, utils.EVMWordUint64(0)...)                                                          // TimesOutAt
+		data = append(data, utils.EVMWordUint64(app.Store.Config.MinimumContractPayment().ToInt().Uint64())...) // AvailableFunds
+		data = append(data, utils.EVMWordUint64(app.Store.Config.MinimumContractPayment().ToInt().Uint64())...) // PaymentAmount
 		mock.Register("eth_call", "0x"+hex.EncodeToString(data))
 	})
 
@@ -952,10 +954,12 @@ func TestIntegration_FluxMonitor_NewRound(t *testing.T) {
 	// Configure fake Eth Node to return 10,000 cents when FM initiates price.
 	eth.Context("Flux Monitor queries FluxAggregator.RoundState()", func(mock *cltest.EthMock) {
 		var data []byte
-		data = append(data, utils.EVMWordUint64(2)...)     // RoundID
-		data = append(data, utils.EVMWordUint64(1)...)     // Eligible
-		data = append(data, utils.EVMWordUint64(10000)...) // LatestAnswer
-		data = append(data, utils.EVMWordUint64(0)...)     // TimesOutAt
+		data = append(data, utils.EVMWordUint64(2)...)                                                          // RoundID
+		data = append(data, utils.EVMWordUint64(1)...)                                                          // Eligible
+		data = append(data, utils.EVMWordUint64(10000)...)                                                      // LatestAnswer
+		data = append(data, utils.EVMWordUint64(0)...)                                                          // TimesOutAt
+		data = append(data, utils.EVMWordUint64(app.Store.Config.MinimumContractPayment().ToInt().Uint64())...) // AvailableFunds
+		data = append(data, utils.EVMWordUint64(app.Store.Config.MinimumContractPayment().ToInt().Uint64())...) // PaymentAmount
 		mock.Register("eth_call", "0x"+hex.EncodeToString(data))
 	})
 
@@ -997,10 +1001,12 @@ func TestIntegration_FluxMonitor_NewRound(t *testing.T) {
 	})
 	eth.Context("Flux Monitor queries FluxAggregator.RoundState()", func(mock *cltest.EthMock) {
 		var data []byte
-		data = append(data, utils.EVMWordUint64(3)...)     // RoundID
-		data = append(data, utils.EVMWordUint64(1)...)     // Eligible
-		data = append(data, utils.EVMWordUint64(10000)...) // LatestAnswer
-		data = append(data, utils.EVMWordUint64(0)...)     // TimesOutAt
+		data = append(data, utils.EVMWordUint64(3)...)                                                          // RoundID
+		data = append(data, utils.EVMWordUint64(1)...)                                                          // Eligible
+		data = append(data, utils.EVMWordUint64(10000)...)                                                      // LatestAnswer
+		data = append(data, utils.EVMWordUint64(0)...)                                                          // TimesOutAt
+		data = append(data, utils.EVMWordUint64(app.Store.Config.MinimumContractPayment().ToInt().Uint64())...) // AvailableFunds
+		data = append(data, utils.EVMWordUint64(app.Store.Config.MinimumContractPayment().ToInt().Uint64())...) // PaymentAmount
 		mock.Register("eth_call", "0x"+hex.EncodeToString(data))
 	})
 	newRounds <- log

--- a/core/internal/mocks/flux_aggregator.go
+++ b/core/internal/mocks/flux_aggregator.go
@@ -3,7 +3,10 @@
 package mocks
 
 import (
+	assets "chainlink/core/assets"
+
 	abi "github.com/ethereum/go-ethereum/accounts/abi"
+
 	common "github.com/ethereum/go-ethereum/common"
 
 	contracts "chainlink/core/services/eth/contracts"
@@ -72,6 +75,29 @@ func (_m *FluxAggregator) EncodeMessageCall(method string, args ...interface{}) 
 	var r1 error
 	if rf, ok := ret.Get(1).(func(string, ...interface{}) error); ok {
 		r1 = rf(method, args...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// GetAvailableFunds provides a mock function with given fields:
+func (_m *FluxAggregator) GetAvailableFunds() (*assets.Link, error) {
+	ret := _m.Called()
+
+	var r0 *assets.Link
+	if rf, ok := ret.Get(0).(func() *assets.Link); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*assets.Link)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func() error); ok {
+		r1 = rf()
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/eth/contracts/FluxAggregator.go
+++ b/core/services/eth/contracts/FluxAggregator.go
@@ -15,7 +15,6 @@ import (
 
 type FluxAggregator interface {
 	ethsvc.ConnectedContract
-	GetAvailableFunds() (*assets.Link, error)
 	RoundState(oracle common.Address) (FluxAggregatorRoundState, error)
 }
 
@@ -74,21 +73,13 @@ func (fa *fluxAggregator) SubscribeToLogs(listener ethsvc.LogListener) (connecte
 	)
 }
 
-// GetAvailableFunds returns the availableFunds contract value.
-func (fa *fluxAggregator) GetAvailableFunds() (*assets.Link, error) {
-	var result big.Int
-	err := fa.Call(&result, "availableFunds")
-	if err != nil {
-		return nil, errors.Wrap(err, "unable to encode message call")
-	}
-	return (*assets.Link)(&result), nil
-}
-
 type FluxAggregatorRoundState struct {
-	ReportableRoundID uint32   `abi:"_reportableRoundId"`
-	EligibleToSubmit  bool     `abi:"_eligibleToSubmit"`
-	LatestAnswer      *big.Int `abi:"_latestRoundAnswer"`
-	TimesOutAt        uint64   `abi:"_timesOutAt"`
+	ReportableRoundID uint32       `abi:"_reportableRoundId"`
+	EligibleToSubmit  bool         `abi:"_eligibleToSubmit"`
+	LatestAnswer      *big.Int     `abi:"_latestRoundAnswer"`
+	TimesOutAt        uint64       `abi:"_timesOutAt"`
+	AvailableFunds    *assets.Link `abi:"_availableFunds"`
+	PaymentAmount     *assets.Link `abi:"_paymentAmount"`
 }
 
 func (fa *fluxAggregator) RoundState(oracle common.Address) (FluxAggregatorRoundState, error) {

--- a/core/services/eth/contracts/FluxAggregator.go
+++ b/core/services/eth/contracts/FluxAggregator.go
@@ -3,6 +3,7 @@ package contracts
 import (
 	"math/big"
 
+	"chainlink/core/assets"
 	"chainlink/core/eth"
 	ethsvc "chainlink/core/services/eth"
 
@@ -14,6 +15,7 @@ import (
 
 type FluxAggregator interface {
 	ethsvc.ConnectedContract
+	GetAvailableFunds() (*assets.Link, error)
 	RoundState(oracle common.Address) (FluxAggregatorRoundState, error)
 }
 
@@ -70,6 +72,16 @@ func (fa *fluxAggregator) SubscribeToLogs(listener ethsvc.LogListener) (connecte
 	return fa.ConnectedContract.SubscribeToLogs(
 		ethsvc.NewDecodingLogListener(fa, fluxAggregatorLogTypes, listener),
 	)
+}
+
+// GetAvailableFunds returns the availableFunds contract value.
+func (fa *fluxAggregator) GetAvailableFunds() (*assets.Link, error) {
+	var result big.Int
+	err := fa.Call(&result, "availableFunds")
+	if err != nil {
+		return nil, errors.Wrap(err, "unable to encode message call")
+	}
+	return (*assets.Link)(&result), nil
 }
 
 type FluxAggregatorRoundState struct {

--- a/core/services/eth/contracts/FluxAggregator.go
+++ b/core/services/eth/contracts/FluxAggregator.go
@@ -3,7 +3,6 @@ package contracts
 import (
 	"math/big"
 
-	"chainlink/core/assets"
 	"chainlink/core/eth"
 	ethsvc "chainlink/core/services/eth"
 
@@ -74,12 +73,12 @@ func (fa *fluxAggregator) SubscribeToLogs(listener ethsvc.LogListener) (connecte
 }
 
 type FluxAggregatorRoundState struct {
-	ReportableRoundID uint32       `abi:"_reportableRoundId"`
-	EligibleToSubmit  bool         `abi:"_eligibleToSubmit"`
-	LatestAnswer      *big.Int     `abi:"_latestRoundAnswer"`
-	TimesOutAt        uint64       `abi:"_timesOutAt"`
-	AvailableFunds    *assets.Link `abi:"_availableFunds"`
-	PaymentAmount     *assets.Link `abi:"_paymentAmount"`
+	ReportableRoundID uint32   `abi:"_reportableRoundId"`
+	EligibleToSubmit  bool     `abi:"_eligibleToSubmit"`
+	LatestAnswer      *big.Int `abi:"_latestRoundAnswer"`
+	TimesOutAt        uint64   `abi:"_timesOutAt"`
+	AvailableFunds    *big.Int `abi:"_availableFunds"`
+	PaymentAmount     *big.Int `abi:"_paymentAmount"`
 }
 
 func (fa *fluxAggregator) RoundState(oracle common.Address) (FluxAggregatorRoundState, error) {

--- a/core/services/eth/contracts/FluxAggregator_test.go
+++ b/core/services/eth/contracts/FluxAggregator_test.go
@@ -6,7 +6,6 @@ import (
 	"math/big"
 	"testing"
 
-	"chainlink/core/assets"
 	"chainlink/core/eth"
 	"chainlink/core/internal/cltest"
 	"chainlink/core/internal/mocks"
@@ -25,64 +24,7 @@ func mustEVMBigInt(t *testing.T, val *big.Int) []byte {
 	return ret
 }
 
-func testFluxAggregatorClient_AvailableFunds(t *testing.T) {
-	aggregatorAddress := cltest.NewAddress()
-
-	// is this correct?
-	const aggregatorRoundState = "c410579e"
-	aggregatorRoundStateSelector := eth.HexToFunctionSelector(aggregatorRoundState)
-
-	selector := make([]byte, 16)
-	copy(selector, aggregatorRoundStateSelector.Bytes())
-	expectedCallArgs := eth.CallArgs{
-		To:   aggregatorAddress,
-		Data: selector,
-	}
-
-	tests := []struct {
-		name         string
-		response     []byte
-		expectedLINK assets.Link
-	}{
-		{
-			"zero",
-			mustEVMBigInt(t, big.NewInt(0)),
-			*cltest.NewLink(t, "0"),
-		},
-		{
-			"non-zero",
-			mustEVMBigInt(t, big.NewInt(100)),
-			*cltest.NewLink(t, "100"),
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.name, func(t *testing.T) {
-			ethClient := new(mocks.Client)
-
-			ethClient.On("Call", mock.Anything, "eth_call", expectedCallArgs, "latest").Return(nil).
-				Run(func(args mock.Arguments) {
-					res := args.Get(0)
-					err := res.(encoding.TextUnmarshaler).UnmarshalText(test.response)
-					require.NoError(t, err)
-				})
-
-			fa, err := contracts.NewFluxAggregator(
-				aggregatorAddress,
-				ethClient,
-				nil,
-			)
-			require.NoError(t, err)
-
-			res, err := fa.GetAvailableFunds()
-			require.NoError(t, err)
-			assert.Equal(t, test.expectedLINK, res)
-			ethClient.AssertExpectations(t)
-		})
-	}
-}
-
-func makeReturnData(roundID uint64, eligible bool, answer uint64) string {
+func makeRoundStateReturnData(roundID uint64, eligible bool, answer, timesOutAt, availableFunds, paymentAmount uint64) string {
 	var data []byte
 	data = append(data, utils.EVMWordUint64(roundID)...)
 	if eligible {
@@ -91,10 +33,13 @@ func makeReturnData(roundID uint64, eligible bool, answer uint64) string {
 		data = append(data, utils.EVMWordUint64(0)...)
 	}
 	data = append(data, utils.EVMWordUint64(answer)...)
+	data = append(data, utils.EVMWordUint64(timesOutAt)...)
+	data = append(data, utils.EVMWordUint64(availableFunds)...)
+	data = append(data, utils.EVMWordUint64(paymentAmount)...)
 	return "0x" + hex.EncodeToString(data)
 }
 
-func testFluxAggregatorClient_RoundState(t *testing.T) {
+func TestFluxAggregatorClient_RoundState(t *testing.T) {
 	aggregatorAddress := cltest.NewAddress()
 
 	const aggregatorRoundState = "c410579e"
@@ -108,34 +53,23 @@ func testFluxAggregatorClient_RoundState(t *testing.T) {
 		Data: append(selector, nodeAddr[:]...),
 	}
 
-	makeReturnData := func(roundID uint64, eligible bool, answer, timesOutAt uint64) string {
-		var data []byte
-		data = append(data, utils.EVMWordUint64(roundID)...)
-		if eligible {
-			data = append(data, utils.EVMWordUint64(1)...)
-		} else {
-			data = append(data, utils.EVMWordUint64(0)...)
-		}
-		data = append(data, utils.EVMWordUint64(answer)...)
-		data = append(data, utils.EVMWordUint64(timesOutAt)...)
-		return "0x" + hex.EncodeToString(data)
-	}
-
-	rawReturnData := `0x00000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000000e`
+	rawReturnData := `0x00000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000100`
 
 	tests := []struct {
-		name               string
-		response           string
-		expectedRoundID    uint32
-		expectedEligible   bool
-		expectedAnswer     *big.Int
-		expectedTimesOutAt uint64
+		name                   string
+		response               string
+		expectedRoundID        uint32
+		expectedEligible       bool
+		expectedAnswer         *big.Int
+		expectedTimesOutAt     uint64
+		expectedAvailableFunds uint64
+		expectedPaymentAmount  uint64
 	}{
-		{"zero, false", makeReturnData(0, false, 0, 0), 0, false, big.NewInt(0), 0},
-		{"non-zero, false", makeReturnData(1, false, 23, 1234), 1, false, big.NewInt(23), 1234},
-		{"zero, true", makeReturnData(0, true, 0, 0), 0, true, big.NewInt(0), 0},
-		{"non-zero true", makeReturnData(12, true, 91, 9876), 12, true, big.NewInt(91), 9876},
-		{"real call data", rawReturnData, 3, true, big.NewInt(15), 14},
+		{"zero, false", makeRoundStateReturnData(0, false, 0, 0, 0, 0), 0, false, big.NewInt(0), 0, 0, 0},
+		{"non-zero, false", makeRoundStateReturnData(1, false, 23, 1234, 36, 72), 1, false, big.NewInt(23), 1234, 36, 72},
+		{"zero, true", makeRoundStateReturnData(0, true, 0, 0, 0, 0), 0, true, big.NewInt(0), 0, 0, 0},
+		{"non-zero true", makeRoundStateReturnData(12, true, 91, 9876, 45, 999), 12, true, big.NewInt(91), 9876, 45, 999},
+		{"real call data", rawReturnData, 3, true, big.NewInt(15), 14, 10, 256},
 	}
 
 	for _, test := range tests {
@@ -158,6 +92,8 @@ func testFluxAggregatorClient_RoundState(t *testing.T) {
 			assert.Equal(t, test.expectedEligible, roundState.EligibleToSubmit)
 			assert.True(t, test.expectedAnswer.Cmp(roundState.LatestAnswer) == 0)
 			assert.Equal(t, test.expectedTimesOutAt, roundState.TimesOutAt)
+			assert.Equal(t, test.expectedAvailableFunds, roundState.AvailableFunds.Uint64())
+			assert.Equal(t, test.expectedPaymentAmount, roundState.PaymentAmount.Uint64())
 			ethClient.AssertExpectations(t)
 		})
 	}

--- a/core/services/eth/contracts/FluxAggregator_test.go
+++ b/core/services/eth/contracts/FluxAggregator_test.go
@@ -94,7 +94,7 @@ func makeReturnData(roundID uint64, eligible bool, answer uint64) string {
 	return "0x" + hex.EncodeToString(data)
 }
 
-func TestFluxAggregatorClient_RoundState(t *testing.T) {
+func testFluxAggregatorClient_RoundState(t *testing.T) {
 	aggregatorAddress := cltest.NewAddress()
 
 	const aggregatorRoundState = "c410579e"

--- a/core/services/eth/contracts/FluxAggregator_test.go
+++ b/core/services/eth/contracts/FluxAggregator_test.go
@@ -2,7 +2,6 @@ package contracts_test
 
 import (
 	"encoding"
-	"encoding/hex"
 	"math/big"
 	"testing"
 
@@ -13,6 +12,7 @@ import (
 	"chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -36,7 +36,7 @@ func makeRoundStateReturnData(roundID uint64, eligible bool, answer, timesOutAt,
 	data = append(data, utils.EVMWordUint64(timesOutAt)...)
 	data = append(data, utils.EVMWordUint64(availableFunds)...)
 	data = append(data, utils.EVMWordUint64(paymentAmount)...)
-	return "0x" + hex.EncodeToString(data)
+	return hexutil.Encode(data)
 }
 
 func TestFluxAggregatorClient_RoundState(t *testing.T) {

--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -579,7 +579,7 @@ func (p *PollingDeviationChecker) respondToNewRoundLog(log *contracts.LogNewRoun
 	} else if roundState.AvailableFunds.Cmp(roundState.PaymentAmount) < 0 {
 		logger.Infow("Ignoring new round request: aggregator is underfunded", p.loggerFieldsForNewRound(log)...)
 		return
-	} else if roundState.PaymentAmount.Cmp(p.store.Config.MinimumContractPayment()) < 0 {
+	} else if roundState.PaymentAmount.Cmp(p.store.Config.MinimumContractPayment().ToInt()) < 0 {
 		logger.Infow("Ignoring new round request: round payment amount < minimum contract payment", p.loggerFieldsForNewRound(log)...)
 		return
 	}
@@ -641,7 +641,7 @@ func (p *PollingDeviationChecker) pollIfEligible(threshold float64) (createdJobR
 	} else if roundState.AvailableFunds.Cmp(roundState.PaymentAmount) < 0 {
 		logger.Infow("Ignoring new round request: aggregator is underfunded", loggerFields...)
 		return false
-	} else if roundState.PaymentAmount.Cmp(p.store.Config.MinimumContractPayment()) < 0 {
+	} else if roundState.PaymentAmount.Cmp(p.store.Config.MinimumContractPayment().ToInt()) < 0 {
 		logger.Infow("Ignoring new round request: round payment amount < minimum contract payment", loggerFields...)
 		return false
 	}

--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -636,13 +636,13 @@ func (p *PollingDeviationChecker) pollIfEligible(threshold float64) (createdJobR
 	}
 
 	if !roundState.EligibleToSubmit {
-		logger.Infow("not eligible to submit, skipping poll", loggerFields...)
+		logger.Infow("skipping poll: not eligible to submit", loggerFields...)
 		return false
 	} else if roundState.AvailableFunds.Cmp(roundState.PaymentAmount) < 0 {
-		logger.Infow("Ignoring new round request: aggregator is underfunded", loggerFields...)
+		logger.Infow("skipping poll: aggregator is underfunded", loggerFields...)
 		return false
 	} else if roundState.PaymentAmount.Cmp(p.store.Config.MinimumContractPayment().ToInt()) < 0 {
-		logger.Infow("Ignoring new round request: round payment amount < minimum contract payment", loggerFields...)
+		logger.Infow("skipping poll: round payment amount < minimum contract payment", loggerFields...)
 		return false
 	}
 

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"chainlink/core/assets"
 	"chainlink/core/cmd"
 	"chainlink/core/internal/cltest"
 	"chainlink/core/internal/mocks"
@@ -164,6 +165,7 @@ func TestPollingDeviationChecker_PollIfEligible(t *testing.T) {
 				LatestAnswer:      big.NewInt(latestAnswerNoPrecision),
 			}
 			fluxAggregator.On("RoundState", nodeAddr).Return(roundState, nil).Maybe()
+			fluxAggregator.On("GetAvailableFunds").Return(assets.NewLink(100), nil).Maybe()
 
 			if test.expectedToPoll {
 				fetcher.On("Fetch").Return(decimal.NewFromInt(test.polledAnswer), nil)
@@ -234,6 +236,9 @@ func TestPollingDeviationChecker_TriggerIdleTimeThreshold(t *testing.T) {
 			answerBigInt := big.NewInt(fetchedAnswer * int64(math.Pow10(int(initr.InitiatorParams.Precision))))
 
 			fluxAggregator.On("SubscribeToLogs", mock.Anything).Return(true, eth.UnsubscribeFunc(func() {}), nil)
+
+			availableFunds := assets.NewLink(100)
+			fluxAggregator.On("GetAvailableFunds").Return(availableFunds, nil).Maybe()
 
 			roundState1 := contracts.FluxAggregatorRoundState{ReportableRoundID: 1, EligibleToSubmit: false, LatestAnswer: answerBigInt} // Initial poll
 			roundState2 := contracts.FluxAggregatorRoundState{ReportableRoundID: 2, EligibleToSubmit: false, LatestAnswer: answerBigInt} // idleThreshold 1

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"chainlink/core/assets"
 	"chainlink/core/cmd"
 	"chainlink/core/internal/cltest"
 	"chainlink/core/internal/mocks"
@@ -180,14 +179,14 @@ func TestPollingDeviationChecker_PollIfEligible(t *testing.T) {
 			const reportableRoundID = 2
 			latestAnswerNoPrecision := test.latestAnswer * int64(math.Pow10(int(initr.InitiatorParams.Precision)))
 
-			var availableFunds *assets.Link
-			var paymentAmount *assets.Link
-			minPayment := store.Config.MinimumContractPayment()
+			var availableFunds *big.Int
+			var paymentAmount *big.Int
+			minPayment := store.Config.MinimumContractPayment().ToInt()
 			if test.funded {
 				availableFunds = minPayment
 				paymentAmount = minPayment
 			} else {
-				availableFunds = assets.NewLink(1)
+				availableFunds = big.NewInt(1)
 				paymentAmount = minPayment
 			}
 
@@ -667,14 +666,14 @@ func TestPollingDeviationChecker_RespondToNewRound(t *testing.T) {
 			fetcher := new(mocks.Fetcher)
 			fluxAggregator := new(mocks.FluxAggregator)
 
-			var availableFunds *assets.Link
-			var paymentAmount *assets.Link
-			minPayment := store.Config.MinimumContractPayment()
+			var availableFunds *big.Int
+			var paymentAmount *big.Int
+			minPayment := store.Config.MinimumContractPayment().ToInt()
 			if test.funded {
 				availableFunds = minPayment
 				paymentAmount = minPayment
 			} else {
-				availableFunds = assets.NewLink(1)
+				availableFunds = big.NewInt(1)
 				paymentAmount = minPayment
 			}
 

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -114,31 +114,52 @@ func TestPollingDeviationChecker_PollIfEligible(t *testing.T) {
 		name             string
 		eligible         bool
 		connected        bool
+		funded           bool
 		threshold        float64
 		latestAnswer     int64
 		polledAnswer     int64
 		expectedToPoll   bool
 		expectedToSubmit bool
 	}{
-		{"eligible, connected, threshold > 0, answers deviate", true, true, 0.1, 1, 100, true, true},
-		{"eligible, connected, threshold > 0, answers do not deviate", true, true, 0.1, 100, 100, true, false},
-		{"eligible, connected, threshold == 0, answers deviate", true, true, 0, 1, 100, true, true},
-		{"eligible, connected, threshold == 0, answers do not deviate", true, true, 0, 1, 100, true, true},
+		{"eligible, connected, funded, threshold > 0, answers deviate", true, true, true, 0.1, 1, 100, true, true},
+		{"eligible, connected, funded, threshold > 0, answers do not deviate", true, true, true, 0.1, 100, 100, true, false},
+		{"eligible, connected, funded, threshold == 0, answers deviate", true, true, true, 0, 1, 100, true, true},
+		{"eligible, connected, funded, threshold == 0, answers do not deviate", true, true, true, 0, 1, 100, true, true},
 
-		{"eligible, disconnected, threshold > 0, answers deviate", true, false, 0.1, 1, 100, false, false},
-		{"eligible, disconnected, threshold > 0, answers do not deviate", true, false, 0.1, 100, 100, false, false},
-		{"eligible, disconnected, threshold == 0, answers deviate", true, false, 0, 1, 100, false, false},
-		{"eligible, disconnected, threshold == 0, answers do not deviate", true, false, 0, 1, 100, false, false},
+		{"eligible, disconnected, funded, threshold > 0, answers deviate", true, false, true, 0.1, 1, 100, false, false},
+		{"eligible, disconnected, funded, threshold > 0, answers do not deviate", true, false, true, 0.1, 100, 100, false, false},
+		{"eligible, disconnected, funded, threshold == 0, answers deviate", true, false, true, 0, 1, 100, false, false},
+		{"eligible, disconnected, funded, threshold == 0, answers do not deviate", true, false, true, 0, 1, 100, false, false},
 
-		{"ineligible, connected, threshold > 0, answers deviate", false, true, 0.1, 1, 100, false, false},
-		{"ineligible, connected, threshold > 0, answers do not deviate", false, true, 0.1, 100, 100, false, false},
-		{"ineligible, connected, threshold == 0, answers deviate", false, true, 0, 1, 100, false, false},
-		{"ineligible, connected, threshold == 0, answers do not deviate", false, true, 0, 1, 100, false, false},
+		{"ineligible, connected, funded, threshold > 0, answers deviate", false, true, true, 0.1, 1, 100, false, false},
+		{"ineligible, connected, funded, threshold > 0, answers do not deviate", false, true, true, 0.1, 100, 100, false, false},
+		{"ineligible, connected, funded, threshold == 0, answers deviate", false, true, true, 0, 1, 100, false, false},
+		{"ineligible, connected, funded, threshold == 0, answers do not deviate", false, true, true, 0, 1, 100, false, false},
 
-		{"ineligible, disconnected, threshold > 0, answers deviate", false, false, 0.1, 1, 100, false, false},
-		{"ineligible, disconnected, threshold > 0, answers do not deviate", false, false, 0.1, 100, 100, false, false},
-		{"ineligible, disconnected, threshold == 0, answers deviate", false, false, 0, 1, 100, false, false},
-		{"ineligible, disconnected, threshold == 0, answers do not deviate", false, false, 0, 1, 100, false, false},
+		{"ineligible, disconnected, funded, threshold > 0, answers deviate", false, false, true, 0.1, 1, 100, false, false},
+		{"ineligible, disconnected, funded, threshold > 0, answers do not deviate", false, false, true, 0.1, 100, 100, false, false},
+		{"ineligible, disconnected, funded, threshold == 0, answers deviate", false, false, true, 0, 1, 100, false, false},
+		{"ineligible, disconnected, funded, threshold == 0, answers do not deviate", false, false, true, 0, 1, 100, false, false},
+
+		{"eligible, connected, underfunded, threshold > 0, answers deviate", true, true, false, 0.1, 1, 100, false, false},
+		{"eligible, connected, underfunded, threshold > 0, answers do not deviate", true, true, false, 0.1, 100, 100, false, false},
+		{"eligible, connected, underfunded, threshold == 0, answers deviate", true, true, false, 0, 1, 100, false, false},
+		{"eligible, connected, underfunded, threshold == 0, answers do not deviate", true, true, false, 0, 1, 100, false, false},
+
+		{"eligible, disconnected, underfunded, threshold > 0, answers deviate", true, false, false, 0.1, 1, 100, false, false},
+		{"eligible, disconnected, underfunded, threshold > 0, answers do not deviate", true, false, false, 0.1, 100, 100, false, false},
+		{"eligible, disconnected, underfunded, threshold == 0, answers deviate", true, false, false, 0, 1, 100, false, false},
+		{"eligible, disconnected, underfunded, threshold == 0, answers do not deviate", true, false, false, 0, 1, 100, false, false},
+
+		{"ineligible, connected, underfunded, threshold > 0, answers deviate", false, true, false, 0.1, 1, 100, false, false},
+		{"ineligible, connected, underfunded, threshold > 0, answers do not deviate", false, true, false, 0.1, 100, 100, false, false},
+		{"ineligible, connected, underfunded, threshold == 0, answers deviate", false, true, false, 0, 1, 100, false, false},
+		{"ineligible, connected, underfunded, threshold == 0, answers do not deviate", false, true, false, 0, 1, 100, false, false},
+
+		{"ineligible, disconnected, underfunded, threshold > 0, answers deviate", false, false, false, 0.1, 1, 100, false, false},
+		{"ineligible, disconnected, underfunded, threshold > 0, answers do not deviate", false, false, false, 0.1, 100, 100, false, false},
+		{"ineligible, disconnected, underfunded, threshold == 0, answers deviate", false, false, false, 0, 1, 100, false, false},
+		{"ineligible, disconnected, underfunded, threshold == 0, answers do not deviate", false, false, false, 0, 1, 100, false, false},
 	}
 
 	store, cleanup := cltest.NewStore(t)
@@ -159,13 +180,25 @@ func TestPollingDeviationChecker_PollIfEligible(t *testing.T) {
 			const reportableRoundID = 2
 			latestAnswerNoPrecision := test.latestAnswer * int64(math.Pow10(int(initr.InitiatorParams.Precision)))
 
+			var availableFunds *assets.Link
+			var paymentAmount *assets.Link
+			minPayment := store.Config.MinimumContractPayment()
+			if test.funded {
+				availableFunds = minPayment
+				paymentAmount = minPayment
+			} else {
+				availableFunds = assets.NewLink(1)
+				paymentAmount = minPayment
+			}
+
 			roundState := contracts.FluxAggregatorRoundState{
 				ReportableRoundID: reportableRoundID,
 				EligibleToSubmit:  test.eligible,
 				LatestAnswer:      big.NewInt(latestAnswerNoPrecision),
+				AvailableFunds:    availableFunds,
+				PaymentAmount:     paymentAmount,
 			}
 			fluxAggregator.On("RoundState", nodeAddr).Return(roundState, nil).Maybe()
-			fluxAggregator.On("GetAvailableFunds").Return(assets.NewLink(100), nil).Maybe()
 
 			if test.expectedToPoll {
 				fetcher.On("Fetch").Return(decimal.NewFromInt(test.polledAnswer), nil)
@@ -236,9 +269,6 @@ func TestPollingDeviationChecker_TriggerIdleTimeThreshold(t *testing.T) {
 			answerBigInt := big.NewInt(fetchedAnswer * int64(math.Pow10(int(initr.InitiatorParams.Precision))))
 
 			fluxAggregator.On("SubscribeToLogs", mock.Anything).Return(true, eth.UnsubscribeFunc(func() {}), nil)
-
-			availableFunds := assets.NewLink(100)
-			fluxAggregator.On("GetAvailableFunds").Return(availableFunds, nil).Maybe()
 
 			roundState1 := contracts.FluxAggregatorRoundState{ReportableRoundID: 1, EligibleToSubmit: false, LatestAnswer: answerBigInt} // Initial poll
 			roundState2 := contracts.FluxAggregatorRoundState{ReportableRoundID: 2, EligibleToSubmit: false, LatestAnswer: answerBigInt} // idleThreshold 1
@@ -400,107 +430,204 @@ func TestPollingDeviationChecker_RespondToNewRound(t *testing.T) {
 	)
 
 	tests := []struct {
+		funded        bool
 		eligible      bool
 		startedBySelf bool
 		roundIDCase
 		answerCase
 	}{
-		{true, true, stored_lt_fetched_lt_log, deviationThresholdExceeded},
-		{true, true, stored_lt_log_lt_fetched, deviationThresholdExceeded},
-		{true, true, fetched_lt_stored_lt_log, deviationThresholdExceeded},
-		{true, true, fetched_lt_log_lt_stored, deviationThresholdExceeded},
-		{true, true, log_lt_fetched_lt_stored, deviationThresholdExceeded},
-		{true, true, log_lt_stored_lt_fetched, deviationThresholdExceeded},
-		{true, true, stored_lt_fetched_eq_log, deviationThresholdExceeded},
-		{true, true, stored_eq_fetched_lt_log, deviationThresholdExceeded},
-		{true, true, stored_eq_log_lt_fetched, deviationThresholdExceeded},
-		{true, true, fetched_lt_stored_eq_log, deviationThresholdExceeded},
-		{true, true, fetched_eq_log_lt_stored, deviationThresholdExceeded},
-		{true, true, log_lt_fetched_eq_stored, deviationThresholdExceeded},
-		{true, true, stored_lt_fetched_lt_log, deviationThresholdNotExceeded},
-		{true, true, stored_lt_log_lt_fetched, deviationThresholdNotExceeded},
-		{true, true, fetched_lt_stored_lt_log, deviationThresholdNotExceeded},
-		{true, true, fetched_lt_log_lt_stored, deviationThresholdNotExceeded},
-		{true, true, log_lt_fetched_lt_stored, deviationThresholdNotExceeded},
-		{true, true, log_lt_stored_lt_fetched, deviationThresholdNotExceeded},
-		{true, true, stored_lt_fetched_eq_log, deviationThresholdNotExceeded},
-		{true, true, stored_eq_fetched_lt_log, deviationThresholdNotExceeded},
-		{true, true, stored_eq_log_lt_fetched, deviationThresholdNotExceeded},
-		{true, true, fetched_lt_stored_eq_log, deviationThresholdNotExceeded},
-		{true, true, fetched_eq_log_lt_stored, deviationThresholdNotExceeded},
-		{true, true, log_lt_fetched_eq_stored, deviationThresholdNotExceeded},
-		{true, false, stored_lt_fetched_lt_log, deviationThresholdExceeded},
-		{true, false, stored_lt_log_lt_fetched, deviationThresholdExceeded},
-		{true, false, fetched_lt_stored_lt_log, deviationThresholdExceeded},
-		{true, false, fetched_lt_log_lt_stored, deviationThresholdExceeded},
-		{true, false, log_lt_fetched_lt_stored, deviationThresholdExceeded},
-		{true, false, log_lt_stored_lt_fetched, deviationThresholdExceeded},
-		{true, false, stored_lt_fetched_eq_log, deviationThresholdExceeded},
-		{true, false, stored_eq_fetched_lt_log, deviationThresholdExceeded},
-		{true, false, stored_eq_log_lt_fetched, deviationThresholdExceeded},
-		{true, false, fetched_lt_stored_eq_log, deviationThresholdExceeded},
-		{true, false, fetched_eq_log_lt_stored, deviationThresholdExceeded},
-		{true, false, log_lt_fetched_eq_stored, deviationThresholdExceeded},
-		{true, false, stored_lt_fetched_lt_log, deviationThresholdNotExceeded},
-		{true, false, stored_lt_log_lt_fetched, deviationThresholdNotExceeded},
-		{true, false, fetched_lt_stored_lt_log, deviationThresholdNotExceeded},
-		{true, false, fetched_lt_log_lt_stored, deviationThresholdNotExceeded},
-		{true, false, log_lt_fetched_lt_stored, deviationThresholdNotExceeded},
-		{true, false, log_lt_stored_lt_fetched, deviationThresholdNotExceeded},
-		{true, false, stored_lt_fetched_eq_log, deviationThresholdNotExceeded},
-		{true, false, stored_eq_fetched_lt_log, deviationThresholdNotExceeded},
-		{true, false, stored_eq_log_lt_fetched, deviationThresholdNotExceeded},
-		{true, false, fetched_lt_stored_eq_log, deviationThresholdNotExceeded},
-		{true, false, fetched_eq_log_lt_stored, deviationThresholdNotExceeded},
-		{true, false, log_lt_fetched_eq_stored, deviationThresholdNotExceeded},
-		{false, true, stored_lt_fetched_lt_log, deviationThresholdExceeded},
-		{false, true, stored_lt_log_lt_fetched, deviationThresholdExceeded},
-		{false, true, fetched_lt_stored_lt_log, deviationThresholdExceeded},
-		{false, true, fetched_lt_log_lt_stored, deviationThresholdExceeded},
-		{false, true, log_lt_fetched_lt_stored, deviationThresholdExceeded},
-		{false, true, log_lt_stored_lt_fetched, deviationThresholdExceeded},
-		{false, true, stored_lt_fetched_eq_log, deviationThresholdExceeded},
-		{false, true, stored_eq_fetched_lt_log, deviationThresholdExceeded},
-		{false, true, stored_eq_log_lt_fetched, deviationThresholdExceeded},
-		{false, true, fetched_lt_stored_eq_log, deviationThresholdExceeded},
-		{false, true, fetched_eq_log_lt_stored, deviationThresholdExceeded},
-		{false, true, log_lt_fetched_eq_stored, deviationThresholdExceeded},
-		{false, true, stored_lt_fetched_lt_log, deviationThresholdNotExceeded},
-		{false, true, stored_lt_log_lt_fetched, deviationThresholdNotExceeded},
-		{false, true, fetched_lt_stored_lt_log, deviationThresholdNotExceeded},
-		{false, true, fetched_lt_log_lt_stored, deviationThresholdNotExceeded},
-		{false, true, log_lt_fetched_lt_stored, deviationThresholdNotExceeded},
-		{false, true, log_lt_stored_lt_fetched, deviationThresholdNotExceeded},
-		{false, true, stored_lt_fetched_eq_log, deviationThresholdNotExceeded},
-		{false, true, stored_eq_fetched_lt_log, deviationThresholdNotExceeded},
-		{false, true, stored_eq_log_lt_fetched, deviationThresholdNotExceeded},
-		{false, true, fetched_lt_stored_eq_log, deviationThresholdNotExceeded},
-		{false, true, fetched_eq_log_lt_stored, deviationThresholdNotExceeded},
-		{false, true, log_lt_fetched_eq_stored, deviationThresholdNotExceeded},
-		{false, false, stored_lt_fetched_lt_log, deviationThresholdExceeded},
-		{false, false, stored_lt_log_lt_fetched, deviationThresholdExceeded},
-		{false, false, fetched_lt_stored_lt_log, deviationThresholdExceeded},
-		{false, false, fetched_lt_log_lt_stored, deviationThresholdExceeded},
-		{false, false, log_lt_fetched_lt_stored, deviationThresholdExceeded},
-		{false, false, log_lt_stored_lt_fetched, deviationThresholdExceeded},
-		{false, false, stored_lt_fetched_eq_log, deviationThresholdExceeded},
-		{false, false, stored_eq_fetched_lt_log, deviationThresholdExceeded},
-		{false, false, stored_eq_log_lt_fetched, deviationThresholdExceeded},
-		{false, false, fetched_lt_stored_eq_log, deviationThresholdExceeded},
-		{false, false, fetched_eq_log_lt_stored, deviationThresholdExceeded},
-		{false, false, log_lt_fetched_eq_stored, deviationThresholdExceeded},
-		{false, false, stored_lt_fetched_lt_log, deviationThresholdNotExceeded},
-		{false, false, stored_lt_log_lt_fetched, deviationThresholdNotExceeded},
-		{false, false, fetched_lt_stored_lt_log, deviationThresholdNotExceeded},
-		{false, false, fetched_lt_log_lt_stored, deviationThresholdNotExceeded},
-		{false, false, log_lt_fetched_lt_stored, deviationThresholdNotExceeded},
-		{false, false, log_lt_stored_lt_fetched, deviationThresholdNotExceeded},
-		{false, false, stored_lt_fetched_eq_log, deviationThresholdNotExceeded},
-		{false, false, stored_eq_fetched_lt_log, deviationThresholdNotExceeded},
-		{false, false, stored_eq_log_lt_fetched, deviationThresholdNotExceeded},
-		{false, false, fetched_lt_stored_eq_log, deviationThresholdNotExceeded},
-		{false, false, fetched_eq_log_lt_stored, deviationThresholdNotExceeded},
-		{false, false, log_lt_fetched_eq_stored, deviationThresholdNotExceeded},
+		{true, true, true, stored_lt_fetched_lt_log, deviationThresholdExceeded},
+		{true, true, true, stored_lt_log_lt_fetched, deviationThresholdExceeded},
+		{true, true, true, fetched_lt_stored_lt_log, deviationThresholdExceeded},
+		{true, true, true, fetched_lt_log_lt_stored, deviationThresholdExceeded},
+		{true, true, true, log_lt_fetched_lt_stored, deviationThresholdExceeded},
+		{true, true, true, log_lt_stored_lt_fetched, deviationThresholdExceeded},
+		{true, true, true, stored_lt_fetched_eq_log, deviationThresholdExceeded},
+		{true, true, true, stored_eq_fetched_lt_log, deviationThresholdExceeded},
+		{true, true, true, stored_eq_log_lt_fetched, deviationThresholdExceeded},
+		{true, true, true, fetched_lt_stored_eq_log, deviationThresholdExceeded},
+		{true, true, true, fetched_eq_log_lt_stored, deviationThresholdExceeded},
+		{true, true, true, log_lt_fetched_eq_stored, deviationThresholdExceeded},
+		{true, true, true, stored_lt_fetched_lt_log, deviationThresholdNotExceeded},
+		{true, true, true, stored_lt_log_lt_fetched, deviationThresholdNotExceeded},
+		{true, true, true, fetched_lt_stored_lt_log, deviationThresholdNotExceeded},
+		{true, true, true, fetched_lt_log_lt_stored, deviationThresholdNotExceeded},
+		{true, true, true, log_lt_fetched_lt_stored, deviationThresholdNotExceeded},
+		{true, true, true, log_lt_stored_lt_fetched, deviationThresholdNotExceeded},
+		{true, true, true, stored_lt_fetched_eq_log, deviationThresholdNotExceeded},
+		{true, true, true, stored_eq_fetched_lt_log, deviationThresholdNotExceeded},
+		{true, true, true, stored_eq_log_lt_fetched, deviationThresholdNotExceeded},
+		{true, true, true, fetched_lt_stored_eq_log, deviationThresholdNotExceeded},
+		{true, true, true, fetched_eq_log_lt_stored, deviationThresholdNotExceeded},
+		{true, true, true, log_lt_fetched_eq_stored, deviationThresholdNotExceeded},
+		{true, true, false, stored_lt_fetched_lt_log, deviationThresholdExceeded},
+		{true, true, false, stored_lt_log_lt_fetched, deviationThresholdExceeded},
+		{true, true, false, fetched_lt_stored_lt_log, deviationThresholdExceeded},
+		{true, true, false, fetched_lt_log_lt_stored, deviationThresholdExceeded},
+		{true, true, false, log_lt_fetched_lt_stored, deviationThresholdExceeded},
+		{true, true, false, log_lt_stored_lt_fetched, deviationThresholdExceeded},
+		{true, true, false, stored_lt_fetched_eq_log, deviationThresholdExceeded},
+		{true, true, false, stored_eq_fetched_lt_log, deviationThresholdExceeded},
+		{true, true, false, stored_eq_log_lt_fetched, deviationThresholdExceeded},
+		{true, true, false, fetched_lt_stored_eq_log, deviationThresholdExceeded},
+		{true, true, false, fetched_eq_log_lt_stored, deviationThresholdExceeded},
+		{true, true, false, log_lt_fetched_eq_stored, deviationThresholdExceeded},
+		{true, true, false, stored_lt_fetched_lt_log, deviationThresholdNotExceeded},
+		{true, true, false, stored_lt_log_lt_fetched, deviationThresholdNotExceeded},
+		{true, true, false, fetched_lt_stored_lt_log, deviationThresholdNotExceeded},
+		{true, true, false, fetched_lt_log_lt_stored, deviationThresholdNotExceeded},
+		{true, true, false, log_lt_fetched_lt_stored, deviationThresholdNotExceeded},
+		{true, true, false, log_lt_stored_lt_fetched, deviationThresholdNotExceeded},
+		{true, true, false, stored_lt_fetched_eq_log, deviationThresholdNotExceeded},
+		{true, true, false, stored_eq_fetched_lt_log, deviationThresholdNotExceeded},
+		{true, true, false, stored_eq_log_lt_fetched, deviationThresholdNotExceeded},
+		{true, true, false, fetched_lt_stored_eq_log, deviationThresholdNotExceeded},
+		{true, true, false, fetched_eq_log_lt_stored, deviationThresholdNotExceeded},
+		{true, true, false, log_lt_fetched_eq_stored, deviationThresholdNotExceeded},
+		{true, false, true, stored_lt_fetched_lt_log, deviationThresholdExceeded},
+		{true, false, true, stored_lt_log_lt_fetched, deviationThresholdExceeded},
+		{true, false, true, fetched_lt_stored_lt_log, deviationThresholdExceeded},
+		{true, false, true, fetched_lt_log_lt_stored, deviationThresholdExceeded},
+		{true, false, true, log_lt_fetched_lt_stored, deviationThresholdExceeded},
+		{true, false, true, log_lt_stored_lt_fetched, deviationThresholdExceeded},
+		{true, false, true, stored_lt_fetched_eq_log, deviationThresholdExceeded},
+		{true, false, true, stored_eq_fetched_lt_log, deviationThresholdExceeded},
+		{true, false, true, stored_eq_log_lt_fetched, deviationThresholdExceeded},
+		{true, false, true, fetched_lt_stored_eq_log, deviationThresholdExceeded},
+		{true, false, true, fetched_eq_log_lt_stored, deviationThresholdExceeded},
+		{true, false, true, log_lt_fetched_eq_stored, deviationThresholdExceeded},
+		{true, false, true, stored_lt_fetched_lt_log, deviationThresholdNotExceeded},
+		{true, false, true, stored_lt_log_lt_fetched, deviationThresholdNotExceeded},
+		{true, false, true, fetched_lt_stored_lt_log, deviationThresholdNotExceeded},
+		{true, false, true, fetched_lt_log_lt_stored, deviationThresholdNotExceeded},
+		{true, false, true, log_lt_fetched_lt_stored, deviationThresholdNotExceeded},
+		{true, false, true, log_lt_stored_lt_fetched, deviationThresholdNotExceeded},
+		{true, false, true, stored_lt_fetched_eq_log, deviationThresholdNotExceeded},
+		{true, false, true, stored_eq_fetched_lt_log, deviationThresholdNotExceeded},
+		{true, false, true, stored_eq_log_lt_fetched, deviationThresholdNotExceeded},
+		{true, false, true, fetched_lt_stored_eq_log, deviationThresholdNotExceeded},
+		{true, false, true, fetched_eq_log_lt_stored, deviationThresholdNotExceeded},
+		{true, false, true, log_lt_fetched_eq_stored, deviationThresholdNotExceeded},
+		{true, false, false, stored_lt_fetched_lt_log, deviationThresholdExceeded},
+		{true, false, false, stored_lt_log_lt_fetched, deviationThresholdExceeded},
+		{true, false, false, fetched_lt_stored_lt_log, deviationThresholdExceeded},
+		{true, false, false, fetched_lt_log_lt_stored, deviationThresholdExceeded},
+		{true, false, false, log_lt_fetched_lt_stored, deviationThresholdExceeded},
+		{true, false, false, log_lt_stored_lt_fetched, deviationThresholdExceeded},
+		{true, false, false, stored_lt_fetched_eq_log, deviationThresholdExceeded},
+		{true, false, false, stored_eq_fetched_lt_log, deviationThresholdExceeded},
+		{true, false, false, stored_eq_log_lt_fetched, deviationThresholdExceeded},
+		{true, false, false, fetched_lt_stored_eq_log, deviationThresholdExceeded},
+		{true, false, false, fetched_eq_log_lt_stored, deviationThresholdExceeded},
+		{true, false, false, log_lt_fetched_eq_stored, deviationThresholdExceeded},
+		{true, false, false, stored_lt_fetched_lt_log, deviationThresholdNotExceeded},
+		{true, false, false, stored_lt_log_lt_fetched, deviationThresholdNotExceeded},
+		{true, false, false, fetched_lt_stored_lt_log, deviationThresholdNotExceeded},
+		{true, false, false, fetched_lt_log_lt_stored, deviationThresholdNotExceeded},
+		{true, false, false, log_lt_fetched_lt_stored, deviationThresholdNotExceeded},
+		{true, false, false, log_lt_stored_lt_fetched, deviationThresholdNotExceeded},
+		{true, false, false, stored_lt_fetched_eq_log, deviationThresholdNotExceeded},
+		{true, false, false, stored_eq_fetched_lt_log, deviationThresholdNotExceeded},
+		{true, false, false, stored_eq_log_lt_fetched, deviationThresholdNotExceeded},
+		{true, false, false, fetched_lt_stored_eq_log, deviationThresholdNotExceeded},
+		{true, false, false, fetched_eq_log_lt_stored, deviationThresholdNotExceeded},
+		{true, false, false, log_lt_fetched_eq_stored, deviationThresholdNotExceeded},
+		{false, true, true, stored_lt_fetched_lt_log, deviationThresholdExceeded},
+		{false, true, true, stored_lt_log_lt_fetched, deviationThresholdExceeded},
+		{false, true, true, fetched_lt_stored_lt_log, deviationThresholdExceeded},
+		{false, true, true, fetched_lt_log_lt_stored, deviationThresholdExceeded},
+		{false, true, true, log_lt_fetched_lt_stored, deviationThresholdExceeded},
+		{false, true, true, log_lt_stored_lt_fetched, deviationThresholdExceeded},
+		{false, true, true, stored_lt_fetched_eq_log, deviationThresholdExceeded},
+		{false, true, true, stored_eq_fetched_lt_log, deviationThresholdExceeded},
+		{false, true, true, stored_eq_log_lt_fetched, deviationThresholdExceeded},
+		{false, true, true, fetched_lt_stored_eq_log, deviationThresholdExceeded},
+		{false, true, true, fetched_eq_log_lt_stored, deviationThresholdExceeded},
+		{false, true, true, log_lt_fetched_eq_stored, deviationThresholdExceeded},
+		{false, true, true, stored_lt_fetched_lt_log, deviationThresholdNotExceeded},
+		{false, true, true, stored_lt_log_lt_fetched, deviationThresholdNotExceeded},
+		{false, true, true, fetched_lt_stored_lt_log, deviationThresholdNotExceeded},
+		{false, true, true, fetched_lt_log_lt_stored, deviationThresholdNotExceeded},
+		{false, true, true, log_lt_fetched_lt_stored, deviationThresholdNotExceeded},
+		{false, true, true, log_lt_stored_lt_fetched, deviationThresholdNotExceeded},
+		{false, true, true, stored_lt_fetched_eq_log, deviationThresholdNotExceeded},
+		{false, true, true, stored_eq_fetched_lt_log, deviationThresholdNotExceeded},
+		{false, true, true, stored_eq_log_lt_fetched, deviationThresholdNotExceeded},
+		{false, true, true, fetched_lt_stored_eq_log, deviationThresholdNotExceeded},
+		{false, true, true, fetched_eq_log_lt_stored, deviationThresholdNotExceeded},
+		{false, true, true, log_lt_fetched_eq_stored, deviationThresholdNotExceeded},
+		{false, true, false, stored_lt_fetched_lt_log, deviationThresholdExceeded},
+		{false, true, false, stored_lt_log_lt_fetched, deviationThresholdExceeded},
+		{false, true, false, fetched_lt_stored_lt_log, deviationThresholdExceeded},
+		{false, true, false, fetched_lt_log_lt_stored, deviationThresholdExceeded},
+		{false, true, false, log_lt_fetched_lt_stored, deviationThresholdExceeded},
+		{false, true, false, log_lt_stored_lt_fetched, deviationThresholdExceeded},
+		{false, true, false, stored_lt_fetched_eq_log, deviationThresholdExceeded},
+		{false, true, false, stored_eq_fetched_lt_log, deviationThresholdExceeded},
+		{false, true, false, stored_eq_log_lt_fetched, deviationThresholdExceeded},
+		{false, true, false, fetched_lt_stored_eq_log, deviationThresholdExceeded},
+		{false, true, false, fetched_eq_log_lt_stored, deviationThresholdExceeded},
+		{false, true, false, log_lt_fetched_eq_stored, deviationThresholdExceeded},
+		{false, true, false, stored_lt_fetched_lt_log, deviationThresholdNotExceeded},
+		{false, true, false, stored_lt_log_lt_fetched, deviationThresholdNotExceeded},
+		{false, true, false, fetched_lt_stored_lt_log, deviationThresholdNotExceeded},
+		{false, true, false, fetched_lt_log_lt_stored, deviationThresholdNotExceeded},
+		{false, true, false, log_lt_fetched_lt_stored, deviationThresholdNotExceeded},
+		{false, true, false, log_lt_stored_lt_fetched, deviationThresholdNotExceeded},
+		{false, true, false, stored_lt_fetched_eq_log, deviationThresholdNotExceeded},
+		{false, true, false, stored_eq_fetched_lt_log, deviationThresholdNotExceeded},
+		{false, true, false, stored_eq_log_lt_fetched, deviationThresholdNotExceeded},
+		{false, true, false, fetched_lt_stored_eq_log, deviationThresholdNotExceeded},
+		{false, true, false, fetched_eq_log_lt_stored, deviationThresholdNotExceeded},
+		{false, true, false, log_lt_fetched_eq_stored, deviationThresholdNotExceeded},
+		{false, false, true, stored_lt_fetched_lt_log, deviationThresholdExceeded},
+		{false, false, true, stored_lt_log_lt_fetched, deviationThresholdExceeded},
+		{false, false, true, fetched_lt_stored_lt_log, deviationThresholdExceeded},
+		{false, false, true, fetched_lt_log_lt_stored, deviationThresholdExceeded},
+		{false, false, true, log_lt_fetched_lt_stored, deviationThresholdExceeded},
+		{false, false, true, log_lt_stored_lt_fetched, deviationThresholdExceeded},
+		{false, false, true, stored_lt_fetched_eq_log, deviationThresholdExceeded},
+		{false, false, true, stored_eq_fetched_lt_log, deviationThresholdExceeded},
+		{false, false, true, stored_eq_log_lt_fetched, deviationThresholdExceeded},
+		{false, false, true, fetched_lt_stored_eq_log, deviationThresholdExceeded},
+		{false, false, true, fetched_eq_log_lt_stored, deviationThresholdExceeded},
+		{false, false, true, log_lt_fetched_eq_stored, deviationThresholdExceeded},
+		{false, false, true, stored_lt_fetched_lt_log, deviationThresholdNotExceeded},
+		{false, false, true, stored_lt_log_lt_fetched, deviationThresholdNotExceeded},
+		{false, false, true, fetched_lt_stored_lt_log, deviationThresholdNotExceeded},
+		{false, false, true, fetched_lt_log_lt_stored, deviationThresholdNotExceeded},
+		{false, false, true, log_lt_fetched_lt_stored, deviationThresholdNotExceeded},
+		{false, false, true, log_lt_stored_lt_fetched, deviationThresholdNotExceeded},
+		{false, false, true, stored_lt_fetched_eq_log, deviationThresholdNotExceeded},
+		{false, false, true, stored_eq_fetched_lt_log, deviationThresholdNotExceeded},
+		{false, false, true, stored_eq_log_lt_fetched, deviationThresholdNotExceeded},
+		{false, false, true, fetched_lt_stored_eq_log, deviationThresholdNotExceeded},
+		{false, false, true, fetched_eq_log_lt_stored, deviationThresholdNotExceeded},
+		{false, false, true, log_lt_fetched_eq_stored, deviationThresholdNotExceeded},
+		{false, false, false, stored_lt_fetched_lt_log, deviationThresholdExceeded},
+		{false, false, false, stored_lt_log_lt_fetched, deviationThresholdExceeded},
+		{false, false, false, fetched_lt_stored_lt_log, deviationThresholdExceeded},
+		{false, false, false, fetched_lt_log_lt_stored, deviationThresholdExceeded},
+		{false, false, false, log_lt_fetched_lt_stored, deviationThresholdExceeded},
+		{false, false, false, log_lt_stored_lt_fetched, deviationThresholdExceeded},
+		{false, false, false, stored_lt_fetched_eq_log, deviationThresholdExceeded},
+		{false, false, false, stored_eq_fetched_lt_log, deviationThresholdExceeded},
+		{false, false, false, stored_eq_log_lt_fetched, deviationThresholdExceeded},
+		{false, false, false, fetched_lt_stored_eq_log, deviationThresholdExceeded},
+		{false, false, false, fetched_eq_log_lt_stored, deviationThresholdExceeded},
+		{false, false, false, log_lt_fetched_eq_stored, deviationThresholdExceeded},
+		{false, false, false, stored_lt_fetched_lt_log, deviationThresholdNotExceeded},
+		{false, false, false, stored_lt_log_lt_fetched, deviationThresholdNotExceeded},
+		{false, false, false, fetched_lt_stored_lt_log, deviationThresholdNotExceeded},
+		{false, false, false, fetched_lt_log_lt_stored, deviationThresholdNotExceeded},
+		{false, false, false, log_lt_fetched_lt_stored, deviationThresholdNotExceeded},
+		{false, false, false, log_lt_stored_lt_fetched, deviationThresholdNotExceeded},
+		{false, false, false, stored_lt_fetched_eq_log, deviationThresholdNotExceeded},
+		{false, false, false, stored_eq_fetched_lt_log, deviationThresholdNotExceeded},
+		{false, false, false, stored_eq_log_lt_fetched, deviationThresholdNotExceeded},
+		{false, false, false, fetched_lt_stored_eq_log, deviationThresholdNotExceeded},
+		{false, false, false, fetched_eq_log_lt_stored, deviationThresholdNotExceeded},
+		{false, false, false, log_lt_fetched_eq_stored, deviationThresholdNotExceeded},
 	}
 
 	for _, test := range tests {
@@ -515,6 +642,12 @@ func TestPollingDeviationChecker_RespondToNewRound(t *testing.T) {
 		} else {
 			name += ", started by other"
 		}
+		if test.funded {
+			name += ", funded"
+		} else {
+			name += ", underfunded"
+		}
+
 		t.Run(name, func(t *testing.T) {
 			store, cleanup := cltest.NewStore(t)
 			defer cleanup()
@@ -522,7 +655,7 @@ func TestPollingDeviationChecker_RespondToNewRound(t *testing.T) {
 			nodeAddr := ensureAccount(t, store)
 
 			expectedToFetchRoundState := !test.startedBySelf
-			expectedToPoll := test.eligible && test.logRoundID >= int64(test.fetchedReportableRoundID) && expectedToFetchRoundState
+			expectedToPoll := expectedToFetchRoundState && test.eligible && test.funded && test.logRoundID >= int64(test.fetchedReportableRoundID)
 			expectedToSubmit := expectedToPoll
 
 			job := cltest.NewJobWithFluxMonitorInitiator()
@@ -534,11 +667,24 @@ func TestPollingDeviationChecker_RespondToNewRound(t *testing.T) {
 			fetcher := new(mocks.Fetcher)
 			fluxAggregator := new(mocks.FluxAggregator)
 
+			var availableFunds *assets.Link
+			var paymentAmount *assets.Link
+			minPayment := store.Config.MinimumContractPayment()
+			if test.funded {
+				availableFunds = minPayment
+				paymentAmount = minPayment
+			} else {
+				availableFunds = assets.NewLink(1)
+				paymentAmount = minPayment
+			}
+
 			if expectedToFetchRoundState {
 				fluxAggregator.On("RoundState", nodeAddr).Return(contracts.FluxAggregatorRoundState{
 					ReportableRoundID: test.fetchedReportableRoundID,
 					LatestAnswer:      big.NewInt(test.latestAnswer * int64(math.Pow10(int(initr.InitiatorParams.Precision)))),
 					EligibleToSubmit:  test.eligible,
+					AvailableFunds:    availableFunds,
+					PaymentAmount:     paymentAmount,
 				}, nil).Once()
 			}
 

--- a/core/utils/ethabi.go
+++ b/core/utils/ethabi.go
@@ -223,6 +223,17 @@ func EVMWordUint64(val uint64) []byte {
 	return word
 }
 
+// EVMWordUint128 returns a uint128 as an EVM word byte array.
+func EVMWordUint128(val *big.Int) ([]byte, error) {
+	bytes := val.Bytes()
+	if val.BitLen() > 128 {
+		return nil, fmt.Errorf("Overflow saving uint128 to EVM word: %v", val)
+	} else if val.Sign() == -1 {
+		return nil, fmt.Errorf("Invalid attempt to save negative value as uint128 to EVM word: %v", val)
+	}
+	return common.LeftPadBytes(bytes, EVMWordByteLen), nil
+}
+
 // EVMWordSignedBigInt returns a big.Int as an EVM word byte array, with
 // support for a signed representation. Returns error on overflow.
 func EVMWordSignedBigInt(val *big.Int) ([]byte, error) {

--- a/evm-contracts/src/v0.6/dev/FluxAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/FluxAggregator.sol
@@ -674,15 +674,24 @@ contract FluxAggregator is AggregatorInterface, Owned {
   function roundState(address _oracle)
     external
     view
-    returns (uint32 _reportableRoundId, bool _eligibleToSubmit, int256 _latestRoundAnswer, uint64 _timesOutAt)
+    returns (
+      uint32 _reportableRoundId,
+      bool _eligibleToSubmit,
+      int256 _latestRoundAnswer,
+      uint64 _timesOutAt,
+      uint128 _availableFunds,
+      uint128 _paymentAmount
+    )
   {
     bool finishedOrTimedOut = rounds[reportingRoundId].details.answers.length >= rounds[reportingRoundId].details.maxAnswers || timedOut(reportingRoundId);
-    uint32 reportableRoundId = finishedOrTimedOut ? reportingRoundId.add(1) : reportingRoundId;
+    _reportableRoundId = finishedOrTimedOut ? reportingRoundId.add(1) : reportingRoundId;
     return (
-      reportableRoundId,
-      eligibleToSubmit(_oracle, reportableRoundId, finishedOrTimedOut),
+      _reportableRoundId,
+      eligibleToSubmit(_oracle, _reportableRoundId, finishedOrTimedOut),
       rounds[latestRoundId].answer,
-      finishedOrTimedOut ? 0 : rounds[reportableRoundId].startedAt + rounds[reportableRoundId].details.timeout
+      finishedOrTimedOut ? 0 : rounds[_reportableRoundId].startedAt + rounds[_reportableRoundId].details.timeout,
+      availableFunds,
+      rounds[_reportableRoundId].details.paymentAmount
     );
   }
 


### PR DESCRIPTION
Ensure there are enough funds available to node operator payments.

 - Is config.MinimumContractPayment the correct to use for the Flux Monitor?
 - How to retrieve Link from the Contract?  I've assumed we can scan the uint128 into a big int.  The TxManager(ethClient) uses a string for some reason:
https://github.com/smartcontractkit/chainlink/blob/develop/core/eth/client.go#L99
 - Needs additional testing, hoping to ping @spooktheducks 

https://www.pivotaltracker.com/story/show/171515563