### PR TITLE
.github/workflows: disable 'Install terrad' job and skip tests

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -67,8 +67,8 @@ jobs:
             ${{ runner.os }}-build-
             ${{ runner.os }}-
       - run: yarn install --frozen-lockfile
-      - name: Install terrad
-        run: ./tools/ci/install_terrad
+#      - name: Install terrad
+#        run: ./tools/ci/install_terrad
       - name: Install solana cli
         run: ./tools/ci/install_solana
       - name: Setup DB

--- a/core/chains/terra/terratxm/txm_test.go
+++ b/core/chains/terra/terratxm/txm_test.go
@@ -34,6 +34,7 @@ import (
 )
 
 func TestTxm_Integration(t *testing.T) {
+	t.Skip("requires terrad")
 	cfg, db := heavyweight.FullTestDBNoFixtures(t, "terra_txm")
 	lggr := logger.TestLogger(t)
 	chainID := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))

--- a/core/cmd/terra_transaction_commands_test.go
+++ b/core/cmd/terra_transaction_commands_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 func TestClient_SendTerraCoins(t *testing.T) {
+	t.Skip("requires terrad")
 	chainID := terratest.RandomChainID()
 	accounts, _, tendermintURL := terraclient.SetupLocalTerraNode(t, chainID)
 	require.Greater(t, len(accounts), 1)


### PR DESCRIPTION
It looks like they removed all of the releases from github: https://github.com/terra-money/core/releases
```
Run ./tools/ci/install_terrad
--2022-05-21 15:34:59--  https://github.com/terra-money/core/releases/download/v0.5.14/terra_0.5.14_Linux_x[8](https://github.com/smartcontractkit/chainlink/runs/6537822264?check_suite_focus=true#step:11:9)6_64.tar.gz
Resolving github.com (github.com)... 140.82.114.3
Connecting to github.com (github.com)|140.82.114.3|:443... connected.
HTTP request sent, awaiting response... 404 Not Found
2022-05-21 15:34:5[9](https://github.com/smartcontractkit/chainlink/runs/6537822264?check_suite_focus=true#step:11:10) ERROR 404: Not Found.
```
https://github.com/smartcontractkit/chainlink/runs/6537822264?check_suite_focus=true
