### PR TITLE
core/services/vrf: fix listenerV1.blockNumberToReqID race

### DIFF
--- a/core/services/vrf/listener_v1.go
+++ b/core/services/vrf/listener_v1.go
@@ -268,11 +268,11 @@ func (lsn *listenerV1) handleLog(lb log.Broadcast, minConfs uint32) {
 		}
 		lsn.respCountMu.Lock()
 		lsn.respCount[v.RequestId]++
-		lsn.respCountMu.Unlock()
 		lsn.blockNumberToReqID.Insert(fulfilledReq{
 			blockNumber: v.Raw.BlockNumber,
 			reqID:       v.RequestId,
 		})
+		lsn.respCountMu.Unlock()
 		lsn.markLogAsConsumed(lb)
 		return
 	}


### PR DESCRIPTION
<details><summary>Race Details</summary>

```
==================
WARNING: DATA RACE
Read at 0x00c004021bd8 by goroutine 111:
  github.com/theodesp/go-heaps/pairing.(*PairHeap).IsEmpty()
      /home/runner/go/pkg/mod/github.com/theodesp/go-heaps@v0.0.0-20190520121037-88e35354fe0a/pairing/pairing_heap.go:105 +0xe4
  github.com/theodesp/go-heaps/pairing.(*PairHeap).FindMin()
      /home/runner/go/pkg/mod/github.com/theodesp/go-heaps@v0.0.0-20190520121037-88e35354fe0a/pairing/pairing_heap.go:116 +0x10b
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).pruneConfirmedRequestCounts()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:185 +0xa8
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runHeadListener.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:220 +0x22c
  github.com/smartcontractkit/chainlink/core/recovery.WrapRecover()
      /home/runner/work/chainlink/chainlink/core/recovery/recover.go:27 +0x90
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runHeadListener()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:209 +0x12b
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1.2()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:139 +0x47

Previous write at 0x00c004021bd8 by goroutine 73:
  github.com/theodesp/go-heaps/pairing.(*PairHeap).Insert()
      /home/runner/go/pkg/mod/github.com/theodesp/go-heaps@v0.0.0-20190520121037-88e35354fe0a/pairing/pairing_heap.go:125 +0x1a47
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).handleLog()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:272 +0x18b7
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runLogListener.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:246 +0x5c
  github.com/smartcontractkit/chainlink/core/recovery.WrapRecover()
      /home/runner/work/chainlink/chainlink/core/recovery/recover.go:27 +0x90
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runLogListener()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:245 +0x418
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1.1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:138 +0x72

Goroutine 111 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:139 +0xa32
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:866 +0xe6
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:109 +0x58
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).StartService()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:195 +0x11c1
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).CreateJob()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:234 +0x87b
  github.com/smartcontractkit/chainlink/core/services/vrf_test.TestIntegration_VRF_JPV2.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/integration_test.go:57 +0x849
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x47

Goroutine 73 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:138 +0x964
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:866 +0xe6
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:109 +0x58
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).StartService()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:195 +0x11c1
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).CreateJob()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:234 +0x87b
  github.com/smartcontractkit/chainlink/core/services/vrf_test.TestIntegration_VRF_JPV2.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/integration_test.go:57 +0x849
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x47
==================
==================
WARNING: DATA RACE
Read at 0x00c004ca8de0 by goroutine 111:
  github.com/theodesp/go-heaps/pairing.(*PairHeap).IsEmpty()
      /home/runner/go/pkg/mod/github.com/theodesp/go-heaps@v0.0.0-20190520121037-88e35354fe0a/pairing/pairing_heap.go:105 +0xfe
  github.com/theodesp/go-heaps/pairing.(*PairHeap).FindMin()
      /home/runner/go/pkg/mod/github.com/theodesp/go-heaps@v0.0.0-20190520121037-88e35354fe0a/pairing/pairing_heap.go:116 +0x10b
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).pruneConfirmedRequestCounts()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:185 +0xa8
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runHeadListener.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:220 +0x22c
  github.com/smartcontractkit/chainlink/core/recovery.WrapRecover()
      /home/runner/work/chainlink/chainlink/core/recovery/recover.go:27 +0x90
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runHeadListener()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:209 +0x12b
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1.2()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:139 +0x47

Previous write at 0x00c004ca8de0 by goroutine 73:
  github.com/theodesp/go-heaps/pairing.(*PairHeap).Insert()
      /home/runner/go/pkg/mod/github.com/theodesp/go-heaps@v0.0.0-20190520121037-88e35354fe0a/pairing/pairing_heap.go:125 +0x198a
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).handleLog()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:272 +0x18b7
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runLogListener.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:246 +0x5c
  github.com/smartcontractkit/chainlink/core/recovery.WrapRecover()
      /home/runner/work/chainlink/chainlink/core/recovery/recover.go:27 +0x90
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runLogListener()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:245 +0x418
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1.1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:138 +0x72

Goroutine 111 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:139 +0xa32
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:866 +0xe6
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:109 +0x58
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).StartService()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:195 +0x11c1
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).CreateJob()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:234 +0x87b
  github.com/smartcontractkit/chainlink/core/services/vrf_test.TestIntegration_VRF_JPV2.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/integration_test.go:57 +0x849
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x47

Goroutine 73 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:138 +0x964
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:866 +0xe6
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:109 +0x58
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).StartService()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:195 +0x11c1
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).CreateJob()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:234 +0x87b
  github.com/smartcontractkit/chainlink/core/services/vrf_test.TestIntegration_VRF_JPV2.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/integration_test.go:57 +0x849
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x47
==================
==================
WARNING: DATA RACE
Read at 0x00c004ca8df0 by goroutine 111:
  github.com/theodesp/go-heaps/pairing.(*PairHeap).deleteItem()
      /home/runner/go/pkg/mod/github.com/theodesp/go-heaps@v0.0.0-20190520121037-88e35354fe0a/pairing/pairing_heap.go:153 +0xa4
  github.com/theodesp/go-heaps/pairing.(*PairHeap).DeleteMin()
      /home/runner/go/pkg/mod/github.com/theodesp/go-heaps@v0.0.0-20190520121037-88e35354fe0a/pairing/pairing_heap.go:141 +0x278
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).pruneConfirmedRequestCounts()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:192 +0x24f
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runHeadListener.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:220 +0x22c
  github.com/smartcontractkit/chainlink/core/recovery.WrapRecover()
      /home/runner/work/chainlink/chainlink/core/recovery/recover.go:27 +0x90
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runHeadListener()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:209 +0x12b
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1.2()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:139 +0x47

Previous write at 0x00c004ca8df0 by goroutine 73:
  github.com/theodesp/go-heaps/pairing.(*PairHeap).Insert()
      /home/runner/go/pkg/mod/github.com/theodesp/go-heaps@v0.0.0-20190520121037-88e35354fe0a/pairing/pairing_heap.go:125 +0x198a
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).handleLog()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:272 +0x18b7
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runLogListener.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:246 +0x5c
  github.com/smartcontractkit/chainlink/core/recovery.WrapRecover()
      /home/runner/work/chainlink/chainlink/core/recovery/recover.go:27 +0x90
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runLogListener()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:245 +0x418
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1.1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:138 +0x72

Goroutine 111 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:139 +0xa32
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:866 +0xe6
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:109 +0x58
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).StartService()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:195 +0x11c1
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).CreateJob()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:234 +0x87b
  github.com/smartcontractkit/chainlink/core/services/vrf_test.TestIntegration_VRF_JPV2.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/integration_test.go:57 +0x849
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x47

Goroutine 73 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:138 +0x964
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:866 +0xe6
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:109 +0x58
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).StartService()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:195 +0x11c1
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).CreateJob()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:234 +0x87b
  github.com/smartcontractkit/chainlink/core/services/vrf_test.TestIntegration_VRF_JPV2.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/integration_test.go:57 +0x849
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x47
==================
==================
WARNING: DATA RACE
Read at 0x00c004ca8de8 by goroutine 111:
  runtime.racereadrange()
      <autogenerated>:1 +0x1b
  github.com/theodesp/go-heaps/pairing.(*PairHeap).DeleteMin()
      /home/runner/go/pkg/mod/github.com/theodesp/go-heaps@v0.0.0-20190520121037-88e35354fe0a/pairing/pairing_heap.go:141 +0x278
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).pruneConfirmedRequestCounts()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:192 +0x24f
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runHeadListener.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:220 +0x22c
  github.com/smartcontractkit/chainlink/core/recovery.WrapRecover()
      /home/runner/work/chainlink/chainlink/core/recovery/recover.go:27 +0x90
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runHeadListener()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:209 +0x12b
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1.2()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:139 +0x47

Previous write at 0x00c004ca8de8 by goroutine 73:
  github.com/theodesp/go-heaps/pairing.(*PairHeap).Insert()
      /home/runner/go/pkg/mod/github.com/theodesp/go-heaps@v0.0.0-20190520121037-88e35354fe0a/pairing/pairing_heap.go:125 +0x198a
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).handleLog()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:272 +0x18b7
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runLogListener.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:246 +0x5c
  github.com/smartcontractkit/chainlink/core/recovery.WrapRecover()
      /home/runner/work/chainlink/chainlink/core/recovery/recover.go:27 +0x90
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).runLogListener()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:245 +0x418
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1.1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:138 +0x72

Goroutine 111 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:139 +0xa32
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:866 +0xe6
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:109 +0x58
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).StartService()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:195 +0x11c1
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).CreateJob()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:234 +0x87b
  github.com/smartcontractkit/chainlink/core/services/vrf_test.TestIntegration_VRF_JPV2.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/integration_test.go:57 +0x849
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x47

Goroutine 73 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:138 +0x964
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:866 +0xe6
  github.com/smartcontractkit/chainlink/core/services/vrf.(*listenerV1).Start()
      /home/runner/work/chainlink/chainlink/core/services/vrf/listener_v1.go:109 +0x58
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).StartService()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:195 +0x11c1
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).CreateJob()
      /home/runner/work/chainlink/chainlink/core/services/job/spawner.go:234 +0x87b
  github.com/smartcontractkit/chainlink/core/services/vrf_test.TestIntegration_VRF_JPV2.func1()
      /home/runner/work/chainlink/chainlink/core/services/vrf/integration_test.go:57 +0x849
  testing.tRunner()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1439 +0x213
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.18.5/x64/src/testing/testing.go:1486 +0x47
==================
```
</details>
https://github.com/smartcontractkit/chainlink/actions/runs/2960423399