### PR TITLE
Add index and show endpoints for OCR job specs

### DIFF
--- a/core/store/models/address.go
+++ b/core/store/models/address.go
@@ -7,11 +7,9 @@ import (
 	"math/big"
 	"strings"
 
-	"github.com/smartcontractkit/chainlink/core/logger"
-
-	"github.com/smartcontractkit/chainlink/core/utils"
-
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
 // EIP55Address is a newtype for string which persists an ethereum address in

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -684,6 +684,27 @@ func Merge(inputs ...JSON) (JSON, error) {
 // Explicit type indicating a 32-byte sha256 hash
 type Sha256Hash [32]byte
 
+// MarshalJSON converts a Sha256Hash to a JSON byte slice.
+func (s Sha256Hash) MarshalJSON() ([]byte, error) {
+	return json.Marshal(s.String())
+}
+
+// UnmarshalJSON converts a bytes slice of JSON to a TaskType.
+func (s *Sha256Hash) UnmarshalJSON(input []byte) error {
+	var shaHash string
+	if err := json.Unmarshal(input, &shaHash); err != nil {
+		return err
+	}
+
+	sha, err := Sha256HashFromHex(shaHash)
+	if err != nil {
+		return err
+	}
+
+	*s = sha
+	return nil
+}
+
 func Sha256HashFromHex(x string) (Sha256Hash, error) {
 	bs, err := hex.DecodeString(x)
 	if err != nil {

--- a/core/store/models/job_spec_v2.go
+++ b/core/store/models/job_spec_v2.go
@@ -3,6 +3,7 @@ package models
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"fmt"
 	"strconv"
 	"time"
 
@@ -13,39 +14,56 @@ import (
 
 type (
 	JobSpecV2 struct {
-		ID                            int32 `gorm:"primary_key"`
-		OffchainreportingOracleSpecID int32
-		OffchainreportingOracleSpec   *OffchainReportingOracleSpec `gorm:"save_association:true;association_autoupdate:true;association_autocreate:true"`
-		PipelineSpecID                int32
+		ID                            int32                        `json:"-" gorm:"primary_key"`
+		OffchainreportingOracleSpecID int32                        `json:"-"`
+		OffchainreportingOracleSpec   *OffchainReportingOracleSpec `json:"offChainReportingOracleSpec" gorm:"save_association:true;association_autoupdate:true;association_autocreate:true"`
+		PipelineSpecID                int32                        `json:"-"`
 	}
 
 	OffchainReportingOracleSpec struct {
-		ID                                     int32          `toml:"-"                 gorm:"primary_key"`
-		ContractAddress                        EIP55Address   `toml:"contractAddress"`
-		P2PPeerID                              PeerID         `toml:"p2pPeerID"         gorm:"column:p2p_peer_id"`
-		P2PBootstrapPeers                      pq.StringArray `toml:"p2pBootstrapPeers" gorm:"column:p2p_bootstrap_peers;type:text[]"`
-		IsBootstrapPeer                        bool           `toml:"isBootstrapPeer"`
-		EncryptedOCRKeyBundleID                Sha256Hash     `toml:"keyBundleID"                 gorm:"type:bytea"`
-		MonitoringEndpoint                     string         `toml:"monitoringEndpoint"`
-		TransmitterAddress                     EIP55Address   `toml:"transmitterAddress"`
-		ObservationTimeout                     Interval       `toml:"observationTimeout" gorm:"type:bigint"`
-		BlockchainTimeout                      Interval       `toml:"blockchainTimeout" gorm:"type:bigint"`
-		ContractConfigTrackerSubscribeInterval Interval       `toml:"contractConfigTrackerSubscribeInterval"`
-		ContractConfigTrackerPollInterval      Interval       `toml:"contractConfigTrackerPollInterval" gorm:"type:bigint"`
-		ContractConfigConfirmations            uint16         `toml:"contractConfigConfirmations"`
-		CreatedAt                              time.Time      `toml:"-"`
-		UpdatedAt                              time.Time      `toml:"-"`
+		ID                                     int32          `json:"-" toml:"-"                 gorm:"primary_key"`
+		ContractAddress                        EIP55Address   `json:"contractAddress" toml:"contractAddress"`
+		P2PPeerID                              PeerID         `json:"p2pPeerID" toml:"p2pPeerID"         gorm:"column:p2p_peer_id"`
+		P2PBootstrapPeers                      pq.StringArray `json:"p2pBootstrapPeers" toml:"p2pBootstrapPeers" gorm:"column:p2p_bootstrap_peers;type:text[]"`
+		IsBootstrapPeer                        bool           `json:"isBootstrapPeer" toml:"isBootstrapPeer"`
+		EncryptedOCRKeyBundleID                Sha256Hash     `json:"keyBundleID" toml:"keyBundleID"                 gorm:"type:bytea"`
+		MonitoringEndpoint                     string         `json:"monitoringEndpoint" toml:"monitoringEndpoint"`
+		TransmitterAddress                     EIP55Address   `json:"transmitterAddress" toml:"transmitterAddress"`
+		ObservationTimeout                     Interval       `json:"observationTimeout" toml:"observationTimeout" gorm:"type:bigint"`
+		BlockchainTimeout                      Interval       `json:"blockchainTimeout" toml:"blockchainTimeout" gorm:"type:bigint"`
+		ContractConfigTrackerSubscribeInterval Interval       `json:"contractConfigTrackerSubscribeInterval" toml:"contractConfigTrackerSubscribeInterval"`
+		ContractConfigTrackerPollInterval      Interval       `json:"contractConfigTrackerPollInterval" toml:"contractConfigTrackerPollInterval" gorm:"type:bigint"`
+		ContractConfigConfirmations            uint16         `json:"contractConfigConfirmations" toml:"contractConfigConfirmations"`
+		CreatedAt                              time.Time      `json:"createdAt" toml:"-"`
+		UpdatedAt                              time.Time      `json:"updatedAt" toml:"-"`
 	}
 
 	PeerID peer.ID
 )
 
+func (js JobSpecV2) GetID() string {
+	return fmt.Sprintf("%v", js.ID)
+}
+
 func (js *JobSpecV2) SetID(value string) error {
-	jobID, err := strconv.ParseInt(value, 10, 32)
+	ID, err := strconv.ParseInt(value, 10, 32)
 	if err != nil {
 		return err
 	}
-	js.ID = int32(jobID)
+	js.ID = int32(ID)
+	return nil
+}
+
+func (s OffchainReportingOracleSpec) GetID() string {
+	return fmt.Sprintf("%v", s.ID)
+}
+
+func (s *OffchainReportingOracleSpec) SetID(value string) error {
+	ID, err := strconv.ParseInt(value, 10, 32)
+	if err != nil {
+		return err
+	}
+	s.ID = int32(ID)
 	return nil
 }
 

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -6,15 +6,18 @@ import (
 	"database/sql"
 	"encoding"
 	"encoding/hex"
-
 	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/postgres" // http://doc.gorm.io/database.html#connecting-to-a-database
 	"github.com/lib/pq"
-
+	"github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/auth"
 	"github.com/smartcontractkit/chainlink/core/gracefulpanic"
@@ -23,12 +26,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/models/vrfkey"
 	"github.com/smartcontractkit/chainlink/core/utils"
-
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/jinzhu/gorm"
-	_ "github.com/jinzhu/gorm/dialects/postgres" // http://doc.gorm.io/database.html#connecting-to-a-database
-	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 	"go.uber.org/multierr"
 )
 
@@ -971,6 +968,14 @@ func (orm *ORM) JobsSorted(sort SortType, offset int, limit int) ([]models.JobSp
 	order := fmt.Sprintf("created_at %s", sort.String())
 	err = orm.getRecords(&jobs, order, offset, limit)
 	return jobs, count, err
+}
+
+// OffChainReportingJobs returns OCR job specs
+func (orm *ORM) OffChainReportingJobs() ([]models.JobSpecV2, error) {
+	orm.MustEnsureAdvisoryLock()
+	var jobs []models.JobSpecV2
+	err := orm.DB.Set("gorm:auto_preload", true).Find(&jobs).Error
+	return jobs, err
 }
 
 // TxFrom returns all transactions from a particular address.

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -974,7 +974,7 @@ func (orm *ORM) JobsSorted(sort SortType, offset int, limit int) ([]models.JobSp
 func (orm *ORM) OffChainReportingJobs() ([]models.JobSpecV2, error) {
 	orm.MustEnsureAdvisoryLock()
 	var jobs []models.JobSpecV2
-	err := orm.DB.Set("gorm:auto_preload", true).Find(&jobs).Error
+	err := orm.DB.Preload("OffchainreportingOracleSpec").Find(&jobs).Error
 	return jobs, err
 }
 
@@ -982,8 +982,7 @@ func (orm *ORM) OffChainReportingJobs() ([]models.JobSpecV2, error) {
 func (orm *ORM) FindOffChainReportingJob(id int32) (models.JobSpecV2, error) {
 	orm.MustEnsureAdvisoryLock()
 	var job models.JobSpecV2
-	err := orm.DB.Set("gorm:auto_preload", true).First(&job, "id = ?", id).Error
-	fmt.Println("err", err)
+	err := orm.DB.Preload("OffchainreportingOracleSpec").First(&job, "id = ?", id).Error
 	return job, err
 }
 

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -978,6 +978,15 @@ func (orm *ORM) OffChainReportingJobs() ([]models.JobSpecV2, error) {
 	return jobs, err
 }
 
+// FindOffChainReportingJob returns OCR job spec by ID
+func (orm *ORM) FindOffChainReportingJob(id int32) (models.JobSpecV2, error) {
+	orm.MustEnsureAdvisoryLock()
+	var job models.JobSpecV2
+	err := orm.DB.Set("gorm:auto_preload", true).First(&job, "id = ?", id).Error
+	fmt.Println("err", err)
+	return job, err
+}
+
 // TxFrom returns all transactions from a particular address.
 func (orm *ORM) TxFrom(from common.Address) ([]models.Tx, error) {
 	orm.MustEnsureAdvisoryLock()

--- a/core/web/helpers.go
+++ b/core/web/helpers.go
@@ -4,12 +4,11 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/smartcontractkit/chainlink/core/store/models"
-	"github.com/smartcontractkit/chainlink/core/store/orm"
-
 	"github.com/gin-gonic/gin"
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/chainlink/core/store/orm"
 )
 
 // StatusCodeForError returns an http status code for an error type.

--- a/core/web/ocr_job_specs_controller.go
+++ b/core/web/ocr_job_specs_controller.go
@@ -30,6 +30,30 @@ func (ocrjsc *OCRJobSpecsController) Index(c *gin.Context) {
 	jsonAPIResponse(c, jobs, "offChainReportingJobSpec")
 }
 
+// Show returns the details of a OCR job spec.
+// Example:
+// "GET <application>/ocr/specs/:ID"
+func (ocrjsc *OCRJobSpecsController) Show(c *gin.Context) {
+	jobSpec := models.JobSpecV2{}
+	err := jobSpec.SetID(c.Param("ID"))
+	if err != nil {
+		jsonAPIError(c, http.StatusUnprocessableEntity, err)
+		return
+	}
+
+	jobSpec, err = ocrjsc.App.GetStore().ORM.FindOffChainReportingJob(jobSpec.ID)
+	if errors.Cause(err) == orm.ErrorNotFound {
+		jsonAPIError(c, http.StatusNotFound, errors.New("OCR job spec not found"))
+		return
+	}
+	if err != nil {
+		jsonAPIError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	jsonAPIResponse(c, jobSpec, "offChainReportingJobSpec")
+}
+
 // Create validates, saves and starts a new OCR job spec.
 // Example:
 // "POST <application>/ocr/specs"

--- a/core/web/ocr_job_specs_controller.go
+++ b/core/web/ocr_job_specs_controller.go
@@ -17,9 +17,22 @@ type OCRJobSpecsController struct {
 	App chainlink.Application
 }
 
-// Create adds validates, saves, and starts a new OCR job spec.
+// Index lists all OCR job specs.
 // Example:
-// "<application>/ocr/specs"
+// "GET <application>/ocr/specs"
+func (ocrjsc *OCRJobSpecsController) Index(c *gin.Context) {
+	jobs, err := ocrjsc.App.GetStore().ORM.OffChainReportingJobs()
+	if err != nil {
+		jsonAPIError(c, http.StatusInternalServerError, err)
+		return
+	}
+
+	jsonAPIResponse(c, jobs, "offChainReportingJobSpec")
+}
+
+// Create validates, saves and starts a new OCR job spec.
+// Example:
+// "POST <application>/ocr/specs"
 func (ocrjsc *OCRJobSpecsController) Create(c *gin.Context) {
 	jobSpec, err := services.ValidatedOracleSpec(c.Request.Body)
 	if err != nil {
@@ -44,7 +57,7 @@ func (ocrjsc *OCRJobSpecsController) Create(c *gin.Context) {
 
 // Delete soft deletes an OCR job spec.
 // Example:
-// "<application>/ocr/specs/:ID"
+// "DELETE <application>/ocr/specs/:ID"
 func (ocrjsc *OCRJobSpecsController) Delete(c *gin.Context) {
 	jobSpec := models.JobSpecV2{}
 	err := jobSpec.SetID(c.Param("ID"))
@@ -63,5 +76,5 @@ func (ocrjsc *OCRJobSpecsController) Delete(c *gin.Context) {
 		return
 	}
 
-	jsonAPIResponseWithStatus(c, nil, "job", http.StatusNoContent)
+	jsonAPIResponseWithStatus(c, nil, "offChainReportingJobSpec", http.StatusNoContent)
 }

--- a/core/web/ocr_job_specs_controller_test.go
+++ b/core/web/ocr_job_specs_controller_test.go
@@ -2,13 +2,17 @@ package web_test
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"testing"
 
+	"github.com/BurntSushi/toml"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/services/offchainreporting"
 	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/chainlink/core/web"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,6 +51,44 @@ func TestOCRJobSpecsController_Create_HappyPath(t *testing.T) {
 
 	// Sanity check to make sure it inserted correctly
 	require.Equal(t, models.EIP55Address("0x613a38AC1659769640aaE063C651F48E0250454C"), job.OffchainreportingOracleSpec.ContractAddress)
+}
+
+func TestOCRJobSpecsController_Index_HappyPath(t *testing.T) {
+	app, client, cleanup := setupOCRJobSpecsControllerTests(t)
+	defer cleanup()
+
+	var ocrJobSpec offchainreporting.OracleSpec
+	toml.DecodeFile("testdata/oracle-spec.toml", &ocrJobSpec)
+	app.AddJobV2(context.Background(), ocrJobSpec)
+
+	response, cleanup := client.Get("/v2/ocr/specs")
+	defer cleanup()
+	cltest.AssertServerResponse(t, response, http.StatusOK)
+
+	ocrJobSpecs := []models.JobSpecV2{}
+	err := web.ParseJSONAPIResponse(cltest.ParseResponseBody(t, response), &ocrJobSpecs)
+	assert.NoError(t, err)
+
+	require.Len(t, ocrJobSpecs, 1)
+
+	assert.Equal(t, ocrJobSpec.ContractAddress, ocrJobSpecs[0].OffchainreportingOracleSpec.ContractAddress)
+	assert.Equal(t, ocrJobSpec.P2PPeerID, ocrJobSpecs[0].OffchainreportingOracleSpec.P2PPeerID)
+	assert.Equal(t, ocrJobSpec.P2PBootstrapPeers, ocrJobSpecs[0].OffchainreportingOracleSpec.P2PBootstrapPeers)
+	assert.Equal(t, ocrJobSpec.IsBootstrapPeer, ocrJobSpecs[0].OffchainreportingOracleSpec.IsBootstrapPeer)
+	assert.Equal(t, ocrJobSpec.EncryptedOCRKeyBundleID, ocrJobSpecs[0].OffchainreportingOracleSpec.EncryptedOCRKeyBundleID)
+	assert.Equal(t, ocrJobSpec.MonitoringEndpoint, ocrJobSpecs[0].OffchainreportingOracleSpec.MonitoringEndpoint)
+	assert.Equal(t, ocrJobSpec.TransmitterAddress, ocrJobSpecs[0].OffchainreportingOracleSpec.TransmitterAddress)
+	assert.Equal(t, ocrJobSpec.ObservationTimeout, ocrJobSpecs[0].OffchainreportingOracleSpec.ObservationTimeout)
+	assert.Equal(t, ocrJobSpec.BlockchainTimeout, ocrJobSpecs[0].OffchainreportingOracleSpec.BlockchainTimeout)
+	assert.Equal(t, ocrJobSpec.ContractConfigTrackerSubscribeInterval, ocrJobSpecs[0].OffchainreportingOracleSpec.ContractConfigTrackerSubscribeInterval)
+	assert.Equal(t, ocrJobSpec.ContractConfigTrackerSubscribeInterval, ocrJobSpecs[0].OffchainreportingOracleSpec.ContractConfigTrackerSubscribeInterval)
+	assert.Equal(t, ocrJobSpec.ContractConfigConfirmations, ocrJobSpecs[0].OffchainreportingOracleSpec.ContractConfigConfirmations)
+
+	// Check that create and update dates are non empty values.
+	// Empty date value is "0001-01-01 00:00:00 +0000 UTC" so we are checking for the
+	// millenia and century characters to be present
+	assert.Contains(t, ocrJobSpecs[0].OffchainreportingOracleSpec.CreatedAt.String(), "20")
+	assert.Contains(t, ocrJobSpecs[0].OffchainreportingOracleSpec.UpdatedAt.String(), "20")
 }
 
 func setupOCRJobSpecsControllerTests(t *testing.T) (*cltest.TestApplication, cltest.HTTPClientCleaner, func()) {

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -272,6 +272,7 @@ func v2Routes(app chainlink.Application, r *gin.RouterGroup) {
 		{
 			ocrjsc := OCRJobSpecsController{app}
 			ocr.GET("/specs", ocrjsc.Index)
+			ocr.GET("/specs/:ID", ocrjsc.Show)
 			ocr.POST("/specs", ocrjsc.Create)
 			ocr.DELETE("/specs/:ID", ocrjsc.Delete)
 		}

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -271,6 +271,7 @@ func v2Routes(app chainlink.Application, r *gin.RouterGroup) {
 		ocr := authv2.Group("/ocr")
 		{
 			ocrjsc := OCRJobSpecsController{app}
+			ocr.GET("/specs", ocrjsc.Index)
 			ocr.POST("/specs", ocrjsc.Create)
 			ocr.DELETE("/specs/:ID", ocrjsc.Delete)
 		}

--- a/core/web/testdata/oracle-spec.toml
+++ b/core/web/testdata/oracle-spec.toml
@@ -5,7 +5,7 @@ p2pPeerID          = "12D3KooWCJUPKsYAnCRTQ7SUNULt4Z9qF8Uk1xadhCs7e9M711Lp"
 p2pBootstrapPeers  = [
     "/dns4/chain.link/tcp/1234/p2p/16Uiu2HAm58SP7UL8zsnpeuwHfytLocaqgnyaYKP8wu7qRdrixLju",
 ]
-isBootstrapPeer    = false
+isBootstrapPeer    = true
 keyBundleID        = "54f02f2756952ee42874182c8a03d51f048b7fc245c05196af50f9266f8e444a"
 monitoringEndpoint = "chain.link:4321"
 transmitterAddress = "0x27548a32b9aD5D64c5945EaE9Da5337bc3169D15"


### PR DESCRIPTION
In subsequent PRs will need to add `observationSource` as right now the `pipeline.Spec` struct sits in a different package and @spooktheducks needs to figure out the best way to share it. We'll also probably gonna want to include job runs and errors too.