### PR TITLE
Pass through logs with 0 num confirmations

### DIFF
--- a/core/services/fluxmonitorv2/flux_monitor.go
+++ b/core/services/fluxmonitorv2/flux_monitor.go
@@ -372,7 +372,7 @@ func (fm *FluxMonitor) consume() {
 			flux_aggregator_wrapper.FluxAggregatorNewRound{}.Topic():      nil,
 			flux_aggregator_wrapper.FluxAggregatorAnswerUpdated{}.Topic(): nil,
 		},
-		NumConfirmations: 1,
+		NumConfirmations: 0,
 	})
 	defer unsubscribe()
 
@@ -384,7 +384,7 @@ func (fm *FluxMonitor) consume() {
 				flags_wrapper.FlagsFlagLowered{}.Topic(): nil,
 				flags_wrapper.FlagsFlagRaised{}.Topic():  nil,
 			},
-			NumConfirmations: 1,
+			NumConfirmations: 0,
 		})
 		defer unsubscribe()
 	}

--- a/core/services/log/broadcaster.go
+++ b/core/services/log/broadcaster.go
@@ -365,6 +365,8 @@ func (b *broadcaster) onNewHeads() {
 			keptDepth = 0
 		}
 
+		// if all subscribers requested 0 confirmations, we always get and delete all logs from the pool,
+		// without comparing their block numbers to the current head's block number.
 		if b.registrations.lowestNumConfirmations == 0 && b.registrations.highestNumConfirmations == 0 {
 			logs, lowest, highest := b.logPool.getAndDeleteAll()
 			if len(logs) > 0 {

--- a/core/services/log/broadcaster_test.go
+++ b/core/services/log/broadcaster_test.go
@@ -451,6 +451,93 @@ func TestBroadcaster_BroadcastsAtCorrectHeights(t *testing.T) {
 	helper.mockEth.assertExpectations(t)
 }
 
+func TestBroadcaster_BroadcastsWithZeroConfirmations(t *testing.T) {
+	t.Parallel()
+
+	const blockHeight int64 = 10
+	helper := newBroadcasterHelper(t, blockHeight, 1)
+	helper.store.Config.Set(orm.EnvVarName("EthFinalityDepth"), uint(1))
+	helper.start()
+
+	contract1, err := flux_aggregator_wrapper.NewFluxAggregator(cltest.NewAddress(), nil)
+	require.NoError(t, err)
+
+	blocks := cltest.NewBlocks(t, 10)
+	addr1SentLogs := []types.Log{
+		cltest.RawNewRoundLog(t, contract1.Address(), cltest.NewHash(), 100, 0, false),
+		cltest.RawNewRoundLog(t, contract1.Address(), cltest.NewHash(), 101, 0, false),
+		cltest.RawNewRoundLog(t, contract1.Address(), cltest.NewHash(), 105, 0, false),
+	}
+
+	listener1 := helper.newLogListener("listener 1")
+	listener2 := helper.newLogListener("listener 2")
+
+	helper.register(listener1, contract1, 0)
+	helper.register(listener2, contract1, 0)
+
+	cleanup, _ := cltest.SimulateIncomingHeads(t, cltest.SimulateIncomingHeadsArgs{
+		StartBlock:     0,
+		EndBlock:       9,
+		BackfillDepth:  10,
+		HeadTrackables: []httypes.HeadTrackable{(helper.lb).(httypes.HeadTrackable)},
+		Blocks:         blocks,
+		Interval:       250 * time.Millisecond,
+	})
+	defer cleanup()
+
+	chRawLogs := <-helper.chchRawLogs
+
+	for _, log := range addr1SentLogs {
+		chRawLogs <- log
+	}
+
+	requireBroadcastCount(t, helper.store, 6)
+	helper.stop()
+
+	requireEqualLogs(t,
+		addr1SentLogs,
+		listener1.received.uniqueLogs,
+	)
+	requireEqualLogs(t,
+		addr1SentLogs,
+		listener2.received.uniqueLogs,
+	)
+
+	// unique sends should be equal to sends overall
+	requireEqualLogs(t,
+		listener1.received.uniqueLogs,
+		listener1.received.logs,
+	)
+	requireEqualLogs(t,
+		listener2.received.uniqueLogs,
+		listener2.received.logs,
+	)
+
+	// the logs should have been received at much earlier heights than logs' block numbers
+	logsOnBlocks := listener2.received.logsOnBlocks()
+	expectedLogsOnBlocks := []logOnBlock{
+		{
+			logBlockNumber: 100,
+			blockNumber:    4,
+			blockHash:      blocks.Hashes[4],
+		},
+		{
+			logBlockNumber: 101,
+			blockNumber:    4,
+			blockHash:      blocks.Hashes[4],
+		},
+		{
+			logBlockNumber: 105,
+			blockNumber:    4,
+			blockHash:      blocks.Hashes[4],
+		},
+	}
+
+	require.Equal(t, logsOnBlocks, expectedLogsOnBlocks)
+
+	helper.mockEth.assertExpectations(t)
+}
+
 func TestBroadcaster_DeletesOldLogsAfterNumberOfHeads(t *testing.T) {
 	t.Parallel()
 

--- a/core/services/log/eth_subscriber.go
+++ b/core/services/log/eth_subscriber.go
@@ -11,7 +11,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/services/eth"
-	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
@@ -149,31 +148,38 @@ func (sub *ethSubscriber) createSubscription(addresses []common.Address, topics 
 	ctx, cancel := utils.ContextFromChan(sub.chStop)
 	defer cancel()
 
-	syncTicker := time.NewTicker(time.Second)
-	defer syncTicker.Stop()
+	utils.RetryWithBackoff(ctx, func() (retry bool) {
 
-	chann := make(chan types.Log, 10000)
-	subb := noopSubscription{chann}
-
-	var latest *models.Head
-	for {
-		select {
-		case <-sub.chStop:
-			return
-		case <-syncTicker.C:
-
-			var fromBlockOverride null.Int64
-			if latest != nil {
-				fromBlockOverride = null.Int64From(latest.Number)
-			}
-			backfilled, abort, latestHead := sub.backfillLogs(fromBlockOverride, addresses, topics)
-			latest = latestHead
-
-			for log : range backfilled {
-				chann <- log
-			}
+		filterQuery := ethereum.FilterQuery{
+			Addresses: addresses,
+			Topics:    [][]common.Hash{topics},
 		}
+		chRawLogs := make(chan types.Log)
+
+		ctx2, cancel := context.WithTimeout(ctx, 15*time.Second)
+		defer cancel()
+
+		logger.Debugw("Calling SubscribeFilterLogs with params", "addresses", addresses, "topics", topics)
+
+		innerSub, err := sub.ethClient.SubscribeFilterLogs(ctx2, filterQuery, chRawLogs)
+		if err != nil {
+			logger.Errorw("Log subscriber could not create subscription to Ethereum node", "err", err)
+			return true
+		}
+
+		subscr = managedSubscriptionImpl{
+			subscription: innerSub,
+			chRawLogs:    chRawLogs,
+		}
+		return false
+	})
+	select {
+	case <-sub.chStop:
+		abort = true
+	default:
+		abort = false
 	}
+	return
 }
 
 // A managedSubscription acts as wrapper for the Subscription. Specifically, the

--- a/core/services/log/eth_subscriber.go
+++ b/core/services/log/eth_subscriber.go
@@ -159,6 +159,8 @@ func (sub *ethSubscriber) createSubscription(addresses []common.Address, topics 
 		ctx2, cancel := context.WithTimeout(ctx, 15*time.Second)
 		defer cancel()
 
+		logger.Debugw("Calling SubscribeFilterLogs with params", "addresses", addresses, "topics", topics)
+
 		innerSub, err := sub.ethClient.SubscribeFilterLogs(ctx2, filterQuery, chRawLogs)
 		if err != nil {
 			logger.Errorw("Log subscriber could not create subscription to Ethereum node", "err", err)

--- a/core/services/log/eth_subscriber.go
+++ b/core/services/log/eth_subscriber.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/services/eth"
+	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
@@ -148,38 +149,31 @@ func (sub *ethSubscriber) createSubscription(addresses []common.Address, topics 
 	ctx, cancel := utils.ContextFromChan(sub.chStop)
 	defer cancel()
 
-	utils.RetryWithBackoff(ctx, func() (retry bool) {
+	syncTicker := time.NewTicker(time.Second)
+	defer syncTicker.Stop()
 
-		filterQuery := ethereum.FilterQuery{
-			Addresses: addresses,
-			Topics:    [][]common.Hash{topics},
+	chann := make(chan types.Log, 10000)
+	subb := noopSubscription{chann}
+
+	var latest *models.Head
+	for {
+		select {
+		case <-sub.chStop:
+			return
+		case <-syncTicker.C:
+
+			var fromBlockOverride null.Int64
+			if latest != nil {
+				fromBlockOverride = null.Int64From(latest.Number)
+			}
+			backfilled, abort, latestHead := sub.backfillLogs(fromBlockOverride, addresses, topics)
+			latest = latestHead
+
+			for log : range backfilled {
+				chann <- log
+			}
 		}
-		chRawLogs := make(chan types.Log)
-
-		ctx2, cancel := context.WithTimeout(ctx, 15*time.Second)
-		defer cancel()
-
-		logger.Debugw("Calling SubscribeFilterLogs with params", "addresses", addresses, "topics", topics)
-
-		innerSub, err := sub.ethClient.SubscribeFilterLogs(ctx2, filterQuery, chRawLogs)
-		if err != nil {
-			logger.Errorw("Log subscriber could not create subscription to Ethereum node", "err", err)
-			return true
-		}
-
-		subscr = managedSubscriptionImpl{
-			subscription: innerSub,
-			chRawLogs:    chRawLogs,
-		}
-		return false
-	})
-	select {
-	case <-sub.chStop:
-		abort = true
-	default:
-		abort = false
 	}
-	return
 }
 
 // A managedSubscription acts as wrapper for the Subscription. Specifically, the

--- a/core/services/log/pool.go
+++ b/core/services/log/pool.go
@@ -1,6 +1,8 @@
 package log
 
 import (
+	"math"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	heaps "github.com/theodesp/go-heaps"
@@ -27,6 +29,39 @@ func (pool *logPool) addLog(log types.Log) {
 	pool.hashesByBlockNumbers[log.BlockNumber] = append(pool.hashesByBlockNumbers[log.BlockNumber], log.BlockHash)
 	pool.logsByBlockHash[log.BlockHash] = append(pool.logsByBlockHash[log.BlockHash], log)
 	pool.heap.Insert(Uint64(log.BlockNumber))
+}
+
+func (pool *logPool) getAndDeleteAll() ([]types.Log, int64, int64) {
+	logsToReturn := make([]types.Log, 0)
+	lowest := int64(math.MaxInt64)
+	highest := int64(0)
+
+	for {
+		item := pool.heap.DeleteMin()
+		if item == nil {
+			break
+		}
+
+		blockNum := uint64(item.(Uint64))
+		logsOnBlock, exists := pool.hashesByBlockNumbers[blockNum]
+		if exists {
+			if int64(blockNum) < lowest {
+				lowest = int64(blockNum)
+			}
+			if int64(blockNum) > highest {
+				highest = int64(blockNum)
+			}
+			for _, hash := range logsOnBlock {
+				logsToReturn = append(logsToReturn, pool.logsByBlockHash[hash]...)
+			}
+			for _, hash := range pool.hashesByBlockNumbers[blockNum] {
+				delete(pool.logsByBlockHash, hash)
+			}
+		}
+
+		delete(pool.hashesByBlockNumbers, blockNum)
+	}
+	return logsToReturn, lowest, highest
 }
 
 func (pool *logPool) getLogsToSend(latestBlockNum int64) ([]types.Log, int64) {

--- a/core/services/log/registrations.go
+++ b/core/services/log/registrations.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"math"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -36,6 +37,7 @@ type (
 		// highest 'NumConfirmations' per all listeners, used to decide about deleting older logs if it's higher than EthFinalityDepth
 		// it's: max(listeners.map(l => l.num_confirmations)
 		highestNumConfirmations uint64
+		lowestNumConfirmations  uint64
 	}
 
 	// The Listener responds to log events through HandleLog.
@@ -55,8 +57,9 @@ type (
 
 func newRegistrations() *registrations {
 	return &registrations{
-		registrations: make(map[common.Address]map[common.Hash]map[Listener]*listenerMetadata),
-		decoders:      make(map[common.Address]ParseLogFunc),
+		registrations:          make(map[common.Address]map[common.Hash]map[Listener]*listenerMetadata),
+		decoders:               make(map[common.Address]ParseLogFunc),
+		lowestNumConfirmations: uint64(math.MaxUint64), // a very high value until first subscriber
 	}
 }
 
@@ -64,8 +67,8 @@ func (r *registrations) addSubscriber(reg registration) (needsResubscribe bool) 
 	addr := reg.opts.Contract
 	r.decoders[addr] = reg.opts.ParseLog
 
-	if reg.opts.NumConfirmations <= 0 {
-		reg.opts.NumConfirmations = 1
+	if reg.opts.NumConfirmations < 0 {
+		reg.opts.NumConfirmations = 0
 	}
 
 	if _, exists := r.registrations[addr]; !exists {
@@ -84,7 +87,7 @@ func (r *registrations) addSubscriber(reg registration) (needsResubscribe bool) 
 		}
 	}
 
-	r.maybeIncreaseHighestNumConfirmations(reg.opts.NumConfirmations)
+	r.maybeUpdateNumConfirmationsRange(reg.opts.NumConfirmations)
 	return
 }
 
@@ -110,31 +113,41 @@ func (r *registrations) removeSubscriber(reg registration) (needsResubscribe boo
 		}
 	}
 
-	r.resetHighestNumConfirmations()
+	r.resetNumConfirmationsRange(reg.opts.NumConfirmations)
 	return
 }
 
-// increase the highestNumConfirmations stored if the new listener has a higher value
-func (r *registrations) maybeIncreaseHighestNumConfirmations(newNumConfirmations uint64) {
+// maybe update the numbers tracking highest and lowest num confirmations
+func (r *registrations) maybeUpdateNumConfirmationsRange(newNumConfirmations uint64) {
 	if newNumConfirmations > r.highestNumConfirmations {
 		r.highestNumConfirmations = newNumConfirmations
 	}
+	if newNumConfirmations < r.lowestNumConfirmations {
+		r.lowestNumConfirmations = newNumConfirmations
+	}
 }
 
-// reset the highest confirmation number per all current listeners
-func (r *registrations) resetHighestNumConfirmations() {
-	highestNumConfirmations := uint64(0)
+// reset the numbers tracking highest and lowest num confirmations
+func (r *registrations) resetNumConfirmationsRange(removedNumConfirmations uint64) {
+	if removedNumConfirmations <= r.lowestNumConfirmations && removedNumConfirmations >= r.highestNumConfirmations {
+		lowestNumConfirmations := uint64(math.MaxUint64)
+		highestNumConfirmations := uint64(0)
 
-	for _, perAddress := range r.registrations {
-		for _, perTopic := range perAddress {
-			for _, listener := range perTopic {
-				if listener.opts.NumConfirmations > highestNumConfirmations {
-					highestNumConfirmations = listener.opts.NumConfirmations
+		for _, perAddress := range r.registrations {
+			for _, perTopic := range perAddress {
+				for _, listener := range perTopic {
+					if listener.opts.NumConfirmations > highestNumConfirmations {
+						highestNumConfirmations = listener.opts.NumConfirmations
+					}
+					if listener.opts.NumConfirmations < lowestNumConfirmations {
+						lowestNumConfirmations = listener.opts.NumConfirmations
+					}
 				}
 			}
 		}
+		r.highestNumConfirmations = highestNumConfirmations
+		r.lowestNumConfirmations = lowestNumConfirmations
 	}
-	r.highestNumConfirmations = highestNumConfirmations
 }
 
 func (r *registrations) addressesAndTopics() ([]common.Address, []common.Hash) {
@@ -191,7 +204,7 @@ func (r *registrations) sendLog(log types.Log, latestHead models.Head, broadcast
 		listener := listener
 		numConfirmations := metadata.opts.NumConfirmations
 
-		if latestBlockNumber < numConfirmations {
+		if numConfirmations != 0 && latestBlockNumber < numConfirmations {
 			// Skipping send because not enough height to send
 			continue
 		}
@@ -199,7 +212,7 @@ func (r *registrations) sendLog(log types.Log, latestHead models.Head, broadcast
 		// We attempt the send multiple times per log (depending on distinct num of confirmations of listeners),
 		// even if the logs are too young
 		// so here we need to see if this particular listener actually should receive it at this depth
-		isOldEnough := (log.BlockNumber + numConfirmations - 1) <= latestBlockNumber
+		isOldEnough := numConfirmations == 0 || (log.BlockNumber+numConfirmations-1) <= latestBlockNumber
 		if !isOldEnough {
 			continue
 		}


### PR DESCRIPTION
If all subscribers are setup with 0 confirmations, do not check logs' block numbers when sending them