### PR TITLE
Skip chainID check if eth_chainId returned error (sendonly)

### DIFF
--- a/core/chains/evm/chain_set.go
+++ b/core/chains/evm/chain_set.go
@@ -72,7 +72,7 @@ func (cll *chainSet) Start(ctx context.Context) error {
 	}
 	for _, c := range cll.Chains() {
 		if err := c.Start(ctx); err != nil {
-			cll.logger.Errorw(fmt.Sprintf("EVM: Chain with ID %s failed to start. You will need to fix this issue and restart the Chainlink node before any services that use this chain will work properly. Got error: %v", c.ID(), err), "evmChainID", c.ID(), "err", err)
+			cll.logger.Criticalw(fmt.Sprintf("EVM: Chain with ID %s failed to start. You will need to fix this issue and restart the Chainlink node before any services that use this chain will work properly. Got error: %v", c.ID(), err), "evmChainID", c.ID(), "err", err)
 			continue
 		}
 		cll.startedChains = append(cll.startedChains, c)

--- a/core/chains/evm/client/send_only_node.go
+++ b/core/chains/evm/client/send_only_node.go
@@ -62,6 +62,7 @@ func NewSendOnlyNode(lggr logger.Logger, httpuri url.URL, name string, chainID *
 // Start setups up and verifies the sendonly node
 // Should only be called once in a node's lifecycle
 // TODO: Failures to dial should put it into a retry loop
+// https://app.shortcut.com/chainlinklabs/story/28182/eth-node-failover-consider-introducing-a-state-for-sendonly-nodes
 func (s *sendOnlyNode) Start(startCtx context.Context) error {
 	s.log.Debugw("evmclient.Client#Dial(...)")
 	if s.dialed {

--- a/core/chains/evm/client/send_only_node.go
+++ b/core/chains/evm/client/send_only_node.go
@@ -146,9 +146,13 @@ func (s *sendOnlyNode) verify(parentCtx context.Context) error {
 	// Note: chainlink-broadcaster does not support eth_chainId RPC method.
 	chainID, err := s.geth.ChainID(ctx)
 	if err != nil {
-		s.log.Warnf("sendonly rpc ChainID responded with error, chainID verification is skipped: %v", err)
+		if err.Error() == "Unsupported RPC call" {
+			s.log.Warn("sendonly node does not support ChainID rpc, verification is skipped")
+		} else {
+			return errors.Errorf("sendonly rpc ChainID error: %v", err)
+		}
 	} else if chainID.Cmp(big.NewInt(0)) == 0 {
-		s.log.Warnf("sendonly rpc ChainID responded with zero value, verification is skipped")
+		s.log.Warn("sendonly rpc ChainID responded with zero value, verification is skipped")
 	} else if chainID.Cmp(s.chainID) != 0 {
 		return errors.Errorf(
 			"sendonly rpc ChainID doesn't match local chain ID: RPC ID=%s, local ID=%s, node name=%s",

--- a/core/chains/evm/client/send_only_node.go
+++ b/core/chains/evm/client/send_only_node.go
@@ -147,6 +147,8 @@ func (s *sendOnlyNode) verify(parentCtx context.Context) error {
 	chainID, err := s.geth.ChainID(ctx)
 	if err != nil {
 		s.log.Warnf("sendonly rpc ChainID responded with error, chainID verification is skipped: %v", err)
+	} else if chainID.Cmp(big.NewInt(0)) == 0 {
+		s.log.Warnf("sendonly rpc ChainID responded with zero value, verification is skipped")
 	} else if chainID.Cmp(s.chainID) != 0 {
 		return errors.Errorf(
 			"sendonly rpc ChainID doesn't match local chain ID: RPC ID=%s, local ID=%s, node name=%s",

--- a/core/services/pipeline/task.http_test.go
+++ b/core/services/pipeline/task.http_test.go
@@ -166,7 +166,9 @@ func TestHTTPTask_Variables(t *testing.T) {
 			}
 			task.HelperSetDependencies(cfg, db, uuid.UUID{})
 
-			test.vars.Set("meta", test.meta)
+			err = test.vars.Set("meta", test.meta)
+			require.NoError(t, err)
+
 			result, runInfo := task.Run(context.Background(), logger.TestLogger(t), test.vars, test.inputs)
 			assert.False(t, runInfo.IsPending)
 			assert.False(t, runInfo.IsRetryable)

--- a/core/services/pipeline/task.http_test.go
+++ b/core/services/pipeline/task.http_test.go
@@ -166,8 +166,7 @@ func TestHTTPTask_Variables(t *testing.T) {
 			}
 			task.HelperSetDependencies(cfg, db, uuid.UUID{})
 
-			err = test.vars.Set("meta", test.meta)
-			require.NoError(t, err)
+			test.vars.Set("meta", test.meta)
 
 			result, runInfo := task.Run(context.Background(), logger.TestLogger(t), test.vars, test.inputs)
 			assert.False(t, runInfo.IsPending)

--- a/core/services/pipeline/task.http_test.go
+++ b/core/services/pipeline/task.http_test.go
@@ -167,7 +167,6 @@ func TestHTTPTask_Variables(t *testing.T) {
 			task.HelperSetDependencies(cfg, db, uuid.UUID{})
 
 			test.vars.Set("meta", test.meta)
-
 			result, runInfo := task.Run(context.Background(), logger.TestLogger(t), test.vars, test.inputs)
 			assert.False(t, runInfo.IsPending)
 			assert.False(t, runInfo.IsRetryable)


### PR DESCRIPTION
from NOPs when using broadcast-mirror as a sendonly node:
```
2022-04-01T07:16:56.465Z [ERROR] EVM: Chain with ID 1 failed to start. You will need to fix this issue and restart the Chainlink node before any services that use this chain will work properly. Got error: failed to dial ethclient: failed to dial pool: failed to verify sendonly node: failed to verify chain ID: Unsupported RPC call                                  err=failed to dial ethclient: failed to dial pool: failed to verify sendonly node: failed to verify chain ID: Unsupported RPC call errVerbose=Unsupported RPC call
```
