### PR TITLE
Do ResumeAllPendingNextBlock in a single transaction

### DIFF
--- a/core/services/run_executor.go
+++ b/core/services/run_executor.go
@@ -48,6 +48,7 @@ func NewRunExecutor(store *store.Store, statsPusher synchronization.StatsPusher)
 
 // Execute performs the work associate with a job run
 func (re *runExecutor) Execute(runID *models.ID) error {
+	logger.Debugw("runExecutor woke up", "runID", runID.String())
 	run, err := re.store.Unscoped().FindJobRun(runID)
 	if err != nil {
 		return errors.Wrapf(err, "error finding run %s", runID)

--- a/core/services/run_executor.go
+++ b/core/services/run_executor.go
@@ -95,6 +95,8 @@ func (re *runExecutor) Execute(runID *models.ID) error {
 			logger.Debugw(fmt.Sprintf("Executed task %s", taskRun.TaskSpec.Type), run.ForLogger("task", taskRun.ID.String(), "elapsed", elapsed)...)
 		}
 
+		validated = true
+
 		if err := re.store.ORM.SaveJobRun(&run); errors.Cause(err) == orm.ErrOptimisticUpdateConflict {
 			logger.Debugw("Optimistic update conflict while updating run", run.ForLogger()...)
 			return nil

--- a/core/services/run_manager.go
+++ b/core/services/run_manager.go
@@ -263,7 +263,14 @@ func (rm *runManager) ResumeAllPendingNextBlock(currentBlockHeight *big.Int) err
 	err := rm.orm.Transaction(func(tx *gorm.DB) error {
 		updateTaskRunsQuery := `
 UPDATE task_runs
-   SET status = ?, confirmations = ?
+   SET status = ?, confirmations = (
+      CASE 
+      WHEN job_runs.creation_height IS NULL OR task_runs.minimum_confirmations IS NULL THEN
+        NULL
+      ELSE
+        GREATEST(0, LEAST(task_runs.minimum_confirmations, (? - job_runs.creation_height) + 1))
+      END
+   )
   FROM job_runs
  WHERE job_runs.status IN (?)
    AND task_runs.job_run_id = job_runs.id

--- a/core/services/run_manager.go
+++ b/core/services/run_manager.go
@@ -257,28 +257,24 @@ func (rm *runManager) ResumeAllPendingNextBlock(currentBlockHeight *big.Int) err
 	observedHeight := utils.NewBig(currentBlockHeight)
 
 	query := `
-WITH job_runs AS (
-	UPDATE job_runs
-	SET
-		status = ?,
-		observed_height = ?
-	WHERE status in (?)
+WITH resumable_job_runs AS (
+	UPDATE    job_runs
+	SET       status = ?,
+	          observed_height = ?
+	WHERE     status in (?)
 	RETURNING id
 )
 UPDATE task_runs
-SET
-	status = ?,
-	confirmations = ?
+SET    status = ?,
+       confirmations = ?
 WHERE
 	id = (
-		SELECT id
-		FROM task_runs
-		WHERE
-			job_run_id = (SELECT id FROM job_runs)
-			AND
-			status in (?)
+		SELECT   id
+		FROM     task_runs
+		WHERE    job_run_id = (SELECT id FROM resumable_job_runs)
+		  AND    status in (?)
 		ORDER BY task_spec_id DESC
-		LIMIT 1
+		LIMIT    1
 	)
 RETURNING job_run_id;`
 

--- a/core/services/run_manager.go
+++ b/core/services/run_manager.go
@@ -264,12 +264,12 @@ func (rm *runManager) ResumeAllPendingNextBlock(currentBlockHeight *big.Int) err
 		updateTaskRunsQuery := `
 UPDATE task_runs
    SET status = ?, confirmations = (
-      CASE 
-      WHEN job_runs.creation_height IS NULL OR task_runs.minimum_confirmations IS NULL THEN
-        NULL
-      ELSE
-        GREATEST(0, LEAST(task_runs.minimum_confirmations, (? - job_runs.creation_height) + 1))
-      END
+     CASE
+     WHEN job_runs.creation_height IS NULL OR task_runs.minimum_confirmations IS NULL THEN
+       NULL
+     ELSE
+       GREATEST(0, LEAST(task_runs.minimum_confirmations, (? - job_runs.creation_height) + 1))
+     END
    )
   FROM job_runs
  WHERE job_runs.status IN (?)

--- a/core/services/run_manager.go
+++ b/core/services/run_manager.go
@@ -265,7 +265,7 @@ func (rm *runManager) ResumeAllPendingNextBlock(currentBlockHeight *big.Int) err
 UPDATE task_runs
    SET status = ?, confirmations = (
      CASE
-     WHEN job_runs.creation_height IS NULL OR task_runs.minimum_confirmations IS NULL THEN
+		 WHEN job_runs.creation_height IS NULL OR task_runs.minimum_confirmations IS NULL OR ?::bigint IS NULL THEN
        NULL
      ELSE
        GREATEST(0, LEAST(task_runs.minimum_confirmations, (? - job_runs.creation_height) + 1))
@@ -275,7 +275,7 @@ UPDATE task_runs
  WHERE job_runs.status IN (?)
    AND task_runs.job_run_id = job_runs.id
    AND task_runs.status IN (?);`
-		result := tx.Exec(updateTaskRunsQuery, models.RunStatusInProgress, observedHeight, resumableRunStatuses, resumableTaskStatuses)
+		result := tx.Exec(updateTaskRunsQuery, models.RunStatusInProgress, observedHeight, observedHeight, resumableRunStatuses, resumableTaskStatuses)
 		if result.Error != nil {
 			return result.Error
 		}

--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -137,34 +137,6 @@ func TestRunManager_ResumeAllPendingNextBlock(t *testing.T) {
 
 	runManager := services.NewRunManager(runQueue, store.Config, store.ORM, pusher, store.TxManager, store.Clock)
 
-	t.Run("reject a run with no tasks", func(t *testing.T) {
-		run := makeJobRunWithInitiator(t, store, models.NewJob())
-		run.SetStatus(models.RunStatusPendingIncomingConfirmations)
-		require.NoError(t, store.CreateJobRun(&run))
-
-		err := runManager.ResumeAllPendingNextBlock(nil)
-		assert.NoError(t, err)
-
-		run, err = store.FindJobRun(run.ID)
-		require.NoError(t, err)
-		assert.Equal(t, models.RunStatusErrored, run.GetStatus())
-	})
-
-	t.Run("leave in pending if not enough incoming confirmations have been met yet", func(t *testing.T) {
-		run := makeJobRunWithInitiator(t, store, cltest.NewJob())
-		run.SetStatus(models.RunStatusPendingIncomingConfirmations)
-		run.TaskRuns[0].MinRequiredIncomingConfirmations = clnull.Uint32From(2)
-		require.NoError(t, store.CreateJobRun(&run))
-
-		err := runManager.ResumeAllPendingNextBlock(big.NewInt(0))
-		require.NoError(t, err)
-
-		run, err = store.FindJobRun(run.ID)
-		require.NoError(t, err)
-		assert.Equal(t, models.RunStatusPendingIncomingConfirmations, run.GetStatus())
-		assert.Equal(t, uint32(1), run.TaskRuns[0].ObservedIncomingConfirmations.Uint32)
-	})
-
 	t.Run("input, should go from pending_incoming_confirmations -> in_progress and save the input", func(t *testing.T) {
 		run := makeJobRunWithInitiator(t, store, cltest.NewJob())
 		run.SetStatus(models.RunStatusPendingIncomingConfirmations)

--- a/core/services/runs.go
+++ b/core/services/runs.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	clnull "github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/services/eth"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
@@ -31,19 +30,6 @@ func validateOnMainChain(run *models.JobRun, taskRun *models.TaskRun, ethClient 
 		)
 	}
 	return nil
-}
-
-func updateTaskRunObservedIncomingConfirmations(currentHeight *utils.Big, jr *models.JobRun, taskRun *models.TaskRun) {
-	if !taskRun.MinRequiredIncomingConfirmations.Valid || jr.CreationHeight == nil || currentHeight == nil {
-		return
-	}
-
-	confs := blockConfirmations(currentHeight, jr.CreationHeight)
-	diff := utils.MinBigs(confs, big.NewInt(int64(taskRun.MinRequiredIncomingConfirmations.Uint32)))
-
-	// diff's ceiling is guaranteed to be MaxUint32 since MinRequiredIncomingConfirmations
-	// ceiling is MaxUint32.
-	taskRun.ObservedIncomingConfirmations = clnull.Uint32From(uint32(diff.Int64()))
 }
 
 func invalidRequest(request models.RunRequest, receipt *types.Receipt) bool {

--- a/core/services/runs.go
+++ b/core/services/runs.go
@@ -7,36 +7,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/core/types"
 
-	"github.com/smartcontractkit/chainlink/core/logger"
 	clnull "github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/services/eth"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
-
-func markInProgressIfSufficientIncomingConfirmations(run *models.JobRun, taskRun *models.TaskRun, currentHeight *utils.Big, ethClient eth.Client) {
-	updateTaskRunObservedIncomingConfirmations(currentHeight, run, taskRun)
-
-	if !meetsMinRequiredIncomingConfirmations(run, taskRun, run.ObservedHeight) {
-		logger.Debugw("Pausing run pending confirmations",
-			run.ForLogger("required_height", taskRun.MinRequiredIncomingConfirmations)...,
-		)
-
-		taskRun.Status = models.RunStatusPendingIncomingConfirmations
-		run.SetStatus(models.RunStatusPendingIncomingConfirmations)
-
-	} else if err := validateOnMainChain(run, taskRun, ethClient); err != nil {
-		logger.Warnw("Failure while trying to validate chain",
-			run.ForLogger("error", err)...,
-		)
-
-		taskRun.SetError(err)
-		run.SetError(err)
-
-	} else {
-		run.SetStatus(models.RunStatusInProgress)
-	}
-}
 
 func validateOnMainChain(run *models.JobRun, taskRun *models.TaskRun, ethClient eth.Client) error {
 	txhash := run.RunRequest.TxHash

--- a/core/store/models/log_events_test.go
+++ b/core/store/models/log_events_test.go
@@ -12,6 +12,7 @@ import (
 
 	ethereum "github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -120,18 +121,21 @@ func TestStartRunOrSALogSubscription_ValidateSenders(t *testing.T) {
 			)
 			defer cleanup()
 
+			js := test.job
+			log := test.logFactory(t, js.ID, cltest.NewAddress(), test.requester, 1, `{}`)
+
 			ethMock := app.EthMock
 			logs := make(chan models.Log, 1)
 			ethMock.Context("app.Start()", func(meth *cltest.EthMock) {
 				meth.RegisterSubscription("logs", logs)
+				meth.RegisterOptional("eth_getTransactionReceipt", &types.Receipt{TxHash: cltest.NewHash(), BlockNumber: big.NewInt(1), BlockHash: log.BlockHash})
 			})
 			assert.NoError(t, app.StartAndConnect())
 
-			js := test.job
 			js.Initiators[0].Requesters = []common.Address{requester}
 			require.NoError(t, app.AddJob(js))
 
-			logs <- test.logFactory(t, js.ID, cltest.NewAddress(), test.requester, 1, `{}`)
+			logs <- log
 			ethMock.EventuallyAllCalled(t)
 
 			gomega.NewGomegaWithT(t).Eventually(func() []models.JobRun {

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -251,17 +251,6 @@ func RetryWithBackoff(ctx context.Context, fn func() (retry bool)) {
 	}
 }
 
-// MinBigs finds the minimum value of a list of big.Ints.
-func MinBigs(first *big.Int, bigs ...*big.Int) *big.Int {
-	min := first
-	for _, n := range bigs {
-		if min.Cmp(n) > 0 {
-			min = n
-		}
-	}
-	return min
-}
-
 // MaxBigs finds the maximum value of a list of big.Ints.
 func MaxBigs(first *big.Int, bigs ...*big.Int) *big.Int {
 	max := first

--- a/core/utils/utils_test.go
+++ b/core/utils/utils_test.go
@@ -2,8 +2,6 @@ package utils_test
 
 import (
 	"context"
-	"fmt"
-	"math/big"
 	"reflect"
 	"strings"
 	"sync"
@@ -229,30 +227,6 @@ func TestClient_ParseEthereumAddress(t *testing.T) {
 	assert.Error(t, notHexErr)
 	_, tooLongErr := parse("0x0123456789abcdef0123456789abcdef0123456789abcdef")
 	assert.Error(t, tooLongErr)
-}
-
-func TestMinBigs(t *testing.T) {
-	tests := []struct {
-		min, max string
-	}{
-		{"0", "0"},
-		{"-1", "0"},
-		{"99", "100"},
-		{"0", "1"},
-		{"4294967295", "4294967296"},
-	}
-
-	for _, test := range tests {
-		t.Run(fmt.Sprintf("%s < %s", test.min, test.max), func(t *testing.T) {
-			left, ok := big.NewInt(0).SetString(test.min, 10)
-			require.True(t, ok)
-			right, ok := big.NewInt(0).SetString(test.max, 10)
-			require.True(t, ok)
-
-			min := utils.MinBigs(left, right)
-			assert.Equal(t, left, min)
-		})
-	}
 }
 
 func TestMaxUint32(t *testing.T) {


### PR DESCRIPTION
Roll the operations up in ResumeAllPendingNextBlock into a single SQL transaction, which should be faster and eliminate optimistic lock failures.

This should make things much faster and reduce a cause of congestion: the calls to eth_getTransactionReceipt when loading all job runs that need to be processed for every head.

This gets moved to happen in the RunExecutor once during Run execution, which impacts a bunch of tests.