### PR TITLE
Touch up operator contract

### DIFF
--- a/contracts/src/v0.7/AuthorizedForwarder.sol
+++ b/contracts/src/v0.7/AuthorizedForwarder.sol
@@ -26,6 +26,14 @@ contract AuthorizedForwarder is ConfirmedOwnerWithProposal, AuthorizedReceiver {
   }
 
   /**
+   * @notice The type and version of this contract
+   * @return Type and version string
+   */
+  function typeAndVersion() external pure virtual returns (string memory) {
+    return "AuthorizedForwarder 1.0.0";
+  }
+
+  /**
    * @notice Forward a call to another contract
    * @dev Only callable by an authorized sender
    * @param to address

--- a/contracts/src/v0.7/Operator.sol
+++ b/contracts/src/v0.7/Operator.sol
@@ -75,6 +75,14 @@ contract Operator is AuthorizedReceiver, ConfirmedOwner, LinkTokenReceiver, Oper
   }
 
   /**
+   * @notice The type and version of this contract
+   * @return Type and version string
+   */
+  function typeAndVersion() external pure virtual returns (string memory) {
+    return "Operator 1.0.0";
+  }
+
+  /**
    * @notice Creates the Chainlink request. This is a backwards compatible API
    * with the Oracle.sol contract, but the behavior changes because
    * callbackAddress is assumed to be the same as the request sender.

--- a/contracts/src/v0.7/Operator.sol
+++ b/contracts/src/v0.7/Operator.sol
@@ -226,8 +226,8 @@ contract Operator is AuthorizedReceiver, ConfirmedOwner, LinkTokenReceiver, Oper
    */
   function transferOwnableContracts(address[] calldata ownable, address newOwner) external onlyOwner {
     for (uint256 i = 0; i < ownable.length; i++) {
-      OwnableInterface(ownable[i]).transferOwnership(newOwner);
       s_owned[ownable[i]] = false;
+      OwnableInterface(ownable[i]).transferOwnership(newOwner);
     }
   }
 
@@ -240,9 +240,9 @@ contract Operator is AuthorizedReceiver, ConfirmedOwner, LinkTokenReceiver, Oper
    */
   function acceptOwnableContracts(address[] calldata ownable) public validateAuthorizedSenderSetter {
     for (uint256 i = 0; i < ownable.length; i++) {
-      OwnableInterface(ownable[i]).acceptOwnership();
       s_owned[ownable[i]] = true;
       emit OwnableContractAccepted(ownable[i]);
+      OwnableInterface(ownable[i]).acceptOwnership();
     }
   }
 

--- a/contracts/src/v0.7/OperatorFactory.sol
+++ b/contracts/src/v0.7/OperatorFactory.sol
@@ -23,6 +23,14 @@ contract OperatorFactory {
   }
 
   /**
+   * @notice The type and version of this contract
+   * @return Type and version string
+   */
+  function typeAndVersion() external pure virtual returns (string memory) {
+    return "OperatorFactory 1.0.0";
+  }
+
+  /**
    * @notice creates a new Operator contract with the msg.sender as owner
    */
   function deployNewOperator() external returns (address) {

--- a/contracts/test/v0.7/AuthorizedForwarder.test.ts
+++ b/contracts/test/v0.7/AuthorizedForwarder.test.ts
@@ -55,11 +55,21 @@ describe('AuthorizedForwarder', () => {
       'ownerForward',
       'setAuthorizedSenders',
       'transferOwnershipWithMessage',
+      'typeAndVersion',
       // ConfirmedOwner
       'transferOwnership',
       'acceptOwnership',
       'owner',
     ])
+  })
+
+  describe('#typeAndVersion', () => {
+    it('describes the authorized forwarder', async () => {
+      assert.equal(
+        await forwarder.typeAndVersion(),
+        'AuthorizedForwarder 1.0.0',
+      )
+    })
   })
 
   describe('deployment', () => {

--- a/contracts/test/v0.7/Operator.test.ts
+++ b/contracts/test/v0.7/Operator.test.ts
@@ -229,21 +229,21 @@ describe('Operator', () => {
       })
 
       it('emits ownership transferred events', async () => {
-        assert.equal(receipt?.events?.[0]?.event, 'OwnershipTransferred')
-        assert.equal(receipt?.events?.[0]?.address, forwarder1.address)
-        assert.equal(receipt?.events?.[0]?.args?.[0], operator.address)
-        assert.equal(receipt?.events?.[0]?.args?.[1], operator2.address)
+        assert.equal(receipt?.events?.[0]?.event, 'OwnableContractAccepted')
+        assert.equal(receipt?.events?.[0]?.args?.[0], forwarder1.address)
 
-        assert.equal(receipt?.events?.[1]?.event, 'OwnableContractAccepted')
-        assert.equal(receipt?.events?.[1]?.args?.[0], forwarder1.address)
+        assert.equal(receipt?.events?.[1]?.event, 'OwnershipTransferred')
+        assert.equal(receipt?.events?.[1]?.address, forwarder1.address)
+        assert.equal(receipt?.events?.[1]?.args?.[0], operator.address)
+        assert.equal(receipt?.events?.[1]?.args?.[1], operator2.address)
 
-        assert.equal(receipt?.events?.[2]?.event, 'OwnershipTransferred')
-        assert.equal(receipt?.events?.[2]?.address, forwarder2.address)
-        assert.equal(receipt?.events?.[2]?.args?.[0], operator.address)
-        assert.equal(receipt?.events?.[2]?.args?.[1], operator2.address)
+        assert.equal(receipt?.events?.[2]?.event, 'OwnableContractAccepted')
+        assert.equal(receipt?.events?.[2]?.args?.[0], forwarder2.address)
 
-        assert.equal(receipt?.events?.[3]?.event, 'OwnableContractAccepted')
-        assert.equal(receipt?.events?.[3]?.args?.[0], forwarder2.address)
+        assert.equal(receipt?.events?.[3]?.event, 'OwnershipTransferred')
+        assert.equal(receipt?.events?.[3]?.address, forwarder2.address)
+        assert.equal(receipt?.events?.[3]?.args?.[0], operator.address)
+        assert.equal(receipt?.events?.[3]?.args?.[1], operator2.address)
       })
     })
 
