### PR TITLE
Fixes an issue where starting operator ui in dev mode would not load the page

### DIFF
--- a/operator_ui/webpack.config.js
+++ b/operator_ui/webpack.config.js
@@ -43,7 +43,7 @@ module.exports = {
   output: {
     filename: '[name].[contenthash].js',
     path: path.resolve(__dirname, 'dist'),
-    publicPath: '/assets/', // JS files are served from `/assets` by web
+    publicPath: '/',
   },
   plugins: [
     new CleanWebpackPlugin(),

--- a/operator_ui/webpack.prod.js
+++ b/operator_ui/webpack.prod.js
@@ -3,5 +3,9 @@ const CompressionPlugin = require('compression-webpack-plugin')
 const webpackBase = require('./webpack.config')
 
 module.exports = Object.assign(webpackBase, {
+  output: {
+    ...webpackBase.output,
+    publicPath: '/assets/', // JS files are served from `/assets` by web
+  },
   plugins: [...webpackBase.plugins, new CompressionPlugin({})],
 })


### PR DESCRIPTION
Operator UI was not loading in dev mode due to the change to the `publicPath` of the output for a production build