### PR TITLE
Fix flakey keeper integration test

### DIFF
--- a/integration-tests/smoke/keeper_test.go
+++ b/integration-tests/smoke/keeper_test.go
@@ -397,6 +397,10 @@ var _ = Describe("Keeper Suite @keeper", func() {
 				)
 			}, "3m", "1s").Should(Succeed())
 
+			existingCnt, err := consumerPerformance.GetUpkeepCount(context.Background())
+			Expect(err).ShouldNot(HaveOccurred(), "Calling consumer's counter shouldn't fail")
+			log.Info().Int64("Upkeep counter", existingCnt.Int64()).Msg("Upkeep counter when consistently block finished")
+
 			// Now increase checkGasLimit on registry
 			highCheckGasLimit := defaultRegistryConfig
 			highCheckGasLimit.CheckGasLimit = uint32(5000000)
@@ -409,7 +413,7 @@ var _ = Describe("Keeper Suite @keeper", func() {
 			Eventually(func(g Gomega) {
 				cnt, err := consumerPerformance.GetUpkeepCount(context.Background())
 				g.Expect(err).ShouldNot(HaveOccurred(), "Calling consumer's Counter shouldn't fail")
-				g.Expect(cnt.Int64()).Should(BeNumerically(">", existingCnt.Int64()+numUpkeepsAllowedForStragglingTxs),
+				g.Expect(cnt.Int64()).Should(BeNumerically(">", existingCnt.Int64()),
 					"Expected consumer counter to be greater than %d, but got %d", existingCnt.Int64(), cnt.Int64(),
 				)
 			}, "1m", "1s").Should(Succeed())

--- a/integration-tests/smoke/keeper_test.go
+++ b/integration-tests/smoke/keeper_test.go
@@ -397,7 +397,7 @@ var _ = Describe("Keeper Suite @keeper", func() {
 				)
 			}, "3m", "1s").Should(Succeed())
 
-			existingCnt, err := consumerPerformance.GetUpkeepCount(context.Background())
+			existingCnt, err = consumerPerformance.GetUpkeepCount(context.Background())
 			Expect(err).ShouldNot(HaveOccurred(), "Calling consumer's counter shouldn't fail")
 			log.Info().Int64("Upkeep counter", existingCnt.Int64()).Msg("Upkeep counter when consistently block finished")
 


### PR DESCRIPTION
Saw a flake for this test: https://github.com/smartcontractkit/chainlink/runs/7672427029?check_suite_focus=true

We were expecting upkeep counter to increase by 6 which i suspect didn't happen within 1 minute.

Instead of expecting upkeep counter to be higher than stragglingTxs, fetch the latest count on counter and expect it to increase by just 1