### PR TITLE
fix gosec warnings, exlude G101,G104,G204,G304 and ingester dir

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -42,6 +42,14 @@ jobs:
       - uses: actions/checkout@v2
       - run: go get -v github.com/kisielk/errcheck
       - run: sh -c "d=\"$($HOME/go/bin/errcheck -ignoretests -asserts -ignoregenerated ./... | grep -v internal)\"; if [ -n \"$d\" ]; then echo \"errcheck output:\" ; echo \"$d\"; exit 1; else exit 0 ; fi" 2>&1
+  sec:
+    name: sec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/setup-go@v2
+      - uses: actions/checkout@v2
+      - run: go get -v github.com/securego/gosec/cmd/gosec
+      - run: $HOME/go/bin/gosec -exclude=G101,G104,G204,G304 -exclude-dir ingester ./...
   # TODO: Enable linters below one by one and fix issues with each
   # lint:
   #   name: Lint
@@ -52,15 +60,4 @@ jobs:
   #     uses: grandcolline/golang-github-actions@v1.1.0
   #     with:
   #       run: lint
-  #       comment: false
-  # sec:
-  #   name: Sec
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #   - uses: actions/checkout@master
-  #   - name: check
-  #     uses: grandcolline/golang-github-actions@v1.1.0
-  #     with:
-  #       run: sec
-  #       flags: "-exclude=G104"
   #       comment: false

--- a/core/internal/gethwrappers/versions.go
+++ b/core/internal/gethwrappers/versions.go
@@ -9,6 +9,8 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/smartcontractkit/chainlink/core/logger"
+
 	"github.com/pkg/errors"
 )
 
@@ -105,7 +107,7 @@ func WriteVersionsDB(db *IntegratedVersion) error {
 	if err != nil {
 		return errors.Wrapf(err, "while opening %s", versionsDBPath)
 	}
-	defer f.Close()
+	defer logger.ErrorIfCalling(f.Close)
 	gethLine := "GETH_VERSION: " + db.GethVersion + "\n"
 	n, err := f.WriteString(gethLine)
 	if err != nil {

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -1138,11 +1138,12 @@ func (orm *ORM) HasConsumedLog(rawLog eth.RawLog, JobID *models.ID) (bool, error
 
 // LogConsumptionExists reports whether a given LogConsumption record already exists
 func (orm *ORM) LogConsumptionExists(lc *models.LogConsumption) (bool, error) {
-	subQuery := "SELECT id FROM log_consumptions " +
+	query := "SELECT exists (" +
+		"SELECT id FROM log_consumptions " +
 		"WHERE block_hash=$1 " +
 		"AND log_index=$2 " +
-		"AND job_id=$3"
-	query := "SELECT exists (" + subQuery + ")"
+		"AND job_id=$3" +
+		")"
 
 	var exists bool
 	err := orm.db.DB().


### PR DESCRIPTION
G101 for hardcoded, e.g. `LinkTokenABI = "[{\"constant\":true..."`.
G104 for error check which was done in previous errcheck GH action.
G204 for  "subprocess launched with variable", e.g. `exec.Command(abigenExecutablePath, "--version")`
G304 for "file inclusion via variable", e.g. `ioutil.ReadFile(path)`