### PR TITLE
Use Golang CI Lint to replace golang/static tests

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,31 @@
+name: golangci-lint
+on: pull_request
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.40.1
+
+          # Optional: working directory, useful for monorepos
+          # working-directory: somedir
+
+          # Optional: golangci-lint command line arguments.
+          args: --timeout=2m0s --tests=false
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          # only-new-issues: true
+
+          # Optional: if set to true then the action will use pre-installed Go.
+          # skip-go-installation: true
+
+          # Optional: if set to true then the action don't cache or restore ~/go/pkg.
+          # skip-pkg-cache: true
+
+          # Optional: if set to true then the action don't cache or restore ~/.cache/go-build.
+          # skip-build-cache: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,31 @@
+linters:
+  enable:
+    - exhaustive
+    - exportloopref
+    - golint
+    - goimports
+    - gosec
+  disable:
+    # Disable these default linters so we match our current lint set up
+    - deadcode
+    - gosimple
+    - ineffassign
+    - structcheck
+    - typecheck
+    - unused
+    - varcheck
+linters-settings:
+  exhaustive:
+    default-signifies-exhaustive: true
+  golint:
+    min-confidence: 1.0
+  gosec:
+    excludes:
+      - G101
+      - G104
+      - G204
+      - G304
+      - G404
+  govet:
+    # report about shadowed variables
+    check-shadowing: true

--- a/core/cmd/prompter.go
+++ b/core/cmd/prompter.go
@@ -75,7 +75,7 @@ func withTerminalResetter(f func()) {
 		logger.Fatal(err)
 	}
 
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -306,7 +306,8 @@ func NewJobPipelineV2(t testing.TB, tc *TestConfig, db *gorm.DB) JobPipelineV2Te
 func NewPipelineORM(t testing.TB, config *TestConfig, db *gorm.DB) (pipeline.ORM, postgres.EventBroadcaster, func()) {
 	t.Helper()
 	eventBroadcaster := postgres.NewEventBroadcaster(config.DatabaseURL(), 0, 0)
-	eventBroadcaster.Start()
+	err := eventBroadcaster.Start()
+	require.NoError(t, err)
 	return pipeline.NewORM(db, config), eventBroadcaster, func() {
 		eventBroadcaster.Close()
 	}
@@ -315,7 +316,8 @@ func NewPipelineORM(t testing.TB, config *TestConfig, db *gorm.DB) (pipeline.ORM
 func NewEthBroadcaster(t testing.TB, store *strpkg.Store, keyStore bulletprooftxmanager.KeyStore, config *TestConfig, keys ...ethkey.Key) (*bulletprooftxmanager.EthBroadcaster, func()) {
 	t.Helper()
 	eventBroadcaster := postgres.NewEventBroadcaster(config.DatabaseURL(), 0, 0)
-	eventBroadcaster.Start()
+	err := eventBroadcaster.Start()
+	require.NoError(t, err)
 	return bulletprooftxmanager.NewEthBroadcaster(store.DB, store.EthClient, config, keyStore, &postgres.NullAdvisoryLocker{}, eventBroadcaster, keys), func() {
 		eventBroadcaster.Close()
 	}
@@ -482,7 +484,8 @@ func NewApplicationWithConfig(t testing.TB, tc *TestConfig, flagsAndDeps ...inte
 	ta.Server = server
 	ta.wsServer = tc.wsServer
 	return ta, func() {
-		ta.StopIfStarted()
+		err := ta.StopIfStarted()
+		require.NoError(t, err)
 	}
 }
 
@@ -532,9 +535,12 @@ func (ta *TestApplication) Start() error {
 	ta.Started = true
 	// TODO - RYAN - we should have a global keystore.Unlock() function
 	// https://app.clubhouse.io/chainlinklabs/story/7735/combine-keystores
-	ta.ChainlinkApplication.KeyStore.Eth().Unlock(Password)
+	err := ta.ChainlinkApplication.KeyStore.Eth().Unlock(Password)
+	if err != nil {
+		return err
+	}
 
-	err := ta.ChainlinkApplication.Start()
+	err = ta.ChainlinkApplication.Start()
 	return err
 }
 
@@ -573,7 +579,10 @@ func (ta *TestApplication) Stop() error {
 	// TODO: Here we double close, which is less than ideal.
 	// We would prefer to invoke a method on an interface that
 	// cleans up only in test.
-	ta.ChainlinkApplication.StopIfStarted()
+	err := ta.ChainlinkApplication.StopIfStarted()
+	if err != nil {
+		return err
+	}
 	cleanUpStore(ta.t, ta.Store)
 	if ta.Server != nil {
 		ta.Server.Close()
@@ -708,7 +717,8 @@ func cleanUpStore(t testing.TB, store *strpkg.Store) {
 			logger.Warn("unable to clear test store:", err)
 		}
 	}()
-	logger.Sync()
+	// Ignore sync errors for testing
+	_ = logger.Sync()
 	require.NoError(t, store.Close())
 }
 
@@ -726,7 +736,8 @@ func ParseJSONAPIErrors(t testing.TB, body io.Reader) *models.JSONAPIErrors {
 	b, err := ioutil.ReadAll(body)
 	require.NoError(t, err)
 	var respJSON models.JSONAPIErrors
-	json.Unmarshal(b, &respJSON)
+	err = json.Unmarshal(b, &respJSON)
+	require.NoError(t, err)
 	return &respJSON
 }
 

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -234,7 +234,7 @@ func NewPeerID() p2ppeer.ID {
 
 func randomBytes(n int) []byte {
 	b := make([]byte, n)
-	rand.Read(b)
+	_, _ = rand.Read(b) // Assignment for errcheck. Only used in tests so we can ignore.
 	return b
 }
 

--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -261,7 +261,7 @@ func NewHTTPMockServer(
 		called = true
 
 		w.WriteHeader(status)
-		io.WriteString(w, response)
+		_, _ = io.WriteString(w, response) // Assignment for errcheck. Only used in tests so we can ignore.
 	})
 
 	server := httptest.NewServer(handler)
@@ -285,7 +285,7 @@ func NewHTTPMockServerWithRequest(
 		called = true
 
 		w.WriteHeader(status)
-		io.WriteString(w, response)
+		_, _ = io.WriteString(w, response) // Assignment for errcheck. Only used in tests so we can ignore.
 	})
 
 	server := httptest.NewServer(handler)
@@ -300,7 +300,7 @@ func NewHTTPMockServerWithAlterableResponse(
 	server = httptest.NewServer(
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, response())
+			_, _ = io.WriteString(w, response())
 		}))
 	return server
 }
