### PR TITLE
Make FunctionSelector.Scan() write to a pointer

### DIFF
--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -334,7 +334,7 @@ func (f FunctionSelector) Value() (driver.Value, error) {
 }
 
 // Scan returns the selector from its serialization in the database
-func (f FunctionSelector) Scan(value interface{}) error {
+func (f *FunctionSelector) Scan(value interface{}) error {
 	temp, ok := value.([]byte)
 	if !ok {
 		return fmt.Errorf("unable to convent %v of type %T to FunctionSelector", value, value)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Brings `/runs` tab back to the operator UI.
 - Signs out a user from operator UI on authentication error.
+- Fixed reading of function selector values in DB.
 
 ### Changes
 


### PR DESCRIPTION
I'm not sure if this even worked previously.

The issue here is that Scan() reads the value, but stores it in a local value instead of a pointer - which means the value would not change. This PR changes Scan() to write to the pointer instead, which will update the value.