### PR TITLE
implement a gas usage wrapper for checkUpkeep function

### DIFF
--- a/contracts/src/v0.8/dev/KeeperRegistryCheckUpkeepGasUsageWrapper.sol
+++ b/contracts/src/v0.8/dev/KeeperRegistryCheckUpkeepGasUsageWrapper.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.13;
+
+import "../KeeperRegistry.sol";
+import "../ConfirmedOwner.sol";
+
+/**
+ * @notice This contract serves as a wrapper around a keeper registry's checkUpkeep function.
+ */
+contract KeeperRegistryCheckUpkeepGasUsageWrapper is ConfirmedOwner {
+  KeeperRegistryExecutableInterface private immutable i_keeperRegistry;
+
+  /**
+   * @param keeperRegistry address of a keeper registry
+   */
+  constructor(KeeperRegistryExecutableInterface keeperRegistry) ConfirmedOwner(msg.sender) {
+    i_keeperRegistry = keeperRegistry;
+  }
+
+  /**
+   * @return the keeper registry
+   */
+  function getKeeperRegistry() external view returns (KeeperRegistryExecutableInterface) {
+    return i_keeperRegistry;
+  }
+
+  /**
+   * @notice This function is called by monitoring service to estimate how much gas checkUpkeep functions will consume.
+   * @param id identifier of the upkeep to check
+   * @param from the address to simulate performing the upkeep from
+   */
+  function checkUpkeep(uint256 id, address from)
+    external
+    returns (
+      bool checkUpkeepSuccess,
+      bytes memory performData,
+      uint256 gasUsed
+    )
+  {
+    uint256 startGas = gasleft();
+    try i_keeperRegistry.checkUpkeep(id, from) returns (
+      bytes memory performData,
+      uint256 maxLinkPayment,
+      uint256 gasLimit,
+      uint256 adjustedGasWei,
+      uint256 linkEth
+    ) {
+      gasUsed = startGas - gasleft();
+      return (true, performData, gasUsed);
+    } catch {
+      gasUsed = startGas - gasleft();
+      return (false, "", gasUsed);
+    }
+  }
+}

--- a/contracts/test/v0.8/dev/KeeperRegistryCheckUpkeepGasUsageWrapper.test.ts
+++ b/contracts/test/v0.8/dev/KeeperRegistryCheckUpkeepGasUsageWrapper.test.ts
@@ -1,0 +1,107 @@
+import { ethers } from 'hardhat'
+import { BigNumber, Signer } from 'ethers'
+import { assert } from 'chai'
+import { KeeperRegistryCheckUpkeepGasUsageWrapper } from '../../../typechain/KeeperRegistryCheckUpkeepGasUsageWrapper'
+import { getUsers, Personas } from '../../test-helpers/setup'
+import {
+  deployMockContract,
+  MockContract,
+} from '@ethereum-waffle/mock-contract'
+import { abi as registryAbi } from '../../../artifacts/src/v0.8/KeeperRegistry.sol/KeeperRegistry.json'
+
+let personas: Personas
+let owner: Signer
+let caller: Signer
+let registryMockContract: MockContract
+let gasUsageWrapper: KeeperRegistryCheckUpkeepGasUsageWrapper
+const upkeepId = 123
+
+describe('KeeperRegistryCheckUpkeepGasUsageWrapper', () => {
+  before(async () => {
+    personas = (await getUsers()).personas
+    owner = personas.Default
+    caller = personas.Nelly
+
+    registryMockContract = await deployMockContract(owner as any, registryAbi)
+    const gasUsageWrapperFactory = await ethers.getContractFactory(
+      'KeeperRegistryCheckUpkeepGasUsageWrapper',
+    )
+    gasUsageWrapper = await gasUsageWrapperFactory
+      .connect(owner)
+      .deploy(registryMockContract.address)
+    await gasUsageWrapper.deployed()
+  })
+
+  describe('checkUpkeep()', () => {
+    it("returns gas used when registry's checkUpkeep executes successfully", async () => {
+      await registryMockContract.mock.checkUpkeep
+        .withArgs(upkeepId, await caller.getAddress())
+        .returns(
+          '0x' /* performData */,
+          BigNumber.from(1000) /* maxLinkPayment */,
+          BigNumber.from(2000) /* gasLimit */,
+          BigNumber.from(3000) /* adjustedGasWei */,
+          BigNumber.from(4000) /* linkEth */,
+        )
+
+      const response = await gasUsageWrapper
+        .connect(caller)
+        .callStatic.checkUpkeep(
+          BigNumber.from(upkeepId),
+          await caller.getAddress(),
+        )
+
+      assert.isTrue(
+        response.checkUpkeepSuccess,
+        'The checkUpkeepSuccess should be true',
+      )
+      assert.equal(
+        response.performData,
+        '0x',
+        'The performData should be forwarded correctly',
+      )
+      assert.isTrue(
+        response.gasUsed > BigNumber.from(0),
+        'The gasUsed value must be larger than 0',
+      )
+    })
+
+    it("returns gas used when registry's checkUpkeep reverts", async () => {
+      await registryMockContract.mock.checkUpkeep
+        .withArgs(upkeepId, await caller.getAddress())
+        .revertsWithReason('Error')
+
+      const response = await gasUsageWrapper
+        .connect(caller)
+        .callStatic.checkUpkeep(
+          BigNumber.from(upkeepId),
+          await caller.getAddress(),
+        )
+
+      assert.isFalse(
+        response.checkUpkeepSuccess,
+        'The checkUpkeepSuccess should be false',
+      )
+      assert.equal(
+        response.performData,
+        '0x',
+        'The performData should be forwarded correctly',
+      )
+      assert.isTrue(
+        response.gasUsed > BigNumber.from(0),
+        'The gasUsed value must be larger than 0',
+      )
+    })
+  })
+
+  describe('getKeeperRegistry()', () => {
+    it('returns the underlying keeper registry', async () => {
+      const registry = await gasUsageWrapper.connect(caller).getKeeperRegistry()
+      assert.equal(
+        registry,
+        registryMockContract.address,
+        'The underlying keeper registry is incorrect',
+      )
+    })
+  })
+})


### PR DESCRIPTION
implement a gas usage wrapper for checkUpkeep function.
monitoring service can call this function to understand how much gas is used for each checkUpkeep calls.
this function can return proper gas usage no matter the underlying checkUpkeep function reverts or not.