### PR TITLE
Chore: v4 LINK contracts for Solidity v8 hardhat tests

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -31,6 +31,7 @@ evm-contracts/dist/**/*
 evm-contracts/abi/**/*
 evm-contracts/ethers/**/*
 evm-contracts/truffle/**/*
+evm-contracts/cache/**/*
 
 # solc_bin
 solc_bin

--- a/evm-contracts/hardhat.config.js
+++ b/evm-contracts/hardhat.config.js
@@ -14,13 +14,26 @@ task('accounts', 'Prints the list of accounts', async (args, hre) => {
  */
 module.exports = {
   solidity: {
-    version: '0.8.4',
-    settings: {
-      optimizer: {
-        enabled: true,
-        runs: 200,
+    compilers: [
+      {
+        version: '0.4.24',
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
       },
-    },
+      {
+        version: '0.8.4',
+        settings: {
+          optimizer: {
+            enabled: true,
+            runs: 200,
+          },
+        },
+      },
+    ],
   },
   paths: {
     sources: './src/v0.8',

--- a/evm-contracts/src/v0.8/tests/v0.4/LinkToken/BasicToken.sol
+++ b/evm-contracts/src/v0.8/tests/v0.4/LinkToken/BasicToken.sol
@@ -1,0 +1,38 @@
+pragma solidity ^0.4.24;
+
+
+import { ERC20Basic as linkERC20Basic } from "./ERC20Basic.sol";
+import { SafeMathChainlink as linkSafeMath } from "./SafeMathChainlink.sol";
+
+
+/**
+ * @title Basic token
+ * @dev Basic version of StandardToken, with no allowances. 
+ */
+contract BasicToken is linkERC20Basic {
+  using linkSafeMath for uint256;
+
+  mapping(address => uint256) balances;
+
+  /**
+  * @dev transfer token for a specified address
+  * @param _to The address to transfer to.
+  * @param _value The amount to be transferred.
+  */
+  function transfer(address _to, uint256 _value) returns (bool) {
+    balances[msg.sender] = balances[msg.sender].sub(_value);
+    balances[_to] = balances[_to].add(_value);
+    Transfer(msg.sender, _to, _value);
+    return true;
+  }
+
+  /**
+  * @dev Gets the balance of the specified address.
+  * @param _owner The address to query the the balance of. 
+  * @return An uint256 representing the amount owned by the passed address.
+  */
+  function balanceOf(address _owner) constant returns (uint256 balance) {
+    return balances[_owner];
+  }
+
+}

--- a/evm-contracts/src/v0.8/tests/v0.4/LinkToken/ERC20.sol
+++ b/evm-contracts/src/v0.8/tests/v0.4/LinkToken/ERC20.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.4.11;
+
+
+import { ERC20Basic as linkERC20Basic } from "./ERC20Basic.sol";
+
+
+/**
+ * @title ERC20 interface
+ * @dev see https://github.com/ethereum/EIPs/issues/20
+ */
+contract ERC20 is linkERC20Basic {
+  function allowance(address owner, address spender) constant returns (uint256);
+  function transferFrom(address from, address to, uint256 value) returns (bool);
+  function approve(address spender, uint256 value) returns (bool);
+  event Approval(address indexed owner, address indexed spender, uint256 value);
+}

--- a/evm-contracts/src/v0.8/tests/v0.4/LinkToken/ERC20Basic.sol
+++ b/evm-contracts/src/v0.8/tests/v0.4/LinkToken/ERC20Basic.sol
@@ -1,0 +1,14 @@
+pragma solidity ^0.4.11;
+
+
+/**
+ * @title ERC20Basic
+ * @dev Simpler version of ERC20 interface
+ * @dev see https://github.com/ethereum/EIPs/issues/179
+ */
+contract ERC20Basic {
+  uint256 public totalSupply;
+  function balanceOf(address who) constant returns (uint256);
+  function transfer(address to, uint256 value) returns (bool);
+  event Transfer(address indexed from, address indexed to, uint256 value);
+}

--- a/evm-contracts/src/v0.8/tests/v0.4/LinkToken/ERC677.sol
+++ b/evm-contracts/src/v0.8/tests/v0.4/LinkToken/ERC677.sol
@@ -1,0 +1,9 @@
+pragma solidity ^0.4.8;
+
+import { ERC20 as linkERC20 } from "./ERC20.sol";
+
+contract ERC677 is linkERC20 {
+  function transferAndCall(address to, uint value, bytes data) returns (bool success);
+
+  event Transfer(address indexed from, address indexed to, uint value, bytes data);
+}

--- a/evm-contracts/src/v0.8/tests/v0.4/LinkToken/ERC677Receiver.sol
+++ b/evm-contracts/src/v0.8/tests/v0.4/LinkToken/ERC677Receiver.sol
@@ -1,0 +1,6 @@
+pragma solidity ^0.4.8;
+
+
+contract ERC677Receiver {
+  function onTokenTransfer(address _sender, uint _value, bytes _data);
+}

--- a/evm-contracts/src/v0.8/tests/v0.4/LinkToken/ERC677Token.sol
+++ b/evm-contracts/src/v0.8/tests/v0.4/LinkToken/ERC677Token.sol
@@ -1,0 +1,47 @@
+pragma solidity ^0.4.11;
+
+
+import "./ERC677.sol";
+import "./ERC677Receiver.sol";
+
+
+contract ERC677Token is ERC677 {
+
+  /**
+  * @dev transfer token to a contract address with additional data if the recipient is a contact.
+  * @param _to The address to transfer to.
+  * @param _value The amount to be transferred.
+  * @param _data The extra data to be passed to the receiving contract.
+  */
+  function transferAndCall(address _to, uint _value, bytes _data)
+    public
+    returns (bool success)
+  {
+    super.transfer(_to, _value);
+    Transfer(msg.sender, _to, _value, _data);
+    if (isContract(_to)) {
+      contractFallback(_to, _value, _data);
+    }
+    return true;
+  }
+
+
+  // PRIVATE
+
+  function contractFallback(address _to, uint _value, bytes _data)
+    private
+  {
+    ERC677Receiver receiver = ERC677Receiver(_to);
+    receiver.onTokenTransfer(msg.sender, _value, _data);
+  }
+
+  function isContract(address _addr)
+    private
+    returns (bool hasCode)
+  {
+    uint length;
+    assembly { length := extcodesize(_addr) }
+    return length > 0;
+  }
+
+}

--- a/evm-contracts/src/v0.8/tests/v0.4/LinkToken/LinkToken.sol
+++ b/evm-contracts/src/v0.8/tests/v0.4/LinkToken/LinkToken.sol
@@ -1,0 +1,83 @@
+pragma solidity ^0.4.11;
+
+
+import "./ERC677Token.sol";
+import { StandardToken as linkStandardToken } from "./StandardToken.sol";
+
+
+contract LinkToken is linkStandardToken, ERC677Token {
+
+  uint public constant totalSupply = 10**27;
+  string public constant name = "ChainLink Token";
+  uint8 public constant decimals = 18;
+  string public constant symbol = "LINK";
+
+  function LinkToken()
+    public
+  {
+    balances[msg.sender] = totalSupply;
+  }
+
+  /**
+  * @dev transfer token to a specified address with additional data if the recipient is a contract.
+  * @param _to The address to transfer to.
+  * @param _value The amount to be transferred.
+  * @param _data The extra data to be passed to the receiving contract.
+  */
+  function transferAndCall(address _to, uint _value, bytes _data)
+    public
+    validRecipient(_to)
+    returns (bool success)
+  {
+    return super.transferAndCall(_to, _value, _data);
+  }
+
+  /**
+  * @dev transfer token to a specified address.
+  * @param _to The address to transfer to.
+  * @param _value The amount to be transferred.
+  */
+  function transfer(address _to, uint _value)
+    public
+    validRecipient(_to)
+    returns (bool success)
+  {
+    return super.transfer(_to, _value);
+  }
+
+  /**
+   * @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
+   * @param _spender The address which will spend the funds.
+   * @param _value The amount of tokens to be spent.
+   */
+  function approve(address _spender, uint256 _value)
+    public
+    validRecipient(_spender)
+    returns (bool)
+  {
+    return super.approve(_spender,  _value);
+  }
+
+  /**
+   * @dev Transfer tokens from one address to another
+   * @param _from address The address which you want to send tokens from
+   * @param _to address The address which you want to transfer to
+   * @param _value uint256 the amount of tokens to be transferred
+   */
+  function transferFrom(address _from, address _to, uint256 _value)
+    public
+    validRecipient(_to)
+    returns (bool)
+  {
+    return super.transferFrom(_from, _to, _value);
+  }
+
+
+  // MODIFIERS
+
+  modifier validRecipient(address _recipient) {
+    require(_recipient != address(0) && _recipient != address(this));
+    _;
+  }
+
+}

--- a/evm-contracts/src/v0.8/tests/v0.4/LinkToken/SafeMathChainlink.sol
+++ b/evm-contracts/src/v0.8/tests/v0.4/LinkToken/SafeMathChainlink.sol
@@ -1,0 +1,52 @@
+pragma solidity ^0.4.11;
+
+
+/**
+ * @title SafeMath
+ * @dev Math operations with safety checks that throw on error
+ */
+library SafeMathChainlink {
+
+  /**
+  * @dev Multiplies two numbers, throws on overflow.
+  */
+  function mul(uint256 _a, uint256 _b) internal pure returns (uint256 c) {
+    // Gas optimization: this is cheaper than asserting 'a' not being zero, but the
+    // benefit is lost if 'b' is also tested.
+    // See: https://github.com/OpenZeppelin/openzeppelin-solidity/pull/522
+    if (_a == 0) {
+      return 0;
+    }
+
+    c = _a * _b;
+    assert(c / _a == _b);
+    return c;
+  }
+
+  /**
+  * @dev Integer division of two numbers, truncating the quotient.
+  */
+  function div(uint256 _a, uint256 _b) internal pure returns (uint256) {
+    // assert(_b > 0); // Solidity automatically throws when dividing by 0
+    // uint256 c = _a / _b;
+    // assert(_a == _b * c + _a % _b); // There is no case in which this doesn't hold
+    return _a / _b;
+  }
+
+  /**
+  * @dev Subtracts two numbers, throws on overflow (i.e. if subtrahend is greater than minuend).
+  */
+  function sub(uint256 _a, uint256 _b) internal pure returns (uint256) {
+    assert(_b <= _a);
+    return _a - _b;
+  }
+
+  /**
+  * @dev Adds two numbers, throws on overflow.
+  */
+  function add(uint256 _a, uint256 _b) internal pure returns (uint256 c) {
+    c = _a + _b;
+    assert(c >= _a);
+    return c;
+  }
+}

--- a/evm-contracts/src/v0.8/tests/v0.4/LinkToken/StandardToken.sol
+++ b/evm-contracts/src/v0.8/tests/v0.4/LinkToken/StandardToken.sol
@@ -1,0 +1,85 @@
+pragma solidity ^0.4.11;
+
+
+import { BasicToken as linkBasicToken } from "./BasicToken.sol";
+import { ERC20 as linkERC20 } from "./ERC20.sol";
+
+
+/**
+ * @title Standard ERC20 token
+ *
+ * @dev Implementation of the basic standard token.
+ * @dev https://github.com/ethereum/EIPs/issues/20
+ * @dev Based on code by FirstBlood: https://github.com/Firstbloodio/token/blob/master/smart_contract/FirstBloodToken.sol
+ */
+contract StandardToken is linkERC20, linkBasicToken {
+
+  mapping (address => mapping (address => uint256)) allowed;
+
+
+  /**
+   * @dev Transfer tokens from one address to another
+   * @param _from address The address which you want to send tokens from
+   * @param _to address The address which you want to transfer to
+   * @param _value uint256 the amount of tokens to be transferred
+   */
+  function transferFrom(address _from, address _to, uint256 _value) returns (bool) {
+    var _allowance = allowed[_from][msg.sender];
+
+    // Check is not needed because sub(_allowance, _value) will already throw if this condition is not met
+    // require (_value <= _allowance);
+
+    balances[_from] = balances[_from].sub(_value);
+    balances[_to] = balances[_to].add(_value);
+    allowed[_from][msg.sender] = _allowance.sub(_value);
+    Transfer(_from, _to, _value);
+    return true;
+  }
+
+  /**
+   * @dev Approve the passed address to spend the specified amount of tokens on behalf of msg.sender.
+   * @param _spender The address which will spend the funds.
+   * @param _value The amount of tokens to be spent.
+   */
+  function approve(address _spender, uint256 _value) returns (bool) {
+    allowed[msg.sender][_spender] = _value;
+    Approval(msg.sender, _spender, _value);
+    return true;
+  }
+
+  /**
+   * @dev Function to check the amount of tokens that an owner allowed to a spender.
+   * @param _owner address The address which owns the funds.
+   * @param _spender address The address which will spend the funds.
+   * @return A uint256 specifying the amount of tokens still available for the spender.
+   */
+  function allowance(address _owner, address _spender) constant returns (uint256 remaining) {
+    return allowed[_owner][_spender];
+  }
+  
+    /*
+   * approve should be called when allowed[_spender] == 0. To increment
+   * allowed value is better to use this function to avoid 2 calls (and wait until 
+   * the first transaction is mined)
+   * From MonolithDAO Token.sol
+   */
+  function increaseApproval (address _spender, uint _addedValue) 
+    returns (bool success) {
+    allowed[msg.sender][_spender] = allowed[msg.sender][_spender].add(_addedValue);
+    Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
+    return true;
+  }
+
+  function decreaseApproval (address _spender, uint _subtractedValue) 
+    returns (bool success) {
+    uint oldValue = allowed[msg.sender][_spender];
+    if (_subtractedValue > oldValue) {
+      allowed[msg.sender][_spender] = 0;
+    } else {
+      allowed[msg.sender][_spender] = oldValue.sub(_subtractedValue);
+    }
+    Approval(msg.sender, _spender, allowed[msg.sender][_spender]);
+    return true;
+  }
+
+}


### PR DESCRIPTION
## Overview

This PR adds LINK contracts, originally compiled and deployed using Solidity v0.4, to the test/ directory in evm-contracts/src/v0.8/

## Details

Before Solidity version 0.8, we used a combination of ethers, typechain and belt (Chainlink internal compilation tool) to compile artifacts for testing. This toolchain is still used for all contracts within v0.4/, v0.5/, v0.6, and v0.7/. For v0.8/ and upwards, we're stripping it out in favour of Hardhat, which can support many compiler versions in the same config.

As we implement new contracts in v0.8, we need infrastructure to test their interaction with existing contracts compiled and deployed to mainnet with old Solidity versions. For example, test that a v0.8 `ChainlinkClient`  can interact with a v0.6 `Oracle` contract. Another example is any contract that interacts with the LINK token, compiled initially and deployed to mainnet using Solidity v0.4.

This PR adds the original v0.4 LINK token contracts to the test directory, inside evm-contracts/src/v0.8, so that they are compiled by Hardhat and therefore accessible to tests.

This could also be achieved by widening our local Hardhat configuration to compile everything with src/. The downside with this is that it blurs the line between the legacy tests, and the new Hardhat tests, and requires Hardhat to compile contracts that are already compiled using belt. IMO, the solution proposed in this PR is the cleaner option, at least in the transition period where we gradually decommission belt and the rest of the legacy toolchain.