### PR TITLE
Fix flaky jobs delete test

### DIFF
--- a/core/web/jobs_controller_test.go
+++ b/core/web/jobs_controller_test.go
@@ -372,8 +372,6 @@ func setupJobsControllerTests(t *testing.T) (*cltest.TestApplication, cltest.HTT
 }
 
 func setupJobSpecsControllerTestsWithJobs(t *testing.T) (*cltest.TestApplication, cltest.HTTPClientCleaner, job.Job, int32, job.Job, int32) {
-	t.Parallel()
-
 	app, cleanup := cltest.NewApplicationWithKey(t)
 	t.Cleanup(cleanup)
 	require.NoError(t, app.Start())


### PR DESCRIPTION
I think ideally `t.Parallel()` is used only individually in each test.

This has a chance of fixing the following, as I think that job is from a different test.

```
2021-08-12T08:15:43Z [37m[INFO]  [0mDELETE /v2/pipeline/job_spec_errors/5              [34mweb/router.go:419[0m       [32mclientIP[0m=127.0.0.1 [32mlatency[0m=7.334195ms [32mmethod[0m=DELETE [32mpath[0m=/v2/pipeline/job_spec_errors/5 [32mservedAt[0m=2021-08-12 08:15:43 [32mstatus[0m=204 
2021-08-12T08:15:43Z [31m[ERROR] [0mError creating services for job                    [34mjob/spawner.go:199[0m      [32merror[0m=given peer with ID 'p2p_' does not match OCR configured peer with ID: p2p_12D3KooWApUJaQB2saFjyEUfq6BmysnsSnhLnY5CF9tURYVKgoXK [32merrorVerbose[0m=given peer with ID 'p2p_' does not match OCR configured peer with ID: p2p_12D3KooWApUJaQB2saFjyEUfq6BmysnsSnhLnY5CF9tURYVKgoXK
github.com/smartcontractkit/chainlink/core/services/offchainreporting.Delegate.ServicesForSpec
	/__w/chainlink/chainlink/core/services/offchainreporting/delegate.go:162
github.com/smartcontractkit/chainlink/core/services/job.(*spawner).startUnclaimedServices
	/__w/chainlink/chainlink/core/services/job/spawner.go:197
github.com/smartcontractkit/chainlink/core/utils.SleeperTaskFuncWorker.Work
	/__w/chainlink/chainlink/core/utils/sleeper_task.go:93
github.com/smartcontractkit/chainlink/core/utils.(*sleeperTask).workerLoop
	/__w/chainlink/chainlink/core/utils/sleeper_task.go:84
runtime.goexit
	/usr/local/go/src/runtime/asm_amd64.s:1371 [32mjobID[0m=145 [32mstacktrace[0m=github.com/smartcontractkit/chainlink/core/services/job.(*spawner).startUnclaimedServices
	/__w/chainlink/chainlink/core/services/job/spawner.go:199
github.com/smartcontractkit/chainlink/core/utils.SleeperTaskFuncWorker.Work
	/__w/chainlink/chainlink/core/utils/sleeper_task.go:93
github.com/smartcontractkit/chainlink/core/utils.(*sleeperTask).workerLoop
	/__w/chainlink/chainlink/core/utils/sleeper_task.go:84 
2021-08-12T08:15:43Z [37m[INFO]  [0mDatabaseBackup: periodic database backups are disabled. To enable automatic backups, set DATABASE_BACKUP_MODE=lite or DATABASE_BACKUP_MODE=full [34mchainlink/application.go:175[0m 
2021-08-12T08:15:43Z [37m[INFO]  [0mJobSpawner: all jobs running                       [34mjob/spawner.go:218[0m      [32mcount[0m=0 
2021-08-12T08:15:43Z [32m[DEBUG] [0mJobSpawner: Starting services for job              [34mjob/spawner.go:204[0m      [32mcount[0m=1 [32mjobID[0m=146 
2021-08-12T08:15:43Z [37m[INFO]  [0mJobSpawner: all jobs running                       [34mjob/spawner.go:218[0m      [32mcount[0m=2 
2021-08-12T08:15:43Z [32m[DEBUG] [0mLogBroadcaster: Subscribing listener               [34mlog/broadcaster.go:447[0m  [32maddress[0m=0x613a38AC1659769640aaE063C651F48E0250454C [32mrequiredBlockConfirmations[0m=1 
=== CONT  TestPipelineJobSpecErrorsController_Delete
    pipeline_job_spec_errors_controller_test.go:34: 
        	Error Trace:	pipeline_job_spec_errors_controller_test.go:34
        	Error:      	"[{%!s(int64=6) %!s(int32=145) given peer with ID 'p2p_' does not match OCR configured peer with ID: p2p_12D3KooWApUJaQB2saFjyEUfq6BmysnsSnhLnY5CF9tURYVKgoXK %!s(uint=1) 2021-08-12 08:15:43.442474 +0000 UTC 2021-08-12 08:15:43.442474 +0000 UTC}]" should have 0 item(s), but has 1
        	Test:       	TestPipelineJobSpecErrorsController_Delete

```