### PR TITLE
Automated DKG setup

### DIFF
--- a/core/cmd/dkg_configure_command.go
+++ b/core/cmd/dkg_configure_command.go
@@ -1,0 +1,274 @@
+package cmd
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"time"
+
+	"github.com/pelletier/go-toml"
+	"github.com/pkg/errors"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/core/services/job"
+	"github.com/smartcontractkit/chainlink/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/core/services/keystore/chaintype"
+	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ocr2key"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
+	"github.com/smartcontractkit/chainlink/core/static"
+	clipkg "github.com/urfave/cli"
+)
+
+type SetupDKGNodePayload struct {
+	OnChainPublicKey  string
+	OffChainPublicKey string
+	ConfigPublicKey   string
+	PeerID            string
+	Transmitter       string
+	DkgEncrypt        string
+	DkgSign           string
+}
+
+type DKGTemplateArgs struct {
+	contractID              string
+	ocrKeyBundleID          string
+	p2pv2BootstrapperPeerID string
+	p2pv2BootstrapperPort   string
+	transmitterID           string
+	chainID                 int64
+	EncryptionPublicKey     string
+	KeyID                   string
+	SigningPublicKey        string
+}
+
+const dkgTemplate = `
+# DKGSpec
+type                 = "offchainreporting2"
+schemaVersion        = 1
+name                 = "ocr2"
+maxTaskDuration      = "30s"
+contractID           = "%s"
+ocrKeyBundleID       = "%s"
+p2pv2Bootstrappers   = ["%s@127.0.0.1:%s"]
+relay                = "evm"
+pluginType           = "dkg"
+transmitterID        = "%s"
+
+[relayConfig]
+chainID              = %d
+
+[pluginConfig]
+EncryptionPublicKey  = "%s"
+KeyID                = "%s"
+SigningPublicKey     = "%s"
+`
+
+const bootstrapTemplate = `
+type                               = "bootstrap"
+schemaVersion                      = 1
+name                               = ""
+id                                 = "1"
+contractID                         = "%s"
+relay                              = "evm"
+
+[relayConfig]
+chainID                            = %d
+`
+
+func (cli *Client) ConfigureDKGNode(c *clipkg.Context) (*SetupDKGNodePayload, error) {
+	lggr := cli.Logger.Named("SetupDKGJob")
+	err := cli.Config.Validate()
+	if err != nil {
+		return nil, errors.Wrap(err, "config validation failed")
+	}
+	lggr.Infow(fmt.Sprintf("Configuring Chainlink Node FOR DKG %s at commit %s", static.Version, static.Sha), "Version", static.Version, "SHA", static.Sha)
+
+	ldb := pg.NewLockedDB(cli.Config, lggr)
+	rootCtx, _ := context.WithCancel(context.Background())
+
+	if err = ldb.Open(rootCtx); err != nil {
+		return nil, cli.errorOut(errors.Wrap(err, "opening db"))
+	}
+	defer lggr.ErrorIfClosing(ldb, "db")
+
+	app, err := cli.AppFactory.NewApplication(cli.Config, ldb.DB())
+	if err != nil {
+		return nil, cli.errorOut(errors.Wrap(err, "fatal error instantiating application"))
+	}
+
+	// Initialize keystore and generate keys.
+	keyStore := app.GetKeyStore()
+	err = setupDKGKeystore(cli, c, app, keyStore)
+	if err != nil {
+		return nil, err
+	}
+
+	// Get all configuration parameters.
+	keyID := c.String("keyID")
+	dkgEncrypt, _ := app.GetKeyStore().DKGEncrypt().GetAll()
+	dkgSign, _ := app.GetKeyStore().DKGSign().GetAll()
+	dkgEncryptKey := dkgEncrypt[0].PublicKeyString()
+	dkgSignKey := dkgSign[0].PublicKeyString()
+	p2p, _ := app.GetKeyStore().P2P().GetAll()
+	ocr2List, _ := app.GetKeyStore().OCR2().GetAll()
+	ethKeys, _ := app.GetKeyStore().Eth().GetAll()
+	transmitterID := ethKeys[0].Address.String()
+	peerID := p2p[0].PeerID().Raw()
+	if c.Bool("isBootstrapper") == false {
+		peerID = c.String("bootstrapperPeerID")
+	}
+
+	// Find the EVM OCR2 bundle.
+	var ocr2 ocr2key.KeyBundle
+	for _, ocr2Item := range ocr2List {
+		if ocr2Item.ChainType() == chaintype.EVM {
+			ocr2 = ocr2Item
+		}
+	}
+	if ocr2 == nil {
+		return nil, cli.errorOut(errors.Wrap(job.ErrNoSuchKeyBundle, "evm OCR2 key bundle not found"))
+	}
+	offChainPublicKey := ocr2.OffchainPublicKey()
+	configPublicKey := ocr2.ConfigEncryptionPublicKey()
+
+	// Set up bootstrapper job if bootstrapper.
+	if c.Bool("isBootstrapper") {
+		err = setupBootstrapperJob(cli, c, app)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Set up DKG job.
+	dkgTemplateArgs := &DKGTemplateArgs{
+		contractID:              c.String("contractID"),
+		ocrKeyBundleID:          ocr2.ID(),
+		p2pv2BootstrapperPeerID: peerID,
+		p2pv2BootstrapperPort:   c.String("bootstrapPort"),
+		transmitterID:           transmitterID,
+		chainID:                 c.Int64("chainID"),
+		EncryptionPublicKey:     dkgEncryptKey,
+		KeyID:                   keyID,
+		SigningPublicKey:        dkgSignKey,
+	}
+	err = createDKGJob(cli, c, app, *dkgTemplateArgs)
+	if err != nil {
+		return nil, err
+	}
+
+	return &SetupDKGNodePayload{
+		OnChainPublicKey:  ocr2.OnChainPublicKey(),
+		OffChainPublicKey: hex.EncodeToString(offChainPublicKey[:]),
+		ConfigPublicKey:   hex.EncodeToString(configPublicKey[:]),
+		PeerID:            p2p[0].PeerID().Raw(),
+		Transmitter:       transmitterID,
+		DkgEncrypt:        dkgEncryptKey,
+		DkgSign:           dkgSignKey,
+	}, nil
+}
+
+func setupDKGKeystore(cli *Client, c *clipkg.Context, app chainlink.Application, keyStore keystore.Master) error {
+	err := cli.KeyStoreAuthenticator.authenticate(c, keyStore)
+	if err != nil {
+		return errors.Wrap(err, "error authenticating keystore")
+	}
+
+	evmChainSet := app.GetChains().EVM
+	if cli.Config.EVMEnabled() {
+		if err != nil {
+			return errors.Wrap(err, "error migrating keystore")
+		}
+
+		for _, ch := range evmChainSet.Chains() {
+			err = keyStore.Eth().EnsureKeys(ch.ID())
+			if err != nil {
+				return errors.Wrap(err, "failed to ensure keystore keys")
+			}
+		}
+	}
+
+	err = keyStore.OCR2().EnsureKeys()
+	if err != nil {
+		return errors.Wrap(err, "failed to ensure ocr key")
+	}
+
+	err = keyStore.DKGSign().EnsureKey()
+	if err != nil {
+		return errors.Wrap(err, "failed to ensure ocr key")
+	}
+
+	err = keyStore.DKGEncrypt().EnsureKey()
+	if err != nil {
+		return errors.Wrap(err, "failed to ensure ocr key")
+	}
+
+	err = keyStore.P2P().EnsureKey()
+	if err != nil {
+		return errors.Wrap(err, "failed to ensure p2p key")
+	}
+
+	return nil
+}
+
+func setupBootstrapperJob(cli *Client, c *clipkg.Context, app chainlink.Application) error {
+	sp := fmt.Sprintf(bootstrapTemplate,
+		c.String("contractID"),
+		c.Int64("chainID"),
+	)
+	var jb job.Job
+	err := toml.Unmarshal([]byte(sp), &jb)
+	if err != nil {
+		return errors.Wrap(err, "failed to unmarshal job spec")
+	}
+	var os job.BootstrapSpec
+	err = toml.Unmarshal([]byte(sp), &os)
+	if err != nil {
+		return errors.Wrap(err, "failed to unmarshal job spec")
+	}
+	jb.BootstrapSpec = &os
+
+	err = app.AddJobV2(context.Background(), &jb)
+	if err != nil {
+		return errors.Wrap(err, "failed to add job")
+	}
+	fmt.Println(sp)
+
+	// Give a cooldown
+	time.Sleep(time.Second)
+
+	return nil
+}
+
+func createDKGJob(cli *Client, c *clipkg.Context, app chainlink.Application, args DKGTemplateArgs) error {
+	// Set up DKG job if.
+	sp := fmt.Sprintf(dkgTemplate,
+		args.contractID,
+		args.ocrKeyBundleID,
+		args.p2pv2BootstrapperPeerID,
+		args.p2pv2BootstrapperPort,
+		args.transmitterID,
+		args.chainID,
+		args.EncryptionPublicKey,
+		args.KeyID,
+		args.SigningPublicKey,
+	)
+
+	var jb job.Job
+	err := toml.Unmarshal([]byte(sp), &jb)
+	if err != nil {
+		return errors.Wrap(err, "failed to unmarshal job spec")
+	}
+	var os job.OCR2OracleSpec
+	err = toml.Unmarshal([]byte(sp), &os)
+	if err != nil {
+		return errors.Wrap(err, "failed to unmarshal job spec")
+	}
+	jb.OCR2OracleSpec = &os
+
+	err = app.AddJobV2(context.Background(), &jb)
+	if err != nil {
+		return errors.Wrap(err, "failed to add job")
+	}
+	fmt.Println(sp)
+
+	return nil
+}

--- a/core/scripts/ocr2vrf/main.go
+++ b/core/scripts/ocr2vrf/main.go
@@ -133,6 +133,8 @@ func main() {
 
 		setDKGConfig(e, *dkgAddress, commands)
 
+	case "dkg-setup":
+		setupDKGNodes(e)
 	default:
 		panic("unrecognized subcommand: " + os.Args[1])
 	}

--- a/core/scripts/ocr2vrf/setup_dkg.go
+++ b/core/scripts/ocr2vrf/setup_dkg.go
@@ -1,0 +1,168 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"math/big"
+	"os"
+	"strings"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/smartcontractkit/chainlink/core/cmd"
+	"github.com/smartcontractkit/chainlink/core/config"
+	"github.com/smartcontractkit/chainlink/core/logger"
+	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
+	"github.com/urfave/cli"
+)
+
+func setupDKGNodes(e helpers.Environment) {
+	client := NewProductionClient()
+	app := cmd.NewApp(client)
+
+	// Parse os arguments.
+	cmd := flag.NewFlagSet("dkg-setup", flag.ExitOnError)
+	keyID := cmd.String("key-id", "aee00d81f822f882b6fe28489822f59ebb21ea95c0ae21d9f67c0239461148fc", "key ID")
+	apiFile := cmd.String("api", "../../../tools/secrets/apicredentials", "api file")
+	passwordFile := cmd.String("password", "../../../tools/secrets/password.txt", "password file")
+	databasePrefix := cmd.String("database-prefix", "postgres://postgres:postgres@localhost:5432/dkg-test", "database prefix")
+	databaseSuffixes := cmd.String("database-suffixes", "sslmode=disable", "database parameters to be added")
+	nodeCount := cmd.Int("node-cout", 5, "number of nodes")
+	fundingAmount := cmd.Int64("funding-amount", 10000000000000000, "amount to fund nodes") // .1 ETH
+	helpers.ParseArgs(cmd, os.Args[2:])
+
+	if *nodeCount < 5 {
+		fmt.Println("Node count too low for DKG job.")
+		os.Exit(1)
+	}
+
+	//Deploy DKG contract.
+	// uncomment for faster txs
+	// e.Owner.GasPrice = e.Owner.GasPrice.Mul(e.Owner.GasPrice, big.NewInt(2))
+	dkgAddress := deployDKG(e).String()
+
+	// Initialize dkg-set-config arguments.
+	onChainPublicKeys := []string{}
+	offChainPublicKeys := []string{}
+	configPublicKeys := []string{}
+	peerIDs := []string{}
+	transmitters := []string{}
+	dkgEncrypters := []string{}
+	dkgSigners := []string{}
+
+	// Iterate through all nodes and create jobs.
+	for i := 0; i < *nodeCount; i++ {
+		flagSet := flag.NewFlagSet("run-dkg-job-creation", flag.ExitOnError)
+		flagSet.String("api", *apiFile, "api file")
+		flagSet.String("password", *passwordFile, "password file")
+		flagSet.String("bootstrapPort", fmt.Sprintf("%d", 8000), "port of bootstrap")
+		flagSet.String("keyID", *keyID, "")
+		flagSet.String("contractID", dkgAddress, "the contract address of the DKG")
+		flagSet.Int64("chainID", e.ChainID, "the chain ID")
+		flagSet.Bool("dangerWillRobinson", true, "for resetting databases")
+		flagSet.Bool("isBootstrapper", i == 0, "is first node")
+		bootstrapperPeerID := ""
+		if len(peerIDs) != 0 {
+			bootstrapperPeerID = peerIDs[0]
+		}
+		flagSet.String("bootstrapperPeerID", bootstrapperPeerID, "is first node")
+
+		// Create context from flags.
+		context := cli.NewContext(app, flagSet, nil)
+
+		// Reset DKG node database.
+		resetDatbase(client, context, i, *databasePrefix, *databaseSuffixes)
+
+		// Setup DKG node.
+		payload := setupDKGNodeFromClient(client, context)
+
+		// Append arguments for dkg-set-config command.
+		onChainPublicKeys = append(onChainPublicKeys, payload.OnChainPublicKey)
+		offChainPublicKeys = append(offChainPublicKeys, payload.OffChainPublicKey)
+		configPublicKeys = append(configPublicKeys, payload.ConfigPublicKey)
+		peerIDs = append(peerIDs, payload.PeerID)
+		transmitters = append(transmitters, payload.Transmitter)
+		dkgEncrypters = append(dkgEncrypters, payload.DkgEncrypt)
+		dkgSigners = append(dkgSigners, payload.DkgSign)
+	}
+
+	// Fund transmitters with funding amount.
+	fundNodes(e, transmitters, *fundingAmount)
+
+	// Construct and print dkg-set-config command.
+	fmt.Println("Generated setConfig Command:")
+	command := fmt.Sprintf(
+		"go run . dkg-set-config --dkg-address %s -key-id %s -onchain-pub-keys %s -offchain-pub-keys %s -config-pub-keys %s -peer-ids %s -transmitters %s -dkg-encryption-pub-keys %s -dkg-signing-pub-keys %s -schedule 1,1,1,1,1",
+		dkgAddress,
+		*keyID,
+		strings.Join(onChainPublicKeys, ","),
+		strings.Join(offChainPublicKeys, ","),
+		strings.Join(configPublicKeys, ","),
+		strings.Join(peerIDs, ","),
+		strings.Join(transmitters, ","),
+		strings.Join(dkgEncrypters, ","),
+		strings.Join(dkgSigners, ","),
+	)
+
+	fmt.Println(command)
+}
+
+func fundNodes(e helpers.Environment, transmitters []string, fundingAmount int64) {
+	fmt.Println("Funding Nodes:")
+
+	block, err := e.Ec.BlockNumber(context.Background())
+	helpers.PanicErr(err)
+
+	nonce, err := e.Ec.NonceAt(context.Background(), e.Owner.From, big.NewInt(int64(block)))
+	helpers.PanicErr(err)
+
+	for i := 0; i < len(transmitters); i++ {
+		tx := types.NewTransaction(
+			nonce+uint64(i),
+			common.HexToAddress(transmitters[i]),
+			big.NewInt(fundingAmount),
+			uint64(21000),
+			e.Owner.GasPrice,
+			nil,
+		)
+		signedTx, err := e.Owner.Signer(e.Owner.From, tx)
+		helpers.PanicErr(err)
+		err = e.Ec.SendTransaction(context.Background(), signedTx)
+		helpers.PanicErr(err)
+
+		fmt.Printf("Sending to %s: %s\n", transmitters[i], helpers.ExplorerLink(e.ChainID, signedTx.Hash()))
+	}
+}
+
+func setupDKGNodeFromClient(client *cmd.Client, context *cli.Context) *cmd.SetupDKGNodePayload {
+	payload, err := client.ConfigureDKGNode(context)
+	helpers.PanicErr(err)
+
+	return payload
+}
+
+func resetDatbase(client *cmd.Client, context *cli.Context, index int, databasePrefix string, databaseSuffixes string) {
+	os.Setenv("DATABASE_URL", fmt.Sprintf("%s-%d?%s", databasePrefix, index, databaseSuffixes))
+	client.ResetDatabase(context)
+}
+
+func NewProductionClient() *cmd.Client {
+	lggr, closeLggr := logger.NewLogger()
+	cfg := config.NewGeneralConfig(lggr)
+
+	prompter := cmd.NewTerminalPrompter()
+	return &cmd.Client{
+		Renderer:                       cmd.RendererTable{Writer: os.Stdout},
+		Config:                         cfg,
+		Logger:                         lggr,
+		CloseLogger:                    closeLggr,
+		AppFactory:                     cmd.ChainlinkAppFactory{},
+		KeyStoreAuthenticator:          cmd.TerminalKeyStoreAuthenticator{Prompter: prompter},
+		FallbackAPIInitializer:         cmd.NewPromptingAPIInitializer(prompter),
+		Runner:                         cmd.ChainlinkRunner{},
+		PromptingSessionRequestBuilder: cmd.NewPromptingSessionRequestBuilder(prompter),
+		ChangePasswordPrompter:         cmd.NewChangePasswordPrompter(),
+		PasswordPrompter:               cmd.NewPasswordPrompter(),
+	}
+}


### PR DESCRIPTION
Automates the following in order:

- Uploads a DKG contract
- Spins up 5 chainlink nodes from scratch onto empty databases
- Initialize ETH keys, OCR2 Keys, DKG Sign & Encrypt Keys, P2P keys on each node
- Add Bootstrap job spec on the first node, add DKG job on all nodes
- Produces the DKG dkg-set-config command populated with arguments.

After this point:

The user spins up their nodes and should see zero configDigest errors. They can then fund those nodes, and run the provided dkg-set-config command; the nodes should pick up these configs and run a dkg job.

I could continue to auto-fund the nodes as well, but wanted to stop before committing too hard. We can first come to a consensus on if this is a good approach, and then clean it up / add to it.