### PR TITLE
Implement `GetJobRun` query

### DIFF
--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -452,7 +452,7 @@ func Test_FindJob(t *testing.T) {
 	})
 }
 
-func Test_JobsByPipelineSpecIDs(t *testing.T) {
+func Test_FindJobsByPipelineSpecIDs(t *testing.T) {
 	t.Parallel()
 
 	config := cltest.NewTestGeneralConfig(t)
@@ -471,7 +471,7 @@ func Test_JobsByPipelineSpecIDs(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("with jobs", func(t *testing.T) {
-		jbs, err := orm.JobsByPipelineSpecIDs([]int32{jb.PipelineSpecID})
+		jbs, err := orm.FindJobsByPipelineSpecIDs([]int32{jb.PipelineSpecID})
 		require.NoError(t, err)
 		assert.Len(t, jbs, 1)
 
@@ -484,7 +484,7 @@ func Test_JobsByPipelineSpecIDs(t *testing.T) {
 	})
 
 	t.Run("without jobs", func(t *testing.T) {
-		jbs, err := orm.JobsByPipelineSpecIDs([]int32{-1})
+		jbs, err := orm.FindJobsByPipelineSpecIDs([]int32{-1})
 		require.NoError(t, err)
 		assert.Len(t, jbs, 0)
 	})

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -464,19 +464,7 @@ func Test_JobsByPipelineSpecIDs(t *testing.T) {
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: config})
 	orm := job.NewTestORM(t, db, cc, pipelineORM, keyStore, config)
 
-	_, bridge := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, config)
-	_, bridge2 := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, config)
-
-	externalJobID := uuid.NewV4()
-	_, address := cltest.MustInsertRandomKey(t, keyStore.Eth())
-	jb, err := offchainreporting.ValidatedOracleSpecToml(cc,
-		testspecs.GenerateOCRSpec(testspecs.OCRSpecParams{
-			JobID:              externalJobID.String(),
-			TransmitterAddress: address.Hex(),
-			DS1BridgeName:      bridge.Name.String(),
-			DS2BridgeName:      bridge2.Name.String(),
-		}).Toml(),
-	)
+	jb, err := directrequest.ValidatedDirectRequestSpec(testspecs.DirectRequestSpec)
 	require.NoError(t, err)
 
 	err = orm.CreateJob(&jb)
@@ -493,8 +481,6 @@ func Test_JobsByPipelineSpecIDs(t *testing.T) {
 		require.Greater(t, jbs[0].PipelineSpecID, int32(0))
 		require.Equal(t, jb.PipelineSpecID, jbs[0].PipelineSpecID)
 		require.NotNil(t, jbs[0].PipelineSpec)
-		require.NotNil(t, jbs[0].OffchainreportingOracleSpecID)
-		require.NotNil(t, jbs[0].OffchainreportingOracleSpec)
 	})
 
 	t.Run("without jobs", func(t *testing.T) {
@@ -739,19 +725,7 @@ func Test_FindPipelineRunByID(t *testing.T) {
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: config})
 	orm := job.NewTestORM(t, db, cc, pipelineORM, keyStore, config)
 
-	_, bridge := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, config)
-	_, bridge2 := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, config)
-
-	externalJobID := uuid.NewV4()
-	_, address := cltest.MustInsertRandomKey(t, keyStore.Eth())
-	jb, err := offchainreporting.ValidatedOracleSpecToml(cc,
-		testspecs.GenerateOCRSpec(testspecs.OCRSpecParams{
-			JobID:              externalJobID.String(),
-			TransmitterAddress: address.Hex(),
-			DS1BridgeName:      bridge.Name.String(),
-			DS2BridgeName:      bridge2.Name.String(),
-		}).Toml(),
-	)
+	jb, err := directrequest.ValidatedDirectRequestSpec(testspecs.DirectRequestSpec)
 	require.NoError(t, err)
 
 	err = orm.CreateJob(&jb)

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -2,6 +2,7 @@ package job_test
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 	"time"
 
@@ -451,6 +452,58 @@ func Test_FindJob(t *testing.T) {
 	})
 }
 
