### PR TITLE
Fetch upkeep ID in keeper tests and pass to cancel upkeep

### DIFF
--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/rs/zerolog v1.26.1
 	github.com/satori/go.uuid v1.2.0
-	github.com/smartcontractkit/chainlink-testing-framework v1.2.3-0.20220523123753-804ebbb6bbf7
+	github.com/smartcontractkit/chainlink-testing-framework v1.2.3-0.20220523174855-155f00640dad
 	github.com/smartcontractkit/helmenv v1.2.2
 )
 

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/onsi/gomega v1.19.0
 	github.com/rs/zerolog v1.26.1
 	github.com/satori/go.uuid v1.2.0
-	github.com/smartcontractkit/chainlink-testing-framework v1.2.3-0.20220523174855-155f00640dad
+	github.com/smartcontractkit/chainlink-testing-framework v1.2.3-0.20220523192039-ef1612f54d71
 	github.com/smartcontractkit/helmenv v1.2.2
 )
 

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1498,8 +1498,8 @@ github.com/slack-go/slack v0.10.3 h1:kKYwlKY73AfSrtAk9UHWCXXfitudkDztNI9GYBviLxw
 github.com/slack-go/slack v0.10.3/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/smartcontractkit/chainlink v0.8.10-0.20200825114219-81dd2fc95bac/go.mod h1:j7qIYHGCN4QqMXdO8g8A9dmUT5vKFmkxPSbjAIfrfNU=
 github.com/smartcontractkit/chainlink v0.9.5-0.20201207211610-6c7fee37d5b7/go.mod h1:kmdLJbVZRCnBLiL6gG+U+1+0ofT3bB48DOF8tjQvcoI=
-github.com/smartcontractkit/chainlink-testing-framework v1.2.3-0.20220523174855-155f00640dad h1:f65QMeaEliQ600HiJf4u1lFoxTJAUTiXqMPOfbuXBQo=
-github.com/smartcontractkit/chainlink-testing-framework v1.2.3-0.20220523174855-155f00640dad/go.mod h1:DmpC8nRuD0hWG/u2zyXpmV1mxRtUi7wRSjy9+tCz2Ww=
+github.com/smartcontractkit/chainlink-testing-framework v1.2.3-0.20220523192039-ef1612f54d71 h1:8vSc64eewOgMST9P/IU9+H9SQq0SYXny9Wxkva+GCeo=
+github.com/smartcontractkit/chainlink-testing-framework v1.2.3-0.20220523192039-ef1612f54d71/go.mod h1:DmpC8nRuD0hWG/u2zyXpmV1mxRtUi7wRSjy9+tCz2Ww=
 github.com/smartcontractkit/helmenv v1.2.2 h1:jP6dHikMXEg90h4PiH1o3DxrC9YncRnXpEx2NFL9FF4=
 github.com/smartcontractkit/helmenv v1.2.2/go.mod h1:hZDi/s7pBOdkdTQRh9X3tiQy1IYF7t/0mYd8gaFWNqE=
 github.com/smartcontractkit/libocr v0.0.0-20201203233047-5d9b24f0cbb5/go.mod h1:bfdSuLnBWCkafDvPGsQ1V6nrXhg046gh227MKi4zkpc=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1498,8 +1498,8 @@ github.com/slack-go/slack v0.10.3 h1:kKYwlKY73AfSrtAk9UHWCXXfitudkDztNI9GYBviLxw
 github.com/slack-go/slack v0.10.3/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/smartcontractkit/chainlink v0.8.10-0.20200825114219-81dd2fc95bac/go.mod h1:j7qIYHGCN4QqMXdO8g8A9dmUT5vKFmkxPSbjAIfrfNU=
 github.com/smartcontractkit/chainlink v0.9.5-0.20201207211610-6c7fee37d5b7/go.mod h1:kmdLJbVZRCnBLiL6gG+U+1+0ofT3bB48DOF8tjQvcoI=
-github.com/smartcontractkit/chainlink-testing-framework v1.2.3-0.20220523123753-804ebbb6bbf7 h1:/qBFg9sjaa5BiXwhmKPMT97HV9HcErFW26vi4efWmoU=
-github.com/smartcontractkit/chainlink-testing-framework v1.2.3-0.20220523123753-804ebbb6bbf7/go.mod h1:DmpC8nRuD0hWG/u2zyXpmV1mxRtUi7wRSjy9+tCz2Ww=
+github.com/smartcontractkit/chainlink-testing-framework v1.2.3-0.20220523174855-155f00640dad h1:f65QMeaEliQ600HiJf4u1lFoxTJAUTiXqMPOfbuXBQo=
+github.com/smartcontractkit/chainlink-testing-framework v1.2.3-0.20220523174855-155f00640dad/go.mod h1:DmpC8nRuD0hWG/u2zyXpmV1mxRtUi7wRSjy9+tCz2Ww=
 github.com/smartcontractkit/helmenv v1.2.2 h1:jP6dHikMXEg90h4PiH1o3DxrC9YncRnXpEx2NFL9FF4=
 github.com/smartcontractkit/helmenv v1.2.2/go.mod h1:hZDi/s7pBOdkdTQRh9X3tiQy1IYF7t/0mYd8gaFWNqE=
 github.com/smartcontractkit/libocr v0.0.0-20201203233047-5d9b24f0cbb5/go.mod h1:bfdSuLnBWCkafDvPGsQ1V6nrXhg046gh227MKi4zkpc=

