### PR TITLE
chore: write test key JSON exports to temp directory

### DIFF
--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -115,7 +115,7 @@ func newEthMockWithTransactionsOnBlocksAssertions(t *testing.T) *evmmocks.Client
 }
 
 func keyNameForTest(t *testing.T) string {
-	return fmt.Sprintf("%s_test_key.json", t.Name())
+	return fmt.Sprintf("%s/%s_test_key.json", t.TempDir(), t.Name())
 }
 
 func deleteKeyExportFile(t *testing.T) {


### PR DESCRIPTION
Fixes an annoyance where sometimes JSON files are leftover due to testing key export commands.