### PR TITLE
Add EthResender which periodically retransmits eth_txes

### DIFF
--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -1312,14 +1312,14 @@ func TestClient_SetLogConfig(t *testing.T) {
 	app := startNewApplication(t)
 	client, _ := app.NewClientAndRenderer()
 
-	infoLevel := "warn"
+	logLevel := "warn"
 	set := flag.NewFlagSet("loglevel", 0)
-	set.String("level", infoLevel, "")
+	set.String("level", logLevel, "")
 	c := cli.NewContext(nil, set, nil)
 
 	err := client.SetLogLevel(c)
-	assert.NoError(t, err)
-	assert.Equal(t, infoLevel, app.Config.LogLevel().String())
+	require.NoError(t, err)
+	assert.Equal(t, logLevel, app.Config.LogLevel().String())
 
 	sqlEnabled := true
 	set = flag.NewFlagSet("logsql", 0)

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -514,11 +514,17 @@ func NewEthTx(t *testing.T, store *strpkg.Store, fromAddress common.Address) mod
 	}
 }
 
-func MustInsertUnconfirmedEthTxWithBroadcastAttempt(t *testing.T, store *strpkg.Store, nonce int64, fromAddress common.Address) models.EthTx {
-	timeNow := time.Now()
+func MustInsertUnconfirmedEthTxWithBroadcastAttempt(t *testing.T, store *strpkg.Store, nonce int64, fromAddress common.Address, opts ...interface{}) models.EthTx {
+	broadcastAt := time.Now()
+	for _, opt := range opts {
+		switch v := opt.(type) {
+		case time.Time:
+			broadcastAt = v
+		}
+	}
 	etx := NewEthTx(t, store, fromAddress)
 
-	etx.BroadcastAt = &timeNow
+	etx.BroadcastAt = &broadcastAt
 	n := nonce
 	etx.Nonce = &n
 	etx.State = models.EthTxUnconfirmed

--- a/core/internal/cltest/simulated_backend.go
+++ b/core/internal/cltest/simulated_backend.go
@@ -416,6 +416,10 @@ func (c *SimulatedBackendClient) BatchCallContext(ctx context.Context, b []rpc.B
 	return nil
 }
 
+func (c *SimulatedBackendClient) RoundRobinBatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
+	return c.BatchCallContext(ctx, b)
+}
+
 // Mine forces the simulated backend to produce a new block every 2 seconds
 func Mine(backend *backends.SimulatedBackend, blockTime time.Duration) (stopMining func()) {
 	timer := time.NewTicker(blockTime)

--- a/core/internal/mocks/client.go
+++ b/core/internal/mocks/client.go
@@ -389,6 +389,20 @@ func (_m *Client) PendingNonceAt(ctx context.Context, account common.Address) (u
 	return r0, r1
 }
 
+// RoundRobinBatchCallContext provides a mock function with given fields: ctx, b
+func (_m *Client) RoundRobinBatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
+	ret := _m.Called(ctx, b)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, []rpc.BatchElem) error); ok {
+		r0 = rf(ctx, b)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // SendRawTx provides a mock function with given fields: bytes
 func (_m *Client) SendRawTx(bytes []byte) (common.Hash, error) {
 	ret := _m.Called(bytes)

--- a/core/services/bulletprooftxmanager/eth_resender.go
+++ b/core/services/bulletprooftxmanager/eth_resender.go
@@ -1,0 +1,158 @@
+package bulletprooftxmanager
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/lib/pq"
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/eth"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/chainlink/core/utils"
+	"gorm.io/gorm"
+)
+
+// pollInterval is the maximum amount of time in addition to
+// EthTxResendAfterThreshold that we will wait before resending an attempt
+const defaultResenderPollInterval = 5 * time.Second
+
+// EthResender periodically picks up transactions that have been languishing
+// unconfirmed for a configured amount of time without being sent, and sends
+// their highest priced attempt again. This helps to defend against geth/parity
+// silently dropping txes, or txes being ejected from the mempool.
+//
+// Previously we relied on the bumper to do this for us implicitly but there
+// can occasionally be problems with this (e.g. abnormally long block times, or
+// if gas bumping is disabled)
+type EthResender struct {
+	db           *gorm.DB
+	ethClient    eth.Client
+	interval     time.Duration
+	ageThreshold time.Duration
+
+	chStop chan struct{}
+	chDone chan struct{}
+}
+
+func NewEthResender(db *gorm.DB, ethClient eth.Client, pollInterval, ethTxResendAfterThreshold time.Duration) *EthResender {
+	if ethTxResendAfterThreshold == 0 {
+		panic("EthResender requires a non-zero threshold")
+	}
+	return &EthResender{
+		db,
+		ethClient,
+		pollInterval,
+		ethTxResendAfterThreshold,
+		make(chan struct{}),
+		make(chan struct{}),
+	}
+}
+
+func (er *EthResender) Start() {
+	logger.Infof("EthResender: Enabled with poll interval of %s and age threshold of %s", er.interval, er.ageThreshold)
+	go er.runLoop()
+}
+
+func (er *EthResender) Stop() {
+	close(er.chStop)
+	<-er.chDone
+}
+
+func (er *EthResender) runLoop() {
+	defer close(er.chDone)
+
+	if err := er.resendUnconfirmed(); err != nil {
+		logger.Warnw("EthResender: failed to resend unconfirmed transactions", "err", err)
+	}
+
+	ticker := time.NewTicker(utils.WithJitter(er.interval))
+	defer ticker.Stop()
+	for {
+		select {
+		case <-er.chStop:
+			return
+		case <-ticker.C:
+			if err := er.resendUnconfirmed(); err != nil {
+				logger.Warnw("EthResender: failed to resend unconfirmed transactions", "err", err)
+			}
+		}
+	}
+}
+
+func (er *EthResender) resendUnconfirmed() error {
+	olderThan := time.Now().Add(-er.ageThreshold)
+	attempts, err := FindEthTxesRequiringResend(er.db, olderThan)
+	if err != nil {
+		return errors.Wrap(err, "failed to findEthTxAttemptsRequiringReceiptFetch")
+	}
+
+	if len(attempts) == 0 {
+		return nil
+	}
+
+	logger.Debugw(fmt.Sprintf("EthResender: re-sending %d transactions that were last sent over %s ago", len(attempts), er.ageThreshold), "n", len(attempts))
+
+	var reqs []rpc.BatchElem
+	for _, attempt := range attempts {
+		req := rpc.BatchElem{
+			Method: "eth_sendRawTransaction",
+			Args:   []interface{}{hexutil.Encode(attempt.SignedRawTx)},
+			Result: &common.Hash{},
+		}
+
+		reqs = append(reqs, req)
+	}
+
+	now := time.Now()
+	if err := er.ethClient.RoundRobinBatchCallContext(context.Background(), reqs); err != nil {
+		return errors.Wrap(err, "failed to re-send transactions")
+	}
+
+	var succeeded []int64
+	for i, req := range reqs {
+		if req.Error == nil {
+			succeeded = append(succeeded, attempts[i].EthTxID)
+		}
+	}
+
+	if err := er.updateBroadcastAts(now, succeeded); err != nil {
+		return errors.Wrap(err, "failed to update last succeeded on attempts")
+	}
+	nSuccess := len(succeeded)
+	nErrored := len(attempts) - nSuccess
+
+	logger.Debugw("EthResender: completed", "nSuccess", nSuccess, "nErrored", nErrored)
+
+	return nil
+}
+
+// FindEthTxesRequiringResend returns the highest priced attempt for each
+// eth_tx that was last sent before or at the given time
+func FindEthTxesRequiringResend(db *gorm.DB, olderThan time.Time) (attempts []models.EthTxAttempt, err error) {
+	err = db.Raw(`
+SELECT DISTINCT ON (eth_tx_id) eth_tx_attempts.*
+FROM eth_tx_attempts
+JOIN eth_txes ON eth_txes.id = eth_tx_attempts.eth_tx_id AND eth_txes.state IN ('unconfirmed', 'confirmed_missing_receipt')
+WHERE eth_tx_attempts.state <> 'in_progress' AND eth_txes.broadcast_at <= ?
+ORDER BY eth_tx_attempts.eth_tx_id ASC, eth_txes.nonce ASC, eth_tx_attempts.gas_price DESC
+`, olderThan).
+		Find(&attempts).Error
+
+	return
+}
+
+func (er *EthResender) updateBroadcastAts(now time.Time, etxIDs []int64) error {
+	// Deliberately do nothing on NULL broadcast_at because that indicates the
+	// tx has been moved into a state where broadcast_at is not relevant, e.g.
+	// fatally errored.
+	//
+	// Since we may have raced with the EthConfirmer (totally OK since highest
+	// priced transaction always wins) we only want to update broadcast_at if
+	// our version is later.
+	return er.db.Exec(`UPDATE eth_txes SET broadcast_at = ? WHERE id = ANY(?) AND broadcast_at < ?`, now, pq.Array(etxIDs), now).Error
+}

--- a/core/services/bulletprooftxmanager/eth_resender_test.go
+++ b/core/services/bulletprooftxmanager/eth_resender_test.go
@@ -1,0 +1,98 @@
+package bulletprooftxmanager_test
+
+import (
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/ethereum/go-ethereum/rpc"
+	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/internal/mocks"
+	"github.com/smartcontractkit/chainlink/core/services/bulletprooftxmanager"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/chainlink/core/utils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_EthResender_FindEthTxesRequiringResend(t *testing.T) {
+	t.Parallel()
+
+	store, cleanup := cltest.NewStore(t)
+	defer cleanup()
+
+	key := cltest.MustInsertRandomKey(t, store.DB)
+	fromAddress := key.Address.Address()
+
+	t.Run("returns nothing if there are no transactions", func(t *testing.T) {
+		olderThan := time.Now()
+		attempts, err := bulletprooftxmanager.FindEthTxesRequiringResend(store.DB, olderThan)
+		require.NoError(t, err)
+		assert.Len(t, attempts, 0)
+	})
+
+	etxs := []models.EthTx{
+		cltest.MustInsertUnconfirmedEthTxWithBroadcastAttempt(t, store, 0, fromAddress, time.Unix(1616509100, 0)),
+		cltest.MustInsertUnconfirmedEthTxWithBroadcastAttempt(t, store, 1, fromAddress, time.Unix(1616509200, 0)),
+		cltest.MustInsertUnconfirmedEthTxWithBroadcastAttempt(t, store, 2, fromAddress, time.Unix(1616509300, 0)),
+	}
+	attempt1_2 := newBroadcastEthTxAttempt(t, etxs[0].ID, store)
+	attempt1_2.GasPrice = *utils.NewBig(big.NewInt(10))
+	require.NoError(t, store.DB.Create(&attempt1_2).Error)
+
+	attempt3_2 := newInProgressEthTxAttempt(t, etxs[2].ID, store)
+	attempt3_2.GasPrice = *utils.NewBig(big.NewInt(10))
+	require.NoError(t, store.DB.Create(&attempt3_2).Error)
+
+	t.Run("returns the highest price attempt for each transaction that was last broadcast before or on the given time", func(t *testing.T) {
+		olderThan := time.Unix(1616509200, 0)
+		attempts, err := bulletprooftxmanager.FindEthTxesRequiringResend(store.DB, olderThan)
+		require.NoError(t, err)
+		assert.Len(t, attempts, 2)
+		assert.Equal(t, attempt1_2.ID, attempts[0].ID)
+		assert.Equal(t, etxs[1].EthTxAttempts[0].ID, attempts[1].ID)
+	})
+}
+
+func Test_EthResender_Start(t *testing.T) {
+	t.Parallel()
+
+	store, cleanup := cltest.NewStore(t)
+	defer cleanup()
+	key := cltest.MustInsertRandomKey(t, store.DB)
+	fromAddress := key.Address.Address()
+
+	t.Run("resends transactions that have been languishing unconfirmed for too long", func(t *testing.T) {
+		ethClient := new(mocks.Client)
+
+		er := bulletprooftxmanager.NewEthResender(store.DB, ethClient, 100*time.Millisecond, 1*time.Hour)
+
+		originalBroadcastAt := time.Unix(1616509100, 0)
+		etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastAttempt(t, store, 0, fromAddress, originalBroadcastAt)
+		etx2 := cltest.MustInsertUnconfirmedEthTxWithBroadcastAttempt(t, store, 1, fromAddress, originalBroadcastAt)
+		cltest.MustInsertUnconfirmedEthTxWithBroadcastAttempt(t, store, 2, fromAddress, time.Now().Add(1*time.Hour))
+
+		ethClient.On("RoundRobinBatchCallContext", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {
+			return len(b) == 2 &&
+				b[0].Method == "eth_sendRawTransaction" && b[0].Args[0] == hexutil.Encode(etx.EthTxAttempts[0].SignedRawTx) &&
+				b[1].Method == "eth_sendRawTransaction" && b[1].Args[0] == hexutil.Encode(etx2.EthTxAttempts[0].SignedRawTx)
+		})).Return(nil)
+
+		func() {
+			er.Start()
+			defer er.Stop()
+
+			cltest.EventuallyExpectationsMet(t, ethClient, 5*time.Second, 10*time.Millisecond)
+		}()
+
+		err := store.DB.First(&etx).Error
+		require.NoError(t, err)
+		err = store.DB.First(&etx2).Error
+		require.NoError(t, err)
+
+		assert.Greater(t, etx.BroadcastAt.Unix(), originalBroadcastAt.Unix())
+		assert.Greater(t, etx2.BroadcastAt.Unix(), originalBroadcastAt.Unix())
+	})
+}

--- a/core/services/bulletprooftxmanager/nonce_syncer.go
+++ b/core/services/bulletprooftxmanager/nonce_syncer.go
@@ -249,6 +249,7 @@ func (s NonceSyncer) fastForwardNonceIfNecessary(ctx context.Context, address co
 			// didn't actually broadcast the transaction, but including it
 			// allows us to avoid changing the state machine limitations and
 			// represents roughly the time we read the tx from the blockchain
+			// so we can pretty much assume it was "broadcast" at this time.
 			ins.Etx.BroadcastAt = &now
 			if err := dbtx.Create(&ins.Etx).Error; err != nil {
 				return errors.Wrap(err, "NonceSyncer#fastForwardNonceIfNecessary failed to create eth_tx")

--- a/core/services/eth/client.go
+++ b/core/services/eth/client.go
@@ -6,6 +6,7 @@ import (
 	"net/url"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -41,6 +42,7 @@ type Client interface {
 	Call(result interface{}, method string, args ...interface{}) error
 	CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error
 	BatchCallContext(ctx context.Context, b []rpc.BatchElem) error
+	RoundRobinBatchCallContext(ctx context.Context, b []rpc.BatchElem) error
 
 	// These methods are reimplemented due to a difference in how block header hashes are
 	// calculated by Parity nodes running on Kovan.  We have to return our own wrapper
@@ -94,6 +96,8 @@ type client struct {
 	SecondaryRPCClients  []RPCClient
 	secondaryURLs        []url.URL
 	mocked               bool
+
+	roundRobinCount uint32
 }
 
 var _ Client = (*client)(nil)
@@ -368,4 +372,22 @@ func (client *client) BatchCallContext(ctx context.Context, b []rpc.BatchElem) e
 		"nBatchElems", len(b),
 	)
 	return client.RPCClient.BatchCallContext(ctx, b)
+}
+
+// RoundRobinBatchCallContext rotates through Primary and all Secondaries, changing node on each call
+func (client *client) RoundRobinBatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
+	nSecondaries := len(client.SecondaryRPCClients)
+	if nSecondaries == 0 {
+		return client.BatchCallContext(ctx, b)
+	}
+
+	// NOTE: AddUint32 returns the number after addition, so we must -1 to get the "current" count
+	count := atomic.AddUint32(&client.roundRobinCount, 1) - 1
+	// idx 0 indicates the primary, subsequent indices represent secondaries
+	rr := int(count % uint32(nSecondaries+1))
+
+	if rr == 0 {
+		return client.BatchCallContext(ctx, b)
+	}
+	return client.SecondaryRPCClients[rr-1].BatchCallContext(ctx, b)
 }

--- a/core/services/eth/null_client.go
+++ b/core/services/eth/null_client.go
@@ -152,3 +152,7 @@ func (nc *NullClient) CodeAt(ctx context.Context, account common.Address, blockN
 func (nc *NullClient) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
 	return nil
 }
+
+func (nc *NullClient) RoundRobinBatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
+	return nil
+}

--- a/core/services/log/broadcaster_test.go
+++ b/core/services/log/broadcaster_test.go
@@ -50,7 +50,7 @@ func TestBroadcaster_AwaitsInitialSubscribersOnStartup(t *testing.T) {
 	listener.On("OnConnect").Return()
 	listener.On("OnDisconnect").Return()
 
-	sub.On("Unsubscribe").Return()
+	sub.On("Unsubscribe").Maybe().Return()
 	sub.On("Err").Return(nil)
 
 	chSubscribe := make(chan struct{}, 10)

--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -52,10 +52,12 @@ type EthTx struct {
 	Value          assets.Eth
 	GasLimit       uint64
 	Error          *string
-	BroadcastAt    *time.Time
-	CreatedAt      time.Time
-	State          EthTxState
-	EthTxAttempts  []EthTxAttempt `gorm:"->"`
+	// BroadcastAt is updated every time an attempt for this eth_tx is re-sent
+	// In almost all cases it will be within a second or so of the actual send time.
+	BroadcastAt   *time.Time
+	CreatedAt     time.Time
+	State         EthTxState
+	EthTxAttempts []EthTxAttempt `gorm:"->"`
 }
 
 func (e EthTx) GetError() error {

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -487,6 +487,16 @@ func (c Config) EthHeadTrackerMaxBufferSize() uint {
 	return uint(c.getWithFallback("EthHeadTrackerMaxBufferSize", parseUint64).(uint64))
 }
 
+// EthTxResendAfterThreshold controls how long the ethResender will wait before
+// re-sending the latest eth_tx_attempt. This is designed a as a fallback to
+// protect against the eth nodes dropping txes (it has been anecdotally
+// observed to happen), networking issues or txes being ejected from the
+// mempool.
+// See eth_resender.go for more details
+func (c Config) EthTxResendAfterThreshold() time.Duration {
+	return c.getWithFallback("EthTxResendAfterThreshold", parseDuration).(time.Duration)
+}
+
 // EthereumURL represents the URL of the Ethereum node to connect Chainlink to.
 func (c Config) EthereumURL() string {
 	return c.viper.GetString(EnvVarName("EthereumURL"))

--- a/core/store/orm/config_reader.go
+++ b/core/store/orm/config_reader.go
@@ -46,6 +46,7 @@ type ConfigReader interface {
 	EthReceiptFetchBatchSize() uint32
 	EthHeadTrackerHistoryDepth() uint
 	EthHeadTrackerMaxBufferSize() uint
+	EthTxResendAfterThreshold() time.Duration
 	SetEthGasPriceDefault(value *big.Int) error
 	EthereumURL() string
 	EthereumSecondaryURLs() []url.URL

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -57,6 +57,7 @@ type ConfigSchema struct {
 	EthHeadTrackerMaxBufferSize               uint            `env:"ETH_HEAD_TRACKER_MAX_BUFFER_SIZE" default:"3"`
 	EthBalanceMonitorBlockDelay               uint16          `env:"ETH_BALANCE_MONITOR_BLOCK_DELAY" default:"1"`
 	EthReceiptFetchBatchSize                  uint32          `env:"ETH_RECEIPT_FETCH_BATCH_SIZE" default:"100"`
+	EthTxResendAfterThreshold                 time.Duration   `env:"ETH_TX_RESEND_AFTER_THRESHOLD" default:"30s"`
 	EthereumURL                               string          `env:"ETH_URL" default:"ws://localhost:8546"`
 	EthereumSecondaryURL                      string          `env:"ETH_SECONDARY_URL" default:""`
 	EthereumSecondaryURLs                     string          `env:"ETH_SECONDARY_URLS" default:""`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -22,9 +22,13 @@ at least '1m', it enables periodic backups.
 Example settings:
 
 `DATABASE_BACKUP_MODE="full"` and `DATABASE_BACKUP_FREQUENCY` not set, will run a full back only at the start of the node.
-
-
 `DATABASE_BACKUP_MODE="lite"` and `DATABASE_BACKUP_FREQUENCY="1h"` will lead to a partial backup on node start and then again a partial backup every one hour.
+
+- Added periodic resending of eth transactions. This means that we no longer rely exclusively on gas bumping to resend unconfirmed transactions that got "lost" for whatever reason. This has two advantages:
+    1. Chainlink no longer relies on gas bumping settings to ensure our transactions always end up in the mempool
+    2. Chainlink will continue to resend existing transactions even in the event that heads are delayed. This is especially useful on chains like Arbitrum which have very long wait times between heads.
+
+Periodic resending can be controlled using the `ETH_TX_RESEND_AFTER_THRESHOLD` env var (default 30s). Unconfirmed transactions will be resent periodically at this interval. It is recommended to leave this at the default setting, but it can be set to any [valid duration](https://golang.org/pkg/time/#ParseDuration) or to 0 to disable periodic resending.
 
 ### Fixed
 


### PR DESCRIPTION
One minor design irration in the existing EthBroadcaster/EthConfirmer
model is that there is no explicit periodic resending of transactions that are
still unconfirmed.

It has been anecdotally many times in production that sent transactions
can "disappear". Networking issues, bugs in the eth node, mempool
pressure ejecting transactions, eth nodes being switched out behind load
balancers etc... the list goes on.

Nobody has noticed a problem up til now because the gas bumper implicitly resends
transactions at ETH_GAS_BUMP_THRESHOLD anyway.

Now that gas bumping can be disabled, the problem has become obvious
since without bumping, some transactions can disappear and never be
resent again leading to a stuck node.

This commit implements explicit periodic resending of unconfirmed
transactions that runs parallel to and independent of the existing gas
bumper. This has two advantages:

1. Does not rely on gas bumping settings to ensure our transactions always end up
in the mempool
2. Chainlink will continue to resend existing transactions even in the event that heads are delayed. This is especially useful on chains like Arbitrum which have very long wait times between heads.

This change is likely to save users a bit of gas and shorten inclusion time
for transactions in some cases since we resend dropped transactions
instead of waiting to bump gas.

It does this at the expense of placing slightly more load on the eth
node.