### PR TITLE
Set log broadcaster Register min incoming confs to 1 for vrfv2

### DIFF
--- a/core/services/vrf/listener_v2.go
+++ b/core/services/vrf/listener_v2.go
@@ -108,7 +108,10 @@ func (lsn *listenerV2) Start() error {
 					},
 				},
 			},
-			// Do not specify min confirmations, as it varies from request to request.
+			// Specify a min incoming confirmations of 1 so that we can receive a request log
+			// right away. We set the real number of confirmations on a per-request basis in
+			// the getConfirmedAt method.
+			MinIncomingConfirmations: 1,
 		})
 
 		latestHead, unsubscribeHeadBroadcaster := lsn.headBroadcaster.Subscribe(lsn)


### PR DESCRIPTION
Set min incoming confs to 1 in the log broadcaster Register call, since we do our own per-request confirmation accounting in the future anyways.