### PR TITLE
Fix TestClient_Profile_InvalidSecondsParam test

### DIFF
--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -412,6 +412,7 @@ func TestClient_Profile_InvalidSecondsParam(t *testing.T) {
 
 	set := flag.NewFlagSet("test", 0)
 	set.String("file", "../internal/fixtures/apicredentials", "")
+	set.Bool("bypass-version-check", true, "")
 	c := cli.NewContext(nil, set, nil)
 	err := client.RemoteLogin(c)
 	require.NoError(t, err)


### PR DESCRIPTION
as title.

Somehow I missed this test in https://github.com/smartcontractkit/chainlink/pull/6123 . Not sure how this test passed in CI