### PR TITLE
Respect chain ID in GetRoundRobin keys

### DIFF
--- a/core/chains/evm/monitor/balance.go
+++ b/core/chains/evm/monitor/balance.go
@@ -164,7 +164,7 @@ func (w *worker) Work() {
 }
 
 func (w *worker) WorkCtx(ctx context.Context) {
-	keys, err := w.bm.ethKeyStore.SendingKeys()
+	keys, err := w.bm.ethKeyStore.SendingKeys(nil)
 	if err != nil {
 		w.bm.logger.Error("BalanceMonitor: error getting keys", err)
 	}

--- a/core/chains/evm/txmgr/eth_confirmer_test.go
+++ b/core/chains/evm/txmgr/eth_confirmer_test.go
@@ -2236,7 +2236,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WhenOutOfEth(t *testing.T) {
 
 	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
 
-	keys, err := ethKeyStore.SendingKeys()
+	keys, err := ethKeyStore.SendingKeys(nil)
 	require.NoError(t, err)
 	keyStates, err := ethKeyStore.GetStatesForKeys(keys)
 	require.NoError(t, err)

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -1510,7 +1510,7 @@ func AssertRecordEventually(t *testing.T, db *sqlx.DB, model interface{}, stmt s
 }
 
 func MustSendingKeyStates(t *testing.T, ethKeyStore keystore.Eth) []ethkey.State {
-	keys, err := ethKeyStore.SendingKeys()
+	keys, err := ethKeyStore.SendingKeys(nil)
 	require.NoError(t, err)
 	states, err := ethKeyStore.GetStatesForKeys(keys)
 	require.NoError(t, err)

--- a/core/internal/features_ocr2_test.go
+++ b/core/internal/features_ocr2_test.go
@@ -113,7 +113,7 @@ func setupNodeOCR2(t *testing.T, owner *bind.TransactOpts, port uint16, dbName s
 
 	config.Overrides.P2PPeerID = peerID
 
-	sendingKeys, err := app.KeyStore.Eth().SendingKeys()
+	sendingKeys, err := app.KeyStore.Eth().SendingKeys(nil)
 	require.NoError(t, err)
 	require.Len(t, sendingKeys, 1)
 	transmitter := sendingKeys[0].Address.Address()

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -352,7 +352,7 @@ func TestIntegration_DirectRequest(t *testing.T) {
 			b := operatorContracts.sim
 			app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, b)
 
-			sendingKeys, err := app.KeyStore.Eth().SendingKeys()
+			sendingKeys, err := app.KeyStore.Eth().SendingKeys(nil)
 			require.NoError(t, err)
 			authorizedSenders := []common.Address{sendingKeys[0].Address.Address()}
 			tx, err := operatorContracts.operator.SetAuthorizedSenders(operatorContracts.user, authorizedSenders)
@@ -531,7 +531,7 @@ func setupNode(t *testing.T, owner *bind.TransactOpts, portV1, portV2 int, dbNam
 		config.Overrides.P2PV2ListenAddresses = []string{fmt.Sprintf("127.0.0.1:%d", portV2)}
 	}
 
-	sendingKeys, err := app.KeyStore.Eth().SendingKeys()
+	sendingKeys, err := app.KeyStore.Eth().SendingKeys(nil)
 	require.NoError(t, err)
 	transmitter := sendingKeys[0].Address.Address()
 
@@ -895,7 +895,7 @@ func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 }
 
 func triggerAllKeys(t *testing.T, app *cltest.TestApplication) {
-	keys, err := app.KeyStore.Eth().SendingKeys()
+	keys, err := app.KeyStore.Eth().SendingKeys(nil)
 	require.NoError(t, err)
 	// FIXME: This is a hack. Remove after https://app.clubhouse.io/chainlinklabs/story/15103/use-in-memory-event-broadcaster-instead-of-postgres-event-broadcaster-in-transactional-tests-so-it-actually-works
 	for _, chain := range app.GetChains().EVM.Chains() {

--- a/core/internal/testutils/testutils.go
+++ b/core/internal/testutils/testutils.go
@@ -32,6 +32,9 @@ import (
 // "test" chain ID to be used without clashes
 var FixtureChainID = big.NewInt(0)
 
+// SimulatedChainID is the chain ID for the go-ethereum simulated backend
+var SimulatedChainID = big.NewInt(1337)
+
 // NewAddress return a random new address
 func NewAddress() common.Address {
 	return common.BytesToAddress(randomBytes(20))

--- a/core/services/blockhashstore/delegate.go
+++ b/core/services/blockhashstore/delegate.go
@@ -63,7 +63,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 			chain.Config().EvmFinalityDepth(), jb.BlockhashStoreSpec.WaitBlocks)
 	}
 
-	keys, err := d.ks.SendingKeys()
+	keys, err := d.ks.SendingKeys(chain.ID())
 	if err != nil {
 		return nil, errors.Wrap(err, "getting sending keys")
 	}

--- a/core/services/feeds/proto/feeds_manager.pb.go
+++ b/core/services/feeds/proto/feeds_manager.pb.go
@@ -7,10 +7,11 @@
 package proto
 
 import (
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
+
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -179,7 +179,7 @@ func (s *service) SyncNodeInfo(id int64) error {
 	}
 
 	// Assemble EVM keys
-	evmKeys, err := s.ethKeyStore.SendingKeys()
+	evmKeys, err := s.ethKeyStore.SendingKeys(nil)
 	if err != nil {
 		return err
 	}

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/hex"
+	"math/big"
 	"testing"
 	"time"
 
@@ -450,7 +451,7 @@ func Test_Service_SyncNodeInfo(t *testing.T) {
 
 	// Mock fetching the information to send
 	svc.orm.On("GetManager", feedsMgr.ID).Return(feedsMgr, nil)
-	svc.ethKeystore.On("SendingKeys").Return(evmKeys, nil)
+	svc.ethKeystore.On("SendingKeys", (*big.Int)(nil)).Return(evmKeys, nil)
 	svc.ethKeystore.
 		On("GetStatesForKeys", evmKeys).
 		Return([]ethkey.State{{Address: sendingKey.Address, EVMChainID: *utils.NewBigI(42)}}, nil)

--- a/core/services/fluxmonitorv2/contract_submitter.go
+++ b/core/services/fluxmonitorv2/contract_submitter.go
@@ -46,7 +46,7 @@ func NewFluxAggregatorContractSubmitter(
 // Submit submits the answer by writing a EthTx for the txmgr to
 // pick up
 func (c *FluxAggregatorContractSubmitter) Submit(roundID *big.Int, submission *big.Int, qopts ...pg.QOpt) error {
-	fromAddress, err := c.keyStore.GetRoundRobinAddress()
+	fromAddress, err := c.keyStore.GetRoundRobinAddress(nil) // FIXME: FluxMonitor probably not compatible with multichain here: https://app.shortcut.com/chainlinklabs/story/34394/fluxmonitor-is-probably-not-compatible-with-multichain
 	if err != nil {
 		return err
 	}

--- a/core/services/fluxmonitorv2/flux_monitor.go
+++ b/core/services/fluxmonitorv2/flux_monitor.go
@@ -452,7 +452,7 @@ func (fm *FluxMonitor) SetOracleAddress() error {
 		fm.logger.Error("failed to get list of oracles from FluxAggregator contract")
 		return errors.Wrap(err, "failed to get list of oracles from FluxAggregator contract")
 	}
-	keys, err := fm.keyStore.SendingKeys()
+	keys, err := fm.keyStore.SendingKeys(nil) // FIXME: FluxMonitor is probably not compatible with multichain here
 	if err != nil {
 		return errors.Wrap(err, "failed to load keys")
 	}

--- a/core/services/fluxmonitorv2/flux_monitor_test.go
+++ b/core/services/fluxmonitorv2/flux_monitor_test.go
@@ -379,7 +379,7 @@ func TestFluxMonitor_PollIfEligible(t *testing.T) {
 
 			fm, tm := setup(t, db)
 
-			tm.keyStore.On("SendingKeys").Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+			tm.keyStore.On("SendingKeys", (*big.Int)(nil)).Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 			tm.logBroadcaster.On("IsConnected").Return(tc.connected).Once()
 
 			// Setup Answers
@@ -529,7 +529,7 @@ func TestFluxMonitor_PollIfEligible_Creates_JobErr(t *testing.T) {
 
 	fm, tm := setup(t, db)
 
-	tm.keyStore.On("SendingKeys").Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+	tm.keyStore.On("SendingKeys", (*big.Int)(nil)).Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 	tm.logBroadcaster.On("IsConnected").Return(true).Once()
 
 	tm.jobORM.
@@ -581,7 +581,7 @@ func TestPollingDeviationChecker_BuffersLogs(t *testing.T) {
 	readyToFillQueue := cltest.NewAwaiter()
 	logsAwaiter := cltest.NewAwaiter()
 
-	tm.keyStore.On("SendingKeys").Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+	tm.keyStore.On("SendingKeys", (*big.Int)(nil)).Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 
 	tm.fluxAggregator.On("Address").Return(common.Address{})
 	tm.fluxAggregator.On("LatestRoundData", nilOpts).Return(freshContractRoundDataResponse()).Maybe()
@@ -777,7 +777,7 @@ func TestFluxMonitor_TriggerIdleTimeThreshold(t *testing.T) {
 
 			fm, tm := setup(t, db, disablePollTicker(true), disableIdleTimer(tc.idleTimerDisabled), setIdleTimerPeriod(tc.idleDuration), withORM(orm))
 
-			tm.keyStore.On("SendingKeys").Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+			tm.keyStore.On("SendingKeys", (*big.Int)(nil)).Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 
 			const fetchedAnswer = 100
 			answerBigInt := big.NewInt(fetchedAnswer)
@@ -857,7 +857,7 @@ func TestFluxMonitor_HibernationTickerFiresMultipleTimes(t *testing.T) {
 		setHibernationState(true),
 	)
 
-	tm.keyStore.On("SendingKeys").Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+	tm.keyStore.On("SendingKeys", (*big.Int)(nil)).Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 
 	const fetchedAnswer = 100
 	answerBigInt := big.NewInt(fetchedAnswer)
@@ -960,7 +960,7 @@ func TestFluxMonitor_HibernationIsEnteredAndRetryTickerStopped(t *testing.T) {
 		setFlags(flags),
 	)
 
-	tm.keyStore.On("SendingKeys").Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+	tm.keyStore.On("SendingKeys", (*big.Int)(nil)).Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 
 	const fetchedAnswer = 100
 	answerBigInt := big.NewInt(fetchedAnswer)
@@ -1071,7 +1071,7 @@ func TestFluxMonitor_IdleTimerResetsOnNewRound(t *testing.T) {
 		setIdleTimerPeriod(2*time.Second),
 	)
 
-	tm.keyStore.On("SendingKeys").Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+	tm.keyStore.On("SendingKeys", (*big.Int)(nil)).Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 
 	const fetchedAnswer = 100
 	answerBigInt := big.NewInt(fetchedAnswer)
@@ -1179,7 +1179,7 @@ func TestFluxMonitor_RoundTimeoutCausesPoll_timesOutAtZero(t *testing.T) {
 	fm, tm := setup(t, db, disablePollTicker(true), disableIdleTimer(true), withORM(orm))
 
 	tm.keyStore.
-		On("SendingKeys").
+		On("SendingKeys", (*big.Int)(nil)).
 		Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).
 		Twice() // Once called from the test, once during start
 
@@ -1243,7 +1243,7 @@ func TestFluxMonitor_UsesPreviousRoundStateOnStartup_RoundTimeout(t *testing.T) 
 
 			fm, tm := setup(t, db, disablePollTicker(true), disableIdleTimer(true), withORM(orm))
 
-			tm.keyStore.On("SendingKeys").Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+			tm.keyStore.On("SendingKeys", (*big.Int)(nil)).Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 
 			tm.logBroadcaster.On("Register", mock.Anything, mock.Anything).Return(func() {})
 			tm.logBroadcaster.On("IsConnected").Return(true).Maybe()
@@ -1319,7 +1319,7 @@ func TestFluxMonitor_UsesPreviousRoundStateOnStartup_IdleTimer(t *testing.T) {
 			)
 			initialPollOccurred := make(chan struct{}, 1)
 
-			tm.keyStore.On("SendingKeys").Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+			tm.keyStore.On("SendingKeys", (*big.Int)(nil)).Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 			tm.logBroadcaster.On("Register", mock.Anything, mock.Anything).Return(func() {})
 			tm.logBroadcaster.On("IsConnected").Return(true).Maybe()
 			tm.fluxAggregator.On("Address").Return(common.Address{})
@@ -1379,7 +1379,7 @@ func TestFluxMonitor_RoundTimeoutCausesPoll_timesOutNotZero(t *testing.T) {
 
 	fm, tm := setup(t, db, disablePollTicker(true), disableIdleTimer(true), withORM(orm))
 
-	tm.keyStore.On("SendingKeys").Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+	tm.keyStore.On("SendingKeys", (*big.Int)(nil)).Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 
 	const fetchedAnswer = 100
 	answerBigInt := big.NewInt(fetchedAnswer)
@@ -1517,7 +1517,7 @@ func TestFluxMonitor_DoesNotDoubleSubmit(t *testing.T) {
 			answer       = 100
 		)
 
-		tm.keyStore.On("SendingKeys").Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+		tm.keyStore.On("SendingKeys", (*big.Int)(nil)).Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 		tm.logBroadcaster.On("IsConnected").Return(true).Maybe()
 
 		// Mocks initiated by the New Round log
@@ -1631,7 +1631,7 @@ func TestFluxMonitor_DoesNotDoubleSubmit(t *testing.T) {
 			roundID = 3
 			answer  = 100
 		)
-		tm.keyStore.On("SendingKeys").Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+		tm.keyStore.On("SendingKeys", (*big.Int)(nil)).Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 		tm.logBroadcaster.On("IsConnected").Return(true).Maybe()
 
 		// First, force the node to try to poll, which should result in a submission
@@ -1727,7 +1727,7 @@ func TestFluxMonitor_DoesNotDoubleSubmit(t *testing.T) {
 			roundID      = 3
 			answer       = 100
 		)
-		tm.keyStore.On("SendingKeys").Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
+		tm.keyStore.On("SendingKeys", (*big.Int)(nil)).Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil).Once()
 		tm.logBroadcaster.On("IsConnected").Return(true).Maybe()
 
 		// First, force the node to try to poll, which should result in a submission
@@ -1875,7 +1875,7 @@ func TestFluxMonitor_DrumbeatTicker(t *testing.T) {
 
 	fm, tm := setup(t, db, disablePollTicker(true), disableIdleTimer(true), enableDrumbeatTicker("@every 3s", 2*time.Second))
 
-	tm.keyStore.On("SendingKeys").Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil)
+	tm.keyStore.On("SendingKeys", (*big.Int)(nil)).Return([]ethkey.KeyV2{{Address: ethkey.EIP55AddressFromAddress(nodeAddr)}}, nil)
 
 	const fetchedAnswer = 100
 	answerBigInt := big.NewInt(fetchedAnswer)

--- a/core/services/fluxmonitorv2/key_store.go
+++ b/core/services/fluxmonitorv2/key_store.go
@@ -1,6 +1,8 @@
 package fluxmonitorv2
 
 import (
+	"math/big"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
@@ -10,8 +12,8 @@ import (
 
 // KeyStoreInterface defines an interface to interact with the keystore
 type KeyStoreInterface interface {
-	SendingKeys() ([]ethkey.KeyV2, error)
-	GetRoundRobinAddress(...common.Address) (common.Address, error)
+	SendingKeys(chainID *big.Int) ([]ethkey.KeyV2, error)
+	GetRoundRobinAddress(chainID *big.Int, addrs ...common.Address) (common.Address, error)
 }
 
 // KeyStore implements KeyStoreInterface

--- a/core/services/fluxmonitorv2/key_store_test.go
+++ b/core/services/fluxmonitorv2/key_store_test.go
@@ -1,9 +1,11 @@
 package fluxmonitorv2_test
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2"
 	"github.com/stretchr/testify/require"
@@ -18,13 +20,24 @@ func TestKeyStore_SendingKeys(t *testing.T) {
 
 	ks := fluxmonitorv2.NewKeyStore(ethKeyStore)
 
-	key, err := ethKeyStore.Create(&cltest.FixtureChainID)
+	key, err := ethKeyStore.Create(testutils.FixtureChainID)
+	require.NoError(t, err)
+	key2, err := ethKeyStore.Create(big.NewInt(1337))
 	require.NoError(t, err)
 
-	keys, err := ks.SendingKeys()
+	keys, err := ks.SendingKeys(testutils.FixtureChainID)
 	require.NoError(t, err)
 	require.Len(t, keys, 1)
 	require.Equal(t, key, keys[0])
+
+	keys, err = ks.SendingKeys(big.NewInt(1337))
+	require.NoError(t, err)
+	require.Len(t, keys, 1)
+	require.Equal(t, key2, keys[0])
+
+	keys, err = ks.SendingKeys(nil)
+	require.NoError(t, err)
+	require.Len(t, keys, 2)
 }
 
 func TestKeyStore_GetRoundRobinAddress(t *testing.T) {
@@ -39,7 +52,7 @@ func TestKeyStore_GetRoundRobinAddress(t *testing.T) {
 	ks := fluxmonitorv2.NewKeyStore(ethKeyStore)
 
 	// Gets the only address in the keystore
-	addr, err := ks.GetRoundRobinAddress()
+	addr, err := ks.GetRoundRobinAddress(nil)
 	require.NoError(t, err)
 	require.Equal(t, k0Address, addr)
 }

--- a/core/services/fluxmonitorv2/mocks/key_store_interface.go
+++ b/core/services/fluxmonitorv2/mocks/key_store_interface.go
@@ -3,6 +3,8 @@
 package mocks
 
 import (
+	big "math/big"
+
 	common "github.com/ethereum/go-ethereum/common"
 	ethkey "github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
 
@@ -14,19 +16,20 @@ type KeyStoreInterface struct {
 	mock.Mock
 }
 
-// GetRoundRobinAddress provides a mock function with given fields: _a0
-func (_m *KeyStoreInterface) GetRoundRobinAddress(_a0 ...common.Address) (common.Address, error) {
-	_va := make([]interface{}, len(_a0))
-	for _i := range _a0 {
-		_va[_i] = _a0[_i]
+// GetRoundRobinAddress provides a mock function with given fields: chainID, addrs
+func (_m *KeyStoreInterface) GetRoundRobinAddress(chainID *big.Int, addrs ...common.Address) (common.Address, error) {
+	_va := make([]interface{}, len(addrs))
+	for _i := range addrs {
+		_va[_i] = addrs[_i]
 	}
 	var _ca []interface{}
+	_ca = append(_ca, chainID)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
 	var r0 common.Address
-	if rf, ok := ret.Get(0).(func(...common.Address) common.Address); ok {
-		r0 = rf(_a0...)
+	if rf, ok := ret.Get(0).(func(*big.Int, ...common.Address) common.Address); ok {
+		r0 = rf(chainID, addrs...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(common.Address)
@@ -34,8 +37,8 @@ func (_m *KeyStoreInterface) GetRoundRobinAddress(_a0 ...common.Address) (common
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(...common.Address) error); ok {
-		r1 = rf(_a0...)
+	if rf, ok := ret.Get(1).(func(*big.Int, ...common.Address) error); ok {
+		r1 = rf(chainID, addrs...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -43,13 +46,13 @@ func (_m *KeyStoreInterface) GetRoundRobinAddress(_a0 ...common.Address) (common
 	return r0, r1
 }
 
-// SendingKeys provides a mock function with given fields:
-func (_m *KeyStoreInterface) SendingKeys() ([]ethkey.KeyV2, error) {
-	ret := _m.Called()
+// SendingKeys provides a mock function with given fields: chainID
+func (_m *KeyStoreInterface) SendingKeys(chainID *big.Int) ([]ethkey.KeyV2, error) {
+	ret := _m.Called(chainID)
 
 	var r0 []ethkey.KeyV2
-	if rf, ok := ret.Get(0).(func() []ethkey.KeyV2); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*big.Int) []ethkey.KeyV2); ok {
+		r0 = rf(chainID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]ethkey.KeyV2)
@@ -57,8 +60,8 @@ func (_m *KeyStoreInterface) SendingKeys() ([]ethkey.KeyV2, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*big.Int) error); ok {
+		r1 = rf(chainID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/keystore/mocks/eth.go
+++ b/core/services/keystore/mocks/eth.go
@@ -180,19 +180,20 @@ func (_m *Eth) GetAll() ([]ethkey.KeyV2, error) {
 	return r0, r1
 }
 
-// GetRoundRobinAddress provides a mock function with given fields: addresses
-func (_m *Eth) GetRoundRobinAddress(addresses ...common.Address) (common.Address, error) {
+// GetRoundRobinAddress provides a mock function with given fields: chainID, addresses
+func (_m *Eth) GetRoundRobinAddress(chainID *big.Int, addresses ...common.Address) (common.Address, error) {
 	_va := make([]interface{}, len(addresses))
 	for _i := range addresses {
 		_va[_i] = addresses[_i]
 	}
 	var _ca []interface{}
+	_ca = append(_ca, chainID)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
 	var r0 common.Address
-	if rf, ok := ret.Get(0).(func(...common.Address) common.Address); ok {
-		r0 = rf(addresses...)
+	if rf, ok := ret.Get(0).(func(*big.Int, ...common.Address) common.Address); ok {
+		r0 = rf(chainID, addresses...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(common.Address)
@@ -200,8 +201,8 @@ func (_m *Eth) GetRoundRobinAddress(addresses ...common.Address) (common.Address
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(...common.Address) error); ok {
-		r1 = rf(addresses...)
+	if rf, ok := ret.Get(1).(func(*big.Int, ...common.Address) error); ok {
+		r1 = rf(chainID, addresses...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -329,13 +330,13 @@ func (_m *Eth) Import(keyJSON []byte, password string, chainID *big.Int) (ethkey
 	return r0, r1
 }
 
-// SendingKeys provides a mock function with given fields:
-func (_m *Eth) SendingKeys() ([]ethkey.KeyV2, error) {
-	ret := _m.Called()
+// SendingKeys provides a mock function with given fields: chainID
+func (_m *Eth) SendingKeys(chainID *big.Int) ([]ethkey.KeyV2, error) {
+	ret := _m.Called(chainID)
 
 	var r0 []ethkey.KeyV2
-	if rf, ok := ret.Get(0).(func() []ethkey.KeyV2); ok {
-		r0 = rf()
+	if rf, ok := ret.Get(0).(func(*big.Int) []ethkey.KeyV2); ok {
+		r0 = rf(chainID)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]ethkey.KeyV2)
@@ -343,8 +344,8 @@ func (_m *Eth) SendingKeys() ([]ethkey.KeyV2, error) {
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func() error); ok {
-		r1 = rf()
+	if rf, ok := ret.Get(1).(func(*big.Int) error); ok {
+		r1 = rf(chainID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/pipeline/mocks/eth_key_store.go
+++ b/core/services/pipeline/mocks/eth_key_store.go
@@ -3,6 +3,8 @@
 package mocks
 
 import (
+	big "math/big"
+
 	common "github.com/ethereum/go-ethereum/common"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -12,19 +14,20 @@ type ETHKeyStore struct {
 	mock.Mock
 }
 
-// GetRoundRobinAddress provides a mock function with given fields: addrs
-func (_m *ETHKeyStore) GetRoundRobinAddress(addrs ...common.Address) (common.Address, error) {
+// GetRoundRobinAddress provides a mock function with given fields: chainID, addrs
+func (_m *ETHKeyStore) GetRoundRobinAddress(chainID *big.Int, addrs ...common.Address) (common.Address, error) {
 	_va := make([]interface{}, len(addrs))
 	for _i := range addrs {
 		_va[_i] = addrs[_i]
 	}
 	var _ca []interface{}
+	_ca = append(_ca, chainID)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
 	var r0 common.Address
-	if rf, ok := ret.Get(0).(func(...common.Address) common.Address); ok {
-		r0 = rf(addrs...)
+	if rf, ok := ret.Get(0).(func(*big.Int, ...common.Address) common.Address); ok {
+		r0 = rf(chainID, addrs...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(common.Address)
@@ -32,8 +35,8 @@ func (_m *ETHKeyStore) GetRoundRobinAddress(addrs ...common.Address) (common.Add
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(...common.Address) error); ok {
-		r1 = rf(addrs...)
+	if rf, ok := ret.Get(1).(func(*big.Int, ...common.Address) error); ok {
+		r1 = rf(chainID, addrs...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/pipeline/task.eth_tx.go
+++ b/core/services/pipeline/task.eth_tx.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"math/big"
 	"reflect"
 	"strconv"
 
@@ -38,7 +39,7 @@ type ETHTxTask struct {
 //go:generate mockery --name ETHKeyStore --output ./mocks/ --case=underscore
 
 type ETHKeyStore interface {
-	GetRoundRobinAddress(addrs ...common.Address) (common.Address, error)
+	GetRoundRobinAddress(chainID *big.Int, addrs ...common.Address) (common.Address, error)
 }
 
 var _ Task = (*ETHTxTask)(nil)
@@ -104,7 +105,7 @@ func (t *ETHTxTask) Run(_ context.Context, lggr logger.Logger, vars Vars, inputs
 		return Result{Error: err}, runInfo
 	}
 
-	fromAddr, err := t.keyStore.GetRoundRobinAddress(fromAddrs...)
+	fromAddr, err := t.keyStore.GetRoundRobinAddress(chain.ID(), fromAddrs...)
 	if err != nil {
 		err = errors.Wrap(err, "ETHTxTask failed to get fromAddress")
 		lggr.Error(err)

--- a/core/services/pipeline/task.eth_tx_test.go
+++ b/core/services/pipeline/task.eth_tx_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	txmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/txmgr/mocks"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
@@ -60,7 +61,7 @@ func TestETHTxTask(t *testing.T) {
 				data := []byte("foobar")
 				gasLimit := uint64(12345)
 				txMeta := &txmgr.EthTxMeta{JobID: 321, RequestID: common.HexToHash("0x5198616554d738d9485d1a7cf53b2f33e09c3bbc8fe9ac0020bd672cd2bc15d2"), RequestTxHash: common.HexToHash("0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8")}
-				keyStore.On("GetRoundRobinAddress", from).Return(from, nil)
+				keyStore.On("GetRoundRobinAddress", testutils.FixtureChainID, from).Return(from, nil)
 				txManager.On("CreateEthTransaction", txmgr.NewTx{
 					FromAddress:    from,
 					ToAddress:      to,
@@ -103,7 +104,7 @@ func TestETHTxTask(t *testing.T) {
 				data := []byte("foobar")
 				gasLimit := uint64(12345)
 				txMeta := &txmgr.EthTxMeta{JobID: 321, RequestID: common.HexToHash("0x5198616554d738d9485d1a7cf53b2f33e09c3bbc8fe9ac0020bd672cd2bc15d2"), RequestTxHash: common.HexToHash("0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8")}
-				keyStore.On("GetRoundRobinAddress", from).Return(from, nil)
+				keyStore.On("GetRoundRobinAddress", testutils.FixtureChainID, from).Return(from, nil)
 				txManager.On("CreateEthTransaction", txmgr.NewTx{
 					FromAddress:    from,
 					ToAddress:      to,
@@ -144,7 +145,7 @@ func TestETHTxTask(t *testing.T) {
 				data := []byte("foobar")
 				gasLimit := uint64(12345)
 				txMeta := &txmgr.EthTxMeta{JobID: 321, RequestID: common.HexToHash("0x5198616554d738d9485d1a7cf53b2f33e09c3bbc8fe9ac0020bd672cd2bc15d2"), RequestTxHash: common.HexToHash("0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8")}
-				keyStore.On("GetRoundRobinAddress", from).Return(from, nil)
+				keyStore.On("GetRoundRobinAddress", testutils.FixtureChainID, from).Return(from, nil)
 				txManager.On("CreateEthTransaction", txmgr.NewTx{
 					FromAddress:    from,
 					ToAddress:      to,
@@ -185,7 +186,7 @@ func TestETHTxTask(t *testing.T) {
 				data := []byte("foobar")
 				gasLimit := uint64(12345)
 				txMeta := &txmgr.EthTxMeta{JobID: 321, RequestID: common.HexToHash("0x5198616554d738d9485d1a7cf53b2f33e09c3bbc8fe9ac0020bd672cd2bc15d2"), RequestTxHash: common.HexToHash("0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8")}
-				keyStore.On("GetRoundRobinAddress").Return(from, nil)
+				keyStore.On("GetRoundRobinAddress", testutils.FixtureChainID).Return(from, nil)
 				txManager.On("CreateEthTransaction", txmgr.NewTx{
 					FromAddress:    from,
 					ToAddress:      to,
@@ -216,7 +217,7 @@ func TestETHTxTask(t *testing.T) {
 				data := []byte("foobar")
 				gasLimit := uint64(12345)
 				txMeta := &txmgr.EthTxMeta{}
-				keyStore.On("GetRoundRobinAddress", from).Return(from, nil)
+				keyStore.On("GetRoundRobinAddress", testutils.FixtureChainID, from).Return(from, nil)
 				txManager.On("CreateEthTransaction", txmgr.NewTx{
 					FromAddress:    from,
 					ToAddress:      to,
@@ -247,7 +248,7 @@ func TestETHTxTask(t *testing.T) {
 				data := []byte("foobar")
 				gasLimit := uint64(999)
 				txMeta := &txmgr.EthTxMeta{JobID: 321, RequestID: common.HexToHash("0x5198616554d738d9485d1a7cf53b2f33e09c3bbc8fe9ac0020bd672cd2bc15d2"), RequestTxHash: common.HexToHash("0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8")}
-				keyStore.On("GetRoundRobinAddress", from).Return(from, nil)
+				keyStore.On("GetRoundRobinAddress", testutils.FixtureChainID, from).Return(from, nil)
 				txManager.On("CreateEthTransaction", txmgr.NewTx{
 					FromAddress:    from,
 					ToAddress:      to,
@@ -283,7 +284,7 @@ func TestETHTxTask(t *testing.T) {
 			nil,
 			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
 				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
-				keyStore.On("GetRoundRobinAddress").Return(nil, errors.New("uh oh"))
+				keyStore.On("GetRoundRobinAddress", testutils.FixtureChainID).Return(nil, errors.New("uh oh"))
 			},
 			nil, pipeline.ErrTaskRunFailed, "while querying keystore", pipeline.RunInfo{IsRetryable: true},
 		},
@@ -306,7 +307,7 @@ func TestETHTxTask(t *testing.T) {
 				data := []byte("foobar")
 				gasLimit := uint64(12345)
 				txMeta := &txmgr.EthTxMeta{JobID: 321, RequestID: common.HexToHash("0x5198616554d738d9485d1a7cf53b2f33e09c3bbc8fe9ac0020bd672cd2bc15d2"), RequestTxHash: common.HexToHash("0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8")}
-				keyStore.On("GetRoundRobinAddress", from).Return(from, nil)
+				keyStore.On("GetRoundRobinAddress", testutils.FixtureChainID, from).Return(from, nil)
 				txManager.On("CreateEthTransaction", txmgr.NewTx{
 					FromAddress:    from,
 					ToAddress:      to,
@@ -400,7 +401,7 @@ func TestETHTxTask(t *testing.T) {
 			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
 				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
 				from := common.HexToAddress("0x882969652440ccf14a5dbb9bd53eb21cb1e11e5c")
-				keyStore.On("GetRoundRobinAddress", from).Return(from, nil)
+				keyStore.On("GetRoundRobinAddress", testutils.FixtureChainID, from).Return(from, nil)
 				txManager.On("CreateEthTransaction", mock.MatchedBy(func(tx txmgr.NewTx) bool {
 					return tx.MinConfirmations == clnull.Uint32From(3) && tx.PipelineTaskRunID != nil
 				})).Return(txmgr.EthTx{}, nil)

--- a/core/services/relay/evm/request_round_db.go
+++ b/core/services/relay/evm/request_round_db.go
@@ -12,8 +12,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
-//go:generate mockery --name OCRContractTrackerDB --output ./mocks/ --case=underscore
-
 // RequestRoundDB stores requested rounds for querying by the median plugin.
 type RequestRoundDB interface {
 	SaveLatestRoundRequested(tx pg.Queryer, rr ocr2aggregator.OCR2AggregatorRoundRequested) error

--- a/core/services/vrf/delegate.go
+++ b/core/services/vrf/delegate.go
@@ -36,7 +36,7 @@ type Delegate struct {
 //go:generate mockery --name GethKeyStore --output mocks/ --case=underscore
 
 type GethKeyStore interface {
-	GetRoundRobinAddress(addresses ...common.Address) (common.Address, error)
+	GetRoundRobinAddress(chainID *big.Int, addresses ...common.Address) (common.Address, error)
 }
 
 type Config interface {
@@ -114,6 +114,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 				cfg:                chain.Config(),
 				l:                  lV2,
 				ethClient:          chain.Client(),
+				chainID:            chain.ID(),
 				logBroadcaster:     chain.LogBroadcaster(),
 				q:                  d.q,
 				coordinator:        coordinatorV2,

--- a/core/services/vrf/delegate_test.go
+++ b/core/services/vrf/delegate_test.go
@@ -76,7 +76,7 @@ func buildVrfUni(t *testing.T, db *sqlx.DB, cfg *configtest.TestGeneralConfig) v
 	require.NoError(t, ks.Unlock("p4SsW0rD1!@#_"))
 	_, err := ks.Eth().Create(big.NewInt(0))
 	require.NoError(t, err)
-	submitter, err := ks.Eth().GetRoundRobinAddress()
+	submitter, err := ks.Eth().GetRoundRobinAddress(nil)
 	require.NoError(t, err)
 	vrfkey, err := ks.VRF().Create()
 	require.NoError(t, err)

--- a/core/services/vrf/integration_v2_test.go
+++ b/core/services/vrf/integration_v2_test.go
@@ -1015,7 +1015,7 @@ func TestIntegrationVRFV2(t *testing.T) {
 	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, uni.backend, key)
 	config.Overrides.GlobalEvmGasLimitDefault = null.NewInt(0, false)
 	config.Overrides.GlobalMinIncomingConfirmations = null.IntFrom(2)
-	keys, err := app.KeyStore.Eth().SendingKeys()
+	keys, err := app.KeyStore.Eth().SendingKeys(nil)
 
 	// Reconfigure the sim chain with a default gas price of 1 gwei,
 	// max gas limit of 2M and a key specific max 10 gwei price.

--- a/core/services/vrf/listener_v2.go
+++ b/core/services/vrf/listener_v2.go
@@ -58,6 +58,7 @@ type listenerV2 struct {
 	cfg            Config
 	l              logger.Logger
 	ethClient      evmclient.Client
+	chainID        *big.Int
 	logBroadcaster log.Broadcaster
 	txm            txmgr.TxManager
 	coordinator    *vrf_coordinator_v2.VRFCoordinatorV2
@@ -330,7 +331,7 @@ func (lsn *listenerV2) processRequestsPerSub(
 
 	// Attempt to process every request, break if we run out of balance
 	for _, req := range reqs {
-		fromAddress, err := lsn.gethks.GetRoundRobinAddress(lsn.fromAddresses()...)
+		fromAddress, err := lsn.gethks.GetRoundRobinAddress(lsn.chainID, lsn.fromAddresses()...)
 		if err != nil {
 			lggr.Errorw("Couldn't get next from address", "err", err)
 			continue

--- a/core/services/vrf/mocks/geth_key_store.go
+++ b/core/services/vrf/mocks/geth_key_store.go
@@ -3,6 +3,8 @@
 package mocks
 
 import (
+	big "math/big"
+
 	common "github.com/ethereum/go-ethereum/common"
 	mock "github.com/stretchr/testify/mock"
 )
@@ -12,19 +14,20 @@ type GethKeyStore struct {
 	mock.Mock
 }
 
-// GetRoundRobinAddress provides a mock function with given fields: addresses
-func (_m *GethKeyStore) GetRoundRobinAddress(addresses ...common.Address) (common.Address, error) {
+// GetRoundRobinAddress provides a mock function with given fields: chainID, addresses
+func (_m *GethKeyStore) GetRoundRobinAddress(chainID *big.Int, addresses ...common.Address) (common.Address, error) {
 	_va := make([]interface{}, len(addresses))
 	for _i := range addresses {
 		_va[_i] = addresses[_i]
 	}
 	var _ca []interface{}
+	_ca = append(_ca, chainID)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
 	var r0 common.Address
-	if rf, ok := ret.Get(0).(func(...common.Address) common.Address); ok {
-		r0 = rf(addresses...)
+	if rf, ok := ret.Get(0).(func(*big.Int, ...common.Address) common.Address); ok {
+		r0 = rf(chainID, addresses...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(common.Address)
@@ -32,8 +35,8 @@ func (_m *GethKeyStore) GetRoundRobinAddress(addresses ...common.Address) (commo
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(...common.Address) error); ok {
-		r1 = rf(addresses...)
+	if rf, ok := ret.Get(1).(func(*big.Int, ...common.Address) error); ok {
+		r1 = rf(chainID, addresses...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/web/eth_keys_controller.go
+++ b/core/web/eth_keys_controller.go
@@ -35,7 +35,7 @@ func (ekc *ETHKeysController) Index(c *gin.Context) {
 	if ekc.App.GetConfig().Dev() {
 		keys, err = ethKeyStore.GetAll()
 	} else {
-		keys, err = ethKeyStore.SendingKeys()
+		keys, err = ethKeyStore.SendingKeys(nil)
 	}
 	if err != nil {
 		err = errors.Errorf("error getting unlocked keys: %v", err)

--- a/core/web/resolver/eth_key_test.go
+++ b/core/web/resolver/eth_key_test.go
@@ -129,7 +129,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 
 				f.Mocks.cfg.On("Dev").Return(false)
 				f.App.On("GetConfig").Return(f.Mocks.cfg)
-				f.Mocks.ethKs.On("SendingKeys").Return(keys, nil)
+				f.Mocks.ethKs.On("SendingKeys", (*big.Int)(nil)).Return(keys, nil)
 				f.Mocks.ethKs.On("GetStatesForKeys", keys).Return(states, nil)
 				f.Mocks.ethKs.On("Get", keys[0].Address.Hex()).Return(keys[0], nil)
 				f.Mocks.ethClient.On("GetLINKBalance", linkAddr, address.Address()).Return(assets.NewLinkFromJuels(12), nil)
@@ -188,7 +188,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 
 				f.Mocks.cfg.On("Dev").Return(false)
 				f.App.On("GetConfig").Return(f.Mocks.cfg)
-				f.Mocks.ethKs.On("SendingKeys").Return(keys, nil)
+				f.Mocks.ethKs.On("SendingKeys", (*big.Int)(nil)).Return(keys, nil)
 				f.Mocks.ethKs.On("GetStatesForKeys", keys).Return(states, nil)
 				f.Mocks.ethKs.On("Get", keys[0].Address.Hex()).Return(keys[0], nil)
 				f.Mocks.chainSet.On("Get", states[0].EVMChainID.ToInt()).Return(f.Mocks.chain, evm.ErrNoChains)
@@ -250,7 +250,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 			before: func(f *gqlTestFramework) {
 				f.Mocks.cfg.On("Dev").Return(false)
 				f.App.On("GetConfig").Return(f.Mocks.cfg)
-				f.Mocks.ethKs.On("SendingKeys").Return(nil, gError)
+				f.Mocks.ethKs.On("SendingKeys", (*big.Int)(nil)).Return(nil, gError)
 				f.Mocks.keystore.On("Eth").Return(f.Mocks.ethKs)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
 			},
@@ -271,7 +271,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 			before: func(f *gqlTestFramework) {
 				f.Mocks.cfg.On("Dev").Return(false)
 				f.App.On("GetConfig").Return(f.Mocks.cfg)
-				f.Mocks.ethKs.On("SendingKeys").Return(keys, nil)
+				f.Mocks.ethKs.On("SendingKeys", (*big.Int)(nil)).Return(keys, nil)
 				f.Mocks.ethKs.On("GetStatesForKeys", keys).Return(nil, gError)
 				f.Mocks.keystore.On("Eth").Return(f.Mocks.ethKs)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -303,7 +303,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 
 				f.Mocks.cfg.On("Dev").Return(false)
 				f.App.On("GetConfig").Return(f.Mocks.cfg)
-				f.Mocks.ethKs.On("SendingKeys").Return(keys, nil)
+				f.Mocks.ethKs.On("SendingKeys", (*big.Int)(nil)).Return(keys, nil)
 				f.Mocks.ethKs.On("GetStatesForKeys", keys).Return(states, nil)
 				f.Mocks.ethKs.On("Get", keys[0].Address.Hex()).Return(ethkey.KeyV2{}, gError)
 				f.Mocks.keystore.On("Eth").Return(f.Mocks.ethKs)
@@ -336,7 +336,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 
 				f.Mocks.cfg.On("Dev").Return(false)
 				f.App.On("GetConfig").Return(f.Mocks.cfg)
-				f.Mocks.ethKs.On("SendingKeys").Return(keys, nil)
+				f.Mocks.ethKs.On("SendingKeys", (*big.Int)(nil)).Return(keys, nil)
 				f.Mocks.ethKs.On("GetStatesForKeys", keys).Return(states, nil)
 				f.Mocks.ethKs.On("Get", keys[0].Address.Hex()).Return(ethkey.KeyV2{}, nil)
 				f.Mocks.keystore.On("Eth").Return(f.Mocks.ethKs)
@@ -373,7 +373,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 
 				f.Mocks.cfg.On("Dev").Return(false)
 				f.App.On("GetConfig").Return(f.Mocks.cfg)
-				f.Mocks.ethKs.On("SendingKeys").Return(keys, nil)
+				f.Mocks.ethKs.On("SendingKeys", (*big.Int)(nil)).Return(keys, nil)
 				f.Mocks.ethKs.On("GetStatesForKeys", keys).Return(states, nil)
 				f.Mocks.ethKs.On("Get", keys[0].Address.Hex()).Return(keys[0], nil)
 				f.Mocks.keystore.On("Eth").Return(f.Mocks.ethKs)
@@ -433,7 +433,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 
 				f.Mocks.cfg.On("Dev").Return(false)
 				f.App.On("GetConfig").Return(f.Mocks.cfg)
-				f.Mocks.ethKs.On("SendingKeys").Return(keys, nil)
+				f.Mocks.ethKs.On("SendingKeys", (*big.Int)(nil)).Return(keys, nil)
 				f.Mocks.ethKs.On("GetStatesForKeys", keys).Return(states, nil)
 				f.Mocks.ethKs.On("Get", keys[0].Address.Hex()).Return(keys[0], nil)
 				f.Mocks.ethClient.On("GetLINKBalance", linkAddr, address.Address()).Return(assets.NewLinkFromJuels(12), nil)

--- a/core/web/resolver/query.go
+++ b/core/web/resolver/query.go
@@ -389,7 +389,7 @@ func (r *Resolver) ETHKeys(ctx context.Context) (*ETHKeysPayloadResolver, error)
 	if r.App.GetConfig().Dev() {
 		keys, err = ks.GetAll()
 	} else {
-		keys, err = ks.SendingKeys()
+		keys, err = ks.SendingKeys(nil)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("error getting unlocked keys: %v", err)


### PR DESCRIPTION
This was leading to problems pinning `ethtx` task to a chain in multichain systems because it can try to use the wrong one and get a "key not pegged to this chain" error