### PR TITLE
Replace peerstore with simpler alternative and improve OCR/Runner performance

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -998,6 +998,29 @@ func WaitForRuns(t testing.TB, j models.JobSpec, store *strpkg.Store, want int) 
 	return jrs
 }
 
+// WaitForRuns waits for the wanted number of completed runs then returns a slice of the JobRuns
+func WaitForCompletedRuns(t testing.TB, j models.JobSpec, store *strpkg.Store, want int) []models.JobRun {
+	t.Helper()
+	g := gomega.NewGomegaWithT(t)
+
+	var jrs []models.JobRun
+	var err error
+	if want == 0 {
+		g.Consistently(func() []models.JobRun {
+			err = store.DB.Where("status = 'completed'").Find(&jrs).Error
+			assert.NoError(t, err)
+			return jrs
+		}, DBWaitTimeout, DBPollingInterval).Should(gomega.HaveLen(want))
+	} else {
+		g.Eventually(func() []models.JobRun {
+			err = store.DB.Where("status = 'completed'").Find(&jrs).Error
+			assert.NoError(t, err)
+			return jrs
+		}, DBWaitTimeout, DBPollingInterval).Should(gomega.HaveLen(want))
+	}
+	return jrs
+}
+
 // AssertRunsStays asserts that the number of job runs for a particular job remains at the provided values
 func AssertRunsStays(t testing.TB, j models.JobSpec, store *strpkg.Store, want int) []models.JobRun {
 	t.Helper()
@@ -1027,6 +1050,20 @@ func WaitForRunsAtLeast(t testing.TB, j models.JobSpec, store *strpkg.Store, wan
 			return len(jrs)
 		}, DBWaitTimeout, DBPollingInterval).Should(gomega.BeNumerically(">=", want))
 	}
+}
+
+func WaitForEthTxCount(t testing.TB, store *strpkg.Store, want int) []models.EthTx {
+	t.Helper()
+	g := gomega.NewGomegaWithT(t)
+
+	var txes []models.EthTx
+	var err error
+	g.Eventually(func() []models.EthTx {
+		err = store.DB.Find(&txes).Error
+		assert.NoError(t, err)
+		return txes
+	}, DBWaitTimeout, DBPollingInterval).Should(gomega.HaveLen(want))
+	return txes
 }
 
 func WaitForEthTxAttemptCount(t testing.TB, store *strpkg.Store, want int) []models.EthTxAttempt {

--- a/core/internal/cltest/job_factories.go
+++ b/core/internal/cltest/job_factories.go
@@ -1,0 +1,84 @@
+package cltest
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/jinzhu/gorm"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/core/services/offchainreporting"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+)
+
+const ocrJobSpecText = `
+type               = "offchainreporting"
+schemaVersion      = 1
+contractAddress    = "%s"
+p2pPeerID          = "%s"
+p2pBootstrapPeers  = [
+    "/dns4/chain.link/tcp/1234/p2p/16Uiu2HAm58SP7UL8zsnpeuwHfytLocaqgnyaYKP8wu7qRdrixLju",
+]
+isBootstrapPeer    = false
+keyBundleID        = "%s"
+monitoringEndpoint = "chain.link:4321"
+transmitterAddress = "%s"
+observationTimeout = "10s"
+blockchainTimeout  = "20s"
+contractConfigTrackerSubscribeInterval = "2m"
+contractConfigTrackerPollInterval = "1m"
+contractConfigConfirmations = 3
+observationSource = """
+    // data source 1
+    ds1          [type=bridge name=voter_turnout];
+    ds1_parse    [type=jsonparse path="one,two"];
+    ds1_multiply [type=multiply times=1.23];
+
+    // data source 2
+    ds2          [type=http method=GET url="https://chain.link/voter_turnout/USA-2020" requestData="{\\"hi\\": \\"hello\\"}"];
+    ds2_parse    [type=jsonparse path="three,four"];
+    ds2_multiply [type=multiply times=4.56];
+
+    ds1 -> ds1_parse -> ds1_multiply -> answer1;
+    ds2 -> ds2_parse -> ds2_multiply -> answer1;
+
+    answer1 [type=median                      index=0];
+    answer2 [type=bridge name=election_winner index=1];
+"""
+`
+
+func MakeOCRJobSpec(t *testing.T, db *gorm.DB) (*offchainreporting.OracleSpec, *models.JobSpecV2) {
+	t.Helper()
+
+	peerID := DefaultP2PPeerID
+	ocrKeyID := DefaultOCRKeyBundleID
+	jobSpecText := fmt.Sprintf(ocrJobSpecText, NewAddress().Hex(), peerID.String(), ocrKeyID, DefaultKey)
+
+	var ocrspec offchainreporting.OracleSpec
+	err := toml.Unmarshal([]byte(jobSpecText), &ocrspec)
+	require.NoError(t, err)
+
+	dbSpec := models.JobSpecV2{OffchainreportingOracleSpec: &ocrspec.OffchainReportingOracleSpec}
+	return &ocrspec, &dbSpec
+}
+
+// `require.Equal` currently has broken handling of `time.Time` values, so we have
+// to do equality comparisons of these structs manually.
+//
+// https://github.com/stretchr/testify/issues/984
+func CompareOCRJobSpecs(t *testing.T, expected, actual models.JobSpecV2) {
+	t.Helper()
+	require.Equal(t, expected.OffchainreportingOracleSpec.ContractAddress, actual.OffchainreportingOracleSpec.ContractAddress)
+	require.Equal(t, expected.OffchainreportingOracleSpec.P2PPeerID, actual.OffchainreportingOracleSpec.P2PPeerID)
+	require.Equal(t, expected.OffchainreportingOracleSpec.P2PBootstrapPeers, actual.OffchainreportingOracleSpec.P2PBootstrapPeers)
+	require.Equal(t, expected.OffchainreportingOracleSpec.IsBootstrapPeer, actual.OffchainreportingOracleSpec.IsBootstrapPeer)
+	require.Equal(t, expected.OffchainreportingOracleSpec.EncryptedOCRKeyBundleID, actual.OffchainreportingOracleSpec.EncryptedOCRKeyBundleID)
+	require.Equal(t, expected.OffchainreportingOracleSpec.MonitoringEndpoint, actual.OffchainreportingOracleSpec.MonitoringEndpoint)
+	require.Equal(t, expected.OffchainreportingOracleSpec.TransmitterAddress, actual.OffchainreportingOracleSpec.TransmitterAddress)
+	require.Equal(t, expected.OffchainreportingOracleSpec.ObservationTimeout, actual.OffchainreportingOracleSpec.ObservationTimeout)
+	require.Equal(t, expected.OffchainreportingOracleSpec.BlockchainTimeout, actual.OffchainreportingOracleSpec.BlockchainTimeout)
+	require.Equal(t, expected.OffchainreportingOracleSpec.ContractConfigTrackerSubscribeInterval, actual.OffchainreportingOracleSpec.ContractConfigTrackerSubscribeInterval)
+	require.Equal(t, expected.OffchainreportingOracleSpec.ContractConfigTrackerPollInterval, actual.OffchainreportingOracleSpec.ContractConfigTrackerPollInterval)
+	require.Equal(t, expected.OffchainreportingOracleSpec.ContractConfigConfirmations, actual.OffchainreportingOracleSpec.ContractConfigConfirmations)
+}

