### PR TITLE
Update assertion in basic keeper smoke test

### DIFF
--- a/integration-tests/smoke/keeper_test.go
+++ b/integration-tests/smoke/keeper_test.go
@@ -193,16 +193,16 @@ var _ = Describe("Keeper Suite @keeper", func() {
 		if testToRun == BasicSmokeTest {
 			By("watches all the registered upkeeps perform and then cancels them from the registry")
 			Eventually(func(g Gomega) {
-				// Check if the upkeeps are performing by analysing their counters and checking they are greater than 0
+				// Check if the upkeeps are performing multiple times by analysing their counters and checking they are greater than 10
 				for i := 0; i < len(upkeepIDs); i++ {
 					counter, err := consumers[i].Counter(context.Background())
 					g.Expect(err).ShouldNot(HaveOccurred(), "Failed to retrieve consumer counter"+
 						" for upkeep at index "+strconv.Itoa(i))
-					g.Expect(counter.Int64()).Should(BeNumerically(">", int64(0)),
+					g.Expect(counter.Int64()).Should(BeNumerically(">", int64(10)),
 						"Expected consumer counter to be greater than 0, but got %d", counter.Int64())
 					log.Info().Int64("Upkeep counter", counter.Int64()).Msg("Number of upkeeps performed")
 				}
-			}, "1m", "1s").Should(Succeed())
+			}, "5m", "1s").Should(Succeed())
 
 			// Cancel all the registered upkeeps via the registry
 			for i := 0; i < len(upkeepIDs); i++ {


### PR DESCRIPTION
Strengthening this test case to also test that the nodes properly process logs, take turns and perform upkeep multiple times