### PR TITLE
Db backups - install CLI tools in docker, fix debug log

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -64,7 +64,15 @@ FROM ubuntu:18.04
 
 ARG CHAINLINK_USER=root
 ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y ca-certificates
+RUN apt-get update && apt-get install -y ca-certificates wget gnupg lsb-release
+
+# Install Postgres for CLI tools, needed specifically for DB backups
+RUN wget --quiet -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
+ && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+ && echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" |tee /etc/apt/sources.list.d/pgdg.list \
+ && apt-get update && apt-get install -y postgresql-client-13 \
+ && apt-get clean all
+
 COPY --from=1 /go/bin/chainlink /usr/local/bin/
 
 RUN if [ ${CHAINLINK_USER} != root ]; then \


### PR DESCRIPTION
Node operators are usually running chainlink in docker, so the image needs the postgres CLI tools installed - pg_dump is among them.

Also, debug log was not redacting the postgres url