### PR TITLE
Optimize FindEthtxesRequiringRebroadcast() for performance

### DIFF
--- a/core/store/migrate/migrations/0150_eth_tx_attempt.sql
+++ b/core/store/migrate/migrations/0150_eth_tx_attempt.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+
+-- +goose StatementBegin
+
+--
+-- Name: eth_txes_state; Type: TYPE; Schema: public; Owner: postgres
+--
+CREATE TYPE eth_tx_attempt AS (
+		 id BIGINT,
+		 eth_tx_id BIGINT,
+		 gas_price NUMERIC(78,0),
+		 signed_raw_tx BYTEA,
+		 hash BYTEA,
+		 broadcast_before_block_num BIGINT,
+		 state eth_tx_attempts_state,
+		 created_at TIMESTAMP,
+		 chain_specific_gas_limit BIGINT,
+		 tx_type SMALLINT,
+		 gas_tip_cap NUMERIC(78,0),
+		 gas_fee_cap NUMERIC(78,0)
+)
+-- +goose StatementEnd
+
+-- +goose Down
+DROP TYPE IF EXISTS eth_tx_attempt;

--- a/core/store/migrate/migrations/0150_eth_tx_attempt.sql
+++ b/core/store/migrate/migrations/0150_eth_tx_attempt.sql
@@ -3,7 +3,7 @@
 -- +goose StatementBegin
 
 --
--- Name: eth_txes_state; Type: TYPE; Schema: public; Owner: postgres
+-- Name: eth_tx_attempt; Type: TYPE; Schema: public; Owner: postgres
 --
 CREATE TYPE eth_tx_attempt AS (
 		 id BIGINT,


### PR DESCRIPTION
Draft of performance-optimized FindEthTxRequiringRebroadcast queries.

Previously there were a sequence of 4 queries sent to the db, each waiting for the previous to complete.  And one of the queries involved a subquery, requiring 2 passes in serial over the same table.

This optimized version combines all 4 queries into a single query, with just a single pass over the tables involved.  Also greatly simplifies the logic needed to process the results returned.