### PR TITLE
🐛 Update "start" command for webpack-cli@v4

### DIFF
--- a/operator_ui/package.json
+++ b/operator_ui/package.json
@@ -7,7 +7,7 @@
     "node": "^12.0.0"
   },
   "scripts": {
-    "start": "NODE_ENV=development webpack-dev-server --open",
+    "start": "webpack serve --env development",
     "serve": "serve dist -p 3000",
     "test": "jest",
     "test:ci": "yarn test --reporters jest-silent-reporter --maxWorkers=50%",


### PR DESCRIPTION
`yarn start` stopped working after an upgrade to `webpack-cli@4.1.0`. This PR fixes that.