### PR TITLE
chore: remove waitBlocks > finality depth check

### DIFF
--- a/core/services/blockhashstore/delegate.go
+++ b/core/services/blockhashstore/delegate.go
@@ -57,12 +57,6 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 			"getting chain ID %d: %w", jb.BlockhashStoreSpec.EVMChainID.ToInt(), err)
 	}
 
-	if jb.BlockhashStoreSpec.WaitBlocks < int32(chain.Config().EvmFinalityDepth()) {
-		return nil, fmt.Errorf(
-			"waitBlocks must be greater than or equal to chain's finality depth (%d), currently %d",
-			chain.Config().EvmFinalityDepth(), jb.BlockhashStoreSpec.WaitBlocks)
-	}
-
 	keys, err := d.ks.EnabledKeysForChain(chain.ID())
 	if err != nil {
 		return nil, errors.Wrap(err, "getting sending keys")

--- a/core/services/blockhashstore/delegate_test.go
+++ b/core/services/blockhashstore/delegate_test.go
@@ -106,14 +106,6 @@ func TestDelegate_ServicesForSpec(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("WaitBlocks less than EvmFinalityDepth", func(t *testing.T) {
-		spec := job.Job{BlockhashStoreSpec: &job.BlockhashStoreSpec{
-			WaitBlocks: defaultWaitBlocks - 1,
-		}}
-		_, err := delegate.ServicesForSpec(spec)
-		assert.Error(t, err)
-	})
-
 	t.Run("missing EnabledKeysForChain", func(t *testing.T) {
 		testData.ethKeyStore.Delete(testData.sendingKey.ID())
 


### PR DESCRIPTION
This check forces us to run with _really low_ finality depths, which is not ideal on chains like Polygon. I don't much see the relationship between these two fields, since `waitBlocks` is used to determine the block number range we provide for an eventual `eth_getLogs` RPC call.