### PR TITLE
tools/bin: restore -p 3 to CI core tests

### DIFF
--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -5,7 +5,7 @@ set +e
 echo "Failed tests and panics: ---------------------"
 echo ""
 GO_LDFLAGS=$(bash tools/bin/ldflags)
-go test -ldflags "$GO_LDFLAGS" -tags integration -coverprofile=coverage.txt -covermode=atomic ./... | tee ./output.txt | grep --line-buffered --line-number -e "\-\-\- FAIL" -e "FAIL\s"
+go test -ldflags "$GO_LDFLAGS" -tags integration -p 3 -coverprofile=coverage.txt -covermode=atomic ./... | tee ./output.txt | grep --line-buffered --line-number -e "\-\-\- FAIL" -e "FAIL\s"
 EXITCODE=${PIPESTATUS[0]}
 echo ""
 echo "----------------------------------------------"


### PR DESCRIPTION
Reverting one piece of #6856 in an attempt to resolve:
> --- FAIL: TestTxm_Integration (30.03s)
> FAIL	github.com/smartcontractkit/chainlink/core/chains/solana/soltxm	127.247s