### PR TITLE
keepers: listen to upkeep migration logs

### DIFF
--- a/core/services/keeper/registry1_1_synchronizer_test.go
+++ b/core/services/keeper/registry1_1_synchronizer_test.go
@@ -17,6 +17,7 @@ import (
 	registry1_1 "github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/keeper_registry_wrapper1_1"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
+	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/keeper"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
@@ -60,6 +61,29 @@ func mockRegistry1_1(
 	if timesGetUpkeepMock > 0 {
 		registryMock.MockResponse("getUpkeep", upkeepConfig).Times(timesGetUpkeepMock)
 	}
+}
+
+func Test_LogListenerOpts1_1(t *testing.T) {
+	db := pgtest.NewSqlxDB(t)
+	korm := keeper.NewORM(db, logger.TestLogger(t), nil, nil)
+	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
+	j := cltest.MustInsertKeeperJob(t, db, korm, cltest.NewEIP55Address(), cltest.NewEIP55Address())
+
+	contractAddress := j.KeeperSpec.ContractAddress.Address()
+	registryMock := cltest.NewContractMockReceiver(t, ethClient, keeper.Registry1_1ABI, contractAddress)
+	registryMock.MockResponse("typeAndVersion", "KeeperRegistry 1.1.0").Once()
+
+	registryWrapper, err := keeper.NewRegistryWrapper(j.KeeperSpec.ContractAddress, ethClient)
+	require.NoError(t, err)
+
+	logListenerOpts, err := registryWrapper.GetLogListenerOpts(1, nil)
+	require.NoError(t, err)
+
+	require.Contains(t, logListenerOpts.LogsWithTopics, registry1_1.KeeperRegistryKeepersUpdated{}.Topic(), "Registry should listen to KeeperRegistryKeepersUpdated log")
+	require.Contains(t, logListenerOpts.LogsWithTopics, registry1_1.KeeperRegistryConfigSet{}.Topic(), "Registry should listen to KeeperRegistryConfigSet log")
+	require.Contains(t, logListenerOpts.LogsWithTopics, registry1_1.KeeperRegistryUpkeepCanceled{}.Topic(), "Registry should listen to KeeperRegistryUpkeepCanceled log")
+	require.Contains(t, logListenerOpts.LogsWithTopics, registry1_1.KeeperRegistryUpkeepRegistered{}.Topic(), "Registry should listen to KeeperRegistryUpkeepRegistered log")
+	require.Contains(t, logListenerOpts.LogsWithTopics, registry1_1.KeeperRegistryUpkeepPerformed{}.Topic(), "Registry should listen to KeeperRegistryUpkeepPerformed log")
 }
 
 func Test_RegistrySynchronizer1_1_Start(t *testing.T) {

--- a/core/services/keeper/registry1_2_synchronizer_test.go
+++ b/core/services/keeper/registry1_2_synchronizer_test.go
@@ -17,6 +17,7 @@ import (
 	registry1_2 "github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/keeper_registry_wrapper1_2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
+	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/keeper"
 )
 
@@ -77,6 +78,32 @@ func mockRegistry1_2(
 	if timesGetUpkeepMock > 0 {
 		registryMock.MockResponse("getUpkeep", upkeepConfig).Times(timesGetUpkeepMock)
 	}
+}
+
+func Test_LogListenerOpts1_2(t *testing.T) {
+	db := pgtest.NewSqlxDB(t)
+	korm := keeper.NewORM(db, logger.TestLogger(t), nil, nil)
+	ethClient := cltest.NewEthClientMockWithDefaultChain(t)
+	j := cltest.MustInsertKeeperJob(t, db, korm, cltest.NewEIP55Address(), cltest.NewEIP55Address())
+
+	contractAddress := j.KeeperSpec.ContractAddress.Address()
+	registryMock := cltest.NewContractMockReceiver(t, ethClient, keeper.Registry1_1ABI, contractAddress)
+	registryMock.MockResponse("typeAndVersion", "KeeperRegistry 1.2.0").Once()
+
+	registryWrapper, err := keeper.NewRegistryWrapper(j.KeeperSpec.ContractAddress, ethClient)
+	require.NoError(t, err)
+
+	logListenerOpts, err := registryWrapper.GetLogListenerOpts(1, nil)
+	require.NoError(t, err)
+
+	require.Contains(t, logListenerOpts.LogsWithTopics, registry1_2.KeeperRegistryKeepersUpdated{}.Topic(), "Registry should listen to KeeperRegistryKeepersUpdated log")
+	require.Contains(t, logListenerOpts.LogsWithTopics, registry1_2.KeeperRegistryConfigSet{}.Topic(), "Registry should listen to KeeperRegistryConfigSet log")
+	require.Contains(t, logListenerOpts.LogsWithTopics, registry1_2.KeeperRegistryUpkeepCanceled{}.Topic(), "Registry should listen to KeeperRegistryUpkeepCanceled log")
+	require.Contains(t, logListenerOpts.LogsWithTopics, registry1_2.KeeperRegistryUpkeepRegistered{}.Topic(), "Registry should listen to KeeperRegistryUpkeepRegistered log")
+	require.Contains(t, logListenerOpts.LogsWithTopics, registry1_2.KeeperRegistryUpkeepPerformed{}.Topic(), "Registry should listen to KeeperRegistryUpkeepPerformed log")
+	require.Contains(t, logListenerOpts.LogsWithTopics, registry1_2.KeeperRegistryUpkeepGasLimitSet{}.Topic(), "Registry should listen to KeeperRegistryUpkeepGasLimitSet log")
+	require.Contains(t, logListenerOpts.LogsWithTopics, registry1_2.KeeperRegistryUpkeepMigrated{}.Topic(), "Registry should listen to KeeperRegistryUpkeepMigrated log")
+	require.Contains(t, logListenerOpts.LogsWithTopics, registry1_2.KeeperRegistryUpkeepReceived{}.Topic(), "Registry should listen to KeeperRegistryUpkeepReceived log")
 }
 
 func Test_RegistrySynchronizer1_2_Start(t *testing.T) {

--- a/core/services/keeper/registry_interface_logs.go
+++ b/core/services/keeper/registry_interface_logs.go
@@ -36,6 +36,8 @@ func (rw *RegistryWrapper) GetLogListenerOpts(minIncomingConfirmations uint32, u
 				registry1_2.KeeperRegistryUpkeepRegistered{}.Topic():  nil,
 				registry1_2.KeeperRegistryUpkeepPerformed{}.Topic():   upkeepPerformedFilter,
 				registry1_2.KeeperRegistryUpkeepGasLimitSet{}.Topic(): nil,
+				registry1_2.KeeperRegistryUpkeepMigrated{}.Topic():    nil,
+				registry1_2.KeeperRegistryUpkeepReceived{}.Topic():    nil,
 			},
 			MinIncomingConfirmations: minIncomingConfirmations,
 		}, nil


### PR DESCRIPTION
I added these logs in https://github.com/smartcontractkit/chainlink/pull/6622 but forgot to add those to the log listener

The tests passed because they directly test the log handler and not listening to logs. 