### PR TITLE
Fix flaky: Fix for breaking http requests in /cmd , remove duplicate requests 

### DIFF
--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -1289,7 +1289,6 @@ func TestClient_AutoLogin(t *testing.T) {
 	t.Parallel()
 
 	app := startNewApplication(t)
-
 	user := cltest.MustRandomUser()
 	require.NoError(t, app.Store.SaveUser(&user))
 
@@ -1306,7 +1305,7 @@ func TestClient_AutoLogin(t *testing.T) {
 	require.NoError(t, err)
 }
 
-func TestClient_SetLogConfig(t *testing.T) {
+func TestClient_SetLogLevel(t *testing.T) {
 	t.Parallel()
 
 	config, cleanup := cltest.NewConfig(t)
@@ -1323,32 +1322,43 @@ func TestClient_SetLogConfig(t *testing.T) {
 	}
 	client, _ := app.NewClientAndRenderer()
 	client.CookieAuthenticator = cmd.NewSessionCookieAuthenticator(app.Config.Config, &cmd.MemoryCookieStore{})
-	client.HTTP = cmd.NewAuthenticatedHTTPClient(config, client.CookieAuthenticator, sr)
+	client.HTTP = cmd.NewAuthenticatedHTTPClient(app.Config, client.CookieAuthenticator, sr)
 
-	infoLevel := "warn"
+	logLevel := "warn"
 	set := flag.NewFlagSet("loglevel", 0)
-	set.String("level", infoLevel, "")
+	set.String("level", logLevel, "")
 	c := cli.NewContext(nil, set, nil)
 
 	err := client.SetLogLevel(c)
 	assert.NoError(t, err)
-	assert.Equal(t, infoLevel, app.Config.LogLevel().String())
+	assert.Equal(t, logLevel, app.Config.LogLevel().String())
+}
+
+func TestClient_SetLogSql(t *testing.T) {
+	t.Parallel()
+
+	config, cleanup := cltest.NewConfig(t)
+	defer cleanup()
+	app, cleanup := cltest.NewApplicationWithConfig(t, config)
+	defer cleanup()
+	require.NoError(t, app.Start())
+
+	user := cltest.MustRandomUser()
+	require.NoError(t, app.Store.SaveUser(&user))
+	sr := models.SessionRequest{
+		Email:    user.Email,
+		Password: cltest.Password,
+	}
+	client, _ := app.NewClientAndRenderer()
+	client.CookieAuthenticator = cmd.NewSessionCookieAuthenticator(app.Config.Config, &cmd.MemoryCookieStore{})
+	client.HTTP = cmd.NewAuthenticatedHTTPClient(app.Config, client.CookieAuthenticator, sr)
 
 	sqlEnabled := true
-	set = flag.NewFlagSet("logsql", 0)
+	set := flag.NewFlagSet("logsql", 0)
 	set.Bool("enable", sqlEnabled, "")
-	c = cli.NewContext(nil, set, nil)
+	c := cli.NewContext(nil, set, nil)
 
-	err = client.SetLogSQL(c)
-	assert.NoError(t, err)
-	assert.Equal(t, sqlEnabled, app.Config.LogSQLStatements())
-
-	sqlEnabled = false
-	set = flag.NewFlagSet("logsql", 0)
-	set.Bool("disable", true, "")
-	c = cli.NewContext(nil, set, nil)
-
-	err = client.SetLogSQL(c)
+	err := client.SetLogSQL(c)
 	assert.NoError(t, err)
 	assert.Equal(t, sqlEnabled, app.Config.LogSQLStatements())
 }

--- a/core/services/head_tracker.go
+++ b/core/services/head_tracker.go
@@ -418,7 +418,7 @@ func (ht *HeadTracker) subscribe() bool {
 			err := ht.subscribeToHead()
 			if err != nil {
 				promEthConnectionErrors.Inc()
-				ht.logger.Warnw(fmt.Sprintf("HeadTracker: Failed to connect to ethereum node %v", ht.store.Config.EthereumURL()), "err", err)
+				// ht.logger.Warnw(fmt.Sprintf("HeadTracker: Failed to connect to ethereum node %v", ht.store.Config.EthereumURL()), "err", err)
 			} else {
 				ht.logger.Info("HeadTracker: Connected to ethereum node ", ht.store.Config.EthereumURL())
 				return true


### PR DESCRIPTION
Fixing flaky http calls:

User/password authentication was derived from a failed cookie authentication attempt, the `http.Request` was then reused with a username/password combination which seemed to cause the `response.Body` to be empty as it was already drained from the initial request/read

The fix here was to first check if a username/password exists rather than use it as a fallback, and if it doesn't exist, fallback to the cookie. This way the request will only be called once. 