### PR TITLE
core/logger: add Critical* and Trace*

### DIFF
--- a/core/logger/critical.go
+++ b/core/logger/critical.go
@@ -1,0 +1,25 @@
+package logger
+
+import "go.uber.org/zap/zapcore"
+
+// encodeLevel is a zapcore.EncodeLevel that encodes crit in place of dpanic for our custom Critical* level.
+func encodeLevel(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
+	if l == zapcore.DPanicLevel {
+		enc.AppendString("crit")
+	} else {
+		zapcore.LowercaseLevelEncoder(l, enc)
+	}
+}
+
+func (l *zapLogger) Critical(args ...interface{}) {
+	// DPanic is used for the appropriate numerical level (between error and panic), but we never actually panic.
+	l.sugaredWithCallerSkip(1).DPanic(args...)
+}
+
+func (l *zapLogger) Criticalf(format string, values ...interface{}) {
+	l.sugaredWithCallerSkip(1).DPanicf(format, values...)
+}
+
+func (l *zapLogger) CriticalW(msg string, keysAndValues ...interface{}) {
+	l.sugaredWithCallerSkip(1).DPanicw(msg, keysAndValues...)
+}

--- a/core/logger/critical.go
+++ b/core/logger/critical.go
@@ -13,13 +13,13 @@ func encodeLevel(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
 
 func (l *zapLogger) Critical(args ...interface{}) {
 	// DPanic is used for the appropriate numerical level (between error and panic), but we never actually panic.
-	l.sugaredWithCallerSkip(1).DPanic(args...)
+	l.sugaredHelper(1).DPanic(args...)
 }
 
 func (l *zapLogger) Criticalf(format string, values ...interface{}) {
-	l.sugaredWithCallerSkip(1).DPanicf(format, values...)
+	l.sugaredHelper(1).DPanicf(format, values...)
 }
 
 func (l *zapLogger) CriticalW(msg string, keysAndValues ...interface{}) {
-	l.sugaredWithCallerSkip(1).DPanicw(msg, keysAndValues...)
+	l.sugaredHelper(1).DPanicw(msg, keysAndValues...)
 }

--- a/core/logger/default.go
+++ b/core/logger/default.go
@@ -44,7 +44,7 @@ func InitLogger(newLogger Logger) {
 			}
 		}(helper)
 	}
-	helper = newLogger.withCallerSkip(1)
+	helper = newLogger.Helper(1)
 }
 
 // Warnw logs a debug message and any additional given information.

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -231,18 +231,6 @@ func (l *zapLogger) ErrorIfClosing(c io.Closer, name string) {
 	}
 }
 
