### PR TITLE
Add error message for very old blocks

### DIFF
--- a/core/services/head_tracker.go
+++ b/core/services/head_tracker.go
@@ -481,6 +481,9 @@ func (ht *HeadTracker) handleNewHead(ctx context.Context, head models.Head) erro
 		}
 	} else {
 		ht.logger().Debugw("HeadTracker: got out of order head", "blockNum", head.Number, "gotHead", head.Hash.Hex(), "highestSeenHead", ht.highestSeenHead.Number)
+		if head.Number < prevHead.Number-int64(ht.store.Config.EthFinalityDepth()) {
+			ht.logger().Errorf("HeadTracker: got very old block with number %d (highest seen was %d). This is a problem and either means a very deep re-org occurred, or the chain went backwards in block numbers. This node will not function correctly without manual intervention.", head.Number, prevHead.Number)
+		}
 	}
 	return nil
 }


### PR DESCRIPTION
On Arbitrum and Optimism resets (or if the node is switched chains) the
local block numbers can be far ahead of the chain block numbers.

We need to indicate to operators that this is a problem.