### PR TITLE
WrapRecover: move to inside of loop in FluxMonitor, PeerStore, and VRF listeners; let pipeline panic

### DIFF
--- a/core/services/fluxmonitorv2/flux_monitor.go
+++ b/core/services/fluxmonitorv2/flux_monitor.go
@@ -264,9 +264,7 @@ func (fm *FluxMonitor) Start() error {
 	return fm.StartOnce("FluxMonitor", func() error {
 		fm.logger.Debug("Starting Flux Monitor for job")
 
-		go gracefulpanic.WrapRecover(func() {
-			fm.consume()
-		})
+		go fm.consume()
 
 		return nil
 	})
@@ -386,38 +384,52 @@ func (fm *FluxMonitor) consume() {
 			return
 
 		case <-fm.chProcessLogs:
-			fm.processLogs()
+			gracefulpanic.WrapRecover(fm.processLogs)
 
 		case at := <-fm.pollManager.PollTickerTicks():
 			tickLogger.Debugf("Poll ticker fired on %v", formatTime(at))
-			fm.pollIfEligible(PollRequestTypePoll, fm.deviationChecker, nil)
+			gracefulpanic.WrapRecover(func() {
+				fm.pollIfEligible(PollRequestTypePoll, fm.deviationChecker, nil)
+			})
 
 		case at := <-fm.pollManager.IdleTimerTicks():
 			tickLogger.Debugf("Idle timer fired on %v", formatTime(at))
-			fm.pollIfEligible(PollRequestTypeIdle, NewZeroDeviationChecker(), nil)
+			gracefulpanic.WrapRecover(func() {
+				fm.pollIfEligible(PollRequestTypeIdle, NewZeroDeviationChecker(), nil)
+			})
 
 		case at := <-fm.pollManager.RoundTimerTicks():
 			tickLogger.Debugf("Round timer fired on %v", formatTime(at))
-			fm.pollIfEligible(PollRequestTypeRound, fm.deviationChecker, nil)
+			gracefulpanic.WrapRecover(func() {
+				fm.pollIfEligible(PollRequestTypeRound, fm.deviationChecker, nil)
+			})
 
 		case at := <-fm.pollManager.HibernationTimerTicks():
 			tickLogger.Debugf("Hibernation timer fired on %v", formatTime(at))
-			fm.pollIfEligible(PollRequestTypeHibernation, NewZeroDeviationChecker(), nil)
+			gracefulpanic.WrapRecover(func() {
+				fm.pollIfEligible(PollRequestTypeHibernation, NewZeroDeviationChecker(), nil)
+			})
 
 		case at := <-fm.pollManager.RetryTickerTicks():
 			tickLogger.Debugf("Retry ticker fired on %v", formatTime(at))
-			fm.pollIfEligible(PollRequestTypeRetry, NewZeroDeviationChecker(), nil)
+			gracefulpanic.WrapRecover(func() {
+				fm.pollIfEligible(PollRequestTypeRetry, NewZeroDeviationChecker(), nil)
+			})
 
 		case at := <-fm.pollManager.DrumbeatTicks():
 			tickLogger.Debugf("Drumbeat ticker fired on %v", formatTime(at))
-			fm.pollIfEligible(PollRequestTypeDrumbeat, NewZeroDeviationChecker(), nil)
+			gracefulpanic.WrapRecover(func() {
+				fm.pollIfEligible(PollRequestTypeDrumbeat, NewZeroDeviationChecker(), nil)
+			})
 
 		case request := <-fm.pollManager.Poll():
 			switch request.Type {
 			case PollRequestTypeUnknown:
 				break
 			default:
-				fm.pollIfEligible(request.Type, fm.deviationChecker, nil)
+				gracefulpanic.WrapRecover(func() {
+					fm.pollIfEligible(request.Type, fm.deviationChecker, nil)
+				})
 			}
 		}
 	}

--- a/core/services/offchainreporting/peerstore.go
+++ b/core/services/offchainreporting/peerstore.go
@@ -68,9 +68,7 @@ func (p *Pstorewrapper) Start() error {
 		if err != nil {
 			return errors.Wrap(err, "could not start peerstore wrapper")
 		}
-		go gracefulpanic.WrapRecover(func() {
-			p.dbLoop()
-		})
+		go p.dbLoop()
 		return nil
 	})
 }
@@ -84,9 +82,11 @@ func (p *Pstorewrapper) dbLoop() {
 		case <-p.ctx.Done():
 			return
 		case <-ticker.C:
-			if err := p.WriteToDB(); err != nil {
-				logger.Errorw("Error writing peerstore to DB", "err", err)
-			}
+			gracefulpanic.WrapRecover(func() {
+				if err := p.WriteToDB(); err != nil {
+					logger.Errorw("Error writing peerstore to DB", "err", err)
+				}
+			})
 		}
 	}
 }

