### PR TITLE
Move http error logs to warn

### DIFF
--- a/core/services/pipeline/http.go
+++ b/core/services/pipeline/http.go
@@ -61,7 +61,7 @@ func (h *HTTPRequest) SendRequest() (responseBody []byte, statusCode int, header
 
 	r, err := client.Do(h.Request)
 	if err != nil {
-		h.Logger.Errorw("http adapter got error", "error", err)
+		h.Logger.Warnw("http adapter got error", "error", err)
 		return nil, 0, nil, err
 	}
 	defer h.Logger.ErrorIfClosing(r.Body, "SendRequest response body")


### PR DESCRIPTION
According to https://github.com/smartcontractkit/documentation/blob/main/docs/Node%20Operators/configuration-variables.md#log_level this  should be reverted back to warn to match docs