### PR TITLE
erigon errors

### DIFF
--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -112,7 +112,7 @@ var erigon = ClientErrors{
 	TransactionAlreadyInMempool:       regexp.MustCompile(`(: |^)(block already known|already known)`),
 	TerminallyUnderpriced:             regexp.MustCompile(`(: |^)transaction underpriced$`),
 	InsufficientEth:                   regexp.MustCompile(`(: |^)(insufficient funds for transfer|insufficient funds for gas \* price \+ value|insufficient balance for transfer)$`),
-	TxFeeExceedsCap:                   regexp.MustCompile(`(: |^)fee cap higher than`),
+	TxFeeExceedsCap:                   regexp.MustCompile(`(: |^)tx fee \([0-9\.]+ [a-zA-Z]+\) exceeds the configured cap \([0-9\.]+ [a-zA-Z]+\)$`),
 	Fatal:                             erigonFatal,
 }
 

--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -100,6 +100,22 @@ var besu = ClientErrors{
 	Fatal:                             besuFatal,
 }
 
+// Erigon
+// See: https://github.com/ledgerwatch/erigon/blob/devel/core/tx_pool.go
+//      https://github.com/ledgerwatch/erigon/blob/devel/core/error.go
+//      https://github.com/ledgerwatch/erigon/blob/devel/core/vm/errors.go
+// Note: some error definitions are unused, many errors are created inline.
+var erigonFatal = regexp.MustCompile(`(: |^)(exceeds block gas limit|invalid sender|negative value|oversized data|gas uint64 overflow|intrinsic gas too low|nonce too high)$`)
+var erigon = ClientErrors{
+	NonceTooLow:                       regexp.MustCompile(`(: |^)nonce too low$`),
+	ReplacementTransactionUnderpriced: regexp.MustCompile(`(: |^)replacement transaction underpriced$`),
+	TransactionAlreadyInMempool:       regexp.MustCompile(`(: |^)(block already known|already known)`),
+	TerminallyUnderpriced:             regexp.MustCompile(`(: |^)transaction underpriced$`),
+	InsufficientEth:                   regexp.MustCompile(`(: |^)(insufficient funds for transfer|insufficient funds for gas \* price \+ value|insufficient balance for transfer)$`),
+	TxFeeExceedsCap:                   regexp.MustCompile(`(: |^)fee cap higher than`),
+	Fatal:                             erigonFatal,
+}
+
 // Arbitrum
 // https://github.com/OffchainLabs/arbitrum/blob/cac30586bc10ecc1ae73e93de517c90984677fdb/packages/arb-evm/evm/result.go#L158
 var arbitrumFatal = regexp.MustCompile(`(: |^)(invalid message format|forbidden sender address|execution reverted: error code)$`)
@@ -160,7 +176,7 @@ var harmony = ClientErrors{
 	Fatal:                   harmonyFatal,
 }
 
