### PR TITLE
Account for 'in_progress' eth_tx and simplify NonceSyncer

### DIFF
--- a/core/services/bulletprooftxmanager/eth_broadcaster_test.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster_test.go
@@ -281,7 +281,6 @@ func TestEthBroadcaster_AssignsNonceOnStart(t *testing.T) {
 		ethClient.On("PendingNonceAt", mock.Anything, mock.MatchedBy(func(account gethCommon.Address) bool {
 			return account.Hex() == fromAddress.Hex()
 		})).Return(ethNodeNonce, nil).Once()
-		ethClient.On("BatchCallContext", mock.Anything, mock.Anything).Return(nil)
 
 		require.NoError(t, eb.Start())
 		defer eb.Close()
@@ -299,7 +298,6 @@ func TestEthBroadcaster_AssignsNonceOnStart(t *testing.T) {
 		require.Equal(t, dummykey.Address, key2.Address)
 		require.Equal(t, 0, int(key2.NextNonce))
 
-		// TODO: Test for zero transaction insertion
 		ethClient.AssertExpectations(t)
 	})
 }

--- a/core/services/bulletprooftxmanager/nonce_syncer.go
+++ b/core/services/bulletprooftxmanager/nonce_syncer.go
@@ -1,28 +1,20 @@
 package bulletprooftxmanager
 
 import (
-	"bytes"
 	"context"
 	"fmt"
-	"sort"
 	"sync"
 	"time"
 
-	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/pkg/errors"
-	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/eth"
 	"github.com/smartcontractkit/chainlink/core/services/postgres"
 	"github.com/smartcontractkit/chainlink/core/store"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/store/orm"
-	"github.com/smartcontractkit/chainlink/core/utils"
 	"go.uber.org/multierr"
-	"gorm.io/gorm"
 )
 
 type (
@@ -118,149 +110,52 @@ func (s NonceSyncer) fastForwardNonceIfNecessary(ctx context.Context, address co
 		return nil
 	}
 
-	localNonce, err := GetNextNonce(s.store.DB, address)
+	selectCtx, cancel := postgres.DefaultQueryCtx()
+	defer cancel()
+	keyNextNonce, err := GetNextNonce(s.store.DB.WithContext(selectCtx), address)
 	if err != nil {
 		return err
+	}
+
+	localNonce := keyNextNonce
+	hasInProgressTransaction, err := s.hasInProgressTransaction(address)
+	if err != nil {
+		return errors.Wrapf(err, "failed to query for in_progress transaction for address %s", address.Hex())
+	} else if hasInProgressTransaction {
+		// If we have an 'in_progress' transacion, our keys.next_nonce will be
+		// one lower than it should because we must have crashed mid-execution.
+		// The EthBroadcaster will automatically take care of this and
+		// increment it by one later, for now we just increment by one here.
+		localNonce++
 	}
 	if chainNonce <= uint64(localNonce) {
 		return nil
 	}
 	logger.Warnw(fmt.Sprintf("NonceSyncer: address %s has been used before, either by an external wallet or a different Chainlink node. "+
 		"Local nonce is %v but the on-chain nonce for this account was %v. "+
+		"It's possible that this node was restored from a backup. If so, transactions sent by the previous node will NOT be re-org protected and in rare cases may need to be manually bumped/resubmitted"+
 		"Please note that using the chainlink keys with an external wallet is NOT SUPPORTED and can lead to missed or stuck transactions. "+
-		"This Chainlink node will now take ownership of this address and may overwrite currently pending transactions",
 		address.Hex(), localNonce, chainNonce),
-		"address", address.Hex(), "localNonce", localNonce, "chainNonce", chainNonce)
+		"address", address.Hex(), "keyNextNonce", keyNextNonce, "localNonce", localNonce, "chainNonce", chainNonce)
 
