### PR TITLE
Add Subscribe() method to head tracker

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -942,10 +942,6 @@ func TestIntegration_FluxMonitor_NewRound(t *testing.T) {
 	err := app.StartAndConnect()
 	require.NoError(t, err)
 
-	gethClient.AssertExpectations(t)
-	rpcClient.AssertExpectations(t)
-	sub.AssertExpectations(t)
-
 	cltest.MockFluxAggCall(gethClient, cltest.FluxAggAddress, "minSubmissionValue").
 		Return(cltest.MustGenericEncode([]string{"uint256"}, big.NewInt(0)), nil).Once()
 	cltest.MockFluxAggCall(gethClient, cltest.FluxAggAddress, "maxSubmissionValue").


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177146392

This PR has two objectives:
* add a `Subscribe()` function to the Head Tracker
* refactor the `NewApplication()` constructor so that the head tracker is available to delegates