### PR TITLE
Remove redundant `Link` from `/jobs`

### DIFF
--- a/operator_ui/src/pages/Jobs/Index.tsx
+++ b/operator_ui/src/pages/Jobs/Index.tsx
@@ -142,21 +142,19 @@ export const JobsIndex = ({ history }: RouteChildrenProps<{}>) => {
                         onClick={() => history.push(`/jobs/${job.id}`)}
                       >
                         <TableCell component="th" scope="row">
-                          <Link href={`/jobs/${job.id}`}>
-                            {job.attributes.name || job.id}
-                            {job.attributes.name && (
-                              <>
-                                <br />
-                                <Typography
-                                  variant="subtitle2"
-                                  color="textSecondary"
-                                  component="span"
-                                >
-                                  {job.id}
-                                </Typography>
-                              </>
-                            )}
-                          </Link>
+                          {job.attributes.name || job.id}
+                          {job.attributes.name && (
+                            <>
+                              <br />
+                              <Typography
+                                variant="subtitle2"
+                                color="textSecondary"
+                                component="span"
+                              >
+                                {job.id}
+                              </Typography>
+                            </>
+                          )}
                         </TableCell>
                         <TableCell>
                           <Typography variant="body1">


### PR DESCRIPTION
The `Link` component is redundant because the row already links to the job details page on click.