### PR TITLE
resolve ticker races

### DIFF
--- a/core/services/offchainreporting/config_overrider_test.go
+++ b/core/services/offchainreporting/config_overrider_test.go
@@ -205,7 +205,7 @@ func (t *FakeTicker) SimulateTick() {
 	t.ticks <- time.Now()
 }
 
-func (t FakeTicker) Ticks() <-chan time.Time {
+func (t *FakeTicker) Ticks() <-chan time.Time {
 	return t.ticks
 }
 

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -803,7 +803,7 @@ func NewPausableTicker(duration time.Duration) PausableTicker {
 }
 
 // Ticks retrieves the ticks from a PausableTicker
-func (t PausableTicker) Ticks() <-chan time.Time {
+func (t *PausableTicker) Ticks() <-chan time.Time {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	if t.ticker == nil {
@@ -907,7 +907,7 @@ func NewResettableTimer() ResettableTimer {
 }
 
 // Ticks retrieves the ticks from a ResettableTimer
-func (t ResettableTimer) Ticks() <-chan time.Time {
+func (t *ResettableTimer) Ticks() <-chan time.Time {
 	t.mu.RLock()
 	defer t.mu.RUnlock()
 	if t.timer == nil {


### PR DESCRIPTION
Resolving some ticker/timer races from methods with value receivers.

Traces:
<details>
<summary>PausableTicker</summary>
<pre><code>
==================
WARNING: DATA RACE
Read at 0x00c0010f0438 by goroutine 32:
  runtime.racereadrange()
      <autogenerated>:1 +0x1b
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Start.func1.1()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:268 +0x30
  github.com/smartcontractkit/chainlink/core/gracefulpanic.WrapRecover()
      /home/jordan/chainlink/core/gracefulpanic/recover.go:15 +0x52
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Start.func1·dwrap·1()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:267 +0x39

Previous write at 0x00c0010f0438 by goroutine 94:
  github.com/smartcontractkit/chainlink/core/utils.(*PausableTicker).Pause()
      /home/jordan/chainlink/core/utils/utils.go:821 +0xf1
  github.com/smartcontractkit/chainlink/core/utils.(*PausableTicker).Destroy()
      /home/jordan/chainlink/core/utils/utils.go:837 +0x44
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*PollManager).Stop()
      /home/jordan/chainlink/core/services/fluxmonitorv2/poll_manager.go:213 +0x37
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Close.func1()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:294 +0x4e
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StopOnce()
      /home/jordan/chainlink/core/utils/utils.go:1011 +0xf9
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Close()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:293 +0x64
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).stopService()
      /home/jordan/chainlink/core/services/job/spawner.go:128 +0x1f0
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).stopAllServices()
      /home/jordan/chainlink/core/services/job/spawner.go:116 +0x66
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).Close.func1()
      /home/jordan/chainlink/core/services/job/spawner.go:92 +0x4e
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StopOnce()
      /home/jordan/chainlink/core/utils/utils.go:1011 +0xf9
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).Close()
      /home/jordan/chainlink/core/services/job/spawner.go:90 +0x5c
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).stop.func1.1()
      /home/jordan/chainlink/core/services/chainlink/application.go:436 +0x211

Goroutine 32 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Start.func1()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:267 +0x178
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:984 +0xf4
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Start()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:264 +0x64
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).StartService()
      /home/jordan/chainlink/core/services/job/spawner.go:167 +0xa15
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).CreateJob()
      /home/jordan/chainlink/core/services/job/spawner.go:209 +0x74b
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).AddJobV2()
      /home/jordan/chainlink/core/services/chainlink/application.go:521 +0x1a1
  github.com/smartcontractkit/chainlink/core/internal/cltest.(*TestApplication).AddJobV2()
      <autogenerated>:1 +0x164
  github.com/smartcontractkit/chainlink/core/web.(*JobsController).Create()
      /home/jordan/chainlink/core/web/jobs_controller.go:130 +0xc21
  github.com/smartcontractkit/chainlink/core/web.(*JobsController).Create-fm()
      /home/jordan/chainlink/core/web/jobs_controller.go:87 +0x44
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x1f9
  github.com/smartcontractkit/chainlink/core/web.RequireAuth.func1()
      /home/jordan/chainlink/core/web/authentication.go:132 +0x136
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x397
  github.com/gin-gonic/contrib/sessions.Sessions.func1()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/contrib@v0.0.0-20190526021735-7fb7810ed2a0/sessions/sessions.go:65 +0x2f4
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x342
  github.com/ulule/limiter/drivers/middleware/gin.(*Middleware).Handle()
      /home/jordan/go/pkg/mod/github.com/ulule/limiter@v0.0.0-20190417201358-7873d115fc4e/drivers/middleware/gin/middleware.go:57 +0x1e6
  github.com/ulule/limiter/drivers/middleware/gin.NewMiddleware.func1()
      /home/jordan/go/pkg/mod/github.com/ulule/limiter@v0.0.0-20190417201358-7873d115fc4e/drivers/middleware/gin/middleware.go:33 +0x3a
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x15c
  github.com/gin-gonic/gin.CustomRecoveryWithWriter.func1()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/recovery.go:99 +0xc5
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x496
  github.com/smartcontractkit/chainlink/core/web.loggerFunc.func1()
      /home/jordan/chainlink/core/web/router.go:431 +0x2e2
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x1e4
  github.com/gin-contrib/size.RequestSizeLimiter.func1()
      /home/jordan/go/pkg/mod/github.com/gin-contrib/size@v0.0.0-20190528085907-355431950c57/size.go:88 +0x17b
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0xae3
  github.com/gin-gonic/gin.(*Engine).handleHTTPRequest()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:489 +0x710
  github.com/gin-gonic/gin.(*Engine).ServeHTTP()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:445 +0x3a5
  net/http.serverHandler.ServeHTTP()
      /snap/go/current/src/net/http/server.go:2878 +0x89a
  net/http.(*conn).serve()
      /snap/go/current/src/net/http/server.go:1929 +0x12e4
  net/http.(*Server).Serve·dwrap·82()
      /snap/go/current/src/net/http/server.go:3033 +0x58

