### PR TITLE
Allow setting KeySpecific overrides on the Chain config

### DIFF
--- a/core/chains/evm/config/config.go
+++ b/core/chains/evm/config/config.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/pkg/errors"
 	ocr "github.com/smartcontractkit/libocr/offchainreporting"
@@ -53,6 +54,7 @@ type ChainScopedOnlyConfig interface {
 	EvmRPCDefaultBatchSize() uint32
 	FlagsContractAddress() string
 	GasEstimatorMode() string
+	KeySpecificMaxGasPriceWei(addr gethcommon.Address) *big.Int
 	LinkContractAddress() string
 	MinIncomingConfirmations() uint32
 	MinRequiredOutgoingConfirmations() uint64
@@ -167,7 +169,7 @@ func (c *chainScopedConfig) logEnvOverrideOnce(name string, envVal interface{}) 
 	if _, ok := c.onceMap[k]; ok {
 		return
 	}
-	c.logger.Warnf("Global ENV var set %s=%v, overriding chain-specific default value for %s", config.TryEnvVarName(name), envVal, name)
+	c.logger.Warnf("Global ENV var set %s=%v, overriding all other values for %s", config.TryEnvVarName(name), envVal, name)
 	c.onceMap[k] = struct{}{}
 }
 
@@ -185,6 +187,23 @@ func (c *chainScopedConfig) logPersistedOverrideOnce(name string, pstVal interfa
 		return
 	}
 	c.logger.Infof("User-specified var set %s=%v, overriding chain-specific default value for %s", name, pstVal, name)
+	c.onceMap[k] = struct{}{}
+}
+
+func (c *chainScopedConfig) logKeySpecificOverrideOnce(name string, addr gethcommon.Address, pstVal interface{}) {
+	k := fmt.Sprintf("ksp-%s", name)
+	c.onceMapMu.RLock()
+	if _, ok := c.onceMap[k]; ok {
+		c.onceMapMu.RUnlock()
+		return
+	}
+	c.onceMapMu.RUnlock()
+	c.onceMapMu.Lock()
+	defer c.onceMapMu.Unlock()
+	if _, ok := c.onceMap[k]; ok {
+		return
+	}
+	c.logger.Infof("Key-specific var set %s=%v for key %s, overriding chain-specific values for %s", name, pstVal, addr.Hex(), name)
 	c.onceMap[k] = struct{}{}
 }
 
@@ -243,7 +262,7 @@ func (c *chainScopedConfig) EvmMaxGasPriceWei() *big.Int {
 		return val
 	}
 	if c.persistedCfg.EvmMaxGasPriceWei != nil {
-		c.logPersistedOverrideOnce("EvmMaxGasPriceWei", c.persistedCfg.EvmGasBumpWei)
+		c.logPersistedOverrideOnce("EvmMaxGasPriceWei", c.persistedCfg.EvmMaxGasPriceWei)
 		return c.persistedCfg.EvmMaxGasPriceWei.ToInt()
 	}
 	n := c.defaultSet.maxGasPriceWei
@@ -546,6 +565,20 @@ func (c *chainScopedConfig) GasEstimatorMode() string {
 		return c.persistedCfg.GasEstimatorMode.String
 	}
 	return c.defaultSet.gasEstimatorMode
+}
+
+func (c *chainScopedConfig) KeySpecificMaxGasPriceWei(addr gethcommon.Address) *big.Int {
+	val, ok := c.GeneralConfig.GlobalEvmMaxGasPriceWei()
+	if ok {
+		c.logEnvOverrideOnce("EvmMaxGasPriceWei", val)
+		return val
+	}
+	keySpecific := c.persistedCfg.KeySpecific[addr.Hex()].EvmMaxGasPriceWei
+	if keySpecific != nil {
+		c.logKeySpecificOverrideOnce("EvmMaxGasPriceWei", addr, keySpecific)
+		return keySpecific.ToInt()
+	}
+	return c.EvmMaxGasPriceWei()
 }
 
 // LinkContractAddress represents the address of the official LINK token

