### PR TITLE
Feature/#174417426 Add funding addr

### DIFF
--- a/CHANGELOG-core.md
+++ b/CHANGELOG-core.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add new env variable ETH_SECONDARY_URL. Default is unset. You may optionally set this to an http(s) ethereum RPC client URL. If set, transactions will also be broadcast to this secondary ethereum node. This allows transaction broadcasting to be more robust in the face of primary ethereum node bugs or failures.
 - Remove configuration option ORACLE_CONTRACT_ADDRESS, it had no effect
 - Add configuration option OPERATOR_CONTRACT_ADDRESS, it filters the contract addresses the node should listen to for Run Logs
+- At startup, the chainlink node will create a new funding address. This will initially be used to pay for cancelling stuck transactions.
 
 ### Fixed
 
@@ -160,7 +161,7 @@ This release contains a number of features aimed at improving the node's reliabi
 
 ### Env var changes
 
-- `ENABLE_BULLETPROOF_TX_MANAGER` - set this to true to enable the experimental new transaction manager 
+- `ENABLE_BULLETPROOF_TX_MANAGER` - set this to true to enable the experimental new transaction manager
 - `ETH_GAS_BUMP_PERCENT` default value has been increased from 10% to 20%
 - `ETH_GAS_BUMP_THRESHOLD` default value has been decreased from 12 to 3
 - `ETH_FINALITY_DEPTH` specifies how deep protection should be against re-orgs. The default is 50. It only applies if BulletproofTxManager is enabled. It is not recommended to change this setting.

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -303,7 +303,7 @@ func TestClient_ImportKey(t *testing.T) {
 	// importing again simply upserts
 	require.NoError(t, client.ImportKey(c))
 
-	keys, err := app.GetStore().Keys()
+	keys, err := app.GetStore().SendKeys()
 	require.NoError(t, err)
 
 	require.Len(t, keys, 2)

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -36,6 +36,11 @@ func TestClient_RunNodeShowsEnv(t *testing.T) {
 	store.Config.Set("LINK_CONTRACT_ADDRESS", "0x514910771AF9Ca656af840dff83E8264EcF986CA")
 	store.Config.Set("CHAINLINK_PORT", 6688)
 
+	ethClient := new(mocks.Client)
+	ethClient.On("Dial", mock.Anything).Return(nil)
+	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(10), nil)
+	store.EthClient = ethClient
+
 	app := new(mocks.Application)
 	app.On("GetStore").Return(store)
 	app.On("Start").Return(nil)
@@ -122,6 +127,11 @@ func TestClient_RunNodeWithPasswords(t *testing.T) {
 			app.On("Start").Maybe().Return(nil)
 			app.On("Stop").Maybe().Return(nil)
 
+			ethClient := new(mocks.Client)
+			ethClient.On("Dial", mock.Anything).Return(nil)
+			ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(10), nil)
+			store.EthClient = ethClient
+
 			_, err = store.KeyStore.NewAccount("password") // matches correct_password.txt
 			require.NoError(t, err)
 
@@ -189,6 +199,11 @@ func TestClient_RunNodeWithAPICredentialsFile(t *testing.T) {
 			app.On("GetStore").Return(store)
 			app.On("Start").Maybe().Return(nil)
 			app.On("Stop").Maybe().Return(nil)
+
+			ethClient := new(mocks.Client)
+			ethClient.On("Dial", mock.Anything).Return(nil)
+			ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(10), nil)
+			store.EthClient = ethClient
 
 			callback := func(*strpkg.Store, string) (string, error) { return "", nil }
 			noauth := cltest.CallbackAuthenticator{Callback: callback}

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -169,6 +169,56 @@ func TestClient_RunNodeWithPasswords(t *testing.T) {
 	}
 }
 
