### PR TITLE
Ensure ocr and p2p keys

### DIFF
--- a/core/services/keystore/ocr.go
+++ b/core/services/keystore/ocr.go
@@ -15,6 +15,7 @@ type OCR interface {
 	Delete(id string) (ocrkey.KeyV2, error)
 	Import(keyJSON []byte, password string) (ocrkey.KeyV2, error)
 	Export(id string, password string) ([]byte, error)
+	EnsureKey() (ocrkey.KeyV2, bool, error)
 
 	GetV1KeysAsV2() ([]ocrkey.KeyV2, error)
 }
@@ -118,6 +119,22 @@ func (ks ocr) Export(id string, password string) ([]byte, error) {
 		return nil, err
 	}
 	return key.ToEncryptedJSON(password, ks.scryptParams)
+}
+
+func (ks ocr) EnsureKey() (ocrkey.KeyV2, bool, error) {
+	ks.lock.Lock()
+	defer ks.lock.Unlock()
+	if ks.isLocked() {
+		return ocrkey.KeyV2{}, false, ErrLocked
+	}
+	if len(ks.keyRing.OCR) > 0 {
+		return ocrkey.KeyV2{}, true, nil
+	}
+	key, err := ocrkey.NewV2()
+	if err != nil {
+		return ocrkey.KeyV2{}, false, err
+	}
+	return key, false, ks.safeAddKey(key)
 }
 
 func (ks ocr) GetV1KeysAsV2() (keys []ocrkey.KeyV2, _ error) {

--- a/core/services/keystore/ocr_test.go
+++ b/core/services/keystore/ocr_test.go
@@ -78,4 +78,17 @@ func Test_OCRKeyStore_E2E(t *testing.T) {
 		_, err = ks.Get(newKey.ID())
 		require.Error(t, err)
 	})
+
+	t.Run("ensures key", func(t *testing.T) {
+		defer reset()
+		_, didExist, err := ks.EnsureKey()
+		require.NoError(t, err)
+		require.False(t, didExist)
+		_, didExist, err = ks.EnsureKey()
+		require.NoError(t, err)
+		require.True(t, didExist)
+		keys, err := ks.GetAll()
+		require.NoError(t, err)
+		require.Equal(t, 1, len(keys))
+	})
 }

--- a/core/services/keystore/p2p_test.go
+++ b/core/services/keystore/p2p_test.go
@@ -78,4 +78,17 @@ func Test_P2PKeyStore_E2E(t *testing.T) {
 		_, err = ks.Get(newKey.ID())
 		require.Error(t, err)
 	})
+
+	t.Run("ensures key", func(t *testing.T) {
+		defer reset()
+		_, didExist, err := ks.EnsureKey()
+		require.NoError(t, err)
+		require.False(t, didExist)
+		_, didExist, err = ks.EnsureKey()
+		require.NoError(t, err)
+		require.True(t, didExist)
+		keys, err := ks.GetAll()
+		require.NoError(t, err)
+		require.Equal(t, 1, len(keys))
+	})
 }


### PR DESCRIPTION
This PR ensures that p2p keys and ocr keys are auto-created on node startup if none exist. This functionality was removed during the keystore upgrade.