### PR TITLE
Test Data Race: TestBroadcaster_ReceivesAllLogsWhenResubscribing 

### DIFF
--- a/core/chains/evm/headtracker/head_tracker_test.go
+++ b/core/chains/evm/headtracker/head_tracker_test.go
@@ -53,12 +53,14 @@ func TestHeadTracker_New(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
 	logger := logger.TestLogger(t)
 	config := cltest.NewTestGeneralConfig(t)
-
-	ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
-	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).Return(sub, nil)
+	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
+	mockEth := &evmtest.MockEth{EthClient: ethClient}
+	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).
+		Return(
+			func(ctx context.Context, ch chan<- *evmtypes.Head) ethereum.Subscription { return mockEth.NewSub(t) },
+			func(ctx context.Context, ch chan<- *evmtypes.Head) error { return nil },
+		)
 	ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(cltest.Head(0), nil)
-	sub.On("Unsubscribe").Maybe().Return(nil)
-	sub.On("Err").Return(nil)
 
 	orm := headtracker.NewORM(db, logger, config, cltest.FixtureChainID)
 	assert.Nil(t, orm.IdempotentInsertHead(testutils.Context(t), cltest.Head(1)))
@@ -127,13 +129,19 @@ func TestHeadTracker_Get(t *testing.T) {
 			config := newCfg(t)
 			orm := headtracker.NewORM(db, logger, config, cltest.FixtureChainID)
 
-			ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
-			sub.On("Err").Return(nil)
-			sub.On("Unsubscribe").Return(nil)
+			ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 			chStarted := make(chan struct{})
+			mockEth := &evmtest.MockEth{
+				EthClient: ethClient,
+			}
 			ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).
-				Run(func(mock.Arguments) { close(chStarted) }).
-				Return(sub, nil)
+				Return(
+					func(ctx context.Context, ch chan<- *evmtypes.Head) ethereum.Subscription {
+						defer close(chStarted)
+						return mockEth.NewSub(t)
+					},
+					func(ctx context.Context, ch chan<- *evmtypes.Head) error { return nil },
+				)
 			ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(cltest.Head(0), nil)
 
 			fnCall := ethClient.On("HeadByNumber", mock.Anything, mock.Anything)
@@ -167,14 +175,18 @@ func TestHeadTracker_Start_NewHeads(t *testing.T) {
 	config := newCfg(t)
 	orm := headtracker.NewORM(db, logger, config, cltest.FixtureChainID)
 
-	ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
-	sub.On("Err").Return(nil)
-	sub.On("Unsubscribe").Return(nil)
+	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 	chStarted := make(chan struct{})
 	ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(cltest.Head(0), nil)
+	mockEth := &evmtest.MockEth{EthClient: ethClient}
 	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).
-		Run(func(mock.Arguments) { close(chStarted) }).
-		Return(sub, nil)
+		Return(
+			func(ctx context.Context, ch chan<- *evmtypes.Head) ethereum.Subscription {
+				defer close(chStarted)
+				return mockEth.NewSub(t)
+			},
+			func(ctx context.Context, ch chan<- *evmtypes.Head) error { return nil },
+		)
 
 	ht := createHeadTracker(t, ethClient, config, orm)
 	ht.Start(t)
@@ -191,9 +203,7 @@ func TestHeadTracker_Start_CancelContext(t *testing.T) {
 	logger := logger.TestLogger(t)
 	config := newCfg(t)
 	orm := headtracker.NewORM(db, logger, config, cltest.FixtureChainID)
-	ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
-	sub.On("Err").Return(nil)
-	sub.On("Unsubscribe").Return(nil)
+	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 	chStarted := make(chan struct{})
 	ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Run(func(args mock.Arguments) {
 		ctx := args.Get(0).(context.Context)
@@ -204,9 +214,15 @@ func TestHeadTracker_Start_CancelContext(t *testing.T) {
 			assert.FailNow(t, "context was not cancelled within 10s")
 		}
 	}).Return(cltest.Head(0), nil)
+	mockEth := &evmtest.MockEth{EthClient: ethClient}
 	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).
-		Run(func(mock.Arguments) { close(chStarted) }).
-		Return(sub, nil)
+		Return(
+			func(ctx context.Context, ch chan<- *evmtypes.Head) ethereum.Subscription {
+				defer close(chStarted)
+				return mockEth.NewSub(t)
+			},
+			func(ctx context.Context, ch chan<- *evmtypes.Head) error { return nil },
+		)
 
 	ht := createHeadTracker(t, ethClient, config, orm)
 
@@ -228,18 +244,20 @@ func TestHeadTracker_CallsHeadTrackableCallbacks(t *testing.T) {
 	config := newCfg(t)
 	orm := headtracker.NewORM(db, logger, config, cltest.FixtureChainID)
 
-	ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
+	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
-	chchHeaders := make(chan chan<- *evmtypes.Head, 1)
+	chchHeaders := make(chan evmtest.RawSub[*evmtypes.Head], 1)
+	mockEth := &evmtest.MockEth{EthClient: ethClient}
 	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			chchHeaders <- args.Get(1).(chan<- *evmtypes.Head)
-		}).
-		Return(sub, nil)
+		Return(
+			func(ctx context.Context, ch chan<- *evmtypes.Head) ethereum.Subscription {
+				sub := mockEth.NewSub(t)
+				chchHeaders <- evmtest.NewRawSub(ch, sub.Err())
+				return sub
+			},
+			func(ctx context.Context, ch chan<- *evmtypes.Head) error { return nil },
+		)
 	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(cltest.Head(0), nil)
-
-	sub.On("Unsubscribe").Return()
-	sub.On("Err").Return(nil)
 
 	checker := &cltest.MockHeadTrackable{}
 	ht := createHeadTrackerWithChecker(t, ethClient, config, orm, checker)
@@ -248,7 +266,7 @@ func TestHeadTracker_CallsHeadTrackableCallbacks(t *testing.T) {
 	assert.Equal(t, int32(0), checker.OnNewLongestChainCount())
 
 	headers := <-chchHeaders
-	headers <- &evmtypes.Head{Number: 1, Hash: utils.NewHash(), EVMChainID: utils.NewBig(&cltest.FixtureChainID)}
+	headers.TrySend(&evmtypes.Head{Number: 1, Hash: utils.NewHash(), EVMChainID: utils.NewBig(&cltest.FixtureChainID)})
 	g.Eventually(func() int32 { return checker.OnNewLongestChainCount() }).Should(gomega.Equal(int32(1)))
 
 	ht.Stop(t)
@@ -264,14 +282,20 @@ func TestHeadTracker_ReconnectOnError(t *testing.T) {
 	config := newCfg(t)
 	orm := headtracker.NewORM(db, logger, config, cltest.FixtureChainID)
 
-	ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
-	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).Return(sub, nil)
+	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
+	mockEth := &evmtest.MockEth{EthClient: ethClient}
+	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).
+		Return(
+			func(ctx context.Context, ch chan<- *evmtypes.Head) ethereum.Subscription { return mockEth.NewSub(t) },
+			func(ctx context.Context, ch chan<- *evmtypes.Head) error { return nil },
+		)
 	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).Return(nil, errors.New("cannot reconnect"))
-	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).Return(sub, nil)
+	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).
+		Return(
+			func(ctx context.Context, ch chan<- *evmtypes.Head) ethereum.Subscription { return mockEth.NewSub(t) },
+			func(ctx context.Context, ch chan<- *evmtypes.Head) error { return nil },
+		)
 	ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(cltest.Head(0), nil)
-	chErr := make(chan error)
-	sub.On("Unsubscribe").Return()
-	sub.On("Err").Return((<-chan error)(chErr))
 
 	checker := &cltest.MockHeadTrackable{}
 	ht := createHeadTrackerWithChecker(t, ethClient, config, orm, checker)
@@ -281,7 +305,7 @@ func TestHeadTracker_ReconnectOnError(t *testing.T) {
 	assert.Equal(t, int32(0), checker.OnNewLongestChainCount())
 
 	// trigger reconnect loop
-	chErr <- errors.New("test error to force reconnect")
+	mockEth.SubsErr(errors.New("test error to force reconnect"))
 	g.Eventually(func() int32 {
 		return checker.OnNewLongestChainCount()
 	}).Should(gomega.Equal(int32(1)))
@@ -296,17 +320,21 @@ func TestHeadTracker_ResubscribeOnSubscriptionError(t *testing.T) {
 	config := newCfg(t)
 	orm := headtracker.NewORM(db, logger, config, cltest.FixtureChainID)
 
-	ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
+	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
-	chchHeaders := make(chan chan<- *evmtypes.Head, 1)
+	chchHeaders := make(chan evmtest.RawSub[*evmtypes.Head], 1)
+	mockEth := &evmtest.MockEth{EthClient: ethClient}
 	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) { chchHeaders <- args.Get(1).(chan<- *evmtypes.Head) }).
 		Twice().
