### PR TITLE
Lock GHAs to shas

### DIFF
--- a/.github/workflows/build-publish-chainlink.yml
+++ b/.github/workflows/build-publish-chainlink.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: [self-hosted, sdlc-ghr-prod]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -38,7 +38,7 @@ jobs:
           --health-retries 5
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - name: Set up Postgres user
         uses: docker://postgres
         with:
@@ -98,7 +98,7 @@ jobs:
       EXPLORER_DOCKER_TAG: ${{ fromJSON('["latest", "develop"]')[github.ref == 'refs/heads/master'] }} # https://github.community/t/do-expressions-support-ternary-operators-to-change-their-returned-value/18114/4
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - name: Login to DockerHub
         uses: docker/login-action@v1
         with:
@@ -113,7 +113,7 @@ jobs:
         working-directory: ./tools/docker
       - name: Store logs artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: logs
           path: ./tools/docker/logs
@@ -128,7 +128,7 @@ jobs:
         password: ${{ secrets.DOCKER_READONLY_PASSWORD }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - name: Yarn cache
         uses: actions/cache@v2
         env:
@@ -158,7 +158,7 @@ jobs:
         password: ${{ secrets.DOCKER_READONLY_PASSWORD }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - name: Yarn cache
         uses: actions/cache@v2
         env:
@@ -187,7 +187,7 @@ jobs:
         password: ${{ secrets.DOCKER_READONLY_PASSWORD }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - name: Yarn cache
         uses: actions/cache@v2
         env:
@@ -217,7 +217,7 @@ jobs:
         password: ${{ secrets.DOCKER_READONLY_PASSWORD }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - name: Yarn cache
         uses: actions/cache@v2
         env:
@@ -247,7 +247,7 @@ jobs:
         password: ${{ secrets.DOCKER_READONLY_PASSWORD }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
       - name: Yarn cache
         uses: actions/cache@v2
         env:
@@ -277,7 +277,7 @@ jobs:
         password: ${{ secrets.DOCKER_READONLY_PASSWORD }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - name: Yarn cache
         uses: actions/cache@v2
         env:
@@ -307,7 +307,7 @@ jobs:
         password: ${{ secrets.DOCKER_READONLY_PASSWORD }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - name: Yarn cache
         uses: actions/cache@v2
         env:
@@ -337,7 +337,7 @@ jobs:
         password: ${{ secrets.DOCKER_READONLY_PASSWORD }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - name: Yarn cache
         uses: actions/cache@v2
         env:
@@ -367,7 +367,7 @@ jobs:
         password: ${{ secrets.DOCKER_READONLY_PASSWORD }}
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - name: Yarn cache
         uses: actions/cache@v2
         env:
@@ -395,7 +395,7 @@ jobs:
         dockerfile: [core/chainlink.Dockerfile]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -73,7 +73,7 @@ jobs:
         run: ./tools/bin/${{ matrix.cmd }}
       - name: Store logs artifacts on failure
         if: failure()
-        uses: actions/upload-artifact@v1
+        uses: actions/upload-artifact@ee69f02b3dfdecd58bb31b4d133da38ba6fe3700
         with:
           name: ${{ matrix.cmd }}_logs
           path: ./output.txt

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
 
       - name: Set up Go
         uses: actions/setup-go@v2

--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -5,7 +5,7 @@ jobs:
     name: vet
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - uses: actions/setup-go@v2
         with:
           go-version: 1.15
@@ -15,7 +15,7 @@ jobs:
     name: shadow
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - uses: actions/setup-go@v2
         with:
           go-version: 1.15
@@ -26,7 +26,7 @@ jobs:
     name: imports
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - uses: actions/setup-go@v2
         with:
           go-version: 1.15
@@ -36,7 +36,7 @@ jobs:
     name: staticheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - uses: actions/setup-go@v2
         with:
           go-version: 1.15
@@ -46,7 +46,7 @@ jobs:
     name: errcheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - uses: actions/setup-go@v2
         with:
           go-version: 1.15
@@ -56,7 +56,7 @@ jobs:
     name: sec
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - uses: actions/setup-go@v2
         with:
           go-version: 1.15
@@ -66,7 +66,7 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - uses: actions/setup-go@v2
         with:
           go-version: 1.15
@@ -76,7 +76,7 @@ jobs:
     name: exportloopref
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - uses: actions/setup-go@v2
         with:
           go-version: 1.15
@@ -86,7 +86,7 @@ jobs:
     name: exhaustive
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
       - uses: actions/setup-go@v2
         with:
           go-version: 1.15

--- a/.github/workflows/sync-develop-from-smartcontractkit-chainlink.yml
+++ b/.github/workflows/sync-develop-from-smartcontractkit-chainlink.yml
@@ -10,7 +10,7 @@ jobs:
     name: Sync
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f@v2
         with:
           ref: develop
         if: env.GITHUB_REPOSITORY != 'smartcontractkit/chainlink'


### PR DESCRIPTION
Replaces https://github.com/smartcontractkit/chainlink/pull/4394 which pinned to versions.