### PR TITLE
Do not refetch blocks below EVM_FINALITY_DEPTH in BlockHistoryEstimator

### DIFF
--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -841,13 +841,10 @@ func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 
 	// BlockHistoryEstimator new blocks
 	ethClient.On("BatchCallContext", mock.Anything, mock.MatchedBy(func(b []rpc.BatchElem) bool {
-		return len(b) == 2 &&
-			b[0].Method == "eth_getBlockByNumber" && b[0].Args[0] == "0x2a" &&
-			b[1].Method == "eth_getBlockByNumber" && b[1].Args[0] == "0x2b"
+		return len(b) == 1 && b[0].Method == "eth_getBlockByNumber" && b[0].Args[0] == "0x2b"
 	})).Return(nil).Run(func(args mock.Arguments) {
 		elems := args.Get(1).([]rpc.BatchElem)
 		elems[0].Result = &b43
-		elems[1].Result = &b42
 	})
 
 	// HeadTracker backfill

--- a/core/services/gas/block_history_estimator.go
+++ b/core/services/gas/block_history_estimator.go
@@ -115,9 +115,6 @@ func (b *BlockHistoryEstimator) OnNewLongestChain(ctx context.Context, head *eth
 func (b *BlockHistoryEstimator) Start() error {
 	return b.StartOnce("BlockHistoryEstimator", func() error {
 		b.logger.Debugw("starting")
-		if uint32(b.config.BlockHistoryEstimatorBlockHistorySize()) > b.config.EvmFinalityDepth() {
-			b.logger.Warnf("GAS_UPDATER_BLOCK_HISTORY_SIZE=%v is greater than ETH_FINALITY_DEPTH=%v, blocks deeper than finality depth will be refetched on every block history estimator cycle, causing unnecessary load on the eth node. Consider decreasing GAS_UPDATER_BLOCK_HISTORY_SIZE or increasing ETH_FINALITY_DEPTH", b.config.BlockHistoryEstimatorBlockHistorySize(), b.config.EvmFinalityDepth())
-		}
 
 		ctx, cancel := context.WithTimeout(b.ctx, maxStartTime)
 		defer cancel()
@@ -314,9 +311,11 @@ func (b *BlockHistoryEstimator) FetchBlocks(ctx context.Context, head *eth.Head)
 	for _, block := range b.rollingBlockHistory {
 		// Make a best-effort to be re-org resistant using the head
 		// chain, refetch blocks that got re-org'd out.
-		// NOTE: Any blocks older than the oldest block in the provided chain
-		// will be also be refetched.
-		if head.IsInChain(block.Hash) {
+		// NOTE: Any blocks in the history that are older than the oldest block
+		// in the provided chain will be assumed final.
+		if block.Number < head.EarliestInChain().Number {
+			blocks[block.Number] = block
+		} else if head.IsInChain(block.Hash) {
 			blocks[block.Number] = block
 		}
 	}


### PR DESCRIPTION
- Prevents spurious warnings on chains with short EVM_FINALITY_DEPTH
  e.g. AVAX