--- a/core/chains/evm/config/helpers_test.go
+++ b/core/chains/evm/config/helpers_test.go
@@ -1,0 +1,7 @@
+package config
+
+import "github.com/smartcontractkit/chainlink/core/chains/evm/types"
+
+func PersistedCfgPtr(cfg ChainScopedConfig) *types.ChainCfg {
+	return &cfg.(*chainScopedConfig).persistedCfg
+}

--- a/core/chains/evm/config/mocks/chain_scoped_config.go
+++ b/core/chains/evm/config/mocks/chain_scoped_config.go
@@ -7,6 +7,8 @@ import (
 
 	assets "github.com/smartcontractkit/chainlink/core/assets"
 
+	common "github.com/ethereum/go-ethereum/common"
+
 	context "context"
 
 	dialects "github.com/smartcontractkit/chainlink/core/store/dialects"
@@ -2116,6 +2118,22 @@ func (_m *ChainScopedConfig) KeyFile() string {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// KeySpecificMaxGasPriceWei provides a mock function with given fields: addr
+func (_m *ChainScopedConfig) KeySpecificMaxGasPriceWei(addr common.Address) *big.Int {
+	ret := _m.Called(addr)
+
+	var r0 *big.Int
+	if rf, ok := ret.Get(0).(func(common.Address) *big.Int); ok {
+		r0 = rf(addr)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
 	}
 
 	return r0

--- a/core/chains/evm/types/types.go
+++ b/core/chains/evm/types/types.go
@@ -64,6 +64,7 @@ type ChainCfg struct {
 	MinRequiredOutgoingConfirmations      null.Int
 	MinimumContractPayment                *assets.Link
 	OCRObservationTimeout                 *models.Duration
+	KeySpecific                           map[string]ChainCfg
 }
 
 func (c *ChainCfg) Scan(value interface{}) error {

--- a/core/chains/evm/types/types_test.go
+++ b/core/chains/evm/types/types_test.go
@@ -4,13 +4,13 @@ import (
 	"math/rand"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/utils"
-
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func Test_PersistsReadsChain(t *testing.T) {

--- a/core/chains/evm/types/types_test.go
+++ b/core/chains/evm/types/types_test.go
@@ -1,0 +1,37 @@
+package types_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
+	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
+	"github.com/smartcontractkit/chainlink/core/utils"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_PersistsReadsChain(t *testing.T) {
+	db := pgtest.NewGormDB(t)
+
+	val := utils.NewBigI(rand.Int63())
+	addr := cltest.NewAddress()
+	ks := make(map[string]types.ChainCfg)
+	ks[addr.Hex()] = types.ChainCfg{EvmMaxGasPriceWei: val}
+	chain := types.Chain{
+		ID: *utils.NewBigI(rand.Int63()),
+		Cfg: types.ChainCfg{
+			KeySpecific: ks,
+		},
+	}
+
+	require.NoError(t, db.Create(&chain).Error)
+
+	var loadedChain types.Chain
+	require.NoError(t, db.First(&loadedChain, "id = ?", chain.ID).Error)
+
+	loadedVal := loadedChain.Cfg.KeySpecific[addr.Hex()].EvmMaxGasPriceWei
+	assert.Equal(t, loadedVal, val)
+}

--- a/core/services/bulletprooftxmanager/bulletprooftxmanager.go
+++ b/core/services/bulletprooftxmanager/bulletprooftxmanager.go
@@ -40,6 +40,9 @@ type Config interface {
 	BlockHistoryEstimatorBlockDelay() uint16
 	BlockHistoryEstimatorBlockHistorySize() uint16
 	BlockHistoryEstimatorTransactionPercentile() uint16
+	EthTxReaperInterval() time.Duration
+	EthTxReaperThreshold() time.Duration
+	EthTxResendAfterThreshold() time.Duration
 	EvmFinalityDepth() uint32
 	EvmGasBumpPercent() uint16
 	EvmGasBumpThreshold() uint64
@@ -54,10 +57,8 @@ type Config interface {
 	EvmMinGasPriceWei() *big.Int
 	EvmNonceAutoSync() bool
 	EvmRPCDefaultBatchSize() uint32
-	EthTxReaperInterval() time.Duration
-	EthTxReaperThreshold() time.Duration
-	EthTxResendAfterThreshold() time.Duration
 	GasEstimatorMode() string
+	KeySpecificMaxGasPriceWei(addr common.Address) *big.Int
 	TriggerFallbackDBPollInterval() time.Duration
 }
 
@@ -345,11 +346,10 @@ func SendEther(db *gorm.DB, chainID *big.Int, from, to common.Address, value ass
 	return etx, err
 }
 
-func newAttempt(ethClient eth.Client, ks KeyStore, chainID big.Int, etx EthTx, gasPrice *big.Int, gasLimit uint64) (EthTxAttempt, error) {
-	if gasPrice == nil {
-		panic("gas price missing")
+func NewAttempt(cfg Config, ethClient eth.Client, ks KeyStore, chainID big.Int, etx EthTx, gasPrice *big.Int, gasLimit uint64) (attempt EthTxAttempt, err error) {
+	if err = validateGas(cfg, gasPrice, gasLimit, etx); err != nil {
+		return attempt, errors.Wrap(err, "error validating gas")
 	}
-	attempt := EthTxAttempt{}
 
 	tx := newLegacyTransaction(
 		uint64(*etx.Nonce),
@@ -373,6 +373,23 @@ func newAttempt(ethClient eth.Client, ks KeyStore, chainID big.Int, etx EthTx, g
 	attempt.Hash = hash
 
 	return attempt, nil
+}
+
+// validateGas is a sanity check - we have other checks elsewhere, but this
+// makes sure we _never_ create an invalid attempt
+func validateGas(cfg Config, gasPrice *big.Int, gasLimit uint64, etx EthTx) error {
+	if gasPrice == nil {
+		panic("gas price missing")
+	}
+	max := cfg.KeySpecificMaxGasPriceWei(etx.FromAddress)
+	if gasPrice.Cmp(max) > 0 {
+		return errors.Errorf("cannot create tx attempt: specified gas price of %s would exceed max configured gas price of %s for key %s", gasPrice.String(), max.String(), etx.FromAddress.Hex())
+	}
+	min := cfg.EvmMinGasPriceWei()
+	if gasPrice.Cmp(min) < 0 {
+		return errors.Errorf("cannot create tx attempt: specified gas price of %s is below min configured gas price of %s for key %s", gasPrice.String(), min.String(), etx.FromAddress.Hex())
+	}
+	return nil
 }
 
 func newLegacyTransaction(nonce uint64, to common.Address, value *big.Int, gasLimit uint64, gasPrice *big.Int, data []byte) gethTypes.LegacyTx {

--- a/core/services/bulletprooftxmanager/eth_broadcaster_test.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster_test.go
@@ -244,7 +244,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_OptimisticLockingOnEthTx(t *testi
 	chBlock := make(chan struct{})
 
 	estimator := new(gasmocks.Estimator)
-	estimator.On("EstimateGas", mock.Anything, mock.Anything).Return(big.NewInt(32), uint64(500), nil).Run(func(_ mock.Arguments) {
+	estimator.On("EstimateGas", mock.Anything, mock.Anything).Return(assets.GWei(32), uint64(500), nil).Run(func(_ mock.Arguments) {
 		close(chStartEstimate)
 		<-chBlock
 	})

--- a/core/services/bulletprooftxmanager/eth_confirmer.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer.go
@@ -855,7 +855,7 @@ func (ec *EthConfirmer) attemptForRebroadcast(ctx context.Context, etx EthTx) (a
 		bumpedGasPrice = ec.config.EvmGasPriceDefault()
 		bumpedGasLimit = etx.GasLimit
 	}
-	return newAttempt(ec.ethClient, ec.keystore, ec.chainID, etx, bumpedGasPrice, bumpedGasLimit)
+	return NewAttempt(ec.config, ec.ethClient, ec.keystore, ec.chainID, etx, bumpedGasPrice, bumpedGasLimit)
 }
 
 func (ec *EthConfirmer) saveInProgressAttempt(attempt *EthTxAttempt) error {
@@ -890,9 +890,9 @@ func (ec *EthConfirmer) handleInProgressAttempt(ctx context.Context, etx EthTx, 
 			"Eth node returned: '%s'. "+
 			"Bumping to %v wei and retrying. "+
 			"ACTION REQUIRED: You should consider increasing ETH_GAS_PRICE_DEFAULT", attempt.GasPrice.String(), sendError.Error(), bumpedGasPrice)
-		replacementAttempt, err := newAttempt(ec.ethClient, ec.keystore, ec.chainID, etx, bumpedGasPrice, bumpedGasLimit)
+		replacementAttempt, err := NewAttempt(ec.config, ec.ethClient, ec.keystore, ec.chainID, etx, bumpedGasPrice, bumpedGasLimit)
 		if err != nil {
-			return errors.Wrap(err, "newAttempt failed")
+			return errors.Wrap(err, "NewAttempt failed")
 		}
 
 		if err := saveReplacementInProgressAttempt(ec.db, attempt, &replacementAttempt); err != nil {
@@ -1213,7 +1213,7 @@ func (ec *EthConfirmer) ForceRebroadcast(beginningNonce uint, endingNonce uint, 
 			if overrideGasLimit != 0 {
 				etx.GasLimit = overrideGasLimit
 			}
-			attempt, err := newAttempt(ec.ethClient, ec.keystore, ec.chainID, *etx, big.NewInt(int64(gasPriceWei)), etx.GasLimit)
+			attempt, err := NewAttempt(ec.config, ec.ethClient, ec.keystore, ec.chainID, *etx, big.NewInt(int64(gasPriceWei)), etx.GasLimit)
 			if err != nil {
 				ec.logger.Errorw("ForceRebroadcast: failed to create new attempt", "ethTxID", etx.ID, "err", err)
 				continue

--- a/core/services/bulletprooftxmanager/eth_confirmer_test.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer_test.go
@@ -2173,7 +2173,7 @@ func TestEthConfirmer_ForceRebroadcast(t *testing.T) {
 	etx1 := cltest.MustInsertUnconfirmedEthTxWithBroadcastAttempt(t, db, 1, fromAddress)
 	etx2 := cltest.MustInsertUnconfirmedEthTxWithBroadcastAttempt(t, db, 2, fromAddress)
 
-	gasPriceWei := uint64(52)
+	gasPriceWei := uint64(assets.GWei(52).Int64())
 	overrideGasLimit := uint64(20000)
 
 	t.Run("rebroadcasts one eth_tx if it falls within in nonce range", func(t *testing.T) {

--- a/core/services/bulletprooftxmanager/mocks/config.go
+++ b/core/services/bulletprooftxmanager/mocks/config.go
@@ -5,6 +5,8 @@ package mocks
 import (
 	big "math/big"
 
+	common "github.com/ethereum/go-ethereum/common"
+
 	mock "github.com/stretchr/testify/mock"
 
 	time "time"
@@ -326,6 +328,22 @@ func (_m *Config) GasEstimatorMode() string {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// KeySpecificMaxGasPriceWei provides a mock function with given fields: addr
+func (_m *Config) KeySpecificMaxGasPriceWei(addr common.Address) *big.Int {
+	ret := _m.Called(addr)
+
+	var r0 *big.Int
+	if rf, ok := ret.Get(0).(func(common.Address) *big.Int); ok {
+		r0 = rf(addr)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
 	}
 
 	return r0


### PR DESCRIPTION
- Currently this can only be set by manual SQL, such as:

```sql
UPDATE evm_chains
SET cfg = jsonb_set(cfg, '{keySpecific}', coalesce(cfg->'keySpecific', '{}') || '{"0xDeadBeefDeadBeefDeadBeefDeadBeef": {"evmMaxGasPriceWei":"888000000000"}}')
WHERE id = '42'; -- chain ID
```