### PR TITLE
Feature/174366168 jobs should have name field

### DIFF
--- a/core/cmd/renderer.go
+++ b/core/cmd/renderer.go
@@ -83,7 +83,7 @@ func (rt RendererTable) Render(v interface{}) error {
 }
 
 func (rt RendererTable) renderJobs(jobs []models.JobSpec) error {
-	table := rt.newTable([]string{"ID", "Created At", "Initiators", "Tasks"})
+	table := rt.newTable([]string{"ID", "Name", "Created At", "Initiators", "Tasks"})
 	for _, v := range jobs {
 		table.Append(jobRowToStrings(v))
 	}
@@ -149,6 +149,7 @@ func jobRowToStrings(job models.JobSpec) []string {
 	p := presenters.JobSpec{JobSpec: job}
 	return []string{
 		p.ID.String(),
+		p.Name,
 		p.FriendlyCreatedAt(),
 		p.FriendlyInitiators(),
 		p.FriendlyTasks(),
@@ -217,9 +218,10 @@ func (rt RendererTable) renderJobRun(run presenters.JobRun) error {
 }
 
 func (rt RendererTable) renderJobSingles(j presenters.JobSpec) error {
-	table := rt.newTable([]string{"ID", "Created At", "Start At", "End At", "Min Payment"})
+	table := rt.newTable([]string{"ID", "Name", "Created At", "Start At", "End At", "Min Payment"})
 	table.Append([]string{
 		j.ID.String(),
+		j.Name,
 		j.FriendlyCreatedAt(),
 		j.FriendlyStartAt(),
 		j.FriendlyEndAt(),

--- a/core/cmd/renderer_test.go
+++ b/core/cmd/renderer_test.go
@@ -29,10 +29,17 @@ func TestRendererJSON_RenderJobs(t *testing.T) {
 
 func TestRendererTable_RenderJobs(t *testing.T) {
 	t.Parallel()
-	r := cmd.RendererTable{Writer: ioutil.Discard}
+
+	buffer := bytes.NewBufferString("")
+	r := cmd.RendererTable{Writer: buffer}
 	job := cltest.NewJob()
 	jobs := []models.JobSpec{job}
 	assert.NoError(t, r.Render(&jobs))
+
+	fmt.Println(buffer)
+	output := buffer.String()
+	assert.Regexp(t, regexp.MustCompile("Job[a-f0-9]{32}"), output)
+	assert.Contains(t, output, "noop")
 }
 
 func TestRendererTable_RenderConfiguration(t *testing.T) {

--- a/core/cmd/renderer_test.go
+++ b/core/cmd/renderer_test.go
@@ -36,7 +36,6 @@ func TestRendererTable_RenderJobs(t *testing.T) {
 	jobs := []models.JobSpec{job}
 	assert.NoError(t, r.Render(&jobs))
 
-	fmt.Println(buffer)
 	output := buffer.String()
 	assert.Regexp(t, regexp.MustCompile("Job[a-f0-9]{32}"), output)
 	assert.Contains(t, output, "noop")

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -678,6 +678,14 @@ func MustInsertKey(t *testing.T, store *strpkg.Store, address common.Address) mo
 	return key
 }
 
+func MustIDFromString(t *testing.T, input string) *models.ID {
+	t.Helper()
+
+	id, err := models.NewIDFromString(input)
+	require.NoError(t, err)
+	return id
+}
+
 func NewEthTx(t *testing.T, store *strpkg.Store, fromAddress ...common.Address) models.EthTx {
 	var address common.Address
 	if len(fromAddress) > 0 {

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -72,6 +72,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1600881493"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1601294261"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1601459029"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1602180905"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -358,6 +359,11 @@ func init() {
 		{
 			ID:      "1601294261",
 			Migrate: migration1601294261.Migrate,
+		},
+		{
+			ID:       "1602180905",
+			Migrate:  migration1602180905.Migrate,
+			Rollback: migration1602180905.Rollback,
 		},
 	}
 }

--- a/core/store/migrations/migration1602180905/migrate.go
+++ b/core/store/migrations/migration1602180905/migrate.go
@@ -3,11 +3,12 @@ package migration1602180905
 import "github.com/jinzhu/gorm"
 
 const up = `
-ALTER TABLE job_specs
-ADD COLUMN name VARCHAR(255) UNIQUE;
+ALTER TABLE job_specs ADD COLUMN name VARCHAR(255);
+CREATE UNIQUE INDEX job_specs_name_index on job_specs (LOWER(name));
 `
 
 const down = `
+DROP INDEX job_specs_name_index;
 ALTER TABLE job_specs REMOVE FIELD name;
 `
 

--- a/core/store/migrations/migration1602180905/migrate.go
+++ b/core/store/migrations/migration1602180905/migrate.go
@@ -1,0 +1,20 @@
+package migration1602180905
+
+import "github.com/jinzhu/gorm"
+
+const up = `
+ALTER TABLE job_specs
+ADD COLUMN name VARCHAR(255) UNIQUE;
+`
+
+const down = `
+ALTER TABLE job_specs REMOVE FIELD name;
+`
+
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(up).Error
+}
+
+func Rollback(tx *gorm.DB) error {
+	return tx.Exec(down).Error
+}

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -87,7 +87,9 @@ func NewJob() JobSpec {
 // JobSpecRequest
 func NewJobFromRequest(jsr JobSpecRequest) JobSpec {
 	jobSpec := NewJob()
-	jobSpec.Name = jsr.Name
+	if jsr.Name != "" {
+		jobSpec.Name = jsr.Name
+	}
 	for _, initr := range jsr.Initiators {
 		init := NewInitiatorFromRequest(initr, jobSpec)
 		jobSpec.Initiators = append(jobSpec.Initiators, init)

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -19,6 +19,7 @@ import (
 
 // JobSpecRequest represents a schema for the incoming job spec request as used by the API.
 type JobSpecRequest struct {
+	Name       string             `json:"name"`
 	Initiators []InitiatorRequest `json:"initiators"`
 	Tasks      []TaskSpecRequest  `json:"tasks"`
 	StartAt    null.Time          `json:"startAt"`
@@ -86,6 +87,7 @@ func NewJob() JobSpec {
 // JobSpecRequest
 func NewJobFromRequest(jsr JobSpecRequest) JobSpec {
 	jobSpec := NewJob()
+	jobSpec.Name = jsr.Name
 	for _, initr := range jsr.Initiators {
 		init := NewInitiatorFromRequest(initr, jobSpec)
 		jobSpec.Initiators = append(jobSpec.Initiators, init)

--- a/core/store/models/job_spec.go
+++ b/core/store/models/job_spec.go
@@ -44,6 +44,7 @@ type TaskSpecRequest struct {
 // individual steps to be carried out), StartAt, EndAt, and CreatedAt fields.
 type JobSpec struct {
 	ID         *ID            `json:"id,omitempty" gorm:"primary_key;not null"`
+	Name       string         `json:"name" gorm:"index;unique;not null"`
 	CreatedAt  time.Time      `json:"createdAt" gorm:"index"`
 	Initiators []Initiator    `json:"initiators"`
 	MinPayment *assets.Link   `json:"minPayment,omitempty" gorm:"type:varchar(255)"`
@@ -73,8 +74,10 @@ func (j *JobSpec) SetID(value string) error {
 // NewJob initializes a new job by generating a unique ID and setting
 // the CreatedAt field to the time of invokation.
 func NewJob() JobSpec {
+	id := NewID()
 	return JobSpec{
-		ID:        NewID(),
+		ID:        id,
+		Name:      fmt.Sprintf("Job%s", id),
 		CreatedAt: time.Now(),
 	}
 }

--- a/core/web/job_specs_controller.go
+++ b/core/web/job_specs_controller.go
@@ -91,7 +91,7 @@ func (jsc *JobSpecsController) Create(c *gin.Context) {
 		case *pq.Error:
 			var apiErr error
 			if err.Constraint == "job_specs_name_key" {
-				apiErr = fmt.Errorf("Job Spec name '%s' already taken", js.Name)
+				apiErr = fmt.Errorf("name '%s' already taken", js.Name)
 			} else {
 				apiErr = err
 			}

--- a/core/web/job_specs_controller.go
+++ b/core/web/job_specs_controller.go
@@ -87,10 +87,10 @@ func (jsc *JobSpecsController) Create(c *gin.Context) {
 		return
 	}
 	if err := jsc.App.AddJob(js); err != nil {
-		switch err.(type) {
+		switch err := err.(type) {
 		case *pq.Error:
 			var apiErr error
-			if err.(*pq.Error).Constraint == "job_specs_name_key" {
+			if err.Constraint == "job_specs_name_key" {
 				apiErr = fmt.Errorf("Job Spec name '%s' already taken", js.Name)
 			} else {
 				apiErr = err

--- a/core/web/job_specs_controller_test.go
+++ b/core/web/job_specs_controller_test.go
@@ -239,12 +239,12 @@ func TestJobSpecsController_Create_CustomName(t *testing.T) {
 	})
 
 	t.Run("it replaces a blank name with a generated one", func(t *testing.T) {
-		jsr, err := jsr.MultiAdd(map[string]interface{}{"name": ""})
+		jsr, err = jsr.MultiAdd(map[string]interface{}{"name": ""})
 		require.NoError(t, err)
-		requestBody, err := json.Marshal(jsr)
+		requestBody, err = json.Marshal(jsr)
 		require.NoError(t, err)
 
-		client := app.NewHTTPClient()
+		client = app.NewHTTPClient()
 		resp, cleanup := client.Post("/v2/specs", bytes.NewReader(requestBody))
 		defer cleanup()
 		cltest.AssertServerResponse(t, resp, http.StatusOK)

--- a/core/web/job_specs_controller_test.go
+++ b/core/web/job_specs_controller_test.go
@@ -228,16 +228,36 @@ func TestJobSpecsController_Create_CustomName(t *testing.T) {
 		defer cleanup()
 		cltest.AssertServerResponse(t, resp, http.StatusOK)
 
-		// Check Response
 		var j models.JobSpec
 		err = cltest.ParseJSONAPIResponse(t, resp, &j)
 		require.NoError(t, err)
 
-		// Check ORM
 		orm := app.GetStore().ORM
 		j, err = orm.FindJob(j.ID)
 		require.NoError(t, err)
 		assert.Equal(t, j.Name, "CustomJobName")
+	})
+
+	t.Run("it replaces a blank name with a generated one", func(t *testing.T) {
+		jsr, err := jsr.MultiAdd(map[string]interface{}{"name": ""})
+		require.NoError(t, err)
+		requestBody, err := json.Marshal(jsr)
+		require.NoError(t, err)
+
+		client := app.NewHTTPClient()
+		resp, cleanup := client.Post("/v2/specs", bytes.NewReader(requestBody))
+		defer cleanup()
+		cltest.AssertServerResponse(t, resp, http.StatusOK)
+
+		var j models.JobSpec
+		err = cltest.ParseJSONAPIResponse(t, resp, &j)
+		require.NoError(t, err)
+
+		orm := app.GetStore().ORM
+		j, err = orm.FindJob(j.ID)
+		require.NoError(t, err)
+		assert.NotEmpty(t, j.Name)
+		assert.NotEqual(t, j.Name, "CustomJobName")
 	})
 
 	t.Run("it rejects an already taken name", func(t *testing.T) {

--- a/core/web/job_specs_controller_test.go
+++ b/core/web/job_specs_controller_test.go
@@ -261,6 +261,11 @@ func TestJobSpecsController_Create_CustomName(t *testing.T) {
 	})
 
 	t.Run("it rejects an already taken name", func(t *testing.T) {
+		jsr, err = jsr.MultiAdd(map[string]interface{}{"name": "CustomJobName"})
+		require.NoError(t, err)
+		requestBody, err = json.Marshal(jsr)
+		require.NoError(t, err)
+
 		resp, cleanup := client.Post("/v2/specs", bytes.NewReader(requestBody))
 		defer cleanup()
 		cltest.AssertServerResponse(t, resp, http.StatusConflict)

--- a/core/web/job_specs_controller_test.go
+++ b/core/web/job_specs_controller_test.go
@@ -207,6 +207,46 @@ func TestJobSpecsController_Create_HappyPath(t *testing.T) {
 	assert.Equal(t, httpGet.GetURL(), "https://bitstamp.net/api/ticker/")
 }
 
+func TestJobSpecsController_Create_CustomName(t *testing.T) {
+	t.Parallel()
+
+	app, cleanup := cltest.NewApplication(t, cltest.LenientEthMock)
+	defer cleanup()
+	require.NoError(t, app.Start())
+
+	client := app.NewHTTPClient()
+
+	fixtureBytes := cltest.MustReadFile(t, "testdata/hello_world_job.json")
+	jsr := cltest.JSONFromBytes(t, fixtureBytes)
+	jsr, err := jsr.MultiAdd(map[string]interface{}{"name": "CustomJobName"})
+	require.NoError(t, err)
+	requestBody, err := json.Marshal(jsr)
+	require.NoError(t, err)
+
+	t.Run("it creates the job spec with the specified custom name", func(t *testing.T) {
+		resp, cleanup := client.Post("/v2/specs", bytes.NewReader(requestBody))
+		defer cleanup()
+		cltest.AssertServerResponse(t, resp, http.StatusOK)
+
+		// Check Response
+		var j models.JobSpec
+		err = cltest.ParseJSONAPIResponse(t, resp, &j)
+		require.NoError(t, err)
+
+		// Check ORM
+		orm := app.GetStore().ORM
+		j, err = orm.FindJob(j.ID)
+		require.NoError(t, err)
+		assert.Equal(t, j.Name, "CustomJobName")
+	})
+
+	t.Run("it rejects an already taken name", func(t *testing.T) {
+		resp, cleanup := client.Post("/v2/specs", bytes.NewReader(requestBody))
+		defer cleanup()
+		cltest.AssertServerResponse(t, resp, http.StatusConflict)
+	})
+}
+
 func TestJobSpecsController_CreateExternalInitiator_Success(t *testing.T) {
 	t.Parallel()
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,7 @@ As a side-effect, we now no longer handle the case where an external wallet used
 - Remove configuration option ORACLE_CONTRACT_ADDRESS, it had no effect
 - Add configuration option OPERATOR_CONTRACT_ADDRESS, it filters the contract addresses the node should listen to for Run Logs
 - At startup, the chainlink node will create a new funding address. This will initially be used to pay for cancelling stuck transactions.
+- Add support for a custom job name, must be unique. A default one will be generated if not supplied.
 
 ### Fixed
 


### PR DESCRIPTION
New name support for job spec, not required, will fill in a default unique name based on the ID if you don't specify.
Otherwise has to be unique. Returns 409 if not.