### PR TITLE
Make keystore keep import/export formats consistent across v1/v2 keys

### DIFF
--- a/core/services/keystore/eth.go
+++ b/core/services/keystore/eth.go
@@ -170,10 +170,11 @@ func (ks *eth) Import(keyJSON []byte, password string, chainID *big.Int) (ethkey
 	if ks.isLocked() {
 		return ethkey.KeyV2{}, ErrLocked
 	}
-	key, err := ethkey.FromEncryptedJSON(keyJSON, password)
+	dKey, err := keystore.DecryptKey(keyJSON, password)
 	if err != nil {
 		return ethkey.KeyV2{}, errors.Wrap(err, "EthKeyStore#ImportKey failed to decrypt key")
 	}
+	key := ethkey.FromPrivateKey(dKey.PrivateKey)
 	if _, found := ks.keyRing.Eth[key.ID()]; found {
 		return ethkey.KeyV2{}, fmt.Errorf("key with ID %s already exists", key.ID())
 	}

--- a/core/services/keystore/eth_test.go
+++ b/core/services/keystore/eth_test.go
@@ -260,6 +260,13 @@ func Test_EthKeyStore_E2E(t *testing.T) {
 		_, err = ks.Get(newKey.ID())
 		require.Error(t, err)
 	})
+
+	t.Run("imports a key exported from a v1 keystore", func(t *testing.T) {
+		exportedKey := `{"address":"0dd359b4f22a30e44b2fd744b679971941865820","crypto":{"cipher":"aes-128-ctr","ciphertext":"b30af964a3b3f37894e599446b4cf2314bbfcd1062e6b35b620d3d20bd9965cc","cipherparams":{"iv":"58a8d75629cc1945da7cf8c24520d1dc"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"c352887e9d427d8a6a1869082619b73fac4566082a99f6e367d126f11b434f28"},"mac":"fd76a588210e0bf73d01332091e0e83a4584ee2df31eaec0e27f9a1b94f024b4"},"id":"a5ee0802-1d7b-45b6-aeb8-ea8a3351e715","version":3}`
+		importedKey, err := ks.Import([]byte(exportedKey), cltest.Password, &cltest.FixtureChainID)
+		require.NoError(t, err)
+		require.Equal(t, "0x0dd359b4f22a30E44b2fD744B679971941865820", importedKey.ID())
+	})
 }
 
 func Test_EthKeyStore_SubscribeToKeyChanges(t *testing.T) {

--- a/core/services/keystore/keys/vrfkey/export.go
+++ b/core/services/keystore/keys/vrfkey/export.go
@@ -1,54 +1,84 @@
 package vrfkey
 
 import (
+	"crypto/ecdsa"
 	"encoding/json"
 
 	keystore "github.com/ethereum/go-ethereum/accounts/keystore"
+	"github.com/google/uuid"
 	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/services/signatures/secp256k1"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
-
-const keyTypeIdentifier = "VRF"
 
 func FromEncryptedJSON(keyJSON []byte, password string) (KeyV2, error) {
 	var export EncryptedVRFKeyExport
 	if err := json.Unmarshal(keyJSON, &export); err != nil {
 		return KeyV2{}, err
 	}
-	privKey, err := keystore.DecryptDataV3(export.Crypto, adulteratedPassword(password))
+
+	// NOTE: We do this shuffle to an anonymous struct
+	// solely to add a a throwaway UUID, so we can leverage
+	// the keystore.DecryptKey from the geth which requires it
+	// as of 1.10.0.
+	keyJSON, err := json.Marshal(struct {
+		Address string              `json:"address"`
+		Crypto  keystore.CryptoJSON `json:"crypto"`
+		Version int                 `json:"version"`
+		Id      string              `json:"id"`
+	}{
+		Address: export.VRFKey.Address,
+		Crypto:  export.VRFKey.Crypto,
+		Version: export.VRFKey.Version,
+		Id:      uuid.New().String(),
+	})
 	if err != nil {
-		return KeyV2{}, errors.Wrap(err, "failed to decrypt VRF key")
+		return KeyV2{}, errors.Wrapf(err, "while marshaling key for decryption")
 	}
-	key := Raw(privKey).Key()
+
+	gethKey, err := keystore.DecryptKey(keyJSON, adulteratedPassword(password))
+	if err != nil {
+		return KeyV2{}, errors.Wrapf(err, "could not decrypt key %s", export.PublicKey.String())
+	}
+
+	key := Raw(gethKey.PrivateKey.D.Bytes()).Key()
 	return key, nil
 }
 
 type EncryptedVRFKeyExport struct {
-	KeyType string              `json:"keyType"`
-	ID      string              `json:"id"`
-	Address string              `json:"address"`
-	Crypto  keystore.CryptoJSON `json:"crypto"`
+	PublicKey secp256k1.PublicKey `json:"PublicKey"`
+	VRFKey    gethKeyStruct       `json:"vrf_key"`
 }
 
 func (key KeyV2) ToEncryptedJSON(password string, scryptParams utils.ScryptParams) (export []byte, err error) {
-	cryptoJSON, err := keystore.EncryptDataV3(
-		key.Raw(),
-		[]byte(adulteratedPassword(password)),
-		scryptParams.N,
-		scryptParams.P,
-	)
+	cryptoJSON, err := keystore.EncryptKey(key.toGethKey(), adulteratedPassword(password), scryptParams.N, scryptParams.P)
 	if err != nil {
-		return nil, errors.Wrapf(err, "could not encrypt VRF key")
+		return nil, errors.Wrapf(err, "failed to encrypt key %s", key.ID())
+	}
+	var gethKey gethKeyStruct
+	err = json.Unmarshal(cryptoJSON, &gethKey)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to unmarshal key %s", key.ID())
 	}
 	encryptedOCRKExport := EncryptedVRFKeyExport{
-		KeyType: keyTypeIdentifier,
-		ID:      key.ID(),
-		Address: key.PublicKey.Address().Hex(),
-		Crypto:  cryptoJSON,
+		PublicKey: key.PublicKey,
+		VRFKey:    gethKey,
 	}
 	return json.Marshal(encryptedOCRKExport)
 }
 
+func (key KeyV2) toGethKey() *keystore.Key {
+	return &keystore.Key{
+		Address:    key.PublicKey.Address(),
+		PrivateKey: &ecdsa.PrivateKey{D: secp256k1.ToInt(*key.k)},
+	}
+}
+
+// passwordPrefix is added to the beginning of the passwords for
+// EncryptedVRFKey's, so that VRF keys can't casually be used as ethereum
+// keys, and vice-versa. If you want to do that, DON'T.
+var passwordPrefix = "don't mix VRF and Ethereum keys!"
+
 func adulteratedPassword(password string) string {
-	return "vrfkey" + password
+	return passwordPrefix + password
 }

--- a/core/services/keystore/keys/vrfkey/private_key.go
+++ b/core/services/keystore/keys/vrfkey/private_key.go
@@ -53,15 +53,6 @@ func (k *PrivateKey) GoString() string {
 	return k.String()
 }
 
-// passwordPrefix is added to the beginning of the passwords for
-// EncryptedVRFKey's, so that VRF keys can't casually be used as ethereum
-// keys, and vice-versa. If you want to do that, DON'T.
-var passwordPrefix = "don't mix VRF and Ethereum keys!"
-
-func adulteratedPasswordV1(auth string) string {
-	return passwordPrefix + auth
-}
-
 // Decrypt returns the PrivateKey in e, decrypted via auth, or an error
 func Decrypt(e EncryptedVRFKey, auth string) (*PrivateKey, error) {
 	// NOTE: We do this shuffle to an anonymous struct
@@ -82,7 +73,7 @@ func Decrypt(e EncryptedVRFKey, auth string) (*PrivateKey, error) {
 	if err != nil {
 		return nil, errors.Wrapf(err, "while marshaling key for decryption")
 	}
-	gethKey, err := keystore.DecryptKey(keyJSON, adulteratedPasswordV1(auth))
+	gethKey, err := keystore.DecryptKey(keyJSON, adulteratedPassword(auth))
 	if err != nil {
 		return nil, errors.Wrapf(err, "could not decrypt key %s",
 			e.PublicKey.String())

--- a/core/services/keystore/ocr_test.go
+++ b/core/services/keystore/ocr_test.go
@@ -91,4 +91,11 @@ func Test_OCRKeyStore_E2E(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, 1, len(keys))
 	})
+
+	t.Run("imports a key exported from a v1 keystore", func(t *testing.T) {
+		exportedKey := `{"id":"7cfd89bbb018e4778a44fd61172e8834dd24b4a2baf61ead795143b117221c61","onChainSigningAddress":"ocrsad_0x2ed5b18b62dacd7a85b6ed19247ea718bdae6114","offChainPublicKey":"ocroff_62a76d04e13dae5870071badea6b113a5123f4ac1a2cbae6b2fb7070dd9dbf2d","configPublicKey":"ocrcfg_75581baab36744671c2b1d75071b07b08b9cb631b3a7155d2f590744983d9c41","crypto":{"cipher":"aes-128-ctr","ciphertext":"60d2e679f08e0b1538cf609e25f2d32c0b7d408f24cab22dd05bffd3b5580c65552097e203f6546e2d792a4f6adb69449fee0fe4dd7f1060970907518e7c33331abd076388af842f03d05c193b03f22f6bf0423d4ae99dbb563c7158b4eac2a31b03c90fb9fd7be217804243151c36c33504469632bc2c89be33e7b9157edf172a52af4d49fa125b8d0358ea63ace90bc181a7164b548e0f12288ec08b919b46afad1b36dbaeda32d8d657a43908f802b6f2354473f538437ba3bd0b0d374d8e836e623484b655c95f4ef11e30baaa47b9075c6dbb53147c4b489f45a4bdcfa6b56ef2e6eaa9e9b88b570517c991de359d7f07226c00259810a8a4196b7d5331e4126529eac9bd80b47b5540940f89ad0e728b3dd50e6da316d9f3cf9b3be9b87ca6b7868daa7e4142fc4a65fc77deea6f4f2b4bce1e38337aa827160d8c50cad92d157309aa251180b894ab1ca9923d709d","cipherparams":{"iv":"a9507e6f2b073c1da1082d40a24864d1"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"267f9450f52af42a918ab5747043c88bd2035fa3d3e0f0cfd2b621981bc9320f"},"mac":"15aeb3fc1903f514bfe70cb2eb5a23820ba904f5edf8aeb1913d447797f74442"}}`
+		importedKey, err := ks.Import([]byte(exportedKey), cltest.Password)
+		require.NoError(t, err)
+		require.Equal(t, "7cfd89bbb018e4778a44fd61172e8834dd24b4a2baf61ead795143b117221c61", importedKey.ID())
+	})
 }

--- a/core/services/keystore/p2p_test.go
+++ b/core/services/keystore/p2p_test.go
@@ -135,4 +135,11 @@ func Test_P2PKeyStore_E2E(t *testing.T) {
 		ks.Delete(key.ID())
 		cltest.AssertCount(t, db, offchainreporting.P2PPeer{}, 1)
 	})
