### PR TITLE
Log audits services/job/orm.go

### DIFF
--- a/core/services/job/spawner.go
+++ b/core/services/job/spawner.go
@@ -105,7 +105,7 @@ func (js *spawner) startAllServices() {
 	// TODO: rename to find AllJobs
 	specs, _, err := js.orm.FindJobs(0, math.MaxUint32)
 	if err != nil {
-		js.lggr.Errorf("Couldn't fetch unclaimed jobs: %v", err)
+		js.lggr.Criticalf("Couldn't fetch unclaimed jobs: %v", err)
 		return
 	}
 


### PR DESCRIPTION
One liner bumping logging ln105 to critical if failed to find jobs.