### PR TITLE
core/chains/evm/config: fix races for chainScopedConfig.persistedCfg

### DIFF
--- a/core/chains/evm/config/config_test.go
+++ b/core/chains/evm/config/config_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/chains"
 	evmconfig "github.com/smartcontractkit/chainlink/core/chains/evm/config"
 	evmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/mocks"
+	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
@@ -64,7 +65,9 @@ func TestChainScopedConfig(t *testing.T) {
 		addr := cltest.NewAddress()
 		randomOtherAddr := cltest.NewAddress()
 		randomOtherKeySpecific := evmtypes.ChainCfg{EvmMaxGasPriceWei: utils.NewBigI(rand.Int63())}
-		evmconfig.PersistedCfgPtr(cfg).KeySpecific[randomOtherAddr.Hex()] = randomOtherKeySpecific
+		evmconfig.UpdatePersistedCfg(cfg, func(cfg *types.ChainCfg) {
+			cfg.KeySpecific[randomOtherAddr.Hex()] = randomOtherKeySpecific
+		})
 
 		t.Run("uses chain-specific default value when nothing is set", func(t *testing.T) {
 			assert.Equal(t, big.NewInt(5000000000000), cfg.KeySpecificMaxGasPriceWei(addr))
@@ -72,14 +75,18 @@ func TestChainScopedConfig(t *testing.T) {
 
 		t.Run("uses chain-specific override value when that is set", func(t *testing.T) {
 			val := utils.NewBigI(rand.Int63())
-			evmconfig.PersistedCfgPtr(cfg).EvmMaxGasPriceWei = val
+			evmconfig.UpdatePersistedCfg(cfg, func(cfg *types.ChainCfg) {
+				cfg.EvmMaxGasPriceWei = val
+			})
 
 			assert.Equal(t, val.String(), cfg.KeySpecificMaxGasPriceWei(addr).String())
 		})
 		t.Run("uses key-specific override value when that is set", func(t *testing.T) {
 			val := utils.NewBigI(rand.Int63())
 			keySpecific := evmtypes.ChainCfg{EvmMaxGasPriceWei: val}
-			evmconfig.PersistedCfgPtr(cfg).KeySpecific[addr.Hex()] = keySpecific
+			evmconfig.UpdatePersistedCfg(cfg, func(cfg *types.ChainCfg) {
+				cfg.KeySpecific[addr.Hex()] = keySpecific
+			})
 
 			assert.Equal(t, val.String(), cfg.KeySpecificMaxGasPriceWei(addr).String())
 		})

--- a/core/chains/evm/config/helpers_test.go
+++ b/core/chains/evm/config/helpers_test.go
@@ -2,8 +2,11 @@ package config
 
 import "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 
-func PersistedCfgPtr(cfg ChainScopedConfig) *types.ChainCfg {
-	return &cfg.(*chainScopedConfig).persistedCfg
+func UpdatePersistedCfg(cfg ChainScopedConfig, updateFn func(*types.ChainCfg)) {
+	c := cfg.(*chainScopedConfig)
+	c.persistMu.Lock()
+	defer c.persistMu.Unlock()
+	updateFn(&c.persistedCfg)
 }
 
 func ChainSpecificConfigDefaultSets() map[int64]chainSpecificConfigDefaultSet {


### PR DESCRIPTION
<details>
<summary>Race Traces</summary>

<pre>
==================
WARNING: DATA RACE
Write at 0x00c0011f7c68 by goroutine 142:
  github.com/smartcontractkit/chainlink/core/chains/evm/config.(*chainScopedConfig).Configure()
      /home/jordan/chainlink/core/chains/evm/config/config.go:116 +0x46
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chainSet).UpdateConfig()
      /home/jordan/chainlink/core/chains/evm/chain_set.go:235 +0x91c
  github.com/smartcontractkit/chainlink/core/web.(*ETHKeysController).Update()
      /home/jordan/chainlink/core/web/eth_keys_controller.go:164 +0x48b
  github.com/smartcontractkit/chainlink/core/web.(*ETHKeysController).Update-fm()
      /home/jordan/chainlink/core/web/eth_keys_controller.go:135 +0x44
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x1f9
  github.com/smartcontractkit/chainlink/core/web/auth.Authenticate.func1()
      /home/jordan/chainlink/core/web/auth/auth.go:156 +0x136
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x397
  github.com/gin-gonic/contrib/sessions.Sessions.func1()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/contrib@v0.0.0-20190526021735-7fb7810ed2a0/sessions/sessions.go:65 +0x2f4
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x342
  github.com/ulule/limiter/drivers/middleware/gin.(*Middleware).Handle()
      /home/jordan/go/pkg/mod/github.com/ulule/limiter@v0.0.0-20190417201358-7873d115fc4e/drivers/middleware/gin/middleware.go:57 +0x1e6
  github.com/ulule/limiter/drivers/middleware/gin.NewMiddleware.func1()
      /home/jordan/go/pkg/mod/github.com/ulule/limiter@v0.0.0-20190417201358-7873d115fc4e/drivers/middleware/gin/middleware.go:33 +0x3a
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x15c
  github.com/gin-gonic/gin.CustomRecoveryWithWriter.func1()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/recovery.go:99 +0xc5
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x4a5
  github.com/smartcontractkit/chainlink/core/web.loggerFunc.func1()
      /home/jordan/chainlink/core/web/router.go:446 +0x2e2
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x1e4
  github.com/gin-contrib/size.RequestSizeLimiter.func1()
      /home/jordan/go/pkg/mod/github.com/gin-contrib/size@v0.0.0-20190528085907-355431950c57/size.go:88 +0x17b
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0xae3
  github.com/gin-gonic/gin.(*Engine).handleHTTPRequest()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:489 +0x710
  github.com/gin-gonic/gin.(*Engine).ServeHTTP()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:445 +0x3a5
  net/http.serverHandler.ServeHTTP()
      /snap/go/current/src/net/http/server.go:2878 +0x89a
  net/http.(*conn).serve()
      /snap/go/current/src/net/http/server.go:1929 +0x12e4
  net/http.(*Server).Serve·dwrap·82()
      /snap/go/current/src/net/http/server.go:3033 +0x58

Previous read at 0x00c0011f7c68 by goroutine 51:
  github.com/smartcontractkit/chainlink/core/chains/evm/config.(*chainScopedConfig).EvmFinalityDepth()
      /home/jordan/chainlink/core/chains/evm/config/config.go:431 +0x5d
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).backfiller()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:248 +0x329
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1·dwrap·14()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:128 +0x39

Goroutine 142 (running) created at:
  net/http.(*Server).Serve()
      /snap/go/current/src/net/http/server.go:3033 +0x847
  net/http/httptest.(*Server).goServe.func1()
      /snap/go/current/src/net/http/httptest/server.go:308 +0xc4

Goroutine 51 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:128 +0xb47
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:983 +0xf4
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:91 +0x64
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chain).Start.func1()
      /home/jordan/chainlink/core/chains/evm/chain.go:179 +0x2e6
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:983 +0xf4
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chain).Start()
      /home/jordan/chainlink/core/chains/evm/chain.go:167 +0x58
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chainSet).Start()
      /home/jordan/chainlink/core/chains/evm/chain_set.go:61 +0x373
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).Start()
      /home/jordan/chainlink/core/services/chainlink/application.go:387 +0x66f
  github.com/smartcontractkit/chainlink/core/internal/cltest.(*TestApplication).Start()
      /home/jordan/chainlink/core/internal/cltest/cltest.go:504 +0xd2
  github.com/smartcontractkit/chainlink/core/cmd_test.startNewApplication()
      /home/jordan/chainlink/core/cmd/remote_client_test.go:75 +0x284
  github.com/smartcontractkit/chainlink/core/cmd_test.TestClient_UpdateETHKey()
      /home/jordan/chainlink/core/cmd/eth_keys_commands_test.go:172 +0x4fe
  testing.tRunner()
      /snap/go/current/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /snap/go/current/src/testing/testing.go:1306 +0x47
