### PR TITLE
Log debug when stats pusher writes

### DIFF
--- a/core/services/synchronization/explorer_client.go
+++ b/core/services/synchronization/explorer_client.go
@@ -316,6 +316,7 @@ func (ec *explorerClient) writeMessage(message []byte, messageType int) error {
 	if _, err := writer.Write(message); err != nil {
 		return err
 	}
+	logger.Debugf("websocketStatsPusher successfully wrote message type %v", messageType)
 
 	return writer.Close()
 }

--- a/core/services/synchronization/explorer_client.go
+++ b/core/services/synchronization/explorer_client.go
@@ -316,7 +316,7 @@ func (ec *explorerClient) writeMessage(message []byte, messageType int) error {
 	if _, err := writer.Write(message); err != nil {
 		return err
 	}
-	logger.Debugf("websocketStatsPusher successfully wrote message type %v", messageType)
+	logger.Debugw("websocketStatsPusher successfully wrote message", "messageType", messageType, "message", message)
 
 	return writer.Close()
 }


### PR DESCRIPTION
Currently the client only logs information when there is an error writing the message