### PR TITLE
Let pipeline tasks accept literal values in input parameter

### DIFF
--- a/core/services/pipeline/task.base64decode.go
+++ b/core/services/pipeline/task.base64decode.go
@@ -10,10 +10,9 @@ import (
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
-//
 // Return types:
-//     bytes
 //
+//	bytes
 type Base64DecodeTask struct {
 	BaseTask `mapstructure:",squash"`
 	Input    string `json:"input"`
@@ -34,7 +33,7 @@ func (t *Base64DecodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, in
 	var input StringParam
 
 	err = multierr.Combine(
-		errors.Wrap(ResolveParam(&input, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+		errors.Wrap(ResolveParam(&input, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err != nil {
 		return Result{Error: err}, runInfo

--- a/core/services/pipeline/task.base64encode.go
+++ b/core/services/pipeline/task.base64encode.go
@@ -10,10 +10,9 @@ import (
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
-//
 // Return types:
-//     string
 //
+//	string
 type Base64EncodeTask struct {
 	BaseTask `mapstructure:",squash"`
 	Input    string `json:"input"`
@@ -33,7 +32,7 @@ func (t *Base64EncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, in
 
 	var stringInput StringParam
 	err = multierr.Combine(
-		errors.Wrap(ResolveParam(&stringInput, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+		errors.Wrap(ResolveParam(&stringInput, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err == nil {
 		// string
@@ -42,7 +41,7 @@ func (t *Base64EncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, in
 
 	var bytesInput BytesParam
 	err = multierr.Combine(
-		errors.Wrap(ResolveParam(&bytesInput, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+		errors.Wrap(ResolveParam(&bytesInput, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err == nil {
 		// bytes

--- a/core/services/pipeline/task.divide.go
+++ b/core/services/pipeline/task.divide.go
@@ -10,10 +10,9 @@ import (
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
-//
 // Return types:
-//    *decimal.Decimal
 //
+//	*decimal.Decimal
 type DivideTask struct {
 	BaseTask  `mapstructure:",squash"`
 	Input     string `json:"input"`
@@ -44,7 +43,7 @@ func (t *DivideTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs [
 		maybePrecision MaybeInt32Param
 	)
 	err = multierr.Combine(
-		errors.Wrap(ResolveParam(&a, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+		errors.Wrap(ResolveParam(&a, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 		errors.Wrap(ResolveParam(&b, From(VarExpr(t.Divisor, vars), NonemptyString(t.Divisor))), "divisor"),
 		errors.Wrap(ResolveParam(&maybePrecision, From(VarExpr(t.Precision, vars), t.Precision)), "precision"),
 	)

--- a/core/services/pipeline/task.hexdecode.go
+++ b/core/services/pipeline/task.hexdecode.go
@@ -11,10 +11,9 @@ import (
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
-//
 // Return types:
-//     bytes
 //
+//	bytes
 type HexDecodeTask struct {
 	BaseTask `mapstructure:",squash"`
 	Input    string `json:"input"`
@@ -35,7 +34,7 @@ func (t *HexDecodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 	var input StringParam
 
 	err = multierr.Combine(
-		errors.Wrap(ResolveParam(&input, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+		errors.Wrap(ResolveParam(&input, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err != nil {
 		return Result{Error: err}, runInfo

--- a/core/services/pipeline/task.hexdecode_test.go
+++ b/core/services/pipeline/task.hexdecode_test.go
@@ -1,6 +1,7 @@
 package pipeline_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -32,21 +33,35 @@ func TestHexDecodeTask(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		assertOK := func(result pipeline.Result, runInfo pipeline.RunInfo) {
+			assert.False(t, runInfo.IsPending)
+			assert.False(t, runInfo.IsRetryable)
+			if test.error == "" {
+				require.NoError(t, result.Error)
+				require.Equal(t, test.result, result.Value)
+			} else {
+				require.ErrorContains(t, result.Error, test.error)
+			}
+		}
 		t.Run(test.name, func(t *testing.T) {
-			t.Run("without vars", func(t *testing.T) {
+			t.Run("without vars through job DAG", func(t *testing.T) {
 				vars := pipeline.NewVarsFrom(nil)
-				task := pipeline.HexDecodeTask{BaseTask: pipeline.NewBaseTask(0, "task", nil, nil, 0), Input: test.input}
-				result, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{{Value: test.input}})
-
-				assert.False(t, runInfo.IsPending)
-				assert.False(t, runInfo.IsRetryable)
-
-				if test.error == "" {
-					require.NoError(t, result.Error)
-					require.Equal(t, test.result, result.Value)
-				} else {
-					require.ErrorContains(t, result.Error, test.error)
+				task := pipeline.HexDecodeTask{BaseTask: pipeline.NewBaseTask(0, "task", nil, nil, 0)}
+				assertOK(task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{{Value: test.input}}))
+			})
+			t.Run("without vars through input param", func(t *testing.T) {
+				inputStr := fmt.Sprintf("%v", test.input)
+				if inputStr == "" {
+					// empty input parameter is indistinguishable from not providing it at all
+					// in that case the task will use an input defined by the job DAG
+					return
 				}
+				vars := pipeline.NewVarsFrom(nil)
+				task := pipeline.HexDecodeTask{
+					BaseTask: pipeline.NewBaseTask(0, "task", nil, nil, 0),
+					Input:    inputStr,
+				}
+				assertOK(task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{}))
 			})
 			t.Run("with vars", func(t *testing.T) {
 				vars := pipeline.NewVarsFrom(map[string]interface{}{
@@ -56,17 +71,7 @@ func TestHexDecodeTask(t *testing.T) {
 					BaseTask: pipeline.NewBaseTask(0, "task", nil, nil, 0),
 					Input:    "$(foo.bar)",
 				}
-				result, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{})
-
-				assert.False(t, runInfo.IsPending)
-				assert.False(t, runInfo.IsRetryable)
-
-				if test.error == "" {
-					require.NoError(t, result.Error)
-					require.Equal(t, test.result, result.Value)
-				} else {
-					require.ErrorContains(t, result.Error, test.error)
-				}
+				assertOK(task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{}))
 			})
 		})
 	}

--- a/core/services/pipeline/task.hexencode.go
+++ b/core/services/pipeline/task.hexencode.go
@@ -11,10 +11,9 @@ import (
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
-//
 // Return types:
-//     string
 //
+//	string
 type HexEncodeTask struct {
 	BaseTask `mapstructure:",squash"`
 	Input    string `json:"input"`
@@ -41,7 +40,7 @@ func (t *HexEncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 
 	var stringInput StringParam
 	err = multierr.Combine(
-		errors.Wrap(ResolveParam(&stringInput, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+		errors.Wrap(ResolveParam(&stringInput, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err == nil {
 		// string
@@ -50,7 +49,7 @@ func (t *HexEncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 
 	var bytesInput BytesParam
 	err = multierr.Combine(
-		errors.Wrap(ResolveParam(&bytesInput, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+		errors.Wrap(ResolveParam(&bytesInput, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err == nil {
 		// bytes
@@ -59,7 +58,7 @@ func (t *HexEncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 
 	var decimalInput DecimalParam
 	err = multierr.Combine(
-		errors.Wrap(ResolveParam(&decimalInput, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+		errors.Wrap(ResolveParam(&decimalInput, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err == nil && !decimalInput.Decimal().IsInteger() {
 		// decimal
@@ -68,7 +67,7 @@ func (t *HexEncodeTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 
 	var bigIntInput MaybeBigIntParam
 	err = multierr.Combine(
-		errors.Wrap(ResolveParam(&bigIntInput, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+		errors.Wrap(ResolveParam(&bigIntInput, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err == nil {
 		// one of integer types

--- a/core/services/pipeline/task.lowercase.go
+++ b/core/services/pipeline/task.lowercase.go
@@ -10,10 +10,9 @@ import (
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
-//
 // Return types:
-//     string
 //
+//	string
 type LowercaseTask struct {
 	BaseTask `mapstructure:",squash"`
 	Input    string `json:"input"`
@@ -34,7 +33,7 @@ func (t *LowercaseTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 	var input StringParam
 
 	err = multierr.Combine(
-		errors.Wrap(ResolveParam(&input, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+		errors.Wrap(ResolveParam(&input, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err != nil {
 		return Result{Error: err}, runInfo

--- a/core/services/pipeline/task.lowercase_test.go
+++ b/core/services/pipeline/task.lowercase_test.go
@@ -1,6 +1,7 @@
 package pipeline_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -28,16 +29,31 @@ func TestLowercaseTask(t *testing.T) {
 	}
 
 	for _, test := range tests {
+		assertOK := func(result pipeline.Result, runInfo pipeline.RunInfo) {
+			assert.False(t, runInfo.IsPending)
+			assert.False(t, runInfo.IsRetryable)
+			require.NoError(t, result.Error)
+			require.Equal(t, test.want, result.Value.(string))
+		}
 		t.Run(test.name, func(t *testing.T) {
-			t.Run("without vars", func(t *testing.T) {
+			t.Run("without vars through job DAG", func(t *testing.T) {
 				vars := pipeline.NewVarsFrom(nil)
-				task := pipeline.LowercaseTask{BaseTask: pipeline.NewBaseTask(0, "task", nil, nil, 0), Input: test.input.(string)}
-				result, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{{Value: test.input}})
-
-				assert.False(t, runInfo.IsPending)
-				assert.False(t, runInfo.IsRetryable)
-				require.NoError(t, result.Error)
-				require.Equal(t, test.want, result.Value.(string))
+				task := pipeline.LowercaseTask{BaseTask: pipeline.NewBaseTask(0, "task", nil, nil, 0)}
+				assertOK(task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{{Value: test.input}}))
+			})
+			t.Run("without vars through input param", func(t *testing.T) {
+				inputStr := fmt.Sprintf("%v", test.input)
+				if inputStr == "" {
+					// empty input parameter is indistinguishable from not providing it at all
+					// in that case the task will use an input defined by the job DAG
+					return
+				}
+				vars := pipeline.NewVarsFrom(nil)
+				task := pipeline.LowercaseTask{
+					BaseTask: pipeline.NewBaseTask(0, "task", nil, nil, 0),
+					Input:    inputStr,
+				}
+				assertOK(task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{}))
 			})
 			t.Run("with vars", func(t *testing.T) {
 				vars := pipeline.NewVarsFrom(map[string]interface{}{
@@ -47,11 +63,7 @@ func TestLowercaseTask(t *testing.T) {
 					BaseTask: pipeline.NewBaseTask(0, "task", nil, nil, 0),
 					Input:    "$(foo.bar)",
 				}
-				result, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{})
-				assert.False(t, runInfo.IsPending)
-				assert.False(t, runInfo.IsRetryable)
-				require.NoError(t, result.Error)
-				require.Equal(t, test.want, result.Value.(string))
+				assertOK(task.Run(testutils.Context(t), logger.TestLogger(t), vars, []pipeline.Result{}))
 			})
 		})
 	}

--- a/core/services/pipeline/task.multiply.go
+++ b/core/services/pipeline/task.multiply.go
@@ -10,10 +10,9 @@ import (
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
-//
 // Return types:
-//    *decimal.Decimal
 //
+//	*decimal.Decimal
 type MultiplyTask struct {
 	BaseTask `mapstructure:",squash"`
 	Input    string `json:"input"`
@@ -41,7 +40,7 @@ func (t *MultiplyTask) Run(_ context.Context, _ logger.Logger, vars Vars, inputs
 	)
 
 	err = multierr.Combine(
-		errors.Wrap(ResolveParam(&a, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+		errors.Wrap(ResolveParam(&a, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 		errors.Wrap(ResolveParam(&b, From(VarExpr(t.Times, vars), NonemptyString(t.Times))), "times"),
 	)
 	if err != nil {

--- a/core/services/pipeline/task.uppercase.go
+++ b/core/services/pipeline/task.uppercase.go
@@ -10,10 +10,9 @@ import (
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
-//
 // Return types:
-//     string
 //
+//	string
 type UppercaseTask struct {
 	BaseTask `mapstructure:",squash"`
 	Input    string `json:"input"`
@@ -34,7 +33,7 @@ func (t *UppercaseTask) Run(_ context.Context, _ logger.Logger, vars Vars, input
 	var input StringParam
 
 	err = multierr.Combine(
-		errors.Wrap(ResolveParam(&input, From(VarExpr(t.Input, vars), Input(inputs, 0))), "input"),
+		errors.Wrap(ResolveParam(&input, From(VarExpr(t.Input, vars), NonemptyString(t.Input), Input(inputs, 0))), "input"),
 	)
 	if err != nil {
 		return Result{Error: err}, runInfo


### PR DESCRIPTION
Fixed for several tasks: multiply, divide, lowercase, uppercase, base64encode, hexencode, base64decode, hexdecode