### PR TITLE
Removed unused `LinkTokenInterface` import

### DIFF
--- a/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol
+++ b/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol
@@ -2,7 +2,6 @@
 // A mock for testing code that relies on VRFCoordinatorV2.
 pragma solidity ^0.8.4;
 
-import "../interfaces/LinkTokenInterface.sol";
 import "../interfaces/VRFCoordinatorV2Interface.sol";
 import "../VRFConsumerBaseV2.sol";
 


### PR DESCRIPTION
`VRFCoordinatorV2Mock` does not depend on `LinkTokenInterface`, so it is safe to remove it.