### PR TITLE
Improvements to off-chain VRF code

### DIFF
--- a/core/store/models/key.go
+++ b/core/store/models/key.go
@@ -48,5 +48,5 @@ func NewKeyFromFile(path string) (Key, error) {
 
 // WriteToDisk writes this key to disk at the passed path.
 func (k *Key) WriteToDisk(path string) error {
-	return utils.WriteFileWithMaxPerms(path, []byte(k.JSON.String()), 0700)
+	return utils.WriteFileWithMaxPerms(path, []byte(k.JSON.String()), 0600)
 }


### PR DESCRIPTION
- Tighten the bound on block numbers in a RandomnessRequest to the constraint
  imposed by a javascript number.

- Don't make VRF key files executable.