### PR TITLE
core/chains/evm/headtracker: resubscribe when Err() chan closed

### DIFF
--- a/core/chains/evm/headtracker/head_listener.go
+++ b/core/chains/evm/headtracker/head_listener.go
@@ -115,7 +115,10 @@ func (hl *headListener) receiveHeaders(ctx context.Context, handleNewHead httype
 			}
 
 		case err, open := <-hl.headSubscription.Err():
-			if open && err != nil {
+			if !open {
+				return errors.New("head listener: subscription Err channel prematurely closed")
+			}
+			if err != nil {
 				return err
 			}
 


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/35707