### PR TITLE
[merged] core/cmd: expand TestClient_RunNodeShowsEnv to include all

### DIFF
--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -2,9 +2,11 @@ package cmd_test
 
 import (
 	"flag"
+	"fmt"
 	"math/big"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -23,6 +25,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/dialects"
 
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
+	"github.com/kylelemons/godebug/diff"
 	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -79,17 +82,92 @@ func TestClient_RunNodeShowsEnv(t *testing.T) {
 
 	logs, err := cltest.ReadLogs(cfg)
 	require.NoError(t, err)
+	msg := cltest.FindLogMessage(logs, func(msg string) bool {
+		return strings.HasPrefix(msg, "Environment variables")
+	})
+	require.NotEmpty(t, msg, "No env var message found")
 
-	assert.Contains(t, logs, "ALLOW_ORIGINS: http://localhost:3000,http://localhost:6688\\n")
-	assert.Contains(t, logs, "BRIDGE_RESPONSE_URL: http://localhost:6688\\n")
-	assert.Contains(t, logs, "BLOCK_BACKFILL_DEPTH: 10\\n")
-	assert.Contains(t, logs, "CHAINLINK_PORT: 6688\\n")
-	assert.Contains(t, logs, "CLIENT_NODE_URL: http://")
-	assert.Contains(t, logs, "ETH_CHAIN_ID: 0\\n")
-	assert.Contains(t, logs, "JSON_CONSOLE: false")
-	assert.Contains(t, logs, "LOG_LEVEL: debug\\n")
-	assert.Contains(t, logs, "LOG_TO_DISK: true")
-	assert.Contains(t, logs, "ROOT: /tmp/chainlink_test/")
+	expected := fmt.Sprintf(`Environment variables
+ALLOW_ORIGINS: http://localhost:3000,http://localhost:6688
+BLOCK_BACKFILL_DEPTH: 10
+BLOCK_HISTORY_ESTIMATOR_BLOCK_DELAY: 0
+BLOCK_HISTORY_ESTIMATOR_BLOCK_HISTORY_SIZE: 0
+BLOCK_HISTORY_ESTIMATOR_TRANSACTION_PERCENTILE: 0
+BRIDGE_RESPONSE_URL: http://localhost:6688
+CHAIN_TYPE: 
+CLIENT_NODE_URL: http://localhost:6688
+DATABASE_BACKUP_FREQUENCY: 1h0m0s
+DATABASE_BACKUP_MODE: none
+DATABASE_MAXIMUM_TX_DURATION: 30m0s
+DATABASE_TIMEOUT: 5s
+DATABASE_LOCKING_MODE: none
+ETH_CHAIN_ID: 0
+DEFAULT_HTTP_LIMIT: 32768
+DEFAULT_HTTP_TIMEOUT: 15s
+CHAINLINK_DEV: true
+ETH_DISABLED: false
+ETH_HTTP_URL: 
+ETH_SECONDARY_URLS: []
+ETH_URL: 
+EXPLORER_URL: 
+FM_DEFAULT_TRANSACTION_QUEUE_DEPTH: 1
+FEATURE_EXTERNAL_INITIATORS: false
+FEATURE_OFFCHAIN_REPORTING: false
+GAS_ESTIMATOR_MODE: 
+INSECURE_FAST_SCRYPT: true
+JSON_CONSOLE: false
+JOB_PIPELINE_REAPER_INTERVAL: 1h0m0s
+JOB_PIPELINE_REAPER_THRESHOLD: 24h0m0s
+KEEPER_DEFAULT_TRANSACTION_QUEUE_DEPTH: 1
+KEEPER_GAS_PRICE_BUFFER_PERCENT: 20
+KEEPER_GAS_TIP_CAP_BUFFER_PERCENT: 20
+KEEPER_MAXIMUM_GRACE_PERIOD: 0
+KEEPER_REGISTRY_CHECK_GAS_OVERHEAD: 0
+KEEPER_REGISTRY_PERFORM_GAS_OVERHEAD: 0
+KEEPER_REGISTRY_SYNC_INTERVAL: 
+KEEPER_REGISTRY_SYNC_UPKEEP_QUEUE_SIZE: 0
+LINK_CONTRACT_ADDRESS: 
+FLAGS_CONTRACT_ADDRESS: 
+LOG_LEVEL: debug
+LOG_SQL_MIGRATIONS: false
+LOG_SQL: false
+LOG_TO_DISK: true
+OCR_BOOTSTRAP_CHECK_INTERVAL: 20s
+TRIGGER_FALLBACK_DB_POLL_INTERVAL: 30s
+OCR_CONTRACT_TRANSMITTER_TRANSMIT_TIMEOUT: 10s
+OCR_DATABASE_TIMEOUT: 10s
+OCR_DEFAULT_TRANSACTION_QUEUE_DEPTH: 1
+OCR_INCOMING_MESSAGE_BUFFER_SIZE: 10
+P2P_BOOTSTRAP_PEERS: []
+P2P_LISTEN_IP: 0.0.0.0
+P2P_LISTEN_PORT: 
+P2P_NETWORKING_STACK: V1
+P2P_PEER_ID: 
+P2PV2_ANNOUNCE_ADDRESSES: []
+P2PV2_BOOTSTRAPPERS: []
+P2PV2_DELTA_DIAL: 15s
+P2PV2_DELTA_RECONCILE: 1m0s
+P2PV2_LISTEN_ADDRESSES: []
+OCR_OUTGOING_MESSAGE_BUFFER_SIZE: 10
+OCR_NEW_STREAM_TIMEOUT: 10s
+OCR_DHT_LOOKUP_INTERVAL: 10
+OCR_TRACE_LOGGING: false
+CHAINLINK_PORT: 6688
+REAPER_EXPIRATION: 240h0m0s
+REPLAY_FROM_BLOCK: -1
+ROOT: %s
+SECURE_COOKIES: true
+SESSION_TIMEOUT: 2m0s
+TELEMETRY_INGRESS_LOGGING: false
+TELEMETRY_INGRESS_SERVER_PUB_KEY: 
+TELEMETRY_INGRESS_URL: 
+CHAINLINK_TLS_HOST: 
+CHAINLINK_TLS_PORT: 6689
+CHAINLINK_TLS_REDIRECT: false`, cfg.RootDir())
+
+	if !strings.Contains(msg, expected) {
+		t.Errorf("Expected to find:\n\n%s\n\nWithin:\n\n%s\n\nDiff:\n\n%s", expected, msg, diff.Diff(expected, msg))
+	}
 
 	app.AssertExpectations(t)
 }


### PR DESCRIPTION
Expanding TestClient_RunNodeShowsEnv to cover the full set of vars.