### PR TITLE
Fixed TestUnit_NodeLifecycle_aliveLoop: transition to OutOfSync

### DIFF
--- a/core/chains/evm/client/node_lifecycle_test.go
+++ b/core/chains/evm/client/node_lifecycle_test.go
@@ -217,17 +217,40 @@ func TestUnit_NodeLifecycle_aliveLoop(t *testing.T) {
 		})
 	})
 
-	t.Run("when no new heads received for threshold, transitions to unreachable", func(t *testing.T) {
-		pollDisabledCfg := TestNodeConfig{NoNewHeadsThreshold: testutils.TestInterval}
-		n := newTestNode(t, pollDisabledCfg)
+	t.Run("when no new heads received for threshold, transitions to out of sync", func(t *testing.T) {
+		cfg := TestNodeConfig{NoNewHeadsThreshold: 1 * time.Second}
+		chSubbed := make(chan struct{})
+		s := testutils.NewWSServer(t, testutils.FixtureChainID,
+			func(method string, params gjson.Result) (respResult string, notifyResult string) {
+				switch method {
+				case "eth_subscribe":
+					select {
+					case chSubbed <- struct{}{}:
+					default:
+					}
+					return `"0x00"`, makeHeadResult(0)
+				case "web3_clientVersion":
+					return `"test client version 2"`, ""
+				default:
+					t.Fatalf("unexpected RPC method: %s", method)
+				}
+				return "", ""
+			})
+		defer s.Close()
+
+		iN := NewNode(cfg, logger.TestLogger(t), *s.WSURL(), nil, "test node", 42, testutils.FixtureChainID)
+		n := iN.(*node)
+
 		dial(t, n)
 		defer n.Close()
 
 		n.wg.Add(1)
 		go n.aliveLoop()
 
+		testutils.WaitWithTimeout(t, chSubbed, "timed out waiting for initial subscription")
+
 		testutils.AssertEventually(t, func() bool {
-			return n.State() == NodeStateUnreachable
+			return n.State() == NodeStateOutOfSync
 		})
 	})
 

--- a/core/chains/evm/headtracker/head_tracker_test.go
+++ b/core/chains/evm/headtracker/head_tracker_test.go
@@ -387,7 +387,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingEnabled(t *testing.T)
 	config := cltest.NewTestGeneralConfig(t)
 	config.Overrides.GlobalEvmFinalityDepth = null.IntFrom(50)
 	// Need to set the buffer to something large since we inject a lot of heads at once and otherwise they will be dropped
-	config.Overrides.GlobalEvmHeadTrackerMaxBufferSize = null.IntFrom(42)
+	config.Overrides.GlobalEvmHeadTrackerMaxBufferSize = null.IntFrom(100)
 
 	// Head sampling enabled
 	d := 2500 * time.Millisecond
@@ -518,7 +518,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled(t *testing.T
 	config := cltest.NewTestGeneralConfig(t)
 	config.Overrides.GlobalEvmFinalityDepth = null.IntFrom(50)
 	// Need to set the buffer to something large since we inject a lot of heads at once and otherwise they will be dropped
-	config.Overrides.GlobalEvmHeadTrackerMaxBufferSize = null.IntFrom(42)
+	config.Overrides.GlobalEvmHeadTrackerMaxBufferSize = null.IntFrom(100)
 	d := 0 * time.Second
 	config.Overrides.GlobalEvmHeadTrackerSamplingInterval = &d
 


### PR DESCRIPTION
I think the old test here was incorrect, so I changed it to test transitioning to OutOfSync state.
