### PR TITLE
core/internal/testutils: use test logger instead of log.Print*

### DIFF
--- a/core/chains/evm/client/node.go
+++ b/core/chains/evm/client/node.go
@@ -288,10 +288,11 @@ func (n *node) verify(callerCtx context.Context) (err error) {
 		promEVMPoolRPCNodeVerifiesFailed.WithLabelValues(n.chainID.String(), n.name).Inc()
 	}
 
-	switch n.state {
+	st := n.State()
+	switch st {
 	case NodeStateDialed, NodeStateOutOfSync, NodeStateInvalidChainID:
 	default:
-		panic(fmt.Sprintf("cannot verify node in state %v", n.state))
+		panic(fmt.Sprintf("cannot verify node in state %v", st))
 	}
 
 	var chainID *big.Int

--- a/core/chains/evm/client/node_fsm_test.go
+++ b/core/chains/evm/client/node_fsm_test.go
@@ -44,7 +44,6 @@ func TestUnit_Node_StateTransitions(t *testing.T) {
 	s := testutils.NewWSServer(t, testutils.FixtureChainID, func(method string, params gjson.Result) (string, string) {
 		return "", ""
 	})
-	defer s.Close()
 	iN := NewNode(TestNodeConfig{}, logger.TestLogger(t), *s.WSURL(), nil, "test node", 42, nil)
 	n := iN.(*node)
 
@@ -52,9 +51,9 @@ func TestUnit_Node_StateTransitions(t *testing.T) {
 
 	t.Run("setState", func(t *testing.T) {
 		n.setState(NodeStateAlive)
-		assert.Equal(t, NodeStateAlive, n.state)
+		assert.Equal(t, NodeStateAlive, n.State())
 		n.setState(NodeStateUndialed)
-		assert.Equal(t, NodeStateUndialed, n.state)
+		assert.Equal(t, NodeStateUndialed, n.State())
 	})
 
 	// must dial to set rpc client for use in state transitions

--- a/core/chains/evm/client/node_lifecycle_test.go
+++ b/core/chains/evm/client/node_lifecycle_test.go
@@ -29,7 +29,6 @@ func newTestNodeWithCallback(t *testing.T, cfg NodeConfig, callback testutils.JS
 	s := testutils.NewWSServer(t, testutils.FixtureChainID, callback)
 	iN := NewNode(cfg, logger.TestLogger(t), *s.WSURL(), nil, "test node", 42, testutils.FixtureChainID)
 	n := iN.(*node)
-	t.Cleanup(s.Close)
 	return n
 }
 
@@ -89,7 +88,7 @@ func TestUnit_NodeLifecycle_aliveLoop(t *testing.T) {
 				}
 				return "this will error", ""
 			default:
-				t.Fatalf("unexpected RPC method: %s", method)
+				t.Errorf("unexpected RPC method: %s", method)
 			}
 			return "", ""
 		})
@@ -132,7 +131,7 @@ func TestUnit_NodeLifecycle_aliveLoop(t *testing.T) {
 				defer calls.Inc()
 				return "this will error", ""
 			default:
-				t.Fatalf("unexpected RPC method: %s", method)
+				t.Errorf("unexpected RPC method: %s", method)
 			}
 			return "", ""
 		})
@@ -192,11 +191,10 @@ func TestUnit_NodeLifecycle_aliveLoop(t *testing.T) {
 					}
 					return `"test client version 2"`, ""
 				default:
-					t.Fatalf("unexpected RPC method: %s", method)
+					t.Errorf("unexpected RPC method: %s", method)
 				}
 				return "", ""
 			})
-		defer s.Close()
 
 		iN := NewNode(cfg, logger.TestLogger(t), *s.WSURL(), nil, "test node", 42, testutils.FixtureChainID)
 		n := iN.(*node)
@@ -236,11 +234,10 @@ func TestUnit_NodeLifecycle_aliveLoop(t *testing.T) {
 				case "web3_clientVersion":
 					return `"test client version 2"`, ""
 				default:
-					t.Fatalf("unexpected RPC method: %s", method)
+					t.Errorf("unexpected RPC method: %s", method)
 				}
 				return "", ""
 			})
-		defer s.Close()
 
 		iN := NewNode(cfg, logger.TestLogger(t), *s.WSURL(), nil, "test node", 42, testutils.FixtureChainID)
 		n := iN.(*node)
@@ -270,12 +267,11 @@ func TestUnit_NodeLifecycle_aliveLoop(t *testing.T) {
 				case "eth_subscribe":
 					return `"0x00"`, makeHeadResult(0)
 				default:
-					t.Fatalf("unexpected RPC method: %s", method)
+					t.Errorf("unexpected RPC method: %s", method)
 				}
 				return "", ""
 			})
 
-		defer s.Close()
 		iN := NewNode(pollDisabledCfg, lggr, *s.WSURL(), nil, "test node", 42, testutils.FixtureChainID)
 		n := iN.(*node)
 		n.nLiveNodes = func() int { return 1 }
@@ -337,11 +333,10 @@ func TestUnit_NodeLifecycle_outOfSyncLoop(t *testing.T) {
 					}
 					return `"0x00"`, makeHeadResult(0)
 				default:
-					t.Fatalf("unexpected RPC method: %s", method)
+					t.Errorf("unexpected RPC method: %s", method)
 				}
 				return "", ""
 			})
-		defer s.Close()
 
 		iN := NewNode(cfg, logger.TestLogger(t), *s.WSURL(), nil, "test node", 42, testutils.FixtureChainID)
 		n := iN.(*node)
