### PR TITLE
bump postgresql-client and ci docker image to v14

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -20,7 +20,7 @@ jobs:
       LOG_LEVEL: debug
     services:
       postgres:
-        image: postgres:13
+        image: postgres:14
         credentials:
           username: ${{ secrets.DOCKER_READONLY_USERNAME }}
           password: ${{ secrets.DOCKER_READONLY_PASSWORD }}
@@ -41,7 +41,7 @@ jobs:
         with:
           args: psql -v ON_ERROR_STOP=1 --username postgres -h postgres -c "CREATE USER chainlink NOSUPERUSER CREATEDB;"
       - name: Install Postgres for CLI tools
-        run: wget --quiet -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list && apt update && apt install -y postgresql-client-13
+        run: wget --quiet -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - && echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" | tee  /etc/apt/sources.list.d/pgdg.list && apt update && apt install -y postgresql-client-14
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"      

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -53,7 +53,7 @@ RUN apt-get update && apt-get install -y ca-certificates wget gnupg lsb-release
 RUN wget --quiet -O - https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
  && wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
  && echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" |tee /etc/apt/sources.list.d/pgdg.list \
- && apt-get update && apt-get install -y postgresql-client-13 \
+ && apt-get update && apt-get install -y postgresql-client-14 \
  && apt-get clean all
 
 COPY --from=1 /go/bin/chainlink /usr/local/bin/


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/stories/space/15978/owned-by-me

It looks like `postgresql-client-14` is already available in their apt repo, so this is a trivial upgrade.