### PR TITLE
Fixes a bug causing proposals to be rejected

### DIFF
--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -130,7 +130,7 @@ func Test_ORM_GetManager(t *testing.T) {
 	assert.True(t, actual.IsOCRBootstrapPeer)
 	assert.Equal(t, ocrBootstrapPeerMultiaddr, actual.OCRBootstrapPeerMultiaddr)
 
-	actual, err = orm.GetManager(-1)
+	_, err = orm.GetManager(-1)
 	require.Error(t, err)
 }
 
@@ -383,7 +383,7 @@ func Test_ORM_GetJobProposal(t *testing.T) {
 		assert.Equal(t, id, actual.ID)
 		assertJobEquals(actual)
 
-		actual, err = orm.GetJobProposal(int64(0))
+		_, err = orm.GetJobProposal(int64(0))
 		require.Error(t, err)
 	})
 
@@ -393,7 +393,7 @@ func Test_ORM_GetJobProposal(t *testing.T) {
 
 		assertJobEquals(actual)
 
-		actual, err = orm.GetJobProposalByRemoteUUID(uuid.NewV4())
+		_, err = orm.GetJobProposalByRemoteUUID(uuid.NewV4())
 		require.Error(t, err)
 	})
 }

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -304,8 +304,7 @@ func (s *service) ProposeJob(jp *JobProposal) (int64, error) {
 		}
 	}
 
-	// Validation checks if a job proposal exists
-	if existing != nil {
+	if err == nil {
 		// Ensure that if the job proposal exists, that it belongs to the feeds manager.
 		if jp.FeedsManagerID != existing.FeedsManagerID {
 			return 0, errors.New("cannot update a job proposal belonging to another feeds manager")

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -252,7 +252,7 @@ func Test_Service_ProposeJob(t *testing.T) {
 			name: "Create success",
 			before: func(svc *TestService) {
 				svc.cfg.On("DefaultHTTPTimeout").Return(httpTimeout)
-				svc.orm.On("GetJobProposalByRemoteUUID", jp.RemoteUUID).Return(nil, sql.ErrNoRows)
+				svc.orm.On("GetJobProposalByRemoteUUID", jp.RemoteUUID).Return(new(feeds.JobProposal), sql.ErrNoRows)
 				svc.orm.On("UpsertJobProposal", &jp).Return(id, nil)
 			},
 			wantID:   id,


### PR DESCRIPTION
The removal of gorm also included a change which would always return a non nil
pointer in the get methods of the feeds ORM. The service method has been changed
to check for the error instead of a nil pointer