### PR TITLE
Implement ReportSerializer interface

### DIFF
--- a/core/services/ocr2/plugins/ocr2vrf/report_serializer.go
+++ b/core/services/ocr2/plugins/ocr2vrf/report_serializer.go
@@ -1,0 +1,47 @@
+package ocr2vrf
+
+import (
+	"github.com/pkg/errors"
+	"go.dedis.ch/kyber/v3"
+
+	"github.com/smartcontractkit/ocr2vrf/ocr2vrf"
+	types "github.com/smartcontractkit/ocr2vrf/types"
+)
+
+type ReportSerializer struct {
+	G kyber.Group
+}
+
+// Return the serialized byte representation of the report, as
+// expected by the onchain machinery.
+func (serializer *ReportSerializer) SerializeReport(r types.AbstractReport) ([]byte, error) {
+
+	s := ocr2vrf.ReportSerializer{
+		G: serializer.G,
+	}
+	packed, err := s.SerializeReport(r)
+
+	if err != nil {
+		return nil, errors.Wrap(err, "serialize report")
+	}
+
+	return packed, nil
+}
+
+func (serializer *ReportSerializer) DeserializeReport(reportBytes []byte) (types.AbstractReport, error) {
+	panic("not implemented.")
+}
+
+// Return the longest possible report which can be passed onchain
+func (serializer *ReportSerializer) MaxReportLength() uint {
+	return 150_000 // TODO: change this.
+}
+
+// Return the predicted length of the output from SerializeReport
+func (serializer *ReportSerializer) ReportLength(a types.AbstractReport) uint {
+	s, err := serializer.SerializeReport(a)
+	if err != nil {
+		return 0
+	}
+	return uint(len(s))
+}

--- a/core/services/ocr2/plugins/ocr2vrf/report_serializer.go
+++ b/core/services/ocr2/plugins/ocr2vrf/report_serializer.go
@@ -28,8 +28,17 @@ func (serializer *ReportSerializer) SerializeReport(r types.AbstractReport) ([]b
 	return packed, nil
 }
 
-func (serializer *ReportSerializer) DeserializeReport(reportBytes []byte) (types.AbstractReport, error) {
-	panic("not implemented.")
+func (serializer *ReportSerializer) DeserializeReport(reportBytes []byte) (types.BeaconReport, error) {
+	s := ocr2vrf.ReportSerializer{
+		G: serializer.G,
+	}
+	r, err := s.DeserializeReport(reportBytes)
+
+	if err != nil {
+		return types.BeaconReport{}, errors.Wrap(err, "deserialize report")
+	}
+
+	return r, nil
 }
 
 // Return the longest possible report which can be passed onchain

--- a/core/services/ocr2/plugins/ocr2vrf/report_serializer_test.go
+++ b/core/services/ocr2/plugins/ocr2vrf/report_serializer_test.go
@@ -37,8 +37,30 @@ func Test_Serialize_Deserialize(t *testing.T) {
 			}},
 		}},
 	}
-	_, err := reportSerializer.SerializeReport(unserializedReport)
+	r, err := reportSerializer.SerializeReport(unserializedReport)
 	require.NoError(t, err)
