### PR TITLE
Adds `/chains/:ID` endpoint

### DIFF
--- a/core/web/router.go
+++ b/core/web/router.go
@@ -311,6 +311,7 @@ func v2Routes(app chainlink.Application, r *gin.RouterGroup) {
 		authv2.PATCH("/log", lgc.Patch)
 
 		chc := ChainsController{app}
+		authv2.GET("/chains/:ID", chc.Show)
 		authv2.GET("/chains/evm", paginatedRequest(chc.Index))
 		authv2.POST("/chains/evm", chc.Create)
 		authv2.GET("/chains/evm/:ID", chc.Show)


### PR DESCRIPTION
Towards: [Add a Show endpoint for chains](https://app.shortcut.com/chainlinklabs/story/19135/add-a-show-endpoint-to-the-api-for-chains)

No tests were added/included due to the controller not having tests. Working on tests in this story: https://app.shortcut.com/chainlinklabs/story/19192/add-tests-for-chains-resource-controller

