### PR TITLE
Enable endpoint to list OCR2 key bundles

### DIFF
--- a/core/web/resolver/ocr2_keys_test.go
+++ b/core/web/resolver/ocr2_keys_test.go
@@ -1,0 +1,97 @@
+package resolver
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	gqlerrors "github.com/graph-gophers/graphql-go/errors"
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils/keystest"
+	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ocr2key"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolver_GetOCR2KeyBundles(t *testing.T) {
+	t.Parallel()
+
+	query := `
+		query GetOCR2KeyBundles {
+			ocr2KeyBundles {
+				results {
+					chainType
+					configPublicKey
+					offChainPublicKey
+					onChainPublicKey
+				}
+			}
+		}
+	`
+
+	gError := errors.New("error")
+	fakeKeys := []ocr2key.KeyBundle{
+		ocr2key.MustNewInsecure(keystest.NewRandReaderFromSeed(1), "evm"),
+		ocr2key.MustNewInsecure(keystest.NewRandReaderFromSeed(1), "terra"),
+		ocr2key.MustNewInsecure(keystest.NewRandReaderFromSeed(1), "solana"),
+	}
+	expectedBundles := []map[string]interface{}{}
+	for _, k := range fakeKeys {
+		configPublic := k.ConfigEncryptionPublicKey()
+		ct, err := ToOCR2ChainType(string(k.ChainType()))
+		require.NoError(t, err)
+
+		expectedBundles = append(expectedBundles, map[string]interface{}{
+			"chainType":         ct,
+			"onChainPublicKey":  fmt.Sprintf("ocr2on_%s_%s", k.ChainType(), k.OnChainPublicKey()),
+			"configPublicKey":   fmt.Sprintf("ocr2cfg_%s_%s", k.ChainType(), hex.EncodeToString(configPublic[:])),
+			"offChainPublicKey": fmt.Sprintf("ocr2off_%s_%s", k.ChainType(), hex.EncodeToString(k.OffchainPublicKey())),
+		})
+	}
+
+	d, err := json.Marshal(map[string]interface{}{
+		"ocr2KeyBundles": map[string]interface{}{
+			"results": expectedBundles,
+		},
+	})
+	assert.NoError(t, err)
+	expected := string(d)
+
+	testCases := []GQLTestCase{
+		unauthorizedTestCase(GQLTestCase{query: query}, "ocr2KeyBundles"),
+		{
+			name:          "success",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.ocr2.On("GetAll").Return(fakeKeys, nil)
+				f.Mocks.keystore.On("OCR2").Return(f.Mocks.ocr2)
+				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
+			},
+			query:  query,
+			result: expected,
+		},
+		{
+			name:          "generic error on GetAll()",
+			authenticated: true,
+			before: func(f *gqlTestFramework) {
+				f.Mocks.ocr2.On("GetAll").Return(nil, gError)
+				f.Mocks.keystore.On("OCR2").Return(f.Mocks.ocr2)
+				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
+			},
+			query:  query,
+			result: `null`,
+			errors: []*gqlerrors.QueryError{
+				{
+					Extensions:    nil,
+					ResolverError: gError,
+					Path:          []interface{}{"ocr2KeyBundles"},
+					Message:       gError.Error(),
+				},
+			},
+		},
+	}
+
+	RunGQLTests(t, testCases)
+}

