### PR TITLE
add validation for dkg plugin configs

### DIFF
--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -200,6 +200,9 @@ func (d Delegate) ServicesForSpec(jobSpec job.Job) ([]job.ServiceCtx, error) {
 			d.dkgSignKs,
 			d.dkgEncryptKs,
 			chain.Client())
+		if err != nil {
+			return nil, errors.Wrap(err, "error while instantiating DKG")
+		}
 	case job.OCR2VRF:
 		ocr2vrfProvider, err2 := evmrelay.NewOCR2VRFRelayer(relayer).NewOCR2VRFProvider(
 			types.RelayArgs{

--- a/core/services/ocr2/plugins/dkg/config/config.go
+++ b/core/services/ocr2/plugins/dkg/config/config.go
@@ -1,5 +1,13 @@
 package config
 
+import (
+	"fmt"
+
+	"github.com/pkg/errors"
+
+	"github.com/smartcontractkit/chainlink/core/services/keystore"
+)
+
 // PluginConfig contains custom arguments for the DKG plugin.
 type PluginConfig struct {
 	EncryptionPublicKey string `json:"encryptionPublicKey"`
@@ -8,7 +16,14 @@ type PluginConfig struct {
 }
 
 // ValidatePluginConfig validates that the given DKG plugin configuration is correct.
-func ValidatePluginConfig(config PluginConfig) error {
-	// TODO
+func ValidatePluginConfig(config PluginConfig, dkgSignKs keystore.DKGSign, dkgEncryptKs keystore.DKGEncrypt) error {
+	_, err := dkgEncryptKs.Get(config.EncryptionPublicKey)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("DKG encryption key: %s not found in key store", config.EncryptionPublicKey))
+	}
+	_, err = dkgSignKs.Get(config.SigningPublicKey)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("DKG sign key: %s not found in key store", config.SigningPublicKey))
+	}
 	return nil
 }

--- a/core/services/ocr2/plugins/dkg/config/config_test.go
+++ b/core/services/ocr2/plugins/dkg/config/config_test.go
@@ -1,0 +1,63 @@
+package config_test
+
+import (
+	"testing"
+
+	"encoding/hex"
+
+	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
+	"github.com/smartcontractkit/chainlink/core/services/ocr2/plugins/dkg/config"
+	"github.com/stretchr/testify/require"
+)
+
+func TestValidatePluginConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := cltest.NewTestGeneralConfig(t)
+	db := pgtest.NewSqlxDB(t)
+	kst := cltest.NewKeyStore(t, db, cfg)
+
+	dkgEncryptKey, err := kst.DKGEncrypt().Create()
+	require.NoError(t, err)
+	dkgSignKey, err := kst.DKGSign().Create()
+	require.NoError(t, err)
+
+	encryptKeyBytes, err := dkgEncryptKey.PublicKey.MarshalBinary()
+	require.NoError(t, err)
+	encryptKey := hex.EncodeToString(encryptKeyBytes)
+
+	signKeyBytes, err := dkgSignKey.PublicKey.MarshalBinary()
+	require.NoError(t, err)
+	signKey := hex.EncodeToString(signKeyBytes)
+
+	pluginConfig := config.PluginConfig{
+		EncryptionPublicKey: encryptKey,
+		SigningPublicKey:    signKey,
+	}
+	t.Run("no error when keys are found", func(t *testing.T) {
+		err = config.ValidatePluginConfig(pluginConfig, kst.DKGSign(), kst.DKGEncrypt())
+		require.NoError(t, err)
+	})
+
+	t.Run("error when encryption key not found", func(t *testing.T) {
+		pluginConfig = config.PluginConfig{
+			EncryptionPublicKey: "wrongKey",
+			SigningPublicKey:    signKey,
+		}
+		err = config.ValidatePluginConfig(pluginConfig, kst.DKGSign(), kst.DKGEncrypt())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "DKG encryption key: wrongKey not found in key store")
+	})
+
+	t.Run("error when sign key not found", func(t *testing.T) {
+		pluginConfig = config.PluginConfig{
+			EncryptionPublicKey: encryptKey,
+			SigningPublicKey:    "wrongKey",
+		}
+
+		err = config.ValidatePluginConfig(pluginConfig, kst.DKGSign(), kst.DKGEncrypt())
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "DKG sign key: wrongKey not found in key store")
+	})
+}

