### PR TITLE
Add typechain support

### DIFF
--- a/contracts/.gitignore
+++ b/contracts/.gitignore
@@ -5,3 +5,4 @@ solc
 abi
 coverage
 coverage.json
+typechain

--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -1,3 +1,5 @@
+import '@typechain/hardhat'
+import '@nomiclabs/hardhat-ethers'
 import '@nomiclabs/hardhat-waffle'
 import 'hardhat-contract-sizer'
 import 'hardhat-abi-exporter'
@@ -25,6 +27,10 @@ export default {
     cache: './cache',
     sources: './src',
     tests: './test',
+  },
+  typechain: {
+    outDir: './typechain',
+    target: 'ethers-v5',
   },
   networks: {
     hardhat: {},

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -27,6 +27,8 @@
     "@nomiclabs/hardhat-ethers": "^2.0.2",
     "@nomiclabs/hardhat-waffle": "^2.0.1",
     "@openzeppelin/test-helpers": "^0.5.11",
+    "@typechain/ethers-v5": "^7.0.1",
+    "@typechain/hardhat": "^2.0.2",
     "@types/cbor": "5.0.1",
     "@types/chai": "^4.2.18",
     "@types/debug": "^4.1.7",
@@ -43,6 +45,7 @@
     "prettier-plugin-solidity": "^1.0.0-beta.18",
     "solidity-coverage": "^0.7.17",
     "ts-node": "^10.0.0",
+    "typechain": "^5.0.0",
     "typescript": "^4.3.2"
   }
 }

