### PR TITLE
Assign the existing single API user as admin when migrating up to RBAC feature

### DIFF
--- a/core/store/migrate/migrations/0131_add_multi_user.sql
+++ b/core/store/migrate/migrations/0131_add_multi_user.sql
@@ -5,6 +5,10 @@ CREATE TYPE user_roles AS ENUM ('admin', 'edit', 'run', 'view');
 
 -- Add new role column to users table, type enum
 ALTER TABLE users ADD role user_roles NOT NULL DEFAULT 'view';
+
+-- We are migrating up from a single user full access user - this should be reflected as the admin 
+UPDATE users SET role = 'admin';
+
 CREATE UNIQUE INDEX unique_users_lowercase_email ON users (lower(email));
 
 -- Update sessions table include email column to key on user tied to session


### PR DESCRIPTION
Without this, the existing user in the DB will default to `view` permissions