### PR TITLE
Update log/pool.go & log/pool_test.go for besu

### DIFF
--- a/core/chains/evm/log/pool.go
+++ b/core/chains/evm/log/pool.go
@@ -44,8 +44,8 @@ type logPool struct {
 	// the logs in the pool.
 	hashesByBlockNumbers map[uint64]map[common.Hash]struct{}
 
-	// A mapping of block hashes, to log index within block, to logs
-	logsByBlockHash map[common.Hash]map[uint]types.Log
+	// A mapping of block hashes, to tx index within block, to log index, to logs
+	logsByBlockHash map[common.Hash]map[uint]map[uint]types.Log
 
 	// This min-heap maintains block numbers of logs in the pool.
 	// it helps us easily determine the minimum log block number
@@ -56,7 +56,7 @@ type logPool struct {
 func newLogPool() *logPool {
 	return &logPool{
 		hashesByBlockNumbers: make(map[uint64]map[common.Hash]struct{}),
-		logsByBlockHash:      make(map[common.Hash]map[uint]types.Log),
+		logsByBlockHash:      make(map[common.Hash]map[uint]map[uint]types.Log),
 		heap:                 pairingHeap.New(),
 	}
 }
@@ -68,9 +68,12 @@ func (pool *logPool) addLog(log types.Log) bool {
 	}
 	pool.hashesByBlockNumbers[log.BlockNumber][log.BlockHash] = struct{}{}
 	if _, exists := pool.logsByBlockHash[log.BlockHash]; !exists {
-		pool.logsByBlockHash[log.BlockHash] = make(map[uint]types.Log)
+		pool.logsByBlockHash[log.BlockHash] = make(map[uint]map[uint]types.Log)
 	}
-	pool.logsByBlockHash[log.BlockHash][log.Index] = log
+	if _, exists := pool.logsByBlockHash[log.BlockHash][log.TxIndex]; !exists {
+		pool.logsByBlockHash[log.BlockHash][log.TxIndex] = make(map[uint]types.Log)
+	}
+	pool.logsByBlockHash[log.BlockHash][log.TxIndex][log.Index] = log
 	min := pool.heap.FindMin()
 	pool.heap.Insert(Uint64(log.BlockNumber))
 	// first or new min
@@ -154,7 +157,11 @@ func (pool *logPool) removeBlock(hash common.Hash, number uint64) {
 }
 
 func (pool *logPool) testOnly_getNumLogsForBlock(bh common.Hash) int {
-	return len(pool.logsByBlockHash[bh])
+	var numLogs int
+	for _, txLogs := range pool.logsByBlockHash[bh] {
+		numLogs += len(txLogs)
+	}
+	return numLogs
 }
 
 type Uint64 uint64
@@ -177,10 +184,12 @@ type logsOnBlock struct {
 	Logs        []types.Log
 }
 
-func newLogsOnBlock(num uint64, logsMap map[uint]types.Log) logsOnBlock {
+func newLogsOnBlock(num uint64, logsMap map[uint]map[uint]types.Log) logsOnBlock {
 	logs := make([]types.Log, 0, len(logsMap))
-	for _, l := range logsMap {
-		logs = append(logs, l)
+	for _, txLogs := range logsMap {
+		for _, l := range txLogs {
+			logs = append(logs, l)
+		}
 	}
 	return logsOnBlock{num, logs}
 }

--- a/core/chains/evm/log/pool_test.go
+++ b/core/chains/evm/log/pool_test.go
@@ -52,6 +52,7 @@ func TestUnit_AddLog(t *testing.T) {
 	blockHash := common.BigToHash(big.NewInt(1))
 	l1 := types.Log{
 		BlockHash:   blockHash,
+		TxIndex:     37,
 		Index:       42,
 		BlockNumber: 1,
 	}
@@ -63,26 +64,39 @@ func TestUnit_AddLog(t *testing.T) {
 	assert.False(t, p.addLog(l1), "AddLog should have returned false for a 2nd reattempt")
 	require.Equal(t, 1, p.testOnly_getNumLogsForBlock(blockHash))
 
-	// 2nd log with same loghash should add a new log, which shouldn't be minimum
+	// 2nd log with higher logIndex but same blockhash should add a new log, which shouldn't be minimum
 	l2 := l1
 	l2.Index = 43
-	assert.False(t, p.addLog(l2), "AddLog should have returned false for same log added")
+	assert.False(t, p.addLog(l2), "AddLog should have returned false for later log added")
 	require.Equal(t, 2, p.testOnly_getNumLogsForBlock(blockHash))
 
-	// New log with different larger BlockNumber/loghash should add a new log, not as minimum
+	// New log with same logIndex but lower txIndex should add a new log, which should be a minimum
+	l2 = l1
+	l2.TxIndex = 13
+	assert.False(t, p.addLog(l2), "AddLog should have returned false for earlier log added")
+	require.Equal(t, 3, p.testOnly_getNumLogsForBlock(blockHash))
+
+	// New log with different larger BlockNumber should add a new log, not as minimum
 	l3 := l1
 	l3.BlockNumber = 3
 	l3.BlockHash = common.BigToHash(big.NewInt(3))
 	assert.False(t, p.addLog(l3), "AddLog should have returned false for same log added")
-	assert.Equal(t, 2, p.testOnly_getNumLogsForBlock(blockHash))
+	assert.Equal(t, 3, p.testOnly_getNumLogsForBlock(blockHash))
 	require.Equal(t, 1, p.testOnly_getNumLogsForBlock(l3.BlockHash))
 
-	// New log with different smaller BlockNumber/loghash should add a new log, as minimum
+	// New log with different smaller BlockNumber should add a new log, as minimum
 	l4 := l1
 	l4.BlockNumber = 0 // New minimum block number
 	l4.BlockHash = common.BigToHash(big.NewInt(0))
 	assert.True(t, p.addLog(l4), "AddLog should have returned true for smallest BlockNumber")
-	assert.Equal(t, 2, p.testOnly_getNumLogsForBlock(blockHash))
+	assert.Equal(t, 3, p.testOnly_getNumLogsForBlock(blockHash))
+	assert.Equal(t, 1, p.testOnly_getNumLogsForBlock(l3.BlockHash))
+	require.Equal(t, 1, p.testOnly_getNumLogsForBlock(l4.BlockHash))
+
+	// Adding duplicate log should not increase number of logs in pool
+	l5 := l1
+	assert.False(t, p.addLog(l5), "AddLog should have returned false for smallest BlockNumber")
+	assert.Equal(t, 3, p.testOnly_getNumLogsForBlock(blockHash))
 	assert.Equal(t, 1, p.testOnly_getNumLogsForBlock(l3.BlockHash))
 	require.Equal(t, 1, p.testOnly_getNumLogsForBlock(l4.BlockHash))
 }


### PR DESCRIPTION
This is a followup to #7072.  This updates the log pool with the same change which was made for logBroadcaster and VRF (add TxIndex in case LogIndex is not unique enough to distinguish different logs from duplicates).

Also update tests for addLog, and add some new ones including attempt to add a duplicate.