### PR TITLE
Flaky test: TestPostgresLockingStrategy_Lock_withLock

### DIFF
--- a/core/store/orm/locking_strategies_test.go
+++ b/core/store/orm/locking_strategies_test.go
@@ -45,7 +45,7 @@ func TestPostgresLockingStrategy_Lock_withLock(t *testing.T) {
 	tc, cleanup := cltest.NewConfig(t)
 	defer cleanup()
 
-	tc.Config.Set("DATABASE_TIMEOUT", "1000ms")
+	tc.Config.Set("DATABASE_TIMEOUT", "500ms")
 	delay := tc.DatabaseTimeout()
 	dbURL := tc.DatabaseURL()
 	if dbURL.String() == "" {
@@ -65,6 +65,7 @@ func TestPostgresLockingStrategy_Lock_withLock(t *testing.T) {
 
 	require.NoError(t, ls.Unlock(delay))
 	require.NoError(t, ls.Unlock(delay))
+
 	require.NoError(t, ls2.Lock(delay), "should get exclusive lock")
 	require.NoError(t, ls2.Unlock(delay))
 }

--- a/core/store/orm/locking_strategies_test.go
+++ b/core/store/orm/locking_strategies_test.go
@@ -45,7 +45,7 @@ func TestPostgresLockingStrategy_Lock_withLock(t *testing.T) {
 	tc, cleanup := cltest.NewConfig(t)
 	defer cleanup()
 
-	tc.Config.Set("DATABASE_TIMEOUT", "500ms")
+	tc.Config.Set("DATABASE_TIMEOUT", "1000ms")
 	delay := tc.DatabaseTimeout()
 	dbURL := tc.DatabaseURL()
 	if dbURL.String() == "" {


### PR DESCRIPTION
From time it seems like it failed after the timeout: (0.51s) but `driver: bad connection` is also a more mysterious suspect
Logs from a failure:

```
=== RUN   TestPostgresLockingStrategy_Lock_withLock
2021-06-28T17:56:13Z [37m[INFO]  [0mCould not get lock, retrying...                    [34morm/locking_strategies.go:142[0m [32mfailCount[0m=1 
2021-06-28T17:56:13Z [37m[INFO]  [0mStill waiting for lock...                          [34morm/locking_strategies.go:144[0m [32mfailCount[0m=2 
2021-06-28T17:56:13Z [37m[INFO]  [0mStill waiting for lock...                          [34morm/locking_strategies.go:144[0m [32mfailCount[0m=4 
2021-06-28T17:56:13Z [37m[INFO]  [0mStill waiting for lock...                          [34morm/locking_strategies.go:144[0m [32mfailCount[0m=8 
2021-06-28T17:56:13Z [37m[INFO]  [0mStill waiting for lock...                          [34morm/locking_strategies.go:144[0m [32mfailCount[0m=16 
2021-06-28T17:56:13Z [37m[INFO]  [0mStill waiting for lock...                          [34morm/locking_strategies.go:144[0m [32mfailCount[0m=32 
    locking_strategies_test.go:68: 
        	Error Trace:	locking_strategies_test.go:68
        	Error:      	Received unexpected error:
        	            	can't acquire advisory lock
        	            	github.com/smartcontractkit/chainlink/core/store/orm.init
        	            		/__w/chainlink/chainlink/core/store/orm/orm.go:52
        	            	runtime.doInit
        	            		/usr/local/go/src/runtime/proc.go:5625
        	            	runtime.doInit
        	            		/usr/local/go/src/runtime/proc.go:5620
        	            	runtime.main
        	            		/usr/local/go/src/runtime/proc.go:191
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1374
        	            	postgres advisory locking strategy failed on .Lock, timeout set to 500ms: driver: bad connection, lock ID: 7095268593392510379
        	            	github.com/smartcontractkit/chainlink/core/store/orm.(*PostgresLockingStrategy).Lock
        	            		/__w/chainlink/chainlink/core/store/orm/locking_strategies.go:92
        	            	github.com/smartcontractkit/chainlink/core/store/orm_test.TestPostgresLockingStrategy_Lock_withLock
        	            		/__w/chainlink/chainlink/core/store/orm/locking_strategies_test.go:68
        	            	testing.tRunner
        	            		/usr/local/go/src/testing/testing.go:1108
        	            	runtime.goexit
        	            		/usr/local/go/src/runtime/asm_amd64.s:1374
        	Test:       	TestPostgresLockingStrategy_Lock_withLock
        	Messages:   	should get exclusive lock
--- FAIL: TestPostgresLockingStrategy_Lock_withLock (0.51s)
```