### PR TITLE
Bump explorer version to 0.8.2

### DIFF
--- a/explorer/client/package.json
+++ b/explorer/client/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chainlink/explorer-client",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.8.2",
   "keywords": [],
   "browserslist": {
     "production": [

--- a/explorer/package.json
+++ b/explorer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@chainlink/explorer",
   "private": true,
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "LINK Explorer",
   "author": "Chainlink Dev Team",
   "license": "MIT",


### PR DESCRIPTION
Hopefully the last thing, possibly didn't follow git flow on last release so the back merge was missing? Anyway, this should match the package.json with the docker image tag.