### PR TITLE
Fix job id usage in directrequest

### DIFF
--- a/core/services/directrequest/delegate.go
+++ b/core/services/directrequest/delegate.go
@@ -61,6 +61,7 @@ func (d *Delegate) ServicesForSpec(spec job.Job) (services []job.Service, err er
 		db:             d.db,
 		pipelineORM:    d.pipelineORM,
 		spec:           *spec.PipelineSpec,
+		job:            spec,
 	}
 	copy(logListener.onChainJobSpecID[:], spec.DirectRequestSpec.OnChainJobSpecID.Bytes())
 	services = append(services, logListener)
@@ -81,6 +82,7 @@ type listener struct {
 	db                *gorm.DB
 	pipelineORM       pipeline.ORM
 	spec              pipeline.Spec
+	job               job.Job
 	onChainJobSpecID  common.Hash
 	runs              sync.Map
 	shutdownWaitGroup sync.WaitGroup
@@ -223,7 +225,7 @@ func (*listener) JobID() models.JobID {
 
 // Job complies with log.Listener
 func (l *listener) JobIDV2() int32 {
-	return l.spec.ID
+	return l.job.ID
 }
 
 // IsV2Job complies with log.Listener

--- a/core/services/directrequest/delegate.go
+++ b/core/services/directrequest/delegate.go
@@ -43,11 +43,11 @@ func (d *Delegate) JobType() job.Type {
 }
 
 // ServicesForSpec returns the log listener service for a direct request job
-func (d *Delegate) ServicesForSpec(spec job.Job) (services []job.Service, err error) {
-	if spec.DirectRequestSpec == nil {
-		return nil, errors.Errorf("services.Delegate expects a *job.DirectRequestSpec to be present, got %v", spec)
+func (d *Delegate) ServicesForSpec(job job.Job) (services []job.Service, err error) {
+	if job.DirectRequestSpec == nil {
+		return nil, errors.Errorf("services.Delegate expects a *job.DirectRequestSpec to be present, got %v", job)
 	}
-	concreteSpec := spec.DirectRequestSpec
+	concreteSpec := job.DirectRequestSpec
 
 	oracle, err := oracle_wrapper.NewOracle(concreteSpec.ContractAddress.Address(), d.ethClient)
 	if err != nil {
@@ -60,10 +60,10 @@ func (d *Delegate) ServicesForSpec(spec job.Job) (services []job.Service, err er
 		pipelineRunner: d.pipelineRunner,
 		db:             d.db,
 		pipelineORM:    d.pipelineORM,
-		spec:           *spec.PipelineSpec,
-		job:            spec,
+		spec:           *job.PipelineSpec,
+		job:            job,
 	}
-	copy(logListener.onChainJobSpecID[:], spec.DirectRequestSpec.OnChainJobSpecID.Bytes())
+	copy(logListener.onChainJobSpecID[:], job.DirectRequestSpec.OnChainJobSpecID.Bytes())
 	services = append(services, logListener)
 
 	return

--- a/core/services/directrequest/delegate_test.go
+++ b/core/services/directrequest/delegate_test.go
@@ -104,6 +104,12 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		err = service.Start()
 		require.NoError(t, err)
 
+		// check if the job exists under the correct ID
+		drJob, err := jobORM.FindJob(listener.JobIDV2())
+		require.NoError(t, err)
+		require.Equal(t, drJob.ID, listener.JobIDV2())
+		require.NotNil(t, drJob.DirectRequestSpec)
+
 		listener.HandleLog(log)
 		runBeganAwaiter.AwaitOrFail(t, 5*time.Second)
 

--- a/core/services/directrequest/delegate_test.go
+++ b/core/services/directrequest/delegate_test.go
@@ -105,8 +105,8 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		require.NoError(t, err)
 
 		// check if the job exists under the correct ID
-		drJob, err := jobORM.FindJob(listener.JobIDV2())
-		require.NoError(t, err)
+		drJob, jErr := jobORM.FindJob(listener.JobIDV2())
+		require.NoError(t, jErr)
 		require.Equal(t, drJob.ID, listener.JobIDV2())
 		require.NotNil(t, drJob.DirectRequestSpec)
 


### PR DESCRIPTION
in `log_broadcasts` table: column `job_id_v2` we have FK to `jobs(id)`
    
but in DirectRequest we have:
``` 
func (l *listener) JobIDV2() int32 {
	return l.spec.ID
}
```

and that field is referring to `pipeline_specs.id`, not `jobs.id`
so to fix it, DirectRequest should keep the whole job object and just use `l.job.ID`