### PR TITLE
Implement Job Proposals GQL queries (when do we get Generics in Go?)

### DIFF
--- a/core/services/feeds/mocks/orm.go
+++ b/core/services/feeds/mocks/orm.go
@@ -218,6 +218,29 @@ func (_m *ORM) GetManager(id int64) (*feeds.FeedsManager, error) {
 	return r0, r1
 }
 
+// GetManagers provides a mock function with given fields: ids
+func (_m *ORM) GetManagers(ids []int64) ([]feeds.FeedsManager, error) {
+	ret := _m.Called(ids)
+
+	var r0 []feeds.FeedsManager
+	if rf, ok := ret.Get(0).(func([]int64) []feeds.FeedsManager); ok {
+		r0 = rf(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]feeds.FeedsManager)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]int64) error); ok {
+		r1 = rf(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // IsJobManaged provides a mock function with given fields: jobID, qopts
 func (_m *ORM) IsJobManaged(jobID int64, qopts ...postgres.QOpt) (bool, error) {
 	_va := make([]interface{}, len(qopts))

--- a/core/services/feeds/mocks/service.go
+++ b/core/services/feeds/mocks/service.go
@@ -144,6 +144,29 @@ func (_m *Service) GetManager(id int64) (*feeds.FeedsManager, error) {
 	return r0, r1
 }
 
+// GetManagers provides a mock function with given fields: ids
+func (_m *Service) GetManagers(ids []int64) ([]feeds.FeedsManager, error) {
+	ret := _m.Called(ids)
+
+	var r0 []feeds.FeedsManager
+	if rf, ok := ret.Get(0).(func([]int64) []feeds.FeedsManager); ok {
+		r0 = rf(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]feeds.FeedsManager)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]int64) error); ok {
+		r1 = rf(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // IsJobManaged provides a mock function with given fields: ctx, jobID
 func (_m *Service) IsJobManaged(ctx context.Context, jobID int64) (bool, error) {
 	ret := _m.Called(ctx, jobID)

--- a/core/services/feeds/orm.go
+++ b/core/services/feeds/orm.go
@@ -3,9 +3,10 @@ package feeds
 import (
 	"database/sql"
 
-	"github.com/pkg/errors"
 	"github.com/lib/pq"
+	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
+
 	"github.com/smartcontractkit/sqlx"
 
 	"github.com/smartcontractkit/chainlink/core/services/postgres"
@@ -90,11 +91,11 @@ func (o *orm) GetManagers(ids []int64) (managers []FeedsManager, err error) {
 	stmt := `
 SELECT id, name, uri, public_key, job_types, is_ocr_bootstrap_peer, ocr_bootstrap_peer_multiaddr, created_at, updated_at
 FROM feeds_managers
-WHERE id = ANY(?)
+WHERE id = ANY($1)
 ORDER BY created_at, id;`
 
 	mgrIds := pq.Array(ids)
-	err = postgres.NewQ(o.db).Get(&managers, stmt, mgrIds)
+	err = postgres.NewQ(o.db).Select(&managers, stmt, mgrIds)
 
 	return managers, errors.Wrap(err, "GetManagers failed")
 }

--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -147,10 +147,10 @@ func Test_ORM_GetManagers(t *testing.T) {
 		OCRBootstrapPeerMultiaddr: ocrBootstrapPeerMultiaddr,
 	}
 
-	id, err := orm.CreateManager(context.Background(), mgr)
+	id, err := orm.CreateManager(context.TODO(), mgr)
 	require.NoError(t, err)
 
-	mgrs, err := orm.GetManagers(context.Background(), []int64{id})
+	mgrs, err := orm.GetManagers(context.TODO(), []int64{id})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(mgrs))
 

--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -163,10 +163,6 @@ func Test_ORM_GetManagers(t *testing.T) {
 	assert.Equal(t, jobTypes, actual.JobTypes)
 	assert.True(t, actual.IsOCRBootstrapPeer)
 	assert.Equal(t, ocrBootstrapPeerMultiaddr, actual.OCRBootstrapPeerMultiaddr)
-
-	actual, err = orm.GetManager(context.Background(), -1)
-	require.Nil(t, actual)
-	require.Error(t, err)
 }
 
 func Test_ORM_UpdateManager(t *testing.T) {

--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -147,10 +147,10 @@ func Test_ORM_GetManagers(t *testing.T) {
 		OCRBootstrapPeerMultiaddr: ocrBootstrapPeerMultiaddr,
 	}
 
-	id, err := orm.CreateManager(context.TODO(), mgr)
+	id, err := orm.CreateManager(mgr)
 	require.NoError(t, err)
 
-	mgrs, err := orm.GetManagers(context.TODO(), []int64{id})
+	mgrs, err := orm.GetManagers([]int64{id})
 	require.NoError(t, err)
 	require.Equal(t, 1, len(mgrs))
 

--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -134,6 +134,41 @@ func Test_ORM_GetManager(t *testing.T) {
 	require.Error(t, err)
 }
 
+func Test_ORM_GetManagers(t *testing.T) {
+	t.Parallel()
+
+	orm := setupORM(t)
+	mgr := &feeds.FeedsManager{
+		URI:                       uri,
+		Name:                      name,
+		PublicKey:                 publicKey,
+		JobTypes:                  jobTypes,
+		IsOCRBootstrapPeer:        true,
+		OCRBootstrapPeerMultiaddr: ocrBootstrapPeerMultiaddr,
+	}
+
+	id, err := orm.CreateManager(context.Background(), mgr)
+	require.NoError(t, err)
+
+	mgrs, err := orm.GetManagers(context.Background(), []int64{id})
+	require.NoError(t, err)
+	require.Equal(t, 1, len(mgrs))
+
+	actual := &mgrs[0]
+
+	assert.Equal(t, id, actual.ID)
+	assert.Equal(t, uri, actual.URI)
+	assert.Equal(t, name, actual.Name)
+	assert.Equal(t, publicKey, actual.PublicKey)
+	assert.Equal(t, jobTypes, actual.JobTypes)
+	assert.True(t, actual.IsOCRBootstrapPeer)
+	assert.Equal(t, ocrBootstrapPeerMultiaddr, actual.OCRBootstrapPeerMultiaddr)
+
+	actual, err = orm.GetManager(context.Background(), -1)
+	require.Nil(t, actual)
+	require.Error(t, err)
+}
+
 func Test_ORM_UpdateManager(t *testing.T) {
 	t.Parallel()
 

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -245,7 +245,7 @@ func (s *service) GetManager(id int64) (*FeedsManager, error) {
 
 // GetManagers get managers services by ids.
 func (s *service) GetManagers(ids []int64) ([]FeedsManager, error) {
-	managers, err := s.orm.GetManagers(context.Background(), ids)
+	managers, err := s.orm.GetManagers(ids)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get managers by IDs")
 	}

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -43,6 +43,7 @@ type Service interface {
 	CreateJobProposal(jp *JobProposal) (int64, error)
 	GetJobProposal(id int64) (*JobProposal, error)
 	GetManager(id int64) (*FeedsManager, error)
+	GetManagers(ids []int64) ([]FeedsManager, error)
 	ListManagers() ([]FeedsManager, error)
 	ListJobProposals() ([]JobProposal, error)
 	ProposeJob(jp *JobProposal) (int64, error)
@@ -240,6 +241,20 @@ func (s *service) GetManager(id int64) (*FeedsManager, error) {
 
 	manager.IsConnectionActive = s.connMgr.IsConnected(manager.ID)
 	return manager, nil
+}
+
+// GetManagers get managers services by ids.
+func (s *service) GetManagers(ids []int64) ([]FeedsManager, error) {
+	managers, err := s.orm.GetManagers(context.Background(), ids)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to get managers by IDs")
+	}
+
+	for _, manager := range managers {
+		manager.IsConnectionActive = s.connMgr.IsConnected(manager.ID)
+	}
+
+	return managers, nil
 }
 
 // CountManagerServices gets the total number of manager services

--- a/core/web/loader/feeds_manager.go
+++ b/core/web/loader/feeds_manager.go
@@ -27,7 +27,7 @@ func (b *feedsBatcher) loadByIDs(ctx context.Context, keys dataloader.Keys) []*d
 		keyOrder[key.String()] = ix
 	}
 
-	// Fetch the chains
+	// Fetch the feeds managers
 	managers, err := b.app.GetFeedsService().GetManagers(managersIDs)
 	if err != nil {
 		return []*dataloader.Result{{Data: nil, Error: err}}
@@ -46,7 +46,7 @@ func (b *feedsBatcher) loadByIDs(ctx context.Context, keys dataloader.Keys) []*d
 		}
 	}
 
-	// fill array positions without any nodes
+	// fill array positions without any feeds managers
 	for _, ix := range keyOrder {
 		results[ix] = &dataloader.Result{Data: nil, Error: errors.New("feeds manager not found")}
 	}

--- a/core/web/loader/feeds_manager.go
+++ b/core/web/loader/feeds_manager.go
@@ -1,0 +1,55 @@
+package loader
+
+import (
+	"context"
+	"errors"
+	"strconv"
+
+	"github.com/graph-gophers/dataloader"
+
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
+)
+
+type feedsBatcher struct {
+	app chainlink.Application
+}
+
+func (b *feedsBatcher) loadByIDs(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
+	// Create a map for remembering the order of keys passed in
+	keyOrder := make(map[string]int, len(keys))
+	// Collect the keys to search for
+	var managersIDs []int64
+	for ix, key := range keys {
+		id, err := strconv.ParseInt(key.String(), 10, 64)
+		if err == nil {
+			managersIDs = append(managersIDs, id)
+		}
+		keyOrder[key.String()] = ix
+	}
+
+	// Fetch the chains
+	managers, err := b.app.GetFeedsService().GetManagers(managersIDs)
+	if err != nil {
+		return []*dataloader.Result{{Data: nil, Error: err}}
+	}
+
+	// Construct the output array of dataloader results
+	results := make([]*dataloader.Result, len(keys))
+	for _, c := range managers {
+		id := strconv.FormatInt(c.ID, 10)
+
+		ix, ok := keyOrder[id]
+		// if found, remove from index lookup map, so we know elements were found
+		if ok {
+			results[ix] = &dataloader.Result{Data: c, Error: nil}
+			delete(keyOrder, id)
+		}
+	}
+
+	// fill array positions without any nodes
+	for _, ix := range keyOrder {
+		results[ix] = &dataloader.Result{Data: nil, Error: errors.New("feeds manager not found")}
+	}
+
+	return results
+}

--- a/core/web/loader/getters.go
+++ b/core/web/loader/getters.go
@@ -7,6 +7,7 @@ import (
 	"github.com/graph-gophers/dataloader"
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
+	"github.com/smartcontractkit/chainlink/core/services/feeds"
 )
 
 // GetChainByID fetches the chain by it's id.
@@ -43,4 +44,21 @@ func GetNodesByChainID(ctx context.Context, id string) ([]types.Node, error) {
 	}
 
 	return nodes, nil
+}
+
+func GetFeedsManagerByID(ctx context.Context, id string) (*feeds.FeedsManager, error) {
+	ldr := For(ctx)
+
+	thunk := ldr.FeedsManagersByIDLoader.Load(ctx, dataloader.StringKey(id))
+	result, err := thunk()
+	if err != nil {
+		return nil, err
+	}
+
+	mgr, ok := result.(feeds.FeedsManager)
+	if !ok {
+		return nil, errors.New("invalid type")
+	}
+
+	return &mgr, nil
 }

--- a/core/web/loader/loader.go
+++ b/core/web/loader/loader.go
@@ -14,19 +14,22 @@ type loadersKey struct{}
 type Dataloader struct {
 	app chainlink.Application
 
-	NodesByChainIDLoader *dataloader.Loader
-	ChainsByIDLoader     *dataloader.Loader
+	NodesByChainIDLoader    *dataloader.Loader
+	ChainsByIDLoader        *dataloader.Loader
+	FeedsManagersByIDLoader *dataloader.Loader
 }
 
 func New(app chainlink.Application) *Dataloader {
 	nodes := &nodeBatcher{app: app}
 	chains := &chainBatcher{app: app}
+	mgrs := &feedsBatcher{app: app}
 
 	return &Dataloader{
 		app: app,
 
-		NodesByChainIDLoader: dataloader.NewBatchedLoader(nodes.loadByChainIDs),
-		ChainsByIDLoader:     dataloader.NewBatchedLoader(chains.loadByIDs),
+		NodesByChainIDLoader:    dataloader.NewBatchedLoader(nodes.loadByChainIDs),
+		ChainsByIDLoader:        dataloader.NewBatchedLoader(chains.loadByIDs),
+		FeedsManagersByIDLoader: dataloader.NewBatchedLoader(mgrs.loadByIDs),
 	}
 }
 

--- a/core/web/resolver/bridge_test.go
+++ b/core/web/resolver/bridge_test.go
@@ -462,7 +462,7 @@ func Test_DeleteBridgeMutation(t *testing.T) {
 				}`,
 		},
 		{
-			name:          "invalid bridge type name",
+			name:          "bridge with jobs associated",
 			authenticated: true,
 			query:         mutation,
 			variables: map[string]interface{}{

--- a/core/web/resolver/errors.go
+++ b/core/web/resolver/errors.go
@@ -15,13 +15,13 @@ const (
 	ErrorCodeStatusConflict ErrorCode = "STATUS_CONFLICT"
 )
 
-type ResolvesNotFoundError struct {
+type NotFoundErrorUnionType struct {
 	err     error
 	message string
 }
 
 // ToNotFoundError resolves to the not found error resolver
-func (e *ResolvesNotFoundError) ToNotFoundError() (*NotFoundErrorResolver, bool) {
+func (e *NotFoundErrorUnionType) ToNotFoundError() (*NotFoundErrorResolver, bool) {
 	if e.err != nil && errors.Is(e.err, sql.ErrNoRows) {
 		return NewNotFoundError(e.message), true
 	}

--- a/core/web/resolver/errors.go
+++ b/core/web/resolver/errors.go
@@ -1,5 +1,11 @@
 package resolver
 
+import (
+	"database/sql"
+
+	"github.com/pkg/errors"
+)
+
 type ErrorCode string
 
 const (
@@ -8,6 +14,20 @@ const (
 	ErrorCodeUnprocessable  ErrorCode = "UNPROCESSABLE"
 	ErrorCodeStatusConflict ErrorCode = "STATUS_CONFLICT"
 )
+
+type ResolvesNotFoundError struct {
+	err     error
+	message string
+}
+
+// ToNotFoundError resolves to the not found error resolver
+func (e *ResolvesNotFoundError) ToNotFoundError() (*NotFoundErrorResolver, bool) {
+	if e.err != nil && errors.Is(e.err, sql.ErrNoRows) {
+		return NewNotFoundError(e.message), true
+	}
+
+	return nil, false
+}
 
 type NotFoundErrorResolver struct {
 	message string

--- a/core/web/resolver/job_proposal.go
+++ b/core/web/resolver/job_proposal.go
@@ -1,0 +1,82 @@
+package resolver
+
+import (
+	"github.com/graph-gophers/graphql-go"
+
+	"github.com/smartcontractkit/chainlink/core/services/feeds"
+)
+
+// JobProposalResolver resolves the Job Proposal type
+type JobProposalResolver struct {
+	jp *feeds.JobProposal
+}
+
+// NewJobProposal creates a new JobProposalResolver
+func NewJobProposal(jp *feeds.JobProposal) *JobProposalResolver {
+	return &JobProposalResolver{jp}
+}
+
+// ID resolves to the job proposal ID
+func (r *JobProposalResolver) ID() graphql.ID {
+	return int32GQLID(int32(r.jp.ID))
+}
+
+// Spec resolves to the job proposal Spec
+func (r *JobProposalResolver) Spec() string {
+	return r.jp.Spec
+}
+
+// Status resolves to the job proposal Status
+func (r *JobProposalResolver) Status() string {
+	return string(r.jp.Status)
+}
+
+// ExternalJobID resolves to the job proposal ExternalJobID
+func (r *JobProposalResolver) ExternalJobID() string {
+	if r.jp.ExternalJobID.Valid {
+		return r.jp.ExternalJobID.UUID.String()
+	}
+
+	return "no valid"
+}
+
+// MultiAddrs resolves to the job proposal MultiAddrs
+func (r *JobProposalResolver) MultiAddrs() []string {
+	return r.jp.Multiaddrs
+}
+
+// ProposedAt resolves to the job proposal ProposedAt date
+func (r *JobProposalResolver) ProposedAt() graphql.Time {
+	return graphql.Time{Time: r.jp.ProposedAt}
+}
+
+// -- GetJobProposal Query --
+
+// JobProposalPayloadResolver resolves the job proposal payload type
+type JobProposalPayloadResolver struct {
+	jp  *feeds.JobProposal
+	err error
+}
+
+// NewJobProposalPayload creates a new job proposal payload
+func NewJobProposalPayload(jp *feeds.JobProposal, err error) *JobProposalPayloadResolver {
+	return &JobProposalPayloadResolver{jp, err}
+}
+
+// ToJobProposal resolves to the job proposal resolver
+func (r *JobProposalPayloadResolver) ToJobProposal() (*JobProposalResolver, bool) {
+	if r.err == nil {
+		return NewJobProposal(r.jp), true
+	}
+
+	return nil, false
+}
+
+// ToNotFoundError resolves to the not found error resolver
+func (r *JobProposalPayloadResolver) ToNotFoundError() (*NotFoundErrorResolver, bool) {
+	if r.err != nil {
+		return NewNotFoundError("job proposal not found"), true
+	}
+
+	return nil, false
+}

--- a/core/web/resolver/job_proposal.go
+++ b/core/web/resolver/job_proposal.go
@@ -133,6 +133,24 @@ type JobProposalPayload interface {
 	ToNotFoundError() (*NotFoundErrorResolver, bool)
 }
 
+type JobProposalAction string
+
+const (
+	approve JobProposalAction = "approve"
+	cancel  JobProposalAction = "cancel"
+)
+
+func ToJobProposalPayload(a JobProposalAction, jp *feeds.JobProposal, err error) (JobProposalPayload, error) {
+	switch a {
+	case approve:
+		return NewApproveJobProposalPayload(jp, err), nil
+	case cancel:
+		return NewCancelJobProposalPayload(jp, err), nil
+	default:
+		return nil, errors.New("invalid job proposal action")
+	}
+}
+
 // -- ApproveJobProposal Mutation --
 
 type ApproveJobProposalPayloadResolver struct {

--- a/core/web/resolver/job_proposal.go
+++ b/core/web/resolver/job_proposal.go
@@ -138,6 +138,7 @@ type JobProposalAction string
 const (
 	approve JobProposalAction = "approve"
 	cancel  JobProposalAction = "cancel"
+	reject  JobProposalAction = "reject"
 )
 
 func ToJobProposalPayload(a JobProposalAction, jp *feeds.JobProposal, err error) (JobProposalPayload, error) {
@@ -146,6 +147,8 @@ func ToJobProposalPayload(a JobProposalAction, jp *feeds.JobProposal, err error)
 		return NewApproveJobProposalPayload(jp, err), nil
 	case cancel:
 		return NewCancelJobProposalPayload(jp, err), nil
+	case reject:
+		return NewRejectJobProposalPayload(jp, err), nil
 	default:
 		return nil, errors.New("invalid job proposal action")
 	}
@@ -216,5 +219,39 @@ func NewCancelJobProposalSuccess(jp *feeds.JobProposal) *CancelJobProposalSucces
 }
 
 func (r *CancelJobProposalSuccessResolver) JobProposal() *JobProposalResolver {
+	return NewJobProposal(r.jp)
+}
+
+// -- RejectJobProposal Mutation --
+
+type RejectJobProposalPayloadResolver struct {
+	jp *feeds.JobProposal
+	ResolvesNotFoundError
+}
+
+func NewRejectJobProposalPayload(jp *feeds.JobProposal, err error) *RejectJobProposalPayloadResolver {
+	e := ResolvesNotFoundError{err: err, message: notFoundErrorMessage}
+
+	return &RejectJobProposalPayloadResolver{jp, e}
+}
+
+// ToRejectJobProposalSuccess resolves to the approval job proposal success resolver
+func (r *RejectJobProposalPayloadResolver) ToRejectJobProposalSuccess() (*RejectJobProposalSuccessResolver, bool) {
+	if r.jp != nil {
+		return NewRejectJobProposalSuccess(r.jp), true
+	}
+
+	return nil, false
+}
+
+type RejectJobProposalSuccessResolver struct {
+	jp *feeds.JobProposal
+}
+
+func NewRejectJobProposalSuccess(jp *feeds.JobProposal) *RejectJobProposalSuccessResolver {
+	return &RejectJobProposalSuccessResolver{jp}
+}
+
+func (r *RejectJobProposalSuccessResolver) JobProposal() *JobProposalResolver {
 	return NewJobProposal(r.jp)
 }

--- a/core/web/resolver/job_proposal.go
+++ b/core/web/resolver/job_proposal.go
@@ -12,6 +12,8 @@ import (
 	"github.com/smartcontractkit/chainlink/core/web/loader"
 )
 
+var notFoundErrorMessage = "job proposal not found"
+
 type JobProposalStatus string
 
 const (
@@ -125,30 +127,29 @@ func (r *JobProposalPayloadResolver) ToNotFoundError() (*NotFoundErrorResolver, 
 	return nil, false
 }
 
+// -- Mutations shared interface --
+
+type JobProposalPayload interface {
+	ToNotFoundError() (*NotFoundErrorResolver, bool)
+}
+
 // -- ApproveJobProposal Mutation --
 
 type ApproveJobProposalPayloadResolver struct {
-	jp  *feeds.JobProposal
-	err error
+	jp *feeds.JobProposal
+	ResolvesNotFoundError
 }
 
 func NewApproveJobProposalPayload(jp *feeds.JobProposal, err error) *ApproveJobProposalPayloadResolver {
-	return &ApproveJobProposalPayloadResolver{jp, err}
+	e := ResolvesNotFoundError{err: err, message: notFoundErrorMessage}
+
+	return &ApproveJobProposalPayloadResolver{jp, e}
 }
 
 // ToApproveJobProposalSuccess resolves to the approval job proposal success resolver
 func (r *ApproveJobProposalPayloadResolver) ToApproveJobProposalSuccess() (*ApproveJobProposalSuccessResolver, bool) {
 	if r.jp != nil {
 		return NewApproveJobProposalSuccess(r.jp), true
-	}
-
-	return nil, false
-}
-
-// ToNotFoundError resolves to the not found error resolver
-func (r *ApproveJobProposalPayloadResolver) ToNotFoundError() (*NotFoundErrorResolver, bool) {
-	if r.err != nil && errors.Is(r.err, sql.ErrNoRows) {
-		return NewNotFoundError("job proposal not found"), true
 	}
 
 	return nil, false
@@ -163,5 +164,39 @@ func NewApproveJobProposalSuccess(jp *feeds.JobProposal) *ApproveJobProposalSucc
 }
 
 func (r *ApproveJobProposalSuccessResolver) JobProposal() *JobProposalResolver {
+	return NewJobProposal(r.jp)
+}
+
+// -- CancelJobProposal Mutation --
+
+type CancelJobProposalPayloadResolver struct {
+	jp *feeds.JobProposal
+	ResolvesNotFoundError
+}
+
+func NewCancelJobProposalPayload(jp *feeds.JobProposal, err error) *CancelJobProposalPayloadResolver {
+	e := ResolvesNotFoundError{err: err, message: notFoundErrorMessage}
+
+	return &CancelJobProposalPayloadResolver{jp, e}
+}
+
+// ToCancelJobProposalSuccess resolves to the approval job proposal success resolver
+func (r *CancelJobProposalPayloadResolver) ToCancelJobProposalSuccess() (*CancelJobProposalSuccessResolver, bool) {
+	if r.jp != nil {
+		return NewCancelJobProposalSuccess(r.jp), true
+	}
+
+	return nil, false
+}
+
+type CancelJobProposalSuccessResolver struct {
+	jp *feeds.JobProposal
+}
+
+func NewCancelJobProposalSuccess(jp *feeds.JobProposal) *CancelJobProposalSuccessResolver {
+	return &CancelJobProposalSuccessResolver{jp}
+}
+
+func (r *CancelJobProposalSuccessResolver) JobProposal() *JobProposalResolver {
 	return NewJobProposal(r.jp)
 }

--- a/core/web/resolver/job_proposal.go
+++ b/core/web/resolver/job_proposal.go
@@ -2,6 +2,7 @@ package resolver
 
 import (
 	"context"
+	"database/sql"
 	"strconv"
 
 	"github.com/graph-gophers/graphql-go"
@@ -117,9 +118,50 @@ func (r *JobProposalPayloadResolver) ToJobProposal() (*JobProposalResolver, bool
 
 // ToNotFoundError resolves to the not found error resolver
 func (r *JobProposalPayloadResolver) ToNotFoundError() (*NotFoundErrorResolver, bool) {
-	if r.err != nil {
+	if r.err != nil && errors.Is(r.err, sql.ErrNoRows) {
 		return NewNotFoundError("job proposal not found"), true
 	}
 
 	return nil, false
+}
+
+// -- ApproveJobProposal Mutation --
+
+type ApproveJobProposalPayloadResolver struct {
+	jp  *feeds.JobProposal
+	err error
+}
+
+func NewApproveJobProposalPayload(jp *feeds.JobProposal, err error) *ApproveJobProposalPayloadResolver {
+	return &ApproveJobProposalPayloadResolver{jp, err}
+}
+
+// ToApproveJobProposalSuccess resolves to the approval job proposal success resolver
+func (r *ApproveJobProposalPayloadResolver) ToApproveJobProposalSuccess() (*ApproveJobProposalSuccessResolver, bool) {
+	if r.jp != nil {
+		return NewApproveJobProposalSuccess(r.jp), true
+	}
+
+	return nil, false
+}
+
+// ToNotFoundError resolves to the not found error resolver
+func (r *ApproveJobProposalPayloadResolver) ToNotFoundError() (*NotFoundErrorResolver, bool) {
+	if r.err != nil && errors.Is(r.err, sql.ErrNoRows) {
+		return NewNotFoundError("job proposal not found"), true
+	}
+
+	return nil, false
+}
+
+type ApproveJobProposalSuccessResolver struct {
+	jp *feeds.JobProposal
+}
+
+func NewApproveJobProposalSuccess(jp *feeds.JobProposal) *ApproveJobProposalSuccessResolver {
+	return &ApproveJobProposalSuccessResolver{jp}
+}
+
+func (r *ApproveJobProposalSuccessResolver) JobProposal() *JobProposalResolver {
+	return NewJobProposal(r.jp)
 }

--- a/core/web/resolver/job_proposal.go
+++ b/core/web/resolver/job_proposal.go
@@ -124,9 +124,10 @@ func (r *JobProposalPayloadResolver) ToJobProposal() (*JobProposalResolver, bool
 type JobProposalAction string
 
 const (
-	approve JobProposalAction = "approve"
-	cancel  JobProposalAction = "cancel"
-	reject  JobProposalAction = "reject"
+	approve    JobProposalAction = "approve"
+	cancel     JobProposalAction = "cancel"
+	reject     JobProposalAction = "reject"
+	updateSpec JobProposalAction = "updateSpec"
 )
 
 // -- ApproveJobProposal Mutation --
@@ -228,5 +229,39 @@ func NewRejectJobProposalSuccess(jp *feeds.JobProposal) *RejectJobProposalSucces
 }
 
 func (r *RejectJobProposalSuccessResolver) JobProposal() *JobProposalResolver {
+	return NewJobProposal(r.jp)
+}
+
+// -- UpdateJobProposalSpec Mutation --
+
+type UpdateJobProposalSpecPayloadResolver struct {
+	jp *feeds.JobProposal
+	NotFoundErrorUnionType
+}
+
+func NewUpdateJobProposalSpecPayload(jp *feeds.JobProposal, err error) *UpdateJobProposalSpecPayloadResolver {
+	e := NotFoundErrorUnionType{err: err, message: notFoundErrorMessage}
+
+	return &UpdateJobProposalSpecPayloadResolver{jp, e}
+}
+
+// ToUpdateJobProposalSpecSuccess resolves to the approval job proposal success resolver
+func (r *UpdateJobProposalSpecPayloadResolver) ToUpdateJobProposalSpecSuccess() (*UpdateJobProposalSpecSuccessResolver, bool) {
+	if r.jp != nil {
+		return NewUpdateJobProposalSpecSuccess(r.jp), true
+	}
+
+	return nil, false
+}
+
+type UpdateJobProposalSpecSuccessResolver struct {
+	jp *feeds.JobProposal
+}
+
+func NewUpdateJobProposalSpecSuccess(jp *feeds.JobProposal) *UpdateJobProposalSpecSuccessResolver {
+	return &UpdateJobProposalSpecSuccessResolver{jp}
+}
+
+func (r *UpdateJobProposalSpecSuccessResolver) JobProposal() *JobProposalResolver {
 	return NewJobProposal(r.jp)
 }

--- a/core/web/resolver/job_proposal.go
+++ b/core/web/resolver/job_proposal.go
@@ -124,10 +124,9 @@ func (r *JobProposalPayloadResolver) ToJobProposal() (*JobProposalResolver, bool
 type JobProposalAction string
 
 const (
-	approve    JobProposalAction = "approve"
-	cancel     JobProposalAction = "cancel"
-	reject     JobProposalAction = "reject"
-	updateSpec JobProposalAction = "updateSpec"
+	approve JobProposalAction = "approve"
+	cancel  JobProposalAction = "cancel"
+	reject  JobProposalAction = "reject"
 )
 
 // -- ApproveJobProposal Mutation --

--- a/core/web/resolver/job_proposal_test.go
+++ b/core/web/resolver/job_proposal_test.go
@@ -250,7 +250,7 @@ func TestResolver_CancelJobProposal(t *testing.T) {
 				"jobProposal": {
 					"id": "1",
 					"spec": "some-spec",
-					"status": "APPROVED",
+					"status": "CANCELLED",
 					"externalJobID": "%s",
 					"multiAddrs": ["1", "2"],
 					"feedsManager": {
@@ -280,7 +280,7 @@ func TestResolver_CancelJobProposal(t *testing.T) {
 				f.Mocks.feedsSvc.On("GetJobProposal", jpID).Return(&feeds.JobProposal{
 					ID:             jpID,
 					Spec:           "some-spec",
-					Status:         feeds.JobProposalStatusApproved,
+					Status:         feeds.JobProposalStatusCancelled,
 					ExternalJobID:  ejID,
 					FeedsManagerID: 1,
 					Multiaddrs:     []string{"1", "2"},

--- a/core/web/resolver/job_proposal_test.go
+++ b/core/web/resolver/job_proposal_test.go
@@ -23,6 +23,10 @@ func TestResolver_GetJobProposal(t *testing.T) {
 					status
 					externalJobID
 					multiAddrs
+					feedsManager {
+						id
+						name
+					}
 				}
 				... on NotFoundError {
 					message
@@ -38,9 +42,13 @@ func TestResolver_GetJobProposal(t *testing.T) {
 			"jobProposal": {
 				"id": "1",
 				"spec": "some-spec",
-				"status": "approved",
+				"status": "APPROVED",
 				"externalJobID": "%s",
-				"multiAddrs": ["1", "2"]
+				"multiAddrs": ["1", "2"],
+				"feedsManager": {
+					"id": "1",
+					"name": "manager"
+				}
 			}
 		}`
 
@@ -50,6 +58,12 @@ func TestResolver_GetJobProposal(t *testing.T) {
 			name:          "success",
 			authenticated: true,
 			before: func(f *gqlTestFramework) {
+				f.Mocks.feedsSvc.On("GetManagers", []int64{1}).Return([]feeds.FeedsManager{
+					{
+						ID:   1,
+						Name: "manager",
+					},
+				}, nil)
 				f.Mocks.feedsSvc.On("GetJobProposal", jpID).Return(&feeds.JobProposal{
 					ID:             jpID,
 					Spec:           "some-spec",

--- a/core/web/resolver/job_proposal_test.go
+++ b/core/web/resolver/job_proposal_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/mock"
 
 	"github.com/smartcontractkit/chainlink/core/services/feeds"
 )
@@ -89,6 +90,122 @@ func TestResolver_GetJobProposal(t *testing.T) {
 			result: `
 			{
 				"jobProposal": {
+					"message": "job proposal not found",
+					"code": "NOT_FOUND"
+				}
+			}`,
+		},
+	}
+
+	RunGQLTests(t, testCases)
+}
+
+func TestResolver_ApproveJobProposal(t *testing.T) {
+	t.Parallel()
+
+	mutation := `
+		mutation ApproveJobProposal($id: ID!) {
+			approveJobProposal(id: $id) {
+				... on ApproveJobProposalSuccess {
+					jobProposal {
+						id
+						spec
+						status
+						externalJobID
+						multiAddrs
+						feedsManager {
+							id
+							name
+						}
+					}
+				}
+				... on NotFoundError {
+					message
+					code
+				}
+			}
+		}`
+
+	jpID := int64(1)
+	ejID := uuid.NullUUID{UUID: uuid.NewV4(), Valid: true}
+	result := `
+		{
+			"approveJobProposal": {
+				"jobProposal": {
+					"id": "1",
+					"spec": "some-spec",
+					"status": "APPROVED",
+					"externalJobID": "%s",
+					"multiAddrs": ["1", "2"],
+					"feedsManager": {
+						"id": "1",
+						"name": "manager"
+					}
+				}
+			}
+		}`
+	variables := map[string]interface{}{
+		"id": "1",
+	}
+
+	testCases := []GQLTestCase{
+		unauthorizedTestCase(GQLTestCase{query: mutation, variables: variables}, "approveJobProposal"),
+		{
+			name:          "success",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.feedsSvc.On("GetManagers", []int64{1}).Return([]feeds.FeedsManager{
+					{
+						ID:   1,
+						Name: "manager",
+					},
+				}, nil)
+				f.Mocks.feedsSvc.On("ApproveJobProposal", mock.Anything, jpID).Return(nil)
+				f.Mocks.feedsSvc.On("GetJobProposal", jpID).Return(&feeds.JobProposal{
+					ID:             jpID,
+					Spec:           "some-spec",
+					Status:         feeds.JobProposalStatusApproved,
+					ExternalJobID:  ejID,
+					FeedsManagerID: 1,
+					Multiaddrs:     []string{"1", "2"},
+					ProposedAt:     time.Time{},
+				}, nil)
+				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
+			},
+			query:     mutation,
+			variables: variables,
+			result:    fmt.Sprintf(result, ejID.UUID.String()),
+		},
+		{
+			name:          "not found error on approval",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.feedsSvc.On("ApproveJobProposal", mock.Anything, jpID).Return(sql.ErrNoRows)
+				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
+			},
+			query:     mutation,
+			variables: variables,
+			result: `
+			{
+				"approveJobProposal": {
+					"message": "job proposal not found",
+					"code": "NOT_FOUND"
+				}
+			}`,
+		},
+		{
+			name:          "not found error on fetch",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.feedsSvc.On("ApproveJobProposal", mock.Anything, jpID).Return(nil)
+				f.Mocks.feedsSvc.On("GetJobProposal", jpID).Return(nil, sql.ErrNoRows)
+				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
+			},
+			query:     mutation,
+			variables: variables,
+			result: `
+			{
+				"approveJobProposal": {
 					"message": "job proposal not found",
 					"code": "NOT_FOUND"
 				}

--- a/core/web/resolver/job_proposal_test.go
+++ b/core/web/resolver/job_proposal_test.go
@@ -215,3 +215,119 @@ func TestResolver_ApproveJobProposal(t *testing.T) {
 
 	RunGQLTests(t, testCases)
 }
+
+func TestResolver_CancelJobProposal(t *testing.T) {
+	t.Parallel()
+
+	mutation := `
+		mutation cancelJobProposal($id: ID!) {
+			cancelJobProposal(id: $id) {
+				... on CancelJobProposalSuccess {
+					jobProposal {
+						id
+						spec
+						status
+						externalJobID
+						multiAddrs
+						feedsManager {
+							id
+							name
+						}
+					}
+				}
+				... on NotFoundError {
+					message
+					code
+				}
+			}
+		}`
+
+	jpID := int64(1)
+	ejID := uuid.NullUUID{UUID: uuid.NewV4(), Valid: true}
+	result := `
+		{
+			"cancelJobProposal": {
+				"jobProposal": {
+					"id": "1",
+					"spec": "some-spec",
+					"status": "APPROVED",
+					"externalJobID": "%s",
+					"multiAddrs": ["1", "2"],
+					"feedsManager": {
+						"id": "1",
+						"name": "manager"
+					}
+				}
+			}
+		}`
+	variables := map[string]interface{}{
+		"id": "1",
+	}
+
+	testCases := []GQLTestCase{
+		unauthorizedTestCase(GQLTestCase{query: mutation, variables: variables}, "cancelJobProposal"),
+		{
+			name:          "success",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.feedsSvc.On("GetManagers", []int64{1}).Return([]feeds.FeedsManager{
+					{
+						ID:   1,
+						Name: "manager",
+					},
+				}, nil)
+				f.Mocks.feedsSvc.On("CancelJobProposal", mock.Anything, jpID).Return(nil)
+				f.Mocks.feedsSvc.On("GetJobProposal", jpID).Return(&feeds.JobProposal{
+					ID:             jpID,
+					Spec:           "some-spec",
+					Status:         feeds.JobProposalStatusApproved,
+					ExternalJobID:  ejID,
+					FeedsManagerID: 1,
+					Multiaddrs:     []string{"1", "2"},
+					ProposedAt:     time.Time{},
+				}, nil)
+				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
+			},
+			query:     mutation,
+			variables: variables,
+			result:    fmt.Sprintf(result, ejID.UUID.String()),
+		},
+		{
+			name:          "not found error on approval",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.feedsSvc.On("CancelJobProposal", mock.Anything, jpID).Return(sql.ErrNoRows)
+				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
+			},
+			query:     mutation,
+			variables: variables,
+			result: `
+			{
+				"cancelJobProposal": {
+					"message": "job proposal not found",
+					"code": "NOT_FOUND"
+				}
+			}`,
+		},
+		{
+			name:          "not found error on fetch",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.feedsSvc.On("CancelJobProposal", mock.Anything, jpID).Return(nil)
+				f.Mocks.feedsSvc.On("GetJobProposal", jpID).Return(nil, sql.ErrNoRows)
+				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
+			},
+			query:     mutation,
+			variables: variables,
+			result: `
+			{
+				"cancelJobProposal": {
+					"message": "job proposal not found",
+					"code": "NOT_FOUND"
+				}
+			}`,
+		},
+	}
+
+	RunGQLTests(t, testCases)
+}

--- a/core/web/resolver/job_proposal_test.go
+++ b/core/web/resolver/job_proposal_test.go
@@ -220,7 +220,7 @@ func TestResolver_CancelJobProposal(t *testing.T) {
 	t.Parallel()
 
 	mutation := `
-		mutation cancelJobProposal($id: ID!) {
+		mutation CancelJobProposal($id: ID!) {
 			cancelJobProposal(id: $id) {
 				... on CancelJobProposalSuccess {
 					jobProposal {
@@ -322,6 +322,122 @@ func TestResolver_CancelJobProposal(t *testing.T) {
 			result: `
 			{
 				"cancelJobProposal": {
+					"message": "job proposal not found",
+					"code": "NOT_FOUND"
+				}
+			}`,
+		},
+	}
+
+	RunGQLTests(t, testCases)
+}
+
+func TestResolver_RejectJobProposal(t *testing.T) {
+	t.Parallel()
+
+	mutation := `
+		mutation RejectJobProposal($id: ID!) {
+			rejectJobProposal(id: $id) {
+				... on RejectJobProposalSuccess {
+					jobProposal {
+						id
+						spec
+						status
+						externalJobID
+						multiAddrs
+						feedsManager {
+							id
+							name
+						}
+					}
+				}
+				... on NotFoundError {
+					message
+					code
+				}
+			}
+		}`
+
+	jpID := int64(1)
+	ejID := uuid.NullUUID{UUID: uuid.NewV4(), Valid: true}
+	result := `
+		{
+			"rejectJobProposal": {
+				"jobProposal": {
+					"id": "1",
+					"spec": "some-spec",
+					"status": "REJECTED",
+					"externalJobID": "%s",
+					"multiAddrs": ["1", "2"],
+					"feedsManager": {
+						"id": "1",
+						"name": "manager"
+					}
+				}
+			}
+		}`
+	variables := map[string]interface{}{
+		"id": "1",
+	}
+
+	testCases := []GQLTestCase{
+		unauthorizedTestCase(GQLTestCase{query: mutation, variables: variables}, "rejectJobProposal"),
+		{
+			name:          "success",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.feedsSvc.On("GetManagers", []int64{1}).Return([]feeds.FeedsManager{
+					{
+						ID:   1,
+						Name: "manager",
+					},
+				}, nil)
+				f.Mocks.feedsSvc.On("RejectJobProposal", mock.Anything, jpID).Return(nil)
+				f.Mocks.feedsSvc.On("GetJobProposal", jpID).Return(&feeds.JobProposal{
+					ID:             jpID,
+					Spec:           "some-spec",
+					Status:         feeds.JobProposalStatusRejected,
+					ExternalJobID:  ejID,
+					FeedsManagerID: 1,
+					Multiaddrs:     []string{"1", "2"},
+					ProposedAt:     time.Time{},
+				}, nil)
+				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
+			},
+			query:     mutation,
+			variables: variables,
+			result:    fmt.Sprintf(result, ejID.UUID.String()),
+		},
+		{
+			name:          "not found error on approval",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.feedsSvc.On("RejectJobProposal", mock.Anything, jpID).Return(sql.ErrNoRows)
+				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
+			},
+			query:     mutation,
+			variables: variables,
+			result: `
+			{
+				"rejectJobProposal": {
+					"message": "job proposal not found",
+					"code": "NOT_FOUND"
+				}
+			}`,
+		},
+		{
+			name:          "not found error on fetch",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.feedsSvc.On("RejectJobProposal", mock.Anything, jpID).Return(nil)
+				f.Mocks.feedsSvc.On("GetJobProposal", jpID).Return(nil, sql.ErrNoRows)
+				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
+			},
+			query:     mutation,
+			variables: variables,
+			result: `
+			{
+				"rejectJobProposal": {
 					"message": "job proposal not found",
 					"code": "NOT_FOUND"
 				}

--- a/core/web/resolver/job_proposal_test.go
+++ b/core/web/resolver/job_proposal_test.go
@@ -1,0 +1,86 @@
+package resolver
+
+import (
+	"database/sql"
+	"fmt"
+	"testing"
+	"time"
+
+	uuid "github.com/satori/go.uuid"
+
+	"github.com/smartcontractkit/chainlink/core/services/feeds"
+)
+
+func TestResolver_GetJobProposal(t *testing.T) {
+	t.Parallel()
+
+	query := `
+		query GetJobProposal {
+			jobProposal(id: "1") {
+				... on JobProposal {
+					id
+					spec
+					status
+					externalJobID
+					multiAddrs
+				}
+				... on NotFoundError {
+					message
+					code
+				}
+			}
+		}`
+
+	jpID := int64(1)
+	ejID := uuid.NullUUID{UUID: uuid.NewV4(), Valid: true}
+	result := `
+		{
+			"jobProposal": {
+				"id": "1",
+				"spec": "some-spec",
+				"status": "approved",
+				"externalJobID": "%s",
+				"multiAddrs": ["1", "2"]
+			}
+		}`
+
+	testCases := []GQLTestCase{
+		unauthorizedTestCase(GQLTestCase{query: query}, "jobProposal"),
+		{
+			name:          "success",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.feedsSvc.On("GetJobProposal", jpID).Return(&feeds.JobProposal{
+					ID:             jpID,
+					Spec:           "some-spec",
+					Status:         feeds.JobProposalStatusApproved,
+					ExternalJobID:  ejID,
+					FeedsManagerID: 1,
+					Multiaddrs:     []string{"1", "2"},
+					ProposedAt:     time.Time{},
+				}, nil)
+				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
+			},
+			query:  query,
+			result: fmt.Sprintf(result, ejID.UUID.String()),
+		},
+		{
+			name:          "not found error",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.feedsSvc.On("GetJobProposal", jpID).Return(nil, sql.ErrNoRows)
+				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
+			},
+			query: query,
+			result: `
+			{
+				"jobProposal": {
+					"message": "job proposal not found",
+					"code": "NOT_FOUND"
+				}
+			}`,
+		},
+	}
+
+	RunGQLTests(t, testCases)
+}

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -497,6 +497,23 @@ func (r *Resolver) CancelJobProposal(ctx context.Context, args struct {
 	return prv, err
 }
 
+func (r *Resolver) RejectJobProposal(ctx context.Context, args struct {
+	ID graphql.ID
+}) (*RejectJobProposalPayloadResolver, error) {
+	rsv, err := r.executeJobProposalAction(ctx, jobProposalAction{
+		args.ID, reject,
+	})
+
+	prv, ok := rsv.(*RejectJobProposalPayloadResolver)
+	if prv != nil && !ok {
+		return nil, errors.New(
+			fmt.Sprintf("expected resolver to be *RejectJobProposalPayloadResolver, got %T", prv),
+		)
+	}
+
+	return prv, err
+}
+
 type jobProposalAction struct {
 	jpID graphql.ID
 	Name JobProposalAction
@@ -520,6 +537,9 @@ func (r *Resolver) executeJobProposalAction(ctx context.Context, action jobPropo
 		break
 	case cancel:
 		err = feedsSvc.CancelJobProposal(ctx, id)
+		break
+	case reject:
+		err = feedsSvc.RejectJobProposal(ctx, id)
 		break
 	default:
 		return nil, errors.New("invalid job proposal action")

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -462,3 +462,38 @@ func (r *Resolver) DeleteVRFKey(ctx context.Context, args struct {
 
 	return NewDeleteVRFKeyPayloadResolver(key, nil), nil
 }
+
+func (r *Resolver) ApproveJobProposal(ctx context.Context, args struct {
+	ID graphql.ID
+}) (*ApproveJobProposalPayloadResolver, error) {
+	if err := authenticateUser(ctx); err != nil {
+		return nil, err
+	}
+
+	id, err := strconv.ParseInt(string(args.ID), 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	feedsSvc := r.App.GetFeedsService()
+
+	err = feedsSvc.ApproveJobProposal(ctx, id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return NewApproveJobProposalPayload(nil, err), nil
+		}
+
+		return nil, err
+	}
+
+	jp, err := feedsSvc.GetJobProposal(id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return NewApproveJobProposalPayload(nil, err), nil
+		}
+
+		return nil, err
+	}
+
+	return NewApproveJobProposalPayload(jp, nil), nil
+}

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -472,9 +472,7 @@ func (r *Resolver) ApproveJobProposal(ctx context.Context, args struct {
 
 	prv, ok := rsv.(*ApproveJobProposalPayloadResolver)
 	if prv != nil && !ok {
-		return nil, errors.New(
-			fmt.Sprintf("expected resolver to be *ApproveJobProposalPayloadResolver, got %T", prv),
-		)
+		return nil, fmt.Errorf("expected resolver to be *ApproveJobProposalPayloadResolver, got %T", prv)
 	}
 
 	return prv, err
@@ -489,9 +487,7 @@ func (r *Resolver) CancelJobProposal(ctx context.Context, args struct {
 
 	prv, ok := rsv.(*CancelJobProposalPayloadResolver)
 	if prv != nil && !ok {
-		return nil, errors.New(
-			fmt.Sprintf("expected resolver to be *CancelJobProposalPayloadResolver, got %T", prv),
-		)
+		return nil, fmt.Errorf("expected resolver to be *CancelJobProposalPayloadResolver, got %T", prv)
 	}
 
 	return prv, err
@@ -506,9 +502,7 @@ func (r *Resolver) RejectJobProposal(ctx context.Context, args struct {
 
 	prv, ok := rsv.(*RejectJobProposalPayloadResolver)
 	if prv != nil && !ok {
-		return nil, errors.New(
-			fmt.Sprintf("expected resolver to be *RejectJobProposalPayloadResolver, got %T", prv),
-		)
+		return nil, fmt.Errorf("expected resolver to be *RejectJobProposalPayloadResolver, got %T", prv)
 	}
 
 	return prv, err
@@ -534,13 +528,10 @@ func (r *Resolver) executeJobProposalAction(ctx context.Context, action jobPropo
 	switch action.Name {
 	case approve:
 		err = feedsSvc.ApproveJobProposal(ctx, id)
-		break
 	case cancel:
 		err = feedsSvc.CancelJobProposal(ctx, id)
-		break
 	case reject:
 		err = feedsSvc.RejectJobProposal(ctx, id)
-		break
 	default:
 		return nil, errors.New("invalid job proposal action")
 	}

--- a/core/web/resolver/query.go
+++ b/core/web/resolver/query.go
@@ -216,6 +216,7 @@ func (r *Resolver) Features(ctx context.Context) (*FeaturesPayloadResolver, erro
 	return NewFeaturesPayloadResolver(r.App.GetConfig()), nil
 }
 
+// Node retrieves a node by ID
 func (r *Resolver) Node(ctx context.Context, args struct{ ID graphql.ID }) (*NodePayloadResolver, error) {
 	if err := authenticateUser(ctx); err != nil {
 		return nil, err
@@ -281,4 +282,29 @@ func (r *Resolver) VRFKey(ctx context.Context, args struct {
 	}
 
 	return NewVRFKeyPayloadResolver(key, nil), err
+}
+
+// JobProposal retrieves a job proposal by ID
+func (r *Resolver) JobProposal(ctx context.Context, args struct {
+	ID graphql.ID
+}) (*JobProposalPayloadResolver, error) {
+	if err := authenticateUser(ctx); err != nil {
+		return nil, err
+	}
+
+	id, err := strconv.ParseInt(string(args.ID), 10, 64)
+	if err != nil {
+		return nil, err
+	}
+
+	jp, err := r.App.GetFeedsService().GetJobProposal(id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return NewJobProposalPayload(nil, err), nil
+		}
+
+		return nil, err
+	}
+
+	return NewJobProposalPayload(jp, err), nil
 }

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -25,6 +25,7 @@ type Query {
 }
 
 type Mutation {
+    approveJobProposal(id: ID!): ApproveJobProposalPayload!
     createBridge(input: CreateBridgeInput!): CreateBridgePayload!
     createCSAKey: CreateCSAKeyPayload!
     createFeedsManager(input: CreateFeedsManagerInput!): CreateFeedsManagerPayload!

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -42,4 +42,5 @@ type Mutation {
     rejectJobProposal(id: ID!): RejectJobProposalPayload!
     updateBridge(name: String!, input: UpdateBridgeInput!): UpdateBridgePayload!
     updateFeedsManager(id: ID!, input: UpdateFeedsManagerInput!): UpdateFeedsManagerPayload!
+    updateJobProposalSpec(id: ID!, input: UpdateJobProposalSpecInput!): UpdateJobProposalSpecPayload!
 }

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -26,6 +26,7 @@ type Query {
 
 type Mutation {
     approveJobProposal(id: ID!): ApproveJobProposalPayload!
+    cancelJobProposal(id: ID!): CancelJobProposalPayload!
     createBridge(input: CreateBridgeInput!): CreateBridgePayload!
     createCSAKey: CreateCSAKeyPayload!
     createFeedsManager(input: CreateFeedsManagerInput!): CreateFeedsManagerPayload!

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -39,6 +39,7 @@ type Mutation {
     deleteP2PKey(id: ID!): DeleteP2PKeyPayload!
     createVRFKey: CreateVRFKeyPayload!
     deleteVRFKey(id: ID!): DeleteVRFKeyPayload!
+    rejectJobProposal(id: ID!): RejectJobProposalPayload!
     updateBridge(name: String!, input: UpdateBridgeInput!): UpdateBridgePayload!
     updateFeedsManager(id: ID!, input: UpdateFeedsManagerInput!): UpdateFeedsManagerPayload!
 }

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -16,6 +16,7 @@ type Query {
     feedsManagers: FeedsManagersPayload!
     job(id: ID!): JobPayload!
     jobs(offset: Int, limit: Int): JobsPayload!
+    jobProposal(id: ID!): JobProposalPayload!
     node(id: ID!): NodePayload!
     ocrKeyBundles: OCRKeyBundlesPayload!
     p2pKeys: P2PKeysPayload!

--- a/core/web/schema/type/job_proposal.graphql
+++ b/core/web/schema/type/job_proposal.graphql
@@ -22,3 +22,9 @@ type ApproveJobProposalSuccess {
 }
 
 union ApproveJobProposalPayload = ApproveJobProposalSuccess | NotFoundError
+
+type CancelJobProposalSuccess {
+    jobProposal: JobProposal!
+}
+
+union CancelJobProposalPayload = CancelJobProposalSuccess | NotFoundError

--- a/core/web/schema/type/job_proposal.graphql
+++ b/core/web/schema/type/job_proposal.graphql
@@ -1,9 +1,16 @@
+enum JobProposalStatus {
+    PENDING
+    APPROVED
+    REJECTED
+    CANCELLED
+}
+
 type JobProposal {
     id: ID!
     spec: String!
-    status: String!
+    status: JobProposalStatus!
     externalJobID: String!
-#    feedsManager: FeedsManager!
+    feedsManager: FeedsManager!
     multiAddrs: [String!]!
     proposedAt: Time!
 }

--- a/core/web/schema/type/job_proposal.graphql
+++ b/core/web/schema/type/job_proposal.graphql
@@ -16,3 +16,9 @@ type JobProposal {
 }
 
 union JobProposalPayload = JobProposal | NotFoundError
+
+type ApproveJobProposalSuccess {
+    jobProposal: JobProposal!
+}
+
+union ApproveJobProposalPayload = ApproveJobProposalSuccess | NotFoundError

--- a/core/web/schema/type/job_proposal.graphql
+++ b/core/web/schema/type/job_proposal.graphql
@@ -28,3 +28,9 @@ type CancelJobProposalSuccess {
 }
 
 union CancelJobProposalPayload = CancelJobProposalSuccess | NotFoundError
+
+type RejectJobProposalSuccess {
+    jobProposal: JobProposal!
+}
+
+union RejectJobProposalPayload = RejectJobProposalSuccess | NotFoundError

--- a/core/web/schema/type/job_proposal.graphql
+++ b/core/web/schema/type/job_proposal.graphql
@@ -9,7 +9,7 @@ type JobProposal {
     id: ID!
     spec: String!
     status: JobProposalStatus!
-    externalJobID: String!
+    externalJobID: String
     feedsManager: FeedsManager!
     multiAddrs: [String!]!
     proposedAt: Time!

--- a/core/web/schema/type/job_proposal.graphql
+++ b/core/web/schema/type/job_proposal.graphql
@@ -1,0 +1,11 @@
+type JobProposal {
+    id: ID!
+    spec: String!
+    status: String!
+    externalJobID: String!
+#    feedsManager: FeedsManager!
+    multiAddrs: [String!]!
+    proposedAt: Time!
+}
+
+union JobProposalPayload = JobProposal | NotFoundError

--- a/core/web/schema/type/job_proposal.graphql
+++ b/core/web/schema/type/job_proposal.graphql
@@ -34,3 +34,13 @@ type RejectJobProposalSuccess {
 }
 
 union RejectJobProposalPayload = RejectJobProposalSuccess | NotFoundError
+
+input UpdateJobProposalSpecInput {
+    spec: String!
+}
+
+type UpdateJobProposalSpecSuccess {
+    jobProposal: JobProposal!
+}
+
+union UpdateJobProposalSpecPayload = UpdateJobProposalSpecSuccess | NotFoundError


### PR DESCRIPTION
Closes: https://app.shortcut.com/chainlinklabs/story/20888/implement-job-proposal-queries

This aims to implement 5 different queries/mutations for job proposals:

- `GetJobProposals`
- `ApproveJobProposal`
- `RejectJobProposal`
- `CancelJobProposal`
- `UpdateJobProposalSpec`