### PR TITLE
Use retry loop instead of waiting for advisory lock

### DIFF
--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -426,7 +426,7 @@ func dropAndCreateDB(parsed url.URL) (err error) {
 }
 
 func migrateTestDB(config *orm.Config) error {
-	orm, err := orm.NewORM(config.DatabaseURL(), config.DatabaseTimeout(), gracefulpanic.NewSignal(), config.GetDatabaseDialectConfiguredOrDefault(), config.GetAdvisoryLockIDConfiguredOrDefault())
+	orm, err := orm.NewORM(config.DatabaseURL(), config.DatabaseTimeout(), gracefulpanic.NewSignal(), config.GetDatabaseDialectConfiguredOrDefault(), config.GetAdvisoryLockIDConfiguredOrDefault(), config.GlobalLockRetryInterval().Duration())
 	if err != nil {
 		return fmt.Errorf("failed to initialize orm: %v", err)
 	}

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -340,7 +340,9 @@ func (cli *Client) HardReset(c *clipkg.Context) error {
 	// Ensure that the CL node is down by trying to acquire the global advisory lock.
 	// This method will panic if it can't get the lock.
 	logger.Info("Make sure the Chainlink node is not running")
-	ormInstance.MustEnsureAdvisoryLock()
+	if err := ormInstance.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 
 	if err := ormInstance.RemoveUnstartedTransactions(); err != nil {
 		logger.Errorw("failed to remove unstarted transactions", "error", err)

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -428,7 +428,7 @@ func dropAndCreateDB(parsed url.URL) (err error) {
 }
 
 func migrateTestDB(config *orm.Config) error {
-	orm, err := orm.NewORM(config.DatabaseURL(), config.DatabaseTimeout(), gracefulpanic.NewSignal(), config.GetDatabaseDialectConfiguredOrDefault(), config.GetAdvisoryLockIDConfiguredOrDefault(), config.GlobalLockRetryInterval().Duration())
+	orm, err := orm.NewORM(config.DatabaseURL(), config.DatabaseTimeout(), gracefulpanic.NewSignal(), config.GetDatabaseDialectConfiguredOrDefault(), config.GetAdvisoryLockIDConfiguredOrDefault(), config.GlobalLockRetryInterval().Duration(), config.ORMMaxOpenConns(), config.ORMMaxIdleConns())
 	if err != nil {
 		return fmt.Errorf("failed to initialize orm: %v", err)
 	}

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -344,7 +344,7 @@ func TestClient_RebroadcastTransactions_BPTXM(t *testing.T) {
 	// the transaction cannot be seen from another connection.
 	config, _, cleanup := cltest.BootstrapThrowawayORM(t, "rebroadcasttransactions", true, true)
 	defer cleanup()
-	config.Config.Dialect = orm.DialectPostgres
+	config.Config.Dialect = orm.DialectPostgresWithoutLock
 	connectedStore, connectedCleanup := cltest.NewStoreWithConfig(config)
 	defer connectedCleanup()
 	_, fromAddress := cltest.MustAddRandomKeyToKeystore(t, connectedStore, 0)

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -230,6 +230,8 @@ func NewTestConfig(t testing.TB, options ...interface{}) *TestConfig {
 	rawConfig.Set("BALANCE_MONITOR_ENABLED", "false")
 	rawConfig.Set("P2P_LISTEN_PORT", "12345")
 	rawConfig.Set("P2P_PEER_ID", DefaultP2PPeerID.String())
+	rawConfig.Set("DATABASE_TIMEOUT", "5s")
+	rawConfig.Set("GLOBAL_LOCK_RETRY_INTERVAL", "10ms")
 	rawConfig.SecretGenerator = mockSecretGenerator{}
 	config := TestConfig{t: t, Config: rawConfig}
 	return &config

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -232,6 +232,8 @@ func NewTestConfig(t testing.TB, options ...interface{}) *TestConfig {
 	rawConfig.Set("P2P_PEER_ID", DefaultP2PPeerID.String())
 	rawConfig.Set("DATABASE_TIMEOUT", "5s")
 	rawConfig.Set("GLOBAL_LOCK_RETRY_INTERVAL", "10ms")
+	rawConfig.Set("ORM_MAX_OPEN_CONNS", "5")
+	rawConfig.Set("ORM_MAX_IDLE_CONNS", "2")
 	rawConfig.SecretGenerator = mockSecretGenerator{}
 	config := TestConfig{t: t, Config: rawConfig}
 	return &config

--- a/core/internal/cltest/postgres.go
+++ b/core/internal/cltest/postgres.go
@@ -65,7 +65,7 @@ func BootstrapThrowawayORM(t *testing.T, name string, migrate bool, loadFixtures
 	require.NoError(t, os.MkdirAll(config.RootDir(), 0700))
 	migrationTestDBURL, err := dropAndCreateThrowawayTestDB(tc.DatabaseURL(), name)
 	require.NoError(t, err)
-	orm, err := orm.NewORM(migrationTestDBURL, config.DatabaseTimeout(), gracefulpanic.NewSignal(), orm.DialectPostgres, config.GetAdvisoryLockIDConfiguredOrDefault(), config.GlobalLockRetryInterval().Duration())
+	orm, err := orm.NewORM(migrationTestDBURL, config.DatabaseTimeout(), gracefulpanic.NewSignal(), orm.DialectPostgresWithoutLock, 0, config.GlobalLockRetryInterval().Duration())
 	require.NoError(t, err)
 	orm.SetLogging(true)
 	tc.Config.Set("DATABASE_URL", migrationTestDBURL)

--- a/core/internal/cltest/postgres.go
+++ b/core/internal/cltest/postgres.go
@@ -65,7 +65,7 @@ func BootstrapThrowawayORM(t *testing.T, name string, migrate bool, loadFixtures
 	require.NoError(t, os.MkdirAll(config.RootDir(), 0700))
 	migrationTestDBURL, err := dropAndCreateThrowawayTestDB(tc.DatabaseURL(), name)
 	require.NoError(t, err)
-	orm, err := orm.NewORM(migrationTestDBURL, config.DatabaseTimeout(), gracefulpanic.NewSignal(), orm.DialectPostgres, config.GetAdvisoryLockIDConfiguredOrDefault())
+	orm, err := orm.NewORM(migrationTestDBURL, config.DatabaseTimeout(), gracefulpanic.NewSignal(), orm.DialectPostgres, config.GetAdvisoryLockIDConfiguredOrDefault(), config.GlobalLockRetryInterval().Duration())
 	require.NoError(t, err)
 	orm.SetLogging(true)
 	tc.Config.Set("DATABASE_URL", migrationTestDBURL)

--- a/core/internal/cltest/postgres.go
+++ b/core/internal/cltest/postgres.go
@@ -65,7 +65,7 @@ func BootstrapThrowawayORM(t *testing.T, name string, migrate bool, loadFixtures
 	require.NoError(t, os.MkdirAll(config.RootDir(), 0700))
 	migrationTestDBURL, err := dropAndCreateThrowawayTestDB(tc.DatabaseURL(), name)
 	require.NoError(t, err)
-	orm, err := orm.NewORM(migrationTestDBURL, config.DatabaseTimeout(), gracefulpanic.NewSignal(), orm.DialectPostgresWithoutLock, 0, config.GlobalLockRetryInterval().Duration())
+	orm, err := orm.NewORM(migrationTestDBURL, config.DatabaseTimeout(), gracefulpanic.NewSignal(), orm.DialectPostgresWithoutLock, 0, config.GlobalLockRetryInterval().Duration(), config.ORMMaxOpenConns(), config.ORMMaxIdleConns())
 	require.NoError(t, err)
 	orm.SetLogging(true)
 	tc.Config.Set("DATABASE_URL", migrationTestDBURL)

--- a/core/services/bulletprooftxmanager/eth_broadcaster_test.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster_test.go
@@ -1114,7 +1114,7 @@ func TestEthBroadcaster_EthTxInsertEventCausesTriggerToFire(t *testing.T) {
 	// NOTE: Testing triggers requires committing transactions and does not work with transactional tests
 	config, _, cleanup := cltest.BootstrapThrowawayORM(t, "eth_tx_triggers", true, true)
 	defer cleanup()
-	config.Config.Dialect = orm.DialectPostgres
+	config.Config.Dialect = orm.DialectPostgresWithoutLock
 	store, cleanup := cltest.NewStoreWithConfig(config)
 	defer cleanup()
 	_, fromAddress := cltest.MustAddRandomKeyToKeystore(t, store, 0)

--- a/core/services/postgres/transaction.go
+++ b/core/services/postgres/transaction.go
@@ -3,9 +3,26 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"fmt"
+	"time"
 
 	"github.com/jinzhu/gorm"
 	"github.com/pkg/errors"
+)
+
+// NOTE: In an ideal world the timeouts below would be set to something sane in
+// the postgres configuration by the user. Since we do not live in an ideal
+// world, it is necessary to override them here.
+//
+// They cannot easily be set at a session level due to how Go's connection
+// pooling works.
+const (
+	// LockTimeout controls the max time we will wait for any kind of database lock.
+	// It's good to set this to _something_ because waiting for locks forever is really bad.
+	LockTimeout = 1 * time.Minute
+	// IdleInTxSessionTimeout controls the max time we leave a transaction open and idle.
+	// It's good to set this to _something_ because leaving transactions open forever is really bad.
+	IdleInTxSessionTimeout = 1 * time.Hour
 )
 
 func GormTransaction(ctx context.Context, db *gorm.DB, fc func(tx *gorm.DB) error, txOptss ...sql.TxOptions) (err error) {
@@ -16,6 +33,10 @@ func GormTransaction(ctx context.Context, db *gorm.DB, fc func(tx *gorm.DB) erro
 		txOpts = DefaultSqlTxOptions
 	}
 	tx := db.BeginTx(ctx, &txOpts)
+	err = tx.Exec(fmt.Sprintf(`SET LOCAL lock_timeout = %v; SET LOCAL idle_in_transaction_session_timeout = %v;`, LockTimeout.Milliseconds(), IdleInTxSessionTimeout.Milliseconds())).Error
+	if err != nil {
+		return errors.Wrap(err, "error setting transaction timeouts")
+	}
 	defer func() {
 		if r := recover(); r != nil {
 			err = errors.Errorf("%+v", r)

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -180,7 +180,10 @@ func (c Config) Set(name string, value interface{}) {
 	logger.Panicf("No configuration parameter for %s", name)
 }
 
-const defaultPostgresAdvisoryLockID int64 = 1027321974924625846
+const (
+	defaultPostgresAdvisoryLockID int64         = 1027321974924625846
+	defaultLockRetryInterval      time.Duration = 30 * time.Second
+)
 
 func (c Config) GetAdvisoryLockIDConfiguredOrDefault() int64 {
 	if c.AdvisoryLockID == 0 {
@@ -252,6 +255,11 @@ func (c Config) DatabaseMaximumTxDuration() time.Duration {
 // DatabaseTimeout represents how long to tolerate non response from the DB.
 func (c Config) DatabaseTimeout() models.Duration {
 	return models.MustMakeDuration(c.getWithFallback("DatabaseTimeout", parseDuration).(time.Duration))
+}
+
+// GlobalLockRetryInterval represents how long to wait before trying again to get the global advisory lock.
+func (c Config) GlobalLockRetryInterval() models.Duration {
+	return models.MustMakeDuration(c.getWithFallback("GlobalLockRetryInterval", parseDuration).(time.Duration))
 }
 
 // DatabaseURL configures the URL for chainlink to connect to. This must be

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -180,10 +180,7 @@ func (c Config) Set(name string, value interface{}) {
 	logger.Panicf("No configuration parameter for %s", name)
 }
 
-const (
-	defaultPostgresAdvisoryLockID int64         = 1027321974924625846
-	defaultLockRetryInterval      time.Duration = 30 * time.Second
-)
+const defaultPostgresAdvisoryLockID int64 = 1027321974924625846
 
 func (c Config) GetAdvisoryLockIDConfiguredOrDefault() int64 {
 	if c.AdvisoryLockID == 0 {

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -655,6 +655,13 @@ func (c Config) OCRKeyBundleID(override *models.Sha256Hash) (models.Sha256Hash, 
 	return models.Sha256Hash{}, errors.Wrap(ErrUnset, "OCR_KEY_BUNDLE_ID")
 }
 
+func (c Config) ORMMaxOpenConns() int {
+	return int(c.getWithFallback("ORMMaxOpenConns", parseUint16).(uint16))
+}
+func (c Config) ORMMaxIdleConns() int {
+	return int(c.getWithFallback("ORMMaxIdleConns", parseUint16).(uint16))
+}
+
 // OperatorContractAddress represents the address where the Operator.sol
 // contract is deployed, this is used for filtering RunLog requests
 func (c Config) OperatorContractAddress() common.Address {

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -658,6 +658,7 @@ func (c Config) OCRKeyBundleID(override *models.Sha256Hash) (models.Sha256Hash, 
 func (c Config) ORMMaxOpenConns() int {
 	return int(c.getWithFallback("ORMMaxOpenConns", parseUint16).(uint16))
 }
+
 func (c Config) ORMMaxIdleConns() int {
 	return int(c.getWithFallback("ORMMaxIdleConns", parseUint16).(uint16))
 }

--- a/core/store/orm/locking_strategies.go
+++ b/core/store/orm/locking_strategies.go
@@ -78,7 +78,7 @@ func (s *PostgresLockingStrategy) Lock(timeout models.Duration) error {
 	}
 
 	if s.config.locking {
-		logger.Debug("Waiting for global lock...")
+		logger.Debug("Trying to get global lock...")
 		err := s.waitForLock(ctx)
 		if err != nil {
 			return errors.Wrapf(ErrNoAdvisoryLock, "postgres advisory locking strategy failed on .Lock, timeout set to %v: %v, lock ID: %v", displayTimeout(timeout), err, s.config.advisoryLockID)

--- a/core/store/orm/locking_strategies_test.go
+++ b/core/store/orm/locking_strategies_test.go
@@ -42,6 +42,8 @@ func TestNewLockingStrategy(t *testing.T) {
 func TestPostgresLockingStrategy_Lock_withLock(t *testing.T) {
 	tc, cleanup := cltest.NewConfig(t)
 	defer cleanup()
+
+	tc.Config.Set("DATABASE_TIMEOUT", "500ms")
 	delay := tc.DatabaseTimeout()
 	if tc.DatabaseURL() == "" {
 		t.Skip("No postgres DatabaseURL set.")
@@ -68,6 +70,8 @@ func TestPostgresLockingStrategy_Lock_withoutLock(t *testing.T) {
 	tc, cleanup := cltest.NewConfig(t)
 	defer cleanup()
 	delay := tc.DatabaseTimeout()
+
+	tc.Config.Set("DATABASE_TIMEOUT", "500ms")
 	if tc.DatabaseURL() == "" {
 		t.Skip("No postgres DatabaseURL set.")
 	}
@@ -93,6 +97,8 @@ func TestPostgresLockingStrategy_Lock_withoutLock(t *testing.T) {
 
 func TestPostgresLockingStrategy_WhenLostIsReacquired(t *testing.T) {
 	tc := cltest.NewTestConfig(t)
+	tc.Config.Set("DATABASE_TIMEOUT", "500ms")
+
 	store, cleanup := cltest.NewStoreWithConfig(tc)
 	defer cleanup()
 
@@ -107,7 +113,7 @@ func TestPostgresLockingStrategy_WhenLostIsReacquired(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ct, err := orm.NewConnection(orm.DialectPostgres, store.Config.DatabaseURL(), tc.Config.GetAdvisoryLockIDConfiguredOrDefault(), tc.Config.GlobalLockRetryInterval().Duration())
+	ct, err := orm.NewConnection(orm.DialectPostgres, store.Config.DatabaseURL(), tc.Config.GetAdvisoryLockIDConfiguredOrDefault(), 10*time.Millisecond)
 	require.NoError(t, err)
 	lock2, err := orm.NewLockingStrategy(ct)
 	require.NoError(t, err)
@@ -118,6 +124,7 @@ func TestPostgresLockingStrategy_WhenLostIsReacquired(t *testing.T) {
 
 func TestPostgresLockingStrategy_CanBeReacquiredByNewNodeAfterDisconnect(t *testing.T) {
 	tc := cltest.NewTestConfig(t)
+	tc.Config.Set("DATABASE_TIMEOUT", "500ms")
 	store, cleanup := cltest.NewStoreWithConfig(tc)
 	defer cleanup()
 
@@ -141,6 +148,7 @@ func TestPostgresLockingStrategy_CanBeReacquiredByNewNodeAfterDisconnect(t *test
 
 func TestPostgresLockingStrategy_WhenReacquiredOriginalNodeErrors(t *testing.T) {
 	tc := cltest.NewTestConfig(t)
+	tc.Config.Set("DATABASE_TIMEOUT", "500ms")
 	store, cleanup := cltest.NewStoreWithConfig(tc)
 	defer cleanup()
 

--- a/core/store/orm/locking_strategies_test.go
+++ b/core/store/orm/locking_strategies_test.go
@@ -29,7 +29,7 @@ func TestNewLockingStrategy(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(string(test.name), func(t *testing.T) {
-			connectionType, err := orm.NewConnection(orm.DialectPostgres, test.path, 42, 1*time.Second)
+			connectionType, err := orm.NewConnection(orm.DialectPostgres, test.path, 42, 1*time.Second, 0, 0)
 			require.NoError(t, err)
 			rval, err := orm.NewLockingStrategy(connectionType)
 			require.NoError(t, err)
@@ -49,7 +49,7 @@ func TestPostgresLockingStrategy_Lock_withLock(t *testing.T) {
 		t.Skip("No postgres DatabaseURL set.")
 	}
 
-	withLock, err := orm.NewConnection(orm.DialectPostgres, tc.DatabaseURL(), tc.GetAdvisoryLockIDConfiguredOrDefault(), tc.GlobalLockRetryInterval().Duration())
+	withLock, err := orm.NewConnection(orm.DialectPostgres, tc.DatabaseURL(), tc.GetAdvisoryLockIDConfiguredOrDefault(), tc.GlobalLockRetryInterval().Duration(), tc.ORMMaxOpenConns(), tc.ORMMaxIdleConns())
 	require.NoError(t, err)
 	ls, err := orm.NewPostgresLockingStrategy(withLock)
 	require.NoError(t, err)
@@ -76,14 +76,14 @@ func TestPostgresLockingStrategy_Lock_withoutLock(t *testing.T) {
 		t.Skip("No postgres DatabaseURL set.")
 	}
 
-	withLock, err := orm.NewConnection(orm.DialectPostgres, tc.DatabaseURL(), tc.GetAdvisoryLockIDConfiguredOrDefault(), tc.GlobalLockRetryInterval().Duration())
+	withLock, err := orm.NewConnection(orm.DialectPostgres, tc.DatabaseURL(), tc.GetAdvisoryLockIDConfiguredOrDefault(), tc.GlobalLockRetryInterval().Duration(), tc.ORMMaxOpenConns(), tc.ORMMaxIdleConns())
 	require.NoError(t, err)
 	ls, err := orm.NewPostgresLockingStrategy(withLock)
 	require.NoError(t, err)
 	require.NoError(t, ls.Lock(delay), "should get exclusive lock")
 	require.NoError(t, ls.Lock(delay), "relocking on same instance is reentrant")
 
-	withoutLock, err := orm.NewConnection(orm.DialectPostgresWithoutLock, tc.DatabaseURL(), tc.GetAdvisoryLockIDConfiguredOrDefault(), tc.GlobalLockRetryInterval().Duration())
+	withoutLock, err := orm.NewConnection(orm.DialectPostgresWithoutLock, tc.DatabaseURL(), tc.GetAdvisoryLockIDConfiguredOrDefault(), tc.GlobalLockRetryInterval().Duration(), tc.ORMMaxOpenConns(), tc.ORMMaxIdleConns())
 	require.NoError(t, err)
 	ls2, err := orm.NewPostgresLockingStrategy(withoutLock)
 	require.NoError(t, err)
@@ -113,7 +113,7 @@ func TestPostgresLockingStrategy_WhenLostIsReacquired(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	ct, err := orm.NewConnection(orm.DialectPostgres, store.Config.DatabaseURL(), tc.Config.GetAdvisoryLockIDConfiguredOrDefault(), 10*time.Millisecond)
+	ct, err := orm.NewConnection(orm.DialectPostgres, store.Config.DatabaseURL(), tc.Config.GetAdvisoryLockIDConfiguredOrDefault(), 10*time.Millisecond, 0, 0)
 	require.NoError(t, err)
 	lock2, err := orm.NewLockingStrategy(ct)
 	require.NoError(t, err)
@@ -133,7 +133,7 @@ func TestPostgresLockingStrategy_CanBeReacquiredByNewNodeAfterDisconnect(t *test
 	require.NoError(t, dbErr)
 
 	orm2ShutdownSignal := gracefulpanic.NewSignal()
-	orm2, err := orm.NewORM(store.Config.DatabaseURL(), store.Config.DatabaseTimeout(), orm2ShutdownSignal, orm.DialectTransactionWrappedPostgres, tc.Config.GetAdvisoryLockIDConfiguredOrDefault(), tc.Config.GlobalLockRetryInterval().Duration())
+	orm2, err := orm.NewORM(store.Config.DatabaseURL(), store.Config.DatabaseTimeout(), orm2ShutdownSignal, orm.DialectTransactionWrappedPostgres, tc.Config.GetAdvisoryLockIDConfiguredOrDefault(), tc.Config.GlobalLockRetryInterval().Duration(), tc.ORMMaxOpenConns(), tc.ORMMaxIdleConns())
 	require.NoError(t, err)
 	defer orm2.Close()
 
@@ -158,7 +158,7 @@ func TestPostgresLockingStrategy_WhenReacquiredOriginalNodeErrors(t *testing.T) 
 	require.NoError(t, connErr)
 	require.NoError(t, dbErr)
 
-	ct, err := orm.NewConnection(orm.DialectPostgres, store.Config.DatabaseURL(), tc.Config.GetAdvisoryLockIDConfiguredOrDefault(), tc.Config.GlobalLockRetryInterval().Duration())
+	ct, err := orm.NewConnection(orm.DialectPostgres, store.Config.DatabaseURL(), tc.Config.GetAdvisoryLockIDConfiguredOrDefault(), tc.Config.GlobalLockRetryInterval().Duration(), tc.ORMMaxOpenConns(), tc.ORMMaxIdleConns())
 	require.NoError(t, err)
 	lock, err := orm.NewLockingStrategy(ct)
 	require.NoError(t, err)

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -71,7 +71,9 @@ func NewORM(uri string, timeout models.Duration, shutdownSignal gracefulpanic.Si
 		advisoryLockTimeout: timeout,
 		shutdownSignal:      shutdownSignal,
 	}
-	orm.MustEnsureAdvisoryLock()
+	if err = orm.MustEnsureAdvisoryLock(); err != nil {
+		return nil, err
+	}
 
 	db, err := ct.initializeDatabase()
 	if err != nil {
@@ -84,12 +86,14 @@ func NewORM(uri string, timeout models.Duration, shutdownSignal gracefulpanic.Si
 
 // MustEnsureAdvisoryLock sends a shutdown signal to the ORM if it an advisory
 // lock cannot be acquired.
-func (orm *ORM) MustEnsureAdvisoryLock() {
+func (orm *ORM) MustEnsureAdvisoryLock() error {
 	err := orm.lockingStrategy.Lock(orm.advisoryLockTimeout)
 	if err != nil {
 		logger.Errorf("unable to lock ORM: %v", err)
 		orm.shutdownSignal.Panic()
+		return err
 	}
+	return nil
 }
 
 func displayTimeout(timeout models.Duration) string {
@@ -135,15 +139,18 @@ func (orm *ORM) Unscoped() *ORM {
 }
 
 // FindBridge looks up a Bridge by its Name.
-func (orm *ORM) FindBridge(name models.TaskType) (models.BridgeType, error) {
-	orm.MustEnsureAdvisoryLock()
-	var bt models.BridgeType
+func (orm *ORM) FindBridge(name models.TaskType) (bt models.BridgeType, err error) {
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return bt, err
+	}
 	return bt, orm.DB.First(&bt, "name = ?", name.String()).Error
 }
 
 // FindBridgesByNames finds multiple bridges by their names.
 func (orm *ORM) FindBridgesByNames(names []string) ([]models.BridgeType, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return nil, err
+	}
 	var bt []models.BridgeType
 	if err := orm.DB.Where("name IN (?)", names).Find(&bt).Error; err != nil {
 		return nil, err
@@ -156,8 +163,10 @@ func (orm *ORM) FindBridgesByNames(names []string) ([]models.BridgeType, error) 
 
 // PendingBridgeType returns the bridge type of the current pending task,
 // or error if not pending bridge.
-func (orm *ORM) PendingBridgeType(jr models.JobRun) (models.BridgeType, error) {
-	orm.MustEnsureAdvisoryLock()
+func (orm *ORM) PendingBridgeType(jr models.JobRun) (bt models.BridgeType, err error) {
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return bt, err
+	}
 	nextTask := jr.NextTaskRun()
 	if nextTask == nil {
 		return models.BridgeType{}, errors.New("Cannot find the pending bridge type of a job run with no unfinished tasks")
@@ -166,9 +175,10 @@ func (orm *ORM) PendingBridgeType(jr models.JobRun) (models.BridgeType, error) {
 }
 
 // FindJob looks up a JobSpec by its ID.
-func (orm *ORM) FindJobSpec(id *models.ID) (models.JobSpec, error) {
-	orm.MustEnsureAdvisoryLock()
-	var job models.JobSpec
+func (orm *ORM) FindJobSpec(id *models.ID) (job models.JobSpec, err error) {
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return job, err
+	}
 	return job, orm.preloadJobs().First(&job, "id = ?", id).Error
 }
 
@@ -185,9 +195,10 @@ func (orm *ORM) FindJobWithErrors(id *models.ID) (models.JobSpec, error) {
 }
 
 // FindInitiator returns the single initiator defined by the passed ID.
-func (orm *ORM) FindInitiator(ID int64) (models.Initiator, error) {
-	orm.MustEnsureAdvisoryLock()
-	initr := models.Initiator{}
+func (orm *ORM) FindInitiator(ID int64) (initr models.Initiator, err error) {
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return initr, err
+	}
 	return initr, orm.DB.
 		Set("gorm:auto_preload", true).
 		First(&initr, "id = ?", ID).Error
@@ -224,10 +235,11 @@ func (orm *ORM) preloadJobRuns() *gorm.DB {
 }
 
 // FindJobRun looks up a JobRun by its ID.
-func (orm *ORM) FindJobRun(id *models.ID) (models.JobRun, error) {
-	orm.MustEnsureAdvisoryLock()
-	var jr models.JobRun
-	err := orm.preloadJobRuns().First(&jr, "id = ?", id).Error
+func (orm *ORM) FindJobRun(id *models.ID) (jr models.JobRun, err error) {
+	if err = orm.MustEnsureAdvisoryLock(); err != nil {
+		return jr, err
+	}
+	err = orm.preloadJobRuns().First(&jr, "id = ?", id).Error
 	return jr, err
 }
 
@@ -263,13 +275,17 @@ func (orm *ORM) Transaction(fc func(tx *gorm.DB) error) (err error) {
 // into multiple sql calls, i.e. orm.SaveJobRun(run), which are better suited
 // in a database transaction.
 func (orm *ORM) convenientTransaction(callback func(*gorm.DB) error) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.Transaction(callback)
 }
 
 // SaveJobRun updates UpdatedAt for a JobRun and saves it
 func (orm *ORM) SaveJobRun(run *models.JobRun) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.convenientTransaction(func(dbtx *gorm.DB) error {
 		result := dbtx.Unscoped().
 			Model(run).
@@ -288,13 +304,17 @@ func (orm *ORM) SaveJobRun(run *models.JobRun) error {
 
 // CreateJobRun inserts a new JobRun
 func (orm *ORM) CreateJobRun(run *models.JobRun) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.DB.Create(run).Error
 }
 
 // LinkEarnedFor shows the total link earnings for a job
 func (orm *ORM) LinkEarnedFor(spec *models.JobSpec) (*assets.Link, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return nil, err
+	}
 	var earned *assets.Link
 	query := orm.DB.Table("job_runs").
 		Joins("JOIN job_specs ON job_runs.job_spec_id = job_specs.id").
@@ -351,14 +371,18 @@ func (orm *ORM) DeleteJobSpecError(ID int64) error {
 
 // CreateExternalInitiator inserts a new external initiator
 func (orm *ORM) CreateExternalInitiator(externalInitiator *models.ExternalInitiator) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	err := orm.DB.Create(externalInitiator).Error
 	return err
 }
 
 // DeleteExternalInitiator removes an external initiator
 func (orm *ORM) DeleteExternalInitiator(name string) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	err := orm.DB.Delete(&models.ExternalInitiator{Name: name}).Error
 	return err
 }
@@ -367,7 +391,9 @@ func (orm *ORM) DeleteExternalInitiator(name string) error {
 func (orm *ORM) FindExternalInitiator(
 	eia *auth.Token,
 ) (*models.ExternalInitiator, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return nil, err
+	}
 	initiator := &models.ExternalInitiator{}
 	err := orm.DB.Where("access_key = ?", eia.AccessKey).Find(initiator).Error
 	if err != nil {
@@ -378,22 +404,26 @@ func (orm *ORM) FindExternalInitiator(
 }
 
 // FindExternalInitiatorByName finds an external initiator given an authentication request
-func (orm *ORM) FindExternalInitiatorByName(iname string) (models.ExternalInitiator, error) {
-	orm.MustEnsureAdvisoryLock()
-	var exi models.ExternalInitiator
+func (orm *ORM) FindExternalInitiatorByName(iname string) (exi models.ExternalInitiator, err error) {
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return exi, err
+	}
 	return exi, orm.DB.First(&exi, "lower(name) = lower(?)", iname).Error
 }
 
 // FindServiceAgreement looks up a ServiceAgreement by its ID.
-func (orm *ORM) FindServiceAgreement(id string) (models.ServiceAgreement, error) {
-	orm.MustEnsureAdvisoryLock()
-	var sa models.ServiceAgreement
+func (orm *ORM) FindServiceAgreement(id string) (sa models.ServiceAgreement, err error) {
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return sa, err
+	}
 	return sa, orm.DB.Set("gorm:auto_preload", true).First(&sa, "id = ?", id).Error
 }
 
 // Jobs fetches all jobs.
 func (orm *ORM) Jobs(cb func(*models.JobSpec) bool, initrTypes ...string) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return Batch(BatchSize, func(offset, limit uint) (uint, error) {
 		scope := orm.DB.Limit(limit).Offset(offset)
 		if len(initrTypes) > 0 {
@@ -436,7 +466,9 @@ func (orm *ORM) Jobs(cb func(*models.JobSpec) bool, initrTypes ...string) error 
 // JobRunsFor fetches all JobRuns with a given Job ID,
 // sorted by their created at time.
 func (orm *ORM) JobRunsFor(jobSpecID *models.ID, limit ...int) ([]models.JobRun, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return nil, err
+	}
 	runs := []models.JobRun{}
 	var lim int
 	if len(limit) == 0 {
@@ -454,7 +486,9 @@ func (orm *ORM) JobRunsFor(jobSpecID *models.ID, limit ...int) ([]models.JobRun,
 
 // JobRunsCountFor returns the current number of runs for the job
 func (orm *ORM) JobRunsCountFor(jobSpecID *models.ID) (int, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return 0, err
+	}
 	var count int
 	err := orm.DB.
 		Model(&models.JobRun{}).
@@ -465,7 +499,9 @@ func (orm *ORM) JobRunsCountFor(jobSpecID *models.ID) (int, error) {
 
 // Sessions returns all sessions limited by the parameters.
 func (orm *ORM) Sessions(offset, limit int) ([]models.Session, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return nil, err
+	}
 	var sessions []models.Session
 	err := orm.DB.
 		Set("gorm:auto_preload", true).
@@ -477,7 +513,9 @@ func (orm *ORM) Sessions(offset, limit int) ([]models.Session, error) {
 
 // GetConfigValue returns the value for a named configuration entry
 func (orm *ORM) GetConfigValue(field string, value encoding.TextUnmarshaler) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	name := EnvVarName(field)
 	config := models.Configuration{}
 	if err := orm.DB.First(&config, "name = ?", name).Error; err != nil {
@@ -488,7 +526,9 @@ func (orm *ORM) GetConfigValue(field string, value encoding.TextUnmarshaler) err
 
 // SetConfigValue returns the value for a named configuration entry
 func (orm *ORM) SetConfigValue(field string, value encoding.TextMarshaler) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	name := EnvVarName(field)
 	textValue, err := value.MarshalText()
 	if err != nil {
@@ -501,14 +541,18 @@ func (orm *ORM) SetConfigValue(field string, value encoding.TextMarshaler) error
 
 // CreateJob saves a job to the database and adds IDs to associated tables.
 func (orm *ORM) CreateJob(job *models.JobSpec) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.convenientTransaction(func(dbtx *gorm.DB) error {
 		return orm.createJob(dbtx, job)
 	})
 }
 
 func (orm *ORM) createJob(tx *gorm.DB, job *models.JobSpec) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	for i := range job.Initiators {
 		job.Initiators[i].JobSpecID = job.ID
 	}
@@ -518,7 +562,9 @@ func (orm *ORM) createJob(tx *gorm.DB, job *models.JobSpec) error {
 
 // ArchiveJob soft deletes the job, job_runs and its initiator.
 func (orm *ORM) ArchiveJob(ID *models.ID) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	j, err := orm.FindJobSpec(ID)
 	if err != nil {
 		return err
@@ -537,7 +583,9 @@ func (orm *ORM) ArchiveJob(ID *models.ID) error {
 // CreateServiceAgreement saves a Service Agreement, its JobSpec and its
 // associations to the database.
 func (orm *ORM) CreateServiceAgreement(sa *models.ServiceAgreement) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.convenientTransaction(func(dbtx *gorm.DB) error {
 		err := orm.createJob(dbtx, &sa.JobSpec)
 		if err != nil {
@@ -551,7 +599,9 @@ func (orm *ORM) CreateServiceAgreement(sa *models.ServiceAgreement) error {
 // UnscopedJobRunsWithStatus passes all JobRuns to a callback, one by one,
 // including those that were soft deleted.
 func (orm *ORM) UnscopedJobRunsWithStatus(cb func(*models.JobRun), statuses ...models.RunStatus) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	var runIDs []string
 	err := orm.DB.Unscoped().
 		Table("job_runs").
@@ -584,7 +634,9 @@ func (orm *ORM) UnscopedJobRunsWithStatus(cb func(*models.JobRun), statuses ...m
 // AnyJobWithType returns true if there is at least one job associated with
 // the type name specified and false otherwise
 func (orm *ORM) AnyJobWithType(taskTypeName string) (bool, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return false, err
+	}
 	db := orm.DB
 	var taskSpec models.TaskSpec
 	rval := db.Where("type = ?", taskTypeName).First(&taskSpec)
@@ -708,7 +760,9 @@ func (orm *ORM) EthTxAttempts(offset, limit int) ([]models.EthTxAttempt, int, er
 
 // FindEthTxAttempt returns an individual EthTxAttempt
 func (orm *ORM) FindEthTxAttempt(hash common.Hash) (*models.EthTxAttempt, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return nil, err
+	}
 	ethTxAttempt := &models.EthTxAttempt{}
 	if err := orm.DB.Preload("EthTx").First(ethTxAttempt, "hash = ?", hash).Error; err != nil {
 		return nil, errors.Wrap(err, "FindEthTxAttempt First(ethTxAttempt) failed")
@@ -718,7 +772,9 @@ func (orm *ORM) FindEthTxAttempt(hash common.Hash) (*models.EthTxAttempt, error)
 
 // MarkRan will set Ran to true for a given initiator
 func (orm *ORM) MarkRan(i models.Initiator, ran bool) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.convenientTransaction(func(dbtx *gorm.DB) error {
 		var newi models.Initiator
 		if err := dbtx.Select("ran").First(&newi, "ID = ?", i.ID).Error; err != nil {
@@ -738,10 +794,11 @@ func (orm *ORM) MarkRan(i models.Initiator, ran bool) error {
 }
 
 // FindUser will return the one API user, or an error.
-func (orm *ORM) FindUser() (models.User, error) {
-	orm.MustEnsureAdvisoryLock()
-	user := models.User{}
-	err := orm.DB.
+func (orm *ORM) FindUser() (user models.User, err error) {
+	if err = orm.MustEnsureAdvisoryLock(); err != nil {
+		return user, err
+	}
+	err = orm.DB.
 		Set("gorm:auto_preload", true).
 		Order("created_at desc").
 		First(&user).Error
@@ -751,7 +808,9 @@ func (orm *ORM) FindUser() (models.User, error) {
 // AuthorizedUserWithSession will return the one API user if the Session ID exists
 // and hasn't expired, and update session's LastUsed field.
 func (orm *ORM) AuthorizedUserWithSession(sessionID string, sessionDuration time.Duration) (models.User, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return models.User{}, err
+	}
 	if len(sessionID) == 0 {
 		return models.User{}, errors.New("Session ID cannot be empty")
 	}
@@ -774,7 +833,9 @@ func (orm *ORM) AuthorizedUserWithSession(sessionID string, sessionDuration time
 
 // DeleteUser will delete the API User in the db.
 func (orm *ORM) DeleteUser() (models.User, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return models.User{}, err
+	}
 	user, err := orm.FindUser()
 	if err != nil {
 		return user, err
@@ -795,20 +856,26 @@ func (orm *ORM) DeleteUser() (models.User, error) {
 
 // DeleteUserSession will erase the session ID for the sole API User.
 func (orm *ORM) DeleteUserSession(sessionID string) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.DB.Where("id = ?", sessionID).Delete(models.Session{}).Error
 }
 
 // DeleteBridgeType removes the bridge type
 func (orm *ORM) DeleteBridgeType(bt *models.BridgeType) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.DB.Delete(bt).Error
 }
 
 // CreateSession will check the password in the SessionRequest against
 // the hashed API User password in the db.
 func (orm *ORM) CreateSession(sr models.SessionRequest) (string, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return "", err
+	}
 	user, err := orm.FindUser()
 	if err != nil {
 		return "", err
@@ -838,20 +905,26 @@ func constantTimeEmailCompare(left, right string) bool {
 
 // ClearSessions removes all sessions.
 func (orm *ORM) ClearSessions() error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.DB.Delete(models.Session{}).Error
 }
 
 // ClearNonCurrentSessions removes all sessions but the id passed in.
 func (orm *ORM) ClearNonCurrentSessions(sessionID string) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.DB.Where("id <> ?", sessionID).Delete(models.Session{}).Error
 }
 
 // JobsSorted returns many JobSpecs sorted by CreatedAt from the store adhering
 // to the passed parameters.
 func (orm *ORM) JobsSorted(sort SortType, offset int, limit int) ([]models.JobSpec, int, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return nil, 0, err
+	}
 	count, err := orm.CountOf(&models.JobSpec{})
 	if err != nil {
 		return nil, 0, err
@@ -865,7 +938,9 @@ func (orm *ORM) JobsSorted(sort SortType, offset int, limit int) ([]models.JobSp
 
 // JobRunsSorted returns job runs ordered and filtered by the passed params.
 func (orm *ORM) JobRunsSorted(sort SortType, offset int, limit int) ([]models.JobRun, int, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return nil, 0, err
+	}
 	count, err := orm.CountOf(&models.JobRun{})
 	if err != nil {
 		return nil, 0, err
@@ -880,7 +955,9 @@ func (orm *ORM) JobRunsSorted(sort SortType, offset int, limit int) ([]models.Jo
 // JobRunsSortedFor returns job runs for a specific job spec ordered and
 // filtered by the passed params.
 func (orm *ORM) JobRunsSortedFor(id *models.ID, order SortType, offset int, limit int) ([]models.JobRun, int, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return nil, 0, err
+	}
 	count, err := orm.JobRunsCountFor(id)
 	if err != nil {
 		return nil, 0, err
@@ -899,7 +976,9 @@ func (orm *ORM) JobRunsSortedFor(id *models.ID, order SortType, offset int, limi
 // BridgeTypes returns bridge types ordered by name filtered limited by the
 // passed params.
 func (orm *ORM) BridgeTypes(offset int, limit int) ([]models.BridgeType, int, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return nil, 0, err
+	}
 	count, err := orm.CountOf(&models.BridgeType{})
 	if err != nil {
 		return nil, 0, err
@@ -912,25 +991,33 @@ func (orm *ORM) BridgeTypes(offset int, limit int) ([]models.BridgeType, int, er
 
 // SaveUser saves the user.
 func (orm *ORM) SaveUser(user *models.User) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.DB.Save(user).Error
 }
 
 // SaveSession saves the session.
 func (orm *ORM) SaveSession(session *models.Session) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.DB.Save(session).Error
 }
 
 // CreateBridgeType saves the bridge type.
 func (orm *ORM) CreateBridgeType(bt *models.BridgeType) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.DB.Create(bt).Error
 }
 
 // UpdateBridgeType updates the bridge type.
 func (orm *ORM) UpdateBridgeType(bt *models.BridgeType, btr *models.BridgeTypeRequest) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	bt.URL = btr.URL
 	bt.Confirmations = btr.Confirmations
 	bt.MinimumContractPayment = btr.MinimumContractPayment
@@ -939,7 +1026,9 @@ func (orm *ORM) UpdateBridgeType(bt *models.BridgeType, btr *models.BridgeTypeRe
 
 // CreateInitiator saves the initiator.
 func (orm *ORM) CreateInitiator(initr *models.Initiator) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	if initr.JobSpecID == nil {
 		// NOTE: This hangs forever if we don't check this here and the
 		// supplied initiator does not have a JobSpecID set.
@@ -1032,7 +1121,9 @@ func (orm *ORM) LastHead() (*models.Head, error) {
 
 // DeleteStaleSessions deletes all sessions before the passed time.
 func (orm *ORM) DeleteStaleSessions(before time.Time) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.DB.Where("last_used < ?", before).Delete(models.Session{}).Error
 }
 
@@ -1045,7 +1136,9 @@ func (orm *ORM) DeleteStaleSessions(before time.Time) error {
 // TaskRuns are removed by ON DELETE CASCADE when the JobRuns and RunResults
 // are deleted.
 func (orm *ORM) BulkDeleteRuns(bulkQuery *models.BulkDeleteRunRequest) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.convenientTransaction(func(dbtx *gorm.DB) error {
 		err := dbtx.Exec(`
 			WITH deleted_job_runs AS (
@@ -1103,7 +1196,9 @@ func (orm *ORM) DeleteKey(address common.Address) error {
 // CreateKeyIfNotExists inserts a key if a key with that address doesn't exist already
 // If a key with this address exists, it does nothing
 func (orm *ORM) CreateKeyIfNotExists(k models.Key) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	err := orm.DB.Set("gorm:insert_option", "ON CONFLICT (address) DO UPDATE SET deleted_at = NULL").Create(&k).Error
 	if err == nil || err.Error() == "sql: no rows in result set" {
 		return nil
@@ -1129,7 +1224,9 @@ func (orm *ORM) DeleteEncryptedSecretVRFKey(k *vrfkey.EncryptedVRFKey) error {
 // FindEncryptedVRFKeys retrieves matches to where from the encrypted keys table, or errors
 func (orm *ORM) FindEncryptedSecretVRFKeys(where ...vrfkey.EncryptedVRFKey) (
 	retrieved []*vrfkey.EncryptedVRFKey, err error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return nil, err
+	}
 	var anonWhere []interface{} // Find needs "where" contents coerced to interface{}
 	for _, constraint := range where {
 		c := constraint
@@ -1208,31 +1305,38 @@ func (orm *ORM) HasConsumedLogV2(blockHash common.Hash, logIndex uint, jobID int
 
 // MarkLogConsumed creates a new LogConsumption record
 func (orm *ORM) MarkLogConsumed(blockHash common.Hash, logIndex uint, jobID *models.ID, blockNumber uint64) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	lc := models.NewLogConsumption(blockHash, logIndex, jobID, nil, blockNumber)
 	return orm.DB.Create(&lc).Error
 }
 
 // MarkLogConsumedV2 creates a new LogConsumption record
 func (orm *ORM) MarkLogConsumedV2(blockHash common.Hash, logIndex uint, jobID int32, blockNumber uint64) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	lc := models.NewLogConsumption(blockHash, logIndex, nil, &jobID, blockNumber)
 	return orm.DB.Create(&lc).Error
 }
 
 // FindOrCreateFluxMonitorRoundStats find the round stats record for a given oracle on a given round, or creates
 // it if no record exists
-func (orm *ORM) FindOrCreateFluxMonitorRoundStats(aggregator common.Address, roundID uint32) (models.FluxMonitorRoundStats, error) {
-	orm.MustEnsureAdvisoryLock()
-	var stats models.FluxMonitorRoundStats
-	err := orm.DB.FirstOrCreate(&stats, models.FluxMonitorRoundStats{Aggregator: aggregator, RoundID: roundID}).Error
+func (orm *ORM) FindOrCreateFluxMonitorRoundStats(aggregator common.Address, roundID uint32) (stats models.FluxMonitorRoundStats, err error) {
+	if err = orm.MustEnsureAdvisoryLock(); err != nil {
+		return stats, err
+	}
+	err = orm.DB.FirstOrCreate(&stats, models.FluxMonitorRoundStats{Aggregator: aggregator, RoundID: roundID}).Error
 	return stats, err
 }
 
 // DeleteFluxMonitorRoundsBackThrough deletes all the RoundStat records for a given oracle address
 // starting from the most recent round back through the given round
 func (orm *ORM) DeleteFluxMonitorRoundsBackThrough(aggregator common.Address, roundID uint32) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.DB.Exec(`
         DELETE FROM flux_monitor_round_stats
         WHERE aggregator = ?
@@ -1243,7 +1347,9 @@ func (orm *ORM) DeleteFluxMonitorRoundsBackThrough(aggregator common.Address, ro
 // MostRecentFluxMonitorRoundID finds roundID of the most recent round that the provided oracle
 // address submitted to
 func (orm *ORM) MostRecentFluxMonitorRoundID(aggregator common.Address) (uint32, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return 0, err
+	}
 	var stats models.FluxMonitorRoundStats
 	err := orm.DB.Order("round_id DESC").First(&stats, "aggregator = ?", aggregator).Error
 	if err != nil {
@@ -1255,7 +1361,9 @@ func (orm *ORM) MostRecentFluxMonitorRoundID(aggregator common.Address) (uint32,
 // UpdateFluxMonitorRoundStats trys to create a RoundStat record for the given oracle
 // at the given round. If one already exists, it increments the num_submissions column.
 func (orm *ORM) UpdateFluxMonitorRoundStats(aggregator common.Address, roundID uint32, jobRunID *models.ID) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.DB.Exec(`
         INSERT INTO flux_monitor_round_stats (
             aggregator, round_id, job_run_id, num_new_round_logs, num_submissions
@@ -1337,13 +1445,17 @@ func (orm *ORM) RemoveUnstartedTransactions() error {
 }
 
 func (orm *ORM) CountOf(t interface{}) (int, error) {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return 0, err
+	}
 	var count int
 	return count, orm.DB.Model(t).Count(&count).Error
 }
 
 func (orm *ORM) getRecords(collection interface{}, order string, offset, limit int) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return orm.DB.
 		Set("gorm:auto_preload", true).
 		Order(order).Limit(limit).Offset(offset).
@@ -1351,7 +1463,9 @@ func (orm *ORM) getRecords(collection interface{}, order string, offset, limit i
 }
 
 func (orm *ORM) RawDB(fn func(*gorm.DB) error) error {
-	orm.MustEnsureAdvisoryLock()
+	if err := orm.MustEnsureAdvisoryLock(); err != nil {
+		return err
+	}
 	return fn(orm.DB)
 }
 
@@ -1461,7 +1575,7 @@ func (ct Connection) initializeDatabase() (*gorm.DB, error) {
 
 	db.SetLogger(newOrmLogWrapper(logger.Default))
 
-	if err := dbutil.SetTimezone(db); err != nil {
+	if err = dbutil.SetTimezone(db); err != nil {
 		return nil, err
 	}
 

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -1430,6 +1430,18 @@ func NewConnection(dialect DialectName, uri string, advisoryLockID int64, lockRe
 	return Connection{}, errors.Errorf("%s is not a valid dialect type", dialect)
 }
 
+// NOTE: In an ideal world the timeouts below would be set to something sane in
+// the postgres configuration by the user. Since we do not live in an ideal
+// world, it is necessary to override them here.
+const (
+	// LockTimeout controls the max time we will wait for any kind of database lock.
+	// It's good to set this to _something_ because waiting for locks forever is really bad.
+	LockTimeout = 1 * time.Minute
+	// IdleInTxSessionTimeout controls the max time we leave a transaction open and idle.
+	// It's good to set this to _something_ because leaving transactions open forever is really bad.
+	IdleInTxSessionTimeout = 1 * time.Hour
+)
+
 func (ct Connection) initializeDatabase() (*gorm.DB, error) {
 	if ct.transactionWrapped {
 		// Dbtx uses the uri as a unique identifier for each transaction. Each ORM
@@ -1451,6 +1463,15 @@ func (ct Connection) initializeDatabase() (*gorm.DB, error) {
 
 	if err := dbutil.SetTimezone(db); err != nil {
 		return nil, err
+	}
+
+	err = db.Exec(fmt.Sprintf(`SET lock_timeout = %v`, LockTimeout.Milliseconds())).Error
+	if err != nil {
+		return nil, errors.Wrap(err, "error setting lock timeout")
+	}
+	err = db.Exec(fmt.Sprintf(`SET idle_in_transaction_session_timeout = %v`, IdleInTxSessionTimeout.Milliseconds())).Error
+	if err != nil {
+		return nil, errors.Wrap(err, "error setting idle in transaction session timeout")
 	}
 
 	return db, nil

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -36,6 +36,7 @@ type ConfigSchema struct {
 	FeatureExternalInitiators                 bool            `env:"FEATURE_EXTERNAL_INITIATORS" default:"false"`
 	FeatureFluxMonitor                        bool            `env:"FEATURE_FLUX_MONITOR" default:"true"`
 	FeatureOffchainReporting                  bool            `env:"FEATURE_OFFCHAIN_REPORTING" default:"false"`
+	GlobalLockRetryInterval                   models.Duration `env:"GLOBAL_LOCK_RETRY_INTERVAL" default:"30s"`
 	MaximumServiceDuration                    models.Duration `env:"MAXIMUM_SERVICE_DURATION" default:"8760h" `
 	MinimumServiceDuration                    models.Duration `env:"MINIMUM_SERVICE_DURATION" default:"0s" `
 	EthGasBumpThreshold                       uint64          `env:"ETH_GAS_BUMP_THRESHOLD" default:"3" `

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -23,7 +23,7 @@ type ConfigSchema struct {
 	BridgeResponseURL                         url.URL         `env:"BRIDGE_RESPONSE_URL"`
 	ChainID                                   big.Int         `env:"ETH_CHAIN_ID" default:"1"`
 	ClientNodeURL                             string          `env:"CLIENT_NODE_URL" default:"http://localhost:6688"`
-	DatabaseTimeout                           models.Duration `env:"DATABASE_TIMEOUT" default:"500ms"`
+	DatabaseTimeout                           models.Duration `env:"DATABASE_TIMEOUT" default:"0"`
 	DatabaseURL                               string          `env:"DATABASE_URL"`
 	DatabaseListenerMinReconnectInterval      time.Duration   `env:"DATABASE_LISTENER_MIN_RECONNECT_INTERVAL" default:"1m"`
 	DatabaseListenerMaxReconnectDuration      time.Duration   `env:"DATABASE_LISTENER_MAX_RECONNECT_DURATION" default:"10m"`
@@ -36,7 +36,7 @@ type ConfigSchema struct {
 	FeatureExternalInitiators                 bool            `env:"FEATURE_EXTERNAL_INITIATORS" default:"false"`
 	FeatureFluxMonitor                        bool            `env:"FEATURE_FLUX_MONITOR" default:"true"`
 	FeatureOffchainReporting                  bool            `env:"FEATURE_OFFCHAIN_REPORTING" default:"false"`
-	GlobalLockRetryInterval                   models.Duration `env:"GLOBAL_LOCK_RETRY_INTERVAL" default:"30s"`
+	GlobalLockRetryInterval                   models.Duration `env:"GLOBAL_LOCK_RETRY_INTERVAL" default:"1s"`
 	MaximumServiceDuration                    models.Duration `env:"MAXIMUM_SERVICE_DURATION" default:"8760h" `
 	MinimumServiceDuration                    models.Duration `env:"MINIMUM_SERVICE_DURATION" default:"0s" `
 	EthGasBumpThreshold                       uint64          `env:"ETH_GAS_BUMP_THRESHOLD" default:"3" `

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -96,6 +96,8 @@ type ConfigSchema struct {
 	OCRTraceLogging                           bool            `env:"OCR_TRACE_LOGGING" default:"false"`
 	OCRMonitoringEndpoint                     string          `env:"OCR_MONITORING_ENDPOINT"`
 	OperatorContractAddress                   common.Address  `env:"OPERATOR_CONTRACT_ADDRESS"`
+	ORMMaxOpenConns                           int             `env:"ORM_MAX_OPEN_CONNS" default:"10"`
+	ORMMaxIdleConns                           int             `env:"ORM_MAX_IDLE_CONNS" default:"5"`
 	P2PAnnounceIP                             net.IP          `env:"P2P_ANNOUNCE_IP"`
 	P2PAnnouncePort                           uint16          `env:"P2P_ANNOUNCE_PORT"`
 	P2PDHTAnnouncementCounterUserPrefix       uint32          `env:"P2P_DHT_ANNOUNCEMENT_COUNTER_USER_PREFIX" default:"0"`

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -212,7 +212,7 @@ func (s *Store) ImportKey(keyJSON []byte, oldPassword string) error {
 }
 
 func initializeORM(config *orm.Config, shutdownSignal gracefulpanic.Signal) (*orm.ORM, error) {
-	orm, err := orm.NewORM(config.DatabaseURL(), config.DatabaseTimeout(), shutdownSignal, config.GetDatabaseDialectConfiguredOrDefault(), config.GetAdvisoryLockIDConfiguredOrDefault())
+	orm, err := orm.NewORM(config.DatabaseURL(), config.DatabaseTimeout(), shutdownSignal, config.GetDatabaseDialectConfiguredOrDefault(), config.GetAdvisoryLockIDConfiguredOrDefault(), config.GlobalLockRetryInterval().Duration())
 	if err != nil {
 		return nil, errors.Wrap(err, "initializeORM#NewORM")
 	}

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -212,7 +212,7 @@ func (s *Store) ImportKey(keyJSON []byte, oldPassword string) error {
 }
 
 func initializeORM(config *orm.Config, shutdownSignal gracefulpanic.Signal) (*orm.ORM, error) {
-	orm, err := orm.NewORM(config.DatabaseURL(), config.DatabaseTimeout(), shutdownSignal, config.GetDatabaseDialectConfiguredOrDefault(), config.GetAdvisoryLockIDConfiguredOrDefault(), config.GlobalLockRetryInterval().Duration())
+	orm, err := orm.NewORM(config.DatabaseURL(), config.DatabaseTimeout(), shutdownSignal, config.GetDatabaseDialectConfiguredOrDefault(), config.GetAdvisoryLockIDConfiguredOrDefault(), config.GlobalLockRetryInterval().Duration(), config.ORMMaxOpenConns(), config.ORMMaxIdleConns())
 	if err != nil {
 		return nil, errors.Wrap(err, "initializeORM#NewORM")
 	}

--- a/core/web/config_controller_test.go
+++ b/core/web/config_controller_test.go
@@ -54,5 +54,5 @@ func TestConfigController_Show(t *testing.T) {
 	assert.Equal(t, orm.NewConfig().BlockBackfillDepth(), cp.BlockBackfillDepth)
 	assert.Equal(t, assets.NewLink(100), cp.MinimumContractPayment)
 	assert.Equal(t, common.Address{}, cp.OperatorContractAddress)
-	assert.Equal(t, time.Millisecond*500, cp.DatabaseTimeout.Duration())
+	assert.Equal(t, time.Second*5, cp.DatabaseTimeout.Duration())
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Support for bignums encoded in CBOR
 - Silence spurious `Job spawner ORM attempted to claim locally-claimed job` warnings
 - OCR now drops transmissions instead of queueing them if the node is out of Ether
+- Fixed a long-standing issue where standby nodes would hold transactions open forever while waiting for a lock. This was preventing postgres from running necessary cleanup operations, resulting in bad database performance. Any node operators running standby failover chainlink nodes should see major database performance improvements with this release and may be able to reduce the size of their database instances.
 
 ### Changed
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Key-related API endpoints have changed. All key-related commands are now namespaced under `/v2/keys/...`, and are standardized across key types.
 - All key deletion commands now perform a soft-delete (i.e. archive) by default. A special CLI flag or query string parameter must be provided to hard-delete a key.
 - Node now supports multiple OCR jobs sharing the same peer ID. If you have more than one key in your database, you must now specify `P2P_PEER_ID` to indicate which key to use.
+- `DATABASE_TIMEOUT` is now set to 0 by default, so that nodes will wait forever for a lock. If you already have `DATABASE_TIMEOUT=0` set explicitly in your env (most node operators) then you don't need to do anything. If you didn't have it set, and you want to keep the old default behaviour where a node exits shortly if it can't get a lock, you can manually set `DATABASE_TIMEOUT=500ms` in your env.
 
 ## [0.9.8] - 2020-12-17
 


### PR DESCRIPTION
Waiting for an advisory lock for a really long time (hours/days/weeks) is problematic.

This is because while waiting for a lock, postgres must hold a
transaction open. This causes problems because postgres must hold the
MVCC snapshot from the start of transaction time and prevents automatic
vacuum and other garbage collection operations.

A common use-case is to run multiple chainlink nodes, one of which is
the "primary" and the other ones wait for the lock. This use case is
causing bad postgres performance because of the long running
transactions that are held open.

This PR replaces the wait with a periodic retry, which does not hold
open a transaction.