### PR TITLE
log broadcaster test races

### DIFF
--- a/core/services/log/broadcaster.go
+++ b/core/services/log/broadcaster.go
@@ -363,7 +363,11 @@ func (b *broadcaster) eventLoop(chRawLogs <-chan types.Log, chErr <-chan error) 
 
 		// testing only
 		case <-b.testPause:
-			<-b.testResume
+			select {
+			case <-b.testResume:
+			case <-b.chStop:
+				return false, nil
+			}
 		}
 	}
 }

--- a/core/services/log/broadcaster.go
+++ b/core/services/log/broadcaster.go
@@ -88,6 +88,9 @@ type (
 		highestSavedHead      *eth.Head
 		lastSeenHeadNumber    atomic.Int64
 		logger                logger.Logger
+
+		// used for testing only
+		testPause, testResume chan struct{}
 	}
 
 	Config interface {
@@ -357,6 +360,10 @@ func (b *broadcaster) eventLoop(chRawLogs <-chan types.Log, chErr <-chan error) 
 
 		case <-b.chStop:
 			return false, nil
+
+		// testing only
+		case <-b.testPause:
+			<-b.testResume
 		}
 	}
 }

--- a/core/services/log/broadcaster_internal_test.go
+++ b/core/services/log/broadcaster_internal_test.go
@@ -76,7 +76,7 @@ func TestBroadcaster_BroadcastsWithZeroConfirmations(t *testing.T) {
 		Return(nil, nil)
 	db := pgtest.NewGormDB(t)
 	dborm := NewORM(db, *ethClient.ChainID())
-	lb := NewBroadcaster(dborm, ethClient, tc{}, logger.Default, nil)
+	lb := NewTestBroadcaster(dborm, ethClient, tc{}, logger.Default, nil)
 	lb.Start()
 	defer lb.Close()
 
@@ -155,6 +155,8 @@ func TestBroadcaster_BroadcastsWithZeroConfirmations(t *testing.T) {
 	}
 	// Wait until the logpool has the 3 logs
 	gm.Eventually(func() bool {
+		lb.Pause()
+		defer lb.Resume()
 		return len(lb.logPool.logsByBlockHash[bh]) == len(addr1SentLogs)
 	}, 2*time.Second, 100*time.Millisecond).Should(gomega.BeTrue())
 

--- a/core/services/log/helpers_internal_test.go
+++ b/core/services/log/helpers_internal_test.go
@@ -19,10 +19,16 @@ func (b *broadcaster) ExportedAppendLogChannel(ch1, ch2 <-chan types.Log) chan t
 
 // Pause pauses the eventLoop until Resume is called.
 func (b *broadcaster) Pause() {
-	b.testPause <- struct{}{}
+	select {
+	case b.testPause <- struct{}{}:
+	case <-b.chStop:
+	}
 }
 
 // Resume resumes the eventLoop after calling Pause.
 func (b *broadcaster) Resume() {
-	b.testResume <- struct{}{}
+	select {
+	case b.testResume <- struct{}{}:
+	case <-b.chStop:
+	}
 }

--- a/core/services/log/helpers_internal_test.go
+++ b/core/services/log/helpers_internal_test.go
@@ -2,18 +2,27 @@ package log
 
 import (
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/eth"
 )
+
+// NewTestBroadcaster creates a broadcaster with Pause/Resume enabled.
+func NewTestBroadcaster(orm ORM, ethClient eth.Client, config Config, logger logger.Logger, highestSavedHead *eth.Head) *broadcaster {
+	b := NewBroadcaster(orm, ethClient, config, logger, highestSavedHead)
+	b.testPause, b.testResume = make(chan struct{}), make(chan struct{})
+	return b
+}
 
 func (b *broadcaster) ExportedAppendLogChannel(ch1, ch2 <-chan types.Log) chan types.Log {
 	return b.appendLogChannel(ch1, ch2)
 }
 
-func (b *broadcaster) ExportedGetPoolCount() func() int {
-	return func() int {
-		count := 0
-		for _, logs := range b.logPool.logsByBlockHash {
-			count += len(logs)
-		}
-		return count
-	}
+// Pause pauses the eventLoop until Resume is called.
+func (b *broadcaster) Pause() {
+	b.testPause <- struct{}{}
+}
+
+// Resume resumes the eventLoop after calling Pause.
+func (b *broadcaster) Resume() {
+	b.testResume <- struct{}{}
 }


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/17962/flakey-testbroadcaster-backfillonnodestartandonreplay

I was originally looking at just `TestBroadcaster_BackfillOnNodeStartAndOnReplay` but detected some races.