### PR TITLE
VRFV2 Wrapper

### DIFF
--- a/contracts/scripts/native_solc_compile_all
+++ b/contracts/scripts/native_solc_compile_all
@@ -61,6 +61,12 @@ $SCRIPTPATH/native_solc8_6_compile tests/VRFV2RevertingExample.sol
 $SCRIPTPATH/native_solc8_6_compile BatchBlockhashStore.sol
 $SCRIPTPATH/native_solc8_6_compile BatchVRFCoordinatorV2.sol
 
+# VRF V2 Wrapper
+$SCRIPTPATH/native_solc8_6_compile dev/VRFV2Wrapper.sol
+$SCRIPTPATH/native_solc8_6_compile dev/VRFV2WrapperInterface.sol
+$SCRIPTPATH/native_solc8_6_compile dev/VRFV2WrapperConsumerBase.sol
+$SCRIPTPATH/native_solc8_6_compile tests/VRFV2WrapperConsumerExample.sol
+
 # Make sure the example consumers compile
 $SCRIPTPATH/native_solc8_6_compile tests/VRFExternalSubOwnerExample.sol
 $SCRIPTPATH/native_solc8_6_compile tests/VRFSingleConsumerExample.sol

--- a/contracts/src/v0.8/dev/VRFV2Wrapper.sol
+++ b/contracts/src/v0.8/dev/VRFV2Wrapper.sol
@@ -1,0 +1,422 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.6;
+
+import "../ConfirmedOwner.sol";
+import "../interfaces/TypeAndVersionInterface.sol";
+import "../VRFConsumerBaseV2.sol";
+import "../interfaces/LinkTokenInterface.sol";
+import "../interfaces/AggregatorV3Interface.sol";
+import "../interfaces/VRFCoordinatorV2Interface.sol";
+import "./VRFV2WrapperInterface.sol";
+import "./VRFV2WrapperConsumerBase.sol";
+
+/**
+ * @notice A wrapper for VRFCoordinatorV2 that provides an interface better suited to one-off
+ * @notice requests for randomness.
+ */
+contract VRFV2Wrapper is ConfirmedOwner, TypeAndVersionInterface, VRFConsumerBaseV2, VRFV2WrapperInterface {
+  event WrapperFulfillmentFailed(uint256 indexed requestId, address indexed consumer);
+
+  LinkTokenInterface public immutable LINK;
+  AggregatorV3Interface public immutable LINK_ETH_FEED;
+  ExtendedVRFCoordinatorV2Interface public immutable COORDINATOR;
+  uint64 public immutable SUBSCRIPTION_ID;
+
+  // 5k is plenty for an EXTCODESIZE call (2600) + warm CALL (100)
+  // and some arithmetic operations.
+  uint256 private constant GAS_FOR_CALL_EXACT_CHECK = 5_000;
+
+  // lastRequestId is the request ID of the most recent VRF V2 request made by this wrapper. This
+  // should only be relied on within the same transaction the request was made.
+  uint256 public override lastRequestId;
+
+  // Configuration fetched from VRFCoordinatorV2
+
+  // s_configured tracks whether this contract has been configured. If not configured, randomness
+  // requests cannot be made.
+  bool public s_configured;
+
+  // s_disabled disables the contract when true. When disabled, new VRF requests cannot be made
+  // but existing ones can still be fulfilled.
+  bool public s_disabled;
+
+  // s_fallbackWeiPerUnitLink is the backup LINK exchange rate used when the LINK/NATIVE feed is
+  // stale.
+  int256 private s_fallbackWeiPerUnitLink;
+
+  // s_stalenessSeconds is the number of seconds before we consider the feed price to be stale and
+  // fallback to fallbackWeiPerUnitLink.
+  uint32 private s_stalenessSeconds;
+
+  // s_fulfillmentFlatFeeLinkPPM is the flat fee in millionths of LINK that VRFCoordinatorV2
+  // charges.
+  uint32 private s_fulfillmentFlatFeeLinkPPM;
+
+  // Other configuration
+
+  // s_wrapperGasOverhead reflects the gas overhead of the wrapper's fulfillRandomWords
+  // function. The cost for this gas is passed to the user.
+  uint32 private s_wrapperGasOverhead;
+
+  // s_coordinatorGasOverhead reflects the gas overhead of the coordinator's fulfillRandomWords
+  // function. The cost for this gas is billed to the subscription, and must therefor be included
+  // in the pricing for wrapped requests. This includes the gas costs of proof verification and
+  // payment calculation in the coordinator.
+  uint32 private s_coordinatorGasOverhead;
+
+  // s_wrapperPremiumPercentage is the premium ratio in percentage. For example, a value of 0
+  // indicates no premium. A value of 15 indicates a 15 percent premium.
+  uint8 private s_wrapperPremiumPercentage;
+
+  // s_keyHash is the key hash to use when requesting randomness. Fees are paid based on current gas
+  // fees, so this should be set to the highest gas lane on the network.
+  bytes32 s_keyHash;
+
+  // s_maxNumWords is the max number of words that can be requested in a single wrapped VRF request.
+  uint8 s_maxNumWords;
+
+  struct Callback {
+    address callbackAddress;
+    uint32 callbackGasLimit;
+    uint256 requestGasPrice;
+    int256 requestWeiPerUnitLink;
+    uint256 juelsPaid;
+  }
+  mapping(uint256 => Callback) /* requestID */ /* callback */
+    public s_callbacks;
+
+  constructor(
+    address _link,
+    address _linkEthFeed,
+    address _coordinator
+  ) ConfirmedOwner(msg.sender) VRFConsumerBaseV2(_coordinator) {
+    LINK = LinkTokenInterface(_link);
+    LINK_ETH_FEED = AggregatorV3Interface(_linkEthFeed);
+    COORDINATOR = ExtendedVRFCoordinatorV2Interface(_coordinator);
+
+    // Create this wrapper's subscription and add itself as a consumer.
+    uint64 subId = ExtendedVRFCoordinatorV2Interface(_coordinator).createSubscription();
+    SUBSCRIPTION_ID = subId;
+    ExtendedVRFCoordinatorV2Interface(_coordinator).addConsumer(subId, address(this));
+  }
+
+  /**
+   * @notice setConfig configures VRFV2Wrapper.
+   *
+   * @dev Sets wrapper-specific configuration based on the given parameters, and fetches any needed
+   * @dev VRFCoordinatorV2 configuration from the coordinator.
+   *
+   * @param _wrapperGasOverhead reflects the gas overhead of the wrapper's fulfillRandomWords
+   *        function.
+   *
+   * @param _coordinatorGasOverhead reflects the gas overhead of the coordinator's
+   *        fulfillRandomWords function.
+   *
+   * @param _wrapperPremiumPercentage is the premium ratio in percentage for wrapper requests.
+   *
+   * @param _keyHash to use for requesting randomness.
+   */
+  function setConfig(
+    uint32 _wrapperGasOverhead,
+    uint32 _coordinatorGasOverhead,
+    uint8 _wrapperPremiumPercentage,
+    bytes32 _keyHash,
+    uint8 _maxNumWords
+  ) external onlyOwner {
+    s_wrapperGasOverhead = _wrapperGasOverhead;
+    s_coordinatorGasOverhead = _coordinatorGasOverhead;
+    s_wrapperPremiumPercentage = _wrapperPremiumPercentage;
+    s_keyHash = _keyHash;
+    s_maxNumWords = _maxNumWords;
+    s_configured = true;
+
+    // Get other configuration from coordinator
+    (, , s_stalenessSeconds, ) = COORDINATOR.getConfig();
+    s_fallbackWeiPerUnitLink = COORDINATOR.getFallbackWeiPerUnitLink();
+    (s_fulfillmentFlatFeeLinkPPM, , , , , , , , ) = COORDINATOR.getFeeConfig();
+  }
+
+  /**
+   * @notice getConfig returns the current VRFV2Wrapper configuration.
+   *
+   * @return fallbackWeiPerUnitLink is the backup LINK exchange rate used when the LINK/NATIVE feed
+   *         is stale.
+   *
+   * @return stalenessSeconds is the number of seconds before we consider the feed price to be stale
+   *         and fallback to fallbackWeiPerUnitLink.
+   *
+   * @return fulfillmentFlatFeeLinkPPM is the flat fee in millionths of LINK that VRFCoordinatorV2
+   *         charges.
+   *
+   * @return wrapperGasOverhead reflects the gas overhead of the wrapper's fulfillRandomWords
+   *         function. The cost for this gas is passed to the user.
+   *
+   * @return coordinatorGasOverhead reflects the gas overhead of the coordinator's
+   *         fulfillRandomWords function.
+   *
+   * @return wrapperPremiumPercentage is the premium ratio in percentage. For example, a value of 0
+   *         indicates no premium. A value of 15 indicates a 15 percent premium.
+   *
+   * @return keyHash is the key hash to use when requesting randomness. Fees are paid based on
+   *         current gas fees, so this should be set to the highest gas lane on the network.
+   *
+   * @return maxNumWords is the max number of words that can be requested in a single wrapped VRF
+   *         request.
+   */
+  function getConfig()
+    external
+    view
+    returns (
+      int256 fallbackWeiPerUnitLink,
+      uint32 stalenessSeconds,
+      uint32 fulfillmentFlatFeeLinkPPM,
+      uint32 wrapperGasOverhead,
+      uint32 coordinatorGasOverhead,
+      uint8 wrapperPremiumPercentage,
+      bytes32 keyHash,
+      uint8 maxNumWords
+    )
+  {
+    return (
+      s_fallbackWeiPerUnitLink,
+      s_stalenessSeconds,
+      s_fulfillmentFlatFeeLinkPPM,
+      s_wrapperGasOverhead,
+      s_coordinatorGasOverhead,
+      s_wrapperPremiumPercentage,
+      s_keyHash,
+      s_maxNumWords
+    );
+  }
+
+  /**
+   * @notice Calculates the price of a VRF request with the given callbackGasLimit at the current
+   * @notice block.
+   *
+   * @dev This function relies on the transaction gas price which is not automatically set during
+   * @dev simulation. To estimate the price at a specific gas price, use the estimatePrice function.
+   *
+   * @param _callbackGasLimit is the gas limit used to estimate the price.
+   */
+  function calculateRequestPrice(uint32 _callbackGasLimit)
+    external
+    view
+    override
+    onlyConfiguredNotDisabled
+    returns (uint256)
+  {
+    int256 weiPerUnitLink = getFeedData();
+    return calculateRequestPriceInternal(_callbackGasLimit, tx.gasprice, weiPerUnitLink);
+  }
+
+  /**
+   * @notice Estimates the price of a VRF request with a specific gas limit and gas price.
+   *
+   * @dev This is a convenience function that can be called in simulation to better understand
+   * @dev pricing.
+   *
+   * @param _callbackGasLimit is the gas limit used to estimate the price.
+   * @param _requestGasPriceWei is the gas price in wei used for the estimation.
+   */
+  function estimateRequestPrice(uint32 _callbackGasLimit, uint256 _requestGasPriceWei)
+    external
+    view
+    override
+    onlyConfiguredNotDisabled
+    returns (uint256)
+  {
+    int256 weiPerUnitLink = getFeedData();
+    return calculateRequestPriceInternal(_callbackGasLimit, _requestGasPriceWei, weiPerUnitLink);
+  }
+
+  function calculateRequestPriceInternal(
+    uint256 _gas,
+    uint256 _requestGasPrice,
+    int256 _weiPerUnitLink
+  ) internal view returns (uint256) {
+    uint256 baseFee = (1e18 * _requestGasPrice * (_gas + s_wrapperGasOverhead + s_coordinatorGasOverhead)) /
+      uint256(_weiPerUnitLink);
+
+    uint256 feeWithPremium = (baseFee * (s_wrapperPremiumPercentage + 100)) / 100;
+
+    uint256 feeWithFlatFee = feeWithPremium + (1e12 * uint256(s_fulfillmentFlatFeeLinkPPM));
+
+    return feeWithFlatFee;
+  }
+
+  /**
+   * @notice onTokenTransfer is called by LinkToken upon payment for a VRF request.
+   *
+   * @dev Reverts if payment is too low.
+   *
+   * @param _sender is the sender of the payment, and the address that will receive a VRF callback
+   *        upon fulfillment.
+   *
+   * @param _amount is the amount of LINK paid in Juels.
+   *
+   * @param _data is the abi-encoded VRF request parameters: uint32 callbackGasLimit,
+   *        uint16 requestConfirmations, and uint32 numWords.
+   */
+  function onTokenTransfer(
+    address _sender,
+    uint256 _amount,
+    bytes calldata _data
+  ) external onlyConfiguredNotDisabled {
+    require(msg.sender == address(LINK), "only callable from LINK");
+
+    (uint32 callbackGasLimit, uint16 requestConfirmations, uint32 numWords) = abi.decode(
+      _data,
+      (uint32, uint16, uint32)
+    );
+    int256 weiPerUnitLink = getFeedData();
+    uint256 price = calculateRequestPriceInternal(callbackGasLimit, tx.gasprice, weiPerUnitLink);
+    require(_amount >= price, "fee too low");
+    require(numWords <= s_maxNumWords, "numWords too high");
+
+    uint256 requestId = COORDINATOR.requestRandomWords(
+      s_keyHash,
+      SUBSCRIPTION_ID,
+      requestConfirmations,
+      callbackGasLimit + s_wrapperGasOverhead,
+      numWords
+    );
+    s_callbacks[requestId] = Callback({
+      callbackAddress: _sender,
+      callbackGasLimit: callbackGasLimit,
+      requestGasPrice: tx.gasprice,
+      requestWeiPerUnitLink: weiPerUnitLink,
+      juelsPaid: _amount
+    });
+    lastRequestId = requestId;
+  }
+
+  /**
+   * @notice withdraw is used by the VRFV2Wrapper's owner to withdraw LINK revenue.
+   *
+   * @param _recipient is the address that should receive the LINK funds.
+   *
+   * @param _amount is the amount of LINK in Juels that should be withdrawn.
+   */
+  function withdraw(address _recipient, uint256 _amount) external onlyOwner {
+    LINK.transfer(_recipient, _amount);
+  }
+
+  /**
+   * @notice enable this contract so that new requests can be accepted.
+   */
+  function enable() external onlyOwner {
+    s_disabled = false;
+  }
+
+  /**
+   * @notice disable this contract so that new requests will be rejected. When disabled, new requests
+   * @notice will revert but existing requests can still be fulfilled.
+   */
+  function disable() external onlyOwner {
+    s_disabled = true;
+  }
+
+  function fulfillRandomWords(uint256 _requestId, uint256[] memory _randomWords) internal override {
+    Callback memory callback = s_callbacks[_requestId];
+    delete s_callbacks[_requestId];
+    require(callback.callbackAddress != address(0), "request not found"); // This should never happen
+
+    VRFV2WrapperConsumerBase c;
+    bytes memory resp = abi.encodeWithSelector(c.rawFulfillRandomWords.selector, _requestId, _randomWords);
+
+    bool success = callWithExactGas(callback.callbackGasLimit, callback.callbackAddress, resp);
+    if (!success) {
+      emit WrapperFulfillmentFailed(_requestId, callback.callbackAddress);
+    }
+  }
+
+  function getFeedData() private view returns (int256) {
+    bool staleFallback = s_stalenessSeconds > 0;
+    uint256 timestamp;
+    int256 weiPerUnitLink;
+    (, weiPerUnitLink, , timestamp, ) = LINK_ETH_FEED.latestRoundData();
+    // solhint-disable-next-line not-rely-on-time
+    if (staleFallback && s_stalenessSeconds < block.timestamp - timestamp) {
+      weiPerUnitLink = s_fallbackWeiPerUnitLink;
+    }
+    require(weiPerUnitLink >= 0, "Invalid LINK wei price");
+    return weiPerUnitLink;
+  }
+
+  /**
+   * @dev calls target address with exactly gasAmount gas and data as calldata
+   * or reverts if at least gasAmount gas is not available.
+   */
+  function callWithExactGas(
+    uint256 gasAmount,
+    address target,
+    bytes memory data
+  ) private returns (bool success) {
+    // solhint-disable-next-line no-inline-assembly
+    assembly {
+      let g := gas()
+      // Compute g -= GAS_FOR_CALL_EXACT_CHECK and check for underflow
+      // The gas actually passed to the callee is min(gasAmount, 63//64*gas available).
+      // We want to ensure that we revert if gasAmount >  63//64*gas available
+      // as we do not want to provide them with less, however that check itself costs
+      // gas.  GAS_FOR_CALL_EXACT_CHECK ensures we have at least enough gas to be able
+      // to revert if gasAmount >  63//64*gas available.
+      if lt(g, GAS_FOR_CALL_EXACT_CHECK) {
+        revert(0, 0)
+      }
+      g := sub(g, GAS_FOR_CALL_EXACT_CHECK)
+      // if g - g//64 <= gasAmount, revert
+      // (we subtract g//64 because of EIP-150)
+      if iszero(gt(sub(g, div(g, 64)), gasAmount)) {
+        revert(0, 0)
+      }
+      // solidity calls check that a contract actually exists at the destination, so we do the same
+      if iszero(extcodesize(target)) {
+        revert(0, 0)
+      }
+      // call and return whether we succeeded. ignore return data
+      // call(gas,addr,value,argsOffset,argsLength,retOffset,retLength)
+      success := call(gasAmount, target, 0, add(data, 0x20), mload(data), 0, 0)
+    }
+    return success;
+  }
+
+  function typeAndVersion() external pure virtual override returns (string memory) {
+    return "VRFV2Wrapper 1.0.0";
+  }
+
+  modifier onlyConfiguredNotDisabled() {
+    require(s_configured, "wrapper is not configured");
+    require(!s_disabled, "wrapper is disabled");
+    _;
+  }
+}
+
+interface ExtendedVRFCoordinatorV2Interface is VRFCoordinatorV2Interface {
+  function getConfig()
+    external
+    view
+    returns (
+      uint16 minimumRequestConfirmations,
+      uint32 maxGasLimit,
+      uint32 stalenessSeconds,
+      uint32 gasAfterPaymentCalculation
+    );
+
+  function getFallbackWeiPerUnitLink() external view returns (int256);
+
+  function getFeeConfig()
+    external
+    view
+    returns (
+      uint32 fulfillmentFlatFeeLinkPPMTier1,
+      uint32 fulfillmentFlatFeeLinkPPMTier2,
+      uint32 fulfillmentFlatFeeLinkPPMTier3,
+      uint32 fulfillmentFlatFeeLinkPPMTier4,
+      uint32 fulfillmentFlatFeeLinkPPMTier5,
+      uint24 reqsForTier2,
+      uint24 reqsForTier3,
+      uint24 reqsForTier4,
+      uint24 reqsForTier5
+    );
+}

