### PR TITLE
Turns out tag builds don't get branches, handle

### DIFF
--- a/tools/ci/push_explorer
+++ b/tools/ci/push_explorer
@@ -6,8 +6,8 @@ set -e
 # Pushes smartcontract/explorer:circleci to relevant location based on passed args:
 # push_explorer <branch> <gittag>
 # ie:
-# push_explorer explorer-master explorer-v0.6.9 -> 0.6.9 and latest
-# push_explorer release/0.6.9                   -> candidate-0.6.9
+# push_explorer '' explorer-v0.6.9          -> 0.6.9 and latest
+# push_explorer release/explorer-0.6.9 ''   -> candidate-0.6.9
 #
 # Ignores anything not matching above.
 #
@@ -37,23 +37,23 @@ tag_and_push() {
   popd
 }
 
-branch_tag=`tools/ci/branch2tag ${circle_branch}`
+branch=`tools/ci/branch2tag ${circle_branch}`
 version_tag=`tools/ci/gittag2dockertag ${circle_tag}`
 
 # version tag takes precedence.
 if [ -n "${version_tag}" ]; then
-  if [[ "${circle_branch}" == master-explorer ]]; then
+  if [[ "${circle_tag}" =~ ^explorer-v([a-zA-Z0-9.]+) ]]; then
     echo "Publishing full release of Explorer ${version_tag}"
     tag_and_push "$version_tag"
     tag_and_push latest
   else
-    echo "Not publishing for tag ${circle_tag} on ${circle_branch}."
+    echo "Not publishing for this '${circle_tag}'."
   fi
-elif [ -n "$branch_tag" ]; then
+elif [ -n "$branch" ]; then
   # Only if we're on explorer branch
   if [[ "${circle_branch}" =~ ^release(s)?\/explorer-(.+)$ ]]; then
     echo "Publishing candidate release of Explorer ${version_tag}"
-    tag_and_push "$branch_tag"
+    tag_and_push "$branch"
   else
     echo "Not publishing for ${circle_branch}."
   fi


### PR DESCRIPTION
When CircleCI builds a tag build, it actually doesn't pass in the branch. So we can't block on it properly here.