--- a/integration-tests/performance/keeper_test.go
+++ b/integration-tests/performance/keeper_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Keeper suite @keeper", func() {
 			linkToken, err = contractDeployer.DeployLinkTokenContract()
 			Expect(err).ShouldNot(HaveOccurred(), "Deploying Link Token Contract shouldn't fail")
 
-			r, consumers := actions.DeployKeeperContracts(
+			r, consumers, _ := actions.DeployKeeperContracts(
 				ethereum.RegistryVersion_1_1,
 				contracts.KeeperRegistrySettings{
 					PaymentPremiumPPB:    uint32(200000000),

--- a/integration-tests/smoke/keeper_test.go
+++ b/integration-tests/smoke/keeper_test.go
@@ -29,6 +29,7 @@ func getKeeperSuite(registryVersion ethereum.KeeperRegistryVersion) func() {
 			contractDeployer contracts.ContractDeployer
 			registry         contracts.KeeperRegistry
 			consumer         contracts.KeeperConsumer
+			upkeepID         *big.Int
 			linkToken        contracts.LinkToken
 			chainlinkNodes   []client.Chainlink
 			env              *environment.Environment
@@ -70,7 +71,7 @@ func getKeeperSuite(registryVersion ethereum.KeeperRegistryVersion) func() {
 				linkToken, err = contractDeployer.DeployLinkTokenContract()
 				Expect(err).ShouldNot(HaveOccurred(), "Deploying Link Token Contract shouldn't fail")
 
-				r, consumers := actions.DeployKeeperContracts(
+				r, consumers, upkeepIDs := actions.DeployKeeperContracts(
 					registryVersion,
 					contracts.KeeperRegistrySettings{
 						PaymentPremiumPPB:    uint32(200000000),
@@ -91,6 +92,7 @@ func getKeeperSuite(registryVersion ethereum.KeeperRegistryVersion) func() {
 				)
 				consumer = consumers[0]
 				registry = r
+				upkeepID = upkeepIDs[0]
 			})
 
 			By("Register Keeper Jobs", func() {
@@ -102,9 +104,6 @@ func getKeeperSuite(registryVersion ethereum.KeeperRegistryVersion) func() {
 
 		Describe("with Keeper job", func() {
 			It("performs upkeep of a target contract, stops upon cancel", func() {
-				// Hardocded upkeep id '0' for now, only works in registry v1.1
-				upkeepID := big.NewInt(int64(0))
-
 				// Let upkeep be performed atleast once
 				Eventually(func(g Gomega) {
 					cnt, err := consumer.Counter(context.Background())
@@ -113,30 +112,26 @@ func getKeeperSuite(registryVersion ethereum.KeeperRegistryVersion) func() {
 					log.Info().Int64("Upkeep counter", cnt.Int64()).Msg("Upkeeps performed")
 				}, "2m", "1s").Should(Succeed())
 
-				if registryVersion == ethereum.RegistryVersion_1_1 {
-					// TODO: Support cancelling upkeep on version 1.2
+				// Now cancel the upkeep as registry owner, it should get immediately cancelled
+				err := registry.CancelUpkeep(upkeepID)
+				Expect(err).ShouldNot(HaveOccurred(), "Upkeep should get cancelled successfully")
+				err = networks.Default.WaitForEvents()
+				Expect(err).ShouldNot(HaveOccurred(), "Error waiting for cancel upkeep tx")
 
-					// Now cancel the upkeep as registry owner, it should get immediately cancelled
-					err := registry.CancelUpkeep(upkeepID)
-					Expect(err).ShouldNot(HaveOccurred(), "Upkeep should get cancelled successfully")
-					err = networks.Default.WaitForEvents()
-					Expect(err).ShouldNot(HaveOccurred(), "Error waiting for cancel upkeep tx")
+				// Get existing performed count
+				existingCnt, err := consumer.Counter(context.Background())
+				Expect(err).ShouldNot(HaveOccurred(), "Calling consumer's Counter shouldn't fail")
+				log.Info().Int64("Upkeep counter", existingCnt.Int64()).Msg("Upkeep cancelled")
 
-					// Get existing performed count
-					existingCnt, err := consumer.Counter(context.Background())
-					Expect(err).ShouldNot(HaveOccurred(), "Calling consumer's Counter shouldn't fail")
-					log.Info().Int64("Upkeep counter", existingCnt.Int64()).Msg("Upkeep cancelled")
-
-					// Expect count to be remain consistent
-					Consistently(func(g Gomega) {
-						cnt, err := consumer.Counter(context.Background())
-						g.Expect(err).ShouldNot(HaveOccurred(), "Calling consumer's Counter shouldn't fail")
-						g.Expect(cnt.Int64()).Should(
-							Equal(existingCnt.Int64()),
-							"Expected consumer counter to to remain constant at %d, but got %d", existingCnt.Int64(), cnt.Int64(),
-						)
-					}, "1m", "1s").Should(Succeed())
-				}
+				// Expect count to be remain consistent
+				Consistently(func(g Gomega) {
+					cnt, err := consumer.Counter(context.Background())
+					g.Expect(err).ShouldNot(HaveOccurred(), "Calling consumer's Counter shouldn't fail")
+					g.Expect(cnt.Int64()).Should(
+						Equal(existingCnt.Int64()),
+						"Expected consumer counter to to remain constant at %d, but got %d", existingCnt.Int64(), cnt.Int64(),
+					)
+				}, "1m", "1s").Should(Succeed())
 			})
 		})
 


### PR DESCRIPTION
Fetch the upkeep ID from registration request through testing framework (https://github.com/smartcontractkit/chainlink-testing-framework/pull/318)

Pass this upkeep ID to cancel, which makes it work across both versions of registries