### PR TITLE
Big numbers should be encoded as string

### DIFF
--- a/core/utils/big.go
+++ b/core/utils/big.go
@@ -61,7 +61,11 @@ func (b *Big) MarshalText() ([]byte, error) {
 
 // MarshalJSON marshals this instance to base 10 number as string.
 func (b *Big) MarshalJSON() ([]byte, error) {
-	return b.MarshalText()
+	text, err := b.MarshalText()
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(string(text))
 }
 
 // UnmarshalText implements encoding.TextUnmarshaler.


### PR DESCRIPTION
Avoid precision loss in poor JSON decoders, and float JSON number
implementations.

It was always supposed to work this way, but ... doesn't.