### PR TITLE
Fix for using private key to sign

### DIFF
--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -208,7 +208,7 @@ runs:
     env:
       COSIGN_PASSWORD: "${{ inputs.cosign-password }}"
     run: |
-      echo "${{ inputs.cosign-public-key }}" > cosign.key
+      echo "${{ inputs.cosign-private-key }}" > cosign.key
       cosign sign --key cosign.key "${{ env.nonroot_image_name }}"
       rm -f cosign.key
 


### PR DESCRIPTION
Using `${{ inputs.cosign-private-key }}` for signing instead of public key