### PR TITLE
Allow missing goose migrations

### DIFF
--- a/core/store/migrate/migrate.go
+++ b/core/store/migrate/migrate.go
@@ -103,7 +103,9 @@ func ensureMigrated(db *sql.DB, lggr logger.Logger) {
 
 func Migrate(db *sql.DB, lggr logger.Logger) error {
 	ensureMigrated(db, lggr)
-	return goose.Up(db, MIGRATIONS_DIR)
+	// WithAllowMissing is necessary when upgrading from 0.10.14 since it
+	// includes out-of-order migrations
+	return goose.Up(db, MIGRATIONS_DIR, goose.WithAllowMissing())
 }
 
 func Rollback(db *sql.DB, lggr logger.Logger, version null.Int) error {


### PR DESCRIPTION
This is necessary to upgrade from 0.10.14