### PR TITLE
Reduce tx timeout in eth_confirmer and fix resend logic

### DIFF
--- a/core/services/bulletprooftxmanager/eth_confirmer.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer.go
@@ -851,7 +851,9 @@ func saveSentAttempt(db *gorm.DB, attempt *models.EthTxAttempt, broadcastAt time
 		return errors.New("expected state to be in_progress")
 	}
 	attempt.State = models.EthTxAttemptBroadcast
-	return postgres.GormTransaction(context.Background(), db, func(tx *gorm.DB) error {
+	ctx, cancel := postgres.DefaultQueryCtx()
+	defer cancel()
+	return postgres.GormTransaction(ctx, db, func(tx *gorm.DB) error {
 		// In case of null broadcast_at (shouldn't happen) we don't want to
 		// update anyway because it indicates a state where broadcast_at makes
 		// no sense e.g. fatal_error
@@ -867,7 +869,9 @@ func saveInsufficientEthAttempt(db *gorm.DB, attempt *models.EthTxAttempt, broad
 		return errors.New("expected state to be either in_progress or insufficient_eth")
 	}
 	attempt.State = models.EthTxAttemptInsufficientEth
-	return postgres.GormTransaction(context.Background(), db, func(tx *gorm.DB) error {
+	ctx, cancel := postgres.DefaultQueryCtx()
+	defer cancel()
+	return postgres.GormTransaction(ctx, db, func(tx *gorm.DB) error {
 		// In case of null broadcast_at (shouldn't happen) we don't want to
 		// update anyway because it indicates a state where broadcast_at makes
 		// no sense e.g. fatal_error


### PR DESCRIPTION
TX TIMEOUT:

We have seen this hit the hard limit (3600s) in prod. It would never
make any sense to wait that long. Reduce the timeout here in the hopes
that if it happens again at least we fail fast enough to get some useful
debugging information.

RESEND LOGIC:

Most requests will always error since the node already knows about them, we ought to update broadcast_at regardless.