### PR TITLE
config: fix conversions for ETH_FINALITY_DEPTH, ETH_HEAD_TRACKER_HISTORY_DEPTH, and ETH_GAS_LIMIT_MULTIPLIER

### DIFF
--- a/core/store/config/evm_config.go
+++ b/core/store/config/evm_config.go
@@ -297,7 +297,7 @@ func (c *evmConfig) SetEvmGasPriceDefault(value *big.Int) error {
 func (c *evmConfig) EvmFinalityDepth() uint {
 	val, ok := lookupEnv("ETH_FINALITY_DEPTH", parseUint64)
 	if ok {
-		return val.(uint)
+		return uint(val.(uint64))
 	}
 	return c.chainSpecificConfig.FinalityDepth
 }
@@ -309,7 +309,7 @@ func (c *evmConfig) EvmFinalityDepth() uint {
 func (c *evmConfig) EvmHeadTrackerHistoryDepth() uint {
 	val, ok := lookupEnv("ETH_HEAD_TRACKER_HISTORY_DEPTH", parseUint64)
 	if ok {
-		return val.(uint)
+		return uint(val.(uint64))
 	}
 	return c.chainSpecificConfig.HeadTrackerHistoryDepth
 }

--- a/core/store/config/general_config.go
+++ b/core/store/config/general_config.go
@@ -1196,7 +1196,7 @@ func parseUint64(s string) (interface{}, error) {
 
 func parseF32(s string) (interface{}, error) {
 	v, err := strconv.ParseFloat(s, 32)
-	return v, err
+	return float32(v), err
 }
 
 func parseURL(s string) (interface{}, error) {


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/19980/unhandled-panic-when-using-env-eth-finality-depth-or-eth-head-tracker-history-depth

Also backports the related #5299