### PR TITLE
Fixes the return of dataloaded proposals in a feeds manager

### DIFF
--- a/core/web/loader/job_proposal.go
+++ b/core/web/loader/job_proposal.go
@@ -36,8 +36,8 @@ func (b *jobProposalBatcher) loadByManagersIDs(_ context.Context, keys dataloade
 	// Generate a map of job proposals to feeds managers IDs
 	jpsForMgr := map[string][]feeds.JobProposal{}
 	for _, jp := range jps {
-		id := strconv.Itoa(int(jp.ID))
-		jpsForMgr[id] = append(jpsForMgr[id], jp)
+		mgrID := strconv.Itoa(int(jp.FeedsManagerID))
+		jpsForMgr[mgrID] = append(jpsForMgr[mgrID], jp)
 	}
 
 	// Construct the output array of dataloader results

--- a/core/web/resolver/feeds_manager_test.go
+++ b/core/web/resolver/feeds_manager_test.go
@@ -74,9 +74,10 @@ func Test_FeedsManagers(t *testing.T) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("GetJobProposalByManagersIDs", []int64{1}).Return([]feeds.JobProposal{
 					{
-						ID:     int64(1),
-						Spec:   `[type=median retries=3 minBackoff="10ms" maxBackoff="10ms" index=0]`,
-						Status: feeds.JobProposalStatusApproved,
+						ID:             int64(100),
+						FeedsManagerID: int64(1),
+						Spec:           `[type=median retries=3 minBackoff="10ms" maxBackoff="10ms" index=0]`,
+						Status:         feeds.JobProposalStatusApproved,
 					},
 				}, nil)
 				f.Mocks.feedsSvc.On("ListManagers").Return([]feeds.FeedsManager{
@@ -108,7 +109,7 @@ func Test_FeedsManagers(t *testing.T) {
 							"isConnectionActive": true,
 							"createdAt": "2021-01-01T00:00:00Z",
 							"jobProposals": [{
-								"id": "1",
+								"id": "100",
 								"spec": "[type=median retries=3 minBackoff=\"10ms\" maxBackoff=\"10ms\" index=0]",
 								"status": "APPROVED"
 							}]


### PR DESCRIPTION
The dataloader was matching by the proposals id, and not it's feeds manager id. This caused the embedded proposals to always return an empty array in the GQL API.

A ticket has been created to add tests for all the dataloaders to prevent this from happening again.