### PR TITLE
Updated CODEOWNERS to include integration tests dependencies

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -60,5 +60,7 @@ package.json @smartcontractkit/prodsec-public
 yarn.lock @smartcontractkit/prodsec-public
 go.mod @smartcontractkit/prodsec-public
 go.sum @smartcontractkit/prodsec-public
+integration-tests/go.mod @smartcontractkit/prodsec-public
+integration-tests/go.sum @smartcontractkit/prodsec-public
 flake.nix @smartcontractkit/prodsec-public
 flake.lock @smartcontractkit/prodsec-public


### PR DESCRIPTION
Because the integration tests have a lot of dependencies and a lot of the Go packages are updated frequently, it would be good to loop in prodsec-public for PRs associated with modifications in the go.mod and go.sum of the integration tests. In this way, we can avoid missing any vulnerabilities caused by any of those updated packages.