### PR TITLE
add optimism2 gas estimator

### DIFF
--- a/core/chains/evm/config/chain_specific_config.go
+++ b/core/chains/evm/config/chain_specific_config.go
@@ -222,7 +222,6 @@ func setChainSpecificConfigDefaultSets() {
 	optimismMainnet.gasEstimatorMode = "Optimism"
 	optimismMainnet.headTrackerHistoryDepth = 10
 	optimismMainnet.headTrackerSamplingInterval = 1 * time.Second
-	optimismMainnet.linkContractAddress = "" // TBD
 	optimismMainnet.linkContractAddress = "0x350a791Bfc2C21F9Ed5d10980Dad2e2638ffa7f6"
 	optimismMainnet.minIncomingConfirmations = 1
 	optimismMainnet.minRequiredOutgoingConfirmations = 0

--- a/core/services/gas/models.go
+++ b/core/services/gas/models.go
@@ -35,6 +35,8 @@ func NewEstimator(lggr logger.Logger, ethClient eth.Client, config Config) Estim
 		return NewFixedPriceEstimator(config)
 	case "Optimism":
 		return NewOptimismEstimator(lggr, config, ethClient)
+	case "Optimism2":
+		return NewOptimism2Estimator(lggr, config, ethClient)
 	default:
 		logger.Warnf("GasEstimator: unrecognised mode '%s', falling back to FixedPriceEstimator", s)
 		return NewFixedPriceEstimator(config)

--- a/core/services/gas/optimism_estimator.go
+++ b/core/services/gas/optimism_estimator.go
@@ -16,11 +16,10 @@ import (
 	"go.uber.org/multierr"
 )
 
-// It's always 0.015 GWei
-// See: https://www.notion.so/How-to-pay-Fees-in-Optimistic-Ethereum-f706f4e5b13e460fa5671af48ce9a695
-const optimisml1GasPrice = 15000000
-
-var _ Estimator = &optimismEstimator{}
+var (
+	_ Estimator = &optimismEstimator{}
+	_ Estimator = &optimism2Estimator{}
+)
 
 //go:generate mockery --name optimismRPCClient --output ./mocks/ --case=underscore --structname OptimismRPCClient
 type optimismRPCClient interface {
@@ -196,6 +195,10 @@ func (o *optimismEstimator) calcGas(calldata []byte, l2GasLimit uint64) (chainSp
 	}
 	chainSpecificGasLimit = uint64(optimismGasLimitBig.Int64())
 
+	// It's always 0.015 GWei
+	// See: https://www.notion.so/How-to-pay-Fees-in-Optimistic-Ethereum-f706f4e5b13e460fa5671af48ce9a695
+	const optimisml1GasPrice = 15000000
+
 	o.logger.Debugw("OptimismEstimator#EstimateGas", "l1GasPrice", l1GasPrice, "l2GasPrice", l2GasPrice, "l2GasLimit", l2GasLimit, "chainSpecificGasLimit", chainSpecificGasLimit, "optimisml1GasPrice", optimisml1GasPrice)
 	return big.NewInt(optimisml1GasPrice), chainSpecificGasLimit, nil
 }
@@ -204,4 +207,144 @@ func (o *optimismEstimator) getGasPrices() (l1GasPrice, l2GasPrice *big.Int) {
 	o.gasPriceMu.RLock()
 	defer o.gasPriceMu.RUnlock()
 	return o.l1GasPrice, o.l2GasPrice
+}
+
+type optimism2Estimator struct {
+	utils.StartStopOnce
+
+	config     Config
+	client     optimismRPCClient
+	pollPeriod time.Duration
+	logger     logger.Logger
+
+	gasPriceMu sync.RWMutex
+	l2GasPrice *big.Int
+
+	chForceRefetch chan (chan struct{})
+	chInitialised  chan struct{}
+	chStop         chan struct{}
+	chDone         chan struct{}
+}
+
+// NewOptimism2Estimator returns a new optimism 2.0 estimator
+func NewOptimism2Estimator(lggr logger.Logger, config Config, client optimismRPCClient) Estimator {
+	return &optimism2Estimator{
+		utils.StartStopOnce{},
+		config,
+		client,
+		10 * time.Second,
+		lggr,
+		sync.RWMutex{},
+		nil,
+		make(chan (chan struct{})),
+		make(chan struct{}),
+		make(chan struct{}),
+		make(chan struct{}),
+	}
+}
+
+func (o *optimism2Estimator) Start() error {
+	return o.StartOnce("Optimism2Estimator", func() error {
+		go o.run()
+		<-o.chInitialised
+		return nil
+	})
+}
+func (o *optimism2Estimator) Close() error {
+	return o.StopOnce("Optimism2Estimator", func() error {
+		close(o.chStop)
+		<-o.chDone
+		return nil
+	})
+}
+
+func (o *optimism2Estimator) run() {
+	defer close(o.chDone)
+
+	t := o.refreshPrice()
+	close(o.chInitialised)
+
+	for {
+		select {
+		case <-o.chStop:
+			return
+		case ch := <-o.chForceRefetch:
+			t.Stop()
+			t = o.refreshPrice()
+			close(ch)
+		case <-t.C:
+			t = o.refreshPrice()
+		}
+	}
+}
+
+func (o *optimism2Estimator) refreshPrice() (t *time.Timer) {
+	t = time.NewTimer(utils.WithJitter(o.pollPeriod))
+
+	var res hexutil.Big
+	if err := o.client.Call(&res, "eth_gasPrice"); err != nil {
+		o.logger.Warnf("Optimism2Estimator: Failed to refresh prices, got error: %s", err)
+		return
+	}
+	bi := (*big.Int)(&res)
+
+	o.logger.Debugw("Optimism2Estimator#refreshPrice", "l2GasPrice", bi)
+
+	o.gasPriceMu.Lock()
+	defer o.gasPriceMu.Unlock()
+	o.l2GasPrice = bi
+	return
+}
+
+func (o *optimism2Estimator) OnNewLongestChain(_ context.Context, _ eth.Head) {}
+
+func (*optimism2Estimator) GetDynamicFee(_ uint64) (fee DynamicFee, chainSpecificGasLimit uint64, err error) {
+	err = errors.New("dynamic fees are not implemented for Optimism")
+	return
+}
+
+func (*optimism2Estimator) BumpDynamicFee(_ DynamicFee, _ uint64) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
+	err = errors.New("dynamic fees are not implemented for Optimism")
+	return
+}
+
+func (o *optimism2Estimator) GetLegacyGas(_ []byte, l2GasLimit uint64, opts ...Opt) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
+	chainSpecificGasLimit = l2GasLimit
+	ok := o.IfStarted(func() {
+		var forceRefetch bool
+		for _, opt := range opts {
+			if opt == OptForceRefetch {
+				forceRefetch = true
+			}
+		}
+		if forceRefetch {
+			ch := make(chan struct{})
+			o.chForceRefetch <- ch
+			select {
+			case <-ch:
+			case <-o.chStop:
+				err = errors.New("estimator stopped")
+				return
+			}
+		}
+		if gasPrice = o.getGasPrice(); gasPrice == nil {
+			err = errors.New("failed to estimate optimism gas; gas price not set")
+			return
+		}
+		o.logger.Debugw("Optimism2Estimator#EstimateGas", "l2GasPrice", gasPrice, "l2GasLimit", l2GasLimit)
+	})
+	if !ok {
+		return nil, 0, errors.New("estimator is not started")
+	}
+	return
+}
+
+func (o *optimism2Estimator) BumpLegacyGas(_ *big.Int, _ uint64) (bumpedGasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
+	return nil, 0, errors.New("bump gas is not supported for optimism")
+}
+
+func (o *optimism2Estimator) getGasPrice() (l2GasPrice *big.Int) {
+	o.gasPriceMu.RLock()
+	defer o.gasPriceMu.RUnlock()
+	return o.l2GasPrice
 }

