### PR TITLE
Implement job proposals GQL relationship with feeds managers

### DIFF
--- a/core/services/feeds/mocks/orm.go
+++ b/core/services/feeds/mocks/orm.go
@@ -172,6 +172,36 @@ func (_m *ORM) GetJobProposal(id int64, qopts ...postgres.QOpt) (*feeds.JobPropo
 	return r0, r1
 }
 
+// GetJobProposalByManagersIDs provides a mock function with given fields: ids, qopts
+func (_m *ORM) GetJobProposalByManagersIDs(ids []int64, qopts ...postgres.QOpt) ([]feeds.JobProposal, error) {
+	_va := make([]interface{}, len(qopts))
+	for _i := range qopts {
+		_va[_i] = qopts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ids)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 []feeds.JobProposal
+	if rf, ok := ret.Get(0).(func([]int64, ...postgres.QOpt) []feeds.JobProposal); ok {
+		r0 = rf(ids, qopts...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]feeds.JobProposal)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]int64, ...postgres.QOpt) error); ok {
+		r1 = rf(ids, qopts...)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetJobProposalByRemoteUUID provides a mock function with given fields: _a0
 func (_m *ORM) GetJobProposalByRemoteUUID(_a0 uuid.UUID) (*feeds.JobProposal, error) {
 	ret := _m.Called(_a0)

--- a/core/services/feeds/mocks/service.go
+++ b/core/services/feeds/mocks/service.go
@@ -121,6 +121,29 @@ func (_m *Service) GetJobProposal(id int64) (*feeds.JobProposal, error) {
 	return r0, r1
 }
 
+// GetJobProposalByManagersIDs provides a mock function with given fields: ids
+func (_m *Service) GetJobProposalByManagersIDs(ids []int64) ([]feeds.JobProposal, error) {
+	ret := _m.Called(ids)
+
+	var r0 []feeds.JobProposal
+	if rf, ok := ret.Get(0).(func([]int64) []feeds.JobProposal); ok {
+		r0 = rf(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]feeds.JobProposal)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]int64) error); ok {
+		r1 = rf(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetManager provides a mock function with given fields: id
 func (_m *Service) GetManager(id int64) (*feeds.FeedsManager, error) {
 	ret := _m.Called(id)

--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -317,6 +317,35 @@ func Test_ORM_ListJobProposals(t *testing.T) {
 	assert.Equal(t, jp.FeedsManagerID, actual.FeedsManagerID)
 }
 
+func Test_ORM_GetJobProposalByManagersIDs(t *testing.T) {
+	t.Parallel()
+
+	orm := setupORM(t)
+	fmID := createFeedsManager(t, orm)
+	uuid := uuid.NewV4()
+
+	jp := &feeds.JobProposal{
+		RemoteUUID:     uuid,
+		Spec:           "",
+		Status:         feeds.JobProposalStatusPending,
+		FeedsManagerID: fmID,
+	}
+
+	id, err := orm.CreateJobProposal(jp)
+	require.NoError(t, err)
+
+	jps, err := orm.GetJobProposalByManagersIDs([]int64{fmID})
+	require.NoError(t, err)
+	require.Len(t, jps, 1)
+
+	actual := jps[0]
+	assert.Equal(t, id, actual.ID)
+	assert.Equal(t, uuid, actual.RemoteUUID)
+	assert.Equal(t, jp.Status, actual.Status)
+	assert.False(t, actual.ExternalJobID.Valid)
+	assert.Equal(t, jp.FeedsManagerID, actual.FeedsManagerID)
+}
+
 func Test_ORM_UpdateJobProposalSpec(t *testing.T) {
 	t.Parallel()
 

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -46,6 +46,7 @@ type Service interface {
 	GetManagers(ids []int64) ([]FeedsManager, error)
 	ListManagers() ([]FeedsManager, error)
 	ListJobProposals() ([]JobProposal, error)
+	GetJobProposalByManagersIDs(ids []int64) ([]JobProposal, error)
 	ProposeJob(jp *JobProposal) (int64, error)
 	RegisterManager(ms *FeedsManager) (int64, error)
 	RejectJobProposal(ctx context.Context, id int64) error
@@ -268,6 +269,11 @@ func (s *service) CountManagers() (int64, error) {
 // by feeds manager
 func (s *service) ListJobProposals() ([]JobProposal, error) {
 	return s.orm.ListJobProposals()
+}
+
+// GetJobProposalByManagersIDs gets job proposals by feeds managers IDs
+func (s *service) GetJobProposalByManagersIDs(ids []int64) ([]JobProposal, error) {
+	return s.orm.GetJobProposalByManagersIDs(ids)
 }
 
 // CreateJobProposal creates a job proposal.

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
@@ -443,6 +444,25 @@ func Test_Service_ListJobProposals(t *testing.T) {
 		Return(jps, nil)
 
 	actual, err := svc.ListJobProposals()
+	require.NoError(t, err)
+
+	assert.Equal(t, actual, jps)
+}
+
+func Test_Service_GetJobProposalByManagersIDs(t *testing.T) {
+	t.Parallel()
+
+	var (
+		jp    = feeds.JobProposal{}
+		jps   = []feeds.JobProposal{jp}
+		fmIDs = []int64{1}
+	)
+	svc := setupTestService(t)
+
+	svc.orm.On("GetJobProposalByManagersIDs", fmIDs).
+		Return(jps, nil)
+
+	actual, err := svc.GetJobProposalByManagersIDs(fmIDs)
 	require.NoError(t, err)
 
 	assert.Equal(t, actual, jps)

--- a/core/web/loader/getters.go
+++ b/core/web/loader/getters.go
@@ -82,3 +82,21 @@ func GetJobRunsByPipelineSpecID(ctx context.Context, id string) ([]pipeline.Run,
 
 	return jbRuns, nil
 }
+
+// GetJobProposalsByFeedsManagerID fetches the job proposals by feeds manager ID.
+func GetJobProposalsByFeedsManagerID(ctx context.Context, id string) ([]feeds.JobProposal, error) {
+	ldr := For(ctx)
+
+	thunk := ldr.JobProposalsByManagerIDLoader.Load(ctx, dataloader.StringKey(id))
+	result, err := thunk()
+	if err != nil {
+		return nil, err
+	}
+
+	jbRuns, ok := result.([]feeds.JobProposal)
+	if !ok {
+		return nil, errors.New("invalid type")
+	}
+
+	return jbRuns, nil
+}

--- a/core/web/loader/job_proposal.go
+++ b/core/web/loader/job_proposal.go
@@ -1,0 +1,60 @@
+package loader
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/graph-gophers/dataloader"
+
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/core/services/feeds"
+)
+
+type jobProposalBatcher struct {
+	app chainlink.Application
+}
+
+func (b *jobProposalBatcher) loadByManagersIDs(_ context.Context, keys dataloader.Keys) []*dataloader.Result {
+	// Create a map for remembering the order of keys passed in
+	keyOrder := make(map[string]int, len(keys))
+	// Collect the keys to search for
+	var mgrsIDs []int64
+	for ix, key := range keys {
+		id, err := strconv.ParseInt(key.String(), 10, 64)
+		if err == nil {
+			mgrsIDs = append(mgrsIDs, id)
+		}
+
+		keyOrder[key.String()] = ix
+	}
+
+	jps, err := b.app.GetFeedsService().GetJobProposalByManagersIDs(mgrsIDs)
+	if err != nil {
+		return []*dataloader.Result{{Data: nil, Error: err}}
+	}
+
+	// Generate a map of job proposals to feeds managers IDs
+	jpsForMgr := map[string][]feeds.JobProposal{}
+	for _, jp := range jps {
+		id := strconv.Itoa(int(jp.ID))
+		jpsForMgr[id] = append(jpsForMgr[id], jp)
+	}
+
+	// Construct the output array of dataloader results
+	results := make([]*dataloader.Result, len(keys))
+	for k, ns := range jpsForMgr {
+		ix, ok := keyOrder[k]
+		// if found, remove from index lookup map so we know elements were found
+		if ok {
+			results[ix] = &dataloader.Result{Data: ns, Error: nil}
+			delete(keyOrder, k)
+		}
+	}
+
+	// fill array positions without any job proposals as an empty slice
+	for _, ix := range keyOrder {
+		results[ix] = &dataloader.Result{Data: []feeds.JobProposal{}, Error: nil}
+	}
+
+	return results
+}

--- a/core/web/loader/loader.go
+++ b/core/web/loader/loader.go
@@ -14,10 +14,11 @@ type loadersKey struct{}
 type Dataloader struct {
 	app chainlink.Application
 
-	NodesByChainIDLoader      *dataloader.Loader
-	ChainsByIDLoader          *dataloader.Loader
-	FeedsManagersByIDLoader   *dataloader.Loader
-	JobRunsByPipelineIDLoader *dataloader.Loader
+	NodesByChainIDLoader          *dataloader.Loader
+	ChainsByIDLoader              *dataloader.Loader
+	FeedsManagersByIDLoader       *dataloader.Loader
+	JobRunsByPipelineIDLoader     *dataloader.Loader
+	JobProposalsByManagerIDLoader *dataloader.Loader
 }
 
 func New(app chainlink.Application) *Dataloader {
@@ -25,14 +26,16 @@ func New(app chainlink.Application) *Dataloader {
 	chains := &chainBatcher{app: app}
 	mgrs := &feedsBatcher{app: app}
 	jbRuns := &jobRunBatcher{app: app}
+	jps := &jobProposalBatcher{app: app}
 
 	return &Dataloader{
 		app: app,
 
-		NodesByChainIDLoader:      dataloader.NewBatchedLoader(nodes.loadByChainIDs),
-		ChainsByIDLoader:          dataloader.NewBatchedLoader(chains.loadByIDs),
-		FeedsManagersByIDLoader:   dataloader.NewBatchedLoader(mgrs.loadByIDs),
-		JobRunsByPipelineIDLoader: dataloader.NewBatchedLoader(jbRuns.loadByPipelineSpecIDs),
+		NodesByChainIDLoader:          dataloader.NewBatchedLoader(nodes.loadByChainIDs),
+		ChainsByIDLoader:              dataloader.NewBatchedLoader(chains.loadByIDs),
+		FeedsManagersByIDLoader:       dataloader.NewBatchedLoader(mgrs.loadByIDs),
+		JobRunsByPipelineIDLoader:     dataloader.NewBatchedLoader(jbRuns.loadByPipelineSpecIDs),
+		JobProposalsByManagerIDLoader: dataloader.NewBatchedLoader(jps.loadByManagersIDs),
 	}
 }
 

--- a/core/web/resolver/feeds_manager.go
+++ b/core/web/resolver/feeds_manager.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"strconv"
@@ -9,6 +10,7 @@ import (
 	"github.com/graph-gophers/graphql-go"
 
 	"github.com/smartcontractkit/chainlink/core/services/feeds"
+	"github.com/smartcontractkit/chainlink/core/web/loader"
 )
 
 type JobType string
@@ -96,6 +98,15 @@ func (r *FeedsManagerResolver) JobTypes() []JobType {
 	}
 
 	return jts
+}
+
+func (r *FeedsManagerResolver) JobProposals(ctx context.Context) ([]*JobProposalResolver, error) {
+	jps, err := loader.GetJobProposalsByFeedsManagerID(ctx, strconv.Itoa(int(r.mgr.ID)))
+	if err != nil {
+		return nil, err
+	}
+
+	return NewJobProposals(jps), nil
 }
 
 // IsBootstrapPeer resolves the feed managers's isBootstrapPeer field.

--- a/core/web/resolver/feeds_manager_test.go
+++ b/core/web/resolver/feeds_manager_test.go
@@ -52,6 +52,11 @@ func Test_FeedsManagers(t *testing.T) {
 						bootstrapPeerMultiaddr
 						isConnectionActive
 						createdAt
+						jobProposals {
+							id
+							spec
+							status
+						}
 					}
 				}
 			}`
@@ -67,6 +72,13 @@ func Test_FeedsManagers(t *testing.T) {
 			authenticated: true,
 			before: func(f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
+				f.Mocks.feedsSvc.On("GetJobProposalByManagersIDs", []int64{1}).Return([]feeds.JobProposal{
+					{
+						ID:     int64(1),
+						Spec:   `[type=median retries=3 minBackoff="10ms" maxBackoff="10ms" index=0]`,
+						Status: feeds.JobProposalStatusApproved,
+					},
+				}, nil)
 				f.Mocks.feedsSvc.On("ListManagers").Return([]feeds.FeedsManager{
 					{
 						ID:                        1,
@@ -94,7 +106,12 @@ func Test_FeedsManagers(t *testing.T) {
 							"isBootstrapPeer": true,
 							"bootstrapPeerMultiaddr": "/dns4/ocr-bootstrap.chain.link/tcp/0000/p2p/7777777",
 							"isConnectionActive": true,
-							"createdAt": "2021-01-01T00:00:00Z"
+							"createdAt": "2021-01-01T00:00:00Z",
+							"jobProposals": [{
+								"id": "1",
+								"spec": "[type=median retries=3 minBackoff=\"10ms\" maxBackoff=\"10ms\" index=0]",
+								"status": "APPROVED"
+							}]
 						}]
 					}
 				}`,

--- a/core/web/resolver/job_proposal.go
+++ b/core/web/resolver/job_proposal.go
@@ -50,8 +50,8 @@ func NewJobProposal(jp *feeds.JobProposal) *JobProposalResolver {
 func NewJobProposals(jps []feeds.JobProposal) []*JobProposalResolver {
 	var resolvers []*JobProposalResolver
 
-	for _, jp := range jps {
-		resolvers = append(resolvers, NewJobProposal(&jp))
+	for i := range jps {
+		resolvers = append(resolvers, NewJobProposal(&jps[i]))
 	}
 
 	return resolvers

--- a/core/web/resolver/job_proposal.go
+++ b/core/web/resolver/job_proposal.go
@@ -47,6 +47,16 @@ func NewJobProposal(jp *feeds.JobProposal) *JobProposalResolver {
 	return &JobProposalResolver{jp}
 }
 
+func NewJobProposals(jps []feeds.JobProposal) []*JobProposalResolver {
+	var resolvers []*JobProposalResolver
+
+	for _, jp := range jps {
+		resolvers = append(resolvers, NewJobProposal(&jp))
+	}
+
+	return resolvers
+}
+
 // ID resolves to the job proposal ID
 func (r *JobProposalResolver) ID() graphql.ID {
 	return int32GQLID(int32(r.jp.ID))

--- a/core/web/schema/type/feeds_manager.graphql
+++ b/core/web/schema/type/feeds_manager.graphql
@@ -10,6 +10,7 @@ type FeedsManager {
 	publicKey: String!
 	jobTypes: [JobType!]!
 	isBootstrapPeer: Boolean!
+	jobProposals: [JobProposal!]!
 	bootstrapPeerMultiaddr: String
 	isConnectionActive: Boolean!
 	createdAt: Time!


### PR DESCRIPTION
Closes: https://app.shortcut.com/chainlinklabs/story/20929/implement-a-jobproposals-resolver-for-feeds-manager

This aims to allow consumers to query job proposals from feeds managers