-	// First fetch
-	//
-	// We have to get the latest block first and then fetch deeper blocks in a
-	// subsequent step, because otherwise we don't know what block numbers to
-	// query for.
-	// pending can be fetched in the initial request because it doesn't rely on
-	// any block number.
-	reqs := []rpc.BatchElem{
-		rpc.BatchElem{
-			Method: "eth_getBlockByNumber",
-			Args:   []interface{}{"pending", true},
-			Result: &models.Block{},
-		},
-		rpc.BatchElem{
-			Method: "eth_getBlockByNumber",
-			Args:   []interface{}{"latest", true},
-			Result: &models.Block{},
-		},
+	updateCtx, cancel := postgres.DefaultQueryCtx()
+	defer cancel()
+
+	// Need to remember to decrement the chain nonce by one to account for in_progress transaction
+	newNextNonce := chainNonce
+	if hasInProgressTransaction {
+		newNextNonce--
 	}
-
-	err = s.ethClient.BatchCallContext(ctx, reqs)
-	if err != nil {
-		return err
+	//  We pass in next_nonce here as an optimistic lock to make sure it
+	//  didn't get changed out from under us. Shouldn't happen but can't hurt.
+	res := s.store.DB.WithContext(updateCtx).Exec(`UPDATE keys SET next_nonce = ?, updated_at = ? WHERE address = ? AND next_nonce = ?`, newNextNonce, time.Now(), address, keyNextNonce)
+	if res.Error != nil {
+		return errors.Wrap(res.Error, "NonceSyncer#fastForwardNonceIfNecessary failed to update keys.next_nonce")
 	}
-
-	if reqs[1].Error != nil {
-		return errors.Wrap(reqs[1].Error, "latest block request returned error")
+	if res.RowsAffected == 0 {
+		return errors.Errorf("NonceSyncer#fastForwardNonceIfNecessary optimistic lock failure fastforwarding nonce %v to %v for key %s", localNonce, chainNonce, address.Hex())
 	}
-	latestBlock, is := reqs[1].Result.(*models.Block)
-	if !is {
-		panic(fmt.Sprintf("invariant violation, expected %T but got %T", &models.Block{}, latestBlock))
-	}
-	latestBlockNum := latestBlock.Number
-
-	floor := latestBlockNum - int64(s.config.EthFinalityDepth())
-	if floor < 0 {
-		floor = 0
-	}
-
-	// Second fetch
-	//
-	// OPTIMISATION NOTE:
-	// The astute observer will note that if multiple keys are behind, we fetch
-	// the same blocks multiple times, doing redundant extra work. This does
-	// put unnecessary load on the eth node, but the most common use-case is
-	// with a single key and given how rare this scenario is, I think we can
-	// live with it.
-	var reqs2 []rpc.BatchElem
-	for i := floor; i < latestBlockNum; i++ {
-		req := rpc.BatchElem{
-			Method: "eth_getBlockByNumber",
-			Args:   []interface{}{models.Int64ToHex(i), true},
-			Result: &models.Block{},
-		}
-		reqs2 = append(reqs2, req)
-	}
-
-	err = s.ethClient.BatchCallContext(ctx, reqs2)
-	if err != nil {
-		return err
-	}
-
-	reqs = append(reqs, reqs2...)
-	var txes []types.Transaction
-	signer := types.NewEIP155Signer(s.config.ChainID())
-
-	// Rip through all transactions in all blocks and keep only the ones sent
-	// from our key
-	for _, req := range reqs {
-		if req.Error != nil {
-			logger.Warnw("NonceSyncer: got error querying for block", "blockNum", req.Args[0], "err", req.Error)
-			continue
-		}
-		block, is := req.Result.(*models.Block)
-		if !is {
-			panic(fmt.Sprintf("invariant violation, expected %T but got %T", &models.Block{}, block))
-		}
-		for _, tx := range block.Transactions {
-			from, err2 := types.Sender(signer, &tx)
-			if err2 != nil {
-				logger.Warnw("NonceSyncer#fastForwardNonceIfNecessary failed to extract 'from' from transaction", "tx", tx, "err", err2)
-				continue
-			}
-			if from == address {
-				txes = append(txes, tx)
-			}
-		}
-	}
-
-	account, err := s.store.KeyStore.GetAccountByAddress(address)
-	if err != nil {
-		return errors.Wrap(err, "NonceSyncer#fastForwardNonceIfNecessary could not get account from keystore")
-	}
-	sort.Slice(txes, func(i, j int) bool { return txes[i].Nonce() < txes[j].Nonce() })
-
-	inserts, err := s.makeInserts(account, latestBlock.Number, txes, chainNonce-1)
-	if err != nil {
-		return errors.Wrap(err, "NonceSyncer#fastForwardNonceIfNecessary error generating transactions for backfill")
-	}
-
-	now := time.Now()
-	return postgres.GormTransaction(ctx, s.store.DB, func(dbtx *gorm.DB) error {
-		//  We pass in next_nonce here as an optimistic lock to make sure it
-		//  didn't get changed out from under us
-		res := dbtx.Exec(`UPDATE keys SET next_nonce = ?, updated_at = ? WHERE address = ? AND next_nonce = ?`, chainNonce, now, address, localNonce)
-		if res.Error != nil {
-			return errors.Wrap(res.Error, "NonceSyncer#fastForwardNonceIfNecessary failed to update keys.next_nonce")
-		}
-		if res.RowsAffected == 0 {
-			return errors.Errorf("NonceSyncer#fastForwardNonceIfNecessary optimistic lock failure fastforwarding nonce %v to %v for key %s", localNonce, chainNonce, address.Hex())
-		}
-
-		for _, ins := range inserts {
-			// Setting broadcast_at here is a bit of a misnomer since this node
-			// didn't actually broadcast the transaction, but including it
-			// allows us to avoid changing the state machine limitations and
-			// represents roughly the time we read the tx from the blockchain
-			// so we can pretty much assume it was "broadcast" at this time.
-			ins.Etx.BroadcastAt = &now
-			if err := dbtx.Create(&ins.Etx).Error; err != nil {
-				return errors.Wrap(err, "NonceSyncer#fastForwardNonceIfNecessary failed to create eth_tx")
-			}
-			ins.Attempt.EthTxID = ins.Etx.ID
-			if err := dbtx.Create(&ins.Attempt).Error; err != nil {
-				return errors.Wrap(err, "NonceSyncer#fastForwardNonceIfNecessary failed to create eth_tx_attempt")
-			}
-		}
-		return nil
-	})
+	return nil
 }
 
 func (s NonceSyncer) pendingNonceFromEthClient(ctx context.Context, account common.Address) (nextNonce uint64, err error) {
@@ -270,137 +165,7 @@ func (s NonceSyncer) pendingNonceFromEthClient(ctx context.Context, account comm
 	return nextNonce, errors.WithStack(err)
 }
 
-func (s NonceSyncer) makeInserts(acct accounts.Account, blockNum int64, txes []types.Transaction, toNonce uint64) (inserts []NSinserttx, err error) {
-	if len(txes) == 0 {
-		return
-	}
-	if !sort.SliceIsSorted(txes, func(i, j int) bool { return txes[i].Nonce() < txes[j].Nonce() }) {
-		return nil, errors.New("expected txes to be sorted in nonce ascending order")
-	}
-	fromNonce := txes[0].Nonce()
-	if fromNonce > toNonce {
-		// I don't know how this could ever happen but we should handle the case anyway
-		return nil, errors.Errorf("fromNonce of %v was greater than toNonce of %v", fromNonce, toNonce)
-	}
-	txMap := make(map[uint64]types.Transaction)
-	for _, tx := range txes {
-		txMap[tx.Nonce()] = tx
-	}
-	for n := fromNonce; n <= toNonce; n++ {
-		nonce := int64(n)
-		tx, exists := txMap[n]
-		if exists {
-			ins, err := s.MakeInsert(tx, acct, blockNum, nonce)
-			if err != nil {
-				logger.Errorw("NonceSyncer: failed to generate transaction, this nonce will not be re-org protected", "address", acct.Address.Hex(), "err", err, "nonce", nonce)
-				continue
-			}
-			inserts = append(inserts, ins)
-		} else {
-			// Use a zero-transaction if its missing for whatever reason
-			// Should really never happen but you never know with geth
-			logger.Warnw(fmt.Sprintf("NonceSyncer: missing transaction for nonce %d, falling back to zero transaction", n), "address", acct.Address.Hex(), "blockNum", blockNum, "nonce", nonce)
-			ins, err := s.MakeZeroInsert(acct, blockNum, nonce)
-			if err != nil {
-				logger.Errorw("NonceSyncer: failed to generate empty transaction, this nonce will not be re-org protected", "address", acct.Address.Hex(), "err", err, "nonce", nonce)
-				continue
-			}
-			inserts = append(inserts, ins)
-		}
-	}
-
-	return inserts, nil
-}
-
-// MakeInsert generates a NSinserttx that perfectly mirrors the on-chain transaction
-//
-// This can be handed off to the EthConfirmer and used to query for receipts
-// and bump gas etc exactly like any other transaction we might have sent.
-func (s NonceSyncer) MakeInsert(tx types.Transaction, acct accounts.Account, blockNum, nonce int64) (ins NSinserttx, err error) {
-	v, _, _ := tx.RawSignatureValues()
-	if v.BitLen() == 0 {
-		// Believe it or not, this is the only way to determine if the tx
-		// is a zero struct without panicking. Thank you, geth.
-		logger.Warnw("NonceSyncer: tx was empty/unsigned. Falling back to zero transaction", "err", err, "txHash", tx.Hash(), "nonce", nonce, "address", acct.Address.Hex())
-		return s.MakeZeroInsert(acct, blockNum, int64(nonce))
-	}
-	// NOTE: We set all transactions to unconfirmed even if they are mined.
-	//
-	// This works out, because the first round of the EthConfirmer will check
-	// for receipts. All these transactions should get receipts if they are confirmed.
-	//
-	// Any transaction not yet confirmed will go into the regular gas bumping
-	// cycle as if it were any normal transaction we had sent ourselves.
-	ins.Etx = models.EthTx{
-		Nonce:          &nonce,
-		FromAddress:    acct.Address,
-		ToAddress:      *tx.To(),
-		EncodedPayload: tx.Data(),
-		Value:          assets.Eth(*tx.Value()),
-		GasLimit:       tx.Gas(),
-		State:          models.EthTxUnconfirmed,
-	}
-	rlp := new(bytes.Buffer)
-	if err := tx.EncodeRLP(rlp); err != nil {
-		logger.Warnw("NonceSyncer: could not encode RLP. Falling back to zero transaction", "err", err, "txHash", tx.Hash(), "nonce", nonce, "address", acct.Address.Hex())
-		return s.MakeZeroInsert(acct, blockNum, int64(nonce))
-	}
-	signedRawTx := rlp.Bytes()
-	ins.Attempt = models.EthTxAttempt{
-		GasPrice:                utils.Big(*tx.GasPrice()),
-		SignedRawTx:             signedRawTx,
-		Hash:                    tx.Hash(),
-		BroadcastBeforeBlockNum: &blockNum,
-		State:                   models.EthTxAttemptBroadcast,
-	}
-
-	return ins, nil
-}
-
-// MakeZeroInsert generates a NSinserttx that represents a zero transaction
-//
-// This transaction will never get a receipt and does not match anything
-// on-chain, but it does serve the purpose of a placeholder for this nonce in
-// case the on-chain version is ejected from the mempool or re-org'd out of the
-// main chain.
-func (s NonceSyncer) MakeZeroInsert(acct accounts.Account, blockNum, nonce int64) (ins NSinserttx, err error) {
-	gasLimit := s.config.EthGasLimitDefault()
-	gasPrice := s.config.EthGasPriceDefault()
-
-	tx, err := makeEmptyTransaction(s.store.KeyStore, uint64(nonce), gasLimit, gasPrice, acct, s.config.ChainID())
-	if err != nil {
-		return ins, errors.Wrap(err, "NonceSyncer#MakeZeroInsert failed to makeEmptyTransaction")
-	}
-	rlp := new(bytes.Buffer)
-	if err := tx.EncodeRLP(rlp); err != nil {
-		return ins, err
-	}
-	// NOTE: These transactions will never get a receipt, but setting them to
-	// unconfirmed still works out.
-	//
-	// If there is a transaction on-chain with the same nonce that is pending,
-	// then this zero transaction will go into the bumping cycle and may or may
-	// not replace the on-chain version.
-	//
-	// If the on-chain transaction is confirmed, this one will eventually be
-	// marked confirmed_missing_receipt when a new transaction is confirmed on
-	// top of it, and will exit the bumping cycle once it's deeper than
-	// ETH_FINALITY_DEPTH.
-	ins.Etx = models.EthTx{
-		Nonce:          &nonce,
-		FromAddress:    acct.Address,
-		ToAddress:      *tx.To(),
-		EncodedPayload: tx.Data(),
-		Value:          assets.Eth(*tx.Value()),
-		GasLimit:       tx.Gas(),
-		State:          models.EthTxUnconfirmed,
-	}
-	ins.Attempt = models.EthTxAttempt{
-		GasPrice:                utils.Big(*gasPrice),
-		SignedRawTx:             rlp.Bytes(),
-		Hash:                    tx.Hash(),
-		BroadcastBeforeBlockNum: &blockNum,
-		State:                   models.EthTxAttemptBroadcast,
-	}
-	return ins, nil
+func (s NonceSyncer) hasInProgressTransaction(account common.Address) (exists bool, err error) {
+	err = s.store.DB.Raw(`SELECT EXISTS(SELECT 1 FROM eth_txes WHERE state = 'in_progress' AND from_address = ?)`, account).Scan(&exists).Error
+	return
 }

--- a/core/services/bulletprooftxmanager/nonce_syncer_test.go
+++ b/core/services/bulletprooftxmanager/nonce_syncer_test.go
@@ -1,17 +1,11 @@
 package bulletprooftxmanager_test
 
 import (
-	"bytes"
 	"context"
-	"math/big"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/accounts"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/pkg/errors"
-	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
 	"github.com/smartcontractkit/chainlink/core/services/bulletprooftxmanager"
@@ -96,40 +90,13 @@ func Test_NonceSyncer_SyncAll(t *testing.T) {
 		ethClient.AssertExpectations(t)
 	})
 
-	t.Run("fast forwards if chain nonce is ahead of local nonce and fills in recent transactions", func(t *testing.T) {
+	t.Run("fast forwards if chain nonce is ahead of local nonce", func(t *testing.T) {
 		store, cleanup := cltest.NewStore(t)
 		defer cleanup()
 		ethClient := new(mocks.Client)
 
 		_, acct1 := cltest.MustAddRandomKeyToKeystore(t, store, int64(0))
 		_, acct2 := cltest.MustAddRandomKeyToKeystore(t, store, int64(32))
-
-		accounts := store.KeyStore.Accounts()
-		txes := makeRandomTransactions(t, store, 5, accounts, store.Config.ChainID())
-
-		bPending := models.Block{
-			Number:       0,
-			Transactions: txes[4:],
-		}
-
-		b2 := models.Block{
-			Number:       2,
-			Hash:         cltest.NewHash(),
-			ParentHash:   cltest.NewHash(),
-			Transactions: txes[0:1],
-		}
-		b41 := models.Block{
-			Number:       41,
-			Hash:         cltest.NewHash(),
-			ParentHash:   cltest.NewHash(),
-			Transactions: txes[2:3],
-		}
-		bLatest := models.Block{
-			Number:       42,
-			Hash:         cltest.NewHash(),
-			ParentHash:   b41.Hash,
-			Transactions: txes[3:4],
-		}
 
 		ethClient.On("PendingNonceAt", mock.Anything, mock.MatchedBy(func(addr common.Address) bool {
 			// Nothing to do for acct2
@@ -139,258 +106,50 @@ func Test_NonceSyncer_SyncAll(t *testing.T) {
 			// acct1 has chain nonce of 5 which is ahead of local nonce 0
 			return acct1 == addr
 		})).Return(uint64(5), nil)
-		ethClient.On("BatchCallContext", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {
-			return len(b) == 2 &&
-				b[0].Method == "eth_getBlockByNumber" && b[0].Args[0] == "pending" && b[0].Args[1] == true &&
-				b[1].Method == "eth_getBlockByNumber" && b[1].Args[0] == "latest" && b[1].Args[1] == true
-		})).Return(nil).Run(func(args mock.Arguments) {
-			elems := args.Get(1).([]rpc.BatchElem)
-			elems[0].Result = &bPending
-			elems[1].Result = &bLatest
-		})
-		ethClient.On("BatchCallContext", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {
-			return len(b) == 42 &&
-				b[0].Args[0] == models.Int64ToHex(0) &&
-				b[1].Args[0] == models.Int64ToHex(1) &&
-				b[41].Args[0] == models.Int64ToHex(41)
-		})).Return(nil).Run(func(args mock.Arguments) {
-			elems := args.Get(1).([]rpc.BatchElem)
-			elems[41].Result = &b41
-			elems[2].Result = &b2
-			elems[3].Error = errors.New("random error thrown in for fun")
-		})
 
 		ns := bulletprooftxmanager.NewNonceSyncer(store, store.Config, ethClient)
 
 		require.NoError(t, ns.SyncAll(context.Background()))
-
-		cltest.AssertCount(t, store, models.EthTx{}, 5)
-		cltest.AssertCount(t, store, models.EthTxAttempt{}, 5)
 
 		assertDatabaseNonce(t, store, acct1, 5)
 
 		ethClient.AssertExpectations(t)
 	})
 
-	t.Run("only backfills to ETH_FINALITY_DEPTH", func(t *testing.T) {
+	t.Run("counts 'in_progress' eth_tx as bumping the local next nonce by 1", func(t *testing.T) {
 		store, cleanup := cltest.NewStore(t)
 		defer cleanup()
-		ethClient := new(mocks.Client)
-
-		store.Config.Set("ETH_FINALITY_DEPTH", 2)
 
 		_, acct1 := cltest.MustAddRandomKeyToKeystore(t, store, int64(0))
 
-		accounts := store.KeyStore.Accounts()
-		txes := makeRandomTransactions(t, store, 5, accounts, store.Config.ChainID())
+		cltest.MustInsertInProgressEthTxWithAttempt(t, store, 1, acct1)
 
-		bPending := models.Block{
-			Number:       0,
-			Transactions: txes[4:],
-		}
-
-		b40 := models.Block{
-			Number:     41,
-			Hash:       cltest.NewHash(),
-			ParentHash: cltest.NewHash(),
-		}
-		b41 := models.Block{
-			Number:       41,
-			Hash:         cltest.NewHash(),
-			ParentHash:   b40.Hash,
-			Transactions: txes[2:3],
-		}
-		bLatest := models.Block{
-			Number:       42,
-			Hash:         cltest.NewHash(),
-			ParentHash:   b41.Hash,
-			Transactions: txes[3:4],
-		}
-
+		ethClient := new(mocks.Client)
 		ethClient.On("PendingNonceAt", mock.Anything, mock.MatchedBy(func(addr common.Address) bool {
-			// acct1 has chain nonce of 5 which is ahead of local nonce 0
+			// acct1 has chain nonce of 1 which is ahead of keys.next_nonce (0)
+			// by 1, but does not need to change when taking into account the in_progress tx
 			return acct1 == addr
-		})).Return(uint64(5), nil)
-		ethClient.On("BatchCallContext", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {
-			return len(b) == 2 &&
-				b[0].Method == "eth_getBlockByNumber" && b[0].Args[0] == "pending" && b[0].Args[1] == true &&
-				b[1].Method == "eth_getBlockByNumber" && b[1].Args[0] == "latest" && b[1].Args[1] == true
-		})).Return(nil).Run(func(args mock.Arguments) {
-			elems := args.Get(1).([]rpc.BatchElem)
-			elems[0].Result = &bPending
-			elems[1].Result = &bLatest
-		})
-		ethClient.On("BatchCallContext", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {
-			return len(b) == 2 &&
-				b[0].Method == "eth_getBlockByNumber" && b[0].Args[0] == models.Int64ToHex(40) &&
-				b[1].Method == "eth_getBlockByNumber" && b[1].Args[0] == models.Int64ToHex(41)
-		})).Return(nil).Run(func(args mock.Arguments) {
-			elems := args.Get(1).([]rpc.BatchElem)
-			elems[0].Result = &b40
-			elems[1].Result = &b41
-		})
-
+		})).Return(uint64(1), nil)
 		ns := bulletprooftxmanager.NewNonceSyncer(store, store.Config, ethClient)
 
 		require.NoError(t, ns.SyncAll(context.Background()))
+		assertDatabaseNonce(t, store, acct1, 0)
 
-		cltest.AssertCount(t, store, models.EthTx{}, 3)
-		cltest.AssertCount(t, store, models.EthTxAttempt{}, 3)
+		ethClient.AssertExpectations(t)
 
-		assertDatabaseNonce(t, store, acct1, 5)
+		ethClient = new(mocks.Client)
+		ethClient.On("PendingNonceAt", mock.Anything, mock.MatchedBy(func(addr common.Address) bool {
+			// acct1 has chain nonce of 2 which is ahead of keys.next_nonce (0)
+			// by 2, but only ahead by 1 if we count the in_progress tx as +1
+			return acct1 == addr
+		})).Return(uint64(2), nil)
+		ns = bulletprooftxmanager.NewNonceSyncer(store, store.Config, ethClient)
+
+		require.NoError(t, ns.SyncAll(context.Background()))
+		assertDatabaseNonce(t, store, acct1, 1)
 
 		ethClient.AssertExpectations(t)
 	})
-}
-
-func Test_NonceSyncer_MakeInsert(t *testing.T) {
-	t.Parallel()
-
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
-	ethClient := new(mocks.Client)
-
-	_, from := cltest.MustAddRandomKeyToKeystore(t, store)
-	acct := accounts.Account{Address: from}
-
-	kst := store.KeyStore
-	kst.Unlock(cltest.Password)
-
-	var blockNum int64 = 42
-	var nonce uint64 = 1
-	to := cltest.NewAddress()
-	amount := big.NewInt(4200)
-	var gasLimit uint64 = 120000
-	gasPrice := big.NewInt(25000000000)
-	data := cltest.MustRandomBytes(t, 72)
-	unsigned := types.NewTransaction(nonce, to, amount, gasLimit, gasPrice, data)
-
-	t.Run("falls back to zero insert if encodeRLP would fail for some reason, e.g. tx is zero struct", func(t *testing.T) {
-		ns := bulletprooftxmanager.NewNonceSyncer(store, store.Config, ethClient)
-
-		tx := types.NewTx(&types.LegacyTx{})
-
-		ins, err := ns.MakeInsert(*tx, acct, blockNum, int64(nonce))
-		require.NoError(t, err)
-
-		assertZero(t, ins, store, from, int64(nonce), blockNum)
-	})
-
-	t.Run("makes insert with the given payload", func(t *testing.T) {
-		tx, err := kst.SignTx(acct, unsigned, store.Config.ChainID())
-		require.NoError(t, err)
-
-		ns := bulletprooftxmanager.NewNonceSyncer(store, store.Config, ethClient)
-
-		ins, err := ns.MakeInsert(*tx, acct, blockNum, int64(nonce))
-		require.NoError(t, err)
-
-		assert.Equal(t, int64(0), ins.Etx.ID)
-		assert.Equal(t, int64(nonce), *ins.Etx.Nonce)
-		assert.Equal(t, from, ins.Etx.FromAddress)
-		assert.Equal(t, *tx.To(), ins.Etx.ToAddress)
-		assert.Equal(t, tx.Data(), ins.Etx.EncodedPayload)
-		assert.Equal(t, *amount, (big.Int)(ins.Etx.Value))
-		assert.Equal(t, tx.Gas(), ins.Etx.GasLimit)
-		assert.Nil(t, ins.Etx.Error)
-		assert.Nil(t, ins.Etx.BroadcastAt)
-		assert.Equal(t, models.EthTxUnconfirmed, ins.Etx.State)
-
-		rlp := new(bytes.Buffer)
-		require.NoError(t, tx.EncodeRLP(rlp))
-
-		assert.Equal(t, int64(0), ins.Attempt.ID)
-		assert.Equal(t, int64(0), ins.Attempt.EthTxID)
-		assert.Equal(t, tx.GasPrice().String(), ins.Attempt.GasPrice.String())
-		assert.Equal(t, rlp.Bytes(), ins.Attempt.SignedRawTx)
-		assert.NotEqual(t, common.Hash{}, ins.Attempt.Hash)
-		assert.NotNil(t, ins.Attempt.BroadcastBeforeBlockNum)
-		assert.Equal(t, blockNum, *ins.Attempt.BroadcastBeforeBlockNum)
-		assert.Equal(t, models.EthTxAttemptBroadcast, ins.Attempt.State)
-	})
-}
-
-func Test_NonceSyncer_MakeZeroInsert(t *testing.T) {
-	t.Parallel()
-
-	var blockNum int64 = 42
-	var nonce int64 = 1
-
-	t.Run("errors if keystore.SignTx errors", func(t *testing.T) {
-		store, cleanup := cltest.NewStore(t)
-		defer cleanup()
-		ethClient := new(mocks.Client)
-		kst := new(mocks.KeyStoreInterface)
-		store.KeyStore = kst
-		acct := accounts.Account{Address: cltest.NewAddress()}
-
-		kst.On("SignTx", acct, mock.Anything, store.Config.ChainID()).Return(nil, errors.New("something exploded"))
-
-		ns := bulletprooftxmanager.NewNonceSyncer(store, store.Config, ethClient)
-
-		_, err := ns.MakeZeroInsert(acct, blockNum, nonce)
-		assert.Error(t, err)
-		assert.Contains(t, err.Error(), "something exploded")
-	})
-
-	t.Run("returns insert with zero EthTx and Attempt", func(t *testing.T) {
-		store, cleanup := cltest.NewStore(t)
-		defer cleanup()
-		ethClient := new(mocks.Client)
-
-		_, from := cltest.MustAddRandomKeyToKeystore(t, store)
-		acct := accounts.Account{Address: from}
-
-		oldKst := store.KeyStore
-		oldKst.Unlock(cltest.Password)
-
-		kst := new(mocks.KeyStoreInterface)
-		store.KeyStore = kst
-
-		kst.On("SignTx", acct, mock.MatchedBy(func(tx *types.Transaction) bool {
-			return int64(tx.Nonce()) == nonce && *tx.To() == from && big.NewInt(0).Cmp(tx.Value()) == 0
-		}), store.Config.ChainID()).Return(
-			func(acct accounts.Account, unsigned *types.Transaction, chainID *big.Int) *types.Transaction {
-				signed, err := oldKst.SignTx(acct, unsigned, chainID)
-				if err != nil {
-					t.Fatal(err)
-				}
-				return signed
-			},
-			func(accounts.Account, *types.Transaction, *big.Int) error { return nil },
-		)
-
-		ns := bulletprooftxmanager.NewNonceSyncer(store, store.Config, ethClient)
-
-		ins, err := ns.MakeZeroInsert(acct, blockNum, nonce)
-		require.NoError(t, err)
-
-		assertZero(t, ins, store, from, nonce, blockNum)
-	})
-}
-
-func assertZero(t *testing.T, ins bulletprooftxmanager.NSinserttx, store *store.Store, from common.Address, nonce, blockNum int64) {
-	t.Helper()
-
-	assert.Equal(t, int64(0), ins.Etx.ID)
-	assert.Equal(t, nonce, *ins.Etx.Nonce)
-	assert.Equal(t, from, ins.Etx.FromAddress)
-	assert.Equal(t, from, ins.Etx.ToAddress)
-	assert.Equal(t, []byte{}, ins.Etx.EncodedPayload)
-	assert.Equal(t, assets.NewEthValue(0), ins.Etx.Value)
-	assert.Equal(t, store.Config.EthGasLimitDefault(), ins.Etx.GasLimit)
-	assert.Nil(t, ins.Etx.Error)
-	assert.Nil(t, ins.Etx.BroadcastAt)
-	assert.Equal(t, models.EthTxUnconfirmed, ins.Etx.State)
-
-	assert.Equal(t, int64(0), ins.Attempt.ID)
-	assert.Equal(t, int64(0), ins.Attempt.EthTxID)
-	assert.Equal(t, store.Config.EthGasPriceDefault().String(), ins.Attempt.GasPrice.String())
-	assert.Len(t, ins.Attempt.SignedRawTx, 103)
-	assert.NotEqual(t, common.Hash{}, ins.Attempt.Hash)
-	assert.NotNil(t, ins.Attempt.BroadcastBeforeBlockNum)
-	assert.Equal(t, blockNum, *ins.Attempt.BroadcastBeforeBlockNum)
-	assert.Equal(t, models.EthTxAttemptBroadcast, ins.Attempt.State)
 }
 
 func assertDatabaseNonce(t *testing.T, store *store.Store, from common.Address, nonce int64) {
@@ -399,17 +158,4 @@ func assertDatabaseNonce(t *testing.T, store *store.Store, from common.Address, 
 	k, err := store.KeyByAddress(from)
 	require.NoError(t, err)
 	assert.Equal(t, nonce, k.NextNonce)
-}
-
-func makeRandomTransactions(t *testing.T, store *store.Store, n int, accounts []accounts.Account, chainID *big.Int) (txes []types.Transaction) {
-	for i := 0; i < n; i++ {
-		unsigned := types.NewTransaction(uint64(i), cltest.NewAddress(), big.NewInt(int64(100+i)), uint64(100000+i), big.NewInt(int64(1000000000+i)), cltest.MustRandomBytes(t, 100+i))
-
-		// rotate accounts
-		acct := accounts[i%len(accounts)]
-		signed, err := store.KeyStore.SignTx(acct, unsigned, chainID)
-		require.NoError(t, err)
-		txes = append(txes, *signed)
-	}
-	return
 }

--- a/core/services/postgres/utils.go
+++ b/core/services/postgres/utils.go
@@ -9,10 +9,12 @@ import (
 	"github.com/pkg/errors"
 )
 
+const DefaultQueryTimeout = 10 * time.Second
+
 // DefaultQueryCtx returns a context with a sensible sanity limit timeout for
 // SQL queries
 func DefaultQueryCtx() (ctx context.Context, cancel context.CancelFunc) {
-	return context.WithTimeout(context.Background(), 10*time.Second)
+	return context.WithTimeout(context.Background(), DefaultQueryTimeout)
 }
 
 func IsSerializationAnomaly(err error) bool {

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -14,8 +14,6 @@ import (
 )
 
 // ConfigSchema records the schema of configuration at the type level
-// FIXME: NonceSyncer is temporarily disabled by default because it's buggy
-// See: https://app.clubhouse.io/chainlinklabs/story/6701/noncesyncer-has-problems-we-should-disable-it-until-it-has-been-a-t-d-and-problems-below-have-been-addressed
 type ConfigSchema struct {
 	AdminCredentialsFile                      string          `env:"ADMIN_CREDENTIALS_FILE" default:"$ROOT/apicredentials"`
 	AllowOrigins                              string          `env:"ALLOW_ORIGINS" default:"http://localhost:3000,http://localhost:6688"`
@@ -54,7 +52,7 @@ type ConfigSchema struct {
 	EthGasPriceDefault                        big.Int         `env:"ETH_GAS_PRICE_DEFAULT"`
 	EthMaxGasPriceWei                         big.Int         `env:"ETH_MAX_GAS_PRICE_WEI"`
 	EthMaxUnconfirmedTransactions             uint64          `env:"ETH_MAX_UNCONFIRMED_TRANSACTIONS" default:"500"`
-	EthNonceAutoSync                          bool            `env:"ETH_NONCE_AUTO_SYNC" default:"false"`
+	EthNonceAutoSync                          bool            `env:"ETH_NONCE_AUTO_SYNC" default:"true"`
 	EthFinalityDepth                          uint            `env:"ETH_FINALITY_DEPTH"`
 	EthHeadTrackerHistoryDepth                uint            `env:"ETH_HEAD_TRACKER_HISTORY_DEPTH"`
 	EthHeadTrackerMaxBufferSize               uint            `env:"ETH_HEAD_TRACKER_MAX_BUFFER_SIZE" default:"3"`


### PR DESCRIPTION
- Fixes a bug where NonceSyncer wouldn't take into account an
'in_progress' transaction left over from a crash
- Remove all the transaction backfilling, which turned out to be too
complex and prone to bugs. We instead log a warning message that makes
it clear to the node operator that they risk stuck transactions and
clearing these is their responsibility.