### PR TITLE
Add suffix for root image as part of future deprecation

### DIFF
--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -112,6 +112,8 @@ runs:
     id: meta-root
     uses: docker/metadata-action@e5622373a38e60fb6d795a4421e56882f2d7a681 # v3.6.2
     with:
+      flavor: |
+        suffix=-root
       # list of Docker images to use as base name for tags
       images: ${{ env.shared-images }}
       tags: ${{ env.shared-tag-list }}


### PR DESCRIPTION
Currently we generate two images with version tags:
- 1.x.y
- 1.x.y-nonroot

This change will give us two images with version tags:
- 1.x.y-root
- 1.x.y-nonroot

The goal will be to no longer announce the root image but keep building it for a short period of time just in case NOPs absolutely need it. In the near future, the "-root" suffixed images will no longer be built/published at all.
