### PR TITLE
core/services/keystore/keys/ocr2key: swap out mustNewKeyFromRaw for simpler emptyKeyBundle

### DIFF
--- a/core/services/keystore/keys/ocr2key/export.go
+++ b/core/services/keystore/keys/ocr2key/export.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
 	"github.com/pkg/errors"
+
 	"github.com/smartcontractkit/chainlink/core/services/keystore/chaintype"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
@@ -33,22 +34,23 @@ func FromEncryptedJSON(keyJSON []byte, password string) (KeyBundle, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to decrypt OCR key")
 	}
+	var kb KeyBundle
 	switch export.ChainType {
 	case chaintype.EVM:
-		key := mustNewKeyFromRaw[*evmKeyring](rawKey, &evmKeyring{})
-		return &key, nil
+		kb = newKeyBundle(new(evmKeyring))
 	case chaintype.Solana:
-		key := mustNewKeyFromRaw[*solanaKeyring](rawKey, &solanaKeyring{})
-		return &key, nil
+		kb = newKeyBundle(new(solanaKeyring))
 	case chaintype.Terra:
-		key := mustNewKeyFromRaw[*terraKeyring](rawKey, &terraKeyring{})
-		return &key, nil
+		kb = newKeyBundle(new(terraKeyring))
 	case chaintype.Starknet:
-		key := mustNewKeyFromRaw[*starknetKeyring](rawKey, &starknetKeyring{})
-		return &key, nil
+		kb = newKeyBundle(new(starknetKeyring))
 	default:
 		return nil, chaintype.NewErrInvalidChainType(export.ChainType)
 	}
+	if err := kb.Unmarshal(rawKey); err != nil {
+		return nil, err
+	}
+	return kb, nil
 }
 
 // ToEncryptedJSON returns encrypted JSON representing key

