### PR TITLE
core/utils: full float precision

### DIFF
--- a/core/utils/big.go
+++ b/core/utils/big.go
@@ -23,9 +23,13 @@ func (b BigFloat) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the json.Unmarshal interface.
 func (b *BigFloat) UnmarshalJSON(buf []byte) error {
-	var f float64
-	if err := json.Unmarshal(buf, &f); err == nil {
-		*b = BigFloat(*big.NewFloat(f))
+	var n json.Number
+	if err := json.Unmarshal(buf, &n); err == nil {
+		f, _, err := new(big.Float).Parse(n.String(), 0)
+		if err != nil {
+			return err
+		}
+		*b = BigFloat(*f)
 		return nil
 	}
 	var bf big.Float

--- a/core/utils/big_test.go
+++ b/core/utils/big_test.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,21 +27,25 @@ func TestBigFloatMarshal(t *testing.T) {
 
 func TestBigFloatUnmarshalFloat64(t *testing.T) {
 	tests := []struct {
-		payload float64
+		payload string
 		exp     *big.Float
 	}{
-		{-1, big.NewFloat(-1)},
-		{100, big.NewFloat(100)},
-		{3.146, big.NewFloat(3.146)},
+		{"-1", big.NewFloat(-1)},
+		{`"-1"`, big.NewFloat(-1)},
+		{"100", big.NewFloat(100)},
+		{`"100"`, big.NewFloat(100)},
+		{"3.146", big.NewFloat(3.146)},
+		{`"3.146"`, big.NewFloat(3.146)},
 	}
 
 	for _, tc := range tests {
-		var b BigFloat
-		buf, err := json.Marshal(tc.payload)
-		require.NoError(t, err)
-		err = json.Unmarshal([]byte(buf), &b)
-		require.NoError(t, err)
-		assert.Equal(t, tc.exp.String(), b.Value().String())
+		tc := tc
+		t.Run(tc.payload, func(t *testing.T) {
+			var b BigFloat
+			err := json.Unmarshal([]byte(tc.payload), &b)
+			require.NoError(t, err)
+			assert.Equal(t, tc.exp.String(), b.Value().String())
+		})
 	}
 }
 
@@ -52,15 +57,19 @@ func TestBigFloatUnmarshalString(t *testing.T) {
 		{"-1", big.NewFloat(-1)},
 		{"100", big.NewFloat(100)},
 		{"3.146", big.NewFloat(3.146)},
+		{"1.000000000000000001", decimal.RequireFromString("1.000000000000000001").BigFloat()},
+		{"1000000.000000000000000001", decimal.RequireFromString("1000000.000000000000000001").BigFloat()},
+		{"1000000000.000000000000000001", decimal.RequireFromString("1000000000.000000000000000001").BigFloat()},
 	}
 
 	for _, tc := range tests {
-		var b BigFloat
-		buf, err := json.Marshal(tc.payload)
-		require.NoError(t, err)
-		err = json.Unmarshal([]byte(buf), &b)
-		require.NoError(t, err)
-		assert.Equal(t, tc.exp.String(), b.Value().String())
+		tc := tc
+		t.Run(tc.payload, func(t *testing.T) {
+			var b BigFloat
+			err := json.Unmarshal([]byte(tc.payload), &b)
+			require.NoError(t, err)
+			assert.Equal(t, tc.exp.String(), b.Value().String())
+		})
 	}
 }
 

--- a/core/utils/ethabi.go
+++ b/core/utils/ethabi.go
@@ -3,16 +3,13 @@ package utils
 import (
 	"bytes"
 	"encoding/binary"
-	"encoding/hex"
 	"fmt"
 	"math/big"
-	"strconv"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
-
-	"github.com/pkg/errors"
-
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
+	"github.com/shopspring/decimal"
 	"github.com/tidwall/gjson"
 )
 
@@ -49,31 +46,6 @@ func GenericEncode(types []string, values ...interface{}) ([]byte, error) {
 // ConcatBytes appends a bunch of byte arrays into a single byte array
 func ConcatBytes(bufs ...[]byte) []byte {
 	return bytes.Join(bufs, []byte{})
-}
-
-// EVMTranscodeBytes converts a json input to an EVM bytes array
-func EVMTranscodeBytes(value gjson.Result) ([]byte, error) {
-	switch value.Type {
-	case gjson.String:
-		return EVMEncodeBytes([]byte(value.Str)), nil
-
-	case gjson.False:
-		return EVMEncodeBytes(EVMWordUint64(0)), nil
-
-	case gjson.True:
-		return EVMEncodeBytes(EVMWordUint64(1)), nil
-
-	case gjson.Number:
-		v := big.NewFloat(value.Num)
-		vInt, _ := v.Int(nil)
-		word, err := EVMWordSignedBigInt(vInt)
-		if err != nil {
-			return nil, errors.Wrap(err, "while converting float to int256")
-		}
-		return EVMEncodeBytes(word), nil
-	default:
-		return []byte{}, fmt.Errorf("unsupported encoding for value: %s", value.Type)
-	}
 }
 
 func roundToEVMWordBorder(length int) int {
@@ -127,15 +99,8 @@ func EVMTranscodeBool(value gjson.Result) ([]byte, error) {
 }
 
 func parseDecimalString(input string) (*big.Int, error) {
-	parseValue, err := strconv.ParseFloat(input, 64)
-	if err != nil {
-		return nil, err
-	}
-	output, ok := big.NewInt(0).SetString(fmt.Sprintf("%.f", parseValue), 10)
-	if !ok {
-		return nil, fmt.Errorf("error parsing decimal %s", input)
-	}
-	return output, nil
+	d, err := decimal.NewFromString(input)
+	return d.BigInt(), err
 }
 
 func parseNumericString(input string) (*big.Int, error) {
@@ -199,40 +164,6 @@ func EVMTranscodeInt256(value gjson.Result) ([]byte, error) {
 	}
 
 	return EVMWordSignedBigInt(output)
-}
-
-// EVMTranscodeJSONWithFormat given a JSON input and a format specifier, encode the
-// value for use by the EVM
-func EVMTranscodeJSONWithFormat(value gjson.Result, format string) ([]byte, error) {
-	switch format {
-	case FormatBytes:
-		return EVMTranscodeBytes(value)
-	case FormatPreformatted:
-		return hex.DecodeString(RemoveHexPrefix(value.Str))
-	case FormatUint256:
-		data, err := EVMTranscodeUint256(value)
-		if err != nil {
-			return []byte{}, err
-		}
-		return EVMEncodeBytes(data), nil
-
-	case FormatInt256:
-		data, err := EVMTranscodeInt256(value)
-		if err != nil {
-			return []byte{}, err
-		}
-		return EVMEncodeBytes(data), nil
-
-	case FormatBool:
-		data, err := EVMTranscodeBool(value)
-		if err != nil {
-			return []byte{}, err
-		}
-		return EVMEncodeBytes(data), nil
-
-	default:
-		return []byte{}, fmt.Errorf("unsupported format: %s", format)
-	}
 }
 
 func EVMWordAddress(val common.Address) []byte {


### PR DESCRIPTION
This change addresses two cases where unmarshling/parsing of 'Big' values was going through `float64` and losing precision along the way.