### PR TITLE
Investigate and Resolve Context Deadline Exceeded Error in log MarkAs…

### DIFF
--- a/core/services/fluxmonitor/flux_monitor.go
+++ b/core/services/fluxmonitor/flux_monitor.go
@@ -813,7 +813,7 @@ func (p *PollingDeviationChecker) processBroadcast(broadcast log.Broadcast) {
 	ctx, cancel = postgres.DefaultQueryCtx()
 	defer cancel()
 	if err = p.logBroadcaster.MarkConsumed(p.store.DB.WithContext(ctx), broadcast); err != nil {
-		logger.Errorf("Error marking log %T as consumed: %v, after processing time: %v", decodedLog, err, time.Since(started))
+		logger.Errorf("Error marking log %T (%v) as consumed: %v, after processing time: %v", decodedLog, broadcast.String(), err, time.Since(started))
 	}
 }
 

--- a/core/services/fluxmonitorv2/flux_monitor.go
+++ b/core/services/fluxmonitorv2/flux_monitor.go
@@ -540,7 +540,7 @@ func (fm *FluxMonitor) markLogAsConsumed(broadcast log.Broadcast, decodedLog int
 	defer cancel()
 	if err := fm.logBroadcaster.MarkConsumed(fm.db.WithContext(ctx), broadcast); err != nil {
 		fm.logger.Errorw("FluxMonitor: failed to mark log as consumed",
-			"err", err, "logType", fmt.Sprintf("%T", decodedLog), "elapsed", time.Since(started))
+			"err", err, "logType", fmt.Sprintf("%T", decodedLog), "log", broadcast.String(), "elapsed", time.Since(started))
 	}
 }
 

--- a/core/services/fluxmonitorv2/flux_monitor.go
+++ b/core/services/fluxmonitorv2/flux_monitor.go
@@ -487,58 +487,60 @@ func (fm *FluxMonitor) processLogs() {
 			fm.logger.Errorf("Failed to convert backlog into LogBroadcast.  Type is %T", maybeBroadcast)
 		}
 
-		// If the log is a duplicate of one we've seen before, ignore it (this
-		// happens because of the LogBroadcaster's backfilling behavior).
-		ctx, cancel := postgres.DefaultQueryCtx()
-		consumed, err := fm.logBroadcaster.WasAlreadyConsumed(fm.db.WithContext(ctx), broadcast)
-		cancel()
+	}
+}
 
