### PR TITLE
Specify minimum compiler version instead of exact one

### DIFF
--- a/evm-contracts/src/v0.6/Oracle.sol
+++ b/evm-contracts/src/v0.6/Oracle.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.6.6;
+pragma solidity ^0.6.6;
 
 import "./LinkTokenReceiver.sol";
 import "./interfaces/ChainlinkRequestInterface.sol";


### PR DESCRIPTION
Unlike all other contracts, this one requires a specific compiler version. That is not on purpose, is it?