@@ -610,21 +610,21 @@ describe('Operator', () => {
       })
 
       it('emits ownership transferred events', async () => {
-        assert.equal(receipt?.events?.[0]?.event, 'OwnershipTransferred')
-        assert.equal(receipt?.events?.[0]?.address, forwarder1.address)
-        assert.equal(receipt?.events?.[0]?.args?.[0], operator.address)
-        assert.equal(receipt?.events?.[0]?.args?.[1], operator2.address)
+        assert.equal(receipt?.events?.[0]?.event, 'OwnableContractAccepted')
+        assert.equal(receipt?.events?.[0]?.args?.[0], forwarder1.address)
 
-        assert.equal(receipt?.events?.[1]?.event, 'OwnableContractAccepted')
-        assert.equal(receipt?.events?.[1]?.args?.[0], forwarder1.address)
+        assert.equal(receipt?.events?.[1]?.event, 'OwnershipTransferred')
+        assert.equal(receipt?.events?.[1]?.address, forwarder1.address)
+        assert.equal(receipt?.events?.[1]?.args?.[0], operator.address)
+        assert.equal(receipt?.events?.[1]?.args?.[1], operator2.address)
 
-        assert.equal(receipt?.events?.[2]?.event, 'OwnershipTransferred')
-        assert.equal(receipt?.events?.[2]?.address, forwarder2.address)
-        assert.equal(receipt?.events?.[2]?.args?.[0], operator.address)
-        assert.equal(receipt?.events?.[2]?.args?.[1], operator2.address)
+        assert.equal(receipt?.events?.[2]?.event, 'OwnableContractAccepted')
+        assert.equal(receipt?.events?.[2]?.args?.[0], forwarder2.address)
 
-        assert.equal(receipt?.events?.[3]?.event, 'OwnableContractAccepted')
-        assert.equal(receipt?.events?.[3]?.args?.[0], forwarder2.address)
+        assert.equal(receipt?.events?.[3]?.event, 'OwnershipTransferred')
+        assert.equal(receipt?.events?.[3]?.address, forwarder2.address)
+        assert.equal(receipt?.events?.[3]?.args?.[0], operator.address)
+        assert.equal(receipt?.events?.[3]?.args?.[1], operator2.address)
 
         assert.equal(
           receipt?.events?.[4]?.event,

--- a/contracts/test/v0.7/Operator.test.ts
+++ b/contracts/test/v0.7/Operator.test.ts
@@ -131,6 +131,7 @@ describe('Operator', () => {
       'setAuthorizedSenders',
       'setAuthorizedSendersOn',
       'transferOwnableContracts',
+      'typeAndVersion',
       'withdraw',
       'withdrawable',
       // Ownable methods:
@@ -138,6 +139,12 @@ describe('Operator', () => {
       'owner',
       'transferOwnership',
     ])
+  })
+
+  describe('#typeAndVersion', () => {
+    it('describes the operator', async () => {
+      assert.equal(await operator.typeAndVersion(), 'Operator 1.0.0')
+    })
   })
 
   describe('#transferOwnableContracts', () => {

--- a/contracts/test/v0.7/OperatorFactory.test.ts
+++ b/contracts/test/v0.7/OperatorFactory.test.ts
@@ -57,7 +57,17 @@ describe('OperatorFactory', () => {
       'deployNewForwarder',
       'deployNewForwarderAndTransferOwnership',
       'getChainlinkToken',
+      'typeAndVersion',
     ])
+  })
+
+  describe('#typeAndVersion', () => {
+    it('describes the authorized forwarder', async () => {
+      assert.equal(
+        await operatorGenerator.typeAndVersion(),
+        'OperatorFactory 1.0.0',
+      )
+    })
   })
 
   describe('#deployNewOperator', () => {


### PR DESCRIPTION
- Follows CEI pattern where it was not being followed
- Adds `typeAndVersion` method to Operator, AuthorizedForwarder, and OperatorFactory