### PR TITLE
Diabolical b64 hex

### DIFF
--- a/core/services/pipeline/task_params.go
+++ b/core/services/pipeline/task_params.go
@@ -232,13 +232,14 @@ type BytesParam []byte
 func (b *BytesParam) UnmarshalPipelineParam(val interface{}) error {
 	switch v := val.(type) {
 	case string:
+		// try hex first
 		if len(v) >= 2 && v[:2] == "0x" {
 			bs, err := hex.DecodeString(v[2:])
-			if err != nil {
-				return err
+			if err == nil {
+				*b = BytesParam(bs)
+				return nil
 			}
-			*b = BytesParam(bs)
-			return nil
+			// The base64 encoding for the binary 0b110100110001 is '0x', so carry on.
 		}
 		// try decoding as base64 first, in case this is a string from the database
 		bs, err := base64.StdEncoding.DecodeString(v)

--- a/core/services/pipeline/task_params_test.go
+++ b/core/services/pipeline/task_params_test.go
@@ -1,8 +1,12 @@
 package pipeline_test
 
 import (
+	"encoding/base64"
+	"encoding/hex"
 	"net/url"
 	"testing"
+
+	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -53,6 +57,14 @@ func TestBytesParam_UnmarshalPipelineParam(t *testing.T) {
 		{"string", "foo bar baz", pipeline.BytesParam("foo bar baz"), nil},
 		{"[]byte", []byte("foo bar baz"), pipeline.BytesParam("foo bar baz"), nil},
 		{"int", 12345, pipeline.BytesParam(nil), pipeline.ErrBadInput},
+
+		// The base64 encoding for the binary 0b110100110001 is '0x', but we assume that means hex, and error out.
+		{"hex-invalid", "0xh",
+			pipeline.BytesParam(nil), hex.InvalidByteError('h')},
+		{"b64-hex-prefix", base64.StdEncoding.EncodeToString([]byte{0b11010011, 0b00011000, 0b01001101}),
+			pipeline.BytesParam(nil), hex.InvalidByteError('h')},
+		{"b64-hex-prefix-2", base64.StdEncoding.EncodeToString(hexutil.MustDecode("0xd3184d")),
+			pipeline.BytesParam(nil), hex.InvalidByteError('h')},
 	}
 
 	for _, test := range tests {

--- a/core/services/pipeline/task_params_test.go
+++ b/core/services/pipeline/task_params_test.go
@@ -2,13 +2,11 @@ package pipeline_test
 
 import (
 	"encoding/base64"
-	"encoding/hex"
 	"net/url"
 	"testing"
 
-	"github.com/ethereum/go-ethereum/common/hexutil"
-
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/pkg/errors"
 	"github.com/shopspring/decimal"
@@ -58,13 +56,13 @@ func TestBytesParam_UnmarshalPipelineParam(t *testing.T) {
 		{"[]byte", []byte("foo bar baz"), pipeline.BytesParam("foo bar baz"), nil},
 		{"int", 12345, pipeline.BytesParam(nil), pipeline.ErrBadInput},
 
-		// The base64 encoding for the binary 0b110100110001 is '0x', but we assume that means hex, and error out.
+		// The base64 encoding for the binary 0b110100110001 is '0x', so we must not error when hex fails, since it might actually be b64.
 		{"hex-invalid", "0xh",
-			pipeline.BytesParam(nil), hex.InvalidByteError('h')},
+			pipeline.BytesParam("0xh"), nil},
 		{"b64-hex-prefix", base64.StdEncoding.EncodeToString([]byte{0b11010011, 0b00011000, 0b01001101}),
-			pipeline.BytesParam(nil), hex.InvalidByteError('h')},
+			pipeline.BytesParam([]byte{0b11010011, 0b00011000, 0b01001101}), nil},
 		{"b64-hex-prefix-2", base64.StdEncoding.EncodeToString(hexutil.MustDecode("0xd3184d")),
-			pipeline.BytesParam(nil), hex.InvalidByteError('h')},
+			pipeline.BytesParam(hexutil.MustDecode("0xd3184d")), nil},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
We can't give up on a failed hex parse attempt, because it might actually be base64 encoded data for which `0x` is a valid prefix.