### PR TITLE
Implement job runs as relationship for jobs

### DIFF
--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -9,6 +9,10 @@ import (
 
 	"github.com/pelletier/go-toml"
 	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v4"
+
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
@@ -21,9 +25,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/vrf"
 	"github.com/smartcontractkit/chainlink/core/services/webhook"
 	"github.com/smartcontractkit/chainlink/core/testdata/testspecs"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v4"
 )
 
 func TestORM(t *testing.T) {
@@ -413,6 +414,64 @@ func Test_PipelineRunsByJobID(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, count, 1)
+		actual := runs[0]
+
+		// Test pipeline run fields
+		assert.Equal(t, run.State, actual.State)
+		assert.Equal(t, run.PipelineSpecID, actual.PipelineSpecID)
+
+		// Test preloaded pipeline spec
+		assert.Equal(t, jb.PipelineSpec.ID, actual.PipelineSpec.ID)
+		assert.Equal(t, jb.ID, actual.PipelineSpec.JobID)
+	})
+}
+
+func Test_PipelineRunsByJobsIDs(t *testing.T) {
+	t.Parallel()
+
+	config := cltest.NewTestGeneralConfig(t)
+	db := pgtest.NewSqlxDB(t)
+
+	keyStore := cltest.NewKeyStore(t, db)
+	err := keyStore.OCR().Add(cltest.DefaultOCRKey)
+	require.NoError(t, err)
+
+	pipelineORM := pipeline.NewORM(db, logger.TestLogger(t))
+	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: config})
+	orm := job.NewTestORM(t, db, cc, pipelineORM, keyStore)
+
+	_, bridge := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{})
+	_, bridge2 := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{})
+
+	externalJobID := uuid.NewV4()
+	_, address := cltest.MustInsertRandomKey(t, keyStore.Eth())
+	jb, err := offchainreporting.ValidatedOracleSpecToml(cc,
+		testspecs.GenerateOCRSpec(testspecs.OCRSpecParams{
+			JobID:              externalJobID.String(),
+			TransmitterAddress: address.Hex(),
+			DS1BridgeName:      bridge.Name.String(),
+			DS2BridgeName:      bridge2.Name.String(),
+		}).Toml(),
+	)
+	require.NoError(t, err)
+
+	err = orm.CreateJob(&jb)
+	require.NoError(t, err)
+
+	t.Run("with no pipeline runs", func(t *testing.T) {
+		runs, err := orm.PipelineRunsByJobsIDs([]int32{jb.ID})
+		require.NoError(t, err)
+		assert.Equal(t, len(runs), 0)
+		assert.Empty(t, runs)
+	})
+
+	t.Run("with a pipeline run", func(t *testing.T) {
+		run := mustInsertPipelineRun(t, pipelineORM, jb)
+
+		runs, err := orm.PipelineRunsByJobsIDs([]int32{jb.ID})
+		require.NoError(t, err)
+
+		assert.Equal(t, len(runs), 1)
 		actual := runs[0]
 
 		// Test pipeline run fields

--- a/core/services/job/mocks/orm.go
+++ b/core/services/job/mocks/orm.go
@@ -278,6 +278,29 @@ func (_m *ORM) PipelineRuns(jobID *int32, offset int, size int) ([]pipeline.Run,
 	return r0, r1, r2
 }
 
+// PipelineRunsByJobsIDs provides a mock function with given fields: jobsIDs
+func (_m *ORM) PipelineRunsByJobsIDs(jobsIDs []int32) ([]pipeline.Run, error) {
+	ret := _m.Called(jobsIDs)
+
+	var r0 []pipeline.Run
+	if rf, ok := ret.Get(0).(func([]int32) []pipeline.Run); ok {
+		r0 = rf(jobsIDs)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]pipeline.Run)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]int32) error); ok {
+		r1 = rf(jobsIDs)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // RecordError provides a mock function with given fields: jobID, description, qopts
 func (_m *ORM) RecordError(jobID int32, description string, qopts ...postgres.QOpt) {
 	_va := make([]interface{}, len(qopts))

--- a/core/web/loader/getters.go
+++ b/core/web/loader/getters.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/services/feeds"
+	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 )
 
 // GetChainByID fetches the chain by it's id.
@@ -46,6 +47,7 @@ func GetNodesByChainID(ctx context.Context, id string) ([]types.Node, error) {
 	return nodes, nil
 }
 
+// GetFeedsManagerByID fetches the feed manager by ID.
 func GetFeedsManagerByID(ctx context.Context, id string) (*feeds.FeedsManager, error) {
 	ldr := For(ctx)
 
@@ -61,4 +63,22 @@ func GetFeedsManagerByID(ctx context.Context, id string) (*feeds.FeedsManager, e
 	}
 
 	return &mgr, nil
+}
+
+// GetJobRunsByPipelineSpecID fetches the job runs by pipeline spec ID.
+func GetJobRunsByPipelineSpecID(ctx context.Context, id string) ([]pipeline.Run, error) {
+	ldr := For(ctx)
+
+	thunk := ldr.JobRunsByPipelineIDLoader.Load(ctx, dataloader.StringKey(id))
+	result, err := thunk()
+	if err != nil {
+		return nil, err
+	}
+
+	jbRuns, ok := result.([]pipeline.Run)
+	if !ok {
+		return nil, errors.New("invalid type")
+	}
+
+	return jbRuns, nil
 }

--- a/core/web/loader/job_run.go
+++ b/core/web/loader/job_run.go
@@ -1,0 +1,55 @@
+package loader
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/graph-gophers/dataloader"
+	"github.com/pkg/errors"
+
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
+)
+
+type jobRunBatcher struct {
+	app chainlink.Application
+}
+
+func (b *jobRunBatcher) loadByPipelineSpecIDs(ctx context.Context, keys dataloader.Keys) []*dataloader.Result {
+	// Create a map for remembering the order of keys passed in
+	keyOrder := make(map[string]int, len(keys))
+	// Collect the keys to search for
+	var plnSpecIDs []int32
+	for ix, key := range keys {
+		id, err := strconv.ParseInt(key.String(), 10, 32)
+		if err == nil {
+			plnSpecIDs = append(plnSpecIDs, int32(id))
+		}
+		keyOrder[key.String()] = ix
+	}
+
+	// Fetch the job runs
+	jbRuns, err := b.app.JobORM().PipelineRunsByJobsIDs(plnSpecIDs)
+	if err != nil {
+		return []*dataloader.Result{{Data: nil, Error: err}}
+	}
+
+	// Construct the output array of dataloader results
+	results := make([]*dataloader.Result, len(keys))
+	for _, c := range jbRuns {
+		id := strconv.FormatInt(c.ID, 10)
+
+		ix, ok := keyOrder[id]
+		// if found, remove from index lookup map, so we know elements were found
+		if ok {
+			results[ix] = &dataloader.Result{Data: c, Error: nil}
+			delete(keyOrder, id)
+		}
+	}
+
+	// fill array positions without any job runs
+	for _, ix := range keyOrder {
+		results[ix] = &dataloader.Result{Data: nil, Error: errors.New("job run not found")}
+	}
+
+	return results
+}

