### PR TITLE
Optimise gas usage in keepers OCR

### DIFF
--- a/contracts/src/v0.8/dev/keeper2_0/KeeperRegistry2_0.sol
+++ b/contracts/src/v0.8/dev/keeper2_0/KeeperRegistry2_0.sol
@@ -78,7 +78,7 @@ contract KeeperRegistry2_0 is
   struct UpkeepTransmitInfo {
     Upkeep upkeep;
     bool earlyChecksPassed;
-    PerformPaymentParams paymentParams;
+    uint96 maxLinkPayment;
     bool performSuccess;
     uint256 gasUsed;
     uint256 gasOverhead;
@@ -107,9 +107,9 @@ contract KeeperRegistry2_0 is
     for (uint256 i = 0; i < parsedReport.upkeepIds.length; i++) {
       upkeepTransmitInfo[i].upkeep = s_upkeep[parsedReport.upkeepIds[i]];
 
-      upkeepTransmitInfo[i].paymentParams = _generatePerformPaymentParams(
-        upkeepTransmitInfo[i].upkeep,
+      upkeepTransmitInfo[i].maxLinkPayment = _getMaxLinkPayment(
         hotVars,
+        upkeepTransmitInfo[i].upkeep.executeGas,
         uint32(parsedReport.wrappedPerformDatas[i].performData.length),
         parsedReport.fastGasWei,
         parsedReport.linkNative,
@@ -119,7 +119,7 @@ contract KeeperRegistry2_0 is
         parsedReport.upkeepIds[i],
         parsedReport.wrappedPerformDatas[i],
         upkeepTransmitInfo[i].upkeep,
-        upkeepTransmitInfo[i].paymentParams
+        upkeepTransmitInfo[i].maxLinkPayment
       );
 
       if (upkeepTransmitInfo[i].earlyChecksPassed) {
@@ -182,6 +182,8 @@ contract KeeperRegistry2_0 is
             hotVars,
             parsedReport.upkeepIds[i],
             upkeepTransmitInfo[i],
+            parsedReport.fastGasWei,
+            parsedReport.linkNative,
             numUpkeepsPassedChecks
           );
           totalPremium += premium;
@@ -505,21 +507,10 @@ contract KeeperRegistry2_0 is
    * @notice calculates the maximum payment for a given gas limit
    * @param gasLimit the gas to calculate payment for
    */
-  function getMaxPaymentForGas(uint256 gasLimit) public view returns (uint96 maxPayment) {
+  function getMaxPaymentForGas(uint32 gasLimit) public view returns (uint96 maxPayment) {
     HotVars memory hotVars = s_hotVars;
     (uint256 fastGasWei, uint256 linkNative) = _getFeedData(hotVars);
-    uint256 gasOverhead = _getMaxGasOverhead(s_storage.maxPerformDataSize, hotVars.f);
-
-    (uint96 gasReimbursement, uint96 premium) = _calculatePaymentAmount(
-      hotVars,
-      gasLimit,
-      gasOverhead,
-      fastGasWei,
-      linkNative,
-      1, // Consider only 1 upkeep in batch to get maxPayment
-      false
-    );
-    return gasReimbursement + premium;
+    return _getMaxLinkPayment(hotVars, gasLimit, s_storage.maxPerformDataSize, fastGasWei, linkNative, false);
   }
 
   /**
@@ -638,7 +629,7 @@ contract KeeperRegistry2_0 is
     uint256 upkeepId,
     PerformDataWrapper memory wrappedPerformData,
     Upkeep memory upkeep,
-    PerformPaymentParams memory paymentParams
+    uint96 maxLinkPayment
   ) internal returns (bool) {
     if (wrappedPerformData.checkBlockNumber < upkeep.lastPerformBlockNumber) {
       // Can happen when another report performed this upkeep after this report was generated
@@ -661,7 +652,7 @@ contract KeeperRegistry2_0 is
       return false;
     }
 
-    if (upkeep.balance < paymentParams.maxLinkPayment) {
+    if (upkeep.balance < maxLinkPayment) {
       // Can happen due to flucutations in gas / link prices
       emit InsufficientFundsUpkeepReport(upkeepId);
       return false;
@@ -723,14 +714,16 @@ contract KeeperRegistry2_0 is
     HotVars memory hotVars,
     uint256 upkeepId,
     UpkeepTransmitInfo memory upkeepTransmitInfo,
+    uint256 fastGasWei,
+    uint256 linkNative,
     uint16 numBatchedUpkeeps
   ) internal returns (uint96 gasReimbursement, uint96 premium) {
     (gasReimbursement, premium) = _calculatePaymentAmount(
       hotVars,
       upkeepTransmitInfo.gasUsed,
       upkeepTransmitInfo.gasOverhead,
-      upkeepTransmitInfo.paymentParams.fastGasWei,
-      upkeepTransmitInfo.paymentParams.linkNative,
+      fastGasWei,
+      linkNative,
       numBatchedUpkeeps,
       true
     );

--- a/contracts/src/v0.8/dev/keeper2_0/KeeperRegistry2_0.sol
+++ b/contracts/src/v0.8/dev/keeper2_0/KeeperRegistry2_0.sol
@@ -205,7 +205,10 @@ contract KeeperRegistry2_0 is
     s_hotVars.totalPremium += totalPremium;
 
     uint40 epochAndRound = uint40(uint256(reportContext[1]));
-    emit Transmitted(s_latestConfigDigest, uint32(epochAndRound >> 8));
+    uint32 epoch = uint32(epochAndRound >> 8);
+    if (epoch > hotVars.latestEpoch) {
+      s_hotVars.latestEpoch = epoch;
+    }
   }
 
   /**
@@ -321,7 +324,8 @@ contract KeeperRegistry2_0 is
       gasCeilingMultiplier: onchainConfigStruct.gasCeilingMultiplier,
       paused: false,
       reentrancyGuard: false,
-      totalPremium: totalPremium
+      totalPremium: totalPremium,
+      latestEpoch: 0
     });
 
     s_storage = Storage({
@@ -473,6 +477,7 @@ contract KeeperRegistry2_0 is
       configCount: s_storage.configCount,
       latestConfigBlockNumber: s_storage.latestConfigBlockNumber,
       latestConfigDigest: s_latestConfigDigest,
+      latestEpoch: s_hotVars.latestEpoch,
       paused: s_hotVars.paused
     });
 
@@ -556,7 +561,7 @@ contract KeeperRegistry2_0 is
       uint32 epoch
     )
   {
-    return (true, configDigest, epoch);
+    return (false, s_latestConfigDigest, s_hotVars.latestEpoch);
   }
 
   ////////

--- a/contracts/src/v0.8/dev/keeper2_0/KeeperRegistryBase2_0.sol
+++ b/contracts/src/v0.8/dev/keeper2_0/KeeperRegistryBase2_0.sol
@@ -37,7 +37,7 @@ abstract contract KeeperRegistryBase2_0 is ConfirmedOwner, ExecutionPrevention {
   uint256 internal constant REGISTRY_GAS_OVERHEAD = 85_000; // Used only in maxPayment estimation, not in actual payment
   uint256 internal constant REGISTRY_PER_SIGNER_GAS_OVERHEAD = 7_500; // Used only in maxPayment estimation, not in actual payment. Value scales with f.
 
-  uint256 internal constant ACCOUNTING_FIXED_GAS_OVERHEAD = 30_000; // Used in actual payment. Fixed overhead per tx
+  uint256 internal constant ACCOUNTING_FIXED_GAS_OVERHEAD = 27_000; // Used in actual payment. Fixed overhead per tx
   uint256 internal constant ACCOUNTING_PER_SIGNER_GAS_OVERHEAD = 1_100; // Used in actual payment. overhead per signer
   uint256 internal constant ACCOUNTING_PER_UPKEEP_GAS_OVERHEAD = 5_800; // Used in actual payment. overhead per upkeep performed
 
@@ -206,15 +206,15 @@ abstract contract KeeperRegistryBase2_0 is ConfirmedOwner, ExecutionPrevention {
    * @member paused if this upkeep has been paused
    */
   struct Upkeep {
-    uint96 balance;
-    address target;
-    // 1 full EVM word
-    uint96 amountSpent;
     uint32 executeGas;
     uint32 maxValidBlocknumber;
-    uint32 lastPerformBlockNumber;
     bool paused;
-    // 7 bytes left in 2nd EVM word
+    address target;
+    // 3 bytes left in 1st EVM word - not written to in transmit
+    uint96 amountSpent;
+    uint96 balance;
+    uint32 lastPerformBlockNumber;
+    // 4 bytes left in 2nd EVM word - written in transmit path
   }
 
   event FundsAdded(uint256 indexed id, address indexed from, uint96 amount);

--- a/contracts/src/v0.8/dev/keeper2_0/KeeperRegistryBase2_0.sol
+++ b/contracts/src/v0.8/dev/keeper2_0/KeeperRegistryBase2_0.sol
@@ -37,7 +37,7 @@ abstract contract KeeperRegistryBase2_0 is ConfirmedOwner, ExecutionPrevention {
   uint256 internal constant REGISTRY_GAS_OVERHEAD = 85_000; // Used only in maxPayment estimation, not in actual payment
   uint256 internal constant REGISTRY_PER_SIGNER_GAS_OVERHEAD = 7_500; // Used only in maxPayment estimation, not in actual payment. Value scales with f.
 
-  uint256 internal constant ACCOUNTING_FIXED_GAS_OVERHEAD = 32_000; // Used in actual payment. Fixed overhead per tx
+  uint256 internal constant ACCOUNTING_FIXED_GAS_OVERHEAD = 30_000; // Used in actual payment. Fixed overhead per tx
   uint256 internal constant ACCOUNTING_PER_SIGNER_GAS_OVERHEAD = 1_100; // Used in actual payment. overhead per signer
   uint256 internal constant ACCOUNTING_PER_UPKEEP_GAS_OVERHEAD = 5_800; // Used in actual payment. overhead per upkeep performed
 
@@ -144,7 +144,8 @@ abstract contract KeeperRegistryBase2_0 is ConfirmedOwner, ExecutionPrevention {
     bool paused; // pause switch for all upkeeps in the registry
     bool reentrancyGuard; // guard against reentrancy
     uint96 totalPremium; // total historical payment to oracles for premium
-    // 4 bytes to 1 EVM word
+    uint32 latestEpoch; // latest epoch for which a report was transmitted
+    // 1 EVM word full
   }
 
   // Config + State storage struct which is not on hot transmit path

--- a/contracts/src/v0.8/dev/keeper2_0/KeeperRegistryBase2_0.sol
+++ b/contracts/src/v0.8/dev/keeper2_0/KeeperRegistryBase2_0.sol
@@ -134,12 +134,6 @@ abstract contract KeeperRegistryBase2_0 is ConfirmedOwner, ExecutionPrevention {
     OPTIMISM
   }
 
-  struct PerformPaymentParams {
-    uint256 fastGasWei;
-    uint256 linkNative;
-    uint256 maxLinkPayment;
-  }
-
   // Config + State storage struct which is on hot transmit path
   struct HotVars {
     uint8 f; // maximum number of faulty oracles
@@ -382,20 +376,20 @@ abstract contract KeeperRegistryBase2_0 is ConfirmedOwner, ExecutionPrevention {
   }
 
   /**
-   * @dev generates a PerformPaymentParams struct containing payment information for an upkeep
+   * @dev generates the max link payment for an upkeep
    */
-  function _generatePerformPaymentParams(
-    Upkeep memory upkeep,
+  function _getMaxLinkPayment(
     HotVars memory hotVars,
+    uint32 executeGas,
     uint32 performDataLength,
     uint256 fastGasWei,
     uint256 linkNative,
     bool isExecution // Whether this is an actual perform execution or just a simulation
-  ) internal view returns (PerformPaymentParams memory) {
+  ) internal view returns (uint96) {
     uint256 gasOverhead = _getMaxGasOverhead(performDataLength, hotVars.f);
     (uint96 reimbursement, uint96 premium) = _calculatePaymentAmount(
       hotVars,
-      upkeep.executeGas,
+      executeGas,
       gasOverhead,
       fastGasWei,
       linkNative,
@@ -403,8 +397,7 @@ abstract contract KeeperRegistryBase2_0 is ConfirmedOwner, ExecutionPrevention {
       isExecution
     );
 
-    return
-      PerformPaymentParams({fastGasWei: fastGasWei, linkNative: linkNative, maxLinkPayment: (reimbursement + premium)});
+    return reimbursement + premium;
   }
 
   /**

--- a/contracts/src/v0.8/dev/keeper2_0/KeeperRegistryLogic2_0.sol
+++ b/contracts/src/v0.8/dev/keeper2_0/KeeperRegistryLogic2_0.sol
@@ -46,15 +46,15 @@ contract KeeperRegistryLogic2_0 is KeeperRegistryBase2_0 {
     if (upkeep.paused) return (false, bytes(""), UpkeepFailureReason.UPKEEP_PAUSED, gasUsed, 0, 0);
 
     (fastGasWei, linkNative) = _getFeedData(hotVars);
-    PerformPaymentParams memory paymentParams = _generatePerformPaymentParams(
-      upkeep,
+    uint96 maxLinkPayment = _getMaxLinkPayment(
       hotVars,
+      upkeep.executeGas,
       s_storage.maxPerformDataSize,
       fastGasWei,
       linkNative,
       false
     );
-    if (upkeep.balance < paymentParams.maxLinkPayment)
+    if (upkeep.balance < maxLinkPayment)
       return (false, bytes(""), UpkeepFailureReason.INSUFFICIENT_BALANCE, gasUsed, fastGasWei, linkNative);
 
     gasUsed = gasleft();

--- a/contracts/src/v0.8/dev/keeper2_0/interfaces/KeeperRegistryInterface2_0.sol
+++ b/contracts/src/v0.8/dev/keeper2_0/interfaces/KeeperRegistryInterface2_0.sol
@@ -48,6 +48,7 @@ struct OnchainConfig {
  * @member configCount ordinal number of current config, out of all configs applied to this contract so far
  * @member latestConfigBlockNumber last block at which this config was set
  * @member latestConfigDigest domain-separation tag for current config
+ * @member latestEpoch for which a report was transmitted
  * @member paused freeze on execution scoped to the entire registry
  */
 struct State {
@@ -59,6 +60,7 @@ struct State {
   uint32 configCount;
   uint32 latestConfigBlockNumber;
   bytes32 latestConfigDigest;
+  uint32 latestEpoch;
   bool paused;
 }
 

--- a/contracts/test/v0.8/dev/keeper2_0/KeeperRegistry2_0.test.ts
+++ b/contracts/test/v0.8/dev/keeper2_0/KeeperRegistry2_0.test.ts
@@ -1413,6 +1413,8 @@ describe('KeeperRegistry2_0', () => {
                     newF,
                     '): calculated overhead: ',
                     gasOverhead.toString(),
+                    ' actual overhead: ',
+                    receipt.gasUsed.sub(gasUsed).toString(),
                     ' margin over gasUsed: ',
                     gasUsed.add(gasOverhead).sub(receipt.gasUsed).toString(),
                   )

--- a/contracts/test/v0.8/dev/keeper2_0/KeeperRegistry2_0.test.ts
+++ b/contracts/test/v0.8/dev/keeper2_0/KeeperRegistry2_0.test.ts
@@ -1258,8 +1258,6 @@ describe('KeeperRegistry2_0', () => {
           const registryLinkBefore = await linkToken.balanceOf(registry.address)
 
           // Do the thing
-          const configDigest = (await registry.getState()).state
-            .latestConfigDigest
           const tx = await getTransmitTx(
             registry,
             keeper1,
@@ -1338,10 +1336,8 @@ describe('KeeperRegistry2_0', () => {
             tx.blockNumber?.toString(),
           )
 
-          // Epoch should be 5 as we used epochAndRound5_1
-          await expect(tx)
-            .to.emit(registry, 'Transmitted')
-            .withArgs(configDigest, 5)
+          // Latest epoch should be 5
+          assert.equal((await registry.getState()).state.latestEpoch, 5)
         }
       })
 
@@ -2761,6 +2757,7 @@ describe('KeeperRegistry2_0', () => {
         updatedConfig.fallbackLinkPrice.toNumber(),
         fbLinkEth.toNumber(),
       )
+      assert.equal(updatedState.latestEpoch, 0)
 
       assert(oldState.configCount + 1 == updatedState.configCount)
       assert(


### PR DESCRIPTION
1. Simplify PerformPaymentParams - no longer need it since we pass in feed values. Saves 250 gas
2. Do not emit transmitted event, instead store latest epoch and return it in latestConfigDigestAndEpoch - 1100 gas
3. optimise upkeep storage to minimise words written to - 2000 gas