### PR TITLE
golangci-lint: fix 9 errors

### DIFF
--- a/core/chains/evm/gas/block_history_estimator_test.go
+++ b/core/chains/evm/gas/block_history_estimator_test.go
@@ -1504,7 +1504,7 @@ func TestBlockHistoryEstimator_GetLegacyGas(t *testing.T) {
 
 	gas.SetRollingBlockHistory(bhe, blocks)
 	bhe.Recalculate(cltest.Head(1))
-	gas.SimulateStart(bhe)
+	gas.SimulateStart(t, bhe)
 
 	t.Run("if gas price is lower than global max and user specified max gas price", func(t *testing.T) {
 		fee, limit, err := bhe.GetLegacyGas(make([]byte, 0), 10000, maxGasPrice)
@@ -1531,7 +1531,7 @@ func TestBlockHistoryEstimator_GetLegacyGas(t *testing.T) {
 	bhe = newBlockHistoryEstimator(t, nil, cfg)
 	gas.SetRollingBlockHistory(bhe, blocks)
 	bhe.Recalculate(cltest.Head(1))
-	gas.SimulateStart(bhe)
+	gas.SimulateStart(t, bhe)
 
 	t.Run("if gas price is higher than global max", func(t *testing.T) {
 		fee, limit, err := bhe.GetLegacyGas(make([]byte, 0), 10000, maxGasPrice)
@@ -1574,7 +1574,7 @@ func TestBlockHistoryEstimator_GetDynamicFee(t *testing.T) {
 	gas.SetRollingBlockHistory(bhe, blocks)
 
 	bhe.Recalculate(cltest.Head(1))
-	gas.SimulateStart(bhe)
+	gas.SimulateStart(t, bhe)
 
 	t.Run("if estimator is missing base fee and gas bumping is enabled", func(t *testing.T) {
 		cfg.On("EvmGasBumpThreshold").Return(uint64(1)).Once()

--- a/core/chains/evm/gas/helpers_test.go
+++ b/core/chains/evm/gas/helpers_test.go
@@ -2,7 +2,10 @@ package gas
 
 import (
 	"math/big"
+	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 func init() {
@@ -48,6 +51,6 @@ func GetLatestBaseFee(b *BlockHistoryEstimator) *big.Int {
 	return b.latestBaseFee
 }
 
-func SimulateStart(b *BlockHistoryEstimator) {
-	b.StartOnce("BlockHistoryEstimatorSimulatedStart", func() error { return nil })
+func SimulateStart(t *testing.T, b *BlockHistoryEstimator) {
+	require.NoError(t, b.StartOnce("BlockHistoryEstimatorSimulatedStart", func() error { return nil }))
 }

--- a/core/chains/solana/soltxm/pendingtx_test.go
+++ b/core/chains/solana/soltxm/pendingtx_test.go
@@ -21,7 +21,8 @@ func TestPendingTxContext(t *testing.T) {
 	newProcess := func(i int) (solana.Signature, context.CancelFunc) {
 		// make random signature
 		sig := make([]byte, 64)
-		rand.Read(sig)
+		_, err := rand.Read(sig)
+		require.NoError(t, err)
 
 		// start subprocess to wait for context
 		ctx, cancel := context.WithCancel(ctx)

--- a/core/logger/zap_test.go
+++ b/core/logger/zap_test.go
@@ -67,7 +67,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 
 		lggr, close, err := zapCfg.newLogger(cfg)
 		assert.NoError(t, err)
-		defer close()
+		defer func() { assert.NoError(t, close()) }()
 
 		pollChan <- time.Now()
 		<-zapCfg.testDiskLogLvlChan
@@ -100,7 +100,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 
 		lggr, close, err := zapCfg.newLogger(cfg)
 		assert.NoError(t, err)
-		defer close()
+		defer func() { assert.NoError(t, close()) }()
 
 		pollChan <- time.Now()
 		<-zapCfg.testDiskLogLvlChan
@@ -133,7 +133,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 
 		lggr, close, err := zapCfg.newLogger(cfg)
 		assert.NoError(t, err)
-		defer close()
+		defer func() { assert.NoError(t, close()) }()
 
 		lggr.Debug("writing to disk on test")
 

--- a/core/services/fluxmonitorv2/flux_monitor_test.go
+++ b/core/services/fluxmonitorv2/flux_monitor_test.go
@@ -1166,7 +1166,7 @@ func TestFluxMonitor_RoundTimeoutCausesPoll_timesOutAtZero(t *testing.T) {
 	tm.fluxAggregator.On("GetOracles", nilOpts).Return(oracles, nil)
 
 	fm.SetOracleAddress()
-	fm.ExportedRoundState()
+	fm.ExportedRoundState(t)
 	fm.Start(testutils.Context(t))
 
 	g.Eventually(ch).Should(gomega.BeClosed())

--- a/core/services/fluxmonitorv2/helpers_test.go
+++ b/core/services/fluxmonitorv2/helpers_test.go
@@ -2,6 +2,9 @@ package fluxmonitorv2
 
 import (
 	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm/log"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/flux_aggregator_wrapper"
@@ -27,8 +30,9 @@ func (fm *FluxMonitor) ExportedBacklog() *utils.BoundedPriorityQueue[log.Broadca
 	return fm.backlog
 }
 
-func (fm *FluxMonitor) ExportedRoundState() {
-	fm.roundState(0)
+func (fm *FluxMonitor) ExportedRoundState(t *testing.T) {
+	_, err := fm.roundState(0)
+	require.NoError(t, err)
 }
 
 func (fm *FluxMonitor) ExportedRespondToNewRoundLog(log *flux_aggregator_wrapper.FluxAggregatorNewRound, broadcast log.Broadcast) {

--- a/core/services/health_test.go
+++ b/core/services/health_test.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/core/services"
 )
@@ -50,10 +51,10 @@ func TestCheck(t *testing.T) {
 	} {
 		c := services.NewChecker()
 		for i, check := range test.checks {
-			c.Register(fmt.Sprint(i), check)
+			require.NoError(t, c.Register(fmt.Sprint(i), check))
 		}
 
-		c.Start()
+		require.NoError(t, c.Start())
 
 		healthy, results := c.IsHealthy()
 

--- a/core/services/keystore/keys/vrfkey/public_key_test.go
+++ b/core/services/keystore/keys/vrfkey/public_key_test.go
@@ -26,7 +26,7 @@ func TestValueScanIdentityPointSet(t *testing.T) {
 		assert.True(t, p.Equal(np), "Point should give the point we constructed pk from")
 		value, err := pk.Value()
 		require.NoError(t, err, "failed to serialize public key for database")
-		nPk.Scan(value)
+		require.NoError(t, nPk.Scan(value))
 		assert.Equal(t, pk, nPk,
 			"roundtripping public key through db Value/Scan gave different key!")
 		nnPk.Set(pk)


### PR DESCRIPTION
Last night's scheduled golangci-lint run shows 10 errors and 6 warnings on the summary page.
<details><summary>https://github.com/smartcontractkit/chainlink/actions/runs/3049234782</summary>

![Screenshot from 2022-09-14 06-51-27](https://user-images.githubusercontent.com/1194128/190146443-c3601d6d-291b-45f9-8373-7b6c2122d855.png)
</details>
This change fixes 9 errors (one is false positive).

We could consider configuring the scheduled run to collect more issues before quitting. I thought default was 50, but I'm not sure what is happening here with 10/6, plus more being logged by the action without details.
![Screenshot from 2022-09-14 06-52-40](https://user-images.githubusercontent.com/1194128/190146599-c8c5a702-6cc0-43ed-bb76-a8d03b35abcf.png)