--- a/core/services/ocr2/plugins/dkg/plugin.go
+++ b/core/services/ocr2/plugins/dkg/plugin.go
@@ -47,7 +47,7 @@ func NewDKG(
 	if err != nil {
 		return &DKGContainer{}, err
 	}
-	err = config.ValidatePluginConfig(pluginConfig)
+	err = config.ValidatePluginConfig(pluginConfig, dkgSignKs, dkgEncryptKs)
 	if err != nil {
 		return &DKGContainer{}, err
 	}

--- a/core/services/ocr2/validate/validate.go
+++ b/core/services/ocr2/validate/validate.go
@@ -1,12 +1,17 @@
 package validate
 
 import (
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+
 	"github.com/lib/pq"
 	"github.com/pelletier/go-toml"
 	"github.com/pkg/errors"
 	libocr2 "github.com/smartcontractkit/libocr/offchainreporting2"
 
 	"github.com/smartcontractkit/chainlink/core/services/job"
+	"github.com/smartcontractkit/chainlink/core/services/ocr2/plugins/dkg/config"
 	"github.com/smartcontractkit/chainlink/core/services/ocrcommon"
 	"github.com/smartcontractkit/chainlink/core/services/relay"
 )
@@ -91,7 +96,8 @@ func validateSpec(tree *toml.Tree, spec job.Job) error {
 			return errors.New("no pipeline specified")
 		}
 	case job.DKG:
-		return nil
+		err := validateDKGSpec(spec.OCR2OracleSpec.PluginConfig)
+		return err
 	case job.OCR2VRF:
 		return nil
 	case "":
@@ -100,5 +106,41 @@ func validateSpec(tree *toml.Tree, spec job.Job) error {
 		return errors.Errorf("invalid pluginType %s", spec.OCR2OracleSpec.PluginType)
 	}
 
+	return nil
+}
+
+func validateDKGSpec(jsonConfig job.JSONConfig) error {
+	if jsonConfig == nil {
+		return errors.New("pluginConfig is empty")
+	}
+	var pluginConfig config.PluginConfig
+	err := json.Unmarshal(jsonConfig.Bytes(), &pluginConfig)
+	if err != nil {
+		return errors.Wrap(err, "error while unmarshaling plugin config")
+	}
+	err = validateHexString(pluginConfig.EncryptionPublicKey, 32)
+	if err != nil {
+		return errors.Wrap(err, "validation error for encryptedPublicKey")
+	}
+	err = validateHexString(pluginConfig.SigningPublicKey, 32)
+	if err != nil {
+		return errors.Wrap(err, "validation error for signingPublicKey")
+	}
+	err = validateHexString(pluginConfig.KeyID, 32)
+	if err != nil {
+		return errors.Wrap(err, "validation error for keyID")
+	}
+
+	return nil
+}
+
+func validateHexString(val string, expectedLengthInBytes uint) error {
+	decoded, err := hex.DecodeString(val)
+	if err != nil {
+		return errors.Wrap(err, fmt.Sprintf("expected hex string but received %s", val))
+	}
+	if len(decoded) != int(expectedLengthInBytes) {
+		return errors.New(fmt.Sprintf("value: %s has unexpected length. Expected %d bytes", val, expectedLengthInBytes))
+	}
 	return nil
 }

--- a/core/services/ocr2/validate/validate_test.go
+++ b/core/services/ocr2/validate/validate_test.go
@@ -364,6 +364,221 @@ chainID = 1337
 				require.Contains(t, err.Error(), "no such relay blerg supported")
 			},
 		},
