### PR TITLE
core/chains/evm/client: fix node_lifecycle_test race condition

### DIFF
--- a/core/chains/evm/client/node_lifecycle_test.go
+++ b/core/chains/evm/client/node_lifecycle_test.go
@@ -438,8 +438,8 @@ func TestUnit_NodeLifecycle_unreachableLoop(t *testing.T) {
 		n.setState(NodeStateUnreachable)
 
 		ch := make(chan struct{})
+		n.wg.Add(1)
 		go func() {
-			n.wg.Add(1)
 			n.unreachableLoop()
 			close(ch)
 		}()


### PR DESCRIPTION
Fixes a race condition in TestUnit_NodeLifecycle_unreachableLoop, causing the test to be flakey