### PR TITLE
Support migration logs keepers

### DIFF
--- a/core/services/keeper/registry1_2_synchronizer_test.go
+++ b/core/services/keeper/registry1_2_synchronizer_test.go
@@ -516,3 +516,43 @@ func Test_RegistrySynchronizer1_2_UpkeepReceivedLog(t *testing.T) {
 	ethMock.AssertExpectations(t)
 	logBroadcast.AssertExpectations(t)
 }
+
+func Test_RegistrySynchronizer1_2_UpkeepMigratedLog(t *testing.T) {
+	db, synchronizer, ethMock, lb, job := setupRegistrySync(t, keeper.RegistryVersion_1_2)
+
+	contractAddress := job.KeeperSpec.ContractAddress.Address()
+	fromAddress := job.KeeperSpec.FromAddress.Address()
+
+	mockRegistry1_2(
+		t,
+		ethMock,
+		contractAddress,
+		registryConfig1_2,
+		[]*big.Int{big.NewInt(3), big.NewInt(69), big.NewInt(420)}, // Upkeep IDs
+		[]common.Address{fromAddress},
+		upkeepConfig1_2,
+		3)
+
+	require.NoError(t, synchronizer.Start(testutils.Context(t)))
+	defer func() { require.NoError(t, synchronizer.Close()) }()
+	cltest.WaitForCount(t, db, "keeper_registries", 1)
+	cltest.WaitForCount(t, db, "upkeep_registrations", 3)
+
+	cfg := cltest.NewTestGeneralConfig(t)
+	head := cltest.MustInsertHead(t, db, cfg, 1)
+	rawLog := types.Log{BlockHash: head.Hash}
+	log := registry1_2.KeeperRegistryUpkeepMigrated{Id: big.NewInt(3)}
+	logBroadcast := new(logmocks.Broadcast)
+	logBroadcast.On("DecodedLog").Return(&log)
+	logBroadcast.On("RawLog").Return(rawLog)
+	logBroadcast.On("String").Maybe().Return("")
+	lb.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
+	lb.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil)
+
+	// Do the thing
+	synchronizer.HandleLog(logBroadcast)
+
+	cltest.WaitForCount(t, db, "upkeep_registrations", 2)
+	ethMock.AssertExpectations(t)
+	logBroadcast.AssertExpectations(t)
+}

--- a/core/services/keeper/registry_interface_logs.go
+++ b/core/services/keeper/registry_interface_logs.go
@@ -125,3 +125,17 @@ func (rw *RegistryWrapper) GetIDFromGasLimitSetLog(broadcast log.Broadcast) (*bi
 		return nil, newUnsupportedVersionError("GetIDFromGasLimitSetLog", rw.Version)
 	}
 }
+
+func (rw *RegistryWrapper) GetUpkeepIdFromReceivedLog(broadcast log.Broadcast) (*big.Int, error) {
+	// Only supported on 1.2
+	switch rw.Version {
+	case RegistryVersion_1_2:
+		broadcastedLog, ok := broadcast.DecodedLog().(*registry1_2.KeeperRegistryUpkeepReceived)
+		if !ok {
+			return nil, errors.Errorf("expected UpkeepReceived log but got %T", broadcastedLog)
+		}
+		return broadcastedLog.Id, nil
+	default:
+		return nil, newUnsupportedVersionError("GetUpkeepIdFromReceivedLog", rw.Version)
+	}
+}

--- a/core/services/keeper/registry_interface_logs.go
+++ b/core/services/keeper/registry_interface_logs.go
@@ -139,3 +139,17 @@ func (rw *RegistryWrapper) GetUpkeepIdFromReceivedLog(broadcast log.Broadcast) (
 		return nil, newUnsupportedVersionError("GetUpkeepIdFromReceivedLog", rw.Version)
 	}
 }
