### PR TITLE
keepers ocr gas optimisation

### DIFF
--- a/contracts/src/v0.8/dev/keeper2_0/KeeperRegistry2_0.sol
+++ b/contracts/src/v0.8/dev/keeper2_0/KeeperRegistry2_0.sol
@@ -161,11 +161,11 @@ contract KeeperRegistry2_0 is
     // This is the overall gas overhead that will be split across performed upkeeps
     // Take upper bound of 16 gas per callData bytes, which is approximated to be reportLength
     // Rest of msg.data is accounted for in accounting overheads
-    gasOverhead = (gasOverhead - gasleft() + 16 * report.length) + ACCOUNTING_GAS_FIXED_OVERHEAD;
+    gasOverhead = (gasOverhead - gasleft() + 16 * report.length) + ACCOUNTING_FIXED_GAS_OVERHEAD;
     if (!upkeepTransmitInfo[0].upkeep.skipSigVerification) {
-      gasOverhead += ACCOUNTING_GAS_FIXED_SIGN_TX_OVERHEAD + (ACCOUNTING_GAS_PER_SIGNER_OVERHEAD * (hotVars.f + 1));
+      gasOverhead += ACCOUNTING_FIXED_SIGN_TX_GAS_OVERHEAD + (ACCOUNTING_PER_SIGNER_GAS_OVERHEAD * (hotVars.f + 1));
     }
-    gasOverhead = gasOverhead / numUpkeepsPassedChecks + ACCOUNTING_GAS_PER_UPKEEP_OVERHEAD;
+    gasOverhead = gasOverhead / numUpkeepsPassedChecks + ACCOUNTING_PER_UPKEEP_GAS_OVERHEAD;
 
     uint96 upkeepPayment;
     uint96 totalPayment;

--- a/contracts/src/v0.8/dev/keeper2_0/KeeperRegistry2_0.sol
+++ b/contracts/src/v0.8/dev/keeper2_0/KeeperRegistry2_0.sol
@@ -132,7 +132,7 @@ contract KeeperRegistry2_0 is
     if (numUpkeepsPassedChecks == 0) revert StaleReport();
 
     if (!upkeepTransmitInfo[0].upkeep.skipSigVerification) {
-      if (hotVars.latestConfigDigest != reportContext[0]) revert ConfigDigestMismatch();
+      if (s_latestConfigDigest != reportContext[0]) revert ConfigDigestMismatch();
       if (rs.length != hotVars.f + 1 || rs.length != ss.length) revert IncorrectNumberOfSignatures();
       _verifyReportSignature(reportContext, report, rs, ss, rawVs);
     }
@@ -202,7 +202,7 @@ contract KeeperRegistry2_0 is
     if (!upkeepTransmitInfo[0].upkeep.skipSigVerification) {
       // Only emit event for signature verified reports
       uint40 epochAndRound = uint40(uint256(reportContext[1]));
-      emit Transmitted(hotVars.latestConfigDigest, uint32(epochAndRound >> 8));
+      emit Transmitted(s_latestConfigDigest, uint32(epochAndRound >> 8));
     }
   }
 
