### PR TITLE
Fixes a bug causing an FMS job proposal to not be approved.

### DIFF
--- a/operator_ui/src/screens/JobProposal/JobProposalScreen.test.tsx
+++ b/operator_ui/src/screens/JobProposal/JobProposalScreen.test.tsx
@@ -216,7 +216,7 @@ describe('JobProposalScreen', () => {
       {
         request: {
           query: APPROVE_JOB_PROPOSAL_SPEC_MUTATION,
-          variables: { id: proposal.specs[0].id },
+          variables: { id: proposal.specs[0].id, force: true },
         },
         result: {
           data: {
@@ -402,7 +402,7 @@ describe('JobProposalScreen', () => {
       {
         request: {
           query: APPROVE_JOB_PROPOSAL_SPEC_MUTATION,
-          variables: { id: proposal.specs[0].id },
+          variables: { id: proposal.specs[0].id, force: true },
         },
         result: {
           data: {

--- a/operator_ui/src/screens/JobProposal/JobProposalScreen.tsx
+++ b/operator_ui/src/screens/JobProposal/JobProposalScreen.tsx
@@ -59,8 +59,8 @@ export const REJECT_JOB_PROPOSAL_SPEC_MUTATION = gql`
 `
 
 export const APPROVE_JOB_PROPOSAL_SPEC_MUTATION = gql`
-  mutation ApproveJobProposalSpec($id: ID!) {
-    approveJobProposalSpec(id: $id) {
+  mutation ApproveJobProposalSpec($id: ID!, $force: Boolean) {
+    approveJobProposalSpec(id: $id, force: $force) {
       ... on ApproveJobProposalSpecSuccess {
         spec {
           id
@@ -205,7 +205,7 @@ export const JobProposalScreen: React.FC = () => {
   const handleApproveJobProposal = async (specID: string) => {
     try {
       const result = await approveJobProposalSpec({
-        variables: { id: specID },
+        variables: { id: specID, force: true },
       })
       const payload = result.data?.approveJobProposalSpec
       switch (payload?.__typename) {


### PR DESCRIPTION
When an running job with the same contract address already exists, you could not
approve the job. A 'force' option was added previously which allowed an approval
to replace the existing job, but this was never updated in the UI GQL request.