### PR TITLE
Fix flattening compilation

### DIFF
--- a/evm-contracts/src/v0.4/Chainlink.sol
+++ b/evm-contracts/src/v0.4/Chainlink.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.4.24;
 
-import { CBOR as CBOR_Chainlink, Buffer } from "./vendor/CBOR.sol";
+import { CBOR as CBOR_Chainlink } from "./vendor/CBOR.sol";
+import { Buffer as Buffer_Chainlink } from "./vendor/Buffer.sol";
 
 /**
  * @title Library for common Chainlink functions
@@ -9,14 +10,14 @@ import { CBOR as CBOR_Chainlink, Buffer } from "./vendor/CBOR.sol";
 library Chainlink {
   uint256 internal constant defaultBufferSize = 256; // solhint-disable-line const-name-snakecase
 
-  using CBOR_Chainlink for Buffer.buffer;
+  using CBOR_Chainlink for Buffer_Chainlink.buffer;
 
   struct Request {
     bytes32 id;
     address callbackAddress;
     bytes4 callbackFunctionId;
     uint256 nonce;
-    Buffer.buffer buf;
+    Buffer_Chainlink.buffer buf;
   }
 
   /**
@@ -34,7 +35,7 @@ library Chainlink {
     address _callbackAddress,
     bytes4 _callbackFunction
   ) internal pure returns (Chainlink.Request memory) {
-    Buffer.init(self.buf, defaultBufferSize);
+    Buffer_Chainlink.init(self.buf, defaultBufferSize);
     self.id = _id;
     self.callbackAddress = _callbackAddress;
     self.callbackFunctionId = _callbackFunction;
@@ -50,8 +51,8 @@ library Chainlink {
   function setBuffer(Request memory self, bytes _data)
     internal pure
   {
-    Buffer.init(self.buf, _data.length);
-    Buffer.append(self.buf, _data);
+    Buffer_Chainlink.init(self.buf, _data.length);
+    Buffer_Chainlink.append(self.buf, _data);
   }
 
   /**

--- a/evm-contracts/src/v0.4/Chainlink.sol
+++ b/evm-contracts/src/v0.4/Chainlink.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.4.24;
 
-import { CBOR as CBOR_Chainlink, Buffer as Buffer_Chainlink } from "./vendor/CBOR.sol";
+import { CBOR as CBOR_Chainlink, Buffer } from "./vendor/CBOR.sol";
 
 /**
  * @title Library for common Chainlink functions
@@ -9,14 +9,14 @@ import { CBOR as CBOR_Chainlink, Buffer as Buffer_Chainlink } from "./vendor/CBO
 library Chainlink {
   uint256 internal constant defaultBufferSize = 256; // solhint-disable-line const-name-snakecase
 
-  using CBOR_Chainlink for Buffer_Chainlink.buffer;
+  using CBOR_Chainlink for Buffer.buffer;
 
   struct Request {
     bytes32 id;
     address callbackAddress;
     bytes4 callbackFunctionId;
     uint256 nonce;
-    Buffer_Chainlink.buffer buf;
+    Buffer.buffer buf;
   }
 
   /**
@@ -34,7 +34,7 @@ library Chainlink {
     address _callbackAddress,
     bytes4 _callbackFunction
   ) internal pure returns (Chainlink.Request memory) {
-    Buffer_Chainlink.init(self.buf, defaultBufferSize);
+    Buffer.init(self.buf, defaultBufferSize);
     self.id = _id;
     self.callbackAddress = _callbackAddress;
     self.callbackFunctionId = _callbackFunction;
@@ -50,8 +50,8 @@ library Chainlink {
   function setBuffer(Request memory self, bytes _data)
     internal pure
   {
-    Buffer_Chainlink.init(self.buf, _data.length);
-    Buffer_Chainlink.append(self.buf, _data);
+    Buffer.init(self.buf, _data.length);
+    Buffer.append(self.buf, _data);
   }
 
   /**

--- a/evm-contracts/src/v0.4/tests/ConcreteChainlink.sol
+++ b/evm-contracts/src/v0.4/tests/ConcreteChainlink.sol
@@ -1,11 +1,12 @@
 pragma solidity 0.4.24;
 
 import "../Chainlink.sol";
-import "../vendor/CBOR.sol";
+import { CBOR as CBOR_Chainlink } from "../vendor/CBOR.sol";
+import { Buffer as Buffer_Chainlink } from "../vendor/Buffer.sol";
 
 contract ConcreteChainlink {
   using Chainlink for Chainlink.Request;
-  using CBOR for Buffer.buffer;
+  using CBOR_Chainlink for Buffer_Chainlink.buffer;
 
   Chainlink.Request private req;
 

--- a/evm-contracts/src/v0.4/tests/MaliciousChainlink.sol
+++ b/evm-contracts/src/v0.4/tests/MaliciousChainlink.sol
@@ -1,17 +1,17 @@
 pragma solidity 0.4.24;
 
-import "../vendor/CBOR.sol";
-
+import { CBOR as CBOR_Chainlink } from "../vendor/CBOR.sol";
+import { Buffer as Buffer_Chainlink } from "../vendor/Buffer.sol";
 
 library MaliciousChainlink {
-  using CBOR for Buffer.buffer;
+  using CBOR_Chainlink for Buffer_Chainlink.buffer;
 
   struct Request {
     bytes32 specId;
     address callbackAddress;
     bytes4 callbackFunctionId;
     uint256 nonce;
-    Buffer.buffer buf;
+    Buffer_Chainlink.buffer buf;
   }
 
   struct WithdrawRequest {
@@ -19,7 +19,7 @@ library MaliciousChainlink {
     address callbackAddress;
     bytes4 callbackFunctionId;
     uint256 nonce;
-    Buffer.buffer buf;
+    Buffer_Chainlink.buffer buf;
   }
 
   function initializeWithdraw(
@@ -28,7 +28,7 @@ library MaliciousChainlink {
     address _callbackAddress,
     bytes4 _callbackFunction
   ) internal pure returns (MaliciousChainlink.WithdrawRequest memory) {
-    Buffer.init(self.buf, 128);
+    Buffer_Chainlink.init(self.buf, 128);
     self.specId = _specId;
     self.callbackAddress = _callbackAddress;
     self.callbackFunctionId = _callbackFunction;

--- a/evm-contracts/src/v0.4/vendor/CBOR.sol
+++ b/evm-contracts/src/v0.4/vendor/CBOR.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.4.19;
 
-import "./Buffer.sol";
+import { Buffer as Buffer_Chainlink } from "./Buffer.sol";
 
 library CBOR {
-  using Buffer for Buffer.buffer;
+  using Buffer_Chainlink for Buffer_Chainlink.buffer;
 
   uint8 private constant MAJOR_TYPE_INT = 0;
   uint8 private constant MAJOR_TYPE_NEGATIVE_INT = 1;
@@ -13,7 +13,7 @@ library CBOR {
   uint8 private constant MAJOR_TYPE_MAP = 5;
   uint8 private constant MAJOR_TYPE_CONTENT_FREE = 7;
 
-  function encodeType(Buffer.buffer memory buf, uint8 major, uint value) private pure {
+  function encodeType(Buffer_Chainlink.buffer memory buf, uint8 major, uint value) private pure {
     if(value <= 23) {
       buf.appendUint8(uint8((major << 5) | value));
     } else if(value <= 0xFF) {
@@ -31,15 +31,15 @@ library CBOR {
     }
   }
 
-  function encodeIndefiniteLengthType(Buffer.buffer memory buf, uint8 major) private pure {
+  function encodeIndefiniteLengthType(Buffer_Chainlink.buffer memory buf, uint8 major) private pure {
     buf.appendUint8(uint8((major << 5) | 31));
   }
 
-  function encodeUInt(Buffer.buffer memory buf, uint value) internal pure {
+  function encodeUInt(Buffer_Chainlink.buffer memory buf, uint value) internal pure {
     encodeType(buf, MAJOR_TYPE_INT, value);
   }
 
-  function encodeInt(Buffer.buffer memory buf, int value) internal pure {
+  function encodeInt(Buffer_Chainlink.buffer memory buf, int value) internal pure {
     if(value >= 0) {
       encodeType(buf, MAJOR_TYPE_INT, uint(value));
     } else {
@@ -47,25 +47,25 @@ library CBOR {
     }
   }
 
-  function encodeBytes(Buffer.buffer memory buf, bytes value) internal pure {
+  function encodeBytes(Buffer_Chainlink.buffer memory buf, bytes value) internal pure {
     encodeType(buf, MAJOR_TYPE_BYTES, value.length);
     buf.append(value);
   }
 
-  function encodeString(Buffer.buffer memory buf, string value) internal pure {
+  function encodeString(Buffer_Chainlink.buffer memory buf, string value) internal pure {
     encodeType(buf, MAJOR_TYPE_STRING, bytes(value).length);
     buf.append(bytes(value));
   }
 
-  function startArray(Buffer.buffer memory buf) internal pure {
+  function startArray(Buffer_Chainlink.buffer memory buf) internal pure {
     encodeIndefiniteLengthType(buf, MAJOR_TYPE_ARRAY);
   }
 
-  function startMap(Buffer.buffer memory buf) internal pure {
+  function startMap(Buffer_Chainlink.buffer memory buf) internal pure {
     encodeIndefiniteLengthType(buf, MAJOR_TYPE_MAP);
   }
 
-  function endSequence(Buffer.buffer memory buf) internal pure {
+  function endSequence(Buffer_Chainlink.buffer memory buf) internal pure {
     encodeIndefiniteLengthType(buf, MAJOR_TYPE_CONTENT_FREE);
   }
 }

--- a/evm-contracts/src/v0.5/Chainlink.sol
+++ b/evm-contracts/src/v0.5/Chainlink.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.5.0;
 
-import { CBOR as CBOR_Chainlink, Buffer as Buffer_Chainlink } from "./vendor/CBOR.sol";
+import { CBOR as CBOR_Chainlink, Buffer } from "./vendor/CBOR.sol";
 
 /**
  * @title Library for common Chainlink functions
@@ -9,14 +9,14 @@ import { CBOR as CBOR_Chainlink, Buffer as Buffer_Chainlink } from "./vendor/CBO
 library Chainlink {
   uint256 internal constant defaultBufferSize = 256; // solhint-disable-line const-name-snakecase
 
-  using CBOR_Chainlink for Buffer_Chainlink.buffer;
+  using CBOR_Chainlink for Buffer.buffer;
 
   struct Request {
     bytes32 id;
     address callbackAddress;
     bytes4 callbackFunctionId;
     uint256 nonce;
-    Buffer_Chainlink.buffer buf;
+    Buffer.buffer buf;
   }
 
   /**
@@ -34,7 +34,7 @@ library Chainlink {
     address _callbackAddress,
     bytes4 _callbackFunction
   ) internal pure returns (Chainlink.Request memory) {
-    Buffer_Chainlink.init(self.buf, defaultBufferSize);
+    Buffer.init(self.buf, defaultBufferSize);
     self.id = _id;
     self.callbackAddress = _callbackAddress;
     self.callbackFunctionId = _callbackFunction;
@@ -50,8 +50,8 @@ library Chainlink {
   function setBuffer(Request memory self, bytes memory _data)
     internal pure
   {
-    Buffer_Chainlink.init(self.buf, _data.length);
-    Buffer_Chainlink.append(self.buf, _data);
+    Buffer.init(self.buf, _data.length);
+    Buffer.append(self.buf, _data);
   }
 
   /**

--- a/evm-contracts/src/v0.5/Chainlink.sol
+++ b/evm-contracts/src/v0.5/Chainlink.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.5.0;
 
-import { CBOR as CBOR_Chainlink, Buffer } from "./vendor/CBOR.sol";
+import { CBOR as CBOR_Chainlink } from "./vendor/CBOR.sol";
+import { Buffer as Buffer_Chainlink } from "./vendor/Buffer.sol";
 
 /**
  * @title Library for common Chainlink functions
@@ -9,14 +10,14 @@ import { CBOR as CBOR_Chainlink, Buffer } from "./vendor/CBOR.sol";
 library Chainlink {
   uint256 internal constant defaultBufferSize = 256; // solhint-disable-line const-name-snakecase
 
-  using CBOR_Chainlink for Buffer.buffer;
+  using CBOR_Chainlink for Buffer_Chainlink.buffer;
 
   struct Request {
     bytes32 id;
     address callbackAddress;
     bytes4 callbackFunctionId;
     uint256 nonce;
-    Buffer.buffer buf;
+    Buffer_Chainlink.buffer buf;
   }
 
   /**
@@ -34,7 +35,7 @@ library Chainlink {
     address _callbackAddress,
     bytes4 _callbackFunction
   ) internal pure returns (Chainlink.Request memory) {
-    Buffer.init(self.buf, defaultBufferSize);
+    Buffer_Chainlink.init(self.buf, defaultBufferSize);
     self.id = _id;
     self.callbackAddress = _callbackAddress;
     self.callbackFunctionId = _callbackFunction;
@@ -50,8 +51,8 @@ library Chainlink {
   function setBuffer(Request memory self, bytes memory _data)
     internal pure
   {
-    Buffer.init(self.buf, _data.length);
-    Buffer.append(self.buf, _data);
+    Buffer_Chainlink.init(self.buf, _data.length);
+    Buffer_Chainlink.append(self.buf, _data);
   }
 
   /**

--- a/evm-contracts/src/v0.5/tests/MaliciousChainlink.sol
+++ b/evm-contracts/src/v0.5/tests/MaliciousChainlink.sol
@@ -1,16 +1,17 @@
 pragma solidity 0.5.0;
 
-import "../vendor/CBOR.sol";
+import { CBOR as CBOR_Chainlink } from "../vendor/CBOR.sol";
+import { Buffer as Buffer_Chainlink } from "../vendor/Buffer.sol";
 
 library MaliciousChainlink {
-  using CBOR for Buffer.buffer;
+  using CBOR_Chainlink for Buffer_Chainlink.buffer;
 
   struct Request {
     bytes32 specId;
     address callbackAddress;
     bytes4 callbackFunctionId;
     uint256 nonce;
-    Buffer.buffer buf;
+    Buffer_Chainlink.buffer buf;
   }
 
   struct WithdrawRequest {
@@ -18,7 +19,7 @@ library MaliciousChainlink {
     address callbackAddress;
     bytes4 callbackFunctionId;
     uint256 nonce;
-    Buffer.buffer buf;
+    Buffer_Chainlink.buffer buf;
   }
 
   function initializeWithdraw(
@@ -27,7 +28,7 @@ library MaliciousChainlink {
     address _callbackAddress,
     bytes4 _callbackFunction
   ) internal pure returns (MaliciousChainlink.WithdrawRequest memory) {
-    Buffer.init(self.buf, 128);
+    Buffer_Chainlink.init(self.buf, 128);
     self.specId = _specId;
     self.callbackAddress = _callbackAddress;
     self.callbackFunctionId = _callbackFunction;

--- a/evm-contracts/src/v0.5/vendor/CBOR.sol
+++ b/evm-contracts/src/v0.5/vendor/CBOR.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.5.0;
 
-import "./Buffer.sol";
+import { Buffer as Buffer_Chainlink } from "./Buffer.sol";
 
 library CBOR {
-  using Buffer for Buffer.buffer;
+  using Buffer_Chainlink for Buffer_Chainlink.buffer;
 
   uint8 private constant MAJOR_TYPE_INT = 0;
   uint8 private constant MAJOR_TYPE_NEGATIVE_INT = 1;
@@ -13,7 +13,7 @@ library CBOR {
   uint8 private constant MAJOR_TYPE_MAP = 5;
   uint8 private constant MAJOR_TYPE_CONTENT_FREE = 7;
 
-  function encodeType(Buffer.buffer memory buf, uint8 major, uint value) private pure {
+  function encodeType(Buffer_Chainlink.buffer memory buf, uint8 major, uint value) private pure {
     if(value <= 23) {
       buf.appendUint8(uint8((major << 5) | value));
     } else if(value <= 0xFF) {
@@ -31,15 +31,15 @@ library CBOR {
     }
   }
 
-  function encodeIndefiniteLengthType(Buffer.buffer memory buf, uint8 major) private pure {
+  function encodeIndefiniteLengthType(Buffer_Chainlink.buffer memory buf, uint8 major) private pure {
     buf.appendUint8(uint8((major << 5) | 31));
   }
 
-  function encodeUInt(Buffer.buffer memory buf, uint value) internal pure {
+  function encodeUInt(Buffer_Chainlink.buffer memory buf, uint value) internal pure {
     encodeType(buf, MAJOR_TYPE_INT, value);
   }
 
-  function encodeInt(Buffer.buffer memory buf, int value) internal pure {
+  function encodeInt(Buffer_Chainlink.buffer memory buf, int value) internal pure {
     if(value >= 0) {
       encodeType(buf, MAJOR_TYPE_INT, uint(value));
     } else {
@@ -47,25 +47,25 @@ library CBOR {
     }
   }
 
-  function encodeBytes(Buffer.buffer memory buf, bytes memory value) internal pure {
+  function encodeBytes(Buffer_Chainlink.buffer memory buf, bytes memory value) internal pure {
     encodeType(buf, MAJOR_TYPE_BYTES, value.length);
     buf.append(value);
   }
 
-  function encodeString(Buffer.buffer memory buf, string memory value) internal pure {
+  function encodeString(Buffer_Chainlink.buffer memory buf, string memory value) internal pure {
     encodeType(buf, MAJOR_TYPE_STRING, bytes(value).length);
     buf.append(bytes(value));
   }
 
-  function startArray(Buffer.buffer memory buf) internal pure {
+  function startArray(Buffer_Chainlink.buffer memory buf) internal pure {
     encodeIndefiniteLengthType(buf, MAJOR_TYPE_ARRAY);
   }
 
-  function startMap(Buffer.buffer memory buf) internal pure {
+  function startMap(Buffer_Chainlink.buffer memory buf) internal pure {
     encodeIndefiniteLengthType(buf, MAJOR_TYPE_MAP);
   }
 
-  function endSequence(Buffer.buffer memory buf) internal pure {
+  function endSequence(Buffer_Chainlink.buffer memory buf) internal pure {
     encodeIndefiniteLengthType(buf, MAJOR_TYPE_CONTENT_FREE);
   }
 }

--- a/evm-contracts/src/v0.6/Chainlink.sol
+++ b/evm-contracts/src/v0.6/Chainlink.sol
@@ -1,6 +1,7 @@
 pragma solidity ^0.6.0;
 
-import { CBOR as CBOR_Chainlink, Buffer } from "./vendor/CBOR.sol";
+import { CBOR as CBOR_Chainlink } from "./vendor/CBOR.sol";
+import { Buffer as Buffer_Chainlink } from "./vendor/Buffer.sol";
 
 /**
  * @title Library for common Chainlink functions
@@ -9,14 +10,14 @@ import { CBOR as CBOR_Chainlink, Buffer } from "./vendor/CBOR.sol";
 library Chainlink {
   uint256 internal constant defaultBufferSize = 256; // solhint-disable-line const-name-snakecase
 
-  using CBOR_Chainlink for Buffer.buffer;
+  using CBOR_Chainlink for Buffer_Chainlink.buffer;
 
   struct Request {
     bytes32 id;
     address callbackAddress;
     bytes4 callbackFunctionId;
     uint256 nonce;
-    Buffer.buffer buf;
+    Buffer_Chainlink.buffer buf;
   }
 
   /**
@@ -34,7 +35,7 @@ library Chainlink {
     address _callbackAddress,
     bytes4 _callbackFunction
   ) internal pure returns (Chainlink.Request memory) {
-    Buffer.init(self.buf, defaultBufferSize);
+    Buffer_Chainlink.init(self.buf, defaultBufferSize);
     self.id = _id;
     self.callbackAddress = _callbackAddress;
     self.callbackFunctionId = _callbackFunction;
@@ -50,8 +51,8 @@ library Chainlink {
   function setBuffer(Request memory self, bytes memory _data)
     internal pure
   {
-    Buffer.init(self.buf, _data.length);
-    Buffer.append(self.buf, _data);
+    Buffer_Chainlink.init(self.buf, _data.length);
+    Buffer_Chainlink.append(self.buf, _data);
   }
 
   /**

--- a/evm-contracts/src/v0.6/Chainlink.sol
+++ b/evm-contracts/src/v0.6/Chainlink.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.6.0;
 
-import { CBOR as CBOR_Chainlink, Buffer as Buffer_Chainlink } from "./vendor/CBOR.sol";
+import { CBOR as CBOR_Chainlink, Buffer } from "./vendor/CBOR.sol";
 
 /**
  * @title Library for common Chainlink functions
@@ -9,14 +9,14 @@ import { CBOR as CBOR_Chainlink, Buffer as Buffer_Chainlink } from "./vendor/CBO
 library Chainlink {
   uint256 internal constant defaultBufferSize = 256; // solhint-disable-line const-name-snakecase
 
-  using CBOR_Chainlink for Buffer_Chainlink.buffer;
+  using CBOR_Chainlink for Buffer.buffer;
 
   struct Request {
     bytes32 id;
     address callbackAddress;
     bytes4 callbackFunctionId;
     uint256 nonce;
-    Buffer_Chainlink.buffer buf;
+    Buffer.buffer buf;
   }
 
   /**
@@ -34,7 +34,7 @@ library Chainlink {
     address _callbackAddress,
     bytes4 _callbackFunction
   ) internal pure returns (Chainlink.Request memory) {
-    Buffer_Chainlink.init(self.buf, defaultBufferSize);
+    Buffer.init(self.buf, defaultBufferSize);
     self.id = _id;
     self.callbackAddress = _callbackAddress;
     self.callbackFunctionId = _callbackFunction;
@@ -50,8 +50,8 @@ library Chainlink {
   function setBuffer(Request memory self, bytes memory _data)
     internal pure
   {
-    Buffer_Chainlink.init(self.buf, _data.length);
-    Buffer_Chainlink.append(self.buf, _data);
+    Buffer.init(self.buf, _data.length);
+    Buffer.append(self.buf, _data);
   }
 
   /**

--- a/evm-contracts/src/v0.6/vendor/CBOR.sol
+++ b/evm-contracts/src/v0.6/vendor/CBOR.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.6.0;
 
-import "./Buffer.sol";
+import { Buffer as Buffer_Chainlink } from "./Buffer.sol";
 
 library CBOR {
-  using Buffer for Buffer.buffer;
+  using Buffer_Chainlink for Buffer_Chainlink.buffer;
 
   uint8 private constant MAJOR_TYPE_INT = 0;
   uint8 private constant MAJOR_TYPE_NEGATIVE_INT = 1;
@@ -13,7 +13,7 @@ library CBOR {
   uint8 private constant MAJOR_TYPE_MAP = 5;
   uint8 private constant MAJOR_TYPE_CONTENT_FREE = 7;
 
-  function encodeType(Buffer.buffer memory buf, uint8 major, uint value) private pure {
+  function encodeType(Buffer_Chainlink.buffer memory buf, uint8 major, uint value) private pure {
     if(value <= 23) {
       buf.appendUint8(uint8((major << 5) | value));
     } else if(value <= 0xFF) {
@@ -31,15 +31,15 @@ library CBOR {
     }
   }
 
-  function encodeIndefiniteLengthType(Buffer.buffer memory buf, uint8 major) private pure {
+  function encodeIndefiniteLengthType(Buffer_Chainlink.buffer memory buf, uint8 major) private pure {
     buf.appendUint8(uint8((major << 5) | 31));
   }
 
-  function encodeUInt(Buffer.buffer memory buf, uint value) internal pure {
+  function encodeUInt(Buffer_Chainlink.buffer memory buf, uint value) internal pure {
     encodeType(buf, MAJOR_TYPE_INT, value);
   }
 
-  function encodeInt(Buffer.buffer memory buf, int value) internal pure {
+  function encodeInt(Buffer_Chainlink.buffer memory buf, int value) internal pure {
     if(value >= 0) {
       encodeType(buf, MAJOR_TYPE_INT, uint(value));
     } else {
@@ -47,25 +47,25 @@ library CBOR {
     }
   }
 
-  function encodeBytes(Buffer.buffer memory buf, bytes memory value) internal pure {
+  function encodeBytes(Buffer_Chainlink.buffer memory buf, bytes memory value) internal pure {
     encodeType(buf, MAJOR_TYPE_BYTES, value.length);
     buf.append(value);
   }
 
-  function encodeString(Buffer.buffer memory buf, string memory value) internal pure {
+  function encodeString(Buffer_Chainlink.buffer memory buf, string memory value) internal pure {
     encodeType(buf, MAJOR_TYPE_STRING, bytes(value).length);
     buf.append(bytes(value));
   }
 
-  function startArray(Buffer.buffer memory buf) internal pure {
+  function startArray(Buffer_Chainlink.buffer memory buf) internal pure {
     encodeIndefiniteLengthType(buf, MAJOR_TYPE_ARRAY);
   }
 
-  function startMap(Buffer.buffer memory buf) internal pure {
+  function startMap(Buffer_Chainlink.buffer memory buf) internal pure {
     encodeIndefiniteLengthType(buf, MAJOR_TYPE_MAP);
   }
 
-  function endSequence(Buffer.buffer memory buf) internal pure {
+  function endSequence(Buffer_Chainlink.buffer memory buf) internal pure {
     encodeIndefiniteLengthType(buf, MAJOR_TYPE_CONTENT_FREE);
   }
 }


### PR DESCRIPTION
`Tl;DR` is that flattening (and thus verifying for Etherscan) any chainlinked (containing `Chainlink.sol` lib) smart contract compiled in truffle is not working due to current limitations of merging tools.

Tools such as `sol-merger` (https://github.com/RyuuGan/sol-merger)
and `truffle-plugin-verify`
(https://github.com/rkalis/truffle-plugin-verify)
used currently to submit flattened smart contracts to Etherscan cannot
correctly compile flattened contracts with any `Chainlink.sol` imports
due to multialiasing (`Buffer` imported more than once under
different aliases). This commit removes this indirection thus
restoring correct functionality of mentioned tools.

Why I chose to open PR instead of adding an issue:
a) Urgency - right now everyone going through introductory tutorial of creating a chainlinked project @ https://docs.chain.link/docs/create-a-chainlinked-project will bump into this issue - Etherscan verification for a chainlinked smart contract (done either manually or via Truffle plugin) compiled via Truffle is failing without introducing this change and  it takes a lot of time to debug too;
b) ROI - it is a small change that would save people going through introductory tutorial a lot of time when they try to verify (or flatten for whatever purpose) their chainlinked contracts.


P.S. If this gets a ticket/tracking # I'd be happy to rename my branch (currently requesting merge from `develop` fork)