-		if err != nil {
-			fm.logger.Errorf("Error determining if log was already consumed: %v", err)
-			continue
-		} else if consumed {
-			fm.logger.Debug("Log was already consumed by Flux Monitor, skipping")
-			continue
+func (fm *FluxMonitor) processBroadcast(broadcast log.Broadcast) {
+
+	// If the log is a duplicate of one we've seen before, ignore it (this
+	// happens because of the LogBroadcaster's backfilling behavior).
+	ctx, cancel := postgres.DefaultQueryCtx()
+	defer cancel()
+	consumed, err := fm.logBroadcaster.WasAlreadyConsumed(fm.db.WithContext(ctx), broadcast)
+
+	if err != nil {
+		fm.logger.Errorf("Error determining if log was already consumed: %v", err)
+		return
+	} else if consumed {
+		fm.logger.Debug("Log was already consumed by Flux Monitor, skipping")
+		return
+	}
+
+	started := time.Now()
+	decodedLog := broadcast.DecodedLog()
+	switch log := decodedLog.(type) {
+	case *flux_aggregator_wrapper.FluxAggregatorNewRound:
+		fm.respondToNewRoundLog(*log, broadcast)
+	case *flux_aggregator_wrapper.FluxAggregatorAnswerUpdated:
+		fm.respondToAnswerUpdatedLog(*log)
+		fm.markLogAsConsumed(broadcast, decodedLog, started)
+	case *flags_wrapper.FlagsFlagRaised:
+		// check the contract before hibernating, because one flag could be lowered
+		// while the other flag remains raised
+		var isFlagLowered bool
+		isFlagLowered, err = fm.flags.IsLowered(fm.contractAddress)
+		fm.logger.ErrorIf(err, "Error determining if flag is still raised")
+		if !isFlagLowered {
+			fm.pollManager.Hibernate()
 		}
-
-		ctx, cancel = postgres.DefaultQueryCtx()
-		started := time.Now()
-
-		decodedLog := broadcast.DecodedLog()
-		switch log := decodedLog.(type) {
-		case *flux_aggregator_wrapper.FluxAggregatorNewRound:
-			fm.respondToNewRoundLog(*log, broadcast)
-		case *flux_aggregator_wrapper.FluxAggregatorAnswerUpdated:
-			fm.respondToAnswerUpdatedLog(*log)
-			if ctx.Err() != nil {
-				logger.Errorf("Timeout when processing log %T, after %v", decodedLog, time.Since(started))
-			} else if err = fm.logBroadcaster.MarkConsumed(fm.db.WithContext(ctx), broadcast); err != nil {
-				fm.logger.Errorw("FluxMonitor: failed to mark log consumed", "err", err)
-			}
-		case *flags_wrapper.FlagsFlagRaised:
-			// check the contract before hibernating, because one flag could be lowered
-			// while the other flag remains raised
-			var isFlagLowered bool
-			isFlagLowered, err = fm.flags.IsLowered(fm.contractAddress)
-			fm.logger.ErrorIf(err, "Error determining if flag is still raised")
-			if !isFlagLowered {
-				fm.pollManager.Hibernate()
-			}
-			if ctx.Err() != nil {
-				logger.Errorf("Timeout when processing log %T, after %v", decodedLog, time.Since(started))
-			} else if err = fm.logBroadcaster.MarkConsumed(fm.db.WithContext(ctx), broadcast); err != nil {
-				fm.logger.Errorw("FluxMonitor: failed to mark log consumed", "err", err)
-			}
-		case *flags_wrapper.FlagsFlagLowered:
-			// Only reactivate if it is hibernating
-			if fm.pollManager.cfg.IsHibernating {
-				fm.pollManager.Awaken(fm.initialRoundState())
-				fm.pollIfEligible(PollRequestTypeAwaken, NewZeroDeviationChecker(), broadcast)
-			}
-		default:
-			fm.logger.Errorf("unknown log %v of type %T", log, log)
+		fm.markLogAsConsumed(broadcast, decodedLog, started)
+	case *flags_wrapper.FlagsFlagLowered:
+		// Only reactivate if it is hibernating
+		if fm.pollManager.cfg.IsHibernating {
+			fm.pollManager.Awaken(fm.initialRoundState())
+			fm.pollIfEligible(PollRequestTypeAwaken, NewZeroDeviationChecker(), broadcast)
 		}
-		cancel()
+	default:
+		fm.logger.Errorf("unknown log %v of type %T", log, log)
+	}
+}
+
+func (fm *FluxMonitor) markLogAsConsumed(broadcast log.Broadcast, decodedLog interface{}, started time.Time) {
+	ctx, cancel := postgres.DefaultQueryCtx()
+	defer cancel()
+	if err := fm.logBroadcaster.MarkConsumed(fm.db.WithContext(ctx), broadcast); err != nil {
+		fm.logger.Errorw("FluxMonitor: failed to mark log as consumed",
+			"err", err, "logType", fmt.Sprintf("%T", decodedLog), "elapsed", time.Since(started))
 	}
 }
 

--- a/core/services/fluxmonitorv2/flux_monitor.go
+++ b/core/services/fluxmonitorv2/flux_monitor.go
@@ -486,7 +486,7 @@ func (fm *FluxMonitor) processLogs() {
 		if !ok {
 			fm.logger.Errorf("Failed to convert backlog into LogBroadcast.  Type is %T", maybeBroadcast)
 		}
-
+		fm.processBroadcast(broadcast)
 	}
 }
 

--- a/core/services/fluxmonitorv2/flux_monitor_test.go
+++ b/core/services/fluxmonitorv2/flux_monitor_test.go
@@ -726,6 +726,7 @@ func TestFluxMonitor_TriggerIdleTimeThreshold(t *testing.T) {
 
 				decodedLog := flux_aggregator_wrapper.FluxAggregatorNewRound{RoundId: big.NewInt(2), StartedAt: big.NewInt(0)}
 				tm.logBroadcast.On("DecodedLog").Return(&decodedLog)
+				tm.logBroadcast.On("String").Maybe().Return("")
 				tm.logBroadcaster.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil)
 				tm.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
 				fm.HandleLog(tm.logBroadcast)
@@ -845,6 +846,7 @@ func TestFluxMonitor_IdleTimerResetsOnNewRound(t *testing.T) {
 	// AnswerUpdated comes in, which attempts to reset the timers
 	tm.logBroadcaster.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil).Once()
 	tm.logBroadcast.On("DecodedLog").Return(&flux_aggregator_wrapper.FluxAggregatorAnswerUpdated{})
+	tm.logBroadcast.On("String").Maybe().Return("")
 	tm.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil).Once()
 	fm.ExportedBacklog().Add(fluxmonitorv2.PriorityNewRoundLog, tm.logBroadcast)
 	fm.ExportedProcessLogs()
