### PR TITLE
ArbitrumValidator.sol - fix withdrawFundsFromL2 msg encoding

### DIFF
--- a/contracts/src/v0.8/dev/ArbitrumValidator.sol
+++ b/contracts/src/v0.8/dev/ArbitrumValidator.sol
@@ -38,7 +38,7 @@ contract ArbitrumValidator is TypeAndVersionInterface, AggregatorValidatorInterf
   address constant ARBSYS_ADDR = address(0x0000000000000000000000000000000000000064);
 
   /// @dev Follows: https://eips.ethereum.org/EIPS/eip-1967
-  address private constant FLAG_ARBITRUM_SEQ_OFFLINE =
+  address public constant FLAG_ARBITRUM_SEQ_OFFLINE =
     address(bytes20(bytes32(uint256(keccak256("chainlink.flags.arbitrum-seq-offline")) - 1)));
   // Encode underlying Flags call/s
   bytes private constant CALL_RAISE_FLAG =
@@ -185,11 +185,11 @@ contract ArbitrumValidator is TypeAndVersionInterface, AggregatorValidatorInterf
    */
   function withdrawFundsFromL2(uint256 amount, address refundAddr) external onlyOwner returns (uint256 id) {
     // Build an xDomain message to trigger the ArbSys precompile, which will create a L2 -> L1 tx transferring `amount`
-    bytes memory message = abi.encodeWithSelector(ArbSys.sendTxToL1.selector, address(this));
+    bytes memory message = abi.encodeWithSelector(ArbSys.withdrawEth.selector, address(this));
     // Make the xDomain call
     // NOTICE: We approximate the max submission cost of sending a retryable tx with specific calldata length.
     uint256 maxSubmissionCost = _approximateMaxSubmissionCost(message.length);
-    uint256 maxGas = 100_000; // static `maxGas` for L2 -> L1 transfer
+    uint256 maxGas = 120_000; // static `maxGas` for L2 -> L1 transfer
     uint256 gasPriceBid = s_gasConfig.gasPriceBid;
     uint256 l1PaymentValue = s_paymentStrategy == PaymentStrategy.L1
       ? _maxRetryableTicketCost(maxSubmissionCost, maxGas, gasPriceBid)

--- a/contracts/src/v0.8/dev/OptimismValidator.sol
+++ b/contracts/src/v0.8/dev/OptimismValidator.sol
@@ -18,7 +18,7 @@ import "./vendor/@eth-optimism/contracts/0.4.7/contracts/optimistic-ethereum/iOV
  */
 contract OptimismValidator is TypeAndVersionInterface, AggregatorValidatorInterface, SimpleWriteAccessController {
   /// @dev Follows: https://eips.ethereum.org/EIPS/eip-1967
-  address private constant FLAG_OPTIMISM_SEQ_OFFLINE =
+  address public constant FLAG_OPTIMISM_SEQ_OFFLINE =
     address(bytes20(bytes32(uint256(keccak256("chainlink.flags.optimism-seq-offline")) - 1)));
   // Encode underlying Flags call/s
   bytes private constant CALL_RAISE_FLAG =


### PR DESCRIPTION
The improper encoding of the xDomain `ArbSys.sendTxToL1` call made the transaction fail on L2.

The bug:

```solidity
bytes memory message = abi.encodeWithSelector(ArbSys.sendTxToL1.selector, address(this));
```

The proper way to do it if using `ArbSys.sendTxToL1` with empty calldata:

```solidity
bytes memory calldataForL1 = abi.encodeWithSelector("");
bytes memory message = abi.encodeWithSelector(ArbSys.sendTxToL1.selector, address(this), calldataForL1);
```

The fix uses a helper fn that does it for us:

```solidity
bytes memory message = abi.encodeWithSelector(ArbSys.withdrawEth.selector, address(this), calldataForL1);
```

Additionally `FLAG_ARBITRUM_SEQ_OFFLINE` & `FLAG_OPTIMISM_SEQ_OFFLINE` constants were made public for convenience.