### PR TITLE
Add gas multiplier config option

### DIFF
--- a/core/services/bulletprooftxmanager/bulletprooftxmanager.go
+++ b/core/services/bulletprooftxmanager/bulletprooftxmanager.go
@@ -63,7 +63,7 @@ func SendEther(s *strpkg.Store, from, to gethCommon.Address, value assets.Eth) (
 	return etx, err
 }
 
-func newAttempt(s *strpkg.Store, etx models.EthTx, suggestedGasPrice *big.Int) (models.EthTxAttempt, error) {
+func newAttempt(ctx context.Context, s *strpkg.Store, etx models.EthTx, suggestedGasPrice *big.Int) (models.EthTxAttempt, error) {
 	attempt := models.EthTxAttempt{}
 	account, err := s.KeyStore.GetAccountByAddress(etx.FromAddress)
 	if err != nil {
@@ -78,7 +78,7 @@ func newAttempt(s *strpkg.Store, etx models.EthTx, suggestedGasPrice *big.Int) (
 	if s.Config.OptimismGasFees() {
 		// Optimism requires special handling, it assumes that clients always call EstimateGas
 		callMsg := ethereum.CallMsg{To: &etx.ToAddress, From: etx.FromAddress, Data: etx.EncodedPayload}
-		gasLimit, estimateGasErr := s.EthClient.EstimateGas(context.TODO(), callMsg)
+		gasLimit, estimateGasErr := s.EthClient.EstimateGas(ctx, callMsg)
 		if estimateGasErr != nil {
 			return attempt, errors.Wrapf(estimateGasErr, "error getting gas price for new transaction %v", etx.ID)
 		}

--- a/core/services/bulletprooftxmanager/bulletprooftxmanager.go
+++ b/core/services/bulletprooftxmanager/bulletprooftxmanager.go
@@ -78,9 +78,9 @@ func newAttempt(s *strpkg.Store, etx models.EthTx, suggestedGasPrice *big.Int) (
 	if s.Config.OptimismGasFees() {
 		// Optimism requires special handling, it assumes that clients always call EstimateGas
 		callMsg := ethereum.CallMsg{To: &etx.ToAddress, From: etx.FromAddress, Data: etx.EncodedPayload}
-		gasLimit, err := s.EthClient.EstimateGas(context.TODO(), callMsg)
-		if err != nil {
-			return attempt, errors.Wrapf(err, "error getting gas price for new transaction %v", etx.ID)
+		gasLimit, estimateGasErr := s.EthClient.EstimateGas(context.TODO(), callMsg)
+		if estimateGasErr != nil {
+			return attempt, errors.Wrapf(estimateGasErr, "error getting gas price for new transaction %v", etx.ID)
 		}
 		etx.GasLimit = gasLimit
 		gasPrice = big.NewInt(optimismGasPrice)

--- a/core/services/bulletprooftxmanager/eth_broadcaster.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster.go
@@ -213,7 +213,7 @@ func (eb *ethBroadcaster) processUnstartedEthTxs(fromAddress gethCommon.Address)
 			return nil
 		}
 		n++
-		a, err := newAttempt(eb.store, *etx, nil)
+		a, err := newAttempt(context.TODO(), eb.store, *etx, nil)
 		if err != nil {
 			return errors.Wrap(err, "processUnstartedEthTxs failed")
 		}
@@ -449,7 +449,7 @@ func (eb *ethBroadcaster) tryAgainWithHigherGasPrice(sendError *eth.SendError, e
 	if bumpedGasPrice.Cmp(attempt.GasPrice.ToInt()) == 0 && bumpedGasPrice.Cmp(eb.config.EthMaxGasPriceWei()) == 0 {
 		return errors.Errorf("Hit gas price bump ceiling, will not bump further. This is a terminal error")
 	}
-	replacementAttempt, err := newAttempt(eb.store, etx, bumpedGasPrice)
+	replacementAttempt, err := newAttempt(context.TODO(), eb.store, etx, bumpedGasPrice)
 	if err != nil {
 		return errors.Wrap(err, "tryAgainWithHigherGasPrice failed")
 	}

--- a/core/services/bulletprooftxmanager/eth_broadcaster.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster.go
@@ -217,6 +217,7 @@ func (eb *ethBroadcaster) processUnstartedEthTxs(fromAddress gethCommon.Address)
 			return nil
 		}
 		n++
+		etx.GasLimit = (uint64)((float64)(etx.GasLimit) * (float64)(eb.config.EthGasLimitMultiplier()))
 		a, err := newAttempt(eb.store, *etx, eb.initialTxGasPrice())
 		if err != nil {
 			return errors.Wrap(err, "processUnstartedEthTxs failed")

--- a/core/services/bulletprooftxmanager/eth_broadcaster_test.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster_test.go
@@ -266,10 +266,10 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Success_WithMultiplier(t *testing
 	defer cleanup()
 	key, fromAddress := cltest.MustAddRandomKeyToKeystore(t, store, 0)
 	store.KeyStore.Unlock(cltest.Password)
+	store.Config.Set("ETH_GAS_LIMIT_MULTIPLIER", "1.3")
 
 	config, cleanup := cltest.NewConfig(t)
 	defer cleanup()
-	config.Set("ETH_GAS_LIMIT_MULTIPLIER", "1.3")
 
 	ethClient := new(mocks.Client)
 	store.EthClient = ethClient

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -656,8 +656,9 @@ func (c Config) EthGasPriceDefault() *big.Int {
 // EthGasLimitMultiplier is a factory by which a transaction's GasLimit is
 // multiplied before transmission. So if the value is 1.1, and the GasLimit for
 // a transaction is 10, 10% will be added before transmission.
+//
 // This factor is always applied, so includes Optimism L2 transactions which
-// uses a default gas limit of 1.
+// uses a default gas limit of 1 and is also applied to EthGasLimitDefault.
 func (c Config) EthGasLimitMultiplier() float32 {
 	return (float32)(c.getWithFallback("EthGasLimitMultiplier", parseF32).(float64))
 }

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -653,6 +653,10 @@ func (c Config) EthGasPriceDefault() *big.Int {
 	return chainSpecificConfig(c).EthGasPriceDefault
 }
 
+func (c Config) EthGasLimitMultiplier() float32 {
+	return (float32)(c.getWithFallback("EthGasLimitMultiplier", parseF32).(float64))
+}
+
 // SetEthGasPriceDefault saves a runtime value for the default gas price for transactions
 func (c Config) SetEthGasPriceDefault(value *big.Int) error {
 	if c.runtimeStore == nil {
@@ -1457,6 +1461,11 @@ func parseUint32(s string) (interface{}, error) {
 
 func parseUint64(s string) (interface{}, error) {
 	v, err := strconv.ParseUint(s, 10, 64)
+	return v, err
+}
+
+func parseF32(s string) (interface{}, error) {
+	v, err := strconv.ParseFloat(s, 32)
 	return v, err
 }
 

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -653,6 +653,11 @@ func (c Config) EthGasPriceDefault() *big.Int {
 	return chainSpecificConfig(c).EthGasPriceDefault
 }
 
+// EthGasLimitMultiplier is a factory by which a transaction's GasLimit is
+// multiplied before transmission. So if the value is 1.1, and the GasLimit for
+// a transaction is 10, 10% will be added before transmission.
+// This factor is always applied, so includes Optimism L2 transactions which
+// uses a default gas limit of 1.
 func (c Config) EthGasLimitMultiplier() float32 {
 	return (float32)(c.getWithFallback("EthGasLimitMultiplier", parseF32).(float64))
 }

--- a/core/store/orm/config_reader.go
+++ b/core/store/orm/config_reader.go
@@ -38,6 +38,7 @@ type ConfigReader interface {
 	EthGasBumpTxDepth() uint16
 	EthGasBumpWei() *big.Int
 	EthGasLimitDefault() uint64
+	EthGasLimitMultiplier() float32
 	EthGasPriceDefault() *big.Int
 	EthHeadTrackerHistoryDepth() uint
 	EthHeadTrackerMaxBufferSize() uint

--- a/core/store/orm/schema.go
+++ b/core/store/orm/schema.go
@@ -45,6 +45,7 @@ type ConfigSchema struct {
 	EthGasBumpTxDepth                         uint16          `env:"ETH_GAS_BUMP_TX_DEPTH" default:"10"`
 	EthGasBumpWei                             big.Int         `env:"ETH_GAS_BUMP_WEI"`
 	EthGasLimitDefault                        uint64          `env:"ETH_GAS_LIMIT_DEFAULT" default:"500000"`
+	EthGasLimitMultiplier                     float32         `env:"ETH_GAS_LIMIT_MULTIPLIER" default:"1.0"`
 	EthGasPriceDefault                        big.Int         `env:"ETH_GAS_PRICE_DEFAULT"`
 	EthHeadTrackerHistoryDepth                uint            `env:"ETH_HEAD_TRACKER_HISTORY_DEPTH"`
 	EthHeadTrackerMaxBufferSize               uint            `env:"ETH_HEAD_TRACKER_MAX_BUFFER_SIZE" default:"3"`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add `ETH_GAS_LIMIT_MULTIPLIER` configuration option, the gas limit is multiplied by this value before transmission. So a value of 1.1 will add 10% to the on chain gas limit when a transaction is submitted.
+
 - Add `MockOracle.sol` for testing contracts
 
 - New CLI command to convert v1 flux monitor jobs (JSON) to 


### PR DESCRIPTION
Move gas calculation into newAttempt, where the actual TX bytes are generated, add multiplier config option, so `1.1` adds 10% to the GasLimit.