### PR TITLE
Fix log pool hashes duplicates

### DIFF
--- a/core/services/log/broadcaster_test.go
+++ b/core/services/log/broadcaster_test.go
@@ -532,13 +532,18 @@ func TestBroadcaster_BroadcastsWithZeroConfirmations(t *testing.T) {
 	require.NoError(t, err)
 
 	blocks := cltest.NewBlocks(t, 10)
+	hash100 := utils.NewHash()
+	hash105 := utils.NewHash()
 	addr1SentLogs := []types.Log{
-		cltest.RawNewRoundLog(t, contract1.Address(), utils.NewHash(), 100, 0, false),
-		cltest.RawNewRoundLog(t, contract1.Address(), utils.NewHash(), 101, 0, false),
-		cltest.RawNewRoundLog(t, contract1.Address(), utils.NewHash(), 105, 0, false),
+		cltest.RawNewRoundLog(t, contract1.Address(), hash100, 100, 0, false),
+		cltest.RawNewRoundLog(t, contract1.Address(), hash105, 105, 0, false),
+		cltest.RawNewRoundLog(t, contract1.Address(), hash105, 105, 1, false),
 	}
 
+	// listener1 does not mark logs as consumed to check the correct number of sends
 	listener1 := helper.newLogListener("listener 1")
+	listener1.SkipMarkingConsumed(true)
+
 	listener2 := helper.newLogListener("listener 2")
 
 	helper.register(listener1, contract1, 0)
@@ -560,7 +565,8 @@ func TestBroadcaster_BroadcastsWithZeroConfirmations(t *testing.T) {
 		chRawLogs <- log
 	}
 
-	requireBroadcastCount(t, helper.store, 6)
+	// 3 because only one listeners is marking logs as consumed
+	requireBroadcastCount(t, helper.store, 3)
 	helper.stop()
 
 	requireEqualLogs(t,
@@ -591,7 +597,7 @@ func TestBroadcaster_BroadcastsWithZeroConfirmations(t *testing.T) {
 			blockHash:      blocks.Hashes[4],
 		},
 		{
-			logBlockNumber: 101,
+			logBlockNumber: 105,
 			blockNumber:    4,
 			blockHash:      blocks.Hashes[4],
 		},


### PR DESCRIPTION
Hashes were unnecessarily kept in an array, which led to appending logs from the map multiple times.
Also because of recent changes to DB fetching, the difference in tests between 'uniqueLogs' and 'logs' was not visible. This is made visible by having one listener not mark logs as consumed