### PR TITLE
chore: [sc-31483] Expand CI -race coverage

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -1,6 +1,9 @@
 name: CI Core
 
-on: push
+on:
+  push:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   core:
@@ -73,6 +76,9 @@ jobs:
         run: ./tools/ci/install_solana
       - name: Setup DB
         run: go run ./core local db preparetest
+      - name: Increase Race Timeout
+        if: github.event.schedule != ''
+        run: echo "TIMEOUT=5m" >> $GITHUB_ENV
       - name: Run tests
         run: ./tools/bin/${{ matrix.cmd }}
       - name: Store logs artifacts on failure

--- a/tools/bin/go_core_race_tests
+++ b/tools/bin/go_core_race_tests
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 set -ex
 
+TIMEOUT="${TIMEOUT:-30s}"
 GO_LDFLAGS=$(bash tools/bin/ldflags)
-GORACE="log_path=$PWD/race" LOG_LEVEL=panic go test -race -ldflags "$GO_LDFLAGS" -shuffle on -timeout 30s -count 10 -p 4 ./core/... | tee ./output.txt
+GORACE="log_path=$PWD/race" LOG_LEVEL=panic go test -race -ldflags "$GO_LDFLAGS" -shuffle on -timeout "$TIMEOUT" -count 10 -p 4 ./core/... | tee ./output.txt
 EXITCODE=${PIPESTATUS[0]}
 # Fail if any race logs are present.
 if ls race.* &>/dev/null


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/31483/expand-ci-race-coverage

Schedule a nightly run of `CI Core` with an increased race test timeout of `5m` from `30s` for better coverage. Many packages still complete very quickly, so this 10x increase only increases the runtime ~2-3x:
![Screenshot from 2022-07-04 19-54-51](https://user-images.githubusercontent.com/1194128/177229849-63c57152-fb76-43c3-84f6-f16f7a5881d2.png)
