### PR TITLE
sc-33541: add a canary upkeep contract and test

### DIFF
--- a/contracts/src/v0.8/dev/CanaryUpkeep.sol
+++ b/contracts/src/v0.8/dev/CanaryUpkeep.sol
@@ -5,6 +5,9 @@ import "../interfaces/KeeperCompatibleInterface.sol";
 import "../interfaces/KeeperRegistryInterface.sol";
 import "../ConfirmedOwner.sol";
 
+error NoKeeperNodes();
+error InsufficientInterval();
+
 /**
  * @notice A canary upkeep which requires a different keeper to service its upkeep at an interval. This makes sure that
  * all keepers are in a healthy state.
@@ -47,6 +50,13 @@ contract CanaryUpkeep is KeeperCompatibleInterface, ConfirmedOwner {
   }
 
   /**
+   * @return the keeper registry
+   */
+  function getKeeperRegistry() external view returns (KeeperRegistryInterface) {
+    return i_keeperRegistry;
+  }
+
+  /**
    * @notice updates the interval
    * @param interval the new interval
    */
@@ -73,10 +83,10 @@ contract CanaryUpkeep is KeeperCompatibleInterface, ConfirmedOwner {
   ) external {
     (State memory _s, Config memory _c, address[] memory keepers) = i_keeperRegistry.getState();
     if (keepers.length == 0) {
-      revert("no keeper nodes exists");
+      revert NoKeeperNodes();
     }
     if (block.timestamp < s_interval + s_timestamp) {
-      revert("Not enough time has passed after the previous upkeep");
+      revert InsufficientInterval();
     }
     // if keepers array is shortened, this statement will make sure keeper index is always valid
     if (s_keeperIndex >= keepers.length) {

--- a/contracts/src/v0.8/dev/CanaryUpkeep.sol
+++ b/contracts/src/v0.8/dev/CanaryUpkeep.sol
@@ -11,16 +11,17 @@ import "../ConfirmedOwner.sol";
  */
 contract CanaryUpkeep is KeeperCompatibleInterface, ConfirmedOwner {
   uint256 private s_keeperIndex;
-  uint256 private s_interval = 300;
+  uint256 private s_interval;
   uint256 private s_timestamp;
-  KeeperRegistryInterface private immutable s_keeperRegistry;
+  KeeperRegistryInterface private immutable i_keeperRegistry;
 
   /**
    * @param keeperRegistry address of a keeper registry
    */
-  constructor(KeeperRegistryInterface keeperRegistry) ConfirmedOwner(msg.sender) {
-    s_keeperRegistry = keeperRegistry;
+  constructor(KeeperRegistryInterface keeperRegistry, uint256 interval) ConfirmedOwner(msg.sender) {
+    i_keeperRegistry = keeperRegistry;
     s_timestamp = block.timestamp;
+    s_interval = interval;
     s_keeperIndex = 0;
   }
 
@@ -59,8 +60,7 @@ contract CanaryUpkeep is KeeperCompatibleInterface, ConfirmedOwner {
   function checkUpkeep(
     bytes calldata /* checkData */
   ) external view returns (bool, bytes memory) {
-    (State memory _s, Config memory _c, address[] memory keepers) = s_keeperRegistry.getState();
-    bool upkeepNeeded = keepers.length != 0 && block.timestamp >= s_interval + s_timestamp;
+    bool upkeepNeeded = block.timestamp >= s_interval + s_timestamp;
     return (upkeepNeeded, bytes(""));
   }
 
@@ -71,7 +71,7 @@ contract CanaryUpkeep is KeeperCompatibleInterface, ConfirmedOwner {
   function performUpkeep(
     bytes calldata /* performData */
   ) external {
-    (State memory _s, Config memory _c, address[] memory keepers) = s_keeperRegistry.getState();
+    (State memory _s, Config memory _c, address[] memory keepers) = i_keeperRegistry.getState();
     if (keepers.length == 0) {
       revert("no keeper nodes exists");
     }

--- a/contracts/src/v0.8/dev/CanaryUpkeep.sol
+++ b/contracts/src/v0.8/dev/CanaryUpkeep.sol
@@ -1,58 +1,90 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity 0.8.13;
 
 import "../interfaces/KeeperCompatibleInterface.sol";
 import "../interfaces/KeeperRegistryInterface.sol";
+import "../ConfirmedOwner.sol";
 
-contract CanaryUpkeep is KeeperCompatibleInterface {
+/**
+ * @notice A canary upkeep which requires a different keeper to service its upkeep at an interval. This makes sure that
+ * all keepers are in a healthy state.
+ */
+contract CanaryUpkeep is KeeperCompatibleInterface, ConfirmedOwner {
+  uint256 private s_keeperIndex;
+  uint256 private s_interval = 300;
+  uint256 private s_timestamp;
+  KeeperRegistryInterface private immutable s_keeperRegistry;
 
-    uint private s_keeperIndex;
-    uint private s_interval = 300;
-    uint private s_timestamp;
-    KeeperRegistryInterface private s_keeperRegistry;
+  /**
+   * @param keeperRegistry address of a keeper registry
+   */
+  constructor(KeeperRegistryInterface keeperRegistry) ConfirmedOwner(msg.sender) {
+    s_keeperRegistry = keeperRegistry;
+    s_timestamp = block.timestamp;
+    s_keeperIndex = 0;
+  }
 
-    constructor(KeeperRegistryInterface keeperRegistry) {
-        s_keeperRegistry = keeperRegistry;
-        s_timestamp = block.timestamp;
-        s_keeperIndex = 0;
+  /**
+   * @return the current keeper index
+   */
+  function getKeeperIndex() external view returns (uint256) {
+    return s_keeperIndex;
+  }
+
+  /**
+   * @return the current timestamp
+   */
+  function getTimestamp() external view returns (uint256) {
+    return s_timestamp;
+  }
+
+  /**
+   * @return the current interval
+   */
+  function getInterval() external view returns (uint256) {
+    return s_interval;
+  }
+
+  /**
+   * @notice updates the interval
+   * @param interval the new interval
+   */
+  function setInterval(uint256 interval) external onlyOwner {
+    s_interval = interval;
+  }
+
+  /**
+   * @notice returns true if keeper array is not empty and sufficient time has passed
+   */
+  function checkUpkeep(
+    bytes calldata /* checkData */
+  ) external view returns (bool, bytes memory) {
+    (State memory _s, Config memory _c, address[] memory keepers) = s_keeperRegistry.getState();
+    bool upkeepNeeded = keepers.length != 0 && block.timestamp >= s_interval + s_timestamp;
+    return (upkeepNeeded, bytes(""));
+  }
+
+  /**
+   * @notice checks keepers array limit, timestamp limit, and requires transaction origin must be the anticipated keeper.
+   * If all checks pass, update the keeper index and timestamp. Otherwise, revert this transaction.
+   */
+  function performUpkeep(
+    bytes calldata /* performData */
+  ) external {
+    (State memory _s, Config memory _c, address[] memory keepers) = s_keeperRegistry.getState();
+    if (keepers.length == 0) {
+      revert("no keeper nodes exists");
+    }
+    if (block.timestamp < s_interval + s_timestamp) {
+      revert("Not enough time has passed after the previous upkeep");
+    }
+    // if keepers array is shortened, this statement will make sure keeper index is always valid
+    if (s_keeperIndex >= keepers.length) {
+      s_keeperIndex = 0;
     }
 
-    function getKeeperIndex() external view returns(uint) {
-        return s_keeperIndex;
-    }
-
-    function getTimestamp() external view returns(uint) {
-        return s_timestamp;
-    }
-
-    function getInterval() external view returns(uint) {
-        return s_interval;
-    }
-
-    function setInterval(uint interval) external {
-        s_interval = interval;
-    }
-
-    function checkUpkeep(bytes calldata checkData) external view returns (bool upkeepNeeded, bytes memory performData) {
-        (State memory _s, Config memory _c, address[] memory keepers) = s_keeperRegistry.getState();
-        upkeepNeeded = keepers.length != 0 && block.timestamp >= s_interval * 1 seconds + s_timestamp;
-        // tx.origin will return 0 in simulated transactions => simulated transactions are often sent to read only functions
-    }
-
-    function performUpkeep(bytes calldata performData) external {
-        (State memory _s, Config memory _c, address[] memory keepers) = s_keeperRegistry.getState();
-        if (keepers.length == 0) {
-            revert("no keeper nodes exists");
-        }
-        if (block.timestamp < s_interval * 1 seconds + s_timestamp) {
-            revert("Not enough time has passed after the previous upkeep");
-        }
-        if (s_keeperIndex >= keepers.length) {
-            s_keeperIndex = 0;
-        }
-
-        require(tx.origin == keepers[s_keeperIndex], "transaction origin is not the anticipated keeper.");
-        s_keeperIndex++;
-        s_timestamp = block.timestamp;
-    }
+    require(tx.origin == keepers[s_keeperIndex], "transaction origin is not the anticipated keeper.");
+    s_keeperIndex = (s_keeperIndex + 1) % keepers.length;
+    s_timestamp = block.timestamp;
+  }
 }

--- a/contracts/src/v0.8/dev/CanaryUpkeep.sol
+++ b/contracts/src/v0.8/dev/CanaryUpkeep.sol
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../interfaces/KeeperCompatibleInterface.sol";
+import "../interfaces/KeeperRegistryInterface.sol";
+
+contract CanaryUpkeep is KeeperCompatibleInterface {
+
+    uint private s_keeperIndex;
+    uint private s_interval = 300;
+    uint private s_timestamp;
+    KeeperRegistryInterface private s_keeperRegistry;
+
+    constructor(KeeperRegistryInterface keeperRegistry) {
+        s_keeperRegistry = keeperRegistry;
+        s_timestamp = block.timestamp;
+        s_keeperIndex = 0;
+    }
+
+    function getKeeperIndex() external view returns(uint) {
+        return s_keeperIndex;
+    }
+
+    function getTimestamp() external view returns(uint) {
+        return s_timestamp;
+    }
+
+    function getInterval() external view returns(uint) {
+        return s_interval;
+    }
+
+    function setInterval(uint interval) external {
+        s_interval = interval;
+    }
+
+    function checkUpkeep(bytes calldata checkData) external view returns (bool upkeepNeeded, bytes memory performData) {
+        (State memory _s, Config memory _c, address[] memory keepers) = s_keeperRegistry.getState();
+        upkeepNeeded = keepers.length != 0 && block.timestamp >= s_interval * 1 seconds + s_timestamp;
+        // tx.origin will return 0 in simulated transactions => simulated transactions are often sent to read only functions
+    }
+
+    function performUpkeep(bytes calldata performData) external {
+        (State memory _s, Config memory _c, address[] memory keepers) = s_keeperRegistry.getState();
+        if (keepers.length == 0) {
+            revert("no keeper nodes exists");
+        }
+        if (block.timestamp < s_interval * 1 seconds + s_timestamp) {
+            revert("Not enough time has passed after the previous upkeep");
+        }
+        if (s_keeperIndex >= keepers.length) {
+            s_keeperIndex = 0;
+        }
+
+        require(tx.origin == keepers[s_keeperIndex], "transaction origin is not the anticipated keeper.");
+        s_keeperIndex++;
+        s_timestamp = block.timestamp;
+    }
+}

--- a/contracts/test/v0.8/CanaryUpkeep.test.ts
+++ b/contracts/test/v0.8/CanaryUpkeep.test.ts
@@ -47,7 +47,8 @@ describe.only('CanaryUpkeep', () => {
     describe('checkUpkeep()', () => {
         it('returns true when sufficient time passes', async () => {
             await fastForward(moment.duration(6, 'minutes').asSeconds())
-            expect(await canaryUpkeep.checkUpkeep('0x')).to.be.true
+            const [ needsUpkeep ] = await canaryUpkeep.checkUpkeep('0x')
+            assert.isTrue(needsUpkeep)
         })
 
         it('returns false when insufficient time passes', async () => {

--- a/contracts/test/v0.8/CanaryUpkeep.test.ts
+++ b/contracts/test/v0.8/CanaryUpkeep.test.ts
@@ -1,0 +1,105 @@
+import { ethers } from 'hardhat'
+import {BigNumber} from "ethers";
+import moment from "moment";
+import {assert, expect} from "chai";
+import { CanaryUpkeep } from '../../typechain/CanaryUpkeep'
+import KeeperRegistryAbi from '../../abi/src/v0.8/KeeperRegistry.sol/KeeperRegistry.json'
+import { fastForward, reset } from '../test-helpers/helpers'
+import {deployMockContract, MockContract} from '@ethereum-waffle/mock-contract'
+import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/signers"
+import {evmRevert} from "../test-helpers/matchers";
+
+let canaryUpkeep: CanaryUpkeep
+let nelly: SignerWithAddress
+let nancy: SignerWithAddress
+let neo: SignerWithAddress
+let keeperAddresses: string[]
+let emptyKeeperAddresses: string[]
+let mockContract: MockContract
+
+describe.only('CanaryUpkeep', () => {
+    beforeEach(async () => {
+        const accounts = await ethers.getSigners()
+        const admin = accounts[1]
+        // initialize fake node operators
+        nelly = accounts[2]
+        nancy = accounts[3]
+        neo = accounts[4]
+        mockContract = await deployMockContract(admin as any, KeeperRegistryAbi);
+
+        // this object is the return type of getState function of KeeperRegistry. we still need to investigate how
+        // to create an object for the return type. for the purpose of this test, only the address array is needed.
+        // hence, the first two sub structs are omitted.
+        keeperAddresses = [nelly.address, nancy.address, neo.address]
+        const getStateReturn = [{}, {}, keeperAddresses];
+        await mockContract.mock.getState.returns(...getStateReturn)
+        const canaryUpkeepFactory = await ethers.getContractFactory(
+            'CanaryUpkeep'
+        )
+        canaryUpkeep = await canaryUpkeepFactory.deploy(ethers.constants.AddressZero)
+        await canaryUpkeep.deployed()
+    })
+
+    afterEach(async () => {
+        await reset()
+    })
+
+    describe('checkUpkeep()', () => {
+        it('returns true when sufficient time passes', async () => {
+            await fastForward(moment.duration(6, 'minutes').asSeconds())
+            expect(await canaryUpkeep.checkUpkeep('0x')).to.be.true
+        })
+
+        it('returns false when insufficient time passes', async () => {
+            await fastForward(moment.duration(2, 'minutes').asSeconds())
+            const [ needsUpkeep ] = await canaryUpkeep.checkUpkeep('0x')
+            assert.isFalse(needsUpkeep)
+        })
+
+        it('returns false when keeper array is empty', async () => {
+            await mockContract.mock.getState.returns({}, {}, emptyKeeperAddresses)
+            await fastForward(moment.duration(6, 'minutes').asSeconds())
+            const [ needsUpkeep ] = await canaryUpkeep.checkUpkeep('0x')
+            assert.isFalse(needsUpkeep)
+        })
+    })
+
+    describe('performUpkeep()', () => {
+        it('enforces that transaction origin is the anticipated keeper', async () => {
+            const oldTimestamp = await canaryUpkeep.connect(keeperAddresses[0]).getTimestamp()
+            await fastForward(moment.duration(6, 'minutes').asSeconds())
+            await canaryUpkeep.connect(keeperAddresses[0]).performUpkeep('0x')
+
+            const keeperIndex = await canaryUpkeep.connect(keeperAddresses[0]).getKeeperIndex()
+            assert.equal(keeperIndex, BigNumber.from(1), "keeper index needs to increment by 1 after performUpkeep")
+
+            const newTimestamp = await canaryUpkeep.connect(keeperAddresses[0]).getTimestamp()
+            const interval = await canaryUpkeep.connect(keeperAddresses[0]).getInterval()
+            assert.isAtLeast(newTimestamp.toNumber() - oldTimestamp.toNumber(), interval.toNumber(), "timestamp needs to be updated after performUpkeep")
+        })
+
+        it('reverts if the keeper array is empty', async () => {
+            await mockContract.mock.getState.returns({}, {}, emptyKeeperAddresses)
+            // await evmRevert(
+            //     canaryUpkeep.connect(keeperAddresses[0]).performUpkeep('0x'),
+            //     "no keeper nodes exists");
+            await expect(canaryUpkeep.connect(keeperAddresses[0]).performUpkeep('0x')).to.be.revertedWith(
+                "no keeper nodes exists"
+            )
+        })
+
+        it('reverts if not enough time has passed', async () => {
+            await fastForward(moment.duration(3, 'minutes').asSeconds())
+            await evmRevert(
+                canaryUpkeep.connect(keeperAddresses[0]).performUpkeep('0x'),
+                "Not enough time has passed after the previous upkeep");
+        })
+
+        it('reverts if an incorrect keeper tries to perform upkeep', async () => {
+            await fastForward(moment.duration(6, 'minutes').asSeconds())
+            await evmRevert(
+                canaryUpkeep.connect(keeperAddresses[1]).performUpkeep('0x'),
+                "transaction origin is not the anticipated keeper.");
+        })
+    })
+})

--- a/contracts/test/v0.8/CanaryUpkeep.test.ts
+++ b/contracts/test/v0.8/CanaryUpkeep.test.ts
@@ -58,7 +58,7 @@ before(async () => {
   ]
 })
 
-describe.only('CanaryUpkeep', () => {
+describe('CanaryUpkeep', () => {
   beforeEach(async () => {
     const keeperRegistryFactory = await ethers.getContractFactory(
       'KeeperRegistry',

--- a/contracts/test/v0.8/CanaryUpkeep.test.ts
+++ b/contracts/test/v0.8/CanaryUpkeep.test.ts
@@ -57,7 +57,7 @@ before(async () => {
   ]
 })
 
-describe.only('CanaryUpkeep', () => {
+describe('CanaryUpkeep', () => {
   beforeEach(async () => {
     const keeperRegistryFactory = await ethers.getContractFactory(
       'KeeperRegistry',

--- a/contracts/test/v0.8/CanaryUpkeep.test.ts
+++ b/contracts/test/v0.8/CanaryUpkeep.test.ts
@@ -45,20 +45,20 @@ const config = {
   registrar,
 }
 
-before(async () => {
-  personas = (await getUsers()).personas
-  owner = personas.Default
-  nelly = personas.Nelly
-  nancy = personas.Nancy
-  ned = personas.Ned
-  keeperAddresses = [
-    await nelly.getAddress(),
-    await nancy.getAddress(),
-    await ned.getAddress(),
-  ]
-})
-
 describe('CanaryUpkeep', () => {
+  before(async () => {
+    personas = (await getUsers()).personas
+    owner = personas.Default
+    nelly = personas.Nelly
+    nancy = personas.Nancy
+    ned = personas.Ned
+    keeperAddresses = [
+      await nelly.getAddress(),
+      await nancy.getAddress(),
+      await ned.getAddress(),
+    ]
+  })
+
   beforeEach(async () => {
     const keeperRegistryFactory = await ethers.getContractFactory(
       'KeeperRegistry',
@@ -197,7 +197,7 @@ describe('CanaryUpkeep', () => {
     it('reverts if the keeper array is empty', async () => {
       await evmRevert(
         canaryUpkeep.connect(nelly).performUpkeep('0x'),
-        'no keeper nodes exists',
+        `NoKeeperNodes`,
       )
     })
 
@@ -206,7 +206,7 @@ describe('CanaryUpkeep', () => {
       await fastForward(moment.duration(3, 'minutes').asSeconds())
       await evmRevert(
         canaryUpkeep.connect(nelly).performUpkeep('0x'),
-        'Not enough time has passed after the previous upkeep',
+        `InsufficientInterval`,
       )
     })
 

--- a/contracts/test/v0.8/CanaryUpkeep.test.ts
+++ b/contracts/test/v0.8/CanaryUpkeep.test.ts
@@ -17,6 +17,7 @@ let ned: Signer
 let keeperAddresses: string[]
 let keeperRegistry: KeeperRegistry
 
+const defaultInterval = 300
 const paymentPremiumPPB = BigNumber.from(250000000)
 const flatFeeMicroLink = BigNumber.from(0)
 const blockCountPerTurn = BigNumber.from(3)
@@ -57,7 +58,7 @@ before(async () => {
   ]
 })
 
-describe('CanaryUpkeep', () => {
+describe.only('CanaryUpkeep', () => {
   beforeEach(async () => {
     const keeperRegistryFactory = await ethers.getContractFactory(
       'KeeperRegistry',
@@ -75,7 +76,7 @@ describe('CanaryUpkeep', () => {
     const canaryUpkeepFactory = await ethers.getContractFactory('CanaryUpkeep')
     canaryUpkeep = await canaryUpkeepFactory
       .connect(owner)
-      .deploy(keeperRegistry.address)
+      .deploy(keeperRegistry.address, defaultInterval)
     await canaryUpkeep.deployed()
   })
 
@@ -120,7 +121,7 @@ describe('CanaryUpkeep', () => {
     it('returns false when keeper array is empty', async () => {
       await fastForward(moment.duration(6, 'minutes').asSeconds())
       const [needsUpkeep] = await canaryUpkeep.checkUpkeep('0x')
-      assert.isFalse(needsUpkeep)
+      assert.isTrue(needsUpkeep)
     })
   })
 

--- a/contracts/test/v0.8/CanaryUpkeep.test.ts
+++ b/contracts/test/v0.8/CanaryUpkeep.test.ts
@@ -1,42 +1,76 @@
 import { ethers } from 'hardhat'
-import {BigNumber} from "ethers";
+import {BigNumber, Signer} from "ethers";
 import moment from "moment";
-import {assert, expect} from "chai";
+import {assert} from "chai";
 import { CanaryUpkeep } from '../../typechain/CanaryUpkeep'
-import KeeperRegistryAbi from '../../abi/src/v0.8/KeeperRegistry.sol/KeeperRegistry.json'
+import { KeeperRegistry } from '../../typechain/KeeperRegistry';
 import { fastForward, reset } from '../test-helpers/helpers'
-import {deployMockContract, MockContract} from '@ethereum-waffle/mock-contract'
-import {SignerWithAddress} from "@nomiclabs/hardhat-ethers/signers"
+import { getUsers, Personas } from '../test-helpers/setup'
 import {evmRevert} from "../test-helpers/matchers";
 
+let personas: Personas
 let canaryUpkeep: CanaryUpkeep
-let nelly: SignerWithAddress
-let nancy: SignerWithAddress
-let neo: SignerWithAddress
+let owner: Signer
+let nelly: Signer
+let nancy: Signer
+let ned: Signer
 let keeperAddresses: string[]
-let emptyKeeperAddresses: string[]
-let mockContract: MockContract
+let keeperRegistry: KeeperRegistry
+
+const paymentPremiumPPB = BigNumber.from(250000000)
+const flatFeeMicroLink = BigNumber.from(0)
+const blockCountPerTurn = BigNumber.from(3)
+const stalenessSeconds = BigNumber.from(43820)
+const gasCeilingMultiplier = BigNumber.from(1)
+const checkGasLimit = BigNumber.from(20000000)
+const fallbackGasPrice = BigNumber.from(200)
+const fallbackLinkPrice = BigNumber.from(200000000)
+const maxPerformGas = BigNumber.from(5000000)
+const minUpkeepSpend = BigNumber.from('1000000000000000000')
+const transcoder = ethers.constants.AddressZero
+const registrar = ethers.constants.AddressZero
+const config = {
+    paymentPremiumPPB,
+    flatFeeMicroLink,
+    blockCountPerTurn,
+    checkGasLimit,
+    stalenessSeconds,
+    gasCeilingMultiplier,
+    minUpkeepSpend,
+    maxPerformGas,
+    fallbackGasPrice,
+    fallbackLinkPrice,
+    transcoder,
+    registrar
+}
+
+before(async () => {
+    personas = (await getUsers()).personas
+    owner = personas.Default
+    nelly = personas.Nelly
+    nancy = personas.Nancy
+    ned = personas.Ned
+    keeperAddresses = [await nelly.getAddress(), await nancy.getAddress(), await ned.getAddress()]
+})
 
 describe.only('CanaryUpkeep', () => {
-    beforeEach(async () => {
-        const accounts = await ethers.getSigners()
-        const admin = accounts[1]
-        // initialize fake node operators
-        nelly = accounts[2]
-        nancy = accounts[3]
-        neo = accounts[4]
-        mockContract = await deployMockContract(admin as any, KeeperRegistryAbi);
 
-        // this object is the return type of getState function of KeeperRegistry. we still need to investigate how
-        // to create an object for the return type. for the purpose of this test, only the address array is needed.
-        // hence, the first two sub structs are omitted.
-        keeperAddresses = [nelly.address, nancy.address, neo.address]
-        const getStateReturn = [{}, {}, keeperAddresses];
-        await mockContract.mock.getState.returns(...getStateReturn)
+    beforeEach(async () => {
+        const keeperRegistryFactory = await ethers.getContractFactory(
+            'KeeperRegistry'
+        )
+        keeperRegistry = await keeperRegistryFactory.connect(owner).deploy(
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+            ethers.constants.AddressZero,
+            config
+        )
+        await keeperRegistry.deployed()
+
         const canaryUpkeepFactory = await ethers.getContractFactory(
             'CanaryUpkeep'
         )
-        canaryUpkeep = await canaryUpkeepFactory.deploy(ethers.constants.AddressZero)
+        canaryUpkeep = await canaryUpkeepFactory.connect(owner).deploy(keeperRegistry.address)
         await canaryUpkeep.deployed()
     })
 
@@ -47,18 +81,19 @@ describe.only('CanaryUpkeep', () => {
     describe('checkUpkeep()', () => {
         it('returns true when sufficient time passes', async () => {
             await fastForward(moment.duration(6, 'minutes').asSeconds())
+            await keeperRegistry.setKeepers(keeperAddresses, keeperAddresses)
             const [ needsUpkeep ] = await canaryUpkeep.checkUpkeep('0x')
             assert.isTrue(needsUpkeep)
         })
 
         it('returns false when insufficient time passes', async () => {
             await fastForward(moment.duration(2, 'minutes').asSeconds())
+            await keeperRegistry.setKeepers(keeperAddresses, keeperAddresses)
             const [ needsUpkeep ] = await canaryUpkeep.checkUpkeep('0x')
             assert.isFalse(needsUpkeep)
         })
 
         it('returns false when keeper array is empty', async () => {
-            await mockContract.mock.getState.returns({}, {}, emptyKeeperAddresses)
             await fastForward(moment.duration(6, 'minutes').asSeconds())
             const [ needsUpkeep ] = await canaryUpkeep.checkUpkeep('0x')
             assert.isFalse(needsUpkeep)
@@ -67,39 +102,60 @@ describe.only('CanaryUpkeep', () => {
 
     describe('performUpkeep()', () => {
         it('enforces that transaction origin is the anticipated keeper', async () => {
-            const oldTimestamp = await canaryUpkeep.connect(keeperAddresses[0]).getTimestamp()
+            await keeperRegistry.setKeepers(keeperAddresses, keeperAddresses)
+
+            const oldTimestamp = await canaryUpkeep.connect(nelly).getTimestamp()
+            const oldKeeperIndex = await canaryUpkeep.connect(nelly).getKeeperIndex()
             await fastForward(moment.duration(6, 'minutes').asSeconds())
-            await canaryUpkeep.connect(keeperAddresses[0]).performUpkeep('0x')
+            await canaryUpkeep.connect(nelly).performUpkeep('0x')
+            const newKeeperIndex = await canaryUpkeep.connect(nelly).getKeeperIndex()
+            assert.equal(newKeeperIndex.toNumber() - oldKeeperIndex.toNumber(), 1, "keeper index needs to increment by 1 after performUpkeep")
 
-            const keeperIndex = await canaryUpkeep.connect(keeperAddresses[0]).getKeeperIndex()
-            assert.equal(keeperIndex, BigNumber.from(1), "keeper index needs to increment by 1 after performUpkeep")
-
-            const newTimestamp = await canaryUpkeep.connect(keeperAddresses[0]).getTimestamp()
-            const interval = await canaryUpkeep.connect(keeperAddresses[0]).getInterval()
+            const newTimestamp = await canaryUpkeep.connect(nelly).getTimestamp()
+            const interval = await canaryUpkeep.connect(nelly).getInterval()
             assert.isAtLeast(newTimestamp.toNumber() - oldTimestamp.toNumber(), interval.toNumber(), "timestamp needs to be updated after performUpkeep")
         })
 
+        it('enforces that keeper index will reset to zero after visiting the last keeper', async () => {
+            await keeperRegistry.setKeepers(keeperAddresses, keeperAddresses)
+
+            await fastForward(moment.duration(6, 'minutes').asSeconds())
+            await canaryUpkeep.connect(nelly).performUpkeep('0x')
+
+            await fastForward(moment.duration(6, 'minutes').asSeconds())
+            await canaryUpkeep.connect(nancy).performUpkeep('0x')
+
+            await fastForward(moment.duration(6, 'minutes').asSeconds())
+            await canaryUpkeep.connect(ned).performUpkeep('0x')
+
+            const keeperIndex = await canaryUpkeep.connect(ned).getKeeperIndex()
+            assert.equal(keeperIndex.toNumber(), keeperAddresses.length, "Keeper index is not updated properly")
+
+            await fastForward(moment.duration(6, 'minutes').asSeconds())
+            await canaryUpkeep.connect(nelly).performUpkeep('0x')
+            const newKeeperIndex = await canaryUpkeep.connect(ned).getKeeperIndex()
+            assert.equal(newKeeperIndex.toNumber(), 1, "Keeper index does not reset to zero after visiting the last keeper")
+        })
+
         it('reverts if the keeper array is empty', async () => {
-            await mockContract.mock.getState.returns({}, {}, emptyKeeperAddresses)
-            // await evmRevert(
-            //     canaryUpkeep.connect(keeperAddresses[0]).performUpkeep('0x'),
-            //     "no keeper nodes exists");
-            await expect(canaryUpkeep.connect(keeperAddresses[0]).performUpkeep('0x')).to.be.revertedWith(
-                "no keeper nodes exists"
-            )
+            await evmRevert(
+                canaryUpkeep.connect(nelly).performUpkeep('0x'),
+                "no keeper nodes exists");
         })
 
         it('reverts if not enough time has passed', async () => {
+            await keeperRegistry.setKeepers(keeperAddresses, keeperAddresses)
             await fastForward(moment.duration(3, 'minutes').asSeconds())
             await evmRevert(
-                canaryUpkeep.connect(keeperAddresses[0]).performUpkeep('0x'),
+                canaryUpkeep.connect(nelly).performUpkeep('0x'),
                 "Not enough time has passed after the previous upkeep");
         })
 
         it('reverts if an incorrect keeper tries to perform upkeep', async () => {
+            await keeperRegistry.setKeepers(keeperAddresses, keeperAddresses)
             await fastForward(moment.duration(6, 'minutes').asSeconds())
             await evmRevert(
-                canaryUpkeep.connect(keeperAddresses[1]).performUpkeep('0x'),
+                canaryUpkeep.connect(nancy).performUpkeep('0x'),
                 "transaction origin is not the anticipated keeper.");
         })
     })


### PR DESCRIPTION
in order to make sure all keepers are healthy:
1. create a canary upkeep which requires a different keeper's service every 5 mins. 
2. added typescript tests.