### PR TITLE
Add some missing indexes and optimise existing ones

### DIFF
--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -34,6 +34,7 @@ import (
 	"chainlink/core/store/migrations/migration1580904019"
 	"chainlink/core/store/migrations/migration1581240419"
 	"chainlink/core/store/migrations/migration1584377646"
+	"chainlink/core/store/migrations/migration1585918589"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -175,6 +176,10 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "1584377646",
 			Migrate: migration1584377646.Migrate,
+		},
+		{
+			ID:      "1585918589",
+			Migrate: migration1585918589.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration1585918589/migrate.go
+++ b/core/store/migrations/migration1585918589/migrate.go
@@ -1,0 +1,69 @@
+package migration1585918589
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate creates and optimises table indexes
+func Migrate(tx *gorm.DB) error {
+	// I can't believe we were missing this one
+	// Need `if not exists` because I created it manually on the kovan util node
+	err := tx.Exec(`
+	CREATE INDEX IF NOT EXISTS idx_task_runs_job_run_id ON task_runs(job_run_id);
+	`).Error
+	if err != nil {
+		return err
+	}
+
+	err = tx.Exec(`
+	CREATE INDEX idx_job_runs_job_spec_id ON job_runs(job_spec_id);
+	`).Error
+	if err != nil {
+		return err
+	}
+
+	// FIXME: This should ideally be unique but there exists non-unique data out in the wild so need to handle that...
+	err = tx.Exec(`
+	CREATE INDEX idx_txs_hash ON tx_attempts(hash);
+	`).Error
+	if err != nil {
+		return err
+	}
+
+	// The majority of runs are completed so there is no point in indexing those ones.
+	// We can reduce the size of the index by excluding this status
+	err = tx.Exec(`
+	DROP INDEX idx_job_runs_status;
+	CREATE INDEX idx_job_runs_status ON job_runs(status) WHERE status != 'completed';
+	`).Error
+	if err != nil {
+		return err
+	}
+
+	// Brin indexes offer much more efficient storage for time series data on large tables
+	return tx.Exec(`
+	DROP INDEX idx_task_runs_created_at;
+	CREATE INDEX idx_task_runs_created_at ON task_runs USING BRIN (created_at);
+
+	DROP INDEX idx_job_runs_created_at;
+	CREATE INDEX idx_job_runs_created_at ON job_runs USING BRIN (created_at);
+
+	CREATE INDEX idx_job_runs_updated_at ON job_runs USING BRIN (updated_at);
+
+	CREATE INDEX idx_job_runs_finished_at ON job_runs USING BRIN (finished_at);
+
+	DROP INDEX idx_job_runs_deleted_at;
+	CREATE INDEX idx_job_runs_deleted_at ON job_runs USING BRIN (deleted_at);
+
+	DROP INDEX idx_sessions_last_used;
+	CREATE INDEX idx_sessions_last_used ON sessions USING BRIN (last_used);
+
+	DROP INDEX idx_sessions_created_at;
+	CREATE INDEX idx_sessions_created_at ON sessions USING BRIN (created_at);
+
+	DROP INDEX idx_tx_attempts_created_at;
+	CREATE INDEX idx_tx_attempts_created_at ON tx_attempts USING BRIN (created_at);
+
+	CREATE INDEX idx_run_requests_created_at ON run_requests USING BRIN (created_at);
+	`).Error
+}


### PR DESCRIPTION
See: https://www.pivotaltracker.com/story/show/172080031

The main one is the index on `task_runs.job_run_id`

WITHOUT INDEX

```
Sort  (cost=92131.66..92131.68 rows=7 width=81) (actual time=2593.549..2593.549 rows=0 loops=1)
  Sort Key: task_spec_id, id
  Sort Method: quicksort  Memory: 25kB
  ->  Seq Scan on task_runs  (cost=0.00..92131.56 rows=7 width=81) (actual time=2593.526..2593.526 rows=0 loops=1)
        Filter: (job_run_id = '8cb11682-3696-4708-b7b2-d4da19af631e'::uuid)
        Rows Removed by Filter: 479090
Planning time: 6.829 ms
Execution time: 2593.578 ms
```

WITH INDEX

```
Sort  (cost=8.45..8.45 rows=1 width=81) (actual time=4.128..4.128 rows=0 loops=1)
  Sort Key: task_spec_id, id
  Sort Method: quicksort  Memory: 25kB
  ->  Index Scan using idx_task_runs_job_run_id on task_runs  (cost=0.42..8.44 rows=1 width=81) (actual time=4.106..4.107 rows=0 loops=1)
        Index Cond: (job_run_id = '8cb11682-3696-4708-b7b2-d4da19af631e'::uuid)
Planning time: 4.871 ms
Execution time: 4.153 ms
```

We run this scan many times per head and without indexes it is extremely expensive.

Adding the indexes is fast:
```
2020-04-03T16:54:19Z [DEBUG]
	CREATE INDEX IF NOT EXISTS idx_task_runs_job_run_id ON task_runs(job_run_id);
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=0.289358959
2020-04-03T16:54:19Z [DEBUG]
	CREATE INDEX idx_job_runs_job_spec_id ON job_runs(job_spec_id);
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=0.072376174
2020-04-03T16:54:19Z [DEBUG]
	CREATE INDEX idx_txs_hash ON tx_attempts(hash);
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=0.105515263
2020-04-03T16:54:19Z [DEBUG]
	DROP INDEX idx_job_runs_status;
	CREATE INDEX idx_job_runs_status ON job_runs(status) WHERE status != 'completed';
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=0.011730034
2020-04-03T16:54:19Z [DEBUG]
	DROP INDEX idx_task_runs_created_at;
	CREATE INDEX idx_task_runs_created_at ON task_runs USING BRIN (created_at);

	DROP INDEX idx_job_runs_created_at;
	CREATE INDEX idx_job_runs_created_at ON job_runs USING BRIN (created_at);

	CREATE INDEX idx_job_runs_updated_at ON job_runs USING BRIN (updated_at);

	CREATE INDEX idx_job_runs_finished_at ON job_runs USING BRIN (finished_at);

	DROP INDEX idx_job_runs_deleted_at;
	CREATE INDEX idx_job_runs_deleted_at ON job_runs USING BRIN (deleted_at);

	DROP INDEX idx_sessions_last_used;
	CREATE INDEX idx_sessions_last_used ON sessions USING BRIN (last_used);

	DROP INDEX idx_sessions_created_at;
	CREATE INDEX idx_sessions_created_at ON sessions USING BRIN (created_at);

	DROP INDEX idx_tx_attempts_created_at;
	CREATE INDEX idx_tx_attempts_created_at ON tx_attempts USING BRIN (created_at);

	CREATE INDEX idx_run_requests_created_at ON run_requests USING BRIN (created_at);
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=0.18809031
```