### PR TITLE
Split up docker file into two stages for explorer

### DIFF
--- a/explorer/Dockerfile
+++ b/explorer/Dockerfile
@@ -6,7 +6,7 @@ RUN mkdir -p /usr/src/app/
 WORKDIR /usr/src/app
 ENV PATH /usr/src/app/node_modules/.bin:$PATH
 
-COPY yarn.lock package.json .yarnrc .yarn/ ./
+COPY yarn.lock package.json .yarnrc ./
 COPY .yarn .yarn
 COPY explorer/package.json ./explorer/
 COPY explorer/client/package.json ./explorer/client/
@@ -18,11 +18,11 @@ COPY tools/ts-helpers/package.json ./tools/ts-helpers/
 COPY styleguide/package.json ./styleguide/
 RUN yarn install --frozen-lockfile
 
-ADD tsconfig.*.json babel.config.js ./
-ADD .git .git
-ADD explorer ./explorer
-ADD tools ./tools
-ADD styleguide ./styleguide
+COPY tsconfig.*.json babel.config.js ./
+COPY .git .git
+COPY explorer ./explorer
+COPY tools ./tools
+COPY styleguide ./styleguide
 RUN yarn setup:explorer
 RUN yarn workspace @chainlink/explorer-client build
 

--- a/explorer/Dockerfile
+++ b/explorer/Dockerfile
@@ -2,13 +2,27 @@ FROM node:10.16.3 as builder
 
 RUN apt-get update && apt-get install -y libudev-dev libusb-dev libusb-1.0-0
 
-RUN mkdir -p /usr/src/app
+RUN mkdir -p /usr/src/app/
 WORKDIR /usr/src/app
 ENV PATH /usr/src/app/node_modules/.bin:$PATH
 
-ADD . .
+COPY yarn.lock package.json .yarnrc .yarn/ ./
+COPY .yarn .yarn
+COPY explorer/package.json ./explorer/
+COPY explorer/client/package.json ./explorer/client/
+COPY tools/package.json ./tools/
+COPY tools/json-api-client/package.json ./tools/json-api-client/
+COPY tools/local-storage/package.json ./tools/local-storage/
+COPY tools/redux/package.json ./tools/redux/
+COPY tools/ts-helpers/package.json ./tools/ts-helpers/
+COPY styleguide/package.json ./styleguide/
+RUN yarn install --frozen-lockfile
 
-RUN yarn install
+ADD tsconfig.*.json babel.config.js ./
+ADD .git .git
+ADD explorer ./explorer
+ADD tools ./tools
+ADD styleguide ./styleguide
 RUN yarn setup:explorer
 RUN yarn workspace @chainlink/explorer-client build
 


### PR DESCRIPTION
This optimizes for:

  1. Only changes to package.json / yarn.lock should redo yarn installs
  2. Only copy in as much as needed for explorer

Also added `--frozen-lockfile` to `yarn install`.