### PR TITLE
prevent oracleRoundState from creeping forward

### DIFF
--- a/evm-contracts/src/v0.6/dev/FluxAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/FluxAggregator.sol
@@ -769,7 +769,8 @@ contract FluxAggregator is AggregatorInterface, Owned {
   {
     require(msg.sender == tx.origin, "off-chain reading only");
 
-    if (supersedable(reportingRoundId)) {
+    bool current = oracles[_oracle].lastReportedRound == reportingRoundId;
+    if (supersedable(reportingRoundId) && current) {
       _roundId = reportingRoundId.add(1);
       _paymentAmount = paymentAmount;
       _eligibleToSubmit = delayed(_oracle, _roundId);


### PR DESCRIPTION
If the minimum number of oracles had submitted, oracleRoundState would
give the next round ID to an oracle that had not submitted on the
current round. Now it prefers the current round if not yet answered.