### PR TITLE
add keepers team to codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -14,7 +14,7 @@
 /core/services/fluxmonitorv2 @jkongie @PiotrTrzpil @spooktheducks @connorwstein
 /core/services/health @archseer @samsondav
 /core/services/job @spooktheducks @connorwstein @archseer
-/core/services/keeper @RyanRHall @samsondav
+/core/services/keeper @smartcontractkit/keepers
 /core/services/keystore @RyanRHall
 /core/services/offchainreporting @spooktheducks @connorwstein @samsondav @archseer
 /core/services/periodicbackup @PiotrTrzpil @samsondav
@@ -36,6 +36,7 @@
 
 # Contracts
 /contracts/ @alexroan @se3000 @connorwstein
+/contracts/**/Keeper* @smartcontractkit/keepers
 
 # Tests
 /integration-tests/ @kalverra


### PR DESCRIPTION
Add keepers team to

1. core node files
2. contracts with filenames that start with Keeper. Currently they would cover:
- KeeperRegistry.sol
- KeeperRegistrar.sol
- KeeperCompatibleInterface.sol
- KeeperRegistryInterface.sol

It's not exhaustive though, example MigratableKeeperRegistryInterface.sol . But it's better than nothing :shrug:
