### PR TITLE
✨ Bring back the "/runs" page

### DIFF
--- a/operator_ui/src/Private.tsx
+++ b/operator_ui/src/Private.tsx
@@ -93,7 +93,21 @@ const Private = ({ classes }: { classes: { content: string } }) => {
                 component={JobRunsShowOverview}
               />
               <PrivateRoute path="/jobs/:jobSpecId" component={JobsShow} />
-              <PrivateRoute exact path="/bridges" component={BridgesIndex} />
+              <PrivateRoute
+                exact
+                path="/runs"
+                render={(props) => (
+                  <JobRunsIndex {...props} pagePath="/runs/page" />
+                )}
+              />
+              <PrivateRoute
+                exact
+                path="/runs/page/:jobRunsPage"
+                render={(props) => (
+                  <JobRunsIndex {...props} pagePath="/runs/page" />
+                )}
+              />
+              ;<PrivateRoute exact path="/bridges" component={BridgesIndex} />
               <PrivateRoute
                 exact
                 path="/bridges/page/:bridgePage"

--- a/operator_ui/src/components/Dashboards/Activity.test.tsx
+++ b/operator_ui/src/components/Dashboards/Activity.test.tsx
@@ -13,6 +13,23 @@ describe('components/Dashboards/Activity', () => {
     expect(component.text()).toContain('Run: runA')
   })
 
+  it('displays a "View More" link when there is more than 1 page of runs', () => {
+    const runs = [
+      partialAsFull<JobRun>({ id: 'runA', createdAt: CREATED_AT }),
+      partialAsFull<JobRun>({ id: 'runB', createdAt: CREATED_AT }),
+    ]
+
+    const componentWithMore = mountWithTheme(
+      <Activity runs={runs} pageSize={1} count={2} />,
+    )
+    expect(componentWithMore.text()).toContain('View More')
+
+    const componentWithoutMore = mountWithTheme(
+      <Activity runs={runs} pageSize={2} count={2} />,
+    )
+    expect(componentWithoutMore.text()).not.toContain('View More')
+  })
+
   it('can show a loading message', () => {
     const component = mountWithTheme(<Activity pageSize={1} />)
     expect(component.text()).toContain('Loading ...')

--- a/operator_ui/src/components/Dashboards/Activity.tsx
+++ b/operator_ui/src/components/Dashboards/Activity.tsx
@@ -11,6 +11,7 @@ import {
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
 import TableCell from '@material-ui/core/TableCell'
+import TableFooter from '@material-ui/core/TableFooter'
 import TableRow from '@material-ui/core/TableRow'
 import Typography from '@material-ui/core/Typography'
 import { JobRun, JobRuns } from 'operator_ui'
@@ -103,7 +104,7 @@ interface Props extends WithStyles<typeof styles> {
   count?: number
 }
 
-const Activity = ({ classes, runs }: Props) => {
+const Activity = ({ classes, runs, count, pageSize }: Props) => {
   let activity
 
   if (!runs) {
@@ -157,6 +158,17 @@ const Activity = ({ classes, runs }: Props) => {
             </TableRow>
           ))}
         </TableBody>
+        {count && count > pageSize && (
+          <TableFooter>
+            <TableRow>
+              <TableCell scope="row" className={classes.footer}>
+                <Button href={'/runs'} component={BaseLink}>
+                  View More
+                </Button>
+              </TableCell>
+            </TableRow>
+          </TableFooter>
+        )}
       </Table>
     )
   }

--- a/operator_ui/src/pages/Header.tsx
+++ b/operator_ui/src/pages/Header.tsx
@@ -31,6 +31,7 @@ import fetchCountSelector from '../selectors/fetchCount'
 
 const SHARED_NAV_ITEMS = [
   ['/jobs', 'Jobs'],
+  ['/runs', 'Runs'],
   ['/bridges', 'Bridges'],
   ['/transactions', 'Transactions'],
   ['/keys', 'Keys'],


### PR DESCRIPTION
Multiple people have mentioned that they were using this page to do a quick skim through the runs and find erroring job runs. We should improve the jobs list to show some summary stats about the job runs instead of using the generic runs page, but this page has been removed prematurely as we haven't given an alternative way to perform the above task.

Revert "💥 Remove "/runs" page from operator UI (#3642)"
This reverts commit f3ba1de95acc1dea315df5c99f113c516014cba0.