### PR TITLE
Capture ocr runtime errors

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -11,15 +11,6 @@ jobs:
           go-version: 1.15
       - run: go mod download
       - run: go vet ./...
-  mod:
-    name: mod
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-go@v2
-        with:
-          go-version: 1.15
-      - run: go mod tidy && test -z "$(git status --porcelain go.sum go.mod)"
   shadow:
     name: shadow
     runs-on: ubuntu-latest

--- a/core/services/offchainreporting/logger.go
+++ b/core/services/offchainreporting/logger.go
@@ -1,6 +1,8 @@
 package offchainreporting
 
 import (
+	"fmt"
+
 	"github.com/smartcontractkit/chainlink/core/logger"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
 )
@@ -8,14 +10,16 @@ import (
 var _ ocrtypes.Logger = &ocrLogger{}
 
 type ocrLogger struct {
-	internal *logger.Logger
-	trace    bool
+	internal  *logger.Logger
+	trace     bool
+	saveError func(string)
 }
 
-func NewLogger(internal *logger.Logger, trace bool) ocrtypes.Logger {
+func NewLogger(internal *logger.Logger, trace bool, saveError func(string)) ocrtypes.Logger {
 	return &ocrLogger{
-		internal: internal,
-		trace:    trace,
+		internal:  internal,
+		trace:     trace,
+		saveError: saveError,
 	}
 }
 
@@ -40,10 +44,18 @@ func (ol *ocrLogger) Warn(msg string, fields ocrtypes.LogFields) {
 }
 
 func (ol *ocrLogger) Error(msg string, fields ocrtypes.LogFields) {
+	ol.saveError(msg + toString(fields))
 	ol.internal.Errorw(msg, toKeysAndValues(fields)...)
 }
 
 // Helpers
+func toString(fields ocrtypes.LogFields) string {
+	res := ""
+	for key, val := range fields {
+		res += fmt.Sprintf("%s: %v", key, val)
+	}
+	return res
+}
 
 func toKeysAndValues(fields ocrtypes.LogFields) []interface{} {
 	out := []interface{}{}

--- a/core/services/pipeline/models.go
+++ b/core/services/pipeline/models.go
@@ -14,6 +14,15 @@ type (
 		CreatedAt    time.Time
 	}
 
+	SpecError struct {
+		ID             int64 `gorm:"primary_key"`
+		PipelineSpecID int32
+		Description    string
+		Occurrences    uint
+		CreatedAt      time.Time
+		UpdatedAt      time.Time
+	}
+
 	TaskSpec struct {
 		ID             int32 `gorm:"primary_key"`
 		DotID          string
@@ -46,10 +55,11 @@ type (
 	}
 )
 
-func (Spec) TableName() string     { return "pipeline_specs" }
-func (Run) TableName() string      { return "pipeline_runs" }
-func (TaskSpec) TableName() string { return "pipeline_task_specs" }
-func (TaskRun) TableName() string  { return "pipeline_task_runs" }
+func (Spec) TableName() string      { return "pipeline_specs" }
+func (SpecError) TableName() string { return "pipeline_spec_errors" }
+func (Run) TableName() string       { return "pipeline_runs" }
+func (TaskSpec) TableName() string  { return "pipeline_task_specs" }
+func (TaskRun) TableName() string   { return "pipeline_task_runs" }
 
 func (s TaskSpec) IsFinalPipelineOutput() bool {
 	return s.SuccessorID.IsZero()

--- a/core/services/pipeline/orm.go
+++ b/core/services/pipeline/orm.go
@@ -29,6 +29,7 @@ type ORM interface {
 	DeleteRunsOlderThan(threshold time.Duration) error
 
 	FindBridge(name models.TaskType) (models.BridgeType, error)
+	RecordError(specID int32, description string)
 }
 
 type orm struct {
@@ -432,6 +433,19 @@ func (o *orm) DeleteRunsOlderThan(threshold time.Duration) error {
 
 func (o *orm) FindBridge(name models.TaskType) (models.BridgeType, error) {
 	return FindBridge(o.db, name)
+}
+
+func (o *orm) RecordError(pipelineSpecID int32, description string) {
+	pse := SpecError{PipelineSpecID: pipelineSpecID, Description: description, Occurrences: 1}
+	err := o.db.
+		Set(
+			"gorm:insert_option",
+			`ON CONFLICT (pipeline_spec_id, description)
+			DO UPDATE SET occurrences = pipeline_spec_errors.occurrences + 1, updated_at = excluded.updated_at`,
+		).
+		Create(&pse).
+		Error
+	logger.ErrorIf(err, fmt.Sprintf("Unable to create PipelineSpecError: %v", err))
 }
 
 // FindBridge find a bridge using the given database

--- a/core/services/pipeline/orm_test.go
+++ b/core/services/pipeline/orm_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
@@ -412,5 +414,32 @@ func TestORM(t *testing.T) {
 				}
 			})
 		}
+	})
+
+	t.Run("increase pipeline spec occurrence", func(t *testing.T) {
+		orm, _, cleanup := cltest.NewPipelineORM(t, config, db)
+		defer cleanup()
+
+		g := pipeline.NewTaskDAG()
+		specID, err := orm.CreateSpec(context.Background(), *g)
+		require.NoError(t, err)
+
+		ocrSpecError1 := "ocr spec 1 errored"
+		ocrSpecError2 := "ocr spec 2 errored"
+		orm.RecordError(specID, ocrSpecError1)
+		orm.RecordError(specID, ocrSpecError1)
+		orm.RecordError(specID, ocrSpecError2)
+
+		var specErrors []pipeline.SpecError
+		err = db.Find(&specErrors).Error
+		require.NoError(t, err)
+		require.Len(t, specErrors, 2)
+
+		assert.Equal(t, specErrors[0].Occurrences, uint(2))
+		assert.Equal(t, specErrors[1].Occurrences, uint(1))
+		assert.True(t, specErrors[0].CreatedAt.Before(specErrors[0].UpdatedAt))
+		assert.Equal(t, specErrors[0].Description, ocrSpecError1)
+		assert.Equal(t, specErrors[1].Description, ocrSpecError2)
+		assert.True(t, specErrors[1].CreatedAt.After(specErrors[0].UpdatedAt))
 	})
 }

