### PR TITLE
Fix setting CHAINLINK_USER value

### DIFF
--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -152,7 +152,7 @@ runs:
       labels: ${{ steps.meta-nonroot.outputs.labels }}
       file: core/chainlink.Dockerfile
       build-args: |
-        CHAINLINK_USER:chainlink
+        CHAINLINK_USER=chainlink
         ${{ env.shared-build-args }}
 
   - name: Save non-root image name in GITHUB_ENV


### PR DESCRIPTION
The user was not being properly assigned to the CHAINLINK_USER env var. We had fixed this previously for other env vars but this one was missed.