==================
==================
WARNING: DATA RACE
Write at 0x00c0011f7cf0 by goroutine 142:
  github.com/smartcontractkit/chainlink/core/chains/evm/config.(*chainScopedConfig).Configure()
      /home/jordan/chainlink/core/chains/evm/config/config.go:116 +0x46
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chainSet).UpdateConfig()
      /home/jordan/chainlink/core/chains/evm/chain_set.go:235 +0x91c
  github.com/smartcontractkit/chainlink/core/web.(*ETHKeysController).Update()
      /home/jordan/chainlink/core/web/eth_keys_controller.go:164 +0x48b
  github.com/smartcontractkit/chainlink/core/web.(*ETHKeysController).Update-fm()
      /home/jordan/chainlink/core/web/eth_keys_controller.go:135 +0x44
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x1f9
  github.com/smartcontractkit/chainlink/core/web/auth.Authenticate.func1()
      /home/jordan/chainlink/core/web/auth/auth.go:156 +0x136
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x397
  github.com/gin-gonic/contrib/sessions.Sessions.func1()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/contrib@v0.0.0-20190526021735-7fb7810ed2a0/sessions/sessions.go:65 +0x2f4
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x342
  github.com/ulule/limiter/drivers/middleware/gin.(*Middleware).Handle()
      /home/jordan/go/pkg/mod/github.com/ulule/limiter@v0.0.0-20190417201358-7873d115fc4e/drivers/middleware/gin/middleware.go:57 +0x1e6
  github.com/ulule/limiter/drivers/middleware/gin.NewMiddleware.func1()
      /home/jordan/go/pkg/mod/github.com/ulule/limiter@v0.0.0-20190417201358-7873d115fc4e/drivers/middleware/gin/middleware.go:33 +0x3a
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x15c
  github.com/gin-gonic/gin.CustomRecoveryWithWriter.func1()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/recovery.go:99 +0xc5
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x4a5
  github.com/smartcontractkit/chainlink/core/web.loggerFunc.func1()
      /home/jordan/chainlink/core/web/router.go:446 +0x2e2
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x1e4
  github.com/gin-contrib/size.RequestSizeLimiter.func1()
      /home/jordan/go/pkg/mod/github.com/gin-contrib/size@v0.0.0-20190528085907-355431950c57/size.go:88 +0x17b
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0xae3
  github.com/gin-gonic/gin.(*Engine).handleHTTPRequest()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:489 +0x710
  github.com/gin-gonic/gin.(*Engine).ServeHTTP()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:445 +0x3a5
  net/http.serverHandler.ServeHTTP()
      /snap/go/current/src/net/http/server.go:2878 +0x89a
  net/http.(*conn).serve()
      /snap/go/current/src/net/http/server.go:1929 +0x12e4
  net/http.(*Server).Serve·dwrap·82()
      /snap/go/current/src/net/http/server.go:3033 +0x58

