### PR TITLE
L2 Emergency Protocol [Optimism]

### DIFF
--- a/contracts/src/v0.8/dev/ArbitrumValidator.sol
+++ b/contracts/src/v0.8/dev/ArbitrumValidator.sol
@@ -7,7 +7,7 @@ import "../interfaces/AccessControllerInterface.sol";
 import "../interfaces/AggregatorV3Interface.sol";
 import "../SimpleWriteAccessController.sol";
 
-/* ./dev dependencies - to be re/moved after audit */
+/* ./dev dependencies - to be moved from ./dev after audit */
 import "./interfaces/ForwarderInterface.sol";
 import "./interfaces/FlagsInterface.sol";
 import "./vendor/arb-bridge-eth/v0.8.0-custom/contracts/bridge/interfaces/IInbox.sol";

--- a/contracts/src/v0.8/dev/OptimismCrossDomainForwarder.sol
+++ b/contracts/src/v0.8/dev/OptimismCrossDomainForwarder.sol
@@ -1,0 +1,87 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../interfaces/TypeAndVersionInterface.sol";
+
+/* ./dev dependencies - to be moved from ./dev after audit */
+import "./CrossDomainForwarder.sol";
+import "./vendor/@eth-optimism/contracts/0.4.7/contracts/optimistic-ethereum/iOVM/bridge/messaging/iOVM_CrossDomainMessenger.sol";
+
+/**
+ * @title OptimismCrossDomainForwarder - L1 xDomain account representation
+ * @notice L2 Contract which receives messages from a specific L1 address and transparently forwards them to the destination.
+ * @dev Any other L2 contract which uses this contract's address as a privileged position,
+ *   can be considered to be owned by the `l1Owner`
+ */
+contract OptimismCrossDomainForwarder is TypeAndVersionInterface, CrossDomainForwarder {
+  // OVM_L2CrossDomainMessenger is a precompile usually deployed to 0x4200000000000000000000000000000000000007
+  address immutable private OVM_CROSS_DOMAIN_MESSENGER;
+
+  /**
+   * @notice creates a new Optimism xDomain Forwarder contract
+   * @param crossDomainMessengerAddr the xDomain bridge messenger (Optimism bridge L2) contract address
+   * @param l1OwnerAddr the L1 owner address that will be allowed to call the forward fn
+   */
+  constructor(
+    address crossDomainMessengerAddr,
+    address l1OwnerAddr
+  )
+    CrossDomainForwarder(l1OwnerAddr)
+  {
+    require(crossDomainMessengerAddr != address(0), "Invalid xDomain Messenger address");
+    OVM_CROSS_DOMAIN_MESSENGER = crossDomainMessengerAddr;
+  }
+
+  /**
+   * @notice versions:
+   *
+   * - OptimismCrossDomainForwarder 0.1.0: initial release
+   *
+   * @inheritdoc TypeAndVersionInterface
+   */
+  function typeAndVersion()
+    external
+    pure
+    override
+    virtual
+    returns (
+      string memory
+    )
+  {
+    return "OptimismCrossDomainForwarder 0.1.0";
+  }
+
+  /**
+   * @dev forwarded only if L2 Messenger calls with `xDomainMessageSender` beeing the L1 owner address
+   * @inheritdoc ForwarderInterface
+   */
+  function forward(
+    address target,
+    bytes memory data
+  )
+    override
+    external
+  {
+    // 1. The call MUST come from the L1 Messenger
+    require(msg.sender == OVM_CROSS_DOMAIN_MESSENGER, "Sender is not the L2 messenger");
+    // 2. The L1 Messenger's caller MUST be the L1 Owner
+    require(iOVM_CrossDomainMessenger(OVM_CROSS_DOMAIN_MESSENGER).xDomainMessageSender() == l1Owner(), "xDomain sender is not the L1 owner");
+    // 3. Make the external call
+    (bool success, bytes memory res) = target.call(data);
+    require(success, string(abi.encode("xDomain call failed:", res)));
+  }
+
+  /**
+   * @notice This is always the address of the OVM_L2CrossDomainMessenger contract
+   * @inheritdoc CrossDomainForwarder
+   */
+  function crossDomainMessenger()
+    public
+    view
+    override
+    virtual
+    returns (address)
+  {
+    return OVM_CROSS_DOMAIN_MESSENGER;
+  }
+}

