### PR TITLE
fix: TestHTTPGet_TimeoutAllowsRetries is still flaky

### DIFF
--- a/core/adapters/http_test.go
+++ b/core/adapters/http_test.go
@@ -110,10 +110,8 @@ func TestHTTPGet_Perform(t *testing.T) {
 }
 
 func TestHTTPGet_TimeoutAllowsRetries(t *testing.T) {
-	t.Parallel()
-
 	store := leanStore()
-	store.Config.Set("DEFAULT_HTTP_TIMEOUT", "30ms")
+	store.Config.Set("DEFAULT_HTTP_TIMEOUT", "80ms")
 	store.Config.Set("MAX_HTTP_ATTEMPTS", "2")
 
 	attempts := make(chan struct{}, 2)
@@ -123,7 +121,7 @@ func TestHTTPGet_TimeoutAllowsRetries(t *testing.T) {
 		require.NoError(t, err)
 		assert.Greater(t, len(b), 0)
 		attempts <- struct{}{}
-		timeoutOnce.Do(func() { time.Sleep(31 * time.Millisecond) })
+		timeoutOnce.Do(func() { time.Sleep(81 * time.Millisecond) })
 	})
 	server := httptest.NewServer(handler)
 	defer server.Close()


### PR DESCRIPTION
The CI runs the tests with -p 4 but runs on a single core.

Based on the output:

    === CONT  TestHTTPGet_TimeoutAllowsRetries
    2021-06-25T01:17:38Z [32m[DEBUG] [0mhttp adapter got 200 in 43.609482ms                [34mutils/http.go:148[0m       [32mstatusCode[0m=200 [32mtimeElapsedSeconds[0m=0.043609482
    2021-06-25T01:17:38Z [32m[DEBUG] [0mhttp adapter finished after 44.074182ms            [34mutils/http.go:157[0m       [32mstatusCode[0m=200 [32mtimeElapsedSeconds[0m=0.044074182
    === RUN   TestHttpPost_Perform/success_with_headers
    2021-06-25T01:17:38Z [33m[WARN]  [0mhttp adapter got error                             [34mutils/http.go:141[0m       [32merror[0m=Post "http://127.0.0.1:45441": context deadline exceeded
    2021-06-25T01:17:38Z [32m[DEBUG] [0mhttp adapter error, will retry                     [34mutils/http.go:127[0m       [32mattempt[0m=1 [32merror[0m=Post "http://127.0.0.1:45441": context deadline exceeded [32mtimeout[0m=0.03
    2021-06-25T01:17:38Z [32m[DEBUG] [0mhttp adapter got 200 in 21.646492ms                [34mutils/http.go:148[0m       [32mstatusCode[0m=200 [32mtimeElapsedSeconds[0m=0.021646492
    2021-06-25T01:17:38Z [32m[DEBUG] [0mhttp adapter finished after 21.764591ms            [34mutils/http.go:157[0m       [32mstatusCode[0m=200 [32mtimeElapsedSeconds[0m=0.021764591
    === RUN   TestHttpPost_Perform/not_found
    === RUN   TestRandom_Perform_CheckFulfillment/both_missing
    === RUN   TestRandom_Perform_CheckFulfillment/address_missing,_seed/block_present
    === RUN   TestRandom_Perform_CheckFulfillment/address_present,_seed/block_missing
    === CONT  TestRandom_Perform_CheckFulfillment
        random_test.go:129: PASS:	CallContract(string,mock.argumentMatcher,string)
    === RUN   TestRandom_Perform_CheckFulfillment/both_present
    --- PASS: TestRandom_Perform (0.19s)
    === CONT  TestRandom_Perform_CheckFulfillment
        random_test.go:129: PASS:	CallContract(string,mock.argumentMatcher,string)
        random_test.go:129: PASS:	CallContract(string,mock.argumentMatcher,string)
    2021-06-25T01:17:38Z [33m[WARN]  [0mhttp adapter got error                             [34mutils/http.go:141[0m       [32merror[0m=Post "http://127.0.0.1:45441": context deadline exceeded
    === CONT  TestHTTPGet_TimeoutAllowsRetries
        http_test.go:138:
                    Error Trace:	http_test.go:138
                    Error:      	Received unexpected error:
                                    Post "http://127.0.0.1:45441": context deadline exceeded
                    Test:       	TestHTTPGet_TimeoutAllowsRetries
    --- FAIL: TestHTTPGet_TimeoutAllowsRetries (0.10s)

It seems that the first attempt fails, then golang switches execution to
a different test. By the time we resume execution the context deadline
already expired.

    GOMAXPROCS=1 LOG_LEVEL=debug go test -v -run "TestHTTPGet_TimeoutAllowsRetries"
    2021-06-25T02:45:11Z [DEBUG] Using seed: 1624589111299866053                    cltest/cltest.go:154
    === RUN   TestHTTPGet_TimeoutAllowsRetries
    === PAUSE TestHTTPGet_TimeoutAllowsRetries
    === CONT  TestHTTPGet_TimeoutAllowsRetries
    2021-06-25T02:45:11Z [WARN]  http adapter got error                             utils/http.go:141       error=Post "http://127.0.0.1:37933": context deadline exceeded
    2021-06-25T02:45:11Z [DEBUG] http adapter error, will retry                     utils/http.go:127       attempt=1 error=Post "http://127.0.0.1:37933": context deadline exceeded timeout=0.03
    2021-06-25T02:45:11Z [WARN]  http adapter got error                             utils/http.go:141       error=Post "http://127.0.0.1:37933": context deadline exceeded
        http_test.go:138:
                    Error Trace:    http_test.go:138
                    Error:          Received unexpected error:
                                    Post "http://127.0.0.1:37933": context deadline exceeded
                    Test:           TestHTTPGet_TimeoutAllowsRetries
    --- FAIL: TestHTTPGet_TimeoutAllowsRetries (0.07s)
    FAIL
    exit status 1
    FAIL    github.com/smartcontractkit/chainlink/core/adapters     0.170s

Don't run the test in parallel and increase the timeout limit to give
the runtime more time.