### PR TITLE
Update the Jobs API to support Flux Monitor V2 in the Operator UI

### DIFF
--- a/core/cmd/presenters.go
+++ b/core/cmd/presenters.go
@@ -80,7 +80,7 @@ type Job struct {
 
 // GetName implements the api2go EntityNamer interface
 func (j Job) GetName() string {
-	return "specDBs"
+	return "jobs"
 }
 
 // GetTasks extracts the tasks from the dependency graph

--- a/core/cmd/presenters_test.go
+++ b/core/cmd/presenters_test.go
@@ -32,7 +32,7 @@ func TestJob_GetName(t *testing.T) {
 
 	job := &cmd.Job{}
 
-	assert.Equal(t, "specDBs", job.GetName())
+	assert.Equal(t, "jobs", job.GetName())
 }
 
 func TestJob_GetTasks(t *testing.T) {

--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -156,11 +156,11 @@ type FluxMonitorSpec struct {
 	IDEmbed
 	ContractAddress models.EIP55Address `json:"contractAddress" toml:"contractAddress"`
 	Precision       int32               `json:"precision,omitempty" gorm:"type:smallint"`
-	Threshold       float32             `json:"threshold,omitempty"`
+	Threshold       float32             `json:"threshold,omitempty" toml:"threshold,float"`
 	// AbsoluteThreshold is the maximum absolute change allowed in a fluxmonitored
 	// value before a new round should be kicked off, so that the current value
 	// can be reported on-chain.
-	AbsoluteThreshold float32       `json:"absoluteThreshold" gorm:"type:float;not null"`
+	AbsoluteThreshold float32       `json:"absoluteThreshold" toml:"absoluteThreshold,float" gorm:"type:float;not null"`
 	PollTimerPeriod   time.Duration `json:"pollTimerPeriod,omitempty" gorm:"type:jsonb"`
 	PollTimerDisabled bool          `json:"pollTimerDisabled,omitempty" gorm:"type:jsonb"`
 	IdleTimerPeriod   time.Duration `json:"idleTimerPeriod,omitempty" gorm:"type:jsonb"`

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -274,6 +274,7 @@ func (o *orm) JobsV2() ([]SpecDB, error) {
 		Preload("PipelineSpec").
 		Preload("OffchainreportingOracleSpec").
 		Preload("DirectRequestSpec").
+		Preload("FluxMonitorSpec").
 		Preload("JobSpecErrors").
 		Find(&jobs).
 		Error
@@ -313,6 +314,7 @@ func (o *orm) FindJob(id int32) (SpecDB, error) {
 	err := o.db.
 		Preload("PipelineSpec").
 		Preload("OffchainreportingOracleSpec").
+		Preload("FluxMonitorSpec").
 		Preload("DirectRequestSpec").
 		Preload("JobSpecErrors").
 		First(&job, "jobs.id = ?", id).

--- a/core/web/jobs_controller.go
+++ b/core/web/jobs_controller.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/services/directrequest"
 	"github.com/smartcontractkit/chainlink/core/services/offchainreporting"
+	"github.com/smartcontractkit/chainlink/core/web/presenters"
 
 	"github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2"
 
@@ -33,7 +34,7 @@ func (jc *JobsController) Index(c *gin.Context) {
 		return
 	}
 
-	jsonAPIResponse(c, jobs, "jobs")
+	jsonAPIResponse(c, presenters.NewJobResources(jobs), "jobs")
 }
 
 // Show returns the details of a job
@@ -58,7 +59,7 @@ func (jc *JobsController) Show(c *gin.Context) {
 		return
 	}
 
-	jsonAPIResponse(c, jobSpec, "offChainReportingJobSpec")
+	jsonAPIResponse(c, presenters.NewJobResource(jobSpec), "jobs")
 }
 
 type GenericJobSpec struct {
@@ -120,7 +121,7 @@ func (jc *JobsController) Create(c *gin.Context) {
 		return
 	}
 
-	jsonAPIResponse(c, job, job.Type.String())
+	jsonAPIResponse(c, presenters.NewJobResource(job), job.Type.String())
 
 }
 

--- a/core/web/presenters/job.go
+++ b/core/web/presenters/job.go
@@ -1,0 +1,205 @@
+package presenters
+
+import (
+	"time"
+
+	"github.com/lib/pq"
+	"github.com/smartcontractkit/chainlink/core/services/job"
+	"github.com/smartcontractkit/chainlink/core/services/pipeline"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+)
+
+// JobSpecType defines the the the spec type of the job
+type JobSpecType string
+
+func (t JobSpecType) String() string {
+	return string(t)
+}
+
+const (
+	// DirectRequestJobSpec defines a Direct Request Job
+	DirectRequestJobSpec JobSpecType = "directrequest"
+	// FluxMonitorJobSpec defines a Flux Monitor Job
+	FluxMonitorJobSpec JobSpecType = "fluxmonitor"
+	// OffChainReportingJobSpec defines an OCR Job
+	OffChainReportingJobSpec JobSpecType = "offchainreporting"
+)
+
+// DirectRequestSpec defines the spec details of a DirectRequest Job
+type DirectRequestSpec struct {
+	ContractAddress  models.EIP55Address `json:"contractAddress"`
+	OnChainJobSpecID string              `json:"onChainJobSpecId"`
+	CreatedAt        time.Time           `json:"createdAt"`
+	UpdatedAt        time.Time           `json:"updatedAt"`
+}
+
+// NewDirectRequestSpec initializes a new DirectRequestSpec from a
+// job.DirectRequestSpec
+func NewDirectRequestSpec(spec *job.DirectRequestSpec) *DirectRequestSpec {
+	return &DirectRequestSpec{
+		ContractAddress:  spec.ContractAddress,
+		OnChainJobSpecID: spec.OnChainJobSpecID.String(),
+		CreatedAt:        spec.CreatedAt,
+		UpdatedAt:        spec.UpdatedAt,
+	}
+}
+
+// FluxMonitorSpec defines the spec details of a FluxMonitor Job
+type FluxMonitorSpec struct {
+	ContractAddress   models.EIP55Address `json:"contractAddress"`
+	Precision         int32               `json:"precision"`
+	Threshold         float32             `json:"threshold"`
+	AbsoluteThreshold float32             `json:"absoluteThreshold"`
+	PollTimerPeriod   string              `json:"pollTimerPeriod"`
+	PollTimerDisabled bool                `json:"pollTimerDisabled"`
+	IdleTimerPeriod   string              `json:"idleTimerPeriod"`
+	IdleTimerDisabled bool                `json:"idleTimerDisabled"`
+	CreatedAt         time.Time           `json:"createdAt"`
+	UpdatedAt         time.Time           `json:"updatedAt"`
+}
+
+// NewFluxMonitorSpec initializes a new DirectFluxMonitorSpec from a
+// job.FluxMonitorSpec
+func NewFluxMonitorSpec(spec *job.FluxMonitorSpec) *FluxMonitorSpec {
+	return &FluxMonitorSpec{
+		ContractAddress:   spec.ContractAddress,
+		Precision:         spec.Precision,
+		Threshold:         spec.Threshold,
+		AbsoluteThreshold: spec.AbsoluteThreshold,
+		PollTimerPeriod:   spec.PollTimerPeriod.String(),
+		PollTimerDisabled: spec.PollTimerDisabled,
+		IdleTimerPeriod:   spec.IdleTimerPeriod.String(),
+		IdleTimerDisabled: spec.IdleTimerDisabled,
+		CreatedAt:         spec.CreatedAt,
+		UpdatedAt:         spec.UpdatedAt,
+	}
+}
+
+// OffChainReportingSpec defines the spec details of a OffChainReporting Job
+type OffChainReportingSpec struct {
+	ContractAddress                        models.EIP55Address  `json:"contractAddress"`
+	P2PPeerID                              *models.PeerID       `json:"p2pPeerID"`
+	P2PBootstrapPeers                      pq.StringArray       `json:"p2pBootstrapPeers"`
+	IsBootstrapPeer                        bool                 `json:"isBootstrapPeer"`
+	EncryptedOCRKeyBundleID                *models.Sha256Hash   `json:"keyBundleID"`
+	TransmitterAddress                     *models.EIP55Address `json:"transmitterAddress"`
+	ObservationTimeout                     models.Interval      `json:"observationTimeout"`
+	BlockchainTimeout                      models.Interval      `json:"blockchainTimeout"`
+	ContractConfigTrackerSubscribeInterval models.Interval      `json:"contractConfigTrackerSubscribeInterval"`
+	ContractConfigTrackerPollInterval      models.Interval      `json:"contractConfigTrackerPollInterval"`
+	ContractConfigConfirmations            uint16               `json:"contractConfigConfirmations"`
+	CreatedAt                              time.Time            `json:"createdAt"`
+	UpdatedAt                              time.Time            `json:"updatedAt"`
+}
+
+// NewOffChainReportingSpec initializes a new OffChainReportingSpec from a
+// job.OffchainReportingOracleSpec
+func NewOffChainReportingSpec(spec *job.OffchainReportingOracleSpec) *OffChainReportingSpec {
+	return &OffChainReportingSpec{
+		ContractAddress:                        spec.ContractAddress,
+		P2PPeerID:                              spec.P2PPeerID,
+		P2PBootstrapPeers:                      spec.P2PBootstrapPeers,
+		IsBootstrapPeer:                        spec.IsBootstrapPeer,
+		EncryptedOCRKeyBundleID:                spec.EncryptedOCRKeyBundleID,
+		TransmitterAddress:                     spec.TransmitterAddress,
+		ObservationTimeout:                     spec.ObservationTimeout,
+		BlockchainTimeout:                      spec.BlockchainTimeout,
+		ContractConfigTrackerSubscribeInterval: spec.ContractConfigTrackerSubscribeInterval,
+		ContractConfigTrackerPollInterval:      spec.ContractConfigTrackerPollInterval,
+		ContractConfigConfirmations:            spec.ContractConfigConfirmations,
+		CreatedAt:                              spec.CreatedAt,
+		UpdatedAt:                              spec.UpdatedAt,
+	}
+}
+
+// PipelineSpec defines the spec details of the pipeline
+type PipelineSpec struct {
+	ID           int32  `json:"id"`
+	DotDAGSource string `json:"dotDagSource"`
+}
+
+// NewPipelineSpec generates a new PipelineSpec from a pipeline.Spec
+func NewPipelineSpec(spec *pipeline.Spec) PipelineSpec {
+	return PipelineSpec{
+		ID:           spec.ID,
+		DotDAGSource: spec.DotDagSource,
+	}
+}
+
+// JobError represents errors on the job
+type JobError struct {
+	ID          int64     `json:"id"`
+	Description string    `json:"description"`
+	Occurrences uint      `json:"occurrences"`
+	CreatedAt   time.Time `json:"createdAt"`
+	UpdatedAt   time.Time `json:"updatedAt"`
+}
+
+func NewJobError(e job.SpecError) JobError {
+	return JobError{
+		ID:          e.ID,
+		Description: e.Description,
+		Occurrences: e.Occurrences,
+		CreatedAt:   e.CreatedAt,
+		UpdatedAt:   e.UpdatedAt,
+	}
+}
+
+// JobResource represents a JobResource
+type JobResource struct {
+	JAID
+	Name                  string                 `json:"name"`
+	Type                  JobSpecType            `json:"type"`
+	SchemaVersion         uint32                 `json:"schemaVersion"`
+	MaxTaskDuration       models.Interval        `json:"maxTaskDuration"`
+	DirectRequestSpec     *DirectRequestSpec     `json:"directRequestSpec"`
+	FluxMonitorSpec       *FluxMonitorSpec       `json:"fluxMonitorSpec"`
+	OffChainReportingSpec *OffChainReportingSpec `json:"offChainReportingOracleSpec"`
+	PipelineSpec          PipelineSpec           `json:"pipelineSpec"`
+	Errors                []JobError             `json:"errors"`
+}
+
+// NewJobResource initializes a new JSONAPI job resource
+func NewJobResource(j job.SpecDB) *JobResource {
+	resource := &JobResource{
+		JAID:            NewJAIDInt32(j.ID),
+		Name:            j.Name.ValueOrZero(),
+		Type:            JobSpecType(j.Type),
+		SchemaVersion:   j.SchemaVersion,
+		MaxTaskDuration: j.MaxTaskDuration,
+		PipelineSpec:    NewPipelineSpec(j.PipelineSpec),
+	}
+
+	switch j.Type {
+	case job.DirectRequest:
+		resource.DirectRequestSpec = NewDirectRequestSpec(j.DirectRequestSpec)
+	case job.FluxMonitor:
+		resource.FluxMonitorSpec = NewFluxMonitorSpec(j.FluxMonitorSpec)
+	case job.OffchainReporting:
+		resource.OffChainReportingSpec = NewOffChainReportingSpec(j.OffchainreportingOracleSpec)
+	}
+
+	jes := []JobError{}
+	for _, e := range j.JobSpecErrors {
+		jes = append(jes, NewJobError((e)))
+	}
+	resource.Errors = jes
+
+	return resource
+}
+
+// NewJobResources initializes a slice of JSONAPI job resources
+func NewJobResources(js []job.SpecDB) []JobResource {
+	rs := []JobResource{}
+
+	for _, j := range js {
+		rs = append(rs, *NewJobResource(j))
+	}
+
+	return rs
+}
+
+// GetName implements the api2go EntityNamer interface
+func (r JobResource) GetName() string {
+	return "jobs"
+}

--- a/core/web/presenters/jsonapi.go
+++ b/core/web/presenters/jsonapi.go
@@ -1,0 +1,28 @@
+package presenters
+
+import (
+	"strconv"
+)
+
+// JAID represents a JSON API ID.
+// It implements the api2go MarshalIdentifier and UnmarshalIdentitier interface.
+type JAID struct {
+	ID string `json:"-"`
+}
+
+// NewJAIDInt32 converts an int32 into a JAID
+func NewJAIDInt32(id int32) JAID {
+	return JAID{strconv.Itoa(int(id))}
+}
+
+// GetID implements the api2go MarshalIdentifier interface.
+func (jaid JAID) GetID() string {
+	return jaid.ID
+}
+
+// SetID implements the api2go UnmarshalIdentitier interface.
+func (jaid *JAID) SetID(value string) error {
+	jaid.ID = value
+
+	return nil
+}


### PR DESCRIPTION
* Preload the Flux Monitor Spec when listing v2 jobs
* Preload the Flux Monitor Spec when showing v2 jobs
* Implement a Job presenter to represent the JSONAPI resource
* Update thejobs controller to use the presenter