### PR TITLE
Add a Nix/NixOS reproducible environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ tools/clroot/db.sqlite3-wal
 .DS_Store
 .envrc
 .env*
+.direnv
 .idea 
 
 # codeship
@@ -44,3 +45,7 @@ cl_backup_*.tar.gz
 
 # Test artifacts
 core/cmd/TestClient_ImportExportP2PKeyBundle_test_key.json
+
+# DB state
+db/
+.s.PGSQL.5432.lock

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,43 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1620759905,
+        "narHash": "sha256-WiyWawrgmyN0EdmiHyG2V+fqReiVi8bM9cRdMaKQOFg=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "b543720b25df6ffdfcf9227afafc5b8c1fabfae8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1621288494,
+        "narHash": "sha256-3lQCSw8/J076UwoQhtSVymOibLuojlqF9BAMP6X+/48=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "673aea9f84c955c94b105797fdc56007017af4db",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,18 @@
+{
+  description = "Hello world";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = inputs@{ self, nixpkgs, flake-utils, ... }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = import nixpkgs { inherit system; overlays = [ ]; };
+      in rec {
+        # packages.hello = 
+        # defaultPackage = packages.hello;
+        devShell = pkgs.callPackage ./shell.nix {};
+      });
+}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,32 @@
+{ stdenv, pkgs }:
+
+pkgs.mkShell {
+  nativeBuildInputs = with pkgs; [
+    go
+
+    postgresql
+    python3
+    curl
+    nodejs-12_x
+    (yarn.override { nodejs = nodejs-12_x; })
+    # TODO: compiler / gcc for secp compilation
+    nodePackages.ganache-cli
+    # py3: web3 slither-analyzer crytic-compile
+    # echidna
+    # go-ethereum # geth
+    # parity # openethereum
+    # go-mockery
+
+    # tooling
+    goimports
+    gopls
+    delve
+
+    # gofuzz
+  ];
+  LD_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib64:$LD_LIBRARY_PATH";
+  GOROOT="${pkgs.go}/share/go";
+
+  PGDATA="db";
+}
+


### PR DESCRIPTION
This might be a bit niche, but my system runs [NixOS](https://nixos.org/). It's defining feature is declarative, reproducible environments system-wide. Think `go.mod`/`yarn.lock` but for everything.  It's also very similar to python's virtualenv.

Nix, the package manager can be ran both on Linux as well as macOS (in lieu of homebrew). Using these definitions allows anyone to run an identical environment, similar to running inside docker (but it's running on the host, meaning no need for virtualization on macOS)

The definition can also be used to package the binary and deploy it on a server, or to generate minimal Docker images (comparable in size to Alpine).

I'm primarily including this in the tree because `.nix` files need to be in git in order to be picked up by the package manager (Note that any file that is not tracked by Git is invisible during Nix evaluation, in order to ensure hermetic evaluation.)

## Usage

1. [Install Nix](https://nixos.wiki/wiki/Flakes#Installing_flakes). This is a bit more involved right now because it requires flake support.
2. Run `nix develop`. You will be put in shell containing all the references. Alternatively, a `direnv` integration exists to automatically change the environment when `cd`-ing into the folder.