### PR TITLE
Remove retry-go

### DIFF
--- a/core/adapters/http.go
+++ b/core/adapters/http.go
@@ -200,7 +200,7 @@ func withRetry(
 		Jitter: true,
 	}
 	for {
-		responseBody, statusCode, err = withRetryFn(client, originalRequest, config)
+		responseBody, statusCode, err = makeHTTPCall(client, originalRequest, config)
 		if err == nil {
 			return responseBody, statusCode, nil
 		}
@@ -220,7 +220,7 @@ func withRetry(
 	}
 }
 
-func withRetryFn(
+func makeHTTPCall(
 	client *http.Client,
 	originalRequest *http.Request,
 	config HTTPRequestConfig,

--- a/core/adapters/http.go
+++ b/core/adapters/http.go
@@ -19,7 +19,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
-	"github.com/avast/retry-go"
+	"github.com/jpillora/backoff"
 )
 
 // HTTPGet requires a URL which is used for a GET request when the adapter is called.
@@ -194,59 +194,70 @@ func withRetry(
 	originalRequest *http.Request,
 	config HTTPRequestConfig,
 ) (responseBody []byte, statusCode int, err error) {
-	err = retry.Do(
-		func() error {
-			ctx, cancel := context.WithTimeout(context.Background(), config.timeout)
-			defer cancel()
-			requestWithTimeout := originalRequest.Clone(ctx)
+	bb := &backoff.Backoff{
+		Min: 100,
+		Max: 20 * time.Minute, // We stop retrying on the number of attempts!
+		Jitter: true,
+	}
+	for {
+		responseBody, statusCode, err = withRetryFn(client, originalRequest, config)
+		if err == nil {
+			return responseBody, statusCode, nil
+		}
+		if uint(bb.Attempt()) > config.maxAttempts { // Stop retrying.
+			return responseBody, statusCode, err
+		}
+		switch err.(type) {
+		// There is no point in retrying a request if the response was
+		// too large since it's likely that all retries will suffer the
+		// same problem
+		case *HTTPResponseTooLargeError:
+			return responseBody, statusCode, err
+		}
+		// Sleep and retry.
+		time.Sleep(bb.Duration())
+		logger.Debugw("http adapter error, will retry", "error", err.Error(), "attempt", bb.Attempt(), "timeout", config.timeout)
+	}
+}
 
-			start := time.Now()
+func withRetryFn(
+	client *http.Client,
+	originalRequest *http.Request,
+	config HTTPRequestConfig,
+) (responseBody []byte, statusCode int, err error) {
+		ctx, cancel := context.WithTimeout(context.Background(), config.timeout)
+		defer cancel()
+		requestWithTimeout := originalRequest.Clone(ctx)
 
-			r, e := client.Do(requestWithTimeout)
-			if e != nil {
-				return e
-			}
-			defer logger.ErrorIfCalling(r.Body.Close)
-			statusCode = r.StatusCode
-			elapsed := time.Since(start)
-			logger.Debugw(fmt.Sprintf("http adapter got %v in %s", statusCode, elapsed), "statusCode", statusCode, "timeElapsedSeconds", elapsed)
+		start := time.Now()
 
-			source := newMaxBytesReader(r.Body, config.sizeLimit)
-			bytes, e := ioutil.ReadAll(source)
-			if e != nil {
-				logger.Errorf("http adapter error reading body: %v", e.Error())
-				return e
-			}
-			elapsed = time.Since(start)
-			logger.Debugw(fmt.Sprintf("http adapter finished after %s", elapsed), "statusCode", statusCode, "timeElapsedSeconds", elapsed)
+		r, e := client.Do(requestWithTimeout)
+		if e != nil {
+			return nil, 0, e
+		}
+		defer logger.ErrorIfCalling(r.Body.Close)
 
-			responseBody = bytes
+		statusCode = r.StatusCode
+		elapsed := time.Since(start)
+		logger.Debugw(fmt.Sprintf("http adapter got %v in %s", statusCode, elapsed), "statusCode", statusCode, "timeElapsedSeconds", elapsed)
 
-			// Retry on 5xx since this might give a different result
-			if 500 <= r.StatusCode && r.StatusCode < 600 {
-				return &RemoteServerError{responseBody, statusCode}
-			}
+		source := newMaxBytesReader(r.Body, config.sizeLimit)
+		bytes, e := ioutil.ReadAll(source)
+		if e != nil {
+			logger.Errorf("http adapter error reading body: %v", e.Error())
+			return nil, statusCode, e
+		}
+		elapsed = time.Since(start)
+		logger.Debugw(fmt.Sprintf("http adapter finished after %s", elapsed), "statusCode", statusCode, "timeElapsedSeconds", elapsed)
 
-			return nil
-		},
-		retry.Attempts(config.maxAttempts),
-		retry.RetryIf(func(err error) bool {
-			switch err.(type) {
-			// There is no point in retrying a request if the response was
-			// too large since it's likely that all retries will suffer the
-			// same problem
-			case *HTTPResponseTooLargeError:
-				return false
-			default:
-				return true
-			}
-		}),
-		retry.OnRetry(func(n uint, err error) {
-			logger.Debugw("http adapter error, will retry", "error", err.Error(), "attempt", n, "timeout", config.timeout)
-		}),
-	)
+		responseBody = bytes
 
-	return responseBody, statusCode, err
+		// Retry on 5xx since this might give a different result
+		if 500 <= r.StatusCode && r.StatusCode < 600 {
+			return responseBody, statusCode, &RemoteServerError{responseBody, statusCode}
+		}
+
+		return responseBody, statusCode, nil
 }
 
 type RemoteServerError struct {

--- a/core/adapters/http_test.go
+++ b/core/adapters/http_test.go
@@ -762,6 +762,7 @@ func TestHTTP_RetryPolicy(t *testing.T) {
 				}
 				w.WriteHeader(200)
 			}))
