### PR TITLE
Add the minPayment field to the V2 FluxMonitor spec

### DIFF
--- a/core/services/fluxmonitorv2/validate_test.go
+++ b/core/services/fluxmonitorv2/validate_test.go
@@ -35,6 +35,8 @@ idleTimerDisabled = false
 pollTimerPeriod = "1m"
 pollTimerDisabled = false
 
+minPayment = 1000000000000000000
+
 observationSource = """
 // data source 1
 ds1 [type=http method=GET url="https://pricesource1.com" requestData="{\\"coin\\": \\"ETH\\", \\"market\\": \\"USD\\"}"];

--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -9,6 +9,7 @@ import (
 
 	"gorm.io/gorm"
 
+	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -165,6 +166,7 @@ type FluxMonitorSpec struct {
 	PollTimerDisabled bool          `json:"pollTimerDisabled,omitempty" gorm:"type:jsonb"`
 	IdleTimerPeriod   time.Duration `json:"idleTimerPeriod,omitempty" gorm:"type:jsonb"`
 	IdleTimerDisabled bool          `json:"idleTimerDisabled,omitempty" gorm:"type:jsonb"`
+	MinPayment        *assets.Link  `json:"minPayment,omitempty" gorm:"type:varchar(255)"`
 	CreatedAt         time.Time     `json:"createdAt" toml:"-"`
 	UpdatedAt         time.Time     `json:"updatedAt" toml:"-"`
 }

--- a/core/store/migrationsv2/0009_add_min_payment_to_flux_monitor_spec.go
+++ b/core/store/migrationsv2/0009_add_min_payment_to_flux_monitor_spec.go
@@ -1,0 +1,29 @@
+package migrationsv2
+
+import (
+	"github.com/go-gormigrate/gormigrate/v2"
+	"gorm.io/gorm"
+)
+
+const (
+	up9 = `
+ALTER TABLE flux_monitor_specs
+ADD min_payment varchar(255);
+`
+	down9 = `
+ALTER TABLE flux_monitor_specs
+DROP COLUMN min_payment;
+`
+)
+
+func init() {
+	Migrations = append(Migrations, &gormigrate.Migration{
+		ID: "0009_add_min_payment_to_flux_monitor_spec",
+		Migrate: func(db *gorm.DB) error {
+			return db.Exec(up9).Error
+		},
+		Rollback: func(db *gorm.DB) error {
+			return db.Exec(down9).Error
+		},
+	})
+}


### PR DESCRIPTION
This field is present in the V1 JobSpec, so we should continue to support it. 

While the field is in the V1 JobSpec struct, I have changed it to be on the FluxMonitorSpec for v2. Since the OCR doesn't support `minPayment`, it shouldn't be on the V2 Job
