### PR TITLE
Use type ID instead of String for OCR key ids

### DIFF
--- a/core/web/resolver/ocr.go
+++ b/core/web/resolver/ocr.go
@@ -6,23 +6,27 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ocrkey"
 )
 
-type OCRKeyBundle struct {
+type OCRKeyBundleResolver struct {
 	key ocrkey.KeyV2
 }
 
-func (k OCRKeyBundle) ID() graphql.ID {
+func NewOCRKeyBundleResolver(key ocrkey.KeyV2) OCRKeyBundleResolver {
+	return OCRKeyBundleResolver{key}
+}
+
+func (k OCRKeyBundleResolver) ID() graphql.ID {
 	return graphql.ID(k.key.ID())
 }
 
-func (k OCRKeyBundle) ConfigPublicKey() string {
+func (k OCRKeyBundleResolver) ConfigPublicKey() string {
 	return ocrkey.ConfigPublicKey(k.key.PublicKeyConfig()).String()
 }
 
-func (k OCRKeyBundle) OffChainPublicKey() string {
+func (k OCRKeyBundleResolver) OffChainPublicKey() string {
 	return k.key.OffChainSigning.PublicKey().String()
 }
 
-func (k OCRKeyBundle) OnChainSigningAddress() string {
+func (k OCRKeyBundleResolver) OnChainSigningAddress() string {
 	return k.key.OnChainSigning.Address().String()
 }
 
@@ -34,10 +38,10 @@ func NewOCRKeyBundlesPayloadResolver(keys []ocrkey.KeyV2) *OCRKeyBundlesPayloadR
 	return &OCRKeyBundlesPayloadResolver{keys}
 }
 
-func (r *OCRKeyBundlesPayloadResolver) Results() []OCRKeyBundle {
-	bundles := []OCRKeyBundle{}
+func (r *OCRKeyBundlesPayloadResolver) Results() []OCRKeyBundleResolver {
+	bundles := []OCRKeyBundleResolver{}
 	for _, k := range r.keys {
-		bundles = append(bundles, OCRKeyBundle{k})
+		bundles = append(bundles, NewOCRKeyBundleResolver(k))
 	}
 	return bundles
 }
@@ -50,8 +54,8 @@ func NewCreateOCRKeyBundlePayloadResolver(key ocrkey.KeyV2) *CreateOCRKeyBundleP
 	return &CreateOCRKeyBundlePayloadResolver{key}
 }
 
-func (r *CreateOCRKeyBundlePayloadResolver) Bundle() OCRKeyBundle {
-	return OCRKeyBundle{r.key}
+func (r *CreateOCRKeyBundlePayloadResolver) Bundle() OCRKeyBundleResolver {
+	return OCRKeyBundleResolver{r.key}
 }
 
 type DeleteOCRKeyBundleSuccessResolver struct {
@@ -62,8 +66,8 @@ func NewDeleteOCRKeyBundleSuccessResolver(key ocrkey.KeyV2) *DeleteOCRKeyBundleS
 	return &DeleteOCRKeyBundleSuccessResolver{key}
 }
 
-func (r *DeleteOCRKeyBundleSuccessResolver) Bundle() OCRKeyBundle {
-	return OCRKeyBundle{r.key}
+func (r *DeleteOCRKeyBundleSuccessResolver) Bundle() OCRKeyBundleResolver {
+	return OCRKeyBundleResolver{r.key}
 }
 
 type DeleteOCRKeyBundlePayloadResolver struct {

--- a/core/web/resolver/ocr.go
+++ b/core/web/resolver/ocr.go
@@ -1,30 +1,29 @@
 package resolver
 
 import (
+	"github.com/graph-gophers/graphql-go"
+
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ocrkey"
 )
 
 type OCRKeyBundle struct {
-	id                    string
-	configPublicKey       ocrkey.ConfigPublicKey
-	offChainPublicKey     ocrkey.OffChainPublicKey
-	onChainSigningAddress ocrkey.OnChainSigningAddress
+	key ocrkey.KeyV2
 }
 
-func (k OCRKeyBundle) ID() string {
-	return k.id
+func (k OCRKeyBundle) ID() graphql.ID {
+	return graphql.ID(k.key.ID())
 }
 
 func (k OCRKeyBundle) ConfigPublicKey() string {
-	return k.configPublicKey.String()
+	return ocrkey.ConfigPublicKey(k.key.PublicKeyConfig()).String()
 }
 
 func (k OCRKeyBundle) OffChainPublicKey() string {
-	return k.offChainPublicKey.String()
+	return k.key.OffChainSigning.PublicKey().String()
 }
 
 func (k OCRKeyBundle) OnChainSigningAddress() string {
-	return k.onChainSigningAddress.String()
+	return k.key.OnChainSigning.Address().String()
 }
 
 type OCRKeyBundlesPayloadResolver struct {
@@ -38,12 +37,7 @@ func NewOCRKeyBundlesPayloadResolver(keys []ocrkey.KeyV2) *OCRKeyBundlesPayloadR
 func (r *OCRKeyBundlesPayloadResolver) Results() []OCRKeyBundle {
 	bundles := []OCRKeyBundle{}
 	for _, k := range r.keys {
-		bundles = append(bundles, OCRKeyBundle{
-			id:                    k.ID(),
-			configPublicKey:       k.PublicKeyConfig(),
-			offChainPublicKey:     k.OffChainSigning.PublicKey(),
-			onChainSigningAddress: k.OnChainSigning.Address(),
-		})
+		bundles = append(bundles, OCRKeyBundle{k})
 	}
 	return bundles
 }
@@ -57,12 +51,7 @@ func NewCreateOCRKeyBundlePayloadResolver(key ocrkey.KeyV2) *CreateOCRKeyBundleP
 }
 
 func (r *CreateOCRKeyBundlePayloadResolver) Bundle() OCRKeyBundle {
-	return OCRKeyBundle{
-		id:                    r.key.ID(),
-		configPublicKey:       r.key.PublicKeyConfig(),
-		offChainPublicKey:     r.key.OffChainSigning.PublicKey(),
-		onChainSigningAddress: r.key.OnChainSigning.Address(),
-	}
+	return OCRKeyBundle{r.key}
 }
 
 type DeleteOCRKeyBundleSuccessResolver struct {
@@ -74,12 +63,7 @@ func NewDeleteOCRKeyBundleSuccessResolver(key ocrkey.KeyV2) *DeleteOCRKeyBundleS
 }
 
 func (r *DeleteOCRKeyBundleSuccessResolver) Bundle() OCRKeyBundle {
-	return OCRKeyBundle{
-		id:                    r.key.ID(),
-		configPublicKey:       r.key.PublicKeyConfig(),
-		offChainPublicKey:     r.key.OffChainSigning.PublicKey(),
-		onChainSigningAddress: r.key.OnChainSigning.Address(),
-	}
+	return OCRKeyBundle{r.key}
 }
 
 type DeleteOCRKeyBundlePayloadResolver struct {

--- a/core/web/resolver/ocr_test.go
+++ b/core/web/resolver/ocr_test.go
@@ -123,7 +123,7 @@ func TestOCRDeleteBundle(t *testing.T) {
 	assert.NoError(t, err)
 
 	mutation := `
-		mutation DeleteOCRKeyBundle($id: String!) {
+		mutation DeleteOCRKeyBundle($id: ID!) {
 			deleteOCRKeyBundle(id: $id) {
 				... on DeleteOCRKeyBundleSuccess {
 					bundle {

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -22,7 +22,7 @@ type Mutation {
     createCSAKey: CreateCSAKeyPayload!
     createFeedsManager(input: CreateFeedsManagerInput!): CreateFeedsManagerPayload!
     createOCRKeyBundle: CreateOCRKeyBundlePayload!
-    deleteOCRKeyBundle(id: String!): DeleteOCRKeyBundlePayload!
+    deleteOCRKeyBundle(id: ID!): DeleteOCRKeyBundlePayload!
     updateBridge(name: String!, input: UpdateBridgeInput!): UpdateBridgePayload!
     updateFeedsManager(id: ID!, input: UpdateFeedsManagerInput!): UpdateFeedsManagerPayload!
 }

--- a/core/web/schema/type/ocr.graphql
+++ b/core/web/schema/type/ocr.graphql
@@ -1,5 +1,5 @@
 type OCRKeyBundle {
-    id: String!
+    id: ID!
     configPublicKey: String!
     offChainPublicKey: String!
     onChainSigningAddress: String!


### PR DESCRIPTION
Follow up to #5357.

Simplify OCRKeyBundle to contain an ocrkey.KeyV2 and make the necessary conversions in the method calls instead.