### PR TITLE
VRF: Fulfill from multiple addresses

### DIFF
--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -6,9 +6,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/lib/pq"
 	"github.com/pelletier/go-toml"
 	uuid "github.com/satori/go.uuid"
-	"github.com/smartcontractkit/chainlink/core/services/ocrbootstrap"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
@@ -23,6 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/keeper"
 	"github.com/smartcontractkit/chainlink/core/services/ocr"
+	"github.com/smartcontractkit/chainlink/core/services/ocrbootstrap"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/core/services/vrf"
 	"github.com/smartcontractkit/chainlink/core/services/webhook"
@@ -334,7 +336,12 @@ func TestORM_CreateJob_VRFV2(t *testing.T) {
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: config})
 	jobORM := job.NewTestORM(t, db, cc, pipelineORM, keyStore, config)
 
-	jb, err := vrf.ValidatedVRFSpec(testspecs.GenerateVRFSpec(testspecs.VRFSpecParams{RequestedConfsDelay: 10}).Toml())
+	fromAddresses := []string{cltest.NewEIP55Address().String(), cltest.NewEIP55Address().String()}
+	jb, err := vrf.ValidatedVRFSpec(testspecs.GenerateVRFSpec(
+		testspecs.VRFSpecParams{
+			RequestedConfsDelay: 10,
+			FromAddresses:       fromAddresses}).
+		Toml())
 	require.NoError(t, err)
 
 	require.NoError(t, jobORM.CreateJob(&jb))
