### PR TITLE
Fix publish test images in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -635,44 +635,26 @@ workflows:
           filters:
             tags:
               only: /^v.*/
-            branches:
-              only:
-                - develop
       - build-publish-ts-integration:
           filters:
             tags:
               only: /^v.*/
-            branches:
-              only:
-                - develop
       - build-publish-cypress-job-server:
           filters:
             tags:
               only: /^v.*/
-            branches:
-              only:
-                - develop
       - build-publish-echo-server:
           filters:
             tags:
               only: /^v.*/
-            branches:
-              only:
-                - develop
       - build-publish-external-adapter:
           filters:
             tags:
               only: /^v.*/
-            branches:
-              only:
-                - develop
       - build-publish-ingester:
           filters:
             tags:
               only: /^v.*/
-            branches:
-              only:
-                - develop
       - reportcoverage:
           requires:
             - core-go-test


### PR DESCRIPTION
The Docker test images used for CI in the Explorer repository did not publish `latest` as expected. 

This PR sets the CircleCI job filters to be identical with `build-publish-chainlink`.