### PR TITLE
Filter github actions workflow runs by modified file paths

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,11 @@
+# GitHub Workflows
+
+## Required Checks and Path Filters
+
+We want to run certain workflows only when certain file paths change. We can accomplish this with [path based filtering on GitHub actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore). The problem that we run into is that we have certain required checks on GitHub that will not run or pass if we have path based filtering that never executes the workflow.
+
+The [solution that GitHub recommends](https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#handling-skipped-but-required-checks) is to create a "dummy" workflow with the same workflow name and job names as the required workflow/jobs with the jobs running a command to simply exit zero immediately to indicate success.
+
+### Solution
+
+If your workflow is named `solidity.yml`, create a `solidity-paths-ignore.yml` file with the same workflow name, event triggers (except for the path filters, use `paths-ignore` instead of `paths`), same job names, and then in the steps feel free to echo a command or explicitly `exit 0` to make sure it passes. See the workflow file names with the `-paths-ignore.yml` suffix in this directory for examples.

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -1,6 +1,6 @@
-name: CI
+name: CI Core
 
-on: [push]
+on: push
 
 jobs:
   core:
@@ -67,30 +67,3 @@ jobs:
         with:
           args: logs ${{ job.services.postgres.id }}
 
-  prepublish_npm:
-    name: Prepublish NPM
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout the repo
-        uses: actions/checkout@v2
-      - name: Setup node
-        uses: actions/setup-node@v2
-        with:
-          node-version: "16"
-      - name: Yarn cache
-        uses: actions/cache@v2
-        env:
-          cache-name: yarn-cache
-        with:
-          path: |
-            ~/.npm
-            ~/.cache
-            **/node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('yarn.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-      - run: yarn install --frozen-lockfile
-      - name: Run prepublish NPM test
-        run: ./tools/ci/prepublish_npm_test

--- a/.github/workflows/dependency-check-paths-ignore.yml
+++ b/.github/workflows/dependency-check-paths-ignore.yml
@@ -1,0 +1,24 @@
+##
+# This workflow needs to be ran in case it is a required check and
+# we conditionally only run the `dependency-check` workflow when certain
+# paths change.
+# If the workflow does not run, and it is ever marked as required,
+# then the check will never pass.
+# This is GitHub's workaround:
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#example
+##
+
+name: Dependency Vulnerability Check
+
+on: 
+  push:
+    paths-ignore:
+      - '**/go.mod'
+      - '**/go.sum'
+jobs:
+  Go:
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No job required" '
+
+

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -1,6 +1,15 @@
+##
+# NOTE: any changes to the event triggers or the paths here should be reflected in:
+#       dependency-check-paths-ignore.yml
+##
+
 name: Dependency Vulnerability Check
 
-on: [push]
+on: 
+  push:
+    paths:
+      - '**/go.mod'
+      - '**/go.sum'
 jobs:
   Go:
     runs-on: ubuntu-latest

--- a/.github/workflows/golangci-lint-paths-ignore.yml
+++ b/.github/workflows/golangci-lint-paths-ignore.yml
@@ -1,0 +1,29 @@
+##
+# This workflow needs to be ran because `lint` is a required check and
+# we conditionally only run the `golangci-lint` workflow when certain paths 
+# change.
+# If the workflow does not run, the required check will never pass. This is
+# GitHub's workaround:
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#example
+##
+
+name: golangci-lint
+
+on:
+  push:
+    branches:
+      - auto
+      - try
+      - rollup
+    paths-ignore:
+      - '**.go'
+  pull_request:
+    paths-ignore:
+      - '**.go'
+
+jobs:
+  golangci:
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No job required" '

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,3 +1,8 @@
+##
+# NOTE: any changes to the event triggers or the paths here should be reflected in:
+#       golangci-lint-paths-ignore.yml
+##
+
 name: golangci-lint
 
 on:
@@ -6,7 +11,11 @@ on:
       - auto
       - try
       - rollup
+    paths:
+      - '**.go'
   pull_request:
+    paths:
+      - '**.go'
 
 jobs:
   golangci:

--- a/.github/workflows/operator-ui-paths-ignore.yml
+++ b/.github/workflows/operator-ui-paths-ignore.yml
@@ -1,0 +1,33 @@
+##
+# This workflow needs to be ran because `Operator UI Tests` is a required check
+# and we conditionally only run the `Operator UI` workflow when certain paths
+# change.
+# If the workflow does not run, the required check will never pass. This is
+# GitHub's workaround:
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#example
+##
+
+name: Operator UI
+
+on:
+  push:
+    branches:
+      - auto
+      - try
+      - rollup
+    paths-ignore:
+      - 'operator_ui/**'
+      - yarn.lock
+      - 'tools/ci/**'
+  pull_request:
+    paths-ignore:
+      - 'operator_ui/**'
+      - yarn.lock
+      - 'tools/ci/**'
+
+jobs:
+  operator-ui:
+    name: Operator UI Tests
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No job required" '

--- a/.github/workflows/operator-ui.yml
+++ b/.github/workflows/operator-ui.yml
@@ -1,3 +1,8 @@
+##
+# NOTE: any changes to the event triggers or the paths here should be reflected in:
+#       operator-ui-paths-ignore.yml
+##
+
 name: Operator UI
 
 on:
@@ -6,7 +11,15 @@ on:
       - auto
       - try
       - rollup
+    paths:
+      - 'operator_ui/**'
+      - yarn.lock
+      - 'tools/ci/**'
   pull_request:
+    paths:
+      - 'operator_ui/**'
+      - yarn.lock
+      - 'tools/ci/**'
 
 jobs:
   operator-ui:

--- a/.github/workflows/solidity-paths-ignore.yml
+++ b/.github/workflows/solidity-paths-ignore.yml
@@ -1,0 +1,38 @@
+##
+# This workflow needs to be ran because `Solidity` is a required check and we 
+# conditionally only run the `Solidity` workflow when certain paths change.
+# If the workflow does not run, the required check will never pass. This is
+# GitHub's workaround:
+# https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/defining-the-mergeability-of-pull-requests/troubleshooting-required-status-checks#example
+##
+
+name: Solidity
+
+on:
+  push:
+    branches:
+      - auto
+      - try
+      - rollup
+    paths-ignore:
+      - 'contracts/**'
+      - yarn.lock
+      - 'tools/ci/**'
+  pull_request:
+    paths-ignore:
+      - 'contracts/**'
+      - yarn.lock
+      - 'tools/ci/**'
+
+jobs:
+  solidity-coverage:
+    name: Solidity Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No job required" '
+  solidity:
+    name: Solidity
+    runs-on: ubuntu-latest
+    steps:
+      - run: 'echo "No job required" '
+

--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -1,3 +1,8 @@
+##
+# NOTE: any changes to the event triggers or the paths here should be reflected in:
+#       solidity-paths-ignore.yml
+##
+
 name: Solidity
 
 on:
@@ -6,7 +11,15 @@ on:
       - auto
       - try
       - rollup
+    paths:
+      - 'contracts/**'
+      - yarn.lock
+      - 'tools/ci/**'
   pull_request:
+    paths:
+      - 'contracts/**'
+      - yarn.lock
+      - 'tools/ci/**'
 
 jobs:
   solidity-coverage:
@@ -70,3 +83,5 @@ jobs:
         run: ./tools/ci/check_solc_hashes
       - name: Run tests
         run: ./tools/ci/solidity_test_hardhat
+      - name: Run prepublish NPM test
+        run: ./tools/ci/prepublish_npm_test


### PR DESCRIPTION
See docs for the [path based filtering on GitHub actions](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore).

The goal is to prevent a PR that only changes `core/` files from executing a workflow that runs `contracts/` tests, for example.

The current changes:
- Only run solidity tests when contracts/ are changed
- Only run frontend tests when operator_ui/ is changed
- Go dependency checks only when go modules are changed
- Go linting only when .go files are changed