### PR TITLE
Add created_at/updated_at to tables where appropriate

### DIFF
--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -40,6 +40,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586342453"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586369235"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586939705"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586956053"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1587027516"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1587580235"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1587975059"
@@ -219,6 +220,10 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "1587975059",
 			Migrate: migration1587975059.Migrate,
+		},
+		{
+			ID:      "1586956053",
+			Migrate: migration1586956053.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration1586956053/migrate.go
+++ b/core/store/migrations/migration1586956053/migrate.go
@@ -1,0 +1,97 @@
+package migration1586956053
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate adds timestamps to tables that ought to have them, but don't
+// Also add some indexes where appropriate
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+	ALTER TABLE bridge_types ADD COLUMN IF NOT EXISTS created_at timestamptz;
+	UPDATE bridge_types SET created_at = '2019-01-01' WHERE created_at IS NULL;
+	CREATE INDEX idx_bridge_types_created_at ON bridge_types USING BRIN (created_at);
+	ALTER TABLE bridge_types ALTER COLUMN created_at SET NOT NULL;
+
+	ALTER TABLE bridge_types ADD COLUMN IF NOT EXISTS updated_at timestamptz;
+	UPDATE bridge_types SET updated_at = '2019-01-01' WHERE updated_at IS NULL;
+	CREATE INDEX idx_bridge_types_updated_at ON bridge_types USING BRIN (updated_at);
+	ALTER TABLE bridge_types ALTER COLUMN updated_at SET NOT NULL;
+
+	ALTER TABLE encrypted_secret_keys ADD COLUMN IF NOT EXISTS created_at timestamptz;
+	UPDATE encrypted_secret_keys SET created_at = '2019-01-01' WHERE created_at IS NULL;
+	ALTER TABLE encrypted_secret_keys ALTER COLUMN created_at SET NOT NULL;
+
+	ALTER TABLE encrypted_secret_keys ADD COLUMN IF NOT EXISTS updated_at timestamptz;
+	UPDATE encrypted_secret_keys SET updated_at = '2019-01-01' WHERE updated_at IS NULL;
+	ALTER TABLE encrypted_secret_keys ALTER COLUMN updated_at SET NOT NULL;
+
+	ALTER TABLE encumbrances ADD COLUMN created_at timestamptz;
+	UPDATE encumbrances SET created_at = '2019-01-01';
+	CREATE INDEX idx_encumbrances_created_at ON encumbrances USING BRIN (created_at);
+	ALTER TABLE encumbrances ALTER COLUMN created_at SET NOT NULL;
+
+	ALTER TABLE encumbrances ADD COLUMN updated_at timestamptz;
+	UPDATE encumbrances SET updated_at = '2019-01-01';
+	CREATE INDEX idx_encumbrances_updated_at ON encumbrances USING BRIN (updated_at);
+	ALTER TABLE encumbrances ALTER COLUMN updated_at SET NOT NULL;
+
+	ALTER TABLE initiators ADD COLUMN updated_at timestamptz;
+	UPDATE initiators SET updated_at = '2019-01-01';
+	CREATE INDEX idx_initiators_updated_at ON initiators USING BRIN (updated_at);
+	ALTER TABLE initiators ALTER COLUMN updated_at SET NOT NULL;
+
+	ALTER TABLE job_specs ADD COLUMN updated_at timestamptz;
+	UPDATE job_specs SET updated_at = '2019-01-01';
+	CREATE INDEX idx_job_specs_updated_at ON job_specs USING BRIN (updated_at);
+	ALTER TABLE job_specs ALTER COLUMN updated_at SET NOT NULL;
+
+	ALTER TABLE keys ADD COLUMN IF NOT EXISTS created_at timestamptz;
+	UPDATE keys SET created_at = '2019-01-01' WHERE created_at IS NULL;
+	ALTER TABLE keys ALTER COLUMN created_at SET NOT NULL;
+
+	ALTER TABLE keys ADD COLUMN IF NOT EXISTS updated_at timestamptz;
+	UPDATE keys SET updated_at = '2019-01-01' WHERE updated_at IS NULL;
+	ALTER TABLE keys ALTER COLUMN updated_at SET NOT NULL;
+
+	ALTER TABLE run_results ADD COLUMN created_at timestamptz;
+	UPDATE run_results SET created_at = '2019-01-01';
+	CREATE INDEX idx_run_results_created_at ON run_results USING BRIN (created_at);
+	ALTER TABLE run_results ALTER COLUMN created_at SET NOT NULL;
+
+	ALTER TABLE run_results ADD COLUMN updated_at timestamptz;
+	UPDATE run_results SET updated_at = '2019-01-01';
+	CREATE INDEX idx_run_results_updated_at ON run_results USING BRIN (updated_at);
+	ALTER TABLE run_results ALTER COLUMN updated_at SET NOT NULL;
+
+	ALTER TABLE service_agreements ADD COLUMN updated_at timestamptz;
+	UPDATE service_agreements SET updated_at = '2019-01-01';
+	CREATE INDEX idx_service_agreements_updated_at ON service_agreements USING BRIN (updated_at);
+	ALTER TABLE service_agreements ALTER COLUMN updated_at SET NOT NULL;
+
+	ALTER TABLE task_runs ADD COLUMN updated_at timestamptz;
+	UPDATE task_runs SET updated_at = '2019-01-01';
+	CREATE INDEX idx_task_runs_updated_at ON task_runs USING BRIN (updated_at);
+	ALTER TABLE task_runs ALTER COLUMN updated_at SET NOT NULL;
+	
+	ALTER TABLE tx_attempts ADD COLUMN IF NOT EXISTS updated_at timestamptz;
+	UPDATE tx_attempts SET updated_at = '2019-01-01' WHERE updated_at IS NULL;
+	CREATE INDEX idx_tx_attempts_updated_at ON tx_attempts USING BRIN (updated_at);
+	ALTER TABLE tx_attempts ALTER COLUMN updated_at SET NOT NULL;
+
+	ALTER TABLE txes ADD COLUMN IF NOT EXISTS created_at timestamptz;
+	UPDATE txes SET created_at = '2019-01-01' WHERE created_at IS NULL;
+	CREATE INDEX idx_txes_created_at ON txes USING BRIN (created_at);
+	ALTER TABLE txes ALTER COLUMN created_at SET NOT NULL;
+
+	ALTER TABLE txes ADD COLUMN IF NOT EXISTS updated_at timestamptz;
+	UPDATE txes SET updated_at = '2019-01-01' WHERE updated_at IS NULL;
+	CREATE INDEX idx_txes_updated_at ON txes USING BRIN (updated_at);
+	ALTER TABLE txes ALTER COLUMN updated_at SET NOT NULL;
+
+	ALTER TABLE users ADD COLUMN IF NOT EXISTS updated_at timestamptz;
+	UPDATE users SET updated_at = '2019-01-01' WHERE updated_at IS NULL;
+	CREATE INDEX idx_users_updated_at ON users USING BRIN (updated_at);
+	ALTER TABLE users ALTER COLUMN updated_at SET NOT NULL;
+	`).Error
+}

--- a/core/store/models/bridge_type.go
+++ b/core/store/models/bridge_type.go
@@ -3,6 +3,7 @@ package models
 import (
 	"crypto/subtle"
 	"fmt"
+	"time"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/utils"
@@ -70,6 +71,8 @@ type BridgeType struct {
 	Salt                   string       `json:"-"`
 	OutgoingToken          string       `json:"outgoingToken"`
 	MinimumContractPayment *assets.Link `json:"minimumContractPayment" gorm:"type:varchar(255)"`
+	CreatedAt              time.Time    `json:"-"`
+	UpdatedAt              time.Time    `json:"-"`
 }
 
 // GetID returns the ID of this structure for jsonapi serialization.

--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -38,6 +38,8 @@ type Tx struct {
 	Confirmed   bool        `gorm:"not null"`
 	SentAt      uint64      `gorm:"not null"`
 	SignedRawTx []byte      `gorm:"not null"`
+	CreatedAt   time.Time   `json:"-"`
+	UpdatedAt   time.Time   `json:"-"`
 }
 
 // String implements Stringer for Tx
@@ -80,6 +82,7 @@ type TxAttempt struct {
 	Confirmed   bool        `gorm:"not null"`
 	SentAt      uint64      `gorm:"not null"`
 	SignedRawTx []byte      `gorm:"not null"`
+	UpdatedAt   time.Time   `json:"-"`
 }
 
 // String implements Stringer for TxAttempt

--- a/core/store/models/job_run.go
+++ b/core/store/models/job_run.go
@@ -249,6 +249,7 @@ type TaskRun struct {
 	MinimumConfirmations clnull.Uint32 `json:"minimumConfirmations"`
 	Confirmations        clnull.Uint32 `json:"confirmations"`
 	CreatedAt            time.Time     `json:"-"`
+	UpdatedAt            time.Time     `json:"-"`
 }
 
 // String returns info on the TaskRun as "ID,Type,Status,Result".
@@ -287,4 +288,6 @@ type RunResult struct {
 	ID           uint32      `json:"-" gorm:"primary_key;auto_increment"`
 	Data         JSON        `json:"data" gorm:"type:text"`
 	ErrorMessage null.String `json:"error"`
+	CreatedAt    time.Time   `json:"-"`
+	UpdatedAt    time.Time   `json:"-"`
 }

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -53,6 +53,7 @@ type JobSpec struct {
 	StartAt    null.Time    `json:"startAt" gorm:"index"`
 	EndAt      null.Time    `json:"endAt" gorm:"index"`
 	DeletedAt  null.Time    `json:"-" gorm:"index"`
+	UpdatedAt  time.Time    `json:"-"`
 }
 
 // GetID returns the ID of this structure for jsonapi serialization.
@@ -200,6 +201,7 @@ type Initiator struct {
 	CreatedAt       time.Time `json:"createdAt" gorm:"index"`
 	InitiatorParams `json:"params,omitempty"`
 	DeletedAt       null.Time `json:"-" gorm:"index"`
+	UpdatedAt       time.Time `json:"-"`
 }
 
 // InitiatorParams is a collection of the possible parameters that different

--- a/core/store/models/key.go
+++ b/core/store/models/key.go
@@ -3,6 +3,7 @@ package models
 import (
 	"errors"
 	"io/ioutil"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/tidwall/gjson"
@@ -16,8 +17,10 @@ import (
 //
 // By default, a key is assumed to represent an ethereum account.
 type Key struct {
-	Address EIP55Address `gorm:"primary_key;type:varchar(64)"`
-	JSON    JSON         `gorm:"type:text"`
+	Address   EIP55Address `gorm:"primary_key;type:varchar(64)"`
+	JSON      JSON         `gorm:"type:text"`
+	CreatedAt time.Time    `json:"-"`
+	UpdatedAt time.Time    `json:"-"`
 }
 
 type EncryptedSecretVRFKey = vrfkey.EncryptedSecretKey

--- a/core/store/models/service_agreement.go
+++ b/core/store/models/service_agreement.go
@@ -35,6 +35,8 @@ type Encumbrance struct {
 	AggInitiateJobSelector eth.FunctionSelector `json:"aggInitiateJobSelector" gorm:"not null"`
 	// selector for fulfillment (oracle reporting) method on aggregator contract
 	AggFulfillSelector eth.FunctionSelector `json:"aggFulfillSelector" gorm:"not null"`
+	CreatedAt          time.Time            `json:"-"`
+	UpdatedAt          time.Time            `json:"-"`
 }
 
 // UnsignedServiceAgreement contains the information to sign a service agreement
@@ -55,6 +57,7 @@ type ServiceAgreement struct {
 	Signature     Signature   `json:"signature" gorm:"type:varchar(255)"`
 	JobSpec       JobSpec     `gorm:"foreignkey:JobSpecID"`
 	JobSpecID     *ID         `json:"jobSpecId"`
+	UpdatedAt     time.Time   `json:"-"`
 }
 
 // ServiceAgreementRequest encodes external ServiceAgreement json representation.

--- a/core/store/models/user.go
+++ b/core/store/models/user.go
@@ -20,6 +20,7 @@ type User struct {
 	TokenKey          string    `json:"tokenKey"`
 	TokenSalt         string    `json:"-"`
 	TokenHashedSecret string    `json:"-"`
+	UpdatedAt         time.Time `json:"-"`
 }
 
 // https://davidcel.is/posts/stop-validating-email-addresses-with-regex/

--- a/core/store/models/vrfkey/serialization.go
+++ b/core/store/models/vrfkey/serialization.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/pkg/errors"
@@ -18,6 +19,8 @@ import (
 type EncryptedSecretKey struct {
 	PublicKey PublicKey     `gorm:"primary_key;type:varchar(68)"`
 	VRFKey    gethKeyStruct `json:"vrf_key" gorm:"type:text"`
+	CreatedAt time.Time     `json:"-"`
+	UpdatedAt time.Time     `json:"-"`
 }
 
 // passwordPrefix is added to the beginning of the passwords for

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -1127,7 +1127,7 @@ func (orm *ORM) BulkDeleteRuns(bulkQuery *models.BulkDeleteRunRequest) error {
 func (orm *ORM) Keys() ([]*models.Key, error) {
 	orm.MustEnsureAdvisoryLock()
 	var keys []*models.Key
-	return keys, orm.db.Find(&keys).Error
+	return keys, orm.db.Find(&keys).Order("created_at ASC").Error
 }
 
 // FirstOrCreateKey returns the first key found or creates a new one in the orm.


### PR DESCRIPTION
This takes about ~20s on the utility node.

We are already over our migration budget for 0.8.3 so this one ought to wait.