### PR TITLE
First v2 migration should be the last v1 migration

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -135,11 +135,10 @@ func CheckSquashUpgrade(db *gorm.DB) error {
 	squashVersionMinus1 := semver.New("0.9.10")
 	currentVersion := semver.New(static.Version)
 	lastV1Migration := "1612225637"
-	firstV2Migration := "1_initial"
 	if squashVersionMinus1.LessThan(*currentVersion) {
-		// Running code later than S - 1. Ensure that we either see
-		// the new migrations format "1_initial" OR we see the last migration
-		q := db.Exec("SELECT * FROM migrations WHERE id = ? OR id = ?", lastV1Migration, firstV2Migration)
+		// Running code later than S - 1. Ensure that we see
+		// the last v1 migration.
+		q := db.Exec("SELECT * FROM migrations WHERE id = ?", lastV1Migration)
 		if q.Error != nil {
 			return q.Error
 		}

--- a/core/services/chainlink/application_test.go
+++ b/core/services/chainlink/application_test.go
@@ -6,11 +6,6 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/smartcontractkit/chainlink/core/services/chainlink"
-	"github.com/smartcontractkit/chainlink/core/static"
-	"github.com/smartcontractkit/chainlink/core/store/migrations"
-	"github.com/smartcontractkit/chainlink/core/store/migrationsv2"
-
 	"github.com/smartcontractkit/chainlink/core/services/eth"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
@@ -20,30 +15,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tevino/abool"
 )
-
-func TestChainlinkApplication_SquashMigrationUpgrade(t *testing.T) {
-	_, orm, cleanup := cltest.BootstrapThrowawayORM(t, "migrationssquash", false)
-	defer cleanup()
-	db := orm.DB
-
-	// Latest migrations should work fine.
-	static.Version = "0.9.11"
-	err := migrationsv2.MigrateUp(db, "")
-	require.NoError(t, err)
-	err = chainlink.CheckSquashUpgrade(db)
-	require.NoError(t, err)
-	err = migrationsv2.MigrateDown(db)
-	require.NoError(t, err)
-
-	// Newer app version with older migrations should fail.
-	err = migrations.MigrateTo(db, "1611388693") // 1 before S-1
-	require.NoError(t, err)
-	err = chainlink.CheckSquashUpgrade(db)
-	t.Log(err)
-	require.Error(t, err)
-
-	static.Version = "unset"
-}
 
 func TestChainlinkApplication_SignalShutdown(t *testing.T) {
 

--- a/core/store/migrationsv2/1_initial.go
+++ b/core/store/migrationsv2/1_initial.go
@@ -3054,7 +3054,7 @@ DROP TYPE eth_tx_attempts_state, eth_txes_state, run_status CASCADE;
 
 func init() {
 	Migrations = append(Migrations, &gormigrate.Migration{
-		ID: "1_initial",
+		ID: "1612225637",
 		Migrate: func(db *gorm.DB) error {
 			return db.Exec(up1).Error
 		},

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -246,7 +246,7 @@ func initializeORM(config *orm.Config, shutdownSignal gracefulpanic.Signal) (*or
 	if err != nil {
 		return nil, errors.Wrap(err, "initializeORM#NewORM")
 	}
-	if err := CheckSquashUpgrade(orm.DB); err != nil {
+	if err = CheckSquashUpgrade(orm.DB); err != nil {
 		panic(err)
 	}
 	if config.MigrateDatabase() {

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -7,6 +7,9 @@ import (
 	"path/filepath"
 	"sync"
 
+	"github.com/coreos/go-semver/semver"
+	"github.com/smartcontractkit/chainlink/core/static"
+
 	"github.com/smartcontractkit/chainlink/core/store/migrationsv2"
 
 	"github.com/smartcontractkit/chainlink/core/gracefulpanic"
@@ -212,10 +215,39 @@ func (s *Store) ImportKey(keyJSON []byte, oldPassword string) error {
 	})
 }
 
+func CheckSquashUpgrade(db *gorm.DB) error {
+	// Ensure that we don't try to run a node version later than the
+	// squashed database versions without first migrating up to just before the squash.
+	// If we don't see the latest migration and node version >= S, error and recommend
+	// first running version S - 1 (S = version in which migrations are squashed).
+	if static.Version == "unset" {
+		return nil
+	}
+	squashVersionMinus1 := semver.New("0.9.10")
+	currentVersion := semver.New(static.Version)
+	lastV1Migration := "1612225637"
+	if squashVersionMinus1.LessThan(*currentVersion) {
+		// Running code later than S - 1. Ensure that we see
+		// the last v1 migration.
+		q := db.Exec("SELECT * FROM migrations WHERE id = ?", lastV1Migration)
+		if q.Error != nil {
+			return q.Error
+		}
+		if q.RowsAffected == 0 {
+			// Do not have the S-1 migration.
+			return errors.Errorf("Need to upgrade to chainlink version %v first before upgrading to version %v in order to run migrations", squashVersionMinus1, currentVersion)
+		}
+	}
+	return nil
+}
+
 func initializeORM(config *orm.Config, shutdownSignal gracefulpanic.Signal) (*orm.ORM, error) {
 	orm, err := orm.NewORM(config.DatabaseURL(), config.DatabaseTimeout(), shutdownSignal, config.GetDatabaseDialectConfiguredOrDefault(), config.GetAdvisoryLockIDConfiguredOrDefault(), config.GlobalLockRetryInterval().Duration(), config.ORMMaxOpenConns(), config.ORMMaxIdleConns())
 	if err != nil {
 		return nil, errors.Wrap(err, "initializeORM#NewORM")
+	}
+	if err := CheckSquashUpgrade(orm.DB); err != nil {
+		panic(err)
 	}
 	if config.MigrateDatabase() {
 		orm.SetLogging(config.LogSQLStatements() || config.LogSQLMigrations())

--- a/core/store/store_test.go
+++ b/core/store/store_test.go
@@ -9,6 +9,11 @@ import (
 	"testing"
 	"time"
 
+	"github.com/smartcontractkit/chainlink/core/static"
+	"github.com/smartcontractkit/chainlink/core/store"
+	"github.com/smartcontractkit/chainlink/core/store/migrations"
+	"github.com/smartcontractkit/chainlink/core/store/migrationsv2"
+
 	"github.com/smartcontractkit/chainlink/core/services/eth"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -20,6 +25,30 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
 )
+
+func TestStore_SquashMigrationUpgrade(t *testing.T) {
+	_, orm, cleanup := cltest.BootstrapThrowawayORM(t, "migrationssquash", false)
+	defer cleanup()
+	db := orm.DB
+
+	// Latest migrations should work fine.
+	static.Version = "0.9.11"
+	err := migrationsv2.MigrateUp(db, "")
+	require.NoError(t, err)
+	err = store.CheckSquashUpgrade(db)
+	require.NoError(t, err)
+	err = migrationsv2.MigrateDown(db)
+	require.NoError(t, err)
+
+	// Newer app version with older migrations should fail.
+	err = migrations.MigrateTo(db, "1611388693") // 1 before S-1
+	require.NoError(t, err)
+	err = store.CheckSquashUpgrade(db)
+	t.Log(err)
+	require.Error(t, err)
+
+	static.Version = "unset"
+}
 
 func TestStore_Start(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
If a user already has the last migration, we shouldn't run the first v2 migration. By naming the first v2 one the same as the last one, we avoid running it. Moving forward we can still use the new naming scheme though.