### PR TITLE
♻ + ✨ Show job name in job spec details pages

### DIFF
--- a/integration/cypress/integration/archiveJob.spec.ts
+++ b/integration/cypress/integration/archiveJob.spec.ts
@@ -16,7 +16,7 @@ context('End to end', function () {
 
     // Archive Job
     cy.get('#created-job').click()
-    cy.contains('h6', 'Job Spec Detail').should('exist')
+    cy.contains('h6', 'Job spec detail').should('exist')
     cy.clickButton('Archive')
     cy.contains('h5', 'Warning').should('exist')
     cy.get('@jobId').then((jobId) => {

--- a/integration/cypress/integration/createAndRunJob.spec.ts
+++ b/integration/cypress/integration/createAndRunJob.spec.ts
@@ -13,7 +13,7 @@ context('End to end', function () {
 
     // Run Job
     cy.get('#created-job').click()
-    cy.contains('Job Spec Detail')
+    cy.contains('Job spec detail')
     cy.clickButton('Run')
     cy.contains('p', 'Successfully created job run')
       .children('a')

--- a/integration/cypress/integration/duplicateJob.spec.ts
+++ b/integration/cypress/integration/duplicateJob.spec.ts
@@ -14,7 +14,7 @@ context('End to end', function () {
       .invoke('text')
       .as('jobId1')
     cy.get('#created-job').click()
-    cy.contains('h6', 'Job Spec Detail').should('exist')
+    cy.contains('h6', 'Job spec detail').should('exist')
 
     // Duplicate Job
     cy.clickLink('Duplicate')
@@ -24,7 +24,7 @@ context('End to end', function () {
       .invoke('text')
       .as('jobId2')
     cy.get('#created-job').click()
-    cy.contains('h6', 'Job Spec Detail').should('exist')
+    cy.contains('h6', 'Job spec detail').should('exist')
 
     // Ensure jobs IDs are different
     cy.get('@jobId1').then((jobId1) => {

--- a/operator_ui/src/pages/Jobs/Definition.test.tsx
+++ b/operator_ui/src/pages/Jobs/Definition.test.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
-import { act } from 'react-dom/test-utils'
-import { JobsDefinition } from 'pages/Jobs/Definition'
+import { JobsShow } from 'pages/Jobs/Show'
 import jsonApiJobSpecFactory from 'factories/jsonApiJobSpec'
 import { Route } from 'react-router-dom'
 import { mountWithProviders } from 'test-helpers/mountWithTheme'
-import syncFetch from 'test-helpers/syncFetch'
+import { syncFetch } from 'test-helpers/syncFetch'
 import globPath from 'test-helpers/globPath'
 
 const JOB_SPEC_ID = 'c60b9927eeae43168ddbe92584937b1b'
@@ -19,17 +18,13 @@ describe('pages/Jobs/Definition', () => {
     )
 
     const wrapper = mountWithProviders(
-      <Route path="/jobs/:jobSpecId/definition" component={JobsDefinition} />,
+      <Route path="/jobs/:jobSpecId" component={JobsShow} />,
       {
-        initialEntries: [`/jobs/${JOB_SPEC_ID}/definition`],
+        initialEntries: [`/jobs/${JOB_SPEC_ID}/json`],
       },
     )
 
-    await act(async () => {
-      await syncFetch(wrapper)
-      wrapper.update()
-    })
-
+    await syncFetch(wrapper)
     expect(wrapper.text()).toContain(
       'Definition{  "initiators": [    {      "id": 1,      "type": "web",      "jobSpecId": "c60b9927eeae43168ddbe92584937b1b"    }  ],  "tasks": [    {      "confirmations": 0,      "type": "httpget",      "params": {        "get": "https://bitstamp.net/api/ticker/"      }    }  ],  "startAt": "2020-09-22T11:49:50.410Z",  "endAt": "2020-09-22T11:59:50.410Z"}',
     )

--- a/operator_ui/src/pages/Jobs/Definition.tsx
+++ b/operator_ui/src/pages/Jobs/Definition.tsx
@@ -1,7 +1,4 @@
 import React from 'react'
-import { RouteComponentProps } from 'react-router-dom'
-import { v2 } from 'api'
-import { ApiResponse } from '@chainlink/json-api-client'
 import {
   createStyles,
   CardContent,
@@ -15,10 +12,8 @@ import {
 } from '@material-ui/core'
 import Content from 'components/Content'
 import PrettyJson from 'components/PrettyJson'
-import { JobSpec } from 'core/store/models'
 import jobSpecDefinition from 'utils/jobSpecDefinition'
-import { useErrorHandler } from 'hooks/useErrorHandler'
-import { useLoadingPlaceholder } from 'hooks/useLoadingPlaceholder'
+import { JobData } from './sharedTypes'
 
 const definitionStyles = (theme: Theme) =>
   createStyles({
@@ -33,27 +28,19 @@ const definitionStyles = (theme: Theme) =>
   })
 
 const Definition: React.FC<
-  RouteComponentProps<{
-    jobSpecId: string
-  }> &
-    WithStyles<typeof definitionStyles>
-> = ({ classes, match }) => {
-  const { jobSpecId } = match.params
-
-  const [jobSpec, setJobSpec] = React.useState<ApiResponse<JobSpec>['data']>()
-  const { error, ErrorComponent, setError } = useErrorHandler()
-  const { LoadingPlaceholder } = useLoadingPlaceholder(!error && !jobSpec)
-
+  {
+    error: unknown
+    ErrorComponent: React.FC
+    LoadingPlaceholder: React.FC
+    jobSpec?: JobData['jobSpec']
+  } & WithStyles<typeof definitionStyles>
+> = ({ classes, error, ErrorComponent, LoadingPlaceholder, jobSpec }) => {
   React.useEffect(() => {
-    document.title = 'Job Definition'
-  }, [])
-
-  React.useEffect(() => {
-    v2.specs
-      .getJobSpec(jobSpecId)
-      .then((response) => setJobSpec(response.data))
-      .catch(setError)
-  }, [jobSpecId, setError])
+    document.title =
+      jobSpec && jobSpec.attributes.name
+        ? `${jobSpec.attributes.name} | Job definition`
+        : 'Job definition'
+  }, [jobSpec])
 
   return (
     <Content>

--- a/operator_ui/src/pages/Jobs/Errors.test.tsx
+++ b/operator_ui/src/pages/Jobs/Errors.test.tsx
@@ -1,10 +1,9 @@
 import React from 'react'
-import { act } from 'react-dom/test-utils'
-import { JobsErrors } from 'pages/Jobs/Errors'
+import { JobsShow } from 'pages/Jobs/Show'
 import jsonApiJobSpecFactory from 'factories/jsonApiJobSpec'
 import { Route } from 'react-router-dom'
 import { mountWithProviders } from 'test-helpers/mountWithTheme'
-import syncFetch from 'test-helpers/syncFetch'
+import { syncFetch } from 'test-helpers/syncFetch'
 import globPath from 'test-helpers/globPath'
 
 const JOB_SPEC_ID = 'c60b9927eeae43168ddbe92584937b1b'
@@ -19,7 +18,7 @@ const errors = [
   },
   {
     createdAt: '2020-10-16T13:18:46.519087+01:00',
-    description: 'Another error',
+    description: '2nd error',
     id: 2,
     occurrences: 1,
     updatedAt: '2020-10-16T13:18:46.519087+01:00',
@@ -43,16 +42,13 @@ describe('pages/Jobs/Errors', () => {
     )
 
     const wrapper = mountWithProviders(
-      <Route path="/jobs/:jobSpecId/errors" component={JobsErrors} />,
+      <Route path="/jobs/:jobSpecId" component={JobsShow} />,
       {
         initialEntries: [`/jobs/${JOB_SPEC_ID}/errors`],
       },
     )
 
-    await act(async () => {
-      await syncFetch(wrapper)
-      wrapper.update()
-    })
+    await syncFetch(wrapper)
 
     expect(wrapper.text()).toContain('Unable to start job subscription')
     expect(wrapper.find('tbody').children().length).toEqual(3)
@@ -63,6 +59,7 @@ describe('pages/Jobs/Errors', () => {
       globPath(`/v2/specs/${JOB_SPEC_ID}`),
       jsonApiJobSpecFactory({
         id: JOB_SPEC_ID,
+        // Intentionally returning 1 result to make sure that we do the correct check
         errors: errors.slice().splice(0, 1),
       }),
     )
@@ -72,12 +69,8 @@ describe('pages/Jobs/Errors', () => {
     // Check that optimistic delete works
     expect(wrapper.find('tbody').children().length).toEqual(2)
 
-    await act(async () => {
-      await syncFetch(wrapper)
-      wrapper.update()
-    })
+    await syncFetch(wrapper)
 
-    // Check that server delete works
-    expect(wrapper.find('tbody').children().length).toEqual(2)
+    expect(wrapper.find('tbody').children().length).toEqual(1)
   })
 })

--- a/operator_ui/src/pages/Jobs/Index.test.tsx
+++ b/operator_ui/src/pages/Jobs/Index.test.tsx
@@ -1,9 +1,8 @@
 /* eslint-env jest */
 import React from 'react'
 import { Route } from 'react-router-dom'
-import { act } from 'react-dom/test-utils'
 import { jsonApiJobSpecs } from 'factories/jsonApiJobSpecs'
-import syncFetch from 'test-helpers/syncFetch'
+import { syncFetch } from 'test-helpers/syncFetch'
 import globPath from 'test-helpers/globPath'
 import { mountWithProviders } from 'test-helpers/mountWithTheme'
 import { JobsIndex, simpleJobFilter } from 'pages/Jobs/Index'
@@ -24,9 +23,7 @@ describe('pages/Jobs/Index', () => {
 
     const wrapper = mountWithProviders(<Route component={JobsIndex} />)
 
-    await act(async () => {
-      await syncFetch(wrapper)
-    })
+    await syncFetch(wrapper)
     expect(wrapper.text()).toContain('c60b9927eeae43168ddbe92584937b1b')
     expect(wrapper.text()).toContain('web')
     expect(wrapper.text()).toContain('just now')
@@ -58,10 +55,7 @@ describe('pages/Jobs/Index', () => {
 
     const wrapper = mountWithProviders(<Route component={JobsIndex} />)
 
-    await act(async () => {
-      await syncFetch(wrapper)
-    })
-    wrapper.update()
+    await syncFetch(wrapper)
 
     // Expect to have 3 jobs initially
     expect(wrapper.find('tbody').children().length).toEqual(3)

--- a/operator_ui/src/pages/Jobs/Index.tsx
+++ b/operator_ui/src/pages/Jobs/Index.tsx
@@ -141,16 +141,22 @@ export const JobsIndex = ({ history }: RouteChildrenProps<{}>) => {
                         key={job.id}
                         onClick={() => history.push(`/jobs/${job.id}`)}
                       >
-                        <TableCell>
-                          {job.attributes.name || '-'}
-                          <br />
-                          <Typography
-                            variant="subtitle2"
-                            color="textSecondary"
-                            component="span"
-                          >
-                            {job.id}
-                          </Typography>
+                        <TableCell component="th" scope="row">
+                          <Link href={`/jobs/${job.id}`}>
+                            {job.attributes.name || job.id}
+                            {job.attributes.name && (
+                              <>
+                                <br />
+                                <Typography
+                                  variant="subtitle2"
+                                  color="textSecondary"
+                                  component="span"
+                                >
+                                  {job.id}
+                                </Typography>
+                              </>
+                            )}
+                          </Link>
                         </TableCell>
                         <TableCell>
                           <Typography variant="body1">

--- a/operator_ui/src/pages/Jobs/RecentRuns.tsx
+++ b/operator_ui/src/pages/Jobs/RecentRuns.tsx
@@ -1,0 +1,151 @@
+import { CardTitle, KeyValueList } from '@chainlink/styleguide'
+import {
+  createStyles,
+  Theme,
+  Typography,
+  WithStyles,
+  withStyles,
+  Card,
+  Grid,
+} from '@material-ui/core'
+import Content from 'components/Content'
+import JobRunsList from 'components/JobRuns/List'
+import TaskList from 'components/Jobs/TaskList'
+import React from 'react'
+import { GWEI_PER_TOKEN } from 'utils/constants'
+import formatMinPayment from 'utils/formatWeiAsset'
+import { formatInitiators } from 'utils/jobSpecInitiators'
+import { JobData } from './sharedTypes'
+
+const totalLinkEarned = (job: NonNullable<JobData['jobSpec']>) => {
+  const zero = '0.000000'
+  const unformatted =
+    job.attributes.earnings &&
+    (job.attributes.earnings / GWEI_PER_TOKEN).toString()
+  const formatted =
+    unformatted &&
+    (unformatted.length >= 3 ? unformatted : (unformatted + '.').padEnd(8, '0'))
+  return formatted || zero
+}
+
+const chartCardStyles = (theme: Theme) =>
+  createStyles({
+    wrapper: {
+      marginLeft: theme.spacing.unit * 3,
+      marginTop: theme.spacing.unit * 2,
+      marginBottom: theme.spacing.unit * 2,
+    },
+    paymentText: {
+      color: theme.palette.secondary.main,
+      fontWeight: 450,
+    },
+    earnedText: {
+      color: theme.palette.text.secondary,
+      fontSize: theme.spacing.unit * 2,
+    },
+  })
+
+interface ChartProps extends WithStyles<typeof chartCardStyles> {
+  jobSpec: NonNullable<JobData['jobSpec']>
+}
+
+const ChartArea = withStyles(chartCardStyles)(
+  ({ classes, jobSpec }: ChartProps) => (
+    <Card>
+      <Grid item className={classes.wrapper}>
+        <Typography className={classes.paymentText} variant="h5">
+          Link Payment
+        </Typography>
+        <Typography className={classes.earnedText}>
+          {totalLinkEarned(jobSpec)}
+        </Typography>
+      </Grid>
+    </Card>
+  ),
+)
+
+export const RecentRuns = ({
+  ErrorComponent,
+  LoadingPlaceholder,
+  error,
+  getJobSpecRuns,
+  jobSpec,
+  recentRuns,
+  recentRunsCount,
+  showJobRunsCount = 5,
+}: {
+  ErrorComponent: React.FC
+  LoadingPlaceholder: React.FC
+  error: unknown
+  getJobSpecRuns: () => Promise<void>
+  jobSpec?: JobData['jobSpec']
+  recentRuns?: JobData['recentRuns']
+  recentRunsCount: JobData['recentRunsCount']
+  showJobRunsCount?: number
+}) => {
+  React.useEffect(() => {
+    document.title =
+      jobSpec && jobSpec.attributes.name
+        ? `${jobSpec.attributes.name} | Job spec details`
+        : 'Job spec details'
+  }, [jobSpec])
+
+  React.useEffect(() => {
+    getJobSpecRuns()
+  }, [getJobSpecRuns])
+
+  return (
+    <Content>
+      <ErrorComponent />
+      <LoadingPlaceholder />
+      {!error && jobSpec && (
+        <Grid container spacing={24}>
+          <Grid item xs={8}>
+            <Card>
+              <CardTitle divider>Recent Job Runs</CardTitle>
+
+              {recentRuns && (
+                <JobRunsList
+                  jobSpecId={jobSpec.id}
+                  runs={recentRuns.map((jobRun) => ({
+                    ...jobRun,
+                    ...jobRun.attributes,
+                  }))}
+                  count={recentRunsCount}
+                  showJobRunsCount={showJobRunsCount}
+                />
+              )}
+            </Card>
+          </Grid>
+          <Grid item xs={4}>
+            <Grid container direction="column">
+              <Grid item xs>
+                <ChartArea jobSpec={jobSpec} />
+              </Grid>
+              <Grid item xs>
+                <Card>
+                  <CardTitle divider>Task List</CardTitle>
+                  <TaskList tasks={jobSpec.attributes.tasks} />
+                </Card>
+              </Grid>
+              <Grid item xs>
+                <KeyValueList
+                  showHead={false}
+                  entries={Object.entries({
+                    runCount: recentRunsCount,
+                    initiator: formatInitiators(jobSpec.attributes.initiators),
+                    minimumPayment: `${
+                      formatMinPayment(Number(jobSpec.attributes.minPayment)) ||
+                      0
+                    } Link`,
+                  })}
+                  titleize
+                />
+              </Grid>
+            </Grid>
+          </Grid>
+        </Grid>
+      )}
+    </Content>
+  )
+}

--- a/operator_ui/src/pages/Jobs/RegionalNav.tsx
+++ b/operator_ui/src/pages/Jobs/RegionalNav.tsx
@@ -215,6 +215,11 @@ const RegionalNavComponent = ({
       <Card className={classes.container}>
         <Grid container spacing={0}>
           <Grid item xs={12}>
+            <Typography variant="subtitle2" color="secondary" gutterBottom>
+              Job spec detail
+            </Typography>
+          </Grid>
+          <Grid item xs={12}>
             <Grid
               container
               spacing={0}

--- a/operator_ui/src/pages/Jobs/RegionalNav.tsx
+++ b/operator_ui/src/pages/Jobs/RegionalNav.tsx
@@ -227,7 +227,7 @@ const RegionalNavComponent = ({
                   color="secondary"
                   className={classes.jobSpecId}
                 >
-                  {(job && job.attributes.name) || jobSpecId}
+                  {job?.attributes.name || jobSpecId}
                 </Typography>
               </Grid>
               <Grid item xs={6} className={classes.actions}>
@@ -267,14 +267,14 @@ const RegionalNavComponent = ({
             </Grid>
           </Grid>
           <Grid item xs={12}>
-            {job && job.attributes.name && (
+            {job?.attributes.name && (
               <Typography variant="subtitle2" color="secondary" gutterBottom>
                 {job.attributes.id}
               </Typography>
             )}
             <Typography variant="subtitle2" color="textSecondary">
               Created{' '}
-              {job && job.attributes.createdAt && (
+              {job?.attributes.createdAt && (
                 <>
                   <TimeAgo tooltip={false}>{job.attributes.createdAt}</TimeAgo>{' '}
                   ({localizedTimestamp(job.attributes.createdAt)})

--- a/operator_ui/src/pages/Jobs/RegionalNav.tsx
+++ b/operator_ui/src/pages/Jobs/RegionalNav.tsx
@@ -24,7 +24,7 @@ import Link from 'components/Link'
 import ErrorMessage from 'components/Notifications/DefaultError'
 import jobSpecDefinition from 'utils/jobSpecDefinition'
 import { isWebInitiator } from 'utils/jobSpecInitiators'
-import { JobData } from './Show'
+import { JobData } from './sharedTypes'
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -215,11 +215,6 @@ const RegionalNavComponent = ({
       <Card className={classes.container}>
         <Grid container spacing={0}>
           <Grid item xs={12}>
-            <Typography variant="subtitle2" color="secondary" gutterBottom>
-              Job Spec Detail
-            </Typography>
-          </Grid>
-          <Grid item xs={12}>
             <Grid
               container
               spacing={0}
@@ -232,7 +227,7 @@ const RegionalNavComponent = ({
                   color="secondary"
                   className={classes.jobSpecId}
                 >
-                  {jobSpecId}
+                  {(job && job.attributes.name) || jobSpecId}
                 </Typography>
               </Grid>
               <Grid item xs={6} className={classes.actions}>
@@ -272,6 +267,11 @@ const RegionalNavComponent = ({
             </Grid>
           </Grid>
           <Grid item xs={12}>
+            {job && job.attributes.name && (
+              <Typography variant="subtitle2" color="secondary" gutterBottom>
+                {job.attributes.id}
+              </Typography>
+            )}
             <Typography variant="subtitle2" color="textSecondary">
               Created{' '}
               {job && job.attributes.createdAt && (

--- a/operator_ui/src/pages/Jobs/Show.test.tsx
+++ b/operator_ui/src/pages/Jobs/Show.test.tsx
@@ -1,4 +1,3 @@
-import { act } from 'react-dom/test-utils'
 import { JobsShow } from 'pages/Jobs/Show'
 import jsonApiJobSpecFactory from 'factories/jsonApiJobSpec'
 import jsonApiJobSpecRunsFactory from 'factories/jsonApiJobSpecRuns'
@@ -6,7 +5,7 @@ import React from 'react'
 import { Route } from 'react-router-dom'
 import isoDate, { MINUTE_MS } from 'test-helpers/isoDate'
 import { mountWithProviders } from 'test-helpers/mountWithTheme'
-import syncFetch from 'test-helpers/syncFetch'
+import { syncFetch } from 'test-helpers/syncFetch'
 import globPath from 'test-helpers/globPath'
 import { GWEI_PER_TOKEN, WEI_PER_TOKEN } from 'utils/constants'
 
@@ -43,9 +42,7 @@ describe('pages/Jobs/Show', () => {
       },
     )
 
-    await act(async () => {
-      await syncFetch(wrapper)
-    })
+    await syncFetch(wrapper)
     expect(wrapper.text()).toContain('c60b9927eeae43168ddbe92584937b1b')
     expect(wrapper.text()).toContain('Initiatorweb')
     expect(wrapper.text()).toContain('Created a minute ago')
@@ -82,9 +79,7 @@ describe('pages/Jobs/Show', () => {
       },
     )
 
-    await act(async () => {
-      await syncFetch(wrapper)
-    })
+    await syncFetch(wrapper)
     expect(wrapper.text()).toContain('View More')
   })
 
@@ -111,11 +106,7 @@ describe('pages/Jobs/Show', () => {
         },
       )
 
-      await act(async () => {
-        await syncFetch(wrapper)
-        wrapper.update()
-      })
-      wrapper.update()
+      await syncFetch(wrapper)
 
       expect(wrapper.find('tbody').first().children().length).toEqual(1)
 
@@ -128,11 +119,8 @@ describe('pages/Jobs/Show', () => {
         ),
       )
       wrapper.find('Button').find({ children: 'Run' }).first().simulate('click')
-      await act(async () => {
-        await syncFetch(wrapper)
-      })
 
-      wrapper.update()
+      await syncFetch(wrapper)
 
       expect(wrapper.find('tbody').first().children().length).toEqual(2)
     })

--- a/operator_ui/src/pages/Jobs/Show.tsx
+++ b/operator_ui/src/pages/Jobs/Show.tsx
@@ -1,98 +1,27 @@
-import { CardTitle, KeyValueList } from '@chainlink/styleguide'
-import {
-  createStyles,
-  Theme,
-  Typography,
-  WithStyles,
-  withStyles,
-  Card,
-  Grid,
-} from '@material-ui/core'
+import React from 'react'
 import { v2 } from 'api'
 import { Route, RouteComponentProps, Switch } from 'react-router-dom'
-import Content from 'components/Content'
-import JobRunsList from 'components/JobRuns/List'
-import TaskList from 'components/Jobs/TaskList'
-import React from 'react'
-import { GWEI_PER_TOKEN } from 'utils/constants'
-import formatMinPayment from 'utils/formatWeiAsset'
-import { formatInitiators } from 'utils/jobSpecInitiators'
-import { JobsDefinition } from './Definition'
-import { JobsErrors } from './Errors'
-import { RegionalNav } from './RegionalNav'
-import { ApiResponse, PaginatedApiResponse } from '@chainlink/json-api-client'
-import { JobSpec, JobRun } from 'core/store/models'
 import { useErrorHandler } from 'hooks/useErrorHandler'
 import { useLoadingPlaceholder } from 'hooks/useLoadingPlaceholder'
+import { JobData } from './sharedTypes'
+import { JobsDefinition } from './Definition'
+import { JobsErrors } from './Errors'
+import { RecentRuns } from './RecentRuns'
+import { RegionalNav } from './RegionalNav'
 
-export type JobData = {
-  jobSpec?: ApiResponse<JobSpec>['data']
-  recentRuns?: PaginatedApiResponse<JobRun[]>['data']
-  recentRunsCount: number
-}
-
-const totalLinkEarned = (job: NonNullable<JobData['jobSpec']>) => {
-  const zero = '0.000000'
-  const unformatted =
-    job.attributes.earnings &&
-    (job.attributes.earnings / GWEI_PER_TOKEN).toString()
-  const formatted =
-    unformatted &&
-    (unformatted.length >= 3 ? unformatted : (unformatted + '.').padEnd(8, '0'))
-  return formatted || zero
-}
-
-const chartCardStyles = (theme: Theme) =>
-  createStyles({
-    wrapper: {
-      marginLeft: theme.spacing.unit * 3,
-      marginTop: theme.spacing.unit * 2,
-      marginBottom: theme.spacing.unit * 2,
-    },
-    paymentText: {
-      color: theme.palette.secondary.main,
-      fontWeight: 450,
-    },
-    earnedText: {
-      color: theme.palette.text.secondary,
-      fontSize: theme.spacing.unit * 2,
-    },
-  })
-
-interface ChartProps extends WithStyles<typeof chartCardStyles> {
-  jobSpec: NonNullable<JobData['jobSpec']>
-}
-
-const ChartArea = withStyles(chartCardStyles)(
-  ({ classes, jobSpec }: ChartProps) => (
-    <Card>
-      <Grid item className={classes.wrapper}>
-        <Typography className={classes.paymentText} variant="h5">
-          Link Payment
-        </Typography>
-        <Typography className={classes.earnedText}>
-          {totalLinkEarned(jobSpec)}
-        </Typography>
-      </Grid>
-    </Card>
-  ),
-)
-
-type Props = {
-  showJobRunsCount: number
-} & RouteComponentProps<{
+type Props = RouteComponentProps<{
   jobSpecId: string
 }>
 
 const DEFAULT_PAGE = 1
 const RECENT_RUNS_COUNT = 5
 
-export const JobsShow: React.FC<Props> = ({ match, showJobRunsCount = 5 }) => {
+export const JobsShow: React.FC<Props> = ({ match }) => {
   const [state, setState] = React.useState<JobData>({
     recentRuns: [],
     recentRunsCount: 0,
   })
-  const { jobSpec, recentRuns, recentRunsCount } = state
+  const { jobSpec } = state
   const { error, ErrorComponent, setError } = useErrorHandler()
   const { LoadingPlaceholder } = useLoadingPlaceholder(!error && !jobSpec)
 
@@ -117,18 +46,23 @@ export const JobsShow: React.FC<Props> = ({ match, showJobRunsCount = 5 }) => {
     [jobSpecId, setError],
   )
 
+  const getJobSpec = React.useCallback(
+    async () =>
+      v2.specs
+        .getJobSpec(jobSpecId)
+        .then((response) =>
+          setState((s) => ({
+            ...s,
+            jobSpec: response.data,
+          })),
+        )
+        .catch(setError),
+    [jobSpecId, setError],
+  )
+
   React.useEffect(() => {
-    v2.specs
-      .getJobSpec(jobSpecId)
-      .then((jobSpecResponse) => {
-        setState((s) => ({
-          ...s,
-          jobSpec: jobSpecResponse.data,
-        }))
-      })
-      .catch(setError)
-    getJobSpecRuns()
-  }, [getJobSpecRuns, jobSpecId, setError])
+    getJobSpec()
+  }, [getJobSpec])
 
   return (
     <div>
@@ -138,66 +72,46 @@ export const JobsShow: React.FC<Props> = ({ match, showJobRunsCount = 5 }) => {
         getJobSpecRuns={getJobSpecRuns}
       />
       <Switch>
-        <Route path={`${match.path}/json`} component={JobsDefinition} />
-        <Route path={`${match.path}/errors`} component={JobsErrors} />
+        <Route
+          path={`${match.path}/json`}
+          render={() => (
+            <JobsDefinition
+              {...{
+                ...state,
+                ErrorComponent,
+                LoadingPlaceholder,
+                error,
+              }}
+            />
+          )}
+        />
+        <Route
+          path={`${match.path}/errors`}
+          render={() => (
+            <JobsErrors
+              {...{
+                ...state,
+                ErrorComponent,
+                LoadingPlaceholder,
+                error,
+                getJobSpec,
+                setState,
+              }}
+            />
+          )}
+        />
         <Route
           path={`${match.path}`}
           render={() => (
-            <Content>
-              <ErrorComponent />
-              <LoadingPlaceholder />
-              {!error && jobSpec && (
-                <Grid container spacing={24}>
-                  <Grid item xs={8}>
-                    <Card>
-                      <CardTitle divider>Recent Job Runs</CardTitle>
-
-                      {recentRuns && (
-                        <JobRunsList
-                          jobSpecId={jobSpec.id}
-                          runs={recentRuns.map((jobRun) => ({
-                            ...jobRun,
-                            ...jobRun.attributes,
-                          }))}
-                          count={recentRunsCount}
-                          showJobRunsCount={showJobRunsCount}
-                        />
-                      )}
-                    </Card>
-                  </Grid>
-                  <Grid item xs={4}>
-                    <Grid container direction="column">
-                      <Grid item xs>
-                        <ChartArea jobSpec={jobSpec} />
-                      </Grid>
-                      <Grid item xs>
-                        <Card>
-                          <CardTitle divider>Task List</CardTitle>
-                          <TaskList tasks={jobSpec.attributes.tasks} />
-                        </Card>
-                      </Grid>
-                      <Grid item xs>
-                        <KeyValueList
-                          showHead={false}
-                          entries={Object.entries({
-                            runCount: recentRunsCount,
-                            initiator: formatInitiators(
-                              jobSpec.attributes.initiators,
-                            ),
-                            minimumPayment: `${
-                              formatMinPayment(
-                                Number(jobSpec.attributes.minPayment),
-                              ) || 0
-                            } Link`,
-                          })}
-                          titleize
-                        />
-                      </Grid>
-                    </Grid>
-                  </Grid>
-                </Grid>
-              )}
-            </Content>
+            <RecentRuns
+              {...{
+                ...state,
+                error,
+                ErrorComponent,
+                LoadingPlaceholder,
+                getJobSpecRuns,
+              }}
+            />
           )}
         />
       </Switch>

--- a/operator_ui/src/pages/Jobs/sharedTypes.ts
+++ b/operator_ui/src/pages/Jobs/sharedTypes.ts
@@ -1,0 +1,8 @@
+import { ApiResponse, PaginatedApiResponse } from '@chainlink/json-api-client'
+import { JobSpec, JobRun } from 'core/store/models'
+
+export type JobData = {
+  jobSpec?: ApiResponse<JobSpec>['data']
+  recentRuns?: PaginatedApiResponse<JobRun[]>['data']
+  recentRunsCount: number
+}

--- a/operator_ui/support/test-helpers/syncFetch.js
+++ b/operator_ui/support/test-helpers/syncFetch.js
@@ -1,3 +1,19 @@
+import { act } from 'react-dom/test-utils'
+
+export const syncFetch = async (wrapper) => {
+  await act(async () => {
+    await global.fetch
+      .flush()
+      .then(() => wrapper.update()) // Render after AJAX request changes state
+      .then(() => wrapper.update()) // Bug in enzyme, can't query conditional fragments without another sync
+  })
+
+  // We want to update the wrapper after the fetch is done.
+  // This is because if you wrap global.fetch.flush() in an
+  // act() block they get executed in the same event loop cycle.
+  wrapper.update()
+}
+
 export default (wrapper) => {
   return global.fetch
     .flush()


### PR DESCRIPTION
### Quick notes
- Had to create a "RecentRuns" component to correctly trigger a document.title change when navigating between Overview/JSON/Errors tabs.
- Fork upgrade to `syncFetch` to reduce duplicate code in tests.


### Screen capture
![Job spec name](https://user-images.githubusercontent.com/9297294/96868873-8ecdbe00-1466-11eb-8fc6-a15d35f84eeb.gif)
