### PR TITLE
Convert text columns to binary blob and varchar to numeric

### DIFF
--- a/core/eth/client.go
+++ b/core/eth/client.go
@@ -21,7 +21,7 @@ type Client interface {
 	GetNonce(address common.Address) (uint64, error)
 	GetEthBalance(address common.Address) (*assets.Eth, error)
 	GetERC20Balance(address common.Address, contractAddress common.Address) (*big.Int, error)
-	SendRawTx(hex string) (common.Hash, error)
+	SendRawTx(bytes []byte) (common.Hash, error)
 	GetTxReceipt(hash common.Hash) (*TxReceipt, error)
 	GetBlockHeight() (uint64, error)
 	GetBlockByNumber(hex string) (Block, error)
@@ -114,9 +114,9 @@ func (client *CallerSubscriberClient) GetERC20Balance(address common.Address, co
 }
 
 // SendRawTx sends a signed transaction to the transaction pool.
-func (client *CallerSubscriberClient) SendRawTx(hex string) (common.Hash, error) {
+func (client *CallerSubscriberClient) SendRawTx(bytes []byte) (common.Hash, error) {
 	result := common.Hash{}
-	err := client.Call(&result, "eth_sendRawTransaction", hex)
+	err := client.Call(&result, "eth_sendRawTransaction", hexutil.Encode(bytes))
 	return result, err
 }
 

--- a/core/eth/client_test.go
+++ b/core/eth/client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -106,10 +107,10 @@ func TestCallerSubscriberClient_SendRawTx(t *testing.T) {
 
 	ethClientMock := new(mocks.CallerSubscriber)
 	ethClient := &eth.CallerSubscriberClient{CallerSubscriber: ethClientMock}
-	txData := "0xdeadbeef"
+	txData := hexutil.MustDecode("0xdeadbeef")
 	returnedHash := cltest.NewHash()
 
-	ethClientMock.On("Call", mock.Anything, "eth_sendRawTransaction", txData).
+	ethClientMock.On("Call", mock.Anything, "eth_sendRawTransaction", "0xdeadbeef").
 		Return(nil).
 		Run(func(args mock.Arguments) {
 			res := args.Get(0).(*common.Hash)

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -212,7 +212,7 @@ func NewTransaction(nonce uint64, sentAtV ...uint64) *models.Tx {
 		GasLimit:    transaction.Gas(),
 		GasPrice:    utils.NewBig(transaction.GasPrice()),
 		Hash:        transaction.Hash(),
-		SignedRawTx: "signed-raw",
+		SignedRawTx: hexutil.MustDecode("0xcafe11"),
 	}
 }
 
@@ -262,7 +262,7 @@ func CreateTxWithNonceGasPriceAndRecipient(
 		GasLimit:    transaction.Gas(),
 		GasPrice:    utils.NewBig(transaction.GasPrice()),
 		Hash:        transaction.Hash(),
-		SignedRawTx: "signed-raw-attempt 1",
+		SignedRawTx: hexutil.MustDecode("0xcafe22"),
 	}
 
 	tx, err := store.CreateTx(tx)
@@ -291,7 +291,7 @@ func AddTxAttempt(
 		GasLimit:    transaction.Gas(),
 		GasPrice:    utils.NewBig(transaction.GasPrice()),
 		Hash:        transaction.Hash(),
-		SignedRawTx: fmt.Sprintf("signed-raw-attempt %d", len(tx.Attempts)+1),
+		SignedRawTx: []byte{byte(len(tx.Attempts))},
 	}
 
 	txAttempt, err := store.AddTxAttempt(tx, newTxAttempt)

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -1075,8 +1075,7 @@ func TestIntegration_RandomnessRequest(t *testing.T) {
 	require.True(t, eth.AllCalled(), eth.Remaining())
 	require.Len(t, attempts, 1)
 
-	rawTx, err := hexutil.Decode(attempts[0].SignedRawTx)
-	require.NoError(t, err)
+	rawTx := attempts[0].SignedRawTx
 	var tx *types.Transaction
 	require.NoError(t, rlp.DecodeBytes(rawTx, &tx))
 	fixtureToAddress := j.Tasks[1].Params.Get("address").String()

--- a/core/internal/mocks/client.go
+++ b/core/internal/mocks/client.go
@@ -217,13 +217,13 @@ func (_m *Client) GetTxReceipt(hash common.Hash) (*eth.TxReceipt, error) {
 	return r0, r1
 }
 
-// SendRawTx provides a mock function with given fields: hex
-func (_m *Client) SendRawTx(hex string) (common.Hash, error) {
-	ret := _m.Called(hex)
+// SendRawTx provides a mock function with given fields: bytes
+func (_m *Client) SendRawTx(bytes []byte) (common.Hash, error) {
+	ret := _m.Called(bytes)
 
 	var r0 common.Hash
-	if rf, ok := ret.Get(0).(func(string) common.Hash); ok {
-		r0 = rf(hex)
+	if rf, ok := ret.Get(0).(func([]byte) common.Hash); ok {
+		r0 = rf(bytes)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(common.Hash)
@@ -231,8 +231,8 @@ func (_m *Client) SendRawTx(hex string) (common.Hash, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(hex)
+	if rf, ok := ret.Get(1).(func([]byte) error); ok {
+		r1 = rf(bytes)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/internal/mocks/tx_manager.go
+++ b/core/internal/mocks/tx_manager.go
@@ -458,13 +458,13 @@ func (_m *TxManager) Register(_a0 []accounts.Account) {
 	_m.Called(_a0)
 }
 
-// SendRawTx provides a mock function with given fields: hex
-func (_m *TxManager) SendRawTx(hex string) (common.Hash, error) {
-	ret := _m.Called(hex)
+// SendRawTx provides a mock function with given fields: bytes
+func (_m *TxManager) SendRawTx(bytes []byte) (common.Hash, error) {
+	ret := _m.Called(bytes)
 
 	var r0 common.Hash
-	if rf, ok := ret.Get(0).(func(string) common.Hash); ok {
-		r0 = rf(hex)
+	if rf, ok := ret.Get(0).(func([]byte) common.Hash); ok {
+		r0 = rf(bytes)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(common.Hash)
@@ -472,8 +472,8 @@ func (_m *TxManager) SendRawTx(hex string) (common.Hash, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(string) error); ok {
-		r1 = rf(hex)
+	if rf, ok := ret.Get(1).(func([]byte) error); ok {
+		r1 = rf(bytes)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -482,14 +482,16 @@ func (_m *TxManager) SendRawTx(hex string) (common.Hash, error) {
 }
 
 // SignedRawTxWithBumpedGas provides a mock function with given fields: originalTx, gasLimit, gasPrice
-func (_m *TxManager) SignedRawTxWithBumpedGas(originalTx models.Tx, gasLimit uint64, gasPrice big.Int) (string, error) {
+func (_m *TxManager) SignedRawTxWithBumpedGas(originalTx models.Tx, gasLimit uint64, gasPrice big.Int) ([]byte, error) {
 	ret := _m.Called(originalTx, gasLimit, gasPrice)
 
-	var r0 string
-	if rf, ok := ret.Get(0).(func(models.Tx, uint64, big.Int) string); ok {
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(models.Tx, uint64, big.Int) []byte); ok {
 		r0 = rf(originalTx, gasLimit, gasPrice)
 	} else {
-		r0 = ret.Get(0).(string)
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
 	}
 
 	var r1 error

--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -263,7 +263,7 @@ func TestRunManager_Create(t *testing.T) {
 	job.Tasks = []models.TaskSpec{cltest.NewTask(t, "NoOp")} // empty params
 	require.NoError(t, store.CreateJob(&job))
 
-	requestID := "RequestID"
+	requestID := common.HexToHash("0xcafe")
 	initiator := job.Initiators[0]
 	rr := models.NewRunRequest(models.JSON{})
 	rr.RequestID = &requestID
@@ -345,7 +345,7 @@ func TestRunManager_Create_fromRunLog_Happy(t *testing.T) {
 			require.NoError(t, app.Store.CreateJob(&job))
 
 			creationHeight := big.NewInt(1)
-			requestID := "RequestID"
+			requestID := common.HexToHash("0xcafe")
 			initiator := job.Initiators[0]
 			rr := models.NewRunRequest(models.JSON{})
 			rr.RequestID = &requestID
@@ -638,7 +638,7 @@ func TestRunManager_Create_fromRunLog_ConnectToLaggingEthNode(t *testing.T) {
 	job.Tasks = []models.TaskSpec{cltest.NewTask(t, "NoOp")}
 	require.NoError(t, store.CreateJob(&job))
 
-	requestID := "RequestID"
+	requestID := common.HexToHash("0xcafe")
 	initiator := job.Initiators[0]
 	rr := models.NewRunRequest(models.JSON{})
 	rr.RequestID = &requestID

--- a/core/services/synchronization/presenters.go
+++ b/core/services/synchronization/presenters.go
@@ -135,7 +135,7 @@ func runLogStatusPresenter(receipt eth.TxReceipt) TxStatus {
 
 type syncInitiatorPresenter struct {
 	Type      string               `json:"type"`
-	RequestID *string              `json:"requestId,omitempty"`
+	RequestID *common.Hash         `json:"requestId,omitempty"`
 	TxHash    *common.Hash         `json:"txHash,omitempty"`
 	Requester *models.EIP55Address `json:"requester,omitempty"`
 }

--- a/core/services/synchronization/presenters_test.go
+++ b/core/services/synchronization/presenters_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 	newAddress := common.HexToAddress("0x9FBDa871d559710256a2502A2517b794B482Db40")
-	requestID := "RequestID"
+	requestID := common.HexToHash("0xcafe")
 	txHash := common.HexToHash("0xdeadbeef")
 
 	task0RunID := models.NewID()
@@ -68,7 +68,7 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 	initiator, ok := data["initiator"].(map[string]interface{})
 	require.True(t, ok)
 	assert.Equal(t, initiator["type"], "runlog")
-	assert.Equal(t, initiator["requestId"], "RequestID")
+	assert.Equal(t, initiator["requestId"], "0x000000000000000000000000000000000000000000000000000000000000cafe")
 	assert.Equal(t, initiator["txHash"], "0x00000000000000000000000000000000000000000000000000000000deadbeef")
 	assert.Equal(t, initiator["requester"], newAddress.Hex())
 
@@ -93,7 +93,7 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 
 func TestSyncJobRunPresenter_Initiators(t *testing.T) {
 	newAddress := common.HexToAddress("0x9FBDa871d559710256a2502A2517b794B482Db40")
-	requestID := "RequestID"
+	requestID := common.HexToHash("0xcafe")
 	txHash := common.HexToHash("0xdeadbeef")
 
 	tests := []struct {
@@ -163,7 +163,7 @@ func TestSyncJobRunPresenter_EthTxTask(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			newAddress := common.HexToAddress("0x9FBDa871d559710256a2502A2517b794B482Db40")
-			requestID := "RequestID"
+			requestID := common.HexToHash("0xcafe")
 			requestTxHash := common.HexToHash("0xdeadbeef")
 			dataJSON := jsonFromFixture(t, test.path)
 			outgoingTxHash := "0x1111111111111111111111111111111111111111111111111111111111111111"

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -38,6 +38,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1585918589"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586163842"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586342453"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586369235"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586939705"
 
 	"github.com/jinzhu/gorm"
@@ -196,6 +197,9 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "1586342453",
 			Migrate: migration1586342453.Migrate,
+		}, {
+			ID:      "1586369235",
+			Migrate: migration1586369235.Migrate,
 		},
 		{
 			ID:      "1586939705",

--- a/core/store/migrations/migrate_test.go
+++ b/core/store/migrations/migrate_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/orm"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/gofrs/uuid"
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
@@ -308,6 +309,49 @@ func TestMigrate_Migration1570675883(t *testing.T) {
 		require.NoError(t, db.Where("id = ?", jobRun.ID).Find(&jobRunFound).Error)
 		assert.Equal(t, `{"a": "b"}`, jobRunFound.Overrides.String())
 		require.Error(t, db.Where("id = ?", overrides.ID).Find(&overrides).Error)
+		return nil
+	})
+	require.NoError(t, err)
+}
+
+func TestMigrate_Migration1586369235(t *testing.T) {
+	// Make sure that the data still reads OK afterward
+	orm, cleanup := bootstrapORM(t)
+	defer cleanup()
+
+	err := orm.RawDB(func(db *gorm.DB) error {
+		require.NoError(t, migrations.MigrateTo(db, "1586163842"))
+		hexEncodedData := "0x3162323831336636383832373462366261623565663264366135343866323038"
+		binaryData := hexutil.MustDecode(hexEncodedData)
+		address := hexutil.MustDecode("0xa0788FC17B1dEe36f057c42B6F373A34B014687e")
+		bigInt := "42000000000000000000" // 42 LINK
+
+		require.NoError(t, db.Exec(`INSERT INTO encumbrances (payment, aggregator, agg_initiate_job_selector, agg_fulfill_selector) VALUES (?, 'a', E'\\xDEADBEEF', E'\\xDEADBEEF')`, bigInt).Error)
+		require.NoError(t, db.Exec(`INSERT INTO run_requests (request_id) VALUES (?::text)`, hexEncodedData).Error)
+		require.NoError(t, db.Exec(`INSERT INTO txes (signed_raw_tx, "from", "to", data, nonce, value, gas_limit, hash, gas_price, confirmed, sent_at) VALUES (?::text, ?, ?, E'\\xDEADBEEF', 42, ?, 42, ?, ?, false, 42)`, hexEncodedData, address, address, bigInt, binaryData, bigInt).Error)
+		require.NoError(t, db.Exec(`INSERT INTO tx_attempts (signed_raw_tx, created_at, hash, gas_price, confirmed, sent_at) VALUES (?::text, NOW(), ?, ?, false, 42)`, hexEncodedData, binaryData, bigInt).Error)
+
+		require.NoError(t, migrations.MigrateTo(db, "1586369235"))
+
+		var e models.Encumbrance
+		require.NoError(t, db.First(&e, "true").Error)
+		assert.Equal(t, e.Payment.ToInt().String(), bigInt)
+
+		var rr models.RunRequest
+		require.NoError(t, db.First(&rr, "true").Error)
+		assert.Equal(t, rr.RequestID.Bytes(), binaryData)
+
+		var tx models.Tx
+		require.NoError(t, db.First(&tx, "true").Error)
+		assert.Equal(t, tx.SignedRawTx, binaryData)
+		assert.Equal(t, tx.GasPrice.String(), bigInt)
+		assert.Equal(t, tx.Value.String(), bigInt)
+
+		var txa models.TxAttempt
+		require.NoError(t, db.First(&txa, "true").Error)
+		assert.Equal(t, txa.SignedRawTx, binaryData)
+		assert.Equal(t, txa.GasPrice.String(), bigInt)
+
 		return nil
 	})
 	require.NoError(t, err)

--- a/core/store/migrations/migration1559081901/migrate.go
+++ b/core/store/migrations/migration1559081901/migrate.go
@@ -1,10 +1,14 @@
 package migration1559081901
 
 import (
-	"github.com/smartcontractkit/chainlink/core/store/models"
+	"time"
 
+	"github.com/smartcontractkit/chainlink/core/utils"
+
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
+	null "gopkg.in/guregu/null.v3"
 )
 
 func Migrate(tx *gorm.DB) error {
@@ -19,10 +23,10 @@ func Migrate(tx *gorm.DB) error {
 	).Error; err != nil {
 		return errors.Wrap(err, "failed to drop txes and txattempts")
 	}
-	if err := tx.AutoMigrate(&models.Tx{}).Error; err != nil {
+	if err := tx.AutoMigrate(&Tx{}).Error; err != nil {
 		return errors.Wrap(err, "failed to auto migrate Tx")
 	}
-	if err := tx.AutoMigrate(&models.TxAttempt{}).Error; err != nil {
+	if err := tx.AutoMigrate(&TxAttempt{}).Error; err != nil {
 		return errors.Wrap(err, "failed to auto migrate TxAttempt")
 	}
 	if err := tx.Exec(
@@ -44,4 +48,47 @@ func Migrate(tx *gorm.DB) error {
 		return errors.Wrap(err, "failed to migrate old Txes, TxAttempts")
 	}
 	return nil
+}
+
+// Tx is a capture of the model representing Txes before migration1586369235
+// Let's please not use gorm automigrate ever again
+type Tx struct {
+	ID uint64 `gorm:"primary_key;auto_increment"`
+
+	// SurrogateID is used to look up a transaction using a secondary ID, used to
+	// associate jobs with transactions so that we don't double spend in certain
+	// failure scenarios
+	SurrogateID null.String `gorm:"index;unique"`
+
+	Attempts []*TxAttempt `json:"-"`
+
+	From     common.Address `gorm:"index;not null"`
+	To       common.Address `gorm:"not null"`
+	Data     []byte         `gorm:"not null"`
+	Nonce    uint64         `gorm:"index;not null"`
+	Value    *utils.Big     `gorm:"type:varchar(78);not null"`
+	GasLimit uint64         `gorm:"not null"`
+
+	// TxAttempt fields manually included; can't embed another primary_key
+	Hash        common.Hash `gorm:"not null"`
+	GasPrice    *utils.Big  `gorm:"type:varchar(78);not null"`
+	Confirmed   bool        `gorm:"not null"`
+	SentAt      uint64      `gorm:"not null"`
+	SignedRawTx string      `gorm:"type:text;not null"`
+}
+
+// TxAttempt is a capture of the model representing TxAttempts before migration1586369235
+type TxAttempt struct {
+	ID uint64 `gorm:"primary_key;auto_increment"`
+
+	TxID uint64 `gorm:"index;type:bigint REFERENCES txes(id) ON DELETE CASCADE"`
+	Tx   *Tx    `json:"-" gorm:"PRELOAD:false;foreignkey:TxID"`
+
+	CreatedAt time.Time `gorm:"index;not null"`
+
+	Hash        common.Hash `gorm:"index;not null"`
+	GasPrice    *utils.Big  `gorm:"type:varchar(78);not null"`
+	Confirmed   bool        `gorm:"not null"`
+	SentAt      uint64      `gorm:"not null"`
+	SignedRawTx string      `gorm:"type:text;not null"`
 }

--- a/core/store/migrations/migration1586369235/migrate.go
+++ b/core/store/migrations/migration1586369235/migrate.go
@@ -1,0 +1,19 @@
+package migration1586369235
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate changes text to binary where appropriate and uses numeric type for very large integers
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+	ALTER TABLE run_requests ALTER COLUMN request_id TYPE bytea USING decode(substring(request_id from 3), 'hex');
+	ALTER TABLE tx_attempts ALTER COLUMN signed_raw_tx TYPE bytea USING decode(substring(signed_raw_tx from 3), 'hex');
+	ALTER TABLE txes ALTER COLUMN signed_raw_tx TYPE bytea USING decode(substring(signed_raw_tx from 3), 'hex');
+
+	ALTER TABLE tx_attempts ALTER COLUMN gas_price TYPE numeric(78, 0) USING gas_price::numeric;
+	ALTER TABLE txes ALTER COLUMN gas_price TYPE numeric(78, 0) USING gas_price::numeric;
+	ALTER TABLE txes ALTER COLUMN value TYPE numeric(78, 0) USING value::numeric;
+	ALTER TABLE encumbrances ALTER COLUMN payment TYPE numeric(78, 0) USING payment::numeric;
+	`).Error
+}

--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -29,15 +29,15 @@ type Tx struct {
 	To       common.Address `gorm:"not null"`
 	Data     []byte         `gorm:"not null"`
 	Nonce    uint64         `gorm:"index;not null"`
-	Value    *utils.Big     `gorm:"type:varchar(78);not null"`
+	Value    *utils.Big     `gorm:"not null"`
 	GasLimit uint64         `gorm:"not null"`
 
 	// TxAttempt fields manually included; can't embed another primary_key
 	Hash        common.Hash `gorm:"not null"`
-	GasPrice    *utils.Big  `gorm:"type:varchar(78);not null"`
+	GasPrice    *utils.Big  `gorm:"not null"`
 	Confirmed   bool        `gorm:"not null"`
 	SentAt      uint64      `gorm:"not null"`
-	SignedRawTx string      `gorm:"type:text;not null"`
+	SignedRawTx []byte      `gorm:"not null"`
 }
 
 // String implements Stringer for Tx
@@ -79,7 +79,7 @@ type TxAttempt struct {
 	GasPrice    *utils.Big  `gorm:"type:varchar(78);not null"`
 	Confirmed   bool        `gorm:"not null"`
 	SentAt      uint64      `gorm:"not null"`
-	SignedRawTx string      `gorm:"type:text;not null"`
+	SignedRawTx []byte      `gorm:"not null"`
 }
 
 // String implements Stringer for TxAttempt

--- a/core/store/models/eth_test.go
+++ b/core/store/models/eth_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -88,7 +89,7 @@ func TestTx_PresenterMatchesHex(t *testing.T) {
 		GasPrice:    utils.NewBig(big.NewInt(333)),
 		Confirmed:   true,
 		SentAt:      1745,
-		SignedRawTx: "signed",
+		SignedRawTx: hexutil.MustDecode("0xcafe"),
 	}
 
 	ptx := presenters.NewTx(&createdTx)
@@ -101,7 +102,7 @@ func TestTx_PresenterMatchesHex(t *testing.T) {
 		`"gasLimit":"1999",`+
 		`"gasPrice":"333",`+
 		`"hash":"0x0000000000000000000000000000000000000000000000000000000000000000",`+
-		`"rawHex":"signed",`+
+		`"rawHex":"0xcafe",`+
 		`"nonce":"32776",`+
 		`"sentAt":"1745",`+
 		`"to":"0x0000000000000000000000000000000000000070",`+

--- a/core/store/models/job_run.go
+++ b/core/store/models/job_run.go
@@ -221,7 +221,7 @@ func (jr *JobRun) ErrorString() string {
 // RunRequest stores the fields used to initiate the parent job run.
 type RunRequest struct {
 	ID            uint32 `gorm:"primary_key"`
-	RequestID     *string
+	RequestID     *common.Hash
 	TxHash        *common.Hash
 	BlockHash     *common.Hash
 	Requester     *common.Address

--- a/core/store/models/log_events.go
+++ b/core/store/models/log_events.go
@@ -14,7 +14,6 @@ import (
 
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/whisper/whisperv6"
 	"github.com/pkg/errors"
 )
@@ -68,7 +67,7 @@ var (
 
 type logRequestParser interface {
 	parseJSON(eth.Log) (JSON, error)
-	parseRequestID(eth.Log) (string, error)
+	parseRequestID(eth.Log) (common.Hash, error)
 }
 
 // topicFactoryMap maps the log topic to a factory method that returns an
@@ -456,12 +455,12 @@ func (p parseRunLog0original) parseJSON(log eth.Log) (JSON, error) {
 	})
 }
 
-func (parseRunLog0original) parseRequestID(log eth.Log) (string, error) {
+func (parseRunLog0original) parseRequestID(log eth.Log) (common.Hash, error) {
 	idData, err := log.Data.SafeByteSlice(0, idSize)
 	if err != nil {
-		return "", err
+		return common.Hash{}, err
 	}
-	return hexutil.Encode(idData), nil
+	return common.BytesToHash(idData), nil
 }
 
 // parseRunLog20190123withFulfillmentParams parses the OracleRequest log format
@@ -506,12 +505,12 @@ func (parseRunLog20190123withFulfillmentParams) parseJSON(log eth.Log) (JSON, er
 	})
 }
 
-func (parseRunLog20190123withFulfillmentParams) parseRequestID(log eth.Log) (string, error) {
+func (parseRunLog20190123withFulfillmentParams) parseRequestID(log eth.Log) (common.Hash, error) {
 	idData, err := log.Data.SafeByteSlice(0, idSize)
 	if err != nil {
-		return "", err
+		return common.Hash{}, err
 	}
-	return common.BytesToHash(idData).Hex(), nil
+	return common.BytesToHash(idData), nil
 }
 
 // parseRunLog20190207withoutIndexes parses the OracleRequest log format after
@@ -565,13 +564,13 @@ func (parseRunLog20190207withoutIndexes) parseJSON(log eth.Log) (JSON, error) {
 	})
 }
 
-func (parseRunLog20190207withoutIndexes) parseRequestID(log eth.Log) (string, error) {
+func (parseRunLog20190207withoutIndexes) parseRequestID(log eth.Log) (common.Hash, error) {
 	start := requesterSize
 	requestIDBytes, err := log.Data.SafeByteSlice(start, start+idSize)
 	if err != nil {
-		return "", err
+		return common.Hash{}, err
 	}
-	return common.BytesToHash(requestIDBytes).Hex(), nil
+	return common.BytesToHash(requestIDBytes), nil
 }
 
 func bytesToHex(data []byte) string {

--- a/core/store/models/log_events_test.go
+++ b/core/store/models/log_events_test.go
@@ -457,7 +457,7 @@ func TestRunLogEvent_RunRequest(t *testing.T) {
 	tests := []struct {
 		name          string
 		log           eth.Log
-		wantRequestID string
+		wantRequestID common.Hash
 		wantTxHash    string
 		wantBlockHash string
 		wantRequester common.Address
@@ -465,7 +465,7 @@ func TestRunLogEvent_RunRequest(t *testing.T) {
 		{
 			name:          "old non-commitment",
 			log:           cltest.LogFromFixture(t, "testdata/requestLog0original.json"),
-			wantRequestID: "0x0000000000000000000000000000000000000000000000000000000000000017",
+			wantRequestID: common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000017"),
 			wantTxHash:    "0xe05b171038320aca6634ce50de669bd0baa337130269c3ce3594ce4d45fc342a",
 			wantBlockHash: "0xde3fb1df888c6c7f77f3a8e9c2582f87e7ad5277d98bd06cfd17cd2d7ea49f42",
 			wantRequester: common.HexToAddress("0xd352677fcded6c358e03c73ea2a8a2832dffc0a4"),
@@ -473,7 +473,7 @@ func TestRunLogEvent_RunRequest(t *testing.T) {
 		{
 			name:          "20190123 with fulfillment params",
 			log:           cltest.LogFromFixture(t, "testdata/requestLog20190123withFulfillmentParams.json"),
-			wantRequestID: "0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8",
+			wantRequestID: common.HexToHash("0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8"),
 			wantTxHash:    "0x04250548cd0b5d03b3bf1331aa83f32b35879440db31a6008d151260a5f3cc76",
 			wantBlockHash: "0xfa0c0d01ce8bd7100b73b1609ababc020e7f51dac75186bb799277c6b4b71e1c",
 			wantRequester: common.HexToAddress("0x9fbda871d559710256a2502a2517b794b482db41"),
@@ -481,7 +481,7 @@ func TestRunLogEvent_RunRequest(t *testing.T) {
 		{
 			name:          "20190207 without indexes",
 			log:           cltest.LogFromFixture(t, "testdata/requestLog20190207withoutIndexes.json"),
-			wantRequestID: "0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8",
+			wantRequestID: common.HexToHash("0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8"),
 			wantTxHash:    "0x04250548cd0b5d03b3bf1331aa83f32b35879440db31a6008d151260a5f3cc76",
 			wantBlockHash: "0x000c0d01ce8bd7100b73b1609ababc020e7f51dac75186bb799277c6b4b71e1c",
 			wantRequester: common.HexToAddress("0x9FBDa871d559710256a2502A2517b794B482Db40"),

--- a/core/store/models/parse_randomness_request.go
+++ b/core/store/models/parse_randomness_request.go
@@ -1,6 +1,7 @@
 package models
 
 import (
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink/core/eth"
@@ -40,10 +41,10 @@ func (parseRandomnessRequest) parseJSON(log eth.Log) (js JSON, err error) {
 	})
 }
 
-func (parseRandomnessRequest) parseRequestID(log eth.Log) (string, error) {
+func (parseRandomnessRequest) parseRequestID(log eth.Log) (common.Hash, error) {
 	parsedLog, err := vrf.ParseRandomnessRequestLog(log)
 	if err != nil {
-		return "", errors.Wrapf(err, "while extracting randomness requestID from %#+v", log)
+		return common.Hash{}, errors.Wrapf(err, "while extracting randomness requestID from %#+v", log)
 	}
-	return parsedLog.RequestID().Hex(), nil
+	return parsedLog.RequestID(), nil
 }

--- a/core/store/models/randomness_log_event.go
+++ b/core/store/models/randomness_log_event.go
@@ -69,10 +69,10 @@ func (le RandomnessLogEvent) RunRequest() (RunRequest, error) {
 			"while parsing request params for VRF run request")
 	}
 
-	str := parsedLog.RequestID().Hex()
+	requestID := parsedLog.RequestID()
 	requester := le.Requester()
 	return RunRequest{
-		RequestID:     &str,
+		RequestID:     &requestID,
 		TxHash:        &le.Log.TxHash,
 		BlockHash:     &le.Log.BlockHash,
 		Requester:     &requester,

--- a/core/store/models/service_agreement.go
+++ b/core/store/models/service_agreement.go
@@ -22,7 +22,7 @@ type Encumbrance struct {
 	// Corresponds to requestDigest in solidity ServiceAgreement struct
 	ID uint `json:"-" gorm:"primary_key;auto_increment"`
 	// Price to request a report based on this agreement
-	Payment *assets.Link `json:"payment,omitempty" gorm:"type:varchar(255)"`
+	Payment *assets.Link `json:"payment,omitempty"`
 	// Expiration is the amount of time an oracle has to answer a request
 	Expiration uint64 `json:"expiration"`
 	// Agreement is valid until this time

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -586,7 +586,7 @@ func NewTx(tx *models.Tx) Tx {
 		GasLimit:  strconv.FormatUint(tx.GasLimit, 10),
 		GasPrice:  tx.GasPrice.String(),
 		Hash:      tx.Hash,
-		Hex:       tx.SignedRawTx,
+		Hex:       hexutil.Encode(tx.SignedRawTx),
 		Nonce:     strconv.FormatUint(tx.Nonce, 10),
 		SentAt:    strconv.FormatUint(tx.SentAt, 10),
 		To:        &tx.To,


### PR DESCRIPTION
Size of tables on sample prod data (utility node):

```
run_requests tx_attempts txes
BEFORE 6264 kB	67 MB	91 MB
AFTER 7024 kB	45 MB	79 MB
```

Another prod node:

```
run_requests tx_attempts txes
64 MB	80 MB	110 MB
59 MB	49 MB	89 MB
```

Time to run migration
```
	ALTER TABLE run_requests ALTER COLUMN request_id TYPE bytea USING decode(substring(request_id from 3), 'hex');
	ALTER TABLE tx_attempts ALTER COLUMN signed_raw_tx TYPE bytea USING decode(substring(signed_raw_tx from 3), 'hex');
	ALTER TABLE txes ALTER COLUMN signed_raw_tx TYPE bytea USING decode(substring(signed_raw_tx from 3), 'hex');

	ALTER TABLE tx_attempts ALTER COLUMN gas_price TYPE numeric(78, 0) USING gas_price::numeric;
	ALTER TABLE txes ALTER COLUMN gas_price TYPE numeric(78, 0) USING gas_price::numeric;
	ALTER TABLE txes ALTER COLUMN value TYPE numeric(78, 0) USING value::numeric;
	ALTER TABLE encumbrances ALTER COLUMN payment TYPE numeric(78, 0) USING payment::numeric;
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=7.283876511
```

~7s