### PR TITLE
FMv2 Drumbeat Random Delay

### DIFF
--- a/core/services/fluxmonitorv2/flux_monitor.go
+++ b/core/services/fluxmonitorv2/flux_monitor.go
@@ -846,9 +846,9 @@ func (fm *FluxMonitor) pollIfEligible(pollReq PollRequestType, deviationChecker 
 		l.Infof("waiting %v (of max: %v) before continuing...", delay, fm.pollManager.cfg.DrumbeatRandomDelay)
 		time.Sleep(delay)
 
-		roundStateNew, err := fm.roundState(roundState.RoundId)
-		if err != nil {
-			l.Errorw("unable to determine eligibility to submit from FluxAggregator contract", "err", err)
+		roundStateNew, err2 := fm.roundState(roundState.RoundId)
+		if err2 != nil {
+			l.Errorw("unable to determine eligibility to submit from FluxAggregator contract", "err", err2)
 			fm.jobORM.RecordError(
 				context.Background(),
 				fm.spec.JobID,

--- a/core/services/fluxmonitorv2/flux_monitor_test.go
+++ b/core/services/fluxmonitorv2/flux_monitor_test.go
@@ -1440,7 +1440,11 @@ func TestFluxMonitor_DrumbeatTicker(t *testing.T) {
 			Return(roundState, nil).
 			Once()
 
-		tm.orm.On("FindOrCreateFluxMonitorRoundStats", contractAddress, uint32(roundID)).
+		tm.fluxAggregator.On("OracleRoundState", nilOpts, nodeAddr, roundID).
+			Return(roundState, nil).
+			Once()
+
+		tm.orm.On("FindOrCreateFluxMonitorRoundStats", contractAddress, roundID).
 			Return(fluxmonitorv2.FluxMonitorRoundStatsV2{Aggregator: contractAddress, RoundID: roundID}, nil).
 			Once()
 

--- a/core/services/fluxmonitorv2/poll_manager.go
+++ b/core/services/fluxmonitorv2/poll_manager.go
@@ -55,7 +55,7 @@ type PollManager struct {
 	idleTimer        utils.ResettableTimer
 	roundTimer       utils.ResettableTimer
 	retryTicker      utils.BackoffTicker
-	drumbeat         utils.CronTicker
+	drumbeat         *utils.CronTicker
 	chPoll           chan PollRequest
 
 	logger *logger.Logger
@@ -78,7 +78,7 @@ func NewPollManager(cfg PollManagerConfig, logger *logger.Logger) (*PollManager,
 		idleTimer.Reset(cfg.IdleTimerPeriod)
 	}
 
-	var drumbeatTicker utils.CronTicker
+	var drumbeatTicker *utils.CronTicker
 	var err error
 	if cfg.DrumbeatEnabled {
 		drumbeatTicker, err = utils.NewCronTicker(cfg.DrumbeatSchedule)

--- a/core/services/fluxmonitorv2/poll_manager.go
+++ b/core/services/fluxmonitorv2/poll_manager.go
@@ -55,7 +55,7 @@ type PollManager struct {
 	idleTimer        utils.ResettableTimer
 	roundTimer       utils.ResettableTimer
 	retryTicker      utils.BackoffTicker
-	drumbeat         *utils.CronTicker
+	drumbeat         utils.CronTicker
 	chPoll           chan PollRequest
 
 	logger *logger.Logger
@@ -78,7 +78,7 @@ func NewPollManager(cfg PollManagerConfig, logger *logger.Logger) (*PollManager,
 		idleTimer.Reset(cfg.IdleTimerPeriod)
 	}
 
-	var drumbeatTicker *utils.CronTicker
+	var drumbeatTicker utils.CronTicker
 	var err error
 	if cfg.DrumbeatEnabled {
 		drumbeatTicker, err = utils.NewCronTicker(cfg.DrumbeatSchedule)

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -815,12 +815,11 @@ func (t *PausableTicker) Destroy() {
 
 type CronTicker struct {
 	*cron.Cron
-	ch            chan time.Time
-	cronRunningMu sync.Mutex
-	cronRunning   bool
+	ch      chan time.Time
+	beenRun *abool.AtomicBool
 }
 
-func NewCronTicker(schedule string) (*CronTicker, error) {
+func NewCronTicker(schedule string) (CronTicker, error) {
 	cron := cron.New(cron.WithSeconds())
 	ch := make(chan time.Time, 1)
 	_, err := cron.AddFunc(schedule, func() {
@@ -830,18 +829,15 @@ func NewCronTicker(schedule string) (*CronTicker, error) {
 		}
 	})
 	if err != nil {
-		return nil, err
+		return CronTicker{beenRun: abool.New()}, err
 	}
-	return &CronTicker{Cron: cron, ch: ch}, nil
+	return CronTicker{Cron: cron, ch: ch, beenRun: abool.New()}, nil
 }
 
 // Start - returns true if the CronTicker was actually started, false otherwise
 func (t *CronTicker) Start() bool {
 	if t.Cron != nil {
-		t.cronRunningMu.Lock()
-		defer t.cronRunningMu.Unlock()
-		if !t.cronRunning {
-			t.cronRunning = true
+		if t.beenRun.SetToIf(false, true) {
 			t.Cron.Start()
 			return true
 		}
@@ -852,10 +848,7 @@ func (t *CronTicker) Start() bool {
 // Stop - returns true if the CronTicker was actually stopped, false otherwise
 func (t *CronTicker) Stop() bool {
 	if t.Cron != nil {
-		t.cronRunningMu.Lock()
-		defer t.cronRunningMu.Unlock()
-		if t.cronRunning {
-			t.cronRunning = false
+		if t.beenRun.SetToIf(true, false) {
 			t.Cron.Stop()
 			return true
 		}

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -820,7 +820,7 @@ type CronTicker struct {
 	cronRunning   bool
 }
 
-func NewCronTicker(schedule string) (CronTicker, error) {
+func NewCronTicker(schedule string) (*CronTicker, error) {
 	cron := cron.New(cron.WithSeconds())
 	ch := make(chan time.Time, 1)
 	_, err := cron.AddFunc(schedule, func() {
@@ -830,9 +830,9 @@ func NewCronTicker(schedule string) (CronTicker, error) {
 		}
 	})
 	if err != nil {
-		return CronTicker{}, err
+		return nil, err
 	}
-	return CronTicker{Cron: cron, ch: ch}, nil
+	return &CronTicker{Cron: cron, ch: ch}, nil
 }
 
 // Start - returns true if the CronTicker was actually started, false otherwise

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -815,20 +815,19 @@ func (t *PausableTicker) Destroy() {
 
 type CronTicker struct {
 	*cron.Cron
-	ch chan time.Time
+	ch            chan time.Time
+	cronRunningMu sync.Mutex
+	cronRunning   bool
 }
 
-func NewCronTicker(schedule string, randomDelay time.Duration) (CronTicker, error) {
+func NewCronTicker(schedule string) (CronTicker, error) {
 	cron := cron.New(cron.WithSeconds())
 	ch := make(chan time.Time, 1)
 	_, err := cron.AddFunc(schedule, func() {
-		delay := time.Duration(mrand.Int63n(int64(randomDelay)))
-		time.AfterFunc(delay, func() {
-			select {
-			case ch <- time.Now():
-			default:
-			}
-		})
+		select {
+		case ch <- time.Now():
+		default:
+		}
 	})
 	if err != nil {
 		return CronTicker{}, err
@@ -836,16 +835,32 @@ func NewCronTicker(schedule string, randomDelay time.Duration) (CronTicker, erro
 	return CronTicker{Cron: cron, ch: ch}, nil
 }
 
-func (t *CronTicker) Start() {
+// Start - returns true if the CronTicker was actually started, false otherwise
+func (t *CronTicker) Start() bool {
 	if t.Cron != nil {
-		t.Cron.Start()
+		t.cronRunningMu.Lock()
+		defer t.cronRunningMu.Unlock()
+		if !t.cronRunning {
+			t.cronRunning = true
+			t.Cron.Start()
+			return true
+		}
 	}
+	return false
 }
 
-func (t *CronTicker) Stop() {
+// Stop - returns true if the CronTicker was actually stopped, false otherwise
+func (t *CronTicker) Stop() bool {
 	if t.Cron != nil {
-		t.Cron.Stop()
+		t.cronRunningMu.Lock()
+		defer t.cronRunningMu.Unlock()
+		if t.cronRunning {
+			t.cronRunning = false
+			t.Cron.Stop()
+			return true
+		}
 	}
+	return false
 }
 
 func (t *CronTicker) Ticks() <-chan time.Time {


### PR DESCRIPTION
- If DrumbeatRandomDelay is set, then there is a delay introduced between getting recommended round from the contract and submitting the transaction - this is for reducing the number of rounds started on chains with instant confirmation.
- Ticker handling now prints the time the ticker was fired (which sometimes might be a few seconds after)
- "started drumbeat ticker" was being printed even if drumbeat was not actually started (as it was already running)