--- a/core/internal/features.go
+++ b/core/internal/features.go
@@ -1,1 +1,0 @@
-package internal

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -116,6 +116,8 @@ func TestIntegration_HttpRequestWithHeaders(t *testing.T) {
 
 	j := cltest.CreateHelloWorldJobViaWeb(t, app, mockServer.URL)
 	jr := cltest.WaitForJobRunToPendOutgoingConfirmations(t, app.Store, cltest.CreateJobRunViaWeb(t, app, j))
+
+	app.EthBroadcaster.Trigger()
 	cltest.WaitForEthTxAttemptCount(t, app.Store, 1)
 
 	// Do the thing

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -258,6 +258,7 @@ func TestIntegration_RunLog(t *testing.T) {
 				eth.Register("eth_getTransactionReceipt", confirmedReceipt)
 			})
 
+			app.EthBroadcaster.Trigger()
 			jr = cltest.WaitForJobRunStatus(t, app.Store, jr, test.wantStatus)
 			assert.True(t, jr.FinishedAt.Valid)
 			assert.Equal(t, int64(requiredConfs), int64(jr.TaskRuns[0].ObservedIncomingConfirmations.Uint32))
@@ -774,10 +775,8 @@ func TestIntegration_FluxMonitor_Deviation(t *testing.T) {
 	safe := confirmed + int64(config.MinRequiredOutgoingConfirmations())
 	inLongestChain := safe - int64(config.GasUpdaterBlockDelay())
 
-	// Single task ethTx receives configuration from FM init and writes to chain.
-	gethClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
-		Return(logsSub, nil)
-	gethClient.On("FilterLogs", mock.Anything, mock.Anything).Return([]models.Log{}, nil)
+	gethClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(logsSub, nil)
+	gethClient.On("FilterLogs", mock.Anything, mock.Anything).Maybe().Return([]models.Log{}, nil)
 
 	// Initial tx attempt sent
 	gethClient.On("SendTransaction", mock.Anything, mock.Anything).
@@ -809,6 +808,8 @@ func TestIntegration_FluxMonitor_Deviation(t *testing.T) {
 	j := cltest.CreateJobSpecViaWeb(t, app, job)
 	jrs := cltest.WaitForRuns(t, j, app.Store, 1)
 	jr := cltest.WaitForJobRunToPendOutgoingConfirmations(t, app.Store, jrs[0])
+
+	app.EthBroadcaster.Trigger()
 	cltest.WaitForEthTxAttemptCount(t, app.Store, 1)
 
 	newHeads := <-chchNewHeads
@@ -951,8 +952,10 @@ func TestIntegration_FluxMonitor_NewRound(t *testing.T) {
 
 	newRounds := <-chchLogs
 	newRounds <- log
+
 	jrs := cltest.WaitForRuns(t, j, app.Store, 1)
 	_ = cltest.WaitForJobRunToPendOutgoingConfirmations(t, app.Store, jrs[0])
+	app.EthBroadcaster.Trigger()
 	cltest.WaitForEthTxAttemptCount(t, app.Store, 1)
 
 	newHeads := <-chchNewHeads

--- a/core/services/bulletprooftxmanager/eth_broadcaster.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster.go
@@ -21,14 +21,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-const (
-	// databasePollInterval indicates how long to wait each time before polling
-	// the database for new eth_txes to send
-	//
-	// This poll is really just a fallback in case the trigger fails for some reason
-	databasePollInterval = 5 * time.Second
-)
-
 // EthBroadcaster monitors eth_txes for transactions that need to
 // be broadcast, assigns nonces and ensures that at least one eth node
 // somewhere has received the transaction successfully.
@@ -138,7 +130,7 @@ func (eb *ethBroadcaster) ethTxInsertTriggerer() {
 func (eb *ethBroadcaster) monitorEthTxs() {
 	defer eb.wg.Done()
 	for {
-		pollDBTimer := time.NewTimer(databasePollInterval)
+		pollDBTimer := time.NewTimer(eb.config.TriggerFallbackDBPollInterval())
 
 		keys, err := eb.store.SendKeys()
 

--- a/core/services/fluxmonitor/flux_monitor_simulated_blockchain_test.go
+++ b/core/services/fluxmonitor/flux_monitor_simulated_blockchain_test.go
@@ -455,6 +455,7 @@ func TestFluxMonitor_HibernationMode(t *testing.T) {
 	config, cfgCleanup := cltest.NewConfig(t)
 	config.Config.Set("DEFAULT_HTTP_TIMEOUT", "100ms")
 	config.Config.Set("FLAGS_CONTRACT_ADDRESS", fa.flagsContractAddress.Hex())
+	config.Config.Set("TRIGGER_FALLBACK_DB_POLL_INTERVAL", "1s")
 	defer cfgCleanup()
 	app, cleanup := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, fa.backend)
 	defer cleanup()

--- a/core/services/fluxmonitor/flux_monitor_simulated_blockchain_test.go
+++ b/core/services/fluxmonitor/flux_monitor_simulated_blockchain_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/flags_wrapper"
 	faw "github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/flux_aggregator_wrapper"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/link_token_interface"
-	"github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
@@ -253,12 +252,10 @@ func waitForRunsAndAttemptsCount(
 	app *cltest.TestApplication,
 	backend *backends.SimulatedBackend,
 ) []models.JobRun {
+	t.Helper()
 	store := app.Store
-
 	jrs := cltest.WaitForRuns(t, job, store, runCount) // Submit answer from
-
 	app.EthBroadcaster.Trigger()
-
 	cltest.WaitForEthTxAttemptCount(t, store, runCount)
 	txa := cltest.GetLastEthTxAttempt(t, store)
 	cltest.WaitForTxInMempool(t, backend, txa.Hash)
@@ -283,6 +280,7 @@ func TestFluxMonitorAntiSpamLogic(t *testing.T) {
 	// Set up chainlink app
 	config, cfgCleanup := cltest.NewConfig(t)
 	config.Config.Set("DEFAULT_HTTP_TIMEOUT", "100ms")
+	config.Config.Set("TRIGGER_FALLBACK_DB_POLL_INTERVAL", "1s")
 	defer cfgCleanup()
 	app, cleanup := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, fa.backend)
 	defer cleanup()
@@ -366,7 +364,8 @@ func TestFluxMonitorAntiSpamLogic(t *testing.T) {
 	nextRoundBalance := initialBalance - fee
 	// Triggers a new round, since price deviation exceeds threshold
 	atomic.StoreInt64(&reportPrice, answer+1)
-	waitForRunsAndAttemptsCount(t, j, 2, app.Store, fa.backend)
+
+	waitForRunsAndAttemptsCount(t, j, 2, app, fa.backend)
 
 	select {
 	case log := <-submissionReceived:
@@ -408,7 +407,7 @@ func TestFluxMonitorAntiSpamLogic(t *testing.T) {
 	err = app.FluxMonitor.(maliciousFluxMonitor).CreateJob(t, j.ID, decimal.New(processedAnswer, precision), big.NewInt(newRound))
 	require.NoError(t, err)
 
-	waitForRunsAndAttemptsCount(t, j, 3, app.Store, fa.backend)
+	waitForRunsAndAttemptsCount(t, j, 3, app, fa.backend)
 
 	select {
 	case <-submissionReceived:
@@ -433,7 +432,7 @@ func TestFluxMonitorAntiSpamLogic(t *testing.T) {
 		completesAnswer: true})
 	// start a legitimate new round
 	atomic.StoreInt64(&reportPrice, reportPrice+3)
-	waitForRunsAndAttemptsCount(t, j, 4, app.Store, fa.backend)
+	waitForRunsAndAttemptsCount(t, j, 4, app, fa.backend)
 
 	select {
 	case <-submissionReceived:
@@ -504,21 +503,21 @@ func TestFluxMonitor_HibernationMode(t *testing.T) {
 	// lower global kill switch flag - should trigger job run
 	fa.flagsContract.LowerFlags(fa.sergey, []common.Address{utils.ZeroAddress})
 	fa.backend.Commit()
-	waitForRunsAndAttemptsCount(t, job, 1, app.Store, fa.backend)
+	waitForRunsAndAttemptsCount(t, job, 1, app, fa.backend)
 
 	// change in price should trigger run
 	reportPrice = int64(2)
-	waitForRunsAndAttemptsCount(t, job, 2, app.Store, fa.backend)
+	waitForRunsAndAttemptsCount(t, job, 2, app, fa.backend)
 
 	// lower contract's flag - should have no effect (but currently does)
 	// TODO - https://www.pivotaltracker.com/story/show/175419789
 	fa.flagsContract.LowerFlags(fa.sergey, []common.Address{initr.Address})
 	fa.backend.Commit()
-	waitForRunsAndAttemptsCount(t, job, 3, app.Store, fa.backend)
+	waitForRunsAndAttemptsCount(t, job, 3, app, fa.backend)
 
 	// change in price should trigger run
 	reportPrice = int64(4)
-	waitForRunsAndAttemptsCount(t, job, 4, app.Store, fa.backend)
+	waitForRunsAndAttemptsCount(t, job, 4, app, fa.backend)
 
 	// raise both flags
 	fa.flagsContract.RaiseFlag(fa.sergey, initr.Address)

--- a/core/services/job/common.go
+++ b/core/services/job/common.go
@@ -27,7 +27,7 @@ type (
 	Config interface {
 		DatabaseMaximumTxDuration() time.Duration
 		DatabaseURL() string
-		JobPipelineDBPollInterval() time.Duration
+		TriggerFallbackDBPollInterval() time.Duration
 		JobPipelineParallelism() uint8
 	}
 )

--- a/core/services/job/spawner.go
+++ b/core/services/job/spawner.go
@@ -138,7 +138,7 @@ func (js *spawner) runLoop() {
 	}
 
 	// Initialize the DB poll ticker
-	dbPollTicker := time.NewTicker(js.config.JobPipelineDBPollInterval())
+	dbPollTicker := time.NewTicker(js.config.TriggerFallbackDBPollInterval())
 	defer dbPollTicker.Stop()
 
 	// Initialize the poll that checks for deleted jobs and removes them

--- a/core/services/offchainreporting/peerstore.go
+++ b/core/services/offchainreporting/peerstore.go
@@ -2,21 +2,149 @@ package offchainreporting
 
 import (
 	"context"
-	"database/sql"
+	"time"
 
-	sqlds "github.com/ipfs/go-ds-sql"
-	pgqueries "github.com/ipfs/go-ds-sql/postgres"
+	"github.com/jinzhu/gorm"
+	p2ppeer "github.com/libp2p/go-libp2p-core/peer"
 	p2ppeerstore "github.com/libp2p/go-libp2p-core/peerstore"
-	p2ppeerstoreds "github.com/libp2p/go-libp2p-peerstore/pstoreds"
+	"github.com/libp2p/go-libp2p-peerstore/pstoremem"
+	ma "github.com/multiformats/go-multiaddr"
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/postgres"
+	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
-const tableName = "p2p_peerstore"
+type (
+	p2pPeer struct {
+		ID        p2ppeer.ID
+		Addr      ma.Multiaddr
+		JobID     int32
+		CreatedAt time.Time
+		UpdatedAt time.Time
+	}
 
-// NewPeerstore creates a new database-backed peerstore
-// NOTE: You can get sql.DB from store with store.DB.DB()
-func NewPeerstore(ctx context.Context, db *sql.DB) (p2ppeerstore.Peerstore, error) {
-	queries := pgqueries.NewQueries(tableName)
-	datastore := sqlds.NewDatastore(db, queries)
-	opts := p2ppeerstoreds.DefaultOpts()
-	return p2ppeerstoreds.NewPeerstore(ctx, datastore, opts)
+	Pstorewrapper struct {
+		utils.StartStopOnce
+		Peerstore     p2ppeerstore.Peerstore
+		jobID         int32
+		db            *gorm.DB
+		writeInterval time.Duration
+		ctx           context.Context
+		ctxCancel     context.CancelFunc
+		chDone        chan struct{}
+	}
+)
+
+// NewPeerstoreWrapper creates a new database-backed peerstore wrapper scoped to the given jobID
+// Multiple peerstore wrappers should not be instantiated with the same jobID
+func NewPeerstoreWrapper(ctx context.Context, db *gorm.DB, writeInterval time.Duration, jobID int32) (*Pstorewrapper, error) {
+	ctx, cancel := context.WithCancel(ctx)
+
+	return &Pstorewrapper{
+		utils.StartStopOnce{},
+		pstoremem.NewPeerstore(),
+		jobID,
+		db,
+		writeInterval,
+		ctx,
+		cancel,
+		make(chan struct{}),
+	}, nil
+}
+
+func (p *Pstorewrapper) Start() error {
+	if !p.OkayToStart() {
+		return errors.New("cannot start")
+	}
+	err := p.readFromDB()
+	if err != nil {
+		return errors.Wrap(err, "could not start peerstore wrapper")
+	}
+	go p.dbLoop()
+	return nil
+}
+
+func (p *Pstorewrapper) dbLoop() {
+	defer close(p.chDone)
+	ticker := time.NewTicker(p.writeInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-p.ctx.Done():
+			return
+		case <-ticker.C:
+			p.writeToDB()
+		}
+	}
+}
+
+func (p *Pstorewrapper) Close() error {
+	if !p.OkayToStop() {
+		return errors.New("cannot stop")
+	}
+	p.ctxCancel()
+	<-p.chDone
+	return p.Peerstore.Close()
+}
+
+func (p *Pstorewrapper) readFromDB() error {
+	peers, err := p.getPeers()
+	if err != nil {
+		return err
+	}
+	for _, peer := range peers {
+		p.Peerstore.AddAddr(peer.ID, peer.Addr, p2ppeerstore.PermanentAddrTTL)
+	}
+	return nil
+}
+
+func (p *Pstorewrapper) getPeers() (peers []p2pPeer, err error) {
+	rows, err := p.db.DB().QueryContext(p.ctx, `SELECT id, addr FROM p2p_peers WHERE job_id = $1`, p.jobID)
+	if err != nil {
+		return nil, errors.Wrap(err, "error querying peers")
+	}
+	defer logger.ErrorIfCalling(rows.Close)
+
+	peers = make([]p2pPeer, 0)
+
+	for rows.Next() {
+		peer := p2pPeer{}
+		var maddr, peerID string
+		rows.Scan(&peerID, &maddr)
+		peer.ID, err = p2ppeer.Decode(peerID)
+		if err != nil {
+			return nil, errors.Wrap(err, "unexpectedly failed to decode peer ID")
+		}
+		peer.Addr, err = ma.NewMultiaddr(maddr)
+		if err != nil {
+			return nil, errors.Wrap(err, "unexpectedly failed to decode peer multiaddr")
+		}
+		peers = append(peers, peer)
+	}
+
+	return peers, nil
+}
+
+func (p *Pstorewrapper) writeToDB() error {
+	err := postgres.GormTransaction(p.ctx, p.db, func(tx *gorm.DB) error {
+		err := tx.Exec(`DELETE FROM p2p_peerstore WHERE job_id = ?`, p.jobID).Error
+		if err != nil {
+			return err
+		}
+		peers := make([]p2pPeer, 0)
+		for _, pid := range p.Peerstore.PeersWithAddrs() {
+			addrs := p.Peerstore.Addrs(pid)
+			for _, addr := range addrs {
+				p := p2pPeer{
+					ID:    pid,
+					Addr:  addr,
+					JobID: p.jobID,
+				}
+				peers = append(peers, p)
+			}
+		}
+		return tx.Create(&peers).Error
+	})
+	return errors.Wrap(err, "could not write peers to DB")
 }

--- a/core/services/offchainreporting/peerstore_test.go
+++ b/core/services/offchainreporting/peerstore_test.go
@@ -9,45 +9,52 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/offchainreporting"
 
 	p2ppeer "github.com/libp2p/go-libp2p-core/peer"
-	ma "github.com/multiformats/go-multiaddr"
 	"github.com/stretchr/testify/require"
 )
 
-func Test_NewPeerstore(t *testing.T) {
+func Test_Peerstore_Start(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
 
-	db := store.DB.DB()
-
-	peerstore, err := offchainreporting.NewPeerstore(context.Background(), db)
+	// Deferring the constraint avoids having to insert an entire set of jobs/specs
+	require.NoError(t, store.DB.Exec(`SET CONSTRAINTS p2p_peers_job_id_fkey DEFERRED`).Error)
+	err := store.DB.Exec(`INSERT INTO p2p_peers (id, addr, created_at, updated_at, job_id) VALUES
+	(
+		'12D3KooWL1yndUw9T2oWXjhfjdwSscWA78YCpUdduA3Cnn4dCtph',
+		'/ip4/127.0.0.1/tcp/12000/p2p/12D3KooWL1yndUw9T2oWXjhfjdwSscWA78YCpUdduA3Cnn4dCtph',
+		NOW(),
+		NOW(),
+		1
+	),
+	(
+		'12D3KooWL1yndUw9T2oWXjhfjdwSscWA78YCpUdduA3Cnn4dCtph',
+		'/ip4/127.0.0.2/tcp/12000/p2p/12D3KooWL1yndUw9T2oWXjhfjdwSscWA78YCpUdduA3Cnn4dCtph',
+		NOW(),
+		NOW(),
+		1
+	),
+	(
+		'12D3KooWL1yndUw9T2oWXjhfjdwSscWA78YCpUdduA3Cnn4dCtph',
+		'/ip4/127.0.0.2/tcp/12000/p2p/12D3KooWL1yndUw9T2oWXjhfjdwSscWA78YCpUdduA3Cnn4dCtph',
+		NOW(),
+		NOW(),
+		2
+	)
+	`).Error
 	require.NoError(t, err)
+
+	wrapper, err := offchainreporting.NewPeerstoreWrapper(context.Background(), store.DB, 1*time.Second, 1)
+	require.NoError(t, err)
+
+	err = wrapper.Start()
+	require.NoError(t, err)
+
+	require.Equal(t, 1, wrapper.Peerstore.PeersWithAddrs().Len())
 
 	peerID, err := p2ppeer.Decode("12D3KooWL1yndUw9T2oWXjhfjdwSscWA78YCpUdduA3Cnn4dCtph")
 	require.NoError(t, err)
-	multiaddr, err := ma.NewMultiaddr("/ip4/127.0.0.1/tcp/12000/p2p/12D3KooWL1yndUw9T2oWXjhfjdwSscWA78YCpUdduA3Cnn4dCtph")
-	require.NoError(t, err)
 
-	peerstore.AddAddr(peerID, multiaddr, 1*time.Hour)
+	maddrs := wrapper.Peerstore.Addrs(peerID)
 
-	peers := peerstore.Peers()
-	require.Len(t, peers, 1)
-	require.Equal(t, peers[0], peerID)
-
-	addrs := peerstore.Addrs(peerID)
-	require.Len(t, addrs, 1)
-
-	require.Equal(t, multiaddr.String(), addrs[0].String())
-
-	// Instantiate a new one to ensure we read from the DB not just from memory
-	peerstore, err = offchainreporting.NewPeerstore(context.Background(), db)
-	require.NoError(t, err)
-	peers = peerstore.Peers()
-	require.Len(t, peers, 1)
-	require.Equal(t, peers[0], peerID)
-
-	addrs = peerstore.Addrs(peerID)
-	require.Len(t, addrs, 1)
-
-	require.Equal(t, multiaddr.String(), addrs[0].String())
-
+	require.Len(t, maddrs, 2)
 }

--- a/core/services/pipeline/common.go
+++ b/core/services/pipeline/common.go
@@ -45,7 +45,7 @@ type (
 		DefaultHTTPTimeout() models.Duration
 		DefaultMaxHTTPAttempts() uint
 		DefaultHTTPAllowUnrestrictedNetworkAccess() bool
-		JobPipelineDBPollInterval() time.Duration
+		TriggerFallbackDBPollInterval() time.Duration
 		JobPipelineMaxTaskDuration() time.Duration
 		JobPipelineParallelism() uint8
 		JobPipelineReaperInterval() time.Duration

--- a/core/services/pipeline/mocks/config.go
+++ b/core/services/pipeline/mocks/config.go
@@ -116,8 +116,8 @@ func (_m *Config) DefaultMaxHTTPAttempts() uint {
 	return r0
 }
 
-// JobPipelineDBPollInterval provides a mock function with given fields:
-func (_m *Config) JobPipelineDBPollInterval() time.Duration {
+// TriggerFallbackDBPollInterval provides a mock function with given fields:
+func (_m *Config) TriggerFallbackDBPollInterval() time.Duration {
 	ret := _m.Called()
 
 	var r0 time.Duration

--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -94,7 +94,7 @@ func (r *runner) runLoop() {
 		newRunEvents = newRunsSubscription.Events()
 	}
 
-	dbPollTicker := time.NewTicker(r.config.JobPipelineDBPollInterval())
+	dbPollTicker := time.NewTicker(r.config.TriggerFallbackDBPollInterval())
 	defer dbPollTicker.Stop()
 
 	runReaperTicker := time.NewTicker(r.config.JobPipelineReaperInterval())

--- a/core/services/pipeline/runner_test.go
+++ b/core/services/pipeline/runner_test.go
@@ -438,16 +438,18 @@ ds1 -> ds1_parse;
 			nil,
 			nil,
 			nil)
-		service, err := sd.ServicesForSpec(sd.FromDBRow(jb))
+		services, err := sd.ServicesForSpec(sd.FromDBRow(jb))
 		require.NoError(t, err)
 
 		// Start and stop the service to generate errors.
 		// We expect a database timeout and a context cancellation
 		// error to show up as pipeline_spec_errors.
-		err = service[0].Start()
-		require.NoError(t, err)
-		err = service[0].Close()
-		require.NoError(t, err)
+		for _, s := range services {
+			err = s.Start()
+			require.NoError(t, err)
+			err = s.Close()
+			require.NoError(t, err)
+		}
 
 		var se []models.JobSpecErrorV2
 		err = db.Find(&se).Error

--- a/core/services/vrf/vrf_simulate_blockchain_test.go
+++ b/core/services/vrf/vrf_simulate_blockchain_test.go
@@ -79,6 +79,8 @@ func TestIntegration_RandomnessRequest(t *testing.T) {
 	jr := runs[0]
 	require.Len(t, jr.TaskRuns, 2)
 	assert.False(t, jr.TaskRuns[0].ObservedIncomingConfirmations.Valid)
+
+	app.EthBroadcaster.Trigger()
 	attempts := cltest.WaitForEthTxAttemptCount(t, app.Store, 1)
 	require.Len(t, attempts, 1)
 

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -86,6 +86,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1604576004"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1604674426"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1604707007"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1605186531"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1605213161"
 
 	gormigrate "gopkg.in/gormigrate.v1"
@@ -420,6 +421,10 @@ func init() {
 		{
 			ID:      "migration1605218542",
 			Migrate: migration1605218542.Migrate,
+		},
+		{
+			ID:      "1605186531",
+			Migrate: migration1605186531.Migrate,
 		},
 	}
 }

--- a/core/store/migrations/migration1605186531/migrate.go
+++ b/core/store/migrations/migration1605186531/migrate.go
@@ -9,5 +9,15 @@ func Migrate(tx *gorm.DB) error {
 		CREATE INDEX idx_pipeline_task_runs_finished_at ON pipeline_task_runs USING BRIN (finished_at);
 		CREATE INDEX idx_job_spec_errors_v2_created_at ON job_spec_errors_v2 USING BRIN (created_at);
 		CREATE INDEX idx_job_spec_errors_v2_finished_at ON job_spec_errors_v2 USING BRIN (updated_at);
+		DROP TABLE p2p_peerstore;
+		CREATE TABLE p2p_peers (
+			id text NOT NULL,
+			addr text NOT NULL,
+			job_id int NOT NULL REFERENCES jobs (id) ON DELETE CASCADE DEFERRABLE INITIALLY IMMEDIATE,
+			created_at timestamptz NOT NULL,
+			updated_at timestamptz NOT NULL
+		);
+		CREATE INDEX p2p_peers_id ON p2p_peers (id);
+		CREATE INDEX p2p_peers_job_id ON p2p_peers (job_id);
     `).Error
 }

--- a/core/store/migrations/migration1605186531/migrate.go
+++ b/core/store/migrations/migration1605186531/migrate.go
@@ -1,0 +1,13 @@
+package migration1605186531
+
+import "github.com/jinzhu/gorm"
+
+// Migrate adds a couple of indexes to pipeline_runs
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+		CREATE INDEX idx_pipeline_runs_finished_at ON pipeline_runs USING BRIN (finished_at);
+		CREATE INDEX idx_pipeline_task_runs_finished_at ON pipeline_task_runs USING BRIN (finished_at);
+		CREATE INDEX idx_job_spec_errors_v2_created_at ON job_spec_errors_v2 USING BRIN (created_at);
+		CREATE INDEX idx_job_spec_errors_v2_finished_at ON job_spec_errors_v2 USING BRIN (updated_at);
+    `).Error
+}

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -419,8 +419,8 @@ func (c Config) InsecureFastScrypt() bool {
 	return c.viper.GetBool(EnvVarName("InsecureFastScrypt"))
 }
 
-func (c Config) JobPipelineDBPollInterval() time.Duration {
-	return c.viper.GetDuration(EnvVarName("JobPipelineDBPollInterval"))
+func (c Config) TriggerFallbackDBPollInterval() time.Duration {
+	return c.viper.GetDuration(EnvVarName("TriggerFallbackDBPollInterval"))
 }
 
 func (c Config) JobPipelineMaxTaskDuration() time.Duration {

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -593,6 +593,10 @@ func (c Config) P2PAnnouncePort() uint16 {
 	return uint16(c.viper.GetUint32(EnvVarName("P2PAnnouncePort")))
 }
 
+func (c Config) P2PPeerstoreWriteInterval() time.Duration {
+	return c.viper.GetDuration(EnvVarName("P2PPeerstoreWriteInterval"))
+}
+
 // Port represents the port Chainlink should listen on for client requests.
 func (c Config) Port() uint16 {
 	return c.getWithFallback("Port", parseUint16).(uint16)

--- a/core/store/orm/config_reader.go
+++ b/core/store/orm/config_reader.go
@@ -84,4 +84,5 @@ type ConfigReader interface {
 	CreateProductionLogger() *logger.Logger
 	SessionSecret() ([]byte, error)
 	SessionOptions() sessions.Options
+	TriggerFallbackDBPollInterval() time.Duration
 }

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -57,7 +57,6 @@ type ConfigSchema struct {
 	GasUpdaterTransactionPercentile           uint16          `env:"GAS_UPDATER_TRANSACTION_PERCENTILE" default:"60"`
 	GasUpdaterEnabled                         bool            `env:"GAS_UPDATER_ENABLED" default:"true"`
 	InsecureFastScrypt                        bool            `env:"INSECURE_FAST_SCRYPT" default:"false"`
-	JobPipelineDBPollInterval                 time.Duration   `env:"JOB_PIPELINE_DB_POLL_INTERVAL" default:"10s"`
 	JobPipelineMaxTaskDuration                time.Duration   `env:"JOB_PIPELINE_MAX_TASK_DURATION" default:"10m"`
 	JobPipelineParallelism                    uint8           `env:"JOB_PIPELINE_PARALLELISM" default:"4"`
 	JobPipelineReaperInterval                 time.Duration   `env:"JOB_PIPELINE_REAPER_INTERVAL" default:"1h"`
@@ -96,6 +95,7 @@ type ConfigSchema struct {
 	RootDir                                   string          `env:"ROOT" default:"~/.chainlink"`
 	SecureCookies                             bool            `env:"SECURE_COOKIES" default:"true"`
 	SessionTimeout                            models.Duration `env:"SESSION_TIMEOUT" default:"15m"`
+	TriggerFallbackDBPollInterval             time.Duration   `env:"TRIGGER_FALLBACK_DB_POLL_INTERVAL" default:"30s"`
 	TLSCertPath                               string          `env:"TLS_CERT_PATH" `
 	TLSHost                                   string          `env:"CHAINLINK_TLS_HOST" `
 	TLSKeyPath                                string          `env:"TLS_KEY_PATH" `

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -89,6 +89,7 @@ type ConfigSchema struct {
 	P2PAnnouncePort                           uint16          `env:"P2P_ANNOUNCE_PORT"`
 	P2PListenIP                               net.IP          `env:"P2P_LISTEN_IP" default:"0.0.0.0"`
 	P2PListenPort                             uint16          `env:"P2P_LISTEN_PORT"`
+	P2PPeerstoreWriteInterval                 time.Duration   `env:"P2P_PEERSTORE_WRITE_INTERVAL" default:"5m"`
 	Port                                      uint16          `env:"CHAINLINK_PORT" default:"6688"`
 	ReaperExpiration                          models.Duration `env:"REAPER_EXPIRATION" default:"240h"`
 	ReplayFromBlock                           int64           `env:"REPLAY_FROM_BLOCK" default:"-1"`

--- a/core/store/presenters/presenters.go
+++ b/core/store/presenters/presenters.go
@@ -99,7 +99,7 @@ type EnvPrinter struct {
 	GasUpdaterEnabled                     bool            `json:"gasUpdaterEnabled"`
 	GasUpdaterTransactionPercentile       uint16          `json:"gasUpdaterTransactionPercentile"`
 	InsecureFastScrypt                    bool            `json:"insecureFastScrypt"`
-	JobPipelineDBPollInterval             time.Duration   `json:"jobPipelineDBPollInterval"`
+	TriggerFallbackDBPollInterval         time.Duration   `json:"jobPipelineDBPollInterval"`
 	JobPipelineMaxTaskDuration            time.Duration   `json:"jobPipelineMaxTaskDuration"`
 	JobPipelineParallelism                uint8           `json:"jobPipelineParallelism"`
 	JobPipelineReaperInterval             time.Duration   `json:"jobPipelineReaperInterval"`
@@ -189,7 +189,7 @@ func NewConfigPrinter(store *store.Store) (ConfigPrinter, error) {
 			GasUpdaterEnabled:                     config.GasUpdaterEnabled(),
 			GasUpdaterTransactionPercentile:       config.GasUpdaterTransactionPercentile(),
 			InsecureFastScrypt:                    config.InsecureFastScrypt(),
-			JobPipelineDBPollInterval:             config.JobPipelineDBPollInterval(),
+			TriggerFallbackDBPollInterval:         config.TriggerFallbackDBPollInterval(),
 			JobPipelineMaxTaskDuration:            config.JobPipelineMaxTaskDuration(),
 			JobPipelineParallelism:                config.JobPipelineParallelism(),
 			JobPipelineReaperInterval:             config.JobPipelineReaperInterval(),

--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/mitchellh/go-homedir v1.1.0
 	github.com/mitchellh/mapstructure v1.3.3
 	github.com/multiformats/go-multiaddr v0.3.1
+	github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416
 	github.com/olekukonko/tablewriter v0.0.4
 	github.com/onsi/gomega v1.10.3
 	github.com/pkg/errors v0.9.1

--- a/go.sum
+++ b/go.sum
@@ -905,7 +905,9 @@ github.com/multiformats/go-varint v0.0.6 h1:gk85QWKxh3TazbLxED/NlDVv8+q+ReFJk7Y2
 github.com/multiformats/go-varint v0.0.6/go.mod h1:3Ls8CIEsrijN6+B7PbrXRPxHRPuXSrVKRY101jdMZYE=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
+github.com/naoina/go-stringutil v0.1.0 h1:rCUeRUHjBjGTSHl0VC00jUPLz8/F9dDzYI70Hzifhks=
 github.com/naoina/go-stringutil v0.1.0/go.mod h1:XJ2SJL9jCtBh+P9q5btrd/Ylo8XwT/h1USek5+NqSA0=
+github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416 h1:shk/vn9oCoOTmwcouEdwIeOtOGA/ELRUw/GwvxwfT+0=
 github.com/naoina/toml v0.1.2-0.20170918210437-9fafd6967416/go.mod h1:NBIhNtsFMo3G2szEBne+bO4gS192HuIYRqfvOWb4i1E=
 github.com/nats-io/jwt v0.3.0/go.mod h1:fRYCDE99xlTsqUzISS1Bi75UBJ6ljOJQOAAu5VglpSg=
 github.com/nats-io/jwt v0.3.2/go.mod h1:/euKqTS1ZD+zzjYrY7pseZrTtWQSjujC7xjPc8wL6eU=


### PR DESCRIPTION
Database-backed peerstore is not designed to be instantiated multiple times on a single database table.

I have replaced it by the memory-backed peerstore with a very simple database persistence/backup thread, scoped to job IDs.

Also in this PR, trigger fallback polling is consolidated under one env var and reduced in frequency to improve performance.