### PR TITLE
Update usage of errors.Is and errors.As

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -7,6 +7,7 @@ linters:
     - gosec
     - misspell
     - rowserrcheck
+    - errorlint
   disable:
     # These are all considered deprecated: https://github.com/golangci/golangci-lint/issues/1841
     - deadcode
@@ -28,6 +29,9 @@ linters-settings:
   govet:
     # report about shadowed variables
     check-shadowing: true
+  errorlint:
+    # Allow formatting of errors without %w
+    errorf: false
   revive:
     confidence: 0.8
     rules:

--- a/core/chains/evm/bulletprooftxmanager/eth_confirmer.go
+++ b/core/chains/evm/bulletprooftxmanager/eth_confirmer.go
@@ -965,7 +965,7 @@ func (ec *EthConfirmer) bumpGas(previousAttempt EthTxAttempt) (bumpedAttempt Eth
 			"This is a bug! Please report to https://github.com/smartcontractkit/chainlink/issues", previousAttempt.ID, previousAttempt.TxType)
 	}
 
-	if errors.Cause(err) == gas.ErrBumpGasExceedsLimit {
+	if errors.Is(errors.Cause(err), gas.ErrBumpGasExceedsLimit) {
 		promGasBumpExceedsLimit.WithLabelValues(ec.chainID.String()).Inc()
 	}
 

--- a/core/chains/evm/gas/block_history_estimator.go
+++ b/core/chains/evm/gas/block_history_estimator.go
@@ -325,7 +325,7 @@ func (b *BlockHistoryEstimator) Recalculate(head *evmtypes.Head) {
 
 	percentileGasPrice, percentileTipCap, err := b.percentilePrices(percentile, enableEIP1559)
 	if err != nil {
-		if err == ErrNoSuitableTransactions {
+		if errors.Is(err, ErrNoSuitableTransactions) {
 			lggr.Debug("No suitable transactions, skipping")
 		} else {
 			lggr.Warnw("Cannot calculate percentile prices", "err", err)

--- a/core/chains/evm/headtracker/orm.go
+++ b/core/chains/evm/headtracker/orm.go
@@ -86,7 +86,7 @@ func (orm *orm) HeadByHash(ctx context.Context, hash common.Hash) (head *evmtype
 	q := orm.q.WithOpts(pg.WithParentCtx(ctx))
 	head = new(evmtypes.Head)
 	err = q.Get(head, `SELECT * FROM evm_heads WHERE evm_chain_id = $1 AND hash = $2`, orm.chainID, hash)
-	if err == sql.ErrNoRows {
+	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
 	return head, err

--- a/core/cmd/client.go
+++ b/core/cmd/client.go
@@ -276,7 +276,7 @@ func tryRunServerUntilCancelled(ctx context.Context, lggr logger.Logger, cfg con
 	for {
 		// try calling runServer() and log error if any
 		if err := runServer(); err != nil {
-			if err != http.ErrServerClosed {
+			if !errors.Is(err, http.ErrServerClosed) {
 				lggr.Criticalf("Error starting server: %v", err)
 			}
 		}

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -211,11 +211,11 @@ func (cli *Client) runNode(c *clipkg.Context) error {
 	}
 
 	var user sessions.User
-	if _, err = NewFileAPIInitializer(c.String("api"), lggr).Initialize(sessionORM); err != nil && err != ErrNoCredentialFile {
+	if _, err = NewFileAPIInitializer(c.String("api"), lggr).Initialize(sessionORM); err != nil && !errors.Is(err, ErrNoCredentialFile) {
 		return errors.Wrap(err, "error creating api initializer")
 	}
 	if user, err = cli.FallbackAPIInitializer.Initialize(sessionORM); err != nil {
-		if err == ErrorNoAPICredentialsAvailable {
+		if errors.Is(err, ErrorNoAPICredentialsAvailable) {
 			return errors.WithStack(err)
 		}
 		return errors.Wrap(err, "error creating fallback initializer")
@@ -246,7 +246,7 @@ func (cli *Client) runNode(c *clipkg.Context) error {
 
 	grp.Go(func() error {
 		errInternal := cli.Runner.Run(grpCtx, app)
-		if errInternal == http.ErrServerClosed {
+		if errors.Is(errInternal, http.ErrServerClosed) {
 			errInternal = nil
 		}
 		// In tests we have custom runners that stop the app gracefully,

--- a/core/cmd/remote_client.go
+++ b/core/cmd/remote_client.go
@@ -299,7 +299,7 @@ func getTOMLString(s string) (string, error) {
 
 func (cli *Client) parseResponse(resp *http.Response) ([]byte, error) {
 	b, err := parseResponse(resp)
-	if err == errUnauthorized {
+	if errors.Is(err, errUnauthorized) {
 		return nil, cli.errorOut(multierr.Append(err, fmt.Errorf("your credentials may be missing, invalid or you may need to login first using the CLI via 'chainlink admin login'")))
 	}
 	if err != nil {

--- a/core/config/general_config.go
+++ b/core/config/general_config.go
@@ -331,10 +331,10 @@ EVM_ENABLED=false
 `)
 	}
 
-	if _, err := c.OCRKeyBundleID(); errors.Cause(err) == ErrInvalid {
+	if _, err := c.OCRKeyBundleID(); errors.Is(errors.Cause(err), ErrInvalid) {
 		return err
 	}
-	if _, err := c.OCRTransmitterAddress(); errors.Cause(err) == ErrInvalid {
+	if _, err := c.OCRTransmitterAddress(); errors.Is(errors.Cause(err), ErrInvalid) {
 		return err
 	}
 	if peers, err := c.P2PBootstrapPeers(); err == nil {

--- a/core/main.go
+++ b/core/main.go
@@ -41,7 +41,7 @@ func NewProductionClient() *cmd.Client {
 	if credentialsFile := cfg.AdminCredentialsFile(); credentialsFile != "" {
 		var err error
 		sr, err = sessionRequestBuilder.Build(credentialsFile)
-		if err != nil && errors.Cause(err) != cmd.ErrNoCredentialFile && !os.IsNotExist(err) {
+		if err != nil && !errors.Is(errors.Cause(err), cmd.ErrNoCredentialFile) && !os.IsNotExist(err) {
 			lggr.Fatalw("Error loading API credentials", "error", err, "credentialsFile", credentialsFile)
 		}
 	}

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -270,7 +270,8 @@ func (o *orm) CreateJob(jb *Job, qopts ...pg.QOpt) error {
 			VALUES (:coordinator_address, :public_key, :min_incoming_confirmations, :evm_chain_id, :from_address, :poll_period, :requested_confs_delay, :request_timeout, NOW(), NOW())
 			RETURNING id;`
 			err := pg.PrepareQueryRowx(tx, sql, &specID, jb.VRFSpec)
-			pqErr, ok := err.(*pgconn.PgError)
+			var pqErr *pgconn.PgError
+			ok := errors.As(err, &pqErr)
 			if err != nil && ok && pqErr.Code == "23503" {
 				if pqErr.ConstraintName == "vrf_specs_public_key_fkey" {
 					return errors.Wrapf(ErrNoSuchPublicKey, "%s", jb.VRFSpec.PublicKey.String())
@@ -437,7 +438,8 @@ func (o *orm) RecordError(jobID int32, description string, qopts ...pg.QOpt) err
 	updated_at = excluded.updated_at`
 	err := q.ExecQ(sql, jobID, description, time.Now())
 	// Noop if the job has been deleted.
-	pqErr, ok := err.(*pgconn.PgError)
+	var pqErr *pgconn.PgError
+	ok := errors.As(err, &pqErr)
 	if err != nil && ok && pqErr.Code == "23503" {
 		if pqErr.ConstraintName == "job_spec_errors_v2_job_id_fkey" {
 			return nil
@@ -619,7 +621,7 @@ func LoadEnvConfigVarsLocalOCR(cfg OCRSpecConfig, os OCROracleSpec) *OCROracleSp
 func LoadEnvConfigVarsOCR(cfg OCRSpecConfig, p2pStore keystore.P2P, os OCROracleSpec) (*OCROracleSpec, error) {
 	if os.TransmitterAddress == nil {
 		ta, err := cfg.OCRTransmitterAddress()
-		if errors.Cause(err) != config.ErrUnset {
+		if !errors.Is(errors.Cause(err), config.ErrUnset) {
 			if err != nil {
 				return nil, err
 			}

--- a/core/services/job/validate_test.go
+++ b/core/services/job/validate_test.go
@@ -20,7 +20,7 @@ type="blah"
 schemaVersion=1
 `,
 			assertion: func(t *testing.T, err error) {
-				require.True(t, errors.Cause(err) == ErrInvalidJobType)
+				require.True(t, errors.Is(errors.Cause(err), ErrInvalidJobType))
 			},
 		},
 		{
@@ -30,7 +30,7 @@ type="vrf"
 schemaVersion=2
 `,
 			assertion: func(t *testing.T, err error) {
-				require.True(t, errors.Cause(err) == ErrInvalidSchemaVersion)
+				require.True(t, errors.Is(errors.Cause(err), ErrInvalidSchemaVersion))
 			},
 		},
 		{
@@ -39,7 +39,7 @@ schemaVersion=2
 type="vrf"
 `,
 			assertion: func(t *testing.T, err error) {
-				require.True(t, errors.Cause(err) == ErrInvalidSchemaVersion)
+				require.True(t, errors.Is(errors.Cause(err), ErrInvalidSchemaVersion))
 			},
 		},
 		{
@@ -49,7 +49,7 @@ type="vrf"
 schemaVersion=1
 `,
 			assertion: func(t *testing.T, err error) {
-				require.True(t, errors.Cause(err) == ErrNoPipelineSpec)
+				require.True(t, errors.Is(errors.Cause(err), ErrNoPipelineSpec))
 			},
 		},
 		{
@@ -60,7 +60,7 @@ schemaVersion=1
 observationSource=""
 `,
 			assertion: func(t *testing.T, err error) {
-				require.True(t, errors.Cause(err) == ErrNoPipelineSpec)
+				require.True(t, errors.Is(errors.Cause(err), ErrNoPipelineSpec))
 			},
 		},
 		{

--- a/core/services/keystore/keys/vrfkey/key_v2.go
+++ b/core/services/keystore/keys/vrfkey/key_v2.go
@@ -121,7 +121,7 @@ func (key KeyV2) GenerateProof(seed *big.Int) (Proof, error) {
 		}
 		proof, err := key.GenerateProofWithNonce(seed, nonce)
 		switch {
-		case err == ErrCGammaEqualsSHash:
+		case errors.Is(err, ErrCGammaEqualsSHash):
 			// This is cryptographically impossible, but if it were ever to happen, we
 			// should try again with a different nonce.
 			continue

--- a/core/services/periodicbackup/backup.go
+++ b/core/services/periodicbackup/backup.go
@@ -191,7 +191,8 @@ func (backup *databaseBackup) runBackup(version string) (*backupResult, error) {
 			maskedArguments: maskedArgs,
 			pgDumpArguments: args,
 		}
-		if ee, ok := err.(*exec.ExitError); ok {
+		var ee *exec.ExitError
+		if errors.As(err, &ee) {
 			return partialResult, errors.Wrapf(err, "pg_dump failed with output: %s", string(ee.Stderr))
 		}
 		return partialResult, errors.Wrap(err, "pg_dump failed")

--- a/core/services/pg/q.go
+++ b/core/services/pg/q.go
@@ -268,7 +268,7 @@ func (q Q) logSqlQuery(query string, args ...interface{}) {
 }
 
 func (q Q) withLogError(err error) error {
-	if err != nil && err != sql.ErrNoRows && q.config != nil && q.config.LogSQL() {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) && q.config != nil && q.config.LogSQL() {
 		q.logger.Errorf("SQL ERROR: %v", err)
 	}
 	return err

--- a/core/services/pipeline/task.http.go
+++ b/core/services/pipeline/task.http.go
@@ -85,7 +85,7 @@ func (t *HTTPTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, input
 
 	responseBytes, statusCode, _, elapsed, err := makeHTTPRequest(requestCtx, lggr, method, url, requestData, allowUnrestrictedNetworkAccess, t.config.DefaultHTTPLimit())
 	if err != nil {
-		if errors.Cause(err) == ErrDisallowedIP {
+		if errors.Is(errors.Cause(err), ErrDisallowedIP) {
 			err = errors.Wrap(err, "connections to local resources are disabled by default, if you are sure this is safe, you can enable on a per-task basis by setting allowUnrestrictedNetworkAccess=true in the pipeline task spec")
 		}
 		return Result{Error: err}, RunInfo{IsRetryable: isRetryableHTTPError(statusCode, err)}

--- a/core/services/pipeline/task_params.go
+++ b/core/services/pipeline/task_params.go
@@ -31,7 +31,7 @@ func ResolveParam(out PipelineParamUnmarshaler, getters []GetterFunc) error {
 	var found bool
 	for _, get := range getters {
 		val, err = get()
-		if errors.Cause(err) == ErrParameterEmpty {
+		if errors.Is(errors.Cause(err), ErrParameterEmpty) {
 			continue
 		} else if err != nil {
 			return err

--- a/core/services/versioning/orm.go
+++ b/core/services/versioning/orm.go
@@ -73,7 +73,8 @@ func CheckVersion(q pg.Queryer, lggr logger.Logger, appVersion string) (appv, db
 		lggr.Debugw("No previous version set", "appVersion", appVersion)
 		return nil, nil, nil
 	} else if err != nil {
-		pqErr, ok := err.(*pgconn.PgError)
+		var pqErr *pgconn.PgError
+		ok := errors.As(err, &pqErr)
 		if ok && pqErr.Code == "42P01" && pqErr.Message == `relation "node_versions" does not exist` {
 			lggr.Debugw("Previous version not set; node_versions table does not exist", "appVersion", appVersion)
 			return nil, nil, nil

--- a/core/services/vrf/validate_test.go
+++ b/core/services/vrf/validate_test.go
@@ -80,7 +80,7 @@ decode_log->vrf->encode_tx->submit_tx
 `,
 			assertion: func(t *testing.T, s job.Job, err error) {
 				require.Error(t, err)
-				require.True(t, ErrKeyNotSet == errors.Cause(err))
+				require.True(t, errors.Is(ErrKeyNotSet, errors.Cause(err)))
 			},
 		},
 		{
@@ -111,7 +111,7 @@ decode_log->vrf->encode_tx->submit_tx
 `,
 			assertion: func(t *testing.T, s job.Job, err error) {
 				require.Error(t, err)
-				require.True(t, ErrKeyNotSet == errors.Cause(err))
+				require.True(t, errors.Is(ErrKeyNotSet, errors.Cause(err)))
 			},
 		},
 		{

--- a/core/web/auth/auth.go
+++ b/core/web/auth/auth.go
@@ -142,7 +142,7 @@ func Authenticate(store Authenticator, methods ...authMethod) gin.HandlerFunc {
 		var err error
 		for _, method := range methods {
 			err = method(c, store)
-			if err != auth.ErrorAuthFailed {
+			if !errors.Is(err, auth.ErrorAuthFailed) {
 				break
 			}
 		}

--- a/core/web/bridge_types_controller.go
+++ b/core/web/bridge_types_controller.go
@@ -25,7 +25,7 @@ func ValidateBridgeTypeNotExist(bt *bridges.BridgeTypeRequest, orm bridges.ORM) 
 	if err == nil {
 		fe.Add(fmt.Sprintf("Bridge Type %v already exists", bt.Name))
 	}
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		fe.Add(fmt.Sprintf("Error determining if bridge type %v already exists", bt.Name))
 	}
 	return fe.CoerceEmptyToNil()

--- a/core/web/eth_keys_controller.go
+++ b/core/web/eth_keys_controller.go
@@ -307,7 +307,7 @@ func (ekc *ETHKeysController) setEthBalance(ctx context.Context, state ethkey.St
 		bal, err = ethClient.BalanceAt(ctx, state.Address.Address(), nil)
 	}
 	return func(r *presenters.ETHKeyResource) error {
-		if errors.Cause(err) == evm.ErrNoChains {
+		if errors.Is(errors.Cause(err), evm.ErrNoChains) {
 			return nil
 		}
 
@@ -334,7 +334,7 @@ func (ekc *ETHKeysController) setLinkBalance(state ethkey.State) presenters.NewE
 	}
 
 	return func(r *presenters.ETHKeyResource) error {
-		if errors.Cause(err) == evm.ErrNoChains {
+		if errors.Is(errors.Cause(err), evm.ErrNoChains) {
 			return nil
 		}
 		if err != nil {
@@ -358,7 +358,7 @@ func (ekc *ETHKeysController) setKeyMaxGasPriceWei(state ethkey.State, keyAddres
 	}
 
 	return func(r *presenters.ETHKeyResource) error {
-		if errors.Cause(err) == evm.ErrNoChains {
+		if errors.Is(errors.Cause(err), evm.ErrNoChains) {
 			return nil
 		}
 		if err != nil {

--- a/core/web/external_initiators_controller.go
+++ b/core/web/external_initiators_controller.go
@@ -33,7 +33,7 @@ func ValidateExternalInitiator(
 		fe.Add("Name must be alphanumeric and may contain '_' or '-'")
 	} else if _, err := orm.FindExternalInitiatorByName(exi.Name); err == nil {
 		fe.Add(fmt.Sprintf("Name %v already exists", exi.Name))
-	} else if err != sql.ErrNoRows {
+	} else if !errors.Is(err, sql.ErrNoRows) {
 		return errors.Wrap(err, "validating external initiator")
 	}
 	return fe.CoerceEmptyToNil()

--- a/core/web/jobs_controller.go
+++ b/core/web/jobs_controller.go
@@ -72,7 +72,7 @@ func (jc *JobsController) Show(c *gin.Context) {
 		return
 	}
 	if err != nil {
-		if errors.Cause(err) == sql.ErrNoRows {
+		if errors.Is(errors.Cause(err), sql.ErrNoRows) {
 			jsonAPIError(c, http.StatusNotFound, errors.New("job not found"))
 		} else {
 			jsonAPIError(c, http.StatusInternalServerError, err)
@@ -148,7 +148,7 @@ func (jc *JobsController) Create(c *gin.Context) {
 	defer cancel()
 	err = jc.App.AddJobV2(ctx, &jb)
 	if err != nil {
-		if errors.Cause(err) == job.ErrNoSuchKeyBundle || errors.As(err, &keystore.KeyNotFoundError{}) || errors.Cause(err) == job.ErrNoSuchTransmitterKey {
+		if errors.Is(errors.Cause(err), job.ErrNoSuchKeyBundle) || errors.As(err, &keystore.KeyNotFoundError{}) || errors.Is(errors.Cause(err), job.ErrNoSuchTransmitterKey) {
 			jsonAPIError(c, http.StatusBadRequest, err)
 			return
 		}

--- a/core/web/ocr2_keys_controller.go
+++ b/core/web/ocr2_keys_controller.go
@@ -34,7 +34,7 @@ func (ocr2kc *OCR2KeysController) Index(c *gin.Context) {
 func (ocr2kc *OCR2KeysController) Create(c *gin.Context) {
 	chainType := chaintype.ChainType(c.Param("chainType"))
 	key, err := ocr2kc.App.GetKeyStore().OCR2().Create(chainType)
-	if errors.Cause(err) == chaintype.ErrInvalidChainType {
+	if errors.Is(errors.Cause(err), chaintype.ErrInvalidChainType) {
 		jsonAPIError(c, http.StatusBadRequest, err)
 		return
 	}

--- a/core/web/resolver/helpers.go
+++ b/core/web/resolver/helpers.go
@@ -57,7 +57,7 @@ func ValidateBridgeTypeUniqueness(bt *bridges.BridgeTypeRequest, orm bridges.ORM
 	if err == nil {
 		return fmt.Errorf("bridge type %v already exists", bt.Name)
 	}
-	if err != nil && err != sql.ErrNoRows {
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
 		return fmt.Errorf("error determining if bridge type %v already exists", bt.Name)
 	}
 

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -501,7 +501,7 @@ func (r *Resolver) DeleteVRFKey(ctx context.Context, args struct {
 
 	key, err := r.App.GetKeyStore().VRF().Delete(string(args.ID))
 	if err != nil {
-		if errors.Cause(err) == keystore.ErrMissingVRFKey {
+		if errors.Is(errors.Cause(err), keystore.ErrMissingVRFKey) {
 			return NewDeleteVRFKeyPayloadResolver(vrfkey.KeyV2{}, err), nil
 		}
 		return nil, err

--- a/core/web/resolver/query.go
+++ b/core/web/resolver/query.go
@@ -280,7 +280,7 @@ func (r *Resolver) VRFKey(ctx context.Context, args struct {
 
 	key, err := r.App.GetKeyStore().VRF().Get(string(args.ID))
 	if err != nil {
-		if errors.Cause(err) == keystore.ErrMissingVRFKey {
+		if errors.Is(errors.Cause(err), keystore.ErrMissingVRFKey) {
 			return NewVRFKeyPayloadResolver(vrfkey.KeyV2{}, err), nil
 		}
 		return nil, err
@@ -409,7 +409,7 @@ func (r *Resolver) ETHKeys(ctx context.Context) (*ETHKeysPayloadResolver, error)
 		}
 
 		chain, err := r.App.GetChains().EVM.Get(state.EVMChainID.ToInt())
-		if errors.Cause(err) == evm.ErrNoChains {
+		if errors.Is(errors.Cause(err), evm.ErrNoChains) {
 			ethKeys = append(ethKeys, ETHKey{
 				addr:  k.Address,
 				state: state,

--- a/core/web/resolver/vrf.go
+++ b/core/web/resolver/vrf.go
@@ -77,7 +77,7 @@ func NewVRFKeyPayloadResolver(key vrfkey.KeyV2, err error) *VRFKeyPayloadResolve
 
 	if err != nil {
 		e = NotFoundErrorUnionType{err: err, message: err.Error(), isExpectedErrorFn: func(err error) bool {
-			return errors.Cause(err) == keystore.ErrMissingVRFKey
+			return errors.Is(errors.Cause(err), keystore.ErrMissingVRFKey)
 		}}
 	}
 
@@ -141,7 +141,7 @@ func NewDeleteVRFKeyPayloadResolver(key vrfkey.KeyV2, err error) *DeleteVRFKeyPa
 
 	if err != nil {
 		e = NotFoundErrorUnionType{err: err, message: err.Error(), isExpectedErrorFn: func(err error) bool {
-			return errors.Cause(err) == keystore.ErrMissingVRFKey
+			return errors.Is(errors.Cause(err), keystore.ErrMissingVRFKey)
 		}}
 	}
 

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -25,6 +25,7 @@ import (
 	"github.com/gin-gonic/gin"
 	graphql "github.com/graph-gophers/graphql-go"
 	"github.com/graph-gophers/graphql-go/relay"
+	"github.com/pkg/errors"
 	"github.com/ulule/limiter"
 	mgin "github.com/ulule/limiter/drivers/middleware/gin"
 	"github.com/ulule/limiter/drivers/store/memory"
@@ -461,7 +462,7 @@ func guiAssetRoutes(engine *gin.Engine, config config.GeneralConfig, lggr logger
 		// Render the React index page for any other unknown requests
 		file, err := assetFs.Open("index.html")
 		if err != nil {
-			if err == fs.ErrNotExist {
+			if errors.Is(err, fs.ErrNotExist) {
 				c.AbortWithStatus(http.StatusNotFound)
 			} else {
 				lggr.Errorf("failed to open static file '%s': %+v", path, err)


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/28873/use-errors-is-to-compare-errors

From Go 1.13, there is a capability to wrap errors. To properly handle wrapped errors we should use errors.Is and errors.As functions when comparing error to value/type respectively. These functions ensure that the whole wrapped chain of errors is checked.

more about go errors: https://go.dev/blog/go1.13-errors

This PR adds go-errorlint package within our lint config (https://github.com/polyfloyd/go-errorlint). Specifically it will do 2 checks:
- If '==' is being used to check error instead of errors.Is
- If err, ok := err.(*ErrorType); ok is being used to check for a type


For the existing places where linter complained, I have updated the files manually. I have left the comparisons done in switch statements as is for now, but going forward linter should help avoid them.