### PR TITLE
core/chains/evm/client: support abitrum nitro 'max fee per gas less than block base fee'

### DIFF
--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -101,9 +101,11 @@ var besu = ClientErrors{
 }
 
 // Erigon
-// See: https://github.com/ledgerwatch/erigon/blob/devel/core/tx_pool.go
-//      https://github.com/ledgerwatch/erigon/blob/devel/core/error.go
-//      https://github.com/ledgerwatch/erigon/blob/devel/core/vm/errors.go
+// See:
+//   - https://github.com/ledgerwatch/erigon/blob/devel/core/tx_pool.go
+//   - https://github.com/ledgerwatch/erigon/blob/devel/core/error.go
+//   - https://github.com/ledgerwatch/erigon/blob/devel/core/vm/errors.go
+//
 // Note: some error definitions are unused, many errors are created inline.
 var erigonFatal = regexp.MustCompile(`(: |^)(exceeds block gas limit|invalid sender|negative value|oversized data|gas uint64 overflow|intrinsic gas too low|nonce too high)$`)
 var erigon = ClientErrors{
@@ -125,7 +127,7 @@ var arbitrum = ClientErrors{
 	// https://app.shortcut.com/chainlinklabs/story/16801/add-full-support-for-incorrect-nonce-on-arbitrum
 	NonceTooLow: regexp.MustCompile(`(: |^)invalid transaction nonce$|(: |^)nonce too low(:|$)`),
 	// TODO: Is it terminally or replacement?
-	TerminallyUnderpriced: regexp.MustCompile(`(: |^)gas price too low$`),
+	TerminallyUnderpriced: regexp.MustCompile(`(: |^)gas price too low$|(: |^)max fee per gas less than block base fee(:|$)`),
 	InsufficientEth:       regexp.MustCompile(`(: |^)(not enough funds for gas|insufficient funds for gas \* price \+ value)`),
 	Fatal:                 arbitrumFatal,
 }


### PR DESCRIPTION
Adding support for the Arbitrum Nitro error:
> call failed: max fee per gas less than block base fee: address 0x336394A3219e71D9d9bd18201d34E95C1Bb7122C, maxFeePerGas: 100000000 baseFee: 109440000

https://github.com/ethereum/go-ethereum/blob/a9ef135e2dd53682d106c6a2aede9187026cc1de/core/state_transition.go#L254