### PR TITLE
core/logger: swap/remove MemoryLogTestingOnly sink for TestLoggerObserved

### DIFF
--- a/core/chains/evm/headtracker/head_broadcaster.go
+++ b/core/chains/evm/headtracker/head_broadcaster.go
@@ -28,7 +28,7 @@ func (set callbackSet) values() []httypes.HeadTrackable {
 // NewHeadBroadcaster creates a new HeadBroadcaster
 func NewHeadBroadcaster(lggr logger.Logger) httypes.HeadBroadcaster {
 	return &headBroadcaster{
-		logger:        lggr.Named(logger.HeadBroadcaster),
+		logger:        lggr.Named("HeadBroadcaster"),
 		callbacks:     make(callbackSet),
 		mailbox:       utils.NewMailbox[*evmtypes.Head](1),
 		mutex:         &sync.Mutex{},

--- a/core/chains/evm/headtracker/head_listener.go
+++ b/core/chains/evm/headtracker/head_listener.go
@@ -45,7 +45,7 @@ func NewHeadListener(lggr logger.Logger, ethClient evmclient.Client, config Conf
 	return &headListener{
 		config:    config,
 		ethClient: ethClient,
-		logger:    lggr.Named(logger.HeadListener),
+		logger:    lggr.Named("HeadListener"),
 		chStop:    chStop,
 	}
 }

--- a/core/chains/evm/headtracker/head_saver.go
+++ b/core/chains/evm/headtracker/head_saver.go
@@ -21,7 +21,7 @@ func NewHeadSaver(lggr logger.Logger, orm ORM, config Config) httypes.HeadSaver 
 	return &headSaver{
 		orm:    orm,
 		config: config,
-		logger: lggr.Named(logger.HeadSaver),
+		logger: lggr.Named("HeadSaver"),
 		heads:  NewHeads(),
 	}
 }

--- a/core/chains/evm/headtracker/head_tracker.go
+++ b/core/chains/evm/headtracker/head_tracker.go
@@ -60,7 +60,7 @@ func NewHeadTracker(
 	headSaver httypes.HeadSaver,
 ) httypes.HeadTracker {
 	chStop := make(chan struct{})
-	lggr = lggr.Named(logger.HeadTracker)
+	lggr = lggr.Named("HeadTracker")
 	return &headTracker{
 		headBroadcaster: headBroadcaster,
 		ethClient:       ethClient,

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"github.com/tidwall/gjson"
+	"go.uber.org/zap/zapcore"
 	"gopkg.in/guregu/null.v4"
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
@@ -53,6 +54,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/chains/terra"
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/config"
+	"github.com/smartcontractkit/chainlink/core/config/envvar"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
@@ -128,15 +130,16 @@ func init() {
 	gomega.SetDefaultConsistentlyPollingInterval(100 * time.Millisecond)
 
 	logger.InitColor(true)
-	lggr := logger.TestLogger(nil)
-	gin.DebugPrintRouteFunc = func(httpMethod, absolutePath, handlerName string, nuHandlers int) {
-		lggr.Debugf("%-6s %-25s --> %s (%d handlers)", httpMethod, absolutePath, handlerName, nuHandlers)
+	if ll, _ := envvar.LogLevel.Parse(); ll.Enabled(zapcore.DebugLevel) {
+		gin.DebugPrintRouteFunc = func(httpMethod, absolutePath, handlerName string, nuHandlers int) {
+			fmt.Printf("[gin] %-6s %-25s --> %s (%d handlers)\n", httpMethod, absolutePath, handlerName, nuHandlers)
+		}
 	}
 
 	// Seed the random number generator, otherwise separate modules will take
 	// the same advisory locks when tested with `go test -p N` for N > 1
 	seed := time.Now().UTC().UnixNano()
-	lggr.Debugf("Using seed: %v", seed)
+	fmt.Printf("cltest random seed: %v\n", seed)
 	rand.Seed(seed)
 
 	// Also seed the local source

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -115,16 +115,6 @@ type Logger interface {
 	Recover(panicErr interface{})
 }
 
-// Constants for service names for package specific logging configuration
-const (
-	HeadTracker     = "HeadTracker"
-	HeadListener    = "HeadListener"
-	HeadSaver       = "HeadSaver"
-	HeadBroadcaster = "HeadBroadcaster"
-	FluxMonitor     = "FluxMonitor"
-	Keeper          = "Keeper"
-)
-
 // newZapConfigProd returns a new production zap.Config.
 func newZapConfigProd(jsonConsole bool, unixTS bool) zap.Config {
 	config := newZapConfigBase()
@@ -243,12 +233,11 @@ type Config struct {
 func (c *Config) New() (Logger, func() error) {
 	cfg := newZapConfigProd(c.JsonConsole, c.UnixTS)
 	cfg.Level.SetLevel(c.LogLevel)
-	l, close, err := zapLoggerConfig{
+	l, close, err := zapDiskLoggerConfig{
 		local:          *c,
-		Config:         cfg,
 		diskStats:      utils.NewDiskStatsProvider(),
 		diskPollConfig: newDiskPollConfig(diskPollInterval),
-	}.newLogger()
+	}.newLogger(cfg)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/core/logger/logger_test.go
+++ b/core/logger/logger_test.go
@@ -9,12 +9,10 @@ import (
 func TestConfig(t *testing.T) {
 	// no sampling
 	assert.Nil(t, newZapConfigBase().Sampling)
-	assert.Nil(t, newZapConfigTest().Sampling)
 	assert.Nil(t, newZapConfigProd(false, false).Sampling)
 
 	// not development, which would trigger panics for Critical level
 	assert.False(t, newZapConfigBase().Development)
-	assert.False(t, newZapConfigTest().Development)
 	assert.False(t, newZapConfigProd(false, false).Development)
 }
 

--- a/core/logger/test_logger_test.go
+++ b/core/logger/test_logger_test.go
@@ -4,25 +4,18 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 func init() {
 	InitColor(false)
-
 }
 
 func TestTestLogger(t *testing.T) {
-	lgr := TestLogger(t)
-	lgr.SetLogLevel(zapcore.InfoLevel)
-	requireContains := func(cs ...string) {
-		t.Helper()
-		logs := MemoryLogTestingOnly().String()
-		for _, c := range cs {
-			require.Contains(t, logs, c)
-		}
-	}
+	lgr, observed := TestLoggerObserved(t, zapcore.DebugLevel)
 
 	const (
 		testName    = "TestTestLogger"
@@ -30,20 +23,29 @@ func TestTestLogger(t *testing.T) {
 	)
 	lgr.Warn(testMessage)
 	// [WARN]  Test message		logger/test_logger_test.go:23    logger=1.0.0@sHaValue.TestLogger
-	requireContains("[WARN]", testMessage, fmt.Sprintf("logger=%s.%s", verShaNameStatic(), testName))
+	logs := observed.TakeAll()
+	require.Len(t, logs, 1)
+	log := logs[0]
+	assert.Equal(t, zap.WarnLevel, log.Level)
+	assert.Equal(t, testMessage, log.Message)
+	assert.Equal(t, fmt.Sprintf("%s.%s", verShaNameStatic(), testName), log.LoggerName)
 
 	const (
 		serviceName    = "ServiceName"
 		serviceMessage = "Service message"
 		key, value     = "key", "value"
-		omittedMessage = "Don't log me"
 	)
 	srvLgr := lgr.Named(serviceName)
 	srvLgr.SetLogLevel(zapcore.DebugLevel)
 	srvLgr.Debugw(serviceMessage, key, value)
 	// [DEBUG]  Service message		logger/test_logger_test.go:35    key=value logger=1.0.0@sHaValue.TestLogger.ServiceName
-	requireContains("[DEBUG]", serviceMessage, fmt.Sprintf("%s=%s", key, value),
-		fmt.Sprintf("logger=%s.%s.%s", verShaNameStatic(), testName, serviceName))
+	logs = observed.TakeAll()
+	require.Len(t, logs, 1)
+	log = logs[0]
+	assert.Equal(t, zap.DebugLevel, log.Level)
+	assert.Equal(t, serviceMessage, log.Message)
+	assert.Equal(t, fmt.Sprintf("%s.%s.%s", verShaNameStatic(), testName, serviceName), log.LoggerName)
+	assert.Equal(t, value, log.ContextMap()[key])
 
 	const (
 		workerName           = "WorkerName"
@@ -54,12 +56,23 @@ func TestTestLogger(t *testing.T) {
 	wrkLgr := srvLgr.Named(workerName).With(idKey, workerId)
 	wrkLgr.Infow(workerMessage, resultKey, resultVal)
 	// [INFO]	Did some work		logger/test_logger_test.go:49    logger=1.0.0@sHaValue.TestLogger.ServiceName.WorkerName result=success workerId=42
-	requireContains("[INFO]", workerMessage, fmt.Sprintf("%s=%s", idKey, workerId),
-		fmt.Sprintf("%s=%s", resultKey, resultVal), fmt.Sprintf("logger=%s.%s.%s.%s", verShaNameStatic(), testName, serviceName, workerName))
+	logs = observed.TakeAll()
+	require.Len(t, logs, 1)
+	log = logs[0]
+	assert.Equal(t, zap.InfoLevel, log.Level)
+	assert.Equal(t, workerMessage, log.Message)
+	assert.Equal(t, fmt.Sprintf("%s.%s.%s.%s", verShaNameStatic(), testName, serviceName, workerName), log.LoggerName)
+	assert.Equal(t, workerId, log.ContextMap()[idKey])
+	assert.Equal(t, resultVal, log.ContextMap()[resultKey])
 
 	const (
 		critMsg = "Critical error"
 	)
 	lgr.Critical(critMsg)
-	requireContains("[CRIT]", critMsg, fmt.Sprintf("logger=%s.%s", verShaNameStatic(), testName))
+	logs = observed.TakeAll()
+	require.Len(t, logs, 1)
+	log = logs[0]
+	assert.Equal(t, zap.DPanicLevel, log.Level)
+	assert.Equal(t, critMsg, log.Message)
+	assert.Equal(t, fmt.Sprintf("%s.%s", verShaNameStatic(), testName), log.LoggerName)
 }

--- a/core/logger/trace_noop_test.go
+++ b/core/logger/trace_noop_test.go
@@ -3,7 +3,6 @@
 package logger
 
 import (
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -11,15 +10,7 @@ import (
 )
 
 func TestTrace(t *testing.T) {
-	lgr := TestLogger(t)
-	lgr.SetLogLevel(zapcore.InfoLevel)
-	requireNotContains := func(ns ...string) {
-		t.Helper()
-		logs := MemoryLogTestingOnly().String()
-		for _, n := range ns {
-			require.NotContains(t, logs, n)
-		}
-	}
+	lgr, observered := TestLoggerObserved(t, zapcore.InfoLevel)
 
 	const (
 		testName    = "TestTrace"
@@ -27,10 +18,10 @@ func TestTrace(t *testing.T) {
 	)
 	lgr.Trace(testMessage)
 	// [DEBUG] [TRACE] Trace message		logger/test_logger_test.go:23    logger=TestLogger
-	requireNotContains("[TRACE]", testMessage, fmt.Sprintf("logger=%s", testName))
+	require.Empty(t, observered.TakeAll())
 
 	lgr.SetLogLevel(zapcore.DebugLevel)
 	lgr.Trace(testMessage)
 	// [DEBUG] [TRACE] Trace message		logger/test_logger_test.go:23    logger=TestLogger
-	requireNotContains("[TRACE]", testMessage, fmt.Sprintf("logger=%s", testName))
+	require.Empty(t, observered.TakeAll())
 }

--- a/core/logger/zap_disk_logging.go
+++ b/core/logger/zap_disk_logging.go
@@ -1,6 +1,8 @@
 package logger
 
 import (
+	"errors"
+	"sync"
 	"time"
 
 	"github.com/smartcontractkit/chainlink/core/utils"
@@ -31,11 +33,23 @@ func newDiskPollConfig(interval time.Duration) zapDiskPollConfig {
 	}
 }
 
-func (cfg zapLoggerConfig) newDiskCore() (zapcore.Core, error) {
+var _ Logger = &zapDiskLogger{}
+
+// zapDiskLoggerConfig defines the struct that serves as config when spinning up a the zap logger
+type zapDiskLoggerConfig struct {
+	local          Config
+	diskStats      utils.DiskStatsProvider
+	diskPollConfig zapDiskPollConfig
+
+	// This is for tests only
+	testDiskLogLvlChan chan zapcore.Level
+}
+
+func (cfg zapDiskLoggerConfig) newDiskCore(diskLogLevel zap.AtomicLevel) (zapcore.Core, error) {
 	availableSpace, err := cfg.diskStats.AvailableSpace(cfg.local.Dir)
 	if err != nil || availableSpace < cfg.local.RequiredDiskSpace() {
 		// Won't log to disk if the directory is not found or there's not enough disk space
-		cfg.diskLogLevel.SetLevel(disabledLevel)
+		diskLogLevel.SetLevel(disabledLevel)
 	}
 
 	var (
@@ -47,13 +61,90 @@ func (cfg zapLoggerConfig) newDiskCore() (zapcore.Core, error) {
 			MaxBackups: cfg.local.FileMaxBackups,
 			Compress:   true,
 		})
-		allLogLevels = zap.LevelEnablerFunc(cfg.diskLogLevel.Enabled)
+		allLogLevels = zap.LevelEnablerFunc(diskLogLevel.Enabled)
 	)
 
 	return zapcore.NewCore(encoder, sink, allLogLevels), nil
 }
 
-func (l *zapLogger) pollDiskSpace() {
+type zapDiskLogger struct {
+	zapLogger
+	config            zapDiskLoggerConfig
+	diskLogLevel      zap.AtomicLevel
+	pollDiskSpaceStop chan struct{}
+	pollDiskSpaceDone chan struct{}
+}
+
+func (cfg zapDiskLoggerConfig) newLogger(zcfg zap.Config, cores ...zapcore.Core) (Logger, func() error, error) {
+	newCore, errWriter, err := cfg.newCore(zcfg)
+	if err != nil {
+		return nil, nil, err
+	}
+	cores = append(cores, newCore)
+	diskLogLevel := zap.NewAtomicLevelAt(zapcore.DebugLevel)
+	if cfg.local.DebugLogsToDisk() {
+		diskCore, diskErr := cfg.newDiskCore(diskLogLevel)
+		if diskErr != nil {
+			return nil, nil, diskErr
+		}
+		cores = append(cores, diskCore)
+	}
+
+	core := zapcore.NewTee(cores...)
+	lggr := &zapDiskLogger{
+		config:            cfg,
+		pollDiskSpaceStop: make(chan struct{}),
+		pollDiskSpaceDone: make(chan struct{}),
+		zapLogger: zapLogger{
+			level:         zcfg.Level,
+			SugaredLogger: zap.New(core, zap.ErrorOutput(errWriter)).Sugar(),
+		},
+		diskLogLevel: diskLogLevel,
+	}
+
+	if cfg.local.DebugLogsToDisk() {
+		go lggr.pollDiskSpace()
+	}
+
+	var once sync.Once
+	close := func() error {
+		once.Do(func() {
+			if cfg.local.DebugLogsToDisk() {
+				close(lggr.pollDiskSpaceStop)
+				<-lggr.pollDiskSpaceDone
+			}
+		})
+
+		return lggr.Sync()
+	}
+
+	return lggr, close, err
+}
+
+func (cfg zapDiskLoggerConfig) newCore(zcfg zap.Config) (zapcore.Core, zapcore.WriteSyncer, error) {
+	encoder := zapcore.NewJSONEncoder(makeEncoderConfig(cfg.local))
+
+	sink, closeOut, err := zap.Open(zcfg.OutputPaths...)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	errSink, _, err := zap.Open(zcfg.ErrorOutputPaths...)
+	if err != nil {
+		closeOut()
+		return nil, nil, err
+	}
+
+	if zcfg.Level == (zap.AtomicLevel{}) {
+		return nil, nil, errors.New("missing Level")
+	}
+
+	filteredLogLevels := zap.LevelEnablerFunc(zcfg.Level.Enabled)
+
+	return zapcore.NewCore(encoder, sink, filteredLogLevels), errSink, nil
+}
+
+func (l *zapDiskLogger) pollDiskSpace() {
 	defer l.config.diskPollConfig.stop()
 	defer close(l.pollDiskSpaceDone)
 
@@ -79,9 +170,9 @@ func (l *zapLogger) pollDiskSpace() {
 				)
 			}
 
-			lvlBefore := l.config.diskLogLevel.Level()
+			lvlBefore := l.diskLogLevel.Level()
 
-			l.config.diskLogLevel.SetLevel(lvl)
+			l.diskLogLevel.SetLevel(lvl)
 
 			if lvlBefore == disabledLevel && lvl == zapcore.DebugLevel {
 				l.Info("Resuming disk logs, disk has enough space")

--- a/core/logger/zap_test.go
+++ b/core/logger/zap_test.go
@@ -15,12 +15,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
 
 func TestZapLogger_OutOfDiskSpace(t *testing.T) {
-	cfg := newZapConfigTest()
+	cfg := newZapConfigBase()
 	ll, invalid := envvar.LogLevel.Parse()
 	assert.Empty(t, invalid)
 
@@ -39,8 +38,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 	assert.NoError(t, err)
 
 	pollCfg := newDiskPollConfig(1 * time.Second)
-	zapCfg := zapLoggerConfig{
-		Config: cfg,
+	zapCfg := zapDiskLoggerConfig{
 		local: Config{
 			Dir:            logsDir,
 			FileMaxAgeDays: 0,
@@ -48,7 +46,6 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 			FileMaxSizeMB:  int(logFileSize / utils.MB),
 		},
 		diskPollConfig: pollCfg,
-		diskLogLevel:   zap.NewAtomicLevelAt(zapcore.DebugLevel),
 	}
 
 	t.Run("on logger creation", func(t *testing.T) {
@@ -69,7 +66,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 		}
 		zapCfg.local.FileMaxSizeMB = int(maxSize/utils.MB) * 2
 
-		lggr, close, err := zapCfg.newLogger()
+		lggr, close, err := zapCfg.newLogger(cfg)
 		assert.NoError(t, err)
 		defer close()
 
@@ -103,7 +100,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 		}
 		zapCfg.local.FileMaxSizeMB = int(maxSize/utils.MB) * 2
 
-		lggr, close, err := zapCfg.newLogger()
+		lggr, close, err := zapCfg.newLogger(cfg)
 		assert.NoError(t, err)
 		defer close()
 
@@ -137,7 +134,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 		}
 		zapCfg.local.FileMaxSizeMB = int(maxSize/utils.MB) * 2
 
-		lggr, close, err := zapCfg.newLogger()
+		lggr, close, err := zapCfg.newLogger(cfg)
 		assert.NoError(t, err)
 		defer close()
 
@@ -187,7 +184,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 		}
 		zapCfg.local.FileMaxSizeMB = int(maxSize/utils.MB) * 2
 
-		lggr, close, err := zapCfg.newLogger()
+		lggr, close, err := zapCfg.newLogger(cfg)
 		assert.NoError(t, err)
 		defer close()
 


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/32902/logger-swap-remove-memorylogtestingonly-sink-for-testloggerobserved

- remove `MemoryLogTestingOnly` sink; use `TestLoggerObserved` instead
- separate disk impl from zap
- cleanup
- `TestLogger`: use https://pkg.go.dev/go.uber.org/zap/zaptest#NewLogger

> Use this with a *testing.T or *testing.B to get logs which get printed only if a test fails or if you ran go test -v.

This doesn't capture _everything_ (so we probably still need the CI filter and artifact hack), but it does limit a ton of noise (any _injected_ loggers) which is a major improvement for local runs and reduces the size of CI logs artifact on failure (~1MB earlier - down from ~30MB). CI seems faster too, just 11-12m compared to 15-20m normally :partying_face: 