### PR TITLE
core/logger: fix caller skip levels

### DIFF
--- a/core/logger/prometheus.go
+++ b/core/logger/prometheus.go
@@ -196,5 +196,5 @@ func (s *prometheusLogger) Sync() error {
 }
 
 func (s *prometheusLogger) Helper(add int) Logger {
-	return s.h.Helper(add)
+	return &prometheusLogger{s.h.Helper(add)}
 }

--- a/core/logger/sentry.go
+++ b/core/logger/sentry.go
@@ -302,7 +302,7 @@ func (s *sentryLogger) Sync() error {
 }
 
 func (s *sentryLogger) Helper(add int) Logger {
-	return s.h.Helper(add)
+	return &sentryLogger{s.h.Helper(add)}
 }
 
 func toMap(args ...interface{}) (m map[string]interface{}) {

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -14,9 +14,10 @@ var _ Logger = &zapLogger{}
 
 type zapLogger struct {
 	*zap.SugaredLogger
-	config zap.Config
-	name   string
-	fields []interface{}
+	config     zap.Config
+	name       string
+	fields     []interface{}
+	callerSkip int
 }
 
 func newZapLogger(cfg zap.Config) (Logger, error) {
@@ -68,6 +69,7 @@ func (l *zapLogger) NewRootLogger(lvl zapcore.Level) (Logger, error) {
 	if err != nil {
 		return nil, err
 	}
+	zl = zl.WithOptions(zap.AddCallerSkip(l.callerSkip))
 	newLogger.SugaredLogger = zl.Named(l.name).Sugar().With(l.fields...)
 	return &newLogger, nil
 }
@@ -75,6 +77,7 @@ func (l *zapLogger) NewRootLogger(lvl zapcore.Level) (Logger, error) {
 func (l *zapLogger) Helper(skip int) Logger {
 	newLogger := *l
 	newLogger.SugaredLogger = l.sugaredHelper(skip)
+	newLogger.callerSkip += skip
 	return &newLogger
 }
 


### PR DESCRIPTION
Fixing two issues that were resulting in incorrect caller skip levels affecting logged source lines and stack traces.
- Wrappers need to re-wrap instead of returning the wrapped result
- `AddCallerSkip` must be explicitly set for `NewRootLogger`s