--- a/contracts/src/v0.8/dev/VRFV2WrapperConsumerBase.sol
+++ b/contracts/src/v0.8/dev/VRFV2WrapperConsumerBase.sol
@@ -1,0 +1,81 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../interfaces/LinkTokenInterface.sol";
+import "./VRFV2WrapperInterface.sol";
+
+/** *******************************************************************************
+ * @notice Interface for contracts using VRF randomness through the VRF V2 wrapper
+ * ********************************************************************************
+ * @dev PURPOSE
+ *
+ * @dev Create VRF V2 requests without the need for subscription management. Rather than creating
+ * @dev and funding a VRF V2 subscription, a user can use this wrapper to create one off requests,
+ * @dev paying up front rather than at fulfillment.
+ *
+ * @dev Since the price is determined using the gas price of the request transaction rather than
+ * @dev the fulfillment transaction, the wrapper charges an additional premium on callback gas
+ * @dev usage, in addition to some extra overhead costs associated with the VRFV2Wrapper contract.
+ * *****************************************************************************
+ * @dev USAGE
+ *
+ * @dev Calling contracts must inherit from VRFV2WrapperConsumerBase. The consumer must be funded
+ * @dev with enough LINK to make the request, otherwise requests will revert. To request randomness,
+ * @dev call the 'requestRandomness' function with the desired VRF parameters. This function handles
+ * @dev paying for the request based on the current pricing.
+ *
+ * @dev Consumers must implement the fullfillRandomWords function, which will be called during
+ * @dev fulfillment with the randomness result.
+ */
+abstract contract VRFV2WrapperConsumerBase {
+  LinkTokenInterface internal immutable LINK;
+  VRFV2WrapperInterface internal immutable VRF_V2_WRAPPER;
+
+  /**
+   * @param _link is the address of LinkToken
+   * @param _vrfV2Wrapper is the address of the VRFV2Wrapper contract
+   */
+  constructor(address _link, address _vrfV2Wrapper) {
+    LINK = LinkTokenInterface(_link);
+    VRF_V2_WRAPPER = VRFV2WrapperInterface(_vrfV2Wrapper);
+  }
+
+  /**
+   * @dev Requests randomness from the VRF V2 wrapper.
+   *
+   * @param _callbackGasLimit is the gas limit that should be used when calling the consumer's
+   *        fulfillRandomWords function.
+   * @param _requestConfirmations is the number of confirmations to wait before fulfilling the
+   *        request. A higher number of confirmations increases security by reducing the likelihood
+   *        that a chain re-org changes a published randomness outcome.
+   * @param _numWords is the number of random words to request.
+   *
+   * @return requestId is the VRF V2 request ID of the newly created randomness request.
+   */
+  function requestRandomness(
+    uint32 _callbackGasLimit,
+    uint16 _requestConfirmations,
+    uint32 _numWords
+  ) internal returns (uint256 requestId) {
+    LINK.transferAndCall(
+      address(VRF_V2_WRAPPER),
+      VRF_V2_WRAPPER.calculateRequestPrice(_callbackGasLimit),
+      abi.encode(_callbackGasLimit, _requestConfirmations, _numWords)
+    );
+    return VRF_V2_WRAPPER.lastRequestId();
+  }
+
+  /**
+   * @notice fulfillRandomWords handles the VRF V2 wrapper response. The consuming contract must
+   * @notice implement it.
+   *
+   * @param _requestId is the VRF V2 request ID.
+   * @param _randomWords is the randomness result.
+   */
+  function fulfillRandomWords(uint256 _requestId, uint256[] memory _randomWords) internal virtual;
+
+  function rawFulfillRandomWords(uint256 _requestId, uint256[] memory _randomWords) external {
+    require(msg.sender == address(VRF_V2_WRAPPER), "only VRF V2 wrapper can fulfill");
+    fulfillRandomWords(_requestId, _randomWords);
+  }
+}

--- a/contracts/src/v0.8/dev/VRFV2WrapperInterface.sol
+++ b/contracts/src/v0.8/dev/VRFV2WrapperInterface.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface VRFV2WrapperInterface {
+  /**
+   * @return the request ID of the most recent VRF V2 request made by this wrapper. This should only
+   * be relied option within the same transaction that the request was made.
+   */
+  function lastRequestId() external view returns (uint256);
+
+  /**
+   * @notice Calculates the price of a VRF request with the given callbackGasLimit at the current
+   * @notice block.
+   *
+   * @dev This function relies on the transaction gas price which is not automatically set during
+   * @dev simulation. To estimate the price at a specific gas price, use the estimatePrice function.
+   *
+   * @param _callbackGasLimit is the gas limit used to estimate the price.
+   */
+  function calculateRequestPrice(uint32 _callbackGasLimit) external view returns (uint256);
+
+  /**
+   * @notice Estimates the price of a VRF request with a specific gas limit and gas price.
+   *
+   * @dev This is a convenience function that can be called in simulation to better understand
+   * @dev pricing.
+   *
+   * @param _callbackGasLimit is the gas limit used to estimate the price.
+   * @param _requestGasPriceWei is the gas price in wei used for the estimation.
+   */
+  function estimateRequestPrice(uint32 _callbackGasLimit, uint256 _requestGasPriceWei) external view returns (uint256);
+}

--- a/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol
+++ b/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol
@@ -258,6 +258,51 @@ contract VRFCoordinatorV2Mock is VRFCoordinatorV2Interface {
     emit ConsumerRemoved(_subId, _consumer);
   }
 
+  function getConfig()
+    external
+    view
+    returns (
+      uint16 minimumRequestConfirmations,
+      uint32 maxGasLimit,
+      uint32 stalenessSeconds,
+      uint32 gasAfterPaymentCalculation
+    )
+  {
+    return (4, 2_500_000, 2_700, 33285);
+  }
+
+  function getFeeConfig()
+    external
+    view
+    returns (
+      uint32 fulfillmentFlatFeeLinkPPMTier1,
+      uint32 fulfillmentFlatFeeLinkPPMTier2,
+      uint32 fulfillmentFlatFeeLinkPPMTier3,
+      uint32 fulfillmentFlatFeeLinkPPMTier4,
+      uint32 fulfillmentFlatFeeLinkPPMTier5,
+      uint24 reqsForTier2,
+      uint24 reqsForTier3,
+      uint24 reqsForTier4,
+      uint24 reqsForTier5
+    )
+  {
+    return (
+      100000, // 0.1 LINK
+      100000, // 0.1 LINK
+      100000, // 0.1 LINK
+      100000, // 0.1 LINK
+      100000, // 0.1 LINK
+      0,
+      0,
+      0,
+      0
+    );
+  }
+
+  function getFallbackWeiPerUnitLink() external view returns (int256) {
+    return 4000000000000000; // 0.004 Ether
+  }
+
   function requestSubscriptionOwnerTransfer(uint64 _subId, address _newOwner) external pure override {
     revert("not implemented");
   }

--- a/contracts/src/v0.8/tests/VRFV2WrapperConsumerExample.sol
+++ b/contracts/src/v0.8/tests/VRFV2WrapperConsumerExample.sol
@@ -1,0 +1,57 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.6;
+
+import "../dev/VRFV2WrapperConsumerBase.sol";
+import "../ConfirmedOwner.sol";
+
+contract VRFV2WrapperConsumerExample is VRFV2WrapperConsumerBase, ConfirmedOwner {
+  event WrappedRequestFulfilled(uint256 requestId, uint256[] randomWords, uint256 payment);
+
+  struct RequestStatus {
+    uint256 paid;
+    bool fulfilled;
+    uint256[] randomWords;
+  }
+  mapping(uint256 => RequestStatus) /* requestId */ /* requestStatus */
+    public s_requests;
+
+  constructor(address _link, address _vrfV2Wrapper)
+    ConfirmedOwner(msg.sender)
+    VRFV2WrapperConsumerBase(_link, _vrfV2Wrapper)
+  {}
+
+  function makeRequest(
+    uint32 _callbackGasLimit,
+    uint16 _requestConfirmations,
+    uint32 _numWords
+  ) external onlyOwner returns (uint256 requestId) {
+    requestId = requestRandomness(_callbackGasLimit, _requestConfirmations, _numWords);
+    s_requests[requestId] = RequestStatus({
+      paid: VRF_V2_WRAPPER.calculateRequestPrice(_callbackGasLimit),
+      randomWords: new uint256[](0),
+      fulfilled: false
+    });
+    return requestId;
+  }
+
+  function fulfillRandomWords(uint256 _requestId, uint256[] memory _randomWords) internal override {
+    require(s_requests[_requestId].paid > 0, "request not found");
+    s_requests[_requestId].fulfilled = true;
+    s_requests[_requestId].randomWords = _randomWords;
+    emit WrappedRequestFulfilled(_requestId, _randomWords, s_requests[_requestId].paid);
+  }
+
+  function getRequestStatus(uint256 _requestId)
+    external
+    view
+    returns (
+      uint256 paid,
+      bool fulfilled,
+      uint256[] memory randomWords
+    )
+  {
+    require(s_requests[_requestId].paid > 0, "request not found");
+    RequestStatus memory request = s_requests[_requestId];
+    return (request.paid, request.fulfilled, request.randomWords);
+  }
+}

--- a/contracts/src/v0.8/tests/VRFV2WrapperOutOfGasConsumerExample.sol
+++ b/contracts/src/v0.8/tests/VRFV2WrapperOutOfGasConsumerExample.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "../dev/VRFV2WrapperConsumerBase.sol";
+import "../ConfirmedOwner.sol";
+
+contract VRFV2WrapperOutOfGasConsumerExample is VRFV2WrapperConsumerBase, ConfirmedOwner {
+  constructor(address _link, address _vrfV2Wrapper)
+    ConfirmedOwner(msg.sender)
+    VRFV2WrapperConsumerBase(_link, _vrfV2Wrapper)
+  {}
+
+  function makeRequest(
+    uint32 _callbackGasLimit,
+    uint16 _requestConfirmations,
+    uint32 _numWords
+  ) external onlyOwner returns (uint256 requestId) {
+    return requestRandomness(_callbackGasLimit, _requestConfirmations, _numWords);
+  }
+
+  function fulfillRandomWords(uint256 _requestId, uint256[] memory _randomWords) internal view override {
+    while (gasleft() > 0) {}
+  }
+}

--- a/contracts/src/v0.8/tests/VRFV2WrapperRevertingConsumerExample.sol
+++ b/contracts/src/v0.8/tests/VRFV2WrapperRevertingConsumerExample.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.13;
+
+import "../dev/VRFV2WrapperConsumerBase.sol";
+import "../ConfirmedOwner.sol";
+
+contract VRFV2WrapperRevertingConsumerExample is VRFV2WrapperConsumerBase, ConfirmedOwner {
+  constructor(address _link, address _vrfV2Wrapper)
+    ConfirmedOwner(msg.sender)
+    VRFV2WrapperConsumerBase(_link, _vrfV2Wrapper)
+  {}
+
+  function makeRequest(
+    uint32 _callbackGasLimit,
+    uint16 _requestConfirmations,
+    uint32 _numWords
+  ) external onlyOwner returns (uint256 requestId) {
+    return requestRandomness(_callbackGasLimit, _requestConfirmations, _numWords);
+  }
+
+  function fulfillRandomWords(uint256 _requestId, uint256[] memory _randomWords) internal pure override {
+    revert("reverting example");
+  }
+}

--- a/contracts/src/v0.8/tests/VRFV2WrapperUnderFundingConsumer.sol
+++ b/contracts/src/v0.8/tests/VRFV2WrapperUnderFundingConsumer.sol
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "../ConfirmedOwner.sol";
+import "../interfaces/LinkTokenInterface.sol";
+import "../dev/VRFV2WrapperInterface.sol";
+
+contract VRFV2WrapperUnderFundingConsumer is ConfirmedOwner {
+  LinkTokenInterface internal immutable LINK;
+  VRFV2WrapperInterface internal immutable VRF_V2_WRAPPER;
+
+  constructor(address _link, address _vrfV2Wrapper) ConfirmedOwner(msg.sender) {
+    LINK = LinkTokenInterface(_link);
+    VRF_V2_WRAPPER = VRFV2WrapperInterface(_vrfV2Wrapper);
+  }
+
+  function makeRequest(
+    uint32 _callbackGasLimit,
+    uint16 _requestConfirmations,
+    uint32 _numWords
+  ) external onlyOwner {
+    LINK.transferAndCall(
+      address(VRF_V2_WRAPPER),
+      // Pay less than the needed amount
+      VRF_V2_WRAPPER.calculateRequestPrice(_callbackGasLimit) - 1,
+      abi.encode(_callbackGasLimit, _requestConfirmations, _numWords)
+    );
+  }
+}

