### PR TITLE
UI for configuring logging

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,3 @@
 core @se3000 @RyanRHall @spooktheducks @samsondav @j16r @connorwstein
+
+/operator-ui/ @DeividasK

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,6 +26,8 @@ Example settings:
 
 `DATABASE_BACKUP_MODE="lite"` and `DATABASE_BACKUP_FREQUENCY="1h"` will lead to a partial backup on node start and then again a partial backup every one hour.
 
+- Logging can now be configured in the Operator UI. 
+
 ### Fixed
 
 - Chainlink node now automatically sets the correct nonce on startup if you are restoring from a previous backup (manual setnextnonce is no longer necessary).

--- a/operator_ui/@types/core/store/models.d.ts
+++ b/operator_ui/@types/core/store/models.d.ts
@@ -539,6 +539,18 @@ declare module 'core/store/models' {
       dotDagSource: string
     }
   }
+
+  export type LogConfigLevel = 'debug' | 'info' | 'warn' | 'error'
+
+  export interface LogConfig {
+     level: LogConfigLevel
+     sqlEnabled: boolean
+  }  
+
+  export interface LogConfigRequest {
+    level: LogConfigLevel
+    sqlEnabled: boolean
+  }  
 }
 
 export interface PipelineTaskRun {
@@ -549,3 +561,4 @@ export interface PipelineTaskRun {
   dotId: string
   type: string
 }
+

--- a/operator_ui/src/api/v2/index.ts
+++ b/operator_ui/src/api/v2/index.ts
@@ -11,6 +11,7 @@ import { OcrKeys } from './ocrKeys'
 import { P2PKeys } from './p2pKeys'
 import { OcrRuns } from './ocrRuns'
 import { Jobs } from './jobs'
+import { LogConfig } from './logConfig'
 
 export class V2 {
   constructor(private api: Api) {}
@@ -27,4 +28,5 @@ export class V2 {
   public p2pKeys = new P2PKeys(this.api)
   public jobs = new Jobs(this.api)
   public ocrRuns = new OcrRuns(this.api)
+  public logConfig = new LogConfig(this.api)
 }

--- a/operator_ui/src/api/v2/logConfig.ts
+++ b/operator_ui/src/api/v2/logConfig.ts
@@ -1,0 +1,36 @@
+import * as jsonapi from 'utils/json-api-client'
+import { boundMethod } from 'autobind-decorator'
+import * as models from 'core/store/models'
+
+/**
+ * Show returns the whitelist of config variables
+ *
+ * @example "<application>/config"
+ */
+const ENDPOINT = '/v2/log'
+
+export class LogConfig {
+  constructor(private api: jsonapi.Api) {}
+
+  /**
+   * Get log configuration variables
+   */
+  @boundMethod
+  public getLogConfig(): Promise<jsonapi.ApiResponse<models.LogConfig>> {
+    return this.show()
+  }
+
+  @boundMethod
+  public updateLogConfig(
+    request: models.LogConfigRequest,
+  ): Promise<jsonapi.ApiResponse<models.LogConfig>> {
+    return this.update(request)
+  }
+
+  private show = this.api.fetchResource<{}, models.LogConfig, {}>(ENDPOINT)
+
+  private update = this.api.updateResource<
+    models.LogConfigRequest,
+    models.LogConfig
+  >(ENDPOINT)
+}

--- a/operator_ui/src/components/KeyValueList.tsx
+++ b/operator_ui/src/components/KeyValueList.tsx
@@ -81,7 +81,7 @@ const HeadCol = ({ children }: HeadColProps) => (
 
 interface KeyValueListProps {
   entries: Array<Array<any>>
-  titleize: boolean
+  titleize?: boolean
   showHead: boolean
   title?: string
   error?: string

--- a/operator_ui/src/pages/Configuration/Index.test.tsx
+++ b/operator_ui/src/pages/Configuration/Index.test.tsx
@@ -1,17 +1,10 @@
-/* eslint-env jest */
-import { ConnectedConfiguration as Configuration } from 'pages/Configuration/Index'
-import configurationFactory from 'factories/configuration'
 import React from 'react'
-import mountWithinStoreAndRouter from 'test-helpers/mountWithinStoreAndRouter'
+import { Route } from 'react-router-dom'
+import { mountWithProviders } from 'test-helpers/mountWithTheme'
 import syncFetch from 'test-helpers/syncFetch'
 import globPath from 'test-helpers/globPath'
-
-const classes = {}
-const mount = (props) => {
-  return mountWithinStoreAndRouter(
-    <Configuration classes={classes} {...props} />,
-  )
-}
+import Configuration from 'pages/Configuration/Index'
+import configurationFactory from 'factories/configuration'
 
 describe('pages/Configuration', () => {
   it('renders the list of configuration options', async () => {
@@ -23,9 +16,14 @@ describe('pages/Configuration', () => {
     })
     global.fetch.getOnce(globPath('/v2/config'), configurationResponse)
 
-    const wrapper = mount()
-
+    const wrapper = mountWithProviders(
+      <Route path="/config" component={Configuration} />,
+      {
+        initialEntries: [`/config`],
+      },
+    )
     await syncFetch(wrapper)
+
     expect(wrapper.text()).toContain('BAND')
     expect(wrapper.text()).toContain('Major Lazer')
     expect(wrapper.text()).toContain('SINGER')

--- a/operator_ui/src/pages/Configuration/Index.tsx
+++ b/operator_ui/src/pages/Configuration/Index.tsx
@@ -1,3 +1,4 @@
+import React, { useEffect } from 'react'
 import { PaddedCard } from 'components/PaddedCard'
 import { KeyValueList } from 'components/KeyValueList'
 import Grid from '@material-ui/core/Grid'
@@ -5,26 +6,30 @@ import Typography from '@material-ui/core/Typography'
 import { fetchConfiguration } from 'actionCreators'
 import Content from 'components/Content'
 import DeleteJobRuns from 'pages/Configuration/DeleteJobRuns'
-import PropTypes from 'prop-types'
-import React, { useEffect } from 'react'
-import { connect } from 'react-redux'
+import { useDispatch, useSelector } from 'react-redux'
 import configurationSelector from 'selectors/configuration'
 import extractBuildInfo from 'utils/extractBuildInfo'
-import matchRouteAndMapDispatchToProps from 'utils/matchRouteAndMapDispatchToProps'
+import { LoggingCard } from './LoggingCard'
 
 const buildInfo = extractBuildInfo()
 
-export const Configuration = ({ fetchConfiguration, data }) => {
+export const Configuration = () => {
+  const dispatch = useDispatch()
+  const config = useSelector(configurationSelector)
+
   useEffect(() => {
     document.title = 'Configuration'
-    fetchConfiguration()
-  }, [fetchConfiguration])
+  })
+
+  useEffect(() => {
+    dispatch(fetchConfiguration())
+  }, [dispatch])
 
   return (
     <Content>
       <Grid container>
         <Grid item sm={12} md={8}>
-          <KeyValueList title="Configuration" entries={data} showHead />
+          <KeyValueList title="Configuration" entries={config} showHead />
         </Grid>
         <Grid item sm={12} md={4}>
           <Grid container>
@@ -51,6 +56,9 @@ export const Configuration = ({ fetchConfiguration, data }) => {
             <Grid item xs={12}>
               <DeleteJobRuns />
             </Grid>
+            <Grid item xs={12}>
+              <LoggingCard />
+            </Grid>
           </Grid>
         </Grid>
       </Grid>
@@ -58,18 +66,4 @@ export const Configuration = ({ fetchConfiguration, data }) => {
   )
 }
 
-Configuration.propTypes = {
-  data: PropTypes.array.isRequired,
-}
-
-const mapStateToProps = (state) => {
-  const data = configurationSelector(state)
-  return { data }
-}
-
-export const ConnectedConfiguration = connect(
-  mapStateToProps,
-  matchRouteAndMapDispatchToProps({ fetchConfiguration }),
-)(Configuration)
-
-export default ConnectedConfiguration
+export default Configuration

--- a/operator_ui/src/pages/Configuration/LoggingCard.test.tsx
+++ b/operator_ui/src/pages/Configuration/LoggingCard.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react'
+import { mountWithProviders } from 'test-helpers/mountWithTheme'
+import { syncFetch } from 'test-helpers/syncFetch'
+import globPath from 'test-helpers/globPath'
+import { logConfigFactory } from 'factories/jsonApiLogConfig'
+import { LoggingCard } from './LoggingCard'
+// import { Checkbox } from '@material-ui/core'
+
+describe('pages/Configuration/LoggingCard', () => {
+  it('renders the logging configuration card', async () => {
+    const logConfig = logConfigFactory({
+      level: 'info',
+      sqlEnabled: false,
+    })
+
+    global.fetch.getOnce(globPath('/v2/log'), logConfig)
+
+    const wrapper = mountWithProviders(<LoggingCard />)
+    await syncFetch(wrapper)
+
+    expect(wrapper.find('input[name="level"]').first().props().value).toEqual(
+      'info',
+    )
+    expect(
+      wrapper.find('input[name="sqlEnabled"]').first().props().checked,
+    ).toEqual(false)
+  })
+
+  it('updates the logging configuration', async () => {
+    const logConfig = logConfigFactory({
+      level: 'info',
+      sqlEnabled: false,
+    })
+
+    global.fetch.getOnce(globPath('/v2/log'), logConfig)
+    const submit = global.fetch.patchOnce(globPath('/v2/log'), logConfig)
+
+    const wrapper = mountWithProviders(<LoggingCard />)
+    await syncFetch(wrapper)
+
+    // Cannot figure out how to change the select and checkbox inputs for submit
+
+    wrapper.find('form').simulate('submit')
+    await syncFetch(wrapper)
+
+    expect(submit.lastCall()[1].body).toEqual(
+      '{"level":"info","sqlEnabled":false}',
+    )
+  })
+})

--- a/operator_ui/src/pages/Configuration/LoggingCard.test.tsx
+++ b/operator_ui/src/pages/Configuration/LoggingCard.test.tsx
@@ -4,7 +4,7 @@ import { syncFetch } from 'test-helpers/syncFetch'
 import globPath from 'test-helpers/globPath'
 import { logConfigFactory } from 'factories/jsonApiLogConfig'
 import { LoggingCard } from './LoggingCard'
-// import { Checkbox } from '@material-ui/core'
+import { act } from 'react-dom/test-utils'
 
 describe('pages/Configuration/LoggingCard', () => {
   it('renders the logging configuration card', async () => {
@@ -38,13 +38,21 @@ describe('pages/Configuration/LoggingCard', () => {
     const wrapper = mountWithProviders(<LoggingCard />)
     await syncFetch(wrapper)
 
-    // Cannot figure out how to change the select and checkbox inputs for submit
+    act(() => {
+      const selectInput = wrapper.find('#select-level').first()
+      const selectOnChange = selectInput.prop('onChange')
+      if (selectOnChange) {
+        selectOnChange({
+          target: { name: 'level', value: 'debug' },
+        } as any)
+      }
+    })
 
     wrapper.find('form').simulate('submit')
     await syncFetch(wrapper)
 
     expect(submit.lastCall()[1].body).toEqual(
-      '{"level":"info","sqlEnabled":false}',
+      '{"level":"debug","sqlEnabled":false}',
     )
   })
 })

--- a/operator_ui/src/pages/Configuration/LoggingCard.tsx
+++ b/operator_ui/src/pages/Configuration/LoggingCard.tsx
@@ -100,7 +100,7 @@ export const LoggingCard = () => {
     }
 
     fetch()
-  }, [])
+  }, [setError])
 
   return (
     <Card>

--- a/operator_ui/src/pages/Configuration/LoggingCard.tsx
+++ b/operator_ui/src/pages/Configuration/LoggingCard.tsx
@@ -1,0 +1,119 @@
+import React, { useEffect, useState } from 'react'
+import capitalize from 'lodash/capitalize'
+import { useDispatch } from 'react-redux'
+import { useFormik } from 'formik'
+import Button from 'components/Button'
+import Card from '@material-ui/core/Card'
+import CardContent from '@material-ui/core/CardContent'
+import CardHeader from '@material-ui/core/CardHeader'
+import Checkbox from '@material-ui/core/Checkbox'
+import FormControlLabel from '@material-ui/core/FormControlLabel'
+import FormGroup from '@material-ui/core/FormGroup'
+import MenuItem from '@material-ui/core/MenuItem'
+import TextField from '@material-ui/core/TextField'
+import * as models from 'core/store/models'
+import { v2 } from 'api'
+import { notifyError, notifySuccess } from 'actionCreators'
+import ErrorMessage from 'components/Notifications/DefaultError'
+import { useErrorHandler } from 'hooks/useErrorHandler'
+import { useLoadingPlaceholder } from 'hooks/useLoadingPlaceholder'
+
+const logLevels = ['debug', 'info', 'warn', 'error']
+
+type FormValues = {
+  level: models.LogConfigLevel
+  sqlEnabled: boolean
+}
+
+const LogConfigurationForm: React.FC<{ initialValues: FormValues }> = ({
+  initialValues,
+}) => {
+  const dispatch = useDispatch()
+  const formik = useFormik({
+    initialValues,
+    onSubmit: async (values) => {
+      try {
+        await v2.logConfig.updateLogConfig(values)
+
+        dispatch(notifySuccess(() => <>Logging Configuration Updated</>, {}))
+      } catch (e) {
+        dispatch(notifyError(ErrorMessage, e))
+      }
+    },
+  })
+
+  return (
+    <form onSubmit={formik.handleSubmit}>
+      <TextField
+        id="select-level"
+        name="level"
+        fullWidth
+        select
+        label="Log Level"
+        value={formik.values.level}
+        onChange={formik.handleChange}
+        error={formik.touched.level && Boolean(formik.errors.level)}
+        helperText={formik.touched.level && formik.errors.level}
+      >
+        {logLevels.map((level) => (
+          <MenuItem key={level} value={level}>
+            {capitalize(level)}
+          </MenuItem>
+        ))}
+      </TextField>
+
+      <FormGroup>
+        <FormControlLabel
+          name="sqlEnabled"
+          control={
+            <Checkbox
+              id="sqlEnabled"
+              checked={formik.values.sqlEnabled}
+              onChange={formik.handleChange}
+            />
+          }
+          label="Log SQL Statements"
+        />
+      </FormGroup>
+
+      <Button variant="primary" type="submit" disabled={formik.isSubmitting}>
+        Update
+      </Button>
+    </form>
+  )
+}
+
+export const LoggingCard = () => {
+  const [logConfig, setLogConfig] = useState<models.LogConfig | null>(null)
+  const { error, ErrorComponent, setError } = useErrorHandler()
+  const { LoadingPlaceholder } = useLoadingPlaceholder(!error && !logConfig)
+
+  useEffect(() => {
+    async function fetch() {
+      try {
+        const res = await v2.logConfig.getLogConfig()
+
+        setLogConfig(res.data.attributes)
+      } catch (e) {
+        setError(e)
+      }
+    }
+
+    fetch()
+  }, [])
+
+  return (
+    <Card>
+      <CardHeader
+        title="Configure Logging"
+        subheader="Overrides the LOG_LEVEL and LOG_SQL_STATEMENTS environment variables"
+      />
+      <CardContent>
+        <LoadingPlaceholder />
+        <ErrorComponent />
+
+        {logConfig && <LogConfigurationForm initialValues={logConfig} />}
+      </CardContent>
+    </Card>
+  )
+}

--- a/operator_ui/src/theme.ts
+++ b/operator_ui/src/theme.ts
@@ -114,6 +114,11 @@ const mainTheme: ThemeOptions = {
         fontSize: '1rem',
       },
     },
+    MuiCardHeader: {
+      title: {
+        marginBottom: spacing.unit,
+      },
+    },
   },
   typography: {
     useNextVariants: true,

--- a/operator_ui/support/factories/jsonApiLogConfig.ts
+++ b/operator_ui/support/factories/jsonApiLogConfig.ts
@@ -1,0 +1,15 @@
+import { ApiResponse } from 'utils/json-api-client'
+import { LogConfig } from 'core/store/models'
+
+export function logConfigFactory(config: Partial<LogConfig>) {
+  return {
+    data: {
+      id: 'log',
+      type: 'logs',
+      attributes: {
+        level: config.level || 'debug',
+        sqlEnabled: config.sqlEnabled || false,
+      },
+    },
+  } as ApiResponse<LogConfig>
+}


### PR DESCRIPTION
Adds a new card to the configurations page which contains a form to update logging configuration.

Currently the tests do not cover updating the form inputs, as I could not figure out how to make that work with Material UI/Enzyme/Jest. However, they do test that the form is submitted and the API request is made with the values in the form.