### PR TITLE
L2 explicit flag added

### DIFF
--- a/contracts/src/v0.6/L2ExplicitFlag.sol
+++ b/contracts/src/v0.6/L2ExplicitFlag.sol
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.6.6;
+
+import "./interfaces/L2FlagInterface.sol";
+import "./interfaces/AccessControllerInterface.sol";
+import "./SimpleReadAccessController.sol";
+
+/**
+ * @title The L2ExplicitFlag contract
+ * @notice Explicit Flag that let readers know about
+ * every feed state inside a L2 network
+ */
+contract L2ExplicitFlag is L2FlagInterface, SimpleReadAccessController {
+    AccessControllerInterface public raisingAccessController;
+
+    event RaisingAccessControllerUpdated(address indexed previous, address indexed current);
+    event FlagLowered(bool _raised);
+    event FlagRaised(bool _raised);
+    bool private raised;
+
+    /**
+     * @param racAddress address for the raising access controller.
+     */
+    constructor(address racAddress) public {
+        setRaisingAccessController(racAddress);
+    }
+
+    /**
+     * @notice allows owner to change the access controller for raising flags.
+     * @param racAddress new address for the raising access controller.
+     */
+    function setRaisingAccessController(address racAddress) public override onlyOwner() {
+        address previous = address(raisingAccessController);
+
+        if (previous != racAddress) {
+            raisingAccessController = AccessControllerInterface(racAddress);
+
+            emit RaisingAccessControllerUpdated(previous, racAddress);
+        }
+    }
+
+    function raiseFlag() external override {
+        require(allowedToChangeFlag(), "Not allowed to raise the flag");
+        if (!raised) {
+            raised = true;
+            emit FlagRaised(raised);
+        }
+    }
+
+    function lowerFlag() external override {
+        require(allowedToChangeFlag(), "Not allowed to lower the flag");
+        if (raised) {
+            raised = false;
+            emit FlagLowered(raised);
+        }
+    }
+
+    function isRaised() external view override returns (bool) {
+        return raised;
+    }
+
+    // PRIVATE
+    function allowedToChangeFlag() private view returns (bool) {
+        return msg.sender == owner || raisingAccessController.hasAccess(msg.sender, msg.data);
+    }
+}

--- a/contracts/src/v0.6/interfaces/L2FlagInterface.sol
+++ b/contracts/src/v0.6/interfaces/L2FlagInterface.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+
+interface L2FlagInterface {
+    function raiseFlag() external;
+
+    function lowerFlag() external;
+
+    function isRaised() external view returns (bool);
+
+    function setRaisingAccessController(address) external;
+}

--- a/contracts/src/v0.6/tests/L2ExplicitFlagTestHelper.sol
+++ b/contracts/src/v0.6/tests/L2ExplicitFlagTestHelper.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.6.0;
+
+import "../L2ExplicitFlag.sol";
+
+contract L2ExplicitFlagTestHelper {
+    L2ExplicitFlag public flag;
+
+    constructor(address flagContract) public {
+        flag = L2ExplicitFlag(flagContract);
+    }
+
+    function isRaised() external view returns (bool) {
+        return flag.isRaised();
+    }
+}

