### PR TITLE
Improve documentation for constant bytecode metadata suffix.

### DIFF
--- a/core/internal/gethwrappers/extract_contract_details.go
+++ b/core/internal/gethwrappers/extract_contract_details.go
@@ -86,8 +86,15 @@ var binarySuffixRegexp = regexp.MustCompile(
 	"^a264697066735822[[:xdigit:]]{68}64736f6c6343[[:xdigit:]]{6}0033$",
 ).MatchString
 
-// constantBinaryMetadataSuffix is a constant stand-in for the metadata suffix
-// which the EVM expects (and in some cases, it seems, requires) to find at the
-// end of the binary object representing a contract under deployment.
+// constantBinaryMetadataSuffix is an arbitrary constant stand-in for the
+// metadata suffix which the EVM expects (and in some cases, it seems, requires)
+// to find at the end of the binary object representing a contract under
+// deployment. See binarySuffixRegexp docstring.
 var constantBinaryMetadataSuffix = "a264697066735822" +
 	strings.Repeat("beef", 68/4) + "64736f6c6343" + "decafe" + "0033"
+
+func init() {
+	if !binarySuffixRegexp(constantBinaryMetadataSuffix) {
+		panic("constantBinaryMetadataSuffix is invalid")
+	}
+}

--- a/core/internal/gethwrappers/go_generate_test.go
+++ b/core/internal/gethwrappers/go_generate_test.go
@@ -200,5 +200,5 @@ func getProjectRoot(t *testing.T) (rootPath string) {
 		}
 	}
 	t.Fatal("could not find project root")
-	panic("can't get here")
+	panic("can't get here") // Appease staticcheck
 }


### PR DESCRIPTION
Per [this comment
](https://github.com/smartcontractkit/chainlink/pull/3015#discussion_r435416359).