### PR TITLE
Fixed mockery usage

### DIFF
--- a/core/chains/solana/monitor/balance_test.go
+++ b/core/chains/solana/monitor/balance_test.go
@@ -12,7 +12,6 @@ import (
 
 	solanaRelay "github.com/smartcontractkit/chainlink-solana/pkg/solana"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/client/mocks"
-
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/solkey"

--- a/core/chains/solana/monitor/balance_test.go
+++ b/core/chains/solana/monitor/balance_test.go
@@ -35,6 +35,7 @@ func TestBalanceMonitor(t *testing.T) {
 	}
 
 	client := new(mocks.ReaderWriter)
+	client.Test(t)
 	type update struct{ acc, bal string }
 	var exp []update
 	for i := range bals {

--- a/core/chains/solana/monitor/balance_test.go
+++ b/core/chains/solana/monitor/balance_test.go
@@ -10,11 +10,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	solanaRelay "github.com/smartcontractkit/chainlink-solana/pkg/solana"
-	"github.com/smartcontractkit/chainlink-solana/pkg/solana/client/mocks"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/solkey"
+
+	solanaRelay "github.com/smartcontractkit/chainlink-solana/pkg/solana"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/client/mocks"
 )
 
 func TestBalanceMonitor(t *testing.T) {

--- a/core/chains/solana/orm_test.go
+++ b/core/chains/solana/orm_test.go
@@ -11,10 +11,11 @@ import (
 
 	"github.com/smartcontractkit/sqlx"
 
-	"github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
 	"github.com/smartcontractkit/chainlink/core/chains/solana"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
 )
 
 func setupORM(t *testing.T) (*sqlx.DB, solana.ORM) {

--- a/core/chains/solana/orm_test.go
+++ b/core/chains/solana/orm_test.go
@@ -9,11 +9,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/sqlx"
+
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
 	"github.com/smartcontractkit/chainlink/core/chains/solana"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
-	"github.com/smartcontractkit/sqlx"
 )
 
 func setupORM(t *testing.T) (*sqlx.DB, solana.ORM) {

--- a/core/chains/solana/orm_test.go
+++ b/core/chains/solana/orm_test.go
@@ -10,11 +10,10 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
-	"github.com/smartcontractkit/sqlx"
-
 	"github.com/smartcontractkit/chainlink/core/chains/solana"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/sqlx"
 )
 
 func setupORM(t *testing.T) (*sqlx.DB, solana.ORM) {

--- a/core/chains/solana/soltxm/txm_internal_test.go
+++ b/core/chains/solana/soltxm/txm_internal_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/client/mocks"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
+
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/solkey"

--- a/core/chains/solana/soltxm/txm_internal_test.go
+++ b/core/chains/solana/soltxm/txm_internal_test.go
@@ -62,21 +62,26 @@ func getTx(t *testing.T, pubkey solana.PublicKey) *solana.Transaction {
 	return tx
 }
 
+func newReaderWriterMock(t *testing.T) *mocks.ReaderWriter {
+	m := new(mocks.ReaderWriter)
+	m.Test(t)
+	t.Cleanup(func() { m.AssertExpectations(t) })
+	return m
+}
+
 func TestTxm(t *testing.T) {
 	// set up configs needed in txm
 	id := "mocknet"
 	lggr := logger.TestLogger(t)
 	cfg := config.NewConfig(db.ChainCfg{}, lggr)
-	mc := new(mocks.ReaderWriter)
-	defer mc.AssertExpectations(t)
+	mc := newReaderWriterMock(t)
 
 	// mock solana keystore
 	key, err := solkey.New()
 	pubkey := key.PublicKey()
 
 	require.NoError(t, err)
-	mkey := new(keyMocks.Solana)
-	defer mkey.AssertExpectations(t)
+	mkey := keyMocks.NewSolana(t)
 	mkey.On("Get", key.ID()).Return(key, nil)
 
 	txm := NewTxm(id, func() (client.ReaderWriter, error) {
@@ -435,16 +440,14 @@ func TestTxm_Enqueue(t *testing.T) {
 	// set up configs needed in txm
 	lggr := logger.TestLogger(t)
 	cfg := config.NewConfig(db.ChainCfg{}, lggr)
-	mc := new(mocks.ReaderWriter)
-	defer mc.AssertExpectations(t)
+	mc := newReaderWriterMock(t)
 
 	// mock solana keystore
 	key, err := solkey.New()
 	pubkey := key.PublicKey()
 
 	require.NoError(t, err)
-	mkey := new(keyMocks.Solana)
-	defer mkey.AssertExpectations(t)
+	mkey := keyMocks.NewSolana(t)
 	mkey.On("Get", key.ID()).Return(key, nil)
 	zerokey := solana.PublicKey{}
 	mkey.On("Get", zerokey.String()).Return(solkey.Key{}, keystore.KeyNotFoundError{ID: zerokey.String(), KeyType: "Solana"})

--- a/core/chains/solana/soltxm/txm_internal_test.go
+++ b/core/chains/solana/soltxm/txm_internal_test.go
@@ -12,6 +12,10 @@ import (
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus/testutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/client"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/client/mocks"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
@@ -20,9 +24,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/solkey"
 	keyMocks "github.com/smartcontractkit/chainlink/core/services/keystore/mocks"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 type soltxmProm struct {

--- a/core/chains/solana/soltxm/txm_test.go
+++ b/core/chains/solana/soltxm/txm_test.go
@@ -46,8 +46,7 @@ func TestTxm_Integration(t *testing.T) {
 	solanaClient.FundTestAccounts(t, []solana.PublicKey{pubKey, loadTestKey.PublicKey()}, url)
 
 	// setup mock keystore
-	mkey := new(mocks.Solana)
-	defer mkey.AssertExpectations(t)
+	mkey := mocks.NewSolana(t)
 	mkey.On("Get", key.ID()).Return(key, nil)
 	mkey.On("Get", loadTestKey.ID()).Return(loadTestKey, nil)
 	mkey.On("Get", pubKeyReceiver.String()).Return(solkey.Key{}, keystore.KeyNotFoundError{ID: pubKeyReceiver.String(), KeyType: "Solana"})

--- a/core/chains/solana/soltxm/txm_test.go
+++ b/core/chains/solana/soltxm/txm_test.go
@@ -10,13 +10,13 @@ import (
 
 	"github.com/gagliardetto/solana-go"
 	"github.com/gagliardetto/solana-go/programs/system"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	relayutils "github.com/smartcontractkit/chainlink-relay/pkg/utils"
 	solanaClient "github.com/smartcontractkit/chainlink-solana/pkg/solana/client"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-
 	"github.com/smartcontractkit/chainlink/core/chains/solana/soltxm"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/logger"

--- a/core/chains/solana/soltxm/txm_test.go
+++ b/core/chains/solana/soltxm/txm_test.go
@@ -14,15 +14,17 @@ import (
 	"github.com/stretchr/testify/require"
 
 	relayutils "github.com/smartcontractkit/chainlink-relay/pkg/utils"
-	solanaClient "github.com/smartcontractkit/chainlink-solana/pkg/solana/client"
-	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
-	"github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
+
 	"github.com/smartcontractkit/chainlink/core/chains/solana/soltxm"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/solkey"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/mocks"
+
+	solanaClient "github.com/smartcontractkit/chainlink-solana/pkg/solana/client"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
 )
 
 func TestTxm_Integration(t *testing.T) {

--- a/core/chains/terra/monitor/balance_test.go
+++ b/core/chains/terra/monitor/balance_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-terra/pkg/terra/client/mocks"
-
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/terrakey"

--- a/core/chains/terra/monitor/balance_test.go
+++ b/core/chains/terra/monitor/balance_test.go
@@ -29,6 +29,7 @@ func TestBalanceMonitor(t *testing.T) {
 		"100000.000000000000000000luna",
 	}
 	client := new(mocks.ReaderWriter)
+	client.Test(t)
 	type update struct{ acc, bal string }
 	var exp []update
 	for i := range bals {

--- a/core/chains/terra/orm_test.go
+++ b/core/chains/terra/orm_test.go
@@ -8,12 +8,13 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/sqlx"
+
 	"github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
 	"github.com/smartcontractkit/chainlink/core/chains/terra"
 	"github.com/smartcontractkit/chainlink/core/chains/terra/types"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
-	"github.com/smartcontractkit/sqlx"
 )
 
 func setupORM(t *testing.T) (*sqlx.DB, types.ORM) {

--- a/core/chains/terra/orm_test.go
+++ b/core/chains/terra/orm_test.go
@@ -8,13 +8,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/sqlx"
-
-	"github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
 	"github.com/smartcontractkit/chainlink/core/chains/terra"
 	"github.com/smartcontractkit/chainlink/core/chains/terra/types"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+
+	"github.com/smartcontractkit/sqlx"
+
+	"github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
 )
 
 func setupORM(t *testing.T) (*sqlx.DB, types.ORM) {

--- a/core/chains/terra/orm_test.go
+++ b/core/chains/terra/orm_test.go
@@ -9,12 +9,11 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
-	"github.com/smartcontractkit/sqlx"
-
 	"github.com/smartcontractkit/chainlink/core/chains/terra"
 	"github.com/smartcontractkit/chainlink/core/chains/terra/types"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/sqlx"
 )
 
 func setupORM(t *testing.T) (*sqlx.DB, types.ORM) {

--- a/core/chains/terra/terratxm/txm_internal_test.go
+++ b/core/chains/terra/terratxm/txm_internal_test.go
@@ -17,21 +17,18 @@ import (
 	tmservicetypes "github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
-	tmtypes "github.com/tendermint/tendermint/proto/tendermint/types"
-	wasmtypes "github.com/terra-money/core/x/wasm/types"
-
 	relayutils "github.com/smartcontractkit/chainlink-relay/pkg/utils"
 	"github.com/smartcontractkit/chainlink-terra/pkg/terra"
 	terraclient "github.com/smartcontractkit/chainlink-terra/pkg/terra/client"
 	tcmocks "github.com/smartcontractkit/chainlink-terra/pkg/terra/client/mocks"
-
+	. "github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/terratest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/utils"
-
-	. "github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
+	tmtypes "github.com/tendermint/tendermint/proto/tendermint/types"
+	wasmtypes "github.com/terra-money/core/x/wasm/types"
 )
 
 func generateExecuteMsg(t *testing.T, msg []byte, from, to cosmostypes.AccAddress) cosmostypes.Msg {

--- a/core/chains/terra/terratxm/txm_internal_test.go
+++ b/core/chains/terra/terratxm/txm_internal_test.go
@@ -7,18 +7,17 @@ import (
 	"testing"
 	"time"
 
+	tmservicetypes "github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
+	cosmostypes "github.com/cosmos/cosmos-sdk/types"
+	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
-	"gopkg.in/guregu/null.v4"
-
-	tmservicetypes "github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
-	cosmostypes "github.com/cosmos/cosmos-sdk/types"
-	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
 	tmtypes "github.com/tendermint/tendermint/proto/tendermint/types"
 	wasmtypes "github.com/terra-money/core/x/wasm/types"
+	"go.uber.org/zap/zapcore"
+	"gopkg.in/guregu/null.v4"
 
 	relayutils "github.com/smartcontractkit/chainlink-relay/pkg/utils"
 	"github.com/smartcontractkit/chainlink-terra/pkg/terra"

--- a/core/chains/terra/terratxm/txm_internal_test.go
+++ b/core/chains/terra/terratxm/txm_internal_test.go
@@ -20,15 +20,16 @@ import (
 	"gopkg.in/guregu/null.v4"
 
 	relayutils "github.com/smartcontractkit/chainlink-relay/pkg/utils"
-	"github.com/smartcontractkit/chainlink-terra/pkg/terra"
-	terraclient "github.com/smartcontractkit/chainlink-terra/pkg/terra/client"
-	tcmocks "github.com/smartcontractkit/chainlink-terra/pkg/terra/client/mocks"
-	. "github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/terratest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/utils"
+
+	"github.com/smartcontractkit/chainlink-terra/pkg/terra"
+	terraclient "github.com/smartcontractkit/chainlink-terra/pkg/terra/client"
+	tcmocks "github.com/smartcontractkit/chainlink-terra/pkg/terra/client/mocks"
+	. "github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
 )
 
 func generateExecuteMsg(t *testing.T, msg []byte, from, to cosmostypes.AccAddress) cosmostypes.Msg {

--- a/core/chains/terra/terratxm/txm_internal_test.go
+++ b/core/chains/terra/terratxm/txm_internal_test.go
@@ -17,6 +17,9 @@ import (
 	tmservicetypes "github.com/cosmos/cosmos-sdk/client/grpc/tmservice"
 	cosmostypes "github.com/cosmos/cosmos-sdk/types"
 	txtypes "github.com/cosmos/cosmos-sdk/types/tx"
+	tmtypes "github.com/tendermint/tendermint/proto/tendermint/types"
+	wasmtypes "github.com/terra-money/core/x/wasm/types"
+
 	relayutils "github.com/smartcontractkit/chainlink-relay/pkg/utils"
 	"github.com/smartcontractkit/chainlink-terra/pkg/terra"
 	terraclient "github.com/smartcontractkit/chainlink-terra/pkg/terra/client"
@@ -27,8 +30,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/terratest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/utils"
-	tmtypes "github.com/tendermint/tendermint/proto/tendermint/types"
-	wasmtypes "github.com/terra-money/core/x/wasm/types"
 )
 
 func generateExecuteMsg(t *testing.T, msg []byte, from, to cosmostypes.AccAddress) cosmostypes.Msg {

--- a/core/cmd/external_initiator_commands_test.go
+++ b/core/cmd/external_initiator_commands_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/web/presenters"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestExternalInitiatorPresenter_RenderTable(t *testing.T) {

--- a/core/services/cron/cron_test.go
+++ b/core/services/cron/cron_test.go
@@ -3,6 +3,11 @@ package cron_test
 import (
 	"testing"
 
+	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
@@ -13,11 +18,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	pipelinemocks "github.com/smartcontractkit/chainlink/core/services/pipeline/mocks"
-
-	uuid "github.com/satori/go.uuid"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
 )
 
 func TestCronV2Pipeline(t *testing.T) {

--- a/core/services/directrequest/delegate_test.go
+++ b/core/services/directrequest/delegate_test.go
@@ -6,10 +6,9 @@ import (
 	"testing"
 	"time"
 
-	uuid "github.com/satori/go.uuid"
-
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	uuid "github.com/satori/go.uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"

--- a/core/services/directrequest/delegate_test.go
+++ b/core/services/directrequest/delegate_test.go
@@ -34,7 +34,7 @@ import (
 
 func TestDelegate_ServicesForSpec(t *testing.T) {
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	runner := new(pipeline_mocks.Runner)
+	runner := pipeline_mocks.NewRunner(t)
 	db := pgtest.NewSqlxDB(t)
 	cfg := configtest.NewTestGeneralConfig(t)
 	cfg.Overrides.GlobalMinIncomingConfirmations = null.IntFrom(1)
@@ -70,7 +70,7 @@ type DirectRequestUniverse struct {
 func NewDirectRequestUniverseWithConfig(t *testing.T, cfg *configtest.TestGeneralConfig, specF func(spec *job.Job)) *DirectRequestUniverse {
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	broadcaster := log_mocks.NewBroadcaster(t)
-	runner := new(pipeline_mocks.Runner)
+	runner := pipeline_mocks.NewRunner(t)
 	broadcaster.On("AddDependents", 1)
 
 	db := pgtest.NewSqlxDB(t)
@@ -122,12 +122,13 @@ func (uni *DirectRequestUniverse) Cleanup() {
 }
 
 func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
+	t.Parallel()
+
 	t.Run("Log is an OracleRequest", func(t *testing.T) {
 		uni := NewDirectRequestUniverse(t)
 		defer uni.Cleanup()
 
-		log := new(log_mocks.Broadcast)
-		defer log.AssertExpectations(t)
+		log := log_mocks.NewBroadcast(t)
 		log.On("ReceiptsRoot").Return(common.Hash{})
 		log.On("TransactionsRoot").Return(common.Hash{})
 		log.On("StateRoot").Return(common.Hash{})
@@ -143,6 +144,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 			},
 		})
 		log.On("DecodedLog").Return(&logOracleRequest)
+		log.On("String").Return("")
 		uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
 
 		runBeganAwaiter := cltest.NewAwaiter()
@@ -169,15 +171,13 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		runBeganAwaiter.AwaitOrFail(t, 5*time.Second)
 
 		uni.service.Close()
-		uni.logBroadcaster.AssertExpectations(t)
-		uni.runner.AssertExpectations(t)
 	})
 
 	t.Run("Log is not consumed, as it's too young", func(t *testing.T) {
 		uni := NewDirectRequestUniverse(t)
 		defer uni.Cleanup()
 
-		log := new(log_mocks.Broadcast)
+		log := log_mocks.NewBroadcast(t)
 
 		uni.logBroadcaster.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil).Maybe()
 		logOracleRequest := operator_wrapper.OperatorOracleRequest{
@@ -191,12 +191,11 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 			BlockNumber: 0,
 		}).Maybe()
 		log.On("DecodedLog").Return(&logOracleRequest).Maybe()
+		log.On("String").Return("")
 		uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil).Maybe()
 
 		err := uni.service.Start(testutils.Context(t))
 		require.NoError(t, err)
-
-		log.AssertExpectations(t)
 
 		uni.listener.HandleLog(log)
 
@@ -216,35 +215,34 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 
 		// but should after this one, as the head Number is larger
 		runBeganAwaiter.AwaitOrFail(t, 5*time.Second)
-		cltest.EventuallyExpectationsMet(t, log, 3*time.Second, 100*time.Millisecond)
 
 		uni.service.Close()
-		uni.logBroadcaster.AssertExpectations(t)
-		uni.runner.AssertExpectations(t)
 	})
 
 	t.Run("Log has wrong jobID", func(t *testing.T) {
 		uni := NewDirectRequestUniverse(t)
 		defer uni.Cleanup()
 
-		log := new(log_mocks.Broadcast)
+		log := log_mocks.NewBroadcast(t)
+		lbAwaiter := cltest.NewAwaiter()
 		uni.logBroadcaster.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil)
-		uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
+		uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Run(func(args mock.Arguments) { lbAwaiter.ItHappened() }).Return(nil)
 
 		logCancelOracleRequest := operator_wrapper.OperatorCancelOracleRequest{RequestId: uni.spec.ExternalIDEncodeStringToTopic()}
-		log.On("DecodedLog").Return(&logCancelOracleRequest)
+		logAwaiter := cltest.NewAwaiter()
+		log.On("DecodedLog").Run(func(args mock.Arguments) { logAwaiter.ItHappened() }).Return(&logCancelOracleRequest)
 		log.On("RawLog").Return(types.Log{
 			Topics: []common.Hash{{}, {}},
 		})
+		log.On("String").Return("")
 
 		err := uni.service.Start(testutils.Context(t))
 		require.NoError(t, err)
 
 		uni.listener.HandleLog(log)
 
-		cltest.EventuallyExpectationsMet(t, uni.logBroadcaster, 3*time.Second, 100*time.Millisecond)
-		cltest.EventuallyExpectationsMet(t, uni.runner, 3*time.Second, 100*time.Millisecond)
-		cltest.EventuallyExpectationsMet(t, log, 3*time.Second, 100*time.Millisecond)
+		logAwaiter.AwaitOrFail(t)
+		lbAwaiter.AwaitOrFail(t)
 
 		uni.service.Close()
 	})
@@ -253,7 +251,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		uni := NewDirectRequestUniverse(t)
 		defer uni.Cleanup()
 
-		log := new(log_mocks.Broadcast)
+		log := log_mocks.NewBroadcast(t)
 
 		uni.logBroadcaster.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil)
 		logCancelOracleRequest := operator_wrapper.OperatorCancelOracleRequest{RequestId: uni.spec.ExternalIDEncodeStringToTopic()}
@@ -263,17 +261,17 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 				uni.spec.ExternalIDEncodeStringToTopic(),
 			},
 		})
+		log.On("String").Return("")
 		log.On("DecodedLog").Return(&logCancelOracleRequest)
-		uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
+		lbAwaiter := cltest.NewAwaiter()
+		uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Run(func(args mock.Arguments) { lbAwaiter.ItHappened() }).Return(nil)
 
 		err := uni.service.Start(testutils.Context(t))
 		require.NoError(t, err)
 
 		uni.listener.HandleLog(log)
 
-		cltest.EventuallyExpectationsMet(t, uni.logBroadcaster, 3*time.Second, 100*time.Millisecond)
-		cltest.EventuallyExpectationsMet(t, uni.runner, 3*time.Second, 100*time.Millisecond)
-		cltest.EventuallyExpectationsMet(t, log, 3*time.Second, 100*time.Millisecond)
+		lbAwaiter.AwaitOrFail(t)
 
 		uni.service.Close()
 	})
@@ -282,7 +280,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		uni := NewDirectRequestUniverse(t)
 		defer uni.Cleanup()
 
-		runLog := new(log_mocks.Broadcast)
+		runLog := log_mocks.NewBroadcast(t)
 		runLog.On("ReceiptsRoot").Return(common.Hash{})
 		runLog.On("TransactionsRoot").Return(common.Hash{})
 		runLog.On("StateRoot").Return(common.Hash{})
@@ -299,9 +297,10 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 			},
 		})
 		runLog.On("DecodedLog").Return(&logOracleRequest)
+		runLog.On("String").Return("")
 		uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
 
-		cancelLog := new(log_mocks.Broadcast)
+		cancelLog := log_mocks.NewBroadcast(t)
 
 		uni.logBroadcaster.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil)
 		logCancelOracleRequest := operator_wrapper.OperatorCancelOracleRequest{RequestId: uni.spec.ExternalIDEncodeStringToTopic()}
@@ -312,6 +311,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 			},
 		})
 		cancelLog.On("DecodedLog").Return(&logCancelOracleRequest)
+		cancelLog.On("String").Return("")
 		uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
 
 		err := uni.service.Start(testutils.Context(t))
@@ -333,16 +333,12 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		uni.listener.HandleLog(runLog)
 
 		runBeganAwaiter.AwaitOrFail(t, timeout)
-		runLog.AssertExpectations(t)
 
 		uni.listener.HandleLog(cancelLog)
 
 		runCancelledAwaiter.AwaitOrFail(t, timeout)
-		cancelLog.AssertExpectations(t)
 
 		uni.service.Close()
-		uni.logBroadcaster.AssertExpectations(t)
-		uni.runner.AssertExpectations(t)
 	})
 
 	t.Run("Log has sufficient funds", func(t *testing.T) {
@@ -352,8 +348,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		uni := NewDirectRequestUniverseWithConfig(t, cfg, nil)
 		defer uni.Cleanup()
 
-		log := new(log_mocks.Broadcast)
-		defer log.AssertExpectations(t)
+		log := log_mocks.NewBroadcast(t)
 		log.On("ReceiptsRoot").Return(common.Hash{})
 		log.On("TransactionsRoot").Return(common.Hash{})
 		log.On("StateRoot").Return(common.Hash{})
@@ -370,6 +365,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 			},
 		})
 		log.On("DecodedLog").Return(&logOracleRequest)
