### PR TITLE
Add larger all in one scripts for VRF contract deployment [sc-41040]

### DIFF
--- a/core/scripts/vrfv2/testnet/README.md
+++ b/core/scripts/vrfv2/testnet/README.md
@@ -52,7 +52,7 @@ cd <YOUR LOCAL CHAINLINK REPO>/core/scripts/vrfv2/testnet
 To deploy the VRFExternalSubOwnerExample contract, run:
 
 ```shell
-go run main.go eoa-consumer-deploy --coordinator-address=$COORDINATOR --link-address=$LINK
+go run . eoa-consumer-deploy --coordinator-address=$COORDINATOR --link-address=$LINK
 ```
 
 You should get the output:
@@ -73,7 +73,7 @@ authorized for a funded subscription.
 ### Creating a Subscription
 
 ```shell
-go run main.go eoa-create-sub --coordinator-address=$COORDINATOR
+go run . eoa-create-sub --coordinator-address=$COORDINATOR
 ```
 
 You should get the output:
@@ -96,7 +96,7 @@ export SUB_ID=<YOUR SUBSCRIPTION ID>
 
 In order to fund your subscription with 10 LINK, run:
 ```shell
-go run main.go eoa-fund-sub --coordinator-address $COORDINATOR --link-address=$LINK  --sub-id=$SUB_ID --amount=10000000000000000000 # 10e18 or 10 LINK
+go run . eoa-fund-sub --coordinator-address $COORDINATOR --link-address=$LINK  --sub-id=$SUB_ID --amount=10000000000000000000 # 10e18 or 10 LINK
 ```
 
 You should get the output:
@@ -109,7 +109,7 @@ Funding sub 61 hash <YOUR FUNDING TX HASH>
 
 To check the LINK balance of your subscription, run:
 ```shell
-go run main.go sub-balance --coordinator-address $COORDINATOR --sub-id=$SUB_ID
+go run . sub-balance --coordinator-address $COORDINATOR --sub-id=$SUB_ID
 ```
 
 You should get the output:
@@ -122,7 +122,7 @@ sub id <YOUR SUB ID> balance: <YOUR SUB BALANCE>
 In order to authorize the consumer contract to use the new subscription, run the
 command:
 ```shell
-go run main.go eoa-add-sub-consumer --coordinator-address $COORDINATOR --sub-id=$SUB_ID --consumer-address=$CONSUMER
+go run . eoa-add-sub-consumer --coordinator-address $COORDINATOR --sub-id=$SUB_ID --consumer-address=$CONSUMER
 ```
 
 ### Requesting Randomness
@@ -132,7 +132,7 @@ subscription, and is ready to request random words.
 
 To make a request, run:
 ```shell
-go run main.go eoa-request --consumer-address=$CONSUMER --sub-id=$SUB_ID --key-hash=$KEY_HASH --num-words 1 
+go run . eoa-request --consumer-address=$CONSUMER --sub-id=$SUB_ID --key-hash=$KEY_HASH --num-words 1 
 ```
 
 You should get the output:
@@ -163,20 +163,20 @@ and fetch many blockhashes in a single transaction.
 ### Deploy a `BatchBlockhashStore` instance
 
 ```
-go run main.go batch-bhs-deploy -bhs-address $BHS_ADDRESS
+go run . batch-bhs-deploy -bhs-address $BHS_ADDRESS
 ```
 
 where `$BHS_ADDRESS` is an environment variable that points to an existing `BlockhashStore` contract. If one is not available,
 you can easily deploy one using this command:
 
 ```
-go run main.go bhs-deploy
+go run . bhs-deploy
 ```
 
 ### Store many blockhashes
 
 ```
-go run main.go batch-bhs-store -batch-bhs-address $BATCH_BHS_ADDRESS -block-numbers 10298742,10298741,10298740,10298739
+go run . batch-bhs-store -batch-bhs-address $BATCH_BHS_ADDRESS -block-numbers 10298742,10298741,10298740,10298739
 ```
 
 where `$BATCH_BHS_ADDRESS` points to the `BatchBlockhashStore` contract deployed above, and `-block-numbers` is a comma-separated
@@ -187,7 +187,7 @@ Please note that these block numbers must not be further than 256 from the lates
 ### Fetch many blockhashes
 
 ```
-go run main.go batch-bhs-get -batch-bhs-address $BATCH_BHS_ADDRESS -block-numbers 10298742,10298741,10298740,10298739
+go run . batch-bhs-get -batch-bhs-address $BATCH_BHS_ADDRESS -block-numbers 10298742,10298741,10298740,10298739
 ```
 
 where `$BATCH_BHS_ADDRESS` points to the `BatchBlockhashStore` contract deployed above, and `-block-numbers` is a comma-separated
