### PR TITLE
Use correct error log method

### DIFF
--- a/core/store/config/general_config.go
+++ b/core/store/config/general_config.go
@@ -400,7 +400,7 @@ func (c *generalConfig) DatabaseBackupURL() *url.URL {
 	}
 	uri, err := url.Parse(s)
 	if err != nil {
-		logger.Error("invalid database backup url %s", s)
+		logger.Errorf("invalid database backup url %s", s)
 		return nil
 	}
 	return uri


### PR DESCRIPTION
The current resulting error in case of invalid DB DSN is
`[ERROR] invalid database url %s"postgres://.....` 