### PR TITLE
Move view functions from proxy to logic

### DIFF
--- a/contracts/src/v0.8/dev/KeeperRegistryBase.sol
+++ b/contracts/src/v0.8/dev/KeeperRegistryBase.sol
@@ -8,7 +8,7 @@ import "./ExecutionPrevention.sol";
 import "../interfaces/AggregatorV3Interface.sol";
 import "../interfaces/LinkTokenInterface.sol";
 import "../interfaces/KeeperCompatibleInterface.sol";
-import {Config, State} from "../interfaces/KeeperRegistryInterface.sol";
+import {Config, State} from "./interfaces/KeeperRegistryInterfaceDev.sol";
 
 /**
  * @notice Base Keeper Registry contract, contains shared logic between

--- a/contracts/src/v0.8/dev/KeeperRegistryDev.sol
+++ b/contracts/src/v0.8/dev/KeeperRegistryDev.sol
@@ -6,7 +6,7 @@ import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
 import "@openzeppelin/contracts/utils/Address.sol";
 import "./KeeperRegistryBase.sol";
 import "../interfaces/TypeAndVersionInterface.sol";
-import {KeeperRegistryExecutableInterface} from "../interfaces/KeeperRegistryInterface.sol";
+import {KeeperRegistryExecutableInterface} from "./interfaces/KeeperRegistryInterfaceDev.sol";
 import "../interfaces/MigratableKeeperRegistryInterface.sol";
 import "../interfaces/UpkeepTranscoderInterface.sol";
 import "../interfaces/ERC677ReceiverInterface.sol";
@@ -368,7 +368,6 @@ contract KeeperRegistryDev is
    */
   function getUpkeep(uint256 id)
     external
-    view
     override
     returns (
       address target,
@@ -381,17 +380,8 @@ contract KeeperRegistryDev is
       uint96 amountSpent
     )
   {
-    Upkeep memory reg = s_upkeep[id];
-    return (
-      reg.target,
-      reg.executeGas,
-      s_checkData[id],
-      reg.balance,
-      reg.lastKeeper,
-      reg.admin,
-      reg.maxValidBlocknumber,
-      reg.amountSpent
-    );
+    // Executed through logic contract
+    _fallback();
   }
 
   /**
@@ -401,17 +391,9 @@ contract KeeperRegistryDev is
    * @dev the order of IDs in the list is **not guaranteed**, therefore, if making successive calls, one
    * should consider keeping the blockheight constant to ensure a wholistic picture of the contract state
    */
