### PR TITLE
core: fix readme logo

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -1,7 +1,7 @@
 <br/>
 <p align="center">
 <a href="https://chain.link" target="_blank">
-<img src="https://raw.githubusercontent.com/smartcontractkit/explorer/develop/styleguide/static/images/logo-core-blue.svg" width="225" alt="Chainlink logo">
+<img src="https://raw.githubusercontent.com/smartcontractkit/chainlink/develop/docs/logo-chainlink-blue.svg" width="225" alt="Chainlink logo">
 </a>
 </p>
 <br/>


### PR DESCRIPTION
The core readme logo url was broken. Updating to the same as root.