### PR TITLE
Load JobIDs for pipeline runs

### DIFF
--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/core/services/postgres"
 	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/sqlx"
 
 	"github.com/jackc/pgconn"
 	"github.com/lib/pq"
@@ -535,6 +536,42 @@ func (o *orm) FindJobIDsWithBridge(name string) ([]int32, error) {
 	return jids, nil
 }
 
+// Preload PipelineSpec.JobID for each Run
+func (o *orm) preloadJobIDs(runs []pipeline.Run) error {
+	db := postgres.UnwrapGormDB(o.db)
+
+	ids := make([]int32, 0, len(runs))
+	for _, run := range runs {
+		ids = append(ids, run.PipelineSpecID)
+	}
+
+	// construct a WHERE IN query
+	sql := `SELECT id, pipeline_spec_id FROM jobs WHERE pipeline_spec_id IN (?);`
+	query, args, err := sqlx.In(sql, ids)
+	if err != nil {
+		return err
+	}
+	query = db.Rebind(query)
+	var results []struct {
+		ID             int32
+		PipelineSpecID int32
+	}
+	if err := db.Select(&results, query, args...); err != nil {
+		return err
+	}
+
+	// fill in fields
+	for i := range runs {
+		for _, result := range results {
+			if result.PipelineSpecID == runs[i].PipelineSpecID {
+				runs[i].PipelineSpec.JobID = result.ID
+			}
+		}
+	}
+
+	return nil
+}
+
 // PipelineRunsByJobID returns all pipeline runs
 func (o *orm) PipelineRuns(offset, size int) ([]pipeline.Run, int, error) {
 	var pipelineRuns []pipeline.Run
@@ -559,6 +596,12 @@ func (o *orm) PipelineRuns(offset, size int) ([]pipeline.Run, int, error) {
 		Order("created_at DESC, id DESC").
 		Find(&pipelineRuns).
 		Error
+
+	if err != nil {
+		return pipelineRuns, int(count), err
+	}
+
+	err = o.preloadJobIDs(pipelineRuns)
 
 	return pipelineRuns, int(count), err
 }
@@ -591,6 +634,11 @@ func (o *orm) PipelineRunsByJobID(jobID int32, offset, size int) ([]pipeline.Run
 		Order("created_at DESC, id DESC").
 		Find(&pipelineRuns).
 		Error
+
+	// can skip preloadJobIDs since we already know the jobID
+	for i := range pipelineRuns {
+		pipelineRuns[i].PipelineSpec.JobID = jobID
+	}
 
 	return pipelineRuns, int(count), err
 }

--- a/core/web/pipeline_runs_controller_test.go
+++ b/core/web/pipeline_runs_controller_test.go
@@ -167,7 +167,7 @@ func TestPipelineRunsController_CreateNoBody_HappyPath(t *testing.T) {
 }
 
 func TestPipelineRunsController_Index_GlobalHappyPath(t *testing.T) {
-	client, _, runIDs, cleanup := setupPipelineRunsControllerTests(t)
+	client, jobID, runIDs, cleanup := setupPipelineRunsControllerTests(t)
 	defer cleanup()
 
 	response, cleanup := client.Get("/v2/pipeline/runs")
@@ -185,6 +185,7 @@ func TestPipelineRunsController_Index_GlobalHappyPath(t *testing.T) {
 	assert.Equal(t, parsedResponse[1].ID, strconv.Itoa(int(runIDs[0])))
 	assert.NotNil(t, parsedResponse[1].CreatedAt)
 	assert.NotNil(t, parsedResponse[1].FinishedAt)
+	assert.Equal(t, jobID, parsedResponse[1].PipelineSpec.JobID)
 	// Successful pipeline runs does not save task runs.
 	require.Len(t, parsedResponse[1].TaskRuns, 0)
 }
@@ -208,6 +209,7 @@ func TestPipelineRunsController_Index_HappyPath(t *testing.T) {
 	assert.Equal(t, parsedResponse[1].ID, strconv.Itoa(int(runIDs[0])))
 	assert.NotNil(t, parsedResponse[1].CreatedAt)
 	assert.NotNil(t, parsedResponse[1].FinishedAt)
+	assert.Equal(t, jobID, parsedResponse[1].PipelineSpec.JobID)
 	// Successful pipeline runs does not save task runs.
 	require.Len(t, parsedResponse[1].TaskRuns, 0)
 }


### PR DESCRIPTION
I went ahead with a `sqlx` based query so we avoid even more `gorm` preloads.