### PR TITLE
Port to 10.4 - Bugfix: Don't allow multiple subscriptions for the same runlog job

### DIFF
--- a/core/services/job_subscriber.go
+++ b/core/services/job_subscriber.go
@@ -89,6 +89,16 @@ func (js *jobSubscriber) Stop() error {
 	return js.jobResumer.Stop()
 }
 
+func (js *jobSubscriber) alreadySubscribed(jobID models.JobID) bool {
+	js.jobsMutex.RLock()
+	defer js.jobsMutex.RUnlock()
+	if _, exists := js.jobSubscriptions[jobID.String()]; exists {
+		logger.Errorw("job subscription already added", "jobID", jobID)
+		return true
+	}
+	return false
+}
+
 // AddJob subscribes to ethereum log events for each "runlog" and "ethlog"
 // initiator in the passed job spec.
 func (js *jobSubscriber) AddJob(job models.JobSpec, bn *models.Head) error {
@@ -96,6 +106,10 @@ func (js *jobSubscriber) AddJob(job models.JobSpec, bn *models.Head) error {
 		return nil
 	}
 
+	if js.alreadySubscribed(job.ID) {
+		return nil
+	}
+	// Create a new subscription for this job
 	sub, err := StartJobSubscription(job, bn, js.store, js.runManager)
 	if err != nil {
 		js.store.UpsertErrorFor(job.ID, "Unable to start job subscription")

--- a/core/services/job_subscriber_test.go
+++ b/core/services/job_subscriber_test.go
@@ -103,7 +103,16 @@ func TestJobSubscriber_AddJob_RemoveJob(t *testing.T) {
 	err := jobSubscriber.AddJob(jobSpec, cltest.Head(321))
 	require.NoError(t, err)
 
-	assert.Len(t, jobSubscriber.Jobs(), 1)
+	// Re-adding the same jobID should be idempotent
+	// and NOT create a new subscription and overwrite
+	jobSpec2 := cltest.NewJobWithLogInitiator()
+	jobSpec2.ID = jobSpec.ID
+	jobSpec2.Name = "should not overwrite"
+	err = jobSubscriber.AddJob(jobSpec, cltest.Head(321))
+	require.NoError(t, err)
+	jbs := jobSubscriber.Jobs()
+	require.Equal(t, 1, len(jbs))
+	require.Equal(t, "", jbs[0].Name)
 
 	err = jobSubscriber.RemoveJob(jobSpec.ID)
 	require.NoError(t, err)


### PR DESCRIPTION
Porting https://github.com/smartcontractkit/chainlink/pull/4289