@@ -200,7 +200,7 @@ In order to store blockhashes farther back than 256 blocks we can make use of th
 Here's how to use it:
 
 ```
-go run main.go batch-bhs-storeVerify -batch-bhs-address $BATCH_BHS_ADDRESS -num-blocks 25 -start-block 10298739
+go run . batch-bhs-storeVerify -batch-bhs-address $BATCH_BHS_ADDRESS -num-blocks 25 -start-block 10298739
 ```
 
 where `$BATCH_BHS_ADDRESS` points to the `BatchBlockhashStore` contract deployed above, `-num-blocks` is the amount of blocks to store, and
@@ -226,7 +226,7 @@ for big block ranges.
 Example:
 
 ```
-go run main.go batch-bhs-backwards -batch-bhs-address $BATCH_BHS_ADDRESS -start-block 25814538 -end-block 25811350 -batch-size 50
+go run . batch-bhs-backwards -batch-bhs-address $BATCH_BHS_ADDRESS -start-block 25814538 -end-block 25811350 -batch-size 50
 ```
 
 This script is simplistic on purpose, where we wait for the transaction to mine before proceeding with the next one. This

--- a/core/scripts/vrfv2/testnet/main.go
+++ b/core/scripts/vrfv2/testnet/main.go
@@ -17,7 +17,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/ethclient"
-	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/shopspring/decimal"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
@@ -26,7 +25,6 @@ import (
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/batch_blockhash_store"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/batch_vrf_coordinator_v2"
-	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/blockhash_store"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/keepers_vrf_consumer"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/link_token_interface"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/vrf_coordinator_v2"
@@ -43,6 +41,12 @@ import (
 var (
 	batchCoordinatorV2ABI = evmtypes.MustGetABI(batch_vrf_coordinator_v2.BatchVRFCoordinatorV2ABI)
 )
+
+type environment struct {
+	owner   *bind.TransactOpts
+	ec      *ethclient.Client
+	chainID int64
+}
 
 type logconfig struct{}
 
@@ -96,6 +100,9 @@ func main() {
 	gp, err := ec.SuggestGasPrice(context.Background())
 	helpers.PanicErr(err)
 	owner.GasPrice = gp
+
+	// the execution environment for the scripts
+	e := environment{owner, ec, chainID}
 
 	// Uncomment the block below if transactions are not getting picked up due to nonce issues:
 	//
@@ -407,23 +414,14 @@ func main() {
 		helpers.PanicErr(err)
 		fmt.Println("latest head number:", h.Number.String())
 	case "bhs-deploy":
-		_, tx, _, err := blockhash_store.DeployBlockhashStore(owner, ec)
-		helpers.PanicErr(err)
-		confirmContractDeployed(context.Background(), ec, tx, chainID)
+		deployBHS(e)
 	case "coordinator-deploy":
 		coordinatorDeployCmd := flag.NewFlagSet("coordinator-deploy", flag.ExitOnError)
 		coordinatorDeployLinkAddress := coordinatorDeployCmd.String("link-address", "", "address of link token")
 		coordinatorDeployBHSAddress := coordinatorDeployCmd.String("bhs-address", "", "address of bhs")
 		coordinatorDeployLinkEthFeedAddress := coordinatorDeployCmd.String("link-eth-feed", "", "address of link-eth-feed")
 		helpers.ParseArgs(coordinatorDeployCmd, os.Args[2:], "link-address", "bhs-address", "link-eth-feed")
-		_, tx, _, err := vrf_coordinator_v2.DeployVRFCoordinatorV2(
-			owner,
-			ec,
-			common.HexToAddress(*coordinatorDeployLinkAddress),
-			common.HexToAddress(*coordinatorDeployBHSAddress),
-			common.HexToAddress(*coordinatorDeployLinkEthFeedAddress))
-		helpers.PanicErr(err)
-		confirmContractDeployed(context.Background(), ec, tx, chainID)
+		deployCoordinator(e, *coordinatorDeployLinkAddress, *coordinatorDeployBHSAddress, *coordinatorDeployLinkEthFeedAddress)
 	case "coordinator-get-config":
 		cmd := flag.NewFlagSet("coordinator-get-config", flag.ExitOnError)
 		setConfigAddress := cmd.String("coordinator-address", "", "coordinator address")
@@ -432,14 +430,7 @@ func main() {
 		coordinator, err := vrf_coordinator_v2.NewVRFCoordinatorV2(common.HexToAddress(*setConfigAddress), ec)
 		helpers.PanicErr(err)
 
-		cfg, err := coordinator.GetConfig(nil)
-		helpers.PanicErr(err)
-
-		feeConfig, err := coordinator.GetFeeConfig(nil)
-		helpers.PanicErr(err)
-
-		fmt.Printf("config: %+v\n", cfg)
-		fmt.Printf("fee config: %+v\n", feeConfig)
+		printCoordinatorConfig(e, *coordinator)
 	case "coordinator-set-config":
 		cmd := flag.NewFlagSet("coordinator-set-config", flag.ExitOnError)
 		setConfigAddress := cmd.String("coordinator-address", "", "coordinator address")
@@ -459,16 +450,17 @@ func main() {
 		reqsForTier5 := cmd.Int64("reqs-for-tier-5", 0, "requests for tier 5")
 
 		helpers.ParseArgs(cmd, os.Args[2:], "coordinator-address", "fallback-wei-per-unit-link")
-
-		coordinator, err := vrf_coordinator_v2.NewVRFCoordinatorV2(common.HexToAddress(*setConfigAddress), ec)
+		coordinator, err := vrf_coordinator_v2.NewVRFCoordinatorV2(common.HexToAddress(*setConfigAddress), e.ec)
 		helpers.PanicErr(err)
 
-		tx, err := coordinator.SetConfig(owner,
-			uint16(*minConfs),         // minRequestConfirmations
-			uint32(*maxGasLimit),      // max gas limit
-			uint32(*stalenessSeconds), // stalenessSeconds
-			uint32(*gasAfterPayment),  // gasAfterPaymentCalculation
-			decimal.RequireFromString(*fallbackWeiPerUnitLink).BigInt(), // 0.01 eth per link fallbackLinkPrice
+		setCoordinatorConfig(
+			e,
+			*coordinator,
+			uint16(*minConfs),
+			uint32(*maxGasLimit),
+			uint32(*stalenessSeconds),
+			uint32(*gasAfterPayment),
+			decimal.RequireFromString(*fallbackWeiPerUnitLink).BigInt(),
 			vrf_coordinator_v2.VRFCoordinatorV2FeeConfig{
 				FulfillmentFlatFeeLinkPPMTier1: uint32(*flatFeeTier1),
 				FulfillmentFlatFeeLinkPPMTier2: uint32(*flatFeeTier2),
@@ -481,8 +473,6 @@ func main() {
 				ReqsForTier5:                   big.NewInt(*reqsForTier5),
 			},
 		)
-		helpers.PanicErr(err)
-		confirmTXMined(context.Background(), ec, tx, chainID)
 	case "coordinator-register-key":
 		coordinatorRegisterKey := flag.NewFlagSet("coordinator-register-key", flag.ExitOnError)
 		registerKeyAddress := coordinatorRegisterKey.String("address", "", "coordinator address")
@@ -496,22 +486,8 @@ func main() {
 		if strings.HasPrefix(*registerKeyUncompressedPubKey, "0x") {
 			*registerKeyUncompressedPubKey = strings.Replace(*registerKeyUncompressedPubKey, "0x", "04", 1)
 		}
-		pubBytes, err := hex.DecodeString(*registerKeyUncompressedPubKey)
-		helpers.PanicErr(err)
-		pk, err := crypto.UnmarshalPubkey(pubBytes)
-		helpers.PanicErr(err)
-		tx, err := coordinator.RegisterProvingKey(owner,
-			common.HexToAddress(*registerKeyOracleAddress),
-			[2]*big.Int{pk.X, pk.Y})
-		helpers.PanicErr(err)
-		confirmTXMined(
-			context.Background(),
-			ec,
-			tx,
-			chainID,
-			fmt.Sprintf("Uncompressed public key: %s,", *registerKeyUncompressedPubKey),
-			fmt.Sprintf("Oracle address: %s,", *registerKeyOracleAddress),
-		)
+
+		registerCoordinatorProvingKey(e, *coordinator, *registerKeyUncompressedPubKey, *registerKeyOracleAddress)
 	case "coordinator-deregister-key":
 		coordinatorDeregisterKey := flag.NewFlagSet("coordinator-deregister-key", flag.ExitOnError)
 		deregisterKeyAddress := coordinatorDeregisterKey.String("address", "", "coordinator address")
@@ -638,18 +614,15 @@ func main() {
 		rid, err := consumer.SRequestId(nil)
 		helpers.PanicErr(err)
 		fmt.Printf("Request config %+v Rw %+v Rid %+v\n", rc, rw, rid)
+	case "deploy-bhs-coordinator-consumer":
+		deployBHSCoordinatorAndConsumer(e)
 	case "eoa-consumer-deploy":
 		consumerDeployCmd := flag.NewFlagSet("eoa-consumer-deploy", flag.ExitOnError)
 		consumerCoordinator := consumerDeployCmd.String("coordinator-address", "", "coordinator address")
 		consumerLinkAddress := consumerDeployCmd.String("link-address", "", "link-address")
 		helpers.ParseArgs(consumerDeployCmd, os.Args[2:], "coordinator-address", "link-address")
-		_, tx, _, err := vrf_external_sub_owner_example.DeployVRFExternalSubOwnerExample(
-			owner,
-			ec,
-			common.HexToAddress(*consumerCoordinator),
-			common.HexToAddress(*consumerLinkAddress))
-		helpers.PanicErr(err)
-		confirmContractDeployed(context.Background(), ec, tx, chainID)
+
+		eoaDeployConsumer(e, *consumerCoordinator, *consumerLinkAddress)
 	case "eoa-load-test-consumer-deploy":
 		loadTestConsumerDeployCmd := flag.NewFlagSet("eoa-load-test-consumer-deploy", flag.ExitOnError)
 		consumerCoordinator := loadTestConsumerDeployCmd.String("coordinator-address", "", "coordinator address")
@@ -668,9 +641,7 @@ func main() {
 		helpers.ParseArgs(createSubCmd, os.Args[2:], "coordinator-address")
 		coordinator, err := vrf_coordinator_v2.NewVRFCoordinatorV2(common.HexToAddress(*coordinatorAddress), ec)
 		helpers.PanicErr(err)
-		tx, err := coordinator.CreateSubscription(owner)
-		helpers.PanicErr(err)
-		confirmTXMined(context.Background(), ec, tx, chainID)
+		eoaCreateSub(e, *coordinator)
 	case "eoa-add-sub-consumer":
 		addSubConsCmd := flag.NewFlagSet("eoa-add-sub-consumer", flag.ExitOnError)
 		coordinatorAddress := addSubConsCmd.String("coordinator-address", "", "coordinator address")
@@ -679,9 +650,7 @@ func main() {
 		helpers.ParseArgs(addSubConsCmd, os.Args[2:], "coordinator-address", "sub-id", "consumer-address")
 		coordinator, err := vrf_coordinator_v2.NewVRFCoordinatorV2(common.HexToAddress(*coordinatorAddress), ec)
 		helpers.PanicErr(err)
-		txadd, err := coordinator.AddConsumer(owner, *subID, common.HexToAddress(*consumerAddress))
-		helpers.PanicErr(err)
-		confirmTXMined(context.Background(), ec, txadd, chainID)
+		eoaAddConsumerToSub(e, *coordinator, uint64(*subID), *consumerAddress)
 	case "eoa-create-fund-authorize-sub":
 		// Lets just treat the owner key as the EOA controlling the sub
 		cfaSubCmd := flag.NewFlagSet("eoa-create-fund-authorize-sub", flag.ExitOnError)
@@ -820,17 +789,7 @@ func main() {
 		}
 		coordinator, err := vrf_coordinator_v2.NewVRFCoordinatorV2(common.HexToAddress(*coordinatorAddress), ec)
 		helpers.PanicErr(err)
-		linkToken, err := link_token_interface.NewLinkToken(common.HexToAddress(*consumerLinkAddress), ec)
-		helpers.PanicErr(err)
-		bal, err := linkToken.BalanceOf(nil, owner.From)
-		helpers.PanicErr(err)
-		fmt.Println("Initial account balance:", bal, owner.From.String(), "Funding amount:", amount.String())
-		b, err := utils.GenericEncode([]string{"uint64"}, uint64(*subID))
-		helpers.PanicErr(err)
-		owner.GasLimit = 500000
-		tx, err := linkToken.TransferAndCall(owner, coordinator.Address(), amount, b)
-		helpers.PanicErr(err)
-		confirmTXMined(context.Background(), ec, tx, chainID, fmt.Sprintf("sub ID: %d", *subID))
+		eoaFundSubscription(e, *coordinator, *consumerLinkAddress, amount, uint64(*subID))
 	case "eoa-read":
 		cmd := flag.NewFlagSet("eoa-read", flag.ExitOnError)
 		consumerAddress := cmd.String("consumer", "", "consumer address")
@@ -948,112 +907,4 @@ func main() {
 	default:
 		panic("unrecognized subcommand: " + os.Args[1])
 	}
-}
-
-func confirmTXMined(context context.Context, client *ethclient.Client, transaction *types.Transaction, chainID int64, txInfo ...string) {
-	fmt.Println("Executing TX", helpers.ExplorerLink(chainID, transaction.Hash()), txInfo)
-	receipt, err := bind.WaitMined(context, client, transaction)
-	helpers.PanicErr(err)
-	fmt.Println("TX", receipt.TxHash, "mined. \nBlock Number:", receipt.BlockNumber, "\nGas Used: ", receipt.GasUsed)
-}
-
-func confirmContractDeployed(context context.Context, client *ethclient.Client, transaction *types.Transaction, chainID int64) {
-	fmt.Println("Executing contract deployment, TX:", helpers.ExplorerLink(chainID, transaction.Hash()))
-	contractAddress, err := bind.WaitDeployed(context, client, transaction)
-	helpers.PanicErr(err)
-	fmt.Println("Contract Address:", contractAddress.String())
-}
-
-func parseIntSlice(arg string) (ret []*big.Int) {
-	parts := strings.Split(arg, ",")
-	ret = []*big.Int{}
-	for _, part := range parts {
-		ret = append(ret, decimal.RequireFromString(part).BigInt())
-	}
-	return ret
-}
-
-func parseAddressSlice(arg string) (ret []common.Address) {
-	parts := strings.Split(arg, ",")
-	ret = []common.Address{}
-	for _, part := range parts {
-		ret = append(ret, common.HexToAddress(part))
-	}
-	return
-}
-
-func parseHashSlice(arg string) (ret []common.Hash) {
-	parts := strings.Split(arg, ",")
-	ret = []common.Hash{}
-	for _, part := range parts {
-		ret = append(ret, common.HexToHash(part))
-	}
-	return
-}
-
-// decreasingBlockRange creates a continugous block range starting with
-// block `start` and ending at block `end`.
-func decreasingBlockRange(start, end *big.Int) (ret []*big.Int, err error) {
-	if start.Cmp(end) == -1 {
-		return nil, fmt.Errorf("start (%s) must be greater than end (%s)", start.String(), end.String())
-	}
-	ret = []*big.Int{}
-	for i := new(big.Int).Set(start); i.Cmp(end) >= 0; i.Sub(i, big.NewInt(1)) {
-		ret = append(ret, new(big.Int).Set(i))
-	}
-	return
-}
-
-func getRlpHeaders(ec *ethclient.Client, blockNumbers []*big.Int) (headers [][]byte, err error) {
-	headers = [][]byte{}
-	for _, blockNum := range blockNumbers {
-		// Get child block since it's the one that has the parent hash in it's header.
-		h, err := ec.HeaderByNumber(
-			context.Background(),
-			new(big.Int).Set(blockNum).Add(blockNum, big.NewInt(1)),
-		)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get header: %+v", err)
-		}
-		rlpHeader, err := rlp.EncodeToBytes(h)
-		if err != nil {
-			return nil, fmt.Errorf("failed to encode rlp: %+v", err)
-		}
-		// Uncomment in case storeVerifyHeader calls are reverting, there may be an issue with the RLP
-		// encoding.
-		// h2, err := ec.HeaderByNumber(context.Background(), blockNum)
-		// if err != nil {
-		// 	return nil, fmt.Errorf("failed to get header: %v", err)
-		// }
-		// fmt.Println("block number:", blockNum, "blockhash:", h2.Hash(), "encoded header of next block:", common.Bytes2Hex(rlpHeader))
-		headers = append(headers, rlpHeader)
-	}
-	return
-}
-
-// binarySearch finds the highest value within the range bottom-top at which the test function is
-// true.
-func binarySearch(top, bottom *big.Int, test func(amount *big.Int) bool) *big.Int {
-	var runs int
-	// While the difference between top and bottom is > 1
-	for new(big.Int).Sub(top, bottom).Cmp(big.NewInt(1)) > 0 {
-		// Calculate midpoint between top and bottom
-		midpoint := new(big.Int).Sub(top, bottom)
-		midpoint.Div(midpoint, big.NewInt(2))
-		midpoint.Add(midpoint, bottom)
-
-		// Check if the midpoint amount is withdrawable
-		if test(midpoint) {
-			bottom = midpoint
-		} else {
-			top = midpoint
-		}
-
-		runs++
-		if runs%10 == 0 {
-			fmt.Printf("Searching... current range %s-%s\n", bottom.String(), top.String())
-		}
-	}
-
-	return bottom
 }

--- a/core/scripts/vrfv2/testnet/super_scripts.go
+++ b/core/scripts/vrfv2/testnet/super_scripts.go
@@ -1,0 +1,104 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+
+	"github.com/shopspring/decimal"
+
+	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/vrf_coordinator_v2"
+	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
+)
+
+func deployBHSCoordinatorAndConsumer(e environment) {
+	coordinatorDeployCmd := flag.NewFlagSet("full-deploy", flag.ExitOnError)
+	linkAddress := coordinatorDeployCmd.String("link-address", "", "address of link token")
+	linkEthAddress := coordinatorDeployCmd.String("link-eth-feed", "", "address of link eth feed")
+	fallbackWeiPerUnitLink := coordinatorDeployCmd.String("fallback-wei-per-unit-link", "", "fallback wei/link ratio")
+	registerKeyUncompressedPubKey := coordinatorDeployCmd.String("uncompressed-pub-key", "", "uncompressed public key")
+	registerKeyOracleAddress := coordinatorDeployCmd.String("oracle-address", "", "oracle address")
+	subscriptionBalanceString := coordinatorDeployCmd.String("subscription-balance", "", "subscription balance")
+	helpers.ParseArgs(
+		coordinatorDeployCmd, os.Args[2:],
+		"link-address",
+		"link-eth-feed",
+		"fallback-wei-per-unit-link",
+		"uncompressed-pub-key",
+		"oracle-address",
+		"subscription-balance",
+	)
+
+	subscriptionBalance, success := big.NewInt(0).SetString(*subscriptionBalanceString, 10)
+	if !success {
+		panic(fmt.Sprintf("failed to parse subscriptionBalance '%s'", *subscriptionBalanceString))
+	}
+
+	// Put key in ECDSA format
+	if strings.HasPrefix(*registerKeyUncompressedPubKey, "0x") {
+		*registerKeyUncompressedPubKey = strings.Replace(*registerKeyUncompressedPubKey, "0x", "04", 1)
+	}
+
+	fmt.Println("\nDeploying BHS...")
+	bhsContractAddress := deployBHS(e)
+
+	fmt.Println("\nDeploying Coordinator...")
+	coordinatorAddress := deployCoordinator(e, *linkAddress, bhsContractAddress.String(), *linkEthAddress)
+	coordinator, err := vrf_coordinator_v2.NewVRFCoordinatorV2(coordinatorAddress, e.ec)
+	helpers.PanicErr(err)
+
+	fmt.Println("\nSetting Config...")
+	setCoordinatorConfig(e, *coordinator, 3, 2.5e6, 86400, 33285, decimal.RequireFromString(*fallbackWeiPerUnitLink).BigInt(),
+		vrf_coordinator_v2.VRFCoordinatorV2FeeConfig{
+			FulfillmentFlatFeeLinkPPMTier1: uint32(500),
+			FulfillmentFlatFeeLinkPPMTier2: uint32(500),
+			FulfillmentFlatFeeLinkPPMTier3: uint32(500),
+			FulfillmentFlatFeeLinkPPMTier4: uint32(500),
+			FulfillmentFlatFeeLinkPPMTier5: uint32(500),
+			ReqsForTier2:                   big.NewInt(0),
+			ReqsForTier3:                   big.NewInt(0),
+			ReqsForTier4:                   big.NewInt(0),
+			ReqsForTier5:                   big.NewInt(0),
+		},
+	)
+
+	fmt.Println("\nConfig set, getting current config from deployed contract...")
+	printCoordinatorConfig(e, *coordinator)
+
+	fmt.Println("\nRegistering proving key...")
+	registerCoordinatorProvingKey(e, *coordinator, *registerKeyUncompressedPubKey, *registerKeyOracleAddress)
+
+	fmt.Println("\nProving key registered, getting proving key hashes from deployed contract...")
+	_, _, s_provingKeyHashes, err := coordinator.GetRequestConfig(nil)
+	helpers.PanicErr(err)
+	fmt.Printf("Hashes: %+v\n", s_provingKeyHashes)
+
+	fmt.Println("\nDeploying consumer...")
+	consumerAddress := eoaDeployConsumer(e, coordinatorAddress.String(), *linkAddress)
+
+	fmt.Println("\nAdding subscription...")
+	eoaCreateSub(e, *coordinator)
+	subID := uint64(1)
+
+	fmt.Println("\nAdding consumer to subscription...")
+	eoaAddConsumerToSub(e, *coordinator, subID, consumerAddress.String())
+
+	fmt.Println("\nFunding subscription...")
+	eoaFundSubscription(e, *coordinator, *linkAddress, subscriptionBalance, subID)
+
+	fmt.Println("\nSubscribed and funded, retrieving subscription from deployed contract...")
+	s, err := coordinator.GetSubscription(nil, subID)
+	helpers.PanicErr(err)
+	fmt.Printf("Subscription %+v\n", s)
+	fmt.Println(
+		"\nDeployment complete.",
+		"\nBlockhash Store contract address:", bhsContractAddress,
+		"\nVRF Coordinator Address:", coordinatorAddress,
+		"\nVRF Consumer Address:", consumerAddress,
+		"\nVRF Subscription Id:", subID,
+		"\nVRF Subscription Balance:", *subscriptionBalanceString,
+		"\nA node can now be configured to run a VRF job with the above configuration.",
+	)
+}

--- a/core/scripts/vrfv2/testnet/util.go
+++ b/core/scripts/vrfv2/testnet/util.go
@@ -1,0 +1,243 @@
+package main
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/ethereum/go-ethereum/rlp"
+	"github.com/shopspring/decimal"
+	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/blockhash_store"
+	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/link_token_interface"
+	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/vrf_coordinator_v2"
+	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/vrf_external_sub_owner_example"
+	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
+	"github.com/smartcontractkit/chainlink/core/utils"
+)
+
+func confirmTXMined(context context.Context, client *ethclient.Client, transaction *types.Transaction, chainID int64, txInfo ...string) {
+	fmt.Println("Executing TX", helpers.ExplorerLink(chainID, transaction.Hash()), txInfo)
+	receipt, err := bind.WaitMined(context, client, transaction)
+	helpers.PanicErr(err)
+	fmt.Println("TX", receipt.TxHash, "mined. \nBlock Number:", receipt.BlockNumber, "\nGas Used: ", receipt.GasUsed)
+}
+
+func confirmContractDeployed(context context.Context, client *ethclient.Client, transaction *types.Transaction, chainID int64) (address common.Address) {
+	fmt.Println("Executing contract deployment, TX:", helpers.ExplorerLink(chainID, transaction.Hash()))
+	contractAddress, err := bind.WaitDeployed(context, client, transaction)
+	helpers.PanicErr(err)
+	fmt.Println("Contract Address:", contractAddress.String())
+	return contractAddress
+}
+
+func deployBHS(e environment) (blockhashStoreAddress common.Address) {
+	_, tx, _, err := blockhash_store.DeployBlockhashStore(e.owner, e.ec)
+	helpers.PanicErr(err)
+	return confirmContractDeployed(context.Background(), e.ec, tx, e.chainID)
+}
+
+func deployCoordinator(
+	e environment,
+	linkAddress string,
+	bhsAddress string,
+	linkEthAddress string,
+) (coordinatorAddress common.Address) {
+	_, tx, _, err := vrf_coordinator_v2.DeployVRFCoordinatorV2(
+		e.owner,
+		e.ec,
+		common.HexToAddress(linkAddress),
+		common.HexToAddress(bhsAddress),
+		common.HexToAddress(linkEthAddress))
+	helpers.PanicErr(err)
+	return confirmContractDeployed(context.Background(), e.ec, tx, e.chainID)
+}
+
+func eoaAddConsumerToSub(e environment, coordinator vrf_coordinator_v2.VRFCoordinatorV2, subID uint64, consumerAddress string) {
+	txadd, err := coordinator.AddConsumer(e.owner, subID, common.HexToAddress(consumerAddress))
+	helpers.PanicErr(err)
+	confirmTXMined(context.Background(), e.ec, txadd, e.chainID)
+}
+
+func eoaCreateSub(e environment, coordinator vrf_coordinator_v2.VRFCoordinatorV2) {
+	tx, err := coordinator.CreateSubscription(e.owner)
+	helpers.PanicErr(err)
+	confirmTXMined(context.Background(), e.ec, tx, e.chainID)
+}
+
+func eoaDeployConsumer(e environment, coordinatorAddress string, linkAddress string) (consumerAddress common.Address) {
+	_, tx, _, err := vrf_external_sub_owner_example.DeployVRFExternalSubOwnerExample(
+		e.owner,
+		e.ec,
+		common.HexToAddress(coordinatorAddress),
+		common.HexToAddress(linkAddress))
+	helpers.PanicErr(err)
+	return confirmContractDeployed(context.Background(), e.ec, tx, e.chainID)
+}
+
+func eoaFundSubscription(e environment, coordinator vrf_coordinator_v2.VRFCoordinatorV2, linkAddress string, amount *big.Int, subID uint64) {
+	linkToken, err := link_token_interface.NewLinkToken(common.HexToAddress(linkAddress), e.ec)
+	helpers.PanicErr(err)
+	bal, err := linkToken.BalanceOf(nil, e.owner.From)
+	helpers.PanicErr(err)
+	fmt.Println("Initial account balance:", bal, e.owner.From.String(), "Funding amount:", amount.String())
+	b, err := utils.GenericEncode([]string{"uint64"}, subID)
+	helpers.PanicErr(err)
+	e.owner.GasLimit = 500000
+	tx, err := linkToken.TransferAndCall(e.owner, coordinator.Address(), amount, b)
+	helpers.PanicErr(err)
+	confirmTXMined(context.Background(), e.ec, tx, e.chainID, fmt.Sprintf("sub ID: %d", subID))
+}
+
+func printCoordinatorConfig(e environment, coordinator vrf_coordinator_v2.VRFCoordinatorV2) {
+	cfg, err := coordinator.GetConfig(nil)
+	helpers.PanicErr(err)
+
+	feeConfig, err := coordinator.GetFeeConfig(nil)
+	helpers.PanicErr(err)
+
+	fmt.Printf("Coordinator config: %+v\n", cfg)
+	fmt.Printf("Coordinator fee config: %+v\n", feeConfig)
+}
+
+func setCoordinatorConfig(
+	e environment,
+	coordinator vrf_coordinator_v2.VRFCoordinatorV2,
+	minConfs uint16,
+	maxGasLimit uint32,
+	stalenessSeconds uint32,
+	gasAfterPayment uint32,
+	fallbackWeiPerUnitLink *big.Int,
+	feeConfig vrf_coordinator_v2.VRFCoordinatorV2FeeConfig,
+) {
+	tx, err := coordinator.SetConfig(
+		e.owner,
+		minConfs,               // minRequestConfirmations
+		maxGasLimit,            // max gas limit
+		stalenessSeconds,       // stalenessSeconds
+		gasAfterPayment,        // gasAfterPaymentCalculation
+		fallbackWeiPerUnitLink, // 0.01 eth per link fallbackLinkPrice
+		feeConfig,
+	)
+	helpers.PanicErr(err)
+	confirmTXMined(context.Background(), e.ec, tx, e.chainID)
+}
+
+func registerCoordinatorProvingKey(e environment, coordinator vrf_coordinator_v2.VRFCoordinatorV2, uncompressed string, oracleAddress string) {
+	pubBytes, err := hex.DecodeString(uncompressed)
+	helpers.PanicErr(err)
+	pk, err := crypto.UnmarshalPubkey(pubBytes)
+	helpers.PanicErr(err)
+	tx, err := coordinator.RegisterProvingKey(e.owner,
+		common.HexToAddress(oracleAddress),
+		[2]*big.Int{pk.X, pk.Y})
+	helpers.PanicErr(err)
+	confirmTXMined(
+		context.Background(),
+		e.ec,
+		tx,
+		e.chainID,
+		fmt.Sprintf("Uncompressed public key: %s,", uncompressed),
+		fmt.Sprintf("Oracle address: %s,", oracleAddress),
+	)
+}
+
+func parseIntSlice(arg string) (ret []*big.Int) {
+	parts := strings.Split(arg, ",")
+	ret = []*big.Int{}
+	for _, part := range parts {
+		ret = append(ret, decimal.RequireFromString(part).BigInt())
+	}
+	return ret
+}
+
+func parseAddressSlice(arg string) (ret []common.Address) {
+	parts := strings.Split(arg, ",")
+	ret = []common.Address{}
+	for _, part := range parts {
+		ret = append(ret, common.HexToAddress(part))
+	}
+	return
+}
+
+func parseHashSlice(arg string) (ret []common.Hash) {
+	parts := strings.Split(arg, ",")
+	ret = []common.Hash{}
+	for _, part := range parts {
+		ret = append(ret, common.HexToHash(part))
+	}
+	return
+}
+
+// decreasingBlockRange creates a continugous block range starting with
+// block `start` and ending at block `end`.
+func decreasingBlockRange(start, end *big.Int) (ret []*big.Int, err error) {
+	if start.Cmp(end) == -1 {
+		return nil, fmt.Errorf("start (%s) must be greater than end (%s)", start.String(), end.String())
+	}
+	ret = []*big.Int{}
+	for i := new(big.Int).Set(start); i.Cmp(end) >= 0; i.Sub(i, big.NewInt(1)) {
+		ret = append(ret, new(big.Int).Set(i))
+	}
+	return
+}
+
+func getRlpHeaders(ec *ethclient.Client, blockNumbers []*big.Int) (headers [][]byte, err error) {
+	headers = [][]byte{}
+	for _, blockNum := range blockNumbers {
+		// Get child block since it's the one that has the parent hash in it's header.
+		h, err := ec.HeaderByNumber(
+			context.Background(),
+			new(big.Int).Set(blockNum).Add(blockNum, big.NewInt(1)),
+		)
+		if err != nil {
+			return nil, fmt.Errorf("failed to get header: %+v", err)
+		}
+		rlpHeader, err := rlp.EncodeToBytes(h)
+		if err != nil {
+			return nil, fmt.Errorf("failed to encode rlp: %+v", err)
+		}
+		// Uncomment in case storeVerifyHeader calls are reverting, there may be an issue with the RLP
+		// encoding.
+		// h2, err := ec.HeaderByNumber(context.Background(), blockNum)
+		// if err != nil {
+		// 	return nil, fmt.Errorf("failed to get header: %v", err)
+		// }
+		// fmt.Println("block number:", blockNum, "blockhash:", h2.Hash(), "encoded header of next block:", common.Bytes2Hex(rlpHeader))
+		headers = append(headers, rlpHeader)
+	}
+	return
+}
+
+// binarySearch finds the highest value within the range bottom-top at which the test function is
+// true.
+func binarySearch(top, bottom *big.Int, test func(amount *big.Int) bool) *big.Int {
+	var runs int
+	// While the difference between top and bottom is > 1
+	for new(big.Int).Sub(top, bottom).Cmp(big.NewInt(1)) > 0 {
+		// Calculate midpoint between top and bottom
+		midpoint := new(big.Int).Sub(top, bottom)
+		midpoint.Div(midpoint, big.NewInt(2))
+		midpoint.Add(midpoint, bottom)
+
+		// Check if the midpoint amount is withdrawable
+		if test(midpoint) {
+			bottom = midpoint
+		} else {
+			top = midpoint
+		}
+
+		runs++
+		if runs%10 == 0 {
+			fmt.Printf("Searching... current range %s-%s\n", bottom.String(), top.String())
+		}
+	}
+
+	return bottom
+}


### PR DESCRIPTION
Draft PR for a possible direction for the superscript.

- Adds util & superscript files as to not clutter the main file
- Extracts relevant logic from main.go and makes it reusable in the util file
- Piggyback off the util functions in the superscript file, making for almost no duplicated logic
- Update readme, as `go run .` now needs to be used instead of `go run main.go`

Discussion Points:
- The main.go file could honestly be overhauled entirely as it is quite dense. The only stuff I moved were utility functions and logic that could be reused by the superscript.
- Not all the utility functions in the util.go file are alike, i.e `getRlpHeaders`, `confirmTXMined`, `deployBHS`. I could understand an argument for leaving some of these helper functions in main.go, or separating them further into different files.