### PR TITLE
Chore/172225059 use db handle more carefully explorer

### DIFF
--- a/explorer/jest.setup.ts
+++ b/explorer/jest.setup.ts
@@ -9,4 +9,6 @@ beforeAll(async () => {
   globalDBConnection = await openDbConnection()
 })
 afterEach(() => clearDb())
-afterAll(async () => await globalDBConnection.close())
+afterAll(async () => {
+  await globalDBConnection.close()
+})

--- a/explorer/jest.setup.ts
+++ b/explorer/jest.setup.ts
@@ -1,5 +1,12 @@
+import { Connection } from 'typeorm'
+import { openDbConnection } from './src/database'
 import { clearDb } from './src/__tests__/testdatabase'
 
 process.env.NODE_ENV = 'test'
 
-afterEach(async () => clearDb())
+let globalDBConnection: Connection
+beforeAll(async () => {
+  globalDBConnection = await openDbConnection()
+})
+afterEach(() => clearDb())
+afterAll(async () => await globalDBConnection.close())

--- a/explorer/src/__tests__/controllers/admin/heads.test.ts
+++ b/explorer/src/__tests__/controllers/admin/heads.test.ts
@@ -2,7 +2,7 @@ import http from 'http'
 import httpStatus from 'http-status-codes'
 import { Connection } from 'typeorm'
 import { BigNumber } from 'bignumber.js'
-import { getDb } from '../../../database'
+import { getDb } from '../../testdatabase'
 import { clearDb } from '../../testdatabase'
 import { createAdmin } from '../../../support/admin'
 import { Head } from '../../../entity/Head'
@@ -18,9 +18,11 @@ let server: http.Server
 let db: Connection
 let rb: RequestBuilder
 
+beforeEach(() => {
+  db = getDb()
+})
 beforeAll(async () => {
-  db = await getDb()
-  server = await start()
+  server = await start(db)
   rb = requestBuilder(server)
 })
 afterAll(done => stop(server, done))

--- a/explorer/src/__tests__/controllers/admin/heads.test.ts
+++ b/explorer/src/__tests__/controllers/admin/heads.test.ts
@@ -1,8 +1,7 @@
 import http from 'http'
 import httpStatus from 'http-status-codes'
-import { Connection } from 'typeorm'
+import { getRepository } from 'typeorm'
 import { BigNumber } from 'bignumber.js'
-import { getDb } from '../../testdatabase'
 import { clearDb } from '../../testdatabase'
 import { createAdmin } from '../../../support/admin'
 import { Head } from '../../../entity/Head'
@@ -15,20 +14,16 @@ const ADMIN_PATH = '/api/v1/admin'
 const adminHeadsPath = `${ADMIN_PATH}/heads`
 
 let server: http.Server
-let db: Connection
 let rb: RequestBuilder
 
