### PR TITLE
Move OCRKeyStore to application

### DIFF
--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -72,7 +72,7 @@ func (cli *Client) RunNode(c *clipkg.Context) error {
 		return cli.errorOut(fmt.Errorf("error authenticating keystore: %+v", err))
 	}
 
-	if authErr := cli.KeyStoreAuthenticator.AuthenticateOCRKey(store, keyStorePwd); authErr != nil {
+	if authErr := cli.KeyStoreAuthenticator.AuthenticateOCRKey(app, keyStorePwd); authErr != nil {
 		return cli.errorOut(errors.Wrapf(authErr, "while authenticating with OCR password"))
 	}
 

--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -177,7 +177,7 @@ func (a CallbackAuthenticator) AuthenticateVRFKey(*store.Store, string) error {
 	return nil
 }
 
-func (a CallbackAuthenticator) AuthenticateOCRKey(*store.Store, string) error {
+func (a CallbackAuthenticator) AuthenticateOCRKey(chainlink.Application, string) error {
 	return nil
 }
 

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -1501,9 +1501,9 @@ func setupNode(t *testing.T, owner *bind.TransactOpts, port int, dbName string, 
 	config, _, ormCleanup := cltest.BootstrapThrowawayORM(t, fmt.Sprintf("%s%d", dbName, port), true)
 	config.Dialect = dialects.PostgresWithoutLock
 	app, appCleanup := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, b)
-	_, _, err := app.Store.OCRKeyStore.GenerateEncryptedP2PKey()
+	_, _, err := app.OCRKeyStore.GenerateEncryptedP2PKey()
 	require.NoError(t, err)
-	p2pIDs := app.Store.OCRKeyStore.DecryptedP2PKeys()
+	p2pIDs := app.OCRKeyStore.DecryptedP2PKeys()
 	require.NoError(t, err)
 	require.Len(t, p2pIDs, 1)
 	peerID := p2pIDs[0].MustGetPeerID().Raw()
@@ -1527,7 +1527,7 @@ func setupNode(t *testing.T, owner *bind.TransactOpts, port int, dbName string, 
 	require.NoError(t, err)
 	b.Commit()
 
-	_, kb, err := app.Store.OCRKeyStore.GenerateEncryptedOCRKeyBundle()
+	_, kb, err := app.OCRKeyStore.GenerateEncryptedOCRKeyBundle()
 	require.NoError(t, err)
 	return app, peerID, transmitter, kb, func() {
 		ormCleanup()

--- a/core/internal/mocks/application.go
+++ b/core/internal/mocks/application.go
@@ -18,6 +18,8 @@ import (
 
 	null "gopkg.in/guregu/null.v4"
 
+	offchainreporting "github.com/smartcontractkit/chainlink/core/services/offchainreporting"
+
 	packr "github.com/gobuffalo/packr"
 
 	pipeline "github.com/smartcontractkit/chainlink/core/services/pipeline"
@@ -224,6 +226,22 @@ func (_m *Application) GetLogger() *logger.Logger {
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*logger.Logger)
+		}
+	}
+
+	return r0
+}
+
+// GetOCRKeyStore provides a mock function with given fields:
+func (_m *Application) GetOCRKeyStore() *offchainreporting.KeyStore {
+	ret := _m.Called()
+
+	var r0 *offchainreporting.KeyStore
+	if rf, ok := ret.Get(0).(func() *offchainreporting.KeyStore); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*offchainreporting.KeyStore)
 		}
 	}
 

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -16,7 +16,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/gracefulpanic"
 	"github.com/smartcontractkit/chainlink/core/services/eth"
