### PR TITLE
Fix regression where gas estimator would not use current gas price

### DIFF
--- a/core/services/bulletprooftxmanager/eth_confirmer_test.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer_test.go
@@ -1349,7 +1349,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 		// Once for the bumped attempt which exceeds limit
 		ethClient.On("SendTransaction", mock.Anything, mock.MatchedBy(func(tx *types.Transaction) bool {
-			return tx.Nonce() == uint64(*etx.Nonce) && tx.GasPrice().Int64() == int64(25000000000)
+			return tx.Nonce() == uint64(*etx.Nonce) && tx.GasPrice().Int64() == int64(20000000000)
 		})).Return(errors.New("tx fee (1.10 ether) exceeds the configured cap (1.00 ether)")).Once()
 
 		// Do the thing
@@ -1373,7 +1373,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	bulletprooftxmanager.SetEthClientOnEthConfirmer(ethClient, ec)
 
 	t.Run("creates new attempt with higher gas price if transaction has an attempt older than threshold", func(t *testing.T) {
-		expectedBumpedGasPrice := big.NewInt(25000000000)
+		expectedBumpedGasPrice := big.NewInt(20000000000)
 		require.Greater(t, expectedBumpedGasPrice.Int64(), attempt1_1.GasPrice.ToInt().Int64())
 
 		ethTx := *types.NewTx(&types.LegacyTx{})
@@ -1425,7 +1425,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	var attempt1_3 bulletprooftxmanager.EthTxAttempt
 
 	t.Run("creates new attempt with higher gas price if transaction is already in mempool (e.g. due to previous crash before we could save the new attempt)", func(t *testing.T) {
-		expectedBumpedGasPrice := big.NewInt(30000000000)
+		expectedBumpedGasPrice := big.NewInt(25000000000)
 		require.Greater(t, expectedBumpedGasPrice.Int64(), attempt1_2.GasPrice.ToInt().Int64())
 
 		ethTx := *types.NewTx(&types.LegacyTx{})
@@ -1467,7 +1467,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	var attempt1_4 bulletprooftxmanager.EthTxAttempt
 
 	t.Run("saves new attempt even for transaction that has already been confirmed (nonce already used)", func(t *testing.T) {
-		expectedBumpedGasPrice := big.NewInt(36000000000)
+		expectedBumpedGasPrice := big.NewInt(30000000000)
 		require.Greater(t, expectedBumpedGasPrice.Int64(), attempt1_2.GasPrice.ToInt().Int64())
 
 		ethTx := *types.NewTx(&types.LegacyTx{})
@@ -1524,7 +1524,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	var attempt2_2 bulletprooftxmanager.EthTxAttempt
 
 	t.Run("saves in_progress attempt on temporary error and returns error", func(t *testing.T) {
-		expectedBumpedGasPrice := big.NewInt(25000000000)
+		expectedBumpedGasPrice := big.NewInt(20000000000)
 		require.Greater(t, expectedBumpedGasPrice.Int64(), attempt2_1.GasPrice.ToInt().Int64())
 
 		ethTx := *types.NewTx(&types.LegacyTx{})
@@ -1595,7 +1595,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	require.NoError(t, db.Save(&attempt2_2).Error)
 
 	t.Run("assumes that 'nonce too low' error means success", func(t *testing.T) {
-		expectedBumpedGasPrice := big.NewInt(30000000000)
+		expectedBumpedGasPrice := big.NewInt(25000000000)
 		require.Greater(t, expectedBumpedGasPrice.Int64(), attempt2_1.GasPrice.ToInt().Int64())
 
 		ethTx := *types.NewTx(&types.LegacyTx{})
@@ -1932,7 +1932,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WhenOutOfEth(t *testing.T) {
 	t.Run("saves attempt with state 'insufficient_eth' if eth node returns this error", func(t *testing.T) {
 		ec := cltest.NewEthConfirmer(t, db, ethClient, config, ethKeyStore, keyStates, nil)
 
-		expectedBumpedGasPrice := big.NewInt(25000000000)
+		expectedBumpedGasPrice := big.NewInt(20000000000)
 		require.Greater(t, expectedBumpedGasPrice.Int64(), attempt1_1.GasPrice.ToInt().Int64())
 
 		ethClient.On("SendTransaction", mock.Anything, mock.MatchedBy(func(tx *types.Transaction) bool {
@@ -1960,7 +1960,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WhenOutOfEth(t *testing.T) {
 	t.Run("does not bump gas when previous error was 'out of eth', instead resubmits existing transaction", func(t *testing.T) {
 		ec := cltest.NewEthConfirmer(t, db, ethClient, config, ethKeyStore, keyStates, nil)
 
-		expectedBumpedGasPrice := big.NewInt(25000000000)
+		expectedBumpedGasPrice := big.NewInt(20000000000)
 		require.Greater(t, expectedBumpedGasPrice.Int64(), attempt1_1.GasPrice.ToInt().Int64())
 
 		ethClient.On("SendTransaction", mock.Anything, mock.MatchedBy(func(tx *types.Transaction) bool {
@@ -1987,7 +1987,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WhenOutOfEth(t *testing.T) {
 	t.Run("saves the attempt as broadcast after node wallet has been topped up with sufficient balance", func(t *testing.T) {
 		ec := cltest.NewEthConfirmer(t, db, ethClient, config, ethKeyStore, keyStates, nil)
 
-		expectedBumpedGasPrice := big.NewInt(25000000000)
+		expectedBumpedGasPrice := big.NewInt(20000000000)
 		require.Greater(t, expectedBumpedGasPrice.Int64(), attempt1_1.GasPrice.ToInt().Int64())
 
 		ethClient.On("SendTransaction", mock.Anything, mock.MatchedBy(func(tx *types.Transaction) bool {

--- a/core/services/gas/fixed_price_estimator.go
+++ b/core/services/gas/fixed_price_estimator.go
@@ -30,7 +30,7 @@ func (f *fixedPriceEstimator) GetLegacyGas(_ []byte, gasLimit uint64, _ ...Opt) 
 }
 
 func (f *fixedPriceEstimator) BumpLegacyGas(originalGasPrice *big.Int, originalGasLimit uint64) (gasPrice *big.Int, gasLimit uint64, err error) {
-	return BumpLegacyGasPriceOnly(f.config, originalGasPrice, originalGasLimit)
+	return BumpLegacyGasPriceOnly(f.config, f.config.EvmGasPriceDefault(), originalGasPrice, originalGasLimit)
 }
 
 func (f *fixedPriceEstimator) GetDynamicFee(originalGasLimit uint64) (d DynamicFee, chainSpecificGasLimit uint64, err error) {
@@ -46,5 +46,5 @@ func (f *fixedPriceEstimator) GetDynamicFee(originalGasLimit uint64) (d DynamicF
 }
 
 func (f *fixedPriceEstimator) BumpDynamicFee(originalFee DynamicFee, originalGasLimit uint64) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
-	return BumpDynamicFeeOnly(f.config, originalFee, originalGasLimit)
+	return BumpDynamicFeeOnly(f.config, f.config.EvmGasTipCapDefault(), originalFee, originalGasLimit)
 }

--- a/core/services/gas/fixed_price_estimator_test.go
+++ b/core/services/gas/fixed_price_estimator_test.go
@@ -13,7 +13,6 @@ import (
 func Test_FixedPriceEstimator(t *testing.T) {
 	t.Parallel()
 
-	// TODO: Add this test for BlockHistoryEstimator also
 	t.Run("GetLegacyGas returns EvmGasPriceDefault from config, with multiplier applied", func(t *testing.T) {
 		config := new(mocks.Config)
 		f := gas.NewFixedPriceEstimator(config)
@@ -42,7 +41,7 @@ func Test_FixedPriceEstimator(t *testing.T) {
 		gasPrice, gasLimit, err := f.BumpLegacyGas(big.NewInt(42), 100000)
 		require.NoError(t, err)
 
-		expectedGasPrice, expectedGasLimit, err := gas.BumpLegacyGasPriceOnly(config, big.NewInt(42), 100000)
+		expectedGasPrice, expectedGasLimit, err := gas.BumpLegacyGasPriceOnly(config, nil, big.NewInt(42), 100000)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedGasLimit, gasLimit)
@@ -83,7 +82,7 @@ func Test_FixedPriceEstimator(t *testing.T) {
 		fee, gasLimit, err := f.BumpDynamicFee(originalFee, 100000)
 		require.NoError(t, err)
 
-		expectedFee, expectedGasLimit, err := gas.BumpDynamicFeeOnly(config, originalFee, 100000)
+		expectedFee, expectedGasLimit, err := gas.BumpDynamicFeeOnly(config, nil, originalFee, 100000)
 		require.NoError(t, err)
 
 		assert.Equal(t, expectedGasLimit, gasLimit)

--- a/core/services/gas/helpers_test.go
+++ b/core/services/gas/helpers_test.go
@@ -10,14 +10,26 @@ func SetRollingBlockHistory(bhe Estimator, blocks []Block) {
 	bhe.(*BlockHistoryEstimator).rollingBlockHistory = blocks
 }
 
-func GetGasPrice(b *BlockHistoryEstimator) *big.Int {
+func SetGasPrice(b *BlockHistoryEstimator, gp *big.Int) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
+	b.gasPrice = gp
+}
+
+func SetTipCap(b *BlockHistoryEstimator, gp *big.Int) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.tipCap = gp
+}
+
+func GetGasPrice(b *BlockHistoryEstimator) *big.Int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	return b.gasPrice
 }
 
 func GetTipCap(b *BlockHistoryEstimator) *big.Int {
-	b.mu.Lock()
-	defer b.mu.Unlock()
+	b.mu.RLock()
+	defer b.mu.RUnlock()
 	return b.tipCap
 }

--- a/core/services/gas/models.go
+++ b/core/services/gas/models.go
@@ -237,8 +237,8 @@ func (t *Transaction) UnmarshalJSON(data []byte) error {
 }
 
 // BumpLegacyGasPriceOnly will increase the price and apply multiplier to the gas limit
-func BumpLegacyGasPriceOnly(config Config, originalGasPrice *big.Int, originalGasLimit uint64) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
-	gasPrice, err = bumpGasPrice(config, originalGasPrice)
+func BumpLegacyGasPriceOnly(config Config, currentGasPrice, originalGasPrice *big.Int, originalGasLimit uint64) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
+	gasPrice, err = bumpGasPrice(config, currentGasPrice, originalGasPrice)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -250,18 +250,25 @@ func BumpLegacyGasPriceOnly(config Config, originalGasPrice *big.Int, originalGa
 // - A configured percentage bump (ETH_GAS_BUMP_PERCENT) on top of the baseline price.
 // - A configured fixed amount of Wei (ETH_GAS_PRICE_WEI) on top of the baseline price.
 // The baseline price is the maximum of the previous gas price attempt and the node's current gas price.
-func bumpGasPrice(config Config, originalGasPrice *big.Int) (*big.Int, error) {
+func bumpGasPrice(config Config, currentGasPrice, originalGasPrice *big.Int) (*big.Int, error) {
 	maxGasPrice := config.EvmMaxGasPriceWei()
-	baselinePrice := max(originalGasPrice, config.EvmGasPriceDefault())
 
 	var priceByPercentage = new(big.Int)
-	priceByPercentage.Mul(baselinePrice, big.NewInt(int64(100+config.EvmGasBumpPercent())))
+	priceByPercentage.Mul(originalGasPrice, big.NewInt(int64(100+config.EvmGasBumpPercent())))
 	priceByPercentage.Div(priceByPercentage, big.NewInt(100))
 
 	var priceByIncrement = new(big.Int)
-	priceByIncrement.Add(baselinePrice, config.EvmGasBumpWei())
+	priceByIncrement.Add(originalGasPrice, config.EvmGasBumpWei())
 
 	bumpedGasPrice := max(priceByPercentage, priceByIncrement)
+	if currentGasPrice != nil {
+		if currentGasPrice.Cmp(maxGasPrice) > 0 {
+			logger.Errorf("invariant violation: ignoring current gas price of %s that would exceed max gas price of %s", currentGasPrice.String(), maxGasPrice.String())
+		} else if bumpedGasPrice.Cmp(currentGasPrice) < 0 {
+			// If the current gas price is higher than the old price bumped, use that instead
+			bumpedGasPrice = currentGasPrice
+		}
+	}
 	if bumpedGasPrice.Cmp(maxGasPrice) > 0 {
 		return maxGasPrice, errors.Wrapf(ErrBumpGasExceedsLimit, "bumped gas price of %s would exceed configured max gas price of %s (original price was %s). %s",
 			bumpedGasPrice.String(), maxGasPrice, originalGasPrice.String(), static.EthNodeConnectivityProblemLabel)
@@ -284,8 +291,8 @@ func max(a, b *big.Int) *big.Int {
 }
 
 // BumpDynamicFeeOnly bumps the tip cap and max gas price if necessary
-func BumpDynamicFeeOnly(config Config, originalFee DynamicFee, originalGasLimit uint64) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
-	bumped, err = bumpDynamicFee(config, originalFee)
+func BumpDynamicFeeOnly(config Config, currentTipCap *big.Int, originalFee DynamicFee, originalGasLimit uint64) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
+	bumped, err = bumpDynamicFee(config, currentTipCap, originalFee)
 	if err != nil {
 		return bumped, 0, err
 	}
@@ -298,7 +305,7 @@ func BumpDynamicFeeOnly(config Config, originalFee DynamicFee, originalGasLimit 
 // - A configured fixed amount of Wei (ETH_GAS_PRICE_WEI) on top of the baseline tip cap.
 // The baseline tip cap is the maximum of the previous tip cap attempt and the node's current tip cap.
 // It increases the max fee cap if it changed
-func bumpDynamicFee(config Config, originalFee DynamicFee) (bumpedFee DynamicFee, err error) {
+func bumpDynamicFee(config Config, currentTipCap *big.Int, originalFee DynamicFee) (bumpedFee DynamicFee, err error) {
 	maxGasPrice := config.EvmMaxGasPriceWei()
 	baselineTipCap := max(originalFee.TipCap, config.EvmGasTipCapDefault())
 
@@ -310,6 +317,14 @@ func bumpDynamicFee(config Config, originalFee DynamicFee) (bumpedFee DynamicFee
 	tipCapByIncrement.Add(baselineTipCap, config.EvmGasBumpWei())
 
 	bumpedTipCap := max(tipCapByPercentage, tipCapByIncrement)
+	if currentTipCap != nil {
+		if currentTipCap.Cmp(maxGasPrice) > 0 {
+			logger.Errorf("invariant violation: ignoring current tip cap of %s that would exceed max gas price of %s", currentTipCap.String(), maxGasPrice.String())
+		} else if bumpedTipCap.Cmp(currentTipCap) < 0 {
+			// If the current gas tip cap is higher than the old tip cap with bump applied, use that instead
+			bumpedTipCap = currentTipCap
+		}
+	}
 	if bumpedTipCap.Cmp(maxGasPrice) > 0 {
 		return bumpedFee, errors.Wrapf(ErrBumpGasExceedsLimit, "bumped tip cap of %s would exceed configured max gas price of %s (original fee: tip cap %s, fee cap %s). %s",
 			bumpedTipCap.String(), maxGasPrice, originalFee.TipCap.String(), originalFee.FeeCap.String(), static.EthNodeConnectivityProblemLabel)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -107,6 +107,10 @@ This only applies to EAs using the `X-Chainlink-Pending` header to signal that t
 
 - `belt/` and `evm-test-helpers/` removed from the codebase.
 
+### Fixed
+
+Fixed a regression whereby the BlockHistoryEstimator would use a bumped value on old gas price even if the new current price was larger than the bumped value.
+
 ## [v1.0.0]
 
 


### PR DESCRIPTION
Accidentally introduced a regression in
9303d55162297c1124a637d121b173244a7d19e8 with the refactor of gas
estimator to support Optimism.

We used to bump on top of the latest price if that was larger. This was
inadvertatently broken so that bumping no longer uses current gas price
from the block history estimator if it's larger.

This commit reintroduces logic such that if the current price is larger
than the bumped price, the current price will be used instead. This
should help make Chainlink more responsive and save a big of gas under
very steep spikes.