### PR TITLE
Increase default lock timeout

### DIFF
--- a/core/services/postgres/transaction.go
+++ b/core/services/postgres/transaction.go
@@ -19,7 +19,7 @@ import (
 const (
 	// LockTimeout controls the max time we will wait for any kind of database lock.
 	// It's good to set this to _something_ because waiting for locks forever is really bad.
-	LockTimeout = 15 * time.Second
+	LockTimeout = 3 * time.Minute
 	// IdleInTxSessionTimeout controls the max time we leave a transaction open and idle.
 	// It's good to set this to _something_ because leaving transactions open forever is really bad.
 	IdleInTxSessionTimeout = 1 * time.Hour


### PR DESCRIPTION
This is reasonable because:

1. Most application transactions now set a context with a much shorter
time limit, and contexts are preferable for timeout control anyway.
2. Migrations occasionally need longer to get a lock and complete. See
this comment from a node operator:

> I belive the culprit is this setting SET LOCAL lock_timeout = 15000. I ran that query manually and it took 79 seconds