### PR TITLE
Chanklink NewApplication Dependency Injection Proposal

### DIFF
--- a/core/services/blockhashstore/delegate.go
+++ b/core/services/blockhashstore/delegate.go
@@ -26,6 +26,12 @@ type Delegate struct {
 	ks     keystore.Eth
 }
 
+func NewDelegateV2() func(*job.DelegateConstConfig) job.Delegate {
+	return func(conf *job.DelegateConstConfig) job.Delegate {
+		return NewDelegate(conf.Logger, conf.ChainSet, conf.KeyStore.Eth())
+	}
+}
+
 // NewDelegate creates a new Delegate.
 func NewDelegate(
 	logger logger.Logger,

--- a/core/services/cron/delegate.go
+++ b/core/services/cron/delegate.go
@@ -15,6 +15,12 @@ type Delegate struct {
 
 var _ job.Delegate = (*Delegate)(nil)
 
+func NewDelegateV2() func(*job.DelegateConstConfig) job.Delegate {
+	return func(conf *job.DelegateConstConfig) job.Delegate {
+		return NewDelegate(conf.Runner, conf.Logger)
+	}
+}
+
 func NewDelegate(pipelineRunner pipeline.Runner, lggr logger.Logger) *Delegate {
 	return &Delegate{
 		pipelineRunner: pipelineRunner,

--- a/core/services/directrequest/delegate.go
+++ b/core/services/directrequest/delegate.go
@@ -39,6 +39,14 @@ type (
 
 var _ job.Delegate = (*Delegate)(nil)
 
+func NewDelegateV2() func(conf *job.DelegateConstConfig) job.Delegate {
+	return func(conf *job.DelegateConstConfig) job.Delegate {
+		var del job.Delegate
+		del = NewDelegate(conf.Logger, conf.Runner, conf.PipelineORM, conf.ChainSet)
+		return del
+	}
+}
+
 func NewDelegate(
 	logger logger.Logger,
 	pipelineRunner pipeline.Runner,

--- a/core/services/job/spawner.go
+++ b/core/services/job/spawner.go
@@ -10,9 +10,13 @@ import (
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/sqlx"
 
+	"github.com/smartcontractkit/chainlink/core/chains/evm"
+	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services"
+	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
+	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
@@ -59,6 +63,18 @@ type (
 		AfterJobCreated(spec Job)
 		BeforeJobDeleted(spec Job)
 	}
+
+	DelegateConstConfig struct {
+		Logger      logger.Logger
+		Runner      pipeline.Runner
+		PipelineORM pipeline.ORM
+		JobORM      ORM
+		ChainSet    evm.ChainSet
+		DB          *sqlx.DB
+		KeyStore    keystore.Master
+		GenConfig   config.GeneralConfig
+	}
+	DelegateConstructor func(*DelegateConstConfig) Delegate
 
 	activeJob struct {
 		delegate Delegate

--- a/core/services/keeper/delegate.go
+++ b/core/services/keeper/delegate.go
@@ -22,6 +22,12 @@ type Delegate struct {
 	chainSet evm.ChainSet
 }
 
+func NewDelegateV2() func(*job.DelegateConstConfig) job.Delegate {
+	return func(conf *job.DelegateConstConfig) job.Delegate {
+		return NewDelegate(conf.DB, conf.JobORM, conf.Runner, conf.Logger, conf.ChainSet)
+	}
+}
+
 // NewDelegate is the constructor of Delegate
 func NewDelegate(
 	db *sqlx.DB,

--- a/core/services/vrf/delegate.go
+++ b/core/services/vrf/delegate.go
@@ -50,6 +50,12 @@ type Config interface {
 	MinIncomingConfirmations() uint32
 }
 
+func NewDelegateV2() func(*job.DelegateConstConfig) job.Delegate {
+	return func(conf *job.DelegateConstConfig) job.Delegate {
+		return NewDelegate(conf.DB, conf.KeyStore, conf.Runner, conf.PipelineORM, conf.ChainSet, conf.Logger, conf.GenConfig)
+	}
+}
+
 func NewDelegate(
 	db *sqlx.DB,
 	ks keystore.Master,

--- a/core/services/webhook/delegate.go
+++ b/core/services/webhook/delegate.go
@@ -28,6 +28,12 @@ type (
 
 var _ job.Delegate = (*Delegate)(nil)
 
+func NewDelegateV2(initiator ExternalInitiatorManager) func(*job.DelegateConstConfig) job.Delegate {
+	return func(conf *job.DelegateConstConfig) job.Delegate {
+		return NewDelegate(conf.Runner, initiator, conf.Logger)
+	}
+}
+
 func NewDelegate(runner pipeline.Runner, externalInitiatorManager ExternalInitiatorManager, lggr logger.Logger) *Delegate {
 	lggr = lggr.Named("Webhook")
 	return &Delegate{


### PR DESCRIPTION
Problem:
The `core/services/keeper` package cannot easily accomplish unit testing on
unexported functions due to circular dependencies when importing from
`core/internal/cltest`. This is primarily due to the chainlink Application
constructor using package specific job.Delegate constructors internally.

For every call to chainlink.NewApplication, a set of delegates is created
and added to the returned Application instance. The `cltest` package calls
this constructor directly for all mocks, forcing the cltest package to
encounter dependency requirements on all sub packages.

Proposal:
Create a delegate constructor function type definition and pass the delegate
constructors to the application constructor.

1. This allows individual tests to declare the delegates they need instead
	of creating the complete default list
2. The cltest package can be used directly for unit tests in the delegate
	packages

Using this new method to construct an app instance in tests would look like
this:

```
// in core/services/keeper
testDelegate := NewDelegateV2()
app := cltest.NewApplication(t, testDelegate)
```

Next Steps:
With the current proposal, tests would need to be modified to accept a list
of delegates instead of the current default (everything). This could be
accomplished by creating a creating a package such as `core/internal/cltest/alldelegates`
that contains an exported NewApplication function that calls cltest.NewApplication
with all delegates. Then every instance of cltest.NewApplication or similar
can call alldelegates.NewApplication instead.

Please let me know your thoughts or concerns with this approach as it relates
to complexity and attempting to solve the original problem of circular depedencies
in unit testing. Thank you!