-func (l *zapLogger) Critical(args ...interface{}) {
-	l.sugaredWithCallerSkip(1).DPanic(args...)
-}
-
-func (l *zapLogger) Criticalf(format string, values ...interface{}) {
-	l.sugaredWithCallerSkip(1).DPanicf(format, values...)
-}
-
-func (l *zapLogger) CriticalW(msg string, keysAndValues ...interface{}) {
-	l.sugaredWithCallerSkip(1).DPanicw(msg, keysAndValues...)
-}
-
 func (l *zapLogger) Error(args ...interface{}) {
 	hub := sentry.CurrentHub().Clone()
 	hub.ConfigureScope(func(scope *sentry.Scope) {
@@ -428,12 +416,6 @@ func InitColor(c bool) {
 func newBaseConfig() zap.Config {
 	cfg := zap.NewProductionConfig()
 	cfg.Sampling = nil
-	cfg.EncoderConfig.EncodeLevel = func(l zapcore.Level, enc zapcore.PrimitiveArrayEncoder) {
-		if l == zapcore.DPanicLevel {
-			enc.AppendString("crit")
-		} else {
-			zapcore.LowercaseLevelEncoder(l, enc)
-		}
-	}
+	cfg.EncoderConfig.EncodeLevel = encodeLevel
 	return cfg
 }

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -1,64 +1,19 @@
 package logger
 
 import (
-	"errors"
-	"fmt"
 	"io"
 	"log"
 	"os"
-	"time"
 
 	"github.com/fatih/color"
-	"github.com/getsentry/sentry-go"
-	"github.com/smartcontractkit/chainlink/core/static"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
-
-const SentryFlushDeadline = 5 * time.Second
 
 var envLvl = zapcore.InfoLevel
 
 func init() {
 	_ = envLvl.Set(os.Getenv("LOG_LEVEL"))
-
-	// If SENTRY_ENVIRONMENT is set, it will override everything. Otherwise infers from CHAINLINK_DEV.
-	var sentryenv string
-	if env := os.Getenv("SENTRY_ENVIRONMENT"); env != "" {
-		sentryenv = env
-	} else if os.Getenv("CHAINLINK_DEV") == "true" {
-		sentryenv = "dev"
-	} else {
-		sentryenv = "prod"
-	}
-	// If SENTRY_DSN is set, it will override everything. Otherwise static.SentryDSN will be used.
-	// If neither are set, sentry is disabled.
-	var sentrydsn string
-	if dsn := os.Getenv("SENTRY_DSN"); dsn != "" {
-		sentrydsn = dsn
-	} else {
-		sentrydsn = static.SentryDSN
-	}
-	// If SENTRY_RELEASE is set, it will override everything. Otherwise, static.Version will be used.
-	var sentryrelease string
-	if release := os.Getenv("SENTRY_RELEASE"); release != "" {
-		sentryrelease = release
-	} else {
-		sentryrelease = static.Version
-	}
-	err := sentry.Init(sentry.ClientOptions{
-		// AttachStacktrace is needed to send stacktrace alongside panics
-		AttachStacktrace: true,
-		Dsn:              sentrydsn,
-		Environment:      sentryenv,
-		Release:          sentryrelease,
-		// Enable printing of SDK debug messages.
-		// Uncomment line below to debug sentry
-		// Debug: true,
-	})
-	if err != nil {
-		log.Fatalf("sentry.Init: %s", err)
-	}
 }
 
 // Logger is the main interface of this package.
@@ -126,30 +81,9 @@ type Logger interface {
 	// Some insignificant errors are suppressed.
 	Sync() error
 
-	// withCallerSkip creates a new logger with the number of callers skipped by
-	// caller annotation increased by add. For wrappers to use internally.
-	withCallerSkip(add int) Logger
-}
-
-var _ Logger = &zapLogger{}
-
-type zapLogger struct {
-	*zap.SugaredLogger
-	config zap.Config
-	name   string
-	fields []interface{}
-}
-
-func newZapLogger(cfg zap.Config) (Logger, error) {
-	zl, err := cfg.Build()
-	if err != nil {
-		return nil, err
-	}
-	return &zapLogger{config: cfg, SugaredLogger: zl.Sugar()}, nil
-}
-
-func (l *zapLogger) SetLogLevel(lvl zapcore.Level) {
-	l.config.Level.SetLevel(lvl)
+	// Helper creates a new logger with the number of callers skipped by caller annotation increased by skip.
+	// This allows wrappers and helpers to point higher up the stack (like testing.T.Helper()).
+	Helper(skip int) Logger
 }
 
 // Constants for service names for package specific logging configuration
@@ -165,203 +99,6 @@ func GetLogServices() []string {
 		FluxMonitor,
 		Keeper,
 	}
-}
-
-func (l *zapLogger) With(args ...interface{}) Logger {
-	newLogger := *l
-	newLogger.SugaredLogger = l.SugaredLogger.With(args...)
-	newLogger.fields = copyFields(l.fields, args...)
-	return &newLogger
-}
-
-// copyFields returns a copy of fields with add appended.
-func copyFields(fields []interface{}, add ...interface{}) []interface{} {
-	f := make([]interface{}, 0, len(fields)+len(add))
-	f = append(f, fields...)
-	f = append(f, add...)
-	return f
-}
-
-func joinName(old, new string) string {
-	if old == "" {
-		return new
-	}
-	return old + "." + new
-}
-
-func (l *zapLogger) Named(name string) Logger {
-	newLogger := *l
-	newLogger.name = joinName(l.name, name)
-	newLogger.SugaredLogger = l.SugaredLogger.Named(name)
-	return &newLogger
-}
-
-func (l *zapLogger) NewRootLogger(lvl zapcore.Level) (Logger, error) {
-	newLogger := *l
-	newLogger.config.Level = zap.NewAtomicLevelAt(lvl)
-	zl, err := newLogger.config.Build()
-	if err != nil {
-		return nil, err
-	}
-	newLogger.SugaredLogger = zl.Named(l.name).Sugar().With(l.fields...)
-	return &newLogger, nil
-}
-
-func (l *zapLogger) withCallerSkip(skip int) Logger {
-	newLogger := *l
-	newLogger.SugaredLogger = l.sugaredWithCallerSkip(skip)
-	return &newLogger
-}
-
-func (l *zapLogger) sugaredWithCallerSkip(skip int) *zap.SugaredLogger {
-	return l.SugaredLogger.Desugar().WithOptions(zap.AddCallerSkip(skip)).Sugar()
-}
-
-func (l *zapLogger) ErrorIf(err error, msg string) {
-	if err != nil {
-		sentry.CaptureException(err)
-		l.withCallerSkip(1).Errorw(msg, "err", err)
-	}
-}
-
-func (l *zapLogger) ErrorIfClosing(c io.Closer, name string) {
-	if err := c.Close(); err != nil {
-		sentry.CaptureException(err)
-		l.withCallerSkip(1).Errorw(fmt.Sprintf("Error closing %s", name), "err", err)
-	}
-}
-
-func (l *zapLogger) Error(args ...interface{}) {
-	hub := sentry.CurrentHub().Clone()
-	hub.ConfigureScope(func(scope *sentry.Scope) {
-		scope.SetContext("logger", map[string]interface{}{
-			"args": args,
-		})
-		scope.SetLevel(sentry.LevelError)
-	})
-	hub.CaptureMessage(fmt.Sprintf("%v", args))
-	l.sugaredWithCallerSkip(1).Error(args...)
-}
-
-func (l *zapLogger) Fatal(args ...interface{}) {
-	defer sentry.Flush(SentryFlushDeadline)
-	hub := sentry.CurrentHub().Clone()
-	hub.ConfigureScope(func(scope *sentry.Scope) {
-		scope.SetContext("logger", map[string]interface{}{
-			"args": args,
-		})
-		scope.SetLevel(sentry.LevelFatal)
-	})
-	hub.CaptureMessage(fmt.Sprintf("%v", args))
-	l.sugaredWithCallerSkip(1).Fatal(args...)
-}
-
-func (l *zapLogger) Panic(args ...interface{}) {
-	defer sentry.Flush(SentryFlushDeadline)
-	hub := sentry.CurrentHub().Clone()
-	hub.ConfigureScope(func(scope *sentry.Scope) {
-		scope.SetContext("logger", map[string]interface{}{
-			"args": args,
-		})
-		scope.SetLevel(sentry.LevelFatal)
-	})
-	hub.CaptureMessage(fmt.Sprintf("%v", args))
-	l.sugaredWithCallerSkip(1).Panic(args...)
-}
-
-func (l *zapLogger) Errorf(format string, values ...interface{}) {
-	hub := sentry.CurrentHub().Clone()
-	hub.ConfigureScope(func(scope *sentry.Scope) {
-		scope.SetContext("logger", map[string]interface{}{
-			"values": values,
-		})
-		scope.SetLevel(sentry.LevelError)
-	})
-	hub.CaptureMessage(fmt.Sprintf(format, values...))
-	l.sugaredWithCallerSkip(1).Errorf(format, values...)
-}
-
-func (l *zapLogger) Fatalf(format string, values ...interface{}) {
-	defer sentry.Flush(SentryFlushDeadline)
-	hub := sentry.CurrentHub().Clone()
-	hub.ConfigureScope(func(scope *sentry.Scope) {
-		scope.SetContext("logger", map[string]interface{}{
-			"values": values,
-		})
-		scope.SetLevel(sentry.LevelFatal)
-	})
-	hub.CaptureMessage(fmt.Sprintf(format, values...))
-	l.sugaredWithCallerSkip(1).Fatalf(format, values...)
-}
-
-func (l *zapLogger) Errorw(msg string, keysAndValues ...interface{}) {
-	hub := sentry.CurrentHub().Clone()
-	hub.ConfigureScope(func(scope *sentry.Scope) {
-		scope.SetContext("logger", toMap(keysAndValues))
-		scope.SetLevel(sentry.LevelError)
-	})
-	hub.CaptureMessage(msg)
-	l.sugaredWithCallerSkip(1).Errorw(msg, keysAndValues...)
-}
-
-func (l *zapLogger) Fatalw(msg string, keysAndValues ...interface{}) {
-	defer sentry.Flush(SentryFlushDeadline)
-	hub := sentry.CurrentHub().Clone()
-	hub.ConfigureScope(func(scope *sentry.Scope) {
-		scope.SetContext("logger", toMap(keysAndValues))
-		scope.SetLevel(sentry.LevelFatal)
-	})
-	hub.CaptureMessage(msg)
-	l.sugaredWithCallerSkip(1).Fatalw(msg, keysAndValues...)
-}
-
-func (l *zapLogger) Panicw(msg string, keysAndValues ...interface{}) {
-	defer sentry.Flush(SentryFlushDeadline)
-	hub := sentry.CurrentHub().Clone()
-	hub.ConfigureScope(func(scope *sentry.Scope) {
-		scope.SetContext("logger", toMap(keysAndValues))
-		scope.SetLevel(sentry.LevelFatal)
-	})
-	hub.CaptureMessage(msg)
-	l.sugaredWithCallerSkip(1).Panicw(msg, keysAndValues...)
-}
-
-func toMap(args ...interface{}) (m map[string]interface{}) {
-	m = make(map[string]interface{}, len(args)/2)
-	for i := 0; i < len(args); {
-		// Make sure this element isn't a dangling key
-		if i == len(args)-1 {
-			break
-		}
-
-		// Consume this value and the next, treating them as a key-value pair. If the
-		// key isn't a string ignore it
-		key, val := args[i], args[i+1]
-		if keyStr, ok := key.(string); ok {
-			m[keyStr] = val
-		}
-		i += 2
-	}
-	return m
-}
-
-func (l *zapLogger) Sync() error {
-	err := l.SugaredLogger.Sync()
-	if err == nil {
-		return nil
-	}
-	var msg string
-	if uw := errors.Unwrap(err); uw != nil {
-		msg = uw.Error()
-	} else {
-		msg = err.Error()
-	}
-	switch msg {
-	case os.ErrInvalid.Error(), "bad file descriptor",
-		"inappropriate ioctl for device":
-		return nil
-	}
-	return err
 }
 
 // newProductionConfig returns a new production zap.Config.
@@ -396,6 +133,7 @@ func NewLogger(c Config) Logger {
 	return newLogger(c.LogLevel(), c.RootDir(), c.JSONConsole(), c.LogToDisk(), c.LogUnixTimestamps())
 }
 
+// newLogger returns a new production Logger with sentry forwarding.
 func newLogger(logLevel zapcore.Level, dir string, jsonConsole bool, toDisk bool, unixTS bool) Logger {
 	cfg := newProductionConfig(dir, jsonConsole, toDisk, unixTS)
 	cfg.Level.SetLevel(logLevel)
@@ -403,7 +141,7 @@ func newLogger(logLevel zapcore.Level, dir string, jsonConsole bool, toDisk bool
 	if err != nil {
 		log.Fatal(err)
 	}
-	return l
+	return newSentryLogger(l)
 }
 
 // InitColor explicitly sets the global color.NoColor option.

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -67,8 +67,12 @@ func init() {
 // The package-level helper functions are being phased out. Loggers should be injected
 // instead (and usually Named as well): e.g. lggr.Named("<service name>")
 //
-// Tests should use a TestLogger, with NewLogger being reserved for actual
-// runtime and limited direct testing.
+// Tips
+//  - Tests should use a TestLogger, with NewLogger being reserved for actual
+//    runtime and limited direct testing.
+//  - Critical level logs should only be used when user intervention is required.
+//  - Trace level logs are omitted unless compiled with the trace tag. For example: go test -tags trace ...
+
 type Logger interface {
 	// With creates a new Logger with the given arguments
 	With(args ...interface{}) Logger
@@ -85,6 +89,7 @@ type Logger interface {
 	// SetLogLevel changes the log level for this and all connected Loggers.
 	SetLogLevel(zapcore.Level)
 
+	Trace(args ...interface{})
 	Debug(args ...interface{})
 	Info(args ...interface{})
 	Warn(args ...interface{})
@@ -93,6 +98,7 @@ type Logger interface {
 	Panic(args ...interface{})
 	Fatal(args ...interface{})
 
+	Tracef(format string, values ...interface{})
 	Debugf(format string, values ...interface{})
 	Infof(format string, values ...interface{})
 	Warnf(format string, values ...interface{})
@@ -101,6 +107,7 @@ type Logger interface {
 	Panicf(format string, values ...interface{})
 	Fatalf(format string, values ...interface{})
 
+	Tracew(msg string, keysAndValues ...interface{})
 	Debugw(msg string, keysAndValues ...interface{})
 	Infow(msg string, keysAndValues ...interface{})
 	Warnw(msg string, keysAndValues ...interface{})

--- a/core/logger/logger_test.go
+++ b/core/logger/logger_test.go
@@ -6,8 +6,14 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNoSampling(t *testing.T) {
+func TestConfig(t *testing.T) {
+	// no sampling
 	assert.Nil(t, newBaseConfig().Sampling)
 	assert.Nil(t, newTestConfig().Sampling)
 	assert.Nil(t, newProductionConfig("", false, true, false).Sampling)
+
+	// not development, which would trigger panics for Critical level
+	assert.False(t, newBaseConfig().Development)
+	assert.False(t, newTestConfig().Development)
+	assert.False(t, newProductionConfig("", false, true, false).Development)
 }

--- a/core/logger/null_logger.go
+++ b/core/logger/null_logger.go
@@ -55,4 +55,4 @@ func (l *nullLogger) ErrorIf(err error, msg string)    {}
 func (l *nullLogger) PanicIf(err error, msg string)    {}
 func (l *nullLogger) ErrorIfClosing(io.Closer, string) {}
 func (l *nullLogger) Sync() error                      { return nil }
-func (l *nullLogger) withCallerSkip(add int) Logger    { return l }
+func (l *nullLogger) Helper(skip int) Logger           { return l }

--- a/core/logger/null_logger.go
+++ b/core/logger/null_logger.go
@@ -22,26 +22,34 @@ func (l *nullLogger) With(args ...interface{}) Logger                 { return l
 func (l *nullLogger) Named(name string) Logger                        { return l }
 func (l *nullLogger) NewRootLogger(lvl zapcore.Level) (Logger, error) { return l, nil }
 func (l *nullLogger) SetLogLevel(_ zapcore.Level)                     {}
-func (l *nullLogger) Debug(args ...interface{})                       {}
-func (l *nullLogger) Info(args ...interface{})                        {}
-func (l *nullLogger) Warn(args ...interface{})                        {}
-func (l *nullLogger) Error(args ...interface{})                       {}
-func (l *nullLogger) Fatal(args ...interface{})                       {}
-func (l *nullLogger) Panic(args ...interface{})                       {}
-func (l *nullLogger) Debugf(format string, values ...interface{})     {}
-func (l *nullLogger) Infof(format string, values ...interface{})      {}
-func (l *nullLogger) Warnf(format string, values ...interface{})      {}
-func (l *nullLogger) Errorf(format string, values ...interface{})     {}
-func (l *nullLogger) Fatalf(format string, values ...interface{})     {}
-func (l *nullLogger) Debugw(msg string, keysAndValues ...interface{}) {}
-func (l *nullLogger) Infow(msg string, keysAndValues ...interface{})  {}
-func (l *nullLogger) Warnw(msg string, keysAndValues ...interface{})  {}
-func (l *nullLogger) Errorw(msg string, keysAndValues ...interface{}) {}
-func (l *nullLogger) Fatalw(msg string, keysAndValues ...interface{}) {}
-func (l *nullLogger) Panicw(msg string, keysAndValues ...interface{}) {}
-func (l *nullLogger) WarnIf(err error, msg string)                    {}
-func (l *nullLogger) ErrorIf(err error, msg string)                   {}
-func (l *nullLogger) PanicIf(err error, msg string)                   {}
-func (l *nullLogger) ErrorIfClosing(io.Closer, string)                {}
-func (l *nullLogger) Sync() error                                     { return nil }
-func (l *nullLogger) withCallerSkip(add int) Logger                   { return l }
+
+func (l *nullLogger) Debug(args ...interface{})    {}
+func (l *nullLogger) Info(args ...interface{})     {}
+func (l *nullLogger) Warn(args ...interface{})     {}
+func (l *nullLogger) Error(args ...interface{})    {}
+func (l *nullLogger) Critical(args ...interface{}) {}
+func (l *nullLogger) Panic(args ...interface{})    {}
+func (l *nullLogger) Fatal(args ...interface{})    {}
+
+func (l *nullLogger) Debugf(format string, values ...interface{})    {}
+func (l *nullLogger) Infof(format string, values ...interface{})     {}
+func (l *nullLogger) Warnf(format string, values ...interface{})     {}
+func (l *nullLogger) Errorf(format string, values ...interface{})    {}
+func (l *nullLogger) Criticalf(format string, values ...interface{}) {}
+func (l *nullLogger) Panicf(format string, values ...interface{})    {}
+func (l *nullLogger) Fatalf(format string, values ...interface{})    {}
+
+func (l *nullLogger) Debugw(msg string, keysAndValues ...interface{})    {}
+func (l *nullLogger) Infow(msg string, keysAndValues ...interface{})     {}
+func (l *nullLogger) Warnw(msg string, keysAndValues ...interface{})     {}
+func (l *nullLogger) Errorw(msg string, keysAndValues ...interface{})    {}
+func (l *nullLogger) CriticalW(msg string, keysAndValues ...interface{}) {}
+func (l *nullLogger) Panicw(msg string, keysAndValues ...interface{})    {}
+func (l *nullLogger) Fatalw(msg string, keysAndValues ...interface{})    {}
+
+func (l *nullLogger) WarnIf(err error, msg string)     {}
+func (l *nullLogger) ErrorIf(err error, msg string)    {}
+func (l *nullLogger) PanicIf(err error, msg string)    {}
+func (l *nullLogger) ErrorIfClosing(io.Closer, string) {}
+func (l *nullLogger) Sync() error                      { return nil }
+func (l *nullLogger) withCallerSkip(add int) Logger    { return l }

--- a/core/logger/null_logger.go
+++ b/core/logger/null_logger.go
@@ -23,6 +23,7 @@ func (l *nullLogger) Named(name string) Logger                        { return l
 func (l *nullLogger) NewRootLogger(lvl zapcore.Level) (Logger, error) { return l, nil }
 func (l *nullLogger) SetLogLevel(_ zapcore.Level)                     {}
 
+func (l *nullLogger) Trace(args ...interface{})    {}
 func (l *nullLogger) Debug(args ...interface{})    {}
 func (l *nullLogger) Info(args ...interface{})     {}
 func (l *nullLogger) Warn(args ...interface{})     {}
@@ -31,6 +32,7 @@ func (l *nullLogger) Critical(args ...interface{}) {}
 func (l *nullLogger) Panic(args ...interface{})    {}
 func (l *nullLogger) Fatal(args ...interface{})    {}
 
+func (l *nullLogger) Tracef(format string, values ...interface{})    {}
 func (l *nullLogger) Debugf(format string, values ...interface{})    {}
 func (l *nullLogger) Infof(format string, values ...interface{})     {}
 func (l *nullLogger) Warnf(format string, values ...interface{})     {}
@@ -39,6 +41,7 @@ func (l *nullLogger) Criticalf(format string, values ...interface{}) {}
 func (l *nullLogger) Panicf(format string, values ...interface{})    {}
 func (l *nullLogger) Fatalf(format string, values ...interface{})    {}
 
+func (l *nullLogger) Tracew(msg string, keysAndValues ...interface{})    {}
 func (l *nullLogger) Debugw(msg string, keysAndValues ...interface{})    {}
 func (l *nullLogger) Infow(msg string, keysAndValues ...interface{})     {}
 func (l *nullLogger) Warnw(msg string, keysAndValues ...interface{})     {}

--- a/core/logger/ocr_wrapper.go
+++ b/core/logger/ocr_wrapper.go
@@ -14,7 +14,7 @@ type ocrWrapper struct {
 
 func NewOCRWrapper(l Logger, trace bool, saveError func(string)) ocrtypes.Logger {
 	return &ocrWrapper{
-		internal:  l.withCallerSkip(2),
+		internal:  l.Helper(2),
 		trace:     trace,
 		saveError: saveError,
 	}

--- a/core/logger/sentry.go
+++ b/core/logger/sentry.go
@@ -1,0 +1,325 @@
+package logger
+
+import (
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"time"
+
+	"github.com/getsentry/sentry-go"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/smartcontractkit/chainlink/core/static"
+)
+
+const SentryFlushDeadline = 5 * time.Second
+
+func init() {
+	// If SENTRY_ENVIRONMENT is set, it will override everything. Otherwise infers from CHAINLINK_DEV.
+	var sentryenv string
+	if env := os.Getenv("SENTRY_ENVIRONMENT"); env != "" {
+		sentryenv = env
+	} else if os.Getenv("CHAINLINK_DEV") == "true" {
+		sentryenv = "dev"
+	} else {
+		sentryenv = "prod"
+	}
+	// If SENTRY_DSN is set, it will override everything. Otherwise static.SentryDSN will be used.
+	// If neither are set, sentry is disabled.
+	var sentrydsn string
+	if dsn := os.Getenv("SENTRY_DSN"); dsn != "" {
+		sentrydsn = dsn
+	} else {
+		sentrydsn = static.SentryDSN
+	}
+	// If SENTRY_RELEASE is set, it will override everything. Otherwise, static.Version will be used.
+	var sentryrelease string
+	if release := os.Getenv("SENTRY_RELEASE"); release != "" {
+		sentryrelease = release
+	} else {
+		sentryrelease = static.Version
+	}
+	err := sentry.Init(sentry.ClientOptions{
+		// AttachStacktrace is needed to send stacktrace alongside panics
+		AttachStacktrace: true,
+		Dsn:              sentrydsn,
+		Environment:      sentryenv,
+		Release:          sentryrelease,
+		// Enable printing of SDK debug messages.
+		// Uncomment line below to debug sentry
+		// Debug: true,
+	})
+	if err != nil {
+		log.Fatalf("sentry.Init: %s", err)
+	}
+}
+
+//TODO could include sentry event IDs with log lines: .With("sentryEvent",*EventID)
+type sentryLogger struct {
+	h Logger
+}
+
+func newSentryLogger(l Logger) Logger {
+	return &sentryLogger{h: l.Helper(1)}
+}
+
+func (s *sentryLogger) With(args ...interface{}) Logger {
+	return &sentryLogger{
+		h: s.h.With(args...),
+	}
+}
+
+func (s *sentryLogger) Named(name string) Logger {
+	return &sentryLogger{
+		h: s.h.Named(name),
+	}
+}
+
+func (s *sentryLogger) NewRootLogger(lvl zapcore.Level) (Logger, error) {
+	h, err := s.h.NewRootLogger(lvl)
+	if err != nil {
+		return nil, err
+	}
+	return &sentryLogger{
+		h: h,
+	}, nil
+}
+
+func (s *sentryLogger) SetLogLevel(level zapcore.Level) {
+	s.h.SetLogLevel(level)
+}
+
+func (s *sentryLogger) Trace(args ...interface{}) {
+	s.h.Trace(args...)
+}
+
+func (s *sentryLogger) Debug(args ...interface{}) {
+	s.h.Debug(args...)
+}
+
+func (s *sentryLogger) Info(args ...interface{}) {
+	s.h.Info(args...)
+}
+
+func (s *sentryLogger) Warn(args ...interface{}) {
+	s.h.Warn(args...)
+}
+
+func (s *sentryLogger) Error(args ...interface{}) {
+	hub := sentry.CurrentHub().Clone()
+	hub.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("logger", map[string]interface{}{
+			"args": args,
+		})
+		scope.SetLevel(sentry.LevelError)
+	})
+	hub.CaptureMessage(fmt.Sprintf("%v", args))
+	s.h.Error(args...)
+}
+
+func (s *sentryLogger) Critical(args ...interface{}) {
+	defer sentry.Flush(SentryFlushDeadline)
+	hub := sentry.CurrentHub().Clone()
+	hub.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("logger", map[string]interface{}{
+			"args": args,
+		})
+		scope.SetLevel(sentry.LevelFatal)
+	})
+	hub.CaptureMessage(fmt.Sprintf("%v", args))
+	s.h.Critical(args...)
+}
+
+func (s *sentryLogger) Panic(args ...interface{}) {
+	defer sentry.Flush(SentryFlushDeadline)
+	hub := sentry.CurrentHub().Clone()
+	hub.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("logger", map[string]interface{}{
+			"args": args,
+		})
+		scope.SetLevel(sentry.LevelFatal)
+	})
+	hub.CaptureMessage(fmt.Sprintf("%v", args))
+	s.h.Panic(args...)
+}
+
+func (s *sentryLogger) Fatal(args ...interface{}) {
+	defer sentry.Flush(SentryFlushDeadline)
+	hub := sentry.CurrentHub().Clone()
+	hub.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("logger", map[string]interface{}{
+			"args": args,
+		})
+		scope.SetLevel(sentry.LevelFatal)
+	})
+	hub.CaptureMessage(fmt.Sprintf("%v", args))
+	s.h.Fatal(args...)
+}
+
+func (s *sentryLogger) Tracef(format string, values ...interface{}) {
+	s.h.Tracef(format, values...)
+}
+
+func (s *sentryLogger) Debugf(format string, values ...interface{}) {
+	s.h.Debugf(format, values...)
+}
+
+func (s *sentryLogger) Infof(format string, values ...interface{}) {
+	s.h.Infof(format, values...)
+}
+
+func (s *sentryLogger) Warnf(format string, values ...interface{}) {
+	s.h.Warnf(format, values...)
+}
+
+func (s *sentryLogger) Errorf(format string, values ...interface{}) {
+	hub := sentry.CurrentHub().Clone()
+	hub.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("logger", map[string]interface{}{
+			"values": values,
+		})
+		scope.SetLevel(sentry.LevelError)
+	})
+	hub.CaptureMessage(fmt.Sprintf(format, values...))
+	s.h.Errorf(format, values...)
+}
+
+func (s *sentryLogger) Criticalf(format string, values ...interface{}) {
+	defer sentry.Flush(SentryFlushDeadline)
+	hub := sentry.CurrentHub().Clone()
+	hub.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("logger", map[string]interface{}{
+			"values": values,
+		})
+		scope.SetLevel(sentry.LevelFatal)
+	})
+	hub.CaptureMessage(fmt.Sprintf(format, values...))
+	s.h.Criticalf(format, values...)
+}
+
+func (s *sentryLogger) Panicf(format string, values ...interface{}) {
+	defer sentry.Flush(SentryFlushDeadline)
+	hub := sentry.CurrentHub().Clone()
+	hub.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("logger", map[string]interface{}{
+			"values": values,
+		})
+		scope.SetLevel(sentry.LevelFatal)
+	})
+	hub.CaptureMessage(fmt.Sprintf(format, values...))
+	s.h.Panicf(format, values...)
+}
+
+func (s *sentryLogger) Fatalf(format string, values ...interface{}) {
+	defer sentry.Flush(SentryFlushDeadline)
+	hub := sentry.CurrentHub().Clone()
+	hub.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("logger", map[string]interface{}{
+			"values": values,
+		})
+		scope.SetLevel(sentry.LevelFatal)
+	})
+	hub.CaptureMessage(fmt.Sprintf(format, values...))
+	s.h.Fatalf(format, values...)
+}
+
+func (s *sentryLogger) Tracew(msg string, keysAndValues ...interface{}) {
+	s.h.Tracew(msg, keysAndValues...)
+}
+
+func (s *sentryLogger) Debugw(msg string, keysAndValues ...interface{}) {
+	s.h.Debugw(msg, keysAndValues...)
+}
+
+func (s *sentryLogger) Infow(msg string, keysAndValues ...interface{}) {
+	s.h.Infow(msg, keysAndValues...)
+}
+
+func (s *sentryLogger) Warnw(msg string, keysAndValues ...interface{}) {
+	s.h.Warnw(msg, keysAndValues...)
+}
+
+func (s *sentryLogger) Errorw(msg string, keysAndValues ...interface{}) {
+	hub := sentry.CurrentHub().Clone()
+	hub.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("logger", toMap(keysAndValues))
+		scope.SetLevel(sentry.LevelError)
+	})
+	hub.CaptureMessage(msg)
+	s.h.Errorw(msg, keysAndValues...)
+}
+
+func (s *sentryLogger) CriticalW(msg string, keysAndValues ...interface{}) {
+	defer sentry.Flush(SentryFlushDeadline)
+	hub := sentry.CurrentHub().Clone()
+	hub.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("logger", toMap(keysAndValues))
+		scope.SetLevel(sentry.LevelFatal)
+	})
+	hub.CaptureMessage(msg)
+	s.h.CriticalW(msg, keysAndValues...)
+}
+
+func (s *sentryLogger) Panicw(msg string, keysAndValues ...interface{}) {
+	defer sentry.Flush(SentryFlushDeadline)
+	hub := sentry.CurrentHub().Clone()
+	hub.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("logger", toMap(keysAndValues))
+		scope.SetLevel(sentry.LevelFatal)
+	})
+	hub.CaptureMessage(msg)
+	s.h.Panicw(msg, keysAndValues...)
+}
+
+func (s *sentryLogger) Fatalw(msg string, keysAndValues ...interface{}) {
+	defer sentry.Flush(SentryFlushDeadline)
+	hub := sentry.CurrentHub().Clone()
+	hub.ConfigureScope(func(scope *sentry.Scope) {
+		scope.SetContext("logger", toMap(keysAndValues))
+		scope.SetLevel(sentry.LevelFatal)
+	})
+	hub.CaptureMessage(msg)
+	s.h.Fatalw(msg, keysAndValues...)
+}
+
+func (s *sentryLogger) ErrorIf(err error, msg string) {
+	if err != nil {
+		sentry.CaptureException(err)
+		s.h.Errorw(msg, "err", err)
+	}
+}
+
+func (s *sentryLogger) ErrorIfClosing(c io.Closer, name string) {
+	if err := c.Close(); err != nil {
+		sentry.CaptureException(err)
+		s.h.Errorw(fmt.Sprintf("Error closing %s", name), "err", err)
+	}
+}
+
+func (s *sentryLogger) Sync() error {
+	return s.h.Sync()
+}
+
+func (s *sentryLogger) Helper(add int) Logger {
+	return s.h.Helper(add)
+}
+
+func toMap(args ...interface{}) (m map[string]interface{}) {
+	m = make(map[string]interface{}, len(args)/2)
+	for i := 0; i < len(args); {
+		// Make sure this element isn't a dangling key
+		if i == len(args)-1 {
+			break
+		}
+
+		// Consume this value and the next, treating them as a key-value pair. If the
+		// key isn't a string ignore it
+		key, val := args[i], args[i+1]
+		if keyStr, ok := key.(string); ok {
+			m[keyStr] = val
+		}
+		i += 2
+	}
+	return m
+}

