### PR TITLE
Update CODEOWNERS for VRF services

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -19,7 +19,13 @@
 /core/services/pipeline @spooktheducks @connorwstein @prashantkumar1982
 /core/services/synchronization
 /core/services/telemetry
-/core/services/vrf @connorwstein @makramkd
+
+# VRF-related services
+/core/services/vrf @smartcontractkit/vrf-team
+/core/services/blockhashstore @smartcontractkit/vrf-team
+/core/services/ocr2/plugins/dkg @smartcontractkit/vrf-team
+/core/services/ocr2/plugins/ocr2vrf @smartcontractkit/vrf-team
+
 /core/services/webhook @spooktheducks
 
 # API


### PR DESCRIPTION
Updating the codeowners for VRF services and also adding codeowners for the blockhashstore and ocr2vrf services.