### PR TITLE
Abort node startup if Chain ID changes

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -453,8 +453,7 @@ func validateCurrentChainID(store *strpkg.Store) error {
 	err := store.GetConfigValue("ChainID", currentChainID)
 	if err != nil {
 		if errors.Cause(err) == orm.ErrorNotFound {
-			err := store.SetConfigValue("ChainID", chainID)
-			if err != nil {
+			if err = store.SetConfigValue("ChainID", chainID); err != nil {
 				return err
 			}
 			return nil

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -448,7 +448,7 @@ var ErrNewChainID = errors.New("The ChainID has changed since last run, this is 
 // Changes to ChainID are not supported, because various records are assumed to
 // represent on chain state.
 func validateCurrentChainID(store *strpkg.Store) error {
-	var currentChainID *big.Int
+	currentChainID := new(big.Int)
 	err := store.GetConfigValue("ChainID", currentChainID)
 	if err != nil && errors.Cause(err) != orm.ErrorNotFound {
 		return err

--- a/core/services/chainlink/application_test.go
+++ b/core/services/chainlink/application_test.go
@@ -7,7 +7,9 @@ import (
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/require"
@@ -70,4 +72,19 @@ func TestChainlinkApplication_resumesPendingConnection_Archived(t *testing.T) {
 
 	require.NoError(t, app.StartAndConnect())
 	_ = cltest.WaitForJobRunToComplete(t, store, jr)
+}
+
+func TestChainlinkApplication_ChangeInChainID(t *testing.T) {
+	config, cfgCleanup := cltest.NewConfig(t)
+	defer cfgCleanup()
+	app, cleanup := cltest.NewApplicationWithConfig(t, config)
+	defer cleanup()
+
+	config.Set("ETH_CHAIN_ID", 7853)
+	require.NoError(t, app.Start())
+	require.NoError(t, app.Stop())
+
+	config.Set("ETH_CHAIN_ID", 2663)
+	err := app.Start()
+	assert.Equal(t, chainlink.ErrNewChainID, err)
 }

--- a/core/services/chainlink/application_test.go
+++ b/core/services/chainlink/application_test.go
@@ -3,6 +3,7 @@
 package chainlink_test
 
 import (
+	"context"
 	"syscall"
 	"testing"
 
@@ -80,11 +81,8 @@ func TestChainlinkApplication_ChangeInChainID(t *testing.T) {
 	app, cleanup := cltest.NewApplicationWithConfig(t, config)
 	defer cleanup()
 
+	require.NoError(t, app.Store.SetConfigStrValue(context.TODO(), "ChainID", "2663"))
 	config.Set("ETH_CHAIN_ID", 7853)
-	require.NoError(t, app.Start())
-	require.NoError(t, app.Stop())
-
-	config.Set("ETH_CHAIN_ID", 2663)
 	err := app.Start()
 	assert.Equal(t, chainlink.ErrNewChainID, err)
 }

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -734,7 +734,9 @@ func (orm *ORM) SetConfigValue(field string, value encoding.TextMarshaler) error
 	if err != nil {
 		return err
 	}
-	return orm.DB.Where(models.Configuration{Name: name}).
+	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+	defer cancel()
+	return orm.DB.WithContext(ctx).Where(models.Configuration{Name: name}).
 		Assign(models.Configuration{Name: name, Value: string(textValue)}).
 		FirstOrCreate(&models.Configuration{}).Error
 }

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -734,9 +734,7 @@ func (orm *ORM) SetConfigValue(field string, value encoding.TextMarshaler) error
 	if err != nil {
 		return err
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
-	defer cancel()
-	return orm.DB.WithContext(ctx).Where(models.Configuration{Name: name}).
+	return orm.DB.Where(models.Configuration{Name: name}).
 		Assign(models.Configuration{Name: name, Value: string(textValue)}).
 		FirstOrCreate(&models.Configuration{}).Error
 }

--- a/core/store/orm/orm.go
+++ b/core/store/orm/orm.go
@@ -749,6 +749,16 @@ func (orm *ORM) SetConfigStrValue(ctx context.Context, field string, value strin
 		FirstOrCreate(&models.Configuration{}).Error
 }
 
+// GetOrSetConfigValue persists the configuration value if not already
+// persisted, always returning the value persisted to the DB.
+func (orm *ORM) GetOrSetConfigValue(field, value string) (string, error) {
+	name := EnvVarName(field)
+	config := models.Configuration{Name: name, Value: value}
+	return config.Value, orm.DB.
+		Where(models.Configuration{Name: name}).
+		FirstOrCreate(&config).Error
+}
+
 // CreateJob saves a job to the database and adds IDs to associated tables.
 func (orm *ORM) CreateJob(job *models.JobSpec) error {
 	return orm.convenientTransaction(func(dbtx *gorm.DB) error {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -77,6 +77,8 @@ In addition, a minor annoyance has been fixed whereby previously if you enabled 
 
 - MINIMUM_CONTRACT_PAYMENT_LINK_JUELS replaces MINIMUM_CONTRACT_PAYMENT, which will be deprecated in a future release.
 
+- If the ETH_CHAIN_ID is changed between successive invocations of the Chainlink Node, it will abort. We cannot currently support this scenario as the Chainlink Node only persists state about the chain it was connected to.
+
 - INSECURE_SKIP_VERIFY configuration variable disables verification of the Chainlink SSL certificates when using the CLI.
 
 - JSON parse tasks (v2) now permit an empty `path` parameter.


### PR DESCRIPTION
Use the config store to save the Chain ID used for the first run of the Chainlink Node.
This should be far cheaper for performance/storage than the proposed implementation of saving a chainID for every row in the heads table.