### PR TITLE
hotfix: log broadcaster duplicates

### DIFF
--- a/core/services/log/orm.go
+++ b/core/services/log/orm.go
@@ -214,10 +214,10 @@ type LogBroadcastAsKey struct {
 	JobId     int32
 }
 
-func NewLogBroadcastAsKey(log types.Log, listener Listener) LogBroadcastAsKey {
+func NewLogBroadcastAsKey(log types.Log, jobID int32) LogBroadcastAsKey {
 	return LogBroadcastAsKey{
 		log.BlockHash,
 		log.Index,
-		listener.JobID(),
+		jobID,
 	}
 }

--- a/core/services/log/pool_test.go
+++ b/core/services/log/pool_test.go
@@ -1,0 +1,19 @@
+package log
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_logPool_addLog(t *testing.T) {
+	p := newLogPool()
+	l := types.Log{BlockHash: common.BigToHash(big.NewInt(123456)), Index: 42}
+	p.addLog(l)
+	require.Len(t, p.logsByBlockHash[l.BlockHash], 1)
+	p.addLog(l)
+	require.Len(t, p.logsByBlockHash[l.BlockHash], 1)
+}


### PR DESCRIPTION
- Use `Listener.JobID int32` for map keys instead of just `Listener interface{}` to prevent duplicate registration
- Deduplicate internal log storage to prevent duplicate `Listener.HandleLog` calls