### PR TITLE
Avoid triggering build publish workflow on release branches.

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -8,7 +8,6 @@ on:
     branches:
       - master
       - develop
-      - 'release/*'
 
 jobs:
   build-sign-publish-chainlink:


### PR DESCRIPTION
We will use GitHub Releases for release candidates going forward.