-		Return(sub, nil)
+		Return(
+			func(ctx context.Context, ch chan<- *evmtypes.Head) ethereum.Subscription {
+				sub := mockEth.NewSub(t)
+				chchHeaders <- evmtest.NewRawSub(ch, sub.Err())
+				return sub
+			},
+			func(ctx context.Context, ch chan<- *evmtypes.Head) error { return nil },
+		)
 	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(cltest.Head(0), nil)
-
-	sub.On("Unsubscribe").Return()
-	sub.On("Err").Return(nil)
 
 	checker := &cltest.MockHeadTrackable{}
 	ht := createHeadTrackerWithChecker(t, ethClient, config, orm, checker)
@@ -316,13 +344,13 @@ func TestHeadTracker_ResubscribeOnSubscriptionError(t *testing.T) {
 
 	headers := <-chchHeaders
 	go func() {
-		headers <- cltest.Head(1)
+		headers.TrySend(cltest.Head(1))
 	}()
 
 	g.Eventually(func() bool { return ht.headTracker.Healthy() == nil }, 5*time.Second, 5*time.Millisecond).Should(gomega.Equal(true))
 
 	// trigger reconnect loop
-	close(headers)
+	headers.CloseCh()
 
 	// wait for full disconnect and a new subscription
 	g.Eventually(func() int32 { return checker.OnNewLongestChainCount() }, 5*time.Second, 5*time.Millisecond).Should(gomega.Equal(int32(1)))
@@ -334,9 +362,13 @@ func TestHeadTracker_Start_LoadsLatestChain(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
 	logger := logger.TestLogger(t)
 	config := newCfg(t)
-	ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
-
-	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).Return(sub, nil)
+	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
+	mockEth := &evmtest.MockEth{EthClient: ethClient}
+	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).
+		Return(
+			func(ctx context.Context, ch chan<- *evmtypes.Head) ethereum.Subscription { return mockEth.NewSub(t) },
+			func(ctx context.Context, ch chan<- *evmtypes.Head) error { return nil },
+		)
 
 	heads := []*evmtypes.Head{
 		cltest.Head(0),
@@ -355,9 +387,6 @@ func TestHeadTracker_Start_LoadsLatestChain(t *testing.T) {
 	ethClient.On("HeadByNumber", mock.Anything, big.NewInt(2)).Return(heads[2], nil)
 	ethClient.On("HeadByNumber", mock.Anything, big.NewInt(1)).Return(heads[1], nil)
 	ethClient.On("HeadByNumber", mock.Anything, big.NewInt(0)).Return(heads[0], nil)
-
-	sub.On("Unsubscribe").Return()
-	sub.On("Err").Return(nil)
 
 	orm := headtracker.NewORM(db, logger, config, cltest.FixtureChainID)
 	trackable := new(htmocks.HeadTrackable)
@@ -393,19 +422,24 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingEnabled(t *testing.T)
 	d := 2500 * time.Millisecond
 	config.Overrides.GlobalEvmHeadTrackerSamplingInterval = &d
 
-	ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
+	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
 	checker := new(htmocks.HeadTrackable)
 	checker.Test(t)
 	orm := headtracker.NewORM(db, logger, config, *config.DefaultChainID())
 	ht := createHeadTrackerWithChecker(t, ethClient, evmtest.NewChainScopedConfig(t, config), orm, checker)
 
-	chchHeaders := make(chan chan<- *evmtypes.Head, 1)
+	chchHeaders := make(chan evmtest.RawSub[*evmtypes.Head], 1)
+	mockEth := &evmtest.MockEth{EthClient: ethClient}
 	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) { chchHeaders <- args.Get(1).(chan<- *evmtypes.Head) }).
-		Return(sub, nil)
-	sub.On("Unsubscribe").Return()
-	sub.On("Err").Return(nil)
+		Return(
+			func(ctx context.Context, ch chan<- *evmtypes.Head) ethereum.Subscription {
+				sub := mockEth.NewSub(t)
+				chchHeaders <- evmtest.NewRawSub(ch, sub.Err())
+				return sub
+			},
+			func(ctx context.Context, ch chan<- *evmtypes.Head) error { return nil },
+		)
 
 	// ---------------------
 	blocks := cltest.NewBlocks(t, 10)
@@ -490,7 +524,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingEnabled(t *testing.T)
 		latestHeadByNumberMu.Lock()
 		latestHeadByNumber[h.Number] = h
 		latestHeadByNumberMu.Unlock()
-		headers <- h
+		headers.TrySend(h)
 	}
 
 	// default 10s may not be sufficient, so using testutils.WaitTimeout(t)
@@ -522,7 +556,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled(t *testing.T
 	d := 0 * time.Second
 	config.Overrides.GlobalEvmHeadTrackerSamplingInterval = &d
 
-	ethClient, sub := cltest.NewEthClientAndSubMockWithDefaultChain(t)
+	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
 
 	checker := new(htmocks.HeadTrackable)
 	checker.Test(t)
@@ -530,14 +564,17 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled(t *testing.T
 	evmcfg := evmtest.NewChainScopedConfig(t, config)
 	ht := createHeadTrackerWithChecker(t, ethClient, evmcfg, orm, checker)
 
-	chchHeaders := make(chan chan<- *evmtypes.Head, 1)
+	chchHeaders := make(chan evmtest.RawSub[*evmtypes.Head], 1)
+	mockEth := &evmtest.MockEth{EthClient: ethClient}
 	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			chchHeaders <- args.Get(1).(chan<- *evmtypes.Head)
-		}).
-		Return(sub, nil)
-	sub.On("Unsubscribe").Return()
-	sub.On("Err").Return(nil)
+		Return(
+			func(ctx context.Context, ch chan<- *evmtypes.Head) ethereum.Subscription {
+				sub := mockEth.NewSub(t)
+				chchHeaders <- evmtest.NewRawSub(ch, sub.Err())
+				return sub
+			},
+			func(ctx context.Context, ch chan<- *evmtypes.Head) error { return nil },
+		)
 
 	// ---------------------
 	blocks := cltest.NewBlocks(t, 10)
@@ -650,7 +687,7 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled(t *testing.T
 		latestHeadByNumberMu.Lock()
 		latestHeadByNumber[h.Number] = h
 		latestHeadByNumberMu.Unlock()
-		headers <- h
+		headers.TrySend(h)
 		time.Sleep(testutils.TestInterval)
 	}
 