+func TestClient_RunNode_CreateFundingKeyIfNotExists(t *testing.T) {
+	t.Parallel()
+
+	store, cleanup := cltest.NewStore(t)
+	// Clear out fixture
+	defer cleanup()
+	_, err := store.KeyStore.NewAccount(cltest.Password)
+	require.NoError(t, err)
+	require.NoError(t, store.KeyStore.Unlock(cltest.Password))
+
+	app := new(mocks.Application)
+	app.On("GetStore").Return(store)
+	app.On("Start").Maybe().Return(nil)
+	app.On("Stop").Maybe().Return(nil)
+
+	ethClient := new(mocks.Client)
+	ethClient.On("Dial", mock.Anything).Return(nil)
+	store.EthClient = ethClient
+
+	_, err = store.KeyStore.NewAccount("password") // matches correct_password.txt
+	require.NoError(t, err)
+
+	callback := func(store *strpkg.Store, phrase string) (string, error) {
+		unlockErr := store.KeyStore.Unlock(phrase)
+		return phrase, unlockErr
+	}
+	auth := cltest.CallbackAuthenticator{Callback: callback}
+	apiPrompt := &cltest.MockAPIInitializer{}
+	client := cmd.Client{
+		Config:                 store.Config,
+		AppFactory:             cltest.InstanceAppFactory{App: app},
+		KeyStoreAuthenticator:  auth,
+		FallbackAPIInitializer: apiPrompt,
+		Runner:                 cltest.EmptyRunner{},
+	}
+
+	var fundingKey = models.Key{}
+	_ = store.DB.Where("is_funding = TRUE").First(&fundingKey).Error
+	assert.Empty(t, fundingKey.ID, "expected no funding key")
+
+	set := flag.NewFlagSet("test", 0)
+	set.String("password", "../internal/fixtures/correct_password.txt", "")
+	ctx := cli.NewContext(nil, set, nil)
+
+	assert.NoError(t, client.RunNode(ctx))
+
+	assert.NoError(t, store.DB.Where("is_funding = TRUE").First(&fundingKey).Error)
+	assert.NotEmpty(t, fundingKey.ID, "expected a new funding key")
+}
+
 func TestClient_RunNodeWithAPICredentialsFile(t *testing.T) {
 	t.Parallel()
 

--- a/core/internal/mocks/key_store_interface.go
+++ b/core/internal/mocks/key_store_interface.go
@@ -37,6 +37,29 @@ func (_m *KeyStoreInterface) Accounts() []accounts.Account {
 	return r0
 }
 
+// Export provides a mock function with given fields: a, passphrase, newPassphrase
+func (_m *KeyStoreInterface) Export(a accounts.Account, passphrase string, newPassphrase string) ([]byte, error) {
+	ret := _m.Called(a, passphrase, newPassphrase)
+
+	var r0 []byte
+	if rf, ok := ret.Get(0).(func(accounts.Account, string, string) []byte); ok {
+		r0 = rf(a, passphrase, newPassphrase)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]byte)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(accounts.Account, string, string) error); ok {
+		r1 = rf(a, passphrase, newPassphrase)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetAccountByAddress provides a mock function with given fields: _a0
 func (_m *KeyStoreInterface) GetAccountByAddress(_a0 common.Address) (accounts.Account, error) {
 	ret := _m.Called(_a0)

--- a/core/services/balance_monitor.go
+++ b/core/services/balance_monitor.go
@@ -100,7 +100,7 @@ type worker struct {
 }
 
 func (w *worker) Work() {
-	keys, err := w.bm.store.Keys()
+	keys, err := w.bm.store.SendKeys()
 	if err != nil {
 		logger.Error("BalanceMonitor: error getting keys", err)
 	}

--- a/core/services/bulletprooftxmanager/eth_broadcaster.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster.go
@@ -120,7 +120,7 @@ func (eb *ethBroadcaster) monitorEthTxs() {
 	for {
 		pollDBTimer := time.NewTimer(databasePollInterval)
 
-		keys, err := eb.store.SendingKeys()
+		keys, err := eb.store.SendKeys()
 
 		if err != nil {
 			logger.Error(errors.Wrap(err, "monitorEthTxs failed getting key"))

--- a/core/services/bulletprooftxmanager/eth_broadcaster.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster.go
@@ -120,7 +120,7 @@ func (eb *ethBroadcaster) monitorEthTxs() {
 	for {
 		pollDBTimer := time.NewTimer(databasePollInterval)
 
-		keys, err := eb.store.Keys()
+		keys, err := eb.store.SendingKeys()
 
 		if err != nil {
 			logger.Error(errors.Wrap(err, "monitorEthTxs failed getting key"))

--- a/core/services/bulletprooftxmanager/eth_broadcaster_test.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster_test.go
@@ -60,7 +60,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Success(t *testing.T) {
 
 	eb := bulletprooftxmanager.NewEthBroadcaster(store, config)
 
-	keys, err := store.Keys()
+	keys, err := store.SendKeys()
 	require.NoError(t, err)
 	key := keys[0]
 	defaultFromAddress := key.Address.Address()
@@ -278,7 +278,7 @@ func TestEthBroadcaster_AssignsNonceOnFirstRun(t *testing.T) {
 
 	eb := bulletprooftxmanager.NewEthBroadcaster(store, config)
 
-	keys, err := store.Keys()
+	keys, err := store.SendKeys()
 	require.NoError(t, err)
 	key := keys[0]
 	defaultFromAddress := key.Address.Address()
@@ -344,7 +344,7 @@ func TestEthBroadcaster_AssignsNonceOnFirstRun(t *testing.T) {
 		require.Equal(t, int64(ethNodeNonce), *ethTx.Nonce)
 
 		// Check key to make sure it has correct nonce assigned
-		keys, err := store.Keys()
+		keys, err := store.SendKeys()
 		require.NoError(t, err)
 		key := keys[0]
 
@@ -373,7 +373,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 		store, cleanup := cltest.NewStore(t)
 		defer cleanup()
-		keys, err := store.Keys()
+		keys, err := store.SendKeys()
 		require.NoError(t, err)
 		key := keys[0]
 		defaultFromAddress := key.Address.Address()
@@ -422,7 +422,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 		eb := bulletprooftxmanager.NewEthBroadcaster(store, config)
 
-		keys, err := store.Keys()
+		keys, err := store.SendKeys()
 		require.NoError(t, err)
 		key := keys[0]
 		defaultFromAddress := key.Address.Address()
@@ -468,7 +468,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 		eb := bulletprooftxmanager.NewEthBroadcaster(store, config)
 
-		keys, err := store.Keys()
+		keys, err := store.SendKeys()
 		require.NoError(t, err)
 		key := keys[0]
 		defaultFromAddress := key.Address.Address()
@@ -514,7 +514,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 		eb := bulletprooftxmanager.NewEthBroadcaster(store, config)
 
-		keys, err := store.Keys()
+		keys, err := store.SendKeys()
 		require.NoError(t, err)
 		key := keys[0]
 		defaultFromAddress := key.Address.Address()
@@ -559,7 +559,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 		eb := bulletprooftxmanager.NewEthBroadcaster(store, config)
 
-		keys, err := store.Keys()
+		keys, err := store.SendKeys()
 		require.NoError(t, err)
 		key := keys[0]
 		defaultFromAddress := key.Address.Address()
@@ -606,7 +606,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 		eb := bulletprooftxmanager.NewEthBroadcaster(store, config)
 
-		keys, err := store.Keys()
+		keys, err := store.SendKeys()
 		require.NoError(t, err)
 		key := keys[0]
 		defaultFromAddress := key.Address.Address()
@@ -656,7 +656,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 		store.Config.Set("ETH_GAS_PRICE_DEFAULT", 500000000000)
 		eb := bulletprooftxmanager.NewEthBroadcaster(store, config)
 
-		keys, err := store.Keys()
+		keys, err := store.SendKeys()
 		require.NoError(t, err)
 		key := keys[0]
 		defaultFromAddress := key.Address.Address()
@@ -718,7 +718,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 	defer cleanup()
 	// Use the real KeyStore loaded from database fixtures
 	store.KeyStore.Unlock(cltest.Password)
-	keys, err := store.Keys()
+	keys, err := store.SendKeys()
 	require.NoError(t, err)
 	key := keys[0]
 	defaultFromAddress := key.Address.Address()
@@ -1080,7 +1080,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_KeystoreErrors(t *testing.T) {
 	kst := new(mocks.KeyStoreInterface)
 	// Use a mock keystore for this test
 	store.KeyStore = kst
-	keys, err := store.Keys()
+	keys, err := store.SendKeys()
 	require.NoError(t, err)
 	key := keys[0]
 	defaultFromAddress := key.Address.Address()
@@ -1192,7 +1192,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Locking(t *testing.T) {
 	defer cleanup()
 	eb2 := bulletprooftxmanager.NewEthBroadcaster(store2, config)
 
-	keys, err := store1.Keys()
+	keys, err := store1.SendKeys()
 	require.NoError(t, err)
 	key := keys[0]
 	defaultFromAddress := key.Address.Address()

--- a/core/services/bulletprooftxmanager/eth_confirmer.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer.go
@@ -92,7 +92,7 @@ func (ec *ethConfirmer) processHead(ctx context.Context, head models.Head) error
 	logger.Debugw("EthConfirmer: finished CheckForReceipts", "headNum", head.Number, "time", time.Since(mark), "id", "eth_confirmer")
 	mark = time.Now()
 
-	keys, err := ec.store.Keys()
+	keys, err := ec.store.SendingKeys()
 	if err != nil {
 		return errors.Wrap(err, "could not fetch keys")
 	}

--- a/core/services/bulletprooftxmanager/eth_confirmer.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer.go
@@ -92,7 +92,7 @@ func (ec *ethConfirmer) processHead(ctx context.Context, head models.Head) error
 	logger.Debugw("EthConfirmer: finished CheckForReceipts", "headNum", head.Number, "time", time.Since(mark), "id", "eth_confirmer")
 	mark = time.Now()
 
-	keys, err := ec.store.SendingKeys()
+	keys, err := ec.store.SendKeys()
 	if err != nil {
 		return errors.Wrap(err, "could not fetch keys")
 	}

--- a/core/services/bulletprooftxmanager/eth_confirmer_test.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer_test.go
@@ -1115,7 +1115,7 @@ func TestEthConfirmer_BumpGasWhereNecessary_WhenOutOfEth(t *testing.T) {
 
 	// Use the real KeyStore loaded from database fixtures
 	store.KeyStore.Unlock(cltest.Password)
-	keys, err := store.Keys()
+	keys, err := store.SendKeys()
 	require.NoError(t, err)
 
 	config, cleanup := cltest.NewConfig(t)
@@ -1220,7 +1220,7 @@ func TestEthConfirmer_EnsureConfirmedTransactionsInLongestChain(t *testing.T) {
 	ethClient := new(mocks.Client)
 	store.EthClient = ethClient
 
-	keys, err := store.Keys()
+	keys, err := store.SendKeys()
 	require.NoError(t, err)
 
 	config, cleanup := cltest.NewConfig(t)

--- a/core/store/key_store.go
+++ b/core/store/key_store.go
@@ -31,6 +31,7 @@ type KeyStoreInterface interface {
 	NewAccount(passphrase string) (accounts.Account, error)
 	SignHash(hash common.Hash) (models.Signature, error)
 	Import(keyJSON []byte, passphrase, newPassphrase string) (accounts.Account, error)
+	Export(a accounts.Account, passphrase, newPassphrase string) ([]byte, error)
 	GetAccounts() []accounts.Account
 	GetAccountByAddress(common.Address) (accounts.Account, error)
 

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -69,6 +69,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1599691818"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1600504870"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1600765286"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1600881493"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -342,6 +343,11 @@ func init() {
 		{
 			ID:      "1600765286",
 			Migrate: migration1600765286.Migrate,
+		},
+		{
+			ID:       "1600881493",
+			Migrate:  migration1600881493.Migrate,
+			Rollback: migration1600881493.Rollback,
 		},
 	}
 }

--- a/core/store/migrations/migration1600881493/migration.go
+++ b/core/store/migrations/migration1600881493/migration.go
@@ -1,0 +1,22 @@
+package migration1600881493
+
+import "github.com/jinzhu/gorm"
+
+const up = `
+ALTER TABLE keys
+ADD COLUMN is_funding BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE UNIQUE INDEX idx_keys_only_one_funding ON keys (is_funding) WHERE is_funding = TRUE;
+`
+
+const down = `
+DROP INDEX idx_keys_only_one_funding;
+ALTER TABLE keys REMOVE FIELD is_funding;
+`
+
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(up).Error
+}
+
+func Rollback(tx *gorm.DB) error {
+	return tx.Exec(down).Error
+}

--- a/core/store/models/eth_test.go
+++ b/core/store/models/eth_test.go
@@ -147,7 +147,7 @@ func TestEthTxAttempt_GetSignedTx(t *testing.T) {
 	store.KeyStore.Unlock(cltest.Password)
 	tx := gethTypes.NewTransaction(uint64(42), cltest.NewAddress(), big.NewInt(142), 242, big.NewInt(342), []byte{1, 2, 3})
 
-	keys, err := store.Keys()
+	keys, err := store.SendKeys()
 	require.NoError(t, err)
 	key := keys[0]
 	fromAddress := key.Address.Address()

--- a/core/store/models/key.go
+++ b/core/store/models/key.go
@@ -28,6 +28,9 @@ type Key struct {
 	NextNonce *int64
 	// LastUsed is the time that the address was last assigned to a transaction
 	LastUsed *time.Time
+	// IsFunding marks the address as being used for rescuing the  node and the pending transactions
+	// Only one key can be IsFunding=true at a time.
+	IsFunding bool
 }
 
 // NewKeyFromFile creates an instance in memory from a key file on disk.

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -1235,10 +1235,18 @@ func (orm *ORM) BulkDeleteRuns(bulkQuery *models.BulkDeleteRunRequest) error {
 	})
 }
 
-// Keys returns all of the keys recorded in the database.
+// Keys returns all of the keys recorded in the database including the funding key.
+// This method is deprecated! You should use SendingKeys() to retrieve all but the funding keys.
 func (orm *ORM) Keys() ([]models.Key, error) {
 	var keys []models.Key
 	return keys, orm.DB.Order("created_at ASC, address ASC").Find(&keys).Error
+}
+
+// SendingKeys will return only the keys that are not is_funding=true.
+func (orm *ORM) SendingKeys() ([]models.Key, error) {
+	var keys []models.Key
+	err := orm.DB.Where("is_funding = FALSE").Order("created_at ASC, address ASC").Find(&keys).Error
+	return keys, err
 }
 
 // KeyByAddress returns the key matching provided address

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -1235,15 +1235,15 @@ func (orm *ORM) BulkDeleteRuns(bulkQuery *models.BulkDeleteRunRequest) error {
 	})
 }
 
-// Keys returns all of the keys recorded in the database including the funding key.
-// This method is deprecated! You should use SendingKeys() to retrieve all but the funding keys.
-func (orm *ORM) Keys() ([]models.Key, error) {
+// AllKeys returns all of the keys recorded in the database including the funding key.
+// This method is deprecated! You should use SendKeys() to retrieve all but the funding keys.
+func (orm *ORM) AllKeys() ([]models.Key, error) {
 	var keys []models.Key
 	return keys, orm.DB.Order("created_at ASC, address ASC").Find(&keys).Error
 }
 
-// SendingKeys will return only the keys that are not is_funding=true.
-func (orm *ORM) SendingKeys() ([]models.Key, error) {
+// SendKeys will return only the keys that are not is_funding=true.
+func (orm *ORM) SendKeys() ([]models.Key, error) {
 	var keys []models.Key
 	err := orm.DB.Where("is_funding = FALSE").Order("created_at ASC, address ASC").Find(&keys).Error
 	return keys, err
@@ -1455,7 +1455,7 @@ func (orm *ORM) ClobberDiskKeyStoreWithDBKeys(keysDir string) error {
 		return err
 	}
 
-	keys, err := orm.Keys()
+	keys, err := orm.AllKeys()
 	if err != nil {
 		return err
 	}

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -1349,7 +1349,7 @@ func (orm *ORM) DeleteEncryptedOCRKeyBundle(key *ocrkey.EncryptedKeyBundle) (err
 func (orm *ORM) GetRoundRobinAddress(addresses ...common.Address) (address common.Address, err error) {
 	err = orm.Transaction(func(tx *gorm.DB) error {
 		q := tx.Set("gorm:query_option", "FOR UPDATE").Order("last_used ASC NULLS FIRST, id ASC")
-		q = q.Where("is_funding != TRUE")
+		q = q.Where("is_funding = FALSE")
 		if len(addresses) > 0 {
 			q = q.Where("address in (?)", addresses)
 		}

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -1245,7 +1245,7 @@ func (orm *ORM) AllKeys() ([]models.Key, error) {
 // SendKeys will return only the keys that are not is_funding=true.
 func (orm *ORM) SendKeys() ([]models.Key, error) {
 	var keys []models.Key
-	err := orm.DB.Where("is_funding = FALSE").Order("created_at ASC, address ASC").Find(&keys).Error
+	err := orm.DB.Where("is_funding != TRUE").Order("created_at ASC, address ASC").Find(&keys).Error
 	return keys, err
 }
 
@@ -1349,6 +1349,7 @@ func (orm *ORM) DeleteEncryptedOCRKeyBundle(key *ocrkey.EncryptedKeyBundle) (err
 func (orm *ORM) GetRoundRobinAddress(addresses ...common.Address) (address common.Address, err error) {
 	err = orm.Transaction(func(tx *gorm.DB) error {
 		q := tx.Set("gorm:query_option", "FOR UPDATE").Order("last_used ASC NULLS FIRST, id ASC")
+		q = q.Where("is_funding != TRUE")
 		if len(addresses) > 0 {
 			q = q.Where("address in (?)", addresses)
 		}

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -1265,6 +1265,35 @@ func TestORM_KeysOrdersByCreatedAtAsc(t *testing.T) {
 	assert.Equal(t, keys[1].Address, laterAddress)
 }
 
+func TestORM_SendingKeys(t *testing.T) {
+	store, cleanup := cltest.NewStore(t)
+	defer cleanup()
+	orm := store.ORM
+
+	testJSON := cltest.JSONFromString(t, "{}")
+
+	sendingAddress, err := models.NewEIP55Address("0x3cb8e3FD9d27e39a5e9e6852b0e96160061fd4ea")
+	require.NoError(t, err)
+	sending := models.Key{Address: sendingAddress, JSON: testJSON}
+
+	require.NoError(t, orm.CreateKeyIfNotExists(sending))
+	time.Sleep(10 * time.Millisecond)
+
+	fundingAddress, err := models.NewEIP55Address("0xBB68588621f7E847070F4cC9B9e70069BA55FC5A")
+	require.NoError(t, err)
+	funding := models.Key{Address: fundingAddress, JSON: testJSON, IsFunding: true}
+
+	require.NoError(t, orm.CreateKeyIfNotExists(funding))
+
+	keys, err := store.Keys()
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
+
+	keys, err = store.SendingKeys()
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+}
+
 func TestORM_SyncDbKeyStoreToDisk(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -1988,10 +1988,12 @@ func TestORM_GetRoundRobinAddress(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
+	fundingKey := models.Key{Address: models.EIP55Address(cltest.NewAddress().Hex()), JSON: cltest.JSONFromString(t, `{"key": 2}`), IsFunding: true}
 	k0Address := "0x3cb8e3FD9d27e39a5e9e6852b0e96160061fd4ea"
 	k1 := models.Key{Address: models.EIP55Address(cltest.NewAddress().Hex()), JSON: cltest.JSONFromString(t, `{"key": 1}`)}
 	k2 := models.Key{Address: models.EIP55Address(cltest.NewAddress().Hex()), JSON: cltest.JSONFromString(t, `{"key": 2}`)}
 
+	require.NoError(t, store.CreateKeyIfNotExists(fundingKey))
 	require.NoError(t, store.CreateKeyIfNotExists(k1))
 	require.NoError(t, store.CreateKeyIfNotExists(k2))
 

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -1256,7 +1256,7 @@ func TestORM_KeysOrdersByCreatedAtAsc(t *testing.T) {
 
 	require.NoError(t, orm.CreateKeyIfNotExists(later))
 
-	keys, err := store.Keys()
+	keys, err := store.SendKeys()
 	require.NoError(t, err)
 
 	require.Len(t, keys, 2)
@@ -1265,7 +1265,7 @@ func TestORM_KeysOrdersByCreatedAtAsc(t *testing.T) {
 	assert.Equal(t, keys[1].Address, laterAddress)
 }
 
-func TestORM_SendingKeys(t *testing.T) {
+func TestORM_SendKeys(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 	orm := store.ORM
@@ -1285,11 +1285,11 @@ func TestORM_SendingKeys(t *testing.T) {
 
 	require.NoError(t, orm.CreateKeyIfNotExists(funding))
 
-	keys, err := store.Keys()
+	keys, err := store.AllKeys()
 	require.NoError(t, err)
 	require.Len(t, keys, 2)
 
-	keys, err = store.SendingKeys()
+	keys, err = store.SendKeys()
 	require.NoError(t, err)
 	require.Len(t, keys, 1)
 }
@@ -1304,7 +1304,7 @@ func TestORM_SyncDbKeyStoreToDisk(t *testing.T) {
 	require.NoError(t, os.RemoveAll(keysDir))
 	require.NoError(t, store.DeleteKey(hexutil.MustDecode("0x3cb8e3fd9d27e39a5e9e6852b0e96160061fd4ea")))
 	// Fixture key is deleted
-	dbkeys, err := store.Keys()
+	dbkeys, err := store.SendKeys()
 	require.NoError(t, err)
 	require.Len(t, dbkeys, 0)
 
@@ -1316,7 +1316,7 @@ func TestORM_SyncDbKeyStoreToDisk(t *testing.T) {
 	err = orm.ClobberDiskKeyStoreWithDBKeys(keysDir)
 	require.NoError(t, err)
 
-	dbkeys, err = store.Keys()
+	dbkeys, err = store.SendKeys()
 	require.NoError(t, err)
 	require.Len(t, dbkeys, 1)
 
@@ -1680,7 +1680,7 @@ func TestORM_EthTaskRunTx(t *testing.T) {
 	defer cleanup()
 
 	sharedTaskRunID := cltest.MustInsertTaskRun(t, store)
-	keys, err := orm.Keys()
+	keys, err := orm.SendKeys()
 	require.NoError(t, err)
 	fromAddress := keys[0].Address.Address()
 

--- a/core/store/store_test.go
+++ b/core/store/store_test.go
@@ -64,7 +64,7 @@ func TestStore_SyncDiskKeyStoreToDB_HappyPath(t *testing.T) {
 	require.NoError(t, store.SyncDiskKeyStoreToDB())
 
 	// assert creation in db is successful
-	keys, err := store.Keys()
+	keys, err := store.SendKeys()
 	require.NoError(t, err)
 	// New key in addition to fixture key gives 2
 	require.Len(t, keys, 2)
@@ -109,7 +109,7 @@ func TestStore_SyncDiskKeyStoreToDB_MultipleKeys(t *testing.T) {
 	require.NoError(t, store.SyncDiskKeyStoreToDB())
 
 	// assert creation in db is successful
-	keys, err := store.Keys()
+	keys, err := store.SendKeys()
 	require.NoError(t, err)
 	require.Len(t, keys, 2)
 
@@ -154,7 +154,7 @@ func TestStore_SyncDiskKeyStoreToDB_DBKeyAlreadyExists(t *testing.T) {
 	store := app.GetStore()
 
 	// assert sync worked on NewApplication
-	keys, err := store.Keys()
+	keys, err := store.SendKeys()
 	require.NoError(t, err)
 	require.Len(t, keys, 1, "key should already exist because of Application#Start")
 
@@ -165,7 +165,7 @@ func TestStore_SyncDiskKeyStoreToDB_DBKeyAlreadyExists(t *testing.T) {
 	require.NoError(t, store.SyncDiskKeyStoreToDB()) // sync
 
 	// assert no change in db
-	keys, err = store.Keys()
+	keys, err = store.SendKeys()
 	require.NoError(t, err)
 	require.Len(t, keys, 1)
 	require.Equal(t, acc.Address.Hex(), keys[0].Address.String())


### PR DESCRIPTION
### Why?

This is the first part in the "node reset" work. 
See more details in the [ticket](https://www.pivotaltracker.com/story/show/174417426)

### How?
- added a is_funded boolean on keys with a unique index meaning only one is_funding=true key is ever allowed in the db
- `chainlink node start` is will now check whether the funding address exists and create one if it doesn't. It also warns the user if the addres doesn't have funds in it! The new funding key will use the same password as the existing sending keys.