### PR TITLE
Fix all of the test flakes 🚀

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -37,3 +37,4 @@
 /core/store @archseer @samsondav @jmank88
 /core/chains @samsondav
 /core/logger @jmank88
+/core/internal @samsondav @jmank88 @archseer

--- a/core/internal/testutils/pgtest/pgtest.go
+++ b/core/internal/testutils/pgtest/pgtest.go
@@ -2,16 +2,10 @@ package pgtest
 
 import (
 	"database/sql"
-	"fmt"
-	"log"
-	"net/url"
-	"os"
-	"strings"
 	"testing"
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/scylladb/go-reflectx"
-	"github.com/smartcontractkit/go-txdb"
 	"github.com/smartcontractkit/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -19,50 +13,10 @@ import (
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
-func init() {
-	dbURL := os.Getenv("DATABASE_URL")
-	if dbURL == "" {
-		log.Fatal("You must provide a DATABASE_URL environment variable")
-	}
-
-	parsed, err := url.Parse(dbURL)
-	if err != nil {
-		panic(err)
-	}
-	if parsed.Path == "" {
-		msg := fmt.Sprintf("invalid DATABASE_URL: `%s`. You must set DATABASE_URL env var to point to your test database. Note that the test database MUST end in `_test` to differentiate from a possible production DB. HINT: Try DATABASE_URL=postgresql://postgres@localhost:5432/chainlink_test?sslmode=disable", parsed.String())
-		panic(msg)
-	}
-	if !strings.HasSuffix(parsed.Path, "_test") {
-		msg := fmt.Sprintf("cannot run tests against database named `%s`. Note that the test database MUST end in `_test` to differentiate from a possible production DB. HINT: Try DATABASE_URL=postgresql://postgres@localhost:5432/chainlink_test?sslmode=disable", parsed.Path[1:])
-		panic(msg)
-	}
-
-	// Disable SavePoints because they cause random errors for reasons I cannot fathom.
-	// NOTE: That this will cause transaction BEGIN/ROLLBACK to effectively be
-	// a no-op, this should have no negative impact on normal test operation.
-	// If you MUST test BEGIN/ROLLBACK behaviour, you will have to configure your
-	// store to use the raw DialectPostgres dialect and setup a one-use database.
-	// See BootstrapThrowawayORM() as a convenience function to help you do this.
-	txdb.Register("txdb", "pgx", dbURL, txdb.SavePointOption(nil))
-	sqlx.BindDriver("txdb", sqlx.DOLLAR)
-}
-
 func NewSqlDB(t *testing.T) *sql.DB {
 	db, err := sql.Open("txdb", uuid.NewV4().String())
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, db.Close()) })
-
-	// There is a bug to do with context cancellation somewhere in txdb or sql.
-	// If you try to use the DB "too quickly" using a .WithContext then cancel
-	// the context, the transaction state gets poisoned or lost somehow and
-	// subsequent queries fail with "sql: transaction has already been
-	// committed or rolled back" (although postgres does not log any errors).
-
-	// Calling SELECT 1 here seems to reliably fix it. Created an issue to track here:
-	// https://github.com/DATA-DOG/go-txdb/issues/43
-	_, err = db.Exec(`SELECT 1`)
-	require.NoError(t, err)
 
 	return db
 }
@@ -71,17 +25,6 @@ func NewSqlxDB(t *testing.T) *sqlx.DB {
 	db, err := sqlx.Open("txdb", uuid.NewV4().String())
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, db.Close()) })
-
-	// There is a bug to do with context cancellation somewhere in txdb or sql.
-	// If you try to use the DB "too quickly" using a .WithContext then cancel
-	// the context, the transaction state gets poisoned or lost somehow and
-	// subsequent queries fail with "sql: transaction has already been
-	// committed or rolled back" (although postgres does not log any errors).
-
-	// Calling SELECT 1 here seems to reliably fix it. Created an issue to track here:
-	// https://github.com/DATA-DOG/go-txdb/issues/43
-	_, err = db.Exec(`SELECT 1`)
-	require.NoError(t, err)
 
 	db.MapperFunc(reflectx.CamelToSnakeASCII)
 

