### PR TITLE
reduce go test package level parallelism

### DIFF
--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -4,7 +4,7 @@ set +e
 
 echo "Failed tests and panics: ---------------------"
 echo ""
-go test -v -p 4 -parallel 4 ./... | tee ./output.txt | grep --line-buffered --line-number -e "\-\-\- FAIL" -e "FAIL\s"
+go test -v -p 3 -parallel 4 ./... | tee ./output.txt | grep --line-buffered --line-number -e "\-\-\- FAIL" -e "FAIL\s"
 EXITCODE=${PIPESTATUS[0]}
 echo ""
 echo "----------------------------------------------"


### PR DESCRIPTION
This change reduces the number of packages tested in parallel from 4 to 3. The run time is not meaningfully affected, suggesting that we are still saturating the processors. The payoff should be that individual tests are less likely to time out since they don't have to compete with as many other concurrent tests, reducing the severity of a worst case scheduling order.