### PR TITLE
core/static: dedupe logic; remove init() logging

### DIFF
--- a/core/cmd/client.go
+++ b/core/cmd/client.go
@@ -103,7 +103,7 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg config.Gene
 	// Set up the versioning ORM
 	verORM := versioning.NewORM(db, appLggr)
 
-	if static.Version != "unset" {
+	if static.Version != static.Unset {
 		var appv, dbv *semver.Version
 		appv, dbv, err = versioning.CheckVersion(db, appLggr, static.Version)
 		if err != nil {
@@ -134,7 +134,7 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg config.Gene
 	}
 
 	// Update to latest version
-	if static.Version != "unset" {
+	if static.Version != static.Unset {
 		version := versioning.NewNodeVersion(static.Version)
 		if err = verORM.UpsertNodeVersion(version); err != nil {
 			return nil, errors.Wrap(err, "UpsertNodeVersion")

--- a/core/cmd/remote_client.go
+++ b/core/cmd/remote_client.go
@@ -605,7 +605,7 @@ func (cli *Client) checkRemoteBuildCompatibility(lggr logger.Logger, onlyWarn bo
 	}
 	remoteVersion, remoteSha := remoteBuildInfo["version"], remoteBuildInfo["commitSHA"]
 
-	remoteSemverUnset := remoteVersion == "unset" || remoteVersion == "" || remoteSha == "unset" || remoteSha == ""
+	remoteSemverUnset := remoteVersion == static.Unset || remoteVersion == "" || remoteSha == static.Unset || remoteSha == ""
 	cliRemoteSemverMismatch := remoteVersion != cliVersion || remoteSha != cliSha
 
 	if remoteSemverUnset || cliRemoteSemverMismatch {

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -128,18 +128,7 @@ func newZapConfigProd(jsonConsole bool, unixTS bool) zap.Config {
 }
 
 func verShaNameStatic() string {
-	return verShaName(static.Version, static.Sha)
-}
-
-func verShaName(ver, sha string) string {
-	if sha == "" {
-		sha = "unset"
-	} else if len(sha) > 7 {
-		sha = sha[:7]
-	}
-	if ver == "" {
-		ver = "unset"
-	}
+	sha, ver := static.Short()
 	return fmt.Sprintf("%s@%s", ver, sha)
 }
 

--- a/core/logger/logger_test.go
+++ b/core/logger/logger_test.go
@@ -15,22 +15,3 @@ func TestConfig(t *testing.T) {
 	assert.False(t, newZapConfigBase().Development)
 	assert.False(t, newZapConfigProd(false, false).Development)
 }
-
-func Test_verShaName(t *testing.T) {
-	for _, tt := range []struct {
-		ver, sha string
-		exp      string
-	}{
-		{"1.0", "1234567890", "1.0@1234567"},
-		{"1", "a", "1@a"},
-		{"", "", "unset@unset"},
-		{"1.0", "", "1.0@unset"},
-		{"", "1234567890", "unset@1234567"},
-	} {
-		t.Run(tt.ver+":"+tt.sha, func(t *testing.T) {
-			if got := verShaName(tt.ver, tt.sha); got != tt.exp {
-				t.Errorf("expected %q but got %q", tt.exp, got)
-			}
-		})
-	}
-}

--- a/core/logger/pyroscope.go
+++ b/core/logger/pyroscope.go
@@ -23,17 +23,7 @@ func StartPyroscope(cfg PyroscopeConfig) (*pyroscope.Profiler, error) {
 	runtime.SetBlockProfileRate(cfg.AutoPprofBlockProfileRate())
 	runtime.SetMutexProfileFraction(cfg.AutoPprofMutexProfileFraction())
 
-	sha := static.Sha
-	ver := static.Version
-
-	if sha == "" {
-		sha = "unset"
-	} else if len(sha) > 7 {
-		sha = sha[:7]
-	}
-	if ver == "" {
-		ver = "unset"
-	}
+	sha, ver := static.Short()
 
 	return pyroscope.Start(pyroscope.Config{
 		// Maybe configurable to identify the specific NOP - TBD

--- a/core/main.go
+++ b/core/main.go
@@ -1,13 +1,29 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
+
+	"github.com/Masterminds/semver/v3"
 
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/recovery"
+	"github.com/smartcontractkit/chainlink/core/static"
 )
+
+func init() {
+	// check version
+	if static.Version == static.Unset {
+		if os.Getenv("CHAINLINK_DEV") == "true" {
+			return
+		}
+		log.Println(`Version was unset but CHAINLINK_DEV was not set to "true". Chainlink should be built with static.Version set to a valid semver for production builds.`)
+	} else if _, err := semver.NewVersion(static.Version); err != nil {
+		panic(fmt.Sprintf("Version invalid: %q is not valid semver", static.Version))
+	}
+}
 
 func main() {
 	recovery.ReportPanics(func() {

--- a/core/services/periodicbackup/backup_test.go
+++ b/core/services/periodicbackup/backup_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/static"
 )
 
 func mustNewDatabaseBackup(t *testing.T, config Config) *databaseBackup {
@@ -69,7 +70,7 @@ func TestPeriodicBackup_RunBackupWithoutVersion(t *testing.T) {
 	periodicBackup := mustNewDatabaseBackup(t, backupConfig)
 	assert.False(t, periodicBackup.frequencyIsTooSmall())
 
-	result, err := periodicBackup.runBackup("unset")
+	result, err := periodicBackup.runBackup(static.Unset)
 	require.NoError(t, err, "error not nil for backup")
 
 	defer os.Remove(result.path)

--- a/core/services/versioning/orm_test.go
+++ b/core/services/versioning/orm_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/static"
 )
 
 func TestORM_NodeVersion_UpsertNodeVersion(t *testing.T) {
@@ -67,7 +68,7 @@ func Test_Version_CheckVersion(t *testing.T) {
 	require.NoError(t, err)
 
 	// invalid app version semver returns error
-	_, _, err = CheckVersion(db, lggr, "unset")
+	_, _, err = CheckVersion(db, lggr, static.Unset)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), `Application version "unset" is not valid semver`)
 	_, _, err = CheckVersion(db, lggr, "some old bollocks")

--- a/core/static/static.go
+++ b/core/static/static.go
@@ -2,26 +2,26 @@ package static
 
 import (
 	"fmt"
-	"log"
 	"net/url"
-	"os"
 	"time"
 
-	"github.com/Masterminds/semver/v3"
 	uuid "github.com/satori/go.uuid"
 )
 
-// Version is the version of application
-// Must be either "unset" or valid semver
-var Version = "unset"
+// Version and Sha are set at compile time via build arguments.
+var (
+	// Version is the semantic version of the build or Unset.
+	Version = Unset
+	// Sha is the commit hash of the build or Unset.
+	Sha = Unset
+)
 
-// Sha string "unset"
-var Sha = "unset"
-
-// InitTime holds the initial start timestamp, based on this package's init func.
-var InitTime time.Time
+// InitTime holds the initial start timestamp.
+var InitTime = time.Now()
 
 const (
+	// Unset is a sentinel value.
+	Unset = "unset"
 	// ExternalInitiatorAccessKeyHeader is the header name for the access key
 	// used by external initiators to authenticate
 	ExternalInitiatorAccessKeyHeader = "X-Chainlink-EA-AccessKey"
@@ -30,25 +30,8 @@ const (
 	ExternalInitiatorSecretHeader = "X-Chainlink-EA-Secret"
 )
 
-func init() {
-	InitTime = time.Now()
-
-	checkVersion()
-}
-
-func checkVersion() {
-	if Version == "unset" {
-		if os.Getenv("CHAINLINK_DEV") == "true" {
-			return
-		}
-		log.Println(`Version was unset but CHAINLINK_DEV was not set to "true". Chainlink should be built with static.Version set to a valid semver for production builds.`)
-	} else if _, err := semver.NewVersion(Version); err != nil {
-		panic(fmt.Sprintf("Version invalid: %q is not valid semver", Version))
-	}
-}
-
 func buildPrettyVersion() string {
-	if Version == "unset" {
+	if Version == Unset {
 		return " "
 	}
 	return fmt.Sprintf(" %s ", Version)
@@ -68,4 +51,21 @@ func SetConsumerName(uri *url.URL, name string, id *uuid.UUID) {
 	}
 	q.Set("application_name", applicationName)
 	uri.RawQuery = q.Encode()
+}
+
+// Short returns a 7-character sha prefix and version, or Unset if blank.
+func Short() (shaPre string, ver string) {
+	return short(Sha, Version)
+}
+
+func short(sha, ver string) (string, string) {
+	if sha == "" {
+		sha = Unset
+	} else if len(sha) > 7 {
+		sha = sha[:7]
+	}
+	if ver == "" {
+		ver = Unset
+	}
+	return sha, ver
 }

--- a/core/static/static_test.go
+++ b/core/static/static_test.go
@@ -1,0 +1,26 @@
+package static
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_short(t *testing.T) {
+	for _, tt := range []struct {
+		ver, sha       string
+		expVer, expSha string
+	}{
+		{"1.0", "1234567890", "1.0", "1234567"},
+		{"1", "a", "1", "a"},
+		{"", "", "unset", "unset"},
+		{"1.0", "", "1.0", "unset"},
+		{"", "1234567890", "unset", "1234567"},
+	} {
+		t.Run(tt.ver+":"+tt.sha, func(t *testing.T) {
+			sha, ver := short(tt.sha, tt.ver)
+			assert.Equal(t, tt.expSha, sha)
+			assert.Equal(t, tt.expVer, ver)
+		})
+	}
+}


### PR DESCRIPTION
- dedupe loose `"unset"` string literals with a `const` `static.Unset`
- dedupe prefix/sanitization logic with a helper func
- move `func init()` logging validation out of `package static` to `package main` so that it doesn't run when chainlink is imported to other projects, or spam test output