### PR TITLE
Make models.AnyTime compat. with Golang v14

### DIFF
--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -326,17 +326,21 @@ func (t AnyTime) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON parses the raw time stored in JSON-encoded
 // data and stores it to the Time field.
 func (t *AnyTime) UnmarshalJSON(b []byte) error {
+	var str string
+
 	var n json.Number
-	if err := json.Unmarshal(b, &n); err != nil {
+	if err := json.Unmarshal(b, &n); err == nil {
+		str = n.String()
+	} else if err := json.Unmarshal(b, &str); err != nil {
 		return err
 	}
 
-	if len(n) == 0 {
+	if len(str) == 0 {
 		t.Valid = false
 		return nil
 	}
 
-	newTime, err := dateparse.ParseAny(n.String())
+	newTime, err := dateparse.ParseAny(str)
 	t.Time = newTime.UTC()
 	t.Valid = true
 	return err

--- a/core/store/models/common_test.go
+++ b/core/store/models/common_test.go
@@ -307,6 +307,7 @@ func TestAnyTime_UnmarshalJSON_Error(t *testing.T) {
 		input string
 	}{
 		{"invalid string", `"1000h"`},
+		{"float", `"1000.123"`},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/core/store/models/common_test.go
+++ b/core/store/models/common_test.go
@@ -278,54 +278,41 @@ func TestWebURL_String_HasNilURL(t *testing.T) {
 
 func TestAnyTime_UnmarshalJSON_Valid(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		want    time.Time
-		errored bool
+		name  string
+		input string
+		want  time.Time
 	}{
-		{"unix string", `"1529445491"`, time.Unix(1529445491, 0).UTC(), false},
-		{"unix int", `1529445491`, time.Unix(1529445491, 0).UTC(), false},
-		{"iso8601 time", `"2018-06-19T22:17:19Z"`, time.Unix(1529446639, 0).UTC(), false},
-		{"iso8601 date", `"2018-06-19"`, time.Unix(1529366400, 0).UTC(), false},
-		{"iso8601 year", `"2018"`, time.Unix(1514764800, 0).UTC(), false},
-		{"invalid string", `"1000h"`, time.Now(), true},
+		{"unix string", `"1529445491"`, time.Unix(1529445491, 0).UTC()},
+		{"unix int", `1529445491`, time.Unix(1529445491, 0).UTC()},
+		{"iso8601 time", `"2018-06-19T22:17:19Z"`, time.Unix(1529446639, 0).UTC()},
+		{"iso8601 date", `"2018-06-19"`, time.Unix(1529366400, 0).UTC()},
+		{"iso8601 year", `"2018"`, time.Unix(1514764800, 0).UTC()},
+		{"null", `null`, time.Time{}},
+		{"empty", `""`, time.Time{}},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var actual models.AnyTime
 			err := json.Unmarshal([]byte(test.input), &actual)
-			if test.errored {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, test.want, actual.Time)
-			}
+			require.NoError(t, err)
+			assert.Equal(t, test.want, actual.Time)
 		})
 	}
 }
 
-func TestAnyTime_UnmarshalJSON_Null(t *testing.T) {
+func TestAnyTime_UnmarshalJSON_Error(t *testing.T) {
 	tests := []struct {
-		name    string
-		input   string
-		want    models.AnyTime
-		errored bool
+		name  string
+		input string
 	}{
-		{"null", `null`, models.AnyTime{}, false},
-		{"empty", `""`, models.AnyTime{}, false},
+		{"invalid string", `"1000h"`},
 	}
-
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			var actual models.AnyTime
 			err := json.Unmarshal([]byte(test.input), &actual)
-			if test.errored {
-				assert.Error(t, err)
-			} else {
-				assert.NoError(t, err)
-				assert.Equal(t, test.want, actual)
-			}
+			assert.Error(t, err)
 		})
 	}
 }


### PR DESCRIPTION
Fix AnyTime's JSON unmarshalling which relied on an older versions of
Golang where json.Number was more lenient on what it would accept.

```
json: invalid number literal, trying to unmarshal "\"2018-06-19T22:17:19Z\"" into Number
```

https://golang.org/doc/go1.14

"Number no longer accepts invalid numbers, to follow the documented behavior more closely. If a program needs to accept invalid numbers like the empty string, consider wrapping the type with Unmarshaler."

https://www.pivotaltracker.com/story/show/172000463