### PR TITLE
Fix failed to connect to explorer warning

### DIFF
--- a/tools/docker/docker-compose.dev.yaml
+++ b/tools/docker/docker-compose.dev.yaml
@@ -29,3 +29,4 @@ services:
       - ../..:$SRCROOT
     depends_on:
       - node
+      - explorer

--- a/tools/docker/docker-compose.yaml
+++ b/tools/docker/docker-compose.yaml
@@ -36,6 +36,8 @@ services:
       - node_password
       - apicredentials
       - keystore
+    depends_on:
+      - explorer
 
   node-2:
     container_name: chainlink-node-2


### PR DESCRIPTION
Originally: https://github.com/smartcontractkit/chainlink/pull/4333

When using compose setup i.e ./compose cld | cldo, running cldev core results in a warning [WARN] Failed to connect to explorer (ws://explorer:3001)
Bring up explorer as part of ./compose cld and ./compose cldo