-beforeEach(() => {
-  db = getDb()
-})
 beforeAll(async () => {
-  server = await start(db)
+  server = await start()
   rb = requestBuilder(server)
 })
 afterAll(done => stop(server, done))
 beforeEach(async () => {
   await clearDb()
-  await createAdmin(db, USERNAME, PASSWORD)
+  await createAdmin(USERNAME, PASSWORD)
 })
 
 describe('GET /api/v1/admin/heads', () => {
@@ -117,5 +112,5 @@ const DEFAULT_HEAD_ATTRS: Pick<
 
 function createHead(attrs: Partial<Head> = {}): Promise<Head> {
   const head = Head.build({ ...DEFAULT_HEAD_ATTRS, ...attrs })
-  return db.manager.save(head)
+  return getRepository(Head).save(head)
 }

--- a/explorer/src/__tests__/controllers/admin/login.test.ts
+++ b/explorer/src/__tests__/controllers/admin/login.test.ts
@@ -1,11 +1,10 @@
 import http from 'http'
 import request from 'supertest'
 import { Connection } from 'typeorm'
-import { getDb } from '../../../database'
+import { getDb } from '../../testdatabase'
 import { createAdmin } from '../../../support/admin'
 import { requestBuilder, RequestBuilder } from '../../../support/requestBuilder'
 import { start, stop } from '../../../support/server'
-import { clearDb } from '../../testdatabase'
 
 const USERNAME = 'myadmin'
 const PASSWORD = 'validpassword'
@@ -15,16 +14,17 @@ let server: http.Server
 let db: Connection
 let rb: RequestBuilder
 
+beforeEach(() => {
+  db = getDb()
+})
 beforeAll(async () => {
-  db = await getDb()
-  server = await start()
+  server = await start(db)
   rb = requestBuilder(server)
 })
 afterAll(done => stop(server, done))
 
 describe('POST /api/v1/admin/login', () => {
   beforeEach(async () => {
-    await clearDb()
     await createAdmin(db, USERNAME, PASSWORD)
   })
 

--- a/explorer/src/__tests__/controllers/admin/login.test.ts
+++ b/explorer/src/__tests__/controllers/admin/login.test.ts
@@ -1,7 +1,5 @@
 import http from 'http'
 import request from 'supertest'
-import { Connection } from 'typeorm'
-import { getDb } from '../../testdatabase'
 import { createAdmin } from '../../../support/admin'
 import { requestBuilder, RequestBuilder } from '../../../support/requestBuilder'
 import { start, stop } from '../../../support/server'
@@ -11,21 +9,17 @@ const PASSWORD = 'validpassword'
 const adminLoginPath = '/api/v1/admin/login'
 
 let server: http.Server
-let db: Connection
 let rb: RequestBuilder
 
-beforeEach(() => {
-  db = getDb()
-})
 beforeAll(async () => {
-  server = await start(db)
+  server = await start()
   rb = requestBuilder(server)
 })
 afterAll(done => stop(server, done))
 
 describe('POST /api/v1/admin/login', () => {
   beforeEach(async () => {
-    await createAdmin(db, USERNAME, PASSWORD)
+    await createAdmin(USERNAME, PASSWORD)
   })
 
   it('returns a 200 with valid credentials', done => {

--- a/explorer/src/__tests__/controllers/admin/nodes.test.ts
+++ b/explorer/src/__tests__/controllers/admin/nodes.test.ts
@@ -1,7 +1,5 @@
 import http from 'http'
 import httpStatus from 'http-status-codes'
-import { Connection } from 'typeorm'
-import { getDb } from '../../testdatabase'
 import { createAdmin } from '../../../support/admin'
 import {
   createChainlinkNode,
@@ -16,19 +14,15 @@ const ADMIN_PATH = '/api/v1/admin'
 const adminNodesPath = `${ADMIN_PATH}/nodes`
 
 let server: http.Server
-let db: Connection
 let rb: RequestBuilder
 
-beforeEach(() => {
-  db = getDb()
-})
 beforeAll(async () => {
-  server = await start(db)
+  server = await start()
   rb = requestBuilder(server)
 })
 afterAll(done => stop(server, done))
 beforeEach(async () => {
-  await createAdmin(db, USERNAME, PASSWORD)
+  await createAdmin(USERNAME, PASSWORD)
 })
 
 describe('POST /api/v1/admin/nodes', () => {
@@ -62,7 +56,7 @@ describe('POST /api/v1/admin/nodes', () => {
   })
 
   it('returns an error when the node already exists', async done => {
-    const [node] = await createChainlinkNode(db, 'nodeA')
+    const [node] = await createChainlinkNode('nodeA')
     const data = { name: node.name }
 
     rb.sendPost(adminNodesPath, USERNAME, PASSWORD, data)
@@ -83,12 +77,12 @@ describe('DELETE /api/v1/admin/nodes/:name', () => {
   }
 
   it('can delete a node', async done => {
-    const [node] = await createChainlinkNode(db, 'nodeA')
+    const [node] = await createChainlinkNode('nodeA')
 
     rb.sendDelete(path(node.name), USERNAME, PASSWORD)
       .expect(httpStatus.OK)
       .expect(async () => {
-        const nodeAfter = await findNode(db, node.id)
+        const nodeAfter = await findNode(node.id)
         expect(nodeAfter).not.toBeDefined()
       })
       .end(done)
@@ -107,7 +101,7 @@ describe('GET /api/v1/admin/nodes/:id', () => {
   }
 
   it('can get a node', async done => {
-    const [node] = await createChainlinkNode(db, 'nodeA')
+    const [node] = await createChainlinkNode('nodeA')
 
     rb.sendGet(path(node.id), USERNAME, PASSWORD)
       .expect(httpStatus.OK)
@@ -118,7 +112,7 @@ describe('GET /api/v1/admin/nodes/:id', () => {
   })
 
   it('returns a 401 unauthorized with invalid admin credentials', async done => {
-    const [node] = await createChainlinkNode(db, 'nodeA')
+    const [node] = await createChainlinkNode('nodeA')
     const _nodePath = path(node.id)
     rb.sendGet(_nodePath, USERNAME, 'invalidpassword')
       .expect(httpStatus.UNAUTHORIZED)

--- a/explorer/src/__tests__/controllers/admin/nodes.test.ts
+++ b/explorer/src/__tests__/controllers/admin/nodes.test.ts
@@ -1,8 +1,7 @@
 import http from 'http'
 import httpStatus from 'http-status-codes'
 import { Connection } from 'typeorm'
-import { getDb } from '../../../database'
-import { clearDb } from '../../testdatabase'
+import { getDb } from '../../testdatabase'
 import { createAdmin } from '../../../support/admin'
 import {
   createChainlinkNode,
@@ -20,14 +19,15 @@ let server: http.Server
 let db: Connection
 let rb: RequestBuilder
 
+beforeEach(() => {
+  db = getDb()
+})
 beforeAll(async () => {
-  db = await getDb()
-  server = await start()
+  server = await start(db)
   rb = requestBuilder(server)
 })
 afterAll(done => stop(server, done))
 beforeEach(async () => {
-  await clearDb()
   await createAdmin(db, USERNAME, PASSWORD)
 })
 

--- a/explorer/src/__tests__/controllers/jobRuns.test.ts
+++ b/explorer/src/__tests__/controllers/jobRuns.test.ts
@@ -1,23 +1,26 @@
 import http from 'http'
 import request from 'supertest'
 import { Connection } from 'typeorm'
-import { getDb } from '../../database'
 import { ChainlinkNode, createChainlinkNode } from '../../entity/ChainlinkNode'
 import { JobRun } from '../../entity/JobRun'
 import { TaskRun } from '../../entity/TaskRun'
 import { createJobRun } from '../../factories'
 import { start, stop } from '../../support/server'
+import { getDb } from '../testdatabase'
 
 let server: http.Server
-let db: Connection
 
+let db: Connection
+beforeEach(async () => {
+  db = getDb()
+})
 beforeAll(async () => {
-  db = await getDb()
-  server = await start()
+  server = await start(db)
 })
 afterAll(done => stop(server, done))
 
 describe('#index', () => {
+
   describe('with no runs', () => {
     it('returns empty', async () => {
       const response = await request(server).get('/api/v1/job_runs')

--- a/explorer/src/__tests__/controllers/jobRuns.test.ts
+++ b/explorer/src/__tests__/controllers/jobRuns.test.ts
@@ -14,7 +14,6 @@ beforeAll(async () => {
 afterAll(done => stop(server, done))
 
 describe('#index', () => {
-
   describe('with no runs', () => {
     it('returns empty', async () => {
       const response = await request(server).get('/api/v1/job_runs')
@@ -64,7 +63,9 @@ describe('#show', () => {
   describe('with out of order task runs', () => {
     let jobRunId: string
     beforeEach(async () => {
-      const [chainlinkNode] = await createChainlinkNode('testOutOfOrderTaskRuns')
+      const [chainlinkNode] = await createChainlinkNode(
+        'testOutOfOrderTaskRuns',
+      )
       const jobRun = new JobRun()
       jobRun.chainlinkNodeId = chainlinkNode.id
       jobRun.runId = 'OutOfOrderTaskRuns'

--- a/explorer/src/__tests__/entity/ChainlinkNode.test.ts
+++ b/explorer/src/__tests__/entity/ChainlinkNode.test.ts
@@ -1,4 +1,5 @@
 import { Connection } from 'typeorm'
+import { getDb } from '../testdatabase'
 import {
   ChainlinkNode,
   createChainlinkNode,
@@ -7,7 +8,6 @@ import {
   uptime,
 } from '../../entity/ChainlinkNode'
 import { createSession, closeSession } from '../../entity/Session'
-import { closeDbConnection, getDb } from '../../database'
 
 async function wait(sec: number) {
   return new Promise(res => {
@@ -18,12 +18,9 @@ async function wait(sec: number) {
 }
 
 let db: Connection
-
-beforeAll(async () => {
-  db = await getDb()
+beforeEach(() => {
+  db = getDb()
 })
-
-afterAll(async () => closeDbConnection())
 
 describe('createChainlinkNode', () => {
   it('returns a valid ChainlinkNode record', async () => {

--- a/explorer/src/__tests__/entity/ChainlinkNode.test.ts
+++ b/explorer/src/__tests__/entity/ChainlinkNode.test.ts
@@ -18,7 +18,9 @@ async function wait(sec: number) {
 
 describe('createChainlinkNode', () => {
   it('returns a valid ChainlinkNode record', async () => {
-    const [chainlinkNode, secret] = await createChainlinkNode('new-valid-chainlink-node-record')
+    const [chainlinkNode, secret] = await createChainlinkNode(
+      'new-valid-chainlink-node-record',
+    )
     expect(chainlinkNode.accessKey).toHaveLength(16)
     expect(chainlinkNode.salt).toHaveLength(32)
     expect(chainlinkNode.hashedSecret).toBeDefined()

--- a/explorer/src/__tests__/entity/ChainlinkNode.test.ts
+++ b/explorer/src/__tests__/entity/ChainlinkNode.test.ts
@@ -1,5 +1,4 @@
-import { Connection } from 'typeorm'
-import { getDb } from '../testdatabase'
+import { getRepository } from 'typeorm'
 import {
   ChainlinkNode,
   createChainlinkNode,
@@ -17,17 +16,9 @@ async function wait(sec: number) {
   })
 }
 
-let db: Connection
-beforeEach(() => {
-  db = getDb()
-})
-
 describe('createChainlinkNode', () => {
   it('returns a valid ChainlinkNode record', async () => {
-    const [chainlinkNode, secret] = await createChainlinkNode(
-      db,
-      'new-valid-chainlink-node-record',
-    )
+    const [chainlinkNode, secret] = await createChainlinkNode('new-valid-chainlink-node-record')
     expect(chainlinkNode.accessKey).toHaveLength(16)
     expect(chainlinkNode.salt).toHaveLength(32)
     expect(chainlinkNode.hashedSecret).toBeDefined()
@@ -35,18 +26,18 @@ describe('createChainlinkNode', () => {
   })
 
   it('reject duplicate ChainlinkNode names', async () => {
-    await createChainlinkNode(db, 'identical')
-    await expect(createChainlinkNode(db, 'identical')).rejects.toThrow()
+    await createChainlinkNode('identical')
+    await expect(createChainlinkNode('identical')).rejects.toThrow()
   })
 })
 
 describe('deleteChainlinkNode', () => {
   it('deletes a ChainlinkNode with the specified name', async () => {
-    await createChainlinkNode(db, 'chainlink-node-to-be-deleted')
-    let count = await db.manager.count(ChainlinkNode)
+    await createChainlinkNode('chainlink-node-to-be-deleted')
+    let count = await getRepository(ChainlinkNode).count()
     expect(count).toBe(1)
-    await deleteChainlinkNode(db, 'chainlink-node-to-be-deleted')
-    count = await db.manager.count(ChainlinkNode)
+    await deleteChainlinkNode('chainlink-node-to-be-deleted')
+    count = await getRepository(ChainlinkNode).count()
     expect(count).toBe(0)
   })
 })
@@ -59,22 +50,22 @@ describe('hashCredentials', () => {
 
 describe('uptime', () => {
   it('returns 0 when no sessions exist', async () => {
-    const [node] = await createChainlinkNode(db, 'chainlink-node')
-    const initialUptime = await uptime(db, node)
+    const [node] = await createChainlinkNode('chainlink-node')
+    const initialUptime = await uptime(node)
     expect(initialUptime).toEqual(0)
   })
 
   it('calculates uptime based on open and closed sessions', async () => {
-    const [node] = await createChainlinkNode(db, 'chainlink-node')
-    const session = await createSession(db, node)
+    const [node] = await createChainlinkNode('chainlink-node')
+    const session = await createSession(node)
     await wait(1)
-    await closeSession(db, session)
-    const uptime1 = await uptime(db, node)
+    await closeSession(session)
+    const uptime1 = await uptime(node)
     expect(uptime1).toBeGreaterThan(0)
     expect(uptime1).toBeLessThan(3)
-    await createSession(db, node)
+    await createSession(node)
     await wait(1)
-    const uptime2 = await uptime(db, node)
+    const uptime2 = await uptime(node)
     expect(uptime2).toBeGreaterThan(uptime1)
     expect(uptime2).toBeLessThan(4)
   })

--- a/explorer/src/__tests__/entity/JobRun.test.ts
+++ b/explorer/src/__tests__/entity/JobRun.test.ts
@@ -1,14 +1,8 @@
-import { Connection } from 'typeorm'
-import { getDb } from '../testdatabase'
+import { getRepository } from 'typeorm'
 import { createChainlinkNode } from '../../entity/ChainlinkNode'
 import { fromString, JobRun, saveJobRunTree } from '../../entity/JobRun'
 import ethtxFixture from '../fixtures/JobRun.ethtx.fixture.json'
 import fixture from '../fixtures/JobRun.fixture.json'
-
-let db: Connection
-beforeEach(() => {
-  db = getDb()
-})
 
 describe('entity/jobRun/fromString', () => {
   it('successfully creates a run and tasks from json', async () => {
@@ -36,12 +30,9 @@ describe('entity/jobRun/fromString', () => {
     expect(jr.taskRuns[0].minimumConfirmations).toEqual('3')
     expect(jr.taskRuns[0].error).toEqual(null)
 
-    const [chainlinkNode] = await createChainlinkNode(
-      db,
-      'job-run-fromString-chainlink-node',
-    )
+    const [chainlinkNode] = await createChainlinkNode('job-run-fromString-chainlink-node')
     jr.chainlinkNodeId = chainlinkNode.id
-    const r = await db.manager.save(jr)
+    const r = await getRepository(JobRun).save(jr)
     expect(r.id).toBeDefined()
     expect(r.type).toEqual('runlog')
     expect(r.taskRuns.length).toEqual(1)
@@ -83,39 +74,33 @@ describe('entity/jobRun/fromString', () => {
 
 describe('entity/jobRun/saveJobRunTree', () => {
   it('updates jobRun error', async () => {
-    const [chainlinkNode] = await createChainlinkNode(
-      db,
-      'testOverwriteJobRunsErrorOnConflict',
-    )
+    const [chainlinkNode] = await createChainlinkNode('testOverwriteJobRunsErrorOnConflict')
 
     const jr = fromString(JSON.stringify(fixture))
     jr.chainlinkNodeId = chainlinkNode.id
-    await saveJobRunTree(db, jr)
+    await saveJobRunTree(jr)
 
-    const initial = await db.manager.findOne(JobRun)
+    const initial = await getRepository(JobRun).findOne()
     expect(initial.status).toEqual('in_progress')
     expect(initial.finishedAt).toBeNull()
 
     jr.status = 'errored'
     jr.error = 'something bad happened'
     jr.finishedAt = new Date('2018-04-01T22:07:04Z')
-    await saveJobRunTree(db, jr)
+    await saveJobRunTree(jr)
 
-    const actual = await db.manager.findOne(JobRun)
+    const actual = await getRepository(JobRun).findOne()
     expect(actual.status).toEqual(jr.status)
     expect(actual.finishedAt).toEqual(jr.finishedAt)
     expect(actual.error).toEqual(jr.error)
   })
 
   it('overwrites taskRun values on conflict', async () => {
-    const [chainlinkNode] = await createChainlinkNode(
-      db,
-      'testOverwriteTaskRunsOnConflict',
-    )
+    const [chainlinkNode] = await createChainlinkNode('testOverwriteTaskRunsOnConflict')
 
     const jr = fromString(JSON.stringify(fixture))
     jr.chainlinkNodeId = chainlinkNode.id
-    await saveJobRunTree(db, jr)
+    await saveJobRunTree(jr)
 
     const modifications = {
       confirmations: '2',
@@ -127,14 +112,14 @@ describe('entity/jobRun/saveJobRunTree', () => {
       transactionStatus: 'fulfilledRunLog',
     }
 
-    const initial = await db.manager.findOne(JobRun)
+    const initial = await getRepository(JobRun).findOne()
     const initialTask = initial.taskRuns[0]
     expect(initialTask).not.toMatchObject(modifications)
 
     Object.assign(jr.taskRuns[0], modifications)
-    await saveJobRunTree(db, jr)
+    await saveJobRunTree(jr)
 
-    const actual = await db.manager.findOne(JobRun)
+    const actual = await getRepository(JobRun).findOne()
     const actualTask = actual.taskRuns[0]
     expect(actualTask).toMatchObject(modifications)
   })

--- a/explorer/src/__tests__/entity/JobRun.test.ts
+++ b/explorer/src/__tests__/entity/JobRun.test.ts
@@ -1,17 +1,14 @@
 import { Connection } from 'typeorm'
-import { closeDbConnection, getDb } from '../../database'
+import { getDb } from '../testdatabase'
 import { createChainlinkNode } from '../../entity/ChainlinkNode'
 import { fromString, JobRun, saveJobRunTree } from '../../entity/JobRun'
 import ethtxFixture from '../fixtures/JobRun.ethtx.fixture.json'
 import fixture from '../fixtures/JobRun.fixture.json'
 
 let db: Connection
-
-beforeAll(async () => {
-  db = await getDb()
+beforeEach(() => {
+  db = getDb()
 })
-
-afterAll(async () => closeDbConnection())
 
 describe('entity/jobRun/fromString', () => {
   it('successfully creates a run and tasks from json', async () => {

--- a/explorer/src/__tests__/entity/JobRun.test.ts
+++ b/explorer/src/__tests__/entity/JobRun.test.ts
@@ -30,7 +30,9 @@ describe('entity/jobRun/fromString', () => {
     expect(jr.taskRuns[0].minimumConfirmations).toEqual('3')
     expect(jr.taskRuns[0].error).toEqual(null)
 
-    const [chainlinkNode] = await createChainlinkNode('job-run-fromString-chainlink-node')
+    const [chainlinkNode] = await createChainlinkNode(
+      'job-run-fromString-chainlink-node',
+    )
     jr.chainlinkNodeId = chainlinkNode.id
     const r = await getRepository(JobRun).save(jr)
     expect(r.id).toBeDefined()
@@ -74,7 +76,9 @@ describe('entity/jobRun/fromString', () => {
 
 describe('entity/jobRun/saveJobRunTree', () => {
   it('updates jobRun error', async () => {
-    const [chainlinkNode] = await createChainlinkNode('testOverwriteJobRunsErrorOnConflict')
+    const [chainlinkNode] = await createChainlinkNode(
+      'testOverwriteJobRunsErrorOnConflict',
+    )
 
     const jr = fromString(JSON.stringify(fixture))
     jr.chainlinkNodeId = chainlinkNode.id
@@ -96,7 +100,9 @@ describe('entity/jobRun/saveJobRunTree', () => {
   })
 
   it('overwrites taskRun values on conflict', async () => {
-    const [chainlinkNode] = await createChainlinkNode('testOverwriteTaskRunsOnConflict')
+    const [chainlinkNode] = await createChainlinkNode(
+      'testOverwriteTaskRunsOnConflict',
+    )
 
     const jr = fromString(JSON.stringify(fixture))
     jr.chainlinkNodeId = chainlinkNode.id

--- a/explorer/src/__tests__/entity/TaskRun.test.ts
+++ b/explorer/src/__tests__/entity/TaskRun.test.ts
@@ -1,17 +1,14 @@
 import { Connection, getCustomRepository } from 'typeorm'
-import { closeDbConnection, getDb } from '../../database'
+import { getDb } from '../testdatabase'
 import { createChainlinkNode } from '../../entity/ChainlinkNode'
 import { fromString, JobRun, saveJobRunTree } from '../../entity/JobRun'
 import fixture from '../fixtures/JobRun.fixture.json'
 import { JobRunRepository } from '../../repositories/JobRunRepository'
 
 let db: Connection
-
-beforeAll(async () => {
-  db = await getDb()
+beforeEach(() => {
+  db = getDb()
 })
-
-afterAll(async () => closeDbConnection())
 
 describe('entity/taskRun', () => {
   it('copies old confirmations to new column on INSERT', async () => {

--- a/explorer/src/__tests__/entity/TaskRun.test.ts
+++ b/explorer/src/__tests__/entity/TaskRun.test.ts
@@ -6,7 +6,9 @@ import { JobRunRepository } from '../../repositories/JobRunRepository'
 
 describe('entity/taskRun', () => {
   it('copies old confirmations to new column on INSERT', async () => {
-    const [chainlinkNode] = await createChainlinkNode('testOverwriteJobRunsErrorOnConflict')
+    const [chainlinkNode] = await createChainlinkNode(
+      'testOverwriteJobRunsErrorOnConflict',
+    )
 
     const jr = fromString(JSON.stringify(fixture))
     jr.chainlinkNodeId = chainlinkNode.id
@@ -34,7 +36,9 @@ describe('entity/taskRun', () => {
   })
 
   it('copies old confirmations to new column on UPDATE', async () => {
-    const [chainlinkNode] = await createChainlinkNode('testOverwriteJobRunsErrorOnConflict')
+    const [chainlinkNode] = await createChainlinkNode(
+      'testOverwriteJobRunsErrorOnConflict',
+    )
 
     const jr = fromString(JSON.stringify(fixture))
     jr.chainlinkNodeId = chainlinkNode.id

--- a/explorer/src/__tests__/entity/TaskRun.test.ts
+++ b/explorer/src/__tests__/entity/TaskRun.test.ts
@@ -1,29 +1,20 @@
-import { Connection, getCustomRepository } from 'typeorm'
-import { getDb } from '../testdatabase'
+import { getConnection, getCustomRepository, getRepository } from 'typeorm'
 import { createChainlinkNode } from '../../entity/ChainlinkNode'
 import { fromString, JobRun, saveJobRunTree } from '../../entity/JobRun'
 import fixture from '../fixtures/JobRun.fixture.json'
 import { JobRunRepository } from '../../repositories/JobRunRepository'
 
-let db: Connection
-beforeEach(() => {
-  db = getDb()
-})
-
 describe('entity/taskRun', () => {
   it('copies old confirmations to new column on INSERT', async () => {
-    const [chainlinkNode] = await createChainlinkNode(
-      db,
-      'testOverwriteJobRunsErrorOnConflict',
-    )
+    const [chainlinkNode] = await createChainlinkNode('testOverwriteJobRunsErrorOnConflict')
 
     const jr = fromString(JSON.stringify(fixture))
     jr.chainlinkNodeId = chainlinkNode.id
-    await saveJobRunTree(db, jr)
+    await saveJobRunTree(jr)
     expect(jr.id).toBeDefined()
 
     // insert into old columns
-    await db.manager.query(
+    await getConnection().query(
       `
       INSERT INTO task_run("jobRunId", index, type, status, confirmations, "minimumConfirmations")
       VALUES ($1, 1, 'randomtask', 'in_progress', 1, 2);
@@ -31,7 +22,7 @@ describe('entity/taskRun', () => {
       [jr.id],
     )
 
-    const jobRunRepository = getCustomRepository(JobRunRepository, db.name)
+    const jobRunRepository = getCustomRepository(JobRunRepository)
     const retrieved = await jobRunRepository.getFirst()
 
     const task = retrieved.taskRuns[1]
@@ -43,19 +34,16 @@ describe('entity/taskRun', () => {
   })
 
   it('copies old confirmations to new column on UPDATE', async () => {
-    const [chainlinkNode] = await createChainlinkNode(
-      db,
-      'testOverwriteJobRunsErrorOnConflict',
-    )
+    const [chainlinkNode] = await createChainlinkNode('testOverwriteJobRunsErrorOnConflict')
 
     const jr = fromString(JSON.stringify(fixture))
     jr.chainlinkNodeId = chainlinkNode.id
-    await saveJobRunTree(db, jr)
+    await saveJobRunTree(jr)
     expect(jr.id).toBeDefined()
     const tr = jr.taskRuns[0]
 
     // update old columns
-    await db.manager.query(
+    await getConnection().query(
       `
       UPDATE task_run SET confirmations = 9, "minimumConfirmations" = 10
       WHERE id = $1;
@@ -63,7 +51,7 @@ describe('entity/taskRun', () => {
       [tr.id],
     )
 
-    const retrieved = await db.manager.findOne(JobRun, jr.id)
+    const retrieved = await getRepository(JobRun).findOne(jr.id)
     const task = retrieved.taskRuns[0]
 
     expect(task.confirmationsOld).toEqual(9)

--- a/explorer/src/__tests__/middleware/adminAuth.test.ts
+++ b/explorer/src/__tests__/middleware/adminAuth.test.ts
@@ -5,8 +5,7 @@ import express from 'express'
 import http from 'http'
 import httpStatus from 'http-status-codes'
 import request from 'supertest'
-import { Connection } from 'typeorm'
-import { getDb } from '../../database'
+import { getConnection, Connection } from 'typeorm'
 import adminAuth from '../../middleware/adminAuth'
 import { createAdmin } from '../../support/admin'
 import { stop } from '../../support/server'
@@ -39,7 +38,7 @@ let server: http.Server
 let db: Connection
 
 beforeAll(async () => {
-  db = await getDb()
+  db = getConnection()
   server = app.listen(null)
 })
 afterAll(done => stop(server, done))

--- a/explorer/src/__tests__/middleware/adminAuth.test.ts
+++ b/explorer/src/__tests__/middleware/adminAuth.test.ts
@@ -5,7 +5,6 @@ import express from 'express'
 import http from 'http'
 import httpStatus from 'http-status-codes'
 import request from 'supertest'
-import { getConnection, Connection } from 'typeorm'
 import adminAuth from '../../middleware/adminAuth'
 import { createAdmin } from '../../support/admin'
 import { stop } from '../../support/server'
@@ -35,17 +34,15 @@ app.use(ROUTE_PATH, adminAuth)
 app.use(ROUTE_PATH, (_, res) => res.sendStatus(200))
 
 let server: http.Server
-let db: Connection
 
 beforeAll(async () => {
-  db = getConnection()
   server = app.listen(null)
 })
 afterAll(done => stop(server, done))
 
 beforeEach(async () => {
   await clearDb()
-  await createAdmin(db, USERNAME, PASSWORD)
+  await createAdmin(USERNAME, PASSWORD)
 })
 
 function sendPostHeaders(path: string, username: string, password: string) {

--- a/explorer/src/__tests__/queries/Search.test.ts
+++ b/explorer/src/__tests__/queries/Search.test.ts
@@ -6,7 +6,9 @@ import { search, count } from '../../queries/search'
 
 describe('search and count', () => {
   beforeEach(async () => {
-    const [chainlinkNode] = await createChainlinkNode('job-run-search-chainlink-node')
+    const [chainlinkNode] = await createChainlinkNode(
+      'job-run-search-chainlink-node',
+    )
 
     const jrA = fromString(JSON.stringify(fixture))
     jrA.chainlinkNodeId = chainlinkNode.id

--- a/explorer/src/__tests__/queries/Search.test.ts
+++ b/explorer/src/__tests__/queries/Search.test.ts
@@ -1,27 +1,17 @@
+import { getRepository } from 'typeorm'
 import fixture from '../fixtures/JobRun.fixture.json'
-import { getDb } from '../testdatabase'
-import { Connection } from 'typeorm'
 import { createChainlinkNode } from '../../entity/ChainlinkNode'
-import { fromString } from '../../entity/JobRun'
+import { JobRun, fromString } from '../../entity/JobRun'
 import { search, count } from '../../queries/search'
-
-let db: Connection
-
-beforeEach(() => {
-  db = getDb()
-})
 
 describe('search and count', () => {
   beforeEach(async () => {
-    const [chainlinkNode] = await createChainlinkNode(
-      db,
-      'job-run-search-chainlink-node',
-    )
+    const [chainlinkNode] = await createChainlinkNode('job-run-search-chainlink-node')
 
     const jrA = fromString(JSON.stringify(fixture))
     jrA.chainlinkNodeId = chainlinkNode.id
     jrA.createdAt = new Date('2019-04-08T01:00:00.000Z')
-    await db.manager.save(jrA)
+    await getRepository(JobRun).save(jrA)
 
     const fixtureB = Object.assign({}, fixture, {
       jobId: 'jobB',
@@ -33,7 +23,7 @@ describe('search and count', () => {
     jrB.txHash = 'fixtureBTxHash'
     jrB.requester = 'fixtureBRequester'
     jrB.requestId = 'fixtureBRequestID'
-    await db.manager.save(jrB)
+    await getRepository(JobRun).save(jrB)
 
     const fixtureC = Object.assign({}, fixture, {
       jobId: 'jobB',
@@ -45,7 +35,7 @@ describe('search and count', () => {
     jrC.txHash = 'fixtureCTxHash'
     jrC.requester = 'fixtureCRequester'
     jrC.requestId = 'fixtureCRequestID'
-    await db.manager.save(jrC)
+    await getRepository(JobRun).save(jrC)
 
     const fixtureD = Object.assign({}, fixture, {
       jobId: 'jobD',
@@ -59,26 +49,26 @@ describe('search and count', () => {
     jrD.requester = '0x56F83bE0b26B1B4B641a2ecAd74b037e131989E2'
     jrD.requestId =
       '0xc4cb943023a30d9102406799150bae23665517ab4b230d41b54490baa3aad42c'
-    await db.manager.save(jrD)
+    await getRepository(JobRun).save(jrD)
   })
 
   it('returns no results when no query is supplied', async () => {
     let results
-    results = await search(db, { searchQuery: undefined })
+    results = await search({ searchQuery: undefined })
     expect(results).toHaveLength(0)
-    results = await search(db, { searchQuery: null })
+    results = await search({ searchQuery: null })
     expect(results).toHaveLength(0)
   })
 
   it('returns results in descending order by createdAt', async () => {
-    const results = await search(db, { searchQuery: 'jobB' })
+    const results = await search({ searchQuery: 'jobB' })
     expect(results.length).toEqual(2)
     expect(results[0].runId).toEqual('runC')
     expect(results[1].runId).toEqual('runB')
   })
 
   it('can set a limit', async () => {
-    const results = await search(db, { searchQuery: 'jobB', limit: 1 })
+    const results = await search({ searchQuery: 'jobB', limit: 1 })
     expect(results).toHaveLength(1)
     expect(results[0].runId).toEqual('runC')
   })
@@ -86,14 +76,14 @@ describe('search and count', () => {
   it('can set a page with a 1 based index', async () => {
     let results
 
-    results = await search(db, {
+    results = await search({
       limit: 1,
       page: 1,
       searchQuery: 'jobB',
     })
     expect(results[0].runId).toEqual('runC')
 
-    results = await search(db, {
+    results = await search({
       limit: 1,
       page: 2,
       searchQuery: 'jobB',
@@ -102,50 +92,50 @@ describe('search and count', () => {
   })
 
   it('returns no results for blank search', async () => {
-    const results = await search(db, { searchQuery: '' })
+    const results = await search({ searchQuery: '' })
     expect(results).toHaveLength(0)
   })
 
   it('returns one result for an exact match on jobId', async () => {
-    const results = await search(db, {
+    const results = await search({
       searchQuery: 'f1xtureAaaaaaaaaaaaaaaaaaaaaaaaa',
     })
     expect(results).toHaveLength(1)
   })
 
   it('returns one result for an exact match on jobId and runId', async () => {
-    const results = await search(db, {
+    const results = await search({
       searchQuery: `${'f1xtureAaaaaaaaaaaaaaaaaaaaaaaaa'} aeb2861d306645b1ba012079aeb2e53a`,
     })
     expect(results).toHaveLength(1)
   })
 
   it('returns two results when two matching runIds are supplied', async () => {
-    const results = await search(db, { searchQuery: 'runB runC' })
+    const results = await search({ searchQuery: 'runB runC' })
     expect(results).toHaveLength(2)
   })
 
   it('returns one result for an exact match on requester', async () => {
     const requester = 'fixtureBRequester'
-    const results = await search(db, { searchQuery: requester })
+    const results = await search({ searchQuery: requester })
     expect(results).toHaveLength(1)
   })
 
   it('returns one result for a case insensitive match on requester', async () => {
     const requester = 'FIXTUREBREQUESTER'
-    const results = await search(db, { searchQuery: requester })
+    const results = await search({ searchQuery: requester })
     expect(results).toHaveLength(1)
   })
 
   it('returns one result for an exact match on requestId', async () => {
     const requestId = 'fixtureBRequestID'
-    const results = await search(db, { searchQuery: requestId })
+    const results = await search({ searchQuery: requestId })
     expect(results).toHaveLength(1)
   })
 
   it('returns one result for an exact match on txHash', async () => {
     const txHash = 'fixtureBTxHash'
-    const results = await search(db, { searchQuery: txHash })
+    const results = await search({ searchQuery: txHash })
     expect(results).toHaveLength(1)
   })
 
@@ -155,19 +145,19 @@ describe('search and count', () => {
     const requester = '56F83bE0b26B1B4B641a2ecAd74b037e131989E2'
     const requestId =
       'c4cb943023a30d9102406799150bae23665517ab4b230d41b54490baa3aad42c'
-    const resultsTxHash = await search(db, { searchQuery: txHash })
-    const resultsRequester = await search(db, { searchQuery: requester })
-    const resultsRequestId = await search(db, { searchQuery: requestId })
+    const resultsTxHash = await search({ searchQuery: txHash })
+    const resultsRequester = await search({ searchQuery: requester })
+    const resultsRequestId = await search({ searchQuery: requestId })
     expect(resultsTxHash).toHaveLength(1)
     expect(resultsRequester).toHaveLength(1)
     expect(resultsRequestId).toHaveLength(1)
-    const resultsPrefixedTxHash = await search(db, {
+    const resultsPrefixedTxHash = await search({
       searchQuery: '0x' + txHash,
     })
-    const resultsPrefixedRequester = await search(db, {
+    const resultsPrefixedRequester = await search({
       searchQuery: '0x' + requester,
     })
-    const resultsPrefixedRequestId = await search(db, {
+    const resultsPrefixedRequestId = await search({
       searchQuery: '0x' + requestId,
     })
     expect(resultsPrefixedTxHash).toHaveLength(1)
@@ -176,7 +166,7 @@ describe('search and count', () => {
   })
 
   it('returns the number of results matching the search query', async () => {
-    const countResult = await count(db, { searchQuery: 'runB runC' })
+    const countResult = await count({ searchQuery: 'runB runC' })
     expect(countResult).toEqual(2)
   })
 })

--- a/explorer/src/__tests__/queries/Search.test.ts
+++ b/explorer/src/__tests__/queries/Search.test.ts
@@ -1,5 +1,5 @@
 import fixture from '../fixtures/JobRun.fixture.json'
-import { closeDbConnection, getDb } from '../../database'
+import { getDb } from '../testdatabase'
 import { Connection } from 'typeorm'
 import { createChainlinkNode } from '../../entity/ChainlinkNode'
 import { fromString } from '../../entity/JobRun'
@@ -7,11 +7,9 @@ import { search, count } from '../../queries/search'
 
 let db: Connection
 
-beforeAll(async () => {
-  db = await getDb()
+beforeEach(() => {
+  db = getDb()
 })
-
-afterAll(async () => closeDbConnection())
 
 describe('search and count', () => {
   beforeEach(async () => {

--- a/explorer/src/__tests__/repositories/JobRunRepository.test.ts
+++ b/explorer/src/__tests__/repositories/JobRunRepository.test.ts
@@ -1,30 +1,21 @@
-import { Connection, getCustomRepository } from 'typeorm'
-import { getDb } from '../testdatabase'
+import { getCustomRepository } from 'typeorm'
 import { JobRunRepository } from '../../repositories/JobRunRepository'
 import * as JobRun from '../../entity/JobRun'
 import ethtxFixture from '../fixtures/JobRun.ethtx.fixture.json'
 import fixture from '../fixtures/JobRun.fixture.json'
 import { createChainlinkNode } from '../../entity/ChainlinkNode'
 
-let db: Connection
-beforeEach(() => {
-  db = getDb()
-})
-
 describe('JobRunRepository tests', () => {
   describe('getFirst', () => {
     it('should return a job run with its task runs sorted', async () => {
-      const [chainlinkNode] = await createChainlinkNode(
-        db,
-        'job-run-fromString-chainlink-node',
-      )
+      const [chainlinkNode] = await createChainlinkNode('job-run-fromString-chainlink-node')
 
       const jr1 = JobRun.fromString(JSON.stringify(ethtxFixture))
       jr1.chainlinkNodeId = chainlinkNode.id
 
-      await JobRun.saveJobRunTree(db, jr1)
+      await JobRun.saveJobRunTree(jr1)
 
-      const jrRepository = getCustomRepository(JobRunRepository, db.name)
+      const jrRepository = getCustomRepository(JobRunRepository)
       const fetchedJr = await jrRepository.getFirst()
 
       fetchedJr.taskRuns.forEach((tr, i) => expect(tr.index).toEqual(i))
@@ -33,10 +24,7 @@ describe('JobRunRepository tests', () => {
 
   describe('findById', () => {
     it('should find a task run by its id with its task runs sorted', async () => {
-      const [chainlinkNode] = await createChainlinkNode(
-        db,
-        'job-run-fromString-chainlink-node',
-      )
+      const [chainlinkNode] = await createChainlinkNode('job-run-fromString-chainlink-node')
 
       const jr1 = JobRun.fromString(JSON.stringify(ethtxFixture))
       jr1.chainlinkNodeId = chainlinkNode.id
@@ -44,10 +32,10 @@ describe('JobRunRepository tests', () => {
       const jr2 = JobRun.fromString(JSON.stringify(fixture))
       jr2.chainlinkNodeId = chainlinkNode.id
 
-      await JobRun.saveJobRunTree(db, jr1)
-      await JobRun.saveJobRunTree(db, jr2)
+      await JobRun.saveJobRunTree(jr1)
+      await JobRun.saveJobRunTree(jr2)
 
-      const jrRepository = getCustomRepository(JobRunRepository, db.name)
+      const jrRepository = getCustomRepository(JobRunRepository)
 
       const fetchedJr1 = await jrRepository.findById(jr1.id)
       expect(fetchedJr1.id).toEqual(jr1.id)

--- a/explorer/src/__tests__/repositories/JobRunRepository.test.ts
+++ b/explorer/src/__tests__/repositories/JobRunRepository.test.ts
@@ -1,18 +1,15 @@
+import { Connection, getCustomRepository } from 'typeorm'
+import { getDb } from '../testdatabase'
 import { JobRunRepository } from '../../repositories/JobRunRepository'
 import * as JobRun from '../../entity/JobRun'
 import ethtxFixture from '../fixtures/JobRun.ethtx.fixture.json'
 import fixture from '../fixtures/JobRun.fixture.json'
-import { Connection, getCustomRepository } from 'typeorm'
-import { getDb, closeDbConnection } from '../../database'
 import { createChainlinkNode } from '../../entity/ChainlinkNode'
 
 let db: Connection
-
-beforeAll(async () => {
-  db = await getDb()
+beforeEach(() => {
+  db = getDb()
 })
-
-afterAll(async () => closeDbConnection())
 
 describe('JobRunRepository tests', () => {
   describe('getFirst', () => {

--- a/explorer/src/__tests__/repositories/JobRunRepository.test.ts
+++ b/explorer/src/__tests__/repositories/JobRunRepository.test.ts
@@ -8,7 +8,9 @@ import { createChainlinkNode } from '../../entity/ChainlinkNode'
 describe('JobRunRepository tests', () => {
   describe('getFirst', () => {
     it('should return a job run with its task runs sorted', async () => {
-      const [chainlinkNode] = await createChainlinkNode('job-run-fromString-chainlink-node')
+      const [chainlinkNode] = await createChainlinkNode(
+        'job-run-fromString-chainlink-node',
+      )
 
       const jr1 = JobRun.fromString(JSON.stringify(ethtxFixture))
       jr1.chainlinkNodeId = chainlinkNode.id
@@ -24,7 +26,9 @@ describe('JobRunRepository tests', () => {
 
   describe('findById', () => {
     it('should find a task run by its id with its task runs sorted', async () => {
-      const [chainlinkNode] = await createChainlinkNode('job-run-fromString-chainlink-node')
+      const [chainlinkNode] = await createChainlinkNode(
+        'job-run-fromString-chainlink-node',
+      )
 
       const jr1 = JobRun.fromString(JSON.stringify(ethtxFixture))
       jr1.chainlinkNodeId = chainlinkNode.id

--- a/explorer/src/__tests__/rpcMethods/upsertJobRun.test.ts
+++ b/explorer/src/__tests__/rpcMethods/upsertJobRun.test.ts
@@ -31,7 +31,9 @@ describe('realtime', () => {
 
   beforeEach(async () => {
     clearDb()
-    ;[chainlinkNode, secret] = await createChainlinkNode('upsertJobRun test chainlinkNode')
+    ;[chainlinkNode, secret] = await createChainlinkNode(
+      'upsertJobRun test chainlinkNode',
+    )
     ws = await newChainlinkNode(chainlinkNode.accessKey, secret)
   })
 

--- a/explorer/src/__tests__/rpcMethods/upsertJobRun.test.ts
+++ b/explorer/src/__tests__/rpcMethods/upsertJobRun.test.ts
@@ -2,7 +2,6 @@ import { Server } from 'http'
 import jayson from 'jayson'
 import { Connection, getCustomRepository } from 'typeorm'
 import WebSocket from 'ws'
-import { getDb } from '../../database'
 import { ChainlinkNode, createChainlinkNode } from '../../entity/ChainlinkNode'
 import { JobRun } from '../../entity/JobRun'
 import { TaskRun } from '../../entity/TaskRun'
@@ -16,7 +15,7 @@ import { start, stop } from '../../support/server'
 import ethtxFixture from '../fixtures/JobRun.ethtx.fixture.json'
 import createFixture from '../fixtures/JobRun.fixture.json'
 import updateFixture from '../fixtures/JobRunUpdate.fixture.json'
-import { clearDb } from '../testdatabase'
+import { getDb, clearDb } from '../testdatabase'
 
 const { INVALID_PARAMS } = jayson.Server.errors
 
@@ -28,11 +27,12 @@ describe('realtime', () => {
   let ws: WebSocket
 
   beforeAll(async () => {
-    server = await start()
-    db = await getDb()
+    db = getDb()
+    server = await start(db)
   })
 
   beforeEach(async () => {
+    db = getDb()
     clearDb()
     ;[chainlinkNode, secret] = await createChainlinkNode(
       db,

--- a/explorer/src/__tests__/server/legacy.test.ts
+++ b/explorer/src/__tests__/server/legacy.test.ts
@@ -1,7 +1,7 @@
 import { Server } from 'http'
+import { getDb } from '../testdatabase'
 import { Connection, getCustomRepository } from 'typeorm'
 import WebSocket from 'ws'
-import { getDb } from '../../database'
 import { ChainlinkNode, createChainlinkNode } from '../../entity/ChainlinkNode'
 import { JobRun } from '../../entity/JobRun'
 import { TaskRun } from '../../entity/TaskRun'
@@ -20,9 +20,12 @@ describe('realtime', () => {
   let secret: string
   let ws: WebSocket
 
+  beforeEach(() => {
+    db = getDb()
+  })
+
   beforeAll(async () => {
-    server = await start()
-    db = await getDb()
+    server = await start(db)
   })
 
   beforeEach(async () => {

--- a/explorer/src/__tests__/server/legacy.test.ts
+++ b/explorer/src/__tests__/server/legacy.test.ts
@@ -24,7 +24,9 @@ describe('realtime', () => {
 
   beforeEach(async () => {
     clearDb()
-    ;[chainlinkNode, secret] = await createChainlinkNode('legacy test chainlinkNode')
+    ;[chainlinkNode, secret] = await createChainlinkNode(
+      'legacy test chainlinkNode',
+    )
     ws = await newChainlinkNode(chainlinkNode.accessKey, secret)
   })
 

--- a/explorer/src/__tests__/server/realtime.test.ts
+++ b/explorer/src/__tests__/server/realtime.test.ts
@@ -27,7 +27,9 @@ describe('realtime', () => {
 
   beforeEach(async () => {
     await clearDb()
-    ;[chainlinkNode, secret] = await createChainlinkNode('realtime test chainlinkNode')
+    ;[chainlinkNode, secret] = await createChainlinkNode(
+      'realtime test chainlinkNode',
+    )
   })
 
   afterAll(done => stop(server, done))

--- a/explorer/src/__tests__/server/realtime.test.ts
+++ b/explorer/src/__tests__/server/realtime.test.ts
@@ -2,7 +2,7 @@ import { Server } from 'http'
 import jayson from 'jayson'
 import { Connection } from 'typeorm'
 import WebSocket from 'ws'
-import { getDb } from '../../database'
+import { getDb } from '../testdatabase'
 import { ChainlinkNode, createChainlinkNode } from '../../entity/ChainlinkNode'
 import {
   createRPCRequest,
@@ -24,9 +24,11 @@ describe('realtime', () => {
   const newAuthenticatedNode = async () =>
     newChainlinkNode(chainlinkNode.accessKey, secret)
 
+  beforeEach(() => {
+    db = getDb()
+  })
   beforeAll(async () => {
-    server = await start()
-    db = await getDb()
+    server = await start(db)
   })
 
   beforeEach(async () => {

--- a/explorer/src/__tests__/server/realtime.test.ts
+++ b/explorer/src/__tests__/server/realtime.test.ts
@@ -1,8 +1,6 @@
 import { Server } from 'http'
 import jayson from 'jayson'
-import { Connection } from 'typeorm'
 import WebSocket from 'ws'
-import { getDb } from '../testdatabase'
 import { ChainlinkNode, createChainlinkNode } from '../../entity/ChainlinkNode'
 import {
   createRPCRequest,
@@ -17,26 +15,19 @@ const { PARSE_ERROR, INVALID_REQUEST, METHOD_NOT_FOUND } = jayson.Server.errors
 
 describe('realtime', () => {
   let server: Server
-  let db: Connection
   let chainlinkNode: ChainlinkNode
   let secret: string
 
   const newAuthenticatedNode = async () =>
     newChainlinkNode(chainlinkNode.accessKey, secret)
 
-  beforeEach(() => {
-    db = getDb()
-  })
   beforeAll(async () => {
-    server = await start(db)
+    server = await start()
   })
 
   beforeEach(async () => {
     await clearDb()
-    ;[chainlinkNode, secret] = await createChainlinkNode(
-      db,
-      'realtime test chainlinkNode',
-    )
+    ;[chainlinkNode, secret] = await createChainlinkNode('realtime test chainlinkNode')
   })
 
   afterAll(done => stop(server, done))

--- a/explorer/src/__tests__/sessions.test.ts
+++ b/explorer/src/__tests__/sessions.test.ts
@@ -1,49 +1,33 @@
 import { authenticate } from '../sessions'
-import { Connection } from 'typeorm'
+import { getRepository } from 'typeorm'
 import { createChainlinkNode } from '../entity/ChainlinkNode'
 import { Session } from '../entity/Session'
-import { getDb } from './testdatabase'
 
 describe('sessions', () => {
-  let db: Connection
-  beforeAll(() => {
-    db = getDb()
-  })
-
   describe('authenticate', () => {
     it('creates a session record', async () => {
-      const [chainlinkNode, secret] = await createChainlinkNode(
-        db,
-        'valid-chainlink-node',
-      )
-      const session = await authenticate(db, chainlinkNode.accessKey, secret)
+      const [chainlinkNode, secret] = await createChainlinkNode('valid-chainlink-node')
+      const session = await authenticate(chainlinkNode.accessKey, secret)
       expect(session).toBeDefined()
       expect(session.chainlinkNodeId).toEqual(chainlinkNode.id)
 
-      let foundSession = await db.manager.findOne(Session)
+      let foundSession = await getRepository(Session).findOne()
       expect(foundSession.chainlinkNodeId).toEqual(chainlinkNode.id)
       expect(foundSession.finishedAt).toBeNull()
 
-      await authenticate(db, chainlinkNode.accessKey, secret)
-      foundSession = await db.manager.findOne(Session, foundSession.id)
+      await authenticate(chainlinkNode.accessKey, secret)
+      foundSession = await getRepository(Session).findOne(foundSession.id) // db.manager.findOne(Session, foundSession.id)
       expect(foundSession.finishedAt).toBeDefined()
     })
 
     it('returns null if no chainlink node exists', async () => {
-      const result = await authenticate(db, '', '')
+      const result = await authenticate('', '')
       expect(result).toBeNull()
     })
 
     it('returns null if the secret is incorrect', async () => {
-      const [chainlinkNode] = await createChainlinkNode(
-        db,
-        'invalid-chainlink-node',
-      )
-      const result = await authenticate(
-        db,
-        chainlinkNode.accessKey,
-        'wrong-secret',
-      )
+      const [chainlinkNode] = await createChainlinkNode('invalid-chainlink-node')
+      const result = await authenticate(chainlinkNode.accessKey, 'wrong-secret')
       expect(result).toBeNull()
     })
   })

--- a/explorer/src/__tests__/sessions.test.ts
+++ b/explorer/src/__tests__/sessions.test.ts
@@ -16,7 +16,7 @@ describe('sessions', () => {
       expect(foundSession.finishedAt).toBeNull()
 
       await authenticate(chainlinkNode.accessKey, secret)
-      foundSession = await getRepository(Session).findOne(foundSession.id) // db.manager.findOne(Session, foundSession.id)
+      foundSession = await getRepository(Session).findOne(foundSession.id)
       expect(foundSession.finishedAt).toBeDefined()
     })
 

--- a/explorer/src/__tests__/sessions.test.ts
+++ b/explorer/src/__tests__/sessions.test.ts
@@ -6,7 +6,9 @@ import { Session } from '../entity/Session'
 describe('sessions', () => {
   describe('authenticate', () => {
     it('creates a session record', async () => {
-      const [chainlinkNode, secret] = await createChainlinkNode('valid-chainlink-node')
+      const [chainlinkNode, secret] = await createChainlinkNode(
+        'valid-chainlink-node',
+      )
       const session = await authenticate(chainlinkNode.accessKey, secret)
       expect(session).toBeDefined()
       expect(session.chainlinkNodeId).toEqual(chainlinkNode.id)
@@ -26,7 +28,9 @@ describe('sessions', () => {
     })
 
     it('returns null if the secret is incorrect', async () => {
-      const [chainlinkNode] = await createChainlinkNode('invalid-chainlink-node')
+      const [chainlinkNode] = await createChainlinkNode(
+        'invalid-chainlink-node',
+      )
       const result = await authenticate(chainlinkNode.accessKey, 'wrong-secret')
       expect(result).toBeNull()
     })

--- a/explorer/src/__tests__/sessions.test.ts
+++ b/explorer/src/__tests__/sessions.test.ts
@@ -1,16 +1,13 @@
 import { authenticate } from '../sessions'
 import { Connection } from 'typeorm'
-import { closeDbConnection, getDb } from '../database'
 import { createChainlinkNode } from '../entity/ChainlinkNode'
 import { Session } from '../entity/Session'
+import { getDb } from './testdatabase'
 
 describe('sessions', () => {
   let db: Connection
-  beforeAll(async () => {
-    db = await getDb()
-  })
-  afterAll(async () => {
-    await closeDbConnection()
+  beforeAll(() => {
+    db = getDb()
   })
 
   describe('authenticate', () => {

--- a/explorer/src/__tests__/testdatabase.ts
+++ b/explorer/src/__tests__/testdatabase.ts
@@ -1,4 +1,4 @@
-import { getDb } from '../database'
+import { getConnection, Connection } from 'typeorm'
 
 if (process.env.NODE_ENV !== 'test') {
   throw Error(
@@ -13,9 +13,10 @@ const TRUNCATE_TABLES: string[] = [
   'ethereum_log',
 ]
 
+export const getDb = () : Connection => {
+  return getConnection()
+}
+
 export const clearDb = async () => {
-  const db = await getDb()
-  if (db) {
-    await db.query(`TRUNCATE TABLE ${TRUNCATE_TABLES.join(',')} CASCADE`)
-  }
+  return getDb().query(`TRUNCATE TABLE ${TRUNCATE_TABLES.join(',')} CASCADE`)
 }

--- a/explorer/src/__tests__/testdatabase.ts
+++ b/explorer/src/__tests__/testdatabase.ts
@@ -1,4 +1,4 @@
-import { getConnection, Connection } from 'typeorm'
+import { getConnection } from 'typeorm'
 
 if (process.env.NODE_ENV !== 'test') {
   throw Error(
@@ -13,10 +13,6 @@ const TRUNCATE_TABLES: string[] = [
   'ethereum_log',
 ]
 
-export const getDb = () : Connection => {
-  return getConnection()
-}
-
 export const clearDb = async () => {
-  return getDb().query(`TRUNCATE TABLE ${TRUNCATE_TABLES.join(',')} CASCADE`)
+  return getConnection().query(`TRUNCATE TABLE ${TRUNCATE_TABLES.join(',')} CASCADE`)
 }

--- a/explorer/src/__tests__/testdatabase.ts
+++ b/explorer/src/__tests__/testdatabase.ts
@@ -14,5 +14,7 @@ const TRUNCATE_TABLES: string[] = [
 ]
 
 export const clearDb = async () => {
-  return getConnection().query(`TRUNCATE TABLE ${TRUNCATE_TABLES.join(',')} CASCADE`)
+  return getConnection().query(
+    `TRUNCATE TABLE ${TRUNCATE_TABLES.join(',')} CASCADE`,
+  )
 }

--- a/explorer/src/bin/migrator.ts
+++ b/explorer/src/bin/migrator.ts
@@ -1,7 +1,7 @@
 import yargs from 'yargs'
 import { Connection } from 'typeorm'
-import { closeDbConnection, getDb } from '../database'
 import { ChainlinkNode } from '../entity/ChainlinkNode'
+import { bootstrap } from '../cli/bootstrap'
 
 const migrate = async () => {
   return bootstrap(async (db: Connection) => {
@@ -34,18 +34,6 @@ const revert = async () => {
   return bootstrap(async (db: Connection) => {
     await db.undoLastMigration()
   })
-}
-
-async function bootstrap(cb: any) {
-  const db = await getDb()
-  try {
-    await cb(db)
-  } catch (err) {
-    console.error(err)
-    process.exit(1)
-  } finally {
-    await closeDbConnection()
-  }
 }
 
 yargs

--- a/explorer/src/cli/admin.ts
+++ b/explorer/src/cli/admin.ts
@@ -1,8 +1,9 @@
 import { createAdmin } from '../support/admin'
 import { bootstrap } from './bootstrap'
+import { Connection } from 'typeorm'
 
 export const seed = async (username: string, password: string) => {
-  return bootstrap(async db => {
+  return bootstrap(async (db: Connection) => {
     const admin = await createAdmin(db, username, password)
 
     console.log('created new chainlink admin')

--- a/explorer/src/cli/admin.ts
+++ b/explorer/src/cli/admin.ts
@@ -1,10 +1,9 @@
 import { createAdmin } from '../support/admin'
 import { bootstrap } from './bootstrap'
-import { Connection } from 'typeorm'
 
 export const seed = async (username: string, password: string) => {
-  return bootstrap(async (db: Connection) => {
-    const admin = await createAdmin(db, username, password)
+  return bootstrap(async () => {
+    const admin = await createAdmin(username, password)
 
     console.log('created new chainlink admin')
     console.log('username: ', admin.username)

--- a/explorer/src/cli/bootstrap.ts
+++ b/explorer/src/cli/bootstrap.ts
@@ -1,11 +1,7 @@
 import { Connection } from 'typeorm'
 import { openDbConnection } from '../database'
 
-interface Callback {
-  (db: Connection): Promise<void>
-}
-
-export async function bootstrap(cb: Callback) {
+export async function bootstrap(cb: (db: Connection) => Promise<void>) {
   const db = await openDbConnection()
   try {
     return await cb(db)

--- a/explorer/src/cli/bootstrap.ts
+++ b/explorer/src/cli/bootstrap.ts
@@ -1,9 +1,10 @@
+import { Connection } from 'typeorm'
 import { openDbConnection } from '../database'
 
-export async function bootstrap(cb: any) {
+export async function bootstrap(cb: (db: Connection) => void) {
   const db = await openDbConnection()
   try {
-    await cb(db)
+    return cb(db)
   } catch (err) {
     console.error(err)
   } finally {

--- a/explorer/src/cli/bootstrap.ts
+++ b/explorer/src/cli/bootstrap.ts
@@ -1,12 +1,17 @@
 import { Connection } from 'typeorm'
 import { openDbConnection } from '../database'
 
-export async function bootstrap(cb: (db: Connection) => void) {
+interface Callback {
+  (db: Connection): Promise<void>
+}
+
+export async function bootstrap(cb: Callback) {
   const db = await openDbConnection()
   try {
-    return cb(db)
+    return await cb(db)
   } catch (err) {
     console.error(err)
+    throw err
   } finally {
     db.close()
   }

--- a/explorer/src/cli/bootstrap.ts
+++ b/explorer/src/cli/bootstrap.ts
@@ -1,9 +1,13 @@
 import { Connection } from 'typeorm'
-import { closeDbConnection, getDb } from '../database'
+import { openDbConnection } from '../database'
 
-export async function bootstrap(callback: (db: Connection) => Promise<void>) {
-  const db = await getDb()
-
-  await callback(db).catch(console.error)
-  await closeDbConnection().catch(console.error)
+export async function bootstrap(cb: any) {
+  openDbConnection().then(async (db: Connection) => {
+    try {
+      await cb(db)
+    } catch (err) {
+      console.error(err)
+    }
+  })
 }
+

--- a/explorer/src/cli/bootstrap.ts
+++ b/explorer/src/cli/bootstrap.ts
@@ -1,13 +1,13 @@
-import { Connection } from 'typeorm'
 import { openDbConnection } from '../database'
 
 export async function bootstrap(cb: any) {
-  openDbConnection().then(async (db: Connection) => {
-    try {
-      await cb(db)
-    } catch (err) {
-      console.error(err)
-    }
-  })
+  const db = await openDbConnection()
+  try {
+    await cb(db)
+  } catch (err) {
+    console.error(err)
+  } finally {
+    db.close()
+  }
 }
 

--- a/explorer/src/cli/bootstrap.ts
+++ b/explorer/src/cli/bootstrap.ts
@@ -11,4 +11,3 @@ export async function bootstrap(cb: (db: Connection) => void) {
     db.close()
   }
 }
-

--- a/explorer/src/controllers/admin/heads.ts
+++ b/explorer/src/controllers/admin/heads.ts
@@ -10,9 +10,7 @@ const router = Router()
 
 router.get('/heads', async (req, res) => {
   const params = parseParams(req.query)
-  const ethereumHeadRepository = getCustomRepository(
-    EthereumHeadRepository,
-  )
+  const ethereumHeadRepository = getCustomRepository(EthereumHeadRepository)
 
   const heads = await ethereumHeadRepository.all(params)
 

--- a/explorer/src/controllers/admin/heads.ts
+++ b/explorer/src/controllers/admin/heads.ts
@@ -1,8 +1,7 @@
 import { Router } from 'express'
-import { getDb } from '../../database'
 import { EthereumHeadRepository } from '../../repositories/EthereumHeadRepository'
 import { Head } from '../../entity/Head'
-import { getCustomRepository } from 'typeorm'
+import { getConnection } from 'typeorm'
 import { parseParams } from '../../utils/pagination'
 import headsSerializer from '../../serializers/headsSerializer'
 import headSerializer from '../../serializers/headSerializer'
@@ -11,10 +10,8 @@ const router = Router()
 
 router.get('/heads', async (req, res) => {
   const params = parseParams(req.query)
-  const db = await getDb()
-  const ethereumHeadRepository = getCustomRepository(
+  const ethereumHeadRepository = getConnection().getCustomRepository(
     EthereumHeadRepository,
-    db.name,
   )
 
   const heads = await ethereumHeadRepository.all(params)
@@ -25,8 +22,7 @@ router.get('/heads', async (req, res) => {
 })
 
 router.get('/heads/:headId', async (req, res) => {
-  const db = await getDb()
-  const ethereumHeadRepository = db.getRepository(Head)
+  const ethereumHeadRepository = getConnection().getRepository(Head)
 
   const { id } = req.params
   const head = await ethereumHeadRepository.findOne(id)

--- a/explorer/src/controllers/admin/heads.ts
+++ b/explorer/src/controllers/admin/heads.ts
@@ -1,7 +1,7 @@
 import { Router } from 'express'
 import { EthereumHeadRepository } from '../../repositories/EthereumHeadRepository'
 import { Head } from '../../entity/Head'
-import { getConnection } from 'typeorm'
+import { getCustomRepository, getRepository } from 'typeorm'
 import { parseParams } from '../../utils/pagination'
 import headsSerializer from '../../serializers/headsSerializer'
 import headSerializer from '../../serializers/headSerializer'
@@ -10,7 +10,7 @@ const router = Router()
 
 router.get('/heads', async (req, res) => {
   const params = parseParams(req.query)
-  const ethereumHeadRepository = getConnection().getCustomRepository(
+  const ethereumHeadRepository = getCustomRepository(
     EthereumHeadRepository,
   )
 
@@ -22,7 +22,7 @@ router.get('/heads', async (req, res) => {
 })
 
 router.get('/heads/:headId', async (req, res) => {
-  const ethereumHeadRepository = getConnection().getRepository(Head)
+  const ethereumHeadRepository = getRepository(Head)
 
   const { id } = req.params
   const head = await ethereumHeadRepository.findOne(id)

--- a/explorer/src/controllers/admin/nodes.ts
+++ b/explorer/src/controllers/admin/nodes.ts
@@ -1,7 +1,7 @@
 import { validate } from 'class-validator'
 import { Router } from 'express'
 import httpStatus from 'http-status-codes'
-import { getConnection, getCustomRepository, getRepository } from 'typeorm'
+import { getCustomRepository, getRepository } from 'typeorm'
 import {
   buildChainlinkNode,
   ChainlinkNode,
@@ -85,10 +85,7 @@ router.get('/nodes/:id', async (req, res) => {
 })
 
 router.delete('/nodes/:name', async (req, res) => {
-  const db = getConnection()
-
-  await db.getRepository(ChainlinkNode).delete({ name: req.params.name })
-
+  await getRepository(ChainlinkNode).delete({ name: req.params.name })
   return res.sendStatus(httpStatus.OK)
 })
 

--- a/explorer/src/controllers/jobRuns.ts
+++ b/explorer/src/controllers/jobRuns.ts
@@ -1,9 +1,8 @@
-import { getDb } from '../database'
+import { getConnection } from 'typeorm'
 import { Router, Request, Response } from 'express'
 import { search, count, SearchParams } from '../queries/search'
 import jobRunsSerializer from '../serializers/jobRunsSerializer'
 import jobRunSerializer from '../serializers/jobRunSerializer'
-import { getCustomRepository } from 'typeorm'
 import { JobRunRepository } from '../repositories/JobRunRepository'
 import * as pagination from '../utils/pagination'
 
@@ -20,7 +19,7 @@ const searchParams = (req: Request): SearchParams => {
 
 router.get('/job_runs', async (req: Request, res: Response) => {
   const params = searchParams(req)
-  const db = await getDb()
+  const db = getConnection()
   const runs = await search(db, params)
   const runCount = await count(db, params)
   const json = jobRunsSerializer(runs, runCount)
@@ -29,8 +28,7 @@ router.get('/job_runs', async (req: Request, res: Response) => {
 
 router.get('/job_runs/:id', async (req: Request, res: Response) => {
   const id = req.params.id
-  const db = await getDb()
-  const jobRunRepository = getCustomRepository(JobRunRepository, db.name)
+  const jobRunRepository = getConnection().getCustomRepository(JobRunRepository)
   const jobRun = await jobRunRepository.findById(id)
 
   if (jobRun) {

--- a/explorer/src/controllers/jobRuns.ts
+++ b/explorer/src/controllers/jobRuns.ts
@@ -1,4 +1,4 @@
-import { getConnection } from 'typeorm'
+import { getCustomRepository } from 'typeorm'
 import { Router, Request, Response } from 'express'
 import { search, count, SearchParams } from '../queries/search'
 import jobRunsSerializer from '../serializers/jobRunsSerializer'
@@ -19,16 +19,15 @@ const searchParams = (req: Request): SearchParams => {
 
 router.get('/job_runs', async (req: Request, res: Response) => {
   const params = searchParams(req)
-  const db = getConnection()
-  const runs = await search(db, params)
-  const runCount = await count(db, params)
+  const runs = await search(params)
+  const runCount = await count(params)
   const json = jobRunsSerializer(runs, runCount)
   return res.send(json)
 })
 
 router.get('/job_runs/:id', async (req: Request, res: Response) => {
   const id = req.params.id
-  const jobRunRepository = getConnection().getCustomRepository(JobRunRepository)
+  const jobRunRepository = getCustomRepository(JobRunRepository)
   const jobRun = await jobRunRepository.findById(id)
 
   if (jobRun) {

--- a/explorer/src/database.ts
+++ b/explorer/src/database.ts
@@ -18,6 +18,7 @@ const loadOptions = (env?: string) => {
   env = env || process.env.TYPEORM_NAME || process.env.NODE_ENV || 'default'
   for (const option of options) {
     if (isEnvEqual(option.name, env)) {
+      delete option.name
       return option
     }
   }

--- a/explorer/src/database.ts
+++ b/explorer/src/database.ts
@@ -41,24 +41,6 @@ const mergeOptions = (): PostgresConnectionOptions => {
   } as PostgresConnectionOptions
 }
 
-// TODO: make not global due to race condition chances https://eslint.org/docs/rules/require-atomic-updates
-/* eslint require-atomic-updates: 'warn' */
-let db: Connection | undefined
-
-export const getDb = async (): Promise<Connection> => {
-  if (db === undefined) {
-    /* eslint-disable-next-line require-atomic-updates */
-    db = await createConnection(mergeOptions())
-  }
-  if (db == null) {
-    throw new Error('no db connection returned')
-  }
-
-  return db
-}
-
-export const closeDbConnection = (): Promise<void> => {
-  const saveDb = db
-  db = null
-  return saveDb.close()
+export const openDbConnection = async (): Promise<Connection> => {
+  return createConnection(mergeOptions())
 }

--- a/explorer/src/entity/Admin.ts
+++ b/explorer/src/entity/Admin.ts
@@ -1,4 +1,4 @@
-import { Column, Connection, Entity, PrimaryGeneratedColumn } from 'typeorm'
+import { getRepository, Column, Entity, PrimaryGeneratedColumn } from 'typeorm'
 import { compare as comparePassword } from '../services/password'
 
 @Entity()
@@ -19,8 +19,8 @@ export class Admin {
   updatedAt: Date
 }
 
-export function find(db: Connection, username: string): Promise<Admin> {
-  return db.getRepository(Admin).findOne({ username })
+export function find(username: string): Promise<Admin> {
+  return getRepository(Admin).findOne({ username })
 }
 
 export async function isValidPassword(

--- a/explorer/src/entity/ChainlinkNode.ts
+++ b/explorer/src/entity/ChainlinkNode.ts
@@ -3,8 +3,9 @@ import { randomBytes } from 'crypto'
 import { sha256 } from 'js-sha256'
 import {
   Column,
-  Connection,
+  createQueryBuilder,
   Entity,
+  getRepository,
   OneToMany,
   PrimaryGeneratedColumn,
   Unique,
@@ -95,18 +96,17 @@ export const buildChainlinkNode = (
 }
 
 export const createChainlinkNode = async (
-  db: Connection,
   name: string,
   url?: string,
 ): Promise<[ChainlinkNode, string]> => {
   const secret = generateRandomString(64)
   const chainlinkNode = ChainlinkNode.build({ name, url, secret })
-  return [await db.manager.save(chainlinkNode), secret]
+  const repo = getRepository(ChainlinkNode)
+  return [await repo.save(chainlinkNode), secret]
 }
 
-export const deleteChainlinkNode = async (db: Connection, name: string) => {
-  return db.manager
-    .createQueryBuilder()
+export const deleteChainlinkNode = async (name: string) => {
+  return createQueryBuilder()
     .delete()
     .from(ChainlinkNode)
     .where('name = :name', {
@@ -123,8 +123,8 @@ export function hashCredentials(
   return sha256(`v0-${accessKey}-${secret}-${salt}`)
 }
 
-export async function find(db: Connection, id: number): Promise<ChainlinkNode> {
-  return db.getRepository(ChainlinkNode).findOne({ id })
+export async function find(id: number): Promise<ChainlinkNode> {
+  return getRepository(ChainlinkNode).findOne({ id })
 }
 
 export interface JobCountReport {
@@ -134,10 +134,7 @@ export interface JobCountReport {
   total: number
 }
 
-export async function jobCountReport(
-  db: Connection,
-  node: ChainlinkNode | number,
-): Promise<JobCountReport> {
+export async function jobCountReport(node: ChainlinkNode | number): Promise<JobCountReport> {
   const id = node instanceof ChainlinkNode ? node.id : node
 
   const initialReport: JobCountReport = {
@@ -147,8 +144,7 @@ export async function jobCountReport(
     total: 0,
   }
 
-  const jobCountQueryResult = await db
-    .getRepository(JobRun)
+  const jobCountQueryResult = await getRepository(JobRun)
     .createQueryBuilder()
     .select('COUNT(*), status')
     .where({ chainlinkNodeId: id })
@@ -168,15 +164,14 @@ export async function jobCountReport(
 // using strategy described here: http://www.sqlines.com/postgresql/how-to/datediff
 // typeORM missing UNION function, so must do in two separate queries or write entire
 // query in raw SQL
-export async function uptime(db: Connection, node: ChainlinkNode | number) {
+export async function uptime(node: ChainlinkNode | number) {
   const id = node instanceof ChainlinkNode ? node.id : node
-  return (await historicUptime(db, id)) + (await currentUptime(db, id))
+  return (await historicUptime(id)) + (await currentUptime(id))
 }
 
 // uptime from completed sessions
-async function historicUptime(db: Connection, id: number): Promise<number> {
-  const queryResult = await db
-    .createQueryBuilder()
+async function historicUptime(id: number): Promise<number> {
+  const queryResult = await createQueryBuilder()
     .select(
       `EXTRACT(EPOCH FROM session."finishedAt" - session."createdAt") as seconds`,
     )
@@ -190,9 +185,8 @@ async function historicUptime(db: Connection, id: number): Promise<number> {
 }
 
 // uptime from current open session
-async function currentUptime(db: Connection, id: number): Promise<number> {
-  const queryResult = await db
-    .createQueryBuilder()
+async function currentUptime(id: number): Promise<number> {
+  const queryResult = await createQueryBuilder()
     .select(
       `FLOOR(EXTRACT(EPOCH FROM (now() - session."createdAt"))) as seconds`,
     )

--- a/explorer/src/entity/ChainlinkNode.ts
+++ b/explorer/src/entity/ChainlinkNode.ts
@@ -134,7 +134,9 @@ export interface JobCountReport {
   total: number
 }
 
-export async function jobCountReport(node: ChainlinkNode | number): Promise<JobCountReport> {
+export async function jobCountReport(
+  node: ChainlinkNode | number,
+): Promise<JobCountReport> {
   const id = node instanceof ChainlinkNode ? node.id : node
 
   const initialReport: JobCountReport = {

--- a/explorer/src/entity/JobRun.ts
+++ b/explorer/src/entity/JobRun.ts
@@ -1,7 +1,8 @@
 import {
   Column,
-  Connection,
   Entity,
+  EntityManager,
+  getConnection,
   ManyToOne,
   OneToMany,
   PrimaryGeneratedColumn,
@@ -110,8 +111,8 @@ export const fromString = (str: string): JobRun => {
   return fromJSONObject(json)
 }
 
-export const saveJobRunTree = async (db: Connection, jobRun: JobRun) => {
-  await db.transaction(async manager => {
+export const saveJobRunTree = async (jobRun: JobRun) => {
+  await getConnection().transaction(async (manager: EntityManager) => {
     let builder = manager.createQueryBuilder()
 
     await builder

--- a/explorer/src/entity/JobRun.ts
+++ b/explorer/src/entity/JobRun.ts
@@ -111,7 +111,7 @@ export const fromString = (str: string): JobRun => {
 }
 
 export const saveJobRunTree = async (db: Connection, jobRun: JobRun) => {
-  await db.manager.transaction(async manager => {
+  await db.transaction(async manager => {
     let builder = manager.createQueryBuilder()
 
     await builder

--- a/explorer/src/entity/Session.ts
+++ b/explorer/src/entity/Session.ts
@@ -55,9 +55,7 @@ export async function retireSessions(): Promise<UpdateResult> {
     .execute()
 }
 
-export async function closeSession(
-  session: Session,
-): Promise<UpdateResult> {
+export async function closeSession(session: Session): Promise<UpdateResult> {
   return getConnection()
     .createQueryBuilder()
     .update(Session)

--- a/explorer/src/entity/Session.ts
+++ b/explorer/src/entity/Session.ts
@@ -1,8 +1,10 @@
 import {
   Column,
-  Connection,
   CreateDateColumn,
   Entity,
+  EntityManager,
+  getConnection,
+  getManager,
   PrimaryGeneratedColumn,
   UpdateDateColumn,
   UpdateResult,
@@ -30,10 +32,10 @@ export class Session {
 }
 
 export async function createSession(
-  db: Connection,
   node: ChainlinkNode,
+  manager?: EntityManager,
 ): Promise<Session> {
-  await db.manager
+  await (manager || getManager())
     .createQueryBuilder()
     .update(Session)
     .set({ finishedAt: () => 'now()' })
@@ -41,11 +43,11 @@ export async function createSession(
     .execute()
   const session = new Session()
   session.chainlinkNodeId = node.id
-  return db.manager.save(session)
+  return (manager || getManager()).save(session)
 }
 
-export async function retireSessions(db: Connection): Promise<UpdateResult> {
-  return db.manager
+export async function retireSessions(): Promise<UpdateResult> {
+  return getConnection()
     .createQueryBuilder()
     .update(Session)
     .set({ finishedAt: new Date() })
@@ -54,10 +56,9 @@ export async function retireSessions(db: Connection): Promise<UpdateResult> {
 }
 
 export async function closeSession(
-  db: Connection,
   session: Session,
 ): Promise<UpdateResult> {
-  return db.manager
+  return getConnection()
     .createQueryBuilder()
     .update(Session)
     .set({ finishedAt: () => 'now()' })

--- a/explorer/src/factories.ts
+++ b/explorer/src/factories.ts
@@ -1,11 +1,10 @@
-import { Connection } from 'typeorm'
+import { getRepository } from 'typeorm'
 import { v4 as uuid } from 'uuid'
 import { ChainlinkNode } from './entity/ChainlinkNode'
 import { JobRun } from './entity/JobRun'
 import { TaskRun } from './entity/TaskRun'
 
 export const createJobRun = async (
-  db: Connection,
   chainlinkNode: ChainlinkNode,
 ): Promise<JobRun> => {
   const jobRun = new JobRun()
@@ -18,7 +17,8 @@ export const createJobRun = async (
   jobRun.requestId = 'requestId' + uuid()
   jobRun.requester = 'requester' + uuid()
   jobRun.createdAt = new Date('2019-04-08T01:00:00.000Z')
-  await db.manager.save(jobRun)
+  const jobRunRepo = getRepository(JobRun)
+  await jobRunRepo.save(jobRun)
 
   const tr = new TaskRun()
   tr.jobRun = jobRun
@@ -27,7 +27,8 @@ export const createJobRun = async (
   tr.type = 'httpget'
   tr.confirmations = '1'
   tr.minimumConfirmations = '3'
-  await db.manager.save(tr)
+  const taskRunRepo = getRepository(TaskRun)
+  await taskRunRepo.save(tr)
 
   return jobRun
 }

--- a/explorer/src/index.ts
+++ b/explorer/src/index.ts
@@ -17,7 +17,6 @@ async function main() {
 
     logger.info('Starting Explorer Node')
     await server(conf)
-
   } catch (e) {
     logger.error({
       msg: `Exception during startup: ${e.message}`,

--- a/explorer/src/index.ts
+++ b/explorer/src/index.ts
@@ -10,20 +10,21 @@ async function main() {
   const version = await getVersion(conf)
   logger.info(version)
 
+  const db = await openDbConnection()
   try {
-    const db = await openDbConnection()
-
     logger.info('Cleaning up sessions...')
-    await retireSessions(db)
+    await retireSessions()
 
     logger.info('Starting Explorer Node')
-    await server(conf, db)
+    await server(conf)
 
   } catch (e) {
     logger.error({
       msg: `Exception during startup: ${e.message}`,
       stack: e.stack,
     })
+  } finally {
+    db.close()
   }
 }
 

--- a/explorer/src/index.ts
+++ b/explorer/src/index.ts
@@ -1,6 +1,5 @@
 import { getConfig } from './config'
 import { openDbConnection } from './database'
-import { Connection } from 'typeorm'
 import { retireSessions } from './entity/Session'
 import { logger } from './logging'
 import server from './server'
@@ -12,18 +11,14 @@ async function main() {
   logger.info(version)
 
   try {
-    openDbConnection().then(async (db: Connection) => {
-      logger.info('Cleaning up sessions...')
-      await retireSessions(db)
+    const db = await openDbConnection()
 
-      logger.info('Starting Explorer Node')
-      await server(conf, db)
-    }).catch(e => {
-      logger.error({
-        msg: `Exception during openDbConnection in startup: ${e.message}`,
-        stack: e.stack,
-      })
-    })
+    logger.info('Cleaning up sessions...')
+    await retireSessions(db)
+
+    logger.info('Starting Explorer Node')
+    await server(conf, db)
+
   } catch (e) {
     logger.error({
       msg: `Exception during startup: ${e.message}`,

--- a/explorer/src/logging.ts
+++ b/explorer/src/logging.ts
@@ -10,11 +10,16 @@ const options: Parameters<typeof pino>[0] = {
     paths: ['req.headers', 'res.headers'],
   },
 }
-if (process.env.EXPLORER_DEV) {
-  options.prettyPrint = { colorize: true }
-  options.level = 'debug'
-} else if (process.env.NODE_ENV === 'test') {
-  options.level = 'silent'
+
+switch (process.env.NODE_ENV) {
+  case 'production':
+    break
+  case 'test':
+    options.level = 'silent'
+  break
+  default:
+    options.prettyPrint = { colorize: true }
+    options.level = 'debug'
 }
 export const logger = pino(options)
 

--- a/explorer/src/logging.ts
+++ b/explorer/src/logging.ts
@@ -16,7 +16,7 @@ switch (process.env.NODE_ENV) {
     break
   case 'test':
     options.level = 'silent'
-  break
+    break
   default:
     options.prettyPrint = { colorize: true }
     options.level = 'debug'

--- a/explorer/src/middleware/adminAuth.ts
+++ b/explorer/src/middleware/adminAuth.ts
@@ -1,4 +1,3 @@
-import { getConnection } from 'typeorm'
 import { Request, Response, NextFunction } from 'express'
 import httpStatus from 'http-status-codes'
 import { find as findAdmin, isValidPassword } from '../entity/Admin'
@@ -21,8 +20,7 @@ export default async function(req: Request, res: Response, next: NextFunction) {
       return
     }
 
-    const db = getConnection()
-    const admin = await findAdmin(db, username)
+    const admin = await findAdmin(username)
     const validPassword = await isValidPassword(password, admin)
 
     // Express.js middleware is sequential

--- a/explorer/src/middleware/adminAuth.ts
+++ b/explorer/src/middleware/adminAuth.ts
@@ -1,7 +1,7 @@
+import { getConnection } from 'typeorm'
 import { Request, Response, NextFunction } from 'express'
 import httpStatus from 'http-status-codes'
 import { find as findAdmin, isValidPassword } from '../entity/Admin'
-import { getDb } from '../database'
 import {
   ADMIN_USERNAME_HEADER,
   ADMIN_PASSWORD_HEADER,
@@ -21,7 +21,7 @@ export default async function(req: Request, res: Response, next: NextFunction) {
       return
     }
 
-    const db = await getDb()
+    const db = getConnection()
     const admin = await findAdmin(db, username)
     const validPassword = await isValidPassword(password, admin)
 

--- a/explorer/src/queries/search.ts
+++ b/explorer/src/queries/search.ts
@@ -1,4 +1,4 @@
-import { Connection, SelectQueryBuilder } from 'typeorm'
+import { getRepository, SelectQueryBuilder } from 'typeorm'
 import { JobRun } from '../entity/JobRun'
 import { PaginationParams } from '../utils/pagination'
 
@@ -19,11 +19,8 @@ const normalizeSearchToken = (id: string): string => {
   return id
 }
 
-const searchBuilder = (
-  db: Connection,
-  params: SearchParams,
-): SelectQueryBuilder<JobRun> => {
-  let query = db.getRepository(JobRun).createQueryBuilder('job_run')
+const searchBuilder = (params: SearchParams): SelectQueryBuilder<JobRun> => {
+  let query = getRepository(JobRun).createQueryBuilder('job_run')
 
   if (params.searchQuery != null) {
     const searchTokens = params.searchQuery.split(/\s+/)
@@ -56,15 +53,15 @@ const searchBuilder = (
   return query
 }
 
-export const search = async (db: Connection, params: SearchParams): Promise<JobRun[]> => {
-  return searchBuilder(db, params)
+export const search = async (params: SearchParams): Promise<JobRun[]> => {
+  return searchBuilder(params)
     .leftJoinAndSelect('job_run.chainlinkNode', 'chainlink_node')
     .orderBy('job_run.createdAt', 'DESC')
     .getMany()
 }
 
-export const count = async (db: Connection, params: SearchParams): Promise<number> => {
-  const result = await searchBuilder(db, params)
+export const count = async (params: SearchParams): Promise<number> => {
+  const result = await searchBuilder(params)
     .select('COUNT(*)', 'count')
     .getRawOne()
 

--- a/explorer/src/queries/search.ts
+++ b/explorer/src/queries/search.ts
@@ -56,20 +56,14 @@ const searchBuilder = (
   return query
 }
 
-export const search = async (
-  db: Connection,
-  params: SearchParams,
-): Promise<JobRun[]> => {
+export const search = async (db: Connection, params: SearchParams): Promise<JobRun[]> => {
   return searchBuilder(db, params)
     .leftJoinAndSelect('job_run.chainlinkNode', 'chainlink_node')
     .orderBy('job_run.createdAt', 'DESC')
     .getMany()
 }
 
-export const count = async (
-  db: Connection,
-  params: SearchParams,
-): Promise<number> => {
+export const count = async (db: Connection, params: SearchParams): Promise<number> => {
   const result = await searchBuilder(db, params)
     .select('COUNT(*)', 'count')
     .getRawOne()

--- a/explorer/src/seed.ts
+++ b/explorer/src/seed.ts
@@ -1,4 +1,4 @@
-import { Connection } from 'typeorm'
+import { getRepository } from 'typeorm'
 import { ChainlinkNode } from './entity/ChainlinkNode'
 import { createJobRun } from './factories'
 
@@ -12,14 +12,15 @@ const CORE_NODE_HASHED_SECRET =
 const CORE_NODE_SALT = '5dhpzBypVnddiYNRRz0eIO9Y6ZBqqv8D'
 const CORE_NODE_ACCESS_KEY = 'bL1wMDLp4GVJ5p5n'
 
-export default async (db: Connection) => {
-  const count = await db.manager.count(ChainlinkNode)
+export default async () => {
+  const repo = getRepository(ChainlinkNode)
+  const count = await repo.count()
 
   if (count === 0) {
-    const node = await db.manager.save(buildChainlinkNode())
+    const node = await repo.save(buildChainlinkNode())
 
-    await createJobRun(db, node)
-    await createJobRun(db, node)
+    await createJobRun(node)
+    await createJobRun(node)
   }
 }
 

--- a/explorer/src/seed.ts
+++ b/explorer/src/seed.ts
@@ -1,6 +1,6 @@
+import { Connection } from 'typeorm'
 import { ChainlinkNode } from './entity/ChainlinkNode'
 import { createJobRun } from './factories'
-import { getDb } from './database'
 
 // NOT FOR PRODUCTION USE
 // THE VALUES IN THIS FILE ARE ONLY USED FOR A LOCAL DEVELOPMENT ENVIRONMENT
@@ -12,8 +12,7 @@ const CORE_NODE_HASHED_SECRET =
 const CORE_NODE_SALT = '5dhpzBypVnddiYNRRz0eIO9Y6ZBqqv8D'
 const CORE_NODE_ACCESS_KEY = 'bL1wMDLp4GVJ5p5n'
 
-export default async () => {
-  const db = await getDb()
+export default async (db: Connection) => {
   const count = await db.manager.count(ChainlinkNode)
 
   if (count === 0) {

--- a/explorer/src/server.ts
+++ b/explorer/src/server.ts
@@ -3,6 +3,7 @@ import express from 'express'
 import helmet from 'helmet'
 import http from 'http'
 import mime from 'mime-types'
+import { Connection } from 'typeorm'
 import { Environment, ExplorerConfig } from './config'
 import * as controllers from './controllers'
 import { addRequestLogging, logger } from './logging'
@@ -10,9 +11,9 @@ import adminAuth from './middleware/adminAuth'
 import seed from './seed'
 import { bootstrapRealtime } from './server/realtime'
 
-export default function server(conf: ExplorerConfig): Promise<http.Server> {
+export default function server(conf: ExplorerConfig, db: Connection): Promise<http.Server> {
   if (conf.env === Environment.DEV) {
-    seed()
+    seed(db)
   }
 
   const app = express()

--- a/explorer/src/server.ts
+++ b/explorer/src/server.ts
@@ -3,7 +3,6 @@ import express from 'express'
 import helmet from 'helmet'
 import http from 'http'
 import mime from 'mime-types'
-import { Connection } from 'typeorm'
 import { Environment, ExplorerConfig } from './config'
 import * as controllers from './controllers'
 import { addRequestLogging, logger } from './logging'
@@ -11,9 +10,9 @@ import adminAuth from './middleware/adminAuth'
 import seed from './seed'
 import { bootstrapRealtime } from './server/realtime'
 
-export default function server(conf: ExplorerConfig, db: Connection): Promise<http.Server> {
+export default function server(conf: ExplorerConfig): Promise<http.Server> {
   if (conf.env === Environment.DEV) {
-    seed(db)
+    seed()
   }
 
   const app = express()

--- a/explorer/src/server/handleMessage.ts
+++ b/explorer/src/server/handleMessage.ts
@@ -1,4 +1,3 @@
-import { Connection } from 'typeorm'
 import rpcServer from './rpcServer'
 import { logger } from '../logging'
 import { fromString, saveJobRunTree } from '../entity/JobRun'
@@ -9,11 +8,11 @@ export interface ServerContext {
 }
 
 // legacy server response synonymous with upsertJobRun RPC method
-const handleLegacy = async (db: Connection, json: string, context: ServerContext) => {
+const handleLegacy = async (json: string, context: ServerContext) => {
   try {
     const jobRun = fromString(json)
     jobRun.chainlinkNodeId = context.chainlinkNodeId
-    await saveJobRunTree(db, jobRun)
+    await saveJobRunTree(jobRun)
     return { status: 201 }
   } catch (e) {
     logger.error(e)
@@ -40,13 +39,12 @@ const handleJSONRCP = (request: string, context: ServerContext) => {
 }
 
 export const handleMessage = async (
-  db: Connection,
   message: string,
   context: ServerContext,
 ) => {
   if (message.includes('jsonrpc')) {
     return await handleJSONRCP(message, context)
   } else {
-    return await handleLegacy(db, message, context)
+    return await handleLegacy(message, context)
   }
 }

--- a/explorer/src/server/realtime.ts
+++ b/explorer/src/server/realtime.ts
@@ -1,5 +1,4 @@
 import http from 'http'
-import { getConnection } from 'typeorm'
 import { logger } from '../logging'
 import WebSocket from 'ws'
 import { authenticate } from '../sessions'
@@ -45,8 +44,7 @@ export const bootstrapRealtime = async (server: http.Server) => {
         return
       }
 
-      const db = getConnection()
-      authenticate(db, accessKey, secret).then((session: Session | null) => {
+      authenticate(accessKey, secret).then((session: Session | null) => {
         if (session === null) {
           logger.info({
             msg: 'client rejected, failed authentication',
@@ -95,8 +93,7 @@ export const bootstrapRealtime = async (server: http.Server) => {
         return
       }
 
-      const db = getConnection()
-      const result = await handleMessage(db, message as string, {
+      const result = await handleMessage(message as string, {
         chainlinkNodeId: session.chainlinkNodeId,
       })
 
@@ -108,8 +105,7 @@ export const bootstrapRealtime = async (server: http.Server) => {
       const existingConnection = connections.get(accessKey)
 
       if (session != null) {
-        const db = getConnection()
-        closeSession(db, session)
+        closeSession(session)
         sessions.delete(accessKey)
       }
       if (ws === existingConnection) {

--- a/explorer/src/server/rpcMethods/upsertJobRun.ts
+++ b/explorer/src/server/rpcMethods/upsertJobRun.ts
@@ -1,6 +1,5 @@
 import { fromJSONObject, saveJobRunTree } from '../../entity/JobRun'
 import { logger } from '../../logging'
-import { getDb } from '../../database'
 import { ServerContext } from './../handleMessage'
 import jayson from 'jayson'
 
@@ -14,10 +13,9 @@ export default async (
   callback: jayson.JSONRPCCallbackTypePlain,
 ) => {
   try {
-    const db = await getDb()
     const jobRun = fromJSONObject(payload)
     jobRun.chainlinkNodeId = context.chainlinkNodeId
-    await saveJobRunTree(db, jobRun)
+    await saveJobRunTree(jobRun)
     callback(null, 'success')
   } catch (e) {
     logger.error(e)

--- a/explorer/src/server/rpcMethods/upsertJobRun.ts
+++ b/explorer/src/server/rpcMethods/upsertJobRun.ts
@@ -1,4 +1,3 @@
-import { getConnection } from 'typeorm'
 import { fromJSONObject, saveJobRunTree } from '../../entity/JobRun'
 import { logger } from '../../logging'
 import { ServerContext } from './../handleMessage'
@@ -16,8 +15,7 @@ export default async (
   try {
     const jobRun = fromJSONObject(payload)
     jobRun.chainlinkNodeId = context.chainlinkNodeId
-    const db = getConnection()
-    await saveJobRunTree(db, jobRun)
+    await saveJobRunTree(jobRun)
     callback(null, 'success')
   } catch (e) {
     logger.error(e)

--- a/explorer/src/server/rpcMethods/upsertJobRun.ts
+++ b/explorer/src/server/rpcMethods/upsertJobRun.ts
@@ -1,3 +1,4 @@
+import { getConnection } from 'typeorm'
 import { fromJSONObject, saveJobRunTree } from '../../entity/JobRun'
 import { logger } from '../../logging'
 import { ServerContext } from './../handleMessage'
@@ -15,7 +16,8 @@ export default async (
   try {
     const jobRun = fromJSONObject(payload)
     jobRun.chainlinkNodeId = context.chainlinkNodeId
-    await saveJobRunTree(jobRun)
+    const db = getConnection()
+    await saveJobRunTree(db, jobRun)
     callback(null, 'success')
   } catch (e) {
     logger.error(e)

--- a/explorer/src/sessions.ts
+++ b/explorer/src/sessions.ts
@@ -21,7 +21,10 @@ export const authenticate = async (
   })
 }
 
-function findNode(manager: EntityManager, accessKey: string): Promise<ChainlinkNode> {
+function findNode(
+  manager: EntityManager,
+  accessKey: string,
+): Promise<ChainlinkNode> {
   return manager.getRepository(ChainlinkNode).findOne({ accessKey })
 }
 

--- a/explorer/src/sessions.ts
+++ b/explorer/src/sessions.ts
@@ -1,4 +1,4 @@
-import { Connection } from 'typeorm'
+import { getConnection, EntityManager } from 'typeorm'
 import { ChainlinkNode, hashCredentials } from './entity/ChainlinkNode'
 import { createSession, Session } from './entity/Session'
 import { timingSafeEqual } from 'crypto'
@@ -6,15 +6,14 @@ import { timingSafeEqual } from 'crypto'
 // authenticate looks up a chainlink node by accessKey and attempts to verify the
 // provided secret, if verification succeeds a Session is returned
 export const authenticate = async (
-  db: Connection,
   accessKey: string,
   secret: string,
 ): Promise<Session | null> => {
-  return db.manager.transaction(async () => {
-    const chainlinkNode = await findNode(db, accessKey)
+  return getConnection().transaction(async (manager: EntityManager) => {
+    const chainlinkNode = await findNode(manager, accessKey)
     if (chainlinkNode != null) {
       if (authenticateSession(accessKey, secret, chainlinkNode)) {
-        return createSession(db, chainlinkNode)
+        return createSession(chainlinkNode, manager)
       }
     }
 
@@ -22,8 +21,8 @@ export const authenticate = async (
   })
 }
 
-function findNode(db: Connection, accessKey: string): Promise<ChainlinkNode> {
-  return db.getRepository(ChainlinkNode).findOne({ accessKey })
+function findNode(manager: EntityManager, accessKey: string): Promise<ChainlinkNode> {
+  return manager.getRepository(ChainlinkNode).findOne({ accessKey })
 }
 
 function authenticateSession(

--- a/explorer/src/support/admin.ts
+++ b/explorer/src/support/admin.ts
@@ -1,9 +1,8 @@
-import { Connection } from 'typeorm'
+import { getRepository } from 'typeorm'
 import { Admin } from '../entity/Admin'
 import { hash } from '../services/password'
 
 export async function createAdmin(
-  db: Connection,
   username: string,
   password: string,
 ) {
@@ -12,5 +11,5 @@ export async function createAdmin(
   admin.username = username
   admin.hashedPassword = hashedPassword
 
-  return db.manager.save(admin)
+  return getRepository(Admin).save(admin)
 }

--- a/explorer/src/support/admin.ts
+++ b/explorer/src/support/admin.ts
@@ -2,10 +2,7 @@ import { getRepository } from 'typeorm'
 import { Admin } from '../entity/Admin'
 import { hash } from '../services/password'
 
-export async function createAdmin(
-  username: string,
-  password: string,
-) {
+export async function createAdmin(username: string, password: string) {
   const hashedPassword = await hash(password)
   const admin = new Admin()
   admin.username = username

--- a/explorer/src/support/server.ts
+++ b/explorer/src/support/server.ts
@@ -1,8 +1,10 @@
 import { randomBytes } from 'crypto'
 import http from 'http'
 import { getConfig } from '../config'
-import { closeDbConnection, getDb } from '../database'
+import { openDbConnection } from '../database'
+import { Connection } from 'typeorm'
 import server from '../server'
+import { logger } from '../logging'
 
 export const DEFAULT_TEST_PORT =
   parseInt(process.env.EXPLORER_TEST_SERVER_PORT, 10) || 8081
@@ -11,18 +13,25 @@ export const DEFAULT_TEST_PORT =
  * Start database then initialize the server on the specified port
  */
 export async function start() {
-  Object.assign(process.env, {
-    EXPLORER_SERVER_PORT: `${DEFAULT_TEST_PORT}`,
-    EXPLORER_COOKIE_SECRET: randomBytes(32).toString('hex'),
+  openDbConnection().then(async (db: Connection) => {
+    Object.assign(process.env, {
+      EXPLORER_SERVER_PORT: `${DEFAULT_TEST_PORT}`,
+      EXPLORER_COOKIE_SECRET: randomBytes(32).toString('hex'),
+    })
+
+    const conf = getConfig()
+    return await server(conf, db)
+  }).catch(e => {
+    logger.error({
+      msg: `Exception during startup: ${e.message}`,
+      stack: e.stack,
+    })
   })
-  const conf = getConfig()
-  await getDb()
-  return await server(conf)
 }
 
 /**
  * Stop the server then close the database connection
  */
 export function stop(server: http.Server, done: jest.DoneCallback): void {
-  server.close(() => closeDbConnection().then(done))
+  server.close(done)
 }

--- a/explorer/src/support/server.ts
+++ b/explorer/src/support/server.ts
@@ -1,4 +1,3 @@
-import { Connection } from 'typeorm'
 import { randomBytes } from 'crypto'
 import http from 'http'
 import { getConfig } from '../config'
@@ -11,19 +10,21 @@ export const DEFAULT_TEST_PORT =
 /**
  * Start database then initialize the server on the specified port
  */
-export async function start(db: Connection): Promise<Server> {
+export async function start(): Promise<Server> {
   Object.assign(process.env, {
     EXPLORER_SERVER_PORT: `${DEFAULT_TEST_PORT}`,
     EXPLORER_COOKIE_SECRET: randomBytes(32).toString('hex'),
   })
 
   const conf = getConfig()
-  return server(conf, db)
+  return server(conf)
 }
 
 /**
  * Stop the server then close the database connection
  */
 export function stop(server: http.Server, done: jest.DoneCallback): void {
-  server.close(done)
+  if (server !== undefined) {
+    server.close(done)
+  }
 }

--- a/explorer/src/support/server.ts
+++ b/explorer/src/support/server.ts
@@ -1,10 +1,9 @@
+import { Connection } from 'typeorm'
 import { randomBytes } from 'crypto'
 import http from 'http'
 import { getConfig } from '../config'
-import { openDbConnection } from '../database'
-import { Connection } from 'typeorm'
 import server from '../server'
-import { logger } from '../logging'
+import { Server } from 'http'
 
 export const DEFAULT_TEST_PORT =
   parseInt(process.env.EXPLORER_TEST_SERVER_PORT, 10) || 8081
@@ -12,21 +11,14 @@ export const DEFAULT_TEST_PORT =
 /**
  * Start database then initialize the server on the specified port
  */
-export async function start() {
-  openDbConnection().then(async (db: Connection) => {
-    Object.assign(process.env, {
-      EXPLORER_SERVER_PORT: `${DEFAULT_TEST_PORT}`,
-      EXPLORER_COOKIE_SECRET: randomBytes(32).toString('hex'),
-    })
-
-    const conf = getConfig()
-    return await server(conf, db)
-  }).catch(e => {
-    logger.error({
-      msg: `Exception during startup: ${e.message}`,
-      stack: e.stack,
-    })
+export async function start(db: Connection): Promise<Server> {
+  Object.assign(process.env, {
+    EXPLORER_SERVER_PORT: `${DEFAULT_TEST_PORT}`,
+    EXPLORER_COOKIE_SECRET: randomBytes(32).toString('hex'),
   })
+
+  const conf = getConfig()
+  return server(conf, db)
 }
 
 /**

--- a/explorer/src/support/server.ts
+++ b/explorer/src/support/server.ts
@@ -21,10 +21,8 @@ export async function start(): Promise<Server> {
 }
 
 /**
- * Stop the server then close the database connection
+ * Stop the server
  */
 export function stop(server: http.Server, done: jest.DoneCallback): void {
-  if (server !== undefined) {
-    server.close(done)
-  }
+  server.close(done)
 }


### PR DESCRIPTION
It looks like the way we're using TypeORM is a little bit incorrect:

  1. We should avoid reconnecting as much as we do, instead connect once in a central place then use repositories/managers and `getConnection` to pull a connection out of the pool.
  2. DB names are meant to be used for multiple connections within a process, not for alternatives

This PR introduces changes as suggested in the TypeORM documentation, and should get rid of DB related deadlocks.