### PR TITLE
Logger interface: remove db reference and associated methods

### DIFF
--- a/core/cmd/client.go
+++ b/core/cmd/client.go
@@ -89,7 +89,7 @@ func (n ChainlinkAppFactory) NewApplication(cfg config.GeneralConfig) (chainlink
 	cfg.SetDB(db)
 	cfg.SetKeyStore(keyStore)
 	// Init service loggers
-	globalLogger := cfg.CreateProductionLogger().WithDB(db)
+	globalLogger := cfg.CreateProductionLogger()
 
 	if cfg.ClobberNodesFromEnv() {
 		if err = evm.ClobberNodesFromEnv(db, cfg); err != nil {

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -582,7 +582,7 @@ func TestClient_SetPkgLogLevel(t *testing.T) {
 	err := client.SetLogPkg(c)
 	require.NoError(t, err)
 
-	level, err := app.Logger.ServiceLogLevel(logPkg)
-	require.NoError(t, err)
+	level, ok := logger.NewORM(app.GetDB()).GetServiceLogLevel(logPkg)
+	require.True(t, ok)
 	assert.Equal(t, logLevel, level)
 }

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -374,7 +374,6 @@ func NewApplicationWithConfig(t testing.TB, cfg *configtest.TestGeneralConfig, f
 	if lggr == nil {
 		lggr = cfg.CreateProductionLogger()
 	}
-	lggr = lggr.WithDB(db)
 	cfg.SetDB(db)
 	if chainORM == nil {
 		chainORM = evm.NewORM(sqlxDB)

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -62,7 +62,6 @@ type Application interface {
 	Start() error
 	Stop() error
 	GetLogger() loggerPkg.Logger
-	SetLogger(func(old loggerPkg.Logger) loggerPkg.Logger)
 	GetHealthChecker() health.Checker
 	GetStore() *strpkg.Store
 	GetDB() *gorm.DB
@@ -321,7 +320,7 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 
 // SetServiceLogger sets the Logger for a given service and stores the setting in the db
 func (app *ChainlinkApplication) SetServiceLogger(ctx context.Context, serviceName string, level string) error {
-	newL, err := app.logger.InitServiceLevelLogger(serviceName, level)
+	newL, err := app.logger.NewServiceLevelLogger(serviceName, level)
 	if err != nil {
 		return err
 	}
@@ -339,7 +338,7 @@ func (app *ChainlinkApplication) SetServiceLogger(ctx context.Context, serviceNa
 		return fmt.Errorf("no service found with name: %s", serviceName)
 	}
 
-	return app.logger.GetORM().SetServiceLogLevel(ctx, serviceName, level)
+	return logger.NewORM(app.GetDB()).SetServiceLogLevel(ctx, serviceName, level)
 }
 
 // Start all necessary services. If successful, nil will be returned.  Also
@@ -470,10 +469,6 @@ func (app *ChainlinkApplication) GetKeyStore() keystore.Master {
 
 func (app *ChainlinkApplication) GetLogger() loggerPkg.Logger {
 	return app.logger
-}
-
-func (app *ChainlinkApplication) SetLogger(fn func(old loggerPkg.Logger) loggerPkg.Logger) {
-	app.logger = fn(app.logger)
 }
 
 func (app *ChainlinkApplication) GetHealthChecker() health.Checker {


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/17321/untangle-logger-from-db

Removing the DB reference from `Logger`s eliminates a lot of unusual API surface, and all of the callers already had their own DB reference available anyways.