--- a/core/internal/testutils/pgtest/txdb.go
+++ b/core/internal/testutils/pgtest/txdb.go
@@ -1,0 +1,451 @@
+package pgtest
+
+import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"io"
+	"net/url"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/smartcontractkit/sqlx"
+	"go.uber.org/multierr"
+)
+
+// txdb is a simplified version of https://github.com/DATA-DOG/go-txdb
+//
+// The original lib has various problems and is hard to understand because it
+// tries to be more general. The version in thie file is more tightly focused
+// to our needs and should be easier to reason about and less likely to have
+// subtle bugs/races.
+//
+// It doesn't currently support savepoints but could be made to if necessary.
+//
+// Transaction BEGIN/ROLLBACK effectively becomes a no-op, this should have no
+// negative impact on normal test operation.
+//
+// If you MUST test BEGIN/ROLLBACK behaviour, you will have to configure your
+// store to use the raw DialectPostgres dialect and setup a one-use database.
+// See heavyweight.FullTestDB() as a convenience function to help you do this,
+// but please use sparingly because as it's name implies, it is expensive.
+func init() {
+	dbURL := os.Getenv("DATABASE_URL")
+	if dbURL == "" {
+		panic("you must provide a DATABASE_URL environment variable")
+	}
+
+	parsed, err := url.Parse(dbURL)
+	if err != nil {
+		panic(err)
+	}
+	if parsed.Path == "" {
+		msg := fmt.Sprintf("invalid DATABASE_URL: `%s`. You must set DATABASE_URL env var to point to your test database. Note that the test database MUST end in `_test` to differentiate from a possible production DB. HINT: Try DATABASE_URL=postgresql://postgres@localhost:5432/chainlink_test?sslmode=disable", parsed.String())
+		panic(msg)
+	}
+	if !strings.HasSuffix(parsed.Path, "_test") {
+		msg := fmt.Sprintf("cannot run tests against database named `%s`. Note that the test database MUST end in `_test` to differentiate from a possible production DB. HINT: Try DATABASE_URL=postgresql://postgres@localhost:5432/chainlink_test?sslmode=disable", parsed.Path[1:])
+		panic(msg)
+	}
+	sql.Register("txdb", &txDriver{
+		dbURL: dbURL,
+		conns: make(map[string]*conn),
+	})
+	sqlx.BindDriver("txdb", sqlx.DOLLAR)
+}
+
+var _ driver.Conn = &conn{}
+
+// txDriver is an sql driver which runs on single transaction
+// when the Close is called, transaction is rolled back
+type txDriver struct {
+	sync.Mutex
+	db      *sql.DB
+	conns   map[string]*conn
+	options []func(*conn) error
+
+	dbURL string
+}
+
+func (d *txDriver) Open(dsn string) (driver.Conn, error) {
+	d.Lock()
+	defer d.Unlock()
+	// Open real db connection if its the first call
+	if d.db == nil {
+		db, err := sql.Open("pgx", d.dbURL)
+		if err != nil {
+			return nil, err
+		}
+		d.db = db
+	}
+	c, exists := d.conns[dsn]
+	if !exists {
+		tx, err := d.db.Begin()
+		if err != nil {
+			return nil, err
+		}
+		c = &conn{tx: tx}
+		d.conns[dsn] = c
+		c.removeSelf = func() error {
+			return d.deleteConn(c)
+		}
+		d.conns[dsn] = c
+	}
+	c.opened++
+	return c, nil
+}
+
+// deleteConn is called by connection when it is closed
+// It also auto-closes the DB when the last checked out connection is closed
+func (d *txDriver) deleteConn(c *conn) error {
+	// must lock here to avoid racing with Open
+	d.Lock()
+	defer d.Unlock()
+
+	delete(d.conns, c.dsn)
+	if len(d.conns) == 0 && d.db != nil {
+		if err := d.db.Close(); err != nil {
+			return err
+		}
+		d.db = nil
+	}
+	return nil
+}
+
+type conn struct {
+	sync.Mutex
+	dsn        string
+	tx         *sql.Tx // tx may be shared by many conns, definitive one lives in the map keyed by DSN on the txDriver. Do not modify from conn
+	ctx        context.Context
+	cancel     context.CancelFunc
+	closed     bool
+	opened     int
+	removeSelf func() error
+}
+
+func (c *conn) Begin() (driver.Tx, error) {
+	c.Lock()
+	defer c.Unlock()
+	if c.closed {
+		panic("conn is closed")
+	}
+	// Begin is a noop because the transaction was already opened
+	return tx{c.tx}, nil
+}
+
+// Implement the "ConnBeginTx" interface
+func (c *conn) BeginTx(ctx context.Context, opts driver.TxOptions) (driver.Tx, error) {
+	// TODO: Fix context handling
+	return c.Begin()
+}
+
+// Prepare returns a prepared statement, bound to this connection.
+func (c *conn) Prepare(query string) (driver.Stmt, error) {
+	return c.PrepareContext(context.Background(), query)
+}
+
+// Implement the "ConnPrepareContext" interface
+func (c *conn) PrepareContext(ctx context.Context, query string) (driver.Stmt, error) {
+	c.Lock()
+	defer c.Unlock()
+	if c.closed {
+		panic("conn is closed")
+	}
+
+	// TODO: Fix context handling
+	// FIXME: It is not safe to give the passed in context to the tx directly
+	// because the tx is shared by many conns and cancelling the context will
+	// destroy the tx which can affect other conns
+	st, err := c.tx.PrepareContext(context.Background(), query)
+	if err != nil {
+		return nil, err
+	}
+	return &stmt{st, c}, nil
+}
+
+// pgx returns nil
+func (c *conn) CheckNamedValue(nv *driver.NamedValue) error {
+	return nil
+}
+
+// Implement the "QueryerContext" interface
+func (c *conn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	c.Lock()
+	defer c.Unlock()
+	if c.closed {
+		panic("conn is closed")
+	}
+
+	// TODO: Fix context handling
+	rs, err := c.tx.QueryContext(context.Background(), query, mapNamedArgs(args)...)
+	if err != nil {
+		return nil, err
+	}
+	defer rs.Close()
+
+	return buildRows(rs)
+}
+
+// Implement the "ExecerContext" interface
+func (c *conn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	c.Lock()
+	defer c.Unlock()
+	if c.closed {
+		panic("conn is closed")
+	}
+	// TODO: Fix context handling
+	return c.tx.ExecContext(context.Background(), query, mapNamedArgs(args)...)
+}
+
+// Close invalidates and potentially stops any current
+// prepared statements and transactions, marking this
+// connection as no longer in use.
+//
+// Because the sql package maintains a free pool of
+// connections and only calls Close when there's a surplus of
+// idle connections, it shouldn't be necessary for drivers to
+// do their own connection caching.
+//
+// Drivers must ensure all network calls made by Close
+// do not block indefinitely (e.g. apply a timeout).
+func (c *conn) Close() (err error) {
+	c.Lock()
+	defer c.Unlock()
+	if c.closed {
+		// Double close, should be a safe to make this a noop
+		// PGX allows double close
+		// See: https://github.com/jackc/pgx/blob/a457da8bffa4f90ad672fa093ee87f20cf06687b/conn.go#L249
+		return nil
+	}
+
+	c.opened--
+	if c.opened == 0 {
+		if c.tx != nil {
+			if err := c.tx.Rollback(); err != nil {
+				panic(err)
+			}
+			c.tx = nil
+		}
+		c.closed = true
+		if err := c.removeSelf(); err != nil {
+			panic(err)
+		}
+	}
+	return
+}
+
+type tx struct {
+	tx *sql.Tx
+}
+
+func (tx tx) Commit() error {
+	// Commit is a noop because the transaction will be rolled back at the end
+	return nil
+}
+
+func (tx tx) Rollback() error {
+	// Rollback is a noop because the transaction will be rolled back at the end
+	return nil
+}
+
+type stmt struct {
+	st   *sql.Stmt
+	conn *conn
+}
+
+func (s stmt) Exec(args []driver.Value) (driver.Result, error) {
+	s.conn.Lock()
+	defer s.conn.Unlock()
+	if s.conn.closed {
+		panic("conn is closed")
+	}
+	return s.st.Exec(mapArgs(args)...)
+}
+
+// Implement the "StmtExecContext" interface
+func (s *stmt) ExecContext(ctx context.Context, args []driver.NamedValue) (driver.Result, error) {
+	s.conn.Lock()
+	defer s.conn.Unlock()
+	if s.conn.closed {
+		panic("conn is closed")
+	}
+	// TODO: Fix context handling
+	return s.st.ExecContext(context.Background(), mapNamedArgs(args)...)
+}
+
+func mapArgs(args []driver.Value) (res []interface{}) {
+	res = make([]interface{}, len(args))
+	for i := range args {
+		res[i] = args[i]
+	}
+	return
+}
+
+func (s stmt) NumInput() int {
+	return -1
+}
+
+func (s stmt) Query(args []driver.Value) (driver.Rows, error) {
+	s.conn.Lock()
+	defer s.conn.Unlock()
+	if s.conn.closed {
+		panic("conn is closed")
+	}
+	rows, err := s.st.Query(mapArgs(args)...)
+	defer func() {
+		err = multierr.Combine(err, rows.Close())
+	}()
+	if err != nil {
+		return nil, err
+	}
+	return buildRows(rows)
+}
+
+// Implement the "StmtQueryContext" interface
+func (s *stmt) QueryContext(ctx context.Context, args []driver.NamedValue) (driver.Rows, error) {
+	s.conn.Lock()
+	defer s.conn.Unlock()
+	if s.conn.closed {
+		panic("conn is closed")
+	}
+	// TODO: Fix context handling
+	rows, err := s.st.QueryContext(context.Background(), mapNamedArgs(args)...)
+	if err != nil {
+		return nil, err
+	}
+	return buildRows(rows)
+}
+
+func (s stmt) Close() error {
+	return s.st.Close()
+}
+
+func buildRows(r *sql.Rows) (driver.Rows, error) {
+	set := &rowSets{}
+	rs := &rows{}
+	if err := rs.read(r); err != nil {
+		return set, err
+	}
+	set.sets = append(set.sets, rs)
+	for r.NextResultSet() {
+		rss := &rows{}
+		if err := rss.read(r); err != nil {
+			return set, err
+		}
+		set.sets = append(set.sets, rss)
+	}
+	return set, nil
+}
+
+// Implement the "RowsNextResultSet" interface
+func (rs *rowSets) HasNextResultSet() bool {
+	return rs.pos+1 < len(rs.sets)
+}
+
+// Implement the "RowsNextResultSet" interface
+func (rs *rowSets) NextResultSet() error {
+	if !rs.HasNextResultSet() {
+		return io.EOF
+	}
+
+	rs.pos++
+	return nil
+}
+
+type rows struct {
+	rows     [][]driver.Value
+	pos      int
+	cols     []string
+	colTypes []*sql.ColumnType
+}
+
+func (r *rows) Columns() []string {
+	return r.cols
+}
+
+func (r *rows) ColumnTypeDatabaseTypeName(index int) string {
+	return r.colTypes[index].DatabaseTypeName()
+}
+
+func (r *rows) Next(dest []driver.Value) error {
+	r.pos++
+	if r.pos > len(r.rows) {
+		return io.EOF
+	}
+
+	for i, val := range r.rows[r.pos-1] {
+		dest[i] = *(val.(*interface{}))
+	}
+
+	return nil
+}
+
+func (r *rows) Close() error {
+	return nil
+}
+
+func (r *rows) read(rs *sql.Rows) error {
+	var err error
+	r.cols, err = rs.Columns()
+	if err != nil {
+		return err
+	}
+
+	r.colTypes, err = rs.ColumnTypes()
+	if err != nil {
+		return err
+	}
+
+	for rs.Next() {
+		values := make([]interface{}, len(r.cols))
+		for i := range values {
+			values[i] = new(interface{})
+		}
+		if err := rs.Scan(values...); err != nil {
+			return err
+		}
+		row := make([]driver.Value, len(r.cols))
+		for i, v := range values {
+			row[i] = driver.Value(v)
+		}
+		r.rows = append(r.rows, row)
+	}
+	return rs.Err()
+}
+
+type rowSets struct {
+	sets []*rows
+	pos  int
+}
+
+func (rs *rowSets) Columns() []string {
+	return rs.sets[rs.pos].cols
+}
+
+func (rs *rowSets) ColumnTypeDatabaseTypeName(index int) string {
+	return rs.sets[rs.pos].ColumnTypeDatabaseTypeName(index)
+}
+
+func (rs *rowSets) Close() error {
+	return nil
+}
+
+// advances to next row
+func (rs *rowSets) Next(dest []driver.Value) error {
+	return rs.sets[rs.pos].Next(dest)
+}
+
+func mapNamedArgs(args []driver.NamedValue) (res []interface{}) {
+	res = make([]interface{}, len(args))
+	for i := range args {
+		name := args[i].Name
+		if name != "" {
+			res[i] = sql.Named(name, args[i].Value)
+		} else {
+			res[i] = args[i].Value
+		}
+	}
+	return
+}