@@ -1111,6 +1113,7 @@ func TestFluxMonitor_RoundTimeoutCausesPoll_timesOutNotZero(t *testing.T) {
 		RoundId:   big.NewInt(0),
 		StartedAt: big.NewInt(time.Now().UTC().Unix()),
 	})
+	tm.logBroadcast.On("String").Maybe().Return("")
 	// To mark it consumed, we need to be eligible to submit.
 	fm.HandleLog(tm.logBroadcast)
 
@@ -1164,6 +1167,7 @@ func TestFluxMonitor_ConsumeLogBroadcast(t *testing.T) {
 
 	tm.logBroadcaster.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil).Once()
 	tm.logBroadcast.On("DecodedLog").Return(&flux_aggregator_wrapper.FluxAggregatorAnswerUpdated{})
+	tm.logBroadcast.On("String").Maybe().Return("")
 	tm.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil).Once()
 
 	fm.ExportedBacklog().Add(fluxmonitorv2.PriorityNewRoundLog, tm.logBroadcast)

--- a/core/services/keeper/registry_synchronizer_process_logs.go
+++ b/core/services/keeper/registry_synchronizer_process_logs.go
@@ -47,8 +47,10 @@ func (rs *RegistrySynchronizer) handleSyncRegistryLog(done func()) {
 		logger.Error(errors.Wrapf(err, "RegistrySynchronizer: unable to sync registry, jobID: %d", rs.job.ID))
 		return
 	}
-	err = rs.logBroadcaster.MarkConsumed(rs.orm.DB, broadcast)
-	logger.ErrorIf((errors.Wrapf(err, "RegistrySynchronizer: unable to mark log as consumed, jobID: %d", rs.job.ID)))
+	ctx, cancel := postgres.DefaultQueryCtx()
+	defer cancel()
+	err = rs.logBroadcaster.MarkConsumed(rs.orm.DB.WithContext(ctx), broadcast)
+	logger.ErrorIf(errors.Wrapf(err, "RegistrySynchronizer: unable to mark SyncRegistryLog log as consumed, jobID: %d, log: %v", rs.job.ID, broadcast.String()))
 }
 
 func (rs *RegistrySynchronizer) handleUpkeepCanceledLogs(done func()) {
@@ -63,32 +65,39 @@ func (rs *RegistrySynchronizer) handleUpkeepCanceledLogs(done func()) {
 			logger.Errorf("RegistrySynchronizer: invariant violation, expected log.Broadcast but got %T", broadcast)
 			continue
 		}
-		txHash := broadcast.RawLog().TxHash.Hex()
-		logger.Debugw("RegistrySynchronizer: processing UpkeepCanceled log", "jobID", rs.job.ID, "txHash", txHash)
-		was, err := rs.logBroadcaster.WasAlreadyConsumed(rs.orm.DB, broadcast)
-		if err != nil {
-			logger.Warn(errors.Wrapf(err, "RegistrySynchronizer: unable to check if log was consumed, jobID: %d", rs.job.ID))
-			continue
-		}
-		if was {
-			continue
-		}
-		log, ok := broadcast.DecodedLog().(*keeper_registry_wrapper.KeeperRegistryUpkeepCanceled)
-		if !ok {
-			logger.Errorf("RegistrySynchronizer: invariant violation, expected UpkeepCanceled log but got %T", log)
-			continue
-		}
-		ctx, cancel := postgres.DefaultQueryCtx()
-		defer cancel()
-		affected, err := rs.orm.BatchDeleteUpkeepsForJob(ctx, rs.job.ID, []int64{log.Id.Int64()})
-		if err != nil {
-			logger.Error(errors.Wrapf(err, "RegistrySynchronizer: unable to batch delete upkeeps, jobID: %d", rs.job.ID))
-			continue
-		}
-		logger.Debugw(fmt.Sprintf("RegistrySynchronizer: deleted %v upkeep registrations", affected), "jobID", rs.job.ID, "txHash", txHash)
-		err = rs.logBroadcaster.MarkConsumed(rs.orm.DB, broadcast)
-		logger.ErrorIf((errors.Wrapf(err, "RegistrySynchronizer: unable to mark log as consumed, jobID: %d", rs.job.ID)))
+		rs.handleUpkeepCancelled(broadcast)
 	}
