### PR TITLE
Fix handling of DEFAULT_HTTP_TIMEOUT in http and bridge tasks

### DIFF
--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -389,7 +389,7 @@ func (r *runner) executeTaskRun(ctx context.Context, spec Spec, taskRun *memoryT
 	// an extremely good reason to change it.
 	ctx, cancel := utils.CombinedContext(ctx, r.chStop)
 	defer cancel()
-	if taskTimeout, isSet := taskRun.task.TaskTimeout(); isSet {
+	if taskTimeout, isSet := taskRun.task.TaskTimeout(); isSet && taskTimeout > 0 {
 		ctx, cancel = context.WithTimeout(ctx, taskTimeout)
 		defer cancel()
 	}

--- a/core/services/pipeline/task.base.go
+++ b/core/services/pipeline/task.base.go
@@ -13,9 +13,9 @@ type BaseTask struct {
 
 	id        int
 	dotID     string
-	Index     int32         `mapstructure:"index" json:"-" `
-	Timeout   time.Duration `mapstructure:"timeout"`
-	FailEarly bool          `mapstructure:"failEarly"`
+	Index     int32          `mapstructure:"index" json:"-" `
+	Timeout   *time.Duration `mapstructure:"timeout"`
+	FailEarly bool           `mapstructure:"failEarly"`
 
 	Retries    null.Uint32   `mapstructure:"retries"`
 	MinBackoff time.Duration `mapstructure:"minBackoff"`
@@ -53,10 +53,10 @@ func (t BaseTask) Inputs() []Task {
 }
 
 func (t BaseTask) TaskTimeout() (time.Duration, bool) {
-	if t.Timeout == time.Duration(0) {
+	if t.Timeout == nil {
 		return time.Duration(0), false
 	}
-	return t.Timeout, true
+	return *t.Timeout, true
 }
 
 func (t BaseTask) TaskRetries() uint32 {

--- a/core/services/pipeline/task.bridge.go
+++ b/core/services/pipeline/task.bridge.go
@@ -105,7 +105,10 @@ func (t *BridgeTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, inp
 		"url", url.String(),
 	)
 
-	responseBytes, statusCode, headers, elapsed, err := makeHTTPRequest(ctx, lggr, "POST", URLParam(url), requestData, allowUnrestrictedNetworkAccess, t.config)
+	requestCtx, cancel := httpRequestCtx(ctx, t, t.config)
+	defer cancel()
+
+	responseBytes, statusCode, headers, elapsed, err := makeHTTPRequest(requestCtx, lggr, "POST", URLParam(url), requestData, allowUnrestrictedNetworkAccess, t.config.DefaultHTTPLimit())
 	if err != nil {
 		return Result{Error: err}, RunInfo{IsRetryable: isRetryableHTTPError(statusCode, err)}
 	}

--- a/core/services/pipeline/task.http.go
+++ b/core/services/pipeline/task.http.go
@@ -80,7 +80,10 @@ func (t *HTTPTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, input
 		"allowUnrestrictedNetworkAccess", allowUnrestrictedNetworkAccess,
 	)
 
-	responseBytes, statusCode, _, elapsed, err := makeHTTPRequest(ctx, lggr, method, url, requestData, allowUnrestrictedNetworkAccess, t.config)
+	requestCtx, cancel := httpRequestCtx(ctx, t, t.config)
+	defer cancel()
+
+	responseBytes, statusCode, _, elapsed, err := makeHTTPRequest(requestCtx, lggr, method, url, requestData, allowUnrestrictedNetworkAccess, t.config.DefaultHTTPLimit())
 	if err != nil {
 		if errors.Cause(err) == ErrDisallowedIP {
 			err = errors.Wrap(err, "connections to local resources are disabled by default, if you are sure this is safe, you can enable on a per-task basis by setting allowUnrestrictedNetworkAccess=true in the pipeline task spec")


### PR DESCRIPTION
- DEFAULT_HTTP_TIMEOUT no longer overrides the task `Timeout` setting
- DEFAULT_HTTP_TIMEOUT is now disabled if set to zero