### PR TITLE
Use our forked version of go-txdb

### DIFF
--- a/core/internal/testutils/pgtest/pgtest.go
+++ b/core/internal/testutils/pgtest/pgtest.go
@@ -9,10 +9,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/DATA-DOG/go-txdb"
 	uuid "github.com/satori/go.uuid"
 	"github.com/scylladb/go-reflectx"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/go-txdb"
 	"github.com/smartcontractkit/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/go.mod
+++ b/go.mod
@@ -215,6 +215,7 @@ require (
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/shirou/gopsutil v3.21.4-0.20210419000835-c7a38de76ee5+incompatible // indirect
 	github.com/sirupsen/logrus v1.8.1 // indirect
+	github.com/smartcontractkit/go-txdb v0.1.4-0.20211026134358-1c83fe89b164 // indirect
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect
 	github.com/spaolacci/murmur3 v1.1.0 // indirect
 	github.com/spf13/afero v1.6.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1465,6 +1465,8 @@ github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartcontractkit/chainlink v0.8.10-0.20200825114219-81dd2fc95bac/go.mod h1:j7qIYHGCN4QqMXdO8g8A9dmUT5vKFmkxPSbjAIfrfNU=
 github.com/smartcontractkit/chainlink v0.9.5-0.20201207211610-6c7fee37d5b7/go.mod h1:kmdLJbVZRCnBLiL6gG+U+1+0ofT3bB48DOF8tjQvcoI=
+github.com/smartcontractkit/go-txdb v0.1.4-0.20211026134358-1c83fe89b164 h1:gUKeCZCt12Bi+A1nAfWi4Ro7nXOvRAZk8l7H1beipeY=
+github.com/smartcontractkit/go-txdb v0.1.4-0.20211026134358-1c83fe89b164/go.mod h1:FQ2spG6UFx1V24tAdp4h+iHG3coFkIx/hBRyE+6DKfY=
 github.com/smartcontractkit/goose/v3 v3.1.1-0.20210921045349-e8cd8fc6557b h1:DwCUCl0MmdfIM5D8ymhPLVFMqebLWZliVQFf5jcNRKA=
 github.com/smartcontractkit/goose/v3 v3.1.1-0.20210921045349-e8cd8fc6557b/go.mod h1:tYsY0oL0yd48jg15POIZfOZiu66mqWpfDd/nJ28KWyU=
 github.com/smartcontractkit/libocr v0.0.0-20201203233047-5d9b24f0cbb5/go.mod h1:bfdSuLnBWCkafDvPGsQ1V6nrXhg046gh227MKi4zkpc=


### PR DESCRIPTION
A hypothesis: that the `realconn` in go-txdb is using pgx in a non-threadsafe way and this is causing "conn busy" etc in our tests