### PR TITLE
Terra relay integration bugs

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -29,8 +29,6 @@ RUN make contracts-operator-ui-build
 FROM golang:1.17-buster
 WORKDIR /chainlink
 
-RUN wget https://github.com/CosmWasm/wasmvm/raw/main/api/libwasmvm.so -O /usr/lib/libwasmvm.so
-
 COPY GNUmakefile VERSION ./
 COPY tools/bin/ldflags ./tools/bin/
 
@@ -64,7 +62,8 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
 
 COPY --from=1 /go/bin/chainlink /usr/local/bin/
 
-COPY --from=1 /usr/lib/libwasmvm.so /usr/lib/libwasmvm.so
+# dependency of terra-money/core
+COPY --from=1 /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@v*/api/libwasmvm.so /usr/lib/libwasmvm.so
 RUN chmod 755 /usr/lib/libwasmvm.so
 
 RUN if [ ${CHAINLINK_USER} != root ]; then \

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -29,6 +29,8 @@ RUN make contracts-operator-ui-build
 FROM golang:1.17-buster
 WORKDIR /chainlink
 
+RUN wget https://github.com/CosmWasm/wasmvm/raw/main/api/libwasmvm.so -O /usr/lib/libwasmvm.so
+
 COPY GNUmakefile VERSION ./
 COPY tools/bin/ldflags ./tools/bin/
 
@@ -61,6 +63,9 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - \
   && apt-get clean all
 
 COPY --from=1 /go/bin/chainlink /usr/local/bin/
+
+COPY --from=1 /usr/lib/libwasmvm.so /usr/lib/libwasmvm.so
+RUN chmod 755 /usr/lib/libwasmvm.so
 
 RUN if [ ${CHAINLINK_USER} != root ]; then \
   useradd --uid 14933 --create-home ${CHAINLINK_USER}; \

--- a/core/chains/terra/terratxm/txm.go
+++ b/core/chains/terra/terratxm/txm.go
@@ -306,10 +306,11 @@ func (txm *Txm) simulate(msgs []TerraMsg, sequence uint64) (*simResults, error) 
 			// remove offending msg and retry
 			if failureIndex == len(toSim)-1 {
 				// we're done, last one failed
+				txm.lggr.Errorw("simulation error found in last msg",  "failure", toSim[failureIndex], "failureIndex", failureIndex, "err", err)
 				break
 			}
 			// otherwise there may be more to sim
