### PR TITLE
update codeql from 1.0.0 to 1.0.18

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,14 +28,14 @@ jobs:
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@b7dd4a6f2c343e29a9ab8e181b2f540816f28bd7
+        uses: github/codeql-action/init@fd3190bba58b65cbefb742009518a03a07af24d7
         with:
           languages: ${{ matrix.language }}
 
       # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
       # If this step fails, then you should remove it and run the build manually (see below)
       - name: Autobuild
-        uses: github/codeql-action/autobuild@b7dd4a6f2c343e29a9ab8e181b2f540816f28bd7
+        uses: github/codeql-action/autobuild@fd3190bba58b65cbefb742009518a03a07af24d7
 
       # ℹ️ Command-line programs to run using the OS shell.
       # 📚 https://git.io/JvXDl
@@ -49,4 +49,4 @@ jobs:
       #   make release
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@b7dd4a6f2c343e29a9ab8e181b2f540816f28bd7
+        uses: github/codeql-action/analyze@fd3190bba58b65cbefb742009518a03a07af24d7


### PR DESCRIPTION
I thought this might resolve issues from using go 1.15.15, but it still has not been upgraded.
```
| Severity |                                                                   Message                                                                    |
+----------+----------------------------------------------------------------------------------------------------------------------------------------------+
| error    | Extraction failed in core/utils/http.go with error ReadAll not declared by package io                                                        |
| error    | Extraction failed in core/chains/evm/chain_set.go with error MaxInt not declared by package math                                             |
| error    | Extraction failed with error package io/fs is not in GOROOT (/opt/hostedtoolcache/go/1.15.15/x64/src/io/fs)                                  |
| error    | Extraction failed with error could not import io/fs (invalid package name: "")                                                               |
| error    | Extraction failed with error ReadDir not declared by package os                                                                              |
| error    | Extraction failed with error ReadFile not declared by package os                                                                             |
| error    | Extraction failed in core/store/migrate/migrate.go with error package embed is not in GOROOT (/opt/hostedtoolcache/go/1.15.15/x64/src/embed) |
| error    | Extraction failed in core/store/migrate/migrate.go with error could not import embed (invalid package name: "")                              |
```