### PR TITLE
Bump @chainlink/styleguide from v0.0.3 to v0.0.4

### DIFF
--- a/operator_ui/package.json
+++ b/operator_ui/package.json
@@ -22,7 +22,7 @@
     "@chainlink/json-api-client": "0.0.2",
     "@chainlink/local-storage": "0.0.2",
     "@chainlink/redux": "0.0.2",
-    "@chainlink/styleguide": "0.0.2",
+    "@chainlink/styleguide": "0.0.4",
     "@material-ui/core": "^3.9.2",
     "@material-ui/icons": "^4.5.1",
     "autobind-decorator": "^2.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2235,10 +2235,10 @@
     redux-devtools-extension "^2.13.8"
     redux-logger "^3.0.6"
 
-"@chainlink/styleguide@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.npmjs.org/@chainlink/styleguide/-/styleguide-0.0.2.tgz#c88a110dc8bc60d093c2cd56b3dc48811d5d2752"
-  integrity sha512-U9mKO1LSQGblOEWnlSp0shFDkqtxOOK70F6BYxNdi99aeK8AYFwpUbZnoQGleGFH6sBc6JlLz8EF2WIDn4nSDw==
+"@chainlink/styleguide@0.0.4":
+  version "0.0.4"
+  resolved "https://registry.npmjs.org/@chainlink/styleguide/-/styleguide-0.0.4.tgz#1bb0eb6fd0d0e0ad49704903c9485e5e8d7fd0e2"
+  integrity sha512-5IMtdJVFRnZDgw2h7pwvbRE8pNtu7UxGyx5GhcPhB3xenUMSpeOvHW9diOEw0S5ymEkW4qmwh9YUkpCdyN/2mA==
   dependencies:
     "@material-ui/core" "^3.9.2"
     change-case "^4.1.1"


### PR DESCRIPTION
Pivotal story: https://www.pivotaltracker.com/n/projects/2441917/stories/175242081

This will fix an issue where some non-string values are not showing up in the configuration of the operator UI.