### PR TITLE
Handle empty CBOR in cbor_parse

### DIFF
--- a/core/services/pipeline/runner_test.go
+++ b/core/services/pipeline/runner_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -282,6 +284,88 @@ func Test_PipelineRunner_ExecuteTaskRunsWithVars(t *testing.T) {
 			}
 		})
 	}
+}
+
+func Test_PipelineRunner_CBORParse(t *testing.T) {
+	db := pgtest.NewGormDB(t)
+	cfg := cltest.NewTestGeneralConfig(t)
+	r, _ := newRunner(t, db, cfg)
+
+	t.Run("diet mode, empty CBOR", func(t *testing.T) {
+		s := `
+decode_log  [type="ethabidecodelog"
+             data="$(jobRun.logData)"
+             topics="$(jobRun.logTopics)"
+             abi="OracleRequest(address requester, bytes32 requestId, uint256 payment, address callbackAddr, bytes4 callbackFunctionId, uint256 cancelExpiration, uint256 dataVersion, bytes cborPayload)"]
+
+decode_cbor [type="cborparse"
+             data="$(decode_log.cborPayload)"
+			 mode=diet]
+
+decode_log -> decode_cbor;
+`
+		d, err := pipeline.Parse(s)
+		require.NoError(t, err)
+
+		spec := pipeline.Spec{DotDagSource: s}
+		global := make(map[string]interface{})
+		jobRun := make(map[string]interface{})
+		global["jobRun"] = jobRun
+		jobRun["logData"] = hexutil.MustDecode("0x0000000000000000000000009c26cc46f57667cba75556014c8e0d5ed7c5b83d17a526ff5d8f916fa2f4a218f6ce0a6e410a0d7823f8238979f8579c2145fd6f0000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000009c26cc46f57667cba75556014c8e0d5ed7c5b83d64ef935700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006148ef28000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000000000")
+		jobRun["logTopics"] = []common.Hash{
+			common.HexToHash("0xd8d7ecc4800d25fa53ce0372f13a416d98907a7ef3d8d3bdd79cf4fe75529c65"),
+			common.HexToHash("0x3963386131316165393962363463373161663333376235643831633737353230"),
+		}
+		vars := pipeline.NewVarsFrom(global)
+
+		_, trrs, err := r.ExecuteRun(context.Background(), spec, vars, logger.Default)
+		require.NoError(t, err)
+		require.Len(t, trrs, len(d.Tasks))
+
+		finalResults := trrs.FinalResult()
+		require.Len(t, finalResults.Values, 1)
+		assert.Equal(t, make(map[string]interface{}), finalResults.Values[0])
+		require.Len(t, finalResults.Errors, 1)
+		assert.Nil(t, finalResults.Errors[0])
+	})
+
+	t.Run("standard mode, string value", func(t *testing.T) {
+		s := `
+decode_log  [type="ethabidecodelog"
+             data="$(jobRun.logData)"
+             topics="$(jobRun.logTopics)"
+             abi="OracleRequest(address requester, bytes32 requestId, uint256 payment, address callbackAddr, bytes4 callbackFunctionId, uint256 cancelExpiration, uint256 dataVersion, bytes cborPayload)"]
+
+decode_cbor [type="cborparse"
+             data="$(decode_log.cborPayload)"
+			 mode=standard]
+
+decode_log -> decode_cbor;
+`
+		d, err := pipeline.Parse(s)
+		require.NoError(t, err)
+
+		spec := pipeline.Spec{DotDagSource: s}
+		global := make(map[string]interface{})
+		jobRun := make(map[string]interface{})
+		global["jobRun"] = jobRun
+		jobRun["logData"] = hexutil.MustDecode("0x0000000000000000000000009c26cc46f57667cba75556014c8e0d5ed7c5b83d17a526ff5d8f916fa2f4a218f6ce0a6e410a0d7823f8238979f8579c2145fd6f0000000000000000000000000000000000000000000000000de0b6b3a76400000000000000000000000000009c26cc46f57667cba75556014c8e0d5ed7c5b83d64ef935700000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000006148ef2800000000000000000000000000000000000000000000000000000000000000010000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000000000463666F6F00000000000000000000000000000000000000000000000000000000")
+		jobRun["logTopics"] = []common.Hash{
+			common.HexToHash("0xd8d7ecc4800d25fa53ce0372f13a416d98907a7ef3d8d3bdd79cf4fe75529c65"),
+			common.HexToHash("0x3963386131316165393962363463373161663333376235643831633737353230"),
+		}
+		vars := pipeline.NewVarsFrom(global)
+
+		_, trrs, err := r.ExecuteRun(context.Background(), spec, vars, logger.Default)
+		require.NoError(t, err)
+		require.Len(t, trrs, len(d.Tasks))
+
+		finalResults := trrs.FinalResult()
+		require.Len(t, finalResults.Values, 1)
+		assert.Equal(t, "foo", finalResults.Values[0])
+		require.Len(t, finalResults.Errors, 1)
+		assert.Nil(t, finalResults.Errors[0])
+	})
 }
 
 func Test_PipelineRunner_HandleFaults(t *testing.T) {

--- a/core/services/pipeline/task.cborparse_test.go
+++ b/core/services/pipeline/task.cborparse_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/pkg/errors"
-	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 )
@@ -113,8 +113,8 @@ func TestCBORParseTask(t *testing.T) {
 				"foo": nil,
 			}),
 			nil,
