### PR TITLE
Fix issues with permissions to approve specs in FMS

### DIFF
--- a/core/services/feeds/mocks/orm.go
+++ b/core/services/feeds/mocks/orm.go
@@ -360,6 +360,29 @@ func (_m *ORM) GetJobProposalByRemoteUUID(_a0 uuid.UUID) (*feeds.JobProposal, er
 	return r0, r1
 }
 
+// GetLatestSpec provides a mock function with given fields: jpID
+func (_m *ORM) GetLatestSpec(jpID int64) (*feeds.JobProposalSpec, error) {
+	ret := _m.Called(jpID)
+
+	var r0 *feeds.JobProposalSpec
+	if rf, ok := ret.Get(0).(func(int64) *feeds.JobProposalSpec); ok {
+		r0 = rf(jpID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*feeds.JobProposalSpec)
+		}
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(int64) error); ok {
+		r1 = rf(jpID)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // GetManager provides a mock function with given fields: id
 func (_m *ORM) GetManager(id int64) (*feeds.FeedsManager, error) {
 	ret := _m.Called(id)

--- a/core/services/feeds/orm.go
+++ b/core/services/feeds/orm.go
@@ -44,6 +44,7 @@ type ORM interface {
 	CancelSpec(id int64, qopts ...pg.QOpt) error
 	CreateSpec(spec JobProposalSpec, qopts ...pg.QOpt) (int64, error)
 	ExistsSpecByJobProposalIDAndVersion(jpID int64, version int32, qopts ...pg.QOpt) (exists bool, err error)
+	GetLatestSpec(jpID int64) (*JobProposalSpec, error)
 	GetSpec(id int64, qopts ...pg.QOpt) (*JobProposalSpec, error)
 	ListSpecsByJobProposalIDs(ids []int64, qopts ...pg.QOpt) ([]JobProposalSpec, error)
 	RejectSpec(id int64, qopts ...pg.QOpt) error
@@ -531,6 +532,26 @@ WHERE id = $1;
 `
 	var spec JobProposalSpec
 	err := o.q.WithOpts(qopts...).Get(&spec, stmt, id)
+
+	return &spec, errors.Wrap(err, "CreateJobProposalSpec failed")
+}
+
+// GetLatestSpec gets the latest spec for a job proposal.
+func (o *orm) GetLatestSpec(jpID int64) (*JobProposalSpec, error) {
+	stmt := `
+	SELECT id, definition, version, status, job_proposal_id, status_updated_at, created_at, updated_at
+FROM job_proposal_specs
+WHERE (job_proposal_id, version) IN
+(
+	SELECT job_proposal_id, MAX(version)
+	FROM job_proposal_specs
+	GROUP BY job_proposal_id
+)
+AND job_proposal_id = $1
+`
+
+	var spec JobProposalSpec
+	err := o.q.Get(&spec, stmt, jpID)
 
 	return &spec, errors.Wrap(err, "CreateJobProposalSpec failed")
 }

--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -760,6 +760,34 @@ func Test_ORM_GetSpec(t *testing.T) {
 	assert.Equal(t, jpID, actual.JobProposalID)
 }
 
+func Test_ORM_GetLatestSpec(t *testing.T) {
+	t.Parallel()
+
+	var (
+		orm  = setupORM(t)
+		fmID = createFeedsManager(t, orm)
+		jpID = createJobProposal(t, orm, feeds.JobProposalStatusPending, fmID)
+	)
+
+	_ = createJobSpec(t, orm, int64(jpID))
+	spec2ID, err := orm.CreateSpec(feeds.JobProposalSpec{
+		Definition:    "spec data",
+		Version:       2,
+		Status:        feeds.SpecStatusPending,
+		JobProposalID: jpID,
+	})
+	require.NoError(t, err)
+
+	actual, err := orm.GetSpec(spec2ID)
+	require.NoError(t, err)
+
+	assert.Equal(t, spec2ID, actual.ID)
+	assert.Equal(t, "spec data", actual.Definition)
+	assert.Equal(t, int32(2), actual.Version)
+	assert.Equal(t, feeds.SpecStatusPending, actual.Status)
+	assert.Equal(t, jpID, actual.JobProposalID)
+}
+
 func Test_ORM_ListSpecsByJobProposalIDs(t *testing.T) {
 	t.Parallel()
 

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -528,8 +528,23 @@ func (s *service) ApproveSpec(ctx context.Context, id int64, force bool) error {
 		return errors.Wrap(err, "orm: job proposal spec")
 	}
 
-	if spec.Status != SpecStatusPending && spec.Status != SpecStatusCancelled {
-		return errors.New("must be a pending or cancelled job proposal")
+	switch spec.Status {
+	case SpecStatusApproved:
+		return errors.New("cannot approved an approved spec")
+	case SpecStatusRejected:
+		return errors.New("cannot approved a rejected spec")
+	case SpecStatusCancelled:
+		// Allowed to approve a cancelled job if it is the latest job
+		latest, err := s.orm.GetLatestSpec(spec.JobProposalID)
+		if err != nil {
+			return errors.New("cannot get latest spec")
+		}
+
+		if latest.ID != spec.ID {
+			return errors.New("cannot approved a cancelled spec")
+		}
+	case SpecStatusPending:
+		// NOOP - pending jobs are allowed to be approved
 	}
 
 	proposal, err := s.orm.GetJobProposal(spec.JobProposalID, pctx)
@@ -559,36 +574,35 @@ func (s *service) ApproveSpec(ctx context.Context, id int64, force bool) error {
 
 	q := s.q.WithOpts(pctx)
 	err = q.Transaction(func(tx pg.Queryer) error {
-
-		existingJobID, err2 := s.jobORM.FindJobIDByAddress(address, pg.WithQueryer(tx))
-		if err2 == nil {
+		existingJobID, txerr := s.jobORM.FindJobIDByAddress(address, pg.WithQueryer(tx))
+		if txerr == nil {
 			if force {
-				if err2 = s.jobSpawner.DeleteJob(existingJobID, pg.WithQueryer(tx)); err2 != nil {
-					return errors.Wrap(err2, "DeleteJob failed")
+				if txerr = s.jobSpawner.DeleteJob(existingJobID, pg.WithQueryer(tx)); txerr != nil {
+					return errors.Wrap(txerr, "DeleteJob failed")
 				}
 			} else {
 				return ErrJobAlreadyExists
 			}
-		} else if !errors.Is(err2, sql.ErrNoRows) {
-			return errors.Wrap(err2, "FindJobIDByAddress failed")
+		} else if !errors.Is(txerr, sql.ErrNoRows) {
+			return errors.Wrap(txerr, "FindJobIDByAddress failed")
 		}
 
 		// Create the job
-		if err = s.jobSpawner.CreateJob(j, pg.WithQueryer(tx)); err != nil {
-			return err
+		if txerr = s.jobSpawner.CreateJob(j, pg.WithQueryer(tx)); txerr != nil {
+			return txerr
 		}
 
 		// Approve the job proposal spec
-		if err = s.orm.ApproveSpec(id, j.ExternalJobID, pg.WithQueryer(tx)); err != nil {
-			return err
+		if txerr = s.orm.ApproveSpec(id, j.ExternalJobID, pg.WithQueryer(tx)); txerr != nil {
+			return txerr
 		}
 
 		// Send to FMS Client
-		if _, err = fmsClient.ApprovedJob(ctx, &pb.ApprovedJobRequest{
+		if _, txerr = fmsClient.ApprovedJob(ctx, &pb.ApprovedJobRequest{
 			Uuid:    proposal.RemoteUUID.String(),
 			Version: int64(spec.Version),
-		}); err != nil {
-			return err
+		}); txerr != nil {
+			return txerr
 		}
 
 		return nil

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -200,8 +200,7 @@ func Test_Service_ListManagers(t *testing.T) {
 	)
 	svc := setupTestService(t)
 
-	svc.orm.On("ListManagers").
-		Return(mgrs, nil)
+	svc.orm.On("ListManagers").Return(mgrs, nil)
 	svc.connMgr.On("IsConnected", mgr.ID).Return(false)
 
 	actual, err := svc.ListManagers()
@@ -1008,7 +1007,7 @@ answer1 [type=median index=0];
 		}
 		cancelledSpec = &feeds.JobProposalSpec{
 			ID:            20,
-			Status:        feeds.SpecStatusPending,
+			Status:        feeds.SpecStatusCancelled,
 			JobProposalID: jp.ID,
 			Version:       1,
 			Definition:    defn,
@@ -1063,13 +1062,14 @@ answer1 [type=median index=0];
 			force: false,
 		},
 		{
-			name: "cancelled job success",
+			name: "cancelled job success when it is the latest spec",
 			before: func(svc *TestService) {
 				svc.cfg.On("DefaultHTTPTimeout").Return(models.MakeDuration(1 * time.Minute))
 
 				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
 				svc.orm.On("GetSpec", cancelledSpec.ID, mock.Anything).Return(cancelledSpec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
+				svc.orm.On("GetLatestSpec", cancelledSpec.JobProposalID).Return(cancelledSpec, nil)
 
 				svc.jobORM.On("FindJobIDByAddress", address, mock.Anything).Return(int32(0), sql.ErrNoRows)
 
@@ -1097,6 +1097,22 @@ answer1 [type=median index=0];
 			},
 			id:    cancelledSpec.ID,
 			force: false,
+		},
+		{
+			name: "cancelled job failed not latest spec",
+			before: func(svc *TestService) {
+				svc.orm.On("GetSpec", cancelledSpec.ID, mock.Anything).Return(cancelledSpec, nil)
+				svc.orm.On("GetLatestSpec", cancelledSpec.JobProposalID).Return(&feeds.JobProposalSpec{
+					ID:            21,
+					Status:        feeds.SpecStatusPending,
+					JobProposalID: jp.ID,
+					Version:       2,
+					Definition:    defn,
+				}, nil)
+			},
+			id:      cancelledSpec.ID,
+			force:   false,
+			wantErr: "cannot approved a cancelled spec",
 		},
 		{
 			name: "already existing job replacement error",
@@ -1160,7 +1176,7 @@ answer1 [type=median index=0];
 			wantErr: "orm: job proposal spec: Not Found",
 		},
 		{
-			name: "job proposal already approved",
+			name: "cannot approved an approved spec",
 			before: func(svc *TestService) {
 				spec := &feeds.JobProposalSpec{
 					ID:     spec.ID,
@@ -1170,7 +1186,20 @@ answer1 [type=median index=0];
 			},
 			id:      spec.ID,
 			force:   false,
-			wantErr: "must be a pending or cancelled job proposal",
+			wantErr: "cannot approved an approved spec",
+		},
+		{
+			name: "cannot approved an rejected spec",
+			before: func(svc *TestService) {
+				spec := &feeds.JobProposalSpec{
+					ID:     spec.ID,
+					Status: feeds.SpecStatusRejected,
+				}
+				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
+			},
+			id:      spec.ID,
+			force:   false,
+			wantErr: "cannot approved a rejected spec",
 		},
 		{
 			name: "job proposal does not exist",

--- a/operator_ui/src/screens/JobProposal/SpecsView.tsx
+++ b/operator_ui/src/screens/JobProposal/SpecsView.tsx
@@ -124,13 +124,16 @@ export const SpecsView = withStyles(styles)(
               >
                 Reject
               </Button>
-              <Button
-                variant="contained"
-                color="primary"
-                onClick={() => openConfirmationDialog('approve', specID)}
-              >
-                Approve
-              </Button>
+
+              {latestSpec.id === specID && (
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={() => openConfirmationDialog('approve', specID)}
+                >
+                  Approve
+                </Button>
+              )}
             </>
           )
         case 'APPROVED':

--- a/operator_ui/src/screens/JobProposal/SpecsView.tsx
+++ b/operator_ui/src/screens/JobProposal/SpecsView.tsx
@@ -143,6 +143,10 @@ export const SpecsView = withStyles(styles)(
             </Button>
           )
         case 'CANCELLED':
+          if (latestSpec.id !== specID) {
+            return null
+          }
+
           return (
             <Button
               variant="contained"


### PR DESCRIPTION
This commit makes changes so that only the latest cancelled and pending jobs can be approved.