### PR TITLE
core/internal: fix race in TestIntegration_OCR2

### DIFF
--- a/core/internal/features_ocr2_test.go
+++ b/core/internal/features_ocr2_test.go
@@ -30,6 +30,7 @@ import (
 	ocrtypes2 "github.com/smartcontractkit/libocr/offchainreporting2/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/maps"
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink/core/bridges"
@@ -378,7 +379,11 @@ juelsPerFeeCoinSource = """
 			require.Len(t, j.JobSpecErrors, ignore)
 		}
 	}
-	assert.Len(t, expectedMeta, 0, "expected metadata %v", expectedMeta)
+	em := map[string]struct{}{}
+	metaLock.Lock()
+	maps.Copy(em, expectedMeta)
+	metaLock.Unlock()
+	assert.Len(t, em, 0, "expected metadata %v", em)
 
 	// Assert we can read the latest config digest and epoch after a report has been submitted.
 	contractABI, err := abi.JSON(strings.NewReader(ocr2aggregator.OCR2AggregatorABI))


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Read at 0x00c001f8a570 by goroutine 88:
  reflect.maplen()
      /opt/hostedtoolcache/go/1.18.5/x64/src/runtime/map.go:1392 +0x0
  reflect.Value.Len()
      /opt/hostedtoolcache/go/1.18.5/x64/src/reflect/value.go:1575 +0x268
  github.com/stretchr/testify/assert.getLen()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.8.0/assert/assertions.go:630 +0x224
  github.com/stretchr/testify/assert.Len()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.8.0/assert/assertions.go:641 +0xb1
  github.com/smartcontractkit/chainlink/core/internal_test.TestIntegration_OCR2()
      /home/runner/work/chainlink-internal/chainlink-internal/core/internal/features_ocr2_test.go:377 +0x2db3
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x47

Previous write at 0x00c001f8a570 by goroutine 631:
  runtime.mapdelete_faststr()
      /opt/hostedtoolcache/go/1.18.5/x64/src/runtime/map_faststr.go:301 +0x0
  github.com/smartcontractkit/chainlink/core/internal_test.TestIntegration_OCR2.func3()
      /home/runner/work/chainlink-internal/chainlink-internal/core/internal/features_ocr2_test.go:272 +0x286
  net/http.HandlerFunc.ServeHTTP()
      /opt/hostedtoolcache/go/1.18.5/x64/src/net/http/server.go:2084 +0x4d
  net/http.serverHandler.ServeHTTP()
      /opt/hostedtoolcache/go/1.18.5/x64/src/net/http/server.go:2916 +0x896
  net/http.(*conn).serve()
      /opt/hostedtoolcache/go/1.18.5/x64/src/net/http/server.go:1966 +0xbaa
  net/http.(*Server).Serve.func3()
      /opt/hostedtoolcache/go/1.18.5/x64/src/net/http/server.go:3071 +0x58

Goroutine 88 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x724
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1839 +0x99
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.runTests()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1837 +0x7e4
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1719 +0xa71
  main.main()
      _testmain.go:59 +0x2e4

Goroutine 631 (running) created at:
  net/http.(*Server).Serve()
      /opt/hostedtoolcache/go/1.18.5/x64/src/net/http/server.go:3071 +0x80c
  net/http/httptest.(*Server).goServe.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/net/http/httptest/server.go:308 +0xb2
==================
```