+		{
+			name: "valid DKG pluginConfig",
+			toml: `
+type = "offchainreporting2"
+schemaVersion = 1
+name = "dkg"
+externalJobID = "6d46d85f-d38c-4f4a-9f00-ac29a25b6330"
+maxTaskDuration = "1s"
+contractID = "0x3e54dCc49F16411A3aaa4cDbC41A25bCa9763Cee"
+ocrKeyBundleID = "08d14c6eed757414d72055d28de6caf06535806c6a14e450f3a2f1c854420e17"
+p2pv2Bootstrappers = [
+	"12D3KooWSbPRwXY4gxFRJT7LWCnjgGbR4S839nfCRCDgQUiNenxa@127.0.0.1:8000"
+]
+relay = "evm"
+pluginType = "dkg"
+transmitterID = "0x74103Cf8b436465870b26aa9Fa2F62AD62b22E35"
+
+[relayConfig]
+chainID = 4
+
+[pluginConfig]
+EncryptionPublicKey = "0e86e8cf899ae9a1b43e023bbe8825b103659bb8d6d4e54f6a3cfae7b106069c"
+SigningPublicKey    = "eb62dbd2beb7c1524275a8019022f6ce6a7e86c9e65e3099452a2b96fc2432b1"
+KeyID               = "6f3b82406688b8ddb944c6f2e6d808f014c8fa8d568d639c25019568c715fbf0"
+`,
+			assertion: func(t *testing.T, os job.Job, err error) {
+				require.NoError(t, err)
+			},
+		},
+		{
+			name: "DKG encryption key is not hex",
+			toml: `
+type = "offchainreporting2"
+schemaVersion = 1
+name = "dkg"
+externalJobID = "6d46d85f-d38c-4f4a-9f00-ac29a25b6330"
+maxTaskDuration = "1s"
+contractID = "0x3e54dCc49F16411A3aaa4cDbC41A25bCa9763Cee"
+ocrKeyBundleID = "08d14c6eed757414d72055d28de6caf06535806c6a14e450f3a2f1c854420e17"
+p2pv2Bootstrappers = [
+	"12D3KooWSbPRwXY4gxFRJT7LWCnjgGbR4S839nfCRCDgQUiNenxa@127.0.0.1:8000"
+]
+relay = "evm"
+pluginType = "dkg"
+transmitterID = "0x74103Cf8b436465870b26aa9Fa2F62AD62b22E35"
+
+[relayConfig]
+chainID = 4
+
+[pluginConfig]
+EncryptionPublicKey = "frog"
+SigningPublicKey    = "eb62dbd2beb7c1524275a8019022f6ce6a7e86c9e65e3099452a2b96fc2432b1"
+KeyID               = "6f3b82406688b8ddb944c6f2e6d808f014c8fa8d568d639c25019568c715fbf0"
+`,
+			assertion: func(t *testing.T, os job.Job, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "expected hex string but received frog")
+				require.Contains(t, err.Error(), "validation error for encryptedPublicKey")
+			},
+		},
+		{
+			name: "DKG encryption key is too short",
+			toml: `
+type = "offchainreporting2"
+schemaVersion = 1
+name = "dkg"
+externalJobID = "6d46d85f-d38c-4f4a-9f00-ac29a25b6330"
+maxTaskDuration = "1s"
+contractID = "0x3e54dCc49F16411A3aaa4cDbC41A25bCa9763Cee"
+ocrKeyBundleID = "08d14c6eed757414d72055d28de6caf06535806c6a14e450f3a2f1c854420e17"
+p2pv2Bootstrappers = [
+	"12D3KooWSbPRwXY4gxFRJT7LWCnjgGbR4S839nfCRCDgQUiNenxa@127.0.0.1:8000"
+]
+relay = "evm"
+pluginType = "dkg"
+transmitterID = "0x74103Cf8b436465870b26aa9Fa2F62AD62b22E35"
+
+[relayConfig]
+chainID = 4
+
+[pluginConfig]
+EncryptionPublicKey = "0e86e8cf899ae9a1b43e023bbe8825b103659bb8d6d4e54f6a3cfae7b10606"
+SigningPublicKey    = "eb62dbd2beb7c1524275a8019022f6ce6a7e86c9e65e3099452a2b96fc2432b1"
+KeyID               = "6f3b82406688b8ddb944c6f2e6d808f014c8fa8d568d639c25019568c715fbf0"
+`,
+			assertion: func(t *testing.T, os job.Job, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value: 0e86e8cf899ae9a1b43e023bbe8825b103659bb8d6d4e54f6a3cfae7b10606 has unexpected length. Expected 32 bytes")
+				require.Contains(t, err.Error(), "validation error for encryptedPublicKey")
+			},
+		},
+		{
+			name: "DKG signing key is not hex",
+			toml: `
+type = "offchainreporting2"
+schemaVersion = 1
+name = "dkg"
+externalJobID = "6d46d85f-d38c-4f4a-9f00-ac29a25b6330"
+maxTaskDuration = "1s"
+contractID = "0x3e54dCc49F16411A3aaa4cDbC41A25bCa9763Cee"
+ocrKeyBundleID = "08d14c6eed757414d72055d28de6caf06535806c6a14e450f3a2f1c854420e17"
+p2pv2Bootstrappers = [
+	"12D3KooWSbPRwXY4gxFRJT7LWCnjgGbR4S839nfCRCDgQUiNenxa@127.0.0.1:8000"
+]
+relay = "evm"
+pluginType = "dkg"
+transmitterID = "0x74103Cf8b436465870b26aa9Fa2F62AD62b22E35"
+
+[relayConfig]
+chainID = 4
+
+[pluginConfig]
+EncryptionPublicKey = "0e86e8cf899ae9a1b43e023bbe8825b103659bb8d6d4e54f6a3cfae7b106069c"
+SigningPublicKey    = "frog"
+KeyID               = "6f3b82406688b8ddb944c6f2e6d808f014c8fa8d568d639c25019568c715fbf0"
+`,
+			assertion: func(t *testing.T, os job.Job, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "expected hex string but received frog")
+				require.Contains(t, err.Error(), "validation error for signingPublicKey")
+			},
+		},
+		{
+			name: "DKG signing key is too short",
+			toml: `
+type = "offchainreporting2"
+schemaVersion = 1
+name = "dkg"
+externalJobID = "6d46d85f-d38c-4f4a-9f00-ac29a25b6330"
+maxTaskDuration = "1s"
+contractID = "0x3e54dCc49F16411A3aaa4cDbC41A25bCa9763Cee"
+ocrKeyBundleID = "08d14c6eed757414d72055d28de6caf06535806c6a14e450f3a2f1c854420e17"
+p2pv2Bootstrappers = [
+	"12D3KooWSbPRwXY4gxFRJT7LWCnjgGbR4S839nfCRCDgQUiNenxa@127.0.0.1:8000"
+]
+relay = "evm"
+pluginType = "dkg"
+transmitterID = "0x74103Cf8b436465870b26aa9Fa2F62AD62b22E35"
+
+[relayConfig]
+chainID = 4
+
+[pluginConfig]
+EncryptionPublicKey = "0e86e8cf899ae9a1b43e023bbe8825b103659bb8d6d4e54f6a3cfae7b106069c"
+SigningPublicKey    = "eb62dbd2beb7c1524275a8019022f6ce6a7e86c9e65e3099452a2b96fc24"
+KeyID               = "6f3b82406688b8ddb944c6f2e6d808f014c8fa8d568d639c25019568c715fbf0"
+`,
+			assertion: func(t *testing.T, os job.Job, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value: eb62dbd2beb7c1524275a8019022f6ce6a7e86c9e65e3099452a2b96fc24 has unexpected length. Expected 32 bytes")
+				require.Contains(t, err.Error(), "validation error for signingPublicKey")
+			},
+		},
+		{
+			name: "DKG keyID is not hex",
+			toml: `
+type = "offchainreporting2"
+schemaVersion = 1
+name = "dkg"
+externalJobID = "6d46d85f-d38c-4f4a-9f00-ac29a25b6330"
+maxTaskDuration = "1s"
+contractID = "0x3e54dCc49F16411A3aaa4cDbC41A25bCa9763Cee"
+ocrKeyBundleID = "08d14c6eed757414d72055d28de6caf06535806c6a14e450f3a2f1c854420e17"
+p2pv2Bootstrappers = [
+	"12D3KooWSbPRwXY4gxFRJT7LWCnjgGbR4S839nfCRCDgQUiNenxa@127.0.0.1:8000"
+]
+relay = "evm"
+pluginType = "dkg"
+transmitterID = "0x74103Cf8b436465870b26aa9Fa2F62AD62b22E35"
+
+[relayConfig]
+chainID = 4
+
+[pluginConfig]
+EncryptionPublicKey = "0e86e8cf899ae9a1b43e023bbe8825b103659bb8d6d4e54f6a3cfae7b106069c"
+SigningPublicKey    = "eb62dbd2beb7c1524275a8019022f6ce6a7e86c9e65e3099452a2b96fc2432b1"
+KeyID               = "frog"
+`,
+			assertion: func(t *testing.T, os job.Job, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "expected hex string but received frog")
+				require.Contains(t, err.Error(), "validation error for keyID")
+			},
+		},
+		{
+			name: "DKG keyID is too long",
+			toml: `
+type = "offchainreporting2"
+schemaVersion = 1
+name = "dkg"
+externalJobID = "6d46d85f-d38c-4f4a-9f00-ac29a25b6330"
+maxTaskDuration = "1s"
+contractID = "0x3e54dCc49F16411A3aaa4cDbC41A25bCa9763Cee"
+ocrKeyBundleID = "08d14c6eed757414d72055d28de6caf06535806c6a14e450f3a2f1c854420e17"
+p2pv2Bootstrappers = [
+	"12D3KooWSbPRwXY4gxFRJT7LWCnjgGbR4S839nfCRCDgQUiNenxa@127.0.0.1:8000"
+]
+relay = "evm"
+pluginType = "dkg"
+transmitterID = "0x74103Cf8b436465870b26aa9Fa2F62AD62b22E35"
+
+[relayConfig]
+chainID = 4
+
+[pluginConfig]
+EncryptionPublicKey = "0e86e8cf899ae9a1b43e023bbe8825b103659bb8d6d4e54f6a3cfae7b106069c"
+SigningPublicKey    = "eb62dbd2beb7c1524275a8019022f6ce6a7e86c9e65e3099452a2b96fc2432b1"
+KeyID               = "6f3b82406688b8ddb944c6f2e6d808f014c8fa8d568d639c25019568c715fbaaaabc"
+`,
+			assertion: func(t *testing.T, os job.Job, err error) {
+				require.Error(t, err)
+				require.Contains(t, err.Error(), "value: 6f3b82406688b8ddb944c6f2e6d808f014c8fa8d568d639c25019568c715fbaaaabc has unexpected length. Expected 32 bytes")
+				require.Contains(t, err.Error(), "validation error for keyID")
+			},
+		},
 	}
 
 	for _, tc := range tt {


### PR DESCRIPTION
Adding validations for DKG plugin config. 
- validates that DKG encryption key, signing key and keyID are hex and 32 bytes (synchronous validation for CLI and UI)
- validates that DKG encryption key and signing key are in the key store (in this case, job is created but the job returns validation error before starting DKG)