### PR TITLE
Default to v2 version of oracle list when on a custom page

### DIFF
--- a/feeds/src/state/ducks/aggregator/selectors.test.ts
+++ b/feeds/src/state/ducks/aggregator/selectors.test.ts
@@ -34,6 +34,19 @@ describe('upcaseOracles', () => {
     expect(upcaseOracles(aggregatedState)).toEqual(expectedResult)
   })
 
+  it('for custom contract returns a record of oracle addresses and names', () => {
+    const aggregatedStateForCustomPage = JSON.parse(
+      JSON.stringify(aggregatedState),
+    )
+    aggregatedStateForCustomPage.aggregator.config = null
+    const expectedResult = {
+      oracleAddress1: 'Oracle 1',
+      oracleAddress2: 'Oracle 2',
+    }
+
+    expect(upcaseOracles(aggregatedStateForCustomPage)).toEqual(expectedResult)
+  })
+
   it('for v3 contract returns a record of node addresses and names', () => {
     const aggregatedStateV3 = JSON.parse(JSON.stringify(aggregatedState))
     aggregatedStateV3.aggregator.config.contractVersion = 3

--- a/feeds/src/state/ducks/aggregator/selectors.ts
+++ b/feeds/src/state/ducks/aggregator/selectors.ts
@@ -10,8 +10,14 @@ export const upcaseOracles = (
    * In v2 of the contract, oracles' list has oracle addresses,
    * but in v3 - node addresses. Therefore, a different record of
    * pairs has to be made for each contract version.
+   *
+   * Custom pages that are used to test new contracts have their
+   * `config` attribute set as `null`, so we need to check that as well.
    */
-  if (state.aggregator.config.contractVersion === 2) {
+  if (
+    state.aggregator.config === null ||
+    state.aggregator.config.contractVersion === 2
+  ) {
     return Object.fromEntries(
       Object.entries(
         state.aggregator.oracleNodes,


### PR DESCRIPTION
Story: https://www.pivotaltracker.com/story/show/174469261

### Quick summary
Creates a list of oracle names for contracts with version 2 on a custom page where config is set to `null`.

### Notes
This is a quick fix for v2 contracts as that is what currently is being tested. Needs more work to:
- Capture these errors automatically without user reports.
- Show correct oracle names for contract version v3.