### PR TITLE
Do not use viper config concurrently in HeadTracker

### DIFF
--- a/core/services/head_tracker.go
+++ b/core/services/head_tracker.go
@@ -135,6 +135,16 @@ type HeadTracker struct {
 	backfillMB            utils.Mailbox
 	subscriptionSucceeded chan struct{}
 	muLogger              sync.RWMutex
+	config                config
+}
+
+type config struct {
+	EthereumUrl                 string
+	EthHeadTrackerHistoryDepth  uint
+	EthHeadTrackerMaxBufferSize uint
+	EthFinalityDepth            uint
+	HeadTimeBudget              time.Duration
+	ChainID                     *big.Int
 }
 
 // NewHeadTracker instantiates a new HeadTracker using the orm to persist new block numbers.
@@ -154,6 +164,14 @@ func NewHeadTracker(l *logger.Logger, store *strpkg.Store, callbacks []strpkg.He
 		log:        l,
 		backfillMB: *utils.NewMailbox(1),
 		done:       make(chan struct{}),
+		config: config{
+			EthereumUrl:                 store.Config.EthereumURL(),
+			EthHeadTrackerHistoryDepth:  store.Config.EthHeadTrackerHistoryDepth(),
+			EthHeadTrackerMaxBufferSize: store.Config.EthHeadTrackerMaxBufferSize(),
+			EthFinalityDepth:            store.Config.EthFinalityDepth(),
+			HeadTimeBudget:              store.Config.HeadTimeBudget(),
+			ChainID:                     store.Config.ChainID(),
+		},
 	}
 }
 
@@ -211,7 +229,7 @@ func (ht *HeadTracker) Stop() error {
 		return nil
 	}
 
-	ht.logger().Info(fmt.Sprintf("Head tracker disconnecting from %v", ht.store.Config.EthereumURL()))
+	ht.logger().Info(fmt.Sprintf("Head tracker disconnecting from %v", ht.config.EthereumUrl))
 	close(ht.done)
 	close(ht.subscriptionSucceeded)
 	ht.started = false
@@ -236,7 +254,7 @@ func (ht *HeadTracker) Save(ctx context.Context, h models.Head) error {
 	} else if err != nil {
 		return err
 	}
-	return ht.store.TrimOldHeads(ctx, ht.store.Config.EthHeadTrackerHistoryDepth())
+	return ht.store.TrimOldHeads(ctx, ht.config.EthHeadTrackerHistoryDepth)
 }
 
 // HighestSeenHead returns the block header with the highest number that has been seen, or nil
