### PR TITLE
Wait for MinOutgoingConfirmations before proceeding in ethtx adapter

### DIFF
--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -32,9 +32,13 @@ type EthTx struct {
 	FunctionSelector eth.FunctionSelector `json:"functionSelector"`
 	DataPrefix       hexutil.Bytes        `json:"dataPrefix"`
 	DataFormat       string               `json:"format"`
+	GasLimit         uint64               `json:"gasLimit,omitempty"`
+
 	// GasPrice only needed for legacy tx manager
 	GasPrice *utils.Big `json:"gasPrice" gorm:"type:numeric"`
-	GasLimit uint64     `json:"gasLimit,omitempty"`
+
+	// MinRequiredOutgoingConfirmations only works with bulletprooftxmanager
+	MinRequiredOutgoingConfirmations uint64 `json:"minRequiredOutgoingConfirmations,omitempty"`
 }
 
 // TaskType returns the type of Adapter.
@@ -70,7 +74,7 @@ func (e *EthTx) perform(input models.RunInput, store *strpkg.Store) models.RunOu
 func (e *EthTx) checkForConfirmation(trtx models.EthTaskRunTx, input models.RunInput, store *store.Store) models.RunOutput {
 	switch trtx.EthTx.State {
 	case models.EthTxConfirmed:
-		return checkEthTxForReceipt(trtx.EthTx.ID, input, store)
+		return e.checkEthTxForReceipt(trtx.EthTx.ID, input, store)
 	case models.EthTxFatalError:
 		return models.NewRunOutputError(trtx.EthTx.GetError())
 	default:
@@ -118,38 +122,54 @@ func (e *EthTx) insertEthTx(input models.RunInput, store *store.Store) models.Ru
 	return models.NewRunOutputPendingOutgoingConfirmationsWithData(input.Data())
 }
 
-func checkEthTxForReceipt(ethTxID int64, input models.RunInput, store *store.Store) models.RunOutput {
+func (e *EthTx) checkEthTxForReceipt(ethTxID int64, input models.RunInput, s *store.Store) models.RunOutput {
+	var minRequiredOutgoingConfirmations uint64
+	if e.MinRequiredOutgoingConfirmations == 0 {
+		minRequiredOutgoingConfirmations = s.Config.MinOutgoingConfirmations()
+	} else {
+		minRequiredOutgoingConfirmations = e.MinRequiredOutgoingConfirmations
+	}
+
+	hash, err := getConfirmedTxHash(ethTxID, s.GetRawDB(), minRequiredOutgoingConfirmations)
+
+	if err != nil {
+		logger.Error(err)
+		return models.NewRunOutputError(err)
+	}
+
+	if hash == nil {
+		return models.NewRunOutputPendingOutgoingConfirmationsWithData(input.Data())
+	}
+
+	output := models.JSON{}
+	output, err = output.Add("result", (*hash).Hex())
+	if err != nil {
+		err = errors.Wrap(err, "checkEthTxForReceipt failed")
+		logger.Error(err)
+		return models.NewRunOutputError(err)
+	}
+	return models.NewRunOutputComplete(output)
+}
+
+func getConfirmedTxHash(ethTxID int64, db *gorm.DB, minRequiredOutgoingConfirmations uint64) (*common.Hash, error) {
 	receipt := models.EthReceipt{}
-	err := store.GetRawDB().
+	err := db.
 		Joins("INNER JOIN eth_tx_attempts ON eth_tx_attempts.hash = eth_receipts.tx_hash AND eth_tx_attempts.eth_tx_id = ?", ethTxID).
 		Joins("INNER JOIN eth_txes ON eth_txes.id = eth_tx_attempts.eth_tx_id AND eth_txes.state = ?", models.EthTxConfirmed).
+		Where("eth_receipts.block_number <= (SELECT max(number) - ? FROM heads)", minRequiredOutgoingConfirmations).
 		First(&receipt).
 		Error
 
 	if err == nil {
-		output := models.JSON{}
-		output, err = output.Add("result", receipt.TxHash.Hex())
-		if err != nil {
-			err = errors.Wrap(err, "checkEthTxForReceipt failed")
-			logger.Error(err)
-			return models.NewRunOutputError(err)
-		}
-		return models.NewRunOutputComplete(output)
+		return &receipt.TxHash, nil
 	}
 
 	if gorm.IsRecordNotFoundError(err) {
-		// If this happens, one of two scenarios is possible:
-		// 1. A re-org occurred between the initial fetch of the eth_tx and this point, and now the eth_tx is unconfirmed again
-		// 2. Something terrible happened and the entire eth_tx or it's receipts have gone missing without a trace
-		// In either case, the best course of action is to remain in
-		// pending_outgoing_confirmations state and check again on the next
-		// go around until the tx manager sorts itself out.
-		return models.NewRunOutputPendingOutgoingConfirmationsWithData(input.Data())
+		return nil, nil
 	}
 
-	err = errors.Wrap(err, "checkForConfirmation could not find receipt for confirmed eth_tx")
-	logger.Error(err)
-	return models.NewRunOutputError(err)
+	return nil, errors.Wrap(err, "getConfirmedTxHash failed")
+
 }
 
 func (e *EthTx) legacyPerform(input models.RunInput, store *strpkg.Store) models.RunOutput {

--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -520,6 +520,8 @@ func TestEthTxAdapter_Perform_BPTXM(t *testing.T) {
 		assert.Equal(t, "70a08231888888880000000000000000000000000000000000000000000000000000009786856756", hex.EncodeToString(etrt.EthTx.EncodedPayload))
 		assert.Equal(t, gasLimit, etrt.EthTx.GasLimit)
 		assert.Equal(t, models.EthTxUnstarted, etrt.EthTx.State)
+
+		notifier.AssertExpectations(t)
 	})
 
 	t.Run("with bytes DataFormat writes correct encoded data to database", func(t *testing.T) {
@@ -610,12 +612,13 @@ func TestEthTxAdapter_Perform_BPTXM(t *testing.T) {
 		assert.Equal(t, models.RunStatusPendingOutgoingConfirmations, runOutput.Status())
 	})
 
-	t.Run("with confirmed transaction returns output complete with transaction hash pulled from receipt", func(t *testing.T) {
+	t.Run("with confirmed transaction with exactly one attempt with exactly one receipt that is younger than minRequiredOutgoingConfirmations, returns output pending_outgoing_confirmations", func(t *testing.T) {
 		adapter := adapters.EthTx{
-			ToAddress:        toAddress,
-			GasLimit:         gasLimit,
-			FunctionSelector: functionSelector,
-			DataPrefix:       dataPrefix,
+			ToAddress:                        toAddress,
+			GasLimit:                         gasLimit,
+			FunctionSelector:                 functionSelector,
+			DataPrefix:                       dataPrefix,
+			MinRequiredOutgoingConfirmations: 12,
 		}
 		jobRunID := models.NewID()
 		taskRunID := cltest.MustInsertTaskRun(t, store)
@@ -624,6 +627,39 @@ func TestEthTxAdapter_Perform_BPTXM(t *testing.T) {
 		confirmedAttemptHash := etx.EthTxAttempts[0].Hash
 
 		cltest.MustInsertEthReceipt(t, store, 1, cltest.NewHash(), confirmedAttemptHash)
+		require.NoError(t, store.IdempotentInsertHead(models.Head{
+			Hash:   cltest.NewHash(),
+			Number: 12,
+		}))
+		store.GetRawDB().Exec(`INSERT INTO eth_task_run_txes (task_run_id, eth_tx_id) VALUES ($1, $2)`, taskRunID.UUID(), etx.ID)
+		input := models.NewRunInputWithResult(jobRunID, taskRunID, "0x9786856756", models.RunStatusUnstarted)
+
+		// Do the thing
+		runOutput := adapter.Perform(*input, store)
+
+		require.NoError(t, runOutput.Error())
+		assert.Equal(t, models.RunStatusPendingOutgoingConfirmations, runOutput.Status())
+	})
+
+	t.Run("with confirmed transaction with exactly one attempt with exactly one receipt that is equal to minRequiredOutgoingConfirmations, returns output complete with transaction hash pulled from receipt", func(t *testing.T) {
+		adapter := adapters.EthTx{
+			ToAddress:                        toAddress,
+			GasLimit:                         gasLimit,
+			FunctionSelector:                 functionSelector,
+			DataPrefix:                       dataPrefix,
+			MinRequiredOutgoingConfirmations: 12,
+		}
+		jobRunID := models.NewID()
+		taskRunID := cltest.MustInsertTaskRun(t, store)
+		etx := cltest.MustInsertConfirmedEthTxWithAttempt(t, store, 3, 1)
+
+		confirmedAttemptHash := etx.EthTxAttempts[0].Hash
+
+		cltest.MustInsertEthReceipt(t, store, 1, cltest.NewHash(), confirmedAttemptHash)
+		require.NoError(t, store.IdempotentInsertHead(models.Head{
+			Hash:   cltest.NewHash(),
+			Number: 13,
+		}))
 		store.GetRawDB().Exec(`INSERT INTO eth_task_run_txes (task_run_id, eth_tx_id) VALUES ($1, $2)`, taskRunID.UUID(), etx.ID)
 		input := models.NewRunInputWithResult(jobRunID, taskRunID, "0x9786856756", models.RunStatusUnstarted)
 
@@ -633,8 +669,66 @@ func TestEthTxAdapter_Perform_BPTXM(t *testing.T) {
 		require.NoError(t, runOutput.Error())
 		assert.Equal(t, models.RunStatusCompleted, runOutput.Status())
 		assert.Equal(t, confirmedAttemptHash.Hex(), runOutput.Result().String())
+	})
 
-		notifier.AssertExpectations(t)
+	t.Run("with confirmed transaction with exactly one attempt with exactly one receipt that is older than minRequiredOutgoingConfirmations, returns output complete with transaction hash pulled from receipt", func(t *testing.T) {
+		adapter := adapters.EthTx{
+			ToAddress:                        toAddress,
+			GasLimit:                         gasLimit,
+			FunctionSelector:                 functionSelector,
+			DataPrefix:                       dataPrefix,
+			MinRequiredOutgoingConfirmations: 12,
+		}
+		jobRunID := models.NewID()
+		taskRunID := cltest.MustInsertTaskRun(t, store)
+		etx := cltest.MustInsertConfirmedEthTxWithAttempt(t, store, 4, 1)
+
+		confirmedAttemptHash := etx.EthTxAttempts[0].Hash
+
+		cltest.MustInsertEthReceipt(t, store, 1, cltest.NewHash(), confirmedAttemptHash)
+		require.NoError(t, store.IdempotentInsertHead(models.Head{
+			Hash:   cltest.NewHash(),
+			Number: 14,
+		}))
+		store.GetRawDB().Exec(`INSERT INTO eth_task_run_txes (task_run_id, eth_tx_id) VALUES ($1, $2)`, taskRunID.UUID(), etx.ID)
+		input := models.NewRunInputWithResult(jobRunID, taskRunID, "0x9786856756", models.RunStatusUnstarted)
+
+		// Do the thing
+		runOutput := adapter.Perform(*input, store)
+
+		require.NoError(t, runOutput.Error())
+		assert.Equal(t, models.RunStatusCompleted, runOutput.Status())
+		assert.Equal(t, confirmedAttemptHash.Hex(), runOutput.Result().String())
+	})
+
+	t.Run("with confirmed transaction with two attempts, one of which has exactly one receipt that is older than the default MinRequiredOutgoingConfirmations, returns output complete with transaction hash pulled from receipt", func(t *testing.T) {
+		adapter := adapters.EthTx{
+			ToAddress:        toAddress,
+			GasLimit:         gasLimit,
+			FunctionSelector: functionSelector,
+			DataPrefix:       dataPrefix,
+		}
+		jobRunID := models.NewID()
+		taskRunID := cltest.MustInsertTaskRun(t, store)
+		etx := cltest.MustInsertConfirmedEthTxWithAttempt(t, store, 5, 1)
+		attempt2 := cltest.MustInsertBroadcastEthTxAttempt(t, etx.ID, store, 2)
+
+		confirmedAttemptHash := attempt2.Hash
+
+		cltest.MustInsertEthReceipt(t, store, 1, cltest.NewHash(), confirmedAttemptHash)
+		require.NoError(t, store.IdempotentInsertHead(models.Head{
+			Hash:   cltest.NewHash(),
+			Number: int64(store.Config.MinOutgoingConfirmations()) + 2,
+		}))
+		store.GetRawDB().Exec(`INSERT INTO eth_task_run_txes (task_run_id, eth_tx_id) VALUES ($1, $2)`, taskRunID.UUID(), etx.ID)
+		input := models.NewRunInputWithResult(jobRunID, taskRunID, "0x9786856756", models.RunStatusUnstarted)
+
+		// Do the thing
+		runOutput := adapter.Perform(*input, store)
+
+		require.NoError(t, runOutput.Error())
+		assert.Equal(t, models.RunStatusCompleted, runOutput.Status())
+		assert.Equal(t, confirmedAttemptHash.Hex(), runOutput.Result().String())
 	})
 
 	t.Run("with transaction that ended up in fatal_error state returns job run error", func(t *testing.T) {
@@ -658,4 +752,5 @@ func TestEthTxAdapter_Perform_BPTXM(t *testing.T) {
 		assert.Equal(t, models.RunStatusErrored, runOutput.Status())
 		assert.Equal(t, "", runOutput.Result().String())
 	})
+
 }

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -770,7 +770,7 @@ func MustInsertUnconfirmedEthTxWithBroadcastAttempt(t *testing.T, store *strpkg.
 	etx.Nonce = &n
 	etx.State = models.EthTxUnconfirmed
 	require.NoError(t, store.GetRawDB().Save(&etx).Error)
-	attempt := NewEthTxAttempt(t, etx.ID, store)
+	attempt := NewEthTxAttempt(t, etx.ID)
 
 	tx := types.NewTransaction(uint64(nonce), NewAddress(), big.NewInt(142), 242, big.NewInt(342), []byte{1, 2, 3})
 	rlp := new(bytes.Buffer)
@@ -792,7 +792,7 @@ func MustInsertConfirmedEthTxWithAttempt(t *testing.T, store *strpkg.Store, nonc
 	etx.Nonce = &nonce
 	etx.State = models.EthTxConfirmed
 	require.NoError(t, store.GetRawDB().Save(&etx).Error)
-	attempt := NewEthTxAttempt(t, etx.ID, store)
+	attempt := NewEthTxAttempt(t, etx.ID)
 	attempt.BroadcastBeforeBlockNum = &broadcastBeforeBlockNum
 	attempt.State = models.EthTxAttemptBroadcast
 	require.NoError(t, store.GetRawDB().Save(&attempt).Error)
@@ -807,7 +807,7 @@ func GetDefaultFromAddress(t *testing.T, store *strpkg.Store) common.Address {
 	return key.Address.Address()
 }
 
-func NewEthTxAttempt(t *testing.T, etxID int64, store *strpkg.Store) models.EthTxAttempt {
+func NewEthTxAttempt(t *testing.T, etxID int64) models.EthTxAttempt {
 	gasPrice := utils.NewBig(big.NewInt(1))
 	return models.EthTxAttempt{
 		EthTxID:  etxID,
@@ -817,6 +817,14 @@ func NewEthTxAttempt(t *testing.T, etxID int64, store *strpkg.Store) models.EthT
 		SignedRawTx: hexutil.MustDecode("0xf889808504a817c8008307a12094000000000000000000000000000000000000000080a400000000000000000000000000000000000000000000000000000000000000000000000025a0838fe165906e2547b9a052c099df08ec891813fea4fcdb3c555362285eb399c5a070db99322490eb8a0f2270be6eca6e3aedbc49ff57ef939cf2774f12d08aa85e"),
 		Hash:        NewHash(),
 	}
+}
+
+func MustInsertBroadcastEthTxAttempt(t *testing.T, etxID int64, store *strpkg.Store, gasPrice int64) models.EthTxAttempt {
+	attempt := NewEthTxAttempt(t, etxID)
+	attempt.State = models.EthTxAttemptBroadcast
+	attempt.GasPrice = *utils.NewBig(big.NewInt(gasPrice))
+	require.NoError(t, store.GetRawDB().Create(&attempt).Error)
+	return attempt
 }
 
 func MustInsertEthReceipt(t *testing.T, s *strpkg.Store, blockNumber int64, blockHash common.Hash, txHash common.Hash) models.EthReceipt {

--- a/core/services/bulletprooftxmanager/eth_broadcaster_test.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster_test.go
@@ -34,7 +34,7 @@ func mustInsertInProgressEthTxWithAttempt(t *testing.T, store *store.Store, nonc
 	etx.Nonce = &nonce
 	etx.State = models.EthTxInProgress
 	require.NoError(t, store.GetRawDB().Save(&etx).Error)
-	attempt := cltest.NewEthTxAttempt(t, etx.ID, store)
+	attempt := cltest.NewEthTxAttempt(t, etx.ID)
 	tx := gethTypes.NewTransaction(uint64(nonce), cltest.NewAddress(), big.NewInt(142), 242, big.NewInt(342), []byte{1, 2, 3})
 	rlp := new(bytes.Buffer)
 	require.NoError(t, tx.EncodeRLP(rlp))

--- a/core/services/bulletprooftxmanager/eth_confirmer_test.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer_test.go
@@ -31,7 +31,7 @@ func mustInsertUnstartedEthTx(t *testing.T, s *store.Store) {
 }
 
 func newBroadcastEthTxAttempt(t *testing.T, etxID int64, store *store.Store, gasPrice ...int64) models.EthTxAttempt {
-	attempt := cltest.NewEthTxAttempt(t, etxID, store)
+	attempt := cltest.NewEthTxAttempt(t, etxID)
 	attempt.State = models.EthTxAttemptBroadcast
 	if len(gasPrice) > 0 {
 		gp := gasPrice[0]

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -420,9 +420,9 @@ func (c Config) MinIncomingConfirmations() uint32 {
 	return c.viper.GetUint32(EnvVarName("MinIncomingConfirmations"))
 }
 
-// MinOutgoingConfirmations represents the minimum number of block
-// confirmations that need to be recorded on an outgoing transaction before a
-// task is completed.
+// MinOutgoingConfirmations represents the default minimum number of block
+// confirmations that need to be recorded on an outgoing ethtx task before the run can move onto the next task.
+// This can be overridden on a per-task basis by setting the `MinRequiredOutgoingConfirmations` parameter.
 func (c Config) MinOutgoingConfirmations() uint64 {
 	return c.viper.GetUint64(EnvVarName("MinOutgoingConfirmations"))
 }


### PR DESCRIPTION
This forces the ethtx adapter to wait for
`MinRequiredOutgoingConfirmations` before marking a transaction as
confirmed and moving on.

It faithfully replicates the legacy ethtx behaviour with one exception:

`MIN_OUTGOING_CONFIRMATIONS` is now a default, and
`minRequiredOutgoingConfirmations` may now also be set on the ethtx task
spec to optionally override this default.