### PR TITLE
ISO8601UTC should not be a public method of logger

### DIFF
--- a/core/logger/prettyconsole.go
+++ b/core/logger/prettyconsole.go
@@ -47,7 +47,7 @@ func (pc PrettyConsole) Write(b []byte) (int, error) {
 func generateHeadline(js gjson.Result) string {
 	sec, dec := math.Modf(js.Get("ts").Float())
 	headline := []interface{}{
-		ISO8601UTC(time.Unix(int64(sec), int64(dec*(1e9)))),
+		iso8601UTC(time.Unix(int64(sec), int64(dec*(1e9)))),
 		" ",
 		coloredLevel(js.Get("level")),
 		fmt.Sprintf("%-50s", js.Get("msg")),
@@ -97,7 +97,7 @@ func coloredLevel(level gjson.Result) string {
 	return color(fmt.Sprintf("%-8s", fmt.Sprint("[", strings.ToUpper(level.String()), "]")))
 }
 
-// ISO8601UTC formats given time to ISO8601.
-func ISO8601UTC(t time.Time) string {
+// iso8601UTC formats given time to ISO8601.
+func iso8601UTC(t time.Time) string {
 	return t.UTC().Format(time.RFC3339)
 }

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -85,7 +85,7 @@ func Uint256ToBytes(x *big.Int) (uint256 []byte, err error) {
 
 // ISO8601UTC formats given time to ISO8601.
 func ISO8601UTC(t time.Time) string {
-	return logger.ISO8601UTC(t)
+	return t.UTC().Format(time.RFC3339)
 }
 
 // NullISO8601UTC returns formatted time if valid, empty string otherwise.


### PR DESCRIPTION
### Why?

- `core/utils#ISO8601UTC()` was a wrapper of `core/logger#ISO8601UTC()` 
- `core/logger#ISO8601UTC()` was not used anywhere else.
- I think having utils depend on logger for this method does not make a lot of sense for a one-liner function. 