### PR TITLE
Only enable gin debug mode if CHAINLINK_DEV & log level low enough

### DIFF
--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -36,7 +36,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	ethCore "github.com/ethereum/go-ethereum/core"
 	"github.com/gin-gonic/contrib/sessions"
-	"github.com/gin-gonic/gin"
 	"github.com/gorilla/securecookie"
 	homedir "github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
@@ -1654,16 +1653,6 @@ func parseHomeDir(str string) (interface{}, error) {
 // LogLevel determines the verbosity of the events to be logged.
 type LogLevel struct {
 	zapcore.Level
-}
-
-// ForGin keeps Gin's mode at the appropriate level with the LogLevel.
-func (ll LogLevel) ForGin() string {
-	switch {
-	case ll.Level < zapcore.InfoLevel:
-		return gin.DebugMode
-	default:
-		return gin.ReleaseMode
-	}
 }
 
 type DatabaseBackupMode string


### PR DESCRIPTION
Gin's debug mode is mostly warnings, and the output formatting can't be
customized. Disable it unless it's a dev setup.

See the attached ticket for more info.