### PR TITLE
fix flakey keeper log tests

### DIFF
--- a/core/services/keeper/registry_synchronizer_test.go
+++ b/core/services/keeper/registry_synchronizer_test.go
@@ -208,7 +208,6 @@ func Test_RegistrySynchronizer_ConfigSetLog(t *testing.T) {
 
 	// Do the thing
 	synchronizer.HandleLog(logBroadcast)
-	synchronizer.ExportedProcessLogs()
 
 	cltest.AssertRecordEventually(t, db, &registry, func() bool {
 		return registry.BlockCountPerTurn == 40
@@ -252,7 +251,6 @@ func Test_RegistrySynchronizer_KeepersUpdatedLog(t *testing.T) {
 
 	// Do the thing
 	synchronizer.HandleLog(logBroadcast)
-	synchronizer.ExportedProcessLogs()
 
 	cltest.AssertRecordEventually(t, db, &registry, func() bool {
 		return registry.NumKeepers == 2
@@ -292,7 +290,6 @@ func Test_RegistrySynchronizer_UpkeepCanceledLog(t *testing.T) {
 
 	// Do the thing
 	synchronizer.HandleLog(logBroadcast)
-	synchronizer.ExportedProcessLogs()
 
 	cltest.WaitForCount(t, db, keeper.UpkeepRegistration{}, 2)
 	ethMock.AssertExpectations(t)
@@ -329,7 +326,6 @@ func Test_RegistrySynchronizer_UpkeepRegisteredLog(t *testing.T) {
 
 	// Do the thing
 	synchronizer.HandleLog(logBroadcast)
-	synchronizer.ExportedProcessLogs()
 
 	cltest.WaitForCount(t, db, keeper.UpkeepRegistration{}, 1)
 	ethMock.AssertExpectations(t)
@@ -373,7 +369,6 @@ func Test_RegistrySynchronizer_UpkeepPerformedLog(t *testing.T) {
 
 	// Do the thing
 	synchronizer.HandleLog(logBroadcast)
-	synchronizer.ExportedProcessLogs()
 
 	g.Eventually(func() int64 {
 		err := db.Find(&upkeep).Error


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/12632/flaky-test-test-registrysynchronizer-keepersupdatedlog