### PR TITLE
Support per task timeout

### DIFF
--- a/core/services/offchainreporting/models.go
+++ b/core/services/offchainreporting/models.go
@@ -11,9 +11,9 @@ import (
 // representation of the OCR job spec.  It fulfills the job.Spec interface
 // and has facilities for unmarshaling the pipeline DAG from the job spec text.
 type OracleSpec struct {
-	Type          string      `toml:"type"`
-	SchemaVersion uint32      `toml:"schemaVersion"`
-	Name          null.String `toml:"name"`
+	Type            string          `toml:"type"`
+	SchemaVersion   uint32          `toml:"schemaVersion"`
+	Name            null.String     `toml:"name"`
 	MaxTaskDuration models.Interval `toml:"maxTaskDuration"`
 
 	models.OffchainReportingOracleSpec

--- a/core/services/offchainreporting/models.go
+++ b/core/services/offchainreporting/models.go
@@ -14,6 +14,7 @@ type OracleSpec struct {
 	Type          string      `toml:"type"`
 	SchemaVersion uint32      `toml:"schemaVersion"`
 	Name          null.String `toml:"name"`
+	MaxTaskDuration models.Interval `toml:"maxTaskDuration"`
 
 	models.OffchainReportingOracleSpec
 

--- a/core/services/offchainreporting/oracle.go
+++ b/core/services/offchainreporting/oracle.go
@@ -80,7 +80,7 @@ func (d jobSpawnerDelegate) ToDBRow(spec job.Spec) models.JobSpecV2 {
 		OffchainreportingOracleSpec: &concreteSpec.OffchainReportingOracleSpec,
 		Type:                        string(JobType),
 		SchemaVersion:               concreteSpec.SchemaVersion,
-		MaxTaskDuration: 			 concreteSpec.MaxTaskDuration,
+		MaxTaskDuration:             concreteSpec.MaxTaskDuration,
 	}
 }
 

--- a/core/services/offchainreporting/oracle.go
+++ b/core/services/offchainreporting/oracle.go
@@ -80,6 +80,7 @@ func (d jobSpawnerDelegate) ToDBRow(spec job.Spec) models.JobSpecV2 {
 		OffchainreportingOracleSpec: &concreteSpec.OffchainReportingOracleSpec,
 		Type:                        string(JobType),
 		SchemaVersion:               concreteSpec.SchemaVersion,
+		MaxTaskDuration: 			 concreteSpec.MaxTaskDuration,
 	}
 }
 

--- a/core/services/pipeline/common_test.go
+++ b/core/services/pipeline/common_test.go
@@ -3,9 +3,33 @@ package pipeline_test
 import (
 	"testing"
 
+	"github.com/bmizerany/assert"
+	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	"github.com/stretchr/testify/require"
 )
+
+func TestTimeoutAttribute(t *testing.T) {
+	g := pipeline.NewTaskDAG()
+	a := `ds1 [type=http method=GET url="https://chain.link/voter_turnout/USA-2020" requestData="{\"hi\": \"hello\"}" timeout="10s"];`
+	err := g.UnmarshalText([]byte(a))
+	require.NoError(t, err)
+	tasks, err := g.TasksInDependencyOrder()
+	require.NoError(t, err)
+	timeout, set := tasks[0].TaskTimeout()
+	assert.Equal(t, cltest.MustParseDuration(t, "10s"), timeout)
+	assert.Equal(t, true, set)
+
+	g = pipeline.NewTaskDAG()
+	a = `ds1 [type=http method=GET url="https://chain.link/voter_turnout/USA-2020" requestData="{\"hi\": \"hello\"}"];`
+	err = g.UnmarshalText([]byte(a))
+	require.NoError(t, err)
+	tasks, err = g.TasksInDependencyOrder()
+	require.NoError(t, err)
+	timeout, set = tasks[0].TaskTimeout()
+	assert.Equal(t, cltest.MustParseDuration(t, "0s"), timeout)
+	assert.Equal(t, false, set)
+}
 
 func Test_TaskHTTPUnmarshal(t *testing.T) {
 	g := pipeline.NewTaskDAG()

--- a/core/services/pipeline/fixtures_test.go
+++ b/core/services/pipeline/fixtures_test.go
@@ -6,6 +6,10 @@ import (
 	"io/ioutil"
 	"net/http"
 	"testing"
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/smartcontractkit/chainlink/core/services"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pelletier/go-toml"
@@ -19,7 +23,8 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/models"
 )
 
-const dotStr = `
+const (
+	dotStr = `
     // data source 1
     ds1          [type=bridge name=voter_turnout];
     ds1_parse    [type=jsonparse path="one,two"];
@@ -36,8 +41,6 @@ const dotStr = `
     answer1 [type=median                      index=0];
     answer2 [type=bridge name=election_winner index=1];
 `
-
-const (
 	ocrJobSpecTemplate = `
 type               = "offchainreporting"
 schemaVersion      = 1
@@ -59,7 +62,6 @@ observationSource = """
 	%s
 """
 `
-
 	voterTurnoutDataSourceTemplate = `
 // data source 1
 ds1          [type=bridge name=voter_turnout];
@@ -85,7 +87,52 @@ ds1_parse    [type=jsonparse path="USD" lax=%t];
 ds1_multiply [type=multiply times=100];
 ds1 -> ds1_parse -> ds1_multiply;
 `
+	minimalNonBootstrapTemplate = `
+		type               = "offchainreporting"
+		schemaVersion      = 1
+		contractAddress    = "%s"
+		p2pPeerID          = "%s"
+		p2pBootstrapPeers  = ["/dns4/chain.link/tcp/1234/p2p/16Uiu2HAm58SP7UL8zsnpeuwHfytLocaqgnyaYKP8wu7qRdrixLju"]
+		isBootstrapPeer    = false 
+		transmitterAddress = "%s"
+		keyBundleID = "%s"
+		observationTimeout = "10s"
+		observationSource = """
+ds1          [type=http method=GET url="%s" %s];
+ds1_parse    [type=jsonparse path="USD" lax=true];
+ds1 -> ds1_parse;
+"""
+`
+	minimalBootstrapTemplate = `
+		type               = "offchainreporting"
+		schemaVersion      = 1
+		contractAddress    = "%s"
+		p2pPeerID          = "%s"
+		p2pBootstrapPeers  = []
+		isBootstrapPeer    = true
+`
 )
+
+func makeMinimalHTTPOracleSpec(t *testing.T, contractAddress, peerID, transmitterAddress, keyBundle, fetchUrl, timeout string) *offchainreporting.OracleSpec {
+	t.Helper()
+	var os = offchainreporting.OracleSpec{
+		OffchainReportingOracleSpec: models.OffchainReportingOracleSpec{
+			P2PBootstrapPeers:                      pq.StringArray{},
+			ObservationTimeout:                     models.Interval(10 * time.Second),
+			BlockchainTimeout:                      models.Interval(20 * time.Second),
+			ContractConfigTrackerSubscribeInterval: models.Interval(2 * time.Minute),
+			ContractConfigTrackerPollInterval:      models.Interval(1 * time.Minute),
+			ContractConfigConfirmations:            uint16(3),
+		},
+		Pipeline: *pipeline.NewTaskDAG(),
+	}
+	s := fmt.Sprintf(minimalNonBootstrapTemplate, contractAddress, peerID, transmitterAddress, keyBundle, fetchUrl, timeout)
+	_, err := services.ValidatedOracleSpecToml(s)
+	require.NoError(t, err)
+	err = toml.Unmarshal([]byte(s), &os)
+	require.NoError(t, err)
+	return &os
+}
 
 func makeVoterTurnoutOCRJobSpec(t *testing.T, db *gorm.DB) (*offchainreporting.OracleSpec, *models.JobSpecV2) {
 	t.Helper()

--- a/core/services/pipeline/fixtures_test.go
+++ b/core/services/pipeline/fixtures_test.go
@@ -98,7 +98,7 @@ ds1 -> ds1_parse -> ds1_multiply;
 		keyBundleID = "%s"
 		observationTimeout = "10s"
 		observationSource = """
-ds1          [type=http method=GET url="%s" %s];
+ds1          [type=http method=GET url="%s" allowunrestrictednetworkaccess="true" %s];
 ds1_parse    [type=jsonparse path="USD" lax=true];
 ds1 -> ds1_parse;
 """

--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -6,6 +6,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/smartcontractkit/chainlink/core/store/models"
+
 	"github.com/jinzhu/gorm"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/postgres"
@@ -198,9 +200,23 @@ func (r *runner) processTaskRun() (anyRemaining bool, err error) {
 			logger.Errorw("Pipeline task run could not be unmarshaled", append(loggerFields, "error", err)...)
 			return Result{Error: err}
 		}
+		var job models.JobSpecV2
+		err = txdb.Find(&job, "id = ?", jobID).Error
+		if err != nil {
+			logger.Errorw("unexpected error could not find job by ID", append(loggerFields, "error", err)...)
+			return Result{Error: err}
+		}
+
+		// Order of precedence for task timeout:
+		// - Specific task timeout (task.TaskTimeout)
+		// - Job level task timeout (job.MaxTaskDuration)
+		// - Node level task timeout (JobPipelineMaxTaskDuration)
 		taskTimeout, isSet := task.TaskTimeout()
 		if isSet {
-			ctx, cancel = context.WithTimeout(ctx, taskTimeout)
+			ctx, cancel = utils.CombinedContext(r.chStop, taskTimeout)
+			defer cancel()
+		} else if job.MaxTaskDuration != models.Interval(time.Duration(0)) {
+			ctx, cancel = utils.CombinedContext(r.chStop, time.Duration(job.MaxTaskDuration))
 			defer cancel()
 		}
 

--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -198,6 +198,11 @@ func (r *runner) processTaskRun() (anyRemaining bool, err error) {
 			logger.Errorw("Pipeline task run could not be unmarshaled", append(loggerFields, "error", err)...)
 			return Result{Error: err}
 		}
+		taskTimeout, isSet := task.TaskTimeout()
+		if isSet {
+			ctx, cancel = context.WithTimeout(ctx, taskTimeout)
+			defer cancel()
+		}
 
 		result := task.Run(ctx, taskRun, inputs)
 		if _, is := result.Error.(FinalErrors); !is && result.Error != nil {

--- a/core/services/pipeline/runner_test.go
+++ b/core/services/pipeline/runner_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"gopkg.in/guregu/null.v4"
+
 	"github.com/pelletier/go-toml"
 
 	"github.com/lib/pq"
@@ -522,6 +524,9 @@ func TestRunner(t *testing.T) {
 		os := makeMinimalHTTPOracleSpec(t, cltest.NewEIP55Address().String(), cltest.DefaultPeerID, cltest.DefaultKey, cltest.DefaultOCRKeyBundleID, serv.URL, `timeout="1ns"`)
 		jb := &models.JobSpecV2{
 			OffchainreportingOracleSpec: &os.OffchainReportingOracleSpec,
+			Name:                        null.NewString("a job", true),
+			Type:                        string(offchainreporting.JobType),
+			SchemaVersion:               1,
 		}
 		err := jobORM.CreateJob(context.Background(), jb, os.TaskDAG())
 		require.NoError(t, err)
@@ -537,6 +542,9 @@ func TestRunner(t *testing.T) {
 		os = makeMinimalHTTPOracleSpec(t, cltest.NewEIP55Address().String(), cltest.DefaultPeerID, cltest.DefaultKey, cltest.DefaultOCRKeyBundleID, serv.URL, "")
 		jb = &models.JobSpecV2{
 			OffchainreportingOracleSpec: &os.OffchainReportingOracleSpec,
+			Name:                        null.NewString("a job 2", true),
+			Type:                        string(offchainreporting.JobType),
+			SchemaVersion:               1,
 		}
 		err = jobORM.CreateJob(context.Background(), jb, os.TaskDAG())
 		require.NoError(t, err)
@@ -554,6 +562,9 @@ func TestRunner(t *testing.T) {
 		jb = &models.JobSpecV2{
 			MaxTaskDuration:             models.Interval(time.Duration(1)),
 			OffchainreportingOracleSpec: &os.OffchainReportingOracleSpec,
+			Name:                        null.NewString("a job 3", true),
+			Type:                        string(offchainreporting.JobType),
+			SchemaVersion:               1,
 		}
 		err = jobORM.CreateJob(context.Background(), jb, os.TaskDAG())
 		require.NoError(t, err)

--- a/core/services/pipeline/runner_test.go
+++ b/core/services/pipeline/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -308,22 +309,6 @@ func TestRunner(t *testing.T) {
 		require.NoError(t, err)
 		kb, _, err := keyStore.GenerateEncryptedOCRKeyBundle()
 		require.NoError(t, err)
-		minimalNonBootstrapTemplate := `
-		type               = "offchainreporting"
-		schemaVersion      = 1
-		contractAddress    = "%s"
-		p2pPeerID          = "%s"
-		p2pBootstrapPeers  = ["/dns4/chain.link/tcp/1234/p2p/16Uiu2HAm58SP7UL8zsnpeuwHfytLocaqgnyaYKP8wu7qRdrixLju"]
-		isBootstrapPeer    = false 
-		transmitterAddress = "%s"
-		keyBundleID = "%s"
-		observationTimeout = "10s"
-		observationSource = """
-ds1          [type=http method=GET url="http://data.com"];
-ds1_parse    [type=jsonparse path="USD" lax=true];
-ds1 -> ds1_parse;
-"""
-`
 		var os = offchainreporting.OracleSpec{
 			OffchainReportingOracleSpec: models.OffchainReportingOracleSpec{
 				P2PBootstrapPeers:                      pq.StringArray{},
@@ -336,7 +321,7 @@ ds1 -> ds1_parse;
 			Pipeline: *pipeline.NewTaskDAG(),
 		}
 
-		s := fmt.Sprintf(minimalNonBootstrapTemplate, cltest.NewEIP55Address(), ek.PeerID, cltest.DefaultKey, kb.ID)
+		s := fmt.Sprintf(minimalNonBootstrapTemplate, cltest.NewEIP55Address(), ek.PeerID, cltest.DefaultKey, kb.ID, "http://blah.com", "")
 		_, err = services.ValidatedOracleSpecToml(s)
 		require.NoError(t, err)
 		err = toml.Unmarshal([]byte(s), &os)
@@ -370,14 +355,6 @@ ds1 -> ds1_parse;
 		keyStore := offchainreporting.NewKeyStore(db, utils.GetScryptParams(config.Config))
 		_, ek, err := keyStore.GenerateEncryptedP2PKey()
 		require.NoError(t, err)
-		minimalBootstrapTemplate := `
-		type               = "offchainreporting"
-		schemaVersion      = 1
-		contractAddress    = "%s"
-		p2pPeerID          = "%s"
-		p2pBootstrapPeers  = []
-		isBootstrapPeer    = true
-`
 		var os = offchainreporting.OracleSpec{
 			OffchainReportingOracleSpec: models.OffchainReportingOracleSpec{
 				P2PBootstrapPeers:                      pq.StringArray{},
@@ -525,5 +502,49 @@ ds1 -> ds1_parse;
 
 		err = runner.AwaitRun(ctx, runID)
 		require.EqualError(t, err, fmt.Sprintf("could not determine if run is finished (run ID: %v): record not found", runID))
+	})
+
+	t.Run("timeouts", func(t *testing.T) {
+		// There are 4 timeouts:
+		// - ObservationTimeout = how long the whole OCR time needs to run, or it fails (default 10 seconds)
+		// - config.JobPipelineMaxTaskDuration() = node level maximum time for a pipeline task (default 10 minutes)
+		// - config.DefaultHTTPTimeout() * config.DefaultMaxHTTPAttempts() = global, http specific timeouts (default 15s * 5 retries = 75s)
+		// - "d1 [.... timeout="2s"]" = per task level timeout (should override the global config)
+		serv := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			time.Sleep(1 * time.Millisecond)
+			res.WriteHeader(http.StatusOK)
+			res.Write([]byte(`{"USD":10.1}`))
+		}))
+		defer serv.Close()
+
+		os := makeMinimalHTTPOracleSpec(t, cltest.NewEIP55Address().String(), cltest.DefaultPeerID, cltest.DefaultKey, cltest.DefaultOCRKeyBundleID, serv.URL, `timeout="1ns"`)
+		jb := &models.JobSpecV2{
+			OffchainreportingOracleSpec: &os.OffchainReportingOracleSpec,
+		}
+		err := jobORM.CreateJob(context.Background(), jb, os.TaskDAG())
+		require.NoError(t, err)
+		runID, err := runner.CreateRun(context.Background(), jb.ID, nil)
+		require.NoError(t, err)
+		err = runner.AwaitRun(context.Background(), runID)
+		require.NoError(t, err)
+		r, err := runner.ResultsForRun(context.Background(), runID)
+		require.NoError(t, err)
+		assert.Error(t, r[0].Error)
+
+		// No task timeout should succeed.
+		os = makeMinimalHTTPOracleSpec(t, cltest.NewEIP55Address().String(), cltest.DefaultPeerID, cltest.DefaultKey, cltest.DefaultOCRKeyBundleID, serv.URL, "")
+		jb = &models.JobSpecV2{
+			OffchainreportingOracleSpec: &os.OffchainReportingOracleSpec,
+		}
+		err = jobORM.CreateJob(context.Background(), jb, os.TaskDAG())
+		require.NoError(t, err)
+		runID, err = runner.CreateRun(context.Background(), jb.ID, nil)
+		require.NoError(t, err)
+		err = runner.AwaitRun(context.Background(), runID)
+		require.NoError(t, err)
+		r, err = runner.ResultsForRun(context.Background(), runID)
+		require.NoError(t, err)
+		assert.Equal(t, 10.1, r[0].Value)
+		assert.NoError(t, r[0].Error)
 	})
 }

--- a/core/services/validators.go
+++ b/core/services/validators.go
@@ -532,6 +532,16 @@ func validateNonBootstrapSpec(tree *toml.Tree, spec offchainreporting.OracleSpec
 	if spec.MaxTaskDuration > spec.ObservationTimeout {
 		return errors.Errorf("max task duration must be < observation timeout")
 	}
+	tasks, err := spec.Pipeline.TasksInDependencyOrder()
+	if err != nil {
+		return errors.Wrap(err, "invalid observation source")
+	}
+	for _, task := range tasks {
+		timeout, set := task.TaskTimeout()
+		if set && timeout > time.Duration(spec.ObservationTimeout) {
+			return errors.Errorf("individual max task duration must be < observation timeout")
+		}
+	}
 	return nil
 }
 

--- a/core/services/validators.go
+++ b/core/services/validators.go
@@ -529,6 +529,9 @@ func validateNonBootstrapSpec(tree *toml.Tree, spec offchainreporting.OracleSpec
 			return errors.Errorf("p2p bootstrap peer %d is invalid: err %v", i, err)
 		}
 	}
+	if spec.MaxTaskDuration > spec.ObservationTimeout {
+		return errors.Errorf("max task duration must be < observation timeout")
+	}
 	return nil
 }
 

--- a/core/services/validators_test.go
+++ b/core/services/validators_test.go
@@ -691,6 +691,30 @@ ds1          [type=bridge name=voter_turnout];
 			},
 		},
 		{
+			name: "individual max task duration > observation timeout should error",
+			toml: `
+type               = "offchainreporting"
+schemaVersion      = 1
+contractAddress    = "0x613a38AC1659769640aaE063C651F48E0250454C"
+p2pPeerID          = "12D3KooWHfYFQ8hGttAYbMCevQVESEQhzJAqFZokMVtom8bNxwGq"
+p2pBootstrapPeers  = [
+"/dns4/chain.link/tcp/1234/p2p/16Uiu2HAm58SP7UL8zsnpeuwHfytLocaqgnyaYKP8wu7qRdrixLju",
+]
+isBootstrapPeer    = false
+keyBundleID        = "73e8966a78ca09bb912e9565cfb79fbe8a6048fab1f0cf49b18047c3895e0447"
+monitoringEndpoint = "chain.link:4321"
+transmitterAddress = "0xaA07d525B4006a2f927D79CA78a23A8ee680A32A"
+observationTimeout = "10s"
+observationSource = """
+ds1          [type=bridge name=voter_turnout timeout="30s"];
+"""
+`,
+			assertion: func(t *testing.T, os offchainreporting.OracleSpec, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "individual max task duration must be < observation timeout")
+			},
+		},
+		{
 			name: "sane defaults",
 			toml: `
 type               = "offchainreporting"

--- a/core/services/validators_test.go
+++ b/core/services/validators_test.go
@@ -666,6 +666,31 @@ monitoringEndpoint = "\t/fd\2ff )(*&^%$#@"
 			},
 		},
 		{
+			name: "max task duration > observation timeout should error",
+			toml: `
+type               = "offchainreporting"
+maxTaskDuration    = "30s"
+schemaVersion      = 1
+contractAddress    = "0x613a38AC1659769640aaE063C651F48E0250454C"
+p2pPeerID          = "12D3KooWHfYFQ8hGttAYbMCevQVESEQhzJAqFZokMVtom8bNxwGq"
+p2pBootstrapPeers  = [
+"/dns4/chain.link/tcp/1234/p2p/16Uiu2HAm58SP7UL8zsnpeuwHfytLocaqgnyaYKP8wu7qRdrixLju",
+]
+isBootstrapPeer    = false
+keyBundleID        = "73e8966a78ca09bb912e9565cfb79fbe8a6048fab1f0cf49b18047c3895e0447"
+monitoringEndpoint = "chain.link:4321"
+transmitterAddress = "0xaA07d525B4006a2f927D79CA78a23A8ee680A32A"
+observationTimeout = "10s"
+observationSource = """
+ds1          [type=bridge name=voter_turnout];
+"""
+`,
+			assertion: func(t *testing.T, os offchainreporting.OracleSpec, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "max task duration must be < observation timeout")
+			},
+		},
+		{
 			name: "sane defaults",
 			toml: `
 type               = "offchainreporting"

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -1,8 +1,9 @@
 package migrations
 
 import (
-	"regexp"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1606320711"
 
+	"regexp"
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration0"
@@ -439,6 +440,10 @@ func init() {
 		{
 			ID:      "migration1606303568",
 			Migrate: migration1606303568.Migrate,
+		},
+		{
+			ID:      "migration1606320711",
+			Migrate: migration1606320711.Migrate,
 		},
 	}
 }

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -4,6 +4,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1606320711"
 
 	"regexp"
+
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration0"

--- a/core/store/migrations/migration1606320711/migrate.go
+++ b/core/store/migrations/migration1606320711/migrate.go
@@ -1,0 +1,9 @@
+package migration1606320711
+
+import "github.com/jinzhu/gorm"
+
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+        ALTER TABLE jobs ADD COLUMN max_task_duration bigint;
+    `).Error
+}

--- a/core/store/models/job_spec_v2.go
+++ b/core/store/models/job_spec_v2.go
@@ -24,6 +24,7 @@ type (
 		Type                          string                       `json:"type"`
 		SchemaVersion                 uint32                       `json:"schemaVersion"`
 		Name                          null.String                  `json:"name"`
+		MaxTaskDuration               Interval                     `json:"maxTaskDuration"`
 	}
 
 	JobSpecErrorV2 struct {

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/araddon/dateparse v0.0.0-20190622164848-0fb0a474d195
 	github.com/aristanetworks/goarista v0.0.0-20191023202215-f096da5361bb // indirect
 	github.com/bitly/go-simplejson v0.5.0
+	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869
 	github.com/boj/redistore v0.0.0-20180917114910-cd5dcc76aeff // indirect
 	github.com/btcsuite/btcd v0.21.0-beta
 	github.com/danielkov/gin-helmet v0.0.0-20171108135313-1387e224435e

--- a/go.sum
+++ b/go.sum
@@ -1087,8 +1087,6 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartcontractkit/chainlink v0.8.10-0.20200825114219-81dd2fc95bac/go.mod h1:j7qIYHGCN4QqMXdO8g8A9dmUT5vKFmkxPSbjAIfrfNU=
-github.com/smartcontractkit/libocr v0.0.0-20201104141745-a805eb2bc4fc h1:8Og6pkrK+O/KUTfG8BCOnDKPMmowJLU/TWhzqYNT9e4=
-github.com/smartcontractkit/libocr v0.0.0-20201104141745-a805eb2bc4fc/go.mod h1:Yfu8T/45S0pf1qQ6JLHMNxXKBNqOfPZLtkA4Urk7njI=
 github.com/smartcontractkit/libocr v0.0.0-20201120141554-a98a18922cd3 h1:vGvNPgjSQXzcxa/6UIqw61F0VeQpLe1aTWG7jn9WaVE=
 github.com/smartcontractkit/libocr v0.0.0-20201120141554-a98a18922cd3/go.mod h1:RtJN4mF8ibkzwTkC8UzBKc3X4DIjk9ajn8WVPNJVQ4Q=
 github.com/smartcontractkit/libocr v0.0.0-20201123232443-3e79f1439e8c h1:oRBpTbjRvfrGf/vQ2TMgGtAITXMcSiPnaCjE2uPJ/40=

--- a/go.sum
+++ b/go.sum
@@ -1087,8 +1087,6 @@ github.com/sirupsen/logrus v1.4.2/go.mod h1:tLMulIdttU9McNUspp0xgXVQah82FyeX6Mwd
 github.com/sirupsen/logrus v1.6.0 h1:UBcNElsrwanuuMsnGSlYmtmgbb23qDR5dG+6X6Oo89I=
 github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrfsX/uA88=
 github.com/smartcontractkit/chainlink v0.8.10-0.20200825114219-81dd2fc95bac/go.mod h1:j7qIYHGCN4QqMXdO8g8A9dmUT5vKFmkxPSbjAIfrfNU=
-github.com/smartcontractkit/libocr v0.0.0-20201120141554-a98a18922cd3 h1:vGvNPgjSQXzcxa/6UIqw61F0VeQpLe1aTWG7jn9WaVE=
-github.com/smartcontractkit/libocr v0.0.0-20201120141554-a98a18922cd3/go.mod h1:RtJN4mF8ibkzwTkC8UzBKc3X4DIjk9ajn8WVPNJVQ4Q=
 github.com/smartcontractkit/libocr v0.0.0-20201123232443-3e79f1439e8c h1:oRBpTbjRvfrGf/vQ2TMgGtAITXMcSiPnaCjE2uPJ/40=
 github.com/smartcontractkit/libocr v0.0.0-20201123232443-3e79f1439e8c/go.mod h1:RtJN4mF8ibkzwTkC8UzBKc3X4DIjk9ajn8WVPNJVQ4Q=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=


### PR DESCRIPTION
Introduces two new ways of specifying timeouts: a the job level with maxTaskDuration and in an individual task with a "timeout". The individual task takes priority. For OCR jobs, both the maxTaskDuration and individual task timeouts, if specified, must be less than observationTimeout.

