### PR TITLE
Make WebAuthnSessionStore concurrent safe

### DIFF
--- a/core/sessions/orm.go
+++ b/core/sessions/orm.go
@@ -124,7 +124,7 @@ func (o *orm) CreateSession(sr SessionRequest) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	lggr := o.lggr.With("user", user)
+	lggr := o.lggr.With("user", user.Email)
 	lggr.Debugw("Found user")
 
 	// Do email and password check first to prevent extra database look up

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -221,7 +221,7 @@ func v2Routes(app chainlink.Application, r *gin.RouterGroup) {
 		authv2.POST("/user/token", uc.NewAPIToken)
 		authv2.POST("/user/token/delete", uc.DeleteAPIToken)
 
-		wa := WebAuthnController{app, nil}
+		wa := NewWebAuthnController(app)
 		authv2.GET("/enroll_webauthn", wa.BeginRegistration)
 		authv2.POST("/enroll_webauthn", wa.FinishRegistration)
 


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/20712

- eliminate lazy init
- protect the internal `inProgressRegistrations` map with a Mutex
- refactor some funcs in to methods to drop nil checks
- wrap some errors to be logged up the stack, instead of calling logger helper funcs
