### PR TITLE
Remove retry-loop for getting block height for FM

### DIFF
--- a/core/services/eth/log_broadcaster.go
+++ b/core/services/eth/log_broadcaster.go
@@ -93,22 +93,12 @@ func (b *logBroadcaster) Start() {
 }
 
 func (b *logBroadcaster) getOnChainBlockHeight() (_ uint64, abort bool) {
-	var currentHeight uint64
-	for {
-		var err error
-		currentHeight, err = b.ethClient.GetBlockHeight()
-		if err == nil {
-			break
-		}
-
+	currentHeight, err := b.ethClient.GetBlockHeight()
+	if err != nil {
 		logger.Errorf("error fetching current block height: %v", err)
-		select {
-		case <-b.chStop:
-			return 0, true
-		case <-time.After(10 * time.Second):
-		}
-		continue
+		return
 	}
+
 	return currentHeight, false
 }
 


### PR DESCRIPTION
Currently, the Chainlink node will block on startup trying to get the block height for the FM.

If the node operator is connecting to a different blockchain and not using Ethereum, this means that the Chainlink node will never finish startup.

This PR removes the reconnect loop, and only does an initial attempt at connecting, so that startup can resume. However this will also remove the reconnect loop for node operators using FM on Ethereum.