### PR TITLE
Remove the unique index on txes.hash

### DIFF
--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -95,6 +95,7 @@ func createTxRunResult(
 		gasLimit,
 	)
 	if err != nil {
+		logger.Error(errors.Wrap(err, "createTxRunResult failed"))
 		return models.NewRunOutputPendingOutgoingConfirmationsWithData(input.Data())
 	}
 
@@ -133,7 +134,7 @@ func createTxRunResult(
 func ensureTxRunResult(input models.RunInput, str *strpkg.Store) models.RunOutput {
 	val, err := input.ResultString()
 	if err != nil {
-		return models.NewRunOutputError(err)
+		return models.NewRunOutputError(errors.Wrapf(err, "while processing ethtx input %#+v", input))
 	}
 
 	hash := common.HexToHash(val)

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -54,6 +54,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1589470036"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1590226486"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1591141873"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1591603775"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -266,6 +267,10 @@ func init() {
 		{
 			ID:      "1591141873",
 			Migrate: migration1591141873.Migrate,
+		},
+		{
+			ID:      "1591603775",
+			Migrate: migration1591603775.Migrate,
 		},
 	}
 }

--- a/core/store/migrations/migration1591603775/migrate.go
+++ b/core/store/migrations/migration1591603775/migrate.go
@@ -1,0 +1,13 @@
+package migration1591603775
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate changes the index on txes.hash to be non-unique again to allow existing buggy code to continue to function
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+		DROP INDEX IF EXISTS idx_txes_hash;
+		CREATE INDEX idx_txes_hash ON txes (hash);
+    `).Error
+}


### PR DESCRIPTION
- Existing code creates duplicates in certain cases when races occur
- It's almost impossible to fix this, the better solution is to allow
the buggy behaviour to continue and focus on shipping the replacement
transaction manager which will eliminate this class of problems