### PR TITLE
Remove behavior to mimic mining in parity-ts test

### DIFF
--- a/tools/ci-ts/test-helpers/common.ts
+++ b/tools/ci-ts/test-helpers/common.ts
@@ -218,32 +218,6 @@ export async function txWait(
 }
 
 /**
- * forces parity to mimic geth's behavior of mining a block every two seconds, by broadcasting a transaction
- * at the same interval from the provided account
- * @param wallet the account to send transactions from
- * @param interval the target interval at which to send those transactions
- */
-export function setRecurringTx(wallet: ethers.Wallet, interval = 2000): number {
-  let waitingForTx = false
-
-  const maybeBroadcast = async () => {
-    if (waitingForTx) return
-    waitingForTx = true
-    const receipt = wallet
-      .sendTransaction({
-        to: ethers.constants.AddressZero,
-        value: 0,
-      })
-      .then(txWait)
-    const timer = wait(interval)
-    await Promise.all([receipt, timer])
-    waitingForTx = false
-  }
-
-  return (setInterval(maybeBroadcast, 100) as unknown) as number
-}
-
-/**
  * adds a listener to the provided contract to watch for the provided
  * events; automatically parses the log data, logs the event emissions,
  * and logs the values of the event data

--- a/tools/ci-ts/tests/flux-monitor.test.ts
+++ b/tools/ci-ts/tests/flux-monitor.test.ts
@@ -64,7 +64,6 @@ let linkToken: contract.Instance<contract.LinkTokenFactory>
 let fluxAggregator: contract.Instance<FluxAggregatorFactory>
 let node1Address: string
 let node2Address: string
-let txInterval: number | undefined
 
 async function assertAggregatorValues(
   latestAnswer: number,
@@ -110,14 +109,6 @@ beforeAll(async () => {
   linkToken = await linkTokenFactory.deploy()
   await linkToken.deployed()
 
-  // FIXME: force parity to "mine" block every 2 seconds
-  // www.pivotaltracker.com/story/show/172321994
-  if (!process.env.GETH_MODE) {
-    const miner = ethers.Wallet.createRandom().connect(provider)
-    await t.fundAddress(miner.address)
-    txInterval = t.setRecurringTx(miner)
-  }
-
   console.log(`Chainlink Node 1 address: ${node1Address}`)
   console.log(`Chainlink Node 2 address: ${node2Address}`)
   console.log(`Contract creator's address: ${carol.address}`)
@@ -148,10 +139,6 @@ afterEach(async () => {
     t.changePriceFeed(EXTERNAL_ADAPTER_2_URL, 100),
   ])
   fluxAggregator.removeAllListeners('*')
-})
-
-afterAll(() => {
-  clearInterval(txInterval)
 })
 
 describe('FluxMonitor / FluxAggregator integration with one node', () => {


### PR DESCRIPTION
Addresses [#172321994](https://www.pivotaltracker.com/story/show/172321994)

This bug is no longer present after most recent roundState and fluxmonitor refactoring.