### PR TITLE
Add new command: config validate

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -354,6 +354,11 @@ func NewApp(client *Client) *cli.App {
 						},
 					},
 				},
+				{
+					Name:   "validate",
+					Usage:  "Validate provided TOML config file",
+					Action: client.ConfigFileValidate,
+				},
 			},
 		},
 

--- a/core/cmd/remote_client.go
+++ b/core/cmd/remote_client.go
@@ -463,6 +463,15 @@ func (cli *Client) ConfigDump(c *clipkg.Context) (err error) {
 	return nil
 }
 
+func (cli *Client) ConfigFileValidate(c *clipkg.Context) error {
+	err := cli.Config.Validate()
+	if err != nil {
+		return err
+	}
+	cli.Config.LogConfiguration(func(params ...any) { fmt.Println(params...) })
+	return err
+}
+
 func normalizePassword(password string) string {
 	return url.QueryEscape(strings.TrimSpace(password))
 }

--- a/core/config/v2/types.go
+++ b/core/config/v2/types.go
@@ -50,6 +50,12 @@ type Core struct {
 	Sentry *Sentry
 }
 
+func (core Core) ValidateConfig() (err error) {
+	// TODO: Add Core-specific validations
+	// https://app.shortcut.com/chainlinklabs/story/33618/add-config-validate-command
+	return
+}
+
 type Secrets struct {
 	DatabaseURL       *models.URL
 	DatabaseBackupURL *models.URL

--- a/core/config/v2/validate.go
+++ b/core/config/v2/validate.go
@@ -35,7 +35,6 @@ func validate(s interface{}) (err error) {
 	v := reflect.ValueOf(s)
 	if t.Kind() == reflect.Ptr {
 		if v.IsNil() {
-			//TODO error if required? https://app.shortcut.com/chainlinklabs/story/33618/add-config-validate-command
 			return
 		}
 		t = t.Elem()
@@ -46,7 +45,6 @@ func validate(s interface{}) (err error) {
 		reflect.Func, reflect.Int, reflect.Int16, reflect.Int32, reflect.Int64, reflect.Int8, reflect.Interface,
 		reflect.Invalid, reflect.Ptr, reflect.String, reflect.Uint, reflect.Uint16, reflect.Uint32, reflect.Uint64,
 		reflect.Uint8, reflect.Uintptr, reflect.UnsafePointer:
-		//TODO additional field validation? e.g. struct tags? https://app.shortcut.com/chainlinklabs/story/33618/add-config-validate-command
 		return
 	case reflect.Struct:
 		for i := 0; i < t.NumField(); i++ {

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -4,7 +4,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 
 	"gopkg.in/guregu/null.v4"
@@ -27,7 +27,7 @@ func runEx(args ...string) {
 	tc.Overrides.Dev = null.BoolFrom(false)
 	lggr := logger.TestLogger(t)
 	testClient := &cmd.Client{
-		Renderer:               cmd.RendererTable{Writer: ioutil.Discard},
+		Renderer:               cmd.RendererTable{Writer: io.Discard},
 		Config:                 tc,
 		Logger:                 lggr,
 		CloseLogger:            lggr.Sync,
@@ -164,6 +164,7 @@ func ExampleRun_config() {
 	//    setgasprice  Set the default gas price to use for outgoing transactions
 	//    loglevel     Set log level
 	//    logsql       Enable/disable sql statement logging
+	//    validate     Validate provided TOML config file
 	//
 	// OPTIONS:
 	//    --help, -h  show help

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -997,6 +997,19 @@ func TestNewGeneralConfig_Logger(t *testing.T) {
 	}
 }
 
+func TestNewGeneralConfig_ParsingError_InvalidSyntax(t *testing.T) {
+	invalidTOML := "{ bad syntax {"
+	_, err := NewGeneralConfig(invalidTOML, secretsTOML, nil)
+	assert.EqualError(t, err, "toml: invalid character at start of key: {")
+}
+
+func TestNewGeneralConfig_ParsingError_DuplicateField(t *testing.T) {
+	invalidTOML := `Dev = false
+Dev = true`
+	_, err := NewGeneralConfig(invalidTOML, secretsTOML, nil)
+	assert.EqualError(t, err, "toml: key Dev is already defined")
+}
+
 func TestNewGeneralConfig_SecretsOverrides(t *testing.T) {
 	// Provide a keystore password file and an env var with DB URL
 	const PWD_OVERRIDE = "great_password"


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/33618/add-config-validate-command

Example (no defaults yet):
[~] CHAINLINK_DEV=true go run ./core/main.go --config min_conf.toml --secrets min_secrets.toml config validate
Input Configuration:
 RootDir = '/rootdir'

Effective Configuration, with defaults applied:
 RootDir = '/rootdir'