### PR TITLE
Faster DB cloning for FullTestDB

### DIFF
--- a/core/chains/evm/txmgr/eth_broadcaster_test.go
+++ b/core/chains/evm/txmgr/eth_broadcaster_test.go
@@ -530,7 +530,7 @@ func TestEthBroadcaster_TransmitChecking(t *testing.T) {
 
 func TestEthBroadcaster_ProcessUnstartedEthTxs_OptimisticLockingOnEthTx(t *testing.T) {
 	// non-transactional DB needed because we deliberately test for FK violation
-	cfg, db := heavyweight.FullTestDB(t, "eth_broadcaster_optimistic_locking", true, true)
+	cfg, db := heavyweight.FullTestDB(t, "eth_broadcaster_optimistic_locking")
 	borm := cltest.NewTxmORM(t, db, cfg)
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
@@ -1651,7 +1651,7 @@ func TestEthBroadcaster_Trigger(t *testing.T) {
 
 func TestEthBroadcaster_EthTxInsertEventCausesTriggerToFire(t *testing.T) {
 	// NOTE: Testing triggers requires committing transactions and does not work with transactional tests
-	cfg, db := heavyweight.FullTestDB(t, "eth_tx_triggers", true, true)
+	cfg, db := heavyweight.FullTestDB(t, "eth_tx_triggers")
 	borm := cltest.NewTxmORM(t, db, cfg)
 
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)

--- a/core/chains/terra/terratxm/txm_test.go
+++ b/core/chains/terra/terratxm/txm_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestTxm_Integration(t *testing.T) {
-	cfg, db := heavyweight.FullTestDB(t, "terra_txm", true, false)
+	cfg, db := heavyweight.FullTestDBWithoutFixtures(t, "terra_txm")
 	lggr := logger.TestLogger(t)
 	chainID := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))
 	logCfg := pgtest.NewPGCfg(true)

--- a/core/chains/terra/terratxm/txm_test.go
+++ b/core/chains/terra/terratxm/txm_test.go
@@ -34,7 +34,7 @@ import (
 )
 
 func TestTxm_Integration(t *testing.T) {
-	cfg, db := heavyweight.FullTestDBWithoutFixtures(t, "terra_txm")
+	cfg, db := heavyweight.FullTestDBNoFixtures(t, "terra_txm")
 	lggr := logger.TestLogger(t)
 	chainID := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))
 	logCfg := pgtest.NewPGCfg(true)

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -46,8 +46,8 @@ import (
 // ownerPermsMask are the file permission bits reserved for owner.
 const ownerPermsMask = os.FileMode(0700)
 
-// PristineDBName is a clean copy of test DB
-// Used by heavyweight.FullTestDB()
+// PristineDBName is a clean copy of test DB with migrations.
+// Used by heavyweight.FullTestDB* functions.
 const PristineDBName = "chainlink_test_pristine"
 
 // RunNode starts the Chainlink core.

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -437,7 +437,7 @@ func TestClient_RebroadcastTransactions_Txm(t *testing.T) {
 	// Use the a non-transactional db for this test because we need to
 	// test multiple connections to the database, and changes made within
 	// the transaction cannot be seen from another connection.
-	config, sqlxDB := heavyweight.FullTestDB(t, "rebroadcasttransactions", true, true)
+	config, sqlxDB := heavyweight.FullTestDB(t, "rebroadcasttransactions")
 	keyStore := cltest.NewKeyStore(t, sqlxDB, config)
 	_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth(), 0)
 
@@ -513,7 +513,7 @@ func TestClient_RebroadcastTransactions_OutsideRange_Txm(t *testing.T) {
 			// Use the a non-transactional db for this test because we need to
 			// test multiple connections to the database, and changes made within
 			// the transaction cannot be seen from another connection.
-			config, sqlxDB := heavyweight.FullTestDB(t, "rebroadcasttransactions_outsiderange", true, true)
+			config, sqlxDB := heavyweight.FullTestDB(t, "rebroadcasttransactions_outsiderange")
 			config.Overrides.Dialect = dialects.Postgres
 
 			keyStore := cltest.NewKeyStore(t, sqlxDB, config)
@@ -574,7 +574,7 @@ func TestClient_RebroadcastTransactions_OutsideRange_Txm(t *testing.T) {
 
 func TestClient_SetNextNonce(t *testing.T) {
 	// Need to use separate database
-	config, sqlxDB := heavyweight.FullTestDB(t, "setnextnonce", true, true)
+	config, sqlxDB := heavyweight.FullTestDB(t, "setnextnonce")
 	ethKeyStore := cltest.NewKeyStore(t, sqlxDB, config).Eth()
 	lggr := logger.TestLogger(t)
 

--- a/core/internal/cltest/heavyweight/orm.go
+++ b/core/internal/cltest/heavyweight/orm.go
@@ -34,13 +34,13 @@ func FullTestDB(t *testing.T, name string) (*configtest.TestGeneralConfig, *sqlx
 	return prepareFullTestDB(t, name, false, true)
 }
 
-// FullTestDBWithoutFixtures is the same as FullTestDB, but it does not load fixtures.
-func FullTestDBWithoutFixtures(t *testing.T, name string) (*configtest.TestGeneralConfig, *sqlx.DB) {
+// FullTestDBNoFixtures is the same as FullTestDB, but it does not load fixtures.
+func FullTestDBNoFixtures(t *testing.T, name string) (*configtest.TestGeneralConfig, *sqlx.DB) {
 	return prepareFullTestDB(t, name, false, false)
 }
 
-// EmptyFullTestDB creates an empty DB (without migrations).
-func EmptyFullTestDB(t *testing.T, name string) (*configtest.TestGeneralConfig, *sqlx.DB) {
+// FullTestDBEmpty creates an empty DB (without migrations).
+func FullTestDBEmpty(t *testing.T, name string) (*configtest.TestGeneralConfig, *sqlx.DB) {
 	return prepareFullTestDB(t, name, true, false)
 }
 

--- a/core/internal/cltest/heavyweight/orm.go
+++ b/core/internal/cltest/heavyweight/orm.go
@@ -19,20 +19,38 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 
+	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/store/dialects"
-	migrations "github.com/smartcontractkit/chainlink/core/store/migrate"
 )
 
-// FullTestDB creates an DB which runs in a separate database than the normal
-// unit tests, so you can do things like use other Postgres connection types
-// with it.
-func FullTestDB(t *testing.T, name string, migrate bool, loadFixtures bool) (*configtest.TestGeneralConfig, *sqlx.DB) {
+// FullTestDB creates a pristine DB which runs in a separate database than the normal
+// unit tests, so you can do things like use other Postgres connection types with it.
+func FullTestDB(t *testing.T, name string) (*configtest.TestGeneralConfig, *sqlx.DB) {
+	return prepareFullTestDB(t, name, false, true)
+}
+
+// FullTestDBWithoutFixtures is the same as FullTestDB, but it does not load fixtures.
+func FullTestDBWithoutFixtures(t *testing.T, name string) (*configtest.TestGeneralConfig, *sqlx.DB) {
+	return prepareFullTestDB(t, name, false, false)
+}
+
+// EmptyFullTestDB creates an empty DB (without migrations).
+func EmptyFullTestDB(t *testing.T, name string) (*configtest.TestGeneralConfig, *sqlx.DB) {
+	return prepareFullTestDB(t, name, true, false)
+}
+
+func prepareFullTestDB(t *testing.T, name string, empty bool, loadFixtures bool) (*configtest.TestGeneralConfig, *sqlx.DB) {
 	testutils.SkipShort(t, "FullTestDB")
+
+	if empty && loadFixtures {
+		t.Fatal("could not load fixtures into an empty DB")
+	}
+
 	overrides := configtest.GeneralConfigOverrides{
 		SecretGenerator: cltest.MockSecretGenerator{},
 	}
@@ -40,7 +58,7 @@ func FullTestDB(t *testing.T, name string, migrate bool, loadFixtures bool) (*co
 	gcfg.Overrides.Dialect = dialects.Postgres
 
 	require.NoError(t, os.MkdirAll(gcfg.RootDir(), 0700))
-	migrationTestDBURL, err := dropAndCreateThrowawayTestDB(gcfg.DatabaseURL(), name)
+	migrationTestDBURL, err := dropAndCreateThrowawayTestDB(gcfg.DatabaseURL(), name, empty)
 	require.NoError(t, err)
 	lggr := logger.TestLogger(t)
 	db, err := pg.NewConnection(migrationTestDBURL, string(dialects.Postgres), pg.Config{
@@ -54,13 +72,11 @@ func FullTestDB(t *testing.T, name string, migrate bool, loadFixtures bool) (*co
 		os.RemoveAll(gcfg.RootDir())
 	})
 	gcfg.Overrides.DatabaseURL = null.StringFrom(migrationTestDBURL)
-	if migrate {
-		require.NoError(t, migrations.Migrate(db.DB, lggr))
-	}
+
 	if loadFixtures {
-		_, filename, _, ok := runtime.Caller(0)
+		_, filename, _, ok := runtime.Caller(1)
 		if !ok {
-			t.Fatal("could not get runtime.Caller(0)")
+			t.Fatal("could not get runtime.Caller(1)")
 		}
 		filepath := path.Join(path.Dir(filename), "../../../store/fixtures/fixtures.sql")
 		fixturesSQL, err := ioutil.ReadFile(filepath)
@@ -72,7 +88,7 @@ func FullTestDB(t *testing.T, name string, migrate bool, loadFixtures bool) (*co
 	return gcfg, db
 }
 
-func dropAndCreateThrowawayTestDB(parsed url.URL, postfix string) (string, error) {
+func dropAndCreateThrowawayTestDB(parsed url.URL, postfix string, empty bool) (string, error) {
 	if parsed.Path == "" {
 		return "", errors.New("path missing from database URL")
 	}
@@ -94,10 +110,13 @@ func dropAndCreateThrowawayTestDB(parsed url.URL, postfix string) (string, error
 	if err != nil {
 		return "", fmt.Errorf("unable to drop postgres migrations test database: %v", err)
 	}
-	// `CREATE DATABASE $1` does not seem to work w CREATE DATABASE
-	_, err = db.Exec(fmt.Sprintf("CREATE DATABASE %s", dbname))
+	if empty {
+		_, err = db.Exec(fmt.Sprintf("CREATE DATABASE %s", dbname))
+	} else {
+		_, err = db.Exec(fmt.Sprintf("CREATE DATABASE %s WITH TEMPLATE %s", dbname, cmd.PristineDBName))
+	}
 	if err != nil {
-		return "", fmt.Errorf("unable to create postgres migrations test database with name '%s': %v", dbname, err)
+		return "", fmt.Errorf("unable to create postgres test database with name '%s': %v", dbname, err)
 	}
 	parsed.Path = fmt.Sprintf("/%s", dbname)
 	return parsed.String(), nil

--- a/core/internal/features_ocr2_test.go
+++ b/core/internal/features_ocr2_test.go
@@ -87,7 +87,7 @@ func setupOCR2Contracts(t *testing.T) (*bind.TransactOpts, *backends.SimulatedBa
 }
 
 func setupNodeOCR2(t *testing.T, owner *bind.TransactOpts, port uint16, dbName string, b *backends.SimulatedBackend) (*cltest.TestApplication, string, common.Address, ocr2key.KeyBundle, *configtest.TestGeneralConfig) {
-	config, _ := heavyweight.FullTestDB(t, fmt.Sprintf("%s%d", dbName, port), true, true)
+	config, _ := heavyweight.FullTestDB(t, fmt.Sprintf("%s%d", dbName, port))
 	config.Overrides.FeatureOffchainReporting = null.BoolFrom(false)
 	config.Overrides.FeatureOffchainReporting2 = null.BoolFrom(true)
 	config.Overrides.P2PEnabled = null.BoolFrom(true)

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -494,7 +494,7 @@ func setupOCRContracts(t *testing.T) (*bind.TransactOpts, *backends.SimulatedBac
 }
 
 func setupNode(t *testing.T, owner *bind.TransactOpts, portV1, portV2 int, dbName string, b *backends.SimulatedBackend, ns ocrnetworking.NetworkingStack) (*cltest.TestApplication, string, common.Address, ocrkey.KeyV2, *configtest.TestGeneralConfig) {
-	config, _ := heavyweight.FullTestDB(t, fmt.Sprintf("%s%d", dbName, portV1), true, true)
+	config, _ := heavyweight.FullTestDB(t, fmt.Sprintf("%s%d", dbName, portV1))
 	config.Overrides.Dev = null.BoolFrom(true) // Disables ocr spec validation so we can have fast polling for the test.
 	config.Overrides.FeatureOffchainReporting = null.BoolFrom(true)
 	config.Overrides.FeatureOffchainReporting2 = null.BoolFrom(true)

--- a/core/services/fluxmonitorv2/flux_monitor_test.go
+++ b/core/services/fluxmonitorv2/flux_monitor_test.go
@@ -305,7 +305,7 @@ func setupStoreWithKey(t *testing.T) (*sqlx.DB, common.Address) {
 
 // setupStoreWithKey setups a new store and adds a key to the keystore
 func setupFullDBWithKey(t *testing.T, name string) (*sqlx.DB, common.Address) {
-	cfg, db := heavyweight.FullTestDB(t, name, true, true)
+	cfg, db := heavyweight.FullTestDB(t, name)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 	_, nodeAddr := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
 

--- a/core/services/fluxmonitorv2/integrations_test.go
+++ b/core/services/fluxmonitorv2/integrations_test.go
@@ -215,7 +215,7 @@ func startApplication(
 	fa fluxAggregatorUniverse,
 	setConfig func(cfg *configtest.TestGeneralConfig),
 ) *cltest.TestApplication {
-	config, _ := heavyweight.FullTestDB(t, dbName(t.Name()), true, true)
+	config, _ := heavyweight.FullTestDB(t, dbName(t.Name()))
 	setConfig(config)
 	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, fa.backend, fa.key)
 	require.NoError(t, app.Start(testutils.Context(t)))

--- a/core/services/keeper/integration_test.go
+++ b/core/services/keeper/integration_test.go
@@ -105,7 +105,7 @@ func TestKeeperEthIntegration(t *testing.T) {
 			backend.Commit()
 
 			// setup app
-			config, db := heavyweight.FullTestDB(t, fmt.Sprintf("keeper_eth_integration_%v", test.eip1559), true, true)
+			config, db := heavyweight.FullTestDB(t, fmt.Sprintf("keeper_eth_integration_%v", test.eip1559))
 			korm := keeper.NewORM(db, logger.TestLogger(t), nil, nil)
 			config.Overrides.GlobalEvmEIP1559DynamicFees = null.BoolFrom(test.eip1559)
 			d := 24 * time.Hour

--- a/core/services/pg/advisory_lock_test.go
+++ b/core/services/pg/advisory_lock_test.go
@@ -21,7 +21,7 @@ func newAdvisoryLock(t *testing.T, db *sqlx.DB, cfg *configtest.TestGeneralConfi
 }
 
 func Test_AdvisoryLock(t *testing.T) {
-	cfg, db := heavyweight.EmptyFullTestDB(t, "advisorylock")
+	cfg, db := heavyweight.FullTestDBEmpty(t, "advisorylock")
 	check := 1 * time.Second
 	cfg.Overrides.AdvisoryLockCheckInterval = &check
 

--- a/core/services/pg/advisory_lock_test.go
+++ b/core/services/pg/advisory_lock_test.go
@@ -21,7 +21,7 @@ func newAdvisoryLock(t *testing.T, db *sqlx.DB, cfg *configtest.TestGeneralConfi
 }
 
 func Test_AdvisoryLock(t *testing.T) {
-	cfg, db := heavyweight.FullTestDB(t, "advisorylock", false, false)
+	cfg, db := heavyweight.EmptyFullTestDB(t, "advisorylock")
 	check := 1 * time.Second
 	cfg.Overrides.AdvisoryLockCheckInterval = &check
 

--- a/core/services/pg/event_broadcaster_test.go
+++ b/core/services/pg/event_broadcaster_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestEventBroadcaster(t *testing.T) {
-	config, _ := heavyweight.FullTestDBWithoutFixtures(t, "event_broadcaster")
+	config, _ := heavyweight.FullTestDBNoFixtures(t, "event_broadcaster")
 
 	eventBroadcaster := cltest.NewEventBroadcaster(t, config.DatabaseURL())
 	require.NoError(t, eventBroadcaster.Start(testutils.Context(t)))

--- a/core/services/pg/event_broadcaster_test.go
+++ b/core/services/pg/event_broadcaster_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestEventBroadcaster(t *testing.T) {
-	config, _ := heavyweight.FullTestDB(t, "event_broadcaster", true, false)
+	config, _ := heavyweight.FullTestDBWithoutFixtures(t, "event_broadcaster")
 
 	eventBroadcaster := cltest.NewEventBroadcaster(t, config.DatabaseURL())
 	require.NoError(t, eventBroadcaster.Start(testutils.Context(t)))

--- a/core/services/pg/lease_lock_test.go
+++ b/core/services/pg/lease_lock_test.go
@@ -22,7 +22,7 @@ func newLeaseLock(t *testing.T, db *sqlx.DB, cfg *configtest.TestGeneralConfig) 
 }
 
 func Test_LeaseLock(t *testing.T) {
-	cfg, db := heavyweight.FullTestDBWithoutFixtures(t, "leaselock")
+	cfg, db := heavyweight.FullTestDBNoFixtures(t, "leaselock")
 	duration := 15 * time.Second
 	refresh := 100 * time.Millisecond
 	cfg.Overrides.LeaseLockDuration = &duration
@@ -182,7 +182,7 @@ func Test_LeaseLock(t *testing.T) {
 	require.NoError(t, db.Close())
 
 	t.Run("on virgin database", func(t *testing.T) {
-		_, db := heavyweight.EmptyFullTestDB(t, "leaselock")
+		_, db := heavyweight.FullTestDBEmpty(t, "leaselock")
 
 		leaseLock1 := newLeaseLock(t, db, cfg)
 

--- a/core/services/pg/lease_lock_test.go
+++ b/core/services/pg/lease_lock_test.go
@@ -22,7 +22,7 @@ func newLeaseLock(t *testing.T, db *sqlx.DB, cfg *configtest.TestGeneralConfig) 
 }
 
 func Test_LeaseLock(t *testing.T) {
-	cfg, db := heavyweight.FullTestDB(t, "leaselock", true, false)
+	cfg, db := heavyweight.FullTestDBWithoutFixtures(t, "leaselock")
 	duration := 15 * time.Second
 	refresh := 100 * time.Millisecond
 	cfg.Overrides.LeaseLockDuration = &duration
@@ -182,7 +182,7 @@ func Test_LeaseLock(t *testing.T) {
 	require.NoError(t, db.Close())
 
 	t.Run("on virgin database", func(t *testing.T) {
-		_, db := heavyweight.FullTestDB(t, "leaselock", false, false)
+		_, db := heavyweight.EmptyFullTestDB(t, "leaselock")
 
 		leaseLock1 := newLeaseLock(t, db, cfg)
 

--- a/core/services/vrf/integration_test.go
+++ b/core/services/vrf/integration_test.go
@@ -43,7 +43,7 @@ func TestIntegration_VRF_JPV2(t *testing.T) {
 	for _, tt := range tests {
 		test := tt
 		t.Run(test.name, func(t *testing.T) {
-			config, _ := heavyweight.FullTestDB(t, fmt.Sprintf("vrf_jpv2_%v", test.eip1559), true, true)
+			config, _ := heavyweight.FullTestDB(t, fmt.Sprintf("vrf_jpv2_%v", test.eip1559))
 			config.Overrides.GlobalEvmEIP1559DynamicFees = null.BoolFrom(test.eip1559)
 			key1 := cltest.MustGenerateRandomKey(t)
 			key2 := cltest.MustGenerateRandomKey(t)
@@ -121,7 +121,7 @@ func TestIntegration_VRF_JPV2(t *testing.T) {
 }
 
 func TestIntegration_VRF_WithBHS(t *testing.T) {
-	config, _ := heavyweight.FullTestDB(t, "vrf_with_bhs", true, true)
+	config, _ := heavyweight.FullTestDB(t, "vrf_with_bhs")
 	config.Overrides.GlobalEvmEIP1559DynamicFees = null.BoolFrom(true)
 	key := cltest.MustGenerateRandomKey(t)
 	cu := newVRFCoordinatorUniverse(t, key)

--- a/core/services/vrf/integration_v2_test.go
+++ b/core/services/vrf/integration_v2_test.go
@@ -538,7 +538,7 @@ func mineBatch(t *testing.T, requestIDs []*big.Int, subID uint64, uni coordinato
 }
 
 func TestVRFV2Integration_SingleConsumer_HappyPath_BatchFulfillment(t *testing.T) {
-	config, db := heavyweight.FullTestDB(t, "vrfv2_singleconsumer_batch_happypath", true, true)
+	config, db := heavyweight.FullTestDB(t, "vrfv2_singleconsumer_batch_happypath")
 	ownerKey := cltest.MustGenerateRandomKey(t)
 	uni := newVRFCoordinatorV2Universe(t, ownerKey, 1)
 	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, uni.backend, ownerKey)
@@ -601,7 +601,7 @@ func TestVRFV2Integration_SingleConsumer_HappyPath_BatchFulfillment(t *testing.T
 }
 
 func TestVRFV2Integration_SingleConsumer_HappyPath_BatchFulfillment_BigGasCallback(t *testing.T) {
-	config, db := heavyweight.FullTestDB(t, "vrfv2_singleconsumer_batch_bigcallback", true, true)
+	config, db := heavyweight.FullTestDB(t, "vrfv2_singleconsumer_batch_bigcallback")
 	ownerKey := cltest.MustGenerateRandomKey(t)
 	uni := newVRFCoordinatorV2Universe(t, ownerKey, 1)
 	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, uni.backend, ownerKey)
@@ -670,7 +670,7 @@ func TestVRFV2Integration_SingleConsumer_HappyPath_BatchFulfillment_BigGasCallba
 }
 
 func TestVRFV2Integration_SingleConsumer_HappyPath(t *testing.T) {
-	config, db := heavyweight.FullTestDB(t, "vrfv2_singleconsumer_happypath", true, true)
+	config, db := heavyweight.FullTestDB(t, "vrfv2_singleconsumer_happypath")
 	ownerKey := cltest.MustGenerateRandomKey(t)
 	uni := newVRFCoordinatorV2Universe(t, ownerKey, 1)
 	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, uni.backend, ownerKey)
@@ -751,7 +751,7 @@ func TestVRFV2Integration_SingleConsumer_HappyPath(t *testing.T) {
 }
 
 func TestVRFV2Integration_SingleConsumer_NeedsBlockhashStore(t *testing.T) {
-	config, db := heavyweight.FullTestDB(t, "vrfv2_needs_blockhash_store", true, true)
+	config, db := heavyweight.FullTestDB(t, "vrfv2_needs_blockhash_store")
 	ownerKey := cltest.MustGenerateRandomKey(t)
 	uni := newVRFCoordinatorV2Universe(t, ownerKey, 1)
 	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, uni.backend, ownerKey)
@@ -850,7 +850,7 @@ func TestVRFV2Integration_SingleConsumer_NeedsBlockhashStore(t *testing.T) {
 }
 
 func TestVRFV2Integration_SingleConsumer_NeedsTopUp(t *testing.T) {
-	config, db := heavyweight.FullTestDB(t, "vrfv2_singleconsumer_needstopup", true, true)
+	config, db := heavyweight.FullTestDB(t, "vrfv2_singleconsumer_needstopup")
 	ownerKey := cltest.MustGenerateRandomKey(t)
 	uni := newVRFCoordinatorV2Universe(t, ownerKey, 1)
 	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, uni.backend, ownerKey)
@@ -915,7 +915,7 @@ func TestVRFV2Integration_SingleConsumer_NeedsTopUp(t *testing.T) {
 }
 
 func TestVRFV2Integration_SingleConsumer_MultipleGasLanes(t *testing.T) {
-	config, db := heavyweight.FullTestDB(t, "vrfv2_singleconsumer_multiplegaslanes", true, true)
+	config, db := heavyweight.FullTestDB(t, "vrfv2_singleconsumer_multiplegaslanes")
 	ownerKey := cltest.MustGenerateRandomKey(t)
 	uni := newVRFCoordinatorV2Universe(t, ownerKey, 1)
 	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, uni.backend, ownerKey)
@@ -1007,7 +1007,7 @@ func TestVRFV2Integration_SingleConsumer_MultipleGasLanes(t *testing.T) {
 }
 
 func TestVRFV2Integration_SingleConsumer_AlwaysRevertingCallback_StillFulfilled(t *testing.T) {
-	config, db := heavyweight.FullTestDB(t, "vrfv2_singleconsumer_alwaysrevertingcallback", true, true)
+	config, db := heavyweight.FullTestDB(t, "vrfv2_singleconsumer_alwaysrevertingcallback")
 	ownerKey := cltest.MustGenerateRandomKey(t)
 	uni := newVRFCoordinatorV2Universe(t, ownerKey, 0)
 	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, uni.backend, ownerKey)
@@ -1192,7 +1192,7 @@ func TestSimpleConsumerExample(t *testing.T) {
 }
 
 func TestIntegrationVRFV2(t *testing.T) {
-	config, _ := heavyweight.FullTestDB(t, "vrf_v2_integration", true, true)
+	config, _ := heavyweight.FullTestDB(t, "vrf_v2_integration")
 	key := cltest.MustGenerateRandomKey(t)
 	uni := newVRFCoordinatorV2Universe(t, key, 1)
 	carol := uni.vrfConsumers[0]
@@ -1383,7 +1383,7 @@ func TestIntegrationVRFV2(t *testing.T) {
 }
 
 func TestMaliciousConsumer(t *testing.T) {
-	config, _ := heavyweight.FullTestDB(t, "vrf_v2_integration_malicious", true, true)
+	config, _ := heavyweight.FullTestDB(t, "vrf_v2_integration_malicious")
 	key := cltest.MustGenerateRandomKey(t)
 	uni := newVRFCoordinatorV2Universe(t, key, 1)
 	carol := uni.vrfConsumers[0]
@@ -1616,7 +1616,7 @@ func TestFulfillmentCost(t *testing.T) {
 }
 
 func TestStartingCountsV1(t *testing.T) {
-	cfg, db := heavyweight.FullTestDB(t, "vrf_test_starting_counts", true, false)
+	cfg, db := heavyweight.FullTestDBWithoutFixtures(t, "vrf_test_starting_counts")
 	_, err := db.Exec(`INSERT INTO evm_chains (id, created_at, updated_at) VALUES (1337, NOW(), NOW())`)
 	require.NoError(t, err)
 	_, err = db.Exec(`INSERT INTO evm_heads (hash, number, parent_hash, created_at, timestamp, evm_chain_id)

--- a/core/services/vrf/integration_v2_test.go
+++ b/core/services/vrf/integration_v2_test.go
@@ -1616,7 +1616,7 @@ func TestFulfillmentCost(t *testing.T) {
 }
 
 func TestStartingCountsV1(t *testing.T) {
-	cfg, db := heavyweight.FullTestDBWithoutFixtures(t, "vrf_test_starting_counts")
+	cfg, db := heavyweight.FullTestDBNoFixtures(t, "vrf_test_starting_counts")
 	_, err := db.Exec(`INSERT INTO evm_chains (id, created_at, updated_at) VALUES (1337, NOW(), NOW())`)
 	require.NoError(t, err)
 	_, err = db.Exec(`INSERT INTO evm_heads (hash, number, parent_hash, created_at, timestamp, evm_chain_id)

--- a/core/store/migrate/migrate_test.go
+++ b/core/store/migrate/migrate_test.go
@@ -60,7 +60,7 @@ func getOCR2Spec100() OffchainReporting2OracleSpec100 {
 }
 
 func TestMigrate_0100_BootstrapConfigs(t *testing.T) {
-	_, db := heavyweight.EmptyFullTestDB(t, migrationDir)
+	_, db := heavyweight.FullTestDBEmpty(t, migrationDir)
 	lggr := logger.TestLogger(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	err := goose.UpTo(db.DB, migrationDir, 99)
@@ -330,7 +330,7 @@ ON jobs.offchainreporting2_oracle_spec_id = ocr2.id`
 }
 
 func TestMigrate_101_GenericOCR2(t *testing.T) {
-	_, db := heavyweight.EmptyFullTestDB(t, migrationDir)
+	_, db := heavyweight.FullTestDBEmpty(t, migrationDir)
 	err := goose.UpTo(db.DB, migrationDir, 100)
 	require.NoError(t, err)
 

--- a/core/store/migrate/migrate_test.go
+++ b/core/store/migrate/migrate_test.go
@@ -60,7 +60,7 @@ func getOCR2Spec100() OffchainReporting2OracleSpec100 {
 }
 
 func TestMigrate_0100_BootstrapConfigs(t *testing.T) {
-	_, db := heavyweight.FullTestDB(t, migrationDir, false, false)
+	_, db := heavyweight.EmptyFullTestDB(t, migrationDir)
 	lggr := logger.TestLogger(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	err := goose.UpTo(db.DB, migrationDir, 99)
@@ -330,7 +330,7 @@ ON jobs.offchainreporting2_oracle_spec_id = ocr2.id`
 }
 
 func TestMigrate_101_GenericOCR2(t *testing.T) {
-	_, db := heavyweight.FullTestDB(t, migrationDir, false, false)
+	_, db := heavyweight.EmptyFullTestDB(t, migrationDir)
 	err := goose.UpTo(db.DB, migrationDir, 100)
 	require.NoError(t, err)
 


### PR DESCRIPTION
Proposal to improve test execution performance by creating full test DB `with template`.

Before (with `go clean -testcache`):
```
real    5m5.151s
user    5m47.092s
sys     0m51.325s
```

After (with `go clean -testcache`):
```
real    3m57.462s
user    3m27.108s
sys     0m31.982s
```

Gain is ~30%
