### PR TITLE
Prevent panics on unexpected EIP1559 errors

### DIFF
--- a/core/services/bulletprooftxmanager/eth_broadcaster.go
+++ b/core/services/bulletprooftxmanager/eth_broadcaster.go
@@ -435,7 +435,7 @@ func (eb *EthBroadcaster) handleInProgressEthTx(etx EthTx, attempt EthTxAttempt,
 		// success (even though the transaction will never confirm) and hand
 		// off to the ethConfirmer to bump gas periodically until we _can_ get
 		// it in
-		eb.logger.Infow("Transaction temporarily underpriced", "ethTxID", etx.ID, "err", sendError.Error(), "gasPriceWei", attempt.GasPrice.String())
+		eb.logger.Infow("Transaction temporarily underpriced", "ethTxID", etx.ID, "err", sendError.Error(), "gasPrice", attempt.GasPrice, "gasTipCap", attempt.GasTipCap, "gasFeeCap", attempt.GasFeeCap)
 		sendError = nil
 	}
 

--- a/core/services/bulletprooftxmanager/eth_confirmer.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer.go
@@ -1031,8 +1031,7 @@ func (ec *EthConfirmer) handleInProgressAttempt(ctx context.Context, etx EthTx, 
 		}
 		promNumGasBumps.WithLabelValues(ec.chainID.String()).Inc()
 		ec.lggr.Errorw(
-			fmt.Sprintf("gas price %v wei was rejected by the eth node for being too low. Eth node returned: '%s'",
-				attempt.GasPrice.String(), sendError.Error()),
+			fmt.Sprintf("gas price was rejected by the eth node for being too low. Eth node returned: '%s'", sendError.Error()),
 			"previousAttempt", attempt, "replacementAttempt", replacementAttempt)
 
 		if err := saveReplacementInProgressAttempt(ec.q, attempt, &replacementAttempt); err != nil {
@@ -1108,22 +1107,22 @@ func (ec *EthConfirmer) handleInProgressAttempt(ctx context.Context, etx EthTx, 
 		// In this case the simplest and most robust way to recover is to ignore
 		// this attempt and wait until the next bump threshold is reached in
 		// order to bump again.
-		ec.lggr.Errorw(fmt.Sprintf("Replacement transaction underpriced at %v wei for eth_tx %v. "+
+		ec.lggr.Errorw(fmt.Sprintf("Replacement transaction underpriced for eth_tx %v. "+
 			"Eth node returned error: '%s'. "+
 			"Either you have set ETH_GAS_BUMP_PERCENT (currently %v%%) too low or an external wallet used this account. "+
 			"Please note that using your node's private keys outside of the chainlink node is NOT SUPPORTED and can lead to missed transactions.",
-			attempt.GasPrice.ToInt().Int64(), etx.ID, sendError.Error(), ec.config.EvmGasBumpPercent()), "err", sendError)
+			etx.ID, sendError.Error(), ec.config.EvmGasBumpPercent()), "err", sendError, "gasPrice", attempt.GasPrice, "gasTipCap", attempt.GasTipCap, "gasFeeCap", attempt.GasFeeCap)
 
 		// Assume success and hand off to the next cycle.
 		sendError = nil
 	}
 
 	if sendError.IsInsufficientEth() {
-		ec.lggr.Errorw(fmt.Sprintf("EthTxAttempt %v (hash 0x%x) at gas price (%s Wei) was rejected due to insufficient eth. "+
+		ec.lggr.Errorw(fmt.Sprintf("EthTxAttempt %v (hash 0x%x) was rejected due to insufficient eth. "+
 			"The eth node returned %s. "+
 			"ACTION REQUIRED: Chainlink wallet with address 0x%x is OUT OF FUNDS",
-			attempt.ID, attempt.Hash, attempt.GasPrice.String(), sendError.Error(), etx.FromAddress,
-		), "err", sendError)
+			attempt.ID, attempt.Hash, sendError.Error(), etx.FromAddress,
+		), "err", sendError, "gasPrice", attempt.GasPrice, "gasTipCap", attempt.GasTipCap, "gasFeeCap", attempt.GasFeeCap)
 		return saveInsufficientEthAttempt(ec.q, ec.lggr, &attempt, now)
 	}
 
@@ -1387,7 +1386,7 @@ func (ec *EthConfirmer) ForceRebroadcast(beginningNonce uint, endingNonce uint, 
 				continue
 			}
 			if err := sendTransaction(context.TODO(), ec.ethClient, attempt, *etx, ec.lggr); err != nil {
-				ec.lggr.Errorw(fmt.Sprintf("ForceRebroadcast: failed to rebroadcast eth_tx %v with nonce %v at gas price %s wei and gas limit %v: %s", etx.ID, *etx.Nonce, attempt.GasPrice.String(), etx.GasLimit, err.Error()), "err", err)
+				ec.lggr.Errorw(fmt.Sprintf("ForceRebroadcast: failed to rebroadcast eth_tx %v with nonce %v and gas limit %v: %s", etx.ID, *etx.Nonce, etx.GasLimit, err.Error()), "err", err, "gasPrice", attempt.GasPrice, "gasTipCap", attempt.GasTipCap, "gasFeeCap", attempt.GasFeeCap)
 				continue
 			}
 			ec.lggr.Infof("ForceRebroadcast: successfully rebroadcast eth_tx %v with hash: 0x%x", etx.ID, attempt.Hash)

--- a/core/services/bulletprooftxmanager/eth_confirmer_test.go
+++ b/core/services/bulletprooftxmanager/eth_confirmer_test.go
@@ -1849,7 +1849,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 		oldEnough, utils.NewBig(assets.GWei(35)), utils.NewBig(assets.GWei(100)), attempt4_1.ID))
 	var attempt4_2 bulletprooftxmanager.EthTxAttempt
 
