### PR TITLE
Prevent undefined database state on job_spec presence

### DIFF
--- a/core/store/migrate/migrations/0054_remove_legacy_pipeline.go
+++ b/core/store/migrate/migrations/0054_remove_legacy_pipeline.go
@@ -32,7 +32,7 @@ func init() {
 }
 
 func Up54(tx *sql.Tx) error {
-	if err := checkNoLegacyJobs(tx); err != nil {
+	if err := CheckNoLegacyJobs(tx); err != nil {
 		return err
 	}
 	if _, err := tx.Exec(up54); err != nil {
@@ -45,13 +45,13 @@ func Down54(tx *sql.Tx) error {
 	return errors.New("irreversible migration")
 }
 
-func checkNoLegacyJobs(tx *sql.Tx) error {
+func CheckNoLegacyJobs(tx *sql.Tx) error {
 	var count int
 	if err := tx.QueryRow(`SELECT COUNT(*) FROM job_specs WHERE deleted_at IS NULL`).Scan(&count); err != nil {
 		return err
 	}
 	if count > 0 {
-		return errors.Errorf("cannot migrate; this release removes support for legacy job specs but there are still %d in the database. Please migrate these jobs specs to the V2 pipeline and make sure job_specs table is empty, then run the migration again", count)
+		return errors.Errorf("cannot migrate; this release removes support for legacy job specs but there are still %d in the database. Please migrate these jobs specs to the V2 pipeline and make sure job_specs table is empty (run sql command: `DELETE FROM job_specs;`), then run the migration again. This upgrade is NOT REVERSIBLE, so it is STRONGLY RECOMMENDED that you take a database backup before continuing.", count)
 	}
 	return nil
 }


### PR DESCRIPTION
The following workflow would lead to broken database state:

1. I run 1.0.0 on top of 0.10.14 with job_specs, it fails with error as expected
2. I try to run 0.10.14 again, it fails with creating application: failed to initialize ORM: initializeORM#Migrate: failed to run migration 1611847145: ERROR: type "eth_tx_attempts_state" already exists (SQLSTATE 42710)
3. I go BACK to 1.0.0 again and now I can’t apply the migrations at all, it simply says panic: Database state is too old. Need to migrate to chainlink version 0.9.10 first before upgrading to this version

Resolve this by running the job_specs check first before anything else.
Then if it fails, the nop can always safely run 0.10.14 on the database
again.

Once the migrations of 1.0.0 have started to be applied, there is no way
to go back.