### PR TITLE
core/services/pipeline: restores test dependent slices

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -612,7 +612,7 @@ func (app *ChainlinkApplication) RunJobV2(
 				},
 				"jobRun": map[string]interface{}{
 					"meta":           meta,
-					"logBlockHash":   testLog.BlockHash,
+					"logBlockHash":   testLog.BlockHash[:],
 					"logBlockNumber": testLog.BlockNumber,
 					"logTxHash":      testLog.TxHash,
 					"logTopics":      testLog.Topics,

--- a/core/services/vrf/listener_v1.go
+++ b/core/services/vrf/listener_v1.go
@@ -359,7 +359,7 @@ func (lsn *listenerV1) ProcessRequest(req *solidity_vrf_coordinator_interface.VR
 			"publicKey":     lsn.job.VRFSpec.PublicKey[:],
 		},
 		"jobRun": map[string]interface{}{
-			"logBlockHash":   req.Raw.BlockHash,
+			"logBlockHash":   req.Raw.BlockHash[:],
 			"logBlockNumber": req.Raw.BlockNumber,
 			"logTxHash":      req.Raw.TxHash,
 			"logTopics":      req.Raw.Topics,

--- a/core/services/vrf/listener_v2.go
+++ b/core/services/vrf/listener_v2.go
@@ -417,7 +417,7 @@ func (lsn *listenerV2) getMaxLinkForFulfillment(maxGasPrice *big.Int, req pendin
 			"maxGasPrice":   maxGasPrice.String(),
 		},
 		"jobRun": map[string]interface{}{
-			"logBlockHash":   req.req.Raw.BlockHash,
+			"logBlockHash":   req.req.Raw.BlockHash[:],
 			"logBlockNumber": req.req.Raw.BlockNumber,
 			"logTxHash":      req.req.Raw.TxHash,
 			"logTopics":      req.req.Raw.Topics,


### PR DESCRIPTION
Restoring slicing removed in #5711, which tests depended on.