### PR TITLE
Attempt to print line numbers of golangci lint issues from CI

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@5c56cd6c9dc07901af25baab6f2b0d9f3b7c3018 # v2.5.2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.43.0
@@ -24,6 +24,8 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
+          # XXX: NO_FUTURE is a hack to avoid this:
+          # Error: please, don't change out-format for golangci-lint: it can be broken in a future, Error: please, don't change out-format for golangci-lint: it can be broken in a future
           args: "--timeout=5m0s --tests=false --out-${NO_FUTURE}format colored-line-number"
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -24,7 +24,7 @@ jobs:
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
-          args: --timeout=5m0s --tests=false
+          args: "--timeout=5m0s --tests=false --out-${NO_FUTURE}format colored-line-number"
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true


### PR DESCRIPTION
Per https://github.com/golangci/golangci-lint-action/issues/119#issuecomment-981090648

Right now lint issues printed from CI don't show files or line numbers, we just see:

```
...
Warning: exported: exported method TestGeneralConfig.P2PNetworkingStack should have comment or be unexported (revive)
Warning: exported: exported method TestGeneralConfig.P2PV2DeltaDial should have comment or be unexported (revive)
Warning: exported: exported method TestGeneralConfig.OCRDatabaseTimeout should have comment or be unexported (revive)
...
```