### PR TITLE
Update hibernation mode to require both flags raised

### DIFF
--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -438,18 +438,22 @@ func (p *PollingDeviationChecker) Start() {
 }
 
 func (p *PollingDeviationChecker) setIsHibernatingStatus() {
-	if p.flagsContract != nil {
-		isHibernating, err := p.isFlagRaised()
-		if err != nil {
-			panic(err)
-		}
-		p.isHibernating = isHibernating
+	if p.flagsContract == nil {
+		p.isHibernating = false
+		return
+	}
+	isFlagLowered, err := p.isFlagLowered()
+	if err != nil {
+		logger.Errorf("unable to set hibernation status: %v", err)
+		p.isHibernating = false
+	} else {
+		p.isHibernating = !isFlagLowered
 	}
 }
 
-func (p *PollingDeviationChecker) isFlagRaised() (bool, error) {
+func (p *PollingDeviationChecker) isFlagLowered() (bool, error) {
 	if p.flagsContract == nil {
-		return false, nil
+		return true, nil
 	}
 	callOpts := bind.CallOpts{
 		Pending: false,
@@ -457,9 +461,9 @@ func (p *PollingDeviationChecker) isFlagRaised() (bool, error) {
 	}
 	flags, err := p.flagsContract.GetFlags(&callOpts, []common.Address{utils.ZeroAddress, p.initr.Address})
 	if err != nil {
-		return false, err
+		return true, err
 	}
-	return flags[0] || flags[1], nil
+	return !flags[0] || !flags[1], nil
 }
 
 // Stop stops this instance from polling, cleaning up resources.
@@ -651,30 +655,35 @@ func (p *PollingDeviationChecker) processLogs() {
 		switch log := broadcast.DecodedLog().(type) {
 		case *contracts.LogNewRound:
 			p.respondToNewRoundLog(*log)
-			err := broadcast.MarkConsumed()
+			err = broadcast.MarkConsumed()
 			if err != nil {
 				logger.Errorf("Error marking log as consumed: %v", err)
 			}
 
 		case *contracts.LogAnswerUpdated:
 			p.respondToAnswerUpdatedLog(*log)
-			err := broadcast.MarkConsumed()
+			err = broadcast.MarkConsumed()
 			if err != nil {
 				logger.Errorf("Error marking log as consumed: %v", err)
 			}
 
 		case *flags_wrapper.FlagsFlagRaised:
-			p.hibernate()
+			// check the contract before hibernating, because one flag could be lowered
+			// while the other flag remains raised
+			var isFlagLowered bool
+			isFlagLowered, err = p.isFlagLowered()
+			logger.ErrorIf(err, "Error determining if flag is still raised")
+			if !isFlagLowered {
+				p.hibernate()
+			}
+			err = broadcast.MarkConsumed()
+			logger.ErrorIf(err, "Error marking log as consumed")
 
 		case *flags_wrapper.FlagsFlagLowered:
-			// check the contract before reactivating, because one flag could be lowered
-			// while the other flag remains raised
-			raised, err := p.isFlagRaised()
-			if err != nil {
-				logger.Errorf("Error determining if flag is still raised: %v", err)
-			} else if !raised {
-				p.reactivate()
-			}
+			p.reactivate()
+			err = broadcast.MarkConsumed()
+			logger.ErrorIf(err, "Error marking log as consumed")
+
 		default:
 			logger.Errorf("unknown log %v of type %T", log, log)
 		}

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -1466,7 +1466,7 @@ func TestPollingDeviationChecker_DoesNotDoubleSubmit(t *testing.T) {
 	})
 }
 
-func TestFluxMonitor_PollingDeviationChecker_IsFlagRaised(t *testing.T) {
+func TestFluxMonitor_PollingDeviationChecker_IsFlagLowered(t *testing.T) {
 	t.Parallel()
 
 	falseFalse := "0x0000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000"
@@ -1479,10 +1479,10 @@ func TestFluxMonitor_PollingDeviationChecker_IsFlagRaised(t *testing.T) {
 		getFlagsResult string
 		expected       bool
 	}{
-		{"both lowered", falseFalse, false},
-		{"contract raised", falseTrue, true},
-		{"global raised", trueFalse, true},
-		{"both raised", trueTrue, true},
+		{"both lowered", falseFalse, true},
+		{"global lowered", falseTrue, true},
+		{"contract lowered", trueFalse, true},
+		{"both raised", trueTrue, false},
 	}
 
 	for _, tt := range tests {
@@ -1537,7 +1537,7 @@ func TestFluxMonitor_PollingDeviationChecker_IsFlagRaised(t *testing.T) {
 			)
 			require.NoError(t, err)
 
-			result, err := checker.ExportedIsFlagRaised()
+			result, err := checker.ExportedIsFlagLowered()
 			require.NoError(t, err)
 			require.Equal(t, test.expected, result)
 		})

--- a/core/services/fluxmonitor/helpers_test.go
+++ b/core/services/fluxmonitor/helpers_test.go
@@ -141,6 +141,6 @@ func (fm *concreteFluxMonitor) CreateJob(t *testing.T, jobSpecId *models.ID, pol
 	return checker.(*PollingDeviationChecker).createJobRun(polledAnswer, uint32(nextRound.Uint64()), payment)
 }
 
-func (p *PollingDeviationChecker) ExportedIsFlagRaised() (bool, error) {
-	return p.isFlagRaised()
+func (p *PollingDeviationChecker) ExportedIsFlagLowered() (bool, error) {
+	return p.isFlagLowered()
 }


### PR DESCRIPTION
Previously the FM required only one flag raised to activate hibernation mode. This PR now requires both flags to be raised.