+
+func (rw *RegistryWrapper) GetUpkeepIdFromMigratedLog(broadcast log.Broadcast) (*big.Int, error) {
+	// Only supported on 1.2
+	switch rw.Version {
+	case RegistryVersion_1_2:
+		broadcastedLog, ok := broadcast.DecodedLog().(*registry1_2.KeeperRegistryUpkeepMigrated)
+		if !ok {
+			return nil, errors.Errorf("expected UpkeepMigrated log but got %T", broadcastedLog)
+		}
+		return broadcastedLog.Id, nil
+	default:
+		return nil, newUnsupportedVersionError("GetUpkeepIdFromMigratedLog", rw.Version)
+	}
+}

--- a/core/services/keeper/registry_synchronizer_core.go
+++ b/core/services/keeper/registry_synchronizer_core.go
@@ -24,6 +24,7 @@ type MailRoom struct {
 	mbSyncRegistry      *utils.Mailbox[log.Broadcast]
 	mbUpkeepPerformed   *utils.Mailbox[log.Broadcast]
 	mbUpkeepRegistered  *utils.Mailbox[log.Broadcast]
+	mbUpkeepReceived    *utils.Mailbox[log.Broadcast]
 	mbUpkeepGasLimitSet *utils.Mailbox[log.Broadcast]
 }
 
@@ -64,6 +65,7 @@ func NewRegistrySynchronizer(opts RegistrySynchronizerOptions) *RegistrySynchron
 		mbSyncRegistry:      utils.NewMailbox[log.Broadcast](1),
 		mbUpkeepPerformed:   utils.NewMailbox[log.Broadcast](3000),
 		mbUpkeepRegistered:  utils.NewMailbox[log.Broadcast](500),