Previous read at 0x00c0011f7cf0 by goroutine 249:
  github.com/smartcontractkit/chainlink/core/chains/evm/config.(*chainScopedConfig).EvmHeadTrackerSamplingInterval()
      /home/jordan/chainlink/core/chains/evm/config/config.go:464 +0x65
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).headCallbackLoop()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:182 +0xc5
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1·dwrap·15()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:129 +0x39

Goroutine 142 (running) created at:
  net/http.(*Server).Serve()
      /snap/go/current/src/net/http/server.go:3033 +0x847
  net/http/httptest.(*Server).goServe.func1()
      /snap/go/current/src/net/http/httptest/server.go:308 +0xc4

Goroutine 249 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:129 +0xbca
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:983 +0xf4
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:91 +0x64
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chain).Start.func1()
      /home/jordan/chainlink/core/chains/evm/chain.go:179 +0x2e6
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:983 +0xf4
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chain).Start()
      /home/jordan/chainlink/core/chains/evm/chain.go:167 +0x58
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chainSet).Start()
      /home/jordan/chainlink/core/chains/evm/chain_set.go:61 +0x373
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).Start()
      /home/jordan/chainlink/core/services/chainlink/application.go:387 +0x66f
  github.com/smartcontractkit/chainlink/core/internal/cltest.(*TestApplication).Start()
      /home/jordan/chainlink/core/internal/cltest/cltest.go:504 +0xd2
  github.com/smartcontractkit/chainlink/core/cmd_test.startNewApplication()
      /home/jordan/chainlink/core/cmd/remote_client_test.go:75 +0x284
  github.com/smartcontractkit/chainlink/core/cmd_test.TestClient_UpdateETHKey()
      /home/jordan/chainlink/core/cmd/eth_keys_commands_test.go:172 +0x4fe
  testing.tRunner()
      /snap/go/current/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /snap/go/current/src/testing/testing.go:1306 +0x47
