### PR TITLE
Publish new @chainlink/contracts version

### DIFF
--- a/evm-contracts/README.md
+++ b/evm-contracts/README.md
@@ -34,22 +34,26 @@ contracts
 │   ├── v0.4
 │   ├── v0.5
 │   ├── v0.6
-│   └── v0.7
+│   ├── v0.7
+│   └── v0.8
 ├── ethers # ethers contract abstractions codegenned from abis
 │   ├── v0.4
 │   ├── v0.5
 │   ├── v0.6
-│   └── v0.7
+│   ├── v0.7
+│   └── v0.8
 ├── src # the contracts themselves, in .sol form
 │   ├── v0.4
 │   ├── v0.5
 │   ├── v0.6
-│   └── v0.7
+│   ├── v0.7
+│   └── v0.8
 └── truffle  # truffle contract abstractions codegenned from abis
     ├── v0.4
     ├── v0.5
     ├── v0.6
-    └── v0.7
+    ├── v0.7
+    └── v0.8
 ```
 
 ## Usage

--- a/evm-contracts/package.json
+++ b/evm-contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/contracts",
-  "version": "0.1.6",
+  "version": "0.1.7",
   "description": "Smart contracts and their language abstractions for chainlink",
   "repository": "https://github.com/smartcontractkit/chainlink",
   "author": "Chainlink devs",


### PR DESCRIPTION
Contract changes:
- Solidity code styling for all versions 0.6 and above
- v0.7 VRFConsumerBase
- v0.8
  - ChainlinkClient
  - AggregatorInterfaces
  - VRFConsumerBase
- MockOracle testing contract