### PR TITLE
Avoid logging naked errors, or logging only .Error()

### DIFF
--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -106,8 +106,9 @@ func (fm *concreteFluxMonitor) Start() error {
 	var wg sync.WaitGroup
 	err := fm.store.Jobs(func(j *models.JobSpec) bool {
 		if j == nil {
+			// FIXME: This seems like an invariant violation?
 			err := errors.New("received nil job")
-			logger.Error(err)
+			logger.Errorw("Unexpected nil job when fetching jobs", "error", err)
 			return true
 		}
 		job := *j

--- a/core/services/head_tracker.go
+++ b/core/services/head_tracker.go
@@ -269,7 +269,7 @@ func (ht *HeadTracker) listenForNewHeads() {
 			return
 		}
 		if err := ht.receiveHeaders(); err != nil {
-			ht.logger.Errorw(fmt.Sprintf("Error in new head subscription, unsubscribed: %s", err.Error()), "err", err)
+			ht.logger.Errorw("Error while receiving headers", "error", err)
 			continue
 		} else {
 			return

--- a/core/services/scheduler.go
+++ b/core/services/scheduler.go
@@ -136,11 +136,11 @@ func (r *Recurring) AddJob(job models.JobSpec) {
 
 			_, err := r.runManager.Create(job.ID, &initr, nil, &models.RunRequest{})
 			if err != nil && !ExpectedRecurringScheduleJobError(err) {
-				logger.Errorw(err.Error())
+				logger.Errorw("Error while scheduling run", "error", err)
 			}
 		})
 		if err != nil {
-			logger.Error(err)
+			logger.Errorw("Error adding cron schedule", "error", err)
 		}
 	}
 }
@@ -189,12 +189,12 @@ func (ot *OneTime) RunJobAt(initiator models.Initiator, job models.JobSpec) {
 
 		_, err := ot.RunManager.Create(job.ID, &initiator, nil, &models.RunRequest{})
 		if err != nil && !ExpectedRecurringScheduleJobError(err) {
-			logger.Error(err.Error())
+			logger.Errorw("Error while scheduling run", "error", err)
 			return
 		}
 
 		if err := ot.Store.MarkRan(initiator, true); err != nil {
-			logger.Error(err.Error())
+			logger.Errorw("Error while marking run as finished", "error", err)
 		}
 	}
 }

--- a/core/services/subscription.go
+++ b/core/services/subscription.go
@@ -165,24 +165,24 @@ func runJob(runManager RunManager, le models.LogRequest) {
 
 	if err := le.ValidateRequester(); err != nil {
 		if _, e := runManager.CreateErrored(jobSpecID, initiator, err); e != nil {
-			logger.Errorw(e.Error())
+			logger.Errorw("CreateErrored failure", "error", e)
 		}
-		logger.Errorw(err.Error(), le.ForLogger()...)
+		logger.Errorw("LogRequest failed validation", le.ForLogger("error", err)...)
 		return
 	}
 
 	rr, err := le.RunRequest()
 	if err != nil {
 		if _, e := runManager.CreateErrored(jobSpecID, initiator, err); e != nil {
-			logger.Errorw(e.Error())
+			logger.Errorw("CreateErrored failure", le.ForLogger("error", e)...)
 		}
-		logger.Errorw(err.Error(), le.ForLogger()...)
+		logger.Errorw("Error decoding LogRequest as RunRequest", le.ForLogger("error", err)...)
 		return
 	}
 
 	_, err = runManager.Create(jobSpecID, &initiator, le.BlockNumber(), &rr)
 	if err != nil {
-		logger.Errorw(err.Error(), le.ForLogger()...)
+		logger.Errorw("Failed to schedule job from LogReuest", le.ForLogger("error", err)...)
 	}
 }
 

--- a/core/store/models/log_events.go
+++ b/core/store/models/log_events.go
@@ -323,7 +323,7 @@ func (le RunLogEvent) Requester() (common.Address, error) {
 func (le RunLogEvent) RunRequest() (RunRequest, error) {
 	requestParams, err := le.JSON()
 	if err != nil {
-		logger.Errorw(err.Error(), le.ForLogger()...)
+		logger.Errorw("Error decoding RunLog to JSON", le.ForLogger("error", err)...)
 		return RunRequest{}, err
 	}
 

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -348,7 +348,7 @@ func loggerFunc() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		buf, err := ioutil.ReadAll(c.Request.Body)
 		if err != nil {
-			logger.Error("Web request log error: ", err.Error())
+			logger.Errorw("Failed to read web response body", "error", err)
 			// Implicitly relies on limits.RequestSizeLimiter
 			// overriding of c.Request.Body to abort gin's Context
 			// inside ioutil.ReadAll.


### PR DESCRIPTION
using w( with `"error", err` logs the stack trace