### PR TITLE
🐛 Fix "View more" link on the Jobs/Show page

### DIFF
--- a/operator_ui/src/components/JobRuns/List.tsx
+++ b/operator_ui/src/components/JobRuns/List.tsx
@@ -1,5 +1,4 @@
 import { TimeAgo } from '@chainlink/styleguide'
-import Card from '@material-ui/core/Card'
 import { createStyles, withStyles, WithStyles } from '@material-ui/core/styles'
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
@@ -158,11 +157,9 @@ interface Props extends WithStyles<typeof styles> {
 
 const List = ({ runs, classes, hideLinks }: Props) => {
   return (
-    <Card className={classes.jobRunsCard}>
-      <Table padding="none">
-        <TableBody>{renderRuns(runs, classes, hideLinks)}</TableBody>
-      </Table>
-    </Card>
+    <Table padding="none">
+      <TableBody>{renderRuns(runs, classes, hideLinks)}</TableBody>
+    </Table>
   )
 }
 

--- a/operator_ui/src/pages/Jobs/RecentRuns.test.tsx
+++ b/operator_ui/src/pages/Jobs/RecentRuns.test.tsx
@@ -1,0 +1,40 @@
+import React from 'react'
+import { Route } from 'react-router-dom'
+import { JobsShow } from 'pages/Jobs/Show'
+import jsonApiJobSpecFactory from 'factories/jsonApiJobSpec'
+import jsonApiJobSpecRunsFactory from 'factories/jsonApiJobSpecRuns'
+import { mountWithProviders } from 'test-helpers/mountWithTheme'
+import { syncFetch } from 'test-helpers/syncFetch'
+import globPath from 'test-helpers/globPath'
+
+const JOB_SPEC_ID = 'c60b9927eeae43168ddbe92584937b1b'
+
+describe('pages/Jobs/RecentRuns', () => {
+  it('displays a view more link if there are more runs than the display count', async () => {
+    const runs = [
+      { id: 'runA', jobId: JOB_SPEC_ID },
+      { id: 'runB', jobId: JOB_SPEC_ID },
+      { id: 'runC', jobId: JOB_SPEC_ID },
+      { id: 'runD', jobId: JOB_SPEC_ID },
+      { id: 'runE', jobId: JOB_SPEC_ID },
+    ]
+
+    const jobSpecResponse = jsonApiJobSpecFactory({
+      id: JOB_SPEC_ID,
+    })
+    const jobRunsResponse = jsonApiJobSpecRunsFactory(runs, 10)
+
+    global.fetch.getOnce(globPath(`/v2/specs/${JOB_SPEC_ID}`), jobSpecResponse)
+    global.fetch.getOnce(globPath('/v2/runs'), jobRunsResponse)
+
+    const wrapper = mountWithProviders(
+      <Route path="/jobs/:jobSpecId" component={JobsShow} />,
+      {
+        initialEntries: [`/jobs/${JOB_SPEC_ID}`],
+      },
+    )
+
+    await syncFetch(wrapper)
+    expect(wrapper.text()).toContain('View More')
+  })
+})

--- a/operator_ui/src/pages/Jobs/RecentRuns.tsx
+++ b/operator_ui/src/pages/Jobs/RecentRuns.tsx
@@ -2,8 +2,6 @@ import { CardTitle, KeyValueList } from '@chainlink/styleguide'
 import {
   Card,
   Grid,
-  TableCell,
-  TableRow,
   Theme,
   Typography,
   WithStyles,
@@ -108,19 +106,15 @@ export const RecentRuns = withStyles(chartCardStyles)(
                       hideLinks={job?.type === 'Off-chain reporting'}
                     />
                     {job?.type === 'Direct request' &&
-                      recentRuns.length > showJobRunsCount && (
-                        <TableRow>
-                          <TableCell>
-                            <div className={classes.runDetails}>
-                              <Button
-                                href={`/jobs/${job.id}/runs`}
-                                component={BaseLink}
-                              >
-                                View More
-                              </Button>
-                            </div>
-                          </TableCell>
-                        </TableRow>
+                      recentRunsCount > showJobRunsCount && (
+                        <div className={classes.runDetails}>
+                          <Button
+                            href={`/jobs/${job.id}/runs`}
+                            component={BaseLink}
+                          >
+                            View More
+                          </Button>
+                        </div>
                       )}
                   </>
                 )}

--- a/operator_ui/src/pages/Jobs/Show.test.tsx
+++ b/operator_ui/src/pages/Jobs/Show.test.tsx
@@ -54,35 +54,6 @@ describe('pages/Jobs/Show', () => {
     expect(wrapper.text()).not.toContain('View More')
   })
 
-  it('displays a view more link if there are more runs than the display count', async () => {
-    const runs = [
-      { id: 'runA', jobId: JOB_SPEC_ID },
-      { id: 'runB', jobId: JOB_SPEC_ID },
-      { id: 'runC', jobId: JOB_SPEC_ID },
-      { id: 'runD', jobId: JOB_SPEC_ID },
-      { id: 'runE', jobId: JOB_SPEC_ID },
-      { id: 'runF', jobId: JOB_SPEC_ID },
-    ]
-
-    const jobSpecResponse = jsonApiJobSpecFactory({
-      id: JOB_SPEC_ID,
-    })
-    const jobRunsResponse = jsonApiJobSpecRunsFactory(runs)
-
-    global.fetch.getOnce(globPath(`/v2/specs/${JOB_SPEC_ID}`), jobSpecResponse)
-    global.fetch.getOnce(globPath('/v2/runs'), jobRunsResponse)
-
-    const wrapper = mountWithProviders(
-      <Route path="/jobs/:jobSpecId" component={JobsShow} />,
-      {
-        initialEntries: [`/jobs/${JOB_SPEC_ID}`],
-      },
-    )
-
-    await syncFetch(wrapper)
-    expect(wrapper.text()).toContain('View More')
-  })
-
   describe('RegionalNav', () => {
     it('clicking on "Run" button triggers a new job and updates the recent jobs list', async () => {
       const runs = [{ id: 'runA', jobId: JOB_SPEC_ID }]


### PR DESCRIPTION
### Quick summary
- "View more" button wasn't showing up because we were testing returned jobs length vs show count which is always gonna be equal or less due to pagination on the backend. The test wasn't setup correctly to catch that.
- Fixed the styles too as the `Card` was added unnecessarily.
- Moved the test to a separate file.

![image](https://user-images.githubusercontent.com/9297294/99570179-79967180-29c9-11eb-8d25-762b42fd30c7.png)
