### PR TITLE
Simplify embedded struct declarations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,7 +8,6 @@ linters:
   disable:
     # Disable these default linters so we match our current lint set up
     - deadcode
-    - gosimple
     - ineffassign
     - structcheck
     - typecheck

--- a/core/services/directrequest/delegate_test.go
+++ b/core/services/directrequest/delegate_test.go
@@ -135,7 +135,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		}
 		log.On("RawLog").Return(types.Log{
 			Topics: []common.Hash{
-				common.Hash{},
+				{},
 				uni.spec.ExternalIDToTopicHash(),
 			},
 		})
@@ -180,7 +180,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		}
 		log.On("RawLog").Return(types.Log{
 			Topics: []common.Hash{
-				common.Hash{},
+				{},
 				uni.spec.ExternalIDToTopicHash(),
 			},
 			BlockNumber: 0,
@@ -222,7 +222,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 
 		uni.logBroadcaster.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil)
 		log.On("RawLog").Return(types.Log{
-			Topics: []common.Hash{common.Hash{}, common.Hash{}},
+			Topics: []common.Hash{{}, {}},
 		})
 
 		err := uni.service.Start()
@@ -247,7 +247,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		logCancelOracleRequest := oracle_wrapper.OracleCancelOracleRequest{RequestId: uni.spec.ExternalIDToTopicHash()}
 		log.On("RawLog").Return(types.Log{
 			Topics: []common.Hash{
-				common.Hash{},
+				{},
 				uni.spec.ExternalIDToTopicHash(),
 			},
 		})
@@ -279,7 +279,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		}
 		runLog.On("RawLog").Return(types.Log{
 			Topics: []common.Hash{
-				common.Hash{},
+				{},
 				uni.spec.ExternalIDToTopicHash(),
 			},
 		})
@@ -292,7 +292,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		logCancelOracleRequest := oracle_wrapper.OracleCancelOracleRequest{RequestId: uni.spec.ExternalIDToTopicHash()}
 		cancelLog.On("RawLog").Return(types.Log{
 			Topics: []common.Hash{
-				common.Hash{},
+				{},
 				uni.spec.ExternalIDToTopicHash(),
 			},
 		})
@@ -350,7 +350,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		}
 		log.On("RawLog").Return(types.Log{
 			Topics: []common.Hash{
-				common.Hash{},
+				{},
 				uni.spec.ExternalIDToTopicHash(),
 			},
 		})
@@ -401,7 +401,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		}
 		log.On("RawLog").Return(types.Log{
 			Topics: []common.Hash{
-				common.Hash{},
+				{},
 				uni.spec.ExternalIDToTopicHash(),
 			},
 		})

