### PR TITLE
core/chains: simplify generic ORM types

### DIFF
--- a/core/chains/evm/chain_set.go
+++ b/core/chains/evm/chain_set.go
@@ -361,11 +361,20 @@ func LoadChainSet(opts ChainSetOpts) (ChainSet, error) {
 	if err := checkOpts(&opts); err != nil {
 		return nil, err
 	}
-	dbchains, nodes, err := opts.ORM.EnabledChainsWithNodes()
+	chains, err := opts.ORM.EnabledChains()
 	if err != nil {
 		return nil, errors.Wrap(err, "error loading chains")
 	}
-	return NewChainSet(opts, dbchains, nodes)
+	nodesSlice, _, err := opts.ORM.Nodes(0, -1)
+	if err != nil {
+		return nil, errors.Wrap(err, "error loading nodes")
+	}
+	nodes := make(map[string][]types.Node)
+	for _, n := range nodesSlice {
+		id := n.EVMChainID.String()
+		nodes[id] = append(nodes[id], n)
+	}
+	return NewChainSet(opts, chains, nodes)
 }
 
 func NewChainSet(opts ChainSetOpts, dbchains []types.Chain, nodes map[string][]types.Node) (ChainSet, error) {

--- a/core/chains/evm/legacy.go
+++ b/core/chains/evm/legacy.go
@@ -10,11 +10,12 @@ import (
 	"github.com/pkg/errors"
 	"gopkg.in/guregu/null.v4"
 
+	"github.com/smartcontractkit/sqlx"
+
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/utils"
-	"github.com/smartcontractkit/sqlx"
 )
 
 type LegacyEthNodeConfig interface {

--- a/core/chains/evm/orm.go
+++ b/core/chains/evm/orm.go
@@ -10,35 +10,8 @@ import (
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
-type orm struct {
-	*chains.ChainsORM[utils.Big, types.ChainCfg, types.Chain]
-	*chains.NodesORM[utils.Big, types.NewNode, types.Node]
-}
-
-var _ types.ORM = (*orm)(nil)
-
 // NewORM returns a new EVM ORM
 func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) types.ORM {
 	q := pg.NewQ(db, lggr.Named("EVMORM"), cfg)
-	return &orm{
-		chains.NewChainsORM[utils.Big, types.ChainCfg, types.Chain](q, "evm"),
-		chains.NewNodesORM[utils.Big, types.NewNode, types.Node](q, "evm", "ws_url", "http_url", "send_only"),
-	}
-}
-
-func (o *orm) EnabledChainsWithNodes() ([]types.Chain, map[string][]types.Node, error) {
-	chains, err := o.EnabledChains()
-	if err != nil {
-		return nil, nil, err
-	}
-	nodes, _, err := o.Nodes(0, -1)
-	if err != nil {
-		return nil, nil, err
-	}
-	nodemap := make(map[string][]types.Node)
-	for _, n := range nodes {
-		id := n.EVMChainID.String()
-		nodemap[id] = append(nodemap[id], n)
-	}
-	return chains, nodemap, nil
+	return chains.NewORM[utils.Big, types.ChainCfg, types.Node](q, "evm", "ws_url", "http_url", "send_only")
 }

--- a/core/chains/evm/orm_test.go
+++ b/core/chains/evm/orm_test.go
@@ -38,7 +38,7 @@ func mustInsertChain(t *testing.T, orm types.ORM) types.Chain {
 func mustInsertNode(t *testing.T, orm types.ORM, chainID utils.Big) types.Node {
 	t.Helper()
 
-	params := types.NewNode{
+	params := types.Node{
 		Name:       "Test node",
 		EVMChainID: chainID,
 		WSURL:      null.StringFrom("ws://localhost:8546"),
@@ -90,7 +90,7 @@ func Test_EVMORM_CreateNode(t *testing.T) {
 	_, initialCount, err := orm.Nodes(0, 25)
 	require.NoError(t, err)
 
-	params := types.NewNode{
+	params := types.Node{
 		Name:       "Test node",
 		EVMChainID: chain.ID,
 		WSURL:      null.StringFrom("ws://localhost:8546"),

--- a/core/chains/evm/types/types.go
+++ b/core/chains/evm/types/types.go
@@ -32,17 +32,17 @@ type ChainConfigORM interface {
 	Clear(chainID utils.Big, key string) error
 }
 
-//go:generate mockery --name ORM --output ./../mocks/ --case=underscore
 type ORM interface {
-	EnabledChainsWithNodes() ([]Chain, map[string][]Node, error)
 	Chain(id utils.Big, qopts ...pg.QOpt) (chain Chain, err error)
+	Chains(offset, limit int, qopts ...pg.QOpt) ([]Chain, int, error)
 	CreateChain(id utils.Big, config ChainCfg, qopts ...pg.QOpt) (Chain, error)
 	UpdateChain(id utils.Big, enabled bool, config ChainCfg, qopts ...pg.QOpt) (Chain, error)
 	DeleteChain(id utils.Big, qopts ...pg.QOpt) error
-	Chains(offset, limit int, qopts ...pg.QOpt) ([]Chain, int, error)
-	CreateNode(data NewNode, qopts ...pg.QOpt) (Node, error)
-	DeleteNode(id int32, qopts ...pg.QOpt) error
 	GetChainsByIDs(ids []utils.Big) (chains []Chain, err error)
+	EnabledChains(...pg.QOpt) ([]Chain, error)
+
+	CreateNode(data Node, qopts ...pg.QOpt) (Node, error)
+	DeleteNode(id int32, qopts ...pg.QOpt) error
 	GetNodesByChainIDs(chainIDs []utils.Big, qopts ...pg.QOpt) (nodes []Node, err error)
 	Node(id int32, qopts ...pg.QOpt) (Node, error)
 	Nodes(offset, limit int, qopts ...pg.QOpt) ([]Node, int, error)

--- a/core/chains/orm.go
+++ b/core/chains/orm.go
@@ -12,37 +12,81 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
-// Chain is a generic DB chain for any configuration type.
-// CFG normally implements sql.Scanner and driver.Valuer, but that is not enforced here.
+// ORM manages chains and nodes.
+//
+// I: Chain ID
+// C: Chain Config
+// N: Node including these default fields:
+//  ID        int32
+//  Name      string
+//  CreatedAt time.Time
+//  UpdatedAt time.Time
+type ORM[I, C, N any] interface {
+	Chain(I, ...pg.QOpt) (Chain[I, C], error)
+	Chains(offset, limit int, qopts ...pg.QOpt) ([]Chain[I, C], int, error)
+	CreateChain(id I, config C, qopts ...pg.QOpt) (Chain[I, C], error)
+	UpdateChain(id I, enabled bool, config C, qopts ...pg.QOpt) (Chain[I, C], error)
+	DeleteChain(id I, qopts ...pg.QOpt) error
+	GetChainsByIDs(ids []I) (chains []Chain[I, C], err error)
+	EnabledChains(...pg.QOpt) ([]Chain[I, C], error)
+
+	CreateNode(N, ...pg.QOpt) (N, error)
+	DeleteNode(int32, ...pg.QOpt) error
+	GetNodesByChainIDs(chainIDs []I, qopts ...pg.QOpt) (nodes []N, err error)
+	Node(int32, ...pg.QOpt) (N, error)
+	NodeNamed(string, ...pg.QOpt) (N, error)
+	Nodes(offset, limit int, qopts ...pg.QOpt) (nodes []N, count int, err error)
+	NodesForChain(chainID I, offset, limit int, qopts ...pg.QOpt) (nodes []N, count int, err error)
+
+	StoreString(chainID I, key, val string) error
+	Clear(chainID I, key string) error
+}
+
+type orm[I, C, N any] struct {
+	*chainsORM[I, C]
+	*nodesORM[I, N]
+}
+
+// NewORM returns an ORM backed by q, for the tables <prefix>_chains and <prefix>_nodes with column <prefix>_chain_id.
+// Additional Node fields should be included in nodeCols.
+func NewORM[I, C, N any](q pg.Q, prefix string, nodeCols ...string) ORM[I, C, N] {
+	return orm[I, C, N]{
+		newChainsORM[I, C](q, prefix),
+		newNodesORM[I, N](q, prefix, nodeCols...),
+	}
+}
+
+// Chain is a generic DB chain for any configuration C and chain id I.
+// C normally implements sql.Scanner and driver.Valuer, but that is not enforced here.
 // A Chain type alias can be used for convenience:
 // 	type Chain = chains.Chain[string, pkg.ChainCfg]
-type Chain[ID, CFG any] struct {
-	ID        ID
-	Cfg       CFG
+type Chain[I, C any] struct {
+	ID        I
+	Cfg       C
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	Enabled   bool
 }
 
-// ChainsORM is a generic ORM for chains.
-type ChainsORM[ID, CFG any, CH Chain[ID, CFG]] struct {
+// chainsORM is a generic ORM for chains.
+type chainsORM[I, C any] struct {
 	q      pg.Q
 	prefix string
 }
 
-// NewChainsORM returns an ChainsORM backed by q, for the table <prefix>_chains.
-func NewChainsORM[ID, CFG any, CH Chain[ID, CFG]](q pg.Q, prefix string) *ChainsORM[ID, CFG, CH] {
-	return &ChainsORM[ID, CFG, CH]{q: q, prefix: prefix}
+// newChainsORM returns an chainsORM backed by q, for the table <prefix>_chains.
+func newChainsORM[I, C any](q pg.Q, prefix string) *chainsORM[I, C] {
+	return &chainsORM[I, C]{q: q, prefix: prefix}
 }
 
-func (o *ChainsORM[ID, CFG, CH]) Chain(id ID, qopts ...pg.QOpt) (dbchain CH, err error) {
+func (o *chainsORM[I, C]) Chain(id I, qopts ...pg.QOpt) (dbchain Chain[I, C], err error) {
 	q := o.q.WithOpts(qopts...)
 	chainSQL := fmt.Sprintf(`SELECT * FROM %s_chains WHERE id = $1;`, o.prefix)
 	err = q.Get(&dbchain, chainSQL, id)
 	return
 }
 
-func (o *ChainsORM[ID, CFG, CH]) GetChainsByIDs(ids []ID) (chains []CH, err error) {
+func (o *chainsORM[I, C]) GetChainsByIDs(ids []I) (chains []Chain[I, C], err error) {
 	sql := fmt.Sprintf(`SELECT * FROM %s_chains WHERE id = ANY($1) ORDER BY created_at, id;`, o.prefix)
 
 	chainIDs := pq.Array(ids)
@@ -53,14 +97,14 @@ func (o *ChainsORM[ID, CFG, CH]) GetChainsByIDs(ids []ID) (chains []CH, err erro
 	return chains, nil
 }
 
-func (o *ChainsORM[ID, CFG, CH]) CreateChain(id ID, config CFG, qopts ...pg.QOpt) (chain CH, err error) {
+func (o *chainsORM[I, C]) CreateChain(id I, config C, qopts ...pg.QOpt) (chain Chain[I, C], err error) {
 	q := o.q.WithOpts(qopts...)
 	sql := fmt.Sprintf(`INSERT INTO %s_chains (id, cfg, created_at, updated_at) VALUES ($1, $2, now(), now()) RETURNING *`, o.prefix)
 	err = q.Get(&chain, sql, id, config)
 	return
 }
 
-func (o *ChainsORM[ID, CFG, CH]) UpdateChain(id ID, enabled bool, config CFG, qopts ...pg.QOpt) (chain CH, err error) {
+func (o *chainsORM[I, C]) UpdateChain(id I, enabled bool, config C, qopts ...pg.QOpt) (chain Chain[I, C], err error) {
 	q := o.q.WithOpts(qopts...)
 	sql := fmt.Sprintf(`UPDATE %s_chains SET enabled = $1, cfg = $2, updated_at = now() WHERE id = $3 RETURNING *`, o.prefix)
 	err = q.Get(&chain, sql, enabled, config, id)
@@ -68,7 +112,7 @@ func (o *ChainsORM[ID, CFG, CH]) UpdateChain(id ID, enabled bool, config CFG, qo
 }
 
 // StoreString saves a string value into the config for the given chain and key
-func (o *ChainsORM[ID, CFG, CH]) StoreString(chainID ID, name, val string) error {
+func (o *chainsORM[I, C]) StoreString(chainID I, name, val string) error {
 	s := fmt.Sprintf(`UPDATE %s_chains SET cfg = cfg || jsonb_build_object($1::text, $2::text) WHERE id = $3`, o.prefix)
 	res, err := o.q.Exec(s, name, val, chainID)
 	if err != nil {
@@ -85,7 +129,7 @@ func (o *ChainsORM[ID, CFG, CH]) StoreString(chainID ID, name, val string) error
 }
 
 // Clear deletes a config value for the given chain and key
-func (o *ChainsORM[ID, CFG, CH]) Clear(chainID ID, name string) error {
+func (o *chainsORM[I, C]) Clear(chainID I, name string) error {
 	s := fmt.Sprintf(`UPDATE %s_chains SET cfg = cfg - $1 WHERE id = $2`, o.prefix)
 	res, err := o.q.Exec(s, name, chainID)
 	if err != nil {
@@ -101,7 +145,7 @@ func (o *ChainsORM[ID, CFG, CH]) Clear(chainID ID, name string) error {
 	return nil
 }
 
-func (o *ChainsORM[ID, CFG, CH]) DeleteChain(id ID, qopts ...pg.QOpt) error {
+func (o *chainsORM[I, C]) DeleteChain(id I, qopts ...pg.QOpt) error {
 	q := o.q.WithOpts(qopts...)
 	query := fmt.Sprintf(`DELETE FROM %s_chains WHERE id = $1`, o.prefix)
 	result, err := q.Exec(query, id)
@@ -118,7 +162,7 @@ func (o *ChainsORM[ID, CFG, CH]) DeleteChain(id ID, qopts ...pg.QOpt) error {
 	return nil
 }
 
-func (o *ChainsORM[ID, CFG, CH]) Chains(offset, limit int, qopts ...pg.QOpt) (chains []CH, count int, err error) {
+func (o *chainsORM[I, C]) Chains(offset, limit int, qopts ...pg.QOpt) (chains []Chain[I, C], count int, err error) {
 	err = o.q.WithOpts(qopts...).Transaction(func(q pg.Queryer) error {
 		if err = q.Get(&count, fmt.Sprintf("SELECT COUNT(*) FROM %s_chains", o.prefix)); err != nil {
 			return errors.Wrap(err, "failed to fetch chains count")
@@ -132,7 +176,7 @@ func (o *ChainsORM[ID, CFG, CH]) Chains(offset, limit int, qopts ...pg.QOpt) (ch
 	return
 }
 
-func (o *ChainsORM[ID, CFG, CH]) EnabledChains(qopts ...pg.QOpt) (chains []CH, err error) {
+func (o *chainsORM[I, C]) EnabledChains(qopts ...pg.QOpt) (chains []Chain[I, C], err error) {
 	q := o.q.WithOpts(qopts...)
 	chainsSQL := fmt.Sprintf(`SELECT * FROM %s_chains WHERE enabled ORDER BY created_at, id;`, o.prefix)
 	if err = q.Select(&chains, chainsSQL); err != nil {
@@ -141,20 +185,14 @@ func (o *ChainsORM[ID, CFG, CH]) EnabledChains(qopts ...pg.QOpt) (chains []CH, e
 	return
 }
 
-// NodesORM is a generic ORM for nodes.
-// ID is the chain id.
-// NEW contains the subset of fields for creating new nodes.
-//
-// OPT: shared generic Node = db.Node[whichever.Node]
-type NodesORM[ID, NEW, N any] struct {
+// nodesORM is a generic ORM for nodes.
+type nodesORM[I, N any] struct {
 	q           pg.Q
 	prefix      string
 	createNodeQ string
 }
 
-// NewNodesORM returns a NodesORM backed by q, for the table <prefix>_nodes.
-// NEW must have fields matching the column <prefix>_chain_id, as well as the given nodeCols.
-func NewNodesORM[ID, NEW, N any](q pg.Q, prefix string, nodeCols ...string) *NodesORM[ID, NEW, N] {
+func newNodesORM[I, N any](q pg.Q, prefix string, nodeCols ...string) *nodesORM[I, N] {
 	// pre-compute query for CreateNode
 	var withColon []string
 	for _, c := range nodeCols {
@@ -164,10 +202,10 @@ func NewNodesORM[ID, NEW, N any](q pg.Q, prefix string, nodeCols ...string) *Nod
 		VALUES (:name, :%s_chain_id, %s, now(), now())
 		RETURNING *;`, prefix, prefix, strings.Join(nodeCols, ", "), prefix, strings.Join(withColon, ", "))
 
-	return &NodesORM[ID, NEW, N]{q: q, prefix: prefix, createNodeQ: query}
+	return &nodesORM[I, N]{q: q, prefix: prefix, createNodeQ: query}
 }
 
-func (o *NodesORM[ID, NEW, N]) CreateNode(data NEW, qopts ...pg.QOpt) (node N, err error) {
+func (o *nodesORM[I, N]) CreateNode(data N, qopts ...pg.QOpt) (node N, err error) {
 	q := o.q.WithOpts(qopts...)
 	stmt, err := q.PrepareNamed(o.createNodeQ)
 	if err != nil {
@@ -177,7 +215,7 @@ func (o *NodesORM[ID, NEW, N]) CreateNode(data NEW, qopts ...pg.QOpt) (node N, e
 	return node, err
 }
 
-func (o *NodesORM[ID, NEW, N]) DeleteNode(id int32, qopts ...pg.QOpt) error {
+func (o *nodesORM[I, N]) DeleteNode(id int32, qopts ...pg.QOpt) error {
 	q := o.q.WithOpts(qopts...)
 	query := fmt.Sprintf(`DELETE FROM %s_nodes WHERE id = $1`, o.prefix)
 	result, err := q.Exec(query, id)
@@ -194,21 +232,21 @@ func (o *NodesORM[ID, NEW, N]) DeleteNode(id int32, qopts ...pg.QOpt) error {
 	return nil
 }
 
-func (o *NodesORM[ID, NEW, N]) Node(id int32, qopts ...pg.QOpt) (node N, err error) {
+func (o *nodesORM[I, N]) Node(id int32, qopts ...pg.QOpt) (node N, err error) {
 	q := o.q.WithOpts(qopts...)
 	err = q.Get(&node, fmt.Sprintf("SELECT * FROM %s_nodes WHERE id = $1;", o.prefix), id)
 
 	return
 }
 
-func (o *NodesORM[ID, NEW, N]) NodeNamed(name string, qopts ...pg.QOpt) (node N, err error) {
+func (o *nodesORM[I, N]) NodeNamed(name string, qopts ...pg.QOpt) (node N, err error) {
 	q := o.q.WithOpts(qopts...)
 	err = q.Get(&node, fmt.Sprintf("SELECT * FROM %s_nodes WHERE name = $1;", o.prefix), name)
 
 	return
 }
 
-func (o *NodesORM[ID, NEW, N]) Nodes(offset, limit int, qopts ...pg.QOpt) (nodes []N, count int, err error) {
+func (o *nodesORM[I, N]) Nodes(offset, limit int, qopts ...pg.QOpt) (nodes []N, count int, err error) {
 	err = o.q.WithOpts(qopts...).Transaction(func(q pg.Queryer) error {
 		if err = q.Get(&count, fmt.Sprintf("SELECT COUNT(*) FROM %s_nodes", o.prefix)); err != nil {
 			return errors.Wrap(err, "failed to fetch nodes count")
@@ -222,7 +260,7 @@ func (o *NodesORM[ID, NEW, N]) Nodes(offset, limit int, qopts ...pg.QOpt) (nodes
 	return
 }
 
-func (o *NodesORM[ID, NEW, N]) NodesForChain(chainID ID, offset, limit int, qopts ...pg.QOpt) (nodes []N, count int, err error) {
+func (o *nodesORM[I, N]) NodesForChain(chainID I, offset, limit int, qopts ...pg.QOpt) (nodes []N, count int, err error) {
 	err = o.q.WithOpts(qopts...).Transaction(func(q pg.Queryer) error {
 		if err = q.Get(&count, fmt.Sprintf("SELECT COUNT(*) FROM %s_nodes WHERE %s_chain_id = $1", o.prefix, o.prefix), chainID); err != nil {
 			return errors.Wrap(err, "failed to fetch nodes count")
@@ -236,7 +274,7 @@ func (o *NodesORM[ID, NEW, N]) NodesForChain(chainID ID, offset, limit int, qopt
 	return
 }
 
-func (o *NodesORM[ID, NEW, N]) GetNodesByChainIDs(chainIDs []ID, qopts ...pg.QOpt) (nodes []N, err error) {
+func (o *nodesORM[I, N]) GetNodesByChainIDs(chainIDs []I, qopts ...pg.QOpt) (nodes []N, err error) {
 	sql := fmt.Sprintf(`SELECT * FROM %s_nodes WHERE %s_chain_id = ANY($1) ORDER BY created_at, id;`, o.prefix, o.prefix)
 
 	cids := pq.Array(chainIDs)

--- a/core/chains/solana/chain_test.go
+++ b/core/chains/solana/chain_test.go
@@ -233,7 +233,7 @@ func (m *mockORM) DeleteChain(id string, qopts ...pg.QOpt) error { panic("unimpl
 
 func (m *mockORM) EnabledChains(opt ...pg.QOpt) ([]Chain, error) { panic("unimplemented") }
 
-func (m *mockORM) CreateNode(node db.NewNode, opt ...pg.QOpt) (db.Node, error) {
+func (m *mockORM) CreateNode(node db.Node, opt ...pg.QOpt) (db.Node, error) {
 	panic("unimplemented")
 }
 

--- a/core/chains/solana/orm.go
+++ b/core/chains/solana/orm.go
@@ -21,7 +21,7 @@ type ORM interface {
 	DeleteChain(id string, qopts ...pg.QOpt) error
 	EnabledChains(...pg.QOpt) ([]Chain, error)
 
-	CreateNode(soldb.NewNode, ...pg.QOpt) (soldb.Node, error)
+	CreateNode(soldb.Node, ...pg.QOpt) (soldb.Node, error)
 	DeleteNode(int32, ...pg.QOpt) error
 	Node(int32, ...pg.QOpt) (soldb.Node, error)
 	NodeNamed(string, ...pg.QOpt) (soldb.Node, error)
@@ -29,18 +29,8 @@ type ORM interface {
 	NodesForChain(chainID string, offset, limit int, qopts ...pg.QOpt) (nodes []soldb.Node, count int, err error)
 }
 
-type orm struct {
-	*chains.ChainsORM[string, soldb.ChainCfg, Chain]
-	*chains.NodesORM[string, soldb.NewNode, soldb.Node]
-}
-
-var _ ORM = (*orm)(nil)
-
 // NewORM returns an ORM backed by db.
 func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) ORM {
 	q := pg.NewQ(db, lggr.Named("ORM"), cfg)
-	return &orm{
-		chains.NewChainsORM[string, soldb.ChainCfg, Chain](q, "solana"),
-		chains.NewNodesORM[string, soldb.NewNode, soldb.Node](q, "solana", "solana_url"),
-	}
+	return chains.NewORM[string, soldb.ChainCfg, soldb.Node](q, "solana", "solana_url")
 }

--- a/core/chains/solana/orm_test.go
+++ b/core/chains/solana/orm_test.go
@@ -44,7 +44,7 @@ func Test_ORM(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, dbcs, 2)
 
-	newNode := db.NewNode{
+	newNode := db.Node{
 		Name:          "first",
 		SolanaChainID: chainIDA,
 		SolanaURL:     "http://tender.mint.test/columbus-5",
@@ -57,7 +57,7 @@ func Test_ORM(t *testing.T) {
 	require.NoError(t, err)
 	assertEqual(t, newNode, gotNode)
 
-	newNode2 := db.NewNode{
+	newNode2 := db.Node{
 		Name:          "second",
 		SolanaChainID: chainIDB,
 		SolanaURL:     "http://tender.mint.test/bombay-12",
@@ -91,7 +91,7 @@ func Test_ORM(t *testing.T) {
 		assertEqual(t, newNode2, gotNodes[0])
 	}
 
-	newNode3 := db.NewNode{
+	newNode3 := db.Node{
 		Name:          "third",
 		SolanaChainID: chainIDB,
 		SolanaURL:     "http://tender.mint.test/bombay-12",
@@ -105,7 +105,7 @@ func Test_ORM(t *testing.T) {
 	assertEqual(t, newNode3, gotNamed)
 }
 
-func assertEqual(t *testing.T, newNode db.NewNode, gotNode db.Node) {
+func assertEqual(t *testing.T, newNode db.Node, gotNode db.Node) {
 	t.Helper()
 
 	assert.Equal(t, newNode.Name, gotNode.Name)

--- a/core/chains/terra/orm.go
+++ b/core/chains/terra/orm.go
@@ -11,18 +11,8 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
-type orm struct {
-	*chains.ChainsORM[string, terradb.ChainCfg, types.Chain]
-	*chains.NodesORM[string, types.NewNode, terradb.Node]
-}
-
-var _ types.ORM = (*orm)(nil)
-
 // NewORM returns an ORM backed by db.
 func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) types.ORM {
 	q := pg.NewQ(db, lggr.Named("ORM"), cfg)
-	return &orm{
-		chains.NewChainsORM[string, terradb.ChainCfg, types.Chain](q, "terra"),
-		chains.NewNodesORM[string, types.NewNode, terradb.Node](q, "terra", "tendermint_url"),
-	}
+	return chains.NewORM[string, terradb.ChainCfg, terradb.Node](q, "terra", "tendermint_url")
 }

--- a/core/chains/terra/orm_test.go
+++ b/core/chains/terra/orm_test.go
@@ -44,7 +44,7 @@ func Test_ORM(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, dbcs, 2)
 
-	newNode := types.NewNode{
+	newNode := db.Node{
 		Name:          "first",
 		TerraChainID:  chainIDA,
 		TendermintURL: "http://tender.mint.test/columbus-5",
@@ -57,7 +57,7 @@ func Test_ORM(t *testing.T) {
 	require.NoError(t, err)
 	assertEqual(t, newNode, gotNode)
 
-	newNode2 := types.NewNode{
+	newNode2 := db.Node{
 		Name:          "second",
 		TerraChainID:  chainIDB,
 		TendermintURL: "http://tender.mint.test/bombay-12",
@@ -91,7 +91,7 @@ func Test_ORM(t *testing.T) {
 		assertEqual(t, newNode2, gotNodes[0])
 	}
 
-	newNode3 := types.NewNode{
+	newNode3 := db.Node{
 		Name:          "third",
 		TerraChainID:  chainIDB,
 		TendermintURL: "http://tender.mint.test/bombay-12",
@@ -108,7 +108,7 @@ func Test_ORM(t *testing.T) {
 	assert.NoError(t, orm.DeleteChain(chainIDB))
 }
 
-func assertEqual(t *testing.T, newNode types.NewNode, gotNode db.Node) {
+func assertEqual(t *testing.T, newNode db.Node, gotNode db.Node) {
 	t.Helper()
 
 	assert.Equal(t, newNode.Name, gotNode.Name)

--- a/core/chains/terra/types/types.go
+++ b/core/chains/terra/types/types.go
@@ -16,7 +16,7 @@ type ORM interface {
 	DeleteChain(id string, qopts ...pg.QOpt) error
 	EnabledChains(...pg.QOpt) ([]Chain, error)
 
-	CreateNode(NewNode, ...pg.QOpt) (db.Node, error)
+	CreateNode(db.Node, ...pg.QOpt) (db.Node, error)
 	DeleteNode(int32, ...pg.QOpt) error
 	Node(int32, ...pg.QOpt) (db.Node, error)
 	NodeNamed(string, ...pg.QOpt) (db.Node, error)

--- a/core/cmd/evm_node_commands_test.go
+++ b/core/cmd/evm_node_commands_test.go
@@ -46,7 +46,7 @@ func TestClient_IndexEVMNodes(t *testing.T) {
 	require.NoError(t, err)
 	chain := mustInsertEVMChain(t, orm)
 
-	params := types.NewNode{
+	params := types.Node{
 		Name:       "Test node",
 		EVMChainID: chain.ID,
 		WSURL:      null.StringFrom("ws://localhost:8546"),
@@ -133,7 +133,7 @@ func TestClient_RemoveEVMNode(t *testing.T) {
 
 	chain := mustInsertEVMChain(t, orm)
 
-	params := types.NewNode{
+	params := types.Node{
 		Name:       "Test node",
 		EVMChainID: chain.ID,
 		WSURL:      null.StringFrom("ws://localhost:8546"),

--- a/core/cmd/solana_node_commands_test.go
+++ b/core/cmd/solana_node_commands_test.go
@@ -46,7 +46,7 @@ func TestClient_IndexSolanaNodes(t *testing.T) {
 	chainID := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))
 	_ = mustInsertSolanaChain(t, orm, chainID)
 
-	params := db.NewNode{
+	params := db.Node{
 		Name:          "second",
 		SolanaChainID: chainID,
 		SolanaURL:     "https://solana.example",
@@ -100,13 +100,13 @@ func TestClient_CreateSolanaNode(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, nodes, initialNodesCount+2)
 	n := nodes[initialNodesCount]
-	assertEqualNodesSolana(t, db.NewNode{
+	assertEqualNodesSolana(t, db.Node{
 		Name:          "first",
 		SolanaChainID: chainIDA,
 		SolanaURL:     "http://tender.mint.test/columbus-5",
 	}, n)
 	n = nodes[initialNodesCount+1]
-	assertEqualNodesSolana(t, db.NewNode{
+	assertEqualNodesSolana(t, db.Node{
 		Name:          "second",
 		SolanaChainID: chainIDB,
 		SolanaURL:     "http://tender.mint.test/bombay-12",
@@ -127,7 +127,7 @@ func TestClient_RemoveSolanaNode(t *testing.T) {
 	chainID := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))
 	_ = mustInsertSolanaChain(t, orm, chainID)
 
-	params := db.NewNode{
+	params := db.Node{
 		Name:          "first",
 		SolanaChainID: chainID,
 		SolanaURL:     "http://tender.mint.test/columbus-5",
@@ -151,7 +151,7 @@ func TestClient_RemoveSolanaNode(t *testing.T) {
 	assertTableRenders(t, r)
 }
 
-func assertEqualNodesSolana(t *testing.T, newNode db.NewNode, gotNode db.Node) {
+func assertEqualNodesSolana(t *testing.T, newNode db.Node, gotNode db.Node) {
 	t.Helper()
 
 	assert.Equal(t, newNode.Name, gotNode.Name)

--- a/core/cmd/solana_transaction_commands_test.go
+++ b/core/cmd/solana_transaction_commands_test.go
@@ -16,6 +16,7 @@ import (
 
 	solanaClient "github.com/smartcontractkit/chainlink-solana/pkg/solana/client"
 	solanadb "github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
+
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 )
@@ -36,7 +37,7 @@ func TestClient_SolanaSendSol(t *testing.T) {
 	chain, err := chains.Solana.Chain(testutils.Context(t), chainID)
 	require.NoError(t, err)
 
-	_, err = chains.Solana.ORM().CreateNode(solanadb.NewNode{
+	_, err = chains.Solana.ORM().CreateNode(solanadb.Node{
 		Name:          t.Name(),
 		SolanaChainID: chainID,
 		SolanaURL:     url,

--- a/core/cmd/terra_node_commands_test.go
+++ b/core/cmd/terra_node_commands_test.go
@@ -46,7 +46,7 @@ func TestClient_IndexTerraNodes(t *testing.T) {
 	chainID := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))
 	_ = mustInsertTerraChain(t, orm, chainID)
 
-	params := types.NewNode{
+	params := db.Node{
 		Name:          "second",
 		TerraChainID:  chainID,
 		TendermintURL: "http://tender.mint.test/bombay-12",
@@ -129,7 +129,7 @@ func TestClient_RemoveTerraNode(t *testing.T) {
 	chainID := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))
 	_ = mustInsertTerraChain(t, orm, chainID)
 
-	params := types.NewNode{
+	params := db.Node{
 		Name:          "first",
 		TerraChainID:  chainID,
 		TendermintURL: "http://tender.mint.test/columbus-5",

--- a/core/cmd/terra_transaction_commands_test.go
+++ b/core/cmd/terra_transaction_commands_test.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/chains/terra/denom"
 	"github.com/smartcontractkit/chainlink/core/chains/terra/terratxm"
-	terratypes "github.com/smartcontractkit/chainlink/core/chains/terra/types"
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
@@ -43,7 +42,7 @@ func TestClient_SendTerraCoins(t *testing.T) {
 	chain, err := chains.Terra.Chain(testutils.Context(t), chainID)
 	require.NoError(t, err)
 
-	_, err = chains.Terra.ORM().CreateNode(terratypes.NewNode{
+	_, err = chains.Terra.ORM().CreateNode(terradb.Node{
 		Name:          t.Name(),
 		TerraChainID:  chainID,
 		TendermintURL: tendermintURL,

--- a/core/internal/testutils/evmtest/evmtest.go
+++ b/core/internal/testutils/evmtest/evmtest.go
@@ -144,10 +144,10 @@ func (mo *MockORM) AddNodes(ns ...evmtypes.Node) {
 	}
 }
 
-func (mo *MockORM) EnabledChainsWithNodes() ([]evmtypes.Chain, map[string][]evmtypes.Node, error) {
+func (mo *MockORM) EnabledChains(qopts ...pg.QOpt) ([]evmtypes.Chain, error) {
 	mo.mu.RLock()
 	defer mo.mu.RUnlock()
-	return maps.Values(mo.chains), mo.nodes, nil
+	return maps.Values(mo.chains), nil
 }
 
 func (mo *MockORM) StoreString(chainID utils.Big, key, val string) error {
@@ -200,7 +200,7 @@ func (mo *MockORM) GetChainsByIDs(ids []utils.Big) (chains []evmtypes.Chain, err
 	return
 }
 
-func (mo *MockORM) CreateNode(data evmtypes.NewNode, qopts ...pg.QOpt) (n evmtypes.Node, err error) {
+func (mo *MockORM) CreateNode(data evmtypes.Node, qopts ...pg.QOpt) (n evmtypes.Node, err error) {
 	mo.mu.Lock()
 	defer mo.mu.Unlock()
 	n.ID = rand.Int31()
@@ -232,8 +232,14 @@ func (mo *MockORM) DeleteNode(id int32, qopts ...pg.QOpt) error {
 }
 
 // Nodes implements evmtypes.ORM
-func (mo *MockORM) Nodes(offset int, limit int, qopts ...pg.QOpt) ([]evmtypes.Node, int, error) {
-	panic("not implemented")
+func (mo *MockORM) Nodes(offset int, limit int, qopts ...pg.QOpt) (nodes []evmtypes.Node, cnt int, err error) {
+	mo.mu.RLock()
+	defer mo.mu.RUnlock()
+	for _, ns := range maps.Values(mo.nodes) {
+		nodes = append(nodes, ns...)
+	}
+	cnt = len(nodes)
+	return
 }
 
 // Node implements evmtypes.ORM

--- a/core/web/evm_nodes_controller.go
+++ b/core/web/evm_nodes_controller.go
@@ -58,7 +58,13 @@ func (nc *EVMNodesController) Create(c *gin.Context) {
 		return
 	}
 
-	node, err := nc.App.EVMORM().CreateNode(request)
+	node, err := nc.App.EVMORM().CreateNode(types.Node{
+		Name:       request.Name,
+		EVMChainID: request.EVMChainID,
+		WSURL:      request.WSURL,
+		HTTPURL:    request.HTTPURL,
+		SendOnly:   request.SendOnly,
+	})
 
 	if err != nil {
 		jsonAPIError(c, http.StatusBadRequest, err)

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -362,7 +362,13 @@ func (r *Resolver) CreateNode(ctx context.Context, args struct {
 		return nil, err
 	}
 
-	node, err := r.App.EVMORM().CreateNode(*args.Input)
+	node, err := r.App.EVMORM().CreateNode(types.Node{
+		Name:       args.Input.Name,
+		EVMChainID: args.Input.EVMChainID,
+		WSURL:      args.Input.WSURL,
+		HTTPURL:    args.Input.HTTPURL,
+		SendOnly:   args.Input.SendOnly,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/core/web/solana_nodes_controller.go
+++ b/core/web/solana_nodes_controller.go
@@ -79,7 +79,11 @@ func (nc *SolanaNodesController) Create(c *gin.Context) {
 		return
 	}
 
-	node, err := orm.CreateNode(request)
+	node, err := orm.CreateNode(db.Node{
+		Name:          request.Name,
+		SolanaChainID: request.SolanaChainID,
+		SolanaURL:     request.SolanaURL,
+	})
 
 	if err != nil {
 		jsonAPIError(c, http.StatusBadRequest, err)

--- a/core/web/terra_nodes_controller.go
+++ b/core/web/terra_nodes_controller.go
@@ -81,7 +81,11 @@ func (nc *TerraNodesController) Create(c *gin.Context) {
 		return
 	}
 
-	node, err := orm.CreateNode(request)
+	node, err := orm.CreateNode(db.Node{
+		Name:          request.Name,
+		TerraChainID:  request.TerraChainID,
+		TendermintURL: request.TendermintURL,
+	})
 
 	if err != nil {
 		jsonAPIError(c, http.StatusBadRequest, err)


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/36673/generic-chain-and-node-types

Following up from #6424, this PR simplifies some of the generic types and further de-duplicates the code.

