### PR TITLE
core/chains/evm/config: update Arbitrum Rinkeby config for Nitro

### DIFF
--- a/core/chains/evm/config/chain_specific_config.go
+++ b/core/chains/evm/config/chain_specific_config.go
@@ -273,6 +273,14 @@ func setChainSpecificConfigDefaultSets() {
 	arbitrumMainnet.ocrContractConfirmations = 1
 	arbitrumRinkeby := arbitrumMainnet
 	arbitrumRinkeby.linkContractAddress = "0x615fBe6372676474d9e6933d310469c9b68e9726"
+	// nitro uses standard gas accounting, so restore default limits.
+	arbitrumRinkeby.gasLimitDefault = fallbackDefaultSet.gasLimitDefault
+	arbitrumRinkeby.gasLimitTransfer = fallbackDefaultSet.gasLimitTransfer
+	// nitro does not use an auction, so reduce the fixed gas price as it no longer represents an upper-bound bid.
+	arbitrumRinkeby.gasPriceDefault = *assets.Wei(1e8)  // 0.1 gwei
+	arbitrumRinkeby.maxGasPriceWei = *assets.Wei(1e8)   // 0.1 gwei
+	arbitrumRinkeby.minGasPriceWei = *assets.Wei(1e8)   // 0.1 gwei
+	arbitrumRinkeby.gasFeeCapDefault = *assets.Wei(1e8) // 0.1 gwei
 
 	// Optimism is an L2 chain. Pending proper L2 support, for now we rely on their sequencer
 	optimismMainnet := fallbackDefaultSet

--- a/core/chains/evm/config/v2/defaults/Arbitrum_Rinkeby.toml
+++ b/core/chains/evm/config/v2/defaults/Arbitrum_Rinkeby.toml
@@ -6,11 +6,10 @@ OCR.ContractConfirmations = 1
 [GasEstimator]
 BumpThreshold = 0
 Mode = 'FixedPrice'
-PriceDefault = '1000 gwei'
-PriceMax = '1000 gwei'
-PriceMin = '1000 gwei'
-LimitDefault = 7_000_000
-LimitTransfer = 800_000
+PriceDefault = '0.1 gwei'
+PriceMax = '0.1 gwei'
+PriceMin = '0.1 gwei'
+FeeCapDefault = '0.1 gwei'
 
 [GasEstimator.BlockHistory]
 BlockHistorySize = 0

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -42,6 +42,7 @@ ETH_GAS_LIMIT_KEEPER_JOB_TYPE # EVM.GasEstimator.LimitKeeperJobType
 ### Changed
 
 - `Arbitrum` chains are no longer restricted to only `FixedPrice` `GAS_ESTIMATOR_MODE`
+- Updated `Arbitrum Rinkeby` configuration for Nitro
 
 ## [1.6.0] - 2022-07-20
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -2777,18 +2777,18 @@ BlockDelay = 1
 
 [GasEstimator]
 Mode = 'FixedPrice'
-PriceDefault = '1 micro'
-PriceMax = '1 micro'
-PriceMin = '1 micro'
-LimitDefault = 7000000
+PriceDefault = '100 mwei'
+PriceMax = '100 mwei'
+PriceMin = '100 mwei'
+LimitDefault = 500000
 LimitMultiplier = '1'
-LimitTransfer = 800000
+LimitTransfer = 21000
 BumpMin = '5 gwei'
 BumpPercent = 20
 BumpThreshold = 0
 BumpTxDepth = 10
 EIP1559DynamicFees = false
-FeeCapDefault = '100 gwei'
+FeeCapDefault = '100 mwei'
 TipCapDefault = '1 wei'
 TipCapMinimum = '1 wei'
 [GasEstimator.BlockHistory]


### PR DESCRIPTION
This change updates the default gas limits and prices for Arbitrum Rinkeby in response to the migration to Nitro on July 28th.