### PR TITLE
Fix unmarshall bug for FluxAggregatorRoundData

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -804,8 +804,7 @@ func TestIntegration_FluxMonitor_Deviation(t *testing.T) {
 		Run(func(args mock.Arguments) {
 			*args.Get(0).(*hexutil.Bytes) = cltest.MakeRoundStateReturnData(2, true, 10000, 7, 0, availableFunds, minPayment, 1)
 		}).
-		Return(nil).
-		Twice()
+		Return(nil)
 
 	// Have server respond with 102 for price when FM checks external price
 	// adapter for deviation. 102 is enough deviation to trigger a job run.

--- a/core/services/eth/contracts/FluxAggregator.go
+++ b/core/services/eth/contracts/FluxAggregator.go
@@ -87,11 +87,11 @@ type FluxAggregatorRoundState struct {
 }
 
 type FluxAggregatorRoundData struct {
-	RoundID         uint32   `abi:"roundId" json:"reportableRoundID"`
+	RoundID         *big.Int `abi:"roundId" json:"reportableRoundID"`
 	Answer          *big.Int `abi:"answer" json:"latestAnswer,omitempty"`
-	StartedAt       uint64   `abi:"startedAt" json:"startedAt"`
-	UpdatedAt       uint64   `abi:"updatedAt" json:"updatedAt"`
-	AnsweredInRound uint32   `abi:"answeredInRound" json:"availableFunds,omitempty"`
+	StartedAt       *big.Int `abi:"startedAt" json:"startedAt"`
+	UpdatedAt       *big.Int `abi:"updatedAt" json:"updatedAt"`
+	AnsweredInRound *big.Int `abi:"answeredInRound" json:"availableFunds,omitempty"`
 }
 
 func (rs FluxAggregatorRoundState) TimesOutAt() uint64 {

--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -1039,7 +1039,8 @@ func (p *PollingDeviationChecker) initialRoundState() contracts.FluxAggregatorRo
 		)
 		return defaultRoundState
 	}
-	latestRoundState, err := p.fluxAggregator.RoundState(p.oracleAddress, latestRoundData.RoundID)
+	roundID := uint32(latestRoundData.RoundID.Uint64())
+	latestRoundState, err := p.fluxAggregator.RoundState(p.oracleAddress, roundID)
 	if err != nil {
 		logger.Warnf(
 			"unable to call roundState for latest round, contract: %s, round: %d, err: %v",

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -41,7 +41,7 @@ var (
 
 	makeRoundDataForRoundID = func(roundID uint32) contracts.FluxAggregatorRoundData {
 		return contracts.FluxAggregatorRoundData{
-			RoundID: roundID,
+			RoundID: big.NewInt(int64(roundID)),
 		}
 	}
 	freshContractRoundDataResponse = func() (contracts.FluxAggregatorRoundData, error) {


### PR DESCRIPTION
This bug occurred because all of the return values from FluxAggregator#latestRoundData() will overflow a uint64, and so the node couldn't unmarshal the response properly. CI didn't catch this because the node gracefully falls back to the default value for setting timers, and we don't have any integration tests that rely on this behavior.