### PR TITLE
Fixed mockery usage for FM

### DIFF
--- a/core/services/fluxmonitorv2/contract_submitter_test.go
+++ b/core/services/fluxmonitorv2/contract_submitter_test.go
@@ -15,9 +15,9 @@ import (
 
 func TestFluxAggregatorContractSubmitter_Submit(t *testing.T) {
 	var (
-		fluxAggregator = new(mocks.FluxAggregator)
-		orm            = new(fmmocks.ORM)
-		keyStore       = new(fmmocks.KeyStoreInterface)
+		fluxAggregator = mocks.NewFluxAggregator(t)
+		orm            = fmmocks.NewORM(t)
+		keyStore       = fmmocks.NewKeyStoreInterface(t)
 		gasLimit       = uint64(2100)
 		submitter      = fluxmonitorv2.NewFluxAggregatorContractSubmitter(fluxAggregator, orm, keyStore, gasLimit)
 

--- a/core/services/fluxmonitorv2/flags_test.go
+++ b/core/services/fluxmonitorv2/flags_test.go
@@ -32,7 +32,7 @@ func TestFlags_IsLowered(t *testing.T) {
 			t.Parallel()
 
 			var (
-				flagsContract = new(mocks.Flags)
+				flagsContract = mocks.NewFlags(t)
 				address       = testutils.NewAddress()
 			)
 
@@ -50,8 +50,6 @@ func TestFlags_IsLowered(t *testing.T) {
 			result, err := flags.IsLowered(address)
 			require.NoError(t, err)
 			require.Equal(t, tc.expected, result)
-
-			flagsContract.AssertExpectations(t)
 		})
 	}
 }

--- a/core/services/fluxmonitorv2/key_store_test.go
+++ b/core/services/fluxmonitorv2/key_store_test.go
@@ -4,11 +4,12 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2"
-	"github.com/stretchr/testify/require"
 )
 
 func TestKeyStore_SendingKeys(t *testing.T) {

--- a/core/services/fluxmonitorv2/orm_test.go
+++ b/core/services/fluxmonitorv2/orm_test.go
@@ -167,10 +167,10 @@ func TestORM_CreateEthTransaction(t *testing.T) {
 	cfg := cltest.NewTestGeneralConfig(t)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
-	strategy := new(txmmocks.TxStrategy)
+	strategy := txmmocks.NewTxStrategy(t)
 
 	var (
-		txm = new(txmmocks.TxManager)
+		txm = txmmocks.NewTxManager(t)
 		orm = fluxmonitorv2.NewORM(db, logger.TestLogger(t), cfg, txm, strategy, txmgr.TransmitCheckerSpec{})
 
 		_, from  = cltest.MustInsertRandomKey(t, ethKeyStore, 0)
@@ -189,6 +189,4 @@ func TestORM_CreateEthTransaction(t *testing.T) {
 	}).Return(txmgr.EthTx{}, nil).Once()
 
 	orm.CreateEthTransaction(from, to, payload, gasLimit)
-
-	txm.AssertExpectations(t)
 }


### PR DESCRIPTION
Part of https://app.shortcut.com/chainlinklabs/story/44670/spike-mockery-usage-overhaul

We know at least two flakey tests in FM and both are hard to investigate due to a mock-related failure:
https://app.shortcut.com/chainlinklabs/story/34983/flakey-testfluxmonitor-hibernationisenteredandretrytickerstopped
https://app.shortcut.com/chainlinklabs/story/46526/test-flake-testfluxmonitor-idletimerresetsonnewround

With the mockery usage fix suggested by @jmank88, it should be easier to find the root cause of those flakey tests in case they appear again. Hence this change for FM.