### PR TITLE
Add absolute-threshold check to fluxmonitor initiator

### DIFF
--- a/CHANGELOG-core.md
+++ b/CHANGELOG-core.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 New cron strings MUST now include time zone. If you want your jobs to run in UTC for example: `CRON_TZ=UTC * * * * *`. Previously, jobs specified without a time zone would run in the server's native time zone, which in most cases is UTC but this was never guaranteed.
 
+### New features
+
+Fluxmonitor initiators may now optionally include an `absoluteThreshold`
+parameter. To trigger a new on-chain report, the absolute difference in the feed
+value must change by at least the `absoluteThreshold` value. If it is
+unspecified or zero, fluxmonitor behavior is unchanged.
+
 ### Added
 - Added Changelog
 

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -148,10 +148,11 @@ func NewJobWithFluxMonitorInitiator() models.JobSpec {
 		JobSpecID: j.ID,
 		Type:      models.InitiatorFluxMonitor,
 		InitiatorParams: models.InitiatorParams{
-			Address:     NewAddress(),
-			RequestData: models.JSON{Result: gjson.Parse(`{"data":{"coin":"ETH","market":"USD"}}`)},
-			Feeds:       models.JSON{Result: gjson.Parse(`["https://lambda.staging.devnet.tools/bnc/call"]`)},
-			Threshold:   0.5,
+			Address:           NewAddress(),
+			RequestData:       models.JSON{Result: gjson.Parse(`{"data":{"coin":"ETH","market":"USD"}}`)},
+			Feeds:             models.JSON{Result: gjson.Parse(`["https://lambda.staging.devnet.tools/bnc/call"]`)},
+			Threshold:         0.5,
+			AbsoluteThreshold: 0.01,
 			IdleTimer: models.IdleTimerConfig{
 				Duration: models.MustMakeDuration(time.Minute),
 			},
@@ -171,11 +172,12 @@ func NewJobWithFluxMonitorInitiatorWithBridge() models.JobSpec {
 		JobSpecID: j.ID,
 		Type:      models.InitiatorFluxMonitor,
 		InitiatorParams: models.InitiatorParams{
-			Address:     NewAddress(),
-			RequestData: models.JSON{Result: gjson.Parse(`{"data":{"coin":"ETH","market":"USD"}}`)},
-			Feeds:       models.JSON{Result: gjson.Parse(`[{"bridge":"testbridge"}]`)},
-			Threshold:   0.5,
-			Precision:   2,
+			Address:           NewAddress(),
+			RequestData:       models.JSON{Result: gjson.Parse(`{"data":{"coin":"ETH","market":"USD"}}`)},
+			Feeds:             models.JSON{Result: gjson.Parse(`[{"bridge":"testbridge"}]`)},
+			Threshold:         0.5,
+			AbsoluteThreshold: 0.01,
+			Precision:         2,
 		},
 	}}
 	return j

--- a/core/internal/testdata/flux_monitor_job.json
+++ b/core/internal/testdata/flux_monitor_job.json
@@ -7,8 +7,11 @@
         "data":{"coin":"ETH","market":"USD"}
       },
       "feeds": [ "https://lambda.staging.devnet.tools/bnc/call" ],
-      "precision": 2,
+      "_comment": "if the relative change in the answer exceeds threshold, a new round is started",
       "threshold": 0.5,
+      "_comment": "if the absolute change in the answer exceeds absoluteThreshold, a new round is started",
+      "absoluteThreshold": 0.01,
+      "precision": 2,
       "idleTimer": {
         "duration": "1h"
       },

--- a/core/services/fluxmonitor/helpers_test.go
+++ b/core/services/fluxmonitor/helpers_test.go
@@ -24,8 +24,8 @@ func ExportedSetCheckerFactory(fm Service, fac DeviationCheckerFactory) {
 	impl.checkerFactory = fac
 }
 