--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -22,6 +22,7 @@ type (
 		CreateRun(ctx context.Context, jobID int32, meta map[string]interface{}) (int64, error)
 		AwaitRun(ctx context.Context, runID int64) error
 		ResultsForRun(ctx context.Context, runID int64) ([]Result, error)
+		RecordError(ctx context.Context, specID int32, description string)
 	}
 
 	runner struct {
@@ -134,6 +135,10 @@ func (r *runner) ResultsForRun(ctx context.Context, runID int64) ([]Result, erro
 	ctx, cancel := utils.CombinedContext(r.chStop, ctx)
 	defer cancel()
 	return r.orm.ResultsForRun(ctx, runID)
+}
+
+func (r *runner) RecordError(ctx context.Context, specID int32, description string) {
+	r.orm.RecordError(specID, description)
 }
 
 // NOTE: This could potentially run on a different machine in the cluster than

--- a/core/services/pipeline/runner_test.go
+++ b/core/services/pipeline/runner_test.go
@@ -2,9 +2,14 @@ package pipeline_test
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
+
+	"github.com/smartcontractkit/chainlink/core/services/offchainreporting"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -287,5 +292,50 @@ func TestRunner(t *testing.T) {
 				t.Fatalf("unknown task '%v'", run.DotID())
 			}
 		}