--- a/core/web/resolver/orc2_keys.go
+++ b/core/web/resolver/orc2_keys.go
@@ -1,0 +1,94 @@
+package resolver
+
+import (
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ocr2key"
+)
+
+type OCR2ChainType string
+
+const (
+	OCR2ChainTypeEVM    OCR2ChainType = "EMV"
+	OCR2ChainTypeSolana OCR2ChainType = "SOLANA"
+	OCR2ChainTypeTerra  OCR2ChainType = "TERRA"
+)
+
+func ToOCR2ChainType(s string) (OCR2ChainType, error) {
+	switch s {
+	case "evm":
+		return OCR2ChainTypeEVM, nil
+	case "solana":
+		return OCR2ChainTypeSolana, nil
+	case "terra":
+		return OCR2ChainTypeTerra, nil
+	default:
+		return "", errors.New("invalid ocr2 chain type")
+	}
+}
+
+func FromOCR2ChainType(ct OCR2ChainType) string {
+	switch ct {
+	case OCR2ChainTypeEVM:
+		return "evm"
+	case OCR2ChainTypeSolana:
+		return "solana"
+	case OCR2ChainTypeTerra:
+		return "terra"
+	default:
+		return strings.ToLower(string(ct))
+	}
+}
+
+type OCR2KeyBundleResolver struct {
+	key ocr2key.KeyBundle
+}
+
+func NewOCR2KeyBundle(key ocr2key.KeyBundle) *OCR2KeyBundleResolver {
+	return &OCR2KeyBundleResolver{key: key}
+}
+
+func (r OCR2KeyBundleResolver) ChainType() *OCR2ChainType {
+	ct, err := ToOCR2ChainType(string(r.key.ChainType()))
+	if err != nil {
+		return nil
+	}
+
+	return &ct
+}
+
+func (r OCR2KeyBundleResolver) OnChainPublicKey() string {
+	return fmt.Sprintf("ocr2on_%s_%s", r.key.ChainType(), r.key.OnChainPublicKey())
+}
+
+func (r OCR2KeyBundleResolver) OffChainPublicKey() string {
+	return fmt.Sprintf("ocr2off_%s_%s", r.key.ChainType(), hex.EncodeToString(r.key.OffchainPublicKey()))
+}
+
+func (r OCR2KeyBundleResolver) ConfigPublicKey() string {
+	configPublic := r.key.ConfigEncryptionPublicKey()
+	return fmt.Sprintf("ocr2cfg_%s_%s", r.key.ChainType(), hex.EncodeToString(configPublic[:]))
+}
+
+// -- OCR2Keys Query --
+
+type OCR2KeyBundlesPayloadResolver struct {
+	keys []ocr2key.KeyBundle
+}
+
+func NewOCR2KeyBundlesPayload(keys []ocr2key.KeyBundle) *OCR2KeyBundlesPayloadResolver {
+	return &OCR2KeyBundlesPayloadResolver{keys: keys}
+}
+
+func (r *OCR2KeyBundlesPayloadResolver) Results() []OCR2KeyBundleResolver {
+	var results []OCR2KeyBundleResolver
+
+	for _, k := range r.keys {
+		results = append(results, *NewOCR2KeyBundle(k))
+	}
+
+	return results
+}

--- a/core/web/resolver/orc2_keys.go
+++ b/core/web/resolver/orc2_keys.go
@@ -15,9 +15,9 @@ type OCR2ChainType string
 const (
 	// OCR2ChainTypeEVM defines OCR2 EVM Chain Type
 	OCR2ChainTypeEVM OCR2ChainType = "EMV"
-	// OCR2ChainType defines OCR2 Solana Chain Type
+	// OCR2ChainTypeSolana defines OCR2 Solana Chain Type
 	OCR2ChainTypeSolana OCR2ChainType = "SOLANA"
-	// OCR2ChainType defines OCR2 Terra Chain Type
+	// OCR2ChainTypeTerra defines OCR2 Terra Chain Type
 	OCR2ChainTypeTerra OCR2ChainType = "TERRA"
 )
 

--- a/core/web/resolver/orc2_keys.go
+++ b/core/web/resolver/orc2_keys.go
@@ -9,14 +9,19 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ocr2key"
 )
 
+// OCR2ChainType defines OCR2 Chain Types accepted on this resolver
 type OCR2ChainType string
 
 const (
-	OCR2ChainTypeEVM    OCR2ChainType = "EMV"
+	// OCR2ChainTypeEVM defines OCR2 EVM Chain Type
+	OCR2ChainTypeEVM OCR2ChainType = "EMV"
+	// OCR2ChainType defines OCR2 Solana Chain Type
 	OCR2ChainTypeSolana OCR2ChainType = "SOLANA"
-	OCR2ChainTypeTerra  OCR2ChainType = "TERRA"
+	// OCR2ChainType defines OCR2 Terra Chain Type
+	OCR2ChainTypeTerra OCR2ChainType = "TERRA"
 )
 