--- a/core/logger/test_logger_test.go
+++ b/core/logger/test_logger_test.go
@@ -64,4 +64,10 @@ func TestTestLogger(t *testing.T) {
 	// [INFO]	Did some work		logger/test_logger_test.go:49    logger=TestLogger.ServiceName.WorkerName result=success workerId=42
 	requireContains("[INFO]", workerMessage, fmt.Sprintf("%s=%s", idKey, workerId),
 		fmt.Sprintf("%s=%s", resultKey, resultVal), fmt.Sprintf("logger=%s.%s.%s", testName, serviceName, workerName))
+
+	const (
+		critMsg = "Critical error"
+	)
+	lgr.Critical(critMsg)
+	requireContains("[CRIT]", critMsg, fmt.Sprintf("logger=%s", testName))
 }

--- a/core/logger/trace.go
+++ b/core/logger/trace.go
@@ -1,0 +1,20 @@
+//go:build trace
+
+package logger
+
+import "fmt"
+
+const tracePrefix = "[TRACE]"
+
+func (l *zapLogger) Trace(args ...interface{}) {
+	args[0] = fmt.Sprint(tracePrefix, args[0])
+	l.sugaredWithCallerSkip(1).Debug(args...)
+}
+
+func (l *zapLogger) Tracef(format string, values ...interface{}) {
+	l.sugaredWithCallerSkip(1).Debugf(fmt.Sprint(tracePrefix, format), values...)
+}
+
+func (l *zapLogger) Tracew(msg string, keysAndValues ...interface{}) {
+	l.sugaredWithCallerSkip(1).Debugw(fmt.Sprint(tracePrefix, msg), keysAndValues...)
+}

