### PR TITLE
Add command to hard reset the database

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -373,8 +373,8 @@ func NewApp(client *Client) *cli.App {
 						},
 						{
 							Name:   "hard-reset",
-							Usage:  "Clean all the state in the production DB. Use with caution!",
-							Action: client.HardResetDatabase,
+							Usage:  "Removes unstarted transactions and attempts to cancel pending transactions. Use with caution, this command cannot be reverted! Only execute when the node is not started! You must have a funding address ready to use",
+							Action: client.HardReset,
 							Flags:  []cli.Flag{},
 						},
 						{

--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -366,9 +366,15 @@ func NewApp(client *Client) *cli.App {
 					Subcommands: []cli.Command{
 						{
 							Name:   "reset",
-							Usage:  "Drop, create and migrate database. Useful for setting up the database in order to run tests or resetting the dev database. WARNING: This will ERASE ALL DATA for the specified DATABASE_URL.",
+							Usage:  "Drop, create and migrate test database. Useful for setting up the database in order to run tests or resetting the dev database. WARNING: This will ERASE ALL DATA for the specified DATABASE_URL.",
 							Hidden: !client.Config.Dev(),
 							Action: client.ResetDatabase,
+							Flags:  []cli.Flag{},
+						},
+						{
+							Name:   "hard-reset",
+							Usage:  "Clean all the state in the production DB. Use with caution!",
+							Action: client.HardResetDatabase,
 							Flags:  []cli.Flag{},
 						},
 						{

--- a/core/store/key_store.go
+++ b/core/store/key_store.go
@@ -31,6 +31,7 @@ type KeyStoreInterface interface {
 	NewAccount(passphrase string) (accounts.Account, error)
 	SignHash(hash common.Hash) (models.Signature, error)
 	Import(keyJSON []byte, passphrase, newPassphrase string) (accounts.Account, error)
+	Export(a acounts.Account, passphrase, newPassphrase string) ([]byte, error)
 	GetAccounts() []accounts.Account
 	GetAccountByAddress(common.Address) (accounts.Account, error)
 

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -66,6 +66,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1598521075"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1598972982"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1599062163"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1600427749"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -327,6 +328,11 @@ func init() {
 		{
 			ID:      "1599062163",
 			Migrate: migration1599062163.Migrate,
+		},
+		{
+			ID:       "1600427749",
+			Migrate:  migration1600427749.Migrate,
+			Rollback: migration1600427749.Rollback,
 		},
 	}
 }

--- a/core/store/migrations/migration1600427749/migrate.go
+++ b/core/store/migrations/migration1600427749/migrate.go
@@ -1,0 +1,24 @@
+package migration1598972982
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+const up = `
+ALTER TABLE keys
+ADD FIELD is_rescue BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE UNIQUE INDEX only_one_rescue ON keys (is_rescue) WHERE is_rescue = TRUE;
+`
+
+const down = `
+DROP INDEX only_one_rescue;
+ALTER TABLE keys REMOVE FIELD is_rescue;
+`
+
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(up).Error
+}
+
+func Rollback(tx *gorm.DB) error {
+	return tx.Exec(down).Error
+}

--- a/core/store/models/key.go
+++ b/core/store/models/key.go
@@ -28,6 +28,9 @@ type Key struct {
 	NextNonce *int64
 	// LastUsed is the time that the address was last assigned to a transaction
 	LastUsed *time.Time
+	// IsFunding marks the address as being used for rescuing the  node and the pending transactions
+	// Only one key can be IsFunding=true at a time.
+	IsFunding bool
 }
 
 // NewKeyFromFile creates an instance in memory from a key file on disk.


### PR DESCRIPTION
## Why?

See https://www.pivotaltracker.com/n/projects/2441917

## How?
- The idea was to only remove job runs that are "unstarted". I added a more complex sequence query to achieve this as well as described how the deletes will cascade
- the simple `TRUNCATE run_request, job_runs, eth_txes, eth_tx_attempts CASCADE;` was deemed unnecessarely distructive. We can extend this to include all the pending states: pending bridge, pending incoming confirmations, pending connection, pending sleep, pending outgoing confirmations. Wdyt @se3000  
- Another idea was to update the latest nonce in the database. We ended up not needing this. CC @samsondav 
- Also from the ticket, afaictl, Flux Monitor will not get blocked after this truncation!
