### PR TITLE
core/chains/evm/client: add node fsm diagram

### DIFF
--- a/core/chains/evm/client/README.md
+++ b/core/chains/evm/client/README.md
@@ -1,0 +1,33 @@
+# EVM Client
+
+## Node FSM
+
+```mermaid
+stateDiagram-v2
+    [*] --> Started : Start()
+    
+    state Started {
+        [*] --> Undialed
+        Undialed --> Unreachable
+        Undialed --> Dialed
+        
+        Unreachable --> Dialed 
+        
+        Dialed --> Unreachable
+        Dialed --> InvalidChainID
+        Dialed --> Alive
+        
+        InvalidChainID --> Unreachable
+        InvalidChainID --> Alive
+        
+        Alive --> Unreachable
+        Alive --> OutOfSync
+        
+        OutOfSync --> Unreachable
+        OutOfSync --> InvalidChainID    
+        OutOfSync --> Alive    
+    }
+    
+    Started --> Closed : Close()
+    Closed --> [*]
+```


### PR DESCRIPTION
@aalu1418 Pointed out github's support for Mermaid diagrams a few weeks ago. This is an attempt to introduce a simple one for the EVM client node finite state machine.
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/creating-diagrams#creating-mermaid-diagrams