--- a/core/services/keystore/keys/ocr2key/export_test.go
+++ b/core/services/keystore/keys/ocr2key/export_test.go
@@ -3,10 +3,11 @@ package ocr2key
 import (
 	"testing"
 
-	"github.com/smartcontractkit/chainlink/core/services/keystore/chaintype"
-	"github.com/smartcontractkit/chainlink/core/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/core/services/keystore/chaintype"
+	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
 func TestExport(t *testing.T) {
@@ -26,6 +27,7 @@ func TestExport(t *testing.T) {
 			ej, err := ToEncryptedJSON(kb, "blah", utils.FastScryptParams)
 			require.NoError(t, err)
 			kbAfter, err := FromEncryptedJSON(ej, "blah")
+			require.NoError(t, err)
 			assert.Equal(t, kbAfter.ID(), kb.ID())
 			assert.Equal(t, kbAfter.PublicKey(), kb.PublicKey())
 			assert.Equal(t, kbAfter.OffchainPublicKey(), kb.OffchainPublicKey())

--- a/core/services/keystore/keys/ocr2key/generic_key_bundle_test.go
+++ b/core/services/keystore/keys/ocr2key/generic_key_bundle_test.go
@@ -5,9 +5,10 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/smartcontractkit/chainlink/core/services/keystore/chaintype"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/core/services/keystore/chaintype"
 )
 
 type (
@@ -52,7 +53,8 @@ func TestGenericKeyBundle_Migrate_UnmarshalMarshal(t *testing.T) {
 		require.NoError(t, err)
 
 		// test Unmarshal with old raw bundle
-		bundle := mustNewKeyFromRaw[*evmKeyring](bundleBytes, &evmKeyring{})
+		bundle := newKeyBundle(&evmKeyring{})
+		require.NoError(t, bundle.Unmarshal(bundleBytes))
 		newBundleBytes, err := bundle.Marshal()
 		require.NoError(t, err)
 
@@ -81,7 +83,8 @@ func TestGenericKeyBundle_Migrate_UnmarshalMarshal(t *testing.T) {
 		require.NoError(t, err)
 
 		// test Unmarshal with old raw bundle
-		bundle := mustNewKeyFromRaw[*solanaKeyring](bundleBytes, &solanaKeyring{})
+		bundle := newKeyBundle(&solanaKeyring{})
+		require.NoError(t, bundle.Unmarshal(bundleBytes))
 		newBundleBytes, err := bundle.Marshal()
 		require.NoError(t, err)
 
@@ -110,7 +113,8 @@ func TestGenericKeyBundle_Migrate_UnmarshalMarshal(t *testing.T) {
 		require.NoError(t, err)
 
 		// test Unmarshal with old raw bundle
-		bundle := mustNewKeyFromRaw[*terraKeyring](bundleBytes, &terraKeyring{})
+		bundle := newKeyBundle(&terraKeyring{})
+		require.NoError(t, bundle.Unmarshal(bundleBytes))
 		newBundleBytes, err := bundle.Marshal()
 		require.NoError(t, err)
 

--- a/core/services/keystore/keys/ocr2key/key_bundle.go
+++ b/core/services/keystore/keys/ocr2key/key_bundle.go
@@ -10,10 +10,11 @@ import (
 	"io"
 
 	"github.com/ethereum/go-ethereum/crypto/secp256k1"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2/types"
+
 	"github.com/smartcontractkit/chainlink/core/services/keystore/chaintype"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ocrkey"
 	"github.com/smartcontractkit/chainlink/core/store/models"
-	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2/types"
 )
 
 //nolint
@@ -36,13 +37,13 @@ var curve = secp256k1.S256()
 func New(chainType chaintype.ChainType) (KeyBundle, error) {
 	switch chainType {
 	case chaintype.EVM:
-		return newKeyBundle(chaintype.EVM, newEVMKeyring)
+		return newKeyBundleRand(chaintype.EVM, newEVMKeyring)
 	case chaintype.Solana:
-		return newKeyBundle(chaintype.Solana, newSolanaKeyring)
+		return newKeyBundleRand(chaintype.Solana, newSolanaKeyring)
 	case chaintype.Terra:
-		return newKeyBundle(chaintype.Terra, newTerraKeyring)
+		return newKeyBundleRand(chaintype.Terra, newTerraKeyring)
 	case chaintype.Starknet:
-		return newKeyBundle(chaintype.Starknet, newStarknetKeyring)
+		return newKeyBundleRand(chaintype.Starknet, newStarknetKeyring)
 	}
 	return nil, chaintype.NewErrInvalidChainType(chainType)
 }
@@ -116,7 +117,7 @@ func (kb keyBundleBase) GoString() string {
 //nolint
 type Raw []byte
 
-func (raw Raw) Key() KeyBundle {
+func (raw Raw) Key() (kb KeyBundle) {
 	var temp struct{ ChainType chaintype.ChainType }
 	err := json.Unmarshal(raw, &temp)
 	if err != nil {
@@ -124,20 +125,20 @@ func (raw Raw) Key() KeyBundle {
 	}
 	switch temp.ChainType {
 	case chaintype.EVM:
-		result := mustNewKeyFromRaw(raw, &evmKeyring{})
-		return &result
+		kb = newKeyBundle(new(evmKeyring))
 	case chaintype.Solana:
-		result := mustNewKeyFromRaw(raw, &solanaKeyring{})
-		return &result
+		kb = newKeyBundle(new(solanaKeyring))
 	case chaintype.Terra:
-		result := mustNewKeyFromRaw(raw, &terraKeyring{})
-		return &result
+		kb = newKeyBundle(new(terraKeyring))
 	case chaintype.Starknet:
-		result := mustNewKeyFromRaw(raw, &starknetKeyring{})
-		return &result
+		kb = newKeyBundle(new(starknetKeyring))
 	default:
 		panic(chaintype.NewErrInvalidChainType(temp.ChainType))
 	}
+	if err := kb.Unmarshal(raw); err != nil {
+		panic(err)
+	}
+	return
 }
 
 // type is added to the beginning of the passwords for OCR key bundles,


### PR DESCRIPTION
@aalu1418 Wdyt? This seems a bit simpler. I don't care about `new(T)` vs. `&T{}` :shrug: 