### PR TITLE
Hotfix/172463818 fix publish explorer tag publish

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -365,7 +365,9 @@ workflows:
       - check_if_rebase_needed:
           filters:
             tags:
-              ignore: /^v.*/
+              ignore:
+                - /^v.*/
+                - /^explorer-v.*/
             branches:
               ignore:
                 - develop
@@ -399,11 +401,15 @@ workflows:
       - styleguide:
           filters:
             tags:
-              only: /^v.*/
+              only:
+                - /^v.*/
+                - /^explorer-v.*/
       - json-api-client:
           filters:
             tags:
-              only: /^v.*/
+              only:
+                - /^v.*/
+                - /^explorer-v.*/
       - operator-ui:
           filters:
             tags:
@@ -419,15 +425,21 @@ workflows:
       - feeds:
           filters:
             tags:
-              only: /^v.*/
+              only:
+                - /^v.*/
+                - /^explorer-v.*/
       - lint:
           filters:
             tags:
-              only: /^v.*/
+              only:
+                - /^v.*/
+                - /^explorer-v.*/
       - prepublish_npm:
           filters:
             tags:
-              only: /^v.*/
+              only:
+                - /^v.*/
+                - /^explorer-v.*/
       - build-publish-explorer:
           requires:
             - styleguide
@@ -435,7 +447,7 @@ workflows:
             - explorer
           filters:
             tags:
-              only: /^v.*/
+              only: /^explorer-v.*/
       - build-chainlink-sgx:
           filters:
             tags:
@@ -460,3 +472,14 @@ workflows:
             - operator-ui
             - rust
             - explorer
+          filters:
+            tags:
+              ignore:
+                - /^v.*/
+                - /^explorer-v.*/
+            branches:
+              ignore:
+                - develop
+                - /^release\/.*/
+                - master
+                - /^hotfix\/.*/

--- a/tools/ci/push_explorer
+++ b/tools/ci/push_explorer
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -ex
+set -e
 
 #
 # Pushes smartcontract/explorer:circleci to relevant location based on passed args:
@@ -40,11 +40,11 @@ tag_and_push() {
 branch_tag=`tools/ci/branch2tag ${circle_branch}` # ie: develop, latest, candidate-*, etc.
 version_tag=`tools/ci/gittag2dockertag ${circle_tag}` # aka GIT_TAG. explorer-v0.9.1 -> 0.9.1
 
-
 # version tag takes precedence.
 if [ -n "${version_tag}" ]; then
   # Only if we have an explorer tag
   if [[ "${circle_tag}" =~ ^explorer-v([a-zA-Z0-9.]+) ]]; then
+    echo "Publishing full release of Explorer ${version_tag}"
     tag_and_push "$version_tag"
     # if version tag, also push latest.
     # ie: after pushing smartcontract/explorer:0.6.9, also update smartcontract/explorer:latest
@@ -55,6 +55,7 @@ if [ -n "${version_tag}" ]; then
 elif [ -n "$branch_tag" ]; then
   # Only if we're on explorer branch
   if [[ "${circle_branch}" =~ ^release(s)?\/explorer-(.+)$ ]]; then
+    echo "Publishing candidate release of Explorer ${version_tag}"
     tag_and_push "$branch_tag"
   else
     echo "Skipping publishing for ${circle_branch}."

--- a/tools/ci/push_explorer
+++ b/tools/ci/push_explorer
@@ -6,11 +6,11 @@ set -e
 # Pushes smartcontract/explorer:circleci to relevant location based on passed args:
 # push_explorer <branch> <gittag>
 # ie:
-# push_explorer master 0.6.9
-# push_explorer develop
-# push_explorer release/0.6.9
+# push_explorer explorer-master explorer-v0.6.9 -> 0.6.9 and latest
+# push_explorer release/0.6.9                   -> candidate-0.6.9
 #
 # Ignores anything not matching above.
+#
 # Key assumption: local version of smartcontract/explorer:circleci is the image
 # to work with.
 #
@@ -37,20 +37,17 @@ tag_and_push() {
   popd
 }
 
-branch_tag=`tools/ci/branch2tag ${circle_branch}` # ie: develop, latest, candidate-*, etc.
-version_tag=`tools/ci/gittag2dockertag ${circle_tag}` # aka GIT_TAG. explorer-v0.9.1 -> 0.9.1
+branch_tag=`tools/ci/branch2tag ${circle_branch}`
+version_tag=`tools/ci/gittag2dockertag ${circle_tag}`
 
 # version tag takes precedence.
 if [ -n "${version_tag}" ]; then
-  # Only if we have an explorer tag
-  if [[ "${circle_tag}" =~ ^explorer-v([a-zA-Z0-9.]+) ]]; then
+  if [[ "${circle_branch}" == master-explorer ]]; then
     echo "Publishing full release of Explorer ${version_tag}"
     tag_and_push "$version_tag"
-    # if version tag, also push latest.
-    # ie: after pushing smartcontract/explorer:0.6.9, also update smartcontract/explorer:latest
     tag_and_push latest
   else
-    echo "Skipping publishing for tag ${circle_tag}."
+    echo "Not publishing for tag ${circle_tag} on ${circle_branch}."
   fi
 elif [ -n "$branch_tag" ]; then
   # Only if we're on explorer branch
@@ -58,8 +55,8 @@ elif [ -n "$branch_tag" ]; then
     echo "Publishing candidate release of Explorer ${version_tag}"
     tag_and_push "$branch_tag"
   else
-    echo "Skipping publishing for ${circle_branch}."
+    echo "Not publishing for ${circle_branch}."
   fi
 else
-  echo "Skipping publishing for this ${circle_tag}/${circle_branch}."
+  echo "Not publishing for '${circle_tag}/${circle_branch}'."
 fi

--- a/tools/ci/push_explorer
+++ b/tools/ci/push_explorer
@@ -50,15 +50,15 @@ if [ -n "${version_tag}" ]; then
     # ie: after pushing smartcontract/explorer:0.6.9, also update smartcontract/explorer:latest
     tag_and_push latest
   else
-    echo "Skipping publishing for this branch/tag."
+    echo "Skipping publishing for tag ${circle_tag}."
   fi
 elif [ -n "$branch_tag" ]; then
   # Only if we're on explorer branch
   if [[ "${circle_branch}" =~ ^release(s)?\/explorer-(.+)$ ]]; then
     tag_and_push "$branch_tag"
   else
-    echo "Skipping publishing for this branch/tag."
+    echo "Skipping publishing for ${circle_branch}."
   fi
 else
-  echo "Skipping publishing for this branch/tag."
+  echo "Skipping publishing for this ${circle_tag}/${circle_branch}."
 fi


### PR DESCRIPTION
CircleCI wasn't building the `build-and-publish-explorer` build on explorer version tags. So added that in.

Also made `publish_explorer` script a little bit stricter, more verbose and corrected the comment at the top.