--- a/core/chains/evm/log/eth_subscriber.go
+++ b/core/chains/evm/log/eth_subscriber.go
@@ -255,6 +255,7 @@ func (sub managedSubscriptionImpl) Logs() chan types.Log {
 
 func (sub managedSubscriptionImpl) Unsubscribe() {
 	sub.subscription.Unsubscribe()
+	<-sub.Err() // ensure sending has stopped before closing the chan
 	close(sub.chRawLogs)
 }
 

--- a/core/chains/evm/log/helpers_test.go
+++ b/core/chains/evm/log/helpers_test.go
@@ -1,6 +1,7 @@
 package log_test
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"sync"
@@ -43,12 +44,12 @@ type broadcasterHelper struct {
 	t            *testing.T
 	lb           log.BroadcasterInTest
 	db           *sqlx.DB
-	mockEth      *mockEth
+	mockEth      *evmtest.MockEth
 	globalConfig *configtest.TestGeneralConfig
 	config       evmconfig.ChainScopedConfig
 
 	// each received channel corresponds to one eth subscription
-	chchRawLogs    chan chan<- types.Log
+	chchRawLogs    chan evmtest.RawSub[types.Log]
 	toUnsubscribe  []func()
 	pipelineHelper cltest.JobPipelineV2TestHelper
 }
@@ -70,9 +71,9 @@ func (c broadcasterHelperCfg) new(t *testing.T, blockHeight int64, timesSubscrib
 		FilterLogsResult:    filterLogsResult,
 	}
 
-	chchRawLogs := make(chan chan<- types.Log, timesSubscribe)
+	chchRawLogs := make(chan evmtest.RawSub[types.Log], timesSubscribe)
 	mockEth := newMockEthClient(t, chchRawLogs, blockHeight, expectedCalls)
-	helper := c.newWithEthClient(t, mockEth.ethClient)
+	helper := c.newWithEthClient(t, mockEth.EthClient)
 	helper.chchRawLogs = chchRawLogs
 	helper.mockEth = mockEth
 	helper.globalConfig.Overrides.GlobalEvmFinalityDepth = null.IntFrom(10)
@@ -358,27 +359,6 @@ type mockListener struct {
 func (l *mockListener) JobID() int32            { return l.jobID }
 func (l *mockListener) HandleLog(log.Broadcast) {}
 
-type mockEth struct {
-	ethClient        *evmmocks.Client
-	sub              *evmmocks.Subscription
-	subscribeCalls   atomic.Int32
-	unsubscribeCalls atomic.Int32
-	checkFilterLogs  func(int64, int64)
-}
-
-func (mock *mockEth) assertExpectations(t *testing.T) {
-	mock.ethClient.AssertExpectations(t)
-	mock.sub.AssertExpectations(t)
-}
-
-func (mock *mockEth) subscribeCallCount() int32 {
-	return mock.subscribeCalls.Load()
-}
-
-func (mock *mockEth) unsubscribeCallCount() int32 {
-	return mock.unsubscribeCalls.Load()
-}
-
 type mockEthClientExpectedCalls struct {
 	SubscribeFilterLogs int
 	HeaderByNumber      int
@@ -387,45 +367,41 @@ type mockEthClientExpectedCalls struct {
 	FilterLogsResult []types.Log
 }
 
-func newMockEthClient(t *testing.T, chchRawLogs chan<- chan<- types.Log, blockHeight int64, expectedCalls mockEthClientExpectedCalls) *mockEth {
-	ethClient, sub := cltest.NewEthClientAndSubMock(t)
-	mockEth := &mockEth{
-		ethClient:       ethClient,
-		sub:             sub,
-		checkFilterLogs: nil,
-	}
-	mockEth.ethClient.On("ChainID", mock.Anything).Return(&cltest.FixtureChainID)
-	mockEth.ethClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			mockEth.subscribeCalls.Inc()
-			chchRawLogs <- args.Get(2).(chan<- types.Log)
-		}).
-		Return(mockEth.sub, nil).
+func newMockEthClient(t *testing.T, chchRawLogs chan<- evmtest.RawSub[types.Log], blockHeight int64, expectedCalls mockEthClientExpectedCalls) *evmtest.MockEth {
+	ethClient := new(evmmocks.Client)
+	ethClient.Test(t)
+	mockEth := &evmtest.MockEth{EthClient: ethClient}
+	mockEth.EthClient.On("ChainID", mock.Anything).Return(&cltest.FixtureChainID)
+	mockEth.EthClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
+		Return(
+			func(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) ethereum.Subscription {
+				sub := mockEth.NewSub(t)
+				chchRawLogs <- evmtest.NewRawSub(ch, sub.Err())
+				return sub
+			},
+			func(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) error {
+				return nil
+			},
+		).
 		Times(expectedCalls.SubscribeFilterLogs)
 
-	mockEth.ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).
+	mockEth.EthClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).
 		Return(&evmtypes.Head{Number: blockHeight}, nil).
 		Times(expectedCalls.HeaderByNumber)
 
 	if expectedCalls.FilterLogs > 0 {
-		mockEth.ethClient.On("FilterLogs", mock.Anything, mock.Anything).
+		mockEth.EthClient.On("FilterLogs", mock.Anything, mock.Anything).
 			Run(func(args mock.Arguments) {
 				filterQuery := args.Get(1).(ethereum.FilterQuery)
 				fromBlock := filterQuery.FromBlock.Int64()
 				toBlock := filterQuery.ToBlock.Int64()
-				if mockEth.checkFilterLogs != nil {
-					mockEth.checkFilterLogs(fromBlock, toBlock)
+				if mockEth.CheckFilterLogs != nil {
+					mockEth.CheckFilterLogs(fromBlock, toBlock)
 				}
 			}).
 			Return(expectedCalls.FilterLogsResult, nil).
 			Times(expectedCalls.FilterLogs)
 	}
 
-	mockEth.sub.On("Err").
-		Return(nil)
-
-	mockEth.sub.On("Unsubscribe").
-		Return().
-		Run(func(mock.Arguments) { mockEth.unsubscribeCalls.Inc() })
 	return mockEth
 }

--- a/core/chains/evm/log/integration_test.go
+++ b/core/chains/evm/log/integration_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/flux_aggregator_wrapper"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/utils"
@@ -42,25 +43,25 @@ func TestBroadcaster_AwaitsInitialSubscribersOnStartup(t *testing.T) {
 	helper.start()
 	defer helper.stop()
 
-	require.Eventually(t, func() bool { return helper.mockEth.subscribeCallCount() == 0 }, cltest.WaitTimeout(t), 100*time.Millisecond)
-	g.Consistently(func() int32 { return helper.mockEth.subscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(0)))
+	require.Eventually(t, func() bool { return helper.mockEth.SubscribeCallCount() == 0 }, cltest.WaitTimeout(t), 100*time.Millisecond)
+	g.Consistently(func() int32 { return helper.mockEth.SubscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(0)))
 
 	helper.lb.DependentReady()
 
-	require.Eventually(t, func() bool { return helper.mockEth.subscribeCallCount() == 0 }, cltest.WaitTimeout(t), 100*time.Millisecond)
-	g.Consistently(func() int32 { return helper.mockEth.subscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(0)))
+	require.Eventually(t, func() bool { return helper.mockEth.SubscribeCallCount() == 0 }, cltest.WaitTimeout(t), 100*time.Millisecond)
+	g.Consistently(func() int32 { return helper.mockEth.SubscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(0)))
 
 	helper.lb.DependentReady()
 
-	require.Eventually(t, func() bool { return helper.mockEth.subscribeCallCount() == 1 }, cltest.WaitTimeout(t), 100*time.Millisecond)
-	g.Consistently(func() int32 { return helper.mockEth.subscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(1)))
+	require.Eventually(t, func() bool { return helper.mockEth.SubscribeCallCount() == 1 }, cltest.WaitTimeout(t), 100*time.Millisecond)
+	g.Consistently(func() int32 { return helper.mockEth.SubscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(1)))
 
 	helper.unsubscribeAll()
 
-	require.Eventually(t, func() bool { return helper.mockEth.unsubscribeCallCount() == 1 }, cltest.WaitTimeout(t), 100*time.Millisecond)
-	g.Consistently(func() int32 { return helper.mockEth.unsubscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(1)))
+	require.Eventually(t, func() bool { return helper.mockEth.UnsubscribeCallCount() == 1 }, cltest.WaitTimeout(t), 100*time.Millisecond)
+	g.Consistently(func() int32 { return helper.mockEth.UnsubscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(1)))
 
-	helper.mockEth.assertExpectations(t)
+	helper.mockEth.AssertExpectations(t)
 }
 
 func TestBroadcaster_ResubscribesOnAddOrRemoveContract(t *testing.T) {
@@ -78,9 +79,9 @@ func TestBroadcaster_ResubscribesOnAddOrRemoveContract(t *testing.T) {
 		FilterLogs:          backfillTimes,
 	}
 
-	chchRawLogs := make(chan chan<- types.Log, backfillTimes)
+	chchRawLogs := make(chan evmtest.RawSub[types.Log], backfillTimes)
 	mockEth := newMockEthClient(t, chchRawLogs, blockHeight, expectedCalls)
-	helper := newBroadcasterHelperWithEthClient(t, mockEth.ethClient, cltest.Head(lastStoredBlockHeight))
+	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight))
 	helper.mockEth = mockEth
 
 	blockBackfillDepth := helper.config.BlockBackfillDepth()
