### PR TITLE
Add round-robin picking of random addresses

### DIFF
--- a/CHANGELOG-core.md
+++ b/CHANGELOG-core.md
@@ -7,9 +7,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Job specs now support pinning to multiple keys using the new `fromAddresses` field in the ethtx task spec.
+
+### Changed
+
+- Using `fromAddress` in ethtx task specs has been deprecated. Please use `fromAddresses` instead.
+
 ### Breaking changes
 
 - Support for RunLogTopic0original and RunLogTopic20190123withFullfillmentParams logs has been dropped. This should not affect any users since these logs predate Chainlink's mainnet launch and have never been used on mainnet.
+
+IMPORTANT: The selection mechanism for keys has changed. When an ethtx task spec is not pinned to a particular key by  defining `fromAddress` or `fromAddresses`, the node will now cycle through all available keys in round robin fashion. This is a change from the previous behaviour where nodes would only pick the earliest created key.
+
+This is done to allow increases in throughput when a node operator has multiple whitelisted addresses for their oracle.
+
+If your node has multiple keys, you will need to take one of the three following actions:
+
+1. Make sure all keys are valid for all job specs
+2. Pin job specs to a valid subset of key(s) using `fromAddresses`
+3. Delete the key(s) you don't want to use
+
+If your node only has one key, no action is required.
+
 
 ## [0.8.8] - 2020-06-29
 

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -59,6 +59,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1591603775"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1592355365"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1594393769"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1594642891"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -291,6 +292,10 @@ func init() {
 		{
 			ID:      "1594393769",
 			Migrate: migration1594393769.Migrate,
+		},
+		{
+			ID:      "1594642891",
+			Migrate: migration1594642891.Migrate,
 		},
 	}
 }

--- a/core/store/migrations/migration1594642891/migrate.go
+++ b/core/store/migrations/migration1594642891/migrate.go
@@ -1,0 +1,12 @@
+package migration1594642891
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+// Migrate adds last_used to keys
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+		ALTER TABLE keys ADD COLUMN last_used timestamptz;
+	`).Error
+}

--- a/core/store/models/address.go
+++ b/core/store/models/address.go
@@ -51,6 +51,11 @@ func (a EIP55Address) String() string {
 	return string(a)
 }
 
+// Hex is idential to String but makes the API similar to common.Address
+func (a EIP55Address) Hex() string {
+	return a.String()
+}
+
 // Format implements fmt.Formatter
 func (a EIP55Address) Format(s fmt.State, c rune) {
 	_, err := fmt.Fprint(s, a.String())

--- a/core/store/models/key.go
+++ b/core/store/models/key.go
@@ -26,6 +26,7 @@ type Key struct {
 	// Conceptually equivalent to geth's `PendingNonceAt` but more reliable
 	// because we have a better view of our own transactions
 	NextNonce int64
+	LastUsed  *time.Time
 }
 
 // NewKeyFromFile creates an instance in memory from a key file on disk.


### PR DESCRIPTION
Instead of just picking the first available key, we should get a random key derived from the job run ID.