### PR TITLE
Display requestTimeout in job UI

### DIFF
--- a/core/web/presenters/job.go
+++ b/core/web/presenters/job.go
@@ -288,6 +288,7 @@ type VRFSpec struct {
 	UpdatedAt                     time.Time             `json:"updatedAt"`
 	EVMChainID                    *utils.Big            `json:"evmChainID"`
 	ChunkSize                     uint32                `json:"chunkSize"`
+	RequestTimeout                models.Duration       `json:"requestTimeout"`
 }
 
 func NewVRFSpec(spec *job.VRFSpec) *VRFSpec {
@@ -303,6 +304,7 @@ func NewVRFSpec(spec *job.VRFSpec) *VRFSpec {
 		UpdatedAt:                spec.UpdatedAt,
 		EVMChainID:               spec.EVMChainID,
 		ChunkSize:                spec.ChunkSize,
+		RequestTimeout:           models.MustMakeDuration(spec.RequestTimeout),
 	}
 }
 

--- a/operator_ui/src/screens/Job/JobView.tsx
+++ b/operator_ui/src/screens/Job/JobView.tsx
@@ -90,6 +90,7 @@ const JOB_PAYLOAD__SPEC = gql`
       batchFulfillmentEnabled
       batchFulfillmentGasMultiplier
       chunkSize
+      requestTimeout
     }
     ... on BlockhashStoreSpec {
       coordinatorV1Address

--- a/operator_ui/src/screens/Job/generateJobDefinition.test.ts
+++ b/operator_ui/src/screens/Job/generateJobDefinition.test.ts
@@ -425,6 +425,7 @@ juelsPerFeeCoinSource = "1000000000"
         publicKey:
           '0x92594ee04c179eb7d439ff1baacd98b81a7d7a6ed55c86ca428fa025bd9c914301',
         requestedConfsDelay: 0,
+        requestTimeout: '1h',
         batchCoordinatorAddress: '0x0000000000000000000000000000000000000000',
         batchFulfillmentEnabled: true,
         batchFulfillmentGasMultiplier: 1.0,
@@ -446,6 +447,7 @@ minIncomingConfirmations = 6
 pollPeriod = "10s"
 publicKey = "0x92594ee04c179eb7d439ff1baacd98b81a7d7a6ed55c86ca428fa025bd9c914301"
 requestedConfsDelay = 0
+requestTimeout = "1h"
 batchCoordinatorAddress = "0x0000000000000000000000000000000000000000"
 batchFulfillmentEnabled = true
 batchFulfillmentGasMultiplier = 1

--- a/operator_ui/src/screens/Job/generateJobDefinition.ts
+++ b/operator_ui/src/screens/Job/generateJobDefinition.ts
@@ -204,6 +204,7 @@ export const generateJobDefinition = (
           'pollPeriod',
           'publicKey',
           'requestedConfsDelay',
+          'requestTimeout',
           'batchCoordinatorAddress',
           'batchFulfillmentEnabled',
           'batchFulfillmentGasMultiplier',


### PR DESCRIPTION
<img width="774" alt="Screen Shot 2022-04-13 at 11 44 06 AM" src="https://user-images.githubusercontent.com/6530589/163137215-09375627-2562-445d-b886-535d4672d08b.png">

It wasn't displayed before, making it difficult to know what it is without querying the database.