### PR TITLE
read p2p peer id from keystore in GeneralConfig

### DIFF
--- a/core/cmd/client.go
+++ b/core/cmd/client.go
@@ -85,8 +85,9 @@ func (n ChainlinkAppFactory) NewApplication(cfg config.GeneralConfig) (chainlink
 	}
 	db := store.DB
 	sqlxDB := postgres.UnwrapGormDB(db)
-	cfg.SetDB(db)
 	keyStore := keystore.New(db, utils.GetScryptParams(cfg))
+	cfg.SetDB(db)
+	cfg.SetKeyStore(keyStore)
 	// Init service loggers
 	globalLogger := cfg.CreateProductionLogger()
 	globalLogger.SetDB(db)

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -132,14 +132,14 @@ func (cli *Client) RunNode(c *clipkg.Context) error {
 		return cli.errorOut(errors.Wrap(err, "failed to ensure ocr key"))
 	}
 	if !didExist {
-		logger.Infow("Created OCR key with ID %s", ocrKey.ID())
+		logger.Infof("Created OCR key with ID %s", ocrKey.ID())
 	}
 	p2pKey, didExist, err := app.GetKeyStore().P2P().EnsureKey()
 	if err != nil {
 		return cli.errorOut(errors.Wrap(err, "failed to ensure p2p key"))
 	}
 	if !didExist {
-		logger.Infow("Created P2P key with ID %s", p2pKey.ID())
+		logger.Infof("Created P2P key with ID %s", p2pKey.ID())
 	}
 
 	logger.Infof("Chainlink booted in %s", time.Since(static.InitTime))

--- a/core/store/config/general_config.go
+++ b/core/store/config/general_config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/p2pkey"
 	"github.com/smartcontractkit/chainlink/core/static"
@@ -156,6 +157,7 @@ type GeneralOnlyConfig interface {
 	SessionSecret() ([]byte, error)
 	SessionTimeout() models.Duration
 	SetDB(*gorm.DB)
+	SetKeyStore(keystore.Master)
 	SetLogLevel(ctx context.Context, value string) error
 	SetLogSQLStatements(ctx context.Context, sqlEnabled bool) error
 	SetDialect(dialects.DialectName)
@@ -231,6 +233,7 @@ type generalConfig struct {
 	viper            *viper.Viper
 	secretGenerator  SecretGenerator
 	ORM              *ORM
+	ks               keystore.Master
 	randomP2PPort    uint16
 	randomP2PPortMtx *sync.RWMutex
 	dialect          dialects.DialectName
@@ -324,6 +327,11 @@ func (c *generalConfig) Validate() error {
 func (c *generalConfig) SetDB(db *gorm.DB) {
 	orm := NewORM(db)
 	c.ORM = orm
+}
+
+// SetKeyStore provides reference to the keystore for runtime configuration values
+func (c *generalConfig) SetKeyStore(ks keystore.Master) {
+	c.ks = ks
 }
 
 func (c *generalConfig) SetDialect(d dialects.DialectName) {
@@ -944,18 +952,17 @@ func (c *generalConfig) P2PPeerID() (p2pkey.PeerID, error) {
 		c.p2ppeerIDmtx.Lock()
 		defer c.p2ppeerIDmtx.Unlock()
 		if c.viper.GetString(EnvVarName("P2PPeerID")) == "" {
-			var keys []p2pkey.EncryptedP2PKey
-			if c.ORM == nil {
-				err = errors.New("db was not set on config")
+			if c.ks == nil {
+				err = errors.New("keystore was not set on config")
 				return
 			}
-			err2 := c.ORM.db.Order("created_at asc, id asc").Find(&keys).Error
+			keys, err2 := c.ks.P2P().GetAll()
 			if err2 != nil {
-				logger.Warnw("Failed to load keys, falling back to env", "err", err2)
+				logger.Warnw("Failed to load keys, falling back to env", "err", err2.Error())
 				return
 			}
 			if len(keys) > 0 {
-				peerID := keys[0].PeerID
+				peerID := keys[0].PeerID()
 				logger.Debugw("P2P_PEER_ID was not set, using the first available key", "peerID", peerID.String())
 				c.viper.Set(EnvVarName("P2PPeerID"), peerID)
 				if len(keys) > 1 {


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/17098/peer-id-in-ocr-is-not-resolved-from-keys