### PR TITLE
Fix query args for upsert

### DIFF
--- a/core/chains/evm/legacy.go
+++ b/core/chains/evm/legacy.go
@@ -46,13 +46,13 @@ func ClobberDBFromEnv(db *sqlx.DB, config LegacyEthNodeConfig, lggr logger.Logge
 	if config.EthereumHTTPURL() != nil {
 		primaryHTTP = null.StringFrom(config.EthereumHTTPURL().String())
 	}
-	if _, err := db.Exec(stmt, fmt.Sprintf("primary-0-%s", ethChainID), ethChainID, primaryWS, primaryHTTP, false, ethChainID, primaryWS, primaryHTTP); err != nil {
+	if _, err := db.Exec(stmt, fmt.Sprintf("primary-0-%s", ethChainID), ethChainID, primaryWS, primaryHTTP, false); err != nil {
 		return errors.Wrap(err, "failed to upsert primary-0")
 	}
 
 	for i, url := range config.EthereumSecondaryURLs() {
 		name := fmt.Sprintf("sendonly-%d-%s", i, ethChainID)
-		if _, err := db.Exec(stmt, name, ethChainID, nil, url.String(), true, ethChainID, nil, url.String()); err != nil {
+		if _, err := db.Exec(stmt, name, ethChainID, nil, url.String(), true); err != nil {
 			return errors.Wrapf(err, "failed to upsert %s", name)
 		}
 	}


### PR DESCRIPTION
Looks like we have too many query arguments for the query that inserts primary/secondary node information into the DB.

Seeing this when running latest `develop` locally:

```
2021-11-10T17:35:33.647-0500 [INFO]  Starting Chainlink Node unset at commit unset      cmd/local_client.go:55  SHA=unset Version=unset logger=boot 
2021-11-10T17:35:33.647-0500 [WARN]  Chainlink is running in DEVELOPMENT mode. This is a security risk if enabled in production. cmd/local_client.go:58  logger=boot 
2021/11/10 17:35:33 goose: no more migrations to run. current version: 84
2021-11-10T17:35:33.722-0500 [INFO]  USE_LEGACY_ETH_ENV_VARS is on, upserting chain %s and replacing primary/send-only nodes. It is recommended to set USE_LEGACY_ETH_ENV_VARS=false on subsequent runs and use the API to administer chains/nodes instead evm/legacy.go:28        evmChainID=4 
creating application: failed to upsert primary-0: expected 5 arguments, got 8
```

Follow up to #5404 _I think_. Not sure how this was working before as the number of query arguments hasn't changed.