### PR TITLE
Convert status to enum type

### DIFF
--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -213,7 +213,8 @@ func TestRunManager_ResumeAllConnecting(t *testing.T) {
 
 		job, err := store.FindJob(run.JobSpecID)
 		require.NoError(t, err)
-		run.TaskRuns = []models.TaskRun{models.TaskRun{ID: models.NewID(), TaskSpecID: job.Tasks[0].ID}}
+		run.TaskRuns = []models.TaskRun{models.TaskRun{ID: models.NewID(), TaskSpecID: job.Tasks[0].ID, Status: models.RunStatusUnstarted}}
+
 		require.NoError(t, store.CreateJobRun(&run))
 		err = runManager.ResumeAllConnecting()
 		assert.NoError(t, err)

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -40,7 +40,8 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586342453"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586369235"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586939705"
-
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1587027516"
+	
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 	gormigrate "gopkg.in/gormigrate.v1"
@@ -204,6 +205,10 @@ func MigrateTo(db *gorm.DB, migrationID string) error {
 		{
 			ID:      "1586939705",
 			Migrate: migration1586939705.Migrate,
+		},
+		{
+			ID:      "1587027516",
+			Migrate: migration1587027516.Migrate,
 		},
 	}
 

--- a/core/store/migrations/migration1587027516/migrate.go
+++ b/core/store/migrations/migration1587027516/migrate.go
@@ -1,0 +1,30 @@
+package migration1587027516
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate converts text columns to enums where appropriate
+func Migrate(tx *gorm.DB) error {
+	// Create two different types for job runs/task runs
+	// These are currently identical because right now they are represented by
+	// one type in the code but may have different meanings in future and
+	// arguably should be split up
+	return tx.Exec(`
+	CREATE TYPE job_run_status AS ENUM ('', 'in_progress', 'pending_confirmations', 'pending_connection', 'pending_bridge', 'pending_sleep', 'errored', 'completed', 'cancelled');
+	CREATE TYPE task_run_status AS ENUM ('', 'in_progress', 'pending_confirmations', 'pending_connection', 'pending_bridge', 'pending_sleep', 'errored', 'completed', 'cancelled');
+
+	-- It's no longer used as of deb84dbfc
+	ALTER TABLE run_results DROP COLUMN status;
+
+	UPDATE job_runs SET status = '' WHERE status IS NULL;
+	UPDATE task_runs SET status = '' WHERE status IS NULL;
+
+	DROP INDEX idx_job_runs_status;
+	ALTER TABLE job_runs ALTER COLUMN status TYPE job_run_status USING status::job_run_status, ALTER COLUMN status SET DEFAULT ''::job_run_status, ALTER COLUMN status SET NOT NULL;
+	CREATE INDEX idx_job_runs_status ON job_runs (status) WHERE status != 'completed'::job_run_status;
+
+	ALTER TABLE task_runs ALTER COLUMN status TYPE task_run_status USING status::task_run_status, ALTER COLUMN status SET DEFAULT ''::task_run_status, ALTER COLUMN status SET NOT NULL;
+	CREATE INDEX idx_task_runs_status ON task_runs (status) WHERE status != 'completed'::task_run_status;
+	`).Error
+}

--- a/core/store/migrations/migration1587027516/migrate.go
+++ b/core/store/migrations/migration1587027516/migrate.go
@@ -11,20 +11,20 @@ func Migrate(tx *gorm.DB) error {
 	// one type in the code but may have different meanings in future and
 	// arguably should be split up
 	return tx.Exec(`
-	CREATE TYPE job_run_status AS ENUM ('', 'in_progress', 'pending_confirmations', 'pending_connection', 'pending_bridge', 'pending_sleep', 'errored', 'completed', 'cancelled');
-	CREATE TYPE task_run_status AS ENUM ('', 'in_progress', 'pending_confirmations', 'pending_connection', 'pending_bridge', 'pending_sleep', 'errored', 'completed', 'cancelled');
+	CREATE TYPE job_run_status AS ENUM ('unstarted', 'in_progress', 'pending_confirmations', 'pending_connection', 'pending_bridge', 'pending_sleep', 'errored', 'completed', 'cancelled');
+	CREATE TYPE task_run_status AS ENUM ('unstarted', 'in_progress', 'pending_confirmations', 'pending_connection', 'pending_bridge', 'pending_sleep', 'errored', 'completed', 'cancelled');
 
 	-- It's no longer used as of deb84dbfc
 	ALTER TABLE run_results DROP COLUMN status;
 
-	UPDATE job_runs SET status = '' WHERE status IS NULL;
-	UPDATE task_runs SET status = '' WHERE status IS NULL;
+	UPDATE job_runs SET status = 'unstarted' WHERE status = '' OR status IS NULL;
+	UPDATE task_runs SET status = 'unstarted' WHERE status = '' OR status IS NULL;
 
 	DROP INDEX idx_job_runs_status;
-	ALTER TABLE job_runs ALTER COLUMN status TYPE job_run_status USING status::job_run_status, ALTER COLUMN status SET DEFAULT ''::job_run_status, ALTER COLUMN status SET NOT NULL;
+	ALTER TABLE job_runs ALTER COLUMN status TYPE job_run_status USING status::job_run_status, ALTER COLUMN status SET DEFAULT 'unstarted'::job_run_status, ALTER COLUMN status SET NOT NULL;
 	CREATE INDEX idx_job_runs_status ON job_runs (status) WHERE status != 'completed'::job_run_status;
 
-	ALTER TABLE task_runs ALTER COLUMN status TYPE task_run_status USING status::task_run_status, ALTER COLUMN status SET DEFAULT ''::task_run_status, ALTER COLUMN status SET NOT NULL;
+	ALTER TABLE task_runs ALTER COLUMN status TYPE task_run_status USING status::task_run_status, ALTER COLUMN status SET DEFAULT 'unstarted'::task_run_status, ALTER COLUMN status SET NOT NULL;
 	CREATE INDEX idx_task_runs_status ON task_runs (status) WHERE status != 'completed'::task_run_status;
 	`).Error
 }

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -26,7 +26,7 @@ type RunStatus string
 
 const (
 	// RunStatusUnstarted is the default state of any run status.
-	RunStatusUnstarted = RunStatus("")
+	RunStatusUnstarted = RunStatus("unstarted")
 	// RunStatusInProgress is used for when a run is actively being executed.
 	RunStatusInProgress = RunStatus("in_progress")
 	// RunStatusPendingConfirmations is used for when a run is awaiting for block confirmations.

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -113,12 +113,14 @@ func (s RunStatus) Value() (driver.Value, error) {
 
 // Scan reads the database value and returns an instance.
 func (s *RunStatus) Scan(value interface{}) error {
-	temp, ok := value.(string)
-	if !ok {
-		return fmt.Errorf("Unable to convert %v of %T to RunStatus", value, value)
+	switch v := value.(type) {
+	case []byte:
+		*s = RunStatus(string(v))
+	case string:
+		*s = RunStatus(v)
+	default:
+		return fmt.Errorf("Unable to convert %#v of %T to RunStatus", value, value)
 	}
-
-	*s = RunStatus(temp)
 	return nil
 }
 

--- a/core/store/models/job_run.go
+++ b/core/store/models/job_run.go
@@ -68,6 +68,7 @@ func MakeJobRun(job *JobSpec, now time.Time, initiator *Initiator, currentHeight
 			ID:       NewID(),
 			JobRunID: run.ID,
 			TaskSpec: task,
+			Status:   RunStatusUnstarted,
 		}
 	}
 	run.SetStatus(RunStatusInProgress)

--- a/core/store/models/job_run.go
+++ b/core/store/models/job_run.go
@@ -33,7 +33,7 @@ type JobRun struct {
 	ResultID       clnull.Uint32 `json:"-"`
 	RunRequest     RunRequest    `json:"-" gorm:"foreignkey:RunRequestID;association_autoupdate:true;association_autocreate:true"`
 	RunRequestID   clnull.Uint32 `json:"-"`
-	Status         RunStatus     `json:"status"`
+	Status         RunStatus     `json:"status" gorm:"default:'unstarted'"`
 	TaskRuns       []TaskRun     `json:"taskRuns"`
 	CreatedAt      time.Time     `json:"createdAt"`
 	FinishedAt     null.Time     `json:"finishedAt"`
@@ -243,7 +243,7 @@ type TaskRun struct {
 	JobRunID             *ID           `json:"-"`
 	Result               RunResult     `json:"result"`
 	ResultID             clnull.Uint32 `json:"-"`
-	Status               RunStatus     `json:"status"`
+	Status               RunStatus     `json:"status" gorm:"default:'unstarted'"`
 	TaskSpec             TaskSpec      `json:"task" gorm:"association_autoupdate:false;association_autocreate:false"`
 	TaskSpecID           uint          `json:"-"`
 	MinimumConfirmations clnull.Uint32 `json:"minimumConfirmations"`

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -339,7 +339,7 @@ func (orm *ORM) SaveJobRun(run *models.JobRun) error {
 // CreateJobRun inserts a new JobRun
 func (orm *ORM) CreateJobRun(run *models.JobRun) error {
 	orm.MustEnsureAdvisoryLock()
-	return orm.db.Debug().Create(run).Error
+	return orm.db.Create(run).Error
 }
 
 // LinkEarnedFor shows the total link earnings for a job

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -339,7 +339,7 @@ func (orm *ORM) SaveJobRun(run *models.JobRun) error {
 // CreateJobRun inserts a new JobRun
 func (orm *ORM) CreateJobRun(run *models.JobRun) error {
 	orm.MustEnsureAdvisoryLock()
-	return orm.db.Create(run).Error
+	return orm.db.Debug().Create(run).Error
 }
 
 // LinkEarnedFor shows the total link earnings for a job


### PR DESCRIPTION
Note that using two distinct types allows for splitting task/job run status in future since they are technically different concepts and combining them has probably caused confusion around understanding of the job/task run flow.

Timing information:

```
	CREATE TYPE job_run_status AS ENUM ('unstarted', 'in_progress', 'pending_confirmations', 'pending_connection', 'pending_bridge', 'pending_sleep', 'errored', 'completed', 'cancelled');
	CREATE TYPE task_run_status AS ENUM ('unstarted', 'in_progress', 'pending_confirmations', 'pending_connection', 'pending_bridge', 'pending_sleep', 'errored', 'completed', 'cancelled');

	-- It's no longer used as of deb84dbfc
	ALTER TABLE run_results DROP COLUMN status;

	UPDATE job_runs SET status = 'unstarted' WHERE status = '' OR status IS NULL;
	UPDATE task_runs SET status = 'unstarted' WHERE status = '' OR status IS NULL;

	DROP INDEX idx_job_runs_status;
	ALTER TABLE job_runs ALTER COLUMN status TYPE job_run_status USING status::job_run_status, ALTER COLUMN status SET DEFAULT 'unstarted'::job_run_status, ALTER COLUMN status SET NOT NULL;
	CREATE INDEX idx_job_runs_status ON job_runs (status) WHERE status != 'completed'::job_run_status;

	ALTER TABLE task_runs ALTER COLUMN status TYPE task_run_status USING status::task_run_status, ALTER COLUMN status SET DEFAULT 'unstarted'::task_run_status, ALTER COLUMN status SET NOT NULL;
	CREATE INDEX idx_task_runs_status ON task_runs (status) WHERE status != 'completed'::task_run_status;
	 gormigrate.v1@v1.6.0/gormigrate.go:364 rows_affected=0 time=1.610841526
```

Migration takes about ~1.5s on utility node DB.

Size reduction:

```
run_results job_runs task_runs
809 MB	49 MB	27 MB
808 MB	35 MB	25 MB
```

This is the final PR for the DB schema audit!

We have now completed this card: https://www.pivotaltracker.com/n/projects/2129823/stories/172080031