### PR TITLE
tools/bin: remove -v from go test

### DIFF
--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -5,7 +5,7 @@ set +e
 echo "Failed tests and panics: ---------------------"
 echo ""
 GO_LDFLAGS=$(bash tools/bin/ldflags)
-go test -ldflags "$GO_LDFLAGS" -tags integration -v -p 3 -parallel 4 -coverprofile=coverage.txt -covermode=atomic ./... | tee ./output.txt | grep --line-buffered --line-number -e "\-\-\- FAIL" -e "FAIL\s"
+go test -ldflags "$GO_LDFLAGS" -tags integration -p 3 -parallel 4 -coverprofile=coverage.txt -covermode=atomic ./... | tee ./output.txt | grep --line-buffered --line-number -e "\-\-\- FAIL" -e "FAIL\s"
 EXITCODE=${PIPESTATUS[0]}
 echo ""
 echo "----------------------------------------------"


### PR DESCRIPTION
I don't think the verbose test option (`go test -v`) is doing us any favors here :thinking: 
It _is_ logging lines that we don't care about, like from successful tests, creating a larger, noisier artifact to comb through on failures.

CI running in ~8-9m now!

Follow up from #6734, which I mistakenly thought had achieved this already. 