### PR TITLE
[WIP] Fixes for CD in 1.2.0 

### DIFF
--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -115,7 +115,7 @@ runs:
 
   - name: Build and push root docker image
     id: buildpush-root
-    uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229 # v2.7.0
+    uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
     with:
       push: ${{ inputs.publish }}
       tags: ${{ steps.meta-root.outputs.tags }}
@@ -145,7 +145,7 @@ runs:
 
   - name: Build and push non-root docker image
     id: buildpush-nonroot
-    uses: docker/build-push-action@a66e35b9cbcf4ad0ea91ffcaf7bbad63ad9e0229 # v2.7.0
+    uses: docker/build-push-action@ac9327eae2b366085ac7f6a2d02df8aa8ead720a # v2.10.0
     with:
       push: ${{ inputs.publish }}
       tags: ${{ steps.meta-nonroot.outputs.tags }}

--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -57,6 +57,8 @@ runs:
   steps:
   - name: Set shared variables
     shell: sh
+    env:
+      PUBLISH: ${{ inputs.publish }}
     # See https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#multiline-strings
     run: |
       SHARED_IMAGES=${{ inputs.ecr-registry }}/${{ inputs.image-name }}
@@ -73,7 +75,23 @@ runs:
       ENVIRONMENT=release
       EOF
       )
+      
+      # If we are not publishing,
+      # then we force an image export
+      # so we can still use the image.name
+      # see https://app.shortcut.com/chainlinklabs/story/33154/docker-image-name-missing-from-metadata  
+      if [ "$PUBLISH" = "false" ]; then
+        SHARED_OUTPUTS=$(
+          cat <<EOF
+        type=image,push=false
+      EOF
+        )
 
+      echo "shared-outputs<<EOF" >> $GITHUB_ENV
+      echo "$SHARED_OUTPUTS" >> $GITHUB_ENV
+      echo "EOF" >> $GITHUB_ENV
+      fi
+      
       echo "shared-images<<EOF" >> $GITHUB_ENV
       echo "$SHARED_IMAGES" >> $GITHUB_ENV
       echo "EOF" >> $GITHUB_ENV
@@ -121,6 +139,7 @@ runs:
       tags: ${{ steps.meta-root.outputs.tags }}
       labels: ${{ steps.meta-root.outputs.labels }}
       file: core/chainlink.Dockerfile
+      outputs: ${{ env.shared-outputs }}
       build-args: |
         CHAINLINK_USER=root
         ${{ env.shared-build-args }}
@@ -151,6 +170,7 @@ runs:
       tags: ${{ steps.meta-nonroot.outputs.tags }}
       labels: ${{ steps.meta-nonroot.outputs.labels }}
       file: core/chainlink.Dockerfile
+      outputs: ${{ env.shared-outputs }}
       build-args: |
         CHAINLINK_USER=chainlink
         ${{ env.shared-build-args }}

--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -83,7 +83,7 @@ runs:
       if [ "$PUBLISH" = "false" ]; then
         SHARED_OUTPUTS=$(
           cat <<EOF
-        type=image,push=false
+        type=docker,dest=/tmp/image.tar
       EOF
         )
 


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/epic/32279/releng-improvements-core-from-v1-2-0?cf_workflow=500000005&ct_workflow=all
- Bump build-push-action to 2.10.0
- Fix image.name not being present
