### PR TITLE
Operator Contract - Remove redundant event params

### DIFF
--- a/evm-contracts/src/v0.7/dev/Operator.sol
+++ b/evm-contracts/src/v0.7/dev/Operator.sol
@@ -49,12 +49,7 @@ contract Operator is
   );
 
   event OracleResponse(
-    bytes32 indexed requestId,
-    uint256 payment,
-    address callbackAddress,
-    bytes4 callbackFunctionId,
-    uint256 expiration,
-    bytes32 data
+    bytes32 indexed requestId
   );
 
   /**
@@ -160,13 +155,7 @@ contract Operator is
     require(s_commitments[requestId] == paramsHash, "Params do not match request ID");
     s_withdrawableTokens = s_withdrawableTokens.add(payment);
     delete s_commitments[requestId];
-    emit OracleResponse(
-      requestId,
-      payment,
-      callbackAddress,
-      callbackFunctionId,
-      expiration,
-      data);
+    emit OracleResponse(requestId);
     require(gasleft() >= MINIMUM_CONSUMER_GAS_LIMIT, "Must provide consumer enough gas");
     // All updates to the oracle's fulfillment should come before calling the
     // callback(addr+functionId) as it is untrusted.

--- a/evm-contracts/test/v0.7/Operator.test.ts
+++ b/evm-contracts/test/v0.7/Operator.test.ts
@@ -340,7 +340,6 @@ describe('Operator', () => {
         const responseEvent = receipt.events?.[0]
         assert.equal(responseEvent?.event, 'OracleResponse')
         assert.equal(responseEvent?.args?.[0], request.requestId)
-        assert.equal(responseEvent?.args?.[5], fulfillParams[5])
       })
     })
 
@@ -409,7 +408,6 @@ describe('Operator', () => {
           const responseEvent = receipt.events?.[0]
           assert.equal(responseEvent?.event, 'OracleResponse')
           assert.equal(responseEvent?.args?.[0], request.requestId)
-          assert.equal(responseEvent?.args?.[5], fulfillParams[5])
         })
 
         it('does not allow a request to be fulfilled twice', async () => {


### PR DESCRIPTION
Removed all but `requestId` from the `OracleResponse` event.