### PR TITLE
Updated CHANGELOGS.md

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 2. Must not contain leading or trailing whitespace
 3. User passwords must not contain the user's API email
 
+- Simplified the Keepers job spec by removing the observation source from the required parameters.
+
 ## [1.5.0] - 2022-06-21
 
 ### Changed


### PR DESCRIPTION
Included a small comment to make a note in the CHANGELOGS.md file about the removal of the observation source from the Keepers job parameter list.