### PR TITLE
core/chains/evm/config: update Arbitrum Nitro default configs

### DIFF
--- a/core/chains/evm/config/chain_specific_config.go
+++ b/core/chains/evm/config/chain_specific_config.go
@@ -285,9 +285,7 @@ func setChainSpecificConfigDefaultSets() {
 	arbitrumMainnet.blockEmissionIdleWarningThreshold = 0
 	arbitrumMainnet.nodeDeadAfterNoNewHeadersThreshold = 0 // Arbitrum only emits blocks when a new tx is received, so this method of liveness detection is not useful
 	arbitrumMainnet.chainType = config.ChainArbitrum
-	arbitrumMainnet.gasBumpThreshold = 0 // Disable gas bumping on arbitrum
-	arbitrumMainnet.gasLimitDefault = 7000000
-	arbitrumMainnet.gasLimitTransfer = 800000            // estimating gas returns 695,344 so 800,000 should be safe with some buffer
+	arbitrumMainnet.gasBumpThreshold = 0                 // Disable gas bumping on arbitrum
 	arbitrumMainnet.gasPriceDefault = *assets.GWei(1000) // Arbitrum uses something like a Vickrey auction model where gas price represents a "max bid". In practice we usually pay much less
 	arbitrumMainnet.maxGasPriceWei = *assets.GWei(1000)  // Fix the gas price
 	arbitrumMainnet.minGasPriceWei = *assets.GWei(1000)  // Fix the gas price
@@ -297,14 +295,7 @@ func setChainSpecificConfigDefaultSets() {
 	arbitrumMainnet.ocrContractConfirmations = 1
 	arbitrumRinkeby := arbitrumMainnet
 	arbitrumRinkeby.linkContractAddress = "0x615fBe6372676474d9e6933d310469c9b68e9726"
-	// nitro uses standard gas accounting, so restore default limits.
-	arbitrumRinkeby.gasLimitDefault = fallbackDefaultSet.gasLimitDefault
-	arbitrumRinkeby.gasLimitTransfer = fallbackDefaultSet.gasLimitTransfer
 	// nitro does not use an auction, so reduce the fixed gas price as it no longer represents an upper-bound bid.
-	arbitrumRinkeby.gasPriceDefault = *assets.Wei(1e8)  // 0.1 gwei
-	arbitrumRinkeby.maxGasPriceWei = *assets.Wei(1e8)   // 0.1 gwei
-	arbitrumRinkeby.minGasPriceWei = *assets.Wei(1e8)   // 0.1 gwei
-	arbitrumRinkeby.gasFeeCapDefault = *assets.Wei(1e8) // 0.1 gwei
 	arbitrumGoerli := arbitrumRinkeby
 	arbitrumGoerli.linkContractAddress = "" //TODO
 

--- a/core/chains/evm/config/v2/defaults/Arbitrum_Goerli.toml
+++ b/core/chains/evm/config/v2/defaults/Arbitrum_Goerli.toml
@@ -3,14 +3,16 @@ ChainType = 'arbitrum'
 OCR.ContractConfirmations = 1
 
 [GasEstimator]
-BumpThreshold = 0
 Mode = 'FixedPrice'
-PriceDefault = '0.1 gwei'
-PriceMax = '0.1 gwei'
-PriceMin = '0.1 gwei'
-FeeCapDefault = '0.1 gwei'
+# Arbitrum uses something like a Vickrey auction model where gas price represents a "max bid". In practice we usually pay much less
+PriceDefault = '1000 gwei'
+PriceMax = '1000 gwei' # Fix the gas price
+PriceMin = '1000 gwei' # Fix the gas price
+# Disable gas bumping on arbitrum
+BumpThreshold = 0
 
 [GasEstimator.BlockHistory]
+# Force an error if someone set GAS_UPDATER_ENABLED=true by accident; we never want to run the block history estimator on arbitrum
 BlockHistorySize = 0
 
 [HeadTracker]

--- a/core/chains/evm/config/v2/defaults/Arbitrum_Mainnet.toml
+++ b/core/chains/evm/config/v2/defaults/Arbitrum_Mainnet.toml
@@ -8,13 +8,8 @@ OCR.ContractConfirmations = 1
 Mode = 'FixedPrice'
 # Arbitrum uses something like a Vickrey auction model where gas price represents a "max bid". In practice we usually pay much less
 PriceDefault = '1000 gwei'
-# Fix the gas price
-PriceMax = '1000 gwei'
-# Fix the gas price
-PriceMin = '1000 gwei'
-LimitDefault = 7_000_000
-# estimating gas returns 695,344 so 800,000 should be safe with some buffer
-LimitTransfer = 800_000
+PriceMax = '1000 gwei' # Fix the gas price
+PriceMin = '1000 gwei' # Fix the gas price
 # Disable gas bumping on arbitrum
 BumpThreshold = 0
 

--- a/core/chains/evm/config/v2/defaults/Arbitrum_Rinkeby.toml
+++ b/core/chains/evm/config/v2/defaults/Arbitrum_Rinkeby.toml
@@ -4,14 +4,16 @@ LinkContractAddress = "0x615fBe6372676474d9e6933d310469c9b68e9726"
 OCR.ContractConfirmations = 1
 
 [GasEstimator]
-BumpThreshold = 0
 Mode = 'FixedPrice'
-PriceDefault = '0.1 gwei'
-PriceMax = '0.1 gwei'
-PriceMin = '0.1 gwei'
-FeeCapDefault = '0.1 gwei'
+# Arbitrum uses something like a Vickrey auction model where gas price represents a "max bid". In practice we usually pay much less
+PriceDefault = '1000 gwei'
+PriceMax = '1000 gwei' # Fix the gas price
+PriceMin = '1000 gwei' # Fix the gas price
+# Disable gas bumping on arbitrum
+BumpThreshold = 0
 
 [GasEstimator.BlockHistory]
+# Force an error if someone set GAS_UPDATER_ENABLED=true by accident; we never want to run the block history estimator on arbitrum
 BlockHistorySize = 0
 
 [HeadTracker]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `forwardingAllowed` per job attribute to allow forwarding txs submitted by the job.
 - Keypath now supports paths with any depth, instead of limiting it to 2
 - `Arbitrum` chains are no longer restricted to only `FixedPrice` `GAS_ESTIMATOR_MODE`
-- Updated `Arbitrum Rinkeby` configuration for Nitro
+- Updated `Arbitrum Rinkeby & Mainnet` configurations for Nitro
 - Add `Arbitrum Goerli` configuration
 - `chainlink admin users update` command is replaced with `chainlink admin users chrole` (only the role can be changed for a user)
 - It is now possible to use the same key across multiple chains.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -2626,9 +2626,9 @@ Mode = 'FixedPrice'
 PriceDefault = '1 micro'
 PriceMax = '1 micro'
 PriceMin = '1 micro'
-LimitDefault = 7000000
+LimitDefault = 500000
 LimitMultiplier = '1'
-LimitTransfer = 800000
+LimitTransfer = 21000
 BumpMin = '5 gwei'
 BumpPercent = 20
 BumpThreshold = 0
@@ -2888,9 +2888,9 @@ BlockDelay = 1
 
 [GasEstimator]
 Mode = 'FixedPrice'
-PriceDefault = '100 mwei'
-PriceMax = '100 mwei'
-PriceMin = '100 mwei'
+PriceDefault = '1 micro'
+PriceMax = '1 micro'
+PriceMin = '1 micro'
 LimitDefault = 500000
 LimitMultiplier = '1'
 LimitTransfer = 21000
@@ -2899,7 +2899,7 @@ BumpPercent = 20
 BumpThreshold = 0
 BumpTxDepth = 10
 EIP1559DynamicFees = false
-FeeCapDefault = '100 mwei'
+FeeCapDefault = '100 gwei'
 TipCapDefault = '1 wei'
 TipCapMinimum = '1 wei'
 [GasEstimator.BlockHistory]
@@ -2954,9 +2954,9 @@ BlockDelay = 1
 
 [GasEstimator]
 Mode = 'FixedPrice'
-PriceDefault = '100 mwei'
-PriceMax = '100 mwei'
-PriceMin = '100 mwei'
+PriceDefault = '1 micro'
+PriceMax = '1 micro'
+PriceMin = '1 micro'
 LimitDefault = 500000
 LimitMultiplier = '1'
 LimitTransfer = 21000
@@ -2965,7 +2965,7 @@ BumpPercent = 20
 BumpThreshold = 0
 BumpTxDepth = 10
 EIP1559DynamicFees = false
-FeeCapDefault = '100 mwei'
+FeeCapDefault = '100 gwei'
 TipCapDefault = '1 wei'
 TipCapMinimum = '1 wei'
 [GasEstimator.BlockHistory]


### PR DESCRIPTION
Aligning develop with 1.8 by picking the change from #7291
(cherry picked from commit 074076611e8284303259126326fff713d18e00ec)