### PR TITLE
marshalJSON OffChainPublicKey into hex string instead of base64

### DIFF
--- a/core/store/models/ocrkey/off_chain_public_key.go
+++ b/core/store/models/ocrkey/off_chain_public_key.go
@@ -3,10 +3,33 @@ package ocrkey
 import (
 	"crypto/ed25519"
 	"encoding/hex"
+	"encoding/json"
+
+	"github.com/ethereum/go-ethereum/common"
 )
 
 type OffChainPublicKey ed25519.PublicKey
 
 func (ocpk OffChainPublicKey) String() string {
-	return hex.EncodeToString(ocpk[:])
+	return hex.EncodeToString(ocpk)
+}
+
+func (ocpk OffChainPublicKey) MarshalJSON() ([]byte, error) {
+	return json.Marshal(ocpk.String())
+}
+
+func (ocpk *OffChainPublicKey) UnmarshalJSON(input []byte) error {
+	var hexString string
+	var result OffChainPublicKey
+
+	if err := json.Unmarshal(input, &hexString); err != nil {
+		return err
+	}
+	result, err := hex.DecodeString(hexString)
+	if err != nil {
+		return err
+	}
+	copy(result[:], result[:common.AddressLength])
+	*ocpk = result
+	return nil
 }

--- a/core/store/models/ocrkey/off_chain_public_key_test.go
+++ b/core/store/models/ocrkey/off_chain_public_key_test.go
@@ -1,0 +1,46 @@
+package ocrkey
+
+import (
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestOCR_OffchainPublicKey_MarshalJSON(t *testing.T) {
+	t.Parallel()
+	rawBytes := make([]byte, 32)
+	rawBytes[31] = 1
+	pubKey := OffChainPublicKey(rawBytes)
+
+	pubKeyString := "0000000000000000000000000000000000000000000000000000000000000001"
+	pubKeyJSON := fmt.Sprintf(`"%s"`, pubKeyString)
+
+	result, err := json.Marshal(pubKey)
+	assert.NoError(t, err)
+	assert.Equal(t, pubKeyJSON, string(result))
+}
+
+func TestOCR_OffchainPublicKey_UnmarshalJSON_Happy(t *testing.T) {
+	t.Parallel()
+
+	pubKeyString := "918a65a518c005d6367309bec4b26805f8afabef72cbf9940d9a0fd04ec80b38"
+	pubKeyJSON := fmt.Sprintf(`"%s"`, pubKeyString)
+	pubKey := OffChainPublicKey{}
+
+	err := json.Unmarshal([]byte(pubKeyJSON), &pubKey)
+	assert.NoError(t, err)
+	assert.Equal(t, pubKeyString, pubKey.String())
+}
+
+func TestOCR_OffchainPublicKey_UnmarshalJSON_Error(t *testing.T) {
+	t.Parallel()
+
+	pubKeyString := "hello world"
+	pubKeyJSON := fmt.Sprintf(`"%s"`, pubKeyString)
+	pubKey := OffChainPublicKey{}
+
+	err := json.Unmarshal([]byte(pubKeyJSON), &pubKey)
+	assert.Error(t, err)
+}


### PR DESCRIPTION
Addresses [#175747490](https://www.pivotaltracker.com/story/show/175747490)