### PR TITLE
fix: implement renderer for solana txs cli command

### DIFF
--- a/core/cmd/solana_transaction_commands.go
+++ b/core/cmd/solana_transaction_commands.go
@@ -15,6 +15,25 @@ import (
 	"github.com/smartcontractkit/chainlink/core/web/presenters"
 )
 
+type SolanaMsgPresenter struct {
+	JAID
+	presenters.SolanaMsgResource
+}
+
+// RenderTable implements TableRenderer
+func (p *SolanaMsgPresenter) RenderTable(rt RendererTable) error {
+	table := rt.newTable([]string{"Chain ID", "From", "To", "Amount"})
+	table.Append([]string{
+		p.ChainID,
+		p.From,
+		p.To,
+		strconv.FormatUint(p.Amount, 10),
+	})
+
+	render(fmt.Sprintf("Solana Message %v", p.ID), table)
+	return nil
+}
+
 // SolanaSendSol transfers sol from the node's account to a specified address.
 func (cli *Client) SolanaSendSol(c *cli.Context) (err error) {
 	if c.NArg() < 3 {
@@ -72,6 +91,6 @@ func (cli *Client) SolanaSendSol(c *cli.Context) (err error) {
 		}
 	}()
 
-	err = cli.renderAPIResponse(resp, &presenters.SolanaMsgResource{})
+	err = cli.renderAPIResponse(resp, &SolanaMsgPresenter{})
 	return err
 }

--- a/core/cmd/solana_transaction_commands_test.go
+++ b/core/cmd/solana_transaction_commands_test.go
@@ -16,8 +16,8 @@ import (
 
 	solanaClient "github.com/smartcontractkit/chainlink-solana/pkg/solana/client"
 	solanadb "github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
+	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/web/presenters"
 )
 
 func TestClient_SolanaSendSol(t *testing.T) {
@@ -87,7 +87,7 @@ func TestClient_SolanaSendSol(t *testing.T) {
 			// Check CLI output
 			require.Greater(t, len(r.Renders), 0)
 			renderer := r.Renders[len(r.Renders)-1]
-			renderedMsg := renderer.(*presenters.SolanaMsgResource)
+			renderedMsg := renderer.(*cmd.SolanaMsgPresenter)
 			fmt.Printf("%+v\n", renderedMsg)
 			require.NotEmpty(t, renderedMsg.ID)
 			assert.Equal(t, chainID, renderedMsg.ChainID)
@@ -95,7 +95,7 @@ func TestClient_SolanaSendSol(t *testing.T) {
 			assert.Equal(t, to.PublicKey().String(), renderedMsg.To)
 			assert.Equal(t, tt.amount, strconv.FormatUint(renderedMsg.Amount, 10))
 
-      time.Sleep(time.Second) // wait for tx execution
+			time.Sleep(time.Second) // wait for tx execution
 
 			// Check balance
 			endBal, err := reader.Balance(from.PublicKey())


### PR DESCRIPTION
Original error:
```
root@chainlink-1:/home/root# chainlink txs solana create --id localnet 1000000000 8zzJk2H2qH24PDu6X2wK2eY3dqLUWjUNCpiV5z3RSr9v BtWaxgc8t6bo64qkeCHqnhPRQcDEeg7g2zBhxQdJAzod
2022-03-30T14:11:52.531Z [DEBUG] Initializing API credentials                                                        file=/root/.chainlink/apicredentials logger=1.2.1@86dd56a
unable to render object of type *presenters.SolanaMsgResource: &{{sol_transfer_e16e2b61-0b57-4b62-874d-808da412f9c7} localnet 8zzJk2H2qH24PDu6X2wK2eY3dqLUWjUNCpiV5z3RSr9v BtWaxgc8t6bo64qkeCHqnhPRQcDEeg7g2zBhxQdJAzod 1000000000}
```