### PR TITLE
wrap errors from pg_dump in dumpSchema

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -20,7 +20,7 @@ jobs:
       LOG_LEVEL: debug
     services:
       postgres:
-        image: postgres
+        image: postgres:13
         credentials:
           username: ${{ secrets.DOCKER_READONLY_USERNAME }}
           password: ${{ secrets.DOCKER_READONLY_PASSWORD }}

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -580,7 +580,10 @@ func dumpSchema(cfg config.GeneralConfig) (string, error) {
 	)
 
 	schema, err := cmd.Output()
-	return string(schema), err
+	if err != nil {
+		return "", fmt.Errorf("failed to dump schema: %v", err)
+	}
+	return string(schema), nil
 }
 
 func checkSchema(cfg config.GeneralConfig, prevSchema string) error {


### PR DESCRIPTION
CI has started failing during DB setup without any useful messages:
```
2021/10/01 12:19:44 goose: no more migrations to run. current version: 74
exit status 1
exit status 1
Error: Process completed with exit code 1.
```

This happened on my local machine when pg_dump was an incompatible version, so adding some context to those errors.