### PR TITLE
increase upkeepPerformed mailbox size

### DIFF
--- a/core/services/keeper/registry_synchronizer_core.go
+++ b/core/services/keeper/registry_synchronizer_core.go
@@ -34,7 +34,7 @@ func NewRegistrySynchronizer(
 	mailRoom := MailRoom{
 		mbUpkeepCanceled:   utils.NewMailbox(50),
 		mbSyncRegistry:     utils.NewMailbox(1),
-		mbUpkeepPerformed:  utils.NewMailbox(1),
+		mbUpkeepPerformed:  utils.NewMailbox(300),
 		mbUpkeepRegistered: utils.NewMailbox(50),
 	}
 	return &RegistrySynchronizer{


### PR DESCRIPTION
the `upkeepPerformed` mailbox is too small, this increases the size. Future store pending to make this value configurable.