### PR TITLE
Add prometheus counter for eth connect errors

### DIFF
--- a/core/services/head_tracker.go
+++ b/core/services/head_tracker.go
@@ -46,7 +46,10 @@ var (
 		Name: "head_tracker_num_heads_dropped",
 		Help: "The total number of heads dropped",
 	})
-
+	promEthConnectionErrors = promauto.NewCounter(prometheus.CounterOpts{
+		Name: "head_tracker_eth_connection_errors",
+		Help: "The total number of eth node connection errors",
+	})
 	// kovanChainID is the Chain ID for Kovan test network
 	kovanChainID = big.NewInt(42)
 )
@@ -399,6 +402,7 @@ func (ht *HeadTracker) subscribe() bool {
 		case <-time.After(ht.sleeper.After()):
 			err := ht.subscribeToHead()
 			if err != nil {
+				promEthConnectionErrors.Inc()
 				ht.logger.Warnw(fmt.Sprintf("HeadTracker: Failed to connect to ethereum node %v", ht.store.Config.EthereumURL()), "err", err)
 			} else {
 				ht.logger.Info("HeadTracker: Connected to ethereum node ", ht.store.Config.EthereumURL())

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -37,6 +37,13 @@ by setting the `ETH_MAX_UNCONFIRMED_TRANSACTIONS` environment variable.
 requestNewRound enables dedicated requesters to request a fresh report to
 be sent to the contract right away regardless of heartbeat or deviation.
 
+- New prometheus metric:
+
+```
+Name: "head_tracker_eth_connection_errors",
+Help: "The total number of eth node connection errors",
+```
+
 ### Fixed
 
 - Improved handling of the case where we exceed the configured TX fee cap in


### PR DESCRIPTION
Adds a prometheus counter that can be used for alerting on eth node connection errors