Goroutine 94 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).stop.func1()
      /home/jordan/chainlink/core/services/chainlink/application.go:419 +0x173
  sync.(*Once).doSlow()
      /snap/go/current/src/sync/once.go:68 +0x127
  sync.(*Once).Do()
      /snap/go/current/src/sync/once.go:59 +0x46
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).stop()
      /home/jordan/chainlink/core/services/chainlink/application.go:417 +0x96
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).StopIfStarted()
      /home/jordan/chainlink/core/services/chainlink/application.go:400 +0xc6
  github.com/smartcontractkit/chainlink/core/internal/cltest.(*TestApplication).Stop()
      /home/jordan/chainlink/core/internal/cltest/cltest.go:537 +0xf2
  github.com/smartcontractkit/chainlink/core/internal/cltest.(*TestApplication).Start.func1()
      /home/jordan/chainlink/core/internal/cltest/cltest.go:521 +0x34
  testing.(*common).Cleanup.func1()
      /snap/go/current/src/testing/testing.go:912 +0x199
  testing.(*common).runCleanup()
      /snap/go/current/src/testing/testing.go:1049 +0x154
  testing.tRunner.func2()
      /snap/go/current/src/testing/testing.go:1253 +0x4f
  testing.tRunner()
      /snap/go/current/src/testing/testing.go:1265 +0x268
  testing.(*T).Run·dwrap·21()
      /snap/go/current/src/testing/testing.go:1306 +0x47
==================
</pre></code>
</details>

<details>
<summary>ResettableTimer</summary>
<pre><code>
==================
WARNING: DATA RACE
Read at 0x00c0010f0450 by goroutine 32:
  runtime.racereadrange()
      <autogenerated>:1 +0x1b
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Start.func1.1()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:268 +0x30
  github.com/smartcontractkit/chainlink/core/gracefulpanic.WrapRecover()
      /home/jordan/chainlink/core/gracefulpanic/recover.go:15 +0x52
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Start.func1·dwrap·1()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:267 +0x39

