### PR TITLE
fix: go build

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,7 +58,7 @@ require (
 	github.com/smartcontractkit/chainlink-relay v0.1.5-0.20220808181113-70f8468a87ee
 	github.com/smartcontractkit/chainlink-solana v0.2.20-0.20220808191530-a957fc4b0712
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20220729175036-d01d60ffd0b4
-	github.com/smartcontractkit/chainlink-terra v0.1.4-0.20220726142934-12e423cf28ba
+	github.com/smartcontractkit/chainlink-terra v0.1.4-0.20220808135715-65639de464bd
 	github.com/smartcontractkit/libocr v0.0.0-20220726132443-ef1f5a4b63d0
 	github.com/smartcontractkit/ocr2vrf v0.0.0-20220802183403-8cb2a10769b5
 	github.com/smartcontractkit/sqlx v1.3.5-0.20210805004948-4be295aacbeb

--- a/go.sum
+++ b/go.sum
@@ -1671,8 +1671,8 @@ github.com/smartcontractkit/chainlink-solana v0.2.20-0.20220808191530-a957fc4b07
 github.com/smartcontractkit/chainlink-solana v0.2.20-0.20220808191530-a957fc4b0712/go.mod h1:KdHa6CPUgP1UQfQazuAoD92ti4O/paDE+wsAxb7886o=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20220729175036-d01d60ffd0b4 h1:N4UxpCGjymk4hpDfOLewjcmqrolOvEbAE+da6ill3QE=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20220729175036-d01d60ffd0b4/go.mod h1:KPGa7AfPNBfPqPbl1c/7lNipFaxG/6Lvf3dRcY60+Yo=
-github.com/smartcontractkit/chainlink-terra v0.1.4-0.20220726142934-12e423cf28ba h1:7jfRNHwLA/kK1jcKSqH+gWc0E3CwGTZ6AvYy+IgybRM=
-github.com/smartcontractkit/chainlink-terra v0.1.4-0.20220726142934-12e423cf28ba/go.mod h1:yspvVUsG5t4OhELSIj9O5dQsz7UqzO8z9J8Ys7scHeU=
+github.com/smartcontractkit/chainlink-terra v0.1.4-0.20220808135715-65639de464bd h1:Kd1dHTQsrWtDWLLD/uxqlxebK/5R88tWRsB3+dYKOmY=
+github.com/smartcontractkit/chainlink-terra v0.1.4-0.20220808135715-65639de464bd/go.mod h1:YRG/9VK+YqjgdcQxjThYbjmC7GU40mR5M8iqpQKd5Cs=
 github.com/smartcontractkit/chainlink-testing-framework v1.1.18 h1:5OaKWgyRSkPyueJaYjwwGNgJHrcv8fH2C03GyVXAzY8=
 github.com/smartcontractkit/helmenv v1.0.71 h1:M94EYcDbyu9zBn2iiNJ3rKxpPqJHT4AjY3yQod08QcU=
 github.com/smartcontractkit/libocr v0.0.0-20220726132443-ef1f5a4b63d0 h1:jKnLPHAE7x5SDLG6PnLqwg+IeZ8gFSmg0iKBJsSuflo=


### PR DESCRIPTION
The commit originally referenced in go.mod (12e423cf28ba) did not exist.

Fetched the latest via `go get github.com/smartcontractkit/chainlink-terra@develop`