### PR TITLE
Implements `setServicesLogLevels` mutation

### DIFF
--- a/core/web/resolver/log.go
+++ b/core/web/resolver/log.go
@@ -26,50 +26,41 @@ func FromLogLevel(logLvl LogLevel) string {
 	}
 }
 
-type ServiceLogLevel struct {
-	Name  string
-	Level LogLevel
+type LogLevelConfig struct {
+	HeadTracker *LogLevel
+	FluxMonitor *LogLevel
+	Keeper      *LogLevel
 }
 
-type ServiceLogLevelInput struct {
-	Name  string   `json:"name"`
-	Level LogLevel `json:"level"`
+type LogLevelConfigResolver struct {
+	cfg *LogLevelConfig
 }
 
-type ServiceLogLevelResolver struct {
-	logLvl ServiceLogLevel
+func NewLogLevelConfig(cfg *LogLevelConfig) *LogLevelConfigResolver {
+	return &LogLevelConfigResolver{cfg}
 }
 
-func NewServiceLogLevel(logLvl ServiceLogLevel) *ServiceLogLevelResolver {
-	return &ServiceLogLevelResolver{logLvl}
+func (r *LogLevelConfigResolver) HeadTracker() *LogLevel {
+	return r.cfg.HeadTracker
 }
 
-func NewServicesLogLevel(logLvls []ServiceLogLevel) []*ServiceLogLevelResolver {
-	var resolvers []*ServiceLogLevelResolver
-	for _, logLvl := range logLvls {
-		resolvers = append(resolvers, NewServiceLogLevel(logLvl))
-	}
-
-	return resolvers
+func (r *LogLevelConfigResolver) FluxMonitor() *LogLevel {
+	return r.cfg.FluxMonitor
 }
 
-func (r *ServiceLogLevelResolver) Name() string {
-	return r.logLvl.Name
-}
-
-func (r *ServiceLogLevelResolver) Level() LogLevel {
-	return r.logLvl.Level
+func (r *LogLevelConfigResolver) Keeper() *LogLevel {
+	return r.cfg.Keeper
 }
 
 // -- SetServiceLogLevel Mutation --
 
 type SetServicesLogLevelsPayloadResolver struct {
-	svcLvls   []ServiceLogLevel
+	cfg       *LogLevelConfig
 	inputErrs map[string]string
 }
 
-func NewSetServicesLogLevelsPayload(svcLvls []ServiceLogLevel, inputErrs map[string]string) *SetServicesLogLevelsPayloadResolver {
-	return &SetServicesLogLevelsPayloadResolver{svcLvls, inputErrs}
+func NewSetServicesLogLevelsPayload(cfg *LogLevelConfig, inputErrs map[string]string) *SetServicesLogLevelsPayloadResolver {
+	return &SetServicesLogLevelsPayloadResolver{cfg, inputErrs}
 }
 
 func (r *SetServicesLogLevelsPayloadResolver) ToSetServicesLogLevelsSuccess() (*SetServicesLogLevelsSuccessResolver, bool) {
@@ -77,7 +68,7 @@ func (r *SetServicesLogLevelsPayloadResolver) ToSetServicesLogLevelsSuccess() (*
 		return nil, false
 	}
 
-	return NewSetServicesLogLevelsSuccess(r.svcLvls), true
+	return NewSetServicesLogLevelsSuccess(r.cfg), true
 }
 
 func (r *SetServicesLogLevelsPayloadResolver) ToInputErrors() (*InputErrorsResolver, bool) {
@@ -95,13 +86,13 @@ func (r *SetServicesLogLevelsPayloadResolver) ToInputErrors() (*InputErrorsResol
 }
 
 type SetServicesLogLevelsSuccessResolver struct {
-	svcLvls []ServiceLogLevel
+	cfg *LogLevelConfig
 }
 
-func NewSetServicesLogLevelsSuccess(svcLvls []ServiceLogLevel) *SetServicesLogLevelsSuccessResolver {
-	return &SetServicesLogLevelsSuccessResolver{svcLvls}
+func NewSetServicesLogLevelsSuccess(cfg *LogLevelConfig) *SetServicesLogLevelsSuccessResolver {
+	return &SetServicesLogLevelsSuccessResolver{cfg}
 }
 
-func (r *SetServicesLogLevelsSuccessResolver) LogLevels() []*ServiceLogLevelResolver {
-	return NewServicesLogLevel(r.svcLvls)
+func (r *SetServicesLogLevelsSuccessResolver) Config() *LogLevelConfigResolver {
+	return NewLogLevelConfig(r.cfg)
 }

--- a/core/web/resolver/log.go
+++ b/core/web/resolver/log.go
@@ -33,10 +33,10 @@ type LogLevelConfig struct {
 }
 
 type LogLevelConfigResolver struct {
-	cfg *LogLevelConfig
+	cfg LogLevelConfig
 }
 
-func NewLogLevelConfig(cfg *LogLevelConfig) *LogLevelConfigResolver {
+func NewLogLevelConfig(cfg LogLevelConfig) *LogLevelConfigResolver {
 	return &LogLevelConfigResolver{cfg}
 }
 
@@ -68,7 +68,7 @@ func (r *SetServicesLogLevelsPayloadResolver) ToSetServicesLogLevelsSuccess() (*
 		return nil, false
 	}
 
-	return NewSetServicesLogLevelsSuccess(r.cfg), true
+	return NewSetServicesLogLevelsSuccess(*r.cfg), true
 }
 
 func (r *SetServicesLogLevelsPayloadResolver) ToInputErrors() (*InputErrorsResolver, bool) {
@@ -86,10 +86,10 @@ func (r *SetServicesLogLevelsPayloadResolver) ToInputErrors() (*InputErrorsResol
 }
 
 type SetServicesLogLevelsSuccessResolver struct {
-	cfg *LogLevelConfig
+	cfg LogLevelConfig
 }
 
-func NewSetServicesLogLevelsSuccess(cfg *LogLevelConfig) *SetServicesLogLevelsSuccessResolver {
+func NewSetServicesLogLevelsSuccess(cfg LogLevelConfig) *SetServicesLogLevelsSuccessResolver {
 	return &SetServicesLogLevelsSuccessResolver{cfg}
 }
 

--- a/core/web/resolver/log.go
+++ b/core/web/resolver/log.go
@@ -1,0 +1,107 @@
+package resolver
+
+import "strings"
+
+type LogLevel string
+
+const (
+	LogLevelDebug = "DEBUG"
+	LogLevelInfo  = "INFO"
+	LogLevelWarn  = "WARN"
+	LogLevelError = "ERROR"
+)
+
+func FromLogLevel(logLvl LogLevel) string {
+	switch logLvl {
+	case LogLevelDebug:
+		return "debug"
+	case LogLevelInfo:
+		return "info"
+	case LogLevelWarn:
+		return "warn"
+	case LogLevelError:
+		return "error"
+	default:
+		return strings.ToLower(string(logLvl))
+	}
+}
+
+type ServiceLogLevel struct {
+	Name  string
+	Level LogLevel
+}
+
+type ServiceLogLevelInput struct {
+	Name  string   `json:"name"`
+	Level LogLevel `json:"level"`
+}
+
+type ServiceLogLevelResolver struct {
+	logLvl ServiceLogLevel
+}
+
+func NewServiceLogLevel(logLvl ServiceLogLevel) *ServiceLogLevelResolver {
+	return &ServiceLogLevelResolver{logLvl}
+}
+
+func NewServicesLogLevel(logLvls []ServiceLogLevel) []*ServiceLogLevelResolver {
+	var resolvers []*ServiceLogLevelResolver
+	for _, logLvl := range logLvls {
+		resolvers = append(resolvers, NewServiceLogLevel(logLvl))
+	}
+
+	return resolvers
+}
+
+func (r *ServiceLogLevelResolver) Name() string {
+	return r.logLvl.Name
+}
+
+func (r *ServiceLogLevelResolver) Level() LogLevel {
+	return r.logLvl.Level
+}
+
+// -- SetServiceLogLevel Mutation --
+
+type SetServicesLogLevelsPayloadResolver struct {
+	svcLvls   []ServiceLogLevel
+	inputErrs map[string]string
+}
+
+func NewSetServicesLogLevelsPayload(svcLvls []ServiceLogLevel, inputErrs map[string]string) *SetServicesLogLevelsPayloadResolver {
+	return &SetServicesLogLevelsPayloadResolver{svcLvls, inputErrs}
+}
+
+func (r *SetServicesLogLevelsPayloadResolver) ToSetServicesLogLevelsSuccess() (*SetServicesLogLevelsSuccessResolver, bool) {
+	if r.inputErrs != nil {
+		return nil, false
+	}
+
+	return NewSetServicesLogLevelsSuccess(r.svcLvls), true
+}
+
+func (r *SetServicesLogLevelsPayloadResolver) ToInputErrors() (*InputErrorsResolver, bool) {
+	if r.inputErrs != nil {
+		var errs []*InputErrorResolver
+
+		for path, message := range r.inputErrs {
+			errs = append(errs, NewInputError(path, message))
+		}
+
+		return NewInputErrors(errs), true
+	}
+
+	return nil, false
+}
+
+type SetServicesLogLevelsSuccessResolver struct {
+	svcLvls []ServiceLogLevel
+}
+
+func NewSetServicesLogLevelsSuccess(svcLvls []ServiceLogLevel) *SetServicesLogLevelsSuccessResolver {
+	return &SetServicesLogLevelsSuccessResolver{svcLvls}
+}
+
+func (r *SetServicesLogLevelsSuccessResolver) LogLevels() []*ServiceLogLevelResolver {
+	return NewServicesLogLevel(r.svcLvls)
+}

--- a/core/web/resolver/log_test.go
+++ b/core/web/resolver/log_test.go
@@ -1,0 +1,100 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink/core/logger"
+)
+
+func TestResolver_SetServiceLogLevel(t *testing.T) {
+	t.Parallel()
+
+	mutation := `
+		mutation SetServicesLogLevels($input: SetServicesLogLevelsInput!) {
+			setServicesLogLevels(input: $input) {
+				... on SetServicesLogLevelsSuccess {
+					logLevels {
+						name
+						level
+					}
+				}
+				... on InputErrors {
+					errors {
+						path
+						message
+						code
+					}
+				}
+			}
+		}`
+	input := map[string]interface{}{
+		"input": map[string]interface{}{
+			"logLevels": []map[string]interface{}{
+				{
+					"name": "name",
+				},
+			},
+		},
+	}
+	invalidInput := map[string]interface{}{
+		"input": map[string]interface{}{
+			"logLevels": []map[string]interface{}{
+				{
+					"name":  logger.HeadTracker,
+					"level": "invalid",
+				},
+			},
+		},
+	}
+
+	testCases := []GQLTestCase{
+		unauthorizedTestCase(GQLTestCase{query: mutation, variables: input}, "setServicesLogLevels"),
+		{
+			name:          "success",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				var lvl zapcore.Level
+				err := lvl.UnmarshalText([]byte("debug"))
+				assert.NoError(t, err)
+
+				f.App.On("SetServiceLogLevel", f.Ctx, logger.HeadTracker, lvl)
+			},
+			query:     mutation,
+			variables: input,
+			result: `
+				{
+					"setServicesLogLevels": {
+						"logLevels": [
+							{
+								"name": "head_tracker",
+								"level": "debug"
+							}
+						]
+					}
+				}`,
+		},
+		{
+			name:          "invalid log level",
+			authenticated: true,
+			query:         mutation,
+			variables:     invalidInput,
+			result: `
+				{
+					"setServicesLogLevels": {
+						"errors": [
+							{
+								"path": "head_tracker/invalid",
+								"message": "invalid log level",
+								"code": "INVALID_INPUT"
+							}
+						]
+					}
+				}`,
+		},
+	}
+
+	RunGQLTests(t, testCases)
+}

--- a/core/web/resolver/log_test.go
+++ b/core/web/resolver/log_test.go
@@ -34,7 +34,8 @@ func TestResolver_SetServiceLogLevel(t *testing.T) {
 		"input": map[string]interface{}{
 			"logLevels": []map[string]interface{}{
 				{
-					"name": "name",
+					"name":  logger.HeadTracker,
+					"level": "DEBUG",
 				},
 			},
 		},

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -598,13 +598,11 @@ func (r *Resolver) executeJobProposalAction(ctx context.Context, action jobPropo
 }
 
 func (r *Resolver) SetServicesLogLevels(ctx context.Context, args struct {
-	Input struct{ Config *LogLevelConfig }
+	Input struct{ Config LogLevelConfig }
 }) (*SetServicesLogLevelsPayloadResolver, error) {
 	if err := authenticateUser(ctx); err != nil {
 		return nil, err
 	}
-
-	fmt.Println(*args.Input.Config)
 
 	if args.Input.Config.HeadTracker != nil {
 		inputErrs, err := r.setServiceLogLevel(ctx, logger.HeadTracker, *args.Input.Config.HeadTracker)
@@ -636,7 +634,7 @@ func (r *Resolver) SetServicesLogLevels(ctx context.Context, args struct {
 		}
 	}
 
-	return NewSetServicesLogLevelsPayload(args.Input.Config, nil), nil
+	return NewSetServicesLogLevelsPayload(&args.Input.Config, nil), nil
 }
 
 func (r *Resolver) setServiceLogLevel(ctx context.Context, svcName string, logLvl LogLevel) (map[string]string, error) {

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -40,6 +40,7 @@ type Mutation {
     createVRFKey: CreateVRFKeyPayload!
     deleteVRFKey(id: ID!): DeleteVRFKeyPayload!
     rejectJobProposal(id: ID!): RejectJobProposalPayload!
+    setServicesLogLevels(input: SetServicesLogLevelsInput!): SetServicesLogLevelsPayload!
     updateBridge(name: String!, input: UpdateBridgeInput!): UpdateBridgePayload!
     updateFeedsManager(id: ID!, input: UpdateFeedsManagerInput!): UpdateFeedsManagerPayload!
     updateJobProposalSpec(id: ID!, input: UpdateJobProposalSpecInput!): UpdateJobProposalSpecPayload!

--- a/core/web/schema/type/log.graphql
+++ b/core/web/schema/type/log.graphql
@@ -5,22 +5,24 @@ enum LogLevel {
     ERROR
 }
 
-type ServiceLogLevel {
-    name: String!
-    level: LogLevel!
+type LogLevelConfig {
+    keeper: LogLevel
+    headTracker: LogLevel
+    fluxMonitor: LogLevel
 }
 
-input ServiceLogLevelInput {
-    name: String!
-    level: LogLevel!
+input LogLevelConfigInput {
+    keeper: LogLevel
+    headTracker: LogLevel
+    fluxMonitor: LogLevel
 }
 
 input SetServicesLogLevelsInput {
-    logLevels: [ServiceLogLevelInput!]!
+   config: LogLevelConfigInput!
 }
 
 type SetServicesLogLevelsSuccess {
-    logLevels: [ServiceLogLevel!]!
+    config: LogLevelConfig
 }
 
 union SetServicesLogLevelsPayload = SetServicesLogLevelsSuccess | InputErrors

--- a/core/web/schema/type/log.graphql
+++ b/core/web/schema/type/log.graphql
@@ -1,0 +1,26 @@
+enum LogLevel {
+    DEBUG,
+    INFO,
+    WARN,
+    ERROR
+}
+
+type ServiceLogLevel {
+    name: String!
+    level: LogLevel!
+}
+
+input ServiceLogLevelInput {
+    name: String!
+    level: LogLevel!
+}
+
+input SetServicesLogLevelsInput {
+    logLevels: [ServiceLogLevelInput!]!
+}
+
+type SetServicesLogLevelsSuccess {
+    logLevels: [ServiceLogLevel!]!
+}
+
+union SetServicesLogLevelsPayload = SetServicesLogLevelsSuccess | InputErrors

--- a/core/web/schema/type/log.graphql
+++ b/core/web/schema/type/log.graphql
@@ -22,7 +22,7 @@ input SetServicesLogLevelsInput {
 }
 
 type SetServicesLogLevelsSuccess {
-    config: LogLevelConfig
+    config: LogLevelConfig!
 }
 
 union SetServicesLogLevelsPayload = SetServicesLogLevelsSuccess | InputErrors

--- a/core/web/schema/type/log.graphql
+++ b/core/web/schema/type/log.graphql
@@ -1,7 +1,7 @@
 enum LogLevel {
-    DEBUG,
-    INFO,
-    WARN,
+    DEBUG
+    INFO
+    WARN
     ERROR
 }
 


### PR DESCRIPTION
Closes: https://app.shortcut.com/chainlinklabs/story/20896/implement-a-setserviceloglevels-mutation

This aims to enable a `setServicesLogLevels` mutation that will allow to set service specific log levels.