==================
==================
WARNING: DATA RACE
Write at 0x00c0036eb468 by goroutine 101:
  github.com/smartcontractkit/chainlink/core/chains/evm/config.(*chainScopedConfig).Configure()
      /home/jordan/chainlink/core/chains/evm/config/config.go:116 +0x46
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chainSet).UpdateConfig()
      /home/jordan/chainlink/core/chains/evm/chain_set.go:235 +0x91c
  github.com/smartcontractkit/chainlink/core/web.(*ETHKeysController).Create()
      /home/jordan/chainlink/core/web/eth_keys_controller.go:108 +0x451
  github.com/smartcontractkit/chainlink/core/web.(*ETHKeysController).Create-fm()
      /home/jordan/chainlink/core/web/eth_keys_controller.go:76 +0x44
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x1f9
  github.com/smartcontractkit/chainlink/core/web/auth.Authenticate.func1()
      /home/jordan/chainlink/core/web/auth/auth.go:156 +0x136
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x397
  github.com/gin-gonic/contrib/sessions.Sessions.func1()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/contrib@v0.0.0-20190526021735-7fb7810ed2a0/sessions/sessions.go:65 +0x2f4
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x342
  github.com/ulule/limiter/drivers/middleware/gin.(*Middleware).Handle()
      /home/jordan/go/pkg/mod/github.com/ulule/limiter@v0.0.0-20190417201358-7873d115fc4e/drivers/middleware/gin/middleware.go:57 +0x1e6
  github.com/ulule/limiter/drivers/middleware/gin.NewMiddleware.func1()
      /home/jordan/go/pkg/mod/github.com/ulule/limiter@v0.0.0-20190417201358-7873d115fc4e/drivers/middleware/gin/middleware.go:33 +0x3a
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x15c
  github.com/gin-gonic/gin.CustomRecoveryWithWriter.func1()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/recovery.go:99 +0xc5
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x4a5
  github.com/smartcontractkit/chainlink/core/web.loggerFunc.func1()
      /home/jordan/chainlink/core/web/router.go:446 +0x2e2
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x1e4
  github.com/gin-contrib/size.RequestSizeLimiter.func1()
      /home/jordan/go/pkg/mod/github.com/gin-contrib/size@v0.0.0-20190528085907-355431950c57/size.go:88 +0x17b
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0xae3
  github.com/gin-gonic/gin.(*Engine).handleHTTPRequest()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:489 +0x710
  github.com/gin-gonic/gin.(*Engine).ServeHTTP()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:445 +0x3a5
  net/http.serverHandler.ServeHTTP()
      /snap/go/current/src/net/http/server.go:2878 +0x89a
  net/http.(*conn).serve()
      /snap/go/current/src/net/http/server.go:1929 +0x12e4
  net/http.(*Server).Serve·dwrap·82()
      /snap/go/current/src/net/http/server.go:3033 +0x58

Previous read at 0x00c0036eb468 by goroutine 105:
  github.com/smartcontractkit/chainlink/core/chains/evm/config.(*chainScopedConfig).EvmFinalityDepth()
      /home/jordan/chainlink/core/chains/evm/config/config.go:431 +0x5d
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).backfiller()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:248 +0x329
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1·dwrap·14()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:128 +0x39

Goroutine 101 (running) created at:
  net/http.(*Server).Serve()
      /snap/go/current/src/net/http/server.go:3033 +0x847
  net/http/httptest.(*Server).goServe.func1()
      /snap/go/current/src/net/http/httptest/server.go:308 +0xc4

Goroutine 105 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:128 +0xb47
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:983 +0xf4
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:91 +0x64
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chain).Start.func1()
      /home/jordan/chainlink/core/chains/evm/chain.go:179 +0x2e6
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:983 +0xf4
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chain).Start()
      /home/jordan/chainlink/core/chains/evm/chain.go:167 +0x58
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chainSet).Start()
      /home/jordan/chainlink/core/chains/evm/chain_set.go:61 +0x373
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).Start()
      /home/jordan/chainlink/core/services/chainlink/application.go:387 +0x66f
  github.com/smartcontractkit/chainlink/core/internal/cltest.(*TestApplication).Start()
      /home/jordan/chainlink/core/internal/cltest/cltest.go:504 +0xd2
  github.com/smartcontractkit/chainlink/core/cmd_test.startNewApplication()
      /home/jordan/chainlink/core/cmd/remote_client_test.go:75 +0x284
  github.com/smartcontractkit/chainlink/core/cmd_test.TestClient_CreateETHKey()
      /home/jordan/chainlink/core/cmd/eth_keys_commands_test.go:117 +0x4fe
  testing.tRunner()
      /snap/go/current/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /snap/go/current/src/testing/testing.go:1306 +0x47
