### PR TITLE
TestWebSocketClient_Send_Unsupported use defer instead of t.Cleanup

### DIFF
--- a/core/services/synchronization/explorer_client_test.go
+++ b/core/services/synchronization/explorer_client_test.go
@@ -107,7 +107,7 @@ func TestWebSocketClient_Send_Binary(t *testing.T) {
 
 func TestWebSocketClient_Send_Unsupported(t *testing.T) {
 	wsserver, cleanup := cltest.NewEventWebSocketServer(t)
-	t.Cleanup(cleanup)
+	defer cleanup()
 
 	explorerClient := synchronization.NewExplorerClient(wsserver.URL, "", "")
 	require.NoError(t, explorerClient.Start())


### PR DESCRIPTION
https://app.clubhouse.io/chainlinklabs/story/15897/test-flake-testwebsocketclient-send-unsupported