### PR TITLE
core/services/pq: for slow sql queries, log the full query

### DIFF
--- a/core/services/pg/q_test.go
+++ b/core/services/pg/q_test.go
@@ -1,0 +1,36 @@
+package pg
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_sprintQ(t *testing.T) {
+	for _, tt := range []struct {
+		name  string
+		query string
+		args  []interface{}
+		exp   string
+	}{
+		{"none",
+			"SELECT * FROM table;",
+			nil,
+			"SELECT * FROM table;"},
+		{"one",
+			"SELECT $1 FROM table;",
+			[]interface{}{"foo"},
+			"SELECT foo FROM table;"},
+		{"two",
+			"SELECT $1 FROM table WHERE bar = $2;",
+			[]interface{}{"foo", 1},
+			"SELECT foo FROM table WHERE bar = 1;"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sprintQ(tt.query, tt.args)
+			t.Log(tt.query, tt.args)
+			t.Log(got)
+			require.Equal(t, tt.exp, got)
+		})
+	}
+}


### PR DESCRIPTION
I saw some `SLOW SQL QUERY` logs and noticed we aren't including _which_ query was slow.