Previous write at 0x00c0010f0450 by goroutine 94:
  github.com/smartcontractkit/chainlink/core/utils.(*ResettableTimer).Stop()
      /home/jordan/chainlink/core/utils/utils.go:925 +0x114
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*PollManager).Stop()
      /home/jordan/chainlink/core/services/fluxmonitorv2/poll_manager.go:214 +0x55
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Close.func1()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:294 +0x4e
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StopOnce()
      /home/jordan/chainlink/core/utils/utils.go:1011 +0xf9
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Close()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:293 +0x64
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).stopService()
      /home/jordan/chainlink/core/services/job/spawner.go:128 +0x1f0
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).stopAllServices()
      /home/jordan/chainlink/core/services/job/spawner.go:116 +0x66
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).Close.func1()
      /home/jordan/chainlink/core/services/job/spawner.go:92 +0x4e
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StopOnce()
      /home/jordan/chainlink/core/utils/utils.go:1011 +0xf9
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).Close()
      /home/jordan/chainlink/core/services/job/spawner.go:90 +0x5c
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).stop.func1.1()
      /home/jordan/chainlink/core/services/chainlink/application.go:436 +0x211

Goroutine 32 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Start.func1()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:267 +0x178
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:984 +0xf4
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Start()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:264 +0x64
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).StartService()
      /home/jordan/chainlink/core/services/job/spawner.go:167 +0xa15
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).CreateJob()
      /home/jordan/chainlink/core/services/job/spawner.go:209 +0x74b
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).AddJobV2()
      /home/jordan/chainlink/core/services/chainlink/application.go:521 +0x1a1
  github.com/smartcontractkit/chainlink/core/internal/cltest.(*TestApplication).AddJobV2()
      <autogenerated>:1 +0x164
  github.com/smartcontractkit/chainlink/core/web.(*JobsController).Create()
      /home/jordan/chainlink/core/web/jobs_controller.go:130 +0xc21
  github.com/smartcontractkit/chainlink/core/web.(*JobsController).Create-fm()
      /home/jordan/chainlink/core/web/jobs_controller.go:87 +0x44
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x1f9
  github.com/smartcontractkit/chainlink/core/web.RequireAuth.func1()
      /home/jordan/chainlink/core/web/authentication.go:132 +0x136
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x397
  github.com/gin-gonic/contrib/sessions.Sessions.func1()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/contrib@v0.0.0-20190526021735-7fb7810ed2a0/sessions/sessions.go:65 +0x2f4
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x342
  github.com/ulule/limiter/drivers/middleware/gin.(*Middleware).Handle()
      /home/jordan/go/pkg/mod/github.com/ulule/limiter@v0.0.0-20190417201358-7873d115fc4e/drivers/middleware/gin/middleware.go:57 +0x1e6
  github.com/ulule/limiter/drivers/middleware/gin.NewMiddleware.func1()
      /home/jordan/go/pkg/mod/github.com/ulule/limiter@v0.0.0-20190417201358-7873d115fc4e/drivers/middleware/gin/middleware.go:33 +0x3a
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x15c
  github.com/gin-gonic/gin.CustomRecoveryWithWriter.func1()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/recovery.go:99 +0xc5
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x496
  github.com/smartcontractkit/chainlink/core/web.loggerFunc.func1()
      /home/jordan/chainlink/core/web/router.go:431 +0x2e2
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x1e4
  github.com/gin-contrib/size.RequestSizeLimiter.func1()
      /home/jordan/go/pkg/mod/github.com/gin-contrib/size@v0.0.0-20190528085907-355431950c57/size.go:88 +0x17b
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0xae3
  github.com/gin-gonic/gin.(*Engine).handleHTTPRequest()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:489 +0x710
  github.com/gin-gonic/gin.(*Engine).ServeHTTP()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:445 +0x3a5
  net/http.serverHandler.ServeHTTP()
      /snap/go/current/src/net/http/server.go:2878 +0x89a
  net/http.(*conn).serve()
      /snap/go/current/src/net/http/server.go:1929 +0x12e4
  net/http.(*Server).Serve·dwrap·82()
      /snap/go/current/src/net/http/server.go:3033 +0x58

