### PR TITLE
fix waitgroup in HB

### DIFF
--- a/core/services/headtracker/head_broadcaster.go
+++ b/core/services/headtracker/head_broadcaster.go
@@ -136,7 +136,7 @@ func (hr *headBroadcaster) executeCallbacks() {
 	)
 
 	wg := sync.WaitGroup{}
-	wg.Add(len(hr.callbacks))
+	wg.Add(len(callbacks))
 
 	for _, callback := range callbacks {
 		go func(hr httypes.HeadTrackable) {


### PR DESCRIPTION
Adding a callback concurrently might cause this. From tests:
```
2021-08-06T20:18:46Z [32m[DEBUG] [0mEthConfirmer: processHead                          [34mbulletprooftxmanager/eth_confirmer.go:154[0m [32mheadNum[0m=49 [32mid[0m=eth_confirmer [32mtime[0m=1628281126.2868748 
2021-08-06T20:18:46Z [32m[DEBUG] [0mHeadBroadcaster: finished callback in 4.7µs        [34mheadtracker/head_broadcaster.go:149[0m [32mblockNumber[0m=49 [32mcallbackType[0m=*services.promReporter [32mid[0m=head_relayer [32mtime[0m=0.0000047 
2021-08-06T20:18:46Z [32m[DEBUG] [0mHeadBroadcaster: finished callback in 7.8µs        [34mheadtracker/head_broadcaster.go:149[0m [32mblockNumber[0m=49 [32mcallbackType[0m=*services.NullBalanceMonitor [32mid[0m=head_relayer [32mtime[0m=0.0000078 
2021-08-06T20:18:46Z [32m[DEBUG] [0mHeadBroadcaster: finished callback in 7.3µs        [34mheadtracker/head_broadcaster.go:149[0m [32mblockNumber[0m=49 [32mcallbackType[0m=*services.NullBalanceMonitor [32mid[0m=head_relayer [32mtime[0m=0.0000073 
panic: sync: negative WaitGroup counter

goroutine 20137 [running]:
sync.(*WaitGroup).Add(0xc000efdb30, 0xffffffffffffffff)
	/usr/local/go/src/sync/waitgroup.go:74 +0x147
sync.(*WaitGroup).Done(0xc000efdb30)
	/usr/local/go/src/sync/waitgroup.go:99 +0x34
github.com/smartcontractkit/chainlink/core/services/headtracker.(*headBroadcaster).executeCallbacks.func1(0xc000efdb30, 0xc006f24aa0, 0x7fc2bcab52a0, 0x314d878)
	/__w/chainlink/chainlink/core/services/headtracker/head_broadcaster.go:150 +0x453
created by github.com/smartcontractkit/chainlink/core/services/headtracker.(*headBroadcaster).executeCallbacks
	/__w/chainlink/chainlink/core/services/headtracker/head_broadcaster.go:142 +0x405
FAIL	github.com/smartcontractkit/chainlink/core/internal	40.119s
```