### PR TITLE
Add linter checks at the beginning of go-postgres CI test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -329,6 +329,7 @@ jobs:
     steps:
       - checkout
       - run: echo $CACHE_VERSION > cache.version
+      - run: ./tools/ci/go_linters
       - restore_cache:
           name: Restore Yarn Package Cache
           key: v{{ checksum "cache.version" }}-yarn-vendor-{{ checksum "yarn.lock" }}

--- a/tools/ci/go_linters
+++ b/tools/ci/go_linters
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+set -e
+
+pushd /tmp > /dev/null
+go get golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow
+go get golang.org/x/tools/cmd/goimports
+popd > /dev/null
+
+go mod download > /dev/null # Prevent this output during `go vet`
+
+echo "Checking for shadowed variables in golang files."
+echo "You can run this command locally with the following commands:"
+echo "  (cd /tmp; go install golang.org/x/tools/go/analysis/passes/shadow/cmd/shadow)"
+# shellcheck disable=SC2016
+echo '  go vet -vettool="$(which shadow)" ./core/...'
+go vet -vettool="$(which shadow)" ./core/...
+echo "Success: No shadowed variables reported."
+
+echo
+# shellcheck disable=SC2016
+echo 'Linting golang files with `go vet ./core/...`'
+go vet ./core/...
+# shellcheck disable=SC2016
+echo 'Success: No complaints from `go vet ./core/...`'
+
+echo
+# shellcheck disable=SC2016
+echo 'Checking for malformatted code/import inconsistencies with `goimports -l ./core`'
+malformed_files="$(goimports -l ./core)"
+if [ -n "$malformed_files" ]; then
+    echo "goimports reported issues with the following files:"
+    echo
+    echo "$malformed_files"
+    echo
+    # shellcheck disable=SC2016
+    echo 'Please run `goimports -w .` locally, and incorporate the resulting '
+    echo "changes into your branch."
+    echo
+    echo "You may need to install goimports locally with the command"
+    # shellcheck disable=SC2016
+    echo '`go get golang.org/x/tools/cmd/goimports`'
+    exit 1
+fi
+echo "Success: No complaints from goimports"
+echo


### PR DESCRIPTION
This adds the existing golang linter tests to the `lint` CI test. Output on success is [in the `
./tools/ci/go_linters` stanza](https://circleci.com/gh/smartcontractkit/chainlink/164682).

It may make sense to add the `shadow` and `goimports` packages to the builder image, instead of installing them here.

It may make sense to make this a github action, instead of a CircleCI test.