+
+	report, err := reportSerializer.DeserializeReport(r)
+	require.NoError(t, err)
+
+	require.Equal(t, unserializedReport, types.AbstractReport{
+		JulesPerFeeCoin:   report.JulesPerFeeCoin,
+		RecentBlockHeight: report.RecentBlockHeight,
+		RecentBlockHash:   common.Hash(report.RecentBlockHash),
+		Outputs: []types.AbstractVRFOutput{{
+			BlockHeight:       report.Outputs[0].BlockHeight,
+			ConfirmationDelay: uint32(report.Outputs[0].ConfirmationDelay.Int64()),
+			Callbacks: []types.AbstractCostedCallbackRequest{{
+				RequestID:      report.Outputs[0].Callbacks[0].Callback.RequestID.Uint64(),
+				NumWords:       report.Outputs[0].Callbacks[0].Callback.NumWords,
+				Requester:      report.Outputs[0].Callbacks[0].Callback.Requester,
+				Arguments:      report.Outputs[0].Callbacks[0].Callback.Arguments,
+				SubscriptionID: report.Outputs[0].Callbacks[0].Callback.SubID,
+				GasAllowance:   report.Outputs[0].Callbacks[0].Callback.GasAllowance,
+				Price:          report.Outputs[0].Callbacks[0].Price,
+			}},
+		}},
+	})
 }
 
 func Test_Serialize_Length(t *testing.T) {

--- a/core/services/ocr2/plugins/ocr2vrf/report_serializer_test.go
+++ b/core/services/ocr2/plugins/ocr2vrf/report_serializer_test.go
@@ -1,0 +1,72 @@
+package ocr2vrf_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/ocr2vrf/altbn_128"
+	"github.com/smartcontractkit/ocr2vrf/types"
+
+	"github.com/smartcontractkit/chainlink/core/services/ocr2/plugins/ocr2vrf"
+)
+
+func Test_Serialize_Deserialize(t *testing.T) {
+	altbn128Suite := &altbn_128.PairingSuite{}
+	reportSerializer := ocr2vrf.ReportSerializer{
+		G: altbn128Suite.G1(),
+	}
+
+	unserializedReport := types.AbstractReport{
+		JulesPerFeeCoin:   big.NewInt(10),
+		RecentBlockHeight: 100,
+		RecentBlockHash:   common.HexToHash("0x002"),
+		Outputs: []types.AbstractVRFOutput{{
+			BlockHeight:       10,
+			ConfirmationDelay: 20,
+			Callbacks: []types.AbstractCostedCallbackRequest{{
+				RequestID:      1,
+				NumWords:       2,
+				Requester:      common.HexToAddress("0x03"),
+				Arguments:      []byte{4},
+				SubscriptionID: 5,
+				GasAllowance:   big.NewInt(6),
+				Price:          big.NewInt(7),
+			}},
+		}},
+	}
+	_, err := reportSerializer.SerializeReport(unserializedReport)
+	require.NoError(t, err)
+}
+
+func Test_Serialize_Length(t *testing.T) {
+	altbn128Suite := &altbn_128.PairingSuite{}
+	reportSerializer := ocr2vrf.ReportSerializer{
+		G: altbn128Suite.G1(),
+	}
+
+	unserializedReport := types.AbstractReport{
+		JulesPerFeeCoin:   big.NewInt(10),
+		RecentBlockHeight: 100,
+		RecentBlockHash:   common.HexToHash("0x002"),
+		Outputs: []types.AbstractVRFOutput{{
+			BlockHeight:       10,
+			ConfirmationDelay: 20,
+			Callbacks: []types.AbstractCostedCallbackRequest{{
+				RequestID:      1,
+				NumWords:       2,
+				Requester:      common.HexToAddress("0x03"),
+				Arguments:      []byte{4},
+				SubscriptionID: 5,
+				GasAllowance:   big.NewInt(6),
+				Price:          big.NewInt(7),
+			}},
+		}},
+	}
+	r, err := reportSerializer.SerializeReport(unserializedReport)
+	require.NoError(t, err)
+
+	require.Equal(t, uint(len(r)), reportSerializer.ReportLength(unserializedReport))
+}


### PR DESCRIPTION
Broken up into 2 commits: the serializer and the deserializer. 

- The serializer uses the ethereum_serializer in ocr2vrf and can be implemented without any changes there.
- The deserializer is in the second commit, and it's a more experimental implementation that requires changes to ocr2vrf.

Branch for ocr2vrf deserialization changes: https://github.com/smartcontractkit/ocr2vrf/commit/72cd20dd4eaaa13a9f286b76ebc3e6f7a1c028a9

Note: the serialization is one way, as the report is converted to a BeaconReport. A BeaconReport is returned on deserialization. To make it two way, a reverse [affineCoordinates](https://github.com/smartcontractkit/ocr2vrf/blob/main/internal/vrf/ethereum_serialization.go#L67) function needs to be made that reconstructs a kyber point from an x and y scalar. Otherwise, the deserialize will return a different type than the serialize.

The deserialize component is not actually critical currently. If we feel that the deserializer is blocked on some ocr2vrf changes, we can just go with the serializer commit for now, and implement the deserializer later in a separate ticket.