### PR TITLE
cli: Add chainlink node db migrate

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -605,8 +605,7 @@ func NewApp(client *Client) *cli.App {
 				{
 					Name:        "db",
 					Usage:       "Commands for managing the database.",
-					Description: "Potentially destructive commands for managing the database, only intended for dev/testing purposes.",
-					Hidden:      !client.Config.Dev(),
+					Description: "Potentially destructive commands for managing the database.",
 					Subcommands: []cli.Command{
 						{
 							Name:   "reset",
@@ -625,6 +624,18 @@ func NewApp(client *Client) *cli.App {
 							Usage:  "Reset database and load fixtures.",
 							Hidden: !client.Config.Dev(),
 							Action: client.PrepareTestDatabase,
+							Flags:  []cli.Flag{},
+						},
+						{
+							Name:   "version",
+							Usage:  "Display the current database version.",
+							Action: client.VersionDatabase,
+							Flags:  []cli.Flag{},
+						},
+						{
+							Name:   "migrate",
+							Usage:  "Migrate the database to the latest version.",
+							Action: client.MigrateDatabase,
 							Flags:  []cli.Flag{},
 						},
 					},

--- a/core/store/migrations/migrate.go
+++ b/core/store/migrations/migrate.go
@@ -59,3 +59,17 @@ func Rollback(db *gorm.DB, m *Migration) error {
 
 	return g.RollbackMigration(m)
 }
+
+func Current(db *gorm.DB) (*Migration, error) {
+	g := New(db, &Options{
+		ValidateUnknownMigrations: false,
+	}, Migrations)
+
+	migration, err := g.getLastRunMigration()
+
+	if err != nil {
+		return nil, err
+	}
+
+	return migration, nil
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add `ETH_MIN_GAS_PRICE_WEI` configuration option. This defaults to 1Gwei on mainnet. Chainlink will never send a transaction at a price lower than this value.
 
+- Add `chainlink node db migrate` for running database migrations. It's
+  recommended to use this and set `MIGRATE_DATABASE=false` if you want to run
+  the migrations separately outside of application startup.
+
 ### Changed
 
 - Chainlink now automatically cleans up old eth_txes to reduce database size. By default, any eth_txes older than a week are pruned on a regular basis. It is recommended to use the default value, however the default can be overridden by setting the `ETH_TX_REAPER_THRESHOLD` env var e.g. `ETH_TX_REAPER_THRESHOLD=24h`. Reaper can be disabled entirely by setting `ETH_TX_REAPER_THRESHOLD=0`. The reaper will run on startup and again every hour (interval is configurable using `ETH_TX_REAPER_INTERVAL`).


### PR DESCRIPTION
Intended for doing database migrations *before* starting the node. Potentially useful in k8s clusters.

Note: this now exposes `chainlink node db` outside of dev mode, but all the subcommands apart from migrate remain disabled.