### PR TITLE
Removed SafeMath being imported in ChainlinkClients

### DIFF
--- a/evm-contracts/src/v0.4/Aggregator.sol
+++ b/evm-contracts/src/v0.4/Aggregator.sol
@@ -4,6 +4,7 @@ import "./ChainlinkClient.sol";
 import "./interfaces/AggregatorInterface.sol";
 import "./vendor/SignedSafeMath.sol";
 import "./vendor/Ownable.sol";
+import "./vendor/SafeMathChainlink.sol";
 
 /**
  * @title An example Chainlink contract with aggregation
@@ -12,6 +13,7 @@ import "./vendor/Ownable.sol";
  * as the contract receives answers.
  */
 contract Aggregator is AggregatorInterface, ChainlinkClient, Ownable {
+  using SafeMathChainlink for uint256;
   using SignedSafeMath for int256;
 
   struct Answer {

--- a/evm-contracts/src/v0.4/ChainlinkClient.sol
+++ b/evm-contracts/src/v0.4/ChainlinkClient.sol
@@ -6,7 +6,6 @@ import "./interfaces/LinkTokenInterface.sol";
 import "./interfaces/ChainlinkRequestInterface.sol";
 import "./interfaces/PointerInterface.sol";
 import { ENSResolver as ENSResolver_Chainlink } from "./vendor/ENSResolver.sol";
-import "./vendor/SafeMathChainlink.sol";
 
 /**
  * @title The ChainlinkClient contract
@@ -15,7 +14,6 @@ import "./vendor/SafeMathChainlink.sol";
  */
 contract ChainlinkClient {
   using Chainlink for Chainlink.Request;
-  using SafeMathChainlink for uint256;
 
   uint256 constant internal LINK = 10**18;
   uint256 constant private AMOUNT_OVERRIDE = 0;

--- a/evm-contracts/src/v0.4/tests/ConcreteChainlinked.sol
+++ b/evm-contracts/src/v0.4/tests/ConcreteChainlinked.sol
@@ -1,9 +1,10 @@
 pragma solidity 0.4.24;
 
 import "../Chainlinked.sol";
-
+import "../vendor/SafeMathChainlink.sol";
 
 contract ConcreteChainlinked is Chainlinked {
+  using SafeMathChainlink for uint256;
 
   constructor(address _link, address _oracle) public {
     setLinkToken(_link);

--- a/evm-contracts/src/v0.4/tests/MaliciousConsumer.sol
+++ b/evm-contracts/src/v0.4/tests/MaliciousConsumer.sol
@@ -2,9 +2,12 @@ pragma solidity 0.4.24;
 
 
 import "../Chainlinked.sol";
+import "../vendor/SafeMathChainlink.sol";
 
 
 contract MaliciousConsumer is Chainlinked {
+  using SafeMathChainlink for uint256;
+
   uint256 constant private ORACLE_PAYMENT = 1 * LINK;
   uint256 private expiration;
 

--- a/evm-contracts/src/v0.5/ChainlinkClient.sol
+++ b/evm-contracts/src/v0.5/ChainlinkClient.sol
@@ -6,7 +6,6 @@ import "./interfaces/LinkTokenInterface.sol";
 import "./interfaces/ChainlinkRequestInterface.sol";
 import "./interfaces/PointerInterface.sol";
 import { ENSResolver as ENSResolver_Chainlink } from "./vendor/ENSResolver.sol";
-import "./vendor/SafeMathChainlink.sol";
 
 /**
  * @title The ChainlinkClient contract
@@ -15,7 +14,6 @@ import "./vendor/SafeMathChainlink.sol";
  */
 contract ChainlinkClient {
   using Chainlink for Chainlink.Request;
-  using SafeMathChainlink for uint256;
 
   uint256 constant internal LINK = 10**18;
   uint256 constant private AMOUNT_OVERRIDE = 0;

--- a/evm-contracts/src/v0.5/tests/MaliciousConsumer.sol
+++ b/evm-contracts/src/v0.5/tests/MaliciousConsumer.sol
@@ -1,8 +1,11 @@
 pragma solidity 0.5.0;
 
 import "../ChainlinkClient.sol";
+import "../vendor/SafeMathChainlink.sol";
 
 contract MaliciousConsumer is ChainlinkClient {
+   using SafeMathChainlink for uint256;
+
   uint256 constant private ORACLE_PAYMENT = 1 * LINK;
   uint256 private expiration;
 

--- a/evm-contracts/src/v0.6/ChainlinkClient.sol
+++ b/evm-contracts/src/v0.6/ChainlinkClient.sol
@@ -7,7 +7,6 @@ import "./interfaces/LinkTokenInterface.sol";
 import "./interfaces/ChainlinkRequestInterface.sol";
 import "./interfaces/PointerInterface.sol";
 import { ENSResolver as ENSResolver_Chainlink } from "./vendor/ENSResolver.sol";
-import "./vendor/SafeMathChainlink.sol";
 
 /**
  * @title The ChainlinkClient contract
@@ -16,7 +15,6 @@ import "./vendor/SafeMathChainlink.sol";
  */
 contract ChainlinkClient {
   using Chainlink for Chainlink.Request;
-  using SafeMathChainlink for uint256;
 
   uint256 constant internal LINK = 10**18;
   uint256 constant private AMOUNT_OVERRIDE = 0;

--- a/evm-contracts/src/v0.6/tests/MaliciousMultiWordConsumer.sol
+++ b/evm-contracts/src/v0.6/tests/MaliciousMultiWordConsumer.sol
@@ -2,8 +2,11 @@
 pragma solidity ^0.6.0;
 
 import "../ChainlinkClient.sol";
+import "../vendor/SafeMathChainlink.sol";
 
 contract MaliciousMultiWordConsumer is ChainlinkClient {
+  using SafeMathChainlink for uint256;
+
   uint256 constant private ORACLE_PAYMENT = 1 * LINK;
   uint256 private expiration;
 

--- a/evm-contracts/src/v0.7/ChainlinkClient.sol
+++ b/evm-contracts/src/v0.7/ChainlinkClient.sol
@@ -6,7 +6,6 @@ import "./interfaces/ENSInterface.sol";
 import "./interfaces/LinkTokenInterface.sol";
 import "./interfaces/ChainlinkRequestInterface.sol";
 import "./interfaces/PointerInterface.sol";
-import "./vendor/SafeMathChainlink.sol";
 import { ENSResolver as ENSResolver_Chainlink } from "./vendor/ENSResolver.sol";
 
 /**
@@ -16,7 +15,6 @@ import { ENSResolver as ENSResolver_Chainlink } from "./vendor/ENSResolver.sol";
  */
 contract ChainlinkClient {
   using Chainlink for Chainlink.Request;
-  using SafeMathChainlink for uint256;
 
   uint256 constant internal LINK = 10**18;
   uint256 constant private AMOUNT_OVERRIDE = 0;


### PR DESCRIPTION
`SafeMathChainlink` is imported in `ChainlinkClient` but never used in that contract.

Fixes #3685 