### PR TITLE
Fixed flakey tests in synchronization module

### DIFF
--- a/core/services/synchronization/telemetry_ingress_batch_client_test.go
+++ b/core/services/synchronization/telemetry_ingress_batch_client_test.go
@@ -1,7 +1,6 @@
 package synchronization_test
 
 import (
-	"context"
 	"net/url"
 	"testing"
 	"time"
@@ -42,17 +41,17 @@ func TestTelemetryIngressBatchClient_HappyPath(t *testing.T) {
 
 	// Create telemetry payloads for different contracts
 	telemPayload1 := synchronization.TelemPayload{
-		Ctx:        context.Background(),
+		Ctx:        testutils.Context(t),
 		Telemetry:  []byte("Mock telem 1"),
 		ContractID: "0x1",
 	}
 	telemPayload2 := synchronization.TelemPayload{
-		Ctx:        context.Background(),
+		Ctx:        testutils.Context(t),
 		Telemetry:  []byte("Mock telem 2"),
 		ContractID: "0x2",
 	}
 	telemPayload3 := synchronization.TelemPayload{
-		Ctx:        context.Background(),
+		Ctx:        testutils.Context(t),
 		Telemetry:  []byte("Mock telem 3"),
 		ContractID: "0x3",
 	}
@@ -94,9 +93,9 @@ func TestTelemetryIngressBatchClient_HappyPath(t *testing.T) {
 	telemIngressClient.Send(telemPayload2)
 
 	// Wait for the telemetry to be handled
-	g.Eventually(contractCounter1.Load, "5s").Should(gomega.Equal(uint32(3)))
-	g.Eventually(contractCounter2.Load, "5s").Should(gomega.Equal(uint32(2)))
-	g.Eventually(contractCounter3.Load, "5s").Should(gomega.Equal(uint32(1)))
+	g.Eventually(func() []uint32 {
+		return []uint32{contractCounter1.Load(), contractCounter2.Load(), contractCounter3.Load()}
+	}).Should(gomega.Equal([]uint32{3, 2, 1}))
 
 	// Client should shut down
 	telemIngressClient.Close()


### PR DESCRIPTION
Closes https://app.shortcut.com/chainlinklabs/story/35343/flakey-testwebsocketclient-status-connectandserverdisconnect