### PR TITLE
remove unused LowestUnsyncedID from orm

### DIFF
--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -579,8 +579,8 @@ func MustInsertKeeperRegistry(t *testing.T, db *sqlx.DB, korm keeper.ORM, ethKey
 
 func MustInsertUpkeepForRegistry(t *testing.T, db *sqlx.DB, cfg keeper.Config, registry keeper.Registry) keeper.UpkeepRegistration {
 	korm := keeper.NewORM(db, logger.TestLogger(t), cfg, txmgr.SendEveryStrategy{})
-	upkeepID, err := korm.LowestUnsyncedID(registry.ID)
-	require.NoError(t, err)
+	mathrand.Seed(time.Now().UnixNano())
+	upkeepID := utils.NewBigI(int64(mathrand.Uint32()))
 	upkeep := keeper.UpkeepRegistration{
 		UpkeepID:   upkeepID,
 		ExecuteGas: uint64(150_000),

--- a/core/services/keeper/orm.go
+++ b/core/services/keeper/orm.go
@@ -91,7 +91,7 @@ RETURNING *
 	return errors.Wrap(err, "failed to upsert upkeep")
 }
 
-// Update the last keeper index for an upkeep
+// UpdateUpkeepLastKeeperIndex updates the last keeper index for an upkeep
 func (korm ORM) UpdateUpkeepLastKeeperIndex(jobID int32, upkeepID *utils.Big, fromAddress ethkey.EIP55Address) error {
 	_, err := korm.q.Exec(`
 	UPDATE upkeep_registrations
@@ -124,7 +124,7 @@ DELETE FROM upkeep_registrations WHERE registry_id IN (
 	return rowsAffected, nil
 }
 
-//EligibleUpkeepsForRegistry fetches eligible upkeeps for processing
+// NewEligibleUpkeepsForRegistry fetches eligible upkeeps for processing
 //The query checks the following conditions
 // - checks the registry address is correct and the registry has some keepers associated
 // -- is it my turn AND my keeper was not the last perform for this upkeep OR my keeper was the last before BUT it is past the grace period
@@ -247,18 +247,6 @@ FROM upkeep_registrations
 WHERE registry_id = $1
 `, regID)
 	return upkeeps, errors.Wrap(err, "allUpkeepIDs failed")
-}
-
-// LowestUnsyncedID returns the largest upkeepID + 1, indicating the expected next upkeepID
-// to sync from the contract
-// Note: This function is only applicable for registry version 1_0 and 1_1
-func (korm ORM) LowestUnsyncedID(regID int64) (nextID *utils.Big, err error) {
-	err = korm.q.Get(&nextID, `
-SELECT coalesce(max(upkeep_id), -1) + 1
-FROM upkeep_registrations
-WHERE registry_id = $1
-`, regID)
-	return nextID, errors.Wrap(err, "LowestUnsyncedID failed")
 }
 
 //SetLastRunInfoForUpkeepOnJob sets the last run block height and the associated keeper index only if the new block height is greater than the previous.

--- a/core/services/keeper/orm_old_turn_test.go
+++ b/core/services/keeper/orm_old_turn_test.go
@@ -180,34 +180,6 @@ func TestKeeperDB_EligibleUpkeeps_FiltersByRegistry(t *testing.T) {
 	assert.Equal(t, 1, len(list2))
 }
 
-func TestKeeperDB_NextUpkeepID(t *testing.T) {
-	t.Parallel()
-	db, config, orm := setupKeeperDB(t)
-	ethKeyStore := cltest.NewKeyStore(t, db, config).Eth()
-
-	registry, _ := cltest.MustInsertKeeperRegistry(t, db, orm, ethKeyStore, 0, 2, 20)
-
-	nextID, err := orm.LowestUnsyncedID(registry.ID)
-	require.NoError(t, err)
-	require.Equal(t, utils.NewBigI(0), nextID)
-
-	upkeep := newUpkeep(registry, 0)
-	err = orm.UpsertUpkeep(&upkeep)
-	require.NoError(t, err)
-
-	nextID, err = orm.LowestUnsyncedID(registry.ID)
-	require.NoError(t, err)
-	require.Equal(t, utils.NewBigI(1), nextID)
-
-	upkeep = newUpkeep(registry, 3)
-	err = orm.UpsertUpkeep(&upkeep)
-	require.NoError(t, err)
-
-	nextID, err = orm.LowestUnsyncedID(registry.ID)
-	require.NoError(t, err)
-	require.Equal(t, utils.NewBigI(4), nextID)
-}
-
 func TestKeeperDB_SetLastRunInfoForUpkeepOnJob(t *testing.T) {
 	t.Parallel()
 	db, config, orm := setupKeeperDB(t)


### PR DESCRIPTION
Before registry 1.2, we always create upkeep id by adding 1 to the currently highest upkeep id.
Starting from registry 1.2, the new logic will generate a random big int id for each upkeep.
This PR will remove the old logic in test and generate a random number for upkeeps in test files.