--- a/core/services/fluxmonitorv2/flux_monitor_test.go
+++ b/core/services/fluxmonitorv2/flux_monitor_test.go
@@ -295,7 +295,7 @@ func TestFluxMonitor_PollIfEligible(t *testing.T) {
 
 			fm, tm := setup(t, store.DB)
 
-			tm.keyStore.On("SendingKeys").Return([]ethkey.Key{ethkey.Key{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+			tm.keyStore.On("SendingKeys").Return([]ethkey.Key{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 			tm.logBroadcaster.On("IsConnected").Return(tc.connected).Once()
 
 			// Setup Answers
@@ -441,7 +441,7 @@ func TestFluxMonitor_PollIfEligible_Creates_JobErr(t *testing.T) {
 
 	fm, tm := setup(t, store.DB)
 
-	tm.keyStore.On("SendingKeys").Return([]ethkey.Key{ethkey.Key{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+	tm.keyStore.On("SendingKeys").Return([]ethkey.Key{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 	tm.logBroadcaster.On("IsConnected").Return(true).Once()
 
 	tm.jobORM.
@@ -494,7 +494,7 @@ func TestPollingDeviationChecker_BuffersLogs(t *testing.T) {
 	chSafeToAssert := make(chan struct{})
 	chSafeToFillQueue := make(chan struct{})
 
-	tm.keyStore.On("SendingKeys").Return([]ethkey.Key{ethkey.Key{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+	tm.keyStore.On("SendingKeys").Return([]ethkey.Key{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 
 	tm.fluxAggregator.On("Address").Return(common.Address{})
 	tm.fluxAggregator.On("LatestRoundData", nilOpts).Return(freshContractRoundDataResponse()).Maybe()
@@ -671,7 +671,7 @@ func TestFluxMonitor_TriggerIdleTimeThreshold(t *testing.T) {
 
 			fm, tm := setup(t, store.DB, disablePollTicker(true), disableIdleTimer(tc.idleTimerDisabled), setIdleTimerPeriod(tc.idleDuration), withORM(orm))
 
-			tm.keyStore.On("SendingKeys").Return([]ethkey.Key{ethkey.Key{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+			tm.keyStore.On("SendingKeys").Return([]ethkey.Key{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 
 			const fetchedAnswer = 100
 			answerBigInt := big.NewInt(fetchedAnswer)
@@ -745,7 +745,7 @@ func TestFluxMonitor_IdleTimerResetsOnNewRound(t *testing.T) {
 		setIdleTimerPeriod(2*time.Second),
 	)
 
-	tm.keyStore.On("SendingKeys").Return([]ethkey.Key{ethkey.Key{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+	tm.keyStore.On("SendingKeys").Return([]ethkey.Key{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 
 	const fetchedAnswer = 100
 	answerBigInt := big.NewInt(fetchedAnswer)
@@ -910,7 +910,7 @@ func TestFluxMonitor_UsesPreviousRoundStateOnStartup_RoundTimeout(t *testing.T) 
 
 			fm, tm := setup(t, store.DB, disablePollTicker(true), disableIdleTimer(true), withORM(orm))
 
-			tm.keyStore.On("SendingKeys").Return([]ethkey.Key{ethkey.Key{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+			tm.keyStore.On("SendingKeys").Return([]ethkey.Key{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 
 			tm.logBroadcaster.On("Register", mock.Anything, mock.Anything).Return(func() {})
 			tm.logBroadcaster.On("IsConnected").Return(true).Maybe()
@@ -983,7 +983,7 @@ func TestFluxMonitor_UsesPreviousRoundStateOnStartup_IdleTimer(t *testing.T) {
 			)
 			initialPollOccurred := make(chan struct{}, 1)
 
-			tm.keyStore.On("SendingKeys").Return([]ethkey.Key{ethkey.Key{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+			tm.keyStore.On("SendingKeys").Return([]ethkey.Key{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 			tm.logBroadcaster.On("Register", mock.Anything, mock.Anything).Return(func() {})
 			tm.logBroadcaster.On("IsConnected").Return(true).Maybe()
 			tm.fluxAggregator.On("Address").Return(common.Address{})
@@ -1040,7 +1040,7 @@ func TestFluxMonitor_RoundTimeoutCausesPoll_timesOutNotZero(t *testing.T) {
 
 	fm, tm := setup(t, store.DB, disablePollTicker(true), disableIdleTimer(true), withORM(orm))
 
-	tm.keyStore.On("SendingKeys").Return([]ethkey.Key{ethkey.Key{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+	tm.keyStore.On("SendingKeys").Return([]ethkey.Key{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 
 	const fetchedAnswer = 100
 	answerBigInt := big.NewInt(fetchedAnswer)
@@ -1204,7 +1204,7 @@ func TestFluxMonitor_DoesNotDoubleSubmit(t *testing.T) {
 			answer  = 100
 		)
 
-		tm.keyStore.On("SendingKeys").Return([]ethkey.Key{ethkey.Key{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+		tm.keyStore.On("SendingKeys").Return([]ethkey.Key{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 		tm.logBroadcaster.On("IsConnected").Return(true).Maybe()
 
 		// Mocks initiated by the New Round log
@@ -1310,7 +1310,7 @@ func TestFluxMonitor_DoesNotDoubleSubmit(t *testing.T) {
 			roundID = 3
 			answer  = 100
 		)
-		tm.keyStore.On("SendingKeys").Return([]ethkey.Key{ethkey.Key{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+		tm.keyStore.On("SendingKeys").Return([]ethkey.Key{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 		tm.logBroadcaster.On("IsConnected").Return(true).Maybe()
 
 		// First, force the node to try to poll, which should result in a submission

--- a/core/services/gasupdater/gas_updater_test.go
+++ b/core/services/gasupdater/gas_updater_test.go
@@ -347,11 +347,11 @@ func TestGasUpdater_Recalculate(t *testing.T) {
 		gasupdater.SetRollingBlockHistory(gu, blocks)
 		gu.Recalculate(*cltest.Head(1))
 
-		blocks = []gasupdater.Block{gasupdater.Block{}}
+		blocks = []gasupdater.Block{{}}
 		gasupdater.SetRollingBlockHistory(gu, blocks)
 		gu.Recalculate(*cltest.Head(1))
 
-		blocks = []gasupdater.Block{gasupdater.Block{Transactions: []gasupdater.Transaction{}}}
+		blocks = []gasupdater.Block{{Transactions: []gasupdater.Transaction{}}}
 		gasupdater.SetRollingBlockHistory(gu, blocks)
 		gu.Recalculate(*cltest.Head(1))
 
@@ -372,12 +372,12 @@ func TestGasUpdater_Recalculate(t *testing.T) {
 		gu := gasupdater.GasUpdaterToStruct(guIface)
 
 		blocks := []gasupdater.Block{
-			gasupdater.Block{
+			{
 				Number:       0,
 				Hash:         cltest.NewHash(),
 				Transactions: cltest.TransactionsFromGasPrices(9001),
 			},
-			gasupdater.Block{
+			{
 				Number:       1,
 				Hash:         cltest.NewHash(),
 				Transactions: cltest.TransactionsFromGasPrices(9002),
@@ -406,12 +406,12 @@ func TestGasUpdater_Recalculate(t *testing.T) {
 		gu := gasupdater.GasUpdaterToStruct(guIface)
 
 		blocks := []gasupdater.Block{
-			gasupdater.Block{
+			{
 				Number:       0,
 				Hash:         cltest.NewHash(),
 				Transactions: cltest.TransactionsFromGasPrices(5),
 			},
-			gasupdater.Block{
+			{
 				Number:       1,
 				Hash:         cltest.NewHash(),
 				Transactions: cltest.TransactionsFromGasPrices(7),
@@ -443,23 +443,23 @@ func TestGasUpdater_Recalculate(t *testing.T) {
 		b2Hash := cltest.NewHash()
 
 		blocks := []gasupdater.Block{
-			gasupdater.Block{
+			{
 				Number:       0,
 				Hash:         b1Hash,
 				ParentHash:   common.Hash{},
 				Transactions: cltest.TransactionsFromGasPrices(50),
 			},
-			gasupdater.Block{
+			{
 				Number:       1,
 				Hash:         b2Hash,
 				ParentHash:   b1Hash,
-				Transactions: []gasupdater.Transaction{gasupdater.Transaction{GasPrice: big.NewInt(70), GasLimit: 42}},
+				Transactions: []gasupdater.Transaction{{GasPrice: big.NewInt(70), GasLimit: 42}},
 			},
-			gasupdater.Block{
+			{
 				Number:       2,
 				Hash:         cltest.NewHash(),
 				ParentHash:   b2Hash,
-				Transactions: []gasupdater.Transaction{gasupdater.Transaction{GasPrice: big.NewInt(90), GasLimit: 0}},
+				Transactions: []gasupdater.Transaction{{GasPrice: big.NewInt(90), GasLimit: 0}},
 			},
 		}
 
@@ -488,7 +488,7 @@ func TestGasUpdater_Recalculate(t *testing.T) {
 		b1Hash := cltest.NewHash()
 
 		blocks := []gasupdater.Block{
-			gasupdater.Block{
+			{
 				Number:       0,
 				Hash:         b1Hash,
 				ParentHash:   common.Hash{},
@@ -520,7 +520,7 @@ func TestGasUpdater_Recalculate(t *testing.T) {
 		b1Hash := cltest.NewHash()
 
 		blocks := []gasupdater.Block{
-			gasupdater.Block{
+			{
 				Number:       0,
 				Hash:         b1Hash,
 				ParentHash:   common.Hash{},
@@ -558,20 +558,20 @@ func TestGasUpdater_Recalculate(t *testing.T) {
 		b1Hash := cltest.NewHash()
 
 		blocks := []gasupdater.Block{
-			gasupdater.Block{
+			{
 				Number:     0,
 				Hash:       b1Hash,
 				ParentHash: common.Hash{},
 				Transactions: []gasupdater.Transaction{
-					gasupdater.Transaction{GasPrice: big.NewInt(50), GasLimit: 42},
-					gasupdater.Transaction{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
-					gasupdater.Transaction{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
-					gasupdater.Transaction{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
-					gasupdater.Transaction{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
-					gasupdater.Transaction{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
-					gasupdater.Transaction{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
-					gasupdater.Transaction{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
-					gasupdater.Transaction{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
+					{GasPrice: big.NewInt(50), GasLimit: 42},
+					{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
+					{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
+					{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
+					{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
+					{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
+					{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
+					{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
+					{GasPrice: unreasonablyHugeGasPrice, GasLimit: 42},
 				},
 			},
 		}

--- a/core/services/pipeline/task.eth_abi_decode_test.go
+++ b/core/services/pipeline/task.eth_abi_decode_test.go
@@ -54,8 +54,8 @@ func TestETHABIDecodeTask(t *testing.T) {
 			map[string]interface{}{
 				"a": common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
 				"u": [][3]*big.Int{
-					[3]*big.Int{big.NewInt(92), big.NewInt(61), big.NewInt(30)},
-					[3]*big.Int{big.NewInt(33), big.NewInt(66), big.NewInt(99)},
+					{big.NewInt(92), big.NewInt(61), big.NewInt(30)},
+					{big.NewInt(33), big.NewInt(66), big.NewInt(99)},
 				},
 				"b":   hexutil.MustDecode("0x666f6f206261722062617a0a"),
 				"b32": utils.Bytes32FromString("stevetoshi sergamoto"),

--- a/core/services/run_manager_test.go
+++ b/core/services/run_manager_test.go
@@ -187,7 +187,7 @@ func TestRunManager_ResumeAllPendingConnection(t *testing.T) {
 
 		job, err := store.FindJobSpec(run.JobSpecID)
 		require.NoError(t, err)
-		run.TaskRuns = []models.TaskRun{models.TaskRun{ID: uuid.NewV4(), TaskSpecID: job.Tasks[0].ID, Status: models.RunStatusUnstarted}}
+		run.TaskRuns = []models.TaskRun{{ID: uuid.NewV4(), TaskSpecID: job.Tasks[0].ID, Status: models.RunStatusUnstarted}}
 
 		require.NoError(t, store.CreateJobRun(&run))
 		err = runManager.ResumeAllPendingConnection()

--- a/core/services/subscription_test.go
+++ b/core/services/subscription_test.go
@@ -353,7 +353,7 @@ func TestServices_StartJobSubscription_RunlogNoTopicMatch(t *testing.T) {
 				Address: sharedAddr,
 				Data:    models.UntrustedBytes(test.data),
 				Topics: []common.Hash{
-					common.Hash{},
+					{},
 					models.IDToTopic(job.ID),
 					cltest.NewAddress().Hash(),
 					common.BigToHash(big.NewInt(0)),

--- a/core/services/synchronization/presenters_test.go
+++ b/core/services/synchronization/presenters_test.go
@@ -36,13 +36,13 @@ func TestSyncJobRunPresenter_HappyPath(t *testing.T) {
 	}
 	run := models.MakeJobRun(&job, time.Now(), &models.Initiator{Type: models.InitiatorRunLog}, big.NewInt(0), &runRequest)
 	run.TaskRuns = []models.TaskRun{
-		models.TaskRun{
+		{
 			ID:                               task0RunID,
 			Status:                           models.RunStatusPendingIncomingConfirmations,
 			ObservedIncomingConfirmations:    clnull.Uint32From(1),
 			MinRequiredIncomingConfirmations: clnull.Uint32From(3),
 		},
-		models.TaskRun{
+		{
 			ID:                               task1RunID,
 			Status:                           models.RunStatusErrored,
 			Result:                           models.RunResult{ErrorMessage: null.StringFrom("yikes fam")},
@@ -183,7 +183,7 @@ func TestSyncJobRunPresenter_EthTxTask(t *testing.T) {
 			run := models.MakeJobRun(&job, time.Now(), &models.Initiator{Type: models.InitiatorRunLog}, big.NewInt(0), &runRequest)
 			run.SetStatus(models.RunStatusCompleted)
 			run.TaskRuns = []models.TaskRun{
-				models.TaskRun{
+				{
 					ID:       uuid.NewV4(),
 					TaskSpec: taskSpec,
 					Status:   models.RunStatusPendingIncomingConfirmations,

--- a/core/services/webhook/external_initiators_test.go
+++ b/core/services/webhook/external_initiators_test.go
@@ -43,7 +43,7 @@ func TestNotifyExternalInitiator_Notified(t *testing.T) {
 			models.JobSpec{
 				ID: models.NewJobID(),
 				Initiators: []models.Initiator{
-					models.Initiator{
+					{
 						Type: models.InitiatorExternal,
 						InitiatorParams: models.InitiatorParams{
 							Name: "somecoin",
@@ -65,13 +65,13 @@ func TestNotifyExternalInitiator_Notified(t *testing.T) {
 			models.JobSpec{
 				ID: models.NewJobID(),
 				Initiators: []models.Initiator{
-					models.Initiator{
+					{
 						Type: models.InitiatorCron,
 					},
-					models.Initiator{
+					{
 						Type: models.InitiatorWeb,
 					},
-					models.Initiator{
+					{
 						Type: models.InitiatorExternal,
 						InitiatorParams: models.InitiatorParams{
 							Name: "somecoin",
@@ -156,10 +156,10 @@ func TestNotifyExternalInitiator_NotNotified(t *testing.T) {
 			models.JobSpec{
 				ID: models.NewJobID(),
 				Initiators: []models.Initiator{
-					models.Initiator{
+					{
 						Type: models.InitiatorCron,
 					},
-					models.Initiator{
+					{
 						Type: models.InitiatorWeb,
 					},
 				},
@@ -213,7 +213,7 @@ func Test_ExternalInitiatorManager_DeleteJob(t *testing.T) {
 			models.JobSpec{
 				ID: models.NewJobID(),
 				Initiators: []models.Initiator{
-					models.Initiator{
+					{
 						Type: models.InitiatorExternal,
 						InitiatorParams: models.InitiatorParams{
 							Name: "somecoin",
@@ -231,13 +231,13 @@ func Test_ExternalInitiatorManager_DeleteJob(t *testing.T) {
 			models.JobSpec{
 				ID: models.NewJobID(),
 				Initiators: []models.Initiator{
-					models.Initiator{
+					{
 						Type: models.InitiatorCron,
 					},
-					models.Initiator{
+					{
 						Type: models.InitiatorWeb,
 					},
-					models.Initiator{
+					{
 						Type: models.InitiatorExternal,
 						InitiatorParams: models.InitiatorParams{
 							Name: "somecoin",

--- a/core/store/models/job_run_test.go
+++ b/core/store/models/job_run_test.go
@@ -174,7 +174,7 @@ func TestJobRun_ApplyOutput_CompletedWithNoTasksRemaining(t *testing.T) {
 
 	job := cltest.NewJobWithWebInitiator()
 	jobRun := cltest.NewJobRun(job)
-	jobRun.TaskRuns = []models.TaskRun{models.TaskRun{}}
+	jobRun.TaskRuns = []models.TaskRun{{}}
 
 	result := models.NewRunOutputComplete(models.JSON{})
 	jobRun.TaskRuns[0].ApplyOutput(result)

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -721,7 +721,7 @@ func TestORM_AnyJobWithType(t *testing.T) {
 	defer cleanup()
 
 	js := cltest.NewJobWithWebInitiator()
-	js.Tasks = []models.TaskSpec{models.TaskSpec{Type: models.MustNewTaskType("bridgetestname")}}
+	js.Tasks = []models.TaskSpec{{Type: models.MustNewTaskType("bridgetestname")}}
 	assert.NoError(t, store.CreateJob(&js))
 	found, err := store.AnyJobWithType("bridgetestname")
 	assert.NoError(t, err)
@@ -876,7 +876,7 @@ func TestORM_PendingBridgeType_success(t *testing.T) {
 	require.NoError(t, store.CreateBridgeType(bt))
 
 	job := cltest.NewJobWithWebInitiator()
-	job.Tasks = []models.TaskSpec{models.TaskSpec{Type: bt.Name}}
+	job.Tasks = []models.TaskSpec{{Type: bt.Name}}
 	assert.NoError(t, store.CreateJob(&job))
 
 	unfinishedRun := cltest.NewJobRun(job)

--- a/core/web/api_test.go
+++ b/core/web/api_test.go
@@ -76,27 +76,27 @@ func TestApi_NewPaginatedResponse(t *testing.T) {
 		},
 		{
 			"a resource collection",
-			"/v2/index", 1, 0, 0, []TestResource{TestResource{Title: "Item 1"}, TestResource{Title: "Item 2"}},
+			"/v2/index", 1, 0, 0, []TestResource{{Title: "Item 1"}, {Title: "Item 2"}},
 			false, `{"data":[{"type":"testResources","id":"1","attributes":{"Title":"Item 1"}},{"type":"testResources","id":"1","attributes":{"Title":"Item 2"}}],"meta":{"count":0}}`,
 		},
 		{
 			"first page of collection results",
-			"/v2/index", 5, 1, 7, []TestResource{TestResource{Title: "Item 1"}},
+			"/v2/index", 5, 1, 7, []TestResource{{Title: "Item 1"}},
 			false, `{"links":{"next":"/v2/index?page=2\u0026size=5"},"data":[{"type":"testResources","id":"1","attributes":{"Title":"Item 1"}}],"meta":{"count":7}}`,
 		},
 		{
 			"middle page of collection results",
-			"/v2/index", 5, 2, 13, []TestResource{TestResource{Title: "Item 2"}},
+			"/v2/index", 5, 2, 13, []TestResource{{Title: "Item 2"}},
 			false, `{"links":{"next":"/v2/index?page=3\u0026size=5","prev":"/v2/index?page=1\u0026size=5"},"data":[{"type":"testResources","id":"1","attributes":{"Title":"Item 2"}}],"meta":{"count":13}}`,
 		},
 		{
 			"end page of collection results",
-			"/v2/index", 5, 3, 13, []TestResource{TestResource{Title: "Item 3"}},
+			"/v2/index", 5, 3, 13, []TestResource{{Title: "Item 3"}},
 			false, `{"links":{"prev":"/v2/index?page=2\u0026size=5"},"data":[{"type":"testResources","id":"1","attributes":{"Title":"Item 3"}}],"meta":{"count":13}}`,
 		},
 		{
 			"path with existing query",
-			"/v2/index?authToken=3123", 1, 0, 2, []TestResource{TestResource{Title: "Item 1"}},
+			"/v2/index?authToken=3123", 1, 0, 2, []TestResource{{Title: "Item 1"}},
 			false, `{"links":{"next":"/v2/index?authToken=3123\u0026page=1\u0026size=1"},"data":[{"type":"testResources","id":"1","attributes":{"Title":"Item 1"}}],"meta":{"count":2}}`,
 		},
 		{

--- a/core/web/job_specs_controller_test.go
+++ b/core/web/job_specs_controller_test.go
@@ -716,10 +716,10 @@ func TestJobSpecsController_Show_MultipleTasks(t *testing.T) {
 	// Create a task with multiple jobs
 	j := cltest.NewJobWithWebInitiator()
 	j.Tasks = []models.TaskSpec{
-		models.TaskSpec{Type: models.MustNewTaskType("Task1")},
-		models.TaskSpec{Type: models.MustNewTaskType("Task2")},
-		models.TaskSpec{Type: models.MustNewTaskType("Task3")},
-		models.TaskSpec{Type: models.MustNewTaskType("Task4")},
+		{Type: models.MustNewTaskType("Task1")},
+		{Type: models.MustNewTaskType("Task2")},
+		{Type: models.MustNewTaskType("Task3")},
+		{Type: models.MustNewTaskType("Task4")},
 	}
 	assert.NoError(t, app.Store.CreateJob(&j))
 


### PR DESCRIPTION
My main motivation here is that this makes the quickfix window in vim way more useful, since by default it'll warn you about all these errors when using vim-go.

Plus I prefer this syntax.