### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -62,7 +62,6 @@ require (
 	github.com/ulule/limiter v0.0.0-20190417201358-7873d115fc4e
 	github.com/unrolled/secure v0.0.0-20190624173513-716474489ad3
 	github.com/urfave/cli v1.22.4
-	github.com/willf/pad v0.0.0-20190207183901-eccfe5d84172
 	go.dedis.ch/fixbuf v1.0.3
 	go.dedis.ch/kyber/v3 v3.0.12
 	go.uber.org/multierr v1.5.0


### PR DESCRIPTION
A small simplification which cuts down on the dependencies in `go.mod`.

Computes the powers of 10 using arithmetic, instead of constructing them from a
string.