### PR TITLE
Add support for besu's non-unique logIndex

### DIFF
--- a/core/chains/evm/log/broadcaster.go
+++ b/core/chains/evm/log/broadcaster.go
@@ -668,12 +668,12 @@ func (b *broadcaster) maybeWarnOnLargeBlockNumberDifference(logBlockNumber int64
 
 // WasAlreadyConsumed reports whether the given consumer had already consumed the given log
 func (b *broadcaster) WasAlreadyConsumed(lb Broadcast, qopts ...pg.QOpt) (bool, error) {
-	return b.orm.WasBroadcastConsumed(lb.RawLog().BlockHash, lb.RawLog().Index, lb.JobID(), qopts...)
+	return b.orm.WasBroadcastConsumed(lb.RawLog().BlockHash, lb.RawLog().TxIndex, lb.RawLog().Index, lb.JobID(), qopts...)
 }
 
 // MarkConsumed marks the log as having been successfully consumed by the subscriber
 func (b *broadcaster) MarkConsumed(lb Broadcast, qopts ...pg.QOpt) error {
-	return b.orm.MarkBroadcastConsumed(lb.RawLog().BlockHash, lb.RawLog().BlockNumber, lb.RawLog().Index, lb.JobID(), qopts...)
+	return b.orm.MarkBroadcastConsumed(lb.RawLog().BlockHash, lb.RawLog().BlockNumber, lb.RawLog().TxIndex, lb.RawLog().Index, lb.JobID(), qopts...)
 }
 
 // MarkManyConsumed marks the logs as having been successfully consumed by the subscriber
@@ -681,16 +681,18 @@ func (b *broadcaster) MarkManyConsumed(lbs []Broadcast, qopts ...pg.QOpt) (err e
 	var (
 		blockHashes  = make([]common.Hash, len(lbs))
 		blockNumbers = make([]uint64, len(lbs))
+		txIndexes    = make([]uint, len(lbs))
 		logIndexes   = make([]uint, len(lbs))
 		jobIDs       = make([]int32, len(lbs))
 	)
 	for i := range lbs {
 		blockHashes[i] = lbs[i].RawLog().BlockHash
 		blockNumbers[i] = lbs[i].RawLog().BlockNumber
+		txIndexes[i] = lbs[i].RawLog().TxIndex
 		logIndexes[i] = lbs[i].RawLog().Index
 		jobIDs[i] = lbs[i].JobID()
 	}
-	return b.orm.MarkBroadcastsConsumed(blockHashes, blockNumbers, logIndexes, jobIDs, qopts...)
+	return b.orm.MarkBroadcastsConsumed(blockHashes, blockNumbers, txIndexes, logIndexes, jobIDs, qopts...)
 }
 
 // test only

--- a/core/chains/evm/log/helpers_test.go
+++ b/core/chains/evm/log/helpers_test.go
@@ -340,11 +340,11 @@ func (listener *simpleLogListener) handleLogBroadcast(t *testing.T, lggr logger.
 }
 
 func (listener *simpleLogListener) WasAlreadyConsumed(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig, broadcast log.Broadcast) (bool, error) {
-	return log.NewORM(listener.db, lggr, cfg, cltest.FixtureChainID).WasBroadcastConsumed(broadcast.RawLog().BlockHash, broadcast.RawLog().Index, listener.jobID)
+	return log.NewORM(listener.db, lggr, cfg, cltest.FixtureChainID).WasBroadcastConsumed(broadcast.RawLog().BlockHash, broadcast.RawLog().TxIndex, broadcast.RawLog().Index, listener.jobID)
 }
 
 func (listener *simpleLogListener) MarkConsumed(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig, broadcast log.Broadcast) error {
-	return log.NewORM(listener.db, lggr, cfg, cltest.FixtureChainID).MarkBroadcastConsumed(broadcast.RawLog().BlockHash, broadcast.RawLog().BlockNumber, broadcast.RawLog().Index, listener.jobID)
+	return log.NewORM(listener.db, lggr, cfg, cltest.FixtureChainID).MarkBroadcastConsumed(broadcast.RawLog().BlockHash, broadcast.RawLog().BlockNumber, broadcast.RawLog().TxIndex, broadcast.RawLog().Index, listener.jobID)
 }
 
 type mockListener struct {

--- a/core/chains/evm/log/integration_test.go
+++ b/core/chains/evm/log/integration_test.go
@@ -366,7 +366,7 @@ func TestBroadcaster_BackfillUnconsumedAfterCrash(t *testing.T) {
 	require.Equal(t, int64(log2.BlockNumber), *blockNum)
 	require.NotEmpty(t, listener.getUniqueLogs())
 	require.Empty(t, listener2.getUniqueLogs())
-	c, err := orm.WasBroadcastConsumed(log1.BlockHash, log1.Index, listener.JobID())
+	c, err := orm.WasBroadcastConsumed(log1.BlockHash, log1.TxIndex, log1.Index, listener.JobID())
 	require.NoError(t, err)
 	require.False(t, c)
 
@@ -404,10 +404,10 @@ func TestBroadcaster_BackfillUnconsumedAfterCrash(t *testing.T) {
 	require.Nil(t, blockNum)
 	require.NotEmpty(t, listener.getUniqueLogs())
 	require.NotEmpty(t, listener2.getUniqueLogs())
-	c, err = orm.WasBroadcastConsumed(log1.BlockHash, log1.Index, listener.JobID())
+	c, err = orm.WasBroadcastConsumed(log1.BlockHash, log1.TxIndex, log1.Index, listener.JobID())
 	require.NoError(t, err)
 	require.True(t, c)
-	c, err = orm.WasBroadcastConsumed(log2.BlockHash, log2.Index, listener2.JobID())
+	c, err = orm.WasBroadcastConsumed(log2.BlockHash, log2.TxIndex, log2.Index, listener2.JobID())
 	require.NoError(t, err)
 	require.False(t, c)
 
@@ -443,7 +443,7 @@ func TestBroadcaster_BackfillUnconsumedAfterCrash(t *testing.T) {
 	require.Nil(t, blockNum)
 	require.Empty(t, listener.getUniqueLogs())
 	require.NotEmpty(t, listener2.getUniqueLogs())
-	c, err = orm.WasBroadcastConsumed(log2.BlockHash, log2.Index, listener2.JobID())
+	c, err = orm.WasBroadcastConsumed(log2.BlockHash, log2.TxIndex, log2.Index, listener2.JobID())
 	require.NoError(t, err)
 	require.True(t, c)
 }

--- a/core/chains/evm/log/orm.go
+++ b/core/chains/evm/log/orm.go
@@ -28,13 +28,13 @@ type ORM interface {
 	// FindBroadcasts returns broadcasts for a range of block numbers, both consumed and unconsumed.
 	FindBroadcasts(fromBlockNum int64, toBlockNum int64) ([]LogBroadcast, error)
 	// CreateBroadcast inserts an unconsumed log broadcast for jobID.
-	CreateBroadcast(blockHash common.Hash, blockNumber uint64, logIndex uint, jobID int32, qopts ...pg.QOpt) error
+	CreateBroadcast(blockHash common.Hash, blockNumber uint64, txIndex uint, logIndex uint, jobID int32, qopts ...pg.QOpt) error
 	// WasBroadcastConsumed returns true if jobID consumed the log broadcast.
-	WasBroadcastConsumed(blockHash common.Hash, logIndex uint, jobID int32, qopts ...pg.QOpt) (bool, error)
+	WasBroadcastConsumed(blockHash common.Hash, txIndex uint, logIndex uint, jobID int32, qopts ...pg.QOpt) (bool, error)
 	// MarkBroadcastConsumed marks the log broadcast as consumed by jobID.
-	MarkBroadcastConsumed(blockHash common.Hash, blockNumber uint64, logIndex uint, jobID int32, qopts ...pg.QOpt) error
+	MarkBroadcastConsumed(blockHash common.Hash, blockNumber uint64, txIndex uint, logIndex uint, jobID int32, qopts ...pg.QOpt) error
 	// MarkBroadcastsConsumed marks the log broadcasts as consumed by jobID.
-	MarkBroadcastsConsumed(blockHashes []common.Hash, blockNumbers []uint64, logIndexes []uint, jobIDs []int32, qopts ...pg.QOpt) error
+	MarkBroadcastsConsumed(blockHashes []common.Hash, blockNumbers []uint64, txIndexes []uint, logIndexes []uint, jobIDs []int32, qopts ...pg.QOpt) error
 	// MarkBroadcastsUnconsumed marks all log broadcasts from all jobs on or after fromBlock as
 	// unconsumed.
 	MarkBroadcastsUnconsumed(fromBlock int64, qopts ...pg.QOpt) error
@@ -60,16 +60,18 @@ func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig, evmChainID big.In
 	return &orm{pg.NewQ(db, lggr, cfg), *utils.NewBig(&evmChainID)}
 }
 
-func (o *orm) WasBroadcastConsumed(blockHash common.Hash, logIndex uint, jobID int32, qopts ...pg.QOpt) (consumed bool, err error) {
+func (o *orm) WasBroadcastConsumed(blockHash common.Hash, txIndex uint, logIndex uint, jobID int32, qopts ...pg.QOpt) (consumed bool, err error) {
 	query := `
 		SELECT consumed FROM log_broadcasts
 		WHERE block_hash = $1
-		AND log_index = $2
-		AND job_id = $3
-		AND evm_chain_id = $4
+		AND (tx_index is NULL OR tx_index = $2) -- NULL-check only for safe upgrade from 1.6.0
+		AND log_index = $3
+		AND job_id = $4
+		AND evm_chain_id = $5
     `
 	args := []interface{}{
 		blockHash,
+		txIndex,
 		logIndex,
 		jobID,
 		o.evmChainID,
@@ -85,7 +87,7 @@ func (o *orm) WasBroadcastConsumed(blockHash common.Hash, logIndex uint, jobID i
 func (o *orm) FindBroadcasts(fromBlockNum int64, toBlockNum int64) ([]LogBroadcast, error) {
 	var broadcasts []LogBroadcast
 	query := `
-		SELECT block_hash, consumed, log_index, job_id FROM log_broadcasts
+		SELECT block_hash, consumed, tx_index, log_index, job_id FROM log_broadcasts
 		WHERE block_number >= $1
 		AND block_number <= $2
 		AND evm_chain_id = $3
@@ -97,53 +99,55 @@ func (o *orm) FindBroadcasts(fromBlockNum int64, toBlockNum int64) ([]LogBroadca
 	return broadcasts, err
 }
 
-func (o *orm) CreateBroadcast(blockHash common.Hash, blockNumber uint64, logIndex uint, jobID int32, qopts ...pg.QOpt) error {
+func (o *orm) CreateBroadcast(blockHash common.Hash, blockNumber uint64, txIndex uint, logIndex uint, jobID int32, qopts ...pg.QOpt) error {
 	q := o.q.WithOpts(qopts...)
 	err := q.ExecQ(`
-        INSERT INTO log_broadcasts (block_hash, block_number, log_index, job_id, created_at, updated_at, consumed, evm_chain_id)
-		VALUES ($1, $2, $3, $4, NOW(), NOW(), false, $5)
-    `, blockHash, blockNumber, logIndex, jobID, o.evmChainID)
+        INSERT INTO log_broadcasts (block_hash, block_number, tx_index, log_index, job_id, created_at, updated_at, consumed, evm_chain_id)
+		VALUES ($1, $2, $3, $4, $5, NOW(), NOW(), false, $6)
+    `, blockHash, blockNumber, txIndex, logIndex, jobID, o.evmChainID)
 	return errors.Wrap(err, "failed to create log broadcast")
 }
 
-func (o *orm) MarkBroadcastConsumed(blockHash common.Hash, blockNumber uint64, logIndex uint, jobID int32, qopts ...pg.QOpt) error {
+func (o *orm) MarkBroadcastConsumed(blockHash common.Hash, blockNumber uint64, txIndex uint, logIndex uint, jobID int32, qopts ...pg.QOpt) error {
 	q := o.q.WithOpts(qopts...)
 	err := q.ExecQ(`
-        INSERT INTO log_broadcasts (block_hash, block_number, log_index, job_id, created_at, updated_at, consumed, evm_chain_id)
-		VALUES ($1, $2, $3, $4, NOW(), NOW(), true, $5)
-		ON CONFLICT (job_id, block_hash, log_index, evm_chain_id) DO UPDATE
+        INSERT INTO log_broadcasts (block_hash, block_number, tx_index, log_index, job_id, created_at, updated_at, consumed, evm_chain_id)
+		VALUES ($1, $2, $3, $4, $5, NOW(), NOW(), true, $6)
+		ON CONFLICT (job_id, block_hash, tx_index, log_index, evm_chain_id) DO UPDATE
 		SET consumed = true, updated_at = NOW()
-    `, blockHash, blockNumber, logIndex, jobID, o.evmChainID)
+    `, blockHash, blockNumber, txIndex, logIndex, jobID, o.evmChainID)
 	return errors.Wrap(err, "failed to mark log broadcast as consumed")
 }
 
 // MarkBroadcastsConsumed marks many broadcasts as consumed.
 // The lengths of all the provided slices must be equal, otherwise an error is returned.
-func (o *orm) MarkBroadcastsConsumed(blockHashes []common.Hash, blockNumbers []uint64, logIndexes []uint, jobIDs []int32, qopts ...pg.QOpt) error {
-	if !utils.AllEqual(len(blockHashes), len(blockNumbers), len(logIndexes), len(jobIDs)) {
-		return fmt.Errorf("all arg slice lengths must be equal, got: %d %d %d %d",
-			len(blockHashes), len(blockNumbers), len(logIndexes), len(jobIDs),
+func (o *orm) MarkBroadcastsConsumed(blockHashes []common.Hash, blockNumbers []uint64, txIndexes []uint, logIndexes []uint, jobIDs []int32, qopts ...pg.QOpt) error {
+	if !utils.AllEqual(len(blockHashes), len(blockNumbers), len(txIndexes), len(logIndexes), len(jobIDs)) {
+		return fmt.Errorf("all arg slice lengths must be equal, got: %d %d %d %d %d",
+			len(blockHashes), len(blockNumbers), len(txIndexes), len(logIndexes), len(jobIDs),
 		)
 	}
 
 	type input struct {
 		BlockHash   common.Hash `db:"blockHash"`
 		BlockNumber uint64      `db:"blockNumber"`
+		TxIndex     uint        `db:"txIndex"`
 		LogIndex    uint        `db:"logIndex"`
 		JobID       int32       `db:"jobID"`
 		ChainID     utils.Big   `db:"chainID"`
 	}
 	inputs := make([]input, len(blockHashes))
 	query := `
-INSERT INTO log_broadcasts (block_hash, block_number, log_index, job_id, created_at, updated_at, consumed, evm_chain_id)
-VALUES (:blockHash, :blockNumber, :logIndex, :jobID, NOW(), NOW(), true, :chainID)
-ON CONFLICT (job_id, block_hash, log_index, evm_chain_id) DO UPDATE
+INSERT INTO log_broadcasts (block_hash, block_number, tx_index, log_index, job_id, created_at, updated_at, consumed, evm_chain_id)
+VALUES (:blockHash, :blockNumber, :txIndex, :logIndex, :jobID, NOW(), NOW(), true, :chainID)
+ON CONFLICT (job_id, block_hash, tx_index, log_index, evm_chain_id) DO UPDATE
 SET consumed = true, updated_at = NOW();
 	`
 	for i := range blockHashes {
 		inputs[i] = input{
 			BlockHash:   blockHashes[i],
 			BlockNumber: blockNumbers[i],
+			TxIndex:     txIndexes[i],
 			LogIndex:    logIndexes[i],
 			JobID:       jobIDs[i],
 			ChainID:     o.evmChainID,
@@ -251,6 +255,7 @@ func (o *orm) removeUnconsumed(qopts ...pg.QOpt) error {
 type LogBroadcast struct {
 	BlockHash common.Hash
 	Consumed  bool
+	TxIndex   uint
 	LogIndex  uint
 	JobID     int32
 }
@@ -258,6 +263,7 @@ type LogBroadcast struct {
 func (b LogBroadcast) AsKey() LogBroadcastAsKey {
 	return LogBroadcastAsKey{
 		b.BlockHash,
+		b.TxIndex,
 		b.LogIndex,
 		b.JobID,
 	}
@@ -266,6 +272,7 @@ func (b LogBroadcast) AsKey() LogBroadcastAsKey {
 // LogBroadcastAsKey - used as key in a map to filter out already consumed logs
 type LogBroadcastAsKey struct {
 	BlockHash common.Hash
+	TxIndex   uint // Needed for uniqueness with besu client
 	LogIndex  uint
 	JobId     int32
 }
@@ -273,6 +280,7 @@ type LogBroadcastAsKey struct {
 func NewLogBroadcastAsKey(log types.Log, listener Listener) LogBroadcastAsKey {
 	return LogBroadcastAsKey{
 		log.BlockHash,
+		log.TxIndex,
 		log.Index,
 		listener.JobID(),
 	}

--- a/core/chains/evm/log/orm_test.go
+++ b/core/chains/evm/log/orm_test.go
@@ -43,12 +43,12 @@ func TestORM_broadcasts(t *testing.T) {
 	require.Zero(t, rowsAffected)
 
 	t.Run("WasBroadcastConsumed_DNE", func(t *testing.T) {
-		_, err := orm.WasBroadcastConsumed(rawLog.BlockHash, rawLog.Index, listener.JobID())
+		_, err := orm.WasBroadcastConsumed(rawLog.BlockHash, rawLog.TxIndex, rawLog.Index, listener.JobID())
 		require.NoError(t, err)
 	})
 
 	require.True(t, t.Run("CreateBroadcast", func(t *testing.T) {
-		err := orm.CreateBroadcast(rawLog.BlockHash, rawLog.BlockNumber, rawLog.Index, listener.JobID())
+		err := orm.CreateBroadcast(rawLog.BlockHash, rawLog.BlockNumber, rawLog.TxIndex, rawLog.Index, listener.JobID())
 		require.NoError(t, err)
 
 		var consumed null.Bool
@@ -58,13 +58,13 @@ func TestORM_broadcasts(t *testing.T) {
 	}))
 
 	t.Run("WasBroadcastConsumed_false", func(t *testing.T) {
-		was, err := orm.WasBroadcastConsumed(rawLog.BlockHash, rawLog.Index, listener.JobID())
+		was, err := orm.WasBroadcastConsumed(rawLog.BlockHash, rawLog.TxIndex, rawLog.Index, listener.JobID())
 		require.NoError(t, err)
 		require.False(t, was)
 	})
 
 	require.True(t, t.Run("MarkBroadcastConsumed", func(t *testing.T) {
-		err := orm.MarkBroadcastConsumed(rawLog.BlockHash, rawLog.BlockNumber, rawLog.Index, listener.JobID())
+		err := orm.MarkBroadcastConsumed(rawLog.BlockHash, rawLog.BlockNumber, rawLog.TxIndex, rawLog.Index, listener.JobID())
 		require.NoError(t, err)
 
 		var consumed null.Bool
@@ -78,24 +78,26 @@ func TestORM_broadcasts(t *testing.T) {
 			err          error
 			blockHashes  []common.Hash
 			blockNumbers []uint64
+			txIndexes    []uint
 			logIndexes   []uint
 			jobIDs       []int32
 		)
 		for i := 0; i < 3; i++ {
 			l := cltest.RandomLog(t)
-			err = orm.CreateBroadcast(l.BlockHash, l.BlockNumber, l.Index, listener.JobID())
+			err = orm.CreateBroadcast(l.BlockHash, l.BlockNumber, l.TxIndex, l.Index, listener.JobID())
 			require.NoError(t, err)
 			blockHashes = append(blockHashes, l.BlockHash)
 			blockNumbers = append(blockNumbers, l.BlockNumber)
+			txIndexes = append(txIndexes, l.TxIndex)
 			logIndexes = append(logIndexes, l.Index)
 			jobIDs = append(jobIDs, listener.JobID())
 
 		}
-		err = orm.MarkBroadcastsConsumed(blockHashes, blockNumbers, logIndexes, jobIDs)
+		err = orm.MarkBroadcastsConsumed(blockHashes, blockNumbers, txIndexes, logIndexes, jobIDs)
 		require.NoError(t, err)
 
 		for i := range blockHashes {
-			was, err := orm.WasBroadcastConsumed(blockHashes[i], logIndexes[i], jobIDs[i])
+			was, err := orm.WasBroadcastConsumed(blockHashes[i], txIndexes[i], logIndexes[i], jobIDs[i])
 			require.NoError(t, err)
 			require.True(t, was)
 		}
@@ -106,25 +108,27 @@ func TestORM_broadcasts(t *testing.T) {
 			err          error
 			blockHashes  []common.Hash
 			blockNumbers []uint64
+			txIndexes    []uint
 			logIndexes   []uint
 			jobIDs       []int32
 		)
 		for i := 0; i < 5; i++ {
 			l := cltest.RandomLog(t)
-			err = orm.CreateBroadcast(l.BlockHash, l.BlockNumber, l.Index, listener.JobID())
+			err = orm.CreateBroadcast(l.BlockHash, l.BlockNumber, l.TxIndex, l.Index, listener.JobID())
 			require.NoError(t, err)
 			blockHashes = append(blockHashes, l.BlockHash)
 			blockNumbers = append(blockNumbers, l.BlockNumber)
+			txIndexes = append(txIndexes, l.TxIndex)
 			logIndexes = append(logIndexes, l.Index)
 			jobIDs = append(jobIDs, listener.JobID())
 
 		}
-		err = orm.MarkBroadcastsConsumed(blockHashes[:len(blockHashes)-2], blockNumbers, logIndexes, jobIDs)
+		err = orm.MarkBroadcastsConsumed(blockHashes[:len(blockHashes)-2], blockNumbers, txIndexes, logIndexes, jobIDs)
 		require.Error(t, err)
 	})
 
 	t.Run("WasBroadcastConsumed_true", func(t *testing.T) {
-		was, err := orm.WasBroadcastConsumed(rawLog.BlockHash, rawLog.Index, listener.JobID())
+		was, err := orm.WasBroadcastConsumed(rawLog.BlockHash, rawLog.TxIndex, rawLog.Index, listener.JobID())
 		require.NoError(t, err)
 		require.True(t, was)
 	})
@@ -173,36 +177,36 @@ func TestORM_MarkUnconsumed(t *testing.T) {
 	logBefore := cltest.RandomLog(t)
 	logBefore.BlockNumber = 34
 	require.NoError(t,
-		orm.CreateBroadcast(logBefore.BlockHash, logBefore.BlockNumber, logBefore.Index, job1.ID))
+		orm.CreateBroadcast(logBefore.BlockHash, logBefore.BlockNumber, logBefore.TxIndex, logBefore.Index, job1.ID))
 	require.NoError(t,
-		orm.MarkBroadcastConsumed(logBefore.BlockHash, logBefore.BlockNumber, logBefore.Index, job1.ID))
+		orm.MarkBroadcastConsumed(logBefore.BlockHash, logBefore.BlockNumber, logBefore.TxIndex, logBefore.Index, job1.ID))
 
 	logAt := cltest.RandomLog(t)
 	logAt.BlockNumber = 38
 	require.NoError(t,
-		orm.CreateBroadcast(logAt.BlockHash, logAt.BlockNumber, logAt.Index, job1.ID))
+		orm.CreateBroadcast(logAt.BlockHash, logAt.BlockNumber, logAt.TxIndex, logAt.Index, job1.ID))
 	require.NoError(t,
-		orm.MarkBroadcastConsumed(logAt.BlockHash, logAt.BlockNumber, logAt.Index, job1.ID))
+		orm.MarkBroadcastConsumed(logAt.BlockHash, logAt.BlockNumber, logAt.TxIndex, logAt.Index, job1.ID))
 
 	logAfter := cltest.RandomLog(t)
 	logAfter.BlockNumber = 40
 	require.NoError(t,
-		orm.CreateBroadcast(logAfter.BlockHash, logAfter.BlockNumber, logAfter.Index, job2.ID))
+		orm.CreateBroadcast(logAfter.BlockHash, logAfter.BlockNumber, logAfter.TxIndex, logAfter.Index, job2.ID))
 	require.NoError(t,
-		orm.MarkBroadcastConsumed(logAfter.BlockHash, logAfter.BlockNumber, logAfter.Index, job2.ID))
+		orm.MarkBroadcastConsumed(logAfter.BlockHash, logAfter.BlockNumber, logAfter.TxIndex, logAfter.Index, job2.ID))
 
 	// logAt and logAfter should now be marked unconsumed. logBefore is still consumed.
 	require.NoError(t, orm.MarkBroadcastsUnconsumed(38))
 
-	consumed, err := orm.WasBroadcastConsumed(logBefore.BlockHash, logBefore.Index, job1.ID)
+	consumed, err := orm.WasBroadcastConsumed(logBefore.BlockHash, logBefore.TxIndex, logBefore.Index, job1.ID)
 	require.NoError(t, err)
 	require.True(t, consumed)
 
-	consumed, err = orm.WasBroadcastConsumed(logAt.BlockHash, logAt.Index, job1.ID)
+	consumed, err = orm.WasBroadcastConsumed(logAt.BlockHash, logAt.TxIndex, logAt.Index, job1.ID)
 	require.NoError(t, err)
 	require.False(t, consumed)
 
-	consumed, err = orm.WasBroadcastConsumed(logAfter.BlockHash, logAfter.Index, job2.ID)
+	consumed, err = orm.WasBroadcastConsumed(logAfter.BlockHash, logAfter.TxIndex, logAfter.Index, job2.ID)
 	require.NoError(t, err)
 	require.False(t, consumed)
 }
@@ -215,13 +219,13 @@ func TestORM_Reinitialize(t *testing.T) {
 	var unconsumed = func(blockNum int64) TestLogBroadcast {
 		hash := common.BigToHash(big.NewInt(rand.Int63()))
 		return TestLogBroadcast{*big.NewInt(blockNum),
-			log.LogBroadcast{hash, false, uint(rand.Uint32()), 0},
+			log.LogBroadcast{hash, false, uint(rand.Uint32()), uint(rand.Uint32()), 0},
 		}
 	}
 	var consumed = func(blockNum int64) TestLogBroadcast {
 		hash := common.BigToHash(big.NewInt(rand.Int63()))
 		return TestLogBroadcast{*big.NewInt(blockNum),
-			log.LogBroadcast{hash, true, uint(rand.Uint32()), 0},
+			log.LogBroadcast{hash, true, uint(rand.Uint32()), uint(rand.Uint32()), 0},
 		}
 	}
 
@@ -265,10 +269,10 @@ func TestORM_Reinitialize(t *testing.T) {
 
 			for _, b := range tt.broadcasts {
 				if b.Consumed {
-					err := orm.MarkBroadcastConsumed(b.BlockHash, b.BlockNumber.Uint64(), b.LogIndex, jobID)
+					err := orm.MarkBroadcastConsumed(b.BlockHash, b.BlockNumber.Uint64(), b.TxIndex, b.LogIndex, jobID)
 					require.NoError(t, err)
 				} else {
-					err := orm.CreateBroadcast(b.BlockHash, b.BlockNumber.Uint64(), b.LogIndex, jobID)
+					err := orm.CreateBroadcast(b.BlockHash, b.BlockNumber.Uint64(), b.TxIndex, b.LogIndex, jobID)
 					require.NoError(t, err)
 				}
 			}

--- a/core/chains/evm/log/registrations.go
+++ b/core/chains/evm/log/registrations.go
@@ -388,7 +388,7 @@ func (r *handler) isAddressRegistered(addr common.Address) bool {
 var _ broadcastCreator = &orm{}
 
 type broadcastCreator interface {
-	CreateBroadcast(blockHash common.Hash, blockNumber uint64, logIndex uint, jobID int32, pqOpts ...pg.QOpt) error
+	CreateBroadcast(blockHash common.Hash, blockNumber uint64, txIndex uint, logIndex uint, jobID int32, pqOpts ...pg.QOpt) error
 }
 
 func (r *handler) sendLog(log types.Log, latestHead evmtypes.Head,
@@ -427,7 +427,7 @@ func (r *handler) sendLog(log types.Log, latestHead evmtypes.Head,
 		jobID := sub.listener.JobID()
 		if !exists {
 			// Create unconsumed broadcast
-			if err := bc.CreateBroadcast(log.BlockHash, log.BlockNumber, log.Index, jobID); err != nil {
+			if err := bc.CreateBroadcast(log.BlockHash, log.BlockNumber, log.TxIndex, log.Index, jobID); err != nil {
 				logger.Errorw("Could not create broadcast log", "blockNumber", log.BlockNumber,
 					"blockHash", log.BlockHash, "address", log.Address, "jobID", jobID, "error", err)
 				continue

--- a/core/services/fluxmonitorv2/integrations_test.go
+++ b/core/services/fluxmonitorv2/integrations_test.go
@@ -425,7 +425,7 @@ func checkLogWasConsumed(t *testing.T, fa fluxAggregatorUniverse, db *sqlx.DB, p
 		block := fa.backend.Blockchain().GetBlockByNumber(blockNumber)
 		require.NotNil(t, block)
 		orm := log.NewORM(db, lggr, cfg, fa.evmChainID)
-		consumed, err := orm.WasBroadcastConsumed(block.Hash(), 0, pipelineSpecID)
+		consumed, err := orm.WasBroadcastConsumed(block.Hash(), 0, 0, pipelineSpecID)
 		require.NoError(t, err)
 		fa.backend.Commit()
 		return consumed

--- a/core/services/vrf/log_dedupe.go
+++ b/core/services/vrf/log_dedupe.go
@@ -43,6 +43,9 @@ type logKey struct {
 	// blockNumber of the block the log was included in. This is necessary to prune old logs.
 	blockNumber uint64
 
+	// transaction id of the transaction which generated this log
+	txIndex uint
+
 	// logIndex of the log in the block.
 	logIndex uint
 }
@@ -55,6 +58,7 @@ func (l *logDeduper) shouldDeliver(log types.Log) bool {
 	key := logKey{
 		blockHash:   log.BlockHash,
 		blockNumber: log.BlockNumber,
+		txIndex:     log.TxIndex,
 		logIndex:    log.Index,
 	}
 

--- a/core/store/migrate/migrations/0132_log_index_uniqueness.sql
+++ b/core/store/migrate/migrations/0132_log_index_uniqueness.sql
@@ -1,0 +1,13 @@
+-- +goose Up
+
+-- Add tx_index column to log_broadcasts
+ALTER TABLE log_broadcasts ADD COLUMN tx_index BIGINT;
+
+DROP INDEX IF EXISTS log_broadcasts_unique_idx;
+CREATE UNIQUE INDEX log_broadcasts_unique_idx ON log_broadcasts USING BTREE (job_id, block_hash, tx_index, log_index, evm_chain_id);
+
+-- +goose Down
+
+DROP INDEX IF EXISTS log_broadcasts_unique_idx;
+ALTER TABLE log_broadcasts DROP COLUMN tx_index;
+CREATE UNIQUE INDEX log_broadcasts_unique_idx ON log_broadcasts USING BTREE (job_id, block_hash, log_index, evm_chain_id);


### PR DESCRIPTION
The besu client doesn't strictly conform to the eth jsonrpc spec (see https://github.com/hyperledger/besu/issues/4114, https://github.com/hyperledger/besu/pull/4164). Instead of logIndex being unique within a block, it's only unique within a transaction. 

This PR adds TxIndex to the key we use to track duplicate logs, making the chainlink node robust enough to support besu or any other clients which behave this way.  There is one implementation of log deduplication in LogBroadcaster, and a similar one in vrf--both have been updated.