@@ -310,7 +310,7 @@ func NewHTTPMockServerWithAlterableResponseAndRequest(t *testing.T, response fun
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			callback(r)
 			w.WriteHeader(http.StatusOK)
-			io.WriteString(w, response())
+			_, _ = io.WriteString(w, response())
 		}))
 	return server
 }

--- a/core/services/keystore/csa.go
+++ b/core/services/keystore/csa.go
@@ -90,8 +90,8 @@ func (ks *CSA) Unlock(password string) error {
 		return err
 	}
 
-	for _, key := range keys {
-		err := ks.unlockAndAddKey(&key, password)
+	for i := range keys {
+		err := ks.unlockAndAddKey(&keys[i], password)
 		errs = multierr.Append(errs, err)
 	}
 

--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -53,6 +53,7 @@ type runner struct {
 }
 
 var (
+	// PromPipelineTaskExecutionTime reports how long each pipeline task took to execute
 	// TODO: Make private again after
 	// https://app.clubhouse.io/chainlinklabs/story/6065/hook-keeper-up-to-use-tasks-in-the-pipeline
 	PromPipelineTaskExecutionTime = promauto.NewGaugeVec(prometheus.GaugeOpts{

--- a/core/services/scheduler.go
+++ b/core/services/scheduler.go
@@ -117,14 +117,15 @@ func (r *Recurring) Stop() {
 // AddJob looks for "cron" initiators, adds them to cron's schedule
 // for execution when specified.
 func (r *Recurring) AddJob(job models.JobSpec) {
-	for _, initr := range job.InitiatorsFor(models.InitiatorCron) {
-		_, err := r.Cron.AddFunc(string(initr.Schedule), func() {
+	initrs := job.InitiatorsFor(models.InitiatorCron)
+	for i := range initrs {
+		_, err := r.Cron.AddFunc(string(initrs[i].Schedule), func() {
 			now := time.Now()
 			if !job.Started(now) || job.Ended(now) {
 				return
 			}
 
-			_, err := r.runManager.Create(job.ID, &initr, nil, &models.RunRequest{})
+			_, err := r.runManager.Create(job.ID, &initrs[i], nil, &models.RunRequest{})
 			if err != nil && !ExpectedRecurringScheduleJobError(err) {
 				logger.Errorw(err.Error())
 			}

--- a/core/store/models/log_events.go
+++ b/core/store/models/log_events.go
@@ -70,7 +70,7 @@ var topicFactoryMap = map[common.Hash]logRequestParser{
 // (InitiatorFluxMonitor kicks off work, but not a user-specified job.)
 var LogBasedChainlinkJobInitiators = []string{InitiatorRunLog, InitiatorEthLog, InitiatorRandomnessLog}
 
-// topicsForInitiatorsWhichRequireJobSpecTopic are the log topics which kick off
+// TopicsForInitiatorsWhichRequireJobSpecIDTopic are the log topics which kick off
 // a user job with the given type of initiator. If chainlink has any jobs with
 // these initiators, it subscribes on startup to logs which match both these
 // topics and some representation of the job spec ID.

--- a/core/store/orm/config.go
+++ b/core/store/orm/config.go
@@ -54,9 +54,10 @@ var (
 
 	configFileNotFoundError = reflect.TypeOf(viper.ConfigFileNotFoundError{})
 
-	// keyed by ChainID
+	// ChainSpecificDefaults are keyed by ChainID
 	ChainSpecificDefaults map[int64]ChainSpecificDefaultSet
-	// If the chain is unknown, fallback to the general defaults
+	// GeneralDefaults are chain defaults for when the chain is unknown.
+	// Fallback to the general defaults.
 	GeneralDefaults ChainSpecificDefaultSet
 )
 


### PR DESCRIPTION
Adds [golangci-lint](https://github.com/golangci/golangci-lint) to the CI test suite. This runs the all the linters in a single job, and also caches dependencies between requests which greatly improves the test speed. I've disabled some default linters to give us the exact same functionality as our current tests, but we may want to consider adding them back in if they could be useful.

Another nice feature this adds are annotations to the files. No longer do you have to dig through the logs to find that error. They will now be [annotations](https://github.com/golangci/golangci-lint-action/blob/master/static/annotations.png) which you can see in the `Files Changed` tab



This covers all the existing tests in `golang/static`. Once this gets merged, we can remove the `golang/static` tests and remove them `required` branch protection. This will help to lighten the load on Github Actions.