### PR TITLE
Update VRF documentation

### DIFF
--- a/evm-contracts/src/v0.6/VRFConsumerBase.sol
+++ b/evm-contracts/src/v0.6/VRFConsumerBase.sol
@@ -71,12 +71,13 @@ import "./VRFRequestIDBase.sol";
  * @dev compatability with previous versions of this contract.
  *
  * @dev Since the block hash of the block which contains the requestRandomness()
- * @dev call is mixed into the input to the VRF *last*, a sufficiently powerful miner
- * @dev could, in principle, fork the blockchain to evict the block containing
- * @dev the request, forcing the request to be included in a different block with a
- * @dev different hash, and therefore a different input to the VRF. However, such an
- * @dev attack would incur a substantial economic cost. This cost scales with the
- * @dev number of blocks the VRF oracle waits until it calls fulfillRandomness().
+ * @dev call is mixed into the input to the VRF *last*, a sufficiently powerful
+ * @dev miner could, in principle, fork the blockchain to evict the block
+ * @dev containing the request, forcing the request to be included in a
+ * @dev different block with a different hash, and therefore a different input
+ * @dev to the VRF. However, such an attack would incur a substantial economic
+ * @dev cost. This cost scales with the number of blocks the VRF oracle waits
+ * @dev until it calls fulfillRandomness().
  */
 abstract contract VRFConsumerBase is VRFRequestIDBase {
 

--- a/evm-contracts/src/v0.6/VRFCoordinator.sol
+++ b/evm-contracts/src/v0.6/VRFCoordinator.sol
@@ -141,7 +141,7 @@ contract VRFCoordinator is VRF, VRFRequestIDBase {
     uint256 nonce = nonces[_keyHash][_sender];
     uint256 preSeed = makeVRFInputSeed(_keyHash, _consumerSeed, _sender, nonce);
     bytes32 requestId = makeRequestId(_keyHash, preSeed);
-    // Cryptographically guaranteed by seed including an increasing nonce
+    // Cryptographically guaranteed by preSeed including an increasing nonce
     assert(callbacks[requestId].callbackContract == address(0));
     callbacks[requestId].callbackContract = _sender;
     assert(_feePaid < 1e27); // Total LINK fits in uint96
@@ -180,7 +180,7 @@ contract VRFCoordinator is VRF, VRFRequestIDBase {
       callback.randomnessFee);
 
     // Forget request. Must precede callback (prevents reentrancy)
-    delete callbacks[requestId]; 
+    delete callbacks[requestId];
     callBackWithRandomness(requestId, randomness, callback.callbackContract);
 
     emit RandomnessRequestFulfilled(requestId, randomness);
@@ -209,7 +209,7 @@ contract VRFCoordinator is VRF, VRFRequestIDBase {
     (bool success,) = consumerContract.call(resp);
     // Avoid unused-local-variable warning. (success is only present to prevent
     // a warning that the return value of consumerContract.call is unused.)
-    (success); 
+    (success);
   }
 
   function getRandomnessFromProof(bytes memory _proof)

--- a/evm-contracts/src/v0.6/VRFRequestIDBase.sol
+++ b/evm-contracts/src/v0.6/VRFRequestIDBase.sol
@@ -5,9 +5,12 @@ contract VRFRequestIDBase {
   /**
    * @notice returns the seed which is actually input to the VRF coordinator
    *
-   * @dev To prevent repetition of VRF output due to repetition against the
-   * @dev user-supplied seed, that seed is combined in a hash with the a
-   * @dev user-specific nonce, and the address of the consuming contract.
+   * @dev To prevent repetition of VRF output due to repetition of the
+   * @dev user-supplied seed, that seed is combined in a hash with the
+   * @dev user-specific nonce, and the address of the consuming contract. The
+   * @dev risk of repetition is mostly mitigated by inclusion of a blockhash in
+   * @dev the final seed, but the nonce does protect against repetition in
+   * @dev requests which are included in a single block.
    *
    * @param _userSeed VRF seed input provided by user
    * @param _requester Address of the requesting contract

--- a/evm-contracts/src/v0.6/VRFRequestIDBase.sol
+++ b/evm-contracts/src/v0.6/VRFRequestIDBase.sol
@@ -3,19 +3,11 @@ pragma solidity ^0.6.0;
 contract VRFRequestIDBase {
 
   /**
-   * @notice returns the seed which is actually input to the VRF
+   * @notice returns the seed which is actually input to the VRF coordinator
    *
    * @dev To prevent repetition of VRF output due to repetition against the
    * @dev user-supplied seed, that seed is combined in a hash with the a
    * @dev user-specific nonce, and the address of the consuming contract.
-   *
-   * @dev Of course, crucial security guranatees would be broken by repetition
-   * @dev of the user-supplied seed, as all the other inputs can be anticipated
-   * @dev and the user-specified seed is public once the initial request is
-   * @dev made, so if the oracle has reason to believe that a user-specified seed
-   * @dev will be repeated, it may be able to anticipate its future outputs. So
-   * @dev it may make sense, for certain applications, for the VRF framework to
-   * @dev simply refuse to operate, if given a seed it's seen before.
    *
    * @param _userSeed VRF seed input provided by user
    * @param _requester Address of the requesting contract


### PR DESCRIPTION
I've gone through the docstrings for the `VRF*.sol` files to bring them up to date with the mandatory inclusion of the blockhash in the VRF seed.