+}
+
+func (rs *RegistrySynchronizer) handleUpkeepCancelled(broadcast log.Broadcast) {
+	txHash := broadcast.RawLog().TxHash.Hex()
+	logger.Debugw("RegistrySynchronizer: processing UpkeepCanceled log", "jobID", rs.job.ID, "txHash", txHash)
+	was, err := rs.logBroadcaster.WasAlreadyConsumed(rs.orm.DB, broadcast)
+	if err != nil {
+		logger.Warn(errors.Wrapf(err, "RegistrySynchronizer: unable to check if log was consumed, jobID: %d", rs.job.ID))
+		return
+	}
+	if was {
+		return
+	}
+	log, ok := broadcast.DecodedLog().(*keeper_registry_wrapper.KeeperRegistryUpkeepCanceled)
+	if !ok {
+		logger.Errorf("RegistrySynchronizer: invariant violation, expected UpkeepCanceled log but got %T", log)
+		return
+	}
+	ctx, cancel := postgres.DefaultQueryCtx()
+	defer cancel()
+	affected, err := rs.orm.BatchDeleteUpkeepsForJob(ctx, rs.job.ID, []int64{log.Id.Int64()})
+	if err != nil {
+		logger.Error(errors.Wrapf(err, "RegistrySynchronizer: unable to batch delete upkeeps, jobID: %d", rs.job.ID))
+		return
+	}
+	logger.Debugw(fmt.Sprintf("RegistrySynchronizer: deleted %v upkeep registrations", affected), "jobID", rs.job.ID, "txHash", txHash)
+
+	ctx, cancel = postgres.DefaultQueryCtx()
+	defer cancel()
+	err = rs.logBroadcaster.MarkConsumed(rs.orm.DB.WithContext(ctx), broadcast)
+	logger.ErrorIf(errors.Wrapf(err, "RegistrySynchronizer: unable to mark KeeperRegistryUpkeepCanceled log as consumed, jobID: %d, log: %v", rs.job.ID, broadcast.String()))
 }
 
 func (rs *RegistrySynchronizer) handleUpkeepRegisteredLogs(done func()) {
@@ -110,29 +119,35 @@ func (rs *RegistrySynchronizer) handleUpkeepRegisteredLogs(done func()) {
 			logger.Errorf("RegistrySynchronizer: invariant violation, expected log.Broadcast but got %T", broadcast)
 			continue
 		}
-		txHash := broadcast.RawLog().TxHash.Hex()
-		logger.Debugw("RegistrySynchronizer: processing UpkeepRegistered log", "jobID", rs.job.ID, "txHash", txHash)
-		was, err := rs.logBroadcaster.WasAlreadyConsumed(rs.orm.DB, broadcast)
-		if err != nil {
-			logger.Warn(errors.Wrapf(err, "RegistrySynchronizer: unable to check if log was consumed, jobID: %d", rs.job.ID))
-			continue
-		}
-		if was {
-			continue
-		}
-		log, ok := broadcast.DecodedLog().(*keeper_registry_wrapper.KeeperRegistryUpkeepRegistered)
-		if !ok {
-			logger.Errorf("RegistrySynchronizer: invariant violation, expected UpkeepRegistered log but got %T", log)
-			continue
-		}
-		err = rs.syncUpkeep(registry, log.Id.Int64())
-		if err != nil {
-			logger.Error(err)
-			continue
-		}
-		err = rs.logBroadcaster.MarkConsumed(rs.orm.DB, broadcast)
-		logger.ErrorIf((errors.Wrapf(err, "RegistrySynchronizer: unable to mark log as consumed, jobID: %d", rs.job.ID)))
+		rs.HandleUpkeepRegistered(broadcast, registry)
 	}
