### PR TITLE
Show proxy address in feeds if there is one

### DIFF
--- a/feeds/public/feeds.json
+++ b/feeds/public/feeds.json
@@ -2,6 +2,7 @@
   {
     "compareOffchain": "https://www.tradingview.com/symbols/ETHUSD/?exchange=COINBASE",
     "contractAddress": "0xF79D6aFBb6dA890132F9D7c355e3015f15F3406F",
+    "proxyAddress": "0x32dbd3214aC75223e27e575C5394430791fake12",
     "contractType": "aggregator",
     "contractVersion": 2,
     "decimalPlaces": 3,

--- a/feeds/src/components/vis/info/Info.test.tsx
+++ b/feeds/src/components/vis/info/Info.test.tsx
@@ -1,0 +1,58 @@
+import { partialAsFull } from '@chainlink/ts-helpers'
+import React from 'react'
+import '@testing-library/jest-dom/extend-expect'
+import { render } from '@testing-library/react'
+import { FeedConfig } from 'config'
+import Info from './Info'
+
+const feed = partialAsFull<FeedConfig>({
+  proxyAddress: 'ProxyAddress1',
+  contractAddress: 'contractAddress1',
+})
+
+const props = {
+  latestAnswer: '1',
+  latestRequestTimestamp: 1,
+  minimumAnswers: 1,
+  oracleAnswers: undefined,
+  oracleList: [],
+  latestAnswerTimestamp: undefined,
+  pendingRoundId: undefined,
+}
+
+describe('Info', () => {
+  describe('Proxy address', () => {
+    it('renders proxy and aggregator contract addresses when there is a proxy address', () => {
+      const { container } = render(<Info config={feed} {...props} />)
+
+      expect(container).toHaveTextContent(`Feed: ${feed.proxyAddress}`)
+      expect(container).toHaveTextContent(`Aggregator: ${feed.contractAddress}`)
+    })
+
+    it('renders only aggregator contract address by default', () => {
+      const feedWithoutProxy = { ...feed }
+      delete feedWithoutProxy.proxyAddress
+
+      const { container } = render(
+        <Info config={feedWithoutProxy} {...props} />,
+      )
+
+      expect(container).not.toHaveTextContent(`Feed: ${feed.proxyAddress}`)
+      expect(container).toHaveTextContent(`Aggregator: ${feed.contractAddress}`)
+    })
+
+    it('renders only aggregator contract address when there is no proxy address (blank)', () => {
+      const feedWithoutProxy = partialAsFull<FeedConfig>({
+        proxyAddress: '',
+        contractAddress: 'contractAddress1',
+      })
+
+      const { container } = render(
+        <Info config={feedWithoutProxy} {...props} />,
+      )
+
+      expect(container).not.toHaveTextContent(`Feed: ${feed.proxyAddress}`)
+      expect(container).toHaveTextContent(`Aggregator: ${feed.contractAddress}`)
+    })
+  })
+})

--- a/feeds/src/components/vis/info/Info.tsx
+++ b/feeds/src/components/vis/info/Info.tsx
@@ -58,7 +58,14 @@ const Info: React.FC<Props> = ({
     <div className="network-graph-info__wrapper">
       <div className="network-graph-info__title">
         <h4 className="network-graph-info__title--address">
-          {config.contractAddress}{' '}
+          {config.proxyAddress && (
+            <>
+              Feed: {config.proxyAddress}{' '}
+              <TooltipQuestion title={'Ethereum contract address'} />
+              <br />
+            </>
+          )}
+          Aggregator: {config.contractAddress}{' '}
           <TooltipQuestion title={'Ethereum contract address'} />
         </h4>
         <h1 className="network-graph-info__title--name">

--- a/feeds/src/config.ts
+++ b/feeds/src/config.ts
@@ -1,5 +1,6 @@
 export interface FeedConfig {
   contractAddress: string
+  proxyAddress?: string
   contractType: 'aggregator'
   valuePrefix: '$' | 'Ξ' | '£' | '¥'
   name: string

--- a/feeds/src/state/ducks/listing/reducers.test.ts
+++ b/feeds/src/state/ducks/listing/reducers.test.ts
@@ -37,6 +37,7 @@ describe('state/ducks/listing/reducers', () => {
       const feedA = partialAsFull<FeedConfig>({
         contractAddress: 'A',
         listing: true,
+        proxyAddress: 'ProxyAddress1',
       })
       const feedB = partialAsFull<FeedConfig>({
         contractAddress: 'B',


### PR DESCRIPTION
Paired with @johnnymugs 💪 

### Summary
- Shows feed proxy address if we have one.

### Other notes
- We've briefly considered writing an integration/contract test but agreed that it would be out of scope and overkill for this ticket.
- There are legitimate cases (at least in the foreseeable future) where we might not have a proxy address, so the implemented check is semi-permanent, i.e. no plans (ticket) to remove it in the future.