==================
==================
WARNING: DATA RACE
Write at 0x00c0036eb4f0 by goroutine 101:
  github.com/smartcontractkit/chainlink/core/chains/evm/config.(*chainScopedConfig).Configure()
      /home/jordan/chainlink/core/chains/evm/config/config.go:116 +0x46
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chainSet).UpdateConfig()
      /home/jordan/chainlink/core/chains/evm/chain_set.go:235 +0x91c
  github.com/smartcontractkit/chainlink/core/web.(*ETHKeysController).Create()
      /home/jordan/chainlink/core/web/eth_keys_controller.go:108 +0x451
  github.com/smartcontractkit/chainlink/core/web.(*ETHKeysController).Create-fm()
      /home/jordan/chainlink/core/web/eth_keys_controller.go:76 +0x44
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x1f9
  github.com/smartcontractkit/chainlink/core/web/auth.Authenticate.func1()
      /home/jordan/chainlink/core/web/auth/auth.go:156 +0x136
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x397
  github.com/gin-gonic/contrib/sessions.Sessions.func1()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/contrib@v0.0.0-20190526021735-7fb7810ed2a0/sessions/sessions.go:65 +0x2f4
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x342
  github.com/ulule/limiter/drivers/middleware/gin.(*Middleware).Handle()
      /home/jordan/go/pkg/mod/github.com/ulule/limiter@v0.0.0-20190417201358-7873d115fc4e/drivers/middleware/gin/middleware.go:57 +0x1e6
  github.com/ulule/limiter/drivers/middleware/gin.NewMiddleware.func1()
      /home/jordan/go/pkg/mod/github.com/ulule/limiter@v0.0.0-20190417201358-7873d115fc4e/drivers/middleware/gin/middleware.go:33 +0x3a
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x15c
  github.com/gin-gonic/gin.CustomRecoveryWithWriter.func1()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/recovery.go:99 +0xc5
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x4a5
  github.com/smartcontractkit/chainlink/core/web.loggerFunc.func1()
      /home/jordan/chainlink/core/web/router.go:446 +0x2e2
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0x1e4
  github.com/gin-contrib/size.RequestSizeLimiter.func1()
      /home/jordan/go/pkg/mod/github.com/gin-contrib/size@v0.0.0-20190528085907-355431950c57/size.go:88 +0x17b
  github.com/gin-gonic/gin.(*Context).Next()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/context.go:165 +0xae3
  github.com/gin-gonic/gin.(*Engine).handleHTTPRequest()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:489 +0x710
  github.com/gin-gonic/gin.(*Engine).ServeHTTP()
      /home/jordan/go/pkg/mod/github.com/gin-gonic/gin@v1.7.2/gin.go:445 +0x3a5
  net/http.serverHandler.ServeHTTP()
      /snap/go/current/src/net/http/server.go:2878 +0x89a
  net/http.(*conn).serve()
      /snap/go/current/src/net/http/server.go:1929 +0x12e4
  net/http.(*Server).Serve·dwrap·82()
      /snap/go/current/src/net/http/server.go:3033 +0x58

Previous read at 0x00c0036eb4f0 by goroutine 184:
  github.com/smartcontractkit/chainlink/core/chains/evm/config.(*chainScopedConfig).EvmHeadTrackerSamplingInterval()
      /home/jordan/chainlink/core/chains/evm/config/config.go:464 +0x65
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).headCallbackLoop()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:182 +0xc5
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1·dwrap·15()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:129 +0x39

Goroutine 101 (running) created at:
  net/http.(*Server).Serve()
      /snap/go/current/src/net/http/server.go:3033 +0x847
  net/http/httptest.(*Server).goServe.func1()
      /snap/go/current/src/net/http/httptest/server.go:308 +0xc4

Goroutine 184 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start.func1()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:129 +0xbca
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:983 +0xf4
  github.com/smartcontractkit/chainlink/core/services/headtracker.(*HeadTracker).Start()
      /home/jordan/chainlink/core/services/headtracker/head_tracker.go:91 +0x64
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chain).Start.func1()
      /home/jordan/chainlink/core/chains/evm/chain.go:179 +0x2e6
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/jordan/chainlink/core/utils/utils.go:983 +0xf4
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chain).Start()
      /home/jordan/chainlink/core/chains/evm/chain.go:167 +0x58
  github.com/smartcontractkit/chainlink/core/chains/evm.(*chainSet).Start()
      /home/jordan/chainlink/core/chains/evm/chain_set.go:61 +0x373
  github.com/smartcontractkit/chainlink/core/services/chainlink.(*ChainlinkApplication).Start()
      /home/jordan/chainlink/core/services/chainlink/application.go:387 +0x66f
  github.com/smartcontractkit/chainlink/core/internal/cltest.(*TestApplication).Start()
      /home/jordan/chainlink/core/internal/cltest/cltest.go:504 +0xd2
  github.com/smartcontractkit/chainlink/core/cmd_test.startNewApplication()
      /home/jordan/chainlink/core/cmd/remote_client_test.go:75 +0x284
  github.com/smartcontractkit/chainlink/core/cmd_test.TestClient_CreateETHKey()
      /home/jordan/chainlink/core/cmd/eth_keys_commands_test.go:117 +0x4fe
  testing.tRunner()
      /snap/go/current/src/testing/testing.go:1259 +0x22f
  testing.(*T).Run·dwrap·21()
      /snap/go/current/src/testing/testing.go:1306 +0x47
==================

</pre>
</details>