### PR TITLE
Keeper registry OCR implementation

### DIFF
--- a/contracts/src/v0.8/dev/keeperocr/interfaces/KeeperRegistryInterfaceOcr.sol
+++ b/contracts/src/v0.8/dev/keeperocr/interfaces/KeeperRegistryInterfaceOcr.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 /**
- * @notice config of the registry
+ * @notice OnChainConfig of the registry
  * @dev only used in params and return values
  * @member paymentPremiumPPB payment premium rate oracles receive on top of
  * being reimbursed for gas, measured in parts per billion
@@ -23,7 +23,8 @@ pragma solidity ^0.8.0;
  * @member transcoder address of the transcoder contract
  * @member registrar address of the registrar contract
  */
-struct Config {
+struct OnChainConfig {
+  // TODO (sc-49442): Optimise config storage
   uint32 paymentPremiumPPB;
   uint32 flatFeeMicroLink; // min 0.000001 LINK, max 4294 LINK
   uint24 blockCountPerTurn;
@@ -65,14 +66,15 @@ struct State {
  * @member paused if this upkeep has been paused
  */
 struct Upkeep {
+  // TODO (sc-49442): Optimise upkeep storage
   uint96 balance;
-  address lastKeeper; // 1 full evm word
   uint96 amountSpent;
-  address admin; // 2 full evm words
+  address admin;
   uint32 executeGas;
   uint32 maxValidBlocknumber;
+  uint32 lastPerformBlockNumber;
   address target;
-  bool paused; // 24 bits to 3 full evm words
+  bool paused;
 }
 
 interface KeeperRegistryBaseInterface {
@@ -132,7 +134,7 @@ interface KeeperRegistryBaseInterface {
     view
     returns (
       State memory,
-      Config memory,
+      OnChainConfig memory,
       address[] memory
     );
 }

--- a/contracts/src/v0.8/dev/keeperocr/interfaces/OCR2Keeper.sol
+++ b/contracts/src/v0.8/dev/keeperocr/interfaces/OCR2Keeper.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+abstract contract OCR2Keeper {
+  // Maximum number of oracles the offchain reporting protocol is designed for
+  uint256 internal constant maxNumOracles = 31;
+
+  /**
+   * @notice triggers a new run of the offchain reporting protocol
+   * @param previousConfigBlockNumber block in which the previous config was set, to simplify historic analysis
+   * @param configDigest configDigest of this configuration
+   * @param configCount ordinal number of this config setting among all config settings over the life of this contract
+   * @param signers ith element is address ith oracle uses to sign a report
+   * @param transmitters ith element is address ith oracle uses to transmit a report via the transmit method
+   * @param f maximum number of faulty/dishonest oracles the protocol can tolerate while still working correctly
+   * @param onchainConfig serialized configuration used by the contract (and possibly oracles)
+   * @param offchainConfigVersion version of the serialization format used for "offchainConfig" parameter
+   * @param offchainConfig serialized configuration used by the oracles exclusively and only passed through the contract
+   */
+  event ConfigSet(
+    uint32 previousConfigBlockNumber,
+    bytes32 configDigest,
+    uint64 configCount,
+    address[] signers,
+    address[] transmitters,
+    uint8 f,
+    bytes onchainConfig,
+    uint64 offchainConfigVersion,
+    bytes offchainConfig
+  );
+
+  /**
+   * @notice sets offchain reporting protocol configuration incl. participating oracles
+   * @param signers addresses with which oracles sign the reports
+   * @param transmitters addresses oracles use to transmit the reports
+   * @param f number of faulty oracles the system can tolerate
+   * @param onchainConfig serialized configuration used by the contract (and possibly oracles)
+   * @param offchainConfigVersion version number for offchainEncoding schema
+   * @param offchainConfig serialized configuration used by the oracles exclusively and only passed through the contract
+   */
+  function setConfig(
+    address[] memory signers,
+    address[] memory transmitters,
+    uint8 f,
+    bytes memory onchainConfig,
+    uint64 offchainConfigVersion,
+    bytes memory offchainConfig
+  ) external virtual;
+
+  /**
+   * @notice information about current offchain reporting protocol configuration
+   * @return configCount ordinal number of current config, out of all configs applied to this contract so far
+   * @return blockNumber block at which this config was set
+   * @return rootConfigDigest domain-separation tag for current config (see _configDigestFromConfigData)
+   */
+  function latestRootConfigDetails()
+    external
+    view
+    virtual
+    returns (
+      uint32 configCount,
+      uint32 blockNumber,
+      bytes32 rootConfigDigest
+    );
+
+  function _configDigestFromConfigData(
+    uint256 chainId,
+    address contractAddress,
+    uint64 configCount,
+    address[] memory signers,
+    address[] memory transmitters,
+    uint8 f,
+    bytes memory onchainConfig,
+    uint64 offchainConfigVersion,
+    bytes memory offchainConfig
+  ) internal pure returns (bytes32) {
+    uint256 h = uint256(
+      keccak256(
+        abi.encode(
+          chainId,
+          contractAddress,
+          configCount,
+          signers,
+          transmitters,
+          f,
+          onchainConfig,
+          offchainConfigVersion,
+          offchainConfig
+        )
+      )
+    );
+    uint256 prefixMask = type(uint256).max << (256 - 16); // 0xFFFF00..00
+    uint256 prefix = 0x0001 << (256 - 16); // 0x000100..00
+    return bytes32((prefix & prefixMask) | (h & ~prefixMask));
+  }
+
+  /**
+  * @notice optionally emited to indicate the latest configDigest and epoch for
+     which a report was successfully transmited. Alternatively, the contract may
+     use latestConfigDigestAndEpoch with scanLogs set to false.
+  */
+  event Transmitted(bytes32 configDigest, uint32 epoch);
+
+  /**
+   * @notice optionally returns the latest configDigest and epoch for which a
+     report was successfully transmitted. Alternatively, the contract may return
+     scanLogs set to true and use Transmitted events to provide this information
+     to offchain watchers.
+   * @return scanLogs indicates whether to rely on the configDigest and epoch
+     returned or whether to scan logs for the Transmitted event instead.
+   * @return configDigest
+   * @return epoch
+   */
+  function latestConfigDigestAndEpoch()
+    external
+    view
+    virtual
+    returns (
+      bool scanLogs,
+      bytes32 configDigest,
+      uint32 epoch
+    );
+
+  /**
+   * @notice transmit is called to post a new report to the contract
+   * @param report serialized report, which the signatures are signing.
+   * @param rs ith element is the R components of the ith signature on report. Must have at most maxNumOracles entries
+   * @param ss ith element is the S components of the ith signature on report. Must have at most maxNumOracles entries
+   * @param rawVs ith element is the the V component of the ith signature
+   */
+  function transmit(
+    // NOTE: If these parameters are changed, expectedMsgDataLength and/or
+    // TRANSMIT_MSGDATA_CONSTANT_LENGTH_COMPONENT need to be changed accordingly
+    bytes32[3] calldata reportContext,
+    bytes calldata report,
+    bytes32[] calldata rs,
+    bytes32[] calldata ss,
+    bytes32 rawVs // signatures
+  ) external virtual;
+}


### PR DESCRIPTION
Copy OCR2Abstract contract from libOCR repo to OCR2Keeper contract. Changes from that:
    - Rename interface name
    - Remove type and version interface - Keeper Registry already implements this
    - Rename configDigest to rootConfigDigest
    - Add numOCRInstances to setConfig
    - Remove onChainConfig param from setConfig. Not sure why it was there, but it was asserted to be empty
    - Add a function to get latest config digests

Keeper Registry Changes:
    - Consolidate all config into 2 structs - onChainConfig and OCRConfig. These will be gas optimised later
    - Have two functions - one to set OCR config and one to set OnChainConfig. Both update the rootConfigDigests
    - ...
