### PR TITLE
core/store/migrations: rename starknet nodes chain id columns

### DIFF
--- a/core/store/migrate/migrations/0134_starknet_nodes_chain_id.sql
+++ b/core/store/migrate/migrations/0134_starknet_nodes_chain_id.sql
@@ -1,0 +1,9 @@
+-- +goose Up
+-- +goose StatementBegin
+ALTER TABLE starknet_nodes RENAME COLUMN chain_id TO starknet_chain_id;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE starknet_nodes RENAME COLUMN starknet_chain_id TO chain_id;
+-- +goose StatementEnd


### PR DESCRIPTION
Renaming `starknet_nodes` `chain_id` column to `starknet_chain_id` to match the generic ORM expectations.

~This should be considered for 1.7.~