### PR TITLE
Remove unnecessary COPY directive for Heroku FeedsUI build

### DIFF
--- a/Dockerfile.web
+++ b/Dockerfile.web
@@ -19,8 +19,6 @@ COPY --from=builder /app/feeds/node_modules feeds/node_modules
 COPY --from=builder /app/feeds/package.json feeds/package.json
 COPY --from=builder /app/feeds/server.js feeds/server.js
 COPY --from=builder /app/feeds/src feeds/src
-COPY --from=builder /app/feeds/src/feeds.json feeds/build/feeds.json
-COPY --from=builder /app/feeds/src/nodes.json feeds/build/nodes.json
 COPY --from=builder /app/feeds/public feeds/public
 COPY --from=builder /app/feeds/build feeds/build
 

--- a/feeds/README.md
+++ b/feeds/README.md
@@ -72,7 +72,7 @@ Build and push a new image from the root of the monorepo
 $ heroku container:push --recursive --arg REACT_APP_INFURA_KEY=abc123,REACT_APP_GA_ID=abc123 REACT_APP_FEEDS_JSON=https://feeds.chain.link/feeds.json REACT_APP_NODES_JSON=https://feeds.chain.link/nodes.json -a the-app-name
 
 # If the config vars are stored in Heroku, you can capture the output in a subshell
-$ heroku container:push --recursive --arg REACT_APP_INFURA_KEY=$(heroku config:get REACT_APP_INFURA_KEY -a the-app-name),REACT_APP_GA_ID=$(heroku config:get REACT_APP_GA_ID -a the-app-name),REACT_APP_FEEDS_JSON=$(heroku config:get REACT_APP_FEEDS_JSON -a the-app-name,REACT_APP_NODES_JSON=$(heroku config:get REACT_APP_NODES_JSON -a the-app-name) -a the-app-name
+$ heroku container:push --recursive --arg REACT_APP_INFURA_KEY=$(heroku config:get REACT_APP_INFURA_KEY -a the-app-name),REACT_APP_GA_ID=$(heroku config:get REACT_APP_GA_ID -a the-app-name),REACT_APP_FEEDS_JSON=$(heroku config:get REACT_APP_FEEDS_JSON -a the-app-name),REACT_APP_NODES_JSON=$(heroku config:get REACT_APP_NODES_JSON -a the-app-name) -a the-app-name
 ```
 
 Deploy the newly built image by releasing the container from the root of the monorepo


### PR DESCRIPTION
It's now part of the `public` directory