+		defer srv.Close()
 		hga := makeHTTPGetAdapter(t, srv)
 		_ = hga.Perform(input, str)
 		if counter != 3 {
@@ -778,6 +779,7 @@ func TestHTTP_RetryPolicy(t *testing.T) {
 				largeBody := fillBlob(str.Config.DefaultHTTPLimit() + 10)
 				w.Write(largeBody)
 			}))
+		defer srv.Close()
 		hga := makeHTTPGetAdapter(t, srv)
 		_ = hga.Perform(input, str)
 		if counter != 1 {
@@ -792,6 +794,7 @@ func TestHTTP_RetryPolicy(t *testing.T) {
 				counter += 1
 				w.WriteHeader(500)
 			}))
+		defer srv.Close()
 		hga := makeHTTPGetAdapter(t, srv)
 		_ = hga.Perform(input, str)
 		expected := str.Config.DefaultMaxHTTPAttempts()

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/Depado/ginprom v1.2.1-0.20200115153638-53bbba851bd8
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
 	github.com/aristanetworks/goarista v0.0.0-20190204200901-2166578f3448 // indirect
-	github.com/avast/retry-go v2.6.0+incompatible
 	github.com/boj/redistore v0.0.0-20160128113310-fc113767cd6b // indirect
 	github.com/btcsuite/btcd v0.0.0-20190115013929-ed77733ec07d
 	github.com/cespare/cp v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -63,8 +63,6 @@ github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hC
 github.com/armon/consul-api v0.0.0-20180202201655-eb2c6b5be1b6/go.mod h1:grANhF5doyWs3UAsr3K4I6qtAmlQcZDesFNEHPZAzj8=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/avast/retry-go v2.6.0+incompatible h1:FelcMrm7Bxacr1/RM8+/eqkDkmVN7tjlsy51dOzB3LI=
-github.com/avast/retry-go v2.6.0+incompatible/go.mod h1:XtSnn+n/sHqQIpZ10K1qAevBhOOCWBLXXy3hyiqqBrY=
 github.com/aws/aws-sdk-go v1.25.48/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973/go.mod h1:Dwedo/Wpr24TaqPxmxbtue+5NUziq4I4S80YR8gNf3Q=
 github.com/beorn7/perks v1.0.0 h1:HWo1m869IqiPhD389kmkxeTalrjNbbJTC8LXupb+sl0=


### PR DESCRIPTION
### Why?

We are using two libraries for doing exponential retries: avast/retry-go and jpillora/backoff. Their config options are similar.

### How?

- I made the decision to remove avast/retry-go because it's only used in adapters/http whereas jpillora/backoff is used in utils and from there in many other places.
- I split the `withRetry` method into two smaller methods: one dealing only with the exponential retry, the other dealing only with the http call. 