--- a/core/logger/trace.go
+++ b/core/logger/trace.go
@@ -4,17 +4,17 @@ package logger
 
 import "fmt"
 
-const tracePrefix = "[TRACE]"
+const tracePrefix = "[TRACE] "
 
 func (l *zapLogger) Trace(args ...interface{}) {
 	args[0] = fmt.Sprint(tracePrefix, args[0])
-	l.sugaredWithCallerSkip(1).Debug(args...)
+	l.sugaredHelper(1).Debug(args...)
 }
 
 func (l *zapLogger) Tracef(format string, values ...interface{}) {
-	l.sugaredWithCallerSkip(1).Debugf(fmt.Sprint(tracePrefix, format), values...)
+	l.sugaredHelper(1).Debugf(fmt.Sprint(tracePrefix, format), values...)
 }
 
 func (l *zapLogger) Tracew(msg string, keysAndValues ...interface{}) {
-	l.sugaredWithCallerSkip(1).Debugw(fmt.Sprint(tracePrefix, msg), keysAndValues...)
+	l.sugaredHelper(1).Debugw(fmt.Sprint(tracePrefix, msg), keysAndValues...)
 }

--- a/core/logger/trace_noop.go
+++ b/core/logger/trace_noop.go
@@ -1,0 +1,9 @@
+//go:build !trace
+
+package logger
+
+func (l *zapLogger) Trace(args ...interface{}) {}
+
+func (l *zapLogger) Tracef(format string, values ...interface{}) {}
+
+func (l *zapLogger) Tracew(msg string, keysAndValues ...interface{}) {}

