### PR TITLE
Remove GQL disable instrospection

### DIFF
--- a/core/web/router.go
+++ b/core/web/router.go
@@ -99,7 +99,6 @@ func graphqlHandler(app chainlink.Application) gin.HandlerFunc {
 	schemaOpts := []graphql.SchemaOpt{}
 	if !app.GetConfig().Dev() {
 		schemaOpts = append(schemaOpts,
-			graphql.DisableIntrospection(),
 			graphql.MaxDepth(10),
 		)
 	}


### PR DESCRIPTION
Disabling introspection disables the ability for the UI to request the __typename
of objects, which it uses for caching. This was causing the UI to crash or display
undefined data.