### PR TITLE
Switch to using Public ECR for pushing images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,4 +59,4 @@ commands:
             # Use temporary keys to get account ID
             accountID=$(aws sts get-caller-identity --output text --query 'Account')
             # docker cli login to ECR
-            aws ecr get-login-password --region "${AWS_REGION}" --profile "default" | docker login --username AWS --password-stdin "${accountID}.dkr.ecr.us-west-2.amazonaws.com/chainlink"
+            aws ecr-public get-login-password --region "us-east-1" --profile "default" | docker login --username AWS --password-stdin "public.ecr.aws"

--- a/tools/ci/push_chainlink
+++ b/tools/ci/push_chainlink
@@ -15,6 +15,9 @@ set -ex
 # to work with.
 #
 
+# Our registry, hosted on Public ECR.
+AWS_ECR_URL=public.ecr.aws/z0b1w9r9
+
 if [ -z "$DOCKERHUB_PASS" ]; then
   echo "Cannot push to dockerhub, credentials are missing."
   exit 1


### PR DESCRIPTION
This PR changes the CI workflow to publish Chainlink images to Public ECR. Still a draft and needs testing.