### PR TITLE
Remove guregu/nullv3 and replace it with ./core/null

### DIFF
--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/eth"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/store"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -15,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
-	"gopkg.in/guregu/null.v3"
 )
 
 const (

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/null"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
@@ -21,7 +22,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
-	"gopkg.in/guregu/null.v3"
 )
 
 func TestClient_RunNodeShowsEnv(t *testing.T) {

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -28,6 +28,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/gracefulpanic"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -54,7 +55,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 	"go.uber.org/zap/zapcore"
-	null "gopkg.in/guregu/null.v3"
 )
 
 const (

--- a/core/internal/mocks/tx_manager.go
+++ b/core/internal/mocks/tx_manager.go
@@ -20,7 +20,7 @@ import (
 
 	models "github.com/smartcontractkit/chainlink/core/store/models"
 
-	null "gopkg.in/guregu/null.v3"
+	null "github.com/smartcontractkit/chainlink/core/null"
 
 	store "github.com/smartcontractkit/chainlink/core/store"
 

--- a/core/null/string.go
+++ b/core/null/string.go
@@ -1,0 +1,123 @@
+// Package null contains SQL types that consider zero input and null input as separate values,
+// with convenient support for JSON and text marshaling.
+// Types in this package will always encode to their null value if null.
+// Use the zero subpackage if you want zero values and null to be treated the same.
+package null
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"reflect"
+)
+
+// String is a nullable string. It supports SQL and JSON serialization.
+// It will marshal to null if null. Blank string input will be considered null.
+type String struct {
+	sql.NullString
+}
+
+// StringFrom creates a new String that will never be blank.
+func StringFrom(s string) String {
+	return NewString(s, true)
+}
+
+// StringFromPtr creates a new String that be null if s is nil.
+func StringFromPtr(s *string) String {
+	if s == nil {
+		return NewString("", false)
+	}
+	return NewString(*s, true)
+}
+
+// ValueOrZero returns the inner value if valid, otherwise zero.
+func (s String) ValueOrZero() string {
+	if !s.Valid {
+		return ""
+	}
+	return s.String
+}
+
+// NewString creates a new String
+func NewString(s string, valid bool) String {
+	return String{
+		NullString: sql.NullString{
+			String: s,
+			Valid:  valid,
+		},
+	}
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+// It supports string and null input. Blank string input does not produce a null String.
+// It also supports unmarshalling a sql.NullString.
+func (s *String) UnmarshalJSON(data []byte) error {
+	var err error
+	var v interface{}
+	if err = json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	switch x := v.(type) {
+	case string:
+		s.String = x
+	case map[string]interface{}:
+		err = json.Unmarshal(data, &s.NullString)
+	case nil:
+		s.Valid = false
+		return nil
+	default:
+		err = fmt.Errorf("json: cannot unmarshal %v into Go value of type null.String", reflect.TypeOf(v).Name())
+	}
+	s.Valid = err == nil
+	return err
+}
+
+// MarshalJSON implements json.Marshaler.
+// It will encode null if this String is null.
+func (s String) MarshalJSON() ([]byte, error) {
+	if !s.Valid {
+		return []byte("null"), nil
+	}
+	return json.Marshal(s.String)
+}
+
+// MarshalText implements encoding.TextMarshaler.
+// It will encode a blank string when this String is null.
+func (s String) MarshalText() ([]byte, error) {
+	if !s.Valid {
+		return []byte{}, nil
+	}
+	return []byte(s.String), nil
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler.
+// It will unmarshal to a null String if the input is a blank string.
+func (s *String) UnmarshalText(text []byte) error {
+	s.String = string(text)
+	s.Valid = s.String != ""
+	return nil
+}
+
+// SetValid changes this String's value and also sets it to be non-null.
+func (s *String) SetValid(v string) {
+	s.String = v
+	s.Valid = true
+}
+
+// Ptr returns a pointer to this String's value, or a nil pointer if this String is null.
+func (s String) Ptr() *string {
+	if !s.Valid {
+		return nil
+	}
+	return &s.String
+}
+
+// IsZero returns true for null strings, for potential future omitempty support.
+func (s String) IsZero() bool {
+	return !s.Valid
+}
+
+// Equal returns true if both strings have the same value or are both null.
+func (s String) Equal(other String) bool {
+	return s.Valid == other.Valid && (!s.Valid || s.String == other.String)
+}

--- a/core/null/string.go
+++ b/core/null/string.go
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2014, Greg Roseberry
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
 // Package null contains SQL types that consider zero input and null input as separate values,
 // with convenient support for JSON and text marshaling.
 // Types in this package will always encode to their null value if null.

--- a/core/null/string_test.go
+++ b/core/null/string_test.go
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2014, Greg Roseberry
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
 package null
 
 import (

--- a/core/null/string_test.go
+++ b/core/null/string_test.go
@@ -1,0 +1,247 @@
+package null
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+var (
+	stringJSON      = []byte(`"test"`)
+	blankStringJSON = []byte(`""`)
+	nullStringJSON  = []byte(`{"String":"test","Valid":true}`)
+
+	nullJSON    = []byte(`null`)
+	invalidJSON = []byte(`:)`)
+	boolJSON    = []byte(`true`)
+)
+
+func TestStringFrom(t *testing.T) {
+	str := StringFrom("test")
+	assertStr(t, str, "StringFrom() string")
+
+	zero := StringFrom("")
+	if !zero.Valid {
+		t.Error("StringFrom(0)", "is invalid, but should be valid")
+	}
+}
+
+func TestStringFromPtr(t *testing.T) {
+	s := "test"
+	sptr := &s
+	str := StringFromPtr(sptr)
+	assertStr(t, str, "StringFromPtr() string")
+
+	null := StringFromPtr(nil)
+	assertNullStr(t, null, "StringFromPtr(nil)")
+}
+
+func TestUnmarshalString(t *testing.T) {
+	var str String
+	err := json.Unmarshal(stringJSON, &str)
+	maybePanic(err)
+	assertStr(t, str, "string json")
+
+	var ns String
+	err = json.Unmarshal(nullStringJSON, &ns)
+	maybePanic(err)
+	assertStr(t, ns, "sql.NullString json")
+
+	var blank String
+	err = json.Unmarshal(blankStringJSON, &blank)
+	maybePanic(err)
+	if !blank.Valid {
+		t.Error("blank string should be valid")
+	}
+
+	var null String
+	err = json.Unmarshal(nullJSON, &null)
+	maybePanic(err)
+	assertNullStr(t, null, "null json")
+
+	var badType String
+	err = json.Unmarshal(boolJSON, &badType)
+	if err == nil {
+		panic("err should not be nil")
+	}
+	assertNullStr(t, badType, "wrong type json")
+
+	var invalid String
+	err = invalid.UnmarshalJSON(invalidJSON)
+	if _, ok := err.(*json.SyntaxError); !ok {
+		t.Errorf("expected json.SyntaxError, not %T", err)
+	}
+	assertNullStr(t, invalid, "invalid json")
+}
+
+func TestTextUnmarshalString(t *testing.T) {
+	var str String
+	err := str.UnmarshalText([]byte("test"))
+	maybePanic(err)
+	assertStr(t, str, "UnmarshalText() string")
+
+	var null String
+	err = null.UnmarshalText([]byte(""))
+	maybePanic(err)
+	assertNullStr(t, null, "UnmarshalText() empty string")
+}
+
+func TestMarshalString(t *testing.T) {
+	str := StringFrom("test")
+	data, err := json.Marshal(str)
+	maybePanic(err)
+	assertJSONEquals(t, data, `"test"`, "non-empty json marshal")
+	data, err = str.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "test", "non-empty text marshal")
+
+	// empty values should be encoded as an empty string
+	zero := StringFrom("")
+	data, err = json.Marshal(zero)
+	maybePanic(err)
+	assertJSONEquals(t, data, `""`, "empty json marshal")
+	data, err = zero.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "", "string marshal text")
+
+	null := StringFromPtr(nil)
+	data, err = json.Marshal(null)
+	maybePanic(err)
+	assertJSONEquals(t, data, `null`, "null json marshal")
+	data, err = null.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, data, "", "string marshal text")
+}
+
+func TestStringPointer(t *testing.T) {
+	str := StringFrom("test")
+	ptr := str.Ptr()
+	if *ptr != "test" {
+		t.Errorf("bad %s string: %#v ≠ %s\n", "pointer", ptr, "test")
+	}
+
+	null := NewString("", false)
+	ptr = null.Ptr()
+	if ptr != nil {
+		t.Errorf("bad %s string: %#v ≠ %s\n", "nil pointer", ptr, "nil")
+	}
+}
+
+func TestStringIsZero(t *testing.T) {
+	str := StringFrom("test")
+	if str.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	blank := StringFrom("")
+	if blank.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	empty := NewString("", true)
+	if empty.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	null := StringFromPtr(nil)
+	if !null.IsZero() {
+		t.Errorf("IsZero() should be true")
+	}
+}
+
+func TestStringSetValid(t *testing.T) {
+	change := NewString("", false)
+	assertNullStr(t, change, "SetValid()")
+	change.SetValid("test")
+	assertStr(t, change, "SetValid()")
+}
+
+func TestStringScan(t *testing.T) {
+	var str String
+	err := str.Scan("test")
+	maybePanic(err)
+	assertStr(t, str, "scanned string")
+
+	var null String
+	err = null.Scan(nil)
+	maybePanic(err)
+	assertNullStr(t, null, "scanned null")
+}
+
+func TestStringValueOrZero(t *testing.T) {
+	valid := NewString("test", true)
+	if valid.ValueOrZero() != "test" {
+		t.Error("unexpected ValueOrZero", valid.ValueOrZero())
+	}
+
+	invalid := NewString("test", false)
+	if invalid.ValueOrZero() != "" {
+		t.Error("unexpected ValueOrZero", invalid.ValueOrZero())
+	}
+}
+
+func TestStringEqual(t *testing.T) {
+	str1 := NewString("foo", false)
+	str2 := NewString("foo", false)
+	assertStringEqualIsTrue(t, str1, str2)
+
+	str1 = NewString("foo", false)
+	str2 = NewString("bar", false)
+	assertStringEqualIsTrue(t, str1, str2)
+
+	str1 = NewString("foo", true)
+	str2 = NewString("foo", true)
+	assertStringEqualIsTrue(t, str1, str2)
+
+	str1 = NewString("foo", true)
+	str2 = NewString("foo", false)
+	assertStringEqualIsFalse(t, str1, str2)
+
+	str1 = NewString("foo", false)
+	str2 = NewString("foo", true)
+	assertStringEqualIsFalse(t, str1, str2)
+
+	str1 = NewString("foo", true)
+	str2 = NewString("bar", true)
+	assertStringEqualIsFalse(t, str1, str2)
+}
+
+func maybePanic(err error) {
+	if err != nil {
+		panic(err)
+	}
+}
+
+func assertStr(t *testing.T, s String, from string) {
+	if s.String != "test" {
+		t.Errorf("bad %s string: %s ≠ %s\n", from, s.String, "test")
+	}
+	if !s.Valid {
+		t.Error(from, "is invalid, but should be valid")
+	}
+}
+
+func assertNullStr(t *testing.T, s String, from string) {
+	if s.Valid {
+		t.Error(from, "is valid, but should be invalid")
+	}
+}
+
+func assertJSONEquals(t *testing.T, data []byte, cmp string, from string) {
+	if string(data) != cmp {
+		t.Errorf("bad %s data: %s ≠ %s\n", from, data, cmp)
+	}
+}
+
+func assertStringEqualIsTrue(t *testing.T, a, b String) {
+	t.Helper()
+	if !a.Equal(b) {
+		t.Errorf("Equal() of String{\"%v\", Valid:%t} and String{\"%v\", Valid:%t} should return true", a.String, a.Valid, b.String, b.Valid)
+	}
+}
+
+func assertStringEqualIsFalse(t *testing.T, a, b String) {
+	t.Helper()
+	if a.Equal(b) {
+		t.Errorf("Equal() of String{\"%v\", Valid:%t} and String{\"%v\", Valid:%t} should return false", a.String, a.Valid, b.String, b.Valid)
+	}
+}

--- a/core/null/time.go
+++ b/core/null/time.go
@@ -1,0 +1,163 @@
+package null
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"reflect"
+	"time"
+)
+
+// Time is a nullable time.Time. It supports SQL and JSON serialization.
+// It will marshal to null if null.
+type Time struct {
+	Time  time.Time
+	Valid bool
+}
+
+// Scan implements the Scanner interface.
+func (t *Time) Scan(value interface{}) error {
+	var err error
+	switch x := value.(type) {
+	case time.Time:
+		t.Time = x
+	case nil:
+		t.Valid = false
+		return nil
+	default:
+		err = fmt.Errorf("null: cannot scan type %T into null.Time: %v", value, value)
+	}
+	t.Valid = err == nil
+	return err
+}
+
+// Value implements the driver Valuer interface.
+func (t Time) Value() (driver.Value, error) {
+	if !t.Valid {
+		return nil, nil
+	}
+	return t.Time, nil
+}
+
+// NewTime creates a new Time.
+func NewTime(t time.Time, valid bool) Time {
+	return Time{
+		Time:  t,
+		Valid: valid,
+	}
+}
+
+// TimeFrom creates a new Time that will always be valid.
+func TimeFrom(t time.Time) Time {
+	return NewTime(t, true)
+}
+
+// TimeFromPtr creates a new Time that will be null if t is nil.
+func TimeFromPtr(t *time.Time) Time {
+	if t == nil {
+		return NewTime(time.Time{}, false)
+	}
+	return NewTime(*t, true)
+}
+
+// ValueOrZero returns the inner value if valid, otherwise zero.
+func (t Time) ValueOrZero() time.Time {
+	if !t.Valid {
+		return time.Time{}
+	}
+	return t.Time
+}
+
+// MarshalJSON implements json.Marshaler.
+// It will encode null if this time is null.
+func (t Time) MarshalJSON() ([]byte, error) {
+	if !t.Valid {
+		return []byte("null"), nil
+	}
+	return t.Time.MarshalJSON()
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+// It supports string, object (e.g. pq.NullTime and friends)
+// and null input.
+func (t *Time) UnmarshalJSON(data []byte) error {
+	var err error
+	var v interface{}
+	if err = json.Unmarshal(data, &v); err != nil {
+		return err
+	}
+	switch x := v.(type) {
+	case string:
+		err = t.Time.UnmarshalJSON(data)
+	case map[string]interface{}:
+		ti, tiOK := x["Time"].(string)
+		valid, validOK := x["Valid"].(bool)
+		if !tiOK || !validOK {
+			return fmt.Errorf(`json: unmarshalling object into Go value of type null.Time requires key "Time" to be of type string and key "Valid" to be of type bool; found %T and %T, respectively`, x["Time"], x["Valid"])
+		}
+		err = t.Time.UnmarshalText([]byte(ti))
+		t.Valid = valid
+		return err
+	case nil:
+		t.Valid = false
+		return nil
+	default:
+		err = fmt.Errorf("json: cannot unmarshal %v into Go value of type null.Time", reflect.TypeOf(v).Name())
+	}
+	t.Valid = err == nil
+	return err
+}
+
+func (t Time) MarshalText() ([]byte, error) {
+	if !t.Valid {
+		return []byte("null"), nil
+	}
+	return t.Time.MarshalText()
+}
+
+func (t *Time) UnmarshalText(text []byte) error {
+	str := string(text)
+	if str == "" || str == "null" {
+		t.Valid = false
+		return nil
+	}
+	if err := t.Time.UnmarshalText(text); err != nil {
+		return err
+	}
+	t.Valid = true
+	return nil
+}
+
+// SetValid changes this Time's value and sets it to be non-null.
+func (t *Time) SetValid(v time.Time) {
+	t.Time = v
+	t.Valid = true
+}
+
+// Ptr returns a pointer to this Time's value, or a nil pointer if this Time is null.
+func (t Time) Ptr() *time.Time {
+	if !t.Valid {
+		return nil
+	}
+	return &t.Time
+}
+
+// IsZero returns true for invalid Times, hopefully for future omitempty support.
+// A non-null Time with a zero value will not be considered zero.
+func (t Time) IsZero() bool {
+	return !t.Valid
+}
+
+// Equal returns true if both Time objects encode the same time or are both null.
+// Two times can be equal even if they are in different locations.
+// For example, 6:00 +0200 CEST and 4:00 UTC are Equal.
+func (t Time) Equal(other Time) bool {
+	return t.Valid == other.Valid && (!t.Valid || t.Time.Equal(other.Time))
+}
+
+// ExactEqual returns true if both Time objects are equal or both null.
+// ExactEqual returns false for times that are in different locations or
+// have a different monotonic clock reading.
+func (t Time) ExactEqual(other Time) bool {
+	return t.Valid == other.Valid && (!t.Valid || t.Time == other.Time)
+}

--- a/core/null/time.go
+++ b/core/null/time.go
@@ -84,27 +84,29 @@ func (t *Time) UnmarshalJSON(data []byte) error {
 	var err error
 	var v interface{}
 	if err = json.Unmarshal(data, &v); err != nil {
+		t.Valid = false
 		return err
 	}
 	switch x := v.(type) {
 	case string:
 		err = t.Time.UnmarshalJSON(data)
+		t.Valid = err == nil
 	case map[string]interface{}:
 		ti, tiOK := x["Time"].(string)
 		valid, validOK := x["Valid"].(bool)
 		if !tiOK || !validOK {
-			return fmt.Errorf(`json: unmarshalling object into Go value of type null.Time requires key "Time" to be of type string and key "Valid" to be of type bool; found %T and %T, respectively`, x["Time"], x["Valid"])
+			err = fmt.Errorf(`json: unmarshalling object into Go value of type null.Time requires key "Time" to be of type string and key "Valid" to be of type bool; found %T and %T, respectively`, x["Time"], x["Valid"])
+			t.Valid = false
+		} else {
+			err = t.Time.UnmarshalText([]byte(ti))
+			t.Valid = valid
 		}
-		err = t.Time.UnmarshalText([]byte(ti))
-		t.Valid = valid
-		return err
 	case nil:
 		t.Valid = false
-		return nil
 	default:
 		err = fmt.Errorf("json: cannot unmarshal %v into Go value of type null.Time", reflect.TypeOf(v).Name())
+		t.Valid = false
 	}
-	t.Valid = err == nil
 	return err
 }
 

--- a/core/null/time.go
+++ b/core/null/time.go
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2014, Greg Roseberry
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
 package null
 
 import (

--- a/core/null/time_test.go
+++ b/core/null/time_test.go
@@ -1,6 +1,7 @@
 package null
 
 import (
+	"database/sql/driver"
 	"encoding/json"
 	"testing"
 	"time"
@@ -141,10 +142,11 @@ func TestTimePointer(t *testing.T) {
 
 func TestTimeScanValue(t *testing.T) {
 	var ti Time
+	var v driver.Value
 	err := ti.Scan(timeValue1)
 	maybePanic(err)
 	assertTime(t, ti, "scanned time")
-	if v, err := ti.Value(); v != timeValue1 || err != nil {
+	if v, err = ti.Value(); v != timeValue1 || err != nil {
 		t.Error("bad value or err:", v, err)
 	}
 
@@ -152,7 +154,7 @@ func TestTimeScanValue(t *testing.T) {
 	err = null.Scan(nil)
 	maybePanic(err)
 	assertNullTime(t, null, "scanned null")
-	if v, err := null.Value(); v != nil || err != nil {
+	if v, err = null.Value(); v != nil || err != nil {
 		t.Error("bad value or err:", v, err)
 	}
 

--- a/core/null/time_test.go
+++ b/core/null/time_test.go
@@ -1,3 +1,16 @@
+/*
+Copyright (c) 2014, Greg Roseberry
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the following disclaimer in the documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
 package null
 
 import (

--- a/core/null/time_test.go
+++ b/core/null/time_test.go
@@ -1,0 +1,298 @@
+package null
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+var (
+	timeString1   = "2012-12-21T21:21:21Z"
+	timeString2   = "2012-12-21T22:21:21+01:00" // Same time as timeString1 but in a different timezone
+	timeString3   = "2018-08-19T01:02:03Z"
+	timeJSON      = []byte(`"` + timeString1 + `"`)
+	nullTimeJSON  = []byte(`null`)
+	timeValue1, _ = time.Parse(time.RFC3339, timeString1)
+	timeValue2, _ = time.Parse(time.RFC3339, timeString2)
+	timeValue3, _ = time.Parse(time.RFC3339, timeString3)
+	timeObject    = []byte(`{"Time":"2012-12-21T21:21:21Z","Valid":true}`)
+	nullObject    = []byte(`{"Time":"0001-01-01T00:00:00Z","Valid":false}`)
+	badObject     = []byte(`{"hello": "world"}`)
+	intJSON       = []byte(`12345`)
+)
+
+func TestUnmarshalTimeJSON(t *testing.T) {
+	var ti Time
+	err := json.Unmarshal(timeJSON, &ti)
+	maybePanic(err)
+	assertTime(t, ti, "UnmarshalJSON() json")
+
+	var null Time
+	err = json.Unmarshal(nullTimeJSON, &null)
+	maybePanic(err)
+	assertNullTime(t, null, "null time json")
+
+	var fromObject Time
+	err = json.Unmarshal(timeObject, &fromObject)
+	maybePanic(err)
+	assertTime(t, fromObject, "time from object json")
+
+	var nullFromObj Time
+	err = json.Unmarshal(nullObject, &nullFromObj)
+	maybePanic(err)
+	assertNullTime(t, nullFromObj, "null from object json")
+
+	var invalid Time
+	err = invalid.UnmarshalJSON(invalidJSON)
+	if _, ok := err.(*json.SyntaxError); !ok {
+		t.Errorf("expected json.SyntaxError, not %T", err)
+	}
+	assertNullTime(t, invalid, "invalid from object json")
+
+	var bad Time
+	err = json.Unmarshal(badObject, &bad)
+	if err == nil {
+		t.Errorf("expected error: bad object")
+	}
+	assertNullTime(t, bad, "bad from object json")
+
+	var wrongType Time
+	err = json.Unmarshal(intJSON, &wrongType)
+	if err == nil {
+		t.Errorf("expected error: wrong type JSON")
+	}
+	assertNullTime(t, wrongType, "wrong type object json")
+}
+
+func TestUnmarshalTimeText(t *testing.T) {
+	ti := TimeFrom(timeValue1)
+	txt, err := ti.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, txt, timeString1, "marshal text")
+
+	var unmarshal Time
+	err = unmarshal.UnmarshalText(txt)
+	maybePanic(err)
+	assertTime(t, unmarshal, "unmarshal text")
+
+	var null Time
+	err = null.UnmarshalText(nullJSON)
+	maybePanic(err)
+	assertNullTime(t, null, "unmarshal null text")
+	txt, err = null.MarshalText()
+	maybePanic(err)
+	assertJSONEquals(t, txt, string(nullJSON), "marshal null text")
+
+	var invalid Time
+	err = invalid.UnmarshalText([]byte("hello world"))
+	if err == nil {
+		t.Error("expected error")
+	}
+	assertNullTime(t, invalid, "bad string")
+}
+
+func TestMarshalTime(t *testing.T) {
+	ti := TimeFrom(timeValue1)
+	data, err := json.Marshal(ti)
+	maybePanic(err)
+	assertJSONEquals(t, data, string(timeJSON), "non-empty json marshal")
+
+	ti.Valid = false
+	data, err = json.Marshal(ti)
+	maybePanic(err)
+	assertJSONEquals(t, data, string(nullJSON), "null json marshal")
+}
+
+func TestTimeFrom(t *testing.T) {
+	ti := TimeFrom(timeValue1)
+	assertTime(t, ti, "TimeFrom() time.Time")
+}
+
+func TestTimeFromPtr(t *testing.T) {
+	ti := TimeFromPtr(&timeValue1)
+	assertTime(t, ti, "TimeFromPtr() time")
+
+	null := TimeFromPtr(nil)
+	assertNullTime(t, null, "TimeFromPtr(nil)")
+}
+
+func TestTimeSetValid(t *testing.T) {
+	var ti time.Time
+	change := NewTime(ti, false)
+	assertNullTime(t, change, "SetValid()")
+	change.SetValid(timeValue1)
+	assertTime(t, change, "SetValid()")
+}
+
+func TestTimePointer(t *testing.T) {
+	ti := TimeFrom(timeValue1)
+	ptr := ti.Ptr()
+	if *ptr != timeValue1 {
+		t.Errorf("bad %s time: %#v ≠ %v\n", "pointer", ptr, timeValue1)
+	}
+
+	var nt time.Time
+	null := NewTime(nt, false)
+	ptr = null.Ptr()
+	if ptr != nil {
+		t.Errorf("bad %s time: %#v ≠ %s\n", "nil pointer", ptr, "nil")
+	}
+}
+
+func TestTimeScanValue(t *testing.T) {
+	var ti Time
+	err := ti.Scan(timeValue1)
+	maybePanic(err)
+	assertTime(t, ti, "scanned time")
+	if v, err := ti.Value(); v != timeValue1 || err != nil {
+		t.Error("bad value or err:", v, err)
+	}
+
+	var null Time
+	err = null.Scan(nil)
+	maybePanic(err)
+	assertNullTime(t, null, "scanned null")
+	if v, err := null.Value(); v != nil || err != nil {
+		t.Error("bad value or err:", v, err)
+	}
+
+	var wrong Time
+	err = wrong.Scan(int64(42))
+	if err == nil {
+		t.Error("expected error")
+	}
+	assertNullTime(t, wrong, "scanned wrong")
+}
+
+func TestTimeValueOrZero(t *testing.T) {
+	valid := TimeFrom(timeValue1)
+	if valid.ValueOrZero() != valid.Time || valid.ValueOrZero().IsZero() {
+		t.Error("unexpected ValueOrZero", valid.ValueOrZero())
+	}
+
+	invalid := valid
+	invalid.Valid = false
+	if !invalid.ValueOrZero().IsZero() {
+		t.Error("unexpected ValueOrZero", invalid.ValueOrZero())
+	}
+}
+
+func TestTimeIsZero(t *testing.T) {
+	str := TimeFrom(timeValue1)
+	if str.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	zero := TimeFrom(time.Time{})
+	if zero.IsZero() {
+		t.Errorf("IsZero() should be false")
+	}
+
+	null := TimeFromPtr(nil)
+	if !null.IsZero() {
+		t.Errorf("IsZero() should be true")
+	}
+}
+
+func TestTimeEqual(t *testing.T) {
+	t1 := NewTime(timeValue1, false)
+	t2 := NewTime(timeValue2, false)
+	assertTimeEqualIsTrue(t, t1, t2)
+
+	t1 = NewTime(timeValue1, false)
+	t2 = NewTime(timeValue3, false)
+	assertTimeEqualIsTrue(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue2, true)
+	assertTimeEqualIsTrue(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue1, true)
+	assertTimeEqualIsTrue(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue2, false)
+	assertTimeEqualIsFalse(t, t1, t2)
+
+	t1 = NewTime(timeValue1, false)
+	t2 = NewTime(timeValue2, true)
+	assertTimeEqualIsFalse(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue3, true)
+	assertTimeEqualIsFalse(t, t1, t2)
+}
+
+func TestTimeExactEqual(t *testing.T) {
+	t1 := NewTime(timeValue1, false)
+	t2 := NewTime(timeValue1, false)
+	assertTimeExactEqualIsTrue(t, t1, t2)
+
+	t1 = NewTime(timeValue1, false)
+	t2 = NewTime(timeValue2, false)
+	assertTimeExactEqualIsTrue(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue1, true)
+	assertTimeExactEqualIsTrue(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue1, false)
+	assertTimeExactEqualIsFalse(t, t1, t2)
+
+	t1 = NewTime(timeValue1, false)
+	t2 = NewTime(timeValue1, true)
+	assertTimeExactEqualIsFalse(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue2, true)
+	assertTimeExactEqualIsFalse(t, t1, t2)
+
+	t1 = NewTime(timeValue1, true)
+	t2 = NewTime(timeValue3, true)
+	assertTimeExactEqualIsFalse(t, t1, t2)
+}
+
+func assertTime(t *testing.T, ti Time, from string) {
+	if ti.Time != timeValue1 {
+		t.Errorf("bad %v time: %v ≠ %v\n", from, ti.Time, timeValue1)
+	}
+	if !ti.Valid {
+		t.Error(from, "is invalid, but should be valid")
+	}
+}
+
+func assertNullTime(t *testing.T, ti Time, from string) {
+	if ti.Valid {
+		t.Error(from, "is valid, but should be invalid")
+	}
+}
+
+func assertTimeEqualIsTrue(t *testing.T, a, b Time) {
+	t.Helper()
+	if !a.Equal(b) {
+		t.Errorf("Equal() of Time{%v, Valid:%t} and Time{%v, Valid:%t} should return true", a.Time, a.Valid, b.Time, b.Valid)
+	}
+}
+
+func assertTimeEqualIsFalse(t *testing.T, a, b Time) {
+	t.Helper()
+	if a.Equal(b) {
+		t.Errorf("Equal() of Time{%v, Valid:%t} and Time{%v, Valid:%t} should return false", a.Time, a.Valid, b.Time, b.Valid)
+	}
+}
+
+func assertTimeExactEqualIsTrue(t *testing.T, a, b Time) {
+	t.Helper()
+	if !a.ExactEqual(b) {
+		t.Errorf("ExactEqual() of Time{%v, Valid:%t} and Time{%v, Valid:%t} should return true", a.Time, a.Valid, b.Time, b.Valid)
+	}
+}
+
+func assertTimeExactEqualIsFalse(t *testing.T, a, b Time) {
+	t.Helper()
+	if a.ExactEqual(b) {
+		t.Errorf("ExactEqual() of Time{%v, Valid:%t} and Time{%v, Valid:%t} should return false", a.Time, a.Valid, b.Time, b.Valid)
+	}
+}

--- a/core/services/fluxmonitor/fetchers.go
+++ b/core/services/fluxmonitor/fetchers.go
@@ -9,9 +9,9 @@ import (
 	"strings"
 
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 
-	"github.com/guregu/null"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/shopspring/decimal"

--- a/core/services/fluxmonitor/fetchers_test.go
+++ b/core/services/fluxmonitor/fetchers_test.go
@@ -9,11 +9,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/guregu/null"
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 )
 

--- a/core/services/run_manager.go
+++ b/core/services/run_manager.go
@@ -8,7 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/adapters"
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/logger"
-	clnull "github.com/smartcontractkit/chainlink/core/null"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/services/synchronization"
 	"github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -107,7 +107,7 @@ func NewRun(
 			continue
 		}
 
-		run.TaskRuns[i].MinRequiredIncomingConfirmations = clnull.Uint32From(
+		run.TaskRuns[i].MinRequiredIncomingConfirmations = null.Uint32From(
 			utils.MaxUint32(
 				config.MinIncomingConfirmations(),
 				task.MinRequiredIncomingConfirmations.Uint32,

--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/eth"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
-	clnull "github.com/smartcontractkit/chainlink/core/null"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/services"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -23,7 +23,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v3"
 )
 
 func makeJobRunWithInitiator(t *testing.T, store *strpkg.Store, job models.JobSpec) models.JobRun {
@@ -153,7 +152,7 @@ func TestRunManager_ResumeAllPendingNextBlock(t *testing.T) {
 	t.Run("leave in pending if not enough incoming confirmations have been met yet", func(t *testing.T) {
 		run := makeJobRunWithInitiator(t, store, cltest.NewJob())
 		run.SetStatus(models.RunStatusPendingIncomingConfirmations)
-		run.TaskRuns[0].MinRequiredIncomingConfirmations = clnull.Uint32From(2)
+		run.TaskRuns[0].MinRequiredIncomingConfirmations = null.Uint32From(2)
 		require.NoError(t, store.CreateJobRun(&run))
 
 		err := runManager.ResumeAllPendingNextBlock(big.NewInt(0))
@@ -168,7 +167,7 @@ func TestRunManager_ResumeAllPendingNextBlock(t *testing.T) {
 	t.Run("input, should go from pending_incoming_confirmations -> in_progress and save the input", func(t *testing.T) {
 		run := makeJobRunWithInitiator(t, store, cltest.NewJob())
 		run.SetStatus(models.RunStatusPendingIncomingConfirmations)
-		run.TaskRuns[0].MinRequiredIncomingConfirmations = clnull.Uint32From(2)
+		run.TaskRuns[0].MinRequiredIncomingConfirmations = null.Uint32From(2)
 		require.NoError(t, store.CreateJobRun(&run))
 
 		observedHeight := big.NewInt(1)
@@ -243,7 +242,7 @@ func TestRunManager_ResumeAllPendingConnection_NotEnoughConfirmations(t *testing
 	run.SetStatus(models.RunStatusPendingConnection)
 	run.CreationHeight = utils.NewBig(big.NewInt(0))
 	run.ObservedHeight = run.CreationHeight
-	run.TaskRuns[0].MinRequiredIncomingConfirmations = clnull.Uint32From(807)
+	run.TaskRuns[0].MinRequiredIncomingConfirmations = null.Uint32From(807)
 	run.TaskRuns[0].Status = models.RunStatusPendingConnection
 	require.NoError(t, store.CreateJobRun(&run))
 

--- a/core/services/runs.go
+++ b/core/services/runs.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/eth"
 	"github.com/smartcontractkit/chainlink/core/logger"
-	clnull "github.com/smartcontractkit/chainlink/core/null"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
@@ -66,7 +66,7 @@ func updateTaskRunObservedIncomingConfirmations(currentHeight *utils.Big, jr *mo
 
 	// diff's ceiling is guaranteed to be MaxUint32 since MinRequiredIncomingConfirmations
 	// ceiling is MaxUint32.
-	taskRun.ObservedIncomingConfirmations = clnull.Uint32From(uint32(diff.Int64()))
+	taskRun.ObservedIncomingConfirmations = null.Uint32From(uint32(diff.Int64()))
 }
 
 func invalidRequest(request models.RunRequest, receipt *eth.TxReceipt) bool {

--- a/core/services/scheduler_test.go
+++ b/core/services/scheduler_test.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/services"
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v3"
 )
 
 func TestScheduler_Start_LoadingRecurringJobs(t *testing.T) {

--- a/core/services/synchronization/presenters.go
+++ b/core/services/synchronization/presenters.go
@@ -5,12 +5,11 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/eth"
-	clnull "github.com/smartcontractkit/chainlink/core/null"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
-	null "gopkg.in/guregu/null.v3"
 )
 
 // SyncJobRunPresenter presents a JobRun for synchronization purposes
@@ -141,11 +140,11 @@ type syncInitiatorPresenter struct {
 }
 
 type syncTaskRunPresenter struct {
-	Index                            int           `json:"index"`
-	Type                             string        `json:"type"`
-	Status                           string        `json:"status"`
-	Error                            null.String   `json:"error"`
-	Result                           interface{}   `json:"result,omitempty"`
-	ObservedIncomingConfirmations    clnull.Uint32 `json:"confirmations"`
-	MinRequiredIncomingConfirmations clnull.Uint32 `json:"minimumConfirmations"`
+	Index                            int         `json:"index"`
+	Type                             string      `json:"type"`
+	Status                           string      `json:"status"`
+	Error                            null.String `json:"error"`
+	Result                           interface{} `json:"result,omitempty"`
+	ObservedIncomingConfirmations    null.Uint32 `json:"confirmations"`
+	MinRequiredIncomingConfirmations null.Uint32 `json:"minimumConfirmations"`
 }

--- a/core/services/synchronization/presenters_test.go
+++ b/core/services/synchronization/presenters_test.go
@@ -8,14 +8,13 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
-	clnull "github.com/smartcontractkit/chainlink/core/null"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
-	null "gopkg.in/guregu/null.v3"
 )
 
 func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
@@ -38,15 +37,15 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 		models.TaskRun{
 			ID:                               task0RunID,
 			Status:                           models.RunStatusPendingIncomingConfirmations,
-			ObservedIncomingConfirmations:    clnull.Uint32From(1),
-			MinRequiredIncomingConfirmations: clnull.Uint32From(3),
+			ObservedIncomingConfirmations:    null.Uint32From(1),
+			MinRequiredIncomingConfirmations: null.Uint32From(3),
 		},
 		models.TaskRun{
 			ID:                               task1RunID,
 			Status:                           models.RunStatusErrored,
 			Result:                           models.RunResult{ErrorMessage: null.StringFrom("yikes fam")},
-			ObservedIncomingConfirmations:    clnull.Uint32From(1),
-			MinRequiredIncomingConfirmations: clnull.Uint32From(3),
+			ObservedIncomingConfirmations:    null.Uint32From(1),
+			MinRequiredIncomingConfirmations: null.Uint32From(3),
 		},
 	}
 	p := SyncJobRunPresenter{JobRun: &run}

--- a/core/store/migrations/migration0/migrate.go
+++ b/core/store/migrations/migration0/migrate.go
@@ -4,14 +4,13 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
-	clnull "github.com/smartcontractkit/chainlink/core/null"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
-	"gopkg.in/guregu/null.v3"
 )
 
 // Migrate runs the initial migration
@@ -201,7 +200,7 @@ type TaskSpec struct {
 	gorm.Model
 	JobSpecID     string `gorm:"index;type:varchar(36) REFERENCES job_specs(id)"`
 	Type          string `gorm:"index;not null"`
-	Confirmations clnull.Uint32
+	Confirmations null.Uint32
 	Params        string `gorm:"type:text"`
 }
 

--- a/core/store/migrations/migration1559081901/migrate.go
+++ b/core/store/migrations/migration1559081901/migrate.go
@@ -3,12 +3,12 @@ package migration1559081901
 import (
 	"time"
 
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
-	null "gopkg.in/guregu/null.v3"
 )
 
 func Migrate(tx *gorm.DB) error {

--- a/core/store/migrations/migration1568833756/migrate.go
+++ b/core/store/migrations/migration1568833756/migrate.go
@@ -3,12 +3,12 @@ package migration1568833756
 import (
 	"time"
 
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
-	"gopkg.in/guregu/null.v3"
 )
 
 // Initiator could be thought of as a trigger, defines how a Job can be

--- a/core/store/models/bridge_run_result.go
+++ b/core/store/models/bridge_run_result.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 
-	null "gopkg.in/guregu/null.v3"
+	"github.com/smartcontractkit/chainlink/core/null"
 )
 
 // BridgeRunResult handles the parsing of RunResults from external adapters.

--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -10,12 +10,12 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rlp"
-	null "gopkg.in/guregu/null.v3"
 )
 
 type EthTxState string

--- a/core/store/models/job_run.go
+++ b/core/store/models/job_run.go
@@ -6,13 +6,12 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
-	clnull "github.com/smartcontractkit/chainlink/core/null"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	null "gopkg.in/guregu/null.v3"
 )
 
 var (
@@ -30,9 +29,9 @@ type JobRun struct {
 	ID             *ID          `json:"id" gorm:"primary_key;not null"`
 	JobSpecID      *ID          `json:"jobId"`
 	Result         RunResult    `json:"result" gorm:"foreignkey:ResultID;association_autoupdate:true;association_autocreate:true"`
-	ResultID       clnull.Int64 `json:"-"`
+	ResultID       null.Int64   `json:"-"`
 	RunRequest     RunRequest   `json:"-" gorm:"foreignkey:RunRequestID;association_autoupdate:true;association_autocreate:true"`
-	RunRequestID   clnull.Int64 `json:"-"`
+	RunRequestID   null.Int64   `json:"-"`
 	Status         RunStatus    `json:"status" gorm:"default:'unstarted'"`
 	TaskRuns       []TaskRun    `json:"taskRuns"`
 	CreatedAt      time.Time    `json:"createdAt"`
@@ -239,17 +238,17 @@ func NewRunRequest(requestParams JSON) *RunRequest {
 // TaskRun stores the Task and represents the status of the
 // Task to be ran.
 type TaskRun struct {
-	ID                               *ID           `json:"id" gorm:"primary_key;not null"`
-	JobRunID                         *ID           `json:"-"`
-	Result                           RunResult     `json:"result"`
-	ResultID                         clnull.Uint32 `json:"-"`
-	Status                           RunStatus     `json:"status" gorm:"default:'unstarted'"`
-	TaskSpec                         TaskSpec      `json:"task" gorm:"association_autoupdate:false;association_autocreate:false"`
-	TaskSpecID                       int64         `json:"-"`
-	MinRequiredIncomingConfirmations clnull.Uint32 `json:"minimumConfirmations" gorm:"column:minimum_confirmations"`
-	ObservedIncomingConfirmations    clnull.Uint32 `json:"confirmations" gorm:"column:confirmations"`
-	CreatedAt                        time.Time     `json:"-"`
-	UpdatedAt                        time.Time     `json:"-"`
+	ID                               *ID         `json:"id" gorm:"primary_key;not null"`
+	JobRunID                         *ID         `json:"-"`
+	Result                           RunResult   `json:"result"`
+	ResultID                         null.Uint32 `json:"-"`
+	Status                           RunStatus   `json:"status" gorm:"default:'unstarted'"`
+	TaskSpec                         TaskSpec    `json:"task" gorm:"association_autoupdate:false;association_autocreate:false"`
+	TaskSpecID                       int64       `json:"-"`
+	MinRequiredIncomingConfirmations null.Uint32 `json:"minimumConfirmations" gorm:"column:minimum_confirmations"`
+	ObservedIncomingConfirmations    null.Uint32 `json:"confirmations" gorm:"column:confirmations"`
+	CreatedAt                        time.Time   `json:"-"`
+	UpdatedAt                        time.Time   `json:"-"`
 }
 
 // String returns info on the TaskRun as "ID,Type,Status,Result".

--- a/core/store/models/job_run_test.go
+++ b/core/store/models/job_run_test.go
@@ -8,13 +8,13 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/services/synchronization"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	null "gopkg.in/guregu/null.v3"
 )
 
 func TestJobRun_RetrievingFromDBWithError(t *testing.T) {

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -9,12 +9,11 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
-	clnull "github.com/smartcontractkit/chainlink/core/null"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
-	null "gopkg.in/guregu/null.v3"
 )
 
 // JobSpecRequest represents a schema for the incoming job spec request as used by the API.
@@ -34,9 +33,9 @@ type InitiatorRequest struct {
 
 // TaskSpecRequest represents a schema for incoming TaskSpec requests as used by the API.
 type TaskSpecRequest struct {
-	Type                             TaskType      `json:"type"`
-	MinRequiredIncomingConfirmations clnull.Uint32 `json:"confirmations"`
-	Params                           JSON          `json:"params"`
+	Type                             TaskType    `json:"type"`
+	MinRequiredIncomingConfirmations null.Uint32 `json:"confirmations"`
+	Params                           JSON        `json:"params"`
 }
 
 // JobSpec is the definition for all the work to be carried out by the node
@@ -353,11 +352,11 @@ type Feeds = JSON
 // Type will be an adapter, and the Params will contain any
 // additional information that adapter would need to operate.
 type TaskSpec struct {
-	ID                               int64         `gorm:"primary_key"`
-	JobSpecID                        *ID           `json:"-"`
-	Type                             TaskType      `json:"type" gorm:"index;not null"`
-	MinRequiredIncomingConfirmations clnull.Uint32 `json:"confirmations" gorm:"column:confirmations"`
-	Params                           JSON          `json:"params" gorm:"type:text"`
+	ID                               int64       `gorm:"primary_key"`
+	JobSpecID                        *ID         `json:"-"`
+	Type                             TaskType    `json:"type" gorm:"index;not null"`
+	MinRequiredIncomingConfirmations null.Uint32 `json:"confirmations" gorm:"column:confirmations"`
+	Params                           JSON        `json:"params" gorm:"type:text"`
 	CreatedAt                        time.Time
 	UpdatedAt                        time.Time
 	DeletedAt                        *time.Time

--- a/core/store/models/job_spec_test.go
+++ b/core/store/models/job_spec_test.go
@@ -8,13 +8,13 @@ import (
 	"github.com/smartcontractkit/chainlink/core/adapters"
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	null "gopkg.in/guregu/null.v3"
 )
 
 func TestNewInitiatorFromRequest(t *testing.T) {

--- a/core/store/models/service_agreement.go
+++ b/core/store/models/service_agreement.go
@@ -10,11 +10,11 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/eth"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
-	null "gopkg.in/guregu/null.v3"
 )
 
 // Encumbrance connects job specifications with on-chain encumbrances.

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/auth"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/services"
 	"github.com/smartcontractkit/chainlink/core/services/synchronization"
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -25,7 +26,6 @@ import (
 	"github.com/jinzhu/gorm"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v3"
 )
 
 func TestORM_AllNotFound(t *testing.T) {

--- a/core/store/tx_manager.go
+++ b/core/store/tx_manager.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/eth"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
 	"github.com/smartcontractkit/chainlink/core/utils"
@@ -24,7 +25,6 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/tevino/abool"
 	"go.uber.org/multierr"
-	"gopkg.in/guregu/null.v3"
 )
 
 const (

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/eth"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
+	"github.com/smartcontractkit/chainlink/core/null"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
@@ -21,7 +22,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v3"
 )
 
 func TestTxManager_CreateTx_Success(t *testing.T) {

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/null"
 
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
@@ -28,7 +29,6 @@ import (
 	"github.com/shopspring/decimal"
 	"golang.org/x/crypto/bcrypt"
 	"golang.org/x/crypto/sha3"
-	null "gopkg.in/guregu/null.v3"
 )
 
 const (


### PR DESCRIPTION
### Why?

We want to reduce the number of dependencies in `core`.  [See original ticket](https://www.pivotaltracker.com/story/show/173114232) The motivation is, primarily, to simplify the codebase and to reduce the attack surface, but also to speed up builds.

We only use [gopkg.in/guregu/null.v3](https://github.com/guregu/null/tree/v3.5.0) for two types `String` and `Time` as a convenience for serialization to/from a JSON-encoded string and database query results. For reference, the interfaces implemented are `encoding.TextMarshaler`, `encoding.TextUnmarshaler`, `json.Marshaler`, `json.Unmarshal` and `sql.Scanner`.

### How?

I made the decision to extract `null.Time` and `null.String` from the source of `null.v3` and merge it with `./core/null`. `./core/null` already does the same thing but for int64 and int32. 
I also copied the tests and refactored the code to pass our static analysis checks.

An alternative would be to vendor the entire library.