### PR TITLE
Fix StartStopOnce test occasionally failing

### DIFF
--- a/core/utils/utils_test.go
+++ b/core/utils/utils_test.go
@@ -523,6 +523,7 @@ func Test_StartStopOnce_MultipleStartNoBlock(t *testing.T) {
 
 			return nil
 		})
+		<-next
 		ch <- 2
 
 	}()
@@ -534,6 +535,7 @@ func Test_StartStopOnce_MultipleStartNoBlock(t *testing.T) {
 		})
 		next <- true
 		ch <- 3
+		next <- true
 
 	}()
 


### PR DESCRIPTION
Execution ordering would race, and especially on -p 1 the first
goroutine might keep executing past the end of StartStopOnce before
yielding execution to the second goroutine.

We explicitly yield now to give the second goroutine time to continue.

```
$ go test -count 10000 -run "Test_StartStopOnce_MultipleStartNoBlock" ./...

--- FAIL: Test_StartStopOnce_MultipleStartNoBlock (0.00s)
    utils_test.go:541:
        	Error Trace:	utils_test.go:541
        	Error:      	Not equal:
        	            	expected: 3
        	            	actual  : 2
        	Test:       	Test_StartStopOnce_MultipleStartNoBlock
--- FAIL: Test_StartStopOnce_MultipleStartNoBlock (0.00s)
    utils_test.go:541:
        	Error Trace:	utils_test.go:541
        	Error:      	Not equal:
        	            	expected: 3
        	            	actual  : 2
        	Test:       	Test_StartStopOnce_MultipleStartNoBlock
--- FAIL: Test_StartStopOnce_MultipleStartNoBlock (0.00s)
    utils_test.go:541:
        	Error Trace:	utils_test.go:541
        	Error:      	Not equal:
        	            	expected: 3
        	            	actual  : 2
        	Test:       	Test_StartStopOnce_MultipleStartNoBlock
FAIL
FAIL	github.com/smartcontractkit/chainlink/core/utils	0.317s
```