--- a/core/web/loader/loader.go
+++ b/core/web/loader/loader.go
@@ -14,22 +14,25 @@ type loadersKey struct{}
 type Dataloader struct {
 	app chainlink.Application
 
-	NodesByChainIDLoader    *dataloader.Loader
-	ChainsByIDLoader        *dataloader.Loader
-	FeedsManagersByIDLoader *dataloader.Loader
+	NodesByChainIDLoader      *dataloader.Loader
+	ChainsByIDLoader          *dataloader.Loader
+	FeedsManagersByIDLoader   *dataloader.Loader
+	JobRunsByPipelineIDLoader *dataloader.Loader
 }
 
 func New(app chainlink.Application) *Dataloader {
 	nodes := &nodeBatcher{app: app}
 	chains := &chainBatcher{app: app}
 	mgrs := &feedsBatcher{app: app}
+	jbRuns := &jobRunBatcher{app: app}
 
 	return &Dataloader{
 		app: app,
 
-		NodesByChainIDLoader:    dataloader.NewBatchedLoader(nodes.loadByChainIDs),
-		ChainsByIDLoader:        dataloader.NewBatchedLoader(chains.loadByIDs),
-		FeedsManagersByIDLoader: dataloader.NewBatchedLoader(mgrs.loadByIDs),
+		NodesByChainIDLoader:      dataloader.NewBatchedLoader(nodes.loadByChainIDs),
+		ChainsByIDLoader:          dataloader.NewBatchedLoader(chains.loadByIDs),
+		FeedsManagersByIDLoader:   dataloader.NewBatchedLoader(mgrs.loadByIDs),
+		JobRunsByPipelineIDLoader: dataloader.NewBatchedLoader(jbRuns.loadByPipelineSpecIDs),
 	}
 }
 

