### PR TITLE
prevent owner from withdrawing funds while oracles are reporting

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -1185,3 +1185,23 @@ func MustResultString(t *testing.T, input models.RunResult) string {
 	require.Equal(t, gjson.String, result.Type, fmt.Sprintf("result type %s is not string", result.Type))
 	return result.String()
 }
+
+func MakeRoundStateReturnData(
+	roundID uint64,
+	eligible bool,
+	answer, timesOutAt, availableFunds, paymentAmount, oracleCount uint64,
+) string {
+	var data []byte
+	data = append(data, utils.EVMWordUint64(roundID)...)
+	if eligible {
+		data = append(data, utils.EVMWordUint64(1)...)
+	} else {
+		data = append(data, utils.EVMWordUint64(0)...)
+	}
+	data = append(data, utils.EVMWordUint64(answer)...)
+	data = append(data, utils.EVMWordUint64(timesOutAt)...)
+	data = append(data, utils.EVMWordUint64(availableFunds)...)
+	data = append(data, utils.EVMWordUint64(paymentAmount)...)
+	data = append(data, utils.EVMWordUint64(oracleCount)...)
+	return hexutil.Encode(data)
+}

--- a/core/services/eth/contracts/FluxAggregator.go
+++ b/core/services/eth/contracts/FluxAggregator.go
@@ -79,6 +79,7 @@ type FluxAggregatorRoundState struct {
 	TimesOutAt        uint64   `abi:"_timesOutAt"`
 	AvailableFunds    *big.Int `abi:"_availableFunds"`
 	PaymentAmount     *big.Int `abi:"_paymentAmount"`
+	OracleCount       uint32   `abi:"_oracleCount"`
 }
 
 func (fa *fluxAggregator) RoundState(oracle common.Address) (FluxAggregatorRoundState, error) {

--- a/core/services/eth/contracts/FluxAggregator_test.go
+++ b/core/services/eth/contracts/FluxAggregator_test.go
@@ -9,35 +9,12 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
 	"github.com/smartcontractkit/chainlink/core/services/eth/contracts"
-	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 )
-
-func mustEVMBigInt(t *testing.T, val *big.Int) []byte {
-	ret, err := utils.EVMWordBigInt(val)
-	require.NoError(t, err, "evm BigInt serialization")
-	return ret
-}
-
-func makeRoundStateReturnData(roundID uint64, eligible bool, answer, timesOutAt, availableFunds, paymentAmount uint64) string {
-	var data []byte
-	data = append(data, utils.EVMWordUint64(roundID)...)
-	if eligible {
-		data = append(data, utils.EVMWordUint64(1)...)
-	} else {
-		data = append(data, utils.EVMWordUint64(0)...)
-	}
-	data = append(data, utils.EVMWordUint64(answer)...)
-	data = append(data, utils.EVMWordUint64(timesOutAt)...)
-	data = append(data, utils.EVMWordUint64(availableFunds)...)
-	data = append(data, utils.EVMWordUint64(paymentAmount)...)
-	return hexutil.Encode(data)
-}
 
 func TestFluxAggregatorClient_RoundState(t *testing.T) {
 	aggregatorAddress := cltest.NewAddress()
@@ -53,7 +30,7 @@ func TestFluxAggregatorClient_RoundState(t *testing.T) {
 		Data: append(selector, nodeAddr[:]...),
 	}
 
-	rawReturnData := `0x00000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000a0000000000000000000000000000000000000000000000000000000000000100`
+	rawReturnData := `0x00000000000000000000000000000000000000000000000000000000000000030000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000f000000000000000000000000000000000000000000000000000000000000000e000000000000000000000000000000000000000000000000000000000000000a00000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000011`
 
 	tests := []struct {
 		name                   string
@@ -65,10 +42,10 @@ func TestFluxAggregatorClient_RoundState(t *testing.T) {
 		expectedAvailableFunds uint64
 		expectedPaymentAmount  uint64
 	}{
-		{"zero, false", makeRoundStateReturnData(0, false, 0, 0, 0, 0), 0, false, big.NewInt(0), 0, 0, 0},
-		{"non-zero, false", makeRoundStateReturnData(1, false, 23, 1234, 36, 72), 1, false, big.NewInt(23), 1234, 36, 72},
-		{"zero, true", makeRoundStateReturnData(0, true, 0, 0, 0, 0), 0, true, big.NewInt(0), 0, 0, 0},
-		{"non-zero true", makeRoundStateReturnData(12, true, 91, 9876, 45, 999), 12, true, big.NewInt(91), 9876, 45, 999},
+		{"zero, false", cltest.MakeRoundStateReturnData(0, false, 0, 0, 0, 0, 17), 0, false, big.NewInt(0), 0, 0, 0},
+		{"non-zero, false", cltest.MakeRoundStateReturnData(1, false, 23, 1234, 36, 72, 17), 1, false, big.NewInt(23), 1234, 36, 72},
+		{"zero, true", cltest.MakeRoundStateReturnData(0, true, 0, 0, 0, 0, 17), 0, true, big.NewInt(0), 0, 0, 0},
+		{"non-zero true", cltest.MakeRoundStateReturnData(12, true, 91, 9876, 45, 999, 17), 12, true, big.NewInt(91), 9876, 45, 999},
 		{"real call data", rawReturnData, 3, true, big.NewInt(15), 14, 10, 256},
 	}
 

--- a/evm-contracts/src/v0.6/dev/FluxAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/FluxAggregator.sol
@@ -748,7 +748,8 @@ contract FluxAggregator is AggregatorInterface, Owned {
       int256 _latestRoundAnswer,
       uint64 _timesOutAt,
       uint128 _availableFunds,
-      uint128 _paymentAmount
+      uint128 _paymentAmount,
+      uint32 _oracleCount
     )
   {
     bool finishedOrTimedOut = rounds[reportingRoundId].details.answers.length >= rounds[reportingRoundId].details.maxAnswers || timedOut(reportingRoundId);
@@ -759,7 +760,8 @@ contract FluxAggregator is AggregatorInterface, Owned {
       rounds[latestRoundId].answer,
       finishedOrTimedOut ? 0 : rounds[_reportableRoundId].startedAt + rounds[_reportableRoundId].details.timeout,
       availableFunds,
-      finishedOrTimedOut ? paymentAmount : rounds[_reportableRoundId].details.paymentAmount
+      finishedOrTimedOut ? paymentAmount : rounds[_reportableRoundId].details.paymentAmount,
+      oracleCount()
     );
   }
 

--- a/evm-contracts/src/v0.6/dev/FluxAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/FluxAggregator.sol
@@ -72,7 +72,15 @@ contract FluxAggregator is AggregatorInterface, Owned {
   uint8 public override decimals;
   bytes32 public description;
 
-  uint256 constant RESERVE_ROUNDS = 2;
+
+  /**
+   * @notice To ensure owner isn't withdrawing required funds as oracles are
+   * submitting updates, we enforce that the contract maintains a minimum
+   * reserve of RESERVE_ROUND * oracleCount() LINK earmarked for payment to
+   * oracles. (Of course, this doesn't prevent the contract from running out of
+   * funds without the owner's intervention.)
+   */
+  uint256 constant private RESERVE_ROUNDS = 2;
 
   uint32 private reportingRoundId;
   uint32 internal latestRoundId;

--- a/evm-contracts/src/v0.6/dev/FluxAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/FluxAggregator.sol
@@ -239,6 +239,9 @@ contract FluxAggregator is AggregatorInterface, Owned {
     onlyOwner()
     onlyValidRange(_minAnswers, _maxAnswers, _restartDelay)
   {
+    uint256 oracleReserve = uint256(_newPaymentAmount).mul(oracleCount()).mul(RESERVE_ROUNDS);
+    require(availableFunds >= oracleReserve, "insufficient funds for payment");
+
     paymentAmount = _newPaymentAmount;
     minAnswerCount = _minAnswers;
     maxAnswerCount = _maxAnswers;

--- a/evm-contracts/src/v0.6/dev/FluxAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/FluxAggregator.sol
@@ -59,6 +59,7 @@ contract FluxAggregator is AggregatorInterface, Owned {
 
   uint256 constant public VERSION = 2;
 
+  LinkTokenInterface public linkToken;
   uint128 public allocatedFunds;
   uint128 public availableFunds;
 
@@ -71,9 +72,10 @@ contract FluxAggregator is AggregatorInterface, Owned {
   uint8 public override decimals;
   bytes32 public description;
 
+  uint256 constant RESERVE_ROUNDS = 2;
+
   uint32 private reportingRoundId;
   uint32 internal latestRoundId;
-  LinkTokenInterface public linkToken;
   mapping(address => OracleStatus) private oracles;
   mapping(uint32 => Round) internal rounds;
   mapping(address => Requester) internal requesters;
@@ -450,7 +452,8 @@ contract FluxAggregator is AggregatorInterface, Owned {
     external
     onlyOwner()
   {
-    require(availableFunds >= _amount, "insufficient available funds");
+    uint256 oracleReserve = uint256(paymentAmount).mul(oracleCount()).mul(RESERVE_ROUNDS);
+    require(uint256(availableFunds).sub(oracleReserve) >= _amount, "insufficient reserve funds");
     require(linkToken.transfer(_recipient, _amount), "token transfer failed");
     updateAvailableFunds();
   }

--- a/evm-contracts/test/v0.6/FluxAggregator.test.ts
+++ b/evm-contracts/test/v0.6/FluxAggregator.test.ts
@@ -312,9 +312,8 @@ describe('FluxAggregator', () => {
       })
 
       it('updates the updated timestamp', async () => {
-        const deployTime = aggregator.deployTransaction.chainId / 1000
         const originalTimestamp = await aggregator.latestTimestamp()
-        assert.closeTo(deployTime, originalTimestamp.toNumber(), timeout)
+        assert.isAbove(originalTimestamp.toNumber(), 0)
 
         await aggregator.connect(personas.Nelly).updateAnswer(nextRound, answer)
 

--- a/evm-contracts/test/v0.6/FluxAggregator.test.ts
+++ b/evm-contracts/test/v0.6/FluxAggregator.test.ts
@@ -2082,4 +2082,107 @@ describe('FluxAggregator', () => {
       })
     })
   })
+
+  describe('#roundState', () => {
+    let minMax
+
+    beforeEach(async () => {
+      const oracles = [personas.Neil, personas.Nelly]
+      for (let i = 0; i < oracles.length; i++) {
+        minMax = i + 1
+        await aggregator
+          .connect(personas.Carol)
+          .addOracle(
+            oracles[i].address,
+            oracles[i].address,
+            minMax,
+            minMax,
+            rrDelay,
+          )
+      }
+    })
+
+    it('returns all of the important round information', async () => {
+      const state = await aggregator
+        .connect(personas.Nelly)
+        .roundState(personas.Nelly.address)
+      matchers.bigNum(1, state._reportableRoundId)
+      assert.equal(true, state._eligibleToSubmit)
+      matchers.bigNum(0, state._latestRoundAnswer)
+      matchers.bigNum(0, state._timesOutAt)
+      matchers.bigNum(deposit, state._availableFunds)
+      matchers.bigNum(paymentAmount, state._paymentAmount) // weird that this is 0
+    })
+
+    describe('after other oracles have reported', () => {
+      beforeEach(async () => {
+        await aggregator.connect(personas.Neil).updateAnswer(nextRound, answer)
+      })
+
+      it('keeps the round ID and allows the oracle to submit', async () => {
+        const state = await aggregator
+          .connect(personas.Nelly)
+          .roundState(personas.Nelly.address)
+        matchers.bigNum(1, state._reportableRoundId)
+        assert.equal(true, state._eligibleToSubmit)
+        matchers.bigNum(0, state._latestRoundAnswer)
+        matchers.bigNum(deposit.sub(paymentAmount), state._availableFunds)
+        matchers.bigNum(paymentAmount, state._paymentAmount)
+      })
+    })
+
+    describe('after the oracle has reported but the others have not', () => {
+      beforeEach(async () => {
+        await aggregator.connect(personas.Nelly).updateAnswer(nextRound, answer)
+      })
+
+      it('keeps the round ID and allows the oracle to submit', async () => {
+        const state = await aggregator
+          .connect(personas.Nelly)
+          .roundState(personas.Nelly.address)
+        matchers.bigNum(1, state._reportableRoundId)
+        assert.equal(false, state._eligibleToSubmit)
+        matchers.bigNum(0, state._latestRoundAnswer) // differs from new version
+        matchers.bigNum(deposit.sub(paymentAmount), state._availableFunds)
+      })
+
+      describe('and the round has timed out', () => {
+        beforeEach(async () => {
+          await h.increaseTimeBy(timeout + 1, provider)
+          await h.mineBlock(provider)
+        })
+
+        it('bumps the round ID and allows the oracle to submit', async () => {
+          const state = await aggregator
+            .connect(personas.Nelly)
+            .roundState(personas.Nelly.address)
+
+          matchers.bigNum(2, state._reportableRoundId)
+          assert.equal(true, state._eligibleToSubmit)
+          matchers.bigNum(0, state._latestRoundAnswer) // differs from new version
+          matchers.bigNum(deposit.sub(paymentAmount), state._availableFunds)
+        })
+      })
+    })
+
+    describe('when all oracles have reported', () => {
+      beforeEach(async () => {
+        const oracles = [personas.Neil, personas.Nelly]
+        for (let i = 0; i < oracles.length; i++) {
+          await aggregator.connect(oracles[i]).updateAnswer(nextRound, answer)
+        }
+      })
+
+      it('bumps the round ID and allows the oracle to submit', async () => {
+        const state = await aggregator
+          .connect(personas.Nelly)
+          .roundState(personas.Nelly.address)
+        matchers.bigNum(2, state._reportableRoundId)
+        assert.equal(true, state._eligibleToSubmit)
+        matchers.bigNum(answer, state._latestRoundAnswer)
+        const expected = deposit.sub(paymentAmount).sub(paymentAmount)
+        matchers.bigNum(expected, state._availableFunds)
+      })
+    })
+  })
 })

--- a/evm-contracts/test/v0.6/FluxAggregator.test.ts
+++ b/evm-contracts/test/v0.6/FluxAggregator.test.ts
@@ -2087,14 +2087,14 @@ describe('FluxAggregator', () => {
     let minMax
 
     beforeEach(async () => {
-      const oracles = [personas.Neil, personas.Nelly]
-      for (let i = 0; i < oracles.length; i++) {
+      oracleAddresses = [personas.Neil, personas.Nelly]
+      for (let i = 0; i < oracleAddresses.length; i++) {
         minMax = i + 1
         await aggregator
           .connect(personas.Carol)
           .addOracle(
-            oracles[i].address,
-            oracles[i].address,
+            oracleAddresses[i].address,
+            oracleAddresses[i].address,
             minMax,
             minMax,
             rrDelay,
@@ -2112,6 +2112,7 @@ describe('FluxAggregator', () => {
       matchers.bigNum(0, state._timesOutAt)
       matchers.bigNum(deposit, state._availableFunds)
       matchers.bigNum(paymentAmount, state._paymentAmount) // weird that this is 0
+      matchers.bigNum(oracleAddresses.length, state._oracleCount) // weird that this is 0
     })
 
     describe('after other oracles have reported', () => {

--- a/tools/ci-ts/tests/flux-monitor.test.ts
+++ b/tools/ci-ts/tests/flux-monitor.test.ts
@@ -155,11 +155,12 @@ afterAll(() => {
 
 describe('FluxMonitor / FluxAggregator integration with one node', () => {
   it('updates the price', async () => {
+    await linkToken.transfer(fluxAggregator.address, deposit).then(t.txWait)
+    await fluxAggregator.updateAvailableFunds().then(t.txWait)
+
     await fluxAggregator
       .addOracle(node1Address, node1Address, 1, 1, 0)
       .then(t.txWait)
-    await linkToken.transfer(fluxAggregator.address, deposit).then(t.txWait)
-    await fluxAggregator.updateAvailableFunds().then(t.txWait)
 
     expect(await fluxAggregator.getOracles()).toEqual([node1Address])
     matchers.bigNum(
@@ -199,14 +200,15 @@ describe('FluxMonitor / FluxAggregator integration with one node', () => {
 
 describe('FluxMonitor / FluxAggregator integration with two nodes', () => {
   beforeEach(async () => {
+    await linkToken.transfer(fluxAggregator.address, deposit).then(t.txWait)
+    await fluxAggregator.updateAvailableFunds().then(t.txWait)
+
     await fluxAggregator
       .addOracle(node1Address, node1Address, 1, 1, 0)
       .then(t.txWait)
     await fluxAggregator
       .addOracle(node2Address, node2Address, 2, 2, 0)
       .then(t.txWait)
-    await linkToken.transfer(fluxAggregator.address, deposit).then(t.txWait)
-    await fluxAggregator.updateAvailableFunds().then(t.txWait)
 
     expect(await fluxAggregator.getOracles()).toEqual([
       node1Address,


### PR DESCRIPTION
Also includes the number of oracles in the `roundStatus` response.