+		mbUpkeepReceived:    utils.NewMailbox[log.Broadcast](500),
 		mbUpkeepGasLimitSet: utils.NewMailbox[log.Broadcast](500),
 	}
 	return &RegistrySynchronizer{

--- a/core/services/keeper/registry_synchronizer_core.go
+++ b/core/services/keeper/registry_synchronizer_core.go
@@ -25,6 +25,7 @@ type MailRoom struct {
 	mbUpkeepPerformed   *utils.Mailbox[log.Broadcast]
 	mbUpkeepRegistered  *utils.Mailbox[log.Broadcast]
 	mbUpkeepReceived    *utils.Mailbox[log.Broadcast]
+	mbUpkeepMigrated    *utils.Mailbox[log.Broadcast]
 	mbUpkeepGasLimitSet *utils.Mailbox[log.Broadcast]
 }
 
@@ -66,6 +67,7 @@ func NewRegistrySynchronizer(opts RegistrySynchronizerOptions) *RegistrySynchron
 		mbUpkeepPerformed:   utils.NewMailbox[log.Broadcast](3000),
 		mbUpkeepRegistered:  utils.NewMailbox[log.Broadcast](500),
 		mbUpkeepReceived:    utils.NewMailbox[log.Broadcast](500),
+		mbUpkeepMigrated:    utils.NewMailbox[log.Broadcast](500),
 		mbUpkeepGasLimitSet: utils.NewMailbox[log.Broadcast](500),
 	}
 	return &RegistrySynchronizer{

--- a/core/services/keeper/registry_synchronizer_log_listener.go
+++ b/core/services/keeper/registry_synchronizer_log_listener.go
@@ -52,6 +52,9 @@ func (rs *RegistrySynchronizer) HandleLog(broadcast log.Broadcast) {
 	case *registry1_2.KeeperRegistryUpkeepGasLimitSet:
 		wasOverCapacity = rs.mailRoom.mbUpkeepGasLimitSet.Deliver(broadcast)
 		mailboxName = "mbUpkeepGasLimitSet"
+	case *registry1_2.KeeperRegistryUpkeepReceived:
+		wasOverCapacity = rs.mailRoom.mbUpkeepReceived.Deliver(broadcast)
+		mailboxName = "mbUpkeepReceived"
 	default:
 		svcLogger.Warn("unexpected log type")
 	}

--- a/core/services/keeper/registry_synchronizer_log_listener.go
+++ b/core/services/keeper/registry_synchronizer_log_listener.go
@@ -55,6 +55,9 @@ func (rs *RegistrySynchronizer) HandleLog(broadcast log.Broadcast) {
 	case *registry1_2.KeeperRegistryUpkeepReceived:
 		wasOverCapacity = rs.mailRoom.mbUpkeepReceived.Deliver(broadcast)
 		mailboxName = "mbUpkeepReceived"
+	case *registry1_2.KeeperRegistryUpkeepMigrated:
+		wasOverCapacity = rs.mailRoom.mbUpkeepMigrated.Deliver(broadcast)
+		mailboxName = "mbUpkeepMigrated"
 	default:
 		svcLogger.Warn("unexpected log type")
 	}

--- a/core/services/keeper/registry_synchronizer_process_logs.go
+++ b/core/services/keeper/registry_synchronizer_process_logs.go
@@ -13,10 +13,11 @@ import (
 
 func (rs *RegistrySynchronizer) processLogs() {
 	wg := sync.WaitGroup{}
-	wg.Add(5)
+	wg.Add(6)
 	go rs.handleSyncRegistryLog(wg.Done)
 	go rs.handleUpkeepCanceledLogs(wg.Done)
 	go rs.handleUpkeepRegisteredLogs(wg.Done)
+	go rs.handleUpkeepReceivedLogs(wg.Done)
 	go rs.handleUpkeepPerformedLogs(wg.Done)
 	go rs.handleUpkeepGasLimitSetLogs(wg.Done)
 	wg.Wait()
@@ -220,5 +221,49 @@ func (rs *RegistrySynchronizer) handleUpkeepGasLimitSet(broadcast log.Broadcast,
 	}
 	if err := rs.logBroadcaster.MarkConsumed(broadcast); err != nil {
 		rs.logger.Error(errors.Wrapf(err, "unable to mark KeeperRegistryUpkeepGasLimitSet log as consumed, log: %v", broadcast.String()))
+	}
+}
+
+func (rs *RegistrySynchronizer) handleUpkeepReceivedLogs(done func()) {
+	defer done()
+	registry, err := rs.orm.RegistryForJob(rs.job.ID)
+	if err != nil {
+		rs.logger.Error(errors.Wrap(err, "unable to find registry for job"))
+		return
+	}
+	for {
+		broadcast, exists := rs.mailRoom.mbUpkeepReceived.Retrieve()
+		if !exists {
+			return
+		}
+		rs.HandleUpkeepReceived(broadcast, registry)
+	}
+}
+
+func (rs *RegistrySynchronizer) HandleUpkeepReceived(broadcast log.Broadcast, registry Registry) {
+	txHash := broadcast.RawLog().TxHash.Hex()
+	rs.logger.Debugw("processing UpkeepReceived log", "txHash", txHash)
+	was, err := rs.logBroadcaster.WasAlreadyConsumed(broadcast)
+	if err != nil {
+		rs.logger.Error(errors.Wrap(err, "unable to check if log was consumed"))
+		return
+	}
+	if was {
+		return
+	}
+
+	upkeepID, err := rs.registryWrapper.GetUpkeepIdFromReceivedLog(broadcast)
+	if err != nil {
+		rs.logger.Error(errors.Wrap(err, "Unable to fetch upkeep ID from received log"))
+		return
+	}
+
+	err = rs.syncUpkeep(registry, utils.NewBig(upkeepID))
+	if err != nil {
+		rs.logger.Error(errors.Wrapf(err, "failed to sync upkeep, log: %v", broadcast.String()))
+		return
+	}
+	if err := rs.logBroadcaster.MarkConsumed(broadcast); err != nil {
+		rs.logger.Error(errors.Wrapf(err, "unable to mark KeeperRegistryUpkeepReceived log as consumed, log: %v", broadcast.String()))
 	}
 }


### PR DESCRIPTION
Add support for migration logs. The behaviour is very similar to existing logs:

- Upkeep migrated => Upkeep cancelled
- Upkeep Received => Upkeep registered

There's a bit of duplication i had to do for these logs but refactoring to reuse most of the code is not straightforward and probably needs generics