### PR TITLE
CI: better FAIL detection

### DIFF
--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -4,7 +4,7 @@ set +e
 
 echo "Failed tests and panics: ---------------------"
 echo ""
-go test -v -p 4 -parallel 4 ./... | tee ./output.txt | grep --line-buffered --line-number -e "\-\-\- FAIL" -e "FAIL "
+go test -v -p 4 -parallel 4 ./... | tee ./output.txt | grep --line-buffered --line-number -e "\-\-\- FAIL" -e "FAIL\s"
 EXITCODE=${PIPESTATUS[0]}
 echo ""
 echo "----------------------------------------------"


### PR DESCRIPTION
Package level fails use a tab after the fail. Match on both.

    FAIL	github.com/smartcontractkit/chainlink/core/internal/gethwrappers	29.820s
    ?   	github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated	[no test files]