### PR TITLE
Use GitHub OIDC for AWS role assumption instead of hardcoded secrets

### DIFF
--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -17,12 +17,6 @@ inputs:
     description: The ECR registry to push to, used in docker/login-action and for tagging images
     default: public.ecr.aws/chainlink
     required: false
-  aws-access-key-id:
-    description: The IAM access key used to authenticate to ECR, used in configuring docker/login-action
-    required: false
-  aws-secret-access-key:
-    description: The IAM access key secret used to authenticate to ECR, used in configuring docker/login-action
-    required: false
   aws-role-to-assume:
     description: The AWS role to assume as the CD user, if any. Used in configuring the docker/login-action
     required: false
@@ -81,8 +75,6 @@ runs:
     name: Configure AWS Credentials
     uses: aws-actions/configure-aws-credentials@ea7b857d8a33dc2fb4ef5a724500044281b49a5e # v1.6.0
     with:
-      aws-access-key-id: ${{ inputs.aws-access-key-id }}
-      aws-secret-access-key: ${{ inputs.aws-secret-access-key }}
       role-to-assume: ${{ inputs.aws-role-to-assume }}
       role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
       aws-region: ${{ inputs.aws-region }}

--- a/.github/workflows/build-custom.yml
+++ b/.github/workflows/build-custom.yml
@@ -35,10 +35,6 @@ on:
         required: false
         type: string
     secrets:
-      AWS_ACCESS_KEY_ID:
-        required: true
-      AWS_SECRET_ACCESS_KEY:
-        required: true
       AWS_REGION:
         required: true
       AWS_ROLE_TO_ASSUME:
@@ -47,6 +43,9 @@ on:
         required: true
 jobs:
   build-chainlink:
+    permissions:
+      id-token: write # This is for OIDC integration with AWS role assumption
+      contents: read  # This is required for actions/checkout@v2
     name: Build Chainlink Image
     runs-on: ubuntu-latest
     steps:
@@ -84,8 +83,6 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 3600

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -12,6 +12,9 @@ on:
 
 jobs:
   build-sign-publish-chainlink:
+    permissions:
+      id-token: write # This is for OIDC integration with AWS role assumption
+      contents: read  # This is required for actions/checkout@v2
     runs-on: ubuntu-20.04
     environment: build-publish
     steps:
@@ -23,8 +26,6 @@ jobs:
         with:
           publish: true
           image-name: chainlink
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           aws-role-duration-seconds: ${{ secrets.AWS_ROLE_DURATION_SECONDS }}
           aws-region: ${{ secrets.AWS_REGION }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,6 +2,9 @@ name: Integration Tests
 on: [pull_request]
 jobs:
   build-chainlink:
+    permissions:
+      id-token: write # This is for OIDC integration with AWS role assumption
+      contents: read  # This is required for actions/checkout@v2
     name: Build Chainlink Image
     runs-on: ubuntu-latest
     steps:
@@ -10,8 +13,6 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 3600
@@ -30,6 +31,9 @@ jobs:
           push: true
 
   smoke:
+    permissions:
+      id-token: write # This is for OIDC integration with AWS role assumption
+      contents: read  # This is required for actions/checkout@v2
     name: Smoke Tests
     runs-on: ubuntu-latest
     needs: build-chainlink
@@ -47,14 +51,9 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.AWS_REGION }}
           role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 3600
-      - name: Login to Amazon ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
       - name: Set Kubernetes Context
         uses: azure/k8s-set-context@v1
         with:


### PR DESCRIPTION
Cannot merge until:

- [ ] OIDC provider is created in AWS
- [ ] New role is created in AWS
- [ ] secrets.AWS_ROLE_TO_ASSUME in GitHub is updated with new role name

Per: https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services