### PR TITLE
Chore/176757974 fix flaky tests

### DIFF
--- a/core/services/job/runner_integration_test.go
+++ b/core/services/job/runner_integration_test.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/smartcontractkit/chainlink/core/services/eth"
+	"github.com/stretchr/testify/mock"
+
 	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/telemetry"
 
@@ -49,6 +52,9 @@ func TestRunner(t *testing.T) {
 
 	key := cltest.MustInsertRandomKey(t, db, 0)
 	transmitterAddress := key.Address.Address()
+
+	rpc, geth, _, _ := cltest.NewEthMocks(t)
+	geth.On("HeaderByNumber", mock.Anything, mock.Anything).Return(&models.Head{Number: 10}, nil)
 
 	t.Run("gets the election result winner", func(t *testing.T) {
 		var httpURL string
@@ -345,7 +351,7 @@ ds1 -> ds1_parse;
 			config.Config,
 			keyStore,
 			nil,
-			nil,
+			eth.NewClientWith(rpc, geth),
 			nil,
 			nil,
 			monitoringEndpoint)
@@ -390,7 +396,7 @@ ds1 -> ds1_parse;
 			config.Config,
 			keyStore,
 			nil,
-			nil,
+			eth.NewClientWith(rpc, geth),
 			nil,
 			pw,
 			monitoringEndpoint,
@@ -452,7 +458,7 @@ ds1 -> ds1_parse;
 			config.Config,
 			keyStore,
 			nil,
-			nil,
+			eth.NewClientWith(rpc, geth),
 			nil,
 			pw,
 			monitoringEndpoint)
@@ -495,7 +501,7 @@ ds1 -> ds1_parse;
 			config.Config,
 			keyStore,
 			nil,
-			nil,
+			eth.NewClientWith(rpc, geth),
 			nil,
 			pw,
 			monitoringEndpoint)
@@ -532,7 +538,7 @@ ds1 -> ds1_parse;
 			config.Config,
 			keyStore,
 			nil,
-			nil,
+			eth.NewClientWith(rpc, geth),
 			nil,
 			pw,
 			monitoringEndpoint)
@@ -568,7 +574,7 @@ ds1 -> ds1_parse;
 			config.Config,
 			keyStore,
 			nil,
-			nil,
+			eth.NewClientWith(rpc, geth),
 			nil,
 			pw,
 			monitoringEndpoint)

