### PR TITLE
Correct the link to the initial operator-ui credentials

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -28,7 +28,7 @@ Acceptance can be accomplished by using the `acceptance` command.
 - The explorer can be reached at `http://localhost:8080`
 - The chainlink node can be reached at `http://localhost:6688`
 
-Credentials for logging into the operator-ui can be found [here](../../core/internals/fixtures/apicredentials)
+Credentials for logging into the operator-ui can be found [here](../../tools/secrets/apicredentials)
 
 ###
 


### PR DESCRIPTION
The current [link](https://github.com/smartcontractkit/chainlink/blob/develop/core/internals/fixtures/apicredentials) in the docker-compose documentation leads to a 404  (page not found) error.