### PR TITLE
Modify EIP-1559 implementation to allow gas bumping

### DIFF
--- a/core/chains/evm/bulletprooftxmanager/eth_broadcaster_test.go
+++ b/core/chains/evm/bulletprooftxmanager/eth_broadcaster_test.go
@@ -241,7 +241,8 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Success(t *testing.T) {
 		cfg.Overrides.GlobalEvmEIP1559DynamicFees = null.BoolFrom(true)
 		rnd := int64(1000000000 + rand.Intn(5000))
 		cfg.Overrides.GlobalEvmGasTipCapDefault = big.NewInt(rnd)
-		cfg.Overrides.GlobalEvmMaxGasPriceWei = big.NewInt(rnd + 1)
+		cfg.Overrides.GlobalEvmGasFeeCapDefault = big.NewInt(rnd + 1)
+		cfg.Overrides.GlobalEvmMaxGasPriceWei = big.NewInt(rnd + 2)
 
 		eipTxWithoutAl := bulletprooftxmanager.EthTx{
 			FromAddress:    fromAddress,

--- a/core/chains/evm/bulletprooftxmanager/eth_confirmer_test.go
+++ b/core/chains/evm/bulletprooftxmanager/eth_confirmer_test.go
@@ -1880,7 +1880,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary(t *testing.T) {
 		attempt4_2 = etx4.EthTxAttempts[0]
 		assert.Nil(t, attempt4_2.GasPrice)
 		assert.Equal(t, assets.GWei(42).String(), attempt4_2.GasTipCap.String())
-		assert.Equal(t, assets.GWei(1000).String(), attempt4_2.GasFeeCap.String())
+		assert.Equal(t, assets.GWei(120).String(), attempt4_2.GasFeeCap.String())
 		assert.Equal(t, bulletprooftxmanager.EthTxAttemptBroadcast, attempt1_2.State)
 
 		ethClient.AssertExpectations(t)

--- a/core/chains/evm/bulletprooftxmanager/mocks/config.go
+++ b/core/chains/evm/bulletprooftxmanager/mocks/config.go
@@ -61,6 +61,20 @@ func (_m *Config) BlockHistoryEstimatorBlockHistorySize() uint16 {
 	return r0
 }
 
+// BlockHistoryEstimatorEIP1559FeeCapBufferBlocks provides a mock function with given fields:
+func (_m *Config) BlockHistoryEstimatorEIP1559FeeCapBufferBlocks() uint16 {
+	ret := _m.Called()
+
+	var r0 uint16
+	if rf, ok := ret.Get(0).(func() uint16); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint16)
+	}
+
+	return r0
+}
+
 // BlockHistoryEstimatorTransactionPercentile provides a mock function with given fields:
 func (_m *Config) BlockHistoryEstimatorTransactionPercentile() uint16 {
 	ret := _m.Called()
@@ -217,8 +231,8 @@ func (_m *Config) EvmGasBumpWei() *big.Int {
 	return r0
 }
 
-// EvmGasFeeCap provides a mock function with given fields:
-func (_m *Config) EvmGasFeeCap() *big.Int {
+// EvmGasFeeCapDefault provides a mock function with given fields:
+func (_m *Config) EvmGasFeeCapDefault() *big.Int {
 	ret := _m.Called()
 
 	var r0 *big.Int

--- a/core/chains/evm/config/chain_specific_config.go
+++ b/core/chains/evm/config/chain_specific_config.go
@@ -10,54 +10,58 @@ import (
 )
 
 var (
-	DefaultMinimumContractPayment        = assets.NewLinkFromJuels(10000000000000) // 0.00001 LINK
+	// DefaultGasFeeCap is the default value to use for Fee Cap in EIP-1559 transactions
+	DefaultGasFeeCap                     = assets.GWei(100)
 	DefaultGasLimit               uint64 = 500000
 	DefaultGasPrice                      = assets.GWei(20)
 	DefaultGasTip                        = assets.GWei(0)
+	DefaultMinimumContractPayment        = assets.NewLinkFromJuels(10000000000000) // 0.00001 LINK
 )
 
 type (
 	// chainSpecificConfigDefaultSet lists the config defaults specific to a particular chain ID
 	chainSpecificConfigDefaultSet struct {
-		balanceMonitorEnabled                      bool
-		balanceMonitorBlockDelay                   uint16
-		blockEmissionIdleWarningThreshold          time.Duration
-		blockHistoryEstimatorBatchSize             uint32
-		blockHistoryEstimatorBlockDelay            uint16
-		blockHistoryEstimatorBlockHistorySize      uint16
-		blockHistoryEstimatorTransactionPercentile uint16
-		chainType                                  chains.ChainType
-		eip1559DynamicFees                         bool
-		ethTxReaperInterval                        time.Duration
-		ethTxReaperThreshold                       time.Duration
-		ethTxResendAfterThreshold                  time.Duration
-		finalityDepth                              uint32
-		flagsContractAddress                       string
-		gasBumpPercent                             uint16
-		gasBumpThreshold                           uint64
-		gasBumpTxDepth                             uint16
-		gasBumpWei                                 big.Int
-		gasEstimatorMode                           string
-		gasLimitDefault                            uint64
-		gasLimitMultiplier                         float32
-		gasLimitTransfer                           uint64
-		gasPriceDefault                            big.Int
-		gasTipCapDefault                           big.Int
-		gasTipCapMinimum                           big.Int
-		headTrackerHistoryDepth                    uint32
-		headTrackerMaxBufferSize                   uint32
-		headTrackerSamplingInterval                time.Duration
-		linkContractAddress                        string
-		logBackfillBatchSize                       uint32
-		maxGasPriceWei                             big.Int
-		maxInFlightTransactions                    uint32
-		maxQueuedTransactions                      uint64
-		minGasPriceWei                             big.Int
-		minIncomingConfirmations                   uint32
-		minRequiredOutgoingConfirmations           uint64
-		minimumContractPayment                     *assets.Link
-		nonceAutoSync                              bool
-		rpcDefaultBatchSize                        uint32
+		balanceMonitorEnabled                          bool
+		balanceMonitorBlockDelay                       uint16
+		blockEmissionIdleWarningThreshold              time.Duration
+		blockHistoryEstimatorBatchSize                 uint32
+		blockHistoryEstimatorBlockDelay                uint16
+		blockHistoryEstimatorBlockHistorySize          uint16
+		blockHistoryEstimatorEIP1559FeeCapBufferBlocks *uint16
+		blockHistoryEstimatorTransactionPercentile     uint16
+		chainType                                      chains.ChainType
+		eip1559DynamicFees                             bool
+		ethTxReaperInterval                            time.Duration
+		ethTxReaperThreshold                           time.Duration
+		ethTxResendAfterThreshold                      time.Duration
+		finalityDepth                                  uint32
+		flagsContractAddress                           string
+		gasBumpPercent                                 uint16
+		gasBumpThreshold                               uint64
+		gasBumpTxDepth                                 uint16
+		gasBumpWei                                     big.Int
+		gasEstimatorMode                               string
+		gasFeeCapDefault                               big.Int
+		gasLimitDefault                                uint64
+		gasLimitMultiplier                             float32
+		gasLimitTransfer                               uint64
+		gasPriceDefault                                big.Int
+		gasTipCapDefault                               big.Int
+		gasTipCapMinimum                               big.Int
+		headTrackerHistoryDepth                        uint32
+		headTrackerMaxBufferSize                       uint32
+		headTrackerSamplingInterval                    time.Duration
+		linkContractAddress                            string
+		logBackfillBatchSize                           uint32
+		maxGasPriceWei                                 big.Int
+		maxInFlightTransactions                        uint32
+		maxQueuedTransactions                          uint64
+		minGasPriceWei                                 big.Int
+		minIncomingConfirmations                       uint32
+		minRequiredOutgoingConfirmations               uint64
+		minimumContractPayment                         *assets.Link
+		nonceAutoSync                                  bool
+		rpcDefaultBatchSize                            uint32
 		// set true if fully configured
 		complete bool
 
@@ -108,6 +112,7 @@ func setChainSpecificConfigDefaultSets() {
 		gasBumpTxDepth:                        10,
 		gasBumpWei:                            *assets.GWei(5),
 		gasEstimatorMode:                      "BlockHistory",
+		gasFeeCapDefault:                      *DefaultGasFeeCap,
 		gasLimitDefault:                       DefaultGasLimit,
 		gasLimitMultiplier:                    1.0,
 		gasLimitTransfer:                      21000,
@@ -202,8 +207,8 @@ func setChainSpecificConfigDefaultSets() {
 	polygonMainnet.headTrackerHistoryDepth = 250 // FinalityDepth + safety margin
 	polygonMainnet.headTrackerSamplingInterval = 1 * time.Second
 	polygonMainnet.blockEmissionIdleWarningThreshold = 15 * time.Second
-	polygonMainnet.maxQueuedTransactions = 2000 // Since re-orgs on Polygon can be so large, we need a large safety buffer to allow time for the queue to clear down before we start dropping transactions
-	polygonMainnet.maxGasPriceWei = *assets.UEther(50)
+	polygonMainnet.maxQueuedTransactions = 2000        // Since re-orgs on Polygon can be so large, we need a large safety buffer to allow time for the queue to clear down before we start dropping transactions
+	polygonMainnet.maxGasPriceWei = *assets.UEther(50) // 50,000 GWei
 	polygonMainnet.minGasPriceWei = *assets.GWei(1)
 	polygonMainnet.ethTxResendAfterThreshold = 5 * time.Minute // 5 minutes is roughly 300 blocks on Polygon. Since re-orgs occur often and can be deep we want to avoid overloading the node with a ton of re-sent unconfirmed transactions.
 	polygonMainnet.blockHistoryEstimatorBlockDelay = 10        // Must be set to something large here because Polygon has so many re-orgs that otherwise we are constantly refetching
@@ -265,6 +270,7 @@ func setChainSpecificConfigDefaultSets() {
 	rskMainnet.gasPriceDefault = *big.NewInt(50000000) // It's about 100 times more expensive than Wei, very roughly speaking
 	rskMainnet.linkContractAddress = "0x14adae34bef7ca957ce2dde5add97ea050123827"
 	rskMainnet.maxGasPriceWei = *big.NewInt(50000000000)
+	rskMainnet.gasFeeCapDefault = *big.NewInt(100000000) // rsk does not yet support EIP-1559 but this allows validation to pass
 	rskMainnet.minGasPriceWei = *big.NewInt(0)
 	rskMainnet.minimumContractPayment = assets.NewLinkFromJuels(1000000000000000)
 	rskTestnet := rskMainnet

--- a/core/chains/evm/config/mocks/chain_scoped_config.go
+++ b/core/chains/evm/config/mocks/chain_scoped_config.go
@@ -415,6 +415,20 @@ func (_m *ChainScopedConfig) BlockHistoryEstimatorBlockHistorySize() uint16 {
 	return r0
 }
 
+// BlockHistoryEstimatorEIP1559FeeCapBufferBlocks provides a mock function with given fields:
+func (_m *ChainScopedConfig) BlockHistoryEstimatorEIP1559FeeCapBufferBlocks() uint16 {
+	ret := _m.Called()
+
+	var r0 uint16
+	if rf, ok := ret.Get(0).(func() uint16); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint16)
+	}
+
+	return r0
+}
+
 // BlockHistoryEstimatorTransactionPercentile provides a mock function with given fields:
 func (_m *ChainScopedConfig) BlockHistoryEstimatorTransactionPercentile() uint16 {
 	ret := _m.Called()
@@ -933,8 +947,8 @@ func (_m *ChainScopedConfig) EvmGasBumpWei() *big.Int {
 	return r0
 }
 
-// EvmGasFeeCap provides a mock function with given fields:
-func (_m *ChainScopedConfig) EvmGasFeeCap() *big.Int {
+// EvmGasFeeCapDefault provides a mock function with given fields:
+func (_m *ChainScopedConfig) EvmGasFeeCapDefault() *big.Int {
 	ret := _m.Called()
 
 	var r0 *big.Int
@@ -1500,6 +1514,27 @@ func (_m *ChainScopedConfig) GlobalBlockHistoryEstimatorBlockHistorySize() (uint
 	return r0, r1
 }
 
+// GlobalBlockHistoryEstimatorEIP1559FeeCapBufferBlocks provides a mock function with given fields:
+func (_m *ChainScopedConfig) GlobalBlockHistoryEstimatorEIP1559FeeCapBufferBlocks() (uint16, bool) {
+	ret := _m.Called()
+
+	var r0 uint16
+	if rf, ok := ret.Get(0).(func() uint16); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint16)
+	}
+
+	var r1 bool
+	if rf, ok := ret.Get(1).(func() bool); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+
+	return r0, r1
+}
+
 // GlobalBlockHistoryEstimatorTransactionPercentile provides a mock function with given fields:
 func (_m *ChainScopedConfig) GlobalBlockHistoryEstimatorTransactionPercentile() (uint16, bool) {
 	ret := _m.Called()
@@ -1733,6 +1768,29 @@ func (_m *ChainScopedConfig) GlobalEvmGasBumpTxDepth() (uint16, bool) {
 
 // GlobalEvmGasBumpWei provides a mock function with given fields:
 func (_m *ChainScopedConfig) GlobalEvmGasBumpWei() (*big.Int, bool) {
+	ret := _m.Called()
+
+	var r0 *big.Int
+	if rf, ok := ret.Get(0).(func() *big.Int); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
+	}
+
+	var r1 bool
+	if rf, ok := ret.Get(1).(func() bool); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+
+	return r0, r1
+}
+
+// GlobalEvmGasFeeCapDefault provides a mock function with given fields:
+func (_m *ChainScopedConfig) GlobalEvmGasFeeCapDefault() (*big.Int, bool) {
 	ret := _m.Called()
 
 	var r0 *big.Int

--- a/core/chains/evm/gas/block_history_estimator.go
+++ b/core/chains/evm/gas/block_history_estimator.go
@@ -75,9 +75,10 @@ type (
 		ctx                 context.Context
 		ctxCancel           context.CancelFunc
 
-		gasPrice *big.Int
-		tipCap   *big.Int
-		mu       sync.RWMutex
+		gasPrice      *big.Int
+		tipCap        *big.Int
+		latestBaseFee *big.Int
+		mu            sync.RWMutex
 
 		logger logger.Logger
 	}
@@ -100,6 +101,7 @@ func NewBlockHistoryEstimator(lggr logger.Logger, ethClient evmclient.Client, co
 		cancel,
 		nil,
 		nil,
+		nil,
 		sync.RWMutex{},
 		lggr.Named("BlockHistoryEstimator"),
 	}
@@ -110,7 +112,26 @@ func NewBlockHistoryEstimator(lggr logger.Logger, ethClient evmclient.Client, co
 // OnNewLongestChain recalculates and sets global gas price if a sampled new head comes
 // in and we are not currently fetching
 func (b *BlockHistoryEstimator) OnNewLongestChain(ctx context.Context, head *evmtypes.Head) {
+	// set latest base fee here to avoid potential lag introduced by block delay
+	// it is really important that base fee be as up-to-date as possible
+	b.setLatestBaseFee(head.BaseFeePerGas)
 	b.mb.Deliver(head)
+}
+
+func (b *BlockHistoryEstimator) setLatestBaseFee(baseFee *utils.Big) {
+	// Non-eip1559 blocks don't include base fee; just ignore
+	if baseFee == nil {
+		return
+	}
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	b.latestBaseFee = new(big.Int)
+	b.latestBaseFee.Set(baseFee.ToInt())
+}
+func (b *BlockHistoryEstimator) getCurrentBaseFee() *big.Int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.latestBaseFee
 }
 
 func (b *BlockHistoryEstimator) Start() error {
@@ -126,6 +147,7 @@ func (b *BlockHistoryEstimator) Start() error {
 			b.logger.Warnw("initial check for latest head failed, head was unexpectedly nil")
 		} else {
 			b.logger.Debugw("Got latest head", "number", latestHead.Number, "blockHash", latestHead.Hash.Hex())
+			b.setLatestBaseFee(latestHead.BaseFeePerGas)
 			b.FetchBlocksAndRecalculate(ctx, latestHead)
 		}
 		b.wg.Add(1)
@@ -176,24 +198,70 @@ func (b *BlockHistoryEstimator) GetDynamicFee(gasLimit uint64) (fee DynamicFee, 
 	if !b.config.EvmEIP1559DynamicFees() {
 		return fee, 0, errors.New("Can't get dynamic fee, EIP1559 is disabled")
 	}
+
+	var feeCap *big.Int
 	var tipCap *big.Int
 	ok := b.IfStarted(func() {
 		chainSpecificGasLimit = applyMultiplier(gasLimit, b.config.EvmGasLimitMultiplier())
-		tipCap = b.getTipCap()
+		b.mu.RLock()
+		defer b.mu.RUnlock()
+		tipCap = b.tipCap
+		if tipCap == nil {
+			err = errors.New("BlockHistoryEstimator has not finished the first gas estimation yet, likely because a failure on start")
+			return
+		}
+		if b.config.EvmGasBumpThreshold() == 0 {
+			// just use the max gas price if gas bumping is disabled
+			feeCap = b.config.EvmMaxGasPriceWei()
+		} else if b.latestBaseFee != nil {
+			// HACK: due to a flaw of how EIP-1559 is implemented we have to
+			// set a much lower FeeCap than the actual maximum we are willing
+			// to pay in order to give ourselves headroom for bumping
+			// See: https://github.com/ethereum/go-ethereum/issues/24284
+			feeCap = calcFeeCap(b.latestBaseFee, b.config, tipCap)
+		} else {
+			// This shouldn't happen since if the tip cap is set, Start must
+			// have succeeded and we would expect an initial base fee to be set
+			// as well
+			err = errors.New("BlockHistoryEstimator: no value for latest block base fee; cannot estimate EIP-1559 base fee")
+			return
+		}
 	})
 	if !ok {
 		return fee, 0, errors.New("BlockHistoryEstimator is not started; cannot estimate gas")
 	}
-	if tipCap == nil {
-		return fee, 0, errors.New("BlockHistoryEstimator has not finished the first gas estimation yet, likely because a failure on start")
+	if err != nil {
+		return fee, 0, err
 	}
-	fee.FeeCap = b.config.EvmMaxGasPriceWei()
+	fee.FeeCap = feeCap
 	fee.TipCap = tipCap
 	return
 }
 
+func calcFeeCap(latestAvailableBaseFeePerGas *big.Int, cfg Config, tipCap *big.Int) (feeCap *big.Int) {
+	const maxBaseFeeIncreasePerBlock float64 = 1.125
+
+	bufferBlocks := int(cfg.BlockHistoryEstimatorEIP1559FeeCapBufferBlocks())
+
+	baseFee := new(big.Float)
+	baseFee.SetInt(latestAvailableBaseFeePerGas)
+	// Find out the worst case base fee before we should bump
+	multiplier := big.NewFloat(maxBaseFeeIncreasePerBlock)
+	for i := 0; i < bufferBlocks; i++ {
+		baseFee.Mul(baseFee, multiplier)
+	}
+
+	baseFeeInt, _ := baseFee.Int(nil)
+	feeCap = new(big.Int).Add(baseFeeInt, tipCap)
+
+	if feeCap.Cmp(cfg.EvmMaxGasPriceWei()) > 0 {
+		return cfg.EvmMaxGasPriceWei()
+	}
+	return feeCap
+}
+
 func (b *BlockHistoryEstimator) BumpDynamicFee(originalFee DynamicFee, originalGasLimit uint64) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
-	return BumpDynamicFeeOnly(b.config, b.logger, b.getTipCap(), originalFee, originalGasLimit)
+	return BumpDynamicFeeOnly(b.config, b.logger, b.getTipCap(), b.getCurrentBaseFee(), originalFee, originalGasLimit)
 }
 
 func (b *BlockHistoryEstimator) runLoop() {

--- a/core/chains/evm/gas/fixed_price_estimator.go
+++ b/core/chains/evm/gas/fixed_price_estimator.go
@@ -41,12 +41,22 @@ func (f *fixedPriceEstimator) GetDynamicFee(originalGasLimit uint64) (d DynamicF
 		return d, 0, errors.New("cannot calculate dynamic fee: EthGasTipCapDefault was not set")
 	}
 	chainSpecificGasLimit = applyMultiplier(originalGasLimit, f.config.EvmGasLimitMultiplier())
+
+	var feeCap *big.Int
+	if f.config.EvmGasBumpThreshold() == 0 {
+		// Gas bumping is disabled, just use the max fee cap
+		feeCap = f.config.EvmMaxGasPriceWei()
+	} else {
+		// Need to leave headroom for bumping so we fallback to the default value here
+		feeCap = f.config.EvmGasFeeCapDefault()
+	}
+
 	return DynamicFee{
-		FeeCap: f.config.EvmGasFeeCap(),
+		FeeCap: feeCap,
 		TipCap: gasTipCap,
 	}, chainSpecificGasLimit, nil
 }
 
 func (f *fixedPriceEstimator) BumpDynamicFee(originalFee DynamicFee, originalGasLimit uint64) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
-	return BumpDynamicFeeOnly(f.config, f.lggr, f.config.EvmGasTipCapDefault(), originalFee, originalGasLimit)
+	return BumpDynamicFeeOnly(f.config, f.lggr, f.config.EvmGasTipCapDefault(), nil, originalFee, originalGasLimit)
 }

--- a/core/chains/evm/gas/gas_test.go
+++ b/core/chains/evm/gas/gas_test.go
@@ -149,6 +149,7 @@ func Test_BumpDynamicFeeOnly(t *testing.T) {
 	for _, test := range []struct {
 		name                   string
 		currentTipCap          *big.Int
+		currentBaseFee         *big.Int
 		originalFee            gas.DynamicFee
 		tipCapDefault          *big.Int
 		bumpPercent            uint16
@@ -162,12 +163,13 @@ func Test_BumpDynamicFeeOnly(t *testing.T) {
 		{
 			name:                   "defaults",
 			currentTipCap:          nil,
-			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(5000)},
+			currentBaseFee:         nil,
+			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(4000)},
 			tipCapDefault:          assets.GWei(20),
 			bumpPercent:            20,
 			bumpWei:                toBigInt("5e9"), // 0.5 GWei
 			maxGasPriceWei:         assets.GWei(5000),
-			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(36), FeeCap: assets.GWei(5000)},
+			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(36), FeeCap: assets.GWei(4800)},
 			originalLimit:          100000,
 			limitMultiplierPercent: 1.0,
 			expectedLimit:          100000,
@@ -175,12 +177,13 @@ func Test_BumpDynamicFeeOnly(t *testing.T) {
 		{
 			name:                   "original + percentage wins",
 			currentTipCap:          nil,
-			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(5000)},
+			currentBaseFee:         nil,
+			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(100)},
 			tipCapDefault:          assets.GWei(20),
 			bumpPercent:            30,
 			bumpWei:                toBigInt("5e9"),  // 0.5 GWei
-			maxGasPriceWei:         toBigInt("5e11"), // 0.5 uEther
-			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(39), FeeCap: assets.GWei(5000)},
+			maxGasPriceWei:         toBigInt("5e11"), // 500GWei
+			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(39), FeeCap: assets.GWei(130)},
 			originalLimit:          100000,
 			limitMultiplierPercent: 1.1,
 			expectedLimit:          110000,
@@ -188,12 +191,13 @@ func Test_BumpDynamicFeeOnly(t *testing.T) {
 		{
 			name:                   "original + fixed wins",
 			currentTipCap:          nil,
-			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(5000)},
+			currentBaseFee:         nil,
+			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(400)},
 			tipCapDefault:          assets.GWei(20),
 			bumpPercent:            20,
 			bumpWei:                toBigInt("8e9"),  // 0.8 GWei
-			maxGasPriceWei:         toBigInt("5e11"), // 0.5 uEther
-			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(38), FeeCap: assets.GWei(5000)},
+			maxGasPriceWei:         toBigInt("5e11"), // 500GWei
+			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(38), FeeCap: assets.GWei(480)},
 			originalLimit:          100000,
 			limitMultiplierPercent: 0.8,
 			expectedLimit:          80000,
@@ -201,12 +205,13 @@ func Test_BumpDynamicFeeOnly(t *testing.T) {
 		{
 			name:                   "default + percentage wins",
 			currentTipCap:          nil,
-			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(5000)},
+			currentBaseFee:         nil,
+			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(400)},
 			tipCapDefault:          assets.GWei(40),
 			bumpPercent:            20,
 			bumpWei:                toBigInt("5e9"),  // 0.5 GWei
-			maxGasPriceWei:         toBigInt("5e11"), // 0.5 uEther
-			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(48), FeeCap: assets.GWei(5000)},
+			maxGasPriceWei:         toBigInt("5e11"), // 500GWei
+			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(48), FeeCap: assets.GWei(480)},
 			originalLimit:          100000,
 			limitMultiplierPercent: 1.0,
 			expectedLimit:          100000,
@@ -214,12 +219,13 @@ func Test_BumpDynamicFeeOnly(t *testing.T) {
 		{
 			name:                   "default + fixed wins",
 			currentTipCap:          assets.GWei(48),
-			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(5000)},
+			currentBaseFee:         nil,
+			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(400)},
 			tipCapDefault:          assets.GWei(40),
 			bumpPercent:            20,
 			bumpWei:                toBigInt("9e9"),  // 0.9 GWei
-			maxGasPriceWei:         toBigInt("5e11"), // 0.5 uEther
-			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(49), FeeCap: assets.GWei(5000)},
+			maxGasPriceWei:         toBigInt("5e11"), // 500GWei
+			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(49), FeeCap: assets.GWei(480)},
 			originalLimit:          100000,
 			limitMultiplierPercent: 1.0,
 			expectedLimit:          100000,
@@ -227,38 +233,57 @@ func Test_BumpDynamicFeeOnly(t *testing.T) {
 		{
 			name:                   "higher current tip cap wins",
 			currentTipCap:          assets.GWei(50),
-			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(5000)},
+			currentBaseFee:         nil,
+			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(400)},
 			tipCapDefault:          assets.GWei(40),
 			bumpPercent:            20,
 			bumpWei:                toBigInt("9e9"),  // 0.9 GWei
-			maxGasPriceWei:         toBigInt("5e11"), // 0.5 uEther
-			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(50), FeeCap: assets.GWei(5000)},
+			maxGasPriceWei:         toBigInt("5e11"), // 500GWei
+			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(50), FeeCap: assets.GWei(480)},
 			originalLimit:          100000,
 			limitMultiplierPercent: 1.0,
 			expectedLimit:          100000,
 		},
 		{
-			name:                   "max increased uses new higher max for FeeCap",
+			name:                   "if bumped tip cap would exceed bumped fee cap, adds fixed value to expectedFee",
 			currentTipCap:          nil,
-			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(5000)},
-			tipCapDefault:          assets.GWei(20),
-			bumpPercent:            20,
-			bumpWei:                toBigInt("5e9"), // 0.5 GWei
-			maxGasPriceWei:         assets.GWei(8000),
-			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(36), FeeCap: assets.GWei(8000)},
+			currentBaseFee:         nil,
+			originalFee:            gas.DynamicFee{TipCap: assets.GWei(10), FeeCap: assets.GWei(20)},
+			tipCapDefault:          assets.GWei(5),
+			bumpPercent:            5,
+			bumpWei:                assets.GWei(50),
+			maxGasPriceWei:         toBigInt("5e11"), // 500GWei
+			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(60), FeeCap: assets.GWei(70)},
 			originalLimit:          100000,
 			limitMultiplierPercent: 1.0,
 			expectedLimit:          100000,
 		},
 		{
-			name:                   "max decreased uses previous higher max for FeeCap",
-			currentTipCap:          nil,
-			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(5000)},
+			name:                   "ignores current base fee and uses previous fee cap if calculated fee cap would be lower",
+			currentTipCap:          assets.GWei(20),
+			currentBaseFee:         assets.GWei(100),
+			originalFee:            gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(400)},
 			tipCapDefault:          assets.GWei(20),
 			bumpPercent:            20,
 			bumpWei:                toBigInt("5e9"), // 0.5 GWei
