### PR TITLE
✨ Bring back the "/runs" page

### DIFF
--- a/operator_ui/src/Private.tsx
+++ b/operator_ui/src/Private.tsx
@@ -93,7 +93,21 @@ const Private = ({ classes }: { classes: { content: string } }) => {
                 component={JobRunsShowOverview}
               />
               <PrivateRoute path="/jobs/:jobSpecId" component={JobsShow} />
-              <PrivateRoute exact path="/bridges" component={BridgesIndex} />
+              <PrivateRoute
+                exact
+                path="/runs"
+                render={(props) => (
+                  <JobRunsIndex {...props} pagePath="/runs/page" />
+                )}
+              />
+              <PrivateRoute
+                exact
+                path="/runs/page/:jobRunsPage"
+                render={(props) => (
+                  <JobRunsIndex {...props} pagePath="/runs/page" />
+                )}
+              />
+              ;<PrivateRoute exact path="/bridges" component={BridgesIndex} />
               <PrivateRoute
                 exact
                 path="/bridges/page/:bridgePage"

--- a/operator_ui/src/Private.tsx
+++ b/operator_ui/src/Private.tsx
@@ -28,6 +28,7 @@ const DashboardsIndex: UniversalComponent<
       recentlyCreatedPageSize: number
     }
 > = universal(import('./pages/Dashboards/Index'), uniOpts)
+const JobRunsIndex = universal(import('./pages/JobRuns/Index'), uniOpts)
 const JobsIndex = universal(import('./pages/JobsIndex/JobsIndex'), uniOpts)
 const JobsShow = universal(import('./pages/Jobs/Show'), uniOpts)
 const JobsNew = universal(import('./pages/Jobs/New'), uniOpts)

--- a/operator_ui/src/components/Dashboards/Activity.test.tsx
+++ b/operator_ui/src/components/Dashboards/Activity.test.tsx
@@ -13,6 +13,23 @@ describe('components/Dashboards/Activity', () => {
     expect(component.text()).toContain('Run: runA')
   })
 
