### PR TITLE
Make BPTXM enabled by default

### DIFF
--- a/core/adapters/eth_tx_abi_encode_test.go
+++ b/core/adapters/eth_tx_abi_encode_test.go
@@ -114,7 +114,10 @@ func TestEthTxABIEncodeAdapter_Perform_ConfirmedWithJSON(t *testing.T) {
 
 	expectedAsHex := strings.Join(append(selector, values...), "")
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cleanup := cltest.NewConfig(t)
+	defer cleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", false)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.LenientEthMock,
 		cltest.EthMockRegisterGetBalance,
 	)

--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -26,7 +26,7 @@ import (
 
 func newStoreWithLegacyTXManager(t *testing.T) (*strpkg.Store, func()) {
 	config, cfCleanup := cltest.NewConfig(t)
-	config.Config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+	config.Config.Set("ENABLE_BULLETPROOF_TX_MANAGER", false)
 	store, strCleanup := cltest.NewStoreWithConfig(config)
 	return store, func() { cfCleanup(); strCleanup() }
 }

--- a/core/adapters/eth_tx_test.go
+++ b/core/adapters/eth_tx_test.go
@@ -24,6 +24,13 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+func newStoreWithLegacyTXManager(t *testing.T) (*strpkg.Store, func()) {
+	config, cfCleanup := cltest.NewConfig(t)
+	config.Config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+	store, strCleanup := cltest.NewStoreWithConfig(config)
+	return store, func() { cfCleanup(); strCleanup() }
+}
+
 func TestEthTxAdapter_Perform(t *testing.T) {
 	t.Parallel()
 
@@ -83,7 +90,7 @@ func TestEthTxAdapter_Perform(t *testing.T) {
 	for _, tt := range tests {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
-			store, cleanup := cltest.NewStore(t)
+			store, cleanup := newStoreWithLegacyTXManager(t)
 			defer cleanup()
 
 			txManager := new(mocks.TxManager)
@@ -111,7 +118,7 @@ func TestEthTxAdapter_Perform(t *testing.T) {
 func TestEthTxAdapter_Perform_BytesFormatWithDataPrefix(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
+	store, cleanup := newStoreWithLegacyTXManager(t)
 	defer cleanup()
 
 	txManager := new(mocks.TxManager)
@@ -141,7 +148,7 @@ func TestEthTxAdapter_Perform_BytesFormatWithDataPrefix(t *testing.T) {
 func TestEthTxAdapter_Perform_Preformatted(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
+	store, cleanup := newStoreWithLegacyTXManager(t)
 	defer cleanup()
 
 	hexPayload := "b72f443a17edf4a55f766cf3c83469e6f96494b16823a41a4acb25800f30310300000000000000000000000000000000000000000000000000000000000000600000000000000000000000000000000000000000000000000000000000000140000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000001b76616c69646174696f6e2e747769747465722e757365726e616d650000000000000000000000000000000000000000000000000000000000000000000000001c76616c69646174696f6e2e747769747465722e7369676e617475726500000000000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000400000000000000000000000000000000000000000000000000000000000000080000000000000000000000000000000000000000000000000000000000000000a64657261696e6265726b00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000008430783965353831646633383765376138343433653636336435386663313736303034356433666362376165643234393633376163633737376262653837643561333934326431363130643265386538626437353066643533633230643466633661383536303737623235656439653538356439616161336439646535626365376238316200000000000000000000000000000000000000000000000000000000"
@@ -170,7 +177,7 @@ func TestEthTxAdapter_Perform_Preformatted(t *testing.T) {
 func TestEthTxAdapter_Perform_FromPendingOutgoingConfirmations_StillPending(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
+	store, cleanup := newStoreWithLegacyTXManager(t)
 	defer cleanup()
 
 	txManager := new(mocks.TxManager)
@@ -194,7 +201,7 @@ func TestEthTxAdapter_Perform_FromPendingOutgoingConfirmations_StillPending(t *t
 func TestEthTxAdapter_Perform_FromPendingOutgoingConfirmations_Safe(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
+	store, cleanup := newStoreWithLegacyTXManager(t)
 	defer cleanup()
 
 	txManager := new(mocks.TxManager)
@@ -229,7 +236,7 @@ func TestEthTxAdapter_Perform_FromPendingOutgoingConfirmations_Safe(t *testing.T
 func TestEthTxAdapter_Perform_AppendingTransactionReceipts(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
+	store, cleanup := newStoreWithLegacyTXManager(t)
 	defer cleanup()
 
 	txManager := new(mocks.TxManager)
@@ -271,7 +278,7 @@ func TestEthTxAdapter_Perform_AppendingTransactionReceipts(t *testing.T) {
 func TestEthTxAdapter_Perform_WithError(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
+	store, cleanup := newStoreWithLegacyTXManager(t)
 	defer cleanup()
 
 	txManager := new(mocks.TxManager)
@@ -290,7 +297,7 @@ func TestEthTxAdapter_Perform_WithError(t *testing.T) {
 func TestEthTxAdapter_Perform_PendingOutgoingConfirmations_WithFatalErrorInTxManager(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
+	store, cleanup := newStoreWithLegacyTXManager(t)
 	defer cleanup()
 
 	txManager := new(mocks.TxManager)
@@ -313,7 +320,7 @@ func TestEthTxAdapter_Perform_PendingOutgoingConfirmations_WithFatalErrorInTxMan
 func TestEthTxAdapter_Perform_PendingOutgoingConfirmations_WithRecoverableErrorInTxManager(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
+	store, cleanup := newStoreWithLegacyTXManager(t)
 	defer cleanup()
 
 	txManager := new(mocks.TxManager)
@@ -337,7 +344,7 @@ func TestEthTxAdapter_Perform_PendingOutgoingConfirmations_WithRecoverableErrorI
 func TestEthTxAdapter_Perform_NotConnectedWhenPendingOutgoingConfirmations(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
+	store, cleanup := newStoreWithLegacyTXManager(t)
 	defer cleanup()
 
 	txManager := new(mocks.TxManager)
@@ -358,7 +365,7 @@ func TestEthTxAdapter_Perform_NotConnectedWhenPendingOutgoingConfirmations(t *te
 func TestEthTxAdapter_Perform_NotConnected(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
+	store, cleanup := newStoreWithLegacyTXManager(t)
 	defer cleanup()
 
 	txManager := new(mocks.TxManager)
@@ -377,7 +384,7 @@ func TestEthTxAdapter_Perform_NotConnected(t *testing.T) {
 func TestEthTxAdapter_Perform_CreateTxWithGasErrorTreatsAsNotConnected(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
+	store, cleanup := newStoreWithLegacyTXManager(t)
 	defer cleanup()
 
 	txManager := new(mocks.TxManager)
@@ -403,7 +410,7 @@ func TestEthTxAdapter_Perform_CreateTxWithGasErrorTreatsAsNotConnected(t *testin
 func TestEthTxAdapter_Perform_CheckAttemptErrorTreatsAsNotConnected(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
+	store, cleanup := newStoreWithLegacyTXManager(t)
 	defer cleanup()
 
 	txManager := new(mocks.TxManager)
@@ -432,7 +439,7 @@ func TestEthTxAdapter_Perform_CheckAttemptErrorTreatsAsNotConnected(t *testing.T
 func TestEthTxAdapter_Perform_CreateTxWithEmptyResponseErrorTreatsAsPendingOutgoingConfirmations(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
+	store, cleanup := newStoreWithLegacyTXManager(t)
 	defer cleanup()
 
 	from := cltest.NewAddress()
@@ -472,7 +479,7 @@ func TestEthTxAdapter_Perform_CreateTxWithEmptyResponseErrorTreatsAsPendingOutgo
 func TestEthTxAdapter_Perform_NoDoubleSpendOnSendTransactionFail(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
+	store, cleanup := newStoreWithLegacyTXManager(t)
 	defer cleanup()
 
 	var sentData []byte
@@ -516,10 +523,7 @@ func TestEthTxAdapter_Perform_NoDoubleSpendOnSendTransactionFail(t *testing.T) {
 func TestEthTxAdapter_Perform_BPTXM(t *testing.T) {
 	t.Parallel()
 
-	config, cleanup := cltest.NewConfig(t)
-	defer cleanup()
-	config.Config.Set("ENABLE_BULLETPROOF_TX_MANAGER", true)
-	store, cleanup := cltest.NewStoreWithConfig(config)
+	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
 	toAddress := cltest.NewAddress()

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -908,8 +908,6 @@ func TestClient_CreateExtraKey(t *testing.T) {
 	kst.On("Unlock", cltest.Password).Return(nil)
 	kst.On("NewAccount", cltest.Password).Return(accounts.Account{}, nil)
 	assert.NoError(t, client.CreateExtraKey(c))
-
-	kst.AssertExpectations(t)
 }
 
 func TestClient_SetMinimumGasPrice(t *testing.T) {
@@ -919,7 +917,6 @@ func TestClient_SetMinimumGasPrice(t *testing.T) {
 	defer cleanup()
 	app, cleanup := setupWithdrawalsApplication(t, config)
 	defer cleanup()
-	app.EthMock.Register("eth_getTransactionCount", "0x100")
 	require.NoError(t, app.StartAndConnect())
 
 	client, _ := app.NewClientAndRenderer()
@@ -928,7 +925,6 @@ func TestClient_SetMinimumGasPrice(t *testing.T) {
 
 	c := cli.NewContext(nil, set, nil)
 
-	// app.EthMock.Register("eth_call", "0xDE0B6B3A7640000")
 	assert.NoError(t, client.SetMinimumGasPrice(c))
 	assert.Equal(t, big.NewInt(8616460799), app.Store.Config.EthGasPriceDefault())
 

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -723,7 +723,6 @@ func TestClient_SendEther_From_BPTXM(t *testing.T) {
 	t.Parallel()
 
 	config, cleanup := cltest.NewConfig(t)
-	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "true")
 	defer cleanup()
 	app, cleanup := setupWithdrawalsApplication(t, config)
 	defer cleanup()

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/utils"
 	"github.com/smartcontractkit/chainlink/core/web"
 
-	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
@@ -66,14 +65,16 @@ func TestIntegration_HttpRequestWithHeaders(t *testing.T) {
 		})
 	defer assertCalled()
 
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cleanup := cltest.NewConfig(t)
+	defer cleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", false)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.LenientEthMock,
 		cltest.EthMockRegisterChainID,
 		cltest.EthMockRegisterGetBlockByNumber,
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()
-	config := app.Config
 	eth := app.EthMock
 
 	newHeads := make(chan *models.Head)
@@ -122,14 +123,16 @@ func TestIntegration_FeeBump(t *testing.T) {
 	mockServer, assertCalled := cltest.NewHTTPMockServer(t, http.StatusOK, "GET", tickerResponse)
 	defer assertCalled()
 
+	config, cleanup := cltest.NewConfig(t)
+	defer cleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", false)
 	// Must use hardcoded key here since the hash has to match attempt1Hash
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.LenientEthMock,
 		cltest.EthMockRegisterGetBalance,
 		cltest.EthMockRegisterGetBlockByNumber,
 	)
 	defer cleanup()
-	config := app.Config
 
 	// Put some distance between these two values so we can explore more of the state space
 	config.Set("ETH_GAS_BUMP_THRESHOLD", 10)
@@ -657,7 +660,10 @@ func TestIntegration_MultiplierUint256(t *testing.T) {
 func TestIntegration_NonceManagement_firstRunWithExistingTxs(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cleanup := cltest.NewConfig(t)
+	defer cleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", false)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.LenientEthMock,
 		cltest.EthMockRegisterChainID,
 		cltest.EthMockRegisterGetBlockByNumber,
@@ -716,7 +722,6 @@ func TestIntegration_SyncJobRuns(t *testing.T) {
 		cltest.EthMockRegisterGetBalance,
 	)
 	kst := new(mocks.KeyStoreInterface)
-	kst.On("Accounts").Return([]accounts.Account{})
 	app.Store.KeyStore = kst
 	defer cleanup()
 
@@ -900,7 +905,10 @@ func TestIntegration_FluxMonitor_Deviation(t *testing.T) {
 	rpcClient := new(mocks.RPCClient)
 	sub := new(mocks.Subscription)
 
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cleanup := cltest.NewConfig(t)
+	defer cleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", false)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		eth.NewClientWith(rpcClient, gethClient),
 	)
 	defer cleanup()
@@ -1003,7 +1011,10 @@ func TestIntegration_FluxMonitor_NewRound(t *testing.T) {
 	rpcClient := new(mocks.RPCClient)
 	sub := new(mocks.Subscription)
 
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cleanup := cltest.NewConfig(t)
+	defer cleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", false)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		eth.NewClientWith(rpcClient, gethClient),
 	)
 	defer cleanup()
@@ -1126,6 +1137,7 @@ func TestIntegration_EthTX_Reconnect(t *testing.T) {
 	t.Parallel()
 
 	config, cfgCleanup := cltest.NewConfig(t)
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", false)
 	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.LenientEthMock,
 		cltest.EthMockRegisterChainID,

--- a/core/services/bulletprooftxmanager/eth_broadcaster_test.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster_test.go
@@ -1276,7 +1276,6 @@ func TestEthBroadcaster_EthTxInsertEventCausesTriggerToFire(t *testing.T) {
 	config.Config.Dialect = orm.DialectPostgres
 	store, cleanup := cltest.NewStoreWithConfig(config)
 	defer cleanup()
-	store.Config.Set("ENABLE_BULLETPROOF_TX_MANAGER", true)
 
 	eb := bulletprooftxmanager.NewEthBroadcaster(store, store.Config)
 	bulletprooftxmanager.ExportedMustStartEthTxInsertListener(eb)

--- a/core/services/fluxmonitor/flux_monitor_simulated_blockchain_test.go
+++ b/core/services/fluxmonitor/flux_monitor_simulated_blockchain_test.go
@@ -256,6 +256,7 @@ func TestFluxMonitorAntiSpamLogic(t *testing.T) {
 
 	// Set up chainlink app
 	config, cfgCleanup := cltest.NewConfig(t)
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", false)
 	config.Config.Set("DEFAULT_HTTP_TIMEOUT", "100ms")
 	defer cfgCleanup()
 	app, cleanup := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, fa.backend)
@@ -417,6 +418,7 @@ func TestFluxMonitor_HibernationMode(t *testing.T) {
 	config, cfgCleanup := cltest.NewConfig(t)
 	config.Config.Set("DEFAULT_HTTP_TIMEOUT", "100ms")
 	config.Config.Set("FLAGS_CONTRACT_ADDRESS", fa.flagsContractAddress.Hex())
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", false)
 	defer cfgCleanup()
 	app, cleanup := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, fa.backend)
 	defer cleanup()

--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
-	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/stretchr/testify/assert"
@@ -362,7 +361,6 @@ func TestRunManager_Create_fromRunLog_Happy(t *testing.T) {
 			sub.On("Unsubscribe").Return()
 
 			kst := new(mocks.KeyStoreInterface)
-			kst.On("Accounts").Return([]accounts.Account{})
 			app.Store.KeyStore = kst
 			defer cleanup()
 
@@ -657,7 +655,6 @@ func TestRunManager_Create_fromRunLog_ConnectToLaggingEthNode(t *testing.T) {
 		cltest.EthMockRegisterGetBalance,
 	)
 	kst := new(mocks.KeyStoreInterface)
-	kst.On("Accounts").Return([]accounts.Account{})
 	app.Store.KeyStore = kst
 	defer cleanup()
 

--- a/core/services/vrf/vrf_simulate_blockchain_test.go
+++ b/core/services/vrf/vrf_simulate_blockchain_test.go
@@ -40,8 +40,10 @@ func registerExistingProvingKey(
 // TODO - this tests's eth client can be entirely replaced with the simulated backend once
 // the GethClient and RPCClient definitions are finished
 func TestIntegration_RandomnessRequest(t *testing.T) {
-	app, cleanup := cltest.NewApplicationWithKey(t,
-		cltest.LenientEthMock,
+	config, cleanup := cltest.NewConfig(t)
+	defer cleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", false)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()

--- a/core/store/models/log_events_test.go
+++ b/core/store/models/log_events_test.go
@@ -123,7 +123,6 @@ func TestStartRunOrSALogSubscription_ValidateSenders(t *testing.T) {
 			ethMock := app.EthMock
 			logs := make(chan models.Log, 1)
 			ethMock.Context("app.Start()", func(meth *cltest.EthMock) {
-				meth.Register("eth_getTransactionCount", "0x1")
 				meth.RegisterSubscription("logs", logs)
 			})
 			assert.NoError(t, app.StartAndConnect())

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -782,7 +782,10 @@ func TestORM_GetLastNonce_StormNotFound(t *testing.T) {
 
 func TestORM_GetLastNonce_Valid(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cleanup := cltest.NewConfig(t)
+	defer cleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", false)
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.EthMockRegisterChainID,
 		cltest.EthMockRegisterGetBalance,
 	)

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -25,7 +25,7 @@ type ConfigSchema struct {
 	DefaultHTTPTimeout               models.Duration `env:"DEFAULT_HTTP_TIMEOUT" default:"15s"`
 	Dev                              bool            `env:"CHAINLINK_DEV" default:"false"`
 	EnableExperimentalAdapters       bool            `env:"ENABLE_EXPERIMENTAL_ADAPTERS" default:"false"`
-	EnableBulletproofTxManager       bool            `env:"ENABLE_BULLETPROOF_TX_MANAGER" default:"false"`
+	EnableBulletproofTxManager       bool            `env:"ENABLE_BULLETPROOF_TX_MANAGER" default:"true"`
 	FeatureExternalInitiators        bool            `env:"FEATURE_EXTERNAL_INITIATORS" default:"false"`
 	FeatureFluxMonitor               bool            `env:"FEATURE_FLUX_MONITOR" default:"false"`
 	MaximumServiceDuration           models.Duration `env:"MAXIMUM_SERVICE_DURATION" default:"8760h" `

--- a/core/store/store_test.go
+++ b/core/store/store_test.go
@@ -20,9 +20,19 @@ import (
 
 func TestStore_Start(t *testing.T) {
 	t.Parallel()
-
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
+	assert.NoError(t, store.Start())
+}
+
+func TestStore_LegacyTxManager_Start(t *testing.T) {
+	t.Parallel()
+
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+	store, storeCleanup := cltest.NewStoreWithConfig(config)
+	defer storeCleanup()
 
 	txManager := new(mocks.TxManager)
 	txManager.On("Register", mock.Anything).Return(big.NewInt(3), nil)
@@ -147,7 +157,6 @@ func TestStore_SyncDiskKeyStoreToDB_DBKeyAlreadyExists(t *testing.T) {
 	)
 	defer cleanup()
 	app.EthMock.Context("app.Start()", func(meth *cltest.EthMock) {
-		meth.Register("eth_getTransactionCount", "0x1")
 		meth.Register("eth_chainId", app.Store.Config.ChainID())
 	})
 	require.NoError(t, app.StartAndConnect())

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -24,7 +24,7 @@ import (
 	"gopkg.in/guregu/null.v3"
 )
 
-func TestTxManager_CreateTx_Success(t *testing.T) {
+func TestLegacyTxManager_CreateTx_Success(t *testing.T) {
 	t.Parallel()
 
 	store, cleanup := cltest.NewStore(t)
@@ -68,7 +68,7 @@ func TestTxManager_CreateTx_Success(t *testing.T) {
 	ethClient.AssertExpectations(t)
 }
 
-func TestTxManager_CreateTx_RoundRobinSuccess(t *testing.T) {
+func TestLegacyTxManager_CreateTx_RoundRobinSuccess(t *testing.T) {
 	t.Parallel()
 
 	store, cleanup := cltest.NewStore(t)
@@ -138,7 +138,7 @@ func TestTxManager_CreateTx_RoundRobinSuccess(t *testing.T) {
 	ethClient.AssertExpectations(t)
 }
 
-func TestTxManager_CreateTx_BreakTxAttemptLimit(t *testing.T) {
+func TestLegacyTxManager_CreateTx_BreakTxAttemptLimit(t *testing.T) {
 	t.Parallel()
 
 	store, cleanup := cltest.NewStore(t)
@@ -204,7 +204,7 @@ func TestTxManager_CreateTx_BreakTxAttemptLimit(t *testing.T) {
 	ethClient.AssertExpectations(t)
 }
 
-func TestTxManager_CreateTx_AttemptErrorDoesNotIncrementNonce(t *testing.T) {
+func TestLegacyTxManager_CreateTx_AttemptErrorDoesNotIncrementNonce(t *testing.T) {
 	t.Parallel()
 
 	config, configCleanup := cltest.NewConfig(t)
@@ -263,7 +263,7 @@ func TestTxManager_CreateTx_AttemptErrorDoesNotIncrementNonce(t *testing.T) {
 	ethMock.EventuallyAllCalled(t)
 }
 
-func TestTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
+func TestLegacyTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -316,7 +316,7 @@ func TestTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
 	}
 }
 
-func TestTxManager_CreateTx_NonceTooLowReloadLimit(t *testing.T) {
+func TestLegacyTxManager_CreateTx_NonceTooLowReloadLimit(t *testing.T) {
 	t.Parallel()
 
 	store, cleanup := cltest.NewStore(t)
@@ -349,7 +349,7 @@ func TestTxManager_CreateTx_NonceTooLowReloadLimit(t *testing.T) {
 	ethClient.AssertExpectations(t)
 }
 
-func TestTxManager_CreateTx_ErrPendingConnection(t *testing.T) {
+func TestLegacyTxManager_CreateTx_ErrPendingConnection(t *testing.T) {
 	t.Parallel()
 
 	store, cleanup := cltest.NewStore(t)
@@ -363,7 +363,7 @@ func TestTxManager_CreateTx_ErrPendingConnection(t *testing.T) {
 	assert.Contains(t, err.Error(), strpkg.ErrPendingConnection.Error())
 }
 
-func TestTxManager_BumpGasUntilSafe_lessThanGasBumpThreshold(t *testing.T) {
+func TestLegacyTxManager_BumpGasUntilSafe_lessThanGasBumpThreshold(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplicationWithKey(t,
@@ -401,7 +401,7 @@ func TestTxManager_BumpGasUntilSafe_lessThanGasBumpThreshold(t *testing.T) {
 	ethMock.EventuallyAllCalled(t)
 }
 
-func TestTxManager_BumpGasUntilSafe_atGasBumpThreshold(t *testing.T) {
+func TestLegacyTxManager_BumpGasUntilSafe_atGasBumpThreshold(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplicationWithKey(t,
@@ -440,7 +440,7 @@ func TestTxManager_BumpGasUntilSafe_atGasBumpThreshold(t *testing.T) {
 	ethMock.EventuallyAllCalled(t)
 }
 
-func TestTxManager_BumpGasUntilSafe_atGasBumpThreshold_bumpsGasMoreInCaseOfUnderpricedTransaction(t *testing.T) {
+func TestLegacyTxManager_BumpGasUntilSafe_atGasBumpThreshold_bumpsGasMoreInCaseOfUnderpricedTransaction(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplicationWithKey(t,
@@ -495,7 +495,7 @@ func TestTxManager_BumpGasUntilSafe_atGasBumpThreshold_bumpsGasMoreInCaseOfUnder
 	ethMock.EventuallyAllCalled(t)
 }
 
-func TestTxManager_BumpGasUntilSafe_atGasBumpThreshold_CapsAtMaxIfMaxGasPriceIsReached(t *testing.T) {
+func TestLegacyTxManager_BumpGasUntilSafe_atGasBumpThreshold_CapsAtMaxIfMaxGasPriceIsReached(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplicationWithKey(t,
@@ -541,7 +541,7 @@ func TestTxManager_BumpGasUntilSafe_atGasBumpThreshold_CapsAtMaxIfMaxGasPriceIsR
 	ethMock.EventuallyAllCalled(t)
 }
 
-func TestTxManager_BumpGasUntilSafe_exceedsGasBumpThreshold(t *testing.T) {
+func TestLegacyTxManager_BumpGasUntilSafe_exceedsGasBumpThreshold(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplicationWithKey(t,
@@ -580,7 +580,7 @@ func TestTxManager_BumpGasUntilSafe_exceedsGasBumpThreshold(t *testing.T) {
 	ethMock.EventuallyAllCalled(t)
 }
 
-func TestTxManager_BumpGasUntilSafe_confirmed(t *testing.T) {
+func TestLegacyTxManager_BumpGasUntilSafe_confirmed(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplicationWithKey(t,
@@ -625,7 +625,7 @@ func TestTxManager_BumpGasUntilSafe_confirmed(t *testing.T) {
 	app.EthMock.EventuallyAllCalled(t)
 }
 
-func TestTxManager_BumpGasUntilSafe_safe(t *testing.T) {
+func TestLegacyTxManager_BumpGasUntilSafe_safe(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
@@ -684,7 +684,7 @@ func TestTxManager_BumpGasUntilSafe_safe(t *testing.T) {
 	}
 }
 
-func TestTxManager_BumpGasUntilSafe_laterConfirmedTx(t *testing.T) {
+func TestLegacyTxManager_BumpGasUntilSafe_laterConfirmedTx(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplicationWithKey(t,
@@ -728,7 +728,7 @@ func TestTxManager_BumpGasUntilSafe_laterConfirmedTx(t *testing.T) {
 	app.EthMock.EventuallyAllCalled(t)
 }
 
-func TestTxManager_BumpGasUntilSafe_erroring(t *testing.T) {
+func TestLegacyTxManager_BumpGasUntilSafe_erroring(t *testing.T) {
 	t.Parallel()
 
 	config, cleanup := cltest.NewConfig(t)
@@ -810,7 +810,7 @@ func TestTxManager_BumpGasUntilSafe_erroring(t *testing.T) {
 	}
 }
 
-func TestTxManager_CheckAttempt(t *testing.T) {
+func TestLegacyTxManager_CheckAttempt(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplicationWithKey(t,
@@ -869,7 +869,7 @@ func TestTxManager_CheckAttempt(t *testing.T) {
 	ethMock.EventuallyAllCalled(t)
 }
 
-func TestTxManager_CheckAttempt_error(t *testing.T) {
+func TestLegacyTxManager_CheckAttempt_error(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplicationWithKey(t,
@@ -899,7 +899,7 @@ func TestTxManager_CheckAttempt_error(t *testing.T) {
 	ethMock.EventuallyAllCalled(t)
 }
 
-func TestTxManager_Register(t *testing.T) {
+func TestLegacyTxManager_Register(t *testing.T) {
 	t.Parallel()
 
 	store, cleanup := cltest.NewStore(t)
@@ -926,7 +926,7 @@ func TestTxManager_Register(t *testing.T) {
 	assert.Equal(t, uint64(0x2d0), aa.Nonce())
 }
 
-func TestTxManager_NextActiveAccount_RoundRobin(t *testing.T) {
+func TestLegacyTxManager_NextActiveAccount_RoundRobin(t *testing.T) {
 	t.Parallel()
 
 	store, cleanup := cltest.NewStore(t)
@@ -965,7 +965,7 @@ func TestTxManager_NextActiveAccount_RoundRobin(t *testing.T) {
 	assert.Equal(t, a0, a2)
 }
 
-func TestTxManager_ReloadNonce(t *testing.T) {
+func TestLegacyTxManager_ReloadNonce(t *testing.T) {
 	t.Parallel()
 
 	ethClient := new(mocks.Client)
@@ -1026,7 +1026,7 @@ func TestManagedAccount_GetAndIncrementNonce_DoesNotIncrementWhenCallbackThrowsE
 	assert.Equal(t, uint64(0), managedAccount.Nonce())
 }
 
-func TestTxManager_LogsETHAndLINKBalancesAfterSuccessfulTx(t *testing.T) {
+func TestLegacyTxManager_LogsETHAndLINKBalancesAfterSuccessfulTx(t *testing.T) {
 	t.Parallel()
 
 	store, cleanup := cltest.NewStore(t)
@@ -1085,7 +1085,7 @@ func TestTxManager_LogsETHAndLINKBalancesAfterSuccessfulTx(t *testing.T) {
 	ethClient.AssertExpectations(t)
 }
 
-func TestTxManager_CreateTxWithGas(t *testing.T) {
+func TestLegacyTxManager_CreateTxWithGas(t *testing.T) {
 	t.Parallel()
 
 	app, cleanup := cltest.NewApplicationWithKey(t,
@@ -1142,7 +1142,7 @@ func TestTxManager_CreateTxWithGas(t *testing.T) {
 	}
 }
 
-func TestTxManager_RebroadcastUnconfirmedTxsOnReconnect(t *testing.T) {
+func TestLegacyTxManager_RebroadcastUnconfirmedTxsOnReconnect(t *testing.T) {
 	t.Parallel()
 
 	store, cleanup := cltest.NewStore(t)
@@ -1184,7 +1184,7 @@ func TestTxManager_RebroadcastUnconfirmedTxsOnReconnect(t *testing.T) {
 	ethClient.AssertExpectations(t)
 }
 
-func TestTxManager_BumpGasByIncrement(t *testing.T) {
+func TestLegacyTxManager_BumpGasByIncrement(t *testing.T) {
 	t.Parallel()
 
 	store, cleanup := cltest.NewStore(t)

--- a/core/store/tx_manager_test.go
+++ b/core/store/tx_manager_test.go
@@ -27,13 +27,14 @@ import (
 func TestLegacyTxManager_CreateTx_Success(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+	store, strCleanup := cltest.NewStoreWithConfig(config)
+	defer strCleanup()
 
 	ethClient := new(mocks.Client)
-
-	config := cltest.NewTestConfig(t)
-	keyStore := strpkg.NewKeyStore(config.KeysDir())
+	keyStore := strpkg.NewKeyStore(cltest.NewTestConfig(t).KeysDir())
 	account, err := keyStore.NewAccount(cltest.Password)
 	require.NoError(t, err)
 	require.NoError(t, keyStore.Unlock(cltest.Password))
@@ -71,13 +72,14 @@ func TestLegacyTxManager_CreateTx_Success(t *testing.T) {
 func TestLegacyTxManager_CreateTx_RoundRobinSuccess(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+	store, strCleanup := cltest.NewStoreWithConfig(config)
+	defer strCleanup()
 
 	ethClient := new(mocks.Client)
-
-	config := cltest.NewTestConfig(t)
-	keyStore := strpkg.NewKeyStore(config.KeysDir())
+	keyStore := strpkg.NewKeyStore(cltest.NewTestConfig(t).KeysDir())
 
 	// Add two accounts
 	_, err := keyStore.NewAccount(cltest.Password)
@@ -141,14 +143,15 @@ func TestLegacyTxManager_CreateTx_RoundRobinSuccess(t *testing.T) {
 func TestLegacyTxManager_CreateTx_BreakTxAttemptLimit(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+	config.Set("CHAINLINK_TX_ATTEMPT_LIMIT", 1)
+	store, strCleanup := cltest.NewStoreWithConfig(config)
+	defer strCleanup()
 
 	ethClient := new(mocks.Client)
-
-	config := cltest.NewTestConfig(t)
-	config.Set("CHAINLINK_TX_ATTEMPT_LIMIT", 1)
-	keyStore := strpkg.NewKeyStore(config.KeysDir())
+	keyStore := strpkg.NewKeyStore(cltest.NewTestConfig(t).KeysDir())
 	account, err := keyStore.NewAccount(cltest.Password)
 	require.NoError(t, err)
 	require.NoError(t, keyStore.Unlock(cltest.Password))
@@ -208,6 +211,7 @@ func TestLegacyTxManager_CreateTx_AttemptErrorDoesNotIncrementNonce(t *testing.T
 	t.Parallel()
 
 	config, configCleanup := cltest.NewConfig(t)
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
 	defer configCleanup()
 
 	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
@@ -279,11 +283,13 @@ func TestLegacyTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
 	for _, tt := range tests {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
-			store, cleanup := cltest.NewStore(t)
-			defer cleanup()
+			config, cfgCleanup := cltest.NewConfig(t)
+			defer cfgCleanup()
+			config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+			store, strCleanup := cltest.NewStore(t)
+			defer strCleanup()
 
 			ethClient := new(mocks.Client)
-			config := cltest.NewTestConfig(t)
 			require.NoError(t, store.KeyStore.Unlock(cltest.Password))
 			manager := strpkg.NewEthTxManager(ethClient, config, store.KeyStore, store.ORM)
 			manager.Register(store.KeyStore.Accounts())
@@ -319,13 +325,14 @@ func TestLegacyTxManager_CreateTx_NonceTooLowReloadSuccess(t *testing.T) {
 func TestLegacyTxManager_CreateTx_NonceTooLowReloadLimit(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+	store, strCleanup := cltest.NewStoreWithConfig(config)
+	defer strCleanup()
 
 	ethClient := new(mocks.Client)
-
-	config := cltest.NewTestConfig(t)
-	keyStore := strpkg.NewKeyStore(config.KeysDir())
+	keyStore := strpkg.NewKeyStore(cltest.NewTestConfig(t).KeysDir())
 	account, err := keyStore.NewAccount(cltest.Password)
 	require.NoError(t, err)
 	require.NoError(t, keyStore.Unlock(cltest.Password))
@@ -352,8 +359,11 @@ func TestLegacyTxManager_CreateTx_NonceTooLowReloadLimit(t *testing.T) {
 func TestLegacyTxManager_CreateTx_ErrPendingConnection(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+	store, strCleanup := cltest.NewStoreWithConfig(config)
+	defer strCleanup()
 	manager := store.TxManager
 
 	to := cltest.NewAddress()
@@ -366,15 +376,17 @@ func TestLegacyTxManager_CreateTx_ErrPendingConnection(t *testing.T) {
 func TestLegacyTxManager_BumpGasUntilSafe_lessThanGasBumpThreshold(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.EthMockRegisterChainID,
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()
 
 	store := app.Store
-	config := store.Config
-
 	txm := store.TxManager
 	from := cltest.GetAccountAddress(t, store)
 	sentAt := uint64(23456)
@@ -404,14 +416,16 @@ func TestLegacyTxManager_BumpGasUntilSafe_lessThanGasBumpThreshold(t *testing.T)
 func TestLegacyTxManager_BumpGasUntilSafe_atGasBumpThreshold(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()
 
 	store := app.Store
-	config := store.Config
-
 	txm := store.TxManager
 	from := cltest.GetAccountAddress(t, store)
 	sentAt := uint64(23456)
@@ -443,15 +457,17 @@ func TestLegacyTxManager_BumpGasUntilSafe_atGasBumpThreshold(t *testing.T) {
 func TestLegacyTxManager_BumpGasUntilSafe_atGasBumpThreshold_bumpsGasMoreInCaseOfUnderpricedTransaction(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+	config.Set("ETH_GAS_BUMP_PERCENT", 10)
+
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()
 
 	store := app.Store
-	config := store.Config
-	config.Set("ETH_GAS_BUMP_PERCENT", 10)
-
 	txm := store.TxManager
 	from := cltest.GetAccountAddress(t, store)
 	sentAt := uint64(23456)
@@ -498,15 +514,17 @@ func TestLegacyTxManager_BumpGasUntilSafe_atGasBumpThreshold_bumpsGasMoreInCaseO
 func TestLegacyTxManager_BumpGasUntilSafe_atGasBumpThreshold_CapsAtMaxIfMaxGasPriceIsReached(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+	config.Set("ETH_MAX_GAS_PRICE_WEI", 500000000000)
+
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()
 
 	store := app.Store
-	store.Config.Set("ETH_MAX_GAS_PRICE_WEI", 500000000000)
-	config := store.Config
-
 	txm := store.TxManager
 	from := cltest.GetAccountAddress(t, store)
 	sentAt := uint64(23456)
@@ -544,14 +562,16 @@ func TestLegacyTxManager_BumpGasUntilSafe_atGasBumpThreshold_CapsAtMaxIfMaxGasPr
 func TestLegacyTxManager_BumpGasUntilSafe_exceedsGasBumpThreshold(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()
 
 	store := app.Store
-	config := store.Config
-
 	txm := store.TxManager
 	from := cltest.GetAccountAddress(t, store)
 	sentAt := uint64(23456)
@@ -583,7 +603,11 @@ func TestLegacyTxManager_BumpGasUntilSafe_exceedsGasBumpThreshold(t *testing.T) 
 func TestLegacyTxManager_BumpGasUntilSafe_confirmed(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()
@@ -591,9 +615,8 @@ func TestLegacyTxManager_BumpGasUntilSafe_confirmed(t *testing.T) {
 		meth.Register("eth_getTransactionCount", "0x1")
 		meth.Register("eth_chainId", app.Store.Config.ChainID())
 	})
-	store := app.Store
-	config := store.Config
 
+	store := app.Store
 	sentAt := uint64(23456)
 	nonce := uint64(234)
 	gasThreshold := int64(sentAt + config.EthGasBumpThreshold())
@@ -641,7 +664,11 @@ func TestLegacyTxManager_BumpGasUntilSafe_safe(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			app, cleanup := cltest.NewApplicationWithKey(t,
+			config, cfgCleanup := cltest.NewConfig(t)
+			defer cfgCleanup()
+			config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+
+			app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 				cltest.EthMockRegisterGetBalance,
 			)
 			defer cleanup()
@@ -650,7 +677,6 @@ func TestLegacyTxManager_BumpGasUntilSafe_safe(t *testing.T) {
 				meth.Register("eth_chainId", app.Store.Config.ChainID())
 			})
 			store := app.Store
-			config := store.Config
 
 			gasThreshold := int64(sentAt + config.EthGasBumpThreshold())
 			minConfs := config.MinRequiredOutgoingConfirmations() - 1
@@ -687,7 +713,11 @@ func TestLegacyTxManager_BumpGasUntilSafe_safe(t *testing.T) {
 func TestLegacyTxManager_BumpGasUntilSafe_laterConfirmedTx(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()
@@ -732,6 +762,7 @@ func TestLegacyTxManager_BumpGasUntilSafe_erroring(t *testing.T) {
 	t.Parallel()
 
 	config, cleanup := cltest.NewConfig(t)
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
 	defer cleanup()
 
 	sentAt1 := uint64(23456)
@@ -813,14 +844,16 @@ func TestLegacyTxManager_BumpGasUntilSafe_erroring(t *testing.T) {
 func TestLegacyTxManager_CheckAttempt(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()
 
 	store := app.Store
-	config := store.Config
-
 	ethMock := app.EthMock
 	ethMock.Register("eth_getTransactionCount", "0x0")
 	ethMock.Register("eth_chainId", config.ChainID())
@@ -872,7 +905,11 @@ func TestLegacyTxManager_CheckAttempt(t *testing.T) {
 func TestLegacyTxManager_CheckAttempt_error(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()
@@ -902,13 +939,16 @@ func TestLegacyTxManager_CheckAttempt_error(t *testing.T) {
 func TestLegacyTxManager_Register(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+	store, strCleanup := cltest.NewStoreWithConfig(config)
+	defer strCleanup()
 
 	ethClient := new(mocks.Client)
 	txm := strpkg.NewEthTxManager(
 		ethClient,
-		orm.NewConfig(),
+		config,
 		nil,
 		store.ORM,
 	)
@@ -929,13 +969,16 @@ func TestLegacyTxManager_Register(t *testing.T) {
 func TestLegacyTxManager_NextActiveAccount_RoundRobin(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+	store, strCleanup := cltest.NewStoreWithConfig(config)
+	defer strCleanup()
 
 	ethClient := new(mocks.Client)
 	txm := strpkg.NewEthTxManager(
 		ethClient,
-		orm.NewConfig(),
+		config,
 		nil,
 		store.ORM,
 	)
@@ -1029,13 +1072,14 @@ func TestManagedAccount_GetAndIncrementNonce_DoesNotIncrementWhenCallbackThrowsE
 func TestLegacyTxManager_LogsETHAndLINKBalancesAfterSuccessfulTx(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+	store, strCleanup := cltest.NewStoreWithConfig(config)
+	defer strCleanup()
 
 	ethClient := new(mocks.Client)
-
-	config := cltest.NewTestConfig(t)
-	keyStore := strpkg.NewKeyStore(config.KeysDir())
+	keyStore := strpkg.NewKeyStore(cltest.NewTestConfig(t).KeysDir())
 	account, err := keyStore.NewAccount(cltest.Password)
 	require.NoError(t, err)
 	require.NoError(t, keyStore.Unlock(cltest.Password))
@@ -1088,14 +1132,17 @@ func TestLegacyTxManager_LogsETHAndLINKBalancesAfterSuccessfulTx(t *testing.T) {
 func TestLegacyTxManager_CreateTxWithGas(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t,
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+
+	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config,
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()
-	store := app.Store
-	config := store.Config
-	manager := store.TxManager
 
+	store := app.Store
+	manager := store.TxManager
 	to := cltest.NewAddress()
 	data, err := hex.DecodeString("0000abcdef")
 	assert.NoError(t, err)
@@ -1145,14 +1192,15 @@ func TestLegacyTxManager_CreateTxWithGas(t *testing.T) {
 func TestLegacyTxManager_RebroadcastUnconfirmedTxsOnReconnect(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
+	config.Set("CHAINLINK_TX_ATTEMPT_LIMIT", 1)
+	store, strCleanup := cltest.NewStoreWithConfig(config)
+	defer strCleanup()
 
 	ethClient := new(mocks.Client)
-
-	config := cltest.NewTestConfig(t)
-	config.Set("CHAINLINK_TX_ATTEMPT_LIMIT", 1)
-	keyStore := strpkg.NewKeyStore(config.KeysDir())
+	keyStore := strpkg.NewKeyStore(cltest.NewTestConfig(t).KeysDir())
 	_, err := keyStore.NewAccount(cltest.Password)
 	require.NoError(t, err)
 	require.NoError(t, keyStore.Unlock(cltest.Password))
@@ -1187,16 +1235,17 @@ func TestLegacyTxManager_RebroadcastUnconfirmedTxsOnReconnect(t *testing.T) {
 func TestLegacyTxManager_BumpGasByIncrement(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
-
-	ethClient := new(mocks.Client)
-
-	config := cltest.NewTestConfig(t)
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	config.Set("ENABLE_BULLETPROOF_TX_MANAGER", "false")
 	config.Set("CHAINLINK_TX_ATTEMPT_LIMIT", 1)
 	config.Set("ETH_GAS_PRICE_DEFAULT", 1)
 	config.Set("ETH_GAS_BUMP_PERCENT", 10)
-	keyStore := strpkg.NewKeyStore(config.KeysDir())
+	store, strCleanup := cltest.NewStoreWithConfig(config)
+	defer strCleanup()
+
+	ethClient := new(mocks.Client)
+	keyStore := strpkg.NewKeyStore(cltest.NewTestConfig(t).KeysDir())
 	txm := strpkg.NewEthTxManager(ethClient, config, keyStore, store.ORM)
 
 	tests := []struct {

--- a/core/web/keys_controller_test.go
+++ b/core/web/keys_controller_test.go
@@ -22,10 +22,6 @@ func TestKeysController_CreateSuccess(t *testing.T) {
 	defer cleanup()
 
 	ethMock := app.EthMock
-	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_getTransactionCount", "0x100")
-	})
-
 	client := app.NewHTTPClient()
 
 	assert.NoError(t, app.StartAndConnect())
@@ -55,11 +51,6 @@ func TestKeysController_InvalidPassword(t *testing.T) {
 	)
 	defer cleanup()
 
-	ethMock := app.EthMock
-	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_getTransactionCount", "0x100")
-	})
-
 	client := app.NewHTTPClient()
 
 	assert.NoError(t, app.StartAndConnect())
@@ -75,8 +66,6 @@ func TestKeysController_InvalidPassword(t *testing.T) {
 	defer cleanup()
 
 	cltest.AssertServerResponse(t, resp, 401)
-
-	ethMock.AllCalled()
 }
 
 func TestKeysController_JSONBindingError(t *testing.T) {
@@ -89,11 +78,6 @@ func TestKeysController_JSONBindingError(t *testing.T) {
 	)
 	defer cleanup()
 
-	ethMock := app.EthMock
-	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_getTransactionCount", "0x100")
-	})
-
 	client := app.NewHTTPClient()
 
 	assert.NoError(t, app.StartAndConnect())
@@ -102,6 +86,4 @@ func TestKeysController_JSONBindingError(t *testing.T) {
 	defer cleanup()
 
 	cltest.AssertServerResponse(t, resp, 422)
-
-	ethMock.AllCalled()
 }

--- a/core/web/transactions_controller_test.go
+++ b/core/web/transactions_controller_test.go
@@ -24,11 +24,6 @@ func TestTransactionsController_Index_Success(t *testing.T) {
 	)
 	defer cleanup()
 
-	ethMock := app.EthMock
-	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_getTransactionCount", "0x100")
-	})
-
 	require.NoError(t, app.Start())
 	store := app.GetStore()
 	client := app.NewHTTPClient()
@@ -67,10 +62,6 @@ func TestTransactionsController_Index_Error(t *testing.T) {
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()
-	ethMock := app.EthMock
-	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_getTransactionCount", "0x100")
-	})
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -88,7 +79,6 @@ func TestTransactionsController_Show_Success(t *testing.T) {
 	ethMock := app.EthMock
 	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
 		ethMock.Register("eth_chainId", app.Store.Config.ChainID())
-		ethMock.Register("eth_getTransactionCount", "0x100")
 	})
 
 	require.NoError(t, app.Start())
@@ -143,11 +133,6 @@ func TestTransactionsController_Show_NotFound(t *testing.T) {
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()
-
-	ethMock := app.EthMock
-	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_getTransactionCount", "0x100")
-	})
 
 	require.NoError(t, app.Start())
 	store := app.GetStore()

--- a/core/web/tx_attempts_controller_test.go
+++ b/core/web/tx_attempts_controller_test.go
@@ -23,11 +23,6 @@ func TestTxAttemptsController_Index_Success(t *testing.T) {
 	)
 	defer cleanup()
 
-	ethMock := app.EthMock
-	ethMock.Context("app.Start()", func(ethMock *cltest.EthMock) {
-		ethMock.Register("eth_getTransactionCount", "0x100")
-	})
-
 	require.NoError(t, app.Start())
 	store := app.GetStore()
 	client := app.NewHTTPClient()
@@ -63,11 +58,8 @@ func TestTxAttemptsController_Index_Error(t *testing.T) {
 		cltest.EthMockRegisterGetBalance,
 	)
 	defer cleanup()
-	app.EthMock.Context("app.Start()", func(meth *cltest.EthMock) {
-		meth.Register("eth_getTransactionCount", "0x1")
-	})
-	require.NoError(t, app.Start())
 
+	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
 	resp, cleanup := client.Get("/v2/tx_attempts?size=TrainingDay")
 	defer cleanup()


### PR DESCRIPTION
This PR enables the BPTXM by default, but leaves the legacy TXM in place. Most tests converted to the BPTXM seamlessly, but many were dependent on the functionality of the legacy TXM. Rather than convert them all here, we simply re-enable the legacy TXM for some tests. These tests should be converted before officially gutting the legacy TXM.

Follow up stories:
* [Convert all tests to use BPTXM](https://www.pivotaltracker.com/story/show/175212591)
* [Remove legacy TXM](https://www.pivotaltracker.com/story/show/175212633)