### PR TITLE
[merged] Implements `Nodes` GQL queries

### DIFF
--- a/core/chains/evm/mocks/orm.go
+++ b/core/chains/evm/mocks/orm.go
@@ -220,6 +220,27 @@ func (_m *ORM) GetNodesByChainIDs(chainIDs []utils.Big) ([]types.Node, error) {
 	return r0, r1
 }
 
+// Node provides a mock function with given fields: id
+func (_m *ORM) Node(id int32) (types.Node, error) {
+	ret := _m.Called(id)
+
+	var r0 types.Node
+	if rf, ok := ret.Get(0).(func(int32) types.Node); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Get(0).(types.Node)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int32) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Nodes provides a mock function with given fields: offset, limit
 func (_m *ORM) Nodes(offset int, limit int) ([]types.Node, int, error) {
 	ret := _m.Called(offset, limit)

--- a/core/chains/evm/orm.go
+++ b/core/chains/evm/orm.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
-	"github.com/smartcontractkit/sqlx"
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/utils"
+	"github.com/smartcontractkit/sqlx"
 )
 
 type orm struct {
@@ -162,6 +162,14 @@ func (o *orm) NodesForChain(chainID utils.Big, offset, limit int) (nodes []types
 
 	sql := `SELECT * FROM nodes WHERE evm_chain_id = $1 ORDER BY created_at, id LIMIT $2 OFFSET $3;`
 	if err = o.db.Select(&nodes, sql, chainID, limit, offset); err != nil {
+		return
+	}
+
+	return
+}
+
+func (o *orm) Node(id int32) (node types.Node, err error) {
+	if err = o.db.Get(&node, "SELECT * FROM nodes WHERE id = $1;", id); err != nil {
 		return
 	}
 

--- a/core/chains/evm/orm.go
+++ b/core/chains/evm/orm.go
@@ -169,9 +169,7 @@ func (o *orm) NodesForChain(chainID utils.Big, offset, limit int) (nodes []types
 }
 
 func (o *orm) Node(id int32) (node types.Node, err error) {
-	if err = o.db.Get(&node, "SELECT * FROM nodes WHERE id = $1;", id); err != nil {
-		return
-	}
+	err = o.db.Get(&node, "SELECT * FROM nodes WHERE id = $1;", id)
 
 	return
 }

--- a/core/chains/evm/orm_test.go
+++ b/core/chains/evm/orm_test.go
@@ -119,10 +119,8 @@ func Test_EVMORM_GetNodesByChainIDs(t *testing.T) {
 	require.Len(t, nodes, 1)
 
 	actual := nodes[0]
-	require.Equal(t, node.EVMChainID, actual.EVMChainID)
-	require.Equal(t, node.WSURL, actual.WSURL)
-	require.Equal(t, node.HTTPURL, actual.HTTPURL)
-	require.Equal(t, node.SendOnly, actual.SendOnly)
+
+	require.Equal(t, node, actual)
 }
 
 func Test_EVMORM_Node(t *testing.T) {
@@ -133,8 +131,5 @@ func Test_EVMORM_Node(t *testing.T) {
 	actual, err := orm.Node(node.ID)
 	assert.NoError(t, err)
 
-	require.Equal(t, node.EVMChainID, actual.EVMChainID)
-	require.Equal(t, node.WSURL, actual.WSURL)
-	require.Equal(t, node.HTTPURL, actual.HTTPURL)
-	require.Equal(t, node.SendOnly, actual.SendOnly)
+	require.Equal(t, node, actual)
 }

--- a/core/chains/evm/orm_test.go
+++ b/core/chains/evm/orm_test.go
@@ -3,9 +3,11 @@ package evm_test
 import (
 	"testing"
 
-	"github.com/smartcontractkit/sqlx"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
+
+	"github.com/smartcontractkit/sqlx"
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
@@ -117,6 +119,20 @@ func Test_EVMORM_GetNodesByChainIDs(t *testing.T) {
 	require.Len(t, nodes, 1)
 
 	actual := nodes[0]
+	require.Equal(t, node.EVMChainID, actual.EVMChainID)
+	require.Equal(t, node.WSURL, actual.WSURL)
+	require.Equal(t, node.HTTPURL, actual.HTTPURL)
+	require.Equal(t, node.SendOnly, actual.SendOnly)
+}
+
+func Test_EVMORM_Node(t *testing.T) {
+	_, orm := setupORM(t)
+	chain := mustInsertChain(t, orm)
+	node := mustInsertNode(t, orm, chain.ID)
+
+	actual, err := orm.Node(node.ID)
+	assert.NoError(t, err)
+
 	require.Equal(t, node.EVMChainID, actual.EVMChainID)
 	require.Equal(t, node.WSURL, actual.WSURL)
 	require.Equal(t, node.HTTPURL, actual.HTTPURL)

--- a/core/chains/evm/types/types.go
+++ b/core/chains/evm/types/types.go
@@ -7,10 +7,11 @@ import (
 	"math/big"
 	"time"
 
+	"gopkg.in/guregu/null.v4"
+
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
-	null "gopkg.in/guregu/null.v4"
 )
 
 type NewNode struct {
@@ -38,6 +39,7 @@ type ORM interface {
 	DeleteNode(id int64) error
 	GetChainsByIDs(ids []utils.Big) (chains []Chain, err error)
 	GetNodesByChainIDs(chainIDs []utils.Big) (nodes []Node, err error)
+	Node(id int32) (Node, error)
 	Nodes(offset, limit int) ([]Node, int, error)
 	NodesForChain(chainID utils.Big, offset, limit int) ([]Node, int, error)
 	ChainConfigORM

--- a/core/internal/testutils/evmtest/evmtest.go
+++ b/core/internal/testutils/evmtest/evmtest.go
@@ -4,6 +4,10 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v4"
+	"gorm.io/gorm"
+
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
 	evmconfig "github.com/smartcontractkit/chainlink/core/chains/evm/config"
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
@@ -17,9 +21,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/log"
 	"github.com/smartcontractkit/chainlink/core/services/postgres"
 	"github.com/smartcontractkit/chainlink/core/utils"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v4"
-	"gorm.io/gorm"
 )
 
 type TestChainOpts struct {
@@ -160,6 +161,10 @@ func (mo *MockORM) DeleteNode(id int64) error {
 }
 
 func (mo *MockORM) Nodes(offset int, limit int) ([]evmtypes.Node, int, error) {
+	panic("not implemented")
+}
+
+func (mo *MockORM) Node(id int32) (evmtypes.Node, error) {
 	panic("not implemented")
 }
 

--- a/core/web/loader/getters.go
+++ b/core/web/loader/getters.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/graph-gophers/dataloader"
+
 	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
 )
 

--- a/core/web/resolver/bridge.go
+++ b/core/web/resolver/bridge.go
@@ -1,7 +1,10 @@
 package resolver
 
 import (
+	"database/sql"
+
 	"github.com/graph-gophers/graphql-go"
+	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink/core/bridges"
 )
@@ -76,7 +79,7 @@ func (r *BridgePayloadResolver) ToBridge() (*BridgeResolver, bool) {
 	return nil, false
 }
 
-// ToBridge implements the NotFoundError union type of the payload
+// ToNotFoundError implements the NotFoundError union type of the payload
 func (r *BridgePayloadResolver) ToNotFoundError() (*NotFoundErrorResolver, bool) {
 	if r.err != nil {
 		return NewNotFoundError("bridge not found"), true
@@ -189,4 +192,91 @@ func NewUpdateBridgeSuccess(bridge bridges.BridgeType) *UpdateBridgeSuccessResol
 // Bridge resolves the success payload's bridge.
 func (r *UpdateBridgeSuccessResolver) Bridge() *BridgeResolver {
 	return NewBridge(r.bridge)
+}
+
+// -- DeleteBridge mutation --
+
+type DeleteBridgePayloadResolver struct {
+	bridge *bridges.BridgeType
+	err    error
+}
+
+func NewDeleteBridgePayload(bridge *bridges.BridgeType, err error) *DeleteBridgePayloadResolver {
+	return &DeleteBridgePayloadResolver{bridge, err}
+}
+
+func (r *DeleteBridgePayloadResolver) ToDeleteBridgeSuccess() (*DeleteBridgeSuccessResolver, bool) {
+	if r.bridge != nil {
+		return NewDeleteBridgeSuccess(r.bridge), true
+	}
+
+	return nil, false
+}
+
+func (r *DeleteBridgePayloadResolver) ToDeleteBridgeConflictError() (*DeleteBridgeConflictErrorResolver, bool) {
+	if r.err != nil {
+		return NewDeleteBridgeConflictError(r.err.Error()), true
+	}
+
+	return nil, false
+}
+
+func (r *DeleteBridgePayloadResolver) ToDeleteBridgeInvalidNameError() (*DeleteBridgeInvalidNameErrorResolver, bool) {
+	if r.err != nil {
+		return NewDeleteBridgeInvalidNameError(r.err.Error()), true
+	}
+
+	return nil, false
+}
+
+func (r *DeleteBridgePayloadResolver) ToNotFoundError() (*NotFoundErrorResolver, bool) {
+	if r.err != nil && errors.Is(r.err, sql.ErrNoRows) {
+		return NewNotFoundError("bridge not found"), true
+	}
+
+	return nil, false
+}
+
+type DeleteBridgeSuccessResolver struct {
+	bridge *bridges.BridgeType
+}
+
+func NewDeleteBridgeSuccess(bridge *bridges.BridgeType) *DeleteBridgeSuccessResolver {
+	return &DeleteBridgeSuccessResolver{bridge}
+}
+
+func (r *DeleteBridgeSuccessResolver) Bridge() *BridgeResolver {
+	return NewBridge(*r.bridge)
+}
+
+type DeleteBridgeConflictErrorResolver struct {
+	message string
+}
+
+func NewDeleteBridgeConflictError(message string) *DeleteBridgeConflictErrorResolver {
+	return &DeleteBridgeConflictErrorResolver{message}
+}
+
+func (r *DeleteBridgeConflictErrorResolver) Message() string {
+	return r.message
+}
+
+func (r *DeleteBridgeConflictErrorResolver) Code() ErrorCode {
+	return ErrorCodeStatusConflict
+}
+
+type DeleteBridgeInvalidNameErrorResolver struct {
+	message string
+}
+
+func NewDeleteBridgeInvalidNameError(message string) *DeleteBridgeInvalidNameErrorResolver {
+	return &DeleteBridgeInvalidNameErrorResolver{message}
+}
+
+func (r *DeleteBridgeInvalidNameErrorResolver) Message() string {
+	return r.message
+}
+
+func (r *DeleteBridgeInvalidNameErrorResolver) Code() ErrorCode {
+	return ErrorCodeUnprocessable
 }

--- a/core/web/resolver/bridge_test.go
+++ b/core/web/resolver/bridge_test.go
@@ -2,9 +2,11 @@ package resolver
 
 import (
 	"database/sql"
+	"encoding/json"
 	"net/url"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -80,6 +82,8 @@ func Test_Bridges(t *testing.T) {
 }
 
 func Test_Bridge(t *testing.T) {
+	t.Parallel()
+
 	var (
 		query = `
 			query GetBridge{
@@ -231,6 +235,8 @@ func Test_CreateBridge(t *testing.T) {
 }
 
 func Test_UpdateBridge(t *testing.T) {
+	t.Parallel()
+
 	var (
 		name     = bridges.TaskType("bridge1")
 		mutation = `
@@ -337,6 +343,144 @@ func Test_UpdateBridge(t *testing.T) {
 					"code": "NOT_FOUND"
 				}
 			}`,
+		},
+	}
+
+	RunGQLTests(t, testCases)
+}
+
+func Test_DeleteBridgeMutation(t *testing.T) {
+	t.Parallel()
+
+	name := bridges.TaskType("bridge1")
+
+	bridgeURL, err := url.Parse("https://test-url.com")
+	require.NoError(t, err)
+
+	link := assets.Link{}
+	err = json.Unmarshal([]byte(`"1"`), &link)
+	assert.NoError(t, err)
+
+	mutation := `
+		mutation DeleteBridge($name: String!) {
+			deleteBridge(name: $name) {
+				... on DeleteBridgeSuccess {
+					bridge {
+						name
+						url
+						confirmations
+						outgoingToken
+						minimumContractPayment
+					}
+				}
+				... on NotFoundError {
+					message
+					code
+				}
+				... on DeleteBridgeInvalidNameError {
+					message
+					code
+				}
+				... on DeleteBridgeConflictError {
+					message
+					code
+				}
+			}
+		}`
+
+	variables := map[string]interface{}{
+		"name": name.String(),
+	}
+
+	testCases := []GQLTestCase{
+		unauthorizedTestCase(GQLTestCase{query: mutation, variables: variables}, "deleteBridge"),
+		{
+			name:          "success",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				bridge := bridges.BridgeType{
+					Name:                   name,
+					URL:                    models.WebURL(*bridgeURL),
+					Confirmations:          1,
+					OutgoingToken:          "some-token",
+					MinimumContractPayment: &link,
+				}
+
+				f.Mocks.bridgeORM.On("FindBridge", name).Return(bridge, nil)
+				f.Mocks.bridgeORM.On("DeleteBridgeType", &bridge).Return(nil)
+				f.Mocks.jobORM.On("FindJobIDsWithBridge", name.String()).Return([]int32{}, nil)
+				f.App.On("JobORM").Return(f.Mocks.jobORM)
+				f.App.On("BridgeORM").Return(f.Mocks.bridgeORM)
+			},
+			query:     mutation,
+			variables: variables,
+			result: `
+				{
+					"deleteBridge": {
+						"bridge": {
+							"name": "bridge1",
+							"url": "https://test-url.com",
+							"confirmations": 1,
+							"outgoingToken": "some-token",
+							"minimumContractPayment": "1"
+						}
+					}
+				}`,
+		},
+		{
+			name:          "invalid bridge type name",
+			authenticated: true,
+			query:         mutation,
+			variables: map[string]interface{}{
+				"name": "][]$$$$324adfas",
+			},
+			result: `
+				{
+					"deleteBridge": {
+						"message": "task type validation: name ][]$$$$324adfas contains invalid characters",
+						"code": "UNPROCESSABLE"
+					}
+				}`,
+		},
+		{
+			name:          "invalid bridge type name",
+			authenticated: true,
+			query:         mutation,
+			variables: map[string]interface{}{
+				"name": "bridge1",
+			},
+			before: func(f *gqlTestFramework) {
+				f.Mocks.bridgeORM.On("FindBridge", name).Return(bridges.BridgeType{}, sql.ErrNoRows)
+				f.App.On("BridgeORM").Return(f.Mocks.bridgeORM)
+			},
+			result: `
+				{
+					"deleteBridge": {
+						"message": "bridge not found",
+						"code": "NOT_FOUND"
+					}
+				}`,
+		},
+		{
+			name:          "invalid bridge type name",
+			authenticated: true,
+			query:         mutation,
+			variables: map[string]interface{}{
+				"name": "bridge1",
+			},
+			before: func(f *gqlTestFramework) {
+				f.Mocks.bridgeORM.On("FindBridge", name).Return(bridges.BridgeType{}, nil)
+				f.Mocks.jobORM.On("FindJobIDsWithBridge", name.String()).Return([]int32{1}, nil)
+				f.App.On("BridgeORM").Return(f.Mocks.bridgeORM)
+				f.App.On("JobORM").Return(f.Mocks.jobORM)
+			},
+			result: `
+				{
+					"deleteBridge": {
+						"message": "bridge has jobs associated with it",
+						"code": "UNPROCESSABLE"
+					}
+				}`,
 		},
 	}
 

--- a/core/web/resolver/errors.go
+++ b/core/web/resolver/errors.go
@@ -3,9 +3,10 @@ package resolver
 type ErrorCode string
 
 const (
-	ErrorCodeNotFound      ErrorCode = "NOT_FOUND"
-	ErrorCodeInvalidInput  ErrorCode = "INVALID_INPUT"
-	ErrorCodeUnprocessable ErrorCode = "UNPROCESSABLE"
+	ErrorCodeNotFound       ErrorCode = "NOT_FOUND"
+	ErrorCodeInvalidInput   ErrorCode = "INVALID_INPUT"
+	ErrorCodeUnprocessable  ErrorCode = "UNPROCESSABLE"
+	ErrorCodeStatusConflict ErrorCode = "STATUS_CONFLICT"
 )
 
 type NotFoundErrorResolver struct {

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/bridges"
+	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/feeds"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
@@ -309,4 +310,19 @@ func (r *Resolver) DeleteOCRKeyBundle(ctx context.Context, args struct {
 	}
 
 	return NewDeleteOCRKeyBundlePayloadResolver(deletedKey, nil), nil
+}
+
+func (r *Resolver) CreateNode(ctx context.Context, args struct {
+	Input *types.NewNode
+}) (*CreateNodePayloadResolver, error) {
+	if err := authenticateUser(ctx); err != nil {
+		return nil, err
+	}
+
+	node, err := r.App.EVMORM().CreateNode(*args.Input)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewCreateNodePayloadResolver(&node), nil
 }

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -340,6 +340,7 @@ func (r *Resolver) DeleteNode(ctx context.Context, args struct {
 		if errors.Is(err, sql.ErrNoRows) {
 			return NewDeleteNodePayloadResolver(nil, err), nil
 		}
+
 		return nil, err
 	}
 

--- a/core/web/resolver/node.go
+++ b/core/web/resolver/node.go
@@ -125,3 +125,42 @@ func NewCreateNodeSuccessResolve(node types.Node) *CreateNodeSuccessResolve {
 func (r *CreateNodeSuccessResolve) Node() *NodeResolver {
 	return NewNode(r.node)
 }
+
+// -- DeleteNode Mutation --
+
+type DeleteNodePayloadResolver struct {
+	node *types.Node
+	err  error
+}
+
+func NewDeleteNodePayloadResolver(node *types.Node, err error) *DeleteNodePayloadResolver {
+	return &DeleteNodePayloadResolver{node, err}
+}
+
+func (r *DeleteNodePayloadResolver) ToDeleteNodeSuccess() (*DeleteNodeSuccessResolver, bool) {
+	if r.node != nil {
+		return NewDeleteNodeSuccessResolver(r.node), true
+	}
+
+	return nil, false
+}
+
+func (r *DeleteNodePayloadResolver) ToNotFoundError() (*NotFoundErrorResolver, bool) {
+	if r.err != nil {
+		return NewNotFoundError("node not found"), true
+	}
+
+	return nil, false
+}
+
+type DeleteNodeSuccessResolver struct {
+	node *types.Node
+}
+
+func NewDeleteNodeSuccessResolver(node *types.Node) *DeleteNodeSuccessResolver {
+	return &DeleteNodeSuccessResolver{node}
+}
+
+func (r *DeleteNodeSuccessResolver) Node() *NodeResolver {
+	return NewNode(*r.node)
+}

--- a/core/web/resolver/node.go
+++ b/core/web/resolver/node.go
@@ -66,3 +66,31 @@ func (r *NodeResolver) CreatedAt() graphql.Time {
 func (r *NodeResolver) UpdatedAt() graphql.Time {
 	return graphql.Time{Time: r.node.UpdatedAt}
 }
+
+// -- Node Query --
+
+type NodePayloadResolver struct {
+	node *types.Node
+	err  error
+}
+
+func NewNodePayloadResolver(node *types.Node, err error) *NodePayloadResolver {
+	return &NodePayloadResolver{node, err}
+}
+
+func (r *NodePayloadResolver) ToNode() (*NodeResolver, bool) {
+	if r.node != nil {
+		return NewNode(*r.node), true
+	}
+
+	return nil, false
+}
+
+// ToNotFoundError implements the NotFoundError union type of the payload
+func (r *NodePayloadResolver) ToNotFoundError() (*NotFoundErrorResolver, bool) {
+	if r.err != nil {
+		return NewNotFoundError("node not found"), true
+	}
+
+	return nil, false
+}

--- a/core/web/resolver/node.go
+++ b/core/web/resolver/node.go
@@ -78,6 +78,7 @@ func NewNodePayloadResolver(node *types.Node, err error) *NodePayloadResolver {
 	return &NodePayloadResolver{node, err}
 }
 
+// ToNode resolves the Node object to be returned if it is found
 func (r *NodePayloadResolver) ToNode() (*NodeResolver, bool) {
 	if r.node != nil {
 		return NewNode(*r.node), true
@@ -93,4 +94,34 @@ func (r *NodePayloadResolver) ToNotFoundError() (*NotFoundErrorResolver, bool) {
 	}
 
 	return nil, false
+}
+
+// -- CreateNode Mutation --
+
+type CreateNodePayloadResolver struct {
+	node *types.Node
+}
+
+func NewCreateNodePayloadResolver(node *types.Node) *CreateNodePayloadResolver {
+	return &CreateNodePayloadResolver{node}
+}
+
+func (r *CreateNodePayloadResolver) ToCreateNodeSuccess() (*CreateNodeSuccessResolve, bool) {
+	if r.node != nil {
+		return NewCreateNodeSuccessResolve(*r.node), true
+	}
+
+	return nil, false
+}
+
+type CreateNodeSuccessResolve struct {
+	node types.Node
+}
+
+func NewCreateNodeSuccessResolve(node types.Node) *CreateNodeSuccessResolve {
+	return &CreateNodeSuccessResolve{node}
+}
+
+func (r *CreateNodeSuccessResolve) Node() *NodeResolver {
+	return NewNode(r.node)
 }

--- a/core/web/resolver/node_test.go
+++ b/core/web/resolver/node_test.go
@@ -30,20 +30,6 @@ func Test_NodeQuery(t *testing.T) {
 				}
 			}
 		}`
-	notFoundQuery := `
-		query GetNode {
-			node(id: "1") {
-				... on Node {
-					name
-					wsURL
-					httpURL
-				}
-				... on NotFoundError {
-					message
-					code
-				}
-			}
-		}`
 
 	nodeID := int32(200)
 
@@ -75,10 +61,10 @@ func Test_NodeQuery(t *testing.T) {
 			name:          "not found error",
 			authenticated: true,
 			before: func(f *gqlTestFramework) {
-				f.Mocks.evmORM.On("Node", int32(1)).Return(types.Node{}, sql.ErrNoRows)
+				f.Mocks.evmORM.On("Node", int32(200)).Return(types.Node{}, sql.ErrNoRows)
 				f.App.On("EVMORM").Return(f.Mocks.evmORM)
 			},
-			query: notFoundQuery,
+			query: query,
 			result: `
 			{
 				"node": {

--- a/core/web/resolver/node_test.go
+++ b/core/web/resolver/node_test.go
@@ -1,0 +1,50 @@
+package resolver
+
+import (
+	"testing"
+
+	"gopkg.in/guregu/null.v4"
+
+	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
+)
+
+func Test_NodeQuery(t *testing.T) {
+	query := `
+		query GetNode {
+			node(id: "200") {
+				name
+				wsURL
+				httpURL
+			}
+		}`
+
+	nodeID := int32(200)
+
+	testCases := []GQLTestCase{
+		unauthorizedTestCase(GQLTestCase{query: query}, "node"),
+		{
+			name:          "success",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.evmORM.On("Node", nodeID).Return(types.Node{
+					ID:      nodeID,
+					Name:    "node-name",
+					WSURL:   null.StringFrom("ws://some-url"),
+					HTTPURL: null.StringFrom("http://some-url"),
+				}, nil)
+				f.App.On("EVMORM").Return(f.Mocks.evmORM)
+			},
+			query: query,
+			result: `
+			{
+				"node": {
+					"name": "node-name",
+					"wsURL": "ws://some-url",
+					"httpURL": "http://some-url"
+				}
+			}`,
+		},
+	}
+
+	RunGQLTests(t, testCases)
+}

--- a/core/web/resolver/query.go
+++ b/core/web/resolver/query.go
@@ -209,3 +209,21 @@ func (r *Resolver) Features(ctx context.Context) (*FeaturesPayloadResolver, erro
 
 	return NewFeaturesPayloadResolver(r.App.GetConfig()), nil
 }
+
+func (r *Resolver) Node(ctx context.Context, args struct{ ID graphql.ID }) (*NodeResolver, error) {
+	if err := authenticateUser(ctx); err != nil {
+		return nil, err
+	}
+
+	id, err := strconv.ParseInt(string(args.ID), 10, 32)
+	if err != nil {
+		return nil, err
+	}
+
+	node, err := r.App.EVMORM().Node(int32(id))
+	if err != nil {
+		return nil, err
+	}
+
+	return NewNode(node), nil
+}

--- a/core/web/resolver/query.go
+++ b/core/web/resolver/query.go
@@ -210,7 +210,7 @@ func (r *Resolver) Features(ctx context.Context) (*FeaturesPayloadResolver, erro
 	return NewFeaturesPayloadResolver(r.App.GetConfig()), nil
 }
 
-func (r *Resolver) Node(ctx context.Context, args struct{ ID graphql.ID }) (*NodeResolver, error) {
+func (r *Resolver) Node(ctx context.Context, args struct{ ID graphql.ID }) (*NodePayloadResolver, error) {
 	if err := authenticateUser(ctx); err != nil {
 		return nil, err
 	}
@@ -222,8 +222,11 @@ func (r *Resolver) Node(ctx context.Context, args struct{ ID graphql.ID }) (*Nod
 
 	node, err := r.App.EVMORM().Node(int32(id))
 	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return NewNodePayloadResolver(nil, err), nil
+		}
 		return nil, err
 	}
 
-	return NewNode(node), nil
+	return NewNodePayloadResolver(&node, nil), nil
 }

--- a/core/web/resolver/resolver_test.go
+++ b/core/web/resolver/resolver_test.go
@@ -15,7 +15,7 @@ import (
 	configMocks "github.com/smartcontractkit/chainlink/core/config/mocks"
 	coremocks "github.com/smartcontractkit/chainlink/core/internal/mocks"
 	feedsMocks "github.com/smartcontractkit/chainlink/core/services/feeds/mocks"
-	jobMocks "github.com/smartcontractkit/chainlink/core/services/job/mocks"
+	jobORMMocks "github.com/smartcontractkit/chainlink/core/services/job/mocks"
 	keystoreMocks "github.com/smartcontractkit/chainlink/core/services/keystore/mocks"
 	clsessions "github.com/smartcontractkit/chainlink/core/sessions"
 	"github.com/smartcontractkit/chainlink/core/web/auth"
@@ -26,8 +26,8 @@ import (
 type mocks struct {
 	bridgeORM *bridgeORMMocks.ORM
 	evmORM    *evmORMMocks.ORM
+	jobORM    *jobORMMocks.ORM
 	feedsSvc  *feedsMocks.Service
-	jobORM    *jobMocks.ORM
 	cfg       *configMocks.GeneralConfig
 	ocr       *keystoreMocks.OCR
 	csa       *keystoreMocks.CSA
@@ -69,8 +69,8 @@ func setupFramework(t *testing.T) *gqlTestFramework {
 	m := &mocks{
 		bridgeORM: &bridgeORMMocks.ORM{},
 		evmORM:    &evmORMMocks.ORM{},
+		jobORM:    &jobORMMocks.ORM{},
 		feedsSvc:  &feedsMocks.Service{},
-		jobORM:    &jobMocks.ORM{},
 		cfg:       &configMocks.GeneralConfig{},
 		ocr:       &keystoreMocks.OCR{},
 		csa:       &keystoreMocks.CSA{},
@@ -83,8 +83,8 @@ func setupFramework(t *testing.T) *gqlTestFramework {
 			app,
 			m.bridgeORM,
 			m.evmORM,
-			m.feedsSvc,
 			m.jobORM,
+			m.feedsSvc,
 			m.cfg,
 			m.ocr,
 			m.csa,

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -24,6 +24,7 @@ type Mutation {
     createBridge(input: CreateBridgeInput!): CreateBridgePayload!
     createCSAKey: CreateCSAKeyPayload!
     createFeedsManager(input: CreateFeedsManagerInput!): CreateFeedsManagerPayload!
+    createNode(input: CreateNodeInput!): CreateNodePayload!
     createOCRKeyBundle: CreateOCRKeyBundlePayload!
     deleteOCRKeyBundle(id: ID!): DeleteOCRKeyBundlePayload!
     updateBridge(name: String!, input: UpdateBridgeInput!): UpdateBridgePayload!

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -16,6 +16,7 @@ type Query {
     feedsManagers: FeedsManagersPayload!
     job(id: ID!): JobPayload!
     jobs(offset: Int, limit: Int): JobsPayload!
+    node(id: ID!): Node!
     ocrKeyBundles: OCRKeyBundlesPayload!
 }
 

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -26,6 +26,7 @@ type Mutation {
     createFeedsManager(input: CreateFeedsManagerInput!): CreateFeedsManagerPayload!
     createNode(input: CreateNodeInput!): CreateNodePayload!
     createOCRKeyBundle: CreateOCRKeyBundlePayload!
+    deleteBridge(name: String!): DeleteBridgePayload!
     deleteNode(id: ID!): DeleteNodePayload!
     deleteOCRKeyBundle(id: ID!): DeleteOCRKeyBundlePayload!
     updateBridge(name: String!, input: UpdateBridgeInput!): UpdateBridgePayload!

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -26,6 +26,7 @@ type Mutation {
     createFeedsManager(input: CreateFeedsManagerInput!): CreateFeedsManagerPayload!
     createNode(input: CreateNodeInput!): CreateNodePayload!
     createOCRKeyBundle: CreateOCRKeyBundlePayload!
+    deleteNode(id: ID!): DeleteNodePayload!
     deleteOCRKeyBundle(id: ID!): DeleteOCRKeyBundlePayload!
     updateBridge(name: String!, input: UpdateBridgeInput!): UpdateBridgePayload!
     updateFeedsManager(id: ID!, input: UpdateFeedsManagerInput!): UpdateFeedsManagerPayload!

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -16,7 +16,7 @@ type Query {
     feedsManagers: FeedsManagersPayload!
     job(id: ID!): JobPayload!
     jobs(offset: Int, limit: Int): JobsPayload!
-    node(id: ID!): Node!
+    node(id: ID!): NodePayload!
     ocrKeyBundles: OCRKeyBundlesPayload!
 }
 

--- a/core/web/schema/type/bridge.graphql
+++ b/core/web/schema/type/bridge.graphql
@@ -48,3 +48,22 @@ type UpdateBridgeSuccess {
 
 # CreateBridgeInput defines the response when updating a bridge
 union UpdateBridgePayload = UpdateBridgeSuccess | NotFoundError
+
+type DeleteBridgeSuccess {
+    bridge: Bridge!
+}
+
+type DeleteBridgeInvalidNameError implements Error {
+    code: ErrorCode!
+    message: String!
+}
+
+type DeleteBridgeConflictError implements Error {
+    code: ErrorCode!
+    message: String!
+}
+
+union DeleteBridgePayload = DeleteBridgeSuccess
+    | DeleteBridgeInvalidNameError
+    | DeleteBridgeConflictError
+    | NotFoundError

--- a/core/web/schema/type/node.graphql
+++ b/core/web/schema/type/node.graphql
@@ -9,3 +9,17 @@ type Node {
 }
 
 union NodePayload = Node | NotFoundError
+
+input CreateNodeInput {
+    name: String!
+    evmChainID: Int!
+    wsURL: String!
+    httpURL: String!
+    sendOnly: Boolean!
+}
+
+type CreateNodeSuccess {
+    node: Node!
+}
+
+union CreateNodePayload = CreateNodeSuccess

--- a/core/web/schema/type/node.graphql
+++ b/core/web/schema/type/node.graphql
@@ -24,7 +24,6 @@ type CreateNodeSuccess {
 
 union CreateNodePayload = CreateNodeSuccess
 
-
 type DeleteNodeSuccess {
     node: Node!
 }

--- a/core/web/schema/type/node.graphql
+++ b/core/web/schema/type/node.graphql
@@ -23,3 +23,10 @@ type CreateNodeSuccess {
 }
 
 union CreateNodePayload = CreateNodeSuccess
+
+
+type DeleteNodeSuccess {
+    node: Node!
+}
+
+union DeleteNodePayload = DeleteNodeSuccess | NotFoundError

--- a/core/web/schema/type/node.graphql
+++ b/core/web/schema/type/node.graphql
@@ -7,3 +7,5 @@ type Node {
     createdAt: Time!
     updatedAt: Time!
 }
+
+union NodePayload = Node | NotFoundError


### PR DESCRIPTION
Closes: https://app.shortcut.com/chainlinklabs/story/20876/implement-node-gql-queries

This PR aims to create 3 GQL endpoints to handle `Nodes` data:

* `GetNode`
* `CreateNode`
* `DeleteNode`