### PR TITLE
Add a note about yarn network timeout issues on install and a solution

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ regarding Chainlink social accounts, news, and networking.
 4. Download Chainlink: `git clone https://github.com/smartcontractkit/chainlink && cd chainlink`
 5. Build and install Chainlink: `make install`
    - If you got any errors regarding locked yarn package, try running `yarn install` before this step
+   - If `yarn install` throws a network connection error, try increasing the network timeout by running `yarn install --network-timeout 150000` before this step
 6. Run the node: `chainlink help`
 
 ### Ethereum Node Requirements


### PR DESCRIPTION
Ran into an issue building on an M1 Macbook with yarn installed via homebrew. the `yarn install` step of the build would fail with an info alert `There appears to be trouble with your network connection. Retrying...` appearing multiple times. This can be due to a slow network or due to large package sizes being downloaded (https://stackoverflow.com/questions/51508364/yarn-there-appears-to-be-trouble-with-your-network-connection-retrying). Added a note in the install the increase the network timeout if this problem arises for anyone else.