### PR TITLE
add config variable to make ethereum connection on startup

### DIFF
--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -88,6 +88,10 @@ func New(
 }
 
 func (fm *concreteFluxMonitor) Start() error {
+	if fm.store.Config.EthereumDisabled() {
+		return nil
+	}
+
 	fm.logBroadcaster.Start()
 
 	go fm.serveInternalRequests()

--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -89,6 +89,7 @@ func New(
 
 func (fm *concreteFluxMonitor) Start() error {
 	if fm.store.Config.EthereumDisabled() {
+		logger.Info("Ethereum disabled: Cannot start Flux Monitor")
 		return nil
 	}
 
@@ -123,6 +124,11 @@ func (fm *concreteFluxMonitor) Start() error {
 
 // Disconnect cleans up running deviation checkers.
 func (fm *concreteFluxMonitor) Stop() {
+	if fm.store.Config.EthereumDisabled() {
+		logger.Info("Flux monitor disabled: cannot stop")
+		return
+	}
+
 	fm.logBroadcaster.Stop()
 	close(fm.chStop)
 	<-fm.chDone

--- a/core/services/fluxmonitor/flux_monitor_internal_test.go
+++ b/core/services/fluxmonitor/flux_monitor_internal_test.go
@@ -1,0 +1,29 @@
+package fluxmonitor
+
+import (
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink/core/services/eth"
+)
+
+func (fm *concreteFluxMonitor) MockLogBroadcaster() *mockLogBroadcaster {
+	mock := mockLogBroadcaster{}
+	fm.logBroadcaster = &mock
+	return &mock
+}
+
+type mockLogBroadcaster struct {
+	Started bool
+}
+
+func (mlb *mockLogBroadcaster) Start() {
+	mlb.Started = true
+}
+func (mlb *mockLogBroadcaster) Register(common.Address, eth.LogListener) bool {
+	return false
+}
+func (mlb *mockLogBroadcaster) Unregister(common.Address, eth.LogListener) {}
+func (mlb *mockLogBroadcaster) Stop()                                      {}
+
+type MockableLogBroadcaster interface {
+	MockLogBroadcaster() *mockLogBroadcaster
+}

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -42,6 +42,35 @@ func ensureAccount(t *testing.T, store *store.Store) common.Address {
 	return acct.Address
 }
 
+func TestConcreteFluxMonitor_Start_withEthereumDisabled(t *testing.T) {
+	tests := []struct {
+		name        string
+		enabled     bool
+		wantStarted bool
+	}{
+		{"enabled", true, false},
+		{"disabled", false, true},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			config, cleanup := cltest.NewConfig(t)
+			defer cleanup()
+			config.Config.Set("ETH_DISABLED", test.enabled)
+			store, cleanup := cltest.NewStoreWithConfig(config)
+			defer cleanup()
+			runManager := new(mocks.RunManager)
+
+			fm := fluxmonitor.New(store, runManager)
+			logBroadcaster := fm.(fluxmonitor.MockableLogBroadcaster).MockLogBroadcaster()
+
+			err := fm.Start()
+			assert.NoError(t, err)
+			assert.Equal(t, test.wantStarted, logBroadcaster.Started)
+		})
+	}
+}
+
 func TestConcreteFluxMonitor_AddJobRemoveJob(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -65,8 +65,8 @@ func TestConcreteFluxMonitor_Start_withEthereumDisabled(t *testing.T) {
 			logBroadcaster := fm.(fluxmonitor.MockableLogBroadcaster).MockLogBroadcaster()
 
 			err := fm.Start()
+			require.NoError(t, err)
 			defer fm.Stop()
-			assert.NoError(t, err)
 			assert.Equal(t, test.wantStarted, logBroadcaster.Started)
 		})
 	}

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -65,6 +65,7 @@ func TestConcreteFluxMonitor_Start_withEthereumDisabled(t *testing.T) {
 			logBroadcaster := fm.(fluxmonitor.MockableLogBroadcaster).MockLogBroadcaster()
 
 			err := fm.Start()
+			defer fm.Stop()
 			assert.NoError(t, err)
 			assert.Equal(t, test.wantStarted, logBroadcaster.Started)
 		})

--- a/core/services/validators.go
+++ b/core/services/validators.go
@@ -122,6 +122,9 @@ func validateFluxMonitor(i models.Initiator, j models.JobSpec, store *store.Stor
 	fe := models.NewJSONAPIErrors()
 	minimumPollingInterval := models.Duration(store.Config.DefaultHTTPTimeout())
 
+	if store.Config.EthereumDisabled() {
+		fe.Add("cannot add flux monitor jobs when ethereum is disabled")
+	}
 	if i.Address == utils.ZeroAddress {
 		fe.Add("no address")
 	}

--- a/core/services/validators_test.go
+++ b/core/services/validators_test.go
@@ -430,6 +430,22 @@ func TestValidateInitiator_FluxMonitorErrors(t *testing.T) {
 	}
 }
 
+func TestValidateInitiator_FluxMonitor_EthereumDisabled(t *testing.T) {
+	t.Parallel()
+
+	config, cleanup := cltest.NewConfig(t)
+	defer cleanup()
+	config.Config.Set("ETH_DISABLED", true)
+	store, cleanup := cltest.NewStoreWithConfig(config)
+	defer cleanup()
+
+	job := cltest.NewJob()
+	var initr models.Initiator
+	require.NoError(t, json.Unmarshal([]byte(validInitiator), &initr))
+	err := services.ValidateInitiator(initr, job, store)
+	require.Error(t, err)
+}
+
 func TestValidateInitiator_FeedsHappy(t *testing.T) {
 	t.Parallel()
 

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -250,6 +250,11 @@ func (c Config) EthereumURL() string {
 	return c.viper.GetString(EnvVarName("EthereumURL"))
 }
 
+// EthereumDisabled shows whether Ethereum interactions are supported.
+func (c Config) EthereumDisabled() bool {
+	return c.viper.GetBool(EnvVarName("EthereumDisabled"))
+}
+
 // GasUpdaterBlockDelay is the number of blocks that the gas updater trails behind head.
 // E.g. if this is set to 3, and we receive block 10, gas updater will
 // fetch block 7.

--- a/core/store/orm/config_test.go
+++ b/core/store/orm/config_test.go
@@ -26,6 +26,7 @@ func TestStore_ConfigDefaults(t *testing.T) {
 	assert.Equal(t, assets.NewLink(1000000000000000000), config.MinimumContractPayment())
 	assert.Equal(t, 15*time.Minute, config.SessionTimeout())
 	assert.Equal(t, new(url.URL), config.BridgeResponseURL())
+	assert.Equal(t, false, config.EthereumDisabled())
 }
 
 func TestConfig_sessionSecret(t *testing.T) {

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -35,6 +35,7 @@ type ConfigSchema struct {
 	EthGasPriceDefault              big.Int        `env:"ETH_GAS_PRICE_DEFAULT" default:"20000000000"`
 	EthMaxGasPriceWei               uint64         `env:"ETH_MAX_GAS_PRICE_WEI" default:"500000000000"`
 	EthereumURL                     string         `env:"ETH_URL" default:"ws://localhost:8546"`
+	EthereumDisabled                bool           `env:"ETH_DISABLED" default:"false"`
 	GasUpdaterBlockDelay            uint16         `env:"GAS_UPDATER_BLOCK_DELAY" default:"3"`
 	GasUpdaterBlockHistorySize      uint16         `env:"GAS_UPDATER_BLOCK_HISTORY_SIZE" default:"24"`
 	GasUpdaterTransactionPercentile uint16         `env:"GAS_UPDATER_TRANSACTION_PERCENTILE" default:"35"`


### PR DESCRIPTION
I think this is a minimal functionality to unblock startup.

I think it would be a bit more robust to allow `fm.AddJob` to be called and log an error. But, I don't think that right now there is any way for that to actually get called without failing on validation first.