### PR TITLE
.github/workflows: bump setup-go to v3 for automatic version recognition and go mod caching

### DIFF
--- a/.github/workflows/build-custom.yml
+++ b/.github/workflows/build-custom.yml
@@ -88,9 +88,9 @@ jobs:
         with:
           repository: ${{ inputs.cl_repo }}
           ref: ${{ github.event.inputs.cl_ref }}
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version-file: 'go.mod'
       - name: Replace GHA URL
         run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
       - name: Replace Solana deps manual flow

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -36,21 +36,10 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@v2
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
-      - name: Go Cache
-        uses: actions/cache@v2
-        with:
-          # * Module download cache
-          # * Build cache (Linux)
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-          key: go-mod-${{ matrix.cmd }}-${{ hashFiles('go.sum') }}
-          restore-keys: |
-            go-mod-${{ matrix.cmd }}-
-            go-mod-
+          go-version-file: 'go.mod'
+          cache: true
       - name: Touching core/web/assets/index.html
         run: mkdir -p core/web/assets && touch core/web/assets/index.html
       - name: Download Go vendor packages

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -31,9 +31,9 @@ jobs:
         uses: actions/checkout@5a4ac9002d0be2fb38bd78e4b4dbde5606d7042f
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version-file: 'go.mod'
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -18,9 +18,9 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.18
+          go-version-file: 'go.mod'
         id: go
 
       - name: Write Go Modules list

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,9 +22,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
-          go-version: ~1.18
+          go-version-file: 'go.mod'
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0


### PR DESCRIPTION
`setup-go@v3` has some nice features to simplify and reduce updates going forward.

Replaces #6416