### PR TITLE
Fixed staticcheck issues + fixed panic on double channel close

### DIFF
--- a/core/chains/evm/config/config_test.go
+++ b/core/chains/evm/config/config_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/chains"
 	evmconfig "github.com/smartcontractkit/chainlink/core/chains/evm/config"
 	evmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/mocks"
-	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
@@ -67,7 +66,7 @@ func TestChainScopedConfig(t *testing.T) {
 		addr := cltest.NewAddress()
 		randomOtherAddr := cltest.NewAddress()
 		randomOtherKeySpecific := evmtypes.ChainCfg{EvmMaxGasPriceWei: utils.NewBigI(rand.Int63())}
-		evmconfig.UpdatePersistedCfg(cfg, func(cfg *types.ChainCfg) {
+		evmconfig.UpdatePersistedCfg(cfg, func(cfg *evmtypes.ChainCfg) {
 			cfg.KeySpecific[randomOtherAddr.Hex()] = randomOtherKeySpecific
 		})
 
@@ -77,7 +76,7 @@ func TestChainScopedConfig(t *testing.T) {
 
 		t.Run("uses chain-specific override value when that is set", func(t *testing.T) {
 			val := utils.NewBigI(rand.Int63())
-			evmconfig.UpdatePersistedCfg(cfg, func(cfg *types.ChainCfg) {
+			evmconfig.UpdatePersistedCfg(cfg, func(cfg *evmtypes.ChainCfg) {
 				cfg.EvmMaxGasPriceWei = val
 			})
 
@@ -86,7 +85,7 @@ func TestChainScopedConfig(t *testing.T) {
 		t.Run("uses key-specific override value when that is set", func(t *testing.T) {
 			val := utils.NewBigI(rand.Int63())
 			keySpecific := evmtypes.ChainCfg{EvmMaxGasPriceWei: val}
-			evmconfig.UpdatePersistedCfg(cfg, func(cfg *types.ChainCfg) {
+			evmconfig.UpdatePersistedCfg(cfg, func(cfg *evmtypes.ChainCfg) {
 				cfg.KeySpecific[addr.Hex()] = keySpecific
 			})
 

--- a/core/chains/evm/legacy_test.go
+++ b/core/chains/evm/legacy_test.go
@@ -70,6 +70,7 @@ func Test_ClobberDBFromEnv(t *testing.T) {
 
 	var sendonlyNodes []evmtypes.Node
 	err = db.Select(&sendonlyNodes, `SELECT * FROM nodes WHERE evm_chain_id = 42 AND send_only ORDER BY http_url`)
+	require.NoError(t, err)
 	require.Len(t, sendonlyNodes, 2)
 
 	assert.True(t, sendonlyNodes[0].SendOnly)

--- a/core/cmd/client.go
+++ b/core/cmd/client.go
@@ -88,15 +88,6 @@ type AppFactory interface {
 // ChainlinkAppFactory is used to create a new Application.
 type ChainlinkAppFactory struct{}
 
-func retryLogMsg(count int) string {
-	if count == 1 {
-		return "Could not get lock, retrying..."
-	} else if count%1000 == 0 || count&(count-1) == 0 {
-		return "Still waiting for lock..."
-	}
-	return ""
-}
-
 // NewApplication returns a new instance of the node with the given config.
 func (n ChainlinkAppFactory) NewApplication(cfg config.GeneralConfig) (chainlink.Application, error) {
 	appLggr := logger.NewLogger(cfg)

--- a/core/internal/testutils/pgtest/txdb.go
+++ b/core/internal/testutils/pgtest/txdb.go
@@ -62,9 +62,8 @@ var _ driver.Conn = &conn{}
 // when the Close is called, transaction is rolled back
 type txDriver struct {
 	sync.Mutex
-	db      *sql.DB
-	conns   map[string]*conn
-	options []func(*conn) error
+	db    *sql.DB
+	conns map[string]*conn
 
 	dbURL string
 }
@@ -118,8 +117,6 @@ type conn struct {
 	sync.Mutex
 	dsn        string
 	tx         *sql.Tx // tx may be shared by many conns, definitive one lives in the map keyed by DSN on the txDriver. Do not modify from conn
-	ctx        context.Context
-	cancel     context.CancelFunc
 	closed     bool
 	opened     int
 	removeSelf func() error

--- a/core/services/bulletprooftxmanager/orm.go
+++ b/core/services/bulletprooftxmanager/orm.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
-	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
 
@@ -246,8 +245,8 @@ func loadEthTxesAttemptsReceipts(q pg.Queryer, etxs []*EthTx) (err error) {
 	if len(etxs) == 0 {
 		return nil
 	}
-	attemptHashM := make(map[gethCommon.Hash]*EthTxAttempt, len(etxs)) // len here is lower bound
-	attemptHashes := make([][]byte, len(etxs))                         // len here is lower bound
+	attemptHashM := make(map[common.Hash]*EthTxAttempt, len(etxs)) // len here is lower bound
+	attemptHashes := make([][]byte, len(etxs))                     // len here is lower bound
 	for _, etx := range etxs {
 		for i, attempt := range etx.EthTxAttempts {
 			attemptHashM[attempt.Hash] = &etx.EthTxAttempts[i]

--- a/core/services/eth/node.go
+++ b/core/services/eth/node.go
@@ -73,9 +73,8 @@ type node struct {
 	log  logger.Logger
 	name string
 
-	state  NodeState
-	mu     sync.RWMutex
-	closed bool
+	state NodeState
+	mu    sync.RWMutex
 }
 
 func NewNode(lggr logger.Logger, wsuri url.URL, httpuri *url.URL, name string) Node {

--- a/core/services/keystore/keys/ethkey/export.go
+++ b/core/services/keystore/keys/ethkey/export.go
@@ -26,7 +26,3 @@ func (key KeyV2) ToEncryptedJSON(password string, scryptParams utils.ScryptParam
 	}
 	return keystore.EncryptKey(dKey, password, scryptParams.N, scryptParams.P)
 }
-
-func adulteratedPassword(password string) string {
-	return "ethkey" + password
-}

--- a/core/services/keystore/keys/vrfkey/crypto.go
+++ b/core/services/keystore/keys/vrfkey/crypto.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/pkg/errors"
 	"github.com/smartcontractkit/chainlink/core/services/signatures/secp256k1"
 	"github.com/smartcontractkit/chainlink/core/utils"
 	bm "github.com/smartcontractkit/chainlink/core/utils/big_math"
@@ -104,19 +103,6 @@ func YSquared(x *big.Int) *big.Int {
 // IsCurveXOrdinate returns true iff there is y s.t. y^2=x^3+7
 func IsCurveXOrdinate(x *big.Int) bool {
 	return IsSquare(YSquared(x))
-}
-
-// packUint256s returns xs serialized as concatenated uint256s, or an error
-func packUint256s(xs ...*big.Int) ([]byte, error) {
-	mem := []byte{}
-	for _, x := range xs {
-		word, err := utils.EVMWordBigInt(x)
-		if err != nil {
-			return []byte{}, errors.Wrap(err, "vrf.packUint256s#EVMWordBigInt")
-		}
-		mem = append(mem, word...)
-	}
-	return mem, nil
 }
 
 // FieldHash hashes xs uniformly into {0, ..., fieldSize-1}. msg is assumed to

--- a/core/services/log/broadcaster_test.go
+++ b/core/services/log/broadcaster_test.go
@@ -893,11 +893,11 @@ func TestBroadcaster_FilterByTopicValues(t *testing.T) {
 
 	<-headsDone
 
-	require.Eventually(t, func() bool { return 4 == len(listener0.received.getUniqueLogs()) }, cltest.WaitTimeout(t), 500*time.Millisecond)
-	require.Eventually(t, func() bool { return 4 == len(listener1.received.getUniqueLogs()) }, cltest.WaitTimeout(t), 500*time.Millisecond)
-	require.Eventually(t, func() bool { return 2 == len(listener2.received.getUniqueLogs()) }, cltest.WaitTimeout(t), 500*time.Millisecond)
-	require.Eventually(t, func() bool { return 3 == len(listener3.received.getUniqueLogs()) }, cltest.WaitTimeout(t), 500*time.Millisecond)
-	require.Eventually(t, func() bool { return 1 == len(listener4.received.getUniqueLogs()) }, cltest.WaitTimeout(t), 500*time.Millisecond)
+	require.Eventually(t, func() bool { return len(listener0.received.getUniqueLogs()) == 4 }, cltest.WaitTimeout(t), 500*time.Millisecond)
+	require.Eventually(t, func() bool { return len(listener1.received.getUniqueLogs()) == 4 }, cltest.WaitTimeout(t), 500*time.Millisecond)
+	require.Eventually(t, func() bool { return len(listener2.received.getUniqueLogs()) == 2 }, cltest.WaitTimeout(t), 500*time.Millisecond)
+	require.Eventually(t, func() bool { return len(listener3.received.getUniqueLogs()) == 3 }, cltest.WaitTimeout(t), 500*time.Millisecond)
+	require.Eventually(t, func() bool { return len(listener4.received.getUniqueLogs()) == 1 }, cltest.WaitTimeout(t), 500*time.Millisecond)
 }
 
 func TestBroadcaster_BroadcastsWithOneDelayedLog(t *testing.T) {

--- a/core/services/ocrcommon/config.go
+++ b/core/services/ocrcommon/config.go
@@ -10,7 +10,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/p2pkey"
 	"github.com/smartcontractkit/libocr/commontypes"
-	ocrcommontypes "github.com/smartcontractkit/libocr/commontypes"
 )
 
 type Config interface {
@@ -38,9 +37,9 @@ type Config interface {
 	ChainType() chains.ChainType
 }
 
-func ParseBootstrapPeers(peers []string) (bootstrapPeers []ocrcommontypes.BootstrapperLocator, err error) {
+func ParseBootstrapPeers(peers []string) (bootstrapPeers []commontypes.BootstrapperLocator, err error) {
 	for _, bs := range peers {
-		var bsl ocrcommontypes.BootstrapperLocator
+		var bsl commontypes.BootstrapperLocator
 		err = bsl.UnmarshalText([]byte(bs))
 		if err != nil {
 			return nil, err
@@ -51,7 +50,7 @@ func ParseBootstrapPeers(peers []string) (bootstrapPeers []ocrcommontypes.Bootst
 }
 
 // Will error unless at least one valid bootstrap peer is found
-func GetValidatedBootstrapPeers(specPeers []string, configPeers []ocrcommontypes.BootstrapperLocator) ([]ocrcommontypes.BootstrapperLocator, error) {
+func GetValidatedBootstrapPeers(specPeers []string, configPeers []commontypes.BootstrapperLocator) ([]commontypes.BootstrapperLocator, error) {
 	bootstrapPeers, err := ParseBootstrapPeers(specPeers)
 	if err != nil {
 		return nil, err

--- a/core/services/ocrcommon/peer_wrapper_test.go
+++ b/core/services/ocrcommon/peer_wrapper_test.go
@@ -1,7 +1,6 @@
 package ocrcommon_test
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/core/services/ocrcommon"
@@ -58,7 +57,7 @@ func Test_SingletonPeerWrapper_Start(t *testing.T) {
 
 		pw := ocrcommon.NewSingletonPeerWrapper(keyStore, cfg, db, logger.TestLogger(t))
 
-		require.Contains(t, pw.Start().Error(), fmt.Sprintf("unable to find P2P key with id"))
+		require.Contains(t, pw.Start().Error(), "unable to find P2P key with id")
 	})
 
 	var k2 p2pkey.KeyV2
@@ -85,6 +84,6 @@ func Test_SingletonPeerWrapper_Start(t *testing.T) {
 
 		pw := ocrcommon.NewSingletonPeerWrapper(keyStore, cfg, db, logger.TestLogger(t))
 
-		require.Contains(t, pw.Start().Error(), fmt.Sprintf("unable to find P2P key with id"))
+		require.Contains(t, pw.Start().Error(), "unable to find P2P key with id")
 	})
 }

--- a/core/utils/mailbox_test.go
+++ b/core/utils/mailbox_test.go
@@ -19,7 +19,7 @@ func TestMailbox(t *testing.T) {
 	chDone := make(chan struct{})
 	go func() {
 		defer close(chDone)
-		for _ = range m.Notify() {
+		for range m.Notify() {
 			for {
 				x, exists := m.Retrieve()
 				if !exists {
@@ -56,7 +56,7 @@ func TestMailbox_NoEmptyReceivesWhenCapacityIsTwo(t *testing.T) {
 	chDone := make(chan struct{})
 	go func() {
 		defer close(chDone)
-		for _ = range m.Notify() {
+		for range m.Notify() {
 			x, exists := m.Retrieve()
 			if !exists {
 				emptyReceives = append(emptyReceives, recvd[len(recvd)-1])


### PR DESCRIPTION
1. Fixed almost all issues reported by `staticcheck` analyser. Later I will be including this tool to GitHub flow.
https://app.shortcut.com/chainlinklabs/story/24407/integrate-staticcheck-tool-for-golang

2. Fixed panic on second channel close (head_listener).
@samsondav @jmank88 please pay attention to `head_listener.go`
