### PR TITLE
Fix invalid string(int) casts

### DIFF
--- a/core/services/gas_updater.go
+++ b/core/services/gas_updater.go
@@ -113,7 +113,7 @@ func (gu *gasUpdater) OnNewLongestChain(ctx context.Context, head models.Head) {
 				logger.Error("GasUpdater error setting gas price: ", err)
 				return
 			}
-			promGasUpdaterSetGasPrice.WithLabelValues(fmt.Sprintf("%v%%", gu.percentile), string(blockToFetch)).Set(float64(percentileGasPrice))
+			promGasUpdaterSetGasPrice.WithLabelValues(fmt.Sprintf("%v%%", gu.percentile), fmt.Sprintf("%d", blockToFetch)).Set(float64(percentileGasPrice))
 		} else {
 			logger.Debugw(fmt.Sprintf("GasUpdater: waiting for blocks: %v/%v", len(gu.rollingBlockHistory), gu.rollingBlockHistorySize), "inHistory", len(gu.rollingBlockHistory), "required", gu.rollingBlockHistorySize)
 		}

--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -67,7 +67,7 @@ func (e EthTx) GetError() error {
 
 // GetID allows EthTx to be used as jsonapi.MarshalIdentifier
 func (e EthTx) GetID() string {
-	return string(e.ID)
+	return fmt.Sprintf("%d", e.ID)
 }
 
 type EthTxAttempt struct {

--- a/core/store/models/eth_test.go
+++ b/core/store/models/eth_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
+	"math"
 	"math/big"
 	"sort"
 	"strconv"
@@ -132,6 +133,11 @@ func TestHighestPricedTxAttemptPerTx(t *testing.T) {
 	assert.Len(t, items, 2)
 	assert.True(t, items[0].GasPrice.ToInt().Cmp(big.NewInt(33333)) == 0)
 	assert.True(t, items[1].GasPrice.ToInt().Cmp(big.NewInt(12211)) == 0)
+}
+
+func TestEthTx_GetID(t *testing.T) {
+	tx := models.EthTx{ID: math.MinInt64}
+	assert.Equal(t, "-9223372036854775808", tx.GetID())
 }
 
 func TestEthTxAttempt_GetSignedTx(t *testing.T) {

--- a/core/store/models/eth_test.go
+++ b/core/store/models/eth_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"sort"
+	"strconv"
 	"testing"
 	"time"
 
@@ -227,7 +228,7 @@ func TestSafeByteSlice_Success(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		t.Run(string(i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			actual, err := test.ary.SafeByteSlice(test.start, test.end)
 			assert.NoError(t, err)
 			assert.Equal(t, test.expected, actual)
@@ -249,7 +250,7 @@ func TestSafeByteSlice_Error(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		t.Run(string(i), func(t *testing.T) {
+		t.Run(strconv.Itoa(i), func(t *testing.T) {
 			actual, err := test.ary.SafeByteSlice(test.start, test.end)
 			assert.EqualError(t, err, "out of bounds slice access")
 			var expected []byte


### PR DESCRIPTION
string(int64) produces a rune, not a string repr of an int

before: math.MaxInt64 prints: `"�"`
now: math.MaxInt64 prints: `"-9223372036854775808"`