### PR TITLE
Disable LogToDisk by default

### DIFF
--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -35,6 +35,7 @@ func TestClient_RunNodeShowsEnv(t *testing.T) {
 	cfg := cltest.NewTestGeneralConfig(t)
 	debug := config.LogLevel{Level: zapcore.DebugLevel}
 	cfg.Overrides.LogLevel = &debug
+	cfg.Overrides.LogToDisk = null.BoolFrom(true)
 	db := pgtest.NewGormDB(t)
 	sessionORM := sessions.NewORM(postgres.UnwrapGormDB(db), time.Minute)
 	keyStore := cltest.NewKeyStore(t, db)

--- a/core/store/config/schema.go
+++ b/core/store/config/schema.go
@@ -113,7 +113,7 @@ type ConfigSchema struct {
 	LogLevel                                   LogLevel                      `env:"LOG_LEVEL"`
 	LogSQLMigrations                           bool                          `env:"LOG_SQL_MIGRATIONS" default:"true"`
 	LogSQLStatements                           bool                          `env:"LOG_SQL" default:"false"`
-	LogToDisk                                  bool                          `env:"LOG_TO_DISK" default:"true"`
+	LogToDisk                                  bool                          `env:"LOG_TO_DISK" default:"false"`
 	MigrateDatabase                            bool                          `env:"MIGRATE_DATABASE" default:"true"`
 	MinIncomingConfirmations                   uint32                        `env:"MIN_INCOMING_CONFIRMATIONS"`
 	MinRequiredOutgoingConfirmations           uint64                        `env:"MIN_OUTGOING_CONFIRMATIONS"`

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Log to Disk
+
+This feature has been disabled by default, turn on with LOG_TO_DISK. For most production uses this is not desirable.
+
 ### Added
 
 #### `merge` task type


### PR DESCRIPTION
This leaks file descriptors in tests, and also slows them down.