### PR TITLE
Logger Injection pt. 8

### DIFF
--- a/core/logger/default.go
+++ b/core/logger/default.go
@@ -48,37 +48,44 @@ func InitLogger(newLogger Logger) {
 }
 
 // Warnw logs a debug message and any additional given information.
+// Deprecated
 func Warnw(msg string, keysAndValues ...interface{}) {
 	helper.Warnw(msg, keysAndValues...)
 }
 
 // Errorw logs an error message, any additional given information, and includes
 // stack trace.
+// Deprecated
 func Errorw(msg string, keysAndValues ...interface{}) {
 	helper.Errorw(msg, keysAndValues...)
 }
 
 // Warnf formats and then logs the message as Warn.
+// Deprecated
 func Warnf(format string, values ...interface{}) {
 	helper.Warnf(format, values...)
 }
 
 // Warn logs a message at the warn level.
+// Deprecated
 func Warn(args ...interface{}) {
 	helper.Warn(args...)
 }
 
 // Error logs an error message.
+// Deprecated
 func Error(args ...interface{}) {
 	helper.Error(args...)
 }
 
 // Errorf logs a message at the error level using Sprintf.
+// Deprecated
 func Errorf(format string, values ...interface{}) {
 	helper.Error(fmt.Sprintf(format, values...))
 }
 
 // Fatalf logs a message at the fatal level using Sprintf.
+// Deprecated
 func Fatalf(format string, values ...interface{}) {
 	helper.Fatal(fmt.Sprintf(format, values...))
 }

