### PR TITLE
Fixing of miscellaneous typos

### DIFF
--- a/core/cmd/local_client_vrf.go
+++ b/core/cmd/local_client_vrf.go
@@ -44,7 +44,7 @@ chainlink local vrf export -f <save_path> -pk %s
 // CreateAndExportWeakVRFKey creates a key in the VRF keystore, protected by the
 // password in the password file, but with weak key-derivation-function
 // parameters, which makes it cheaper for testing, but also more vulnerable to
-// bruteforcing of the encyrpted key material. For testing purposes only!
+// bruteforcing of the encrypted key material. For testing purposes only!
 //
 // The key is only stored at the specified file location, not stored in the DB.
 func (cli *Client) CreateAndExportWeakVRFKey(c *clipkg.Context) error {

--- a/core/services/vrf/vrf_coordinator_solidity_crosscheck_test.go
+++ b/core/services/vrf/vrf_coordinator_solidity_crosscheck_test.go
@@ -250,7 +250,7 @@ func TestFulfillRandomness(t *testing.T) {
 	assert.Equal(t, randomnessRequestLog.RequestID(), common.Hash(requestID), "VRFConsumer has different request ID than logged from randomness request!")
 	neilBalance, err := coordinator.rootContract.WithdrawableTokens(
 		nil, coordinator.neil.From)
-	require.NoError(t, err, "failed to get neil's token balance, after he successfully fullfilled a randomness request")
+	require.NoError(t, err, "failed to get neil's token balance, after he successfully fulfilled a randomness request")
 	assert.True(t, equal(neilBalance, fee), "neil's balance on VRFCoordinator was not paid his fee, despite succesfull fulfillment of randomness request!")
 }
 

--- a/core/services/vrf/vrf_solidity_crosscheck_test.go
+++ b/core/services/vrf/vrf_solidity_crosscheck_test.go
@@ -367,7 +367,7 @@ func TestVRF_MarshalProof(t *testing.T) {
 		mproof[corruptionTargetByte] += 1
 		_, err = deployVRFTestHelper(t).RandomValueFromVRFProof(nil, mproof[:])
 		require.True(t, inAddressZeroBytes(corruptionTargetByte) || err != nil,
-			"VRF verfication accepted a bad proof! Changed byte %d from %d to %d in %s, which is of length %d",
+			"VRF verification accepted a bad proof! Changed byte %d from %d to %d in %s, which is of length %d",
 			corruptionTargetByte, originalByte, mproof[corruptionTargetByte],
 			mproof.String(), len(mproof))
 		require.True(t,

--- a/core/store/vrf_key_store.go
+++ b/core/store/vrf_key_store.go
@@ -12,7 +12,7 @@ import (
 	"chainlink/core/store/models/vrfkey"
 )
 
-// VRFKeyStore tracks auxillary VRF secret keys, and generates their VRF proofs
+// VRFKeyStore tracks auxiliary VRF secret keys, and generates their VRF proofs
 //
 // VRF proofs need access to the actual secret key, which geth does not expose.
 // Similar to the way geth's KeyStore exposes signing capability, VRFKeyStore


### PR DESCRIPTION
Fixed four small typos found in either commented sections of code, or in error messages.