@@ -346,6 +353,13 @@ func TestORM_CreateJob_VRFV2(t *testing.T) {
 	var requestTimeout time.Duration
 	require.NoError(t, db.Get(&requestTimeout, `SELECT request_timeout FROM vrf_specs LIMIT 1`))
 	require.Equal(t, 24*time.Hour, requestTimeout)
+	var fa pq.ByteaArray
+	require.NoError(t, db.Get(&fa, `SELECT from_addresses FROM vrf_specs LIMIT 1`))
+	var actual []string
+	for _, b := range fa {
+		actual = append(actual, common.BytesToAddress(b).String())
+	}
+	require.ElementsMatch(t, fromAddresses, actual)
 	require.NoError(t, jobORM.DeleteJob(jb.ID))
 	cltest.AssertCount(t, db, "vrf_specs", 0)
 	cltest.AssertCount(t, db, "jobs", 0)

--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -425,13 +425,13 @@ type KeeperSpec struct {
 
 type VRFSpec struct {
 	ID                       int32
-	CoordinatorAddress       ethkey.EIP55Address  `toml:"coordinatorAddress"`
-	PublicKey                secp256k1.PublicKey  `toml:"publicKey"`
-	MinIncomingConfirmations uint32               `toml:"minIncomingConfirmations"`
-	ConfirmationsEnv         bool                 `toml:"-"`
-	EVMChainID               *utils.Big           `toml:"evmChainID"`
-	FromAddress              *ethkey.EIP55Address `toml:"fromAddress"`
-	PollPeriod               time.Duration        `toml:"pollPeriod"` // For v2 jobs
+	CoordinatorAddress       ethkey.EIP55Address   `toml:"coordinatorAddress"`
+	PublicKey                secp256k1.PublicKey   `toml:"publicKey"`
+	MinIncomingConfirmations uint32                `toml:"minIncomingConfirmations"`
+	ConfirmationsEnv         bool                  `toml:"-"`
+	EVMChainID               *utils.Big            `toml:"evmChainID"`
+	FromAddresses            []ethkey.EIP55Address `toml:"fromAddresses"`
+	PollPeriod               time.Duration         `toml:"pollPeriod"` // For v2 jobs
 	PollPeriodEnv            bool
 	RequestedConfsDelay      int64         `toml:"requestedConfsDelay"` // For v2 jobs. Optional, defaults to 0 if not provided.
 	RequestTimeout           time.Duration `toml:"requestTimeout"`      // Optional, defaults to 24hr if not provided.

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -8,10 +8,11 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/jackc/pgconn"
+	"github.com/lib/pq"
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
-	"github.com/smartcontractkit/sqlx"
 	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink/core/bridges"
@@ -27,6 +28,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	relaytypes "github.com/smartcontractkit/chainlink/core/services/relay/types"
 	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/sqlx"
 )
 
 var (
@@ -264,10 +266,11 @@ func (o *orm) CreateJob(jb *Job, qopts ...pg.QOpt) error {
 			jb.CronSpecID = &specID
 		case VRF:
 			var specID int32
-			sql := `INSERT INTO vrf_specs (coordinator_address, public_key, min_incoming_confirmations, evm_chain_id, from_address, poll_period, requested_confs_delay, request_timeout, created_at, updated_at)
-			VALUES (:coordinator_address, :public_key, :min_incoming_confirmations, :evm_chain_id, :from_address, :poll_period, :requested_confs_delay, :request_timeout, NOW(), NOW())
+			sql := `INSERT INTO vrf_specs (coordinator_address, public_key, min_incoming_confirmations, evm_chain_id, from_addresses, poll_period, requested_confs_delay, request_timeout, created_at, updated_at)
+			VALUES (:coordinator_address, :public_key, :min_incoming_confirmations, :evm_chain_id, :from_addresses, :poll_period, :requested_confs_delay, :request_timeout, NOW(), NOW())
 			RETURNING id;`
-			err := pg.PrepareQueryRowx(tx, sql, &specID, jb.VRFSpec)
+
+			err := pg.PrepareQueryRowx(tx, sql, &specID, toVRFSpecRow(jb.VRFSpec))
 			var pqErr *pgconn.PgError
 			ok := errors.As(err, &pqErr)
 			if err != nil && ok && pqErr.Code == "23503" {
@@ -981,7 +984,7 @@ func LoadAllJobTypes(tx pg.Queryer, job *Job) error {
 		loadJobType(tx, job, "KeeperSpec", "keeper_specs", job.KeeperSpecID),
 		loadJobType(tx, job, "CronSpec", "cron_specs", job.CronSpecID),
 		loadJobType(tx, job, "WebhookSpec", "webhook_specs", job.WebhookSpecID),
-		loadJobType(tx, job, "VRFSpec", "vrf_specs", job.VRFSpecID),
+		loadVRFJob(tx, job, job.VRFSpecID),
 		loadJobType(tx, job, "BlockhashStoreSpec", "blockhash_store_specs", job.BlockhashStoreSpecID),
 		loadJobType(tx, job, "BootstrapSpec", "bootstrap_specs", job.BootstrapSpecID),
 	)
@@ -1007,6 +1010,45 @@ func loadJobType(tx pg.Queryer, job *Job, field, table string, id *int32) error 
 	}
 	reflect.ValueOf(job).Elem().FieldByName(field).Set(destVal)
 	return nil
+}
+
+func loadVRFJob(tx pg.Queryer, job *Job, id *int32) error {
+	if id == nil {
+		return nil
+	}
+
+	var row vrfSpecRow
+	err := tx.Get(&row, `SELECT * FROM vrf_specs WHERE id = $1`, *id)
+	if err != nil {
+		return errors.Wrapf(err, `failed to load job type VRFSpec with id %d`, *id)
+	}
+
+	job.VRFSpec = row.toVRFSpec()
+	return nil
+}
+
+// vrfSpecRow is a helper type for reading and writing VRF specs to the database. This is necessary
+// because the bytea[] in the DB is not automatically convertible to or from the spec's
+// FromAddresses field. pq.ByteaArray must be used instead.
+type vrfSpecRow struct {
+	*VRFSpec
+	FromAddresses pq.ByteaArray
+}
+
+func toVRFSpecRow(spec *VRFSpec) vrfSpecRow {
+	addresses := make(pq.ByteaArray, len(spec.FromAddresses))
+	for i, a := range spec.FromAddresses {
+		addresses[i] = a.Bytes()
+	}
+	return vrfSpecRow{VRFSpec: spec, FromAddresses: addresses}
+}
+
+func (r vrfSpecRow) toVRFSpec() *VRFSpec {
+	for _, a := range r.FromAddresses {
+		r.VRFSpec.FromAddresses = append(r.VRFSpec.FromAddresses,
+			ethkey.EIP55AddressFromAddress(common.BytesToAddress(a)))
+	}
+	return r.VRFSpec
 }
 
 func loadJobSpecErrors(tx pg.Queryer, jb *Job) error {

--- a/core/services/vrf/integration_v2_test.go
+++ b/core/services/vrf/integration_v2_test.go
@@ -293,9 +293,14 @@ func subscribeVRF(
 	return sub, subID
 }
 
-func createVRFJobs(t *testing.T, keys []ethkey.KeyV2, app *cltest.TestApplication, uni coordinatorV2Universe) (jobs []job.Job) {
+func createVRFJobs(t *testing.T, fromKeys [][]ethkey.KeyV2, app *cltest.TestApplication, uni coordinatorV2Universe) (jobs []job.Job) {
 	// Create separate jobs for each gas lane and register their keys
-	for i, key := range keys {
+	for i, keys := range fromKeys {
+		var keyStrs []string
+		for _, k := range keys {
+			keyStrs = append(keyStrs, k.Address.String())
+		}
+
 		vrfkey, err := app.GetKeyStore().VRF().Create()
 		require.NoError(t, err)
 
@@ -307,7 +312,7 @@ func createVRFJobs(t *testing.T, keys []ethkey.KeyV2, app *cltest.TestApplicatio
 			CoordinatorAddress:       uni.rootContractAddress.String(),
 			MinIncomingConfirmations: incomingConfs,
 			PublicKey:                vrfkey.PublicKey.String(),
-			FromAddress:              key.Address.String(),
+			FromAddresses:            keyStrs,
 			V2:                       true,
 		}).Toml()
 		jb, err := vrf.ValidatedVRFSpec(s)
@@ -327,7 +332,7 @@ func createVRFJobs(t *testing.T, keys []ethkey.KeyV2, app *cltest.TestApplicatio
 				count++
 			}
 		}
-		return count == len(keys)
+		return count == len(fromKeys)
 	}, cltest.WaitTimeout(t), 100*time.Millisecond).Should(gomega.BeTrue())
 	// Unfortunately the lb needs heads to be able to backfill logs to new subscribers.
 	// To avoid confirming
@@ -492,23 +497,29 @@ func TestVRFV2Integration_SingleConsumer_HappyPath(t *testing.T) {
 	subID := subscribeAndAssertSubscriptionCreatedEvent(t, consumerContract, consumer, consumerContractAddress, big.NewInt(5e18), uni)
 
 	// Create gas lane.
-	key, err := app.KeyStore.Eth().Create(big.NewInt(1337))
+	key1, err := app.KeyStore.Eth().Create(big.NewInt(1337))
 	require.NoError(t, err)
-	sendEth(t, ownerKey, uni.backend, key.Address.Address(), 10)
+	key2, err := app.KeyStore.Eth().Create(big.NewInt(1337))
+	require.NoError(t, err)
+	sendEth(t, ownerKey, uni.backend, key1.Address.Address(), 10)
+	sendEth(t, ownerKey, uni.backend, key2.Address.Address(), 10)
 	configureSimChain(t, app, map[string]types.ChainCfg{
-		key.Address.String(): {
+		key1.Address.String(): {
+			EvmMaxGasPriceWei: utils.NewBig(big.NewInt(10e9)), // 10 gwei
+		},
+		key2.Address.String(): {
 			EvmMaxGasPriceWei: utils.NewBig(big.NewInt(10e9)), // 10 gwei
 		},
 	}, big.NewInt(10e9))
 	require.NoError(t, app.Start(testutils.Context(t)))
 
-	// Create VRF job.
-	jbs := createVRFJobs(t, []ethkey.KeyV2{key}, app, uni)
+	// Create VRF job using key1 and key2 on the same gas lane.
+	jbs := createVRFJobs(t, [][]ethkey.KeyV2{{key1, key2}}, app, uni)
 	keyHash := jbs[0].VRFSpec.PublicKey.MustHash()
 
-	// Make the randomness request.
+	// Make the first randomness request.
 	numWords := uint32(20)
-	requestID, _ := requestRandomnessAndAssertRandomWordsRequestedEvent(t, consumerContract, consumer, keyHash, subID, numWords, uni)
+	requestID1, _ := requestRandomnessAndAssertRandomWordsRequestedEvent(t, consumerContract, consumer, keyHash, subID, numWords, uni)
 
 	// Wait for fulfillment to be queued.
 	gomega.NewGomegaWithT(t).Eventually(func() bool {
@@ -519,14 +530,35 @@ func TestVRFV2Integration_SingleConsumer_HappyPath(t *testing.T) {
 		return len(runs) == 1
 	}, cltest.WaitTimeout(t), time.Second).Should(gomega.BeTrue())
 
-	// Mine the fulfillment that was queued.
-	mine(t, requestID, subID, uni, db)
+	// Mine the fulfillments that were queued.
+	mine(t, requestID1, subID, uni, db)
 
 	// Assert correct state of RandomWordsFulfilled event.
-	assertRandomWordsFulfilled(t, requestID, true, uni)
+	assertRandomWordsFulfilled(t, requestID1, true, uni)
 
+	// Make the second randomness request and assert fulfillment is successful
+	requestID2, _ := requestRandomnessAndAssertRandomWordsRequestedEvent(t, consumerContract, consumer, keyHash, subID, numWords, uni)
+	gomega.NewGomegaWithT(t).Eventually(func() bool {
+		uni.backend.Commit()
+		runs, err := app.PipelineORM().GetAllRuns()
+		require.NoError(t, err)
+		t.Log("runs", len(runs))
+		return len(runs) == 2
+	}, cltest.WaitTimeout(t), time.Second).Should(gomega.BeTrue())
+	mine(t, requestID2, subID, uni, db)
+	assertRandomWordsFulfilled(t, requestID2, true, uni)
+	
 	// Assert correct number of random words sent by coordinator.
 	assertNumRandomWords(t, consumerContract, numWords)
+
+	// Assert that both send addresses were used to fulfill the requests
+	n, err := uni.backend.PendingNonceAt(context.Background(), key1.Address.Address())
+	require.NoError(t, err)
+	require.EqualValues(t, 1, n)
+
+	n, err = uni.backend.PendingNonceAt(context.Background(), key2.Address.Address())
+	require.NoError(t, err)
+	require.EqualValues(t, 1, n)
 
 	t.Log("Done!")
 }
@@ -567,7 +599,7 @@ func TestVRFV2Integration_SingleConsumer_NeedsBlockhashStore(t *testing.T) {
 	}, big.NewInt(10e9))
 
 	// Create VRF job.
-	vrfJobs := createVRFJobs(t, []ethkey.KeyV2{vrfKey}, app, uni)
+	vrfJobs := createVRFJobs(t, [][]ethkey.KeyV2{{vrfKey}}, app, uni)
 	keyHash := vrfJobs[0].VRFSpec.PublicKey.MustHash()
 
 	_ = createAndStartBHSJob(
@@ -656,7 +688,7 @@ func TestVRFV2Integration_SingleConsumer_NeedsTopUp(t *testing.T) {
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	// Create VRF job.
-	jbs := createVRFJobs(t, []ethkey.KeyV2{key}, app, uni)
+	jbs := createVRFJobs(t, [][]ethkey.KeyV2{{key}}, app, uni)
 	keyHash := jbs[0].VRFSpec.PublicKey.MustHash()
 
 	numWords := uint32(20)
@@ -728,7 +760,7 @@ func TestVRFV2Integration_SingleConsumer_MultipleGasLanes(t *testing.T) {
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	// Create VRF jobs.
-	jbs := createVRFJobs(t, []ethkey.KeyV2{cheapKey, expensiveKey}, app, uni)
+	jbs := createVRFJobs(t, [][]ethkey.KeyV2{{cheapKey}, {expensiveKey}}, app, uni)
 	cheapHash := jbs[0].VRFSpec.PublicKey.MustHash()
 	expensiveHash := jbs[1].VRFSpec.PublicKey.MustHash()
 
@@ -813,7 +845,7 @@ func TestVRFV2Integration_SingleConsumer_AlwaysRevertingCallback_StillFulfilled(
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	// Create VRF job.
-	jbs := createVRFJobs(t, []ethkey.KeyV2{key}, app, uni)
+	jbs := createVRFJobs(t, [][]ethkey.KeyV2{{key}}, app, uni)
 	keyHash := jbs[0].VRFSpec.PublicKey.MustHash()
 
 	// Make the randomness request.
@@ -1007,7 +1039,7 @@ func TestIntegrationVRFV2(t *testing.T) {
 		CoordinatorAddress:       uni.rootContractAddress.String(),
 		MinIncomingConfirmations: incomingConfs,
 		PublicKey:                vrfkey.PublicKey.String(),
-		FromAddress:              keys[0].Address.String(),
+		FromAddresses:            []string{keys[0].Address.String()},
 		V2:                       true,
 	}).Toml()
 	jb, err := vrf.ValidatedVRFSpec(s)

--- a/core/services/vrf/integration_v2_test.go
+++ b/core/services/vrf/integration_v2_test.go
@@ -530,7 +530,7 @@ func TestVRFV2Integration_SingleConsumer_HappyPath(t *testing.T) {
 		return len(runs) == 1
 	}, cltest.WaitTimeout(t), time.Second).Should(gomega.BeTrue())
 
-	// Mine the fulfillments that were queued.
+	// Mine the fulfillment that was queued.
 	mine(t, requestID1, subID, uni, db)
 
 	// Assert correct state of RandomWordsFulfilled event.
@@ -547,7 +547,7 @@ func TestVRFV2Integration_SingleConsumer_HappyPath(t *testing.T) {
 	}, cltest.WaitTimeout(t), time.Second).Should(gomega.BeTrue())
 	mine(t, requestID2, subID, uni, db)
 	assertRandomWordsFulfilled(t, requestID2, true, uni)
-	
+
 	// Assert correct number of random words sent by coordinator.
 	assertNumRandomWords(t, consumerContract, numWords)
 

--- a/core/services/vrf/listener_v1.go
+++ b/core/services/vrf/listener_v1.go
@@ -382,6 +382,7 @@ func (lsn *listenerV1) ProcessRequest(req request) bool {
 			"externalJobID": lsn.job.ExternalJobID,
 			"name":          lsn.job.Name.ValueOrZero(),
 			"publicKey":     lsn.job.VRFSpec.PublicKey[:],
+			"from":          lsn.fromAddresses(),
 		},
 		"jobRun": map[string]interface{}{
 			"logBlockHash":   req.req.Raw.BlockHash[:],
@@ -449,6 +450,14 @@ func (lsn *listenerV1) HandleLog(lb log.Broadcast) {
 		lsn.l.Error("l mailbox is over capacity - dropped the oldest l")
 		incDroppedReqs(lsn.job.Name.ValueOrZero(), lsn.job.ExternalJobID, v1, reasonMailboxSize)
 	}
+}
+
+func (lsn *listenerV1) fromAddresses() []common.Address {
+	var addresses []common.Address
+	for _, a := range lsn.job.VRFSpec.FromAddresses {
+		addresses = append(addresses, a.Address())
+	}
+	return addresses
 }
 
 // Job complies with log.Listener

--- a/core/services/vrf/listener_v2.go
+++ b/core/services/vrf/listener_v2.go
@@ -330,7 +330,7 @@ func (lsn *listenerV2) processRequestsPerSub(
 	for _, req := range reqs {
 		fromAddress, err := lsn.gethks.GetRoundRobinAddress(lsn.fromAddresses()...)
 		if err != nil {
-			lggr.Errorw("Couldn't get next from address", "error", err)
+			lggr.Errorw("Couldn't get next from address", "err", err)
 			continue
 		}
 		maxGasPriceWei := lsn.cfg.KeySpecificMaxGasPriceWei(fromAddress)

--- a/core/services/vrf/listener_v2_test.go
+++ b/core/services/vrf/listener_v2_test.go
@@ -88,19 +88,19 @@ func TestMaybeSubtractReservedLink(t *testing.T) {
 
 	// Insert an unstarted eth tx with link metadata
 	addEthTx(t, db, k.Address.Address(), txmgr.EthTxUnstarted, "10000", subID)
-	start, err := MaybeSubtractReservedLink(lggr, q, k.Address.Address(), big.NewInt(100_000), chainID, subID)
+	start, err := MaybeSubtractReservedLink(lggr, q, big.NewInt(100_000), chainID, subID)
 	require.NoError(t, err)
 	assert.Equal(t, "90000", start.String())
 
 	// A confirmed tx should not affect the starting balance
 	addConfirmedEthTx(t, db, k.Address.Address(), "10000", subID, 1)
-	start, err = MaybeSubtractReservedLink(lggr, q, k.Address.Address(), big.NewInt(100_000), chainID, subID)
+	start, err = MaybeSubtractReservedLink(lggr, q, big.NewInt(100_000), chainID, subID)
 	require.NoError(t, err)
 	assert.Equal(t, "90000", start.String())
 
 	// An unconfirmed tx _should_ affect the starting balance.
 	addEthTx(t, db, k.Address.Address(), txmgr.EthTxUnstarted, "10000", subID)
-	start, err = MaybeSubtractReservedLink(lggr, q, k.Address.Address(), big.NewInt(100_000), chainID, subID)
+	start, err = MaybeSubtractReservedLink(lggr, q, big.NewInt(100_000), chainID, subID)
 	require.NoError(t, err)
 	assert.Equal(t, "80000", start.String())
 
@@ -108,7 +108,7 @@ func TestMaybeSubtractReservedLink(t *testing.T) {
 	otherSubID := uint64(2)
 	require.NoError(t, err)
 	addEthTx(t, db, k.Address.Address(), txmgr.EthTxUnstarted, "10000", otherSubID)
-	start, err = MaybeSubtractReservedLink(lggr, q, k.Address.Address(), big.NewInt(100_000), chainID, subID)
+	start, err = MaybeSubtractReservedLink(lggr, q, big.NewInt(100_000), chainID, subID)
 	require.NoError(t, err)
 	require.Equal(t, "80000", start.String())
 
@@ -118,14 +118,14 @@ func TestMaybeSubtractReservedLink(t *testing.T) {
 
 	anotherSubID := uint64(3)
 	addEthTx(t, db, k2.Address.Address(), txmgr.EthTxUnstarted, "10000", anotherSubID)
-	start, err = MaybeSubtractReservedLink(lggr, q, k.Address.Address(), big.NewInt(100_000), chainID, subID)
+	start, err = MaybeSubtractReservedLink(lggr, q, big.NewInt(100_000), chainID, subID)
 	require.NoError(t, err)
 	require.Equal(t, "80000", start.String())
 
 	// A subscriber's balance is deducted with the link reserved across multiple keys,
 	// i.e, gas lanes.
 	addEthTx(t, db, k2.Address.Address(), txmgr.EthTxUnstarted, "10000", subID)
-	start, err = MaybeSubtractReservedLink(lggr, q, k2.Address.Address(), big.NewInt(100_000), chainID, subID)
+	start, err = MaybeSubtractReservedLink(lggr, q, big.NewInt(100_000), chainID, subID)
 	require.NoError(t, err)
 	require.Equal(t, "70000", start.String())
 }

--- a/core/store/migrate/migrations/0107_vrf_multiple_from_addresses.sql
+++ b/core/store/migrate/migrations/0107_vrf_multiple_from_addresses.sql
@@ -1,0 +1,15 @@
+-- +goose Up
+ALTER TABLE vrf_specs ADD COLUMN from_addresses bytea[] DEFAULT '{}' NOT NULL ;
+
+UPDATE vrf_specs SET from_addresses = from_addresses || from_address
+WHERE from_address IS NOT NULL;
+
+ALTER TABLE vrf_specs DROP COLUMN from_address;
+
+-- +goose Down
+ALTER TABLE vrf_specs ADD COLUMN from_address bytea;
+
+UPDATE vrf_specs SET from_address = from_addresses[1]
+WHERE array_length(from_addresses, 1) > 0;
+
+ALTER TABLE vrf_specs DROP COLUMN from_addresses;

--- a/core/testdata/testspecs/v2_specs.go
+++ b/core/testdata/testspecs/v2_specs.go
@@ -243,7 +243,7 @@ type VRFSpecParams struct {
 	Name                     string
 	CoordinatorAddress       string
 	MinIncomingConfirmations int
-	FromAddress              string
+	FromAddresses            []string
 	PublicKey                string
 	ObservationSource        string
 	RequestedConfsDelay      int
@@ -301,6 +301,7 @@ encode_tx    [type=ethabiencode
 submit_tx  [type=ethtx to="%s"
             data="$(encode_tx)"
             minConfirmations="0"
+            from="$(jobSpec.from)"
             txMeta="{\\"requestTxHash\\": $(jobRun.logTxHash),\\"requestID\\": $(decode_log.requestID),\\"jobID\\": $(jobSpec.databaseID)}"
             transmitChecker="{\\"CheckerType\\": \\"vrf_v1\\", \\"VRFCoordinatorAddress\\": \\"%s\\"}"]
 decode_log->vrf->encode_tx->submit_tx
@@ -349,8 +350,12 @@ observationSource = """
 `
 	toml := fmt.Sprintf(template, jobID, name, coordinatorAddress, confirmations, params.RequestedConfsDelay,
 		requestTimeout.String(), publicKey, observationSource)
-	if params.FromAddress != "" {
-		toml = toml + "\n" + fmt.Sprintf(`fromAddress = "%s"`, params.FromAddress)
+	if len(params.FromAddresses) != 0 {
+		var addresses []string
+		for _, address := range params.FromAddresses {
+			addresses = append(addresses, fmt.Sprintf("%q", address))
+		}
+		toml = toml + "\n" + fmt.Sprintf(`fromAddresses = [%s]`, strings.Join(addresses, ", "))
 	}
 
 	return VRFSpec{VRFSpecParams: VRFSpecParams{

--- a/core/web/presenters/job.go
+++ b/core/web/presenters/job.go
@@ -276,21 +276,21 @@ func NewCronSpec(spec *job.CronSpec) *CronSpec {
 }
 
 type VRFSpec struct {
-	CoordinatorAddress       ethkey.EIP55Address  `json:"coordinatorAddress"`
-	PublicKey                secp256k1.PublicKey  `json:"publicKey"`
-	FromAddress              *ethkey.EIP55Address `json:"fromAddress"`
-	PollPeriod               models.Duration      `json:"pollPeriod"`
-	MinIncomingConfirmations uint32               `json:"confirmations"`
-	CreatedAt                time.Time            `json:"createdAt"`
-	UpdatedAt                time.Time            `json:"updatedAt"`
-	EVMChainID               *utils.Big           `json:"evmChainID"`
+	CoordinatorAddress       ethkey.EIP55Address   `json:"coordinatorAddress"`
+	PublicKey                secp256k1.PublicKey   `json:"publicKey"`
+	FromAddresses            []ethkey.EIP55Address `json:"fromAddresses"`
+	PollPeriod               models.Duration       `json:"pollPeriod"`
+	MinIncomingConfirmations uint32                `json:"confirmations"`
+	CreatedAt                time.Time             `json:"createdAt"`
+	UpdatedAt                time.Time             `json:"updatedAt"`
+	EVMChainID               *utils.Big            `json:"evmChainID"`
 }
 
 func NewVRFSpec(spec *job.VRFSpec) *VRFSpec {
 	return &VRFSpec{
 		CoordinatorAddress:       spec.CoordinatorAddress,
 		PublicKey:                spec.PublicKey,
-		FromAddress:              spec.FromAddress,
+		FromAddresses:            spec.FromAddresses,
 		PollPeriod:               models.MustMakeDuration(spec.PollPeriod),
 		MinIncomingConfirmations: spec.MinIncomingConfirmations,
 		CreatedAt:                spec.CreatedAt,

--- a/core/web/resolver/spec.go
+++ b/core/web/resolver/spec.go
@@ -619,14 +619,17 @@ func (r *VRFSpecResolver) EVMChainID() *string {
 	return &chainID
 }
 
-// FromAddress resolves the spec's from address.
-func (r *VRFSpecResolver) FromAddress() *string {
-	if r.spec.FromAddress == nil {
+// FromAddresses resolves the spec's from addresses.
+func (r *VRFSpecResolver) FromAddresses() *[]string {
+	if len(r.spec.FromAddresses) == 0 {
 		return nil
 	}
 
-	addr := r.spec.FromAddress.String()
-	return &addr
+	var addresses []string
+	for _, a := range r.spec.FromAddresses {
+		addresses = append(addresses, a.Address().String())
+	}
+	return &addresses
 }
 
 // PollPeriod resolves the spec's poll period.

--- a/core/web/resolver/spec_test.go
+++ b/core/web/resolver/spec_test.go
@@ -582,7 +582,10 @@ func TestResolver_VRFSpec(t *testing.T) {
 	coordinatorAddress, err := ethkey.NewEIP55Address("0x613a38AC1659769640aaE063C651F48E0250454C")
 	require.NoError(t, err)
 
-	fromAddress, err := ethkey.NewEIP55Address("0x3cCad4715152693fE3BC4460591e3D3Fbd071b42")
+	fromAddress1, err := ethkey.NewEIP55Address("0x3cCad4715152693fE3BC4460591e3D3Fbd071b42")
+	require.NoError(t, err)
+
+	fromAddress2, err := ethkey.NewEIP55Address("0x2301958F1BFbC9A068C2aC9c6166Bf483b95864C")
 	require.NoError(t, err)
 
 	pubKey, err := secp256k1.NewPublicKeyFromHex("0x9dc09a0f898f3b5e8047204e7ce7e44b587920932f08431e29c9bf6923b8450a01")
@@ -601,7 +604,7 @@ func TestResolver_VRFSpec(t *testing.T) {
 						CoordinatorAddress:       coordinatorAddress,
 						CreatedAt:                f.Timestamp(),
 						EVMChainID:               utils.NewBigI(42),
-						FromAddress:              &fromAddress,
+						FromAddresses:            []ethkey.EIP55Address{fromAddress1, fromAddress2},
 						PollPeriod:               1 * time.Minute,
 						PublicKey:                pubKey,
 						RequestedConfsDelay:      10,
@@ -619,7 +622,7 @@ func TestResolver_VRFSpec(t *testing.T) {
 									coordinatorAddress
 									createdAt
 									evmChainID
-									fromAddress
+									fromAddresses
 									minIncomingConfirmations
 									pollPeriod
 									publicKey
@@ -639,7 +642,7 @@ func TestResolver_VRFSpec(t *testing.T) {
 							"coordinatorAddress": "0x613a38AC1659769640aaE063C651F48E0250454C",
 							"createdAt": "2021-01-01T00:00:00Z",
 							"evmChainID": "42",
-							"fromAddress": "0x3cCad4715152693fE3BC4460591e3D3Fbd071b42",
+							"fromAddresses": ["0x3cCad4715152693fE3BC4460591e3D3Fbd071b42", "0x2301958F1BFbC9A068C2aC9c6166Bf483b95864C"],
 							"minIncomingConfirmations": 1,
 							"pollPeriod": "1m0s",
 							"publicKey": "0x9dc09a0f898f3b5e8047204e7ce7e44b587920932f08431e29c9bf6923b8450a01",

--- a/core/web/schema/type/spec.graphql
+++ b/core/web/schema/type/spec.graphql
@@ -94,7 +94,7 @@ type VRFSpec {
     coordinatorAddress: String!
     createdAt: Time!
     evmChainID: String
-    fromAddress: String
+    fromAddresses: [String!]
     minIncomingConfirmations: Int!
     minIncomingConfirmationsEnv: Boolean!
     pollPeriod: String!

--- a/operator_ui/src/screens/Job/JobView.tsx
+++ b/operator_ui/src/screens/Job/JobView.tsx
@@ -83,7 +83,7 @@ const JOB_PAYLOAD__SPEC = gql`
     ... on VRFSpec {
       evmChainID
       coordinatorAddress
-      fromAddress
+      fromAddresses
       minIncomingConfirmations
       minIncomingConfirmationsEnv
       pollPeriod

--- a/operator_ui/src/screens/Job/generateJobDefinition.test.ts
+++ b/operator_ui/src/screens/Job/generateJobDefinition.test.ts
@@ -418,7 +418,7 @@ juelsPerFeeCoinSource = "1000000000"
         __typename: 'VRFSpec',
         coordinatorAddress: '0x0000000000000000000000000000000000000000',
         evmChainID: '42',
-        fromAddress: '',
+        fromAddresses: ['0x3cCad4715152693fE3BC4460591e3D3Fbd071b42'],
         minIncomingConfirmations: 6,
         minIncomingConfirmationsEnv: false,
         pollPeriod: '10s',
@@ -437,7 +437,7 @@ name = "vrf job"
 externalJobID = "00000000-0000-0000-0000-0000000000001"
 coordinatorAddress = "0x0000000000000000000000000000000000000000"
 evmChainID = "42"
-fromAddress = ""
+fromAddresses = [ "0x3cCad4715152693fE3BC4460591e3D3Fbd071b42" ]
 minIncomingConfirmations = 6
 pollPeriod = "10s"
 publicKey = "0x92594ee04c179eb7d439ff1baacd98b81a7d7a6ed55c86ca428fa025bd9c914301"

--- a/operator_ui/src/screens/Job/generateJobDefinition.ts
+++ b/operator_ui/src/screens/Job/generateJobDefinition.ts
@@ -199,7 +199,7 @@ export const generateJobDefinition = (
           job.spec,
           'coordinatorAddress',
           'evmChainID',
-          'fromAddress',
+          'fromAddresses',
           'minIncomingConfirmations',
           'pollPeriod',
           'publicKey',


### PR DESCRIPTION
Update VRF V1 and V2 job specs to accept mulitple from addresses.
When enqueing fulfillments, we will round robin between them. The
goal of this is to increase throughput for VRF fulfillments on V1
and V2.