--- a/core/services/bulletprooftxmanager/models.go
+++ b/core/services/bulletprooftxmanager/models.go
@@ -15,7 +15,6 @@ import (
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
-	"github.com/smartcontractkit/chainlink/core/logger"
 	cnull "github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/services/gas"
 	"github.com/smartcontractkit/chainlink/core/services/pg/datatypes"
@@ -178,7 +177,6 @@ func (a EthTxAttempt) GetSignedTx() (*types.Transaction, error) {
 	s := rlp.NewStream(bytes.NewReader(a.SignedRawTx), 0)
 	signedTx := new(types.Transaction)
 	if err := signedTx.DecodeRLP(s); err != nil {
-		logger.Error("could not decode RLP")
 		return nil, err
 	}
 	return signedTx, nil

--- a/core/services/fluxmonitorv2/flux_monitor.go
+++ b/core/services/fluxmonitorv2/flux_monitor.go
@@ -733,7 +733,7 @@ func (fm *FluxMonitor) respondToNewRoundLog(log flux_aggregator_wrapper.FluxAggr
 		newRoundLogger.Errorw(fmt.Sprintf("error executing new run for job ID %v name %v", fm.spec.JobID, fm.spec.JobName), "err", err)
 		return
 	}
-	result, err := results.FinalResult().SingularResult()
+	result, err := results.FinalResult(newRoundLogger).SingularResult()
 	if err != nil || result.Error != nil {
 		newRoundLogger.Errorw("can't fetch answer", "err", err, "result", result)
 		fm.jobORM.TryRecordError(fm.spec.JobID, "Error polling")
@@ -936,7 +936,7 @@ func (fm *FluxMonitor) pollIfEligible(pollReq PollRequestType, deviationChecker 
 		fm.jobORM.TryRecordError(fm.spec.JobID, "Error polling")
 		return
 	}
-	result, err := results.FinalResult().SingularResult()
+	result, err := results.FinalResult(l).SingularResult()
 	if err != nil || result.Error != nil {
 		l.Errorw("can't fetch answer", "err", err, "result", result)
 		fm.jobORM.TryRecordError(fm.spec.JobID, "Error polling")

--- a/core/services/keystore/p2p.go
+++ b/core/services/keystore/p2p.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/pkg/errors"
 
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/p2pkey"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
@@ -175,7 +174,7 @@ func (ks *p2p) GetOrFirst(id p2pkey.PeerID) (p2pkey.KeyV2, error) {
 	if id != "" {
 		return ks.getByID(id)
 	} else if len(ks.keyRing.P2P) == 1 {
-		logger.Warn("No P2P_PEER_ID set, defaulting to first key in database")
+		ks.logger.Warn("No P2P_PEER_ID set, defaulting to first key in database")
 		for _, key := range ks.keyRing.P2P {
 			return key, nil
 		}

--- a/core/services/offchainreporting/data_source.go
+++ b/core/services/offchainreporting/data_source.go
@@ -53,7 +53,7 @@ func (ds *dataSource) Observe(ctx context.Context) (ocrtypes.Observation, error)
 	var observation ocrtypes.Observation
 	md, err := bridges.MarshalBridgeMetaData(ds.currentAnswer())
 	if err != nil {
-		logger.Warnw("unable to attach metadata for run", "err", err)
+		ds.ocrLogger.Warnw("unable to attach metadata for run", "err", err)
 	}
 
 	vars := pipeline.NewVarsFrom(map[string]interface{}{
@@ -71,7 +71,7 @@ func (ds *dataSource) Observe(ctx context.Context) (ocrtypes.Observation, error)
 	if err != nil {
 		return observation, errors.Wrapf(err, "error executing run for spec ID %v", ds.spec.ID)
 	}
-	finalResult := trrs.FinalResult()
+	finalResult := trrs.FinalResult(ds.ocrLogger)
 
 	// Do the database write in a non-blocking fashion
 	// so we can return the observation results immediately.

--- a/core/services/pipeline/common.go
+++ b/core/services/pipeline/common.go
@@ -186,7 +186,7 @@ type TaskRunResults []TaskRunResult
 
 // FinalResult pulls the FinalResult for the pipeline_run from the task runs
 // It needs to respect the output index of each task
-func (trrs TaskRunResults) FinalResult() FinalResult {
+func (trrs TaskRunResults) FinalResult(l logger.Logger) FinalResult {
 	var found bool
 	var fr FinalResult
 	sort.Slice(trrs, func(i, j int) bool {
@@ -202,8 +202,7 @@ func (trrs TaskRunResults) FinalResult() FinalResult {
 	}
 
 	if !found {
-		logger.Errorw("expected at least one task to be final", "tasks", trrs)
-		panic("expected at least one task to be final")
+		l.Panicw("Expected at least one task to be final", "tasks", trrs)
 	}
 	return fr
 }

--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -445,7 +445,7 @@ func (r *runner) ExecuteAndInsertFinishedRun(ctx context.Context, spec Spec, var
 		return 0, finalResult, errors.Wrapf(err, "error executing run for spec ID %v", spec.ID)
 	}
 
-	finalResult = trrs.FinalResult()
+	finalResult = trrs.FinalResult(l)
 
 	// don't insert if we exited early
 	if run.FailEarly {

--- a/core/services/vrf/listener_v2.go
+++ b/core/services/vrf/listener_v2.go
@@ -435,12 +435,12 @@ func (lsn *listenerV2) getMaxLinkForFulfillment(maxGasPrice *big.Int, req pendin
 			"err", err, "max gas price", maxGasPrice, "reqID", req.req.RequestId)
 		return maxLink, run, payload, gaslimit, errors.New("run errored")
 	}
-	if len(trrs.FinalResult().Values) != 1 {
+	if len(trrs.FinalResult(lsn.l).Values) != 1 {
 		lsn.l.Errorw("Unexpected number of outputs", "err", err)
 		return maxLink, run, payload, gaslimit, errors.New("unexpected number of outputs")
 	}
 	// Run succeeded, we expect a byte array representing the billing amount
-	b, ok := trrs.FinalResult().Values[0].([]uint8)
+	b, ok := trrs.FinalResult(lsn.l).Values[0].([]uint8)
 	if !ok {
 		lsn.l.Errorw("Unexpected type")
 		return maxLink, run, payload, gaslimit, errors.New("expected []uint8 final result")

--- a/core/web/presenters/vrf_key.go
+++ b/core/web/presenters/vrf_key.go
@@ -17,10 +17,10 @@ func (VRFKeyResource) GetName() string {
 	return "encryptedVRFKeys"
 }
 
-func NewVRFKeyResource(key vrfkey.KeyV2) *VRFKeyResource {
+func NewVRFKeyResource(key vrfkey.KeyV2, lggr logger.Logger) *VRFKeyResource {
 	uncompressed, err := key.PublicKey.StringUncompressed()
 	if err != nil {
-		logger.Error("unable to get uncompressed pk", "err", err)
+		lggr.Errorw("Unable to get uncompressed pk", "err", err)
 	}
 	return &VRFKeyResource{
 		JAID:         NewJAID(key.PublicKey.String()),
@@ -30,10 +30,10 @@ func NewVRFKeyResource(key vrfkey.KeyV2) *VRFKeyResource {
 	}
 }
 
-func NewVRFKeyResources(keys []vrfkey.KeyV2) []VRFKeyResource {
+func NewVRFKeyResources(keys []vrfkey.KeyV2, lggr logger.Logger) []VRFKeyResource {
 	rs := []VRFKeyResource{}
 	for _, key := range keys {
-		rs = append(rs, *NewVRFKeyResource(key))
+		rs = append(rs, *NewVRFKeyResource(key, lggr))
 	}
 
 	return rs

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -453,7 +453,7 @@ func loggerFunc(lggr logger.Logger) gin.HandlerFunc {
 			"status", c.Writer.Status(),
 			"path", c.Request.URL.Path,
 			"query", redact(c.Request.URL.Query()),
-			"body", readBody(rdr),
+			"body", readBody(rdr, lggr),
 			"clientIP", c.ClientIP(),
 			"errors", c.Errors.String(),
 			"servedAt", end.Format("2006-01-02 15:04:05"),
@@ -479,11 +479,11 @@ func uiCorsHandler(config WebSecurityConfig) gin.HandlerFunc {
 	return cors.New(c)
 }
 
-func readBody(reader io.Reader) string {
+func readBody(reader io.Reader, lggr logger.Logger) string {
 	buf := new(bytes.Buffer)
 	_, err := buf.ReadFrom(reader)
 	if err != nil {
-		logger.Warn("unable to read from body for sanitization: ", err)
+		lggr.Warn("unable to read from body for sanitization: ", err)
 		return "*FAILED TO READ BODY*"
 	}
 
@@ -493,7 +493,7 @@ func readBody(reader io.Reader) string {
 
 	s, err := readSanitizedJSON(buf)
 	if err != nil {
-		logger.Warn("unable to sanitize json for logging: ", err)
+		lggr.Warn("unable to sanitize json for logging: ", err)
 		return "*FAILED TO READ BODY*"
 	}
 	return s

--- a/core/web/vrf_keys_controller.go
+++ b/core/web/vrf_keys_controller.go
@@ -24,7 +24,7 @@ func (vrfkc *VRFKeysController) Index(c *gin.Context) {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
 	}
-	jsonAPIResponse(c, presenters.NewVRFKeyResources(keys), "vrfKey")
+	jsonAPIResponse(c, presenters.NewVRFKeyResources(keys, vrfkc.App.GetLogger()), "vrfKey")
 }
 
 // Create and return a VRF key
@@ -36,7 +36,7 @@ func (vrfkc *VRFKeysController) Create(c *gin.Context) {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
 	}
-	jsonAPIResponse(c, presenters.NewVRFKeyResource(pk), "vrfKey")
+	jsonAPIResponse(c, presenters.NewVRFKeyResource(pk, vrfkc.App.GetLogger()), "vrfKey")
 }
 
 // Delete a VRF key
@@ -55,7 +55,7 @@ func (vrfkc *VRFKeysController) Delete(c *gin.Context) {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
 	}
-	jsonAPIResponse(c, presenters.NewVRFKeyResource(key), "vrfKey")
+	jsonAPIResponse(c, presenters.NewVRFKeyResource(key, vrfkc.App.GetLogger()), "vrfKey")
 }
 
 // Import imports a VRF key
@@ -76,7 +76,7 @@ func (vrfkc *VRFKeysController) Import(c *gin.Context) {
 		return
 	}
 
-	jsonAPIResponse(c, presenters.NewVRFKeyResource(key), "vrfKey")
+	jsonAPIResponse(c, presenters.NewVRFKeyResource(key, vrfkc.App.GetLogger()), "vrfKey")
 }
 
 // Export exports a VRF key


### PR DESCRIPTION
Story details: https://app.shortcut.com/chainlinklabs/story/18500

This is the last _standard_ logger injection PR. After this change, the only remaining uses of the default helper methods are from general and chain-specific config parsing/validation. Converting those will be a little more nuanced, since the logger is normally constructed from an already validated configuration.