+
+	t.Run("imports a key exported from a v1 keystore", func(t *testing.T) {
+		exportedKey := `{"publicKey":"fcc1fdebde28322dde17233fe7bd6dcde447d60d5cc1de518962deed102eea35","peerID":"p2p_12D3KooWSq2UZgSXvhGLG5uuAAmz1JNjxHMJViJB39aorvbbYo8p","crypto":{"cipher":"aes-128-ctr","ciphertext":"adb2dff72148a8cd467f6f06a03869e7cedf180cf2a4decdb86875b2e1cf3e58c4bd2b721ecdaa88a0825fa9abfc309bf32dbb35a5c0b6cb01ac89a956d78e0550eff351","cipherparams":{"iv":"6cc4381766a4efc39f762b2b8d09dfba"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"ff5055ae4cdcdc2d0404307d578262e2caeb0210f82db3a0ecbdba727c6f5259"},"mac":"d37e4f1dea98d85960ef3205099fc71741715ae56a3b1a8f9215a78de9b95595"}}`
+		importedKey, err := ks.Import([]byte(exportedKey), cltest.Password)
+		require.NoError(t, err)
+		require.Equal(t, "12D3KooWSq2UZgSXvhGLG5uuAAmz1JNjxHMJViJB39aorvbbYo8p", importedKey.ID())
+	})
 }