+func Test_JobsByPipelineSpecIDs(t *testing.T) {
+	t.Parallel()
+
+	config := cltest.NewTestGeneralConfig(t)
+	db := pgtest.NewSqlxDB(t)
+	keyStore := cltest.NewKeyStore(t, db, config)
+	keyStore.OCR().Add(cltest.DefaultOCRKey)
+
+	pipelineORM := pipeline.NewORM(db, logger.TestLogger(t), config)
+	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: config})
+	orm := job.NewTestORM(t, db, cc, pipelineORM, keyStore, config)
+
+	_, bridge := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, config)
+	_, bridge2 := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, config)
+
+	externalJobID := uuid.NewV4()
+	_, address := cltest.MustInsertRandomKey(t, keyStore.Eth())
+	jb, err := offchainreporting.ValidatedOracleSpecToml(cc,
+		testspecs.GenerateOCRSpec(testspecs.OCRSpecParams{
+			JobID:              externalJobID.String(),
+			TransmitterAddress: address.Hex(),
+			DS1BridgeName:      bridge.Name.String(),
+			DS2BridgeName:      bridge2.Name.String(),
+		}).Toml(),
+	)
+	require.NoError(t, err)
+
+	err = orm.CreateJob(&jb)
+	require.NoError(t, err)
+
+	t.Run("with jobs", func(t *testing.T) {
+		jbs, err := orm.JobsByPipelineSpecIDs([]int32{jb.PipelineSpecID})
+		require.NoError(t, err)
+		assert.Len(t, jbs, 1)
+
+		assert.Equal(t, jb.ID, jbs[0].ID)
+		assert.Equal(t, jb.Name, jbs[0].Name)
+
+		require.Greater(t, jbs[0].PipelineSpecID, int32(0))
+		require.Equal(t, jb.PipelineSpecID, jbs[0].PipelineSpecID)
+		require.NotNil(t, jbs[0].PipelineSpec)
+		require.NotNil(t, jbs[0].OffchainreportingOracleSpecID)
+		require.NotNil(t, jbs[0].OffchainreportingOracleSpec)
+	})
+
+	t.Run("without jobs", func(t *testing.T) {
+		jbs, err := orm.JobsByPipelineSpecIDs([]int32{-1})
+		require.NoError(t, err)
+		assert.Len(t, jbs, 0)
+	})
+}
+
 func Test_FindPipelineRuns(t *testing.T) {
 	t.Parallel()
 
@@ -662,6 +715,61 @@ func Test_FindPipelineRunsByIDs(t *testing.T) {
 		require.Len(t, actual, 1)
 
 		actualRun := actual[0]
+		// Test pipeline run fields
+		assert.Equal(t, run.State, actualRun.State)
+		assert.Equal(t, run.PipelineSpecID, actualRun.PipelineSpecID)
+
+		// Test preloaded pipeline spec
+		assert.Equal(t, jb.PipelineSpec.ID, actualRun.PipelineSpec.ID)
+		assert.Equal(t, jb.ID, actualRun.PipelineSpec.JobID)
+	})
+}
+
+func Test_FindPipelineRunByID(t *testing.T) {
+	t.Parallel()
+
+	config := cltest.NewTestGeneralConfig(t)
+	db := pgtest.NewSqlxDB(t)
+
+	keyStore := cltest.NewKeyStore(t, db, config)
+	err := keyStore.OCR().Add(cltest.DefaultOCRKey)
+	require.NoError(t, err)
+
+	pipelineORM := pipeline.NewORM(db, logger.TestLogger(t), config)
+	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: config})
+	orm := job.NewTestORM(t, db, cc, pipelineORM, keyStore, config)
+
+	_, bridge := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, config)
+	_, bridge2 := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, config)
+
+	externalJobID := uuid.NewV4()
+	_, address := cltest.MustInsertRandomKey(t, keyStore.Eth())
+	jb, err := offchainreporting.ValidatedOracleSpecToml(cc,
+		testspecs.GenerateOCRSpec(testspecs.OCRSpecParams{
+			JobID:              externalJobID.String(),
+			TransmitterAddress: address.Hex(),
+			DS1BridgeName:      bridge.Name.String(),
+			DS2BridgeName:      bridge2.Name.String(),
+		}).Toml(),
+	)
+	require.NoError(t, err)
+
+	err = orm.CreateJob(&jb)
+	require.NoError(t, err)
+
+	t.Run("with no pipeline run", func(t *testing.T) {
+		run, err := orm.FindPipelineRunByID(-1)
+		assert.Equal(t, run, pipeline.Run{})
+		require.ErrorIs(t, err, sql.ErrNoRows)
+	})
+
+	t.Run("with a pipeline run", func(t *testing.T) {
+		run := mustInsertPipelineRun(t, pipelineORM, jb)
+
+		actual, err := orm.FindPipelineRunByID(run.ID)
+		require.NoError(t, err)
+
+		actualRun := actual
 		// Test pipeline run fields
 		assert.Equal(t, run.State, actualRun.State)
 		assert.Equal(t, run.PipelineSpecID, actualRun.PipelineSpecID)

--- a/core/services/job/mocks/orm.go
+++ b/core/services/job/mocks/orm.go
@@ -234,6 +234,29 @@ func (_m *ORM) FindJobs(offset int, limit int) ([]job.Job, int, error) {
 	return r0, r1, r2
 }
 
+// FindJobsByPipelineSpecIDs provides a mock function with given fields: ids
+func (_m *ORM) FindJobsByPipelineSpecIDs(ids []int32) ([]job.Job, error) {
+	ret := _m.Called(ids)
+
+	var r0 []job.Job
+	if rf, ok := ret.Get(0).(func([]int32) []job.Job); ok {
+		r0 = rf(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]job.Job)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]int32) error); ok {
+		r1 = rf(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FindPipelineRunByID provides a mock function with given fields: id
 func (_m *ORM) FindPipelineRunByID(id int64) (pipeline.Run, error) {
 	ret := _m.Called(id)
@@ -369,29 +392,6 @@ func (_m *ORM) InsertWebhookSpec(webhookSpec *job.WebhookSpec, qopts ...pg.QOpt)
 	}
 
 	return r0
-}
-
-// JobsByPipelineSpecIDs provides a mock function with given fields: ids
-func (_m *ORM) JobsByPipelineSpecIDs(ids []int32) ([]job.Job, error) {
-	ret := _m.Called(ids)
-
-	var r0 []job.Job
-	if rf, ok := ret.Get(0).(func([]int32) []job.Job); ok {
-		r0 = rf(ids)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]job.Job)
-		}
-	}
-
-	var r1 error
-	if rf, ok := ret.Get(1).(func([]int32) error); ok {
-		r1 = rf(ids)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
 }
 
 // PipelineRuns provides a mock function with given fields: jobID, offset, size

