### PR TITLE
Don't wait for I/O on Explorer Start()

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,8 @@ Periodic resending can be controlled using the `ETH_TX_RESEND_AFTER_THRESHOLD` e
 
 ### Fixed
 
+- Under certain circumstances a poorly configured Explorer could delay Chainlink node startup by up to 45 seconds.
+
 - Chainlink node now automatically sets the correct nonce on startup if you are restoring from a previous backup (manual setnextnonce is no longer necessary).
 
 - Flux monitor jobs should now work correctly with [outlier-detection](https://github.com/smartcontractkit/external-adapters-js/tree/develop/composite/outlier-detection) and [market-closure](https://github.com/smartcontractkit/external-adapters-js/tree/develop/composite/market-closure) external adapters.


### PR DESCRIPTION
The Explorer Client startup loop tries to connect, and waits for a result from the connect at Startup.
I believe this Start blocks Application startup.
So in the worst case, this could block chainlink by up to 45 seconds before it can process jobs.