### PR TITLE
Head tracker heads buffer

### DIFF
--- a/core/internal/cltest/simulated_backend.go
+++ b/core/internal/cltest/simulated_backend.go
@@ -68,7 +68,6 @@ func NewApplicationWithConfigAndKeyOnSimulatedBlockchain(
 	client := &SimulatedBackendClient{b: backend, t: t, chainId: chainId}
 	eventBroadcaster := postgres.NewEventBroadcaster(cfg.DatabaseURL(), 0, 0)
 
-	ht := models.MustMakeDuration(10 * time.Millisecond)
 	zero := models.MustMakeDuration(0 * time.Millisecond)
 	reaperThreshold := models.MustMakeDuration(100 * time.Millisecond)
 	simulatedBackendChain := evmtypes.Chain{
@@ -76,7 +75,7 @@ func NewApplicationWithConfigAndKeyOnSimulatedBlockchain(
 		Cfg: evmtypes.ChainCfg{
 			GasEstimatorMode:                 null.StringFrom("FixedPrice"),
 			EvmHeadTrackerMaxBufferSize:      null.IntFrom(100),
-			EvmHeadTrackerSamplingInterval:   &ht,
+			EvmHeadTrackerSamplingInterval:   &zero, // Head sampling disabled
 			EthTxResendAfterThreshold:        &zero,
 			EvmFinalityDepth:                 null.IntFrom(15),
 			EthTxReaperThreshold:             &reaperThreshold,

--- a/core/services/headtracker/head_tracker.go
+++ b/core/services/headtracker/head_tracker.go
@@ -31,6 +31,9 @@ var (
 	}, []string{"evmChainID"})
 )
 
+// HeadsBufferSize - The buffer is used when heads sampling is disabled, to ensure the callback is run for every head
+const HeadsBufferSize = 10
+
 // HeadTracker holds and stores the latest block number experienced by this particular node
 // in a thread safe manner. Reconstitutes the last block number from the data
 // store on reboot.
@@ -72,7 +75,7 @@ func NewHeadTracker(
 		config:          config,
 		log:             l,
 		backfillMB:      *utils.NewMailbox(1),
-		callbackMB:      *utils.NewMailbox(1),
+		callbackMB:      *utils.NewMailbox(HeadsBufferSize),
 		chStop:          chStop,
 		wgDone:          &wgDone,
 		headListener:    NewHeadListener(l, ethClient, config, chStop, &wgDone, sleepers...),
@@ -193,7 +196,11 @@ func (ht *HeadTracker) headCallbackLoop() {
 			case <-ht.chStop:
 				return
 			case <-debounceHead.C:
-				ht.callbackOnLatestHead()
+				item := ht.callbackMB.RetrieveLatestAndClear()
+				if item == nil {
+					continue
+				}
+				ht.callbackOnLatestHead(item)
 			}
 		}
 	} else {
@@ -203,20 +210,22 @@ func (ht *HeadTracker) headCallbackLoop() {
 			case <-ht.chStop:
 				return
 			case <-ht.callbackMB.Notify():
-				ht.callbackOnLatestHead()
+				for {
+					item, exists := ht.callbackMB.Retrieve()
+					if !exists {
+						break
+					}
+					ht.callbackOnLatestHead(item)
+				}
 			}
 		}
 	}
 }
 
-func (ht *HeadTracker) callbackOnLatestHead() {
+func (ht *HeadTracker) callbackOnLatestHead(item interface{}) {
 	ctx, cancel := utils.ContextFromChan(ht.chStop)
 	defer cancel()
 
-	item, exists := ht.callbackMB.Retrieve()
-	if !exists {
-		return
-	}
 	head, ok := item.(models.Head)
 	if !ok {
 		panic(fmt.Sprintf("expected `models.Head`, got %T", item))
@@ -242,7 +251,7 @@ func (ht *HeadTracker) backfiller() {
 					panic(fmt.Sprintf("expected `models.Head`, got %T", head))
 				}
 				{
-					ctx, cancel := utils.ContextFromChan(ht.chStop)
+					ctx, cancel := eth.DefaultQueryCtx()
 					err := ht.Backfill(ctx, h, uint(ht.config.EvmFinalityDepth()))
 					if err != nil {
 						ht.logger().Warnw("HeadTracker: unexpected error while backfilling heads", "err", err)

--- a/core/services/headtracker/head_tracker.go
+++ b/core/services/headtracker/head_tracker.go
@@ -188,7 +188,7 @@ func (ht *HeadTracker) headCallbackLoop() {
 
 	samplingInterval := ht.config.EvmHeadTrackerSamplingInterval()
 	if samplingInterval > 0 {
-		ht.logger().Infof("Head sampling interval is set to: %v", samplingInterval)
+		ht.logger().Infof("Head sampling is enabled - sampling interval is set to: %v", samplingInterval)
 		debounceHead := time.NewTicker(samplingInterval)
 		defer debounceHead.Stop()
 		for {

--- a/core/services/headtracker/head_tracker_test.go
+++ b/core/services/headtracker/head_tracker_test.go
@@ -317,6 +317,7 @@ func TestHeadTracker_Start_LoadsLatestChain(t *testing.T) {
 
 	orm := headtracker.NewORM(db, cltest.FixtureChainID)
 	trackable := new(htmocks.HeadTrackable)
+	trackable.Test(t)
 	ht := createHeadTrackerWithChecker(ethClient, config, orm, trackable)
 
 	require.NoError(t, orm.IdempotentInsertHead(context.Background(), *heads[2]))
@@ -352,6 +353,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingEnabled(t *testing.T)
 	ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
 
 	checker := new(htmocks.HeadTrackable)
+	checker.Test(t)
 	orm := headtracker.NewORM(store.DB, *config.DefaultChainID())
 	ht := createHeadTrackerWithChecker(ethClient, evmtest.NewChainScopedConfig(t, config), orm, checker)
 
@@ -476,6 +478,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled(t *testing.T
 	ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
 
 	checker := new(htmocks.HeadTrackable)
+	checker.Test(t)
 	orm := headtracker.NewORM(store.DB, cltest.FixtureChainID)
 	evmcfg := evmtest.NewChainScopedConfig(t, config)
 	ht := createHeadTrackerWithChecker(ethClient, evmcfg, orm, checker)
@@ -494,7 +497,6 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled(t *testing.T
 	head0 := blocks.Head(0) // models.Head{Number: 0, Hash: utils.NewHash(), ParentHash: utils.NewHash(), Timestamp: time.Unix(0, 0)}
 	// Initial query
 	ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(head0, nil)
-	require.NoError(t, ht.Start())
 
 	headSeq := cltest.NewHeadBuffer(t)
 	headSeq.Append(blocks.Head(0))
@@ -571,6 +573,8 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled(t *testing.T
 			require.Equal(t, h.Parent.Parent.Parent.Parent.Hash, blocksForked.Head(1).Hash)
 			close(lastHead)
 		}).Return().Once()
+
+	require.NoError(t, ht.Start())
 
 	headers := <-chchHeaders
 


### PR DESCRIPTION
In case head sampling is disabled, we have have a larger heads buffer to ensure every head callback is run