### PR TITLE
Add guards on fluxmonitor threshold of 0.

### DIFF
--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -372,6 +372,10 @@ func NewPollingDeviationChecker(
 	pollDelay models.Duration,
 	readyForLogs func(),
 ) (*PollingDeviationChecker, error) {
+	threshold := float64(initr.InitiatorParams.Threshold)
+	if threshold == 0 {
+		return nil, errors.WithStack(fmt.Errorf("threshold of 0 is not allowed"))
+	}
 	return &PollingDeviationChecker{
 		readyForLogs:       readyForLogs,
 		store:              store,
@@ -858,6 +862,11 @@ func (p *PollingDeviationChecker) loggerFieldsForAnswerUpdated(log *contracts.Lo
 
 // OutsideDeviation checks whether the next price is outside the threshold.
 func OutsideDeviation(curAnswer, nextAnswer decimal.Decimal, threshold float64) bool {
+	if threshold == 0 {
+		// This is prevented by the fluxmonitor initiator's validation logic, and by
+		// NewPollingDeviationChecker
+		panic("deviation threshold of 0 is not allowed")
+	}
 	loggerFields := []interface{}{
 		"threshold", threshold,
 		"currentAnswer", curAnswer,

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -155,43 +155,20 @@ func TestPollingDeviationChecker_PollIfEligible(t *testing.T) {
 	}{
 		{"eligible, connected, funded, threshold > 0, answers deviate", true, true, true, 0.1, 1, 100, true, true},
 		{"eligible, connected, funded, threshold > 0, answers do not deviate", true, true, true, 0.1, 100, 100, true, false},
-		{"eligible, connected, funded, threshold == 0, answers deviate", true, true, true, 0, 1, 100, true, true},
-		{"eligible, connected, funded, threshold == 0, answers do not deviate", true, true, true, 0, 1, 100, true, true},
-
 		{"eligible, disconnected, funded, threshold > 0, answers deviate", true, false, true, 0.1, 1, 100, false, false},
 		{"eligible, disconnected, funded, threshold > 0, answers do not deviate", true, false, true, 0.1, 100, 100, false, false},
-		{"eligible, disconnected, funded, threshold == 0, answers deviate", true, false, true, 0, 1, 100, false, false},
-		{"eligible, disconnected, funded, threshold == 0, answers do not deviate", true, false, true, 0, 1, 100, false, false},
-
 		{"ineligible, connected, funded, threshold > 0, answers deviate", false, true, true, 0.1, 1, 100, false, false},
 		{"ineligible, connected, funded, threshold > 0, answers do not deviate", false, true, true, 0.1, 100, 100, false, false},
-		{"ineligible, connected, funded, threshold == 0, answers deviate", false, true, true, 0, 1, 100, false, false},
-		{"ineligible, connected, funded, threshold == 0, answers do not deviate", false, true, true, 0, 1, 100, false, false},
-
 		{"ineligible, disconnected, funded, threshold > 0, answers deviate", false, false, true, 0.1, 1, 100, false, false},
 		{"ineligible, disconnected, funded, threshold > 0, answers do not deviate", false, false, true, 0.1, 100, 100, false, false},
-		{"ineligible, disconnected, funded, threshold == 0, answers deviate", false, false, true, 0, 1, 100, false, false},
-		{"ineligible, disconnected, funded, threshold == 0, answers do not deviate", false, false, true, 0, 1, 100, false, false},
-
 		{"eligible, connected, underfunded, threshold > 0, answers deviate", true, true, false, 0.1, 1, 100, false, false},
 		{"eligible, connected, underfunded, threshold > 0, answers do not deviate", true, true, false, 0.1, 100, 100, false, false},
-		{"eligible, connected, underfunded, threshold == 0, answers deviate", true, true, false, 0, 1, 100, false, false},
-		{"eligible, connected, underfunded, threshold == 0, answers do not deviate", true, true, false, 0, 1, 100, false, false},
-
 		{"eligible, disconnected, underfunded, threshold > 0, answers deviate", true, false, false, 0.1, 1, 100, false, false},
 		{"eligible, disconnected, underfunded, threshold > 0, answers do not deviate", true, false, false, 0.1, 100, 100, false, false},
-		{"eligible, disconnected, underfunded, threshold == 0, answers deviate", true, false, false, 0, 1, 100, false, false},
-		{"eligible, disconnected, underfunded, threshold == 0, answers do not deviate", true, false, false, 0, 1, 100, false, false},
-
 		{"ineligible, connected, underfunded, threshold > 0, answers deviate", false, true, false, 0.1, 1, 100, false, false},
 		{"ineligible, connected, underfunded, threshold > 0, answers do not deviate", false, true, false, 0.1, 100, 100, false, false},
-		{"ineligible, connected, underfunded, threshold == 0, answers deviate", false, true, false, 0, 1, 100, false, false},
-		{"ineligible, connected, underfunded, threshold == 0, answers do not deviate", false, true, false, 0, 1, 100, false, false},
-
 		{"ineligible, disconnected, underfunded, threshold > 0, answers deviate", false, false, false, 0.1, 1, 100, false, false},
 		{"ineligible, disconnected, underfunded, threshold > 0, answers do not deviate", false, false, false, 0.1, 100, 100, false, false},
-		{"ineligible, disconnected, underfunded, threshold == 0, answers deviate", false, false, false, 0, 1, 100, false, false},
-		{"ineligible, disconnected, underfunded, threshold == 0, answers do not deviate", false, false, false, 0, 1, 100, false, false},
 	}
 
 	store, cleanup := cltest.NewStore(t)

--- a/core/services/validators.go
+++ b/core/services/validators.go
@@ -118,6 +118,15 @@ func ValidateInitiator(i models.Initiator, j models.JobSpec, store *store.Store)
 	}
 }
 
+// DeviationThresholdValid is true iff threshold is an acceptable deviation
+// threshold for a fluxmonitor initiator
+func CheckDeviationThreshold(threshold float32) error {
+	if threshold <= 0 {
+		return fmt.Errorf("deviation threshold must be positive, got %f", threshold)
+	}
+	return nil
+}
+
 func validateFluxMonitor(i models.Initiator, j models.JobSpec, store *store.Store) error {
 	fe := models.NewJSONAPIErrors()
 	minimumPollingInterval := models.Duration(store.Config.DefaultHTTPTimeout())
@@ -131,8 +140,8 @@ func validateFluxMonitor(i models.Initiator, j models.JobSpec, store *store.Stor
 	if !i.IdleThreshold.IsInstant() && i.IdleThreshold.Shorter(i.PollingInterval) {
 		fe.Add("idleThreshold must be equal or greater than the pollingInterval")
 	}
-	if i.Threshold <= 0 {
-		fe.Add("bad threshold")
+	if err := CheckDeviationThreshold(i.Threshold); err != nil {
+		fe.Add("bad threshold: " + err.Error())
 	}
 	if i.RequestData.String() == "" {
 		fe.Add("no requestdata")


### PR DESCRIPTION
A concern was raised that `OutsideDeviation()` doesn't correctly handle
`curAnswer == 0 && nextAnswer == 0 && threshold == 0`. This adds a local guard
in in OutsideDeviation which makes it clear that `threshold == 0` is forbidden
during job initialization by validation of the fluxmonitor parameters.