### PR TITLE
cover different cases for oracleRoundState

### DIFF
--- a/evm-contracts/src/v0.6/dev/FluxAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/FluxAggregator.sol
@@ -588,7 +588,8 @@ contract FluxAggregator is AggregatorInterface, Owned {
   {
     require(msg.sender == tx.origin, "off-chain reading only");
 
-    bool current = oracles[_oracle].lastReportedRound == reportingRoundId;
+    bool current = oracles[_oracle].lastReportedRound == reportingRoundId ||
+      !acceptingSubmissions(reportingRoundId); // oracle reorted OR max submissions have been received
     if (supersedable(reportingRoundId) && current) {
       _roundId = reportingRoundId.add(1);
       _paymentAmount = paymentAmount;

--- a/evm-contracts/src/v0.6/dev/FluxAggregator.sol
+++ b/evm-contracts/src/v0.6/dev/FluxAggregator.sol
@@ -588,9 +588,12 @@ contract FluxAggregator is AggregatorInterface, Owned {
   {
     require(msg.sender == tx.origin, "off-chain reading only");
 
-    bool current = oracles[_oracle].lastReportedRound == reportingRoundId ||
-      !acceptingSubmissions(reportingRoundId); // oracle reorted OR max submissions have been received
-    if (supersedable(reportingRoundId) && current) {
+    bool shouldSupersede = oracles[_oracle].lastReportedRound == reportingRoundId ||
+      !acceptingSubmissions(reportingRoundId);
+    // Instead of nudging oracles to submit to the next round, the inclusion of
+    // the shouldSupersede bool in the if condition pushes them towards
+    // submitting in a currently open round.
+    if (supersedable(reportingRoundId) && shouldSupersede) {
       _roundId = reportingRoundId.add(1);
       _paymentAmount = paymentAmount;
       _eligibleToSubmit = delayed(_oracle, _roundId);

--- a/evm-contracts/test/v0.6/FluxAggregator.test.ts
+++ b/evm-contracts/test/v0.6/FluxAggregator.test.ts
@@ -94,8 +94,8 @@ describe('FluxAggregator', () => {
     return nextRound
   }
 
-  const ShouldBeUpdated = 'expects it to be different'
-  const ShouldNotBeUpdated = 'expects it to equal'
+  const ShouldBeSet = 'expects it to be different'
+  const ShouldNotBeSet = 'expects it to equal'
   let startingState: any
 
   async function checkOracleRoundState(
@@ -111,21 +111,54 @@ describe('FluxAggregator', () => {
       paymentAmount: ethers.utils.BigNumberish
     },
   ) {
-    assert.equal(want.eligibleToSubmit, state._eligibleToSubmit)
-    matchers.bigNum(want.roundId, state._roundId)
-    matchers.bigNum(want.latestSubmission, state._latestSubmission)
-    if (want.startedAt === ShouldBeUpdated) {
+    assert.equal(
+      want.eligibleToSubmit,
+      state._eligibleToSubmit,
+      'round state: unexecpted eligibility',
+    )
+    matchers.bigNum(
+      want.roundId,
+      state._roundId,
+      'round state: unexpected Round ID',
+    )
+    matchers.bigNum(
+      want.latestSubmission,
+      state._latestSubmission,
+      'round state: unexpected latest submission',
+    )
+    if (want.startedAt === ShouldBeSet) {
       assert.isAbove(
         state._startedAt.toNumber(),
         startingState._startedAt.toNumber(),
+        'round state: expected the started at to be the same as previous',
       )
     } else {
-      matchers.bigNum(0, state._startedAt)
+      matchers.bigNum(
+        0,
+        state._startedAt,
+        'round state: expected the started at not to be updated',
+      )
     }
-    matchers.bigNum(want.timeout, state._timeout.toNumber())
-    matchers.bigNum(want.availableFunds, state._availableFunds)
-    matchers.bigNum(want.oracleCount, state._oracleCount)
-    matchers.bigNum(want.paymentAmount, state._paymentAmount)
+    matchers.bigNum(
+      want.timeout,
+      state._timeout.toNumber(),
+      'round state: unexepcted timeout',
+    )
+    matchers.bigNum(
+      want.availableFunds,
+      state._availableFunds,
+      'round state: unexepected funds',
+    )
+    matchers.bigNum(
+      want.oracleCount,
+      state._oracleCount,
+      'round state: unexpected oracle count',
+    )
+    matchers.bigNum(
+      want.paymentAmount,
+      state._paymentAmount,
+      'round state: unexpected paymentamount',
+    )
   }
 
   const deployment = setup.snapshot(provider, async () => {
@@ -1961,7 +1994,7 @@ describe('FluxAggregator', () => {
         eligibleToSubmit: true,
         roundId: 2,
         latestSubmission: previousSubmission,
-        startedAt: ShouldNotBeUpdated,
+        startedAt: ShouldNotBeSet,
         timeout: 0,
         availableFunds: baseFunds,
         oracleCount: oracles.length,
@@ -2003,7 +2036,7 @@ describe('FluxAggregator', () => {
             eligibleToSubmit: true,
             roundId: 2,
             latestSubmission: previousSubmission,
-            startedAt: ShouldBeUpdated,
+            startedAt: ShouldBeSet,
             timeout,
             availableFunds: baseFunds.sub(paymentAmount),
             oracleCount: oracles.length,
@@ -2026,7 +2059,7 @@ describe('FluxAggregator', () => {
             eligibleToSubmit: false,
             roundId: 2,
             latestSubmission: answer,
-            startedAt: ShouldBeUpdated,
+            startedAt: ShouldBeSet,
             timeout,
             availableFunds: baseFunds.sub(paymentAmount),
             oracleCount: oracles.length,
@@ -2049,7 +2082,7 @@ describe('FluxAggregator', () => {
               eligibleToSubmit: true,
               roundId: 3,
               latestSubmission: answer,
-              startedAt: ShouldNotBeUpdated,
+              startedAt: ShouldNotBeSet,
               timeout: 0,
               availableFunds: baseFunds.sub(paymentAmount),
               oracleCount: oracles.length,
@@ -2077,7 +2110,7 @@ describe('FluxAggregator', () => {
             eligibleToSubmit: true,
             roundId: 2,
             latestSubmission: previousSubmission,
-            startedAt: ShouldBeUpdated,
+            startedAt: ShouldBeSet,
             timeout,
             availableFunds: baseFunds.sub(paymentAmount.mul(3)),
             oracleCount: oracles.length,
@@ -2104,7 +2137,7 @@ describe('FluxAggregator', () => {
             eligibleToSubmit: true,
             roundId: 3,
             latestSubmission: answer,
-            startedAt: ShouldNotBeUpdated,
+            startedAt: ShouldNotBeSet,
             timeout: 0,
             availableFunds: baseFunds.sub(paymentAmount.mul(3)),
             oracleCount: oracles.length,
@@ -2127,7 +2160,7 @@ describe('FluxAggregator', () => {
               eligibleToSubmit: true,
               roundId: 3,
               latestSubmission: answer,
-              startedAt: ShouldNotBeUpdated,
+              startedAt: ShouldNotBeSet,
               timeout: 0,
               availableFunds: baseFunds.sub(paymentAmount.mul(3)),
               oracleCount: oracles.length,
@@ -2162,7 +2195,7 @@ describe('FluxAggregator', () => {
             eligibleToSubmit: true,
             roundId: 3,
             latestSubmission: previousSubmission,
-            startedAt: ShouldNotBeUpdated,
+            startedAt: ShouldNotBeSet,
             timeout: 0,
             availableFunds: baseFunds.sub(paymentAmount.mul(4)),
             oracleCount: oracles.length,
@@ -2196,7 +2229,7 @@ describe('FluxAggregator', () => {
             eligibleToSubmit: true,
             roundId: 3,
             latestSubmission: answer,
-            startedAt: ShouldNotBeUpdated,
+            startedAt: ShouldNotBeSet,
             timeout: 0,
             availableFunds: baseFunds.sub(paymentAmount.mul(4)),
             oracleCount: oracles.length,
@@ -2229,7 +2262,7 @@ describe('FluxAggregator', () => {
             eligibleToSubmit: true,
             roundId: 2,
             latestSubmission: previousSubmission,
-            startedAt: ShouldBeUpdated,
+            startedAt: ShouldBeSet,
             timeout,
             availableFunds: baseFunds.sub(paymentAmount.mul(2)),
             oracleCount: oracles.length,
@@ -2252,7 +2285,7 @@ describe('FluxAggregator', () => {
             eligibleToSubmit: false,
             roundId: 2,
             latestSubmission: answer,
-            startedAt: ShouldBeUpdated,
+            startedAt: ShouldBeSet,
             timeout,
             availableFunds: baseFunds.sub(paymentAmount.mul(2)),
             oracleCount: oracles.length,
@@ -2275,7 +2308,7 @@ describe('FluxAggregator', () => {
               eligibleToSubmit: false,
               roundId: 3,
               latestSubmission: answer,
-              startedAt: ShouldNotBeUpdated,
+              startedAt: ShouldNotBeSet,
               timeout: 0,
               availableFunds: baseFunds.sub(paymentAmount.mul(2)),
               oracleCount: oracles.length,
@@ -2303,7 +2336,7 @@ describe('FluxAggregator', () => {
             eligibleToSubmit: true,
             roundId: 2,
             latestSubmission: previousSubmission,
-            startedAt: ShouldBeUpdated,
+            startedAt: ShouldBeSet,
             timeout,
             availableFunds: baseFunds.sub(paymentAmount.mul(3)),
             oracleCount: oracles.length,
@@ -2330,7 +2363,7 @@ describe('FluxAggregator', () => {
             eligibleToSubmit: false,
             roundId: 3,
             latestSubmission: answer,
-            startedAt: ShouldNotBeUpdated,
+            startedAt: ShouldNotBeSet,
             timeout: 0,
             availableFunds: baseFunds.sub(paymentAmount.mul(3)),
             oracleCount: oracles.length,
@@ -2353,7 +2386,7 @@ describe('FluxAggregator', () => {
               eligibleToSubmit: false, // restart delay enforced
               roundId: 3,
               latestSubmission: answer,
-              startedAt: ShouldNotBeUpdated,
+              startedAt: ShouldNotBeSet,
               timeout: 0,
               availableFunds: baseFunds.sub(paymentAmount.mul(3)),
               oracleCount: oracles.length,
@@ -2388,7 +2421,7 @@ describe('FluxAggregator', () => {
             eligibleToSubmit: false,
             roundId: 3,
             latestSubmission: previousSubmission,
-            startedAt: ShouldNotBeUpdated,
+            startedAt: ShouldNotBeSet,
             timeout: 0, // details have been deleted
             availableFunds: baseFunds.sub(paymentAmount.mul(4)),
             oracleCount: oracles.length,
@@ -2422,7 +2455,7 @@ describe('FluxAggregator', () => {
             eligibleToSubmit: false,
             roundId: 3,
             latestSubmission: answer,
-            startedAt: ShouldNotBeUpdated,
+            startedAt: ShouldNotBeSet,
             timeout: 0,
             availableFunds: baseFunds.sub(paymentAmount.mul(4)),
             oracleCount: oracles.length,

--- a/evm-contracts/test/v0.6/FluxAggregator.test.ts
+++ b/evm-contracts/test/v0.6/FluxAggregator.test.ts
@@ -2159,14 +2159,14 @@ describe('FluxAggregator', () => {
           )
 
           await checkOracleRoundState(state, {
-            eligibleToSubmit: false, // FIXME
-            roundId: 2,
+            eligibleToSubmit: true,
+            roundId: 3,
             latestSubmission: previousSubmission,
-            startedAt: ShouldBeUpdated,
+            startedAt: ShouldNotBeUpdated,
             timeout: 0,
             availableFunds: baseFunds.sub(paymentAmount.mul(4)),
             oracleCount: oracles.length,
-            paymentAmount: 0,
+            paymentAmount,
           })
         })
       })
@@ -2386,13 +2386,13 @@ describe('FluxAggregator', () => {
 
           await checkOracleRoundState(state, {
             eligibleToSubmit: false,
-            roundId: 2,
+            roundId: 3,
             latestSubmission: previousSubmission,
-            startedAt: ShouldBeUpdated,
+            startedAt: ShouldNotBeUpdated,
             timeout: 0, // details have been deleted
             availableFunds: baseFunds.sub(paymentAmount.mul(4)),
             oracleCount: oracles.length,
-            paymentAmount: 0, // deltails have been deleted
+            paymentAmount,
           })
         })
       })


### PR DESCRIPTION
I couldn't find a good way to make this table driven, so there is a fair amount of duplication, but I tried to DRY it up with some test helpers. I tried to cover a few branches of options, in this order:

Restart Delay Enforced: (`yes`, `no`)
	----- Submissions: (`< min`, `>= min && < max`, `>= max`)
		---------- Timed Out: (`yes`, `no`)