--- a/core/services/offchainreporting/run_saver.go
+++ b/core/services/offchainreporting/run_saver.go
@@ -1,7 +1,6 @@
 package offchainreporting
 
 import (
-	"github.com/smartcontractkit/chainlink/core/gracefulpanic"
 	"github.com/smartcontractkit/sqlx"
 
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -37,15 +36,13 @@ func (r *RunResultSaver) Start() error {
 			for {
 				select {
 				case run := <-r.runResults:
-					gracefulpanic.WrapRecover(func() {
-						r.logger.Infow("RunSaver: saving job run", "run", run)
-						// We do not want save successful TaskRuns as OCR runs very frequently so a lot of records
-						// are produced and the successful TaskRuns do not provide value.
-						_, err := r.pipelineRunner.InsertFinishedRun(r.db, run, false)
-						if err != nil {
-							r.logger.Errorw("error inserting finished results", "err", err)
-						}
-					})
+					r.logger.Infow("RunSaver: saving job run", "run", run)
+					// We do not want save successful TaskRuns as OCR runs very frequently so a lot of records
+					// are produced and the successful TaskRuns do not provide value.
+					_, err := r.pipelineRunner.InsertFinishedRun(r.db, run, false)
+					if err != nil {
+						r.logger.Errorw("error inserting finished results", "err", err)
+					}
 				case <-r.done:
 					return
 				}

--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"context"
 	"fmt"
-	"runtime/debug"
 	"sort"
 	"sync"
 	"time"
@@ -282,20 +281,6 @@ func (r *runner) run(
 	for taskRun := range scheduler.taskCh {
 		// execute
 		go func(taskRun *memoryTaskRun) {
-			defer func() {
-				if err := recover(); err != nil {
-					logger.Default.Errorw("goroutine panicked executing run", "panic", err, "stacktrace", string(debug.Stack()))
-
-					t := time.Now()
-					scheduler.report(todo, TaskRunResult{
-						ID:         uuid.NewV4(),
-						Task:       taskRun.task,
-						Result:     Result{Error: ErrRunPanicked{err}},
-						FinishedAt: null.TimeFrom(t),
-						CreatedAt:  t, // TODO: more accurate start time
-					})
-				}
-			}()
 			result := r.executeTaskRun(ctx, run.PipelineSpec, taskRun, l)
 
 			logTaskRunToPrometheus(result, run.PipelineSpec)

--- a/core/services/postgres/sqlx.go
+++ b/core/services/postgres/sqlx.go
@@ -3,7 +3,6 @@ package postgres
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/pkg/errors"
 
@@ -49,38 +48,8 @@ func SqlxTransaction(ctx context.Context, q Queryer, fc func(tx *sqlx.Tx) error,
 	case *sqlx.Tx:
 		// nested transaction: just use the outer transaction
 		err = fc(db)
-
 	case *sqlx.DB:
-		opts := &DefaultSqlTxOptions
-		if len(txOpts) > 0 {
-			opts = &txOpts[0]
-		}
-
-		var tx *sqlx.Tx
-		tx, err = db.BeginTxx(ctx, opts)
-		panicked := false
-
-		defer func() {
-			// Make sure to rollback when panic, Block error or Commit error
-			if panicked || err != nil {
-				if perr := tx.Rollback(); perr != nil {
-					panic(perr)
-				}
-			}
-		}()
-
-		_, err = tx.Exec(fmt.Sprintf(`SET LOCAL lock_timeout = %v; SET LOCAL idle_in_transaction_session_timeout = %v;`, LockTimeout.Milliseconds(), IdleInTxSessionTimeout.Milliseconds()))
-		if err != nil {
-			return errors.Wrap(err, "error setting transaction timeouts")
-		}
-
-		panicked = true
-		err = fc(tx)
-		panicked = false
-
-		if err == nil {
-			err = errors.WithStack(tx.Commit())
-		}
+		err = sqlxTransaction(ctx, db, fc, txOpts...)
 	default:
 		err = errors.Errorf("invalid db type")
 	}

--- a/core/services/postgres/transaction.go
+++ b/core/services/postgres/transaction.go
@@ -7,7 +7,9 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/sqlx"
+	"go.uber.org/multierr"
 	"gorm.io/gorm"
 )
 
@@ -94,21 +96,39 @@ func DBWithDefaultContext(db *gorm.DB, fc func(db *gorm.DB) error) error {
 }
 
 func SqlTransaction(ctx context.Context, rdb *sql.DB, fc func(tx *sqlx.Tx) error, txOpts ...sql.TxOptions) (err error) {
+	db := WrapDbWithSqlx(rdb)
+	return sqlxTransaction(ctx, db, fc, txOpts...)
+}
+
+func sqlxTransaction(ctx context.Context, db *sqlx.DB, fc func(tx *sqlx.Tx) error, txOpts ...sql.TxOptions) (err error) {
 	opts := &DefaultSqlTxOptions
 	if len(txOpts) > 0 {
 		opts = &txOpts[0]
 	}
-	db := WrapDbWithSqlx(rdb)
 
-	tx, err := db.BeginTxx(ctx, opts)
-	panicked := false
+	var tx *sqlx.Tx
+	tx, err = db.BeginTxx(ctx, opts)
+	if err != nil {
+		return errors.Wrap(err, "failed to begin transaction")
+	}
 
 	defer func() {
-		// Make sure to rollback when panic, Block error or Commit error
-		if panicked || err != nil {
-			if perr := tx.Rollback(); perr != nil {
-				panic(perr)
+		if p := recover(); p != nil {
+			// A panic occurred, rollback and repanic
+			logger.Errorf("panic in transaction, rolling back: %s", p)
+			if rerr := tx.Rollback(); rerr != nil {
+				logger.Error("failed to rollback on panic: %s", rerr)
 			}
+			panic(p)
+		} else if err != nil {
+			logger.Debugf("error in transaction, rolling back: %s", err)
+			// An error occurred, rollback and return error
+			if rerr := tx.Rollback(); rerr != nil {
+				err = multierr.Combine(err, errors.WithStack(rerr))
+			}
+		} else {
+			// All good! Time to commit.
+			err = errors.WithStack(tx.Commit())
 		}
 	}()
 
@@ -117,13 +137,7 @@ func SqlTransaction(ctx context.Context, rdb *sql.DB, fc func(tx *sqlx.Tx) error
 		return errors.Wrap(err, "error setting transaction timeouts")
 	}
 
-	panicked = true
 	err = fc(tx)
-	panicked = false
-
-	if err == nil {
-		err = errors.WithStack(tx.Commit())
-	}
 
 	return
 }

--- a/core/services/postgres/transaction_manager.go
+++ b/core/services/postgres/transaction_manager.go
@@ -79,6 +79,9 @@ func (txm *gormTransactionManager) TransactWithContext(ctx context.Context, fn T
 
 	// Start the transaction and insert it into the context.
 	tx := txm.db.Begin(&opts.txOpts)
+	if err = tx.Error; err != nil {
+		return errors.Wrap(err, "failed to begin transaction")
+	}
 	ctx = context.WithValue(ctx, txKey{}, tx)
 
 	// Ensure that a deadline is set unless disabled by an option.

--- a/core/services/vrf/listener_v2.go
+++ b/core/services/vrf/listener_v2.go
@@ -119,12 +119,8 @@ func (lsn *listenerV2) Start() error {
 			lsn.setLatestHead(*latestHead)
 		}
 
-		go gracefulpanic.WrapRecover(func() {
-			lsn.runLogListener([]func(){unsubscribeLogs}, minConfs)
-		})
-		go gracefulpanic.WrapRecover(func() {
-			lsn.runHeadListener(unsubscribeHeadBroadcaster)
-		})
+		go lsn.runLogListener([]func(){unsubscribeLogs}, minConfs)
+		go lsn.runHeadListener(unsubscribeHeadBroadcaster)
 		return nil
 	})
 }
@@ -250,7 +246,9 @@ func (lsn *listenerV2) runLogListener(unsubscribes []func(), minConfs uint32) {
 				if !ok {
 					panic(fmt.Sprintf("VRFListenerV2: invariant violated, expected log.Broadcast got %T", i))
 				}
-				lsn.handleLog(lb, minConfs)
+				gracefulpanic.WrapRecover(func() {
+					lsn.handleLog(lb, minConfs)
+				})
 			}
 		}
 	}

--- a/core/store/config/evm_config.go
+++ b/core/store/config/evm_config.go
@@ -297,7 +297,7 @@ func (c *evmConfig) SetEvmGasPriceDefault(value *big.Int) error {
 func (c *evmConfig) EvmFinalityDepth() uint {
 	val, ok := lookupEnv("ETH_FINALITY_DEPTH", parseUint64)
 	if ok {
-		return val.(uint)
+		return uint(val.(uint64))
 	}
 	return c.chainSpecificConfig.FinalityDepth
 }
@@ -309,7 +309,7 @@ func (c *evmConfig) EvmFinalityDepth() uint {
 func (c *evmConfig) EvmHeadTrackerHistoryDepth() uint {
 	val, ok := lookupEnv("ETH_HEAD_TRACKER_HISTORY_DEPTH", parseUint64)
 	if ok {
-		return val.(uint)
+		return uint(val.(uint64))
 	}
 	return c.chainSpecificConfig.HeadTrackerHistoryDepth
 }

--- a/core/store/config/general_config.go
+++ b/core/store/config/general_config.go
@@ -1196,7 +1196,7 @@ func parseUint64(s string) (interface{}, error) {
 
 func parseF32(s string) (interface{}, error) {
 	v, err := strconv.ParseFloat(s, 32)
-	return v, err
+	return float32(v), err
 }
 
 func parseURL(s string) (interface{}, error) {


### PR DESCRIPTION
Push `gracefulpanic.WrapRecover` calls down the stack to more tightly wrap panic sources, so that long running systems stay up and processing when individual units of work panic.
```diff
-go gracefulpanic.WrapRecover(func() {
+go func() {
  for {
-    doWork()
+    gracefulpanic.WrapRecover(doWork)
  }
-})
+}()
```
Except for two places in the pipeline where recovery is removed.

Also carrying over four commits from rc0.