### PR TITLE
Alias tools/bin/abigen to phony target abigen

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -68,6 +68,8 @@ contracts-operator-ui-build: # only compiles tsc and builds contracts and operat
 	yarn setup:chainlink
 	CHAINLINK_VERSION="$(VERSION)@$(COMMIT_SHA)" yarn workspace @chainlink/operator-ui build
 
+.PHONY: abigen
+abigen: tools/bin/abigen
 tools/bin/abigen:
 	./tools/bin/build_abigen
 


### PR DESCRIPTION
If you run `go generate ./core/internal/gethwrappers` and you don't have `abigen` installed, it'll say: 

    no native abigen; you must install it (`make abigen` in the chainlink root dir): fork/exec ...

But `make abigen` will fail as there is no target. So... create that alias (dummy target).