### PR TITLE
Use Run as atomic concurrency unit rather than TaskRun

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -1109,7 +1109,7 @@ func WaitForPipelineComplete(t testing.TB, nodeID int, jobID int32, jo job.ORM, 
 		prs, _, err := jo.PipelineRunsByJobID(jobID, 0, 1000)
 		assert.NoError(t, err)
 		for i := range prs {
-			if prs[i].Outputs != nil {
+			if !prs[i].Outputs.Null {
 				errs, err := prs[i].Errors.MarshalJSON()
 				assert.NoError(t, err)
 				if string(errs) != "[null]" {
@@ -1648,4 +1648,13 @@ func MustNewKeyedTransactor(t *testing.T, key *ecdsa.PrivateKey, chainID int64) 
 	require.NoError(t, err)
 
 	return transactor
+}
+
+func MustNewJSONSerializable(t *testing.T, s string) pipeline.JSONSerializable {
+	t.Helper()
+
+	js := new(pipeline.JSONSerializable)
+	err := js.UnmarshalJSON([]byte(s))
+	require.NoError(t, err)
+	return *js
 }

--- a/core/services/job/job_pipeline_orm_integration_test.go
+++ b/core/services/job/job_pipeline_orm_integration_test.go
@@ -287,10 +287,7 @@ func TestPipelineORM_Integration(t *testing.T) {
 				)
 				go func() {
 					err2 := postgres.GormTransaction(context.Background(), db, func(tx *gorm.DB) error {
-						err2 := tx.Exec(`
-							DELETE FROM pipeline_runs
-							WHERE id = ?
-                        `, runID2).Error
+						err2 := tx.Exec(`DELETE FROM pipeline_runs WHERE id = ?`, runID2).Error
 						assert.NoError(t, err2)
 
 						close(chClaimed)

--- a/core/services/pipeline/graph.go
+++ b/core/services/pipeline/graph.go
@@ -62,7 +62,7 @@ func (g TaskDAG) TasksInDependencyOrder() ([]Task, error) {
 			continue
 		}
 
-		task, err := UnmarshalTaskFromMap(TaskType(node.attrs["type"]), node.attrs, node.dotID, nil, nil)
+		task, err := UnmarshalTaskFromMap(TaskType(node.attrs["type"]), node.attrs, node.dotID, nil, nil, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/core/services/pipeline/mocks/orm.go
+++ b/core/services/pipeline/mocks/orm.go
@@ -137,19 +137,19 @@ func (_m *ORM) ListenForNewRuns() (postgres.Subscription, error) {
 	return r0, r1
 }
 
-// ProcessNextUnclaimedTaskRun provides a mock function with given fields: ctx, fn
-func (_m *ORM) ProcessNextUnclaimedTaskRun(ctx context.Context, fn pipeline.ProcessTaskRunFunc) (bool, error) {
+// ProcessNextUnfinishedRun provides a mock function with given fields: ctx, fn
+func (_m *ORM) ProcessNextUnfinishedRun(ctx context.Context, fn pipeline.ProcessRunFunc) (bool, error) {
 	ret := _m.Called(ctx, fn)
 
 	var r0 bool
-	if rf, ok := ret.Get(0).(func(context.Context, pipeline.ProcessTaskRunFunc) bool); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, pipeline.ProcessRunFunc) bool); ok {
 		r0 = rf(ctx, fn)
 	} else {
 		r0 = ret.Get(0).(bool)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, pipeline.ProcessTaskRunFunc) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, pipeline.ProcessRunFunc) error); ok {
 		r1 = rf(ctx, fn)
 	} else {
 		r1 = ret.Error(1)

--- a/core/services/pipeline/models.go
+++ b/core/services/pipeline/models.go
@@ -23,6 +23,7 @@ type (
 		ID             int32            `json:"-" gorm:"primary_key"`
 		DotID          string           `json:"dotId"`
 		PipelineSpecID int32            `json:"-"`
+		PipelineSpec   Spec             `json:"-"`
 		Type           TaskType         `json:"-"`
 		JSON           JSONSerializable `json:"-" gorm:"type:jsonb"`
 		Index          int32            `json:"-"`
@@ -31,15 +32,15 @@ type (
 	}
 
 	Run struct {
-		ID               int64             `json:"-" gorm:"primary_key"`
-		PipelineSpecID   int32             `json:"-"`
-		PipelineSpec     Spec              `json:"pipelineSpec"`
-		Meta             JSONSerializable  `json:"meta"`
-		Errors           *JSONSerializable `json:"errors" gorm:"type:jsonb"`
-		Outputs          *JSONSerializable `json:"outputs" gorm:"type:jsonb"`
-		CreatedAt        time.Time         `json:"createdAt"`
-		FinishedAt       *time.Time        `json:"finishedAt"`
-		PipelineTaskRuns []TaskRun         `json:"taskRuns" gorm:"foreignkey:PipelineRunID;association_autoupdate:false;association_autocreate:false"`
+		ID               int64            `json:"-" gorm:"primary_key"`
+		PipelineSpecID   int32            `json:"-"`
+		PipelineSpec     Spec             `json:"pipelineSpec"`
+		Meta             JSONSerializable `json:"meta"`
+		Errors           JSONSerializable `json:"errors" gorm:"type:jsonb"`
+		Outputs          JSONSerializable `json:"outputs" gorm:"type:jsonb"`
+		CreatedAt        time.Time        `json:"createdAt"`
+		FinishedAt       *time.Time       `json:"finishedAt"`
+		PipelineTaskRuns []TaskRun        `json:"taskRuns" gorm:"foreignkey:PipelineRunID;association_autoupdate:false;association_autocreate:false"`
 	}
 
 	TaskRun struct {
@@ -72,6 +73,15 @@ func (r *Run) SetID(value string) error {
 	}
 	r.ID = int64(ID)
 	return nil
+}
+
+func (r Run) HasErrors() bool {
+	return r.FinalErrors().HasErrors()
+}
+
+func (r Run) FinalErrors() (f FinalErrors) {
+	f, _ = r.Errors.Val.(FinalErrors)
+	return f
 }
 
 func (tr TaskRun) GetID() string {

--- a/core/services/pipeline/orm.go
+++ b/core/services/pipeline/orm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jinzhu/gorm"
@@ -23,7 +24,7 @@ type (
 	ORM interface {
 		CreateSpec(ctx context.Context, db *gorm.DB, taskDAG TaskDAG, maxTaskTimeout models.Interval) (int32, error)
 		CreateRun(ctx context.Context, jobID int32, meta map[string]interface{}) (int64, error)
-		ProcessNextUnclaimedTaskRun(ctx context.Context, fn ProcessTaskRunFunc) (bool, error)
+		ProcessNextUnfinishedRun(ctx context.Context, fn ProcessRunFunc) (bool, error)
 		ListenForNewRuns() (postgres.Subscription, error)
 		AwaitRun(ctx context.Context, runID int64) error
 		RunFinished(runID int64) (bool, error)
@@ -112,7 +113,7 @@ func (o *orm) CreateSpec(ctx context.Context, tx *gorm.DB, taskDAG TaskDAG, maxT
 			DotID:          task.DotID(),
 			PipelineSpecID: spec.ID,
 			Type:           task.Type(),
-			JSON:           JSONSerializable{task},
+			JSON:           JSONSerializable{task, false},
 			Index:          task.OutputIndex(),
 			SuccessorID:    successorID,
 		}
@@ -164,23 +165,26 @@ func (o *orm) CreateRun(ctx context.Context, jobID int32, meta map[string]interf
 	return runID, errors.WithStack(err)
 }
 
-type ProcessTaskRunFunc func(ctx context.Context, txdb *gorm.DB, jobID int32, ptRun TaskRun, predecessors []TaskRun) Result
+// TODO: Remove generation of special "result" task
+// TODO: Remove the unique index on successor_id
+// https://www.pivotaltracker.com/story/show/176557536
+type ProcessRunFunc func(ctx context.Context, txdb *gorm.DB, pRun Run) []TaskRunResult
 
-// ProcessNextUnclaimedTaskRun chooses any arbitrary incomplete TaskRun from the DB
-// whose parent TaskRuns have already been processed.
-func (o *orm) ProcessNextUnclaimedTaskRun(ctx context.Context, fn ProcessTaskRunFunc) (anyRemaining bool, err error) {
+// ProcessNextUnfinishedRun pulls the next available unfinished run from the
+// database and passes it into the provided ProcessRunFunc for execution.
+func (o *orm) ProcessNextUnfinishedRun(ctx context.Context, fn ProcessRunFunc) (anyRemaining bool, err error) {
 	// Passed in context cancels on (chStop || JobPipelineMaxTaskDuration)
 	utils.RetryWithBackoff(ctx, func() (retry bool) {
-		err = o.processNextUnclaimedTaskRun(ctx, fn)
+		err = o.processNextUnfinishedRun(ctx, fn)
 		// "Record not found" errors mean that we're done with all unclaimed
-		// task runs.
+		// job runs.
 		if postgres.IsRecordNotFound(err) {
 			anyRemaining = false
 			retry = false
 			err = nil
 		} else if err != nil {
 			retry = true
-			err = errors.Wrap(err, "Pipeline runner could not process task run")
+			err = errors.Wrap(err, "Pipeline runner could not process job run")
 			logger.Error(err)
 
 		} else {
@@ -192,139 +196,111 @@ func (o *orm) ProcessNextUnclaimedTaskRun(ctx context.Context, fn ProcessTaskRun
 	return anyRemaining, errors.WithStack(err)
 }
 
-func (o *orm) processNextUnclaimedTaskRun(ctx context.Context, fn ProcessTaskRunFunc) error {
+func (o *orm) processNextUnfinishedRun(ctx context.Context, fn ProcessRunFunc) error {
 	// Passed in context cancels on (chStop || JobPipelineMaxTaskDuration)
 	txContext, cancel := context.WithTimeout(context.Background(), o.config.DatabaseMaximumTxDuration())
 	defer cancel()
+	var pRun Run
 
 	err := postgres.GormTransaction(txContext, o.db, func(tx *gorm.DB) error {
-		var ptRun TaskRun
-		var predecessors []TaskRun
-
-		// NOTE: Manual loads below can probably be replaced with Joins in
-		// gormv2.
-		//
-		// Further optimisations (condensing into fewer queries) are
-		// probably possible if this turns out to be a hot path
-
-		// Find (and lock) the next unlocked, unfinished pipeline_task_run with no uncompleted predecessors
 		err := tx.Raw(`
-            SELECT * from pipeline_task_runs WHERE id IN (
-                SELECT pipeline_task_runs.id FROM pipeline_task_runs
-                    INNER JOIN pipeline_task_specs ON pipeline_task_runs.pipeline_task_spec_id = pipeline_task_specs.id
-                    LEFT JOIN pipeline_task_specs AS predecessor_specs ON predecessor_specs.successor_id = pipeline_task_specs.id
-                    LEFT JOIN pipeline_task_runs AS predecessor_unfinished_runs ON predecessor_specs.id = predecessor_unfinished_runs.pipeline_task_spec_id
-                          AND pipeline_task_runs.pipeline_run_id = predecessor_unfinished_runs.pipeline_run_id
-                WHERE pipeline_task_runs.finished_at IS NULL
-                GROUP BY (pipeline_task_runs.id)
-                HAVING (
-                    bool_and(predecessor_unfinished_runs.finished_at IS NOT NULL)
-                    OR
-                    count(predecessor_unfinished_runs.id) = 0
-                )
-            )
-            LIMIT 1
-            FOR UPDATE OF pipeline_task_runs SKIP LOCKED;
-        `).Scan(&ptRun).Error
+		SELECT id FROM pipeline_runs
+		WHERE finished_at IS NULL
+		ORDER BY id ASC
+		FOR UPDATE SKIP LOCKED
+		LIMIT 1
+		`).Scan(&pRun).Error
 		if err != nil {
-			return errors.Wrap(err, "error finding next task run")
+			return errors.Wrap(err, "error finding next pipeline run")
 		}
-
-		// Load the TaskSpec
-		if err = tx.Where("id = ?", ptRun.PipelineTaskSpecID).First(&ptRun.PipelineTaskSpec).Error; err != nil {
-			return errors.Wrap(err, "error finding next task run's spec")
-		}
-
-		// Load the PipelineRun
-		if err = tx.Where("id = ?", ptRun.PipelineRunID).First(&ptRun.PipelineRun).Error; err != nil {
-			return errors.Wrap(err, "error finding next task run's pipeline.Run")
-		}
-
-		// Find all the predecessor task runs
+		// NOTE: We have to lock and load in two distinct queries to work
+		// around a bizarre bug in gormv1.
+		// Trying to lock and load in one hit _sometimes_ fails to preload
+		// associations for no discernable reason.
 		err = tx.
-			Preload("PipelineTaskSpec").
-			Raw(`
-                SELECT pipeline_task_runs.* FROM pipeline_task_runs
-                INNER JOIN pipeline_task_specs AS specs_right ON specs_right.id = pipeline_task_runs.pipeline_task_spec_id
-                LEFT JOIN pipeline_task_specs AS specs_left ON specs_left.id = specs_right.successor_id
-                LEFT JOIN pipeline_task_runs AS successors ON successors.pipeline_task_spec_id = specs_left.id
-                      AND successors.pipeline_run_id = pipeline_task_runs.pipeline_run_id
-                WHERE successors.id = ?
-                ORDER BY pipeline_task_runs.index ASC
-            `, ptRun.ID).
-			Find(&predecessors).Error
+			Preload("PipelineTaskRuns.PipelineTaskSpec.PipelineSpec").
+			Where("pipeline_runs.id = ?", pRun.ID).
+			First(&pRun).Error
 		if err != nil {
-			return errors.Wrap(err, "error finding task run predecessors")
+			return errors.Wrap(err, "error loading run associations")
 		}
 
-		// Get the job ID
-		var job struct{ ID int32 }
-		err = tx.Raw(`
-            SELECT jobs.id FROM pipeline_task_runs
-            INNER JOIN pipeline_task_specs ON pipeline_task_specs.id = pipeline_task_runs.pipeline_task_spec_id
-            INNER JOIN jobs ON jobs.pipeline_spec_id = pipeline_task_specs.pipeline_spec_id
-            WHERE pipeline_task_runs.id = ?
-    		LIMIT 1
-        `, ptRun.ID).Scan(&job).Error
-		// TODO: Needs test, what happens if it can't find the job?!
+		logger.Infow("Pipeline run started", "runID", pRun.ID)
+
+		trrs := fn(ctx, tx, pRun)
+
+		if err = o.updateTaskRuns(tx, trrs); err != nil {
+			return errors.Wrap(err, "could not update task runs")
+		}
+
+		if err = o.UpdatePipelineRun(tx, &pRun, trrs); err != nil {
+			return errors.Wrap(err, "could not mark pipeline_run as finished")
+		}
+
+		err = o.eventBroadcaster.NotifyInsideGormTx(tx, postgres.ChannelRunCompleted, fmt.Sprintf("%v", pRun.ID))
 		if err != nil {
-			return errors.Wrap(err, "error finding job ID")
+			return errors.Wrap(err, "could not notify pipeline_run_completed")
 		}
 
-		// Call the callback
-		result := fn(ctx, tx, job.ID, ptRun, predecessors)
+		elapsed := time.Since(pRun.CreatedAt)
+		promPipelineRunTotalTimeToCompletion.WithLabelValues(string(pRun.PipelineSpecID)).Set(float64(elapsed))
 
-		// Update the task run record with the output and error
-		var out interface{}
-		var errString null.String
-		if result.Value != nil {
-			out = &JSONSerializable{Val: result.Value}
-		}
-		if finalErrors, is := result.Error.(FinalErrors); is {
-			errString = null.StringFrom(finalErrors.Error())
-		} else if result.Error != nil {
-			logger.Errorw("Error in pipeline task", "error", result.Error)
-			errString = null.StringFrom(result.Error.Error())
-		}
-		err = tx.Exec(`UPDATE pipeline_task_runs SET output = ?, error = ?, finished_at = ? WHERE id = ?`, out, errString, time.Now(), ptRun.ID).Error
-		if err != nil {
-			return errors.Wrap(err, "could not mark pipeline_task_run as finished")
+		if pRun.HasErrors() {
+			promPipelineRunErrors.WithLabelValues(string(pRun.PipelineSpecID)).Inc()
 		}
 
-		pipelineSpecIDStr := string(ptRun.PipelineTaskSpec.PipelineSpecID)
-		var status string
-		if result.Error != nil {
-			status = "error"
-		} else {
-			status = "completed"
-		}
-		promPipelineTasksTotalFinished.WithLabelValues(pipelineSpecIDStr, string(ptRun.PipelineTaskSpec.Type), status).Inc()
-
-		if ptRun.PipelineTaskSpec.IsFinalPipelineOutput() {
-			err = tx.Exec(`UPDATE pipeline_runs SET finished_at = ?, outputs = ?, errors = ? WHERE id = ?`, time.Now(), out, errString, ptRun.PipelineRunID).Error
-			if err != nil {
-				return errors.Wrap(err, "could not mark pipeline_run as finished")
-			}
-			// Emit a Postgres notification if this is the final `ResultTask`
-			err = o.eventBroadcaster.NotifyInsideGormTx(tx, postgres.ChannelRunCompleted, fmt.Sprintf("%v", ptRun.PipelineRunID))
-			if err != nil {
-				return errors.Wrap(err, "could not notify pipeline_run_completed")
-			}
-
-			elapsed := time.Since(ptRun.CreatedAt)
-			promPipelineRunTotalTimeToCompletion.WithLabelValues(pipelineSpecIDStr).Set(float64(elapsed))
-			if finalErrors, is := result.Error.(FinalErrors); (is && finalErrors.HasErrors()) || result.Error != nil {
-				promPipelineRunErrors.WithLabelValues(pipelineSpecIDStr).Inc()
-			}
-
-			logger.Infow("Pipeline run completed", "runID", ptRun.PipelineRunID)
-		}
 		return nil
 	})
 	if err != nil {
-		return errors.Wrap(err, "while processing task run")
+		return errors.Wrap(err, "while processing run")
 	}
+	logger.Infow("Pipeline run completed", "runID", pRun.ID)
 	return nil
+}
+
+// updateTaskRuns updates multiple task runs in one query
+func (o *orm) updateTaskRuns(db *gorm.DB, trrs []TaskRunResult) error {
+	sql := `
+UPDATE pipeline_task_runs AS ptr SET
+output = updates.output,
+error = updates.error,
+finished_at = updates.finished_at
+FROM (VALUES
+%s
+) AS updates(id, output, error, finished_at)
+WHERE ptr.id = updates.id
+`
+	// NOTE: gormv1 does not support bulk updates so we have to
+	// manually construct it ourselves
+	valueStrings := []string{}
+	valueArgs := []interface{}{}
+	for _, trr := range trrs {
+		valueStrings = append(valueStrings, "(?::bigint, ?::jsonb, ?::text, ?::timestamptz)")
+		valueArgs = append(valueArgs, trr.ID, trr.Result.OutputDB(), trr.Result.ErrorDB(), trr.FinishedAt)
+	}
+
+	/* #nosec G201 */
+	stmt := fmt.Sprintf(sql, strings.Join(valueStrings, ","))
+	return db.Exec(stmt, valueArgs...).Error
+}
+
+func (o *orm) UpdatePipelineRun(db *gorm.DB, run *Run, trrs []TaskRunResult) error {
+	var result Result
+	for _, trr := range trrs {
+		if trr.IsFinal {
+			// FIXME: This assumes there is only one final result and will
+			// have to change when the magical "__result__" type is removed
+			// https://www.pivotaltracker.com/story/show/176557536
+			result = trr.Result
+		}
+	}
+
+	return db.Raw(`
+		UPDATE pipeline_runs SET finished_at = ?, outputs = ?, errors = ?
+		WHERE id = ?
+		RETURNING *
+		`, time.Now(), result.OutputDB(), result.ErrorsDB(), run.ID).
+		Scan(run).Error
 }
 
 func (o *orm) ListenForNewRuns() (postgres.Subscription, error) {
@@ -445,6 +421,8 @@ func (o *orm) ResultsForRun(ctx context.Context, runID int64) ([]Result, error) 
 
 func (o *orm) RunFinished(runID int64) (bool, error) {
 	var done struct{ Done bool }
+	// TODO: Since we denormalised this can be made more efficient
+	// https://www.pivotaltracker.com/story/show/176557536
 	err := o.db.Raw(`
         SELECT finished_at IS NOT NULL AS done
         FROM pipeline_task_runs

--- a/core/services/pipeline/orm_test.go
+++ b/core/services/pipeline/orm_test.go
@@ -1,0 +1,97 @@
+package pipeline_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/services/pipeline"
+	"github.com/smartcontractkit/chainlink/core/services/postgres/mocks"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v4"
+)
+
+func Test_PipelineORM_CreateRun(t *testing.T) {
+	store, cleanup := cltest.NewStore(t)
+	defer cleanup()
+	db := store.DB
+
+	eventBroadcaster := new(mocks.EventBroadcaster)
+	orm := pipeline.NewORM(db, store.Config, eventBroadcaster)
+
+	job := cltest.MustInsertSampleDirectRequestJob(t, db)
+	meta := make(map[string]interface{})
+
+	runID, err := orm.CreateRun(context.Background(), job.ID, meta)
+	require.NoError(t, err)
+
+	// Check that JobRun, TaskRuns were created
+
+	var prs []pipeline.Run
+	var trs []pipeline.TaskRun
+
+	require.NoError(t, db.Find(&prs).Error)
+	require.NoError(t, db.Find(&trs).Error)
+
+	require.Len(t, prs, 1)
+	require.Equal(t, runID, prs[0].ID)
+	require.Len(t, trs, 4)
+}
+
+func Test_PipelineORM_UpdatePipelineRun(t *testing.T) {
+	store, cleanup := cltest.NewStore(t)
+	defer cleanup()
+	db := store.DB
+
+	require.NoError(t, db.Exec(`SET CONSTRAINTS pipeline_runs_pipeline_spec_id_fkey DEFERRED`).Error)
+
+	eventBroadcaster := new(mocks.EventBroadcaster)
+	orm := pipeline.NewORM(db, store.Config, eventBroadcaster)
+
+	t.Run("saves errored run with string error correctly", func(t *testing.T) {
+		run := cltest.MustInsertPipelineRun(t, db)
+		trrs := []pipeline.TaskRunResult{
+			pipeline.TaskRunResult{
+				IsFinal: true,
+				Result: pipeline.Result{
+					Value: []interface{}{nil},
+					Error: errors.New("Random: String, foo"),
+				},
+				FinishedAt: time.Now(),
+			},
+		}
+
+		err := orm.UpdatePipelineRun(db, &run, trrs)
+		require.NoError(t, err)
+
+		require.Equal(t, []interface{}{nil}, run.Outputs.Val)
+		require.Equal(t, "Random: String, foo", run.Errors.Val)
+		require.NotNil(t, run.FinishedAt)
+	})
+
+	t.Run("saves errored run with final errors correctly", func(t *testing.T) {
+		run := cltest.MustInsertPipelineRun(t, db)
+		trrs := []pipeline.TaskRunResult{
+			pipeline.TaskRunResult{
+				IsFinal: true,
+				Result: pipeline.Result{
+					Value: []interface{}{nil},
+					Error: pipeline.FinalErrors([]null.String{
+						null.String{},
+						null.StringFrom(`Random: String, foo`),
+					}),
+				},
+				FinishedAt: time.Now(),
+			},
+		}
+
+		err := orm.UpdatePipelineRun(db, &run, trrs)
+		require.NoError(t, err)
+
+		require.Equal(t, []interface{}{nil}, run.Outputs.Val)
+		require.Equal(t, []interface{}{nil, "Random: String, foo"}, run.Errors.Val)
+		require.NotNil(t, run.FinishedAt)
+	})
+}

--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -384,10 +384,8 @@ func (r *runner) executeTaskRun(ctx context.Context, txdb *gorm.DB, taskRun Task
 		specificTaskCtx, cancel = utils.CombinedContext(r.chStop, time.Duration(spec.MaxTaskDuration))
 		defer cancel()
 	}
-	ctx, cancel := utils.CombinedContext(ctx, specificTaskCtx)
-	defer cancel()
 
-	result := task.Run(ctx, taskRun, inputs)
+	result := task.Run(specificTaskCtx, taskRun, inputs)
 	if _, is := result.Error.(FinalErrors); !is && result.Error != nil {
 		logger.Errorw("Pipeline task run errored", append(loggerFields, "error", result.Error)...)
 	} else {

--- a/core/services/pipeline/runner_test.go
+++ b/core/services/pipeline/runner_test.go
@@ -1,0 +1,258 @@
+package pipeline_test
+
+import (
+	"context"
+	"fmt"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/shopspring/decimal"
+	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/services/pipeline"
+	"github.com/smartcontractkit/chainlink/core/services/pipeline/mocks"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/chainlink/core/utils"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v4"
+)
+
+// TODO: Add a test for multiple terminal tasks after __result__ is deprecated
+// https://www.pivotaltracker.com/story/show/176557536
+func Test_PipelineRunner_ExecuteTaskRuns(t *testing.T) {
+	store, cleanup := cltest.NewStore(t)
+	defer cleanup()
+
+	btcUSDPairing := utils.MustUnmarshalToMap(`{"data":{"coin":"BTC","market":"USD"}}`)
+
+	// 1. Setup bridge
+	s1 := httptest.NewServer(fakePriceResponder(t, btcUSDPairing, decimal.NewFromInt(9700)))
+	defer s1.Close()
+
+	bridgeFeedURL, err := url.ParseRequestURI(s1.URL)
+	require.NoError(t, err)
+	bridgeFeedWebURL := (*models.WebURL)(bridgeFeedURL)
+
+	_, bridge := cltest.NewBridgeType(t, "example-bridge")
+	bridge.URL = *bridgeFeedWebURL
+	require.NoError(t, store.ORM.DB.Create(&bridge).Error)
+
+	// 2. Setup success HTTP
+	s2 := httptest.NewServer(fakePriceResponder(t, btcUSDPairing, decimal.NewFromInt(9600)))
+	defer s2.Close()
+
+	s4 := httptest.NewServer(fakeStringResponder(t, "foo-index-1"))
+	defer s4.Close()
+	s5 := httptest.NewServer(fakeStringResponder(t, "bar-index-2"))
+	defer s5.Close()
+
+	orm := new(mocks.ORM)
+
+	r := pipeline.NewRunner(orm, store.Config)
+
+	spec := pipeline.Spec{ID: 142}
+	taskRuns := []pipeline.TaskRun{
+		// 1. Bridge request, succeeds
+		pipeline.TaskRun{
+			ID: 10,
+			PipelineTaskSpec: pipeline.TaskSpec{
+				ID:           1,
+				DotID:        `ds1`,
+				Type:         "bridge",
+				JSON:         cltest.MustNewJSONSerializable(t, `{"name": "example-bridge", "Timeout": 0, "requestData": {"data": {"coin": "BTC", "market": "USD"}}}`),
+				SuccessorID:  null.IntFrom(2),
+				PipelineSpec: spec,
+			},
+		},
+		pipeline.TaskRun{
+			ID: 11,
+			PipelineTaskSpec: pipeline.TaskSpec{
+				ID:           2,
+				DotID:        `ds1_parse`,
+				Type:         "jsonparse",
+				JSON:         cltest.MustNewJSONSerializable(t, `{"Lax": false, "path": ["data", "result"], "Timeout": 0}`),
+				SuccessorID:  null.IntFrom(3),
+				PipelineSpec: spec,
+			},
+		},
+		pipeline.TaskRun{
+			ID: 12,
+			PipelineTaskSpec: pipeline.TaskSpec{
+				ID:           3,
+				DotID:        `ds1_multiply`,
+				Type:         "multiply",
+				JSON:         cltest.MustNewJSONSerializable(t, `{"times": "1000000000000000000", "Timeout": 0}`),
+				SuccessorID:  null.IntFrom(102),
+				PipelineSpec: spec,
+			},
+		},
+		// 2. HTTP request, succeeds
+		pipeline.TaskRun{
+			ID: 21,
+			PipelineTaskSpec: pipeline.TaskSpec{
+				ID:           33,
+				DotID:        `ds2`,
+				Type:         "http",
+				JSON:         cltest.MustNewJSONSerializable(t, fmt.Sprintf(`{"method": "GET", "url": "%s", "requestData": {"data": {"coin": "BTC", "market": "USD"}}}`, s2.URL)),
+				SuccessorID:  null.IntFrom(32),
+				PipelineSpec: spec,
+			},
+		},
+		pipeline.TaskRun{
+			ID: 22,
+			PipelineTaskSpec: pipeline.TaskSpec{
+				ID:           32,
+				DotID:        `ds2_parse`,
+				Type:         "jsonparse",
+				JSON:         cltest.MustNewJSONSerializable(t, `{"Lax": false, "path": ["data", "result"], "Timeout": 0}`),
+				SuccessorID:  null.IntFrom(31),
+				PipelineSpec: spec,
+			},
+		},
+		pipeline.TaskRun{
+			ID: 23,
+			PipelineTaskSpec: pipeline.TaskSpec{
+				ID:           31,
+				DotID:        `ds2_multiply`,
+				Type:         "multiply",
+				JSON:         cltest.MustNewJSONSerializable(t, `{"times": "1000000000000000000", "Timeout": 0}`),
+				SuccessorID:  null.IntFrom(102),
+				PipelineSpec: spec,
+			},
+		},
+		// 3. HTTP request, fails
+		pipeline.TaskRun{
+			ID: 41,
+			PipelineTaskSpec: pipeline.TaskSpec{
+				ID:           51,
+				DotID:        `ds3`,
+				Type:         "http",
+				JSON:         cltest.MustNewJSONSerializable(t, `{"method": "GET", "url": "http://test.invalid", "requestData": {"data": {"coin": "BTC", "market": "USD"}}}`),
+				SuccessorID:  null.IntFrom(52),
+				PipelineSpec: spec,
+			},
+		},
+		pipeline.TaskRun{
+			ID: 42,
+			PipelineTaskSpec: pipeline.TaskSpec{
+				ID:           52,
+				DotID:        `ds3_parse`,
+				Type:         "jsonparse",
+				JSON:         cltest.MustNewJSONSerializable(t, `{"Lax": false, "path": ["data", "result"], "Timeout": 0}`),
+				SuccessorID:  null.IntFrom(53),
+				PipelineSpec: spec,
+			},
+		},
+		pipeline.TaskRun{
+			ID: 43,
+			PipelineTaskSpec: pipeline.TaskSpec{
+				ID:           53,
+				DotID:        `ds3_multiply`,
+				Type:         "multiply",
+				JSON:         cltest.MustNewJSONSerializable(t, `{"times": "1000000000000000000", "Timeout": 0}`),
+				SuccessorID:  null.IntFrom(102),
+				PipelineSpec: spec,
+			},
+		},
+		// MEDIAN
+		pipeline.TaskRun{
+			ID: 30,
+			PipelineTaskSpec: pipeline.TaskSpec{
+				ID:           102,
+				DotID:        `median`,
+				Type:         "median",
+				JSON:         cltest.MustNewJSONSerializable(t, `{"allowedFaults": 1}`),
+				SuccessorID:  null.IntFrom(203),
+				Index:        0,
+				PipelineSpec: spec,
+			},
+		},
+		// 4. HTTP Request, side by side with median to test indexing
+		pipeline.TaskRun{
+			ID: 71,
+			PipelineTaskSpec: pipeline.TaskSpec{
+				ID:           72,
+				DotID:        `ds4`,
+				Type:         "http",
+				JSON:         cltest.MustNewJSONSerializable(t, fmt.Sprintf(`{"method": "GET", "url": "%s"}`, s4.URL)),
+				SuccessorID:  null.IntFrom(203),
+				Index:        1,
+				PipelineSpec: spec,
+			},
+		},
+		// 5. HTTP Request, side by side with median to test indexing
+		pipeline.TaskRun{
+			ID: 73,
+			PipelineTaskSpec: pipeline.TaskSpec{
+				ID:           74,
+				DotID:        `ds5`,
+				Type:         "http",
+				JSON:         cltest.MustNewJSONSerializable(t, fmt.Sprintf(`{"method": "GET", "url": "%s"}`, s5.URL)),
+				SuccessorID:  null.IntFrom(203),
+				Index:        2,
+				PipelineSpec: spec,
+			},
+		},
+		// 6. Result
+		pipeline.TaskRun{
+			ID: 13,
+			PipelineTaskSpec: pipeline.TaskSpec{
+				ID:           203,
+				DotID:        `__result__`,
+				Type:         "result",
+				JSON:         cltest.MustNewJSONSerializable(t, `{}`),
+				SuccessorID:  null.Int{},
+				PipelineSpec: spec,
+			},
+		},
+	}
+
+	run := pipeline.Run{
+		ID:               242,
+		PipelineSpec:     spec,
+		PipelineTaskRuns: taskRuns,
+	}
+
+	trrs := r.ExecuteRun(context.Background(), store.DB, run)
+
+	require.Len(t, trrs, len(taskRuns))
+
+	var finalResults []pipeline.Result
+	for _, trr := range trrs {
+		if trr.IsFinal {
+			finalResults = append(finalResults, trr.Result)
+		}
+	}
+
+	require.Len(t, finalResults, 1)
+	result := finalResults[0]
+
+	require.Len(t, result.Value, 3)
+	finalValues := result.Value.([]interface{})
+
+	{
+		// Median
+		finalValue := finalValues[0].(decimal.Decimal)
+		require.Equal(t, "9650000000000000000000", finalValue.String())
+
+	}
+
+	{
+		// Strings 1 and 2
+		require.Equal(t, "foo-index-1", finalValues[1].(string))
+		require.Equal(t, "bar-index-2", finalValues[2].(string))
+	}
+
+	require.Len(t, result.Error, 3)
+	finalError := result.Error.(pipeline.FinalErrors)
+	require.False(t, finalError.HasErrors())
+
+	var errorResults []pipeline.TaskRunResult
+	for _, trr := range trrs {
+		if trr.Result.Error != nil && !trr.IsFinal {
+			errorResults = append(errorResults, trr)
+		}
+	}
+	// There are three tasks in the erroring pipeline
+	require.Len(t, errorResults, 3)
+}

--- a/core/services/pipeline/task.bridge_test.go
+++ b/core/services/pipeline/task.bridge_test.go
@@ -90,6 +90,14 @@ func fakePriceResponder(t *testing.T, requestData map[string]interface{}, result
 	})
 }
 
+func fakeStringResponder(t *testing.T, s string) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, err := w.Write([]byte(s))
+		require.NoError(t, err)
+	})
+}
+
 func TestBridgeTask_Happy(t *testing.T) {
 	store, cleanup := cltest.NewStore(t)
 	defer cleanup()
@@ -120,7 +128,7 @@ func TestBridgeTask_Happy(t *testing.T) {
 
 	result := task.Run(context.Background(), pipeline.TaskRun{
 		PipelineRun: pipeline.Run{
-			Meta: pipeline.JSONSerializable{emptyMeta},
+			Meta: pipeline.JSONSerializable{emptyMeta, false},
 		},
 	}, nil)
 	require.NoError(t, result.Error)
@@ -130,7 +138,7 @@ func TestBridgeTask_Happy(t *testing.T) {
 			Result decimal.Decimal `json:"result"`
 		} `json:"data"`
 	}
-	json.Unmarshal(result.Value.([]byte), &x)
+	json.Unmarshal([]byte(result.Value.(string)), &x)
 	require.Equal(t, decimal.NewFromInt(9700), x.Data.Result)
 }
 
@@ -176,7 +184,7 @@ func TestBridgeTask_Meta(t *testing.T) {
 
 	task.Run(context.Background(), pipeline.TaskRun{
 		PipelineRun: pipeline.Run{
-			Meta: pipeline.JSONSerializable{request},
+			Meta: pipeline.JSONSerializable{request, false},
 		},
 	}, nil)
 }
@@ -266,7 +274,7 @@ func TestBridgeTask_ErrorIfBridgeMissing(t *testing.T) {
 
 	result := task.Run(context.Background(), pipeline.TaskRun{
 		PipelineRun: pipeline.Run{
-			Meta: pipeline.JSONSerializable{emptyMeta},
+			Meta: pipeline.JSONSerializable{emptyMeta, false},
 		},
 	}, nil)
 	require.Nil(t, result.Value)
@@ -335,7 +343,7 @@ func TestBridgeTask_AddsID(t *testing.T) {
 
 	r := task.Run(context.Background(), pipeline.TaskRun{
 		PipelineRun: pipeline.Run{
-			Meta: pipeline.JSONSerializable{emptyMeta},
+			Meta: pipeline.JSONSerializable{emptyMeta, false},
 		},
 	}, nil)
 	require.NoError(t, r.Error)

--- a/core/services/pipeline/task.http.go
+++ b/core/services/pipeline/task.http.go
@@ -144,7 +144,11 @@ func (t *HTTPTask) Run(ctx context.Context, taskRun TaskRun, inputs []Result) Re
 		"response", string(responseBytes),
 		"url", t.URL.String(),
 	)
-	return Result{Value: responseBytes}
+	// NOTE: We always stringify the response since this is required for all current jobs.
+	// If a binary response is required we might consider adding an adapter
+	// flag such as  "BinaryMode: true" which passes through raw binary as the
+	// value instead.
+	return Result{Value: string(responseBytes)}
 }
 
 func (t *HTTPTask) allowUnrestrictedNetworkAccess() bool {

--- a/core/services/pipeline/task.http_test.go
+++ b/core/services/pipeline/task.http_test.go
@@ -47,7 +47,7 @@ func TestHTTPTask_Happy(t *testing.T) {
 
 	result := task.Run(context.Background(), pipeline.TaskRun{
 		PipelineRun: pipeline.Run{
-			Meta: pipeline.JSONSerializable{emptyMeta},
+			Meta: pipeline.JSONSerializable{emptyMeta, false},
 		},
 	}, nil)
 	require.NoError(t, result.Error)
@@ -57,7 +57,7 @@ func TestHTTPTask_Happy(t *testing.T) {
 			Result decimal.Decimal `json:"result"`
 		} `json:"data"`
 	}
-	json.Unmarshal(result.Value.([]byte), &x)
+	json.Unmarshal([]byte(result.Value.(string)), &x)
 	require.Equal(t, decimal.NewFromInt(9700), x.Data.Result)
 }
 

--- a/core/services/pipeline/task.result.go
+++ b/core/services/pipeline/task.result.go
@@ -10,6 +10,9 @@ import (
 	"gopkg.in/guregu/null.v4"
 )
 
+// TODO: This task type is no longer necessary, we should deprecate/remove it.
+// See: https://www.pivotaltracker.com/story/show/176557536
+
 // ResultTask exists solely as a Postgres performance optimization.  It's added
 // automatically to the end of every pipeline, and it receives the outputs of all
 // tasks that have no successor tasks.  This allows the pipeline runner to detect
@@ -43,6 +46,10 @@ func (t *ResultTask) Run(_ context.Context, taskRun TaskRun, inputs []Result) Re
 	return Result{Value: values, Error: errors}
 }
 
+// FIXME: This error/FinalErrors conflation exists solely because of the __result__ task.
+// It is confusing and needs to go, making this note to remove it along with the
+// special __result__ task.
+// https://www.pivotaltracker.com/story/show/176557536
 type FinalErrors []null.String
 
 func (fe FinalErrors) HasErrors() bool {

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -4,6 +4,7 @@ import (
 	"regexp"
 
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1609963213"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1611388693"
 
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1608217193"
 
@@ -492,6 +493,10 @@ func init() {
 		{
 			ID:      "1610630629",
 			Migrate: migration1610630629.Migrate,
+		},
+		{
+			ID:      "1611388693",
+			Migrate: migration1611388693.Migrate,
 		},
 	}
 }

--- a/core/store/migrations/migration1611388693/migrate.go
+++ b/core/store/migrations/migration1611388693/migrate.go
@@ -1,0 +1,12 @@
+package migration1611388693
+
+import "github.com/jinzhu/gorm"
+
+// Migrate adds the proper index to optimise the pipeline ORM for locking on runs instead of task runs
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+		CREATE INDEX IF NOT EXISTS idx_pipeline_runs_unfinished_runs ON pipeline_runs (id) WHERE finished_at IS NULL;
+		DROP INDEX IF EXISTS idx_pipeline_task_runs_optimise_find_predecessor_unfinished_runs;
+		DROP INDEX IF EXISTS idx_pipeline_task_runs_unfinished;
+	`).Error
+}

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -501,12 +501,18 @@ func (c Config) TriggerFallbackDBPollInterval() time.Duration {
 	return c.getWithFallback("TriggerFallbackDBPollInterval", parseDuration).(time.Duration)
 }
 
+// JobPipelineMaxTaskDuration is the maximum time that an individual task should be allowed to run
 func (c Config) JobPipelineMaxTaskDuration() time.Duration {
 	return c.getWithFallback("JobPipelineMaxTaskDuration", parseDuration).(time.Duration)
 }
 
+// JobPipelineMaxRunDuration is the maximum time that a job run may take
+func (c Config) JobPipelineMaxRunDuration() time.Duration {
+	return c.getWithFallback("JobPipelineMaxRunDuration", parseDuration).(time.Duration)
+}
+
 // JobPipelineParallelism controls how many workers the pipeline.Runner
-// uses in parallel
+// uses in parallel (how many pipeline runs may simultaneously be executing)
 func (c Config) JobPipelineParallelism() uint8 {
 	return c.getWithFallback("JobPipelineParallelism", parseUint8).(uint8)
 }

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -61,6 +61,7 @@ type ConfigSchema struct {
 	GasUpdaterEnabled                         bool            `env:"GAS_UPDATER_ENABLED" default:"true"`
 	InsecureFastScrypt                        bool            `env:"INSECURE_FAST_SCRYPT" default:"false"`
 	JobPipelineMaxTaskDuration                time.Duration   `env:"JOB_PIPELINE_MAX_TASK_DURATION" default:"10m"`
+	JobPipelineMaxRunDuration                 time.Duration   `env:"JOB_PIPELINE_MAX_RUN_DURATION" default:"10m"`
 	JobPipelineParallelism                    uint8           `env:"JOB_PIPELINE_PARALLELISM" default:"4"`
 	JobPipelineReaperInterval                 time.Duration   `env:"JOB_PIPELINE_REAPER_INTERVAL" default:"1h"`
 	JobPipelineReaperThreshold                time.Duration   `env:"JOB_PIPELINE_REAPER_THRESHOLD" default:"168h"`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a UI bug with fluxmonitor jobs where initiator params were bunched up.
+- Improved performance of OCR jobs to reduce database load
 
 ## [0.9.9] - 2021-01-18
 


### PR DESCRIPTION
This reduces database load considerably and moves the parallel task execution into software.