### PR TITLE
Handle remote conn closure for lease/advisory locking

### DIFF
--- a/core/services/pg/helpers_test.go
+++ b/core/services/pg/helpers_test.go
@@ -1,0 +1,7 @@
+package pg
+
+import "github.com/smartcontractkit/sqlx"
+
+func GetConn(ll LeaseLock) *sqlx.Conn {
+	return ll.(*leaseLock).conn
+}

--- a/core/services/pg/lease_lock_test.go
+++ b/core/services/pg/lease_lock_test.go
@@ -19,9 +19,9 @@ func newLeaseLock(t *testing.T, db *sqlx.DB) pg.LeaseLock {
 }
 
 func Test_LeaseLock(t *testing.T) {
-	t.Run("on migrated database", func(t *testing.T) {
-		_, db := heavyweight.FullTestDB(t, "leaselock", true, false)
+	cfg, db := heavyweight.FullTestDB(t, "leaselock", true, false)
 
+	t.Run("on migrated database", func(t *testing.T) {
 		leaseLock1 := newLeaseLock(t, db)
 
 		err := leaseLock1.TakeAndHold()
@@ -55,6 +55,36 @@ func Test_LeaseLock(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, leaseLock2.ClientID(), clientID)
 	})
+
+	t.Run("recovers and re-opens connection if it's closed externally", func(t *testing.T) {
+		leaseLock := newLeaseLock(t, db)
+
+		err := leaseLock.TakeAndHold()
+		require.NoError(t, err)
+		defer leaseLock.Release()
+
+		conn := pg.GetConn(leaseLock)
+
+		var prevExpiresAt time.Time
+
+		err = conn.Close()
+		require.NoError(t, err)
+
+		err = db.Get(&prevExpiresAt, `SELECT expires_at FROM lease_lock`)
+		require.NoError(t, err)
+
+		time.Sleep(cfg.LeaseLockRefreshInterval() + 1*time.Second)
+
+		var expiresAt time.Time
+
+		err = db.Get(&expiresAt, `SELECT expires_at FROM lease_lock`)
+		require.NoError(t, err)
+
+		// The lease lock must have recovered and re-opened the connection if the second expires_at is later
+		assert.Greater(t, expiresAt.Unix(), prevExpiresAt.Unix())
+	})
+
+	require.NoError(t, db.Close())
 
 	t.Run("on virgin database", func(t *testing.T) {
 		_, db := heavyweight.FullTestDB(t, "leaselock", false, false)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -210,8 +210,8 @@ Traditionally Chainlink has used an advisory lock to manage this. However, advis
 For this reason, we have introduced a new locking mode, `lease`, which is likely to become the default in future. `lease`-mode works as follows:
 - Have one row in a database which is updated periodically with the client ID
 - CL node A will run a background process on start that updates this e.g. once per second
-- CL node B will spinlock, checking periodically to see if the update got too old. If it goes more than, say, 5s without updating, it assumes that node A is dead and takes over. Now CL node B is the owner of the row and it updates this every second
-- If CL node A comes back somehow, it will go to take out a lease and realise that the database has been leased to another process, so it will panic and quit immediately
+- CL node B will spinlock, checking periodically to see if the update got too old. If it goes more than a set period without updating, it assumes that node A is dead and takes over. Now CL node B is the owner of the row and it updates this every second
+- If CL node A comes back somehow, it will go to take out a lease and realise that the database has been leased to another process, so it will exit the entire application immediately
 
 The default is set to `dual` which used both advisory locking AND lease locking, for backwards compatibility. However, it is recommended that node operators who know what they are doing, or explicitly want to stop using the advisory locking mode set `DATABASE_LOCKING_MODE=lease` in their env.
 


### PR DESCRIPTION
Note that if the advisory lock is held and the application is running,
if the remote conn is closed the advisory lock will be released but the
application will keep on running.

For this reason we recommend using the lease lock.