### PR TITLE
renamed Buffer.sol to avoid conflicts in Truffle console

### DIFF
--- a/evm-contracts/src/v0.6/Chainlink.sol
+++ b/evm-contracts/src/v0.6/Chainlink.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.6.0;
 
 import { CBOR as CBOR_Chainlink } from "./vendor/CBOR.sol";
-import { BufferChainlink as Buffer_Chainlink } from "./vendor/BufferChainlink.sol";
+import { BufferChainlink } from "./vendor/BufferChainlink.sol";
 
 /**
  * @title Library for common Chainlink functions
@@ -10,14 +10,14 @@ import { BufferChainlink as Buffer_Chainlink } from "./vendor/BufferChainlink.so
 library Chainlink {
   uint256 internal constant defaultBufferSize = 256; // solhint-disable-line const-name-snakecase
 
-  using CBOR_Chainlink for Buffer_Chainlink.buffer;
+  using CBOR_Chainlink for BufferChainlink.buffer;
 
   struct Request {
     bytes32 id;
     address callbackAddress;
     bytes4 callbackFunctionId;
     uint256 nonce;
-    Buffer_Chainlink.buffer buf;
+    BufferChainlink.buffer buf;
   }
 
   /**
@@ -35,7 +35,7 @@ library Chainlink {
     address _callbackAddress,
     bytes4 _callbackFunction
   ) internal pure returns (Chainlink.Request memory) {
-    Buffer_Chainlink.init(self.buf, defaultBufferSize);
+    BufferChainlink.init(self.buf, defaultBufferSize);
     self.id = _id;
     self.callbackAddress = _callbackAddress;
     self.callbackFunctionId = _callbackFunction;
@@ -51,8 +51,8 @@ library Chainlink {
   function setBuffer(Request memory self, bytes memory _data)
     internal pure
   {
-    Buffer_Chainlink.init(self.buf, _data.length);
-    Buffer_Chainlink.append(self.buf, _data);
+    BufferChainlink.init(self.buf, _data.length);
+    BufferChainlink.append(self.buf, _data);
   }
 
   /**

--- a/evm-contracts/src/v0.6/Chainlink.sol
+++ b/evm-contracts/src/v0.6/Chainlink.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.6.0;
 
-import { CBOR as CBOR_Chainlink } from "./vendor/CBOR.sol";
+import { CBORChainlink } from "./vendor/CBORChainlink.sol";
 import { BufferChainlink } from "./vendor/BufferChainlink.sol";
 
 /**
@@ -10,7 +10,7 @@ import { BufferChainlink } from "./vendor/BufferChainlink.sol";
 library Chainlink {
   uint256 internal constant defaultBufferSize = 256; // solhint-disable-line const-name-snakecase
 
-  using CBOR_Chainlink for BufferChainlink.buffer;
+  using CBORChainlink for BufferChainlink.buffer;
 
   struct Request {
     bytes32 id;

--- a/evm-contracts/src/v0.6/Chainlink.sol
+++ b/evm-contracts/src/v0.6/Chainlink.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.6.0;
 
 import { CBOR as CBOR_Chainlink } from "./vendor/CBOR.sol";
-import { Buffer as Buffer_Chainlink } from "./vendor/Buffer.sol";
+import { BufferChainlink as Buffer_Chainlink } from "./vendor/BufferChainlink.sol";
 
 /**
  * @title Library for common Chainlink functions

--- a/evm-contracts/src/v0.6/vendor/BufferChainlink.sol
+++ b/evm-contracts/src/v0.6/vendor/BufferChainlink.sol
@@ -8,7 +8,7 @@ pragma solidity ^0.6.0;
 * current contents of the buffer. The bytes object should not be stored between
 * operations, as it may change due to resizing of the buffer.
 */
