### PR TITLE
prevent ownership transfers to self

### DIFF
--- a/evm-contracts/src/v0.7/dev/Owned.sol
+++ b/evm-contracts/src/v0.7/dev/Owned.sol
@@ -30,6 +30,8 @@ contract Owned {
     external
     onlyOwner()
   {
+    require(_to != msg.sender, "Cannot transfer to self");
+
     pendingOwner = _to;
 
     emit OwnershipTransferRequested(owner, _to);

--- a/evm-contracts/test/v0.7/Owned.test.ts
+++ b/evm-contracts/test/v0.7/Owned.test.ts
@@ -84,6 +84,13 @@ describe('Owned', () => {
         expect(h.eventArgs(event).to).toEqual(newOwner.address)
         expect(h.eventArgs(event).from).toEqual(owner.address)
       })
+
+      it('does not allow ownership transfer to self', async () => {
+        await matchers.evmRevert(
+          owned.connect(owner).transferOwnership(owner.address),
+          'Cannot transfer to self',
+        )
+      })
     })
   })
 


### PR DESCRIPTION
This avoids emitting misleading log events.