### PR TITLE
Possible fix for DB deadlock / flacky tests

### DIFF
--- a/core/services/job/spawner_test.go
+++ b/core/services/job/spawner_test.go
@@ -42,7 +42,7 @@ func (d delegate) ServicesForSpec(js job.Job) ([]job.Service, error) {
 }
 
 func clearDB(t *testing.T, db *sqlx.DB) {
-	_, err := db.Exec(`TRUNCATE jobs, pipeline_runs, pipeline_specs, pipeline_task_runs CASCADE`)
+	_, err := db.Exec(`DELETE FROM jobs, pipeline_runs, pipeline_specs, pipeline_task_runs`)
 	require.NoError(t, err)
 }
 


### PR DESCRIPTION
Background: https://stackoverflow.com/questions/28750137/truncate-on-one-table-blocked-by-select-of-another

The fix is based on the postgres log attached to the first ticket below. The fix is not confirmed since it is hard to reproduce the issue, but we hope it may improve the situation at the price of longer execution.

Possibly fixes: https://app.shortcut.com/chainlinklabs/story/27909/flakey-test-testbroadcaster-deletesoldlogsonlyafterfinalitydepth-deadlock-detected
Possibly fixes: https://app.shortcut.com/chainlinklabs/story/27446/flakey-test-testbroadcaster-shallowbackfillonnodestart-deadlock-detected