-library Buffer {
+library BufferChainlink {
   /**
   * @dev Represents a mutable buffer. Buffers have a current value (buf) and
   *      a capacity. The capacity may be longer than the current value, in

--- a/evm-contracts/src/v0.6/vendor/CBOR.sol
+++ b/evm-contracts/src/v0.6/vendor/CBOR.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.6.0;
 
-import { Buffer as Buffer_Chainlink } from "./Buffer.sol";
+import { BufferChainlink as Buffer_Chainlink } from "./BufferChainlink.sol";
 
 library CBOR {
   using Buffer_Chainlink for Buffer_Chainlink.buffer;

--- a/evm-contracts/src/v0.6/vendor/CBOR.sol
+++ b/evm-contracts/src/v0.6/vendor/CBOR.sol
@@ -1,9 +1,9 @@
 pragma solidity ^0.6.0;
 
-import { BufferChainlink as Buffer_Chainlink } from "./BufferChainlink.sol";
+import { BufferChainlink } from "./BufferChainlink.sol";
 
 library CBOR {
-  using Buffer_Chainlink for Buffer_Chainlink.buffer;
+  using BufferChainlink for BufferChainlink.buffer;
 
   uint8 private constant MAJOR_TYPE_INT = 0;
   uint8 private constant MAJOR_TYPE_NEGATIVE_INT = 1;
@@ -13,7 +13,7 @@ library CBOR {
   uint8 private constant MAJOR_TYPE_MAP = 5;
   uint8 private constant MAJOR_TYPE_CONTENT_FREE = 7;
 
-  function encodeType(Buffer_Chainlink.buffer memory buf, uint8 major, uint value) private pure {
+  function encodeType(BufferChainlink.buffer memory buf, uint8 major, uint value) private pure {
     if(value <= 23) {
       buf.appendUint8(uint8((major << 5) | value));
     } else if(value <= 0xFF) {
@@ -31,15 +31,15 @@ library CBOR {
     }
   }
 
-  function encodeIndefiniteLengthType(Buffer_Chainlink.buffer memory buf, uint8 major) private pure {
+  function encodeIndefiniteLengthType(BufferChainlink.buffer memory buf, uint8 major) private pure {
     buf.appendUint8(uint8((major << 5) | 31));
   }
 
-  function encodeUInt(Buffer_Chainlink.buffer memory buf, uint value) internal pure {
+  function encodeUInt(BufferChainlink.buffer memory buf, uint value) internal pure {
     encodeType(buf, MAJOR_TYPE_INT, value);
   }
 
-  function encodeInt(Buffer_Chainlink.buffer memory buf, int value) internal pure {
+  function encodeInt(BufferChainlink.buffer memory buf, int value) internal pure {
     if(value >= 0) {
       encodeType(buf, MAJOR_TYPE_INT, uint(value));
     } else {
@@ -47,25 +47,25 @@ library CBOR {
     }
   }
 
-  function encodeBytes(Buffer_Chainlink.buffer memory buf, bytes memory value) internal pure {
+  function encodeBytes(BufferChainlink.buffer memory buf, bytes memory value) internal pure {
     encodeType(buf, MAJOR_TYPE_BYTES, value.length);
     buf.append(value);
   }
 
-  function encodeString(Buffer_Chainlink.buffer memory buf, string memory value) internal pure {
+  function encodeString(BufferChainlink.buffer memory buf, string memory value) internal pure {
     encodeType(buf, MAJOR_TYPE_STRING, bytes(value).length);
     buf.append(bytes(value));
   }
 
-  function startArray(Buffer_Chainlink.buffer memory buf) internal pure {
+  function startArray(BufferChainlink.buffer memory buf) internal pure {
     encodeIndefiniteLengthType(buf, MAJOR_TYPE_ARRAY);
   }
 
-  function startMap(Buffer_Chainlink.buffer memory buf) internal pure {
+  function startMap(BufferChainlink.buffer memory buf) internal pure {
     encodeIndefiniteLengthType(buf, MAJOR_TYPE_MAP);
   }
 
-  function endSequence(Buffer_Chainlink.buffer memory buf) internal pure {
+  function endSequence(BufferChainlink.buffer memory buf) internal pure {
     encodeIndefiniteLengthType(buf, MAJOR_TYPE_CONTENT_FREE);
   }
 }

--- a/evm-contracts/src/v0.6/vendor/CBORChainlink.sol
+++ b/evm-contracts/src/v0.6/vendor/CBORChainlink.sol
@@ -2,7 +2,7 @@ pragma solidity ^0.6.0;
 
 import { BufferChainlink } from "./BufferChainlink.sol";
 
-library CBOR {
+library CBORChainlink {
   using BufferChainlink for BufferChainlink.buffer;
 
   uint8 private constant MAJOR_TYPE_INT = 0;


### PR DESCRIPTION
fixes #3322

Untested. Please review and check. I also think the alias `BufferChainlink as Buffer_Chainlink` is not necessary but I left it to not be too invasive.