### PR TITLE
Display error message on sign in form when server is down

### DIFF
--- a/explorer/client/src/actions/helpers.ts
+++ b/explorer/client/src/actions/helpers.ts
@@ -2,6 +2,7 @@ import * as jsonapi from '@chainlink/json-api-client'
 import { Action } from 'redux'
 import { ThunkAction } from 'redux-thunk'
 import { AppState } from '../reducers'
+import { FetchAdminSignoutSucceededAction } from '../reducers/actions'
 
 /**
  * Extract the inner type of a promise if any
@@ -60,16 +61,14 @@ export function request<
           const data = normalizeData(json)
           dispatch({ type: `FETCH_${type}_SUCCEEDED`, data })
         })
-        .catch((error: Error) => {
-          dispatch({ type: `FETCH_${type}_ERROR`, error })
+        .catch(e => {
+          dispatch({ type: `FETCH_${type}_ERROR`, errors: e.errors })
 
-          if (error instanceof jsonapi.AuthenticationError) {
-            dispatch({ type: 'FETCH_ADMIN_SIGNOUT_SUCCEEDED' })
-          } else {
-            dispatch({
-              type: 'NOTIFY_ERROR',
-              error,
-            })
+          if (e instanceof jsonapi.AuthenticationError) {
+            const fetchAdminSignoutSucceededAction: FetchAdminSignoutSucceededAction = {
+              type: 'FETCH_ADMIN_SIGNOUT_SUCCEEDED',
+            }
+            dispatch(fetchAdminSignoutSucceededAction)
           }
         })
     }

--- a/explorer/client/src/components/Forms/SignIn.tsx
+++ b/explorer/client/src/components/Forms/SignIn.tsx
@@ -32,6 +32,7 @@ const styles = ({ palette, spacing }: Theme) =>
     error: {
       backgroundColor: palette.error.light,
       marginTop: spacing.unit * 2,
+      padding: spacing.unit * 2,
     },
     errorText: {
       color: palette.error.main,
@@ -94,14 +95,12 @@ export const SignIn = withStyles(styles)(
                     return (
                       <Grid item xs={12} key={idx}>
                         <Card raised={false} className={classes.error}>
-                          <CardContent>
-                            <Typography
-                              variant="body1"
-                              className={classes.errorText}
-                            >
-                              {text}
-                            </Typography>
-                          </CardContent>
+                          <Typography
+                            variant="body1"
+                            className={classes.errorText}
+                          >
+                            {text}
+                          </Typography>
                         </Card>
                       </Grid>
                     )

--- a/explorer/client/src/containers/Admin/Header.tsx
+++ b/explorer/client/src/containers/Admin/Header.tsx
@@ -51,7 +51,6 @@ interface OwnProps {
 
 interface StateProps {
   authenticated: boolean
-  errors: string[]
 }
 
 interface Props
@@ -101,7 +100,6 @@ const mapStateToProps: MapStateToProps<
 > = state => {
   return {
     authenticated: state.adminAuth.allowed,
-    errors: state.notifications.errors,
   }
 }
 

--- a/explorer/client/src/reducers/actions.ts
+++ b/explorer/client/src/reducers/actions.ts
@@ -1,11 +1,4 @@
-/**
- * NOTIFY_ERROR
- */
-
-export interface NotifyErrorAction {
-  type: 'NOTIFY_ERROR'
-  text: string
-}
+import * as jsonapi from '@chainlink/json-api-client'
 
 /**
  * ADMIN_SIGNIN_SUCCEEDED
@@ -24,7 +17,7 @@ export interface FetchAdminSigninSucceededAction {
 
 export interface FetchAdminSigninErrorAction {
   type: 'FETCH_ADMIN_SIGNIN_ERROR'
-  error: Error
+  errors: jsonapi.ErrorItem[]
 }
 
 /**
@@ -72,7 +65,7 @@ export type FetchAdminOperatorsSucceededAction = {
 
 export type FetchAdminOperatorsErrorAction = {
   type: 'FETCH_ADMIN_OPERATORS_ERROR'
-  error: Error
+  errors: jsonapi.ErrorItem[]
 }
 
 /**
@@ -109,7 +102,7 @@ export type FetchAdminOperatorSucceededAction = {
 
 export type FetchAdminOperatorErrorAction = {
   type: 'FETCH_ADMIN_OPERATOR_ERROR'
-  error: Error
+  errors: jsonapi.ErrorItem[]
 }
 
 /**
@@ -149,7 +142,7 @@ export interface AdminHeadsNormalizedData {
 
 export type FetchAdminHeadsErrorAction = {
   type: 'FETCH_ADMIN_HEADS_ERROR'
-  error: Error
+  errors: jsonapi.ErrorItem[]
 }
 
 /**
@@ -186,7 +179,7 @@ export type FetchAdminHeadSucceededAction = {
 
 export type FetchAdminHeadErrorAction = {
   type: 'FETCH_ADMIN_HEAD_ERROR'
-  error: Error
+  errors: jsonapi.ErrorItem[]
 }
 
 /**
@@ -227,7 +220,7 @@ export type FetchJobRunsSucceededAction = {
 
 export type FetchJobRunsErrorAction = {
   type: 'FETCH_JOB_RUNS_ERROR'
-  error: Error
+  errors: jsonapi.ErrorItem[]
 }
 
 /**
@@ -264,7 +257,7 @@ export interface FetchJobRunSucceededAction {
 
 export type FetchJobRunErrorAction = {
   type: 'FETCH_JOB_RUN_ERROR'
-  error: Error
+  errors: jsonapi.ErrorItem[]
 }
 
 /**
@@ -277,7 +270,6 @@ export interface UpdateQueryAction {
 }
 
 export type Actions =
-  | NotifyErrorAction
   | FetchAdminSigninSucceededAction
   | FetchAdminSigninErrorAction
   | FetchAdminSignoutSucceededAction

--- a/explorer/client/src/reducers/adminHeads.test.ts
+++ b/explorer/client/src/reducers/adminHeads.test.ts
@@ -76,7 +76,12 @@ describe('reducers/adminHeads', () => {
   describe('FETCH_ADMIN_HEADS_ERROR', () => {
     const action: FetchAdminHeadsErrorAction = {
       type: 'FETCH_ADMIN_HEADS_ERROR',
-      error: new Error('An error'),
+      errors: [
+        {
+          status: 500,
+          detail: 'An error',
+        },
+      ],
     }
 
     it('sets loading to false', () => {

--- a/explorer/client/src/reducers/adminOperators.test.ts
+++ b/explorer/client/src/reducers/adminOperators.test.ts
@@ -81,7 +81,12 @@ describe('reducers/adminOperators', () => {
   describe('FETCH_ADMIN_OPERATORS_ERROR', () => {
     const action: FetchAdminOperatorsErrorAction = {
       type: 'FETCH_ADMIN_OPERATORS_ERROR',
-      error: new Error('An error'),
+      errors: [
+        {
+          status: 500,
+          detail: 'An error',
+        },
+      ],
     }
 
     it('sets loading to false', () => {

--- a/explorer/client/src/reducers/jobRuns.test.ts
+++ b/explorer/client/src/reducers/jobRuns.test.ts
@@ -83,7 +83,12 @@ describe('reducers/jobRuns', () => {
   describe('FETCH_JOB_RUNS_ERROR', () => {
     const action: FetchJobRunsErrorAction = {
       type: 'FETCH_JOB_RUNS_ERROR',
-      error: new Error('An error'),
+      errors: [
+        {
+          status: 500,
+          detail: 'An error',
+        },
+      ],
     }
 
     it('sets loading to false', () => {
@@ -149,7 +154,12 @@ describe('reducers/jobRuns', () => {
   describe('FETCH_JOB_RUN_ERROR', () => {
     const action: FetchJobRunErrorAction = {
       type: 'FETCH_JOB_RUN_ERROR',
-      error: new Error('An error'),
+      errors: [
+        {
+          status: 500,
+          detail: 'An error',
+        },
+      ],
     }
 
     it('sets loading to false', () => {

--- a/explorer/client/src/reducers/notifications.test.ts
+++ b/explorer/client/src/reducers/notifications.test.ts
@@ -1,21 +1,40 @@
-import * as jsonapi from '@chainlink/json-api-client'
-import { partialAsFull } from '@chainlink/ts-helpers'
 import reducer, { INITIAL_STATE } from '../reducers'
 import { FetchAdminSigninErrorAction } from '../reducers/actions'
 
-describe('reducers/jobRuns', () => {
+describe('reducers/notifications', () => {
   describe('FETCH_ADMIN_SIGNIN_ERROR', () => {
-    it('adds a notification for AuthenticationError', () => {
-      const response = partialAsFull<Response>({})
+    it('adds a notification for invalid credentials', () => {
       const action: FetchAdminSigninErrorAction = {
         type: 'FETCH_ADMIN_SIGNIN_ERROR',
-        error: new jsonapi.AuthenticationError(response),
+        errors: [{ status: 401, detail: 'Unauthorized' }],
       }
       const state = reducer(INITIAL_STATE, action)
 
       expect(state.notifications.errors).toEqual([
-        'Invalid username and password.',
+        'Invalid username and password',
       ])
+    })
+
+    it("adds a notification when the server can't process the request", () => {
+      const action: FetchAdminSigninErrorAction = {
+        type: 'FETCH_ADMIN_SIGNIN_ERROR',
+        errors: [{ status: 500, detail: 'Internal Server Error' }],
+      }
+      const state = reducer(INITIAL_STATE, action)
+
+      expect(state.notifications.errors).toEqual([
+        'Error processing your request. Please ensure your connection is active and try again',
+      ])
+    })
+
+    it('adds a notification with a pass through message by default', () => {
+      const action: FetchAdminSigninErrorAction = {
+        type: 'FETCH_ADMIN_SIGNIN_ERROR',
+        errors: [{ status: 404, detail: 'Not Found' }],
+      }
+      const state = reducer(INITIAL_STATE, action)
+
+      expect(state.notifications.errors).toEqual(['Not Found'])
     })
   })
 })

--- a/explorer/client/src/reducers/notifications.ts
+++ b/explorer/client/src/reducers/notifications.ts
@@ -1,4 +1,3 @@
-import * as jsonapi from '@chainlink/json-api-client'
 import { Actions } from './actions'
 import { Reducer } from 'redux'
 
@@ -13,21 +12,20 @@ const notificationsReducer: Reducer<State, Actions> = (
   action,
 ) => {
   switch (action.type) {
-    case 'FETCH_ADMIN_SIGNIN_ERROR':
-      if (isUnauthorized(action.error)) {
-        return { errors: ['Invalid username and password.'] }
-      }
-
-      return state
-    case 'NOTIFY_ERROR':
-      return { errors: [action.text] }
+    case 'FETCH_ADMIN_SIGNIN_ERROR': {
+      const errors = action.errors.map(e => {
+        if (e.status === 500) {
+          return 'Error processing your request. Please ensure your connection is active and try again'
+        } else if (e.status === 401) {
+          return 'Invalid username and password'
+        }
+        return e.detail
+      })
+      return { errors }
+    }
     default:
       return state
   }
-}
-
-function isUnauthorized(error: Error) {
-  return error instanceof jsonapi.AuthenticationError
 }
 
 export default notificationsReducer

--- a/tools/json-api-client/src/transport/json.ts
+++ b/tools/json-api-client/src/transport/json.ts
@@ -167,15 +167,22 @@ async function parseResponse<T>(response: Response): Promise<T> {
 }
 
 async function errorItems(response: Response): Promise<ErrorItem[]> {
-  const json = await response.json()
+  return response
+    .json()
+    .then(json => {
+      if (json.errors) {
+        return json.errors.map((e: ErrorsObject) => ({
+          status: response.status,
+          detail: e.detail,
+        }))
+      }
 
-  if (json.errors) {
-    return json.errors.map((e: ErrorsObject) => ({
-      status: response.status,
-      detail: e.detail,
-    }))
-  }
+      return defaultResponseErrors(response)
+    })
+    .catch(() => defaultResponseErrors(response))
+}
 
+function defaultResponseErrors(response: Response): ErrorItem[] {
   return [
     {
       status: response.status,


### PR DESCRIPTION
- Removes unrequired `NOTIFY_ERROR` action
- Notification reducer hydrates from the existing `_ERROR` action
- Ensures error actions are serializable

# SignIn Form Notification Errors

![Screen Shot 2020-05-08 at 5 15 13 PM](https://user-images.githubusercontent.com/680789/81458686-8ac81100-9150-11ea-99ba-da7a0f887dfe.png)
![Screen Shot 2020-05-08 at 5 14 23 PM](https://user-images.githubusercontent.com/680789/81458688-8e5b9800-9150-11ea-9ae9-a48ad33227e7.png)

# Errors within a Table

![Screen Shot 2020-05-08 at 5 16 14 PM](https://user-images.githubusercontent.com/680789/81458685-86035d00-9150-11ea-98f8-367bcfc19bb7.png)

