### PR TITLE
Speed up job runs page

### DIFF
--- a/explorer/src/controllers/jobRuns.ts
+++ b/explorer/src/controllers/jobRuns.ts
@@ -1,6 +1,6 @@
 import { getCustomRepository } from 'typeorm'
 import { Router, Request, Response } from 'express'
-import { search, count, SearchParams } from '../queries/search'
+import { search, SearchParams } from '../queries/search'
 import jobRunsSerializer from '../serializers/jobRunsSerializer'
 import jobRunSerializer from '../serializers/jobRunSerializer'
 import { JobRunRepository } from '../repositories/JobRunRepository'
@@ -19,9 +19,8 @@ const searchParams = (req: Request): SearchParams => {
 
 router.get('/job_runs', async (req: Request, res: Response) => {
   const params = searchParams(req)
-  const runs = await search(params)
-  const runCount = await count(params)
-  const json = jobRunsSerializer(runs, runCount)
+  const { results, totalRecords } = await search(params)
+  const json = jobRunsSerializer(results, totalRecords)
   return res.send(json)
 })
 

--- a/explorer/src/migration/1588016794171-SpeedUpJobRunSearch.ts
+++ b/explorer/src/migration/1588016794171-SpeedUpJobRunSearch.ts
@@ -1,18 +1,16 @@
-import {MigrationInterface, QueryRunner} from "typeorm";
+import { MigrationInterface, QueryRunner } from 'typeorm'
 
 export class SpeedUpJobRunSearch1588016794171 implements MigrationInterface {
-
-    public async up(queryRunner: QueryRunner): Promise<any> {
-      await queryRunner.query(`
+  public async up(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
         CREATE INDEX "job_run_searchable_addresses" ON "job_run" USING GIN
           ((ARRAY["job_run"."runId","job_run"."jobId","job_run"."requestId","job_run"."requester", "job_run"."txHash"]));
       `)
-    }
+  }
 
-    public async down(queryRunner: QueryRunner): Promise<any> {
-      await queryRunner.query(`
+  public async down(queryRunner: QueryRunner): Promise<any> {
+    await queryRunner.query(`
         DROP INDEX "job_run_searchable_addresses";
       `)
-    }
-
+  }
 }

--- a/explorer/src/migration/1588016794171-SpeedUpJobRunSearch.ts
+++ b/explorer/src/migration/1588016794171-SpeedUpJobRunSearch.ts
@@ -1,0 +1,18 @@
+import {MigrationInterface, QueryRunner} from "typeorm";
+
+export class SpeedUpJobRunSearch1588016794171 implements MigrationInterface {
+
+    public async up(queryRunner: QueryRunner): Promise<any> {
+      await queryRunner.query(`
+        CREATE INDEX "job_run_searchable_addresses" ON "job_run" USING GIN
+          ((ARRAY["job_run"."runId","job_run"."jobId","job_run"."requestId","job_run"."requester", "job_run"."txHash"]));
+      `)
+    }
+
+    public async down(queryRunner: QueryRunner): Promise<any> {
+      await queryRunner.query(`
+        DROP INDEX "job_run_searchable_addresses";
+      `)
+    }
+
+}


### PR DESCRIPTION
- Add GIN index for searching across multiple fields
- Reduce 2 queries down to 1 by including count