--- a/contracts/test/v0.8/dev/VRFV2Wrapper.test.ts
+++ b/contracts/test/v0.8/dev/VRFV2Wrapper.test.ts
@@ -1,0 +1,634 @@
+import { expect, assert } from 'chai'
+import { BigNumber, BigNumberish, Signer } from 'ethers'
+import { ethers } from 'hardhat'
+import { toBytes32String, reset } from '../../test-helpers/helpers'
+import { bigNumEquals } from '../../test-helpers/matchers'
+import { describe } from 'mocha'
+import {
+  LinkToken,
+  MockV3Aggregator,
+  MockV3Aggregator__factory,
+  VRFCoordinatorV2Mock,
+  VRFV2Wrapper,
+  VRFV2WrapperConsumerExample,
+  VRFV2WrapperRevertingConsumerExample,
+  VRFV2WrapperOutOfGasConsumerExample,
+} from '../../../typechain'
+
+describe('VRFV2Wrapper', () => {
+  const pointOneLink = BigNumber.from('100000000000000000')
+  const pointZeroZeroThreeLink = BigNumber.from('3000000000000000')
+  const oneHundredLink = BigNumber.from('100000000000000000000')
+  const oneHundredGwei = BigNumber.from('100000000000')
+  const fiftyGwei = BigNumber.from('50000000000')
+
+  // Configuration
+
+  // This value is the worst-case gas overhead from the wrapper contract under the following
+  // conditions, plus some wiggle room:
+  //   - 10 words requested
+  //   - Refund issued to consumer
+  const wrapperGasOverhead = BigNumber.from(60_000)
+  const coordinatorGasOverhead = BigNumber.from(52_000)
+  const wrapperPremiumPercentage = 10
+  const maxNumWords = 10
+  const weiPerUnitLink = pointZeroZeroThreeLink
+  const flatFee = pointOneLink
+
+  let wrapper: VRFV2Wrapper
+  let coordinator: VRFCoordinatorV2Mock
+  let link: LinkToken
+  let wrongLink: LinkToken
+  let linkEthFeed: MockV3Aggregator
+  let consumer: VRFV2WrapperConsumerExample
+  let consumerWrongLink: VRFV2WrapperConsumerExample
+  let consumerRevert: VRFV2WrapperRevertingConsumerExample
+  let consumerOutOfGas: VRFV2WrapperOutOfGasConsumerExample
+
+  let owner: Signer
+  let requester: Signer
+  let consumerOwner: Signer
+  let withdrawRecipient: Signer
+
+  // This should match implementation in VRFV2Wrapper::calculateGasPriceInternal
+  const calculatePrice = (
+    gasLimit: BigNumberish,
+    _wrapperGasOverhead: BigNumberish = wrapperGasOverhead,
+    _coordinatorGasOverhead: BigNumberish = coordinatorGasOverhead,
+    _gasPriceWei: BigNumberish = oneHundredGwei,
+    _weiPerUnitLink: BigNumberish = weiPerUnitLink,
+    _wrapperPremium: BigNumberish = wrapperPremiumPercentage,
+    _flatFee: BigNumberish = flatFee,
+  ): BigNumber => {
+    const totalGas = BigNumber.from(0)
+      .add(gasLimit)
+      .add(_wrapperGasOverhead)
+      .add(_coordinatorGasOverhead)
+    const baseFee = BigNumber.from('1000000000000000000')
+      .mul(_gasPriceWei)
+      .mul(totalGas)
+      .div(_weiPerUnitLink)
+    const withPremium = baseFee
+      .mul(BigNumber.from(100).add(_wrapperPremium))
+      .div(100)
+    return withPremium.add(_flatFee)
+  }
+
+  before(async () => {
+    await reset()
+  })
+
+  beforeEach(async () => {
+    const accounts = await ethers.getSigners()
+    owner = accounts[0]
+    requester = accounts[1]
+    consumerOwner = accounts[2]
+    withdrawRecipient = accounts[3]
+
+    const coordinatorFactory = await ethers.getContractFactory(
+      'VRFCoordinatorV2Mock',
+      owner,
+    )
+    coordinator = await coordinatorFactory.deploy(
+      pointOneLink,
+      1e9, // 0.000000001 LINK per gas
+    )
+
+    const linkEthFeedFactory = (await ethers.getContractFactory(
+      'src/v0.8/tests/MockV3Aggregator.sol:MockV3Aggregator',
+      owner,
+    )) as unknown as MockV3Aggregator__factory
+    linkEthFeed = await linkEthFeedFactory.deploy(18, weiPerUnitLink) // 1 LINK = 0.003 ETH
+
+    const linkFactory = await ethers.getContractFactory('LinkToken', owner)
+    link = await linkFactory.deploy()
+    wrongLink = await linkFactory.deploy()
+
+    const wrapperFactory = await ethers.getContractFactory(
+      'VRFV2Wrapper',
+      owner,
+    )
+    wrapper = await wrapperFactory.deploy(
+      link.address,
+      linkEthFeed.address,
+      coordinator.address,
+    )
+
+    const consumerFactory = await ethers.getContractFactory(
+      'VRFV2WrapperConsumerExample',
+      consumerOwner,
+    )
+    consumer = await consumerFactory.deploy(link.address, wrapper.address)
+    consumerWrongLink = await consumerFactory.deploy(
+      wrongLink.address,
+      wrapper.address,
+    )
+    consumerRevert = await consumerFactory.deploy(link.address, wrapper.address)
+
+    const revertingConsumerFactory = await ethers.getContractFactory(
+      'VRFV2WrapperRevertingConsumerExample',
+      consumerOwner,
+    )
+    consumerRevert = await revertingConsumerFactory.deploy(
+      link.address,
+      wrapper.address,
+    )
+
+    const outOfGasConsumerFactory = await ethers.getContractFactory(
+      'VRFV2WrapperOutOfGasConsumerExample',
+      consumerOwner,
+    )
+    consumerOutOfGas = await outOfGasConsumerFactory.deploy(
+      link.address,
+      wrapper.address,
+    )
+  })
+
+  const configure = async (): Promise<void> => {
+    await expect(
+      wrapper
+        .connect(owner)
+        .setConfig(
+          wrapperGasOverhead,
+          coordinatorGasOverhead,
+          wrapperPremiumPercentage,
+          toBytes32String('keyHash'),
+          maxNumWords,
+        ),
+    ).to.not.be.reverted
+  }
+
+  const fund = async (address: string, amount: BigNumber): Promise<void> => {
+    await expect(link.connect(owner).transfer(address, amount)).to.not.be
+      .reverted
+  }
+
+  const fundSub = async (): Promise<void> => {
+    await expect(coordinator.connect(owner).fundSubscription(1, oneHundredLink))
+      .to.not.be.reverted
+  }
+
+  describe('calculatePrice', async () => {
+    // Note: This is a meta-test for the calculatePrice func above. It is then assumed correct for
+    // the remainder of the tests
+    it('can calculate price at 50 gwei, 100k limit', async () => {
+      const result = calculatePrice(
+        100_000,
+        wrapperGasOverhead,
+        coordinatorGasOverhead,
+        fiftyGwei,
+        weiPerUnitLink,
+        wrapperPremiumPercentage,
+        flatFee,
+      )
+      bigNumEquals(BigNumber.from('3986666666666666666'), result)
+    })
+
+    it('can calculate price at 50 gwei, 200k limit', async () => {
+      const result = calculatePrice(
+        200_000,
+        wrapperGasOverhead,
+        coordinatorGasOverhead,
+        fiftyGwei,
+        weiPerUnitLink,
+        wrapperPremiumPercentage,
+        flatFee,
+      )
+      bigNumEquals(BigNumber.from('5820000000000000000'), result)
+    })
+
+    it('can calculate price at 100 gwei, 100k limit', async () => {
+      const result = calculatePrice(
+        200_000,
+        wrapperGasOverhead,
+        coordinatorGasOverhead,
+        oneHundredGwei,
+        weiPerUnitLink,
+        wrapperPremiumPercentage,
+        flatFee,
+      )
+      bigNumEquals(BigNumber.from('11540000000000000000'), result)
+    })
+
+    it('can calculate price at 100 gwei, 100k limit, 25% premium', async () => {
+      const result = calculatePrice(
+        200_000,
+        wrapperGasOverhead,
+        coordinatorGasOverhead,
+        oneHundredGwei,
+        weiPerUnitLink,
+        25,
+        flatFee,
+      )
+      bigNumEquals(BigNumber.from('13100000000000000000'), result)
+    })
+  })
+
+  describe('#setConfig/#getConfig', async () => {
+    it('can be configured', async () => {
+      await configure()
+
+      const resp = await wrapper.connect(requester).getConfig()
+      bigNumEquals(BigNumber.from('4000000000000000'), resp[0]) // fallbackWeiPerUnitLink
+      bigNumEquals(2_700, resp[1]) // stalenessSeconds
+      bigNumEquals(BigNumber.from('100000'), resp[2]) // fulfillmentFlatFeeLinkPPM
+      bigNumEquals(wrapperGasOverhead, resp[3])
+      bigNumEquals(coordinatorGasOverhead, resp[4])
+      bigNumEquals(wrapperPremiumPercentage, resp[5])
+      assert.equal(resp[6], toBytes32String('keyHash'))
+      bigNumEquals(10, resp[7])
+    })
+
+    it('can be reconfigured', async () => {
+      await configure()
+
+      await expect(
+        wrapper.connect(owner).setConfig(
+          140_000, // wrapperGasOverhead
+          195_000, // coordinatorGasOverhead
+          9, // wrapperPremiumPercentage
+          toBytes32String('keyHash2'), // keyHash
+          9, // maxNumWords
+        ),
+      ).to.not.be.reverted
+
+      const resp = await wrapper.connect(requester).getConfig()
+      bigNumEquals(BigNumber.from('4000000000000000'), resp[0]) // fallbackWeiPerUnitLink
+      bigNumEquals(2_700, resp[1]) // stalenessSeconds
+      bigNumEquals(BigNumber.from('100000'), resp[2]) // fulfillmentFlatFeeLinkPPM
+      bigNumEquals(140_000, resp[3]) // wrapperGasOverhead
+      bigNumEquals(195_000, resp[4]) // coordinatorGasOverhead
+      bigNumEquals(9, resp[5]) // wrapperPremiumPercentage
+      assert.equal(resp[6], toBytes32String('keyHash2')) // keyHash
+      bigNumEquals(9, resp[7]) // maxNumWords
+    })
+
+    it('cannot be configured by a non-owner', async () => {
+      await expect(
+        wrapper.connect(requester).setConfig(
+          10_000, // wrapperGasOverhead
+          10_000, // coordinatorGasOverhead
+          10, // wrapperPremiumPercentage
+          toBytes32String('keyHash'), // keyHash
+          10, // maxNumWords
+        ),
+      ).to.be.reverted
+    })
+  })
+  describe('#calculatePrice', async () => {
+    it('cannot calculate price when not configured', async () => {
+      await expect(wrapper.connect(requester).calculateRequestPrice(100_000)).to
+        .be.reverted
+    })
+    it('can calculate price at 50 gwei, 100k gas', async () => {
+      await configure()
+      const expected = calculatePrice(
+        100_000,
+        wrapperGasOverhead,
+        coordinatorGasOverhead,
+        fiftyGwei,
+        weiPerUnitLink,
+        wrapperPremiumPercentage,
+        flatFee,
+      )
+      const resp = await wrapper
+        .connect(requester)
+        .calculateRequestPrice(100_000, { gasPrice: fiftyGwei })
+      bigNumEquals(expected, resp)
+    })
+
+    it('can calculate price at 100 gwei, 100k gas', async () => {
+      await configure()
+      const expected = calculatePrice(
+        100_000,
+        wrapperGasOverhead,
+        coordinatorGasOverhead,
+        oneHundredGwei,
+        weiPerUnitLink,
+        wrapperPremiumPercentage,
+        flatFee,
+      )
+      const resp = await wrapper
+        .connect(requester)
+        .calculateRequestPrice(100_000, { gasPrice: oneHundredGwei })
+      bigNumEquals(expected, resp)
+    })
+
+    it('can calculate price at 100 gwei, 200k gas', async () => {
+      await configure()
+      const expected = calculatePrice(
+        200_000,
+        wrapperGasOverhead,
+        coordinatorGasOverhead,
+        oneHundredGwei,
+        weiPerUnitLink,
+        wrapperPremiumPercentage,
+        flatFee,
+      )
+      const resp = await wrapper
+        .connect(requester)
+        .calculateRequestPrice(200_000, { gasPrice: oneHundredGwei })
+      bigNumEquals(expected, resp)
+    })
+  })
+
+  describe('#estimatePrice', async () => {
+    it('cannot estimate price when not configured', async () => {
+      await expect(
+        wrapper
+          .connect(requester)
+          .estimateRequestPrice(100_000, oneHundredGwei),
+      ).to.be.reverted
+    })
+    it('can estimate price at 50 gwei, 100k gas', async () => {
+      await configure()
+      const expected = calculatePrice(
+        100_000,
+        wrapperGasOverhead,
+        coordinatorGasOverhead,
+        fiftyGwei,
+        weiPerUnitLink,
+        wrapperPremiumPercentage,
+        flatFee,
+      )
+      const resp = await wrapper
+        .connect(requester)
+        .estimateRequestPrice(100_000, fiftyGwei)
+      bigNumEquals(expected, resp)
+    })
+
+    it('can estimate price at 100 gwei, 100k gas', async () => {
+      await configure()
+      const expected = calculatePrice(
+        100_000,
+        wrapperGasOverhead,
+        coordinatorGasOverhead,
+        oneHundredGwei,
+        weiPerUnitLink,
+        wrapperPremiumPercentage,
+        flatFee,
+      )
+      const resp = await wrapper
+        .connect(requester)
+        .estimateRequestPrice(100_000, oneHundredGwei)
+      bigNumEquals(expected, resp)
+    })
+
+    it('can estimate price at 100 gwei, 200k gas', async () => {
+      await configure()
+      const expected = calculatePrice(
+        200_000,
+        wrapperGasOverhead,
+        coordinatorGasOverhead,
+        oneHundredGwei,
+        weiPerUnitLink,
+        wrapperPremiumPercentage,
+        flatFee,
+      )
+      const resp = await wrapper
+        .connect(requester)
+        .estimateRequestPrice(200_000, oneHundredGwei)
+      bigNumEquals(expected, resp)
+    })
+  })
+
+  describe('#onTokenTransfer/#fulfillRandomWords', async () => {
+    it('cannot request randomness when not configured', async () => {
+      await expect(
+        consumer
+          .connect(consumerOwner)
+          .makeRequest(80_000, 3, 2, { gasPrice: oneHundredGwei }),
+      ).to.be.reverted
+    })
+    it('can only be called through LinkToken', async () => {
+      configure()
+      await expect(
+        wrongLink
+          .connect(owner)
+          .transfer(consumerWrongLink.address, oneHundredLink),
+      ).to.not.be.reverted
+      await expect(
+        consumerWrongLink
+          .connect(consumerOwner)
+          .makeRequest(80_000, 3, 2, { gasPrice: oneHundredGwei }),
+      ).to.be.reverted
+    })
+    it('can request and fulfill randomness', async () => {
+      await configure()
+      await fund(consumer.address, oneHundredLink)
+      await fundSub()
+
+      await expect(
+        consumer
+          .connect(consumerOwner)
+          .makeRequest(100_000, 3, 1, { gasPrice: oneHundredGwei }),
+      ).to.emit(coordinator, 'RandomWordsRequested')
+
+      const price = calculatePrice(100_000)
+
+      // Check that the wrapper has the paid amount
+      bigNumEquals(price, await link.balanceOf(wrapper.address))
+
+      const { paid, fulfilled } = await consumer.s_requests(1 /* requestId */)
+      bigNumEquals(price, paid)
+      expect(fulfilled).to.be.false
+
+      // fulfill the request
+      await expect(
+        coordinator
+          .connect(owner)
+          .fulfillRandomWordsWithOverride(1, wrapper.address, [123]),
+      )
+        .to.emit(coordinator, 'RandomWordsFulfilled')
+        .to.emit(consumer, 'WrappedRequestFulfilled')
+        .withArgs(1, [123], BigNumber.from(price))
+
+      const expectedBalance = price
+      const diff = expectedBalance
+        .sub(await link.balanceOf(wrapper.address))
+        .abs()
+      expect(diff.lt(pointOneLink)).to.be.true
+    })
+    it('does not revert if consumer runs out of gas', async () => {
+      await configure()
+      await fund(consumerOutOfGas.address, oneHundredLink)
+      await fundSub()
+
+      await expect(
+        consumerOutOfGas
+          .connect(consumerOwner)
+          .makeRequest(100_000, 3, 1, { gasPrice: oneHundredGwei }),
+      ).to.emit(coordinator, 'RandomWordsRequested')
+
+      const price = calculatePrice(100_000)
+
+      // Check that the wrapper has the paid amount
+      bigNumEquals(price, await link.balanceOf(wrapper.address))
+
+      // fulfill the request
+      await expect(
+        coordinator
+          .connect(owner)
+          .fulfillRandomWordsWithOverride(1, wrapper.address, [123]),
+      )
+        .to.emit(coordinator, 'RandomWordsFulfilled')
+        .to.emit(wrapper, 'WrapperFulfillmentFailed')
+    })
+    it('does not revert if consumer reverts', async () => {
+      await configure()
+      await fund(consumerRevert.address, oneHundredLink)
+      await fundSub()
+
+      await expect(
+        consumerRevert
+          .connect(consumerOwner)
+          .makeRequest(100_000, 3, 1, { gasPrice: oneHundredGwei }),
+      ).to.emit(coordinator, 'RandomWordsRequested')
+
+      const price = calculatePrice(100_000)
+
+      // Check that the wrapper has the paid amount
+      bigNumEquals(price, await link.balanceOf(wrapper.address))
+
+      // fulfill the request
+      await expect(
+        coordinator
+          .connect(owner)
+          .fulfillRandomWordsWithOverride(1, wrapper.address, [123]),
+      )
+        .to.emit(coordinator, 'RandomWordsFulfilled')
+        .to.emit(wrapper, 'WrapperFulfillmentFailed')
+
+      const expectedBalance = price
+      const diff = expectedBalance
+        .sub(await link.balanceOf(wrapper.address))
+        .abs()
+
+      expect(diff.lt(pointOneLink)).to.be.true
+    })
+  })
+  describe('#disable/#enable', async () => {
+    it('can only calculate price when enabled', async () => {
+      await configure()
+
+      await expect(wrapper.connect(owner).disable()).to.not.be.reverted
+      await expect(
+        wrapper
+          .connect(consumerOwner)
+          .calculateRequestPrice(100_000, { gasPrice: oneHundredGwei }),
+      ).to.be.reverted
+
+      await expect(wrapper.connect(owner).enable()).to.not.be.reverted
+      await expect(
+        wrapper
+          .connect(consumerOwner)
+          .calculateRequestPrice(100_000, { gasPrice: oneHundredGwei }),
+      ).to.not.be.reverted
+    })
+
+    it('can only estimate price when enabled', async () => {
+      await configure()
+
+      await expect(wrapper.connect(owner).disable()).to.not.be.reverted
+      await expect(
+        wrapper
+          .connect(consumerOwner)
+          .estimateRequestPrice(100_000, oneHundredGwei),
+      ).to.be.reverted
+
+      await expect(wrapper.connect(owner).enable()).to.not.be.reverted
+      await expect(
+        wrapper
+          .connect(consumerOwner)
+          .estimateRequestPrice(100_000, oneHundredGwei),
+      ).to.not.be.reverted
+    })
+
+    it('can be configured while disabled', async () => {
+      await expect(wrapper.connect(owner).disable()).to.not.be.reverted
+      await configure()
+    })
+
+    it('can only request randomness when enabled', async () => {
+      await configure()
+      await fund(consumer.address, oneHundredLink)
+      await fundSub()
+
+      await expect(wrapper.connect(owner).disable()).to.not.be.reverted
+      await expect(
+        consumer
+          .connect(consumerOwner)
+          .makeRequest(100_000, 3, 1, { gasPrice: oneHundredGwei }),
+      ).to.be.reverted
+
+      await expect(wrapper.connect(owner).enable()).to.not.be.reverted
+      await expect(
+        consumer
+          .connect(consumerOwner)
+          .makeRequest(100_000, 3, 1, { gasPrice: oneHundredGwei }),
+      ).to.not.be.reverted
+    })
+
+    it('can fulfill randomness when disabled', async () => {
+      await configure()
+      await fund(consumer.address, oneHundredLink)
+      await fundSub()
+
+      await expect(
+        consumer
+          .connect(consumerOwner)
+          .makeRequest(100_000, 3, 1, { gasPrice: oneHundredGwei }),
+      ).to.not.be.reverted
+      await expect(wrapper.connect(owner).disable()).to.not.be.reverted
+
+      await expect(
+        coordinator
+          .connect(owner)
+          .fulfillRandomWordsWithOverride(1, wrapper.address, [123]),
+      )
+        .to.emit(coordinator, 'RandomWordsFulfilled')
+        .to.emit(consumer, 'WrappedRequestFulfilled')
+    })
+  })
+
+  describe('#withdraw', async () => {
+    it('can withdraw funds to the owner', async () => {
+      await configure()
+      await fund(wrapper.address, oneHundredLink)
+      const recipientAddress = await withdrawRecipient.getAddress()
+
+      // Withdraw half the funds
+      await expect(
+        wrapper
+          .connect(owner)
+          .withdraw(recipientAddress, oneHundredLink.div(2)),
+      ).to.not.be.reverted
+      bigNumEquals(
+        oneHundredLink.div(2),
+        await link.balanceOf(recipientAddress),
+      )
+      bigNumEquals(oneHundredLink.div(2), await link.balanceOf(wrapper.address))
+
+      // Withdraw the rest
+      await expect(
+        wrapper
+          .connect(owner)
+          .withdraw(recipientAddress, oneHundredLink.div(2)),
+      ).to.not.be.reverted
+      bigNumEquals(oneHundredLink, await link.balanceOf(recipientAddress))
+      bigNumEquals(0, await link.balanceOf(wrapper.address))
+    })
+
+    it('cannot withdraw funds to non owners', async () => {
+      await configure()
+      await fund(wrapper.address, oneHundredLink)
+      const recipientAddress = await withdrawRecipient.getAddress()
+
+      await expect(
+        wrapper
+          .connect(consumerOwner)
+          .withdraw(recipientAddress, oneHundredLink.div(2)),
+      ).to.be.reverted
+    })
+  })
+})

