### PR TITLE
Make sure Send/Receive in StatsPusher can be canceled

### DIFF
--- a/core/services/synchronization/explorer_client.go
+++ b/core/services/synchronization/explorer_client.go
@@ -66,7 +66,6 @@ func (NoopExplorerClient) Receive(context.Context, ...time.Duration) ([]byte, er
 type explorerClient struct {
 	boot             *sync.RWMutex
 	conn             *websocket.Conn
-	cancel           context.CancelFunc
 	sendText         chan []byte
 	sendBinary       chan []byte
 	dropMessageCount uint32
@@ -79,8 +78,7 @@ type explorerClient struct {
 	secret           string
 	logging          bool
 
-	closeRequested chan struct{}
-	closed         chan struct{}
+	done chan struct{}
 
 	statusMtx sync.RWMutex
 }
@@ -93,19 +91,14 @@ func NewExplorerClient(url *url.URL, accessKey, secret string, loggingArgs ...bo
 		logging = loggingArgs[0]
 	}
 	return &explorerClient{
-		url:        url,
-		sendText:   make(chan []byte, SendBufferSize),
-		sendBinary: make(chan []byte, SendBufferSize),
-		receive:    make(chan []byte),
-		boot:       new(sync.RWMutex),
-		sleeper:    utils.NewBackoffSleeper(),
-		status:     ConnectionStatusDisconnected,
-		accessKey:  accessKey,
-		secret:     secret,
-		logging:    logging,
-
-		closeRequested: make(chan struct{}),
-		closed:         make(chan struct{}),
+		url:       url,
+		receive:   make(chan []byte),
+		boot:      new(sync.RWMutex),
+		sleeper:   utils.NewBackoffSleeper(),
+		status:    ConnectionStatusDisconnected,
+		accessKey: accessKey,
+		secret:    secret,
+		logging:   logging,
 	}
 }
 
@@ -130,12 +123,13 @@ func (ec *explorerClient) Start() error {
 		return nil
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	ec.cancel = cancel
+	ec.done = make(chan struct{})
+
 	wg := &sync.WaitGroup{}
 	wg.Add(1)
-	go ec.connectAndWritePump(ctx, wg)
+	go ec.connectAndWritePump(wg)
 	wg.Wait()
+
 	ec.started = true
 	return nil
 }
@@ -233,42 +227,39 @@ const (
 // Inspired by https://github.com/gorilla/websocket/blob/master/examples/chat/client.go
 // lexical confinement of done chan allows multiple connectAndWritePump routines
 // to clean up independent of itself by reducing shared state. i.e. a passed done, not ec.done.
-func (ec *explorerClient) connectAndWritePump(parentCtx context.Context, wg *sync.WaitGroup) {
-	doneWaiting := false
-	logger.Infow("Connecting to explorer", "url", ec.url)
-
+func (ec *explorerClient) connectAndWritePump(wg *sync.WaitGroup) {
+	var doneOnce sync.Once
+	defer doneOnce.Do(wg.Done)
 	for {
 		select {
-		case <-parentCtx.Done():
-			if !doneWaiting {
-				wg.Done()
-			}
-			return
 		case <-time.After(ec.sleeper.After()):
-			connectionCtx, cancel := context.WithCancel(parentCtx)
+			ctx, cancel := utils.ContextFromChan(ec.done)
 			defer cancel()
 
-			if err := ec.connect(connectionCtx); err != nil {
+			logger.Infow("Connecting to explorer", "url", ec.url)
+			err := ec.connect(ctx)
+			if ctx.Err() != nil {
+				return
+			} else if err != nil {
+				doneOnce.Do(wg.Done)
 				ec.setStatus(ConnectionStatusError)
-				if !doneWaiting {
-					wg.Done()
-				}
 				logger.Warn("Failed to connect to explorer (", ec.url.String(), "): ", err)
 				break
 			}
 
+			ec.sendText = make(chan []byte, SendBufferSize)
+			ec.sendBinary = make(chan []byte, SendBufferSize)
 			ec.setStatus(ConnectionStatusConnected)
 
-			if !doneWaiting {
-				wg.Done()
-			}
+			doneOnce.Do(wg.Done)
 			logger.Infow("Connected to explorer", "url", ec.url)
 			ec.sleeper.Reset()
-			go ec.readPump(cancel)
-			ec.writePump(connectionCtx)
-		}
+			go ec.readPump()
+			ec.writePump()
 
-		doneWaiting = true
+		case <-ec.done:
+			return
+		}
 	}
 }
 
@@ -279,16 +270,15 @@ func (ec *explorerClient) setStatus(s ConnectionStatus) {
 }
 
 // Inspired by https://github.com/gorilla/websocket/blob/master/examples/chat/client.go#L82
-func (ec *explorerClient) writePump(ctx context.Context) {
+func (ec *explorerClient) writePump() {
 	ticker := time.NewTicker(pingPeriod)
 	defer func() {
 		ticker.Stop()
 		ec.wrapConnErrorIf(ec.conn.Close()) // exclusive responsibility to close ws conn
 	}()
+
 	for {
 		select {
-		case <-ctx.Done():
-			return
 		case message, open := <-ec.sendText:
 			if !open {
 				ec.wrapConnErrorIf(ec.conn.WriteMessage(websocket.CloseMessage, []byte{}))
@@ -299,6 +289,7 @@ func (ec *explorerClient) writePump(ctx context.Context) {
 				logger.Warnw("websocketStatsPusher: error writing text message", "err", err)
 				return
 			}
+
 		case message, open := <-ec.sendBinary:
 			if !open {
 				ec.wrapConnErrorIf(ec.conn.WriteMessage(websocket.CloseMessage, []byte{}))
@@ -309,12 +300,16 @@ func (ec *explorerClient) writePump(ctx context.Context) {
 				logger.Warnw("websocketStatsPusher: error writing binary message", "err", err)
 				return
 			}
+
 		case <-ticker.C:
 			ec.wrapConnErrorIf(ec.conn.SetWriteDeadline(time.Now().Add(writeWait)))
 			if err := ec.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
 				ec.wrapConnErrorIf(err)
 				return
 			}
+
+		case <-ec.done:
+			return
 		}
 	}
 }
@@ -344,7 +339,9 @@ func (ec *explorerClient) connect(ctx context.Context) error {
 	authHeader.Add("X-Explore-Chainlink-Core-Sha", static.Sha)
 
 	conn, _, err := websocket.DefaultDialer.DialContext(ctx, ec.url.String(), authHeader)
-	if err != nil {
+	if ctx.Err() != nil {
+		return fmt.Errorf("websocketStatsPusher#connect context canceled: %v", ctx.Err())
+	} else if err != nil {
 		return fmt.Errorf("websocketStatsPusher#connect: %v", err)
 	}
 
@@ -362,9 +359,7 @@ const CloseTimeout = 100 * time.Millisecond
 // For more details on how disconnection messages are handled, see:
 //  * https://stackoverflow.com/a/48181794/639773
 //  * https://github.com/gorilla/websocket/blob/master/examples/chat/client.go#L56
-func (ec *explorerClient) readPump(cancel context.CancelFunc) {
-	defer cancel()
-
+func (ec *explorerClient) readPump() {
 	ec.conn.SetReadLimit(maxMessageSize)
 	_ = ec.conn.SetReadDeadline(time.Now().Add(pongWait))
 	ec.conn.SetPongHandler(func(string) error {
@@ -376,14 +371,10 @@ func (ec *explorerClient) readPump(cancel context.CancelFunc) {
 		messageType, message, err := ec.conn.ReadMessage()
 		if err != nil {
 			if websocket.IsUnexpectedCloseError(err, expectedCloseMessages...) {
-				logger.Warn(fmt.Sprintf("readPump: %v", err))
+				logger.Warnw("Unexpected close error on ExplorerClient", "err", err)
 			}
-			select {
-			case <-ec.closeRequested:
-				ec.closed <- struct{}{}
-			case <-time.After(CloseTimeout):
-				logger.Warn("websocket readPump failed to notify closer")
-			}
+			close(ec.sendText)
+			close(ec.sendBinary)
 			return
 		}
 
@@ -405,15 +396,12 @@ func (ec *explorerClient) Close() error {
 	ec.boot.Lock()
 	defer ec.boot.Unlock()
 
-	if ec.started {
-		ec.cancel()
+	if !ec.started {
+		return nil
 	}
+
 	ec.started = false
-	select {
-	case ec.closeRequested <- struct{}{}:
-		<-ec.closed
-	case <-time.After(CloseTimeout):
-		logger.Warn("websocketClient.Close failed to be notified from readPump")
-	}
+	close(ec.done)
+
 	return nil
 }

--- a/core/services/synchronization/explorer_client_test.go
+++ b/core/services/synchronization/explorer_client_test.go
@@ -1,6 +1,7 @@
 package synchronization_test
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -85,7 +86,7 @@ func TestWebSocketClient_Send_DefaultsToTextMessage(t *testing.T) {
 	defer explorerClient.Close()
 
 	expectation := `{"hello": "world"}`
-	explorerClient.Send([]byte(expectation))
+	explorerClient.Send(context.Background(), []byte(expectation))
 	cltest.CallbackOrTimeout(t, "receive stats", func() {
 		require.Equal(t, expectation, <-wsserver.ReceivedText)
 	})
@@ -100,7 +101,7 @@ func TestWebSocketClient_Send_TextMessage(t *testing.T) {
 	defer explorerClient.Close()
 
 	expectation := `{"hello": "world"}`
-	explorerClient.Send([]byte(expectation), synchronization.ExplorerTextMessage)
+	explorerClient.Send(context.Background(), []byte(expectation), synchronization.ExplorerTextMessage)
 	cltest.CallbackOrTimeout(t, "receive stats", func() {
 		require.Equal(t, expectation, <-wsserver.ReceivedText)
 	})
@@ -116,7 +117,7 @@ func TestWebSocketClient_Send_Binary(t *testing.T) {
 
 	address := common.HexToAddress("0xabc123")
 	addressBytes := address.Bytes()
-	explorerClient.Send(addressBytes, synchronization.ExplorerBinaryMessage)
+	explorerClient.Send(context.Background(), addressBytes, synchronization.ExplorerBinaryMessage)
 	cltest.CallbackOrTimeout(t, "receive stats", func() {
 		require.Equal(t, addressBytes, <-wsserver.ReceivedBinary)
 	})
@@ -131,7 +132,7 @@ func TestWebSocketClient_Send_Unsupported(t *testing.T) {
 	defer explorerClient.Close()
 
 	assert.PanicsWithValue(t, "send on explorer client received unsupported message type -1", func() {
-		explorerClient.Send([]byte(`{"hello": "world"}`), -1)
+		explorerClient.Send(context.Background(), []byte(`{"hello": "world"}`), -1)
 	})
 }
 
@@ -144,7 +145,7 @@ func TestWebSocketClient_Send_WithAck(t *testing.T) {
 	defer explorerClient.Close()
 
 	expectation := `{"hello": "world"}`
-	explorerClient.Send([]byte(expectation))
+	explorerClient.Send(context.Background(), []byte(expectation))
 	cltest.CallbackOrTimeout(t, "receive stats", func() {
 		require.Equal(t, expectation, <-wsserver.ReceivedText)
 		err := wsserver.Broadcast(`{"result": 200}`)
@@ -152,7 +153,7 @@ func TestWebSocketClient_Send_WithAck(t *testing.T) {
 	})
 
 	cltest.CallbackOrTimeout(t, "receive response", func() {
-		response, err := explorerClient.Receive()
+		response, err := explorerClient.Receive(context.Background())
 		assert.NoError(t, err)
 		assert.NotNil(t, response)
 	})
@@ -167,13 +168,13 @@ func TestWebSocketClient_Send_WithAckTimeout(t *testing.T) {
 	defer explorerClient.Close()
 
 	expectation := `{"hello": "world"}`
-	explorerClient.Send([]byte(expectation))
+	explorerClient.Send(context.Background(), []byte(expectation))
 	cltest.CallbackOrTimeout(t, "receive stats", func() {
 		require.Equal(t, expectation, <-wsserver.ReceivedText)
 	})
 
 	cltest.CallbackOrTimeout(t, "receive response", func() {
-		_, err := explorerClient.Receive(100 * time.Millisecond)
+		_, err := explorerClient.Receive(context.Background(), 100*time.Millisecond)
 		assert.Error(t, err)
 		assert.Equal(t, err, synchronization.ErrReceiveTimeout)
 	}, 300*time.Millisecond)

--- a/core/services/synchronization/explorer_client_test.go
+++ b/core/services/synchronization/explorer_client_test.go
@@ -55,7 +55,7 @@ func TestWebSocketClient_ReconnectLoop(t *testing.T) {
 }
 
 func TestWebSocketClient_Authentication(t *testing.T) {
-	headerChannel := make(chan http.Header)
+	headerChannel := make(chan http.Header, 1)
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		headerChannel <- r.Header
 	}

--- a/core/services/telemetry/telemetry.go
+++ b/core/services/telemetry/telemetry.go
@@ -1,6 +1,10 @@
 package telemetry
 
-import "github.com/smartcontractkit/chainlink/core/services/synchronization"
+import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink/core/services/synchronization"
+)
 
 type Agent struct {
 	explorerClient synchronization.ExplorerClient
@@ -14,5 +18,5 @@ func NewAgent(explorerClient synchronization.ExplorerClient) *Agent {
 
 // SendLog sends a telemetry log to the explorer
 func (t *Agent) SendLog(log []byte) {
-	t.explorerClient.Send(log, synchronization.ExplorerBinaryMessage)
+	t.explorerClient.Send(context.Background(), log, synchronization.ExplorerBinaryMessage)
 }


### PR DESCRIPTION
The StatsPusher tests are very slow, this should speed them up a bit...

Before:
ok  	github.com/smartcontractkit/chainlink/core/services/synchronization	79.264s

After: (ctx first step)
ok  	github.com/smartcontractkit/chainlink/core/services/synchronization	52.237s

Before: -run Auth
ok      github.com/smartcontractkit/chainlink/core/services/synchronization     45.389s

After: (Start() optimization) -run Auth
ok      github.com/smartcontractkit/chainlink/core/services/synchronization     0.386s

final: 
ok  	github.com/smartcontractkit/chainlink/core/services/synchronization	8.971s