### PR TITLE
Trim whitespace from search term before filtering in UI Jobs

### DIFF
--- a/operator_ui/src/pages/JobsIndex/JobsIndex.test.tsx
+++ b/operator_ui/src/pages/JobsIndex/JobsIndex.test.tsx
@@ -120,7 +120,7 @@ describe('pages/JobsIndex/JobsIndex', () => {
 
     wrapper
       .find('input[name="search"]')
-      .simulate('change', { target: { value: 'web' } })
+      .simulate('change', { target: { value: 'web   ' } }) // Tests trimming whitespace as well
 
     expect(wrapper.find('tbody').children().length).toEqual(1)
   })

--- a/operator_ui/src/pages/JobsIndex/JobsIndex.tsx
+++ b/operator_ui/src/pages/JobsIndex/JobsIndex.tsx
@@ -281,7 +281,9 @@ export const JobsIndex = ({
     document.title = 'Jobs'
   }, [])
 
-  const jobFilter = React.useMemo(() => simpleJobFilter(search), [search])
+  const jobFilter = React.useMemo(() => simpleJobFilter(search.trim()), [
+    search,
+  ])
 
   useEffect(() => {
     getJobs().then(setJobs).catch(setError)


### PR DESCRIPTION
Whitespace at the start and end of the search term would cause jobs to not match