### PR TITLE
Make sure cron validator and cron runner have same init

### DIFF
--- a/core/services/cron/cron.go
+++ b/core/services/cron/cron.go
@@ -33,7 +33,7 @@ func NewCronFromJobSpec(
 	)
 
 	return &Cron{
-		cronRunner:     cron.New(cron.WithSeconds()),
+		cronRunner:     cronRunner(),
 		logger:         cronLogger,
 		jobSpec:        jobSpec,
 		pipelineRunner: pipelineRunner,
@@ -81,4 +81,8 @@ func (cr *Cron) runPipeline() {
 	if err != nil {
 		cr.logger.Errorf("Error executing new run for jobSpec ID %v", cr.jobSpec.ID)
 	}
+}
+
+func cronRunner() *cron.Cron {
+	return cron.New(cron.WithSeconds())
 }

--- a/core/services/cron/cron.go
+++ b/core/services/cron/cron.go
@@ -1,6 +1,8 @@
 package cron
 
 import (
+	"fmt"
+
 	"github.com/robfig/cron/v3"
 
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -45,7 +47,7 @@ func (cr *Cron) Start() error {
 
 	_, err := cr.cronRunner.AddFunc(cr.jobSpec.CronSpec.CronSchedule, cr.runPipeline)
 	if err != nil {
-		cr.logger.Errorf("Error running cr job(id: %d): %v", cr.jobSpec.ID, err)
+		cr.logger.Errorw(fmt.Sprintf("Error running cron job %d", cr.jobSpec.ID), "error", err, "schedule", cr.jobSpec.CronSpec.CronSchedule, "jobID", cr.jobSpec.ID)
 		return err
 	}
 	cr.cronRunner.Start()

--- a/core/services/cron/validate.go
+++ b/core/services/cron/validate.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
-	"github.com/robfig/cron/v3"
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/smartcontractkit/chainlink/core/services/job"
@@ -44,7 +43,7 @@ func ValidatedCronSpec(tomlString string) (job.Job, error) {
 		return jb, errors.New("cron schedule must specify a time zone using CRON_TZ, e.g. 'CRON_TZ=UTC 5 * * * *', or use the @every syntax, e.g. '@hourly'")
 	}
 
-	if _, err := cron.New(cron.WithSeconds()).AddFunc(spec.CronSchedule, func() {}); err != nil {
+	if _, err := cronRunner().AddFunc(spec.CronSchedule, func() {}); err != nil {
 		return jb, errors.Errorf("error parsing cron schedule: %v", err)
 	}
 

--- a/core/services/cron/validate.go
+++ b/core/services/cron/validate.go
@@ -44,7 +44,7 @@ func ValidatedCronSpec(tomlString string) (job.Job, error) {
 		return jb, errors.New("cron schedule must specify a time zone using CRON_TZ, e.g. 'CRON_TZ=UTC 5 * * * *', or use the @every syntax, e.g. '@hourly'")
 	}
 
-	if _, err := cron.New().AddFunc(spec.CronSchedule, func() {}); err != nil {
+	if _, err := cron.New(cron.WithSeconds()).AddFunc(spec.CronSchedule, func() {}); err != nil {
 		return jb, errors.Errorf("error parsing cron schedule: %v", err)
 	}
 

--- a/core/services/cron/validate_test.go
+++ b/core/services/cron/validate_test.go
@@ -22,7 +22,7 @@ func TestValidatedCronJobSpec(t *testing.T) {
 			toml: `
 type            = "cron"
 schemaVersion   = 1
-schedule        = "CRON_TZ=UTC 0 0 1 1 *"
+schedule        = "CRON_TZ=UTC 0 0 1 1 * *"
 observationSource   = """
 ds          [type=http method=GET url="https://chain.link/ETH-USD"];
 ds_parse    [type=jsonparse path="data,price"];
@@ -45,7 +45,7 @@ ds -> ds_parse -> ds_multiply;
 			toml: `
 type            = "cron"
 schemaVersion   = 1
-schedule        = "0 0 1 1 *"
+schedule        = "0 0 1 1 * *"
 observationSource   = """
 ds          [type=http method=GET url="https://chain.link/ETH-USD"];
 ds_parse    [type=jsonparse path="data,price"];
@@ -73,7 +73,7 @@ ds -> ds_parse -> ds_multiply;
 `,
 			assertion: func(t *testing.T, s job.Job, err error) {
 				require.Error(t, err)
-				assert.Equal(t, "error parsing cron schedule: expected exactly 5 fields, found 2: [x x]", err.Error())
+				assert.Equal(t, "error parsing cron schedule: expected exactly 6 fields, found 2: [x x]", err.Error())
 			},
 		},
 	}

--- a/core/testdata/testspecs/v2_specs.go
+++ b/core/testdata/testspecs/v2_specs.go
@@ -16,7 +16,7 @@ externalJobID     =  "123e4567-e89b-12d3-a456-426655440002"
 	CronSpec = `
 type            = "cron"
 schemaVersion   = 1
-schedule        = "CRON_TZ=UTC 0 0 1 1 *"
+schedule        = "CRON_TZ=UTC * 0 0 1 1 *"
 externalJobID     =  "123e4567-e89b-12d3-a456-426655440003"
 observationSource   = """
 ds          [type=http method=GET url="https://chain.link/ETH-USD"];

--- a/core/web/jobs_controller_test.go
+++ b/core/web/jobs_controller_test.go
@@ -163,7 +163,7 @@ func TestJobController_Create_HappyPath(t *testing.T) {
 				err := web.ParseJSONAPIResponse(cltest.ParseResponseBody(t, r), &resource)
 				assert.NoError(t, err)
 				assert.NotNil(t, resource.PipelineSpec.DotDAGSource)
-				require.Equal(t, "CRON_TZ=UTC 0 0 1 1 *", jb.CronSpec.CronSchedule)
+				require.Equal(t, "CRON_TZ=UTC * 0 0 1 1 *", jb.CronSpec.CronSchedule)
 			},
 		},
 		{

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix inability to create jobs with a cron schedule.
+
 ## [0.10.9] - 2021-07-05
 
 ### Changed


### PR DESCRIPTION
Validator was `cron.New()` but runner used `cron.New(WithSeconds)` so you couldn't actually create a job with a useable cron schedule.