+}
+
+func (rs *RegistrySynchronizer) HandleUpkeepRegistered(broadcast log.Broadcast, registry Registry) {
+	txHash := broadcast.RawLog().TxHash.Hex()
+	logger.Debugw("RegistrySynchronizer: processing UpkeepRegistered log", "jobID", rs.job.ID, "txHash", txHash)
+	was, err := rs.logBroadcaster.WasAlreadyConsumed(rs.orm.DB, broadcast)
+	if err != nil {
+		logger.Warn(errors.Wrapf(err, "RegistrySynchronizer: unable to check if log was consumed, jobID: %d", rs.job.ID))
+		return
+	}
+	if was {
+		return
+	}
+	log, ok := broadcast.DecodedLog().(*keeper_registry_wrapper.KeeperRegistryUpkeepRegistered)
+	if !ok {
+		logger.Errorf("RegistrySynchronizer: invariant violation, expected UpkeepRegistered log but got %T", log)
+		return
+	}
+	err = rs.syncUpkeep(registry, log.Id.Int64())
+	if err != nil {
+		logger.Error(err)
+		return
+	}
+	ctx, cancel := postgres.DefaultQueryCtx()
+	defer cancel()
+	err = rs.logBroadcaster.MarkConsumed(rs.orm.DB.WithContext(ctx), broadcast)
+	logger.ErrorIf(errors.Wrapf(err, "RegistrySynchronizer: unable to mark KeeperRegistryUpkeepRegistered log as consumed, jobID: %d, log: %v", rs.job.ID, broadcast.String()))
 }
 
 func (rs *RegistrySynchronizer) handleUpkeepPerformedLogs(done func()) {
@@ -147,31 +162,37 @@ func (rs *RegistrySynchronizer) handleUpkeepPerformedLogs(done func()) {
 			logger.Errorf("RegistrySynchronizer: invariant violation, expected log.Broadcast but got %T", broadcast)
 			continue
 		}
-		txHash := broadcast.RawLog().TxHash.Hex()
-		logger.Debugw("RegistrySynchronizer: processing UpkeepPerformed log", "jobID", rs.job.ID, "txHash", txHash)
-		was, err := rs.logBroadcaster.WasAlreadyConsumed(rs.orm.DB, broadcast)
-		if err != nil {
-			logger.Warn(errors.Wrapf(err, "RegistrySynchronizer: unable to check if log was consumed, jobID: %d", rs.job.ID))
-			continue
-		}
-		if was {
-			continue
-		}
-		log, ok := broadcast.DecodedLog().(*keeper_registry_wrapper.KeeperRegistryUpkeepPerformed)
-		if !ok {
-			logger.Errorf("RegistrySynchronizer: invariant violation, expected UpkeepPerformed log but got %T", log)
-			continue
-		}
-		ctx, cancel := postgres.DefaultQueryCtx()
-		defer cancel()
-		db := rs.orm.DB.WithContext(ctx)
-		// set last run to 0 so that keeper can resume checkUpkeep()
-		err = rs.orm.SetLastRunHeightForUpkeepOnJob(db, rs.job.ID, log.Id.Int64(), 0)
-		if err != nil {
-			logger.Error(err)
-			continue
-		}
-		err = rs.logBroadcaster.MarkConsumed(rs.orm.DB, broadcast)
-		logger.ErrorIf((errors.Wrapf(err, "RegistrySynchronizer: unable to mark log as consumed, jobID: %d", rs.job.ID)))
+		rs.handleUpkeepPerformed(broadcast)
 	}