--- a/core/logger/trace_noop_test.go
+++ b/core/logger/trace_noop_test.go
@@ -1,0 +1,36 @@
+//go:build !trace
+
+package logger
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestTrace(t *testing.T) {
+	lgr := TestLogger(t)
+	lgr.SetLogLevel(zapcore.InfoLevel)
+	requireNotContains := func(ns ...string) {
+		t.Helper()
+		logs := MemoryLogTestingOnly().String()
+		for _, n := range ns {
+			require.NotContains(t, logs, n)
+		}
+	}
+
+	const (
+		testName    = "TestTrace"
+		testMessage = "Trace message"
+	)
+	lgr.Trace(testMessage)
+	// [DEBUG] [TRACE] Trace message		logger/test_logger_test.go:23    logger=TestLogger
+	requireNotContains("[TRACE]", testMessage, fmt.Sprintf("logger=%s", testName))
+
+	lgr.SetLogLevel(zapcore.DebugLevel)
+	lgr.Trace(testMessage)
+	// [DEBUG] [TRACE] Trace message		logger/test_logger_test.go:23    logger=TestLogger
+	requireNotContains("[TRACE]", testMessage, fmt.Sprintf("logger=%s", testName))
+}

--- a/core/logger/trace_test.go
+++ b/core/logger/trace_test.go
@@ -3,7 +3,6 @@
 package logger
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,11 +32,11 @@ func TestTrace(t *testing.T) {
 		testMessage = "Trace message"
 	)
 	lgr.Trace(testMessage)
