### PR TITLE
Add an id to bridge GQL queries and mutations

### DIFF
--- a/core/web/resolver/bridge.go
+++ b/core/web/resolver/bridge.go
@@ -27,9 +27,14 @@ func NewBridges(bridges []bridges.BridgeType) []*BridgeResolver {
 	return resolvers
 }
 
+// ID resolves the bridge's name as the id (Bridge does not have an id).
+func (r *BridgeResolver) ID() graphql.ID {
+	return graphql.ID(r.bridge.Name.String())
+}
+
 // Name resolves the bridge's name.
 func (r *BridgeResolver) Name() string {
-	return string(r.bridge.Name)
+	return r.bridge.Name.String()
 }
 
 // URL resolves the bridge's url.

--- a/core/web/resolver/bridge_test.go
+++ b/core/web/resolver/bridge_test.go
@@ -23,6 +23,7 @@ func Test_Bridges(t *testing.T) {
 			query GetBridges {
 				bridges {
 					results {
+						id
 						name
 						url
 						confirmations
@@ -63,6 +64,7 @@ func Test_Bridges(t *testing.T) {
 			{
 				"bridges": {
 					"results": [{
+						"id": "bridge1",
 						"name": "bridge1",
 						"url": "https://external.adapter",
 						"confirmations": 1,
@@ -87,8 +89,9 @@ func Test_Bridge(t *testing.T) {
 	var (
 		query = `
 			query GetBridge{
-				bridge(name: "bridge1") {
+				bridge(id: "bridge1") {
 					... on Bridge {
+						id
 						name
 						url
 						confirmations
@@ -127,6 +130,7 @@ func Test_Bridge(t *testing.T) {
 			query: query,
 			result: `{
 				"bridge": {
+					"id": "bridge1",
 					"name": "bridge1",
 					"url": "https://external.adapter",
 					"confirmations": 1,
@@ -166,6 +170,7 @@ func Test_CreateBridge(t *testing.T) {
 				createBridge(input: $input) {
 					... on CreateBridgeSuccess {
 						bridge {
+							id
 							name
 							url
 							confirmations
@@ -218,6 +223,7 @@ func Test_CreateBridge(t *testing.T) {
 				{
 					"createBridge": {
 						"bridge": {
+							"id": "bridge1",
 							"name": "bridge1",
 							"url": "https://external.adapter",
 							"confirmations": 1,
@@ -240,10 +246,11 @@ func Test_UpdateBridge(t *testing.T) {
 	var (
 		name     = bridges.TaskType("bridge1")
 		mutation = `
-			mutation updateBridge($input: UpdateBridgeInput!) {
-				updateBridge(name: "bridge1", input: $input) {
+			mutation updateBridge($id: ID!, $input: UpdateBridgeInput!) {
+				updateBridge(id: $id, input: $input) {
 					... on UpdateBridgeSuccess {
 						bridge {
+							id
 							name
 							url
 							confirmations
@@ -259,6 +266,7 @@ func Test_UpdateBridge(t *testing.T) {
 				}
 			}`
 		variables = map[string]interface{}{
+			"id": "bridge1",
 			"input": map[string]interface{}{
 				"name":                   "bridge-updated",
 				"url":                    "https://external.adapter.new",
@@ -318,6 +326,7 @@ func Test_UpdateBridge(t *testing.T) {
 			result: `{
 				"updateBridge": {
 					"bridge": {
+						"id": "bridge-updated",
 						"name": "bridge-updated",
 						"url": "https://external.adapter.new",
 						"confirmations": 2,
@@ -362,10 +371,11 @@ func Test_DeleteBridgeMutation(t *testing.T) {
 	assert.NoError(t, err)
 
 	mutation := `
-		mutation DeleteBridge($name: String!) {
-			deleteBridge(name: $name) {
+		mutation DeleteBridge($id: ID!) {
+			deleteBridge(id: $id) {
 				... on DeleteBridgeSuccess {
 					bridge {
+						id
 						name
 						url
 						confirmations
@@ -389,7 +399,7 @@ func Test_DeleteBridgeMutation(t *testing.T) {
 		}`
 
 	variables := map[string]interface{}{
-		"name": name.String(),
+		"id": name.String(),
 	}
 
 	testCases := []GQLTestCase{
@@ -418,6 +428,7 @@ func Test_DeleteBridgeMutation(t *testing.T) {
 				{
 					"deleteBridge": {
 						"bridge": {
+							"id": "bridge1",
 							"name": "bridge1",
 							"url": "https://test-url.com",
 							"confirmations": 1,
@@ -432,7 +443,7 @@ func Test_DeleteBridgeMutation(t *testing.T) {
 			authenticated: true,
 			query:         mutation,
 			variables: map[string]interface{}{
-				"name": "][]$$$$324adfas",
+				"id": "][]$$$$324adfas",
 			},
 			result: `
 				{
@@ -447,7 +458,7 @@ func Test_DeleteBridgeMutation(t *testing.T) {
 			authenticated: true,
 			query:         mutation,
 			variables: map[string]interface{}{
-				"name": "bridge1",
+				"id": "bridge1",
 			},
 			before: func(f *gqlTestFramework) {
 				f.Mocks.bridgeORM.On("FindBridge", name).Return(bridges.BridgeType{}, sql.ErrNoRows)
@@ -466,7 +477,7 @@ func Test_DeleteBridgeMutation(t *testing.T) {
 			authenticated: true,
 			query:         mutation,
 			variables: map[string]interface{}{
-				"name": "bridge1",
+				"id": "bridge1",
 			},
 			before: func(f *gqlTestFramework) {
 				f.Mocks.bridgeORM.On("FindBridge", name).Return(bridges.BridgeType{}, nil)

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -171,7 +171,7 @@ type updateBridgeInput struct {
 }
 
 func (r *Resolver) UpdateBridge(ctx context.Context, args struct {
-	Name  string
+	ID    graphql.ID
 	Input updateBridgeInput
 }) (*UpdateBridgePayloadResolver, error) {
 	if err := authenticateUser(ctx); err != nil {
@@ -198,7 +198,7 @@ func (r *Resolver) UpdateBridge(ctx context.Context, args struct {
 		MinimumContractPayment: minContractPayment,
 	}
 
-	taskType, err := bridges.NewTaskType(args.Name)
+	taskType, err := bridges.NewTaskType(string(args.ID))
 	if err != nil {
 		return nil, err
 	}
@@ -364,13 +364,13 @@ func (r *Resolver) DeleteNode(ctx context.Context, args struct {
 }
 
 func (r *Resolver) DeleteBridge(ctx context.Context, args struct {
-	Name string
+	ID graphql.ID
 }) (*DeleteBridgePayloadResolver, error) {
 	if err := authenticateUser(ctx); err != nil {
 		return nil, err
 	}
 
-	taskType, err := bridges.NewTaskType(args.Name)
+	taskType, err := bridges.NewTaskType(string(args.ID))
 	if err != nil {
 		return NewDeleteBridgePayload(nil, err), nil
 	}
@@ -385,7 +385,7 @@ func (r *Resolver) DeleteBridge(ctx context.Context, args struct {
 		return nil, err
 	}
 
-	jobsUsingBridge, err := r.App.JobORM().FindJobIDsWithBridge(args.Name)
+	jobsUsingBridge, err := r.App.JobORM().FindJobIDsWithBridge(string(args.ID))
 	if err != nil {
 		return nil, err
 	}

--- a/core/web/resolver/query.go
+++ b/core/web/resolver/query.go
@@ -15,12 +15,12 @@ import (
 )
 
 // Bridge retrieves a bridges by name.
-func (r *Resolver) Bridge(ctx context.Context, args struct{ Name string }) (*BridgePayloadResolver, error) {
+func (r *Resolver) Bridge(ctx context.Context, args struct{ ID graphql.ID }) (*BridgePayloadResolver, error) {
 	if err := authenticateUser(ctx); err != nil {
 		return nil, err
 	}
 
-	name, err := bridges.NewTaskType(args.Name)
+	name, err := bridges.NewTaskType(string(args.ID))
 	if err != nil {
 		return nil, err
 	}

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -6,7 +6,7 @@ schema {
 }
 
 type Query {
-    bridge(name: String!): BridgePayload!
+    bridge(id: ID!): BridgePayload!
     bridges(offset: Int, limit: Int): BridgesPayload!
     chain(id: ID!): ChainPayload!
     chains(offset: Int, limit: Int): ChainsPayload!
@@ -33,7 +33,7 @@ type Mutation {
     createNode(input: CreateNodeInput!): CreateNodePayload!
     createOCRKeyBundle: CreateOCRKeyBundlePayload!
     createP2PKey: CreateP2PKeyPayload!
-    deleteBridge(name: String!): DeleteBridgePayload!
+    deleteBridge(id: ID!): DeleteBridgePayload!
     deleteNode(id: ID!): DeleteNodePayload!
     deleteOCRKeyBundle(id: ID!): DeleteOCRKeyBundlePayload!
     deleteP2PKey(id: ID!): DeleteP2PKeyPayload!
@@ -42,7 +42,7 @@ type Mutation {
     rejectJobProposal(id: ID!): RejectJobProposalPayload!
     setServicesLogLevels(input: SetServicesLogLevelsInput!): SetServicesLogLevelsPayload!
     setSQLLogging(input: SetSQLLoggingInput!): SetSQLLoggingPayload!
-    updateBridge(name: String!, input: UpdateBridgeInput!): UpdateBridgePayload!
+    updateBridge(id: ID!, input: UpdateBridgeInput!): UpdateBridgePayload!
     updateFeedsManager(id: ID!, input: UpdateFeedsManagerInput!): UpdateFeedsManagerPayload!
     updateJobProposalSpec(id: ID!, input: UpdateJobProposalSpecInput!): UpdateJobProposalSpecPayload!
     updateUserPassword(input: UpdatePasswordInput!): UpdatePasswordPayload!

--- a/core/web/schema/type/bridge.graphql
+++ b/core/web/schema/type/bridge.graphql
@@ -1,4 +1,5 @@
 type Bridge {
+    id: ID!
     name: String!
     url: String!
     confirmations: Int!


### PR DESCRIPTION
Bridge queries were using the name as bridges don't actually have an id. However this can cause issues with caching in the UI, so this commit adds an id to the query which is the same as the name