### PR TITLE
Handle case of eth_key_states is not already populated on keystore migrate

### DIFF
--- a/core/chains/evm/config/mocks/chain_scoped_config.go
+++ b/core/chains/evm/config/mocks/chain_scoped_config.go
@@ -17,8 +17,6 @@ import (
 
 	gorm "gorm.io/gorm"
 
-	keystore "github.com/smartcontractkit/chainlink/core/services/keystore"
-
 	logger "github.com/smartcontractkit/chainlink/core/logger"
 
 	mock "github.com/stretchr/testify/mock"
@@ -2691,7 +2689,7 @@ func (_m *ChainScopedConfig) P2PNetworkingStackRaw() string {
 }
 
 // P2PPeerID provides a mock function with given fields:
-func (_m *ChainScopedConfig) P2PPeerID() (p2pkey.PeerID, error) {
+func (_m *ChainScopedConfig) P2PPeerID() p2pkey.PeerID {
 	ret := _m.Called()
 
 	var r0 p2pkey.PeerID
@@ -2701,14 +2699,7 @@ func (_m *ChainScopedConfig) P2PPeerID() (p2pkey.PeerID, error) {
 		r0 = ret.Get(0).(p2pkey.PeerID)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
 // P2PPeerIDRaw provides a mock function with given fields:
@@ -2990,11 +2981,6 @@ func (_m *ChainScopedConfig) SetEvmGasPriceDefault(value *big.Int) error {
 	}
 
 	return r0
-}
-
-// SetKeyStore provides a mock function with given fields: _a0
-func (_m *ChainScopedConfig) SetKeyStore(_a0 keystore.Master) {
-	_m.Called(_a0)
 }
 
 // SetLogLevel provides a mock function with given fields: ctx, value

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -87,12 +87,17 @@ func (cli *Client) RunNode(c *clipkg.Context) error {
 		}
 	}
 
-	err = keyStore.Migrate(vrfpwd)
+	chainSet := app.GetChainSet()
+	dflt, err := chainSet.Default()
+	if err != nil {
+		return cli.errorOut(err)
+	}
+	err = keyStore.Migrate(vrfpwd, dflt.ID())
 	if err != nil {
 		return cli.errorOut(errors.Wrap(err, "error migrating keystore"))
 	}
 
-	for _, ch := range app.GetChainSet().Chains() {
+	for _, ch := range chainSet.Chains() {
 		skey, sexisted, fkey, fexisted, err2 := app.GetKeyStore().Eth().EnsureKeys(ch.ID())
 		if err2 != nil {
 			return cli.errorOut(err)

--- a/core/services/feeds/proto/feeds_manager.pb.go
+++ b/core/services/feeds/proto/feeds_manager.pb.go
@@ -7,10 +7,11 @@
 package proto
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/core/services/feeds/proto/feeds_manager_wsrpc.pb.go
+++ b/core/services/feeds/proto/feeds_manager_wsrpc.pb.go
@@ -7,6 +7,7 @@ package proto
 
 import (
 	context "context"
+
 	wsrpc "github.com/smartcontractkit/wsrpc"
 )
 

--- a/core/services/keystore/eth.go
+++ b/core/services/keystore/eth.go
@@ -41,7 +41,7 @@ type Eth interface {
 	GetStatesForKeys([]ethkey.KeyV2) ([]ethkey.State, error)
 	GetStatesForChain(chainID *big.Int) ([]ethkey.State, error)
 
-	GetV1KeysAsV2() ([]ethkey.KeyV2, []ethkey.State, error)
+	GetV1KeysAsV2(chainID *big.Int) ([]ethkey.KeyV2, []ethkey.State, error)
 }
 
 type eth struct {
@@ -356,7 +356,7 @@ func (ks *eth) GetStatesForChain(chainID *big.Int) (states []ethkey.State, err e
 	return
 }
 
-func (ks *eth) GetV1KeysAsV2() (keys []ethkey.KeyV2, states []ethkey.State, _ error) {
+func (ks *eth) GetV1KeysAsV2(chainID *big.Int) (keys []ethkey.KeyV2, states []ethkey.State, _ error) {
 	v1Keys, err := ks.orm.GetEncryptedV1EthKeys()
 	if err != nil {
 		return keys, states, err
@@ -369,9 +369,10 @@ func (ks *eth) GetV1KeysAsV2() (keys []ethkey.KeyV2, states []ethkey.State, _ er
 		keyV2 := ethkey.FromPrivateKey(dKey.PrivateKey)
 		keys = append(keys, keyV2)
 		state := ethkey.State{
-			Address:   keyV1.Address,
-			NextNonce: keyV1.NextNonce,
-			IsFunding: keyV1.IsFunding,
+			Address:    keyV1.Address,
+			NextNonce:  keyV1.NextNonce,
+			IsFunding:  keyV1.IsFunding,
+			EVMChainID: *utils.NewBig(chainID),
 		}
 		states = append(states, state)
 	}

--- a/core/services/keystore/mocks/eth.go
+++ b/core/services/keystore/mocks/eth.go
@@ -302,13 +302,13 @@ func (_m *Eth) GetStatesForKeys(_a0 []ethkey.KeyV2) ([]ethkey.State, error) {
 	return r0, r1
 }
 
-// GetV1KeysAsV2 provides a mock function with given fields:
-func (_m *Eth) GetV1KeysAsV2() ([]ethkey.KeyV2, []ethkey.State, error) {
-	ret := _m.Called()
+// GetV1KeysAsV2 provides a mock function with given fields: chainID
+func (_m *Eth) GetV1KeysAsV2(chainID *big.Int) ([]ethkey.KeyV2, []ethkey.State, error) {
+	ret := _m.Called(chainID)
 
 	var r0 []ethkey.KeyV2
-	if rf, ok := ret.Get(0).(func() []ethkey.KeyV2); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*big.Int) []ethkey.KeyV2); ok {
+		r0 = rf(chainID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]ethkey.KeyV2)
@@ -316,8 +316,8 @@ func (_m *Eth) GetV1KeysAsV2() ([]ethkey.KeyV2, []ethkey.State, error) {
 	}
 
 	var r1 []ethkey.State
-	if rf, ok := ret.Get(1).(func() []ethkey.State); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*big.Int) []ethkey.State); ok {
+		r1 = rf(chainID)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).([]ethkey.State)
@@ -325,8 +325,8 @@ func (_m *Eth) GetV1KeysAsV2() ([]ethkey.KeyV2, []ethkey.State, error) {
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func() error); ok {
-		r2 = rf()
+	if rf, ok := ret.Get(2).(func(*big.Int) error); ok {
+		r2 = rf(chainID)
 	} else {
 		r2 = ret.Error(2)
 	}


### PR DESCRIPTION
The upgrade path of 0.10.14 => 1.0.0 => 1.0.1 will work fine because the
eth_key_states table has already been filled by the keystore migration
software.

But if the user has gone 0.10.14 => 1.0.1 won't work because the
interrim step of populating the eth_key_states has not run, so we need
to make sure we include the default chain ID.