### PR TITLE
Fix logging in LogBroadcaster

### DIFF
--- a/core/services/log/broadcaster.go
+++ b/core/services/log/broadcaster.go
@@ -130,7 +130,7 @@ func (b *broadcaster) Start() error {
 		if b.latestHeadFromDb != nil {
 			logger.Debugw("LogBroadcaster: Starting at latest head from DB", "blockNumber", b.latestHeadFromDb.Number, "blockHash", b.latestHeadFromDb.Hash)
 		} else {
-			logger.Warn("LogBroadcaster: Latest head from DB was not set or does not exist.")
+			logger.Info("LogBroadcaster: Latest head from DB was not set or does not exist.")
 		}
 		go b.awaitInitialSubscribers()
 		return nil
@@ -245,7 +245,7 @@ func (b *broadcaster) startResubscribeLoop() {
 
 		shouldResubscribe, err := b.eventLoop(chRawLogs, subscription.Err())
 		if err != nil {
-			logger.Warn(err)
+			logger.Warnf("LogBroadcaster: error in the event loop - will reconnect. %v", err.Error())
 			b.connected.UnSet()
 			continue
 		} else if !shouldResubscribe {

--- a/core/services/log/broadcaster.go
+++ b/core/services/log/broadcaster.go
@@ -245,7 +245,7 @@ func (b *broadcaster) startResubscribeLoop() {
 
 		shouldResubscribe, err := b.eventLoop(chRawLogs, subscription.Err())
 		if err != nil {
-			logger.Warnw("LogBroadcaster: error in the event loop - will reconnect", "error", err)
+			logger.Warnw("LogBroadcaster: error in the event loop - will reconnect", "err", err)
 			b.connected.UnSet()
 			continue
 		} else if !shouldResubscribe {

--- a/core/services/log/broadcaster.go
+++ b/core/services/log/broadcaster.go
@@ -245,7 +245,7 @@ func (b *broadcaster) startResubscribeLoop() {
 
 		shouldResubscribe, err := b.eventLoop(chRawLogs, subscription.Err())
 		if err != nil {
-			logger.Warnf("LogBroadcaster: error in the event loop - will reconnect. %v", err.Error())
+			logger.Warnw("LogBroadcaster: error in the event loop - will reconnect", "error", err)
 			b.connected.UnSet()
 			continue
 		} else if !shouldResubscribe {

--- a/core/services/log/eth_subscriber.go
+++ b/core/services/log/eth_subscriber.go
@@ -47,7 +47,7 @@ func (sub *ethSubscriber) backfillLogs(fromBlockOverride *models.Head, addresses
 
 		latestBlock, err := sub.ethClient.HeaderByNumber(ctx, nil)
 		if err != nil {
-			logger.Errorw("LogBroadcaster: backfill - could not fetch latest block header, will retry", "error", err)
+			logger.Errorw("LogBroadcaster: backfill - could not fetch latest block header, will retry", "err", err)
 			return true
 		} else if latestBlock == nil {
 			logger.Warn("LogBroadcaster: got nil block header, will retry")
@@ -77,7 +77,7 @@ func (sub *ethSubscriber) backfillLogs(fromBlockOverride *models.Head, addresses
 
 		logs, err := sub.ethClient.FilterLogs(ctx, q)
 		if err != nil {
-			logger.Errorw("Log subscriber backfill: could not fetch logs", "error", err)
+			logger.Errorw("Log subscriber backfill: could not fetch logs", "err", err)
 			return true
 		}
 
@@ -128,7 +128,7 @@ func (sub *ethSubscriber) createSubscription(addresses []common.Address, topics 
 
 		innerSub, err := sub.ethClient.SubscribeFilterLogs(ctx2, filterQuery, chRawLogs)
 		if err != nil {
-			logger.Errorw("Log subscriber could not create subscription to Ethereum node", "error", err)
+			logger.Errorw("Log subscriber could not create subscription to Ethereum node", "err", err)
 			return true
 		}
 

--- a/core/services/log/eth_subscriber.go
+++ b/core/services/log/eth_subscriber.go
@@ -47,10 +47,10 @@ func (sub *ethSubscriber) backfillLogs(fromBlockOverride *models.Head, addresses
 
 		latestBlock, err := sub.ethClient.HeaderByNumber(ctx, nil)
 		if err != nil {
-			logger.Errorw("Log subscriber backfill: could not fetch latest block header", "error", err)
+			logger.Errorw("LogBroadcaster: backfill - could not fetch latest block header, will retry", "error", err)
 			return true
 		} else if latestBlock == nil {
-			logger.Warn("got nil block header")
+			logger.Warn("LogBroadcaster: got nil block header, will retry")
 			return true
 		}
 		currentHeight := uint64(latestBlock.Number)


### PR DESCRIPTION
"Latest head from DB was not set or does not exist." should be INFO as it can legitimately happen on an empty DB