### PR TITLE
core/chains/evm/logpoller: fix data race

### DIFF
--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -60,7 +60,7 @@ type logPoller struct {
 	finalityDepth     int64         // finality depth is taken to mean that block (head - finality) is finalized
 	backfillBatchSize int64         // batch size to use when backfilling finalized logs
 
-	filterMu  sync.Mutex
+	filterMu  sync.RWMutex
 	addresses map[common.Address]struct{}
 	eventSigs map[common.Hash]struct{}
 
@@ -506,6 +506,8 @@ func (lp *logPoller) findBlockAfterLCA(ctx context.Context, current *types.Heade
 }
 
 func (lp *logPoller) assertInFilter(eventSigs []common.Hash, addresses []common.Address) error {
+	lp.filterMu.RLock()
+	defer lp.filterMu.RUnlock()
 	for _, eventSig := range eventSigs {
 		if _, ok := lp.eventSigs[eventSig]; !ok {
 			return errors.Errorf("eventSig %x not registered", eventSig)


### PR DESCRIPTION
Yesterday's scheduled CI run detected a data race:
https://github.com/smartcontractkit/chainlink/actions/runs/2945061909
<details><summary>Race Details</summary>

```
==================
WARNING: DATA RACE
Read at 0x00c0059d49c0 by goroutine 421:
  runtime.mapaccess2()
      /opt/hostedtoolcache/go/1.18.5/x64/src/runtime/map.go:456 +0x0
  github.com/smartcontractkit/chainlink/core/chains/evm/logpoller.(*logPoller).assertInFilter()
      /home/runner/work/chainlink/chainlink/core/chains/evm/logpoller/log_poller.go:510 +0x26f
  github.com/smartcontractkit/chainlink/core/chains/evm/logpoller.(*logPoller).LatestLogByEventSigWithConfs()
      /home/runner/work/chainlink/chainlink/core/chains/evm/logpoller/log_poller.go:598 +0xe6
  github.com/smartcontractkit/chainlink/core/services/relay/evm.(*ConfigPoller).LatestConfigDetails()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/config_poller.go:157 +0x202
  github.com/smartcontractkit/libocr/offchainreporting2/internal/managed.(*trackConfigState).checkLatestConfigDetails()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/internal/managed/track_config.go:103 +0x36a
  github.com/smartcontractkit/libocr/offchainreporting2/internal/managed.(*trackConfigState).run()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/internal/managed/track_config.go:45 +0x275
  github.com/smartcontractkit/libocr/offchainreporting2/internal/managed.TrackConfig()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/internal/managed/track_config.go:178 +0x1d4
  github.com/smartcontractkit/libocr/offchainreporting2/internal/managed.(*runWithContractConfigState).run.func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/internal/managed/run_with_contract_config.go:67 +0x1f9
  github.com/smartcontractkit/libocr/subprocesses.(*Subprocesses).Go.func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/subprocesses/subprocesses.go:29 +0x73

Previous write at 0x00c0059d49c0 by goroutine 209:
  [failed to restore the stack]

Goroutine 421 (running) created at:
  github.com/smartcontractkit/libocr/subprocesses.(*Subprocesses).Go()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/subprocesses/subprocesses.go:27 +0xdc
  github.com/smartcontractkit/libocr/offchainreporting2/internal/managed.(*runWithContractConfigState).run()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/internal/managed/run_with_contract_config.go:66 +0x144
  github.com/smartcontractkit/libocr/offchainreporting2/internal/managed.runWithContractConfig()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/internal/managed/run_with_contract_config.go:40 +0x1f8
  github.com/smartcontractkit/libocr/offchainreporting2/internal/managed.RunManagedOracle()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/internal/managed/managed_oracle.go:54 +0x7d2
  github.com/smartcontractkit/libocr/offchainreporting2.(*Oracle).Start.func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/oracle.go:114 +0x418
  github.com/smartcontractkit/libocr/subprocesses.(*Subprocesses).Go.func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/subprocesses/subprocesses.go:29 +0x73

Goroutine 209 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x724
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1839 +0x99
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.runTests()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1837 +0x7e4
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1719 +0xa71
  main.main()
      _testmain.go:59 +0x2e4
==================
==================
WARNING: DATA RACE
Read at 0x00c0059d4990 by goroutine 421:
  runtime.mapaccess2()
      /opt/hostedtoolcache/go/1.18.5/x64/src/runtime/map.go:456 +0x0
  github.com/smartcontractkit/chainlink/core/chains/evm/logpoller.(*logPoller).assertInFilter()
      /home/runner/work/chainlink/chainlink/core/chains/evm/logpoller/log_poller.go:515 +0x12c
  github.com/smartcontractkit/chainlink/core/chains/evm/logpoller.(*logPoller).LatestLogByEventSigWithConfs()
      /home/runner/work/chainlink/chainlink/core/chains/evm/logpoller/log_poller.go:598 +0xe6
  github.com/smartcontractkit/chainlink/core/services/relay/evm.(*ConfigPoller).LatestConfigDetails()
      /home/runner/work/chainlink/chainlink/core/services/relay/evm/config_poller.go:157 +0x202
  github.com/smartcontractkit/libocr/offchainreporting2/internal/managed.(*trackConfigState).checkLatestConfigDetails()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/internal/managed/track_config.go:103 +0x36a
  github.com/smartcontractkit/libocr/offchainreporting2/internal/managed.(*trackConfigState).run()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/internal/managed/track_config.go:45 +0x275
  github.com/smartcontractkit/libocr/offchainreporting2/internal/managed.TrackConfig()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/internal/managed/track_config.go:178 +0x1d4
  github.com/smartcontractkit/libocr/offchainreporting2/internal/managed.(*runWithContractConfigState).run.func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/internal/managed/run_with_contract_config.go:67 +0x1f9
  github.com/smartcontractkit/libocr/subprocesses.(*Subprocesses).Go.func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/subprocesses/subprocesses.go:29 +0x73

Previous write at 0x00c0059d4990 by goroutine 209:
  [failed to restore the stack]

Goroutine 421 (running) created at:
  github.com/smartcontractkit/libocr/subprocesses.(*Subprocesses).Go()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/subprocesses/subprocesses.go:27 +0xdc
  github.com/smartcontractkit/libocr/offchainreporting2/internal/managed.(*runWithContractConfigState).run()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/internal/managed/run_with_contract_config.go:66 +0x144
  github.com/smartcontractkit/libocr/offchainreporting2/internal/managed.runWithContractConfig()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/internal/managed/run_with_contract_config.go:40 +0x1f8
  github.com/smartcontractkit/libocr/offchainreporting2/internal/managed.RunManagedOracle()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/internal/managed/managed_oracle.go:54 +0x7d2
  github.com/smartcontractkit/libocr/offchainreporting2.(*Oracle).Start.func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/offchainreporting2/oracle.go:114 +0x418
  github.com/smartcontractkit/libocr/subprocesses.(*Subprocesses).Go.func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20220812191430-db92a9fdaa52/subprocesses/subprocesses.go:29 +0x73

Goroutine 209 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x724
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1839 +0x99
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.runTests()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1837 +0x7e4
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1719 +0xa71
  main.main()
      _testmain.go:59 +0x2e4
==================
```
</details>