### PR TITLE
Do not resend insufficient_eth attempts for confirmed/errored transactions

### DIFF
--- a/core/services/bulletprooftxmanager/eth_confirmer.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer.go
@@ -776,7 +776,7 @@ func FindEthTxsRequiringResubmissionDueToInsufficientEth(db *gorm.DB, address ge
 			return db.Order("eth_tx_attempts.gas_price DESC")
 		}).
 		Joins("INNER JOIN eth_tx_attempts ON eth_txes.id = eth_tx_attempts.eth_tx_id AND eth_tx_attempts.state = 'insufficient_eth'").
-		Where("eth_txes.from_address = ?", address).
+		Where("eth_txes.from_address = ? AND eth_txes.state = 'unconfirmed'", address).
 		Order("nonce ASC").
 		Find(&etxs).Error
 

--- a/core/services/offchainreporting/transmitter.go
+++ b/core/services/offchainreporting/transmitter.go
@@ -35,6 +35,11 @@ func (t *transmitter) CreateEthTransaction(ctx context.Context, toAddress gethCo
 	}
 
 	value := 0
+	// NOTE: It is important to remember that eth_tx_attempts with state
+	// insufficient_eth can actually hang around long after the node has been
+	// refunded and started sending transactions again.
+	// This is because they are not ever deleted if attached to an eth_tx that
+	// is moved into confirmed/fatal_error state
 	res, err := t.db.ExecContext(ctx, `
 INSERT INTO eth_txes (from_address, to_address, encoded_payload, value, gas_limit, state, created_at)
 SELECT $1,$2,$3,$4,$5,'unstarted',NOW()


### PR DESCRIPTION
Fixes a potential panic in rare cases and reduces unnecessary resends.