-			maxGasPriceWei:         assets.GWei(3000),
-			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(36), FeeCap: assets.GWei(5000)},
+			maxGasPriceWei:         assets.GWei(5000),
+			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(36), FeeCap: assets.GWei(480)},
+			originalLimit:          100000,
+			limitMultiplierPercent: 1.0,
+			expectedLimit:          100000,
+		},
+		{
+			name:           "uses current base fee to calculate fee cap if that would be higher than the existing one",
+			currentTipCap:  assets.GWei(20),
+			currentBaseFee: assets.GWei(1000),
+			originalFee:    gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(400)},
+			tipCapDefault:  assets.GWei(20),
+			bumpPercent:    20,
+			bumpWei:        toBigInt("5e9"), // 0.5 GWei
+			maxGasPriceWei: assets.GWei(5000),
+			// base fee * 4 blocks * 1.125 % plus new tip cap to give max
+			// 1000 * (1.125 ^ 4) + 36 ~= 1637
+			expectedFee:            gas.DynamicFee{TipCap: assets.GWei(36), FeeCap: big.NewInt(1637806640625)},
 			originalLimit:          100000,
 			limitMultiplierPercent: 1.0,
 			expectedLimit:          100000,
@@ -272,7 +297,10 @@ func Test_BumpDynamicFeeOnly(t *testing.T) {
 			cfg.On("EvmGasBumpWei").Return(test.bumpWei)
 			cfg.On("EvmMaxGasPriceWei").Return(test.maxGasPriceWei)
 			cfg.On("EvmGasLimitMultiplier").Return(test.limitMultiplierPercent)
-			actual, limit, err := gas.BumpDynamicFeeOnly(cfg, logger.TestLogger(t), test.currentTipCap, test.originalFee, test.originalLimit)
+			if test.currentBaseFee != nil {
+				cfg.On("BlockHistoryEstimatorEIP1559FeeCapBufferBlocks").Return(uint16(4))
+			}
+			actual, limit, err := gas.BumpDynamicFeeOnly(cfg, logger.TestLogger(t), test.currentTipCap, test.currentBaseFee, test.originalFee, test.originalLimit)
 			require.NoError(t, err)
 			if actual.TipCap.Cmp(test.expectedFee.TipCap) != 0 {
 				t.Fatalf("TipCap not equal, expected %s but got %s", test.expectedFee.TipCap.String(), actual.TipCap.String())
@@ -295,10 +323,19 @@ func Test_BumpDynamicFeeOnly_HitsMaxError(t *testing.T) {
 	cfg.On("EvmGasBumpWei").Return(assets.Wei(5000000000))
 	cfg.On("EvmMaxGasPriceWei").Return(assets.GWei(40))
 
-	originalFee := gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(100)}
-	_, _, err := gas.BumpDynamicFeeOnly(cfg, logger.TestLogger(t), nil, originalFee, 42)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "bumped tip cap of 45000000000 would exceed configured max gas price of 40000000000 (original fee: tip cap 30000000000, fee cap 100000000000)")
+	t.Run("tip cap hits max", func(t *testing.T) {
+		originalFee := gas.DynamicFee{TipCap: assets.GWei(30), FeeCap: assets.GWei(100)}
+		_, _, err := gas.BumpDynamicFeeOnly(cfg, logger.TestLogger(t), nil, nil, originalFee, 42)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bumped tip cap of 45000000000 would exceed configured max gas price of 40000000000 (original fee: tip cap 30000000000, fee cap 100000000000)")
+	})
+
+	t.Run("fee cap hits max", func(t *testing.T) {
+		originalFee := gas.DynamicFee{TipCap: assets.GWei(10), FeeCap: assets.GWei(100)}
+		_, _, err := gas.BumpDynamicFeeOnly(cfg, logger.TestLogger(t), nil, nil, originalFee, 42)
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "bumped fee cap of 150000000000 would exceed configured max gas price of 40000000000 (original fee: tip cap 10000000000, fee cap 100000000000)")
+	})
 }
 
 // toBigInt is used to convert scientific notation string to a *big.Int

