### PR TITLE
Set not null on a few columns that should never be null

### DIFF
--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
-	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/ethereum/go-ethereum/common"
+	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -208,11 +208,14 @@ func TestRunManager_ResumeAllConnecting(t *testing.T) {
 	})
 
 	t.Run("input, should go from pending -> in progress", func(t *testing.T) {
-		run := makeJobRunWithInitiator(t, store, models.NewJob())
+		run := makeJobRunWithInitiator(t, store, cltest.NewJob())
 		run.SetStatus(models.RunStatusPendingConnection)
-		run.TaskRuns = []models.TaskRun{models.TaskRun{ID: models.NewID()}}
+
+		job, err := store.FindJob(run.JobSpecID)
+		require.NoError(t, err)
+		run.TaskRuns = []models.TaskRun{models.TaskRun{ID: models.NewID(), TaskSpecID: job.Tasks[0].ID}}
 		require.NoError(t, store.CreateJobRun(&run))
-		err := runManager.ResumeAllConnecting()
+		err = runManager.ResumeAllConnecting()
 		assert.NoError(t, err)
 
 		run, err = store.FindJobRun(run.ID)

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -38,6 +38,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1585918589"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586163842"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586342453"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586939705"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -195,6 +196,10 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "1586342453",
 			Migrate: migration1586342453.Migrate,
+		},
+		{
+			ID:      "1586939705",
+			Migrate: migration1586939705.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration1586939705/migrate.go
+++ b/core/store/migrations/migration1586939705/migrate.go
@@ -1,0 +1,59 @@
+package migration1586939705
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate sets not null on columns that should always have a value
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+	ALTER TABLE bridge_types ALTER COLUMN url SET NOT NULL;
+	ALTER TABLE bridge_types ALTER COLUMN confirmations SET DEFAULT 0;
+	ALTER TABLE bridge_types ALTER COLUMN confirmations SET NOT NULL;
+	ALTER TABLE bridge_types ALTER COLUMN incoming_token_hash SET NOT NULL;
+	ALTER TABLE bridge_types ALTER COLUMN salt SET NOT NULL;
+	ALTER TABLE bridge_types ALTER COLUMN outgoing_token SET NOT NULL;
+
+	ALTER TABLE configurations ALTER COLUMN created_at SET NOT NULL;
+	ALTER TABLE configurations ALTER COLUMN updated_at SET NOT NULL;
+
+	ALTER TABLE encrypted_secret_keys ALTER COLUMN public_key SET NOT NULL;
+	ALTER TABLE encrypted_secret_keys ALTER COLUMN vrf_key SET NOT NULL;
+
+	ALTER TABLE external_initiators ALTER COLUMN created_at SET NOT NULL;
+	ALTER TABLE external_initiators ALTER COLUMN updated_at SET NOT NULL;
+
+	ALTER TABLE initiators ALTER COLUMN job_spec_id SET NOT NULL;
+	ALTER TABLE initiators ALTER COLUMN created_at SET NOT NULL;
+
+	ALTER TABLE job_runs ALTER COLUMN created_at SET NOT NULL;
+	ALTER TABLE job_runs ALTER COLUMN updated_at SET NOT NULL;
+	ALTER TABLE job_runs ALTER COLUMN job_spec_id SET NOT NULL;
+
+	ALTER TABLE job_specs ALTER COLUMN created_at SET NOT NULL;
+
+	ALTER TABLE keys ALTER COLUMN json SET NOT NULL;
+
+	ALTER TABLE run_requests ALTER COLUMN created_at SET NOT NULL;
+
+	ALTER TABLE service_agreements ALTER COLUMN created_at SET NOT NULL;
+	
+	ALTER TABLE sessions ALTER COLUMN created_at SET NOT NULL;
+
+	ALTER TABLE sync_events ALTER COLUMN created_at SET NOT NULL;
+	ALTER TABLE sync_events ALTER COLUMN updated_at SET NOT NULL;
+	ALTER TABLE sync_events ALTER COLUMN body SET NOT NULL;
+
+	ALTER TABLE task_runs ALTER COLUMN created_at SET NOT NULL;
+	ALTER TABLE task_runs ALTER COLUMN task_spec_id SET NOT NULL;
+	ALTER TABLE task_runs ALTER COLUMN job_run_id SET NOT NULL;
+
+	ALTER TABLE task_specs ALTER COLUMN created_at SET NOT NULL;
+	ALTER TABLE task_specs ALTER COLUMN updated_at SET NOT NULL;
+	ALTER TABLE task_specs ALTER COLUMN job_spec_id SET NOT NULL;
+
+	ALTER TABLE tx_attempts ALTER COLUMN tx_id SET NOT NULL;
+
+	ALTER TABLE users ALTER COLUMN created_at SET NOT NULL;
+	`).Error
+}

--- a/core/store/models/job_run.go
+++ b/core/store/models/job_run.go
@@ -244,7 +244,7 @@ type TaskRun struct {
 	ResultID             clnull.Uint32 `json:"-"`
 	Status               RunStatus     `json:"status"`
 	TaskSpec             TaskSpec      `json:"task" gorm:"association_autoupdate:false;association_autocreate:false"`
-	TaskSpecID           clnull.Uint32 `json:"-"`
+	TaskSpecID           uint          `json:"-"`
 	MinimumConfirmations clnull.Uint32 `json:"minimumConfirmations"`
 	Confirmations        clnull.Uint32 `json:"confirmations"`
 	CreatedAt            time.Time     `json:"-"`

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -194,7 +194,7 @@ const (
 // to a parent JobID.
 type Initiator struct {
 	ID        uint32 `json:"id" gorm:"primary_key;auto_increment"`
-	JobSpecID *ID    `json:"jobSpecId" gorm:"index;type:varchar(36) REFERENCES job_specs(id)"`
+	JobSpecID *ID    `json:"jobSpecId"`
 
 	// Type is one of the Initiator* string constants defined just above.
 	Type            string    `json:"type" gorm:"index;not null"`

--- a/core/store/models/job_spec_test.go
+++ b/core/store/models/job_spec_test.go
@@ -125,7 +125,7 @@ func TestInitiatorParams(t *testing.T) {
 	assert.Equal(t, address, saved.InitiatorParams.Address)
 	assert.Equal(t, requesters, saved.InitiatorParams.Requesters)
 	assert.Equal(t, "foo", saved.InitiatorParams.Name)
-	assert.Equal(t, json, *saved.InitiatorParams.Body)
+	assert.JSONEq(t, json.String(), saved.InitiatorParams.Body.String())
 	assert.Equal(t, big, saved.InitiatorParams.FromBlock)
 	assert.Equal(t, big, saved.InitiatorParams.ToBlock)
 	assert.Equal(t, topics, saved.InitiatorParams.Topics)

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -97,7 +97,7 @@ func TestORM_CreateExternalInitiator(t *testing.T) {
 	exi, err := models.NewExternalInitiator(token, &req)
 	require.NoError(t, err)
 	require.NoError(t, store.CreateExternalInitiator(exi))
-	require.Equal(t, store.CreateExternalInitiator(exi), orm.ErrorConflict)
+	require.Equal(t, store.CreateExternalInitiator(exi).Error(), `pq: duplicate key value violates unique constraint "external_initiators_name_key"`)
 }
 
 func TestORM_DeleteExternalInitiator(t *testing.T) {


### PR DESCRIPTION
This is not an exhaustive list. Some columns remain unclear:

- encumbrances.*
- initiators.*
- job_runs.status
- task_runs.status
- service_agreements.*
- txes.surrogate_id

Timing information:

This migration is fast. On the utility node DB it takes about 150ms.

```
2020-04-15T10:37:28Z [DEBUG]
	ALTER TABLE bridge_types ALTER COLUMN url SET NOT NULL;
	ALTER TABLE bridge_types ALTER COLUMN confirmations SET DEFAULT 0;
	ALTER TABLE bridge_types ALTER COLUMN confirmations SET NOT NULL;
	ALTER TABLE bridge_types ALTER COLUMN incoming_token_hash SET NOT NULL;
	ALTER TABLE bridge_types ALTER COLUMN salt SET NOT NULL;
	ALTER TABLE bridge_types ALTER COLUMN outgoing_token SET NOT NULL;

	ALTER TABLE configurations ALTER COLUMN created_at SET NOT NULL;
	ALTER TABLE configurations ALTER COLUMN updated_at SET NOT NULL;

	ALTER TABLE encrypted_secret_keys ALTER COLUMN public_key SET NOT NULL;
	ALTER TABLE encrypted_secret_keys ALTER COLUMN vrf_key SET NOT NULL;

	ALTER TABLE external_initiators ALTER COLUMN created_at SET NOT NULL;
	ALTER TABLE external_initiators ALTER COLUMN updated_at SET NOT NULL;
	ALTER TABLE external_initiators ALTER COLUMN url SET NOT NULL;

	ALTER TABLE initiators ALTER COLUMN job_spec_id SET NOT NULL;
	ALTER TABLE initiators ALTER COLUMN created_at SET NOT NULL;

	ALTER TABLE job_runs ALTER COLUMN created_at SET NOT NULL;
	ALTER TABLE job_runs ALTER COLUMN updated_at SET NOT NULL;
	ALTER TABLE job_runs ALTER COLUMN job_spec_id SET NOT NULL;

	ALTER TABLE job_specs ALTER COLUMN created_at SET NOT NULL;

	ALTER TABLE keys ALTER COLUMN json SET NOT NULL;

	ALTER TABLE run_requests ALTER COLUMN created_at SET NOT NULL;

	ALTER TABLE service_agreements ALTER COLUMN created_at SET NOT NULL;

	ALTER TABLE sessions ALTER COLUMN created_at SET NOT NULL;

	ALTER TABLE sync_events ALTER COLUMN created_at SET NOT NULL;
	ALTER TABLE sync_events ALTER COLUMN updated_at SET NOT NULL;
	ALTER TABLE sync_events ALTER COLUMN body SET NOT NULL;

	ALTER TABLE task_runs ALTER COLUMN created_at SET NOT NULL;
	ALTER TABLE task_runs ALTER COLUMN task_spec_id SET NOT NULL;
	ALTER TABLE task_runs ALTER COLUMN job_run_id SET NOT NULL;

	ALTER TABLE task_specs ALTER COLUMN created_at SET NOT NULL;
	ALTER TABLE task_specs ALTER COLUMN updated_at SET NOT NULL;
	ALTER TABLE task_specs ALTER COLUMN job_spec_id SET NOT NULL;

	ALTER TABLE tx_attempts ALTER COLUMN tx_id SET NOT NULL;

	ALTER TABLE users ALTER COLUMN created_at SET NOT NULL;
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=0.15653032
```