-	// [DEBUG] [TRACE] Trace message		logger/test_logger_test.go:23    logger=TestLogger
-	requireNotContains("[TRACE]", testMessage, fmt.Sprintf("logger=%s", testName))
+	// [DEBUG] [TRACE] Trace message
+	requireNotContains(testMessage)
 
 	lgr.SetLogLevel(zapcore.DebugLevel)
 	lgr.Trace(testMessage)
-	// [DEBUG] [TRACE] Trace message		logger/test_logger_test.go:23    logger=TestLogger
-	requireContains("[DEBUG]", "[TRACE]", testMessage, fmt.Sprintf("logger=%s", testName))
+	// [DEBUG] [TRACE] Trace message
+	requireContains("[DEBUG]", "[TRACE]", testMessage)
 }

--- a/core/logger/trace_test.go
+++ b/core/logger/trace_test.go
@@ -1,0 +1,43 @@
+//go:build trace
+
+package logger
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+)
+
+func TestTrace(t *testing.T) {
+	lgr := TestLogger(t)
+	lgr.SetLogLevel(zapcore.InfoLevel)
+	requireContains := func(cs ...string) {
+		t.Helper()
+		logs := MemoryLogTestingOnly().String()
+		for _, c := range cs {
+			require.Contains(t, logs, c)
+		}
+	}
+	requireNotContains := func(ns ...string) {
+		t.Helper()
+		logs := MemoryLogTestingOnly().String()
+		for _, n := range ns {
+			require.NotContains(t, logs, n)
+		}
+	}
+
+	const (
+		testName    = "TestTrace"
+		testMessage = "Trace message"
+	)
+	lgr.Trace(testMessage)
+	// [DEBUG] [TRACE] Trace message		logger/test_logger_test.go:23    logger=TestLogger
+	requireNotContains("[TRACE]", testMessage, fmt.Sprintf("logger=%s", testName))
+
+	lgr.SetLogLevel(zapcore.DebugLevel)
+	lgr.Trace(testMessage)
+	// [DEBUG] [TRACE] Trace message		logger/test_logger_test.go:23    logger=TestLogger
+	requireContains("[DEBUG]", "[TRACE]", testMessage, fmt.Sprintf("logger=%s", testName))
+}

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -1,0 +1,114 @@
+package logger
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+var _ Logger = &zapLogger{}
+
+type zapLogger struct {
+	*zap.SugaredLogger
+	config zap.Config
+	name   string
+	fields []interface{}
+}
+
+func newZapLogger(cfg zap.Config) (Logger, error) {
+	zl, err := cfg.Build()
+	if err != nil {
+		return nil, err
+	}
+	return &zapLogger{config: cfg, SugaredLogger: zl.Sugar()}, nil
+}
+
+func (l *zapLogger) SetLogLevel(lvl zapcore.Level) {
+	l.config.Level.SetLevel(lvl)
+}
+
+func (l *zapLogger) With(args ...interface{}) Logger {
+	newLogger := *l
+	newLogger.SugaredLogger = l.SugaredLogger.With(args...)
+	newLogger.fields = copyFields(l.fields, args...)
+	return &newLogger
+}
+
+// copyFields returns a copy of fields with add appended.
+func copyFields(fields []interface{}, add ...interface{}) []interface{} {
+	f := make([]interface{}, 0, len(fields)+len(add))
+	f = append(f, fields...)
+	f = append(f, add...)
+	return f
+}
+
+func joinName(old, new string) string {
+	if old == "" {
+		return new
+	}
+	return old + "." + new
+}
+
+func (l *zapLogger) Named(name string) Logger {
+	newLogger := *l
+	newLogger.name = joinName(l.name, name)
+	newLogger.SugaredLogger = l.SugaredLogger.Named(name)
+	newLogger.Trace("Named logger created")
+	return &newLogger
+}
+
+func (l *zapLogger) NewRootLogger(lvl zapcore.Level) (Logger, error) {
+	newLogger := *l
+	newLogger.config.Level = zap.NewAtomicLevelAt(lvl)
+	zl, err := newLogger.config.Build()
+	if err != nil {
+		return nil, err
+	}
+	newLogger.SugaredLogger = zl.Named(l.name).Sugar().With(l.fields...)
+	return &newLogger, nil
+}
+
+func (l *zapLogger) Helper(skip int) Logger {
+	newLogger := *l
+	newLogger.SugaredLogger = l.sugaredHelper(skip)
+	return &newLogger
+}
+
+func (l *zapLogger) sugaredHelper(skip int) *zap.SugaredLogger {
+	return l.SugaredLogger.Desugar().WithOptions(zap.AddCallerSkip(skip)).Sugar()
+}
+
+func (l *zapLogger) ErrorIf(err error, msg string) {
+	if err != nil {
+		l.Helper(1).Errorw(msg, "err", err)
+	}
+}
+
+func (l *zapLogger) ErrorIfClosing(c io.Closer, name string) {
+	if err := c.Close(); err != nil {
+		l.Helper(1).Errorw(fmt.Sprintf("Error closing %s", name), "err", err)
+	}
+}
+
+func (l *zapLogger) Sync() error {
+	err := l.SugaredLogger.Sync()
+	if err == nil {
+		return nil
+	}
+	var msg string
+	if uw := errors.Unwrap(err); uw != nil {
+		msg = uw.Error()
+	} else {
+		msg = err.Error()
+	}
+	switch msg {
+	case os.ErrInvalid.Error(), "bad file descriptor",
+		"inappropriate ioctl for device":
+		return nil
+	}
+	return err
+}