--- a/core/internal/gethwrappers/generated/vrfv2_wrapper/vrfv2_wrapper.go
+++ b/core/internal/gethwrappers/generated/vrfv2_wrapper/vrfv2_wrapper.go
@@ -1,0 +1,1104 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package vrfv2_wrapper
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated"
+)
+
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+var VRFV2WrapperMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_link\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_linkEthFeed\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_coordinator\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"have\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"want\",\"type\":\"address\"}],\"name\":\"OnlyCoordinatorCanFulfill\",\"type\":\"error\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"OwnershipTransferRequested\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"uint256\",\"name\":\"requestId\",\"type\":\"uint256\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"consumer\",\"type\":\"address\"}],\"name\":\"WrapperFulfillmentFailed\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"COORDINATOR\",\"outputs\":[{\"internalType\":\"contractExtendedVRFCoordinatorV2Interface\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"LINK\",\"outputs\":[{\"internalType\":\"contractLinkTokenInterface\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"LINK_ETH_FEED\",\"outputs\":[{\"internalType\":\"contractAggregatorV3Interface\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"SUBSCRIPTION_ID\",\"outputs\":[{\"internalType\":\"uint64\",\"name\":\"\",\"type\":\"uint64\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"acceptOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_callbackGasLimit\",\"type\":\"uint32\"}],\"name\":\"calculateRequestPrice\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"disable\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"enable\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_callbackGasLimit\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"_requestGasPriceWei\",\"type\":\"uint256\"}],\"name\":\"estimateRequestPrice\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"getConfig\",\"outputs\":[{\"internalType\":\"int256\",\"name\":\"fallbackWeiPerUnitLink\",\"type\":\"int256\"},{\"internalType\":\"uint32\",\"name\":\"stalenessSeconds\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"fulfillmentFlatFeeLinkPPM\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"wrapperGasOverhead\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"coordinatorGasOverhead\",\"type\":\"uint32\"},{\"internalType\":\"uint8\",\"name\":\"wrapperPremiumPercentage\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"keyHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint8\",\"name\":\"maxNumWords\",\"type\":\"uint8\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"lastRequestId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_sender\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_amount\",\"type\":\"uint256\"},{\"internalType\":\"bytes\",\"name\":\"_data\",\"type\":\"bytes\"}],\"name\":\"onTokenTransfer\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"requestId\",\"type\":\"uint256\"},{\"internalType\":\"uint256[]\",\"name\":\"randomWords\",\"type\":\"uint256[]\"}],\"name\":\"rawFulfillRandomWords\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"s_callbacks\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"callbackAddress\",\"type\":\"address\"},{\"internalType\":\"uint32\",\"name\":\"callbackGasLimit\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"requestGasPrice\",\"type\":\"uint256\"},{\"internalType\":\"int256\",\"name\":\"requestWeiPerUnitLink\",\"type\":\"int256\"},{\"internalType\":\"uint256\",\"name\":\"juelsPaid\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"s_configured\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"s_disabled\",\"outputs\":[{\"internalType\":\"bool\",\"name\":\"\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_wrapperGasOverhead\",\"type\":\"uint32\"},{\"internalType\":\"uint32\",\"name\":\"_coordinatorGasOverhead\",\"type\":\"uint32\"},{\"internalType\":\"uint8\",\"name\":\"_wrapperPremiumPercentage\",\"type\":\"uint8\"},{\"internalType\":\"bytes32\",\"name\":\"_keyHash\",\"type\":\"bytes32\"},{\"internalType\":\"uint8\",\"name\":\"_maxNumWords\",\"type\":\"uint8\"}],\"name\":\"setConfig\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"typeAndVersion\",\"outputs\":[{\"internalType\":\"string\",\"name\":\"\",\"type\":\"string\"}],\"stateMutability\":\"pure\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_recipient\",\"type\":\"address\"},{\"internalType\":\"uint256\",\"name\":\"_amount\",\"type\":\"uint256\"}],\"name\":\"withdraw\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	Bin: "0x6101206040523480156200001257600080fd5b506040516200232b3803806200232b8339810160408190526200003591620002c2565b8033806000816200008d5760405162461bcd60e51b815260206004820152601860248201527f43616e6e6f7420736574206f776e657220746f207a65726f000000000000000060448201526064015b60405180910390fd5b600080546001600160a01b0319166001600160a01b0384811691909117909155811615620000c057620000c081620001f9565b5050506001600160601b0319606091821b811660805284821b811660a05283821b811660c0529082901b1660e0526040805163288688f960e21b815290516000916001600160a01b0384169163a21a23e49160048082019260209290919082900301818787803b1580156200013457600080fd5b505af115801562000149573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906200016f91906200030c565b60c081901b6001600160c01b03191661010052604051631cd0704360e21b81526001600160401b03821660048201523060248201529091506001600160a01b03831690637341c10c90604401600060405180830381600087803b158015620001d657600080fd5b505af1158015620001eb573d6000803e3d6000fd5b50505050505050506200033e565b6001600160a01b038116331415620002545760405162461bcd60e51b815260206004820152601760248201527f43616e6e6f74207472616e7366657220746f2073656c66000000000000000000604482015260640162000084565b600180546001600160a01b0319166001600160a01b0383811691821790925560008054604051929316917fed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae12789190a350565b80516001600160a01b0381168114620002bd57600080fd5b919050565b600080600060608486031215620002d857600080fd5b620002e384620002a5565b9250620002f360208501620002a5565b91506200030360408501620002a5565b90509250925092565b6000602082840312156200031f57600080fd5b81516001600160401b03811681146200033757600080fd5b9392505050565b60805160601c60a05160601c60c05160601c60e05160601c6101005160c01c611f5a620003d1600039600081816101810152610be201526000818161026e01528181610ba301528181610eea01528181610fcb01526110660152600081816103e7015261151a01526000818161020501528181610a0201526111b80152600081816104f2015261055a0152611f5a6000f3fe608060405234801561001057600080fd5b50600436106101775760003560e01c80637fb5d19d116100d8578063ad1783611161008c578063f2fde38b11610066578063f2fde38b146104ab578063f3fef3a3146104be578063fc2a88c3146104d157600080fd5b8063ad178361146103e2578063c15ce4d714610409578063c3f909d41461041c57600080fd5b8063a3907d71116100bd578063a3907d71146103b5578063a4c0ed36146103bd578063a608a1e1146103d057600080fd5b80637fb5d19d146103845780638da5cb5b1461039757600080fd5b80633b2bcbf11161012f57806348baa1c51161011457806348baa1c5146102b157806357a8070a1461035f57806379ba50971461037c57600080fd5b80633b2bcbf1146102695780634306d3541461029057600080fd5b80631b6b6d23116101605780631b6b6d23146102005780631fe543e31461024c5780632f2770db1461026157600080fd5b8063030932bb1461017c578063181f5a77146101c1575b600080fd5b6101a37f000000000000000000000000000000000000000000000000000000000000000081565b60405167ffffffffffffffff90911681526020015b60405180910390f35b604080518082018252601281527f56524656325772617070657220312e302e300000000000000000000000000000602082015290516101b89190611d18565b6102277f000000000000000000000000000000000000000000000000000000000000000081565b60405173ffffffffffffffffffffffffffffffffffffffff90911681526020016101b8565b61025f61025a366004611a47565b6104da565b005b61025f61059a565b6102277f000000000000000000000000000000000000000000000000000000000000000081565b6102a361029e366004611b36565b6105d0565b6040519081526020016101b8565b61031b6102bf366004611a2e565b600860205260009081526040902080546001820154600283015460039093015473ffffffffffffffffffffffffffffffffffffffff8316937401000000000000000000000000000000000000000090930463ffffffff16929085565b6040805173ffffffffffffffffffffffffffffffffffffffff909616865263ffffffff9094166020860152928401919091526060830152608082015260a0016101b8565b60035461036c9060ff1681565b60405190151581526020016101b8565b61025f6106d7565b6102a3610392366004611b9e565b6107d4565b60005473ffffffffffffffffffffffffffffffffffffffff16610227565b61025f6108da565b61025f6103cb36600461190d565b61090c565b60035461036c90610100900460ff1681565b6102277f000000000000000000000000000000000000000000000000000000000000000081565b61025f610417366004611c72565b610da5565b6004546005546006546007546040805194855263ffffffff80851660208701526401000000008504811691860191909152680100000000000000008404811660608601526c01000000000000000000000000840416608085015260ff700100000000000000000000000000000000909304831660a085015260c08401919091521660e0820152610100016101b8565b61025f6104b93660046118c8565b611150565b61025f6104cc3660046118e3565b611164565b6102a360025481565b3373ffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000000000000000000000000000000000161461058c576040517f1cf993f400000000000000000000000000000000000000000000000000000000815233600482015273ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001660248201526044015b60405180910390fd5b6105968282611239565b5050565b6105a2611444565b600380547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00ff16610100179055565b60035460009060ff1661063f576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601960248201527f77726170706572206973206e6f7420636f6e66696775726564000000000000006044820152606401610583565b600354610100900460ff16156106b1576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601360248201527f777261707065722069732064697361626c6564000000000000000000000000006044820152606401610583565b60006106bb6114c7565b90506106ce8363ffffffff163a8361163b565b9150505b919050565b60015473ffffffffffffffffffffffffffffffffffffffff163314610758576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601660248201527f4d7573742062652070726f706f736564206f776e6572000000000000000000006044820152606401610583565b60008054337fffffffffffffffffffffffff00000000000000000000000000000000000000008083168217845560018054909116905560405173ffffffffffffffffffffffffffffffffffffffff90921692909183917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e091a350565b60035460009060ff16610843576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601960248201527f77726170706572206973206e6f7420636f6e66696775726564000000000000006044820152606401610583565b600354610100900460ff16156108b5576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601360248201527f777261707065722069732064697361626c6564000000000000000000000000006044820152606401610583565b60006108bf6114c7565b90506108d28463ffffffff16848361163b565b949350505050565b6108e2611444565b600380547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00ff169055565b60035460ff16610978576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601960248201527f77726170706572206973206e6f7420636f6e66696775726564000000000000006044820152606401610583565b600354610100900460ff16156109ea576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601360248201527f777261707065722069732064697361626c6564000000000000000000000000006044820152606401610583565b3373ffffffffffffffffffffffffffffffffffffffff7f00000000000000000000000000000000000000000000000000000000000000001614610a89576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601760248201527f6f6e6c792063616c6c61626c652066726f6d204c494e4b0000000000000000006044820152606401610583565b60008080610a9984860186611b53565b9250925092506000610aa96114c7565b90506000610abe8563ffffffff163a8461163b565b905080881015610b2a576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152600b60248201527f66656520746f6f206c6f770000000000000000000000000000000000000000006044820152606401610583565b60075460ff1663ffffffff84161115610b9f576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601160248201527f6e756d576f72647320746f6f20686967680000000000000000000000000000006044820152606401610583565b60007f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16635d3b1d306006547f000000000000000000000000000000000000000000000000000000000000000088600560089054906101000a900463ffffffff168b610c209190611df1565b6040517fffffffff0000000000000000000000000000000000000000000000000000000060e087901b168152600481019490945267ffffffffffffffff909216602484015261ffff16604483015263ffffffff90811660648301528716608482015260a401602060405180830381600087803b158015610c9f57600080fd5b505af1158015610cb3573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610cd791906119b6565b6040805160a08101825273ffffffffffffffffffffffffffffffffffffffff9c8d16815263ffffffff98891660208083019182523a83850190815260608401988952608084019e8f52600086815260089092529390209151825491519e167fffffffffffffffff00000000000000000000000000000000000000000000000090911617740100000000000000000000000000000000000000009d9099169c909c02979097178b55955160018b0155505051600280890191909155955160039097019690965550909255505050565b610dad611444565b6005805460ff808616700100000000000000000000000000000000027fffffffffffffffffffffffffffffff00ffffffffffffffffffffffffffffffff63ffffffff8981166c01000000000000000000000000027fffffffffffffffffffffffffffffffff00000000ffffffffffffffffffffffff918c166801000000000000000002919091167fffffffffffffffffffffffffffffffff0000000000000000ffffffffffffffff909516949094179390931792909216919091179091556006839055600780549183167fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00928316179055600380549091166001179055604080517fc3f909d4000000000000000000000000000000000000000000000000000000008152905173ffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000000000000000000000000000000000169163c3f909d4916004828101926080929190829003018186803b158015610f3057600080fd5b505afa158015610f44573d6000803e3d6000fd5b505050506040513d601f19601f82011682018060405250810190610f6891906119cf565b50600580547fffffffffffffffffffffffffffffffffffffffffffffffffffffffff000000001663ffffffff929092169190911790555050604080517f356dac7100000000000000000000000000000000000000000000000000000000815290517f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff169163356dac71916004808301926020929190829003018186803b15801561102657600080fd5b505afa15801561103a573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061105e91906119b6565b6004819055507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16635fbbc0d26040518163ffffffff1660e01b81526004016101206040518083038186803b1580156110cb57600080fd5b505afa1580156110df573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906111039190611bbc565b50506005805463ffffffff909816640100000000027fffffffffffffffffffffffffffffffffffffffffffffffff00000000ffffffff909816979097179096555050505050505050505050565b611158611444565b61116181611724565b50565b61116c611444565b6040517fa9059cbb00000000000000000000000000000000000000000000000000000000815273ffffffffffffffffffffffffffffffffffffffff8381166004830152602482018390527f0000000000000000000000000000000000000000000000000000000000000000169063a9059cbb90604401602060405180830381600087803b1580156111fc57600080fd5b505af1158015611210573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906112349190611994565b505050565b6000828152600860208181526040808420815160a081018352815473ffffffffffffffffffffffffffffffffffffffff808216835263ffffffff740100000000000000000000000000000000000000008304168387015260018401805495840195909552600284018054606085015260038501805460808601528b8a52979096527fffffffffffffffff000000000000000000000000000000000000000000000000909116909255918590559184905592909155815116611356576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601160248201527f72657175657374206e6f7420666f756e640000000000000000000000000000006044820152606401610583565b600080631fe543e360e01b8585604051602401611374929190611d8b565b604051602081830303815290604052907bffffffffffffffffffffffffffffffffffffffffffffffffffffffff19166020820180517bffffffffffffffffffffffffffffffffffffffffffffffffffffffff8381831617835250505050905060006113ee846020015163ffffffff1685600001518461181a565b90508061143c57835160405173ffffffffffffffffffffffffffffffffffffffff9091169087907fc551b83c151f2d1c7eeb938ac59008e0409f1c1dc1e2f112449d4d79b458902290600090a35b505050505050565b60005473ffffffffffffffffffffffffffffffffffffffff1633146114c5576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601660248201527f4f6e6c792063616c6c61626c65206279206f776e6572000000000000000000006044820152606401610583565b565b600554604080517ffeaf968c000000000000000000000000000000000000000000000000000000008152905160009263ffffffff161515918391829173ffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000000000000000000000000000000000169163feaf968c9160048082019260a092909190829003018186803b15801561156157600080fd5b505afa158015611575573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906115999190611cd4565b5094509092508491505080156115bf57506115b48242611eb6565b60055463ffffffff16105b156115c957506004545b6000811215611634576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601660248201527f496e76616c6964204c494e4b20776569207072696365000000000000000000006044820152606401610583565b9392505050565b6005546000908190839063ffffffff6c01000000000000000000000000820481169161167591680100000000000000009091041688611dd9565b61167f9190611dd9565b61169186670de0b6b3a7640000611e79565b61169b9190611e79565b6116a59190611e3e565b6005549091506000906064906116d290700100000000000000000000000000000000900460ff1682611e19565b6116df9060ff1684611e79565b6116e99190611e3e565b60055490915060009061170f90640100000000900463ffffffff1664e8d4a51000611e79565b6117199083611dd9565b979650505050505050565b73ffffffffffffffffffffffffffffffffffffffff81163314156117a4576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601760248201527f43616e6e6f74207472616e7366657220746f2073656c660000000000000000006044820152606401610583565b600180547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff83811691821790925560008054604051929316917fed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae12789190a350565b60005a61138881101561182c57600080fd5b61138881039050846040820482031161184457600080fd5b50823b61185057600080fd5b60008083516020850160008789f1949350505050565b803573ffffffffffffffffffffffffffffffffffffffff811681146106d257600080fd5b805162ffffff811681146106d257600080fd5b803560ff811681146106d257600080fd5b805169ffffffffffffffffffff811681146106d257600080fd5b6000602082840312156118da57600080fd5b61163482611866565b600080604083850312156118f657600080fd5b6118ff83611866565b946020939093013593505050565b6000806000806060858703121561192357600080fd5b61192c85611866565b935060208501359250604085013567ffffffffffffffff8082111561195057600080fd5b818701915087601f83011261196457600080fd5b81358181111561197357600080fd5b88602082850101111561198557600080fd5b95989497505060200194505050565b6000602082840312156119a657600080fd5b8151801515811461163457600080fd5b6000602082840312156119c857600080fd5b5051919050565b600080600080608085870312156119e557600080fd5b84516119f081611f2b565b6020860151909450611a0181611f3b565b6040860151909350611a1281611f3b565b6060860151909250611a2381611f3b565b939692955090935050565b600060208284031215611a4057600080fd5b5035919050565b60008060408385031215611a5a57600080fd5b8235915060208084013567ffffffffffffffff80821115611a7a57600080fd5b818601915086601f830112611a8e57600080fd5b813581811115611aa057611aa0611efc565b8060051b6040517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0603f83011681018181108582111715611ae357611ae3611efc565b604052828152858101935084860182860187018b1015611b0257600080fd5b600095505b83861015611b25578035855260019590950194938601938601611b07565b508096505050505050509250929050565b600060208284031215611b4857600080fd5b813561163481611f3b565b600080600060608486031215611b6857600080fd5b8335611b7381611f3b565b92506020840135611b8381611f2b565b91506040840135611b9381611f3b565b809150509250925092565b60008060408385031215611bb157600080fd5b82356118ff81611f3b565b60008060008060008060008060006101208a8c031215611bdb57600080fd5b8951611be681611f3b565b60208b0151909950611bf781611f3b565b60408b0151909850611c0881611f3b565b60608b0151909750611c1981611f3b565b60808b0151909650611c2a81611f3b565b9450611c3860a08b0161188a565b9350611c4660c08b0161188a565b9250611c5460e08b0161188a565b9150611c636101008b0161188a565b90509295985092959850929598565b600080600080600060a08688031215611c8a57600080fd5b8535611c9581611f3b565b94506020860135611ca581611f3b565b9350611cb36040870161189d565b925060608601359150611cc86080870161189d565b90509295509295909350565b600080600080600060a08688031215611cec57600080fd5b611cf5866118ae565b9450602086015193506040860151925060608601519150611cc8608087016118ae565b600060208083528351808285015260005b81811015611d4557858101830151858201604001528201611d29565b81811115611d57576000604083870101525b50601f017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe016929092016040019392505050565b6000604082018483526020604081850152818551808452606086019150828701935060005b81811015611dcc57845183529383019391830191600101611db0565b5090979650505050505050565b60008219821115611dec57611dec611ecd565b500190565b600063ffffffff808316818516808303821115611e1057611e10611ecd565b01949350505050565b600060ff821660ff84168060ff03821115611e3657611e36611ecd565b019392505050565b600082611e74577f4e487b7100000000000000000000000000000000000000000000000000000000600052601260045260246000fd5b500490565b6000817fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff0483118215151615611eb157611eb1611ecd565b500290565b600082821015611ec857611ec8611ecd565b500390565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052601160045260246000fd5b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fd5b61ffff8116811461116157600080fd5b63ffffffff8116811461116157600080fdfea164736f6c6343000806000a",
+}
+
+var VRFV2WrapperABI = VRFV2WrapperMetaData.ABI
+
+var VRFV2WrapperBin = VRFV2WrapperMetaData.Bin
+
+func DeployVRFV2Wrapper(auth *bind.TransactOpts, backend bind.ContractBackend, _link common.Address, _linkEthFeed common.Address, _coordinator common.Address) (common.Address, *types.Transaction, *VRFV2Wrapper, error) {
+	parsed, err := VRFV2WrapperMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(VRFV2WrapperBin), backend, _link, _linkEthFeed, _coordinator)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &VRFV2Wrapper{VRFV2WrapperCaller: VRFV2WrapperCaller{contract: contract}, VRFV2WrapperTransactor: VRFV2WrapperTransactor{contract: contract}, VRFV2WrapperFilterer: VRFV2WrapperFilterer{contract: contract}}, nil
+}
+
+type VRFV2Wrapper struct {
+	address common.Address
+	abi     abi.ABI
+	VRFV2WrapperCaller
+	VRFV2WrapperTransactor
+	VRFV2WrapperFilterer
+}
+
+type VRFV2WrapperCaller struct {
+	contract *bind.BoundContract
+}
+
+type VRFV2WrapperTransactor struct {
+	contract *bind.BoundContract
+}
+
+type VRFV2WrapperFilterer struct {
+	contract *bind.BoundContract
+}
+
+type VRFV2WrapperSession struct {
+	Contract     *VRFV2Wrapper
+	CallOpts     bind.CallOpts
+	TransactOpts bind.TransactOpts
+}
+
+type VRFV2WrapperCallerSession struct {
+	Contract *VRFV2WrapperCaller
+	CallOpts bind.CallOpts
+}
+
+type VRFV2WrapperTransactorSession struct {
+	Contract     *VRFV2WrapperTransactor
+	TransactOpts bind.TransactOpts
+}
+
+type VRFV2WrapperRaw struct {
+	Contract *VRFV2Wrapper
+}
+
+type VRFV2WrapperCallerRaw struct {
+	Contract *VRFV2WrapperCaller
+}
+
+type VRFV2WrapperTransactorRaw struct {
+	Contract *VRFV2WrapperTransactor
+}
+
+func NewVRFV2Wrapper(address common.Address, backend bind.ContractBackend) (*VRFV2Wrapper, error) {
+	abi, err := abi.JSON(strings.NewReader(VRFV2WrapperABI))
+	if err != nil {
+		return nil, err
+	}
+	contract, err := bindVRFV2Wrapper(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2Wrapper{address: address, abi: abi, VRFV2WrapperCaller: VRFV2WrapperCaller{contract: contract}, VRFV2WrapperTransactor: VRFV2WrapperTransactor{contract: contract}, VRFV2WrapperFilterer: VRFV2WrapperFilterer{contract: contract}}, nil
+}
+
+func NewVRFV2WrapperCaller(address common.Address, caller bind.ContractCaller) (*VRFV2WrapperCaller, error) {
+	contract, err := bindVRFV2Wrapper(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperCaller{contract: contract}, nil
+}
+
+func NewVRFV2WrapperTransactor(address common.Address, transactor bind.ContractTransactor) (*VRFV2WrapperTransactor, error) {
+	contract, err := bindVRFV2Wrapper(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperTransactor{contract: contract}, nil
+}
+
+func NewVRFV2WrapperFilterer(address common.Address, filterer bind.ContractFilterer) (*VRFV2WrapperFilterer, error) {
+	contract, err := bindVRFV2Wrapper(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperFilterer{contract: contract}, nil
+}
+
+func bindVRFV2Wrapper(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(VRFV2WrapperABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _VRFV2Wrapper.Contract.VRFV2WrapperCaller.contract.Call(opts, result, method, params...)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.VRFV2WrapperTransactor.contract.Transfer(opts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.VRFV2WrapperTransactor.contract.Transact(opts, method, params...)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _VRFV2Wrapper.Contract.contract.Call(opts, result, method, params...)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.contract.Transfer(opts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.contract.Transact(opts, method, params...)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCaller) COORDINATOR(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _VRFV2Wrapper.contract.Call(opts, &out, "COORDINATOR")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) COORDINATOR() (common.Address, error) {
+	return _VRFV2Wrapper.Contract.COORDINATOR(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCallerSession) COORDINATOR() (common.Address, error) {
+	return _VRFV2Wrapper.Contract.COORDINATOR(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCaller) LINK(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _VRFV2Wrapper.contract.Call(opts, &out, "LINK")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) LINK() (common.Address, error) {
+	return _VRFV2Wrapper.Contract.LINK(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCallerSession) LINK() (common.Address, error) {
+	return _VRFV2Wrapper.Contract.LINK(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCaller) LINKETHFEED(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _VRFV2Wrapper.contract.Call(opts, &out, "LINK_ETH_FEED")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) LINKETHFEED() (common.Address, error) {
+	return _VRFV2Wrapper.Contract.LINKETHFEED(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCallerSession) LINKETHFEED() (common.Address, error) {
+	return _VRFV2Wrapper.Contract.LINKETHFEED(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCaller) SUBSCRIPTIONID(opts *bind.CallOpts) (uint64, error) {
+	var out []interface{}
+	err := _VRFV2Wrapper.contract.Call(opts, &out, "SUBSCRIPTION_ID")
+
+	if err != nil {
+		return *new(uint64), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(uint64)).(*uint64)
+
+	return out0, err
+
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) SUBSCRIPTIONID() (uint64, error) {
+	return _VRFV2Wrapper.Contract.SUBSCRIPTIONID(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCallerSession) SUBSCRIPTIONID() (uint64, error) {
+	return _VRFV2Wrapper.Contract.SUBSCRIPTIONID(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCaller) CalculateRequestPrice(opts *bind.CallOpts, _callbackGasLimit uint32) (*big.Int, error) {
+	var out []interface{}
+	err := _VRFV2Wrapper.contract.Call(opts, &out, "calculateRequestPrice", _callbackGasLimit)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) CalculateRequestPrice(_callbackGasLimit uint32) (*big.Int, error) {
+	return _VRFV2Wrapper.Contract.CalculateRequestPrice(&_VRFV2Wrapper.CallOpts, _callbackGasLimit)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCallerSession) CalculateRequestPrice(_callbackGasLimit uint32) (*big.Int, error) {
+	return _VRFV2Wrapper.Contract.CalculateRequestPrice(&_VRFV2Wrapper.CallOpts, _callbackGasLimit)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCaller) EstimateRequestPrice(opts *bind.CallOpts, _callbackGasLimit uint32, _requestGasPriceWei *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _VRFV2Wrapper.contract.Call(opts, &out, "estimateRequestPrice", _callbackGasLimit, _requestGasPriceWei)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) EstimateRequestPrice(_callbackGasLimit uint32, _requestGasPriceWei *big.Int) (*big.Int, error) {
+	return _VRFV2Wrapper.Contract.EstimateRequestPrice(&_VRFV2Wrapper.CallOpts, _callbackGasLimit, _requestGasPriceWei)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCallerSession) EstimateRequestPrice(_callbackGasLimit uint32, _requestGasPriceWei *big.Int) (*big.Int, error) {
+	return _VRFV2Wrapper.Contract.EstimateRequestPrice(&_VRFV2Wrapper.CallOpts, _callbackGasLimit, _requestGasPriceWei)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCaller) GetConfig(opts *bind.CallOpts) (GetConfig,
+
+	error) {
+	var out []interface{}
+	err := _VRFV2Wrapper.contract.Call(opts, &out, "getConfig")
+
+	outstruct := new(GetConfig)
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.FallbackWeiPerUnitLink = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.StalenessSeconds = *abi.ConvertType(out[1], new(uint32)).(*uint32)
+	outstruct.FulfillmentFlatFeeLinkPPM = *abi.ConvertType(out[2], new(uint32)).(*uint32)
+	outstruct.WrapperGasOverhead = *abi.ConvertType(out[3], new(uint32)).(*uint32)
+	outstruct.CoordinatorGasOverhead = *abi.ConvertType(out[4], new(uint32)).(*uint32)
+	outstruct.WrapperPremiumPercentage = *abi.ConvertType(out[5], new(uint8)).(*uint8)
+	outstruct.KeyHash = *abi.ConvertType(out[6], new([32]byte)).(*[32]byte)
+	outstruct.MaxNumWords = *abi.ConvertType(out[7], new(uint8)).(*uint8)
+
+	return *outstruct, err
+
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) GetConfig() (GetConfig,
+
+	error) {
+	return _VRFV2Wrapper.Contract.GetConfig(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCallerSession) GetConfig() (GetConfig,
+
+	error) {
+	return _VRFV2Wrapper.Contract.GetConfig(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCaller) LastRequestId(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _VRFV2Wrapper.contract.Call(opts, &out, "lastRequestId")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) LastRequestId() (*big.Int, error) {
+	return _VRFV2Wrapper.Contract.LastRequestId(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCallerSession) LastRequestId() (*big.Int, error) {
+	return _VRFV2Wrapper.Contract.LastRequestId(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _VRFV2Wrapper.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) Owner() (common.Address, error) {
+	return _VRFV2Wrapper.Contract.Owner(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCallerSession) Owner() (common.Address, error) {
+	return _VRFV2Wrapper.Contract.Owner(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCaller) SCallbacks(opts *bind.CallOpts, arg0 *big.Int) (SCallbacks,
+
+	error) {
+	var out []interface{}
+	err := _VRFV2Wrapper.contract.Call(opts, &out, "s_callbacks", arg0)
+
+	outstruct := new(SCallbacks)
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.CallbackAddress = *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+	outstruct.CallbackGasLimit = *abi.ConvertType(out[1], new(uint32)).(*uint32)
+	outstruct.RequestGasPrice = *abi.ConvertType(out[2], new(*big.Int)).(**big.Int)
+	outstruct.RequestWeiPerUnitLink = *abi.ConvertType(out[3], new(*big.Int)).(**big.Int)
+	outstruct.JuelsPaid = *abi.ConvertType(out[4], new(*big.Int)).(**big.Int)
+
+	return *outstruct, err
+
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) SCallbacks(arg0 *big.Int) (SCallbacks,
+
+	error) {
+	return _VRFV2Wrapper.Contract.SCallbacks(&_VRFV2Wrapper.CallOpts, arg0)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCallerSession) SCallbacks(arg0 *big.Int) (SCallbacks,
+
+	error) {
+	return _VRFV2Wrapper.Contract.SCallbacks(&_VRFV2Wrapper.CallOpts, arg0)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCaller) SConfigured(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _VRFV2Wrapper.contract.Call(opts, &out, "s_configured")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) SConfigured() (bool, error) {
+	return _VRFV2Wrapper.Contract.SConfigured(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCallerSession) SConfigured() (bool, error) {
+	return _VRFV2Wrapper.Contract.SConfigured(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCaller) SDisabled(opts *bind.CallOpts) (bool, error) {
+	var out []interface{}
+	err := _VRFV2Wrapper.contract.Call(opts, &out, "s_disabled")
+
+	if err != nil {
+		return *new(bool), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(bool)).(*bool)
+
+	return out0, err
+
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) SDisabled() (bool, error) {
+	return _VRFV2Wrapper.Contract.SDisabled(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCallerSession) SDisabled() (bool, error) {
+	return _VRFV2Wrapper.Contract.SDisabled(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCaller) TypeAndVersion(opts *bind.CallOpts) (string, error) {
+	var out []interface{}
+	err := _VRFV2Wrapper.contract.Call(opts, &out, "typeAndVersion")
+
+	if err != nil {
+		return *new(string), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(string)).(*string)
+
+	return out0, err
+
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) TypeAndVersion() (string, error) {
+	return _VRFV2Wrapper.Contract.TypeAndVersion(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperCallerSession) TypeAndVersion() (string, error) {
+	return _VRFV2Wrapper.Contract.TypeAndVersion(&_VRFV2Wrapper.CallOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _VRFV2Wrapper.contract.Transact(opts, "acceptOwnership")
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) AcceptOwnership() (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.AcceptOwnership(&_VRFV2Wrapper.TransactOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.AcceptOwnership(&_VRFV2Wrapper.TransactOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactor) Disable(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _VRFV2Wrapper.contract.Transact(opts, "disable")
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) Disable() (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.Disable(&_VRFV2Wrapper.TransactOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactorSession) Disable() (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.Disable(&_VRFV2Wrapper.TransactOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactor) Enable(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _VRFV2Wrapper.contract.Transact(opts, "enable")
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) Enable() (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.Enable(&_VRFV2Wrapper.TransactOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactorSession) Enable() (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.Enable(&_VRFV2Wrapper.TransactOpts)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactor) OnTokenTransfer(opts *bind.TransactOpts, _sender common.Address, _amount *big.Int, _data []byte) (*types.Transaction, error) {
+	return _VRFV2Wrapper.contract.Transact(opts, "onTokenTransfer", _sender, _amount, _data)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) OnTokenTransfer(_sender common.Address, _amount *big.Int, _data []byte) (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.OnTokenTransfer(&_VRFV2Wrapper.TransactOpts, _sender, _amount, _data)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactorSession) OnTokenTransfer(_sender common.Address, _amount *big.Int, _data []byte) (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.OnTokenTransfer(&_VRFV2Wrapper.TransactOpts, _sender, _amount, _data)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactor) RawFulfillRandomWords(opts *bind.TransactOpts, requestId *big.Int, randomWords []*big.Int) (*types.Transaction, error) {
+	return _VRFV2Wrapper.contract.Transact(opts, "rawFulfillRandomWords", requestId, randomWords)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) RawFulfillRandomWords(requestId *big.Int, randomWords []*big.Int) (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.RawFulfillRandomWords(&_VRFV2Wrapper.TransactOpts, requestId, randomWords)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactorSession) RawFulfillRandomWords(requestId *big.Int, randomWords []*big.Int) (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.RawFulfillRandomWords(&_VRFV2Wrapper.TransactOpts, requestId, randomWords)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactor) SetConfig(opts *bind.TransactOpts, _wrapperGasOverhead uint32, _coordinatorGasOverhead uint32, _wrapperPremiumPercentage uint8, _keyHash [32]byte, _maxNumWords uint8) (*types.Transaction, error) {
+	return _VRFV2Wrapper.contract.Transact(opts, "setConfig", _wrapperGasOverhead, _coordinatorGasOverhead, _wrapperPremiumPercentage, _keyHash, _maxNumWords)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) SetConfig(_wrapperGasOverhead uint32, _coordinatorGasOverhead uint32, _wrapperPremiumPercentage uint8, _keyHash [32]byte, _maxNumWords uint8) (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.SetConfig(&_VRFV2Wrapper.TransactOpts, _wrapperGasOverhead, _coordinatorGasOverhead, _wrapperPremiumPercentage, _keyHash, _maxNumWords)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactorSession) SetConfig(_wrapperGasOverhead uint32, _coordinatorGasOverhead uint32, _wrapperPremiumPercentage uint8, _keyHash [32]byte, _maxNumWords uint8) (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.SetConfig(&_VRFV2Wrapper.TransactOpts, _wrapperGasOverhead, _coordinatorGasOverhead, _wrapperPremiumPercentage, _keyHash, _maxNumWords)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactor) TransferOwnership(opts *bind.TransactOpts, to common.Address) (*types.Transaction, error) {
+	return _VRFV2Wrapper.contract.Transact(opts, "transferOwnership", to)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) TransferOwnership(to common.Address) (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.TransferOwnership(&_VRFV2Wrapper.TransactOpts, to)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactorSession) TransferOwnership(to common.Address) (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.TransferOwnership(&_VRFV2Wrapper.TransactOpts, to)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactor) Withdraw(opts *bind.TransactOpts, _recipient common.Address, _amount *big.Int) (*types.Transaction, error) {
+	return _VRFV2Wrapper.contract.Transact(opts, "withdraw", _recipient, _amount)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperSession) Withdraw(_recipient common.Address, _amount *big.Int) (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.Withdraw(&_VRFV2Wrapper.TransactOpts, _recipient, _amount)
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperTransactorSession) Withdraw(_recipient common.Address, _amount *big.Int) (*types.Transaction, error) {
+	return _VRFV2Wrapper.Contract.Withdraw(&_VRFV2Wrapper.TransactOpts, _recipient, _amount)
+}
+
+type VRFV2WrapperOwnershipTransferRequestedIterator struct {
+	Event *VRFV2WrapperOwnershipTransferRequested
+
+	contract *bind.BoundContract
+	event    string
+
+	logs chan types.Log
+	sub  ethereum.Subscription
+	done bool
+	fail error
+}
+
+func (it *VRFV2WrapperOwnershipTransferRequestedIterator) Next() bool {
+
+	if it.fail != nil {
+		return false
+	}
+
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(VRFV2WrapperOwnershipTransferRequested)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+
+	select {
+	case log := <-it.logs:
+		it.Event = new(VRFV2WrapperOwnershipTransferRequested)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+func (it *VRFV2WrapperOwnershipTransferRequestedIterator) Error() error {
+	return it.fail
+}
+
+func (it *VRFV2WrapperOwnershipTransferRequestedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+type VRFV2WrapperOwnershipTransferRequested struct {
+	From common.Address
+	To   common.Address
+	Raw  types.Log
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperFilterer) FilterOwnershipTransferRequested(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*VRFV2WrapperOwnershipTransferRequestedIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _VRFV2Wrapper.contract.FilterLogs(opts, "OwnershipTransferRequested", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperOwnershipTransferRequestedIterator{contract: _VRFV2Wrapper.contract, event: "OwnershipTransferRequested", logs: logs, sub: sub}, nil
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperFilterer) WatchOwnershipTransferRequested(opts *bind.WatchOpts, sink chan<- *VRFV2WrapperOwnershipTransferRequested, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _VRFV2Wrapper.contract.WatchLogs(opts, "OwnershipTransferRequested", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+
+				event := new(VRFV2WrapperOwnershipTransferRequested)
+				if err := _VRFV2Wrapper.contract.UnpackLog(event, "OwnershipTransferRequested", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperFilterer) ParseOwnershipTransferRequested(log types.Log) (*VRFV2WrapperOwnershipTransferRequested, error) {
+	event := new(VRFV2WrapperOwnershipTransferRequested)
+	if err := _VRFV2Wrapper.contract.UnpackLog(event, "OwnershipTransferRequested", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+type VRFV2WrapperOwnershipTransferredIterator struct {
+	Event *VRFV2WrapperOwnershipTransferred
+
+	contract *bind.BoundContract
+	event    string
+
+	logs chan types.Log
+	sub  ethereum.Subscription
+	done bool
+	fail error
+}
+
+func (it *VRFV2WrapperOwnershipTransferredIterator) Next() bool {
+
+	if it.fail != nil {
+		return false
+	}
+
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(VRFV2WrapperOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+
+	select {
+	case log := <-it.logs:
+		it.Event = new(VRFV2WrapperOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+func (it *VRFV2WrapperOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+func (it *VRFV2WrapperOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+type VRFV2WrapperOwnershipTransferred struct {
+	From common.Address
+	To   common.Address
+	Raw  types.Log
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*VRFV2WrapperOwnershipTransferredIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _VRFV2Wrapper.contract.FilterLogs(opts, "OwnershipTransferred", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperOwnershipTransferredIterator{contract: _VRFV2Wrapper.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *VRFV2WrapperOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _VRFV2Wrapper.contract.WatchLogs(opts, "OwnershipTransferred", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+
+				event := new(VRFV2WrapperOwnershipTransferred)
+				if err := _VRFV2Wrapper.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperFilterer) ParseOwnershipTransferred(log types.Log) (*VRFV2WrapperOwnershipTransferred, error) {
+	event := new(VRFV2WrapperOwnershipTransferred)
+	if err := _VRFV2Wrapper.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+type VRFV2WrapperWrapperFulfillmentFailedIterator struct {
+	Event *VRFV2WrapperWrapperFulfillmentFailed
+
+	contract *bind.BoundContract
+	event    string
+
+	logs chan types.Log
+	sub  ethereum.Subscription
+	done bool
+	fail error
+}
+
+func (it *VRFV2WrapperWrapperFulfillmentFailedIterator) Next() bool {
+
+	if it.fail != nil {
+		return false
+	}
+
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(VRFV2WrapperWrapperFulfillmentFailed)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+
+	select {
+	case log := <-it.logs:
+		it.Event = new(VRFV2WrapperWrapperFulfillmentFailed)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+func (it *VRFV2WrapperWrapperFulfillmentFailedIterator) Error() error {
+	return it.fail
+}
+
+func (it *VRFV2WrapperWrapperFulfillmentFailedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+type VRFV2WrapperWrapperFulfillmentFailed struct {
+	RequestId *big.Int
+	Consumer  common.Address
+	Raw       types.Log
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperFilterer) FilterWrapperFulfillmentFailed(opts *bind.FilterOpts, requestId []*big.Int, consumer []common.Address) (*VRFV2WrapperWrapperFulfillmentFailedIterator, error) {
+
+	var requestIdRule []interface{}
+	for _, requestIdItem := range requestId {
+		requestIdRule = append(requestIdRule, requestIdItem)
+	}
+	var consumerRule []interface{}
+	for _, consumerItem := range consumer {
+		consumerRule = append(consumerRule, consumerItem)
+	}
+
+	logs, sub, err := _VRFV2Wrapper.contract.FilterLogs(opts, "WrapperFulfillmentFailed", requestIdRule, consumerRule)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperWrapperFulfillmentFailedIterator{contract: _VRFV2Wrapper.contract, event: "WrapperFulfillmentFailed", logs: logs, sub: sub}, nil
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperFilterer) WatchWrapperFulfillmentFailed(opts *bind.WatchOpts, sink chan<- *VRFV2WrapperWrapperFulfillmentFailed, requestId []*big.Int, consumer []common.Address) (event.Subscription, error) {
+
+	var requestIdRule []interface{}
+	for _, requestIdItem := range requestId {
+		requestIdRule = append(requestIdRule, requestIdItem)
+	}
+	var consumerRule []interface{}
+	for _, consumerItem := range consumer {
+		consumerRule = append(consumerRule, consumerItem)
+	}
+
+	logs, sub, err := _VRFV2Wrapper.contract.WatchLogs(opts, "WrapperFulfillmentFailed", requestIdRule, consumerRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+
+				event := new(VRFV2WrapperWrapperFulfillmentFailed)
+				if err := _VRFV2Wrapper.contract.UnpackLog(event, "WrapperFulfillmentFailed", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+func (_VRFV2Wrapper *VRFV2WrapperFilterer) ParseWrapperFulfillmentFailed(log types.Log) (*VRFV2WrapperWrapperFulfillmentFailed, error) {
+	event := new(VRFV2WrapperWrapperFulfillmentFailed)
+	if err := _VRFV2Wrapper.contract.UnpackLog(event, "WrapperFulfillmentFailed", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+type GetConfig struct {
+	FallbackWeiPerUnitLink    *big.Int
+	StalenessSeconds          uint32
+	FulfillmentFlatFeeLinkPPM uint32
+	WrapperGasOverhead        uint32
+	CoordinatorGasOverhead    uint32
+	WrapperPremiumPercentage  uint8
+	KeyHash                   [32]byte
+	MaxNumWords               uint8
+}
+type SCallbacks struct {
+	CallbackAddress       common.Address
+	CallbackGasLimit      uint32
+	RequestGasPrice       *big.Int
+	RequestWeiPerUnitLink *big.Int
+	JuelsPaid             *big.Int
+}
+
+func (_VRFV2Wrapper *VRFV2Wrapper) ParseLog(log types.Log) (generated.AbigenLog, error) {
+	switch log.Topics[0] {
+	case _VRFV2Wrapper.abi.Events["OwnershipTransferRequested"].ID:
+		return _VRFV2Wrapper.ParseOwnershipTransferRequested(log)
+	case _VRFV2Wrapper.abi.Events["OwnershipTransferred"].ID:
+		return _VRFV2Wrapper.ParseOwnershipTransferred(log)
+	case _VRFV2Wrapper.abi.Events["WrapperFulfillmentFailed"].ID:
+		return _VRFV2Wrapper.ParseWrapperFulfillmentFailed(log)
+
+	default:
+		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
+	}
+}
+
+func (VRFV2WrapperOwnershipTransferRequested) Topic() common.Hash {
+	return common.HexToHash("0xed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae1278")
+}
+
+func (VRFV2WrapperOwnershipTransferred) Topic() common.Hash {
+	return common.HexToHash("0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0")
+}
+
+func (VRFV2WrapperWrapperFulfillmentFailed) Topic() common.Hash {
+	return common.HexToHash("0xc551b83c151f2d1c7eeb938ac59008e0409f1c1dc1e2f112449d4d79b4589022")
+}
+
+func (_VRFV2Wrapper *VRFV2Wrapper) Address() common.Address {
+	return _VRFV2Wrapper.address
+}
+
+type VRFV2WrapperInterface interface {
+	COORDINATOR(opts *bind.CallOpts) (common.Address, error)
+
+	LINK(opts *bind.CallOpts) (common.Address, error)
+
+	LINKETHFEED(opts *bind.CallOpts) (common.Address, error)
+
+	SUBSCRIPTIONID(opts *bind.CallOpts) (uint64, error)
+
+	CalculateRequestPrice(opts *bind.CallOpts, _callbackGasLimit uint32) (*big.Int, error)
+
+	EstimateRequestPrice(opts *bind.CallOpts, _callbackGasLimit uint32, _requestGasPriceWei *big.Int) (*big.Int, error)
+
+	GetConfig(opts *bind.CallOpts) (GetConfig,
+
+		error)
+
+	LastRequestId(opts *bind.CallOpts) (*big.Int, error)
+
+	Owner(opts *bind.CallOpts) (common.Address, error)
+
+	SCallbacks(opts *bind.CallOpts, arg0 *big.Int) (SCallbacks,
+
+		error)
+
+	SConfigured(opts *bind.CallOpts) (bool, error)
+
+	SDisabled(opts *bind.CallOpts) (bool, error)
+
+	TypeAndVersion(opts *bind.CallOpts) (string, error)
+
+	AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error)
+
+	Disable(opts *bind.TransactOpts) (*types.Transaction, error)
+
+	Enable(opts *bind.TransactOpts) (*types.Transaction, error)
+
+	OnTokenTransfer(opts *bind.TransactOpts, _sender common.Address, _amount *big.Int, _data []byte) (*types.Transaction, error)
+
+	RawFulfillRandomWords(opts *bind.TransactOpts, requestId *big.Int, randomWords []*big.Int) (*types.Transaction, error)
+
+	SetConfig(opts *bind.TransactOpts, _wrapperGasOverhead uint32, _coordinatorGasOverhead uint32, _wrapperPremiumPercentage uint8, _keyHash [32]byte, _maxNumWords uint8) (*types.Transaction, error)
+
+	TransferOwnership(opts *bind.TransactOpts, to common.Address) (*types.Transaction, error)
+
+	Withdraw(opts *bind.TransactOpts, _recipient common.Address, _amount *big.Int) (*types.Transaction, error)
+
+	FilterOwnershipTransferRequested(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*VRFV2WrapperOwnershipTransferRequestedIterator, error)
+
+	WatchOwnershipTransferRequested(opts *bind.WatchOpts, sink chan<- *VRFV2WrapperOwnershipTransferRequested, from []common.Address, to []common.Address) (event.Subscription, error)
+
+	ParseOwnershipTransferRequested(log types.Log) (*VRFV2WrapperOwnershipTransferRequested, error)
+
+	FilterOwnershipTransferred(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*VRFV2WrapperOwnershipTransferredIterator, error)
+
+	WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *VRFV2WrapperOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error)
+
+	ParseOwnershipTransferred(log types.Log) (*VRFV2WrapperOwnershipTransferred, error)
+
+	FilterWrapperFulfillmentFailed(opts *bind.FilterOpts, requestId []*big.Int, consumer []common.Address) (*VRFV2WrapperWrapperFulfillmentFailedIterator, error)
+
+	WatchWrapperFulfillmentFailed(opts *bind.WatchOpts, sink chan<- *VRFV2WrapperWrapperFulfillmentFailed, requestId []*big.Int, consumer []common.Address) (event.Subscription, error)
+
+	ParseWrapperFulfillmentFailed(log types.Log) (*VRFV2WrapperWrapperFulfillmentFailed, error)
+
+	ParseLog(log types.Log) (generated.AbigenLog, error)
+
+	Address() common.Address
+}

--- a/core/internal/gethwrappers/generated/vrfv2_wrapper_consumer_example/vrfv2_wrapper_consumer_example.go
+++ b/core/internal/gethwrappers/generated/vrfv2_wrapper_consumer_example/vrfv2_wrapper_consumer_example.go
@@ -1,0 +1,775 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package vrfv2_wrapper_consumer_example
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated"
+)
+
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+var VRFV2WrapperConsumerExampleMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"address\",\"name\":\"_link\",\"type\":\"address\"},{\"internalType\":\"address\",\"name\":\"_vrfV2Wrapper\",\"type\":\"address\"}],\"stateMutability\":\"nonpayable\",\"type\":\"constructor\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"OwnershipTransferRequested\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":true,\"internalType\":\"address\",\"name\":\"from\",\"type\":\"address\"},{\"indexed\":true,\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"OwnershipTransferred\",\"type\":\"event\"},{\"anonymous\":false,\"inputs\":[{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"requestId\",\"type\":\"uint256\"},{\"indexed\":false,\"internalType\":\"uint256[]\",\"name\":\"randomWords\",\"type\":\"uint256[]\"},{\"indexed\":false,\"internalType\":\"uint256\",\"name\":\"payment\",\"type\":\"uint256\"}],\"name\":\"WrappedRequestFulfilled\",\"type\":\"event\"},{\"inputs\":[],\"name\":\"acceptOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_requestId\",\"type\":\"uint256\"}],\"name\":\"getRequestStatus\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"paid\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"fulfilled\",\"type\":\"bool\"},{\"internalType\":\"uint256[]\",\"name\":\"randomWords\",\"type\":\"uint256[]\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_callbackGasLimit\",\"type\":\"uint32\"},{\"internalType\":\"uint16\",\"name\":\"_requestConfirmations\",\"type\":\"uint16\"},{\"internalType\":\"uint32\",\"name\":\"_numWords\",\"type\":\"uint32\"}],\"name\":\"makeRequest\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"requestId\",\"type\":\"uint256\"}],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"owner\",\"outputs\":[{\"internalType\":\"address\",\"name\":\"\",\"type\":\"address\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"_requestId\",\"type\":\"uint256\"},{\"internalType\":\"uint256[]\",\"name\":\"_randomWords\",\"type\":\"uint256[]\"}],\"name\":\"rawFulfillRandomWords\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"name\":\"s_requests\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"paid\",\"type\":\"uint256\"},{\"internalType\":\"bool\",\"name\":\"fulfilled\",\"type\":\"bool\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"address\",\"name\":\"to\",\"type\":\"address\"}],\"name\":\"transferOwnership\",\"outputs\":[],\"stateMutability\":\"nonpayable\",\"type\":\"function\"}]",
+	Bin: "0x60c060405234801561001057600080fd5b5060405161102a38038061102a83398101604081905261002f9161019f565b6001600160601b0319606083811b821660805282901b1660a052338060008161009f5760405162461bcd60e51b815260206004820152601860248201527f43616e6e6f7420736574206f776e657220746f207a65726f000000000000000060448201526064015b60405180910390fd5b600080546001600160a01b0319166001600160a01b03848116919091179091558116156100cf576100cf816100d9565b50505050506101d2565b6001600160a01b0381163314156101325760405162461bcd60e51b815260206004820152601760248201527f43616e6e6f74207472616e7366657220746f2073656c660000000000000000006044820152606401610096565b600180546001600160a01b0319166001600160a01b0383811691821790925560008054604051929316917fed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae12789190a350565b80516001600160a01b038116811461019a57600080fd5b919050565b600080604083850312156101b257600080fd5b6101bb83610183565b91506101c960208401610183565b90509250929050565b60805160601c60a05160601c610e18610212600039600081816101b8015281816102e30152818161069901526107c00152600061066f0152610e186000f3fe608060405234801561001057600080fd5b506004361061007d5760003560e01c80638da5cb5b1161005b5780638da5cb5b146100c5578063a168fa89146100ed578063d8a4676f1461012c578063f2fde38b1461014e57600080fd5b80630c09b832146100825780631fe543e3146100a857806379ba5097146100bd575b600080fd5b610095610090366004610c6a565b610161565b6040519081526020015b60405180910390f35b6100bb6100b6366004610b7b565b6102cb565b005b6100bb61037d565b60005460405173ffffffffffffffffffffffffffffffffffffffff909116815260200161009f565b6101176100fb366004610b49565b6002602052600090815260409020805460019091015460ff1682565b6040805192835290151560208301520161009f565b61013f61013a366004610b49565b61047a565b60405161009f93929190610db2565b6100bb61015c366004610aea565b61058c565b600061016b6105a0565b610176848484610623565b6040805160608101918290527f4306d3540000000000000000000000000000000000000000000000000000000090915263ffffffff86166064820152909150807f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff16634306d3546084830160206040518083038186803b15801561020e57600080fd5b505afa158015610222573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906102469190610b62565b8152600060208083018290526040805183815280830182529381019390935284825260028082529183902084518155848201516001820180547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00169115159190911790559284015180516102c1938501929190910190610a71565b5050509392505050565b3373ffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000000000000000000000000000000000161461036f576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601f60248201527f6f6e6c792056524620563220777261707065722063616e2066756c66696c6c0060448201526064015b60405180910390fd5b6103798282610864565b5050565b60015473ffffffffffffffffffffffffffffffffffffffff1633146103fe576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601660248201527f4d7573742062652070726f706f736564206f776e6572000000000000000000006044820152606401610366565b60008054337fffffffffffffffffffffffff00000000000000000000000000000000000000008083168217845560018054909116905560405173ffffffffffffffffffffffffffffffffffffffff90921692909183917f8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e091a350565b60008181526002602052604081205481906060906104f4576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601160248201527f72657175657374206e6f7420666f756e640000000000000000000000000000006044820152606401610366565b6000848152600260208181526040808420815160608101835281548152600182015460ff161515818501529381018054835181860281018601855281815292949386019383018282801561056757602002820191906000526020600020905b815481526020019060010190808311610553575b5050509190925250508151602083015160409093015190989297509550909350505050565b6105946105a0565b61059d8161097b565b50565b60005473ffffffffffffffffffffffffffffffffffffffff163314610621576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601660248201527f4f6e6c792063616c6c61626c65206279206f776e6572000000000000000000006044820152606401610366565b565b6040517f4306d35400000000000000000000000000000000000000000000000000000000815263ffffffff8416600482015260009073ffffffffffffffffffffffffffffffffffffffff7f0000000000000000000000000000000000000000000000000000000000000000811691634000aea0917f00000000000000000000000000000000000000000000000000000000000000009190821690634306d3549060240160206040518083038186803b1580156106de57600080fd5b505afa1580156106f2573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906107169190610b62565b6040805163ffffffff808b16602083015261ffff8a169282019290925290871660608201526080016040516020818303038152906040526040518463ffffffff1660e01b815260040161076b93929190610cf1565b602060405180830381600087803b15801561078557600080fd5b505af1158015610799573d6000803e3d6000fd5b505050506040513d601f19601f820116820180604052508101906107bd9190610b27565b507f000000000000000000000000000000000000000000000000000000000000000073ffffffffffffffffffffffffffffffffffffffff1663fc2a88c36040518163ffffffff1660e01b815260040160206040518083038186803b15801561082457600080fd5b505afa158015610838573d6000803e3d6000fd5b505050506040513d601f19601f8201168201806040525081019061085c9190610b62565b949350505050565b6000828152600260205260409020546108d9576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601160248201527f72657175657374206e6f7420666f756e640000000000000000000000000000006044820152606401610366565b6000828152600260208181526040909220600181810180547fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff00169091179055835161092c93919092019190840190610a71565b50600082815260026020526040908190205490517f6c84e12b4c188e61f1b4727024a5cf05c025fa58467e5eedf763c0744c89da7b9161096f9185918591610d89565b60405180910390a15050565b73ffffffffffffffffffffffffffffffffffffffff81163314156109fb576040517f08c379a000000000000000000000000000000000000000000000000000000000815260206004820152601760248201527f43616e6e6f74207472616e7366657220746f2073656c660000000000000000006044820152606401610366565b600180547fffffffffffffffffffffffff00000000000000000000000000000000000000001673ffffffffffffffffffffffffffffffffffffffff83811691821790925560008054604051929316917fed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae12789190a350565b828054828255906000526020600020908101928215610aac579160200282015b82811115610aac578251825591602001919060010190610a91565b50610ab8929150610abc565b5090565b5b80821115610ab85760008155600101610abd565b803563ffffffff81168114610ae557600080fd5b919050565b600060208284031215610afc57600080fd5b813573ffffffffffffffffffffffffffffffffffffffff81168114610b2057600080fd5b9392505050565b600060208284031215610b3957600080fd5b81518015158114610b2057600080fd5b600060208284031215610b5b57600080fd5b5035919050565b600060208284031215610b7457600080fd5b5051919050565b60008060408385031215610b8e57600080fd5b8235915060208084013567ffffffffffffffff80821115610bae57600080fd5b818601915086601f830112610bc257600080fd5b813581811115610bd457610bd4610ddc565b8060051b6040517fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0603f83011681018181108582111715610c1757610c17610ddc565b604052828152858101935084860182860187018b1015610c3657600080fd5b600095505b83861015610c59578035855260019590950194938601938601610c3b565b508096505050505050509250929050565b600080600060608486031215610c7f57600080fd5b610c8884610ad1565b9250602084013561ffff81168114610c9f57600080fd5b9150610cad60408501610ad1565b90509250925092565b600081518084526020808501945080840160005b83811015610ce657815187529582019590820190600101610cca565b509495945050505050565b73ffffffffffffffffffffffffffffffffffffffff8416815260006020848184015260606040840152835180606085015260005b81811015610d4157858101830151858201608001528201610d25565b81811115610d53576000608083870101525b50601f017fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffe0169290920160800195945050505050565b838152606060208201526000610da26060830185610cb6565b9050826040830152949350505050565b8381528215156020820152606060408201526000610dd36060830184610cb6565b95945050505050565b7f4e487b7100000000000000000000000000000000000000000000000000000000600052604160045260246000fdfea164736f6c6343000806000a",
+}
+
+var VRFV2WrapperConsumerExampleABI = VRFV2WrapperConsumerExampleMetaData.ABI
+
+var VRFV2WrapperConsumerExampleBin = VRFV2WrapperConsumerExampleMetaData.Bin
+
+func DeployVRFV2WrapperConsumerExample(auth *bind.TransactOpts, backend bind.ContractBackend, _link common.Address, _vrfV2Wrapper common.Address) (common.Address, *types.Transaction, *VRFV2WrapperConsumerExample, error) {
+	parsed, err := VRFV2WrapperConsumerExampleMetaData.GetAbi()
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	if parsed == nil {
+		return common.Address{}, nil, nil, errors.New("GetABI returned nil")
+	}
+
+	address, tx, contract, err := bind.DeployContract(auth, *parsed, common.FromHex(VRFV2WrapperConsumerExampleBin), backend, _link, _vrfV2Wrapper)
+	if err != nil {
+		return common.Address{}, nil, nil, err
+	}
+	return address, tx, &VRFV2WrapperConsumerExample{VRFV2WrapperConsumerExampleCaller: VRFV2WrapperConsumerExampleCaller{contract: contract}, VRFV2WrapperConsumerExampleTransactor: VRFV2WrapperConsumerExampleTransactor{contract: contract}, VRFV2WrapperConsumerExampleFilterer: VRFV2WrapperConsumerExampleFilterer{contract: contract}}, nil
+}
+
+type VRFV2WrapperConsumerExample struct {
+	address common.Address
+	abi     abi.ABI
+	VRFV2WrapperConsumerExampleCaller
+	VRFV2WrapperConsumerExampleTransactor
+	VRFV2WrapperConsumerExampleFilterer
+}
+
+type VRFV2WrapperConsumerExampleCaller struct {
+	contract *bind.BoundContract
+}
+
+type VRFV2WrapperConsumerExampleTransactor struct {
+	contract *bind.BoundContract
+}
+
+type VRFV2WrapperConsumerExampleFilterer struct {
+	contract *bind.BoundContract
+}
+
+type VRFV2WrapperConsumerExampleSession struct {
+	Contract     *VRFV2WrapperConsumerExample
+	CallOpts     bind.CallOpts
+	TransactOpts bind.TransactOpts
+}
+
+type VRFV2WrapperConsumerExampleCallerSession struct {
+	Contract *VRFV2WrapperConsumerExampleCaller
+	CallOpts bind.CallOpts
+}
+
+type VRFV2WrapperConsumerExampleTransactorSession struct {
+	Contract     *VRFV2WrapperConsumerExampleTransactor
+	TransactOpts bind.TransactOpts
+}
+
+type VRFV2WrapperConsumerExampleRaw struct {
+	Contract *VRFV2WrapperConsumerExample
+}
+
+type VRFV2WrapperConsumerExampleCallerRaw struct {
+	Contract *VRFV2WrapperConsumerExampleCaller
+}
+
+type VRFV2WrapperConsumerExampleTransactorRaw struct {
+	Contract *VRFV2WrapperConsumerExampleTransactor
+}
+
+func NewVRFV2WrapperConsumerExample(address common.Address, backend bind.ContractBackend) (*VRFV2WrapperConsumerExample, error) {
+	abi, err := abi.JSON(strings.NewReader(VRFV2WrapperConsumerExampleABI))
+	if err != nil {
+		return nil, err
+	}
+	contract, err := bindVRFV2WrapperConsumerExample(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperConsumerExample{address: address, abi: abi, VRFV2WrapperConsumerExampleCaller: VRFV2WrapperConsumerExampleCaller{contract: contract}, VRFV2WrapperConsumerExampleTransactor: VRFV2WrapperConsumerExampleTransactor{contract: contract}, VRFV2WrapperConsumerExampleFilterer: VRFV2WrapperConsumerExampleFilterer{contract: contract}}, nil
+}
+
+func NewVRFV2WrapperConsumerExampleCaller(address common.Address, caller bind.ContractCaller) (*VRFV2WrapperConsumerExampleCaller, error) {
+	contract, err := bindVRFV2WrapperConsumerExample(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperConsumerExampleCaller{contract: contract}, nil
+}
+
+func NewVRFV2WrapperConsumerExampleTransactor(address common.Address, transactor bind.ContractTransactor) (*VRFV2WrapperConsumerExampleTransactor, error) {
+	contract, err := bindVRFV2WrapperConsumerExample(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperConsumerExampleTransactor{contract: contract}, nil
+}
+
+func NewVRFV2WrapperConsumerExampleFilterer(address common.Address, filterer bind.ContractFilterer) (*VRFV2WrapperConsumerExampleFilterer, error) {
+	contract, err := bindVRFV2WrapperConsumerExample(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperConsumerExampleFilterer{contract: contract}, nil
+}
+
+func bindVRFV2WrapperConsumerExample(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(VRFV2WrapperConsumerExampleABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _VRFV2WrapperConsumerExample.Contract.VRFV2WrapperConsumerExampleCaller.contract.Call(opts, result, method, params...)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.Contract.VRFV2WrapperConsumerExampleTransactor.contract.Transfer(opts)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.Contract.VRFV2WrapperConsumerExampleTransactor.contract.Transact(opts, method, params...)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _VRFV2WrapperConsumerExample.Contract.contract.Call(opts, result, method, params...)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.Contract.contract.Transfer(opts)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.Contract.contract.Transact(opts, method, params...)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleCaller) GetRequestStatus(opts *bind.CallOpts, _requestId *big.Int) (GetRequestStatus,
+
+	error) {
+	var out []interface{}
+	err := _VRFV2WrapperConsumerExample.contract.Call(opts, &out, "getRequestStatus", _requestId)
+
+	outstruct := new(GetRequestStatus)
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Paid = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Fulfilled = *abi.ConvertType(out[1], new(bool)).(*bool)
+	outstruct.RandomWords = *abi.ConvertType(out[2], new([]*big.Int)).(*[]*big.Int)
+
+	return *outstruct, err
+
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleSession) GetRequestStatus(_requestId *big.Int) (GetRequestStatus,
+
+	error) {
+	return _VRFV2WrapperConsumerExample.Contract.GetRequestStatus(&_VRFV2WrapperConsumerExample.CallOpts, _requestId)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleCallerSession) GetRequestStatus(_requestId *big.Int) (GetRequestStatus,
+
+	error) {
+	return _VRFV2WrapperConsumerExample.Contract.GetRequestStatus(&_VRFV2WrapperConsumerExample.CallOpts, _requestId)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleCaller) Owner(opts *bind.CallOpts) (common.Address, error) {
+	var out []interface{}
+	err := _VRFV2WrapperConsumerExample.contract.Call(opts, &out, "owner")
+
+	if err != nil {
+		return *new(common.Address), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(common.Address)).(*common.Address)
+
+	return out0, err
+
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleSession) Owner() (common.Address, error) {
+	return _VRFV2WrapperConsumerExample.Contract.Owner(&_VRFV2WrapperConsumerExample.CallOpts)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleCallerSession) Owner() (common.Address, error) {
+	return _VRFV2WrapperConsumerExample.Contract.Owner(&_VRFV2WrapperConsumerExample.CallOpts)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleCaller) SRequests(opts *bind.CallOpts, arg0 *big.Int) (SRequests,
+
+	error) {
+	var out []interface{}
+	err := _VRFV2WrapperConsumerExample.contract.Call(opts, &out, "s_requests", arg0)
+
+	outstruct := new(SRequests)
+	if err != nil {
+		return *outstruct, err
+	}
+
+	outstruct.Paid = *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+	outstruct.Fulfilled = *abi.ConvertType(out[1], new(bool)).(*bool)
+
+	return *outstruct, err
+
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleSession) SRequests(arg0 *big.Int) (SRequests,
+
+	error) {
+	return _VRFV2WrapperConsumerExample.Contract.SRequests(&_VRFV2WrapperConsumerExample.CallOpts, arg0)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleCallerSession) SRequests(arg0 *big.Int) (SRequests,
+
+	error) {
+	return _VRFV2WrapperConsumerExample.Contract.SRequests(&_VRFV2WrapperConsumerExample.CallOpts, arg0)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleTransactor) AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.contract.Transact(opts, "acceptOwnership")
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleSession) AcceptOwnership() (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.Contract.AcceptOwnership(&_VRFV2WrapperConsumerExample.TransactOpts)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleTransactorSession) AcceptOwnership() (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.Contract.AcceptOwnership(&_VRFV2WrapperConsumerExample.TransactOpts)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleTransactor) MakeRequest(opts *bind.TransactOpts, _callbackGasLimit uint32, _requestConfirmations uint16, _numWords uint32) (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.contract.Transact(opts, "makeRequest", _callbackGasLimit, _requestConfirmations, _numWords)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleSession) MakeRequest(_callbackGasLimit uint32, _requestConfirmations uint16, _numWords uint32) (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.Contract.MakeRequest(&_VRFV2WrapperConsumerExample.TransactOpts, _callbackGasLimit, _requestConfirmations, _numWords)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleTransactorSession) MakeRequest(_callbackGasLimit uint32, _requestConfirmations uint16, _numWords uint32) (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.Contract.MakeRequest(&_VRFV2WrapperConsumerExample.TransactOpts, _callbackGasLimit, _requestConfirmations, _numWords)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleTransactor) RawFulfillRandomWords(opts *bind.TransactOpts, _requestId *big.Int, _randomWords []*big.Int) (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.contract.Transact(opts, "rawFulfillRandomWords", _requestId, _randomWords)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleSession) RawFulfillRandomWords(_requestId *big.Int, _randomWords []*big.Int) (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.Contract.RawFulfillRandomWords(&_VRFV2WrapperConsumerExample.TransactOpts, _requestId, _randomWords)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleTransactorSession) RawFulfillRandomWords(_requestId *big.Int, _randomWords []*big.Int) (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.Contract.RawFulfillRandomWords(&_VRFV2WrapperConsumerExample.TransactOpts, _requestId, _randomWords)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleTransactor) TransferOwnership(opts *bind.TransactOpts, to common.Address) (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.contract.Transact(opts, "transferOwnership", to)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleSession) TransferOwnership(to common.Address) (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.Contract.TransferOwnership(&_VRFV2WrapperConsumerExample.TransactOpts, to)
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleTransactorSession) TransferOwnership(to common.Address) (*types.Transaction, error) {
+	return _VRFV2WrapperConsumerExample.Contract.TransferOwnership(&_VRFV2WrapperConsumerExample.TransactOpts, to)
+}
+
+type VRFV2WrapperConsumerExampleOwnershipTransferRequestedIterator struct {
+	Event *VRFV2WrapperConsumerExampleOwnershipTransferRequested
+
+	contract *bind.BoundContract
+	event    string
+
+	logs chan types.Log
+	sub  ethereum.Subscription
+	done bool
+	fail error
+}
+
+func (it *VRFV2WrapperConsumerExampleOwnershipTransferRequestedIterator) Next() bool {
+
+	if it.fail != nil {
+		return false
+	}
+
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(VRFV2WrapperConsumerExampleOwnershipTransferRequested)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+
+	select {
+	case log := <-it.logs:
+		it.Event = new(VRFV2WrapperConsumerExampleOwnershipTransferRequested)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+func (it *VRFV2WrapperConsumerExampleOwnershipTransferRequestedIterator) Error() error {
+	return it.fail
+}
+
+func (it *VRFV2WrapperConsumerExampleOwnershipTransferRequestedIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+type VRFV2WrapperConsumerExampleOwnershipTransferRequested struct {
+	From common.Address
+	To   common.Address
+	Raw  types.Log
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleFilterer) FilterOwnershipTransferRequested(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*VRFV2WrapperConsumerExampleOwnershipTransferRequestedIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _VRFV2WrapperConsumerExample.contract.FilterLogs(opts, "OwnershipTransferRequested", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperConsumerExampleOwnershipTransferRequestedIterator{contract: _VRFV2WrapperConsumerExample.contract, event: "OwnershipTransferRequested", logs: logs, sub: sub}, nil
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleFilterer) WatchOwnershipTransferRequested(opts *bind.WatchOpts, sink chan<- *VRFV2WrapperConsumerExampleOwnershipTransferRequested, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _VRFV2WrapperConsumerExample.contract.WatchLogs(opts, "OwnershipTransferRequested", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+
+				event := new(VRFV2WrapperConsumerExampleOwnershipTransferRequested)
+				if err := _VRFV2WrapperConsumerExample.contract.UnpackLog(event, "OwnershipTransferRequested", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleFilterer) ParseOwnershipTransferRequested(log types.Log) (*VRFV2WrapperConsumerExampleOwnershipTransferRequested, error) {
+	event := new(VRFV2WrapperConsumerExampleOwnershipTransferRequested)
+	if err := _VRFV2WrapperConsumerExample.contract.UnpackLog(event, "OwnershipTransferRequested", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+type VRFV2WrapperConsumerExampleOwnershipTransferredIterator struct {
+	Event *VRFV2WrapperConsumerExampleOwnershipTransferred
+
+	contract *bind.BoundContract
+	event    string
+
+	logs chan types.Log
+	sub  ethereum.Subscription
+	done bool
+	fail error
+}
+
+func (it *VRFV2WrapperConsumerExampleOwnershipTransferredIterator) Next() bool {
+
+	if it.fail != nil {
+		return false
+	}
+
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(VRFV2WrapperConsumerExampleOwnershipTransferred)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+
+	select {
+	case log := <-it.logs:
+		it.Event = new(VRFV2WrapperConsumerExampleOwnershipTransferred)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+func (it *VRFV2WrapperConsumerExampleOwnershipTransferredIterator) Error() error {
+	return it.fail
+}
+
+func (it *VRFV2WrapperConsumerExampleOwnershipTransferredIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+type VRFV2WrapperConsumerExampleOwnershipTransferred struct {
+	From common.Address
+	To   common.Address
+	Raw  types.Log
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleFilterer) FilterOwnershipTransferred(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*VRFV2WrapperConsumerExampleOwnershipTransferredIterator, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _VRFV2WrapperConsumerExample.contract.FilterLogs(opts, "OwnershipTransferred", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperConsumerExampleOwnershipTransferredIterator{contract: _VRFV2WrapperConsumerExample.contract, event: "OwnershipTransferred", logs: logs, sub: sub}, nil
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleFilterer) WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *VRFV2WrapperConsumerExampleOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error) {
+
+	var fromRule []interface{}
+	for _, fromItem := range from {
+		fromRule = append(fromRule, fromItem)
+	}
+	var toRule []interface{}
+	for _, toItem := range to {
+		toRule = append(toRule, toItem)
+	}
+
+	logs, sub, err := _VRFV2WrapperConsumerExample.contract.WatchLogs(opts, "OwnershipTransferred", fromRule, toRule)
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+
+				event := new(VRFV2WrapperConsumerExampleOwnershipTransferred)
+				if err := _VRFV2WrapperConsumerExample.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleFilterer) ParseOwnershipTransferred(log types.Log) (*VRFV2WrapperConsumerExampleOwnershipTransferred, error) {
+	event := new(VRFV2WrapperConsumerExampleOwnershipTransferred)
+	if err := _VRFV2WrapperConsumerExample.contract.UnpackLog(event, "OwnershipTransferred", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+type VRFV2WrapperConsumerExampleWrappedRequestFulfilledIterator struct {
+	Event *VRFV2WrapperConsumerExampleWrappedRequestFulfilled
+
+	contract *bind.BoundContract
+	event    string
+
+	logs chan types.Log
+	sub  ethereum.Subscription
+	done bool
+	fail error
+}
+
+func (it *VRFV2WrapperConsumerExampleWrappedRequestFulfilledIterator) Next() bool {
+
+	if it.fail != nil {
+		return false
+	}
+
+	if it.done {
+		select {
+		case log := <-it.logs:
+			it.Event = new(VRFV2WrapperConsumerExampleWrappedRequestFulfilled)
+			if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+				it.fail = err
+				return false
+			}
+			it.Event.Raw = log
+			return true
+
+		default:
+			return false
+		}
+	}
+
+	select {
+	case log := <-it.logs:
+		it.Event = new(VRFV2WrapperConsumerExampleWrappedRequestFulfilled)
+		if err := it.contract.UnpackLog(it.Event, it.event, log); err != nil {
+			it.fail = err
+			return false
+		}
+		it.Event.Raw = log
+		return true
+
+	case err := <-it.sub.Err():
+		it.done = true
+		it.fail = err
+		return it.Next()
+	}
+}
+
+func (it *VRFV2WrapperConsumerExampleWrappedRequestFulfilledIterator) Error() error {
+	return it.fail
+}
+
+func (it *VRFV2WrapperConsumerExampleWrappedRequestFulfilledIterator) Close() error {
+	it.sub.Unsubscribe()
+	return nil
+}
+
+type VRFV2WrapperConsumerExampleWrappedRequestFulfilled struct {
+	RequestId   *big.Int
+	RandomWords []*big.Int
+	Payment     *big.Int
+	Raw         types.Log
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleFilterer) FilterWrappedRequestFulfilled(opts *bind.FilterOpts) (*VRFV2WrapperConsumerExampleWrappedRequestFulfilledIterator, error) {
+
+	logs, sub, err := _VRFV2WrapperConsumerExample.contract.FilterLogs(opts, "WrappedRequestFulfilled")
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperConsumerExampleWrappedRequestFulfilledIterator{contract: _VRFV2WrapperConsumerExample.contract, event: "WrappedRequestFulfilled", logs: logs, sub: sub}, nil
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleFilterer) WatchWrappedRequestFulfilled(opts *bind.WatchOpts, sink chan<- *VRFV2WrapperConsumerExampleWrappedRequestFulfilled) (event.Subscription, error) {
+
+	logs, sub, err := _VRFV2WrapperConsumerExample.contract.WatchLogs(opts, "WrappedRequestFulfilled")
+	if err != nil {
+		return nil, err
+	}
+	return event.NewSubscription(func(quit <-chan struct{}) error {
+		defer sub.Unsubscribe()
+		for {
+			select {
+			case log := <-logs:
+
+				event := new(VRFV2WrapperConsumerExampleWrappedRequestFulfilled)
+				if err := _VRFV2WrapperConsumerExample.contract.UnpackLog(event, "WrappedRequestFulfilled", log); err != nil {
+					return err
+				}
+				event.Raw = log
+
+				select {
+				case sink <- event:
+				case err := <-sub.Err():
+					return err
+				case <-quit:
+					return nil
+				}
+			case err := <-sub.Err():
+				return err
+			case <-quit:
+				return nil
+			}
+		}
+	}), nil
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExampleFilterer) ParseWrappedRequestFulfilled(log types.Log) (*VRFV2WrapperConsumerExampleWrappedRequestFulfilled, error) {
+	event := new(VRFV2WrapperConsumerExampleWrappedRequestFulfilled)
+	if err := _VRFV2WrapperConsumerExample.contract.UnpackLog(event, "WrappedRequestFulfilled", log); err != nil {
+		return nil, err
+	}
+	event.Raw = log
+	return event, nil
+}
+
+type GetRequestStatus struct {
+	Paid        *big.Int
+	Fulfilled   bool
+	RandomWords []*big.Int
+}
+type SRequests struct {
+	Paid      *big.Int
+	Fulfilled bool
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExample) ParseLog(log types.Log) (generated.AbigenLog, error) {
+	switch log.Topics[0] {
+	case _VRFV2WrapperConsumerExample.abi.Events["OwnershipTransferRequested"].ID:
+		return _VRFV2WrapperConsumerExample.ParseOwnershipTransferRequested(log)
+	case _VRFV2WrapperConsumerExample.abi.Events["OwnershipTransferred"].ID:
+		return _VRFV2WrapperConsumerExample.ParseOwnershipTransferred(log)
+	case _VRFV2WrapperConsumerExample.abi.Events["WrappedRequestFulfilled"].ID:
+		return _VRFV2WrapperConsumerExample.ParseWrappedRequestFulfilled(log)
+
+	default:
+		return nil, fmt.Errorf("abigen wrapper received unknown log topic: %v", log.Topics[0])
+	}
+}
+
+func (VRFV2WrapperConsumerExampleOwnershipTransferRequested) Topic() common.Hash {
+	return common.HexToHash("0xed8889f560326eb138920d842192f0eb3dd22b4f139c87a2c57538e05bae1278")
+}
+
+func (VRFV2WrapperConsumerExampleOwnershipTransferred) Topic() common.Hash {
+	return common.HexToHash("0x8be0079c531659141344cd1fd0a4f28419497f9722a3daafe3b4186f6b6457e0")
+}
+
+func (VRFV2WrapperConsumerExampleWrappedRequestFulfilled) Topic() common.Hash {
+	return common.HexToHash("0x6c84e12b4c188e61f1b4727024a5cf05c025fa58467e5eedf763c0744c89da7b")
+}
+
+func (_VRFV2WrapperConsumerExample *VRFV2WrapperConsumerExample) Address() common.Address {
+	return _VRFV2WrapperConsumerExample.address
+}
+
+type VRFV2WrapperConsumerExampleInterface interface {
+	GetRequestStatus(opts *bind.CallOpts, _requestId *big.Int) (GetRequestStatus,
+
+		error)
+
+	Owner(opts *bind.CallOpts) (common.Address, error)
+
+	SRequests(opts *bind.CallOpts, arg0 *big.Int) (SRequests,
+
+		error)
+
+	AcceptOwnership(opts *bind.TransactOpts) (*types.Transaction, error)
+
+	MakeRequest(opts *bind.TransactOpts, _callbackGasLimit uint32, _requestConfirmations uint16, _numWords uint32) (*types.Transaction, error)
+
+	RawFulfillRandomWords(opts *bind.TransactOpts, _requestId *big.Int, _randomWords []*big.Int) (*types.Transaction, error)
+
+	TransferOwnership(opts *bind.TransactOpts, to common.Address) (*types.Transaction, error)
+
+	FilterOwnershipTransferRequested(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*VRFV2WrapperConsumerExampleOwnershipTransferRequestedIterator, error)
+
+	WatchOwnershipTransferRequested(opts *bind.WatchOpts, sink chan<- *VRFV2WrapperConsumerExampleOwnershipTransferRequested, from []common.Address, to []common.Address) (event.Subscription, error)
+
+	ParseOwnershipTransferRequested(log types.Log) (*VRFV2WrapperConsumerExampleOwnershipTransferRequested, error)
+
+	FilterOwnershipTransferred(opts *bind.FilterOpts, from []common.Address, to []common.Address) (*VRFV2WrapperConsumerExampleOwnershipTransferredIterator, error)
+
+	WatchOwnershipTransferred(opts *bind.WatchOpts, sink chan<- *VRFV2WrapperConsumerExampleOwnershipTransferred, from []common.Address, to []common.Address) (event.Subscription, error)
+
+	ParseOwnershipTransferred(log types.Log) (*VRFV2WrapperConsumerExampleOwnershipTransferred, error)
+
+	FilterWrappedRequestFulfilled(opts *bind.FilterOpts) (*VRFV2WrapperConsumerExampleWrappedRequestFulfilledIterator, error)
+
+	WatchWrappedRequestFulfilled(opts *bind.WatchOpts, sink chan<- *VRFV2WrapperConsumerExampleWrappedRequestFulfilled) (event.Subscription, error)
+
+	ParseWrappedRequestFulfilled(log types.Log) (*VRFV2WrapperConsumerExampleWrappedRequestFulfilled, error)
+
+	ParseLog(log types.Log) (generated.AbigenLog, error)
+
+	Address() common.Address
+}

--- a/core/internal/gethwrappers/generated/vrfv2_wrapper_interface/vrfv2_wrapper_interface.go
+++ b/core/internal/gethwrappers/generated/vrfv2_wrapper_interface/vrfv2_wrapper_interface.go
@@ -1,0 +1,230 @@
+// Code generated - DO NOT EDIT.
+// This file is a generated binding and any manual changes will be lost.
+
+package vrfv2_wrapper_interface
+
+import (
+	"errors"
+	"math/big"
+	"strings"
+
+	ethereum "github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/ethereum/go-ethereum/event"
+)
+
+var (
+	_ = errors.New
+	_ = big.NewInt
+	_ = strings.NewReader
+	_ = ethereum.NotFound
+	_ = bind.Bind
+	_ = common.Big1
+	_ = types.BloomLookup
+	_ = event.NewSubscription
+)
+
+var VRFV2WrapperInterfaceMetaData = &bind.MetaData{
+	ABI: "[{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_callbackGasLimit\",\"type\":\"uint32\"}],\"name\":\"calculateRequestPrice\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[{\"internalType\":\"uint32\",\"name\":\"_callbackGasLimit\",\"type\":\"uint32\"},{\"internalType\":\"uint256\",\"name\":\"_requestGasPriceWei\",\"type\":\"uint256\"}],\"name\":\"estimateRequestPrice\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"},{\"inputs\":[],\"name\":\"lastRequestId\",\"outputs\":[{\"internalType\":\"uint256\",\"name\":\"\",\"type\":\"uint256\"}],\"stateMutability\":\"view\",\"type\":\"function\"}]",
+}
+
+var VRFV2WrapperInterfaceABI = VRFV2WrapperInterfaceMetaData.ABI
+
+type VRFV2WrapperInterface struct {
+	address common.Address
+	abi     abi.ABI
+	VRFV2WrapperInterfaceCaller
+	VRFV2WrapperInterfaceTransactor
+	VRFV2WrapperInterfaceFilterer
+}
+
+type VRFV2WrapperInterfaceCaller struct {
+	contract *bind.BoundContract
+}
+
+type VRFV2WrapperInterfaceTransactor struct {
+	contract *bind.BoundContract
+}
+
+type VRFV2WrapperInterfaceFilterer struct {
+	contract *bind.BoundContract
+}
+
+type VRFV2WrapperInterfaceSession struct {
+	Contract     *VRFV2WrapperInterface
+	CallOpts     bind.CallOpts
+	TransactOpts bind.TransactOpts
+}
+
+type VRFV2WrapperInterfaceCallerSession struct {
+	Contract *VRFV2WrapperInterfaceCaller
+	CallOpts bind.CallOpts
+}
+
+type VRFV2WrapperInterfaceTransactorSession struct {
+	Contract     *VRFV2WrapperInterfaceTransactor
+	TransactOpts bind.TransactOpts
+}
+
+type VRFV2WrapperInterfaceRaw struct {
+	Contract *VRFV2WrapperInterface
+}
+
+type VRFV2WrapperInterfaceCallerRaw struct {
+	Contract *VRFV2WrapperInterfaceCaller
+}
+
+type VRFV2WrapperInterfaceTransactorRaw struct {
+	Contract *VRFV2WrapperInterfaceTransactor
+}
+
+func NewVRFV2WrapperInterface(address common.Address, backend bind.ContractBackend) (*VRFV2WrapperInterface, error) {
+	abi, err := abi.JSON(strings.NewReader(VRFV2WrapperInterfaceABI))
+	if err != nil {
+		return nil, err
+	}
+	contract, err := bindVRFV2WrapperInterface(address, backend, backend, backend)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperInterface{address: address, abi: abi, VRFV2WrapperInterfaceCaller: VRFV2WrapperInterfaceCaller{contract: contract}, VRFV2WrapperInterfaceTransactor: VRFV2WrapperInterfaceTransactor{contract: contract}, VRFV2WrapperInterfaceFilterer: VRFV2WrapperInterfaceFilterer{contract: contract}}, nil
+}
+
+func NewVRFV2WrapperInterfaceCaller(address common.Address, caller bind.ContractCaller) (*VRFV2WrapperInterfaceCaller, error) {
+	contract, err := bindVRFV2WrapperInterface(address, caller, nil, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperInterfaceCaller{contract: contract}, nil
+}
+
+func NewVRFV2WrapperInterfaceTransactor(address common.Address, transactor bind.ContractTransactor) (*VRFV2WrapperInterfaceTransactor, error) {
+	contract, err := bindVRFV2WrapperInterface(address, nil, transactor, nil)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperInterfaceTransactor{contract: contract}, nil
+}
+
+func NewVRFV2WrapperInterfaceFilterer(address common.Address, filterer bind.ContractFilterer) (*VRFV2WrapperInterfaceFilterer, error) {
+	contract, err := bindVRFV2WrapperInterface(address, nil, nil, filterer)
+	if err != nil {
+		return nil, err
+	}
+	return &VRFV2WrapperInterfaceFilterer{contract: contract}, nil
+}
+
+func bindVRFV2WrapperInterface(address common.Address, caller bind.ContractCaller, transactor bind.ContractTransactor, filterer bind.ContractFilterer) (*bind.BoundContract, error) {
+	parsed, err := abi.JSON(strings.NewReader(VRFV2WrapperInterfaceABI))
+	if err != nil {
+		return nil, err
+	}
+	return bind.NewBoundContract(address, parsed, caller, transactor, filterer), nil
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _VRFV2WrapperInterface.Contract.VRFV2WrapperInterfaceCaller.contract.Call(opts, result, method, params...)
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _VRFV2WrapperInterface.Contract.VRFV2WrapperInterfaceTransactor.contract.Transfer(opts)
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _VRFV2WrapperInterface.Contract.VRFV2WrapperInterfaceTransactor.contract.Transact(opts, method, params...)
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceCallerRaw) Call(opts *bind.CallOpts, result *[]interface{}, method string, params ...interface{}) error {
+	return _VRFV2WrapperInterface.Contract.contract.Call(opts, result, method, params...)
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceTransactorRaw) Transfer(opts *bind.TransactOpts) (*types.Transaction, error) {
+	return _VRFV2WrapperInterface.Contract.contract.Transfer(opts)
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceTransactorRaw) Transact(opts *bind.TransactOpts, method string, params ...interface{}) (*types.Transaction, error) {
+	return _VRFV2WrapperInterface.Contract.contract.Transact(opts, method, params...)
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceCaller) CalculateRequestPrice(opts *bind.CallOpts, _callbackGasLimit uint32) (*big.Int, error) {
+	var out []interface{}
+	err := _VRFV2WrapperInterface.contract.Call(opts, &out, "calculateRequestPrice", _callbackGasLimit)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceSession) CalculateRequestPrice(_callbackGasLimit uint32) (*big.Int, error) {
+	return _VRFV2WrapperInterface.Contract.CalculateRequestPrice(&_VRFV2WrapperInterface.CallOpts, _callbackGasLimit)
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceCallerSession) CalculateRequestPrice(_callbackGasLimit uint32) (*big.Int, error) {
+	return _VRFV2WrapperInterface.Contract.CalculateRequestPrice(&_VRFV2WrapperInterface.CallOpts, _callbackGasLimit)
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceCaller) EstimateRequestPrice(opts *bind.CallOpts, _callbackGasLimit uint32, _requestGasPriceWei *big.Int) (*big.Int, error) {
+	var out []interface{}
+	err := _VRFV2WrapperInterface.contract.Call(opts, &out, "estimateRequestPrice", _callbackGasLimit, _requestGasPriceWei)
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceSession) EstimateRequestPrice(_callbackGasLimit uint32, _requestGasPriceWei *big.Int) (*big.Int, error) {
+	return _VRFV2WrapperInterface.Contract.EstimateRequestPrice(&_VRFV2WrapperInterface.CallOpts, _callbackGasLimit, _requestGasPriceWei)
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceCallerSession) EstimateRequestPrice(_callbackGasLimit uint32, _requestGasPriceWei *big.Int) (*big.Int, error) {
+	return _VRFV2WrapperInterface.Contract.EstimateRequestPrice(&_VRFV2WrapperInterface.CallOpts, _callbackGasLimit, _requestGasPriceWei)
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceCaller) LastRequestId(opts *bind.CallOpts) (*big.Int, error) {
+	var out []interface{}
+	err := _VRFV2WrapperInterface.contract.Call(opts, &out, "lastRequestId")
+
+	if err != nil {
+		return *new(*big.Int), err
+	}
+
+	out0 := *abi.ConvertType(out[0], new(*big.Int)).(**big.Int)
+
+	return out0, err
+
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceSession) LastRequestId() (*big.Int, error) {
+	return _VRFV2WrapperInterface.Contract.LastRequestId(&_VRFV2WrapperInterface.CallOpts)
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterfaceCallerSession) LastRequestId() (*big.Int, error) {
+	return _VRFV2WrapperInterface.Contract.LastRequestId(&_VRFV2WrapperInterface.CallOpts)
+}
+
+func (_VRFV2WrapperInterface *VRFV2WrapperInterface) Address() common.Address {
+	return _VRFV2WrapperInterface.address
+}
+
+type VRFV2WrapperInterfaceInterface interface {
+	CalculateRequestPrice(opts *bind.CallOpts, _callbackGasLimit uint32) (*big.Int, error)
+
+	EstimateRequestPrice(opts *bind.CallOpts, _callbackGasLimit uint32, _requestGasPriceWei *big.Int) (*big.Int, error)
+
+	LastRequestId(opts *bind.CallOpts) (*big.Int, error)
+
+	Address() common.Address
+}

--- a/core/internal/gethwrappers/generation/generated-wrapper-dependency-versions-do-not-edit.txt
+++ b/core/internal/gethwrappers/generation/generated-wrapper-dependency-versions-do-not-edit.txt
@@ -41,3 +41,6 @@ vrf_malicious_consumer_v2: ../../../contracts/solc/v0.8.6/VRFMaliciousConsumerV2
 vrf_ownerless_consumer_example: ../../../contracts/solc/v0.8.6/VRFOwnerlessConsumerExample.abi ../../../contracts/solc/v0.8.6/VRFOwnerlessConsumerExample.bin 9893b3805863273917fb282eed32274e32aa3d5c2a67a911510133e1218132be
 vrf_single_consumer_example: ../../../contracts/solc/v0.8.6/VRFSingleConsumerExample.abi ../../../contracts/solc/v0.8.6/VRFSingleConsumerExample.bin 892a5ed35da2e933f7fd7835cd6f7f70ef3aa63a9c03a22c5b1fd026711b0ece
 vrfv2_reverting_example: ../../../contracts/solc/v0.8.6/VRFV2RevertingExample.abi ../../../contracts/solc/v0.8.6/VRFV2RevertingExample.bin 0e4eb8e0f92fab1f74a6bef7951b511e2c2f7b7134ca1dc65928234ec73dca9a
+vrfv2_wrapper: ../../../contracts/solc/v0.8.6/VRFV2Wrapper.abi ../../../contracts/solc/v0.8.6/VRFV2Wrapper.bin b08c92d720b9a5d2067499fbc640597310cf626fe431af3670cc3ad3af44d99c
+vrfv2_wrapper_consumer_example: ../../../contracts/solc/v0.8.6/VRFV2WrapperConsumerExample.abi ../../../contracts/solc/v0.8.6/VRFV2WrapperConsumerExample.bin 5ba19b3f180edbefec2b15ef5471a7c21a6716add91cf7918bd7fa1099c0c939
+vrfv2_wrapper_interface: ../../../contracts/solc/v0.8.6/VRFV2WrapperInterface.abi ../../../contracts/solc/v0.8.6/VRFV2WrapperInterface.bin ff8560169de171a68b360b7438d13863682d07040d984fd0fb096b2379421003

--- a/core/internal/gethwrappers/go_generate.go
+++ b/core/internal/gethwrappers/go_generate.go
@@ -55,6 +55,11 @@ package gethwrappers
 //go:generate go run ./generation/generate/wrap.go ../../../contracts/solc/v0.8.6/VRFExternalSubOwnerExample.abi ../../../contracts/solc/v0.8.6/VRFExternalSubOwnerExample.bin VRFExternalSubOwnerExample vrf_external_sub_owner_example
 //go:generate go run ./generation/generate/wrap.go ../../../contracts/solc/v0.8.6/VRFV2RevertingExample.abi ../../../contracts/solc/v0.8.6/VRFV2RevertingExample.bin VRFV2RevertingExample vrfv2_reverting_example
 
+// VRF V2 Wrapper
+//go:generate go run ./generation/generate/wrap.go ../../../contracts/solc/v0.8.6/VRFV2Wrapper.abi ../../../contracts/solc/v0.8.6/VRFV2Wrapper.bin VRFV2Wrapper vrfv2_wrapper
+//go:generate go run ./generation/generate/wrap.go ../../../contracts/solc/v0.8.6/VRFV2WrapperInterface.abi ../../../contracts/solc/v0.8.6/VRFV2WrapperInterface.bin VRFV2WrapperInterface vrfv2_wrapper_interface
+//go:generate go run ./generation/generate/wrap.go ../../../contracts/solc/v0.8.6/VRFV2WrapperConsumerExample.abi ../../../contracts/solc/v0.8.6/VRFV2WrapperConsumerExample.bin VRFV2WrapperConsumerExample vrfv2_wrapper_consumer_example
+
 // Keepers X VRF v2
 //go:generate go run ./generation/generate/wrap.go ../../../contracts/solc/v0.8.6/KeepersVRFConsumer.abi ../../../contracts/solc/v0.8.6/KeepersVRFConsumer.bin KeepersVRFConsumer keepers_vrf_consumer
 

--- a/core/scripts/vrfv2/testnet/super_scripts.go
+++ b/core/scripts/vrfv2/testnet/super_scripts.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/hex"
 	"flag"
 	"fmt"
@@ -8,8 +9,10 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/shopspring/decimal"
 
+	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/link_token_interface"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/vrf_coordinator_v2"
 	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
 )
@@ -137,4 +140,58 @@ func deployUniverse(e helpers.Environment) {
 		"\nVRF Subscription Balance:", *subscriptionBalanceString,
 		"\nA node can now be configured to run a VRF job with the above configuration.",
 	)
+}
+
+func deployWrapperUniverse(e helpers.Environment) {
+	cmd := flag.NewFlagSet("wrapper-universe-deploy", flag.ExitOnError)
+	linkAddress := cmd.String("link-address", "", "address of link token")
+	linkETHFeedAddress := cmd.String("link-eth-feed", "", "address of link-eth-feed")
+	coordinatorAddress := cmd.String("coordinator-address", "", "address of the vrf coordinator v2 contract")
+	wrapperGasOverhead := cmd.Uint("wrapper-gas-overhead", 50_000, "amount of gas overhead in wrapper fulfillment")
+	coordinatorGasOverhead := cmd.Uint("coordinator-gas-overhead", 52_000, "amount of gas overhead in coordinator fulfillment")
+	wrapperPremiumPercentage := cmd.Uint("wrapper-premium-percentage", 25, "gas premium charged by wrapper")
+	keyHash := cmd.String("key-hash", "", "the keyhash that wrapper requests should use")
+	maxNumWords := cmd.Uint("max-num-words", 10, "the keyhash that wrapper requests should use")
+	subFunding := cmd.String("sub-funding", "10000000000000000000", "amount to fund the subscription with")
+	consumerFunding := cmd.String("consumer-funding", "10000000000000000000", "amount to fund the consumer with")
+	helpers.ParseArgs(cmd, os.Args[2:], "link-address", "link-eth-feed", "coordinator-address", "key-hash")
+
+	amount, s := big.NewInt(0).SetString(*subFunding, 10)
+	if !s {
+		panic(fmt.Sprintf("failed to parse top up amount '%s'", *subFunding))
+	}
+
+	wrapper, subID := wrapperDeploy(e,
+		common.HexToAddress(*linkAddress),
+		common.HexToAddress(*linkETHFeedAddress),
+		common.HexToAddress(*coordinatorAddress))
+
+	wrapperConfigure(e,
+		wrapper,
+		*wrapperGasOverhead,
+		*coordinatorGasOverhead,
+		*wrapperPremiumPercentage,
+		*keyHash,
+		*maxNumWords)
+
+	consumer := wrapperConsumerDeploy(e,
+		common.HexToAddress(*linkAddress),
+		wrapper)
+
+	coordinator, err := vrf_coordinator_v2.NewVRFCoordinatorV2(common.HexToAddress(*coordinatorAddress), e.Ec)
+	helpers.PanicErr(err)
+
+	eoaFundSubscription(e, *coordinator, *linkAddress, amount, subID)
+
+	link, err := link_token_interface.NewLinkToken(common.HexToAddress(*linkAddress), e.Ec)
+	helpers.PanicErr(err)
+	consumerAmount, s := big.NewInt(0).SetString(*consumerFunding, 10)
+	if !s {
+		panic(fmt.Sprintf("failed to parse top up amount '%s'", *consumerFunding))
+	}
+
+	tx, err := link.Transfer(e.Owner, consumer, consumerAmount)
+	helpers.PanicErr(err)
+	helpers.ConfirmTXMined(context.Background(), e.Ec, tx, e.ChainID)
+
 }


### PR DESCRIPTION
VRFV2 Wrapper Implementation

The VRFV2 wrapper exposes an interface for VRFV2 similar to V1,
allowing consumers to pay upfront rather than manage subscriptions.

Original PR: https://github.com/smartcontractkit/chainlink/pull/6675