--- a/contracts/src/v0.8/dev/OptimismValidator.sol
+++ b/contracts/src/v0.8/dev/OptimismValidator.sol
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../interfaces/TypeAndVersionInterface.sol";
+import "../interfaces/AggregatorValidatorInterface.sol";
+import "../interfaces/AccessControllerInterface.sol";
+import "../SimpleWriteAccessController.sol";
+
+/* ./dev dependencies - to be moved from ./dev after audit */
+import "./interfaces/FlagsInterface.sol";
+import "./interfaces/ForwarderInterface.sol";
+import "./vendor/@eth-optimism/contracts/0.4.7/contracts/optimistic-ethereum/iOVM/bridge/messaging/iOVM_CrossDomainMessenger.sol";
+
+/**
+ * @title OptimismValidator - makes xDomain L2 Flags contract call (using L2 xDomain Forwarder contract)
+ * @notice Allows to raise and lower Flags on the Optimism L2 network through L1 bridge
+ *  - The internal AccessController controls the access of the validate method
+ */
+contract OptimismValidator is TypeAndVersionInterface, AggregatorValidatorInterface, SimpleWriteAccessController {
+  /// @dev Follows: https://eips.ethereum.org/EIPS/eip-1967
+  address constant private FLAG_OPTIMISM_SEQ_OFFLINE = address(bytes20(bytes32(uint256(keccak256("chainlink.flags.optimism-seq-offline")) - 1)));
+  // Encode underlying Flags call/s
+  bytes constant private CALL_RAISE_FLAG = abi.encodeWithSelector(FlagsInterface.raiseFlag.selector, FLAG_OPTIMISM_SEQ_OFFLINE);
+  bytes constant private CALL_LOWER_FLAG = abi.encodeWithSelector(FlagsInterface.lowerFlag.selector, FLAG_OPTIMISM_SEQ_OFFLINE);
+  uint32 constant private CALL_GAS_LIMIT = 1_200_000;
+  int256 constant private ANSWER_SEQ_OFFLINE = 1;
+
+  address immutable public CROSS_DOMAIN_MESSENGER;
+  address immutable public L2_CROSS_DOMAIN_FORWARDER;
+  address immutable public L2_FLAGS;
+
+  /**
+   * @param crossDomainMessengerAddr address the xDomain bridge messenger (Optimism bridge L1) contract address
+   * @param l2CrossDomainForwarderAddr the L2 Forwarder contract address
+   * @param l2FlagsAddr the L2 Flags contract address
+   */
+  constructor(
+    address crossDomainMessengerAddr,
+    address l2CrossDomainForwarderAddr,
+    address l2FlagsAddr
+  ) {
+    require(crossDomainMessengerAddr != address(0), "Invalid xDomain Messenger address");
+    require(l2CrossDomainForwarderAddr != address(0), "Invalid L2 xDomain Forwarder address");
+    require(l2FlagsAddr != address(0), "Invalid L2 Flags address");
+    CROSS_DOMAIN_MESSENGER = crossDomainMessengerAddr;
+    L2_CROSS_DOMAIN_FORWARDER = l2CrossDomainForwarderAddr;
+    L2_FLAGS = l2FlagsAddr;
+  }
+
+  /**
+   * @notice versions:
+   *
+   * - OptimismValidator 0.1.0: initial release
+   *
+   * @inheritdoc TypeAndVersionInterface
+   */
+  function typeAndVersion()
+    external
+    pure
+    override
+    virtual
+    returns (
+      string memory
+    )
+  {
+    return "OptimismValidator 0.1.0";
+  }
+
+  /**
+   * @notice validate method sends an xDomain L2 tx to update Flags contract, in case of change from `previousAnswer`.
+   * @dev A message is sent via the Optimism CrossDomainMessenger L1 contract. The "payment" for L2 execution happens on L1,
+   *   using the gas attached to this tx (some extra gas is burned by the Optimism bridge to avoid DoS attacks).
+   *   This method is accessed controlled.
+   * @param previousAnswer previous aggregator answer
+   * @param currentAnswer new aggregator answer - value of 1 considers the service offline.
+   */
+  function validate(
+    uint256 /* previousRoundId */,
+    int256 previousAnswer,
+    uint256 /* currentRoundId */,
+    int256 currentAnswer
+  )
+    external
+    override
+    checkAccess()
+    returns (bool)
+  {
+    // Avoids resending to L2 the same tx on every call
+    if (previousAnswer == currentAnswer) {
+      return true; // noop
+    }
+
+    // Encode the Forwarder call
+    bytes4 selector = ForwarderInterface.forward.selector;
+    address target = L2_FLAGS;
+    // Choose and encode the underlying Flags call
+    bytes memory data = currentAnswer == ANSWER_SEQ_OFFLINE ? CALL_RAISE_FLAG : CALL_LOWER_FLAG;
+    bytes memory message = abi.encodeWithSelector(selector, target, data);
+    // Make the xDomain call
+    iOVM_CrossDomainMessenger(CROSS_DOMAIN_MESSENGER).sendMessage(L2_CROSS_DOMAIN_FORWARDER, message, CALL_GAS_LIMIT);
+    // return success
+    return true;
+  }
+}

--- a/contracts/src/v0.8/dev/vendor/@eth-optimism/contracts/0.4.7/contracts/optimistic-ethereum/iOVM/bridge/messaging/iOVM_CrossDomainMessenger.sol
+++ b/contracts/src/v0.8/dev/vendor/@eth-optimism/contracts/0.4.7/contracts/optimistic-ethereum/iOVM/bridge/messaging/iOVM_CrossDomainMessenger.sol
@@ -1,0 +1,39 @@
+pragma solidity >=0.7.6 <0.9.0;
+
+/**
+ * @title iOVM_CrossDomainMessenger
+ */
+interface iOVM_CrossDomainMessenger {
+
+    /**********
+     * Events *
+     **********/
+
+    event SentMessage(bytes message);
+    event RelayedMessage(bytes32 msgHash);
+    event FailedRelayedMessage(bytes32 msgHash);
+
+
+    /*************
+     * Variables *
+     *************/
+
+    function xDomainMessageSender() external view returns (address);
+
+
+    /********************
+     * Public Functions *
+     ********************/
+
+    /**
+     * Sends a cross domain message to the target messenger.
+     * @param _target Target contract address.
+     * @param _message Message to send to the target.
+     * @param _gasLimit Gas limit for the provided message.
+     */
+    function sendMessage(
+        address _target,
+        bytes calldata _message,
+        uint32 _gasLimit
+    ) external;
+}


### PR DESCRIPTION
Moving Optimism contracts from [smartcontractkit/optimism-contracts](https://github.com/smartcontractkit/optimism-contracts) [6d74c9f](https://github.com/smartcontractkit/optimism-contracts/commit/6d74c9fc872f579242a91c6c3ad3ff7492c42608) (the source repo is now archived)

These contracts are audited and will be deployed to Optimism after October 2021 Regenesis, which should bring back "full" EVM support.