### PR TITLE
Update eth_tx_attempts with broadcast state when fetching receipt

### DIFF
--- a/core/services/bulletprooftxmanager/eth_broadcaster.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster.go
@@ -383,7 +383,7 @@ func saveUnconfirmed(store *store.Store, etx *models.EthTx, attempt models.EthTx
 	if attempt.State != models.EthTxAttemptInProgress {
 		return errors.New("attempt must be in in_progress state")
 	}
-	logger.Debugw("EthBroadcaster: successfully broadcast transaction", "ethTxID", etx.ID, "txHash", attempt.Hash.Hex())
+	logger.Debugw("EthBroadcaster: successfully broadcast transaction", "ethTxID", etx.ID, "ethTxAttemptID", attempt.ID, "txHash", attempt.Hash.Hex())
 	etx.State = models.EthTxUnconfirmed
 	attempt.State = models.EthTxAttemptBroadcast
 	return store.Transaction(func(tx *gorm.DB) error {

--- a/core/services/bulletprooftxmanager/eth_confirmer_test.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer_test.go
@@ -42,6 +42,16 @@ func newBroadcastEthTxAttempt(t *testing.T, etxID int64, store *store.Store, gas
 	return attempt
 }
 
+func newInProgressEthTxAttempt(t *testing.T, etxID int64, store *store.Store, gasPrice ...int64) models.EthTxAttempt {
+	attempt := cltest.NewEthTxAttempt(t, etxID)
+	attempt.State = models.EthTxAttemptInProgress
+	if len(gasPrice) > 0 {
+		gp := gasPrice[0]
+		attempt.GasPrice = *utils.NewBig(big.NewInt(gp))
+	}
+	return attempt
+}
+
 func mustInsertInProgressEthTx(t *testing.T, store *store.Store, nonce int64, fromAddress gethCommon.Address) models.EthTx {
 	etx := cltest.NewEthTx(t, store, fromAddress)
 	etx.State = models.EthTxInProgress
@@ -123,7 +133,6 @@ func TestEthConfirmer_CheckForReceipts(t *testing.T) {
 	ec := bulletprooftxmanager.NewEthConfirmer(store, config)
 
 	nonce := int64(0)
-	var err error
 	ctx := context.Background()
 	blockNum := int64(0)
 
@@ -156,6 +165,7 @@ func TestEthConfirmer_CheckForReceipts(t *testing.T) {
 		// Do the thing
 		require.NoError(t, ec.CheckForReceipts(ctx, blockNum))
 
+		var err error
 		etx1, err = store.FindEthTxWithAttempts(etx1.ID)
 		require.Len(t, etx1.EthTxAttempts, 1)
 		attempt1_1 = etx1.EthTxAttempts[0]
@@ -356,6 +366,43 @@ func TestEthConfirmer_CheckForReceipts(t *testing.T) {
 
 		ethClient.AssertExpectations(t)
 	})
+
+	etx4 := cltest.MustInsertUnconfirmedEthTxWithBroadcastAttempt(t, store, nonce, fromAddress)
+	nonce++
+
+	t.Run("on receipt fetch marks in_progress eth_tx_attempt as broadcast", func(t *testing.T) {
+		attempt4_2 := newInProgressEthTxAttempt(t, etx4.ID, store)
+		attempt4_2.GasPrice = *utils.NewBig(big.NewInt(10))
+
+		require.NoError(t, store.DB.Create(&attempt4_2).Error)
+
+		gethReceipt := gethTypes.Receipt{
+			TxHash:           attempt4_2.Hash,
+			BlockHash:        cltest.NewHash(),
+			BlockNumber:      big.NewInt(42),
+			TransactionIndex: uint(1),
+		}
+		// Second attempt is confirmed
+		ethClient.On("TransactionReceipt", mock.Anything, mock.MatchedBy(func(txHash gethCommon.Hash) bool {
+			return txHash == attempt4_2.Hash
+		})).Return(&gethReceipt, nil).Once()
+
+		// Do the thing
+		require.NoError(t, ec.CheckForReceipts(ctx, blockNum))
+
+		ethClient.AssertExpectations(t)
+
+		// Check that the state was updated
+		var err error
+		etx4, err = store.FindEthTxWithAttempts(etx4.ID)
+		require.NoError(t, err)
+
+		attempt4_2 = etx4.EthTxAttempts[1]
+
+		// And the attempts
+		require.Equal(t, models.EthTxAttemptBroadcast, attempt4_2.State)
+		require.Equal(t, int64(42), *attempt4_2.BroadcastBeforeBlockNum)
+	})
 }
 
 func TestEthConfirmer_CheckForReceipts_confirmed_missing_receipt(t *testing.T) {
@@ -472,7 +519,7 @@ func TestEthConfirmer_CheckForReceipts_confirmed_missing_receipt(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, models.EthTxConfirmed, etx0.State)
 
-		ethReceipt = etx0.EthTxAttempts[0].EthReceipts[0]
+		ethReceipt = etx0.EthTxAttempts[1].EthReceipts[0]
 		require.Equal(t, gethReceipt0.BlockHash, ethReceipt.BlockHash)
 	})
 

--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -422,7 +422,7 @@ func (r *runner) executeTaskRun(ctx context.Context, txdb *gorm.DB, spec Spec, t
 	result := task.Run(ctx, taskRun, inputs)
 	if _, is := result.Error.(FinalErrors); !is && result.Error != nil {
 		f := append(loggerFields, "error", result.Error)
-		logger.Errorw("Pipeline task run errored", f...)
+		logger.Warnw("Pipeline task run errored", f...)
 	} else {
 		f := append(loggerFields, "result", result.Value)
 		switch v := result.Value.(type) {

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1609963213"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1611388693"
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1611847145"
+	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1612225637"
 
 	"github.com/smartcontractkit/chainlink/core/store/migrations/migration1608217193"
 
@@ -502,6 +503,10 @@ func init() {
 		{
 			ID:      "1611847145",
 			Migrate: migration1611847145.Migrate,
+		},
+		{
+			ID:      "1612225637",
+			Migrate: migration1612225637.Migrate,
 		},
 	}
 }

--- a/core/store/migrations/migration1612225637/migrate.go
+++ b/core/store/migrations/migration1612225637/migrate.go
@@ -1,0 +1,12 @@
+package migration1612225637
+
+import "github.com/jinzhu/gorm"
+
+// Migrate fixes the cases where eth_tx_attempts might be erroneously left forever in in_progress state
+func Migrate(tx *gorm.DB) error {
+	return tx.Exec(`
+	UPDATE eth_tx_attempts SET state = 'broadcast', broadcast_before_block_num = eth_receipts.block_number
+	FROM eth_receipts
+	WHERE eth_tx_attempts.state = 'in_progress' AND eth_tx_attempts.hash = eth_receipts.tx_hash
+	`).Error
+}

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -719,7 +719,9 @@ func (orm *ORM) FindEthTaskRunTxByTaskRunID(taskRunID uuid.UUID) (*models.EthTas
 // FindEthTxWithAttempts finds the EthTx with its attempts and receipts preloaded
 func (orm *ORM) FindEthTxWithAttempts(etxID int64) (models.EthTx, error) {
 	etx := models.EthTx{}
-	err := orm.DB.Preload("EthTxAttempts.EthReceipts").First(&etx, "id = ?", &etxID).Error
+	err := orm.DB.Preload("EthTxAttempts", func(db *gorm.DB) *gorm.DB {
+		return db.Order("gas_price asc, id asc")
+	}).Preload("EthTxAttempts.EthReceipts").First(&etx, "id = ?", &etxID).Error
 	return etx, err
 }
 


### PR DESCRIPTION
While debugging stuck nodes after out-of-eth errors, I found that we could
enter a state where the attempt is left `in_progress` even though it has a
receipt. Within the model of BPTXM it shouldn't be harmful, but there is no
reason not to update the attempts with the correct data anyway.