### PR TITLE
Workaround for http.Request#Clone bug, fails to copy body

### DIFF
--- a/core/utils/http.go
+++ b/core/utils/http.go
@@ -94,7 +94,10 @@ func makeHTTPCall(
 		return nil, 0, err
 	}
 	var b bytes.Buffer
-	b.ReadFrom(originalRequestBody)
+	_, err = b.ReadFrom(originalRequestBody)
+	if err != nil {
+		return nil, 0, err
+	}
 	requestWithTimeout.Body = ioutil.NopCloser(&b)
 
 	start := time.Now()

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,10 @@ Numerous key-related UX improvements:
 - Two new env variables are added `P2P_ANNOUNCE_IP` and `P2P_ANNOUNCE_PORT` which allow node operators to override locally detected values for the chainlink node's externally reachable IP/port.
 - `OCR_LISTEN_IP` and `OCR_LISTEN_PORT` have been renamed to `P2P_LISTEN_IP` and `P2P_LISTEN_PORT` for consistency.
 
+### Fixed
+
+- Fixed an issue where the HTTP adapter would send an empty body on retries.
+
 ## [0.9.4] - 2020-11-04
 
 ### Fixed


### PR DESCRIPTION
See https://go-review.googlesource.com/c/go/+/212408/ and https://github.com/golang/go/issues/36095.
The `Clone` method in the Go standard library is documented as doing a deep copy, but it doesn't clone the Body.
As a workaround make a copy to the `requestWithTimeout` using the `GetBody` method.