+  it('displays a "View More" link when there is more than 1 page of runs', () => {
+    const runs = [
+      partialAsFull<JobRun>({ id: 'runA', createdAt: CREATED_AT }),
+      partialAsFull<JobRun>({ id: 'runB', createdAt: CREATED_AT }),
+    ]
+
+    const componentWithMore = mountWithTheme(
+      <Activity runs={runs} pageSize={1} count={2} />,
+    )
+    expect(componentWithMore.text()).toContain('View More')
+
+    const componentWithoutMore = mountWithTheme(
+      <Activity runs={runs} pageSize={2} count={2} />,
+    )
+    expect(componentWithoutMore.text()).not.toContain('View More')
+  })
+
   it('can show a loading message', () => {
     const component = mountWithTheme(<Activity pageSize={1} />)
     expect(component.text()).toContain('Loading ...')

--- a/operator_ui/src/components/Dashboards/Activity.tsx
+++ b/operator_ui/src/components/Dashboards/Activity.tsx
@@ -11,6 +11,7 @@ import {
 import Table from '@material-ui/core/Table'
 import TableBody from '@material-ui/core/TableBody'
 import TableCell from '@material-ui/core/TableCell'
+import TableFooter from '@material-ui/core/TableFooter'
 import TableRow from '@material-ui/core/TableRow'
 import Typography from '@material-ui/core/Typography'
 import { JobRun, JobRuns } from 'operator_ui'
@@ -103,7 +104,7 @@ interface Props extends WithStyles<typeof styles> {
   count?: number
 }
 
-const Activity = ({ classes, runs }: Props) => {
+const Activity = ({ classes, runs, count, pageSize }: Props) => {
   let activity
 
   if (!runs) {
@@ -157,6 +158,17 @@ const Activity = ({ classes, runs }: Props) => {
             </TableRow>
           ))}
         </TableBody>
+        {count && count > pageSize && (
+          <TableFooter>
+            <TableRow>
+              <TableCell scope="row" className={classes.footer}>
+                <Button href={'/runs'} component={BaseLink}>
+                  View More
+                </Button>
+              </TableCell>
+            </TableRow>
+          </TableFooter>
+        )}
       </Table>
     )
   }

--- a/operator_ui/src/pages/Header.tsx
+++ b/operator_ui/src/pages/Header.tsx
@@ -31,6 +31,7 @@ import fetchCountSelector from '../selectors/fetchCount'
 
 const SHARED_NAV_ITEMS = [
   ['/jobs', 'Jobs'],
+  ['/runs', 'Runs'],
   ['/bridges', 'Bridges'],
   ['/transactions', 'Transactions'],
   ['/keys', 'Keys'],

--- a/operator_ui/src/pages/JobRuns/Index.js
+++ b/operator_ui/src/pages/JobRuns/Index.js
@@ -1,0 +1,127 @@
+import React, { useState, useEffect } from 'react'
+import PropTypes from 'prop-types'
+import { connect } from 'react-redux'
+import { withStyles } from '@material-ui/core/styles'
+import Card from '@material-ui/core/Card'
+import TablePagination from '@material-ui/core/TablePagination'
+import matchRouteAndMapDispatchToProps from 'utils/matchRouteAndMapDispatchToProps'
+import { fetchJobRuns } from 'actionCreators'
+import jobRunsSelector from 'selectors/jobRuns'
+import jobRunsCountSelector from 'selectors/jobRunsCount'
+import List from '../Jobs/JobRunsList'
+import TableButtons, { FIRST_PAGE } from 'components/TableButtons'
+import Title from 'components/Title'
+import Content from 'components/Content'
+
+const styles = (theme) => ({
+  breadcrumb: {
+    marginTop: theme.spacing.unit * 5,
+    marginBottom: theme.spacing.unit * 5,
+  },
+})
+
+const renderLatestRuns = (props, state, handleChangePage) => {
+  const { jobSpecId, latestJobRuns, jobRunsCount = 0, pageSize } = props
+  const pagePath = props.pagePath.replace(':jobSpecId', jobSpecId)
+
+  const TableButtonsWithProps = () => (
+    <TableButtons
+      history={props.history}
+      count={jobRunsCount}
+      onChangePage={handleChangePage}
+      page={state.page}
+      specID={jobSpecId}
+      rowsPerPage={pageSize}
+      replaceWith={pagePath}
+    />
+  )
+  return (
+    <Card>
+      <List
+        jobSpecId={jobSpecId}
+        runs={latestJobRuns}
+        showJobRunsCount={jobRunsCount}
+      />
+      <TablePagination
+        component="div"
+        count={jobRunsCount}
+        rowsPerPage={pageSize}
+        rowsPerPageOptions={[pageSize]}
+        page={state.page - 1}
+        onChangePage={
+          () => {} /* handler required by component, so make it a no-op */
+        }
+        onChangeRowsPerPage={
+          () => {} /* handler required by component, so make it a no-op */
+        }
+        ActionsComponent={TableButtonsWithProps}
+      />
+    </Card>
+  )
+}
+
+const Fetching = () => <div>Fetching...</div>
+
+const renderDetails = (props, state, handleChangePage) => {
+  if (props.latestJobRuns) {
+    return renderLatestRuns(props, state, handleChangePage)
+  } else {
+    return <Fetching />
+  }
+}
+
+export const Index = (props) => {
+  const { jobSpecId, fetchJobRuns, pageSize, match } = props
+  const [page, setPage] = useState(FIRST_PAGE)
+
+  useEffect(() => {
+    document.title = 'Job Runs'
+    const queryPage = parseInt(match?.params.jobRunsPage, 10) || FIRST_PAGE
+    setPage(queryPage)
+    fetchJobRuns({ jobSpecId, page: queryPage, size: pageSize })
+  }, [fetchJobRuns, jobSpecId, pageSize, match])
+  const handleChangePage = (_, pageNum) => {
+    fetchJobRuns({ jobSpecId, page: pageNum, size: pageSize })
+    setPage(pageNum)
+  }
+
+  return (
+    <Content>
+      <Title>Runs</Title>
+
+      {renderDetails(props, { page }, handleChangePage)}
+    </Content>
+  )
+}
+
+Index.propTypes = {
+  classes: PropTypes.object.isRequired,
+  latestJobRuns: PropTypes.array,
+  jobRunsCount: PropTypes.number,
+  pageSize: PropTypes.number.isRequired,
+  pagePath: PropTypes.string.isRequired,
+}
+
+Index.defaultProps = {
+  latestJobRuns: [],
+  pageSize: 25,
+}
+
+const mapStateToProps = (state, ownProps) => {
+  const jobSpecId = ownProps.match.params.jobSpecId
+  const jobRunsCount = jobRunsCountSelector(state)
+  const latestJobRuns = jobRunsSelector(state, jobSpecId)
+
+  return {
+    jobSpecId,
+    latestJobRuns,
+    jobRunsCount,
+  }
+}
+
+export const ConnectedIndex = connect(
+  mapStateToProps,
+  matchRouteAndMapDispatchToProps({ fetchJobRuns }),
+)(Index)
+
+export default withStyles(styles)(ConnectedIndex)

--- a/operator_ui/src/pages/JobRuns/Index.test.js
+++ b/operator_ui/src/pages/JobRuns/Index.test.js
@@ -1,0 +1,113 @@
+import createStore from 'createStore'
+import { ConnectedIndex as Index } from 'pages/JobRuns/Index'
+import jsonApiJobSpecRunFactory from 'factories/jsonApiJobSpecRuns'
+import React from 'react'
+import { Provider } from 'react-redux'
+import { MemoryRouter } from 'react-router-dom'
+import clickFirstPage from 'test-helpers/clickFirstPage'
+import clickLastPage from 'test-helpers/clickLastPage'
+import clickNextPage from 'test-helpers/clickNextPage'
+import clickPreviousPage from 'test-helpers/clickPreviousPage'
+import mountWithTheme from 'test-helpers/mountWithTheme'
+import syncFetch from 'test-helpers/syncFetch'
+import globPath from 'test-helpers/globPath'
+
+const classes = {}
+const mountIndex = (props) =>
+  mountWithTheme(
+    <Provider store={createStore()}>
+      <MemoryRouter>
+        <Index
+          classes={classes}
+          pagePath="/jobs/:jobSpecId/runs/page"
+          {...props}
+        />
+      </MemoryRouter>
+    </Provider>,
+  )
+
+describe('pages/JobRuns/Index', () => {
+  const jobSpecId = 'c60b9927eeae43168ddbe92584937b1b'
+
+  it('renders the runs for the job spec', async () => {
+    expect.assertions(2)
+
+    const runsResponse = jsonApiJobSpecRunFactory([{ jobId: jobSpecId }])
+    global.fetch.getOnce(globPath('/v2/runs'), runsResponse)
+
+    const props = { match: { params: { jobSpecId } } }
+    const wrapper = mountIndex(props)
+
+    await syncFetch(wrapper)
+    expect(wrapper.text()).toContain(runsResponse.data[0].id)
+    expect(wrapper.text()).toContain('Complete')
+  })
+
+  it('can page through the list of runs', async () => {
+    expect.assertions(12)
+
+    const pageOneResponse = jsonApiJobSpecRunFactory(
+      [{ id: 'ID-ON-FIRST-PAGE', jobId: jobSpecId }],
+      3,
+    )
+    global.fetch.getOnce(globPath('/v2/runs'), pageOneResponse)
+
+    const props = { match: { params: { jobSpecId } }, pageSize: 1 }
+    const wrapper = mountIndex(props)
+
+    await syncFetch(wrapper)
+    expect(wrapper.text()).toContain('ID-ON-FIRST-PAGE')
+    expect(wrapper.text()).not.toContain('ID-ON-SECOND-PAGE')
+
+    const pageTwoResponse = jsonApiJobSpecRunFactory(
+      [{ id: 'ID-ON-SECOND-PAGE', jobId: jobSpecId }],
+      3,
+    )
+    global.fetch.getOnce(globPath('/v2/runs'), pageTwoResponse)
+    clickNextPage(wrapper)
+
+    await syncFetch(wrapper)
+    expect(wrapper.text()).not.toContain('ID-ON-FIRST-PAGE')
+    expect(wrapper.text()).toContain('ID-ON-SECOND-PAGE')
+
+    global.fetch.getOnce(globPath('/v2/runs'), pageOneResponse)
+    clickPreviousPage(wrapper)
+
+    await syncFetch(wrapper)
+    expect(wrapper.text()).toContain('ID-ON-FIRST-PAGE')
+    expect(wrapper.text()).not.toContain('ID-ON-SECOND-PAGE')
+
+    const pageThreeResponse = jsonApiJobSpecRunFactory(
+      [{ id: 'ID-ON-THIRD-PAGE', jobId: jobSpecId }],
+      3,
+    )
+    global.fetch.getOnce(globPath('/v2/runs'), pageThreeResponse)
+    clickLastPage(wrapper)
+
+    await syncFetch(wrapper)
+    expect(wrapper.text()).toContain('ID-ON-THIRD-PAGE')
+    expect(wrapper.text()).not.toContain('ID-ON-FIRST-PAGE')
+    expect(wrapper.text()).not.toContain('ID-ON-SECOND-PAGE')
+
+    global.fetch.getOnce(globPath('/v2/runs'), pageOneResponse)
+    clickFirstPage(wrapper)
+
+    await syncFetch(wrapper)
+    expect(wrapper.text()).not.toContain('ID-ON-SECOND-PAGE')
+    expect(wrapper.text()).not.toContain('ID-ON-THIRD-PAGE')
+    expect(wrapper.text()).toContain('ID-ON-FIRST-PAGE')
+  })
+
+  it('displays an empty message', async () => {
+    expect.assertions(1)
+
+    const runsResponse = jsonApiJobSpecRunFactory([])
+    await global.fetch.getOnce(globPath('/v2/runs'), runsResponse)
+
+    const props = { match: { params: { jobSpecId } } }
+    const wrapper = mountIndex(props)
+
+    await syncFetch(wrapper)
+    expect(wrapper.text()).toContain('No jobs have been run yet')
+  })
+})


### PR DESCRIPTION
Multiple people have mentioned that they were using this page to do a quick skim through the runs and find erroring job runs or other information related to last runs. We should improve the jobs list to show some summary stats about the job runs instead of using the generic runs page, but this page has been removed prematurely as we haven't given an alternative way to perform those tasks.

Revert "💥 Remove "/runs" page from operator UI (#3642)"
This reverts commit f3ba1de.