### PR TITLE
Improve failed tests output grepping

### DIFF
--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -5,6 +5,8 @@ set +e
 go test -v -p 4 -parallel 4 ./... >./output.txt
 EXITCODE=$?
 grep "\-\-\- FAIL" output.txt
+grep "FAIL	" output.txt
+grep "driver: bad connection" output.txt
 echo "Exit code: $EXITCODE"
 if [[ $EXITCODE == 1 ]]; then
   echo "Encountered test failures."


### PR DESCRIPTION
we have some ‘bad connection’ lines quite commonly, but they don’t always fail the tests.

In some cases, the actual failed test was not easily visible in the output so we were mislead into thinking that ‘bad connection’ is the issue.