### PR TITLE
core/web: solana chains controller test race

### DIFF
--- a/core/web/solana_chains_controller_test.go
+++ b/core/web/solana_chains_controller_test.go
@@ -13,10 +13,11 @@ import (
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/pkg/errors"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
+
+	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
 
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
 
@@ -34,20 +35,14 @@ func Test_SolanaChainsController_Create(t *testing.T) {
 
 	newChainId := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))
 
-	second, err := utils.NewDuration(time.Second)
-	require.NoError(t, err)
-	minute, err := utils.NewDuration(time.Minute)
-	require.NoError(t, err)
-	hour, err := utils.NewDuration(time.Hour)
-	require.NoError(t, err)
 	body, err := json.Marshal(web.NewCreateChainRequest(
 		newChainId,
 		&db.ChainCfg{
-			BalancePollPeriod:   &second,
-			ConfirmPollPeriod:   &minute,
-			OCR2CachePollPeriod: &minute,
-			OCR2CacheTTL:        &second,
-			TxTimeout:           &hour,
+			BalancePollPeriod:   utils.MustNewDuration(time.Second),
+			ConfirmPollPeriod:   utils.MustNewDuration(time.Minute),
+			OCR2CachePollPeriod: utils.MustNewDuration(time.Minute),
+			OCR2CacheTTL:        utils.MustNewDuration(time.Second),
+			TxTimeout:           utils.MustNewDuration(time.Hour),
 			SkipPreflight:       null.BoolFrom(false),
 			Commitment:          null.StringFrom(string(rpc.CommitmentRecent)),
 		}))