--- a/core/recovery/recover.go
+++ b/core/recovery/recover.go
@@ -25,7 +25,7 @@ func WrapRecover(lggr logger.Logger, fn func()) {
 			sentry.CurrentHub().Recover(err)
 			sentry.Flush(logger.SentryFlushDeadline)
 
-			lggr.Errorw("goroutine panicked", "panic", err, "stacktrace", string(debug.Stack()))
+			lggr.CriticalW("Recovered goroutine panic", "panic", err, "stacktrace", string(debug.Stack()))
 		}
 	}()
 	fn()
@@ -37,7 +37,7 @@ func WrapRecoverHandle(lggr logger.Logger, fn func(), onPanic func(interface{}))
 			sentry.CurrentHub().Recover(err)
 			sentry.Flush(logger.SentryFlushDeadline)
 
-			lggr.Errorw("goroutine panicked", "panic", err, "stacktrace", string(debug.Stack()))
+			lggr.CriticalW("Recovered goroutine panic", "panic", err, "stacktrace", string(debug.Stack()))
 
 			if onPanic != nil {
 				onPanic(err)


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/21618/introduce-more-granular-log-levels

- `Critical*`: `[CRIT]` (repurposing zap's `dpanic`)
- `Trace*`: `[DEBUG] [TRACE]` (iff `//go:build trace`)
- refactor some related Sentry and SQL log helpers