### PR TITLE
Set fetch depth on golanci job to detect new changes

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,6 +14,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:


### PR DESCRIPTION
This is to fix a problem where the golangci lint action is detecting lint issues on all files, even those not modified by a PR.