### PR TITLE
tools/bin: update go_core_race_tests and add to CI matrix

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        cmd: ['go_core_tests']
+        cmd: ['go_core_tests', 'go_core_race_tests']
     name: Core Tests
     runs-on: ubuntu-latest
     env:
@@ -58,7 +58,9 @@ jobs:
         uses: actions/upload-artifact@v2.3.0
         with:
           name: ${{ matrix.cmd }}_logs
-          path: ./output.txt
+          path: |
+            ./output.txt
+            ./race.*
       - name: Print postgres logs
         if: always()
         uses: docker://docker:latest

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,8 @@ cl_backup_*.tar.gz
 
 # Test artifacts
 core/cmd/TestClient_ImportExportP2PKeyBundle_test_key.json
+output.txt
+race.*
 
 # DB state
 db/

--- a/tools/bin/go_core_race_tests
+++ b/tools/bin/go_core_race_tests
@@ -1,3 +1,19 @@
 #!/usr/bin/env bash
 set -ex
-go test -race -timeout 1800s -v -p 4 -parallel 4 ./...
+
+GO_LDFLAGS=$(bash tools/bin/ldflags)
+# remove -short for complete coverage
+GORACE="log_path=$PWD/race" LOG_LEVEL=panic go test -race -ldflags "$GO_LDFLAGS" -short -shuffle on -timeout 30s -count 10 -p 4 ./core/... | tee ./output.txt
+EXITCODE=${PIPESTATUS[0]}
+# Fail if any race logs are present.
+if ls race.* &>/dev/null
+then
+  echo "Race(s) detected"
+  exit 1
+fi
+if test $EXITCODE -gt 1
+then
+  exit $EXITCODE
+else
+  exit 0
+fi


### PR DESCRIPTION
This adds minimal use of `go test -race` to CI. It runs parallel to the normal tests, and I tried to calibrate it to about the same run time, so it won't slow anything down. Additionally, the race script only fails if races are detected, not for regular test failures.

Already have a hit:
https://app.shortcut.com/chainlinklabs/story/30515