### PR TITLE
Flaky tests - lack of BlockByNumber mock

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -524,6 +524,12 @@ func NewEthMocksWithStartupAssertions(t testing.TB) (*mocks.Client, *mocks.Subsc
 	c.On("EthSubscribe", mock.Anything, mock.Anything, "newHeads").Maybe().Return(EmptyMockSubscription(), nil)
 	c.On("SubscribeNewHead", mock.Anything, mock.Anything).Maybe().Return(EmptyMockSubscription(), nil)
 	c.On("SendTransaction", mock.Anything, mock.Anything).Maybe().Return(nil)
+
+	block := types.NewBlockWithHeader(&types.Header{
+		Number: big.NewInt(100),
+	})
+	c.On("BlockByNumber", mock.Anything, mock.Anything).Maybe().Return(block, nil)
+
 	s.On("Err").Return(nil).Maybe()
 	s.On("Unsubscribe").Return(nil).Maybe()
 	return c, s, assertMocksCalled


### PR DESCRIPTION
fixes a panic:

```
=== CONT  TestJobSpecsController_Destroy
2021-06-28T08:52:00Z [37m[INFO]  [0mEthConfirmer: Gas bumping is enabled, unconfirmed transactions will have their gas price bumped every 3 blocks [34mbulletprooftxmanager/eth_confirmer.go:87[0m [32methGasBumpThreshold[0m=3 
2021-06-28T08:52:00Z [32m[DEBUG] [0mStarting HeadTracker                               [34mutils/utils.go:903[0m      [32mlogger[0m=head_tracker 
2021-06-28T08:52:00Z [37m[INFO]  [0mHeadListener: Connecting to ethereum node ws://127.0.0.1:46719 in 0s [34mheadtracker/head_listener.go:101[0m [32mlogger[0m=head_tracker 
2021-06-28T08:52:00Z [37m[INFO]  [0mJobSpawner: all jobs running                       [34mjob/spawner.go:221[0m      [32mcount[0m=0 
2021-06-28T08:52:00Z [37m[INFO]  [0mJobSpawner: all jobs running                       [34mjob/spawner.go:221[0m      [32mcount[0m=0 
2021-06-28T08:52:00Z [37m[INFO]  [0mJobSpawner: all jobs running                       [34mjob/spawner.go:221[0m      [32mcount[0m=0 
panic: 
assert: mock: I don't know what to return because the method call was unexpected.
    Either do Mock.On("BlockByNumber").Return(...) first, or remove the BlockByNumber() call.
    This method was unexpected:
        BlockByNumber(*context.timerCtx,*big.Int)
        0: &context.timerCtx{cancelCtx:context.cancelCtx{Context:(*context.emptyCtx)(0xc0000b6010), mu:sync.Mutex{state:0, sema:0x0}, done:(chan struct {})(nil), children:map[context.canceler]struct {}(nil), err:error(nil)}, timer:(*time.Timer)(0xc0095d2690), deadline:time.Time{wall:0xc02e814e9f5f0806, ext:12702136620, loc:(*time.Location)(0x323e740)}}
        1: <nil>
    at: [client.go:69 subscription.go:45 job_subscriber.go:140 job_subscriber.go:192 orm.go:640 orm.go:1662 orm.go:614 job_subscriber.go:189 head_broadcaster.go:83 head_tracker.go:150 head_tracker.go:146 head_listener.go:205 head_listener.go:176 head_listener.go:101 asm_amd64.s:1374]

goroutine 10350 [running]:
github.com/stretchr/testify/mock.(*Mock).fail(0xc0092f7cc0, 0x1e4be4c, 0xc1, 0xc0095c17c0, 0x4, 0x4)
    /go/pkg/mod/github.com/stretchr/testify@v1.7.0/mock/mock.go:254 +0x17f
github.com/stretchr/testify/mock.(*Mock).MethodCalled(0xc0092f7cc0, 0x2e0a98c, 0xd, 0xc0095d64e0, 0x2, 0x2, 0xc0095c1400, 0x4, 0x4)
    /go/pkg/mod/github.com/stretchr/testify@v1.7.0/mock/mock.go:418 +0xe78
github.com/stretchr/testify/mock.(*Mock).Called(0xc0092f7cc0, 0xc0095d64e0, 0x2, 0
```