### PR TITLE
Publish integration Docker images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -360,6 +360,96 @@ jobs:
           name: Docker build
           command: |
             SGX_ENABLED=yes DOCKER_TAG=circleci make docker
+  build-publish-integration:
+    resource_class: large
+    machine:
+      image: circleci/classic:201808-01
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          name: Docker login
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USER" --password-stdin
+      - run:
+          name: Docker build
+          command: docker build -f tools/docker/integration.Dockerfile --build-arg SRCROOT=/chainlink -t smartcontract/integration:circleci .
+      - run:
+          name: Docker push, if applicable
+          command: |
+            tools/ci/push_image "${CIRCLE_BRANCH}" "${CIRCLE_TAG}" integration
+  build-publish-cypress-job-server:
+    resource_class: large
+    machine:
+      image: circleci/classic:201808-01
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          name: Docker login
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USER" --password-stdin
+      - run:
+          name: Docker build
+          command: docker build -f tools/cypress-job-server/Dockerfile --build-arg SRCROOT=/chainlink -t smartcontract/cypress-job-server:circleci .
+      - run:
+          name: Docker push, if applicable
+          command: |
+            tools/ci/push_image "${CIRCLE_BRANCH}" "${CIRCLE_TAG}" cypress-job-server
+  build-publish-echo-server:
+    resource_class: large
+    machine:
+      image: circleci/classic:201808-01
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          name: Docker login
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USER" --password-stdin
+      - run:
+          name: Docker build
+          command: docker build -f tools/echo-server/Dockerfile --build-arg SRCROOT=/chainlink -t smartcontract/echo-server:circleci .
+      - run:
+          name: Docker push, if applicable
+          command: |
+            tools/ci/push_image "${CIRCLE_BRANCH}" "${CIRCLE_TAG}" echo-server
+  build-publish-external-adapter:
+    resource_class: large
+    machine:
+      image: circleci/classic:201808-01
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          name: Docker login
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USER" --password-stdin
+      - run:
+          name: Docker build
+          command: docker build -f tools/external-adapter/Dockerfile -t smartcontract/external-adapter:circleci .
+      - run:
+          name: Docker push, if applicable
+          command: |
+            tools/ci/push_image "${CIRCLE_BRANCH}" "${CIRCLE_TAG}" external-adapter
+  build-publish-ingester:
+    resource_class: large
+    machine:
+      image: circleci/classic:201808-01
+      docker_layer_caching: true
+    steps:
+      - checkout
+      - run:
+          name: Docker login
+          command: |
+            echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USER" --password-stdin
+      - run:
+          name: Docker build
+          command: docker build -f ingester/ingester.Dockerfile -t smartcontract/ingester:circleci .
+      - run:
+          name: Docker push, if applicable
+          command: |
+            tools/ci/push_image "${CIRCLE_BRANCH}" "${CIRCLE_TAG}" ingester
   reportcoverage:
     docker:
       - image: smartcontract/builder:1.0.33
@@ -523,6 +613,41 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+      - build-publish-integration:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only:
+                - develop
+      - build-publish-cypress-job-server:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only:
+                - develop
+      - build-publish-echo-server:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only:
+                - develop
+      - build-publish-external-adapter:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only:
+                - develop
+      - build-publish-ingester:
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              only:
+                - develop
       - reportcoverage:
           requires:
             - core-go-test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -373,11 +373,11 @@ jobs:
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USER" --password-stdin
       - run:
           name: Docker build
-          command: docker build -f tools/docker/integration.Dockerfile --build-arg SRCROOT=/chainlink -t smartcontract/integration:circleci .
+          command: docker build -f tools/docker/integration.Dockerfile --build-arg SRCROOT=/chainlink -t smartcontract/test-integration:circleci .
       - run:
           name: Docker push, if applicable
           command: |
-            tools/ci/push_image "${CIRCLE_BRANCH}" "${CIRCLE_TAG}" integration
+            tools/ci/push_image "${CIRCLE_BRANCH}" "${CIRCLE_TAG}" test-integration
   build-publish-cypress-job-server:
     resource_class: large
     machine:
@@ -391,11 +391,11 @@ jobs:
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USER" --password-stdin
       - run:
           name: Docker build
-          command: docker build -f tools/cypress-job-server/Dockerfile --build-arg SRCROOT=/chainlink -t smartcontract/cypress-job-server:circleci .
+          command: docker build -f tools/cypress-job-server/Dockerfile --build-arg SRCROOT=/chainlink -t smartcontract/test-cypress-job-server:circleci .
       - run:
           name: Docker push, if applicable
           command: |
-            tools/ci/push_image "${CIRCLE_BRANCH}" "${CIRCLE_TAG}" cypress-job-server
+            tools/ci/push_image "${CIRCLE_BRANCH}" "${CIRCLE_TAG}" test-cypress-job-server
   build-publish-echo-server:
     resource_class: large
     machine:
@@ -409,11 +409,11 @@ jobs:
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USER" --password-stdin
       - run:
           name: Docker build
