### PR TITLE
fix and deduplicate logger sync error handling

### DIFF
--- a/core/logger/default.go
+++ b/core/logger/default.go
@@ -1,7 +1,6 @@
 package logger
 
 import (
-	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -43,12 +42,8 @@ func InitLogger(newLogger Logger) {
 	if Default != nil {
 		defer func(l Logger) {
 			if err := l.Sync(); err != nil {
-				if errors.Unwrap(err).Error() != os.ErrInvalid.Error() &&
-					errors.Unwrap(err).Error() != "inappropriate ioctl for device" &&
-					errors.Unwrap(err).Error() != "bad file descriptor" {
-					// logger.Sync() will return 'invalid argument' error when closing file
-					log.Fatalf("failed to sync logger %+v", err)
-				}
+				// logger.Sync() will return 'invalid argument' error when closing file
+				log.Fatalf("failed to sync logger %+v", err)
 			}
 		}(Default)
 	}

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -3,7 +3,6 @@ package chainlink
 import (
 	"bytes"
 	"context"
-	stderr "errors"
 	"fmt"
 	"math/big"
 	"os"
@@ -420,11 +419,7 @@ func (app *ChainlinkApplication) stop() (err error) {
 			var merr error
 			defer func() {
 				if lerr := app.logger.Sync(); lerr != nil {
-					if stderr.Unwrap(lerr).Error() != os.ErrInvalid.Error() &&
-						stderr.Unwrap(lerr).Error() != "inappropriate ioctl for device" &&
-						stderr.Unwrap(lerr).Error() != "bad file descriptor" {
-						merr = multierr.Append(merr, lerr)
-					}
+					merr = multierr.Append(merr, lerr)
 				}
 			}()
 			app.logger.Info("Gracefully exiting...")


### PR DESCRIPTION
Fixing a secondary nil panic from #5243 which masks the primary error.