### PR TITLE
fix flakey solidity tests

### DIFF
--- a/contracts/test/v0.8/KeeperRegistry.test.ts
+++ b/contracts/test/v0.8/KeeperRegistry.test.ts
@@ -966,11 +966,9 @@ describe('KeeperRegistry', () => {
       it('uses the fallback gas price if the feed price is non-sensical [ @skip-coverage ]', async () => {
         const normalAmount = await getPerformPaymentAmount()
         const roundId = 99
-
         const currentBlockNum = await ethers.provider.getBlockNumber()
         const currentBlock = await ethers.provider.getBlock(currentBlockNum)
         const updatedAt = currentBlock.timestamp
-
         const startedAt = 946684799
         await gasPriceFeed
           .connect(owner)
@@ -1000,11 +998,9 @@ describe('KeeperRegistry', () => {
       it('uses the fallback link price if the feed price is non-sensical [ @skip-coverage ]', async () => {
         const normalAmount = await getPerformPaymentAmount()
         const roundId = 99
-
         const currentBlockNum = await ethers.provider.getBlockNumber()
         const currentBlock = await ethers.provider.getBlock(currentBlockNum)
         const updatedAt = currentBlock.timestamp
-
         const startedAt = 946684799
         await linkEthFeed
           .connect(owner)

--- a/contracts/test/v0.8/KeeperRegistry.test.ts
+++ b/contracts/test/v0.8/KeeperRegistry.test.ts
@@ -966,7 +966,12 @@ describe('KeeperRegistry', () => {
       it('uses the fallback gas price if the feed price is non-sensical [ @skip-coverage ]', async () => {
         const normalAmount = await getPerformPaymentAmount()
         const roundId = 99
-        const updatedAt = Math.floor(Date.now() / 1000)
+        
+        const currentBlockNum = await ethers.provider.getBlockNumber()
+        const currentBlock = await ethers.provider.getBlock(currentBlockNum)
+        const currentTimestamp = currentBlock.timestamp
+        const updatedAt = currentTimestamp
+
         const startedAt = 946684799
         await gasPriceFeed
           .connect(owner)
@@ -996,7 +1001,12 @@ describe('KeeperRegistry', () => {
       it('uses the fallback link price if the feed price is non-sensical [ @skip-coverage ]', async () => {
         const normalAmount = await getPerformPaymentAmount()
         const roundId = 99
-        const updatedAt = Math.floor(Date.now() / 1000)
+        
+        const currentBlockNum = await ethers.provider.getBlockNumber()
+        const currentBlock = await ethers.provider.getBlock(currentBlockNum)
+        const currentTimestamp = currentBlock.timestamp
+        const updatedAt = currentTimestamp
+
         const startedAt = 946684799
         await linkEthFeed
           .connect(owner)

--- a/contracts/test/v0.8/KeeperRegistry.test.ts
+++ b/contracts/test/v0.8/KeeperRegistry.test.ts
@@ -966,7 +966,7 @@ describe('KeeperRegistry', () => {
       it('uses the fallback gas price if the feed price is non-sensical [ @skip-coverage ]', async () => {
         const normalAmount = await getPerformPaymentAmount()
         const roundId = 99
-        
+
         const currentBlockNum = await ethers.provider.getBlockNumber()
         const currentBlock = await ethers.provider.getBlock(currentBlockNum)
         const currentTimestamp = currentBlock.timestamp
@@ -1001,7 +1001,7 @@ describe('KeeperRegistry', () => {
       it('uses the fallback link price if the feed price is non-sensical [ @skip-coverage ]', async () => {
         const normalAmount = await getPerformPaymentAmount()
         const roundId = 99
-        
+
         const currentBlockNum = await ethers.provider.getBlockNumber()
         const currentBlock = await ethers.provider.getBlock(currentBlockNum)
         const currentTimestamp = currentBlock.timestamp

--- a/contracts/test/v0.8/KeeperRegistry.test.ts
+++ b/contracts/test/v0.8/KeeperRegistry.test.ts
@@ -969,8 +969,7 @@ describe('KeeperRegistry', () => {
 
         const currentBlockNum = await ethers.provider.getBlockNumber()
         const currentBlock = await ethers.provider.getBlock(currentBlockNum)
-        const currentTimestamp = currentBlock.timestamp
-        const updatedAt = currentTimestamp
+        const updatedAt = currentBlock.timestamp
 
         const startedAt = 946684799
         await gasPriceFeed
@@ -1004,8 +1003,7 @@ describe('KeeperRegistry', () => {
 
         const currentBlockNum = await ethers.provider.getBlockNumber()
         const currentBlock = await ethers.provider.getBlock(currentBlockNum)
-        const currentTimestamp = currentBlock.timestamp
-        const updatedAt = currentTimestamp
+        const updatedAt = currentBlock.timestamp
 
         const startedAt = 946684799
         await linkEthFeed

--- a/contracts/test/v0.8/dev/OptimismValidator.test.ts
+++ b/contracts/test/v0.8/dev/OptimismValidator.test.ts
@@ -77,8 +77,7 @@ describe('OptimismValidator', () => {
 
       const currentBlockNum = await ethers.provider.getBlockNumber()
       const currentBlock = await ethers.provider.getBlock(currentBlockNum)
-      const currentTimestamp = currentBlock.timestamp
-      const futureTimestamp = currentTimestamp + 5000
+      const futureTimestamp = currentBlock.timestamp + 5000
 
       await ethers.provider.send('evm_setNextBlockTimestamp', [futureTimestamp])
       const sequencerStatusRecorderCallData =

--- a/contracts/test/v0.8/dev/OptimismValidator.test.ts
+++ b/contracts/test/v0.8/dev/OptimismValidator.test.ts
@@ -75,12 +75,16 @@ describe('OptimismValidator', () => {
     it('posts sequencer status when there is not status change', async () => {
       await optimismValidator.addAccess(eoaValidator.address)
 
-      const now = Math.ceil(Date.now() / 1000) + 5000
-      await ethers.provider.send('evm_setNextBlockTimestamp', [now])
+      const currentBlockNum = await ethers.provider.getBlockNumber()
+      const currentBlock = await ethers.provider.getBlock(currentBlockNum)
+      const currentTimestamp = currentBlock.timestamp
+      const futureTimestamp = currentTimestamp + 5000
+
+      await ethers.provider.send('evm_setNextBlockTimestamp', [futureTimestamp])
       const sequencerStatusRecorderCallData =
         optimismUptimeFeedFactory.interface.encodeFunctionData('updateStatus', [
           false,
-          now,
+          futureTimestamp,
         ])
 
       await expect(optimismValidator.connect(eoaValidator).validate(0, 0, 0, 0))


### PR DESCRIPTION
These tests use Date.now() to set a timestamp but it can cause flakes as hardhat expects blocks to have increasing timestamps

Remove instances of Date.now() by querying the current block timestamp