### PR TITLE
Flux monitor test should fail on ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -424,9 +424,7 @@ workflows:
             - go-postgres
             - solidity
             - geth-postgres
-            - geth-postgres-ts
             - parity-postgres
-            - parity-postgres-ts
             - styleguide
             - json-api-client
             - operator-ui

--- a/tools/ci-ts/tests/flux-monitor.test.ts
+++ b/tools/ci-ts/tests/flux-monitor.test.ts
@@ -15,6 +15,7 @@ const {
   CLIENT_NODE_2_URL,
   EXTERNAL_ADAPTER_URL,
   EXTERNAL_ADAPTER_2_URL,
+  MINIMUM_CONTRACT_PAYMENT,
 } = t.getEnvVars([
   'NODE_1_CONTAINER',
   'NODE_2_CONTAINER',
@@ -22,6 +23,7 @@ const {
   'CLIENT_NODE_2_URL',
   'EXTERNAL_ADAPTER_URL',
   'EXTERNAL_ADAPTER_2_URL',
+  'MINIMUM_CONTRACT_PAYMENT',
 ])
 
 const provider = t.createProvider()
@@ -116,7 +118,7 @@ beforeEach(async () => {
   fluxMonitorJob = JSON.parse(JSON.stringify(fluxMonitorJobTemplate)) // perform a deep clone
   fluxAggregator = await fluxAggregatorFactory.deploy(
     linkToken.address,
-    1,
+    MINIMUM_CONTRACT_PAYMENT,
     10,
     1,
     ethers.utils.formatBytes32String('ETH/USD'),

--- a/tools/docker/compose
+++ b/tools/docker/compose
@@ -119,12 +119,14 @@ case "$1" in
     $deps up --exit-code-from wait-db wait-db
     $deps up --exit-code-from wait-db-2 wait-db-2
     set +e
-    $ts_test run integration-ts /bin/sh -c \
+    $dev_ts_integration run integration-ts /bin/sh -c \
       "docker cp chainlink-node:/usr/local/bin/chainlink /usr/local/bin/chainlink \
       && yarn workspace @chainlink/ci-ts test --runInBand ${@:2}"
+    exit_code=$?
     set -e
     save_test_logs
     $ts_test down -v
+    exit $exit_code
     ;;
   test:ts:dev)
     $deps up --exit-code-from wait-db wait-db
@@ -133,9 +135,11 @@ case "$1" in
     $dev_ts_integration run integration-ts /bin/sh -c \
       "docker cp chainlink-node:/usr/local/bin/chainlink /usr/local/bin/chainlink \
       && yarn workspace @chainlink/ci-ts test --verbose --runInBand ${@:2}"
+    exit_code=$?
     set -e
     save_test_logs
     $dev_ts_integration down -v
+    exit $exit_code
     ;;
   integration | i)
     $test ${@:2}

--- a/tools/docker/docker-compose.ts-integration.yaml
+++ b/tools/docker/docker-compose.ts-integration.yaml
@@ -18,17 +18,18 @@ services:
       - external-adapter
       - external-adapter-2
     environment:
-      - SRCROOT
-      - GETH_MODE
       - CHAINLINK_DEV=TRUE # need this for service agreements subcommand
       - CHAINLINK_URL
+      - CLIENT_NODE_URL # used to send remote commands
+      - CLIENT_NODE_2_URL
       - ETH_HTTP_URL
       - EXTERNAL_ADAPTER_URL
-      - CLIENT_NODE_URL # used to send remote commands
+      - EXTERNAL_ADAPTER_2_URL
+      - GETH_MODE
+      - MINIMUM_CONTRACT_PAYMENT
       - NODE_1_CONTAINER
       - NODE_2_CONTAINER
-      - CLIENT_NODE_2_URL
-      - EXTERNAL_ADAPTER_2_URL
+      - SRCROOT
     secrets:
       - apicredentials
 


### PR DESCRIPTION
All CI tests were passing because the the jest tests were wrapped in `set +e`

This PR makes the exit code of `compost test:ts` that of the jest test

It also makes the test use `MINIMUM_CONTRACT_PAYMENT` env var, squashing an easy bug

Firstly identified, is this [bug](https://www.pivotaltracker.com/story/show/172085379)