-func (p *PollingDeviationChecker) ExportedPollIfEligible(threshold float64) bool {
-	return p.pollIfEligible(threshold)
+func (p *PollingDeviationChecker) ExportedPollIfEligible(threshold, absoluteThreshold float64) bool {
+	return p.pollIfEligible(DeviationThresholds{Rel: threshold, Abs: absoluteThreshold})
 }
 
 func (p *PollingDeviationChecker) ExportedSetStoredReportableRoundID(roundID *big.Int) {

--- a/core/services/validators.go
+++ b/core/services/validators.go
@@ -131,7 +131,20 @@ func validateFluxMonitor(i models.Initiator, j models.JobSpec, store *store.Stor
 		fe.Add("no requestdata")
 	}
 	if i.Threshold <= 0 {
-		fe.Add("threshold must be > 0")
+		fe.Add("bad 'threshold' parameter; this is the maximum relative change " +
+			"allowed in the monitored value, before a new report should be made; " +
+			"it must be positive, and appear in the job initiator parameters; e.g." +
+			`{"initiators": [{"type":"fluxmonitor", "params":{"threshold": 0.5}}]} ` +
+			"means that the value can change by up to half its last-reported value " +
+			"before a new report is made")
+	}
+	if i.AbsoluteThreshold < 0 {
+		fe.Add("bad 'absoluteThreshold' value; this is the maximum absolute " +
+			"change allowed in the monitored value, before a new report should be " +
+			"made; it must be nonnegative and appear in the job initiator parameters; e.g." +
+			`{"initiators":[{"type":"fluxmonitor","params":{"absoluteThreshold":0.01}}]} ` +
+			"means that the value can change by up to 0.01 units " +
+			"before a new report is made")
 	}
 
 	if i.PollTimer.Disabled && i.IdleTimer.Disabled {

--- a/core/services/validators_test.go
+++ b/core/services/validators_test.go
@@ -418,7 +418,7 @@ func TestValidateInitiator_FluxMonitorErrors(t *testing.T) {
 		{"address", cltest.MustJSONDel(t, validInitiator, "params.address")},
 		{"feeds", cltest.MustJSONSet(t, validInitiator, "params.feeds", []string{})},
 		{"threshold", cltest.MustJSONDel(t, validInitiator, "params.threshold")},
-		{"threshold must be > 0", cltest.MustJSONSet(t, validInitiator, "params.threshold", -5)},
+		{"must be positive", cltest.MustJSONSet(t, validInitiator, "params.threshold", -5)},
 		{"requestdata", cltest.MustJSONDel(t, validInitiator, "params.requestdata")},
 		{"pollTimer enabled, but no period specified", cltest.MustJSONDel(t, validInitiator, "params.pollTimer.period")},
 		{"period must be equal or greater than 15s", cltest.MustJSONSet(t, validInitiator, "params.pollTimer.period", "1s")},

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -44,6 +44,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1586956053"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1587027516"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1587580235"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1587591248"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1587975059"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1588088353"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1588293486"
@@ -211,6 +212,10 @@ func init() {
 		{
 			ID:      "1587580235",
 			Migrate: migration1587580235.Migrate,
+		},
+		{
+			ID:      "1587591248",
+			Migrate: migration1587591248.Migrate,
 		},
 		{
 			ID:      "1587975059",

--- a/core/store/migrations/migration1587591248/migrate.go
+++ b/core/store/migrations/migration1587591248/migrate.go
@@ -1,0 +1,11 @@
+package migration1587591248
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate changes all json columns to be jsonb
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(
+		`ALTER TABLE initiators ADD COLUMN "absolute_threshold" float;`).Error
+}

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -217,12 +217,16 @@ type InitiatorParams struct {
 	ToBlock    *utils.Big        `json:"toBlock,omitempty" gorm:"type:varchar(255)"`
 	Topics     Topics            `json:"topics,omitempty"`
 
-	RequestData JSON            `json:"requestData,omitempty" gorm:"type:text"`
-	Feeds       Feeds           `json:"feeds,omitempty" gorm:"type:text"`
-	Precision   int32           `json:"precision,omitempty" gorm:"type:smallint"`
-	Threshold   float32         `json:"threshold,omitempty"`
-	PollTimer   PollTimerConfig `json:"pollTimer,omitempty" gorm:"type:jsonb"`
-	IdleTimer   IdleTimerConfig `json:"idleTimer,omitempty" gorm:"type:jsonb"`
+	RequestData JSON    `json:"requestData,omitempty" gorm:"type:text"`
+	Feeds       Feeds   `json:"feeds,omitempty" gorm:"type:text"`
+	Precision   int32   `json:"precision,omitempty" gorm:"type:smallint"`
+	Threshold   float32 `json:"threshold,omitempty"`
+	// AbsoluteThreshold is the maximum absolute change allowed in a fluxmonitored
+	// value before a new round should be kicked off, so that the current value
+	// can be reported on-chain.
+	AbsoluteThreshold float32         `json:"absoluteThreshold" gorm:"type:float;not null"`
+	PollTimer         PollTimerConfig `json:"pollTimer,omitempty" gorm:"type:jsonb"`
+	IdleTimer         IdleTimerConfig `json:"idleTimer,omitempty" gorm:"type:jsonb"`
 }
 
 type PollTimerConfig struct {

--- a/core/store/models/job_spec_test.go
+++ b/core/store/models/job_spec_test.go
@@ -49,8 +49,9 @@ func TestNewInitiatorFromRequest(t *testing.T) {
 					PollTimer: models.PollTimerConfig{
 						Period: models.MustMakeDuration(1 * time.Minute),
 					},
-					Precision: 2,
-					Threshold: 5,
+					Precision:         2,
+					Threshold:         5,
+					AbsoluteThreshold: 0.01,
 				},
 			},
 			jobSpec: job,
@@ -64,8 +65,9 @@ func TestNewInitiatorFromRequest(t *testing.T) {
 					PollTimer: models.PollTimerConfig{
 						Period: models.MustMakeDuration(1 * time.Minute),
 					},
-					Precision: 2,
-					Threshold: 5,
+					Precision:         2,
+					Threshold:         5,
+					AbsoluteThreshold: 0.01,
 				},
 			},
 		},
@@ -104,20 +106,21 @@ func TestInitiatorParams(t *testing.T) {
 	i := models.Initiator{
 		JobSpecID: j.ID,
 		InitiatorParams: models.InitiatorParams{
-			Schedule:    schedule,
-			Time:        time,
-			Ran:         true,
-			Address:     address,
-			Requesters:  requesters,
-			Name:        "foo",
-			Body:        &json,
-			FromBlock:   big,
-			ToBlock:     big,
-			Topics:      topics,
-			RequestData: json,
-			Feeds:       json,
-			Threshold:   42.42,
-			Precision:   42,
+			Schedule:          schedule,
+			Time:              time,
+			Ran:               true,
+			Address:           address,
+			Requesters:        requesters,
+			Name:              "foo",
+			Body:              &json,
+			FromBlock:         big,
+			ToBlock:           big,
+			Topics:            topics,
+			RequestData:       json,
+			Feeds:             json,
+			Threshold:         42.42,
+			AbsoluteThreshold: 54, // https://spooniom.com/6-9-42/
+			Precision:         42,
 			IdleTimer: models.IdleTimerConfig{
 				Duration: duration,
 			},
@@ -146,6 +149,8 @@ func TestInitiatorParams(t *testing.T) {
 	assert.Equal(t, duration, saved.InitiatorParams.IdleTimer.Duration)
 	assert.Equal(t, json, saved.InitiatorParams.Feeds)
 	assert.Equal(t, float32(42.42), saved.InitiatorParams.Threshold)
+	assert.Equal(t, i.InitiatorParams.AbsoluteThreshold,
+		saved.InitiatorParams.AbsoluteThreshold)
 	assert.Equal(t, int32(42), saved.InitiatorParams.Precision)
 	assert.Equal(t, duration, saved.InitiatorParams.PollTimer.Period)
 

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -379,13 +379,15 @@ func initiatorParams(i Initiator) (interface{}, error) {
 		}{i.Name}, nil
 	case models.InitiatorFluxMonitor:
 		return struct {
-			Address         common.Address  `json:"address"`
-			RequestData     models.JSON     `json:"requestData"`
-			Feeds           models.JSON     `json:"feeds"`
-			Threshold       float32         `json:"threshold"`
-			Precision       int32           `json:"precision"`
-			PollingInterval models.Duration `json:"pollingInterval"`
-		}{i.Address, i.RequestData, i.Feeds, i.Threshold, i.Precision, i.PollTimer.Period}, nil
+			Address           common.Address  `json:"address"`
+			RequestData       models.JSON     `json:"requestData"`
+			Feeds             models.JSON     `json:"feeds"`
+			Threshold         float32         `json:"threshold"`
+			AbsoluteThreshold float32         `json:"absoluteThreshold"`
+			Precision         int32           `json:"precision"`
+			PollingInterval   models.Duration `json:"pollingInterval"`
+		}{i.Address, i.RequestData, i.Feeds, i.Threshold, i.AbsoluteThreshold,
+			i.Precision, i.PollTimer.Period}, nil
 	case models.InitiatorRandomnessLog:
 		return struct{ Address common.Address }{i.Address}, nil
 	default:

--- a/tools/ci-ts/fixtures/flux-monitor-job.ts
+++ b/tools/ci-ts/fixtures/flux-monitor-job.ts
@@ -13,6 +13,7 @@ export default {
         feeds: [''], // set before use
         precision: 2,
         threshold: 5,
+        absoluteThreshold: 0,
         idleTimer: {
           disabled: true,
         },


### PR DESCRIPTION
This addresses the concern about feeds with values roughly the same size as their variance (which would trigger lots of uninformative updates) by adding an *absolute* threshold parameter which the feed value must also change by. The default absolute threshold value of 0 means that the absolute threshold always triggers, so it degenerates to the old behavior for the relative threshold. (Though it returns false if both the old and new values are zero, since in that case the relative difference is undefined.)