### PR TITLE
FMv2 drumbeat Random delay

### DIFF
--- a/core/services/fluxmonitorv2/flux_monitor.go
+++ b/core/services/fluxmonitorv2/flux_monitor.go
@@ -830,9 +830,9 @@ func (fm *FluxMonitor) pollIfEligible(pollReq PollRequestType, deviationChecker 
 		l.Infof("waiting %v (of max: %v) before continuing...", delay, fm.pollManager.cfg.DrumbeatRandomDelay)
 		time.Sleep(delay)
 
-		roundStateNew, err := fm.roundState(roundState.RoundId)
-		if err != nil {
-			l.Errorw("unable to determine eligibility to submit from FluxAggregator contract", "err", err)
+		roundStateNew, err2 := fm.roundState(roundState.RoundId)
+		if err2 != nil {
+			l.Errorw("unable to determine eligibility to submit from FluxAggregator contract", "err", err2)
 			fm.jobORM.RecordError(
 				context.Background(),
 				fm.spec.JobID,

--- a/core/services/fluxmonitorv2/flux_monitor.go
+++ b/core/services/fluxmonitorv2/flux_monitor.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	mrand "math/rand"
 	"reflect"
 	"time"
 
@@ -388,28 +389,28 @@ func (fm *FluxMonitor) consume() {
 		case <-fm.chProcessLogs:
 			fm.processLogs()
 
-		case <-fm.pollManager.PollTickerTicks():
-			tickLogger.Debug("Poll ticker fired")
+		case at := <-fm.pollManager.PollTickerTicks():
+			tickLogger.Debugf("Poll ticker fired on %v", formatTime(at))
 			fm.pollIfEligible(PollRequestTypePoll, fm.deviationChecker, nil)
 
-		case <-fm.pollManager.IdleTimerTicks():
-			tickLogger.Debug("Idle timer fired")
+		case at := <-fm.pollManager.IdleTimerTicks():
+			tickLogger.Debugf("Idle timer fired on %v", formatTime(at))
 			fm.pollIfEligible(PollRequestTypeIdle, NewZeroDeviationChecker(), nil)
 
-		case <-fm.pollManager.RoundTimerTicks():
-			tickLogger.Debug("Round timer fired")
+		case at := <-fm.pollManager.RoundTimerTicks():
+			tickLogger.Debugf("Round timer fired on %v", formatTime(at))
 			fm.pollIfEligible(PollRequestTypeRound, fm.deviationChecker, nil)
 
-		case <-fm.pollManager.HibernationTimerTicks():
-			tickLogger.Debug("Hibernation timer fired")
+		case at := <-fm.pollManager.HibernationTimerTicks():
+			tickLogger.Debugf("Hibernation timer fired on %v", formatTime(at))
 			fm.pollIfEligible(PollRequestTypeHibernation, NewZeroDeviationChecker(), nil)
 
-		case <-fm.pollManager.RetryTickerTicks():
-			tickLogger.Debug("Retry ticker fired")
+		case at := <-fm.pollManager.RetryTickerTicks():
+			tickLogger.Debugf("Retry ticker fired on %v", formatTime(at))
 			fm.pollIfEligible(PollRequestTypeRetry, NewZeroDeviationChecker(), nil)
 
-		case <-fm.pollManager.DrumbeatTicks():
-			tickLogger.Debug("Drumbeat ticker fired")
+		case at := <-fm.pollManager.DrumbeatTicks():
+			tickLogger.Debugf("Drumbeat ticker fired on %v", formatTime(at))
 			fm.pollIfEligible(PollRequestTypeDrumbeat, NewZeroDeviationChecker(), nil)
 
 		case request := <-fm.pollManager.Poll():
@@ -421,6 +422,11 @@ func (fm *FluxMonitor) consume() {
 			}
 		}
 	}
+}
+
+func formatTime(at time.Time) string {
+	ago := time.Since(at)
+	return fmt.Sprintf("%v (%v ago)", at.UTC().Format(time.RFC3339), ago)
 }
 
 // SetOracleAddress sets the oracle address which matches the node's keys.
@@ -815,6 +821,29 @@ func (fm *FluxMonitor) pollIfEligible(pollReq PollRequestType, deviationChecker 
 		return
 	}
 
+	l = l.With("reportableRound", roundState.RoundId)
+
+	// Because drumbeat ticker may fire at the same time on multiple nodes, we wait a short random duration
+	// after getting a recommended round id, to avoid starting multiple rounds in case of chains with instant tx confirmation
+	if pollReq == PollRequestTypeDrumbeat && fm.pollManager.cfg.DrumbeatEnabled && fm.pollManager.cfg.DrumbeatRandomDelay > 0 {
+		delay := time.Duration(mrand.Int63n(int64(fm.pollManager.cfg.DrumbeatRandomDelay)))
+		l.Infof("waiting %v (of max: %v) before continuing...", delay, fm.pollManager.cfg.DrumbeatRandomDelay)
+		time.Sleep(delay)
+
+		roundStateNew, err := fm.roundState(roundState.RoundId)
+		if err != nil {
+			l.Errorw("unable to determine eligibility to submit from FluxAggregator contract", "err", err)
+			fm.jobORM.RecordError(
+				context.Background(),
+				fm.spec.JobID,
+				"Unable to call roundState method on provided contract. Check contract address.",
+			)
+
+			return
+		}
+		roundState = roundStateNew
+	}
+
 	fm.pollManager.Reset(roundState)
 	// Retry if a idle timer fails
 	defer func() {
@@ -829,8 +858,6 @@ func (fm *FluxMonitor) pollIfEligible(pollReq PollRequestType, deviationChecker 
 			fm.pollManager.StopRetryTicker()
 		}
 	}()
-
-	l = l.With("reportableRound", roundState.RoundId)
 
 	roundStats, jobRunStatus, err := fm.statsAndStatusForRound(roundState.RoundId)
 	if err != nil {

--- a/core/services/fluxmonitorv2/flux_monitor_test.go
+++ b/core/services/fluxmonitorv2/flux_monitor_test.go
@@ -1412,6 +1412,9 @@ func TestFluxMonitor_DrumbeatTicker(t *testing.T) {
 	store, nodeAddr := setupStoreWithKey(t)
 	oracles := []common.Address{nodeAddr, cltest.NewAddress()}
 
+	// a setup with a random delay being zero
+	_, _ = setup(t, store.DB, enableDrumbeatTicker("@every 10s", 0))
+
 	fm, tm := setup(t, store.DB, disablePollTicker(true), disableIdleTimer(true), enableDrumbeatTicker("@every 3s", 2*time.Second))
 
 	tm.keyStore.On("SendingKeys").Return([]ethkey.Key{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil)

--- a/core/services/fluxmonitorv2/flux_monitor_test.go
+++ b/core/services/fluxmonitorv2/flux_monitor_test.go
@@ -1443,7 +1443,11 @@ func TestFluxMonitor_DrumbeatTicker(t *testing.T) {
 			Return(roundState, nil).
 			Once()
 
-		tm.orm.On("FindOrCreateFluxMonitorRoundStats", contractAddress, uint32(roundID)).
+		tm.fluxAggregator.On("OracleRoundState", nilOpts, nodeAddr, roundID).
+			Return(roundState, nil).
+			Once()
+
+		tm.orm.On("FindOrCreateFluxMonitorRoundStats", contractAddress, roundID).
 			Return(fluxmonitorv2.FluxMonitorRoundStatsV2{Aggregator: contractAddress, RoundID: roundID}, nil).
 			Once()
 

--- a/core/services/fluxmonitorv2/poll_manager.go
+++ b/core/services/fluxmonitorv2/poll_manager.go
@@ -55,7 +55,7 @@ type PollManager struct {
 	idleTimer        utils.ResettableTimer
 	roundTimer       utils.ResettableTimer
 	retryTicker      utils.BackoffTicker
-	drumbeat         utils.CronTicker
+	drumbeat         *utils.CronTicker
 	chPoll           chan PollRequest
 
 	logger *logger.Logger
@@ -78,7 +78,7 @@ func NewPollManager(cfg PollManagerConfig, logger *logger.Logger) (*PollManager,
 		idleTimer.Reset(cfg.IdleTimerPeriod)
 	}
 
-	var drumbeatTicker utils.CronTicker
+	var drumbeatTicker *utils.CronTicker
 	var err error
 	if cfg.DrumbeatEnabled {
 		drumbeatTicker, err = utils.NewCronTicker(cfg.DrumbeatSchedule)

--- a/core/services/fluxmonitorv2/poll_manager.go
+++ b/core/services/fluxmonitorv2/poll_manager.go
@@ -55,7 +55,7 @@ type PollManager struct {
 	idleTimer        utils.ResettableTimer
 	roundTimer       utils.ResettableTimer
 	retryTicker      utils.BackoffTicker
-	drumbeat         *utils.CronTicker
+	drumbeat         utils.CronTicker
 	chPoll           chan PollRequest
 
 	logger *logger.Logger
@@ -78,7 +78,7 @@ func NewPollManager(cfg PollManagerConfig, logger *logger.Logger) (*PollManager,
 		idleTimer.Reset(cfg.IdleTimerPeriod)
 	}
 
-	var drumbeatTicker *utils.CronTicker
+	var drumbeatTicker utils.CronTicker
 	var err error
 	if cfg.DrumbeatEnabled {
 		drumbeatTicker, err = utils.NewCronTicker(cfg.DrumbeatSchedule)

--- a/core/services/fluxmonitorv2/validate_test.go
+++ b/core/services/fluxmonitorv2/validate_test.go
@@ -35,6 +35,10 @@ idleTimerDisabled = false
 pollTimerPeriod = "1m"
 pollTimerDisabled = false
 
+drumbeatEnabled = true
+drumbeatSchedule = "@every 1m"
+drumbeatRandomDelay = "10s"
+
 minPayment = 1000000000000000000
 
 observationSource = """
@@ -65,6 +69,10 @@ answer1 [type=median index=0];
 				assert.Equal(t, 1*time.Second, spec.IdleTimerPeriod)
 				assert.Equal(t, false, spec.IdleTimerDisabled)
 				assert.Equal(t, 1*time.Minute, spec.PollTimerPeriod)
+				assert.Equal(t, false, spec.PollTimerDisabled)
+				assert.Equal(t, true, spec.DrumbeatEnabled)
+				assert.Equal(t, "@every 1m", spec.DrumbeatSchedule)
+				assert.Equal(t, 10*time.Second, spec.DrumbeatRandomDelay)
 				assert.Equal(t, false, spec.PollTimerDisabled)
 				assert.Equal(t, assets.NewLink(1000000000000000000), spec.MinPayment)
 				assert.NotZero(t, j.Pipeline)

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -821,7 +821,7 @@ type CronTicker struct {
 	cronRunning   bool
 }
 
-func NewCronTicker(schedule string) (CronTicker, error) {
+func NewCronTicker(schedule string) (*CronTicker, error) {
 	cron := cron.New(cron.WithSeconds())
 	ch := make(chan time.Time, 1)
 	_, err := cron.AddFunc(schedule, func() {
@@ -831,9 +831,9 @@ func NewCronTicker(schedule string) (CronTicker, error) {
 		}
 	})
 	if err != nil {
-		return CronTicker{}, err
+		return nil, err
 	}
-	return CronTicker{Cron: cron, ch: ch}, nil
+	return &CronTicker{Cron: cron, ch: ch}, nil
 }
 
 // Start - returns true if the CronTicker was actually started, false otherwise

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -816,20 +816,19 @@ func (t *PausableTicker) Destroy() {
 
 type CronTicker struct {
 	*cron.Cron
-	ch chan time.Time
+	ch            chan time.Time
+	cronRunningMu sync.Mutex
+	cronRunning   bool
 }
 
-func NewCronTicker(schedule string, randomDelay time.Duration) (CronTicker, error) {
+func NewCronTicker(schedule string) (CronTicker, error) {
 	cron := cron.New(cron.WithSeconds())
 	ch := make(chan time.Time, 1)
 	_, err := cron.AddFunc(schedule, func() {
-		delay := time.Duration(mrand.Int63n(int64(randomDelay)))
-		time.AfterFunc(delay, func() {
-			select {
-			case ch <- time.Now():
-			default:
-			}
-		})
+		select {
+		case ch <- time.Now():
+		default:
+		}
 	})
 	if err != nil {
 		return CronTicker{}, err
@@ -837,16 +836,32 @@ func NewCronTicker(schedule string, randomDelay time.Duration) (CronTicker, erro
 	return CronTicker{Cron: cron, ch: ch}, nil
 }
 
-func (t *CronTicker) Start() {
+// Start - returns true if the CronTicker was actually started, false otherwise
+func (t *CronTicker) Start() bool {
 	if t.Cron != nil {
-		t.Cron.Start()
+		t.cronRunningMu.Lock()
+		defer t.cronRunningMu.Unlock()
+		if !t.cronRunning {
+			t.cronRunning = true
+			t.Cron.Start()
+			return true
+		}
 	}
+	return false
 }
 
-func (t *CronTicker) Stop() {
+// Stop - returns true if the CronTicker was actually stopped, false otherwise
+func (t *CronTicker) Stop() bool {
 	if t.Cron != nil {
-		t.Cron.Stop()
+		t.cronRunningMu.Lock()
+		defer t.cronRunningMu.Unlock()
+		if t.cronRunning {
+			t.cronRunning = false
+			t.Cron.Stop()
+			return true
+		}
 	}
+	return false
 }
 
 func (t *CronTicker) Ticks() <-chan time.Time {


### PR DESCRIPTION
- If DrumbeatRandomDelay is set, then there is a delay introduced between getting recommended round from the contract and submitting the transaction - this is for reducing the number of rounds started on chains with instant confirmation.
- Ticker handling now prints the time the ticker was fired (which sometimes might be a few seconds after)
- "started drumbeat ticker" was being printed even if drumbeat was not actually started (as it was already running)