### PR TITLE
Performance improvements for Arbitrum config lookup with libocr

### DIFF
--- a/core/services/offchainreporting/arbitrum_block_translator.go
+++ b/core/services/offchainreporting/arbitrum_block_translator.go
@@ -1,0 +1,258 @@
+package offchainreporting
+
+import (
+	"context"
+	"fmt"
+	"math/big"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/eth"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/chainlink/core/utils"
+)
+
+// ArbitrumBlockTranslator uses Arbitrum's special L1BlockNumber to optimise log lookups
+// Performance matters here hence the use of both memo AND cache
+// We don't ever want to do the same work more than once because calling eth_getBlockByNumber a lot is expensive
+type ArbitrumBlockTranslator struct {
+	ethClient eth.Client
+	// l2->l1 cache
+	cache   map[int64]int64
+	cacheMu sync.RWMutex
+	l2Locks utils.KeyedMutex
+}
+
+// NewArbitrumBlockTranslator returns a concrete ArbitrumBlockTranslator
+func NewArbitrumBlockTranslator(ethClient eth.Client) *ArbitrumBlockTranslator {
+	return &ArbitrumBlockTranslator{
+		ethClient,
+		make(map[int64]int64),
+		sync.RWMutex{},
+		utils.KeyedMutex{},
+	}
+}
+
+// NumberToQueryRange implements BlockTranslator interface
+func (a *ArbitrumBlockTranslator) NumberToQueryRange(ctx context.Context, changedInL1Block uint64) (fromBlock *big.Int, toBlock *big.Int) {
+	var err error
+	fromBlock, toBlock, err = a.BinarySearch(ctx, int64(changedInL1Block))
+	if err != nil {
+		logger.Warnw("ArbitrumBlockTranslator: failed to binary search L2->L1, falling back to slow scan over entire chain", "err", err)
+		return big.NewInt(0), nil
+	}
+
+	return
+}
+
+// BinarySearch uses both cache and RPC calls to find the smallest possible range of L2 block numbers that encompasses the given L1 block number
+//
+// Imagine as a virtual array of L1 block numbers indexed by L2 block numbers
+// L1 values are likely duplicated so it looks something like
+// [42, 42, 42, 42, 42, 155, 155, 155, 430, 430, 430, 430, 430, ...]
+// Theoretical max difference between L1 values is typically about 5, "worst case" is 6545 but can be arbtrarily high if sequencer is broken
+// The general strategy here is to search in from the left to find the leftmost edge of the L1 we are looking for
+// Then search in from the right to find the rightmost edge
+// The range of L2s encompassed from leftmost thru rightmost represent all possible L2s that correspond to the L1 value we are looking for
+func (a *ArbitrumBlockTranslator) BinarySearch(ctx context.Context, targetL1 int64) (l2lowerBound *big.Int, l2upperBound *big.Int, err error) {
+	mark := time.Now()
+	var n int
+	defer func() {
+		duration := time.Since(mark)
+		logger.Debugw(fmt.Sprintf("ArbitrumBlockTranslator#binarySearch completed in %s with %d total lookups", duration, n), "finishedIn", duration, "err", err, "nLookups", n)
+	}()
+	var h *models.Head
+
+	// l2lower...l2upper is the exclusive range of L2 block numbers in which
+	// transactions that called block.number will return the given L1 block
+	// number
+	var l2lower int64
+	var l2upper int64
+
+	var skipUpperBound bool
+
+	{
+		var maybeL2Upper *int64
+		l2lower, maybeL2Upper = a.reverseLookup(targetL1)
+		if maybeL2Upper != nil {
+			l2upper = *maybeL2Upper
+		} else {
+			// Initial query to get highest L1 and L2 numbers
+			h, err = a.ethClient.HeaderByNumber(ctx, nil)
+			n++
+			if err != nil {
+				return nil, nil, err
+			}
+			if h == nil {
+				return nil, nil, errors.New("got nil head")
+			}
+			if !h.L1BlockNumber.Valid {
+				return nil, nil, errors.New("head was missing L1 block number")
+			}
+			currentL1 := h.L1BlockNumber.Int64
+			currentL2 := h.Number
+
+			a.cachePut(currentL2, currentL1)
+
+			// NOTE: This case shouldn't ever happen but we ought to handle them in the least broken way possible
+			if targetL1 > currentL1 {
+				// real upper must always be nil, we can skip the upper limit part of the binary search
+				logger.Debugf("ArbitrumBlockTranslator#BinarySearch target of %d is above current L1 block number of %d, using nil for upper bound", targetL1, currentL1)
+				return big.NewInt(currentL2), nil, nil
+			} else if targetL1 == currentL1 {
+				// NOTE: If the latest seen L2 block corresponds to the target L1
+				// block, we have to leave the top end of the range open because future
+				// L2 blocks can be produced that would also match
+				skipUpperBound = true
+			}
+			l2upper = currentL2
+		}
+	}
+
+	logger.Tracef("ArbitrumBlockTranslator#BinarySearch starting search for L2 range wrapping L1 block number %d between bounds [%d, %d]", targetL1, l2lower, l2upper)
+
+	// LEFT EDGE
+
+	// Expect either left or right search to make an exact match, if they don't something has gone badly wrong
+	var exactMatch bool
+	{
+		l2lower, err = search(l2lower, l2upper+1, func(l2 int64) (bool, error) {
+			l1, miss, err := a.arbL2ToL1(ctx, l2)
+			if miss {
+				n++
+			}
+			if err != nil {
+				return false, err
+			}
+			if targetL1 == l1 {
+				exactMatch = true
+			}
+			return l1 >= targetL1, nil
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	// RIGHT EDGE
+	if !skipUpperBound {
+		r, err := search(l2lower, l2upper+1, func(l2 int64) (bool, error) {
+			l1, miss, err := a.arbL2ToL1(ctx, l2)
+			if miss {
+				n++
+			}
+			if err != nil {
+				return false, err
+			}
+			if targetL1 == l1 {
+				exactMatch = true
+			}
+			return l1 > targetL1, nil
+		})
+		if err != nil {
+			return nil, nil, err
+		}
+		l2upper = r - 1
+		l2upperBound = big.NewInt(l2upper)
+	}
+	if !exactMatch {
+		return nil, nil, errors.Errorf("target L1 block number %d is not represented by any L2 block", targetL1)
+	}
+	return big.NewInt(l2lower), l2upperBound, nil
+}
+
+// reverseLookup takes an l1 and returns lower and upper bounds for an L2 based on cache data
+func (a *ArbitrumBlockTranslator) reverseLookup(targetL1 int64) (from int64, to *int64) {
+	type val struct {
+		l1 int64
+		l2 int64
+	}
+	vals := make([]val, 0)
+
+	a.cacheMu.RLock()
+	defer a.cacheMu.RUnlock()
+
+	for l2, l1 := range a.cache {
+		vals = append(vals, val{l1, l2})
+	}
+
+	sort.Slice(vals, func(i, j int) bool { return vals[i].l1 < vals[j].l1 })
+
+	for _, val := range vals {
+		if val.l1 < targetL1 {
+			from = val.l2
+		} else if val.l1 > targetL1 && to == nil {
+			// workaround golang footgun; can't take a pointer to val
+			l2 := val.l2
+			to = &l2
+		}
+	}
+	return
+}
+
+func (a *ArbitrumBlockTranslator) arbL2ToL1(ctx context.Context, l2 int64) (l1 int64, cacheMiss bool, err error) {
+	// This locking block synchronises access specifically around one l2 number so we never fetch the same data concurrently
+	// One thread will wait while the other fetches
+	unlock := a.l2Locks.LockInt64(l2)
+	defer unlock()
+
+	var exists bool
+	if l1, exists = a.cacheGet(l2); exists {
+		return l1, false, err
+	}
+
+	h, err := a.ethClient.HeaderByNumber(ctx, big.NewInt(l2))
+	if err != nil {
+		return 0, true, err
+	}
+	if h == nil {
+		return 0, true, errors.New("got nil head")
+	}
+	if !h.L1BlockNumber.Valid {
+		return 0, true, errors.New("head was missing L1 block number")
+	}
+	l1 = h.L1BlockNumber.Int64
+
+	a.cachePut(l2, l1)
+
+	return l1, true, nil
+}
+
+func (a *ArbitrumBlockTranslator) cacheGet(l2 int64) (l1 int64, exists bool) {
+	a.cacheMu.RLock()
+	defer a.cacheMu.RUnlock()
+	l1, exists = a.cache[l2]
+	return
+}
+
+func (a *ArbitrumBlockTranslator) cachePut(l2, l1 int64) {
+	a.cacheMu.Lock()
+	defer a.cacheMu.Unlock()
+	a.cache[l2] = l1
+}
+
+// stolen from golang standard library and modified for 64-bit ints,
+// customisable range and erroring function
+// see: https://golang.org/src/sort/search.go
+func search(i, j int64, f func(int64) (bool, error)) (int64, error) {
+	// Define f(-1) == false and f(n) == true.
+	// Invariant: f(i-1) == false, f(j) == true.
+	for i < j {
+		h := int64(uint64(i+j) >> 1) // avoid overflow when computing h
+		// i ≤ h < j
+		is, err := f(h)
+		if err != nil {
+			return 0, err
+		}
+		if !is {
+			i = h + 1 // preserves f(i-1) == false
+		} else {
+			j = h // preserves f(j) == true
+		}
+	}
+	// i == j, f(i-1) == false, and f(j) (= f(i)) == true  =>  answer is i.
+	return i, nil
+}

--- a/core/services/offchainreporting/arbitrum_block_translator.go
+++ b/core/services/offchainreporting/arbitrum_block_translator.go
@@ -139,7 +139,8 @@ func (a *ArbitrumBlockTranslator) BinarySearch(ctx context.Context, targetL1 int
 
 	// RIGHT EDGE
 	if !skipUpperBound {
-		r, err := search(l2lower, l2upper+1, func(l2 int64) (bool, error) {
+		var r int64
+		r, err = search(l2lower, l2upper+1, func(l2 int64) (bool, error) {
 			l1, miss, err := a.arbL2ToL1(ctx, l2)
 			if miss {
 				n++
@@ -156,12 +157,11 @@ func (a *ArbitrumBlockTranslator) BinarySearch(ctx context.Context, targetL1 int
 			return nil, nil, err
 		}
 		l2upper = r - 1
-		l2upperBound = big.NewInt(l2upper)
 	}
 	if !exactMatch {
 		return nil, nil, errors.Errorf("target L1 block number %d is not represented by any L2 block", targetL1)
 	}
-	return big.NewInt(l2lower), l2upperBound, nil
+	return big.NewInt(l2lower), big.NewInt(l2upper), nil
 }
 
 // reverseLookup takes an l1 and returns lower and upper bounds for an L2 based on cache data

--- a/core/services/offchainreporting/arbitrum_block_translator.go
+++ b/core/services/offchainreporting/arbitrum_block_translator.go
@@ -120,12 +120,12 @@ func (a *ArbitrumBlockTranslator) BinarySearch(ctx context.Context, targetL1 int
 	var exactMatch bool
 	{
 		l2lower, err = search(l2lower, l2upper+1, func(l2 int64) (bool, error) {
-			l1, miss, err := a.arbL2ToL1(ctx, l2)
+			l1, miss, err2 := a.arbL2ToL1(ctx, l2)
 			if miss {
 				n++
 			}
-			if err != nil {
-				return false, err
+			if err2 != nil {
+				return false, err2
 			}
 			if targetL1 == l1 {
 				exactMatch = true
@@ -141,12 +141,12 @@ func (a *ArbitrumBlockTranslator) BinarySearch(ctx context.Context, targetL1 int
 	if !skipUpperBound {
 		var r int64
 		r, err = search(l2lower, l2upper+1, func(l2 int64) (bool, error) {
-			l1, miss, err := a.arbL2ToL1(ctx, l2)
+			l1, miss, err2 := a.arbL2ToL1(ctx, l2)
 			if miss {
 				n++
 			}
-			if err != nil {
-				return false, err
+			if err2 != nil {
+				return false, err2
 			}
 			if targetL1 == l1 {
 				exactMatch = true
@@ -157,11 +157,12 @@ func (a *ArbitrumBlockTranslator) BinarySearch(ctx context.Context, targetL1 int
 			return nil, nil, err
 		}
 		l2upper = r - 1
+		l2upperBound = big.NewInt(l2upper)
 	}
 	if !exactMatch {
 		return nil, nil, errors.Errorf("target L1 block number %d is not represented by any L2 block", targetL1)
 	}
-	return big.NewInt(l2lower), big.NewInt(l2upper), nil
+	return big.NewInt(l2lower), l2upperBound, nil
 }
 
 // reverseLookup takes an l1 and returns lower and upper bounds for an L2 based on cache data

--- a/core/services/offchainreporting/arbitrum_block_translator_test.go
+++ b/core/services/offchainreporting/arbitrum_block_translator_test.go
@@ -1,0 +1,263 @@
+package offchainreporting_test
+
+import (
+	"context"
+	"math/big"
+	mrand "math/rand"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/internal/mocks"
+	"github.com/smartcontractkit/chainlink/core/null"
+	"github.com/smartcontractkit/chainlink/core/services/offchainreporting"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+)
+
+func TestArbitrumBlockTranslator_BinarySearch(t *testing.T) {
+	t.Parallel()
+
+	blocks := generateDeterministicL2Blocks()
+
+	t.Run("returns range of current to nil if target is above current block number", func(t *testing.T) {
+		client := new(mocks.Client)
+		abt := offchainreporting.NewArbitrumBlockTranslator(client)
+		ctx := context.Background()
+
+		var changedInL1Block int64 = 5541
+
+		latestBlock := blocks[1000]
+		client.On("HeaderByNumber", ctx, (*big.Int)(nil)).Return(&latestBlock, nil).Once()
+
+		from, to, err := abt.BinarySearch(ctx, changedInL1Block)
+		require.NoError(t, err)
+
+		assert.Equal(t, big.NewInt(1000), from)
+		assert.Equal(t, (*big.Int)(nil), to)
+		client.AssertExpectations(t)
+	})
+
+	t.Run("returns error if changedInL1Block is less than the lowest possible L1 block on the L2 chain", func(t *testing.T) {
+		client := new(mocks.Client)
+		abt := offchainreporting.NewArbitrumBlockTranslator(client)
+		ctx := context.Background()
+
+		var changedInL1Block int64 = 42
+
+		latestBlock := blocks[1000]
+		client.On("HeaderByNumber", ctx, (*big.Int)(nil)).Return(&latestBlock, nil).Once()
+
+		tmp := new(models.Head)
+		client.On("HeaderByNumber", ctx, mock.AnythingOfType("*big.Int")).Return(tmp, nil).Run(func(args mock.Arguments) {
+			*tmp = blocks[args[1].(*big.Int).Int64()]
+		})
+
+		_, _, err := abt.BinarySearch(ctx, changedInL1Block)
+
+		assert.EqualError(t, err, "target L1 block number 42 is not represented by any L2 block")
+
+		client.AssertExpectations(t)
+	})
+
+	t.Run("returns error if L1 block number does not exist for any range of L2 blocks", func(t *testing.T) {
+		client := new(mocks.Client)
+		abt := offchainreporting.NewArbitrumBlockTranslator(client)
+		ctx := context.Background()
+
+		var changedInL1Block int64 = 5043
+
+		latestBlock := blocks[1000]
+		client.On("HeaderByNumber", ctx, (*big.Int)(nil)).Return(&latestBlock, nil).Once()
+
+		tmp := new(models.Head)
+		client.On("HeaderByNumber", ctx, mock.AnythingOfType("*big.Int")).Return(tmp, nil).Run(func(args mock.Arguments) {
+			*tmp = blocks[args[1].(*big.Int).Int64()]
+		})
+
+		_, _, err := abt.BinarySearch(ctx, changedInL1Block)
+
+		assert.EqualError(t, err, "target L1 block number 5043 is not represented by any L2 block")
+
+		client.AssertExpectations(t)
+	})
+
+	t.Run("returns correct range of L2 blocks that encompasses all possible blocks that might contain the given L1 block number", func(t *testing.T) {
+		client := new(mocks.Client)
+		abt := offchainreporting.NewArbitrumBlockTranslator(client)
+		ctx := context.Background()
+
+		var changedInL1Block int64 = 5042
+
+		latestBlock := blocks[1000]
+		client.On("HeaderByNumber", ctx, (*big.Int)(nil)).Return(&latestBlock, nil).Once()
+
+		tmp := new(models.Head)
+		client.On("HeaderByNumber", ctx, mock.AnythingOfType("*big.Int")).Return(tmp, nil).Run(func(args mock.Arguments) {
+			h := blocks[args[1].(*big.Int).Int64()]
+			*tmp = h
+		})
+
+		from, to, err := abt.BinarySearch(ctx, changedInL1Block)
+		require.NoError(t, err)
+
+		assert.Equal(t, big.NewInt(98), from)
+		assert.Equal(t, big.NewInt(137), to)
+
+		client.AssertExpectations(t)
+	})
+
+	t.Run("handles edge case where L1 is the smallest possible value", func(t *testing.T) {
+		client := new(mocks.Client)
+		abt := offchainreporting.NewArbitrumBlockTranslator(client)
+		ctx := context.Background()
+
+		var changedInL1Block int64 = 5000
+
+		latestBlock := blocks[1000]
+		client.On("HeaderByNumber", ctx, (*big.Int)(nil)).Return(&latestBlock, nil).Once()
+
+		tmp := new(models.Head)
+		client.On("HeaderByNumber", ctx, mock.AnythingOfType("*big.Int")).Return(tmp, nil).Run(func(args mock.Arguments) {
+			h := blocks[args[1].(*big.Int).Int64()]
+			*tmp = h
+		})
+
+		from, to, err := abt.BinarySearch(ctx, changedInL1Block)
+		require.NoError(t, err)
+
+		assert.Equal(t, big.NewInt(0), from)
+		assert.Equal(t, big.NewInt(16), to)
+
+		client.AssertExpectations(t)
+	})
+
+	t.Run("leaves upper bound unbounded where L1 is the largest possible value", func(t *testing.T) {
+		client := new(mocks.Client)
+		abt := offchainreporting.NewArbitrumBlockTranslator(client)
+		ctx := context.Background()
+
+		var changedInL1Block int64 = 5540
+
+		latestBlock := blocks[1000]
+		client.On("HeaderByNumber", ctx, (*big.Int)(nil)).Return(&latestBlock, nil).Once()
+
+		tmp := new(models.Head)
+		client.On("HeaderByNumber", ctx, mock.AnythingOfType("*big.Int")).Return(tmp, nil).Run(func(args mock.Arguments) {
+			h := blocks[args[1].(*big.Int).Int64()]
+			*tmp = h
+		})
+
+		from, to, err := abt.BinarySearch(ctx, changedInL1Block)
+		require.NoError(t, err)
+
+		assert.Equal(t, big.NewInt(986), from)
+		assert.Equal(t, (*big.Int)(nil), to)
+		// assert.Equal(t, (*big.Int)(nil), to)
+
+		client.AssertExpectations(t)
+	})
+
+	t.Run("caches duplicate lookups", func(t *testing.T) {
+		client := new(mocks.Client)
+		abt := offchainreporting.NewArbitrumBlockTranslator(client)
+		ctx := context.Background()
+
+		var changedInL1Block int64 = 5042
+
+		latestBlock := blocks[1000]
+		// Latest is never cached
+		client.On("HeaderByNumber", ctx, (*big.Int)(nil)).Return(&latestBlock, nil).Once()
+
+		tmp := new(models.Head)
+		client.On("HeaderByNumber", ctx, mock.AnythingOfType("*big.Int")).Times(20+18+14).Return(tmp, nil).Run(func(args mock.Arguments) {
+			h := blocks[args[1].(*big.Int).Int64()]
+			*tmp = h
+		})
+
+		// First search, nothing cached (total 21 - bsearch 20)
+		from, to, err := abt.BinarySearch(ctx, changedInL1Block)
+		require.NoError(t, err)
+
+		assert.Equal(t, big.NewInt(98), from)
+		assert.Equal(t, big.NewInt(137), to)
+
+		var changedInL1Block2 int64 = 5351
+
+		// Second search, initial lookup cached + space reduced to [549, 1000] (total 18 - bsearch 18)
+		from, to, err = abt.BinarySearch(ctx, changedInL1Block2)
+		require.NoError(t, err)
+
+		assert.Equal(t, big.NewInt(670), from)
+		assert.Equal(t, big.NewInt(697), to)
+
+		var changedInL1Block3 int64 = 5193
+
+		// Third search, initial lookup cached + space reduced to [323, 500] (total 14 - bsearch 14)
+		from, to, err = abt.BinarySearch(ctx, changedInL1Block3)
+		require.NoError(t, err)
+
+		assert.Equal(t, big.NewInt(403), from)
+		assert.Equal(t, big.NewInt(448), to)
+
+		client.AssertExpectations(t)
+	})
+
+	// TODO: test edge cases - at left edge of range, at right edge
+}
+
+func TestArbitrumBlockTranslator_NumberToQueryRange(t *testing.T) {
+	t.Parallel()
+
+	t.Run("falls back to whole range on error", func(t *testing.T) {
+		client := new(mocks.Client)
+		abt := offchainreporting.NewArbitrumBlockTranslator(client)
+		ctx := context.Background()
+		var changedInL1Block uint64 = 5042
+
+		client.On("HeaderByNumber", ctx, (*big.Int)(nil)).Return(nil, errors.New("something exploded")).Once()
+
+		from, to := abt.NumberToQueryRange(ctx, changedInL1Block)
+		assert.Equal(t, big.NewInt(0), from)
+		assert.Equal(t, (*big.Int)(nil), to)
+	})
+
+	t.Run("falls back to whole range on missing head", func(t *testing.T) {
+		client := new(mocks.Client)
+		abt := offchainreporting.NewArbitrumBlockTranslator(client)
+		ctx := context.Background()
+		var changedInL1Block uint64 = 5042
+
+		client.On("HeaderByNumber", ctx, (*big.Int)(nil)).Return(nil, nil).Once()
+
+		from, to := abt.NumberToQueryRange(ctx, changedInL1Block)
+		assert.Equal(t, big.NewInt(0), from)
+		assert.Equal(t, (*big.Int)(nil), to)
+	})
+}
+
+func generateDeterministicL2Blocks() (heads []models.Head) {
+	source := mrand.NewSource(0)
+	deterministicRand := mrand.New(source)
+	l2max := 1000
+	var l1BlockNumber int64 = 5000
+	var parentHash common.Hash
+	for i := 0; i <= l2max; i++ {
+		head := models.Head{
+			Number:        int64(i),
+			L1BlockNumber: null.Int64From(l1BlockNumber),
+			Hash:          cltest.NewHash(),
+			ParentHash:    parentHash,
+		}
+		parentHash = head.Hash
+		heads = append(heads, head)
+		if deterministicRand.Intn(10) == 1 { // 10% chance
+			// l1 number should jump by "about" 5 but this is variable depending on whether the sequencer got to post, network conditions etc
+			l1BlockNumber += int64(deterministicRand.Intn(6) + 4)
+		}
+	}
+	return
+}

--- a/core/services/offchainreporting/block_translator.go
+++ b/core/services/offchainreporting/block_translator.go
@@ -1,23 +1,26 @@
 package offchainreporting
 
 import (
+	"context"
 	"math/big"
 
 	"github.com/smartcontractkit/chainlink/core/chains"
+	"github.com/smartcontractkit/chainlink/core/services/eth"
+	"github.com/smartcontractkit/chainlink/core/store/models"
 )
 
 // BlockTranslator converts emitted block numbers (from block.number) into a
 // block number range suitable for query in FilterLogs
 type BlockTranslator interface {
-	NumberToQueryRange(changedInBlock uint64) (fromBlock *big.Int, toBlock *big.Int)
+	NumberToQueryRange(ctx context.Context, changedInL1Block uint64) (fromBlock *big.Int, toBlock *big.Int)
 }
 
 // NewBlockTranslator returns the block translator for the given chain
-func NewBlockTranslator(chain *chains.Chain) BlockTranslator {
+func NewBlockTranslator(chain *chains.Chain, client eth.Client) BlockTranslator {
 	if chain == nil {
 		return &l1BlockTranslator{}
 	} else if chain.IsArbitrum() {
-		return newArbitrumBlockTranslator(chain)
+		return NewArbitrumBlockTranslator(client)
 	} else if chain.IsOptimism() {
 		return newOptimismBlockTranslator()
 	}
@@ -26,26 +29,11 @@ func NewBlockTranslator(chain *chains.Chain) BlockTranslator {
 
 type l1BlockTranslator struct{}
 
-func (*l1BlockTranslator) NumberToQueryRange(changedInBlock uint64) (fromBlock *big.Int, toBlock *big.Int) {
-	return big.NewInt(int64(changedInBlock)), big.NewInt(int64(changedInBlock))
+func (*l1BlockTranslator) NumberToQueryRange(_ context.Context, changedInL1Block uint64) (fromBlock *big.Int, toBlock *big.Int) {
+	return big.NewInt(int64(changedInL1Block)), big.NewInt(int64(changedInL1Block))
 }
 
-type arbitrumBlockTranslator struct{}
-
-func newArbitrumBlockTranslator(chain *chains.Chain) *arbitrumBlockTranslator {
-	return &arbitrumBlockTranslator{}
-}
-
-func (a *arbitrumBlockTranslator) NumberToQueryRange(changedInBlock uint64) (fromBlock *big.Int, toBlock *big.Int) {
-	// TODO: OPTIMISE THIS
-	// TODO: Logic goes here that:
-	// 1. Subscribes to SequencerBatchDeliveredFromOrigin on https://github.com/OffchainLabs/arbitrum/blob/next/packages/arb-bridge-eth/contracts/bridge/SequencerInbox.sol#L138
-	// 2. Updates local state with mapping of L1 range -> L2 range
-	// 3. Includes some sort of database persistence?
-	// Currently we simply query the entire block range. This is correct, but very slow and suboptimal
-	// See: https://app.clubhouse.io/chainlinklabs/story/11270/optimise-blocktranslator-ocr-for-optimism-and-arbitrum
-	return big.NewInt(0), nil
-}
+func (*l1BlockTranslator) OnNewLongestChain(context.Context, models.Head) {}
 
 type optimismBlockTranslator struct{}
 
@@ -53,9 +41,9 @@ func newOptimismBlockTranslator() *optimismBlockTranslator {
 	return &optimismBlockTranslator{}
 }
 
-func (*optimismBlockTranslator) NumberToQueryRange(changedInBlock uint64) (fromBlock *big.Int, toBlock *big.Int) {
+func (*optimismBlockTranslator) NumberToQueryRange(_ context.Context, changedInL1Block uint64) (fromBlock *big.Int, toBlock *big.Int) {
 	// TODO: OPTIMISE THIS
 	// Currently we simply query the entire block range. This is correct, but very slow and suboptimal
-	// See: https://app.clubhouse.io/chainlinklabs/story/11270/optimise-blocktranslator-ocr-for-optimism-and-arbitrum
+	// https://app.clubhouse.io/chainlinklabs/story/11524/optimise-blocktranslator-ocr-for-optimism
 	return big.NewInt(0), nil
 }

--- a/core/services/offchainreporting/block_translator_test.go
+++ b/core/services/offchainreporting/block_translator_test.go
@@ -1,45 +1,50 @@
 package offchainreporting_test
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/core/chains"
+	"github.com/smartcontractkit/chainlink/core/internal/mocks"
 	"github.com/smartcontractkit/chainlink/core/services/offchainreporting"
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_BlockTranslator(t *testing.T) {
+	ethClient := new(mocks.Client)
+	ctx := context.Background()
+
 	t.Run("for L1 chains, returns the block changed argument", func(t *testing.T) {
 		chain := chains.ChainFromID(big.NewInt(1))
 
-		bt := offchainreporting.NewBlockTranslator(chain)
+		bt := offchainreporting.NewBlockTranslator(chain, ethClient)
 
-		from, to := bt.NumberToQueryRange(42)
+		from, to := bt.NumberToQueryRange(ctx, 42)
 
 		assert.Equal(t, big.NewInt(42), from)
 		assert.Equal(t, big.NewInt(42), to)
 	})
 
-	t.Run("for L2 chains, returns an initial block number and nil", func(t *testing.T) {
-		bt := offchainreporting.NewBlockTranslator(chains.ArbitrumMainnet)
-		from, to := bt.NumberToQueryRange(42)
+	t.Run("for optimism, returns an initial block number and nil", func(t *testing.T) {
+		bt := offchainreporting.NewBlockTranslator(chains.OptimismMainnet, ethClient)
+		from, to := bt.NumberToQueryRange(ctx, 42)
 		assert.Equal(t, big.NewInt(0), from)
 		assert.Equal(t, (*big.Int)(nil), to)
 
-		bt = offchainreporting.NewBlockTranslator(chains.ArbitrumRinkeby)
-		from, to = bt.NumberToQueryRange(42)
-		assert.Equal(t, big.NewInt(0), from)
-		assert.Equal(t, (*big.Int)(nil), to)
-
-		bt = offchainreporting.NewBlockTranslator(chains.OptimismMainnet)
-		from, to = bt.NumberToQueryRange(42)
-		assert.Equal(t, big.NewInt(0), from)
-		assert.Equal(t, (*big.Int)(nil), to)
-
-		bt = offchainreporting.NewBlockTranslator(chains.OptimismKovan)
-		from, to = bt.NumberToQueryRange(42)
+		bt = offchainreporting.NewBlockTranslator(chains.OptimismKovan, ethClient)
+		from, to = bt.NumberToQueryRange(ctx, 42)
 		assert.Equal(t, big.NewInt(0), from)
 		assert.Equal(t, (*big.Int)(nil), to)
 	})
+
+	t.Run("for arbitrum, returns the ArbitrumBlockTranslator", func(t *testing.T) {
+		bt := offchainreporting.NewBlockTranslator(chains.ArbitrumMainnet, ethClient)
+		assert.IsType(t, &offchainreporting.ArbitrumBlockTranslator{}, bt)
+
+		bt = offchainreporting.NewBlockTranslator(chains.ArbitrumRinkeby, ethClient)
+		assert.IsType(t, &offchainreporting.ArbitrumBlockTranslator{}, bt)
+	})
+
+	ethClient.AssertExpectations(t)
 }

--- a/core/store/migrations/0040_heads_l1_block_number.go
+++ b/core/store/migrations/0040_heads_l1_block_number.go
@@ -1,0 +1,24 @@
+package migrations
+
+import (
+	"gorm.io/gorm"
+)
+
+const up40 = `
+ALTER TABLE heads ADD COLUMN l1_block_number bigint;
+`
+const down40 = `
+ALTER TABLE heads DROP COLUMN l1_block_number;
+`
+
+func init() {
+	Migrations = append(Migrations, &Migration{
+		ID: "0040_heads_l1_block_number",
+		Migrate: func(db *gorm.DB) error {
+			return db.Exec(up40).Error
+		},
+		Rollback: func(db *gorm.DB) error {
+			return db.Exec(down40).Error
+		},
+	})
+}

--- a/core/store/models/eth.go
+++ b/core/store/models/eth.go
@@ -15,6 +15,7 @@ import (
 	uuid "github.com/satori/go.uuid"
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -126,13 +127,14 @@ func (a EthTxAttempt) GetSignedTx() (*types.Transaction, error) {
 
 // Head represents a BlockNumber, BlockHash.
 type Head struct {
-	ID         uint64
-	Hash       common.Hash
-	Number     int64
-	ParentHash common.Hash
-	Parent     *Head `gorm:"-"`
-	Timestamp  time.Time
-	CreatedAt  time.Time
+	ID            uint64
+	Hash          common.Hash
+	Number        int64
+	L1BlockNumber null.Int64
+	ParentHash    common.Hash
+	Parent        *Head `gorm:"-"`
+	Timestamp     time.Time
+	CreatedAt     time.Time
 }
 
 // NewHead returns a Head instance.
@@ -253,10 +255,11 @@ func (h *Head) NextInt() *big.Int {
 
 func (h *Head) UnmarshalJSON(bs []byte) error {
 	type head struct {
-		Hash       common.Hash    `json:"hash"`
-		Number     *hexutil.Big   `json:"number"`
-		ParentHash common.Hash    `json:"parentHash"`
-		Timestamp  hexutil.Uint64 `json:"timestamp"`
+		Hash          common.Hash    `json:"hash"`
+		Number        *hexutil.Big   `json:"number"`
+		ParentHash    common.Hash    `json:"parentHash"`
+		Timestamp     hexutil.Uint64 `json:"timestamp"`
+		L1BlockNumber *hexutil.Big   `json:"l1BlockNumber"`
 	}
 
 	var jsonHead head
@@ -274,6 +277,9 @@ func (h *Head) UnmarshalJSON(bs []byte) error {
 	h.Number = (*big.Int)(jsonHead.Number).Int64()
 	h.ParentHash = jsonHead.ParentHash
 	h.Timestamp = time.Unix(int64(jsonHead.Timestamp), 0).UTC()
+	if jsonHead.L1BlockNumber != nil {
+		h.L1BlockNumber = null.Int64From((*big.Int)(jsonHead.L1BlockNumber).Int64())
+	}
 	return nil
 }
 

--- a/core/store/models/eth_test.go
+++ b/core/store/models/eth_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -283,6 +284,16 @@ func TestHead_UnmarshalJSON(t *testing.T) {
 				Timestamp:  time.Unix(0x58318da2, 0).UTC(),
 			},
 		},
+		{"arbitrum",
+			`{"number":"0x15156","hash":"0x752dab43f7a2482db39227d46cd307623b26167841e2207e93e7566ab7ab7871","parentHash":"0x923ad1e27c1d43cb2d2fb09e26d2502ca4b4914a2e0599161d279c6c06117d34","mixHash":"0x0000000000000000000000000000000000000000000000000000000000000000","nonce":"0x0000000000000000","sha3Uncles":"0x1dcc4de8dec75d7aab85b567b6ccd41ad312451b948a7413f0a142fd40d49347","logsBloom":"0x00000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000","transactionsRoot":"0x71448077f5ce420a8e24db62d4d58e8d8e6ad2c7e76318868e089d41f7e0faf3","stateRoot":"0x0000000000000000000000000000000000000000000000000000000000000000","receiptsRoot":"0x2c292672b8fc9d223647a2569e19721f0757c96a1421753a93e141f8e56cf504","miner":"0x0000000000000000000000000000000000000000","difficulty":"0x0","totalDifficulty":"0x0","extraData":"0x","size":"0x0","gasLimit":"0x11278208","gasUsed":"0x3d1fe9","timestamp":"0x60d0952d","transactions":["0xa1ea93556b93ed3b45cb24f21c8deb584e6a9049c35209242651bf3533c23b98","0xfc6593c45ba92351d17173aa1381e84734d252ab0169887783039212c4a41024","0x85ee9d04fd0ebb5f62191eeb53cb45d9c0945d43eba444c3548de2ac8421682f","0x50d120936473e5b75f6e04829ad4eeca7a1df7d3c5026ebb5d34af936a39b29c"],"uncles":[],"l1BlockNumber":"0x8652f9"}`,
+			models.Head{
+				Hash:          common.HexToHash("0x752dab43f7a2482db39227d46cd307623b26167841e2207e93e7566ab7ab7871"),
+				Number:        0x15156,
+				ParentHash:    common.HexToHash("0x923ad1e27c1d43cb2d2fb09e26d2502ca4b4914a2e0599161d279c6c06117d34"),
+				Timestamp:     time.Unix(0x60d0952d, 0).UTC(),
+				L1BlockNumber: null.Int64From(0x8652f9),
+			},
+		},
 		{"not found",
 			`null`,
 			models.Head{},
@@ -295,10 +306,11 @@ func TestHead_UnmarshalJSON(t *testing.T) {
 			var head models.Head
 			err := head.UnmarshalJSON([]byte(test.json))
 			require.NoError(t, err)
-			require.Equal(t, test.expected.Hash, head.Hash)
-			require.Equal(t, test.expected.Number, head.Number)
-			require.Equal(t, test.expected.ParentHash, head.ParentHash)
-			require.Equal(t, test.expected.Timestamp.UTC().Unix(), head.Timestamp.UTC().Unix())
+			assert.Equal(t, test.expected.Hash, head.Hash)
+			assert.Equal(t, test.expected.Number, head.Number)
+			assert.Equal(t, test.expected.ParentHash, head.ParentHash)
+			assert.Equal(t, test.expected.Timestamp.UTC().Unix(), head.Timestamp.UTC().Unix())
+			assert.Equal(t, test.expected.L1BlockNumber, head.L1BlockNumber)
 		})
 	}
 }

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -981,3 +981,17 @@ func WithJitter(d time.Duration) time.Duration {
 	jitter = jitter - (jitter / 2)
 	return time.Duration(int(d) + jitter)
 }
+
+// KeyedMutex allows to lock based on particular values
+type KeyedMutex struct {
+	mutexes sync.Map
+}
+
+// LockInt64 locks the value for read/write
+func (m *KeyedMutex) LockInt64(key int64) func() {
+	value, _ := m.mutexes.LoadOrStore(key, new(sync.Mutex))
+	mtx := value.(*sync.Mutex)
+	mtx.Lock()
+
+	return func() { mtx.Unlock() }
+}


### PR DESCRIPTION
Uses binary search and caching to narrow down the range of L2 blocks for the config lookup and make it much more performant.