-			txm.lggr.Errorw("simulation error found in a msg", "retrying", toSim[failureIndex+1:], "failure", toSim[failureIndex], "failureIndex", failureIndex)
+			txm.lggr.Errorw("simulation error found in a msg", "retrying", toSim[failureIndex+1:], "failure", toSim[failureIndex], "failureIndex", failureIndex, "err", err)
 			toSim = toSim[failureIndex+1:]
 		} else {
 			// we're done they all succeeded

--- a/core/chains/terra/terratxm/txm.go
+++ b/core/chains/terra/terratxm/txm.go
@@ -306,7 +306,7 @@ func (txm *Txm) simulate(msgs []TerraMsg, sequence uint64) (*simResults, error) 
 			// remove offending msg and retry
 			if failureIndex == len(toSim)-1 {
 				// we're done, last one failed
-				txm.lggr.Errorw("simulation error found in last msg",  "failure", toSim[failureIndex], "failureIndex", failureIndex, "err", err)
+				txm.lggr.Errorw("simulation error found in last msg", "failure", toSim[failureIndex], "failureIndex", failureIndex, "err", err)
 				break
 			}
 			// otherwise there may be more to sim

--- a/core/services/keystore/keys/ocr2key/terra_keyring.go
+++ b/core/services/keystore/keys/ocr2key/terra_keyring.go
@@ -65,11 +65,17 @@ func (ok *terraKeyring) Sign(reportCtx ocrtypes.ReportContext, report ocrtypes.R
 }
 
 func (ok *terraKeyring) Verify(publicKey ocrtypes.OnchainPublicKey, reportCtx ocrtypes.ReportContext, report ocrtypes.Report, signature []byte) bool {
+	var cosmosPub cosmosed25519.PubKey
+	err := cosmosPub.UnmarshalAmino(publicKey)
+	if err != nil {
+		return false
+	}
 	hash, err := ok.reportToSigData(reportCtx, report)
 	if err != nil {
 		return false
 	}
-	return ok.PubKey().VerifySignature(hash, signature[32:])
+	result := cosmosPub.VerifySignature(hash, signature[32:])
+	return result
 }
 
 func (ok *terraKeyring) MaxSignatureLength() int {

--- a/core/services/keystore/keys/ocr2key/terra_keyring.go
+++ b/core/services/keystore/keys/ocr2key/terra_keyring.go
@@ -41,7 +41,7 @@ func (ok *terraKeyring) reportToSigData(reportCtx ocrtypes.ReportContext, report
 	if err != nil {
 		return nil, err
 	}
-	reportLen := make([]byte, 8)
+	reportLen := make([]byte, 4)
 	binary.BigEndian.PutUint32(reportLen[0:], uint32(len(report)))
 	h.Write(reportLen[:])
 	h.Write(report)
@@ -90,5 +90,6 @@ func (ok *terraKeyring) marshal() ([]byte, error) {
 func (ok *terraKeyring) unmarshal(in []byte) error {
 	key := cosmosed25519.GenPrivKeyFromSecret(in)
 	ok.PrivKey = key
+	ok.secret = in
 	return nil
 }

--- a/core/services/keystore/keys/ocr2key/terra_keyring_test.go
+++ b/core/services/keystore/keys/ocr2key/terra_keyring_test.go
@@ -1,0 +1,19 @@
+package ocr2key
+
+import (
+	"testing"
+
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2/types"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTerraKeyRing_Sign_Verify(t *testing.T) {
+	kr1 := newTerraKeyring()
+	kr2 := newTerraKeyring()
+	ctx := ocrtypes.ReportContext{}
+	report := ocrtypes.Report{}
+	sig, err := kr1.Sign(ctx, report)
+	require.NoError(t, err)
+	result := kr2.Verify(kr1.PublicKey(), ctx, report, sig)
+	require.True(t, result)
+}

--- a/core/services/keystore/models_test.go
+++ b/core/services/keystore/models_test.go
@@ -22,7 +22,7 @@ func TestKeyRing_Encrypt_Decrypt(t *testing.T) {
 	csa1, csa2 := csakey.MustNewV2XXXTestingOnly(big.NewInt(1)), csakey.MustNewV2XXXTestingOnly(big.NewInt(2))
 	eth1, eth2 := mustNewEthKey(t), mustNewEthKey(t)
 	ocr1, ocr2 := ocrkey.MustNewV2XXXTestingOnly(big.NewInt(1)), ocrkey.MustNewV2XXXTestingOnly(big.NewInt(2))
-	ocr2_1, ocr2_2, ocr2_3 := ocr2key.MustNewInsecure(rand.Reader, "evm"), ocr2key.MustNewInsecure(rand.Reader, "solana"), ocr2key.MustNewInsecure(rand.Reader, "terra")
+	ocr2_evm, ocr2_sol, ocr2_ter := ocr2key.MustNewInsecure(rand.Reader, "evm"), ocr2key.MustNewInsecure(rand.Reader, "solana"), ocr2key.MustNewInsecure(rand.Reader, "terra")
 	p2p1, p2p2 := p2pkey.MustNewV2XXXTestingOnly(big.NewInt(1)), p2pkey.MustNewV2XXXTestingOnly(big.NewInt(2))
 	sol1, sol2 := solkey.MustNewInsecure(rand.Reader), solkey.MustNewInsecure(rand.Reader)
 	vrf1, vrf2 := vrfkey.MustNewV2XXXTestingOnly(big.NewInt(1)), vrfkey.MustNewV2XXXTestingOnly(big.NewInt(2))
@@ -30,7 +30,7 @@ func TestKeyRing_Encrypt_Decrypt(t *testing.T) {
 		CSA:    []csakey.Raw{csa1.Raw(), csa2.Raw()},
 		Eth:    []ethkey.Raw{eth1.Raw(), eth2.Raw()},
 		OCR:    []ocrkey.Raw{ocr1.Raw(), ocr2.Raw()},
-		OCR2:   []ocr2key.Raw{ocr2_1.Raw(), ocr2_2.Raw(), ocr2_3.Raw()},
+		OCR2:   []ocr2key.Raw{ocr2_evm.Raw(), ocr2_sol.Raw(), ocr2_ter.Raw()},
 		P2P:    []p2pkey.Raw{p2p1.Raw(), p2p2.Raw()},
 		Solana: []solkey.Raw{sol1.Raw(), sol2.Raw()},
 		VRF:    []vrfkey.Raw{vrf1.Raw(), vrf2.Raw()},
@@ -64,12 +64,12 @@ func TestKeyRing_Encrypt_Decrypt(t *testing.T) {
 	require.Equal(t, originalKeyRing.OCR[ocr2.ID()].OffChainEncryption, decryptedKeyRing.OCR[ocr2.ID()].OffChainEncryption)
 	// compare ocr2 keys
 	require.Equal(t, 3, len(decryptedKeyRing.OCR2))
-	require.Equal(t, originalKeyRing.OCR2[ocr2_1.ID()].ID(), decryptedKeyRing.OCR2[ocr2_1.ID()].ID())
-	require.Equal(t, originalKeyRing.OCR2[ocr2_2.ID()].ID(), decryptedKeyRing.OCR2[ocr2_2.ID()].ID())
-	require.Equal(t, originalKeyRing.OCR2[ocr2_3.ID()].ID(), decryptedKeyRing.OCR2[ocr2_3.ID()].ID())
-	require.Equal(t, originalKeyRing.OCR2[ocr2_1.ID()].ChainType(), decryptedKeyRing.OCR2[ocr2_1.ID()].ChainType())
-	require.Equal(t, originalKeyRing.OCR2[ocr2_2.ID()].ChainType(), decryptedKeyRing.OCR2[ocr2_2.ID()].ChainType())
-	require.Equal(t, originalKeyRing.OCR2[ocr2_3.ID()].ChainType(), decryptedKeyRing.OCR2[ocr2_3.ID()].ChainType())
+	require.Equal(t, originalKeyRing.OCR2[ocr2_evm.ID()].ID(), decryptedKeyRing.OCR2[ocr2_evm.ID()].ID())
+	require.Equal(t, originalKeyRing.OCR2[ocr2_sol.ID()].ID(), decryptedKeyRing.OCR2[ocr2_sol.ID()].ID())
+	require.Equal(t, originalKeyRing.OCR2[ocr2_ter.ID()].ID(), decryptedKeyRing.OCR2[ocr2_ter.ID()].ID())
+	require.Equal(t, originalKeyRing.OCR2[ocr2_evm.ID()].ChainType(), decryptedKeyRing.OCR2[ocr2_evm.ID()].ChainType())
+	require.Equal(t, originalKeyRing.OCR2[ocr2_sol.ID()].ChainType(), decryptedKeyRing.OCR2[ocr2_sol.ID()].ChainType())
+	require.Equal(t, originalKeyRing.OCR2[ocr2_ter.ID()].ChainType(), decryptedKeyRing.OCR2[ocr2_ter.ID()].ChainType())
 	// compare p2p keys
 	require.Equal(t, 2, len(decryptedKeyRing.P2P))
 	require.Equal(t, originalKeyRing.P2P[p2p1.ID()].GetPublic(), decryptedKeyRing.P2P[p2p1.ID()].GetPublic())

--- a/core/services/keystore/models_test.go
+++ b/core/services/keystore/models_test.go
@@ -22,7 +22,7 @@ func TestKeyRing_Encrypt_Decrypt(t *testing.T) {
 	csa1, csa2 := csakey.MustNewV2XXXTestingOnly(big.NewInt(1)), csakey.MustNewV2XXXTestingOnly(big.NewInt(2))
 	eth1, eth2 := mustNewEthKey(t), mustNewEthKey(t)
 	ocr1, ocr2 := ocrkey.MustNewV2XXXTestingOnly(big.NewInt(1)), ocrkey.MustNewV2XXXTestingOnly(big.NewInt(2))
-	ocr2_1, ocr2_2 := ocr2key.MustNewInsecure(rand.Reader, "evm"), ocr2key.MustNewInsecure(rand.Reader, "solana")
+	ocr2_1, ocr2_2, ocr2_3 := ocr2key.MustNewInsecure(rand.Reader, "evm"), ocr2key.MustNewInsecure(rand.Reader, "solana"), ocr2key.MustNewInsecure(rand.Reader, "terra")
 	p2p1, p2p2 := p2pkey.MustNewV2XXXTestingOnly(big.NewInt(1)), p2pkey.MustNewV2XXXTestingOnly(big.NewInt(2))
 	sol1, sol2 := solkey.MustNewInsecure(rand.Reader), solkey.MustNewInsecure(rand.Reader)
 	vrf1, vrf2 := vrfkey.MustNewV2XXXTestingOnly(big.NewInt(1)), vrfkey.MustNewV2XXXTestingOnly(big.NewInt(2))
@@ -30,7 +30,7 @@ func TestKeyRing_Encrypt_Decrypt(t *testing.T) {
 		CSA:    []csakey.Raw{csa1.Raw(), csa2.Raw()},
 		Eth:    []ethkey.Raw{eth1.Raw(), eth2.Raw()},
 		OCR:    []ocrkey.Raw{ocr1.Raw(), ocr2.Raw()},
-		OCR2:   []ocr2key.Raw{ocr2_1.Raw(), ocr2_2.Raw()},
+		OCR2:   []ocr2key.Raw{ocr2_1.Raw(), ocr2_2.Raw(), ocr2_3.Raw()},
 		P2P:    []p2pkey.Raw{p2p1.Raw(), p2p2.Raw()},
 		Solana: []solkey.Raw{sol1.Raw(), sol2.Raw()},
 		VRF:    []vrfkey.Raw{vrf1.Raw(), vrf2.Raw()},
@@ -63,11 +63,13 @@ func TestKeyRing_Encrypt_Decrypt(t *testing.T) {
 	require.Equal(t, originalKeyRing.OCR[ocr2.ID()].OffChainSigning, decryptedKeyRing.OCR[ocr2.ID()].OffChainSigning)
 	require.Equal(t, originalKeyRing.OCR[ocr2.ID()].OffChainEncryption, decryptedKeyRing.OCR[ocr2.ID()].OffChainEncryption)
 	// compare ocr2 keys
-	require.Equal(t, 2, len(decryptedKeyRing.OCR2))
+	require.Equal(t, 3, len(decryptedKeyRing.OCR2))
 	require.Equal(t, originalKeyRing.OCR2[ocr2_1.ID()].ID(), decryptedKeyRing.OCR2[ocr2_1.ID()].ID())
 	require.Equal(t, originalKeyRing.OCR2[ocr2_2.ID()].ID(), decryptedKeyRing.OCR2[ocr2_2.ID()].ID())
+	require.Equal(t, originalKeyRing.OCR2[ocr2_3.ID()].ID(), decryptedKeyRing.OCR2[ocr2_3.ID()].ID())
 	require.Equal(t, originalKeyRing.OCR2[ocr2_1.ID()].ChainType(), decryptedKeyRing.OCR2[ocr2_1.ID()].ChainType())
 	require.Equal(t, originalKeyRing.OCR2[ocr2_2.ID()].ChainType(), decryptedKeyRing.OCR2[ocr2_2.ID()].ChainType())
+	require.Equal(t, originalKeyRing.OCR2[ocr2_3.ID()].ChainType(), decryptedKeyRing.OCR2[ocr2_3.ID()].ChainType())
 	// compare p2p keys
 	require.Equal(t, 2, len(decryptedKeyRing.P2P))
 	require.Equal(t, originalKeyRing.P2P[p2p1.ID()].GetPublic(), decryptedKeyRing.P2P[p2p1.ID()].GetPublic())

--- a/core/services/keystore/ocr2_test.go
+++ b/core/services/keystore/ocr2_test.go
@@ -22,7 +22,8 @@ func Test_OCR2KeyStore_E2E(t *testing.T) {
 		_, err := db.Exec("DELETE FROM encrypted_key_rings")
 		require.NoError(t, err)
 		keyStore.ResetXXXTestOnly()
-		keyStore.Unlock(cltest.Password)
+		err = keyStore.Unlock(cltest.Password)
+		require.NoError(t, err)
 	}
 
 	t.Run("initializes with an empty state", func(t *testing.T) {


### PR DESCRIPTION
This PR addresses the following:
* [x] adds `libwasmvm.so` to the chainlink image (dep of terra-core)
* [x] fixes a bug in the reportToSigData func, where the byte array was 2X bigger than expected on the contract
* [x] fixes a terra key bug where verifying sigs was using the wrong pub key
* [x] fixes a terra key bug where marshaling / unmarshaling was borked