### PR TITLE
Remove ambiguity around confirmations in direct request delegate

### DIFF
--- a/core/services/directrequest/delegate_test.go
+++ b/core/services/directrequest/delegate_test.go
@@ -34,7 +34,7 @@ func TestDelegate_ServicesForSpec(t *testing.T) {
 	defer cleanupDB()
 
 	config := testConfig{
-		minRequiredOutgoingConfirmations: 1,
+		minIncomingConfirmations: 1,
 	}
 	delegate := directrequest.NewDelegate(broadcaster, runner, nil, ethClient, orm.DB, config)
 
@@ -109,7 +109,7 @@ func NewDirectRequestUniverseWithConfig(t *testing.T, drConfig testConfig) *Dire
 
 func NewDirectRequestUniverse(t *testing.T) *DirectRequestUniverse {
 	drConfig := testConfig{
-		minRequiredOutgoingConfirmations: 1,
+		minIncomingConfirmations: 1,
 	}
 	return NewDirectRequestUniverseWithConfig(t, drConfig)
 }
@@ -332,8 +332,8 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 
 	t.Run("Log has sufficient funds", func(t *testing.T) {
 		drConfig := testConfig{
-			minRequiredOutgoingConfirmations: 1,
-			minimumContractPayment:           assets.NewLink(100),
+			minIncomingConfirmations: 1,
+			minimumContractPayment:   assets.NewLink(100),
 		}
 		uni := NewDirectRequestUniverseWithConfig(t, drConfig)
 		defer uni.Cleanup()
@@ -383,8 +383,8 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 
 	t.Run("Log has insufficient funds", func(t *testing.T) {
 		drConfig := testConfig{
-			minRequiredOutgoingConfirmations: 1,
-			minimumContractPayment:           assets.NewLink(100),
+			minIncomingConfirmations: 1,
+			minimumContractPayment:   assets.NewLink(100),
 		}
 		uni := NewDirectRequestUniverseWithConfig(t, drConfig)
 		defer uni.Cleanup()
@@ -423,12 +423,12 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 }
 
 type testConfig struct {
-	minRequiredOutgoingConfirmations uint64
-	minimumContractPayment           *assets.Link
+	minIncomingConfirmations uint32
+	minimumContractPayment   *assets.Link
 }
 
-func (c testConfig) MinRequiredOutgoingConfirmations() uint64 {
-	return c.minRequiredOutgoingConfirmations
+func (c testConfig) MinIncomingConfirmations() uint32 {
+	return c.minIncomingConfirmations
 }
 
 func (c testConfig) MinimumContractPayment() *assets.Link {

--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -180,12 +180,12 @@ func (WebhookSpec) TableName() string {
 }
 
 type DirectRequestSpec struct {
-	ID               int32               `toml:"-" gorm:"primary_key"`
-	ContractAddress  models.EIP55Address `toml:"contractAddress"`
-	OnChainJobSpecID models.JobID        `toml:"jobID"`
-	NumConfirmations clnull.Uint32       `toml:"numConfirmations"`
-	CreatedAt        time.Time           `toml:"-"`
-	UpdatedAt        time.Time           `toml:"-"`
+	ID                       int32               `toml:"-" gorm:"primary_key"`
+	ContractAddress          models.EIP55Address `toml:"contractAddress"`
+	OnChainJobSpecID         models.JobID        `toml:"jobID"`
+	MinIncomingConfirmations clnull.Uint32       `toml:"minIncomingConfirmations"`
+	CreatedAt                time.Time           `toml:"-"`
+	UpdatedAt                time.Time           `toml:"-"`
 }
 
 func (DirectRequestSpec) TableName() string {

--- a/core/store/migrations/0032_rename_direct_request_specs_num_confirmations.go
+++ b/core/store/migrations/0032_rename_direct_request_specs_num_confirmations.go
@@ -1,0 +1,20 @@
+package migrations
+
+import (
+	"gorm.io/gorm"
+)
+
+const up32 = `ALTER TABLE direct_request_specs RENAME COLUMN num_confirmations TO min_incoming_confirmations;`
+const down32 = `ALTER TABLE direct_request_specs RENAME COLUMN min_incoming_confirmations TO num_confirmations;`
+
+func init() {
+	Migrations = append(Migrations, &Migration{
+		ID: "0032_rename_direct_request_specs_num_confirmations",
+		Migrate: func(db *gorm.DB) error {
+			return db.Exec(up32).Error
+		},
+		Rollback: func(db *gorm.DB) error {
+			return db.Exec(down32).Error
+		},
+	})
+}

--- a/core/web/presenters/job.go
+++ b/core/web/presenters/job.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/smartcontractkit/chainlink/core/assets"
+	clnull "github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -31,19 +32,21 @@ const (
 
 // DirectRequestSpec defines the spec details of a DirectRequest Job
 type DirectRequestSpec struct {
-	ContractAddress  models.EIP55Address `json:"contractAddress"`
-	OnChainJobSpecID string              `json:"onChainJobSpecID"`
-	Initiator        string              `json:"initiator"`
-	CreatedAt        time.Time           `json:"createdAt"`
-	UpdatedAt        time.Time           `json:"updatedAt"`
+	ContractAddress          models.EIP55Address `json:"contractAddress"`
+	OnChainJobSpecID         string              `json:"onChainJobSpecID"`
+	MinIncomingConfirmations clnull.Uint32       `json:"minIncomingConfirmations"`
+	Initiator                string              `json:"initiator"`
+	CreatedAt                time.Time           `json:"createdAt"`
+	UpdatedAt                time.Time           `json:"updatedAt"`
 }
 
 // NewDirectRequestSpec initializes a new DirectRequestSpec from a
 // job.DirectRequestSpec
 func NewDirectRequestSpec(spec *job.DirectRequestSpec) *DirectRequestSpec {
 	return &DirectRequestSpec{
-		ContractAddress:  spec.ContractAddress,
-		OnChainJobSpecID: spec.OnChainJobSpecID.String(),
+		ContractAddress:          spec.ContractAddress,
+		OnChainJobSpecID:         spec.OnChainJobSpecID.String(),
+		MinIncomingConfirmations: spec.MinIncomingConfirmations,
 		// This is hardcoded to runlog. When we support other intiators, we need
 		// to change this
 		Initiator: "runlog",

--- a/core/web/presenters/job_test.go
+++ b/core/web/presenters/job_test.go
@@ -85,6 +85,7 @@ func TestJob(t *testing.T) {
 						"directRequestSpec": {
 							"contractAddress": "%s",
 							"onChainJobSpecID": "0eec7e1dd0d2476ca1a872dfb6633f46",
+							"minIncomingConfirmations": null,
 							"initiator": "runlog",
 							"createdAt":"2000-01-01T00:00:00Z",
 							"updatedAt":"2000-01-01T00:00:00Z"

--- a/operator_ui/@types/core/store/models.d.ts
+++ b/operator_ui/@types/core/store/models.d.ts
@@ -481,6 +481,7 @@ declare module 'core/store/models' {
     directRequestSpec: {
       initiator: 'runlog'
       contractAddress: common.Address
+      minIncomingConfirmations: number | null
       onChainJobSpecID: string
       createdAt: time.Time
     }

--- a/operator_ui/src/pages/Jobs/generateJobSpecDefinition.test.ts
+++ b/operator_ui/src/pages/Jobs/generateJobSpecDefinition.test.ts
@@ -313,6 +313,7 @@ observationSource = """
       directRequestSpec: {
         initiator: 'runlog',
         contractAddress: '0x3cCad4715152693fE3BC4460591e3D3Fbd071b42',
+        minIncomingConfirmations: 3,
         onChainJobSpecID: '0eec7e1dd0d2476ca1a872dfb6633f46',
         createdAt: '2021-02-19T16:00:01.115227+08:00',
       },
@@ -329,6 +330,7 @@ observationSource = """
 schemaVersion = 1
 name = "DR Job Spec"
 onChainJobSpecID = "0eec7e1dd0d2476ca1a872dfb6633f46"
+minIncomingConfirmations = 3
 contractAddress = "0x3cCad4715152693fE3BC4460591e3D3Fbd071b42"
 maxTaskDuration = "10s"
 observationSource = """

--- a/operator_ui/src/pages/Jobs/generateJobSpecDefinition.ts
+++ b/operator_ui/src/pages/Jobs/generateJobSpecDefinition.ts
@@ -204,7 +204,11 @@ function generateDirectRequestDefinition(
     type,
     maxTaskDuration,
   } = attrs
-  const { contractAddress, onChainJobSpecID } = directRequestSpec
+  const {
+    contractAddress,
+    onChainJobSpecID,
+    minIncomingConfirmations,
+  } = directRequestSpec
 
   return stringifyJobSpec({
     value: {
@@ -212,6 +216,7 @@ function generateDirectRequestDefinition(
       schemaVersion,
       name,
       onChainJobSpecID,
+      minIncomingConfirmations,
       contractAddress,
       maxTaskDuration,
       observationSource: pipelineSpec.dotDagSource,


### PR DESCRIPTION
It was using the wrong confirmations (outgoing, not incoming).

I renamed everything to make it clearer.