### PR TITLE
Using ctx for DB locks

### DIFF
--- a/core/services/pg/advisory_lock_test.go
+++ b/core/services/pg/advisory_lock_test.go
@@ -26,9 +26,10 @@ func Test_AdvisoryLock(t *testing.T) {
 	cfg.Overrides.AdvisoryLockCheckInterval = &check
 
 	t.Run("takes lock", func(t *testing.T) {
+		ctx1, cancel1 := context.WithCancel(context.Background())
 		advLock1 := newAdvisoryLock(t, db, cfg)
 
-		err := advLock1.TakeAndHold()
+		err := advLock1.TakeAndHold(ctx1)
 		require.NoError(t, err)
 
 		var lockTaken bool
@@ -38,8 +39,9 @@ func Test_AdvisoryLock(t *testing.T) {
 
 		started2 := make(chan struct{})
 		advLock2 := newAdvisoryLock(t, db, cfg)
+		ctx2, cancel2 := context.WithCancel(context.Background())
 		go func() {
-			err := advLock2.TakeAndHold()
+			err := advLock2.TakeAndHold(ctx2)
 			require.NoError(t, err)
 			close(started2)
 		}()
@@ -47,7 +49,8 @@ func Test_AdvisoryLock(t *testing.T) {
 		// Give it plenty of time for advLock2 to have a few tries at getting the lease
 		time.Sleep(cfg.AdvisoryLockCheckInterval() * 5)
 
-		advLock1.Release()
+		cancel1()
+		advLock1.WaitForRelease()
 
 		select {
 		case <-started2:
@@ -59,7 +62,7 @@ func Test_AdvisoryLock(t *testing.T) {
 		require.NoError(t, err)
 		assert.True(t, lockTaken)
 
-		advLock2.Release()
+		cancel2()
 
 		// pg_locks is not atomic
 		time.Sleep(100 * time.Millisecond)
@@ -70,6 +73,7 @@ func Test_AdvisoryLock(t *testing.T) {
 	})
 
 	t.Run("recovers and re-opens connection if it's closed externally on initial take wait", func(t *testing.T) {
+		rctx, rcancel := context.WithCancel(context.Background())
 		advLock := newAdvisoryLock(t, db, cfg)
 
 		// simulate another application holding advisory lock to force it to retry
@@ -90,7 +94,7 @@ func Test_AdvisoryLock(t *testing.T) {
 
 		gotLease := make(chan struct{})
 		go func() {
-			err = advLock.TakeAndHold()
+			err = advLock.TakeAndHold(rctx)
 			require.NoError(t, err)
 			close(gotLease)
 		}()
@@ -115,7 +119,8 @@ func Test_AdvisoryLock(t *testing.T) {
 
 		assert.True(t, exists)
 
-		advLock.Release()
+		rcancel()
+		advLock.WaitForRelease()
 	})
 
 	require.NoError(t, db.Close())

--- a/core/services/pg/lease_lock.go
+++ b/core/services/pg/lease_lock.go
@@ -86,14 +86,14 @@ func (l *leaseLock) TakeAndHold(ctx context.Context) (err error) {
 		var err error
 
 		err = func() error {
-			ctx, cancel := DefaultQueryCtxWithParent(ctx)
+			qctx, cancel := DefaultQueryCtxWithParent(ctx)
 			defer cancel()
 			if l.conn == nil {
-				if err = l.checkoutConn(ctx); err != nil {
+				if err = l.checkoutConn(qctx); err != nil {
 					return errors.Wrap(err, "lease lock failed to checkout initial connection")
 				}
 			}
-			gotLease, err = l.getLease(ctx, isInitial)
+			gotLease, err = l.getLease(qctx, isInitial)
 			if errors.Is(err, sql.ErrConnDone) {
 				l.logger.Warnw("DB connection was unexpectedly closed; checking out a new one", "err", err)
 				l.conn = nil


### PR DESCRIPTION
This changes `TakeAndHold()` to receive `ctx` which is signaling when it needs to release a DB lock.
(this is a part of https://github.com/smartcontractkit/chainlink/pull/5827)