+// ToOCR2ChainType turns a valid string into a OCR2ChainType
 func ToOCR2ChainType(s string) (OCR2ChainType, error) {
 	switch s {
 	case "evm":
@@ -30,6 +35,7 @@ func ToOCR2ChainType(s string) (OCR2ChainType, error) {
 	}
 }
 
+// FromOCR2ChainType returns the string (lowercased) value from a OCR2ChainType
 func FromOCR2ChainType(ct OCR2ChainType) string {
 	switch ct {
 	case OCR2ChainTypeEVM:
@@ -43,14 +49,17 @@ func FromOCR2ChainType(ct OCR2ChainType) string {
 	}
 }
 
+// OCR2KeyBundleResolver defines the OCR2 Key bundle on GQL
 type OCR2KeyBundleResolver struct {
 	key ocr2key.KeyBundle
 }
 
+// NewOCR2KeyBundle creates a new GQL OCR2 key bundle resolver
 func NewOCR2KeyBundle(key ocr2key.KeyBundle) *OCR2KeyBundleResolver {
 	return &OCR2KeyBundleResolver{key: key}
 }
 
+// ChainType returns the OCR2 Key bundle chain type
 func (r OCR2KeyBundleResolver) ChainType() *OCR2ChainType {
 	ct, err := ToOCR2ChainType(string(r.key.ChainType()))
 	if err != nil {
@@ -60,14 +69,17 @@ func (r OCR2KeyBundleResolver) ChainType() *OCR2ChainType {
 	return &ct
 }
 
+// OnChainPublicKey returns the OCR2 Key bundle on-chain public key
 func (r OCR2KeyBundleResolver) OnChainPublicKey() string {
 	return fmt.Sprintf("ocr2on_%s_%s", r.key.ChainType(), r.key.OnChainPublicKey())
 }
 
+// OffChainPublicKey returns the OCR2 Key bundle off-chain public key
 func (r OCR2KeyBundleResolver) OffChainPublicKey() string {
 	return fmt.Sprintf("ocr2off_%s_%s", r.key.ChainType(), hex.EncodeToString(r.key.OffchainPublicKey()))
 }
 
+// ConfigPublicKey returns the OCR2 Key bundle config public key
 func (r OCR2KeyBundleResolver) ConfigPublicKey() string {
 	configPublic := r.key.ConfigEncryptionPublicKey()
 	return fmt.Sprintf("ocr2cfg_%s_%s", r.key.ChainType(), hex.EncodeToString(configPublic[:]))
@@ -75,14 +87,17 @@ func (r OCR2KeyBundleResolver) ConfigPublicKey() string {
 
 // -- OCR2Keys Query --
 
+// OCR2KeyBundlesPayloadResolver defines the OCR2 Key bundles query resolver
 type OCR2KeyBundlesPayloadResolver struct {
 	keys []ocr2key.KeyBundle
 }
 
+// NewOCR2KeyBundlesPayload returns the OCR2 key bundles resolver
 func NewOCR2KeyBundlesPayload(keys []ocr2key.KeyBundle) *OCR2KeyBundlesPayloadResolver {
 	return &OCR2KeyBundlesPayloadResolver{keys: keys}
 }
 
+// Results resolves the list of OCR2 key bundles
 func (r *OCR2KeyBundlesPayloadResolver) Results() []OCR2KeyBundleResolver {
 	var results []OCR2KeyBundleResolver
 

--- a/core/web/resolver/orc2_keys.go
+++ b/core/web/resolver/orc2_keys.go
@@ -14,7 +14,7 @@ type OCR2ChainType string
 
 const (
 	// OCR2ChainTypeEVM defines OCR2 EVM Chain Type
-	OCR2ChainTypeEVM OCR2ChainType = "EMV"
+	OCR2ChainTypeEVM OCR2ChainType = "EVM"
 	// OCR2ChainTypeSolana defines OCR2 Solana Chain Type
 	OCR2ChainTypeSolana OCR2ChainType = "SOLANA"
 	// OCR2ChainTypeTerra defines OCR2 Terra Chain Type

--- a/core/web/resolver/query.go
+++ b/core/web/resolver/query.go
@@ -534,6 +534,7 @@ func (r *Resolver) SQLLogging(ctx context.Context) (*GetSQLLoggingPayloadResolve
 	return NewGetSQLLoggingPayload(enabled), nil
 }
 
+// OCR2KeyBundles resolves the list of OCR2 key bundles
 func (r *Resolver) OCR2KeyBundles(ctx context.Context) (*OCR2KeyBundlesPayloadResolver, error) {
 	if err := authenticateUser(ctx); err != nil {
 		return nil, err

--- a/core/web/resolver/query.go
+++ b/core/web/resolver/query.go
@@ -533,3 +533,16 @@ func (r *Resolver) SQLLogging(ctx context.Context) (*GetSQLLoggingPayloadResolve
 
 	return NewGetSQLLoggingPayload(enabled), nil
 }
+
+func (r *Resolver) OCR2KeyBundles(ctx context.Context) (*OCR2KeyBundlesPayloadResolver, error) {
+	if err := authenticateUser(ctx); err != nil {
+		return nil, err
+	}
+
+	ekbs, err := r.App.GetKeyStore().OCR2().GetAll()
+	if err != nil {
+		return nil, err
+	}
+
+	return NewOCR2KeyBundlesPayload(ekbs), nil
+}

--- a/core/web/resolver/resolver_test.go
+++ b/core/web/resolver/resolver_test.go
@@ -39,6 +39,7 @@ type mocks struct {
 	cfg         *configMocks.GeneralConfig
 	scfg        *evmConfigMocks.ChainScopedConfig
 	ocr         *keystoreMocks.OCR
+	ocr2        *keystoreMocks.OCR2
 	csa         *keystoreMocks.CSA
 	keystore    *keystoreMocks.Master
 	ethKs       *keystoreMocks.Eth
@@ -95,6 +96,7 @@ func setupFramework(t *testing.T) *gqlTestFramework {
 		cfg:         &configMocks.GeneralConfig{},
 		scfg:        &evmConfigMocks.ChainScopedConfig{},
 		ocr:         &keystoreMocks.OCR{},
+		ocr2:        &keystoreMocks.OCR2{},
 		csa:         &keystoreMocks.CSA{},
 		keystore:    &keystoreMocks.Master{},
 		ethKs:       &keystoreMocks.Eth{},
@@ -122,6 +124,7 @@ func setupFramework(t *testing.T) *gqlTestFramework {
 			m.cfg,
 			m.scfg,
 			m.ocr,
+			m.ocr2,
 			m.csa,
 			m.keystore,
 			m.ethKs,

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -30,6 +30,7 @@ type Query {
     node(id: ID!): NodePayload!
     nodes(offset: Int, limit: Int): NodesPayload!
     ocrKeyBundles: OCRKeyBundlesPayload!
+    ocr2KeyBundles: OCR2KeyBundlesPayload!
     p2pKeys: P2PKeysPayload!
     solanaKeys: SolanaKeysPayload!
     sqlLogging: GetSQLLoggingPayload!

--- a/core/web/schema/type/orc2_keys.graphql
+++ b/core/web/schema/type/orc2_keys.graphql
@@ -1,5 +1,5 @@
 enum OCR2ChainType {
-    EMV
+    EVM
     TERRA
 	SOLANA
 }

--- a/core/web/schema/type/orc2_keys.graphql
+++ b/core/web/schema/type/orc2_keys.graphql
@@ -1,0 +1,18 @@
+enum OCR2ChainType {
+    EMV
+    TERRA
+	SOLANA
+}
+
+
+type OCR2KeyBundle {
+	chainType: OCR2ChainType
+	configPublicKey: String!
+	onChainPublicKey: String!
+	offChainPublicKey: String!
+}
+
+type OCR2KeyBundlesPayload {
+    results: [OCR2KeyBundle!]!
+}
+


### PR DESCRIPTION
Closes: https://app.shortcut.com/chainlinklabs/story/24012/add-a-query-to-list-all-ocr2-key-bundles