### PR TITLE
Convert NULL tx_index values in log_broadcaster to -1

### DIFF
--- a/core/chains/evm/log/orm.go
+++ b/core/chains/evm/log/orm.go
@@ -64,7 +64,7 @@ func (o *orm) WasBroadcastConsumed(blockHash common.Hash, txIndex uint, logIndex
 	query := `
 		SELECT consumed FROM log_broadcasts
 		WHERE block_hash = $1
-		AND (tx_index is NULL OR tx_index = $2) -- NULL-check only for safe upgrade from 1.6.0
+		AND (tx_index = -1 OR tx_index = $2)
 		AND log_index = $3
 		AND job_id = $4
 		AND evm_chain_id = $5

--- a/core/store/migrate/migrations/0135_tx_index_not_null.sql
+++ b/core/store/migrate/migrations/0135_tx_index_not_null.sql
@@ -1,0 +1,10 @@
+-- +goose Up
+-- +goose StatementBegin
+UPDATE log_broadcasts SET tx_index=-1 WHERE tx_index IS NULL;
+ALTER TABLE log_broadcasts ALTER COLUMN tx_index SET NOT NULL;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+ALTER TABLE log_broadcasts ALTER COLUMN tx_index DROP NOT NULL;
+-- +goose StatementEnd


### PR DESCRIPTION
Hot fix for db migration issue with upgrading log_broadcaster table from 1.6.0 to 1.7.0