### PR TITLE
Show BPTXM txs on transaction page in operator UI

### DIFF
--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -665,9 +665,13 @@ func (orm *ORM) IdempotentInsertEthTaskRunTx(taskRunID models.ID, fromAddress co
 	}
 }
 
-// EthTransactions returns all transactions limited by passed parameters.
-func (orm *ORM) EthTransactionsWithOrderedAttempts(offset, limit int) ([]models.EthTx, int, error) {
-	count, err := orm.CountOf(&models.EthTx{})
+// EthTransactionsWithAttempts returns all eth transactions with at least one attempt
+// limited by passed parameters. Attempts are sorted by created_at.
+func (orm *ORM) EthTransactionsWithAttempts(offset, limit int) ([]models.EthTx, int, error) {
+	ethTXIDs := orm.DB.Select("DISTINCT eth_tx_id").Table("eth_tx_attempts").QueryExpr()
+
+	var count int
+	err := orm.DB.Table("eth_txes").Where("id IN (?)", ethTXIDs).Count(&count).Error
 	if err != nil {
 		return nil, 0, err
 	}
@@ -675,10 +679,12 @@ func (orm *ORM) EthTransactionsWithOrderedAttempts(offset, limit int) ([]models.
 	var txs []models.EthTx
 	err = orm.DB.
 		Preload("EthTxAttempts", func(db *gorm.DB) *gorm.DB {
-			return db.Order("created_at asc")
+			return db.Order("created_at desc")
 		}).
+		Where("id IN (?)", ethTXIDs).
 		Order("id desc").Limit(limit).Offset(offset).
 		Find(&txs).Error
+
 	return txs, count, err
 }
 

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -668,10 +668,16 @@ func (orm *ORM) IdempotentInsertEthTaskRunTx(taskRunID models.ID, fromAddress co
 // EthTransactionsWithAttempts returns all eth transactions with at least one attempt
 // limited by passed parameters. Attempts are sorted by created_at.
 func (orm *ORM) EthTransactionsWithAttempts(offset, limit int) ([]models.EthTx, int, error) {
-	ethTXIDs := orm.DB.Select("DISTINCT eth_tx_id").Table("eth_tx_attempts").QueryExpr()
+	ethTXIDs := orm.DB.
+		Select("DISTINCT eth_tx_id").
+		Table("eth_tx_attempts").
+		QueryExpr()
 
 	var count int
-	err := orm.DB.Table("eth_txes").Where("id IN (?)", ethTXIDs).Count(&count).Error
+	err := orm.DB.
+		Table("eth_txes").
+		Where("id IN (?)", ethTXIDs).
+		Count(&count).Error
 	if err != nil {
 		return nil, 0, err
 	}

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -730,11 +730,11 @@ func NewTxFromAttempt(txAttempt models.TxAttempt) Tx {
 	return NewTx(tx)
 }
 
-func NewEthTxFromAttempt(txa *models.EthTxAttempt) EthTx {
-	return newEthTxWithAttempt(&txa.EthTx, txa)
+func NewEthTxFromAttempt(txa models.EthTxAttempt) EthTx {
+	return newEthTxWithAttempt(txa.EthTx, txa)
 }
 
-func newEthTxWithAttempt(tx *models.EthTx, txa *models.EthTxAttempt) EthTx {
+func newEthTxWithAttempt(tx models.EthTx, txa models.EthTxAttempt) EthTx {
 	ethTX := EthTx{
 		Data:     hexutil.Bytes(tx.EncodedPayload),
 		From:     &tx.FromAddress,

--- a/core/web/transactions_controller.go
+++ b/core/web/transactions_controller.go
@@ -23,7 +23,7 @@ func (tc *TransactionsController) Index(c *gin.Context, size, page, offset int) 
 	ptxs := make([]presenters.EthTx, len(txs))
 	for i, tx := range txs {
 		tx.EthTxAttempts[0].EthTx = tx
-		ptxs[i] = presenters.NewEthTxFromAttempt(&tx.EthTxAttempts[0])
+		ptxs[i] = presenters.NewEthTxFromAttempt(tx.EthTxAttempts[0])
 	}
 	paginatedResponse(c, "transactions", size, page, ptxs, count, err)
 }
@@ -44,5 +44,5 @@ func (tc *TransactionsController) Show(c *gin.Context) {
 		return
 	}
 
-	jsonAPIResponse(c, presenters.NewEthTxFromAttempt(ethTxAttempt), "transaction")
+	jsonAPIResponse(c, presenters.NewEthTxFromAttempt(*ethTxAttempt), "transaction")
 }

--- a/core/web/transactions_controller.go
+++ b/core/web/transactions_controller.go
@@ -17,19 +17,15 @@ type TransactionsController struct {
 	App chainlink.Application
 }
 
-// Index returns paginated transaction attempts
+// Index returns paginated transactions
 func (tc *TransactionsController) Index(c *gin.Context, size, page, offset int) {
-	txs, count, err := tc.App.GetStore().EthTransactionsWithOrderedAttempts(offset, size)
+	txs, count, err := tc.App.GetStore().EthTransactionsWithAttempts(offset, size)
 	ptxs := make([]presenters.EthTx, len(txs))
 	for i, tx := range txs {
-		if len(tx.EthTxAttempts) > 0 {
-			lastAttempt := len(tx.EthTxAttempts) - 1
-			ptxs[i] = presenters.NewEthTxWithAttempt(&tx, &tx.EthTxAttempts[lastAttempt])
-		} else {
-			ptxs[i] = presenters.NewEthTx(&tx)
-		}
+		tx.EthTxAttempts[0].EthTx = tx
+		ptxs[i] = presenters.NewEthTxFromAttempt(&tx.EthTxAttempts[0])
 	}
-	paginatedResponse(c, "eth_transactions", size, page, ptxs, count, err)
+	paginatedResponse(c, "transactions", size, page, ptxs, count, err)
 }
 
 // Show returns the details of a Ethereum Transasction details.
@@ -48,5 +44,5 @@ func (tc *TransactionsController) Show(c *gin.Context) {
 		return
 	}
 
-	jsonAPIResponse(c, presenters.NewEthTxWithAttempt(&ethTxAttempt.EthTx, ethTxAttempt), "transaction")
+	jsonAPIResponse(c, presenters.NewEthTxFromAttempt(ethTxAttempt), "transaction")
 }

--- a/core/web/transactions_controller_test.go
+++ b/core/web/transactions_controller_test.go
@@ -43,7 +43,7 @@ func TestTransactionsController_Index_Success(t *testing.T) {
 	attempt.BroadcastBeforeBlockNum = &blockNum
 	require.NoError(t, store.DB.Create(&attempt).Error)
 
-	_, count, err := store.EthTransactionsWithOrderedAttempts(0, 100)
+	_, count, err := store.EthTransactionsWithAttempts(0, 100)
 	require.NoError(t, err)
 	require.Equal(t, count, 3)
 
@@ -107,7 +107,7 @@ func TestTransactionsController_Show_Success(t *testing.T) {
 
 	ptx := presenters.EthTx{}
 	require.NoError(t, cltest.ParseJSONAPIResponse(t, resp, &ptx))
-	txp := presenters.NewEthTxWithAttempt(&tx, &attempt)
+	txp := presenters.NewEthTxFromAttempt(&attempt)
 
 	assert.Equal(t, txp.State, ptx.State)
 	assert.Equal(t, txp.Data, ptx.Data)

--- a/core/web/transactions_controller_test.go
+++ b/core/web/transactions_controller_test.go
@@ -107,7 +107,7 @@ func TestTransactionsController_Show_Success(t *testing.T) {
 
 	ptx := presenters.EthTx{}
 	require.NoError(t, cltest.ParseJSONAPIResponse(t, resp, &ptx))
-	txp := presenters.NewEthTxFromAttempt(&attempt)
+	txp := presenters.NewEthTxFromAttempt(attempt)
 
 	assert.Equal(t, txp.State, ptx.State)
 	assert.Equal(t, txp.Data, ptx.Data)

--- a/core/web/tx_attempts_controller.go
+++ b/core/web/tx_attempts_controller.go
@@ -17,7 +17,7 @@ func (tac *TxAttemptsController) Index(c *gin.Context, size, page, offset int) {
 	attempts, count, err := tac.App.GetStore().EthTxAttempts(offset, size)
 	ptxs := make([]presenters.EthTx, len(attempts))
 	for i, attempt := range attempts {
-		ptxs[i] = presenters.NewEthTxFromAttempt(&attempt)
+		ptxs[i] = presenters.NewEthTxFromAttempt(attempt)
 	}
 	paginatedResponse(c, "transactions", size, page, ptxs, count, err)
 }

--- a/core/web/tx_attempts_controller.go
+++ b/core/web/tx_attempts_controller.go
@@ -19,5 +19,5 @@ func (tac *TxAttemptsController) Index(c *gin.Context, size, page, offset int) {
 	for i, attempt := range attempts {
 		ptxs[i] = presenters.NewEthTxFromAttempt(&attempt)
 	}
-	paginatedResponse(c, "eth_transactions", size, page, ptxs, count, err)
+	paginatedResponse(c, "transactions", size, page, ptxs, count, err)
 }

--- a/operator_ui/@types/core/store/presenters.d.ts
+++ b/operator_ui/@types/core/store/presenters.d.ts
@@ -93,7 +93,7 @@ declare module 'core/store/presenters' {
    * Tx is a jsonapi wrapper for an Ethereum Transaction.
    */
   export interface Tx {
-    confirmed?: boolean
+    state?: string
     data?: hexutil.Bytes
     from?: Pointer<common.Address>
     gasLimit?: string


### PR DESCRIPTION
Addresses [#175182772](https://www.pivotaltracker.com/story/show/175182772)

This PR changes a couple things:
* changes data payload from `eth_transactions` to `transactions`, matching what is expected by frontend
* changes index endpoint **to only show eth_txs that have at least one attempt** - while we could find a way to render both, I think it's much easier to just wait for the eth_tx to have an attempt.
* changes `confirmed` boolean to `state` field
 
![ss](https://user-images.githubusercontent.com/14809513/98400903-ad60b700-2019-11eb-8bb3-1635158c6982.png)
