### PR TITLE
ReplayFromBlock can only be in future

### DIFF
--- a/core/services/bulletprooftxmanager/eth_confirmer.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer.go
@@ -651,7 +651,7 @@ func unbroadcastAttempt(db *gorm.DB, attempt models.EthTxAttempt) error {
 // Deliberately does not take the advisory lock (we don't write to the database so this is safe from a data integrity perspective).
 // This is in case of some unforeseen scenario where the node is refusing to release the lock. KISS.
 func (ec *ethConfirmer) ForceRebroadcast(beginningNonce uint, endingNonce uint, gasPriceWei uint64, address gethCommon.Address, overrideGasLimit uint64) error {
-	logger.Info("ForceRebroadcast: will rebroadcast transactions for all nonces between %v and %v", beginningNonce, endingNonce)
+	logger.Infof("ForceRebroadcast: will rebroadcast transactions for all nonces between %v and %v", beginningNonce, endingNonce)
 
 	for n := beginningNonce; n <= endingNonce; n++ {
 		etx, err := findEthTxWithNonce(ec.store.DB, address, n)
@@ -667,7 +667,7 @@ func (ec *ethConfirmer) ForceRebroadcast(beginningNonce uint, endingNonce uint, 
 			}
 			logger.Infof("ForceRebroadcast: successfully rebroadcast empty transaction with nonce %v and hash %s", n, hash)
 		} else {
-			logger.Debugf("ForceRebroadcast: got eth_tx %v with nonce %v, will rebroadcast this transaction", etx.ID, etx.Nonce)
+			logger.Debugf("ForceRebroadcast: got eth_tx %v with nonce %v, will rebroadcast this transaction", etx.ID, *etx.Nonce)
 			if overrideGasLimit != 0 {
 				etx.GasLimit = overrideGasLimit
 			}
@@ -680,7 +680,7 @@ func (ec *ethConfirmer) ForceRebroadcast(beginningNonce uint, endingNonce uint, 
 				logger.Errorf("ForceRebroadcast: failed to rebroadcast eth_tx %v with nonce %v at gas price %s wei and gas limit %v: %s", etx.ID, *etx.Nonce, attempt.GasPrice.String(), etx.GasLimit, err.Error())
 				continue
 			}
-			logger.Infof("ForceRebroadcast: successfully rebroadcast eth_tx %v with hash: %s", etx.ID, attempt.Hash)
+			logger.Infof("ForceRebroadcast: successfully rebroadcast eth_tx %v with hash: 0x%x", etx.ID, attempt.Hash)
 		}
 	}
 	return nil

--- a/core/services/subscription.go
+++ b/core/services/subscription.go
@@ -40,8 +40,12 @@ func StartJobSubscription(job models.JobSpec, head *models.Head, store *strpkg.S
 
 	nextHead := head.NextInt() // Exclude current block from subscription
 	if replayFromBlock := store.Config.ReplayFromBlock(); replayFromBlock >= 0 {
-		replayFromBlockBN := big.NewInt(replayFromBlock)
-		nextHead = replayFromBlockBN
+		if replayFromBlock >= nextHead.Int64() {
+			logger.Infof("StartJobSubscription: Next head was supposed to be %v but ReplayFromBlock flag manually overrides to %v, will subscribe from blocknum %v", nextHead, replayFromBlock, replayFromBlock)
+			replayFromBlockBN := big.NewInt(replayFromBlock)
+			nextHead = replayFromBlockBN
+		}
+		logger.Warnf("StartJobSubscription: ReplayFromBlock was set to %v which is older than the next head of %v, will subscribe from blocknum %v", replayFromBlock, nextHead, nextHead)
 	}
 
 	for _, initr := range initrs {

--- a/core/services/subscription_test.go
+++ b/core/services/subscription_test.go
@@ -293,11 +293,11 @@ func TestServices_NewInitiatorSubscription_EthLog_ReplayFromBlock(t *testing.T) 
 		wantFromBlock       *big.Int
 	}{
 		{"head < ReplayFromBlock, no initr fromBlock", 5, nil, big.NewInt(10)},
-		{"head > ReplayFromBlock, no initr fromBlock", 14, nil, big.NewInt(10)},
+		{"head > ReplayFromBlock, no initr fromBlock", 14, nil, big.NewInt(15)},
 		{"head < ReplayFromBlock, initr fromBlock > ReplayFromBlock", 5, utils.NewBig(big.NewInt(12)), big.NewInt(12)},
 		{"head < ReplayFromBlock, initr fromBlock < ReplayFromBlock", 5, utils.NewBig(big.NewInt(8)), big.NewInt(10)},
-		{"head > ReplayFromBlock, initr fromBlock > ReplayFromBlock", 14, utils.NewBig(big.NewInt(12)), big.NewInt(12)},
-		{"head > ReplayFromBlock, initr fromBlock < ReplayFromBlock", 14, utils.NewBig(big.NewInt(8)), big.NewInt(10)},
+		{"head > ReplayFromBlock, initr fromBlock > ReplayFromBlock", 14, utils.NewBig(big.NewInt(12)), big.NewInt(15)},
+		{"head > ReplayFromBlock, initr fromBlock < ReplayFromBlock", 14, utils.NewBig(big.NewInt(8)), big.NewInt(15)},
 	}
 
 	for _, test := range cases {
@@ -356,7 +356,7 @@ func TestServices_NewInitiatorSubscription_RunLog_ReplayFromBlock(t *testing.T) 
 		wantFromBlock *big.Int
 	}{
 		{"head < ReplayFromBlock", 5, big.NewInt(10)},
-		{"head > ReplayFromBlock", 14, big.NewInt(10)},
+		{"head > ReplayFromBlock", 14, big.NewInt(15)},
 	}
 
 	for _, test := range cases {


### PR DESCRIPTION
This prevents a problem where after a node has already booted, if the eth node
disconnects/reconnects the node would replay again from the given -r argument.
This can lead to unexpected replaying of old jobs from long ago.