### PR TITLE
Do balance checking in SleeperTask

### DIFF
--- a/CHANGELOG-core.md
+++ b/CHANGELOG-core.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   This migration will allow future version of chainlink to automatically clean up unneeded log_consumption records.
   This migration should execute very fast.
 - External Adapters for the Flux Monitor will now receive the Flux Monitor round state info as the meta payload.
+- Reduce frequency of balance checking.
 
 ### Fixed
 

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -912,7 +912,7 @@ func TestIntegration_FluxMonitor_Deviation(t *testing.T) {
 	sub.On("Unsubscribe").Return(nil).Maybe()
 	gethClient.On("ChainID", mock.Anything).Return(app.Store.Config.ChainID(), nil)
 	gethClient.On("PendingNonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(256), nil)
-	gethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(oneETH.ToInt(), nil)
+	gethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(oneETH.ToInt(), nil)
 	chchNewHeads := make(chan chan<- *models.Head, 1)
 	rpcClient.On("EthSubscribe", mock.Anything, mock.Anything, "newHeads").
 		Run(func(args mock.Arguments) { chchNewHeads <- args.Get(1).(chan<- *models.Head) }).
@@ -1019,7 +1019,7 @@ func TestIntegration_FluxMonitor_NewRound(t *testing.T) {
 	sub.On("Unsubscribe").Return(nil).Maybe()
 	gethClient.On("ChainID", mock.Anything).Return(app.Store.Config.ChainID(), nil)
 	gethClient.On("PendingNonceAt", mock.Anything, mock.Anything, mock.Anything).Return(uint64(256), nil)
-	gethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(oneETH.ToInt(), nil)
+	gethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(oneETH.ToInt(), nil)
 	chchNewHeads := make(chan chan<- *models.Head, 1)
 	rpcClient.On("EthSubscribe", mock.Anything, mock.Anything, "newHeads").
 		Run(func(args mock.Arguments) { chchNewHeads <- args.Get(1).(chan<- *models.Head) }).

--- a/core/services/balance_monitor.go
+++ b/core/services/balance_monitor.go
@@ -18,7 +18,7 @@ import (
 type BalanceMonitor interface {
 	store.HeadTrackable
 	GetEthBalance(gethCommon.Address) *assets.Eth
-	Stop()
+	Stop() error
 }
 
 type balanceMonitor struct {
@@ -47,8 +47,8 @@ func (bm *balanceMonitor) Connect(_ *models.Head) error {
 }
 
 // Stop shuts down the BalanceMonitor, should not be used after this
-func (bm *balanceMonitor) Stop() {
-	bm.sleeperTask.Stop()
+func (bm *balanceMonitor) Stop() error {
+	return bm.sleeperTask.Stop()
 }
 
 // Disconnect complies with HeadTrackable

--- a/core/services/balance_monitor.go
+++ b/core/services/balance_monitor.go
@@ -33,7 +33,7 @@ func NewBalanceMonitor(store *store.Store) BalanceMonitor {
 		store:          store,
 		ethBalances:    make(map[gethCommon.Address]*assets.Eth),
 		ethBalancesMtx: new(sync.RWMutex),
-		headQueue:      make(chan *models.Head, 1),
+		headQueue:      make(chan *models.Head),
 	}
 	go balanceWorker(bm)
 	return bm

--- a/core/services/balance_monitor.go
+++ b/core/services/balance_monitor.go
@@ -117,10 +117,11 @@ func (w *worker) Work() {
 	wg.Wait()
 }
 
-const ethFetchTimeout = 2 * time.Second
+// Approximately ETH block time
+const ethFetchTimeout = 15 * time.Second
 
 func (w *worker) checkAccountBalance(k models.Key) {
-	ctx, cancel := context.WithTimeout(context.TODO(), ethFetchTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), ethFetchTimeout)
 	defer cancel()
 
 	bal, err := w.bm.store.EthClient.BalanceAt(ctx, k.Address.Address(), nil)

--- a/core/services/balance_monitor_test.go
+++ b/core/services/balance_monitor_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/onsi/gomega"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
 	"github.com/smartcontractkit/chainlink/core/services"
@@ -18,9 +19,9 @@ import (
 	"github.com/pkg/errors"
 )
 
-func TestBalanceMonitor_Connect(t *testing.T) {
-	var nilBigInt *big.Int
+var nilBigInt *big.Int
 
+func TestBalanceMonitor_Connect(t *testing.T) {
 	t.Run("updates balance from nil for multiple keys", func(t *testing.T) {
 		store, cleanup := cltest.NewStore(t)
 		defer cleanup()
@@ -36,13 +37,14 @@ func TestBalanceMonitor_Connect(t *testing.T) {
 		k1Addr := k1.Address.Address()
 
 		bm := services.NewBalanceMonitor(store)
+		defer bm.Stop()
+
 		k0bal := big.NewInt(42)
 		k1bal := big.NewInt(43)
 		assert.Nil(t, bm.GetEthBalance(k0Addr))
 		assert.Nil(t, bm.GetEthBalance(k1Addr))
 
 		gethClient.On("BalanceAt", mock.Anything, k0Addr, nilBigInt).Once().Return(k0bal, nil)
-
 		gethClient.On("BalanceAt", mock.Anything, k1Addr, nilBigInt).Once().Return(k1bal, nil)
 
 		head := cltest.Head(0)
@@ -50,8 +52,12 @@ func TestBalanceMonitor_Connect(t *testing.T) {
 		// Do the thing
 		bm.Connect(head)
 
-		assert.Equal(t, k0bal, bm.GetEthBalance(k0Addr).ToInt())
-		assert.Equal(t, k1bal, bm.GetEthBalance(k1Addr).ToInt())
+		gomega.NewGomegaWithT(t).Eventually(func() *big.Int {
+			return bm.GetEthBalance(k0Addr).ToInt()
+		}).Should(gomega.Equal(k0bal))
+		gomega.NewGomegaWithT(t).Eventually(func() *big.Int {
+			return bm.GetEthBalance(k1Addr).ToInt()
+		}).Should(gomega.Equal(k1bal))
 
 		gethClient.AssertExpectations(t)
 	})
@@ -69,6 +75,7 @@ func TestBalanceMonitor_Connect(t *testing.T) {
 		k0Addr := k0.Address.Address()
 
 		bm := services.NewBalanceMonitor(store)
+		defer bm.Stop()
 		k0bal := big.NewInt(42)
 
 		gethClient.On("BalanceAt", mock.Anything, k0Addr, nilBigInt).Once().Return(k0bal, nil)
@@ -76,7 +83,9 @@ func TestBalanceMonitor_Connect(t *testing.T) {
 		// Do the thing
 		bm.Connect(nil)
 
-		assert.Equal(t, k0bal, bm.GetEthBalance(k0Addr).ToInt())
+		gomega.NewGomegaWithT(t).Eventually(func() *big.Int {
+			return bm.GetEthBalance(k0Addr).ToInt()
+		}).Should(gomega.Equal(k0bal))
 
 		gethClient.AssertExpectations(t)
 	})
@@ -94,13 +103,16 @@ func TestBalanceMonitor_Connect(t *testing.T) {
 		k0Addr := k0.Address.Address()
 
 		bm := services.NewBalanceMonitor(store)
+		defer bm.Stop()
 
 		gethClient.On("BalanceAt", mock.Anything, k0Addr, nilBigInt).Once().Return(nil, errors.New("a little easter egg for the 4chan link marines error"))
 
 		// Do the thing
 		bm.Connect(nil)
 
-		assert.Nil(t, bm.GetEthBalance(k0Addr))
+		gomega.NewGomegaWithT(t).Consistently(func() *big.Int {
+			return bm.GetEthBalance(k0Addr).ToInt()
+		}).Should(gomega.BeNil())
 
 		gethClient.AssertExpectations(t)
 	})
@@ -123,6 +135,7 @@ func TestBalanceMonitor_OnNewLongestChain_UpdatesBalance(t *testing.T) {
 		k1Addr := k1.Address.Address()
 
 		bm := services.NewBalanceMonitor(store)
+		defer bm.Stop()
 		k0bal := big.NewInt(42)
 		// Deliberately larger than a 64 bit unsigned integer to test overflow
 		k1bal := big.NewInt(0)
@@ -130,14 +143,18 @@ func TestBalanceMonitor_OnNewLongestChain_UpdatesBalance(t *testing.T) {
 
 		head := cltest.Head(0)
 
-		gethClient.On("BalanceAt", mock.Anything, k0Addr, big.NewInt(head.Number)).Once().Return(k0bal, nil)
-		gethClient.On("BalanceAt", mock.Anything, k1Addr, big.NewInt(head.Number)).Once().Return(k1bal, nil)
+		gethClient.On("BalanceAt", mock.Anything, k0Addr, nilBigInt).Once().Return(k0bal, nil)
+		gethClient.On("BalanceAt", mock.Anything, k1Addr, nilBigInt).Once().Return(k1bal, nil)
 
 		// Do the thing
 		bm.OnNewLongestChain(context.TODO(), *head)
 
-		assert.Equal(t, k0bal, bm.GetEthBalance(k0Addr).ToInt())
-		assert.Equal(t, k1bal, bm.GetEthBalance(k1Addr).ToInt())
+		gomega.NewGomegaWithT(t).Eventually(func() *big.Int {
+			return bm.GetEthBalance(k0Addr).ToInt()
+		}).Should(gomega.Equal(k0bal))
+		gomega.NewGomegaWithT(t).Eventually(func() *big.Int {
+			return bm.GetEthBalance(k1Addr).ToInt()
+		}).Should(gomega.Equal(k1bal))
 
 		// Do it again
 		k0bal2 := big.NewInt(142)
@@ -145,53 +162,17 @@ func TestBalanceMonitor_OnNewLongestChain_UpdatesBalance(t *testing.T) {
 
 		head = cltest.Head(1)
 
-		gethClient.On("BalanceAt", mock.Anything, k0Addr, big.NewInt(head.Number)).Once().Return(k0bal2, nil)
-		gethClient.On("BalanceAt", mock.Anything, k1Addr, big.NewInt(head.Number)).Once().Return(k1bal2, nil)
+		gethClient.On("BalanceAt", mock.Anything, k0Addr, nilBigInt).Once().Return(k0bal2, nil)
+		gethClient.On("BalanceAt", mock.Anything, k1Addr, nilBigInt).Once().Return(k1bal2, nil)
 
 		bm.OnNewLongestChain(context.TODO(), *head)
 
-		assert.Equal(t, k0bal2, bm.GetEthBalance(k0Addr).ToInt())
-		assert.Equal(t, k1bal2, bm.GetEthBalance(k1Addr).ToInt())
-
-		gethClient.AssertExpectations(t)
-	})
-
-	t.Run("lags behind by ETH_BALANCE_MONITOR_BLOCK_DELAY blocks", func(t *testing.T) {
-		store, cleanup := cltest.NewStore(t)
-		defer cleanup()
-		store.Config.Set("ETH_BALANCE_MONITOR_BLOCK_DELAY", 2)
-		k0 := cltest.MustDefaultKey(t, store)
-		k0Addr := k0.Address.Address()
-
-		gethClient := new(mocks.GethClient)
-		store.EthClient = eth.NewClientWith(nil, gethClient)
-		bm := services.NewBalanceMonitor(store)
-
-		// If lagged head would be negative, just uses 0
-		k0bal := big.NewInt(42)
-		gethClient.On("BalanceAt", mock.Anything, k0Addr, big.NewInt(0)).Once().Return(k0bal, nil)
-		head := cltest.Head(0)
-		bm.OnNewLongestChain(context.TODO(), *head)
-
-		assert.Equal(t, k0bal, bm.GetEthBalance(k0Addr).ToInt())
-
-		// If lagged head would be negative, just uses 0
-		k0bal = big.NewInt(43)
-		gethClient.On("BalanceAt", mock.Anything, k0Addr, big.NewInt(0)).Once().Return(k0bal, nil)
-		head = cltest.Head(1)
-		bm.OnNewLongestChain(context.TODO(), *head)
-
-		// If lagged head is exactly 0, uses 0
-		k0bal = big.NewInt(44)
-		gethClient.On("BalanceAt", mock.Anything, k0Addr, big.NewInt(0)).Once().Return(k0bal, nil)
-		head = cltest.Head(2)
-		bm.OnNewLongestChain(context.TODO(), *head)
-
-		// If lagged head is positive, uses it
-		k0bal = big.NewInt(44)
-		gethClient.On("BalanceAt", mock.Anything, k0Addr, big.NewInt(1)).Once().Return(k0bal, nil)
-		head = cltest.Head(3)
-		bm.OnNewLongestChain(context.TODO(), *head)
+		gomega.NewGomegaWithT(t).Eventually(func() *big.Int {
+			return bm.GetEthBalance(k0Addr).ToInt()
+		}).Should(gomega.Equal(k0bal2))
+		gomega.NewGomegaWithT(t).Eventually(func() *big.Int {
+			return bm.GetEthBalance(k1Addr).ToInt()
+		}).Should(gomega.Equal(k1bal2))
 
 		gethClient.AssertExpectations(t)
 	})
@@ -212,10 +193,10 @@ func TestBalanceMonitor_FewerRPCCallsWhenBehind(t *testing.T) {
 	head := cltest.Head(0)
 	mockUnblocker := make(chan time.Time)
 
-	// Only expect this once, even though 10 heads will come in
+	// Only expect this twice, even though 10 heads will come in
 	gethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).
 		WaitUntil(mockUnblocker).
-		Once().
+		Twice().
 		Return(big.NewInt(42), nil)
 
 	// Do the thing multiple times
@@ -225,7 +206,8 @@ func TestBalanceMonitor_FewerRPCCallsWhenBehind(t *testing.T) {
 
 	// Unblock the mock
 	mockUnblocker <- time.Time{}
+	mockUnblocker <- time.Time{}
 
-	bm.Disconnect()
+	bm.Stop()
 	gethClient.AssertExpectations(t)
 }

--- a/core/services/balance_monitor_test.go
+++ b/core/services/balance_monitor_test.go
@@ -212,10 +212,10 @@ func TestBalanceMonitor_FewerRPCCallsWhenBehind(t *testing.T) {
 	head := cltest.Head(0)
 	mockUnblocker := make(chan time.Time)
 
-	// Only expect this twice, even though 10 heads will come in
+	// Only expect this once, even though 10 heads will come in
 	gethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).
 		WaitUntil(mockUnblocker).
-		Twice().
+		Once().
 		Return(big.NewInt(42), nil)
 
 	// Do the thing multiple times
@@ -224,7 +224,6 @@ func TestBalanceMonitor_FewerRPCCallsWhenBehind(t *testing.T) {
 	}
 
 	// Unblock the mock
-	mockUnblocker <- time.Time{}
 	mockUnblocker <- time.Time{}
 
 	bm.Disconnect()

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -117,6 +117,7 @@ func NewApplication(config *orm.Config, onConnectCallbacks ...func(Application))
 		Exiter:                   os.Exit,
 		pendingConnectionResumer: pendingConnectionResumer,
 		shutdownSignal:           shutdownSignal,
+		balanceMonitor:           balanceMonitor,
 	}
 
 	headTrackables := []strpkg.HeadTrackable{gasUpdater}

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -72,6 +72,7 @@ type ChainlinkApplication struct {
 	pendingConnectionResumer *pendingConnectionResumer
 	shutdownOnce             sync.Once
 	shutdownSignal           gracefulpanic.Signal
+	balanceMonitor           services.BalanceMonitor
 }
 
 // NewApplication initializes a new store if one is not already
@@ -212,6 +213,7 @@ func (app *ChainlinkApplication) Stop() error {
 
 		app.Scheduler.Stop()
 		merr = multierr.Append(merr, app.HeadTracker.Stop())
+		app.balanceMonitor.Stop()
 		merr = multierr.Append(merr, app.JobSubscriber.Stop())
 		app.FluxMonitor.Stop()
 		merr = multierr.Append(merr, app.EthBroadcaster.Stop())

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -214,7 +214,7 @@ func (app *ChainlinkApplication) Stop() error {
 
 		app.Scheduler.Stop()
 		merr = multierr.Append(merr, app.HeadTracker.Stop())
-		app.balanceMonitor.Stop()
+		merr = multierr.Append(merr, app.balanceMonitor.Stop())
 		merr = multierr.Append(merr, app.JobSubscriber.Stop())
 		app.FluxMonitor.Stop()
 		merr = multierr.Append(merr, app.EthBroadcaster.Stop())


### PR DESCRIPTION
Make a best effort attempt to get the latest balance, rather than trying to get every single head's balance.

Use a SleeperTask, adds Stop to BalanceMonitor.