### PR TITLE
Fixed allowUnrestrictedNetworkAccess example

### DIFF
--- a/core/services/pipeline/task.http.go
+++ b/core/services/pipeline/task.http.go
@@ -107,7 +107,7 @@ func (t *HTTPTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, input
 	responseBytes, statusCode, respHeaders, elapsed, err := makeHTTPRequest(requestCtx, lggr, method, url, reqHeaders, requestData, client, t.config.DefaultHTTPLimit())
 	if err != nil {
 		if errors.Is(errors.Cause(err), clhttp.ErrDisallowedIP) {
-			err = errors.Wrap(err, "connections to local resources are disabled by default, if you are sure this is safe, you can enable on a per-task basis by setting allowUnrestrictedNetworkAccess=true in the pipeline task spec")
+			err = errors.Wrap(err, `connections to local resources are disabled by default, if you are sure this is safe, you can enable on a per-task basis by setting allowUnrestrictedNetworkAccess="true" in the pipeline task spec, e.g. fetch [type="http" method=GET url="$(decode_cbor.url)" allowUnrestrictedNetworkAccess="true"]`)
 		}
 		return Result{Error: err}, RunInfo{IsRetryable: isRetryableHTTPError(statusCode, err)}
 	}


### PR DESCRIPTION
Closes https://app.shortcut.com/chainlinklabs/story/43091/update-the-error-message-to-show-the-way-how-allowunrestrictednetworkaccess-true-should-be-used