### PR TITLE
core/services/fluxmonitorv2: FluxMonitor fmt.Formatter hack to resolve mock race

### DIFF
--- a/core/services/fluxmonitorv2/helpers_test.go
+++ b/core/services/fluxmonitorv2/helpers_test.go
@@ -12,7 +12,7 @@ import (
 // This is a hack to work around a race in github.com/stretchr/testify which
 // prints internal fields, including the state of nested, embeded mutexes.
 func (fm *FluxMonitor) Format(f fmt.State, verb rune) {
-	fmt.Fprintf(f, "%p", fm)
+	fmt.Fprintf(f, "%[1]T<%[1]p>", fm)
 }
 
 func (fm *FluxMonitor) ExportedPollIfEligible(threshold, absoluteThreshold float64) {

--- a/core/services/fluxmonitorv2/helpers_test.go
+++ b/core/services/fluxmonitorv2/helpers_test.go
@@ -1,10 +1,19 @@
 package fluxmonitorv2
 
 import (
+	"fmt"
+
 	"github.com/smartcontractkit/chainlink/core/chains/evm/log"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/flux_aggregator_wrapper"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
+
+// Format implements fmt.Formatter to always print just the pointer address.
+// This is a hack to work around a race in github.com/stretchr/testify which
+// prints internal fields, including the state of nested, embeded mutexes.
+func (fm *FluxMonitor) Format(f fmt.State, verb rune) {
+	fmt.Fprintf(f, "%p", fm)
+}
 
 func (fm *FluxMonitor) ExportedPollIfEligible(threshold, absoluteThreshold float64) {
 	fm.pollIfEligible(PollRequestTypePoll, NewDeviationChecker(threshold, absoluteThreshold, fm.logger), nil)

--- a/tools/bin/go_core_race_tests
+++ b/tools/bin/go_core_race_tests
@@ -2,8 +2,7 @@
 set -ex
 
 GO_LDFLAGS=$(bash tools/bin/ldflags)
-# remove -short for complete coverage
-GORACE="log_path=$PWD/race" LOG_LEVEL=panic go test -race -ldflags "$GO_LDFLAGS" -short -shuffle on -timeout 30s -count 10 -p 4 ./core/... | tee ./output.txt
+GORACE="log_path=$PWD/race" LOG_LEVEL=panic go test -race -ldflags "$GO_LDFLAGS" -shuffle on -timeout 30s -count 10 -p 4 ./core/... | tee ./output.txt
 EXITCODE=${PIPESTATUS[0]}
 # Fail if any race logs are present.
 if ls race.* &>/dev/null


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/21636

- [x] added hack to resolve race
- [x] removed `-short` from race tests
- [ ] ~recalibrate other params to match regular test if too slow now?~ seems ok for now :shrug:  (still not blocking)
![Screenshot from 2022-03-05 10-37-15](https://user-images.githubusercontent.com/1194128/156892153-347b6a37-6465-4064-8b16-12747c4770a4.png)
