### PR TITLE
Create new build-publish-develop workflow that pushes to develop image ECR

### DIFF
--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -1,6 +1,6 @@
 name: Build and Publish Chainlink
 
-description: A composite action that allows building and publishing signed chainlink images. Note that this action only supports public ECR repositories. The value of the registry to login to in the docker/login-action setup is hardcoded to 'public.ecr.aws'
+description: A composite action that allows building and publishing signed chainlink images.
 
 inputs:
   # Inputs for publishing
@@ -9,13 +9,17 @@ inputs:
     default: "false"
     required: false
 
-  image-name:
-    description: The name of the image, should match the repository name in ECR
-    required: true
-
-  ecr-registry:
-    description: The ECR registry to push to, used in docker/login-action and for tagging images
-    default: public.ecr.aws/chainlink
+  ecr-prefix:
+    description: The ECR registry scope
+    default: public.ecr.aws
+    required: false
+  ecr-repo-path:
+    description: Name of the ECR registry to push to, used in docker/login-action and for tagging images
+    default: chainlink/chainlink
+    required: false
+  aws-use-access-key:
+    description: If true, aws will be authenticated via 'aws-access-key-id', else role will be assumed through OIDC
+    default: true
     required: false
   aws-access-key-id:
     description: The IAM access key used to authenticate to ECR, used in configuring docker/login-action
@@ -63,7 +67,7 @@ runs:
     shell: sh
     # See https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#multiline-strings
     run: |
