### PR TITLE
Fix geth contract wrapper failure handling

### DIFF
--- a/core/internal/gethwrappers/generation/abigen.sh
+++ b/core/internal/gethwrappers/generation/abigen.sh
@@ -46,6 +46,12 @@ else # Must use dockerized abigen
     DOCKER_IMAGE="ethereum/client-go:alltools-$GETH_VERSION"
     echo -n "Native abigen unavailable, broken, or wrong version (need version "
     echo "$GETH_VERSION). Invoking abigen from $DOCKER_IMAGE docker image."
+    echo
+    echo "If you want to install abigen natively into \$GOPATH/bin, run the following commands:"
+    echo "$ td=`mktemp -d`; pushd \"$td\""
+    echo "$ git clone https://github.com/ethereum/go-ethereum/"
+    echo "$ cd go-ethereum; git checkout $NATIVE_ABIGEN_VERSION; cd cmd/abigen"
+    echo "$ go install; popd; rm -rf \"$td\""
     CONTAINER_NAME_PATH="$(mktemp)"
     rm -f "$CONTAINER_NAME_PATH"
     docker run -v "${COMMON_PARENT_DIRECTORY}:${COMMON_PARENT_DIRECTORY}" \

--- a/core/internal/gethwrappers/go_generate_test.go
+++ b/core/internal/gethwrappers/go_generate_test.go
@@ -196,8 +196,7 @@ func init() {
 	}
 	fmt.Printf("some solidity artifacts missing (%s); rebuilding...",
 		solidityArtifactsMissing)
-	compileCmd := strings.Fields(compileCommand(nil))
-	cmd := exec.Command(compileCmd[0], compileCmd[1:]...)
+	cmd := exec.Command("bash", "-c", compileCommand(nil))
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {


### PR DESCRIPTION
This 

- Makes the `go generate` output more specific to `gethwrappers`, making errors easier to spot
- Accomodates a bashism in the solidity recompile command which was confusing `cmd.Exec` when a solidity compiler artifact could not be found.