### PR TITLE
core/logger: sanitize static Sha and Version for baseLoggerName

### DIFF
--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -141,8 +141,20 @@ func newProductionConfig(dir string, jsonConsole bool, toDisk bool, unixTS bool)
 	return config
 }
 
-func baseLoggerName() string {
-	return fmt.Sprintf("%s@%s", static.Version, static.Sha[:7])
+func verShaNameStatic() string {
+	return verShaName(static.Version, static.Sha)
+}
+
+func verShaName(ver, sha string) string {
+	if sha == "" {
+		sha = "unset"
+	} else if len(sha) > 7 {
+		sha = sha[:7]
+	}
+	if ver == "" {
+		ver = "unset"
+	}
+	return fmt.Sprintf("%s@%s", ver, sha)
 }
 
 // NewLogger returns a new Logger configured from environment variables, and logs any parsing errors.
@@ -185,7 +197,7 @@ func NewLogger() Logger {
 	for _, msg := range parseErrs {
 		l.Error(msg)
 	}
-	return l.Named(baseLoggerName())
+	return l.Named(verShaNameStatic())
 }
 
 type Config struct {

--- a/core/logger/logger_test.go
+++ b/core/logger/logger_test.go
@@ -17,3 +17,22 @@ func TestConfig(t *testing.T) {
 	assert.False(t, newTestConfig().Development)
 	assert.False(t, newProductionConfig("", false, true, false).Development)
 }
+
+func Test_verShaName(t *testing.T) {
+	for _, tt := range []struct {
+		ver, sha string
+		exp      string
+	}{
+		{"1.0", "1234567890", "1.0@1234567"},
+		{"1", "a", "1@a"},
+		{"", "", "unset@unset"},
+		{"1.0", "", "1.0@unset"},
+		{"", "1234567890", "unset@1234567"},
+	} {
+		t.Run(tt.ver+":"+tt.sha, func(t *testing.T) {
+			if got := verShaName(tt.ver, tt.sha); got != tt.exp {
+				t.Errorf("expected %q but got %q", tt.exp, got)
+			}
+		})
+	}
+}

--- a/core/logger/test_logger.go
+++ b/core/logger/test_logger.go
@@ -82,7 +82,7 @@ func TestLogger(t T) Logger {
 	if t == nil {
 		return l
 	}
-	return l.Named(baseLoggerName()).Named(t.Name())
+	return l.Named(verShaNameStatic()).Named(t.Name())
 }
 
 func newTestConfig() zap.Config {

--- a/core/logger/test_logger_test.go
+++ b/core/logger/test_logger_test.go
@@ -37,7 +37,7 @@ func TestTestLogger(t *testing.T) {
 	)
 	lgr.Warn(testMessage)
 	// [WARN]  Test message		logger/test_logger_test.go:23    logger=1.0.0@sHaValue.TestLogger
-	requireContains("[WARN]", testMessage, fmt.Sprintf("logger=%s.%s", baseLoggerName(), testName))
+	requireContains("[WARN]", testMessage, fmt.Sprintf("logger=%s.%s", verShaNameStatic(), testName))
 
 	const (
 		serviceName    = "ServiceName"
@@ -50,7 +50,7 @@ func TestTestLogger(t *testing.T) {
 	srvLgr.Debugw(serviceMessage, key, value)
 	// [DEBUG]  Service message		logger/test_logger_test.go:35    key=value logger=1.0.0@sHaValue.TestLogger.ServiceName
 	requireContains("[DEBUG]", serviceMessage, fmt.Sprintf("%s=%s", key, value),
-		fmt.Sprintf("logger=%s.%s.%s", baseLoggerName(), testName, serviceName))
+		fmt.Sprintf("logger=%s.%s.%s", verShaNameStatic(), testName, serviceName))
 	lgr.Debugw(omittedMessage) // omitted since still Info level
 	requireNotContains(omittedMessage)
 
@@ -64,11 +64,11 @@ func TestTestLogger(t *testing.T) {
 	wrkLgr.Infow(workerMessage, resultKey, resultVal)
 	// [INFO]	Did some work		logger/test_logger_test.go:49    logger=1.0.0@sHaValue.TestLogger.ServiceName.WorkerName result=success workerId=42
 	requireContains("[INFO]", workerMessage, fmt.Sprintf("%s=%s", idKey, workerId),
-		fmt.Sprintf("%s=%s", resultKey, resultVal), fmt.Sprintf("logger=%s.%s.%s.%s", baseLoggerName(), testName, serviceName, workerName))
+		fmt.Sprintf("%s=%s", resultKey, resultVal), fmt.Sprintf("logger=%s.%s.%s.%s", verShaNameStatic(), testName, serviceName, workerName))
 
 	const (
 		critMsg = "Critical error"
 	)
 	lgr.Critical(critMsg)
-	requireContains("[CRIT]", critMsg, fmt.Sprintf("logger=%s.%s", baseLoggerName(), testName))
+	requireContains("[CRIT]", critMsg, fmt.Sprintf("logger=%s.%s", verShaNameStatic(), testName))
 }

--- a/core/static/static.go
+++ b/core/static/static.go
@@ -14,7 +14,7 @@ import (
 var Version = "unset"
 
 // Sha string "unset"
-var Sha = "unsetSHA"
+var Sha = "unset"
 
 var InitTime time.Time
 


### PR DESCRIPTION
Setting empty or too short of a value for Sha would cause a panic. Sanitize and only slice if necessary instead.