Goroutine 94 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).stop.func1()
      /home/jordan/chainlink/core/services/chainlink/application.go:419 +0x173
  sync.(*Once).doSlow()
      /snap/go/current/src/sync/once.go:68 +0x127
  sync.(*Once).Do()
      /snap/go/current/src/sync/once.go:59 +0x46
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).stop()
      /home/jordan/chainlink/core/services/chainlink/application.go:417 +0x96
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).StopIfStarted()
      /home/jordan/chainlink/core/services/chainlink/application.go:400 +0xc6
  github.com/smartcontractkit/chainlink/core/internal/cltest.(*TestApplication).Stop()
      /home/jordan/chainlink/core/internal/cltest/cltest.go:537 +0xf2
  github.com/smartcontractkit/chainlink/core/internal/cltest.(*TestApplication).Start.func1()
      /home/jordan/chainlink/core/internal/cltest/cltest.go:521 +0x34
  testing.(*common).Cleanup.func1()
      /snap/go/current/src/testing/testing.go:912 +0x199
  testing.(*common).runCleanup()
      /snap/go/current/src/testing/testing.go:1049 +0x154
  testing.tRunner.func2()
      /snap/go/current/src/testing/testing.go:1253 +0x4f
  testing.tRunner()
      /snap/go/current/src/testing/testing.go:1265 +0x268
  testing.(*T).Run·dwrap·21()
      /snap/go/current/src/testing/testing.go:1306 +0x47
==================
</pre></code>
</details>

<details>
<summary>PausableTicker</summary>
<pre><code>
==================
WARNING: DATA RACE
Read at 0x00c003906578 by goroutine 112:
  runtime.racereadrange()
      <autogenerated>:1 +0x1b
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Start.func1.1()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:268 +0x30
  github.com/smartcontractkit/chainlink/core/gracefulpanic.WrapRecover()
      /home/jordan/chainlink/core/gracefulpanic/recover.go:15 +0x52
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Start.func1·dwrap·1()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:267 +0x39

Previous write at 0x00c003906578 by goroutine 150:
  github.com/smartcontractkit/chainlink/core/utils.(*PausableTicker).Pause()
      /home/jordan/chainlink/core/utils/utils.go:821 +0xf1
  github.com/smartcontractkit/chainlink/core/utils.(*PausableTicker).Destroy()
      /home/jordan/chainlink/core/utils/utils.go:837 +0x44
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*PollManager).Stop()
      /home/jordan/chainlink/core/services/fluxmonitorv2/poll_manager.go:213 +0x37
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Close.func1()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:294 +0x4e
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StopOnce()
      /home/jordan/chainlink/core/utils/utils.go:1011 +0xf9
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Close()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:293 +0x64
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).stopService()
      /home/jordan/chainlink/core/services/job/spawner.go:128 +0x1f0
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).stopAllServices()
      /home/jordan/chainlink/core/services/job/spawner.go:116 +0x66
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).Close.func1()
      /home/jordan/chainlink/core/services/job/spawner.go:92 +0x4e
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StopOnce()
      /home/jordan/chainlink/core/utils/utils.go:1011 +0xf9
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).Close()
      /home/jordan/chainlink/core/services/job/spawner.go:90 +0x5c
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).stop.func1.1()
      /home/jordan/chainlink/core/services/chainlink/application.go:436 +0x211