-	t.Run("bumps using EIP-1559 rules when existing attempts are of type 0x2", func(t *testing.T) {
+	t.Run("EIP-1559: bumps using EIP-1559 rules when existing attempts are of type 0x2", func(t *testing.T) {
 		cfg.Overrides.GlobalEvmMaxGasPriceWei = assets.GWei(1000)
 		ethTx := *types.NewTx(&types.DynamicFeeTx{})
 		kst.On("SignTx",
@@ -1890,7 +1890,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 	require.NoError(t, db.Get(&attempt4_2, `UPDATE eth_tx_attempts SET broadcast_before_block_num=$1, gas_tip_cap=$2, gas_fee_cap=$3 WHERE id=$4 RETURNING *`,
 		oldEnough, utils.NewBig(assets.GWei(999)), utils.NewBig(assets.GWei(1000)), attempt4_2.ID))
 
-	t.Run("resubmits at the old price and does not create a new attempt if one of the bumped EIP-1559 transactions would have its tip cap exceed ETH_MAX_GAS_PRICE_WEI", func(t *testing.T) {
+	t.Run("EIP-1559: resubmits at the old price and does not create a new attempt if one of the bumped EIP-1559 transactions would have its tip cap exceed ETH_MAX_GAS_PRICE_WEI", func(t *testing.T) {
 		cfg.Overrides.GlobalEvmMaxGasPriceWei = assets.GWei(1000)
 
 		// Third attempt failed to bump, resubmits old one instead
@@ -1913,6 +1913,49 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 
 		ethClient.AssertExpectations(t)
 		kst.AssertExpectations(t)
+	})
+
+	require.NoError(t, db.Get(&attempt4_2, `UPDATE eth_tx_attempts SET broadcast_before_block_num=$1, gas_tip_cap=$2, gas_fee_cap=$3 WHERE id=$4 RETURNING *`,
+		oldEnough, utils.NewBig(assets.GWei(45)), utils.NewBig(assets.GWei(100)), attempt4_2.ID))
+
+	t.Run("EIP-1559: saves attempt anyway if replacement transaction is underpriced because the bumped gas price is insufficiently higher than the previous one", func(t *testing.T) {
+		// NOTE: This test case was empirically impossible when I tried it on eth mainnet (any EIP1559 transaction with a higher tip cap is accepted even if it's only 1 wei more) but appears to be possible on Polygon/Matic, probably due to poor design that applies the 10% minumum to the overall value (base fee + tip cap)
+		expectedBumpedTipCap := assets.GWei(54)
+		require.Greater(t, expectedBumpedTipCap.Int64(), attempt4_2.GasTipCap.ToInt().Int64())
+
+		ethTx := *types.NewTx(&types.LegacyTx{})
+		kst.On("SignTx",
+			fromAddress,
+			mock.MatchedBy(func(tx *types.Transaction) bool {
+				if int64(tx.Nonce()) != *etx4.Nonce || expectedBumpedTipCap.Cmp(tx.GasTipCap()) != 0 {
+					return false
+				}
+				ethTx = *tx
+				return true
+			}),
+			mock.Anything).Return(&ethTx, nil).Once()
+		ethClient.On("SendTransaction", mock.Anything, mock.MatchedBy(func(tx *types.Transaction) bool {
+			return int64(tx.Nonce()) == *etx4.Nonce && expectedBumpedTipCap.Cmp(tx.GasTipCap()) == 0
+		})).Return(errors.New("replacement transaction underpriced")).Once()
+
+		// Do it
+		require.NoError(t, ec.RebroadcastWhereNecessary(context.TODO(), currentHead))
+
+		etx4, err = borm.FindEthTxWithAttempts(etx4.ID)
+		require.NoError(t, err)
+
+		assert.Equal(t, bulletprooftxmanager.EthTxUnconfirmed, etx4.State)
+
+		require.Len(t, etx4.EthTxAttempts, 3)
+		require.Equal(t, attempt4_1.ID, etx4.EthTxAttempts[2].ID)
+		require.Equal(t, attempt4_2.ID, etx4.EthTxAttempts[1].ID)
+		attempt4_3 := etx4.EthTxAttempts[0]
+
+		assert.Equal(t, expectedBumpedTipCap.Int64(), attempt4_3.GasTipCap.ToInt().Int64())
+
+		kst.AssertExpectations(t)
+		ethClient.AssertExpectations(t)
+
 	})
 
 	kst.AssertExpectations(t)


### PR DESCRIPTION
It appears that Polygon behaves differently than mainnet and can
sometimes return unexpected errors in EIP1559 mode. We may not handle
these correctly as it stands, but regardless, we certainly should not
panic.