### PR TITLE
Better error messages for golang wrapper dependency issues

### DIFF
--- a/core/services/vrf/go_generate_test.go
+++ b/core/services/vrf/go_generate_test.go
@@ -223,6 +223,9 @@ func compileCommand(t *testing.T) string {
 	return strings.Trim(string(cmd), "\n")
 }
 
+// boxOutput formats its arguments as fmt.Printf, and encloses them in a box of
+// arrows pointing at their content, in order to better highlight it. See
+// ExampleBoxOutput
 func boxOutput(s string, args ...interface{}) string {
 	s = fmt.Sprintf(s, args...)
 	lines := strings.Split(s, "\n")
@@ -246,4 +249,19 @@ func boxOutput(s string, args ...interface{}) string {
 	rv += "→  " + strings.Repeat(" ", maxlen) + "  ←\n"
 	return "\n" + rv + "↗" + strings.Repeat("↑", internalLength) + "↖" + // bottom line
 		"\n\n"
+}
+
+func ExampleBoxOutput() {
+	fmt.Println()
+	fmt.Print(boxOutput("%s is %d", "foo", 17))
+	// Output:
+	// ↘↓↓↓↓↓↓↓↓↓↓↓↓↓↙
+	// →             ←
+	// →  README     ←
+	// →             ←
+	// →  foo is 17  ←
+	// →             ←
+	// →  README     ←
+	// →             ←
+	// ↗↑↑↑↑↑↑↑↑↑↑↑↑↑↖
 }

--- a/core/services/vrf/go_generate_test.go
+++ b/core/services/vrf/go_generate_test.go
@@ -226,9 +226,9 @@ func compileCommand(t *testing.T) string {
 // boxOutput formats its arguments as fmt.Printf, and encloses them in a box of
 // arrows pointing at their content, in order to better highlight it. See
 // ExampleBoxOutput
-func boxOutput(s string, args ...interface{}) string {
-	s = fmt.Sprintf(s, args...)
-	lines := strings.Split(s, "\n")
+func boxOutput(errorMsgTemplate string, errorMsgValues ...interface{}) string {
+	errorMsgTemplate = fmt.Sprintf(errorMsgTemplate, errorMsgValues...)
+	lines := strings.Split(errorMsgTemplate, "\n")
 	maxlen := 0
 	for _, line := range lines {
 		if len(line) > maxlen {
@@ -236,18 +236,18 @@ func boxOutput(s string, args ...interface{}) string {
 		}
 	}
 	internalLength := maxlen + 4
-	rv := "↘" + strings.Repeat("↓", internalLength) + "↙\n" // top line
-	rv += "→  " + strings.Repeat(" ", maxlen) + "  ←\n"
+	output := "↘" + strings.Repeat("↓", internalLength) + "↙\n" // top line
+	output += "→  " + strings.Repeat(" ", maxlen) + "  ←\n"
 	readme := strings.Repeat("README ", maxlen/7)
-	rv += "→  " + readme + strings.Repeat(" ", maxlen-len(readme)) + "  ←\n"
-	rv += "→  " + strings.Repeat(" ", maxlen) + "  ←\n"
+	output += "→  " + readme + strings.Repeat(" ", maxlen-len(readme)) + "  ←\n"
+	output += "→  " + strings.Repeat(" ", maxlen) + "  ←\n"
 	for _, line := range lines {
-		rv += "→  " + line + strings.Repeat(" ", maxlen-len(line)) + "  ←\n"
+		output += "→  " + line + strings.Repeat(" ", maxlen-len(line)) + "  ←\n"
 	}
-	rv += "→  " + strings.Repeat(" ", maxlen) + "  ←\n"
-	rv += "→  " + readme + strings.Repeat(" ", maxlen-len(readme)) + "  ←\n"
-	rv += "→  " + strings.Repeat(" ", maxlen) + "  ←\n"
-	return "\n" + rv + "↗" + strings.Repeat("↑", internalLength) + "↖" + // bottom line
+	output += "→  " + strings.Repeat(" ", maxlen) + "  ←\n"
+	output += "→  " + readme + strings.Repeat(" ", maxlen-len(readme)) + "  ←\n"
+	output += "→  " + strings.Repeat(" ", maxlen) + "  ←\n"
+	return "\n" + output + "↗" + strings.Repeat("↑", internalLength) + "↖" + // bottom line
 		"\n\n"
 }
 


### PR DESCRIPTION
These error messages contain shell commands which should be run in order to
bring the golang wrappers into line with the current solidity contracts and the
current geth version. Those instructions were easy to miss in the error output,
which was blocking people. This changes the output highlight the instructions.