@@ -89,7 +90,7 @@ func TestBroadcaster_ResubscribesOnAddOrRemoveContract(t *testing.T) {
 
 	// the first backfill should use the height of last head saved to the db,
 	// minus maxNumConfirmations of subscribers and minus blockBackfillDepth
-	mockEth.checkFilterLogs = func(fromBlock int64, toBlock int64) {
+	mockEth.CheckFilterLogs = func(fromBlock int64, toBlock int64) {
 		backfillCount.Store(1)
 		require.Equal(t, lastStoredBlockHeight-numConfirmations-int64(blockBackfillDepth), fromBlock)
 	}
@@ -106,15 +107,15 @@ func TestBroadcaster_ResubscribesOnAddOrRemoveContract(t *testing.T) {
 	helper.start()
 	defer helper.stop()
 
-	require.Eventually(t, func() bool { return helper.mockEth.subscribeCallCount() == 1 }, cltest.WaitTimeout(t), time.Second)
-	gomega.NewWithT(t).Consistently(func() int32 { return helper.mockEth.subscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(1)))
-	gomega.NewWithT(t).Consistently(func() int32 { return helper.mockEth.unsubscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(0)))
+	require.Eventually(t, func() bool { return helper.mockEth.SubscribeCallCount() == 1 }, cltest.WaitTimeout(t), time.Second)
+	gomega.NewWithT(t).Consistently(func() int32 { return helper.mockEth.SubscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(1)))
+	gomega.NewWithT(t).Consistently(func() int32 { return helper.mockEth.UnsubscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(0)))
 
 	require.Eventually(t, func() bool { return backfillCount.Load() == 1 }, cltest.WaitTimeout(t), 100*time.Millisecond)
 	helper.unsubscribeAll()
 
 	// now the backfill must use the blockBackfillDepth
-	mockEth.checkFilterLogs = func(fromBlock int64, toBlock int64) {
+	mockEth.CheckFilterLogs = func(fromBlock int64, toBlock int64) {
 		require.Equal(t, blockHeight-int64(blockBackfillDepth), fromBlock)
 		backfillCount.Store(2)
 	}
@@ -122,13 +123,13 @@ func TestBroadcaster_ResubscribesOnAddOrRemoveContract(t *testing.T) {
 	listenerLast := helper.newLogListenerWithJob("last")
 	helper.register(listenerLast, newMockContract(), 1)
 
-	require.Eventually(t, func() bool { return helper.mockEth.unsubscribeCallCount() >= 1 }, cltest.WaitTimeout(t), time.Second)
-	gomega.NewWithT(t).Consistently(func() int32 { return helper.mockEth.subscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(2)))
-	gomega.NewWithT(t).Consistently(func() int32 { return helper.mockEth.unsubscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(1)))
+	require.Eventually(t, func() bool { return helper.mockEth.UnsubscribeCallCount() >= 1 }, cltest.WaitTimeout(t), time.Second)
+	gomega.NewWithT(t).Consistently(func() int32 { return helper.mockEth.SubscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(2)))
+	gomega.NewWithT(t).Consistently(func() int32 { return helper.mockEth.UnsubscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(1)))
 
 	require.Eventually(t, func() bool { return backfillCount.Load() == 2 }, cltest.WaitTimeout(t), time.Second)
 
-	helper.mockEth.assertExpectations(t)
+	helper.mockEth.AssertExpectations(t)
 }
 
 func TestBroadcaster_BackfillOnNodeStartAndOnReplay(t *testing.T) {
@@ -145,9 +146,9 @@ func TestBroadcaster_BackfillOnNodeStartAndOnReplay(t *testing.T) {
 		FilterLogs:          2,
 	}
 
-	chchRawLogs := make(chan chan<- types.Log, backfillTimes)
+	chchRawLogs := make(chan evmtest.RawSub[types.Log], backfillTimes)
 	mockEth := newMockEthClient(t, chchRawLogs, blockHeight, expectedCalls)
-	helper := newBroadcasterHelperWithEthClient(t, mockEth.ethClient, cltest.Head(lastStoredBlockHeight))
+	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight))
 	helper.mockEth = mockEth
 
 	maxNumConfirmations := int64(10)
@@ -164,7 +165,7 @@ func TestBroadcaster_BackfillOnNodeStartAndOnReplay(t *testing.T) {
 
 	// the first backfill should use the height of last head saved to the db,
 	// minus maxNumConfirmations of subscribers and minus blockBackfillDepth
-	mockEth.checkFilterLogs = func(fromBlock int64, toBlock int64) {
+	mockEth.CheckFilterLogs = func(fromBlock int64, toBlock int64) {
 		times := backfillCount.Inc() - 1
 		if times == 0 {
 			require.Equal(t, lastStoredBlockHeight-maxNumConfirmations-int64(blockBackfillDepth), fromBlock)
@@ -177,7 +178,7 @@ func TestBroadcaster_BackfillOnNodeStartAndOnReplay(t *testing.T) {
 		helper.start()
 		defer helper.stop()
 
-		require.Eventually(t, func() bool { return helper.mockEth.subscribeCallCount() == 1 }, cltest.WaitTimeout(t), time.Second)
+		require.Eventually(t, func() bool { return helper.mockEth.SubscribeCallCount() == 1 }, cltest.WaitTimeout(t), time.Second)
 		require.Eventually(t, func() bool { return backfillCount.Load() == 1 }, cltest.WaitTimeout(t), time.Second)
 
 		helper.lb.ReplayFromBlock(replayFrom, false)
@@ -185,8 +186,8 @@ func TestBroadcaster_BackfillOnNodeStartAndOnReplay(t *testing.T) {
 		require.Eventually(t, func() bool { return backfillCount.Load() >= 2 }, cltest.WaitTimeout(t), time.Second)
 	}()
 
-	require.Eventually(t, func() bool { return helper.mockEth.unsubscribeCallCount() >= 1 }, cltest.WaitTimeout(t), time.Second)
-	helper.mockEth.assertExpectations(t)
+	require.Eventually(t, func() bool { return helper.mockEth.UnsubscribeCallCount() >= 1 }, cltest.WaitTimeout(t), time.Second)
+	helper.mockEth.AssertExpectations(t)
 }
 
 func TestBroadcaster_ReplaysLogs(t *testing.T) {
@@ -202,11 +203,11 @@ func TestBroadcaster_ReplaysLogs(t *testing.T) {
 		blocks.LogOnBlockNum(7, contract.Address()),
 	}
 
-	mockEth := newMockEthClient(t, make(chan chan<- types.Log, 4), blockHeight, mockEthClientExpectedCalls{
+	mockEth := newMockEthClient(t, make(chan evmtest.RawSub[types.Log], 4), blockHeight, mockEthClientExpectedCalls{
 		FilterLogs:       4,
 		FilterLogsResult: sentLogs,
 	})
-	helper := newBroadcasterHelperWithEthClient(t, mockEth.ethClient, cltest.Head(blockHeight))
+	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(blockHeight))
 	helper.mockEth = mockEth
 
 	listener := helper.newLogListenerWithJob("listener")
@@ -257,7 +258,7 @@ func TestBroadcaster_ReplaysLogs(t *testing.T) {
 
 	}()
 
-	require.Eventually(t, func() bool { return helper.mockEth.unsubscribeCallCount() >= 1 }, cltest.WaitTimeout(t), time.Second)
+	require.Eventually(t, func() bool { return helper.mockEth.UnsubscribeCallCount() >= 1 }, cltest.WaitTimeout(t), time.Second)
 }
 
 func TestBroadcaster_BackfillUnconsumedAfterCrash(t *testing.T) {
@@ -309,8 +310,8 @@ func TestBroadcaster_BackfillUnconsumedAfterCrash(t *testing.T) {
 		})
 
 		chRawLogs := <-helper.chchRawLogs
-		chRawLogs <- log1
-		chRawLogs <- log2
+		chRawLogs.TrySend(log1)
+		chRawLogs.TrySend(log2)
 
 		<-headsDone
 
@@ -460,9 +461,9 @@ func TestBroadcaster_ShallowBackfillOnNodeStart(t *testing.T) {
 		FilterLogs:          backfillTimes,
 	}
 
-	chchRawLogs := make(chan chan<- types.Log, backfillTimes)
+	chchRawLogs := make(chan evmtest.RawSub[types.Log], backfillTimes)
 	mockEth := newMockEthClient(t, chchRawLogs, blockHeight, expectedCalls)
-	helper := newBroadcasterHelperWithEthClient(t, mockEth.ethClient, cltest.Head(lastStoredBlockHeight))
+	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight))
 	helper.mockEth = mockEth
 
 	backfillDepth := 15
@@ -479,7 +480,7 @@ func TestBroadcaster_ShallowBackfillOnNodeStart(t *testing.T) {
 	helper.register(listener2, newMockContract(), uint32(2))
 
 	// the backfill does not use the height from DB because BlockBackfillSkip is true
-	mockEth.checkFilterLogs = func(fromBlock int64, toBlock int64) {
+	mockEth.CheckFilterLogs = func(fromBlock int64, toBlock int64) {
 		backfillCount.Store(1)
 		require.Equal(t, blockHeight-int64(backfillDepth), fromBlock)
 	}
@@ -488,12 +489,12 @@ func TestBroadcaster_ShallowBackfillOnNodeStart(t *testing.T) {
 		helper.start()
 		defer helper.stop()
 
-		require.Eventually(t, func() bool { return helper.mockEth.subscribeCallCount() == 1 }, cltest.WaitTimeout(t), time.Second)
+		require.Eventually(t, func() bool { return helper.mockEth.SubscribeCallCount() == 1 }, cltest.WaitTimeout(t), time.Second)
 		require.Eventually(t, func() bool { return backfillCount.Load() == 1 }, cltest.WaitTimeout(t), time.Second)
 	}()
 
-	require.Eventually(t, func() bool { return helper.mockEth.unsubscribeCallCount() >= 1 }, cltest.WaitTimeout(t), time.Second)
-	helper.mockEth.assertExpectations(t)
+	require.Eventually(t, func() bool { return helper.mockEth.UnsubscribeCallCount() >= 1 }, cltest.WaitTimeout(t), time.Second)
+	helper.mockEth.AssertExpectations(t)
 }
 
 func TestBroadcaster_BackfillInBatches(t *testing.T) {
@@ -512,9 +513,9 @@ func TestBroadcaster_BackfillInBatches(t *testing.T) {
 		FilterLogs:          expectedBatches,
 	}
 
-	chchRawLogs := make(chan chan<- types.Log, backfillTimes)
+	chchRawLogs := make(chan evmtest.RawSub[types.Log], backfillTimes)
 	mockEth := newMockEthClient(t, chchRawLogs, blockHeight, expectedCalls)
-	helper := newBroadcasterHelperWithEthClient(t, mockEth.ethClient, cltest.Head(lastStoredBlockHeight))
+	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight))
 	helper.mockEth = mockEth
 
 	blockBackfillDepth := helper.config.BlockBackfillDepth()
@@ -525,7 +526,7 @@ func TestBroadcaster_BackfillInBatches(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	backfillStart := lastStoredBlockHeight - numConfirmations - int64(blockBackfillDepth)
 	// the first backfill should start from before the last stored head
-	mockEth.checkFilterLogs = func(fromBlock int64, toBlock int64) {
+	mockEth.CheckFilterLogs = func(fromBlock int64, toBlock int64) {
 		times := backfillCount.Inc() - 1
 		lggr.Infof("Log Batch: --------- times %v - %v, %v", times, fromBlock, toBlock)
 
@@ -549,9 +550,9 @@ func TestBroadcaster_BackfillInBatches(t *testing.T) {
 
 	helper.unsubscribeAll()
 
-	require.Eventually(t, func() bool { return helper.mockEth.unsubscribeCallCount() >= 1 }, cltest.WaitTimeout(t), time.Second)
+	require.Eventually(t, func() bool { return helper.mockEth.UnsubscribeCallCount() >= 1 }, cltest.WaitTimeout(t), time.Second)
 
-	helper.mockEth.assertExpectations(t)
+	helper.mockEth.AssertExpectations(t)
 }
 
 func TestBroadcaster_BackfillALargeNumberOfLogs(t *testing.T) {
@@ -585,9 +586,9 @@ func TestBroadcaster_BackfillALargeNumberOfLogs(t *testing.T) {
 		FilterLogsResult: backfilledLogs,
 	}
 
-	chchRawLogs := make(chan chan<- types.Log, backfillTimes)
+	chchRawLogs := make(chan evmtest.RawSub[types.Log], backfillTimes)
 	mockEth := newMockEthClient(t, chchRawLogs, blockHeight, expectedCalls)
-	helper := newBroadcasterHelperWithEthClient(t, mockEth.ethClient, cltest.Head(lastStoredBlockHeight))
+	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight))
 	helper.mockEth = mockEth
 
 	helper.globalConfig.Overrides.GlobalEvmLogBackfillBatchSize = null.IntFrom(int64(batchSize))
@@ -595,7 +596,7 @@ func TestBroadcaster_BackfillALargeNumberOfLogs(t *testing.T) {
 	var backfillCount atomic.Int64
 
 	lggr := logger.TestLogger(t)
-	mockEth.checkFilterLogs = func(fromBlock int64, toBlock int64) {
+	mockEth.CheckFilterLogs = func(fromBlock int64, toBlock int64) {
 		times := backfillCount.Inc() - 1
 		lggr.Warnf("Log Batch: --------- times %v - %v, %v", times, fromBlock, toBlock)
 	}
@@ -607,9 +608,9 @@ func TestBroadcaster_BackfillALargeNumberOfLogs(t *testing.T) {
 	g.Eventually(func() int64 { return backfillCount.Load() }, cltest.WaitTimeout(t), time.Second).Should(gomega.Equal(int64(expectedBatches)))
 
 	helper.unsubscribeAll()
-	g.Eventually(func() int32 { return helper.mockEth.unsubscribeCallCount() }, cltest.WaitTimeout(t), time.Second).Should(gomega.BeNumerically(">=", int32(1)))
+	g.Eventually(func() int32 { return helper.mockEth.UnsubscribeCallCount() }, cltest.WaitTimeout(t), time.Second).Should(gomega.BeNumerically(">=", int32(1)))
 
-	helper.mockEth.assertExpectations(t)
+	helper.mockEth.AssertExpectations(t)
 }
 
 func TestBroadcaster_BroadcastsToCorrectRecipients(t *testing.T) {
@@ -659,10 +660,10 @@ func TestBroadcaster_BroadcastsToCorrectRecipients(t *testing.T) {
 		chRawLogs := <-helper.chchRawLogs
 
 		for _, log := range addr1SentLogs {
-			chRawLogs <- log
+			chRawLogs.TrySend(log)
 		}
 		for _, log := range addr2SentLogs {
-			chRawLogs <- log
+			chRawLogs.TrySend(log)
 		}
 
 		<-headsDone
@@ -674,7 +675,7 @@ func TestBroadcaster_BroadcastsToCorrectRecipients(t *testing.T) {
 		requireEqualLogs(t, addr2SentLogs, listener3.received.getUniqueLogs())
 		requireEqualLogs(t, addr2SentLogs, listener4.received.getUniqueLogs())
 	}()
-	helper.mockEth.assertExpectations(t)
+	helper.mockEth.AssertExpectations(t)
 }
 
 func TestBroadcaster_BroadcastsAtCorrectHeights(t *testing.T) {
@@ -708,7 +709,7 @@ func TestBroadcaster_BroadcastsAtCorrectHeights(t *testing.T) {
 	chRawLogs := <-helper.chchRawLogs
 
 	for _, log := range addr1SentLogs {
-		chRawLogs <- log
+		chRawLogs.TrySend(log)
 	}
 
 	helper.requireBroadcastCount(5)
@@ -757,7 +758,7 @@ func TestBroadcaster_BroadcastsAtCorrectHeights(t *testing.T) {
 	assert.Equal(t, len(logsOnBlocks), len(expectedLogsOnBlocks))
 	require.Equal(t, logsOnBlocks, expectedLogsOnBlocks)
 
-	helper.mockEth.assertExpectations(t)
+	helper.mockEth.AssertExpectations(t)
 }
 
 func TestBroadcaster_DeletesOldLogsAfterNumberOfHeads(t *testing.T) {
@@ -795,7 +796,7 @@ func TestBroadcaster_DeletesOldLogsAfterNumberOfHeads(t *testing.T) {
 	chRawLogs := <-helper.chchRawLogs
 
 	for _, log := range addr1SentLogs {
-		chRawLogs <- log
+		chRawLogs.TrySend(log)
 	}
 
 	helper.requireBroadcastCount(6)
@@ -860,7 +861,7 @@ func TestBroadcaster_DeletesOldLogsOnlyAfterFinalityDepth(t *testing.T) {
 	chRawLogs := <-helper.chchRawLogs
 
 	for _, log := range addr1SentLogs {
-		chRawLogs <- log
+		chRawLogs.TrySend(log)
 	}
 
 	<-headsDone
@@ -962,7 +963,7 @@ func TestBroadcaster_FilterByTopicValues(t *testing.T) {
 	chRawLogs := <-helper.chchRawLogs
 
 	for _, log := range addr1SentLogs {
-		chRawLogs <- log
+		chRawLogs.TrySend(log)
 	}
 
 	<-headsDone
@@ -998,9 +999,9 @@ func TestBroadcaster_BroadcastsWithOneDelayedLog(t *testing.T) {
 
 	chRawLogs := <-helper.chchRawLogs
 
-	chRawLogs <- addr1SentLogs[0]
-	chRawLogs <- addr1SentLogs[1]
-	chRawLogs <- addr1SentLogs[2]
+	chRawLogs.TrySend(addr1SentLogs[0])
+	chRawLogs.TrySend(addr1SentLogs[1])
+	chRawLogs.TrySend(addr1SentLogs[2])
 
 	<-cltest.SimulateIncomingHeads(t, cltest.SimulateIncomingHeadsArgs{
 		StartBlock:     0,
@@ -1009,7 +1010,7 @@ func TestBroadcaster_BroadcastsWithOneDelayedLog(t *testing.T) {
 		Blocks:         blocks,
 	})
 
-	chRawLogs <- addr1SentLogs[3]
+	chRawLogs.TrySend(addr1SentLogs[3])
 
 	<-cltest.SimulateIncomingHeads(t, cltest.SimulateIncomingHeadsArgs{
 		StartBlock:     4,
@@ -1021,7 +1022,7 @@ func TestBroadcaster_BroadcastsWithOneDelayedLog(t *testing.T) {
 	helper.requireBroadcastCount(4)
 	helper.stop()
 
-	helper.mockEth.assertExpectations(t)
+	helper.mockEth.AssertExpectations(t)
 }
 
 func TestBroadcaster_BroadcastsAtCorrectHeightsWithLogsEarlierThanHeads(t *testing.T) {
@@ -1045,7 +1046,7 @@ func TestBroadcaster_BroadcastsAtCorrectHeightsWithLogsEarlierThanHeads(t *testi
 	chRawLogs := <-helper.chchRawLogs
 
 	for _, log := range addr1SentLogs {
-		chRawLogs <- log
+		chRawLogs.TrySend(log)
 	}
 
 	<-cltest.SimulateIncomingHeads(t, cltest.SimulateIncomingHeadsArgs{
@@ -1069,7 +1070,7 @@ func TestBroadcaster_BroadcastsAtCorrectHeightsWithLogsEarlierThanHeads(t *testi
 		listener1.received.getLogs(),
 	)
 
-	helper.mockEth.assertExpectations(t)
+	helper.mockEth.AssertExpectations(t)
 }
 
 func TestBroadcaster_BroadcastsAtCorrectHeightsWithHeadsEarlierThanLogs(t *testing.T) {
@@ -1101,7 +1102,7 @@ func TestBroadcaster_BroadcastsAtCorrectHeightsWithHeadsEarlierThanLogs(t *testi
 	})
 
 	for _, log := range addr1SentLogs {
-		chRawLogs <- log
+		chRawLogs.TrySend(log)
 	}
 
 	<-cltest.SimulateIncomingHeads(t, cltest.SimulateIncomingHeadsArgs{
@@ -1125,7 +1126,7 @@ func TestBroadcaster_BroadcastsAtCorrectHeightsWithHeadsEarlierThanLogs(t *testi
 		listener1.received.getLogs(),
 	)
 
-	helper.mockEth.assertExpectations(t)
+	helper.mockEth.AssertExpectations(t)
 }
 
 func TestBroadcaster_Register_ResubscribesToMostRecentlySeenBlock(t *testing.T) {
@@ -1135,28 +1136,41 @@ func TestBroadcaster_Register_ResubscribesToMostRecentlySeenBlock(t *testing.T) 
 		expectedBlock = 5
 	)
 	var (
-		ethClient, sub = cltest.NewEthClientAndSubMock(t)
-		contract0      = newMockContract()
-		contract1      = newMockContract()
-		contract2      = newMockContract()
+		ethClient = new(evmmocks.Client)
+		contract0 = newMockContract()
+		contract1 = newMockContract()
+		contract2 = newMockContract()
 	)
-
-	chchRawLogs := make(chan chan<- types.Log, backfillTimes)
+	ethClient.Test(t)
+	mockEth := &evmtest.MockEth{EthClient: ethClient}
+	chchRawLogs := make(chan evmtest.RawSub[types.Log], backfillTimes)
 	chStarted := make(chan struct{})
 	ethClient.On("ChainID", mock.Anything).Return(&cltest.FixtureChainID)
 	ethClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			chchRawLogs <- args.Get(2).(chan<- types.Log)
-			close(chStarted)
-		}).
-		Return(sub, nil).
+		Return(
+			func(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) ethereum.Subscription {
+				defer close(chStarted)
+				sub := mockEth.NewSub(t)
+				chchRawLogs <- evmtest.NewRawSub(ch, sub.Err())
+				return sub
+			},
+			func(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) error {
+				return nil
+			},
+		).
 		Once()
 
 	ethClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			chchRawLogs <- args.Get(2).(chan<- types.Log)
-		}).
-		Return(sub, nil).
+		Return(
+			func(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) ethereum.Subscription {
+				sub := mockEth.NewSub(t)
+				chchRawLogs <- evmtest.NewRawSub(ch, sub.Err())
+				return sub
+			},
+			func(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) error {
+				return nil
+			},
+		).
 		Times(3)
 
 	ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).
@@ -1194,9 +1208,6 @@ func TestBroadcaster_Register_ResubscribesToMostRecentlySeenBlock(t *testing.T) 
 		}).
 		Return(nil, nil).
 		Once()
-
-	sub.On("Unsubscribe").Return()
-	sub.On("Err").Return(nil)
 
 	helper := newBroadcasterHelperWithEthClient(t, ethClient, nil)
 	helper.lb.AddDependents(1)
@@ -1253,7 +1264,6 @@ func TestBroadcaster_Register_ResubscribesToMostRecentlySeenBlock(t *testing.T) 
 	}
 
 	cltest.EventuallyExpectationsMet(t, ethClient, cltest.WaitTimeout(t), time.Second)
-	cltest.EventuallyExpectationsMet(t, sub, cltest.WaitTimeout(t), time.Second)
 }
 
 func TestBroadcaster_ReceivesAllLogsWhenResubscribing(t *testing.T) {
@@ -1381,7 +1391,7 @@ func TestBroadcaster_ReceivesAllLogsWhenResubscribing(t *testing.T) {
 						return
 					}
 					lggr.Warnf("  ** yup!")
-					chRawLogs1 <- logsA[uint(head.Number)]
+					chRawLogs1.TrySend(logsA[uint(head.Number)])
 				})},
 			})
 
@@ -1390,10 +1400,10 @@ func TestBroadcaster_ReceivesAllLogsWhenResubscribing(t *testing.T) {
 			logListenerA.requireAllReceived(t, expectedA)
 
 			<-headsDone
-			helper.mockEth.ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(&evmtypes.Head{Number: test.blockHeight2}, nil).Once()
+			helper.mockEth.EthClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(&evmtypes.Head{Number: test.blockHeight2}, nil).Once()
 
 			combinedLogs := append(pickLogs(logsA, test.backfillableLogs), pickLogs(logsB, test.backfillableLogs)...)
-			call := helper.mockEth.ethClient.On("FilterLogs", mock.Anything, mock.Anything).Return(combinedLogs, nil).Once()
+			call := helper.mockEth.EthClient.On("FilterLogs", mock.Anything, mock.Anything).Return(combinedLogs, nil).Once()
 			call.Run(func(args mock.Arguments) {
 				// Validate that the ethereum.FilterQuery is specified correctly for the backfill that we expect
 				fromBlock := args.Get(1).(ethereum.FilterQuery).FromBlock
@@ -1413,18 +1423,19 @@ func TestBroadcaster_ReceivesAllLogsWhenResubscribing(t *testing.T) {
 
 			// Send second batch of new logs
 			chRawLogs2 := <-helper.chchRawLogs
-			_ = cltest.SimulateIncomingHeads(t, cltest.SimulateIncomingHeadsArgs{
+			headsDone = cltest.SimulateIncomingHeads(t, cltest.SimulateIncomingHeadsArgs{
 				StartBlock: test.blockHeight2,
 				Blocks:     blocks,
 				HeadTrackables: []httypes.HeadTrackable{(helper.lb).(httypes.HeadTrackable), cltest.HeadTrackableFunc(func(_ context.Context, head *evmtypes.Head) {
 					if _, exists := logsA[uint(head.Number)]; exists && batchContains(test.batch2, uint(head.Number)) {
-						chRawLogs2 <- logsA[uint(head.Number)]
+						chRawLogs2.TrySend(logsA[uint(head.Number)])
 					}
 					if _, exists := logsB[uint(head.Number)]; exists && batchContains(test.batch2, uint(head.Number)) {
-						chRawLogs2 <- logsB[uint(head.Number)]
+						chRawLogs2.TrySend(logsB[uint(head.Number)])
 					}
 				})},
 			})
+			defer func() { <-headsDone }()
 
 			expectedA = newReceived(pickLogs(logsA, test.expectedFilteredA))
 			expectedB := newReceived(pickLogs(logsB, test.expectedFilteredB))
@@ -1432,7 +1443,7 @@ func TestBroadcaster_ReceivesAllLogsWhenResubscribing(t *testing.T) {
 			logListenerB.requireAllReceived(t, expectedB)
 			helper.requireBroadcastCount(len(test.expectedFilteredA) + len(test.expectedFilteredB))
 
-			helper.mockEth.ethClient.AssertExpectations(t)
+			helper.mockEth.EthClient.AssertExpectations(t)
 		})
 	}
 }
@@ -1526,14 +1537,14 @@ func TestBroadcaster_InjectsBroadcastRecordFunctions(t *testing.T) {
 
 	chRawLogs := <-helper.chchRawLogs
 
-	chRawLogs <- log1
-	chRawLogs <- log2
+	chRawLogs.TrySend(log1)
+	chRawLogs.TrySend(log2)
 
 	<-headsDone
 	require.Eventually(t, func() bool { return len(logListener.received.getUniqueLogs()) >= 2 }, cltest.WaitTimeout(t), time.Second)
 	helper.requireBroadcastCount(2)
 
-	helper.mockEth.ethClient.AssertExpectations(t)
+	helper.mockEth.EthClient.AssertExpectations(t)
 }
 
 func TestBroadcaster_ProcessesLogsFromReorgsAndMissedHead(t *testing.T) {
@@ -1603,11 +1614,7 @@ func TestBroadcaster_ProcessesLogsFromReorgsAndMissedHead(t *testing.T) {
 			ctx, _ := context.WithTimeout(context.Background(), cltest.WaitTimeout(t))
 			(helper.lb).(httypes.HeadTrackable).OnNewLongestChain(ctx, x)
 		case types.Log:
-			select {
-			case chRawLogs <- x:
-			case <-time.After(cltest.WaitTimeout(t)):
-				t.Fatal("timed out sending log")
-			}
+			chRawLogs.TrySend(x)
 		}
 		time.Sleep(250 * time.Millisecond)
 	}
@@ -1622,7 +1629,7 @@ func TestBroadcaster_ProcessesLogsFromReorgsAndMissedHead(t *testing.T) {
 	require.Equal(t, expectedA, listenerA.getUniqueLogs())
 	require.Equal(t, expectedB, listenerB.getUniqueLogs())
 
-	helper.mockEth.ethClient.AssertExpectations(t)
+	helper.mockEth.EthClient.AssertExpectations(t)
 }
 
 func TestBroadcaster_BackfillsForNewListeners(t *testing.T) {
@@ -1630,8 +1637,8 @@ func TestBroadcaster_BackfillsForNewListeners(t *testing.T) {
 
 	const blockHeight int64 = 0
 	helper := newBroadcasterHelper(t, blockHeight, 2)
-	helper.mockEth.ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(&evmtypes.Head{Number: blockHeight}, nil).Times(2)
-	helper.mockEth.ethClient.On("FilterLogs", mock.Anything, mock.Anything).Return(nil, nil).Times(2)
+	helper.mockEth.EthClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(&evmtypes.Head{Number: blockHeight}, nil).Times(2)
+	helper.mockEth.EthClient.On("FilterLogs", mock.Anything, mock.Anything).Return(nil, nil).Times(2)
 
 	helper.start()
 	defer helper.stop()
@@ -1647,8 +1654,8 @@ func TestBroadcaster_BackfillsForNewListeners(t *testing.T) {
 		flux_aggregator_wrapper.FluxAggregatorAnswerUpdated{},
 	}
 	helper.registerWithTopics(listener1, contract, topics1, 1)
-	require.Eventually(t, func() bool { return helper.mockEth.subscribeCallCount() == 1 }, cltest.WaitTimeout(t), 100*time.Millisecond)
-	g.Consistently(func() int32 { return helper.mockEth.subscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(1)))
+	require.Eventually(t, func() bool { return helper.mockEth.SubscribeCallCount() == 1 }, cltest.WaitTimeout(t), 100*time.Millisecond)
+	g.Consistently(func() int32 { return helper.mockEth.SubscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(1)))
 
 	<-helper.chchRawLogs
 
@@ -1656,8 +1663,8 @@ func TestBroadcaster_BackfillsForNewListeners(t *testing.T) {
 		flux_aggregator_wrapper.FluxAggregatorNewRound{},
 	}
 	helper.registerWithTopics(listener2, contract, topics2, 1)
-	require.Eventually(t, func() bool { return helper.mockEth.subscribeCallCount() == 2 }, cltest.WaitTimeout(t), 100*time.Millisecond)
-	g.Consistently(func() int32 { return helper.mockEth.subscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(2)))
+	require.Eventually(t, func() bool { return helper.mockEth.SubscribeCallCount() == 2 }, cltest.WaitTimeout(t), 100*time.Millisecond)
+	g.Consistently(func() int32 { return helper.mockEth.SubscribeCallCount() }, 1*time.Second, cltest.DBPollingInterval).Should(gomega.Equal(int32(2)))
 
 	helper.unsubscribeAll()
 }
@@ -1678,28 +1685,26 @@ func requireEqualLogs(t *testing.T, expectedLogs, actualLogs []types.Log) {
 	}
 }
 
-type sub struct {
-}
-
-func (s sub) Unsubscribe() {
-}
-
-func (s sub) Err() <-chan error {
-	return nil
-}
-
 func TestBroadcaster_BroadcastsWithZeroConfirmations(t *testing.T) {
 	gm := gomega.NewWithT(t)
 
 	ethClient := new(evmmocks.Client)
 	ethClient.Test(t)
+	mockEth := &evmtest.MockEth{EthClient: ethClient}
 	ethClient.On("ChainID").Return(big.NewInt(0)).Maybe()
-	logsChCh := make(chan chan<- types.Log)
+	logsChCh := make(chan evmtest.RawSub[types.Log])
 	ethClient.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) {
-			logsChCh <- args.Get(2).(chan<- types.Log)
-		}).
-		Return(sub{}, nil)
+		Return(
+			func(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) ethereum.Subscription {
+				sub := mockEth.NewSub(t)
+				logsChCh <- evmtest.NewRawSub(ch, sub.Err())
+				return sub
+			},
+			func(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) error {
+				return nil
+			},
+		).
+		Once()
 	ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).
 		Return(&evmtypes.Head{Number: 1}, nil)
 	ethClient.On("FilterLogs", mock.Anything, mock.Anything).
@@ -1762,11 +1767,7 @@ func TestBroadcaster_BroadcastsWithZeroConfirmations(t *testing.T) {
 	logs := <-logsChCh
 
 	for _, log := range addr1SentLogs {
-		select {
-		case logs <- log:
-		case <-time.After(time.Second):
-			t.Error("failed to send log to log broadcaster")
-		}
+		logs.TrySend(log)
 	}
 	// Wait until the logpool has the 3 logs
 	gm.Eventually(func() bool {

--- a/core/chains/evm/txmgr/transmitchecker_test.go
+++ b/core/chains/evm/txmgr/transmitchecker_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestFactory(t *testing.T) {
-	client, _ := cltest.NewEthMocksWithDefaultChain(t)
+	client := cltest.NewEthMocksWithDefaultChain(t)
 	factory := &txmgr.CheckerFactory{Client: client}
 
 	t.Run("no checker", func(t *testing.T) {

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -426,54 +426,38 @@ func NewApplicationWithConfig(t testing.TB, cfg *configtest.TestGeneralConfig, f
 	return ta
 }
 
-func NewEthMocksWithDefaultChain(t testing.TB) (c *evmMocks.Client, s *evmMocks.Subscription) {
+func NewEthMocksWithDefaultChain(t testing.TB) (c *evmMocks.Client) {
 	testutils.SkipShortDB(t)
-	c, s = NewEthMocks(t)
+	c = NewEthMocks(t)
 	c.On("ChainID").Return(&FixtureChainID).Maybe()
 	return
 }
 
-func NewEthMocks(t testing.TB) (*evmMocks.Client, *evmMocks.Subscription) {
-	c, s := NewEthClientAndSubMock(t)
+func NewEthMocks(t testing.TB) *evmMocks.Client {
+	c := new(evmMocks.Client)
+	c.Test(t)
 	switch tt := t.(type) {
 	case *testing.T:
 		t.Cleanup(func() {
 			c.AssertExpectations(tt)
-			s.AssertExpectations(tt)
 		})
 	}
-	return c, s
-}
-
-func NewEthClientAndSubMock(t mock.TestingT) (*evmMocks.Client, *evmMocks.Subscription) {
-	mockSub := new(evmMocks.Subscription)
-	mockSub.Test(t)
-	mockEth := new(evmMocks.Client)
-	mockEth.Test(t)
-	return mockEth, mockSub
-}
-
-func NewEthClientAndSubMockWithDefaultChain(t mock.TestingT) (*evmMocks.Client, *evmMocks.Subscription) {
-	mockEth, mockSub := NewEthClientAndSubMock(t)
-	mockEth.On("ChainID").Return(&FixtureChainID).Maybe()
-	return mockEth, mockSub
-}
-
-func NewEthClientMock(t mock.TestingT) *evmMocks.Client {
-	mockEth := new(evmMocks.Client)
-	mockEth.Test(t)
-	return mockEth
-}
-
-func NewEthClientMockWithDefaultChain(t testing.TB) *evmMocks.Client {
-	c := NewEthClientMock(t)
-	c.On("ChainID").Return(&FixtureChainID).Maybe()
 	return c
+}
+
+// Deprecated: use evmtest.NewEthClientMock
+func NewEthClientMock(t mock.TestingT) *evmMocks.Client {
+	return evmtest.NewEthClientMock(t)
+}
+
+// Deprecated: use evmtest.NewEthClientMockWithDefaultChain
+func NewEthClientMockWithDefaultChain(t testing.TB) *evmMocks.Client {
+	return evmtest.NewEthClientMockWithDefaultChain(t)
 }
 
 func NewEthMocksWithStartupAssertions(t testing.TB) *evmMocks.Client {
 	testutils.SkipShort(t, "long test")
-	c, s := NewEthMocks(t)
+	c := NewEthMocks(t)
 	c.On("Dial", mock.Anything).Maybe().Return(nil)
 	c.On("SubscribeNewHead", mock.Anything, mock.Anything).Maybe().Return(EmptyMockSubscription(t), nil)
 	c.On("SendTransaction", mock.Anything, mock.Anything).Maybe().Return(nil)
@@ -486,15 +470,13 @@ func NewEthMocksWithStartupAssertions(t testing.TB) *evmMocks.Client {
 	})
 	c.On("BlockByNumber", mock.Anything, mock.Anything).Maybe().Return(block, nil)
 
-	s.On("Err").Return(nil).Maybe()
-	s.On("Unsubscribe").Return(nil).Maybe()
 	return c
 }
 
 // NewEthMocksWithTransactionsOnBlocksAssertions sets an Eth mock with transactions on blocks
 func NewEthMocksWithTransactionsOnBlocksAssertions(t testing.TB) *evmMocks.Client {
 	testutils.SkipShort(t, "long test")
-	c, s := NewEthMocks(t)
+	c := NewEthMocks(t)
 	c.On("Dial", mock.Anything).Maybe().Return(nil)
 	c.On("SubscribeNewHead", mock.Anything, mock.Anything).Maybe().Return(EmptyMockSubscription(t), nil)
 	c.On("SendTransaction", mock.Anything, mock.Anything).Maybe().Return(nil)
@@ -521,9 +503,6 @@ func NewEthMocksWithTransactionsOnBlocksAssertions(t testing.TB) *evmMocks.Clien
 		Number: big.NewInt(100),
 	})
 	c.On("BlockByNumber", mock.Anything, mock.Anything).Maybe().Return(block, nil)
-
-	s.On("Err").Return(nil).Maybe()
-	s.On("Unsubscribe").Return(nil).Maybe()
 
 	return c
 }

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
@@ -795,8 +796,8 @@ func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 	cfg := cltest.NewTestGeneralConfig(t)
 	cfg.Overrides.GlobalBalanceMonitorEnabled = null.BoolFrom(false)
 
-	ethClient, sub := cltest.NewEthMocksWithDefaultChain(t)
-	chchNewHeads := make(chan chan<- *evmtypes.Head, 1)
+	ethClient := cltest.NewEthMocksWithDefaultChain(t)
+	chchNewHeads := make(chan evmtest.RawSub[*evmtypes.Head], 1)
 
 	db := pgtest.NewSqlxDB(t)
 	kst := cltest.NewKeyStore(t, db, cfg)
@@ -831,12 +832,16 @@ func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 	h41 := evmtypes.Head{Hash: b41.Hash, ParentHash: h40.Hash, Number: 41, EVMChainID: evmChainID}
 	h42 := evmtypes.Head{Hash: b42.Hash, ParentHash: h41.Hash, Number: 42, EVMChainID: evmChainID}
 
-	sub.On("Err").Return(nil)
-	sub.On("Unsubscribe").Return(nil).Maybe()
-
+	mockEth := &evmtest.MockEth{EthClient: ethClient}
 	ethClient.On("SubscribeNewHead", mock.Anything, mock.Anything).
-		Run(func(args mock.Arguments) { chchNewHeads <- args.Get(1).(chan<- *evmtypes.Head) }).
-		Return(sub, nil)
+		Return(
+			func(ctx context.Context, ch chan<- *evmtypes.Head) ethereum.Subscription {
+				sub := mockEth.NewSub(t)
+				chchNewHeads <- evmtest.NewRawSub(ch, sub.Err())
+				return sub
+			},
+			func(ctx context.Context, ch chan<- *evmtypes.Head) error { return nil },
+		)
 	// Nonce syncer
 	ethClient.On("PendingNonceAt", mock.Anything, mock.Anything).Maybe().Return(uint64(0), nil)
 
@@ -857,7 +862,7 @@ func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(oneETH.ToInt(), nil)
 
 	require.NoError(t, cc.Start(testutils.Context(t)))
-	var newHeads chan<- *evmtypes.Head
+	var newHeads evmtest.RawSub[*evmtypes.Head]
 	select {
 	case newHeads = <-chchNewHeads:
 	case <-time.After(10 * time.Second):
@@ -885,7 +890,7 @@ func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 	ethClient.On("HeadByNumber", mock.Anything, big.NewInt(41)).Return(&h41, nil)
 
 	// Simulate one new head and check the gas price got updated
-	newHeads <- cltest.Head(43)
+	newHeads.TrySend(cltest.Head(43))
 
 	gomega.NewWithT(t).Eventually(func() string {
 		gasPrice, _, err := estimator.GetLegacyGas(nil, 500000)

--- a/core/internal/testutils/evmtest/evmtest.go
+++ b/core/internal/testutils/evmtest/evmtest.go
@@ -8,6 +8,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
+	"github.com/stretchr/testify/mock"
+	"go.uber.org/atomic"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slices"
 
@@ -20,9 +23,11 @@ import (
 	evmconfig "github.com/smartcontractkit/chainlink/core/chains/evm/config"
 	httypes "github.com/smartcontractkit/chainlink/core/chains/evm/headtracker/types"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/log"
+	evmMocks "github.com/smartcontractkit/chainlink/core/chains/evm/mocks"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/config"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
@@ -271,4 +276,84 @@ func ChainArbitrumRinkeby(t *testing.T) evmconfig.ChainScopedConfig { return sco
 func scopedConfig(t *testing.T, chainID int64) evmconfig.ChainScopedConfig {
 	return evmconfig.NewChainScopedConfig(big.NewInt(chainID), evmtypes.ChainCfg{}, nil,
 		logger.TestLogger(t), configtest.NewTestGeneralConfig(t))
+}
+
+func NewEthClientMock(t mock.TestingT) *evmMocks.Client {
+	mockEth := new(evmMocks.Client)
+	mockEth.Test(t)
+	return mockEth
+}
+
+func NewEthClientMockWithDefaultChain(t testing.TB) *evmMocks.Client {
+	c := NewEthClientMock(t)
+	c.On("ChainID").Return(testutils.FixtureChainID).Maybe()
+	return c
+}
+
+type MockEth struct {
+	EthClient       *evmMocks.Client
+	CheckFilterLogs func(int64, int64)
+
+	subs             []*evmMocks.Subscription
+	errChs           []chan error
+	subscribeCalls   atomic.Int32
+	unsubscribeCalls atomic.Int32
+}
+
+func (m *MockEth) AssertExpectations(t *testing.T) {
+	m.EthClient.AssertExpectations(t)
+	for _, sub := range m.subs {
+		sub.AssertExpectations(t)
+	}
+}
+
+func (m *MockEth) SubscribeCallCount() int32 {
+	return m.subscribeCalls.Load()
+}
+
+func (m *MockEth) UnsubscribeCallCount() int32 {
+	return m.unsubscribeCalls.Load()
+}
+
+func (m *MockEth) NewSub(t *testing.T) ethereum.Subscription {
+	m.subscribeCalls.Inc()
+	sub := new(evmMocks.Subscription)
+	sub.Test(t)
+	errCh := make(chan error)
+	sub.On("Err").
+		Return(func() <-chan error { return errCh })
+	sub.On("Unsubscribe").
+		Run(func(mock.Arguments) {
+			m.unsubscribeCalls.Inc()
+			close(errCh)
+		}).Return().Maybe()
+	m.subs = append(m.subs, sub)
+	m.errChs = append(m.errChs, errCh)
+	return sub
+}
+
+func (m *MockEth) SubsErr(err error) {
+	for _, errCh := range m.errChs {
+		errCh <- err
+	}
+}
+
+type RawSub[T any] struct {
+	ch  chan<- T
+	err <-chan error
+}
+
+func NewRawSub[T any](ch chan<- T, err <-chan error) RawSub[T] {
+	return RawSub[T]{ch: ch, err: err}
+}
+
+func (r *RawSub[T]) CloseCh() {
+	close(r.ch)
+}
+
+func (r *RawSub[T]) TrySend(t T) {
+	select {
+	case <-r.err:
+	case r.ch <- t:
+	}
 }

--- a/core/services/job/runner_integration_test.go
+++ b/core/services/job/runner_integration_test.go
@@ -57,7 +57,7 @@ func TestRunner(t *testing.T) {
 	keyStore := cltest.NewKeyStore(t, db, config)
 	ethKeyStore := keyStore.Eth()
 
-	ethClient, _ := cltest.NewEthMocksWithDefaultChain(t)
+	ethClient := cltest.NewEthMocksWithDefaultChain(t)
 	ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(cltest.Head(10), nil)
 	ethClient.On("CallContract", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(nil, nil)
 

--- a/core/services/job/spawner_test.go
+++ b/core/services/job/spawner_test.go
@@ -60,7 +60,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 	_, bridge := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, config)
 	_, bridge2 := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, config)
 
-	ethClient, _ := cltest.NewEthMocksWithDefaultChain(t)
+	ethClient := cltest.NewEthMocksWithDefaultChain(t)
 	ethClient.On("CallContext", mock.Anything, mock.Anything, "eth_getBlockByNumber", mock.Anything, false).
 		Run(func(args mock.Arguments) {
 			head := args.Get(1).(**evmtypes.Head)


### PR DESCRIPTION
Story details: https://app.shortcut.com/chainlinklabs/story/35669
Resolving this race required wiring up some error channels in mock subscriptions, and should improve test reliability besides.