### PR TITLE
resolve race due to NewBig shallow copy

### DIFF
--- a/core/utils/big.go
+++ b/core/utils/big.go
@@ -47,8 +47,9 @@ type Big big.Int
 // NewBig constructs a Big from *big.Int.
 func NewBig(i *big.Int) *Big {
 	if i != nil {
-		b := Big(*i)
-		return &b
+		var b big.Int
+		b.Set(i)
+		return (*Big)(&b)
 	}
 	return nil
 }


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Read at 0x00c0002112f8 by goroutine 64:
  runtime.racereadrange()
      <autogenerated>:1 +0x1b
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).backfill()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:311 +0x757
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Backfill()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:273 +0x217
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).backfiller()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:248 +0x374
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1·dwrap·14()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:128 +0x39

Previous write at 0x00c0002112f8 by goroutine 121:
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadListener).receiveHeaders()
      /home/jordan/chainlink/core/services/headtracker/head_listener.go:131 +0x4b3
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadListener).ListenForNewHeads()
      /home/jordan/chainlink/core/services/headtracker/head_listener.go:96 +0x1b5
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1·dwrap·13()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:127 +0x58

Goroutine 64 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:128 +0xb47
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:984 +0xf4
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:91 +0x64
  github.com/smartcontractkit/chainlink/core/services/headtracker_test.headTrackerUniverse.Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker_test.go:927 +0x55
  github.com/smartcontractkit/chainlink/core/services/headtracker_test.TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled()
      /home/jordan/chainlink/core/services/headtracker/head_tracker_test.go:567 +0x14ac
  testing.tRunner()
      /snap/go/current/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /snap/go/current/src/testing/testing.go:1306 +0x47

Goroutine 121 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:127 +0xac4
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:984 +0xf4
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:91 +0x64
  github.com/smartcontractkit/chainlink/core/services/headtracker_test.headTrackerUniverse.Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker_test.go:927 +0x55
  github.com/smartcontractkit/chainlink/core/services/headtracker_test.TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled()
      /home/jordan/chainlink/core/services/headtracker/head_tracker_test.go:567 +0x14ac
  testing.tRunner()
      /snap/go/current/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /snap/go/current/src/testing/testing.go:1306 +0x47
==================
==================
WARNING: DATA RACE
Read at 0x00c00045ec60 by goroutine 64:
  math/big.(*Int).Cmp()
      /snap/go/current/src/math/big/int.go:328 +0x4b
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*ORM).IdempotentInsertHead()
      /home/jordan/chainlink/core/services/headtracker/orm.go:32 +0x12d
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadSaver).Save()
      /home/jordan/chainlink/core/services/headtracker/head_saver.go:33 +0x18f
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).fetchAndSaveHead()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:332 +0x31b
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).backfill()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:311 +0x757
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Backfill()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:273 +0x217
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).backfiller()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:248 +0x374
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1·dwrap·14()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:128 +0x39

Previous write at 0x00c00045ec60 by goroutine 121:
  github.com/smartcontractkit/chainlink/core/utils.NewBig()
      /home/jordan/chainlink/core/utils/big.go:50 +0x3a9
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadListener).receiveHeaders()
      /home/jordan/chainlink/core/services/headtracker/head_listener.go:131 +0x3e5
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadListener).ListenForNewHeads()
      /home/jordan/chainlink/core/services/headtracker/head_listener.go:96 +0x1b5
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1·dwrap·13()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:127 +0x58

Goroutine 64 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:128 +0xb47
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:984 +0xf4
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:91 +0x64
  github.com/smartcontractkit/chainlink/core/services/headtracker_test.headTrackerUniverse.Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker_test.go:927 +0x55
  github.com/smartcontractkit/chainlink/core/services/headtracker_test.TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled()
      /home/jordan/chainlink/core/services/headtracker/head_tracker_test.go:567 +0x14ac
  testing.tRunner()
      /snap/go/current/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /snap/go/current/src/testing/testing.go:1306 +0x47

Goroutine 121 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:127 +0xac4
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:984 +0xf4
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:91 +0x64
  github.com/smartcontractkit/chainlink/core/services/headtracker_test.headTrackerUniverse.Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker_test.go:927 +0x55
  github.com/smartcontractkit/chainlink/core/services/headtracker_test.TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled()
      /home/jordan/chainlink/core/services/headtracker/head_tracker_test.go:567 +0x14ac
  testing.tRunner()
      /snap/go/current/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /snap/go/current/src/testing/testing.go:1306 +0x47
==================
==================
WARNING: DATA RACE
Read at 0x00c00045ec68 by goroutine 64:
  math/big.(*Int).Cmp()
      /snap/go/current/src/math/big/int.go:329 +0x84
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*ORM).IdempotentInsertHead()
      /home/jordan/chainlink/core/services/headtracker/orm.go:32 +0x12d
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadSaver).Save()
      /home/jordan/chainlink/core/services/headtracker/head_saver.go:33 +0x18f
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).fetchAndSaveHead()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:332 +0x31b
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).backfill()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:311 +0x757
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Backfill()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:273 +0x217
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).backfiller()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:248 +0x374
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1·dwrap·14()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:128 +0x39

Previous write at 0x00c00045ec68 by goroutine 121:
  github.com/smartcontractkit/chainlink/core/utils.NewBig()
      /home/jordan/chainlink/core/utils/big.go:50 +0x3a9
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadListener).receiveHeaders()
      /home/jordan/chainlink/core/services/headtracker/head_listener.go:131 +0x3e5
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadListener).ListenForNewHeads()
      /home/jordan/chainlink/core/services/headtracker/head_listener.go:96 +0x1b5
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1·dwrap·13()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:127 +0x58

Goroutine 64 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:128 +0xb47
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:984 +0xf4
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:91 +0x64
  github.com/smartcontractkit/chainlink/core/services/headtracker_test.headTrackerUniverse.Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker_test.go:927 +0x55
  github.com/smartcontractkit/chainlink/core/services/headtracker_test.TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled()
      /home/jordan/chainlink/core/services/headtracker/head_tracker_test.go:567 +0x14ac
  testing.tRunner()
      /snap/go/current/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /snap/go/current/src/testing/testing.go:1306 +0x47

Goroutine 121 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:127 +0xac4
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:984 +0xf4
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:91 +0x64
  github.com/smartcontractkit/chainlink/core/services/headtracker_test.headTrackerUniverse.Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker_test.go:927 +0x55
  github.com/smartcontractkit/chainlink/core/services/headtracker_test.TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled()
      /home/jordan/chainlink/core/services/headtracker/head_tracker_test.go:567 +0x14ac
  testing.tRunner()
      /snap/go/current/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /snap/go/current/src/testing/testing.go:1306 +0x47
==================
```