### PR TITLE
Use jsonb instead of text for json columns

### DIFF
--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -308,7 +308,7 @@ func TestRunManager_Create_DoesNotSaveToTaskSpec(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, job.Tasks, 1)
 	require.Len(t, retrievedJob.Tasks, 1)
-	assert.Equal(t, job.Tasks[0].Params, retrievedJob.Tasks[0].Params)
+	assert.JSONEq(t, job.Tasks[0].Params.String(), retrievedJob.Tasks[0].Params.String())
 }
 
 func TestRunManager_Create_fromRunLog_Happy(t *testing.T) {

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -34,6 +34,7 @@ import (
 	"chainlink/core/store/migrations/migration1580904019"
 	"chainlink/core/store/migrations/migration1581240419"
 	"chainlink/core/store/migrations/migration1584377646"
+	"chainlink/core/store/migrations/migration1585908150"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -175,6 +176,10 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "1584377646",
 			Migrate: migration1584377646.Migrate,
+		},
+		{
+			ID:      "1585908150",
+			Migrate: migration1585908150.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration1585908150/migrate.go
+++ b/core/store/migrations/migration1585908150/migrate.go
@@ -1,0 +1,23 @@
+package migration1585908150
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate changes all json columns to be jsonb
+func Migrate(tx *gorm.DB) error {
+	err := tx.Exec(`
+		ALTER TABLE initiators ALTER COLUMN params TYPE jsonb USING params::jsonb;
+		ALTER TABLE keys ALTER COLUMN json TYPE jsonb USING json::jsonb;
+		ALTER TABLE run_requests ALTER COLUMN request_params DROP DEFAULT;
+		ALTER TABLE run_requests ALTER COLUMN request_params TYPE jsonb USING request_params::jsonb;
+		ALTER TABLE run_requests ALTER COLUMN request_params SET DEFAULT '{}'::jsonb;
+		ALTER TABLE run_results ALTER COLUMN data TYPE jsonb USING data::jsonb;
+		ALTER TABLE task_specs ALTER COLUMN params TYPE jsonb USING params::jsonb;
+	`).Error
+	// More migrations will be added here...
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -130,7 +130,7 @@ type JSON struct {
 
 // Value returns this instance serialized for database storage.
 func (j JSON) Value() (driver.Value, error) {
-	s := j.String()
+	s := j.Bytes()
 	if len(s) == 0 {
 		return nil, nil
 	}
@@ -139,12 +139,14 @@ func (j JSON) Value() (driver.Value, error) {
 
 // Scan reads the database value and returns an instance.
 func (j *JSON) Scan(value interface{}) error {
-	temp, ok := value.(string)
-	if !ok {
+	switch v := value.(type) {
+	case string:
+		*j = JSON{Result: gjson.Parse(v)}
+	case []byte:
+		*j = JSON{Result: gjson.ParseBytes(v)}
+	default:
 		return fmt.Errorf("Unable to convert %v of %T to JSON", value, value)
 	}
-
-	*j = JSON{Result: gjson.Parse(temp)}
 	return nil
 }
 

--- a/core/store/store_test.go
+++ b/core/store/store_test.go
@@ -72,7 +72,7 @@ func TestStore_SyncDiskKeyStoreToDB_HappyPath(t *testing.T) {
 	// assert contents are the same
 	content, err := utils.FileContents(filepath.Join(app.Config.KeysDir(), files[0]))
 	require.NoError(t, err)
-	require.Equal(t, keys[0].JSON.String(), content)
+	require.JSONEq(t, keys[0].JSON.String(), content)
 }
 
 func TestStore_SyncDiskKeyStoreToDB_MultipleKeys(t *testing.T) {
@@ -120,7 +120,7 @@ func TestStore_SyncDiskKeyStoreToDB_MultipleKeys(t *testing.T) {
 		require.NoError(t, err)
 
 		payloadAddress := gjson.Parse(content).Get("address").String()
-		require.Equal(t, content, payloads[payloadAddress])
+		require.JSONEq(t, content, payloads[payloadAddress])
 	}
 }
 


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/172080031

Merging into feature branch instead of develop. I will put all the DB improvements into chore/overhaul-db-schema branch so we can review them together before a final merge into develop.

NOTE:

On copy of chainlink prod node:
```
		ALTER TABLE initiators ALTER COLUMN params TYPE jsonb USING params::jsonb;
		ALTER TABLE keys ALTER COLUMN json TYPE jsonb USING json::jsonb;
		ALTER TABLE run_requests ALTER COLUMN request_params DROP DEFAULT;
		ALTER TABLE run_requests ALTER COLUMN request_params TYPE jsonb USING request_params::jsonb;
		ALTER TABLE run_requests ALTER COLUMN request_params SET DEFAULT '{}'::jsonb;
		ALTER TABLE run_results ALTER COLUMN data TYPE jsonb USING data::jsonb;
		ALTER TABLE task_specs ALTER COLUMN params TYPE jsonb USING params::jsonb;
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=14.941350274
```

Table size increased slightly (about 10%).