### PR TITLE
Signing address rendered as check-summed address

### DIFF
--- a/core/services/keystore/keys/ocrkey/on_chain_signing_address.go
+++ b/core/services/keystore/keys/ocrkey/on_chain_signing_address.go
@@ -17,7 +17,8 @@ const onChainSigningAddressPrefix = "ocrsad_"
 type OnChainSigningAddress ocrtypes.OnChainSigningAddress
 
 func (ocsa OnChainSigningAddress) String() string {
-	return fmt.Sprintf("%s%s", onChainSigningAddressPrefix, hexutil.Encode(ocsa[:]))
+	address := common.BytesToAddress(ocsa[:])
+	return fmt.Sprintf("%s%s", onChainSigningAddressPrefix, address)
 }
 
 func (ocsa OnChainSigningAddress) MarshalJSON() ([]byte, error) {

--- a/core/services/keystore/keys/ocrkey/on_chain_signing_address_test.go
+++ b/core/services/keystore/keys/ocrkey/on_chain_signing_address_test.go
@@ -1,0 +1,19 @@
+package ocrkey_test
+
+import (
+	"github.com/stretchr/testify/require"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ocrkey"
+)
+
+func TestOCR_OnChainSigningAddress_String(t *testing.T) {
+	t.Parallel()
+
+	// should contain EIP55CapitalizedAddress
+	const ocrSigningKey = "ocrsad_0x30762A700F7d836528dfB14DD60Ec2A3aEaA7694"
+	var address ocrkey.OnChainSigningAddress
+	err := address.UnmarshalText([]byte(ocrSigningKey))
+	require.NoError(t, err)
+	require.Equal(t, ocrSigningKey, address.String())
+}


### PR DESCRIPTION
Fixes https://app.shortcut.com/chainlinklabs/story/13163/ocrsigningaddress-not-generating-check-summed-address

As per @nzleet the fix is all about how we render Signing Address, it should be a check-summed address.

How to test:
- start a node
- go to keys configuration
- make sure OCR keys have Signing Address displayed as check-summed addresses
