### PR TITLE
rename methods to avoid interface confusion

### DIFF
--- a/evm-contracts/src/v0.6/dev/FluxAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/FluxAggregator.sol
@@ -397,7 +397,7 @@ contract FluxAggregator is AggregatorInterface, Owned {
   /**
    * @notice query the available amount of LINK for an oracle to withdraw
    */
-  function withdrawable(address _oracle)
+  function withdrawablePayment(address _oracle)
     external
     view
     returns (uint256)
@@ -412,7 +412,7 @@ contract FluxAggregator is AggregatorInterface, Owned {
    * @param _recipient is the address to send the LINK to
    * @param _amount is the amount of LINK to send
    */
-  function withdraw(address _oracle, address _recipient, uint256 _amount)
+  function withdrawPayment(address _oracle, address _recipient, uint256 _amount)
     external
   {
     require(oracles[_oracle].admin == msg.sender);

--- a/evm-contracts/test/v0.6/FluxAggregator.test.ts
+++ b/evm-contracts/test/v0.6/FluxAggregator.test.ts
@@ -84,10 +84,11 @@ describe('FluxAggregator', () => {
 
   it('has a limited public interface', () => {
     matchers.publicAbi(fluxAggregatorFactory, [
-      'addOracle',
       'acceptAdmin',
+      'addOracle',
       'allocatedFunds',
       'availableFunds',
+      'decimals',
       'description',
       'getAdmin',
       'getAnswer',
@@ -105,22 +106,21 @@ describe('FluxAggregator', () => {
       'onTokenTransfer',
       'oracleCount',
       'paymentAmount',
-      'decimals',
       'removeOracle',
       'reportingRound',
       'reportingRoundStartedAt',
       'restartDelay',
       'roundState',
+      'setAuthorization',
       'startNewRound',
       'timeout',
       'transferAdmin',
       'updateAnswer',
       'updateAvailableFunds',
       'updateFutureRounds',
-      'setAuthorization',
-      'withdraw',
       'withdrawFunds',
-      'withdrawable',
+      'withdrawPayment',
+      'withdrawablePayment',
       'VERSION',
       // Owned methods:
       'acceptOwnership',
@@ -230,7 +230,7 @@ describe('FluxAggregator', () => {
           0,
           await aggregator
             .connect(personas.Neil)
-            .withdrawable(personas.Neil.address),
+            .withdrawablePayment(personas.Neil.address),
         )
 
         await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
@@ -239,19 +239,19 @@ describe('FluxAggregator', () => {
           paymentAmount,
           await aggregator
             .connect(personas.Neil)
-            .withdrawable(personas.Neil.address),
+            .withdrawablePayment(personas.Neil.address),
         )
         matchers.bigNum(
           0,
           await aggregator
             .connect(personas.Ned)
-            .withdrawable(personas.Ned.address),
+            .withdrawablePayment(personas.Ned.address),
         )
         matchers.bigNum(
           0,
           await aggregator
             .connect(personas.Nelly)
-            .withdrawable(personas.Nelly.address),
+            .withdrawablePayment(personas.Nelly.address),
         )
       })
 
@@ -440,13 +440,13 @@ describe('FluxAggregator', () => {
           0,
           await aggregator
             .connect(personas.Neil)
-            .withdrawable(personas.Neil.address),
+            .withdrawablePayment(personas.Neil.address),
         )
         matchers.bigNum(
           0,
           await aggregator
             .connect(personas.Nelly)
-            .withdrawable(personas.Nelly.address),
+            .withdrawablePayment(personas.Nelly.address),
         )
 
         await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
@@ -459,13 +459,13 @@ describe('FluxAggregator', () => {
           paymentAmount,
           await aggregator
             .connect(personas.Neil)
-            .withdrawable(personas.Neil.address),
+            .withdrawablePayment(personas.Neil.address),
         )
         matchers.bigNum(
           paymentAmount,
           await aggregator
             .connect(personas.Nelly)
-            .withdrawable(personas.Nelly.address),
+            .withdrawablePayment(personas.Nelly.address),
         )
       })
     })
@@ -1501,7 +1501,7 @@ describe('FluxAggregator', () => {
     })
   })
 
-  describe('#withdraw', () => {
+  describe('#withdrawPayment', () => {
     beforeEach(async () => {
       await aggregator
         .connect(personas.Carol)
@@ -1521,7 +1521,11 @@ describe('FluxAggregator', () => {
 
       await aggregator
         .connect(personas.Neil)
-        .withdraw(personas.Neil.address, personas.Neil.address, paymentAmount)
+        .withdrawPayment(
+          personas.Neil.address,
+          personas.Neil.address,
+          paymentAmount,
+        )
 
       matchers.bigNum(
         originalBalance.sub(paymentAmount),
@@ -1538,7 +1542,11 @@ describe('FluxAggregator', () => {
 
       await aggregator
         .connect(personas.Neil)
-        .withdraw(personas.Neil.address, personas.Neil.address, paymentAmount)
+        .withdrawPayment(
+          personas.Neil.address,
+          personas.Neil.address,
+          paymentAmount,
+        )
 
       matchers.bigNum(
         originalAllocation.sub(paymentAmount),
@@ -1551,7 +1559,7 @@ describe('FluxAggregator', () => {
         await matchers.evmRevert(
           aggregator
             .connect(personas.Neil)
-            .withdraw(
+            .withdrawPayment(
               personas.Neil.address,
               personas.Neil.address,
               paymentAmount.add(ethers.utils.bigNumberify(1)),
@@ -1565,7 +1573,7 @@ describe('FluxAggregator', () => {
         await matchers.evmRevert(
           aggregator
             .connect(personas.Nelly)
-            .withdraw(
+            .withdrawPayment(
               personas.Neil.address,
               personas.Nelly.address,
               ethers.utils.bigNumberify(1),

--- a/evm-contracts/test/v0.6/WhitelistedAggregator.test.ts
+++ b/evm-contracts/test/v0.6/WhitelistedAggregator.test.ts
@@ -55,11 +55,12 @@ describe('WhitelistedAggregator', () => {
 
   it('has a limited public interface', () => {
     matchers.publicAbi(aggregatorFactory, [
-      'addOracle',
       'acceptAdmin',
+      'addOracle',
       'addToWhitelist',
       'allocatedFunds',
       'availableFunds',
+      'decimals',
       'description',
       'getAdmin',
       'getAnswer',
@@ -77,7 +78,6 @@ describe('WhitelistedAggregator', () => {
       'onTokenTransfer',
       'oracleCount',
       'paymentAmount',
-      'decimals',
       'removeFromWhitelist',
       'removeOracle',
       'reportingRound',
@@ -92,9 +92,9 @@ describe('WhitelistedAggregator', () => {
       'updateAvailableFunds',
       'updateFutureRounds',
       'whitelisted',
-      'withdraw',
       'withdrawFunds',
-      'withdrawable',
+      'withdrawPayment',
+      'withdrawablePayment',
       'VERSION',
       // Owned methods:
       'acceptOwnership',


### PR DESCRIPTION
witdraw => withdrawPayment
withdrawable => withdrawablePayment

`availableFunds` was taken.