### PR TITLE
solana: handle parallel client creation, return same client

### DIFF
--- a/core/chains/solana/chain.go
+++ b/core/chains/solana/chain.go
@@ -160,14 +160,13 @@ func (c *chain) verifiedClient(node db.Node) (solanaclient.ReaderWriter, error) 
 	if !exists {
 		c.clientLock.Lock()
 		// recheck when writing to prevent parallel writes (discard duplicate if exists)
-		if _, exists = c.clientCache[url]; !exists {
+		if client, exists = c.clientCache[url]; !exists {
 			c.clientCache[url] = client
 		}
 		c.clientLock.Unlock()
 	}
 
-	// return client from cache
-	return c.clientCache[url].rw, nil
+	return client.rw, nil
 }
 
 func (c *chain) Start(ctx context.Context) error {

--- a/core/chains/solana/chain.go
+++ b/core/chains/solana/chain.go
@@ -155,15 +155,22 @@ func (c *chain) verifiedClient(node db.Node) (solanaclient.ReaderWriter, error) 
 		return nil, errors.Errorf("client returned mismatched chain id (expected: %s, got: %s): %s", expectedID, client.id, url)
 	}
 
+	// recheck if client already exists (prevent parallel writing)
+	c.clientLock.RLock()
+	_, exists = c.clientCache[url]
+	c.clientLock.RUnlock()
+
 	// save client if doesn't exist and checks have passed
 	// if checks failed, client is not saved and can retry when a new client is requested
+	// check if cached client exists
 	if !exists {
 		c.clientLock.Lock()
 		c.clientCache[url] = client
 		c.clientLock.Unlock()
 	}
 
-	return client.rw, nil
+	// return client from cache
+	return c.clientCache[url].rw, nil
 }
 
 func (c *chain) Start(ctx context.Context) error {

--- a/core/chains/solana/chain.go
+++ b/core/chains/solana/chain.go
@@ -160,8 +160,10 @@ func (c *chain) verifiedClient(node db.Node) (solanaclient.ReaderWriter, error) 
 	if !exists {
 		c.clientLock.Lock()
 		// recheck when writing to prevent parallel writes (discard duplicate if exists)
-		if client, exists = c.clientCache[url]; !exists {
+		if cached, exists := c.clientCache[url]; !exists {
 			c.clientCache[url] = client
+		} else {
+			client = cached
 		}
 		c.clientLock.Unlock()
 	}


### PR DESCRIPTION
Address concern: https://github.com/smartcontractkit/chainlink/pull/6393#discussion_r846280119