### PR TITLE
Fix logging of msg in ethereum requests

### DIFF
--- a/core/chains/evm/client/node.go
+++ b/core/chains/evm/client/node.go
@@ -715,7 +715,7 @@ func (n *node) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumb
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("msg", msg, "blockNumber", blockNumber)
+	lggr := n.newRqLggr(switching(n)).With("callMsg", msg, "blockNumber", blockNumber)
 
 	lggr.Debug("RPC call: evmclient.Client#CallContract")
 	start := time.Now()


### PR DESCRIPTION
- "msg" has special meaning and overrides the main log message, we
  intended to log it as structured data instead.