### PR TITLE
Remove string-format linter

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,7 +16,7 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          args: --timeout=2m0s --tests=false
+          args: --timeout=3m0s --tests=false
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -59,7 +59,7 @@ linters-settings:
       - name: waitgroup-by-value
       - name: unconditional-recursion
       - name: struct-tag
-      - name: string-format
+      # - name: string-format
       - name: string-of-int
       # - name: range-val-address
       - name: range-val-in-closure


### PR DESCRIPTION
We don't have any string formatting requirements, so this was producing a warning when running lint.