--- a/core/services/gas/optimism_estimator_test.go
+++ b/core/services/gas/optimism_estimator_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/gas"
@@ -70,4 +71,51 @@ func Test_OptimismGasPriceResponse_UnmarshalJSON(t *testing.T) {
 	err := json.Unmarshal(data, &g)
 	assert.NoError(t, err)
 	assert.Equal(t, gas.OptimismGasPricesResponse{L1GasPrice: big.NewInt(5500000000), L2GasPrice: big.NewInt(9)}, g)
+}
+
+func Test_Optimism2Estimator(t *testing.T) {
+	t.Parallel()
+
+	config := new(mocks.Config)
+	client := new(mocks.OptimismRPCClient)
+	o := gas.NewOptimism2Estimator(logger.Default, config, client)
+
+	calldata := []byte{0x00, 0x00, 0x01, 0x02, 0x03}
+	var gasLimit uint64 = 80000
+
+	t.Run("calling EstimateGas on unstarted estimator returns error", func(t *testing.T) {
+		_, _, err := o.GetLegacyGas(calldata, gasLimit)
+		assert.EqualError(t, err, "estimator is not started")
+	})
+
+	t.Run("calling EstimateGas on started estimator returns prices", func(t *testing.T) {
+		client.On("Call", mock.Anything, "eth_gasPrice").Return(nil).Run(func(args mock.Arguments) {
+			res := args.Get(0).(*hexutil.Big)
+			(*big.Int)(res).SetInt64(42)
+		})
+
+		require.NoError(t, o.Start())
+		gasPrice, chainSpecificGasLimit, err := o.GetLegacyGas(calldata, gasLimit)
+		require.NoError(t, err)
+		assert.Equal(t, big.NewInt(42), gasPrice)
+		assert.Equal(t, gasLimit, chainSpecificGasLimit)
+	})
+
+	t.Run("calling BumpGas always returns error", func(t *testing.T) {
+		_, _, err := o.BumpLegacyGas(big.NewInt(42), gasLimit)
+		assert.EqualError(t, err, "bump gas is not supported for optimism")
+	})
+
+	t.Run("calling EstimateGas on started estimator if initial call failed returns error", func(t *testing.T) {
+		config := new(mocks.Config)
+		client := new(mocks.OptimismRPCClient)
+		o = gas.NewOptimism2Estimator(logger.Default, config, client)
+
+		client.On("Call", mock.Anything, "eth_gasPrice").Return(errors.New("kaboom"))
+
+		require.NoError(t, o.Start())
+
+		_, _, err := o.GetLegacyGas(calldata, gasLimit)
+		assert.EqualError(t, err, "failed to estimate optimism gas; gas price not set")
+	})
 }


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/16888/cl-node-should-support-new-optimism-gas-fee-scheme