### PR TITLE
Retry indefinitely on TxFeeExceedsCapError

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -27,6 +27,10 @@ ETH_GAS_LIMIT_KEEPER_JOB_TYPE # EVM.GasEstimator.LimitKeeperJobType
 
 4. global `ETH_GAS_LIMIT_DEFAULT` (`EVM.GasEstimator.LimitDefault`) value is the last resort.
 
+### Fixed
+
+Addressed a very rare bug where using multiple nodes with differently configured RPC tx fee caps could cause missed transaction. Reminder to everyone to ensure that your RPC nodes have no caps (for more information see the [performance and tuning guide](https://docs.chain.link/docs/evm-performance-configuration/)).
+
 ### Changed
 
 - After feedback from users, password complexity requirements have been simplified. These are the new, simplified requirements for any kind of password used with Chainlink:


### PR DESCRIPTION
In the case of multiple RPC nodes, some can have a configured cap whilst
others do not. Because we broadcast in parallel to all nodes, this can
lead to a TxFeeExceedsCapError even if the tx has been accepted into the
mempool by another node.

Marking fatal error could lead to nonce re-use, so the correct thing to
do in this case instead is to continue retrying indefinitely and move
ahead only once a tx with that nonce has been accepted.
