### PR TITLE
add tool to lint the core codebase

### DIFF
--- a/tools/bin/lint
+++ b/tools/bin/lint
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+set -euo pipefail
+
+cd "$(dirname "$0")"/../../core
+
+echo "go vet"
+go vet ./...
+echo "shadow"
+go vet -vettool=$HOME/go/bin/shadow ./...
+echo "goimports"
+goimports -d ./
+echo "staticcheck"
+staticcheck ./...
+echo "errcheck"
+errcheck -ignoretests -asserts -ignoregenerated ./...
+echo "gosec"
+gosec -exclude=G101,G104,G204,G304 -exclude-dir ingester ./...
+echo "golint"
+golint -min_confidence 1 ./...


### PR DESCRIPTION
### Why?

Because pushing something to git only for the CI to tell you that static checks have failed wastes time! 
The idea is, that before pushing, you execute `./bin/tools/lint` which will run "the same" go static analysis tools we have in CI. If there are problems you can fix them locally before pushing to the branch.

### How?

Added a bash script that lints `./core`. To use it, you need to install and have in your $PATH: shadow, goimports, staticcheck, errcheck, gosec, golint!