--- a/core/services/job/runner_integration_test.go
+++ b/core/services/job/runner_integration_test.go
@@ -54,7 +54,12 @@ func TestRunner(t *testing.T) {
 	transmitterAddress := key.Address.Address()
 
 	rpc, geth, _, _ := cltest.NewEthMocks(t)
-	geth.On("HeaderByNumber", mock.Anything, mock.Anything).Return(&models.Head{Number: 10}, nil)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.Anything, false).
+		Run(func(args mock.Arguments) {
+			head := args.Get(1).(**models.Head)
+			*head = cltest.Head(10)
+		}).
+		Return(nil)
 
 	t.Run("gets the election result winner", func(t *testing.T) {
 		var httpURL string

--- a/core/services/job/spawner_test.go
+++ b/core/services/job/spawner_test.go
@@ -5,6 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/smartcontractkit/chainlink/core/services/eth"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+
 	"github.com/jinzhu/gorm"
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
@@ -59,6 +62,9 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 	key := cltest.MustInsertRandomKey(t, db)
 	address := key.Address.Address()
 
+	rpc, geth, _, _ := cltest.NewEthMocks(t)
+	geth.On("HeaderByNumber", mock.Anything, mock.Anything).Return(&models.Head{Number: 10}, nil)
+
 	t.Run("starts and stops job services when jobs are added and removed", func(t *testing.T) {
 		jobSpecA := makeOCRJobSpec(t, address)
 		jobSpecA.Type = jobTypeA
@@ -72,14 +78,14 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 		serviceA2 := new(mocks.Service)
 		serviceA1.On("Start").Return(nil).Once()
 		serviceA2.On("Start").Return(nil).Once().Run(func(mock.Arguments) { eventuallyA.ItHappened() })
-		delegateA := &delegate{jobTypeA, []job.Service{serviceA1, serviceA2}, 0, make(chan struct{}), offchainreporting.NewDelegate(nil, orm, nil, nil, nil, nil, nil, nil, monitoringEndpoint)}
+		delegateA := &delegate{jobTypeA, []job.Service{serviceA1, serviceA2}, 0, make(chan struct{}), offchainreporting.NewDelegate(nil, orm, nil, nil, nil, eth.NewClientWith(rpc, geth), nil, nil, monitoringEndpoint)}
 		eventuallyB := cltest.NewAwaiter()
 		serviceB1 := new(mocks.Service)
 		serviceB2 := new(mocks.Service)
 		serviceB1.On("Start").Return(nil).Once()
 		serviceB2.On("Start").Return(nil).Once().Run(func(mock.Arguments) { eventuallyB.ItHappened() })
 
-		delegateB := &delegate{jobTypeB, []job.Service{serviceB1, serviceB2}, 0, make(chan struct{}), offchainreporting.NewDelegate(nil, orm, nil, nil, nil, nil, nil, nil, monitoringEndpoint)}
+		delegateB := &delegate{jobTypeB, []job.Service{serviceB1, serviceB2}, 0, make(chan struct{}), offchainreporting.NewDelegate(nil, orm, nil, nil, nil, eth.NewClientWith(rpc, geth), nil, nil, monitoringEndpoint)}
 		spawner := job.NewSpawner(orm, config, map[job.Type]job.Delegate{
 			jobTypeA: delegateA,
 			jobTypeB: delegateB,
@@ -131,7 +137,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 
 		orm := job.NewORM(db, config.Config, pipeline.NewORM(db, config, eventBroadcaster), eventBroadcaster, &postgres.NullAdvisoryLocker{})
 		defer orm.Close()
-		delegateA := &delegate{jobTypeA, []job.Service{serviceA1, serviceA2}, 0, nil, offchainreporting.NewDelegate(nil, orm, nil, nil, nil, nil, nil, nil, monitoringEndpoint)}
+		delegateA := &delegate{jobTypeA, []job.Service{serviceA1, serviceA2}, 0, nil, offchainreporting.NewDelegate(nil, orm, nil, nil, nil, eth.NewClientWith(rpc, geth), nil, nil, monitoringEndpoint)}
 		spawner := job.NewSpawner(orm, config, map[job.Type]job.Delegate{
 			jobTypeA: delegateA,
 		})
@@ -162,7 +168,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 
 		orm := job.NewORM(db, config.Config, pipeline.NewORM(db, config, eventBroadcaster), eventBroadcaster, &postgres.NullAdvisoryLocker{})
 		defer orm.Close()
-		delegateA := &delegate{jobTypeA, []job.Service{serviceA1, serviceA2}, 0, nil, offchainreporting.NewDelegate(nil, orm, nil, nil, nil, nil, nil, nil, monitoringEndpoint)}
+		delegateA := &delegate{jobTypeA, []job.Service{serviceA1, serviceA2}, 0, nil, offchainreporting.NewDelegate(nil, orm, nil, nil, nil, eth.NewClientWith(rpc, geth), nil, nil, monitoringEndpoint)}
 		spawner := job.NewSpawner(orm, config, map[job.Type]job.Delegate{
 			jobTypeA: delegateA,
 		})
@@ -198,7 +204,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 
 		orm := job.NewORM(db, config.Config, pipeline.NewORM(db, config, eventBroadcaster), eventBroadcaster, &postgres.NullAdvisoryLocker{})
 		defer orm.Close()
-		delegateA := &delegate{jobTypeA, []job.Service{serviceA1, serviceA2}, 0, nil, offchainreporting.NewDelegate(nil, nil, nil, nil, nil, nil, nil, nil, monitoringEndpoint)}
+		delegateA := &delegate{jobTypeA, []job.Service{serviceA1, serviceA2}, 0, nil, offchainreporting.NewDelegate(nil, nil, nil, nil, nil, eth.NewClientWith(rpc, geth), nil, nil, monitoringEndpoint)}
 		spawner := job.NewSpawner(orm, config, map[job.Type]job.Delegate{
 			jobTypeA: delegateA,
 		})

--- a/core/services/job/spawner_test.go
+++ b/core/services/job/spawner_test.go
@@ -63,7 +63,12 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 	address := key.Address.Address()
 
 	rpc, geth, _, _ := cltest.NewEthMocks(t)
-	geth.On("HeaderByNumber", mock.Anything, mock.Anything).Return(&models.Head{Number: 10}, nil)
+	rpc.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.Anything, false).
+		Run(func(args mock.Arguments) {
+			head := args.Get(1).(**models.Head)
+			*head = cltest.Head(10)
+		}).
+		Return(nil)
 
 	t.Run("starts and stops job services when jobs are added and removed", func(t *testing.T) {
 		jobSpecA := makeOCRJobSpec(t, address)


### PR DESCRIPTION
The issue is that _sometimes_ the ocr code makes it far enough during a test to attempt to use the nil ethClient to read the highest block. This fix just mocks the eth client for tests using NewDelegate.