### PR TITLE
Named Loggers

### DIFF
--- a/core/chains/evm/chain.go
+++ b/core/chains/evm/chain.go
@@ -91,7 +91,7 @@ func newChain(dbchain types.Chain, opts ChainSetOpts) (*chain, error) {
 	if cfg.EthereumDisabled() {
 		headTracker = &headtracker.NullTracker{}
 	} else if opts.GenHeadTracker == nil {
-		headTrackerLogger, err2 := l.NewServiceLevelLogger(logger.HeadTracker, headTrackerLL)
+		headTrackerLogger, err2 := l.NamedLevel(logger.HeadTracker, headTrackerLL)
 		if err2 != nil {
 			return nil, errors.Wrapf(err2, "failed to instantiate head tracker for chain with ID %s", dbchain.ID.String())
 		}

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -156,7 +156,7 @@ func (cli *Client) RunNode(c *clipkg.Context) error {
 }
 
 func loggedStop(app chainlink.Application) {
-	logger.WarnIf(app.Stop())
+	logger.WarnIf(app.Stop(), "Error stopping app")
 }
 
 func checkFilePermissions(rootDir string) error {

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -49,18 +49,20 @@ const ownerPermsMask = os.FileMode(0700)
 // RunNode starts the Chainlink core.
 func (cli *Client) RunNode(c *clipkg.Context) error {
 	logger.SetLogger(cli.Config.CreateProductionLogger())
+	lggr := logger.Default.Named("boot")
 
 	err := cli.Config.Validate()
 	if err != nil {
 		return cli.errorOut(err)
 	}
 
-	logger.Infow(fmt.Sprintf("Starting Chainlink Node %s at commit %s", static.Version, static.Sha), "id", "boot", "Version", static.Version, "SHA", static.Sha, "InstanceUUID", static.InstanceUUID)
+	lggr.Infow(fmt.Sprintf("Starting Chainlink Node %s at commit %s", static.Version, static.Sha), "Version", static.Version, "SHA", static.Sha, "InstanceUUID", static.InstanceUUID)
+
 	if cli.Config.Dev() {
-		logger.Warn("Chainlink is running in DEVELOPMENT mode. This is a security risk if enabled in production.")
+		lggr.Warn("Chainlink is running in DEVELOPMENT mode. This is a security risk if enabled in production.")
 	}
 	if cli.Config.EthereumDisabled() {
-		logger.Warn("Ethereum is disabled. Chainlink will only run services that can operate without an ethereum connection")
+		lggr.Warn("Ethereum is disabled. Chainlink will only run services that can operate without an ethereum connection")
 	}
 
 	app, err := cli.AppFactory.NewApplication(cli.Config)
@@ -102,10 +104,10 @@ func (cli *Client) RunNode(c *clipkg.Context) error {
 			return cli.errorOut(err)
 		}
 		if !fexisted {
-			logger.Infow("New funding address created", "address", fkey.Address.Hex(), "evmChainID", ch.ID())
+			lggr.Infow("New funding address created", "address", fkey.Address.Hex(), "evmChainID", ch.ID())
 		}
 		if !sexisted {
-			logger.Infow("New sending address created", "address", skey.Address.Hex(), "evmChainID", ch.ID())
+			lggr.Infow("New sending address created", "address", skey.Address.Hex(), "evmChainID", ch.ID())
 		}
 	}
 
@@ -114,18 +116,18 @@ func (cli *Client) RunNode(c *clipkg.Context) error {
 		return cli.errorOut(errors.Wrap(err, "failed to ensure ocr key"))
 	}
 	if !didExist {
-		logger.Infof("Created OCR key with ID %s", ocrKey.ID())
+		lggr.Infof("Created OCR key with ID %s", ocrKey.ID())
 	}
 	p2pKey, didExist, err := app.GetKeyStore().P2P().EnsureKey()
 	if err != nil {
 		return cli.errorOut(errors.Wrap(err, "failed to ensure p2p key"))
 	}
 	if !didExist {
-		logger.Infof("Created P2P key with ID %s", p2pKey.ID())
+		lggr.Infof("Created P2P key with ID %s", p2pKey.ID())
 	}
 
 	if e := checkFilePermissions(cli.Config.RootDir()); e != nil {
-		logger.Warn(e)
+		lggr.Warn(e)
 	}
 
 	var user sessions.User
@@ -139,7 +141,7 @@ func (cli *Client) RunNode(c *clipkg.Context) error {
 		return cli.errorOut(fmt.Errorf("error creating fallback initializer: %+v", err))
 	}
 
-	logger.Info("API exposed for user ", user.Email)
+	lggr.Info("API exposed for user ", user.Email)
 	if e := app.Start(); e != nil {
 		return cli.errorOut(fmt.Errorf("error starting app: %+v", e))
 	}
@@ -149,7 +151,7 @@ func (cli *Client) RunNode(c *clipkg.Context) error {
 		return cli.errorOut(err)
 	}
 
-	logger.Infof("Chainlink booted in %s", time.Since(static.InitTime))
+	lggr.Infof("Chainlink booted in %s", time.Since(static.InitTime))
 	return cli.errorOut(cli.Runner.Run(app))
 }
 

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -69,7 +69,7 @@ func startNewApplication(t *testing.T, setup ...func(opts *startOptions)) *cltes
 		sopts.SetConfig(config)
 	}
 
-	l := config.CreateProductionLogger().With("testname", t.Name())
+	l := config.CreateProductionLogger().Named(t.Name())
 	sopts.FlagsAndDeps = append(sopts.FlagsAndDeps, l)
 	app := cltest.NewApplicationWithConfigAndKey(t, config, sopts.FlagsAndDeps...)
 

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -69,10 +69,7 @@ func startNewApplication(t *testing.T, setup ...func(opts *startOptions)) *cltes
 		sopts.SetConfig(config)
 	}
 
