### PR TITLE
VRF Support managing consumers in VRFCoordinatorV2Mock [sc-33934]

### DIFF
--- a/contracts/test/v0.8/dev/VRFCoordinatorV2Mock.test.ts
+++ b/contracts/test/v0.8/dev/VRFCoordinatorV2Mock.test.ts
@@ -204,8 +204,20 @@ describe('VRFCoordinatorV2Mock', () => {
     })
   })
   describe('#fulfillRandomWords', async function () {
+    it('fails to fulfill without being a valid consumer', async function () {
+      let subId = await createSubscription()
+
+      await expect(
+        vrfCoordinatorV2Mock
+          .connect(subOwner)
+          .requestRandomWords(keyhash, subId, 3, 500_000, 2),
+      ).to.be.revertedWith('InvalidConsumer')
+    })
     it('fails to fulfill with insufficient funds', async function () {
       let subId = await createSubscription()
+      await vrfCoordinatorV2Mock
+        .connect(subOwner)
+        .addConsumer(subId, await subOwner.getAddress())
 
       await expect(
         vrfCoordinatorV2Mock
@@ -223,6 +235,9 @@ describe('VRFCoordinatorV2Mock', () => {
     })
     it('can request and fulfill [ @skip-coverage ]', async function () {
       let subId = await createSubscription()
+      await vrfCoordinatorV2Mock
+        .connect(subOwner)
+        .addConsumer(subId, vrfConsumerV2.address)
       await expect(
         vrfCoordinatorV2Mock.connect(subOwner).fundSubscription(subId, oneLink),
       ).to.not.be.reverted


### PR DESCRIPTION
Adds implementation in VRFCoordinatorV2Mock for adding/removing consumers, and retrieving subscriptions with consumers. There is one added test that runs a full 1.5 seconds ('cannot add more than the consumer maximum'). If 1.5s is too long, I can remove the consumer maximum test to be frugal on testing time.