### PR TITLE
tools/docker/compose: remove unused

### DIFF
--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -147,13 +147,6 @@ To remove any containers, volumes, and networks related to our docker-compose se
 ./compose clean
 ```
 
-Individual clean commands are included for CI purposes when matrix jobs are being executed.
-
-```sh
-./compose test:down
-./compose test:ts:down
-```
-
 ### Running your own commands based off of docker-compose
 
 The following commands allow you do just about anything:

--- a/tools/docker/compose
+++ b/tools/docker/compose
@@ -30,21 +30,6 @@ dev="$base -f docker-compose.dev.yaml"                                  # config
 clean_docker() {
   $base down -v --remove-orphans
   $dev down -v --remove-orphans
-  $test down -v --remove-orphans
-  $deps down -v --remove-orphans
-  $ts_test down -v --remove-orphans
-}
-
-function save_test_logs() {
-  mkdir -p logs
-  $ts_test logs --no-color node &>./logs/node.log
-  $ts_test logs --no-color node-2 &>./logs/node-2.log
-  $ts_test logs --no-color devnet &>./logs/devnet.log
-  $ts_test logs --no-color node-db &>./logs/node-db.log
-  $ts_test logs --no-color node-db-2 &>./logs/node-db-2.log
-  $ts_test logs --no-color explorer &>./logs/explorer.log
-  $ts_test logs --no-color explorer-db &>./logs/explorer-db.log
-  $ts_test logs --no-color external-adapter &>./logs/external-adapter.log
 }
 
 function usage() {
@@ -77,9 +62,6 @@ clean)
   ;;
 logs)
   $base logs -f ${@:2}
-  ;;
-logs:test:save)
-  save_test_logs
   ;;
 cld)
   $dev build
@@ -116,7 +98,6 @@ cl:restart)
   $base rm --force --stop node-db
   docker volume rm --force docker_node-db-data
   ./compose eth:restart
-  $deps up --abort-on-container-exit --remove-orphans wait-db wait-db
   $base start node
   ;;
 *)


### PR DESCRIPTION
- ~`cldev` is still using `node import` which was removed in #4812~ (handled elsewhere)
- remove unused code