### PR TITLE
Make geth-compatible errors more generic; fix for Optimism

### DIFF
--- a/core/services/bulletprooftxmanager/eth_confirmer.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer.go
@@ -779,7 +779,7 @@ func (ec *ethConfirmer) handleInProgressAttempt(ctx context.Context, etx models.
 		logger.Errorf("gas price %v wei was rejected by the eth node for being too low. "+
 			"Eth node returned: '%s'. "+
 			"Bumping to %v wei and retrying. "+
-			"ACTION REQUIRED: You should consider increasing ETH_GAS_PRICE_DEFAULT", attempt.GasPrice, sendError.Error(), bumpedGasPrice)
+			"ACTION REQUIRED: You should consider increasing ETH_GAS_PRICE_DEFAULT", attempt.GasPrice.String(), sendError.Error(), bumpedGasPrice)
 		replacementAttempt, err := newAttempt(ec.store, etx, bumpedGasPrice)
 		if err != nil {
 			return errors.Wrap(err, "newAttempt failed")

--- a/core/services/eth/errors_test.go
+++ b/core/services/eth/errors_test.go
@@ -25,6 +25,9 @@ func Test_Eth_Errors(t *testing.T) {
 		// Arbitrum
 		err = eth.NewSendErrorS("transaction rejected: nonce too low")
 		assert.True(t, err.IsNonceTooLowError())
+		// Optimism
+		err = eth.NewSendErrorS("invalid transaction: nonce too low")
+		assert.True(t, err.IsNonceTooLowError())
 	})
 
 	t.Run("IsReplacementUnderpriced", func(t *testing.T) {
@@ -65,6 +68,9 @@ func Test_Eth_Errors(t *testing.T) {
 		// Geth
 		err = eth.NewSendErrorS("transaction underpriced")
 		assert.True(t, err.IsTerminallyUnderpriced())
+
+		err = eth.NewSendErrorS("replacement transaction underpriced")
+		assert.False(t, err.IsTerminallyUnderpriced())
 		// Parity
 		err = eth.NewSendErrorS("There are too many transactions in the queue. Your transaction was dropped due to limit. Try increasing the fee.")
 		assert.False(t, err.IsTerminallyUnderpriced())
@@ -95,6 +101,9 @@ func Test_Eth_Errors(t *testing.T) {
 		assert.True(t, err.IsInsufficientEth())
 		// Arbitrum
 		err = eth.NewSendErrorS("transaction rejected: insufficient funds for gas * price + value")
+		assert.True(t, err.IsInsufficientEth())
+		// Optimism
+		err = eth.NewSendErrorS("invalid transaction: insufficient funds for gas * price + value")
 		assert.True(t, err.IsInsufficientEth())
 		// Nil
 		err = eth.NewSendError(nil)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -23,6 +23,8 @@ DB load and significantly improves the performance of archiving OCR jobs.
 
 - Added `GAS_UPDATER_BATCH_SIZE` option to workaround `websocket: read limit exceeded` issues on BSC
 
+- Basic support for Optimism chain: node no longer gets stuck with 'nonce too low' error if connection is lost
+
 ## [0.10.4] - 2021-04-05
 
 ### Added


### PR DESCRIPTION
- Both Optimisim and Arbiturm prepend strings to geth errors. It seems
more robust to simply match the error string at the end.