### PR TITLE
Retry on bad connection

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -933,7 +933,7 @@ func TestIntegration_FluxMonitor_NewRound(t *testing.T) {
 	availableFunds := minPayment * 100
 
 	// Start, connect, and initialize node
-	sub.On("Err").Return(nil)
+	sub.On("Err").Return(nil).Maybe()
 	sub.On("Unsubscribe").Return(nil).Maybe()
 	gethClient.On("ChainID", mock.Anything).Return(app.Store.Config.ChainID(), nil)
 	gethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(oneETH.ToInt(), nil)

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -1601,8 +1601,7 @@ func (ct Connection) initializeDatabase() (*gorm.DB, error) {
 		}), &gorm.Config{Logger: newLogger})
 		if err != nil {
 			if err == driver.ErrBadConn {
-				logger.Warnw("retrying to connect", "err", err)
-				// Use the underlying connection with the unique uri for txdb.
+				logger.Warnw("retrying to connect to database", "err", err, "dsn", originalURI)
 				d, err = sql.Open(string(ct.dialect), ct.uri)
 				if err != nil {
 					return nil, err


### PR DESCRIPTION
With this retry I've been able to run `DATABASE_URL=postgresql://postgres:node@localhost:5432/chainlink_test?sslmode=disable go test -count=20 -run TestIntegration_FluxMonitor* ./core/internal/...` successfully. 