### PR TITLE
Reliably repro index out of range [0] with length 0 (or "conn busy") test flake

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -334,7 +334,7 @@ func NewApplicationWithConfig(t testing.TB, cfg *configtest.TestGeneralConfig, f
 		MaxIdleConns:     cfg.ORMMaxIdleConns(),
 	})
 	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, sqlxDB.Close()) })
+	// t.Cleanup(func() { assert.NoError(t, sqlxDB.Close()) })
 
 	var ethClient eth.Client
 	var externalInitiatorManager webhook.ExternalInitiatorManager

--- a/core/internal/cltest/heavyweight/orm.go
+++ b/core/internal/cltest/heavyweight/orm.go
@@ -14,7 +14,6 @@ import (
 	"runtime"
 	"testing"
 
-	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/postgres"
@@ -30,9 +29,9 @@ import (
 // FullTestDB creates an DB which runs in a separate database than the normal
 // unit tests, so you can do things like use other Postgres connection types
 // with it.
-func FullTestDB(t *testing.T, name string, migrate bool, loadFixtures bool) (*configtest.TestGeneralConfig, *sqlx.DB, *gorm.DB) {
+func FullTestDB(t testing.TB, name string, migrate bool, loadFixtures bool) (*configtest.TestGeneralConfig, *sqlx.DB, *gorm.DB) {
 	overrides := configtest.GeneralConfigOverrides{
-		SecretGenerator: cltest.MockSecretGenerator{},
+		SecretGenerator: configtest.MockSecretGenerator{},
 	}
 	gcfg := configtest.NewTestGeneralConfigWithOverrides(t, overrides)
 	gcfg.SetDialect(dialects.Postgres)

--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -433,12 +433,6 @@ func (m *MockSessionRequestBuilder) Build(string) (sessions.SessionRequest, erro
 	return sessions.SessionRequest{Email: APIEmail, Password: Password}, nil
 }
 
-type MockSecretGenerator struct{}
-
-func (m MockSecretGenerator) Generate(string) ([]byte, error) {
-	return []byte(SessionSecret), nil
-}
-
 type MockChangePasswordPrompter struct {
 	web.UpdatePasswordRequest
 	err error

--- a/core/internal/testutils/configtest/mocks.go
+++ b/core/internal/testutils/configtest/mocks.go
@@ -1,0 +1,12 @@
+package configtest
+
+const (
+	// SessionSecret is the hardcoded secret solely used for test
+	SessionSecret = "clsession_test_secret"
+)
+
+type MockSecretGenerator struct{}
+
+func (m MockSecretGenerator) Generate(string) ([]byte, error) {
+	return []byte(SessionSecret), nil
+}

--- a/core/internal/testutils/pgtest/pgtest.go
+++ b/core/internal/testutils/pgtest/pgtest.go
@@ -13,7 +13,6 @@ import (
 	"github.com/scylladb/go-reflectx"
 	"github.com/smartcontractkit/go-txdb"
 	"github.com/smartcontractkit/sqlx"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gorm.io/driver/postgres"
 	"gorm.io/gorm"
@@ -81,7 +80,7 @@ func GormDBFromSql(t *testing.T, db *sql.DB) *gorm.DB {
 func NewSqlDB(t *testing.T) *sql.DB {
 	db, err := sql.Open("txdb", uuid.NewV4().String())
 	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, db.Close()) })
+	// t.Cleanup(func() { assert.NoError(t, db.Close()) })
 
 	// There is a bug to do with context cancellation somewhere in txdb, sql or
 	// gorm. If you try to use the DB "too quickly" using a .WithContext then
@@ -102,7 +101,7 @@ func NewSqlDB(t *testing.T) *sql.DB {
 func NewSqlxDB(t *testing.T) *sqlx.DB {
 	db, err := sqlx.Open("txdb", uuid.NewV4().String())
 	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, db.Close()) })
+	// t.Cleanup(func() { assert.NoError(t, db.Close()) })
 
 	db.MapperFunc(reflectx.CamelToSnakeASCII)
 

--- a/core/internal/testutils/pgtest/pgtest.go
+++ b/core/internal/testutils/pgtest/pgtest.go
@@ -20,6 +20,7 @@ import (
 	"gorm.io/gorm/clause"
 
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/shutdown"
 )
 
 func init() {
@@ -51,6 +52,9 @@ func init() {
 	// https://app.clubhouse.io/chainlinklabs/story/8781/remove-dependency-on-gorm
 	txdb.Register("txdb", "pgx", dbURL, txdb.SavePointOption(nil))
 	sqlx.BindDriver("txdb", sqlx.DOLLAR)
+
+	// Always hard panic in any test that requires the DB
+	shutdown.HardPanic = true
 }
 
 func NewGormDB(t *testing.T) *gorm.DB {

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -464,7 +464,7 @@ func (app *ChainlinkApplication) stop() (err error) {
 
 			// DB should pretty much always be closed last
 			app.logger.Debug("Closing DB...")
-			merr = multierr.Append(merr, app.sqlxDB.Close())
+			// merr = multierr.Append(merr, app.sqlxDB.Close())
 
 			app.logger.Info("Exited all services")
 

--- a/core/services/directrequest/delegate.go
+++ b/core/services/directrequest/delegate.go
@@ -81,6 +81,9 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.Service, error) {
 		return nil, errors.Wrapf(err, "DirectRequest: failed to create an operator wrapper for address: %v", concreteSpec.ContractAddress.Address().String())
 	}
 
+	if jb.PipelineSpec == nil {
+		panic("BALLS PipelineSpec nil")
+	}
 	svcLogger := d.logger.
 		With(
 			"contract", concreteSpec.ContractAddress.Address().String(),

--- a/core/services/postgres/event_broadcaster.go
+++ b/core/services/postgres/event_broadcaster.go
@@ -111,7 +111,7 @@ func (b *eventBroadcaster) Close() error {
 		defer b.subscriptionsMu.RUnlock()
 		b.subscriptions = nil
 
-		err = multierr.Append(err, b.db.Close())
+		// err = multierr.Append(err, b.db.Close())
 		err = multierr.Append(err, b.listener.Close())
 		close(b.chStop)
 		<-b.chDone

--- a/core/services/postgres/q.go
+++ b/core/services/postgres/q.go
@@ -6,6 +6,7 @@ package postgres
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -104,6 +105,7 @@ func PrepareQueryRowx(q Queryer, sql string, dest interface{}, arg interface{}) 
 	if err != nil {
 		return errors.Wrap(err, "error preparing named statement")
 	}
+	fmt.Printf("BALLS q %#v\n", q)
 	return errors.Wrap(stmt.QueryRowx(arg).Scan(dest), "error querying row")
 }
 
@@ -115,9 +117,9 @@ func (q Q) Context() (context.Context, context.CancelFunc) {
 }
 
 func (q Q) Transaction(lggr logger.Logger, fc func(q Queryer) error) error {
-	ctx, cancel := q.Context()
-	defer cancel()
-	return SqlxTransaction(ctx, q.Queryer, lggr, fc)
+	// ctx, cancel := q.Context()
+	// defer cancel()
+	return SqlxTransaction(context.Background(), q.Queryer, lggr, fc)
 }
 
 // CAUTION: A subtle problem lurks here, because the following code is buggy:

--- a/core/services/postgres/transaction.go
+++ b/core/services/postgres/transaction.go
@@ -9,7 +9,6 @@ import (
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/sqlx"
-	"go.uber.org/multierr"
 	"gorm.io/gorm"
 )
 
@@ -129,38 +128,41 @@ func sqlxTransaction(ctx context.Context, db *sqlx.DB, lggr logger.Logger, fn fu
 
 func sqlxTransactionQ(ctx context.Context, db *sqlx.DB, lggr logger.Logger, fn func(q Queryer) error, optss ...TxOptions) (err error) {
 	lockTimeout, idleInTxSessionTimeout, txOpts := applyDefaults(optss)
+	fmt.Println(txOpts)
 
-	tx, err := db.BeginTxx(ctx, &txOpts)
-	if err != nil {
-		return errors.Wrap(err, "failed to begin transaction")
-	}
+	// tx, err := db.BeginTxx(ctx, &txOpts)
+	// if err != nil {
+	//     return errors.Wrap(err, "failed to begin transaction")
+	// }
+	tx := db
 
 	defer func() {
-		if p := recover(); p != nil {
-			// A panic occurred, rollback and repanic
-			lggr.Errorf("Panic in transaction, rolling back: %s", p)
-			done := make(chan struct{})
-			go func() {
-				if rerr := tx.Rollback(); rerr != nil {
-					lggr.Errorf("Failed to rollback on panic: %s", rerr)
-				}
-				close(done)
-			}()
-			select {
-			case <-done:
-				panic(p)
-			case <-time.After(10 * time.Second):
-				panic(fmt.Sprintf("panic in transaction; aborting rollback that took longer than 10s: %s", p))
-			}
-		} else if err != nil {
-			lggr.Debugf("Error in transaction, rolling back: %s", err)
-			// An error occurred, rollback and return error
-			if rerr := tx.Rollback(); rerr != nil {
-				err = multierr.Combine(err, errors.WithStack(rerr))
-			}
-		} else {
+		// if p := recover(); p != nil {
+		//     // A panic occurred, rollback and repanic
+		//     lggr.Errorf("Panic in transaction, rolling back: %s", p)
+		//     done := make(chan struct{})
+		//     go func() {
+		//         if rerr := tx.Rollback(); rerr != nil {
+		//             lggr.Errorf("Failed to rollback on panic: %s", rerr)
+		//         }
+		//         close(done)
+		//     }()
+		//     select {
+		//     case <-done:
+		//         panic(p)
+		//     case <-time.After(10 * time.Second):
+		//         panic(fmt.Sprintf("panic in transaction; aborting rollback that took longer than 10s: %s", p))
+		//     }
+		// } else if err != nil {
+		//     lggr.Debugf("Error in transaction, rolling back: %s", err)
+		//     // An error occurred, rollback and return error
+		//     if rerr := tx.Rollback(); rerr != nil {
+		//         err = multierr.Combine(err, errors.WithStack(rerr))
+		//     }
+		// } else {
+		if err == nil {
 			// All good! Time to commit.
-			err = errors.WithStack(tx.Commit())
+			// err = errors.WithStack(tx.Commit())
 		}
 	}()
 

--- a/core/web/auth/gql_test.go
+++ b/core/web/auth/gql_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	clsessions "github.com/smartcontractkit/chainlink/core/sessions"
 	"github.com/smartcontractkit/chainlink/core/sessions/mocks"
 	"github.com/smartcontractkit/chainlink/core/web/auth"
@@ -43,7 +44,7 @@ func Test_AuthenticateGQL_Authenticated(t *testing.T) {
 	t.Parallel()
 
 	sessionORM := &mocks.ORM{}
-	sessionStore := sessions.NewCookieStore([]byte(cltest.SessionSecret))
+	sessionStore := sessions.NewCookieStore([]byte(configtest.SessionSecret))
 	sessionID := "sessionID"
 
 	r := gin.Default()

--- a/core/web/jobs_controller_test.go
+++ b/core/web/jobs_controller_test.go
@@ -100,7 +100,7 @@ func TestJobsController_Create_ValidationFailure_OffchainReportingSpec(t *testin
 }
 
 func TestJobController_Create_DirectRequest_Fast(t *testing.T) {
-	t.Skip("TODO: fix this: https://app.shortcut.com/chainlinklabs/story/15334/orm-failed-to-load-unclaimed-job-specs-context-timeout")
+	// t.Skip("TODO: fix this: https://app.shortcut.com/chainlinklabs/story/15334/orm-failed-to-load-unclaimed-job-specs-context-timeout")
 	app, client := setupJobsControllerTests(t)
 	app.KeyStore.OCR().Add(cltest.DefaultOCRKey)
 	app.KeyStore.P2P().Add(cltest.DefaultP2PKey)

--- a/core/web/jobs_controller_test.go
+++ b/core/web/jobs_controller_test.go
@@ -105,7 +105,7 @@ func TestJobController_Create_DirectRequest_Fast(t *testing.T) {
 	app.KeyStore.OCR().Add(cltest.DefaultOCRKey)
 	app.KeyStore.P2P().Add(cltest.DefaultP2PKey)
 
-	n := 10
+	n := 100
 
 	var wg sync.WaitGroup
 	for i := 0; i < n; i++ {

--- a/go.mod
+++ b/go.mod
@@ -253,3 +253,5 @@ replace github.com/dgrijalva/jwt-go => github.com/form3tech-oss/jwt-go v3.2.1+in
 // Use our fork that supports out-of-order migrations
 // https://github.com/pressly/goose/issues/262
 replace github.com/pressly/goose/v3 => github.com/smartcontractkit/goose/v3 v3.1.1-0.20210921045349-e8cd8fc6557b
+
+replace github.com/smartcontractkit/go-txdb => /Users/sam/code/smartcontractkit/go-txdb

--- a/go.sum
+++ b/go.sum
@@ -1491,8 +1491,6 @@ github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/smartcontractkit/chainlink v0.8.10-0.20200825114219-81dd2fc95bac/go.mod h1:j7qIYHGCN4QqMXdO8g8A9dmUT5vKFmkxPSbjAIfrfNU=
 github.com/smartcontractkit/chainlink v0.9.5-0.20201207211610-6c7fee37d5b7/go.mod h1:kmdLJbVZRCnBLiL6gG+U+1+0ofT3bB48DOF8tjQvcoI=
-github.com/smartcontractkit/go-txdb v0.1.4-0.20211026134358-1c83fe89b164 h1:gUKeCZCt12Bi+A1nAfWi4Ro7nXOvRAZk8l7H1beipeY=
-github.com/smartcontractkit/go-txdb v0.1.4-0.20211026134358-1c83fe89b164/go.mod h1:FQ2spG6UFx1V24tAdp4h+iHG3coFkIx/hBRyE+6DKfY=
 github.com/smartcontractkit/goose/v3 v3.1.1-0.20210921045349-e8cd8fc6557b h1:DwCUCl0MmdfIM5D8ymhPLVFMqebLWZliVQFf5jcNRKA=
 github.com/smartcontractkit/goose/v3 v3.1.1-0.20210921045349-e8cd8fc6557b/go.mod h1:tYsY0oL0yd48jg15POIZfOZiu66mqWpfDd/nJ28KWyU=
 github.com/smartcontractkit/libocr v0.0.0-20201203233047-5d9b24f0cbb5/go.mod h1:bfdSuLnBWCkafDvPGsQ1V6nrXhg046gh227MKi4zkpc=


### PR DESCRIPTION
Enable a test that reliably reproduces one or more of the following test flakes:

`conn busy`
`index out of range [0] with length 0`
`driver: bad connection`

The test is called `TestJobController_Create_DirectRequest_Fast`.

This PR is a placeholder to sit here while I try various ideas to get to the bottom of this and fix it.

Upstream issue: https://github.com/jackc/pgx/issues/1100

Notes:

- Doesn't seem to be affected by removing all calls to `db.Close`
- Does not seem to be related to opening/closing transactions in application code (removing begin/commit calls still shows error)
- Problem goes away when using the heavyweight orm and not go-txdb (so the bug is likely in go-txdb)