### PR TITLE
Tests: audit (*T).Cleanup() uses

### DIFF
--- a/core/cmd/client_test.go
+++ b/core/cmd/client_test.go
@@ -46,8 +46,7 @@ func TestTerminalCookieAuthenticator_AuthenticateWithoutSession(t *testing.T) {
 func TestTerminalCookieAuthenticator_AuthenticateWithSession(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	defer cleanup()
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	tests := []struct {
@@ -136,8 +135,7 @@ func TestTerminalAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			store, cleanup := cltest.NewStore(t)
-			defer cleanup()
+			store := cltest.NewStore(t)
 
 			mock := &cltest.MockCountingPrompter{EnteredStrings: test.enteredStrings, NotTerminal: !test.isTerminal}
 			tai := cmd.NewPromptingAPIInitializer(mock)
@@ -166,8 +164,7 @@ func TestTerminalAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 func TestTerminalAPIInitializer_InitializeWithExistingAPIUser(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	initialUser := cltest.MustRandomUser()
 	require.NoError(t, store.SaveUser(&initialUser))
@@ -195,10 +192,9 @@ func TestFileAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			store, cleanup := cltest.NewStore(t)
+			store := cltest.NewStore(t)
 			// Clear out fixture user
 			store.DeleteUser()
-			defer cleanup()
 
 			tfi := cmd.NewFileAPIInitializer(test.file)
 			user, err := tfi.Initialize(store)
@@ -218,8 +214,7 @@ func TestFileAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 func TestFileAPIInitializer_InitializeWithExistingAPIUser(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	tests := []struct {
 		name      string

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -32,8 +32,7 @@ func TestClient_RunNodeShowsEnv(t *testing.T) {
 	cfg := cltest.NewTestGeneralConfig(t)
 	debug := config.LogLevel{Level: zapcore.DebugLevel}
 	cfg.Overrides.LogLevel = &debug
-	store, cleanup := cltest.NewStoreWithConfig(t, cfg)
-	defer cleanup()
+	store := cltest.NewStoreWithConfig(t, cfg)
 	keyStore := cltest.NewKeyStore(t, store.DB)
 	_, err := keyStore.Eth().Create(&cltest.FixtureChainID)
 	require.NoError(t, err)
@@ -108,8 +107,7 @@ func TestClient_RunNodeWithPasswords(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			store, cleanup := cltest.NewStore(t)
-			defer cleanup()
+			store := cltest.NewStore(t)
 			keyStore := cltest.NewKeyStore(t, store.DB)
 			// Clear out fixture
 			err := store.DeleteUser()
@@ -154,8 +152,7 @@ func TestClient_RunNodeWithPasswords(t *testing.T) {
 func TestClient_RunNode_CreateFundingKeyIfNotExists(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 	keyStore := cltest.NewKeyStore(t, store.DB)
 	_, err := keyStore.Eth().Create(&cltest.FixtureChainID)
 	require.NoError(t, err)
@@ -213,10 +210,9 @@ func TestClient_RunNodeWithAPICredentialsFile(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := cltest.NewTestGeneralConfig(t)
 
-			store, cleanup := cltest.NewStoreWithConfig(t, cfg)
+			store := cltest.NewStoreWithConfig(t, cfg)
 			// Clear out fixture
 			store.DeleteUser()
-			defer cleanup()
 			keyStore := cltest.NewKeyStore(t, store.DB)
 			_, err := keyStore.Eth().Create(&cltest.FixtureChainID)
 			require.NoError(t, err)
@@ -292,10 +288,8 @@ func TestClient_RebroadcastTransactions_BPTXM(t *testing.T) {
 	// Use the a non-transactional db for this test because we need to
 	// test multiple connections to the database, and changes made within
 	// the transaction cannot be seen from another connection.
-	config, _, cleanup := heavyweight.FullTestORM(t, "rebroadcasttransactions", true, true)
-	defer cleanup()
-	connectedStore, connectedCleanup := cltest.NewStoreWithConfig(t, config)
-	defer connectedCleanup()
+	config, _ := heavyweight.FullTestORM(t, "rebroadcasttransactions", true, true)
+	connectedStore := cltest.NewStoreWithConfig(t, config)
 	keyStore := cltest.NewKeyStore(t, connectedStore.DB)
 	_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth(), 0)
 
@@ -322,8 +316,7 @@ func TestClient_RebroadcastTransactions_BPTXM(t *testing.T) {
 
 	config.SetDialect(dialects.PostgresWithoutLock)
 
-	store, cleanup := cltest.NewStoreWithConfig(t, config)
-	defer cleanup()
+	store := cltest.NewStoreWithConfig(t, config)
 	require.NoError(t, connectedStore.Start())
 
 	app := new(mocks.Application)
@@ -379,11 +372,9 @@ func TestClient_RebroadcastTransactions_OutsideRange_BPTXM(t *testing.T) {
 			// Use the a non-transactional db for this test because we need to
 			// test multiple connections to the database, and changes made within
 			// the transaction cannot be seen from another connection.
-			config, _, cleanup := heavyweight.FullTestORM(t, "rebroadcasttransactions_outsiderange", true, true)
-			defer cleanup()
+			config, _ := heavyweight.FullTestORM(t, "rebroadcasttransactions_outsiderange", true, true)
 			config.SetDialect(dialects.Postgres)
-			connectedStore, connectedCleanup := cltest.NewStoreWithConfig(t, config)
-			defer connectedCleanup()
+			connectedStore := cltest.NewStoreWithConfig(t, config)
 			keyStore := cltest.NewKeyStore(t, connectedStore.DB)
 
 			_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth(), 0)
@@ -405,8 +396,7 @@ func TestClient_RebroadcastTransactions_OutsideRange_BPTXM(t *testing.T) {
 			// Lock, because the db locking strategy is decided when we
 			// initialize the store/ORM.
 			config.SetDialect(dialects.PostgresWithoutLock)
-			store, cleanup := cltest.NewStoreWithConfig(t, config)
-			defer cleanup()
+			store := cltest.NewStoreWithConfig(t, config)
 			require.NoError(t, connectedStore.Start())
 
 			app := new(mocks.Application)
@@ -448,11 +438,9 @@ func TestClient_RebroadcastTransactions_OutsideRange_BPTXM(t *testing.T) {
 
 func TestClient_SetNextNonce(t *testing.T) {
 	// Need to use separate database
-	config, _, cleanup := heavyweight.FullTestORM(t, "setnextnonce", true, true)
-	defer cleanup()
+	config, _ := heavyweight.FullTestORM(t, "setnextnonce", true, true)
 	config.SetDialect(dialects.Postgres)
-	store, cleanup := cltest.NewStoreWithConfig(t, config)
-	defer cleanup()
+	store := cltest.NewStoreWithConfig(t, config)
 	ethKeyStore := cltest.NewKeyStore(t, store.DB).Eth()
 
 	client := cmd.Client{

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -69,12 +69,9 @@ func startNewApplication(t *testing.T, setup ...func(opts *startOptions)) *cltes
 		sopts.SetConfig(config)
 	}
 
-	var app *cltest.TestApplication
-	var cleanup func()
 	l := config.CreateProductionLogger().With("testname", t.Name())
 	sopts.FlagsAndDeps = append(sopts.FlagsAndDeps, l)
-	app, cleanup = cltest.NewApplicationWithConfigAndKey(t, config, sopts.FlagsAndDeps...)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationWithConfigAndKey(t, config, sopts.FlagsAndDeps...)
 	app.Logger = l
 	app.Logger.SetDB(app.GetDB())
 

--- a/core/cmd/renderer_test.go
+++ b/core/cmd/renderer_test.go
@@ -34,8 +34,7 @@ func TestRendererJSON_RenderVRFKeys(t *testing.T) {
 func TestRendererTable_RenderConfiguration(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	defer cleanup()
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
 

--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -225,7 +225,7 @@ func NewHTTPMockServer(
 	wantMethod string,
 	response string,
 	callback ...func(http.Header, string),
-) (*httptest.Server, func()) {
+) *httptest.Server {
 	called := false
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		b, err := ioutil.ReadAll(r.Body)
@@ -241,10 +241,11 @@ func NewHTTPMockServer(
 	})
 
 	server := httptest.NewServer(handler)
-	return server, func() {
+	t.Cleanup(func() {
 		server.Close()
 		assert.True(t, called, "expected call Mock HTTP endpoint '%s'", server.URL)
-	}
+	})
+	return server
 }
 
 // NewHTTPMockServerWithRequest creates http test server that makes the request
@@ -254,7 +255,7 @@ func NewHTTPMockServerWithRequest(
 	status int,
 	response string,
 	callback func(r *http.Request),
-) (*httptest.Server, func()) {
+) *httptest.Server {
 	called := false
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		callback(r)
@@ -265,10 +266,11 @@ func NewHTTPMockServerWithRequest(
 	})
 
 	server := httptest.NewServer(handler)
-	return server, func() {
+	t.Cleanup(func() {
 		server.Close()
 		assert.True(t, called, "expected call Mock HTTP endpoint '%s'", server.URL)
-	}
+	})
+	return server
 }
 
 func NewHTTPMockServerWithAlterableResponse(

--- a/core/internal/cltest/simulated_backend.go
+++ b/core/internal/cltest/simulated_backend.go
@@ -61,7 +61,7 @@ func NewApplicationWithConfigAndKeyOnSimulatedBlockchain(
 	cfg *configtest.TestGeneralConfig,
 	backend *backends.SimulatedBackend,
 	flagsAndDeps ...interface{},
-) (app *TestApplication, cleanup func()) {
+) *TestApplication {
 	chainId := backend.Blockchain().Config().ChainID
 	cfg.Overrides.DefaultChainID = chainId
 
@@ -88,10 +88,8 @@ func NewApplicationWithConfigAndKeyOnSimulatedBlockchain(
 
 	flagsAndDeps = append(flagsAndDeps, client, eventBroadcaster, simulatedBackendChain)
 
-	app, appCleanup := NewApplicationWithConfigAndKey(t, cfg, flagsAndDeps...)
-
-	// appCleanup calls app.Stop() which will client.Close on the simulated backend
-	return app, appCleanup
+	//  app.Stop() will call client.Close on the simulated backend
+	return NewApplicationWithConfigAndKey(t, cfg, flagsAndDeps...)
 }
 
 func MustNewSimulatedBackendKeyedTransactor(t *testing.T, key *ecdsa.PrivateKey) *bind.TransactOpts {

--- a/core/services/bulletprooftxmanager/eth_broadcaster_test.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster_test.go
@@ -42,8 +42,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Success(t *testing.T) {
 	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 
-	eb, cleanup := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
-	defer cleanup()
+	eb := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
 
 	toAddress := gethCommon.HexToAddress("0x6C03DDA95a2AEd917EeCc6eddD4b9D16E6380411")
 	timeNow := time.Now()
@@ -231,8 +230,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Success(t *testing.T) {
 
 func TestEthBroadcaster_ProcessUnstartedEthTxs_OptimisticLockingOnEthTx(t *testing.T) {
 	// non-transactional DB needed because we deliberately test for FK violation
-	cfg, orm, cleanupDB := heavyweight.FullTestORM(t, "eth_broadcaster_optimistic_locking", true, true)
-	t.Cleanup(cleanupDB)
+	cfg, orm := heavyweight.FullTestORM(t, "eth_broadcaster_optimistic_locking", true, true)
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 	db := orm.DB
 	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
@@ -301,8 +299,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Success_WithMultiplier(t *testing
 
 	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
-	eb, cleanup := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
-	defer cleanup()
+	eb := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
 
 	ethClient.On("SendTransaction", mock.Anything, mock.MatchedBy(func(tx *gethTypes.Transaction) bool {
 		assert.Equal(t, int(1600), int(tx.Gas()))
@@ -343,8 +340,7 @@ func TestEthBroadcaster_AssignsNonceOnStart(t *testing.T) {
 	t.Run("when eth node returns error", func(t *testing.T) {
 		ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
-		eb, cleanup := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, keyStates)
-		defer cleanup()
+		eb := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, keyStates)
 
 		ethClient.On("PendingNonceAt", mock.Anything, mock.MatchedBy(func(account gethCommon.Address) bool {
 			return account.Hex() == dummyAddress.Hex()
@@ -375,8 +371,7 @@ func TestEthBroadcaster_AssignsNonceOnStart(t *testing.T) {
 	t.Run("when eth node returns nonce", func(t *testing.T) {
 		ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
-		eb, cleanup := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, keyStates)
-		defer cleanup()
+		eb := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, keyStates)
 
 		ethClient.On("PendingNonceAt", mock.Anything, mock.MatchedBy(func(account gethCommon.Address) bool {
 			return account.Hex() == dummyAddress.Hex()
@@ -461,8 +456,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 		ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
-		eb, cleanup := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
-		defer cleanup()
+		eb := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
 
 		// Crashed right after we commit the database transaction that saved
 		// the nonce to the eth_tx so eth_key_states.next_nonce has not been
@@ -496,8 +490,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 		ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
-		eb, cleanup := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
-		defer cleanup()
+		eb := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
 
 		// Crashed right after we commit the database transaction that saved
 		// the nonce to the eth_tx so keys.next_nonce has not been
@@ -531,8 +524,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 		ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
-		eb, cleanup := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
-		defer cleanup()
+		eb := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
 
 		// Crashed right after we commit the database transaction that saved
 		// the nonce to the eth_tx so keys.next_nonce has not been
@@ -565,8 +557,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 		ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
-		eb, cleanup := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
-		defer cleanup()
+		eb := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
 
 		// Crashed right after we commit the database transaction that saved
 		// the nonce to the eth_tx so keys.next_nonce has not been
@@ -600,8 +591,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 		ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
-		eb, cleanup := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
-		defer cleanup()
+		eb := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
 
 		// Crashed right after we commit the database transaction that saved
 		// the nonce to the eth_tx so keys.next_nonce has not been
@@ -641,8 +631,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 
 		ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
-		eb, cleanup := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
-		defer cleanup()
+		eb := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
 
 		// Crashed right after we commit the database transaction that saved
 		// the nonce to the eth_tx so keys.next_nonce has not been
@@ -703,8 +692,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
-	eb, cleanup := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
-	defer cleanup()
+	eb := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState})
 
 	t.Run("if external wallet sent a transaction from the account and now the nonce is one higher than it should be and we got replacement underpriced then we assume a previous transaction of ours was the one that succeeded, and hand off to EthConfirmer", func(t *testing.T) {
 		etx := bulletprooftxmanager.EthTx{
@@ -1098,8 +1086,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_KeystoreErrors(t *testing.T) {
 	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
 	kst := new(ksmocks.Eth)
-	eb, cleanup := cltest.NewEthBroadcaster(t, db, ethClient, kst, evmcfg, []ethkey.State{keyState})
-	defer cleanup()
+	eb := cltest.NewEthBroadcaster(t, db, ethClient, kst, evmcfg, []ethkey.State{keyState})
 
 	t.Run("tx signing fails", func(t *testing.T) {
 		etx := bulletprooftxmanager.EthTx{
@@ -1182,8 +1169,7 @@ func TestEthBroadcaster_Trigger(t *testing.T) {
 	cfg := cltest.NewTestGeneralConfig(t)
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
-	eb, cleanup := cltest.NewEthBroadcaster(t, db, cltest.NewEthClientMockWithDefaultChain(t), ethKeyStore, evmcfg, []ethkey.State{})
-	defer cleanup()
+	eb := cltest.NewEthBroadcaster(t, db, cltest.NewEthClientMockWithDefaultChain(t), ethKeyStore, evmcfg, []ethkey.State{})
 
 	eb.Trigger(cltest.NewAddress())
 	eb.Trigger(cltest.NewAddress())
@@ -1192,16 +1178,15 @@ func TestEthBroadcaster_Trigger(t *testing.T) {
 
 func TestEthBroadcaster_EthTxInsertEventCausesTriggerToFire(t *testing.T) {
 	// NOTE: Testing triggers requires committing transactions and does not work with transactional tests
-	cfg, orm, cleanup := heavyweight.FullTestORM(t, "eth_tx_triggers", true, true)
-	defer cleanup()
+	cfg, orm := heavyweight.FullTestORM(t, "eth_tx_triggers", true, true)
 	db := orm.DB
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 	_, fromAddress := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
 	eventBroadcaster := postgres.NewEventBroadcaster(evmcfg.DatabaseURL(), 0, 0)
-	eventBroadcaster.Start()
-	defer eventBroadcaster.Close()
+	require.NoError(t, eventBroadcaster.Start())
+	t.Cleanup(func() { require.NoError(t, eventBroadcaster.Close()) })
 
 	ethTxInsertListener, err := eventBroadcaster.Subscribe(postgres.ChannelInsertOnEthTx, "")
 	require.NoError(t, err)

--- a/core/services/chainlink/application_test.go
+++ b/core/services/chainlink/application_test.go
@@ -7,19 +7,16 @@ import (
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/stretchr/testify/require"
 
 	"github.com/onsi/gomega"
-	"github.com/stretchr/testify/require"
 	"github.com/tevino/abool"
 )
 
 func TestChainlinkApplication_SignalShutdown(t *testing.T) {
 	ethClient, _, assertMocksCalled := cltest.NewEthMocksWithStartupAssertions(t)
 	defer assertMocksCalled()
-	app, cleanup := cltest.NewApplication(t,
-		ethClient,
-	)
-	defer cleanup()
+	app := cltest.NewApplication(t, ethClient)
 	completed := abool.New()
 	app.Exiter = func(code int) {
 		completed.Set()

--- a/core/services/cron/cron_test.go
+++ b/core/services/cron/cron_test.go
@@ -27,8 +27,7 @@ func TestCronV2Pipeline(t *testing.T) {
 	db := pgtest.NewGormDB(t)
 	keyStore := cltest.NewKeyStore(t, db)
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: cfg, Client: cltest.NewEthClientMockWithDefaultChain(t)})
-	orm, eventBroadcaster, cleanupPipeline := cltest.NewPipelineORM(t, cfg, db)
-	t.Cleanup(cleanupPipeline)
+	orm, eventBroadcaster := cltest.NewPipelineORM(t, cfg, db)
 	jobORM := job.NewORM(db, cc, orm, eventBroadcaster, keyStore)
 
 	spec := &job.Job{

--- a/core/services/eth/models_test.go
+++ b/core/services/eth/models_test.go
@@ -86,8 +86,7 @@ func TestEthTx_GetID(t *testing.T) {
 }
 
 func TestEthTxAttempt_GetSignedTx(t *testing.T) {
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 	ethKeyStore := cltest.NewKeyStore(t, store.DB).Eth()
 	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
 	tx := gethTypes.NewTransaction(uint64(42), cltest.NewAddress(), big.NewInt(142), 242, big.NewInt(342), []byte{1, 2, 3})

--- a/core/services/fluxmonitorv2/flux_monitor_test.go
+++ b/core/services/fluxmonitorv2/flux_monitor_test.go
@@ -284,11 +284,9 @@ func withORM(orm fluxmonitorv2.ORM) func(*setupOptions) {
 
 // setupStoreWithKey setups a new store and adds a key to the keystore
 func setupStoreWithKey(t *testing.T) (*store.Store, common.Address) {
-	store, cleanup := cltest.NewStore(t)
+	store := cltest.NewStore(t)
 	ethKeyStore := cltest.NewKeyStore(t, store.DB).Eth()
 	_, nodeAddr := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
-
-	t.Cleanup(cleanup)
 
 	return store, nodeAddr
 }

--- a/core/services/fluxmonitorv2/integrations_test.go
+++ b/core/services/fluxmonitorv2/integrations_test.go
@@ -201,7 +201,7 @@ func (fau fluxAggregatorUniverse) WatchSubmissionReceived(t *testing.T, addresse
 	return submissionReceived
 }
 
-func setupApplication(
+func startApplication(
 	t *testing.T,
 	fa fluxAggregatorUniverse,
 	setConfig func(cfg *configtest.TestGeneralConfig),
@@ -209,9 +209,8 @@ func setupApplication(
 	config := cltest.NewTestGeneralConfig(t)
 	setConfig(config)
 
-	app, cleanup := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, fa.backend, fa.key)
-	t.Cleanup(cleanup)
-
+	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, fa.backend, fa.key)
+	require.NoError(t, app.Start())
 	return app
 }
 
@@ -424,11 +423,10 @@ func TestFluxMonitor_Deviation(t *testing.T) {
 	checkOraclesAdded(t, fa, oracleList)
 
 	// Set up chainlink app
-	app := setupApplication(t, fa, func(cfg *configtest.TestGeneralConfig) {
+	app := startApplication(t, fa, func(cfg *configtest.TestGeneralConfig) {
 		cfg.Overrides.SetDefaultHTTPTimeout(100 * time.Millisecond)
 		cfg.Overrides.SetTriggerFallbackDBPollInterval(1 * time.Second)
 	})
-	require.NoError(t, app.Start())
 
 	type k struct{ latestAnswer, updatedAt string }
 	expectedMeta := map[k]int{}
@@ -586,12 +584,11 @@ func TestFluxMonitor_NewRound(t *testing.T) {
 	checkOraclesAdded(t, fa, oracleList)
 
 	// Set up chainlink app
-	app := setupApplication(t, fa, func(cfg *configtest.TestGeneralConfig) {
+	app := startApplication(t, fa, func(cfg *configtest.TestGeneralConfig) {
 		cfg.Overrides.SetDefaultHTTPTimeout(100 * time.Millisecond)
 		cfg.Overrides.SetTriggerFallbackDBPollInterval(1 * time.Second)
 		cfg.Overrides.GlobalFlagsContractAddress = null.StringFrom(fa.flagsContractAddress.Hex())
 	})
-	require.NoError(t, app.Start())
 
 	initialBalance := currentBalance(t, &fa).Int64()
 
@@ -692,13 +689,12 @@ func TestFluxMonitor_HibernationMode(t *testing.T) {
 	fa.backend.Commit()
 	checkOraclesAdded(t, fa, oracleList)
 
-	// Set up chainlink app
-	app := setupApplication(t, fa, func(cfg *configtest.TestGeneralConfig) {
+	// Start chainlink app
+	app := startApplication(t, fa, func(cfg *configtest.TestGeneralConfig) {
 		cfg.Overrides.SetDefaultHTTPTimeout(100 * time.Millisecond)
 		cfg.Overrides.SetTriggerFallbackDBPollInterval(1 * time.Second)
 		cfg.Overrides.GlobalFlagsContractAddress = null.StringFrom(fa.flagsContractAddress.Hex())
 	})
-	require.NoError(t, app.Start())
 
 	// Create mock server
 	reportPrice := atomic.NewInt64(1)
@@ -801,13 +797,12 @@ func TestFluxMonitor_InvalidSubmission(t *testing.T) {
 	fa.backend.Commit()
 
 	// Set up chainlink app
-	app := setupApplication(t, fa, func(cfg *configtest.TestGeneralConfig) {
+	app := startApplication(t, fa, func(cfg *configtest.TestGeneralConfig) {
 		cfg.Overrides.SetDefaultHTTPTimeout(100 * time.Millisecond)
 		cfg.Overrides.SetTriggerFallbackDBPollInterval(1 * time.Second)
 		cfg.Overrides.GlobalMinRequiredOutgoingConfirmations = null.IntFrom(2)
 		cfg.Overrides.GlobalEvmHeadTrackerMaxBufferSize = null.IntFrom(100)
 	})
-	require.NoError(t, app.Start())
 
 	// Report a price that is above the maximum allowed value,
 	// causing it to revert.
@@ -877,11 +872,10 @@ func TestFluxMonitorAntiSpamLogic(t *testing.T) {
 	checkOraclesAdded(t, fa, oracleList)
 
 	// Set up chainlink app
-	app := setupApplication(t, fa, func(cfg *configtest.TestGeneralConfig) {
+	app := startApplication(t, fa, func(cfg *configtest.TestGeneralConfig) {
 		cfg.Overrides.SetDefaultHTTPTimeout(100 * time.Millisecond)
 		cfg.Overrides.SetTriggerFallbackDBPollInterval(1 * time.Second)
 	})
-	require.NoError(t, app.Start())
 
 	answer := int64(1) // Answer the nodes give on the first round
 

--- a/core/services/fluxmonitorv2/orm_test.go
+++ b/core/services/fluxmonitorv2/orm_test.go
@@ -23,8 +23,7 @@ import (
 func TestORM_MostRecentFluxMonitorRoundID(t *testing.T) {
 	t.Parallel()
 
-	corestore, cleanup := cltest.NewStore(t)
-	t.Cleanup(cleanup)
+	corestore := cltest.NewStore(t)
 
 	orm := fluxmonitorv2.NewORM(corestore.DB, nil, nil)
 
@@ -80,8 +79,7 @@ func TestORM_UpdateFluxMonitorRoundStats(t *testing.T) {
 	t.Parallel()
 
 	cfg := cltest.NewTestGeneralConfig(t)
-	corestore, cleanup := cltest.NewStore(t, cfg)
-	t.Cleanup(cleanup)
+	corestore := cltest.NewStore(t, cfg)
 
 	keyStore := cltest.NewKeyStore(t, corestore.DB)
 
@@ -167,8 +165,7 @@ func makeJob(t *testing.T) *job.Job {
 func TestORM_CreateEthTransaction(t *testing.T) {
 	t.Parallel()
 
-	corestore, cleanup := cltest.NewStore(t)
-	t.Cleanup(cleanup)
+	corestore := cltest.NewStore(t)
 	ethKeyStore := cltest.NewKeyStore(t, corestore.DB).Eth()
 
 	strategy := new(bptxmmocks.TxStrategy)

--- a/core/services/headtracker/head_broadcaster_test.go
+++ b/core/services/headtracker/head_broadcaster_test.go
@@ -20,8 +20,7 @@ func TestHeadBroadcaster_Subscribe(t *testing.T) {
 
 	cfg := cltest.NewTestGeneralConfig(t)
 	evmCfg := evmtest.NewChainScopedConfig(t, cfg)
-	store, cleanup := cltest.NewStoreWithConfig(t, cfg)
-	defer cleanup()
+	store := cltest.NewStoreWithConfig(t, cfg)
 	logger := store.Config.CreateProductionLogger()
 
 	sub := new(mocks.Subscription)

--- a/core/services/headtracker/head_tracker_test.go
+++ b/core/services/headtracker/head_tracker_test.go
@@ -336,8 +336,7 @@ func TestHeadTracker_Start_LoadsLatestChain(t *testing.T) {
 func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingEnabled(t *testing.T) {
 	// Need separate db because ht.Stop() will cancel the ctx, causing a db connection
 	// close and go-txdb rollback.
-	config, _, cleanupDB := heavyweight.FullTestORM(t, "switches_longest_chain", true, true)
-	t.Cleanup(cleanupDB)
+	config, _ := heavyweight.FullTestORM(t, "switches_longest_chain", true, true)
 	config.Overrides.GlobalEvmFinalityDepth = null.IntFrom(50)
 	// Need to set the buffer to something large since we inject a lot of heads at once and otherwise they will be dropped
 	config.Overrides.GlobalEvmHeadTrackerMaxBufferSize = null.IntFrom(42)
@@ -346,8 +345,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingEnabled(t *testing.T)
 	d := 1500 * time.Millisecond
 	config.Overrides.GlobalEvmHeadTrackerSamplingInterval = &d
 
-	store, cleanup := cltest.NewStoreWithConfig(t, config)
-	t.Cleanup(cleanup)
+	store := cltest.NewStoreWithConfig(t, config)
 
 	ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
 
@@ -462,8 +460,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingEnabled(t *testing.T)
 func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled(t *testing.T) {
 	// Need separate db because ht.Stop() will cancel the ctx, causing a db connection
 	// close and go-txdb rollback.
-	config, _, cleanupDB := heavyweight.FullTestORM(t, "switches_longest_chain", true, true)
-	t.Cleanup(cleanupDB)
+	config, _ := heavyweight.FullTestORM(t, "switches_longest_chain", true, true)
 
 	config.Overrides.GlobalEvmFinalityDepth = null.IntFrom(50)
 	// Need to set the buffer to something large since we inject a lot of heads at once and otherwise they will be dropped
@@ -471,8 +468,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled(t *testing.T
 	d := 0 * time.Second
 	config.Overrides.GlobalEvmHeadTrackerSamplingInterval = &d
 
-	store, cleanup := cltest.NewStoreWithConfig(t, config)
-	t.Cleanup(cleanup)
+	store := cltest.NewStoreWithConfig(t, config)
 
 	ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
 

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -29,8 +29,7 @@ import (
 
 func TestORM(t *testing.T) {
 	t.Parallel()
-	config, oldORM, cleanupDB := heavyweight.FullTestORM(t, "services_job_orm", true, true)
-	defer cleanupDB()
+	config, oldORM := heavyweight.FullTestORM(t, "services_job_orm", true, true)
 	db := oldORM.DB
 	keyStore := cltest.NewKeyStore(t, db)
 	ethKeyStore := keyStore.Eth()
@@ -38,8 +37,7 @@ func TestORM(t *testing.T) {
 	keyStore.OCR().Add(cltest.DefaultOCRKey)
 	keyStore.P2P().Add(cltest.DefaultP2PKey)
 
-	pipelineORM, eventBroadcaster, cleanupORM := cltest.NewPipelineORM(t, config, db)
-	defer cleanupORM()
+	pipelineORM, eventBroadcaster := cltest.NewPipelineORM(t, config, db)
 
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: config})
 	orm := job.NewORM(db, cc, pipelineORM, eventBroadcaster, keyStore)
@@ -187,8 +185,7 @@ func TestORM_CheckForDeletedJobs(t *testing.T) {
 	_, bridge2 := cltest.NewBridgeType(t, "election_winner", "http://blah.com")
 	require.NoError(t, db.Create(bridge2).Error)
 
-	pipelineORM, eventBroadcaster, cleanupORM := cltest.NewPipelineORM(t, config, db)
-	defer cleanupORM()
+	pipelineORM, eventBroadcaster := cltest.NewPipelineORM(t, config, db)
 
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: config})
 	orm := job.NewORM(db, cc, pipelineORM, eventBroadcaster, keyStore)
@@ -221,8 +218,7 @@ func TestORM_DeleteJob_DeletesAssociatedRecords(t *testing.T) {
 	keyStore.OCR().Add(cltest.DefaultOCRKey)
 	keyStore.P2P().Add(cltest.DefaultP2PKey)
 
-	pipelineORM, eventBroadcaster, cleanupORM := cltest.NewPipelineORM(t, config, db)
-	defer cleanupORM()
+	pipelineORM, eventBroadcaster := cltest.NewPipelineORM(t, config, db)
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: config})
 	orm := job.NewORM(db, cc, pipelineORM, eventBroadcaster, keyStore)
 	defer orm.Close()

--- a/core/services/job/job_pipeline_orm_integration_test.go
+++ b/core/services/job/job_pipeline_orm_integration_test.go
@@ -42,10 +42,9 @@ func TestPipelineORM_Integration(t *testing.T) {
         answer2 [type=bridge name=election_winner index=1];
     `
 
-	config, oldORM, cleanupDB := heavyweight.FullTestORM(t, "pipeline_orm", true, true)
+	config, oldORM := heavyweight.FullTestORM(t, "pipeline_orm", true, true)
 	config.Overrides.SetDefaultHTTPTimeout(30 * time.Millisecond)
 	config.Overrides.DefaultMaxHTTPAttempts = null.IntFrom(1)
-	defer cleanupDB()
 	db := oldORM.DB
 	keyStore := cltest.NewKeyStore(t, db)
 	ethKeyStore := keyStore.Eth()
@@ -99,8 +98,7 @@ func TestPipelineORM_Integration(t *testing.T) {
 
 	t.Run("creates task DAGs", func(t *testing.T) {
 		clearJobsDb(t, db)
-		orm, _, cleanup := cltest.NewPipelineORM(t, config, db)
-		defer cleanup()
+		orm, _ := cltest.NewPipelineORM(t, config, db)
 
 		p, err := pipeline.Parse(DotStr)
 		require.NoError(t, err)
@@ -120,8 +118,7 @@ func TestPipelineORM_Integration(t *testing.T) {
 
 	t.Run("creates runs", func(t *testing.T) {
 		clearJobsDb(t, db)
-		orm, eventBroadcaster, cleanup := cltest.NewPipelineORM(t, config, db)
-		defer cleanup()
+		orm, eventBroadcaster := cltest.NewPipelineORM(t, config, db)
 		cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{Client: cltest.NewEthClientMockWithDefaultChain(t), DB: db, GeneralConfig: config})
 		runner := pipeline.NewRunner(orm, config, cc, nil, nil)
 		defer runner.Close()

--- a/core/services/job/spawner_test.go
+++ b/core/services/job/spawner_test.go
@@ -48,8 +48,7 @@ func clearDB(t *testing.T, db *gorm.DB) {
 }
 
 func TestSpawner_CreateJobDeleteJob(t *testing.T) {
-	config, oldORM, cleanupDB := heavyweight.FullTestORM(t, "services_job_spawner", true, true)
-	defer cleanupDB()
+	config, oldORM := heavyweight.FullTestORM(t, "services_job_spawner", true, true)
 	db := oldORM.DB
 	keyStore := cltest.NewKeyStore(t, db)
 	ethKeyStore := keyStore.Eth()
@@ -57,8 +56,8 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 	keyStore.P2P().Add(cltest.DefaultP2PKey)
 
 	eventBroadcaster := postgres.NewEventBroadcaster(config.DatabaseURL(), 0, 0)
-	eventBroadcaster.Start()
-	defer eventBroadcaster.Close()
+	require.NoError(t, eventBroadcaster.Start())
+	t.Cleanup(func() { require.NoError(t, eventBroadcaster.Close()) })
 
 	_, address := cltest.MustInsertRandomKey(t, ethKeyStore)
 	_, bridge := cltest.NewBridgeType(t, "voter_turnout", "http://blah.com")

--- a/core/services/keeper/integration_test.go
+++ b/core/services/keeper/integration_test.go
@@ -87,8 +87,7 @@ func TestKeeperEthIntegration(t *testing.T) {
 	backend.Commit()
 
 	// setup app
-	config, _, cfgCleanup := heavyweight.FullTestORM(t, "keeper_eth_integration", true, true)
-	defer cfgCleanup()
+	config, _ := heavyweight.FullTestORM(t, "keeper_eth_integration", true, true)
 	d := 24 * time.Hour
 	// disable full sync ticker for test
 	config.Overrides.KeeperRegistrySyncInterval = &d
@@ -100,8 +99,7 @@ func TestKeeperEthIntegration(t *testing.T) {
 	config.Overrides.KeeperMaximumGracePeriod = null.IntFrom(0)
 	// helps prevent missed heads
 	config.Overrides.GlobalEvmHeadTrackerMaxBufferSize = null.IntFrom(100)
-	app, appCleanup := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, backend, nodeKey)
-	defer appCleanup()
+	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, backend, nodeKey)
 	require.NoError(t, app.Start())
 
 	// create job

--- a/core/services/offchainreporting/contract_tracker_test.go
+++ b/core/services/offchainreporting/contract_tracker_test.go
@@ -74,8 +74,7 @@ func newContractTrackerUni(t *testing.T, opts ...interface{}) (uni contractTrack
 	uni.hb = new(htmocks.HeadBroadcaster)
 	uni.ec = cltest.NewEthClientMock(t)
 
-	s, c := cltest.NewStore(t)
-	t.Cleanup(c)
+	s := cltest.NewStore(t)
 	uni.tracker = offchainreporting.NewOCRContractTracker(
 		contract,
 		filterer,

--- a/core/services/offchainreporting/discoverer_database_test.go
+++ b/core/services/offchainreporting/discoverer_database_test.go
@@ -10,8 +10,7 @@ import (
 )
 
 func Test_DiscovererDatabase(t *testing.T) {
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	db := store.DB
 	require.NoError(t, db.Exec(`SET CONSTRAINTS offchainreporting_discoverer_announcements_local_peer_id_fkey DEFERRED`).Error)

--- a/core/services/offchainreporting/peerstore_test.go
+++ b/core/services/offchainreporting/peerstore_test.go
@@ -14,8 +14,7 @@ import (
 )
 
 func Test_Peerstore_Start(t *testing.T) {
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	// Deferring the constraint avoids having to insert an entire set of jobs/specs
 	require.NoError(t, store.DB.Exec(`SET CONSTRAINTS p2p_peers_peer_id_fkey DEFERRED`).Error)
@@ -61,8 +60,7 @@ func Test_Peerstore_Start(t *testing.T) {
 }
 
 func Test_Peerstore_WriteToDB(t *testing.T) {
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	// Deferring the constraint avoids having to insert an entire set of jobs/specs
 	require.NoError(t, store.DB.Exec(`SET CONSTRAINTS p2p_peers_peer_id_fkey DEFERRED`).Error)

--- a/core/services/offchainreporting/transmitter_test.go
+++ b/core/services/offchainreporting/transmitter_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func Test_Transmitter_CreateEthTransaction(t *testing.T) {
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 	ethKeyStore := cltest.NewKeyStore(t, store.DB).Eth()
 
 	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)

--- a/core/services/postgres/event_broadcaster_test.go
+++ b/core/services/postgres/event_broadcaster_test.go
@@ -13,12 +13,11 @@ import (
 )
 
 func TestEventBroadcaster(t *testing.T) {
-	config, _, cleanupDB := heavyweight.FullTestORM(t, "event_broadcaster", true, false)
-	defer cleanupDB()
+	config, _ := heavyweight.FullTestORM(t, "event_broadcaster", true, false)
 
 	eventBroadcaster := postgres.NewEventBroadcaster(config.DatabaseURL(), 0, 0)
-	eventBroadcaster.Start()
-	defer eventBroadcaster.Close()
+	require.NoError(t, eventBroadcaster.Start())
+	t.Cleanup(func() { require.NoError(t, eventBroadcaster.Close()) })
 
 	t.Run("doesn't broadcast unrelated events (no payload filter)", func(t *testing.T) {
 		sub, err := eventBroadcaster.Subscribe("foo", "")

--- a/core/services/validators_test.go
+++ b/core/services/validators_test.go
@@ -15,8 +15,7 @@ import (
 func TestValidateBridgeType(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	tests := []struct {
 		description string
@@ -108,8 +107,7 @@ func TestValidateBridgeType(t *testing.T) {
 func TestValidateBridgeNotExist(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	// Create a duplicate
 	bt := models.BridgeType{}
@@ -128,8 +126,7 @@ func TestValidateBridgeNotExist(t *testing.T) {
 func TestValidateExternalInitiator(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	url := cltest.WebURL(t, "https://a.web.url")
 

--- a/core/services/vrf/integration_test.go
+++ b/core/services/vrf/integration_test.go
@@ -26,12 +26,10 @@ import (
 )
 
 func TestIntegration_VRF_JPV2(t *testing.T) {
-	config, _, cleanupDB := heavyweight.FullTestORM(t, "vrf_jpv2", true, true)
-	defer cleanupDB()
+	config, _ := heavyweight.FullTestORM(t, "vrf_jpv2", true, true)
 	key := cltest.MustGenerateRandomKey(t)
 	cu := newVRFCoordinatorUniverse(t, key)
-	app, cleanup := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, cu.backend, key)
-	defer cleanup()
+	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, cu.backend, key)
 	require.NoError(t, app.Start())
 
 	vrfkey, err := app.KeyStore.VRF().Create()

--- a/core/services/vrf/integration_v2_test.go
+++ b/core/services/vrf/integration_v2_test.go
@@ -156,16 +156,14 @@ func newVRFCoordinatorV2Universe(t *testing.T, key ethkey.KeyV2) coordinatorV2Un
 }
 
 func TestIntegrationVRFV2(t *testing.T) {
-	config, _, cleanupDB := heavyweight.FullTestORM(t, "vrf_v2_integration", true, true)
-	defer cleanupDB()
+	config, _ := heavyweight.FullTestORM(t, "vrf_v2_integration", true, true)
 	key := cltest.MustGenerateRandomKey(t)
 	uni := newVRFCoordinatorV2Universe(t, key)
 	config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(2000000)
 
 	gasPrice := decimal.NewFromBigInt(evmconfig.DefaultGasPrice, 0)
 
-	app, cleanup := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, uni.backend, key)
-	defer cleanup()
+	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, uni.backend, key)
 	require.NoError(t, app.Start())
 
 	vrfkey, err := app.GetKeyStore().VRF().Create()
@@ -335,14 +333,12 @@ func TestIntegrationVRFV2(t *testing.T) {
 }
 
 func TestMaliciousConsumer(t *testing.T) {
-	config, _, cleanupDB := heavyweight.FullTestORM(t, "vrf_v2_integration_malicious", true, true)
-	defer cleanupDB()
+	config, _ := heavyweight.FullTestORM(t, "vrf_v2_integration_malicious", true, true)
 	key := cltest.MustGenerateRandomKey(t)
 	uni := newVRFCoordinatorV2Universe(t, key)
 	config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(2000000)
 
-	app, cleanup := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, uni.backend, key)
-	defer cleanup()
+	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, uni.backend, key)
 	require.NoError(t, app.Start())
 
 	err := app.GetKeyStore().Unlock(cltest.Password)
@@ -433,8 +429,7 @@ func TestRequestCost(t *testing.T) {
 	uni := newVRFCoordinatorV2Universe(t, key)
 
 	cfg := cltest.NewTestGeneralConfig(t)
-	app, cleanup := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, cfg, uni.backend, key)
-	defer cleanup()
+	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, cfg, uni.backend, key)
 	require.NoError(t, app.Start())
 
 	vrfkey, err := app.GetKeyStore().VRF().Create()
@@ -474,8 +469,7 @@ func TestMaxConsumersCost(t *testing.T) {
 	uni := newVRFCoordinatorV2Universe(t, key)
 
 	cfg := cltest.NewTestGeneralConfig(t)
-	app, cleanup := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, cfg, uni.backend, key)
-	defer cleanup()
+	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, cfg, uni.backend, key)
 	require.NoError(t, app.Start())
 	_, err := uni.consumerContract.TestCreateSubscriptionAndFund(uni.carol,
 		big.NewInt(1000000000000000000)) // 0.1 LINK
@@ -507,8 +501,7 @@ func TestFulfillmentCost(t *testing.T) {
 	uni := newVRFCoordinatorV2Universe(t, key)
 
 	cfg := cltest.NewTestGeneralConfig(t)
-	app, cleanup := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, cfg, uni.backend, key)
-	defer cleanup()
+	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, cfg, uni.backend, key)
 	require.NoError(t, app.Start())
 
 	vrfkey, err := app.GetKeyStore().VRF().Create()

--- a/core/services/vrf/proof/proof_response_test.go
+++ b/core/services/vrf/proof/proof_response_test.go
@@ -19,8 +19,7 @@ import (
 )
 
 func TestMarshaledProof(t *testing.T) {
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 	keyStore := cltest.NewKeyStore(t, store.DB)
 	key := cltest.DefaultVRFKey
 	keyStore.VRF().Add(key)

--- a/core/store/orm/locking_strategies_test.go
+++ b/core/store/orm/locking_strategies_test.go
@@ -104,8 +104,7 @@ func TestPostgresLockingStrategy_WhenLostIsReacquired(t *testing.T) {
 	d := 500 * time.Millisecond
 	tc.Overrides.DatabaseTimeout = &d
 
-	store, cleanup := cltest.NewStoreWithConfig(t, tc)
-	defer cleanup()
+	store := cltest.NewStoreWithConfig(t, tc)
 
 	delay := store.Config.DatabaseTimeout()
 
@@ -138,8 +137,7 @@ func TestPostgresLockingStrategy_CanBeReacquiredByNewNodeAfterDisconnect(t *test
 	tc := cltest.NewTestGeneralConfig(t)
 	d := 500 * time.Millisecond
 	tc.Overrides.DatabaseTimeout = &d
-	store, cleanup := cltest.NewStoreWithConfig(t, tc)
-	defer cleanup()
+	store := cltest.NewStoreWithConfig(t, tc)
 
 	// NewStore no longer takes a lock on opening, so do something that does...
 	err := store.ORM.RawDBWithAdvisoryLock(func(db *gorm.DB) error {
@@ -170,8 +168,7 @@ func TestPostgresLockingStrategy_WhenReacquiredOriginalNodeErrors(t *testing.T) 
 	tc := cltest.NewTestGeneralConfig(t)
 	d := 500 * time.Millisecond
 	tc.Overrides.DatabaseTimeout = &d
-	store, cleanup := cltest.NewStoreWithConfig(t, tc)
-	defer cleanup()
+	store := cltest.NewStoreWithConfig(t, tc)
 
 	delay := store.Config.DatabaseTimeout()
 

--- a/core/store/orm/orm_test.go
+++ b/core/store/orm/orm_test.go
@@ -18,8 +18,7 @@ import (
 )
 
 func TestORM_CreateExternalInitiator(t *testing.T) {
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	token := auth.NewToken()
 	req := models.ExternalInitiatorRequest{
@@ -35,8 +34,7 @@ func TestORM_CreateExternalInitiator(t *testing.T) {
 }
 
 func TestORM_DeleteExternalInitiator(t *testing.T) {
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	token := auth.NewToken()
 	req := models.ExternalInitiatorRequest{
@@ -61,8 +59,7 @@ func TestORM_DeleteExternalInitiator(t *testing.T) {
 func TestORM_FindBridge(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	bt := models.BridgeType{}
 	bt.Name = models.MustNewTaskType("solargridreporting")
@@ -94,8 +91,7 @@ func TestORM_FindBridge(t *testing.T) {
 func TestORM_FindUser(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 	user1 := cltest.MustNewUser(t, "test1@email1.net", "password1")
 	user2 := cltest.MustNewUser(t, "test2@email2.net", "password2")
 	user2.CreatedAt = time.Now().Add(-24 * time.Hour)
@@ -127,8 +123,7 @@ func TestORM_AuthorizedUserWithSession(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			store, cleanup := cltest.NewStore(t)
-			defer cleanup()
+			store := cltest.NewStore(t)
 
 			user := cltest.MustNewUser(t, "have@email", "password")
 			require.NoError(t, store.SaveUser(&user))
@@ -158,8 +153,7 @@ func TestORM_AuthorizedUserWithSession(t *testing.T) {
 func TestORM_DeleteUser(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	_, err := store.FindUser()
 	require.NoError(t, err)
@@ -174,8 +168,7 @@ func TestORM_DeleteUser(t *testing.T) {
 func TestORM_DeleteUserSession(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	session := models.NewSession()
 	require.NoError(t, store.DB.Save(&session).Error)
@@ -194,8 +187,7 @@ func TestORM_DeleteUserSession(t *testing.T) {
 func TestORM_CreateSession(t *testing.T) {
 	t.Parallel()
 
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	initial := cltest.MustRandomUser()
 	require.NoError(t, store.SaveUser(&initial))
@@ -232,8 +224,7 @@ func TestORM_CreateSession(t *testing.T) {
 }
 
 func TestORM_EthTransactionsWithAttempts(t *testing.T) {
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 	db := store.DB
 	ethKeyStore := cltest.NewKeyStore(t, db).Eth()
 
@@ -279,8 +270,7 @@ func TestORM_EthTransactionsWithAttempts(t *testing.T) {
 }
 
 func TestORM_UpdateBridgeType(t *testing.T) {
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 
 	firstBridge := &models.BridgeType{
 		Name: "UniqueName",

--- a/core/store/store_test.go
+++ b/core/store/store_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func TestStore_SquashMigrationUpgrade(t *testing.T) {
-	_, orm, cleanup := heavyweight.FullTestORM(t, "migrationssquash", false, false)
-	defer cleanup()
+	_, orm := heavyweight.FullTestORM(t, "migrationssquash", false, false)
 	db := orm.DB
 
 	// Latest migrations should work fine.
@@ -34,8 +33,7 @@ func TestStore_UpsertLatestNodeVersion(t *testing.T) {
 	t.Parallel()
 
 	t.Run("static version unset", func(t *testing.T) {
-		store, cleanup := cltest.NewStore(t)
-		t.Cleanup(cleanup)
+		store := cltest.NewStore(t)
 		verORM := versioning.NewORM(postgres.WrapDbWithSqlx(
 			postgres.MustSQLDB(store.DB)),
 		)
@@ -49,8 +47,7 @@ func TestStore_UpsertLatestNodeVersion(t *testing.T) {
 
 	t.Run("static version set", func(t *testing.T) {
 		static.Version = "0.9.11"
-		store, cleanup := cltest.NewStore(t)
-		t.Cleanup(cleanup)
+		store := cltest.NewStore(t)
 		verORM := versioning.NewORM(postgres.WrapDbWithSqlx(
 			postgres.MustSQLDB(store.DB)),
 		)
@@ -66,16 +63,14 @@ func TestStore_UpsertLatestNodeVersion(t *testing.T) {
 
 func TestStore_Start(t *testing.T) {
 	t.Parallel()
-	store, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	store := cltest.NewStore(t)
 	assert.NoError(t, store.Start())
 }
 
 func TestStore_Close(t *testing.T) {
 	t.Parallel()
 
-	s, cleanup := cltest.NewStore(t)
-	defer cleanup()
+	s := cltest.NewStore(t)
 
 	assert.NoError(t, s.Close())
 }

--- a/core/web/bridge_types_controller_test.go
+++ b/core/web/bridge_types_controller_test.go
@@ -17,8 +17,7 @@ import (
 )
 
 func BenchmarkBridgeTypesController_Index(b *testing.B) {
-	app, cleanup := cltest.NewApplication(b)
-	b.Cleanup(cleanup)
+	app := cltest.NewApplication(b)
 	client := app.NewHTTPClient()
 
 	b.ResetTimer()
@@ -32,8 +31,7 @@ func BenchmarkBridgeTypesController_Index(b *testing.B) {
 func TestBridgeTypesController_Index(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
 
@@ -99,8 +97,7 @@ func setupBridgeControllerIndex(t testing.TB, store *store.Store) ([]*models.Bri
 func TestBridgeTypesController_Create_Success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
 
@@ -128,8 +125,7 @@ func TestBridgeTypesController_Create_Success(t *testing.T) {
 func TestBridgeTypesController_Update_Success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
 
@@ -152,9 +148,9 @@ func TestBridgeTypesController_Update_Success(t *testing.T) {
 func TestBridgeController_Show(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start())
+
 	client := app.NewHTTPClient()
 
 	bt := &models.BridgeType{
@@ -182,8 +178,7 @@ func TestBridgeController_Show(t *testing.T) {
 func TestBridgeTypesController_Create_AdapterExistsError(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -199,8 +194,7 @@ func TestBridgeTypesController_Create_AdapterExistsError(t *testing.T) {
 func TestBridgeTypesController_Create_BindJSONError(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -216,8 +210,7 @@ func TestBridgeTypesController_Create_BindJSONError(t *testing.T) {
 func TestBridgeTypesController_Create_DatabaseError(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()

--- a/core/web/config_controller_test.go
+++ b/core/web/config_controller_test.go
@@ -17,8 +17,7 @@ import (
 func TestConfigController_Show(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
 

--- a/core/web/cors_test.go
+++ b/core/web/cors_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
-	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 )
 
@@ -15,11 +14,6 @@ func TestCors_DefaultOrigins(t *testing.T) {
 	config := cltest.NewTestGeneralConfig(t)
 	config.Overrides.AllowOrigins = null.StringFrom("http://localhost:3000,http://localhost:6689")
 	config.Overrides.EthereumDisabled = null.BoolFrom(true)
-	app, cleanup := cltest.NewApplicationWithConfig(t, config)
-	t.Cleanup(cleanup)
-	require.NoError(t, app.Start())
-
-	client := app.NewHTTPClient()
 
 	tests := []struct {
 		origin     string
@@ -32,6 +26,10 @@ func TestCors_DefaultOrigins(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.origin, func(t *testing.T) {
+			app := cltest.NewApplicationWithConfig(t, config)
+
+			client := app.NewHTTPClient()
+
 			headers := map[string]string{"Origin": test.origin}
 			resp, cleanup := client.Get("/v2/config", headers)
 			defer cleanup()
@@ -59,8 +57,7 @@ func TestCors_OverrideOrigins(t *testing.T) {
 			config := cltest.NewTestGeneralConfig(t)
 			config.Overrides.AllowOrigins = null.StringFrom(test.allow)
 			config.Overrides.EthereumDisabled = null.BoolFrom(true)
-			app, cleanup := cltest.NewApplicationWithConfig(t, config)
-			defer cleanup()
+			app := cltest.NewApplicationWithConfig(t, config)
 
 			client := app.NewHTTPClient()
 

--- a/core/web/eth_keys_controller_test.go
+++ b/core/web/eth_keys_controller_test.go
@@ -25,8 +25,7 @@ func TestETHKeysController_Index_Success(t *testing.T) {
 	cfg.Overrides.Dev = null.BoolFrom(true)
 	cfg.Overrides.GlobalEvmNonceAutoSync = null.BoolFrom(false)
 	cfg.Overrides.GlobalBalanceMonitorEnabled = null.BoolFrom(false)
-	app, cleanup := cltest.NewApplicationWithConfig(t, cfg, ethClient)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationWithConfig(t, cfg, ethClient)
 
 	app.KeyStore.Unlock(cltest.Password)
 
@@ -81,12 +80,11 @@ func TestETHKeysController_Index_NotDev(t *testing.T) {
 	cfg.Overrides.GlobalEvmNonceAutoSync = null.BoolFrom(false)
 	cfg.Overrides.GlobalBalanceMonitorEnabled = null.BoolFrom(false)
 	cfg.Overrides.GlobalGasEstimatorMode = null.StringFrom("FixedPrice")
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, cfg, ethClient)
-	t.Cleanup(cleanup)
 
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(256), nil).Once()
 	ethClient.On("GetLINKBalance", mock.Anything, mock.Anything).Return(assets.NewLinkFromJuels(256), nil).Once()
 
+	app := cltest.NewApplicationWithConfigAndKey(t, cfg, ethClient)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -111,8 +109,7 @@ func TestETHKeysController_Index_NotDev(t *testing.T) {
 func TestETHKeysController_Index_NoAccounts(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -134,8 +131,7 @@ func TestETHKeysController_CreateSuccess(t *testing.T) {
 	config := cltest.NewTestGeneralConfig(t)
 	config.Overrides.GlobalBalanceMonitorEnabled = null.BoolFrom(false)
 	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
-	app, cleanup := cltest.NewApplicationWithConfigAndKey(t, config, ethClient)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationWithConfigAndKey(t, config, ethClient)
 
 	verify := cltest.MockApplicationEthCalls(t, app, ethClient)
 	defer verify()

--- a/core/web/external_initiators_controller_test.go
+++ b/core/web/external_initiators_controller_test.go
@@ -19,9 +19,9 @@ import (
 func TestExternalInitiatorsController_Index(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	defer cleanup()
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
+
 	client := app.NewHTTPClient()
 
 	db := app.GetDB()
@@ -81,8 +81,7 @@ func TestExternalInitiatorsController_Index(t *testing.T) {
 func TestExternalInitiatorsController_Create_success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -107,8 +106,7 @@ func TestExternalInitiatorsController_Create_success(t *testing.T) {
 func TestExternalInitiatorsController_Create_without_URL(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -133,8 +131,7 @@ func TestExternalInitiatorsController_Create_without_URL(t *testing.T) {
 func TestExternalInitiatorsController_Create_invalid(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -149,8 +146,7 @@ func TestExternalInitiatorsController_Create_invalid(t *testing.T) {
 func TestExternalInitiatorsController_Delete(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	exi := models.ExternalInitiator{
@@ -169,8 +165,7 @@ func TestExternalInitiatorsController_Delete(t *testing.T) {
 func TestExternalInitiatorsController_DeleteNotFound(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()

--- a/core/web/features_controller_test.go
+++ b/core/web/features_controller_test.go
@@ -36,10 +36,8 @@ func Test_FeaturesController_List(t *testing.T) {
 func setupFeaturesControllerTest(t *testing.T) (*cltest.TestApplication, cltest.HTTPClientCleaner) {
 	os.Setenv("FEATURE_UI_CSA_KEYS", "true")
 
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
-	app.Start()
-
+	app := cltest.NewApplication(t)
+	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
 
 	return app, client

--- a/core/web/feeds_manager_controller_test.go
+++ b/core/web/feeds_manager_controller_test.go
@@ -187,10 +187,8 @@ func Test_FeedsManagersController_Show(t *testing.T) {
 }
 
 func setupFeedsManagerTest(t *testing.T) (*cltest.TestApplication, cltest.HTTPClientCleaner) {
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
-	app.Start()
-
+	app := cltest.NewApplication(t)
+	require.NoError(t, app.Start())
 	// We need a CSA key to establish a connection to the FMS
 	app.KeyStore.CSA().Create()
 

--- a/core/web/gui_assets_test.go
+++ b/core/web/gui_assets_test.go
@@ -14,8 +14,7 @@ import (
 func TestGuiAssets_DefaultIndexHtml_OK(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start())
 
 	client := &http.Client{}
@@ -45,8 +44,7 @@ func TestGuiAssets_DefaultIndexHtml_OK(t *testing.T) {
 func TestGuiAssets_DefaultIndexHtml_NotFound(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start())
 
 	client := &http.Client{}
@@ -79,8 +77,7 @@ func TestGuiAssets_DefaultIndexHtml_RateLimited(t *testing.T) {
 
 	config := cltest.NewTestGeneralConfig(t)
 	config.Overrides.Dev = null.BoolFrom(false)
-	app, cleanup := cltest.NewApplicationWithConfig(t, config)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationWithConfig(t, config)
 	require.NoError(t, app.Start())
 
 	client := &http.Client{}
@@ -102,8 +99,7 @@ func TestGuiAssets_DefaultIndexHtml_RateLimited(t *testing.T) {
 func TestGuiAssets_AssetsExact(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start())
 
 	client := &http.Client{}
@@ -120,8 +116,7 @@ func TestGuiAssets_AssetsExact(t *testing.T) {
 func TestGuiAssets_AssetsExactCompressed(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start())
 
 	client := &http.Client{}

--- a/core/web/health_controller_test.go
+++ b/core/web/health_controller_test.go
@@ -29,8 +29,7 @@ func TestHealthController_Readyz(t *testing.T) {
 	}
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
-			app, cleanup := cltest.NewApplicationWithKey(t)
-			t.Cleanup(cleanup)
+			app := cltest.NewApplicationWithKey(t)
 			healthChecker := new(mocks.Checker)
 			healthChecker.On("Start").Return(nil).Once()
 			healthChecker.On("IsReady").Return(tc.ready, nil).Once()

--- a/core/web/job_proposals_controller_test.go
+++ b/core/web/job_proposals_controller_test.go
@@ -403,10 +403,8 @@ type TestJobProposalsController struct {
 }
 
 func setupJobProposalsTest(t *testing.T) *TestJobProposalsController {
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
-	app.Start()
-
+	app := cltest.NewApplication(t)
+	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
 
 	// Defer the FK requirement of a feeds manager.

--- a/core/web/jobs_controller_test.go
+++ b/core/web/jobs_controller_test.go
@@ -267,8 +267,7 @@ func TestJobController_Create_HappyPath(t *testing.T) {
 }
 
 func TestJobsController_Create_WebhookSpec(t *testing.T) {
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	_, bridge := cltest.NewBridgeType(t, "fetch_bridge", "http://foo.bar")
@@ -386,8 +385,7 @@ func runDirectRequestJobSpecAssertions(t *testing.T, ereJobSpecFromFile job.Job,
 }
 
 func setupJobsControllerTests(t *testing.T) (*cltest.TestApplication, cltest.HTTPClientCleaner) {
-	app, cleanup := cltest.NewApplicationWithKey(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationWithKey(t)
 	require.NoError(t, app.Start())
 
 	_, bridge := cltest.NewBridgeType(t, "voter_turnout", "http://blah.com")
@@ -402,8 +400,7 @@ func setupJobsControllerTests(t *testing.T) (*cltest.TestApplication, cltest.HTT
 }
 
 func setupJobSpecsControllerTestsWithJobs(t *testing.T) (*cltest.TestApplication, cltest.HTTPClientCleaner, job.Job, int32, job.Job, int32) {
-	app, cleanup := cltest.NewApplicationWithKey(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationWithKey(t)
 	require.NoError(t, app.Start())
 	app.KeyStore.OCR().Add(cltest.DefaultOCRKey)
 	app.KeyStore.P2P().Add(cltest.DefaultP2PKey)

--- a/core/web/log_controller_test.go
+++ b/core/web/log_controller_test.go
@@ -42,8 +42,7 @@ func TestLogController_GetLogConfig(t *testing.T) {
 	sqlEnabled := true
 	cfg.Overrides.LogSQLStatements = null.BoolFrom(sqlEnabled)
 
-	app, cleanup := cltest.NewApplicationWithConfig(t, cfg)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationWithConfig(t, cfg)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -70,8 +69,7 @@ func TestLogController_GetLogConfig(t *testing.T) {
 func TestLogController_PatchLogConfig(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
 

--- a/core/web/ocr_keys_controller_test.go
+++ b/core/web/ocr_keys_controller_test.go
@@ -85,8 +85,7 @@ func TestOCRKeysController_Delete_HappyPath(t *testing.T) {
 func setupOCRKeysControllerTests(t *testing.T) (cltest.HTTPClientCleaner, keystore.OCR) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
 

--- a/core/web/p2p_keys_controller_test.go
+++ b/core/web/p2p_keys_controller_test.go
@@ -39,8 +39,7 @@ func TestP2PKeysController_Index_HappyPath(t *testing.T) {
 func TestP2PKeysController_Create_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
 	keyStore := app.GetKeyStore()
@@ -98,8 +97,7 @@ func TestP2PKeysController_Delete_HappyPath(t *testing.T) {
 func setupP2PKeysControllerTests(t *testing.T) (cltest.HTTPClientCleaner, keystore.Master) {
 	t.Helper()
 
-	app, cleanup := cltest.NewApplication(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start())
 	app.KeyStore.OCR().Add(cltest.DefaultOCRKey)
 	app.KeyStore.P2P().Add(cltest.DefaultP2PKey)

--- a/core/web/ping_controller_test.go
+++ b/core/web/ping_controller_test.go
@@ -16,8 +16,7 @@ import (
 func TestPingController_Show_APICredentials(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	defer cleanup()
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -32,8 +31,7 @@ func TestPingController_Show_APICredentials(t *testing.T) {
 func TestPingController_Show_ExternalInitiatorCredentials(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	defer cleanup()
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	eia := &auth.Token{
@@ -71,8 +69,7 @@ func TestPingController_Show_ExternalInitiatorCredentials(t *testing.T) {
 func TestPingController_Show_NoCredentials(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	defer cleanup()
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	client := http.Client{}

--- a/core/web/pipeline_runs_controller_test.go
+++ b/core/web/pipeline_runs_controller_test.go
@@ -37,19 +37,17 @@ func TestPipelineRunsController_CreateWithBody_HappyPath(t *testing.T) {
 	cfg.Overrides.SetTriggerFallbackDBPollInterval(10 * time.Millisecond)
 	cfg.Overrides.EthereumDisabled = null.BoolFrom(true)
 
-	app, cleanup := cltest.NewApplicationWithConfig(t, cfg, ethClient)
-	defer cleanup()
+	app := cltest.NewApplicationWithConfig(t, cfg, ethClient)
 	require.NoError(t, app.Start())
 
 	// Setup the bridge
 	{
-		mockServer, cleanup := cltest.NewHTTPMockServerWithRequest(t, 200, `{}`, func(r *http.Request) {
+		mockServer := cltest.NewHTTPMockServerWithRequest(t, 200, `{}`, func(r *http.Request) {
 			defer r.Body.Close()
 			bs, err := ioutil.ReadAll(r.Body)
 			require.NoError(t, err)
 			require.Equal(t, `{"result":"12345"}`, string(bs))
 		})
-		defer cleanup()
 
 		_, bridge := cltest.NewBridgeType(t, "my_bridge", mockServer.URL)
 		require.NoError(t, app.GetDB().Create(bridge).Error)
@@ -105,25 +103,22 @@ func TestPipelineRunsController_CreateNoBody_HappyPath(t *testing.T) {
 	cfg.Overrides.SetTriggerFallbackDBPollInterval(10 * time.Millisecond)
 	cfg.Overrides.EthereumDisabled = null.BoolFrom(true)
 
-	app, cleanup := cltest.NewApplicationWithConfig(t, cfg, ethClient)
-	defer cleanup()
+	app := cltest.NewApplicationWithConfig(t, cfg, ethClient)
 	require.NoError(t, app.Start())
 
 	// Setup the bridges
 	{
-		mockServer, cleanup := cltest.NewHTTPMockServer(t, 200, "POST", `{"data":{"result":"123.45"}}`)
-		defer cleanup()
+		mockServer := cltest.NewHTTPMockServer(t, 200, "POST", `{"data":{"result":"123.45"}}`)
 
 		_, bridge := cltest.NewBridgeType(t, "fetch_bridge", mockServer.URL)
 		require.NoError(t, app.GetDB().Create(bridge).Error)
 
-		mockServer, cleanup = cltest.NewHTTPMockServerWithRequest(t, 200, `{}`, func(r *http.Request) {
+		mockServer = cltest.NewHTTPMockServerWithRequest(t, 200, `{}`, func(r *http.Request) {
 			defer r.Body.Close()
 			bs, err := ioutil.ReadAll(r.Body)
 			require.NoError(t, err)
 			require.Equal(t, `{"result":"12345"}`, string(bs))
 		})
-		defer cleanup()
 
 		_, bridge = cltest.NewBridgeType(t, "submit_bridge", mockServer.URL)
 		require.NoError(t, app.GetDB().Create(bridge).Error)
@@ -167,8 +162,7 @@ func TestPipelineRunsController_CreateNoBody_HappyPath(t *testing.T) {
 }
 
 func TestPipelineRunsController_Index_GlobalHappyPath(t *testing.T) {
-	client, jobID, runIDs, cleanup := setupPipelineRunsControllerTests(t)
-	defer cleanup()
+	client, jobID, runIDs := setupPipelineRunsControllerTests(t)
 
 	response, cleanup := client.Get("/v2/pipeline/runs")
 	defer cleanup()
@@ -191,8 +185,7 @@ func TestPipelineRunsController_Index_GlobalHappyPath(t *testing.T) {
 }
 
 func TestPipelineRunsController_Index_HappyPath(t *testing.T) {
-	client, jobID, runIDs, cleanup := setupPipelineRunsControllerTests(t)
-	defer cleanup()
+	client, jobID, runIDs := setupPipelineRunsControllerTests(t)
 
 	response, cleanup := client.Get("/v2/jobs/" + fmt.Sprintf("%v", jobID) + "/runs")
 	defer cleanup()
@@ -215,8 +208,7 @@ func TestPipelineRunsController_Index_HappyPath(t *testing.T) {
 }
 
 func TestPipelineRunsController_Index_Pagination(t *testing.T) {
-	client, jobID, runIDs, cleanup := setupPipelineRunsControllerTests(t)
-	defer cleanup()
+	client, jobID, runIDs := setupPipelineRunsControllerTests(t)
 
 	response, cleanup := client.Get("/v2/jobs/" + fmt.Sprintf("%v", jobID) + "/runs?page=1&size=1")
 	defer cleanup()
@@ -238,8 +230,7 @@ func TestPipelineRunsController_Index_Pagination(t *testing.T) {
 }
 
 func TestPipelineRunsController_Show_HappyPath(t *testing.T) {
-	client, jobID, runIDs, cleanup := setupPipelineRunsControllerTests(t)
-	defer cleanup()
+	client, jobID, runIDs := setupPipelineRunsControllerTests(t)
 
 	response, cleanup := client.Get("/v2/jobs/" + fmt.Sprintf("%v", jobID) + "/runs/" + fmt.Sprintf("%v", runIDs[0]))
 	defer cleanup()
@@ -259,8 +250,7 @@ func TestPipelineRunsController_Show_HappyPath(t *testing.T) {
 
 func TestPipelineRunsController_ShowRun_InvalidID(t *testing.T) {
 	t.Parallel()
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	defer cleanup()
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 	client := app.NewHTTPClient()
 
@@ -269,18 +259,18 @@ func TestPipelineRunsController_ShowRun_InvalidID(t *testing.T) {
 	cltest.AssertServerResponse(t, response, http.StatusUnprocessableEntity)
 }
 
-func setupPipelineRunsControllerTests(t *testing.T) (cltest.HTTPClientCleaner, int32, []int64, func()) {
+func setupPipelineRunsControllerTests(t *testing.T) (cltest.HTTPClientCleaner, int32, []int64) {
 	t.Parallel()
 	ethClient, _, assertMocksCalled := cltest.NewEthMocksWithStartupAssertions(t)
 	defer assertMocksCalled()
 	cfg := cltest.NewTestGeneralConfig(t)
 	cfg.Overrides.EthereumDisabled = null.BoolFrom(true)
-	app, cleanup := cltest.NewApplicationWithConfig(t, cfg, ethClient)
+	app := cltest.NewApplicationWithConfig(t, cfg, ethClient)
 	require.NoError(t, app.Start())
 	app.KeyStore.OCR().Add(cltest.DefaultOCRKey)
 	app.KeyStore.P2P().Add(cltest.DefaultP2PKey)
 	client := app.NewHTTPClient()
-	mockHTTP, cleanupHTTP := cltest.NewHTTPMockServer(t, http.StatusOK, "GET", `{"USD": 1}`)
+	mockHTTP := cltest.NewHTTPMockServer(t, http.StatusOK, "GET", `{"USD": 1}`)
 
 	key, _ := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
@@ -322,8 +312,5 @@ func setupPipelineRunsControllerTests(t *testing.T) (cltest.HTTPClientCleaner, i
 	secondRunID, err := app.RunJobV2(context.Background(), jb.ID, nil)
 	require.NoError(t, err)
 
-	return client, jb.ID, []int64{firstRunID, secondRunID}, func() {
-		cleanup()
-		cleanupHTTP()
-	}
+	return client, jb.ID, []int64{firstRunID, secondRunID}
 }

--- a/core/web/router_test.go
+++ b/core/web/router_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestTokenAuthRequired_NoCredentials(t *testing.T) {
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	router := web.Router(app)
@@ -31,8 +30,7 @@ func TestTokenAuthRequired_NoCredentials(t *testing.T) {
 }
 
 func TestTokenAuthRequired_SessionCredentials(t *testing.T) {
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	router := web.Router(app)
@@ -47,8 +45,7 @@ func TestTokenAuthRequired_SessionCredentials(t *testing.T) {
 }
 
 func TestTokenAuthRequired_TokenCredentials(t *testing.T) {
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	router := web.Router(app)
@@ -80,8 +77,7 @@ func TestTokenAuthRequired_TokenCredentials(t *testing.T) {
 }
 
 func TestTokenAuthRequired_BadTokenCredentials(t *testing.T) {
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	router := web.Router(app)
@@ -113,8 +109,7 @@ func TestTokenAuthRequired_BadTokenCredentials(t *testing.T) {
 }
 
 func TestSessions_RateLimited(t *testing.T) {
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	router := web.Router(app)
@@ -142,8 +137,7 @@ func TestSessions_RateLimited(t *testing.T) {
 }
 
 func TestRouter_LargePOSTBody(t *testing.T) {
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	router := web.Router(app)
@@ -162,8 +156,7 @@ func TestRouter_LargePOSTBody(t *testing.T) {
 }
 
 func TestRouter_GinHelmetHeaders(t *testing.T) {
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	router := web.Router(app)

--- a/core/web/sessions_controller_test.go
+++ b/core/web/sessions_controller_test.go
@@ -21,9 +21,8 @@ import (
 func TestSessionsController_Create(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	defer cleanup()
-	app.Start()
+	app := cltest.NewApplicationEVMDisabled(t)
+	require.NoError(t, app.Start())
 
 	config := app.Store.Config
 	client := http.Client{}
@@ -77,9 +76,8 @@ func TestSessionsController_Create(t *testing.T) {
 func TestSessionsController_Create_ReapSessions(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	defer cleanup()
-	app.Start()
+	app := cltest.NewApplicationEVMDisabled(t)
+	require.NoError(t, app.Start())
 
 	staleSession := cltest.NewSession()
 	staleSession.LastUsed = time.Now().Add(-cltest.MustParseDuration(t, "241h"))
@@ -107,8 +105,7 @@ func TestSessionsController_Create_ReapSessions(t *testing.T) {
 func TestSessionsController_Destroy(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	defer cleanup()
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	correctSession := models.NewSession()
@@ -149,8 +146,7 @@ func TestSessionsController_Destroy_ReapSessions(t *testing.T) {
 	t.Parallel()
 
 	client := http.Client{}
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	defer cleanup()
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	correctSession := models.NewSession()

--- a/core/web/transactions_controller_test.go
+++ b/core/web/transactions_controller_test.go
@@ -20,8 +20,7 @@ import (
 func TestTransactionsController_Index_Success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationWithKey(t)
 	require.NoError(t, app.Start())
 
 	store := app.GetStore()
@@ -66,8 +65,7 @@ func TestTransactionsController_Index_Success(t *testing.T) {
 func TestTransactionsController_Index_Error(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationWithKey(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -79,10 +77,9 @@ func TestTransactionsController_Index_Error(t *testing.T) {
 func TestTransactionsController_Show_Success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
-	t.Cleanup(cleanup)
-
+	app := cltest.NewApplicationWithKey(t)
 	require.NoError(t, app.Start())
+
 	db := app.GetDB()
 	client := app.NewHTTPClient()
 	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), 0)
@@ -113,10 +110,9 @@ func TestTransactionsController_Show_Success(t *testing.T) {
 func TestTransactionsController_Show_NotFound(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
-	t.Cleanup(cleanup)
-
+	app := cltest.NewApplicationWithKey(t)
 	require.NoError(t, app.Start())
+
 	db := app.GetDB()
 	client := app.NewHTTPClient()
 	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), 0)

--- a/core/web/transfer_controller_test.go
+++ b/core/web/transfer_controller_test.go
@@ -19,8 +19,7 @@ import (
 func TestTransfersController_CreateSuccess_From(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationWithKey(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -50,8 +49,7 @@ func TestTransfersController_CreateSuccess_From(t *testing.T) {
 func TestTransfersController_TransferError(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationWithKey(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -73,8 +71,7 @@ func TestTransfersController_TransferError(t *testing.T) {
 func TestTransfersController_JSONBindingError(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationWithKey(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()

--- a/core/web/tx_attempts_controller_test.go
+++ b/core/web/tx_attempts_controller_test.go
@@ -16,10 +16,9 @@ import (
 func TestTxAttemptsController_Index_Success(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
-	t.Cleanup(cleanup)
-
+	app := cltest.NewApplicationWithKey(t)
 	require.NoError(t, app.Start())
+
 	db := app.GetDB()
 	client := app.NewHTTPClient()
 
@@ -48,10 +47,9 @@ func TestTxAttemptsController_Index_Success(t *testing.T) {
 func TestTxAttemptsController_Index_Error(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationWithKey(t)
-	t.Cleanup(cleanup)
-
+	app := cltest.NewApplicationWithKey(t)
 	require.NoError(t, app.Start())
+
 	client := app.NewHTTPClient()
 	resp, cleanup := client.Get("/v2/tx_attempts?size=TrainingDay")
 	t.Cleanup(cleanup)

--- a/core/web/user_controller_test.go
+++ b/core/web/user_controller_test.go
@@ -16,9 +16,9 @@ import (
 )
 
 func TestUserController_UpdatePassword(t *testing.T) {
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
+
 	client := app.NewHTTPClient()
 
 	testCases := []struct {
@@ -69,8 +69,7 @@ func TestUserController_UpdatePassword(t *testing.T) {
 func TestUserController_NewAPIToken(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -92,8 +91,7 @@ func TestUserController_NewAPIToken(t *testing.T) {
 func TestUserController_NewAPIToken_unauthorized(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -109,8 +107,7 @@ func TestUserController_NewAPIToken_unauthorized(t *testing.T) {
 func TestUserController_DeleteAPIKey(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()
@@ -127,8 +124,7 @@ func TestUserController_DeleteAPIKey(t *testing.T) {
 func TestUserController_DeleteAPIKey_unauthorized(t *testing.T) {
 	t.Parallel()
 
-	app, cleanup := cltest.NewApplicationEVMDisabled(t)
-	t.Cleanup(cleanup)
+	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start())
 
 	client := app.NewHTTPClient()


### PR DESCRIPTION
https://app.clubhouse.io/chainlinklabs/story/16794/tests-audit-t-cleanup-uses

Most of this change is mechanical find/replace boilerplate reduction of test cleanup code, but there are also a few related fixes that I will note.