### PR TITLE
Fixed LOG_FILE_MAX_SIZE handling

### DIFF
--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -74,9 +74,9 @@ func TestClient_RunNodeShowsEnv(t *testing.T) {
 	assert.NoError(t, err)
 
 	lcfg := logger.Config{
-		LogLevel:    zapcore.DebugLevel,
-		FileMaxSize: int(logFileSize),
-		Dir:         t.TempDir(),
+		LogLevel:      zapcore.DebugLevel,
+		FileMaxSizeMB: int(logFileSize / utils.MB),
+		Dir:           t.TempDir(),
 	}
 
 	tmpFile, err := os.CreateTemp(lcfg.Dir, "*")
@@ -416,8 +416,8 @@ func TestClient_DiskMaxSizeBeforeRotateOptionDisablesAsExpected(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := logger.Config{
-				Dir:         t.TempDir(),
-				FileMaxSize: int(tt.logFileSize(t)),
+				Dir:           t.TempDir(),
+				FileMaxSizeMB: int(tt.logFileSize(t) / utils.MB),
 			}
 			assert.NoError(t, os.MkdirAll(cfg.Dir, os.FileMode(0700)))
 

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -195,13 +195,13 @@ func NewLogger() (Logger, func() error) {
 		parseErrs = append(parseErrs, invalid)
 	}
 	if fileMaxSize == 0 || invalid != "" {
-		c.FileMaxSize = 0 // default is 100Mb
-		parseErrs = append(parseErrs, "LogFileMaxSize will default to 100Mb")
+		c.FileMaxSizeMB = 5120 * utils.MB // our default (env var) is 5120mb
+		parseErrs = append(parseErrs, "LogFileMaxSize will default to 5120mb")
 	} else if fileMaxSize < utils.MB {
-		c.FileMaxSize = 1 // 1Mb
+		c.FileMaxSizeMB = 1 // 1Mb is the minimum accepted by logging backend
 		parseErrs = append(parseErrs, "LogFileMaxSize will default to 1Mb")
 	} else {
-		c.FileMaxSize = int(fileMaxSize / utils.MB)
+		c.FileMaxSizeMB = int(fileMaxSize / utils.MB)
 	}
 
 	if c.DebugLogsToDisk() {
@@ -211,7 +211,7 @@ func NewLogger() (Logger, func() error) {
 		)
 
 		fileMaxAge, invalid = envvar.LogFileMaxAge.Parse()
-		c.FileMaxAge = int(fileMaxAge)
+		c.FileMaxAgeDays = int(fileMaxAge)
 		if invalid != "" {
 			parseErrs = append(parseErrs, invalid)
 		}
@@ -240,8 +240,8 @@ type Config struct {
 	Dir            string
 	JsonConsole    bool
 	UnixTS         bool
-	FileMaxSize    int // megabytes
-	FileMaxAge     int // days
+	FileMaxSizeMB  int
+	FileMaxAgeDays int
 	FileMaxBackups int // files
 }
 
@@ -265,12 +265,12 @@ func (c *Config) New() (Logger, func() error) {
 
 // DebugLogsToDisk returns whether debug logs should be stored in disk
 func (c Config) DebugLogsToDisk() bool {
-	return c.FileMaxSize > 0
+	return c.FileMaxSizeMB > 0
 }
 
 // RequiredDiskSpace returns the required disk space in order to allow debug logs to be stored in disk
 func (c Config) RequiredDiskSpace() utils.FileSize {
-	return utils.FileSize(c.FileMaxSize * utils.MB * (c.FileMaxBackups + 1))
+	return utils.FileSize(c.FileMaxSizeMB * utils.MB * (c.FileMaxBackups + 1))
 }
 
 // InitColor explicitly sets the global color.NoColor option.

--- a/core/logger/zap_disk_logging.go
+++ b/core/logger/zap_disk_logging.go
@@ -42,8 +42,8 @@ func (cfg zapLoggerConfig) newDiskCore() (zapcore.Core, error) {
 		encoder = zapcore.NewConsoleEncoder(makeEncoderConfig(cfg.local))
 		sink    = zapcore.AddSync(&lumberjack.Logger{
 			Filename:   logFileURI(cfg.local.Dir),
-			MaxSize:    cfg.local.FileMaxSize,
-			MaxAge:     cfg.local.FileMaxAge,
+			MaxSize:    cfg.local.FileMaxSizeMB,
+			MaxAge:     cfg.local.FileMaxAgeDays,
 			MaxBackups: cfg.local.FileMaxBackups,
 			Compress:   true,
 		})

--- a/core/logger/zap_test.go
+++ b/core/logger/zap_test.go
@@ -43,9 +43,9 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 		Config: cfg,
 		local: Config{
 			Dir:            logsDir,
-			FileMaxAge:     0,
+			FileMaxAgeDays: 0,
 			FileMaxBackups: 1,
-			FileMaxSize:    int(logFileSize),
+			FileMaxSizeMB:  int(logFileSize / utils.MB),
 		},
 		diskPollConfig: pollCfg,
 		diskLogLevel:   zap.NewAtomicLevelAt(zapcore.DebugLevel),
@@ -67,7 +67,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 			stop:     stop,
 			pollChan: pollChan,
 		}
-		zapCfg.local.FileMaxSize = int(maxSize) * 2
+		zapCfg.local.FileMaxSizeMB = int(maxSize/utils.MB) * 2
 
 		lggr, close, err := zapCfg.newLogger()
 		assert.NoError(t, err)
@@ -101,7 +101,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 			stop:     stop,
 			pollChan: pollChan,
 		}
-		zapCfg.local.FileMaxSize = int(maxSize) * 2
+		zapCfg.local.FileMaxSizeMB = int(maxSize/utils.MB) * 2
 
 		lggr, close, err := zapCfg.newLogger()
 		assert.NoError(t, err)
@@ -135,7 +135,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 			stop:     stop,
 			pollChan: pollChan,
 		}
-		zapCfg.local.FileMaxSize = int(maxSize) * 2
+		zapCfg.local.FileMaxSizeMB = int(maxSize/utils.MB) * 2
 
 		lggr, close, err := zapCfg.newLogger()
 		assert.NoError(t, err)
@@ -185,7 +185,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 			stop:     stop,
 			pollChan: pollChan,
 		}
-		zapCfg.local.FileMaxSize = int(maxSize) * 2
+		zapCfg.local.FileMaxSizeMB = int(maxSize/utils.MB) * 2
 
 		lggr, close, err := zapCfg.newLogger()
 		assert.NoError(t, err)


### PR DESCRIPTION
Closes https://app.shortcut.com/chainlinklabs/story/37408/nops-support-log-file-max-size-not-working-with-default