### PR TITLE
Use published Explorer images in compose

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -80,10 +80,12 @@ jobs:
       matrix:
         test: ['test', 'test:ts']
         geth: [true, false]
+        explorer: ['latest', 'develop']
     env:
       GETH_MODE: ${{ matrix.geth }}
       CI: true
       CHAINLINK_DB_NAME: postgres
+      EXPLORER_DOCKER_TAG: ${{ matrix.explorer }}
     steps:
       - name: Checkout the repo
         uses: actions/checkout@v2

--- a/tools/docker/compose
+++ b/tools/docker/compose
@@ -10,12 +10,24 @@ if [ -z $CI ]; then
   export DOCKER_BUILDKIT=1
 fi
 
+# Export Explorer docker tag to be used in docker-compose files
+if [ -z $EXPLORER_DOCKER_TAG ]; then
+  export EXPLORER_DOCKER_TAG="develop"
+fi
+
 base_files="-f docker-compose.yaml -f docker-compose.postgres.yaml"
 # Allow for choosing between geth or parity
 if [ $GETH_MODE ]; then
   base_files="$base_files -f docker-compose.gethnet.yaml"
 else
   base_files="$base_files -f docker-compose.paritynet.yaml"
+fi
+
+# Build Explorer from source if path is set
+if [ $EXPLORER_SOURCE_PATH ]; then
+  base_files="$base_files -f docker-compose.explorer-source.yaml"
+else
+  base_files="$base_files -f docker-compose.explorer.yaml"
 fi
 
 base="docker-compose $base_files"                                       # base config, used standalone for acceptance

--- a/tools/docker/docker-compose.explorer-source.yaml
+++ b/tools/docker/docker-compose.explorer-source.yaml
@@ -1,0 +1,19 @@
+version: '3.5'
+
+services:
+  explorer:
+    container_name: chainlink-explorer
+    image: chainlink/explorer
+    build:
+      context: $EXPLORER_SOURCE_PATH
+      dockerfile: explorer/Dockerfile
+    entrypoint: yarn workspace @chainlink/explorer dev:compose
+    restart: always
+    ports:
+      - 8080:3001
+    depends_on:
+      - explorer-db
+    environment:
+      - EXPLORER_COOKIE_SECRET
+      - EXPLORER_SERVER_PORT
+      - PGPASSWORD=$EXPLORER_PGPASSWORD

--- a/tools/docker/docker-compose.explorer.yaml
+++ b/tools/docker/docker-compose.explorer.yaml
@@ -1,0 +1,16 @@
+version: '3.5'
+
+services:
+  explorer:
+    container_name: chainlink-explorer
+    image: smartcontract/explorer:${EXPLORER_DOCKER_TAG}
+    entrypoint: yarn workspace @chainlink/explorer dev:compose
+    restart: always
+    ports:
+      - 8080:3001
+    depends_on:
+      - explorer-db
+    environment:
+      - EXPLORER_COOKIE_SECRET
+      - EXPLORER_SERVER_PORT
+      - PGPASSWORD=$EXPLORER_PGPASSWORD

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -68,23 +68,6 @@ services:
       - apicredentials
       - keystore
 
-  explorer:
-    container_name: chainlink-explorer
-    image: chainlink/explorer
-    build:
-      context: ../../
-      dockerfile: explorer/Dockerfile
-    entrypoint: yarn workspace @chainlink/explorer dev:compose
-    restart: always
-    ports:
-      - 8080:3001
-    depends_on:
-      - explorer-db
-    environment:
-      - EXPLORER_COOKIE_SECRET
-      - EXPLORER_SERVER_PORT
-      - PGPASSWORD=$EXPLORER_PGPASSWORD
-
   explorer-db:
     container_name: chainlink-explorer-db
     image: postgres:11.6


### PR DESCRIPTION
### What
Allows Docker compose script to run integration tests using either the Explorer images published to Docker Hub, or by building Explorer from source. 

Either the image tag or source code path can be specified via environment variables.

### Why
Explorer is moving to its own repository. These changes allow CI to run against `latest` and `develop` images of Explorer that will be published by the new repo. 

With the option to run the tests by building from source, developers can also maintain a similar local workflow after Explorer is split out. 

### Notes
- This adds two items to the CI testing matrix which doubles the number of integration test jobs. 
