### PR TITLE
Deflake TestFluxMonitor(AntiSpamLogic|_HibernationMode)

### DIFF
--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -122,11 +122,12 @@ func (e *EthTx) insertEthTx(input models.RunInput, store *strpkg.Store) models.R
 		logger.Error(err)
 		return models.NewRunOutputError(err)
 	}
+
 	if e.ABIEncoding != nil {
 		// ABI encoding includes the data prefix if set.
-		encodedPayload = utils.ConcatBytes(e.FunctionSelector.Bytes(), txData)
+		encodedPayload = append(e.FunctionSelector.Bytes(), txData...)
 	} else {
-		encodedPayload = utils.ConcatBytes(e.FunctionSelector.Bytes(), e.DataPrefix, txData)
+		encodedPayload = append(append(e.FunctionSelector.Bytes(), e.DataPrefix...), txData...)
 	}
 
 	var gasLimit uint64
@@ -319,9 +320,9 @@ func getTxData(e *EthTx, input models.RunInput) ([]byte, error) {
 			// If we have a data prefix (reqID), encoding is:
 			// [4byte fs][0x00..40][reqID][arg1]
 			payloadOffset = utils.EVMWordUint64(utils.EVMWordByteLen * 2)
-			return utils.ConcatBytes(payloadOffset, output), nil
+			return append(payloadOffset, output...), nil
 		}
-		return utils.ConcatBytes(payloadOffset, output), nil
+		return append(payloadOffset, output...), nil
 	}
-	return utils.ConcatBytes(output), nil
+	return output, nil
 }

--- a/core/internal/cltest/client.go
+++ b/core/internal/cltest/client.go
@@ -268,9 +268,9 @@ func (c *SimulatedBackendClient) SubscribeNewHead(ctx context.Context, channel c
 					// channel.
 					defer func() {
 						if r := recover(); r != nil {
-							fmt.Println(
+							logger.Warn(
 								"warning: SubscribeNewHead attempted to put a head on a "+
-									"closed channel:", head)
+									"closed channel: %s", head)
 						}
 					}()
 					channel <- head

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -1006,29 +1006,6 @@ func WaitForRuns(t testing.TB, j models.JobSpec, store *strpkg.Store, want int) 
 	return jrs
 }
 
-// WaitForRuns waits for the wanted number of completed runs then returns a slice of the JobRuns
-func WaitForCompletedRuns(t testing.TB, j models.JobSpec, store *strpkg.Store, want int) []models.JobRun {
-	t.Helper()
-	g := gomega.NewGomegaWithT(t)
-
-	var jrs []models.JobRun
-	var err error
-	if want == 0 {
-		g.Consistently(func() []models.JobRun {
-			err = store.DB.Where("status = 'completed'").Find(&jrs).Error
-			assert.NoError(t, err)
-			return jrs
-		}, DBWaitTimeout, DBPollingInterval).Should(gomega.HaveLen(want))
-	} else {
-		g.Eventually(func() []models.JobRun {
-			err = store.DB.Where("status = 'completed'").Find(&jrs).Error
-			assert.NoError(t, err)
-			return jrs
-		}, DBWaitTimeout, DBPollingInterval).Should(gomega.HaveLen(want))
-	}
-	return jrs
-}
-
 // AssertRunsStays asserts that the number of job runs for a particular job remains at the provided values
 func AssertRunsStays(t testing.TB, j models.JobSpec, store *strpkg.Store, want int) []models.JobRun {
 	t.Helper()
@@ -1058,20 +1035,6 @@ func WaitForRunsAtLeast(t testing.TB, j models.JobSpec, store *strpkg.Store, wan
 			return len(jrs)
 		}, DBWaitTimeout, DBPollingInterval).Should(gomega.BeNumerically(">=", want))
 	}
-}
-
-func WaitForEthTxCount(t testing.TB, store *strpkg.Store, want int) []models.EthTx {
-	t.Helper()
-	g := gomega.NewGomegaWithT(t)
-
-	var txes []models.EthTx
-	var err error
-	g.Eventually(func() []models.EthTx {
-		err = store.DB.Order("nonce desc").Find(&txes).Error
-		assert.NoError(t, err)
-		return txes
-	}, DBWaitTimeout, DBPollingInterval).Should(gomega.HaveLen(want))
-	return txes
 }
 
 func WaitForEthTxAttemptsForEthTx(t testing.TB, store *strpkg.Store, ethTx models.EthTx) []models.EthTxAttempt {

--- a/core/services/bulletprooftxmanager/eth_confirmer.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer.go
@@ -473,7 +473,7 @@ func (ec *ethConfirmer) handleInProgressAttempt(ctx context.Context, etx models.
 		// This should really not ever happen in normal operation since we
 		// already bumped above the required minimum in ethBroadcaster.
 		//
-		// It could conceivably happen if the remote eth node changed it's configuration.
+		// It could conceivably happen if the remote eth node changed its configuration.
 		bumpedGasPrice, err := BumpGas(ec.config, attempt.GasPrice.ToInt())
 		if err != nil {
 			return errors.Wrap(err, "could not bump gas for terminally underpriced transaction")


### PR DESCRIPTION
This adds a missing .Commit() call to the simulated-backend ethereum client,
which was causing flux-monitor answers to be submitted in an unexpected order.

It also tightens up synchronization of the test with the simulated backend a
little, by waiting for log emmissions.

I've run both of these tests one hundred times without a failure.