### PR TITLE
💥 Change "POST /v2/ocr/specs" to require TOML in JSON

### DIFF
--- a/core/services/validators.go
+++ b/core/services/validators.go
@@ -3,13 +3,15 @@ package services
 import (
 	"encoding/json"
 	"fmt"
-	"io"
 	"net/url"
 	"regexp"
 	"strings"
 	"time"
 
+	"github.com/BurntSushi/toml"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/jinzhu/gorm"
+	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/adapters"
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/services/offchainreporting"
@@ -17,12 +19,8 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
 	"github.com/smartcontractkit/chainlink/core/utils"
-	"go.uber.org/multierr"
-
-	"github.com/BurntSushi/toml"
-	"github.com/ethereum/go-ethereum/common/hexutil"
-	"github.com/pkg/errors"
 	"github.com/tidwall/gjson"
+	"go.uber.org/multierr"
 )
 
 // ValidateJob checks the job and its associated Initiators and Tasks for any
@@ -379,9 +377,9 @@ func ValidateServiceAgreement(sa models.ServiceAgreement, store *store.Store) er
 }
 
 // ValidatedOracleSpec validates an oracle spec that came from TOML
-func ValidatedOracleSpec(r io.Reader) (spec offchainreporting.OracleSpec, err error) {
+func ValidatedOracleSpec(tomlString string) (spec offchainreporting.OracleSpec, err error) {
 	var m toml.MetaData
-	m, err = toml.DecodeReader(r, &spec)
+	m, err = toml.Decode(tomlString, &spec)
 	if err != nil {
 		return spec, err
 	}

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -607,6 +607,11 @@ type CreateKeyRequest struct {
 	CurrentPassword string `json:"current_password"`
 }
 
+// CreateOCRJobSpecRequest represents a request to create and start and OCR job spec.
+type CreateOCRJobSpecRequest struct {
+	TOML string `json:"toml"`
+}
+
 // AddressCollection is an array of common.Address
 // serializable to and from a database.
 type AddressCollection []common.Address

--- a/core/web/ocr_job_specs_controller.go
+++ b/core/web/ocr_job_specs_controller.go
@@ -58,7 +58,12 @@ func (ocrjsc *OCRJobSpecsController) Show(c *gin.Context) {
 // Example:
 // "POST <application>/ocr/specs"
 func (ocrjsc *OCRJobSpecsController) Create(c *gin.Context) {
-	jobSpec, err := services.ValidatedOracleSpec(c.Request.Body)
+	request := models.CreateOCRJobSpecRequest{}
+	if err := c.ShouldBindJSON(&request); err != nil {
+		jsonAPIError(c, http.StatusUnprocessableEntity, err)
+		return
+	}
+	jobSpec, err := services.ValidatedOracleSpec(request.TOML)
 	if err != nil {
 		jsonAPIError(c, http.StatusBadRequest, err)
 		return

--- a/core/web/ocr_job_specs_controller_test.go
+++ b/core/web/ocr_job_specs_controller_test.go
@@ -3,6 +3,7 @@ package web_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -21,9 +22,10 @@ func TestOCRJobSpecsController_Create_ValidationFailure(t *testing.T) {
 	_, client, cleanup := setupOCRJobSpecsControllerTests(t)
 	defer cleanup()
 
-	fixtureBytes := cltest.MustReadFile(t, "testdata/oracle-spec-invalid-key.toml")
-
-	resp, cleanup := client.Post("/v2/ocr/specs", bytes.NewReader(fixtureBytes))
+	body, _ := json.Marshal(models.CreateOCRJobSpecRequest{
+		TOML: string(cltest.MustReadFile(t, "testdata/oracle-spec-invalid-key.toml")),
+	})
+	resp, cleanup := client.Post("/v2/ocr/specs", bytes.NewReader(body))
 	defer cleanup()
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 
@@ -36,9 +38,10 @@ func TestOCRJobSpecsController_Create_HappyPath(t *testing.T) {
 	app, client, cleanup := setupOCRJobSpecsControllerTests(t)
 	defer cleanup()
 
-	fixtureBytes := cltest.MustReadFile(t, "testdata/oracle-spec.toml")
-
-	resp, cleanup := client.Post("/v2/ocr/specs", bytes.NewReader(fixtureBytes))
+	body, _ := json.Marshal(models.CreateOCRJobSpecRequest{
+		TOML: string(cltest.MustReadFile(t, "testdata/oracle-spec.toml")),
+	})
+	resp, cleanup := client.Post("/v2/ocr/specs", bytes.NewReader(body))
 	defer cleanup()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 


### PR DESCRIPTION
Right now we have to send TOML and the lib we are using (`json-api`) doesn't allow sending anything other than JSON, which is limiting. I've discussed with @spooktheducks the idea that it might be worth looking into removing it's usage as _it doesn't seem that we are utilising_ the advanced features of the library like magic pagination links. This PR is a quick fix in the meantime as we are blocked on creating a way to submit OCR job specs through UI.