### PR TITLE
Fixes GQL API url when env var is not provided on build

### DIFF
--- a/operator_ui/src/apollo.ts
+++ b/operator_ui/src/apollo.ts
@@ -1,8 +1,10 @@
 import { ApolloClient, InMemoryCache, HttpLink } from '@apollo/client'
 import generatedIntrospection from 'src/types/generated/possibleTypes'
 
+const baseURL = process.env.CHAINLINK_BASEURL ?? location.origin
+
 const httpLink = new HttpLink({
-  uri: `${process.env.CHAINLINK_BASEURL}/query`,
+  uri: `${baseURL}/query`,
   credentials: 'include',
 })
 


### PR DESCRIPTION
When the CHAINLINK_BASEURL is not provided, the Apollo client would use the `localhost:6688/undefined/query`
as the query uri. This commit fixes the base url to default to the location origin if a environment variable
is not provided