-	l := config.CreateProductionLogger().Named(t.Name())
-	sopts.FlagsAndDeps = append(sopts.FlagsAndDeps, l)
 	app := cltest.NewApplicationWithConfigAndKey(t, config, sopts.FlagsAndDeps...)
-
 	require.NoError(t, app.Start())
 
 	return app

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -376,7 +376,7 @@ func NewApplicationWithConfig(t testing.TB, cfg *configtest.TestGeneralConfig, f
 		}
 	}
 	if lggr == nil {
-		lggr = cfg.CreateProductionLogger()
+		lggr = cfg.CreateProductionLogger().Named(t.Name())
 	}
 	cfg.SetDB(db)
 	if chainORM == nil {

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -232,7 +232,7 @@ func NewWSServer(msg string, callback func(data []byte)) (*httptest.Server, stri
 
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		conn, err := upgrader.Upgrade(w, r, nil)
-		logger.PanicIf(err)
+		logger.PanicIf(err, "Failed to upgrade WS connection")
 		for {
 			_, data, err := conn.ReadMessage()
 			if err != nil {
@@ -252,7 +252,7 @@ func NewWSServer(msg string, callback func(data []byte)) (*httptest.Server, stri
 	server := httptest.NewServer(handler)
 
 	u, err := url.Parse(server.URL)
-	logger.PanicIf(err)
+	logger.PanicIf(err, "Failed to parse url")
 	u.Scheme = "ws"
 
 	return server, u.String(), func() {

--- a/core/internal/testutils/evmtest/evmtest.go
+++ b/core/internal/testutils/evmtest/evmtest.go
@@ -33,7 +33,6 @@ type TestChainOpts struct {
 	DB             *gorm.DB
 	TxManager      bulletprooftxmanager.TxManager
 	KeyStore       keystore.Eth
-	Logger         logger.Logger
 }
 
 func NewChainScopedConfig(t testing.TB, cfg config.GeneralConfig) evmconfig.ChainScopedConfig {
@@ -71,12 +70,10 @@ func NewChainSet(t testing.TB, testopts TestChainOpts) evm.ChainSet {
 		}
 
 	}
-	if testopts.Logger != nil {
-		opts.Logger = testopts.Logger
-	} else if opts.Config != nil {
-		opts.Logger = opts.Config.CreateProductionLogger()
+	if opts.Config != nil {
+		opts.Logger = opts.Config.CreateProductionLogger().Named(t.Name())
 	} else {
-		opts.Logger = logger.Default
+		opts.Logger = logger.Default.Named(t.Name())
 	}
 
 	opts.Config = testopts.GeneralConfig

--- a/core/logger/default.go
+++ b/core/logger/default.go
@@ -133,8 +133,8 @@ func Error(args ...interface{}) {
 	skipDefault.Error(args...)
 }
 
-func WarnIf(err error) {
-	skipDefault.WarnIf(err)
+func WarnIf(err error, msg string) {
+	skipDefault.WarnIf(err, msg)
 }
 
 func ErrorIf(err error, optionalMsg ...string) {
@@ -171,8 +171,8 @@ func Panic(args ...interface{}) {
 }
 
 // PanicIf logs the error if present.
-func PanicIf(err error) {
-	skipDefault.PanicIf(err)
+func PanicIf(err error, msg string) {
+	skipDefault.PanicIf(err, msg)
 }
 
 // Sync flushes any buffered log entries.

--- a/core/logger/default.go
+++ b/core/logger/default.go
@@ -12,7 +12,8 @@ import (
 var (
 	// Default logger for use throughout the project.
 	// All the package-level functions are calling Default.
-	Default Logger
+	Default     Logger
+	skipDefault Logger // Default.withCallerSkip(1) for helper funcs
 )
 
 func init() {
@@ -52,125 +53,126 @@ func SetLogger(newLogger Logger) {
 		}(Default)
 	}
 	Default = newLogger
+	skipDefault = Default.withCallerSkip(1)
 }
 
 // Infow logs an info message and any additional given information.
 func Infow(msg string, keysAndValues ...interface{}) {
-	Default.Infow(msg, keysAndValues...)
+	skipDefault.Infow(msg, keysAndValues...)
 }
 
 // Debugw logs a debug message and any additional given information.
 func Debugw(msg string, keysAndValues ...interface{}) {
-	Default.Debugw(msg, keysAndValues...)
+	skipDefault.Debugw(msg, keysAndValues...)
 }
 
 // Warnw logs a debug message and any additional given information.
 func Warnw(msg string, keysAndValues ...interface{}) {
-	Default.Warnw(msg, keysAndValues...)
+	skipDefault.Warnw(msg, keysAndValues...)
 }
 
 // Errorw logs an error message, any additional given information, and includes
 // stack trace.
 func Errorw(msg string, keysAndValues ...interface{}) {
-	Default.Errorw(msg, keysAndValues...)
+	skipDefault.Errorw(msg, keysAndValues...)
 }
 
 // Logs and returns a new error
 func NewErrorw(msg string, keysAndValues ...interface{}) error {
-	Default.Errorw(msg, keysAndValues...)
+	skipDefault.Errorw(msg, keysAndValues...)
 	return errors.New(msg)
 }
 
 // Infof formats and then logs the message.
 func Infof(format string, values ...interface{}) {
-	Default.Infof(format, values...)
+	skipDefault.Infof(format, values...)
 }
 
 // Debugf formats and then logs the message.
 func Debugf(format string, values ...interface{}) {
-	Default.Debugf(format, values...)
+	skipDefault.Debugf(format, values...)
 }
 
 // Tracef is a shim stand-in for when we have real trace-level logging support
 func Tracef(format string, values ...interface{}) {
-	Default.Debug("TRACE: " + fmt.Sprintf(format, values...))
+	skipDefault.Debug("TRACE: " + fmt.Sprintf(format, values...))
 }
 
 // Warnf formats and then logs the message as Warn.
 func Warnf(format string, values ...interface{}) {
-	Default.Warnf(format, values...)
+	skipDefault.Warnf(format, values...)
 }
 
 // Panicf formats and then logs the message before panicking.
 func Panicf(format string, values ...interface{}) {
-	Default.Panic(fmt.Sprintf(format, values...))
+	skipDefault.Panic(fmt.Sprintf(format, values...))
 }
 
 // Info logs an info message.
 func Info(args ...interface{}) {
-	Default.Info(args...)
+	skipDefault.Info(args...)
 }
 
 // Debug logs a debug message.
 func Debug(args ...interface{}) {
-	Default.Debug(args...)
+	skipDefault.Debug(args...)
 }
 
 // Trace is a shim stand-in for when we have real trace-level logging support
 func Trace(args ...interface{}) {
-	Default.Debug(append([]interface{}{"TRACE: "}, args...))
+	skipDefault.Debug(append([]interface{}{"TRACE: "}, args...))
 }
 
 // Warn logs a message at the warn level.
 func Warn(args ...interface{}) {
-	Default.Warn(args...)
+	skipDefault.Warn(args...)
 }
 
 // Error logs an error message.
 func Error(args ...interface{}) {
-	Default.Error(args...)
+	skipDefault.Error(args...)
 }
 
 func WarnIf(err error) {
-	Default.WarnIf(err)
+	skipDefault.WarnIf(err)
 }
 
 func ErrorIf(err error, optionalMsg ...string) {
-	Default.ErrorIf(err, optionalMsg...)
+	skipDefault.ErrorIf(err, optionalMsg...)
 }
 
-func ErrorIfCalling(f func() error, optionalMsg ...string) {
-	Default.ErrorIfCalling(f, optionalMsg...)
+func ErrorIfCalling(f func() error) {
+	skipDefault.ErrorIfCalling(f)
 }
 
 // Fatal logs a fatal message then exits the application.
 func Fatal(args ...interface{}) {
-	Default.Fatal(args...)
+	skipDefault.Fatal(args...)
 }
 
 // Errorf logs a message at the error level using Sprintf.
 func Errorf(format string, values ...interface{}) {
-	Error(fmt.Sprintf(format, values...))
+	skipDefault.Error(fmt.Sprintf(format, values...))
 }
 
 // Fatalf logs a message at the fatal level using Sprintf.
 func Fatalf(format string, values ...interface{}) {
-	Fatal(fmt.Sprintf(format, values...))
+	skipDefault.Fatal(fmt.Sprintf(format, values...))
 }
 
 // Fatalw logs a message and exits the application
 func Fatalw(msg string, keysAndValues ...interface{}) {
-	Default.Fatalw(msg, keysAndValues...)
+	skipDefault.Fatalw(msg, keysAndValues...)
 }
 
 // Panic logs a panic message then panics.
 func Panic(args ...interface{}) {
-	Default.Panic(args...)
+	skipDefault.Panic(args...)
 }
 
 // PanicIf logs the error if present.
 func PanicIf(err error) {
-	Default.PanicIf(err)
+	skipDefault.PanicIf(err)
 }
 
 // Sync flushes any buffered log entries.

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -17,11 +17,11 @@ import (
 type Logger interface {
 	// With creates a new logger with the given arguments
 	With(args ...interface{}) Logger
-	// Named creates a new logger sub-scoped for id.
+	// Named creates a new logger sub-scoped with name.
 	// Names are inherited and dot-separated.
-	//   a := l.Named("a") // id=a logger=a
-	//   b := a.Named("b") // id=b logger=a.b
-	Named(id string) Logger
+	//   a := l.Named("a") // logger=a
+	//   b := a.Named("b") // logger=a.b
+	Named(name string) Logger
 	// NamedLevel creates a new Named logger with logLevel.
 	NamedLevel(id string, logLevel string) (Logger, error)
 
@@ -114,11 +114,10 @@ func joinName(old, new string) string {
 	return old + "." + new
 }
 
-func (l *zapLogger) Named(id string) Logger {
+func (l *zapLogger) Named(name string) Logger {
 	newLogger := *l
-	newLogger.name = joinName(l.name, id)
-	newLogger.SugaredLogger = l.SugaredLogger.Named(id).With("id", id)
-	newLogger.fields = copyFields(l.fields, "id", id)
+	newLogger.name = joinName(l.name, name)
+	newLogger.SugaredLogger = l.SugaredLogger.Named(name)
 	return &newLogger
 }
 
@@ -188,7 +187,7 @@ func CreateProductionLogger(dir string, jsonConsole bool, lvl zapcore.Level, toD
 	}
 }
 
-func (l *zapLogger) NamedLevel(id string, logLevel string) (Logger, error) {
+func (l *zapLogger) NamedLevel(name string, logLevel string) (Logger, error) {
 	var ll zapcore.Level
 	if err := ll.UnmarshalText([]byte(logLevel)); err != nil {
 		return nil, err
@@ -200,8 +199,7 @@ func (l *zapLogger) NamedLevel(id string, logLevel string) (Logger, error) {
 	}
 
 	newLogger := *l
-	newLogger.name = joinName(l.name, id)
-	newLogger.fields = copyFields(l.fields, "id", id)
-	newLogger.SugaredLogger = zl.Named(newLogger.name).Sugar().With(newLogger.fields...)
+	newLogger.name = joinName(l.name, name)
+	newLogger.SugaredLogger = zl.Named(newLogger.name).Sugar().With(l.fields...)
 	return &newLogger, nil
 }

--- a/core/logger/ocr_wrapper.go
+++ b/core/logger/ocr_wrapper.go
@@ -14,7 +14,7 @@ type ocrWrapper struct {
 
 func NewOCRWrapper(l Logger, trace bool, saveError func(string)) ocrtypes.Logger {
 	return &ocrWrapper{
-		internal:  l.withCallerSkip(1),
+		internal:  l.withCallerSkip(2),
 		trace:     trace,
 		saveError: saveError,
 	}

--- a/core/logger/test_logger.go
+++ b/core/logger/test_logger.go
@@ -65,7 +65,7 @@ func CreateTestLogger(lvl zapcore.Level) Logger {
 	config := zap.NewProductionConfig()
 	config.Level.SetLevel(lvl)
 	config.OutputPaths = []string{"pretty://console", "memory://"}
-	zl, err := config.Build(zap.AddCallerSkip(1))
+	zl, err := config.Build()
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -80,7 +80,7 @@ func CreateMemoryTestLogger(lvl zapcore.Level) Logger {
 	config := zap.NewProductionConfig()
 	config.Level.SetLevel(lvl)
 	config.OutputPaths = []string{"memory://"}
-	zl, err := config.Build(zap.AddCallerSkip(1))
+	zl, err := config.Build()
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/core/main.go
+++ b/core/main.go
@@ -17,7 +17,7 @@ func main() {
 // Run runs the CLI, providing further command instructions by default.
 func Run(client *cmd.Client, args ...string) {
 	app := cmd.NewApp(client)
-	logger.WarnIf(app.Run(args))
+	logger.WarnIf(app.Run(args), "Error running app")
 }
 
 // NewProductionClient configures an instance of the CLI to be used

--- a/core/services/balance_monitor.go
+++ b/core/services/balance_monitor.go
@@ -111,20 +111,18 @@ func (bm *balanceMonitor) updateBalance(ethBal assets.Eth, address gethCommon.Ad
 	bm.ethBalances[address] = &ethBal
 	bm.ethBalancesMtx.Unlock()
 
-	loggerFields := []interface{}{
+	lgr := bm.logger.Named("balance_log").With(
 		"address", address.Hex(),
 		"ethBalance", ethBal.String(),
-		"weiBalance", ethBal.ToInt(),
-		"id", "balance_log",
-	}
+		"weiBalance", ethBal.ToInt())
 
 	if oldBal == nil {
-		bm.logger.Infow(fmt.Sprintf("ETH balance for %s: %s", address.Hex(), ethBal.String()), loggerFields...)
+		lgr.Infof("ETH balance for %s: %s", address.Hex(), ethBal.String())
 		return
 	}
 
 	if ethBal.Cmp(oldBal) != 0 {
-		bm.logger.Infow(fmt.Sprintf("New ETH balance for %s: %s", address.Hex(), ethBal.String()), loggerFields...)
+		lgr.Infof("New ETH balance for %s: %s", address.Hex(), ethBal.String())
 	}
 }
 

--- a/core/services/bulletprooftxmanager/reaper.go
+++ b/core/services/bulletprooftxmanager/reaper.go
@@ -40,7 +40,7 @@ func NewReaper(lggr logger.Logger, db *gorm.DB, config ReaperConfig, chainID big
 		db,
 		config,
 		*utils.NewBig(&chainID),
-		lggr.With("id", "bptxm_reaper"),
+		lggr.Named("bptxm_reaper"),
 		atomic.NewInt64(-1),
 		make(chan struct{}, 1),
 		make(chan struct{}),

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -317,9 +317,9 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 	return app, nil
 }
 
-// SetServiceLogger sets the Logger for a given service and stores the setting in the db
+// SetServiceLogger sets the Logger level for a given service and stores the setting in the db.
 func (app *ChainlinkApplication) SetServiceLogger(ctx context.Context, serviceName string, level string) error {
-	newL, err := app.logger.NewServiceLevelLogger(serviceName, level)
+	newL, err := app.logger.NamedLevel(serviceName, level)
 	if err != nil {
 		return err
 	}

--- a/core/services/gas/block_history_estimator.go
+++ b/core/services/gas/block_history_estimator.go
@@ -100,7 +100,7 @@ func NewBlockHistoryEstimator(lggr logger.Logger, ethClient eth.Client, config C
 		nil,
 		nil,
 		sync.RWMutex{},
-		lggr.With("id", "block_history_estimator"),
+		lggr.Named("block_history_estimator"),
 	}
 
 	return b

--- a/core/services/headtracker/head_tracker.go
+++ b/core/services/headtracker/head_tracker.go
@@ -285,7 +285,6 @@ func (ht *HeadTracker) backfill(ctxParent context.Context, head eth.Head, baseHe
 	fetched := 0
 	ht.logger().Debugw("HeadTracker: starting backfill",
 		"blockNumber", head.Number,
-		"id", "head_tracker",
 		"n", head.Number-baseHeight,
 		"fromBlockHeight", baseHeight,
 		"toBlockHeight", head.Number-1)
@@ -297,7 +296,6 @@ func (ht *HeadTracker) backfill(ctxParent context.Context, head eth.Head, baseHe
 			"fetched", fetched,
 			"blockNumber", head.Number,
 			"time", time.Since(mark),
-			"id", "head_tracker",
 			"n", head.Number-baseHeight,
 			"fromBlockHeight", baseHeight,
 			"toBlockHeight", head.Number-1,

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -396,7 +396,7 @@ func guiAssetRoutes(box packr.Box, engine *gin.Engine, config config.GeneralConf
 			}
 
 		}
-		defer logger.ErrorIfCalling(file.Close, "failed when close file")
+		defer logger.ErrorIfCalling(file.Close)
 
 		http.ServeContent(c.Writer, c.Request, path, time.Time{}, file)
 	})


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/17319/named-loggers

- tighten up the Logger API
- untangle caller skip levels for stack traces
- consolidate `Named()`/`"logger"`/`"id"` to just `Named()`=>`logger=rootName.nameA.nameB`
- test application loggers `Named(test.Name())` 
-  ~Replace (some) message prefixes with Names?~ can follow up case-by-case