@@ -81,8 +76,6 @@ func Test_SolanaChainsController_Show(t *testing.T) {
 
 	const validId = "Chainlink-12"
 
-	hour, err := utils.NewDuration(time.Hour)
-	require.NoError(t, err)
 	testCases := []struct {
 		name           string
 		inputId        string
@@ -95,7 +88,7 @@ func Test_SolanaChainsController_Show(t *testing.T) {
 			want: func(t *testing.T, app *cltest.TestApplication) *db.Chain {
 				newChainConfig := db.ChainCfg{
 					SkipPreflight: null.BoolFrom(false),
-					TxTimeout:     &hour,
+					TxTimeout:     utils.MustNewDuration(time.Hour),
 				}
 
 				chain := db.Chain{
@@ -152,13 +145,11 @@ func Test_SolanaChainsController_Index(t *testing.T) {
 
 	controller := setupSolanaChainsControllerTest(t)
 
-	hour, err := utils.NewDuration(time.Hour)
-	require.NoError(t, err)
 	newChains := []web.CreateChainRequest[string, *db.ChainCfg]{
 		{
 			ID: fmt.Sprintf("ChainlinktestA-%d", rand.Int31n(999999)),
 			Config: &db.ChainCfg{
-				TxTimeout: &hour,
+				TxTimeout: utils.MustNewDuration(time.Hour),
 			},
 		},
 		{
@@ -224,13 +215,11 @@ func Test_SolanaChainsController_Index(t *testing.T) {
 func Test_SolanaChainsController_Update(t *testing.T) {
 	t.Parallel()
 
-	hour, err := utils.NewDuration(time.Hour)
-	require.NoError(t, err)
 	chainUpdate := web.UpdateChainRequest[*db.ChainCfg]{
 		Enabled: true,
 		Config: &db.ChainCfg{
 			SkipPreflight: null.BoolFrom(false),
-			TxTimeout:     &hour,
+			TxTimeout:     utils.MustNewDuration(time.Hour),
 		},
 	}
 
@@ -248,7 +237,7 @@ func Test_SolanaChainsController_Update(t *testing.T) {
 			chainBeforeUpdate: func(t *testing.T, app *cltest.TestApplication) *db.Chain {
 				newChainConfig := db.ChainCfg{
 					SkipPreflight: null.BoolFrom(false),
-					TxTimeout:     &hour,
+					TxTimeout:     utils.MustNewDuration(time.Hour),
 				}
 
 				chain := db.Chain{
@@ -311,11 +300,9 @@ func Test_SolanaChainsController_Delete(t *testing.T) {
 
 	controller := setupSolanaChainsControllerTest(t)
 
-	hour, err := utils.NewDuration(time.Hour)
-	require.NoError(t, err)
 	newChainConfig := db.ChainCfg{
 		SkipPreflight: null.BoolFrom(false),
-		TxTimeout:     &hour,
+		TxTimeout:     utils.MustNewDuration(time.Hour),
 	}
 
 	chainId := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))


### PR DESCRIPTION
Fixing test variable races. These predated a helper that avoids the issue in the first place.
https://github.com/smartcontractkit/chainlink/actions/runs/2941127917
```
==================
WARNING: DATA RACE
Write at 0x00c010276ad8 by goroutine 374:
  github.com/smartcontractkit/chainlink-relay/pkg/utils.(*Duration).UnmarshalJSON()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-relay@v0.1.6-0.20220824173548-dab4ac0a6595/pkg/utils/duration.go:54 +0x130
  encoding/json.(*decodeState).literalStore()
      /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/decode.go:871 +0x34e4
  encoding/json.(*decodeState).value()
      /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/decode.go:387 +0x24e
  encoding/json.(*decodeState).object()
      /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/decode.go:774 +0x11e4
  encoding/json.(*decodeState).value()
      /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/decode.go:373 +0xb2
  encoding/json.(*decodeState).unmarshal()
      /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/decode.go:180 +0x3d6
  encoding/json.Unmarshal()
      /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/decode.go:107 +0x225
  github.com/smartcontractkit/chainlink-solana/pkg/solana/db.(*ChainCfg).Scan()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-solana@v0.2.20-0.20220824175208-161686d7493e/pkg/solana/db/db.go:56 +0x71
  database/sql.convertAssignRows()
      /opt/hostedtoolcache/go/1.18.5/x64/src/database/sql/convert.go:385 +0x335c
  database/sql.(*Rows).Scan()
      /opt/hostedtoolcache/go/1.18.5/x64/src/database/sql/sql.go:3287 +0x53d
  github.com/smartcontractkit/sqlx.(*Row).Scan()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/sqlx@v1.3.5-0.20210805004948-4be295aacbeb/sqlx.go:207 +0x1dd
  github.com/smartcontractkit/sqlx.(*Row).scanAny()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/sqlx@v1.3.5-0.20210805004948-4be295aacbeb/sqlx.go:793 +0xa86
  github.com/smartcontractkit/sqlx.Get()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/sqlx@v1.3.5-0.20210805004948-4be295aacbeb/sqlx.go:694 +0x9d
  github.com/smartcontractkit/sqlx.(*DB).Get()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/sqlx@v1.3.5-0.20210805004948-4be295aacbeb/sqlx.go:324 +0x124
  github.com/smartcontractkit/chainlink/core/internal/testutils/solanatest.MustInsertChain()
      /home/runner/work/chainlink/chainlink/core/internal/testutils/solanatest/solanatest.go:18 +0xe5
  github.com/smartcontractkit/chainlink/core/web_test.Test_SolanaChainsController_Update.func1()
      /home/runner/work/chainlink/chainlink/core/web/solana_chains_controller_test.go:259 +0x1e6
  github.com/smartcontractkit/chainlink/core/web_test.Test_SolanaChainsController_Update.func3()
      /home/runner/work/chainlink/chainlink/core/web/solana_chains_controller_test.go:283 +0xa5
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x47

Previous read at 0x00c010276ad8 by goroutine 275:
  github.com/smartcontractkit/chainlink-relay/pkg/utils.(*Duration).MarshalJSON()
      <autogenerated>:1 +0x49
  encoding/json.marshalerEncoder()
      /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/encode.go:479 +0x132
  encoding/json.structEncoder.encode()
      /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/encode.go:761 +0x2ba
  encoding/json.structEncoder.encode-fm()
      <autogenerated>:1 +0xdb
  encoding/json.ptrEncoder.encode()
      /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/encode.go:945 +0x3c2
  encoding/json.ptrEncoder.encode-fm()
      <autogenerated>:1 +0x90
  encoding/json.structEncoder.encode()
      /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/encode.go:761 +0x2ba
  encoding/json.structEncoder.encode-fm()
      <autogenerated>:1 +0xdb
  encoding/json.(*encodeState).reflectValue()
      /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/encode.go:360 +0x88
  encoding/json.(*encodeState).marshal()
      /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/encode.go:332 +0x20b
  encoding/json.Marshal()
      /opt/hostedtoolcache/go/1.18.5/x64/src/encoding/json/encode.go:161 +0x51
  github.com/smartcontractkit/chainlink/core/web_test.Test_SolanaChainsController_Update.func3()
      /home/runner/work/chainlink/chainlink/core/web/solana_chains_controller_test.go:285 +0xec
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x47

Goroutine 374 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x724
  github.com/smartcontractkit/chainlink/core/web_test.Test_SolanaChainsController_Update()
      /home/runner/work/chainlink/chainlink/core/web/solana_chains_controller_test.go:278 +0x4aa
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x47

Goroutine 275 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x724
  github.com/smartcontractkit/chainlink/core/web_test.Test_SolanaChainsController_Update()
      /home/runner/work/chainlink/chainlink/core/web/solana_chains_controller_test.go:278 +0x4aa
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x47
==================
```