### PR TITLE
Put roundState in meta data when making EA requests from FM

### DIFF
--- a/CHANGELOG-core.md
+++ b/CHANGELOG-core.md
@@ -11,11 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Chainlink header images to the following `README.md` files: root, core, 
+- Chainlink header images to the following `README.md` files: root, core,
   evm-contracts, and evm-test-helpers.
 - Database migrations: new log_consumptions records will contain the number of the associated block.
   This migration will allow future version of chainlink to automatically clean up unneeded log_consumption records.
   This migration should execute very fast.
+- External Adapters for the Flux Monitor will now receive the Flux Monitor round state info as the meta payload.
 
 ### Fixed
 

--- a/core/internal/mocks/fetcher.go
+++ b/core/internal/mocks/fetcher.go
@@ -13,20 +13,20 @@ type Fetcher struct {
 	mock.Mock
 }
 
-// Fetch provides a mock function with given fields:
-func (_m *Fetcher) Fetch() (decimal.Decimal, error) {
-	ret := _m.Called()
+// Fetch provides a mock function with given fields: _a0
+func (_m *Fetcher) Fetch(_a0 map[string]interface{}) (decimal.Decimal, error) {
+	ret := _m.Called(_a0)
 
 	var r0 decimal.Decimal
-	if rf, ok := ret.Get(0).(func() decimal.Decimal); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(map[string]interface{}) decimal.Decimal); ok {
+		r0 = rf(_a0)
 	} else {
 		r0 = ret.Get(0).(decimal.Decimal)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(map[string]interface{}) error); ok {
+		r1 = rf(_a0)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/eth/contracts/FluxAggregator.go
+++ b/core/services/eth/contracts/FluxAggregator.go
@@ -73,14 +73,14 @@ func (fa *fluxAggregator) SubscribeToLogs(listener eth.LogListener) (connected b
 }
 
 type FluxAggregatorRoundState struct {
-	ReportableRoundID uint32   `abi:"_roundId"`
-	EligibleToSubmit  bool     `abi:"_eligibleToSubmit"`
-	LatestAnswer      *big.Int `abi:"_latestSubmission"`
-	Timeout           uint64   `abi:"_timeout"`
-	StartedAt         uint64   `abi:"_startedAt"`
-	AvailableFunds    *big.Int `abi:"_availableFunds"`
-	PaymentAmount     *big.Int `abi:"_paymentAmount"`
-	OracleCount       uint8    `abi:"_oracleCount"`
+	ReportableRoundID uint32   `abi:"_roundId" json:"reportableRoundID"`
+	EligibleToSubmit  bool     `abi:"_eligibleToSubmit" json:"eligibleToSubmit"`
+	LatestAnswer      *big.Int `abi:"_latestSubmission" json:"latestAnswer,omitempty"`
+	Timeout           uint64   `abi:"_timeout" json:"timeout"`
+	StartedAt         uint64   `abi:"_startedAt" json:"startedAt"`
+	AvailableFunds    *big.Int `abi:"_availableFunds" json:"availableFunds,omitempty"`
+	PaymentAmount     *big.Int `abi:"_paymentAmount" json:"paymentAmount,omitempty"`
+	OracleCount       uint8    `abi:"_oracleCount" json:"oracleCount"`
 }
 
 func (rs FluxAggregatorRoundState) TimesOutAt() uint64 {

--- a/core/services/fluxmonitor/fetchers.go
+++ b/core/services/fluxmonitor/fetchers.go
@@ -1,6 +1,7 @@
 package fluxmonitor
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -23,19 +24,19 @@ import (
 // Fetcher is the interface encapsulating all functionality needed to retrieve
 // a price.
 type Fetcher interface {
-	Fetch() (decimal.Decimal, error)
+	Fetch(map[string]interface{}) (decimal.Decimal, error)
 }
 
 // httpFetcher retrieves data via HTTP from an external price adapter source.
 type httpFetcher struct {
 	client      *http.Client
 	url         *url.URL
-	requestData string
+	requestData map[string]interface{}
 }
 
 func newHTTPFetcher(
 	timeout models.Duration,
-	requestData string,
+	requestData map[string]interface{},
 	url *url.URL,
 ) Fetcher {
 	client := &http.Client{Timeout: timeout.Duration(), Transport: http.DefaultTransport}
@@ -49,12 +50,14 @@ func newHTTPFetcher(
 	}
 }
 
-func (p *httpFetcher) Fetch() (decimal.Decimal, error) {
-	request, err := withRandomID(p.requestData)
+func (p *httpFetcher) Fetch(meta map[string]interface{}) (decimal.Decimal, error) {
+	request := withIDAndMeta(p.requestData, meta)
+	body, err := json.Marshal(request)
 	if err != nil {
-		return decimal.Decimal{}, errors.Wrap(err, fmt.Sprintf("unable to fetch price from %s, cannot add request ID", p.url.String()))
+		return decimal.Decimal{}, errors.Wrap(err, "error encoding request body as JSON")
 	}
-	r, err := p.client.Post(p.url.String(), "application/json", strings.NewReader(request))
+
+	r, err := p.client.Post(p.url.String(), "application/json", bytes.NewReader(body))
 	if err != nil {
 		return decimal.Decimal{}, errors.Wrap(err, fmt.Sprintf("unable to fetch price from %s with payload '%s'", p.url.String(), p.requestData))
 	}
@@ -90,16 +93,14 @@ func (p *httpFetcher) String() string {
 	return fmt.Sprintf("http price fetcher: %s", p.url.String())
 }
 
-// withRandomID add an arbitrary "id" field to the request json
-// this is done in order to keep request payloads consistent in format
-// between flux monitor polling requests and http/bridge adapters
-func withRandomID(rawReqData string) (string, error) {
-	rawReqData = strings.TrimSpace(rawReqData)
-	valid := json.Valid([]byte(rawReqData))
-	if !valid {
-		return "", errors.New(fmt.Sprintf("invalid raw request json: %s", rawReqData))
+func withIDAndMeta(request, meta map[string]interface{}) map[string]interface{} {
+	output := make(map[string]interface{})
+	for k, v := range request {
+		output[k] = v
 	}
-	return fmt.Sprintf(`{"id":"%s",%s`, models.NewID(), rawReqData[1:]), nil
+	output["id"] = models.NewID()
+	output["meta"] = meta
+	return output
 }
 
 type adapterResponseData struct {
@@ -127,7 +128,7 @@ type medianFetcher struct {
 // from all passed URLs using httpFetcher, and returns the median.
 func newMedianFetcherFromURLs(
 	timeout models.Duration,
-	requestData string,
+	requestData map[string]interface{},
 	priceURLs []*url.URL,
 ) (Fetcher, error) {
 	fetchers := []Fetcher{}
@@ -153,7 +154,7 @@ func newMedianFetcher(fetchers ...Fetcher) (Fetcher, error) {
 	}, nil
 }
 
-func (m *medianFetcher) Fetch() (decimal.Decimal, error) {
+func (m *medianFetcher) Fetch(meta map[string]interface{}) (decimal.Decimal, error) {
 	prices := []decimal.Decimal{}
 	fetchErrors := []error{}
 
@@ -166,7 +167,7 @@ func (m *medianFetcher) Fetch() (decimal.Decimal, error) {
 	for _, fetcher := range m.fetchers {
 		fetcher := fetcher
 		go func() {
-			price, err := fetcher.Fetch()
+			price, err := fetcher.Fetch(meta)
 			if err != nil {
 				logger.Error(err)
 				chResults <- result{err: err}

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -281,7 +281,7 @@ func TestPollingDeviationChecker_PollIfEligible(t *testing.T) {
 				fluxAggregator.On("RoundState", nodeAddr, uint32(0)).Return(roundState, nil).Maybe()
 
 				if test.expectedToPoll {
-					fetcher.On("Fetch", roundState).Return(decimal.NewFromInt(test.polledAnswer), nil)
+					fetcher.On("Fetch", mock.Anything).Return(decimal.NewFromInt(test.polledAnswer), nil)
 				}
 
 				if test.expectedToSubmit {
@@ -432,7 +432,7 @@ func TestPollingDeviationChecker_BuffersLogs(t *testing.T) {
 	fluxAggregator.On("RoundState", nodeAddr, uint32(4)).Return(makeRoundStateForRoundID(4), nil).Once()
 
 	fetcher := new(mocks.Fetcher)
-	fetcher.On("Fetch").Return(decimal.NewFromInt(fetchedValue), nil)
+	fetcher.On("Fetch", mock.Anything).Return(decimal.NewFromInt(fetchedValue), nil)
 
 	rm := new(mocks.RunManager)
 	run := cltest.NewJobRun(job)
@@ -841,7 +841,7 @@ func TestPollingDeviationChecker_RespondToNewRound(t *testing.T) {
 			}
 
 			if expectedToPoll {
-				fetcher.On("Fetch").Return(decimal.NewFromInt(test.polledAnswer), nil).Once()
+				fetcher.On("Fetch", mock.Anything).Return(decimal.NewFromInt(test.polledAnswer), nil).Once()
 			}
 
 			if expectedToSubmit {
@@ -1352,7 +1352,7 @@ func TestPollingDeviationChecker_DoesNotDoubleSubmit(t *testing.T) {
 				OracleCount:       1,
 			}, nil).
 			Once()
-		fetcher.On("Fetch").
+		fetcher.On("Fetch", mock.Anything).
 			Return(decimal.NewFromInt(answer), nil).
 			Once()
 		fluxAggregator.On("GetMethodID", "submit").
@@ -1433,7 +1433,7 @@ func TestPollingDeviationChecker_DoesNotDoubleSubmit(t *testing.T) {
 				OracleCount:       1,
 			}, nil).
 			Once()
-		fetcher.On("Fetch").
+		fetcher.On("Fetch", mock.Anything).
 			Return(decimal.NewFromInt(answer), nil).
 			Once()
 		fluxAggregator.On("GetMethodID", "submit").

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -1433,7 +1433,8 @@ func TestPollingDeviationChecker_DoesNotDoubleSubmit(t *testing.T) {
 				OracleCount:       1,
 			}, nil).
 			Once()
-		fetcher.On("Fetch", mock.Anything).
+		meta := utils.MustUnmarshalToMap(`{"availableFunds":100000, "eligibleToSubmit":true, "latestAnswer":100, "oracleCount":1, "paymentAmount":100, "reportableRoundID":3, "startedAt":0, "timeout":0}`)
+		fetcher.On("Fetch", meta).
 			Return(decimal.NewFromInt(answer), nil).
 			Once()
 		fluxAggregator.On("GetMethodID", "submit").

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -281,7 +281,7 @@ func TestPollingDeviationChecker_PollIfEligible(t *testing.T) {
 				fluxAggregator.On("RoundState", nodeAddr, uint32(0)).Return(roundState, nil).Maybe()
 
 				if test.expectedToPoll {
-					fetcher.On("Fetch").Return(decimal.NewFromInt(test.polledAnswer), nil)
+					fetcher.On("Fetch", roundState).Return(decimal.NewFromInt(test.polledAnswer), nil)
 				}
 
 				if test.expectedToSubmit {

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -269,6 +269,22 @@ func (j JSON) CBOR() ([]byte, error) {
 	}
 }
 
+// MarshalToMap converts a struct (typically) to a map[string] so it can be
+// manipulated without repeatedly serializing/deserializing
+func MarshalToMap(input interface{}) (map[string]interface{}, error) {
+	bytes, err := json.Marshal(input)
+	if err != nil {
+		return nil, err
+	}
+	var output map[string]interface{}
+	err = json.Unmarshal(bytes, &output)
+	if err != nil {
+		// Technically this should be impossible
+		return nil, err
+	}
+	return output, nil
+}
+
 // WebURL contains the URL of the endpoint.
 type WebURL url.URL
 

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -348,6 +348,22 @@ func CoerceInterfaceMapToStringMap(in interface{}) (interface{}, error) {
 	}
 }
 
+// UnmarshalToMap takes an input json string and returns a map[string]interface i.e. a raw object
+func UnmarshalToMap(input string) (map[string]interface{}, error) {
+	var output map[string]interface{}
+	err := json.Unmarshal([]byte(input), &output)
+	return output, err
+}
+
+// MustUnmarshalToMap performs UnmarshalToMap, panics upon failure
+func MustUnmarshalToMap(input string) map[string]interface{} {
+	output, err := UnmarshalToMap(input)
+	if err != nil {
+		panic(err)
+	}
+	return output
+}
+
 // HashPassword wraps around bcrypt.GenerateFromPassword for a friendlier API.
 func HashPassword(password string) (string, error) {
 	bytes, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)

--- a/go.sum
+++ b/go.sum
@@ -545,6 +545,7 @@ github.com/multiformats/go-multiaddr-fmt v0.1.0 h1:WLEFClPycPkp4fnIzoFoV9FVd49/e
 github.com/multiformats/go-multiaddr-fmt v0.1.0/go.mod h1:hGtDIW4PU4BqJ50gW2quDuPVjyWNZxToGUh/HwTZYJo=
 github.com/multiformats/go-multiaddr-net v0.1.4 h1:g6gwydsfADqFvrHoMkS0n9Ok9CG6F7ytOH/bJDkhIOY=
 github.com/multiformats/go-multiaddr-net v0.1.4/go.mod h1:ilNnaM9HbmVFqsb/qcNysjCu4PVONlrBZpHIrw/qQuA=
+github.com/multiformats/go-multiaddr-net v0.2.0 h1:MSXRGN0mFymt6B1yo/6BPnIRpLPEnKgQNvVfCX5VDJk=
 github.com/multiformats/go-multiaddr-net v0.2.0/go.mod h1:gGdH3UXny6U3cKKYCvpXI5rnK7YaOIEOPVDI9tsJbEA=
 github.com/multiformats/go-multibase v0.0.1 h1:PN9/v21eLywrFWdFNsFKaU04kLJzuYzmrJR+ubhT9qA=
 github.com/multiformats/go-multibase v0.0.1/go.mod h1:bja2MqRZ3ggyXtZSEDKpl0uO/gviWFaSteVbWT51qgs=


### PR DESCRIPTION
When the FluxMonitor posts to External Adapters, it will now include the RoundState as the "meta" field in the request, serialized to a JSON object with lower camelcase keys.