### PR TITLE
Revert changes to the ArbitrumSequencerUpdateFeed contract test

### DIFF
--- a/contracts/test/v0.8/dev/ArbitrumSequencerUptimeFeed.test.ts
+++ b/contracts/test/v0.8/dev/ArbitrumSequencerUptimeFeed.test.ts
@@ -221,7 +221,7 @@ describe('ArbitrumSequencerUptimeFeed', () => {
       const noUpdateTx = await _noUpdateTx.wait(1)
       // Assert no update
       expect(await arbitrumSequencerUptimeFeed.latestAnswer()).to.equal(0)
-      expect(noUpdateTx.cumulativeGasUsed).to.equal(26317)
+      expect(noUpdateTx.cumulativeGasUsed).to.equal(26329)
 
       // Gas for update
       const _updateTx = await arbitrumSequencerUptimeFeed
@@ -230,7 +230,7 @@ describe('ArbitrumSequencerUptimeFeed', () => {
       const updateTx = await _updateTx.wait(1)
       // Assert update
       expect(await arbitrumSequencerUptimeFeed.latestAnswer()).to.equal(1)
-      expect(updateTx.cumulativeGasUsed).to.equal(93076)
+      expect(updateTx.cumulativeGasUsed).to.equal(93088)
     })
 
     it('should consume a known amount of gas for getRoundData(uint80) @skip-coverage', async () => {


### PR DESCRIPTION
This is causing our solidity tests to consistently fail. Unsure how this actually passed CI in the first place