### PR TITLE
Test Flake: TestClient_IndexNodes

### DIFF
--- a/core/cmd/node_commands_test.go
+++ b/core/cmd/node_commands_test.go
@@ -44,6 +44,7 @@ func TestClient_IndexNodes(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Nil(t, client.IndexNodes(cltest.EmptyCLIContext()))
+	require.NotEmpty(t, r.Renders)
 	nodes := *r.Renders[0].(*cmd.NodePresenters)
 	require.Len(t, nodes, initialCount+1)
 	n := nodes[initialCount]


### PR DESCRIPTION
https://app.clubhouse.io/chainlinklabs/story/16787/test-flake-testclient-indexnodes

```
--- FAIL: TestClient_IndexNodes (0.18s)
...
panic: runtime error: index out of range [0] with length 0 [recovered]
    panic: runtime error: index out of range [0] with length 0
 ```