-	"github.com/smartcontractkit/chainlink/core/services/offchainreporting"
 	"github.com/smartcontractkit/chainlink/core/services/postgres"
 	"github.com/smartcontractkit/chainlink/core/store/migrations"
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -48,7 +47,6 @@ type Store struct {
 	Clock          utils.AfterNower
 	KeyStore       KeyStoreInterface
 	VRFKeyStore    *vrf.VRFKeyStore
-	OCRKeyStore    *offchainreporting.KeyStore
 	EthClient      eth.Client
 	NotifyNewEthTx NotifyNewEthTx
 	AdvisoryLocker postgres.AdvisoryLocker
@@ -106,7 +104,6 @@ func newStoreWithKeyStore(
 		AdvisoryLocker: advisoryLocker,
 		Config:         config,
 		KeyStore:       keyStore,
-		OCRKeyStore:    offchainreporting.NewKeyStore(orm.DB, scryptParams),
 		ORM:            orm,
 		EthClient:      ethClient,
 		closeOnce:      &sync.Once{},

--- a/core/web/ocr_keys_controller.go
+++ b/core/web/ocr_keys_controller.go
@@ -22,7 +22,7 @@ type OCRKeysController struct {
 // Example:
 // "GET <application>/keys/ocr"
 func (ocrkc *OCRKeysController) Index(c *gin.Context) {
-	ekbs, err := ocrkc.App.GetStore().OCRKeyStore.FindEncryptedOCRKeyBundles()
+	ekbs, err := ocrkc.App.GetOCRKeyStore().FindEncryptedOCRKeyBundles()
 	if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
@@ -34,7 +34,7 @@ func (ocrkc *OCRKeysController) Index(c *gin.Context) {
 // Example:
 // "POST <application>/keys/ocr"
 func (ocrkc *OCRKeysController) Create(c *gin.Context) {
-	_, ekb, err := ocrkc.App.GetStore().OCRKeyStore.GenerateEncryptedOCRKeyBundle()
+	_, ekb, err := ocrkc.App.GetOCRKeyStore().GenerateEncryptedOCRKeyBundle()
 	if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
@@ -62,15 +62,15 @@ func (ocrkc *OCRKeysController) Delete(c *gin.Context) {
 		jsonAPIError(c, http.StatusUnprocessableEntity, err)
 		return
 	}
-	ekb, err := ocrkc.App.GetStore().OCRKeyStore.FindEncryptedOCRKeyBundleByID(id)
+	ekb, err := ocrkc.App.GetOCRKeyStore().FindEncryptedOCRKeyBundleByID(id)
 	if err != nil {
 		jsonAPIError(c, http.StatusNotFound, err)
 		return
 	}
 	if hardDelete {
-		err = ocrkc.App.GetStore().OCRKeyStore.DeleteEncryptedOCRKeyBundle(&ekb)
+		err = ocrkc.App.GetOCRKeyStore().DeleteEncryptedOCRKeyBundle(&ekb)
 	} else {
-		err = ocrkc.App.GetStore().OCRKeyStore.ArchiveEncryptedOCRKeyBundle(&ekb)
+		err = ocrkc.App.GetOCRKeyStore().ArchiveEncryptedOCRKeyBundle(&ekb)
 	}
 	if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
@@ -85,14 +85,13 @@ func (ocrkc *OCRKeysController) Delete(c *gin.Context) {
 func (ocrkc *OCRKeysController) Import(c *gin.Context) {
 	defer logger.ErrorIfCalling(c.Request.Body.Close)
 
-	store := ocrkc.App.GetStore()
 	bytes, err := ioutil.ReadAll(c.Request.Body)
 	if err != nil {
 		jsonAPIError(c, http.StatusBadRequest, err)
 		return
 	}
 	oldPassword := c.Query("oldpassword")
-	encryptedOCRKeyBundle, err := store.OCRKeyStore.ImportOCRKeyBundle(bytes, oldPassword)
+	encryptedOCRKeyBundle, err := ocrkc.App.GetOCRKeyStore().ImportOCRKeyBundle(bytes, oldPassword)
 	if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
@@ -114,7 +113,7 @@ func (ocrkc *OCRKeysController) Export(c *gin.Context) {
 		return
 	}
 	newPassword := c.Query("newpassword")
-	bytes, err := ocrkc.App.GetStore().OCRKeyStore.ExportOCRKeyBundle(id, newPassword)
+	bytes, err := ocrkc.App.GetOCRKeyStore().ExportOCRKeyBundle(id, newPassword)
 	if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return

--- a/core/web/ocr_keys_controller_test.go
+++ b/core/web/ocr_keys_controller_test.go
@@ -110,6 +110,5 @@ func setupOCRKeysControllerTests(t *testing.T) (cltest.HTTPClientCleaner, *offch
 	require.NoError(t, app.StartAndConnect())
 	client := app.NewHTTPClient()
 
-	OCRKeyStore := app.GetStore().OCRKeyStore
-	return client, OCRKeyStore
+	return client, app.GetOCRKeyStore()
 }

--- a/core/web/p2p_keys_controller.go
+++ b/core/web/p2p_keys_controller.go
@@ -22,7 +22,7 @@ type P2PKeysController struct {
 // Example:
 // "GET <application>/keys/p2p"
 func (p2pkc *P2PKeysController) Index(c *gin.Context) {
-	keys, err := p2pkc.App.GetStore().OCRKeyStore.FindEncryptedP2PKeys()
+	keys, err := p2pkc.App.GetOCRKeyStore().FindEncryptedP2PKeys()
 	if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
@@ -34,7 +34,7 @@ func (p2pkc *P2PKeysController) Index(c *gin.Context) {
 // Example:
 // "POST <application>/keys/p2p"
 func (p2pkc *P2PKeysController) Create(c *gin.Context) {
-	_, key, err := p2pkc.App.GetStore().OCRKeyStore.GenerateEncryptedP2PKey()
+	_, key, err := p2pkc.App.GetOCRKeyStore().GenerateEncryptedP2PKey()
 	if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
@@ -63,15 +63,15 @@ func (p2pkc *P2PKeysController) Delete(c *gin.Context) {
 		jsonAPIError(c, http.StatusUnprocessableEntity, err)
 		return
 	}
-	key, err := p2pkc.App.GetStore().OCRKeyStore.FindEncryptedP2PKeyByID(ep2pk.ID)
+	key, err := p2pkc.App.GetOCRKeyStore().FindEncryptedP2PKeyByID(ep2pk.ID)
 	if err != nil {
 		jsonAPIError(c, http.StatusNotFound, err)
 		return
 	}
 	if hardDelete {
-		err = p2pkc.App.GetStore().OCRKeyStore.DeleteEncryptedP2PKey(key)
+		err = p2pkc.App.GetOCRKeyStore().DeleteEncryptedP2PKey(key)
 	} else {
-		err = p2pkc.App.GetStore().OCRKeyStore.ArchiveEncryptedP2PKey(key)
+		err = p2pkc.App.GetOCRKeyStore().ArchiveEncryptedP2PKey(key)
 	}
 	if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
@@ -86,14 +86,13 @@ func (p2pkc *P2PKeysController) Delete(c *gin.Context) {
 func (p2pkc *P2PKeysController) Import(c *gin.Context) {
 	defer logger.ErrorIfCalling(c.Request.Body.Close)
 
-	store := p2pkc.App.GetStore()
 	bytes, err := ioutil.ReadAll(c.Request.Body)
 	if err != nil {
 		jsonAPIError(c, http.StatusBadRequest, err)
 		return
 	}
 	oldPassword := c.Query("oldpassword")
-	key, err := store.OCRKeyStore.ImportP2PKey(bytes, oldPassword)
+	key, err := p2pkc.App.GetOCRKeyStore().ImportP2PKey(bytes, oldPassword)
 	if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
@@ -116,7 +115,7 @@ func (p2pkc *P2PKeysController) Export(c *gin.Context) {
 	}
 	id := int32(id64)
 	newPassword := c.Query("newpassword")
-	bytes, err := p2pkc.App.GetStore().OCRKeyStore.ExportP2PKey(id, newPassword)
+	bytes, err := p2pkc.App.GetOCRKeyStore().ExportP2PKey(id, newPassword)
 	if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return

--- a/core/web/p2p_keys_controller_test.go
+++ b/core/web/p2p_keys_controller_test.go
@@ -118,6 +118,6 @@ func setupP2PKeysControllerTests(t *testing.T) (cltest.HTTPClientCleaner, *offch
 
 	client := app.NewHTTPClient()
 
-	OCRKeyStore := app.GetStore().OCRKeyStore
+	OCRKeyStore := app.GetOCRKeyStore()
 	return client, OCRKeyStore
 }

--- a/core/web/pipeline_runs_controller_test.go
+++ b/core/web/pipeline_runs_controller_test.go
@@ -285,7 +285,7 @@ func setupPipelineRunsControllerTests(t *testing.T) (cltest.HTTPClientCleaner, i
 	require.NoError(t, err)
 	ocrJobSpec.OffchainreportingOracleSpec = &os
 
-	err = app.Store.OCRKeyStore.Unlock(cltest.Password)
+	err = app.OCRKeyStore.Unlock(cltest.Password)
 	require.NoError(t, err)
 
 	jobID, err := app.AddJobV2(context.Background(), ocrJobSpec, null.String{})


### PR DESCRIPTION
https://app.clubhouse.io/chainlinklabs/story/10097/remove-ocr-as-dependency-of-store-package

This PR (albeit, somewhat naively) removes the `offchainreporting` package as a dependency of the `store` package, unblocking [this story](https://app.clubhouse.io/chainlinklabs/story/9559/coalesce-fragmented-insert-into-eth-txes-into-function-in-bulletprooftxmanager-package). We do this by moving the `OCRKeystore` to the `Application`. You might think "well hey why don't we move all the keystores to the application?". [That's coming here](https://app.clubhouse.io/chainlinklabs/story/7735/combine-keystores). But why not do it now? [Trying to avoid massive merge conflicts](https://github.com/smartcontractkit/chainlink/pull/4447).