### PR TITLE
FMv2 logging improvements around tickers

### DIFF
--- a/core/services/fluxmonitorv2/flux_monitor.go
+++ b/core/services/fluxmonitorv2/flux_monitor.go
@@ -388,28 +388,28 @@ func (fm *FluxMonitor) consume() {
 		case <-fm.chProcessLogs:
 			fm.processLogs()
 
-		case <-fm.pollManager.PollTickerTicks():
-			tickLogger.Debug("Poll ticker fired")
+		case at := <-fm.pollManager.PollTickerTicks():
+			tickLogger.Debugf("Poll ticker fired on %v", at)
 			fm.pollIfEligible(PollRequestTypePoll, fm.deviationChecker, nil)
 
-		case <-fm.pollManager.IdleTimerTicks():
-			tickLogger.Debug("Idle timer fired")
+		case at := <-fm.pollManager.IdleTimerTicks():
+			tickLogger.Debugf("Idle timer fired on %v", at)
 			fm.pollIfEligible(PollRequestTypeIdle, NewZeroDeviationChecker(), nil)
 
-		case <-fm.pollManager.RoundTimerTicks():
-			tickLogger.Debug("Round timer fired")
+		case at := <-fm.pollManager.RoundTimerTicks():
+			tickLogger.Debugf("Round timer fired on %v", at)
 			fm.pollIfEligible(PollRequestTypeRound, fm.deviationChecker, nil)
 
-		case <-fm.pollManager.HibernationTimerTicks():
-			tickLogger.Debug("Hibernation timer fired")
+		case at := <-fm.pollManager.HibernationTimerTicks():
+			tickLogger.Debugf("Hibernation timer fired on %v", at)
 			fm.pollIfEligible(PollRequestTypeHibernation, NewZeroDeviationChecker(), nil)
 
-		case <-fm.pollManager.RetryTickerTicks():
-			tickLogger.Debug("Retry ticker fired")
+		case at := <-fm.pollManager.RetryTickerTicks():
+			tickLogger.Debugf("Retry ticker fired on %v", at)
 			fm.pollIfEligible(PollRequestTypeRetry, NewZeroDeviationChecker(), nil)
 
-		case <-fm.pollManager.DrumbeatTicks():
-			tickLogger.Debug("Drumbeat ticker fired")
+		case at := <-fm.pollManager.DrumbeatTicks():
+			tickLogger.Debugf("Drumbeat ticker fired on %v", at)
 			fm.pollIfEligible(PollRequestTypeDrumbeat, NewZeroDeviationChecker(), nil)
 
 		case request := <-fm.pollManager.Poll():

--- a/core/services/fluxmonitorv2/poll_manager.go
+++ b/core/services/fluxmonitorv2/poll_manager.go
@@ -325,14 +325,15 @@ func (pm *PollManager) startRoundTimer(roundTimesOutAt uint64) {
 // startDrumbeat starts the drumbeat ticker if it is enabled
 func (pm *PollManager) startDrumbeat() {
 	if !pm.cfg.DrumbeatEnabled {
-		pm.logger.Debug("disabling drumbeat")
-		pm.drumbeat.Stop()
-
+		if pm.drumbeat.Stop() {
+			pm.logger.Debug("disabled drumbeat ticker")
+		}
 		return
 	}
 
-	pm.logger.Debugw("starting drumbeat ticker", "schedule", pm.cfg.DrumbeatSchedule, "randomDelay", fmt.Sprintf("%v", pm.cfg.DrumbeatRandomDelay))
-	pm.drumbeat.Start()
+	if pm.drumbeat.Start() {
+		pm.logger.Debugw("started drumbeat ticker", "schedule", pm.cfg.DrumbeatSchedule, "randomDelay", fmt.Sprintf("%v", pm.cfg.DrumbeatRandomDelay))
+	}
 }
 
 func roundStateTimesOutAt(rs flux_aggregator_wrapper.OracleRoundState) uint64 {


### PR DESCRIPTION
- Ticker handling now prints the time the ticker was fired (which sometimes might be a few seconds after)
- "started drumbeat ticker" was being printed even if drumbeat was not actually started (as it was already running)