+}
+
+func (rs *RegistrySynchronizer) handleUpkeepPerformed(broadcast log.Broadcast) {
+	txHash := broadcast.RawLog().TxHash.Hex()
+	logger.Debugw("RegistrySynchronizer: processing UpkeepPerformed log", "jobID", rs.job.ID, "txHash", txHash)
+	was, err := rs.logBroadcaster.WasAlreadyConsumed(rs.orm.DB, broadcast)
+	if err != nil {
+		logger.Warn(errors.Wrapf(err, "RegistrySynchronizer: unable to check if log was consumed, jobID: %d", rs.job.ID))
+		return
+	}
+	if was {
+		return
+	}
+	log, ok := broadcast.DecodedLog().(*keeper_registry_wrapper.KeeperRegistryUpkeepPerformed)
+	if !ok {
+		logger.Errorf("RegistrySynchronizer: invariant violation, expected UpkeepPerformed log but got %T", log)
+		return
+	}
+	ctx, cancel := postgres.DefaultQueryCtx()
+	defer cancel()
+	db := rs.orm.DB.WithContext(ctx)
+	// set last run to 0 so that keeper can resume checkUpkeep()
+	err = rs.orm.SetLastRunHeightForUpkeepOnJob(db, rs.job.ID, log.Id.Int64(), 0)
+	if err != nil {
+		logger.Error(err)
+		return
+	}
+	ctx, cancel = postgres.DefaultQueryCtx()
+	defer cancel()
+	err = rs.logBroadcaster.MarkConsumed(rs.orm.DB.WithContext(ctx), broadcast)
+	logger.ErrorIf(errors.Wrapf(err, "RegistrySynchronizer: unable to mark KeeperRegistryUpkeepPerformed log as consumed, jobID: %d, log: %v", rs.job.ID, broadcast.String()))
 }

--- a/core/services/keeper/registry_synchronizer_test.go
+++ b/core/services/keeper/registry_synchronizer_test.go
@@ -194,6 +194,7 @@ func Test_RegistrySynchronizer_ConfigSetLog(t *testing.T) {
 	logBroadcast := new(logmocks.Broadcast)
 	logBroadcast.On("DecodedLog").Return(&log)
 	logBroadcast.On("RawLog").Return(rawLog)
+	logBroadcast.On("String").Maybe().Return("")
 	lb.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
 	lb.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil)
 
@@ -238,6 +239,7 @@ func Test_RegistrySynchronizer_KeepersUpdatedLog(t *testing.T) {
 	logBroadcast := new(logmocks.Broadcast)
 	logBroadcast.On("DecodedLog").Return(&log)
 	logBroadcast.On("RawLog").Return(rawLog)
+	logBroadcast.On("String").Maybe().Return("")
 	lb.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
 	lb.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil)
 
@@ -277,6 +279,7 @@ func Test_RegistrySynchronizer_UpkeepCanceledLog(t *testing.T) {
 	logBroadcast := new(logmocks.Broadcast)
 	logBroadcast.On("DecodedLog").Return(&log)
 	logBroadcast.On("RawLog").Return(rawLog)
+	logBroadcast.On("String").Maybe().Return("")
 	lb.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
 	lb.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil)
 
@@ -313,6 +316,7 @@ func Test_RegistrySynchronizer_UpkeepRegisteredLog(t *testing.T) {
 	logBroadcast := new(logmocks.Broadcast)
 	logBroadcast.On("DecodedLog").Return(&log)
 	logBroadcast.On("RawLog").Return(rawLog)
+	logBroadcast.On("String").Maybe().Return("")
 	lb.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
 	lb.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil)
 
@@ -356,6 +360,7 @@ func Test_RegistrySynchronizer_UpkeepPerformedLog(t *testing.T) {
 	logBroadcast := new(logmocks.Broadcast)
 	logBroadcast.On("DecodedLog").Return(&log)
 	logBroadcast.On("RawLog").Return(rawLog)
+	logBroadcast.On("String").Maybe().Return("")
 	lb.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
 	lb.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil)
 

--- a/core/services/offchainreporting/contract_tracker.go
+++ b/core/services/offchainreporting/contract_tracker.go
@@ -293,7 +293,9 @@ func (t *OCRContractTracker) HandleLog(lb log.Broadcast) {
 		logger.Debugw("OCRContractTracker: got unrecognised log topic", "topic", topics[0])
 	}
 	if !consumed {
-		t.logger.ErrorIfCalling(func() error { return t.logBroadcaster.MarkConsumed(t.gdb, lb) })
+		ctx, cancel := postgres.DefaultQueryCtx()
+		defer cancel()
+		t.logger.ErrorIfCalling(func() error { return t.logBroadcaster.MarkConsumed(t.gdb.WithContext(ctx), lb) })
 	}
 }
 


### PR DESCRIPTION
1. Use a dedicated context with postgres timeout for each individual MarkAsConsumed
2. Extract main log processing logic into separate methods so that we can safely do `defer cancel()` not in a loop

Please see with whitespace disabled: https://github.com/smartcontractkit/chainlink/pull/4721/files?diff=split&w=1