### PR TITLE
Fix Flaky Test caused due to a race condition

### DIFF
--- a/core/chains/evm/log/broadcaster_test.go
+++ b/core/chains/evm/log/broadcaster_test.go
@@ -571,6 +571,10 @@ func TestBroadcaster_BroadcastsToCorrectRecipients(t *testing.T) {
 		helper.start()
 		defer helper.stop()
 
+		helper.register(listener1, contract1, 1)
+		helper.register(listener2, contract1, 1)
+		helper.register(listener3, contract2, 1)
+		helper.register(listener4, contract2, 1)
 		headsDone := cltest.SimulateIncomingHeads(t, cltest.SimulateIncomingHeadsArgs{
 			StartBlock:     0,
 			EndBlock:       9,
@@ -578,11 +582,6 @@ func TestBroadcaster_BroadcastsToCorrectRecipients(t *testing.T) {
 			Blocks:         blocks,
 		})
 
-		time.Sleep(9 * time.Second)
-		helper.register(listener1, contract1, 1)
-		helper.register(listener2, contract1, 1)
-		helper.register(listener3, contract2, 1)
-		helper.register(listener4, contract2, 1)
 		defer helper.unsubscribeAll()
 
 		chRawLogs := <-helper.chchRawLogs

--- a/core/chains/evm/log/broadcaster_test.go
+++ b/core/chains/evm/log/broadcaster_test.go
@@ -578,6 +578,7 @@ func TestBroadcaster_BroadcastsToCorrectRecipients(t *testing.T) {
 			Blocks:         blocks,
 		})
 
+		time.Sleep(9 * time.Second)
 		helper.register(listener1, contract1, 1)
 		helper.register(listener2, contract1, 1)
 		helper.register(listener3, contract2, 1)


### PR DESCRIPTION
Ticket: https://app.shortcut.com/chainlinklabs/story/29513/flaky-test-testbroadcaster-broadcaststocorrectrecipients

The flakiness is because the test is first simulating head broadcasts, before registering log broadcast listeners for them.
And later it is trying to verify that all registered listeners got their broadcasts correctly.

The race condition occurs, since the heads simulation runs async, and most of the times, the registrations for listeners happens before heads can be broadcaster from other thread.
But sometimes when the registrations are late, this test fails.
