### PR TITLE
Automatic fallback to RoundRobin

### DIFF
--- a/core/chains/evm/client/node_lifecycle.go
+++ b/core/chains/evm/client/node_lifecycle.go
@@ -108,10 +108,6 @@ func (n *node) aliveLoop() {
 		subErrC = sub.Err()
 	} else {
 		lggr.Debug("Head liveness checking disabled")
-
-		if n.cfg.NodeSelectionMode() == NodeSelectionMode_HighestHead {
-			lggr.Error("NODE_SELECTION_MODE=HighestHead requires NODE_NO_NEW_HEADS_THRESHOLD to be configured")
-		}
 	}
 
 	var pollCh <-chan time.Time

--- a/core/chains/evm/client/node_selector_highest_head.go
+++ b/core/chains/evm/client/node_selector_highest_head.go
@@ -49,3 +49,7 @@ func (s *highestHeadNodeSelector) Select() Node {
 
 	return node
 }
+
+func (s *highestHeadNodeSelector) Name() string {
+	return NodeSelectionMode_HighestHead
+}

--- a/core/chains/evm/client/node_selector_round_robin.go
+++ b/core/chains/evm/client/node_selector_round_robin.go
@@ -32,3 +32,7 @@ func (s *roundRobinSelector) Select() Node {
 
 	return liveNodes[idx]
 }
+
+func (s roundRobinSelector) Name() string {
+	return NodeSelectionMode_RoundRobin
+}

--- a/core/chains/evm/client/pool.go
+++ b/core/chains/evm/client/pool.go
@@ -38,11 +38,14 @@ type NodeSelector interface {
 	// Select() returns a Node, or nil if none can be selected.
 	// Implementation must be thread-safe.
 	Select() Node
+	// Name() returns the strategy name, e.g. "HighestHead" or "RoundRobin"
+	Name() string
 }
 
 // PoolConfig represents settings for the Pool
 type PoolConfig interface {
 	NodeSelectionMode() string
+	NodeNoNewHeadsThreshold() time.Duration
 }
 
 // Pool represents an abstraction over one or more primary nodes
@@ -76,12 +79,19 @@ func NewPool(logger logger.Logger, cfg PoolConfig, nodes []Node, sendonlys []Sen
 		}
 	}()
 
+	lggr := logger.Named("Pool").With("evmChainID", chainID.String())
+
+	if cfg.NodeNoNewHeadsThreshold() == 0 && cfg.NodeSelectionMode() == NodeSelectionMode_HighestHead {
+		lggr.Warn("NODE_SELECTION_MODE=HighestHead will not work for NODE_NO_NEW_HEADS_THRESHOLD=0, the pool will use RoundRobin mode.")
+		nodeSelector = NewRoundRobinSelector(nodes)
+	}
+
 	p := &Pool{
 		utils.StartStopOnce{},
 		nodes,
 		sendonlys,
 		chainID,
-		logger.Named("Pool").With("evmChainID", chainID.String()),
+		lggr,
 		cfg,
 		nodeSelector,
 		make(chan struct{}),
@@ -232,7 +242,7 @@ func (p *Pool) selectNode() Node {
 	node := p.nodeSelector.Select()
 
 	if node == nil {
-		p.logger.Criticalw("No live RPC nodes available", "NodeSelectionMode", p.config.NodeSelectionMode())
+		p.logger.Criticalw("No live RPC nodes available", "NodeSelectionMode", p.nodeSelector.Name())
 		return &erroringNode{errMsg: fmt.Sprintf("no live nodes available for chain %s", p.chainID.String())}
 	}
 

--- a/core/chains/evm/client/pool_test.go
+++ b/core/chains/evm/client/pool_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"testing"
+	"time"
 
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
@@ -24,15 +25,21 @@ import (
 )
 
 type poolConfig struct {
-	selectionMode string
+	selectionMode       string
+	noNewHeadsThreshold time.Duration
 }
 
 func (c poolConfig) NodeSelectionMode() string {
 	return c.selectionMode
 }
 
+func (c poolConfig) NodeNoNewHeadsThreshold() time.Duration {
+	return c.noNewHeadsThreshold
+}
+
 var defaultConfig evmclient.PoolConfig = &poolConfig{
-	selectionMode: evmclient.NodeSelectionMode_RoundRobin,
+	selectionMode:       evmclient.NodeSelectionMode_RoundRobin,
+	noNewHeadsThreshold: 0,
 }
 
 func TestPool_Dial(t *testing.T) {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -21,7 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `NODE_SELECTION_MODE` (`EVM.NodePool.SelectionMode`) controls node picking strategy. Supported values: `HighestHead` (default) and `RoundRobin`:
   - `RoundRobin` mode simply iterates among available alive nodes. This was the default behavior prior to this release.
   - `HighestHead` mode picks a node having the highest reported head number among other alive nodes. When several nodes have the same latest head number, the strategy sticks to the last used node.
-  This mode requires `NODE_NO_NEW_HEADS_THRESHOLD` to be configured, otherwise it will always use the first alive node.
+  For chains having `NODE_NO_NEW_HEADS_THRESHOLD=0` (such as Arbitrum, Optimism), the implementation will fall back to `RoundRobin` mode.
 - New `keys eth chain` command
   - This can also be accessed at `/v2/keys/evm/chain`.
   - Usage examples:


### PR DESCRIPTION
To prevent the error message when `NodeSelectionMode=HighestHead` and `NoNewHeadsThreshold=0` are set, the idea is to fall back to `RoundRobin` (with a warning message), because `HighestHead` makes little sense for chains having `NoNewHeadsThreshold=0`.