--- a/core/services/job/mocks/orm.go
+++ b/core/services/job/mocks/orm.go
@@ -234,6 +234,27 @@ func (_m *ORM) FindJobs(offset int, limit int) ([]job.Job, int, error) {
 	return r0, r1, r2
 }
 
+// FindPipelineRunByID provides a mock function with given fields: id
+func (_m *ORM) FindPipelineRunByID(id int64) (pipeline.Run, error) {
+	ret := _m.Called(id)
+
+	var r0 pipeline.Run
+	if rf, ok := ret.Get(0).(func(int64) pipeline.Run); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Get(0).(pipeline.Run)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int64) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // FindPipelineRunIDsByJobID provides a mock function with given fields: jobID, offset, limit
 func (_m *ORM) FindPipelineRunIDsByJobID(jobID int32, offset int, limit int) ([]int64, error) {
 	ret := _m.Called(jobID, offset, limit)
@@ -348,6 +369,29 @@ func (_m *ORM) InsertWebhookSpec(webhookSpec *job.WebhookSpec, qopts ...pg.QOpt)
 	}
 
 	return r0
+}
+
+// JobsByPipelineSpecIDs provides a mock function with given fields: ids
+func (_m *ORM) JobsByPipelineSpecIDs(ids []int32) ([]job.Job, error) {
+	ret := _m.Called(ids)
+
+	var r0 []job.Job
+	if rf, ok := ret.Get(0).(func([]int32) []job.Job); ok {
+		r0 = rf(ids)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]job.Job)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func([]int32) error); ok {
+		r1 = rf(ids)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // PipelineRuns provides a mock function with given fields: jobID, offset, size

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -56,7 +56,7 @@ type ORM interface {
 	FindPipelineRunsByIDs(ids []int64) (runs []pipeline.Run, err error)
 	CountPipelineRunsByJobID(jobID int32) (count int32, err error)
 
-	JobsByPipelineSpecIDs(ids []int32) ([]Job, error)
+	FindJobsByPipelineSpecIDs(ids []int32) ([]Job, error)
 	FindPipelineRunByID(id int64) (pipeline.Run, error)
 }
 
@@ -742,7 +742,7 @@ WHERE pipeline_runs.pipeline_spec_id = (SELECT jobs.pipeline_spec_id FROM JOBS W
 	return count, errors.Wrap(err, "PipelineRunsByJobsIDs failed")
 }
 
-func (o *orm) JobsByPipelineSpecIDs(ids []int32) ([]Job, error) {
+func (o *orm) FindJobsByPipelineSpecIDs(ids []int32) ([]Job, error) {
 	var jbs []Job
 
 	err := o.q.Transaction(func(tx pg.Queryer) error {
@@ -766,7 +766,7 @@ func (o *orm) JobsByPipelineSpecIDs(ids []int32) ([]Job, error) {
 		return nil
 	})
 
-	return jbs, errors.Wrap(err, "JobsByPipelineSpecIDs failed")
+	return jbs, errors.Wrap(err, "FindJobsByPipelineSpecIDs failed")
 }
 
 // PipelineRuns returns pipeline runs for a job, with spec and taskruns loaded, latest first

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -55,6 +55,9 @@ type ORM interface {
 	FindPipelineRunIDsByJobID(jobID int32, offset, limit int) (ids []int64, err error)
 	FindPipelineRunsByIDs(ids []int64) (runs []pipeline.Run, err error)
 	CountPipelineRunsByJobID(jobID int32) (count int32, err error)
+
+	JobsByPipelineSpecIDs(ids []int32) ([]Job, error)
+	FindPipelineRunByID(id int64) (pipeline.Run, error)
 }
 
 type orm struct {
@@ -696,6 +699,31 @@ WHERE id = ANY($1)
 	return runs, errors.Wrap(err, "GetPipelineRunsByIDs failed")
 }
 
+// FindPipelineRunByID returns pipeline run with the id.
+func (o *orm) FindPipelineRunByID(id int64) (pipeline.Run, error) {
+	var run pipeline.Run
+
+	err := o.q.Transaction(func(tx pg.Queryer) error {
+		stmt := `
+SELECT pipeline_runs.*
+FROM pipeline_runs
+WHERE id = $1
+`
+
+		if err := tx.Get(&run, stmt, id); err != nil {
+			return errors.Wrap(err, "error loading run")
+		}
+
+		runs, err := o.loadPipelineRunsRelations([]pipeline.Run{run}, tx)
+
+		run = runs[0]
+
+		return err
+	})
+
+	return run, errors.Wrap(err, "FindPipelineRunByID failed")
+}
+
 // CountPipelineRunsByJobID returns the total number of pipeline runs for a job.
 func (o *orm) CountPipelineRunsByJobID(jobID int32) (count int32, err error) {
 	err = o.q.Transaction(func(tx pg.Queryer) error {
@@ -712,6 +740,33 @@ WHERE pipeline_runs.pipeline_spec_id = (SELECT jobs.pipeline_spec_id FROM JOBS W
 	})
 
 	return count, errors.Wrap(err, "PipelineRunsByJobsIDs failed")
+}
+
+func (o *orm) JobsByPipelineSpecIDs(ids []int32) ([]Job, error) {
+	var jbs []Job
+
+	err := o.q.Transaction(func(tx pg.Queryer) error {
+		stmt := `SELECT * FROM jobs WHERE jobs.pipeline_spec_id = ANY($1) ORDER BY id ASC
+`
+		if err := tx.Select(&jbs, stmt, ids); err != nil {
+			return errors.Wrap(err, "error fetching jobs by pipeline spec IDs")
+		}
+
+		err := LoadAllJobsTypes(tx, jbs)
+		if err != nil {
+			return err
+		}
+		for i := range jbs {
+			err = o.LoadEnvConfigVars(&jbs[i])
+			if err != nil {
+				return err
+			}
+		}
+
+		return nil
+	})
+
+	return jbs, errors.Wrap(err, "JobsByPipelineSpecIDs failed")
 }
 
 // PipelineRuns returns pipeline runs for a job, with spec and taskruns loaded, latest first

--- a/core/web/loader/getters.go
+++ b/core/web/loader/getters.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/services/feeds"
+	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/core/utils/stringutils"
 )
@@ -110,4 +111,22 @@ func GetJobProposalsByFeedsManagerID(ctx context.Context, id string) ([]feeds.Jo
 	}
 
 	return jbRuns, nil
+}
+
+// GetJobByPipelineSpecID fetches the job by pipeline spec ID.
+func GetJobByPipelineSpecID(ctx context.Context, id string) (*job.Job, error) {
+	ldr := For(ctx)
+
+	thunk := ldr.JobsByPipelineSpecIDLoader.Load(ctx, dataloader.StringKey(id))
+	result, err := thunk()
+	if err != nil {
+		return nil, err
+	}
+
+	jb, ok := result.(job.Job)
+	if !ok {
+		return nil, errors.New("invalid type")
+	}
+
+	return &jb, nil
 }

--- a/core/web/loader/job.go
+++ b/core/web/loader/job.go
@@ -1,0 +1,55 @@
+package loader
+
+import (
+	"context"
+	"errors"
+
+	"github.com/graph-gophers/dataloader"
+
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/core/utils/stringutils"
+)
+
+type jobBatcher struct {
+	app chainlink.Application
+}
+
+func (b *jobBatcher) loadByPipelineSpecIDs(_ context.Context, keys dataloader.Keys) []*dataloader.Result {
+	// Create a map for remembering the order of keys passed in
+	keyOrder := make(map[string]int, len(keys))
+	// Collect the keys to search for
+	var plSpecIDs []int32
+	for ix, key := range keys {
+		id, err := stringutils.ToInt32(key.String())
+		if err == nil {
+			plSpecIDs = append(plSpecIDs, id)
+		}
+		keyOrder[key.String()] = ix
+	}
+
+	// Fetch the jobs
+	jobs, err := b.app.JobORM().JobsByPipelineSpecIDs(plSpecIDs)
+	if err != nil {
+		return []*dataloader.Result{{Data: nil, Error: err}}
+	}
+
+	// Construct the output array of dataloader results
+	results := make([]*dataloader.Result, len(keys))
+	for _, j := range jobs {
+		id := stringutils.FromInt32(j.PipelineSpecID)
+
+		ix, ok := keyOrder[id]
+		// if found, remove from index lookup map, so we know elements were found
+		if ok {
+			results[ix] = &dataloader.Result{Data: j, Error: nil}
+			delete(keyOrder, id)
+		}
+	}
+
+	// fill array positions without any jobs
+	for _, ix := range keyOrder {
+		results[ix] = &dataloader.Result{Data: nil, Error: errors.New("job not found")}
+	}
+
+	return results
+}

--- a/core/web/loader/job.go
+++ b/core/web/loader/job.go
@@ -28,7 +28,7 @@ func (b *jobBatcher) loadByPipelineSpecIDs(_ context.Context, keys dataloader.Ke
 	}
 
 	// Fetch the jobs
-	jobs, err := b.app.JobORM().JobsByPipelineSpecIDs(plSpecIDs)
+	jobs, err := b.app.JobORM().FindJobsByPipelineSpecIDs(plSpecIDs)
 	if err != nil {
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}

--- a/core/web/loader/loader.go
+++ b/core/web/loader/loader.go
@@ -18,6 +18,7 @@ type Dataloader struct {
 	ChainsByIDLoader              *dataloader.Loader
 	FeedsManagersByIDLoader       *dataloader.Loader
 	JobRunsByIDLoader             *dataloader.Loader
+	JobsByPipelineSpecIDLoader    *dataloader.Loader
 	JobProposalsByManagerIDLoader *dataloader.Loader
 }
 
@@ -27,6 +28,7 @@ func New(app chainlink.Application) *Dataloader {
 	mgrs := &feedsBatcher{app: app}
 	jobRuns := &jobRunBatcher{app: app}
 	jps := &jobProposalBatcher{app: app}
+	jbs := &jobBatcher{app: app}
 
 	return &Dataloader{
 		app: app,
@@ -35,6 +37,7 @@ func New(app chainlink.Application) *Dataloader {
 		ChainsByIDLoader:              dataloader.NewBatchedLoader(chains.loadByIDs),
 		FeedsManagersByIDLoader:       dataloader.NewBatchedLoader(mgrs.loadByIDs),
 		JobRunsByIDLoader:             dataloader.NewBatchedLoader(jobRuns.loadByIDs),
+		JobsByPipelineSpecIDLoader:    dataloader.NewBatchedLoader(jbs.loadByPipelineSpecIDs),
 		JobProposalsByManagerIDLoader: dataloader.NewBatchedLoader(jps.loadByManagersIDs),
 	}
 }

--- a/core/web/loader/loader_test.go
+++ b/core/web/loader/loader_test.go
@@ -257,7 +257,7 @@ func TestLoader_JobsByPipelineSpecIDs(t *testing.T) {
 		job2 := job.Job{ID: int32(3), PipelineSpecID: int32(2)}
 		job3 := job.Job{ID: int32(4), PipelineSpecID: int32(3)}
 
-		jobsORM.On("JobsByPipelineSpecIDs", []int32{3, 1, 2}).Return([]job.Job{
+		jobsORM.On("FindJobsByPipelineSpecIDs", []int32{3, 1, 2}).Return([]job.Job{
 			job1, job2, job3,
 		}, nil)
 		app.On("JobORM").Return(jobsORM)
@@ -284,7 +284,7 @@ func TestLoader_JobsByPipelineSpecIDs(t *testing.T) {
 			mock.AssertExpectationsForObjects(t, app, jobsORM)
 		})
 
-		jobsORM.On("JobsByPipelineSpecIDs", []int32{3, 1, 2}).Return([]job.Job{}, sql.ErrNoRows)
+		jobsORM.On("FindJobsByPipelineSpecIDs", []int32{3, 1, 2}).Return([]job.Job{}, sql.ErrNoRows)
 		app.On("JobORM").Return(jobsORM)
 
 		batcher := jobBatcher{app}

--- a/core/web/loader/loader_test.go
+++ b/core/web/loader/loader_test.go
@@ -2,6 +2,7 @@ package loader
 
 import (
 	"context"
+	"database/sql"
 	"testing"
 
 	"github.com/graph-gophers/dataloader"
@@ -14,6 +15,7 @@ import (
 	coremocks "github.com/smartcontractkit/chainlink/core/internal/mocks"
 	"github.com/smartcontractkit/chainlink/core/services/feeds"
 	feedsMocks "github.com/smartcontractkit/chainlink/core/services/feeds/mocks"
+	"github.com/smartcontractkit/chainlink/core/services/job"
 	jobORMMocks "github.com/smartcontractkit/chainlink/core/services/job/mocks"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/core/utils"
@@ -235,4 +237,63 @@ func TestLoader_JobRuns(t *testing.T) {
 	assert.Equal(t, run3, found[0].Data)
 	assert.Equal(t, run1, found[1].Data)
 	assert.Equal(t, run2, found[2].Data)
+}
+
+func TestLoader_JobsByPipelineSpecIDs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with out errors", func(t *testing.T) {
+		t.Parallel()
+
+		jobsORM := &jobORMMocks.ORM{}
+		app := &coremocks.Application{}
+		ctx := InjectDataloader(context.Background(), app)
+
+		defer t.Cleanup(func() {
+			mock.AssertExpectationsForObjects(t, app, jobsORM)
+		})
+
+		job1 := job.Job{ID: int32(2), PipelineSpecID: int32(1)}
+		job2 := job.Job{ID: int32(3), PipelineSpecID: int32(2)}
+		job3 := job.Job{ID: int32(4), PipelineSpecID: int32(3)}
+
+		jobsORM.On("JobsByPipelineSpecIDs", []int32{3, 1, 2}).Return([]job.Job{
+			job1, job2, job3,
+		}, nil)
+		app.On("JobORM").Return(jobsORM)
+
+		batcher := jobBatcher{app}
+
+		keys := dataloader.NewKeysFromStrings([]string{"3", "1", "2"})
+		found := batcher.loadByPipelineSpecIDs(ctx, keys)
+
+		require.Len(t, found, 3)
+		assert.Equal(t, job3, found[0].Data)
+		assert.Equal(t, job1, found[1].Data)
+		assert.Equal(t, job2, found[2].Data)
+	})
+
+	t.Run("with errors", func(t *testing.T) {
+		t.Parallel()
+
+		jobsORM := &jobORMMocks.ORM{}
+		app := &coremocks.Application{}
+		ctx := InjectDataloader(context.Background(), app)
+
+		defer t.Cleanup(func() {
+			mock.AssertExpectationsForObjects(t, app, jobsORM)
+		})
+
+		jobsORM.On("JobsByPipelineSpecIDs", []int32{3, 1, 2}).Return([]job.Job{}, sql.ErrNoRows)
+		app.On("JobORM").Return(jobsORM)
+
+		batcher := jobBatcher{app}
+
+		keys := dataloader.NewKeysFromStrings([]string{"3", "1", "2"})
+		found := batcher.loadByPipelineSpecIDs(ctx, keys)
+
+		require.Len(t, found, 1)
+		assert.Nil(t, found[0].Data)
+		assert.ErrorIs(t, found[0].Error, sql.ErrNoRows)
+	})
 }

--- a/core/web/resolver/job.go
+++ b/core/web/resolver/job.go
@@ -92,7 +92,6 @@ func (r *JobResolver) Runs(ctx context.Context, args struct {
 	offset := pageOffset(args.Offset)
 	limit := pageLimit(args.Limit)
 
-	//
 	if limit > 100 {
 		limit = 100
 	}
@@ -112,7 +111,7 @@ func (r *JobResolver) Runs(ctx context.Context, args struct {
 		return nil, err
 	}
 
-	return NewJobRunsPayload(runs, count), nil
+	return NewJobRunsPayload(runs, count, r.app), nil
 }
 
 // JobsPayloadResolver resolves a page of jobs

--- a/core/web/resolver/job_run.go
+++ b/core/web/resolver/job_run.go
@@ -1,26 +1,32 @@
 package resolver
 
 import (
+	"context"
+
 	"github.com/graph-gophers/graphql-go"
 
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
+	"github.com/smartcontractkit/chainlink/core/utils/stringutils"
+	"github.com/smartcontractkit/chainlink/core/web/loader"
 )
 
 var outputRetrievalErrorStr = "error: unable to retrieve outputs"
 
 type JobRunResolver struct {
 	run pipeline.Run
+	app chainlink.Application
 }
 
-func NewJobRun(run pipeline.Run) *JobRunResolver {
-	return &JobRunResolver{run: run}
+func NewJobRun(run pipeline.Run, app chainlink.Application) *JobRunResolver {
+	return &JobRunResolver{run: run, app: app}
 }
 
-func NewJobRuns(runs []pipeline.Run) []*JobRunResolver {
+func NewJobRuns(runs []pipeline.Run, app chainlink.Application) []*JobRunResolver {
 	var resolvers []*JobRunResolver
 
 	for _, run := range runs {
-		resolvers = append(resolvers, NewJobRun(run))
+		resolvers = append(resolvers, NewJobRun(run, app))
 	}
 
 	return resolvers
@@ -89,6 +95,16 @@ func (r *JobRunResolver) TaskRuns() []*TaskRunResolver {
 	return []*TaskRunResolver{}
 }
 
+func (r *JobRunResolver) Job(ctx context.Context) (*JobResolver, error) {
+	plnSpecID := stringutils.FromInt32(r.run.PipelineSpecID)
+	job, err := loader.GetJobByPipelineSpecID(ctx, plnSpecID)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewJob(r.app, *job), nil
+}
+
 func (r *JobRunResolver) CreatedAt() graphql.Time {
 	return graphql.Time{Time: r.run.CreatedAt}
 }
@@ -97,22 +113,46 @@ func (r *JobRunResolver) FinishedAt() *graphql.Time {
 	return &graphql.Time{Time: r.run.FinishedAt.ValueOrZero()}
 }
 
+// -- JobRun query --
+
+type JobRunPayloadResolver struct {
+	jr  *pipeline.Run
+	app chainlink.Application
+	NotFoundErrorUnionType
+}
+
+func NewJobRunPayload(jr *pipeline.Run, app chainlink.Application, err error) *JobRunPayloadResolver {
+	e := NotFoundErrorUnionType{err: err, message: "job run not found", isExpectedErrorFn: nil}
+
+	return &JobRunPayloadResolver{jr: jr, app: app, NotFoundErrorUnionType: e}
+}
+
+func (r *JobRunPayloadResolver) ToJobRun() (*JobRunResolver, bool) {
+	if r.err != nil {
+		return nil, false
+	}
+
+	return NewJobRun(*r.jr, r.app), true
+}
+
 // JobRunsPayloadResolver resolves a page of job runs
 type JobRunsPayloadResolver struct {
 	runs  []pipeline.Run
 	total int32
+	app   chainlink.Application
 }
 
-func NewJobRunsPayload(runs []pipeline.Run, total int32) *JobRunsPayloadResolver {
+func NewJobRunsPayload(runs []pipeline.Run, total int32, app chainlink.Application) *JobRunsPayloadResolver {
 	return &JobRunsPayloadResolver{
 		runs:  runs,
 		total: total,
+		app:   app,
 	}
 }
 
 // Results returns the job runs.
 func (r *JobRunsPayloadResolver) Results() []*JobRunResolver {
-	return NewJobRuns(r.runs)
+	return NewJobRuns(r.runs, r.app)
 }
 
 // Metadata returns the pagination metadata.

--- a/core/web/resolver/job_run_test.go
+++ b/core/web/resolver/job_run_test.go
@@ -1,12 +1,16 @@
 package resolver
 
 import (
+	"database/sql"
 	"testing"
 
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/pkg/errors"
+	"gopkg.in/guregu/null.v4"
 
+	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
+	"github.com/smartcontractkit/chainlink/core/utils/stringutils"
 )
 
 func TestQuery_PaginatedJobsRuns(t *testing.T) {
@@ -67,6 +71,126 @@ func TestQuery_PaginatedJobsRuns(t *testing.T) {
 					ResolverError: gError,
 					Path:          []interface{}{"jobsRuns"},
 					Message:       gError.Error(),
+				},
+			},
+		},
+	}
+
+	RunGQLTests(t, testCases)
+}
+
+func TestResolver_JobRun(t *testing.T) {
+	t.Parallel()
+
+	query := `
+		query GetJobRun($id: ID!) {
+			jobRun(id: $id) {
+				... on JobRun {
+					id
+					job {
+						id
+						name
+					}
+				}
+				... on NotFoundError {
+					code
+					message
+				}
+			}
+		}`
+	variables := map[string]interface{}{
+		"id": "2",
+	}
+	gError := errors.New("error")
+	_, idError := stringutils.ToInt64("asdasads")
+
+	testCases := []GQLTestCase{
+		unauthorizedTestCase(GQLTestCase{query: query, variables: variables}, "jobRun"),
+		{
+			name:          "success",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.jobORM.On("FindPipelineRunByID", int64(2)).Return(pipeline.Run{
+					ID:             2,
+					PipelineSpecID: 5,
+				}, nil)
+				f.Mocks.jobORM.On("JobsByPipelineSpecIDs", []int32{5}).Return([]job.Job{
+					{
+						ID:             1,
+						PipelineSpecID: 2,
+						Name:           null.StringFrom("first-one"),
+					},
+					{
+						ID:             2,
+						PipelineSpecID: 5,
+						Name:           null.StringFrom("second-one"),
+					},
+				}, nil)
+				f.App.On("JobORM").Return(f.Mocks.jobORM)
+			},
+			query:     query,
+			variables: variables,
+			result: `
+				{
+					"jobRun": {
+						"id": "2",
+						"job": {
+							"id": "2",
+							"name": "second-one"
+						}
+					}
+				}`,
+		},
+		{
+			name:          "not found error",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.jobORM.On("FindPipelineRunByID", int64(2)).Return(pipeline.Run{}, sql.ErrNoRows)
+				f.App.On("JobORM").Return(f.Mocks.jobORM)
+			},
+			query:     query,
+			variables: variables,
+			result: `
+				{
+					"jobRun": {
+						"code": "NOT_FOUND",
+						"message": "job run not found"
+					}
+				}`,
+		},
+		{
+			name:          "generic error on FindPipelineRunByID()",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.jobORM.On("FindPipelineRunByID", int64(2)).Return(pipeline.Run{}, gError)
+				f.App.On("JobORM").Return(f.Mocks.jobORM)
+			},
+			query:     query,
+			variables: variables,
+			result:    `null`,
+			errors: []*gqlerrors.QueryError{
+				{
+					Extensions:    nil,
+					ResolverError: gError,
+					Path:          []interface{}{"jobRun"},
+					Message:       gError.Error(),
+				},
+			},
+		},
+		{
+			name:          "invalid ID error",
+			authenticated: true,
+			query:         query,
+			variables: map[string]interface{}{
+				"id": "asdasads",
+			},
+			result: `null`,
+			errors: []*gqlerrors.QueryError{
+				{
+					Extensions:    nil,
+					ResolverError: idError,
+					Path:          []interface{}{"jobRun"},
+					Message:       idError.Error(),
 				},
 			},
 		},

--- a/core/web/resolver/job_run_test.go
+++ b/core/web/resolver/job_run_test.go
@@ -114,7 +114,7 @@ func TestResolver_JobRun(t *testing.T) {
 					ID:             2,
 					PipelineSpecID: 5,
 				}, nil)
-				f.Mocks.jobORM.On("JobsByPipelineSpecIDs", []int32{5}).Return([]job.Job{
+				f.Mocks.jobORM.On("FindJobsByPipelineSpecIDs", []int32{5}).Return([]job.Job{
 					{
 						ID:             1,
 						PipelineSpecID: 2,

--- a/core/web/resolver/query.go
+++ b/core/web/resolver/query.go
@@ -345,5 +345,29 @@ func (r *Resolver) JobsRuns(ctx context.Context, args struct {
 		return nil, err
 	}
 
-	return NewJobRunsPayload(runs, int32(count)), nil
+	return NewJobRunsPayload(runs, int32(count), r.App), nil
+}
+
+func (r *Resolver) JobRun(ctx context.Context, args struct {
+	ID graphql.ID
+}) (*JobRunPayloadResolver, error) {
+	if err := authenticateUser(ctx); err != nil {
+		return nil, err
+	}
+
+	id, err := stringutils.ToInt64(string(args.ID))
+	if err != nil {
+		return nil, err
+	}
+
+	jr, err := r.App.JobORM().FindPipelineRunByID(id)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return NewJobRunPayload(nil, r.App, err), nil
+		}
+
+		return nil, err
+	}
+
+	return NewJobRunPayload(&jr, r.App, err), nil
 }

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -17,6 +17,7 @@ type Query {
     job(id: ID!): JobPayload!
     jobs(offset: Int, limit: Int): JobsPayload!
     jobProposal(id: ID!): JobProposalPayload!
+    jobRun(id: ID!): JobRunPayload!
     jobsRuns(offset: Int, limit: Int): JobsRunsPayload!
     node(id: ID!): NodePayload!
     nodes(offset: Int, limit: Int): NodesPayload!

--- a/core/web/schema/type/job_run.graphql
+++ b/core/web/schema/type/job_run.graphql
@@ -7,6 +7,7 @@ type JobRun {
     createdAt: Time!
     finishedAt: Time
     taskRuns: [TaskRun!]!
+    job: Job!
 }
 
 # JobRunsPayload defines the response when fetching a page of runs


### PR DESCRIPTION
Closes: https://app.shortcut.com/chainlinklabs/story/22456/gql-api-job-run-query

This aims to enable a query to fetch Job Runs by ID, allowing to fetch the related Job via data-loading.