### PR TITLE
Fixes null OCR1 config fields from sending empty strings

### DIFF
--- a/core/services/feeds/models_test.go
+++ b/core/services/feeds/models_test.go
@@ -79,44 +79,126 @@ func Test_OCR1Config_Value(t *testing.T) {
 	t.Parallel()
 
 	var (
-		give = OCR1Config{
-			Enabled:     true,
-			IsBootstrap: false,
-			Multiaddr:   null.StringFrom("multiaddr"),
-			P2PPeerID:   null.StringFrom("peerid"),
-			KeyBundleID: null.StringFrom("ocrkeyid"),
-		}
-		want = `{"enabled":true,"is_bootstrap":false,"multiaddr":"multiaddr","p2p_peer_id":"peerid","key_bundle_id":"ocrkeyid"}`
+		multiaddr   = "multiaddr"
+		p2pPeerID   = "peerid"
+		keyBundleID = "ocrkeyid"
 	)
 
-	val, err := give.Value()
-	require.NoError(t, err)
+	tests := []struct {
+		name string
+		give OCR1Config
+		want string
+	}{
+		{
+			name: "all fields populated",
+			give: OCR1Config{
+				Enabled:     true,
+				IsBootstrap: false,
+				Multiaddr:   null.StringFrom(multiaddr),
+				P2PPeerID:   null.StringFrom(p2pPeerID),
+				KeyBundleID: null.StringFrom(keyBundleID),
+			},
+			want: `{"enabled":true,"is_bootstrap":false,"multiaddr":"multiaddr","p2p_peer_id":"peerid","key_bundle_id":"ocrkeyid"}`,
+		},
+		{
+			name: "bootstrap fields populated",
+			give: OCR1Config{
+				Enabled:     true,
+				IsBootstrap: true,
+				Multiaddr:   null.StringFrom(multiaddr),
+				P2PPeerID:   null.StringFromPtr(nil),
+				KeyBundleID: null.StringFromPtr(nil),
+			},
+			want: `{"enabled":true,"is_bootstrap":true,"multiaddr":"multiaddr","p2p_peer_id":null,"key_bundle_id":null}`,
+		},
+		{
+			name: "multiaddr field populated",
+			give: OCR1Config{
+				Enabled:     true,
+				IsBootstrap: false,
+				Multiaddr:   null.StringFromPtr(nil),
+				P2PPeerID:   null.StringFrom(p2pPeerID),
+				KeyBundleID: null.StringFrom(keyBundleID),
+			},
+			want: `{"enabled":true,"is_bootstrap":false,"multiaddr":null,"p2p_peer_id":"peerid","key_bundle_id":"ocrkeyid"}`,
+		},
+	}
 
-	actual, ok := val.([]byte)
-	require.True(t, ok)
+	for _, tt := range tests {
+		tt := tt
 
-	assert.Equal(t, want, string(actual))
+		t.Run(tt.name, func(t *testing.T) {
+			val, err := tt.give.Value()
+			require.NoError(t, err)
+
+			actual, ok := val.([]byte)
+			require.True(t, ok)
+
+			assert.Equal(t, tt.want, string(actual))
+		})
+	}
 }
 
 func Test_OCR1Config_Scan(t *testing.T) {
 	t.Parallel()
 
 	var (
-		give = `{"enabled":true,"is_bootstrap":false,"multiaddr":"multiaddr","p2p_peer_id":"peerid","key_bundle_id":"ocrkeyid"}`
-		want = OCR1Config{
-			Enabled:     true,
-			IsBootstrap: false,
-			Multiaddr:   null.StringFrom("multiaddr"),
-			P2PPeerID:   null.StringFrom("peerid"),
-			KeyBundleID: null.StringFrom("ocrkeyid"),
-		}
+		multiaddr   = "multiaddr"
+		p2pPeerID   = "peerid"
+		keyBundleID = "ocrkeyid"
 	)
 
-	var actual OCR1Config
-	err := actual.Scan([]byte(give))
-	require.NoError(t, err)
+	tests := []struct {
+		name string
+		give string
+		want OCR1Config
+	}{
+		{
+			name: "all fields populated",
+			give: `{"enabled":true,"is_bootstrap":false,"multiaddr":"multiaddr","p2p_peer_id":"peerid","key_bundle_id":"ocrkeyid"}`,
+			want: OCR1Config{
+				Enabled:     true,
+				IsBootstrap: false,
+				Multiaddr:   null.StringFrom(multiaddr),
+				P2PPeerID:   null.StringFrom(p2pPeerID),
+				KeyBundleID: null.StringFrom(keyBundleID),
+			},
+		},
+		{
+			name: "bootstrap fields populated",
+			give: `{"enabled":true,"is_bootstrap":true,"multiaddr":"multiaddr","p2p_peer_id":null,"key_bundle_id":null}`,
+			want: OCR1Config{
+				Enabled:     true,
+				IsBootstrap: true,
+				Multiaddr:   null.StringFrom(multiaddr),
+				P2PPeerID:   null.StringFromPtr(nil),
+				KeyBundleID: null.StringFromPtr(nil),
+			},
+		},
+		{
+			name: "multiaddr field populated",
+			give: `{"enabled":true,"is_bootstrap":false,"multiaddr":null,"p2p_peer_id":"peerid","key_bundle_id":"ocrkeyid"}`,
+			want: OCR1Config{
+				Enabled:     true,
+				IsBootstrap: false,
+				Multiaddr:   null.StringFromPtr(nil),
+				P2PPeerID:   null.StringFrom(p2pPeerID),
+				KeyBundleID: null.StringFrom(keyBundleID),
+			},
+		},
+	}
 
-	assert.Equal(t, want, actual)
+	for _, tt := range tests {
+		tt := tt
+
+		t.Run(tt.name, func(t *testing.T) {
+			var actual OCR1Config
+			err := actual.Scan([]byte(tt.give))
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.want, actual)
+		})
+	}
 }
 
 func Test_OCR2Config_Value(t *testing.T) {

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -200,7 +200,7 @@ func (s *service) SyncNodeInfo(id int64) error {
 	for _, cfg := range cfgs {
 		cfgMsg, msgErr := s.newChainConfigMsg(cfg)
 		if msgErr != nil {
-			s.lggr.Errorf("SyncNodeInfo: %w", msgErr)
+			s.lggr.Errorf("SyncNodeInfo: %v", msgErr)
 
 			continue
 		}

--- a/operator_ui/src/screens/FeedsManager/SupportedChainsCard.tsx
+++ b/operator_ui/src/screens/FeedsManager/SupportedChainsCard.tsx
@@ -207,9 +207,12 @@ export const SupportedChainsCard = withStyles(styles)(
               fluxMonitorEnabled: values.fluxMonitorEnabled,
               ocr1Enabled: values.ocr1Enabled,
               ocr1IsBootstrap: values.ocr1IsBootstrap,
-              ocr1Multiaddr: values.ocr1Multiaddr,
-              ocr1P2PPeerID: values.ocr1P2PPeerID,
-              ocr1KeyBundleID: values.ocr1KeyBundleID,
+              ocr1Multiaddr:
+                values.ocr1Multiaddr !== '' ? values.ocr1Multiaddr : null,
+              ocr1P2PPeerID:
+                values.ocr1P2PPeerID !== '' ? values.ocr1P2PPeerID : null,
+              ocr1KeyBundleID:
+                values.ocr1KeyBundleID != '' ? values.ocr1KeyBundleID : null,
               ocr2Enabled: false, // We don't want to support OCR2 in the UI yet.
             },
           },
@@ -254,7 +257,6 @@ export const SupportedChainsCard = withStyles(styles)(
     }
 
     const handleUpdateSubmit = async (values: FormValues) => {
-      console.log('handleUpdateSubmit')
       if (!editCfg) {
         return
       }
@@ -269,9 +271,12 @@ export const SupportedChainsCard = withStyles(styles)(
               fluxMonitorEnabled: values.fluxMonitorEnabled,
               ocr1Enabled: values.ocr1Enabled,
               ocr1IsBootstrap: values.ocr1IsBootstrap,
-              ocr1Multiaddr: values.ocr1Multiaddr,
-              ocr1P2PPeerID: values.ocr1P2PPeerID,
-              ocr1KeyBundleID: values.ocr1KeyBundleID,
+              ocr1Multiaddr:
+                values.ocr1Multiaddr !== '' ? values.ocr1Multiaddr : null,
+              ocr1P2PPeerID:
+                values.ocr1P2PPeerID !== '' ? values.ocr1P2PPeerID : null,
+              ocr1KeyBundleID:
+                values.ocr1KeyBundleID != '' ? values.ocr1KeyBundleID : null,
               ocr2Enabled: false, // We don't want to support OCR2 in the UI yet.
             },
           },


### PR DESCRIPTION
This was causing empty strings to be persisted as JSONB and causing the sync with FMS to not send the bootstrap nodes as it failed to fetch the P2P and OCR Key Bundle details