### PR TITLE
adjust default OCR step max duration in ocr2vrf scripts

### DIFF
--- a/core/scripts/ocr2vrf/main.go
+++ b/core/scripts/ocr2vrf/main.go
@@ -86,11 +86,11 @@ func main() {
 		deltaGrace := cmd.Duration("delta-grace", 20*time.Second, "duration of delta grace")
 		deltaStage := cmd.Duration("delta-stage", 20*time.Second, "duration of delta grace")
 		maxRounds := cmd.Uint("max-rounds", 3, "maximum number of rounds")
-		maxDurationQuery := cmd.Duration("max-duration-query", 5*time.Second, "maximum duration of query")
-		maxDurationObservation := cmd.Duration("max-duration-observation", 5*time.Second, "maximum duration of observation method")
-		maxDurationReport := cmd.Duration("max-duration-report", 5*time.Second, "maximum duration of report method")
-		maxDurationAccept := cmd.Duration("max-duration-accept", 5*time.Second, "maximum duration of shouldAcceptFinalizedReport method")
-		maxDurationTransmit := cmd.Duration("max-duration-transmit", 5*time.Second, "maximum duration of shouldTransmitAcceptedReport method")
+		maxDurationQuery := cmd.Duration("max-duration-query", 10*time.Millisecond, "maximum duration of query")
+		maxDurationObservation := cmd.Duration("max-duration-observation", 10*time.Second, "maximum duration of observation method")
+		maxDurationReport := cmd.Duration("max-duration-report", 10*time.Second, "maximum duration of report method")
+		maxDurationAccept := cmd.Duration("max-duration-accept", 10*time.Millisecond, "maximum duration of shouldAcceptFinalizedReport method")
+		maxDurationTransmit := cmd.Duration("max-duration-transmit", 1*time.Second, "maximum duration of shouldTransmitAcceptedReport method")
 
 		helpers.ParseArgs(cmd,
 			os.Args[2:],


### PR DESCRIPTION
Benchmarking details here: https://smartcontract-it.atlassian.net/browse/VRF-29

average execution time for Report() and Observation() were ~1 second. ShouldTransmitAcceptedReport() was ~100ms. For these 3 steps, default max duration is set to 10x. 

Query() is not used for DKG and ShouldTransmitAcceptedReport() simply returns true as of now (less than 1 microsecond) so setting these to 10ms for now. 

