### PR TITLE
💥 Remove "/runs" page from operator UI

### DIFF
--- a/operator_ui/src/Private.tsx
+++ b/operator_ui/src/Private.tsx
@@ -143,21 +143,7 @@ const Private = ({ classes }: { classes: { content: string } }) => {
                 component={JobRunsShowErrorLog}
               />
               <PrivateRoute path="/jobs/:jobSpecId" component={JobsShow} />
-              <PrivateRoute
-                exact
-                path="/runs"
-                render={(props) => (
-                  <JobRunsIndex {...props} pagePath="/runs/page" />
-                )}
-              />
-              <PrivateRoute
-                exact
-                path="/runs/page/:jobRunsPage"
-                render={(props) => (
-                  <JobRunsIndex {...props} pagePath="/runs/page" />
-                )}
-              />
-              ;<PrivateRoute exact path="/bridges" component={BridgesIndex} />
+              <PrivateRoute exact path="/bridges" component={BridgesIndex} />
               <PrivateRoute
                 exact
                 path="/bridges/page/:bridgePage"

--- a/operator_ui/src/components/Dashboards/Activity.test.tsx
+++ b/operator_ui/src/components/Dashboards/Activity.test.tsx
@@ -13,23 +13,6 @@ describe('components/Dashboards/Activity', () => {
     expect(component.text()).toContain('Run: runA')
   })
 
-  it('displays a "View More" link when there is more than 1 page of runs', () => {
-    const runs = [
-      partialAsFull<JobRun>({ id: 'runA', createdAt: CREATED_AT }),
-      partialAsFull<JobRun>({ id: 'runB', createdAt: CREATED_AT }),
-    ]
-
-    const componentWithMore = mountWithTheme(
-      <Activity runs={runs} pageSize={1} count={2} />,
-    )
-    expect(componentWithMore.text()).toContain('View More')
-
-    const componentWithoutMore = mountWithTheme(
-      <Activity runs={runs} pageSize={2} count={2} />,
-    )
-    expect(componentWithoutMore.text()).not.toContain('View More')
-  })
-
   it('can show a loading message', () => {
     const component = mountWithTheme(<Activity pageSize={1} />)
     expect(component.text()).toContain('Loading ...')

--- a/operator_ui/src/components/Dashboards/Activity.tsx
+++ b/operator_ui/src/components/Dashboards/Activity.tsx
@@ -11,7 +11,6 @@ import {
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
 import TableCell from '@material-ui/core/TableCell'
-import TableFooter from '@material-ui/core/TableFooter'
 import TableRow from '@material-ui/core/TableRow'
 import Typography from '@material-ui/core/Typography'
 import { JobRun, JobRuns } from 'operator_ui'
@@ -104,7 +103,7 @@ interface Props extends WithStyles<typeof styles> {
   count?: number
 }
 
-const Activity = ({ classes, runs, count, pageSize }: Props) => {
+const Activity = ({ classes, runs }: Props) => {
   let activity
 
   if (!runs) {
@@ -158,17 +157,6 @@ const Activity = ({ classes, runs, count, pageSize }: Props) => {
             </TableRow>
           ))}
         </TableBody>
-        {count && count > pageSize && (
-          <TableFooter>
-            <TableRow>
-              <TableCell scope="row" className={classes.footer}>
-                <Button href={'/runs'} component={BaseLink}>
-                  View More
-                </Button>
-              </TableCell>
-            </TableRow>
-          </TableFooter>
-        )}
       </Table>
     )
   }

--- a/operator_ui/src/pages/Header.tsx
+++ b/operator_ui/src/pages/Header.tsx
@@ -31,7 +31,6 @@ import fetchCountSelector from '../selectors/fetchCount'
 
 const SHARED_NAV_ITEMS = [
   ['/jobs', 'Jobs'],
-  ['/runs', 'Runs'],
   ['/bridges', 'Bridges'],
   ['/transactions', 'Transactions'],
   ['/keys', 'Keys'],


### PR DESCRIPTION
The page is not useful due to lack of filtering and a large number of job runs. Job scoped job run pages ("/jobs/:jobSpecId/runs") should be used instead.