### PR TITLE
go test -short: skip more tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,7 +157,11 @@ If you do end up modifying the migrations for the database, you will need to rer
 go test ./...
 ```
 
-Note: You can use flag ```-parallel=1``` to limit CPU usage in background, by default, it is set to the value of GOMAXPROCS
+### Notes
+
+- The `parallel` flag can be used to limit CPU usage, for running tests in the background (`-parallel=4`) - the default is `GOMAXPROCS`
+- The `p` flag can be used to limit the number of _packages_ tested concurrently, if they are interferring with one another (`-p=1`)
+- The `-short` flag skips tests which depend on the database, for quickly spot checking simpler tests in around one minute (you may still need a phony env var to pass some validation: `DATABASE_URL=_test`)
 
 ### Solidity Development
 

--- a/core/chains/evm/log/helpers_test.go
+++ b/core/chains/evm/log/helpers_test.go
@@ -84,9 +84,6 @@ func newBroadcasterHelperWithEthClient(t *testing.T, ethClient evmclient.Client,
 }
 
 func (c broadcasterHelperCfg) newWithEthClient(t *testing.T, ethClient evmclient.Client) *broadcasterHelper {
-	if testing.Short() {
-		t.Skip("skipping due to broadcasterHelper")
-	}
 	if c.db == nil {
 		c.db = pgtest.NewSqlxDB(t)
 	}

--- a/core/chains/evm/txmgr/transmitchecker_test.go
+++ b/core/chains/evm/txmgr/transmitchecker_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 func TestFactory(t *testing.T) {
-	client, _, _ := cltest.NewEthMocksWithDefaultChain(t)
+	client, _ := cltest.NewEthMocksWithDefaultChain(t)
 	factory := &txmgr.CheckerFactory{Client: client}
 
 	t.Run("no checker", func(t *testing.T) {

--- a/core/cmd/eth_keys_commands_test.go
+++ b/core/cmd/eth_keys_commands_test.go
@@ -83,8 +83,7 @@ func TestEthKeysPresenter_RenderTable(t *testing.T) {
 func TestClient_ListETHKeys(t *testing.T) {
 	t.Parallel()
 
-	ethClient, assertMocksCalled := newEthMock(t)
-	defer assertMocksCalled()
+	ethClient := newEthMock(t)
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(42), nil)
 	ethClient.On("GetLINKBalance", mock.Anything, mock.Anything).Return(assets.NewLinkFromJuels(42), nil)
 	app := startNewApplication(t,
@@ -109,8 +108,7 @@ func TestClient_ListETHKeys(t *testing.T) {
 func TestClient_CreateETHKey(t *testing.T) {
 	t.Parallel()
 
-	ethClient, assertMocksCalled := newEthMock(t)
-	defer assertMocksCalled()
+	ethClient := newEthMock(t)
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(42), nil)
 	ethClient.On("GetLINKBalance", mock.Anything, mock.Anything).Return(assets.NewLinkFromJuels(42), nil)
 	app := startNewApplication(t,
@@ -164,8 +162,7 @@ func TestClient_CreateETHKey(t *testing.T) {
 func TestClient_UpdateETHKey(t *testing.T) {
 	t.Parallel()
 
-	ethClient, assertMocksCalled := newEthMock(t)
-	defer assertMocksCalled()
+	ethClient := newEthMock(t)
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(42), nil)
 	ethClient.On("GetLINKBalance", mock.Anything, mock.Anything).Return(assets.NewLinkFromJuels(42), nil)
 	app := startNewApplication(t,
@@ -202,8 +199,7 @@ func TestClient_UpdateETHKey(t *testing.T) {
 func TestClient_DeleteETHKey(t *testing.T) {
 	t.Parallel()
 
-	ethClient, assertMocksCalled := newEthMock(t)
-	defer assertMocksCalled()
+	ethClient := newEthMock(t)
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(42), nil)
 	ethClient.On("GetLINKBalance", mock.Anything, mock.Anything).Return(assets.NewLinkFromJuels(42), nil)
 	app := startNewApplication(t,
@@ -240,8 +236,7 @@ func TestClient_ImportExportETHKey_NoChains(t *testing.T) {
 
 	t.Cleanup(func() { deleteKeyExportFile(t) })
 
-	ethClient, assertMocksCalled := newEthMock(t)
-	defer assertMocksCalled()
+	ethClient := newEthMock(t)
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(42), nil)
 	ethClient.On("GetLINKBalance", mock.Anything, mock.Anything).Return(assets.NewLinkFromJuels(42), nil)
 	app := startNewApplication(t,
@@ -333,8 +328,7 @@ func TestClient_ImportExportETHKey_WithChains(t *testing.T) {
 
 	t.Cleanup(func() { deleteKeyExportFile(t) })
 
-	ethClient, assertMocksCalled := newEthMock(t)
-	defer assertMocksCalled()
+	ethClient := newEthMock(t)
 	app := startNewApplication(t,
 		withMocks(ethClient),
 		withConfigSet(func(c *configtest.TestGeneralConfig) {

--- a/core/cmd/evm_transaction_commands_test.go
+++ b/core/cmd/evm_transaction_commands_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/urfave/cli"
-	null "gopkg.in/guregu/null.v4"
+	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
@@ -114,8 +114,7 @@ func TestClient_SendEther_From_Txm(t *testing.T) {
 	balance, err := assets.NewEthValueS("200")
 	require.NoError(t, err)
 
-	ethMock, assertMocksCalled := newEthMockWithTransactionsOnBlocksAssertions(t)
-	defer assertMocksCalled()
+	ethMock := newEthMockWithTransactionsOnBlocksAssertions(t)
 
 	ethMock.On("BalanceAt", mock.Anything, key.Address.Address(), (*big.Int)(nil)).Return(balance.ToInt(), nil)
 
@@ -162,8 +161,7 @@ func TestClient_SendEther_From_Txm_WEI(t *testing.T) {
 	balance, err := assets.NewEthValueS("200")
 	require.NoError(t, err)
 
-	ethMock, assertMocksCalled := newEthMockWithTransactionsOnBlocksAssertions(t)
-	defer assertMocksCalled()
+	ethMock := newEthMockWithTransactionsOnBlocksAssertions(t)
 
 	ethMock.On("BalanceAt", mock.Anything, key.Address.Address(), (*big.Int)(nil)).Return(balance.ToInt(), nil)
 

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -103,20 +103,15 @@ func withKey() func(opts *startOptions) {
 	}
 }
 
-func newEthMock(t *testing.T) (*evmmocks.Client, func()) {
+func newEthMock(t *testing.T) *evmmocks.Client {
 	t.Helper()
-
-	ethClient, _, assertMocksCalled := cltest.NewEthMocksWithStartupAssertions(t)
-
-	return ethClient, assertMocksCalled
+	return cltest.NewEthMocksWithStartupAssertions(t)
 }
 
-func newEthMockWithTransactionsOnBlocksAssertions(t *testing.T) (*evmmocks.Client, func()) {
+func newEthMockWithTransactionsOnBlocksAssertions(t *testing.T) *evmmocks.Client {
 	t.Helper()
 
-	ethClient, _, assertMocksCalled := cltest.NewEthMocksWithTransactionsOnBlocksAssertions(t)
-
-	return ethClient, assertMocksCalled
+	return cltest.NewEthMocksWithTransactionsOnBlocksAssertions(t)
 }
 
 func keyNameForTest(t *testing.T) string {
@@ -486,8 +481,7 @@ func TestClient_Profile(t *testing.T) {
 func TestClient_SetDefaultGasPrice(t *testing.T) {
 	t.Parallel()
 
-	ethMock, assertMocksCalled := newEthMock(t)
-	defer assertMocksCalled()
+	ethMock := newEthMock(t)
 	app := startNewApplication(t,
 		withKey(),
 		withMocks(ethMock),

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -301,6 +301,9 @@ const (
 // This should only be used in full integration tests. For controller tests, see NewApplicationEVMDisabled
 func NewApplicationWithConfig(t testing.TB, cfg *configtest.TestGeneralConfig, flagsAndDeps ...interface{}) *TestApplication {
 	t.Helper()
+	if testing.Short() {
+		t.Skip("DB dependency")
+	}
 
 	lggr := logger.TestLogger(t)
 
@@ -410,25 +413,25 @@ func NewApplicationWithConfig(t testing.TB, cfg *configtest.TestGeneralConfig, f
 	return ta
 }
 
-func NewEthMocksWithDefaultChain(t testing.TB) (c *evmMocks.Client, s *evmMocks.Subscription, f func()) {
-	c, s, f = NewEthMocks(t)
+func NewEthMocksWithDefaultChain(t testing.TB) (c *evmMocks.Client, s *evmMocks.Subscription) {
+	if testing.Short() {
+		t.Skip("skipping: DB dependency")
+	}
+	c, s = NewEthMocks(t)
 	c.On("ChainID").Return(&FixtureChainID).Maybe()
 	return
 }
 
-func NewEthMocks(t testing.TB) (*evmMocks.Client, *evmMocks.Subscription, func()) {
+func NewEthMocks(t testing.TB) (*evmMocks.Client, *evmMocks.Subscription) {
 	c, s := NewEthClientAndSubMock(t)
-	var assertMocksCalled func()
 	switch tt := t.(type) {
 	case *testing.T:
-		assertMocksCalled = func() {
+		t.Cleanup(func() {
 			c.AssertExpectations(tt)
 			s.AssertExpectations(tt)
-		}
-	case *testing.B:
-		assertMocksCalled = func() {}
+		})
 	}
-	return c, s, assertMocksCalled
+	return c, s
 }
 
 func NewEthClientAndSubMock(t mock.TestingT) (*evmMocks.Client, *evmMocks.Subscription) {
@@ -457,8 +460,11 @@ func NewEthClientMockWithDefaultChain(t testing.TB) *evmMocks.Client {
 	return c
 }
 
-func NewEthMocksWithStartupAssertions(t testing.TB) (*evmMocks.Client, *evmMocks.Subscription, func()) {
-	c, s, assertMocksCalled := NewEthMocks(t)
+func NewEthMocksWithStartupAssertions(t testing.TB) *evmMocks.Client {
+	if testing.Short() {
+		t.Skip("skipping: long test")
+	}
+	c, s := NewEthMocks(t)
 	c.On("Dial", mock.Anything).Maybe().Return(nil)
 	c.On("SubscribeNewHead", mock.Anything, mock.Anything).Maybe().Return(EmptyMockSubscription(t), nil)
 	c.On("SendTransaction", mock.Anything, mock.Anything).Maybe().Return(nil)
@@ -473,12 +479,15 @@ func NewEthMocksWithStartupAssertions(t testing.TB) (*evmMocks.Client, *evmMocks
 
 	s.On("Err").Return(nil).Maybe()
 	s.On("Unsubscribe").Return(nil).Maybe()
-	return c, s, assertMocksCalled
+	return c
 }
 
 // NewEthMocksWithTransactionsOnBlocksAssertions sets an Eth mock with transactions on blocks
-func NewEthMocksWithTransactionsOnBlocksAssertions(t testing.TB) (*evmMocks.Client, *evmMocks.Subscription, func()) {
-	c, s, assertMocksCalled := NewEthMocks(t)
+func NewEthMocksWithTransactionsOnBlocksAssertions(t testing.TB) *evmMocks.Client {
+	if testing.Short() {
+		t.Skip("skipping: long test")
+	}
+	c, s := NewEthMocks(t)
 	c.On("Dial", mock.Anything).Maybe().Return(nil)
 	c.On("SubscribeNewHead", mock.Anything, mock.Anything).Maybe().Return(EmptyMockSubscription(t), nil)
 	c.On("SendTransaction", mock.Anything, mock.Anything).Maybe().Return(nil)
@@ -508,7 +517,8 @@ func NewEthMocksWithTransactionsOnBlocksAssertions(t testing.TB) (*evmMocks.Clie
 
 	s.On("Err").Return(nil).Maybe()
 	s.On("Unsubscribe").Return(nil).Maybe()
-	return c, s, assertMocksCalled
+
+	return c
 }
 
 func newServer(app chainlink.Application) *httptest.Server {

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -301,9 +301,7 @@ const (
 // This should only be used in full integration tests. For controller tests, see NewApplicationEVMDisabled
 func NewApplicationWithConfig(t testing.TB, cfg *configtest.TestGeneralConfig, flagsAndDeps ...interface{}) *TestApplication {
 	t.Helper()
-	if testing.Short() {
-		t.Skip("DB dependency")
-	}
+	testutils.SkipShortDB(t)
 
 	lggr := logger.TestLogger(t)
 
@@ -414,9 +412,7 @@ func NewApplicationWithConfig(t testing.TB, cfg *configtest.TestGeneralConfig, f
 }
 
 func NewEthMocksWithDefaultChain(t testing.TB) (c *evmMocks.Client, s *evmMocks.Subscription) {
-	if testing.Short() {
-		t.Skip("skipping: DB dependency")
-	}
+	testutils.SkipShortDB(t)
 	c, s = NewEthMocks(t)
 	c.On("ChainID").Return(&FixtureChainID).Maybe()
 	return
@@ -461,9 +457,7 @@ func NewEthClientMockWithDefaultChain(t testing.TB) *evmMocks.Client {
 }
 
 func NewEthMocksWithStartupAssertions(t testing.TB) *evmMocks.Client {
-	if testing.Short() {
-		t.Skip("skipping: long test")
-	}
+	testutils.SkipShort(t, "long test")
 	c, s := NewEthMocks(t)
 	c.On("Dial", mock.Anything).Maybe().Return(nil)
 	c.On("SubscribeNewHead", mock.Anything, mock.Anything).Maybe().Return(EmptyMockSubscription(t), nil)
@@ -484,9 +478,7 @@ func NewEthMocksWithStartupAssertions(t testing.TB) *evmMocks.Client {
 
 // NewEthMocksWithTransactionsOnBlocksAssertions sets an Eth mock with transactions on blocks
 func NewEthMocksWithTransactionsOnBlocksAssertions(t testing.TB) *evmMocks.Client {
-	if testing.Short() {
-		t.Skip("skipping: long test")
-	}
+	testutils.SkipShort(t, "long test")
 	c, s := NewEthMocks(t)
 	c.On("Dial", mock.Anything).Maybe().Return(nil)
 	c.On("SubscribeNewHead", mock.Anything, mock.Anything).Maybe().Return(EmptyMockSubscription(t), nil)

--- a/core/internal/cltest/heavyweight/orm.go
+++ b/core/internal/cltest/heavyweight/orm.go
@@ -14,25 +14,25 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/smartcontractkit/sqlx"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v4"
+
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/store/dialects"
 	migrations "github.com/smartcontractkit/chainlink/core/store/migrate"
-	"github.com/smartcontractkit/sqlx"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v4"
 )
 
 // FullTestDB creates an DB which runs in a separate database than the normal
 // unit tests, so you can do things like use other Postgres connection types
 // with it.
 func FullTestDB(t *testing.T, name string, migrate bool, loadFixtures bool) (*configtest.TestGeneralConfig, *sqlx.DB) {
-	if testing.Short() {
-		t.Skip("skipping due to use of FullTestDB")
-	}
+	testutils.SkipShort(t, "FullTestDB")
 	overrides := configtest.GeneralConfigOverrides{
 		SecretGenerator: cltest.MockSecretGenerator{},
 	}

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -552,9 +552,7 @@ func setupNode(t *testing.T, owner *bind.TransactOpts, portV1, portV2 int, dbNam
 }
 
 func TestIntegration_OCR(t *testing.T) {
-	if testing.Short() {
-		t.Skip()
-	}
+	testutils.SkipShort(t, "long test")
 	tests := []struct {
 		id        int
 		portStart int // Test need to run in parallel, all need distinct port ranges.

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -72,8 +72,7 @@ var oneETH = assets.Eth(*big.NewInt(1000000000000000000))
 func TestIntegration_ExternalInitiatorV2(t *testing.T) {
 	t.Parallel()
 
-	ethClient, _, assertMockCalls := cltest.NewEthMocksWithStartupAssertions(t)
-	defer assertMockCalls()
+	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
 
 	cfg := cltest.NewTestGeneralConfig(t)
 	cfg.Overrides.FeatureExternalInitiators = null.BoolFrom(true)
@@ -248,8 +247,8 @@ observationSource   = """
 func TestIntegration_AuthToken(t *testing.T) {
 	t.Parallel()
 
-	ethClient, _, assertMockCalls := cltest.NewEthMocksWithStartupAssertions(t)
-	defer assertMockCalls()
+	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
+
 	app := cltest.NewApplication(t, ethClient)
 	require.NoError(t, app.Start(testutils.Context(t)))
 
@@ -798,8 +797,7 @@ func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 	cfg := cltest.NewTestGeneralConfig(t)
 	cfg.Overrides.GlobalBalanceMonitorEnabled = null.BoolFrom(false)
 
-	ethClient, sub, assertMocksCalled := cltest.NewEthMocksWithDefaultChain(t)
-	defer assertMocksCalled()
+	ethClient, sub := cltest.NewEthMocksWithDefaultChain(t)
 	chchNewHeads := make(chan chan<- *evmtypes.Head, 1)
 
 	db := pgtest.NewSqlxDB(t)

--- a/core/internal/testutils/pgtest/pgtest.go
+++ b/core/internal/testutils/pgtest/pgtest.go
@@ -22,6 +22,9 @@ func NewPGCfg(logSQL bool) pg.LogConfig { return PGCfg{logSQL} }
 func (p PGCfg) LogSQL() bool            { return p.logSQL }
 
 func NewSqlDB(t *testing.T) *sql.DB {
+	if testing.Short() {
+		t.Skip("DB dependency")
+	}
 	db, err := sql.Open("txdb", uuid.NewV4().String())
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, db.Close()) })
@@ -30,6 +33,9 @@ func NewSqlDB(t *testing.T) *sql.DB {
 }
 
 func NewSqlxDB(t *testing.T) *sqlx.DB {
+	if testing.Short() {
+		t.Skip("DB dependency")
+	}
 	db, err := sqlx.Open("txdb", uuid.NewV4().String())
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, db.Close()) })

--- a/core/internal/testutils/pgtest/pgtest.go
+++ b/core/internal/testutils/pgtest/pgtest.go
@@ -10,6 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
@@ -22,9 +23,7 @@ func NewPGCfg(logSQL bool) pg.LogConfig { return PGCfg{logSQL} }
 func (p PGCfg) LogSQL() bool            { return p.logSQL }
 
 func NewSqlDB(t *testing.T) *sql.DB {
-	if testing.Short() {
-		t.Skip("DB dependency")
-	}
+	testutils.SkipShortDB(t)
 	db, err := sql.Open("txdb", uuid.NewV4().String())
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, db.Close()) })
@@ -33,9 +32,7 @@ func NewSqlDB(t *testing.T) *sql.DB {
 }
 
 func NewSqlxDB(t *testing.T) *sqlx.DB {
-	if testing.Short() {
-		t.Skip("DB dependency")
-	}
+	testutils.SkipShortDB(t)
 	db, err := sqlx.Open("txdb", uuid.NewV4().String())
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, db.Close()) })

--- a/core/internal/testutils/testutils.go
+++ b/core/internal/testutils/testutils.go
@@ -309,3 +309,15 @@ func WaitForLogMessageCount(t *testing.T, observedLogs *observer.ObservedLogs, m
 		return false
 	})
 }
+
+// SkipShort skips tb during -short runs, and notes why.
+func SkipShort(tb testing.TB, why string) {
+	if testing.Short() {
+		tb.Skipf("skipping: %s", why)
+	}
+}
+
+// SkipShortDB skips tb during -short runs, and notes the DB dependency.
+func SkipShortDB(tb testing.TB) {
+	SkipShort(tb, "DB dependency")
+}

--- a/core/services/fluxmonitorv2/flux_monitor_test.go
+++ b/core/services/fluxmonitorv2/flux_monitor_test.go
@@ -172,9 +172,7 @@ type setupOptions struct {
 // functional options to configure the setup
 func setup(t *testing.T, db *sqlx.DB, optionFns ...func(*setupOptions)) (*fluxmonitorv2.FluxMonitor, *testMocks) {
 	t.Helper()
-	if testing.Short() {
-		t.Skip("skipping")
-	}
+	testutils.SkipShort(t, "long test")
 
 	tm := setupMocks(t)
 	options := setupOptions{

--- a/core/services/fluxmonitorv2/integrations_test.go
+++ b/core/services/fluxmonitorv2/integrations_test.go
@@ -26,6 +26,8 @@ import (
 	"go.uber.org/atomic"
 	"gopkg.in/guregu/null.v4"
 
+	"github.com/smartcontractkit/sqlx"
+
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/bridges"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/log"
@@ -45,7 +47,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 	"github.com/smartcontractkit/chainlink/core/web"
-	"github.com/smartcontractkit/sqlx"
 )
 
 const description = "exactly thirty-three characters!!"
@@ -102,9 +103,7 @@ func WithMinMaxSubmission(min, max *big.Int) func(cfg *fluxAggregatorUniverseCon
 // arguments match the arguments of the same name in the FluxAggregator
 // constructor.
 func setupFluxAggregatorUniverse(t *testing.T, configOptions ...func(cfg *fluxAggregatorUniverseConfig)) fluxAggregatorUniverse {
-	if testing.Short() {
-		t.Skip("skipping due to VRFCoordinatorV2Universe")
-	}
+	testutils.SkipShort(t, "VRFCoordinatorV2Universe")
 	cfg := &fluxAggregatorUniverseConfig{
 		MinSubmission: big.NewInt(0),
 		MaxSubmission: big.NewInt(100000000000),

--- a/core/services/job/runner_integration_test.go
+++ b/core/services/job/runner_integration_test.go
@@ -57,7 +57,7 @@ func TestRunner(t *testing.T) {
 	keyStore := cltest.NewKeyStore(t, db, config)
 	ethKeyStore := keyStore.Eth()
 
-	ethClient, _, _ := cltest.NewEthMocksWithDefaultChain(t)
+	ethClient, _ := cltest.NewEthMocksWithDefaultChain(t)
 	ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(cltest.Head(10), nil)
 	ethClient.On("CallContract", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(nil, nil)
 
@@ -751,8 +751,7 @@ ds1 -> ds1_parse;
 func TestRunner_Success_Callback_AsyncJob(t *testing.T) {
 	t.Parallel()
 
-	ethClient, _, assertMockCalls := cltest.NewEthMocksWithStartupAssertions(t)
-	defer assertMockCalls()
+	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
 
 	cfg := cltest.NewTestGeneralConfig(t)
 	cfg.Overrides.FeatureExternalInitiators = null.BoolFrom(true)
@@ -929,8 +928,7 @@ func TestRunner_Success_Callback_AsyncJob(t *testing.T) {
 func TestRunner_Error_Callback_AsyncJob(t *testing.T) {
 	t.Parallel()
 
-	ethClient, _, assertMockCalls := cltest.NewEthMocksWithStartupAssertions(t)
-	defer assertMockCalls()
+	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
 
 	cfg := cltest.NewTestGeneralConfig(t)
 	cfg.Overrides.FeatureExternalInitiators = null.BoolFrom(true)

--- a/core/services/job/spawner_test.go
+++ b/core/services/job/spawner_test.go
@@ -66,7 +66,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 			head := args.Get(1).(**evmtypes.Head)
 			*head = cltest.Head(10)
 		}).
-		Return(nil)
+		Return(nil).Maybe()
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, Client: ethClient, GeneralConfig: config})
 
 	t.Run("should respect its dependents", func(t *testing.T) {

--- a/core/services/job/spawner_test.go
+++ b/core/services/job/spawner_test.go
@@ -60,7 +60,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 	_, bridge := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, config)
 	_, bridge2 := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, config)
 
-	ethClient, _, _ := cltest.NewEthMocksWithDefaultChain(t)
+	ethClient, _ := cltest.NewEthMocksWithDefaultChain(t)
 	ethClient.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.Anything, false).
 		Run(func(args mock.Arguments) {
 			head := args.Get(1).(**evmtypes.Head)

--- a/core/services/periodicbackup/backup_test.go
+++ b/core/services/periodicbackup/backup_test.go
@@ -7,14 +7,18 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func mustNewDatabaseBackup(t *testing.T, config Config) *databaseBackup {
+	if testing.Short() {
+		t.Skip("skipping: DB dependency")
+	}
 	b, err := NewDatabaseBackup(config, logger.TestLogger(t))
 	require.NoError(t, err)
 	return b.(*databaseBackup)

--- a/core/services/periodicbackup/backup_test.go
+++ b/core/services/periodicbackup/backup_test.go
@@ -11,14 +11,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/core/config"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
 func mustNewDatabaseBackup(t *testing.T, config Config) *databaseBackup {
-	if testing.Short() {
-		t.Skip("skipping: DB dependency")
-	}
+	testutils.SkipShortDB(t)
 	b, err := NewDatabaseBackup(config, logger.TestLogger(t))
 	require.NoError(t, err)
 	return b.(*databaseBackup)

--- a/core/services/pg/locked_db_test.go
+++ b/core/services/pg/locked_db_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 
@@ -13,9 +14,7 @@ import (
 )
 
 func TestLockedDB_HappyPath(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping: DB dependency")
-	}
+	testutils.SkipShortDB(t)
 	config := cltest.NewTestGeneralConfig(t)
 	config.Overrides.DatabaseLockingMode = null.StringFrom("dual")
 	lggr := logger.TestLogger(t)
@@ -31,9 +30,7 @@ func TestLockedDB_HappyPath(t *testing.T) {
 }
 
 func TestLockedDB_ContextCancelled(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping: DB dependency")
-	}
+	testutils.SkipShortDB(t)
 	config := cltest.NewTestGeneralConfig(t)
 	config.Overrides.DatabaseLockingMode = null.StringFrom("dual")
 	lggr := logger.TestLogger(t)
@@ -47,9 +44,7 @@ func TestLockedDB_ContextCancelled(t *testing.T) {
 }
 
 func TestLockedDB_OpenTwice(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping: DB dependency")
-	}
+	testutils.SkipShortDB(t)
 	config := cltest.NewTestGeneralConfig(t)
 	config.Overrides.DatabaseLockingMode = null.StringFrom("lease")
 	lggr := logger.TestLogger(t)
@@ -65,9 +60,7 @@ func TestLockedDB_OpenTwice(t *testing.T) {
 }
 
 func TestLockedDB_TwoInstances(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping: DB dependency")
-	}
+	testutils.SkipShortDB(t)
 	config := cltest.NewTestGeneralConfig(t)
 	config.Overrides.DatabaseLockingMode = null.StringFrom("dual")
 	lggr := logger.TestLogger(t)
@@ -89,9 +82,7 @@ func TestLockedDB_TwoInstances(t *testing.T) {
 }
 
 func TestOpenUnlockedDB(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping: DB dependency")
-	}
+	testutils.SkipShortDB(t)
 	config := cltest.NewTestGeneralConfig(t)
 	lggr := logger.TestLogger(t)
 

--- a/core/services/pg/locked_db_test.go
+++ b/core/services/pg/locked_db_test.go
@@ -13,6 +13,9 @@ import (
 )
 
 func TestLockedDB_HappyPath(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: DB dependency")
+	}
 	config := cltest.NewTestGeneralConfig(t)
 	config.Overrides.DatabaseLockingMode = null.StringFrom("dual")
 	lggr := logger.TestLogger(t)
@@ -28,6 +31,9 @@ func TestLockedDB_HappyPath(t *testing.T) {
 }
 
 func TestLockedDB_ContextCancelled(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: DB dependency")
+	}
 	config := cltest.NewTestGeneralConfig(t)
 	config.Overrides.DatabaseLockingMode = null.StringFrom("dual")
 	lggr := logger.TestLogger(t)
@@ -41,6 +47,9 @@ func TestLockedDB_ContextCancelled(t *testing.T) {
 }
 
 func TestLockedDB_OpenTwice(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: DB dependency")
+	}
 	config := cltest.NewTestGeneralConfig(t)
 	config.Overrides.DatabaseLockingMode = null.StringFrom("lease")
 	lggr := logger.TestLogger(t)
@@ -56,6 +65,9 @@ func TestLockedDB_OpenTwice(t *testing.T) {
 }
 
 func TestLockedDB_TwoInstances(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: DB dependency")
+	}
 	config := cltest.NewTestGeneralConfig(t)
 	config.Overrides.DatabaseLockingMode = null.StringFrom("dual")
 	lggr := logger.TestLogger(t)
@@ -77,6 +89,9 @@ func TestLockedDB_TwoInstances(t *testing.T) {
 }
 
 func TestOpenUnlockedDB(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping: DB dependency")
+	}
 	config := cltest.NewTestGeneralConfig(t)
 	lggr := logger.TestLogger(t)
 

--- a/core/services/vrf/integration_v2_test.go
+++ b/core/services/vrf/integration_v2_test.go
@@ -25,6 +25,8 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 
+	"github.com/smartcontractkit/sqlx"
+
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
@@ -54,7 +56,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/testdata/testspecs"
 	"github.com/smartcontractkit/chainlink/core/utils"
-	"github.com/smartcontractkit/sqlx"
 )
 
 // vrfConsumerContract is the common interface implemented by
@@ -103,9 +104,7 @@ var (
 )
 
 func newVRFCoordinatorV2Universe(t *testing.T, key ethkey.KeyV2, numConsumers int) coordinatorV2Universe {
-	if testing.Short() {
-		t.Skip("skipping due to VRFCoordinatorV2Universe")
-	}
+	testutils.SkipShort(t, "VRFCoordinatorV2Universe")
 	oracleTransactor := cltest.MustNewSimulatedBackendKeyedTransactor(t, key.ToEcdsaPrivKey())
 	var (
 		sergey       = newIdentity(t)

--- a/core/web/eth_keys_controller_test.go
+++ b/core/web/eth_keys_controller_test.go
@@ -20,8 +20,7 @@ import (
 func TestETHKeysController_Index_Success(t *testing.T) {
 	t.Parallel()
 
-	ethClient, _, assertMocksCalled := cltest.NewEthMocksWithStartupAssertions(t)
-	defer assertMocksCalled()
+	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
 	cfg := cltest.NewTestGeneralConfig(t)
 	cfg.Overrides.Dev = null.BoolFrom(true)
 	cfg.Overrides.GlobalEvmNonceAutoSync = null.BoolFrom(false)
@@ -74,8 +73,7 @@ func TestETHKeysController_Index_Success(t *testing.T) {
 func TestETHKeysController_Index_NotDev(t *testing.T) {
 	t.Parallel()
 
-	ethClient, _, assertMocksCalled := cltest.NewEthMocksWithStartupAssertions(t)
-	defer assertMocksCalled()
+	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
 	cfg := cltest.NewTestGeneralConfig(t)
 	cfg.Overrides.Dev = null.BoolFrom(false)
 	cfg.Overrides.GlobalEvmNonceAutoSync = null.BoolFrom(false)

--- a/core/web/evm_transfer_controller_test.go
+++ b/core/web/evm_transfer_controller_test.go
@@ -24,8 +24,7 @@ func TestTransfersController_CreateSuccess_From(t *testing.T) {
 
 	key := cltest.MustGenerateRandomKey(t)
 
-	ethClient, _, assertMockCalls := cltest.NewEthMocksWithTransactionsOnBlocksAssertions(t)
-	defer assertMockCalls()
+	ethClient := cltest.NewEthMocksWithTransactionsOnBlocksAssertions(t)
 
 	balance, err := assets.NewEthValueS("200")
 	require.NoError(t, err)
@@ -65,8 +64,7 @@ func TestTransfersController_CreateSuccess_From_WEI(t *testing.T) {
 
 	key := cltest.MustGenerateRandomKey(t)
 
-	ethClient, _, assertMockCalls := cltest.NewEthMocksWithTransactionsOnBlocksAssertions(t)
-	defer assertMockCalls()
+	ethClient := cltest.NewEthMocksWithTransactionsOnBlocksAssertions(t)
 
 	balance, err := assets.NewEthValueS("2")
 	require.NoError(t, err)
@@ -105,8 +103,7 @@ func TestTransfersController_CreateSuccess_From_BalanceMonitorDisabled(t *testin
 
 	key := cltest.MustGenerateRandomKey(t)
 
-	ethClient, _, assertMockCalls := cltest.NewEthMocksWithTransactionsOnBlocksAssertions(t)
-	defer assertMockCalls()
+	ethClient := cltest.NewEthMocksWithTransactionsOnBlocksAssertions(t)
 
 	balance, err := assets.NewEthValueS("200")
 	require.NoError(t, err)
@@ -174,8 +171,7 @@ func TestTransfersController_TransferBalanceToLowError(t *testing.T) {
 
 	key := cltest.MustGenerateRandomKey(t)
 
-	ethClient, _, assertMockCalls := cltest.NewEthMocksWithTransactionsOnBlocksAssertions(t)
-	defer assertMockCalls()
+	ethClient := cltest.NewEthMocksWithTransactionsOnBlocksAssertions(t)
 
 	ethClient.On("PendingNonceAt", mock.Anything, key.Address.Address()).Return(uint64(1), nil)
 	ethClient.On("BalanceAt", mock.Anything, key.Address.Address(), (*big.Int)(nil)).Return(assets.NewEth(10).ToInt(), nil)
@@ -209,8 +205,7 @@ func TestTransfersController_TransferBalanceToLowError_ZeroBalance(t *testing.T)
 
 	key := cltest.MustGenerateRandomKey(t)
 
-	ethClient, _, assertMockCalls := cltest.NewEthMocksWithTransactionsOnBlocksAssertions(t)
-	defer assertMockCalls()
+	ethClient := cltest.NewEthMocksWithTransactionsOnBlocksAssertions(t)
 
 	balance, err := assets.NewEthValueS("0")
 	require.NoError(t, err)

--- a/core/web/pipeline_runs_controller_test.go
+++ b/core/web/pipeline_runs_controller_test.go
@@ -29,8 +29,7 @@ import (
 func TestPipelineRunsController_CreateWithBody_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	ethClient, _, assertMocksCalled := cltest.NewEthMocksWithStartupAssertions(t)
-	defer assertMocksCalled()
+	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
 	cfg := cltest.NewTestGeneralConfig(t)
 
 	cfg.Overrides.SetDefaultHTTPTimeout(2 * time.Second)
@@ -88,8 +87,7 @@ func TestPipelineRunsController_CreateWithBody_HappyPath(t *testing.T) {
 func TestPipelineRunsController_CreateNoBody_HappyPath(t *testing.T) {
 	t.Parallel()
 
-	ethClient, _, assertMocksCalled := cltest.NewEthMocksWithStartupAssertions(t)
-	defer assertMocksCalled()
+	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
 	cfg := cltest.NewTestGeneralConfig(t)
 
 	cfg.Overrides.SetDefaultHTTPTimeout(2 * time.Second)
@@ -247,8 +245,7 @@ func TestPipelineRunsController_ShowRun_InvalidID(t *testing.T) {
 
 func setupPipelineRunsControllerTests(t *testing.T) (cltest.HTTPClientCleaner, int32, []int64) {
 	t.Parallel()
-	ethClient, _, assertMocksCalled := cltest.NewEthMocksWithStartupAssertions(t)
-	defer assertMocksCalled()
+	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
 	cfg := cltest.NewTestGeneralConfig(t)
 	cfg.Overrides.EVMRPCEnabled = null.BoolFrom(false)
 	cfg.Overrides.FeatureOffchainReporting = null.BoolFrom(true)


### PR DESCRIPTION
This PR updates the set of tests skipped by `-short` to include everything that depends on the DB so that there are not any external dependencies to set up. The run time is reduced to around one minute.