@@ -299,7 +299,6 @@ contract KeeperRegistry2_0 is
 
     s_hotVars = HotVars({
       f: f,
-      latestConfigDigest: s_hotVars.latestConfigDigest,
       paymentPremiumPPB: onchainConfigStruct.paymentPremiumPPB,
       flatFeeMicroLink: onchainConfigStruct.flatFeeMicroLink,
       stalenessSeconds: onchainConfigStruct.stalenessSeconds,
@@ -328,7 +327,7 @@ contract KeeperRegistry2_0 is
     s_storage.latestConfigBlockNumber = uint32(block.number);
     s_storage.configCount += 1;
 
-    s_hotVars.latestConfigDigest = _configDigestFromConfigData(
+    s_latestConfigDigest = _configDigestFromConfigData(
       block.chainid,
       address(this),
       s_storage.configCount,
@@ -342,7 +341,7 @@ contract KeeperRegistry2_0 is
 
     emit ConfigSet(
       previousConfigBlockNumber,
-      s_hotVars.latestConfigDigest,
+      s_latestConfigDigest,
       s_storage.configCount,
       signers,
       transmitters,
@@ -445,7 +444,7 @@ contract KeeperRegistry2_0 is
       numUpkeeps: s_upkeepIDs.length(),
       configCount: s_storage.configCount,
       latestConfigBlockNumber: s_storage.latestConfigBlockNumber,
-      latestConfigDigest: s_hotVars.latestConfigDigest,
+      latestConfigDigest: s_latestConfigDigest,
       paused: s_hotVars.paused
     });
 
@@ -524,7 +523,7 @@ contract KeeperRegistry2_0 is
       bytes32 configDigest
     )
   {
-    return (s_storage.configCount, s_storage.latestConfigBlockNumber, s_hotVars.latestConfigDigest);
+    return (s_storage.configCount, s_storage.latestConfigBlockNumber, s_latestConfigDigest);
   }
 
   /**

--- a/contracts/src/v0.8/dev/keeper2_0/KeeperRegistryBase2_0.sol
+++ b/contracts/src/v0.8/dev/keeper2_0/KeeperRegistryBase2_0.sol
@@ -33,8 +33,11 @@ abstract contract KeeperRegistryBase2_0 is ConfirmedOwner, ExecutionPrevention {
   // L1_FEE_DATA_PADDING includes 35 bytes for L1 data padding for Optimism
   bytes internal constant L1_FEE_DATA_PADDING =
     "0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
-  uint256 internal constant REGISTRY_GAS_OVERHEAD = 95_000; // Used only in maxPayment estimation, not in actual payment
+
+  uint256 internal constant REGISTRY_GAS_OVERHEAD = 90_000; // Used only in maxPayment estimation, not in actual payment
+  uint256 internal constant VERIFY_SIGN_TX_GAS_OVERHEAD = 5_000; // Used only in maxPayment estimation, not in actual payment
   uint256 internal constant VERIFY_PER_SIGNER_GAS_OVERHEAD = 7_500; // Used only in maxPayment estimation, not in actual payment. Value scales with f.
+
   uint256 internal constant ACCOUNTING_GAS_FIXED_OVERHEAD = 26_500; // Used in actual payment. Fixed overhead per tx
   uint256 internal constant ACCOUNTING_GAS_FIXED_SIGN_TX_OVERHEAD = 2_000; // Used in actual payment. fixed overhead for sig verified tx
   uint256 internal constant ACCOUNTING_GAS_PER_UPKEEP_OVERHEAD = 5_500; // Used in actual payment. overhead per upkeep performed
@@ -63,6 +66,7 @@ abstract contract KeeperRegistryBase2_0 is ConfirmedOwner, ExecutionPrevention {
   address[] internal s_transmittersList; // s_transmittersList contains the transmission address of each oracle
   mapping(address => address) internal s_transmitterPayees; // s_payees contains the mapping from transmitter to payee.
   mapping(address => address) internal s_proposedPayee; // proposed payee for a transmitter
+  bytes32 internal s_latestConfigDigest; // Read on transmit path in case of signature verification
   HotVars internal s_hotVars; // Mixture of config and state, used in transmit
   Storage internal s_storage; // Mixture of config and state, not used in transmit
   uint256 internal s_fallbackGasPrice;
@@ -140,14 +144,13 @@ abstract contract KeeperRegistryBase2_0 is ConfirmedOwner, ExecutionPrevention {
   // Config + State storage struct which is on hot transmit path
   struct HotVars {
     uint8 f; // maximum number of faulty oracles
-    bytes32 latestConfigDigest; // latest config digest which is checked against every report
     uint32 paymentPremiumPPB; // premium percentage charged to user over tx cost
     uint32 flatFeeMicroLink; // flat fee charged to user for every perform
     uint24 stalenessSeconds; // Staleness tolerance for feeds
     uint16 gasCeilingMultiplier; // multiplier on top of fast gas feed for upper bound
     bool paused; // pause switch for all upkeeps in the registry
     bool reentrancyGuard; // guard against reentrancy
-    // 12 bytes to 1 EVM word
+    // 16 bytes to 1 EVM word
   }
 
   // Config + State storage struct which is not on hot transmit path
@@ -412,7 +415,12 @@ abstract contract KeeperRegistryBase2_0 is ConfirmedOwner, ExecutionPrevention {
     if (skipSigVerification) {
       return REGISTRY_GAS_OVERHEAD + 16 * performDataLength;
     }
-    return REGISTRY_GAS_OVERHEAD + (VERIFY_PER_SIGNER_GAS_OVERHEAD * (f + 1)) + 16 * performDataLength;
+    return
+      REGISTRY_GAS_OVERHEAD +
+      VERIFY_SIGN_TX_GAS_OVERHEAD +
+      (VERIFY_PER_SIGNER_GAS_OVERHEAD * (f + 1)) +
+      16 *
+      performDataLength;
   }
 
   /**

--- a/contracts/src/v0.8/dev/keeper2_0/KeeperRegistryBase2_0.sol
+++ b/contracts/src/v0.8/dev/keeper2_0/KeeperRegistryBase2_0.sol
@@ -38,10 +38,10 @@ abstract contract KeeperRegistryBase2_0 is ConfirmedOwner, ExecutionPrevention {
   uint256 internal constant VERIFY_SIGN_TX_GAS_OVERHEAD = 5_000; // Used only in maxPayment estimation, not in actual payment
   uint256 internal constant VERIFY_PER_SIGNER_GAS_OVERHEAD = 7_500; // Used only in maxPayment estimation, not in actual payment. Value scales with f.
 
-  uint256 internal constant ACCOUNTING_GAS_FIXED_OVERHEAD = 26_500; // Used in actual payment. Fixed overhead per tx
-  uint256 internal constant ACCOUNTING_GAS_FIXED_SIGN_TX_OVERHEAD = 2_000; // Used in actual payment. fixed overhead for sig verified tx
-  uint256 internal constant ACCOUNTING_GAS_PER_UPKEEP_OVERHEAD = 5_500; // Used in actual payment. overhead per upkeep performed
-  uint256 internal constant ACCOUNTING_GAS_PER_SIGNER_OVERHEAD = 1_100; // Used in actual payment. overhead per signer
+  uint256 internal constant ACCOUNTING_FIXED_GAS_OVERHEAD = 26_500; // Used in actual payment. Fixed overhead per tx
+  uint256 internal constant ACCOUNTING_FIXED_SIGN_TX_GAS_OVERHEAD = 2_000; // Used in actual payment. fixed overhead for sig verified tx
+  uint256 internal constant ACCOUNTING_PER_UPKEEP_GAS_OVERHEAD = 5_500; // Used in actual payment. overhead per upkeep performed
+  uint256 internal constant ACCOUNTING_PER_SIGNER_GAS_OVERHEAD = 1_100; // Used in actual payment. overhead per signer
 
   OVM_GasPriceOracle internal constant OPTIMISM_ORACLE = OVM_GasPriceOracle(0x420000000000000000000000000000000000000F);
   ArbGasInfo internal constant ARB_NITRO_ORACLE = ArbGasInfo(0x000000000000000000000000000000000000006C);

--- a/contracts/test/v0.8/dev/keeper2_0/KeeperRegistry2_0.test.ts
+++ b/contracts/test/v0.8/dev/keeper2_0/KeeperRegistry2_0.test.ts
@@ -38,7 +38,8 @@ const transmitGasOverhead = BigNumber.from(800000)
 const checkGasOverhead = BigNumber.from(400000)
 
 // These values should match the constants declared in registry
-const registryGasOverhead = BigNumber.from(95000)
+const registryGasOverhead = BigNumber.from(90000)
+const verifySignTxGasOverhead = BigNumber.from(5000)
 const verifyPerSignerGasOverhead = BigNumber.from(7500)
 const cancellationDelay = 50
 
@@ -321,6 +322,7 @@ describe('KeeperRegistry2_0', () => {
 
     let fPlusOne = BigNumber.from(f + 1)
     let totalGasOverhead = registryGasOverhead
+      .add(verifySignTxGasOverhead)
       .add(verifyPerSignerGasOverhead.mul(fPlusOne))
       .add(BigNumber.from('16').mul(maxPerformDataSize))
 
@@ -2044,6 +2046,7 @@ describe('KeeperRegistry2_0', () => {
                   assert.isTrue(
                     gasOverhead.lt(
                       registryGasOverhead
+                        .add(verifySignTxGasOverhead)
                         .add(
                           verifyPerSignerGasOverhead.mul(
                             BigNumber.from(newF + 1),
@@ -2347,9 +2350,11 @@ describe('KeeperRegistry2_0', () => {
 
                   let gasOverheadCap = registryGasOverhead // 0 performData length
                   if (sigVerification) {
-                    gasOverheadCap = gasOverheadCap.add(
-                      verifyPerSignerGasOverhead.mul(BigNumber.from(f + 1)),
-                    )
+                    gasOverheadCap = gasOverheadCap
+                      .add(verifySignTxGasOverhead)
+                      .add(
+                        verifyPerSignerGasOverhead.mul(BigNumber.from(f + 1)),
+                      )
                   }
                   let overheadCanGetCapped =
                     numPassingUpkeeps == 1 && numFailingUpkeeps > 0


### PR DESCRIPTION
Take out config digest out of hot vars

- Save 4K gas on skip sig verification path
- Save 2K gas on sig verification path