### PR TITLE
Log warning when exceeding configured gas limit in estimategas task

### DIFF
--- a/core/services/pipeline/task.estimategas.go
+++ b/core/services/pipeline/task.estimategas.go
@@ -88,6 +88,10 @@ func (t *EstimateGasLimitTask) Run(_ context.Context, lggr logger.Logger, vars V
 	}
 	gasLimitFinal := gasLimitWithMultiplier.Uint64()
 	if gasLimitFinal > maximumGasLimit {
+		lggr.Warnw("EstimateGas: estimated amount is greater than configured limit, fallback to configured limit",
+			"estimate", gasLimitFinal,
+			"fallback", maximumGasLimit,
+		)
 		gasLimitFinal = maximumGasLimit
 	}
 	return Result{Value: gasLimitFinal}, runInfo


### PR DESCRIPTION
Ticket: https://app.shortcut.com/chainlinklabs/story/29913/log-when-transaction-gas-limit-is-exceeded-in-estimategas-task

