### PR TITLE
Fixes job_proposal_status migration to work with Postgres v11

### DIFF
--- a/core/store/migrate/migrations/0066_update_job_proposal_status.sql
+++ b/core/store/migrate/migrations/0066_update_job_proposal_status.sql
@@ -1,8 +1,26 @@
 -- +goose Up
 -- +goose StatementBegin
 
--- Add the new enum value
-ALTER TYPE job_proposal_status ADD VALUE 'cancelled';
+-- We must remove the old contraint to add an enum value to support Postgres v11
+ALTER TABLE job_proposals
+DROP CONSTRAINT chk_job_proposals_status_fsm;
+
+-- Drop the cancelled enum value. Unfortunately postgres does not support a
+-- a way to remove a value from an enum.
+ALTER TYPE job_proposal_status RENAME TO job_proposal_status_old;
+CREATE TYPE job_proposal_status AS ENUM('pending', 'approved', 'rejected', 'cancelled');
+
+ALTER TABLE job_proposals ALTER COLUMN status TYPE job_proposal_status USING status::text::job_proposal_status;
+
+DROP TYPE job_proposal_status_old;
+
+-- Add the contraint back
+ALTER TABLE job_proposals
+ADD CONSTRAINT chk_job_proposals_status_fsm CHECK (
+	(status = 'pending' AND external_job_id IS NULL) OR
+	(status = 'approved' AND external_job_id IS NOT NULL) OR
+	(status = 'rejected' AND external_job_id IS NULL)
+);
 
 -- +goose StatementEnd
 


### PR DESCRIPTION
Postgres v11 does not allow ALTER TYPE ... ADD VALUE to be run within a transaction.
This commit changes the up migration to drop the old type and add the new updated type