+	})
+
+	t.Run("test pipeline spec error is created", func(t *testing.T) {
+		// Create a keystore with an ocr key bundle and p2p key.
+		keyStore := offchainreporting.NewKeyStore(db, utils.GetScryptParams(config.Config))
+		_, ek, err := keyStore.GenerateEncryptedP2PKey()
+		require.NoError(t, err)
+		kb, _, err := keyStore.GenerateEncryptedOCRKeyBundle()
+		require.NoError(t, err)
+		spec := fmt.Sprintf(ocrJobSpecTemplate, cltest.NewAddress().Hex(), ek.PeerID, kb.ID, cltest.DefaultKey, fmt.Sprintf(simpleFetchDataSourceTemplate, "blah", true))
+		ocrspec, dbSpec := makeOCRJobSpecWithHTTPURL(t, db, spec)
+
+		// Create an OCR job
+		err = jobORM.CreateJob(context.Background(), dbSpec, ocrspec.TaskDAG())
+		require.NoError(t, err)
+		var jb models.JobSpecV2
+		err = db.Preload("OffchainreportingOracleSpec", "p2p_peer_id = ?", ek.PeerID).
+			Find(&jb).Error
+		require.NoError(t, err)
+
+		config.Config.Set("P2P_LISTEN_PORT", 2000) // Required to create job spawner delegate.
+		sd := offchainreporting.NewJobSpawnerDelegate(
+			db,
+			config.Config,
+			keyStore,
+			runner,
+			nil,
+			nil)
+		service, err := sd.ServicesForSpec(sd.FromDBRow(jb))
+		require.NoError(t, err)
+
+		// Start and stop the service to generate errors.
+		// We expect a database timeout and a context cancellation
+		// error to show up as pipeline_spec_errors.
+		err = service[0].Start()
+		require.NoError(t, err)
+		err = service[0].Close()
+		require.NoError(t, err)
+
+		var se []pipeline.SpecError
+		err = db.Find(&se).Error
+		require.NoError(t, err)
+		require.Len(t, se, 2)
+		assert.Equal(t, uint(1), se[0].Occurrences)
+		assert.Equal(t, uint(1), se[1].Occurrences)
 	})
 }

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -78,6 +78,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1603724707"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1603816329"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1604003825"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1604437959"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
@@ -389,6 +390,10 @@ func init() {
 		{
 			ID:      "1604003825",
 			Migrate: migration1604003825.Migrate,
+		},
+		{
+			ID:      "1604437959",
+			Migrate: migration1604437959.Migrate,
 		},
 	}
 }

--- a/core/store/migrations/migration1604437959/migrate.go
+++ b/core/store/migrations/migration1604437959/migrate.go
@@ -1,0 +1,27 @@
+package migration1604437959
+
+import "github.com/jinzhu/gorm"
+
+const up = `
+	CREATE TABLE "pipeline_spec_errors" (
+		"id" bigserial primary key,
+		"pipeline_spec_id" int REFERENCES pipeline_specs (id),
+		"description" text NOT NULL,
+		"occurrences" integer DEFAULT 1 NOT NULL,
+		"created_at" timestamptz NOT NULL,
+		"updated_at" timestamptz NOT NULL
+	);
+	CREATE UNIQUE INDEX pipeline_spec_errors_unique_idx ON pipeline_spec_errors ("pipeline_spec_id", "description");
+`
+
+const down = `
+	DROP TABLE "pipeline_spec_errors"
+`
+
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(up).Error
+}
+
+func Rollback(tx *gorm.DB) error {
+	return tx.Exec(down).Error
+}


### PR DESCRIPTION
The chainlink node can accept new job spec posts while its disconnected from an eth node, so it doesn't validate some of the parameters (e.g. a contract address in a spec). If there are errors between specifying a job and running it (i.e. contract self-destructs in between) we still want to capture those errors, yet there are not specific to a job task but issues with the spec itself. Those errors are currently saved in the job_spec_errors table. 

We want to do something analogous for the v2 job pipeline, so I added a similar table: pipeline_spec_errors. The only current job type using the pipeline is ocr type jobs and to capture those spec errors, I put a function closure on the logger which has access to pipeline.ORM to save the errors.