### PR TITLE
Optimize Job Delete

### DIFF
--- a/core/internal/mocks/fetcher.go
+++ b/core/internal/mocks/fetcher.go
@@ -3,6 +3,8 @@
 package mocks
 
 import (
+	context "context"
+
 	decimal "github.com/shopspring/decimal"
 
 	mock "github.com/stretchr/testify/mock"
@@ -13,20 +15,20 @@ type Fetcher struct {
 	mock.Mock
 }
 
-// Fetch provides a mock function with given fields: _a0
-func (_m *Fetcher) Fetch(_a0 map[string]interface{}) (decimal.Decimal, error) {
-	ret := _m.Called(_a0)
+// Fetch provides a mock function with given fields: _a0, _a1
+func (_m *Fetcher) Fetch(_a0 map[string]interface{}, _a1 context.Context) (decimal.Decimal, error) {
+	ret := _m.Called(_a0, _a1)
 
 	var r0 decimal.Decimal
-	if rf, ok := ret.Get(0).(func(map[string]interface{}) decimal.Decimal); ok {
-		r0 = rf(_a0)
+	if rf, ok := ret.Get(0).(func(map[string]interface{}, context.Context) decimal.Decimal); ok {
+		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(decimal.Decimal)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(map[string]interface{}) error); ok {
-		r1 = rf(_a0)
+	if rf, ok := ret.Get(1).(func(map[string]interface{}, context.Context) error); ok {
+		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/internal/mocks/fetcher.go
+++ b/core/internal/mocks/fetcher.go
@@ -16,18 +16,18 @@ type Fetcher struct {
 }
 
 // Fetch provides a mock function with given fields: _a0, _a1
-func (_m *Fetcher) Fetch(_a0 map[string]interface{}, _a1 context.Context) (decimal.Decimal, error) {
+func (_m *Fetcher) Fetch(_a0 context.Context, _a1 map[string]interface{}) (decimal.Decimal, error) {
 	ret := _m.Called(_a0, _a1)
 
 	var r0 decimal.Decimal
-	if rf, ok := ret.Get(0).(func(map[string]interface{}, context.Context) decimal.Decimal); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, map[string]interface{}) decimal.Decimal); ok {
 		r0 = rf(_a0, _a1)
 	} else {
 		r0 = ret.Get(0).(decimal.Decimal)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(map[string]interface{}, context.Context) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, map[string]interface{}) error); ok {
 		r1 = rf(_a0, _a1)
 	} else {
 		r1 = ret.Error(1)

--- a/core/services/fluxmonitor/fetchers.go
+++ b/core/services/fluxmonitor/fetchers.go
@@ -26,7 +26,7 @@ import (
 // Fetcher is the interface encapsulating all functionality needed to retrieve
 // a price.
 type Fetcher interface {
-	Fetch(map[string]interface{}, context.Context) (decimal.Decimal, error)
+	Fetch(context.Context, map[string]interface{}) (decimal.Decimal, error)
 }
 
 // httpFetcher retrieves data via HTTP from an external price adapter source.
@@ -55,7 +55,7 @@ func newHTTPFetcher(
 	}
 }
 
-func (p *httpFetcher) Fetch(meta map[string]interface{}, ctx context.Context) (decimal.Decimal, error) {
+func (p *httpFetcher) Fetch(ctx context.Context, meta map[string]interface{}) (decimal.Decimal, error) {
 	request := withIDAndMeta(p.requestData, meta)
 	body, err := json.Marshal(request)
 	if err != nil {
@@ -167,7 +167,7 @@ func newMedianFetcher(fetchers ...Fetcher) (Fetcher, error) {
 	}, nil
 }
 
-func (m *medianFetcher) Fetch(meta map[string]interface{}, ctx context.Context) (decimal.Decimal, error) {
+func (m *medianFetcher) Fetch(ctx context.Context, meta map[string]interface{}) (decimal.Decimal, error) {
 	prices := []decimal.Decimal{}
 	fetchErrors := []error{}
 
@@ -180,7 +180,7 @@ func (m *medianFetcher) Fetch(meta map[string]interface{}, ctx context.Context) 
 	for _, fetcher := range m.fetchers {
 		fetcher := fetcher
 		go func() {
-			price, err := fetcher.Fetch(meta, ctx)
+			price, err := fetcher.Fetch(ctx, meta)
 			if err != nil {
 				logger.Warn(err)
 				chResults <- result{err: err}

--- a/core/services/fluxmonitor/fetchers.go
+++ b/core/services/fluxmonitor/fetchers.go
@@ -26,7 +26,7 @@ import (
 // Fetcher is the interface encapsulating all functionality needed to retrieve
 // a price.
 type Fetcher interface {
-	Fetch(map[string]interface{}) (decimal.Decimal, error)
+	Fetch(map[string]interface{}, context.Context) (decimal.Decimal, error)
 }
 
 // httpFetcher retrieves data via HTTP from an external price adapter source.
@@ -35,7 +35,6 @@ type httpFetcher struct {
 	url         *url.URL
 	requestData map[string]interface{}
 	sizeLimit   int64
-	ctx         context.Context
 }
 
 func newHTTPFetcher(
@@ -43,7 +42,6 @@ func newHTTPFetcher(
 	requestData map[string]interface{},
 	url *url.URL,
 	sizeLimit int64,
-	ctx context.Context,
 ) Fetcher {
 	client := &http.Client{Timeout: timeout.Duration(), Transport: http.DefaultTransport}
 	client.Transport = promhttp.InstrumentRoundTripperDuration(promFMResponseTime, client.Transport)
@@ -53,19 +51,18 @@ func newHTTPFetcher(
 		client:      client,
 		url:         url,
 		requestData: requestData,
-		ctx:         ctx,
 		sizeLimit:   sizeLimit,
 	}
 }
 
-func (p *httpFetcher) Fetch(meta map[string]interface{}) (decimal.Decimal, error) {
+func (p *httpFetcher) Fetch(meta map[string]interface{}, ctx context.Context) (decimal.Decimal, error) {
 	request := withIDAndMeta(p.requestData, meta)
 	body, err := json.Marshal(request)
 	if err != nil {
 		return decimal.Decimal{}, errors.Wrap(err, "error encoding request body as JSON")
 	}
 
-	req, err := http.NewRequestWithContext(p.ctx, "POST", p.url.String(), bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, "POST", p.url.String(), bytes.NewReader(body))
 	if err != nil {
 		return decimal.Decimal{}, errors.Wrap(err, "unable to create request")
 	}
@@ -146,11 +143,10 @@ func newMedianFetcherFromURLs(
 	requestData map[string]interface{},
 	priceURLs []*url.URL,
 	sizeLimit int64,
-	ctx context.Context,
 ) (Fetcher, error) {
 	fetchers := []Fetcher{}
 	for _, url := range priceURLs {
-		ps := newHTTPFetcher(timeout, requestData, url, sizeLimit, ctx)
+		ps := newHTTPFetcher(timeout, requestData, url, sizeLimit)
 		fetchers = append(fetchers, ps)
 	}
 
@@ -171,7 +167,7 @@ func newMedianFetcher(fetchers ...Fetcher) (Fetcher, error) {
 	}, nil
 }
 
-func (m *medianFetcher) Fetch(meta map[string]interface{}) (decimal.Decimal, error) {
+func (m *medianFetcher) Fetch(meta map[string]interface{}, ctx context.Context) (decimal.Decimal, error) {
 	prices := []decimal.Decimal{}
 	fetchErrors := []error{}
 
@@ -184,7 +180,7 @@ func (m *medianFetcher) Fetch(meta map[string]interface{}) (decimal.Decimal, err
 	for _, fetcher := range m.fetchers {
 		fetcher := fetcher
 		go func() {
-			price, err := fetcher.Fetch(meta)
+			price, err := fetcher.Fetch(meta, ctx)
 			if err != nil {
 				logger.Warn(err)
 				chResults <- result{err: err}

--- a/core/services/fluxmonitor/fetchers_test.go
+++ b/core/services/fluxmonitor/fetchers_test.go
@@ -1,6 +1,7 @@
 package fluxmonitor
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -74,7 +75,7 @@ func TestNewMedianFetcherFromURLs_Happy(t *testing.T) {
 				urls = append(urls, newURL)
 			}
 
-			medianFetcher, err := newMedianFetcherFromURLs(defaultHTTPTimeout, ethUSDPairing, urls, 32768)
+			medianFetcher, err := newMedianFetcherFromURLs(defaultHTTPTimeout, ethUSDPairing, urls, 32768, context.Background())
 			require.NoError(t, err)
 
 			medianPrice, err := medianFetcher.Fetch(emptyMeta)
@@ -89,7 +90,7 @@ func TestNewMedianFetcherFromURLs_EmptyError(t *testing.T) {
 	defer s1.Close()
 	var urls []*url.URL
 
-	_, err := newMedianFetcherFromURLs(defaultHTTPTimeout, ethUSDPairing, urls, 32768)
+	_, err := newMedianFetcherFromURLs(defaultHTTPTimeout, ethUSDPairing, urls, 32768, context.Background())
 	require.Error(t, err)
 }
 
@@ -100,7 +101,7 @@ func TestHTTPFetcher_Happy(t *testing.T) {
 	feedURL, err := url.ParseRequestURI(s1.URL)
 	require.NoError(t, err)
 
-	fetcher := newHTTPFetcher(defaultHTTPTimeout, btcUSDPairing, feedURL, 32768)
+	fetcher := newHTTPFetcher(defaultHTTPTimeout, btcUSDPairing, feedURL, 32768, context.Background())
 	price, err := fetcher.Fetch(emptyMeta)
 	require.NoError(t, err)
 	assert.Equal(t, decimal.NewFromInt(9700), price)
@@ -135,7 +136,7 @@ func TestHTTPFetcher_Meta(t *testing.T) {
 	feedURL, err := url.ParseRequestURI(s1.URL)
 	require.NoError(t, err)
 
-	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
+	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768, context.Background())
 	fetcher.Fetch(request)
 }
 
@@ -155,7 +156,7 @@ func TestHTTPFetcher_ErrorMessage(t *testing.T) {
 	feedURL, err := url.ParseRequestURI(server.URL)
 	require.NoError(t, err)
 
-	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
+	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768, context.Background())
 	price, err := fetcher.Fetch(emptyMeta)
 	assert.Error(t, err)
 	assert.Equal(t, decimal.NewFromInt(0).String(), price.String())
@@ -175,7 +176,7 @@ func TestHTTPFetcher_OnlyErrorMessage(t *testing.T) {
 	feedURL, err := url.ParseRequestURI(server.URL)
 	require.NoError(t, err)
 
-	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
+	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768, context.Background())
 	price, err := fetcher.Fetch(emptyMeta)
 	assert.Error(t, err)
 	assert.Equal(t, decimal.NewFromInt(0).String(), price.String())
@@ -194,7 +195,7 @@ func TestHTTPFetcher_NoResultNorErrorMessage(t *testing.T) {
 	feedURL, err := url.ParseRequestURI(server.URL)
 	require.NoError(t, err)
 
-	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
+	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768, context.Background())
 	price, err := fetcher.Fetch(emptyMeta)
 	assert.Error(t, err)
 	assert.True(t, decimal.NewFromInt(0).Equal(price))
@@ -338,6 +339,6 @@ func TestHTTPFetcher_AddsArbitraryRequestID(t *testing.T) {
 	feedURL, err := url.ParseRequestURI(s1.URL)
 	require.NoError(t, err)
 
-	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
+	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768, context.Background())
 	fetcher.Fetch(emptyMeta)
 }

--- a/core/services/fluxmonitor/fetchers_test.go
+++ b/core/services/fluxmonitor/fetchers_test.go
@@ -78,7 +78,7 @@ func TestNewMedianFetcherFromURLs_Happy(t *testing.T) {
 			medianFetcher, err := newMedianFetcherFromURLs(defaultHTTPTimeout, ethUSDPairing, urls, 32768)
 			require.NoError(t, err)
 
-			medianPrice, err := medianFetcher.Fetch(emptyMeta, context.Background())
+			medianPrice, err := medianFetcher.Fetch(context.Background(), emptyMeta)
 			require.NoError(t, err)
 			assert.Equal(t, test.expect, medianPrice.String())
 		})
@@ -102,7 +102,7 @@ func TestHTTPFetcher_Happy(t *testing.T) {
 	require.NoError(t, err)
 
 	fetcher := newHTTPFetcher(defaultHTTPTimeout, btcUSDPairing, feedURL, 32768)
-	price, err := fetcher.Fetch(emptyMeta, context.Background())
+	price, err := fetcher.Fetch(context.Background(), emptyMeta)
 	require.NoError(t, err)
 	assert.Equal(t, decimal.NewFromInt(9700), price)
 }
@@ -137,7 +137,7 @@ func TestHTTPFetcher_Meta(t *testing.T) {
 	require.NoError(t, err)
 
 	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
-	fetcher.Fetch(request, context.Background())
+	fetcher.Fetch(context.Background(), request)
 }
 
 func TestHTTPFetcher_ErrorMessage(t *testing.T) {
@@ -157,7 +157,7 @@ func TestHTTPFetcher_ErrorMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
-	price, err := fetcher.Fetch(emptyMeta, context.Background())
+	price, err := fetcher.Fetch(context.Background(), emptyMeta)
 	assert.Error(t, err)
 	assert.Equal(t, decimal.NewFromInt(0).String(), price.String())
 	assert.Contains(t, err.Error(), "could not hit data fetcher")
@@ -177,7 +177,7 @@ func TestHTTPFetcher_OnlyErrorMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
-	price, err := fetcher.Fetch(emptyMeta, context.Background())
+	price, err := fetcher.Fetch(context.Background(), emptyMeta)
 	assert.Error(t, err)
 	assert.Equal(t, decimal.NewFromInt(0).String(), price.String())
 	assert.Contains(t, err.Error(), "RequestId")
@@ -196,7 +196,7 @@ func TestHTTPFetcher_NoResultNorErrorMessage(t *testing.T) {
 	require.NoError(t, err)
 
 	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
-	price, err := fetcher.Fetch(emptyMeta, context.Background())
+	price, err := fetcher.Fetch(context.Background(), emptyMeta)
 	assert.Error(t, err)
 	assert.True(t, decimal.NewFromInt(0).Equal(price))
 }
@@ -235,7 +235,7 @@ func TestMedianFetcher_FetchError(t *testing.T) {
 	s2 := newErroringPricedFetcher()
 	medianFetcher, err := newMedianFetcher(s1, s2)
 	require.NoError(t, err)
-	price, err := medianFetcher.Fetch(emptyMeta, context.Background())
+	price, err := medianFetcher.Fetch(context.Background(), emptyMeta)
 	assert.Error(t, err)
 	assert.Equal(t, decimal.NewFromInt(0).String(), price.String())
 }
@@ -259,7 +259,7 @@ func TestMedianFetcher_MajorityFetches(t *testing.T) {
 			medianFetcher, err := newMedianFetcher(test.fetchers...)
 			require.NoError(t, err)
 
-			medianPrice, err := medianFetcher.Fetch(emptyMeta, context.Background())
+			medianPrice, err := medianFetcher.Fetch(context.Background(), emptyMeta)
 			assert.NoError(t, err)
 			assert.True(t, decimal.NewFromInt(100).Equal(medianPrice))
 		})
@@ -287,7 +287,7 @@ func TestMedianFetcher_MajorityFetchesCalculatesCorrectMedian(t *testing.T) {
 			medianFetcher, err := newMedianFetcher(test.fetchers...)
 			require.NoError(t, err)
 
-			medianPrice, err := medianFetcher.Fetch(emptyMeta, context.Background())
+			medianPrice, err := medianFetcher.Fetch(context.Background(), emptyMeta)
 			assert.NoError(t, err)
 			assert.Equal(t, medianPrice.String(), test.expectedMedian)
 		})
@@ -313,7 +313,7 @@ func TestMedianFetcher_MinorityErrors(t *testing.T) {
 			medianFetcher, err := newMedianFetcher(test.fetchers...)
 			require.NoError(t, err)
 
-			medianPrice, err := medianFetcher.Fetch(emptyMeta, context.Background())
+			medianPrice, err := medianFetcher.Fetch(context.Background(), emptyMeta)
 			assert.Error(t, err)
 			assert.True(t, decimal.NewFromInt(0).Equal(medianPrice))
 		})
@@ -340,5 +340,5 @@ func TestHTTPFetcher_AddsArbitraryRequestID(t *testing.T) {
 	require.NoError(t, err)
 
 	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
-	fetcher.Fetch(emptyMeta, context.Background())
+	fetcher.Fetch(context.Background(), emptyMeta)
 }

--- a/core/services/fluxmonitor/fetchers_test.go
+++ b/core/services/fluxmonitor/fetchers_test.go
@@ -75,10 +75,10 @@ func TestNewMedianFetcherFromURLs_Happy(t *testing.T) {
 				urls = append(urls, newURL)
 			}
 
-			medianFetcher, err := newMedianFetcherFromURLs(defaultHTTPTimeout, ethUSDPairing, urls, 32768, context.Background())
+			medianFetcher, err := newMedianFetcherFromURLs(defaultHTTPTimeout, ethUSDPairing, urls, 32768)
 			require.NoError(t, err)
 
-			medianPrice, err := medianFetcher.Fetch(emptyMeta)
+			medianPrice, err := medianFetcher.Fetch(emptyMeta, context.Background())
 			require.NoError(t, err)
 			assert.Equal(t, test.expect, medianPrice.String())
 		})
@@ -90,7 +90,7 @@ func TestNewMedianFetcherFromURLs_EmptyError(t *testing.T) {
 	defer s1.Close()
 	var urls []*url.URL
 
-	_, err := newMedianFetcherFromURLs(defaultHTTPTimeout, ethUSDPairing, urls, 32768, context.Background())
+	_, err := newMedianFetcherFromURLs(defaultHTTPTimeout, ethUSDPairing, urls, 32768)
 	require.Error(t, err)
 }
 
@@ -101,8 +101,8 @@ func TestHTTPFetcher_Happy(t *testing.T) {
 	feedURL, err := url.ParseRequestURI(s1.URL)
 	require.NoError(t, err)
 
-	fetcher := newHTTPFetcher(defaultHTTPTimeout, btcUSDPairing, feedURL, 32768, context.Background())
-	price, err := fetcher.Fetch(emptyMeta)
+	fetcher := newHTTPFetcher(defaultHTTPTimeout, btcUSDPairing, feedURL, 32768)
+	price, err := fetcher.Fetch(emptyMeta, context.Background())
 	require.NoError(t, err)
 	assert.Equal(t, decimal.NewFromInt(9700), price)
 }
@@ -136,8 +136,8 @@ func TestHTTPFetcher_Meta(t *testing.T) {
 	feedURL, err := url.ParseRequestURI(s1.URL)
 	require.NoError(t, err)
 
-	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768, context.Background())
-	fetcher.Fetch(request)
+	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
+	fetcher.Fetch(request, context.Background())
 }
 
 func TestHTTPFetcher_ErrorMessage(t *testing.T) {
@@ -156,8 +156,8 @@ func TestHTTPFetcher_ErrorMessage(t *testing.T) {
 	feedURL, err := url.ParseRequestURI(server.URL)
 	require.NoError(t, err)
 
-	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768, context.Background())
-	price, err := fetcher.Fetch(emptyMeta)
+	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
+	price, err := fetcher.Fetch(emptyMeta, context.Background())
 	assert.Error(t, err)
 	assert.Equal(t, decimal.NewFromInt(0).String(), price.String())
 	assert.Contains(t, err.Error(), "could not hit data fetcher")
@@ -176,8 +176,8 @@ func TestHTTPFetcher_OnlyErrorMessage(t *testing.T) {
 	feedURL, err := url.ParseRequestURI(server.URL)
 	require.NoError(t, err)
 
-	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768, context.Background())
-	price, err := fetcher.Fetch(emptyMeta)
+	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
+	price, err := fetcher.Fetch(emptyMeta, context.Background())
 	assert.Error(t, err)
 	assert.Equal(t, decimal.NewFromInt(0).String(), price.String())
 	assert.Contains(t, err.Error(), "RequestId")
@@ -195,8 +195,8 @@ func TestHTTPFetcher_NoResultNorErrorMessage(t *testing.T) {
 	feedURL, err := url.ParseRequestURI(server.URL)
 	require.NoError(t, err)
 
-	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768, context.Background())
-	price, err := fetcher.Fetch(emptyMeta)
+	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
+	price, err := fetcher.Fetch(emptyMeta, context.Background())
 	assert.Error(t, err)
 	assert.True(t, decimal.NewFromInt(0).Equal(price))
 }
@@ -235,7 +235,7 @@ func TestMedianFetcher_FetchError(t *testing.T) {
 	s2 := newErroringPricedFetcher()
 	medianFetcher, err := newMedianFetcher(s1, s2)
 	require.NoError(t, err)
-	price, err := medianFetcher.Fetch(emptyMeta)
+	price, err := medianFetcher.Fetch(emptyMeta, context.Background())
 	assert.Error(t, err)
 	assert.Equal(t, decimal.NewFromInt(0).String(), price.String())
 }
@@ -259,7 +259,7 @@ func TestMedianFetcher_MajorityFetches(t *testing.T) {
 			medianFetcher, err := newMedianFetcher(test.fetchers...)
 			require.NoError(t, err)
 
-			medianPrice, err := medianFetcher.Fetch(emptyMeta)
+			medianPrice, err := medianFetcher.Fetch(emptyMeta, context.Background())
 			assert.NoError(t, err)
 			assert.True(t, decimal.NewFromInt(100).Equal(medianPrice))
 		})
@@ -287,7 +287,7 @@ func TestMedianFetcher_MajorityFetchesCalculatesCorrectMedian(t *testing.T) {
 			medianFetcher, err := newMedianFetcher(test.fetchers...)
 			require.NoError(t, err)
 
-			medianPrice, err := medianFetcher.Fetch(emptyMeta)
+			medianPrice, err := medianFetcher.Fetch(emptyMeta, context.Background())
 			assert.NoError(t, err)
 			assert.Equal(t, medianPrice.String(), test.expectedMedian)
 		})
@@ -313,7 +313,7 @@ func TestMedianFetcher_MinorityErrors(t *testing.T) {
 			medianFetcher, err := newMedianFetcher(test.fetchers...)
 			require.NoError(t, err)
 
-			medianPrice, err := medianFetcher.Fetch(emptyMeta)
+			medianPrice, err := medianFetcher.Fetch(emptyMeta, context.Background())
 			assert.Error(t, err)
 			assert.True(t, decimal.NewFromInt(0).Equal(medianPrice))
 		})
@@ -339,6 +339,6 @@ func TestHTTPFetcher_AddsArbitraryRequestID(t *testing.T) {
 	feedURL, err := url.ParseRequestURI(s1.URL)
 	require.NoError(t, err)
 
-	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768, context.Background())
-	fetcher.Fetch(emptyMeta)
+	fetcher := newHTTPFetcher(defaultHTTPTimeout, ethUSDPairing, feedURL, 32768)
+	fetcher.Fetch(emptyMeta, context.Background())
 }

--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -164,9 +164,15 @@ func (fm *concreteFluxMonitor) serveInternalRequests() {
 				logger.Debugf("job '%s' is missing from the flux monitor", jobID.String())
 				continue
 			}
+			waiter := sync.WaitGroup()
+			waiter.Add(len(checkers))
 			for _, checker := range checkers {
-				checker.Stop()
+				go func() {
+					checker.Stop()
+					waiter.Done()
+				}()
 			}
+			waiter.Wait()
 			delete(jobMap, jobID)
 
 		case <-fm.chStop:

--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -885,7 +885,7 @@ func (p *PollingDeviationChecker) respondToNewRoundLog(log flux_aggregator_wrapp
 
 	ctx, cancel := utils.CombinedContext(p.chStop)
 	defer cancel()
-	polledAnswer, err := p.fetcher.Fetch(request, ctx)
+	polledAnswer, err := p.fetcher.Fetch(ctx, request)
 	if err != nil {
 		logger.Errorw(fmt.Sprintf("unable to fetch median price: %v", err), p.loggerFieldsForNewRound(log)...)
 		return
@@ -1012,7 +1012,7 @@ func (p *PollingDeviationChecker) pollIfEligible(thresholds DeviationThresholds)
 
 	ctx, cancel := utils.CombinedContext(p.chStop)
 	defer cancel()
-	polledAnswer, err := p.fetcher.Fetch(request, ctx)
+	polledAnswer, err := p.fetcher.Fetch(ctx, request)
 	if err != nil {
 		l.Errorw("can't fetch answer", "err", err)
 		p.store.UpsertErrorFor(p.JobID(), "Error polling")

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -238,7 +238,7 @@ func TestPollingDeviationChecker_PollIfEligible(t *testing.T) {
 			fluxAggregator.On("OracleRoundState", nilOpts, nodeAddr, uint32(0)).Return(roundState, nil).Maybe()
 
 			if test.expectedToPoll {
-				fetcher.On("Fetch", mock.Anything).Return(decimal.NewFromInt(answers.polledAnswer), nil)
+				fetcher.On("Fetch", mock.Anything, mock.Anything).Return(decimal.NewFromInt(answers.polledAnswer), nil)
 			}
 
 			if test.expectedToSubmit {
@@ -404,7 +404,7 @@ func TestPollingDeviationChecker_BuffersLogs(t *testing.T) {
 	fluxAggregator.On("Address").Return(initr.Address, nil)
 
 	fetcher := new(mocks.Fetcher)
-	fetcher.On("Fetch", mock.Anything).Return(decimal.NewFromInt(fetchedValue), nil)
+	fetcher.On("Fetch", mock.Anything, mock.Anything).Return(decimal.NewFromInt(fetchedValue), nil)
 
 	logBroadcaster := new(mocks.LogBroadcaster)
 	logBroadcaster.On("Register", initr.Address, mock.Anything).Return(true)
@@ -1050,7 +1050,7 @@ func TestPollingDeviationChecker_RespondToNewRound(t *testing.T) {
 			}
 
 			if expectedToPoll {
-				fetcher.On("Fetch", mock.Anything).Return(decimal.NewFromInt(test.polledAnswer), nil).Once()
+				fetcher.On("Fetch", mock.Anything, mock.Anything).Return(decimal.NewFromInt(test.polledAnswer), nil).Once()
 			}
 
 			if expectedToSubmit {
@@ -1585,7 +1585,7 @@ func TestPollingDeviationChecker_DoesNotDoubleSubmit(t *testing.T) {
 				OracleCount:      1,
 			}, nil).
 			Once()
-		fetcher.On("Fetch", mock.Anything).
+		fetcher.On("Fetch", mock.Anything, mock.Anything).
 			Return(decimal.NewFromInt(answer), nil).
 			Once()
 		rm.On("Create", job.ID, &initr, mock.Anything, mock.Anything).
@@ -1671,7 +1671,7 @@ func TestPollingDeviationChecker_DoesNotDoubleSubmit(t *testing.T) {
 			}, nil).
 			Once()
 		meta := utils.MustUnmarshalToMap(`{"AvailableFunds":100000, "EligibleToSubmit":true, "LatestSubmission":100, "OracleCount":1, "PaymentAmount":100, "RoundId":3, "StartedAt":0, "Timeout":0}`)
-		fetcher.On("Fetch", meta).
+		fetcher.On("Fetch", meta, mock.Anything).
 			Return(decimal.NewFromInt(answer), nil).
 			Once()
 		rm.On("Create", job.ID, &initr, mock.Anything, mock.Anything).

--- a/core/services/fluxmonitor/flux_monitor_test.go
+++ b/core/services/fluxmonitor/flux_monitor_test.go
@@ -1671,7 +1671,7 @@ func TestPollingDeviationChecker_DoesNotDoubleSubmit(t *testing.T) {
 			}, nil).
 			Once()
 		meta := utils.MustUnmarshalToMap(`{"AvailableFunds":100000, "EligibleToSubmit":true, "LatestSubmission":100, "OracleCount":1, "PaymentAmount":100, "RoundId":3, "StartedAt":0, "Timeout":0}`)
-		fetcher.On("Fetch", meta, mock.Anything).
+		fetcher.On("Fetch", mock.Anything, meta).
 			Return(decimal.NewFromInt(answer), nil).
 			Once()
 		rm.On("Create", job.ID, &initr, mock.Anything, mock.Anything).

--- a/core/services/fluxmonitor/helpers_test.go
+++ b/core/services/fluxmonitor/helpers_test.go
@@ -77,7 +77,7 @@ func newFixedPricedFetcher(price decimal.Decimal) *fixedFetcher {
 	return &fixedFetcher{price: price}
 }
 
-func (ps *fixedFetcher) Fetch(map[string]interface{}, context.Context) (decimal.Decimal, error) {
+func (ps *fixedFetcher) Fetch(context.Context, map[string]interface{}) (decimal.Decimal, error) {
 	return ps.price, nil
 }
 
@@ -87,7 +87,7 @@ func newErroringPricedFetcher() *erroringFetcher {
 	return &erroringFetcher{}
 }
 
-func (*erroringFetcher) Fetch(map[string]interface{}, context.Context) (decimal.Decimal, error) {
+func (*erroringFetcher) Fetch(context.Context, map[string]interface{}) (decimal.Decimal, error) {
 	return decimal.NewFromInt(0), errors.New("failed to fetch; I always error")
 }
 

--- a/core/services/fluxmonitor/helpers_test.go
+++ b/core/services/fluxmonitor/helpers_test.go
@@ -1,6 +1,7 @@
 package fluxmonitor
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io/ioutil"
@@ -76,7 +77,7 @@ func newFixedPricedFetcher(price decimal.Decimal) *fixedFetcher {
 	return &fixedFetcher{price: price}
 }
 
-func (ps *fixedFetcher) Fetch(map[string]interface{}) (decimal.Decimal, error) {
+func (ps *fixedFetcher) Fetch(map[string]interface{}, context.Context) (decimal.Decimal, error) {
 	return ps.price, nil
 }
 
@@ -86,7 +87,7 @@ func newErroringPricedFetcher() *erroringFetcher {
 	return &erroringFetcher{}
 }
 
-func (*erroringFetcher) Fetch(map[string]interface{}) (decimal.Decimal, error) {
+func (*erroringFetcher) Fetch(map[string]interface{}, context.Context) (decimal.Decimal, error) {
 	return decimal.NewFromInt(0), errors.New("failed to fetch; I always error")
 }
 

--- a/go.sum
+++ b/go.sum
@@ -1253,6 +1253,8 @@ github.com/tidwall/gjson v1.6.1 h1:LRbvNuNuvAiISWg6gxLEFuCe72UKy5hDqhxW/8183ws=
 github.com/tidwall/gjson v1.6.1/go.mod h1:BaHyNc5bjzYkPqgLq7mdVzeiRtULKULXLgZFKsxEHI0=
 github.com/tidwall/gjson v1.6.3 h1:aHoiiem0dr7GHkW001T1SMTJ7X5PvyekH5WX0whWGnI=
 github.com/tidwall/gjson v1.6.3/go.mod h1:BaHyNc5bjzYkPqgLq7mdVzeiRtULKULXLgZFKsxEHI0=
+github.com/tidwall/gjson v1.6.7 h1:Mb1M9HZCRWEcXQ8ieJo7auYyyiSux6w9XN3AdTpxJrE=
+github.com/tidwall/gjson v1.6.7/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
 github.com/tidwall/gjson v1.6.8 h1:CTmXMClGYPAmln7652e69B7OLXfTi5ABcPPwjIWUv7w=
 github.com/tidwall/gjson v1.6.8/go.mod h1:zeFuBCIqD4sN/gmqBzZ4j7Jd6UcA2Fc56x7QFsv+8fI=
 github.com/tidwall/match v1.0.1 h1:PnKP62LPNxHKTwvHHZZzdOAOCtsJTjo6dZLCwpKm5xc=
@@ -1266,6 +1268,8 @@ github.com/tidwall/pretty v1.0.2/go.mod h1:XNkn88O1ChpSDQmQeStsy+sBenx6DDtFZJxhV
 github.com/tidwall/sjson v1.1.1/go.mod h1:yvVuSnpEQv5cYIrO+AT6kw4QVfd5SDZoGIS7/5+fZFs=
 github.com/tidwall/sjson v1.1.2 h1:NC5okI+tQ8OG/oyzchvwXXxRxCV/FVdhODbPKkQ25jQ=
 github.com/tidwall/sjson v1.1.2/go.mod h1:SEzaDwxiPzKzNfUEO4HbYF/m4UCSJDsGgNqsS1LvdoY=
+github.com/tidwall/sjson v1.1.4 h1:bTSsPLdAYF5QNLSwYsKfBKKTnlGbIuhqL3CpRsjzGhg=
+github.com/tidwall/sjson v1.1.4/go.mod h1:wXpKXu8CtDjKAZ+3DrKY5ROCorDFahq8l0tey/Lx1fg=
 github.com/tidwall/sjson v1.1.5 h1:wsUceI/XDyZk3J1FUvuuYlK62zJv2HO2Pzb8A5EWdUE=
 github.com/tidwall/sjson v1.1.5/go.mod h1:VuJzsZnTowhSxWdOgsAnb886i4AjEyTkk7tNtsL7EYE=
 github.com/tjfoc/gmsm v1.0.1/go.mod h1:XxO4hdhhrzAd+G4CjDqaOkd0hUzmtPR/d3EiBBMn/wc=


### PR DESCRIPTION
* JobSubscriber now does Unsubscribe in parallel, timeUnsubscribe can take worst case 100ms * the number of subscribers, now worst case 100ms.
* Fetcher HTTP operations were not cancelled, could take worst case HTTP timeout (default 15s)
* Flux Monitor HTTP operations were not cancelled similar to above
* Flux Monitor does parallel shutdown of checkers