### PR TITLE
Add unique index on txes.hash

### DIFF
--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -40,6 +40,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586342453"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586369235"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586939705"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586949323"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586956053"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1587027516"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1587580235"
@@ -229,6 +230,10 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "1588293486",
 			Migrate: migration1588293486.Migrate,
+		},
+		{
+			ID:      "1586949323",
+			Migrate: migration1586949323.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration1586949323/migrate.go
+++ b/core/store/migrations/migration1586949323/migrate.go
@@ -1,0 +1,32 @@
+package migration1586949323
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate makes txes.hash a unique index
+// Due to faulty logic, there are some duplicates out in the wild (even though this should never happen).
+// In the case of duplicate hashes, we keep the earliest row for each hash (by ID) and delete all other duplicate rows.
+// Foreign key cascades will also cause all related tx_attempts to be deleted as well.
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+	DROP INDEX IF EXISTS idx_txs_hash;
+
+	WITH duplicate_txes_hash AS (
+		SELECT hash FROM txes GROUP BY hash HAVING count(hash) > 1
+	), txes_to_delete AS (
+		SELECT id
+		FROM txes
+		JOIN duplicate_txes_hash dups ON dups.hash = txes.hash
+		WHERE id NOT IN (
+			SELECT DISTINCT ON (txes.hash) id
+			FROM txes
+			JOIN duplicate_txes_hash dups ON dups.hash = txes.hash
+			ORDER BY txes.hash, id ASC
+		)
+	)
+	DELETE FROM txes WHERE id IN (SELECT id FROM txes_to_delete);
+
+	CREATE UNIQUE INDEX idx_txes_hash ON txes (hash);
+	`).Error
+}

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -1377,7 +1377,7 @@ func TestORM_UnconfirmedTxAttempts(t *testing.T) {
 	})
 
 	t.Run("tx #2, 3 attempts", func(t *testing.T) {
-		transaction := cltest.NewTransaction(0)
+		transaction := cltest.NewTransaction(1)
 		transaction.SurrogateID = null.StringFrom("1")
 		tx, err := store.CreateTx(transaction)
 		require.NoError(t, err)
@@ -1385,11 +1385,11 @@ func TestORM_UnconfirmedTxAttempts(t *testing.T) {
 		_, err = store.AddTxAttempt(tx, transaction)
 		require.NoError(t, err)
 
-		transaction = cltest.NewTransaction(0, 1)
+		transaction = cltest.NewTransaction(1, 1)
 		_, err = store.AddTxAttempt(tx, transaction)
 		require.NoError(t, err)
 
-		transaction = cltest.NewTransaction(0, 2)
+		transaction = cltest.NewTransaction(1, 2)
 		_, err = store.AddTxAttempt(tx, transaction)
 		require.NoError(t, err)
 		require.Len(t, tx.Attempts, 3)
@@ -1404,8 +1404,8 @@ func TestORM_UnconfirmedTxAttempts(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("tx #2, 2 attempts", func(t *testing.T) {
-		transaction := cltest.NewTransaction(0)
+	t.Run("tx #3, 2 attempts", func(t *testing.T) {
+		transaction := cltest.NewTransaction(2)
 		transaction.SurrogateID = null.StringFrom("2")
 		tx, err := store.CreateTx(transaction)
 		require.NoError(t, err)
@@ -1413,7 +1413,7 @@ func TestORM_UnconfirmedTxAttempts(t *testing.T) {
 		_, err = store.AddTxAttempt(tx, transaction)
 		require.NoError(t, err)
 
-		transaction = cltest.NewTransaction(0, 1)
+		transaction = cltest.NewTransaction(2, 1)
 		_, err = store.AddTxAttempt(tx, transaction)
 		require.NoError(t, err)
 

--- a/go.sum
+++ b/go.sum
@@ -219,6 +219,7 @@ github.com/golang/protobuf v1.4.0-rc.1/go.mod h1:ceaxUfeHdC40wWswd/P6IGgMaK3YpKi
 github.com/golang/protobuf v1.4.0-rc.1.0.20200221234624-67d41d38c208/go.mod h1:xKAWHe0F5eneWXFV3EuXVDTCmh+JuBKY0li0aMyXATA=
 github.com/golang/protobuf v1.4.0-rc.2/go.mod h1:LlEzMj4AhA7rCAGe4KMBDvJI+AwstrUpVNzEA03Pprs=
 github.com/golang/protobuf v1.4.0-rc.4.0.20200313231945-b860323f09d0/go.mod h1:WU3c8KckQ9AFe+yFwt9sWVRKCVIyN9cPHBJSNnbL67w=
+github.com/golang/protobuf v1.4.0 h1:oOuy+ugB+P/kBdUnG5QaMXSIyJ1q38wWSojYCb3z5VQ=
 github.com/golang/protobuf v1.4.0/go.mod h1:jodUvKwWbYaEsadDk5Fwe5c77LiNKVO9IDvqG2KuDX0=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db h1:woRePGFeVFfLKN/pOkfl+p/TAqKOfFu+7KPlMVpok/w=
 github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEWrmP2Q=
@@ -439,6 +440,7 @@ github.com/prometheus/procfs v0.0.0-20190507164030-5867b95ac084/go.mod h1:TjEm7z
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.0.8 h1:+fpWZdT24pJBiqJdAwYBjPSk+5YmQzYNPYzQsdzLkt8=
 github.com/prometheus/procfs v0.0.8/go.mod h1:7Qr8sr6344vo1JqZ6HhLceV9o3AJ1Ff+GxbHq6oeK9A=
+github.com/prometheus/procfs v0.0.11 h1:DhHlBtkHWPYi8O2y31JkK0TF+DGM+51OopZjH/Ia5qI=
 github.com/prometheus/procfs v0.0.11/go.mod h1:lV6e/gmhEcM9IjHGsFOCxxuZ+z1YqCvr4OA4YeYWdaU=
 github.com/prometheus/tsdb v0.6.2-0.20190402121629-4f204dcbc150/go.mod h1:qhTCs0VvXwvX/y3TZrWD7rabWM+ijKTux40TwIPHuXU=
 github.com/prometheus/tsdb v0.7.1 h1:YZcsG11NqnK4czYLrWd9mpEuAJIHVQLwdrleYfszMAA=
@@ -642,6 +644,7 @@ golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200122134326-e047566fdf82/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527 h1:uYVVQ9WP/Ds2ROhcaGPeIdVq0RIXVLwsHlnvJ+cT1So=
 golang.org/x/sys v0.0.0-20200302150141-5c8b2ff67527/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f h1:gWF768j/LaZugp8dyS4UwsslYCYz9XgFxvlgsn0n9H8=
 golang.org/x/sys v0.0.0-20200420163511-1957bb5e6d1f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -686,6 +689,7 @@ google.golang.org/protobuf v0.0.0-20200109180630-ec00e32a8dfd/go.mod h1:DFci5gLY
 google.golang.org/protobuf v0.0.0-20200221191635-4d8936d0db64/go.mod h1:kwYJMbMJ01Woi6D6+Kah6886xMZcty6N08ah7+eCXa0=
 google.golang.org/protobuf v0.0.0-20200228230310-ab0ca4ff8a60/go.mod h1:cfTl7dwQJ+fmap5saPgwCLgHXTUD7jkjRqWcaiX5VyM=
 google.golang.org/protobuf v1.20.1-0.20200309200217-e05f789c0967/go.mod h1:A+miEFZTKqfCUM6K7xSMQL9OKL/b6hQv+e19PK+JZNE=
+google.golang.org/protobuf v1.21.0 h1:qdOKuR/EIArgaWNjetjgTzgVTAZ+S/WXVrq9HW9zimw=
 google.golang.org/protobuf v1.21.0/go.mod h1:47Nbq4nVaFHyn7ilMalzfO3qCViNmqZ2kzikPIcrTAo=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
The code assumes that the hash on txes is unique, but it isn't enforced. And
there are duplicates in the wild. Enforcing this may cause the code to error
out in some edge cases where it wouldn't have before, exposing whatever bug
caused these duplicates to appear.

Migration is fast. Timing information on utility node DB:

```
	DROP INDEX IF EXISTS idx_txs_hash;

	WITH duplicate_txes_hash AS (
		SELECT hash FROM txes GROUP BY hash HAVING count(hash) > 1
	), txes_to_delete AS (
		SELECT id
		FROM txes
		JOIN duplicate_txes_hash dups ON dups.hash = txes.hash
		WHERE id NOT IN (
			SELECT DISTINCT ON (txes.hash) id
			FROM txes
			JOIN duplicate_txes_hash dups ON dups.hash = txes.hash
			ORDER BY txes.hash, id ASC
		)
	)
	DELETE FROM txes WHERE id IN (SELECT id FROM txes_to_delete);

	CREATE UNIQUE INDEX idx_txes_hash ON txes (hash);
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=0.434967806
```