### PR TITLE
Optimize docker container build

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -47,12 +47,6 @@ chainlink-build: ## Build & install the chainlink binary.
 
 .PHONY: operator-ui
 operator-ui: ## Build the static frontend UI.
-	yarn setup:chainlink
-	CHAINLINK_VERSION="$(VERSION)@$(COMMIT_SHA)" yarn workspace @chainlink/operator-ui build
-
-.PHONY: contracts-operator-ui-build
-contracts-operator-ui-build: # Only compiles tsc and builds contracts and operator-ui.
-	yarn setup:chainlink
 	CHAINLINK_VERSION="$(VERSION)@$(COMMIT_SHA)" yarn workspace @chainlink/operator-ui build
 
 .PHONY: abigen

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -23,8 +23,8 @@ COPY operator_ui ./operator_ui
 # Create the directory that the operator-ui build assets will be placed in.
 RUN mkdir -p core/web
 
-# Build operator-ui and the smart contracts
-RUN make contracts-operator-ui-build
+# Build operator-ui 
+RUN make operator-ui
 
 # Build image: Chainlink binary
 FROM golang:1.18-buster as buildgo

--- a/operator_ui/package.json
+++ b/operator_ui/package.json
@@ -13,6 +13,7 @@
     "test:ci": "yarn test --reporters jest-silent-reporter --maxWorkers=50%",
     "watch": "yarn test --watchAll --notify",
     "clean": "tsc -b --clean && rimraf -rf artifacts tmp dist",
+    "prebuild": "yarn generate",
     "build": "NODE_ENV=production webpack --config webpack.prod.js",
     "presetup": "yarn generate",
     "setup": "tsc -b",


### PR DESCRIPTION
I noticed that we dont seem to use anything related to hardhat output nor abi output, since we always checkin the latest `go generate` output from abi files, and they're enforced via our go unit tests.

This makes our builds around 15% faster, and reduces the docker build logging output by 35%