### PR TITLE
GNUmakefile: document commands for help list

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -11,13 +11,13 @@ GOFLAGS = -ldflags "$(GO_LDFLAGS)"
 install: operator-ui-autoinstall install-chainlink-autoinstall ## Install chainlink and all its dependencies.
 
 .PHONY: install-git-hooks
-install-git-hooks:
+install-git-hooks: ## Install git hooks.
 	git config core.hooksPath .githooks
 
 .PHONY: install-chainlink-autoinstall
-install-chainlink-autoinstall: | gomod install-chainlink
+install-chainlink-autoinstall: | gomod install-chainlink ## Autoinstall chainlink.
 .PHONY: operator-ui-autoinstall
-operator-ui-autoinstall: | yarndep operator-ui
+operator-ui-autoinstall: | yarndep operator-ui ## Autoinstall frontend UI.
 
 .PHONY: gomod
 gomod: ## Ensure chainlink's go dependencies are installed.
@@ -27,7 +27,7 @@ gomod: ## Ensure chainlink's go dependencies are installed.
 	go mod download
 
 .PHONY: yarndep
-yarndep: ## Ensure all yarn dependencies are installed
+yarndep: ## Ensure all yarn dependencies are installed.
 	yarn install --frozen-lockfile --prefer-offline
 
 .PHONY: install-chainlink
@@ -39,7 +39,7 @@ chainlink: operator-ui ## Build the chainlink binary.
 	go build $(GOFLAGS) -o $@ ./core/
 
 .PHONY: chainlink-build
-chainlink-build:
+chainlink-build: ## Build & install the chainlink binary.
 	go build $(GOFLAGS) -o chainlink ./core/
 	cp chainlink $(GOBIN)/chainlink
 
@@ -49,40 +49,40 @@ operator-ui: ## Build the static frontend UI.
 	CHAINLINK_VERSION="$(VERSION)@$(COMMIT_SHA)" yarn workspace @chainlink/operator-ui build
 
 .PHONY: contracts-operator-ui-build
-contracts-operator-ui-build: # only compiles tsc and builds contracts and operator-ui
+contracts-operator-ui-build: # Only compiles tsc and builds contracts and operator-ui.
 	yarn setup:chainlink
 	CHAINLINK_VERSION="$(VERSION)@$(COMMIT_SHA)" yarn workspace @chainlink/operator-ui build
 
 .PHONY: abigen
-abigen:
+abigen: ## Build & install abigen.
 	./tools/bin/build_abigen
 
 .PHONY: go-solidity-wrappers
-go-solidity-wrappers: tools/bin/abigen ## Recompiles solidity contracts and their go wrappers
+go-solidity-wrappers: tools/bin/abigen ## Recompiles solidity contracts and their go wrappers.
 	./contracts/scripts/native_solc_compile_all
 	go generate ./core/internal/gethwrappers
 
 .PHONY: testdb
-testdb: ## Prepares the test database
+testdb: ## Prepares the test database.
 	go run ./core/main.go local db preparetest
 
 .PHONY: testdb
-testdb-user-only: ## Prepares the test database
+testdb-user-only: ## Prepares the test database with user only.
 	go run ./core/main.go local db preparetest --user-only
 
 # Format for CI
 .PHONY: presubmit
-presubmit:
+presubmit: ## Format go files and imports.
 	goimports -w ./core
 	gofmt -w ./core
-	go mod tidy
+	go mod tidy -compat=1.17
 
 .PHONY: mockery
-mockery: $(mockery)
+mockery: $(mockery) ## Install mockery.
 	go install github.com/vektra/mockery/v2@v2.8.0
 
 .PHONY: telemetry-protobuf
-telemetry-protobuf: $(telemetry-protobuf)
+telemetry-protobuf: $(telemetry-protobuf) ## Generate telemetry protocol buffers.
 	protoc \
 	--go_out=. \
 	--go_opt=paths=source_relative \
@@ -91,8 +91,10 @@ telemetry-protobuf: $(telemetry-protobuf)
 	./core/services/synchronization/telem/*.proto
 
 .PHONY: test_smoke
-test_smoke: # Run integration smoke tests
-	ginkgo -v -r --junit-report=tests-smoke-report.xml --keep-going --trace --randomize-all --randomize-suites -tags smoke --progress $(args) ./integration-tests/smoke 
+test_smoke: # Run integration smoke tests.
+	ginkgo -v -r --junit-report=tests-smoke-report.xml \
+	--keep-going --trace --randomize-all --randomize-suites \
+	-tags smoke --progress $(args) ./integration-tests/smoke
 
 
 help:
@@ -104,4 +106,5 @@ help:
 	@echo "   \___  >___|  (____  /__|___|  /____/__|___|  /__|_ \\"
 	@echo "       \/     \/     \/        \/             \/     \/"
 	@echo ""
-	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | \
+	awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
`make help` only lists commands with comments. This PR adds comments to the undocumented.
```console
$ make help

         .__           .__       .__  .__        __
    ____ |  |__ _____  |__| ____ |  | |__| ____ |  | __
  _/ ___\|  |  \\__  \ |  |/    \|  | |  |/    \|  |/ /
  \  \___|   Y  \/ __ \|  |   |  \  |_|  |   |  \    <
   \___  >___|  (____  /__|___|  /____/__|___|  /__|_ \
       \/     \/     \/        \/             \/     \/

chainlink                      Build the chainlink binary.
gomod                          Ensure chainlink's go dependencies are installed.
go-solidity-wrappers           Recompiles solidity contracts and their go wrappers
install-chainlink              Install the chainlink binary.
install                        Install chainlink and all its dependencies.
operator-ui                    Build the static frontend UI.
testdb                         Prepares the test database
testdb-user-only               Prepares the test database
yarndep                        Ensure all yarn dependencies are installed
```
```console
$ make help

         .__           .__       .__  .__        __
    ____ |  |__ _____  |__| ____ |  | |__| ____ |  | __
  _/ ___\|  |  \\__  \ |  |/    \|  | |  |/    \|  |/ /
  \  \___|   Y  \/ __ \|  |   |  \  |_|  |   |  \    <
   \___  >___|  (____  /__|___|  /____/__|___|  /__|_ \
       \/     \/     \/        \/             \/     \/

abigen                         Build & install abigen.
chainlink-build                Build & install the chainlink binary.
chainlink                      Build the chainlink binary.
gomod                          Ensure chainlink's go dependencies are installed.
go-solidity-wrappers           Recompiles solidity contracts and their go wrappers.
install-chainlink-autoinstall  Autoinstall chainlink.
install-chainlink              Install the chainlink binary.
install-git-hooks              Install git hooks.
install                        Install chainlink and all its dependencies.
mockery                        Install mockery.
operator-ui-autoinstall        Autoinstall frontend UI.
operator-ui                    Build the static frontend UI.
presubmit                      Format go files and imports.
telemetry-protobuf             Generate telemetry protocol buffers.
testdb                         Prepares the test database.
testdb-user-only               Prepares the test database with user only.
yarndep                        Ensure all yarn dependencies are installed.
```