-var clients = []ClientErrors{parity, geth, arbitrum, optimism, metis, substrate, avalanche, nethermind, harmony, besu}
+var clients = []ClientErrors{parity, geth, arbitrum, optimism, metis, substrate, avalanche, nethermind, harmony, besu, erigon}
 
 func (s *SendError) is(errorType int) bool {
 	if s == nil || s.err == nil {

--- a/core/chains/evm/client/errors_test.go
+++ b/core/chains/evm/client/errors_test.go
@@ -34,6 +34,7 @@ func Test_Eth_Errors(t *testing.T) {
 		tests := []errorCase{
 			{"nonce too low", true, "Geth"},
 			{"Nonce too low", true, "Besu"},
+			{"nonce too low", true, "Erigon"},
 			{"Transaction nonce is too low. Try incrementing the nonce.", true, "Parity"},
 			{"transaction rejected: nonce too low", true, "Arbitrum"},
 			{"invalid transaction nonce", true, "Arbitrum"},
@@ -74,6 +75,7 @@ func Test_Eth_Errors(t *testing.T) {
 		tests := []errorCase{
 			{"replacement transaction underpriced", true, "geth"},
 			{"Replacement transaction underpriced", true, "Besu"},
+			{"replacement transaction underpriced", true, "Erigon"},
 			{"Transaction gas price 100wei is too low. There is another transaction with same nonce in the queue with gas price 150wei. Try increasing the gas price or incrementing the nonce.", true, "Parity"},
 			{"There are too many transactions in the queue. Your transaction was dropped due to limit. Try increasing the fee.", false, "Parity"},
 			{"gas price too low", false, "Arbitrum"},
@@ -98,6 +100,8 @@ func Test_Eth_Errors(t *testing.T) {
 			// This one is present in the light client (?!)
 			{"Known transaction (7f65)", true, "Geth"},
 			{"Known transaction", true, "Besu"},
+			{"already known", true, "Erigon"},
+			{"block already known", true, "Erigon"},
 			{"Transaction with the same hash was already imported.", true, "Parity"},
 			{"call failed: AlreadyKnown", true, "Nethermind"},
 			{"call failed: OwnNonceAlreadyUsed", true, "Nethermind"},
@@ -117,6 +121,7 @@ func Test_Eth_Errors(t *testing.T) {
 			{"transaction underpriced", true, "geth"},
 			{"replacement transaction underpriced", false, "geth"},
 			{"Gas price below configured minimum gas price", true, "Besu"},
+			{"transaction underpriced", true, "Erigon"},
 			{"There are too many transactions in the queue. Your transaction was dropped due to limit. Try increasing the fee.", false, "Parity"},
 			{"Transaction gas price is too low. It does not satisfy your node's minimal gas price (minimal: 100 got: 50). Try increasing the gas price.", true, "Parity"},
 			{"gas price too low", true, "Arbitrum"},
@@ -152,6 +157,9 @@ func Test_Eth_Errors(t *testing.T) {
 			{"insufficient funds for gas * price + value", true, "Geth"},
 			{"insufficient balance for transfer", true, "Geth"},
 			{"Upfront cost exceeds account balance", true, "Besu"},
+			{"insufficient funds for transfer", true, "Erigon"},
+			{"insufficient funds for gas * price + value", true, "Erigon"},
+			{"insufficient balance for transfer", true, "Erigon"},
 			{"Insufficient balance for transaction. Balance=100.25, Cost=200.50", true, "Parity"},
 			{"Insufficient funds. The account you tried to send transaction from does not have enough funds. Required 200.50 and got: 100.25.", true, "Parity"},
 			{"transaction rejected: insufficient funds for gas * price + value", true, "Arbitrum"},
@@ -173,6 +181,7 @@ func Test_Eth_Errors(t *testing.T) {
 			{"tx fee (1.10 FTM) exceeds the configured cap (1.00 FTM)", true, "geth"},
 			{"tx fee (1.10 foocoin) exceeds the configured cap (1.00 foocoin)", true, "geth"},
 			{"Transaction fee cap exceeded", true, "Besu"},
+			{"fee cap higher than 2^256-1", true, "Erigon"},
 		}
 		for _, test := range tests {
 			err = evmclient.NewSendErrorS(test.message)
@@ -252,6 +261,15 @@ func Test_Eth_Errors_Fatal(t *testing.T) {
 		{"Intrinsic gas exceeds gas limit", true, "Besu"},
 		{"Transaction gas limit exceeds block gas limit", true, "Besu"},
 		{"Invalid signature", true, "Besu"},
+
+		{"insufficient funds for transfer", false, "Erigon"},
+		{"exceeds block gas limit", true, "Erigon"},
+		{"invalid sender", true, "Erigon"},
+		{"negative value", true, "Erigon"},
+		{"oversized data", true, "Erigon"},
+		{"gas uint64 overflow", true, "Erigon"},
+		{"intrinsic gas too low", true, "Erigon"},
+		{"nonce too high", true, "Erigon"},
 
 		{"Insufficient funds. The account you tried to send transaction from does not have enough funds. Required 100 and got: 50.", false, "Parity"},
 		{"Supplied gas is beyond limit.", true, "Parity"},

--- a/core/chains/evm/client/errors_test.go
+++ b/core/chains/evm/client/errors_test.go
@@ -181,7 +181,7 @@ func Test_Eth_Errors(t *testing.T) {
 			{"tx fee (1.10 FTM) exceeds the configured cap (1.00 FTM)", true, "geth"},
 			{"tx fee (1.10 foocoin) exceeds the configured cap (1.00 foocoin)", true, "geth"},
 			{"Transaction fee cap exceeded", true, "Besu"},
-			{"fee cap higher than 2^256-1", true, "Erigon"},
+			{"tx fee (1.10 ether) exceeds the configured cap (1.00 ether)", true, "Erigon"},
 		}
 		for _, test := range tests {
 			err = evmclient.NewSendErrorS(test.message)


### PR DESCRIPTION
Part of https://app.shortcut.com/chainlinklabs/story/12735/support-erigon-eth-client-in-core

The client has many errors defined as vars, e.g.:
https://github.com/ledgerwatch/erigon/blob/devel/core/tx_pool.go
https://github.com/ledgerwatch/erigon/blob/devel/core/error.go
https://github.com/ledgerwatch/erigon/blob/devel/core/vm/errors.go

but, many of those are unused. What's worse - they also have plenty of errors creating inline, that is not using any error definitions.

A good part is that all the errors are identical to geth.