+		log.On("String").Return("")
 		uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
 
 		runBeganAwaiter := cltest.NewAwaiter()
@@ -393,8 +389,6 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		runBeganAwaiter.AwaitOrFail(t, 5*time.Second)
 
 		uni.service.Close()
-		uni.logBroadcaster.AssertExpectations(t)
-		uni.runner.AssertExpectations(t)
 	})
 
 	t.Run("Log has insufficient funds", func(t *testing.T) {
@@ -404,8 +398,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		uni := NewDirectRequestUniverseWithConfig(t, cfg, nil)
 		defer uni.Cleanup()
 
-		log := new(log_mocks.Broadcast)
-		defer log.AssertExpectations(t)
+		log := log_mocks.NewBroadcast(t)
 
 		uni.logBroadcaster.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil)
 		logOracleRequest := operator_wrapper.OperatorOracleRequest{
@@ -419,6 +412,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 			},
 		})
 		log.On("DecodedLog").Return(&logOracleRequest)
+		log.On("String").Return("")
 		markConsumedLogAwaiter := cltest.NewAwaiter()
 		uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 			markConsumedLogAwaiter.ItHappened()
@@ -432,8 +426,6 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		markConsumedLogAwaiter.AwaitOrFail(t, 5*time.Second)
 
 		uni.service.Close()
