### PR TITLE
Add hexencode/base64encode tasks

### DIFF
--- a/core/services/pipeline/common.go
+++ b/core/services/pipeline/common.go
@@ -314,7 +314,9 @@ const (
 	TaskTypeUppercase        TaskType = "uppercase"
 	TaskTypeConditional      TaskType = "conditional"
 	TaskTypeHexDecode        TaskType = "hexdecode"
+	TaskTypeHexEncode        TaskType = "hexencode"
 	TaskTypeBase64Decode     TaskType = "base64decode"
+	TaskTypeBase64Encode     TaskType = "base64encode"
 
 	// Testing only.
 	TaskTypePanic TaskType = "panic"
@@ -399,8 +401,12 @@ func UnmarshalTaskFromMap(taskType TaskType, taskMap interface{}, ID int, dotID 
 		task = &ConditionalTask{BaseTask: BaseTask{id: ID, dotID: dotID}}
 	case TaskTypeHexDecode:
 		task = &HexDecodeTask{BaseTask: BaseTask{id: ID, dotID: dotID}}
+	case TaskTypeHexEncode:
+		task = &HexEncodeTask{BaseTask: BaseTask{id: ID, dotID: dotID}}
 	case TaskTypeBase64Decode:
 		task = &Base64DecodeTask{BaseTask: BaseTask{id: ID, dotID: dotID}}
+	case TaskTypeBase64Encode:
+		task = &Base64EncodeTask{BaseTask: BaseTask{id: ID, dotID: dotID}}
 	default:
 		return nil, errors.Errorf(`unknown task type: "%v"`, taskType)
 	}

--- a/core/services/pipeline/task.base64encode.go
+++ b/core/services/pipeline/task.base64encode.go
@@ -1,0 +1,53 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/base64"
+
+	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+
+	"github.com/smartcontractkit/chainlink/core/logger"
+)
+
+//
+// Return types:
+//     string
+//
+type Base64EncodeTask struct {
+	BaseTask `mapstructure:",squash"`
+	Input    string `json:"input"`
+}
+
+var _ Task = (*Base64EncodeTask)(nil)
+
+func (t *Base64EncodeTask) Type() TaskType {
+	return TaskTypeBase64Decode
+}
+
+func (t *Base64EncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs []Result) (result Result, runInfo RunInfo) {
+	_, err := CheckInputs(inputs, 0, 1, 0)
+	if err != nil {
+		return Result{Error: errors.Wrap(err, "task inputs")}, runInfo
+	}
+
+	var stringInput StringParam
+	err = multierr.Combine(
+		errors.Wrap(ResolveParam(&stringInput, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+	)
+	if err == nil {
+		// string
+		return Result{Value: base64.StdEncoding.EncodeToString([]byte(stringInput.String()))}, runInfo
+	}
+
+	var bytesInput BytesParam
+	err = multierr.Combine(
+		errors.Wrap(ResolveParam(&bytesInput, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+	)
+	if err == nil {
+		// bytes
+		return Result{Value: base64.StdEncoding.EncodeToString(bytesInput)}, runInfo
+	}
+
+	return Result{Error: err}, runInfo
+}

--- a/core/services/pipeline/task.base64encode_test.go
+++ b/core/services/pipeline/task.base64encode_test.go
@@ -1,0 +1,76 @@
+package pipeline_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/pipeline"
+)
+
+func TestBase64EncodeTask(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		input  interface{}
+		result string
+		error  string
+	}{
+
+		// success
+		{"string input 1", "Hello, playground", "SGVsbG8sIHBsYXlncm91bmQ=", ""},
+		{"string input 2", "=test=test=", "PXRlc3Q9dGVzdD0=", ""},
+		{"empty string", "", "", ""},
+		{"bytes input 1", []byte{0xaa, 0xbb, 0xcc, 0xdd}, "qrvM3Q==", ""},
+		{"empty bytes", []byte{}, "", ""},
+
+		// failure (unsupported types)
+		{"int", 234, "", "bad input for task"},
+		{"bool", false, "", "bad input for task"},
+		{"float", 3.14, "", "bad input for task"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Run("without vars", func(t *testing.T) {
+				vars := pipeline.NewVarsFrom(nil)
+				task := pipeline.Base64EncodeTask{BaseTask: pipeline.NewBaseTask(0, "task", nil, nil, 0)}
+				result, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{{Value: test.input}})
+
+				assert.False(t, runInfo.IsPending)
+				assert.False(t, runInfo.IsRetryable)
+
+				if test.error == "" {
+					require.NoError(t, result.Error)
+					require.Equal(t, test.result, result.Value)
+				} else {
+					require.ErrorContains(t, result.Error, test.error)
+				}
+			})
+			t.Run("with vars", func(t *testing.T) {
+				vars := pipeline.NewVarsFrom(map[string]interface{}{
+					"foo": map[string]interface{}{"bar": test.input},
+				})
+				task := pipeline.Base64EncodeTask{
+					BaseTask: pipeline.NewBaseTask(0, "task", nil, nil, 0),
+					Input:    "$(foo.bar)",
+				}
+				result, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{})
+
+				assert.False(t, runInfo.IsPending)
+				assert.False(t, runInfo.IsRetryable)
+
+				if test.error == "" {
+					require.NoError(t, result.Error)
+					require.Equal(t, test.result, result.Value)
+				} else {
+					require.ErrorContains(t, result.Error, test.error)
+				}
+			})
+		})
+	}
+}

