### PR TITLE
increase timeout in keepers check gas limit test

### DIFF
--- a/integration-tests/smoke/keeper_test.go
+++ b/integration-tests/smoke/keeper_test.go
@@ -394,7 +394,7 @@ var _ = Describe("Keeper Suite @keeper", func() {
 					BeNumerically("<=", existingCnt.Int64()+numUpkeepsAllowedForStragglingTxs),
 					"Expected consumer counter to remain constant at %d, but got %d", existingCnt.Int64(), cnt.Int64(),
 				)
-			}, "1m", "1s").Should(Succeed())
+			}, "3m", "1s").Should(Succeed())
 
 			// Now increase checkGasLimit on registry
 			highCheckGasLimit := defaultRegistryConfig


### PR DESCRIPTION
We increased the assertion that upkeep count increases by 6 in [PR](https://github.com/smartcontractkit/chainlink/pull/6992)

Let's also increase the timeout for when we expect this to happen, to make the test more stable and [consistent with other tests](https://github.com/smartcontractkit/chainlink/pull/6992#discussion_r926985431). 