### PR TITLE
Fixed flakey tests in head_tracker

### DIFF
--- a/core/chains/evm/headtracker/head_broadcaster_test.go
+++ b/core/chains/evm/headtracker/head_broadcaster_test.go
@@ -31,9 +31,7 @@ func waitHeadBroadcasterToStart(t *testing.T, hb types.HeadBroadcaster) {
 
 	hb.BroadcastNewLongestChain(cltest.Head(1))
 	g := gomega.NewWithT(t)
-	g.Eventually(func() int32 {
-		return subscriber.OnNewLongestChainCount()
-	}).Should(gomega.Equal(int32(1)))
+	g.Eventually(subscriber.OnNewLongestChainCount).Should(gomega.Equal(int32(1)))
 }
 
 func TestHeadBroadcaster_Subscribe(t *testing.T) {
@@ -78,7 +76,7 @@ func TestHeadBroadcaster_Subscribe(t *testing.T) {
 	headers := <-chchHeaders
 	h := evmtypes.Head{Number: 1, Hash: utils.NewHash(), ParentHash: utils.NewHash(), EVMChainID: utils.NewBig(&cltest.FixtureChainID)}
 	headers <- &h
-	g.Eventually(func() int32 { return checker1.OnNewLongestChainCount() }).Should(gomega.Equal(int32(1)))
+	g.Eventually(checker1.OnNewLongestChainCount).Should(gomega.Equal(int32(1)))
 
 	latest2, _ := hb.Subscribe(checker2)
 	// "latest head" is set here to the most recent head received
@@ -88,7 +86,7 @@ func TestHeadBroadcaster_Subscribe(t *testing.T) {
 	unsubscribe1()
 
 	headers <- &evmtypes.Head{Number: 2, Hash: utils.NewHash(), ParentHash: h.Hash, EVMChainID: utils.NewBig(&cltest.FixtureChainID)}
-	g.Eventually(func() int32 { return checker2.OnNewLongestChainCount() }).Should(gomega.Equal(int32(1)))
+	g.Eventually(checker2.OnNewLongestChainCount).Should(gomega.Equal(int32(1)))
 
 	require.NoError(t, ht.Close())
 	require.NoError(t, hb.Close())
@@ -112,19 +110,19 @@ func TestHeadBroadcaster_BroadcastNewLongestChain(t *testing.T) {
 	_, unsubscribe2 := broadcaster.Subscribe(subscriber2)
 
 	broadcaster.BroadcastNewLongestChain(cltest.Head(1))
-	g.Eventually(func() int32 { return subscriber1.OnNewLongestChainCount() }).Should(gomega.Equal(int32(1)))
+	g.Eventually(subscriber1.OnNewLongestChainCount).Should(gomega.Equal(int32(1)))
 
 	unsubscribe1()
 
 	broadcaster.BroadcastNewLongestChain(cltest.Head(2))
-	g.Eventually(func() int32 { return subscriber2.OnNewLongestChainCount() }).Should(gomega.Equal(int32(2)))
+	g.Eventually(subscriber2.OnNewLongestChainCount).Should(gomega.Equal(int32(2)))
 
 	unsubscribe2()
 
 	subscriber3 := &cltest.MockHeadTrackable{}
 	_, unsubscribe3 := broadcaster.Subscribe(subscriber3)
 	broadcaster.BroadcastNewLongestChain(cltest.Head(1))
-	g.Eventually(func() int32 { return subscriber3.OnNewLongestChainCount() }).Should(gomega.Equal(int32(1)))
+	g.Eventually(subscriber3.OnNewLongestChainCount).Should(gomega.Equal(int32(1)))
 
 	unsubscribe3()
 

--- a/core/chains/evm/headtracker/head_listener.go
+++ b/core/chains/evm/headtracker/head_listener.go
@@ -2,7 +2,6 @@ package headtracker
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/ethereum/go-ethereum"
@@ -65,7 +64,7 @@ func (hl *headListener) ListenForNewHeads(handleNewHead httypes.NewHeadHandler, 
 		if ctx.Err() != nil {
 			break
 		} else if err != nil {
-			hl.logger.Errorw(fmt.Sprintf("Error in new head subscription, unsubscribed: %s", err.Error()), "err", err)
+			hl.logger.Errorw("Error in new head subscription, unsubscribed", "err", err)
 			continue
 		} else {
 			break
@@ -131,7 +130,7 @@ func (hl *headListener) receiveHeaders(ctx context.Context, handleNewHead httype
 
 		case <-noHeadsAlarmC:
 			// We haven't received a head on the channel for a long time, log a warning
-			hl.logger.Warn(fmt.Sprintf("have not received a head for %v", noHeadsAlarmDuration))
+			hl.logger.Warnf("have not received a head for %v", noHeadsAlarmDuration)
 			hl.receivingHeads.Store(false)
 		}
 	}
@@ -155,7 +154,7 @@ func (hl *headListener) subscribe(ctx context.Context) bool {
 			err := hl.subscribeToHead(ctx)
 			if err != nil {
 				promEthConnectionErrors.WithLabelValues(hl.ethClient.ChainID().String()).Inc()
-				hl.logger.Warnw(fmt.Sprintf("Failed to subscribe to heads on chain %s", chainID), "err", err)
+				hl.logger.Warnw("Failed to subscribe to heads on chain", "chainID", chainID, "err", err)
 			} else {
 				hl.logger.Debugf("Subscribed to heads on chain %s", chainID)
 				return true


### PR DESCRIPTION
Fixes https://app.shortcut.com/chainlinklabs/story/47110/flaky-test-testheadbroadcaster-broadcastnewlongestchain