--- a/contracts/test/v0.6/AggregatorFacade.test.ts
+++ b/contracts/test/v0.6/AggregatorFacade.test.ts
@@ -18,11 +18,11 @@ before(async () => {
 
   defaultAccount = users.roles.defaultAccount
   linkTokenFactory = await ethers.getContractFactory(
-    'LinkToken',
+    'src/v0.4/LinkToken.sol:LinkToken',
     defaultAccount,
   )
   aggregatorFactory = await ethers.getContractFactory(
-    'Aggregator',
+    'src/v0.4/Aggregator.sol:Aggregator',
     defaultAccount,
   )
   oracleFactory = await ethers.getContractFactory(
@@ -30,7 +30,7 @@ before(async () => {
     defaultAccount,
   )
   aggregatorFacadeFactory = await ethers.getContractFactory(
-    'AggregatorFacade',
+    'src/v0.6/AggregatorFacade.sol:AggregatorFacade',
     defaultAccount,
   )
 })

--- a/contracts/test/v0.6/BasicConsumer.test.ts
+++ b/contracts/test/v0.6/BasicConsumer.test.ts
@@ -31,7 +31,7 @@ before(async () => {
     roles.oracleNode,
   )
   linkTokenFactory = await ethers.getContractFactory(
-    'LinkToken',
+    'src/v0.4/LinkToken.sol:LinkToken',
     roles.defaultAccount,
   )
 })

--- a/contracts/test/v0.6/BlockhashStore.test.ts
+++ b/contracts/test/v0.6/BlockhashStore.test.ts
@@ -165,7 +165,7 @@ const binanceBlocks: TestBlocks[] = [
 before(async () => {
   personas = (await getUsers()).personas
   blockhashStoreTestHelperFactory = await ethers.getContractFactory(
-    'BlockhashStoreTestHelper',
+    'src/v0.6/tests/BlockhashStoreTestHelper.sol:BlockhashStoreTestHelper',
     personas.Default,
   )
 })

--- a/contracts/test/v0.6/ChainlinkClient.test.ts
+++ b/contracts/test/v0.6/ChainlinkClient.test.ts
@@ -39,7 +39,7 @@ before(async () => {
     roles.defaultAccount,
   )
   linkTokenFactory = await ethers.getContractFactory(
-    'LinkToken',
+    'src/v0.4/LinkToken.sol:LinkToken',
     roles.defaultAccount,
   )
 })

--- a/contracts/test/v0.6/CheckedMath.test.ts
+++ b/contracts/test/v0.6/CheckedMath.test.ts
@@ -13,7 +13,7 @@ let personas: Personas
 before(async () => {
   personas = (await getUsers()).personas
   mathFactory = await ethers.getContractFactory(
-    'CheckedMathTestHelper',
+    'src/v0.6/tests/CheckedMathTestHelper.sol:CheckedMathTestHelper',
     personas.Default,
   )
 })

--- a/contracts/test/v0.6/DeviationFlaggingValidator.test.ts
+++ b/contracts/test/v0.6/DeviationFlaggingValidator.test.ts
@@ -13,7 +13,7 @@ let acFactory: ContractFactory
 before(async () => {
   personas = (await getUsers()).personas
   validatorFactory = await ethers.getContractFactory(
-    'DeviationFlaggingValidator',
+    'src/v0.6/DeviationFlaggingValidator.sol:DeviationFlaggingValidator',
     personas.Carol,
   )
   flagsFactory = await ethers.getContractFactory(

--- a/contracts/test/v0.6/FluxAggregator.test.ts
+++ b/contracts/test/v0.6/FluxAggregator.test.ts
@@ -33,22 +33,28 @@ let emptyAddress: string
 
 before(async () => {
   personas = (await getUsers()).personas
-  linkTokenFactory = await ethers.getContractFactory('LinkToken')
-  fluxAggregatorFactory = await ethers.getContractFactory('FluxAggregator')
+  linkTokenFactory = await ethers.getContractFactory(
+    'src/v0.4/LinkToken.sol:LinkToken',
+  )
+  fluxAggregatorFactory = await ethers.getContractFactory(
+    'src/v0.6/FluxAggregator.sol:FluxAggregator',
+  )
   validatorMockFactory = await ethers.getContractFactory(
-    'AggregatorValidatorMock',
+    'src/v0.6/tests/AggregatorValidatorMock.sol:AggregatorValidatorMock',
   )
   testHelperFactory = await ethers.getContractFactory(
-    'FluxAggregatorTestHelper',
+    'src/v0.6/tests/FluxAggregatorTestHelper.sol:FluxAggregatorTestHelper',
   )
   validatorFactory = await ethers.getContractFactory(
-    'DeviationFlaggingValidator',
+    'src/v0.6/DeviationFlaggingValidator.sol:DeviationFlaggingValidator',
   )
   flagsFactory = await ethers.getContractFactory('src/v0.6/Flags.sol:Flags')
   acFactory = await ethers.getContractFactory(
     'src/v0.6/SimpleWriteAccessController.sol:SimpleWriteAccessController',
   )
-  gasGuzzlerFactory = await ethers.getContractFactory('GasGuzzler')
+  gasGuzzlerFactory = await ethers.getContractFactory(
+    'src/v0.6/tests/GasGuzzler.sol:GasGuzzler',
+  )
   emptyAddress = constants.AddressZero
 })
 

--- a/contracts/test/v0.6/SignedSafeMath.test.ts
+++ b/contracts/test/v0.6/SignedSafeMath.test.ts
@@ -11,7 +11,7 @@ before(async () => {
   const personas: Personas = (await getUsers()).personas
   defaultAccount = personas.Default
   concreteSignedSafeMathFactory = await ethers.getContractFactory(
-    'ConcreteSignedSafeMath',
+    'src/v0.6/tests/ConcreteSignedSafeMath.sol:ConcreteSignedSafeMath',
     defaultAccount,
   )
 })

--- a/contracts/test/v0.6/VRFD20.test.ts
+++ b/contracts/test/v0.6/VRFD20.test.ts
@@ -30,15 +30,15 @@ before(async () => {
   roles = users.roles
   personas = users.personas
   linkTokenFactory = await ethers.getContractFactory(
-    'LinkToken',
+    'src/v0.4/LinkToken.sol:LinkToken',
     roles.defaultAccount,
   )
   vrfCoordinatorMockFactory = await ethers.getContractFactory(
-    'VRFCoordinatorMock',
+    'src/v0.6/tests/VRFCoordinatorMock.sol:VRFCoordinatorMock',
     roles.defaultAccount,
   )
   vrfD20Factory = await ethers.getContractFactory(
-    'VRFD20',
+    'src/v0.6/examples/VRFD20.sol:VRFD20',
     roles.defaultAccount,
   )
 })

--- a/contracts/test/v0.7/AggregatorProxy.test.ts
+++ b/contracts/test/v0.7/AggregatorProxy.test.ts
@@ -28,7 +28,7 @@ before(async () => {
   defaultAccount = users.roles.defaultAccount
 
   linkTokenFactory = await ethers.getContractFactory(
-    'LinkToken',
+    'src/v0.4/LinkToken.sol:LinkToken',
     defaultAccount,
   )
   aggregatorFactory = await ethers.getContractFactory(
@@ -36,22 +36,33 @@ before(async () => {
     defaultAccount,
   )
   historicAggregatorFactory = await ethers.getContractFactory(
-    'MockV2Aggregator',
+    'src/v0.7/tests/MockV2Aggregator.sol:MockV2Aggregator',
     defaultAccount,
   )
   aggregatorFacadeFactory = await ethers.getContractFactory(
-    'AggregatorFacade',
+    'src/v0.6/AggregatorFacade.sol:AggregatorFacade',
+    defaultAccount,
+  )
+  historicAggregatorFactory = await ethers.getContractFactory(
+    'src/v0.7/tests/MockV2Aggregator.sol:MockV2Aggregator',
+    defaultAccount,
+  )
+  aggregatorFacadeFactory = await ethers.getContractFactory(
+    'src/v0.6/AggregatorFacade.sol:AggregatorFacade',
     defaultAccount,
   )
   aggregatorProxyFactory = await ethers.getContractFactory(
-    'AggregatorProxy',
+    'src/v0.7/dev/AggregatorProxy.sol:AggregatorProxy',
     defaultAccount,
   )
   fluxAggregatorFactory = await ethers.getContractFactory(
-    'FluxAggregator',
+    'src/v0.6/FluxAggregator.sol:FluxAggregator',
     defaultAccount,
   )
-  reverterFactory = await ethers.getContractFactory('Reverter', defaultAccount)
+  reverterFactory = await ethers.getContractFactory(
+    'src/v0.6/tests/Reverter.sol:Reverter',
+    defaultAccount,
+  )
 })
 
 describe('AggregatorProxy', () => {

--- a/contracts/test/v0.7/AuthorizedForwarder.test.ts
+++ b/contracts/test/v0.7/AuthorizedForwarder.test.ts
@@ -21,11 +21,11 @@ before(async () => {
     roles.defaultAccount,
   )
   forwarderFactory = await ethers.getContractFactory(
-    'AuthorizedForwarder',
+    'src/v0.7/AuthorizedForwarder.sol:AuthorizedForwarder',
     roles.defaultAccount,
   )
   linkTokenFactory = await ethers.getContractFactory(
-    'LinkToken',
+    'src/v0.4/LinkToken.sol:LinkToken',
     roles.defaultAccount,
   )
 })

--- a/contracts/test/v0.7/ChainlinkClient.test.ts
+++ b/contracts/test/v0.7/ChainlinkClient.test.ts
@@ -35,11 +35,11 @@ before(async () => {
     roles.defaultAccount,
   )
   operatorFactory = await ethers.getContractFactory(
-    'Operator',
+    'src/v0.7/Operator.sol:Operator',
     roles.defaultAccount,
   )
   linkTokenFactory = await ethers.getContractFactory(
-    'LinkToken',
+    'src/v0.4/LinkToken.sol:LinkToken',
     roles.defaultAccount,
   )
 })

--- a/contracts/test/v0.7/CompoundPriceFlaggingValidator.test.ts
+++ b/contracts/test/v0.7/CompoundPriceFlaggingValidator.test.ts
@@ -21,7 +21,7 @@ before(async () => {
   personas = (await getUsers()).personas
 
   validatorFactory = await ethers.getContractFactory(
-    'CompoundPriceFlaggingValidator',
+    'src/v0.7/dev/CompoundPriceFlaggingValidator.sol:CompoundPriceFlaggingValidator',
     personas.Carol,
   )
   acFactory = await ethers.getContractFactory(
@@ -37,7 +37,7 @@ before(async () => {
     personas.Carol,
   )
   compoundOracleFactory = await ethers.getContractFactory(
-    'MockCompoundOracle',
+    'src/v0.7/tests/MockCompoundOracle.sol:MockCompoundOracle',
     personas.Carol,
   )
 })

--- a/contracts/test/v0.7/ConfirmedOwner.test.ts
+++ b/contracts/test/v0.7/ConfirmedOwner.test.ts
@@ -21,7 +21,7 @@ before(async () => {
   newOwner = personas.Ned
 
   confirmedOwnerTestHelperFactory = await ethers.getContractFactory(
-    'ConfirmedOwnerTestHelper',
+    'src/v0.7/tests/ConfirmedOwnerTestHelper.sol:ConfirmedOwnerTestHelper',
     owner,
   )
   confirmedOwnerFactory = await ethers.getContractFactory(

--- a/contracts/test/v0.7/Operator.test.ts
+++ b/contracts/test/v0.7/Operator.test.ts
@@ -72,11 +72,17 @@ before(async () => {
     'src/v0.4/tests/MaliciousConsumer.sol:MaliciousConsumer',
   )
   maliciousMultiWordConsumerFactory = await ethers.getContractFactory(
-    'MaliciousMultiWordConsumer',
+    'src/v0.6/tests/MaliciousMultiWordConsumer.sol:MaliciousMultiWordConsumer',
   )
-  operatorFactory = await ethers.getContractFactory('Operator')
-  forwarderFactory = await ethers.getContractFactory('AuthorizedForwarder')
-  linkTokenFactory = await ethers.getContractFactory('LinkToken')
+  operatorFactory = await ethers.getContractFactory(
+    'src/v0.7/Operator.sol:Operator',
+  )
+  forwarderFactory = await ethers.getContractFactory(
+    'src/v0.7/AuthorizedForwarder.sol:AuthorizedForwarder',
+  )
+  linkTokenFactory = await ethers.getContractFactory(
+    'src/v0.4/LinkToken.sol:LinkToken',
+  )
 })
 
 describe('Operator', () => {

--- a/contracts/test/v0.7/OperatorFactory.test.ts
+++ b/contracts/test/v0.7/OperatorFactory.test.ts
@@ -16,19 +16,19 @@ before(async () => {
 
   roles = users.roles
   linkTokenFactory = await ethers.getContractFactory(
-    'LinkToken',
+    'src/v0.4/LinkToken.sol:LinkToken',
     roles.defaultAccount,
   )
   operatorGeneratorFactory = await ethers.getContractFactory(
-    'OperatorFactory',
+    'src/v0.7/OperatorFactory.sol:OperatorFactory',
     roles.defaultAccount,
   )
   operatorFactory = await ethers.getContractFactory(
-    'Operator',
+    'src/v0.7/Operator.sol:Operator',
     roles.defaultAccount,
   )
   forwarderFactory = await ethers.getContractFactory(
-    'AuthorizedForwarder',
+    'src/v0.7/AuthorizedForwarder.sol:AuthorizedForwarder',
     roles.defaultAccount,
   )
 })

--- a/contracts/test/v0.7/StalenessFlaggingValidator.test.ts
+++ b/contracts/test/v0.7/StalenessFlaggingValidator.test.ts
@@ -21,7 +21,7 @@ before(async () => {
   personas = (await getUsers()).personas
 
   validatorFactory = await ethers.getContractFactory(
-    'StalenessFlaggingValidator',
+    'src/v0.7/dev/StalenessFlaggingValidator.sol:StalenessFlaggingValidator',
     personas.Carol,
   )
   flagsFactory = await ethers.getContractFactory(

--- a/contracts/test/v0.7/UpkeepRegistrationRequests.test.ts
+++ b/contracts/test/v0.7/UpkeepRegistrationRequests.test.ts
@@ -365,16 +365,19 @@ describe('UpkeepRegistrationRequests', () => {
         )
 
       //register with auto approve OFF
-      let abiEncodedBytes = registrar.interface.encodeFunctionData('register', [
-        upkeepName,
-        emptyBytes,
-        mock.address,
-        executeGas,
-        await admin.getAddress(),
-        emptyBytes,
-        amount,
-        source,
-      ])
+      const abiEncodedBytes = registrar.interface.encodeFunctionData(
+        'register',
+        [
+          upkeepName,
+          emptyBytes,
+          mock.address,
+          executeGas,
+          await admin.getAddress(),
+          emptyBytes,
+          amount,
+          source,
+        ],
+      )
 
       const tx = await linkToken.transferAndCall(
         registrar.address,
@@ -514,16 +517,19 @@ describe('UpkeepRegistrationRequests', () => {
         )
 
       //register with auto approve OFF
-      let abiEncodedBytes = registrar.interface.encodeFunctionData('register', [
-        upkeepName,
-        emptyBytes,
-        mock.address,
-        executeGas,
-        await admin.getAddress(),
-        emptyBytes,
-        amount,
-        source,
-      ])
+      const abiEncodedBytes = registrar.interface.encodeFunctionData(
+        'register',
+        [
+          upkeepName,
+          emptyBytes,
+          mock.address,
+          executeGas,
+          await admin.getAddress(),
+          emptyBytes,
+          amount,
+          source,
+        ],
+      )
       const tx = await linkToken.transferAndCall(
         registrar.address,
         amount,

--- a/contracts/test/v0.7/gasUsage.test.ts
+++ b/contracts/test/v0.7/gasUsage.test.ts
@@ -21,7 +21,7 @@ before(async () => {
 
   roles = users.roles
   operatorFactory = await ethers.getContractFactory(
-    'Operator',
+    'src/v0.7/Operator.sol:Operator',
     roles.defaultAccount,
   )
   oracleFactory = await ethers.getContractFactory(
@@ -33,7 +33,7 @@ before(async () => {
     roles.defaultAccount,
   )
   linkTokenFactory = await ethers.getContractFactory(
-    'LinkToken',
+    'src/v0.4/LinkToken.sol:LinkToken',
     roles.defaultAccount,
   )
 })

--- a/contracts/test/v0.8/ChainlinkClient.test.ts
+++ b/contracts/test/v0.8/ChainlinkClient.test.ts
@@ -35,11 +35,11 @@ before(async () => {
     roles.defaultAccount,
   )
   operatorFactory = await ethers.getContractFactory(
-    'Operator',
+    'src/v0.7/Operator.sol:Operator',
     roles.defaultAccount,
   )
   linkTokenFactory = await ethers.getContractFactory(
-    'LinkToken',
+    'src/v0.4/LinkToken.sol:LinkToken',
     roles.defaultAccount,
   )
 })

--- a/contracts/test/v0.8/ValidatorProxy.test.ts
+++ b/contracts/test/v0.8/ValidatorProxy.test.ts
@@ -26,7 +26,10 @@ before(async () => {
 
 describe('ValidatorProxy', () => {
   beforeEach(async () => {
-    const vpf = await ethers.getContractFactory('ValidatorProxy', owner)
+    const vpf = await ethers.getContractFactory(
+      'src/v0.8/ValidatorProxy.sol:ValidatorProxy',
+      owner,
+    )
     validatorProxy = await vpf.deploy(aggregatorAddress, validatorAddress)
     validatorProxy = await validatorProxy.deployed()
   })
@@ -279,7 +282,10 @@ describe('ValidatorProxy', () => {
       })
 
       it('reverts when there is no validator set', async () => {
-        const vpf = await ethers.getContractFactory('ValidatorProxy', owner)
+        const vpf = await ethers.getContractFactory(
+          'src/v0.8/ValidatorProxy.sol:ValidatorProxy',
+          owner,
+        )
         validatorProxy = await vpf.deploy(
           aggregatorAddress,
           constants.AddressZero,
@@ -296,12 +302,15 @@ describe('ValidatorProxy', () => {
         let mockValidator1: Contract
         beforeEach(async () => {
           const mvf = await ethers.getContractFactory(
-            'MockAggregatorValidator',
+            'src/v0.8/mocks/MockAggregatorValidator.sol:MockAggregatorValidator',
             owner,
           )
           mockValidator1 = await mvf.deploy(1)
           mockValidator1 = await mockValidator1.deployed()
-          const vpf = await ethers.getContractFactory('ValidatorProxy', owner)
+          const vpf = await ethers.getContractFactory(
+            'src/v0.8/ValidatorProxy.sol:ValidatorProxy',
+            owner,
+          )
           validatorProxy = await vpf.deploy(
             aggregatorAddress,
             mockValidator1.address,
@@ -332,7 +341,7 @@ describe('ValidatorProxy', () => {
 
           beforeEach(async () => {
             const mvf = await ethers.getContractFactory(
-              'MockAggregatorValidator',
+              'src/v0.8/mocks/MockAggregatorValidator.sol:MockAggregatorValidator',
               owner,
             )
             mockValidator2 = await mvf.deploy(2)

--- a/contracts/test/v0.8/dev/VRFCoordinatorV2.test.ts
+++ b/contracts/test/v0.8/dev/VRFCoordinatorV2.test.ts
@@ -30,7 +30,7 @@ describe('VRFCoordinatorV2', () => {
   let c: config
 
   beforeEach(async () => {
-    let accounts = await ethers.getSigners()
+    const accounts = await ethers.getSigners()
     owner = accounts[0]
     subOwner = accounts[1]
     subOwnerAddress = await subOwner.getAddress()
@@ -38,20 +38,23 @@ describe('VRFCoordinatorV2', () => {
     random = accounts[3]
     randomAddress = await random.getAddress()
     oracle = accounts[4]
-    let ltFactory = await ethers.getContractFactory('LinkToken', accounts[0])
+    const ltFactory = await ethers.getContractFactory(
+      'src/v0.4/LinkToken.sol:LinkToken',
+      accounts[0],
+    )
     linkToken = await ltFactory.deploy()
-    let bhFactory = await ethers.getContractFactory(
-      'BlockhashStore',
+    const bhFactory = await ethers.getContractFactory(
+      'src/v0.6/dev/BlockhashStore.sol:BlockhashStore',
       accounts[0],
     )
     blockHashStore = await bhFactory.deploy()
-    let mockAggregatorV3Factory = await ethers.getContractFactory(
+    const mockAggregatorV3Factory = await ethers.getContractFactory(
       'src/v0.7/tests/MockV3Aggregator.sol:MockV3Aggregator',
       accounts[0],
     )
     mockLinkEth = await mockAggregatorV3Factory.deploy(0, linkEth)
-    let vrfCoordinatorV2Factory = await ethers.getContractFactory(
-      'VRFCoordinatorV2',
+    const vrfCoordinatorV2Factory = await ethers.getContractFactory(
+      'src/v0.8/dev/VRFCoordinatorV2.sol:VRFCoordinatorV2',
       accounts[0],
     )
     vrfCoordinatorV2 = await vrfCoordinatorV2Factory.deploy(
@@ -59,8 +62,8 @@ describe('VRFCoordinatorV2', () => {
       blockHashStore.address,
       mockLinkEth.address,
     )
-    let vrfCoordinatorV2TestHelperFactory = await ethers.getContractFactory(
-      'VRFCoordinatorV2TestHelper',
+    const vrfCoordinatorV2TestHelperFactory = await ethers.getContractFactory(
+      'src/v0.8/tests/VRFCoordinatorV2TestHelper.sol:VRFCoordinatorV2TestHelper',
       accounts[0],
     )
     vrfCoordinatorV2TestHelper = await vrfCoordinatorV2TestHelperFactory.deploy(
@@ -369,7 +372,7 @@ describe('VRFCoordinatorV2', () => {
         vrfCoordinatorV2.connect(subOwner).addConsumer(subId, randomAddress),
       ).to.be.revertedWith(`TooManyConsumers()`)
       // Same is true if we first create with the maximum
-      let consumers: string[] = []
+      const consumers: string[] = []
       for (let i = 0; i < 100; i++) {
         consumers.push(randomAddressString())
       }
@@ -587,7 +590,7 @@ describe('VRFCoordinatorV2', () => {
           BigNumber.from('-900'),
         ],
       ]
-      for (let [fn, expectedBalanceChange] of balanceChangingFns) {
+      for (const [fn, expectedBalanceChange] of balanceChangingFns) {
         const startingBalance = await vrfCoordinatorV2.s_totalBalance()
         await fn()
         const endingBalance = await vrfCoordinatorV2.s_totalBalance()
@@ -979,11 +982,11 @@ describe('VRFCoordinatorV2', () => {
     })
 
     it('non-positive link wei price should revert', async function () {
-      let mockAggregatorV3Factory = await ethers.getContractFactory(
+      const mockAggregatorV3Factory = await ethers.getContractFactory(
         'src/v0.7/tests/MockV3Aggregator.sol:MockV3Aggregator',
         owner,
       )
-      let vrfCoordinatorV2TestHelperFactory = await ethers.getContractFactory(
+      const vrfCoordinatorV2TestHelperFactory = await ethers.getContractFactory(
         'VRFCoordinatorV2TestHelper',
         owner,
       )
@@ -1023,7 +1026,7 @@ describe('VRFCoordinatorV2', () => {
   describe('#keyRegistration', async function () {
     it('register key emits log', async function () {
       const testKey = [BigNumber.from('1'), BigNumber.from('2')]
-      let kh = await vrfCoordinatorV2.hashOfKey(testKey)
+      const kh = await vrfCoordinatorV2.hashOfKey(testKey)
       await expect(
         vrfCoordinatorV2.registerProvingKey(subOwnerAddress, testKey),
       )
@@ -1032,7 +1035,7 @@ describe('VRFCoordinatorV2', () => {
     })
     it('cannot re-register key', async function () {
       const testKey = [BigNumber.from('1'), BigNumber.from('2')]
-      let kh = await vrfCoordinatorV2.hashOfKey(testKey)
+      const kh = await vrfCoordinatorV2.hashOfKey(testKey)
       await vrfCoordinatorV2.registerProvingKey(subOwnerAddress, testKey)
       await expect(
         vrfCoordinatorV2.registerProvingKey(subOwnerAddress, testKey),
@@ -1040,7 +1043,7 @@ describe('VRFCoordinatorV2', () => {
     })
     it('deregister key emits log', async function () {
       const testKey = [BigNumber.from('1'), BigNumber.from('2')]
-      let kh = await vrfCoordinatorV2.hashOfKey(testKey)
+      const kh = await vrfCoordinatorV2.hashOfKey(testKey)
       await vrfCoordinatorV2.registerProvingKey(subOwnerAddress, testKey)
       await expect(vrfCoordinatorV2.deregisterProvingKey(testKey))
         .to.emit(vrfCoordinatorV2, 'ProvingKeyDeregistered')
@@ -1048,7 +1051,7 @@ describe('VRFCoordinatorV2', () => {
     })
     it('cannot deregister unregistered key', async function () {
       const testKey = [BigNumber.from('1'), BigNumber.from('2')]
-      let kh = await vrfCoordinatorV2.hashOfKey(testKey)
+      const kh = await vrfCoordinatorV2.hashOfKey(testKey)
       await expect(
         vrfCoordinatorV2.deregisterProvingKey(testKey),
       ).to.be.revertedWith(`NoSuchProvingKey("${kh}")`)
@@ -1115,14 +1118,14 @@ describe('VRFCoordinatorV2', () => {
       ).to.be.revertedWith(`NoCorrespondingRequest()`)
     })
     it('incorrect commitment wrong blocknum', async function () {
-      let subId = await createSubscription()
+      const subId = await createSubscription()
       await linkToken.connect(subOwner).transferAndCall(
         vrfCoordinatorV2.address,
         BigNumber.from('1000000000000000000'), // 1 link > 0.1 min.
         ethers.utils.defaultAbiCoder.encode(['uint64'], [subId]),
       )
       const testKey = [BigNumber.from('1'), BigNumber.from('2')]
-      let kh = await vrfCoordinatorV2.hashOfKey(testKey)
+      const kh = await vrfCoordinatorV2.hashOfKey(testKey)
       const tx = await vrfCoordinatorV2.connect(consumer).requestRandomWords(
         kh, // keyhash
         subId, // subId

--- a/package.json
+++ b/package.json
@@ -1,12 +1,20 @@
 {
   "private": true,
   "license": "MIT",
-  "workspaces": [
-    "contracts",
-    "operator_ui",
-    "tools",
-    "tools/external-adapter"
-  ],
+  "workspaces": {
+    "packages": [
+      "contracts",
+      "operator_ui",
+      "tools",
+      "tools/external-adapter"
+    ],
+    "nohoist": [
+      "**/typechain",
+      "**/typechain/**",
+      "**/@typechain/ethers-v5",
+      "**/@typechain/ethers-v5/**"
+    ]
+  },
   "engines": {
     "node": "^12.0.0"
   },

--- a/tools/ci/solidity_coverage
+++ b/tools/ci/solidity_coverage
@@ -2,4 +2,5 @@
 
 set -e
 
+yarn workspace @chainlink/contracts compile
 yarn workspace @chainlink/contracts coverage

--- a/tools/ci/solidity_test_hardhat
+++ b/tools/ci/solidity_test_hardhat
@@ -2,4 +2,5 @@
 
 set -e
 
+yarn workspace @chainlink/contracts compile
 yarn workspace @chainlink/contracts test

--- a/yarn.lock
+++ b/yarn.lock
@@ -3263,6 +3263,21 @@
   dependencies:
     ethers "^5.0.2"
 
+"@typechain/ethers-v5@^7.0.1":
+  version "7.1.0"
+  resolved "https://registry.npmjs.org/@typechain/ethers-v5/-/ethers-v5-7.1.0.tgz#75593294e8920151c9dbba6cf3e74c6aab2b570f"
+  integrity sha512-zTRwNBtmO0BoOlNi5Q6PKg9OIH5rnJJGAoUC7AnHJpWvWHtlZ9jjbUcCWniKA2dm50zL1ykAh5GqeBp33ju3Qw==
+  dependencies:
+    lodash "^4.17.15"
+    ts-essentials "^7.0.1"
+
+"@typechain/hardhat@^2.0.2":
+  version "2.3.0"
+  resolved "https://registry.npmjs.org/@typechain/hardhat/-/hardhat-2.3.0.tgz#dc7f29281637b38b77c7c046ae82700703395d0f"
+  integrity sha512-zERrtNol86L4DX60ktnXxP7Cq8rSZHPaQvsChyiQQVuvVs2FTLm24Yi+MYnfsIdbUBIXZG7SxDWhtCF5I0tJNQ==
+  dependencies:
+    fs-extra "^9.1.0"
+
 "@types/abstract-leveldown@*":
   version "5.0.1"
   resolved "https://registry.npmjs.org/@types/abstract-leveldown/-/abstract-leveldown-5.0.1.tgz#3c7750d0186b954c7f2d2f6acc8c3c7ba0c3412e"
@@ -4751,6 +4766,11 @@ asynckit@^0.4.0:
   version "0.4.0"
   resolved "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
 
 atob@^2.1.2:
   version "2.1.2"
@@ -9508,6 +9528,16 @@ fs-extra@^8.1.0:
     jsonfile "^4.0.0"
     universalify "^0.1.0"
 
+fs-extra@^9.1.0:
+  version "9.1.0"
+  resolved "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-minipass@^1.2.7:
   version "1.2.7"
   resolved "https://registry.npmjs.org/fs-minipass/-/fs-minipass-1.2.7.tgz#ccff8570841e7fe4265693da88936c55aed7f7c7"
@@ -11763,6 +11793,15 @@ jsonfile@^4.0.0:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonfile@^6.0.1:
+  version "6.1.0"
+  resolved "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"
+  integrity sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
+  dependencies:
+    universalify "^2.0.0"
+  optionalDependencies:
+    graceful-fs "^4.1.6"
+
 jsonify@~0.0.0:
   version "0.0.0"
   resolved "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz#2c74b6ee41d93ca51b7b5aaee8f503631d252a73"
@@ -12741,7 +12780,7 @@ mkdirp-promise@^5.0.1:
   dependencies:
     mkdirp "*"
 
-mkdirp@*, mkdirp@1.x:
+mkdirp@*, mkdirp@1.x, mkdirp@^1.0.4:
   version "1.0.4"
   resolved "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
@@ -16552,6 +16591,11 @@ ts-essentials@^6.0.3:
   resolved "https://registry.npmjs.org/ts-essentials/-/ts-essentials-6.0.7.tgz#5f4880911b7581a873783740ce8b94da163d18a6"
   integrity sha512-2E4HIIj4tQJlIHuATRHayv0EfMGK3ris/GRk1E3CFnsZzeNV+hUmelbaTZHLtXaZppM5oLhHRtO04gINC4Jusw==
 
+ts-essentials@^7.0.1:
+  version "7.0.3"
+  resolved "https://registry.npmjs.org/ts-essentials/-/ts-essentials-7.0.3.tgz#686fd155a02133eedcc5362dc8b5056cde3e5a38"
+  integrity sha512-8+gr5+lqO3G84KdiTSMRLtuyJ+nTBVRKuCrK4lidMPdVeEp0uqC875uE5NMcaA7YYMN7XsNiFQuMvasF8HT/xQ==
+
 ts-generator@^0.1.1:
   version "0.1.1"
   resolved "https://registry.npmjs.org/ts-generator/-/ts-generator-0.1.1.tgz#af46f2fb88a6db1f9785977e9590e7bcd79220ab"
@@ -16726,6 +16770,22 @@ typechain@^3.0.0:
     ts-essentials "^6.0.3"
     ts-generator "^0.1.1"
 
+typechain@^5.0.0:
+  version "5.1.2"
+  resolved "https://registry.npmjs.org/typechain/-/typechain-5.1.2.tgz#c8784d6155a8e69397ca47f438a3b4fb2aa939da"
+  integrity sha512-FuaCxJd7BD3ZAjVJoO+D6TnqKey3pQdsqOBsC83RKYWKli5BDhdf0TPkwfyjt20TUlZvOzJifz+lDwXsRkiSKA==
+  dependencies:
+    "@types/prettier" "^2.1.1"
+    command-line-args "^4.0.7"
+    debug "^4.1.1"
+    fs-extra "^7.0.0"
+    glob "^7.1.6"
+    js-sha3 "^0.8.0"
+    lodash "^4.17.15"
+    mkdirp "^1.0.4"
+    prettier "^2.1.2"
+    ts-essentials "^7.0.1"
+
 typedarray-to-buffer@^3.1.5:
   version "3.1.5"
   resolved "https://registry.npmjs.org/typedarray-to-buffer/-/typedarray-to-buffer-3.1.5.tgz#a97ee7a9ff42691b9f783ff1bc5112fe3fca9080"
@@ -16860,6 +16920,11 @@ universalify@^0.1.0:
   version "0.1.2"
   resolved "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz#b646f69be3942dabcecc9d6639c80dc105efaa66"
   integrity sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==
+
+universalify@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz#75a4984efedc4b08975c5aeb73f530d02df25717"
+  integrity sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
 
 unorm@^1.3.3:
   version "1.6.0"


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/13782/migrate-contract-repos-to-use-typechain

This PR does the following:
* adds typechain support to harhat
* migrates the `KeeperRegistry` test to use typed contract objects
* updates all other tests to ignore typechain contracts and use generic contracts instead (this will allow us to convert the tests one at a time in the future).