### PR TITLE
Fixed mockery usage for pipeline

### DIFF
--- a/core/services/pipeline/runner_test.go
+++ b/core/services/pipeline/runner_test.go
@@ -37,10 +37,10 @@ import (
 
 func newRunner(t testing.TB, db *sqlx.DB, cfg *configtest.TestGeneralConfig) (pipeline.Runner, *mocks.ORM) {
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: cfg})
-	orm := new(mocks.ORM)
+	orm := mocks.NewORM(t)
 	q := pg.NewQ(db, logger.TestLogger(t), cfg)
 
-	orm.On("GetQ").Return(q)
+	orm.On("GetQ").Return(q).Maybe()
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 	c := clhttptest.NewTestLocalOnlyHTTPClient()
 	r := pipeline.NewRunner(orm, cfg, cc, ethKeyStore, nil, logger.TestLogger(t), c, c)
@@ -401,10 +401,10 @@ func Test_PipelineRunner_HandleFaults(t *testing.T) {
 	// but a sufficient number of them still complete within the desired time frame
 	// and so we can still obtain a median.
 	db := pgtest.NewSqlxDB(t)
-	orm := new(mocks.ORM)
+	orm := mocks.NewORM(t)
 	q := pg.NewQ(db, logger.TestLogger(t), cltest.NewTestGeneralConfig(t))
 
-	orm.On("GetQ").Return(q)
+	orm.On("GetQ").Return(q).Maybe()
 	m1 := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 		time.Sleep(100 * time.Millisecond)
 		res.WriteHeader(http.StatusOK)
@@ -452,9 +452,9 @@ answer1 [type=median                      index=0];
 
 func Test_PipelineRunner_HandleFaultsPersistRun(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	orm := new(mocks.ORM)
+	orm := mocks.NewORM(t)
 	q := pg.NewQ(db, logger.TestLogger(t), cltest.NewTestGeneralConfig(t))
-	orm.On("GetQ").Return(q)
+	orm.On("GetQ").Return(q).Maybe()
 	orm.On("InsertFinishedRun", mock.Anything, mock.Anything, mock.Anything).
 		Run(func(args mock.Arguments) {
 			args.Get(0).(*pipeline.Run).ID = 1

--- a/core/services/pipeline/task.eth_call_test.go
+++ b/core/services/pipeline/task.eth_call_test.go
@@ -220,7 +220,7 @@ func TestETHCallTask(t *testing.T) {
 				contractAddr := common.HexToAddress("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF")
 				ethClient.
 					On("CallContract", mock.Anything, ethereum.CallMsg{To: &contractAddr, Data: []byte("foo bar")}, (*big.Int)(nil)).
-					Return([]byte("baz quux"), nil)
+					Return([]byte("baz quux"), nil).Maybe()
 			},
 			nil, nil, "chain not found",
 		},
@@ -238,17 +238,17 @@ func TestETHCallTask(t *testing.T) {
 				Gas:        test.gas,
 			}
 
-			ethClient := new(evmmocks.Client)
-			config := new(pipelinemocks.Config)
+			ethClient := evmmocks.NewClient(t)
+			config := pipelinemocks.NewConfig(t)
 			test.setupClientMocks(ethClient, config)
 
 			cfg := configtest.NewTestGeneralConfig(t)
 			cfg.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(int64(gasLimit))
 			cfg.Overrides.GlobalEvmGasLimitDRJobType = null.IntFrom(int64(drJobTypeGasLimit))
 
-			keyStore := new(keystoremocks.Eth)
+			keyStore := keystoremocks.NewEth(t)
 			keyStore.Test(t)
-			txManager := new(txmmocks.TxManager)
+			txManager := txmmocks.NewTxManager(t)
 			txManager.Test(t)
 			db := pgtest.NewSqlxDB(t)
 

--- a/core/services/pipeline/task.eth_tx_test.go
+++ b/core/services/pipeline/task.eth_tx_test.go
@@ -540,9 +540,9 @@ func TestETHTxTask(t *testing.T) {
 				TransmitChecker:  test.transmitChecker,
 			}
 
-			keyStore := new(keystoremocks.Eth)
+			keyStore := keystoremocks.NewEth(t)
 			keyStore.Test(t)
-			txManager := new(txmmocks.TxManager)
+			txManager := txmmocks.NewTxManager(t)
 			txManager.Test(t)
 			db := pgtest.NewSqlxDB(t)
 			cfg := configtest.NewTestGeneralConfig(t)
@@ -569,9 +569,6 @@ func TestETHTxTask(t *testing.T) {
 				require.NoError(t, result.Error)
 				require.Equal(t, test.expected, result.Value)
 			}
-
-			keyStore.AssertExpectations(t)
-			txManager.AssertExpectations(t)
 		})
 	}
 }

--- a/core/services/pipeline/task_params_test.go
+++ b/core/services/pipeline/task_params_test.go
@@ -658,7 +658,7 @@ func TestResolveValue(t *testing.T) {
 	t.Parallel()
 
 	t.Run("calls getters in order until the first one that returns without ErrParameterEmpty", func(t *testing.T) {
-		param := new(mocks.PipelineParamUnmarshaler)
+		param := mocks.NewPipelineParamUnmarshaler(t)
 		param.On("UnmarshalPipelineParam", mock.Anything).Return(nil)
 
 		called := []int{}
@@ -680,12 +680,10 @@ func TestResolveValue(t *testing.T) {
 		err := pipeline.ResolveParam(param, getters)
 		require.NoError(t, err)
 		require.Equal(t, []int{0, 1}, called)
-
-		param.AssertExpectations(t)
 	})
 
 	t.Run("returns any GetterFunc error that isn't ErrParameterEmpty", func(t *testing.T) {
-		param := new(mocks.PipelineParamUnmarshaler)
+		param := mocks.NewPipelineParamUnmarshaler(t)
 		called := []int{}
 		expectedErr := errors.New("some other issue")
 
@@ -712,7 +710,7 @@ func TestResolveValue(t *testing.T) {
 	t.Run("calls UnmarshalPipelineParam with the value obtained from the GetterFuncs", func(t *testing.T) {
 		expectedValue := 123
 
-		param := new(mocks.PipelineParamUnmarshaler)
+		param := mocks.NewPipelineParamUnmarshaler(t)
 		param.On("UnmarshalPipelineParam", expectedValue).Return(nil)
 
 		getters := []pipeline.GetterFunc{
@@ -723,15 +721,13 @@ func TestResolveValue(t *testing.T) {
 
 		err := pipeline.ResolveParam(param, getters)
 		require.NoError(t, err)
-
-		param.AssertExpectations(t)
 	})
 
 	t.Run("returns any error returned by UnmarshalPipelineParam", func(t *testing.T) {
 		expectedValue := 123
 		expectedErr := errors.New("some issue")
 
-		param := new(mocks.PipelineParamUnmarshaler)
+		param := mocks.NewPipelineParamUnmarshaler(t)
 		param.On("UnmarshalPipelineParam", expectedValue).Return(expectedErr)
 
 		getters := []pipeline.GetterFunc{
@@ -742,7 +738,5 @@ func TestResolveValue(t *testing.T) {
 
 		err := pipeline.ResolveParam(param, getters)
 		require.Equal(t, expectedErr, err)
-
-		param.AssertExpectations(t)
 	})
 }


### PR DESCRIPTION
Part of https://app.shortcut.com/chainlinklabs/story/44670/spike-mockery-usage-overhaul