### PR TITLE
seperate flux aggregator's requester delay from oracle delay

### DIFF
--- a/evm-contracts/src/v0.6/dev/FluxAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/FluxAggregator.sol
@@ -53,6 +53,7 @@ contract FluxAggregator is AggregatorInterface, Owned {
 
   struct Requester {
     bool authorized;
+    uint32 delay;
   }
 
   uint256 constant public VERSION = 2;
@@ -516,13 +517,18 @@ contract FluxAggregator is AggregatorInterface, Owned {
    * @param _requester is the address to set permissions for
    * @param _allowed is a boolean specifying whether they can start new rounds or not
    */
-  function setAuthorization(address _requester, bool _allowed)
+  function setAuthorization(address _requester, bool _allowed, uint32 _delay)
     external
     onlyOwner()
   {
     if (requesters[_requester].authorized == _allowed) return;
 
-    requesters[_requester].authorized = _allowed;
+    if (_allowed) {
+      requesters[_requester].authorized = _allowed;
+      requesters[_requester].delay = _delay;
+    } else {
+      delete requesters[_requester];
+    }
 
     emit RequesterAuthorizationSet(_requester, _allowed);
   }

--- a/evm-contracts/src/v0.6/dev/FluxAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/FluxAggregator.sol
@@ -102,7 +102,7 @@ contract FluxAggregator is AggregatorInterface, Owned {
   );
   event RequesterPermissionsSet(
     address indexed requester,
-    bool allowed,
+    bool authorized,
     uint32 delay
   );
 
@@ -524,22 +524,23 @@ contract FluxAggregator is AggregatorInterface, Owned {
   /**
    * @notice allows the owner to specify new non-oracles to start new rounds
    * @param _requester is the address to set permissions for
-   * @param _allowed is a boolean specifying whether they can start new rounds or not
+   * @param _authorized is a boolean specifying whether they can start new rounds or not
+   * @param _delay is the number of rounds the requester must wait before starting another round
    */
-  function setRequesterPermissions(address _requester, bool _allowed, uint32 _delay)
+  function setRequesterPermissions(address _requester, bool _authorized, uint32 _delay)
     external
     onlyOwner()
   {
-    if (requesters[_requester].authorized == _allowed) return;
+    if (requesters[_requester].authorized == _authorized) return;
 
-    if (_allowed) {
-      requesters[_requester].authorized = _allowed;
+    if (_authorized) {
+      requesters[_requester].authorized = _authorized;
       requesters[_requester].delay = _delay;
     } else {
       delete requesters[_requester];
     }
 
-    emit RequesterPermissionsSet(_requester, _allowed, _delay);
+    emit RequesterPermissionsSet(_requester, _authorized, _delay);
   }
 
   /**
@@ -869,7 +870,7 @@ contract FluxAggregator is AggregatorInterface, Owned {
   }
 
   modifier onlyWithPreviousAnswer(uint32 _id) {
-    require(rounds[_id.sub(1)].updatedAt != 0, "preious round unanswered");
+    require(rounds[_id.sub(1)].updatedAt != 0, "previous round unanswered");
     _;
   }
 

--- a/evm-contracts/src/v0.6/dev/FluxAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/FluxAggregator.sol
@@ -89,13 +89,21 @@ contract FluxAggregator is AggregatorInterface, Owned {
   event OracleAdded(address indexed oracle);
   event OracleRemoved(address indexed oracle);
   event OracleAdminUpdated(address indexed oracle, address indexed newAdmin);
-  event OracleAdminUpdateRequested(address indexed oracle, address admin, address newAdmin);
+  event OracleAdminUpdateRequested(
+    address indexed oracle,
+    address admin,
+    address newAdmin
+  );
   event SubmissionReceived(
     int256 indexed answer,
     uint32 indexed round,
     address indexed oracle
   );
-  event RequesterAuthorizationSet(address indexed requester, bool allowed);
+  event RequesterPermissionsSet(
+    address indexed requester,
+    bool allowed,
+    uint32 delay
+  );
 
   uint32 constant private ROUND_MAX = 2**32-1;
 
@@ -517,7 +525,7 @@ contract FluxAggregator is AggregatorInterface, Owned {
    * @param _requester is the address to set permissions for
    * @param _allowed is a boolean specifying whether they can start new rounds or not
    */
-  function setAuthorization(address _requester, bool _allowed, uint32 _delay)
+  function setRequesterPermissions(address _requester, bool _allowed, uint32 _delay)
     external
     onlyOwner()
   {
@@ -530,7 +538,7 @@ contract FluxAggregator is AggregatorInterface, Owned {
       delete requesters[_requester];
     }
 
-    emit RequesterAuthorizationSet(_requester, _allowed);
+    emit RequesterPermissionsSet(_requester, _allowed, _delay);
   }
 
   /**

--- a/evm-contracts/src/v0.6/dev/FluxAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/FluxAggregator.sol
@@ -51,6 +51,10 @@ contract FluxAggregator is AggregatorInterface, Owned {
     address pendingAdmin;
   }
 
+  struct Requester {
+    bool authorized;
+  }
+
   uint256 constant public VERSION = 2;
 
   uint128 public allocatedFunds;
@@ -70,7 +74,7 @@ contract FluxAggregator is AggregatorInterface, Owned {
   LinkTokenInterface public linkToken;
   mapping(address => OracleStatus) private oracles;
   mapping(uint32 => Round) internal rounds;
-  mapping(address => bool) internal authorizedRequesters;
+  mapping(address => Requester) internal requesters;
   address[] private oracleAddresses;
 
   event AvailableFundsUpdated(uint256 indexed amount);
@@ -516,9 +520,9 @@ contract FluxAggregator is AggregatorInterface, Owned {
     external
     onlyOwner()
   {
-    if (authorizedRequesters[_requester] == _allowed) return;
+    if (requesters[_requester].authorized == _allowed) return;
 
-    authorizedRequesters[_requester] = _allowed;
+    requesters[_requester].authorized = _allowed;
 
     emit RequesterAuthorizationSet(_requester, _allowed);
   }
@@ -833,7 +837,7 @@ contract FluxAggregator is AggregatorInterface, Owned {
   }
 
   modifier onlyAuthorizedRequesters() {
-    require(authorizedRequesters[msg.sender], "not authorized requester");
+    require(requesters[msg.sender].authorized, "not authorized requester");
     _;
   }
 

--- a/evm-contracts/test/v0.6/FluxAggregator.test.ts
+++ b/evm-contracts/test/v0.6/FluxAggregator.test.ts
@@ -1853,6 +1853,34 @@ describe('FluxAggregator', () => {
         })
       })
     })
+
+    describe('when there is a restart delay set', () => {
+      beforeEach(async () => {
+        await aggregator.setRequesterPermissions(personas.Eddy.address, true, 1)
+      })
+
+      it('reverts if a round is started before the delay', async () => {
+        await aggregator.connect(personas.Eddy).startNewRound()
+
+        await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
+        nextRound = nextRound + 1
+
+        // Eddy can't start because of the delay
+        await matchers.evmRevert(
+          aggregator.connect(personas.Eddy).startNewRound(),
+          'must delay requests',
+        )
+        // Carol starts a new round instead
+        await aggregator.connect(personas.Carol).startNewRound()
+
+        // round completes
+        await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
+        nextRound = nextRound + 1
+
+        // now Eddy can start again
+        await aggregator.connect(personas.Eddy).startNewRound()
+      })
+    })
   })
 
   describe('#setRequesterPermissions', () => {

--- a/evm-contracts/test/v0.6/FluxAggregator.test.ts
+++ b/evm-contracts/test/v0.6/FluxAggregator.test.ts
@@ -112,7 +112,7 @@ describe('FluxAggregator', () => {
       'reportingRoundStartedAt',
       'restartDelay',
       'roundState',
-      'setAuthorization',
+      'setRequesterPermissions',
       'startNewRound',
       'timeout',
       'transferAdmin',
@@ -1810,7 +1810,7 @@ describe('FluxAggregator', () => {
       await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
       nextRound = nextRound + 1
 
-      await aggregator.setAuthorization(personas.Carol.address, true, 0)
+      await aggregator.setRequesterPermissions(personas.Carol.address, true, 0)
     })
 
     it('announces a new round via log event', async () => {
@@ -1855,7 +1855,7 @@ describe('FluxAggregator', () => {
     })
   })
 
-  describe('#setAuthorization', () => {
+  describe('#setRequesterPermissions', () => {
     beforeEach(async () => {
       await aggregator
         .connect(personas.Carol)
@@ -1867,13 +1867,13 @@ describe('FluxAggregator', () => {
 
     describe('when called by the owner', () => {
       it('allows the specified address to start new rounds', async () => {
-        await aggregator.setAuthorization(personas.Neil.address, true, 0)
+        await aggregator.setRequesterPermissions(personas.Neil.address, true, 0)
 
         await aggregator.connect(personas.Neil).startNewRound()
       })
 
       it('emits a log announcing the update', async () => {
-        const tx = await aggregator.setAuthorization(
+        const tx = await aggregator.setRequesterPermissions(
           personas.Neil.address,
           true,
           0,
@@ -1881,7 +1881,7 @@ describe('FluxAggregator', () => {
         const receipt = await tx.wait()
         const event = matchers.eventExists(
           receipt,
-          aggregator.interface.events.RequesterAuthorizationSet,
+          aggregator.interface.events.RequesterPermissionsSet,
         )
         const args = h.eventArgs(event)
 
@@ -1891,11 +1891,15 @@ describe('FluxAggregator', () => {
 
       describe('when the address is already authorized', () => {
         beforeEach(async () => {
-          await aggregator.setAuthorization(personas.Neil.address, true, 0)
+          await aggregator.setRequesterPermissions(
+            personas.Neil.address,
+            true,
+            0,
+          )
         })
 
         it('does not emit a log for already authorized accounts', async () => {
-          const tx = await aggregator.setAuthorization(
+          const tx = await aggregator.setRequesterPermissions(
             personas.Neil.address,
             true,
             0,
@@ -1907,11 +1911,19 @@ describe('FluxAggregator', () => {
 
       describe('when permission is removed by the owner', () => {
         beforeEach(async () => {
-          await aggregator.setAuthorization(personas.Neil.address, true, 0)
+          await aggregator.setRequesterPermissions(
+            personas.Neil.address,
+            true,
+            0,
+          )
         })
 
         it('does not allow the specified address to start new rounds', async () => {
-          await aggregator.setAuthorization(personas.Neil.address, false, 0)
+          await aggregator.setRequesterPermissions(
+            personas.Neil.address,
+            false,
+            0,
+          )
 
           await matchers.evmRevert(
             aggregator.connect(personas.Neil).startNewRound(),
@@ -1920,7 +1932,7 @@ describe('FluxAggregator', () => {
         })
 
         it('emits a log announcing the update', async () => {
-          const tx = await aggregator.setAuthorization(
+          const tx = await aggregator.setRequesterPermissions(
             personas.Neil.address,
             false,
             0,
@@ -1928,7 +1940,7 @@ describe('FluxAggregator', () => {
           const receipt = await tx.wait()
           const event = matchers.eventExists(
             receipt,
-            aggregator.interface.events.RequesterAuthorizationSet,
+            aggregator.interface.events.RequesterPermissionsSet,
           )
           const args = h.eventArgs(event)
 
@@ -1937,7 +1949,7 @@ describe('FluxAggregator', () => {
         })
 
         it('does not emit a log for accounts without authorization', async () => {
-          const tx = await aggregator.setAuthorization(
+          const tx = await aggregator.setRequesterPermissions(
             personas.Ned.address,
             false,
             0,
@@ -1953,7 +1965,7 @@ describe('FluxAggregator', () => {
         await matchers.evmRevert(
           aggregator
             .connect(personas.Neil)
-            .setAuthorization(personas.Neil.address, true, 0),
+            .setRequesterPermissions(personas.Neil.address, true, 0),
           'Only callable by owner',
         )
 

--- a/evm-contracts/test/v0.6/FluxAggregator.test.ts
+++ b/evm-contracts/test/v0.6/FluxAggregator.test.ts
@@ -1914,7 +1914,7 @@ describe('FluxAggregator', () => {
         const args = h.eventArgs(event)
 
         assert.equal(args.requester, personas.Neil.address)
-        assert.equal(args.allowed, true)
+        assert.equal(args.authorized, true)
       })
 
       describe('when the address is already authorized', () => {
@@ -1973,7 +1973,7 @@ describe('FluxAggregator', () => {
           const args = h.eventArgs(event)
 
           assert.equal(args.requester, personas.Neil.address)
-          assert.equal(args.allowed, false)
+          assert.equal(args.authorized, false)
         })
 
         it('does not emit a log for accounts without authorization', async () => {

--- a/evm-contracts/test/v0.6/FluxAggregator.test.ts
+++ b/evm-contracts/test/v0.6/FluxAggregator.test.ts
@@ -1810,7 +1810,7 @@ describe('FluxAggregator', () => {
       await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
       nextRound = nextRound + 1
 
-      await aggregator.setAuthorization(personas.Carol.address, true)
+      await aggregator.setAuthorization(personas.Carol.address, true, 0)
     })
 
     it('announces a new round via log event', async () => {
@@ -1867,7 +1867,7 @@ describe('FluxAggregator', () => {
 
     describe('when called by the owner', () => {
       it('allows the specified address to start new rounds', async () => {
-        await aggregator.setAuthorization(personas.Neil.address, true)
+        await aggregator.setAuthorization(personas.Neil.address, true, 0)
 
         await aggregator.connect(personas.Neil).startNewRound()
       })
@@ -1876,6 +1876,7 @@ describe('FluxAggregator', () => {
         const tx = await aggregator.setAuthorization(
           personas.Neil.address,
           true,
+          0,
         )
         const receipt = await tx.wait()
         const event = matchers.eventExists(
@@ -1890,13 +1891,14 @@ describe('FluxAggregator', () => {
 
       describe('when the address is already authorized', () => {
         beforeEach(async () => {
-          await aggregator.setAuthorization(personas.Neil.address, true)
+          await aggregator.setAuthorization(personas.Neil.address, true, 0)
         })
 
         it('does not emit a log for already authorized accounts', async () => {
           const tx = await aggregator.setAuthorization(
             personas.Neil.address,
             true,
+            0,
           )
           const receipt = await tx.wait()
           assert.equal(0, receipt?.logs?.length)
@@ -1905,11 +1907,11 @@ describe('FluxAggregator', () => {
 
       describe('when permission is removed by the owner', () => {
         beforeEach(async () => {
-          await aggregator.setAuthorization(personas.Neil.address, true)
+          await aggregator.setAuthorization(personas.Neil.address, true, 0)
         })
 
         it('does not allow the specified address to start new rounds', async () => {
-          await aggregator.setAuthorization(personas.Neil.address, false)
+          await aggregator.setAuthorization(personas.Neil.address, false, 0)
 
           await matchers.evmRevert(
             aggregator.connect(personas.Neil).startNewRound(),
@@ -1921,6 +1923,7 @@ describe('FluxAggregator', () => {
           const tx = await aggregator.setAuthorization(
             personas.Neil.address,
             false,
+            0,
           )
           const receipt = await tx.wait()
           const event = matchers.eventExists(
@@ -1937,6 +1940,7 @@ describe('FluxAggregator', () => {
           const tx = await aggregator.setAuthorization(
             personas.Ned.address,
             false,
+            0,
           )
           const receipt = await tx.wait()
           assert.equal(0, receipt?.logs?.length)
@@ -1949,7 +1953,7 @@ describe('FluxAggregator', () => {
         await matchers.evmRevert(
           aggregator
             .connect(personas.Neil)
-            .setAuthorization(personas.Neil.address, true),
+            .setAuthorization(personas.Neil.address, true, 0),
           'Only callable by owner',
         )
 

--- a/evm-contracts/test/v0.6/WhitelistedAggregator.test.ts
+++ b/evm-contracts/test/v0.6/WhitelistedAggregator.test.ts
@@ -83,7 +83,7 @@ describe('WhitelistedAggregator', () => {
       'reportingRoundStartedAt',
       'restartDelay',
       'roundState',
-      'setAuthorization',
+      'setRequesterPermissions',
       'startNewRound',
       'timeout',
       'transferAdmin',


### PR DESCRIPTION
Blocked until [this PR](https://github.com/smartcontractkit/chainlink/pull/2705) gets merged, as it builds on top of it.