### PR TITLE
Feature/#174372638 Refactor core/logger for OCR

### DIFF
--- a/core/cmd/client.go
+++ b/core/cmd/client.go
@@ -13,7 +13,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/smartcontractkit/chainlink/core/logger"
+	logpkg "github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -30,7 +30,14 @@ var (
 	// ErrorNoAPICredentialsAvailable is returned when not run from a terminal
 	// and no API credentials have been provided
 	ErrorNoAPICredentialsAvailable = errors.New("API credentials must be supplied")
+
+	logger *logpkg.Logger
 )
+
+func init() {
+	cfg := orm.NewConfig()
+	logger = cfg.CreateProductionLogger()
+}
 
 // Client is the shell for the node, local commands and remote commands.
 type Client struct {

--- a/core/cmd/enclave.go
+++ b/core/cmd/enclave.go
@@ -2,10 +2,6 @@
 
 package cmd
 
-import (
-	"github.com/smartcontractkit/chainlink/core/logger"
-)
-
 // InitEnclave is a stub in non SGX enabled builds.
 func InitEnclave() error {
 	logger.Infow("SGX enclave *NOT* loaded")

--- a/core/cmd/enclave_sgx.go
+++ b/core/cmd/enclave_sgx.go
@@ -2,8 +2,6 @@
 
 package cmd
 
-import "github.com/smartcontractkit/chainlink/core/logger"
-
 // InitEnclave initialized the SGX enclave for use by adapters
 func InitEnclave() error {
 	logger.Infow("SGX Enclave Loaded")

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -17,7 +17,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink/core/gracefulpanic"
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/bulletprooftxmanager"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
@@ -45,7 +44,6 @@ func (cli *Client) RunNode(c *clipkg.Context) error {
 	}
 
 	updateConfig(cli.Config, c.Bool("debug"), c.Int64("replay-from-block"))
-	logger.SetLogger(cli.Config.CreateProductionLogger())
 	logger.Infow("Starting Chainlink Node " + strpkg.Version + " at commit " + strpkg.Sha)
 
 	err = InitEnclave()
@@ -230,7 +228,6 @@ func (cli *Client) RebroadcastTransactions(c *clipkg.Context) (err error) {
 	}
 	address := gethCommon.BytesToAddress(addressBytes)
 
-	logger.SetLogger(cli.Config.CreateProductionLogger())
 	cli.Config.Dialect = orm.DialectPostgresWithoutLock
 	app := cli.AppFactory.NewApplication(cli.Config)
 	defer func() {
@@ -336,7 +333,6 @@ func rebroadcastLegacyTransactions(store *strpkg.Store, beginningNonce uint, end
 // ResetDatabase drops, creates and migrates the database specified by DATABASE_URL
 // This is useful to setup the database for testing
 func (cli *Client) ResetDatabase(c *clipkg.Context) error {
-	logger.SetLogger(cli.Config.CreateProductionLogger())
 	config := orm.NewConfig()
 	if config.DatabaseURL() == "" {
 		return cli.errorOut(errors.New("You must set DATABASE_URL env variable. HINT: If you are running this to set up your local test database, try DATABASE_URL=postgresql://postgres@localhost:5432/chainlink_test?sslmode=disable"))
@@ -440,7 +436,6 @@ func insertFixtures(config *orm.Config) (err error) {
 
 // DeleteUser is run locally to remove the User row from the node's database.
 func (cli *Client) DeleteUser(c *clipkg.Context) (err error) {
-	logger.SetLogger(cli.Config.CreateProductionLogger())
 	app := cli.AppFactory.NewApplication(cli.Config)
 	defer func() {
 		if serr := app.Stop(); serr != nil {
@@ -460,7 +455,6 @@ func (cli *Client) SetNextNonce(c *clipkg.Context) error {
 	addressHex := c.String("address")
 	nextNonce := c.Uint64("nextNonce")
 
-	logger.SetLogger(cli.Config.CreateProductionLogger())
 	db, err := gorm.Open(string(orm.DialectPostgres), cli.Config.DatabaseURL())
 	if err != nil {
 		return cli.errorOut(err)
@@ -483,7 +477,6 @@ func (cli *Client) SetNextNonce(c *clipkg.Context) error {
 
 // ImportKey imports a key to be used with the chainlink node
 func (cli *Client) ImportKey(c *clipkg.Context) error {
-	logger.SetLogger(cli.Config.CreateProductionLogger())
 	app := cli.AppFactory.NewApplication(cli.Config)
 
 	if !c.Args().Present() {

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -272,9 +272,6 @@ func TestClient_LogToDiskOptionDisablesAsExpected(t *testing.T) {
 			require.NoError(t, os.MkdirAll(config.KeysDir(), os.FileMode(0700)))
 			defer os.RemoveAll(config.RootDir())
 
-			previousLogger := logger.GetLogger().Desugar()
-			logger.SetLogger(config.CreateProductionLogger())
-			defer logger.SetLogger(previousLogger)
 			filepath := filepath.Join(config.RootDir(), "log.jsonl")
 			_, err := os.Stat(filepath)
 			assert.Equal(t, os.IsNotExist(err), !tt.fileShouldExist)

--- a/core/cmd/local_client_vrf.go
+++ b/core/cmd/local_client_vrf.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	clipkg "github.com/urfave/cli"
 
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models/vrfkey"
 	"github.com/smartcontractkit/chainlink/core/store/orm"

--- a/core/cmd/prompter.go
+++ b/core/cmd/prompter.go
@@ -8,8 +8,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/smartcontractkit/chainlink/core/logger"
-
 	"golang.org/x/crypto/ssh/terminal"
 )
 

--- a/core/cmd/renderer.go
+++ b/core/cmd/renderer.go
@@ -6,7 +6,6 @@ import (
 	"reflect"
 	"strconv"
 
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
 	"github.com/smartcontractkit/chainlink/core/store/presenters"

--- a/core/internal/cltest/client.go
+++ b/core/internal/cltest/client.go
@@ -16,7 +16,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
 
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/eth"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -26,7 +26,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/gracefulpanic"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
-	"github.com/smartcontractkit/chainlink/core/logger"
+	logpkg "github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -78,11 +78,13 @@ var storeCounter uint64
 
 var minimumContractPayment = assets.NewLink(100)
 
+var logger *logpkg.Logger
+
 func init() {
 	gin.SetMode(gin.TestMode)
 	gomega.SetDefaultEventuallyTimeout(3 * time.Second)
 	lvl := logLevelFromEnv()
-	logger.SetLogger(CreateTestLogger(lvl))
+	logger = logpkg.CreateTestLogger(lvl)
 	// Register txdb as dialect wrapping postgres
 	// See: DialectTransactionWrappedPostgres
 	config := orm.NewConfig()

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -16,7 +16,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/adapters"
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/fluxmonitor"
 	strpkg "github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"

--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/chainlink/core/cmd"
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/eth"
 	"github.com/smartcontractkit/chainlink/core/store"

--- a/core/logger/default.go
+++ b/core/logger/default.go
@@ -1,0 +1,155 @@
+package logger
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+
+	"go.uber.org/zap"
+)
+
+var (
+	// Default logger for use throughout the project.
+	// All the package-level functions are calling Default.
+	Default *Logger
+)
+
+func init() {
+	err := zap.RegisterSink("pretty", prettyConsoleSink(os.Stderr))
+	if err != nil {
+		log.Fatalf("failed to register pretty printer %+v", err)
+	}
+	err = registerOSSinks()
+	if err != nil {
+		log.Fatalf("failed to register os specific sinks %+v", err)
+	}
+
+	zl, err := zap.NewProduction()
+	if err != nil {
+		log.Fatal(err)
+	}
+	setLogger(zl)
+}
+
+// setLogger sets the internal logger to the given input.
+func setLogger(zl *zap.Logger) {
+	if Default != nil {
+		defer func() {
+			if err := Default.Sync(); err != nil {
+				if errors.Unwrap(err).Error() != os.ErrInvalid.Error() &&
+					errors.Unwrap(err).Error() != "inappropriate ioctl for device" &&
+					errors.Unwrap(err).Error() != "bad file descriptor" {
+					// logger.Sync() will return 'invalid argument' error when closing file
+					log.Fatalf("failed to sync logger %+v", err)
+				}
+			}
+		}()
+	}
+	Default = &Logger{
+		SugaredLogger: zl.Sugar(),
+	}
+}
+
+// Infow logs an info message and any additional given information.
+func Infow(msg string, keysAndValues ...interface{}) {
+	Default.Infow(msg, keysAndValues...)
+}
+
+// Debugw logs a debug message and any additional given information.
+func Debugw(msg string, keysAndValues ...interface{}) {
+	Default.Debugw(msg, keysAndValues...)
+}
+
+// Warnw logs a debug message and any additional given information.
+func Warnw(msg string, keysAndValues ...interface{}) {
+	Default.Warnw(msg, keysAndValues...)
+}
+
+// Errorw logs an error message, any additional given information, and includes
+// stack trace.
+func Errorw(msg string, keysAndValues ...interface{}) {
+	Default.Errorw(msg, keysAndValues...)
+}
+
+// Infof formats and then logs the message.
+func Infof(format string, values ...interface{}) {
+	Default.Info(fmt.Sprintf(format, values...))
+}
+
+// Debugf formats and then logs the message.
+func Debugf(format string, values ...interface{}) {
+	Default.Debug(fmt.Sprintf(format, values...))
+}
+
+// Warnf formats and then logs the message as Warn.
+func Warnf(format string, values ...interface{}) {
+	Default.Warn(fmt.Sprintf(format, values...))
+}
+
+// Panicf formats and then logs the message before panicking.
+func Panicf(format string, values ...interface{}) {
+	Default.Panic(fmt.Sprintf(format, values...))
+}
+
+// Info logs an info message.
+func Info(args ...interface{}) {
+	Default.Info(args...)
+}
+
+// Debug logs a debug message.
+func Debug(args ...interface{}) {
+	Default.Debug(args...)
+}
+
+// Warn logs a message at the warn level.
+func Warn(args ...interface{}) {
+	Default.Warn(args...)
+}
+
+// Error logs an error message.
+func Error(args ...interface{}) {
+	Default.Error(args...)
+}
+
+func WarnIf(err error) {
+	Default.WarnIf(err)
+}
+
+func ErrorIf(err error, optionalMsg ...string) {
+	Default.ErrorIf(err, optionalMsg...)
+}
+
+func ErrorIfCalling(f func() error, optionalMsg ...string) {
+	Default.ErrorIfCalling(f, optionalMsg...)
+}
+
+// Fatal logs a fatal message then exits the application.
+func Fatal(args ...interface{}) {
+	Default.Fatal(args...)
+}
+
+// Errorf logs a message at the error level using Sprintf.
+func Errorf(format string, values ...interface{}) {
+	Error(fmt.Sprintf(format, values...))
+}
+
+// Fatalf logs a message at the fatal level using Sprintf.
+func Fatalf(format string, values ...interface{}) {
+	Fatal(fmt.Sprintf(format, values...))
+}
+
+// Panic logs a panic message then panics.
+func Panic(args ...interface{}) {
+	Default.Panic(args...)
+}
+
+// PanicIf logs the error if present.
+func PanicIf(err error) {
+	Default.PanicIf(err)
+}
+
+// Sync flushes any buffered log entries.
+func Sync() error {
+	return Default.Sync()
+}

--- a/core/logger/doc.go
+++ b/core/logger/doc.go
@@ -1,0 +1,7 @@
+// package logger exports multiple type loggers:
+// - the *Logger type is a wrapper over uber/zap#SugaredLogger with added conditional utilities.
+// - the Default instance is exported and used in all top-level functions (similar to godoc.org/log). This is sufficient for most use-cases.
+// - ProductionLogger() builds a *Logger which stores logs on disk.
+// - CreateTestLogger() prints log lines formatted for test runners. Use this in your tests!
+// - CreateMemoryTestLogger() records logs in memory. It's useful for making assertions on the produced logs.
+package logger

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -3,55 +3,17 @@
 package logger
 
 import (
-	stderr "errors"
-	"fmt"
 	"log"
-	"net/url"
-	"os"
 	"reflect"
 	"runtime"
-	"sync"
 
 	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
-var (
-	logger *Logger
-	mtx    sync.RWMutex
-)
-
-func init() {
-	err := zap.RegisterSink("pretty", prettyConsoleSink(os.Stderr))
-	if err != nil {
-		log.Fatalf("failed to register pretty printer %+v", err)
-	}
-	err = registerOSSinks()
-	if err != nil {
-		log.Fatalf("failed to register os specific sinks %+v", err)
-	}
-
-	zl, err := zap.NewProduction()
-	if err != nil {
-		log.Fatal(err)
-	}
-	SetLogger(zl)
-}
-
-func GetLogger() *Logger {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	return logger
-}
-
-func prettyConsoleSink(s zap.Sink) func(*url.URL) (zap.Sink, error) {
-	return func(*url.URL) (zap.Sink, error) {
-		return PrettyConsole{s}, nil
-	}
-}
-
-// Logger holds a field for the logger interface.
+// Logger is the main interface of this package.
+// It implements uber/zap's SugaredLogger interface and adds conditional logging helpers.
 type Logger struct {
 	*zap.SugaredLogger
 }
@@ -63,29 +25,54 @@ func (l *Logger) Write(b []byte) (int, error) {
 	return len(b), nil
 }
 
-// SetLogger sets the internal logger to the given input.
-func SetLogger(zl *zap.Logger) {
-	mtx.Lock()
-	defer mtx.Unlock()
-	if logger != nil {
-		defer func() {
-			if err := logger.Sync(); err != nil {
-				if stderr.Unwrap(err).Error() != os.ErrInvalid.Error() &&
-					stderr.Unwrap(err).Error() != "inappropriate ioctl for device" &&
-					stderr.Unwrap(err).Error() != "bad file descriptor" {
-					// logger.Sync() will return 'invalid argument' error when closing file
-					log.Fatalf("failed to sync logger %+v", err)
-				}
-			}
-		}()
+// WarnIf logs the error if present.
+func (l *Logger) WarnIf(err error) {
+	if err != nil {
+		l.Warn(err)
 	}
-	logger = &Logger{zl.Sugar()}
+}
+
+// ErrorIf logs the error if present.
+func (l *Logger) ErrorIf(err error, optionalMsg ...string) {
+	if err != nil {
+		if len(optionalMsg) > 0 {
+			l.Error(errors.Wrap(err, optionalMsg[0]))
+		} else {
+			l.Error(err)
+		}
+	}
+}
+
+// ErrorIfCalling calls the given function and logs the error of it if there is.
+func (l *Logger) ErrorIfCalling(f func() error, optionalMsg ...string) {
+	err := f()
+	if err != nil {
+		e := errors.Wrap(err, runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name())
+		if len(optionalMsg) > 0 {
+			Default.Error(errors.Wrap(e, optionalMsg[0]))
+		} else {
+			Default.Error(e)
+		}
+	}
+}
+
+func (l *Logger) PanicIf(err error) {
+	if err != nil {
+		l.Panic(err)
+	}
+}
+
+// CreateLogger dwisott
+func CreateLogger(zl *zap.SugaredLogger) *Logger {
+	return &Logger{
+		SugaredLogger: zl,
+	}
 }
 
 // CreateProductionLogger returns a log config for the passed directory
 // with the given LogLevel and customizes stdout for pretty printing.
 func CreateProductionLogger(
-	dir string, jsonConsole bool, lvl zapcore.Level, toDisk bool) *zap.Logger {
+	dir string, jsonConsole bool, lvl zapcore.Level, toDisk bool) *Logger {
 	config := zap.NewProductionConfig()
 	if !jsonConsole {
 		config.OutputPaths = []string{"pretty://console"}
@@ -101,167 +88,7 @@ func CreateProductionLogger(
 	if err != nil {
 		log.Fatal(err)
 	}
-	return zl
-}
-
-// Infow logs an info message and any additional given information.
-func Infow(msg string, keysAndValues ...interface{}) {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	logger.Infow(msg, keysAndValues...)
-}
-
-// Debugw logs a debug message and any additional given information.
-func Debugw(msg string, keysAndValues ...interface{}) {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	logger.Debugw(msg, keysAndValues...)
-}
-
-// Warnw logs a debug message and any additional given information.
-func Warnw(msg string, keysAndValues ...interface{}) {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	logger.Warnw(msg, keysAndValues...)
-}
-
-// Errorw logs an error message, any additional given information, and includes
-// stack trace.
-func Errorw(msg string, keysAndValues ...interface{}) {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	logger.Errorw(msg, keysAndValues...)
-}
-
-// Infof formats and then logs the message.
-func Infof(format string, values ...interface{}) {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	logger.Info(fmt.Sprintf(format, values...))
-}
-
-// Debugf formats and then logs the message.
-func Debugf(format string, values ...interface{}) {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	logger.Debug(fmt.Sprintf(format, values...))
-}
-
-// Warnf formats and then logs the message as Warn.
-func Warnf(format string, values ...interface{}) {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	logger.Warn(fmt.Sprintf(format, values...))
-}
-
-// Panicf formats and then logs the message before panicking.
-func Panicf(format string, values ...interface{}) {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	logger.Panic(fmt.Sprintf(format, values...))
-}
-
-// Info logs an info message.
-func Info(args ...interface{}) {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	logger.Info(args...)
-}
-
-// Debug logs a debug message.
-func Debug(args ...interface{}) {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	logger.Debug(args...)
-}
-
-// Warn logs a message at the warn level.
-func Warn(args ...interface{}) {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	logger.Warn(args...)
-}
-
-// Error logs an error message.
-func Error(args ...interface{}) {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	logger.Error(args...)
-}
-
-// WarnIf logs the error if present.
-func WarnIf(err error) {
-	if err != nil {
-		mtx.RLock()
-		defer mtx.RUnlock()
-		logger.Warn(err)
+	return &Logger{
+		SugaredLogger: zl.Sugar(),
 	}
-}
-
-// ErrorIf logs the error if present.
-func ErrorIf(err error, optionalMsg ...string) {
-	if err != nil {
-		mtx.RLock()
-		defer mtx.RUnlock()
-		if len(optionalMsg) > 0 {
-			logger.Error(errors.Wrap(err, optionalMsg[0]))
-		} else {
-			logger.Error(err)
-		}
-	}
-}
-
-// ErrorIfCalling calls the given function and logs the error of it if there is.
-func ErrorIfCalling(f func() error, optionalMsg ...string) {
-	err := f()
-	if err != nil {
-		mtx.RLock()
-		defer mtx.RUnlock()
-		e := errors.Wrap(err, runtime.FuncForPC(reflect.ValueOf(f).Pointer()).Name())
-		if len(optionalMsg) > 0 {
-			logger.Error(errors.Wrap(e, optionalMsg[0]))
-		} else {
-			logger.Error(e)
-		}
-	}
-}
-
-// PanicIf logs the error if present.
-func PanicIf(err error) {
-	if err != nil {
-		mtx.RLock()
-		defer mtx.RUnlock()
-		logger.Panic(err)
-	}
-}
-
-// Fatal logs a fatal message then exits the application.
-func Fatal(args ...interface{}) {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	logger.Fatal(args...)
-}
-
-// Errorf logs a message at the error level using Sprintf.
-func Errorf(format string, values ...interface{}) {
-	Error(fmt.Sprintf(format, values...))
-}
-
-// Fatalf logs a message at the fatal level using Sprintf.
-func Fatalf(format string, values ...interface{}) {
-	Fatal(fmt.Sprintf(format, values...))
-}
-
-// Panic logs a panic message then panics.
-func Panic(args ...interface{}) {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	logger.Panic(args...)
-}
-
-// Sync flushes any buffered log entries.
-func Sync() error {
-	mtx.RLock()
-	defer mtx.RUnlock()
-	return logger.Sync()
 }

--- a/core/logger/prettyconsole.go
+++ b/core/logger/prettyconsole.go
@@ -3,6 +3,7 @@ package logger
 import (
 	"fmt"
 	"math"
+	"net/url"
 	"sort"
 	"strings"
 	"time"
@@ -100,4 +101,10 @@ func coloredLevel(level gjson.Result) string {
 // iso8601UTC formats given time to ISO8601.
 func iso8601UTC(t time.Time) string {
 	return t.UTC().Format(time.RFC3339)
+}
+
+func prettyConsoleSink(s zap.Sink) func(*url.URL) (zap.Sink, error) {
+	return func(*url.URL) (zap.Sink, error) {
+		return PrettyConsole{s}, nil
+	}
 }

--- a/core/logger/test_logger.go
+++ b/core/logger/test_logger.go
@@ -1,4 +1,4 @@
-package cltest
+package logger
 
 // Based on https://stackoverflow.com/a/52737940
 
@@ -7,8 +7,6 @@ import (
 	"log"
 	"net/url"
 	"sync"
-
-	"github.com/smartcontractkit/chainlink/core/logger"
 
 	"github.com/fatih/color"
 	"go.uber.org/zap"
@@ -48,7 +46,7 @@ var createSinkOnce sync.Once
 func registerMemorySink() {
 	testMemoryLog = &MemorySink{m: sync.Mutex{}, b: bytes.Buffer{}}
 	if err := zap.RegisterSink("memory", func(*url.URL) (zap.Sink, error) {
-		return logger.PrettyConsole{Sink: testMemoryLog}, nil
+		return PrettyConsole{Sink: testMemoryLog}, nil
 	}); err != nil {
 		panic(err)
 	}
@@ -61,7 +59,7 @@ func MemoryLogTestingOnly() *MemorySink {
 
 // CreateTestLogger creates a logger that directs output to PrettyConsole
 // configured for test output, and to the buffer testMemoryLog.
-func CreateTestLogger(lvl zapcore.Level) *zap.Logger {
+func CreateTestLogger(lvl zapcore.Level) *Logger {
 	_ = MemoryLogTestingOnly() // Make sure memory log is created
 	color.NoColor = false
 	config := zap.NewProductionConfig()
@@ -71,12 +69,14 @@ func CreateTestLogger(lvl zapcore.Level) *zap.Logger {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return zl
+	return &Logger{
+		SugaredLogger: zl.Sugar(),
+	}
 }
 
 // CreateMemoryTestLogger creates a logger that only directs output to the
 // buffer testMemoryLog.
-func CreateMemoryTestLogger(lvl zapcore.Level) *zap.Logger {
+func CreateMemoryTestLogger(lvl zapcore.Level) *Logger {
 	_ = MemoryLogTestingOnly() // Make sure memory log is created
 	color.NoColor = true
 	config := zap.NewProductionConfig()
@@ -86,5 +86,7 @@ func CreateMemoryTestLogger(lvl zapcore.Level) *zap.Logger {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return zl
+	return &Logger{
+		SugaredLogger: zl.Sugar(),
+	}
 }

--- a/core/logger/test_logger.go
+++ b/core/logger/test_logger.go
@@ -73,20 +73,3 @@ func CreateTestLogger(lvl zapcore.Level) *Logger {
 		SugaredLogger: zl.Sugar(),
 	}
 }
-
-// CreateMemoryTestLogger creates a logger that only directs output to the
-// buffer testMemoryLog.
-func CreateMemoryTestLogger(lvl zapcore.Level) *Logger {
-	_ = MemoryLogTestingOnly() // Make sure memory log is created
-	color.NoColor = true
-	config := zap.NewProductionConfig()
-	config.Level.SetLevel(lvl)
-	config.OutputPaths = []string{"memory://"}
-	zl, err := config.Build(zap.AddCallerSkip(1))
-	if err != nil {
-		log.Fatal(err)
-	}
-	return &Logger{
-		SugaredLogger: zl.Sugar(),
-	}
-}

--- a/core/logger/test_logger_test.go
+++ b/core/logger/test_logger_test.go
@@ -1,4 +1,4 @@
-package cltest
+package logger
 
 import (
 	"testing"

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -25,7 +25,6 @@ import (
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
@@ -549,7 +548,7 @@ func (c Config) CertFile() string {
 // CreateProductionLogger returns a custom logger for the config's root
 // directory and LogLevel, with pretty printing for stdout. If LOG_TO_DISK is
 // false, the logger will only log to stdout.
-func (c Config) CreateProductionLogger() *zap.Logger {
+func (c Config) CreateProductionLogger() *logger.Logger {
 	return logger.CreateProductionLogger(
 		c.RootDir(), c.JSONConsole(), c.LogLevel().Level, c.LogToDisk())
 }

--- a/core/store/orm/config_reader.go
+++ b/core/store/orm/config_reader.go
@@ -5,11 +5,11 @@ import (
 	"net/url"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
+	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/gin-gonic/contrib/sessions"
-	"go.uber.org/zap"
 )
 
 // ConfigReader represents just the read side of the config
@@ -75,7 +75,7 @@ type ConfigReader interface {
 	tlsDir() string
 	KeyFile() string
 	CertFile() string
-	CreateProductionLogger() *zap.Logger
+	CreateProductionLogger() *logger.Logger
 	SessionSecret() ([]byte, error)
 	SessionOptions() sessions.Options
 }

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -1556,7 +1556,7 @@ func (ct Connection) initializeDatabase() (*gorm.DB, error) {
 		return nil, errors.Wrapf(err, "unable to open %s for gorm DB", ct.uri)
 	}
 
-	db.SetLogger(newOrmLogWrapper(logger.GetLogger()))
+	db.SetLogger(newOrmLogWrapper(logger.Default))
 
 	if err := dbutil.SetTimezone(db); err != nil {
 		return nil, err


### PR DESCRIPTION
### Why?

- Prepare the logger package for use in OCR: *Logger's interface is now in one place and it's easy to create *Loggers with different configurations.
- core/logger should not trip off the race detector

### How?
- ditch the `SetLogger()/GetLogger()` interface in favour of a package level `Default *Logger`. 
- move test logger from cltest into logger
- sort out loggers used in the ORM, in cltest, and in core/cmd

You can review this PR commit by commit, for the files in the core/logger package, it's better if you look a the new version as a whole, they are heavily modified so the github diff will be confusing.

### Left to do
- [x] drop CreateMemoryTestLogger - this is not used anywhere afaict
- [x] find a way to fix the VRF test which depends on log output 😱  

This test `TestIntegration_RandomnessRequest` in [core/services/vrf/vrf_simulated_blockchain_test.go](https://github.com/smartcontractkit/chainlink/blob/develop/core/services/vrf/vrf_simulate_blockchain_test.go#L39-L41) fails because it makes assertions against the log frames recorded during the execution of the test by the chainlink node using the `MemorySink` from `uber/zap`. Since the logger can't be passed to the VRF server and, with this PR, you no longer can change the global logger, it will use `Default`, which does not records log frames.  