### PR TITLE
Add ETH_MAX_UNCONFIRMED_TRANSACTIONS limit

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -34,3 +34,5 @@ evm-contracts/truffle/**/*
 
 # solc_bin
 solc_bin
+
+docs/

--- a/core/adapters/eth_tx.go
+++ b/core/adapters/eth_tx.go
@@ -1,6 +1,7 @@
 package adapters
 
 import (
+	"context"
 	"encoding/json"
 	"math/big"
 	"reflect"
@@ -150,6 +151,12 @@ func (e *EthTx) insertEthTx(input models.RunInput, store *strpkg.Store) models.R
 		gasLimit = store.Config.EthGasLimitDefault()
 	} else {
 		gasLimit = e.GasLimit
+	}
+
+	if err := utils.CheckOKToTransmit(context.Background(), store.MustSQLDB(), fromAddress, store.Config.EthMaxUnconfirmedTransactions()); err != nil {
+		err = errors.Wrap(err, "number of unconfirmed transactions exceeds ETH_MAX_UNCONFIRMED_TRANSACTIONS")
+		logger.Error(err)
+		return models.NewRunOutputError(err)
 	}
 
 	if err := store.IdempotentInsertEthTaskRunTx(taskRunID, fromAddress, toAddress, encodedPayload, gasLimit); err != nil {

--- a/core/services/offchainreporting/delegate.go
+++ b/core/services/offchainreporting/delegate.go
@@ -169,7 +169,7 @@ func (d Delegate) ServicesForSpec(jobSpec job.SpecDB) (services []job.Service, e
 			return nil, err
 		}
 		contractTransmitter := NewOCRContractTransmitter(concreteSpec.ContractAddress.Address(), contractCaller, contractABI,
-			NewTransmitter(db, ta.Address(), d.config.EthGasLimitDefault()))
+			NewTransmitter(db, ta.Address(), d.config.EthGasLimitDefault(), d.config.EthMaxUnconfirmedTransactions()))
 
 		oracle, err := ocr.NewOracle(ocr.OracleArgs{
 			Database: NewDB(db, concreteSpec.ID),

--- a/core/services/offchainreporting/transmitter_test.go
+++ b/core/services/offchainreporting/transmitter_test.go
@@ -25,7 +25,7 @@ func Test_Transmitter_CreateEthTransaction(t *testing.T) {
 	toAddress := cltest.NewAddress()
 	payload := []byte{1, 2, 3}
 
-	transmitter := offchainreporting.NewTransmitter(db, fromAddress, gasLimit)
+	transmitter := offchainreporting.NewTransmitter(db, fromAddress, gasLimit, 0)
 
 	require.NoError(t, transmitter.CreateEthTransaction(context.Background(), toAddress, payload))
 
@@ -51,7 +51,7 @@ func Test_Transmitter_CreateEthTransaction_OutOfEth(t *testing.T) {
 	gasLimit := uint64(1000)
 	toAddress := cltest.NewAddress()
 
-	transmitter := offchainreporting.NewTransmitter(db, thisKey.Address.Address(), gasLimit)
+	transmitter := offchainreporting.NewTransmitter(db, thisKey.Address.Address(), gasLimit, 0)
 
 	t.Run("if another key has any transactions with insufficient eth errors, transmits as normal", func(t *testing.T) {
 		payload := cltest.MustRandomBytes(t, 100)

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -371,6 +371,14 @@ func (c Config) EthMaxGasPriceWei() *big.Int {
 	return c.getWithFallback("EthMaxGasPriceWei", parseBigInt).(*big.Int)
 }
 
+// EthMaxUnconfirmedTransactions is the maximum number of unconfirmed
+// transactions per key that are allowed to be in flight before jobs will start
+// failing and rejecting send of any further transactions.
+// 0 value disables
+func (c Config) EthMaxUnconfirmedTransactions() uint64 {
+	return c.getWithFallback("EthMaxUnconfirmedTransactions", parseUint64).(uint64)
+}
+
 // EthGasLimitDefault sets the default gas limit for outgoing transactions.
 func (c Config) EthGasLimitDefault() uint64 {
 	return c.getWithFallback("EthGasLimitDefault", parseUint64).(uint64)

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -46,6 +46,7 @@ type ConfigSchema struct {
 	EthGasLimitDefault                        uint64          `env:"ETH_GAS_LIMIT_DEFAULT" default:"500000"`
 	EthGasPriceDefault                        big.Int         `env:"ETH_GAS_PRICE_DEFAULT" default:"20000000000"`
 	EthMaxGasPriceWei                         uint64          `env:"ETH_MAX_GAS_PRICE_WEI" default:"1500000000000"`
+	EthMaxUnconfirmedTransactions             uint64          `env:"ETH_MAX_UNCONFIRMED_TRANSACTIONS" default:"500"`
 	EthFinalityDepth                          uint            `env:"ETH_FINALITY_DEPTH" default:"50"`
 	EthHeadTrackerHistoryDepth                uint            `env:"ETH_HEAD_TRACKER_HISTORY_DEPTH" default:"100"`
 	EthHeadTrackerMaxBufferSize               uint            `env:"ETH_HEAD_TRACKER_MAX_BUFFER_SIZE" default:"3"`

--- a/core/utils/queries.go
+++ b/core/utils/queries.go
@@ -1,0 +1,44 @@
+package utils
+
+import (
+	"context"
+	"database/sql"
+
+	gethCommon "github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+)
+
+// CheckOKToTransmit returns an error if the transaction is not OK to transmit
+// based on existing eth_txes in the database.
+//
+// NOTE: This is in the utils package to avoid import cycles, since it is used
+// in both offchainreporting and adapters. Tests can be found in
+// bulletprooftxmanager_test.go
+func CheckOKToTransmit(ctx context.Context, db *sql.DB, fromAddress gethCommon.Address, maxUnconfirmedTransactions uint64) (err error) {
+	if maxUnconfirmedTransactions == 0 {
+		return nil
+	}
+	var rows *sql.Rows
+	rows, err = db.QueryContext(ctx, `SELECT count(*) FROM eth_txes WHERE from_address = $1 AND state = 'unconfirmed'`, fromAddress)
+	if err != nil {
+		err = errors.Wrap(err, "bulletprooftxmanager.CheckOKToTransmit query failed")
+		return
+	}
+	defer func() {
+		err = multierr.Combine(err, rows.Close())
+	}()
+	var count uint64
+	for rows.Next() {
+		err = rows.Scan(&count)
+		if err != nil {
+			err = errors.Wrap(err, "bulletprooftxmanager.CheckOKToTransmit scan failed")
+			return
+		}
+	}
+
+	if count > maxUnconfirmedTransactions {
+		err = errors.Errorf("cannot transmit eth transaction; there are currently %v unconfirmed transactions in the queue which exceeds the configured maximum of %v", count, maxUnconfirmedTransactions)
+	}
+	return
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -10,17 +10,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Better debug logging in Gas Updater
+- `ETH_MAX_UNCONFIRMED_TRANSACTIONS`
+
+Chainlink node now has a maximum number of unconfirmed transactions that
+may be in flight at any one time (per key).
+
+If this limit is reached, further attempts t send transactions will fail
+and the relevant job will be marked as failed.
+
+Jobs will continue to fail until at least one transaction is confirmed
+and the queue size is reduced. This is introduced as a sanity limit to
+prevent unbounded sending of transactions e.g. in the case that the eth
+node is failing to broadcast to the network.
+
+The default is set to 500 which considered high enough that it should
+never be reached under normal operation. This limit can be configured
+using the `ETH_MAX_UNCONFIRMED_TRANSACTIONS` environment variable.
 
 ### Fixed
 
 - Improved handling of the case where we exceed the configured TX fee cap in
-  geth. Node will now fatally error jobs if the total transaction costs exceeds
-  the configured cap (default 1 Eth). Also, it will no longer continue
-  to bump gas on transactions that started hitting this limit and instead
-  continue to resubmit at the highest price that worked. Node operators should
-  check their geth nodes and remove this cap if configured, you can do this by
-  running your geth node with `--rpc.gascap=0 --rpc.txfeecap=0` or setting
-  these values in your config toml.
+  geth.
+
+Node will now fatally error jobs if the total transaction costs exceeds the
+configured cap (default 1 Eth). Also, it will no longer continue to bump gas on
+transactions that started hitting this limit and instead continue to resubmit
+at the highest price that worked.
+
+Node operators should check their geth nodes and remove this cap if configured,
+you can do this by running your geth node with `--rpc.gascap=0
+--rpc.txfeecap=0` or setting these values in your config toml.
 
 ## [0.10.1] - 2021-02-23
 

--- a/go.sum
+++ b/go.sum
@@ -758,6 +758,7 @@ github.com/libp2p/go-libp2p-core v0.6.1/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJB
 github.com/libp2p/go-libp2p-core v0.7.0/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJBt/G1rVvhz5XT8=
 github.com/libp2p/go-libp2p-core v0.8.0 h1:5K3mT+64qDTKbV3yTdbMCzJ7O6wbNsavAEb8iqBvBcI=
 github.com/libp2p/go-libp2p-core v0.8.0/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJBt/G1rVvhz5XT8=
+github.com/libp2p/go-libp2p-core v0.8.5 h1:aEgbIcPGsKy6zYcC+5AJivYFedhYa4sW7mIpWpUaLKw=
 github.com/libp2p/go-libp2p-core v0.8.5/go.mod h1:FfewUH/YpvWbEB+ZY9AQRQ4TAD8sJBt/G1rVvhz5XT8=
 github.com/libp2p/go-libp2p-crypto v0.1.0/go.mod h1:sPUokVISZiy+nNuTTH/TY+leRSxnFj/2GLjtOTW90hI=
 github.com/libp2p/go-libp2p-discovery v0.2.0/go.mod h1:s4VGaxYMbw4+4+tsoQTqh7wfxg97AEdo4GYBt6BadWg=
@@ -1119,6 +1120,7 @@ github.com/onsi/gomega v1.10.3 h1:gph6h/qe9GSUw1NhH1gp+qb+h8rXD8Cy60Z32Qw3ELA=
 github.com/onsi/gomega v1.10.3/go.mod h1:V9xEwhxec5O8UDM77eCW8vLymOMltsqPVYWrpDsH8xc=
 github.com/onsi/gomega v1.10.4 h1:NiTx7EEvBzu9sFOD1zORteLSt3o8gnlvZZwSE9TnY9U=
 github.com/onsi/gomega v1.10.4/go.mod h1:g/HbgYopi++010VEqkFgJHKC09uJiW9UkXvMUuKHUCQ=
+github.com/onsi/gomega v1.10.5 h1:7n6FEkpFmfCoo2t+YYqXH0evK+a9ICQz0xcAy9dYcaQ=
 github.com/onsi/gomega v1.10.5/go.mod h1:gza4q3jKQJijlu05nKWRCW/GavJumGt8aNRxWg7mt48=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
 github.com/openconfig/gnmi v0.0.0-20190823184014-89b2bf29312c/go.mod h1:t+O9It+LKzfOAhKTT5O0ehDix+MTqbtT0T9t+7zzOvc=


### PR DESCRIPTION
Chainlink node now has a maximum number of unconfirmed transactions that
may be in flight at any one time (per key).

If this limit is reached, further attempts t send transactions will fail
and the relevant job will be marked as failed.

Jobs will continue to fail until at least one transaction is confirmed
and the queue size is reduced. This is introduced as a sanity limit to
prevent unbounded sending of transactions e.g. in the case that the eth
node is failing to broadcast to the network.

The default is set to 500 which considered high enough that it should
never be reached under normal operation. This limit can be configured
using the `ETH_MAX_UNCONFIRMED_TRANSACTIONS` environment variable.