### PR TITLE
Improve logging levels on core/services/pg

### DIFF
--- a/core/services/pg/advisory_lock.go
+++ b/core/services/pg/advisory_lock.go
@@ -122,7 +122,7 @@ func (l *advisoryLock) checkoutConn(ctx context.Context) (err error) {
 // getLock obtains exclusive session level advisory lock if available.
 // It will either obtain the lock and return true, or return false if the lock cannot be acquired immediately.
 func (l *advisoryLock) getLock(ctx context.Context) (locked bool, err error) {
-	l.logger.Trace("Taking advisory lock")
+	l.logger.Debug("Taking advisory lock")
 	sqlQuery := "SELECT pg_try_advisory_lock($1)"
 	err = l.conn.QueryRowContext(ctx, sqlQuery, l.id).Scan(&locked)
 	return locked, errors.WithStack(err)

--- a/core/services/pg/event_broadcaster.go
+++ b/core/services/pg/event_broadcaster.go
@@ -164,7 +164,7 @@ func (b *eventBroadcaster) Subscribe(channel, payloadFilter string) (Subscriptio
 		queue:            utils.NewBoundedQueue(1000),
 		chEvents:         make(chan Event),
 		chDone:           make(chan struct{}),
-		lggr:             b.lggr,
+		lggr:             logger.Sugared(b.lggr),
 	}
 	sub.processQueueWorker = utils.NewSleeperTask(
 		utils.SleeperFuncTask(sub.processQueue, "SubscriptionQueueProcessor"),
@@ -237,7 +237,7 @@ type subscription struct {
 	processQueueWorker utils.SleeperTask
 	chEvents           chan Event
 	chDone             chan struct{}
-	lggr               logger.Logger
+	lggr               logger.SugaredLogger
 }
 
 var _ Subscription = (*subscription)(nil)
@@ -260,7 +260,7 @@ func (sub *subscription) processQueue() {
 	for !sub.queue.Empty() {
 		event, ok := sub.queue.Take().(Event)
 		if !ok {
-			sub.lggr.Errorf("Postgres event broadcaster subscription expected an Event, got %T", event)
+			sub.lggr.AssumptionViolationf("Postgres event broadcaster subscription expected an Event, got %T", event)
 			continue
 		}
 		select {

--- a/core/services/pg/transaction.go
+++ b/core/services/pg/transaction.go
@@ -111,7 +111,7 @@ func sqlxTransactionQ(ctx context.Context, db TxBeginner, lggr logger.Logger, fn
 				panic(fmt.Sprintf("panic in transaction; aborting rollback that took longer than 10s: %s", p))
 			}
 		} else if err != nil {
-			lggr.Debugf("Error in transaction, rolling back: %s", err)
+			lggr.Errorf("Error in transaction, rolling back: %s", err)
 			// An error occurred, rollback and return error
 			if rerr := tx.Rollback(); rerr != nil {
 				err = multierr.Combine(err, errors.WithStack(rerr))


### PR DESCRIPTION
- Move to use sugared logger for AssumptionViolation helpers
- bump lock logs to debug
- bump tx errors log to err instead of debug