### PR TITLE
Fixes "Killed: 9" code-signing crash on MacOS

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -33,6 +33,7 @@ yarndep: ## Ensure all yarn dependencies are installed.
 .PHONY: install-chainlink
 install-chainlink: chainlink ## Install the chainlink binary.
 	mkdir -p $(GOBIN)
+	rm -f $(GOBIN)/chainlink
 	cp $< $(GOBIN)/chainlink
 
 chainlink: operator-ui ## Build the chainlink binary.
@@ -41,6 +42,7 @@ chainlink: operator-ui ## Build the chainlink binary.
 .PHONY: chainlink-build
 chainlink-build: ## Build & install the chainlink binary.
 	go build $(GOFLAGS) -o chainlink ./core/
+	rm -f $(GOBIN)/chainlink
 	cp chainlink $(GOBIN)/chainlink
 
 .PHONY: operator-ui


### PR DESCRIPTION
Apple does not support using "cp" to update a signed binary with a newer
version of it.

Their policy is that once a binary is signed, its contents is never expected
to change or the OS reserves the right to immediately kill it as soon as
anything tries to run it in case it's malware.

The only supported means of replacing a signed binary on recent versions of
MacOS is to completely remove it first and create a brand new file (which must
have a different inode) with a new signature:
https://developer.apple.com/documentation/security/updating_mac_software/