-  function getActiveUpkeepIDs(uint256 startIndex, uint256 maxCount) external view override returns (uint256[] memory) {
-    uint256 maxIdx = s_upkeepIDs.length();
-    if (startIndex >= maxIdx) revert IndexOutOfRange();
-    if (maxCount == 0) {
-      maxCount = maxIdx - startIndex;
-    }
-    uint256[] memory ids = new uint256[](maxCount);
-    for (uint256 idx = 0; idx < maxCount; idx++) {
-      ids[idx] = s_upkeepIDs.at(startIndex + idx);
-    }
-    return ids;
+  function getActiveUpkeepIDs(uint256 startIndex, uint256 maxCount) external override returns (uint256[] memory) {
+    // Executed through logic contract
+    _fallback();
   }
 
   /**
@@ -419,7 +401,6 @@ contract KeeperRegistryDev is
    */
   function getKeeperInfo(address query)
     external
-    view
     override
     returns (
       address payee,
@@ -427,8 +408,8 @@ contract KeeperRegistryDev is
       uint96 balance
     )
   {
-    KeeperInfo memory keeper = s_keeperInfo[query];
-    return (keeper.payee, keeper.active, keeper.balance);
+    // Executed through logic contract
+    _fallback();
   }
 
   /**
@@ -436,7 +417,6 @@ contract KeeperRegistryDev is
    */
   function getState()
     external
-    view
     override
     returns (
       State memory state,
@@ -444,49 +424,34 @@ contract KeeperRegistryDev is
       address[] memory keepers
     )
   {
-    Storage memory store = s_storage;
-    state.nonce = store.nonce;
-    state.ownerLinkBalance = s_ownerLinkBalance;
-    state.expectedLinkBalance = s_expectedLinkBalance;
-    state.numUpkeeps = s_upkeepIDs.length();
-    config.paymentPremiumPPB = store.paymentPremiumPPB;
-    config.flatFeeMicroLink = store.flatFeeMicroLink;
-    config.blockCountPerTurn = store.blockCountPerTurn;
-    config.checkGasLimit = store.checkGasLimit;
-    config.stalenessSeconds = store.stalenessSeconds;
-    config.gasCeilingMultiplier = store.gasCeilingMultiplier;
-    config.minUpkeepSpend = store.minUpkeepSpend;
-    config.maxPerformGas = store.maxPerformGas;
-    config.fallbackGasPrice = s_fallbackGasPrice;
-    config.fallbackLinkPrice = s_fallbackLinkPrice;
-    config.transcoder = s_transcoder;
-    config.registrar = s_registrar;
-    return (state, config, s_keeperList);
+    // Executed through logic contract
+    _fallback();
   }
 
   /**
    * @notice calculates the minimum balance required for an upkeep to remain eligible
    * @param id the upkeep id to calculate minimum balance for
    */
-  function getMinBalanceForUpkeep(uint256 id) external view returns (uint96 minBalance) {
-    return getMaxPaymentForGas(s_upkeep[id].executeGas);
+  function getMinBalanceForUpkeep(uint256 id) external returns (uint96 minBalance) {
+    // Executed through logic contract
+    _fallback();
   }
 
   /**
    * @notice calculates the maximum payment for a given gas limit
    * @param gasLimit the gas to calculate payment for
    */
-  function getMaxPaymentForGas(uint256 gasLimit) public view returns (uint96 maxPayment) {
-    (uint256 gasWei, uint256 linkEth) = _getFeedData();
-    uint256 adjustedGasWei = _adjustGasPrice(gasWei, false);
-    return _calculatePaymentAmount(gasLimit, adjustedGasWei, linkEth);
+  function getMaxPaymentForGas(uint256 gasLimit) public returns (uint96 maxPayment) {
+    // Executed through logic contract
+    _fallback();
   }
 
   /**
    * @notice retrieves the migration permission for a peer registry
    */
-  function getPeerRegistryMigrationPermission(address peer) external view returns (MigrationPermission) {
-    return s_peerRegistryMigrationPermission[peer];
+  function getPeerRegistryMigrationPermission(address peer) external returns (MigrationPermission) {
+    // Executed through logic contract
+    _fallback();
   }
 
   /**

--- a/contracts/src/v0.8/dev/KeeperRegistryDev.sol
+++ b/contracts/src/v0.8/dev/KeeperRegistryDev.sol
@@ -369,6 +369,7 @@ contract KeeperRegistryDev is
   function getUpkeep(uint256 id)
     external
     override
+    cannotExecute
     returns (
       address target,
       uint32 executeGas,
@@ -391,7 +392,12 @@ contract KeeperRegistryDev is
    * @dev the order of IDs in the list is **not guaranteed**, therefore, if making successive calls, one
    * should consider keeping the blockheight constant to ensure a wholistic picture of the contract state
    */
-  function getActiveUpkeepIDs(uint256 startIndex, uint256 maxCount) external override returns (uint256[] memory) {
+  function getActiveUpkeepIDs(uint256 startIndex, uint256 maxCount)
+    external
+    override
+    cannotExecute
+    returns (uint256[] memory)
+  {
     // Executed through logic contract
     _fallback();
   }
@@ -402,6 +408,7 @@ contract KeeperRegistryDev is
   function getKeeperInfo(address query)
     external
     override
+    cannotExecute
     returns (
       address payee,
       bool active,
@@ -418,6 +425,7 @@ contract KeeperRegistryDev is
   function getState()
     external
     override
+    cannotExecute
     returns (
       State memory state,
       Config memory config,
@@ -432,7 +440,7 @@ contract KeeperRegistryDev is
    * @notice calculates the minimum balance required for an upkeep to remain eligible
    * @param id the upkeep id to calculate minimum balance for
    */
-  function getMinBalanceForUpkeep(uint256 id) external returns (uint96 minBalance) {
+  function getMinBalanceForUpkeep(uint256 id) external cannotExecute returns (uint96 minBalance) {
     // Executed through logic contract
     _fallback();
   }
@@ -441,7 +449,7 @@ contract KeeperRegistryDev is
    * @notice calculates the maximum payment for a given gas limit
    * @param gasLimit the gas to calculate payment for
    */
-  function getMaxPaymentForGas(uint256 gasLimit) public returns (uint96 maxPayment) {
+  function getMaxPaymentForGas(uint256 gasLimit) public cannotExecute returns (uint96 maxPayment) {
     // Executed through logic contract
     _fallback();
   }
@@ -449,7 +457,7 @@ contract KeeperRegistryDev is
   /**
    * @notice retrieves the migration permission for a peer registry
    */
-  function getPeerRegistryMigrationPermission(address peer) external returns (MigrationPermission) {
+  function getPeerRegistryMigrationPermission(address peer) external cannotExecute returns (MigrationPermission) {
     // Executed through logic contract
     _fallback();
   }

--- a/contracts/src/v0.8/dev/KeeperRegistryLogic.sol
+++ b/contracts/src/v0.8/dev/KeeperRegistryLogic.sol
@@ -1,12 +1,18 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.6;
 
+import "@openzeppelin/contracts/utils/structs/EnumerableSet.sol";
+import "@openzeppelin/contracts/utils/Address.sol";
 import "./KeeperRegistryBase.sol";
 
 /**
- * @notice Logic contract, works in tandem with KeeperRegistry as a proxy
+ * @notice Logic contract, works in tandem with KeeperRegistry as a proxy.
+ * It's own state is never used.
  */
 contract KeeperRegistryLogic is KeeperRegistryBase {
+  using Address for address;
+  using EnumerableSet for EnumerableSet.UintSet;
+
   /**
    * @param link address of the LINK Token
    * @param linkEthFeed address of the LINK/ETH price feed
@@ -18,6 +24,9 @@ contract KeeperRegistryLogic is KeeperRegistryBase {
     address fastGasFeed
   ) KeeperRegistryBase(link, linkEthFeed, fastGasFeed) {}
 
+  /**
+   * @dev Called through KeeperRegistry main contract
+   */
   function checkUpkeep(uint256 id, address from)
     external
     cannotExecute
@@ -43,5 +52,122 @@ contract KeeperRegistryLogic is KeeperRegistryBase {
     _prePerformUpkeep(upkeep, params.from, params.maxLinkPayment);
 
     return (performData, params.maxLinkPayment, params.gasLimit, params.adjustedGasWei, params.linkEth);
+  }
+
+  /**
+   * @dev Called through KeeperRegistry main contract
+   */
+  function getUpkeep(uint256 id)
+    external
+    view
+    returns (
+      address target,
+      uint32 executeGas,
+      bytes memory checkData,
+      uint96 balance,
+      address lastKeeper,
+      address admin,
+      uint64 maxValidBlocknumber,
+      uint96 amountSpent
+    )
+  {
+    Upkeep memory reg = s_upkeep[id];
+    return (
+      reg.target,
+      reg.executeGas,
+      s_checkData[id],
+      reg.balance,
+      reg.lastKeeper,
+      reg.admin,
+      reg.maxValidBlocknumber,
+      reg.amountSpent
+    );
+  }
+
+  /**
+   * @dev Called through KeeperRegistry main contract
+   */
+  function getActiveUpkeepIDs(uint256 startIndex, uint256 maxCount) external view returns (uint256[] memory) {
+    uint256 maxIdx = s_upkeepIDs.length();
+    if (startIndex >= maxIdx) revert IndexOutOfRange();
+    if (maxCount == 0) {
+      maxCount = maxIdx - startIndex;
+    }
+    uint256[] memory ids = new uint256[](maxCount);
+    for (uint256 idx = 0; idx < maxCount; idx++) {
+      ids[idx] = s_upkeepIDs.at(startIndex + idx);
+    }
+    return ids;
+  }
+
+  /**
+   * @dev Called through KeeperRegistry main contract
+   */
+  function getKeeperInfo(address query)
+    external
+    view
+    returns (
+      address payee,
+      bool active,
+      uint96 balance
+    )
+  {
+    KeeperInfo memory keeper = s_keeperInfo[query];
+    return (keeper.payee, keeper.active, keeper.balance);
+  }
+
+  /**
+   * @dev Called through KeeperRegistry main contract
+   */
+  function getState()
+    external
+    view
+    returns (
+      State memory state,
+      Config memory config,
+      address[] memory keepers
+    )
+  {
+    Storage memory store = s_storage;
+    state.nonce = store.nonce;
+    state.ownerLinkBalance = s_ownerLinkBalance;
+    state.expectedLinkBalance = s_expectedLinkBalance;
+    state.numUpkeeps = s_upkeepIDs.length();
+    config.paymentPremiumPPB = store.paymentPremiumPPB;
+    config.flatFeeMicroLink = store.flatFeeMicroLink;
+    config.blockCountPerTurn = store.blockCountPerTurn;
+    config.checkGasLimit = store.checkGasLimit;
+    config.stalenessSeconds = store.stalenessSeconds;
+    config.gasCeilingMultiplier = store.gasCeilingMultiplier;
+    config.minUpkeepSpend = store.minUpkeepSpend;
+    config.maxPerformGas = store.maxPerformGas;
+    config.fallbackGasPrice = s_fallbackGasPrice;
+    config.fallbackLinkPrice = s_fallbackLinkPrice;
+    config.transcoder = s_transcoder;
+    config.registrar = s_registrar;
+    return (state, config, s_keeperList);
+  }
+
+  /**
+   * @dev Called through KeeperRegistry main contract
+   */
+  function getMinBalanceForUpkeep(uint256 id) external view returns (uint96 minBalance) {
+    return getMaxPaymentForGas(s_upkeep[id].executeGas);
+  }
+
+  /**
+   * @dev Called through KeeperRegistry main contract
+   */
+  function getMaxPaymentForGas(uint256 gasLimit) public view returns (uint96 maxPayment) {
+    (uint256 gasWei, uint256 linkEth) = _getFeedData();
+    uint256 adjustedGasWei = _adjustGasPrice(gasWei, false);
+    return _calculatePaymentAmount(gasLimit, adjustedGasWei, linkEth);
+  }
+
+  /**
+   * @dev Called through KeeperRegistry main contract
+   */
+  function getPeerRegistryMigrationPermission(address peer) external view returns (MigrationPermission) {
+    return s_peerRegistryMigrationPermission[peer];
   }
 }

--- a/contracts/src/v0.8/dev/interfaces/KeeperRegistryInterfaceDev.sol
+++ b/contracts/src/v0.8/dev/interfaces/KeeperRegistryInterfaceDev.sol
@@ -1,0 +1,165 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/**
+ * @notice config of the registry
+ * @dev only used in params and return values
+ * @member paymentPremiumPPB payment premium rate oracles receive on top of
+ * being reimbursed for gas, measured in parts per billion
+ * @member flatFeeMicroLink flat fee paid to oracles for performing upkeeps,
+ * priced in MicroLink; can be used in conjunction with or independently of
+ * paymentPremiumPPB
+ * @member blockCountPerTurn number of blocks each oracle has during their turn to
+ * perform upkeep before it will be the next keeper's turn to submit
+ * @member checkGasLimit gas limit when checking for upkeep
+ * @member stalenessSeconds number of seconds that is allowed for feed data to
+ * be stale before switching to the fallback pricing
+ * @member gasCeilingMultiplier multiplier to apply to the fast gas feed price
+ * when calculating the payment ceiling for keepers
+ * @member minUpkeepSpend minimum LINK that an upkeep must spend before cancelling
+ * @member maxPerformGas max executeGas allowed for an upkeep on this registry
+ * @member fallbackGasPrice gas price used if the gas price feed is stale
+ * @member fallbackLinkPrice LINK price used if the LINK price feed is stale
+ * @member transcoder address of the transcoder contract
+ * @member registrar address of the registrar contract
+ */
+struct Config {
+  uint32 paymentPremiumPPB;
+  uint32 flatFeeMicroLink; // min 0.000001 LINK, max 4294 LINK
+  uint24 blockCountPerTurn;
+  uint32 checkGasLimit;
+  uint24 stalenessSeconds;
+  uint16 gasCeilingMultiplier;
+  uint96 minUpkeepSpend;
+  uint32 maxPerformGas;
+  uint256 fallbackGasPrice;
+  uint256 fallbackLinkPrice;
+  address transcoder;
+  address registrar;
+}
+
+/**
+ * @notice config of the registry
+ * @dev only used in params and return values
+ * @member nonce used for ID generation
+ * @ownerLinkBalance withdrawable balance of LINK by contract owner
+ * @numUpkeeps total number of upkeeps on the registry
+ */
+struct State {
+  uint32 nonce;
+  uint96 ownerLinkBalance;
+  uint256 expectedLinkBalance;
+  uint256 numUpkeeps;
+}
+
+interface KeeperRegistryBaseInterface {
+  function registerUpkeep(
+    address target,
+    uint32 gasLimit,
+    address admin,
+    bytes calldata checkData
+  ) external returns (uint256 id);
+
+  function performUpkeep(uint256 id, bytes calldata performData) external returns (bool success);
+
+  function cancelUpkeep(uint256 id) external;
+
+  function addFunds(uint256 id, uint96 amount) external;
+
+  function setUpkeepGasLimit(uint256 id, uint32 gasLimit) external;
+}
+
+/**
+ * @dev The view methods are not actually marked as view in the implementation
+ * but we want them to be easily queried off-chain. Solidity will not compile
+ * if we actually inherit from this interface, so we document it here.
+ */
+interface KeeperRegistryInterface is KeeperRegistryBaseInterface {
+  function checkUpkeep(uint256 upkeepId, address from)
+    external
+    view
+    returns (
+      bytes memory performData,
+      uint256 maxLinkPayment,
+      uint256 gasLimit,
+      int256 gasWei,
+      int256 linkEth
+    );
+
+  function getUpkeep(uint256 id)
+    external
+    view
+    returns (
+      address target,
+      uint32 executeGas,
+      bytes memory checkData,
+      uint96 balance,
+      address lastKeeper,
+      address admin,
+      uint64 maxValidBlocknumber,
+      uint96 amountSpent
+    );
+
+  function getActiveUpkeepIDs(uint256 startIndex, uint256 maxCount) external view returns (uint256[] memory);
+
+  function getKeeperInfo(address query)
+    external
+    view
+    returns (
+      address payee,
+      bool active,
+      uint96 balance
+    );
+
+  function getState()
+    external
+    view
+    returns (
+      State memory,
+      Config memory,
+      address[] memory
+    );
+}
+
+interface KeeperRegistryExecutableInterface is KeeperRegistryBaseInterface {
+  function checkUpkeep(uint256 upkeepId, address from)
+    external
+    returns (
+      bytes memory performData,
+      uint256 maxLinkPayment,
+      uint256 gasLimit,
+      uint256 adjustedGasWei,
+      uint256 linkEth
+    );
+
+  function getUpkeep(uint256 id)
+    external
+    returns (
+      address target,
+      uint32 executeGas,
+      bytes memory checkData,
+      uint96 balance,
+      address lastKeeper,
+      address admin,
+      uint64 maxValidBlocknumber,
+      uint96 amountSpent
+    );
+
+  function getActiveUpkeepIDs(uint256 startIndex, uint256 maxCount) external returns (uint256[] memory);
+
+  function getKeeperInfo(address query)
+    external
+    returns (
+      address payee,
+      bool active,
+      uint96 balance
+    );
+
+  function getState()
+    external
+    returns (
+      State memory,
+      Config memory,
+      address[] memory
+    );
+}

--- a/contracts/test/v0.8/dev/KeeperRegistryDev.test.ts
+++ b/contracts/test/v0.8/dev/KeeperRegistryDev.test.ts
@@ -300,7 +300,7 @@ describe('KeeperRegistryDev', () => {
       await registry.connect(owner).setKeepers(oldKeepers, oldPayees)
       assert.deepEqual(
         oldKeepers,
-        (await registry.callStatic.getState()).keepers,
+        (await registry.connect(zeroAddress).callStatic.getState()).keepers,
       )
 
       // remove keepers
@@ -312,7 +312,7 @@ describe('KeeperRegistryDev', () => {
       const tx = await registry.connect(owner).setKeepers(newKeepers, newPayees)
       assert.deepEqual(
         newKeepers,
-        (await registry.callStatic.getState()).keepers,
+        (await registry.connect(zeroAddress).callStatic.getState()).keepers,
       )
 
       await expect(tx)
@@ -328,13 +328,13 @@ describe('KeeperRegistryDev', () => {
           [await keeper1.getAddress(), await keeper3.getAddress()],
           [await payee1.getAddress(), await payee3.getAddress()],
         )
-      const added = await registry.callStatic.getKeeperInfo(
-        await keeper1.getAddress(),
-      )
+      const added = await registry
+        .connect(zeroAddress)
+        .callStatic.getKeeperInfo(await keeper1.getAddress())
       assert.isTrue(added.active)
-      const removed = await registry.callStatic.getKeeperInfo(
-        await keeper2.getAddress(),
-      )
+      const removed = await registry
+        .connect(zeroAddress)
+        .callStatic.getKeeperInfo(await keeper2.getAddress())
       assert.isFalse(removed.active)
     })
 
@@ -347,7 +347,7 @@ describe('KeeperRegistryDev', () => {
       await registry.connect(owner).setKeepers(oldKeepers, oldPayees)
       assert.deepEqual(
         oldKeepers,
-        (await registry.callStatic.getState()).keepers,
+        (await registry.connect(zeroAddress).callStatic.getState()).keepers,
       )
 
       const newKeepers = [
@@ -358,12 +358,12 @@ describe('KeeperRegistryDev', () => {
       const tx = await registry.connect(owner).setKeepers(newKeepers, newPayees)
       assert.deepEqual(
         newKeepers,
-        (await registry.callStatic.getState()).keepers,
+        (await registry.connect(zeroAddress).callStatic.getState()).keepers,
       )
 
-      const ignored = await registry.callStatic.getKeeperInfo(
-        await keeper2.getAddress(),
-      )
+      const ignored = await registry
+        .connect(zeroAddress)
+        .callStatic.getKeeperInfo(await keeper2.getAddress())
       assert.equal(await payee2.getAddress(), ignored.payee)
       assert.equal(true, ignored.active)
 
@@ -476,7 +476,9 @@ describe('KeeperRegistryDev', () => {
       await expect(tx)
         .to.emit(registry, 'UpkeepRegistered')
         .withArgs(id, executeGas, await admin.getAddress())
-      const registration = await registry.callStatic.getUpkeep(id)
+      const registration = await registry
+        .connect(zeroAddress)
+        .callStatic.getUpkeep(id)
       assert.equal(mock.address, registration.target)
       assert.equal(0, registration.balance.toNumber())
       assert.equal(emptyBytes, registration.checkData)
@@ -500,7 +502,9 @@ describe('KeeperRegistryDev', () => {
 
     it('adds to the balance of the registration', async () => {
       await registry.connect(keeper1).addFunds(id, amount)
-      const registration = await registry.callStatic.getUpkeep(id)
+      const registration = await registry
+        .connect(zeroAddress)
+        .callStatic.getUpkeep(id)
       assert.isTrue(amount.eq(registration.balance))
     })
 
@@ -559,12 +563,14 @@ describe('KeeperRegistryDev', () => {
     })
 
     it('updates the gas limit successfully', async () => {
-      const initialGasLimit = (await registry.callStatic.getUpkeep(id))
-        .executeGas
+      const initialGasLimit = (
+        await registry.connect(zeroAddress).callStatic.getUpkeep(id)
+      ).executeGas
       assert.equal(initialGasLimit, executeGas.toNumber())
       await registry.connect(admin).setUpkeepGasLimit(id, newGasLimit)
-      const updatedGasLimit = (await registry.callStatic.getUpkeep(id))
-        .executeGas
+      const updatedGasLimit = (
+        await registry.connect(zeroAddress).callStatic.getUpkeep(id)
+      ).executeGas
       assert.equal(updatedGasLimit, newGasLimit.toNumber())
     })
 
@@ -713,11 +719,15 @@ describe('KeeperRegistryDev', () => {
     async function getPerformPaymentAmount() {
       _lastKeeper = _lastKeeper === keeper1 ? keeper2 : keeper1
       const before = (
-        await registry.callStatic.getKeeperInfo(await _lastKeeper.getAddress())
+        await registry
+          .connect(zeroAddress)
+          .callStatic.getKeeperInfo(await _lastKeeper.getAddress())
       ).balance
       await registry.connect(_lastKeeper).performUpkeep(id, '0x')
       const after = (
-        await registry.callStatic.getKeeperInfo(await _lastKeeper.getAddress())
+        await registry
+          .connect(zeroAddress)
+          .callStatic.getKeeperInfo(await _lastKeeper.getAddress())
       ).balance
       const difference = after.sub(before)
       return difference
@@ -808,10 +818,12 @@ describe('KeeperRegistryDev', () => {
       })
 
       it('updates payment balances', async () => {
-        const keeperBefore = await registry.callStatic.getKeeperInfo(
-          await keeper1.getAddress(),
-        )
-        const registrationBefore = await registry.callStatic.getUpkeep(id)
+        const keeperBefore = await registry
+          .connect(zeroAddress)
+          .callStatic.getKeeperInfo(await keeper1.getAddress())
+        const registrationBefore = await registry
+          .connect(zeroAddress)
+          .callStatic.getUpkeep(id)
         const keeperLinkBefore = await linkToken.balanceOf(
           await keeper1.getAddress(),
         )
@@ -820,10 +832,12 @@ describe('KeeperRegistryDev', () => {
         // Do the thing
         await registry.connect(keeper1).performUpkeep(id, '0x')
 
-        const keeperAfter = await registry.callStatic.getKeeperInfo(
-          await keeper1.getAddress(),
-        )
-        const registrationAfter = await registry.callStatic.getUpkeep(id)
+        const keeperAfter = await registry
+          .connect(zeroAddress)
+          .callStatic.getKeeperInfo(await keeper1.getAddress())
+        const registrationAfter = await registry
+          .connect(zeroAddress)
+          .callStatic.getUpkeep(id)
         const keeperLinkAfter = await linkToken.balanceOf(
           await keeper1.getAddress(),
         )
@@ -836,14 +850,18 @@ describe('KeeperRegistryDev', () => {
       })
 
       it('updates amount spent correctly', async () => {
-        const registrationBefore = await registry.callStatic.getUpkeep(id)
+        const registrationBefore = await registry
+          .connect(zeroAddress)
+          .callStatic.getUpkeep(id)
         const balanceBefore = registrationBefore.balance
         const amountSpentBefore = registrationBefore.amountSpent
 
         // Do the thing
         await registry.connect(keeper1).performUpkeep(id, '0x')
 
-        const registrationAfter = await registry.callStatic.getUpkeep(id)
+        const registrationAfter = await registry
+          .connect(zeroAddress)
+          .callStatic.getUpkeep(id)
         const balanceAfter = registrationAfter.balance
         const amountSpentAfter = registrationAfter.amountSpent
 
@@ -858,12 +876,16 @@ describe('KeeperRegistryDev', () => {
 
       it('only pays for gas used [ @skip-coverage ]', async () => {
         const before = (
-          await registry.callStatic.getKeeperInfo(await keeper1.getAddress())
+          await registry
+            .connect(zeroAddress)
+            .callStatic.getKeeperInfo(await keeper1.getAddress())
         ).balance
         const tx = await registry.connect(keeper1).performUpkeep(id, '0x')
         const receipt = await tx.wait()
         const after = (
-          await registry.callStatic.getKeeperInfo(await keeper1.getAddress())
+          await registry
+            .connect(zeroAddress)
+            .callStatic.getKeeperInfo(await keeper1.getAddress())
         ).balance
 
         const max = linkForGas(executeGas.toNumber())
@@ -894,14 +916,18 @@ describe('KeeperRegistryDev', () => {
         })
 
         const before = (
-          await registry.callStatic.getKeeperInfo(await keeper1.getAddress())
+          await registry
+            .connect(zeroAddress)
+            .callStatic.getKeeperInfo(await keeper1.getAddress())
         ).balance
         const tx = await registry
           .connect(keeper1)
           .performUpkeep(id, '0x', { gasPrice })
         const receipt = await tx.wait()
         const after = (
-          await registry.callStatic.getKeeperInfo(await keeper1.getAddress())
+          await registry
+            .connect(zeroAddress)
+            .callStatic.getKeeperInfo(await keeper1.getAddress())
         ).balance
 
         const max = linkForGas(executeGas).mul(multiplier)
@@ -933,14 +959,18 @@ describe('KeeperRegistryDev', () => {
         })
 
         const before = (
-          await registry.callStatic.getKeeperInfo(await keeper1.getAddress())
+          await registry
+            .connect(zeroAddress)
+            .callStatic.getKeeperInfo(await keeper1.getAddress())
         ).balance
         const tx = await registry
           .connect(keeper1)
           .performUpkeep(id, '0x', { gasPrice })
         const receipt = await tx.wait()
         const after = (
-          await registry.callStatic.getKeeperInfo(await keeper1.getAddress())
+          await registry
+            .connect(zeroAddress)
+            .callStatic.getKeeperInfo(await keeper1.getAddress())
         ).balance
 
         const max = linkForGas(executeGas.toNumber()).mul(effectiveMultiplier)
@@ -965,14 +995,18 @@ describe('KeeperRegistryDev', () => {
         await linkToken.connect(owner).approve(registry.address, toWei('100'))
         await registry.connect(owner).addFunds(id, toWei('100'))
         const keeperBalanceBefore = (
-          await registry.callStatic.getKeeperInfo(await keeper1.getAddress())
+          await registry
+            .connect(zeroAddress)
+            .callStatic.getKeeperInfo(await keeper1.getAddress())
         ).balance
 
         // Do the thing
         await registry.connect(keeper1).performUpkeep(id, '0x')
 
         const keeperBalanceAfter = (
-          await registry.callStatic.getKeeperInfo(await keeper1.getAddress())
+          await registry
+            .connect(zeroAddress)
+            .callStatic.getKeeperInfo(await keeper1.getAddress())
         ).balance
         assert.isTrue(keeperBalanceAfter.gt(keeperBalanceBefore))
       })
@@ -1109,9 +1143,9 @@ describe('KeeperRegistryDev', () => {
         await linkToken
           .connect(owner)
           .transfer(autoFunderUpkeep.address, toWei('1000'))
-        let maxPayment = await registry.callStatic.getMaxPaymentForGas(
-          executeGas,
-        )
+        let maxPayment = await registry
+          .connect(zeroAddress)
+          .callStatic.getMaxPaymentForGas(executeGas)
 
         // First set auto funding amount to 0 and verify that balance is deducted upon performUpkeep
         let initialBalance = toWei('100')
@@ -1120,8 +1154,9 @@ describe('KeeperRegistryDev', () => {
         await autoFunderUpkeep.setIsEligible(true)
         await registry.connect(keeper1).performUpkeep(upkeepID, '0x')
 
-        let postUpkeepBalance = (await registry.callStatic.getUpkeep(upkeepID))
-          .balance
+        let postUpkeepBalance = (
+          await registry.connect(zeroAddress).callStatic.getUpkeep(upkeepID)
+        ).balance
         assert.isTrue(postUpkeepBalance.lt(initialBalance)) // Balance should be deducted
         assert.isTrue(postUpkeepBalance.gte(initialBalance.sub(maxPayment))) // Balance should not be deducted more than maxPayment
 
@@ -1132,8 +1167,9 @@ describe('KeeperRegistryDev', () => {
         await autoFunderUpkeep.setIsEligible(true)
         await registry.connect(keeper2).performUpkeep(upkeepID, '0x')
 
-        postUpkeepBalance = (await registry.callStatic.getUpkeep(upkeepID))
-          .balance
+        postUpkeepBalance = (
+          await registry.connect(zeroAddress).callStatic.getUpkeep(upkeepID)
+        ).balance
         // Balance should increase by autoTopupAmount and decrease by max maxPayment
         assert.isTrue(
           postUpkeepBalance.gte(
@@ -1162,14 +1198,18 @@ describe('KeeperRegistryDev', () => {
         await autoFunderUpkeep.setIsEligible(true)
         await autoFunderUpkeep.setShouldCancel(true)
 
-        let registration = await registry.callStatic.getUpkeep(upkeepID)
+        let registration = await registry
+          .connect(zeroAddress)
+          .callStatic.getUpkeep(upkeepID)
         const oldExpiration = registration.maxValidBlocknumber
 
         // Do the thing
         await registry.connect(keeper1).performUpkeep(upkeepID, '0x')
 
         // Verify upkeep gets cancelled
-        registration = await registry.callStatic.getUpkeep(upkeepID)
+        registration = await registry
+          .connect(zeroAddress)
+          .callStatic.getUpkeep(upkeepID)
         const newExpiration = registration.maxValidBlocknumber
         assert.isTrue(newExpiration.lt(oldExpiration))
       })
@@ -1217,7 +1257,9 @@ describe('KeeperRegistryDev', () => {
         )
         const registryBefore = await linkToken.balanceOf(registry.address)
 
-        let registration = await registry.callStatic.getUpkeep(id)
+        let registration = await registry
+          .connect(zeroAddress)
+          .callStatic.getUpkeep(id)
         let previousBalance = registration.balance
 
         await registry
@@ -1230,7 +1272,9 @@ describe('KeeperRegistryDev', () => {
         assert.isTrue(payee1Before.add(previousBalance).eq(payee1After))
         assert.isTrue(registryBefore.sub(previousBalance).eq(registryAfter))
 
-        registration = await registry.callStatic.getUpkeep(id)
+        registration = await registry
+          .connect(zeroAddress)
+          .callStatic.getUpkeep(id)
         assert.equal(0, registration.balance.toNumber())
       })
 
@@ -1254,9 +1298,12 @@ describe('KeeperRegistryDev', () => {
         const payee1Before = await linkToken.balanceOf(
           await payee1.getAddress(),
         )
-        let upkeepBefore = (await registry.callStatic.getUpkeep(id)).balance
-        let ownerBefore = (await registry.callStatic.getState()).state
-          .ownerLinkBalance
+        let upkeepBefore = (
+          await registry.connect(zeroAddress).callStatic.getUpkeep(id)
+        ).balance
+        let ownerBefore = (
+          await registry.connect(zeroAddress).callStatic.getState()
+        ).state.ownerLinkBalance
         assert.equal(0, ownerBefore.toNumber())
 
         let amountSpent = toWei('100').sub(upkeepBefore)
@@ -1267,9 +1314,12 @@ describe('KeeperRegistryDev', () => {
           .withdrawFunds(id, await payee1.getAddress())
 
         const payee1After = await linkToken.balanceOf(await payee1.getAddress())
-        let upkeepAfter = (await registry.callStatic.getUpkeep(id)).balance
-        let ownerAfter = (await registry.callStatic.getState()).state
-          .ownerLinkBalance
+        let upkeepAfter = (
+          await registry.connect(zeroAddress).callStatic.getUpkeep(id)
+        ).balance
+        let ownerAfter = (
+          await registry.connect(zeroAddress).callStatic.getState()
+        ).state.ownerLinkBalance
 
         // Post upkeep balance should be 0
         assert.equal(0, upkeepAfter.toNumber())
@@ -1300,18 +1350,24 @@ describe('KeeperRegistryDev', () => {
         const payee1Before = await linkToken.balanceOf(
           await payee1.getAddress(),
         )
-        let upkeepBefore = (await registry.callStatic.getUpkeep(id)).balance
-        let ownerBefore = (await registry.callStatic.getState()).state
-          .ownerLinkBalance
+        let upkeepBefore = (
+          await registry.connect(zeroAddress).callStatic.getUpkeep(id)
+        ).balance
+        let ownerBefore = (
+          await registry.connect(zeroAddress).callStatic.getState()
+        ).state.ownerLinkBalance
         assert.equal(0, ownerBefore.toNumber())
 
         await registry
           .connect(admin)
           .withdrawFunds(id, await payee1.getAddress())
         const payee1After = await linkToken.balanceOf(await payee1.getAddress())
-        let ownerAfter = (await registry.callStatic.getState()).state
-          .ownerLinkBalance
-        let upkeepAfter = (await registry.callStatic.getUpkeep(id)).balance
+        let ownerAfter = (
+          await registry.connect(zeroAddress).callStatic.getState()
+        ).state.ownerLinkBalance
+        let upkeepAfter = (
+          await registry.connect(zeroAddress).callStatic.getUpkeep(id)
+        ).balance
 
         assert.equal(0, upkeepAfter.toNumber())
         // No funds should be transferred, all of upkeepBefore should be given to owner
@@ -1339,18 +1395,24 @@ describe('KeeperRegistryDev', () => {
         const payee1Before = await linkToken.balanceOf(
           await payee1.getAddress(),
         )
-        let upkeepBefore = (await registry.callStatic.getUpkeep(id)).balance
-        let ownerBefore = (await registry.callStatic.getState()).state
-          .ownerLinkBalance
+        let upkeepBefore = (
+          await registry.connect(zeroAddress).callStatic.getUpkeep(id)
+        ).balance
+        let ownerBefore = (
+          await registry.connect(zeroAddress).callStatic.getState()
+        ).state.ownerLinkBalance
         assert.equal(0, ownerBefore.toNumber())
 
         await registry
           .connect(admin)
           .withdrawFunds(id, await payee1.getAddress())
         const payee1After = await linkToken.balanceOf(await payee1.getAddress())
-        let ownerAfter = (await registry.callStatic.getState()).state
-          .ownerLinkBalance
-        let upkeepAfter = (await registry.callStatic.getUpkeep(id)).balance
+        let ownerAfter = (
+          await registry.connect(zeroAddress).callStatic.getState()
+        ).state.ownerLinkBalance
+        let upkeepAfter = (
+          await registry.connect(zeroAddress).callStatic.getUpkeep(id)
+        ).balance
 
         assert.equal(0, upkeepAfter.toNumber())
         // No cancellation fees for owner
@@ -1388,21 +1450,25 @@ describe('KeeperRegistryDev', () => {
         transcoder: transcoder.address,
         registrar: ethers.constants.AddressZero,
       })
-      let upkeepBalance = (await registry.callStatic.getUpkeep(id)).balance
+      let upkeepBalance = (
+        await registry.connect(zeroAddress).callStatic.getUpkeep(id)
+      ).balance
       const ownerBefore = await linkToken.balanceOf(await owner.getAddress())
 
       await registry.connect(owner).cancelUpkeep(id)
       await registry.connect(admin).withdrawFunds(id, await payee1.getAddress())
       // Transfered to owner balance on registry
-      let ownerRegistryBalance = (await registry.callStatic.getState()).state
-        .ownerLinkBalance
+      let ownerRegistryBalance = (
+        await registry.connect(zeroAddress).callStatic.getState()
+      ).state.ownerLinkBalance
       assert.isTrue(ownerRegistryBalance.eq(upkeepBalance))
 
       // Now withdraw
       await registry.connect(owner).withdrawOwnerFunds()
 
-      ownerRegistryBalance = (await registry.callStatic.getState()).state
-        .ownerLinkBalance
+      ownerRegistryBalance = (
+        await registry.connect(zeroAddress).callStatic.getState()
+      ).state.ownerLinkBalance
       const ownerAfter = await linkToken.balanceOf(await owner.getAddress())
 
       // Owner registry balance should be changed to 0
@@ -1432,7 +1498,9 @@ describe('KeeperRegistryDev', () => {
       it('sets the registration to invalid immediately', async () => {
         const tx = await registry.connect(owner).cancelUpkeep(id)
         const receipt = await tx.wait()
-        const registration = await registry.callStatic.getUpkeep(id)
+        const registration = await registry
+          .connect(zeroAddress)
+          .callStatic.getUpkeep(id)
         assert.equal(
           registration.maxValidBlocknumber.toNumber(),
           receipt.blockNumber,
@@ -1469,14 +1537,18 @@ describe('KeeperRegistryDev', () => {
 
         beforeEach(async () => {
           await registry.connect(admin).cancelUpkeep(id)
-          const registration = await registry.callStatic.getUpkeep(id)
+          const registration = await registry
+            .connect(zeroAddress)
+            .callStatic.getUpkeep(id)
           oldExpiration = registration.maxValidBlocknumber
         })
 
         it('allows the owner to cancel it more quickly', async () => {
           await registry.connect(owner).cancelUpkeep(id)
 
-          const registration = await registry.callStatic.getUpkeep(id)
+          const registration = await registry
+            .connect(zeroAddress)
+            .callStatic.getUpkeep(id)
           const newExpiration = registration.maxValidBlocknumber
           assert.isTrue(newExpiration.lt(oldExpiration))
         })
@@ -1489,7 +1561,9 @@ describe('KeeperRegistryDev', () => {
       it('sets the registration to invalid in 50 blocks', async () => {
         const tx = await registry.connect(admin).cancelUpkeep(id)
         const receipt = await tx.wait()
-        const registration = await registry.callStatic.getUpkeep(id)
+        const registration = await registry
+          .connect(zeroAddress)
+          .callStatic.getUpkeep(id)
         assert.equal(
           registration.maxValidBlocknumber.toNumber(),
           receipt.blockNumber + 50,
@@ -1594,10 +1668,13 @@ describe('KeeperRegistryDev', () => {
     it('updates the balances', async () => {
       const to = await nonkeeper.getAddress()
       const keeperBefore = (
-        await registry.callStatic.getKeeperInfo(await keeper1.getAddress())
+        await registry
+          .connect(zeroAddress)
+          .callStatic.getKeeperInfo(await keeper1.getAddress())
       ).balance
-      const registrationBefore = (await registry.callStatic.getUpkeep(id))
-        .balance
+      const registrationBefore = (
+        await registry.connect(zeroAddress).callStatic.getUpkeep(id)
+      ).balance
       const toLinkBefore = await linkToken.balanceOf(to)
       const registryLinkBefore = await linkToken.balanceOf(registry.address)
 
@@ -1607,10 +1684,13 @@ describe('KeeperRegistryDev', () => {
         .withdrawPayment(await keeper1.getAddress(), to)
 
       const keeperAfter = (
-        await registry.callStatic.getKeeperInfo(await keeper1.getAddress())
+        await registry
+          .connect(zeroAddress)
+          .callStatic.getKeeperInfo(await keeper1.getAddress())
       ).balance
-      const registrationAfter = (await registry.callStatic.getUpkeep(id))
-        .balance
+      const registrationAfter = (
+        await registry.connect(zeroAddress).callStatic.getUpkeep(id)
+      ).balance
       const toLinkAfter = await linkToken.balanceOf(to)
       const registryLinkAfter = await linkToken.balanceOf(registry.address)
 
@@ -1622,7 +1702,9 @@ describe('KeeperRegistryDev', () => {
 
     it('emits a log announcing the withdrawal', async () => {
       const balance = (
-        await registry.callStatic.getKeeperInfo(await keeper1.getAddress())
+        await registry
+          .connect(zeroAddress)
+          .callStatic.getKeeperInfo(await keeper1.getAddress())
       ).balance
       const tx = await registry
         .connect(payee1)
@@ -1674,9 +1756,9 @@ describe('KeeperRegistryDev', () => {
           await payee2.getAddress(),
         )
 
-      const info = await registry.callStatic.getKeeperInfo(
-        await keeper1.getAddress(),
-      )
+      const info = await registry
+        .connect(zeroAddress)
+        .callStatic.getKeeperInfo(await keeper1.getAddress())
       assert.equal(await payee1.getAddress(), info.payee)
     })
 
@@ -1748,9 +1830,9 @@ describe('KeeperRegistryDev', () => {
     it('does change the payee', async () => {
       await registry.connect(payee2).acceptPayeeship(await keeper1.getAddress())
 
-      const info = await registry.callStatic.getKeeperInfo(
-        await keeper1.getAddress(),
-      )
+      const info = await registry
+        .connect(zeroAddress)
+        .callStatic.getKeeperInfo(await keeper1.getAddress())
       assert.equal(await payee2.getAddress(), info.payee)
     })
   })
@@ -1786,7 +1868,8 @@ describe('KeeperRegistryDev', () => {
     })
 
     it('updates the config', async () => {
-      const old = (await registry.callStatic.getState()).config
+      const old = (await registry.connect(zeroAddress).callStatic.getState())
+        .config
       assert.isTrue(paymentPremiumPPB.eq(old.paymentPremiumPPB))
       assert.isTrue(flatFeeMicroLink.eq(old.flatFeeMicroLink))
       assert.isTrue(blockCountPerTurn.eq(old.blockCountPerTurn))
@@ -1808,7 +1891,9 @@ describe('KeeperRegistryDev', () => {
         registrar: ethers.constants.AddressZero,
       })
 
-      const updated = (await registry.callStatic.getState()).config
+      const updated = (
+        await registry.connect(zeroAddress).callStatic.getState()
+      ).config
       assert.equal(updated.paymentPremiumPPB, payment.toNumber())
       assert.equal(updated.flatFeeMicroLink, flatFee.toNumber())
       assert.equal(updated.blockCountPerTurn, checks.toNumber())
@@ -1895,11 +1980,15 @@ describe('KeeperRegistryDev', () => {
     it('updates the funds of the job id passed', async () => {
       const data = ethers.utils.defaultAbiCoder.encode(['uint256'], [id])
 
-      const before = (await registry.callStatic.getUpkeep(id)).balance
+      const before = (
+        await registry.connect(zeroAddress).callStatic.getUpkeep(id)
+      ).balance
       await linkToken
         .connect(owner)
         .transferAndCall(registry.address, amount, data)
-      const after = (await registry.callStatic.getUpkeep(id)).balance
+      const after = (
+        await registry.connect(zeroAddress).callStatic.getUpkeep(id)
+      ).balance
 
       assert.isTrue(before.add(amount).eq(after))
     })
@@ -2056,7 +2145,9 @@ describe('KeeperRegistryDev', () => {
               transcoder: transcoder.address,
               registrar: ethers.constants.AddressZero,
             })
-            const price = await registry.callStatic.getMaxPaymentForGas(gas)
+            const price = await registry
+              .connect(zeroAddress)
+              .callStatic.getMaxPaymentForGas(gas)
             expect(price).to.equal(linkForGas(gas, premium, flatFee))
           }
         }
@@ -2067,23 +2158,24 @@ describe('KeeperRegistryDev', () => {
   describe('#setPeerRegistryMigrationPermission() / #getPeerRegistryMigrationPermission()', () => {
     const peer = randomAddress()
     it('allows the owner to set the peer registries', async () => {
-      let permission =
-        await registry.callStatic.getPeerRegistryMigrationPermission(peer)
+      let permission = await registry
+        .connect(zeroAddress)
+        .callStatic.getPeerRegistryMigrationPermission(peer)
       expect(permission).to.equal(0)
       await registry.setPeerRegistryMigrationPermission(peer, 1)
-      permission = await registry.callStatic.getPeerRegistryMigrationPermission(
-        peer,
-      )
+      permission = await registry
+        .connect(zeroAddress)
+        .callStatic.getPeerRegistryMigrationPermission(peer)
       expect(permission).to.equal(1)
       await registry.setPeerRegistryMigrationPermission(peer, 2)
-      permission = await registry.callStatic.getPeerRegistryMigrationPermission(
-        peer,
-      )
+      permission = await registry
+        .connect(zeroAddress)
+        .callStatic.getPeerRegistryMigrationPermission(peer)
       expect(permission).to.equal(2)
       await registry.setPeerRegistryMigrationPermission(peer, 0)
-      permission = await registry.callStatic.getPeerRegistryMigrationPermission(
-        peer,
-      )
+      permission = await registry
+        .connect(zeroAddress)
+        .callStatic.getPeerRegistryMigrationPermission(peer)
       expect(permission).to.equal(0)
     })
     it('reverts if passed an unsupported permission', async () => {
@@ -2108,46 +2200,61 @@ describe('KeeperRegistryDev', () => {
       })
 
       it('migrates an upkeep', async () => {
-        expect((await registry.callStatic.getUpkeep(id)).balance).to.equal(
-          toWei('100'),
-        )
-        expect((await registry.callStatic.getUpkeep(id)).checkData).to.equal(
-          randomBytes,
-        )
         expect(
-          (await registry.callStatic.getState()).state.numUpkeeps,
+          (await registry.connect(zeroAddress).callStatic.getUpkeep(id))
+            .balance,
+        ).to.equal(toWei('100'))
+        expect(
+          (await registry.connect(zeroAddress).callStatic.getUpkeep(id))
+            .checkData,
+        ).to.equal(randomBytes)
+        expect(
+          (await registry.connect(zeroAddress).callStatic.getState()).state
+            .numUpkeeps,
         ).to.equal(1)
         // migrate
         await registry.connect(admin).migrateUpkeeps([id], registry2.address)
         expect(
-          (await registry.callStatic.getState()).state.numUpkeeps,
+          (await registry.connect(zeroAddress).callStatic.getState()).state
+            .numUpkeeps,
         ).to.equal(0)
         expect(
-          (await registry2.callStatic.getState()).state.numUpkeeps,
+          (await registry2.connect(zeroAddress).callStatic.getState()).state
+            .numUpkeeps,
         ).to.equal(1)
-        expect((await registry.callStatic.getUpkeep(id)).balance).to.equal(0)
-        expect((await registry.callStatic.getUpkeep(id)).checkData).to.equal(
-          '0x',
-        )
-        expect((await registry2.callStatic.getUpkeep(id)).balance).to.equal(
-          toWei('100'),
-        )
         expect(
-          (await registry2.callStatic.getState()).state.expectedLinkBalance,
+          (await registry.connect(zeroAddress).callStatic.getUpkeep(id))
+            .balance,
+        ).to.equal(0)
+        expect(
+          (await registry.connect(zeroAddress).callStatic.getUpkeep(id))
+            .checkData,
+        ).to.equal('0x')
+        expect(
+          (await registry2.connect(zeroAddress).callStatic.getUpkeep(id))
+            .balance,
         ).to.equal(toWei('100'))
-        expect((await registry2.callStatic.getUpkeep(id)).checkData).to.equal(
-          randomBytes,
-        )
+        expect(
+          (await registry2.connect(zeroAddress).callStatic.getState()).state
+            .expectedLinkBalance,
+        ).to.equal(toWei('100'))
+        expect(
+          (await registry2.connect(zeroAddress).callStatic.getUpkeep(id))
+            .checkData,
+        ).to.equal(randomBytes)
       })
       it('emits an event on both contracts', async () => {
-        expect((await registry.callStatic.getUpkeep(id)).balance).to.equal(
-          toWei('100'),
-        )
-        expect((await registry.callStatic.getUpkeep(id)).checkData).to.equal(
-          randomBytes,
-        )
         expect(
-          (await registry.callStatic.getState()).state.numUpkeeps,
+          (await registry.connect(zeroAddress).callStatic.getUpkeep(id))
+            .balance,
+        ).to.equal(toWei('100'))
+        expect(
+          (await registry.connect(zeroAddress).callStatic.getUpkeep(id))
+            .checkData,
+        ).to.equal(randomBytes)
+        expect(
+          (await registry.connect(zeroAddress).callStatic.getState()).state
+            .numUpkeeps,
         ).to.equal(1)
         const tx = registry
           .connect(admin)
@@ -2238,11 +2345,13 @@ describe('KeeperRegistryDev', () => {
       await mock.setCanPerform(true)
       // upkeep 1 is underfunded, 2 is funded
       const minBalance1 = (
-        await registry.callStatic.getMaxPaymentForGas(executeGas)
+        await registry
+          .connect(zeroAddress)
+          .callStatic.getMaxPaymentForGas(executeGas)
       ).sub(1)
-      const minBalance2 = await registry.callStatic.getMaxPaymentForGas(
-        executeGas,
-      )
+      const minBalance2 = await registry
+        .connect(zeroAddress)
+        .callStatic.getMaxPaymentForGas(executeGas)
       await registry.connect(owner).addFunds(upkeepID1, minBalance1)
       await registry.connect(owner).addFunds(upkeepID2, minBalance2)
       // upkeep 1 check should revert, 2 should succeed
@@ -2277,7 +2386,9 @@ describe('KeeperRegistryDev', () => {
       await linkToken.connect(keeper1).approve(registry.address, toWei('100'))
       await mock.setCanCheck(true)
       await mock.setCanPerform(true)
-      const minBalance = await registry.callStatic.getMinBalanceForUpkeep(id)
+      const minBalance = await registry
+        .connect(zeroAddress)
+        .callStatic.getMinBalanceForUpkeep(id)
       const tooLow = minBalance.sub(oneWei)
       await registry.connect(keeper1).addFunds(id, tooLow)
       await evmRevert(


### PR DESCRIPTION
This PR tries to move rest of the view functions behind proxy. Solidity does not allow view functions to have delegate calls inside them.

The cleanest way I could make it work, is to make those functions non view, while keeping them as view on logic contract. This also meant that our interface need to be duplicate which is not ideal.


---------

Contract size after this PR:
Existing dev registry: 23.99Mb
Registry after this refactor: 22.57Mb

So this PR helps in **reducing size by 1.42Mb**