### PR TITLE
internal/config: fix TOML parse error

### DIFF
--- a/internal/config/docs.go
+++ b/internal/config/docs.go
@@ -194,7 +194,6 @@ func parseTOMLDocs(s string) (items []fmt.Stringer, err error) {
 			desc = append(desc, strings.TrimSpace(line[1:]))
 		} else if strings.TrimSpace(line) == "" {
 			// empty
-			currentTable = &globalTable
 			if len(desc) > 0 {
 				items = append(items, desc)
 				desc = nil


### PR DESCRIPTION
In #6935 @pinebit discovered that I misinterpretted the TOML spec in the docs generation script. A line break should not reset the context to the global level.

> Under that, and until the next header or EOF, are the key/values of that table. Key/value pairs within tables are not guaranteed to be in any specific order.

https://toml.io/en/v1.0.0#table