+			map[string]interface{}{},
 			nil,
-			pipeline.ErrBadInput,
 			"data",
 		},
 		{
@@ -140,14 +140,14 @@ func TestCBORParseTask(t *testing.T) {
 			result := task.Run(context.Background(), test.vars, test.inputs)
 
 			if test.expectedErrorCause != nil {
-				require.Equal(t, test.expectedErrorCause, errors.Cause(result.Error))
-				require.Nil(t, result.Value)
+				assert.Equal(t, test.expectedErrorCause, errors.Cause(result.Error))
+				assert.Nil(t, result.Value)
 				if test.expectedErrorContains != "" {
-					require.Contains(t, result.Error.Error(), test.expectedErrorContains)
+					assert.Contains(t, result.Error.Error(), test.expectedErrorContains)
 				}
 			} else {
-				require.NoError(t, result.Error)
-				require.Equal(t, test.expected, result.Value)
+				assert.NoError(t, result.Error)
+				assert.Equal(t, test.expected, result.Value)
 			}
 		})
 	}

--- a/core/store/models/cbor.go
+++ b/core/store/models/cbor.go
@@ -9,16 +9,17 @@ import (
 	"github.com/fxamacker/cbor/v2"
 )
 
-// ParseCBOR attempts to coerce the input byte array into valid CBOR
+// ParseDietCBOR attempts to coerce the input byte array into valid CBOR
 // and then coerces it into a JSON object.
-func ParseCBOR(b []byte) (JSON, error) {
-	if len(b) == 0 {
-		return JSON{}, nil
-	}
+// Assumes the input is "diet" CBOR which is like CBOR, except:
+// 1. It is guaranteed to always be a map
+// 2. It may or may not include the opening and closing markers "{}"
+func ParseDietCBOR(b []byte) (JSON, error) {
+	b = autoAddMapDelimiters(b)
 
 	var m map[interface{}]interface{}
 
-	if err := cbor.Unmarshal(autoAddMapDelimiters(b), &m); err != nil {
+	if err := cbor.Unmarshal(b, &m); err != nil {
 		return JSON{}, err
 	}
 
@@ -36,13 +37,23 @@ func ParseCBOR(b []byte) (JSON, error) {
 	return js, json.Unmarshal(jsb, &js)
 }
 
+// ParseStandardCBOR parses CBOR in "standards compliant" mode.
+// Literal values are passed through "as-is".
+// The input is not assumed to be a map.
+// Empty inputs will return nil.
+func ParseStandardCBOR(b []byte) (a interface{}, err error) {
+	if len(b) == 0 {
+		return nil, nil
+	}
+	if err = cbor.Unmarshal(b, &a); err != nil {
+		return nil, err
+	}
+	return
+}
+
 // Automatically add missing start map and end map to a CBOR encoded buffer
 func autoAddMapDelimiters(b []byte) []byte {
-	if len(b) < 2 {
-		return b
-	}
-
-	if (b[0] >> 5) != 5 {
+	if len(b) == 0 || (len(b) > 1 && (b[0]>>5) != 5) {
 		var buffer bytes.Buffer
 		buffer.Write([]byte{0xbf})
 		buffer.Write(b)

--- a/core/store/models/cbor_test.go
+++ b/core/store/models/cbor_test.go
@@ -99,7 +99,7 @@ func Test_ParseCBOR(t *testing.T) {
 			false,
 		},
 		{"empty object", `0xa0`, jsonMustUnmarshal(t, `{}`), false},
-		{"empty string", `0x`, JSON{}, false},
+		{"empty string", `0x`, jsonMustUnmarshal(t, `{}`), false},
 		{"invalid CBOR", `0xff`, JSON{}, true},
 	}
 
@@ -108,7 +108,7 @@ func Test_ParseCBOR(t *testing.T) {
 			b, err := hexutil.Decode(test.in)
 			assert.NoError(t, err)
 
-			json, err := ParseCBOR(b)
+			json, err := ParseDietCBOR(b)
 			if test.wantErrored {
 				assert.Error(t, err)
 			} else {
@@ -163,9 +163,9 @@ func Test_autoAddMapDelimiters(t *testing.T) {
 			hexutil.MustDecode("0xbf636B65796576616C7565ff"),
 		},
 		{
-			"empty",
+			"empty input adds delimiters",
 			[]byte{},
-			[]byte{},
+			[]byte{0xbf, 0xff},
 		},
 	}
 


### PR DESCRIPTION
Chainlink uses its own special version of CBOR called "diet CBOR" which
is like CBOR, except:

1. It is guaranteed to always be a map
2. It strips the opening and closing markers "{}"

This commit extends `cbor_parse` to always return a map even if data is missing when `mode="diet"` 