--- a/core/services/keystore/vrf_test.go
+++ b/core/services/keystore/vrf_test.go
@@ -79,4 +79,11 @@ func Test_VRFKeyStore_E2E(t *testing.T) {
 		_, err = ks.Get(newKey.ID())
 		require.Error(t, err)
 	})
+
+	t.Run("imports a key exported from a v1 keystore", func(t *testing.T) {
+		exportedKey := `{"PublicKey":"0xd2377bc6be8a2c5ce163e1867ee42ef111e320686f940a98e52e9c019ca0606800","vrf_key":{"address":"b94276ad4e5452732ec0cccf30ef7919b67844b6","crypto":{"cipher":"aes-128-ctr","ciphertext":"ff66d61d02dba54a61bab1ceb8414643f9e76b7351785d2959e2c8b50ee69a92","cipherparams":{"iv":"75705da271b11e330a27b8d593a3930c"},"kdf":"scrypt","kdfparams":{"dklen":32,"n":262144,"p":1,"r":8,"salt":"efe5b372e4fe79d0af576a79d65a1ee35d0792d9c92b70107b5ada1817ea7c7b"},"mac":"e4d0bb08ffd004ab03aeaa42367acbd9bb814c6cfd981f5157503f54c30816e7"},"version":3}}`
+		importedKey, err := ks.Import([]byte(exportedKey), cltest.Password)
+		require.NoError(t, err)
+		require.Equal(t, "0xd2377bc6be8a2c5ce163e1867ee42ef111e320686f940a98e52e9c019ca0606800", importedKey.ID())
+	})
 }


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/18300/trying-to-import-key-fails-with-not-valid-eip55-formatted-address