### PR TITLE
move asserts out of test Cleanup

### DIFF
--- a/core/cmd/eth_keys_commands_test.go
+++ b/core/cmd/eth_keys_commands_test.go
@@ -80,7 +80,8 @@ func TestEthKeysPresenter_RenderTable(t *testing.T) {
 func TestClient_ListETHKeys(t *testing.T) {
 	t.Parallel()
 
-	ethClient := newEthMock(t)
+	ethClient, assertMocksCalled := newEthMock(t)
+	defer assertMocksCalled()
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(42), nil)
 	ethClient.On("GetLINKBalance", mock.Anything, mock.Anything).Return(assets.NewLinkFromJuels(42), nil)
 	app := startNewApplication(t,
@@ -105,7 +106,8 @@ func TestClient_ListETHKeys(t *testing.T) {
 func TestClient_CreateETHKey(t *testing.T) {
 	t.Parallel()
 
-	ethClient := newEthMock(t)
+	ethClient, assertMocksCalled := newEthMock(t)
+	defer assertMocksCalled()
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(42), nil)
 	ethClient.On("GetLINKBalance", mock.Anything, mock.Anything).Return(assets.NewLinkFromJuels(42), nil)
 	app := startNewApplication(t,
@@ -137,7 +139,8 @@ func TestClient_CreateETHKey(t *testing.T) {
 func TestClient_DeleteEthKey(t *testing.T) {
 	t.Parallel()
 
-	ethClient := newEthMock(t)
+	ethClient, assertMocksCalled := newEthMock(t)
+	defer assertMocksCalled()
 	app := startNewApplication(t,
 		withKey(),
 		withMocks(ethClient),
@@ -167,7 +170,8 @@ func TestClient_ImportExportETHKey_NoChains(t *testing.T) {
 
 	t.Cleanup(func() { deleteKeyExportFile(t) })
 
-	ethClient := newEthMock(t)
+	ethClient, assertMocksCalled := newEthMock(t)
+	defer assertMocksCalled()
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(42), nil)
 	ethClient.On("GetLINKBalance", mock.Anything, mock.Anything).Return(assets.NewLinkFromJuels(42), nil)
 	app := startNewApplication(t,
@@ -255,7 +259,8 @@ func TestClient_ImportExportETHKey_WithChains(t *testing.T) {
 
 	t.Cleanup(func() { deleteKeyExportFile(t) })
 
-	ethClient := newEthMock(t)
+	ethClient, assertMocksCalled := newEthMock(t)
+	defer assertMocksCalled()
 	app := startNewApplication(t,
 		withMocks(ethClient),
 		withConfigSet(func(c *configtest.TestGeneralConfig) {

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -102,13 +102,12 @@ func withKey() func(opts *startOptions) {
 	}
 }
 
-func newEthMock(t *testing.T) *mocks.Client {
+func newEthMock(t *testing.T) (*mocks.Client, func()) {
 	t.Helper()
 
 	ethClient, _, assertMocksCalled := cltest.NewEthMocksWithStartupAssertions(t)
-	t.Cleanup(assertMocksCalled)
 
-	return ethClient
+	return ethClient, assertMocksCalled
 }
 
 func keyNameForTest(t *testing.T) string {
@@ -324,9 +323,11 @@ func TestClient_ChangePassword(t *testing.T) {
 func TestClient_SetDefaultGasPrice(t *testing.T) {
 	t.Parallel()
 
+	ethMock, assertMocksCalled := newEthMock(t)
+	defer assertMocksCalled()
 	app := startNewApplication(t,
 		withKey(),
-		withMocks(newEthMock(t)),
+		withMocks(ethMock),
 		withConfigSet(func(c *configtest.TestGeneralConfig) {
 			c.Overrides.EVMDisabled = null.BoolFrom(false)
 			c.Overrides.GlobalEvmNonceAutoSync = null.BoolFrom(false)

--- a/core/cmd/transaction_commands_test.go
+++ b/core/cmd/transaction_commands_test.go
@@ -105,9 +105,11 @@ func TestClient_IndexTxAttempts(t *testing.T) {
 func TestClient_SendEther_From_BPTXM(t *testing.T) {
 	t.Parallel()
 
+	ethMock, assertMocksCalled := newEthMock(t)
+	defer assertMocksCalled()
 	app := startNewApplication(t,
 		withKey(),
-		withMocks(newEthMock(t)),
+		withMocks(ethMock),
 		withConfigSet(func(c *configtest.TestGeneralConfig) {
 			c.Overrides.EVMDisabled = null.BoolFrom(false)
 			c.Overrides.GlobalEvmNonceAutoSync = null.BoolFrom(false)

--- a/core/web/eth_keys_controller_test.go
+++ b/core/web/eth_keys_controller_test.go
@@ -20,7 +20,7 @@ func TestETHKeysController_Index_Success(t *testing.T) {
 	t.Parallel()
 
 	ethClient, _, assertMocksCalled := cltest.NewEthMocksWithStartupAssertions(t)
-	t.Cleanup(assertMocksCalled)
+	defer assertMocksCalled()
 	cfg := cltest.NewTestGeneralConfig(t)
 	cfg.Overrides.Dev = null.BoolFrom(true)
 	cfg.Overrides.GlobalEvmNonceAutoSync = null.BoolFrom(false)
@@ -75,7 +75,7 @@ func TestETHKeysController_Index_NotDev(t *testing.T) {
 	t.Parallel()
 
 	ethClient, _, assertMocksCalled := cltest.NewEthMocksWithStartupAssertions(t)
-	t.Cleanup(assertMocksCalled)
+	defer assertMocksCalled()
 	cfg := cltest.NewTestGeneralConfig(t)
 	cfg.Overrides.Dev = null.BoolFrom(false)
 	cfg.Overrides.GlobalEvmNonceAutoSync = null.BoolFrom(false)


### PR DESCRIPTION
https://app.clubhouse.io/chainlinklabs/story/14558/potential-race-condition-in-tests-in-assertexpectations

Move asserts out of `t.Cleanup()`, which is executed after test completion, at which point it is no longer valid to fail the test. This may also untangle races blocking test completion, as in the stack trace linked on the story.