--- a/core/web/resolver/job.go
+++ b/core/web/resolver/job.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"strconv"
@@ -8,6 +9,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/smartcontractkit/chainlink/core/services/job"
+	"github.com/smartcontractkit/chainlink/core/web/loader"
 )
 
 // JobResolver resolves the Job type.
@@ -67,7 +69,7 @@ func (r *JobResolver) Name() string {
 
 // ObservationSource resolves the job's observation source.
 //
-// This could potentially by moved to a dataloader in the future as we are
+// This could potentially be moved to a dataloader in the future as we are
 // fetching it from a relationship.
 func (r *JobResolver) ObservationSource() string {
 	return r.j.PipelineSpec.DotDagSource
@@ -81,6 +83,15 @@ func (r *JobResolver) SchemaVersion() int32 {
 // Spec resolves the job's spec.
 func (r *JobResolver) Spec() *SpecResolver {
 	return NewSpec(r.j)
+}
+
+func (r *JobResolver) JobRuns(ctx context.Context) ([]*JobRunResolver, error) {
+	runs, err := loader.GetJobRunsByPipelineSpecID(ctx, strconv.Itoa(int(r.j.PipelineSpecID)))
+	if err != nil {
+		return nil, err
+	}
+
+	return NewJobRuns(runs), nil
 }
 
 // JobsPayloadResolver resolves a page of jobs

--- a/core/web/resolver/job.go
+++ b/core/web/resolver/job.go
@@ -85,7 +85,7 @@ func (r *JobResolver) Spec() *SpecResolver {
 	return NewSpec(r.j)
 }
 
-func (r *JobResolver) JobRuns(ctx context.Context) ([]*JobRunResolver, error) {
+func (r *JobResolver) Runs(ctx context.Context) ([]*JobRunResolver, error) {
 	runs, err := loader.GetJobRunsByPipelineSpecID(ctx, strconv.Itoa(int(r.j.PipelineSpecID)))
 	if err != nil {
 		return nil, err

--- a/core/web/resolver/job_run.go
+++ b/core/web/resolver/job_run.go
@@ -1,0 +1,72 @@
+package resolver
+
+import (
+	"strconv"
+
+	"github.com/graph-gophers/graphql-go"
+
+	"github.com/smartcontractkit/chainlink/core/services/pipeline"
+)
+
+var outputRetrievalErrorStr = "error: unable to retrieve outputs"
+
+type JobRunResolver struct {
+	run pipeline.Run
+}
+
+func NewJobRun(run pipeline.Run) *JobRunResolver {
+	return &JobRunResolver{run}
+}
+
+func NewJobRuns(runs []pipeline.Run) []*JobRunResolver {
+	var resolvers []*JobRunResolver
+
+	for _, run := range runs {
+		resolvers = append(resolvers, NewJobRun(run))
+	}
+
+	return resolvers
+}
+
+func (r *JobRunResolver) Outputs() []*string {
+	if !r.run.Outputs.Valid {
+		return []*string{&outputRetrievalErrorStr}
+	}
+
+	outputs, err := r.run.StringOutputs()
+	if err != nil {
+		errMsg := err.Error()
+		return []*string{&errMsg}
+	}
+
+	return outputs
+}
+
+func (r *JobRunResolver) PipelineSpecID() graphql.ID {
+	return graphql.ID(strconv.Itoa(int(r.run.PipelineSpecID)))
+}
+
+func (r *JobRunResolver) FatalErrors() []*string {
+	return r.run.StringAllErrors()
+}
+
+func (r *JobRunResolver) AllErrors() []*string {
+	return r.run.StringAllErrors()
+}
+
+func (r *JobRunResolver) Inputs() string {
+	val, err := r.run.Inputs.MarshalJSON()
+	if err != nil {
+		return "error: unable to retrieve inputs"
+	}
+
+	return string(val)
+}
+
+// ObservationSource resolves the job's observation source.
+//
+// This could potentially be moved to a dataloader in the future as we are
+// fetching it from a relationship.
+func (r *JobRunResolver) ObservationSource() string {
+	return r.run.PipelineSpec.DotDagSource
+}

--- a/core/web/resolver/job_run.go
+++ b/core/web/resolver/job_run.go
@@ -63,10 +63,30 @@ func (r *JobRunResolver) Inputs() string {
 	return string(val)
 }
 
-// ObservationSource resolves the job's observation source.
+// ObservationSource resolves the job run's observation source.
 //
 // This could potentially be moved to a dataloader in the future as we are
 // fetching it from a relationship.
 func (r *JobRunResolver) ObservationSource() string {
 	return r.run.PipelineSpec.DotDagSource
+}
+
+// TaskRuns resolves the job run's task runs
+//
+// This could be moved to a data loader later, which means also modifying to ORM
+// to not get everything at once
+func (r *JobRunResolver) TaskRuns() []*TaskRunResolver {
+	if len(r.run.PipelineTaskRuns) > 0 {
+		return NewTaskRuns(r.run.PipelineTaskRuns)
+	}
+
+	return []*TaskRunResolver{}
+}
+
+func (r *JobRunResolver) CreatedAt() graphql.Time {
+	return graphql.Time{Time: r.run.CreatedAt}
+}
+
+func (r *JobRunResolver) FinishedAt() *graphql.Time {
+	return &graphql.Time{Time: r.run.FinishedAt.ValueOrZero()}
 }

--- a/core/web/resolver/job_run.go
+++ b/core/web/resolver/job_run.go
@@ -28,6 +28,10 @@ func NewJobRuns(runs []pipeline.Run) []*JobRunResolver {
 	return resolvers
 }
 
+func (r *JobRunResolver) ID() graphql.ID {
+	return graphql.ID(strconv.Itoa(int(r.run.ID)))
+}
+
 func (r *JobRunResolver) Outputs() []*string {
 	if !r.run.Outputs.Valid {
 		return []*string{&outputRetrievalErrorStr}

--- a/core/web/resolver/job_run.go
+++ b/core/web/resolver/job_run.go
@@ -46,12 +46,24 @@ func (r *JobRunResolver) PipelineSpecID() graphql.ID {
 	return graphql.ID(strconv.Itoa(int(r.run.PipelineSpecID)))
 }
 
-func (r *JobRunResolver) FatalErrors() []*string {
-	return r.run.StringAllErrors()
+func (r *JobRunResolver) FatalErrors() []string {
+	var errs []string
+
+	for _, err := range r.run.StringFatalErrors() {
+		errs = append(errs, *err)
+	}
+
+	return errs
 }
 
-func (r *JobRunResolver) AllErrors() []*string {
-	return r.run.StringAllErrors()
+func (r *JobRunResolver) AllErrors() []string {
+	var errs []string
+
+	for _, err := range r.run.StringAllErrors() {
+		errs = append(errs, *err)
+	}
+
+	return errs
 }
 
 func (r *JobRunResolver) Inputs() string {
@@ -61,14 +73,6 @@ func (r *JobRunResolver) Inputs() string {
 	}
 
 	return string(val)
-}
-
-// ObservationSource resolves the job run's observation source.
-//
-// This could potentially be moved to a dataloader in the future as we are
-// fetching it from a relationship.
-func (r *JobRunResolver) ObservationSource() string {
-	return r.run.PipelineSpec.DotDagSource
 }
 
 // TaskRuns resolves the job run's task runs

--- a/core/web/resolver/job_test.go
+++ b/core/web/resolver/job_test.go
@@ -33,6 +33,7 @@ func TestResolver_Jobs(t *testing.T) {
 							__typename
 						}
 						runs {
+							id
 							allErrors
 							outputs
 							createdAt
@@ -52,12 +53,13 @@ func TestResolver_Jobs(t *testing.T) {
 			name:          "get jobs success",
 			authenticated: true,
 			before: func(f *gqlTestFramework) {
-				id := int32(12)
+				plnSpecID := int32(12)
 
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
-				f.Mocks.jobORM.On("PipelineRunsByJobsIDs", []int32{id}).Return([]pipeline.Run{
+				f.Mocks.jobORM.On("PipelineRunsByJobsIDs", []int32{plnSpecID}).Return([]pipeline.Run{
 					{
-						PipelineSpecID: id,
+						ID:             int64(1),
+						PipelineSpecID: plnSpecID,
 						State:          pipeline.RunStatusRunning,
 						Outputs:        pipeline.JSONSerializable{Valid: false},
 						AllErrors:      pipeline.RunErrors{},
@@ -74,7 +76,7 @@ func TestResolver_Jobs(t *testing.T) {
 						ExternalJobID:               externalJobID,
 						CreatedAt:                   f.Timestamp(),
 						Type:                        job.OffchainReporting,
-						PipelineSpecID:              id,
+						PipelineSpecID:              plnSpecID,
 						OffchainreportingOracleSpec: &job.OffchainReportingOracleSpec{},
 						PipelineSpec: &pipeline.Spec{
 							DotDagSource: "ds1 [type=bridge name=voter_turnout];",
@@ -98,6 +100,7 @@ func TestResolver_Jobs(t *testing.T) {
 							},
 							"runs": [
 								{
+									"id": "1",
 									"allErrors": [],
 									"outputs": ["error: unable to retrieve outputs"],
 									"createdAt": "2021-01-01T00:00:00Z"

--- a/core/web/resolver/task_run.go
+++ b/core/web/resolver/task_run.go
@@ -1,0 +1,62 @@
+package resolver
+
+import (
+	"github.com/graph-gophers/graphql-go"
+
+	"github.com/smartcontractkit/chainlink/core/services/pipeline"
+)
+
+type TaskRunResolver struct {
+	tr pipeline.TaskRun
+}
+
+func NewTaskRun(tr pipeline.TaskRun) *TaskRunResolver {
+	return &TaskRunResolver{tr}
+}
+
+func NewTaskRuns(runs []pipeline.TaskRun) []*TaskRunResolver {
+	var resolvers []*TaskRunResolver
+
+	for _, run := range runs {
+		resolvers = append(resolvers, NewTaskRun(run))
+	}
+
+	return resolvers
+}
+
+func (r *TaskRunResolver) ID() graphql.ID {
+	return graphql.ID(r.tr.ID.String())
+}
+
+func (r *TaskRunResolver) Type() string {
+	return string(r.tr.Type)
+}
+
+func (r *TaskRunResolver) Output() string {
+	val, err := r.tr.Output.MarshalJSON()
+	if err != nil {
+		return "error: unable to retrieve output"
+	}
+
+	return string(val)
+}
+
+func (r *TaskRunResolver) Error() *string {
+	if r.tr.Error.Valid {
+		return r.tr.Error.Ptr()
+	}
+
+	return nil
+}
+
+func (r *TaskRunResolver) CreatedAt() graphql.Time {
+	return graphql.Time{Time: r.tr.CreatedAt}
+}
+
+func (r *TaskRunResolver) FinishedAt() *graphql.Time {
+	return &graphql.Time{Time: r.tr.FinishedAt.ValueOrZero()}
+}
+
+func (r *TaskRunResolver) DotID() string {
+	return r.tr.GetDotID()
+}

--- a/core/web/schema/type/job.graphql
+++ b/core/web/schema/type/job.graphql
@@ -5,7 +5,7 @@ type Job {
     maxTaskDuration: String!
     externalJobID: String!
     spec: JobSpec!
-    jobRuns: [JobRun!]!
+    runs: [JobRun!]!
     observationSource: String!
     errors: [JobError!]!
     createdAt: Time!

--- a/core/web/schema/type/job.graphql
+++ b/core/web/schema/type/job.graphql
@@ -5,6 +5,7 @@ type Job {
     maxTaskDuration: String!
     externalJobID: String!
     spec: JobSpec!
+    jobRuns: [JobRun!]!
     observationSource: String!
     errors: [JobError!]!
     createdAt: Time!

--- a/core/web/schema/type/job_run.graphql
+++ b/core/web/schema/type/job_run.graphql
@@ -1,12 +1,11 @@
 type JobRun {
     outputs: [String]!
-    allErrors: [String]!
-    fatalErrors: [String]!
+    allErrors: [String!]!
+    fatalErrors: [String!]!
     inputs: String!
     createdAt: Time!
     finishedAt: Time
     taskRuns: [TaskRun!]!
-    observationSource: String!
 }
 
 union JobRunPayload = JobRun | NotFoundError

--- a/core/web/schema/type/job_run.graphql
+++ b/core/web/schema/type/job_run.graphql
@@ -1,4 +1,5 @@
 type JobRun {
+    id: ID!
     outputs: [String]!
     allErrors: [String!]!
     fatalErrors: [String!]!

--- a/core/web/schema/type/job_run.graphql
+++ b/core/web/schema/type/job_run.graphql
@@ -1,13 +1,12 @@
 type JobRun {
     outputs: [String]!
-    errors: [String]!
     allErrors: [String]!
     fatalErrors: [String]!
     inputs: String!
-    createdAt: [Time!]!
-    finishedAt: [Time!]!
-    # taskRuns
-    # pipelineSpec
+    createdAt: Time!
+    finishedAt: Time
+    taskRuns: [TaskRun!]!
+    observationSource: String!
 }
 
 union JobRunPayload = JobRun | NotFoundError

--- a/core/web/schema/type/job_run.graphql
+++ b/core/web/schema/type/job_run.graphql
@@ -1,0 +1,13 @@
+type JobRun {
+    outputs: [String]!
+    errors: [String]!
+    allErrors: [String]!
+    fatalErrors: [String]!
+    inputs: String!
+    createdAt: [Time!]!
+    finishedAt: [Time!]!
+    # taskRuns
+    # pipelineSpec
+}
+
+union JobRunPayload = JobRun | NotFoundError

--- a/core/web/schema/type/task_run.go.graphql
+++ b/core/web/schema/type/task_run.go.graphql
@@ -1,0 +1,9 @@
+type TaskRun {
+    id: ID!
+    dotID: String!
+    type: String!
+    output: String!
+    error: String
+    createdAt: Time!
+    finishedAt: Time
+}


### PR DESCRIPTION
Closes: https://app.shortcut.com/chainlinklabs/story/20930/implement-runs-field-on-a-job

This aims to add a relationship to jobs so consumers can also get the pipeline runs related.