### PR TITLE
Show OCR job page ("/jobs/:id") in UI

### DIFF
--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -956,7 +956,7 @@ func (orm *ORM) OffChainReportingJobRuns(jobID int32, offset, size int) ([]pipel
 		Where("jobs.id = ?", jobID).
 		Limit(size).
 		Offset(offset).
-		Order("created_at ASC, id ASC").
+		Order("created_at DESC, id DESC").
 		Find(&pipelineRuns).
 		Error
 

--- a/core/web/ocr_job_runs_controller_test.go
+++ b/core/web/ocr_job_runs_controller_test.go
@@ -54,17 +54,17 @@ func TestOCRJobRunsController_Index_HappyPath(t *testing.T) {
 	assert.NoError(t, err)
 
 	require.Len(t, parsedResponse, 2)
-	assert.Equal(t, parsedResponse[0].ID, runIDs[0])
-	assert.NotNil(t, parsedResponse[0].CreatedAt)
-	assert.NotNil(t, parsedResponse[0].FinishedAt)
-	require.Len(t, parsedResponse[0].PipelineTaskRuns, 4)
+	assert.Equal(t, parsedResponse[1].ID, runIDs[0])
+	assert.NotNil(t, parsedResponse[1].CreatedAt)
+	assert.NotNil(t, parsedResponse[1].FinishedAt)
+	require.Len(t, parsedResponse[1].PipelineTaskRuns, 4)
 }
 
 func TestOCRJobRunsController_Index_Pagination(t *testing.T) {
 	client, jobID, runIDs, cleanup := setupOCRJobRunsControllerTests(t)
 	defer cleanup()
 
-	response, cleanup := client.Get("/v2/ocr/specs/" + fmt.Sprintf("%v", jobID) + "/runs?page=2&size=1")
+	response, cleanup := client.Get("/v2/ocr/specs/" + fmt.Sprintf("%v", jobID) + "/runs?page=1&size=1")
 	defer cleanup()
 	cltest.AssertServerResponse(t, response, http.StatusOK)
 

--- a/integration/cypress/integration/archiveJob.spec.ts
+++ b/integration/cypress/integration/archiveJob.spec.ts
@@ -16,7 +16,7 @@ context('End to end', function () {
 
     // Archive Job
     cy.get('#created-job').click()
-    cy.contains('h6', 'Job spec detail').should('exist')
+    cy.contains('h6', 'job spec detail').should('exist')
     cy.clickButton('Archive')
     cy.contains('h5', 'Warning').should('exist')
     cy.get('@jobId').then((jobId) => {

--- a/integration/cypress/integration/createAndRunJob.spec.ts
+++ b/integration/cypress/integration/createAndRunJob.spec.ts
@@ -13,7 +13,7 @@ context('End to end', function () {
 
     // Run Job
     cy.get('#created-job').click()
-    cy.contains('Job spec detail')
+    cy.contains('job spec detail')
     cy.clickButton('Run')
     cy.contains('p', 'Successfully created job run')
       .children('a')

--- a/integration/cypress/integration/duplicateJob.spec.ts
+++ b/integration/cypress/integration/duplicateJob.spec.ts
@@ -14,7 +14,7 @@ context('End to end', function () {
       .invoke('text')
       .as('jobId1')
     cy.get('#created-job').click()
-    cy.contains('h6', 'Job spec detail').should('exist')
+    cy.contains('h6', 'job spec detail').should('exist')
 
     // Duplicate Job
     cy.clickLink('Duplicate')
@@ -24,7 +24,7 @@ context('End to end', function () {
       .invoke('text')
       .as('jobId2')
     cy.get('#created-job').click()
-    cy.contains('h6', 'Job spec detail').should('exist')
+    cy.contains('h6', 'job spec detail').should('exist')
 
     // Ensure jobs IDs are different
     cy.get('@jobId1').then((jobId1) => {

--- a/operator_ui/src/actionCreators.ts
+++ b/operator_ui/src/actionCreators.ts
@@ -147,11 +147,15 @@ export const deleteJobSpec = (
   id: string,
   successCallback: React.ReactNode,
   errorCallback: React.ReactNode,
+  jobType: 'Off-chain reporting' | 'Direct request',
 ) => {
   return (dispatch: Dispatch) => {
     dispatch({ type: ResourceActionType.REQUEST_DELETE })
 
-    return api.v2.specs
+    const endpoint =
+      jobType === 'Direct request' ? api.v2.specs : api.v2.ocrSpecs
+
+    return endpoint
       .destroyJobSpec(id)
       .then((doc) => {
         dispatch(receiveDeleteSuccess(id))

--- a/operator_ui/src/api/v2/index.ts
+++ b/operator_ui/src/api/v2/index.ts
@@ -9,6 +9,7 @@ import { Transactions } from './transactions'
 import { User } from './user'
 import { OcrKeys } from './ocrKeys'
 import { P2PKeys } from './p2pKeys'
+import { OcrRuns } from './ocrRuns'
 import { OcrSpecs } from './ocrSpecs'
 
 export class V2 {
@@ -25,4 +26,5 @@ export class V2 {
   public ocrKeys = new OcrKeys(this.api)
   public p2pKeys = new P2PKeys(this.api)
   public ocrSpecs = new OcrSpecs(this.api)
+  public ocrRuns = new OcrRuns(this.api)
 }

--- a/operator_ui/src/api/v2/ocrRuns.ts
+++ b/operator_ui/src/api/v2/ocrRuns.ts
@@ -10,10 +10,12 @@ export class OcrRuns {
   @boundMethod
   public getJobSpecRuns({
     jobSpecId,
+    page,
+    size,
   }: jsonapi.PaginatedRequestParams & { jobSpecId: string }): Promise<
     jsonapi.PaginatedApiResponse<models.OcrJobRun[]>
   > {
-    return this.index(undefined, { jobSpecId })
+    return this.index({ page, size }, { jobSpecId })
   }
 
   private index = this.api.fetchResource<{}, models.OcrJobRun[]>(ENDPOINT)

--- a/operator_ui/src/api/v2/ocrRuns.ts
+++ b/operator_ui/src/api/v2/ocrRuns.ts
@@ -1,0 +1,20 @@
+import * as jsonapi from '@chainlink/json-api-client'
+import { boundMethod } from 'autobind-decorator'
+import * as models from 'core/store/models'
+
+export const ENDPOINT = '/v2/ocr/specs/:jobSpecId/runs'
+
+export class OcrRuns {
+  constructor(private api: jsonapi.Api) {}
+
+  @boundMethod
+  public getJobSpecRuns({
+    jobSpecId,
+  }: jsonapi.PaginatedRequestParams & { jobSpecId: string }): Promise<
+    jsonapi.PaginatedApiResponse<models.OcrJobRun[]>
+  > {
+    return this.index(undefined, { jobSpecId })
+  }
+
+  private index = this.api.fetchResource<{}, models.OcrJobRun[]>(ENDPOINT)
+}

--- a/operator_ui/src/api/v2/ocrSpecs.ts
+++ b/operator_ui/src/api/v2/ocrSpecs.ts
@@ -4,6 +4,7 @@ import * as models from 'core/store/models'
 
 export const ENDPOINT = '/v2/ocr/specs'
 const SHOW_ENDPOINT = `${ENDPOINT}/:specId`
+const DESTROY_ENDPOINT = `${ENDPOINT}/:specId`
 
 export class OcrSpecs {
   constructor(private api: jsonapi.Api) {}
@@ -27,6 +28,11 @@ export class OcrSpecs {
     return this.create(ocrJobSpecRequest)
   }
 
+  @boundMethod
+  public destroyJobSpec(id: string): Promise<jsonapi.ApiResponse<null>> {
+    return this.destroy(undefined, { specId: id })
+  }
+
   private index = this.api.fetchResource<{}, models.OcrJobSpec[]>(ENDPOINT)
 
   private create = this.api.createResource<
@@ -41,4 +47,12 @@ export class OcrSpecs {
       specId: string
     }
   >(SHOW_ENDPOINT)
+
+  private destroy = this.api.deleteResource<
+    undefined,
+    null,
+    {
+      specId: string
+    }
+  >(DESTROY_ENDPOINT)
 }

--- a/operator_ui/src/api/v2/ocrSpecs.ts
+++ b/operator_ui/src/api/v2/ocrSpecs.ts
@@ -1,12 +1,9 @@
 import * as jsonapi from '@chainlink/json-api-client'
 import { boundMethod } from 'autobind-decorator'
 import * as models from 'core/store/models'
-/**
- * Create validates, saves and starts a new off-chain reporting job.
- *
- * @example "POST <application>/ocr/specs"
- */
+
 export const ENDPOINT = '/v2/ocr/specs'
+const SHOW_ENDPOINT = `${ENDPOINT}/:specId`
 
 export class OcrSpecs {
   constructor(private api: jsonapi.Api) {}
@@ -14,6 +11,11 @@ export class OcrSpecs {
   @boundMethod
   public getJobSpecs(): Promise<jsonapi.ApiResponse<models.OcrJobSpec[]>> {
     return this.index()
+  }
+
+  @boundMethod
+  public getJobSpec(id: string): Promise<jsonapi.ApiResponse<models.JobSpec>> {
+    return this.show({}, { specId: id })
   }
 
   @boundMethod
@@ -29,4 +31,12 @@ export class OcrSpecs {
     models.OcrJobSpecRequest,
     models.OcrJobSpec
   >(ENDPOINT)
+
+  private show = this.api.fetchResource<
+    {},
+    models.JobSpec,
+    {
+      specId: string
+    }
+  >(SHOW_ENDPOINT)
 }

--- a/operator_ui/src/api/v2/ocrSpecs.ts
+++ b/operator_ui/src/api/v2/ocrSpecs.ts
@@ -14,7 +14,9 @@ export class OcrSpecs {
   }
 
   @boundMethod
-  public getJobSpec(id: string): Promise<jsonapi.ApiResponse<models.JobSpec>> {
+  public getJobSpec(
+    id: string,
+  ): Promise<jsonapi.ApiResponse<models.OcrJobSpec>> {
     return this.show({}, { specId: id })
   }
 
@@ -34,7 +36,7 @@ export class OcrSpecs {
 
   private show = this.api.fetchResource<
     {},
-    models.JobSpec,
+    models.OcrJobSpec,
     {
       specId: string
     }

--- a/operator_ui/src/api/v2/runs.ts
+++ b/operator_ui/src/api/v2/runs.ts
@@ -37,14 +37,10 @@ export class Runs {
   constructor(private api: jsonapi.Api) {}
 
   @boundMethod
-  public getJobSpecRuns({
-    jobSpecId,
-  }: jsonapi.PaginatedRequestParams & { jobSpecId: string }): Promise<
-    jsonapi.PaginatedApiResponse<models.JobRun[]>
-  > {
-    return this.index({
-      jobSpecId,
-    })
+  public getJobSpecRuns(
+    params: jsonapi.PaginatedRequestParams & { jobSpecId: string },
+  ): Promise<jsonapi.PaginatedApiResponse<models.JobRun[]>> {
+    return this.index(params)
   }
   /**
    * Get n most recent job runs

--- a/operator_ui/src/api/v2/runs.ts
+++ b/operator_ui/src/api/v2/runs.ts
@@ -10,6 +10,7 @@ import * as presenters from 'core/store/presenters'
  */
 export interface IndexParams extends jsonapi.PaginatedRequestParams {
   jobSpecId?: string
+  sort?: '-createdAt'
 }
 const INDEX_ENDPOINT = '/v2/runs'
 
@@ -36,11 +37,19 @@ const SHOW_ENDPOINT = '/v2/runs/:runId'
 export class Runs {
   constructor(private api: jsonapi.Api) {}
 
+  /**
+   * Get a paginated response of job spec runs
+   *
+   * @param params Job spec params
+   */
   @boundMethod
   public getJobSpecRuns(
-    params: jsonapi.PaginatedRequestParams & { jobSpecId: string },
+    params: IndexParams,
   ): Promise<jsonapi.PaginatedApiResponse<models.JobRun[]>> {
-    return this.index(params)
+    return this.index({
+      sort: '-createdAt',
+      ...params,
+    })
   }
   /**
    * Get n most recent job runs
@@ -51,7 +60,7 @@ export class Runs {
   public getRecentJobRuns(
     n: number,
   ): Promise<jsonapi.PaginatedApiResponse<models.JobRun[]>> {
-    return this.index({ size: n })
+    return this.index({ size: n, sort: '-createdAt' })
   }
 
   /**

--- a/operator_ui/src/api/v2/runs.ts
+++ b/operator_ui/src/api/v2/runs.ts
@@ -10,7 +10,6 @@ import * as presenters from 'core/store/presenters'
  */
 export interface IndexParams extends jsonapi.PaginatedRequestParams {
   jobSpecId?: string
-  sort?: '-createdAt'
 }
 const INDEX_ENDPOINT = '/v2/runs'
 
@@ -37,18 +36,14 @@ const SHOW_ENDPOINT = '/v2/runs/:runId'
 export class Runs {
   constructor(private api: jsonapi.Api) {}
 
-  /**
-   * Get a paginated response of job spec runs
-   *
-   * @param params Job spec params
-   */
   @boundMethod
-  public getJobSpecRuns(
-    params: IndexParams,
-  ): Promise<jsonapi.PaginatedApiResponse<models.JobRun[]>> {
+  public getJobSpecRuns({
+    jobSpecId,
+  }: jsonapi.PaginatedRequestParams & { jobSpecId: string }): Promise<
+    jsonapi.PaginatedApiResponse<models.JobRun[]>
+  > {
     return this.index({
-      sort: '-createdAt',
-      ...params,
+      jobSpecId,
     })
   }
   /**
@@ -60,7 +55,7 @@ export class Runs {
   public getRecentJobRuns(
     n: number,
   ): Promise<jsonapi.PaginatedApiResponse<models.JobRun[]>> {
-    return this.index({ size: n, sort: '-createdAt' })
+    return this.index({ size: n })
   }
 
   /**

--- a/operator_ui/src/components/JobRuns/List.tsx
+++ b/operator_ui/src/components/JobRuns/List.tsx
@@ -7,11 +7,9 @@ import TableCell from '@material-ui/core/TableCell'
 import TableRow from '@material-ui/core/TableRow'
 import Typography from '@material-ui/core/Typography'
 import classNames from 'classnames'
-import { JobRun } from 'core/store/models'
+import { RunStatus } from 'core/store/models'
 import React from 'react'
 import titleize from '../../utils/titleize'
-import BaseLink from '../BaseLink'
-import Button from '../Button'
 import Link from '../Link'
 
 const styles = (theme: any) =>
@@ -75,7 +73,16 @@ const classFromStatus = (classes: any, status: string) => {
   return classes[status.toLowerCase()]
 }
 
-const renderRuns = (runs: JobRun[], classes: any) => {
+const renderRuns = (
+  runs: {
+    createdAt: string
+    id: string
+    status: RunStatus
+    jobId: string
+  }[],
+  classes: any,
+  hideLinks: undefined | boolean,
+) => {
   if (runs && runs.length === 0) {
     return (
       <TableRow>
@@ -91,15 +98,21 @@ const renderRuns = (runs: JobRun[], classes: any) => {
       </TableRow>
     )
   } else if (runs) {
-    return runs.map((r: JobRun) => (
+    return runs.map((r) => (
       <TableRow key={r.id}>
         <TableCell className={classes.idCell} scope="row">
           <div className={classes.runDetails}>
-            <Link href={`/jobs/${r.jobId}/runs/id/${r.id}`}>
-              <Typography variant="h5" color="primary" component="span">
+            {hideLinks ? (
+              <Typography variant="h5" color="textPrimary" component="span">
                 {r.id}
               </Typography>
-            </Link>
+            ) : (
+              <Link href={`/jobs/${r.jobId}/runs/id/${r.id}`}>
+                <Typography variant="h5" color="primary" component="span">
+                  {r.id}
+                </Typography>
+              </Link>
+            )}
           </div>
         </TableCell>
         <TableCell className={classes.stampCell}>
@@ -134,30 +147,20 @@ const renderRuns = (runs: JobRun[], classes: any) => {
 }
 
 interface Props extends WithStyles<typeof styles> {
-  jobSpecId: string
-  runs: JobRun[]
-  count: number
-  showJobRunsCount: number
+  runs: {
+    createdAt: string
+    id: string
+    status: RunStatus
+    jobId: string
+  }[]
+  hideLinks?: boolean
 }
 
-const List = ({ jobSpecId, runs, count, showJobRunsCount, classes }: Props) => {
+const List = ({ runs, classes, hideLinks }: Props) => {
   return (
     <Card className={classes.jobRunsCard}>
       <Table padding="none">
-        <TableBody>
-          {renderRuns(runs, classes)}
-          {runs && count > showJobRunsCount && (
-            <TableRow>
-              <TableCell>
-                <div className={classes.runDetails}>
-                  <Button href={`/jobs/${jobSpecId}/runs`} component={BaseLink}>
-                    View More
-                  </Button>
-                </div>
-              </TableCell>
-            </TableRow>
-          )}
-        </TableBody>
+        <TableBody>{renderRuns(runs, classes, hideLinks)}</TableBody>
       </Table>
     </Card>
   )

--- a/operator_ui/src/pages/Jobs/Definition.test.tsx
+++ b/operator_ui/src/pages/Jobs/Definition.test.tsx
@@ -20,7 +20,7 @@ describe('pages/Jobs/Definition', () => {
     const wrapper = mountWithProviders(
       <Route path="/jobs/:jobSpecId" component={JobsShow} />,
       {
-        initialEntries: [`/jobs/${JOB_SPEC_ID}/json`],
+        initialEntries: [`/jobs/${JOB_SPEC_ID}/definition`],
       },
     )
 

--- a/operator_ui/src/pages/Jobs/Definition.tsx
+++ b/operator_ui/src/pages/Jobs/Definition.tsx
@@ -32,15 +32,15 @@ const Definition: React.FC<
     error: unknown
     ErrorComponent: React.FC
     LoadingPlaceholder: React.FC
+    job?: JobData['job']
     jobSpec?: JobData['jobSpec']
   } & WithStyles<typeof definitionStyles>
-> = ({ classes, error, ErrorComponent, LoadingPlaceholder, jobSpec }) => {
+> = ({ classes, error, ErrorComponent, LoadingPlaceholder, job, jobSpec }) => {
   React.useEffect(() => {
-    document.title =
-      jobSpec && jobSpec.attributes.name
-        ? `${jobSpec.attributes.name} | Job definition`
-        : 'Job definition'
-  }, [jobSpec])
+    document.title = job?.name
+      ? `${job.name} | Job definition`
+      : 'Job definition'
+  }, [job])
 
   return (
     <Content>

--- a/operator_ui/src/pages/Jobs/Errors.tsx
+++ b/operator_ui/src/pages/Jobs/Errors.tsx
@@ -18,6 +18,7 @@ export const JobsErrors: React.FC<{
   error: unknown
   ErrorComponent: React.FC
   LoadingPlaceholder: React.FC
+  job?: JobData['job']
   jobSpec?: JobData['jobSpec']
   setState: React.Dispatch<React.SetStateAction<JobData>>
   getJobSpec: () => Promise<void>
@@ -26,15 +27,13 @@ export const JobsErrors: React.FC<{
   ErrorComponent,
   getJobSpec,
   LoadingPlaceholder,
+  job,
   jobSpec,
   setState,
 }) => {
   React.useEffect(() => {
-    document.title =
-      jobSpec && jobSpec.attributes.name
-        ? `${jobSpec.attributes.name} | Job errors`
-        : 'Job errors'
-  }, [jobSpec])
+    document.title = job?.name ? `${job?.name} | Job errors` : 'Job errors'
+  }, [job])
 
   const handleDismiss = async (jobSpecErrorId: string) => {
     // Optimistic delete

--- a/operator_ui/src/pages/Jobs/RecentRuns.tsx
+++ b/operator_ui/src/pages/Jobs/RecentRuns.tsx
@@ -1,13 +1,17 @@
 import { CardTitle, KeyValueList } from '@chainlink/styleguide'
 import {
-  createStyles,
+  Card,
+  Grid,
+  TableCell,
+  TableRow,
   Theme,
   Typography,
   WithStyles,
+  createStyles,
   withStyles,
-  Card,
-  Grid,
 } from '@material-ui/core'
+import Button from 'components/Button'
+import BaseLink from 'components/BaseLink'
 import Content from 'components/Content'
 import JobRunsList from 'components/JobRuns/List'
 import React from 'react'
@@ -58,6 +62,11 @@ const chartCardStyles = ({ spacing, palette }: Theme) =>
     status: {
       marginRight: spacing.unit * 2,
       marginLeft: -22,
+    },
+    runDetails: {
+      paddingTop: spacing.unit * 2,
+      paddingBottom: spacing.unit * 2,
+      paddingLeft: spacing.unit * 2,
     },
   })
 
@@ -110,15 +119,31 @@ export const RecentRuns = withStyles(chartCardStyles)(
                 <CardTitle divider>Recent Job Runs</CardTitle>
 
                 {recentRuns && (
-                  <JobRunsList
-                    jobSpecId={job.id}
-                    runs={recentRuns.map((jobRun) => ({
-                      ...jobRun,
-                      ...jobRun.attributes,
-                    }))}
-                    count={recentRunsCount}
-                    showJobRunsCount={showJobRunsCount}
-                  />
+                  <>
+                    <JobRunsList
+                      runs={recentRuns.map(
+                        (jobRun: NonNullable<JobData['recentRuns']>[0]) => ({
+                          ...jobRun,
+                        }),
+                      )}
+                      hideLinks={job?.type === 'Off-chain reporting'}
+                    />
+                    {job?.type === 'Direct request' &&
+                      recentRuns.length > showJobRunsCount && (
+                        <TableRow>
+                          <TableCell>
+                            <div className={classes.runDetails}>
+                              <Button
+                                href={`/jobs/${job.id}/runs`}
+                                component={BaseLink}
+                              >
+                                View More
+                              </Button>
+                            </div>
+                          </TableCell>
+                        </TableRow>
+                      )}
+                  </>
                 )}
               </Card>
             </Grid>
@@ -135,7 +160,7 @@ export const RecentRuns = withStyles(chartCardStyles)(
                           Link Payment
                         </Typography>
                         <Typography className={classes.earnedText}>
-                          {totalLinkEarned(jobSpec)}
+                          {totalLinkEarned(job)}
                         </Typography>
                       </Grid>
                     </Card>

--- a/operator_ui/src/pages/Jobs/RecentRuns.tsx
+++ b/operator_ui/src/pages/Jobs/RecentRuns.tsx
@@ -14,6 +14,7 @@ import Button from 'components/Button'
 import BaseLink from 'components/BaseLink'
 import Content from 'components/Content'
 import JobRunsList from 'components/JobRuns/List'
+import TaskList from 'components/Jobs/TaskList'
 import React from 'react'
 import { GWEI_PER_TOKEN } from 'utils/constants'
 import formatMinPayment from 'utils/formatWeiAsset'
@@ -44,34 +45,12 @@ const chartCardStyles = ({ spacing, palette }: Theme) =>
       color: palette.text.secondary,
       fontSize: spacing.unit * 2,
     },
-    container: {
-      margin: 0,
-      marginLeft: spacing.unit * 2,
-      paddingLeft: 0,
-    },
-    item: {
-      borderLeft: 'solid 2px',
-      borderColor: palette.grey[200],
-      display: 'flex',
-      alignItems: 'center',
-      listStyle: 'none',
-      paddingBottom: spacing.unit * 1,
-      paddingTop: spacing.unit * 1,
-      marginLeft: spacing.unit * 2,
-    },
-    status: {
-      marginRight: spacing.unit * 2,
-      marginLeft: -22,
-    },
     runDetails: {
       paddingTop: spacing.unit * 2,
       paddingBottom: spacing.unit * 2,
       paddingLeft: spacing.unit * 2,
     },
   })
-
-import ListIcon from 'components/Icons/ListIcon'
-import titleize from 'utils/titleize'
 
 interface Props extends WithStyles<typeof chartCardStyles> {
   ErrorComponent: React.FC
@@ -168,22 +147,7 @@ export const RecentRuns = withStyles(chartCardStyles)(
                   <Grid item xs>
                     <Card>
                       <CardTitle divider>Task List</CardTitle>
-                      <ul className={classes.container}>
-                        {job.tasks &&
-                          job.tasks.map((task, idx) => {
-                            return (
-                              <li key={idx} className={classes.item}>
-                                <ListIcon
-                                  width={40}
-                                  className={classes.status}
-                                />
-                                <Typography variant="body1" inline>
-                                  {titleize(task.type)}
-                                </Typography>
-                              </li>
-                            )
-                          })}
-                      </ul>
+                      <TaskList tasks={job.tasks} />
                     </Card>
                   </Grid>
                   <Grid item xs>

--- a/operator_ui/src/pages/Jobs/RecentRuns.tsx
+++ b/operator_ui/src/pages/Jobs/RecentRuns.tsx
@@ -10,142 +10,176 @@ import {
 } from '@material-ui/core'
 import Content from 'components/Content'
 import JobRunsList from 'components/JobRuns/List'
-import TaskList from 'components/Jobs/TaskList'
 import React from 'react'
 import { GWEI_PER_TOKEN } from 'utils/constants'
 import formatMinPayment from 'utils/formatWeiAsset'
 import { formatInitiators } from 'utils/jobSpecInitiators'
-import { JobData } from './sharedTypes'
+import { DirectRequestJob, JobData } from './sharedTypes'
 
-const totalLinkEarned = (job: NonNullable<JobData['jobSpec']>) => {
+const totalLinkEarned = (job: DirectRequestJob) => {
   const zero = '0.000000'
-  const unformatted =
-    job.attributes.earnings &&
-    (job.attributes.earnings / GWEI_PER_TOKEN).toString()
+  const unformatted = job.earnings && (job.earnings / GWEI_PER_TOKEN).toString()
   const formatted =
     unformatted &&
     (unformatted.length >= 3 ? unformatted : (unformatted + '.').padEnd(8, '0'))
   return formatted || zero
 }
 
-const chartCardStyles = (theme: Theme) =>
+const chartCardStyles = ({ spacing, palette }: Theme) =>
   createStyles({
     wrapper: {
-      marginLeft: theme.spacing.unit * 3,
-      marginTop: theme.spacing.unit * 2,
-      marginBottom: theme.spacing.unit * 2,
+      marginLeft: spacing.unit * 3,
+      marginTop: spacing.unit * 2,
+      marginBottom: spacing.unit * 2,
     },
     paymentText: {
-      color: theme.palette.secondary.main,
+      color: palette.secondary.main,
       fontWeight: 450,
     },
     earnedText: {
-      color: theme.palette.text.secondary,
-      fontSize: theme.spacing.unit * 2,
+      color: palette.text.secondary,
+      fontSize: spacing.unit * 2,
+    },
+    container: {
+      margin: 0,
+      marginLeft: spacing.unit * 2,
+      paddingLeft: 0,
+    },
+    item: {
+      borderLeft: 'solid 2px',
+      borderColor: palette.grey[200],
+      display: 'flex',
+      alignItems: 'center',
+      listStyle: 'none',
+      paddingBottom: spacing.unit * 1,
+      paddingTop: spacing.unit * 1,
+      marginLeft: spacing.unit * 2,
+    },
+    status: {
+      marginRight: spacing.unit * 2,
+      marginLeft: -22,
     },
   })
 
-interface ChartProps extends WithStyles<typeof chartCardStyles> {
-  jobSpec: NonNullable<JobData['jobSpec']>
-}
+import ListIcon from 'components/Icons/ListIcon'
+import titleize from 'utils/titleize'
 
-const ChartArea = withStyles(chartCardStyles)(
-  ({ classes, jobSpec }: ChartProps) => (
-    <Card>
-      <Grid item className={classes.wrapper}>
-        <Typography className={classes.paymentText} variant="h5">
-          Link Payment
-        </Typography>
-        <Typography className={classes.earnedText}>
-          {totalLinkEarned(jobSpec)}
-        </Typography>
-      </Grid>
-    </Card>
-  ),
-)
-
-export const RecentRuns = ({
-  ErrorComponent,
-  LoadingPlaceholder,
-  error,
-  getJobSpecRuns,
-  jobSpec,
-  recentRuns,
-  recentRunsCount,
-  showJobRunsCount = 5,
-}: {
+interface Props extends WithStyles<typeof chartCardStyles> {
   ErrorComponent: React.FC
   LoadingPlaceholder: React.FC
   error: unknown
   getJobSpecRuns: () => Promise<void>
+  job?: JobData['job']
   jobSpec?: JobData['jobSpec']
   recentRuns?: JobData['recentRuns']
   recentRunsCount: JobData['recentRunsCount']
   showJobRunsCount?: number
-}) => {
-  React.useEffect(() => {
-    document.title =
-      jobSpec && jobSpec.attributes.name
-        ? `${jobSpec.attributes.name} | Job spec details`
+}
+
+export const RecentRuns = withStyles(chartCardStyles)(
+  ({
+    classes,
+    ErrorComponent,
+    LoadingPlaceholder,
+    error,
+    getJobSpecRuns,
+    job,
+    jobSpec,
+    recentRuns,
+    recentRunsCount,
+    showJobRunsCount = 5,
+  }: Props) => {
+    React.useEffect(() => {
+      document.title = job?.name
+        ? `${job.name} | Job spec details`
         : 'Job spec details'
-  }, [jobSpec])
+    }, [job])
 
-  React.useEffect(() => {
-    getJobSpecRuns()
-  }, [getJobSpecRuns])
+    React.useEffect(() => {
+      getJobSpecRuns()
+    }, [getJobSpecRuns])
 
-  return (
-    <Content>
-      <ErrorComponent />
-      <LoadingPlaceholder />
-      {!error && jobSpec && (
-        <Grid container spacing={24}>
-          <Grid item xs={8}>
-            <Card>
-              <CardTitle divider>Recent Job Runs</CardTitle>
+    return (
+      <Content>
+        <ErrorComponent />
+        <LoadingPlaceholder />
+        {!error && job && (
+          <Grid container spacing={24}>
+            <Grid item xs={8}>
+              <Card>
+                <CardTitle divider>Recent Job Runs</CardTitle>
 
-              {recentRuns && (
-                <JobRunsList
-                  jobSpecId={jobSpec.id}
-                  runs={recentRuns.map((jobRun) => ({
-                    ...jobRun,
-                    ...jobRun.attributes,
-                  }))}
-                  count={recentRunsCount}
-                  showJobRunsCount={showJobRunsCount}
-                />
+                {recentRuns && (
+                  <JobRunsList
+                    jobSpecId={job.id}
+                    runs={recentRuns.map((jobRun) => ({
+                      ...jobRun,
+                      ...jobRun.attributes,
+                    }))}
+                    count={recentRunsCount}
+                    showJobRunsCount={showJobRunsCount}
+                  />
+                )}
+              </Card>
+            </Grid>
+            <Grid item xs={4}>
+              {job?.type === 'Direct request' && jobSpec && (
+                <Grid container direction="column">
+                  <Grid item xs>
+                    <Card>
+                      <Grid item className={classes.wrapper}>
+                        <Typography
+                          className={classes.paymentText}
+                          variant="h5"
+                        >
+                          Link Payment
+                        </Typography>
+                        <Typography className={classes.earnedText}>
+                          {totalLinkEarned(jobSpec)}
+                        </Typography>
+                      </Grid>
+                    </Card>
+                  </Grid>
+                  <Grid item xs>
+                    <Card>
+                      <CardTitle divider>Task List</CardTitle>
+                      <ul className={classes.container}>
+                        {job.tasks &&
+                          job.tasks.map((task, idx) => {
+                            return (
+                              <li key={idx} className={classes.item}>
+                                <ListIcon
+                                  width={40}
+                                  className={classes.status}
+                                />
+                                <Typography variant="body1" inline>
+                                  {titleize(task.type)}
+                                </Typography>
+                              </li>
+                            )
+                          })}
+                      </ul>
+                    </Card>
+                  </Grid>
+                  <Grid item xs>
+                    <KeyValueList
+                      showHead={false}
+                      entries={Object.entries({
+                        runCount: recentRunsCount,
+                        initiator: formatInitiators(job.initiators),
+                        minimumPayment: `${
+                          formatMinPayment(Number(job.minPayment)) || 0
+                        } Link`,
+                      })}
+                      titleize
+                    />
+                  </Grid>
+                </Grid>
               )}
-            </Card>
-          </Grid>
-          <Grid item xs={4}>
-            <Grid container direction="column">
-              <Grid item xs>
-                <ChartArea jobSpec={jobSpec} />
-              </Grid>
-              <Grid item xs>
-                <Card>
-                  <CardTitle divider>Task List</CardTitle>
-                  <TaskList tasks={jobSpec.attributes.tasks} />
-                </Card>
-              </Grid>
-              <Grid item xs>
-                <KeyValueList
-                  showHead={false}
-                  entries={Object.entries({
-                    runCount: recentRunsCount,
-                    initiator: formatInitiators(jobSpec.attributes.initiators),
-                    minimumPayment: `${
-                      formatMinPayment(Number(jobSpec.attributes.minPayment)) ||
-                      0
-                    } Link`,
-                  })}
-                  titleize
-                />
-              </Grid>
             </Grid>
           </Grid>
-        </Grid>
-      )}
-    </Content>
-  )
-}
+        )}
+      </Content>
+    )
+  },
+)

--- a/operator_ui/src/pages/Jobs/RegionalNav.tsx
+++ b/operator_ui/src/pages/Jobs/RegionalNav.tsx
@@ -24,7 +24,7 @@ import CopyJobSpec from 'components/CopyJobSpec'
 import Close from 'components/Icons/Close'
 import Link from 'components/Link'
 import ErrorMessage from 'components/Notifications/DefaultError'
-import { Job } from './sharedTypes'
+import { JobData } from './sharedTypes'
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -120,7 +120,7 @@ interface Props extends WithStyles<typeof styles> {
   createJobRun: Function
   deleteJobSpec: Function
   jobSpecId: string
-  job?: Job
+  job: JobData['job']
   url: string
   getJobSpecRuns: () => Promise<void>
 }
@@ -135,7 +135,7 @@ const RegionalNavComponent = ({
 }: Props) => {
   const location = useLocation()
   const navErrorsActive = location.pathname.endsWith('/errors')
-  const navDefinitionActive = location.pathname.endsWith('/json')
+  const navDefinitionActive = location.pathname.endsWith('/definition')
   const navOverviewActive = !navDefinitionActive && !navErrorsActive
   const [modalOpen, setModalOpen] = React.useState(false)
   const [archived, setArchived] = React.useState(false)
@@ -151,7 +151,12 @@ const RegionalNavComponent = ({
     ).then(() => getJobSpecRuns())
   }
   const handleDelete = (id: string) => {
-    deleteJobSpec(id, () => DeleteSuccessNotification({ id }), ErrorMessage)
+    deleteJobSpec(
+      id,
+      () => DeleteSuccessNotification({ id }),
+      ErrorMessage,
+      job?.type,
+    )
     setArchived(true)
   }
   return (
@@ -251,14 +256,16 @@ const RegionalNavComponent = ({
                     >
                       Archive
                     </Button>
-                    {job.initiators && isWebInitiator(job.initiators) && (
-                      <Button
-                        onClick={handleRun}
-                        className={classes.regionalNavButton}
-                      >
-                        Run
-                      </Button>
-                    )}
+                    {job.type === 'Direct request' &&
+                      job.initiators &&
+                      isWebInitiator(job.initiators) && (
+                        <Button
+                          onClick={handleRun}
+                          className={classes.regionalNavButton}
+                        >
+                          Run
+                        </Button>
+                      )}
                     {job.definition && (
                       <Button
                         href={`/jobs/new?definition=${encodeURIComponent(
@@ -307,28 +314,32 @@ const RegionalNavComponent = ({
                   Overview
                 </Link>
               </ListItem>
-              <ListItem className={classes.horizontalNavItem}>
-                <Link
-                  href={`/jobs/${jobSpecId}/json`}
-                  className={classNames(
-                    classes.horizontalNavLink,
-                    navDefinitionActive && classes.activeNavLink,
-                  )}
-                >
-                  Definition
-                </Link>
-              </ListItem>
-              <ListItem className={classes.horizontalNavItem}>
-                <Link
-                  href={`/jobs/${jobSpecId}/errors`}
-                  className={classNames(
-                    classes.horizontalNavLink,
-                    navErrorsActive && classes.activeNavLink,
-                  )}
-                >
-                  {errorsTabText}
-                </Link>
-              </ListItem>
+              {job?.type === 'Direct request' && (
+                <>
+                  <ListItem className={classes.horizontalNavItem}>
+                    <Link
+                      href={`/jobs/${jobSpecId}/definition`}
+                      className={classNames(
+                        classes.horizontalNavLink,
+                        navDefinitionActive && classes.activeNavLink,
+                      )}
+                    >
+                      Definition
+                    </Link>
+                  </ListItem>
+                  <ListItem className={classes.horizontalNavItem}>
+                    <Link
+                      href={`/jobs/${jobSpecId}/errors`}
+                      className={classNames(
+                        classes.horizontalNavLink,
+                        navErrorsActive && classes.activeNavLink,
+                      )}
+                    >
+                      {errorsTabText}
+                    </Link>
+                  </ListItem>
+                </>
+              )}
             </List>
           </Grid>
         </Grid>

--- a/operator_ui/src/pages/Jobs/RegionalNav.tsx
+++ b/operator_ui/src/pages/Jobs/RegionalNav.tsx
@@ -218,9 +218,11 @@ const RegionalNavComponent = ({
       <Card className={classes.container}>
         <Grid container spacing={0}>
           <Grid item xs={12}>
-            <Typography variant="subtitle2" color="secondary" gutterBottom>
-              {job?.type} job spec detail
-            </Typography>
+            {job && (
+              <Typography variant="subtitle2" color="secondary" gutterBottom>
+                {job?.type} job spec detail
+              </Typography>
+            )}
           </Grid>
           <Grid item xs={12}>
             <Grid
@@ -230,45 +232,51 @@ const RegionalNavComponent = ({
               className={classes.mainRow}
             >
               <Grid item xs={6}>
-                <Typography
-                  variant="h3"
-                  color="secondary"
-                  className={classes.jobSpecId}
-                >
-                  {job?.name || jobSpecId}
-                </Typography>
+                {job && (
+                  <Typography
+                    variant="h3"
+                    color="secondary"
+                    className={classes.jobSpecId}
+                  >
+                    {job.name || jobSpecId}
+                  </Typography>
+                )}
               </Grid>
               <Grid item xs={6} className={classes.actions}>
-                <Button
-                  className={classes.regionalNavButton}
-                  onClick={() => setModalOpen(true)}
-                >
-                  Archive
-                </Button>
-                {job?.initiators && isWebInitiator(job.initiators) && (
-                  <Button
-                    onClick={handleRun}
-                    className={classes.regionalNavButton}
-                  >
-                    Run
-                  </Button>
-                )}
-                {job?.definition && (
-                  <Button
-                    href={`/jobs/new?definition=${encodeURIComponent(
-                      JSON.stringify(job?.definition),
-                    )}`}
-                    component={BaseLink}
-                    className={classes.regionalNavButton}
-                  >
-                    Duplicate
-                  </Button>
-                )}
-                {job?.definition && (
-                  <CopyJobSpec
-                    JobSpec={job.definition}
-                    className={classes.regionalNavButton}
-                  />
+                {job && (
+                  <>
+                    <Button
+                      className={classes.regionalNavButton}
+                      onClick={() => setModalOpen(true)}
+                    >
+                      Archive
+                    </Button>
+                    {job.initiators && isWebInitiator(job.initiators) && (
+                      <Button
+                        onClick={handleRun}
+                        className={classes.regionalNavButton}
+                      >
+                        Run
+                      </Button>
+                    )}
+                    {job.definition && (
+                      <Button
+                        href={`/jobs/new?definition=${encodeURIComponent(
+                          JSON.stringify(job.definition),
+                        )}`}
+                        component={BaseLink}
+                        className={classes.regionalNavButton}
+                      >
+                        Duplicate
+                      </Button>
+                    )}
+                    {job.definition && (
+                      <CopyJobSpec
+                        JobSpec={job.definition}
+                        className={classes.regionalNavButton}
+                      />
+                    )}
+                  </>
                 )}
               </Grid>
             </Grid>
@@ -279,15 +287,12 @@ const RegionalNavComponent = ({
                 {job.id}
               </Typography>
             )}
-            <Typography variant="subtitle2" color="textSecondary">
-              Created{' '}
-              {job?.createdAt && (
-                <>
-                  <TimeAgo tooltip={false}>{job.createdAt}</TimeAgo> (
-                  {localizedTimestamp(job.createdAt)})
-                </>
-              )}
-            </Typography>
+            {job?.createdAt && (
+              <Typography variant="subtitle2" color="textSecondary">
+                Created <TimeAgo tooltip={false}>{job.createdAt}</TimeAgo> (
+                {localizedTimestamp(job.createdAt)})
+              </Typography>
+            )}
           </Grid>
           <Grid item xs={12}>
             <List className={classes.horizontalNav}>
@@ -310,7 +315,7 @@ const RegionalNavComponent = ({
                     navDefinitionActive && classes.activeNavLink,
                   )}
                 >
-                  JSON
+                  Definition
                 </Link>
               </ListItem>
               <ListItem className={classes.horizontalNavItem}>

--- a/operator_ui/src/pages/Jobs/RegionalNav.tsx
+++ b/operator_ui/src/pages/Jobs/RegionalNav.tsx
@@ -12,7 +12,7 @@ import {
 } from '@material-ui/core/styles'
 import Typography from '@material-ui/core/Typography'
 import { ApiResponse } from '@chainlink/json-api-client'
-import { JobSpec, OcrJobSpec, JobSpecError, Initiator } from 'core/store/models'
+import { JobSpec } from 'core/store/models'
 import classNames from 'classnames'
 import React from 'react'
 import { connect } from 'react-redux'
@@ -24,7 +24,7 @@ import CopyJobSpec from 'components/CopyJobSpec'
 import Close from 'components/Icons/Close'
 import Link from 'components/Link'
 import ErrorMessage from 'components/Notifications/DefaultError'
-import jobSpecDefinition from 'utils/jobSpecDefinition'
+import { Job } from './sharedTypes'
 
 const styles = (theme: Theme) =>
   createStyles({
@@ -120,16 +120,7 @@ interface Props extends WithStyles<typeof styles> {
   createJobRun: Function
   deleteJobSpec: Function
   jobSpecId: string
-  job:
-    | {
-        type: 'Direct request'
-        jobSpec: ApiResponse<JobSpec>['data']
-      }
-    | {
-        type: 'Off-chain reporting'
-        jobSpec: ApiResponse<OcrJobSpec>['data']
-      }
-    | null
+  job?: Job
   url: string
   getJobSpecRuns: () => Promise<void>
 }
@@ -138,7 +129,7 @@ const RegionalNavComponent = ({
   classes,
   createJobRun,
   jobSpecId,
-  job: mixedJob,
+  job,
   deleteJobSpec,
   getJobSpecRuns,
 }: Props) => {
@@ -146,37 +137,6 @@ const RegionalNavComponent = ({
   const navErrorsActive = location.pathname.endsWith('/errors')
   const navDefinitionActive = location.pathname.endsWith('/json')
   const navOverviewActive = !navDefinitionActive && !navErrorsActive
-
-  let job:
-    | {
-        id: string
-        name?: string
-        errors: JobSpecError[]
-        definition: unknown
-        initiators: undefined | Initiator[]
-        createdAt: string
-      }
-    | undefined
-
-  if (mixedJob?.type === 'Off-chain reporting') {
-    job = {
-      ...mixedJob.jobSpec.attributes.offChainReportingOracleSpec,
-      id: mixedJob.jobSpec.id,
-      errors: mixedJob.jobSpec.attributes.errors,
-      definition: undefined,
-      initiators: undefined,
-    }
-  } else if (mixedJob?.type === 'Direct request') {
-    job = {
-      ...mixedJob.jobSpec.attributes,
-      id: mixedJob.jobSpec.id,
-      definition: jobSpecDefinition({
-        ...mixedJob.jobSpec,
-        ...mixedJob.jobSpec.attributes,
-      }),
-    }
-  }
-
   const [modalOpen, setModalOpen] = React.useState(false)
   const [archived, setArchived] = React.useState(false)
   const errorsTabText =
@@ -259,7 +219,7 @@ const RegionalNavComponent = ({
         <Grid container spacing={0}>
           <Grid item xs={12}>
             <Typography variant="subtitle2" color="secondary" gutterBottom>
-              {mixedJob?.type} job spec detail
+              {job?.type} job spec detail
             </Typography>
           </Grid>
           <Grid item xs={12}>

--- a/operator_ui/src/pages/Jobs/Show.tsx
+++ b/operator_ui/src/pages/Jobs/Show.tsx
@@ -79,8 +79,7 @@ export const JobsShow: React.FC<Props> = ({ match }) => {
               id: jobSpec.id,
               errors: jobSpec.attributes.errors,
               definition: undefined,
-              initiators: undefined,
-              type: 'Off-chain-reporting',
+              type: 'Off-chain reporting',
             },
           }))
         })
@@ -121,7 +120,7 @@ export const JobsShow: React.FC<Props> = ({ match }) => {
       />
       <Switch>
         <Route
-          path={`${match.path}/json`}
+          path={`${match.path}/definition`}
           render={() => (
             <JobsDefinition
               {...{

--- a/operator_ui/src/pages/Jobs/sharedTypes.ts
+++ b/operator_ui/src/pages/Jobs/sharedTypes.ts
@@ -1,5 +1,12 @@
 import { ApiResponse, PaginatedApiResponse } from '@chainlink/json-api-client'
-import { JobSpec, OcrJobSpec, JobRun, OcrJobRun } from 'core/store/models'
+import {
+  JobSpec,
+  OcrJobSpec,
+  JobRun,
+  OcrJobRun,
+  JobSpecError,
+  Initiator,
+} from 'core/store/models'
 
 export type JobRunsResponse =
   | PaginatedApiResponse<JobRun[]>
@@ -7,7 +14,18 @@ export type JobRunsResponse =
 
 export type JobSpecResponse = ApiResponse<JobSpec> | ApiResponse<OcrJobSpec>
 
+export type Job = {
+  createdAt: string
+  definition: unknown
+  errors: JobSpecError[]
+  id: string
+  initiators: undefined | Initiator[]
+  name?: string
+  type: 'Off-chain-reporting' | 'Direct request'
+}
+
 export type JobData = {
+  job?: Job
   jobSpec?: JobSpecResponse['data']
   recentRuns?: JobRunsResponse['data']
   recentRunsCount: number

--- a/operator_ui/src/pages/Jobs/sharedTypes.ts
+++ b/operator_ui/src/pages/Jobs/sharedTypes.ts
@@ -1,8 +1,14 @@
 import { ApiResponse, PaginatedApiResponse } from '@chainlink/json-api-client'
-import { JobSpec, JobRun } from 'core/store/models'
+import { JobSpec, OcrJobSpec, JobRun, OcrJobRun } from 'core/store/models'
+
+export type JobRunsResponse =
+  | PaginatedApiResponse<JobRun[]>
+  | PaginatedApiResponse<OcrJobRun[]>
+
+export type JobSpecResponse = ApiResponse<JobSpec> | ApiResponse<OcrJobSpec>
 
 export type JobData = {
-  jobSpec?: ApiResponse<JobSpec>['data']
-  recentRuns?: PaginatedApiResponse<JobRun[]>['data']
+  jobSpec?: JobSpecResponse['data']
+  recentRuns?: JobRunsResponse['data']
   recentRunsCount: number
 }

--- a/operator_ui/src/pages/Jobs/sharedTypes.ts
+++ b/operator_ui/src/pages/Jobs/sharedTypes.ts
@@ -1,11 +1,12 @@
 import { ApiResponse, PaginatedApiResponse } from '@chainlink/json-api-client'
 import {
-  JobSpec,
-  OcrJobSpec,
-  JobRun,
-  OcrJobRun,
-  JobSpecError,
   Initiator,
+  JobRun,
+  JobSpec,
+  JobSpecError,
+  OcrJobRun,
+  OcrJobSpec,
+  TaskSpec,
 } from 'core/store/models'
 
 export type JobRunsResponse =
@@ -14,18 +15,28 @@ export type JobRunsResponse =
 
 export type JobSpecResponse = ApiResponse<JobSpec> | ApiResponse<OcrJobSpec>
 
-export type Job = {
+export type BaseJob = {
   createdAt: string
   definition: unknown
   errors: JobSpecError[]
   id: string
-  initiators: undefined | Initiator[]
   name?: string
-  type: 'Off-chain-reporting' | 'Direct request'
+}
+
+export type OffChainReportingJob = BaseJob & {
+  type: 'Off-chain reporting'
+}
+
+export type DirectRequestJob = BaseJob & {
+  earnings: number | null
+  initiators: Initiator[]
+  minPayment?: string | null
+  tasks: TaskSpec[]
+  type: 'Direct request'
 }
 
 export type JobData = {
-  job?: Job
+  job?: DirectRequestJob | OffChainReportingJob
   jobSpec?: JobSpecResponse['data']
   recentRuns?: JobRunsResponse['data']
   recentRunsCount: number

--- a/operator_ui/src/pages/Jobs/sharedTypes.ts
+++ b/operator_ui/src/pages/Jobs/sharedTypes.ts
@@ -7,6 +7,7 @@ import {
   OcrJobRun,
   OcrJobSpec,
   TaskSpec,
+  RunStatus,
 } from 'core/store/models'
 
 export type JobRunsResponse =
@@ -21,6 +22,13 @@ export type BaseJob = {
   errors: JobSpecError[]
   id: string
   name?: string
+}
+
+export type BaseJobRun = {
+  createdAt: string
+  id: string
+  status: RunStatus
+  jobId: string
 }
 
 export type OffChainReportingJob = BaseJob & {
@@ -38,6 +46,6 @@ export type DirectRequestJob = BaseJob & {
 export type JobData = {
   job?: DirectRequestJob | OffChainReportingJob
   jobSpec?: JobSpecResponse['data']
-  recentRuns?: JobRunsResponse['data']
+  recentRuns?: BaseJobRun[]
   recentRunsCount: number
 }

--- a/operator_ui/src/pages/JobsIndex/DirectRequestRow.tsx
+++ b/operator_ui/src/pages/JobsIndex/DirectRequestRow.tsx
@@ -28,7 +28,11 @@ export const DirectRequestRow = withStyles(styles)(
     const history = useHistory()
 
     return (
-      <TableRow hover onClick={() => history.push(`/jobs/${job.id}`)}>
+      <TableRow
+        style={{ cursor: 'pointer' }}
+        hover
+        onClick={() => history.push(`/jobs/${job.id}`)}
+      >
         <TableCell className={classes.cell} component="th" scope="row">
           {job.attributes.name || job.id}
           {job.attributes.name && (

--- a/operator_ui/src/pages/JobsIndex/OcrJobRow.tsx
+++ b/operator_ui/src/pages/JobsIndex/OcrJobRow.tsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { useHistory } from 'react-router-dom'
 import { TableCell, TableRow, Typography } from '@material-ui/core'
 import { TimeAgo } from '@chainlink/styleguide'
 import { OffChainReporting } from './JobsIndex'
@@ -22,8 +23,13 @@ interface Props extends WithStyles<typeof styles> {
 }
 
 export const OcrJobRow = withStyles(styles)(({ job, classes }: Props) => {
+  const history = useHistory()
   return (
-    <TableRow>
+    <TableRow
+      style={{ cursor: 'pointer' }}
+      hover
+      onClick={() => history.push(`/jobs/${job.id}`)}
+    >
       <TableCell className={classes.cell} component="th" scope="row">
         {job.attributes.offChainReportingOracleSpec.name || job.id}
         {job.attributes.offChainReportingOracleSpec.name && (


### PR DESCRIPTION
### Quick summary
- Creates a shared `Job` type and updates `Errors` and `Definition` components to use that type
- Adds OCR job page ("/jobs/:id") in UI
- Adds delete ("Archive") functionality for OCR jobs
- Pulled "View more" button out of `operator_ui/src/components/JobRuns/List.tsx` component as it's only relevant for the `RecentRuns` page.
- Inlined `ChartArea` component.

### Notes
- Make sure to use "Hide whitespace changes" when reviewing.
- Ignore failing tests - it's flaky "TestFluxMonitorAntiSpamLogic" and "error while removing network: network docker_default id c83773e3da26a89d7cf0f0c57543b438d5eb2094a8a0d1133f4a8f62c0d7cf20 has active endpoints" 🙄

### Screenshot
![image](https://user-images.githubusercontent.com/9297294/99245733-0390df80-27fc-11eb-8e69-bd85ac0ac27f.png)

### Things that will be done in follow up PRs
- Add OCR job spec "Definition" page
- Add OCR job spec "Errors" page
- Add OCR job spec "Duplicate" and "Copy" buttons
- Add OCR job run page with tasks visualisation
- Remove `/runs` page as it's not useful due to lack of filtering and a large number of job runs.