### PR TITLE
BulletproofTxManager part 1: ethtx writes to table

### DIFF
--- a/core/adapters/bridge.go
+++ b/core/adapters/bridge.go
@@ -80,7 +80,7 @@ func (ba *Bridge) handleNewRun(input models.RunInput, meta *models.JSON, bridgeR
 		return models.NewRunOutputError(baRunResultError("post to external adapter", err))
 	}
 
-	input = *models.NewRunInput(input.JobRunID(), data, input.Status())
+	input = input.CloneWithData(data)
 	return ba.responseToRunResult(body, input)
 }
 

--- a/core/adapters/bridge_test.go
+++ b/core/adapters/bridge_test.go
@@ -93,6 +93,7 @@ func TestBridge_PerformAcceptsNonJsonObjectResponses(t *testing.T) {
 	defer cleanup()
 	store.Config.Set("BRIDGE_RESPONSE_URL", cltest.WebURL(t, ""))
 	jobRunID := models.NewID()
+	taskRunID := *models.NewID()
 
 	mock, cleanup := cltest.NewHTTPMockServer(t, http.StatusOK, "POST", fmt.Sprintf(`{"jobRunID": "%s", "data": 251990120, "statusCode": 200}`, jobRunID.String()),
 		func(h http.Header, b string) {},
@@ -103,7 +104,7 @@ func TestBridge_PerformAcceptsNonJsonObjectResponses(t *testing.T) {
 	params := cltest.JSONFromString(t, `{"bodyParam": true}`)
 	ba := &adapters.Bridge{BridgeType: *bt, Params: params}
 
-	input := *models.NewRunInput(jobRunID, cltest.JSONFromString(t, `{"jobRunID": "jobID", "data": 251990120, "statusCode": 200}`), models.RunStatusUnstarted)
+	input := *models.NewRunInput(jobRunID, taskRunID, cltest.JSONFromString(t, `{"jobRunID": "jobID", "data": 251990120, "statusCode": 200}`), models.RunStatusUnstarted)
 	result := ba.Perform(input, store)
 	require.NoError(t, result.Error())
 	assert.Equal(t, "251990120", result.Result().String())
@@ -132,7 +133,7 @@ func TestBridge_Perform_transitionsTo(t *testing.T) {
 			_, bt := cltest.NewBridgeType(t, "auctionBidding", mock.URL)
 			ba := &adapters.Bridge{BridgeType: *bt}
 
-			input := *models.NewRunInputWithResult(models.NewID(), "100", test.status)
+			input := *models.NewRunInputWithResult(models.NewID(), *models.NewID(), "100", test.status)
 			result := ba.Perform(input, store)
 
 			assert.Equal(t, test.result, result.Data().String())
@@ -164,6 +165,7 @@ func TestBridge_Perform_startANewRun(t *testing.T) {
 	defer cleanup()
 	store.Config.Set("BRIDGE_RESPONSE_URL", "")
 	runID := models.NewID()
+	taskRunID := *models.NewID()
 	wantedBody := fmt.Sprintf(`{"id":"%v","data":{"result":"lot 49"}}`, runID)
 
 	for _, test := range cases {
@@ -177,7 +179,7 @@ func TestBridge_Perform_startANewRun(t *testing.T) {
 			_, bt := cltest.NewBridgeType(t, "auctionBidding", mock.URL)
 			eb := &adapters.Bridge{BridgeType: *bt}
 
-			input := *models.NewRunInput(runID, cltest.JSONFromString(t, `{"result": "lot 49"}`), models.RunStatusUnstarted)
+			input := *models.NewRunInput(runID, taskRunID, cltest.JSONFromString(t, `{"result": "lot 49"}`), models.RunStatusUnstarted)
 			result := eb.Perform(input, store)
 			val := result.Result()
 			assert.Equal(t, test.want, val.String())

--- a/core/adapters/copy.go
+++ b/core/adapters/copy.go
@@ -24,6 +24,6 @@ func (c *Copy) Perform(input models.RunInput, store *store.Store) models.RunOutp
 	}
 
 	jp := JSONParse{Path: c.CopyPath}
-	input = *models.NewRunInput(input.JobRunID(), data, input.Status())
+	input = input.CloneWithData(data)
 	return jp.Perform(input, store)
 }

--- a/core/adapters/random_test.go
+++ b/core/adapters/random_test.go
@@ -48,7 +48,7 @@ func TestRandom_Perform(t *testing.T) {
 	require.NoError(t, err) // Can't fail
 	jsonInput, err = jsonInput.Add("keyHash", publicKey.MustHash().Hex())
 	require.NoError(t, err) // Can't fail
-	input := models.NewRunInput(&models.ID{}, jsonInput, models.RunStatusUnstarted)
+	input := models.NewRunInput(&models.ID{}, models.ID{}, jsonInput, models.RunStatusUnstarted)
 	result := adapter.Perform(*input, store)
 	require.NoError(t, result.Error(), "while running random adapter")
 	proof := hexutil.MustDecode(result.Result().String())
@@ -65,7 +65,7 @@ func TestRandom_Perform(t *testing.T) {
 			"in RandomValueFromVRFProof has changed?")
 	jsonInput, err = jsonInput.Add("keyHash", common.Hash{})
 	require.NoError(t, err)
-	input = models.NewRunInput(&models.ID{}, jsonInput, models.RunStatusUnstarted)
+	input = models.NewRunInput(&models.ID{}, models.ID{}, jsonInput, models.RunStatusUnstarted)
 	result = adapter.Perform(*input, store)
 	require.Error(t, result.Error(), "must reject if keyHash doesn't match")
 }

--- a/core/assets/currencies.go
+++ b/core/assets/currencies.go
@@ -233,3 +233,25 @@ func (*Eth) Symbol() string {
 func (e *Eth) ToInt() *big.Int {
 	return (*big.Int)(e)
 }
+
+// Scan reads the database value and returns an instance.
+func (e *Eth) Scan(value interface{}) error {
+	switch v := value.(type) {
+	case []uint8:
+		// The SQL library returns numeric() types as []uint8 of the string representation
+		decoded, ok := e.SetString(string(v), 10)
+		if !ok {
+			return fmt.Errorf("Unable to set string %v of %T to base 10 big.Int for Eth", value, value)
+		}
+		*e = *decoded
+	default:
+		return fmt.Errorf("Unable to convert %v of %T to Eth", value, value)
+	}
+
+	return nil
+}
+
+// Value returns the Eth value for serialization to database.
+func (e *Eth) Value() (driver.Value, error) {
+	return e.String(), nil
+}

--- a/core/services/run_executor.go
+++ b/core/services/run_executor.go
@@ -67,7 +67,7 @@ func (re *runExecutor) Execute(runID *models.ID) error {
 			start := time.Now()
 
 			// NOTE: adapters may define and return the new job run status in here
-			result := re.executeTask(&run, taskRun)
+			result := re.executeTask(&run, *taskRun)
 
 			taskRun.ApplyOutput(result)
 			run.ApplyOutput(result)
@@ -105,16 +105,16 @@ func (re *runExecutor) Execute(runID *models.ID) error {
 	return nil
 }
 
-func (re *runExecutor) executeTask(run *models.JobRun, taskRun *models.TaskRun) models.RunOutput {
-	taskCopy := taskRun.TaskSpec // deliberately copied to keep mutations local
+func (re *runExecutor) executeTask(run *models.JobRun, taskRun models.TaskRun) models.RunOutput {
+	taskSpec := taskRun.TaskSpec
 
-	params, err := models.Merge(run.RunRequest.RequestParams, taskCopy.Params)
+	params, err := models.Merge(run.RunRequest.RequestParams, taskSpec.Params)
 	if err != nil {
 		return models.NewRunOutputError(err)
 	}
-	taskCopy.Params = params
+	taskSpec.Params = params
 
-	adapter, err := adapters.For(taskCopy, re.store.Config, re.store.ORM)
+	adapter, err := adapters.For(taskSpec, re.store.Config, re.store.ORM)
 	if err != nil {
 		return models.NewRunOutputError(err)
 	}
@@ -131,7 +131,7 @@ func (re *runExecutor) executeTask(run *models.JobRun, taskRun *models.TaskRun) 
 		return models.NewRunOutputError(err)
 	}
 
-	input := *models.NewRunInput(run.ID, data, taskRun.Status)
+	input := *models.NewRunInput(run.ID, *taskRun.ID, data, taskRun.Status)
 	result := adapter.Perform(input, re.store)
 	promAdapterCallsVec.WithLabelValues(run.JobSpecID.String(), string(adapter.TaskType()), string(result.Status())).Inc()
 

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -49,6 +49,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1588088353"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1588293486"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1588757164"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1589206996"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -241,6 +242,10 @@ func init() {
 		{
 			ID:      "1588757164",
 			Migrate: migration1588757164.Migrate,
+		},
+		{
+			ID:      "1589206996",
+			Migrate: migration1589206996.Migrate,
 		},
 	}
 }

--- a/core/store/migrations/migrate_test.go
+++ b/core/store/migrations/migrate_test.go
@@ -2,18 +2,15 @@ package migrations_test
 
 import (
 	"fmt"
-	"os"
 	"testing"
 	"time"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
-	"github.com/smartcontractkit/chainlink/core/gracefulpanic"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/store/migrations"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration0"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1560881855"
 	"github.com/smartcontractkit/chainlink/core/store/models"
-	"github.com/smartcontractkit/chainlink/core/store/orm"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -24,26 +21,8 @@ import (
 	gormigrate "gopkg.in/gormigrate.v1"
 )
 
-func bootstrapORM(t *testing.T) (*orm.ORM, func()) {
-	tc, cleanup := cltest.NewConfig(t)
-	config := tc.Config
-
-	require.NoError(t, os.MkdirAll(config.RootDir(), 0700))
-	migrationTestDBURL, err := cltest.DropAndCreateThrowawayTestDB(tc.DatabaseURL(), "migrations")
-	require.NoError(t, err)
-	orm, err := orm.NewORM(migrationTestDBURL, config.DatabaseTimeout(), gracefulpanic.NewSignal(), orm.DialectPostgres, config.GetAdvisoryLockIDConfiguredOrDefault())
-	require.NoError(t, err)
-	orm.SetLogging(true)
-
-	return orm, func() {
-		assert.NoError(t, orm.Close())
-		cleanup()
-		os.RemoveAll(config.RootDir())
-	}
-}
-
 func TestMigrate_Migrations(t *testing.T) {
-	orm, cleanup := bootstrapORM(t)
+	orm, cleanup := cltest.BootstrapORMWithNewDatabase(t, "migrations", false)
 	defer cleanup()
 
 	err := orm.RawDB(func(db *gorm.DB) error {
@@ -72,7 +51,7 @@ func TestMigrate_Migrations(t *testing.T) {
 }
 
 func TestMigrate_Migration1560881855(t *testing.T) {
-	orm, cleanup := bootstrapORM(t)
+	orm, cleanup := cltest.BootstrapORMWithNewDatabase(t, "migrations", false)
 	defer cleanup()
 
 	err := orm.RawDB(func(db *gorm.DB) error {
@@ -105,7 +84,7 @@ INSERT INTO job_runs (id, job_spec_id, overrides_id) VALUES ('%s', '%s', (SELECT
 }
 
 func TestMigrate_Migration1560881846(t *testing.T) {
-	orm, cleanup := bootstrapORM(t)
+	orm, cleanup := cltest.BootstrapORMWithNewDatabase(t, "migrations", false)
 	defer cleanup()
 
 	err := orm.RawDB(func(db *gorm.DB) error {
@@ -129,7 +108,7 @@ func TestMigrate_Migration1560881846(t *testing.T) {
 }
 
 func TestMigrate_Migration1565210496(t *testing.T) {
-	orm, cleanup := bootstrapORM(t)
+	orm, cleanup := cltest.BootstrapORMWithNewDatabase(t, "migrations", false)
 	defer cleanup()
 
 	err := orm.RawDB(func(db *gorm.DB) error {
@@ -160,7 +139,7 @@ func TestMigrate_Migration1565210496(t *testing.T) {
 }
 
 func TestMigrate_Migration1565291711(t *testing.T) {
-	orm, cleanup := bootstrapORM(t)
+	orm, cleanup := cltest.BootstrapORMWithNewDatabase(t, "migrations", false)
 	defer cleanup()
 
 	err := orm.RawDB(func(db *gorm.DB) error {
@@ -190,7 +169,7 @@ func TestMigrate_Migration1565291711(t *testing.T) {
 }
 
 func TestMigrate_Migration1565877314(t *testing.T) {
-	orm, cleanup := bootstrapORM(t)
+	orm, cleanup := cltest.BootstrapORMWithNewDatabase(t, "migrations", false)
 	defer cleanup()
 
 	err := orm.RawDB(func(db *gorm.DB) error {
@@ -216,7 +195,7 @@ func TestMigrate_Migration1565877314(t *testing.T) {
 
 func TestMigrate_Migration1586369235(t *testing.T) {
 	// Make sure that the data still reads OK afterward
-	orm, cleanup := bootstrapORM(t)
+	orm, cleanup := cltest.BootstrapORMWithNewDatabase(t, "migrations", false)
 	defer cleanup()
 
 	err := orm.RawDB(func(db *gorm.DB) error {
@@ -258,7 +237,7 @@ func TestMigrate_Migration1586369235(t *testing.T) {
 }
 
 func TestMigrate_NewerVersionGuard(t *testing.T) {
-	orm, cleanup := bootstrapORM(t)
+	orm, cleanup := cltest.BootstrapORMWithNewDatabase(t, "migrations", false)
 	defer cleanup()
 
 	err := orm.RawDB(func(db *gorm.DB) error {

--- a/core/store/migrations/migration1589206996/migrate.go
+++ b/core/store/migrations/migration1589206996/migrate.go
@@ -1,0 +1,64 @@
+package migration1589206996
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate adds the requisite tables for the BulletproofTxManager
+// I have tried to make an intelligent guess at the required indexes and
+// constraints but this will need revisiting after the system has been finished
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+	  	CREATE TABLE eth_transactions (
+			id BIGSERIAL PRIMARY KEY,
+			nonce bigint, 
+			from_address bytea,
+			to_address bytea NOT NULL,
+			encoded_payload bytea NOT NULL,
+			value numeric(78, 0) NOT NULL,
+		 	gas_limit bigint NOT NULL,
+			created_at timestamptz NOT NULL
+	  	);
+
+		CREATE UNIQUE INDEX idx_eth_transactions_nonce_from_address ON eth_transactions (nonce, from_address);
+		CREATE INDEX idx_eth_transactions_created_at ON eth_transactions USING BRIN (created_at);
+
+		ALTER TABLE eth_transactions ADD CONSTRAINT chk_nonce_requires_from_address CHECK (
+			nonce IS NULL OR from_address IS NOT NULL
+		);
+
+		CREATE TABLE eth_transaction_attempts (
+			id BIGSERIAL PRIMARY KEY,
+		 	eth_transaction_id bigint REFERENCES eth_transactions (id) NOT NULL,
+		 	gas_price numeric(78,0) NOT NULL,
+		 	signed_raw_tx bytea NOT NULL,
+		 	hash bytea,
+		 	error text,
+		 	confirmed_in_block_num bigint,
+		 	confirmed_in_block_hash bytea,
+		 	confirmed_at timestamptz,
+		 	created_at timestamptz NOT NULL
+		);
+
+		ALTER TABLE eth_transaction_attempts ADD CONSTRAINT chk_hash_must_have_associated_fields CHECK (
+			(hash IS NULL AND confirmed_in_block_num IS NULL AND confirmed_in_block_hash IS NULL AND confirmed_at IS NULL)
+			OR
+			(hash IS NOT NULL AND confirmed_in_block_num IS NOT NULL AND confirmed_in_block_hash IS NOT NULL AND confirmed_at IS NOT NULL)
+		);
+
+		CREATE UNIQUE INDEX idx_eth_transaction_attempts_signed_raw_tx ON eth_transaction_attempts (signed_raw_tx);
+		CREATE UNIQUE INDEX idx_eth_transaction_attempts_hash ON eth_transaction_attempts (hash);
+		CREATE INDEX idx_eth_transaction_attempts ON eth_transaction_attempts (eth_transaction_id);
+		CREATE INDEX idx_eth_transactions_confirmed_in_block_num ON eth_transaction_attempts (confirmed_in_block_num) WHERE confirmed_in_block_num IS NOT NULL;
+		CREATE INDEX idx_eth_transactions_confirmed_in_block_hash ON eth_transaction_attempts (confirmed_in_block_hash) WHERE confirmed_in_block_hash IS NOT NULL;
+		CREATE INDEX idx_eth_transactions_attempts_created_at ON eth_transaction_attempts USING BRIN (created_at);
+
+		CREATE TABLE eth_task_run_transactions (
+			task_run_id uuid NOT NULL REFERENCES task_runs (id) ON DELETE CASCADE,
+			eth_transaction_id bigint NOT NULL REFERENCES eth_transactions (id) ON DELETE CASCADE
+		);
+
+		CREATE UNIQUE INDEX idx_eth_task_run_transactions_task_run_id ON eth_task_run_transactions (task_run_id);
+		CREATE UNIQUE INDEX idx_eth_task_run_transactions_eth_transaction_id ON eth_task_run_transactions (eth_transaction_id);
+	`).Error
+}

--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -5,6 +5,8 @@ import (
 	"math/big"
 	"time"
 
+	uuid "github.com/satori/go.uuid"
+	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -12,6 +14,36 @@ import (
 	"github.com/jinzhu/gorm"
 	null "gopkg.in/guregu/null.v3"
 )
+
+type EthTaskRunTransaction struct {
+	TaskRunID        uuid.UUID
+	EthTransactionID int64
+	EthTransaction   EthTransaction
+}
+
+type EthTransaction struct {
+	ID             int64
+	Nonce          *int64
+	FromAddress    *common.Address
+	ToAddress      common.Address
+	EncodedPayload []byte
+	Value          *assets.Eth
+	GasLimit       uint64
+	CreatedAt      time.Time
+}
+
+type EthTransactionAttempt struct {
+	ID                   int64
+	EthTransactionID     int64
+	GasPrice             utils.Big
+	SignedRawTx          []byte
+	Hash                 common.Hash
+	Error                *string
+	ConfirmedInBlockNum  *int64
+	ConfirmedInBlockHash common.Hash
+	ConfirmedAt          *time.Time
+	CreatedAt            time.Time
+}
 
 // Tx contains fields necessary for an Ethereum transaction with
 // an additional field for the TxAttempt.

--- a/core/store/models/id.go
+++ b/core/store/models/id.go
@@ -13,6 +13,11 @@ import (
 // ID is a UUID that has a custom display format
 type ID uuid.UUID
 
+// UUID converts it back into a uuid.UUID
+func (id ID) UUID() uuid.UUID {
+	return uuid.UUID(id)
+}
+
 // NewID returns a new ID
 func NewID() *ID {
 	uuid := uuid.NewV4()

--- a/core/store/models/run_input.go
+++ b/core/store/models/run_input.go
@@ -8,30 +8,33 @@ import (
 
 // RunInput represents the input for performing a Task
 type RunInput struct {
-	jobRunID ID
-	data     JSON
-	status   RunStatus
+	jobRunID  ID
+	taskRunID ID
+	data      JSON
+	status    RunStatus
 }
 
 // NewRunInput creates a new RunInput with arbitrary data
-func NewRunInput(jobRunID *ID, data JSON, status RunStatus) *RunInput {
+func NewRunInput(jobRunID *ID, taskRunID ID, data JSON, status RunStatus) *RunInput {
 	return &RunInput{
-		jobRunID: *jobRunID,
-		data:     data,
-		status:   status,
+		jobRunID:  *jobRunID,
+		taskRunID: taskRunID,
+		data:      data,
+		status:    status,
 	}
 }
 
 // NewRunInputWithResult creates a new RunInput with a value in the "result" field
-func NewRunInputWithResult(jobRunID *ID, value interface{}, status RunStatus) *RunInput {
+func NewRunInputWithResult(jobRunID *ID, taskRunID ID, value interface{}, status RunStatus) *RunInput {
 	data, err := JSON{}.Add("result", value)
 	if err != nil {
 		panic(fmt.Sprintf("invariant violated, add should not fail on empty JSON %v", err))
 	}
 	return &RunInput{
-		jobRunID: *jobRunID,
-		data:     data,
-		status:   status,
+		jobRunID:  *jobRunID,
+		taskRunID: taskRunID,
+		data:      data,
+		status:    status,
 	}
 }
 
@@ -62,4 +65,14 @@ func (ri RunInput) Data() JSON {
 // JobRunID returns this RunInput's JobRunID
 func (ri RunInput) JobRunID() *ID {
 	return &ri.jobRunID
+}
+
+// TaskRunID returns this RunInput's TaskRunID
+func (ri RunInput) TaskRunID() ID {
+	return ri.taskRunID
+}
+
+func (ri RunInput) CloneWithData(data JSON) RunInput {
+	ri.data = data
+	return ri
 }

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -204,6 +204,12 @@ func (c Config) EnableExperimentalAdapters() bool {
 	return c.viper.GetBool(EnvVarName("EnableExperimentalAdapters"))
 }
 
+// EnableBulletproofTxManager uses the new tx manager for ethtx tasks. Careful,
+// toggling this on and off could cause transactions to become lost
+func (c Config) EnableBulletproofTxManager() bool {
+	return c.viper.GetBool(EnvVarName("EnableBulletproofTxManager"))
+}
+
 // FeatureExternalInitiators enables the External Initiator feature.
 func (c Config) FeatureExternalInitiators() bool {
 	return c.viper.GetBool(EnvVarName("FeatureExternalInitiators"))

--- a/core/store/orm/config_reader.go
+++ b/core/store/orm/config_reader.go
@@ -29,6 +29,7 @@ type ConfigReader interface {
 	MaximumServiceDuration() models.Duration
 	MinimumServiceDuration() models.Duration
 	EnableExperimentalAdapters() bool
+	EnableBulletproofTxManager() bool
 	EthGasBumpPercent() uint16
 	EthGasBumpThreshold() uint64
 	EthGasBumpWei() *big.Int

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -1538,3 +1538,79 @@ func TestJobs_SQLiteBatchSizeIntegrity(t *testing.T) {
 
 	assert.Equal(t, jobNumber, counter)
 }
+
+func TestORM_EthTaskRunTransaction(t *testing.T) {
+	t.Parallel()
+
+	// NOTE: Must sidestep transactional tests since we rely on error codes for this function
+	orm, cleanup := cltest.BootstrapORMWithNewDatabase(t, "eth_task_run_transactions", true)
+	defer cleanup()
+	store, cleanup := cltest.NewStore(t)
+	defer cleanup()
+	store.ORM = orm
+
+	sharedTaskRunID := cltest.MustInsertTaskRun(t, store)
+
+	t.Run("creates eth_task_run_transaction and eth_transaction", func(t *testing.T) {
+		fromAddress := cltest.NewAddress()
+		toAddress := cltest.NewAddress()
+		encodedPayload := []byte{0, 1, 2}
+		gasLimit := uint64(42)
+
+		err := store.IdempotentInsertEthTaskRunTransaction(sharedTaskRunID, &fromAddress, toAddress, encodedPayload, gasLimit)
+		require.NoError(t, err)
+
+		etrt, err := store.FindEthTaskRunTransactionByTaskRunID(sharedTaskRunID)
+		require.NoError(t, err)
+
+		assert.Equal(t, sharedTaskRunID.UUID(), etrt.TaskRunID)
+		require.NotNil(t, etrt.EthTransaction)
+		assert.Nil(t, etrt.EthTransaction.Nonce)
+		require.NotNil(t, etrt.EthTransaction.FromAddress)
+		assert.Equal(t, fromAddress, *etrt.EthTransaction.FromAddress)
+		assert.Equal(t, toAddress, etrt.EthTransaction.ToAddress)
+		assert.Equal(t, encodedPayload, etrt.EthTransaction.EncodedPayload)
+		assert.Equal(t, gasLimit, etrt.EthTransaction.GasLimit)
+
+		// Do it again to test idempotence
+		err = store.IdempotentInsertEthTaskRunTransaction(sharedTaskRunID, &fromAddress, toAddress, encodedPayload, gasLimit)
+		require.NoError(t, err)
+
+		// Ensure it didn't leave a stray EthTransaction hanging around
+		store.RawDB(func(db *gorm.DB) error {
+			var count int
+			require.NoError(t, db.Table("eth_transactions").Count(&count).Error)
+			assert.Equal(t, 1, count)
+			return nil
+		})
+	})
+
+	t.Run("returns error if eth_task_run_transaction already exists with this task run ID but has different values", func(t *testing.T) {
+		fromAddress := cltest.NewAddress()
+		toAddress := cltest.NewAddress()
+		encodedPayload := []byte{3, 2, 1}
+		gasLimit := uint64(24)
+
+		err := store.IdempotentInsertEthTaskRunTransaction(sharedTaskRunID, &fromAddress, toAddress, encodedPayload, gasLimit)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "transaction already exists for task run ID")
+	})
+
+	t.Run("handles nil from address", func(t *testing.T) {
+		taskRunID := cltest.MustInsertTaskRun(t, store)
+
+		toAddress := cltest.NewAddress()
+		encodedPayload := []byte{0, 1, 2}
+		gasLimit := uint64(42)
+
+		err := store.IdempotentInsertEthTaskRunTransaction(taskRunID, nil, toAddress, encodedPayload, gasLimit)
+		require.NoError(t, err)
+
+		etrt, err := store.FindEthTaskRunTransactionByTaskRunID(taskRunID)
+		require.NoError(t, err)
+
+		require.NotNil(t, etrt.EthTransaction)
+		require.Nil(t, etrt.EthTransaction.FromAddress)
+	})
+
+}

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -24,6 +24,7 @@ type ConfigSchema struct {
 	DefaultHTTPTimeout              models.Duration `env:"DEFAULT_HTTP_TIMEOUT" default:"15s"`
 	Dev                             bool            `env:"CHAINLINK_DEV" default:"false"`
 	EnableExperimentalAdapters      bool            `env:"ENABLE_EXPERIMENTAL_ADAPTERS" default:"false"`
+	EnableBulletproofTxManager      bool            `env:"ENABLE_BULLETPROOF_TX_MANAGER" default:"false"`
 	FeatureExternalInitiators       bool            `env:"FEATURE_EXTERNAL_INITIATORS" default:"false"`
 	FeatureFluxMonitor              bool            `env:"FEATURE_FLUX_MONITOR" default:"false"`
 	MaximumServiceDuration          models.Duration `env:"MAXIMUM_SERVICE_DURATION" default:"8760h" `


### PR DESCRIPTION
The first part of this ticket: https://www.pivotaltracker.com/story/show/171753295
See design proposal: https://www.notion.so/chainlink/DESIGN-PROPOSAL-BulletproofTxManager-81436286a142411d95e336b0c295c457

This commit changes ethtx so that it writes to the `eth_transactions`
table instead when ENABLE_BULLETPROOF_TX_MANAGER flag is turned on