-          command: docker build -f tools/echo-server/Dockerfile --build-arg SRCROOT=/chainlink -t smartcontract/echo-server:circleci .
+          command: docker build -f tools/echo-server/Dockerfile --build-arg SRCROOT=/chainlink -t smartcontract/test-echo-server:circleci .
       - run:
           name: Docker push, if applicable
           command: |
-            tools/ci/push_image "${CIRCLE_BRANCH}" "${CIRCLE_TAG}" echo-server
+            tools/ci/push_image "${CIRCLE_BRANCH}" "${CIRCLE_TAG}" test-echo-server
   build-publish-external-adapter:
     resource_class: large
     machine:
@@ -427,11 +427,11 @@ jobs:
             echo "$DOCKERHUB_PASS" | docker login -u "$DOCKERHUB_USER" --password-stdin
       - run:
           name: Docker build
-          command: docker build -f tools/external-adapter/Dockerfile -t smartcontract/external-adapter:circleci .
+          command: docker build -f tools/external-adapter/Dockerfile -t smartcontract/test-external-adapter:circleci .
       - run:
           name: Docker push, if applicable
           command: |
-            tools/ci/push_image "${CIRCLE_BRANCH}" "${CIRCLE_TAG}" external-adapter
+            tools/ci/push_image "${CIRCLE_BRANCH}" "${CIRCLE_TAG}" test-external-adapter
   build-publish-ingester:
     resource_class: large
     machine:

--- a/tools/ci/push_image
+++ b/tools/ci/push_image
@@ -17,11 +17,11 @@ set -ex
 # to work with.
 #
 # Argument <image> is likely one of the following:
-# integration
-# cypress_job_server
+# test-integration
+# test-cypress-job-server
+# test-external-adapter
+# test-echo-server
 # ingester
-# external_adapter
-# echo_server
 #
 
 if [ -z "$DOCKERHUB_PASS" ]

--- a/tools/ci/push_image
+++ b/tools/ci/push_image
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -ex
+
+#
+# Generic Docker image pusher that follows the same push logic found in push_chainlink
+#
+# Pushes smartcontract/<image>:circleci to relevant location based on passed args:
+# push_image <branch> <gittag> <image>
+# ie:
+# push_image master 0.6.9 integration
+# push_image develop echo_server
+# push_image release/0.6.9 ingester
+#
+# Ignores anything not matching above.
+# Key assumption: local version of smartcontract/<image>:circleci is the image
+# to work with.
+#
+# Argument <image> is likely one of the following:
+# integration
+# cypress_job_server
+# ingester
+# external_adapter
+# echo_server
+#
+
+if [ -z "$DOCKERHUB_PASS" ]
+then
+  echo "Cannot push to dockerhub, credentials are missing."
+  exit 1
+fi
+
+circle_branch="$1"
+circle_tag="$2"
+image_name="$3"
+
+tag_and_push() {
+  # ie: docker tag and push smartcontract/<image>:0.9.1, since DOCKER_TAG=0.9.1
+  docker_tag=$1
+  docker tag smartcontract/${image_name}:circleci smartcontract/${image_name}:${docker_tag}
+  docker push smartcontract/${image_name}:${docker_tag}
+}
+
+branch_tag=`tools/ci/branch2tag ${circle_branch}` # ie: develop, latest, candidate-*, etc.
+version_tag=`tools/ci/gittag2dockertag ${circle_tag}` # aka GIT_TAG. v0.9.1 -> 0.9.1
+
+# version tag takes precedence.
+if [ -n "${version_tag}" ]; then
+  # Only if we don't have an explorer tag
+  if [[ "${circle_tag}" =~ ^explorer-v([a-zA-Z0-9.]+) ]]; then
+    echo "Skipping publishing for this branch/tag."
+  else
+    tag_and_push "$version_tag"
+    # if version tag, also push latest.
+    # ie: after pushing smartcontract/<image>:0.6.9, also update smartcontract/<image>:latest
+    tag_and_push latest
+  fi
+elif [ -n "$branch_tag" ]; then
+  # Only if we're not on explorer branch
+  if [[ "${circle_branch}" =~ ^release(s)?\/explorer-(.+)$ ]]; then
+    echo "Skipping publishing for this branch/tag."
+  else
+    tag_and_push "$branch_tag"
+  fi
+else
+  echo "Skipping publishing for this branch/tag."
+fi


### PR DESCRIPTION
The goal of this PR is to publish all Docker images required to run the integration tests (i.e. `./compose test`) on both Chainlink release and push to `develop`. This is in preparation for separating out `explorer` into its own repository. 

With these images published, the `docker-compose` setup for the integration tests can be recreated with minimal duplicated code. 

Images to be published:
 - `test-integration` from `tools/docker/integration.Dockerfile`
 - `test-cypress-job-server` from `tools/cypress-job-server/Dockerfile`
 - `test-echo-server` from `tools/echo-server/Dockerfile`
 - `test-external-adapter` from `tools/external-adapter/Dockerfile`
 - `ingester` from `ingester/ingester.Dockerfile`

If it helps review, I've been testing these changes on [a fork of the repository](https://github.com/skubakdj/chainlink/pull/3) (with a few additional commits to adapt the setup to a test account). 