### PR TITLE
Add config var for operator factory address

### DIFF
--- a/core/chains/evm/config/chain_specific_config.go
+++ b/core/chains/evm/config/chain_specific_config.go
@@ -52,6 +52,7 @@ type (
 		headTrackerMaxBufferSize                       uint32
 		headTrackerSamplingInterval                    time.Duration
 		linkContractAddress                            string
+		operatorFactoryAddress                         string
 		logBackfillBatchSize                           uint32
 		logPollInterval                                time.Duration
 		maxGasPriceWei                                 big.Int
@@ -128,6 +129,7 @@ func setChainSpecificConfigDefaultSets() {
 		headTrackerMaxBufferSize:              3,
 		headTrackerSamplingInterval:           1 * time.Second,
 		linkContractAddress:                   "",
+		operatorFactoryAddress:                "",
 		logBackfillBatchSize:                  100,
 		logPollInterval:                       15 * time.Second,
 		maxGasPriceWei:                        *assets.GWei(100000),
@@ -155,20 +157,26 @@ func setChainSpecificConfigDefaultSets() {
 	mainnet.eip1559DynamicFees = true // enable EIP-1559 on Eth Mainnet and all testnets
 	mainnet.linkContractAddress = "0x514910771AF9Ca656af840dff83E8264EcF986CA"
 	mainnet.minimumContractPayment = assets.NewLinkFromJuels(100000000000000000) // 0.1 LINK
+	mainnet.operatorFactoryAddress = "0x3e64cd889482443324f91bfa9c84fe72a511f48a"
+
 	// NOTE: There are probably other variables we can tweak for Kovan and other
 	// test chains, but the defaults have been working fine and if it ain't
 	// broke, don't fix it.
 	ropsten := mainnet
 	ropsten.linkContractAddress = "0x20fe562d797a42dcb3399062ae9546cd06f63280"
+	ropsten.operatorFactoryAddress = ""
 	kovan := mainnet
 	kovan.linkContractAddress = "0xa36085F69e2889c224210F603D836748e7dC0088"
+	kovan.operatorFactoryAddress = "0x8007e24251b1D2Fc518Eb843A701d9cD21fe0aA3"
 	kovan.eip1559DynamicFees = false // FIXME: Kovan has strange behaviour with EIP1559, see: https://app.shortcut.com/chainlinklabs/story/34098/kovan-can-emit-blocks-that-violate-assumptions-in-block-history-estimator
 	goerli := mainnet
 	goerli.linkContractAddress = "0x326c977e6efc84e512bb9c30f76e30c160ed06fb"
 	goerli.eip1559DynamicFees = false // TODO: EIP1559 on goerli has not been adequately tested, see: https://app.shortcut.com/chainlinklabs/story/34098/kovan-can-emit-blocks-that-violate-assumptions-in-block-history-estimator
+	goerli.operatorFactoryAddress = ""
 	rinkeby := mainnet
 	rinkeby.linkContractAddress = "0x01BE23585060835E02B77ef475b0Cc51aA1e0709"
 	rinkeby.eip1559DynamicFees = false // TODO: EIP1559 on rinkeby has not been adequately tested, see: https://app.shortcut.com/chainlinklabs/story/34098/kovan-can-emit-blocks-that-violate-assumptions-in-block-history-estimator
+	rinkeby.operatorFactoryAddress = ""
 
 	// xDai currently uses AuRa (like Parity) consensus so finality rules will be similar to parity
 	// See: https://www.poa.network/for-users/whitepaper/poadao-v1/proof-of-authority

--- a/core/chains/evm/config/config.go
+++ b/core/chains/evm/config/config.go
@@ -69,6 +69,7 @@ type ChainScopedOnlyConfig interface {
 	ChainType() config.ChainType
 	KeySpecificMaxGasPriceWei(addr gethcommon.Address) *big.Int
 	LinkContractAddress() string
+	OperatorFactoryAddress() string
 	MinIncomingConfirmations() uint32
 	MinimumContractPayment() *assets.Link
 	NodeNoNewHeadsThreshold() time.Duration
@@ -744,6 +745,24 @@ func (c *chainScopedConfig) LinkContractAddress() string {
 	c.persistMu.RUnlock()
 	if p.Valid {
 		c.logPersistedOverrideOnce("LinkContractAddress", p.String)
+		return p.String
+	}
+	return c.defaultSet.linkContractAddress
+}
+
+// OperatorFactoryAddress represents the address of the official LINK token
+// contract on the current Chain
+func (c *chainScopedConfig) OperatorFactoryAddress() string {
+	val, ok := c.GeneralConfig.GlobalOperatorFactoryAddress()
+	if ok {
+		c.logEnvOverrideOnce("OperatorFactoryAddress", val)
+		return val
+	}
+	c.persistMu.RLock()
+	p := c.persistedCfg.OperatorFactoryAddress
+	c.persistMu.RUnlock()
+	if p.Valid {
+		c.logPersistedOverrideOnce("OperatorFactoryAddress", p.String)
 		return p.String
 	}
 	return c.defaultSet.linkContractAddress

--- a/core/chains/evm/config/config_test.go
+++ b/core/chains/evm/config/config_test.go
@@ -161,6 +161,28 @@ func TestChainScopedConfig(t *testing.T) {
 			assert.Equal(t, val, cfg.LinkContractAddress())
 		})
 	})
+
+	t.Run("OperatorFactoryAddress", func(t *testing.T) {
+		t.Run("uses chain-specific default value when nothing is set", func(t *testing.T) {
+			assert.Equal(t, "", cfg.OperatorFactoryAddress())
+		})
+
+		t.Run("uses chain-specific override value when that is set", func(t *testing.T) {
+			val := testutils.NewAddress().String()
+			evmconfig.UpdatePersistedCfg(cfg, func(cfg *evmtypes.ChainCfg) {
+				cfg.OperatorFactoryAddress = null.StringFrom(val)
+			})
+
+			assert.Equal(t, val, cfg.OperatorFactoryAddress())
+		})
+
+		t.Run("uses global value when that is set", func(t *testing.T) {
+			val := testutils.NewAddress().String()
+			gcfg.Overrides.OperatorFactoryAddress = null.StringFrom(val)
+
+			assert.Equal(t, val, cfg.OperatorFactoryAddress())
+		})
+	})
 }
 
 func TestChainScopedConfig_BSCDefaults(t *testing.T) {

--- a/core/chains/evm/config/mocks/chain_scoped_config.go
+++ b/core/chains/evm/config/mocks/chain_scoped_config.go
@@ -2259,6 +2259,27 @@ func (_m *ChainScopedConfig) GlobalLinkContractAddress() (string, bool) {
 	return r0, r1
 }
 
+// GlobalOperatorFactoryAddress provides a mock function with given fields:
+func (_m *ChainScopedConfig) GlobalOperatorFactoryAddress() (string, bool) {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 bool
+	if rf, ok := ret.Get(1).(func() bool); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+
+	return r0, r1
+}
+
 // GlobalMinIncomingConfirmations provides a mock function with given fields:
 func (_m *ChainScopedConfig) GlobalMinIncomingConfirmations() (uint32, bool) {
 	ret := _m.Called()
@@ -2811,6 +2832,20 @@ func (_m *ChainScopedConfig) LeaseLockRefreshInterval() time.Duration {
 
 // LinkContractAddress provides a mock function with given fields:
 func (_m *ChainScopedConfig) LinkContractAddress() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// OperatorFactoryAddress provides a mock function with given fields:
+func (_m *ChainScopedConfig) OperatorFactoryAddress() string {
 	ret := _m.Called()
 
 	var r0 string

--- a/core/chains/evm/types/types.go
+++ b/core/chains/evm/types/types.go
@@ -84,6 +84,7 @@ type ChainCfg struct {
 	GasEstimatorMode                               null.String
 	KeySpecific                                    map[string]ChainCfg
 	LinkContractAddress                            null.String
+	OperatorFactoryAddress                         null.String
 	MinIncomingConfirmations                       null.Int
 	MinimumContractPayment                         *assets.Link
 	OCRObservationTimeout                          *models.Duration

--- a/core/config/envvar/schema.go
+++ b/core/config/envvar/schema.go
@@ -152,6 +152,7 @@ type ConfigSchema struct {
 	EvmLogPollInterval                time.Duration `env:"ETH_LOG_POLL_INTERVAL"`
 	EvmRPCDefaultBatchSize            uint32        `env:"ETH_RPC_DEFAULT_BATCH_SIZE"`
 	LinkContractAddress               string        `env:"LINK_CONTRACT_ADDRESS"`
+	OperatorFactoryAddress            string        `env:"OPERATOR_FACTORY_ADDRESS"`
 	MinIncomingConfirmations          uint32        `env:"MIN_INCOMING_CONFIRMATIONS"`
 	MinimumContractPayment            assets.Link   `env:"MINIMUM_CONTRACT_PAYMENT_LINK_JUELS"`
 	// Node liveness checking

--- a/core/config/envvar/schema_test.go
+++ b/core/config/envvar/schema_test.go
@@ -127,6 +127,7 @@ func TestConfigSchema(t *testing.T) {
 		"LeaseLockDuration":                              "LEASE_LOCK_DURATION",
 		"LeaseLockRefreshInterval":                       "LEASE_LOCK_REFRESH_INTERVAL",
 		"LinkContractAddress":                            "LINK_CONTRACT_ADDRESS",
+		"OperatorFactoryAddress":                         "OPERATOR_FACTORY_ADDRESS",
 		"LogFileDir":                                     "LOG_FILE_DIR",
 		"LogLevel":                                       "LOG_LEVEL",
 		"LogSQL":                                         "LOG_SQL",

--- a/core/config/general_config.go
+++ b/core/config/general_config.go
@@ -221,6 +221,7 @@ type GlobalConfig interface {
 	GlobalFlagsContractAddress() (string, bool)
 	GlobalGasEstimatorMode() (string, bool)
 	GlobalLinkContractAddress() (string, bool)
+	GlobalOperatorFactoryAddress() (string, bool)
 	GlobalMinIncomingConfirmations() (uint32, bool)
 	GlobalMinimumContractPayment() (*assets.Link, bool)
 	GlobalNodeNoNewHeadsThreshold() (time.Duration, bool)
@@ -1285,6 +1286,9 @@ func (c *generalConfig) GlobalChainType() (string, bool) {
 }
 func (c *generalConfig) GlobalLinkContractAddress() (string, bool) {
 	return lookupEnv(c, envvar.Name("LinkContractAddress"), parse.String)
+}
+func (c *generalConfig) GlobalOperatorFactoryAddress() (string, bool) {
+	return lookupEnv(c, envvar.Name("OperatorFactoryAddress"), parse.String)
 }
 func (c *generalConfig) GlobalMinIncomingConfirmations() (uint32, bool) {
 	return lookupEnv(c, envvar.Name("MinIncomingConfirmations"), parse.Uint32)

--- a/core/config/mocks/general_config.go
+++ b/core/config/mocks/general_config.go
@@ -1702,6 +1702,27 @@ func (_m *GeneralConfig) GlobalLinkContractAddress() (string, bool) {
 	return r0, r1
 }
 
+// GlobalOperatorFactoryAddress provides a mock function with given fields:
+func (_m *GeneralConfig) GlobalOperatorFactoryAddress() (string, bool) {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	var r1 bool
+	if rf, ok := ret.Get(1).(func() bool); ok {
+		r1 = rf()
+	} else {
+		r1 = ret.Get(1).(bool)
+	}
+
+	return r0, r1
+}
+
 // GlobalMinIncomingConfirmations provides a mock function with given fields:
 func (_m *GeneralConfig) GlobalMinIncomingConfirmations() (uint32, bool) {
 	ret := _m.Called()

--- a/core/internal/testutils/configtest/general_config.go
+++ b/core/internal/testutils/configtest/general_config.go
@@ -100,6 +100,7 @@ type GeneralConfigOverrides struct {
 	TriggerFallbackDBPollInterval           *time.Duration
 	KeySpecific                             map[string]types.ChainCfg
 	LinkContractAddress                     null.String
+	OperatorFactoryAddress                  null.String
 
 	// Feature Flags
 	FeatureExternalInitiators null.Bool
@@ -756,4 +757,12 @@ func (c *TestGeneralConfig) GlobalLinkContractAddress() (string, bool) {
 		return c.Overrides.LinkContractAddress.String, true
 	}
 	return c.GeneralConfig.GlobalLinkContractAddress()
+}
+
+// GlobalOperatorFactoryAddress allows to override the LINK contract address
+func (c *TestGeneralConfig) GlobalOperatorFactoryAddress() (string, bool) {
+	if c.Overrides.OperatorFactoryAddress.Valid {
+		return c.Overrides.OperatorFactoryAddress.String, true
+	}
+	return c.GeneralConfig.GlobalOperatorFactoryAddress()
 }


### PR DESCRIPTION
This PR adds config var for operator factory contract and sets the defaults for chains with this contract deployed. We use OperatorFactory to deploy new operators/forwarders and transfer ownership

Current defaults:
Mainnet: https://etherscan.io/address/0x3e64cd889482443324f91bfa9c84fe72a511f48a
Kovan: https://kovan.etherscan.io/address/0x8007e24251b1D2Fc518Eb843A701d9cD21fe0aA3