### PR TITLE
Improve listener logging

### DIFF
--- a/core/services/pipeline/models.go
+++ b/core/services/pipeline/models.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -137,6 +138,18 @@ func (re RunErrors) HasError() bool {
 		}
 	}
 	return false
+}
+
+// ToError coalesces all non-nil errors into a single error object.
+// This is useful for logging.
+func (re RunErrors) ToError() error {
+	msgBuilder := strings.Builder{}
+	for i, e := range re {
+		if !e.IsZero() {
+			msgBuilder.WriteString(fmt.Sprintf("error %d (%s), ", i+1, e.String))
+		}
+	}
+	return errors.New(msgBuilder.String())
 }
 
 type ResumeRequest struct {

--- a/core/services/pipeline/models_test.go
+++ b/core/services/pipeline/models_test.go
@@ -1,13 +1,15 @@
 package pipeline_test
 
 import (
-	"errors"
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/chainlink/core/services/pipeline"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
+
+	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 )
 
 func TestRunStatus(t *testing.T) {
@@ -72,4 +74,13 @@ func TestRun_Status(t *testing.T) {
 			assert.Equal(t, tc.want, tc.run.Status())
 		})
 	}
+}
+
+func TestRunErrors_ToError(t *testing.T) {
+	runErrors := pipeline.RunErrors{}
+	runErrors = append(runErrors, null.NewString("bad thing happened", true))
+	runErrors = append(runErrors, null.NewString("pretty bad thing happened", true))
+	runErrors = append(runErrors, null.NewString("", false))
+	expected := errors.New("error 1 (bad thing happened), error 2 (pretty bad thing happened), ")
+	require.Equal(t, expected.Error(), runErrors.ToError().Error())
 }

--- a/core/services/pipeline/models_test.go
+++ b/core/services/pipeline/models_test.go
@@ -81,6 +81,6 @@ func TestRunErrors_ToError(t *testing.T) {
 	runErrors = append(runErrors, null.NewString("bad thing happened", true))
 	runErrors = append(runErrors, null.NewString("pretty bad thing happened", true))
 	runErrors = append(runErrors, null.NewString("", false))
-	expected := errors.New("error 1 (bad thing happened), error 2 (pretty bad thing happened), ")
+	expected := errors.New("bad thing happened; pretty bad thing happened")
 	require.Equal(t, expected.Error(), runErrors.ToError().Error())
 }

--- a/core/services/vrf/listener_v2.go
+++ b/core/services/vrf/listener_v2.go
@@ -307,16 +307,22 @@ func (lsn *listenerV2) processRequestsPerSub(
 		return
 	}
 	lggr := lsn.l.With(
-		"sub", reqs[0].req.SubId,
+		"subID", reqs[0].req.SubId,
 		"maxGasPrice", maxGasPrice.String(),
 		"reqs", len(reqs),
 		"startBalance", startBalance.String(),
 		"startBalanceNoReservedLink", startBalanceNoReserveLink.String(),
 	)
 	lggr.Infow("Processing requests for subscription")
+
 	// Attempt to process every request, break if we run out of balance
 	var processed = make(map[string]struct{})
