### PR TITLE
Add short cut for absent BUILDER var to login stage

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,10 +43,10 @@ commands:
       - run:
           name: Docker login for ECR using temporary creds
           command: |
-            # If CIRCLECI is not defined (i.e. the user who submitted the PR is
+            # If BUILDER is not defined (i.e. the user who submitted the PR is
             # probably not on the chainlink team) short circuit this step and
             # succed
-            if [[ -z "$CIRCLECI" ]]; then
+            if [[ -z "$BUILDER" ]]; then
               exit 0
             fi
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,6 +27,7 @@ workflows:
           filters:
             tags:
               only: /^v.*/
+
 commands:
   setup-aws-ecr:
     description: 'Install aws cli and login to public and private ECR'
@@ -42,6 +43,13 @@ commands:
       - run:
           name: Docker login for ECR using temporary creds
           command: |
+            # If CIRCLECI is not defined (i.e. the user who submitted the PR is
+            # probably not on the chainlink team) short circuit this step and
+            # succed
+            if [[ -z "$CIRCLECI" ]]; then
+              exit 0
+            fi
+
             # Get temporary credentials to access resoures available to specific role
             temporaryCredentials=$(
               aws sts assume-role \

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -99,7 +99,7 @@ docker = docker build \
 
 .PHONY: docker-circleci
 docker-circleci:
-	test -n "$$CIRCLECI" && $(docker) || true
+	test -n "$$BUILDER" && $(docker) || true
 
 .PHONY: docker
 docker: ## Build the docker image.


### PR DESCRIPTION
If a user outside of chainlink submits a PR, the CircleCI runner runs build-and-publish without env vars.
This exits early for those users, allowing the build to pass for them.