### PR TITLE
Make feeds.json & nodes.json configurable

### DIFF
--- a/feeds/@types/global.d.ts
+++ b/feeds/@types/global.d.ts
@@ -2,7 +2,7 @@ declare global {
   namespace NodeJS {
     export interface ProcessEnv {
       NODE_ENV: 'development' | 'production' | 'test'
-      REACT_APP_INFURA_KEY: string
+      REACT_APP_INFURA_KEY?: string
       REACT_APP_GA_ID?: string
       REACT_APP_FEEDS_JSON?: string
       REACT_APP_NODES_JSON?: string

--- a/feeds/@types/global.d.ts
+++ b/feeds/@types/global.d.ts
@@ -1,0 +1,11 @@
+declare global {
+  namespace NodeJS {
+    export interface ProcessEnv {
+      NODE_ENV: 'development' | 'production' | 'test'
+      REACT_APP_INFURA_KEY: string
+      REACT_APP_GA_ID?: string
+      REACT_APP_FEEDS_JSON?: string
+      REACT_APP_NODES_JSON?: string
+    }
+  }
+}

--- a/feeds/README.md
+++ b/feeds/README.md
@@ -54,10 +54,10 @@ $ heroku container:login
 Build and push a new image from the root of the monorepo
 
 ```
-$ heroku container:push --recursive --arg REACT_APP_INFURA_KEY=abc123,REACT_APP_GA_ID=abc123 -a the-app-name
+$ heroku container:push --recursive --arg REACT_APP_INFURA_KEY=abc123,REACT_APP_GA_ID=abc123 REACT_APP_FEEDS_JSON=https://feeds.chain.link/feeds.json REACT_APP_NODES_JSON=https://feeds.chain.link/nodes.json -a the-app-name
 
 # If the config vars are stored in Heroku, you can capture the output in a subshell
-$ heroku container:push --recursive --arg REACT_APP_INFURA_KEY=$(heroku config:get REACT_APP_INFURA_KEY -a the-app-name),REACT_APP_GA_ID=$(heroku config:get REACT_APP_GA_ID -a the-app-name) -a the-app-name
+$ heroku container:push --recursive --arg REACT_APP_INFURA_KEY=$(heroku config:get REACT_APP_INFURA_KEY -a the-app-name),REACT_APP_GA_ID=$(heroku config:get REACT_APP_GA_ID -a the-app-name),REACT_APP_FEEDS_JSON=$(heroku config:get REACT_APP_FEEDS_JSON -a the-app-name,REACT_APP_NODES_JSON=$(heroku config:get REACT_APP_NODES_JSON -a the-app-name) -a the-app-name
 ```
 
 Deploy the newly built image by releasing the container from the root of the monorepo
@@ -98,3 +98,12 @@ Color Codes
 - Red: A check has failed (hover for tooltip that includes failed checks)
 - Yellow: Unknown status (when the price health check is not configured)
 - Green: Ok
+
+## Available env vars
+
+```
+REACT_APP_INFURA_KEY    - infura key
+REACT_APP_GA_ID         - google analytics key
+REACT_APP_FEEDS_JSON    - URL to load reference contract feeds
+REACT_APP_NODES_JSON    - URL to load oracle nodes
+```

--- a/feeds/README.md
+++ b/feeds/README.md
@@ -86,6 +86,22 @@ On the landing page you can enable live health checks with:
 https://feeds.chain.link?health=true
 ```
 
+### Override feeds & nodes JSON endpoints
+
+Override the urls with a URI encoded query param
+
+```
+https://feeds.chain.link?feeds-json=https%3A%2F%2Fweiwatchers.com%2Ffeeds.json
+https://feeds.chain.link?nodes-json=https%3A%2F%2Fweiwatchers.com%2Fnodes.json
+```
+
+You can use the browser console to encode your URI:
+
+```javascript
+> encodeURIComponent('https://weiwatchers.com/feeds.json')
+"https%3A%2F%2Fweiwatchers.com%2Ffeeds.json"
+```
+
 ![reference-contract-health](./docs/reference-contract-health.png)
 
 #### Checks

--- a/feeds/src/config.test.ts
+++ b/feeds/src/config.test.ts
@@ -2,61 +2,39 @@ import { partialAsFull } from '@chainlink/ts-helpers'
 import { Config } from './config'
 
 describe('config', () => {
-  it('returns infura key from the process env', () => {
-    const processEnv = {
-      NODE_ENV: 'test' as const,
-      PUBLIC_URL: 'https://test.dev',
-      REACT_APP_INFURA_KEY: 'infuraKey',
-    }
+  const originalEnv = { ...process.env }
+  beforeEach(() => {
+    process.env = originalEnv
+  })
 
-    expect(Config.infuraKey(processEnv)).toEqual('infuraKey')
+  it('returns infura key from the process env', () => {
+    process.env.REACT_APP_INFURA_KEY = 'infuraKey'
+    expect(Config.infuraKey()).toEqual('infuraKey')
   })
 
   it('returns the google analytics id from the process env', () => {
-    const processEnv = {
-      NODE_ENV: 'test' as const,
-      PUBLIC_URL: 'https://test.dev',
-      REACT_APP_GA_ID: 'ga-id',
-    }
-
-    expect(Config.gaId(processEnv)).toEqual('ga-id')
+    process.env.REACT_APP_GA_ID = 'ga-id'
+    expect(Config.gaId()).toEqual('ga-id')
   })
 
   describe('feeds json', () => {
     it('returns feeds json from the process env', () => {
-      const processEnv = {
-        NODE_ENV: 'test' as const,
-        PUBLIC_URL: 'https://test.dev',
-        REACT_APP_FEEDS_JSON: 'https://test.dev/feeds.json',
-      }
-
-      expect(Config.feedsJson(processEnv)).toEqual(
-        'https://test.dev/feeds.json',
-      )
+      process.env.REACT_APP_FEEDS_JSON = 'https://test.dev/feeds.json'
+      expect(Config.feedsJson()).toEqual('https://test.dev/feeds.json')
     })
 
-    it('returns a default feeds json when not provided', () => {
-      const processEnv = {
-        NODE_ENV: 'test' as const,
-        PUBLIC_URL: 'https://test.dev',
-      }
-
-      expect(Config.feedsJson(processEnv)).toEqual(
-        'https://weiwatchers.com/feeds.json',
-      )
+    it('returns a default feeds json when undefined', () => {
+      process.env.REACT_APP_FEEDS_JSON = undefined
+      expect(Config.feedsJson()).toEqual('https://weiwatchers.com/feeds.json')
     })
 
     it('can override feeds json with a query parameter', () => {
       const location = partialAsFull<Location>({
         search: '?feeds-json=https%3A%2F%2Foverride.dev%2Ffeeds.json',
       })
-      const processEnv = {
-        NODE_ENV: 'test' as const,
-        PUBLIC_URL: 'https://test.dev',
-        REACT_APP_FEEDS_JSON: 'https://test.dev/feeds.json',
-      }
+      process.env.REACT_APP_FEEDS_JSON = 'https://test.dev/feeds.json'
 
-      expect(Config.feedsJson(processEnv, location)).toEqual(
+      expect(Config.feedsJson(process.env, location)).toEqual(
         'https://override.dev/feeds.json',
       )
     })
@@ -64,39 +42,22 @@ describe('config', () => {
 
   describe('nodes json', () => {
     it('returns nodes json from the process env', () => {
-      const processEnv = {
-        NODE_ENV: 'test' as const,
-        PUBLIC_URL: 'https://test.dev',
-        REACT_APP_NODES_JSON: 'https://test.dev/nodes.json',
-      }
-
-      expect(Config.nodesJson(processEnv)).toEqual(
-        'https://test.dev/nodes.json',
-      )
+      process.env.REACT_APP_NODES_JSON = 'https://test.dev/nodes.json'
+      expect(Config.nodesJson()).toEqual('https://test.dev/nodes.json')
     })
 
-    it('returns a default nodes json when not provided', () => {
-      const processEnv = {
-        NODE_ENV: 'test' as const,
-        PUBLIC_URL: 'https://test.dev',
-      }
-
-      expect(Config.nodesJson(processEnv)).toEqual(
-        'https://weiwatchers.com/nodes.json',
-      )
+    it('returns a default nodes json when undefined', () => {
+      process.env.REACT_APP_NODES_JSON = undefined
+      expect(Config.nodesJson()).toEqual('https://weiwatchers.com/nodes.json')
     })
 
     it('can override nodes json with a query parameter', () => {
       const location = partialAsFull<Location>({
         search: '?nodes-json=https%3A%2F%2Foverride.dev%2Fnodes.json',
       })
-      const processEnv = {
-        NODE_ENV: 'test' as const,
-        PUBLIC_URL: 'https://test.dev',
-        REACT_APP_FEEDS_JSON: 'https://test.dev/nodes.json',
-      }
+      process.env.REACT_APP_FEEDS_JSON = 'https://test.dev/nodes.json'
 
-      expect(Config.nodesJson(processEnv, location)).toEqual(
+      expect(Config.nodesJson(process.env, location)).toEqual(
         'https://override.dev/nodes.json',
       )
     })

--- a/feeds/src/config.test.ts
+++ b/feeds/src/config.test.ts
@@ -25,7 +25,7 @@ describe('config', () => {
 
     it('returns a default feeds json when undefined', () => {
       process.env.REACT_APP_FEEDS_JSON = undefined
-      expect(Config.feedsJson()).toEqual('https://weiwatchers.com/feeds.json')
+      expect(Config.feedsJson()).toEqual('/feeds.json')
     })
 
     it('can override feeds json with a query parameter', () => {
@@ -48,7 +48,7 @@ describe('config', () => {
 
     it('returns a default nodes json when undefined', () => {
       process.env.REACT_APP_NODES_JSON = undefined
-      expect(Config.nodesJson()).toEqual('https://weiwatchers.com/nodes.json')
+      expect(Config.nodesJson()).toEqual('/nodes.json')
     })
 
     it('can override nodes json with a query parameter', () => {

--- a/feeds/src/config.test.ts
+++ b/feeds/src/config.test.ts
@@ -1,4 +1,4 @@
-// import { partialAsFull } from '@chainlink/ts-helpers'
+import { partialAsFull } from '@chainlink/ts-helpers'
 import { Config } from './config'
 
 describe('config', () => {
@@ -22,45 +22,83 @@ describe('config', () => {
     expect(Config.gaId(processEnv)).toEqual('ga-id')
   })
 
-  it('returns feeds json from the process env', () => {
-    const processEnv = {
-      NODE_ENV: 'test' as const,
-      PUBLIC_URL: 'https://test.dev',
-      REACT_APP_FEEDS_JSON: 'https://test.dev/feeds.json',
-    }
+  describe('feeds json', () => {
+    it('returns feeds json from the process env', () => {
+      const processEnv = {
+        NODE_ENV: 'test' as const,
+        PUBLIC_URL: 'https://test.dev',
+        REACT_APP_FEEDS_JSON: 'https://test.dev/feeds.json',
+      }
 
-    expect(Config.feedsJson(processEnv)).toEqual('https://test.dev/feeds.json')
+      expect(Config.feedsJson(processEnv)).toEqual(
+        'https://test.dev/feeds.json',
+      )
+    })
+
+    it('returns a default feeds json when not provided', () => {
+      const processEnv = {
+        NODE_ENV: 'test' as const,
+        PUBLIC_URL: 'https://test.dev',
+      }
+
+      expect(Config.feedsJson(processEnv)).toEqual(
+        'https://weiwatchers.com/feeds.json',
+      )
+    })
+
+    it('can override feeds json with a query parameter', () => {
+      const location = partialAsFull<Location>({
+        search: '?feeds-json=https%3A%2F%2Foverride.dev%2Ffeeds.json',
+      })
+      const processEnv = {
+        NODE_ENV: 'test' as const,
+        PUBLIC_URL: 'https://test.dev',
+        REACT_APP_FEEDS_JSON: 'https://test.dev/feeds.json',
+      }
+
+      expect(Config.feedsJson(processEnv, location)).toEqual(
+        'https://override.dev/feeds.json',
+      )
+    })
   })
 
-  it('returns a default feeds json when not provided', () => {
-    const processEnv = {
-      NODE_ENV: 'test' as const,
-      PUBLIC_URL: 'https://test.dev',
-    }
+  describe('nodes json', () => {
+    it('returns nodes json from the process env', () => {
+      const processEnv = {
+        NODE_ENV: 'test' as const,
+        PUBLIC_URL: 'https://test.dev',
+        REACT_APP_NODES_JSON: 'https://test.dev/nodes.json',
+      }
 
-    expect(Config.feedsJson(processEnv)).toEqual(
-      'https://weiwatchers.com/feeds.json',
-    )
-  })
+      expect(Config.nodesJson(processEnv)).toEqual(
+        'https://test.dev/nodes.json',
+      )
+    })
 
-  it('returns nodes json from the process env', () => {
-    const processEnv = {
-      NODE_ENV: 'test' as const,
-      PUBLIC_URL: 'https://test.dev',
-      REACT_APP_NODES_JSON: 'https://test.dev/nodes.json',
-    }
+    it('returns a default nodes json when not provided', () => {
+      const processEnv = {
+        NODE_ENV: 'test' as const,
+        PUBLIC_URL: 'https://test.dev',
+      }
 
-    expect(Config.nodesJson(processEnv)).toEqual('https://test.dev/nodes.json')
-  })
+      expect(Config.nodesJson(processEnv)).toEqual(
+        'https://weiwatchers.com/nodes.json',
+      )
+    })
 
-  it('returns a default nodes json when not provided', () => {
-    const processEnv = {
-      NODE_ENV: 'test' as const,
-      PUBLIC_URL: 'https://test.dev',
-    }
+    it('can override nodes json with a query parameter', () => {
+      const location = partialAsFull<Location>({
+        search: '?nodes-json=https%3A%2F%2Foverride.dev%2Fnodes.json',
+      })
+      const processEnv = {
+        NODE_ENV: 'test' as const,
+        PUBLIC_URL: 'https://test.dev',
+        REACT_APP_FEEDS_JSON: 'https://test.dev/nodes.json',
+      }
 
-    expect(Config.nodesJson(processEnv)).toEqual(
-      'https://weiwatchers.com/nodes.json',
-    )
+      expect(Config.nodesJson(processEnv, location)).toEqual(
+        'https://override.dev/nodes.json',
+      )
+    })
   })
 })

--- a/feeds/src/config.test.ts
+++ b/feeds/src/config.test.ts
@@ -1,0 +1,66 @@
+// import { partialAsFull } from '@chainlink/ts-helpers'
+import { Config } from './config'
+
+describe('config', () => {
+  it('returns infura key from the process env', () => {
+    const processEnv = {
+      NODE_ENV: 'test' as const,
+      PUBLIC_URL: 'https://test.dev',
+      REACT_APP_INFURA_KEY: 'infuraKey',
+    }
+
+    expect(Config.infuraKey(processEnv)).toEqual('infuraKey')
+  })
+
+  it('returns the google analytics id from the process env', () => {
+    const processEnv = {
+      NODE_ENV: 'test' as const,
+      PUBLIC_URL: 'https://test.dev',
+      REACT_APP_GA_ID: 'ga-id',
+    }
+
+    expect(Config.gaId(processEnv)).toEqual('ga-id')
+  })
+
+  it('returns feeds json from the process env', () => {
+    const processEnv = {
+      NODE_ENV: 'test' as const,
+      PUBLIC_URL: 'https://test.dev',
+      REACT_APP_FEEDS_JSON: 'https://test.dev/feeds.json',
+    }
+
+    expect(Config.feedsJson(processEnv)).toEqual('https://test.dev/feeds.json')
+  })
+
+  it('returns a default feeds json when not provided', () => {
+    const processEnv = {
+      NODE_ENV: 'test' as const,
+      PUBLIC_URL: 'https://test.dev',
+    }
+
+    expect(Config.feedsJson(processEnv)).toEqual(
+      'https://weiwatchers.com/feeds.json',
+    )
+  })
+
+  it('returns nodes json from the process env', () => {
+    const processEnv = {
+      NODE_ENV: 'test' as const,
+      PUBLIC_URL: 'https://test.dev',
+      REACT_APP_NODES_JSON: 'https://test.dev/nodes.json',
+    }
+
+    expect(Config.nodesJson(processEnv)).toEqual('https://test.dev/nodes.json')
+  })
+
+  it('returns a default nodes json when not provided', () => {
+    const processEnv = {
+      NODE_ENV: 'test' as const,
+      PUBLIC_URL: 'https://test.dev',
+    }
+
+    expect(Config.nodesJson(processEnv)).toEqual(
+      'https://weiwatchers.com/nodes.json',
+    )
+  })
+})

--- a/feeds/src/config.ts
+++ b/feeds/src/config.ts
@@ -48,12 +48,12 @@ class UrlConfig {
 }
 
 export class Config {
-  static infuraKey(env = process.env): string {
-    return env.REACT_APP_INFURA_KEY ?? ''
+  static infuraKey(env = process.env): string | undefined {
+    return env.REACT_APP_INFURA_KEY
   }
 
-  static gaId(env = process.env): string {
-    return env.REACT_APP_GA_ID ?? ''
+  static gaId(env = process.env): string | undefined {
+    return env.REACT_APP_GA_ID
   }
 
   static feedsJson(env = process.env, location = window.location): string {

--- a/feeds/src/config.ts
+++ b/feeds/src/config.ts
@@ -25,14 +25,32 @@ export interface OracleNode {
   networkId: number
 }
 
-export interface Config {
-  feedsJson: string
-  nodesJson: string
-}
+export class Config {
+  static infuraKey(env = process.env): string {
+    if (env.REACT_APP_INFURA_KEY === undefined) {
+      return ''
+    }
+    return env.REACT_APP_INFURA_KEY
+  }
 
-export const DefaultConfig: Config = {
-  feedsJson:
-    process.env.REACT_APP_FEEDS_JSON ?? 'https://feeds.chain.link/feeds.json',
-  nodesJson:
-    process.env.REACT_APP_NODES_JSON ?? 'https://feeds.chain.link/nodes.json',
+  static gaId(env = process.env): string {
+    if (env.REACT_APP_GA_ID === undefined) {
+      return ''
+    }
+    return env.REACT_APP_GA_ID
+  }
+
+  static feedsJson(env = process.env): string {
+    if (env.REACT_APP_FEEDS_JSON === undefined) {
+      return 'https://weiwatchers.com/feeds.json'
+    }
+    return env.REACT_APP_FEEDS_JSON
+  }
+
+  static nodesJson(env = process.env): string {
+    if (env.REACT_APP_NODES_JSON === undefined) {
+      return 'https://weiwatchers.com/nodes.json'
+    }
+    return env.REACT_APP_NODES_JSON
+  }
 }

--- a/feeds/src/config.ts
+++ b/feeds/src/config.ts
@@ -68,7 +68,7 @@ export class Config {
       return urlFeedsJson
     }
     if (env.REACT_APP_FEEDS_JSON === undefined) {
-      return 'https://weiwatchers.com/feeds.json'
+      return '/feeds.json'
     }
     return env.REACT_APP_FEEDS_JSON
   }
@@ -79,7 +79,7 @@ export class Config {
       return urlNodesJson
     }
     if (env.REACT_APP_NODES_JSON === undefined) {
-      return 'https://weiwatchers.com/nodes.json'
+      return '/nodes.json'
     }
     return env.REACT_APP_NODES_JSON
   }

--- a/feeds/src/config.ts
+++ b/feeds/src/config.ts
@@ -25,6 +25,28 @@ export interface OracleNode {
   networkId: number
 }
 
+class UrlConfig {
+  static feedsJson(location: Location): string | undefined {
+    const query = new URLSearchParams(location.search)
+    const feedsJson = query.get('feeds-json')
+
+    if (feedsJson) {
+      return decodeURIComponent(feedsJson)
+    }
+    return undefined
+  }
+
+  static nodesJson(location: Location): string | undefined {
+    const query = new URLSearchParams(location.search)
+    const nodesJson = query.get('nodes-json')
+
+    if (nodesJson) {
+      return decodeURIComponent(nodesJson)
+    }
+    return undefined
+  }
+}
+
 export class Config {
   static infuraKey(env = process.env): string {
     if (env.REACT_APP_INFURA_KEY === undefined) {
@@ -40,14 +62,22 @@ export class Config {
     return env.REACT_APP_GA_ID
   }
 
-  static feedsJson(env = process.env): string {
+  static feedsJson(env = process.env, location = window.location): string {
+    const urlFeedsJson = UrlConfig.feedsJson(location)
+    if (urlFeedsJson) {
+      return urlFeedsJson
+    }
     if (env.REACT_APP_FEEDS_JSON === undefined) {
       return 'https://weiwatchers.com/feeds.json'
     }
     return env.REACT_APP_FEEDS_JSON
   }
 
-  static nodesJson(env = process.env): string {
+  static nodesJson(env = process.env, location = window.location): string {
+    const urlNodesJson = UrlConfig.nodesJson(location)
+    if (urlNodesJson) {
+      return urlNodesJson
+    }
     if (env.REACT_APP_NODES_JSON === undefined) {
       return 'https://weiwatchers.com/nodes.json'
     }

--- a/feeds/src/config.ts
+++ b/feeds/src/config.ts
@@ -49,17 +49,11 @@ class UrlConfig {
 
 export class Config {
   static infuraKey(env = process.env): string {
-    if (env.REACT_APP_INFURA_KEY === undefined) {
-      return ''
-    }
-    return env.REACT_APP_INFURA_KEY
+    return env.REACT_APP_INFURA_KEY ?? ''
   }
 
   static gaId(env = process.env): string {
-    if (env.REACT_APP_GA_ID === undefined) {
-      return ''
-    }
-    return env.REACT_APP_GA_ID
+    return env.REACT_APP_GA_ID ?? ''
   }
 
   static feedsJson(env = process.env, location = window.location): string {
@@ -67,10 +61,7 @@ export class Config {
     if (urlFeedsJson) {
       return urlFeedsJson
     }
-    if (env.REACT_APP_FEEDS_JSON === undefined) {
-      return '/feeds.json'
-    }
-    return env.REACT_APP_FEEDS_JSON
+    return env.REACT_APP_FEEDS_JSON ?? '/feeds.json'
   }
 
   static nodesJson(env = process.env, location = window.location): string {
@@ -78,9 +69,6 @@ export class Config {
     if (urlNodesJson) {
       return urlNodesJson
     }
-    if (env.REACT_APP_NODES_JSON === undefined) {
-      return '/nodes.json'
-    }
-    return env.REACT_APP_NODES_JSON
+    return env.REACT_APP_NODES_JSON ?? '/nodes.json'
   }
 }

--- a/feeds/src/config.ts
+++ b/feeds/src/config.ts
@@ -24,3 +24,15 @@ export interface OracleNode {
   name: string
   networkId: number
 }
+
+export interface Config {
+  feedsJson: string
+  nodesJson: string
+}
+
+export const DefaultConfig: Config = {
+  feedsJson:
+    process.env.REACT_APP_FEEDS_JSON ?? 'https://feeds.chain.link/feeds.json',
+  nodesJson:
+    process.env.REACT_APP_NODES_JSON ?? 'https://feeds.chain.link/nodes.json',
+}

--- a/feeds/src/contracts/utils.ts
+++ b/feeds/src/contracts/utils.ts
@@ -1,6 +1,7 @@
 import { ethers } from 'ethers'
 import { FunctionFragment } from 'ethers/utils'
 import { JsonRpcProvider, Log } from 'ethers/providers'
+import { Config } from '../config'
 import { networkName, Networks } from '../utils'
 
 /**
@@ -18,8 +19,6 @@ export function createContract(
   return new ethers.Contract(address, contractInterface, provider)
 }
 
-const REACT_APP_INFURA_KEY = process.env.REACT_APP_INFURA_KEY
-
 /**
  * Initialize the infura provider for the given network
  *
@@ -29,7 +28,7 @@ export function createInfuraProvider(
   networkId: Networks = Networks.MAINNET,
 ): JsonRpcProvider {
   const provider = new ethers.providers.JsonRpcProvider(
-    `https://${networkName(networkId)}.infura.io/v3/${REACT_APP_INFURA_KEY}`,
+    `https://${networkName(networkId)}.infura.io/v3/${Config.infuraKey()}`,
   )
   provider.pollingInterval = 8000
 

--- a/feeds/src/index.tsx
+++ b/feeds/src/index.tsx
@@ -3,12 +3,13 @@ import ReactDOM from 'react-dom'
 import { Provider as ReduxProvider } from 'react-redux'
 import * as serviceWorker from './serviceWorker'
 import App from './App'
+import { Config } from './config'
 import createStore from './state/createStore'
 import { PersistGate } from 'redux-persist/integration/react'
 import ReactGA from 'react-ga'
 import './theme.css'
 
-ReactGA.initialize(process.env['REACT_APP_GA_ID'] || '')
+ReactGA.initialize(Config.gaId())
 
 const { store, persistor } = createStore()
 

--- a/feeds/src/index.tsx
+++ b/feeds/src/index.tsx
@@ -9,7 +9,7 @@ import { PersistGate } from 'redux-persist/integration/react'
 import ReactGA from 'react-ga'
 import './theme.css'
 
-ReactGA.initialize(Config.gaId())
+ReactGA.initialize(Config.gaId() ?? '')
 
 const { store, persistor } = createStore()
 

--- a/feeds/src/state/ducks/aggregator/operations.ts
+++ b/feeds/src/state/ducks/aggregator/operations.ts
@@ -3,7 +3,7 @@ import { Dispatch } from 'redux'
 import _ from 'lodash'
 import moment from 'moment'
 import { ethers } from 'ethers'
-import { FeedConfig, OracleNode } from 'config'
+import { FeedConfig, OracleNode, DefaultConfig } from 'config'
 import { Networks } from '../../../utils'
 import * as actions from './actions'
 import AggregatorAbi from '../../../contracts/AggregatorAbi.json'
@@ -24,7 +24,7 @@ export function fetchFeedByPair(pairPath: string, networkPath = 'mainnet') {
     dispatch(actions.fetchFeedByPairBegin())
 
     jsonapi
-      .fetchWithTimeout('/feeds.json', {})
+      .fetchWithTimeout(DefaultConfig.feedsJson, {})
       .then((r: Response) => r.json())
       .then((json: FeedConfig[]) => {
         const networkId = NETWORK_PATHS[networkPath] ?? Networks.MAINNET
@@ -49,7 +49,7 @@ export function fetchFeedByAddress(contractAddress: string) {
     dispatch(actions.fetchFeedByAddressBegin())
 
     jsonapi
-      .fetchWithTimeout('/feeds.json', {})
+      .fetchWithTimeout(DefaultConfig.feedsJson, {})
       .then((r: Response) => r.json())
       .then((json: FeedConfig[]) => {
         const feed = json.find(f => f.contractAddress === contractAddress)
@@ -74,7 +74,7 @@ export function fetchOracleNodes() {
     dispatch(actions.fetchOracleNodesBegin())
 
     jsonapi
-      .fetchWithTimeout('/nodes.json', {})
+      .fetchWithTimeout(DefaultConfig.nodesJson, {})
       .then((r: Response) => r.json())
       .then((json: OracleNode[]) => {
         dispatch(actions.fetchOracleNodesSuccess(json))

--- a/feeds/src/state/ducks/aggregator/operations.ts
+++ b/feeds/src/state/ducks/aggregator/operations.ts
@@ -3,7 +3,7 @@ import { Dispatch } from 'redux'
 import _ from 'lodash'
 import moment from 'moment'
 import { ethers } from 'ethers'
-import { FeedConfig, OracleNode, DefaultConfig } from 'config'
+import { FeedConfig, OracleNode, Config } from '../../../config'
 import { Networks } from '../../../utils'
 import * as actions from './actions'
 import AggregatorAbi from '../../../contracts/AggregatorAbi.json'
@@ -24,7 +24,7 @@ export function fetchFeedByPair(pairPath: string, networkPath = 'mainnet') {
     dispatch(actions.fetchFeedByPairBegin())
 
     jsonapi
-      .fetchWithTimeout(DefaultConfig.feedsJson, {})
+      .fetchWithTimeout(Config.feedsJson(), {})
       .then((r: Response) => r.json())
       .then((json: FeedConfig[]) => {
         const networkId = NETWORK_PATHS[networkPath] ?? Networks.MAINNET
@@ -49,7 +49,7 @@ export function fetchFeedByAddress(contractAddress: string) {
     dispatch(actions.fetchFeedByAddressBegin())
 
     jsonapi
-      .fetchWithTimeout(DefaultConfig.feedsJson, {})
+      .fetchWithTimeout(Config.feedsJson(), {})
       .then((r: Response) => r.json())
       .then((json: FeedConfig[]) => {
         const feed = json.find(f => f.contractAddress === contractAddress)
@@ -74,7 +74,7 @@ export function fetchOracleNodes() {
     dispatch(actions.fetchOracleNodesBegin())
 
     jsonapi
-      .fetchWithTimeout(DefaultConfig.nodesJson, {})
+      .fetchWithTimeout(Config.nodesJson(), {})
       .then((r: Response) => r.json())
       .then((json: OracleNode[]) => {
         dispatch(actions.fetchOracleNodesSuccess(json))

--- a/feeds/src/state/ducks/listing/operations.ts
+++ b/feeds/src/state/ducks/listing/operations.ts
@@ -2,7 +2,7 @@ import * as jsonapi from '@chainlink/json-api-client'
 import { Dispatch } from 'redux'
 import { FunctionFragment } from 'ethers/utils'
 import { JsonRpcProvider } from 'ethers/providers'
-import { FeedConfig, DefaultConfig } from 'config'
+import { FeedConfig, Config } from '../../../config'
 import * as actions from './actions'
 import {
   formatAnswer,
@@ -17,7 +17,7 @@ export function fetchFeeds() {
   return async (dispatch: Dispatch) => {
     dispatch(actions.fetchFeedsBegin())
     jsonapi
-      .fetchWithTimeout(DefaultConfig.feedsJson, {})
+      .fetchWithTimeout(Config.feedsJson(), {})
       .then((r: Response) => r.json())
       .then((json: FeedConfig[]) => {
         dispatch(actions.fetchFeedsSuccess(json))

--- a/feeds/src/state/ducks/listing/operations.ts
+++ b/feeds/src/state/ducks/listing/operations.ts
@@ -2,7 +2,7 @@ import * as jsonapi from '@chainlink/json-api-client'
 import { Dispatch } from 'redux'
 import { FunctionFragment } from 'ethers/utils'
 import { JsonRpcProvider } from 'ethers/providers'
-import { FeedConfig } from 'config'
+import { FeedConfig, DefaultConfig } from 'config'
 import * as actions from './actions'
 import {
   formatAnswer,
@@ -17,7 +17,7 @@ export function fetchFeeds() {
   return async (dispatch: Dispatch) => {
     dispatch(actions.fetchFeedsBegin())
     jsonapi
-      .fetchWithTimeout('/feeds.json', {})
+      .fetchWithTimeout(DefaultConfig.feedsJson, {})
       .then((r: Response) => r.json())
       .then((json: FeedConfig[]) => {
         dispatch(actions.fetchFeedsSuccess(json))


### PR DESCRIPTION
Allows `feeds.json` & `nodes.json` to be served from another source e.g. https://github.com/smartcontractkit/feeds_data.

- https://weiwatchers.com/feeds.json
- https://weiwatchers.com/nodes.json

Can be configured via environment variables & overridden with query params