### PR TITLE
Run chainlink image under a chainlink user instead of root

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -73,10 +73,19 @@ FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y ca-certificates
 
-WORKDIR /root
+# Creating chainlink user
+RUN mkdir -p /home/chainlink/bin/
+RUN echo "chainlink:x:1000:" >> /etc/group
+RUN echo "chainlink::1000:1000:chainlink user:/home/chainlink:/bin/bash" >> /etc/passwd
+RUN chown -R chainlink:chainlink /home/chainlink
 
-COPY --from=1 /go/bin/chainlink /usr/local/bin/
+COPY --from=1 /go/bin/chainlink /home/chainlink/bin/
+RUN chown chainlink:chainlink /home/chainlink/bin/chainlink
+
+USER chainlink
+WORKDIR /home/chainlink
+
 
 EXPOSE 6688
-ENTRYPOINT ["chainlink"]
+ENTRYPOINT ["/home/chainlink/bin/chainlink"]
 CMD ["local", "node"]

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -79,6 +79,9 @@ RUN useradd --home-dir=/home/chainlink --create-home --shell=/bin/bash --uid=100
 COPY --from=1 /go/bin/chainlink /usr/local/bin/
 RUN chmod +x /usr/local/bin/chainlink
 
+# Required to mount tls certificates and env files in the docs.
+RUN mkdir /chainlink && chown chainlink:chainlink -R /chainlink
+
 USER chainlink
 WORKDIR /home/chainlink
 

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -74,18 +74,15 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update && apt-get install -y ca-certificates
 
 # Creating chainlink user
-RUN mkdir -p /home/chainlink/bin/
-RUN echo "chainlink:x:1000:" >> /etc/group
-RUN echo "chainlink::1000:1000:chainlink user:/home/chainlink:/bin/bash" >> /etc/passwd
-RUN chown -R chainlink:chainlink /home/chainlink
+RUN useradd --home-dir=/home/chainlink --create-home --shell=/bin/bash --uid=1000 --user-group chainlink
 
-COPY --from=1 /go/bin/chainlink /home/chainlink/bin/
-RUN chown chainlink:chainlink /home/chainlink/bin/chainlink
+COPY --from=1 /go/bin/chainlink /usr/local/bin/
+RUN chmod +x /usr/local/bin/chainlink
 
 USER chainlink
 WORKDIR /home/chainlink
 
 
 EXPOSE 6688
-ENTRYPOINT ["/home/chainlink/bin/chainlink"]
+ENTRYPOINT ["/usr/local/bin/chainlink"]
 CMD ["local", "node"]


### PR DESCRIPTION
### Why

Docker recommends you don't run containers as root. 
Since root is the default user for docker containers, we were running the chainlink binary as root.

### How

I'm creating a new `chainlink` user with home under `/home/chainlink`. 
The chainlink binary is placed in the same place as before `/usr/local/bin/chainlink` but it is executed by the `chainlink` user.

<img width="713" alt="Screenshot 2020-07-27 at 18 01 41" src="https://user-images.githubusercontent.com/462588/88570369-dc878580-d033-11ea-8ce5-49c9e0f45245.png">
