### PR TITLE
Refactor forwarders naming

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -1085,9 +1085,9 @@ func NewApp(client *Client) *cli.App {
 					Action: client.ListForwarders,
 				},
 				{
-					Name:   "create",
-					Usage:  "Create a new forwarder",
-					Action: client.CreateForwarder,
+					Name:   "track",
+					Usage:  "Track a new forwarder",
+					Action: client.TrackForwarder,
 					Flags: []cli.Flag{
 						cli.Int64Flag{
 							Name:  "evmChainID, c",

--- a/core/cmd/forwarders_commands.go
+++ b/core/cmd/forwarders_commands.go
@@ -85,7 +85,7 @@ func (cli *Client) DeleteForwarder(c *cli.Context) (err error) {
 }
 
 // AddForwarder adds forwarder address to node db.
-func (cli *Client) CreateForwarder(c *cli.Context) (err error) {
+func (cli *Client) TrackForwarder(c *cli.Context) (err error) {
 	addressHex := c.String("address")
 	chainIDStr := c.String("evmChainID")
 
@@ -104,7 +104,7 @@ func (cli *Client) CreateForwarder(c *cli.Context) (err error) {
 		}
 	}
 
-	request, err := json.Marshal(web.CreateEVMForwarderRequest{
+	request, err := json.Marshal(web.TrackEVMForwarderRequest{
 		EVMChainID: (*utils.Big)(chainID),
 		Address:    address,
 	})
@@ -112,7 +112,7 @@ func (cli *Client) CreateForwarder(c *cli.Context) (err error) {
 		return cli.errorOut(err)
 	}
 
-	resp, err := cli.HTTP.Post("/v2/nodes/evm/forwarders", bytes.NewReader(request))
+	resp, err := cli.HTTP.Post("/v2/nodes/evm/forwarders/track", bytes.NewReader(request))
 	if err != nil {
 		return cli.errorOut(err)
 	}

--- a/core/cmd/forwarders_commands.go
+++ b/core/cmd/forwarders_commands.go
@@ -84,7 +84,7 @@ func (cli *Client) DeleteForwarder(c *cli.Context) (err error) {
 	return nil
 }
 
-// AddForwarder adds forwarder address to node db.
+// TrackForwarder tracks forwarder address in db.
 func (cli *Client) TrackForwarder(c *cli.Context) (err error) {
 	addressHex := c.String("address")
 	chainIDStr := c.String("evmChainID")

--- a/core/cmd/forwarders_commands_test.go
+++ b/core/cmd/forwarders_commands_test.go
@@ -63,7 +63,7 @@ func TestEVMForwarderPresenter_RenderTable(t *testing.T) {
 	assert.Contains(t, output, createdAt.Format(time.RFC3339))
 }
 
-func TestClient_CreateEVMForwarder(t *testing.T) {
+func TestClient_TrackEVMForwarder(t *testing.T) {
 	t.Parallel()
 
 	app := startNewApplication(t, withConfigSet(func(c *configtest.TestGeneralConfig) {
@@ -83,7 +83,7 @@ func TestClient_CreateEVMForwarder(t *testing.T) {
 	set.Bool("bypass-version-check", true, "")
 	set.String("address", "0x5431F5F973781809D18643b87B44921b11355d81", "")
 	set.Int("evmChainID", int(chain.ID.ToInt().Int64()), "")
-	err = client.CreateForwarder(cli.NewContext(nil, set, nil))
+	err = client.TrackForwarder(cli.NewContext(nil, set, nil))
 	require.NoError(t, err)
 	require.Len(t, r.Renders, 1)
 	createOutput, ok := r.Renders[0].(*cmd.EVMForwarderPresenter)
@@ -108,7 +108,7 @@ func TestClient_CreateEVMForwarder(t *testing.T) {
 	require.Equal(t, 0, len(fwds))
 }
 
-func TestClient_CreateEVMForwarder_BadAddress(t *testing.T) {
+func TestClient_TrackEVMForwarder_BadAddress(t *testing.T) {
 	t.Parallel()
 
 	app := startNewApplication(t, withConfigSet(func(c *configtest.TestGeneralConfig) {
@@ -131,7 +131,7 @@ func TestClient_CreateEVMForwarder_BadAddress(t *testing.T) {
 	set.Bool("bypass-version-check", true, "")
 	set.String("address", "0xWrongFormatAddress", "")
 	set.Int("evmChainID", int(chain.ID.ToInt().Int64()), "")
-	err = client.CreateForwarder(cli.NewContext(nil, set, nil))
+	err = client.TrackForwarder(cli.NewContext(nil, set, nil))
 	require.Contains(t, err.Error(), "could not decode address: invalid hex string")
 }
 

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -770,7 +770,7 @@ func ExampleRun_forwarders() {
 	//
 	// COMMANDS:
 	//    list    List all stored forwarders addresses
-	//    create  Create a new forwarder
+	//    track   Track a new forwarder
 	//    delete  Delete a forwarder address
 	//
 	// OPTIONS:

--- a/core/web/auth/auth_test.go
+++ b/core/web/auth/auth_test.go
@@ -303,7 +303,7 @@ var routesRolesMap = [...]routeRules{
 	{"DELETE", "/v2/nodes/solana/MOCK", false, false, true},
 	{"DELETE", "/v2/nodes/terra/MOCK", false, false, true},
 	{"GET", "/v2/nodes/evm/forwarders", true, true, true},
-	{"POST", "/v2/nodes/evm/forwarders", false, false, true},
+	{"POST", "/v2/nodes/evm/forwarders/track", false, false, true},
 	{"DELETE", "/v2/nodes/evm/forwarders/MOCK", false, false, true},
 	{"GET", "/v2/build_info", true, true, true},
 	{"GET", "/v2/ping", true, true, true},

--- a/core/web/evm_forwarders_controller.go
+++ b/core/web/evm_forwarders_controller.go
@@ -36,15 +36,15 @@ func (cc *EVMForwardersController) Index(c *gin.Context, size, page, offset int)
 	paginatedResponse(c, "forwarder", size, page, resources, count, err)
 }
 
-// CreateEVMForwarderRequest is a JSONAPI request for creating an EVM forwarder.
-type CreateEVMForwarderRequest struct {
+// TrackEVMForwarderRequest is a JSONAPI request for creating an EVM forwarder.
+type TrackEVMForwarderRequest struct {
 	EVMChainID *utils.Big     `json:"chainID"`
 	Address    common.Address `json:"address"`
 }
 
-// Create adds a new EVM forwarder.
-func (cc *EVMForwardersController) Create(c *gin.Context) {
-	request := &CreateEVMForwarderRequest{}
+// Track adds a new EVM forwarder.
+func (cc *EVMForwardersController) Track(c *gin.Context) {
+	request := &TrackEVMForwarderRequest{}
 
 	if err := c.ShouldBindJSON(&request); err != nil {
 		jsonAPIError(c, http.StatusUnprocessableEntity, err)

--- a/core/web/evm_forwarders_controller_test.go
+++ b/core/web/evm_forwarders_controller_test.go
@@ -37,7 +37,7 @@ func setupEVMForwardersControllerTest(t *testing.T) *TestEVMForwardersController
 	}
 }
 
-func Test_EVMForwardersController_Create(t *testing.T) {
+func Test_EVMForwardersController_Track(t *testing.T) {
 	t.Parallel()
 
 	controller := setupEVMForwardersControllerTest(t)
@@ -50,14 +50,14 @@ func Test_EVMForwardersController_Create(t *testing.T) {
 
 	// Build EVMForwarderRequest
 	address := common.HexToAddress("0x5431F5F973781809D18643b87B44921b11355d81")
-	body, err := json.Marshal(web.CreateEVMForwarderRequest{
+	body, err := json.Marshal(web.TrackEVMForwarderRequest{
 		EVMChainID: &dbChain.ID,
 		Address:    address,
 	},
 	)
 	require.NoError(t, err)
 
-	resp, cleanup := controller.client.Post("/v2/nodes/evm/forwarders", bytes.NewReader(body))
+	resp, cleanup := controller.client.Post("/v2/nodes/evm/forwarders/track", bytes.NewReader(body))
 	t.Cleanup(cleanup)
 	require.Equal(t, http.StatusCreated, resp.StatusCode)
 
@@ -80,7 +80,7 @@ func Test_EVMForwardersController_Index(t *testing.T) {
 	require.NoError(t, err)
 
 	// Build EVMForwarderRequest
-	fwdrs := []web.CreateEVMForwarderRequest{
+	fwdrs := []web.TrackEVMForwarderRequest{
 		{
 			EVMChainID: &dbChain.ID,
 			Address:    common.HexToAddress("0x5431F5F973781809D18643b87B44921b11355d81"),
@@ -92,14 +92,14 @@ func Test_EVMForwardersController_Index(t *testing.T) {
 	}
 	for _, fwdr := range fwdrs {
 
-		body, err := json.Marshal(web.CreateEVMForwarderRequest{
+		body, err := json.Marshal(web.TrackEVMForwarderRequest{
 			EVMChainID: &dbChain.ID,
 			Address:    fwdr.Address,
 		},
 		)
 		require.NoError(t, err)
 
-		resp, cleanup := controller.client.Post("/v2/nodes/evm/forwarders", bytes.NewReader(body))
+		resp, cleanup := controller.client.Post("/v2/nodes/evm/forwarders/track", bytes.NewReader(body))
 		t.Cleanup(cleanup)
 		require.Equal(t, http.StatusCreated, resp.StatusCode)
 	}

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -404,7 +404,7 @@ func v2Routes(app chainlink.Application, r *gin.RouterGroup) {
 
 		efc := EVMForwardersController{app}
 		authv2.GET("/nodes/evm/forwarders", paginatedRequest(efc.Index))
-		authv2.POST("/nodes/evm/forwarders", auth.RequiresEditRole(efc.Create))
+		authv2.POST("/nodes/evm/forwarders/track", auth.RequiresEditRole(efc.Track))
 		authv2.DELETE("/nodes/evm/forwarders/:fwdID", auth.RequiresEditRole(efc.Delete))
 
 		build_info := BuildInfoController{app}

--- a/operator_ui/src/screens/Job/__snapshots__/TabDefinition.test.tsx.snap
+++ b/operator_ui/src/screens/Job/__snapshots__/TabDefinition.test.tsx.snap
@@ -6,6 +6,7 @@ schemaVersion = 1
 name = \\"direct request job\\"
 externalJobID = \\"00000000-0000-0000-0000-0000000000001\\"
 gasLimit = 1_000
+forwardingAllowed = false
 maxTaskDuration = \\"10s\\"
 contractAddress = \\"0x0000000000000000000000000000000000000000\\"
 evmChainID = \\"42\\"

--- a/operator_ui/src/screens/Job/generateJobDefinition.test.ts
+++ b/operator_ui/src/screens/Job/generateJobDefinition.test.ts
@@ -104,6 +104,7 @@ observationSource = """
       externalJobID: '00000000-0000-0000-0000-0000000000001',
       maxTaskDuration: '10s',
       gasLimit: 1000,
+      forwardingAllowed: false,
       spec: {
         __typename: 'KeeperSpec',
         contractAddress: '0x0000000000000000000000000000000000000000',
@@ -120,6 +121,7 @@ schemaVersion = 1
 name = "keeper job"
 externalJobID = "00000000-0000-0000-0000-0000000000001"
 gasLimit = 1_000
+forwardingAllowed = false
 contractAddress = "0x0000000000000000000000000000000000000000"
 evmChainID = "42"
 fromAddress = "0xa8037A20989AFcBC51798de9762b351D63ff462e"

--- a/operator_ui/src/screens/Job/generateJobDefinition.ts
+++ b/operator_ui/src/screens/Job/generateJobDefinition.ts
@@ -15,6 +15,7 @@ const extractJobFields = (job: JobPayload_Fields, ...otherKeys: string[]) => {
     'name',
     'externalJobID',
     'gasLimit',
+    'forwardingAllowed',
     ...otherKeys,
   )
 }

--- a/operator_ui/support/factories/gql/fetchJob.ts
+++ b/operator_ui/support/factories/gql/fetchJob.ts
@@ -15,6 +15,7 @@ export function buildJob(
     externalJobID: '00000000-0000-0000-0000-0000000000001',
     maxTaskDuration: '10s',
     gasLimit: 1000,
+    forwardingAllowed: false,
     spec: {
       __typename: 'DirectRequestSpec',
       contractAddress: '0x0000000000000000000000000000000000000000',


### PR DESCRIPTION
We might potentially need to have a separate create that deploys the forwarder on chain. Renaming now ahead of release makes it easier to implement that in the future.