### PR TITLE
core/chains: generics cleanup; constrain Config to implement Scanner and Valuer; remove runtime type check for UpdateConfig

### DIFF
--- a/core/chains/chain_set.go
+++ b/core/chains/chain_set.go
@@ -52,10 +52,9 @@ type ChainSet[I ID, C Config, N Node, S ChainService[C]] interface {
 }
 
 // ChainService is a live, runtime chain instance, with supporting services.
-type ChainService[D Config] interface {
+type ChainService[C Config] interface {
 	services.ServiceCtx
-	// Optionally, may support runtime reconfiguration by implementing
-	//  UpdateConfig(D)
+	UpdateConfig(C)
 }
 
 // ChainSetOpts holds options for configuring a ChainSet via NewChainSet.
@@ -213,11 +212,7 @@ func (c *chainSet[I, C, N, S]) Configure(ctx context.Context, id I, enabled bool
 		return dbchain, c.initializeChain(ctx, dbchain)
 	case exists:
 		// Exists in memory, no toggling: Update in-memory chain
-		if updatable, ok := any(chain).(interface{ UpdateConfig(C) }); ok {
-			updatable.UpdateConfig(config)
-		} else {
-			c.lggr.Warnw("Unable to reconfigure chain live. Node must be restarted to use new updated configuration.", "id", sid)
-		}
+		chain.UpdateConfig(config)
 	}
 
 	return dbchain, nil

--- a/core/chains/constraints.go
+++ b/core/chains/constraints.go
@@ -1,13 +1,17 @@
 package chains
 
+import (
+	"database/sql"
+	"database/sql/driver"
+)
+
 // ID types represent unique identifiers within a particular chain type. Using string is recommended.
 type ID any
 
-// Config types should have fields for chain configuration, and normally implement sql.Scanner and driver.Valuer, but
-// that is not enforced here since legacy types used mixed pointer and value receivers.
+// Config types should have fields for chain configuration, and implement sql.Scanner and driver.Valuer for persistence in JSON format.
 type Config interface {
-	// sql.Scanner
-	// driver.Valuer
+	sql.Scanner
+	driver.Valuer
 }
 
 // Node types should be a struct including these default fields:

--- a/core/chains/evm/chain.go
+++ b/core/chains/evm/chain.go
@@ -33,6 +33,7 @@ type Chain interface {
 	ID() *big.Int
 	Client() evmclient.Client
 	Config() evmconfig.ChainScopedConfig
+	UpdateConfig(*types.ChainCfg)
 	LogBroadcaster() log.Broadcaster
 	HeadBroadcaster() httypes.HeadBroadcaster
 	TxManager() txmgr.TxManager
@@ -65,7 +66,7 @@ func newChain(dbchain types.DBChain, nodes []types.Node, opts ChainSetOpts) (*ch
 	if !dbchain.Enabled {
 		return nil, errors.Errorf("cannot create new chain with ID %s, the chain is disabled", dbchain.ID.String())
 	}
-	cfg := evmconfig.NewChainScopedConfig(chainID, dbchain.Cfg, opts.ORM, l, opts.Config)
+	cfg := evmconfig.NewChainScopedConfig(chainID, *dbchain.Cfg, opts.ORM, l, opts.Config)
 	if err := cfg.Validate(); err != nil {
 		return nil, errors.Wrapf(err, "cannot create new chain with ID %s, config validation failed", dbchain.ID.String())
 	}
@@ -283,6 +284,7 @@ func (c *chain) Healthy() (merr error) {
 func (c *chain) ID() *big.Int                             { return c.id }
 func (c *chain) Client() evmclient.Client                 { return c.client }
 func (c *chain) Config() evmconfig.ChainScopedConfig      { return c.cfg }
+func (c *chain) UpdateConfig(cfg *types.ChainCfg)         { c.cfg.Configure(*cfg) }
 func (c *chain) LogBroadcaster() log.Broadcaster          { return c.logBroadcaster }
 func (c *chain) LogPoller() *logpoller.LogPoller          { return c.logPoller }
 func (c *chain) HeadBroadcaster() httypes.HeadBroadcaster { return c.headBroadcaster }

--- a/core/chains/evm/chain_set.go
+++ b/core/chains/evm/chain_set.go
@@ -39,10 +39,10 @@ type ChainSet interface {
 	services.ServiceCtx
 	Get(id *big.Int) (Chain, error)
 	Show(id utils.Big) (types.DBChain, error)
-	Add(ctx context.Context, id utils.Big, config types.ChainCfg) (types.DBChain, error)
+	Add(ctx context.Context, id utils.Big, config *types.ChainCfg) (types.DBChain, error)
 	Remove(id utils.Big) error
 	Default() (Chain, error)
-	Configure(ctx context.Context, id utils.Big, enabled bool, config types.ChainCfg) (types.DBChain, error)
+	Configure(ctx context.Context, id utils.Big, enabled bool, config *types.ChainCfg) (types.DBChain, error)
 	UpdateConfig(id *big.Int, updaters ...ChainConfigUpdater) error
 	Chains() []Chain
 	Index(offset, limit int) ([]types.DBChain, int, error)
@@ -167,7 +167,7 @@ func (cll *chainSet) initializeChain(ctx context.Context, dbchain *types.DBChain
 	return nil
 }
 
-func (cll *chainSet) Add(ctx context.Context, id utils.Big, config types.ChainCfg) (types.DBChain, error) {
+func (cll *chainSet) Add(ctx context.Context, id utils.Big, config *types.ChainCfg) (types.DBChain, error) {
 	cll.chainsMu.Lock()
 	defer cll.chainsMu.Unlock()
 
@@ -201,7 +201,7 @@ func (cll *chainSet) Remove(id utils.Big) error {
 	return chain.Close()
 }
 
-func (cll *chainSet) Configure(ctx context.Context, id utils.Big, enabled bool, config types.ChainCfg) (types.DBChain, error) {
+func (cll *chainSet) Configure(ctx context.Context, id utils.Big, enabled bool, config *types.ChainCfg) (types.DBChain, error) {
 	cll.chainsMu.Lock()
 	defer cll.chainsMu.Unlock()
 
@@ -225,7 +225,7 @@ func (cll *chainSet) Configure(ctx context.Context, id utils.Big, enabled bool, 
 		return dbchain, cll.initializeChain(ctx, &dbchain)
 	case exists:
 		// Exists in memory, no toggling: Update in-memory chain
-		if err = chain.Config().Configure(config); err != nil {
+		if chain.Config().Configure(*config); err != nil {
 			return dbchain, err
 		}
 		// TODO: recreate ethClient etc if node set changed
@@ -257,9 +257,9 @@ func (cll *chainSet) UpdateConfig(id *big.Int, updaters ...ChainConfigUpdater) e
 		}
 	}
 
-	_, err = cll.orm.UpdateChain(*bid, dbchain.Enabled, updatedConfig)
+	_, err = cll.orm.UpdateChain(*bid, dbchain.Enabled, &updatedConfig)
 	if err == nil {
-		return chain.Config().Configure(updatedConfig)
+		chain.Config().Configure(updatedConfig)
 	}
 
 	return err

--- a/core/chains/evm/config/config.go
+++ b/core/chains/evm/config/config.go
@@ -92,7 +92,7 @@ type ChainScopedConfig interface {
 	ChainScopedOnlyConfig
 	Validate() error
 	// Both Configure() and PersistedConfig() should be accessed through ChainSet methods only.
-	Configure(config evmtypes.ChainCfg) error
+	Configure(config evmtypes.ChainCfg)
 	PersistedConfig() evmtypes.ChainCfg
 }
 
@@ -129,7 +129,7 @@ func NewChainScopedConfig(chainID *big.Int, cfg evmtypes.ChainCfg, orm evmtypes.
 		id:            chainID,
 		knownID:       exists,
 		onceMap:       make(map[string]struct{})}
-	_ = css.Configure(cfg)
+	css.Configure(cfg)
 	return &css
 }
 
@@ -140,11 +140,11 @@ func (c *chainScopedConfig) Validate() (err error) {
 	)
 }
 
-func (c *chainScopedConfig) Configure(config evmtypes.ChainCfg) (err error) {
+func (c *chainScopedConfig) Configure(config evmtypes.ChainCfg) {
 	c.persistMu.Lock()
 	defer c.persistMu.Unlock()
 	c.persistedCfg = config
-	return nil
+	return
 }
 
 func (c *chainScopedConfig) PersistedConfig() evmtypes.ChainCfg {

--- a/core/chains/evm/config/mocks/chain_scoped_config.go
+++ b/core/chains/evm/config/mocks/chain_scoped_config.go
@@ -516,17 +516,8 @@ func (_m *ChainScopedConfig) ClientNodeURL() string {
 }
 
 // Configure provides a mock function with given fields: _a0
-func (_m *ChainScopedConfig) Configure(_a0 types.ChainCfg) error {
-	ret := _m.Called(_a0)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func(types.ChainCfg) error); ok {
-		r0 = rf(_a0)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
+func (_m *ChainScopedConfig) Configure(_a0 types.ChainCfg) {
+	_m.Called(_a0)
 }
 
 // DatabaseBackupDir provides a mock function with given fields:
@@ -668,20 +659,6 @@ func (_m *ChainScopedConfig) DefaultChainID() *big.Int {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*big.Int)
 		}
-	}
-
-	return r0
-}
-
-// DefaultHTTPAllowUnrestrictedNetworkAccess provides a mock function with given fields:
-func (_m *ChainScopedConfig) DefaultHTTPAllowUnrestrictedNetworkAccess() bool {
-	ret := _m.Called()
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
 	}
 
 	return r0
@@ -4066,20 +4043,6 @@ func (_m *ChainScopedConfig) SolanaNodes() string {
 	return r0
 }
 
-// TerraNodes provides a mock function with given fields:
-func (_m *ChainScopedConfig) TerraNodes() string {
-	ret := _m.Called()
-
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
 // TLSCertPath provides a mock function with given fields:
 func (_m *ChainScopedConfig) TLSCertPath() string {
 	ret := _m.Called()
@@ -4301,6 +4264,20 @@ func (_m *ChainScopedConfig) TerraEnabled() bool {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// TerraNodes provides a mock function with given fields:
+func (_m *ChainScopedConfig) TerraNodes() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/core/chains/evm/mocks/chain.go
+++ b/core/chains/evm/mocks/chain.go
@@ -10,6 +10,8 @@ import (
 
 	context "context"
 
+	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
+
 	log "github.com/smartcontractkit/chainlink/core/chains/evm/log"
 
 	logger "github.com/smartcontractkit/chainlink/core/logger"
@@ -244,4 +246,9 @@ func (_m *Chain) TxManager() txmgr.TxManager {
 	}
 
 	return r0
+}
+
+// UpdateConfig provides a mock function with given fields: _a0
+func (_m *Chain) UpdateConfig(_a0 *evmtypes.ChainCfg) {
+	_m.Called(_a0)
 }

--- a/core/chains/evm/mocks/chain_set.go
+++ b/core/chains/evm/mocks/chain_set.go
@@ -7,6 +7,7 @@ import (
 	big "math/big"
 
 	evm "github.com/smartcontractkit/chainlink/core/chains/evm"
+
 	mock "github.com/stretchr/testify/mock"
 
 	types "github.com/smartcontractkit/chainlink/core/chains/evm/types"
@@ -20,18 +21,18 @@ type ChainSet struct {
 }
 
 // Add provides a mock function with given fields: ctx, id, config
-func (_m *ChainSet) Add(ctx context.Context, id utils.Big, config types.ChainCfg) (types.DBChain, error) {
+func (_m *ChainSet) Add(ctx context.Context, id utils.Big, config *types.ChainCfg) (types.DBChain, error) {
 	ret := _m.Called(ctx, id, config)
 
 	var r0 types.DBChain
-	if rf, ok := ret.Get(0).(func(context.Context, utils.Big, types.ChainCfg) types.DBChain); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, utils.Big, *types.ChainCfg) types.DBChain); ok {
 		r0 = rf(ctx, id, config)
 	} else {
 		r0 = ret.Get(0).(types.DBChain)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, utils.Big, types.ChainCfg) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, utils.Big, *types.ChainCfg) error); ok {
 		r1 = rf(ctx, id, config)
 	} else {
 		r1 = ret.Error(1)
@@ -85,19 +86,40 @@ func (_m *ChainSet) Close() error {
 }
 
 // Configure provides a mock function with given fields: ctx, id, enabled, config
-func (_m *ChainSet) Configure(ctx context.Context, id utils.Big, enabled bool, config types.ChainCfg) (types.DBChain, error) {
+func (_m *ChainSet) Configure(ctx context.Context, id utils.Big, enabled bool, config *types.ChainCfg) (types.DBChain, error) {
 	ret := _m.Called(ctx, id, enabled, config)
 
 	var r0 types.DBChain
-	if rf, ok := ret.Get(0).(func(context.Context, utils.Big, bool, types.ChainCfg) types.DBChain); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, utils.Big, bool, *types.ChainCfg) types.DBChain); ok {
 		r0 = rf(ctx, id, enabled, config)
 	} else {
 		r0 = ret.Get(0).(types.DBChain)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(context.Context, utils.Big, bool, types.ChainCfg) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, utils.Big, bool, *types.ChainCfg) error); ok {
 		r1 = rf(ctx, id, enabled, config)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// CreateNode provides a mock function with given fields: ctx, data
+func (_m *ChainSet) CreateNode(ctx context.Context, data types.Node) (types.Node, error) {
+	ret := _m.Called(ctx, data)
+
+	var r0 types.Node
+	if rf, ok := ret.Get(0).(func(context.Context, types.Node) types.Node); ok {
+		r0 = rf(ctx, data)
+	} else {
+		r0 = ret.Get(0).(types.Node)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(context.Context, types.Node) error); ok {
+		r1 = rf(ctx, data)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -126,6 +148,20 @@ func (_m *ChainSet) Default() (evm.Chain, error) {
 	}
 
 	return r0, r1
+}
+
+// DeleteNode provides a mock function with given fields: ctx, id
+func (_m *ChainSet) DeleteNode(ctx context.Context, id int32) error {
+	ret := _m.Called(ctx, id)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(context.Context, int32) error); ok {
+		r0 = rf(ctx, id)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
 }
 
 // Get provides a mock function with given fields: id
@@ -269,6 +305,36 @@ func (_m *ChainSet) Healthy() error {
 	return r0
 }
 
+// Index provides a mock function with given fields: offset, limit
+func (_m *ChainSet) Index(offset int, limit int) ([]types.DBChain, int, error) {
+	ret := _m.Called(offset, limit)
+
+	var r0 []types.DBChain
+	if rf, ok := ret.Get(0).(func(int, int) []types.DBChain); ok {
+		r0 = rf(offset, limit)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]types.DBChain)
+		}
+	}
+
+	var r1 int
+	if rf, ok := ret.Get(1).(func(int, int) int); ok {
+		r1 = rf(offset, limit)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	var r2 error
+	if rf, ok := ret.Get(2).(func(int, int) error); ok {
+		r2 = rf(offset, limit)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
+}
+
 // ORM provides a mock function with given fields:
 func (_m *ChainSet) ORM() types.ORM {
 	ret := _m.Called()
@@ -313,6 +379,27 @@ func (_m *ChainSet) Remove(id utils.Big) error {
 	return r0
 }
 
+// Show provides a mock function with given fields: id
+func (_m *ChainSet) Show(id utils.Big) (types.DBChain, error) {
+	ret := _m.Called(id)
+
+	var r0 types.DBChain
+	if rf, ok := ret.Get(0).(func(utils.Big) types.DBChain); ok {
+		r0 = rf(id)
+	} else {
+		r0 = ret.Get(0).(types.DBChain)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(utils.Big) error); ok {
+		r1 = rf(id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
 // Start provides a mock function with given fields: _a0
 func (_m *ChainSet) Start(_a0 context.Context) error {
 	ret := _m.Called(_a0)
@@ -346,20 +433,4 @@ func (_m *ChainSet) UpdateConfig(id *big.Int, updaters ...evm.ChainConfigUpdater
 	}
 
 	return r0
-}
-
-func (_m *ChainSet) CreateNode(ctx context.Context, data types.Node) (types.Node, error) {
-	panic("implement me")
-}
-
-func (_m *ChainSet) DeleteNode(ctx context.Context, id int32) error {
-	panic("implement me")
-}
-
-func (_m *ChainSet) Show(id utils.Big) (types.DBChain, error) {
-	panic("implement me")
-}
-
-func (_m *ChainSet) Index(offset, limit int) ([]types.DBChain, int, error) {
-	panic("implement me")
 }

--- a/core/chains/evm/orm.go
+++ b/core/chains/evm/orm.go
@@ -13,5 +13,5 @@ import (
 // NewORM returns a new EVM ORM
 func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) types.ORM {
 	q := pg.NewQ(db, lggr.Named("EVMORM"), cfg)
-	return chains.NewORM[utils.Big, types.ChainCfg, types.Node](q, "evm", "ws_url", "http_url", "send_only")
+	return chains.NewORM[utils.Big, *types.ChainCfg, types.Node](q, "evm", "ws_url", "http_url", "send_only")
 }

--- a/core/chains/evm/orm_test.go
+++ b/core/chains/evm/orm_test.go
@@ -29,8 +29,7 @@ func mustInsertChain(t *testing.T, orm types.ORM) types.DBChain {
 	t.Helper()
 
 	id := utils.NewBigI(99)
-	config := types.ChainCfg{}
-	chain, err := orm.CreateChain(*id, config)
+	chain, err := orm.CreateChain(*id, nil)
 	require.NoError(t, err)
 	return chain
 }
@@ -58,8 +57,7 @@ func Test_EVMORM_CreateChain(t *testing.T) {
 	require.NoError(t, err)
 
 	id := utils.NewBigI(99)
-	config := types.ChainCfg{}
-	chain, err := orm.CreateChain(*id, config)
+	chain, err := orm.CreateChain(*id, nil)
 	require.NoError(t, err)
 	require.Equal(t, chain.ID.ToInt().Int64(), id.ToInt().Int64())
 

--- a/core/chains/evm/types/types.go
+++ b/core/chains/evm/types/types.go
@@ -35,8 +35,8 @@ type ChainConfigORM interface {
 type ORM interface {
 	Chain(id utils.Big, qopts ...pg.QOpt) (chain DBChain, err error)
 	Chains(offset, limit int, qopts ...pg.QOpt) ([]DBChain, int, error)
-	CreateChain(id utils.Big, config ChainCfg, qopts ...pg.QOpt) (DBChain, error)
-	UpdateChain(id utils.Big, enabled bool, config ChainCfg, qopts ...pg.QOpt) (DBChain, error)
+	CreateChain(id utils.Big, config *ChainCfg, qopts ...pg.QOpt) (DBChain, error)
+	UpdateChain(id utils.Big, enabled bool, config *ChainCfg, qopts ...pg.QOpt) (DBChain, error)
 	DeleteChain(id utils.Big, qopts ...pg.QOpt) error
 	GetChainsByIDs(ids []utils.Big) (chains []DBChain, err error)
 	EnabledChains(...pg.QOpt) ([]DBChain, error)
@@ -100,11 +100,11 @@ func (c *ChainCfg) Scan(value interface{}) error {
 	return json.Unmarshal(b, c)
 }
 
-func (c ChainCfg) Value() (driver.Value, error) {
+func (c *ChainCfg) Value() (driver.Value, error) {
 	return json.Marshal(c)
 }
 
-type DBChain = chains.DBChain[utils.Big, ChainCfg]
+type DBChain = chains.DBChain[utils.Big, *ChainCfg]
 
 type Node struct {
 	ID         int32

--- a/core/chains/evm/types/types_test.go
+++ b/core/chains/evm/types/types_test.go
@@ -23,7 +23,7 @@ func Test_PersistsReadsChain(t *testing.T) {
 	ks[addr.Hex()] = types.ChainCfg{EvmMaxGasPriceWei: val}
 	chain := types.DBChain{
 		ID: *utils.NewBigI(rand.Int63()),
-		Cfg: types.ChainCfg{
+		Cfg: &types.ChainCfg{
 			KeySpecific: ks,
 		},
 	}

--- a/core/chains/orm.go
+++ b/core/chains/orm.go
@@ -12,16 +12,17 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
-// ORM manages chains and nodes.
-type ORM[I ID, C Config, N Node] interface {
-	Chain(I, ...pg.QOpt) (DBChain[I, C], error)
-	Chains(offset, limit int, qopts ...pg.QOpt) ([]DBChain[I, C], int, error)
-	CreateChain(id I, config C, qopts ...pg.QOpt) (DBChain[I, C], error)
-	UpdateChain(id I, enabled bool, config C, qopts ...pg.QOpt) (DBChain[I, C], error)
+type ChainsORM[I ID, CFG Config, C DBChain[I, CFG]] interface {
+	Chain(I, ...pg.QOpt) (C, error)
+	Chains(offset, limit int, qopts ...pg.QOpt) ([]C, int, error)
+	CreateChain(id I, config CFG, qopts ...pg.QOpt) (C, error)
+	UpdateChain(id I, enabled bool, config CFG, qopts ...pg.QOpt) (C, error)
 	DeleteChain(id I, qopts ...pg.QOpt) error
-	GetChainsByIDs(ids []I) (chains []DBChain[I, C], err error)
-	EnabledChains(...pg.QOpt) ([]DBChain[I, C], error)
+	GetChainsByIDs(ids []I) (chains []C, err error)
+	EnabledChains(...pg.QOpt) ([]C, error)
+}
 
+type NodesORM[I ID, N Node] interface {
 	CreateNode(N, ...pg.QOpt) (N, error)
 	DeleteNode(int32, ...pg.QOpt) error
 	GetNodesByChainIDs(chainIDs []I, qopts ...pg.QOpt) (nodes []N, err error)
@@ -29,6 +30,13 @@ type ORM[I ID, C Config, N Node] interface {
 	NodeNamed(string, ...pg.QOpt) (N, error)
 	Nodes(offset, limit int, qopts ...pg.QOpt) (nodes []N, count int, err error)
 	NodesForChain(chainID I, offset, limit int, qopts ...pg.QOpt) (nodes []N, count int, err error)
+}
+
+// ORM manages chains and nodes.
+type ORM[I ID, C Config, N Node] interface {
+	ChainsORM[I, C, DBChain[I, C]]
+
+	NodesORM[I, N]
 
 	StoreString(chainID I, key, val string) error
 	Clear(chainID I, key string) error

--- a/core/chains/orm_test.go
+++ b/core/chains/orm_test.go
@@ -1,18 +1,35 @@
 package chains_test
 
 import (
+	"database/sql/driver"
+	"encoding/json"
 	"time"
 
+	"github.com/pkg/errors"
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink/core/chains"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
-func ExampleNewORM() {
-	type Config struct {
-		Foo null.String
+type Config struct {
+	Foo null.String
+}
+
+func (c *Config) Scan(value any) error {
+	b, ok := value.([]byte)
+	if !ok {
+		return errors.New("type assertion to []byte failed")
 	}
+
+	return json.Unmarshal(b, c)
+}
+
+func (c *Config) Value() (driver.Value, error) {
+	return json.Marshal(c)
+}
+
+func ExampleNewORM() {
 	type Node = struct {
 		ID             int32
 		Name           string
@@ -23,7 +40,7 @@ func ExampleNewORM() {
 		UpdatedAt      time.Time
 	}
 	var q pg.Q
-	_ = chains.NewORM[string, Config, Node](q, "example", "url", "bar")
+	_ = chains.NewORM[string, *Config, Node](q, "example", "url", "bar")
 
 	// Output:
 }

--- a/core/chains/solana/chain.go
+++ b/core/chains/solana/chain.go
@@ -55,7 +55,7 @@ type cachedClient struct {
 
 // NewChain returns a new chain backed by node.
 func NewChain(db *sqlx.DB, ks keystore.Solana, logCfg pg.LogConfig, eb pg.EventBroadcaster, dbchain DBChain, orm ORM, lggr logger.Logger) (*chain, error) {
-	cfg := config.NewConfig(dbchain.Cfg, lggr)
+	cfg := config.NewConfig(*dbchain.Cfg, lggr)
 	lggr = lggr.With("chainID", dbchain.ID, "chainSet", "solana")
 	var ch = chain{
 		id:          dbchain.ID,
@@ -80,8 +80,8 @@ func (c *chain) Config() config.Config {
 	return c.cfg
 }
 
-func (c *chain) UpdateConfig(cfg db.ChainCfg) {
-	c.cfg.Update(cfg)
+func (c *chain) UpdateConfig(cfg *db.ChainCfg) {
+	c.cfg.Update(*cfg)
 }
 
 func (c *chain) TxManager() solana.TxManager {

--- a/core/chains/solana/chain_set.go
+++ b/core/chains/solana/chain_set.go
@@ -53,7 +53,7 @@ func (o *ChainSetOpts) Validate() (err error) {
 	return
 }
 
-func (o *ChainSetOpts) ORMAndLogger() (chains.ORM[string, db.ChainCfg, db.Node], logger.Logger) {
+func (o *ChainSetOpts) ORMAndLogger() (chains.ORM[string, *db.ChainCfg, db.Node], logger.Logger) {
 	return o.ORM, o.Logger
 }
 
@@ -70,9 +70,9 @@ func (o *ChainSetOpts) NewChain(dbchain DBChain) (solana.Chain, error) {
 type ChainSet interface {
 	solana.ChainSet
 
-	Add(context.Context, string, db.ChainCfg) (DBChain, error)
+	Add(context.Context, string, *db.ChainCfg) (DBChain, error)
 	Remove(string) error
-	Configure(ctx context.Context, id string, enabled bool, config db.ChainCfg) (DBChain, error)
+	Configure(ctx context.Context, id string, enabled bool, config *db.ChainCfg) (DBChain, error)
 	Show(id string) (DBChain, error)
 	Index(offset, limit int) ([]DBChain, int, error)
 	GetNodes(ctx context.Context, offset, limit int) (nodes []db.Node, count int, err error)
@@ -83,5 +83,5 @@ type ChainSet interface {
 
 // NewChainSet returns a new chain set for opts.
 func NewChainSet(opts ChainSetOpts) (ChainSet, error) {
-	return chains.NewChainSet[string, db.ChainCfg, db.Node, solana.Chain](&opts, func(s string) string { return s })
+	return chains.NewChainSet[string, *db.ChainCfg, db.Node, solana.Chain](&opts, func(s string) string { return s })
 }

--- a/core/chains/solana/chain_test.go
+++ b/core/chains/solana/chain_test.go
@@ -237,11 +237,11 @@ func (m *mockORM) Chains(offset, limit int, qopts ...pg.QOpt) ([]DBChain, int, e
 	panic("unimplemented")
 }
 
-func (m *mockORM) CreateChain(id string, config db.ChainCfg, qopts ...pg.QOpt) (DBChain, error) {
+func (m *mockORM) CreateChain(id string, config *db.ChainCfg, qopts ...pg.QOpt) (DBChain, error) {
 	panic("unimplemented")
 }
 
-func (m *mockORM) UpdateChain(id string, enabled bool, config db.ChainCfg, qopts ...pg.QOpt) (DBChain, error) {
+func (m *mockORM) UpdateChain(id string, enabled bool, config *db.ChainCfg, qopts ...pg.QOpt) (DBChain, error) {
 	panic("unimplemented")
 }
 

--- a/core/chains/solana/mocks/chain.go
+++ b/core/chains/solana/mocks/chain.go
@@ -8,6 +8,8 @@ import (
 
 	context "context"
 
+	db "github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
+
 	mock "github.com/stretchr/testify/mock"
 
 	solana "github.com/smartcontractkit/chainlink-solana/pkg/solana"
@@ -143,6 +145,11 @@ func (_m *Chain) TxManager() solana.TxManager {
 	}
 
 	return r0
+}
+
+// UpdateConfig provides a mock function with given fields: _a0
+func (_m *Chain) UpdateConfig(_a0 *db.ChainCfg) {
+	_m.Called(_a0)
 }
 
 // NewChain creates a new instance of Chain. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.

--- a/core/chains/solana/orm.go
+++ b/core/chains/solana/orm.go
@@ -10,14 +10,14 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
-type DBChain = chains.DBChain[string, soldb.ChainCfg]
+type DBChain = chains.DBChain[string, *soldb.ChainCfg]
 
 // ORM manages solana chains and nodes.
 type ORM interface {
 	Chain(string, ...pg.QOpt) (DBChain, error)
 	Chains(offset, limit int, qopts ...pg.QOpt) ([]DBChain, int, error)
-	CreateChain(id string, config soldb.ChainCfg, qopts ...pg.QOpt) (DBChain, error)
-	UpdateChain(id string, enabled bool, config soldb.ChainCfg, qopts ...pg.QOpt) (DBChain, error)
+	CreateChain(id string, config *soldb.ChainCfg, qopts ...pg.QOpt) (DBChain, error)
+	UpdateChain(id string, enabled bool, config *soldb.ChainCfg, qopts ...pg.QOpt) (DBChain, error)
 	DeleteChain(id string, qopts ...pg.QOpt) error
 	GetChainsByIDs(ids []string) (chains []DBChain, err error)
 	EnabledChains(...pg.QOpt) ([]DBChain, error)
@@ -36,10 +36,10 @@ type ORM interface {
 	Clear(chainID string, key string) error
 }
 
-var _ chains.ORM[string, soldb.ChainCfg, soldb.Node] = (ORM)(nil)
+var _ chains.ORM[string, *soldb.ChainCfg, soldb.Node] = (ORM)(nil)
 
 // NewORM returns an ORM backed by db.
 func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) ORM {
 	q := pg.NewQ(db, lggr.Named("ORM"), cfg)
-	return chains.NewORM[string, soldb.ChainCfg, soldb.Node](q, "solana", "solana_url")
+	return chains.NewORM[string, *soldb.ChainCfg, soldb.Node](q, "solana", "solana_url")
 }

--- a/core/chains/solana/orm_test.go
+++ b/core/chains/solana/orm_test.go
@@ -34,10 +34,10 @@ func Test_ORM(t *testing.T) {
 	require.Empty(t, dbcs)
 
 	chainIDA := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))
-	_, err = orm.CreateChain(chainIDA, db.ChainCfg{})
+	_, err = orm.CreateChain(chainIDA, nil)
 	require.NoError(t, err)
 	chainIDB := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))
-	_, err = orm.CreateChain(chainIDB, db.ChainCfg{})
+	_, err = orm.CreateChain(chainIDB, nil)
 	require.NoError(t, err)
 
 	dbcs, err = orm.EnabledChains()

--- a/core/chains/terra/chain.go
+++ b/core/chains/terra/chain.go
@@ -51,7 +51,7 @@ type chain struct {
 
 // NewChain returns a new chain backed by node.
 func NewChain(db *sqlx.DB, ks keystore.Terra, logCfg pg.LogConfig, eb pg.EventBroadcaster, dbchain types.DBChain, orm types.ORM, lggr logger.Logger) (*chain, error) {
-	cfg := terra.NewConfig(dbchain.Cfg, lggr)
+	cfg := terra.NewConfig(*dbchain.Cfg, lggr)
 	lggr = lggr.With("terraChainID", dbchain.ID)
 	var ch = chain{
 		id:   dbchain.ID,
@@ -85,8 +85,8 @@ func (c *chain) Config() terra.Config {
 	return c.cfg
 }
 
-func (c *chain) UpdateConfig(cfg db.ChainCfg) {
-	c.cfg.Update(cfg)
+func (c *chain) UpdateConfig(cfg *db.ChainCfg) {
+	c.cfg.Update(*cfg)
 }
 
 func (c *chain) TxManager() terra.TxManager {

--- a/core/chains/terra/chain_set.go
+++ b/core/chains/terra/chain_set.go
@@ -61,7 +61,7 @@ func (o *ChainSetOpts) Validate() (err error) {
 	return
 }
 
-func (o *ChainSetOpts) ORMAndLogger() (chains.ORM[string, db.ChainCfg, db.Node], logger.Logger) {
+func (o *ChainSetOpts) ORMAndLogger() (chains.ORM[string, *db.ChainCfg, db.Node], logger.Logger) {
 	return o.ORM, o.Logger
 }
 
@@ -78,9 +78,9 @@ func (o *ChainSetOpts) NewChain(dbchain types.DBChain) (terra.Chain, error) {
 type ChainSet interface {
 	terra.ChainSet
 
-	Add(context.Context, string, db.ChainCfg) (types.DBChain, error)
+	Add(context.Context, string, *db.ChainCfg) (types.DBChain, error)
 	Remove(string) error
-	Configure(ctx context.Context, id string, enabled bool, config db.ChainCfg) (types.DBChain, error)
+	Configure(ctx context.Context, id string, enabled bool, config *db.ChainCfg) (types.DBChain, error)
 	Show(id string) (types.DBChain, error)
 	Index(offset, limit int) ([]types.DBChain, int, error)
 	GetNodes(ctx context.Context, offset, limit int) (nodes []db.Node, count int, err error)
@@ -91,5 +91,5 @@ type ChainSet interface {
 
 // NewChainSet returns a new chain set for opts.
 func NewChainSet(opts ChainSetOpts) (ChainSet, error) {
-	return chains.NewChainSet[string, db.ChainCfg, db.Node, terra.Chain](&opts, func(s string) string { return s })
+	return chains.NewChainSet[string, *db.ChainCfg, db.Node, terra.Chain](&opts, func(s string) string { return s })
 }

--- a/core/chains/terra/mocks/chain.go
+++ b/core/chains/terra/mocks/chain.go
@@ -7,6 +7,8 @@ import (
 
 	client "github.com/smartcontractkit/chainlink-terra/pkg/terra/client"
 
+	db "github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
+
 	mock "github.com/stretchr/testify/mock"
 
 	terra "github.com/smartcontractkit/chainlink-terra/pkg/terra"
@@ -142,6 +144,11 @@ func (_m *Chain) TxManager() terra.TxManager {
 	}
 
 	return r0
+}
+
+// UpdateConfig provides a mock function with given fields: _a0
+func (_m *Chain) UpdateConfig(_a0 *db.ChainCfg) {
+	_m.Called(_a0)
 }
 
 // NewChain creates a new instance of Chain. It also registers the testing.TB interface on the mock and a cleanup function to assert the mocks expectations.

--- a/core/chains/terra/orm.go
+++ b/core/chains/terra/orm.go
@@ -14,5 +14,5 @@ import (
 // NewORM returns an ORM backed by db.
 func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) types.ORM {
 	q := pg.NewQ(db, lggr.Named("ORM"), cfg)
-	return chains.NewORM[string, terradb.ChainCfg, terradb.Node](q, "terra", "tendermint_url")
+	return chains.NewORM[string, *terradb.ChainCfg, terradb.Node](q, "terra", "tendermint_url")
 }

--- a/core/chains/terra/orm_test.go
+++ b/core/chains/terra/orm_test.go
@@ -34,10 +34,10 @@ func Test_ORM(t *testing.T) {
 	require.Empty(t, dbcs)
 
 	chainIDA := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))
-	_, err = orm.CreateChain(chainIDA, db.ChainCfg{})
+	_, err = orm.CreateChain(chainIDA, nil)
 	require.NoError(t, err)
 	chainIDB := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))
-	_, err = orm.CreateChain(chainIDB, db.ChainCfg{})
+	_, err = orm.CreateChain(chainIDB, nil)
 	require.NoError(t, err)
 
 	dbcs, err = orm.EnabledChains()

--- a/core/chains/terra/terratxm/orm_test.go
+++ b/core/chains/terra/terratxm/orm_test.go
@@ -22,7 +22,7 @@ func TestORM(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	logCfg := pgtest.NewPGCfg(true)
 	chainID := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))
-	_, err := terra.NewORM(db, lggr, logCfg).CreateChain(chainID, ChainCfg{})
+	_, err := terra.NewORM(db, lggr, logCfg).CreateChain(chainID, nil)
 	require.NoError(t, err)
 	o := NewORM(chainID, db, lggr, logCfg)
 

--- a/core/chains/terra/terratxm/txm_test.go
+++ b/core/chains/terra/terratxm/txm_test.go
@@ -44,12 +44,12 @@ func TestTxm_Integration(t *testing.T) {
 			"uluna": fallbackGasPrice,
 		}),
 	}, lggr)
-	dbChain, err := terra.NewORM(db, lggr, logCfg).CreateChain(chainID, ChainCfg{
+	dbChain, err := terra.NewORM(db, lggr, logCfg).CreateChain(chainID, &ChainCfg{
 		FallbackGasPriceULuna: null.StringFrom(fallbackGasPrice.Amount.String()),
 		GasLimitMultiplier:    null.FloatFrom(1.5),
 	})
 	require.NoError(t, err)
-	chainCfg := pkgterra.NewConfig(dbChain.Cfg, lggr)
+	chainCfg := pkgterra.NewConfig(*dbChain.Cfg, lggr)
 	orm := terratxm.NewORM(chainID, db, lggr, logCfg)
 	eb := pg.NewEventBroadcaster(cfg.DatabaseURL(), 0, 0, lggr, uuid.NewV4())
 	require.NoError(t, eb.Start(testutils.Context(t)))

--- a/core/chains/terra/types/types.go
+++ b/core/chains/terra/types/types.go
@@ -11,8 +11,8 @@ import (
 type ORM interface {
 	Chain(string, ...pg.QOpt) (DBChain, error)
 	Chains(offset, limit int, qopts ...pg.QOpt) ([]DBChain, int, error)
-	CreateChain(id string, config db.ChainCfg, qopts ...pg.QOpt) (DBChain, error)
-	UpdateChain(id string, enabled bool, config db.ChainCfg, qopts ...pg.QOpt) (DBChain, error)
+	CreateChain(id string, config *db.ChainCfg, qopts ...pg.QOpt) (DBChain, error)
+	UpdateChain(id string, enabled bool, config *db.ChainCfg, qopts ...pg.QOpt) (DBChain, error)
 	DeleteChain(id string, qopts ...pg.QOpt) error
 	GetChainsByIDs(ids []string) (chains []DBChain, err error)
 	EnabledChains(...pg.QOpt) ([]DBChain, error)
@@ -31,7 +31,7 @@ type ORM interface {
 	Clear(chainID string, key string) error
 }
 
-type DBChain = chains.DBChain[string, db.ChainCfg]
+type DBChain = chains.DBChain[string, *db.ChainCfg]
 
 // NewNode defines a new node to create.
 type NewNode struct {

--- a/core/cmd/evm_chains_commands.go
+++ b/core/cmd/evm_chains_commands.go
@@ -58,6 +58,6 @@ func (ps EVMChainPresenters) RenderTable(rt RendererTable) error {
 	return nil
 }
 
-func EVMChainClient(client *Client) ChainClient[evmtypes.ChainCfg, presenters.EVMChainResource, EVMChainPresenter, EVMChainPresenters] {
-	return newChainClient[evmtypes.ChainCfg, presenters.EVMChainResource, EVMChainPresenter, EVMChainPresenters](client, "evm")
+func EVMChainClient(client *Client) ChainClient[*evmtypes.ChainCfg, presenters.EVMChainResource, EVMChainPresenter, EVMChainPresenters] {
+	return newChainClient[*evmtypes.ChainCfg, presenters.EVMChainResource, EVMChainPresenter, EVMChainPresenters](client, "evm")
 }

--- a/core/cmd/evm_chains_commands_test.go
+++ b/core/cmd/evm_chains_commands_test.go
@@ -38,7 +38,7 @@ func TestClient_IndexEVMChains(t *testing.T) {
 	require.NoError(t, err)
 
 	id := newRandChainID()
-	chain, err := orm.CreateChain(*id, types.ChainCfg{})
+	chain, err := orm.CreateChain(*id, nil)
 	require.NoError(t, err)
 
 	require.Nil(t, cmd.EVMChainClient(client).IndexChains(cltest.EmptyCLIContext()))
@@ -99,7 +99,7 @@ func TestClient_RemoveEVMChain(t *testing.T) {
 	require.NoError(t, err)
 
 	id := newRandChainID()
-	_, err = orm.CreateChain(*id, types.ChainCfg{})
+	_, err = orm.CreateChain(*id, nil)
 	require.NoError(t, err)
 	chains, _, err := orm.Chains(0, 25)
 	require.NoError(t, err)
@@ -136,7 +136,7 @@ func TestClient_ConfigureEVMChain(t *testing.T) {
 	require.NoError(t, err)
 
 	id := newRandChainID()
-	_, err = orm.CreateChain(*id, types.ChainCfg{
+	_, err = orm.CreateChain(*id, &types.ChainCfg{
 		BlockHistoryEstimatorBlockDelay: null.IntFrom(5),
 		EvmFinalityDepth:                null.IntFrom(5),
 		EvmGasBumpPercent:               null.IntFrom(3),

--- a/core/cmd/evm_node_commands_test.go
+++ b/core/cmd/evm_node_commands_test.go
@@ -20,8 +20,7 @@ import (
 
 func mustInsertEVMChain(t *testing.T, orm types.ORM) types.DBChain {
 	id := utils.NewBig(testutils.NewRandomEVMChainID())
-	config := types.ChainCfg{}
-	chain, err := orm.CreateChain(*id, config)
+	chain, err := orm.CreateChain(*id, nil)
 	require.NoError(t, err)
 	return chain
 }

--- a/core/cmd/forwarders_commands_test.go
+++ b/core/cmd/forwarders_commands_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/urfave/cli"
 	"gopkg.in/guregu/null.v4"
 
-	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
@@ -75,7 +74,7 @@ func TestClient_CreateEVMForwarder(t *testing.T) {
 	// Create chain
 	orm := app.EVMORM()
 	id := newRandChainID()
-	chain, err := orm.CreateChain(*id, types.ChainCfg{})
+	chain, err := orm.CreateChain(*id, nil)
 	require.NoError(t, err)
 
 	// Create the fwdr
@@ -123,7 +122,7 @@ func TestClient_CreateEVMForwarder_BadAddress(t *testing.T) {
 	require.NoError(t, err)
 
 	id := newRandChainID()
-	chain, err := orm.CreateChain(*id, types.ChainCfg{})
+	chain, err := orm.CreateChain(*id, nil)
 	require.NoError(t, err)
 
 	// Create the fwdr

--- a/core/cmd/solana_chains_commands.go
+++ b/core/cmd/solana_chains_commands.go
@@ -59,6 +59,6 @@ func (ps SolanaChainPresenters) RenderTable(rt RendererTable) error {
 	return nil
 }
 
-func SolanaChainClient(client *Client) ChainClient[db.ChainCfg, presenters.SolanaChainResource, SolanaChainPresenter, SolanaChainPresenters] {
-	return newChainClient[db.ChainCfg, presenters.SolanaChainResource, SolanaChainPresenter, SolanaChainPresenters](client, "solana")
+func SolanaChainClient(client *Client) ChainClient[*db.ChainCfg, presenters.SolanaChainResource, SolanaChainPresenter, SolanaChainPresenters] {
+	return newChainClient[*db.ChainCfg, presenters.SolanaChainResource, SolanaChainPresenter, SolanaChainPresenters](client, "solana")
 }

--- a/core/cmd/solana_chains_commands_test.go
+++ b/core/cmd/solana_chains_commands_test.go
@@ -28,7 +28,7 @@ func TestClient_IndexSolanaChains(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := testutils.Context(t)
-	chain, err := sol.Add(ctx, solanatest.RandomChainID(), db.ChainCfg{})
+	chain, err := sol.Add(ctx, solanatest.RandomChainID(), nil)
 	require.NoError(t, err)
 
 	require.Nil(t, cmd.SolanaChainClient(client).IndexChains(cltest.EmptyCLIContext()))
@@ -78,7 +78,7 @@ func TestClient_RemoveSolanaChain(t *testing.T) {
 
 	ctx := testutils.Context(t)
 	solanaChainID := solanatest.RandomChainID()
-	_, err = sol.Add(ctx, solanaChainID, db.ChainCfg{})
+	_, err = sol.Add(ctx, solanaChainID, nil)
 	require.NoError(t, err)
 	chains, _, err := sol.Index(0, 25)
 	require.NoError(t, err)
@@ -116,7 +116,7 @@ func TestClient_ConfigureSolanaChain(t *testing.T) {
 		TxTimeout:         &hour,
 	}
 	ctx := testutils.Context(t)
-	_, err = sol.Add(ctx, solanaChainID, original)
+	_, err = sol.Add(ctx, solanaChainID, &original)
 	require.NoError(t, err)
 	chains, _, err := sol.Index(0, 25)
 	require.NoError(t, err)

--- a/core/cmd/solana_node_commands_test.go
+++ b/core/cmd/solana_node_commands_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func mustInsertSolanaChain(t *testing.T, sol solana.ChainSet, id string) solana.DBChain {
-	chain, err := sol.Add(testutils.Context(t), id, db.ChainCfg{})
+	chain, err := sol.Add(testutils.Context(t), id, nil)
 	require.NoError(t, err)
 	return chain
 }

--- a/core/cmd/solana_transaction_commands_test.go
+++ b/core/cmd/solana_transaction_commands_test.go
@@ -32,7 +32,7 @@ func TestClient_SolanaSendSol(t *testing.T) {
 	solanaClient.FundTestAccounts(t, []solana.PublicKey{from.PublicKey()}, url)
 
 	chains := app.GetChains()
-	_, err = chains.Solana.Add(testutils.Context(t), chainID, solanadb.ChainCfg{})
+	_, err = chains.Solana.Add(testutils.Context(t), chainID, nil)
 	require.NoError(t, err)
 	chain, err := chains.Solana.Chain(testutils.Context(t), chainID)
 	require.NoError(t, err)

--- a/core/cmd/terra_chains_commands.go
+++ b/core/cmd/terra_chains_commands.go
@@ -59,6 +59,6 @@ func (ps TerraChainPresenters) RenderTable(rt RendererTable) error {
 	return nil
 }
 
-func TerraChainClient(client *Client) ChainClient[db.ChainCfg, presenters.TerraChainResource, TerraChainPresenter, TerraChainPresenters] {
-	return newChainClient[db.ChainCfg, presenters.TerraChainResource, TerraChainPresenter, TerraChainPresenters](client, "terra")
+func TerraChainClient(client *Client) ChainClient[*db.ChainCfg, presenters.TerraChainResource, TerraChainPresenter, TerraChainPresenters] {
+	return newChainClient[*db.ChainCfg, presenters.TerraChainResource, TerraChainPresenter, TerraChainPresenters](client, "terra")
 }

--- a/core/cmd/terra_chains_commands_test.go
+++ b/core/cmd/terra_chains_commands_test.go
@@ -30,7 +30,7 @@ func TestClient_IndexTerraChains(t *testing.T) {
 	require.NoError(t, err)
 
 	ctx := testutils.Context(t)
-	chain, err := ter.Add(ctx, terratest.RandomChainID(), db.ChainCfg{})
+	chain, err := ter.Add(ctx, terratest.RandomChainID(), nil)
 	require.NoError(t, err)
 
 	require.Nil(t, cmd.TerraChainClient(client).IndexChains(cltest.EmptyCLIContext()))
@@ -80,7 +80,7 @@ func TestClient_RemoveTerraChain(t *testing.T) {
 
 	ctx := testutils.Context(t)
 	terraChainID := terratest.RandomChainID()
-	_, err = ter.Add(ctx, terraChainID, db.ChainCfg{})
+	_, err = ter.Add(ctx, terraChainID, nil)
 	require.NoError(t, err)
 	chains, _, err := ter.Index(0, 25)
 	require.NoError(t, err)
@@ -118,7 +118,7 @@ func TestClient_ConfigureTerraChain(t *testing.T) {
 		ConfirmPollPeriod:     &minute,
 	}
 	ctx := testutils.Context(t)
-	_, err = ter.Add(ctx, terraChainID, original)
+	_, err = ter.Add(ctx, terraChainID, &original)
 	require.NoError(t, err)
 	chains, _, err := ter.Index(0, 25)
 	require.NoError(t, err)

--- a/core/cmd/terra_node_commands_test.go
+++ b/core/cmd/terra_node_commands_test.go
@@ -22,7 +22,7 @@ import (
 )
 
 func mustInsertTerraChain(t *testing.T, ter terra.ChainSet, id string) types.DBChain {
-	chain, err := ter.Add(testutils.Context(t), id, db.ChainCfg{})
+	chain, err := ter.Add(testutils.Context(t), id, nil)
 	require.NoError(t, err)
 	return chain
 }

--- a/core/cmd/terra_transaction_commands_test.go
+++ b/core/cmd/terra_transaction_commands_test.go
@@ -37,7 +37,7 @@ func TestClient_SendTerraCoins(t *testing.T) {
 	require.NoError(t, app.GetKeyStore().Terra().Add(terrakey.Raw(from.PrivateKey.Bytes()).Key()))
 
 	chains := app.GetChains()
-	_, err := chains.Terra.Add(testutils.Context(t), chainID, terradb.ChainCfg{})
+	_, err := chains.Terra.Add(testutils.Context(t), chainID, nil)
 	require.NoError(t, err)
 	chain, err := chains.Terra.Chain(testutils.Context(t), chainID)
 	require.NoError(t, err)

--- a/core/internal/cltest/simulated_backend.go
+++ b/core/internal/cltest/simulated_backend.go
@@ -66,7 +66,7 @@ func NewApplicationWithConfigAndKeyOnSimulatedBlockchain(
 	reaperThreshold := models.MustMakeDuration(100 * time.Millisecond)
 	simulatedBackendChain := evmtypes.DBChain{
 		ID: *utils.NewBigI(SimulatedBackendEVMChainID),
-		Cfg: evmtypes.ChainCfg{
+		Cfg: &evmtypes.ChainCfg{
 			GasEstimatorMode:                 null.StringFrom("FixedPrice"),
 			EvmHeadTrackerMaxBufferSize:      null.IntFrom(100),
 			EvmHeadTrackerSamplingInterval:   &zero, // Head sampling disabled

--- a/core/internal/testutils/evmtest/evmtest.go
+++ b/core/internal/testutils/evmtest/evmtest.go
@@ -87,7 +87,7 @@ func NewChainSet(t testing.TB, testopts TestChainOpts) evm.ChainSet {
 	chains := []evmtypes.DBChain{
 		{
 			ID:      *utils.NewBigI(0),
-			Cfg:     testopts.ChainCfg,
+			Cfg:     &testopts.ChainCfg,
 			Enabled: true,
 		},
 	}
@@ -173,11 +173,11 @@ func (mo *MockORM) Chain(id utils.Big, qopts ...pg.QOpt) (evmtypes.DBChain, erro
 	return c, nil
 }
 
-func (mo *MockORM) CreateChain(id utils.Big, config evmtypes.ChainCfg, qopts ...pg.QOpt) (evmtypes.DBChain, error) {
+func (mo *MockORM) CreateChain(id utils.Big, config *evmtypes.ChainCfg, qopts ...pg.QOpt) (evmtypes.DBChain, error) {
 	panic("not implemented")
 }
 
-func (mo *MockORM) UpdateChain(id utils.Big, enabled bool, config evmtypes.ChainCfg, qopts ...pg.QOpt) (evmtypes.DBChain, error) {
+func (mo *MockORM) UpdateChain(id utils.Big, enabled bool, config *evmtypes.ChainCfg, qopts ...pg.QOpt) (evmtypes.DBChain, error) {
 	return evmtypes.DBChain{}, nil
 }
 

--- a/core/services/vrf/integration_v2_test.go
+++ b/core/services/vrf/integration_v2_test.go
@@ -1158,7 +1158,7 @@ func configureSimChain(t *testing.T, app *cltest.TestApplication, ks map[string]
 		testutils.Context(t),
 		*utils.NewBigI(1337),
 		true,
-		types.ChainCfg{
+		&types.ChainCfg{
 			GasEstimatorMode:                 null.StringFrom("FixedPrice"),
 			EvmGasPriceDefault:               utils.NewBig(defaultGasPrice),
 			EvmHeadTrackerMaxBufferSize:      null.IntFrom(100),

--- a/core/web/evm_chains_controller.go
+++ b/core/web/evm_chains_controller.go
@@ -16,6 +16,6 @@ func NewEVMChainsController(app chainlink.Application) ChainsController {
 		err = id.UnmarshalText([]byte(s))
 		return
 	}
-	return newChainsController[utils.Big, types.ChainCfg, presenters.EVMChainResource](
+	return newChainsController[utils.Big, *types.ChainCfg, presenters.EVMChainResource](
 		"evm", app.GetChains().EVM, ErrEVMNotEnabled, parse, presenters.NewEVMChainResource)
 }

--- a/core/web/evm_chains_controller_test.go
+++ b/core/web/evm_chains_controller_test.go
@@ -31,7 +31,7 @@ func Test_EVMChainsController_Create(t *testing.T) {
 	newChainId := *utils.NewBigI(42)
 
 	body, err := json.Marshal(web.NewCreateChainRequest(newChainId,
-		types.ChainCfg{
+		&types.ChainCfg{
 			BlockHistoryEstimatorBlockDelay:       null.IntFrom(1),
 			BlockHistoryEstimatorBlockHistorySize: null.IntFrom(12),
 			EvmEIP1559DynamicFees:                 null.BoolFrom(false),
@@ -84,7 +84,7 @@ func Test_EVMChainsController_Show(t *testing.T) {
 				chain := types.DBChain{
 					ID:      *validId,
 					Enabled: true,
-					Cfg:     newChainConfig,
+					Cfg:     &newChainConfig,
 				}
 				evmtest.MustInsertChain(t, app.GetSqlxDB(), &chain)
 
@@ -146,10 +146,10 @@ func Test_EVMChainsController_Index(t *testing.T) {
 
 	controller := setupEVMChainsControllerTest(t)
 
-	newChains := []web.CreateChainRequest[utils.Big, types.ChainCfg]{
+	newChains := []web.CreateChainRequest[utils.Big, *types.ChainCfg]{
 		{
 			ID: *utils.NewBigI(24),
-			Config: types.ChainCfg{
+			Config: &types.ChainCfg{
 				BlockHistoryEstimatorBlockDelay:       null.IntFrom(13),
 				BlockHistoryEstimatorBlockHistorySize: null.IntFrom(1),
 				EvmEIP1559DynamicFees:                 null.BoolFrom(true),
@@ -158,7 +158,7 @@ func Test_EVMChainsController_Index(t *testing.T) {
 		},
 		{
 			ID: *utils.NewBigI(30),
-			Config: types.ChainCfg{
+			Config: &types.ChainCfg{
 				BlockHistoryEstimatorBlockDelay:       null.IntFrom(5),
 				BlockHistoryEstimatorBlockHistorySize: null.IntFrom(2),
 				EvmEIP1559DynamicFees:                 null.BoolFrom(false),
@@ -227,9 +227,9 @@ func Test_EVMChainsController_Index(t *testing.T) {
 func Test_EVMChainsController_Update(t *testing.T) {
 	t.Parallel()
 
-	chainUpdate := web.UpdateChainRequest[types.ChainCfg]{
+	chainUpdate := web.UpdateChainRequest[*types.ChainCfg]{
 		Enabled: true,
-		Config: types.ChainCfg{
+		Config: &types.ChainCfg{
 			BlockHistoryEstimatorBlockDelay:       null.IntFrom(55),
 			BlockHistoryEstimatorBlockHistorySize: null.IntFrom(33),
 			EvmEIP1559DynamicFees:                 null.BoolFrom(true),
@@ -260,7 +260,7 @@ func Test_EVMChainsController_Update(t *testing.T) {
 				chain := types.DBChain{
 					ID:      *validId,
 					Enabled: true,
-					Cfg:     newChainConfig,
+					Cfg:     &newChainConfig,
 				}
 				evmtest.MustInsertChain(t, app.GetSqlxDB(), &chain)
 
@@ -339,7 +339,7 @@ func Test_EVMChainsController_Delete(t *testing.T) {
 	chain := types.DBChain{
 		ID:      chainId,
 		Enabled: true,
-		Cfg:     newChainConfig,
+		Cfg:     &newChainConfig,
 	}
 	evmtest.MustInsertChain(t, controller.app.GetSqlxDB(), &chain)
 

--- a/core/web/evm_forwarders_controller_test.go
+++ b/core/web/evm_forwarders_controller_test.go
@@ -8,14 +8,14 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/manyminds/api2go/jsonapi"
-	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/utils"
 	"github.com/smartcontractkit/chainlink/core/web"
 	"github.com/smartcontractkit/chainlink/core/web/presenters"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 type TestEVMForwardersController struct {
@@ -44,9 +44,8 @@ func Test_EVMForwardersController_Create(t *testing.T) {
 
 	// Setting up chain
 	chainId := testutils.NewRandomEVMChainID()
-	chaincfg := types.ChainCfg{}
 	chainSet := controller.app.GetChains().EVM
-	dbChain, err := chainSet.ORM().CreateChain(utils.Big(*chainId), chaincfg)
+	dbChain, err := chainSet.ORM().CreateChain(utils.Big(*chainId), nil)
 	require.NoError(t, err)
 
 	// Build EVMForwarderRequest
@@ -76,9 +75,8 @@ func Test_EVMForwardersController_Index(t *testing.T) {
 
 	// Setting up chain
 	chainId := testutils.NewRandomEVMChainID()
-	chaincfg := types.ChainCfg{}
 	chainSet := controller.app.GetChains().EVM
-	dbChain, err := chainSet.ORM().CreateChain(utils.Big(*chainId), chaincfg)
+	dbChain, err := chainSet.ORM().CreateChain(utils.Big(*chainId), nil)
 	require.NoError(t, err)
 
 	// Build EVMForwarderRequest

--- a/core/web/presenters/evm_chain.go
+++ b/core/web/presenters/evm_chain.go
@@ -11,7 +11,7 @@ import (
 
 // EVMChainResource is an EVM chain JSONAPI resource.
 type EVMChainResource struct {
-	chainResource[evmtypes.ChainCfg]
+	chainResource[*evmtypes.ChainCfg]
 }
 
 // GetName implements the api2go EntityNamer interface
@@ -21,7 +21,7 @@ func (r EVMChainResource) GetName() string {
 
 // NewEVMChainResource returns a new EVMChainResource for chain.
 func NewEVMChainResource(chain evmtypes.DBChain) EVMChainResource {
-	return EVMChainResource{chainResource[evmtypes.ChainCfg]{
+	return EVMChainResource{chainResource[*evmtypes.ChainCfg]{
 		JAID:      NewJAIDInt64(chain.ID.ToInt().Int64()),
 		Config:    chain.Cfg,
 		Enabled:   chain.Enabled,

--- a/core/web/presenters/solana_chain.go
+++ b/core/web/presenters/solana_chain.go
@@ -10,7 +10,7 @@ import (
 
 // SolanaChainResource is an Solana chain JSONAPI resource.
 type SolanaChainResource struct {
-	chainResource[db.ChainCfg]
+	chainResource[*db.ChainCfg]
 }
 
 // GetName implements the api2go EntityNamer interface
@@ -20,7 +20,7 @@ func (r SolanaChainResource) GetName() string {
 
 // NewSolanaChainResource returns a new SolanaChainResource for chain.
 func NewSolanaChainResource(chain solana.DBChain) SolanaChainResource {
-	return SolanaChainResource{chainResource[db.ChainCfg]{
+	return SolanaChainResource{chainResource[*db.ChainCfg]{
 		JAID:      NewJAID(chain.ID),
 		Config:    chain.Cfg,
 		Enabled:   chain.Enabled,

--- a/core/web/presenters/terra_chain.go
+++ b/core/web/presenters/terra_chain.go
@@ -10,7 +10,7 @@ import (
 
 // TerraChainResource is an Terra chain JSONAPI resource.
 type TerraChainResource struct {
-	chainResource[db.ChainCfg]
+	chainResource[*db.ChainCfg]
 }
 
 // GetName implements the api2go EntityNamer interface
@@ -20,7 +20,7 @@ func (r TerraChainResource) GetName() string {
 
 // NewTerraChainResource returns a new TerraChainResource for chain.
 func NewTerraChainResource(chain types.DBChain) TerraChainResource {
-	return TerraChainResource{chainResource[db.ChainCfg]{
+	return TerraChainResource{chainResource[*db.ChainCfg]{
 		JAID:      NewJAID(chain.ID),
 		Config:    chain.Cfg,
 		Enabled:   chain.Enabled,

--- a/core/web/resolver/evm_chain.go
+++ b/core/web/resolver/evm_chain.go
@@ -39,7 +39,7 @@ func (r *ChainResolver) Enabled() bool {
 
 // Config resolves the chain's configuration field
 func (r *ChainResolver) Config() *ChainConfigResolver {
-	return NewChainConfig(r.chain.Cfg)
+	return NewChainConfig(*r.chain.Cfg)
 }
 
 // CreatedAt resolves the chain's created at field.

--- a/core/web/resolver/evm_chain_test.go
+++ b/core/web/resolver/evm_chain_test.go
@@ -77,7 +77,7 @@ func TestResolver_Chains(t *testing.T) {
 					ID:        chainID,
 					Enabled:   true,
 					CreatedAt: f.Timestamp(),
-					Cfg: types.ChainCfg{
+					Cfg: &types.ChainCfg{
 						BlockHistoryEstimatorBlockDelay: null.IntFrom(1),
 						EthTxReaperThreshold:            &threshold,
 						EthTxResendAfterThreshold:       &threshold,
@@ -198,7 +198,7 @@ func TestResolver_Chain(t *testing.T) {
 					ID:        chainID,
 					Enabled:   true,
 					CreatedAt: f.Timestamp(),
-					Cfg: types.ChainCfg{
+					Cfg: &types.ChainCfg{
 						BlockHistoryEstimatorBlockDelay: null.IntFrom(1),
 						EthTxReaperThreshold:            &threshold,
 						EthTxResendAfterThreshold:       &threshold,
@@ -383,11 +383,11 @@ func TestResolver_CreateChain(t *testing.T) {
 					},
 				}
 
-				f.Mocks.chainSet.On("Add", mock.Anything, *utils.NewBigI(1233), cfg).Return(types.DBChain{
+				f.Mocks.chainSet.On("Add", mock.Anything, *utils.NewBigI(1233), &cfg).Return(types.DBChain{
 					ID:        *utils.NewBigI(1233),
 					Enabled:   true,
 					CreatedAt: f.Timestamp(),
-					Cfg:       cfg,
+					Cfg:       &cfg,
 				}, nil)
 				f.App.On("GetChains").Return(chainlink.Chains{EVM: f.Mocks.chainSet})
 			},
@@ -458,11 +458,11 @@ func TestResolver_CreateChain(t *testing.T) {
 					},
 				}
 
-				f.Mocks.chainSet.On("Add", mock.Anything, *utils.NewBigI(1233), cfg).Return(types.DBChain{
+				f.Mocks.chainSet.On("Add", mock.Anything, *utils.NewBigI(1233), &cfg).Return(types.DBChain{
 					ID:        *utils.NewBigI(1233),
 					Enabled:   true,
 					CreatedAt: f.Timestamp(),
-					Cfg:       cfg,
+					Cfg:       &cfg,
 				}, gError)
 				f.App.On("GetChains").Return(chainlink.Chains{EVM: f.Mocks.chainSet})
 			},
@@ -686,11 +686,11 @@ func TestResolver_UpdateChain(t *testing.T) {
 					},
 				}
 
-				f.Mocks.chainSet.On("Configure", mock.Anything, chainID, true, cfg).Return(types.DBChain{
+				f.Mocks.chainSet.On("Configure", mock.Anything, chainID, true, &cfg).Return(types.DBChain{
 					ID:        chainID,
 					Enabled:   true,
 					CreatedAt: f.Timestamp(),
-					Cfg:       cfg,
+					Cfg:       &cfg,
 				}, nil)
 				f.App.On("GetChains").Return(chainlink.Chains{EVM: f.Mocks.chainSet})
 			},
@@ -761,7 +761,7 @@ func TestResolver_UpdateChain(t *testing.T) {
 					},
 				}
 
-				f.Mocks.chainSet.On("Configure", mock.Anything, chainID, true, cfg).Return(types.DBChain{}, sql.ErrNoRows)
+				f.Mocks.chainSet.On("Configure", mock.Anything, chainID, true, &cfg).Return(types.DBChain{}, sql.ErrNoRows)
 				f.App.On("GetChains").Return(chainlink.Chains{EVM: f.Mocks.chainSet})
 			},
 			query:     mutation,
@@ -794,7 +794,7 @@ func TestResolver_UpdateChain(t *testing.T) {
 					},
 				}
 
-				f.Mocks.chainSet.On("Configure", mock.Anything, chainID, true, cfg).Return(types.DBChain{}, gError)
+				f.Mocks.chainSet.On("Configure", mock.Anything, chainID, true, &cfg).Return(types.DBChain{}, gError)
 				f.App.On("GetChains").Return(chainlink.Chains{EVM: f.Mocks.chainSet})
 			},
 			query:     mutation,

--- a/core/web/resolver/mutation.go
+++ b/core/web/resolver/mutation.go
@@ -1026,7 +1026,7 @@ func (r *Resolver) CreateChain(ctx context.Context, args struct {
 		chainCfg.KeySpecific = sCfgs
 	}
 
-	chain, err := r.App.GetChains().EVM.Add(ctx, id, *chainCfg)
+	chain, err := r.App.GetChains().EVM.Add(ctx, id, chainCfg)
 	if err != nil {
 		return nil, err
 	}
@@ -1074,7 +1074,7 @@ func (r *Resolver) UpdateChain(ctx context.Context, args struct {
 		chainCfg.KeySpecific = sCfgs
 	}
 
-	chain, err := r.App.GetChains().EVM.Configure(ctx, id, args.Input.Enabled, *chainCfg)
+	chain, err := r.App.GetChains().EVM.Configure(ctx, id, args.Input.Enabled, chainCfg)
 	if err != nil {
 		if errors.Is(err, sql.ErrNoRows) {
 			return NewUpdateChainPayload(nil, nil, err), nil

--- a/core/web/solana_chains_controller.go
+++ b/core/web/solana_chains_controller.go
@@ -8,6 +8,6 @@ import (
 )
 
 func NewSolanaChainsController(app chainlink.Application) ChainsController {
-	return newChainsController[string, db.ChainCfg]("solana", app.GetChains().Solana, ErrSolanaNotEnabled,
+	return newChainsController[string, *db.ChainCfg]("solana", app.GetChains().Solana, ErrSolanaNotEnabled,
 		func(s string) (string, error) { return s, nil }, presenters.NewSolanaChainResource)
 }

--- a/core/web/solana_chains_controller_test.go
+++ b/core/web/solana_chains_controller_test.go
@@ -39,7 +39,7 @@ func Test_SolanaChainsController_Create(t *testing.T) {
 	hour := models.MustMakeDuration(time.Hour)
 	body, err := json.Marshal(web.NewCreateChainRequest(
 		newChainId,
-		db.ChainCfg{
+		&db.ChainCfg{
 			BalancePollPeriod:   &second,
 			ConfirmPollPeriod:   &minute,
 			OCR2CachePollPeriod: &minute,
@@ -149,16 +149,16 @@ func Test_SolanaChainsController_Index(t *testing.T) {
 	controller := setupSolanaChainsControllerTest(t)
 
 	hour := models.MustMakeDuration(time.Hour)
-	newChains := []web.CreateChainRequest[string, db.ChainCfg]{
+	newChains := []web.CreateChainRequest[string, *db.ChainCfg]{
 		{
 			ID: fmt.Sprintf("ChainlinktestA-%d", rand.Int31n(999999)),
-			Config: db.ChainCfg{
+			Config: &db.ChainCfg{
 				TxTimeout: &hour,
 			},
 		},
 		{
 			ID: fmt.Sprintf("ChainlinktestB-%d", rand.Int31n(999999)),
-			Config: db.ChainCfg{
+			Config: &db.ChainCfg{
 				SkipPreflight: null.BoolFrom(false),
 			},
 		},
@@ -169,7 +169,7 @@ func Test_SolanaChainsController_Index(t *testing.T) {
 		solanatest.MustInsertChain(t, controller.app.GetSqlxDB(), &db.Chain{
 			ID:      ch.ID,
 			Enabled: true,
-			Cfg:     ch.Config,
+			Cfg:     *ch.Config,
 		})
 	}
 
@@ -220,9 +220,9 @@ func Test_SolanaChainsController_Update(t *testing.T) {
 	t.Parallel()
 
 	hour := models.MustMakeDuration(time.Hour)
-	chainUpdate := web.UpdateChainRequest[db.ChainCfg]{
+	chainUpdate := web.UpdateChainRequest[*db.ChainCfg]{
 		Enabled: true,
-		Config: db.ChainCfg{
+		Config: &db.ChainCfg{
 			SkipPreflight: null.BoolFrom(false),
 			TxTimeout:     &hour,
 		},

--- a/core/web/terra_chains_controller.go
+++ b/core/web/terra_chains_controller.go
@@ -9,6 +9,6 @@ import (
 
 func NewTerraChainsController(app chainlink.Application) ChainsController {
 	parse := func(s string) (string, error) { return s, nil }
-	return newChainsController[string, db.ChainCfg, presenters.TerraChainResource](
+	return newChainsController[string, *db.ChainCfg, presenters.TerraChainResource](
 		"terra", app.GetChains().Terra, ErrTerraNotEnabled, parse, presenters.NewTerraChainResource)
 }

--- a/core/web/terra_chains_controller_test.go
+++ b/core/web/terra_chains_controller_test.go
@@ -36,7 +36,7 @@ func Test_TerraChainsController_Create(t *testing.T) {
 	minute := models.MustMakeDuration(time.Minute)
 	body, err := json.Marshal(web.NewCreateChainRequest(
 		newChainId,
-		db.ChainCfg{
+		&db.ChainCfg{
 			BlocksUntilTxTimeout:  null.IntFrom(1),
 			ConfirmPollPeriod:     &minute,
 			FallbackGasPriceULuna: null.StringFrom("9.999"),
@@ -139,16 +139,16 @@ func Test_TerraChainsController_Index(t *testing.T) {
 
 	controller := setupTerraChainsControllerTest(t)
 
-	newChains := []web.CreateChainRequest[string, db.ChainCfg]{
+	newChains := []web.CreateChainRequest[string, *db.ChainCfg]{
 		{
 			ID: fmt.Sprintf("ChainlinktestA-%d", rand.Int31n(999999)),
-			Config: db.ChainCfg{
+			Config: &db.ChainCfg{
 				FallbackGasPriceULuna: null.StringFrom("9.999"),
 			},
 		},
 		{
 			ID: fmt.Sprintf("ChainlinktestB-%d", rand.Int31n(999999)),
-			Config: db.ChainCfg{
+			Config: &db.ChainCfg{
 				GasLimitMultiplier: null.FloatFrom(1.55555),
 			},
 		},
@@ -159,7 +159,7 @@ func Test_TerraChainsController_Index(t *testing.T) {
 		terratest.MustInsertChain(t, controller.app.GetSqlxDB(), &db.Chain{
 			ID:      ch.ID,
 			Enabled: true,
-			Cfg:     ch.Config,
+			Cfg:     *ch.Config,
 		})
 	}
 
@@ -209,9 +209,9 @@ func Test_TerraChainsController_Index(t *testing.T) {
 func Test_TerraChainsController_Update(t *testing.T) {
 	t.Parallel()
 
-	chainUpdate := web.UpdateChainRequest[db.ChainCfg]{
+	chainUpdate := web.UpdateChainRequest[*db.ChainCfg]{
 		Enabled: true,
-		Config: db.ChainCfg{
+		Config: &db.ChainCfg{
 			FallbackGasPriceULuna: null.StringFrom("9.999"),
 			GasLimitMultiplier:    null.FloatFrom(1.55555),
 		},

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/ethereum/go-ethereum v1.10.16
 	github.com/fatih/color v1.13.0
 	github.com/fxamacker/cbor/v2 v2.4.0
-	github.com/gagliardetto/solana-go v1.4.1-0.20220413001530-3e39c80b7211
+	github.com/gagliardetto/solana-go v1.4.1-0.20220428092759-5250b4abbb27
 	github.com/getsentry/sentry-go v0.12.0
 	github.com/gin-contrib/cors v1.3.1
 	github.com/gin-contrib/expvar v0.0.0-20181230111036-f23b556cc79f
@@ -54,8 +54,8 @@ require (
 	github.com/scylladb/go-reflectx v1.0.1
 	github.com/shirou/gopsutil/v3 v3.22.2
 	github.com/shopspring/decimal v1.3.1
-	github.com/smartcontractkit/chainlink-solana v0.2.20-0.20220420200429-3da7f865d367
-	github.com/smartcontractkit/chainlink-terra v0.1.4-0.20220510145600-e520ea1fab70
+	github.com/smartcontractkit/chainlink-solana v0.2.20-0.20220511162535-82acbc64de81
+	github.com/smartcontractkit/chainlink-terra v0.1.4-0.20220511163217-2c0014142e12
 	github.com/smartcontractkit/libocr v0.0.0-20220414173908-cdfa6bef133a
 	github.com/smartcontractkit/sqlx v1.3.5-0.20210805004948-4be295aacbeb
 	github.com/smartcontractkit/terra.go v1.0.3-0.20220108002221-62b39252ee16
@@ -248,6 +248,7 @@ require (
 	github.com/mitchellh/pointerstructure v1.2.0 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
+	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 // indirect
 	github.com/mtibben/percent v0.2.1 // indirect
 	github.com/multiformats/go-base32 v0.0.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -642,8 +642,8 @@ github.com/gagliardetto/binary v0.6.1 h1:vGrbUym10xaaswadfnuSDr0xlP3NZS5XWbLqENJ
 github.com/gagliardetto/binary v0.6.1/go.mod h1:aOfYkc20U0deHaHn/LVZXiqlkDbFAX0FpTlDhsXa0S0=
 github.com/gagliardetto/gofuzz v1.2.2 h1:XL/8qDMzcgvR4+CyRQW9UGdwPRPMHVJfqQ/uMvSUuQw=
 github.com/gagliardetto/gofuzz v1.2.2/go.mod h1:bkH/3hYLZrMLbfYWA0pWzXmi5TTRZnu4pMGZBkqMKvY=
-github.com/gagliardetto/solana-go v1.4.1-0.20220413001530-3e39c80b7211 h1:o+QozGVXw4UUBaoX0+mGOPzIzxkEyJFfW3fM9OGyM+s=
-github.com/gagliardetto/solana-go v1.4.1-0.20220413001530-3e39c80b7211/go.mod h1:NFuoDwHPvw858ZMHUJr6bkhN8qHt4x6e+U3EYHxAwNY=
+github.com/gagliardetto/solana-go v1.4.1-0.20220428092759-5250b4abbb27 h1:q2IztKyRQUxJ6abXRsawaBtvDFvM+szj4jDqV4od1gs=
+github.com/gagliardetto/solana-go v1.4.1-0.20220428092759-5250b4abbb27/go.mod h1:NFuoDwHPvw858ZMHUJr6bkhN8qHt4x6e+U3EYHxAwNY=
 github.com/gagliardetto/treeout v0.1.4 h1:ozeYerrLCmCubo1TcIjFiOWTTGteOOHND1twdFpgwaw=
 github.com/gagliardetto/treeout v0.1.4/go.mod h1:loUefvXTrlRG5rYmJmExNryyBRh8f89VZhmMOyCyqok=
 github.com/garyburd/redigo v0.0.0-20150301180006-535138d7bcd7/go.mod h1:NR3MbYisc3/PwhQ00EMzDiPmrwpPxAn5GI05/YaO1SY=
@@ -729,7 +729,6 @@ github.com/go-sourcemap/sourcemap v2.1.2+incompatible/go.mod h1:F8jJfvm2KbVjc5Nq
 github.com/go-sourcemap/sourcemap v2.1.3+incompatible/go.mod h1:F8jJfvm2KbVjc5NqelyYJmf/v5J0dwNLS2mL4sNA1Jg=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
-github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
 github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
@@ -1155,8 +1154,6 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfC
 github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
 github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
-github.com/jmoiron/sqlx v1.3.4 h1:wv+0IJZfL5z0uZoUjlpKgHkgaFSYD+r9CfrXjEXsO7w=
-github.com/jmoiron/sqlx v1.3.4/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
 github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
 github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
@@ -1571,8 +1568,8 @@ github.com/moby/sys/mountinfo v0.4.0/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2J
 github.com/moby/sys/mountinfo v0.4.1/go.mod h1:rEr8tzG/lsIZHBtN/JjGG+LMYx9eXgW2JI+6q0qou+A=
 github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGqsZeMYowQ=
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
+github.com/moby/term v0.0.0-20201216013528-df9cb8a40635 h1:rzf0wL0CHVc8CEsgyygG0Mn9CNCCPZqOPaz8RiiHYQk=
 github.com/moby/term v0.0.0-20201216013528-df9cb8a40635/go.mod h1:FBS0z0QWA44HXygs7VXDUOGoN/1TV3RuWkLO04am3wc=
-github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -1582,6 +1579,7 @@ github.com/modern-go/reflect2 v1.0.2 h1:xBagoLtFs94CBntxluKeaWgTMpvLxC4ur3nMaC9G
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/modocache/gover v0.0.0-20171022184752-b58185e213c5/go.mod h1:caMODM3PzxT8aQXRPkAt8xlV/e7d7w8GM5g0fa5F0D8=
 github.com/morikuni/aec v1.0.0 h1:nP9CBfwrvYnBRgY6qfDQkygYDmYwOilePFkwzv4dU8A=
+github.com/morikuni/aec v1.0.0/go.mod h1:BbKIizmSmc5MMPqRYbxO4ZU0S0+P200+tUnFx7PXmsc=
 github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1 h1:mPMvm6X6tf4w8y7j9YIt6V9jfWhL6QlbEc7CCmeQlWk=
 github.com/mostynb/zstdpool-freelist v0.0.0-20201229113212-927304c0c3b1/go.mod h1:ye2e/VUEtE2BHE+G/QcKkcLQVAEJoYRFj5VUOQatCRE=
 github.com/moul/http2curl v1.0.0/go.mod h1:8UbvGypXm98wA/IqH45anm5Y2Z6ep6O31QGOAZ3H0fQ=
@@ -1936,12 +1934,10 @@ github.com/sirupsen/logrus v1.6.0/go.mod h1:7uNnSEd1DgxDLC74fIahvMZmmYsHGZGEOFrf
 github.com/sirupsen/logrus v1.7.0/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
 github.com/sirupsen/logrus v1.8.1 h1:dJKuHgqk1NNQlqoA6BTlM1Wf9DOH3NBjQyu0h9+AZZE=
 github.com/sirupsen/logrus v1.8.1/go.mod h1:yWOB1SBYBC5VeMP7gHvWumXLIWorT60ONWic61uBYv0=
-github.com/smartcontractkit/chainlink-solana v0.2.20-0.20220420200429-3da7f865d367 h1:HfFnFidkNFhtEGWwPmdmv6j6apGo3Z5yuuUyU6VVQAE=
-github.com/smartcontractkit/chainlink-solana v0.2.20-0.20220420200429-3da7f865d367/go.mod h1:iwugJOiM4V58Lt181Pp0MoPwnqTH2lE55bhddWTOdsg=
-github.com/smartcontractkit/chainlink-terra v0.1.4-0.20220420200433-90c1ac0f3c2a h1:shnSDB+PfiEwjR6XDc/s5aWUcZJ7CYHkJsNoMDv4MPM=
-github.com/smartcontractkit/chainlink-terra v0.1.4-0.20220420200433-90c1ac0f3c2a/go.mod h1:N1iTQh1GKVD89SNRXuxD+88mC6+u8dzkwchM9dtbHtM=
-github.com/smartcontractkit/chainlink-terra v0.1.4-0.20220510145600-e520ea1fab70 h1:kORA1+5/a003DOB5H/08JYsbZUWkbGl8O668L6ONqtQ=
-github.com/smartcontractkit/chainlink-terra v0.1.4-0.20220510145600-e520ea1fab70/go.mod h1:KwN6XgunWXtvdvg+ftzuBx8Wjh6UF4mBVHhWIJY1z5A=
+github.com/smartcontractkit/chainlink-solana v0.2.20-0.20220511162535-82acbc64de81 h1:+DuwuyOUmZ/uSh7YlnMOXj7RCok7aDzqSG7Ynvv1OZ8=
+github.com/smartcontractkit/chainlink-solana v0.2.20-0.20220511162535-82acbc64de81/go.mod h1:DU0pOCt9JWyyAli9aLWjTC4R8IwuwlF43+nxfn+3NDs=
+github.com/smartcontractkit/chainlink-terra v0.1.4-0.20220511163217-2c0014142e12 h1:cjGEUwYBb0FDUUR/CbjEd9bDybA2gai3zpWrKe3L68I=
+github.com/smartcontractkit/chainlink-terra v0.1.4-0.20220511163217-2c0014142e12/go.mod h1:/ot4OBG8HmrEiApz51hfa3+rxLrcwNms1CoPJzmW/EU=
 github.com/smartcontractkit/libocr v0.0.0-20220414173908-cdfa6bef133a h1:j5v0DlqdteLKgCB7My1On+KOO4levVV51byFGt3DoNA=
 github.com/smartcontractkit/libocr v0.0.0-20220414173908-cdfa6bef133a/go.mod h1:tHNcoCeQdbRfjvVZjvd3n8yNTKUdnM+NmlWgSHhfceY=
 github.com/smartcontractkit/sqlx v1.3.5-0.20210805004948-4be295aacbeb h1:OMaBUb4X9IFPLbGbCHsMU+kw/BPCrewaVwWGIBc0I4A=


### PR DESCRIPTION
Generics cleanup. Tighter constraints and interfaces. The `ChainCfg` pointer change is a bit noisy, but it gives us compile time guarantees and affords a nicer API in many places where we can now pass `nil` instead of instantiating an empty/zero struct.

Requires:
- [x] https://github.com/smartcontractkit/chainlink-terra/pull/285
- [x] https://github.com/smartcontractkit/chainlink-solana/pull/336