### PR TITLE
Cap reorg doubling

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -328,7 +328,7 @@ func TestIntegration_RunLog(t *testing.T) {
 func TestIntegration_RandomnessReorgProtection(t *testing.T) {
 	config, cfgCleanup := cltest.NewConfig(t)
 	t.Cleanup(cfgCleanup)
-	config.Set("MIN_INCOMING_CONFIRMATIONS", 6)
+	config.Set("MIN_INCOMING_CONFIRMATIONS", 30)
 
 	ethClient, sub, assertMockCalls := cltest.NewEthMocks(t)
 	defer assertMockCalls()
@@ -368,7 +368,7 @@ func TestIntegration_RandomnessReorgProtection(t *testing.T) {
 	logs <- log
 	runs := cltest.WaitForRuns(t, jb, app.Store, 1)
 	cltest.WaitForJobRunToPendIncomingConfirmations(t, app.Store, runs[0])
-	assert.Equal(t, uint32(6), runs[0].TaskRuns[0].MinRequiredIncomingConfirmations.Uint32)
+	assert.Equal(t, uint32(30), runs[0].TaskRuns[0].MinRequiredIncomingConfirmations.Uint32)
 
 	// Same requestID log again should result in a doubling of incoming confs
 	log.TxHash = cltest.NewHash()
@@ -377,7 +377,7 @@ func TestIntegration_RandomnessReorgProtection(t *testing.T) {
 	logs <- log
 	runs = cltest.WaitForRuns(t, jb, app.Store, 2)
 	cltest.WaitForJobRunToPendIncomingConfirmations(t, app.Store, runs[0])
-	assert.Equal(t, uint32(6)*2, runs[0].TaskRuns[0].MinRequiredIncomingConfirmations.Uint32)
+	assert.Equal(t, uint32(30)*2, runs[0].TaskRuns[0].MinRequiredIncomingConfirmations.Uint32)
 
 	// Same requestID log again should result in a doubling of incoming confs
 	log.TxHash = cltest.NewHash()
@@ -386,15 +386,24 @@ func TestIntegration_RandomnessReorgProtection(t *testing.T) {
 	logs <- log
 	runs = cltest.WaitForRuns(t, jb, app.Store, 3)
 	cltest.WaitForJobRunToPendIncomingConfirmations(t, app.Store, runs[0])
-	assert.Equal(t, uint32(6)*2*2, runs[0].TaskRuns[0].MinRequiredIncomingConfirmations.Uint32)
+	assert.Equal(t, uint32(30)*2*2, runs[0].TaskRuns[0].MinRequiredIncomingConfirmations.Uint32)
+
+	// Should be capped at 200
+	log.TxHash = cltest.NewHash()
+	log.BlockHash = cltest.NewHash()
+	log.BlockNumber = 103
+	logs <- log
+	runs = cltest.WaitForRuns(t, jb, app.Store, 4)
+	cltest.WaitForJobRunToPendIncomingConfirmations(t, app.Store, runs[0])
+	assert.Equal(t, uint32(200), runs[0].TaskRuns[0].MinRequiredIncomingConfirmations.Uint32)
 
 	// New requestID should be back to original
 	randLog.RequestID = cltest.NewHash()
 	newReqLog := cltest.NewRandomnessRequestLog(t, randLog, sender, 104)
 	logs <- newReqLog
-	runs = cltest.WaitForRuns(t, jb, app.Store, 4)
+	runs = cltest.WaitForRuns(t, jb, app.Store, 5)
 	cltest.WaitForJobRunToPendIncomingConfirmations(t, app.Store, runs[0])
-	assert.Equal(t, uint32(6), runs[0].TaskRuns[0].MinRequiredIncomingConfirmations.Uint32)
+	assert.Equal(t, uint32(30), runs[0].TaskRuns[0].MinRequiredIncomingConfirmations.Uint32)
 }
 
 func TestIntegration_StartAt(t *testing.T) {

--- a/core/services/feeds/proto/feeds_manager.pb.go
+++ b/core/services/feeds/proto/feeds_manager.pb.go
@@ -7,10 +7,11 @@
 package proto
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/core/services/feeds/proto/feeds_manager_wsrpc.pb.go
+++ b/core/services/feeds/proto/feeds_manager_wsrpc.pb.go
@@ -7,6 +7,7 @@ package proto
 
 import (
 	context "context"
+
 	wsrpc "github.com/smartcontractkit/wsrpc"
 )
 

--- a/core/testdata/testspecs/v1_specs.go
+++ b/core/testdata/testspecs/v1_specs.go
@@ -15,7 +15,7 @@ var (
   "tasks": [
     {
       "type": "random",
-      "confirmations": 6,
+      "confirmations": 30,
       "params": {
         "_comment": "Note: the following key is ONLY AN EXAMPLE, and not secure.",
         "_comment2": "Use the public key reported when you ran chainlink local vrf create, instead",


### PR DESCRIPTION
To port as a hotfix on 10.8