### PR TITLE
Fix integration test failures because of grep and timeouts

### DIFF
--- a/integration/common
+++ b/integration/common
@@ -44,13 +44,13 @@ launch_chainlink() {
   pushd tools/docker
   # Grab logs from our node service and find the unlocked account
   waitFor "docker logs chainlink-node 2>&1 | grep 'Unlocked account'" 10
-  export CHAINLINK_NODE_ADDRESS=`docker logs chainlink-node 2>&1 | grep 'Unlocked account' | awk '{print$5}'`
+  export CHAINLINK_NODE_ADDRESS=`docker logs chainlink-node 2>&1 | grep 'Unlocked account' | head -n 1 | awk '{print$5}'`
 
   # If we're using geth for this test
   # then we need to fund our hardcoded devnet address with the developer account given by geth
   if [ $GETH_MODE ]
   then
-    export DEVELOPER_ACCOUNT=`docker logs geth 2>&1 | grep "Using developer account" | awk -F "=" '{print$2}'`
+    export DEVELOPER_ACCOUNT=`docker logs geth 2>&1 | grep "Using developer account" | head -n 1 | awk -F "=" '{print$2}'`
     yarn workspace @chainlink/integration-scripts fund-address
   fi
   popd

--- a/tools/docker/compose
+++ b/tools/docker/compose
@@ -140,6 +140,10 @@ test:ts)
   $deps up --exit-code-from wait-db wait-db
   $deps up --exit-code-from wait-db-2 wait-db-2
   set +e
+
+  # Avoiding hanging, because of a bug: https://github.com/docker/compose/issues/3106
+  export COMPOSE_INTERACTIVE_NO_CLI=1
+
   $ts_test run integration-ts /bin/sh -c \
     "docker cp chainlink-node:/usr/local/bin/chainlink /usr/local/bin/chainlink \
       && yarn workspace @chainlink/ci-ts test --runInBand ${@:2}"


### PR DESCRIPTION
`| head -n 1` was needed to make sure only one address (from one line) is put into the env variable