### PR TITLE
key-specific gas limit support for gas estimator

### DIFF
--- a/core/chains/evm/gas/block_history_estimator.go
+++ b/core/chains/evm/gas/block_history_estimator.go
@@ -177,7 +177,7 @@ func (b *BlockHistoryEstimator) Close() error {
 	})
 }
 
-func (b *BlockHistoryEstimator) GetLegacyGas(_ []byte, gasLimit uint64, _ ...Opt) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
+func (b *BlockHistoryEstimator) GetLegacyGas(_ []byte, gasLimit uint64, maxGasPriceWei *big.Int, _ ...Opt) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
 	ok := b.IfStarted(func() {
 		chainSpecificGasLimit = applyMultiplier(gasLimit, b.config.EvmGasLimitMultiplier())
 		gasPrice = b.getGasPrice()
@@ -188,6 +188,7 @@ func (b *BlockHistoryEstimator) GetLegacyGas(_ []byte, gasLimit uint64, _ ...Opt
 	if gasPrice == nil {
 		return nil, 0, errors.New("BlockHistoryEstimator has not finished the first gas estimation yet, likely because a failure on start")
 	}
+	gasPrice = capGasPrice(gasPrice, maxGasPriceWei, b.config)
 	return
 }
 
@@ -202,11 +203,11 @@ func (b *BlockHistoryEstimator) getTipCap() *big.Int {
 	return b.tipCap
 }
 
-func (b *BlockHistoryEstimator) BumpLegacyGas(originalGasPrice *big.Int, gasLimit uint64) (bumpedGasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
-	return BumpLegacyGasPriceOnly(b.config, b.logger, b.getGasPrice(), originalGasPrice, gasLimit)
+func (b *BlockHistoryEstimator) BumpLegacyGas(originalGasPrice *big.Int, gasLimit uint64, maxGasPriceWei *big.Int) (bumpedGasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
+	return BumpLegacyGasPriceOnly(b.config, b.logger, b.getGasPrice(), originalGasPrice, gasLimit, maxGasPriceWei)
 }
 
-func (b *BlockHistoryEstimator) GetDynamicFee(gasLimit uint64) (fee DynamicFee, chainSpecificGasLimit uint64, err error) {
+func (b *BlockHistoryEstimator) GetDynamicFee(gasLimit uint64, maxGasPriceWei *big.Int) (fee DynamicFee, chainSpecificGasLimit uint64, err error) {
 	if !b.config.EvmEIP1559DynamicFees() {
 		return fee, 0, errors.New("Can't get dynamic fee, EIP1559 is disabled")
 	}
@@ -222,15 +223,16 @@ func (b *BlockHistoryEstimator) GetDynamicFee(gasLimit uint64) (fee DynamicFee, 
 			err = errors.New("BlockHistoryEstimator has not finished the first gas estimation yet, likely because a failure on start")
 			return
 		}
+		maxGasPrice := getMaxGasPrice(maxGasPriceWei, b.config)
 		if b.config.EvmGasBumpThreshold() == 0 {
 			// just use the max gas price if gas bumping is disabled
-			feeCap = b.config.EvmMaxGasPriceWei()
+			feeCap = maxGasPrice
 		} else if b.latestBaseFee != nil {
 			// HACK: due to a flaw of how EIP-1559 is implemented we have to
 			// set a much lower FeeCap than the actual maximum we are willing
 			// to pay in order to give ourselves headroom for bumping
 			// See: https://github.com/ethereum/go-ethereum/issues/24284
-			feeCap = calcFeeCap(b.latestBaseFee, b.config, tipCap)
+			feeCap = calcFeeCap(b.latestBaseFee, b.config, tipCap, maxGasPrice)
 		} else {
 			// This shouldn't happen on EIP-1559 blocks, since if the tip cap
 			// is set, Start must have succeeded and we would expect an initial
@@ -250,7 +252,7 @@ func (b *BlockHistoryEstimator) GetDynamicFee(gasLimit uint64) (fee DynamicFee, 
 	return
 }
 
-func calcFeeCap(latestAvailableBaseFeePerGas *big.Int, cfg Config, tipCap *big.Int) (feeCap *big.Int) {
+func calcFeeCap(latestAvailableBaseFeePerGas *big.Int, cfg Config, tipCap *big.Int, maxGasPriceWei *big.Int) (feeCap *big.Int) {
 	const maxBaseFeeIncreasePerBlock float64 = 1.125
 
 	bufferBlocks := int(cfg.BlockHistoryEstimatorEIP1559FeeCapBufferBlocks())
@@ -266,14 +268,14 @@ func calcFeeCap(latestAvailableBaseFeePerGas *big.Int, cfg Config, tipCap *big.I
 	baseFeeInt, _ := baseFee.Int(nil)
 	feeCap = new(big.Int).Add(baseFeeInt, tipCap)
 
-	if feeCap.Cmp(cfg.EvmMaxGasPriceWei()) > 0 {
-		return cfg.EvmMaxGasPriceWei()
+	if feeCap.Cmp(maxGasPriceWei) > 0 {
+		return maxGasPriceWei
 	}
 	return feeCap
 }
 
-func (b *BlockHistoryEstimator) BumpDynamicFee(originalFee DynamicFee, originalGasLimit uint64) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
-	return BumpDynamicFeeOnly(b.config, b.logger, b.getTipCap(), b.getCurrentBaseFee(), originalFee, originalGasLimit)
+func (b *BlockHistoryEstimator) BumpDynamicFee(originalFee DynamicFee, originalGasLimit uint64, maxGasPriceWei *big.Int) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
+	return BumpDynamicFeeOnly(b.config, b.logger, b.getTipCap(), b.getCurrentBaseFee(), originalFee, originalGasLimit, maxGasPriceWei)
 }
 
 func (b *BlockHistoryEstimator) runLoop() {

--- a/core/chains/evm/gas/block_history_estimator_test.go
+++ b/core/chains/evm/gas/block_history_estimator_test.go
@@ -64,6 +64,7 @@ func TestBlockHistoryEstimator_Start(t *testing.T) {
 	var historySize uint16 = 2
 	var percentile uint16 = 35
 	minGasPrice := big.NewInt(1)
+	maxGasPrice := big.NewInt(100)
 
 	config.On("BlockHistoryEstimatorBatchSize").Return(batchSize)
 	config.On("BlockHistoryEstimatorBlockDelay").Return(blockDelay)
@@ -187,11 +188,11 @@ func TestBlockHistoryEstimator_Start(t *testing.T) {
 
 		assert.Nil(t, gas.GetLatestBaseFee(bhe))
 
-		_, _, err = bhe.GetLegacyGas(make([]byte, 0), 100)
+		_, _, err = bhe.GetLegacyGas(make([]byte, 0), 100, maxGasPrice)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "has not finished the first gas estimation yet")
 
-		_, _, err = bhe.GetDynamicFee(100)
+		_, _, err = bhe.GetDynamicFee(100, maxGasPrice)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "has not finished the first gas estimation yet")
 
@@ -213,11 +214,11 @@ func TestBlockHistoryEstimator_Start(t *testing.T) {
 
 		assert.Equal(t, big.NewInt(420), gas.GetLatestBaseFee(bhe))
 
-		_, _, err = bhe.GetLegacyGas(make([]byte, 0), 100)
+		_, _, err = bhe.GetLegacyGas(make([]byte, 0), 100, maxGasPrice)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "has not finished the first gas estimation yet")
 
-		_, _, err = bhe.GetDynamicFee(100)
+		_, _, err = bhe.GetDynamicFee(100, maxGasPrice)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "has not finished the first gas estimation yet")
 
@@ -260,11 +261,11 @@ func TestBlockHistoryEstimator_Start(t *testing.T) {
 
 		assert.Equal(t, big.NewInt(420), gas.GetLatestBaseFee(bhe))
 
-		_, _, err = bhe.GetLegacyGas(make([]byte, 0), 100)
+		_, _, err = bhe.GetLegacyGas(make([]byte, 0), 100, maxGasPrice)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "has not finished the first gas estimation yet")
 
-		_, _, err = bhe.GetDynamicFee(100)
+		_, _, err = bhe.GetDynamicFee(100, maxGasPrice)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "has not finished the first gas estimation yet")
 
@@ -1570,6 +1571,75 @@ func TestBlockHistoryEstimator_EIP1559Block_Unmarshal(t *testing.T) {
 	assert.Equal(t, "0x13d4ecea98e37359e63e39e350ed0b1456e1acbf985eb8d4a0ef0e89a705c10d", block.Transactions[3].Hash.String())
 }
 
+func TestBlockHistoryEstimator_GetLegacyGas(t *testing.T) {
+	t.Parallel()
+
+	cfg := newConfigWithEIP1559DynamicFeesDisabled(t)
+
+	maxGasPrice := big.NewInt(1000000)
+	cfg.On("BlockHistoryEstimatorTransactionPercentile").Return(uint16(35))
+	cfg.On("EvmEIP1559DynamicFees").Return(false)
+	cfg.On("EvmGasLimitMultiplier").Return(float32(1))
+	cfg.On("EvmMaxGasPriceWei").Return(maxGasPrice)
+	cfg.On("EvmMinGasPriceWei").Return(big.NewInt(0))
+
+	bhe := newBlockHistoryEstimator(t, nil, cfg)
+
+	blocks := []gas.Block{
+		{
+			Number:       0,
+			Hash:         utils.NewHash(),
+			Transactions: cltest.LegacyTransactionsFromGasPrices(1000),
+		},
+		{
+			Number:       1,
+			Hash:         utils.NewHash(),
+			Transactions: cltest.LegacyTransactionsFromGasPrices(1200),
+		},
+	}
+
+	gas.SetRollingBlockHistory(bhe, blocks)
+	bhe.Recalculate(cltest.Head(1))
+	gas.SimulateStart(bhe)
+
+	t.Run("if gas price is lower than global max and user specified max gas price", func(t *testing.T) {
+		fee, limit, err := bhe.GetLegacyGas(make([]byte, 0), 10000, maxGasPrice)
+		require.NoError(t, err)
+
+		assert.Equal(t, big.NewInt(1000), fee)
+		assert.Equal(t, 10000, int(limit))
+	})
+
+	t.Run("if gas price is higher than user-specified max", func(t *testing.T) {
+		fee, limit, err := bhe.GetLegacyGas(make([]byte, 0), 10000, big.NewInt(800))
+		require.NoError(t, err)
+
+		assert.Equal(t, big.NewInt(800), fee)
+		assert.Equal(t, 10000, int(limit))
+	})
+
+	cfg = newConfigWithEIP1559DynamicFeesDisabled(t)
+	cfg.On("BlockHistoryEstimatorTransactionPercentile").Return(uint16(35))
+	cfg.On("EvmEIP1559DynamicFees").Return(false)
+	cfg.On("EvmGasLimitMultiplier").Return(float32(1))
+	cfg.On("EvmMaxGasPriceWei").Return(big.NewInt(700))
+	cfg.On("EvmMinGasPriceWei").Return(big.NewInt(0))
+	bhe = newBlockHistoryEstimator(t, nil, cfg)
+	gas.SetRollingBlockHistory(bhe, blocks)
+	bhe.Recalculate(cltest.Head(1))
+	gas.SimulateStart(bhe)
+
+	t.Run("if gas price is higher than global max", func(t *testing.T) {
+		fee, limit, err := bhe.GetLegacyGas(make([]byte, 0), 10000, maxGasPrice)
+		require.NoError(t, err)
+
+		assert.Equal(t, big.NewInt(700), fee)
+		assert.Equal(t, 10000, int(limit))
+	})
+
+	cfg.AssertExpectations(t)
+}
+
 func TestBlockHistoryEstimator_GetDynamicFee(t *testing.T) {
 	t.Parallel()
 
@@ -1579,8 +1649,8 @@ func TestBlockHistoryEstimator_GetDynamicFee(t *testing.T) {
 	cfg.On("BlockHistoryEstimatorTransactionPercentile").Return(uint16(35))
 	cfg.On("EvmEIP1559DynamicFees").Return(true)
 	cfg.On("EvmGasLimitMultiplier").Return(float32(1))
-	cfg.On("EvmGasTipCapMinimum").Return(big.NewInt(0))
 	cfg.On("EvmMaxGasPriceWei").Return(maxGasPrice)
+	cfg.On("EvmGasTipCapMinimum").Return(big.NewInt(0))
 	cfg.On("EvmMinGasPriceWei").Return(big.NewInt(0))
 
 	bhe := newBlockHistoryEstimator(t, nil, cfg)
@@ -1607,7 +1677,7 @@ func TestBlockHistoryEstimator_GetDynamicFee(t *testing.T) {
 	t.Run("if estimator is missing base fee and gas bumping is enabled", func(t *testing.T) {
 		cfg.On("EvmGasBumpThreshold").Return(uint64(1)).Once()
 
-		_, _, err := bhe.GetDynamicFee(100000)
+		_, _, err := bhe.GetDynamicFee(100000, maxGasPrice)
 		require.Error(t, err)
 		assert.Contains(t, err.Error(), "f")
 	})
@@ -1615,7 +1685,7 @@ func TestBlockHistoryEstimator_GetDynamicFee(t *testing.T) {
 	t.Run("if estimator is missing base fee and gas bumping is disabled", func(t *testing.T) {
 		cfg.On("EvmGasBumpThreshold").Return(uint64(0)).Once()
 
-		fee, limit, err := bhe.GetDynamicFee(100000)
+		fee, limit, err := bhe.GetDynamicFee(100000, maxGasPrice)
 		require.NoError(t, err)
 		assert.Equal(t, gas.DynamicFee{FeeCap: maxGasPrice, TipCap: big.NewInt(6000)}, fee)
 		assert.Equal(t, 100000, int(limit))
@@ -1628,7 +1698,7 @@ func TestBlockHistoryEstimator_GetDynamicFee(t *testing.T) {
 	t.Run("if gas bumping is enabled", func(t *testing.T) {
 		cfg.On("EvmGasBumpThreshold").Return(uint64(1)).Once()
 
-		fee, limit, err := bhe.GetDynamicFee(100000)
+		fee, limit, err := bhe.GetDynamicFee(100000, maxGasPrice)
 		require.NoError(t, err)
 
 		assert.Equal(t, gas.DynamicFee{FeeCap: big.NewInt(186203), TipCap: big.NewInt(6000)}, fee)
@@ -1638,10 +1708,44 @@ func TestBlockHistoryEstimator_GetDynamicFee(t *testing.T) {
 	t.Run("if gas bumping is disabled", func(t *testing.T) {
 		cfg.On("EvmGasBumpThreshold").Return(uint64(0)).Once()
 
-		fee, limit, err := bhe.GetDynamicFee(100000)
+		fee, limit, err := bhe.GetDynamicFee(100000, maxGasPrice)
 		require.NoError(t, err)
 
 		assert.Equal(t, gas.DynamicFee{FeeCap: maxGasPrice, TipCap: big.NewInt(6000)}, fee)
+		assert.Equal(t, 100000, int(limit))
+	})
+
+	t.Run("if gas bumping is enabled and local max gas price set", func(t *testing.T) {
+		cfg.On("EvmGasBumpThreshold").Return(uint64(1)).Once()
+
+		fee, limit, err := bhe.GetDynamicFee(100000, big.NewInt(180000))
+		require.NoError(t, err)
+
+		assert.Equal(t, gas.DynamicFee{FeeCap: big.NewInt(180000), TipCap: big.NewInt(6000)}, fee)
+		assert.Equal(t, 100000, int(limit))
+	})
+
+	t.Run("if bump threshold is 0 and local max gas price set", func(t *testing.T) {
+		cfg.On("EvmGasBumpThreshold").Return(uint64(0)).Once()
+
+		fee, limit, err := bhe.GetDynamicFee(100000, big.NewInt(100))
+		require.NoError(t, err)
+
+		assert.Equal(t, gas.DynamicFee{FeeCap: big.NewInt(100), TipCap: big.NewInt(6000)}, fee)
+		assert.Equal(t, 100000, int(limit))
+	})
+
+	h = cltest.Head(1)
+	h.BaseFeePerGas = utils.NewBigI(900000)
+	bhe.OnNewLongestChain(context.Background(), h)
+
+	t.Run("if gas bumping is enabled and global max gas price lower than local max gas price", func(t *testing.T) {
+		cfg.On("EvmGasBumpThreshold").Return(uint64(1)).Once()
+
+		fee, limit, err := bhe.GetDynamicFee(100000, big.NewInt(1200000))
+		require.NoError(t, err)
+
+		assert.Equal(t, gas.DynamicFee{FeeCap: big.NewInt(1000000), TipCap: big.NewInt(6000)}, fee)
 		assert.Equal(t, 100000, int(limit))
 	})
 
@@ -1650,21 +1754,21 @@ func TestBlockHistoryEstimator_GetDynamicFee(t *testing.T) {
 
 func TestBlockHistoryEstimator_Bumps(t *testing.T) {
 	t.Parallel()
+	maxGasPrice := big.NewInt(1000000)
 
 	t.Run("BumpLegacyGas calls BumpLegacyGasPriceOnly with proper current gas price", func(t *testing.T) {
 		config := newConfigWithEIP1559DynamicFeesDisabled(t)
 		bhe := newBlockHistoryEstimator(t, nil, config)
-
 		config.On("EvmGasBumpPercent").Return(uint16(10))
 		config.On("EvmGasBumpWei").Return(big.NewInt(150))
-		config.On("EvmMaxGasPriceWei").Return(big.NewInt(1000000))
+		config.On("EvmMaxGasPriceWei").Return(maxGasPrice)
 		config.On("EvmGasLimitMultiplier").Return(float32(1.1))
 
 		t.Run("ignores nil current gas price", func(t *testing.T) {
-			gasPrice, gasLimit, err := bhe.BumpLegacyGas(big.NewInt(42), 100000)
+			gasPrice, gasLimit, err := bhe.BumpLegacyGas(big.NewInt(42), 100000, maxGasPrice)
 			require.NoError(t, err)
 
-			expectedGasPrice, expectedGasLimit, err := gas.BumpLegacyGasPriceOnly(config, logger.TestLogger(t), nil, big.NewInt(42), 100000)
+			expectedGasPrice, expectedGasLimit, err := gas.BumpLegacyGasPriceOnly(config, logger.TestLogger(t), nil, big.NewInt(42), 100000, maxGasPrice)
 			require.NoError(t, err)
 
 			assert.Equal(t, expectedGasLimit, gasLimit)
@@ -1672,13 +1776,13 @@ func TestBlockHistoryEstimator_Bumps(t *testing.T) {
 		})
 
 		t.Run("ignores current gas price > max gas price", func(t *testing.T) {
-			gasPrice, gasLimit, err := bhe.BumpLegacyGas(big.NewInt(42), 100000)
+			gasPrice, gasLimit, err := bhe.BumpLegacyGas(big.NewInt(42), 100000, maxGasPrice)
 			require.NoError(t, err)
 
 			massive := big.NewInt(100000000000000)
 			gas.SetGasPrice(bhe, massive)
 
-			expectedGasPrice, expectedGasLimit, err := gas.BumpLegacyGasPriceOnly(config, logger.TestLogger(t), massive, big.NewInt(42), 100000)
+			expectedGasPrice, expectedGasLimit, err := gas.BumpLegacyGasPriceOnly(config, logger.TestLogger(t), massive, big.NewInt(42), 100000, maxGasPrice)
 			require.NoError(t, err)
 
 			assert.Equal(t, expectedGasLimit, gasLimit)
@@ -1688,7 +1792,7 @@ func TestBlockHistoryEstimator_Bumps(t *testing.T) {
 		t.Run("ignores current gas price < bumped gas price", func(t *testing.T) {
 			gas.SetGasPrice(bhe, big.NewInt(191))
 
-			gasPrice, gasLimit, err := bhe.BumpLegacyGas(big.NewInt(42), 100000)
+			gasPrice, gasLimit, err := bhe.BumpLegacyGas(big.NewInt(42), 100000, maxGasPrice)
 			require.NoError(t, err)
 
 			assert.Equal(t, 110000, int(gasLimit))
@@ -1698,11 +1802,33 @@ func TestBlockHistoryEstimator_Bumps(t *testing.T) {
 		t.Run("uses current gas price > bumped gas price", func(t *testing.T) {
 			gas.SetGasPrice(bhe, big.NewInt(193))
 
-			gasPrice, gasLimit, err := bhe.BumpLegacyGas(big.NewInt(42), 100000)
+			gasPrice, gasLimit, err := bhe.BumpLegacyGas(big.NewInt(42), 100000, maxGasPrice)
 			require.NoError(t, err)
 
 			assert.Equal(t, 110000, int(gasLimit))
 			assert.Equal(t, big.NewInt(193), gasPrice)
+		})
+
+		t.Run("bumped gas price > max gas price", func(t *testing.T) {
+			gas.SetGasPrice(bhe, big.NewInt(191))
+
+			gasPrice, gasLimit, err := bhe.BumpLegacyGas(big.NewInt(42), 100000, big.NewInt(100))
+			require.Error(t, err)
+
+			assert.Nil(t, gasPrice)
+			assert.Equal(t, 0, int(gasLimit))
+			assert.Contains(t, err.Error(), "bumped gas price of 192 would exceed configured max gas price of 100 (original price was 42).")
+		})
+
+		t.Run("current gas price > max gas price", func(t *testing.T) {
+			gas.SetGasPrice(bhe, big.NewInt(193))
+
+			gasPrice, gasLimit, err := bhe.BumpLegacyGas(big.NewInt(42), 100000, big.NewInt(100))
+			require.Error(t, err)
+
+			assert.Nil(t, gasPrice)
+			assert.Equal(t, 0, int(gasLimit))
+			assert.Contains(t, err.Error(), "bumped gas price of 192 would exceed configured max gas price of 100 (original price was 42).")
 		})
 
 		config.AssertExpectations(t)
@@ -1714,13 +1840,13 @@ func TestBlockHistoryEstimator_Bumps(t *testing.T) {
 
 		config.On("EvmGasBumpPercent").Return(uint16(10))
 		config.On("EvmGasBumpWei").Return(big.NewInt(150))
-		config.On("EvmMaxGasPriceWei").Return(big.NewInt(1000000))
+		config.On("EvmMaxGasPriceWei").Return(maxGasPrice)
 		config.On("EvmGasLimitMultiplier").Return(float32(1.1))
 		config.On("EvmGasTipCapDefault").Return(big.NewInt(52))
 
 		t.Run("when current tip cap is nil", func(t *testing.T) {
 			originalFee := gas.DynamicFee{FeeCap: big.NewInt(100), TipCap: big.NewInt(25)}
-			fee, gasLimit, err := bhe.BumpDynamicFee(originalFee, 100000)
+			fee, gasLimit, err := bhe.BumpDynamicFee(originalFee, 100000, maxGasPrice)
 			require.NoError(t, err)
 
 			assert.Equal(t, 110000, int(gasLimit))
@@ -1730,7 +1856,7 @@ func TestBlockHistoryEstimator_Bumps(t *testing.T) {
 			gas.SetTipCap(bhe, big.NewInt(201))
 
 			originalFee := gas.DynamicFee{FeeCap: big.NewInt(100), TipCap: big.NewInt(25)}
-			fee, gasLimit, err := bhe.BumpDynamicFee(originalFee, 100000)
+			fee, gasLimit, err := bhe.BumpDynamicFee(originalFee, 100000, maxGasPrice)
 			require.NoError(t, err)
 
 			assert.Equal(t, 110000, int(gasLimit))
@@ -1740,7 +1866,7 @@ func TestBlockHistoryEstimator_Bumps(t *testing.T) {
 			gas.SetTipCap(bhe, big.NewInt(203))
 
 			originalFee := gas.DynamicFee{FeeCap: big.NewInt(100), TipCap: big.NewInt(25)}
-			fee, gasLimit, err := bhe.BumpDynamicFee(originalFee, 100000)
+			fee, gasLimit, err := bhe.BumpDynamicFee(originalFee, 100000, maxGasPrice)
 			require.NoError(t, err)
 
 			assert.Equal(t, 110000, int(gasLimit))
@@ -1750,11 +1876,35 @@ func TestBlockHistoryEstimator_Bumps(t *testing.T) {
 			gas.SetTipCap(bhe, big.NewInt(1000000000000000))
 
 			originalFee := gas.DynamicFee{FeeCap: big.NewInt(100), TipCap: big.NewInt(25)}
-			fee, gasLimit, err := bhe.BumpDynamicFee(originalFee, 100000)
+			fee, gasLimit, err := bhe.BumpDynamicFee(originalFee, 100000, maxGasPrice)
 			require.NoError(t, err)
 
 			assert.Equal(t, 110000, int(gasLimit))
 			assert.Equal(t, gas.DynamicFee{FeeCap: big.NewInt(250), TipCap: big.NewInt(202)}, fee)
+		})
+
+		t.Run("bumped tip cap price > max gas price", func(t *testing.T) {
+			gas.SetTipCap(bhe, big.NewInt(203))
+
+			originalFee := gas.DynamicFee{FeeCap: big.NewInt(100), TipCap: big.NewInt(990000)}
+			fee, gasLimit, err := bhe.BumpDynamicFee(originalFee, 100000, maxGasPrice)
+			require.Error(t, err)
+
+			assert.Equal(t, 0, int(gasLimit))
+			assert.Equal(t, gas.DynamicFee{}, fee)
+			assert.Contains(t, err.Error(), "bumped tip cap of 1089000 would exceed configured max gas price of 1000000 (original fee: tip cap 990000, fee cap 100)")
+		})
+
+		t.Run("bumped fee cap price > max gas price", func(t *testing.T) {
+			gas.SetTipCap(bhe, big.NewInt(203))
+
+			originalFee := gas.DynamicFee{FeeCap: big.NewInt(990000), TipCap: big.NewInt(25)}
+			fee, gasLimit, err := bhe.BumpDynamicFee(originalFee, 100000, maxGasPrice)
+			require.Error(t, err)
+
+			assert.Equal(t, 0, int(gasLimit))
+			assert.Equal(t, gas.DynamicFee{}, fee)
+			assert.Contains(t, err.Error(), "bumped fee cap of 1089000 would exceed configured max gas price of 1000000 (original fee: tip cap 25, fee cap 990000)")
 		})
 
 		config.AssertExpectations(t)

--- a/core/chains/evm/gas/fixed_price_estimator.go
+++ b/core/chains/evm/gas/fixed_price_estimator.go
@@ -27,17 +27,18 @@ func (f *fixedPriceEstimator) Start(context.Context) error                      
 func (f *fixedPriceEstimator) Close() error                                          { return nil }
 func (f *fixedPriceEstimator) OnNewLongestChain(_ context.Context, _ *evmtypes.Head) {}
 
-func (f *fixedPriceEstimator) GetLegacyGas(_ []byte, gasLimit uint64, _ ...Opt) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
+func (f *fixedPriceEstimator) GetLegacyGas(_ []byte, gasLimit uint64, maxGasPriceWei *big.Int, _ ...Opt) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
 	gasPrice = f.config.EvmGasPriceDefault()
 	chainSpecificGasLimit = applyMultiplier(gasLimit, f.config.EvmGasLimitMultiplier())
+	gasPrice = capGasPrice(gasPrice, maxGasPriceWei, f.config)
 	return
 }
 
-func (f *fixedPriceEstimator) BumpLegacyGas(originalGasPrice *big.Int, originalGasLimit uint64) (gasPrice *big.Int, gasLimit uint64, err error) {
-	return BumpLegacyGasPriceOnly(f.config, f.lggr, f.config.EvmGasPriceDefault(), originalGasPrice, originalGasLimit)
+func (f *fixedPriceEstimator) BumpLegacyGas(originalGasPrice *big.Int, originalGasLimit uint64, maxGasPriceWei *big.Int) (gasPrice *big.Int, gasLimit uint64, err error) {
+	return BumpLegacyGasPriceOnly(f.config, f.lggr, f.config.EvmGasPriceDefault(), originalGasPrice, originalGasLimit, maxGasPriceWei)
 }
 
-func (f *fixedPriceEstimator) GetDynamicFee(originalGasLimit uint64) (d DynamicFee, chainSpecificGasLimit uint64, err error) {
+func (f *fixedPriceEstimator) GetDynamicFee(originalGasLimit uint64, maxGasPriceWei *big.Int) (d DynamicFee, chainSpecificGasLimit uint64, err error) {
 	gasTipCap := f.config.EvmGasTipCapDefault()
 	if gasTipCap == nil {
 		return d, 0, errors.New("cannot calculate dynamic fee: EthGasTipCapDefault was not set")
@@ -47,7 +48,7 @@ func (f *fixedPriceEstimator) GetDynamicFee(originalGasLimit uint64) (d DynamicF
 	var feeCap *big.Int
 	if f.config.EvmGasBumpThreshold() == 0 {
 		// Gas bumping is disabled, just use the max fee cap
-		feeCap = f.config.EvmMaxGasPriceWei()
+		feeCap = getMaxGasPrice(maxGasPriceWei, f.config)
 	} else {
 		// Need to leave headroom for bumping so we fallback to the default value here
 		feeCap = f.config.EvmGasFeeCapDefault()
@@ -59,6 +60,6 @@ func (f *fixedPriceEstimator) GetDynamicFee(originalGasLimit uint64) (d DynamicF
 	}, chainSpecificGasLimit, nil
 }
 
-func (f *fixedPriceEstimator) BumpDynamicFee(originalFee DynamicFee, originalGasLimit uint64) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
-	return BumpDynamicFeeOnly(f.config, f.lggr, f.config.EvmGasTipCapDefault(), nil, originalFee, originalGasLimit)
+func (f *fixedPriceEstimator) BumpDynamicFee(originalFee DynamicFee, originalGasLimit uint64, maxGasPriceWei *big.Int) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
+	return BumpDynamicFeeOnly(f.config, f.lggr, f.config.EvmGasTipCapDefault(), nil, originalFee, originalGasLimit, maxGasPriceWei)
 }

--- a/core/chains/evm/gas/l2_suggested_estimator.go
+++ b/core/chains/evm/gas/l2_suggested_estimator.go
@@ -113,17 +113,17 @@ func (o *l2SuggestedEstimator) refreshPrice() (t *time.Timer) {
 
 func (o *l2SuggestedEstimator) OnNewLongestChain(_ context.Context, _ *evmtypes.Head) {}
 
-func (*l2SuggestedEstimator) GetDynamicFee(_ uint64) (fee DynamicFee, chainSpecificGasLimit uint64, err error) {
+func (*l2SuggestedEstimator) GetDynamicFee(_ uint64, _ *big.Int) (fee DynamicFee, chainSpecificGasLimit uint64, err error) {
 	err = errors.New("dynamic fees are not implemented for this layer 2")
 	return
 }
 
-func (*l2SuggestedEstimator) BumpDynamicFee(_ DynamicFee, _ uint64) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
+func (*l2SuggestedEstimator) BumpDynamicFee(_ DynamicFee, _ uint64, _ *big.Int) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
 	err = errors.New("dynamic fees are not implemented for this layer 2")
 	return
 }
 
-func (o *l2SuggestedEstimator) GetLegacyGas(_ []byte, l2GasLimit uint64, opts ...Opt) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
+func (o *l2SuggestedEstimator) GetLegacyGas(_ []byte, l2GasLimit uint64, maxGasPriceWei *big.Int, opts ...Opt) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
 	chainSpecificGasLimit = l2GasLimit
 	ok := o.IfStarted(func() {
 		var forceRefetch bool
@@ -151,10 +151,14 @@ func (o *l2SuggestedEstimator) GetLegacyGas(_ []byte, l2GasLimit uint64, opts ..
 	if !ok {
 		return nil, 0, errors.New("estimator is not started")
 	}
+	// For L2 chains (e.g. Optimism), submitting a transaction that is not priced high enough will cause the call to fail, so if the cap is lower than the RPC suggested gas price, this transaction cannot succeed
+	if gasPrice != nil && gasPrice.Cmp(maxGasPriceWei) > 0 {
+		return nil, 0, errors.Errorf("estimated gas price: %s is greater than the maximum gas price configured: %s", gasPrice.String(), maxGasPriceWei.String())
+	}
 	return
 }
 
-func (o *l2SuggestedEstimator) BumpLegacyGas(_ *big.Int, _ uint64) (bumpedGasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
+func (o *l2SuggestedEstimator) BumpLegacyGas(_ *big.Int, _ uint64, _ *big.Int) (bumpedGasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
 	return nil, 0, errors.New("bump gas is not supported for this l2")
 }
 

--- a/core/chains/evm/gas/l2_suggested_estimator_test.go
+++ b/core/chains/evm/gas/l2_suggested_estimator_test.go
@@ -21,13 +21,15 @@ func TestL2SuggestedEstimator(t *testing.T) {
 
 	config := new(mocks.Config)
 	client := new(mocks.OptimismRPCClient)
+	maxGasPrice := big.NewInt(100)
+	config.On("EvmMaxGasPriceWei").Return(maxGasPrice)
 	o := gas.NewL2SuggestedEstimator(logger.TestLogger(t), config, client)
 
 	calldata := []byte{0x00, 0x00, 0x01, 0x02, 0x03}
 	var gasLimit uint64 = 80000
 
 	t.Run("calling EstimateGas on unstarted estimator returns error", func(t *testing.T) {
-		_, _, err := o.GetLegacyGas(calldata, gasLimit)
+		_, _, err := o.GetLegacyGas(calldata, gasLimit, maxGasPrice)
 		assert.EqualError(t, err, "estimator is not started")
 	})
 
@@ -39,20 +41,60 @@ func TestL2SuggestedEstimator(t *testing.T) {
 
 		require.NoError(t, o.Start(testutils.Context(t)))
 		t.Cleanup(func() { require.NoError(t, o.Close()) })
-		gasPrice, chainSpecificGasLimit, err := o.GetLegacyGas(calldata, gasLimit)
+		gasPrice, chainSpecificGasLimit, err := o.GetLegacyGas(calldata, gasLimit, maxGasPrice)
 		require.NoError(t, err)
 		assert.Equal(t, big.NewInt(42), gasPrice)
 		assert.Equal(t, gasLimit, chainSpecificGasLimit)
 	})
 
+	t.Run("gas price is lower than user specified max gas price", func(t *testing.T) {
+		config := new(mocks.Config)
+		client := new(mocks.OptimismRPCClient)
+		config.On("EvmMaxGasPriceWei").Return(maxGasPrice)
+		o := gas.NewL2SuggestedEstimator(logger.TestLogger(t), config, client)
+
+		client.On("Call", mock.Anything, "eth_gasPrice").Return(nil).Run(func(args mock.Arguments) {
+			res := args.Get(0).(*hexutil.Big)
+			(*big.Int)(res).SetInt64(42)
+		})
+
+		require.NoError(t, o.Start(testutils.Context(t)))
+		t.Cleanup(func() { require.NoError(t, o.Close()) })
+		gasPrice, chainSpecificGasLimit, err := o.GetLegacyGas(calldata, gasLimit, big.NewInt(40))
+		require.Error(t, err)
+		assert.EqualError(t, err, "estimated gas price: 42 is greater than the maximum gas price configured: 40")
+		assert.Nil(t, gasPrice)
+		assert.Equal(t, uint64(0), chainSpecificGasLimit)
+	})
+
+	t.Run("gas price is lower than global max gas price", func(t *testing.T) {
+		config := new(mocks.Config)
+		client := new(mocks.OptimismRPCClient)
+		config.On("EvmMaxGasPriceWei").Return(maxGasPrice)
+		o := gas.NewL2SuggestedEstimator(logger.TestLogger(t), config, client)
+
+		client.On("Call", mock.Anything, "eth_gasPrice").Return(nil).Run(func(args mock.Arguments) {
+			res := args.Get(0).(*hexutil.Big)
+			(*big.Int)(res).SetInt64(120)
+		})
+
+		require.NoError(t, o.Start(testutils.Context(t)))
+		t.Cleanup(func() { require.NoError(t, o.Close()) })
+		gasPrice, chainSpecificGasLimit, err := o.GetLegacyGas(calldata, gasLimit, big.NewInt(110))
+		assert.EqualError(t, err, "estimated gas price: 120 is greater than the maximum gas price configured: 110")
+		assert.Nil(t, gasPrice)
+		assert.Equal(t, uint64(0), chainSpecificGasLimit)
+	})
+
 	t.Run("calling BumpGas always returns error", func(t *testing.T) {
-		_, _, err := o.BumpLegacyGas(big.NewInt(42), gasLimit)
+		_, _, err := o.BumpLegacyGas(big.NewInt(42), gasLimit, big.NewInt(10))
 		assert.EqualError(t, err, "bump gas is not supported for this l2")
 	})
 
 	t.Run("calling EstimateGas on started estimator if initial call failed returns error", func(t *testing.T) {
 		config := new(mocks.Config)
 		client := new(mocks.OptimismRPCClient)
+		config.On("EvmMaxGasPriceWei").Return(maxGasPrice)
 		o := gas.NewL2SuggestedEstimator(logger.TestLogger(t), config, client)
 
 		client.On("Call", mock.Anything, "eth_gasPrice").Return(errors.New("kaboom"))
@@ -60,7 +102,7 @@ func TestL2SuggestedEstimator(t *testing.T) {
 		require.NoError(t, o.Start(testutils.Context(t)))
 		t.Cleanup(func() { require.NoError(t, o.Close()) })
 
-		_, _, err := o.GetLegacyGas(calldata, gasLimit)
+		_, _, err := o.GetLegacyGas(calldata, gasLimit, maxGasPrice)
 		assert.EqualError(t, err, "failed to estimate l2 gas; gas price not set")
 	})
 }

--- a/core/chains/evm/gas/mocks/estimator.go
+++ b/core/chains/evm/gas/mocks/estimator.go
@@ -19,27 +19,27 @@ type Estimator struct {
 	mock.Mock
 }
 
-// BumpDynamicFee provides a mock function with given fields: original, gasLimit
-func (_m *Estimator) BumpDynamicFee(original gas.DynamicFee, gasLimit uint64) (gas.DynamicFee, uint64, error) {
-	ret := _m.Called(original, gasLimit)
+// BumpDynamicFee provides a mock function with given fields: original, gasLimit, maxGasPriceWei
+func (_m *Estimator) BumpDynamicFee(original gas.DynamicFee, gasLimit uint64, maxGasPriceWei *big.Int) (gas.DynamicFee, uint64, error) {
+	ret := _m.Called(original, gasLimit, maxGasPriceWei)
 
 	var r0 gas.DynamicFee
-	if rf, ok := ret.Get(0).(func(gas.DynamicFee, uint64) gas.DynamicFee); ok {
-		r0 = rf(original, gasLimit)
+	if rf, ok := ret.Get(0).(func(gas.DynamicFee, uint64, *big.Int) gas.DynamicFee); ok {
+		r0 = rf(original, gasLimit, maxGasPriceWei)
 	} else {
 		r0 = ret.Get(0).(gas.DynamicFee)
 	}
 
 	var r1 uint64
-	if rf, ok := ret.Get(1).(func(gas.DynamicFee, uint64) uint64); ok {
-		r1 = rf(original, gasLimit)
+	if rf, ok := ret.Get(1).(func(gas.DynamicFee, uint64, *big.Int) uint64); ok {
+		r1 = rf(original, gasLimit, maxGasPriceWei)
 	} else {
 		r1 = ret.Get(1).(uint64)
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(gas.DynamicFee, uint64) error); ok {
-		r2 = rf(original, gasLimit)
+	if rf, ok := ret.Get(2).(func(gas.DynamicFee, uint64, *big.Int) error); ok {
+		r2 = rf(original, gasLimit, maxGasPriceWei)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -47,13 +47,13 @@ func (_m *Estimator) BumpDynamicFee(original gas.DynamicFee, gasLimit uint64) (g
 	return r0, r1, r2
 }
 
-// BumpLegacyGas provides a mock function with given fields: originalGasPrice, gasLimit
-func (_m *Estimator) BumpLegacyGas(originalGasPrice *big.Int, gasLimit uint64) (*big.Int, uint64, error) {
-	ret := _m.Called(originalGasPrice, gasLimit)
+// BumpLegacyGas provides a mock function with given fields: originalGasPrice, gasLimit, maxGasPriceWei
+func (_m *Estimator) BumpLegacyGas(originalGasPrice *big.Int, gasLimit uint64, maxGasPriceWei *big.Int) (*big.Int, uint64, error) {
+	ret := _m.Called(originalGasPrice, gasLimit, maxGasPriceWei)
 
 	var r0 *big.Int
-	if rf, ok := ret.Get(0).(func(*big.Int, uint64) *big.Int); ok {
-		r0 = rf(originalGasPrice, gasLimit)
+	if rf, ok := ret.Get(0).(func(*big.Int, uint64, *big.Int) *big.Int); ok {
+		r0 = rf(originalGasPrice, gasLimit, maxGasPriceWei)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*big.Int)
@@ -61,15 +61,15 @@ func (_m *Estimator) BumpLegacyGas(originalGasPrice *big.Int, gasLimit uint64) (
 	}
 
 	var r1 uint64
-	if rf, ok := ret.Get(1).(func(*big.Int, uint64) uint64); ok {
-		r1 = rf(originalGasPrice, gasLimit)
+	if rf, ok := ret.Get(1).(func(*big.Int, uint64, *big.Int) uint64); ok {
+		r1 = rf(originalGasPrice, gasLimit, maxGasPriceWei)
 	} else {
 		r1 = ret.Get(1).(uint64)
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(*big.Int, uint64) error); ok {
-		r2 = rf(originalGasPrice, gasLimit)
+	if rf, ok := ret.Get(2).(func(*big.Int, uint64, *big.Int) error); ok {
+		r2 = rf(originalGasPrice, gasLimit, maxGasPriceWei)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -91,27 +91,27 @@ func (_m *Estimator) Close() error {
 	return r0
 }
 
-// GetDynamicFee provides a mock function with given fields: gasLimit
-func (_m *Estimator) GetDynamicFee(gasLimit uint64) (gas.DynamicFee, uint64, error) {
-	ret := _m.Called(gasLimit)
+// GetDynamicFee provides a mock function with given fields: gasLimit, maxGasPriceWei
+func (_m *Estimator) GetDynamicFee(gasLimit uint64, maxGasPriceWei *big.Int) (gas.DynamicFee, uint64, error) {
+	ret := _m.Called(gasLimit, maxGasPriceWei)
 
 	var r0 gas.DynamicFee
-	if rf, ok := ret.Get(0).(func(uint64) gas.DynamicFee); ok {
-		r0 = rf(gasLimit)
+	if rf, ok := ret.Get(0).(func(uint64, *big.Int) gas.DynamicFee); ok {
+		r0 = rf(gasLimit, maxGasPriceWei)
 	} else {
 		r0 = ret.Get(0).(gas.DynamicFee)
 	}
 
 	var r1 uint64
-	if rf, ok := ret.Get(1).(func(uint64) uint64); ok {
-		r1 = rf(gasLimit)
+	if rf, ok := ret.Get(1).(func(uint64, *big.Int) uint64); ok {
+		r1 = rf(gasLimit, maxGasPriceWei)
 	} else {
 		r1 = ret.Get(1).(uint64)
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func(uint64) error); ok {
-		r2 = rf(gasLimit)
+	if rf, ok := ret.Get(2).(func(uint64, *big.Int) error); ok {
+		r2 = rf(gasLimit, maxGasPriceWei)
 	} else {
 		r2 = ret.Error(2)
 	}
@@ -119,20 +119,20 @@ func (_m *Estimator) GetDynamicFee(gasLimit uint64) (gas.DynamicFee, uint64, err
 	return r0, r1, r2
 }
 
-// GetLegacyGas provides a mock function with given fields: calldata, gasLimit, opts
-func (_m *Estimator) GetLegacyGas(calldata []byte, gasLimit uint64, opts ...gas.Opt) (*big.Int, uint64, error) {
+// GetLegacyGas provides a mock function with given fields: calldata, gasLimit, maxGasPriceWei, opts
+func (_m *Estimator) GetLegacyGas(calldata []byte, gasLimit uint64, maxGasPriceWei *big.Int, opts ...gas.Opt) (*big.Int, uint64, error) {
 	_va := make([]interface{}, len(opts))
 	for _i := range opts {
 		_va[_i] = opts[_i]
 	}
 	var _ca []interface{}
-	_ca = append(_ca, calldata, gasLimit)
+	_ca = append(_ca, calldata, gasLimit, maxGasPriceWei)
 	_ca = append(_ca, _va...)
 	ret := _m.Called(_ca...)
 
 	var r0 *big.Int
-	if rf, ok := ret.Get(0).(func([]byte, uint64, ...gas.Opt) *big.Int); ok {
-		r0 = rf(calldata, gasLimit, opts...)
+	if rf, ok := ret.Get(0).(func([]byte, uint64, *big.Int, ...gas.Opt) *big.Int); ok {
+		r0 = rf(calldata, gasLimit, maxGasPriceWei, opts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*big.Int)
@@ -140,15 +140,15 @@ func (_m *Estimator) GetLegacyGas(calldata []byte, gasLimit uint64, opts ...gas.
 	}
 
 	var r1 uint64
-	if rf, ok := ret.Get(1).(func([]byte, uint64, ...gas.Opt) uint64); ok {
-		r1 = rf(calldata, gasLimit, opts...)
+	if rf, ok := ret.Get(1).(func([]byte, uint64, *big.Int, ...gas.Opt) uint64); ok {
+		r1 = rf(calldata, gasLimit, maxGasPriceWei, opts...)
 	} else {
 		r1 = ret.Get(1).(uint64)
 	}
 
 	var r2 error
-	if rf, ok := ret.Get(2).(func([]byte, uint64, ...gas.Opt) error); ok {
-		r2 = rf(calldata, gasLimit, opts...)
+	if rf, ok := ret.Get(2).(func([]byte, uint64, *big.Int, ...gas.Opt) error); ok {
+		r2 = rf(calldata, gasLimit, maxGasPriceWei, opts...)
 	} else {
 		r2 = ret.Error(2)
 	}

--- a/core/chains/evm/gas/models.go
+++ b/core/chains/evm/gas/models.go
@@ -19,6 +19,7 @@ import (
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	bigmath "github.com/smartcontractkit/chainlink/core/utils/big_math"
 )
 
 var (
@@ -77,10 +78,18 @@ type Estimator interface {
 	OnNewLongestChain(context.Context, *evmtypes.Head)
 	Start(context.Context) error
 	Close() error
-	GetLegacyGas(calldata []byte, gasLimit uint64, opts ...Opt) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error)
-	BumpLegacyGas(originalGasPrice *big.Int, gasLimit uint64) (bumpedGasPrice *big.Int, chainSpecificGasLimit uint64, err error)
-	GetDynamicFee(gasLimit uint64) (fee DynamicFee, chainSpecificGasLimit uint64, err error)
-	BumpDynamicFee(original DynamicFee, gasLimit uint64) (bumped DynamicFee, chainSpecificGasLimit uint64, err error)
+	// Calculates initial gas fee for non-EIP1559 transaction
+	// maxGasPriceWei parameter is the highest possible gas fee cap that the function will return
+	GetLegacyGas(calldata []byte, gasLimit uint64, maxGasPriceWei *big.Int, opts ...Opt) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error)
+	// Increases gas price and/or limit for non-EIP1559 transactions
+	// if the bumped gas fee is greater than maxGasPriceWei, the method returns an error
+	BumpLegacyGas(originalGasPrice *big.Int, gasLimit uint64, maxGasPriceWei *big.Int) (bumpedGasPrice *big.Int, chainSpecificGasLimit uint64, err error)
+	// Calculates initial gas fee for gas for EIP1559 transactions
+	// maxGasPriceWei parameter is the highest possible gas fee cap that the function will return
+	GetDynamicFee(gasLimit uint64, maxGasPriceWei *big.Int) (fee DynamicFee, chainSpecificGasLimit uint64, err error)
+	// Increases gas price and/or limit for non-EIP1559 transactions
+	// if the bumped gas fee or tip caps are greater than maxGasPriceWei, the method returns an error
+	BumpDynamicFee(original DynamicFee, gasLimit uint64, maxGasPriceWei *big.Int) (bumped DynamicFee, chainSpecificGasLimit uint64, err error)
 }
 
 // Opt is an option for a gas estimator
@@ -266,8 +275,8 @@ func (t *Transaction) UnmarshalJSON(data []byte) error {
 }
 
 // BumpLegacyGasPriceOnly will increase the price and apply multiplier to the gas limit
-func BumpLegacyGasPriceOnly(cfg Config, lggr logger.SugaredLogger, currentGasPrice, originalGasPrice *big.Int, originalGasLimit uint64) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
-	gasPrice, err = bumpGasPrice(cfg, lggr, currentGasPrice, originalGasPrice)
+func BumpLegacyGasPriceOnly(cfg Config, lggr logger.SugaredLogger, currentGasPrice, originalGasPrice *big.Int, originalGasLimit uint64, maxGasPriceWei *big.Int) (gasPrice *big.Int, chainSpecificGasLimit uint64, err error) {
+	gasPrice, err = bumpGasPrice(cfg, lggr, currentGasPrice, originalGasPrice, maxGasPriceWei)
 	if err != nil {
 		return nil, 0, err
 	}
@@ -279,9 +288,8 @@ func BumpLegacyGasPriceOnly(cfg Config, lggr logger.SugaredLogger, currentGasPri
 // - A configured percentage bump (ETH_GAS_BUMP_PERCENT) on top of the baseline price.
 // - A configured fixed amount of Wei (ETH_GAS_PRICE_WEI) on top of the baseline price.
 // The baseline price is the maximum of the previous gas price attempt and the node's current gas price.
-func bumpGasPrice(cfg Config, lggr logger.SugaredLogger, currentGasPrice, originalGasPrice *big.Int) (*big.Int, error) {
-	maxGasPrice := cfg.EvmMaxGasPriceWei()
-
+func bumpGasPrice(cfg Config, lggr logger.SugaredLogger, currentGasPrice, originalGasPrice *big.Int, maxGasPriceWei *big.Int) (*big.Int, error) {
+	maxGasPrice := getMaxGasPrice(maxGasPriceWei, cfg)
 	var priceByPercentage = new(big.Int)
 	priceByPercentage.Mul(originalGasPrice, big.NewInt(int64(100+cfg.EvmGasBumpPercent())))
 	priceByPercentage.Div(priceByPercentage, big.NewInt(100))
@@ -322,8 +330,8 @@ func max(a, b *big.Int) *big.Int {
 }
 
 // BumpDynamicFeeOnly bumps the tip cap and max gas price if necessary
-func BumpDynamicFeeOnly(config Config, lggr logger.SugaredLogger, currentTipCap *big.Int, currentBaseFee *big.Int, originalFee DynamicFee, originalGasLimit uint64) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
-	bumped, err = bumpDynamicFee(config, lggr, currentTipCap, currentBaseFee, originalFee)
+func BumpDynamicFeeOnly(config Config, lggr logger.SugaredLogger, currentTipCap *big.Int, currentBaseFee *big.Int, originalFee DynamicFee, originalGasLimit uint64, maxGasPriceWei *big.Int) (bumped DynamicFee, chainSpecificGasLimit uint64, err error) {
+	bumped, err = bumpDynamicFee(config, lggr, currentTipCap, currentBaseFee, originalFee, maxGasPriceWei)
 	if err != nil {
 		return bumped, 0, err
 	}
@@ -341,9 +349,9 @@ func BumpDynamicFeeOnly(config Config, lggr logger.SugaredLogger, currentTipCap 
 // the Tip only. Unfortunately due to a flaw of how EIP-1559 is implemented we
 // have to bump FeeCap by at least 10% each time we bump the tip cap.
 // See: https://github.com/ethereum/go-ethereum/issues/24284
-func bumpDynamicFee(cfg Config, lggr logger.SugaredLogger, currentTipCap, currentBaseFee *big.Int, originalFee DynamicFee) (bumpedFee DynamicFee, err error) {
-	maxGasPrice := cfg.EvmMaxGasPriceWei()
-	baselineTipCap := max(originalFee.TipCap, cfg.EvmGasTipCapDefault())
+func bumpDynamicFee(cfg Config, lggr logger.SugaredLogger, currentTipCap, currentBaseFee *big.Int, originalFee DynamicFee, maxGasPriceWei *big.Int) (bumpedFee DynamicFee, err error) {
+	maxGasPrice := getMaxGasPrice(maxGasPriceWei, cfg)
+	baselineTipCap := bigmath.Max(originalFee.TipCap, cfg.EvmGasTipCapDefault())
 
 	bumpedTipCap := increaseByPercentageOrIncrement(baselineTipCap, cfg.EvmGasBumpPercent(), cfg.EvmGasBumpWei())
 
@@ -376,8 +384,8 @@ func bumpDynamicFee(cfg Config, lggr logger.SugaredLogger, currentTipCap, curren
 		if currentBaseFee.Cmp(maxGasPrice) > 0 {
 			lggr.Warnf("Ignoring current base fee of %s which is greater than max gas price of %s", currentBaseFee.String(), maxGasPrice.String())
 		} else {
-			currentFeeCap := calcFeeCap(currentBaseFee, cfg, bumpedTipCap)
-			bumpedFeeCap = max(bumpedFeeCap, currentFeeCap)
+			currentFeeCap := calcFeeCap(currentBaseFee, cfg, bumpedTipCap, maxGasPrice)
+			bumpedFeeCap = bigmath.Max(bumpedFeeCap, currentFeeCap)
 		}
 	}
 
@@ -404,4 +412,13 @@ func increaseByPercentage(original *big.Int, percentage uint16) (bumped *big.Int
 	bumped.Mul(original, big.NewInt(int64(100+percentage)))
 	bumped.Div(bumped, big.NewInt(100))
 	return
+}
+
+func getMaxGasPrice(userSpecifiedMax *big.Int, config Config) *big.Int {
+	return bigmath.Min(config.EvmMaxGasPriceWei(), userSpecifiedMax)
+}
+
+func capGasPrice(calculatedGasPrice, userSpecifiedMax *big.Int, config Config) *big.Int {
+	maxGasPrice := getMaxGasPrice(userSpecifiedMax, config)
+	return bigmath.Min(calculatedGasPrice, maxGasPrice)
 }

--- a/core/chains/evm/txmgr/eth_broadcaster.go
+++ b/core/chains/evm/txmgr/eth_broadcaster.go
@@ -286,8 +286,9 @@ func (eb *EthBroadcaster) processUnstartedEthTxs(ctx context.Context, fromAddres
 		}
 		n++
 		var a EthTxAttempt
+		keySpecificMaxGasPriceWei := eb.config.KeySpecificMaxGasPriceWei(etx.FromAddress)
 		if eb.config.EvmEIP1559DynamicFees() {
-			fee, gasLimit, err := eb.estimator.GetDynamicFee(etx.GasLimit)
+			fee, gasLimit, err := eb.estimator.GetDynamicFee(etx.GasLimit, keySpecificMaxGasPriceWei)
 			if err != nil {
 				return errors.Wrap(err, "failed to get dynamic gas fee")
 			}
@@ -296,7 +297,7 @@ func (eb *EthBroadcaster) processUnstartedEthTxs(ctx context.Context, fromAddres
 				return errors.Wrap(err, "processUnstartedEthTxs failed")
 			}
 		} else {
-			gasPrice, gasLimit, err := eb.estimator.GetLegacyGas(etx.EncodedPayload, etx.GasLimit)
+			gasPrice, gasLimit, err := eb.estimator.GetLegacyGas(etx.EncodedPayload, etx.GasLimit, keySpecificMaxGasPriceWei)
 			if err != nil {
 				return errors.Wrap(err, "failed to estimate gas")
 			}
@@ -616,7 +617,8 @@ func (eb *EthBroadcaster) tryAgainBumpingGas(ctx context.Context, lgr logger.Log
 }
 
 func (eb *EthBroadcaster) tryAgainBumpingLegacyGas(ctx context.Context, lgr logger.Logger, etx EthTx, attempt EthTxAttempt, initialBroadcastAt time.Time) error {
-	bumpedGasPrice, bumpedGasLimit, err := eb.estimator.BumpLegacyGas(attempt.GasPrice.ToInt(), etx.GasLimit)
+	keySpecificMaxGasPriceWei := eb.config.KeySpecificMaxGasPriceWei(etx.FromAddress)
+	bumpedGasPrice, bumpedGasLimit, err := eb.estimator.BumpLegacyGas(attempt.GasPrice.ToInt(), etx.GasLimit, keySpecificMaxGasPriceWei)
 	if err != nil {
 		return errors.Wrap(err, "tryAgainBumpingLegacyGas failed")
 	}
@@ -627,7 +629,8 @@ func (eb *EthBroadcaster) tryAgainBumpingLegacyGas(ctx context.Context, lgr logg
 }
 
 func (eb *EthBroadcaster) tryAgainBumpingDynamicFeeGas(ctx context.Context, lgr logger.Logger, etx EthTx, attempt EthTxAttempt, initialBroadcastAt time.Time) error {
-	bumpedFee, bumpedGasLimit, err := eb.estimator.BumpDynamicFee(attempt.DynamicFee(), etx.GasLimit)
+	keySpecificMaxGasPriceWei := eb.config.KeySpecificMaxGasPriceWei(etx.FromAddress)
+	bumpedFee, bumpedGasLimit, err := eb.estimator.BumpDynamicFee(attempt.DynamicFee(), etx.GasLimit, keySpecificMaxGasPriceWei)
 	if err != nil {
 		return errors.Wrap(err, "tryAgainBumpingDynamicFeeGas failed")
 	}
@@ -641,7 +644,8 @@ func (eb *EthBroadcaster) tryAgainWithNewEstimation(ctx context.Context, lgr log
 	if attempt.TxType == 0x2 {
 		return errors.Errorf("AssumptionViolation: re-estimation is not supported for EIP-1559 transactions. Eth node returned error: %v. This is a bug.", sendError.Error())
 	}
-	gasPrice, gasLimit, err := eb.estimator.GetLegacyGas(etx.EncodedPayload, etx.GasLimit, gas.OptForceRefetch)
+	keySpecificMaxGasPriceWei := eb.config.KeySpecificMaxGasPriceWei(etx.FromAddress)
+	gasPrice, gasLimit, err := eb.estimator.GetLegacyGas(etx.EncodedPayload, etx.GasLimit, keySpecificMaxGasPriceWei, gas.OptForceRefetch)
 	if err != nil {
 		return errors.Wrap(err, "tryAgainWithNewEstimation failed to estimate gas")
 	}

--- a/core/chains/evm/txmgr/eth_broadcaster_test.go
+++ b/core/chains/evm/txmgr/eth_broadcaster_test.go
@@ -546,7 +546,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_OptimisticLockingOnEthTx(t *testi
 	chBlock := make(chan struct{})
 
 	estimator := new(gasmocks.Estimator)
-	estimator.On("GetLegacyGas", mock.Anything, mock.Anything).Return(assets.GWei(32), uint64(500), nil).Run(func(_ mock.Arguments) {
+	estimator.On("GetLegacyGas", mock.Anything, mock.Anything, evmcfg.KeySpecificMaxGasPriceWei(fromAddress)).Return(assets.GWei(32), uint64(500), nil).Run(func(_ mock.Arguments) {
 		close(chStartEstimate)
 		<-chBlock
 	})

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -958,7 +958,7 @@ func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 	t.Parallel()
 
 	var initialDefaultGasPrice int64 = 5000000000
-
+	maxGasPrice := big.NewInt(50000000000)
 	cfg := cltest.NewTestGeneralConfig(t)
 	cfg.Overrides.GlobalBalanceMonitorEnabled = null.BoolFrom(false)
 
@@ -1037,7 +1037,7 @@ func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 
 	chain := evmtest.MustGetDefaultChain(t, cc)
 	estimator := chain.TxManager().GetGasEstimator()
-	gasPrice, gasLimit, err := estimator.GetLegacyGas(nil, 500000)
+	gasPrice, gasLimit, err := estimator.GetLegacyGas(nil, 500000, maxGasPrice)
 	require.NoError(t, err)
 	assert.Equal(t, uint64(500000), gasLimit)
 	assert.Equal(t, "41500000000", gasPrice.String())
@@ -1059,7 +1059,7 @@ func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 	newHeads.TrySend(cltest.Head(43))
 
 	gomega.NewWithT(t).Eventually(func() string {
-		gasPrice, _, err := estimator.GetLegacyGas(nil, 500000)
+		gasPrice, _, err := estimator.GetLegacyGas(nil, 500000, maxGasPrice)
 		require.NoError(t, err)
 		return gasPrice.String()
 	}, cltest.WaitTimeout(t), cltest.DBPollingInterval).Should(gomega.Equal("45000000000"))

--- a/core/services/keeper/common.go
+++ b/core/services/keeper/common.go
@@ -1,8 +1,10 @@
 package keeper
 
 import (
+	"math/big"
 	"time"
 
+	gethcommon "github.com/ethereum/go-ethereum/common"
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/keeper_registry_wrapper1_1"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/keeper_registry_wrapper1_2"
@@ -13,6 +15,7 @@ var Registry1_2ABI = evmtypes.MustGetABI(keeper_registry_wrapper1_2.KeeperRegist
 
 type Config interface {
 	EvmEIP1559DynamicFees() bool
+	KeySpecificMaxGasPriceWei(addr gethcommon.Address) *big.Int
 	KeeperDefaultTransactionQueueDepth() uint32
 	KeeperGasPriceBufferPercent() uint32
 	KeeperGasTipCapBufferPercent() uint32

--- a/core/services/keeper/upkeep_executer.go
+++ b/core/services/keeper/upkeep_executer.go
@@ -274,11 +274,12 @@ func (ex *UpkeepExecuter) estimateGasPrice(upkeep UpkeepRegistration) (gasPrice 
 		return nil, fee, errors.Wrap(err, "unable to construct performUpkeep data")
 	}
 
+	keySpecificGasPriceWei := ex.config.KeySpecificMaxGasPriceWei(upkeep.Registry.FromAddress.Address())
 	if ex.config.EvmEIP1559DynamicFees() {
-		fee, _, err = ex.gasEstimator.GetDynamicFee(upkeep.ExecuteGas)
+		fee, _, err = ex.gasEstimator.GetDynamicFee(upkeep.ExecuteGas, keySpecificGasPriceWei)
 		fee.TipCap = addBuffer(fee.TipCap, ex.config.KeeperGasTipCapBufferPercent())
 	} else {
-		gasPrice, _, err = ex.gasEstimator.GetLegacyGas(performTxData, upkeep.ExecuteGas)
+		gasPrice, _, err = ex.gasEstimator.GetLegacyGas(performTxData, upkeep.ExecuteGas, keySpecificGasPriceWei)
 		gasPrice = addBuffer(gasPrice, ex.config.KeeperGasPriceBufferPercent())
 	}
 	if err != nil {

--- a/core/services/keeper/upkeep_executer_test.go
+++ b/core/services/keeper/upkeep_executer_test.go
@@ -42,7 +42,18 @@ func newHead() evmtypes.Head {
 	return evmtypes.NewHead(big.NewInt(20), utils.NewHash(), utils.NewHash(), 1000, utils.NewBigI(0))
 }
 
-func setup(t *testing.T) (
+func mockEstimator(t *testing.T) (estimator *gasmocks.Estimator) {
+	estimator = new(gasmocks.Estimator)
+	estimator.Test(t)
+	estimator.On("GetLegacyGas", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(assets.GWei(60), uint64(0), nil)
+	estimator.On("GetDynamicFee", mock.Anything, mock.Anything).Maybe().Return(gas.DynamicFee{
+		FeeCap: assets.GWei(60),
+		TipCap: assets.GWei(60),
+	}, uint64(60), nil)
+	return
+}
+
+func setup(t *testing.T, estimator *gasmocks.Estimator) (
 	*sqlx.DB,
 	*configtest.TestGeneralConfig,
 	*evmmocks.Client,
@@ -69,14 +80,7 @@ func setup(t *testing.T) (
 	ethClient.On("BlockByNumber", mock.Anything, mock.Anything).Maybe().Return(block, nil)
 	txm := new(txmmocks.TxManager)
 	txm.Test(t)
-	estimator := new(gasmocks.Estimator)
-	estimator.Test(t)
 	txm.On("GetGasEstimator").Return(estimator)
-	estimator.On("GetLegacyGas", mock.Anything, mock.Anything).Maybe().Return(assets.GWei(60), uint64(0), nil)
-	estimator.On("GetDynamicFee", mock.Anything).Maybe().Return(gas.DynamicFee{
-		FeeCap: assets.GWei(60),
-		TipCap: assets.GWei(60),
-	}, uint64(60), nil)
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{TxManager: txm, DB: db, Client: ethClient, KeyStore: keyStore.Eth(), GeneralConfig: cfg})
 	jpv2 := cltest.NewJobPipelineV2(t, cfg, cc, db, keyStore, nil, nil)
 	ch := evmtest.MustGetDefaultChain(t, cc)
@@ -113,7 +117,7 @@ var checkPerformResponse = struct {
 
 func Test_UpkeepExecuter_ErrorsIfStartedTwice(t *testing.T) {
 	t.Parallel()
-	_, _, _, executer, _, _, _, _, _, _, _, _ := setup(t)
+	_, _, _, executer, _, _, _, _, _, _, _, _ := setup(t, mockEstimator(t))
 	err := executer.Start(testutils.Context(t)) // already started in setup()
 	require.Error(t, err)
 }
@@ -122,7 +126,7 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 	t.Parallel()
 
 	t.Run("runs upkeep on triggering block number", func(t *testing.T) {
-		db, config, ethMock, executer, registry, upkeep, job, jpv2, txm, _, _, _ := setup(t)
+		db, config, ethMock, executer, registry, upkeep, job, jpv2, txm, _, _, _ := setup(t, mockEstimator(t))
 
 		gasLimit := upkeep.ExecuteGas + config.KeeperRegistryPerformGasOverhead()
 		gasPrice := bigmath.Div(bigmath.Mul(assets.GWei(60), 100+config.KeeperGasPriceBufferPercent()), 100)
@@ -167,7 +171,7 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 
 	t.Run("runs upkeep on triggering block number on EIP1559 and non-EIP1559 chains", func(t *testing.T) {
 		runTest := func(t *testing.T, eip1559 bool) {
-			db, config, ethMock, executer, registry, upkeep, job, jpv2, txm, _, _, _ := setup(t)
+			db, config, ethMock, executer, registry, upkeep, job, jpv2, txm, _, _, _ := setup(t, mockEstimator(t))
 
 			config.Overrides.GlobalEvmEIP1559DynamicFees = null.BoolFrom(eip1559)
 
@@ -230,7 +234,7 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 	})
 
 	t.Run("errors if submission key not found", func(t *testing.T) {
-		_, config, ethMock, executer, registry, _, job, jpv2, _, keyStore, _, _ := setup(t)
+		_, config, ethMock, executer, registry, _, job, jpv2, _, keyStore, _, _ := setup(t, mockEstimator(t))
 
 		// replace expected key with random one
 		_, err := keyStore.Eth().Create(&cltest.FixtureChainID)
@@ -266,7 +270,7 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 	})
 
 	t.Run("errors if submission chain not found", func(t *testing.T) {
-		db, _, ethMock, _, _, _, job, jpv2, _, _, ch, orm := setup(t)
+		db, _, ethMock, _, _, _, job, jpv2, _, _, ch, orm := setup(t, mockEstimator(t))
 
 		// change chain ID to non-configured chain
 		job.KeeperSpec.EVMChainID = (*utils.Big)(big.NewInt(999))
@@ -283,7 +287,7 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 	})
 
 	t.Run("triggers if heads are skipped but later heads arrive within range", func(t *testing.T) {
-		db, config, ethMock, executer, registry, upkeep, job, jpv2, txm, _, _, _ := setup(t)
+		db, config, ethMock, executer, registry, upkeep, job, jpv2, txm, _, _, _ := setup(t, mockEstimator(t))
 
 		etxs := []cltest.Awaiter{
 			cltest.NewAwaiter(),
@@ -317,13 +321,85 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 
 		ethMock.AssertExpectations(t)
 	})
+
+	t.Run("verify key specific max gas price is passed into estimator for EIP1559 and non-EIP1559 chains", func(t *testing.T) {
+		runTest := func(t *testing.T, estimator *gasmocks.Estimator, eip1559 bool) {
+			db, config, ethMock, executer, registry, upkeep, job, jpv2, txm, _, _, _ := setup(t, estimator)
+			config.Overrides.GlobalEvmEIP1559DynamicFees = null.BoolFrom(eip1559)
+
+			gasLimit := upkeep.ExecuteGas + config.KeeperRegistryPerformGasOverhead()
+			gasPrice := bigmath.Div(bigmath.Mul(assets.GWei(60), 100+config.KeeperGasPriceBufferPercent()), 100)
+			baseFeePerGas := utils.NewBig(big.NewInt(0).Mul(gasPrice, big.NewInt(2)))
+
+			ethTxCreated := cltest.NewAwaiter()
+			txm.On("CreateEthTransaction",
+				mock.MatchedBy(func(newTx txmgr.NewTx) bool { return newTx.GasLimit == gasLimit }),
+			).
+				Once().
+				Return(txmgr.EthTx{
+					ID: 1,
+				}, nil).
+				Run(func(mock.Arguments) { ethTxCreated.ItHappened() })
+
+			registryMock := cltest.NewContractMockReceiver(t, ethMock, keeper.Registry1_1ABI, registry.ContractAddress.Address())
+			registryMock.MockMatchedResponse(
+				"checkUpkeep",
+				func(callArgs ethereum.CallMsg) bool {
+					expectedGasPrice := bigmath.Div(
+						bigmath.Mul(baseFeePerGas.ToInt(), 100+config.KeeperBaseFeeBufferPercent()),
+						100,
+					)
+
+					return bigmath.Equal(callArgs.GasPrice, expectedGasPrice) &&
+						650_000 == callArgs.Gas
+				},
+				checkUpkeepResponse,
+			)
+			registryMock.MockMatchedResponse(
+				"performUpkeep",
+				func(callArgs ethereum.CallMsg) bool { return true },
+				checkPerformResponse,
+			)
+
+			head := newHead()
+			head.BaseFeePerGas = baseFeePerGas
+
+			executer.OnNewLongestChain(context.Background(), &head)
+			ethTxCreated.AwaitOrFail(t)
+			runs := cltest.WaitForPipelineComplete(t, 0, job.ID, 1, 8, jpv2.Jrm, time.Second, 100*time.Millisecond)
+			require.Len(t, runs, 1)
+			assert.False(t, runs[0].HasErrors())
+			assert.False(t, runs[0].HasFatalErrors())
+			waitLastRunHeight(t, db, upkeep, 20)
+
+			ethMock.AssertExpectations(t)
+			txm.AssertExpectations(t)
+		}
+
+		t.Run("EIP1559", func(t *testing.T) {
+			estimator := new(gasmocks.Estimator)
+			estimator.Test(t)
+			estimator.On("GetDynamicFee", mock.Anything, big.NewInt(100000000000000)).Return(gas.DynamicFee{
+				FeeCap: assets.GWei(60),
+				TipCap: assets.GWei(60),
+			}, uint64(60), nil)
+			runTest(t, estimator, true)
+		})
+
+		t.Run("non-EIP1559", func(t *testing.T) {
+			estimator := new(gasmocks.Estimator)
+			estimator.Test(t)
+			estimator.On("GetLegacyGas", mock.Anything, mock.Anything, big.NewInt(100000000000000)).Return(assets.GWei(60), uint64(0), nil)
+			runTest(t, estimator, false)
+		})
+	})
 }
 
 func Test_UpkeepExecuter_PerformsUpkeep_Error(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewWithT(t)
 
-	db, _, ethMock, executer, registry, _, _, _, _, _, _, _ := setup(t)
+	db, _, ethMock, executer, registry, _, _, _, _, _, _, _ := setup(t, mockEstimator(t))
 
 	wasCalled := atomic.NewBool(false)
 	registryMock := cltest.NewContractMockReceiver(t, ethMock, keeper.Registry1_1ABI, registry.ContractAddress.Address())

--- a/core/utils/big_math/big_math.go
+++ b/core/utils/big_math/big_math.go
@@ -51,6 +51,17 @@ func Max(x, y interface{}) *big.Int {
 	return yBig
 }
 
+// Min returns the min of the two given values after coercing them to big.Int,
+// or panics if it cannot.
+func Min(x, y interface{}) *big.Int {
+	xBig := bnIfy(x)
+	yBig := bnIfy(y)
+	if xBig.Cmp(yBig) == -1 {
+		return xBig
+	}
+	return yBig
+}
+
 // Accumulate returns the sum of the given slice after coercing all elements
 // to a big.Int, or panics if it cannot.
 func Accumulate(s []interface{}) (r *big.Int) {

--- a/core/utils/big_math/big_math_test.go
+++ b/core/utils/big_math/big_math_test.go
@@ -45,6 +45,44 @@ func TestMax(t *testing.T) {
 	}
 }
 
+func TestMin(t *testing.T) {
+	testCases := []struct {
+		x        interface{}
+		y        interface{}
+		expected *big.Int
+	}{
+		{
+			x:        int32(1),
+			y:        int32(2),
+			expected: big.NewInt(1),
+		},
+		{
+			x:        big.NewInt(1),
+			y:        big.NewInt(2),
+			expected: big.NewInt(1),
+		},
+		{
+			x:        float64(1.0),
+			y:        float64(2.0),
+			expected: big.NewInt(1),
+		},
+		{
+			x:        "2",
+			y:        "1",
+			expected: big.NewInt(1),
+		},
+		{
+			x:        uint(2),
+			y:        uint(1),
+			expected: big.NewInt(1),
+		},
+	}
+	for _, testCase := range testCases {
+		m := Min(testCase.x, testCase.y)
+		require.Equal(t, 0, testCase.expected.Cmp(m))
+	}
+}
+
 func TestAccumulate(t *testing.T) {
 	s := []interface{}{1, 2, 3, 4, 5}
 	expected := big.NewInt(15)

--- a/core/web/evm_transfer_controller.go
+++ b/core/web/evm_transfer_controller.go
@@ -92,7 +92,8 @@ func ValidateEthBalanceForTransfer(c *gin.Context, chain evm.Chain, fromAddr com
 
 	gasLimit := chain.Config().EvmGasLimitTransfer()
 	estimator := chain.TxManager().GetGasEstimator()
-	gasPrice, gasLimit, err = estimator.GetLegacyGas(nil, gasLimit)
+
+	gasPrice, gasLimit, err = estimator.GetLegacyGas(nil, gasLimit, chain.Config().KeySpecificMaxGasPriceWei(fromAddr))
 	if err != nil {
 		return errors.Wrap(err, "failed to estimate gas")
 	}


### PR DESCRIPTION
Hot fix https://app.shortcut.com/chainlinklabs/story/42337/investigate-why-60-gwei-fulfillments-are-not-timely-enough

honor key-specific max gas limit when calculating initial max gas cap for eip1559 transactions
when increasing gas cap for pending requests, make sure that we won’t bump gas beyond key-specific limits

Related PR: https://github.com/smartcontractkit/chainlink/pull/6733