### PR TITLE
Implement mutation to set the global log level

### DIFF
--- a/core/web/resolver/log.go
+++ b/core/web/resolver/log.go
@@ -181,3 +181,48 @@ func NewGlobalLogLevelPayload(lgLvl string) *GlobalLogLevelPayloadResolver {
 func (r *GlobalLogLevelPayloadResolver) ToGlobalLogLevel() (*GlobalLogLevelResolver, bool) {
 	return GlobalLogLevel(r.lgLvl), true
 }
+
+// -- UpdateGlobalLogLevel Mutation --
+
+type SetGlobalLogLevelPayloadResolver struct {
+	lvl       LogLevel
+	inputErrs map[string]string
+}
+
+func NewSetGlobalLogLevelPayload(lvl LogLevel, inputErrs map[string]string) *SetGlobalLogLevelPayloadResolver {
+	return &SetGlobalLogLevelPayloadResolver{lvl: lvl, inputErrs: inputErrs}
+}
+
+func (r *SetGlobalLogLevelPayloadResolver) ToInputErrors() (*InputErrorsResolver, bool) {
+	if r.inputErrs != nil {
+		var errs []*InputErrorResolver
+
+		for path, message := range r.inputErrs {
+			errs = append(errs, NewInputError(path, message))
+		}
+
+		return NewInputErrors(errs), true
+	}
+
+	return nil, false
+}
+
+func (r *SetGlobalLogLevelPayloadResolver) ToSetGlobalLogLevelSuccess() (*SetGlobalLogLevelSuccessResolver, bool) {
+	if r.inputErrs != nil {
+		return nil, false
+	}
+
+	return NewSetGlobalLogLevelSuccess(r.lvl), true
+}
+
+type SetGlobalLogLevelSuccessResolver struct {
+	lvl LogLevel
+}
+
+func NewSetGlobalLogLevelSuccess(lvl LogLevel) *SetGlobalLogLevelSuccessResolver {
+	return &SetGlobalLogLevelSuccessResolver{lvl: lvl}
+}
+
+func (r *SetGlobalLogLevelSuccessResolver) GlobalLogLevel() *GlobalLogLevelResolver {
+	return GlobalLogLevel(FromLogLevel(r.lvl))
+}

--- a/core/web/resolver/log_test.go
+++ b/core/web/resolver/log_test.go
@@ -180,3 +180,75 @@ func TestResolver_GlobalLogLevel(t *testing.T) {
 
 	RunGQLTests(t, testCases)
 }
+
+func TestResolver_SetGlobalLogLevel(t *testing.T) {
+	t.Parallel()
+
+	mutation := `
+		mutation SetGlobalLogLevel($level: LogLevel!) {
+			setGlobalLogLevel(level: $level) {
+				... on SetGlobalLogLevelSuccess {
+					globalLogLevel {
+						level
+					}
+				}
+				... on InputErrors {
+					errors {
+						path
+						message
+						code
+					}
+				}
+			}
+		}`
+	variables := map[string]interface{}{
+		"level": LogLevelError,
+	}
+
+	var errorLvl zapcore.Level
+	err := errorLvl.UnmarshalText([]byte("error"))
+	assert.NoError(t, err)
+
+	gError := errors.New("error")
+
+	testCases := []GQLTestCase{
+		unauthorizedTestCase(GQLTestCase{query: mutation, variables: variables}, "setGlobalLogLevel"),
+		{
+			name:          "success",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.App.On("SetLogLevel", errorLvl).Return(nil)
+			},
+			query:     mutation,
+			variables: variables,
+			result: `
+				{
+					"setGlobalLogLevel": {
+						"globalLogLevel": {
+							"level": "ERROR"
+						}
+					}
+				}`,
+		},
+		{
+			name:          "generic error on SetLogLevel",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.App.On("SetLogLevel", errorLvl).Return(gError)
+			},
+			query:     mutation,
+			variables: variables,
+			result:    `null`,
+			errors: []*gqlerrors.QueryError{
+				{
+					Extensions:    nil,
+					ResolverError: gError,
+					Path:          []interface{}{"setGlobalLogLevel"},
+					Message:       gError.Error(),
+				},
+			},
+		},
+	}
+
+	RunGQLTests(t, testCases)
+}

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -1073,3 +1073,27 @@ func (r *Resolver) RunJob(ctx context.Context, args struct {
 
 	return NewRunJobPayload(&plnRun, r.App, nil), nil
 }
+
+func (r *Resolver) SetGlobalLogLevel(ctx context.Context, args struct {
+	Level LogLevel
+}) (*SetGlobalLogLevelPayloadResolver, error) {
+	if err := authenticateUser(ctx); err != nil {
+		return nil, err
+	}
+
+	var lvl zapcore.Level
+	logLvl := FromLogLevel(args.Level)
+
+	err := lvl.UnmarshalText([]byte(logLvl))
+	if err != nil {
+		return NewSetGlobalLogLevelPayload("", map[string]string{
+			"level": "invalid log level",
+		}), nil
+	}
+
+	if err := r.App.SetLogLevel(lvl); err != nil {
+		return nil, err
+	}
+
+	return NewSetGlobalLogLevelPayload(args.Level, nil), nil
+}

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -60,6 +60,7 @@ type Mutation {
     dismissJobError(id: ID!): DismissJobErrorPayload!
     rejectJobProposal(id: ID!): RejectJobProposalPayload!
     runJob(id: ID!): RunJobPayload!
+    setGlobalLogLevel(level: LogLevel!): SetGlobalLogLevelPayload!
     setServicesLogLevels(input: SetServicesLogLevelsInput!): SetServicesLogLevelsPayload!
     setSQLLogging(input: SetSQLLoggingInput!): SetSQLLoggingPayload!
     updateBridge(id: ID!, input: UpdateBridgeInput!): UpdateBridgePayload!

--- a/core/web/schema/type/log.graphql
+++ b/core/web/schema/type/log.graphql
@@ -46,3 +46,9 @@ type SetSQLLoggingSuccess {
 }
 
 union SetSQLLoggingPayload = SetSQLLoggingSuccess
+
+type SetGlobalLogLevelSuccess {
+    globalLogLevel: GlobalLogLevel!
+}
+
+union SetGlobalLogLevelPayload = SetGlobalLogLevelSuccess | InputErrors


### PR DESCRIPTION
Closes: https://app.shortcut.com/chainlinklabs/story/24198/gql-mutation-to-update-modify-the-global-log-level