--- a/core/services/pipeline/task.hexencode.go
+++ b/core/services/pipeline/task.hexencode.go
@@ -1,0 +1,82 @@
+package pipeline
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+
+	"github.com/pkg/errors"
+	"go.uber.org/multierr"
+
+	"github.com/smartcontractkit/chainlink/core/logger"
+)
+
+//
+// Return types:
+//     string
+//
+type HexEncodeTask struct {
+	BaseTask `mapstructure:",squash"`
+	Input    string `json:"input"`
+}
+
+var _ Task = (*HexEncodeTask)(nil)
+
+func (t *HexEncodeTask) Type() TaskType {
+	return TaskTypeHexEncode
+}
+
+func addHexPrefix(val string) string {
+	if len(val) > 0 {
+		return "0x" + val
+	}
+	return ""
+}
+
+func (t *HexEncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs []Result) (result Result, runInfo RunInfo) {
+	_, err := CheckInputs(inputs, 0, 1, 0)
+	if err != nil {
+		return Result{Error: errors.Wrap(err, "task inputs")}, runInfo
+	}
+
+	var stringInput StringParam
+	err = multierr.Combine(
+		errors.Wrap(ResolveParam(&stringInput, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+	)
+	if err == nil {
+		// string
+		return Result{Value: addHexPrefix(hex.EncodeToString([]byte(stringInput.String())))}, runInfo
+	}
+
+	var bytesInput BytesParam
+	err = multierr.Combine(
+		errors.Wrap(ResolveParam(&bytesInput, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+	)
+	if err == nil {
+		// bytes
+		return Result{Value: addHexPrefix(hex.EncodeToString(bytesInput))}, runInfo
+	}
+
+	var decimalInput DecimalParam
+	err = multierr.Combine(
+		errors.Wrap(ResolveParam(&decimalInput, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+	)
+	if err == nil && !decimalInput.Decimal().IsInteger() {
+		// decimal
+		return Result{Error: errors.New("decimal input")}, runInfo
+	}
+
+	var bigIntInput MaybeBigIntParam
+	err = multierr.Combine(
+		errors.Wrap(ResolveParam(&bigIntInput, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+	)
+	if err == nil {
+		// one of integer types
+		if bigIntInput.BigInt().Sign() == -1 {
+			return Result{Error: errors.New("negative integer")}, runInfo
+		}
+		return Result{Value: addHexPrefix(fmt.Sprintf("%x", bigIntInput.BigInt()))}, runInfo
+	}
+
+	return Result{Error: err}, runInfo
+}

--- a/core/services/pipeline/task.hexencode_test.go
+++ b/core/services/pipeline/task.hexencode_test.go
@@ -1,0 +1,99 @@
+package pipeline_test
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/pipeline"
+)
+
+func TestHexEncodeTask(t *testing.T) {
+	t.Parallel()
+	bigTwo, bigThree := big.NewInt(2), big.NewInt(3)
+
+	tests := []struct {
+		name   string
+		input  interface{}
+		result string
+		error  string
+	}{
+
+		// success integers
+		{"zero", 0, "0x0", ""},
+		{"small int", 1, "0x1", ""},
+		{"two-byte integer", 256, "0x100", ""},
+		{"uint8", uint8(10), "0xa", ""},
+		{"small int64", int64(456), "0x1c8", ""},
+		{"large int64", int64(999000000000), "0xe8990a4600", ""},
+		{"bigint 1", bigTwo.Exp(bigTwo, big.NewInt(100), nil), "0x10000000000000000000000000", ""},
+		{"bigint 2", bigThree.Exp(bigThree, big.NewInt(100), nil), "0x5a4653ca673768565b41f775d6947d55cf3813d1", ""},
+		{"decimal type but integer value", 1.0, "0x1", ""},
+		{"decimal type but integer value zero", 0.0, "0x0", ""},
+
+		// success strings/bytes
+		{"string ascii bytes", "xyz", "0x78797a", ""},
+		{"string with whitespace", "1 x *", "0x312078202a", ""},
+		{"string shouldn't convert to int", "456", "0x343536", ""},
+		{"don't detect hex in string", "0xff", "0x30786666", ""},
+		// NOTE: for byte arrays, output is padded to full bytes (i.e. a potential leading zero)
+		{"bytes remain bytes", []byte{0xa, 0x0, 0xff, 0x1}, "0x0a00ff01", ""},
+
+		// success empty results
+		{"empty string", "", "", ""},
+		{"empty byte array", []byte{}, "", ""},
+
+		// failure
+		{"negative int", -1, "", "negative integer"},
+		{"negative float", -1.0, "", "negative integer"},
+		{"negative int64", int64(-10), "", "negative integer"},
+		{"negative bigint", big.NewInt(-100), "", "negative integer"},
+		{"input of type bool", true, "", "bad input for task"},
+		{"input of type decimal", 1.44, "", "decimal input"},
+		{"input of type decimal and negative", -0.44, "", "decimal input"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Run("without vars", func(t *testing.T) {
+				vars := pipeline.NewVarsFrom(nil)
+				task := pipeline.HexEncodeTask{BaseTask: pipeline.NewBaseTask(0, "task", nil, nil, 0)}
+				result, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{{Value: test.input}})
+
+				assert.False(t, runInfo.IsPending)
+				assert.False(t, runInfo.IsRetryable)
+
+				if test.error == "" {
+					require.NoError(t, result.Error)
+					require.Equal(t, test.result, result.Value)
+				} else {
+					require.ErrorContains(t, result.Error, test.error)
+				}
+			})
+			t.Run("with vars", func(t *testing.T) {
+				vars := pipeline.NewVarsFrom(map[string]interface{}{
+					"foo": map[string]interface{}{"bar": test.input},
+				})
+				task := pipeline.HexEncodeTask{
+					BaseTask: pipeline.NewBaseTask(0, "task", nil, nil, 0),
+					Input:    "$(foo.bar)",
+				}
+				result, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{})
+
+				assert.False(t, runInfo.IsPending)
+				assert.False(t, runInfo.IsRetryable)
+
+				if test.error == "" {
+					require.NoError(t, result.Error)
+					require.Equal(t, test.result, result.Value)
+				} else {
+					require.ErrorContains(t, result.Error, test.error)
+				}
+			})
+		})
+	}
+}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `hexencode` and `base64encode` tasks (pipeline).
+- `forwardingAllowed` per job attribute to allow forwarding txs submitted by the job.
+
+### Changed
+
+- `Arbitrum` chains are no longer restricted to only `FixedPrice` `GAS_ESTIMATOR_MODE`
+- Updated `Arbitrum Rinkeby` configuration for Nitro
+
+## 1.7.0 - 2022-08-08
+
+### Added
 
 - `forwardingAllowed` per job attribute to allow forwarding txs submitted by the job.
 - `p2pv2Bootstrappers` has been added as a new optional property of OCR1 job specs; default may still be specified with P2PV2_BOOTSTRAPPERS config param


### PR DESCRIPTION
Adding two new tasks: hexencode and base64encode
Docs in: https://github.com/smartcontractkit/documentation/pull/909