### PR TITLE
Update all package.json with a preinstall script to prevent npm install

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -6,6 +6,7 @@
   "license": "MIT",
   "private": false,
   "scripts": {
+    "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('Please use yarn to install dependencies\\n\\n')\"",
     "test": "hardhat test",
     "size": "hardhat size-contracts",
     "clean": "hardhat clean",

--- a/operator_ui/package.json
+++ b/operator_ui/package.json
@@ -7,6 +7,7 @@
     "node": "^12.0.0"
   },
   "scripts": {
+    "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('Please use yarn to install dependencies\\n\\n')\"",
     "start": "webpack serve --config webpack.dev.js",
     "serve": "serve dist -p 3000 --config webpack.prod.js",
     "test": "jest",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "node": "^12.0.0"
   },
   "scripts": {
+    "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('Please use yarn to install dependencies\\n\\n')\"",
     "lint": "eslint --ext js,jsx,ts,tsx .",
     "lint:evm": "eslint --ext js,jsx,ts,tsx contracts/",
     "prettier:check": "yarn prettier '**/*' --check --ignore-unknown",

--- a/tools/external-adapter/package.json
+++ b/tools/external-adapter/package.json
@@ -6,6 +6,7 @@
   "repository": "https://github.com/smartcontractkit/chainlink",
   "license": "MIT",
   "scripts": {
+    "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('Please use yarn to install dependencies\\n\\n')\"",
     "start": "node .",
     "setup": "tsc -b",
     "clean": "tsc -b --clean"

--- a/tools/package.json
+++ b/tools/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.5",
   "license": "MIT",
   "scripts": {
+    "preinstall": "node -e \"if(process.env.npm_execpath.indexOf('yarn') === -1) throw new Error('Please use yarn to install dependencies\\n\\n')\"",
     "depcheck": "echo '@chainlink/tools' && depcheck || true"
   },
   "engines": {


### PR DESCRIPTION
This is a duplicate of https://github.com/smartcontractkit/chainlink/pull/5050 created internally instead to avoid CI issues