### PR TITLE
Fixes an issue where fetching preloaded jobIDs for a run could fail

### DIFF
--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -429,6 +429,11 @@ func (o *orm) FindJobIDsWithBridge(name string) ([]int32, error) {
 
 // Preload PipelineSpec.JobID for each Run
 func (o *orm) preloadJobIDs(runs []pipeline.Run) error {
+	// Abort early if there are no runs
+	if len(runs) == 0 {
+		return nil
+	}
+
 	db := postgres.UnwrapGormDB(o.db)
 
 	ids := make([]int32, 0, len(runs))


### PR DESCRIPTION
When no run are present, the call to preloadJobIDs would fail with

`empty slice passed to 'in' query`

This commit fixes this by aborting early if no runs are provided