### PR TITLE
Fixed flakey TestBroadcaster_BroadcastsToCorrectRecipients

### DIFF
--- a/core/chains/evm/log/helpers_test.go
+++ b/core/chains/evm/log/helpers_test.go
@@ -165,7 +165,7 @@ func (helper *broadcasterHelper) requireBroadcastCount(expectedCount int) {
 		return count.Count, err
 	}
 
-	g.Eventually(comparisonFunc, cltest.WaitTimeout(helper.t), time.Second).Should(gomega.Equal(expectedCount))
+	g.Eventually(comparisonFunc, testutils.WaitTimeout(helper.t), time.Second).Should(gomega.Equal(expectedCount))
 	g.Consistently(comparisonFunc, 1*time.Second, 200*time.Millisecond).Should(gomega.Equal(expectedCount))
 }
 

--- a/core/chains/evm/log/integration_test.go
+++ b/core/chains/evm/log/integration_test.go
@@ -638,14 +638,15 @@ func TestBroadcaster_BroadcastsToCorrectRecipients(t *testing.T) {
 	listener3 := helper.newLogListenerWithJob("listener 3")
 	listener4 := helper.newLogListenerWithJob("listener 4")
 
+	helper.register(listener1, contract1, 1)
+	helper.register(listener2, contract1, 1)
+	helper.register(listener3, contract2, 1)
+	helper.register(listener4, contract2, 1)
+
 	func() {
 		helper.start()
 		defer helper.stop()
 
-		helper.register(listener1, contract1, 1)
-		helper.register(listener2, contract1, 1)
-		helper.register(listener3, contract2, 1)
-		helper.register(listener4, contract2, 1)
 		headsDone := cltest.SimulateIncomingHeads(t, cltest.SimulateIncomingHeadsArgs{
 			StartBlock:     0,
 			EndBlock:       9,

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -864,7 +864,7 @@ const (
 	AssertNoActionTimeout = 3 * time.Second
 )
 
-// WaitTimeout is just preserved for compatabilty. Use testutils.WaitTimeout directly instead.
+// WaitTimeout is just preserved for compatibility. Use testutils.WaitTimeout directly instead.
 // Deprecated
 var WaitTimeout = testutils.WaitTimeout
 


### PR DESCRIPTION
Closes https://app.shortcut.com/chainlinklabs/story/35298/flakey-testbroadcaster-broadcaststocorrectrecipients

Also observed flake for `TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled`
probably due to the same full db name as for `TestHeadTracker_SwitchesToLongestChainWithHeadSamplingEnabled`.
I removed the full DB requirement because it does not seem reasonable for these tests.
