### PR TITLE
Expand pragma versions for a few v0.6 contracts

### DIFF
--- a/evm-contracts/src/v0.6/Owned.sol
+++ b/evm-contracts/src/v0.6/Owned.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.0;
+pragma solidity >0.6.0 <0.8.0;
 
 /**
  * @title The Owned contract

--- a/evm-contracts/src/v0.6/SimpleWriteAccessController.sol
+++ b/evm-contracts/src/v0.6/SimpleWriteAccessController.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.0;
+pragma solidity >0.6.0 <0.8.0;
 
 import "./Owned.sol";
 import "./interfaces/AccessControllerInterface.sol";

--- a/evm-contracts/src/v0.6/interfaces/AccessControllerInterface.sol
+++ b/evm-contracts/src/v0.6/interfaces/AccessControllerInterface.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.6.0;
+pragma solidity >0.6.0 <0.8.0;
 
 interface AccessControllerInterface {
   function hasAccess(address user, bytes calldata data) external view returns (bool);


### PR DESCRIPTION
This is required to include these contracts as a submodule of the LinkToken repo, where we'd need to support solc 0.7.