### PR TITLE
Fixed `FileSize` conversions

### DIFF
--- a/core/utils/files.go
+++ b/core/utils/files.go
@@ -101,8 +101,6 @@ func EnsureFilepathMaxPerms(filepath string, perms os.FileMode) (err error) {
 // FileSize repesents a file size in bytes.
 type FileSize uint64
 
-var fsregex = regexp.MustCompile(`(\d+\.?\d*)(tb|gb|mb|kb|b)?`)
-
 //nolint
 const (
 	KB = 1000
@@ -111,15 +109,28 @@ const (
 	TB = 1000 * GB
 )
 
+var (
+	fsregex = regexp.MustCompile(`(\d+\.?\d*)(tb|gb|mb|kb|b)?`)
+
+	fsUnitMap = map[string]int{
+		"tb": TB,
+		"gb": GB,
+		"mb": MB,
+		"kb": KB,
+		"b":  1,
+		"":   1,
+	}
+)
+
 // MarshalText encodes s as a human readable string.
 func (s FileSize) MarshalText() ([]byte, error) {
-	if s > TB {
+	if s >= TB {
 		return []byte(fmt.Sprintf("%.2ftb", float64(s)/TB)), nil
-	} else if s > GB {
+	} else if s >= GB {
 		return []byte(fmt.Sprintf("%.2fgb", float64(s)/GB)), nil
-	} else if s > MB {
+	} else if s >= MB {
 		return []byte(fmt.Sprintf("%.2fmb", float64(s)/MB)), nil
-	} else if s > KB {
+	} else if s >= KB {
 		return []byte(fmt.Sprintf("%.2fkb", float64(s)/KB)), nil
 	}
 	return []byte(fmt.Sprintf("%db", s)), nil
@@ -127,35 +138,28 @@ func (s FileSize) MarshalText() ([]byte, error) {
 
 // UnmarshalText parses a file size from bs in to s.
 func (s *FileSize) UnmarshalText(bs []byte) error {
-	matches := fsregex.FindAllStringSubmatch(strings.ToLower(string(bs)), -1)
-	if len(matches) != 1 {
-		return errors.Errorf(`bad filesize: "%v"`, string(bs))
-	} else if len(matches[0]) != 3 {
-		return errors.Errorf(`bad filesize: "%v"`, string(bs))
+	lc := strings.ToLower(strings.TrimSpace(string(bs)))
+	matches := fsregex.FindAllStringSubmatch(lc, -1)
+	if len(matches) != 1 || len(matches[0]) != 3 || fmt.Sprintf("%s%s", matches[0][1], matches[0][2]) != lc {
+		return errors.Errorf(`bad filesize expression: "%v"`, string(bs))
 	}
+
 	var (
 		num  = matches[0][1]
 		unit = matches[0][2]
 	)
-	bytes, err := strconv.ParseFloat(num, 64)
+
+	value, err := strconv.ParseFloat(num, 64)
 	if err != nil {
-		return err
+		return errors.Errorf(`bad filesize value: "%v"`, string(bs))
 	}
 
-	switch unit {
-	case "", "b":
-	case "kb":
-		bytes *= KB
-	case "mb":
-		bytes *= MB
-	case "gb":
-		bytes *= GB
-	case "tb":
-		bytes *= TB
-	default:
+	u, ok := fsUnitMap[unit]
+	if !ok {
 		return errors.Errorf(`bad filesize unit: "%v"`, unit)
 	}
-	*s = FileSize(bytes)
+
+	*s = FileSize(value * float64(u))
 	return nil
 }
 

--- a/core/utils/files_test.go
+++ b/core/utils/files_test.go
@@ -1,0 +1,92 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileSize_MarshalText_String(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    FileSize
+		expected string
+	}{
+		{FileSize(0), "0b"},
+		{FileSize(1), "1b"},
+		{FileSize(MB), "1.00mb"},
+		{FileSize(KB), "1.00kb"},
+		{FileSize(MB), "1.00mb"},
+		{FileSize(GB), "1.00gb"},
+		{FileSize(TB), "1.00tb"},
+		{FileSize(5 * GB), "5.00gb"},
+		{FileSize(0.5 * GB), "500.00mb"},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.expected, func(t *testing.T) {
+			t.Parallel()
+
+			bstr, err := test.input.MarshalText()
+			assert.NoError(t, err)
+			assert.Equal(t, test.expected, string(bstr))
+			assert.Equal(t, test.expected, test.input.String())
+		})
+	}
+}
+
+func TestFileSize_UnmarshalText(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		input    string
+		expected FileSize
+		valid    bool
+	}{
+		// valid
+		{"0", FileSize(0), true},
+		{"0.0", FileSize(0), true},
+		{"1.12345", FileSize(1), true},
+		{"123", FileSize(123), true},
+		{"123", FileSize(123), true},
+		{"123b", FileSize(123), true},
+		{"123B", FileSize(123), true},
+		{"123kb", FileSize(123 * KB), true},
+		{"123KB", FileSize(123 * KB), true},
+		{"123mb", FileSize(123 * MB), true},
+		{"123gb", FileSize(123 * GB), true},
+		{"123tb", FileSize(123 * TB), true},
+		{"5.5mb", FileSize(5.5 * MB), true},
+		{"0.5mb", FileSize(0.5 * MB), true},
+		// invalid
+		{"", FileSize(0), false},
+		{"xyz", FileSize(0), false},
+		{"-1g", FileSize(0), false},
+		{"+1g", FileSize(0), false},
+		{"1g", FileSize(0), false},
+		{"1t", FileSize(0), false},
+		{"1a", FileSize(0), false},
+		{"1tbtb", FileSize(0), false},
+		{"1tb1tb", FileSize(0), false},
+	}
+
+	for _, test := range tests {
+		test := test
+
+		t.Run(test.input, func(t *testing.T) {
+			t.Parallel()
+
+			var fs FileSize
+			err := fs.UnmarshalText([]byte(test.input))
+			if test.valid {
+				assert.NoError(t, err)
+				assert.Equal(t, test.expected, fs)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes https://app.shortcut.com/chainlinklabs/story/38647/nops-support-log-file-max-size-confusion