### PR TITLE
Separate offset/limit from count query

### DIFF
--- a/explorer/src/__tests__/queries/Search.test.ts
+++ b/explorer/src/__tests__/queries/Search.test.ts
@@ -171,4 +171,9 @@ describe('search and count', () => {
     const countResult = await count({ searchQuery: 'runB runC' })
     expect(countResult).toEqual(2)
   })
+
+  it('returns the number of results matching the search query for the second page', async () => {
+    const countResult = await count({ searchQuery: 'runB runC', page: 2 })
+    expect(countResult).toEqual(2)
+  })
 })

--- a/explorer/src/__tests__/queries/Search.test.ts
+++ b/explorer/src/__tests__/queries/Search.test.ts
@@ -171,9 +171,4 @@ describe('search and count', () => {
     const countResult = await count({ searchQuery: 'runB runC' })
     expect(countResult).toEqual(2)
   })
-
-  it('returns the number of results matching the search query for the second page', async () => {
-    const countResult = await count({ searchQuery: 'runB runC', page: 2 })
-    expect(countResult).toEqual(2)
-  })
 })

--- a/explorer/src/queries/search.ts
+++ b/explorer/src/queries/search.ts
@@ -68,7 +68,9 @@ export const search = async (params: SearchParams): Promise<JobRun[]> => {
     .getMany()
 }
 
-export const count = async (params: SearchParams): Promise<number> => {
+export const count = async (
+  params: Pick<SearchParams, 'searchQuery'>,
+): Promise<number> => {
   const result = await searchBuilder(params.searchQuery)
     .select('COUNT(*)', 'count')
     .getRawOne()

--- a/explorer/src/queries/search.ts
+++ b/explorer/src/queries/search.ts
@@ -41,6 +41,14 @@ const searchBuilder = (params: SearchParams): SelectQueryBuilder<JobRun> => {
     query = query.where('true = false')
   }
 
+  return query
+}
+
+const pagedSearchBuilder = (
+  params: SearchParams,
+): SelectQueryBuilder<JobRun> => {
+  let query = searchBuilder(params)
+
   if (params.limit != null) {
     query = query.limit(params.limit)
   }
@@ -54,7 +62,7 @@ const searchBuilder = (params: SearchParams): SelectQueryBuilder<JobRun> => {
 }
 
 export const search = async (params: SearchParams): Promise<JobRun[]> => {
-  return searchBuilder(params)
+  return pagedSearchBuilder(params)
     .leftJoinAndSelect('job_run.chainlinkNode', 'chainlink_node')
     .orderBy('job_run.createdAt', 'DESC')
     .getMany()

--- a/explorer/src/queries/search.ts
+++ b/explorer/src/queries/search.ts
@@ -19,11 +19,11 @@ const normalizeSearchToken = (id: string): string => {
   return id
 }
 
-const searchBuilder = (params: SearchParams): SelectQueryBuilder<JobRun> => {
+const searchBuilder = (searchQuery?: string): SelectQueryBuilder<JobRun> => {
   let query = getRepository(JobRun).createQueryBuilder('job_run')
 
-  if (params.searchQuery != null) {
-    const searchTokens = params.searchQuery.split(/\s+/)
+  if (searchQuery != null) {
+    const searchTokens = searchQuery.split(/\s+/)
     const normalizedSearchTokens = searchTokens.map(normalizeSearchToken)
     query = query
       .where('job_run.runId IN(:...searchTokens)', { searchTokens })
@@ -47,7 +47,7 @@ const searchBuilder = (params: SearchParams): SelectQueryBuilder<JobRun> => {
 const pagedSearchBuilder = (
   params: SearchParams,
 ): SelectQueryBuilder<JobRun> => {
-  let query = searchBuilder(params)
+  let query = searchBuilder(params.searchQuery)
 
   if (params.limit != null) {
     query = query.limit(params.limit)
@@ -69,7 +69,7 @@ export const search = async (params: SearchParams): Promise<JobRun[]> => {
 }
 
 export const count = async (params: SearchParams): Promise<number> => {
-  const result = await searchBuilder(params)
+  const result = await searchBuilder(params.searchQuery)
     .select('COUNT(*)', 'count')
     .getRawOne()
 


### PR DESCRIPTION
The count tries to reuse the search builder which adds LIMIT / OFFSET to the query, but these are incompatible with aggregates in postgres, so after the first page, you'll get a null result instead of a count.