### PR TITLE
🐛 Fix date parsing in the `/jobs/:id/errors` page on Firefox

### DIFF
--- a/operator_ui/src/pages/Jobs/Errors.tsx
+++ b/operator_ui/src/pages/Jobs/Errors.tsx
@@ -85,18 +85,14 @@ export const JobsErrors: React.FC<{
                     <TableCell>
                       <Typography variant="body1">
                         <TimeAgo tooltip>
-                          {localizedTimestamp(
-                            jobSpecError.createdAt.toString(),
-                          )}
+                          {localizedTimestamp(jobSpecError.createdAt)}
                         </TimeAgo>
                       </Typography>
                     </TableCell>
                     <TableCell>
                       <Typography variant="body1">
                         <TimeAgo tooltip>
-                          {localizedTimestamp(
-                            jobSpecError.updatedAt.toString(),
-                          )}
+                          {localizedTimestamp(jobSpecError.updatedAt)}
                         </TimeAgo>
                       </Typography>
                     </TableCell>

--- a/operator_ui/src/pages/Jobs/Errors.tsx
+++ b/operator_ui/src/pages/Jobs/Errors.tsx
@@ -11,7 +11,7 @@ import {
 import { v2 } from 'api'
 import Button from 'components/Button'
 import Content from 'components/Content'
-import { localizedTimestamp, TimeAgo } from '@chainlink/styleguide'
+import { TimeAgo } from '@chainlink/styleguide'
 import { JobData } from './sharedTypes'
 
 export const JobsErrors: React.FC<{
@@ -84,16 +84,12 @@ export const JobsErrors: React.FC<{
                     </TableCell>
                     <TableCell>
                       <Typography variant="body1">
-                        <TimeAgo tooltip>
-                          {localizedTimestamp(jobSpecError.createdAt)}
-                        </TimeAgo>
+                        <TimeAgo tooltip>{jobSpecError.createdAt}</TimeAgo>
                       </Typography>
                     </TableCell>
                     <TableCell>
                       <Typography variant="body1">
-                        <TimeAgo tooltip>
-                          {localizedTimestamp(jobSpecError.updatedAt)}
-                        </TimeAgo>
+                        <TimeAgo tooltip>{jobSpecError.updatedAt}</TimeAgo>
                       </Typography>
                     </TableCell>
                     <TableCell>


### PR DESCRIPTION
`localizedTimestamp` was failing consistently on Firefox. Removing it fixed the issue. It also seems redundant as it was formatting the timestamp just to pass it to `Date.parse` in `TimeAgo` anyways 🤷‍♂️

Might address https://github.com/smartcontractkit/chainlink/issues/3504.