### PR TITLE
v0.6: typo OwnershipTransfered to OwnershipTransferred

### DIFF
--- a/evm-contracts/src/v0.6/Owned.sol
+++ b/evm-contracts/src/v0.6/Owned.sol
@@ -13,7 +13,7 @@ contract Owned {
     address indexed from,
     address indexed to
   );
-  event OwnershipTransfered(
+  event OwnershipTransferred(
     address indexed from,
     address indexed to
   );
@@ -47,7 +47,7 @@ contract Owned {
     owner = msg.sender;
     pendingOwner = address(0);
 
-    emit OwnershipTransfered(oldOwner, msg.sender);
+    emit OwnershipTransferred(oldOwner, msg.sender);
   }
 
   /**

--- a/evm-contracts/test/v0.6/Owned.test.ts
+++ b/evm-contracts/test/v0.6/Owned.test.ts
@@ -104,7 +104,7 @@ describe('Owned', () => {
         const tx = await owned.connect(newOwner).acceptOwnership()
         const receipt = await tx.wait()
 
-        const event = h.findEventIn(receipt, ownedEvents.OwnershipTransfered)
+        const event = h.findEventIn(receipt, ownedEvents.OwnershipTransferred)
         expect(h.eventArgs(event).to).toEqual(newOwner.address)
         expect(h.eventArgs(event).from).toEqual(owner.address)
       })


### PR DESCRIPTION
Saw a small typo in v0.6 and thought I'd help catch it early
There's an extra "r" on OwnershipTransferred