-		uni.logBroadcaster.AssertExpectations(t)
-		uni.runner.AssertExpectations(t)
 	})
 
 	t.Run("requesters is specified and log is requested by a whitelisted address", func(t *testing.T) {
@@ -446,8 +438,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		})
 		defer uni.Cleanup()
 
-		log := new(log_mocks.Broadcast)
-		defer log.AssertExpectations(t)
+		log := log_mocks.NewBroadcast(t)
 		log.On("ReceiptsRoot").Return(common.Hash{})
 		log.On("TransactionsRoot").Return(common.Hash{})
 		log.On("StateRoot").Return(common.Hash{})
@@ -465,6 +456,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 			},
 		})
 		log.On("DecodedLog").Return(&logOracleRequest)
+		log.On("String").Return("")
 		markConsumedLogAwaiter := cltest.NewAwaiter()
 		uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 			markConsumedLogAwaiter.ItHappened()
@@ -491,8 +483,6 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		runBeganAwaiter.AwaitOrFail(t, 5*time.Second)
 
 		uni.service.Close()
-		uni.logBroadcaster.AssertExpectations(t)
-		uni.runner.AssertExpectations(t)
 	})
 
 	t.Run("requesters is specified and log is requested by a non-whitelisted address", func(t *testing.T) {
@@ -505,8 +495,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		})
 		defer uni.Cleanup()
 
-		log := new(log_mocks.Broadcast)
-		defer log.AssertExpectations(t)
+		log := log_mocks.NewBroadcast(t)
 
 		uni.logBroadcaster.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil)
 		logOracleRequest := operator_wrapper.OperatorOracleRequest{
@@ -521,6 +510,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 			},
 		})
 		log.On("DecodedLog").Return(&logOracleRequest)
+		log.On("String").Return("")
 		markConsumedLogAwaiter := cltest.NewAwaiter()
 		uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 			markConsumedLogAwaiter.ItHappened()
@@ -534,7 +524,5 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		markConsumedLogAwaiter.AwaitOrFail(t, 5*time.Second)
 
 		uni.service.Close()
-		uni.logBroadcaster.AssertExpectations(t)
-		uni.runner.AssertExpectations(t)
 	})
 }

