### PR TITLE
core/web: add migration warning if run log job may have relied on JSON path dot separator

### DIFF
--- a/.github/workflows/build-custom.yml
+++ b/.github/workflows/build-custom.yml
@@ -57,7 +57,7 @@ jobs:
           ref: ${{ github.event.inputs.cl_ref }}
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.17.2'
+          go-version: ~1.17
       - name: Replace Solana deps manual flow
         if: ${{ github.event.inputs.dep_solana_sha }}
         run: |

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.17
+          go-version: ~1.17
       - name: Get Yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ~1.17
         id: go
 
       - name: Write Go Modules list

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -5,12 +5,17 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/setup-go@v2
+        with:
+          go-version: ~1.17
       - uses: actions/checkout@v2
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
           version: v1.40.1
+
+          skip-go-installation: true
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
@@ -19,7 +24,7 @@ jobs:
           args: --timeout=3m0s --tests=false
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
+          only-new-issues: true
 
           # Optional: if set to true then the action will use pre-installed Go.
           # skip-go-installation: true


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/34700/json-parse-tasks-support-custom-path-separators

The JSON parse task path separator was changed from `.` in V1 to `,` in V2. This change updates the job migration to log a warning if a run log job may have depended on the V1 separator.