### PR TITLE
golangci-lint: schedule nightly run

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -22,6 +22,8 @@ on:
       - '**/go.mod'
       - '**/go.sum'
       - '.golangci.yml'
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
   golangci:
@@ -44,7 +46,8 @@ jobs:
           go-version-file: 'go.mod'
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
-        if: github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release/'))
+        # any scheduled run or push, but skip PRs from release branches
+        if: github.event.schedule != '' || github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release/'))
         with:
           version: v1.49.0
-          only-new-issues: true # show only new issues if it's a pull request
+          only-new-issues: ${{github.event.schedule == ''}} # show only new issues, unless it's a scheduled run


### PR DESCRIPTION
Schedule a nightly run of `golangci-lint` w/o the 'new issues only' option, to better track technical debt and improve visibility of things that may have gotten past us.