### PR TITLE
improve error logs when creating test db

### DIFF
--- a/core/internal/cltest/heavyweight/orm.go
+++ b/core/internal/cltest/heavyweight/orm.go
@@ -102,7 +102,8 @@ func dropAndCreateThrowawayTestDB(parsed url.URL, postfix string, empty bool) (s
 	parsed.Path = "/postgres"
 	db, err := sql.Open(string(dialects.Postgres), parsed.String())
 	if err != nil {
-		return "", fmt.Errorf("unable to open postgres database for creating test db: %+v", err)
+		return "", fmt.Errorf("In order to drop the test database, we need to connect to a separate database"+
+			" called 'postgres'. But we are unable to open 'postgres' database: %+v\n", err)
 	}
 	defer db.Close()
 


### PR DESCRIPTION
wanted to create a new database in flight like [this](https://stackoverflow.com/a/57539582) but i realize there is not "CREATE DATABASE *** IF NOT EXISTS" in postgres. I don't want to assume a database name is not used by anyone. Hence, I just updated the error logs.