--- a/core/services/headtracker/head_tracker_test.go
+++ b/core/services/headtracker/head_tracker_test.go
@@ -52,6 +52,7 @@ func TestHeadTracker_New(t *testing.T) {
 	ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
 	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).Return(sub, nil)
 	ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(cltest.Head(0), nil)
+	sub.On("Unsubscribe").Maybe().Return(nil)
 	sub.On("Err").Return(nil)
 
 	orm := headtracker.NewORM(db, cltest.FixtureChainID)

--- a/core/services/headtracker/head_tracker_test.go
+++ b/core/services/headtracker/head_tracker_test.go
@@ -62,7 +62,7 @@ func TestHeadTracker_New(t *testing.T) {
 
 	evmcfg := newCfg(t)
 	ht := createHeadTracker(t, ethClient, evmcfg, orm)
-	assert.Nil(t, ht.Start())
+	ht.Start(t)
 	latest := ht.headTracker.LatestChain()
 	require.NotNil(t, latest)
 	assert.Equal(t, last.Number, latest.Number)
@@ -139,8 +139,7 @@ func TestHeadTracker_Get(t *testing.T) {
 			}
 
 			ht := createHeadTracker(t, ethClient, config, orm)
-			ht.Start()
-			defer ht.Stop()
+			ht.Start(t)
 
 			if test.toSave != nil {
 				err := ht.headTracker.Save(context.TODO(), *test.toSave)
@@ -169,11 +168,10 @@ func TestHeadTracker_Start_NewHeads(t *testing.T) {
 		Return(sub, nil)
 
 	ht := createHeadTracker(t, ethClient, config, orm)
+	ht.Start(t)
 
-	assert.NoError(t, ht.Start())
 	<-chStarted
 
-	ht.Stop()
 	ethClient.AssertExpectations(t)
 }
 
@@ -201,14 +199,14 @@ func TestHeadTracker_CallsHeadTrackableCallbacks(t *testing.T) {
 	checker := &cltest.MockHeadTrackable{}
 	ht := createHeadTrackerWithChecker(t, ethClient, config, orm, checker)
 
-	require.Nil(t, ht.Start())
+	ht.Start(t)
 	assert.Equal(t, int32(0), checker.OnNewLongestChainCount())
 
 	headers := <-chchHeaders
 	headers <- &eth.Head{Number: 1, Hash: utils.NewHash()}
 	g.Eventually(func() int32 { return checker.OnNewLongestChainCount() }).Should(gomega.Equal(int32(1)))
 
-	require.NoError(t, ht.Stop())
+	ht.Stop(t)
 	assert.Equal(t, int32(1), checker.OnNewLongestChainCount())
 }
 
@@ -233,15 +231,12 @@ func TestHeadTracker_ReconnectOnError(t *testing.T) {
 	ht := createHeadTrackerWithChecker(t, ethClient, config, orm, checker)
 
 	// connect
-	assert.Nil(t, ht.Start())
+	ht.Start(t)
 	assert.Equal(t, int32(0), checker.OnNewLongestChainCount())
 
 	// trigger reconnect loop
 	chErr <- errors.New("Test error to force reconnect")
 	g.Eventually(func() int32 { return checker.OnNewLongestChainCount() }).Should(gomega.Equal(int32(1)))
-
-	// stop
-	assert.NoError(t, ht.Stop())
 }
 
 func TestHeadTracker_ResubscribeOnSubscriptionError(t *testing.T) {
@@ -267,8 +262,7 @@ func TestHeadTracker_ResubscribeOnSubscriptionError(t *testing.T) {
 	checker := &cltest.MockHeadTrackable{}
 	ht := createHeadTrackerWithChecker(t, ethClient, config, orm, checker)
 
-	// connect
-	assert.Nil(t, ht.Start())
+	ht.Start(t)
 	assert.Equal(t, int32(0), checker.OnNewLongestChainCount())
 
 	headers := <-chchHeaders
@@ -280,9 +274,6 @@ func TestHeadTracker_ResubscribeOnSubscriptionError(t *testing.T) {
 
 	// wait for full disconnect and a new subscription
 	g.Eventually(func() int32 { return checker.OnNewLongestChainCount() }, 5*time.Second, 5*time.Millisecond).Should(gomega.Equal(int32(1)))
-
-	// stop
-	assert.NoError(t, ht.Stop())
 }
 
 func TestHeadTracker_Start_LoadsLatestChain(t *testing.T) {
@@ -326,7 +317,7 @@ func TestHeadTracker_Start_LoadsLatestChain(t *testing.T) {
 	trackable.On("OnNewLongestChain", mock.Anything, mock.MatchedBy(func(h eth.Head) bool {
 		return h.Number == 3 && h.Hash == heads[3].Hash && h.ParentHash == heads[2].Hash && h.Parent.Number == 2 && h.Parent.Hash == heads[2].Hash && h.Parent.Parent == nil
 	})).Once().Return()
-	assert.Nil(t, ht.Start())
+	ht.Start(t)
 
 	h, err := orm.LatestHead(context.TODO())
 	require.NoError(t, err)
@@ -367,7 +358,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingEnabled(t *testing.T)
 	head0 := blocks.Head(0) // eth.Head{Number: 0, Hash: utils.NewHash(), ParentHash: utils.NewHash(), Timestamp: time.Unix(0, 0)}
 	// Initial query
 	ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(head0, nil)
-	assert.Nil(t, ht.Start())
+	ht.Start(t)
 
 	headSeq := cltest.NewHeadBuffer(t)
 	headSeq.Append(blocks.Head(0))
@@ -441,7 +432,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingEnabled(t *testing.T)
 	}
 
 	gomega.NewWithT(t).Eventually(lastHead).Should(gomega.BeClosed())
-	require.NoError(t, ht.Stop())
+	ht.Stop(t)
 	assert.Equal(t, int64(5), ht.headTracker.LatestChain().Number)
 
 	for _, h := range headSeq.Heads {
@@ -565,7 +556,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled(t *testing.T
 			close(lastHead)
 		}).Return().Once()
 
-	require.NoError(t, ht.Start())
+	ht.Start(t)
 
 	headers := <-chchHeaders
 
@@ -595,7 +586,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled(t *testing.T
 	}
 
 	gomega.NewWithT(t).Eventually(lastHead).Should(gomega.BeClosed())
-	require.NoError(t, ht.Stop())
+	ht.Stop(t)
 	assert.Equal(t, int64(5), ht.headTracker.LatestChain().Number)
 
 	for _, h := range headSeq.Heads {
@@ -885,6 +876,7 @@ func createHeadTracker(t *testing.T, ethClient eth.Client, config headtracker.Co
 	lggr := logger.TestLogger(t)
 	hb := headtracker.NewHeadBroadcaster(lggr)
 	return &headTrackerUniverse{
+		mu:              new(sync.Mutex),
 		headTracker:     headtracker.NewHeadTracker(lggr, ethClient, config, orm, hb),
 		headBroadcaster: hb,
 	}
@@ -898,6 +890,7 @@ func createHeadTrackerWithNeverSleeper(t testing.TB, ethClient eth.Client, cfg *
 	_, err := headtracker.LoadFromDB(ht)
 	require.NoError(t, err)
 	return &headTrackerUniverse{
+		mu:              new(sync.Mutex),
 		headTracker:     ht,
 		headBroadcaster: hb,
 	}
@@ -907,28 +900,41 @@ func createHeadTrackerWithChecker(t *testing.T, ethClient eth.Client, config hea
 	lggr := logger.TestLogger(t)
 	hb := headtracker.NewHeadBroadcaster(lggr)
 	hb.Subscribe(checker)
-	require.NoError(t, hb.Start())
 	return &headTrackerUniverse{
+		mu:              new(sync.Mutex),
 		headTracker:     headtracker.NewHeadTracker(lggr, ethClient, config, orm, hb, cltest.NeverSleeper{}),
 		headBroadcaster: hb,
 	}
 }
 
 type headTrackerUniverse struct {
+	mu              *sync.Mutex
+	stopped         bool
 	headTracker     *headtracker.HeadTracker
 	headBroadcaster httypes.HeadBroadcaster
 }
 
-func (u headTrackerUniverse) Backfill(ctx context.Context, head eth.Head, depth uint) error {
+func (u *headTrackerUniverse) Backfill(ctx context.Context, head eth.Head, depth uint) error {
 	return u.headTracker.Backfill(ctx, head, depth)
 }
 
-func (u headTrackerUniverse) Start() error {
-	u.headBroadcaster.Start()
-	return u.headTracker.Start()
+func (u *headTrackerUniverse) Start(t *testing.T) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	require.NoError(t, u.headBroadcaster.Start())
+	require.NoError(t, u.headTracker.Start())
+	t.Cleanup(func() {
+		u.Stop(t)
+	})
 }
 
-func (u headTrackerUniverse) Stop() error {
-	u.headBroadcaster.Close()
-	return u.headTracker.Stop()
+func (u *headTrackerUniverse) Stop(t *testing.T) {
+	u.mu.Lock()
+	defer u.mu.Unlock()
+	if u.stopped {
+		return
+	}
+	u.stopped = true
+	require.NoError(t, u.headBroadcaster.Close())
+	require.NoError(t, u.headTracker.Stop())
 }


### PR DESCRIPTION
Now gorm is gone we can finally implement a proper fix for the test flakes.

Currently testing:

- [x] `go test -p 1 ./... -parallel 1`
- [x] `go test -p 4 ./... -parallel 4`
- [x] `go test -p 8 ./... -parallel 8`
- [x] `GOPROCS=1 go test -p 1 ./... -parallel 1`
- [x] `GOPROCS=1 go test -p 8 ./... -parallel 8`
- [x] CI run without failure x1
- [x] CI run without failure x2
- [x] CI run without failure x3
- [x] CI run without failure x4
- [x] CI run without failure x5

❌ `go test -race -p 8 ./... -parallel 8` - fails but not due to DB/txdb