### PR TITLE
🐛 Do not send a `DESTROY /session` request on 401

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Silence spurious `Job spawner ORM attempted to claim locally-claimed job` warnings
 - OCR now drops transmissions instead of queueing them if the node is out of Ether
 - Fixed a long-standing issue where standby nodes would hold transactions open forever while waiting for a lock. This was preventing postgres from running necessary cleanup operations, resulting in bad database performance. Any node operators running standby failover chainlink nodes should see major database performance improvements with this release and may be able to reduce the size of their database instances.
+- Fixed an issue where expired session tokens in operator UI would cause a large number of reqeusts to be sent to the node, resulting in a temporary rate-limit and 429 errors.
 
 ### Changed
 

--- a/operator_ui/src/actionCreators.ts
+++ b/operator_ui/src/actionCreators.ts
@@ -109,7 +109,6 @@ export const receiveSignoutSuccess = () => ({
 })
 
 function sendSignOut(dispatch: Dispatch) {
-  dispatch({ type: AuthActionType.REQUEST_SIGNOUT })
   return api.sessions
     .destroySession()
     .then(() => dispatch(receiveSignoutSuccess()))
@@ -242,7 +241,7 @@ export const updateBridge = (
 // The calls above will be converted gradually.
 const handleError = (dispatch: Dispatch) => (error: Error) => {
   if (error instanceof jsonapi.AuthenticationError) {
-    sendSignOut(dispatch)
+    dispatch(receiveSignoutSuccess())
   } else {
     dispatch(notifyError(({ msg }: any) => msg, error))
   }

--- a/operator_ui/src/reducers/actions.ts
+++ b/operator_ui/src/reducers/actions.ts
@@ -77,7 +77,6 @@ export enum AuthActionType {
   RECEIVE_SIGNIN_SUCCESS = 'RECEIVE_SIGNIN_SUCCESS',
   RECEIVE_SIGNIN_FAIL = 'RECEIVE_SIGNIN_FAIL',
   RECEIVE_SIGNIN_ERROR = 'RECEIVE_SIGNIN_ERROR',
-  REQUEST_SIGNOUT = 'REQUEST_SIGNOUT',
   RECEIVE_SIGNOUT_SUCCESS = 'RECEIVE_SIGNOUT_SUCCESS',
   RECEIVE_SIGNOUT_ERROR = 'RECEIVE_SIGNOUT_ERROR',
 }
@@ -113,13 +112,6 @@ export interface ReceiveSigninErrorAction
   extends Action<AuthActionType.RECEIVE_SIGNIN_ERROR> {
   errors: any[]
 }
-
-/**
- * REQUEST_SIGNOUT
- */
-
-export interface RequestSignoutAction
-  extends Action<AuthActionType.REQUEST_SIGNOUT> {}
 
 /**
  * RECEIVE_SIGNOUT_SUCCESS

--- a/operator_ui/src/reducers/actions.ts
+++ b/operator_ui/src/reducers/actions.ts
@@ -389,7 +389,6 @@ export type Actions =
   | ReceiveSigninSuccessAction
   | ReceiveSigninFailAction
   | ReceiveSigninErrorAction
-  | RequestSignoutAction
   | ReceiveSignoutSuccessAction
   | ReceiveSignoutErrorAction
   | RequestCreateAction


### PR DESCRIPTION
The issue was that on a 401 error we'd try to send a request to `DESTROY /v2/sessions` endpoint which itself is behind auth. This resulted in an infinite loop of 401 error -> request to destroy a session -> 401 error -> ...

Also removes a redundant `dispatch({ type: AuthActionType.REQUEST_SIGNOUT })` action as it's unused and just clutters the codebase.