### PR TITLE
Remove ineffective check from FluxMonitor/geth integration test

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -26,14 +26,14 @@ jobs:
       - uses: actions/setup-go@v2
       - run: go get -v golang.org/x/tools/cmd/goimports
       - run: d="$($HOME/go/bin/goimports -d ./)" && if [ -n "$d" ]; then echo "goimports generated output:" ; echo "$d"; exit 1; fi
-  # staticcheck:
-  #   name: staticheck
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: actions/setup-go@v2
-  #     - run: go install honnef.co/go/tools/cmd/staticcheck
-  #     - run: $HOME/go/bin/staticcheck ./...
+  staticcheck:
+    name: staticheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-go@v2
+      - run: go install honnef.co/go/tools/cmd/staticcheck
+      - run: $HOME/go/bin/staticcheck ./...
   # TODO: Enable linters below one by one and fix issues with each
   # lint:
   #   name: Lint

--- a/core/adapters/eth_tx_abi_encode.go
+++ b/core/adapters/eth_tx_abi_encode.go
@@ -374,7 +374,7 @@ var hexDigitsRegexp = regexp.MustCompile("^[0-9a-fA-F]*$")
 func bigIntFromJSON(jval interface{}, name string) (*big.Int, error) {
 	switch val := jval.(type) {
 	case string:
-		n := big.NewInt(0)
+		var n = big.NewInt(0)
 		valid := false
 		if utils.HasHexPrefix(val) {
 			if !hexDigitsRegexp.MatchString(val[2:]) {

--- a/core/adapters/http.go
+++ b/core/adapters/http.go
@@ -331,8 +331,7 @@ type QueryParameters url.Values
 
 // UnmarshalJSON implements the Unmarshaler interface
 func (qp *QueryParameters) UnmarshalJSON(input []byte) error {
-	values := url.Values{}
-	strs := []string{}
+	var strs []string
 	var err error
 
 	// input is a string like "someKey0=someVal0&someKey1=someVal1"
@@ -350,7 +349,7 @@ func (qp *QueryParameters) UnmarshalJSON(input []byte) error {
 		return fmt.Errorf("unable to unmarshal query parameters: %s", input)
 	}
 
-	values, err = buildValues(strs)
+	values, err := buildValues(strs)
 	if err != nil {
 		return fmt.Errorf("unable to build query parameters: %s", input)
 	}

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -50,7 +50,6 @@ import (
 	"github.com/jinzhu/gorm"
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/onsi/gomega"
-	"github.com/smartcontractkit/chainlink/core/store"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
@@ -310,7 +309,7 @@ func NewApplicationWithConfigAndKeyOnSimulatedBlockchain(
 	tc.Config.Set("ETH_CHAIN_ID", chainId)
 	app, appCleanup := NewApplicationWithConfigAndKey(t, tc, flags...)
 	var client SimulatedBackendClient
-	if txm, ok := app.Store.TxManager.(*store.EthTxManager); ok {
+	if txm, ok := app.Store.TxManager.(*strpkg.EthTxManager); ok {
 		client = SimulatedBackendClient{b: backend, t: t, chainId: chainId}
 		txm.Client = &client
 	} else {
@@ -1008,15 +1007,15 @@ func ParseNullableTime(t testing.TB, s string) null.Time {
 
 // Head given the value convert it into an Head
 func Head(val interface{}) *models.Head {
-	switch val.(type) {
+	switch t := val.(type) {
 	case int:
-		return models.NewHead(big.NewInt(int64(val.(int))), NewHash())
+		return models.NewHead(big.NewInt(int64(t)), NewHash())
 	case uint64:
-		return models.NewHead(big.NewInt(int64(val.(uint64))), NewHash())
+		return models.NewHead(big.NewInt(int64(t)), NewHash())
 	case int64:
-		return models.NewHead(big.NewInt(val.(int64)), NewHash())
+		return models.NewHead(big.NewInt(t), NewHash())
 	case *big.Int:
-		return models.NewHead(val.(*big.Int), NewHash())
+		return models.NewHead(t, NewHash())
 	default:
 		logger.Panicf("Could not convert %v of type %T to Head", val, val)
 		return nil

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -21,7 +21,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/fluxmonitor"
 	"github.com/smartcontractkit/chainlink/core/services/vrf"
-	"github.com/smartcontractkit/chainlink/core/store"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
@@ -617,7 +616,7 @@ func NewJobRunPendingBridge(job models.JobSpec) models.JobRun {
 }
 
 // CreateJobRunWithStatus returns a new job run with the specified status that has been persisted
-func CreateJobRunWithStatus(t testing.TB, store *store.Store, job models.JobSpec, status models.RunStatus) models.JobRun {
+func CreateJobRunWithStatus(t testing.TB, store *strpkg.Store, job models.JobSpec, status models.RunStatus) models.JobRun {
 	run := NewJobRun(job)
 	run.SetStatus(status)
 	require.NoError(t, store.CreateJobRun(&run))
@@ -688,7 +687,7 @@ func NewRunInputWithResultAndJobRunID(value interface{}, jobRunID *models.ID) mo
 	return *models.NewRunInputWithResult(jobRunID, value, models.RunStatusUnstarted)
 }
 
-func NewPollingDeviationChecker(t *testing.T, s *store.Store) *fluxmonitor.PollingDeviationChecker {
+func NewPollingDeviationChecker(t *testing.T, s *strpkg.Store) *fluxmonitor.PollingDeviationChecker {
 	fluxAggregator := new(mocks.FluxAggregator)
 	runManager := new(mocks.RunManager)
 	fetcher := new(mocks.Fetcher)

--- a/core/internal/gethwrappers/go_generate_test.go
+++ b/core/internal/gethwrappers/go_generate_test.go
@@ -93,6 +93,7 @@ func compareCurrentCompilerAritfactAgainstRecordsAndSoliditySources(
 	// Normalize the whitespace in the ABI JSON
 	abiBytes, err := utils.NormalizedJSON(
 		[]byte(gjson.GetBytes(compilerJSON, abiPath).String()))
+	assert.NoError(t, err, "failed to normalize JSON %s", compilerJSON)
 	binBytes := gjson.GetBytes(compilerJSON, binPath).String()
 	if !isLINKCompilerOutput {
 		// Remove the varying contract metadata, as in ./generation/generate.sh

--- a/core/null/int64.go
+++ b/core/null/int64.go
@@ -134,18 +134,18 @@ func (i *Int64) Scan(value interface{}) error {
 		*i = Int64From(safe)
 	case uint:
 		if typed > uint(math.MaxInt64) {
-			return fmt.Errorf("Unable to convert %v of %T to Int64; overflow", value, value)
+			return fmt.Errorf("unable to convert %v of %T to Int64; overflow", value, value)
 		}
 		safe := int64(typed)
 		*i = Int64From(safe)
 	case uint64:
 		if typed > uint64(math.MaxInt64) {
-			return fmt.Errorf("Unable to convert %v of %T to Int64; overflow", value, value)
+			return fmt.Errorf("unable to convert %v of %T to Int64; overflow", value, value)
 		}
 		safe := int64(typed)
 		*i = Int64From(safe)
 	default:
-		return fmt.Errorf("Unable to convert %v of %T to Int64", value, value)
+		return fmt.Errorf("unable to convert %v of %T to Int64", value, value)
 	}
 	return nil
 }

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -11,7 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services"
 	"github.com/smartcontractkit/chainlink/core/services/fluxmonitor"
 	"github.com/smartcontractkit/chainlink/core/services/synchronization"
-	"github.com/smartcontractkit/chainlink/core/store"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
@@ -39,7 +38,7 @@ func (c *headTrackableCallback) OnNewHead(*models.Head) {}
 type Application interface {
 	Start() error
 	Stop() error
-	GetStore() *store.Store
+	GetStore() *strpkg.Store
 	GetStatsPusher() synchronization.StatsPusher
 	WakeSessionReaper()
 	AddJob(job models.JobSpec) error
@@ -62,7 +61,7 @@ type ChainlinkApplication struct {
 	GasUpdater               services.GasUpdater
 	FluxMonitor              fluxmonitor.Service
 	Scheduler                *services.Scheduler
-	Store                    *store.Store
+	Store                    *strpkg.Store
 	SessionReaper            services.SleeperTask
 	pendingConnectionResumer *pendingConnectionResumer
 	shutdownOnce             sync.Once
@@ -75,7 +74,7 @@ type ChainlinkApplication struct {
 // be used by the node.
 func NewApplication(config *orm.Config, onConnectCallbacks ...func(Application)) Application {
 	shutdownSignal := gracefulpanic.NewSignal()
-	store := store.NewStore(config, shutdownSignal)
+	store := strpkg.NewStore(config, shutdownSignal)
 	config.SetRuntimeStore(store.ORM)
 
 	statsPusher := synchronization.NewStatsPusher(
@@ -178,7 +177,7 @@ func (app *ChainlinkApplication) Stop() error {
 }
 
 // GetStore returns the pointer to the store for the ChainlinkApplication.
-func (app *ChainlinkApplication) GetStore() *store.Store {
+func (app *ChainlinkApplication) GetStore() *strpkg.Store {
 	return app.Store
 }
 

--- a/core/services/eth/log_broadcaster.go
+++ b/core/services/eth/log_broadcaster.go
@@ -361,11 +361,8 @@ func (b *logBroadcaster) onAddListener(r registration) (needsResubscribe bool) {
 	}
 	b.listeners[r.address][r.listener] = struct{}{}
 
-	if !knownAddress {
-		// Recreate the subscription with the new contract address
-		return true
-	}
-	return false
+	// Recreate the subscription with the new contract address
+	return !knownAddress
 }
 
 func (b *logBroadcaster) onRemoveListener(r registration) (needsResubscribe bool) {

--- a/core/services/eth/log_broadcaster_test.go
+++ b/core/services/eth/log_broadcaster_test.go
@@ -522,6 +522,7 @@ func TestLogBroadcaster_ReceivesAllLogsWhenResubscribing(t *testing.T) {
 			var recvd []*eth.Log
 
 			handleLog := func(lb ethsvc.LogBroadcast, err error) {
+				require.NoError(t, err)
 				consumed, err := lb.WasAlreadyConsumed()
 				require.NoError(t, err)
 				if !consumed {
@@ -671,6 +672,7 @@ func TestLogBroadcaster_InjectsLogConsumptionRecordFunctions(t *testing.T) {
 	job := createJob(t, store)
 	logListener := simpleLogListener{
 		func(lb ethsvc.LogBroadcast, err error) {
+			require.NoError(t, err)
 			consumed, err := lb.WasAlreadyConsumed()
 			require.NoError(t, err)
 			require.False(t, consumed)

--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -753,7 +753,7 @@ func (p *PollingDeviationChecker) pollIfEligible(
 		"absoluteThreshold", thresholds.Abs,
 	}
 
-	if p.connected.IsSet() == false {
+	if !p.connected.IsSet() {
 		logger.Warnw("not connected to Ethereum node, skipping poll", loggerFields...)
 		return false
 	}

--- a/core/services/fluxmonitor/helpers_test.go
+++ b/core/services/fluxmonitor/helpers_test.go
@@ -102,10 +102,10 @@ func dataWithResult(t *testing.T, result decimal.Decimal) adapterResponseData {
 	return data
 }
 
-// XXXTestingOnlyCreateJob is used in TestFluxMonitorAntiSpamLogic to create a
+// CreateJob is used in TestFluxMonitorAntiSpamLogic to create a
 // job with a specific answer and round, for testing nodes with malicious
 // behavior
-func (fm *concreteFluxMonitor) XXXTestingOnlyCreateJob(t *testing.T,
+func (fm *concreteFluxMonitor) CreateJob(t *testing.T,
 	jobSpecId *models.ID, polledAnswer decimal.Decimal,
 	nextRound *big.Int) error {
 	jobSpec, err := fm.store.ORM.FindJob(jobSpecId)

--- a/core/services/gas_updater.go
+++ b/core/services/gas_updater.go
@@ -74,7 +74,6 @@ func (gu *gasUpdater) Connect(bn *models.Head) error {
 }
 
 func (gu *gasUpdater) Disconnect() {
-	return
 }
 
 // OnNewHead recalculates and sets global gas price on every head

--- a/core/services/signatures/ethdss/ethdss_test.go
+++ b/core/services/signatures/ethdss/ethdss_test.go
@@ -28,8 +28,6 @@ var partSec []kyber.Scalar
 var longterms []*dkg.DistKeyShare
 var randoms []*dkg.DistKeyShare
 
-var dss []*DSS
-
 var msg *big.Int
 
 var randomStream = cryptotest.NewStream(&testing.T{}, 0)

--- a/core/services/signatures/secp256k1/point.go
+++ b/core/services/signatures/secp256k1/point.go
@@ -312,9 +312,6 @@ func Coordinates(p kyber.Point) (*big.Int, *big.Int) {
 	return p.(*secp256k1Point).X.int(), p.(*secp256k1Point).Y.int()
 }
 
-var halfQ = big.NewInt(0).Add(big.NewInt(0).Rsh(GroupOrder, 1),
-	big.NewInt(1)) // Half secp256k1 group order + 1
-
 // ValidPublicKey returns true iff p can be used in the optimized on-chain
 // Schnorr-signature verification. See SchnorrSECP256K1.sol for details.
 func ValidPublicKey(p kyber.Point) bool {

--- a/core/services/vrf/vrf.go
+++ b/core/services/vrf/vrf.go
@@ -65,7 +65,6 @@ func add(addend1, addend2 *big.Int) *big.Int         { return i().Add(addend1, a
 func div(dividend, divisor *big.Int) *big.Int        { return i().Div(dividend, divisor) }
 func equal(left, right *big.Int) bool                { return left.Cmp(right) == 0 }
 func exp(base, exponent, modulus *big.Int) *big.Int  { return i().Exp(base, exponent, modulus) }
-func lsh(num *big.Int, bits uint) *big.Int           { return i().Lsh(num, bits) }
 func mul(multiplicand, multiplier *big.Int) *big.Int { return i().Mul(multiplicand, multiplier) }
 func mod(dividend, divisor *big.Int) *big.Int        { return i().Mod(dividend, divisor) }
 func sub(minuend, subtrahend *big.Int) *big.Int      { return i().Sub(minuend, subtrahend) }

--- a/core/store/models/address_test.go
+++ b/core/store/models/address_test.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -32,7 +31,7 @@ func TestEIP55Address(t *testing.T) {
 		0xb0, 0x14, 0x68, 0x7e,
 	}), address.Hash())
 
-	assert.Equal(t, "0xa0788FC17B1dEe36f057c42B6F373A34B014687e", fmt.Sprintf("%s", address))
+	assert.Equal(t, "0xa0788FC17B1dEe36f057c42B6F373A34B014687e", address.String())
 
 	zeroAddress := EIP55Address("")
 	err := json.Unmarshal([]byte(`"0xa0788FC17B1dEe36f057c42B6F373A34B014687e"`), &zeroAddress)

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -127,7 +127,7 @@ func (j JobSpec) InitiatorsFor(types ...string) []Initiator {
 func (j JobSpec) InitiatorExternal(name string) *Initiator {
 	var found *Initiator
 	for _, i := range j.InitiatorsFor(InitiatorExternal) {
-		if strings.ToLower(i.Name) == strings.ToLower(name) {
+		if strings.EqualFold(i.Name, name) {
 			found = &i
 			break
 		}

--- a/core/store/models/signature_test.go
+++ b/core/store/models/signature_test.go
@@ -2,7 +2,6 @@ package models
 
 import (
 	"encoding/json"
-	"fmt"
 	"math/big"
 	"testing"
 
@@ -28,7 +27,7 @@ func TestSignature(t *testing.T) {
 
 	assert.Equal(t, str, signature.String())
 
-	assert.Equal(t, str, fmt.Sprintf("%s", signature))
+	assert.Equal(t, str, signature.String())
 
 	zerosignature := Signature{}
 	err = json.Unmarshal([]byte(`"0xb7a987222fc36c4c8ed1b91264867a422769998aadbeeb1c697586a04fa2b616025b5ca936ec5bdb150999e298b6ecf09251d3c4dd1306dedec0692e7037584800"`), &zerosignature)

--- a/core/store/models/user_test.go
+++ b/core/store/models/user_test.go
@@ -55,11 +55,13 @@ func TestAuthenticateUserByToken(t *testing.T) {
 	var user models.User
 
 	token, err := user.GenerateAuthToken()
+	assert.NoError(t, err, "failed when generate auth token")
 	ok, err := models.AuthenticateUserByToken(token, &user)
 	require.NoError(t, err)
 	assert.True(t, ok, "authentication must be successful")
 
 	_, err = user.GenerateAuthToken()
+	assert.NoError(t, err, "failed to generate auth token")
 	ok, err = models.AuthenticateUserByToken(token, &user)
 	require.NoError(t, err)
 	assert.False(t, ok, "authentication must fail with past token")

--- a/core/store/models/vrfkey/serialization_test.go
+++ b/core/store/models/vrfkey/serialization_test.go
@@ -10,7 +10,6 @@ import (
 
 var phrase = "as3r8phu82u9ru843cdi4298yf"
 
-var serialSK = 0xdeadbeefdeadbee
 var serialK = mustNewPrivateKey(big.NewInt(int64(sk)))
 
 func TestEncryptDecryptRoundTrip(t *testing.T) {

--- a/core/store/orm/config_test.go
+++ b/core/store/orm/config_test.go
@@ -99,9 +99,11 @@ func TestStore_addressParser(t *testing.T) {
 
 	val, err = parseAddress("0x0")
 	assert.Error(t, err)
+	assert.Nil(t, val)
 
 	val, err = parseAddress("x")
 	assert.Error(t, err)
+	assert.Nil(t, val)
 }
 
 func TestStore_bigIntParser(t *testing.T) {
@@ -115,9 +117,11 @@ func TestStore_bigIntParser(t *testing.T) {
 
 	val, err = parseBigInt("x")
 	assert.Error(t, err)
+	assert.Nil(t, val)
 
 	val, err = parseBigInt("")
 	assert.Error(t, err)
+	assert.Nil(t, val)
 }
 
 func TestStore_levelParser(t *testing.T) {
@@ -131,6 +135,7 @@ func TestStore_levelParser(t *testing.T) {
 
 	val, err = parseLogLevel("primus sucks")
 	assert.Error(t, err)
+	assert.Equal(t, val, LogLevel{})
 }
 
 func TestStore_urlParser(t *testing.T) {

--- a/core/store/orm/locking_strategies.go
+++ b/core/store/orm/locking_strategies.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"fmt"
 	"sync"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -28,13 +27,6 @@ func NewLockingStrategy(ct Connection) (LockingStrategy, error) {
 type LockingStrategy interface {
 	Lock(timeout models.Duration) error
 	Unlock(timeout models.Duration) error
-}
-
-func normalizedTimeout(timeout time.Duration) <-chan time.Time {
-	if timeout == 0 {
-		return make(chan time.Time) // never time out
-	}
-	return time.After(timeout)
 }
 
 // PostgresLockingStrategy uses a postgres advisory lock to ensure exclusive

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -1154,6 +1154,7 @@ func TestORM_FindTxByAttempt_CurrentAttempt(t *testing.T) {
 
 	createdTx := cltest.CreateTx(t, store, from, 1)
 	fetchedTx, fetchedTxAttempt, err := store.FindTxByAttempt(createdTx.Hash)
+	assert.NoError(t, err, "failed to find tx:%s in store", createdTx.Hash)
 
 	assert.Equal(t, createdTx.ID, fetchedTx.ID)
 	assert.Equal(t, createdTx.From, fetchedTx.From)
@@ -1418,6 +1419,7 @@ func TestORM_FindAllTxsInNonceRange(t *testing.T) {
 		require.NoError(t, err)
 		createdTxs = append(createdTxs, *tx)
 	}
+	assert.Len(t, createdTxs, 3)
 
 	txs, err := store.FindAllTxsInNonceRange(2, 3)
 	require.NoError(t, err)
@@ -1499,6 +1501,7 @@ func TestJobs_SQLiteBatchSizeIntegrity(t *testing.T) {
 		require.NoError(t, store.CreateJob(&job))
 		jobs = append(jobs, job)
 	}
+	assert.Len(t, jobs, jobNumber)
 
 	counter := 0
 	err := store.Jobs(func(j *models.JobSpec) bool {

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -101,13 +101,13 @@ func (wrapper *lazyRPCWrapper) Call(result interface{}, method string, args ...i
 	return wrapper.client.Call(result, method, args...)
 }
 
-func (wrapper *lazyRPCWrapper) Subscribe(_ context.Context, channel interface{}, args ...interface{}) (eth.Subscription, error) {
+func (wrapper *lazyRPCWrapper) Subscribe(ctx context.Context, channel interface{}, args ...interface{}) (eth.Subscription, error) {
 	err := wrapper.lazyDialInitializer()
 	if err != nil {
 		return nil, err
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	ctx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 	wrapper.limiter.Wait(ctx)
 

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -101,7 +101,7 @@ func (wrapper *lazyRPCWrapper) Call(result interface{}, method string, args ...i
 	return wrapper.client.Call(result, method, args...)
 }
 
-func (wrapper *lazyRPCWrapper) Subscribe(ctx context.Context, channel interface{}, args ...interface{}) (eth.Subscription, error) {
+func (wrapper *lazyRPCWrapper) Subscribe(_ context.Context, channel interface{}, args ...interface{}) (eth.Subscription, error) {
 	err := wrapper.lazyDialInitializer()
 	if err != nil {
 		return nil, err

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -10,7 +10,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/eth"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
-	"github.com/smartcontractkit/chainlink/core/store"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
@@ -949,7 +948,7 @@ func TestTxManager_ReloadNonce(t *testing.T) {
 	t.Parallel()
 
 	ethClient := new(mocks.Client)
-	txm := store.NewEthTxManager(
+	txm := strpkg.NewEthTxManager(
 		ethClient,
 		orm.NewConfig(),
 		nil,
@@ -958,7 +957,7 @@ func TestTxManager_ReloadNonce(t *testing.T) {
 
 	from := common.HexToAddress("0xbf4ed7b27f1d666546e30d74d50d173d20bca754")
 	account := accounts.Account{Address: from}
-	ma := store.NewManagedAccount(account, 0)
+	ma := strpkg.NewManagedAccount(account, 0)
 
 	nonce := uint64(234)
 	ethClient.On("GetNonce", from).Return(nonce, nil)

--- a/core/store/vrf_key_store_test.go
+++ b/core/store/vrf_key_store_test.go
@@ -16,12 +16,9 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/solidity_verifier_wrapper"
-	"github.com/smartcontractkit/chainlink/core/services/signatures/secp256k1"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models/vrfkey"
 )
-
-var suite = secp256k1.NewBlakeKeccackSecp256k1()
 
 // NB: For changes to the VRF solidity code to be reflected here, "go generate"
 // must be run in core/services/vrf.

--- a/core/utils/big.go
+++ b/core/utils/big.go
@@ -86,11 +86,6 @@ func (b *Big) UnmarshalText(input []byte) error {
 	return nil
 }
 
-func (b *Big) setBytes(value []uint8) *Big {
-	w := (*big.Int)(b).SetBytes(value)
-	return (*Big)(w)
-}
-
 func (b *Big) setString(s string, base int) (*Big, bool) {
 	w, ok := (*big.Int)(b).SetString(s, base)
 	return (*Big)(w), ok

--- a/core/utils/ethabi_test.go
+++ b/core/utils/ethabi_test.go
@@ -101,6 +101,7 @@ func TestEVMWordSignedBigInt(t *testing.T) {
 
 	val, err = EVMWordSignedBigInt(new(big.Int).Add(MaxInt256, big.NewInt(1)))
 	assert.Error(t, err)
+	assert.Nil(t, val)
 }
 
 func TestEVMWordBigInt(t *testing.T) {
@@ -118,6 +119,7 @@ func TestEVMWordBigInt(t *testing.T) {
 
 	val, err = EVMWordBigInt(new(big.Int).SetInt64(-1))
 	assert.Error(t, err)
+	assert.Nil(t, val)
 
 	val, err = EVMWordBigInt(MaxUint256)
 	assert.NoError(t, err)
@@ -125,6 +127,7 @@ func TestEVMWordBigInt(t *testing.T) {
 
 	val, err = EVMWordBigInt(new(big.Int).Add(MaxUint256, big.NewInt(1)))
 	assert.Error(t, err)
+	assert.Nil(t, val)
 }
 
 func TestEVMTranscodeBytes(t *testing.T) {

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -99,7 +99,7 @@ func NullISO8601UTC(t null.Time) string {
 // DurationFromNow returns the amount of time since the Time
 // field was last updated.
 func DurationFromNow(t time.Time) time.Duration {
-	return t.Sub(time.Now())
+	return time.Until(t)
 }
 
 // FormatJSON applies indent to format a JSON response.

--- a/core/web/api_test.go
+++ b/core/web/api_test.go
@@ -154,6 +154,7 @@ func TestNewJSONAPIResponse(t *testing.T) {
 
 	buffer, err := NewJSONAPIResponse(12981)
 	assert.Error(t, err)
+	assert.Len(t, buffer, 0)
 
 	r := DummyResource{ID: "782"}
 	buffer, err = NewJSONAPIResponse(&r)


### PR DESCRIPTION
This was caught by @vlyl's `staticcheck` work (Thanks, @vlyl.)  `reportPrice = answer + 1` was intended to have a side-effect, attempting to trigger a premature report from the fluxmonitor. For that to work, the `reportPrice` argument to `checkNewRoundBlocked` should have been a pointer. However, fluxmonitor is too well-behaved to fall for that, and the message this test was checking for, `"skipping poll: not eligible to submit"` occurs anyway, so this test was passing without checking anything useful.