### PR TITLE
Fix stopping no-heads ticker

### DIFF
--- a/core/services/head_tracker.go
+++ b/core/services/head_tracker.go
@@ -83,17 +83,16 @@ func (r *headRingBuffer) Start() {
 func (r *headRingBuffer) run() {
 	noHeadsAlarm := time.Minute
 	t := time.NewTicker(noHeadsAlarm)
-	defer t.Stop()
 	for {
 		select {
 		case h, ok := <-r.in:
+			// We've received a head, reset the no heads alarm
+			t.Stop()
 			if !ok {
 				// If the channel is closed, do not handle any more heads.
 				close(r.out)
 				return
 			}
-			// We've received a head, reset the no heads alarm
-			t.Stop()
 			t = time.NewTicker(noHeadsAlarm)
 
 			if h == nil {

--- a/core/services/head_tracker.go
+++ b/core/services/head_tracker.go
@@ -92,8 +92,7 @@ func (r *headRingBuffer) run() {
 				return
 			}
 			// We've received a head, reset the no heads alarm
-			t.Stop()
-			t = time.NewTicker(noHeadsAlarm)
+			t.Reset(noHeadsAlarm)
 
 			if h == nil {
 				r.logger().Error("HeadTracker: got nil block header")
@@ -339,7 +338,7 @@ func (ht *HeadTracker) listenForNewHeads() {
 		if ctx.Err() != nil {
 			break
 		} else if err != nil {
-			ht.logger().Errorw(fmt.Sprintf("Error in new head subscription, unsubscribed: %s", err.Error()), "err", err)
+			ht.logger().Errorw("Error in new head subscription, unsubscribed", "err", err)
 			continue
 		} else {
 			break

--- a/core/services/head_tracker.go
+++ b/core/services/head_tracker.go
@@ -83,6 +83,7 @@ func (r *headRingBuffer) Start() {
 func (r *headRingBuffer) run() {
 	noHeadsAlarm := time.Minute
 	t := time.NewTicker(noHeadsAlarm)
+	defer t.Stop()
 	for {
 		select {
 		case h, ok := <-r.in:

--- a/core/services/head_tracker.go
+++ b/core/services/head_tracker.go
@@ -93,7 +93,8 @@ func (r *headRingBuffer) run() {
 				return
 			}
 			// We've received a head, reset the no heads alarm
-			t.Reset(noHeadsAlarm)
+			t.Stop()
+			t = time.NewTicker(noHeadsAlarm)
 
 			if h == nil {
 				r.logger().Error("HeadTracker: got nil block header")


### PR DESCRIPTION
A new ringbuffer is created on every subscribe for heads, but in case of in channel close, the ticker is not closed.
Which led to multiple firings of `HeadTracker: have not received a head for 1m0s`

```
2021-05-20T14:56:04Z [DEBUG] HeadTracker: Received new head #4825041 (0x499fd1) services/head_tracker.go:508 blockHash=0x2198fa0db3e72177736358c978611dd6f5e416ac3cbca5fc757905030f985338 blockHeight=4825041 logger=head_tracker parentHeadHash=0x7ea88472b29c618a2e788c02dd904035901517205e624ac6b8ad6b32d6aca58c 
2021-05-20T14:56:04Z [DEBUG] HeadTracker initiating callbacks                   services/head_tracker.go:318 chainLength=50 headNum=4825041 logger=head_tracker numCallbacks=8 
....
2021-05-20T14:56:05Z [DEBUG] HeadTracker finished processing head 4825041 in 4.710307ms services/head_tracker.go:599 blockNumber=4825041 id=head_tracker logger=head_tracker time=0.004710307 
2021-05-20T14:56:09Z [WARN]  HeadTracker: have not received a head for 1m0s     services/head_tracker.go:129 
2021-05-20T14:56:10Z [WARN]  HeadTracker: have not received a head for 1m0s     services/head_tracker.go:129 
2021-05-20T14:56:12Z [WARN]  HeadTracker: have not received a head for 1m0s     services/head_tracker.go:129 
2021-05-20T14:56:16Z [WARN]  HeadTracker: have not received a head for 1m0s  
```