### PR TITLE
fix: [sc-49980] No Headers Received - Fantom Testnet

### DIFF
--- a/core/chains/evm/config/chain_specific_config.go
+++ b/core/chains/evm/config/chain_specific_config.go
@@ -316,6 +316,8 @@ func setChainSpecificConfigDefaultSets() {
 	fantomMainnet.nodeDeadAfterNoNewHeadersThreshold = 30 * time.Second
 	fantomTestnet := fantomMainnet
 	fantomTestnet.linkContractAddress = "0xfafedb041c0dd4fa2dc0d87a6b0979ee6fa7af5f"
+	fantomTestnet.blockEmissionIdleWarningThreshold = 0
+	fantomTestnet.nodeDeadAfterNoNewHeadersThreshold = 0 // Fantom testnet only emits blocks when a new tx is received, so this method of liveness detection is not useful
 
 	// RSK
 	// RSK prices its txes in sats not wei

--- a/core/chains/evm/config/v2/defaults/Fantom_Testnet.toml
+++ b/core/chains/evm/config/v2/defaults/Fantom_Testnet.toml
@@ -13,7 +13,8 @@ PriceMax = '0.2 milli'
 BlockDelay = 2
 
 [HeadTracker]
-BlockEmissionIdleWarningThreshold = '15s'
+BlockEmissionIdleWarningThreshold = '0'
 
 [NodePool]
-NoNewHeadsThreshold = '30s'
+# Fantom testnet only emits blocks when a new tx is received, so this method of liveness detection is not useful
+NoNewHeadsThreshold = '0'

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -2472,13 +2472,13 @@ TransactionPercentile = 60
 
 
 [HeadTracker]
-BlockEmissionIdleWarningThreshold = '15s'
+BlockEmissionIdleWarningThreshold = '0s'
 HistoryDepth = 100
 MaxBufferSize = 3
 SamplingInterval = '1s'
 
 [NodePool]
-NoNewHeadsThreshold = '30s'
+NoNewHeadsThreshold = '0s'
 PollFailureThreshold = 5
 PollInterval = '10s'
 


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/49980
Disable liveliness, since Fantom testnet only produces blocks when txs are sent:
![Screenshot from 2022-08-09 11-40-42](https://user-images.githubusercontent.com/1194128/183708918-c580e847-0e04-40a9-ba48-cc9dbd4e9eaf.png)
