### PR TITLE
 Llimit core ci test output to failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -33,7 +33,10 @@ jobs:
             - '/go/pkg/mod'
       - run: yarn setup:contracts
       - run: go run ./core local db preparetest
-      - run: go test -v -p 4 -parallel 4 ./...
+      - run: go test -v -p 4 -parallel 4 ./... | tee ./output.txt | grep "\-\-\- FAIL" || echo "All passed!" # only show failures
+      - store_artifacts:
+          path: ./output.txt
+
   rust:
     docker:
       - image: smartcontract/builder:1.0.33


### PR DESCRIPTION
This PR will make it so that the output someone views in circleCI will be limited to the lists of the names of the tests that failed (no other info will be available). The full output of the test, will be available under the artifacts tab.