### PR TITLE
WIP Use latest version of the builder image for the builder-cache image

### DIFF
--- a/builder-cache.Dockerfile
+++ b/builder-cache.Dockerfile
@@ -1,4 +1,4 @@
-FROM smartcontract/builder:1.0.34
+FROM smartcontract/builder:1.0.35
 
 WORKDIR /chainlink
 COPY go.mod go.sum yarn.lock package.json .yarnrc GNUmakefile ./


### PR DESCRIPTION
DON'T MERGE!
This change uses the last published version of the builder cache image.
This introduces a new node.js version which HASN'T BEEN TESTED against our node projects yet!