--- a/contracts/test/v0.6/L2ExplicitFlag.test.ts
+++ b/contracts/test/v0.6/L2ExplicitFlag.test.ts
@@ -1,0 +1,232 @@
+import { ethers } from "hardhat";
+import { publicAbi } from "../test-helpers/helpers";
+import { assert, expect } from "chai";
+import { Contract, ContractFactory } from "ethers";
+import { Personas, getUsers } from "../test-helpers/setup";
+
+let personas: Personas;
+
+let controllerFactory: ContractFactory;
+let l2ExplicitFlagFactory: ContractFactory;
+let consumerFactory: ContractFactory;
+
+let controller: Contract;
+let flags: Contract;
+let consumer: Contract;
+
+before(async () => {
+  personas = (await getUsers()).personas;
+  controllerFactory = await ethers.getContractFactory("SimpleWriteAccessController", personas.Nelly);
+  consumerFactory = await ethers.getContractFactory("L2ExplicitFlagTestHelper", personas.Nelly);
+  l2ExplicitFlagFactory = await ethers.getContractFactory("L2ExplicitFlag", personas.Nelly);
+});
+
+describe("L2 Explicit Flag", () => {
+  beforeEach(async () => {
+    controller = await controllerFactory.deploy();
+    flags = await l2ExplicitFlagFactory.deploy(controller.address);
+    await flags.disableAccessCheck();
+    consumer = await consumerFactory.deploy(flags.address);
+  });
+
+  it("has a limited public interface", async () => {
+    publicAbi(flags, [
+      "isRaised",
+      "lowerFlag",
+      "raiseFlag",
+      "raisingAccessController",
+      "setRaisingAccessController",
+      // Ownable methods:
+      "acceptOwnership",
+      "owner",
+      "transferOwnership",
+      // AccessControl methods:
+      "addAccess",
+      "disableAccessCheck",
+      "enableAccessCheck",
+      "removeAccess",
+      "checkEnabled",
+      "hasAccess",
+    ]);
+  });
+
+  describe("#raiseFlag", () => {
+    describe("when called by the owner", () => {
+      it("updates the warning flag", async () => {
+        assert.equal(false, await flags.isRaised());
+
+        await flags.connect(personas.Nelly).raiseFlag();
+
+        assert.equal(true, await flags.isRaised());
+      });
+
+      it("emits an event log", async () => {
+        await expect(flags.connect(personas.Nelly).raiseFlag()).to.emit(flags, "FlagRaised").withArgs(true);
+      });
+
+      describe("if the flag has already been raised", () => {
+        beforeEach(async () => {
+          await flags.connect(personas.Nelly).raiseFlag();
+        });
+
+        it("emits an event log", async () => {
+          const tx = await flags.connect(personas.Nelly).raiseFlag();
+          const receipt = await tx.wait();
+          assert.equal(0, receipt.events?.length);
+        });
+      });
+    });
+
+    describe("when called by an enabled setter", () => {
+      beforeEach(async () => {
+        await controller.connect(personas.Nelly).addAccess(await personas.Neil.getAddress());
+      });
+
+      it("raise the flag", async () => {
+        await flags.connect(personas.Neil).raiseFlag(), assert.equal(true, await flags.isRaised());
+      });
+    });
+
+    describe("when called by a non-enabled setter", () => {
+      it("reverts", async () => {
+        await expect(flags.connect(personas.Neil).raiseFlag()).to.be.revertedWith("Not allowed to raise the flag");
+      });
+    });
+
+    describe("when called when there is no raisingAccessController", () => {
+      beforeEach(async () => {
+        await expect(
+          flags.connect(personas.Nelly).setRaisingAccessController("0x0000000000000000000000000000000000000000"),
+        ).to.emit(flags, "RaisingAccessControllerUpdated");
+        assert.equal("0x0000000000000000000000000000000000000000", await flags.raisingAccessController());
+      });
+
+      it("succeeds for the owner", async () => {
+        await flags.connect(personas.Nelly).raiseFlag();
+        assert.equal(true, await flags.isRaised());
+      });
+
+      it("reverts for non-owner", async () => {
+        await expect(flags.connect(personas.Neil).raiseFlag()).to.be.reverted;
+      });
+    });
+  });
+
+  describe("#lowerFlag", () => {
+    beforeEach(async () => {
+      await flags.connect(personas.Nelly).raiseFlag();
+    });
+
+    describe("when called by the owner", () => {
+      it("updates the warning flag", async () => {
+        assert.equal(true, await flags.isRaised());
+
+        await flags.connect(personas.Nelly).lowerFlag();
+
+        assert.equal(false, await flags.isRaised());
+      });
+
+      it("emits an event log", async () => {
+        await expect(flags.connect(personas.Nelly).lowerFlag()).to.emit(flags, "FlagLowered").withArgs(false);
+      });
+
+      describe("if the flag has already been lowered", () => {
+        beforeEach(async () => {
+          await flags.connect(personas.Nelly).lowerFlag();
+        });
+
+        it("emits an event log", async () => {
+          const tx = await flags.connect(personas.Nelly).lowerFlag();
+          const receipt = await tx.wait();
+          assert.equal(0, receipt.events?.length);
+        });
+      });
+    });
+
+    describe("when called by an enabled setter", () => {
+      beforeEach(async () => {
+        await controller.connect(personas.Nelly).addAccess(await personas.Neil.getAddress());
+      });
+
+      it("lower the flag", async () => {
+        await flags.connect(personas.Neil).lowerFlag(), assert.equal(false, await flags.isRaised());
+      });
+    });
+
+    describe("when called by a non-enabled setter", () => {
+      it("reverts", async () => {
+        await expect(flags.connect(personas.Neil).lowerFlag()).to.be.revertedWith("Not allowed to lower the flag");
+      });
+    });
+
+    describe("when called when there is no raisingAccessController", () => {
+      beforeEach(async () => {
+        await expect(
+          flags.connect(personas.Nelly).setRaisingAccessController("0x0000000000000000000000000000000000000000"),
+        ).to.emit(flags, "RaisingAccessControllerUpdated");
+        assert.equal("0x0000000000000000000000000000000000000000", await flags.raisingAccessController());
+      });
+
+      it("succeeds for the owner", async () => {
+        await flags.connect(personas.Nelly).lowerFlag();
+        assert.equal(false, await flags.isRaised());
+      });
+
+      it("reverts for non-owner", async () => {
+        await expect(flags.connect(personas.Neil).lowerFlag()).to.be.reverted;
+      });
+    });
+  });
+
+  describe("#isRaised", () => {
+    describe("when called by a consumer", () => {
+      it("gets the correct status", async () => {
+        assert.equal(false, await consumer.isRaised());
+        await flags.connect(personas.Nelly).raiseFlag();
+        assert.equal(true, await consumer.isRaised());
+      });
+    });
+  });
+
+  describe("#setRaisingAccessController", () => {
+    let controller2: Contract;
+
+    beforeEach(async () => {
+      controller2 = await controllerFactory.connect(personas.Nelly).deploy();
+      await controller2.connect(personas.Nelly).enableAccessCheck();
+    });
+
+    it("updates access control rules", async () => {
+      const neilAddress = await personas.Neil.getAddress();
+      await controller.connect(personas.Nelly).addAccess(neilAddress);
+      await flags.connect(personas.Neil).raiseFlag(); // doesn't raise
+
+      await flags.connect(personas.Nelly).setRaisingAccessController(controller2.address);
+
+      await expect(flags.connect(personas.Neil).raiseFlag()).to.be.revertedWith("Not allowed to raise the flag");
+    });
+
+    it("emits a log announcing the change", async () => {
+      await expect(flags.connect(personas.Nelly).setRaisingAccessController(controller2.address))
+        .to.emit(flags, "RaisingAccessControllerUpdated")
+        .withArgs(controller.address, controller2.address);
+    });
+
+    it("does not emit a log when there is no change", async () => {
+      await flags.connect(personas.Nelly).setRaisingAccessController(controller2.address);
+
+      await expect(flags.connect(personas.Nelly).setRaisingAccessController(controller2.address)).to.not.emit(
+        flags,
+        "RaisingAccessControllerUpdated",
+      );
+    });
+
+    describe("when called by a non-owner", () => {
+      it("reverts", async () => {
+        await expect(flags.connect(personas.Neil).setRaisingAccessController(controller2.address)).to.be.revertedWith(
+          "Only callable by owner",
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
Included a ExplicitFlag contract for the Layer 2 Emergency situation.

Read the [Protocol proposal ](https://www.notion.so/chainlink/L2-Emergency-Protocol-Sequencer-offline-c184e0919da441b8b824db35f748db29#5e12066a78e0433b9d5acc78a28dcea9)for more context