### PR TITLE
Fix log broadcaster force flag (#6311)

### DIFF
--- a/core/chains/evm/log/broadcaster.go
+++ b/core/chains/evm/log/broadcaster.go
@@ -188,7 +188,7 @@ func (b *broadcaster) Start(context.Context) error {
 
 // ReplayFromBlock implements the Broadcaster interface.
 func (b *broadcaster) ReplayFromBlock(number int64, forceBroadcast bool) {
-	b.logger.Infof("Replay requested from block number: %v", number)
+	b.logger.Infow("Replay requested", "block number", number, "force", forceBroadcast)
 	select {
 	case b.replayChannel <- replayRequest{
 		fromBlock:      number,

--- a/core/cmd/remote_client.go
+++ b/core/cmd/remote_client.go
@@ -127,18 +127,17 @@ func (cli *Client) getPage(requestURI string, page int, model interface{}) (err 
 
 // ReplayFromBlock replays chain data from the given block number until the most recent
 func (cli *Client) ReplayFromBlock(c *clipkg.Context) (err error) {
-
 	blockNumber := c.Int64("block-number")
 	if blockNumber <= 0 {
 		return cli.errorOut(errors.New("Must pass a positive value in '--block-number' parameter"))
 	}
 
-	forceBroadcast := c.Bool("force-broadcast")
+	forceBroadcast := c.Bool("force")
 
 	buf := bytes.NewBufferString("{}")
 	resp, err := cli.HTTP.Post(
 		fmt.Sprintf(
-			"/v2/replay_from_block/%v?force_broadcast=%s",
+			"/v2/replay_from_block/%v?force=%s",
 			blockNumber,
 			strconv.FormatBool(forceBroadcast),
 		), buf)

--- a/core/web/replay_controller.go
+++ b/core/web/replay_controller.go
@@ -24,13 +24,13 @@ func (bdc *ReplayController) ReplayFromBlock(c *gin.Context) {
 		return
 	}
 
-	// check if force_broadcast query string parameter provided
+	// check if "force" query string parameter provided
 	var force bool
 	var err error
 	if fb := c.Query("force"); fb != "" {
 		force, err = strconv.ParseBool(fb)
 		if err != nil {
-			jsonAPIError(c, http.StatusUnprocessableEntity, errors.Wrap(err, "boolean value required for 'force_broadcast' query string param"))
+			jsonAPIError(c, http.StatusUnprocessableEntity, errors.Wrap(err, "boolean value required for 'force' query string param"))
 			return
 		}
 	}

--- a/core/web/replay_controller.go
+++ b/core/web/replay_controller.go
@@ -25,10 +25,10 @@ func (bdc *ReplayController) ReplayFromBlock(c *gin.Context) {
 	}
 
 	// check if force_broadcast query string parameter provided
-	var forceBroadcast bool
+	var force bool
 	var err error
-	if fb := c.Query("force_broadcast"); fb != "" {
-		forceBroadcast, err = strconv.ParseBool(fb)
+	if fb := c.Query("force"); fb != "" {
+		force, err = strconv.ParseBool(fb)
 		if err != nil {
 			jsonAPIError(c, http.StatusUnprocessableEntity, errors.Wrap(err, "boolean value required for 'force_broadcast' query string param"))
 			return
@@ -58,7 +58,7 @@ func (bdc *ReplayController) ReplayFromBlock(c *gin.Context) {
 	}
 	chainID := chain.ID()
 
-	if err := bdc.App.ReplayFromBlock(chainID, uint64(blockNumber), forceBroadcast); err != nil {
+	if err := bdc.App.ReplayFromBlock(chainID, uint64(blockNumber), force); err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
 	}


### PR DESCRIPTION
"force" was used in one spot, and "force-broadcast" in another
preventing the flag from being propagated. Fix it.

(cherry picked from commit 0cafb6a6ba4fbdad1f484b3ff16a71614183e529)