### PR TITLE
Avoid dividing by zero in EstimateFeeJuels

### DIFF
--- a/core/services/vrf/listener_v2.go
+++ b/core/services/vrf/listener_v2.go
@@ -427,11 +427,14 @@ func (lsn *listenerV2) estimateFeeJuels(
 	// NOTE: no need to sanity check this as this is for logging purposes only
 	// and should not be used to determine whether a user has enough funds in actuality,
 	// we should always simulate for that.
-	juelsNeeded := EstimateFeeJuels(
+	juelsNeeded, err := EstimateFeeJuels(
 		req.CallbackGasLimit,
 		maxGasPriceWei,
 		roundData.Answer,
 	)
+	if err != nil {
+		return nil, errors.Wrap(err, "estimate fee juels")
+	}
 	return juelsNeeded, nil
 }
 
@@ -663,12 +666,16 @@ const GasProofVerification uint32 = 200_000
 
 // EstimateFeeJuels estimates the amount of link needed to fulfill a request
 // given the callback gas limit, the gas price, and the wei per unit link.
-func EstimateFeeJuels(callbackGasLimit uint32, maxGasPriceWei, weiPerUnitLink *big.Int) *big.Int {
+// An error is returned if the wei per unit link provided is zero.
+func EstimateFeeJuels(callbackGasLimit uint32, maxGasPriceWei, weiPerUnitLink *big.Int) (*big.Int, error) {
+	if weiPerUnitLink.Cmp(big.NewInt(0)) == 0 {
+		return nil, errors.New("wei per unit link is zero")
+	}
 	maxGasUsed := big.NewInt(int64(callbackGasLimit + GasProofVerification))
 	costWei := maxGasUsed.Mul(maxGasUsed, maxGasPriceWei)
 	// Multiply by 1e18 first so that we don't lose a ton of digits due to truncation when we divide
 	// by weiPerUnitLink
 	numerator := costWei.Mul(costWei, big.NewInt(1e18))
 	costJuels := numerator.Quo(numerator, weiPerUnitLink)
-	return costJuels
+	return costJuels, nil
 }

--- a/core/services/vrf/listener_v2_helpers_test.go
+++ b/core/services/vrf/listener_v2_helpers_test.go
@@ -14,12 +14,18 @@ func TestListener_EstimateFeeJuels(t *testing.T) {
 	callbackGasLimit := uint32(150_000)
 	maxGasPriceGwei := assets.GWei(30)
 	weiPerUnitLink := big.NewInt(5898160000000000)
-	actual := vrf.EstimateFeeJuels(callbackGasLimit, maxGasPriceGwei, weiPerUnitLink)
+	actual, err := vrf.EstimateFeeJuels(callbackGasLimit, maxGasPriceGwei, weiPerUnitLink)
 	expected := big.NewInt(1780216203019246680)
 	require.True(t, actual.Cmp(expected) == 0, "expected:", expected.String(), "actual:", actual.String())
+	require.NoError(t, err)
 
 	weiPerUnitLink = big.NewInt(5898161234554321)
-	actual = vrf.EstimateFeeJuels(callbackGasLimit, maxGasPriceGwei, weiPerUnitLink)
+	actual, err = vrf.EstimateFeeJuels(callbackGasLimit, maxGasPriceGwei, weiPerUnitLink)
 	expected = big.NewInt(1780215830399116719)
 	require.True(t, actual.Cmp(expected) == 0, "expected:", expected.String(), "actual:", actual.String())
+	require.NoError(t, err)
+
+	actual, err = vrf.EstimateFeeJuels(callbackGasLimit, maxGasPriceGwei, big.NewInt(0))
+	require.Nil(t, actual)
+	require.Error(t, err)
 }


### PR DESCRIPTION
In practice, this might happen if we have a busted feed giving us bad
values for `LatestRoundData` or similar methods.