### PR TITLE
MWR follow up: support multiply adapter

### DIFF
--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -3,6 +3,7 @@ package adapters
 import (
 	"math/big"
 	"reflect"
+	"strconv"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -233,6 +234,8 @@ var (
 			"bytes4":  {},
 			"bytes":   {},
 			"address": {},
+			"uint256": {},
+			"int256": {},
 		},
 		gjson.True: {
 			"bool": {},
@@ -279,6 +282,14 @@ func getTxDataUsingABIEncoding(encodingSpec []string, jsonValues []gjson.Result)
 
 		switch jsonValues[i].Type {
 		case gjson.String:
+			if argType == "uint256" || argType == "int256" {
+				v, err := strconv.ParseInt(jsonValues[i].String(), 10, 64)
+				if err != nil {
+					return nil, errors.Wrapf(ErrInvalidABIEncoding, "can't convert %v to %v", jsonValues[i].Value(), argType)
+				}
+				values[i] = big.NewInt(v)
+				continue
+			}
 			// Only supports hex strings.
 			b, err := hexutil.Decode(jsonValues[i].String())
 			if err != nil {

--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -235,7 +235,7 @@ var (
 			"bytes":   {},
 			"address": {},
 			"uint256": {},
-			"int256": {},
+			"int256":  {},
 		},
 		gjson.True: {
 			"bool": {},

--- a/core/adapters/eth_tx_internal_test.go
+++ b/core/adapters/eth_tx_internal_test.go
@@ -66,6 +66,17 @@ func TestGetTxData(t *testing.T) {
 			},
 		},
 		{
+			name:        "ints as strings",
+			abiEncoding: []string{"int256", "uint256"},
+			argTypes:    abi.Arguments{{Type: Int256}, {Type: Uint256}},
+			args:        []interface{}{"-1234", "1234"},
+			assertion: func(t *testing.T, vals []interface{}) {
+				require.Len(t, vals, 2)
+				assert.Equal(t, big.NewInt(-1234), vals[0])
+				assert.Equal(t, big.NewInt(1234), vals[1])
+			},
+		},
+		{
 			name:        "multiple int256",
 			abiEncoding: []string{"int256", "int256"},
 			argTypes:    abi.Arguments{{Type: Int256}, {Type: Int256}},

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.1
 	github.com/gorilla/websocket v1.4.2
-	github.com/ipfs/go-datastore v0.4.5 // indirect
 	github.com/jinzhu/gorm v1.9.16
 	github.com/jpillora/backoff v1.0.0
 	github.com/lib/pq v1.8.0


### PR DESCRIPTION
The multiply adapter stringifies its input, so if you want to multiply an integer before encoding it, the encoding needs to be able to map json strings to integers as well. Open question whether the multiply adapter should preserve its input typing, but regardless its better to have the abi encoding support more mappings like string->ints. 