### PR TITLE
Increasing test coverage for task_params.go

### DIFF
--- a/core/services/pipeline/task_object_params.go
+++ b/core/services/pipeline/task_object_params.go
@@ -129,12 +129,3 @@ func (o *ObjectParam) UnmarshalPipelineParam(val interface{}) error {
 
 	return fmt.Errorf("bad input for task: %T", val)
 }
-
-func MustNewObjectParam(val interface{}) *ObjectParam {
-	var value ObjectParam
-	err := value.UnmarshalPipelineParam(val)
-	if err != nil {
-		panic(fmt.Errorf("failed to init ObjectParam from %v, err: %w", val, err))
-	}
-	return &value
-}

--- a/core/services/pipeline/task_object_params_test.go
+++ b/core/services/pipeline/task_object_params_test.go
@@ -77,12 +77,12 @@ func TestObjectParam_Marshal(t *testing.T) {
 		input  *pipeline.ObjectParam
 		output string
 	}{
-		{"nil", pipeline.MustNewObjectParam(nil), "null"},
-		{"bool", pipeline.MustNewObjectParam(true), "true"},
-		{"integer", pipeline.MustNewObjectParam(17), `"17"`},
-		{"string", pipeline.MustNewObjectParam("hello world"), `"hello world"`},
-		{"array", pipeline.MustNewObjectParam([]int{17, 19}), "[17,19]"},
-		{"map", pipeline.MustNewObjectParam(map[string]interface{}{"key": 19}), `{"key":19}`},
+		{"nil", mustNewObjectParam(nil), "null"},
+		{"bool", mustNewObjectParam(true), "true"},
+		{"integer", mustNewObjectParam(17), `"17"`},
+		{"string", mustNewObjectParam("hello world"), `"hello world"`},
+		{"array", mustNewObjectParam([]int{17, 19}), "[17,19]"},
+		{"map", mustNewObjectParam(map[string]interface{}{"key": 19}), `{"key":19}`},
 	}
 
 	for _, test := range tests {

--- a/core/services/pipeline/task_object_params_test.go
+++ b/core/services/pipeline/task_object_params_test.go
@@ -77,12 +77,12 @@ func TestObjectParam_Marshal(t *testing.T) {
 		input  *pipeline.ObjectParam
 		output string
 	}{
-		{"nil", mustNewObjectParam(nil), "null"},
-		{"bool", mustNewObjectParam(true), "true"},
-		{"integer", mustNewObjectParam(17), `"17"`},
-		{"string", mustNewObjectParam("hello world"), `"hello world"`},
-		{"array", mustNewObjectParam([]int{17, 19}), "[17,19]"},
-		{"map", mustNewObjectParam(map[string]interface{}{"key": 19}), `{"key":19}`},
+		{"nil", mustNewObjectParam(t, nil), "null"},
+		{"bool", mustNewObjectParam(t, true), "true"},
+		{"integer", mustNewObjectParam(t, 17), `"17"`},
+		{"string", mustNewObjectParam(t, "hello world"), `"hello world"`},
+		{"array", mustNewObjectParam(t, []int{17, 19}), "[17,19]"},
+		{"map", mustNewObjectParam(t, map[string]interface{}{"key": 19}), `{"key":19}`},
 	}
 
 	for _, test := range tests {

--- a/core/services/pipeline/task_params.go
+++ b/core/services/pipeline/task_params.go
@@ -151,6 +151,14 @@ type MaybeUint64Param struct {
 	isSet bool
 }
 
+// NewMaybeUint64Param creates new instance of MaybeUint64Param
+func NewMaybeUint64Param(n uint64, isSet bool) MaybeUint64Param {
+	return MaybeUint64Param{
+		n:     n,
+		isSet: isSet,
+	}
+}
+
 func (p *MaybeUint64Param) UnmarshalPipelineParam(val interface{}) error {
 	var n uint64
 	switch v := val.(type) {
@@ -202,6 +210,14 @@ func (p MaybeUint64Param) Uint64() (uint64, bool) {
 type MaybeInt32Param struct {
 	n     int32
 	isSet bool
+}
+
+// NewMaybeInt32Param creates new instance of MaybeInt32Param
+func NewMaybeInt32Param(n int32, isSet bool) MaybeInt32Param {
+	return MaybeInt32Param{
+		n:     n,
+		isSet: isSet,
+	}
 }
 
 func (p *MaybeInt32Param) UnmarshalPipelineParam(val interface{}) error {
@@ -502,12 +518,12 @@ func (s *HashSliceParam) UnmarshalPipelineParam(val interface{}) error {
 	case string:
 		err := json.Unmarshal([]byte(v), &dsp)
 		if err != nil {
-			return err
+			return errors.Wrapf(ErrBadInput, "HashSliceParam: %v", err)
 		}
 	case []byte:
 		err := json.Unmarshal(v, &dsp)
 		if err != nil {
-			return err
+			return errors.Wrapf(ErrBadInput, "HashSliceParam: %v", err)
 		}
 	case []interface{}:
 		for _, h := range v {
@@ -518,6 +534,16 @@ func (s *HashSliceParam) UnmarshalPipelineParam(val interface{}) error {
 					return errors.Wrapf(ErrBadInput, "HashSliceParam: %v", err)
 				}
 				dsp = append(dsp, hash)
+			} else if b, is := h.([]byte); is {
+				// same semantic as AddressSliceParam
+				var hash common.Hash
+				err := hash.UnmarshalText(b)
+				if err != nil {
+					return errors.Wrapf(ErrBadInput, "HashSliceParam: %v", err)
+				}
+				dsp = append(dsp, hash)
+			} else if h, is := h.(common.Hash); is {
+				dsp = append(dsp, h)
 			} else {
 				return errors.Wrap(ErrBadInput, "HashSliceParam")
 			}
@@ -616,6 +642,13 @@ func (p *JSONPathParam) UnmarshalPipelineParam(val interface{}) error {
 
 type MaybeBigIntParam struct {
 	n *big.Int
+}
+
+// NewMaybeBigIntParam creates a new instance of MaybeBigIntParam
+func NewMaybeBigIntParam(n *big.Int) MaybeBigIntParam {
+	return MaybeBigIntParam{
+		n: n,
+	}
 }
 
 func (p *MaybeBigIntParam) UnmarshalPipelineParam(val interface{}) error {

--- a/core/services/pipeline/task_params_test.go
+++ b/core/services/pipeline/task_params_test.go
@@ -29,8 +29,8 @@ func TestStringParam_UnmarshalPipelineParam(t *testing.T) {
 		{"string", "foo bar baz", pipeline.StringParam("foo bar baz"), nil},
 		{"[]byte", []byte("foo bar baz"), pipeline.StringParam("foo bar baz"), nil},
 		{"int", 12345, pipeline.StringParam(""), pipeline.ErrBadInput},
-		{"*object", mustNewObjectParam(`boz bar bap`), pipeline.StringParam("boz bar bap"), nil},
-		{"object", *mustNewObjectParam(`boz bar bap`), pipeline.StringParam("boz bar bap"), nil},
+		{"*object", mustNewObjectParam(t, `boz bar bap`), pipeline.StringParam("boz bar bap"), nil},
+		{"object", *mustNewObjectParam(t, `boz bar bap`), pipeline.StringParam("boz bar bap"), nil},
 	}
 
 	for _, test := range tests {
@@ -60,8 +60,8 @@ func TestBytesParam_UnmarshalPipelineParam(t *testing.T) {
 		{"int", 12345, pipeline.BytesParam(nil), pipeline.ErrBadInput},
 		{"hex-invalid", "0xh", pipeline.BytesParam("0xh"), nil},
 		{"valid-hex", hexutil.MustDecode("0xd3184d"), pipeline.BytesParam(hexutil.MustDecode("0xd3184d")), nil},
-		{"*object", mustNewObjectParam(`boz bar bap`), pipeline.BytesParam("boz bar bap"), nil},
-		{"object", *mustNewObjectParam(`boz bar bap`), pipeline.BytesParam("boz bar bap"), nil},
+		{"*object", mustNewObjectParam(t, `boz bar bap`), pipeline.BytesParam("boz bar bap"), nil},
+		{"object", *mustNewObjectParam(t, `boz bar bap`), pipeline.BytesParam("boz bar bap"), nil},
 	}
 
 	for _, test := range tests {
@@ -340,8 +340,8 @@ func TestBoolParam_UnmarshalPipelineParam(t *testing.T) {
 		{"bool true", true, pipeline.BoolParam(true), nil},
 		{"bool false", false, pipeline.BoolParam(false), nil},
 		{"int", int8(123), pipeline.BoolParam(false), pipeline.ErrBadInput},
-		{"*object", mustNewObjectParam(true), pipeline.BoolParam(true), nil},
-		{"object", *mustNewObjectParam(true), pipeline.BoolParam(true), nil},
+		{"*object", mustNewObjectParam(t, true), pipeline.BoolParam(true), nil},
+		{"object", *mustNewObjectParam(t, true), pipeline.BoolParam(true), nil},
 	}
 
 	for _, test := range tests {
@@ -373,7 +373,7 @@ func TestDecimalParam_UnmarshalPipelineParam(t *testing.T) {
 		{"float32", float32(123.45), pipeline.DecimalParam(d), nil},
 		{"float64", float64(123.45), pipeline.DecimalParam(d), nil},
 		{"bool", false, pipeline.DecimalParam(dNull), pipeline.ErrBadInput},
-		{"object", mustNewObjectParam(123.45), pipeline.DecimalParam(d), nil},
+		{"object", mustNewObjectParam(t, 123.45), pipeline.DecimalParam(d), nil},
 	}
 
 	for _, test := range tests {
@@ -461,8 +461,8 @@ func TestMapParam_UnmarshalPipelineParam(t *testing.T) {
 		{"from []byte", []byte(inputStr), expected, nil},
 		{"from map", inputMap, expected, nil},
 		{"from nil", nil, pipeline.MapParam(nil), nil},
-		{"from *object", mustNewObjectParam(inputMap), expected, nil},
-		{"from object", *mustNewObjectParam(inputMap), expected, nil},
+		{"from *object", mustNewObjectParam(t, inputMap), expected, nil},
+		{"from object", *mustNewObjectParam(t, inputMap), expected, nil},
 		{"wrong type", 123, pipeline.MapParam(nil), pipeline.ErrBadInput},
 	}
 

--- a/core/services/pipeline/task_params_test.go
+++ b/core/services/pipeline/task_params_test.go
@@ -1,6 +1,7 @@
 package pipeline_test
 
 import (
+	"math/big"
 	"net/url"
 	"testing"
 
@@ -28,7 +29,8 @@ func TestStringParam_UnmarshalPipelineParam(t *testing.T) {
 		{"string", "foo bar baz", pipeline.StringParam("foo bar baz"), nil},
 		{"[]byte", []byte("foo bar baz"), pipeline.StringParam("foo bar baz"), nil},
 		{"int", 12345, pipeline.StringParam(""), pipeline.ErrBadInput},
-		{"object", pipeline.MustNewObjectParam(`boz bar bap`), pipeline.StringParam("boz bar bap"), nil},
+		{"*object", mustNewObjectParam(`boz bar bap`), pipeline.StringParam("boz bar bap"), nil},
+		{"object", *mustNewObjectParam(`boz bar bap`), pipeline.StringParam("boz bar bap"), nil},
 	}
 
 	for _, test := range tests {
@@ -58,7 +60,8 @@ func TestBytesParam_UnmarshalPipelineParam(t *testing.T) {
 		{"int", 12345, pipeline.BytesParam(nil), pipeline.ErrBadInput},
 		{"hex-invalid", "0xh", pipeline.BytesParam("0xh"), nil},
 		{"valid-hex", hexutil.MustDecode("0xd3184d"), pipeline.BytesParam(hexutil.MustDecode("0xd3184d")), nil},
-		{"object", pipeline.MustNewObjectParam(`boz bar bap`), pipeline.BytesParam("boz bar bap"), nil},
+		{"*object", mustNewObjectParam(`boz bar bap`), pipeline.BytesParam("boz bar bap"), nil},
+		{"object", *mustNewObjectParam(`boz bar bap`), pipeline.BytesParam("boz bar bap"), nil},
 	}
 
 	for _, test := range tests {
@@ -181,6 +184,7 @@ func TestUint64Param_UnmarshalPipelineParam(t *testing.T) {
 		{"uint16", uint16(123), pipeline.Uint64Param(123), nil},
 		{"uint32", uint32(123), pipeline.Uint64Param(123), nil},
 		{"uint64", uint64(123), pipeline.Uint64Param(123), nil},
+		{"float64", float64(123), pipeline.Uint64Param(123), nil},
 		{"bool", true, pipeline.Uint64Param(0), pipeline.ErrBadInput},
 	}
 
@@ -190,6 +194,131 @@ func TestUint64Param_UnmarshalPipelineParam(t *testing.T) {
 			t.Parallel()
 
 			var p pipeline.Uint64Param
+			err := p.UnmarshalPipelineParam(test.input)
+			require.Equal(t, test.err, errors.Cause(err))
+			require.Equal(t, test.expected, p)
+		})
+	}
+}
+
+func TestMaybeUint64Param_UnmarshalPipelineParam(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected interface{}
+		err      error
+	}{
+		{"string", "123", pipeline.NewMaybeUint64Param(123, true), nil},
+		{"int", int(123), pipeline.NewMaybeUint64Param(123, true), nil},
+		{"int8", int8(123), pipeline.NewMaybeUint64Param(123, true), nil},
+		{"int16", int16(123), pipeline.NewMaybeUint64Param(123, true), nil},
+		{"int32", int32(123), pipeline.NewMaybeUint64Param(123, true), nil},
+		{"int64", int64(123), pipeline.NewMaybeUint64Param(123, true), nil},
+		{"uint", uint(123), pipeline.NewMaybeUint64Param(123, true), nil},
+		{"uint8", uint8(123), pipeline.NewMaybeUint64Param(123, true), nil},
+		{"uint16", uint16(123), pipeline.NewMaybeUint64Param(123, true), nil},
+		{"uint32", uint32(123), pipeline.NewMaybeUint64Param(123, true), nil},
+		{"uint64", uint64(123), pipeline.NewMaybeUint64Param(123, true), nil},
+		{"float64", float64(123), pipeline.NewMaybeUint64Param(123, true), nil},
+		{"bool", true, pipeline.NewMaybeUint64Param(0, false), pipeline.ErrBadInput},
+		{"empty string", "", pipeline.NewMaybeUint64Param(0, false), nil},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var p pipeline.MaybeUint64Param
+			err := p.UnmarshalPipelineParam(test.input)
+			require.Equal(t, test.err, errors.Cause(err))
+			require.Equal(t, test.expected, p)
+		})
+	}
+}
+
+func TestMaybeBigIntParam_UnmarshalPipelineParam(t *testing.T) {
+	t.Parallel()
+
+	fromInt := func(n int64) pipeline.MaybeBigIntParam {
+		return pipeline.NewMaybeBigIntParam(big.NewInt(n))
+	}
+
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected interface{}
+		err      error
+	}{
+		{"string", "123", fromInt(123), nil},
+		{"empty string", "", pipeline.NewMaybeBigIntParam(nil), nil},
+		{"nil", nil, pipeline.NewMaybeBigIntParam(nil), nil},
+		{"*big.Int", big.NewInt(123), fromInt(123), nil},
+		{"int", int(123), fromInt(123), nil},
+		{"int8", int8(123), fromInt(123), nil},
+		{"int16", int16(123), fromInt(123), nil},
+		{"int32", int32(123), fromInt(123), nil},
+		{"int64", int64(123), fromInt(123), nil},
+		{"uint", uint(123), fromInt(123), nil},
+		{"uint8", uint8(123), fromInt(123), nil},
+		{"uint16", uint16(123), fromInt(123), nil},
+		{"uint32", uint32(123), fromInt(123), nil},
+		{"uint64", uint64(123), fromInt(123), nil},
+		{"float64", float64(123), fromInt(123), nil},
+		{"bool", true, pipeline.NewMaybeBigIntParam(nil), pipeline.ErrBadInput},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var p pipeline.MaybeBigIntParam
+			err := p.UnmarshalPipelineParam(test.input)
+			require.Equal(t, test.err, errors.Cause(err))
+			require.Equal(t, test.expected, p)
+		})
+	}
+}
+
+func TestMaybeInt32Param_UnmarshalPipelineParam(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected interface{}
+		err      error
+	}{
+		{"string", "123", pipeline.NewMaybeInt32Param(123, true), nil},
+		{"int", int(123), pipeline.NewMaybeInt32Param(123, true), nil},
+		{"int8", int8(123), pipeline.NewMaybeInt32Param(123, true), nil},
+		{"int16", int16(123), pipeline.NewMaybeInt32Param(123, true), nil},
+		{"int32", int32(123), pipeline.NewMaybeInt32Param(123, true), nil},
+		{"int64", int64(123), pipeline.NewMaybeInt32Param(123, true), nil},
+		{"uint", uint(123), pipeline.NewMaybeInt32Param(123, true), nil},
+		{"uint8", uint8(123), pipeline.NewMaybeInt32Param(123, true), nil},
+		{"uint16", uint16(123), pipeline.NewMaybeInt32Param(123, true), nil},
+		{"uint32", uint32(123), pipeline.NewMaybeInt32Param(123, true), nil},
+		{"uint64", uint64(123), pipeline.NewMaybeInt32Param(123, true), nil},
+		{"float64", float64(123), pipeline.NewMaybeInt32Param(123, true), nil},
+		{"bool", true, pipeline.NewMaybeInt32Param(0, false), pipeline.ErrBadInput},
+		{"empty string", "", pipeline.NewMaybeInt32Param(0, false), nil},
+		{"string overflow", "100000000000", pipeline.NewMaybeInt32Param(0, false), pipeline.ErrBadInput},
+		{"int64 overflow", int64(123 << 32), pipeline.NewMaybeInt32Param(0, false), pipeline.ErrBadInput},
+		{"negative int64 overflow", -int64(123 << 32), pipeline.NewMaybeInt32Param(0, false), pipeline.ErrBadInput},
+		{"uint64 overflow", uint64(123 << 32), pipeline.NewMaybeInt32Param(0, false), pipeline.ErrBadInput},
+		{"float overflow", float64(123 << 32), pipeline.NewMaybeInt32Param(0, false), pipeline.ErrBadInput},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var p pipeline.MaybeInt32Param
 			err := p.UnmarshalPipelineParam(test.input)
 			require.Equal(t, test.err, errors.Cause(err))
 			require.Equal(t, test.expected, p)
@@ -211,7 +340,8 @@ func TestBoolParam_UnmarshalPipelineParam(t *testing.T) {
 		{"bool true", true, pipeline.BoolParam(true), nil},
 		{"bool false", false, pipeline.BoolParam(false), nil},
 		{"int", int8(123), pipeline.BoolParam(false), pipeline.ErrBadInput},
-		{"object", pipeline.MustNewObjectParam(true), pipeline.BoolParam(true), nil},
+		{"*object", mustNewObjectParam(true), pipeline.BoolParam(true), nil},
+		{"object", *mustNewObjectParam(true), pipeline.BoolParam(true), nil},
 	}
 
 	for _, test := range tests {
@@ -243,7 +373,7 @@ func TestDecimalParam_UnmarshalPipelineParam(t *testing.T) {
 		{"float32", float32(123.45), pipeline.DecimalParam(d), nil},
 		{"float64", float64(123.45), pipeline.DecimalParam(d), nil},
 		{"bool", false, pipeline.DecimalParam(dNull), pipeline.ErrBadInput},
-		{"object", pipeline.MustNewObjectParam(123.45), pipeline.DecimalParam(d), nil},
+		{"object", mustNewObjectParam(123.45), pipeline.DecimalParam(d), nil},
 	}
 
 	for _, test := range tests {
@@ -321,15 +451,32 @@ func TestMapParam_UnmarshalPipelineParam(t *testing.T) {
 		},
 	}
 
-	var got1 pipeline.MapParam
-	err := got1.UnmarshalPipelineParam(inputStr)
-	require.NoError(t, err)
-	require.Equal(t, expected, got1)
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected interface{}
+		err      error
+	}{
+		{"from string", inputStr, expected, nil},
+		{"from []byte", []byte(inputStr), expected, nil},
+		{"from map", inputMap, expected, nil},
+		{"from nil", nil, pipeline.MapParam(nil), nil},
+		{"from *object", mustNewObjectParam(inputMap), expected, nil},
+		{"from object", *mustNewObjectParam(inputMap), expected, nil},
+		{"wrong type", 123, pipeline.MapParam(nil), pipeline.ErrBadInput},
+	}
 
-	var got2 pipeline.MapParam
-	err = got2.UnmarshalPipelineParam(inputMap)
-	require.NoError(t, err)
-	require.Equal(t, expected, got2)
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var p pipeline.MapParam
+			err := p.UnmarshalPipelineParam(test.input)
+			require.Equal(t, test.err, errors.Cause(err))
+			require.Equal(t, test.expected, p)
+		})
+	}
 }
 
 func TestSliceParam_UnmarshalPipelineParam(t *testing.T) {
@@ -345,6 +492,7 @@ func TestSliceParam_UnmarshalPipelineParam(t *testing.T) {
 		{"[]byte", []byte(`[1, 2, 3]`), pipeline.SliceParam([]interface{}{float64(1), float64(2), float64(3)}), nil},
 		{"string", `[1, 2, 3]`, pipeline.SliceParam([]interface{}{float64(1), float64(2), float64(3)}), nil},
 		{"bool", true, pipeline.SliceParam(nil), pipeline.ErrBadInput},
+		{"nil", nil, pipeline.SliceParam(nil), nil},
 	}
 
 	for _, test := range tests {
@@ -356,6 +504,44 @@ func TestSliceParam_UnmarshalPipelineParam(t *testing.T) {
 			err := p.UnmarshalPipelineParam(test.input)
 			require.Equal(t, test.err, errors.Cause(err))
 			require.Equal(t, test.expected, p)
+		})
+	}
+}
+
+func TestHashSliceParam_UnmarshalPipelineParam(t *testing.T) {
+	t.Parallel()
+
+	hash1 := common.HexToHash("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+	hash2 := common.HexToHash("0xcafebabecafebabecafebabecafebabecafebabedeadbeefdeadbeefdeadbeef")
+	expected := pipeline.HashSliceParam{hash1, hash2}
+
+	tests := []struct {
+		name     string
+		input    interface{}
+		expected interface{}
+		err      error
+	}{
+		{"json", `[ "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", "0xcafebabecafebabecafebabecafebabecafebabedeadbeefdeadbeefdeadbeef" ]`, expected, nil},
+		{"[]common.Hash", []common.Hash{hash1, hash2}, expected, nil},
+		{"[]interface{} with common.Hash", []interface{}{hash1, hash2}, expected, nil},
+		{"[]interface{} with strings", []interface{}{hash1.String(), hash2.String()}, expected, nil},
+		{"[]interface{} with []byte", []interface{}{[]byte(hash1.String()), []byte(hash2.String())}, expected, nil},
+		{"nil", nil, pipeline.HashSliceParam(nil), nil},
+		{"bad json", `[ "0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef" "0xcafebabecafebabecafebabecafebabecafebabedeadbeefdeadbeefdeadbeef" ]`, nil, pipeline.ErrBadInput},
+		{"[]interface{} with bad types", []interface{}{123, true}, nil, pipeline.ErrBadInput},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			var p pipeline.HashSliceParam
+			err := p.UnmarshalPipelineParam(test.input)
+			require.Equal(t, test.err, errors.Cause(err))
+			if test.expected != nil {
+				require.Equal(t, test.expected, p)
+			}
 		})
 	}
 }
@@ -373,6 +559,7 @@ func TestDecimalSliceParam_UnmarshalPipelineParam(t *testing.T) {
 	t.Parallel()
 
 	expected := pipeline.DecimalSliceParam{*mustDecimal(t, "1.1"), *mustDecimal(t, "2.2"), *mustDecimal(t, "3.3")}
+	decimalsSlice := []decimal.Decimal{*mustDecimal(t, "1.1"), *mustDecimal(t, "2.2"), *mustDecimal(t, "3.3")}
 
 	tests := []struct {
 		name     string
@@ -385,6 +572,8 @@ func TestDecimalSliceParam_UnmarshalPipelineParam(t *testing.T) {
 		{"[]byte", `[1.1, "2.2", 3.3]`, expected, nil},
 		{"[]interface{} with error", `[1.1, true, "abc"]`, pipeline.DecimalSliceParam(nil), pipeline.ErrBadInput},
 		{"bool", true, pipeline.DecimalSliceParam(nil), pipeline.ErrBadInput},
+		{"nil", nil, pipeline.DecimalSliceParam(nil), nil},
+		{"[]decimal.Decimal", decimalsSlice, expected, nil},
 	}
 
 	for _, test := range tests {
@@ -415,6 +604,7 @@ func TestJSONPathParam_UnmarshalPipelineParam(t *testing.T) {
 		{"string", `1.1,2.2,3.3,sergey`, expected, nil},
 		{"[]byte", []byte(`1.1,2.2,3.3,sergey`), expected, nil},
 		{"bool", true, pipeline.JSONPathParam(nil), pipeline.ErrBadInput},
+		{"nil", nil, pipeline.JSONPathParam(nil), nil},
 	}
 
 	for _, test := range tests {

--- a/core/services/pipeline/test_helpers_test.go
+++ b/core/services/pipeline/test_helpers_test.go
@@ -3,6 +3,7 @@ package pipeline_test
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
+	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	"github.com/smartcontractkit/sqlx"
 )
 
@@ -47,4 +49,13 @@ func makeBridge(t *testing.T, db *sqlx.DB, expectedRequest, response interface{}
 	_, bt := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{URL: bridgeFeedURL.String()}, cfg)
 
 	return server, bt.Name.String()
+}
+
+func mustNewObjectParam(val interface{}) *pipeline.ObjectParam {
+	var value pipeline.ObjectParam
+	err := value.UnmarshalPipelineParam(val)
+	if err != nil {
+		panic(fmt.Errorf("failed to init ObjectParam from %v, err: %w", val, err))
+	}
+	return &value
 }

--- a/core/services/pipeline/test_helpers_test.go
+++ b/core/services/pipeline/test_helpers_test.go
@@ -3,7 +3,6 @@ package pipeline_test
 import (
 	"bytes"
 	"encoding/json"
-	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
@@ -51,11 +50,10 @@ func makeBridge(t *testing.T, db *sqlx.DB, expectedRequest, response interface{}
 	return server, bt.Name.String()
 }
 
-func mustNewObjectParam(val interface{}) *pipeline.ObjectParam {
+func mustNewObjectParam(t *testing.T, val interface{}) *pipeline.ObjectParam {
 	var value pipeline.ObjectParam
-	err := value.UnmarshalPipelineParam(val)
-	if err != nil {
-		panic(fmt.Errorf("failed to init ObjectParam from %v, err: %w", val, err))
+	if err := value.UnmarshalPipelineParam(val); err != nil {
+		t.Fatalf("failed to init ObjectParam from %v, err: %v", val, err)
 	}
 	return &value
 }


### PR DESCRIPTION
Part of https://app.shortcut.com/chainlinklabs/story/36835/add-tests-core-services-pipeline
