### PR TITLE
Add foreign keys

### DIFF
--- a/core/null/uint32.go
+++ b/core/null/uint32.go
@@ -134,6 +134,15 @@ func (i *Uint32) Scan(value interface{}) error {
 			return fmt.Errorf("Unable to convert %v of %T to Uint32; overflow", value, value)
 		}
 		*i = Uint32From(safe)
+	case uint:
+		safe := uint32(typed)
+		if uint(safe) != typed {
+			return fmt.Errorf("Unable to convert %v of %T to Uint32; overflow", value, value)
+		}
+		*i = Uint32From(safe)
+	case uint32:
+		safe := typed
+		*i = Uint32From(safe)
 	default:
 		return fmt.Errorf("Unable to convert %v of %T to Uint32", value, value)
 	}

--- a/core/null/uint32_test.go
+++ b/core/null/uint32_test.go
@@ -168,6 +168,24 @@ func TestUint32Scan(t *testing.T) {
 	assert.True(t, i.Valid)
 	assert.Equal(t, uint32(12345), i.Uint32)
 
+	// int64 overflows uint32
+	err = i.Scan(int64(math.MaxInt64))
+	require.Error(t, err)
+
+	err = i.Scan(uint(12345))
+	require.NoError(t, err)
+	assert.True(t, i.Valid)
+	assert.Equal(t, uint32(12345), i.Uint32)
+
+	// uint overflows uint32
+	err = i.Scan(uint(math.MaxUint64))
+	require.Error(t, err)
+
+	err = i.Scan(uint32(12345))
+	require.NoError(t, err)
+	assert.True(t, i.Valid)
+	assert.Equal(t, uint32(12345), i.Uint32)
+
 	err = i.Scan(nil)
 	require.NoError(t, err)
 	assert.False(t, i.Valid)

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -35,6 +35,7 @@ import (
 	"chainlink/core/store/migrations/migration1581240419"
 	"chainlink/core/store/migrations/migration1584377646"
 	"chainlink/core/store/migrations/migration1585918589"
+	"chainlink/core/store/migrations/migration1586163842"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -180,6 +181,10 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "1585918589",
 			Migrate: migration1585918589.Migrate,
+		},
+		{
+			ID:      "1586163842",
+			Migrate: migration1586163842.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migrate_test.go
+++ b/core/store/migrations/migrate_test.go
@@ -296,7 +296,7 @@ func TestMigrate_Migration1570675883(t *testing.T) {
 		jobRun := migration0.JobRun{
 			ID:             utils.NewBytes32ID(),
 			JobSpecID:      jobSpec.ID,
-			OverridesID:    overrides.ID,
+			OverridesID:    uint(overrides.ID),
 			CreationHeight: "0",
 			ObservedHeight: "0",
 		}

--- a/core/store/migrations/migration1585918589/migrate.go
+++ b/core/store/migrations/migration1585918589/migrate.go
@@ -23,8 +23,9 @@ func Migrate(tx *gorm.DB) error {
 	}
 
 	// FIXME: This should ideally be unique but there exists non-unique data out in the wild so need to handle that...
+	// Same for tx_attempts
 	err = tx.Exec(`
-	CREATE INDEX idx_txs_hash ON tx_attempts(hash);
+	CREATE INDEX idx_txs_hash ON txes(hash);
 	`).Error
 	if err != nil {
 		return err
@@ -52,9 +53,6 @@ func Migrate(tx *gorm.DB) error {
 
 	CREATE INDEX idx_job_runs_finished_at ON job_runs USING BRIN (finished_at);
 
-	DROP INDEX idx_job_runs_deleted_at;
-	CREATE INDEX idx_job_runs_deleted_at ON job_runs USING BRIN (deleted_at);
-
 	DROP INDEX idx_sessions_last_used;
 	CREATE INDEX idx_sessions_last_used ON sessions USING BRIN (last_used);
 
@@ -65,5 +63,8 @@ func Migrate(tx *gorm.DB) error {
 	CREATE INDEX idx_tx_attempts_created_at ON tx_attempts USING BRIN (created_at);
 
 	CREATE INDEX idx_run_requests_created_at ON run_requests USING BRIN (created_at);
+
+	CREATE INDEX idx_task_specs_created_at ON task_specs USING BRIN (created_at);
+	CREATE INDEX idx_task_specs_updated_at ON task_specs USING BRIN (updated_at);
 	`).Error
 }

--- a/core/store/migrations/migration1586163842/migrate.go
+++ b/core/store/migrations/migration1586163842/migrate.go
@@ -1,0 +1,65 @@
+package migration1586163842
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate adds foreign keys that were missing
+func Migrate(tx *gorm.DB) error {
+	// Add a few more useful indexes while we are here. This also speeds up
+	// some queries in this migration
+	err := tx.Exec(`
+	CREATE INDEX idx_task_specs_job_spec_id ON task_specs (job_spec_id);
+	CREATE INDEX idx_job_runs_run_request_id ON job_runs (run_request_id);
+	CREATE INDEX idx_job_runs_result_id ON job_runs (result_id);
+	CREATE INDEX idx_job_runs_initiator_id ON job_runs (initiator_id);
+	CREATE INDEX idx_task_runs_result_id ON task_runs (result_id);
+	`).Error
+	if err != nil {
+		return err
+	}
+
+	// Need to cast initiators.job_spec_id to UUID to be compatible with referenced key
+	err = tx.Exec(`
+	ALTER TABLE initiators ALTER COLUMN job_spec_id TYPE uuid USING job_spec_id::uuid;
+	`).Error
+	if err != nil {
+		return err
+	}
+
+	// Before we were using 0 as the null value, need to set to explicit null for FK
+	err = tx.Exec(`
+	UPDATE job_runs SET result_id = NULL WHERE result_id = 0;
+	UPDATE job_runs SET run_request_id = NULL WHERE run_request_id = 0;
+	UPDATE job_runs SET initiator_id = NULL WHERE initiator_id = 0;
+	UPDATE task_runs SET result_id = NULL WHERE result_id = 0;
+	UPDATE task_runs SET task_spec_id = NULL WHERE task_spec_id = 0;
+	`).Error
+	if err != nil {
+		return err
+	}
+
+	// This was assumed by the code and probably would have crashed/hung if this assumption was violated.
+	// Let's make that explicit.
+	err = tx.Exec(`
+	ALTER TABLE job_runs ALTER COLUMN initiator_id SET NOT NULL;
+	`).Error
+	if err != nil {
+		return err
+	}
+
+	// Add the foreign keys
+	err = tx.Exec(`
+	ALTER TABLE initiators ADD CONSTRAINT fk_initiators_job_spec_id FOREIGN KEY (job_spec_id) REFERENCES job_specs (id) ON DELETE RESTRICT;
+	ALTER TABLE job_runs ADD CONSTRAINT fk_job_runs_result_id FOREIGN KEY (result_id) REFERENCES run_results (id) ON DELETE CASCADE;
+	ALTER TABLE job_runs ADD CONSTRAINT fk_job_runs_run_request_id FOREIGN KEY (run_request_id) REFERENCES run_requests (id) ON DELETE CASCADE;
+	ALTER TABLE job_runs ADD CONSTRAINT fk_job_runs_initiator_id FOREIGN KEY (initiator_id) REFERENCES initiators (id) ON DELETE CASCADE;
+	ALTER TABLE service_agreements ADD CONSTRAINT fk_service_agreements_encumbrance_id FOREIGN KEY (encumbrance_id) REFERENCES encumbrances (id) ON DELETE RESTRICT;
+	ALTER TABLE task_runs ADD CONSTRAINT fk_task_runs_result_id FOREIGN KEY (result_id) REFERENCES run_results (id) ON DELETE CASCADE;
+	ALTER TABLE task_runs ADD CONSTRAINT fk_task_runs_task_spec_id FOREIGN KEY (task_spec_id) REFERENCES task_specs (id) ON DELETE CASCADE;
+	`).Error
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/core/store/migrations/migration1586163842/migrate.go
+++ b/core/store/migrations/migration1586163842/migrate.go
@@ -42,6 +42,7 @@ func Migrate(tx *gorm.DB) error {
 	// This was assumed by the code and probably would have crashed/hung if this assumption was violated.
 	// Let's make that explicit.
 	err = tx.Exec(`
+	DELETE FROM job_runs WHERE initiator_id IS NULL;
 	ALTER TABLE job_runs ALTER COLUMN initiator_id SET NOT NULL;
 	`).Error
 	if err != nil {

--- a/core/store/models/job_run.go
+++ b/core/store/models/job_run.go
@@ -27,23 +27,23 @@ var (
 // JobRun tracks the status of a job by holding its TaskRuns and the
 // Result of each Run.
 type JobRun struct {
-	ID             *ID          `json:"id" gorm:"primary_key;not null"`
-	JobSpecID      *ID          `json:"jobId" gorm:"index;not null;type:varchar(36) REFERENCES job_specs(id)"`
-	Result         RunResult    `json:"result"`
-	ResultID       uint         `json:"-"`
-	RunRequest     RunRequest   `json:"-"`
-	RunRequestID   uint         `json:"-"`
-	Status         RunStatus    `json:"status" gorm:"index"`
-	TaskRuns       []TaskRun    `json:"taskRuns"`
-	CreatedAt      time.Time    `json:"createdAt" gorm:"index"`
-	FinishedAt     null.Time    `json:"finishedAt"`
-	UpdatedAt      time.Time    `json:"updatedAt"`
-	Initiator      Initiator    `json:"initiator" gorm:"association_autoupdate:false;association_autocreate:false"`
-	InitiatorID    uint         `json:"-"`
-	CreationHeight *utils.Big   `json:"creationHeight"`
-	ObservedHeight *utils.Big   `json:"observedHeight"`
-	DeletedAt      null.Time    `json:"-" gorm:"index"`
-	Payment        *assets.Link `json:"payment,omitempty"`
+	ID             *ID           `json:"id" gorm:"primary_key;not null"`
+	JobSpecID      *ID           `json:"jobId"`
+	Result         RunResult     `json:"result" gorm:"foreignkey:ResultID;association_autoupdate:true;association_autocreate:true"`
+	ResultID       clnull.Uint32 `json:"-"`
+	RunRequest     RunRequest    `json:"-" gorm:"foreignkey:RunRequestID;association_autoupdate:true;association_autocreate:true"`
+	RunRequestID   clnull.Uint32 `json:"-"`
+	Status         RunStatus     `json:"status"`
+	TaskRuns       []TaskRun     `json:"taskRuns"`
+	CreatedAt      time.Time     `json:"createdAt"`
+	FinishedAt     null.Time     `json:"finishedAt"`
+	UpdatedAt      time.Time     `json:"updatedAt"`
+	Initiator      Initiator     `json:"initiator" gorm:"foreignkey:InitiatorID;association_autoupdate:false;association_autocreate:false"`
+	InitiatorID    uint32        `json:"-"`
+	CreationHeight *utils.Big    `json:"creationHeight"`
+	ObservedHeight *utils.Big    `json:"observedHeight"`
+	DeletedAt      null.Time     `json:"-"`
+	Payment        *assets.Link  `json:"payment,omitempty"`
 }
 
 // MakeJobRun returns a new JobRun copy
@@ -220,7 +220,7 @@ func (jr *JobRun) ErrorString() string {
 
 // RunRequest stores the fields used to initiate the parent job run.
 type RunRequest struct {
-	ID            uint `gorm:"primary_key"`
+	ID            uint32 `gorm:"primary_key"`
 	RequestID     *string
 	TxHash        *common.Hash
 	BlockHash     *common.Hash
@@ -239,15 +239,15 @@ func NewRunRequest(requestParams JSON) *RunRequest {
 // Task to be ran.
 type TaskRun struct {
 	ID                   *ID           `json:"id" gorm:"primary_key;not null"`
-	JobRunID             *ID           `json:"-" gorm:"index;not null;type:varchar(36) REFERENCES job_runs(id) ON DELETE CASCADE"`
+	JobRunID             *ID           `json:"-"`
 	Result               RunResult     `json:"result"`
-	ResultID             uint          `json:"-"`
+	ResultID             clnull.Uint32 `json:"-"`
 	Status               RunStatus     `json:"status"`
 	TaskSpec             TaskSpec      `json:"task" gorm:"association_autoupdate:false;association_autocreate:false"`
-	TaskSpecID           uint          `json:"-" gorm:"index;not null REFERENCES task_specs(id)"`
+	TaskSpecID           clnull.Uint32 `json:"-"`
 	MinimumConfirmations clnull.Uint32 `json:"minimumConfirmations"`
 	Confirmations        clnull.Uint32 `json:"confirmations"`
-	CreatedAt            time.Time     `json:"-" gorm:"index"`
+	CreatedAt            time.Time     `json:"-"`
 }
 
 // String returns info on the TaskRun as "ID,Type,Status,Result".
@@ -283,7 +283,7 @@ func (tr *TaskRun) ApplyOutput(result RunOutput) {
 // RunResult keeps track of the outcome of a TaskRun or JobRun. It stores the
 // Data and ErrorMessage.
 type RunResult struct {
-	ID           uint        `json:"-" gorm:"primary_key;auto_increment"`
+	ID           uint32      `json:"-" gorm:"primary_key;auto_increment"`
 	Data         JSON        `json:"data" gorm:"type:text"`
 	ErrorMessage null.String `json:"error"`
 }

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -193,8 +193,8 @@ const (
 // Initiators will have their own unique ID, but will be associated
 // to a parent JobID.
 type Initiator struct {
-	ID        uint `json:"id" gorm:"primary_key;auto_increment"`
-	JobSpecID *ID  `json:"jobSpecId" gorm:"index;type:varchar(36) REFERENCES job_specs(id)"`
+	ID        uint32 `json:"id" gorm:"primary_key;auto_increment"`
+	JobSpecID *ID    `json:"jobSpecId" gorm:"index;type:varchar(36) REFERENCES job_specs(id)"`
 
 	// Type is one of the Initiator* string constants defined just above.
 	Type            string    `json:"type" gorm:"index;not null"`

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -1050,9 +1050,10 @@ func (orm *ORM) UpdateBridgeType(bt *models.BridgeType, btr *models.BridgeTypeRe
 func (orm *ORM) CreateInitiator(initr *models.Initiator) error {
 	orm.MustEnsureAdvisoryLock()
 	if initr.JobSpecID == nil {
-		// FIXME: This hangs forever if we don't check this here and the
+		// NOTE: This hangs forever if we don't check this here and the
 		// supplied initiator does not have a JobSpecID set.
 		// I do not know why. Seems to be something going wrong inside gorm
+		logger.Error("cannot create initiator without job spec ID")
 		return errors.New("requires job spec ID")
 	}
 	return orm.db.Create(initr).Error

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -231,7 +231,7 @@ func (orm *ORM) FindJob(id *models.ID) (models.JobSpec, error) {
 }
 
 // FindInitiator returns the single initiator defined by the passed ID.
-func (orm *ORM) FindInitiator(ID uint) (models.Initiator, error) {
+func (orm *ORM) FindInitiator(ID uint32) (models.Initiator, error) {
 	orm.MustEnsureAdvisoryLock()
 	initr := models.Initiator{}
 	return initr, orm.db.
@@ -337,10 +337,13 @@ func (orm *ORM) SaveJobRun(run *models.JobRun) error {
 			Where("updated_at = ?", run.UpdatedAt).
 			Omit("deleted_at").
 			Save(run)
+		if result.Error != nil {
+			return result.Error
+		}
 		if result.RowsAffected == 0 {
 			return OptimisticUpdateConflictError
 		}
-		return result.Error
+		return nil
 	})
 }
 
@@ -538,7 +541,7 @@ func (orm *ORM) createJob(tx *gorm.DB, job *models.JobSpec) error {
 	return tx.Create(job).Error
 }
 
-// ArchiveJob soft deletes the job and its associated job runs.
+// ArchiveJob soft deletes the job, job_runs and its initiator.
 func (orm *ORM) ArchiveJob(ID *models.ID) error {
 	orm.MustEnsureAdvisoryLock()
 	j, err := orm.FindJob(ID)
@@ -548,9 +551,9 @@ func (orm *ORM) ArchiveJob(ID *models.ID) error {
 
 	return orm.convenientTransaction(func(dbtx *gorm.DB) error {
 		return multierr.Combine(
-			dbtx.Where("job_spec_id = ?", ID).Delete(&models.Initiator{}).Error,
-			dbtx.Where("job_spec_id = ?", ID).Delete(&models.TaskSpec{}).Error,
-			dbtx.Where("job_spec_id = ?", ID).Delete(&models.JobRun{}).Error,
+			dbtx.Exec("UPDATE initiators SET deleted_at = NOW() WHERE job_spec_id = ?", ID).Error,
+			dbtx.Exec("UPDATE task_specs SET deleted_at = NOW() WHERE job_spec_id = ?", ID).Error,
+			dbtx.Exec("UPDATE job_runs SET deleted_at = NOW() WHERE job_spec_id = ?", ID).Error,
 			dbtx.Delete(&j).Error,
 		)
 	})
@@ -1046,6 +1049,12 @@ func (orm *ORM) UpdateBridgeType(bt *models.BridgeType, btr *models.BridgeTypeRe
 // CreateInitiator saves the initiator.
 func (orm *ORM) CreateInitiator(initr *models.Initiator) error {
 	orm.MustEnsureAdvisoryLock()
+	if initr.JobSpecID == nil {
+		// FIXME: This hangs forever if we don't check this here and the
+		// supplied initiator does not have a JobSpecID set.
+		// I do not know why. Seems to be something going wrong inside gorm
+		return errors.New("requires job spec ID")
+	}
 	return orm.db.Create(initr).Error
 }
 
@@ -1096,55 +1105,23 @@ func (orm *ORM) DeleteTransaction(ethtx *models.Tx) error {
 // BulkDeleteRuns removes JobRuns and their related records: TaskRuns and
 // RunResults.
 //
-// TaskRuns are removed by ON DELETE CASCADE when the JobRuns are
-// deleted, but RunResults are not using foreign keys because multiple foreign
-// keys on a record creates an ambiguity with gorm.
+// RunResults and RunRequests are pointed at by JobRuns so we must use two CTEs
+// to remove both parents in one hit.
+//
+// TaskRuns are removed by ON DELETE CASCADE when the JobRuns and RunResults
+// are deleted.
 func (orm *ORM) BulkDeleteRuns(bulkQuery *models.BulkDeleteRunRequest) error {
 	orm.MustEnsureAdvisoryLock()
 	return orm.convenientTransaction(func(dbtx *gorm.DB) error {
 		err := dbtx.Exec(`
-			DELETE
-			FROM run_results
-			WHERE run_results.id IN (SELECT result_id
-															FROM job_runs
-															WHERE status IN (?) AND updated_at < ?)`,
+			WITH deleted_job_runs AS (
+				DELETE FROM job_runs WHERE status IN (?) AND updated_at < ? RETURNING result_id, run_request_id
+			),
+			deleted_run_results AS (
+				DELETE FROM run_results WHERE id IN (SELECT result_id FROM deleted_job_runs)
+			)
+			DELETE FROM run_requests WHERE id IN (SELECT run_request_id FROM deleted_job_runs)`,
 			bulkQuery.Status.ToStrings(), bulkQuery.UpdatedBefore).Error
-		if err != nil {
-			return errors.Wrap(err, "error deleting JobRun's RunResults")
-		}
-
-		// and run_requests
-		err = dbtx.Exec(`
-			DELETE
-			FROM run_requests
-			WHERE run_requests.id IN (SELECT run_request_id
-															FROM job_runs
-															WHERE status IN (?) AND updated_at < ?)`,
-			bulkQuery.Status.ToStrings(), bulkQuery.UpdatedBefore).Error
-		if err != nil {
-			return errors.Wrap(err, "error deleting JobRun's RunRequests")
-		}
-
-		// and then task runs using a join in the subquery
-		err = dbtx.Exec(`
-			DELETE
-			FROM run_results
-			WHERE run_results.id IN (SELECT task_runs.result_id
-															FROM task_runs
-															INNER JOIN job_runs ON
-																task_runs.job_run_id = job_runs.id
-															WHERE job_runs.status IN (?) AND job_runs.updated_at < ?)`,
-			bulkQuery.Status.ToStrings(), bulkQuery.UpdatedBefore).Error
-		if err != nil {
-			return errors.Wrap(err, "error deleting TaskRuns's RunResults")
-		}
-
-		err = dbtx.
-			Where("status IN (?)", bulkQuery.Status.ToStrings()).
-			Where("updated_at < ?", bulkQuery.UpdatedBefore).
-			Unscoped().
-			Delete(&[]models.JobRun{}).
-			Error
 		if err != nil {
 			return errors.Wrap(err, "error deleting JobRuns")
 		}


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/172080031

This adds a few more index and puts a foreign key constraint on every column that should have one.

Timing information:

```
2020-04-07T15:18:53Z [DEBUG]
	CREATE INDEX idx_task_specs_job_spec_id ON task_specs (job_spec_id);
	CREATE INDEX idx_job_runs_run_request_id ON job_runs (run_request_id);
	CREATE INDEX idx_job_runs_result_id ON job_runs (result_id);
	CREATE INDEX idx_job_runs_initiator_id ON job_runs (initiator_id);
	CREATE INDEX idx_task_runs_result_id ON task_runs (result_id);
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=0.308167744
2020-04-07T15:18:53Z [DEBUG]
	ALTER TABLE initiators ALTER COLUMN job_spec_id TYPE uuid USING job_spec_id::uuid;
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=0.006978406
2020-04-07T15:18:54Z [DEBUG]
	UPDATE job_runs SET result_id = NULL WHERE result_id = 0;
	UPDATE job_runs SET run_request_id = NULL WHERE run_request_id = 0;
	UPDATE job_runs SET initiator_id = NULL WHERE initiator_id = 0;
	UPDATE task_runs SET result_id = NULL WHERE result_id = 0;
	UPDATE task_runs SET task_spec_id = NULL WHERE task_spec_id = 0;
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=0.923095353
2020-04-07T15:18:54Z [DEBUG]
	ALTER TABLE job_runs ALTER COLUMN initiator_id SET NOT NULL;
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=0.016074715
2020-04-07T15:18:54Z [DEBUG]
	ALTER TABLE initiators ADD CONSTRAINT fk_initiators_job_spec_id FOREIGN KEY (job_spec_id) REFERENCES job_specs (id) ON DELETE RESTRICT;
	ALTER TABLE job_runs ADD CONSTRAINT fk_job_runs_result_id FOREIGN KEY (result_id) REFERENCES run_results (id) ON DELETE CASCADE;
	ALTER TABLE job_runs ADD CONSTRAINT fk_job_runs_run_request_id FOREIGN KEY (run_request_id) REFERENCES run_requests (id) ON DELETE CASCADE;
	ALTER TABLE job_runs ADD CONSTRAINT fk_job_runs_initiator_id FOREIGN KEY (initiator_id) REFERENCES initiators (id) ON DELETE CASCADE;
	ALTER TABLE service_agreements ADD CONSTRAINT fk_service_agreements_encumbrance_id FOREIGN KEY (encumbrance_id) REFERENCES encumbrances (id) ON DELETE RESTRICT;
	ALTER TABLE task_runs ADD CONSTRAINT fk_task_runs_result_id FOREIGN KEY (result_id) REFERENCES run_results (id) ON DELETE CASCADE;
	ALTER TABLE task_runs ADD CONSTRAINT fk_task_runs_task_spec_id FOREIGN KEY (task_spec_id) REFERENCES task_specs (id) ON DELETE CASCADE;
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=0.208532368
```

Total time ~1.5 seconds