-      SHARED_IMAGES=${{ inputs.ecr-registry }}/${{ inputs.image-name }}
+      SHARED_IMAGES=${{ inputs.ecr-prefix }}/${{ inputs.ecr-repo-path }}
 
       SHARED_TAG_LIST=$(cat << EOF
       type=ref,event=branch
@@ -89,7 +93,7 @@ runs:
       echo "$SHARED_BUILD_ARGS" >> $GITHUB_ENV
       echo "EOF" >> $GITHUB_ENV
 
-  - if: inputs.publish == 'true'
+  - if: inputs.publish == 'true' && inputs.aws-use-access-key == 'true'
     name: Configure AWS Credentials
     uses: aws-actions/configure-aws-credentials@ea7b857d8a33dc2fb4ef5a724500044281b49a5e # v1.6.0
     with:
@@ -99,11 +103,19 @@ runs:
       role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
       aws-region: ${{ inputs.aws-region }}
 
+  - if: inputs.publish == 'true' && inputs.aws-use-access-key == 'false'
+    name: Configure AWS Credentials
+    uses: aws-actions/configure-aws-credentials@ea7b857d8a33dc2fb4ef5a724500044281b49a5e # v1.6.0
+    with:
+      role-to-assume: ${{ inputs.aws-role-to-assume }}
+      role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
+      aws-region: ${{ inputs.aws-region }}
+
   - if: inputs.publish == 'true'
     name: Login to ECR
     uses: docker/login-action@42d299face0c5c43a0487c477f595ac9cf22f1a7 # v1.12.0
     with:
-      registry: public.ecr.aws
+      registry: ${{ inputs.ecr-prefix }}
 
   - name: Setup Docker Buildx
     uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # v1.6.0
@@ -178,7 +190,7 @@ runs:
       echo "Fail build if non-root image runs as user: root"
       # if we're publishing the image, it doesn't get loaded into the local docker daemon
       # so we need to pull the image into our daemon
-      if [ $PUBLISH = "true" ]; then 
+      if [ $PUBLISH = "true" ]; then
        docker pull "${nonroot_image_name}"
       fi
       docker inspect "${nonroot_image_name}" | jq -r '.[].Config.User' | ( ! grep "root" )

--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -9,23 +9,21 @@ inputs:
     default: "false"
     required: false
 
-  ecr-prefix:
+  ecr-hostname:
     description: The ECR registry scope
     default: public.ecr.aws
     required: false
-  ecr-repo-path:
-    description: Name of the ECR registry to push to, used in docker/login-action and for tagging images
+  ecr-image-name:
+    description: |
+      The image name with path, in the format of `[registry]/repository`. For private ECR repos the registry name is optional, where for public repos, it is required.
+      Eg. Public ECR repo `chainlink` and registry alias `chainlinklabs` should be `chainlinklabs/chainlink`. For a private ECR repo `chainlink` the image name should be `chainlink`
     default: chainlink/chainlink
     required: false
-  aws-use-access-key:
-    description: If true, aws will be authenticated via 'aws-access-key-id', else role will be assumed through OIDC
-    default: true
-    required: false
   aws-access-key-id:
-    description: The IAM access key used to authenticate to ECR, used in configuring docker/login-action
+    description: The IAM access key used to authenticate to ECR, used in configuring docker/login-action. Omit this and aws-secret-access-key to attempt OIDC authentication
     required: false
   aws-secret-access-key:
-    description: The IAM access key secret used to authenticate to ECR, used in configuring docker/login-action
+    description: The IAM access key secret used to authenticate to ECR, used in configuring docker/login-action. Omit this and aws-secret-access-key to attempt OIDC authentication
     required: false
   aws-role-to-assume:
     description: The AWS role to assume as the CD user, if any. Used in configuring the docker/login-action
@@ -67,7 +65,7 @@ runs:
     shell: sh
     # See https://docs.github.com/en/actions/learn-github-actions/workflow-commands-for-github-actions#multiline-strings
     run: |
-      SHARED_IMAGES=${{ inputs.ecr-prefix }}/${{ inputs.ecr-repo-path }}
+      SHARED_IMAGES=${{ inputs.ecr-hostname }}/${{ inputs.ecr-image-name }}
 
       SHARED_TAG_LIST=$(cat << EOF
       type=ref,event=branch
@@ -93,7 +91,8 @@ runs:
       echo "$SHARED_BUILD_ARGS" >> $GITHUB_ENV
       echo "EOF" >> $GITHUB_ENV
 
-  - if: inputs.publish == 'true' && inputs.aws-use-access-key == 'true'
+  - if: inputs.publish == 'true'
+    # Log in to AWS for publish to ECR, OIDC auth will be attempted instead if both access-key fields are empty
     name: Configure AWS Credentials
     uses: aws-actions/configure-aws-credentials@ea7b857d8a33dc2fb4ef5a724500044281b49a5e # v1.6.0
     with:
@@ -103,19 +102,11 @@ runs:
       role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
       aws-region: ${{ inputs.aws-region }}
 
-  - if: inputs.publish == 'true' && inputs.aws-use-access-key == 'false'
-    name: Configure AWS Credentials
-    uses: aws-actions/configure-aws-credentials@ea7b857d8a33dc2fb4ef5a724500044281b49a5e # v1.6.0
-    with:
-      role-to-assume: ${{ inputs.aws-role-to-assume }}
-      role-duration-seconds: ${{ inputs.aws-role-duration-seconds }}
-      aws-region: ${{ inputs.aws-region }}
-
   - if: inputs.publish == 'true'
     name: Login to ECR
     uses: docker/login-action@42d299face0c5c43a0487c477f595ac9cf22f1a7 # v1.12.0
     with:
-      registry: ${{ inputs.ecr-prefix }}
+      registry: ${{ inputs.ecr-hostname }}
 
   - name: Setup Docker Buildx
     uses: docker/setup-buildx-action@94ab11c41e45d028884a99163086648e898eed25 # v1.6.0

--- a/.github/workflows/build-publish-develop.yml
+++ b/.github/workflows/build-publish-develop.yml
@@ -1,4 +1,4 @@
-name: 'Build Chainlink and push image with latest develop tag'
+name: 'Push develop to private ECR'
 
 on:
   push:
@@ -6,7 +6,7 @@ on:
       - develop
 
 jobs:
-  build-publish-chainlink-develop:
+  push-chainlink-develop:
     runs-on: ubuntu-20.04
     environment: build-develop
     permissions:
@@ -20,9 +20,8 @@ jobs:
         uses: ./.github/actions/build-sign-publish-chainlink
         with:
           publish: true
-          aws-use-access-key: false
           aws-role-to-assume: ${{ secrets.AWS_OIDC_IAM_ROLE_ARN }}
           aws-role-duration-seconds: ${{ secrets.AWS_ROLE_DURATION_SECONDS }}
           aws-region: ${{ secrets.AWS_REGION }}
-          ecr-prefix: ${{ secrets.AWS_DEVELOP_ECR_PREFIX }}
-          ecr-repo-path: chainlink
+          ecr-hostname: ${{ secrets.AWS_DEVELOP_ECR_HOSTNAME }}
+          ecr-image-name: chainlink

--- a/.github/workflows/build-publish-develop.yml
+++ b/.github/workflows/build-publish-develop.yml
@@ -20,7 +20,6 @@ jobs:
         uses: ./.github/actions/build-sign-publish-chainlink
         with:
           publish: true
-          image-name: chainlink
           aws-use-access-key: false
           aws-role-to-assume: ${{ secrets.AWS_OIDC_IAM_ROLE_ARN }}
           aws-role-duration-seconds: ${{ secrets.AWS_ROLE_DURATION_SECONDS }}

--- a/.github/workflows/build-publish-develop.yml
+++ b/.github/workflows/build-publish-develop.yml
@@ -1,0 +1,29 @@
+name: 'Build Chainlink and push image with latest develop tag'
+
+on:
+  push:
+    branches:
+      - develop
+
+jobs:
+  build-publish-chainlink-develop:
+    runs-on: ubuntu-20.04
+    environment: build-develop
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@ec3a7ce113134d7a93b817d10a8272cb61118579 # v2.4.0
+
+      - name: Build, sign and publish chainlink image
+        uses: ./.github/actions/build-sign-publish-chainlink
+        with:
+          publish: true
+          image-name: chainlink
+          aws-use-access-key: false
+          aws-role-to-assume: ${{ secrets.AWS_OIDC_IAM_ROLE_ARN }}
+          aws-role-duration-seconds: ${{ secrets.AWS_ROLE_DURATION_SECONDS }}
+          aws-region: ${{ secrets.AWS_REGION }}
+          ecr-prefix: ${{ secrets.AWS_DEVELOP_ECR_PREFIX }}
+          ecr-repo-path: chainlink

--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -20,7 +20,6 @@ jobs:
         uses: ./.github/actions/build-sign-publish-chainlink
         with:
           publish: true
-          image-name: chainlink
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           aws-role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,5 +18,4 @@ jobs:
         uses: ./.github/actions/build-sign-publish-chainlink
         with:
           publish: false
-          image-name: test-chainlink
           sign-images: false


### PR DESCRIPTION
- Create new build-publish-develop workflow that pushes to develop image ECR
- Update composite actions to allow AWS authentication via OIDC and rework inputs to support any registry path