### PR TITLE
Implement mutation to delete OCR2 key bundles

### DIFF
--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -1122,3 +1122,25 @@ func (r *Resolver) CreateOCR2KeyBundle(ctx context.Context, args struct {
 
 	return NewCreateOCR2KeyBundlePayload(&key), nil
 }
+
+// DeleteOCR2KeyBundle resolves a create OCR2 Key bundle mutation
+func (r *Resolver) DeleteOCR2KeyBundle(ctx context.Context, args struct {
+	ID graphql.ID
+}) (*DeleteOCR2KeyBundlePayloadResolver, error) {
+	if err := authenticateUser(ctx); err != nil {
+		return nil, err
+	}
+
+	id := string(args.ID)
+	key, err := r.App.GetKeyStore().OCR2().Get(id)
+	if err != nil {
+		return NewDeleteOCR2KeyBundlePayloadResolver(nil, err), nil
+	}
+
+	err = r.App.GetKeyStore().OCR2().Delete(id)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewDeleteOCR2KeyBundlePayloadResolver(&key, nil), nil
+}

--- a/core/web/schema/schema.graphql
+++ b/core/web/schema/schema.graphql
@@ -58,6 +58,7 @@ type Mutation {
     deleteJob(id: ID!): DeleteJobPayload!
     deleteNode(id: ID!): DeleteNodePayload!
     deleteOCRKeyBundle(id: ID!): DeleteOCRKeyBundlePayload!
+    deleteOCR2KeyBundle(id: ID!): DeleteOCR2KeyBundlePayload!
     deleteP2PKey(id: ID!): DeleteP2PKeyPayload!
     createVRFKey: CreateVRFKeyPayload!
     deleteVRFKey(id: ID!): DeleteVRFKeyPayload!

--- a/core/web/schema/type/orc2_keys.graphql
+++ b/core/web/schema/type/orc2_keys.graphql
@@ -6,6 +6,7 @@ enum OCR2ChainType {
 
 
 type OCR2KeyBundle {
+	id: ID!
 	chainType: OCR2ChainType
 	configPublicKey: String!
 	onChainPublicKey: String!
@@ -22,3 +23,8 @@ type CreateOCR2KeyBundleSuccess {
 
 union CreateOCR2KeyBundlePayload = CreateOCR2KeyBundleSuccess
 
+type DeleteOCR2KeyBundleSuccess {
+    bundle: OCR2KeyBundle!
+}
+
+union DeleteOCR2KeyBundlePayload = DeleteOCR2KeyBundleSuccess | NotFoundError


### PR DESCRIPTION
Closes: https://app.shortcut.com/chainlinklabs/story/24013/add-a-mutation-to-delete-an-ocr2-key-bundle