### PR TITLE
read p2p peer id from keystore in GeneralConfig

### DIFF
--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -251,14 +251,14 @@ func ensureKeys(ctx context.Context, cfg config.GeneralConfig, ethClient eth.Cli
 		return errors.Wrap(err, "failed to ensure ocr key")
 	}
 	if !didExist {
-		logger.Infow("Created OCR key with ID %s", ocrKey.ID())
+		logger.Infof("Created OCR key with ID %s", ocrKey.ID())
 	}
 	p2pKey, didExist, err := ks.P2P().EnsureKey()
 	if err != nil {
 		return errors.Wrap(err, "failed to ensure p2p key")
 	}
 	if !didExist {
-		logger.Infow("Created P2P key with ID %s", p2pKey.ID())
+		logger.Infof("Created P2P key with ID %s", p2pKey.ID())
 	}
 
 	return nil

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -146,12 +146,12 @@ func NewApplication(logger *loggerPkg.Logger, cfg config.EVMConfig, ethClient et
 	sqlxDB := postgres.UnwrapGormDB(store.DB)
 	gormTxm := postgres.NewGormTransactionManager(store.DB)
 
-	setupConfig(cfg, store.DB)
-
-	healthChecker := health.NewChecker()
-
 	scryptParams := utils.GetScryptParams(cfg)
 	keyStore := keystore.New(store.DB, scryptParams)
+
+	setupConfig(cfg, store.DB, keyStore)
+
+	healthChecker := health.NewChecker()
 
 	telemetryIngressClient := synchronization.TelemetryIngressClient(&synchronization.NoopTelemetryIngressClient{})
 	explorerClient := synchronization.ExplorerClient(&synchronization.NoopExplorerClient{})
@@ -424,8 +424,9 @@ func (app *ChainlinkApplication) SetServiceLogger(ctx context.Context, serviceNa
 	return app.logger.Orm.SetServiceLogLevel(ctx, serviceName, level)
 }
 
-func setupConfig(cfg config.GeneralConfig, db *gorm.DB) {
+func setupConfig(cfg config.GeneralConfig, db *gorm.DB, ks keystore.Master) {
 	cfg.SetDB(db)
+	cfg.SetKeyStore(ks)
 }
 
 // Start all necessary services. If successful, nil will be returned.  Also


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/17098/peer-id-in-ocr-is-not-resolved-from-keys