--- a/core/services/fluxmonitorv2/flags.go
+++ b/core/services/fluxmonitorv2/flags.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+
 	evmclient "github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated"
 	"github.com/smartcontractkit/chainlink/core/internal/gethwrappers/generated/flags_wrapper"

--- a/core/services/keeper/registry1_2_synchronizer_test.go
+++ b/core/services/keeper/registry1_2_synchronizer_test.go
@@ -140,7 +140,6 @@ func Test_RegistrySynchronizer1_2_Start(t *testing.T) {
 
 	err = synchronizer.Start(testutils.Context(t))
 	require.Error(t, err)
-	ethMock.AssertExpectations(t)
 }
 
 func Test_RegistrySynchronizer1_2_FullSync(t *testing.T) {
@@ -196,7 +195,6 @@ func Test_RegistrySynchronizer1_2_FullSync(t *testing.T) {
 	require.Equal(t, uint64(upkeepConfig1_2.ExecuteGas), upkeepRegistration.ExecuteGas)
 
 	assertUpkeepIDs(t, db, []int64{3, 69, 420})
-	ethMock.AssertExpectations(t)
 
 	// 2nd sync. Cancel upkeep (id 3) and add a new upkeep (id 2022)
 	mockRegistry1_2(
@@ -215,8 +213,6 @@ func Test_RegistrySynchronizer1_2_FullSync(t *testing.T) {
 	cltest.AssertCount(t, db, "keeper_registries", 1)
 	cltest.AssertCount(t, db, "upkeep_registrations", 3)
 	assertUpkeepIDs(t, db, []int64{69, 420, 2022})
-
-	ethMock.AssertExpectations(t)
 }
 
 func Test_RegistrySynchronizer1_2_ConfigSetLog(t *testing.T) {
@@ -256,7 +252,7 @@ func Test_RegistrySynchronizer1_2_ConfigSetLog(t *testing.T) {
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_2.KeeperRegistryConfigSet{}
-	logBroadcast := new(logmocks.Broadcast)
+	logBroadcast := logmocks.NewBroadcast(t)
 	logBroadcast.On("DecodedLog").Return(&log)
 	logBroadcast.On("RawLog").Return(rawLog)
 	logBroadcast.On("String").Maybe().Return("")
@@ -270,8 +266,6 @@ func Test_RegistrySynchronizer1_2_ConfigSetLog(t *testing.T) {
 		return registry.BlockCountPerTurn == 40
 	})
 	cltest.AssertCount(t, db, "keeper_registries", 1)
-	ethMock.AssertExpectations(t)
-	logBroadcast.AssertExpectations(t)
 }
 
 func Test_RegistrySynchronizer1_2_KeepersUpdatedLog(t *testing.T) {
@@ -310,7 +304,7 @@ func Test_RegistrySynchronizer1_2_KeepersUpdatedLog(t *testing.T) {
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_2.KeeperRegistryKeepersUpdated{}
-	logBroadcast := new(logmocks.Broadcast)
+	logBroadcast := logmocks.NewBroadcast(t)
 	logBroadcast.On("DecodedLog").Return(&log)
 	logBroadcast.On("RawLog").Return(rawLog)
 	logBroadcast.On("String").Maybe().Return("")
@@ -324,8 +318,6 @@ func Test_RegistrySynchronizer1_2_KeepersUpdatedLog(t *testing.T) {
 		return registry.NumKeepers == 2
 	})
 	cltest.AssertCount(t, db, "keeper_registries", 1)
-	ethMock.AssertExpectations(t)
-	logBroadcast.AssertExpectations(t)
 }
 
 func Test_RegistrySynchronizer1_2_UpkeepCanceledLog(t *testing.T) {
@@ -355,7 +347,7 @@ func Test_RegistrySynchronizer1_2_UpkeepCanceledLog(t *testing.T) {
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_2.KeeperRegistryUpkeepCanceled{Id: big.NewInt(3)}
-	logBroadcast := new(logmocks.Broadcast)
+	logBroadcast := logmocks.NewBroadcast(t)
 	logBroadcast.On("DecodedLog").Return(&log)
 	logBroadcast.On("RawLog").Return(rawLog)
 	logBroadcast.On("String").Maybe().Return("")
@@ -366,8 +358,6 @@ func Test_RegistrySynchronizer1_2_UpkeepCanceledLog(t *testing.T) {
 	synchronizer.HandleLog(logBroadcast)
 
 	cltest.WaitForCount(t, db, "upkeep_registrations", 2)
-	ethMock.AssertExpectations(t)
-	logBroadcast.AssertExpectations(t)
 }
 
 func Test_RegistrySynchronizer1_2_UpkeepRegisteredLog(t *testing.T) {
@@ -400,7 +390,7 @@ func Test_RegistrySynchronizer1_2_UpkeepRegisteredLog(t *testing.T) {
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_2.KeeperRegistryUpkeepRegistered{Id: big.NewInt(420)}
-	logBroadcast := new(logmocks.Broadcast)
+	logBroadcast := logmocks.NewBroadcast(t)
 	logBroadcast.On("DecodedLog").Return(&log)
 	logBroadcast.On("RawLog").Return(rawLog)
 	logBroadcast.On("String").Maybe().Return("")
@@ -411,8 +401,6 @@ func Test_RegistrySynchronizer1_2_UpkeepRegisteredLog(t *testing.T) {
 	synchronizer.HandleLog(logBroadcast)
 
 	cltest.WaitForCount(t, db, "upkeep_registrations", 2)
-	ethMock.AssertExpectations(t)
-	logBroadcast.AssertExpectations(t)
 }
 
 func Test_RegistrySynchronizer1_2_UpkeepPerformedLog(t *testing.T) {
@@ -446,7 +434,7 @@ func Test_RegistrySynchronizer1_2_UpkeepPerformedLog(t *testing.T) {
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash, BlockNumber: 200}
 	log := registry1_2.KeeperRegistryUpkeepPerformed{Id: big.NewInt(3), From: fromAddress}
-	logBroadcast := new(logmocks.Broadcast)
+	logBroadcast := logmocks.NewBroadcast(t)
 	logBroadcast.On("DecodedLog").Return(&log)
 	logBroadcast.On("RawLog").Return(rawLog)
 	logBroadcast.On("String").Maybe().Return("")
@@ -469,9 +457,6 @@ func Test_RegistrySynchronizer1_2_UpkeepPerformedLog(t *testing.T) {
 		require.NoError(t, err)
 		return upkeep.LastKeeperIndex.Int64
 	}, cltest.WaitTimeout(t), cltest.DBPollingInterval).Should(gomega.Equal(int64(0)))
-
-	ethMock.AssertExpectations(t)
-	logBroadcast.AssertExpectations(t)
 }
 
 func Test_RegistrySynchronizer1_2_UpkeepGasLimitSetLog(t *testing.T) {
@@ -515,7 +500,7 @@ func Test_RegistrySynchronizer1_2_UpkeepGasLimitSetLog(t *testing.T) {
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_2.KeeperRegistryUpkeepGasLimitSet{Id: big.NewInt(3), GasLimit: big.NewInt(4_000_000)}
-	logBroadcast := new(logmocks.Broadcast)
+	logBroadcast := logmocks.NewBroadcast(t)
 	logBroadcast.On("DecodedLog").Return(&log)
 	logBroadcast.On("RawLog").Return(rawLog)
 	logBroadcast.On("String").Maybe().Return("")
@@ -526,8 +511,6 @@ func Test_RegistrySynchronizer1_2_UpkeepGasLimitSetLog(t *testing.T) {
 	synchronizer.HandleLog(logBroadcast)
 
 	g.Eventually(getExecuteGas, cltest.WaitTimeout(t), cltest.DBPollingInterval).Should(gomega.Equal(uint64(4_000_000)))
-	ethMock.AssertExpectations(t)
-	logBroadcast.AssertExpectations(t)
 }
 
 func Test_RegistrySynchronizer1_2_UpkeepReceivedLog(t *testing.T) {
@@ -560,7 +543,7 @@ func Test_RegistrySynchronizer1_2_UpkeepReceivedLog(t *testing.T) {
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_2.KeeperRegistryUpkeepReceived{Id: big.NewInt(420)}
-	logBroadcast := new(logmocks.Broadcast)
+	logBroadcast := logmocks.NewBroadcast(t)
 	logBroadcast.On("DecodedLog").Return(&log)
 	logBroadcast.On("RawLog").Return(rawLog)
 	logBroadcast.On("String").Maybe().Return("")
@@ -571,8 +554,6 @@ func Test_RegistrySynchronizer1_2_UpkeepReceivedLog(t *testing.T) {
 	synchronizer.HandleLog(logBroadcast)
 
 	cltest.WaitForCount(t, db, "upkeep_registrations", 2)
-	ethMock.AssertExpectations(t)
-	logBroadcast.AssertExpectations(t)
 }
 
 func Test_RegistrySynchronizer1_2_UpkeepMigratedLog(t *testing.T) {
@@ -602,7 +583,7 @@ func Test_RegistrySynchronizer1_2_UpkeepMigratedLog(t *testing.T) {
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_2.KeeperRegistryUpkeepMigrated{Id: big.NewInt(3)}
-	logBroadcast := new(logmocks.Broadcast)
+	logBroadcast := logmocks.NewBroadcast(t)
 	logBroadcast.On("DecodedLog").Return(&log)
 	logBroadcast.On("RawLog").Return(rawLog)
 	logBroadcast.On("String").Maybe().Return("")
@@ -613,6 +594,4 @@ func Test_RegistrySynchronizer1_2_UpkeepMigratedLog(t *testing.T) {
 	synchronizer.HandleLog(logBroadcast)
 
 	cltest.WaitForCount(t, db, "upkeep_registrations", 2)
-	ethMock.AssertExpectations(t)
-	logBroadcast.AssertExpectations(t)
 }

--- a/core/services/keeper/upkeep_executer_test.go
+++ b/core/services/keeper/upkeep_executer_test.go
@@ -87,7 +87,7 @@ func setup(t *testing.T, estimator *gasmocks.Estimator) (
 	executer := keeper.NewUpkeepExecuter(job, orm, jpv2.Pr, ethClient, ch.HeadBroadcaster(), ch.TxManager().GetGasEstimator(), lggr, ch.Config())
 	upkeep := cltest.MustInsertUpkeepForRegistry(t, db, ch.Config(), registry)
 	err := executer.Start(testutils.Context(t))
-	t.Cleanup(func() { txm.AssertExpectations(t); estimator.AssertExpectations(t); executer.Close() })
+	t.Cleanup(func() { executer.Close() })
 	require.NoError(t, err)
 	return db, cfg, ethClient, executer, registry, upkeep, job, jpv2, txm, keyStore, ch, orm
 }
@@ -161,9 +161,6 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 		assert.False(t, runs[0].HasErrors())
 		assert.False(t, runs[0].HasFatalErrors())
 		waitLastRunHeight(t, db, upkeep, 20)
-
-		ethMock.AssertExpectations(t)
-		txm.AssertExpectations(t)
 	})
 
 	t.Run("runs upkeep on triggering block number on EIP1559 and non-EIP1559 chains", func(t *testing.T) {
@@ -216,9 +213,6 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 			assert.False(t, runs[0].HasErrors())
 			assert.False(t, runs[0].HasFatalErrors())
 			waitLastRunHeight(t, db, upkeep, 20)
-
-			ethMock.AssertExpectations(t)
-			txm.AssertExpectations(t)
 		}
 
 		t.Run("EIP1559", func(t *testing.T) {
@@ -262,8 +256,6 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 		require.Len(t, runs, 1)
 		assert.True(t, runs[0].HasErrors())
 		assert.True(t, runs[0].HasFatalErrors())
-
-		ethMock.AssertExpectations(t)
 	})
 
 	t.Run("errors if submission chain not found", func(t *testing.T) {
@@ -282,7 +274,6 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 		// TODO we want to see an errored run result once this is completed
 		// https://app.shortcut.com/chainlinklabs/story/25397/remove-failearly-flag-from-eth-call-task
 		cltest.AssertPipelineRunsStays(t, jb.PipelineSpecID, db, 0)
-		ethMock.AssertExpectations(t)
 	})
 
 	t.Run("triggers if heads are skipped but later heads arrive within range", func(t *testing.T) {
@@ -317,8 +308,6 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 		assert.False(t, runs[0].HasErrors())
 		etxs[0].AwaitOrFail(t)
 		waitLastRunHeight(t, db, upkeep, 36)
-
-		ethMock.AssertExpectations(t)
 	})
 
 	t.Run("verify key specific max gas price is passed into estimator for EIP1559 and non-EIP1559 chains", func(t *testing.T) {
@@ -370,9 +359,6 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 			assert.False(t, runs[0].HasErrors())
 			assert.False(t, runs[0].HasFatalErrors())
 			waitLastRunHeight(t, db, upkeep, 20)
-
-			ethMock.AssertExpectations(t)
-			txm.AssertExpectations(t)
 		}
 
 		t.Run("EIP1559", func(t *testing.T) {
@@ -394,6 +380,7 @@ func Test_UpkeepExecuter_PerformsUpkeep_Happy(t *testing.T) {
 
 func Test_UpkeepExecuter_PerformsUpkeep_Error(t *testing.T) {
 	t.Parallel()
+
 	g := gomega.NewWithT(t)
 
 	db, _, ethMock, executer, registry, _, _, _, _, _, _, _ := setup(t, mockEstimator(t))
@@ -409,5 +396,4 @@ func Test_UpkeepExecuter_PerformsUpkeep_Error(t *testing.T) {
 
 	g.Eventually(wasCalled.Load).Should(gomega.Equal(true))
 	cltest.AssertCountStays(t, db, "eth_txes", 0)
-	ethMock.AssertExpectations(t)
 }

--- a/core/services/keeper/upkeep_executer_test.go
+++ b/core/services/keeper/upkeep_executer_test.go
@@ -16,8 +16,6 @@ import (
 	"go.uber.org/atomic"
 	"gopkg.in/guregu/null.v4"
 
-	"github.com/smartcontractkit/sqlx"
-
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/gas"
@@ -37,6 +35,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/utils"
 	bigmath "github.com/smartcontractkit/chainlink/core/utils/big_math"
+	"github.com/smartcontractkit/sqlx"
 )
 
 func newHead() evmtypes.Head {

--- a/core/services/keeper/upkeep_executer_test.go
+++ b/core/services/keeper/upkeep_executer_test.go
@@ -16,6 +16,8 @@ import (
 	"go.uber.org/atomic"
 	"gopkg.in/guregu/null.v4"
 
+	"github.com/smartcontractkit/sqlx"
+
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/gas"
@@ -35,7 +37,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/utils"
 	bigmath "github.com/smartcontractkit/chainlink/core/utils/big_math"
-	"github.com/smartcontractkit/sqlx"
 )
 
 func newHead() evmtypes.Head {

--- a/core/services/ocr/config_overrider_test.go
+++ b/core/services/ocr/config_overrider_test.go
@@ -42,10 +42,6 @@ func newConfigOverriderUni(t *testing.T, pollITicker utils.TickerBase, flagsCont
 
 	uni.contractAddress = contractAddress
 
-	t.Cleanup(func() {
-		flagsContract.AssertExpectations(t)
-	})
-
 	return uni
 }
 

--- a/core/services/ocr/config_overrider_test.go
+++ b/core/services/ocr/config_overrider_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
+
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
@@ -18,7 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/core/services/ocr"
 	"github.com/smartcontractkit/chainlink/core/utils"
-	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
 )
 
 type configOverriderUni struct {

--- a/core/services/ocr/config_overrider_test.go
+++ b/core/services/ocr/config_overrider_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/onsi/gomega"
-	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
@@ -19,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/core/services/ocr"
 	"github.com/smartcontractkit/chainlink/core/utils"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
 )
 
 type configOverriderUni struct {

--- a/core/services/ocr/contract_tracker_test.go
+++ b/core/services/ocr/contract_tracker_test.go
@@ -12,6 +12,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/libocr/gethwrappers/offchainaggregator"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
+
 	evmconfig "github.com/smartcontractkit/chainlink/core/chains/evm/config"
 	htmocks "github.com/smartcontractkit/chainlink/core/chains/evm/headtracker/mocks"
 	logmocks "github.com/smartcontractkit/chainlink/core/chains/evm/log/mocks"
@@ -26,8 +29,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/ocr"
 	ocrmocks "github.com/smartcontractkit/chainlink/core/services/ocr/mocks"
-	"github.com/smartcontractkit/libocr/gethwrappers/offchainaggregator"
-	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
 )
 
 func mustNewContract(t *testing.T, address gethCommon.Address) *offchain_aggregator_wrapper.OffchainAggregator {

--- a/core/services/ocr/contract_tracker_test.go
+++ b/core/services/ocr/contract_tracker_test.go
@@ -8,8 +8,6 @@ import (
 	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
-	"github.com/smartcontractkit/libocr/gethwrappers/offchainaggregator"
-	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -28,6 +26,8 @@ import (
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/ocr"
 	ocrmocks "github.com/smartcontractkit/chainlink/core/services/ocr/mocks"
+	"github.com/smartcontractkit/libocr/gethwrappers/offchainaggregator"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
 )
 
 func mustNewContract(t *testing.T, address gethCommon.Address) *offchain_aggregator_wrapper.OffchainAggregator {

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator_test.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/pkg/errors"
-	"github.com/smartcontractkit/ocr2vrf/dkg"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -26,6 +25,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/ocr2/plugins/ocr2vrf/coordinator/mocks"
+	"github.com/smartcontractkit/ocr2vrf/dkg"
 	ocr2vrftypes "github.com/smartcontractkit/ocr2vrf/types"
 )
 

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator_test.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator_test.go
@@ -1,7 +1,6 @@
 package coordinator
 
 import (
-	"context"
 	"crypto/rand"
 	"math/big"
 	"testing"
@@ -14,7 +13,6 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/ocr2vrf/dkg"
-	ocr2vrftypes "github.com/smartcontractkit/ocr2vrf/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -25,45 +23,49 @@ import (
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	dkg_wrapper "github.com/smartcontractkit/chainlink/core/internal/gethwrappers/ocr2vrf/generated/dkg"
 	vrf_wrapper "github.com/smartcontractkit/chainlink/core/internal/gethwrappers/ocr2vrf/generated/vrf_beacon_coordinator"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/ocr2/plugins/ocr2vrf/coordinator/mocks"
+	ocr2vrftypes "github.com/smartcontractkit/ocr2vrf/types"
 )
 
 func TestCoordinator_BeaconPeriod(t *testing.T) {
+	t.Parallel()
+
 	t.Run("valid output", func(t *testing.T) {
-		coordinatorContract := &mocks.VRFBeaconCoordinator{}
+		coordinatorContract := mocks.NewVRFBeaconCoordinator(t)
 		coordinatorContract.
 			On("IBeaconPeriodBlocks", mock.Anything).
 			Return(big.NewInt(10), nil)
-		defer coordinatorContract.AssertExpectations(t)
 		c := &coordinator{
 			coordinatorContract: coordinatorContract,
 		}
-		period, err := c.BeaconPeriod(context.TODO())
+		period, err := c.BeaconPeriod(testutils.Context(t))
 		assert.NoError(t, err)
 		assert.Equal(t, uint16(10), period)
 	})
 
 	t.Run("invalid output", func(t *testing.T) {
-		coordinatorContract := &mocks.VRFBeaconCoordinator{}
+		coordinatorContract := mocks.NewVRFBeaconCoordinator(t)
 		coordinatorContract.
 			On("IBeaconPeriodBlocks", mock.Anything).
 			Return(nil, errors.New("rpc error"))
-		defer coordinatorContract.AssertExpectations(t)
 		c := &coordinator{
 			coordinatorContract: coordinatorContract,
 		}
-		_, err := c.BeaconPeriod(context.TODO())
+		_, err := c.BeaconPeriod(testutils.Context(t))
 		assert.Error(t, err)
 	})
 }
 
 func TestCoordinator_DKGVRFCommittees(t *testing.T) {
+	t.Parallel()
+
 	t.Run("happy path", func(t *testing.T) {
 		// In this test the DKG and VRF committees have the same signers and
 		// transmitters. This may (?) be different in practice.
 
-		lp := &lp_mocks.LogPoller{}
+		lp := lp_mocks.NewLogPoller(t)
 		tp := newTopics()
 
 		coordinatorAddress := newAddress(t)
@@ -76,7 +78,6 @@ func TestCoordinator_DKGVRFCommittees(t *testing.T) {
 			Return(&logpoller.Log{
 				Data: hexutil.MustDecode("0x0000000000000000000000000000000000000000000000000000000000a6fca200010576e704b4a519484d6239ef17f1f5b4a82e330b0daf827ed4dc2789971b0000000000000000000000000000000000000000000000000000000000000032000000000000000000000000000000000000000000000000000000000000012000000000000000000000000000000000000000000000000000000000000001e0000000000000000000000000000000000000000000000000000000000000000100000000000000000000000000000000000000000000000000000000000002a0000000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000002e000000000000000000000000000000000000000000000000000000000000000050000000000000000000000000a8cbea12a06869d3ec432ab9682dab6c761d591000000000000000000000000f4f9db7bb1d16b7cdfb18ec68994c26964f5985300000000000000000000000022fb3f90c539457f00d8484438869135e604a65500000000000000000000000033cbcedccb11c9773ad78e214ba342e979255ab30000000000000000000000006ffaa96256fbc1012325cca88c79f725c33eed80000000000000000000000000000000000000000000000000000000000000000500000000000000000000000074103cf8b436465870b26aa9fa2f62ad62b22e3500000000000000000000000038a6cb196f805cc3041f6645a5a6cec27b64430d00000000000000000000000047d7095cfebf8285bdaa421bc8268d0db87d933c000000000000000000000000a8842be973800ff61d80d2d53fa62c3a685380eb0000000000000000000000003750e31321aee8c024751877070e8d5f704ce98700000000000000000000000000000000000000000000000000000000000000206f3b82406688b8ddb944c6f2e6d808f014c8fa8d568d639c25019568c715fbf000000000000000000000000000000000000000000000000000000000000004220880d88ee16f1080c8afa0251880c8afa025208090dfc04a288090dfc04a30033a05010101010142206c5ca6f74b532222ac927dd3de235d46a943e372c0563393a33b01dcfd3f371c4220855114d25c2ef5e85fffe4f20a365672d8f2dba3b2ec82333f494168a2039c0442200266e835634db00977cbc1caa4db10e1676c1a4c0fcbc6ba7f09300f0d1831824220980cd91f7a73f20f4b0d51d00cd4e00373dc2beafbb299ca3c609757ab98c8304220eb6d36e2af8922085ff510bbe1eb8932a0e3295ca9f047fef25d90e69c52948f4a34313244334b6f6f574463364b7232644542684b59326b336e685057694676544565325331703978544532544b74344d7572716f684a34313244334b6f6f574b436e4367724b637743324a3577576a626e355435335068646b6b6f57454e534a39546537544b7836366f4a4a34313244334b6f6f575239616f675948786b357a38636b624c4c56346e426f7a777a747871664a7050586671336d4a7232796452474a34313244334b6f6f5744695444635565675637776b313133473366476a69616259756f54436f3157726f6f53656741343263556f544a34313244334b6f6f574e64687072586b5472665370354d5071736270467a70364167394a53787358694341434442676454424c656652820300050e416c74424e2d3132382047e282810e86e8cf899ae9a1b43e023bbe8825b103659bb8d6d4e54f6a3cfae7b106069c216a812d7616e47f0bd38fa4863f48fbcda6a38af4c58d2233dfa7cf79620947042d09f923e0a2f7a2270391e8b058d8bdb8f79fe082b7b627f025651c7290382fdff97c3181d15d162c146ce87ff752499d2acc2b26011439a12e29571a6f1e1defb1751c3be4258c493984fd9f0f6b4a26c539870b5f15bfed3d8ffac92499eb62dbd2beb7c1524275a8019022f6ce6a7e86c9e65e3099452a2b96fc2432b127a112970e1adf615f823b2b2180754c2f0ee01f1b389e56df55ca09702cd0401b66ff71779d2dd67222503a85ab921b28c329cc1832800b192d0b0247c0776e1b9653dc00df48daa6364287c84c0382f5165e7269fef06d10bc67c1bba252305d1af0dc7bb0fe92558eb4c5f38c23163dee1cfb34a72020669dbdfe337c16f3307472616e736c61746f722066726f6d20416c74424e2d3132382047e2828120746f20416c74424e2d3132382047e282825880ade2046080c8afa0256880c8afa0257080ade204788094ebdc0382019e010a205034214e0bd4373f38e162cf9fc9133e2f3b71441faa4c3d1ac01c1877f1cd2712200e03e975b996f911abba2b79d2596c2150bc94510963c40a1137a03df6edacdb1a107dee1cdb894163813bb3da604c9c133c1a10bb33302eeafbd55d352e35dcc5d2b3311a10d2c658b6b93d74a02d467849b6fe75251a10fea5308cc1fea69e7246eafe7ca8a3a51a1048efe1ad873b6f025ac0243bdef715f8000000000000000000000000000000000000000000000000000000000000"),
 			}, nil)
-		defer lp.AssertExpectations(t)
 
 		expectedDKGVRF := ocr2vrftypes.OCRCommittee{
 			Signers: []common.Address{
@@ -101,7 +102,7 @@ func TestCoordinator_DKGVRFCommittees(t *testing.T) {
 			coordinatorAddress: coordinatorAddress,
 			dkgAddress:         dkgAddress,
 		}
-		actualDKG, actualVRF, err := c.DKGVRFCommittees(context.TODO())
+		actualDKG, actualVRF, err := c.DKGVRFCommittees(testutils.Context(t))
 		assert.NoError(t, err)
 		assert.ElementsMatch(t, expectedDKGVRF.Signers, actualDKG.Signers)
 		assert.ElementsMatch(t, expectedDKGVRF.Transmitters, actualDKG.Transmitters)
@@ -110,13 +111,12 @@ func TestCoordinator_DKGVRFCommittees(t *testing.T) {
 	})
 
 	t.Run("vrf log poll fails", func(t *testing.T) {
-		lp := &lp_mocks.LogPoller{}
+		lp := lp_mocks.NewLogPoller(t)
 		tp := newTopics()
 
 		coordinatorAddress := newAddress(t)
 		lp.On("LatestLogByEventSigWithConfs", tp.configSetTopic, coordinatorAddress, 1).
 			Return(nil, errors.New("rpc error"))
-		defer lp.AssertExpectations(t)
 
 		c := &coordinator{
 			lp:                 lp,
@@ -124,12 +124,12 @@ func TestCoordinator_DKGVRFCommittees(t *testing.T) {
 			coordinatorAddress: coordinatorAddress,
 		}
 
-		_, _, err := c.DKGVRFCommittees(context.TODO())
+		_, _, err := c.DKGVRFCommittees(testutils.Context(t))
 		assert.Error(t, err)
 	})
 
 	t.Run("dkg log poll fails", func(t *testing.T) {
-		lp := &lp_mocks.LogPoller{}
+		lp := lp_mocks.NewLogPoller(t)
 		tp := newTopics()
 		coordinatorAddress := newAddress(t)
 		dkgAddress := newAddress(t)
@@ -139,7 +139,6 @@ func TestCoordinator_DKGVRFCommittees(t *testing.T) {
 			}, nil)
 		lp.On("LatestLogByEventSigWithConfs", tp.configSetTopic, dkgAddress, 1).
 			Return(nil, errors.New("rpc error"))
-		defer lp.AssertExpectations(t)
 
 		c := &coordinator{
 			lp:                 lp,
@@ -147,39 +146,39 @@ func TestCoordinator_DKGVRFCommittees(t *testing.T) {
 			coordinatorAddress: coordinatorAddress,
 			dkgAddress:         dkgAddress,
 		}
-		_, _, err := c.DKGVRFCommittees(context.TODO())
+		_, _, err := c.DKGVRFCommittees(testutils.Context(t))
 		assert.Error(t, err)
 	})
 }
 
 func TestCoordinator_ProvingKeyHash(t *testing.T) {
+	t.Parallel()
+
 	t.Run("valid output", func(t *testing.T) {
 		h := crypto.Keccak256Hash([]byte("hello world"))
 		var expected [32]byte
 		copy(expected[:], h.Bytes())
-		coordinatorContract := &mocks.VRFBeaconCoordinator{}
+		coordinatorContract := mocks.NewVRFBeaconCoordinator(t)
 		coordinatorContract.
 			On("SProvingKeyHash", mock.Anything).
 			Return(expected, nil)
-		defer coordinatorContract.AssertExpectations(t)
 		c := &coordinator{
 			coordinatorContract: coordinatorContract,
 		}
-		provingKeyHash, err := c.ProvingKeyHash(context.TODO())
+		provingKeyHash, err := c.ProvingKeyHash(testutils.Context(t))
 		assert.NoError(t, err)
 		assert.ElementsMatch(t, expected[:], provingKeyHash[:])
 	})
 
 	t.Run("invalid output", func(t *testing.T) {
-		coordinatorContract := &mocks.VRFBeaconCoordinator{}
+		coordinatorContract := mocks.NewVRFBeaconCoordinator(t)
 		coordinatorContract.
 			On("SProvingKeyHash", mock.Anything).
 			Return([32]byte{}, errors.New("rpc error"))
-		defer coordinatorContract.AssertExpectations(t)
 		c := &coordinator{
 			coordinatorContract: coordinatorContract,
 		}
-		_, err := c.ProvingKeyHash(context.TODO())
+		_, err := c.ProvingKeyHash(testutils.Context(t))
 		assert.Error(t, err)
 	})
 }
@@ -195,17 +194,16 @@ func TestCoordinator_ReportBlocks(t *testing.T) {
 		require.NoError(t, err)
 
 		latestHeadNumber := int64(200)
-		evmClient := &evm_mocks.Client{}
+		evmClient := evm_mocks.NewClient(t)
 		evmClient.On("HeadByNumber", mock.Anything, mock.Anything).
 			Return(&evmtypes.Head{
 				Number: latestHeadNumber,
 			}, nil)
-		defer evmClient.AssertExpectations(t)
 
 		tp := newTopics()
 
 		lookbackBlocks := int64(50)
-		lp := &lp_mocks.LogPoller{}
+		lp := lp_mocks.NewLogPoller(t)
 		lp.On(
 			"LogsWithSigs",
 			latestHeadNumber-lookbackBlocks,
@@ -223,7 +221,6 @@ func TestCoordinator_ReportBlocks(t *testing.T) {
 			newRandomnessRequestedLog(t, 3, 195, 192),
 			newRandomnessRequestedLog(t, 3, 195, 193),
 		}, nil)
-		defer lp.AssertExpectations(t)
 
 		lp.On("GetBlocks", []uint64{195}, mock.Anything).
 			Return([]logpoller.LogPollerBlock{
@@ -244,7 +241,7 @@ func TestCoordinator_ReportBlocks(t *testing.T) {
 		}
 
 		blocks, callbacks, err := c.ReportBlocks(
-			context.TODO(),
+			testutils.Context(t),
 			0, // slotInterval: unused
 			map[uint32]struct{}{3: {}},
 			time.Duration(0),
@@ -266,17 +263,16 @@ func TestCoordinator_ReportBlocks(t *testing.T) {
 		require.NoError(t, err)
 
 		latestHeadNumber := int64(200)
-		evmClient := &evm_mocks.Client{}
+		evmClient := evm_mocks.NewClient(t)
 		evmClient.On("HeadByNumber", mock.Anything, mock.Anything).
 			Return(&evmtypes.Head{
 				Number: latestHeadNumber,
 			}, nil)
-		defer evmClient.AssertExpectations(t)
 
 		tp := newTopics()
 
 		lookbackBlocks := int64(50)
-		lp := &lp_mocks.LogPoller{}
+		lp := lp_mocks.NewLogPoller(t)
 		lp.On(
 			"LogsWithSigs",
 			latestHeadNumber-lookbackBlocks,
@@ -294,7 +290,6 @@ func TestCoordinator_ReportBlocks(t *testing.T) {
 			newRandomnessFulfillmentRequestedLog(t, 3, 195, 192, 2),
 			newRandomnessFulfillmentRequestedLog(t, 3, 195, 193, 3),
 		}, nil)
-		defer lp.AssertExpectations(t)
 
 		lp.On("GetBlocks", []uint64{195}, mock.Anything).
 			Return([]logpoller.LogPollerBlock{
@@ -315,7 +310,7 @@ func TestCoordinator_ReportBlocks(t *testing.T) {
 		}
 
 		blocks, callbacks, err := c.ReportBlocks(
-			context.TODO(),
+			testutils.Context(t),
 			0, // slotInterval: unused
 			map[uint32]struct{}{3: {}},
 			time.Duration(0),
@@ -337,17 +332,16 @@ func TestCoordinator_ReportBlocks(t *testing.T) {
 		require.NoError(t, err)
 
 		latestHeadNumber := int64(200)
-		evmClient := &evm_mocks.Client{}
+		evmClient := evm_mocks.NewClient(t)
 		evmClient.On("HeadByNumber", mock.Anything, mock.Anything).
 			Return(&evmtypes.Head{
 				Number: latestHeadNumber,
 			}, nil)
-		defer evmClient.AssertExpectations(t)
 
 		tp := newTopics()
 
 		lookbackBlocks := int64(50)
-		lp := &lp_mocks.LogPoller{}
+		lp := lp_mocks.NewLogPoller(t)
 		lp.On(
 			"LogsWithSigs",
 			latestHeadNumber-lookbackBlocks,
@@ -371,7 +365,6 @@ func TestCoordinator_ReportBlocks(t *testing.T) {
 				},
 			}),
 		}, nil)
-		defer lp.AssertExpectations(t)
 
 		var r []uint64
 		lp.On("GetBlocks", r, mock.Anything).
@@ -388,7 +381,7 @@ func TestCoordinator_ReportBlocks(t *testing.T) {
 		}
 
 		blocks, callbacks, err := c.ReportBlocks(
-			context.TODO(),
+			testutils.Context(t),
 			0, // slotInterval: unused
 			map[uint32]struct{}{3: {}},
 			time.Duration(0),
@@ -410,17 +403,16 @@ func TestCoordinator_ReportBlocks(t *testing.T) {
 		require.NoError(t, err)
 
 		latestHeadNumber := int64(200)
-		evmClient := &evm_mocks.Client{}
+		evmClient := evm_mocks.NewClient(t)
 		evmClient.On("HeadByNumber", mock.Anything, mock.Anything).
 			Return(&evmtypes.Head{
 				Number: latestHeadNumber,
 			}, nil)
-		defer evmClient.AssertExpectations(t)
 
 		tp := newTopics()
 
 		lookbackBlocks := int64(50)
-		lp := &lp_mocks.LogPoller{}
+		lp := lp_mocks.NewLogPoller(t)
 		lp.On(
 			"LogsWithSigs",
 			latestHeadNumber-lookbackBlocks,
@@ -447,7 +439,6 @@ func TestCoordinator_ReportBlocks(t *testing.T) {
 				},
 			}),
 		}, nil)
-		defer lp.AssertExpectations(t)
 
 		var r []uint64
 		lp.On("GetBlocks", r, mock.Anything).
@@ -464,7 +455,7 @@ func TestCoordinator_ReportBlocks(t *testing.T) {
 		}
 
 		blocks, callbacks, err := c.ReportBlocks(
-			context.TODO(),
+			testutils.Context(t),
 			0, // slotInterval: unused
 			map[uint32]struct{}{3: {}},
 			time.Duration(0),
@@ -479,10 +470,12 @@ func TestCoordinator_ReportBlocks(t *testing.T) {
 
 func TestCoordinator_ReportWillBeTransmitted(t *testing.T) {
 	c := &coordinator{}
-	assert.NoError(t, c.ReportWillBeTransmitted(context.TODO(), ocr2vrftypes.AbstractReport{}))
+	assert.NoError(t, c.ReportWillBeTransmitted(testutils.Context(t), ocr2vrftypes.AbstractReport{}))
 }
 
 func TestCoordinator_MarshalUnmarshal(t *testing.T) {
+	t.Parallel()
+
 	coordinatorAddress := newAddress(t)
 	vrfBeaconCoordinator, err := vrf_wrapper.NewVRFBeaconCoordinator(coordinatorAddress, nil)
 	require.NoError(t, err)
@@ -541,7 +534,7 @@ func TestCoordinator_ReportIsOnchain(t *testing.T) {
 		round := uint8(3)
 		epochAndRound := toEpochAndRoundUint40(epoch, round)
 		enrTopic := common.BytesToHash(common.LeftPadBytes(epochAndRound.Bytes(), 32))
-		lp := &lp_mocks.LogPoller{}
+		lp := lp_mocks.NewLogPoller(t)
 		lp.On("IndexedLogs", tp.newTransmissionTopic, coordinatorAddress, 2, []common.Hash{
 			enrTopic,
 		}, 1, mock.Anything).Return([]logpoller.Log{
@@ -557,7 +550,7 @@ func TestCoordinator_ReportIsOnchain(t *testing.T) {
 			topics:             tp,
 		}
 
-		present, err := c.ReportIsOnchain(context.TODO(), epoch, round)
+		present, err := c.ReportIsOnchain(testutils.Context(t), epoch, round)
 		assert.NoError(t, err)
 		assert.True(t, present)
 	})
@@ -570,7 +563,7 @@ func TestCoordinator_ReportIsOnchain(t *testing.T) {
 		round := uint8(3)
 		epochAndRound := toEpochAndRoundUint40(epoch, round)
 		enrTopic := common.BytesToHash(common.LeftPadBytes(epochAndRound.Bytes(), 32))
-		lp := &lp_mocks.LogPoller{}
+		lp := lp_mocks.NewLogPoller(t)
 		lp.On("IndexedLogs", tp.newTransmissionTopic, coordinatorAddress, 2, []common.Hash{
 			enrTopic,
 		}, 1, mock.Anything).Return([]logpoller.Log{}, nil)
@@ -582,7 +575,7 @@ func TestCoordinator_ReportIsOnchain(t *testing.T) {
 			topics:             tp,
 		}
 
-		present, err := c.ReportIsOnchain(context.TODO(), epoch, round)
+		present, err := c.ReportIsOnchain(testutils.Context(t), epoch, round)
 		assert.NoError(t, err)
 		assert.False(t, present)
 	})
@@ -590,68 +583,68 @@ func TestCoordinator_ReportIsOnchain(t *testing.T) {
 }
 
 func TestCoordinator_ConfirmationDelays(t *testing.T) {
+	t.Parallel()
+
 	t.Run("valid output", func(t *testing.T) {
 		expected := [8]uint32{1, 2, 3, 4, 5, 6, 7, 8}
 		ret := [8]*big.Int{}
 		for i, delay := range expected {
 			ret[i] = big.NewInt(int64(delay))
 		}
-		coordinatorContract := &mocks.VRFBeaconCoordinator{}
+		coordinatorContract := mocks.NewVRFBeaconCoordinator(t)
 		coordinatorContract.
 			On("GetConfirmationDelays", mock.Anything).
 			Return(ret, nil)
-		defer coordinatorContract.AssertExpectations(t)
 		c := &coordinator{
 			coordinatorContract: coordinatorContract,
 		}
-		confDelays, err := c.ConfirmationDelays(context.TODO())
+		confDelays, err := c.ConfirmationDelays(testutils.Context(t))
 		assert.NoError(t, err)
 		assert.Equal(t, expected[:], confDelays[:])
 	})
 
 	t.Run("invalid output", func(t *testing.T) {
-		coordinatorContract := &mocks.VRFBeaconCoordinator{}
+		coordinatorContract := mocks.NewVRFBeaconCoordinator(t)
 		coordinatorContract.
 			On("GetConfirmationDelays", mock.Anything).
 			Return([8]*big.Int{}, errors.New("rpc error"))
-		defer coordinatorContract.AssertExpectations(t)
 		c := &coordinator{
 			coordinatorContract: coordinatorContract,
 		}
-		_, err := c.ConfirmationDelays(context.TODO())
+		_, err := c.ConfirmationDelays(testutils.Context(t))
 		assert.Error(t, err)
 	})
 }
 
 func TestCoordinator_KeyID(t *testing.T) {
+	t.Parallel()
+
 	t.Run("valid output", func(t *testing.T) {
 		var keyIDBytes [32]byte
 		keyIDBytes[0] = 1
 		expected := dkg.KeyID(keyIDBytes)
-		coordinatorContract := &mocks.VRFBeaconCoordinator{}
+		coordinatorContract := mocks.NewVRFBeaconCoordinator(t)
 		coordinatorContract.
 			On("SKeyID", mock.Anything).
 			Return(keyIDBytes, nil)
-		defer coordinatorContract.AssertExpectations(t)
 		c := &coordinator{
 			coordinatorContract: coordinatorContract,
 		}
-		keyID, err := c.KeyID(context.TODO())
+		keyID, err := c.KeyID(testutils.Context(t))
 		assert.NoError(t, err)
 		assert.Equal(t, expected[:], keyID[:])
 	})
 
 	t.Run("invalid output", func(t *testing.T) {
 		var emptyBytes [32]byte
-		coordinatorContract := &mocks.VRFBeaconCoordinator{}
+		coordinatorContract := mocks.NewVRFBeaconCoordinator(t)
 		coordinatorContract.
 			On("SKeyID", mock.Anything).
 			Return(emptyBytes, errors.New("rpc error"))
-		defer coordinatorContract.AssertExpectations(t)
 		c := &coordinator{
 			coordinatorContract: coordinatorContract,
 		}
-		_, err := c.KeyID(context.TODO())
+		_, err := c.KeyID(testutils.Context(t))
 		assert.Error(t, err)
 	})
 }

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator_test.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator_test.go
@@ -16,6 +16,9 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/ocr2vrf/dkg"
+	ocr2vrftypes "github.com/smartcontractkit/ocr2vrf/types"
+
 	"github.com/smartcontractkit/chainlink/core/chains/evm/logpoller"
 	lp_mocks "github.com/smartcontractkit/chainlink/core/chains/evm/logpoller/mocks"
 	evm_mocks "github.com/smartcontractkit/chainlink/core/chains/evm/mocks"
@@ -25,8 +28,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/ocr2/plugins/ocr2vrf/coordinator/mocks"
-	"github.com/smartcontractkit/ocr2vrf/dkg"
-	ocr2vrftypes "github.com/smartcontractkit/ocr2vrf/types"
 )
 
 func TestCoordinator_BeaconPeriod(t *testing.T) {

--- a/core/services/relay/evm/request_round_tracker_test.go
+++ b/core/services/relay/evm/request_round_tracker_test.go
@@ -7,6 +7,8 @@ import (
 	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
+	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -25,8 +27,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/ocr2/testhelpers"
 	"github.com/smartcontractkit/chainlink/core/services/relay/evm"
 	"github.com/smartcontractkit/chainlink/core/services/relay/evm/mocks"
-	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
-	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2/types"
 )
 
 func mustNewContract(t *testing.T, address gethCommon.Address) *offchain_aggregator_wrapper.OffchainAggregator {

--- a/core/services/relay/evm/request_round_tracker_test.go
+++ b/core/services/relay/evm/request_round_tracker_test.go
@@ -8,7 +8,6 @@ import (
 
 	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -27,6 +26,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/ocr2/testhelpers"
 	"github.com/smartcontractkit/chainlink/core/services/relay/evm"
 	"github.com/smartcontractkit/chainlink/core/services/relay/evm/mocks"
+	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2/types"
 )
 

--- a/core/services/relay/evm/request_round_tracker_test.go
+++ b/core/services/relay/evm/request_round_tracker_test.go
@@ -4,10 +4,9 @@ import (
 	"context"
 	"testing"
 
-	"github.com/pkg/errors"
-
 	gethCommon "github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"


### PR DESCRIPTION
Closes: https://app.shortcut.com/chainlinklabs/story/44670/spike-mockery-usage-overhaul

Terra: https://github.com/smartcontractkit/chainlink-terra/pull/304
Solana: https://github.com/smartcontractkit/chainlink-solana/pull/383

The only remaining piece is `cltest.EventuallyExpectationsMet()` which is used by several integration tests and I could not easily replace this function with `Awaiter` or similar mechanisms. I have too little context on those tests to make it right.