@@ -319,7 +337,7 @@ func (ht *HeadTracker) backfiller() {
 				}
 				{
 					ctx, cancel := utils.ContextFromChan(ht.done)
-					err := ht.Backfill(ctx, h, ht.store.Config.EthFinalityDepth())
+					err := ht.Backfill(ctx, h, ht.config.EthFinalityDepth)
 					defer cancel()
 					if err != nil {
 						ht.logger().Warnw("HeadTracker: unexpected error while backfilling heads", "err", err)
@@ -426,7 +444,7 @@ func (ht *HeadTracker) subscribe() bool {
 			return false
 		}
 
-		ht.logger().Info("HeadTracker: Connecting to ethereum node ", ht.store.Config.EthereumURL(), " in ", ht.sleeper.Duration())
+		ht.logger().Info("HeadTracker: Connecting to ethereum node ", ht.config.EthereumUrl, " in ", ht.sleeper.Duration())
 		select {
 		case <-ht.done:
 			return false
@@ -434,9 +452,9 @@ func (ht *HeadTracker) subscribe() bool {
 			err := ht.subscribeToHead()
 			if err != nil {
 				promEthConnectionErrors.Inc()
-				ht.logger().Warnw(fmt.Sprintf("HeadTracker: Failed to connect to ethereum node %v", ht.store.Config.EthereumURL()), "err", err)
+				ht.logger().Warnw(fmt.Sprintf("HeadTracker: Failed to connect to ethereum node %v", ht.config.EthereumUrl), "err", err)
 			} else {
-				ht.logger().Info("HeadTracker: Connected to ethereum node ", ht.store.Config.EthereumURL())
+				ht.logger().Info("HeadTracker: Connected to ethereum node ", ht.config.EthereumUrl)
 				return true
 			}
 		}
@@ -453,7 +471,7 @@ func (ht *HeadTracker) receiveHeaders(ctx context.Context) error {
 			if !open {
 				return errors.New("HeadTracker: outHeaders prematurely closed")
 			}
-			timeBudget := ht.store.Config.HeadTimeBudget()
+			timeBudget := ht.config.HeadTimeBudget
 			{
 				deadlineCtx, cancel := context.WithTimeout(ctx, timeBudget)
 				defer cancel()
@@ -483,7 +501,7 @@ func (ht *HeadTracker) handleNewHead(ctx context.Context, head models.Head) erro
 		promCallbackDuration.Set(ms)
 		promCallbackDurationHist.Observe(ms)
 		if elapsed > ht.callbackExecutionThreshold() {
-			ht.logger().Warnw(fmt.Sprintf("HeadTracker finished processing head %v in %s which exceeds callback execution threshold of %s", number, elapsed.String(), ht.store.Config.HeadTimeBudget().String()), "blockNumber", number, "time", elapsed, "id", "head_tracker")
+			ht.logger().Warnw(fmt.Sprintf("HeadTracker finished processing head %v in %s which exceeds callback execution threshold of %s", number, elapsed.String(), ht.config.HeadTimeBudget.String()), "blockNumber", number, "time", elapsed, "id", "head_tracker")
 		} else {
 			ht.logger().Debugw(fmt.Sprintf("HeadTracker finished processing head %v in %s", number, elapsed.String()), "blockNumber", number, "time", elapsed, "id", "head_tracker")
 		}
@@ -521,7 +539,7 @@ func (ht *HeadTracker) handleNewHead(ctx context.Context, head models.Head) erro
 func (ht *HeadTracker) handleNewHighestHead(ctx context.Context, head models.Head) error {
 	promCurrentHead.Set(float64(head.Number))
 
-	headWithChain, err := ht.store.Chain(ctx, head.Hash, ht.store.Config.EthFinalityDepth())
+	headWithChain, err := ht.store.Chain(ctx, head.Hash, ht.config.EthFinalityDepth)
 	if ctx.Err() != nil {
 		return nil
 	} else if err != nil {
@@ -537,7 +555,7 @@ func (ht *HeadTracker) handleNewHighestHead(ctx context.Context, head models.Hea
 // be a problem and will log a warning.
 // Here we set it to the average time between blocks.
 func (ht *HeadTracker) callbackExecutionThreshold() time.Duration {
-	return ht.store.Config.HeadTimeBudget() / 2
+	return ht.config.HeadTimeBudget / 2
 }
 
 func (ht *HeadTracker) onNewLongestChain(ctx context.Context, headWithChain models.Head) {
@@ -574,7 +592,7 @@ func (ht *HeadTracker) subscribeToHead() error {
 
 	ht.inHeaders = make(chan *models.Head)
 	var rb *headRingBuffer
-	rb, ht.outHeaders = newHeadRingBuffer(ht.inHeaders, int(ht.store.Config.EthHeadTrackerMaxBufferSize()), ht.logger)
+	rb, ht.outHeaders = newHeadRingBuffer(ht.inHeaders, int(ht.config.EthHeadTrackerMaxBufferSize), ht.logger)
 	// It will autostop when we close inHeaders channel
 	rb.Start()
 
@@ -637,10 +655,10 @@ func verifyEthereumChainID(ht *HeadTracker) error {
 		return err
 	}
 
-	if ethereumChainID.Cmp(ht.store.Config.ChainID()) != 0 {
+	if ethereumChainID.Cmp(ht.config.ChainID) != 0 {
 		return fmt.Errorf(
 			"ethereum ChainID doesn't match chainlink config.ChainID: config ID=%d, eth RPC ID=%d",
-			ht.store.Config.ChainID(),
+			ht.config.ChainID,
 			ethereumChainID,
 		)
 	}


### PR DESCRIPTION
Viper is not thread-safe.

https://github.com/spf13/viper/issues/268

While this is most likely not a problem in production (as we don't Set values outside of application start), it may cause tests to panic when a test uses `Set` while another part of the code tries to gets values from the config.


The following happened in 'TestClient_DeleteJobV2'.
This PR would only likely reduce the chance of the panic, but not remove it completely.
```
2021-05-04T16:02:38Z [37m[INFO]  [0mHeadTracker: Connecting to ethereum node ws://127.0.0.1:38829 in 0s [34mservices/head_tracker.go:288[0m [32mlogger[0m=head_tracker 
2021-05-04T16:02:38Z [32m[DEBUG] [0mNullClient#SubscribeNewHead                        [34meth/null_client.go:79[0m   
2021-05-04T16:02:38Z [32m[DEBUG] [0mNullClient#ChainID                                 [34meth/null_client.go:88[0m   
2021-05-04T16:02:38Z [33m[WARN]  [0mHeadTracker: Failed to connect to ethereum node ws://127.0.0.1:38829 [34mservices/head_tracker.go:288[0m [32merr[0m=verifyEthereumChainID failed: ethereum ChainID doesn't match chainlink config.ChainID: config ID=3, eth RPC ID=1 [32merrVerbose[0m=ethereum ChainID doesn't match chainlink config.ChainID: config ID=3, eth RPC ID=1
verifyEthereumChainID failed
github.com/smartcontractkit/chainlink/core/services.(*HeadTracker).subscribeToHead
	/__w/chainlink/chainlink/core/services/head_tracker.go:587
github.com/smartcontractkit/chainlink/core/services.(*HeadTracker).subscribe
	/__w/chainlink/chainlink/core/services/head_tracker.go:434
github.com/smartcontractkit/chainlink/core/services.(*HeadTracker).listenForNewHeads
	/__w/chainlink/chainlink/core/services/head_tracker.go:288
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1374 [32mlogger[0m=head_tracker 
fatal error: concurrent map read and map write

goroutine 2881 [running]:
runtime.throw(0x1d78a99, 0x21)
	/usr/local/go/src/runtime/panic.go:1116 +0x72 fp=0xc0021299a0 sp=0xc002129970 pc=0x43e732
runtime.mapaccess2_faststr(0x19fa080, 0xc0436767b0, 0xc00180c5f0, 0x7, 0x0, 0x1)
	/usr/local/go/src/runtime/map_faststr.go:116 +0x4a5 fp=0xc002129a10 sp=0xc0021299a0 pc=0x41b005
github.com/spf13/viper.(*Viper).searchMap(0xc0018dbd40, 0xc0436767b0, 0xc0437647b0, 0x1, 0x1, 0x0, 0xc0437647b0)
	/go/pkg/mod/github.com/spf13/viper@v1.7.1/viper.go:557 +0x5f fp=0xc002129a58 sp=0xc002129a10 pc=0x11d761f
github.com/spf13/viper.(*Viper).find(0xc0018dbd40, 0xc00180c5f0, 0x7, 0x1, 0x0, 0x0)
	/go/pkg/mod/github.com/spf13/viper@v1.7.1/viper.go:1042 +0x15c fp=0xc002129b78 sp=0xc002129a58 pc=0x11d9ebc
github.com/spf13/viper.(*Viper).Get(0xc0018dbd40, 0x1946bd1, 0x7, 0x0, 0x0)
	/go/pkg/mod/github.com/spf13/viper@v1.7.1/viper.go:728 +0x85 fp=0xc002129c08 sp=0xc002129b78 pc=0x11d7f65
github.com/spf13/viper.(*Viper).GetString(0xc0018dbd40, 0x1946bd1, 0x7, 0x7, 0x1f44370)
	/go/pkg/mod/github.com/spf13/viper@v1.7.1/viper.go:793 +0x3f fp=0xc002129c48 sp=0xc002129c08 pc=0x11d8a9f
github.com/smartcontractkit/chainlink/core/store/orm.Config.EthereumURL(0xc0018dbd40, 0x2125580, 0x3189498, 0xc00279c200, 0x1cd6ee6, 0x10, 0x375f4ed85d772032, 0xc000197d68, 0x2)
	/__w/chainlink/chainlink/core/store/orm/config.go:735 +0x58 fp=0xc002129c80 sp=0xc002129c48 pc=0x1377b98
github.com/smartcontractkit/chainlink/core/services.(*HeadTracker).subscribe(0xc00232f770, 0x215ce20)
	/__w/chainlink/chainlink/core/services/head_tracker.go:429 +0x1a5 fp=0xc002129ef0 sp=0xc002129c80 pc=0x160eaa5
github.com/smartcontractkit/chainlink/core/services.(*HeadTracker).listenForNewHeads(0xc00232f770)
	/__w/chainlink/chainlink/core/services/head_tracker.go:288 +0x176 fp=0xc002129fd8 sp=0xc002129ef0 pc=0x160d116
runtime.goexit()
	/usr/local/go/src/runtime/asm_amd64.s:1374 +0x1 fp=0xc002129fe0 sp=0xc002129fd8 pc=0x477601
created by github.com/smartcontractkit/chainlink/core/services.(*HeadTracker).Start
	/__w/chainlink/chainlink/core/services/head_tracker.go:198 +0x15e

```