### PR TITLE
Nil on new heads in log broadcaster

### DIFF
--- a/core/services/log/broadcaster.go
+++ b/core/services/log/broadcaster.go
@@ -192,7 +192,10 @@ func (b *broadcaster) Connect(head *models.Head) error { return nil }
 func (b *broadcaster) Disconnect()                     {}
 
 func (b *broadcaster) OnNewLongestChain(ctx context.Context, head models.Head) {
-	b.newHeads.Deliver(head)
+	wasOverCapacity := b.newHeads.Deliver(head)
+	if wasOverCapacity {
+		logger.Debug("LogBroadcaster: Dropped the older head in the mailbox, while inserting latest (which is fine)")
+	}
 }
 
 func (b *broadcaster) IsConnected() bool {

--- a/core/services/log/broadcaster.go
+++ b/core/services/log/broadcaster.go
@@ -319,6 +319,8 @@ func (b *broadcaster) onNewHeads() {
 		latestHead = &head
 	}
 
+	// latestHead may sometimes be nil on high rate of heads,
+	// when 'b.newHeads.Notify()' receives more times that the number of items in the mailbox
 	if latestHead != nil {
 		logger.Tracew("LogBroadcaster: Received head", "blockNumber", latestHead.Number, "blockHash", latestHead.Hash)
 

--- a/core/services/log/broadcaster.go
+++ b/core/services/log/broadcaster.go
@@ -321,6 +321,7 @@ func (b *broadcaster) onNewHeads() {
 
 	// latestHead may sometimes be nil on high rate of heads,
 	// when 'b.newHeads.Notify()' receives more times that the number of items in the mailbox
+	// Some heads may be missed (which is fine for LogBroadcaster logic) but the latest one in a burst will be received
 	if latestHead != nil {
 		logger.Tracew("LogBroadcaster: Received head", "blockNumber", latestHead.Number, "blockHash", latestHead.Hash)
 

--- a/core/services/log/broadcaster.go
+++ b/core/services/log/broadcaster.go
@@ -194,7 +194,7 @@ func (b *broadcaster) Disconnect()                     {}
 func (b *broadcaster) OnNewLongestChain(ctx context.Context, head models.Head) {
 	wasOverCapacity := b.newHeads.Deliver(head)
 	if wasOverCapacity {
-		logger.Debug("LogBroadcaster: Dropped the older head in the mailbox, while inserting latest (which is fine)")
+		logger.Tracew("LogBroadcaster: Dropped the older head in the mailbox, while inserting latest (which is fine)", "latestBlockNumber", head.Number)
 	}
 }
 

--- a/core/services/log/pool.go
+++ b/core/services/log/pool.go
@@ -22,7 +22,7 @@ func (pool *logPool) addLog(log types.Log) {
 	pool.allLogs = append(pool.allLogs, log)
 }
 
-func (pool *logPool) getLogsToSend(head *models.Head, highestNumConfirmations uint64, finalityDepth uint64) []types.Log {
+func (pool *logPool) getLogsToSend(head models.Head, highestNumConfirmations uint64, finalityDepth uint64) []types.Log {
 	latestBlockNum := uint64(head.Number)
 	logsToReturn := pool.allLogs
 	var logsToKeep []types.Log

--- a/core/services/log/registrations.go
+++ b/core/services/log/registrations.go
@@ -180,7 +180,7 @@ func (r *registrations) isAddressRegistered(address common.Address) bool {
 	return exists
 }
 
-func (r *registrations) sendLogs(logs []types.Log, orm ORM, latestHead *models.Head) {
+func (r *registrations) sendLogs(logs []types.Log, orm ORM, latestHead models.Head) {
 	updates := make([]listenerMetadataUpdate, 0)
 	for _, log := range logs {
 		r.sendLog(log, orm, latestHead, &updates)
@@ -206,7 +206,7 @@ func filtersContainValues(topicValues []common.Hash, filters [][]Topic) bool {
 	return true
 }
 
-func (r *registrations) sendLog(log types.Log, orm ORM, latestHead *models.Head, updates *[]listenerMetadataUpdate) {
+func (r *registrations) sendLog(log types.Log, orm ORM, latestHead models.Head, updates *[]listenerMetadataUpdate) {
 	latestBlockNumber := uint64(latestHead.Number)
 	var wg sync.WaitGroup
 	for listener, metadata := range r.registrations[log.Address][log.Topics[0]] {
@@ -273,7 +273,7 @@ func (r *registrations) sendLog(log types.Log, orm ORM, latestHead *models.Head,
 //	After processing the logs in this batch, the listenerMetadata structures that we touched, are updated
 //  with new information about the canonical chain and the lowestAllowedBlockNumber value (higher every time) that is used to guard against double-sends
 //  Note that the updates are applied only after all the logs for the (latest height - num_confirmations) head height were sent.
-func applyListenerInfoUpdates(updates []listenerMetadataUpdate, latestHead *models.Head) {
+func applyListenerInfoUpdates(updates []listenerMetadataUpdate, latestHead models.Head) {
 	for _, update := range updates {
 		if update.toUpdate.lastSeenChain == nil || latestHead.IsInChain(update.toUpdate.lastSeenChain.Hash) {
 			if update.toUpdate.lowestAllowedBlockNumber < update.newLowestAllowedBlockNumber {
@@ -294,6 +294,6 @@ func applyListenerInfoUpdates(updates []listenerMetadataUpdate, latestHead *mode
 			update.toUpdate.lowestAllowedBlockNumber = 0
 		}
 		// Setting as latest head for this listener
-		update.toUpdate.lastSeenChain = latestHead
+		update.toUpdate.lastSeenChain = &latestHead
 	}
 }


### PR DESCRIPTION
Handling an edge cases for the mailbox under heavy load, similar to: https://github.com/smartcontractkit/chainlink/pull/4368