### PR TITLE
Implement `DeleteChain` mutation

### DIFF
--- a/core/web/resolver/chain.go
+++ b/core/web/resolver/chain.go
@@ -141,3 +141,34 @@ func NewCreateChainSuccess(chain *types.Chain) *CreateChainSuccessResolver {
 func (r *CreateChainSuccessResolver) Chain() *ChainResolver {
 	return NewChain(*r.chain)
 }
+
+type DeleteChainPayloadResolver struct {
+	chain *types.Chain
+	NotFoundErrorUnionType
+}
+
+func NewDeleteChainPayload(chain *types.Chain, err error) *DeleteChainPayloadResolver {
+	e := NotFoundErrorUnionType{err: err, message: "chain not found", isExpectedErrorFn: nil}
+
+	return &DeleteChainPayloadResolver{chain: chain, NotFoundErrorUnionType: e}
+}
+
+func (r *DeleteChainPayloadResolver) ToDeleteChainSuccess() (*DeleteChainSuccessResolver, bool) {
+	if r.chain == nil {
+		return nil, false
+	}
+
+	return NewDeleteChainSuccess(*r.chain), true
+}
+
+type DeleteChainSuccessResolver struct {
+	chain types.Chain
+}
+
+func NewDeleteChainSuccess(chain types.Chain) *DeleteChainSuccessResolver {
+	return &DeleteChainSuccessResolver{chain: chain}
+}
+
+func (r *DeleteChainSuccessResolver) Chain() *ChainResolver {
+	return NewChain(r.chain)
+}

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -38,6 +38,7 @@ type Mutation {
     createP2PKey: CreateP2PKeyPayload!
     deleteAPIToken(input: DeleteAPITokenInput!): DeleteAPITokenPayload!
     deleteBridge(id: ID!): DeleteBridgePayload!
+    deleteChain(id: ID!): DeleteChainPayload!
     deleteNode(id: ID!): DeleteNodePayload!
     deleteOCRKeyBundle(id: ID!): DeleteOCRKeyBundlePayload!
     deleteP2PKey(id: ID!): DeleteP2PKeyPayload!

--- a/core/web/schema/type/chain.graphql
+++ b/core/web/schema/type/chain.graphql
@@ -25,3 +25,9 @@ type CreateChainSuccess {
 }
 
 union CreateChainPayload = CreateChainSuccess | InputErrors
+
+type DeleteChainSuccess {
+    chain: Chain!
+}
+
+union DeleteChainPayload = DeleteChainSuccess | NotFoundError


### PR DESCRIPTION
Closes: https://app.shortcut.com/chainlinklabs/story/21715/add-a-deletechain-mutation

This aims to enable a mutation endpoint to delete chains