### PR TITLE
VRF V2: Use aggregator v3 latest round data

### DIFF
--- a/core/internal/gethwrappers/generated/aggregator_v3_interface/aggregator_v3_interface.go
+++ b/core/internal/gethwrappers/generated/aggregator_v3_interface/aggregator_v3_interface.go
@@ -1,0 +1,319 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package aggregator_v3_interface
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+var AggregatorV3InterfaceMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[],\"name\":\"decimals\",\"outputs\":[{\"internalType\":\"uint8\",\"name\":\"\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"description\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint80\",\"name\":\"_roundId\",\"type\":\"uint80\"}],\"name\":\"getRoundData\",\"outputs\":[{\"internalType\":\"uint80\",\"name\":\"roundId\",\"type\":\"uint80\"},{\"internalType\":\"int256\",\"name\":\"answer\",\"type\":\"int256\"},{\"internalType\":\"uint256\",\"name\":\"startedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"updatedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint80\",\"name\":\"answeredInRound\",\"type\":\"uint80\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"latestRoundData\",\"outputs\":[{\"internalType\":\"uint80\",\"name\":\"roundId\",\"type\":\"uint80\"},{\"internalType\":\"int256\",\"name\":\"answer\",\"type\":\"int256\"},{\"internalType\":\"uint256\",\"name\":\"startedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint256\",\"name\":\"updatedAt\",\"type\":\"uint256\"},{\"internalType\":\"uint80\",\"name\":\"answeredInRound\",\"type\":\"uint80\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"version\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+var AggregatorV3InterfaceABI = AggregatorV3InterfaceMetaData.ABI
+
+type AggregatorV3Interface struct {
+	address common.Address
+	abi     abi.ABI
+	AggregatorV3InterfaceCaller
+	AggregatorV3InterfaceTransactor
+	AggregatorV3InterfaceFilterer
+}
+
+type AggregatorV3InterfaceCaller struct {
+	contract *bind.BoundContract
+}
+
+type AggregatorV3InterfaceTransactor struct {
+	contract *bind.BoundContract
+}
+
+type AggregatorV3InterfaceFilterer struct {
+	contract *bind.BoundContract
+}
+
+type AggregatorV3InterfaceSession struct {
+	Contract     *AggregatorV3Interface
+	CallOpts     bind.CallOpts
+	TransactOpts bind.TransactOpts
+}
+
+type AggregatorV3InterfaceCallerSession struct {
+	Contract *AggregatorV3InterfaceCaller
+	CallOpts bind.CallOpts
+}
+
+type AggregatorV3InterfaceTransactorSession struct {
+	Contract     *AggregatorV3InterfaceTransactor
+	TransactOpts bind.TransactOpts
+}
+
+type AggregatorV3InterfaceRaw struct {
+	Contract *AggregatorV3Interface
+}
+
+type AggregatorV3InterfaceCallerRaw struct {
+	Contract *AggregatorV3InterfaceCaller
+}
+
+type AggregatorV3InterfaceTransactorRaw struct {
+	Contract *AggregatorV3InterfaceTransactor
+}
+
+func NewAggregatorV3Interface(address common.Address, backend bind.ContractBackend) (*AggregatorV3Interface, error) {
+	abi, err := abi.JSON(strings.NewReader(AggregatorV3InterfaceABI))
+	if err != nil {
+		return nil, err
+	}
+	contract, err := bindAggregatorV3Interface(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &AggregatorV3Interface{address: address, abi: abi, AggregatorV3InterfaceCaller: AggregatorV3InterfaceCaller{contract: contract}, AggregatorV3InterfaceTransactor: AggregatorV3InterfaceTransactor{contract: contract}, AggregatorV3InterfaceFilterer: AggregatorV3InterfaceFilterer{contract: contract}}, nil
+}
+
+func NewAggregatorV3InterfaceCaller(address common.Address, caller bind.ContractCaller) (*AggregatorV3InterfaceCaller, error) {
+	contract, err := bindAggregatorV3Interface(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AggregatorV3InterfaceCaller{contract: contract}, nil
+}
+
+func NewAggregatorV3InterfaceTransactor(address common.Address, transactor bind.ContractTransactor) (*AggregatorV3InterfaceTransactor, error) {
+	contract, err := bindAggregatorV3Interface(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &AggregatorV3InterfaceTransactor{contract: contract}, nil
+}
+
+func NewAggregatorV3InterfaceFilterer(address common.Address, filterer bind.ContractFilterer) (*AggregatorV3InterfaceFilterer, error) {
+	contract, err := bindAggregatorV3Interface(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &AggregatorV3InterfaceFilterer{contract: contract}, nil
+}
+
+func bindAggregatorV3Interface(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(AggregatorV3InterfaceABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _AggregatorV3Interface.Contract.AggregatorV3InterfaceCaller.contract.Call(opts, result, method, params...)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AggregatorV3Interface.Contract.AggregatorV3InterfaceTransactor.contract.Transfer(opts)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _AggregatorV3Interface.Contract.AggregatorV3InterfaceTransactor.contract.Transact(opts, method, params...)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _AggregatorV3Interface.Contract.contract.Call(opts, result, method, params...)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _AggregatorV3Interface.Contract.contract.Transfer(opts)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _AggregatorV3Interface.Contract.contract.Transact(opts, method, params...)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceCaller) Decimals(opts *bind.CallOpts) (uint8, error) {
+	var out []interface{}
+	err := _AggregatorV3Interface.contract.Call(opts, &out, "decimals")
+
+	if err != nil {
+		return *new(uint8), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint8)).(*uint8)
+
+	return out0, err
+
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceSession) Decimals() (uint8, error) {
+	return _AggregatorV3Interface.Contract.Decimals(&_AggregatorV3Interface.CallOpts)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceCallerSession) Decimals() (uint8, error) {
+	return _AggregatorV3Interface.Contract.Decimals(&_AggregatorV3Interface.CallOpts)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceCaller) Description(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _AggregatorV3Interface.contract.Call(opts, &out, "description")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceSession) Description() (string, error) {
+	return _AggregatorV3Interface.Contract.Description(&_AggregatorV3Interface.CallOpts)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceCallerSession) Description() (string, error) {
+	return _AggregatorV3Interface.Contract.Description(&_AggregatorV3Interface.CallOpts)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceCaller) GetRoundData(opts *bind.CallOpts, _roundId *big.Int) (GetRoundData,
+
+	error) {
+	var out []interface{}
+	err := _AggregatorV3Interface.contract.Call(opts, &out, "getRoundData", _roundId)
+
+	outstruct := new(GetRoundData)
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.RoundId = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Answer = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.StartedAt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.UpdatedAt = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.AnsweredInRound = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceSession) GetRoundData(_roundId *big.Int) (GetRoundData,
+
+	error) {
+	return _AggregatorV3Interface.Contract.GetRoundData(&_AggregatorV3Interface.CallOpts, _roundId)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceCallerSession) GetRoundData(_roundId *big.Int) (GetRoundData,
+
+	error) {
+	return _AggregatorV3Interface.Contract.GetRoundData(&_AggregatorV3Interface.CallOpts, _roundId)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceCaller) LatestRoundData(opts *bind.CallOpts) (LatestRoundData,
+
+	error) {
+	var out []interface{}
+	err := _AggregatorV3Interface.contract.Call(opts, &out, "latestRoundData")
+
+	outstruct := new(LatestRoundData)
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.RoundId = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Answer = *abi.ConvertType(out[1], new(*big.Int)).(**big.Int)
+	outstruct.StartedAt = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.UpdatedAt = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.AnsweredInRound = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceSession) LatestRoundData() (LatestRoundData,
+
+	error) {
+	return _AggregatorV3Interface.Contract.LatestRoundData(&_AggregatorV3Interface.CallOpts)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceCallerSession) LatestRoundData() (LatestRoundData,
+
+	error) {
+	return _AggregatorV3Interface.Contract.LatestRoundData(&_AggregatorV3Interface.CallOpts)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceCaller) Version(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _AggregatorV3Interface.contract.Call(opts, &out, "version")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceSession) Version() (*big.Int, error) {
+	return _AggregatorV3Interface.Contract.Version(&_AggregatorV3Interface.CallOpts)
+}
+
+func (_AggregatorV3Interface *AggregatorV3InterfaceCallerSession) Version() (*big.Int, error) {
+	return _AggregatorV3Interface.Contract.Version(&_AggregatorV3Interface.CallOpts)
+}
+
+type GetRoundData struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}
+type LatestRoundData struct {
+	RoundId         *big.Int
+	Answer          *big.Int
+	StartedAt       *big.Int
+	UpdatedAt       *big.Int
+	AnsweredInRound *big.Int
+}
+
+func (_AggregatorV3Interface *AggregatorV3Interface) Address() common.Address {
+	return _AggregatorV3Interface.address
+}
+
+type AggregatorV3InterfaceInterface interface {
+	Decimals(opts *bind.CallOpts) (uint8, error)
+
+	Description(opts *bind.CallOpts) (string, error)
+
+	GetRoundData(opts *bind.CallOpts, _roundId *big.Int) (GetRoundData,
+
+		error)
+
+	LatestRoundData(opts *bind.CallOpts) (LatestRoundData,
+
+		error)
+
+	Version(opts *bind.CallOpts) (*big.Int, error)
+
+	Address() common.Address
+}

--- a/core/internal/gethwrappers/generation/generated-wrapper-dependency-versions-do-not-edit.txt
+++ b/core/internal/gethwrappers/generation/generated-wrapper-dependency-versions-do-not-edit.txt
@@ -1,5 +1,6 @@
 GETH_VERSION: 1.10.15
 aggregator_v2v3_interface: ../../../contracts/solc/v0.8/AggregatorV2V3Interface.abi ../../../contracts/solc/v0.8/AggregatorV2V3Interface.bin ec03a11bfb3d34b3e9a8d25ad58751aa3e3e160144f1979d2b023a0e4582b964
+aggregator_v3_interface: ../../../contracts/solc/v0.8/AggregatorV3Interface.abi ../../../contracts/solc/v0.8/AggregatorV3Interface.bin 351b55d3b0f04af67db6dfb5c92f1c64479400ca1fec77afc20bc0ce65cb49ab
 blockhash_store: ../../../contracts/solc/v0.6/BlockhashStore.abi ../../../contracts/solc/v0.6/BlockhashStore.bin 6b3da771f033b3a5e53bf112396d0698debf65a8dcd81370f07d72948c8b14d9
 consumer_wrapper: ../../../contracts/solc/v0.7/Consumer.abi ../../../contracts/solc/v0.7/Consumer.bin 894d1cbd920dccbd36d92918c1037c6ded34f66f417ccb18ec3f33c64ef83ec5
 derived_price_feed_wrapper: ../../../contracts/solc/v0.7/DerivedPriceFeed.abi ../../../contracts/solc/v0.7/DerivedPriceFeed.bin 754190a4e868d35913f7f4ab3fbc605afdbc1b64d68ea53d8de89fd6b036fe06

--- a/core/internal/gethwrappers/go_generate.go
+++ b/core/internal/gethwrappers/go_generate.go
@@ -45,6 +45,7 @@ package gethwrappers
 
 // Aggregators
 //go:generate go run ./generation/generate/wrap.go ../../../contracts/solc/v0.8/AggregatorV2V3Interface.abi ../../../contracts/solc/v0.8/AggregatorV2V3Interface.bin AggregatorV2V3Interface aggregator_v2v3_interface
+//go:generate go run ./generation/generate/wrap.go ../../../contracts/solc/v0.8/AggregatorV3Interface.abi ../../../contracts/solc/v0.8/AggregatorV3Interface.bin AggregatorV3Interface aggregator_v3_interface
 
 // To run these commands, you must either install docker, or the correct version
 // of abigen. The latter can be installed with these commands, at least on linux:

--- a/core/services/vrf/delegate.go
+++ b/core/services/vrf/delegate.go
@@ -10,10 +10,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/theodesp/go-heaps/pairing"
 
-	"github.com/smartcontractkit/sqlx"
-
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
-	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/aggregator_v2v3_interface"
+	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/aggregator_v3_interface"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/solidity_vrf_coordinator_interface"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/vrf_coordinator_v2"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -22,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/core/utils"
+	"github.com/smartcontractkit/sqlx"
 )
 
 type Delegate struct {
@@ -105,7 +104,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.Service, error) {
 			if err != nil {
 				return nil, err
 			}
-			aggregator, err := aggregator_v2v3_interface.NewAggregatorV2V3Interface(linkEthFeedAddress, chain.Client())
+			aggregator, err := aggregator_v3_interface.NewAggregatorV3Interface(linkEthFeedAddress, chain.Client())
 			if err != nil {
 				return nil, err
 			}

--- a/core/services/vrf/listener_v2.go
+++ b/core/services/vrf/listener_v2.go
@@ -20,7 +20,7 @@ import (
 	httypes "github.com/smartcontractkit/chainlink/core/chains/evm/headtracker/types"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/log"
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
-	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/aggregator_v2v3_interface"
+	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/aggregator_v3_interface"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/vrf_coordinator_v2"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/null"
@@ -91,7 +91,7 @@ type listenerV2 struct {
 	wg *sync.WaitGroup
 
 	// aggregator client to get link/eth feed prices from chain.
-	aggregator *aggregator_v2v3_interface.AggregatorV2V3Interface
+	aggregator *aggregator_v3_interface.AggregatorV3Interface
 }
 
 func (lsn *listenerV2) Start() error {
@@ -420,7 +420,7 @@ func (lsn *listenerV2) estimateFeeJuels(
 	// Don't use up too much time to get this info, it's not critical for operating vrf.
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
 	defer cancel()
-	weiPerUnitLink, err := lsn.aggregator.LatestAnswer(&bind.CallOpts{Context: ctx})
+	roundData, err := lsn.aggregator.LatestRoundData(&bind.CallOpts{Context: ctx})
 	if err != nil {
 		return nil, errors.Wrap(err, "get aggregator latestAnswer")
 	}
@@ -430,7 +430,7 @@ func (lsn *listenerV2) estimateFeeJuels(
 	juelsNeeded := EstimateFeeJuels(
 		req.CallbackGasLimit,
 		maxGasPriceWei,
-		weiPerUnitLink,
+		roundData.Answer,
 	)
 	return juelsNeeded, nil
 }


### PR DESCRIPTION
Switch VRF V2 to use the aggregator v3 interface func
latestRoundData to match what's being used in the VRFCoordinatorV2
contract.