### PR TITLE
Support delete for errored ocr job

### DIFF
--- a/core/services/pipeline/runner_test.go
+++ b/core/services/pipeline/runner_test.go
@@ -337,5 +337,11 @@ func TestRunner(t *testing.T) {
 		require.Len(t, se, 2)
 		assert.Equal(t, uint(1), se[0].Occurrences)
 		assert.Equal(t, uint(1), se[1].Occurrences)
+
+		// Ensure we can delete an errored job.
+		_, err = jobORM.ClaimUnclaimedJobs(context.Background())
+		require.NoError(t, err)
+		err = jobORM.DeleteJob(context.Background(), jb.ID)
+		require.NoError(t, err)
 	})
 }

--- a/core/services/pipeline/runner_test.go
+++ b/core/services/pipeline/runner_test.go
@@ -343,5 +343,8 @@ func TestRunner(t *testing.T) {
 		require.NoError(t, err)
 		err = jobORM.DeleteJob(context.Background(), jb.ID)
 		require.NoError(t, err)
+		err = db.Find(&se).Error
+		require.NoError(t, err)
+		require.Len(t, se, 0)
 	})
 }

--- a/core/store/migrations/migration1604437959/migrate.go
+++ b/core/store/migrations/migration1604437959/migrate.go
@@ -5,7 +5,7 @@ import "github.com/jinzhu/gorm"
 const up = `
 	CREATE TABLE "pipeline_spec_errors" (
 		"id" bigserial primary key,
-		"pipeline_spec_id" int REFERENCES pipeline_specs (id),
+		"pipeline_spec_id" int REFERENCES pipeline_specs(id) ON DELETE CASCADE,
 		"description" text NOT NULL,
 		"occurrences" integer DEFAULT 1 NOT NULL,
 		"created_at" timestamptz NOT NULL,


### PR DESCRIPTION
Realized that https://github.com/smartcontractkit/chainlink/pull/3559 broke the delete of OCR jobs. Fixed by cascading.