### PR TITLE
Add AssumptionViolation logger helper

### DIFF
--- a/core/chains/evm/gas/block_history_estimator.go
+++ b/core/chains/evm/gas/block_history_estimator.go
@@ -86,7 +86,7 @@ type (
 		latestBaseFee *big.Int
 		mu            sync.RWMutex
 
-		logger logger.Logger
+		logger logger.SugaredLogger
 	}
 )
 
@@ -109,7 +109,7 @@ func NewBlockHistoryEstimator(lggr logger.Logger, ethClient evmclient.Client, cf
 		nil,
 		nil,
 		sync.RWMutex{},
-		lggr.Named("BlockHistoryEstimator"),
+		logger.Sugared(lggr.Named("BlockHistoryEstimator")),
 	}
 
 	return b
@@ -619,12 +619,12 @@ func (b *BlockHistoryEstimator) EffectiveGasPrice(block Block, tx Transaction) *
 		}
 		if tx.MaxFeePerGas.Cmp(block.BaseFeePerGas) < 0 {
 			// This should not pass config validation
-			b.logger.Errorw("AssumptionViolation: MaxFeePerGas >= BaseFeePerGas", "block", block, "tx", tx)
+			b.logger.AssumptionViolationw("MaxFeePerGas >= BaseFeePerGas", "block", block, "tx", tx)
 			return nil
 		}
 		if tx.MaxFeePerGas.Cmp(tx.MaxPriorityFeePerGas) < 0 {
 			// This should not pass config validation
-			b.logger.Errorw("AssumptionViolation: MaxFeePerGas >= MaxPriorityFeePerGas", "block", block, "tx", tx)
+			b.logger.AssumptionViolationw("MaxFeePerGas >= MaxPriorityFeePerGas", "block", block, "tx", tx)
 			return nil
 		}
 		if tx.GasPrice != nil {
@@ -660,7 +660,7 @@ func (b *BlockHistoryEstimator) EffectiveTipCap(block Block, tx Transaction) *bi
 		}
 		effectiveTipCap := big.NewInt(0).Sub(tx.GasPrice, block.BaseFeePerGas)
 		if effectiveTipCap.Cmp(big.NewInt(0)) < 0 {
-			b.logger.Errorw("AssumptionViolation: GasPrice - BaseFeePerGas >= 0", "block", block, "tx", tx)
+			b.logger.AssumptionViolationw("GasPrice - BaseFeePerGas >= 0", "block", block, "tx", tx)
 			return nil
 		}
 		return effectiveTipCap

--- a/core/chains/evm/gas/fixed_price_estimator.go
+++ b/core/chains/evm/gas/fixed_price_estimator.go
@@ -14,13 +14,13 @@ var _ Estimator = &fixedPriceEstimator{}
 
 type fixedPriceEstimator struct {
 	config Config
-	lggr   logger.Logger
+	lggr   logger.SugaredLogger
 }
 
 // NewFixedPriceEstimator returns a new "FixedPrice" estimator which will
 // always use the config default values for gas prices and limits
 func NewFixedPriceEstimator(cfg Config, lggr logger.Logger) Estimator {
-	return &fixedPriceEstimator{cfg, lggr.Named("FixedPriceEstimator")}
+	return &fixedPriceEstimator{cfg, logger.Sugared(lggr.Named("FixedPriceEstimator"))}
 }
 
 func (f *fixedPriceEstimator) Start(context.Context) error                           { return nil }

--- a/core/chains/evm/gas/models.go
+++ b/core/chains/evm/gas/models.go
@@ -281,7 +281,7 @@ func BumpLegacyGasPriceOnly(cfg Config, lggr logger.Logger, currentGasPrice, ori
 // - A configured percentage bump (ETH_GAS_BUMP_PERCENT) on top of the baseline price.
 // - A configured fixed amount of Wei (ETH_GAS_PRICE_WEI) on top of the baseline price.
 // The baseline price is the maximum of the previous gas price attempt and the node's current gas price.
-func bumpGasPrice(cfg Config, lggr logger.Logger, currentGasPrice, originalGasPrice *big.Int) (*big.Int, error) {
+func bumpGasPrice(cfg Config, lggr logger.SugaredLogger, currentGasPrice, originalGasPrice *big.Int) (*big.Int, error) {
 	maxGasPrice := cfg.EvmMaxGasPriceWei()
 
 	var priceByPercentage = new(big.Int)
@@ -296,7 +296,7 @@ func bumpGasPrice(cfg Config, lggr logger.Logger, currentGasPrice, originalGasPr
 		if currentGasPrice.Cmp(maxGasPrice) > 0 {
 			// Shouldn't happen because the estimator should not be allowed to
 			// estimate a higher gas than the maximum allowed
-			lggr.Errorf("AssumptionViolation: Ignoring current gas price of %s that would exceed max gas price of %s", currentGasPrice.String(), maxGasPrice.String())
+			lggr.AssumptionViolationf("Ignoring current gas price of %s that would exceed max gas price of %s", currentGasPrice.String(), maxGasPrice.String())
 		} else if bumpedGasPrice.Cmp(currentGasPrice) < 0 {
 			// If the current gas price is higher than the old price bumped, use that instead
 			bumpedGasPrice = currentGasPrice

--- a/core/logger/sugared.go
+++ b/core/logger/sugared.go
@@ -1,0 +1,37 @@
+package logger
+
+// SugaredLogger extends the base Logger interface with syntactic sugar, similar to zap.SugaredLogger.
+type SugaredLogger interface {
+	Logger
+	//TODO document
+	AssumptionViolation(args ...interface{})
+	AssumptionViolationf(format string, vals ...interface{})
+	AssumptionViolationw(msg string, keyvals ...interface{})
+}
+
+func Sugared(l Logger) SugaredLogger {
+	return &sugared{
+		Logger: l,
+		h:      l.Helper(1),
+	}
+}
+
+type sugared struct {
+	Logger
+	h Logger // helper with stack trace skip level
+}
+
+// AssumptionViolation wraps Error logs with assumption violation tag.
+func (s *sugared) AssumptionViolation(args ...interface{}) {
+	s.h.Error(append([]interface{}{"AssumptionViolation:"}, args...))
+}
+
+// AssumptionViolationf wraps Errorf logs with assumption violation tag.
+func (s *sugared) AssumptionViolationf(format string, vals ...interface{}) {
+	s.h.Errorf("AssumptionViolation: "+format, vals...)
+}
+
+// AssumptionViolationw wraps Errorw logs with assumption violation tag.
+func (s *sugared) AssumptionViolationw(msg string, keyvals ...interface{}) {
+	s.h.Errorw("AssumptionViolation: "+msg, keyvals...)
+}


### PR DESCRIPTION
This PR adds AssumptionViolation logger helper wrapping Error logs, changes uses where AssumptionViolation is used within an Error log.

Some AssumptionViolation remaining entries are used within Panic logs and next steps for them should be looked at one by one after this PR