### PR TITLE
Add GHA version of CD pipeline

### DIFF
--- a/.github/actions/build-publish-chainlink/action.yml
+++ b/.github/actions/build-publish-chainlink/action.yml
@@ -1,0 +1,117 @@
+name: Build and Publish Chainlink
+
+description: A composite action that allows building and publishing chainlink images
+
+inputs:
+  # Inputs for publishing
+  publish:
+    description: When set to the string boolean value of "true", the resulting built image will be published
+    default: "false" 
+    required: false
+  
+  image-name:
+    description: The name of the image, should match the repository name in ECR
+    required: true
+  
+  ecr-registry:
+    description: The ECR registry to push to, used in docker/login-action and for tagging images
+    default: public.ecr.aws/chainlink
+    required: false 
+  aws-access-key-id:
+    description: The IAM access key used to authenticate to ECR, used in docker/login-action
+    required: false
+  aws-access-key-secret:
+    description: The IAM access key secret used to authenticate to ECR, used in docker/login-action
+    required: false
+  aws-region: 
+    description: The AWS region the ECR repository is located in, should only be needed for public ECR repositories, used in docker/login-action
+    required: false    
+
+runs:
+  using: composite
+  steps:
+  - name: Set shared variables
+    shell: sh
+    # See https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#multiline-strings
+    run: |
+      SHARED_IMAGES=${{ inputs.ecr-registry }}/${{ inputs.image-name }}
+
+      SHARED_TAG_LIST=$(cat << EOF
+      type=ref,event=branch
+      type=semver,pattern={{version}}
+      type=sha,format=short
+      EOF
+      )
+
+      SHARED_BUILD_ARGS=$(cat << EOF
+      COMMIT_SHA:${{ github.sha }}
+      ENVIRONMENT:release
+      EOF
+      )
+
+      echo "shared-images<<EOF" >> $GITHUB_ENV
+      echo "$SHARED_IMAGES" >> $GITHUB_ENV
+      echo "EOF" >> $GITHUB_ENV
+
+      echo "shared-tag-list<<EOF" >> $GITHUB_ENV
+      echo "$SHARED_TAG_LIST" >> $GITHUB_ENV
+      echo "EOF" >> $GITHUB_ENV
+
+      echo "shared-build-args<<EOF" >> $GITHUB_ENV
+      echo "$SHARED_BUILD_ARGS" >> $GITHUB_ENV
+      echo "EOF" >> $GITHUB_ENV
+
+  - if: inputs.publish == 'true'
+    name: Login to ECR
+    uses: docker/login-action@42d299face0c5c43a0487c477f595ac9cf22f1a7 # v1.12.0
+    with:
+      registry: ${{ inputs.ecr-registry }}
+      username: ${{ inputs.aws-access-key-id }}
+      password: ${{ inputs.aws-access-key-secret }}
+    env:
+      AWS_REGION: ${{ inputs.aws-region }}
+
+  - name: Setup Docker Buildx
+    uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # v1.6.0
+  
+  - name: Generate docker metadata for root image
+    id: meta-root
+    uses: docker/metadata-action@e5622373a38e60fb6d795a4421e56882f2d7a681 # v3.6.2
+    with:
+      # list of Docker images to use as base name for tags
+      images: ${{ env.shared-images }}
+      tags: ${{ env.shared-tag-list }}
+      
+  
+  - name: Build and push root docker image
+    uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229 # v2.7.0
+    with:
+      push: ${{ inputs.publish }}
+      tags: ${{ steps.meta-root.outputs.tags }}
+      labels: ${{ steps.meta-root.outputs.labels }}
+      file: core/chainlink.Dockerfile
+      build-args: |
+        CHAINLINK_USER:root
+        ${{ env.shared-build-args }}
+  
+  - name: Generate docker metadata for non-root image 
+    id: meta-nonroot
+    uses: docker/metadata-action@e5622373a38e60fb6d795a4421e56882f2d7a681 # v3.6.2
+    with:
+      flavor: |
+        latest=auto
+        prefix=
+        suffix=-nonroot,onlatest=true
+      images: ${{ env.shared-images }}
+      tags: ${{ env.shared-tag-list }}
+  
+  - name: Build and push non-root docker image
+    uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229 # v2.7.0
+    with:
+      push: ${{ inputs.publish }}
+      tags: ${{ steps.meta-nonroot.outputs.tags }}
+      labels: ${{ steps.meta-nonroot.outputs.labels }}
+      file: core/chainlink.Dockerfile
+      build-args: |
+        CHAINLINK_USER:chainlink
+        ${{ env.shared-build-args }}

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -6,7 +6,7 @@ on:
     tags:
       - 'v*'
     branches:
-      - main
+      - master
       - develop
       - 'release/*'
 

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -1,0 +1,28 @@
+name: 'Build Chainlink and Publish'
+
+on:
+  # Mimics old circleci behaviour
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main
+      - develop
+      - 'release/*'
+
+jobs:
+  build-publish-chainlink:
+    runs-on: ubuntu-20.04
+    environment: build-publish
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+
+      - name: Build and publish chainlink image
+        uses: ./.github/actions/build-publish-chainlink
+        with:
+          publish: true
+          image-name: test-chainlink
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-access-key-secret: ${{ secrets.AWS_ACCESS_KEY_SECRET }}
+          aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
   push:
     branches:
-      - main
+      - master
 
 jobs:
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: 'Build Chainlink'
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+
+  build-chainlink:
+    runs-on: ubuntu-20.04
+    environment: build
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+
+      - name: Build chainlink image
+        uses: ./.github/actions/build-publish-chainlink
+        with:
+          publish: false
+          image-name: test-chainlink


### PR DESCRIPTION
Adds a CD pipeline that serves as a replacement for our current circleci pipeline. Note the `test-chainlink` image name for the respective `build` and `build-publish` environments. Once this passes testing, then we'll be able to change this value to a prod value. 