### PR TITLE
Pass through logs for 0 confirmations

### DIFF
--- a/core/services/fluxmonitorv2/flux_monitor.go
+++ b/core/services/fluxmonitorv2/flux_monitor.go
@@ -371,7 +371,7 @@ func (fm *FluxMonitor) consume() {
 			flux_aggregator_wrapper.FluxAggregatorNewRound{}.Topic():      nil,
 			flux_aggregator_wrapper.FluxAggregatorAnswerUpdated{}.Topic(): nil,
 		},
-		NumConfirmations: 1,
+		NumConfirmations: 0,
 	})
 	defer unsubscribe()
 
@@ -383,7 +383,7 @@ func (fm *FluxMonitor) consume() {
 				flags_wrapper.FlagsFlagLowered{}.Topic(): nil,
 				flags_wrapper.FlagsFlagRaised{}.Topic():  nil,
 			},
-			NumConfirmations: 1,
+			NumConfirmations: 0,
 		})
 		defer unsubscribe()
 	}

--- a/core/services/log/broadcaster.go
+++ b/core/services/log/broadcaster.go
@@ -407,7 +407,7 @@ func (b *broadcaster) onNewHeads() {
 
 		// if all subscribers requested 0 confirmations, we always get and delete all logs from the pool,
 		// without comparing their block numbers to the current head's block number.
-		if b.registrations.lowestNumConfirmations == 0 && b.registrations.highestNumConfirmations == 0 {
+		if b.registrations.highestNumConfirmations == 0 {
 			logs, lowest, highest := b.logPool.getAndDeleteAll()
 			if len(logs) > 0 {
 				broadcasts, err := b.orm.FindConsumedLogs(lowest, highest)

--- a/core/services/log/eth_subscriber.go
+++ b/core/services/log/eth_subscriber.go
@@ -213,6 +213,8 @@ func (sub *ethSubscriber) createSubscription(addresses []common.Address, topics 
 		ctx2, cancel := eth.DefaultQueryCtx(ctx)
 		defer cancel()
 
+		logger.Debugw("Calling SubscribeFilterLogs with params", "addresses", addresses, "topics", topics)
+
 		innerSub, err := sub.ethClient.SubscribeFilterLogs(ctx2, filterQuery, chRawLogs)
 		if err != nil {
 			logger.Errorw("Log subscriber could not create subscription to Ethereum node", "err", err)

--- a/core/services/log/helpers_test.go
+++ b/core/services/log/helpers_test.go
@@ -40,7 +40,9 @@ type broadcasterHelper struct {
 	mockEth *mockEth
 
 	// each received channel corresponds to one eth subscription
-	chchRawLogs   chan chan<- types.Log
+	chchRawLogs chan chan<- types.Log
+
+	sentLogs      chan types.Log
 	toUnsubscribe []func()
 	storeCleanup  func()
 }

--- a/core/services/log/registrations.go
+++ b/core/services/log/registrations.go
@@ -1,6 +1,7 @@
 package log
 
 import (
+	"math"
 	"sync"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -36,6 +37,7 @@ type (
 		// highest 'NumConfirmations' per all listeners, used to decide about deleting older logs if it's higher than EthFinalityDepth
 		// it's: max(listeners.map(l => l.num_confirmations)
 		highestNumConfirmations uint64
+		lowestNumConfirmations  uint64
 	}
 
 	subscribers struct {
@@ -59,8 +61,9 @@ type (
 
 func newRegistrations() *registrations {
 	return &registrations{
-		subscribers: make(map[uint64]*subscribers),
-		decoders:    make(map[common.Address]ParseLogFunc),
+		subscribers:            make(map[uint64]*subscribers),
+		decoders:               make(map[common.Address]ParseLogFunc), // a high value is set until first subscriber, to avoid a special case in comparison to its NumConfirmations
+		lowestNumConfirmations: uint64(math.MaxUint64),
 	}
 }
 
@@ -68,39 +71,38 @@ func (r *registrations) addSubscriber(reg registration) (needsResubscribe bool) 
 	addr := reg.opts.Contract
 	r.decoders[addr] = reg.opts.ParseLog
 
-	if reg.opts.NumConfirmations == 0 {
-		reg.opts.NumConfirmations = 1
-	}
-
 	if _, exists := r.subscribers[reg.opts.NumConfirmations]; !exists {
 		r.subscribers[reg.opts.NumConfirmations] = newSubscribers()
 	}
 
 	needsResubscribe = r.subscribers[reg.opts.NumConfirmations].addSubscriber(reg)
 
-	r.maybeIncreaseHighestNumConfirmations(reg.opts.NumConfirmations)
+	r.maybeUpdateNumConfirmationsRange(reg.opts.NumConfirmations)
 	return
 }
 
 func (r *registrations) removeSubscriber(reg registration) (needsResubscribe bool) {
-	l, exists := r.subscribers[reg.opts.NumConfirmations]
+	subscribers, exists := r.subscribers[reg.opts.NumConfirmations]
 	if !exists {
 		return
 	}
 
-	needsResubscribe = l.removeSubscriber(reg)
+	needsResubscribe = subscribers.removeSubscriber(reg)
 
-	// we only need to re-evaluate highestNumConfirmations if the removed value was highest
-	if reg.opts.NumConfirmations == r.highestNumConfirmations {
-		r.resetHighestNumConfirmations()
+	if len(r.subscribers[reg.opts.NumConfirmations].handlers) == 0 {
+		delete(r.subscribers, reg.opts.NumConfirmations)
+		r.resetNumConfirmationsRange()
 	}
 	return
 }
 
-// increase the highestNumConfirmations stored if the new listener has a higher value
-func (r *registrations) maybeIncreaseHighestNumConfirmations(newNumConfirmations uint64) {
+// maybe update the numbers tracking highest and lowest num confirmations
+func (r *registrations) maybeUpdateNumConfirmationsRange(newNumConfirmations uint64) {
 	if newNumConfirmations > r.highestNumConfirmations {
 		r.highestNumConfirmations = newNumConfirmations
+	}
+	if newNumConfirmations < r.lowestNumConfirmations {
+		r.lowestNumConfirmations = newNumConfirmations
 	}
 }
 
@@ -113,6 +115,23 @@ func (r *registrations) resetHighestNumConfirmations() {
 		}
 	}
 	r.highestNumConfirmations = highestNumConfirmations
+}
+
+// reset the numbers tracking highest and lowest num confirmations
+func (r *registrations) resetNumConfirmationsRange() {
+	lowestNumConfirmations := uint64(math.MaxUint64)
+	highestNumConfirmations := uint64(0)
+
+	for numConfirmations := range r.subscribers {
+		if numConfirmations > highestNumConfirmations {
+			highestNumConfirmations = numConfirmations
+		}
+		if numConfirmations < lowestNumConfirmations {
+			lowestNumConfirmations = numConfirmations
+		}
+	}
+	r.highestNumConfirmations = highestNumConfirmations
+	r.lowestNumConfirmations = lowestNumConfirmations
 }
 
 func (r *registrations) addressesAndTopics() ([]common.Address, []common.Hash) {
@@ -146,13 +165,16 @@ func (r *registrations) sendLogs(logsToSend []logsOnBlock, latestHead models.Hea
 
 	for _, logsPerBlock := range logsToSend {
 		for numConfirmations, subscribers := range r.subscribers {
-			if latestBlockNumber < numConfirmations {
-				// Skipping send because the block is definitely too young
+
+			if numConfirmations != 0 && latestBlockNumber < numConfirmations {
+				// Skipping send because not enough height to send
 				continue
 			}
-			// We attempt the send multiple times per log
+
+			// We attempt the send multiple times per log (depending on distinct num of confirmations of listeners),
+			// even if the logs are too young
 			// so here we need to see if this particular listener actually should receive it at this depth
-			isOldEnough := (logsPerBlock.BlockNumber + numConfirmations - 1) <= latestBlockNumber
+			isOldEnough := numConfirmations == 0 || (logsPerBlock.BlockNumber+numConfirmations-1) <= latestBlockNumber
 			if !isOldEnough {
 				continue
 			}
@@ -285,6 +307,9 @@ func (r *subscribers) sendLog(log types.Log, latestHead models.Head, broadcasts 
 				continue
 			}
 		}
+
+		logger.Debugw("LogBroadcaster: Sending out log",
+			"blockNumber", log.BlockNumber, "blockHash", log.BlockHash, "address", log.Address, "latestBlockNumber", latestBlockNumber)
 
 		wg.Add(1)
 		go func() {


### PR DESCRIPTION
If all subscribers are setup with 0 confirmations, do not check logs' block numbers when sending them