Goroutine 112 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Start.func1()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:267 +0x178
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:984 +0xf4
  github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2.(*FluxMonitor).Start()
      /home/jordan/chainlink/core/services/fluxmonitorv2/flux_monitor.go:264 +0x64
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).StartService()
      /home/jordan/chainlink/core/services/job/spawner.go:167 +0xa15
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).CreateJob()
      /home/jordan/chainlink/core/services/job/spawner.go:209 +0x74b
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).AddJobV2()
      /home/jordan/chainlink/core/services/chainlink/application.go:521 +0x1a1
  github.com/smartcontractkit/chainlink/core/internal/cltest.(*TestApplication).AddJobV2()
      <autogenerated>:1 +0x164
  github.com/smartcontractkit/chainlink/core/web.(*JobsController).Create()
      /home/jordan/chainlink/core/web/jobs_controller.go:130 +0xc21
  github.com/smartcontractkit/chainlink/core/web.(*JobsController).Create-fm()
      /home/jordan/chainlink/core/web/jobs_controller.go:87 +0x44
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x1f9
  github.com/smartcontractkit/chainlink/core/web.RequireAuth.func1()
      /home/jordan/chainlink/core/web/authentication.go:132 +0x136
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x397
  github.com/gin-gonic/contrib/sessions.Sessions.func1()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/contrib@v0.0.0-20190526021735-7fb7810ed2a0/sessions/sessions.go:65 +0x2f4
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x342
  github.com/ulule/limiter/drivers/middleware/gin.(*Middleware).Handle()
      /home/jordan/go/pkg/mod/github.com/ulule/limiter@v0.0.0-20190417201358-7873d115fc4e/drivers/middleware/gin/middleware.go:57 +0x1e6
  github.com/ulule/limiter/drivers/middleware/gin.NewMiddleware.func1()
      /home/jordan/go/pkg/mod/github.com/ulule/limiter@v0.0.0-20190417201358-7873d115fc4e/drivers/middleware/gin/middleware.go:33 +0x3a
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x15c
  github.com/gin-gonic/gin.CustomRecoveryWithWriter.func1()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/recovery.go:99 +0xc5
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x496
  github.com/smartcontractkit/chainlink/core/web.loggerFunc.func1()
      /home/jordan/chainlink/core/web/router.go:431 +0x2e2
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x1e4
  github.com/gin-contrib/size.RequestSizeLimiter.func1()
      /home/jordan/go/pkg/mod/github.com/gin-contrib/size@v0.0.0-20190528085907-355431950c57/size.go:88 +0x17b
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0xae3
  github.com/gin-gonic/gin.(*Engine).handleHTTPRequest()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:489 +0x710
  github.com/gin-gonic/gin.(*Engine).ServeHTTP()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:445 +0x3a5
  net/http.serverHandler.ServeHTTP()
      /snap/go/current/src/net/http/server.go:2878 +0x89a
  net/http.(*conn).serve()
      /snap/go/current/src/net/http/server.go:1929 +0x12e4
  net/http.(*Server).Serve·dwrap·82()
      /snap/go/current/src/net/http/server.go:3033 +0x58

Goroutine 150 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).stop.func1()
      /home/jordan/chainlink/core/services/chainlink/application.go:419 +0x173
  sync.(*Once).doSlow()
      /snap/go/current/src/sync/once.go:68 +0x127
  sync.(*Once).Do()
      /snap/go/current/src/sync/once.go:59 +0x46
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).stop()
      /home/jordan/chainlink/core/services/chainlink/application.go:417 +0x96
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).StopIfStarted()
      /home/jordan/chainlink/core/services/chainlink/application.go:400 +0xc6
  github.com/smartcontractkit/chainlink/core/internal/cltest.(*TestApplication).Stop()
      /home/jordan/chainlink/core/internal/cltest/cltest.go:537 +0xf2
  github.com/smartcontractkit/chainlink/core/internal/cltest.(*TestApplication).Start.func1()
      /home/jordan/chainlink/core/internal/cltest/cltest.go:521 +0x34
  testing.(*common).Cleanup.func1()
      /snap/go/current/src/testing/testing.go:912 +0x199
  testing.(*common).runCleanup()
      /snap/go/current/src/testing/testing.go:1049 +0x154
  testing.tRunner.func2()
      /snap/go/current/src/testing/testing.go:1253 +0x4f
  testing.tRunner()
      /snap/go/current/src/testing/testing.go:1265 +0x268
  testing.(*T).Run·dwrap·21()
      /snap/go/current/src/testing/testing.go:1306 +0x47
==================
</pre></code>
</details>