### PR TITLE
Enable rebroadcast-transactions to work with BPTXM

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -319,20 +319,24 @@ func NewApp(client *Client) *cli.App {
 					Action: client.RebroadcastTransactions,
 					Flags: []cli.Flag{
 						cli.Uint64Flag{
-							Name:  "beginningNonce",
+							Name:  "beginningNonce, b",
 							Usage: "beginning of nonce range to rebroadcast",
 						},
 						cli.Uint64Flag{
-							Name:  "endingNonce",
+							Name:  "endingNonce, e",
 							Usage: "end of nonce range to rebroadcast (inclusive)",
 						},
 						cli.Uint64Flag{
-							Name:  "gasPriceWei",
+							Name:  "gasPriceWei, g",
 							Usage: "gas price (in Wei) to rebroadcast transactions at",
 						},
 						cli.StringFlag{
 							Name:  "password, p",
 							Usage: "text file holding the password for the node's account",
+						},
+						cli.StringFlag{
+							Name:  "address, a",
+							Usage: "The address (in hex format) for the key which we want to rebroadcast transactions",
 						},
 						cli.Uint64Flag{
 							Name:  "gasLimit",

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/gracefulpanic"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/bulletprooftxmanager"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/migrations"
@@ -26,6 +27,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/presenters"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
+	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/jinzhu/gorm"
 	clipkg "github.com/urfave/cli"
@@ -227,6 +229,13 @@ func (cli *Client) RebroadcastTransactions(c *clipkg.Context) (err error) {
 	endingNonce := c.Uint("endingNonce")
 	gasPriceWei := c.Uint64("gasPriceWei")
 	overrideGasLimit := c.Uint64("gasLimit")
+	addressHex := c.String("address")
+
+	addressBytes, err := hexutil.Decode(addressHex)
+	if err != nil {
+		return cli.errorOut(errors.Wrap(err, "could not decode address"))
+	}
+	address := gethCommon.BytesToAddress(addressBytes)
 
 	logger.SetLogger(cli.Config.CreateProductionLogger())
 	cli.Config.Dialect = orm.DialectPostgresWithoutLock
@@ -249,9 +258,23 @@ func (cli *Client) RebroadcastTransactions(c *clipkg.Context) (err error) {
 
 	err = store.Start()
 	if err != nil {
-		return err
+		return cli.errorOut(err)
 	}
 
+	if store.Config.EnableBulletproofTxManager() {
+		logger.Infof("Rebroadcasting transactions from %v to %v", beginningNonce, endingNonce)
+
+		ec := bulletprooftxmanager.NewEthConfirmer(store, cli.Config)
+		err = ec.ForceRebroadcast(beginningNonce, endingNonce, gasPriceWei, address, overrideGasLimit)
+	} else {
+		logger.Infof("Rebroadcasting legacy transactions from %v to %v", beginningNonce, endingNonce)
+
+		err = rebroadcastLegacyTransactions(store, beginningNonce, endingNonce, gasPriceWei, overrideGasLimit)
+	}
+	return cli.errorOut(err)
+}
+
+func rebroadcastLegacyTransactions(store *strpkg.Store, beginningNonce uint, endingNonce uint, gasPriceWei uint64, overrideGasLimit uint64) (err error) {
 	lastHead, err := store.LastHead()
 	if err != nil {
 		return err

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -280,6 +280,7 @@ func TestClient_RebroadcastTransactions_WithinRange(t *testing.T) {
 	set.Uint("endingNonce", endingNonce, "")
 	set.Uint64("gasPriceWei", gasPrice.Uint64(), "")
 	set.Uint64("gasLimit", gasLimit, "")
+	set.String("address", "0x3cb8e3FD9d27e39a5e9e6852b0e96160061fd4ea", "")
 	c := cli.NewContext(nil, set, nil)
 
 	tests := []struct {
@@ -298,6 +299,7 @@ func TestClient_RebroadcastTransactions_WithinRange(t *testing.T) {
 			config, _, cleanup := cltest.BootstrapThrowawayORM(t, "rebroadcasttransactions", true)
 			defer cleanup()
 			config.Config.Dialect = orm.DialectPostgres
+			config.Set("ENABLE_BULLETPROOF_TX_MANAGER", false)
 			connectedStore, connectedCleanup := cltest.NewStoreWithConfig(config)
 			defer connectedCleanup()
 
@@ -368,6 +370,7 @@ func TestClient_RebroadcastTransactions_OutsideRange(t *testing.T) {
 	set.Uint("endingNonce", endingNonce, "")
 	set.Uint64("gasPriceWei", gasPrice.Uint64(), "")
 	set.Uint64("gasLimit", gasLimit, "")
+	set.String("address", "0x3cb8e3FD9d27e39a5e9e6852b0e96160061fd4ea", "")
 	c := cli.NewContext(nil, set, nil)
 
 	tests := []struct {

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -803,6 +803,7 @@ func MustInsertConfirmedEthTxWithAttempt(t *testing.T, store *strpkg.Store, nonc
 func GetDefaultFromAddress(t *testing.T, store *strpkg.Store) common.Address {
 	keys, err := store.Keys()
 	require.NoError(t, err)
+	require.Len(t, keys, 1)
 	key := keys[0]
 	return key.Address.Address()
 }

--- a/core/services/bulletprooftxmanager/eth_confirmer.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer.go
@@ -562,46 +562,77 @@ func unbroadcastAttempt(db *gorm.DB, a models.EthTxAttempt) error {
 	return errors.Wrap(db.Exec(`UPDATE eth_tx_attempts SET broadcast_before_block_num = NULL, state = 'in_progress' WHERE id = ?`, a.ID).Error, "unbroadcastAttempt failed")
 }
 
-// ForceRebroadcast forcibly rebroadcasts eth_txes in the given nonce range at the given gas price.
+// ForceRebroadcast sends a transaction for every nonce in the given nonce range at the given gas price.
+// If an eth_tx exists for this nonce, we re-send the existing eth_tx with the supplied parameters.
+// If an eth_tx doesn't exist for this nonce, we send a zero transaction.
 // This operates completely orthogonal to the normal EthConfirmer and can result in untracked attempts!
 // Only for emergency usage.
 // Deliberately does not take the advisory lock (we don't write to the database so this is safe from a data integrity perspective).
 // This is in case of some unforeseen scenario where the node is refusing to release the lock. KISS.
 func (ec *ethConfirmer) ForceRebroadcast(beginningNonce uint, endingNonce uint, gasPriceWei uint64, address gethCommon.Address, overrideGasLimit uint64) error {
-	etxs, err := findAllEthTxsInNonceRange(ec.store.GetRawDB(), address, beginningNonce, endingNonce)
-	if err != nil {
-		return err
-	}
+	logger.Info("ForceRebroadcast: will rebroadcast transactions for all nonces between %v and %v", beginningNonce, endingNonce)
 
-	logger.Info("ForceRebroadcast: will rebroadcast %v transactions between nonce %v and %v", len(etxs), beginningNonce, endingNonce)
-
-	for _, etx := range etxs {
-		logger.Debugf("ForceRebroadcast: will rebroadcast eth_tx %v with nonce %v", etx.ID, etx.Nonce)
-		if overrideGasLimit != 0 {
-			etx.GasLimit = overrideGasLimit
-		}
-		attempt, err := newAttempt(ec.store, etx, big.NewInt(int64(gasPriceWei)))
+	for n := beginningNonce; n <= endingNonce; n++ {
+		etx, err := findEthTxWithNonce(ec.store.GetRawDB(), address, n)
 		if err != nil {
-			logger.Errorf("ForceRebroadcast: failed to create new attempt for eth_tx %v: %s", etx.ID, err.Error())
+			return errors.Wrap(err, "ForceRebroadcast failed")
 		}
-		err = sendTransaction(ec.gethClientWrapper, attempt)
-		if err != (*sendError)(nil) {
-			logger.Errorf("ForceRebroadcast: failed to rebroadcast eth_tx %v with nonce %v at gas price %s wei and gas limit %v: %s", etx.ID, *etx.Nonce, attempt.GasPrice.String(), etx.GasLimit, err.Error())
+		if etx == nil {
+			logger.Debugf("ForceRebroadcast: no eth_tx found with nonce %v, will rebroadcast empty transaction", n)
+			hash, err := ec.sendEmptyTransaction(address, n, overrideGasLimit, gasPriceWei)
+			if err != nil {
+				logger.Errorf("ForceRebroadcast: failed to send empty transaction with nonce %v: %s", n, err.Error())
+				continue
+			}
+			logger.Infof("ForceRebroadcast: successfully rebroadcast empty transaction with nonce %v and hash %s", n, hash)
+		} else {
+			logger.Debugf("ForceRebroadcast: got eth_tx %v with nonce %v, will rebroadcast this transaction", etx.ID, etx.Nonce)
+			if overrideGasLimit != 0 {
+				etx.GasLimit = overrideGasLimit
+			}
+			attempt, err := newAttempt(ec.store, *etx, big.NewInt(int64(gasPriceWei)))
+			if err != nil {
+				logger.Errorf("ForceRebroadcast: failed to create new attempt for eth_tx %v: %s", etx.ID, err.Error())
+				continue
+			}
+			if err := sendTransaction(ec.gethClientWrapper, attempt); err != nil {
+				logger.Errorf("ForceRebroadcast: failed to rebroadcast eth_tx %v with nonce %v at gas price %s wei and gas limit %v: %s", etx.ID, *etx.Nonce, attempt.GasPrice.String(), etx.GasLimit, err.Error())
+				continue
+			}
+			logger.Infof("ForceRebroadcast: successfully rebroadcast eth_tx %v with hash: %s", etx.ID, attempt.Hash)
 		}
-		logger.Infof("ForceRebroadcast: successfully rebroadcast eth_tx %v with hash: %s", etx.ID, attempt.Hash)
 	}
 	return nil
 }
 
+func (ec *ethConfirmer) sendEmptyTransaction(fromAddress gethCommon.Address, nonce uint, overrideGasLimit uint64, gasPriceWei uint64) (gethCommon.Hash, error) {
+	gasLimit := overrideGasLimit
+	if gasLimit == 0 {
+		gasLimit = ec.config.EthGasLimitDefault()
+	}
+	account, err := ec.store.KeyStore.GetAccountByAddress(fromAddress)
+	if err != nil {
+		return gethCommon.Hash{}, errors.Wrap(err, "(ethConfirmer).sendEmptyTransaction failed")
+	}
+	tx, err := sendEmptyTransaction(ec.gethClientWrapper, ec.store.KeyStore, uint64(nonce), gasLimit, big.NewInt(int64(gasPriceWei)), account, ec.config.ChainID())
+	if err != nil {
+		return gethCommon.Hash{}, errors.Wrap(err, "(ethConfirmer).sendEmptyTransaction failed")
+	}
+	return tx.Hash(), nil
+}
+
 // findAllEthTxsInNonceRange returns an array of eth_txes for the given key
 // matching the inclusive range between beginningNonce and endingNonce
-func findAllEthTxsInNonceRange(db *gorm.DB, fromAddress gethCommon.Address, beginningNonce uint, endingNonce uint) ([]models.EthTx, error) {
-	etxs := []models.EthTx{}
+func findEthTxWithNonce(db *gorm.DB, fromAddress gethCommon.Address, nonce uint) (*models.EthTx, error) {
+	etx := models.EthTx{}
 	err := db.
 		Preload("EthTxAttempts", func(db *gorm.DB) *gorm.DB {
 			return db.Order("eth_tx_attempts.gas_price DESC")
 		}).
-		Find(&etxs, "from_address = ? AND nonce BETWEEN ? AND ? AND state IN ('confirmed','unconfirmed')", fromAddress, beginningNonce, endingNonce).
+		First(&etx, "from_address = ? AND nonce = ? AND state IN ('confirmed','unconfirmed')", fromAddress, nonce).
 		Error
-	return etxs, errors.Wrap(err, "findAllEthTxsInNonceRange failed")
+	if gorm.IsRecordNotFoundError(err) {
+		return nil, nil
+	}
+	return &etx, errors.Wrap(err, "findEthTxsWithNonce failed")
 }

--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -99,6 +99,15 @@ func (a EthTxAttempt) GetSignedTx() (*types.Transaction, error) {
 	return signedTx, nil
 }
 
+// MustGetSignedTx decodes the SignedRawTx or panics
+func (a EthTxAttempt) MustGetSignedTx() types.Transaction {
+	signedTx, err := a.GetSignedTx()
+	if err != nil {
+		panic(err)
+	}
+	return *signedTx
+}
+
 // Tx contains fields necessary for an Ethereum transaction with
 // an additional field for the TxAttempt.
 type Tx struct {

--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -99,15 +99,6 @@ func (a EthTxAttempt) GetSignedTx() (*types.Transaction, error) {
 	return signedTx, nil
 }
 
-// MustGetSignedTx decodes the SignedRawTx or panics
-func (a EthTxAttempt) MustGetSignedTx() types.Transaction {
-	signedTx, err := a.GetSignedTx()
-	if err != nil {
-		panic(err)
-	}
-	return *signedTx
-}
-
 // Tx contains fields necessary for an Ethereum transaction with
 // an additional field for the TxAttempt.
 type Tx struct {


### PR DESCRIPTION
Note that this also modifies the command to force zero transactions on a particular nonce even if we don't have a corresponding attempt.