### PR TITLE
Unlock pragma on VRF Consumer contracts

### DIFF
--- a/evm-contracts/package.json
+++ b/evm-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/contracts",
-  "version": "0.0.6",
+  "version": "0.0.7",
   "description": "Smart contracts and their language abstractions for chainlink",
   "repository": "https://github.com/smartcontractkit/chainlink",
   "author": "Chainlink devs",

--- a/evm-contracts/src/v0.6/VRFConsumerBase.sol
+++ b/evm-contracts/src/v0.6/VRFConsumerBase.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.6;
+pragma solidity ^0.6.0;
 
 import "./vendor/SafeMath.sol";
 

--- a/evm-contracts/src/v0.6/VRFRequestIDBase.sol
+++ b/evm-contracts/src/v0.6/VRFRequestIDBase.sol
@@ -1,4 +1,4 @@
-pragma solidity 0.6.6;
+pragma solidity ^0.6.0;
 
 contract VRFRequestIDBase {
 


### PR DESCRIPTION
Users of the VRF contracts shouldn't be required to use Solidity 0.6.6 specifically, but any Solidity version 0.6.0 and above.