### PR TITLE
Start EthBroadcaster after GasUpdater

### DIFF
--- a/core/services/bulletprooftxmanager/eth_broadcaster.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster.go
@@ -36,7 +36,7 @@ import (
 // - existence of a saved eth_tx_attempt
 type EthBroadcaster interface {
 	Start() error
-	Stop() error
+	Close() error
 
 	Trigger()
 
@@ -93,7 +93,7 @@ func (eb *ethBroadcaster) Start() error {
 	return nil
 }
 
-func (eb *ethBroadcaster) Stop() error {
+func (eb *ethBroadcaster) Close() error {
 	if !eb.OkayToStop() {
 		return errors.New("EthBroadcaster is already stopped")
 	}

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -227,7 +227,7 @@ func NewApplication(config *orm.Config, ethClient eth.Client, advisoryLocker pos
 		logger.Debug("Off-chain reporting disabled")
 	}
 	jobSpawner := job.NewSpawner(jobORM, store.Config, delegates)
-	subservices = append(subservices, jobSpawner, pipelineRunner, ethConfirmer)
+	subservices = append(subservices, jobSpawner, pipelineRunner, ethBroadcaster, ethConfirmer)
 
 	store.NotifyNewEthTx = ethBroadcaster
 
@@ -336,7 +336,6 @@ func (app *ChainlinkApplication) Start() error {
 		app.LogBroadcaster.Start,
 		app.EventBroadcaster.Start,
 		app.FluxMonitor.Start,
-		app.EthBroadcaster.Start,
 	}
 
 	for _, task := range subtasks {
@@ -426,8 +425,6 @@ func (app *ChainlinkApplication) stop() error {
 		merr = multierr.Append(merr, app.JobSubscriber.Stop())
 		logger.Debug("Stopping FluxMonitor...")
 		app.FluxMonitor.Stop()
-		logger.Debug("Stopping EthBroadcaster...")
-		merr = multierr.Append(merr, app.EthBroadcaster.Stop())
 		logger.Debug("Stopping EventBroadcaster...")
 		merr = multierr.Append(merr, app.EventBroadcaster.Stop())
 		logger.Debug("Stopping LogBroadcaster...")


### PR DESCRIPTION
EthBroadcaster uses the gas price so needs to be started after GasUpdater backfills the price.
EthBroadcaster.Trigger() is used in tests so can't easily move it to subservices