### PR TITLE
Fix docker image loading when publishing an image

### DIFF
--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -166,8 +166,15 @@ runs:
   - name: Check if non-root image runs as root
     id: check-nonroot-runs-root
     shell: sh
+    env:
+      PUBLISH: ${{ inputs.publish }}
     run: |
       echo "Fail build if non-root image runs as user: root"
+      # if we're publishing the image, it doesn't get loaded into the local docker daemon
+      # so we need to pull the image into our daemon
+      if [ $PUBLISH = "true" ]; then 
+       docker pull "${nonroot_image_name}"
+      fi
       docker inspect "${nonroot_image_name}" | jq -r '.[].Config.User' | ( ! grep "root" )
 
   - if: inputs.sign-images == 'true'


### PR DESCRIPTION
If we're publishing an image, buildx doesnt load the image into the
local docker daemon. So now when we're publishing an image, we pull it
down from the registry into our local daemon so we can perform a root
user check on it.