+	// Keep track of the number of times we process each request - this could be > 1
+	// especially if we run into re-orgs. This is exclusively for logging purposes.
+	uniqueRequests := map[string]int{}
 	for _, req := range reqs {
+		uniqueRequests[req.req.RequestId.String()]++
+
 		// This check to see if the log was consumed needs to be in the same
 		// goroutine as the mark consumed to avoid processing duplicates.
 		if !lsn.shouldProcessLog(req.lb) {
@@ -324,10 +330,14 @@ func (lsn *listenerV2) processRequestsPerSub(
 		}
 
 		vrfRequest := req.req
+		rlog := lggr.With(
+			"reqID", vrfRequest.RequestId.String(),
+			"txHash", vrfRequest.Raw.TxHash,
+		)
 
 		// Check if we can ignore the request due to it's age.
 		if time.Now().UTC().Sub(req.utcTimestamp) >= maxRequestAge {
-			lggr.Infow("Request too old, dropping it", "reqID", vrfRequest.RequestId.String())
+			rlog.Infow("Request too old, dropping it")
 			lsn.markLogAsConsumed(req.lb)
 			processed[vrfRequest.RequestId.String()] = struct{}{}
 			continue
@@ -337,11 +347,11 @@ func (lsn *listenerV2) processRequestsPerSub(
 		// If so we just mark it completed
 		callback, err := lsn.coordinator.GetCommitment(nil, vrfRequest.RequestId)
 		if err != nil {
-			lggr.Errorw("Unable to check if already fulfilled, processing anyways", "err", err, "txHash", vrfRequest.Raw.TxHash)
+			rlog.Errorw("Unable to check if already fulfilled, processing anyways", "err", err)
 		} else if utils.IsEmpty(callback[:]) {
 			// If seedAndBlockNumber is zero then the response has been fulfilled
 			// and we should skip it
-			lggr.Infow("Request already fulfilled", "txHash", vrfRequest.Raw.TxHash, "subID", vrfRequest.SubId, "callback", callback)
+			rlog.Infow("Request already fulfilled", "callback", callback)
 			lsn.markLogAsConsumed(req.lb)
 			processed[vrfRequest.RequestId.String()] = struct{}{}
 			continue
@@ -350,15 +360,16 @@ func (lsn *listenerV2) processRequestsPerSub(
 		// The ethcall will error if there is currently insufficient balance onchain.
 		maxLink, run, payload, gaslimit, err := lsn.getMaxLinkForFulfillment(maxGasPrice, req)
 		if err != nil {
+			rlog.Warnw("Unable to get max link for fulfillment, skipping request", "err", err)
 			continue
 		}
 		if startBalance.Cmp(maxLink) < 0 {
 			// Insufficient funds, have to wait for a user top up
 			// leave it unprocessed for now
-			lggr.Infow("Insufficient link balance to fulfill a request, breaking", "balance", startBalance, "maxLink", maxLink)
+			rlog.Infow("Insufficient link balance to fulfill a request, breaking", "maxLink", maxLink)
 			break
 		}
-		lggr.Infow("Enqueuing fulfillment", "balance", startBalance, "reqID", vrfRequest.RequestId)
+		rlog.Infow("Enqueuing fulfillment")
 		// We have enough balance to service it, lets enqueue for bptxm
 		err = postgres.NewGormTransactionManager(lsn.db).Transact(func(ctx context.Context) error {
 			tx := postgres.TxFromContext(ctx, lsn.db)
@@ -384,10 +395,7 @@ func (lsn *listenerV2) processRequestsPerSub(
 			return err
 		})
 		if err != nil {
-			lggr.Errorw("Error enqueuing fulfillment, requeuing request",
-				"err", err,
-				"reqID", vrfRequest.RequestId,
-				"txHash", vrfRequest.Raw.TxHash)
+			rlog.Errorw("Error enqueuing fulfillment, requeuing request", "err", err)
 			continue
 		}
 		// If we successfully enqueued for the bptxm, subtract that balance
@@ -410,7 +418,9 @@ func (lsn *listenerV2) processRequestsPerSub(
 	lggr.Infow("Finished processing for sub",
 		"total reqs", len(reqs),
 		"total processed", len(processed),
-		"total remaining", len(toKeep))
+		"total remaining", len(toKeep),
+		"total unique", len(uniqueRequests),
+	)
 }
 
 // Here we use the pipeline to parse the log, generate a vrf response
@@ -445,17 +455,17 @@ func (lsn *listenerV2) getMaxLinkForFulfillment(maxGasPrice *big.Int, req pendin
 	// The call task will fail if there are insufficient funds
 	if run.AllErrors.HasError() {
 		lsn.l.Warnw("Simulation errored, possibly insufficient funds. Request will remain unprocessed until funds are available",
-			"err", err, "max gas price", maxGasPrice, "reqID", req.req.RequestId)
-		return maxLink, run, payload, gaslimit, errors.New("run errored")
+			"err", run.AllErrors.ToError(), "max gas price", maxGasPrice, "reqID", req.req.RequestId)
+		return maxLink, run, payload, gaslimit, errors.Wrap(run.AllErrors.ToError(), "simulation errored")
 	}
 	if len(trrs.FinalResult().Values) != 1 {
-		lsn.l.Errorw("Unexpected number of outputs", "err", err)
+		lsn.l.Errorw("Unexpected number of outputs", "expectedNumOutputs", 1, "actualNumOutputs", len(trrs.FinalResult().Values))
 		return maxLink, run, payload, gaslimit, errors.New("unexpected number of outputs")
 	}
 	// Run succeeded, we expect a byte array representing the billing amount
 	b, ok := trrs.FinalResult().Values[0].([]uint8)
 	if !ok {
-		lsn.l.Errorw("Unexpected type")
+		lsn.l.Errorw("Unexpected type, expected []uint8 final result")
 		return maxLink, run, payload, gaslimit, errors.New("expected []uint8 final result")
 	}
 	maxLink = utils.HexToBig(hexutil.Encode(b)[2:])

--- a/core/services/vrf/listener_v2.go
+++ b/core/services/vrf/listener_v2.go
@@ -317,12 +317,7 @@ func (lsn *listenerV2) processRequestsPerSub(
 
 	// Attempt to process every request, break if we run out of balance
 	var processed = make(map[string]struct{})
-	// Keep track of the number of times we process each request - this could be > 1
-	// especially if we run into re-orgs. This is exclusively for logging purposes.
-	uniqueRequests := map[string]int{}
 	for _, req := range reqs {
-		uniqueRequests[req.req.RequestId.String()]++
-
 		// This check to see if the log was consumed needs to be in the same
 		// goroutine as the mark consumed to avoid processing duplicates.
 		if !lsn.shouldProcessLog(req.lb) {
@@ -419,7 +414,7 @@ func (lsn *listenerV2) processRequestsPerSub(
 		"total reqs", len(reqs),
 		"total processed", len(processed),
 		"total remaining", len(toKeep),
-		"total unique", len(uniqueRequests),
+		"total unique", len(toRequestSet(reqs)),
 	)
 }
 
@@ -629,4 +624,12 @@ func (lsn *listenerV2) HandleLog(lb log.Broadcast) {
 // Job complies with log.Listener
 func (lsn *listenerV2) JobID() int32 {
 	return lsn.job.ID
+}
+
+func toRequestSet(reqs []pendingRequest) map[string]struct{} {
+	s := map[string]struct{}{}
+	for _, r := range reqs {
+		s[r.req.RequestId.String()] = struct{}{}
+	}
+	return s
 }


### PR DESCRIPTION
* Add tx hash to log fields
* Add simulation revert reason to logs + include it in a wrapped error
  that is returned from getMaxLinkForFulfillment
* Log number of unique requests processed in case there is a re-org and
  we get somewhat cryptic error messages.

Cherry picked from #5555 but merging into `vrfv2-fixes` rather than `develop`. #5555 is merging into develop.