@@ -384,11 +379,10 @@ func TestUnit_NodeLifecycle_outOfSyncLoop(t *testing.T) {
 					return `"0x00"`, makeNewHeadWSMessage(42)
 				case "eth_unsubscribe":
 				default:
-					t.Fatalf("unexpected RPC method: %s", method)
+					t.Errorf("unexpected RPC method: %s", method)
 				}
 				return "", ""
 			})
-		defer s.Close()
 
 		iN := NewNode(cfg, lggr, *s.WSURL(), nil, "test node", 0, testutils.FixtureChainID)
 		n := iN.(*node)
@@ -435,11 +429,10 @@ func TestUnit_NodeLifecycle_outOfSyncLoop(t *testing.T) {
 					}
 					return `"0x00"`, makeHeadResult(0)
 				default:
-					t.Fatalf("unexpected RPC method: %s", method)
+					t.Errorf("unexpected RPC method: %s", method)
 				}
 				return "", ""
 			})
-		defer s.Close()
 
 		iN := NewNode(cfg, logger.TestLogger(t), *s.WSURL(), nil, "test node", 42, testutils.FixtureChainID)
 		n := iN.(*node)
@@ -494,7 +487,6 @@ func TestUnit_NodeLifecycle_unreachableLoop(t *testing.T) {
 	t.Run("on successful redial but failed verify, transitions to invalid chain ID", func(t *testing.T) {
 		cfg := TestNodeConfig{}
 		s := testutils.NewWSServer(t, testutils.FixtureChainID, standardHandler)
-		t.Cleanup(s.Close)
 		lggr, observedLogs := logger.TestLoggerObserved(t, zap.ErrorLevel)
 		iN := NewNode(cfg, lggr, *s.WSURL(), nil, "test node", 0, big.NewInt(42))
 		n := iN.(*node)
@@ -564,7 +556,6 @@ func TestUnit_NodeLifecycle_invalidChainIDLoop(t *testing.T) {
 	t.Run("on failed verify, keeps checking", func(t *testing.T) {
 		cfg := TestNodeConfig{}
 		s := testutils.NewWSServer(t, testutils.FixtureChainID, standardHandler)
-		t.Cleanup(s.Close)
 		lggr, observedLogs := logger.TestLoggerObserved(t, zap.ErrorLevel)
 		iN := NewNode(cfg, lggr, *s.WSURL(), nil, "test node", 0, big.NewInt(42))
 		n := iN.(*node)

--- a/core/chains/evm/client/pool_test.go
+++ b/core/chains/evm/client/pool_test.go
@@ -149,6 +149,7 @@ func TestPool_Dial(t *testing.T) {
 				assert.Contains(t, err.Error(), test.errStr)
 			} else {
 				require.NoError(t, err)
+				p.Close()
 			}
 		})
 	}

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -232,7 +232,6 @@ type TestApplication struct {
 // If chainID is set, then eth_chainId calls will be automatically handled.
 func NewWSServer(t *testing.T, chainID *big.Int, callback testutils.JSONRPCHandler) string {
 	server := testutils.NewWSServer(t, chainID, callback)
-	t.Cleanup(server.Close)
 	return server.WSURL().String()
 }
 

--- a/core/internal/testutils/testutils.go
+++ b/core/internal/testutils/testutils.go
@@ -202,7 +202,6 @@ func (ts *testWSServer) MustWriteBinaryMessageSync(t *testing.T, msg string) {
 		t.Fatalf("expected 1 conn, got %d", len(conns))
 	}
 	conn := conns[0]
-	conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 	err := conn.WriteMessage(websocket.BinaryMessage, []byte(msg))
 	require.NoError(t, err)
 }
@@ -227,7 +226,6 @@ func (ts *testWSServer) newWSHandler(chainID *big.Int, callback JSONRPCHandler) 
 		ts.mu.Unlock()
 		defer ts.wg.Done()
 		for {
-			conn.SetReadDeadline(time.Now().Add(5 * time.Second))
 			_, data, err := conn.ReadMessage()
 			if err != nil {
 				if websocket.IsCloseError(err, websocket.CloseNormalClosure, websocket.CloseAbnormalClosure) {
@@ -263,7 +261,6 @@ func (ts *testWSServer) newWSHandler(chainID *big.Int, callback JSONRPCHandler) 
 			msg := fmt.Sprintf(`{"jsonrpc":"2.0","id":%s,"result":%s}`, id, resp)
 			ts.t.Logf("Sending message: %v", msg)
 			ts.mu.Lock()
-			conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 			err = conn.WriteMessage(websocket.BinaryMessage, []byte(msg))
 			ts.mu.Unlock()
 			if err != nil {
@@ -276,7 +273,6 @@ func (ts *testWSServer) newWSHandler(chainID *big.Int, callback JSONRPCHandler) 
 				msg := fmt.Sprintf(`{"jsonrpc":"2.0","method":"eth_subscription","params":{"subscription":"0x00","result":%s}}`, notify)
 				ts.t.Log("Sending message", msg)
 				ts.mu.Lock()
-				conn.SetWriteDeadline(time.Now().Add(5 * time.Second))
 				err = conn.WriteMessage(websocket.BinaryMessage, []byte(msg))
 				ts.mu.Unlock()
 				if err != nil {


### PR DESCRIPTION
These `log.Print*` calls are noisy and disconnected from their tests. Use `t.Log*` variants instead.