--- a/core/chains/evm/gas/helpers_test.go
+++ b/core/chains/evm/gas/helpers_test.go
@@ -33,3 +33,13 @@ func GetTipCap(b *BlockHistoryEstimator) *big.Int {
 	defer b.mu.RUnlock()
 	return b.tipCap
 }
+
+func GetLatestBaseFee(b *BlockHistoryEstimator) *big.Int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return b.latestBaseFee
+}
+
+func SimulateStart(b *BlockHistoryEstimator) {
+	b.StartOnce("BlockHistoryEstimatorSimulatedStart", func() error { return nil })
+}

--- a/core/chains/evm/gas/mocks/config.go
+++ b/core/chains/evm/gas/mocks/config.go
@@ -57,6 +57,20 @@ func (_m *Config) BlockHistoryEstimatorBlockHistorySize() uint16 {
 	return r0
 }
 
+// BlockHistoryEstimatorEIP1559FeeCapBufferBlocks provides a mock function with given fields:
+func (_m *Config) BlockHistoryEstimatorEIP1559FeeCapBufferBlocks() uint16 {
+	ret := _m.Called()
+
+	var r0 uint16
+	if rf, ok := ret.Get(0).(func() uint16); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint16)
+	}
+
+	return r0
+}
+
 // BlockHistoryEstimatorTransactionPercentile provides a mock function with given fields:
 func (_m *Config) BlockHistoryEstimatorTransactionPercentile() uint16 {
 	ret := _m.Called()
@@ -127,6 +141,20 @@ func (_m *Config) EvmGasBumpPercent() uint16 {
 	return r0
 }
 
+// EvmGasBumpThreshold provides a mock function with given fields:
+func (_m *Config) EvmGasBumpThreshold() uint64 {
+	ret := _m.Called()
+
+	var r0 uint64
+	if rf, ok := ret.Get(0).(func() uint64); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint64)
+	}
+
+	return r0
+}
+
 // EvmGasBumpWei provides a mock function with given fields:
 func (_m *Config) EvmGasBumpWei() *big.Int {
 	ret := _m.Called()
@@ -143,8 +171,8 @@ func (_m *Config) EvmGasBumpWei() *big.Int {
 	return r0
 }
 
-// EvmGasFeeCap provides a mock function with given fields:
-func (_m *Config) EvmGasFeeCap() *big.Int {
+// EvmGasFeeCapDefault provides a mock function with given fields:
+func (_m *Config) EvmGasFeeCapDefault() *big.Int {
 	ret := _m.Called()
 
 	var r0 *big.Int

--- a/core/chains/evm/gas/models.go
+++ b/core/chains/evm/gas/models.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"math"
 	"math/big"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -28,20 +29,21 @@ func IsBumpErr(err error) bool {
 	return err != nil && (errors.Is(err, ErrBumpGasExceedsLimit) || errors.Is(err, ErrBump))
 }
 
-func NewEstimator(lggr logger.Logger, ethClient evmclient.Client, config Config) Estimator {
-	s := config.GasEstimatorMode()
+// NewEstimator returns the estimator for a given config
+func NewEstimator(lggr logger.Logger, ethClient evmclient.Client, cfg Config) Estimator {
+	s := cfg.GasEstimatorMode()
 	switch s {
 	case "BlockHistory":
-		return NewBlockHistoryEstimator(lggr, ethClient, config, *ethClient.ChainID())
+		return NewBlockHistoryEstimator(lggr, ethClient, cfg, *ethClient.ChainID())
 	case "FixedPrice":
-		return NewFixedPriceEstimator(config, lggr)
+		return NewFixedPriceEstimator(cfg, lggr)
 	case "Optimism":
-		return NewOptimismEstimator(lggr, config, ethClient)
+		return NewOptimismEstimator(lggr, cfg, ethClient)
 	case "Optimism2":
-		return NewOptimism2Estimator(lggr, config, ethClient)
+		return NewOptimism2Estimator(lggr, cfg, ethClient)
 	default:
 		lggr.Warnf("GasEstimator: unrecognised mode '%s', falling back to FixedPriceEstimator", s)
-		return NewFixedPriceEstimator(config, lggr)
+		return NewFixedPriceEstimator(cfg, lggr)
 	}
 }
 
@@ -82,12 +84,14 @@ type Config interface {
 	BlockHistoryEstimatorBlockDelay() uint16
 	BlockHistoryEstimatorBlockHistorySize() uint16
 	BlockHistoryEstimatorTransactionPercentile() uint16
+	BlockHistoryEstimatorEIP1559FeeCapBufferBlocks() uint16
 	ChainType() chains.ChainType
 	EvmEIP1559DynamicFees() bool
 	EvmFinalityDepth() uint32
 	EvmGasBumpPercent() uint16
+	EvmGasBumpThreshold() uint64
 	EvmGasBumpWei() *big.Int
-	EvmGasFeeCap() *big.Int
+	EvmGasFeeCapDefault() *big.Int
 	EvmGasLimitMultiplier() float32
 	EvmGasPriceDefault() *big.Int
 	EvmGasTipCapDefault() *big.Int
@@ -130,6 +134,7 @@ type Block struct {
 	Hash          common.Hash
 	ParentHash    common.Hash
 	BaseFeePerGas *big.Int
+	Timestamp     time.Time
 	Transactions  []Transaction
 }
 
@@ -138,6 +143,7 @@ type blockInternal struct {
 	Hash          common.Hash
 	ParentHash    common.Hash
 	BaseFeePerGas *hexutil.Big
+	Timestamp     hexutil.Uint64
 	Transactions  []Transaction
 }
 
@@ -148,6 +154,7 @@ func (b Block) MarshalJSON() ([]byte, error) {
 		b.Hash,
 		b.ParentHash,
 		(*hexutil.Big)(b.BaseFeePerGas),
+		(hexutil.Uint64)(uint64(b.Timestamp.Unix())),
 		b.Transactions,
 	})
 }
@@ -167,6 +174,7 @@ func (b *Block) UnmarshalJSON(data []byte) error {
 		bi.Hash,
 		bi.ParentHash,
 		(*big.Int)(bi.BaseFeePerGas),
+		time.Unix((int64((uint64)(bi.Timestamp))), 0),
 		bi.Transactions,
 	}
 	return nil
@@ -240,12 +248,12 @@ func (t *Transaction) UnmarshalJSON(data []byte) error {
 }
 
 // BumpLegacyGasPriceOnly will increase the price and apply multiplier to the gas limit
-func BumpLegacyGasPriceOnly(config Config, lggr logger.Logger, currentGasPrice, originalGasPrice *big.Int, originalGasLimit uint64) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
-	gasPrice, err = bumpGasPrice(config, lggr, currentGasPrice, originalGasPrice)
+func BumpLegacyGasPriceOnly(cfg Config, lggr logger.Logger, currentGasPrice, originalGasPrice *big.Int, originalGasLimit uint64) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
+	gasPrice, err = bumpGasPrice(cfg, lggr, currentGasPrice, originalGasPrice)
 	if err != nil {
 		return nil, 0, err
 	}
-	chainSpecificGasLimit = applyMultiplier(originalGasLimit, config.EvmGasLimitMultiplier())
+	chainSpecificGasLimit = applyMultiplier(originalGasLimit, cfg.EvmGasLimitMultiplier())
 	return
 }
 
@@ -253,15 +261,15 @@ func BumpLegacyGasPriceOnly(config Config, lggr logger.Logger, currentGasPrice, 
 // - A configured percentage bump (ETH_GAS_BUMP_PERCENT) on top of the baseline price.
 // - A configured fixed amount of Wei (ETH_GAS_PRICE_WEI) on top of the baseline price.
 // The baseline price is the maximum of the previous gas price attempt and the node's current gas price.
-func bumpGasPrice(config Config, lggr logger.Logger, currentGasPrice, originalGasPrice *big.Int) (*big.Int, error) {
-	maxGasPrice := config.EvmMaxGasPriceWei()
+func bumpGasPrice(cfg Config, lggr logger.Logger, currentGasPrice, originalGasPrice *big.Int) (*big.Int, error) {
+	maxGasPrice := cfg.EvmMaxGasPriceWei()
 
 	var priceByPercentage = new(big.Int)
-	priceByPercentage.Mul(originalGasPrice, big.NewInt(int64(100+config.EvmGasBumpPercent())))
+	priceByPercentage.Mul(originalGasPrice, big.NewInt(int64(100+cfg.EvmGasBumpPercent())))
 	priceByPercentage.Div(priceByPercentage, big.NewInt(100))
 
 	var priceByIncrement = new(big.Int)
-	priceByIncrement.Add(originalGasPrice, config.EvmGasBumpWei())
+	priceByIncrement.Add(originalGasPrice, cfg.EvmGasBumpWei())
 
 	bumpedGasPrice := max(priceByPercentage, priceByIncrement)
 	if currentGasPrice != nil {
@@ -294,8 +302,8 @@ func max(a, b *big.Int) *big.Int {
 }
 
 // BumpDynamicFeeOnly bumps the tip cap and max gas price if necessary
-func BumpDynamicFeeOnly(config Config, lggr logger.Logger, currentTipCap *big.Int, originalFee DynamicFee, originalGasLimit uint64) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
-	bumped, err = bumpDynamicFee(config, lggr, currentTipCap, originalFee)
+func BumpDynamicFeeOnly(config Config, lggr logger.Logger, currentTipCap *big.Int, currentBaseFee *big.Int, originalFee DynamicFee, originalGasLimit uint64) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
+	bumped, err = bumpDynamicFee(config, lggr, currentTipCap, currentBaseFee, originalFee)
 	if err != nil {
 		return bumped, 0, err
 	}
@@ -307,19 +315,18 @@ func BumpDynamicFeeOnly(config Config, lggr logger.Logger, currentTipCap *big.In
 // - A configured percentage bump (ETH_GAS_BUMP_PERCENT) on top of the baseline tip cap.
 // - A configured fixed amount of Wei (ETH_GAS_PRICE_WEI) on top of the baseline tip cap.
 // The baseline tip cap is the maximum of the previous tip cap attempt and the node's current tip cap.
-// It increases the max fee cap if it changed
-func bumpDynamicFee(config Config, lggr logger.Logger, currentTipCap *big.Int, originalFee DynamicFee) (bumpedFee DynamicFee, err error) {
-	maxGasPrice := config.EvmMaxGasPriceWei()
-	baselineTipCap := max(originalFee.TipCap, config.EvmGasTipCapDefault())
+// It increases the max fee cap by GasBumpPercent
+//
+// NOTE: We would prefer to have set a large FeeCap and leave it fixed, bumping
+// the Tip only. Unfortunately due to a flaw of how EIP-1559 is implemented we
+// have to bump FeeCap by at least 10% each time we bump the tip cap.
+// See: https://github.com/ethereum/go-ethereum/issues/24284
+func bumpDynamicFee(cfg Config, lggr logger.Logger, currentTipCap, currentBaseFee *big.Int, originalFee DynamicFee) (bumpedFee DynamicFee, err error) {
+	maxGasPrice := cfg.EvmMaxGasPriceWei()
+	baselineTipCap := max(originalFee.TipCap, cfg.EvmGasTipCapDefault())
 
-	var tipCapByPercentage = new(big.Int)
-	tipCapByPercentage.Mul(baselineTipCap, big.NewInt(int64(100+config.EvmGasBumpPercent())))
-	tipCapByPercentage.Div(tipCapByPercentage, big.NewInt(100))
+	bumpedTipCap := increaseByPercentageOrIncrement(baselineTipCap, cfg.EvmGasBumpPercent(), cfg.EvmGasBumpWei())
 
-	var tipCapByIncrement = new(big.Int)
-	tipCapByIncrement.Add(baselineTipCap, config.EvmGasBumpWei())
-
-	bumpedTipCap := max(tipCapByPercentage, tipCapByIncrement)
 	if currentTipCap != nil {
 		if currentTipCap.Cmp(maxGasPrice) > 0 {
 			lggr.Errorf("invariant violation: ignoring current tip cap of %s that would exceed max gas price of %s", currentTipCap.String(), maxGasPrice.String())
@@ -340,7 +347,41 @@ func bumpDynamicFee(config Config, lggr logger.Logger, currentTipCap *big.Int, o
 			"ETH_GAS_BUMP_PERCENT or ETH_GAS_BUMP_WEI", bumpedTipCap.String(), originalFee.TipCap.String())
 	}
 
-	bumpedFeeCap := max(originalFee.FeeCap, maxGasPrice)
+	// Always bump the FeeCap by at least the bump percentage (should be greater than or
+	// equal to than geth's configured bump minimum which is 10%)
+	// See: https://github.com/ethereum/go-ethereum/blob/bff330335b94af3643ac2fb809793f77de3069d4/core/tx_list.go#L298
+	bumpedFeeCap := increaseByPercentageOrIncrement(originalFee.FeeCap, cfg.EvmGasBumpPercent(), cfg.EvmGasBumpWei())
+
+	if currentBaseFee != nil {
+		if currentBaseFee.Cmp(maxGasPrice) > 0 {
+			lggr.Warnf("ignoring current base fee of %s which is greater than max gas price of %s", currentBaseFee.String(), maxGasPrice.String())
+		} else {
+			currentFeeCap := calcFeeCap(currentBaseFee, cfg, bumpedTipCap)
+			bumpedFeeCap = max(bumpedFeeCap, currentFeeCap)
+		}
+	}
+
+	if bumpedFeeCap.Cmp(maxGasPrice) > 0 {
+		return bumpedFee, errors.Wrapf(ErrBumpGasExceedsLimit, "bumped fee cap of %s would exceed configured max gas price of %s (original fee: tip cap %s, fee cap %s). %s",
+			bumpedFeeCap.String(), maxGasPrice, originalFee.TipCap.String(), originalFee.FeeCap.String(), static.EthNodeConnectivityProblemLabel)
+	}
 
 	return DynamicFee{FeeCap: bumpedFeeCap, TipCap: bumpedTipCap}, nil
+}
+
+// Returns whichever is greater, the percentage bump or the bump by fixed increment
+func increaseByPercentageOrIncrement(original *big.Int, percentage uint16, increment *big.Int) (bumped *big.Int) {
+	percentageBump := increaseByPercentage(original, percentage)
+
+	incrementBump := new(big.Int).Add(original, increment)
+
+	return max(percentageBump, incrementBump)
+}
+
+func increaseByPercentage(original *big.Int, percentage uint16) (bumped *big.Int) {
+	bumped = new(big.Int)
+	bumped.Set(original)
+	bumped.Mul(original, big.NewInt(int64(100+percentage)))
+	bumped.Div(bumped, big.NewInt(100))
+	return
 }

--- a/core/chains/evm/types/types.go
+++ b/core/chains/evm/types/types.go
@@ -46,35 +46,37 @@ type ORM interface {
 }
 
 type ChainCfg struct {
-	BlockHistoryEstimatorBlockDelay       null.Int
-	BlockHistoryEstimatorBlockHistorySize null.Int
-	EthTxReaperThreshold                  *models.Duration
-	EthTxResendAfterThreshold             *models.Duration
-	EvmEIP1559DynamicFees                 null.Bool
-	EvmFinalityDepth                      null.Int
-	EvmGasBumpPercent                     null.Int
-	EvmGasBumpTxDepth                     null.Int
-	EvmGasBumpWei                         *utils.Big
-	EvmGasLimitDefault                    null.Int
-	EvmGasLimitMultiplier                 null.Float
-	EvmGasPriceDefault                    *utils.Big
-	EvmGasTipCapDefault                   *utils.Big
-	EvmGasTipCapMinimum                   *utils.Big
-	EvmHeadTrackerHistoryDepth            null.Int
-	EvmHeadTrackerMaxBufferSize           null.Int
-	EvmHeadTrackerSamplingInterval        *models.Duration
-	EvmLogBackfillBatchSize               null.Int
-	EvmMaxGasPriceWei                     *utils.Big
-	EvmNonceAutoSync                      null.Bool
-	EvmRPCDefaultBatchSize                null.Int
-	FlagsContractAddress                  null.String
-	GasEstimatorMode                      null.String
-	ChainType                             null.String
-	MinIncomingConfirmations              null.Int
-	MinRequiredOutgoingConfirmations      null.Int
-	MinimumContractPayment                *assets.Link
-	OCRObservationTimeout                 *models.Duration
-	KeySpecific                           map[string]ChainCfg
+	BlockHistoryEstimatorBlockDelay                null.Int
+	BlockHistoryEstimatorBlockHistorySize          null.Int
+	BlockHistoryEstimatorEIP1559FeeCapBufferBlocks null.Int
+	EthTxReaperThreshold                           *models.Duration
+	EthTxResendAfterThreshold                      *models.Duration
+	EvmEIP1559DynamicFees                          null.Bool
+	EvmFinalityDepth                               null.Int
+	EvmGasBumpPercent                              null.Int
+	EvmGasBumpTxDepth                              null.Int
+	EvmGasBumpWei                                  *utils.Big
+	EvmGasFeeCapDefault                            *utils.Big
+	EvmGasLimitDefault                             null.Int
+	EvmGasLimitMultiplier                          null.Float
+	EvmGasPriceDefault                             *utils.Big
+	EvmGasTipCapDefault                            *utils.Big
+	EvmGasTipCapMinimum                            *utils.Big
+	EvmHeadTrackerHistoryDepth                     null.Int
+	EvmHeadTrackerMaxBufferSize                    null.Int
+	EvmHeadTrackerSamplingInterval                 *models.Duration
+	EvmLogBackfillBatchSize                        null.Int
+	EvmMaxGasPriceWei                              *utils.Big
+	EvmNonceAutoSync                               null.Bool
+	EvmRPCDefaultBatchSize                         null.Int
+	FlagsContractAddress                           null.String
+	GasEstimatorMode                               null.String
+	ChainType                                      null.String
+	MinIncomingConfirmations                       null.Int
+	MinRequiredOutgoingConfirmations               null.Int
+	MinimumContractPayment                         *assets.Link
+	OCRObservationTimeout                          *models.Duration
+	KeySpecific                                    map[string]ChainCfg
 }
 
 func (c *ChainCfg) Scan(value interface{}) error {

--- a/core/config/envvar/schema.go
+++ b/core/config/envvar/schema.go
@@ -127,6 +127,7 @@ type ConfigSchema struct {
 	EvmGasBumpThreshold        uint64   `env:"ETH_GAS_BUMP_THRESHOLD"`
 	EvmGasBumpTxDepth          uint16   `env:"ETH_GAS_BUMP_TX_DEPTH"`
 	EvmGasBumpWei              *big.Int `env:"ETH_GAS_BUMP_WEI"`
+	EvmGasFeeCapDefault        *big.Int `env:"EVM_GAS_FEE_CAP_DEFAULT"`
 	EvmGasLimitDefault         uint64   `env:"ETH_GAS_LIMIT_DEFAULT"`
 	EvmGasLimitMultiplier      float32  `env:"ETH_GAS_LIMIT_MULTIPLIER"`
 	EvmGasLimitTransfer        uint64   `env:"ETH_GAS_LIMIT_TRANSFER"`
@@ -139,11 +140,12 @@ type ConfigSchema struct {
 	EvmMinGasPriceWei          *big.Int `env:"ETH_MIN_GAS_PRICE_WEI"`
 	EvmNonceAutoSync           bool     `env:"ETH_NONCE_AUTO_SYNC"`
 	// Gas Estimation
-	GasEstimatorMode                           string `env:"GAS_ESTIMATOR_MODE"`
-	BlockHistoryEstimatorBatchSize             uint32 `env:"BLOCK_HISTORY_ESTIMATOR_BATCH_SIZE"`
-	BlockHistoryEstimatorBlockDelay            uint16 `env:"BLOCK_HISTORY_ESTIMATOR_BLOCK_DELAY"`
-	BlockHistoryEstimatorBlockHistorySize      uint16 `env:"BLOCK_HISTORY_ESTIMATOR_BLOCK_HISTORY_SIZE"`
-	BlockHistoryEstimatorTransactionPercentile uint16 `env:"BLOCK_HISTORY_ESTIMATOR_TRANSACTION_PERCENTILE"`
+	GasEstimatorMode                               string `env:"GAS_ESTIMATOR_MODE"`
+	BlockHistoryEstimatorBatchSize                 uint32 `env:"BLOCK_HISTORY_ESTIMATOR_BATCH_SIZE"`
+	BlockHistoryEstimatorBlockDelay                uint16 `env:"BLOCK_HISTORY_ESTIMATOR_BLOCK_DELAY"`
+	BlockHistoryEstimatorBlockHistorySize          uint16 `env:"BLOCK_HISTORY_ESTIMATOR_BLOCK_HISTORY_SIZE"`
+	BlockHistoryEstimatorEIP1559FeeCapBufferBlocks uint16 `env:"BLOCK_HISTORY_ESTIMATOR_EIP1559_FEE_CAP_BUFFER_BLOCKS"`
+	BlockHistoryEstimatorTransactionPercentile     uint16 `env:"BLOCK_HISTORY_ESTIMATOR_TRANSACTION_PERCENTILE"`
 
 	// Job Pipeline and tasks
 	DefaultHTTPAllowUnrestrictedNetworkAccess bool            `env:"DEFAULT_HTTP_ALLOW_UNRESTRICTED_NETWORK_ACCESS" default:"false"`

--- a/core/config/envvar/schema_test.go
+++ b/core/config/envvar/schema_test.go
@@ -70,6 +70,7 @@ func TestConfigSchema(t *testing.T) {
 		"EvmGasBumpThreshold":                        "ETH_GAS_BUMP_THRESHOLD",
 		"EvmGasBumpTxDepth":                          "ETH_GAS_BUMP_TX_DEPTH",
 		"EvmGasBumpWei":                              "ETH_GAS_BUMP_WEI",
+		"EvmGasFeeCapDefault":                        "EVM_GAS_FEE_CAP_DEFAULT",
 		"EvmGasLimitDefault":                         "ETH_GAS_LIMIT_DEFAULT",
 		"EvmGasLimitMultiplier":                      "ETH_GAS_LIMIT_MULTIPLIER",
 		"EvmGasLimitTransfer":                        "ETH_GAS_LIMIT_TRANSFER",

--- a/core/config/general_config.go
+++ b/core/config/general_config.go
@@ -163,7 +163,9 @@ type GlobalConfig interface {
 	GlobalBlockHistoryEstimatorBatchSize() (uint32, bool)
 	GlobalBlockHistoryEstimatorBlockDelay() (uint16, bool)
 	GlobalBlockHistoryEstimatorBlockHistorySize() (uint16, bool)
+	GlobalBlockHistoryEstimatorEIP1559FeeCapBufferBlocks() (uint16, bool)
 	GlobalBlockHistoryEstimatorTransactionPercentile() (uint16, bool)
+	GlobalChainType() (string, bool)
 	GlobalEthTxReaperInterval() (time.Duration, bool)
 	GlobalEthTxReaperThreshold() (time.Duration, bool)
 	GlobalEthTxResendAfterThreshold() (time.Duration, bool)
@@ -174,6 +176,7 @@ type GlobalConfig interface {
 	GlobalEvmGasBumpThreshold() (uint64, bool)
 	GlobalEvmGasBumpTxDepth() (uint16, bool)
 	GlobalEvmGasBumpWei() (*big.Int, bool)
+	GlobalEvmGasFeeCapDefault() (*big.Int, bool)
 	GlobalEvmGasLimitDefault() (uint64, bool)
 	GlobalEvmGasLimitMultiplier() (float32, bool)
 	GlobalEvmGasLimitTransfer() (uint64, bool)
@@ -192,7 +195,6 @@ type GlobalConfig interface {
 	GlobalEvmRPCDefaultBatchSize() (uint32, bool)
 	GlobalFlagsContractAddress() (string, bool)
 	GlobalGasEstimatorMode() (string, bool)
-	GlobalChainType() (string, bool)
 	GlobalLinkContractAddress() (string, bool)
 	GlobalMinIncomingConfirmations() (uint32, bool)
 	GlobalMinRequiredOutgoingConfirmations() (uint64, bool)
@@ -1139,6 +1141,20 @@ func (c *generalConfig) GlobalEvmGasBumpWei() (*big.Int, bool) {
 		return nil, false
 	}
 	return val.(*big.Int), ok
+}
+func (c *generalConfig) GlobalEvmGasFeeCapDefault() (*big.Int, bool) {
+	val, ok := c.lookupEnv(envvar.Name("EvmGasFeeCapDefault"), parse.BigInt)
+	if val == nil {
+		return nil, false
+	}
+	return val.(*big.Int), ok
+}
+func (c *generalConfig) GlobalBlockHistoryEstimatorEIP1559FeeCapBufferBlocks() (uint16, bool) {
+	val, ok := c.lookupEnv(envvar.Name("BlockHistoryEstimatorEIP1559FeeCapBufferBlocks"), parse.Uint16)
+	if val == nil {
+		return 0, false
+	}
+	return val.(uint16), ok
 }
 func (c *generalConfig) GlobalEvmGasLimitDefault() (uint64, bool) {
 	val, ok := c.lookupEnv(envvar.Name("EvmGasLimitDefault"), parse.Uint64)

--- a/core/config/mocks/general_config.go
+++ b/core/config/mocks/general_config.go
@@ -960,6 +960,27 @@ func (_m *GeneralConfig) GlobalBlockHistoryEstimatorBlockHistorySize() (uint16, 
 	return r0, r1
 }
 
+// GlobalBlockHistoryEstimatorEIP1559FeeCapBufferBlocks provides a mock function with given fields:
+func (_m *GeneralConfig) GlobalBlockHistoryEstimatorEIP1559FeeCapBufferBlocks() (uint16, bool) {
+	ret := _m.Called()
+
+	var r0 uint16
+	if rf, ok := ret.Get(0).(func() uint16); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint16)
+	}
+
+	var r1 bool
+	if rf, ok := ret.Get(1).(func() bool); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+
+	return r0, r1
+}
+
 // GlobalBlockHistoryEstimatorTransactionPercentile provides a mock function with given fields:
 func (_m *GeneralConfig) GlobalBlockHistoryEstimatorTransactionPercentile() (uint16, bool) {
 	ret := _m.Called()
@@ -1193,6 +1214,29 @@ func (_m *GeneralConfig) GlobalEvmGasBumpTxDepth() (uint16, bool) {
 
 // GlobalEvmGasBumpWei provides a mock function with given fields:
 func (_m *GeneralConfig) GlobalEvmGasBumpWei() (*big.Int, bool) {
+	ret := _m.Called()
+
+	var r0 *big.Int
+	if rf, ok := ret.Get(0).(func() *big.Int); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*big.Int)
+		}
+	}
+
+	var r1 bool
+	if rf, ok := ret.Get(1).(func() bool); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+
+	return r0, r1
+}
+
+// GlobalEvmGasFeeCapDefault provides a mock function with given fields:
+func (_m *GeneralConfig) GlobalEvmGasFeeCapDefault() (*big.Int, bool) {
 	ret := _m.Called()
 
 	var r0 *big.Int

--- a/core/internal/testutils/configtest/general_config.go
+++ b/core/internal/testutils/configtest/general_config.go
@@ -65,6 +65,7 @@ type GeneralConfigOverrides struct {
 	GlobalEvmGasBumpPercent                   null.Int
 	GlobalEvmGasBumpTxDepth                   null.Int
 	GlobalEvmGasBumpWei                       *big.Int
+	GlobalEvmGasFeeCapDefault                 *big.Int
 	GlobalEvmGasLimitDefault                  null.Int
 	GlobalEvmGasLimitMultiplier               null.Float
 	GlobalEvmGasPriceDefault                  *big.Int
@@ -452,6 +453,14 @@ func (c *TestGeneralConfig) GlobalBalanceMonitorEnabled() (bool, bool) {
 		return c.Overrides.GlobalBalanceMonitorEnabled.Bool, true
 	}
 	return c.GeneralConfig.GlobalBalanceMonitorEnabled()
+}
+
+// GlobalEvmGasFeeCapDefault is the override for EvmGasFeeCapDefault
+func (c *TestGeneralConfig) GlobalEvmGasFeeCapDefault() (*big.Int, bool) {
+	if c.Overrides.GlobalEvmGasFeeCapDefault != nil {
+		return c.Overrides.GlobalEvmGasFeeCapDefault, true
+	}
+	return c.GeneralConfig.GlobalEvmGasFeeCapDefault()
 }
 
 func (c *TestGeneralConfig) GlobalEvmGasLimitDefault() (uint64, bool) {

--- a/core/services/vrf/integration_v2_test.go
+++ b/core/services/vrf/integration_v2_test.go
@@ -1168,8 +1168,9 @@ func TestMaliciousConsumer(t *testing.T) {
 	uni := newVRFCoordinatorV2Universe(t, key, 1)
 	carol := uni.vrfConsumers[0]
 	config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(2000000)
-	config.Overrides.GlobalEvmMaxGasPriceWei = big.NewInt(1000000000)  // 1 gwei
-	config.Overrides.GlobalEvmGasPriceDefault = big.NewInt(1000000000) // 1 gwei
+	config.Overrides.GlobalEvmMaxGasPriceWei = assets.GWei(1)
+	config.Overrides.GlobalEvmGasPriceDefault = assets.GWei(1)
+	config.Overrides.GlobalEvmGasFeeCapDefault = assets.GWei(1)
 
 	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, uni.backend, key)
 	require.NoError(t, app.Start())

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,27 @@ New ENV vars:
 - `ADVISORY_LOCK_CHECK_INTERVAL` (default: 1s) - when advisory locking mode is enabled, this controls how often Chainlink checks to make sure it still holds the advisory lock. It is recommended to leave this at the default.
 - `ADVISORY_LOCK_ID` (default: 1027321974924625846) - when advisory locking mode is enabled, the application advisory lock ID can be changed using this env var. All instances of Chainlink that might run on a particular database must share the same advisory lock ID. It is recommended to leave this at the default.
 - `LOG_FILE_DIR` (default: chainlink root directory) - if `LOG_TO_DISK` is enabled, this env var allows you to override the output directory for logging.
+- `BLOCK_HISTORY_ESTIMATOR_EIP1559_FEE_CAP_BUFFER_BLOCKS` - if EIP1559 mode is enabled, this optional env var controls the buffer blocks to add to the current base fee when sending a transaction. By default, the gas bumping threshold + 1 block is used. It is not recommended to change this unless you know what you are doing.
+- `EVM_GAS_FEE_CAP_DEFAULT` - if EIP1559 mode is enabled, and FixedPrice gas estimator is used, this env var controls the fixed initial fee cap.
+
+### Fixed
+
+Fixed issues with EIP-1559 related to gas bumping. Due to [go-ethereum's implementation](https://github.com/ethereum/go-ethereum/blob/bff330335b94af3643ac2fb809793f77de3069d4/core/tx_list.go#L298) which introduces additional restrictions on top of the EIP-1559 spec, we must bump the FeeCap at least 10% each time in order for the gas bump to be accepted.
+
+The new EIP-1559 implementation works as follows:
+
+If you are using FixedPriceEstimator:
+- With gas bumping disabled, it will submit all transactions with `feecap=ETH_MAX_GAS_PRICE_WEI` and `tipcap=EVM_GAS_TIP_CAP_DEFAULT`
+- With gas bumping enabled, it will submit all transactions initially with `feecap=EVM_GAS_FEE_CAP_DEFAULT` and `tipcap=EVM_GAS_TIP_CAP_DEFAULT`.  
+
+If you are using BlockHistoryEstimator (default for most chains):
+- With gas bumping disabled, it will submit all transactions with `feecap=ETH_MAX_GAS_PRICE_WEI` and `tipcap=<calculated using past blocks>`
+- With gas bumping enabled (default for most chains) it will submit all transactions initially with `feecap=current block base fee * (1.125 ^ N)` where N is configurable by setting BLOCK_HISTORY_ESTIMATOR_EIP1559_FEE_CAP_BUFFER_BLOCKS but defaults to `gas bump threshold+1` and `tipcap=<calculated using past blocks>`
+
+Bumping works as follows:
+
+- Increase tipcap by `max(tipcap * (1 + ETH_GAS_BUMP_PERCENT), tipcap + ETH_GAS_BUMP_WEI)`
+- Increase feecap by `max(feecap * (1 + ETH_GAS_BUMP_PERCENT), feecap + ETH_GAS_BUMP_WEI)`
 
 ## [1.1.0] - 2022-01-25
 


### PR DESCRIPTION
Needed to change our EIP-1559 implementation in order to work around a
restrictive implementation of EIP-1559 in go-ethereum.

See: https://github.com/ethereum/go-ethereum/issues/24284

The new EIP-1559 works as follows:

If you are using FixedPriceEstimator:
- With gas bumping disabled, it will submit all transactions with
  feecap=ETH_MAX_GAS_PRICE_WEI and tipcap=EVM_GAS_TIP_CAP_DEFAULT
- With gas bumping enabled, it will submit all transactions initially
  with feecap=EVM_GAS_FEE_CAP_DEFAULT and tipcap=EVM_GAS_TIP_CAP_DEFAULT

If you are using BlockHistoryEstimator:
- With gas bumping disabled, it will submit all transactions with
  feecap=ETH_MAX_GAS_PRICE_WEI and tipcap=<calculated using past blocks>
- With gas bumping enabled, it will submit all transactions initially
  with feecap=<current block base fee * 12.5% headroom for N buffer
  blocks in the future, where N is configurable by setting
  BLOCK_HISTORY_ESTIMATOR_EIP1559_FEE_CAP_BUFFER_BLOCKS but defaults to
  the gas bump threshold+1> and tipcap=<calculated using past blocks>

(cherry picked from commit d177190c5dcc34a0f1a83bb999d7f7f2b2be2187)