### PR TITLE
Bump build-publish-chainlink circleci job box size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 jobs:
   build-publish-chainlink:
-    resource_class: large
+    resource_class: 2xlarge
     machine:
       image: circleci/classic:201808-01
       docker_layer_caching: true


### PR DESCRIPTION
Cuts down `build-publish-chainlink` runtime from 8m30s -> 5m