### PR TITLE
 enable race detection for smoke tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -183,6 +183,7 @@ jobs:
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
+          CGO_ENABLED: 1
 
       ## Run this step when changes that do not need the test to run are made
       - name: Run Setup
@@ -310,6 +311,7 @@ jobs:
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
+          CGO_ENABLED: 1
       - name: cleanup
         if: always()
         uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/cleanup@e72f0a768ac934afce498a802de893d89b12802f # v2.1.1

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -22,7 +22,7 @@ operator-ui-autoinstall: | operator-ui ## Autoinstall frontend UI.
 .PHONY: pnpmdep
 pnpmdep: ## Install solidity contract dependencies through pnpm
 	(cd contracts && pnpm i)
-	
+
 .PHONY: gomod
 gomod: ## Ensure chainlink's go dependencies are installed.
 	@if [ -z "`which gencodec`" ]; then \

--- a/integration-tests/Makefile
+++ b/integration-tests/Makefile
@@ -123,29 +123,29 @@ test_perf: test_need_operator_assets ## Run core node performance tests.
 # Soak
 .PHONY: test_soak_ocr
 test_soak_ocr:
-	go test -v -count=1 -run TestOCRSoak ./soak
+	go test -v -count=1 -race -run TestOCRSoak ./soak
 
 .PHONY: test_soak_ocr_simulated
 test_soak_ocr_simulated:
-	SELECTED_NETWORKS="SIMULATED" go test -v -count=1 -run TestOCRSoak ./soak
+	SELECTED_NETWORKS="SIMULATED" go test -v -count=1 -race -run TestOCRSoak ./soak
 
 .PHONY: test_soak_forwarder_ocr
 test_soak_forwarder_ocr:
-	go test -v -count=1 -run TestForwarderOCRSoak ./soak
+	go test -v -count=1 -race -run TestForwarderOCRSoak ./soak
 
 .PHONY: test_soak_forwarder_ocr_simulated
 test_soak_forwarder_ocr_simulated:
-	SELECTED_NETWORKS="SIMULATED" go test -v -count=1 -run TestForwarderOCRSoak ./soak
+	SELECTED_NETWORKS="SIMULATED" go test -v -count=1 -race -run TestForwarderOCRSoak ./soak
 
 .PHONY: test_soak_automation
 test_soak_automation:
-	go test -v -run ^TestAutomationBenchmark$$ ./benchmark -count=1
+	go test -v -race -run ^TestAutomationBenchmark$$ ./benchmark -count=1
 
 .PHONY: test_soak_automation_simulated
 test_soak_automation_simulated:
 	SELECTED_NETWORKS="SIMULATED" \
 	TEST_INPUTS="TEST_TYPE=SOAK,NUMBEROFCONTRACTS=50,BLOCKRANGE=1000,BLOCKINTERVAL=50,GRAFANA_DASHBOARD_URL=https://chainlinklabs.grafana.net/d/Q8n6m1unz/chainlink-keepers-qa?orgId=1" \
-	go test -v -run ^TestAutomationBenchmark$$ ./benchmark -count=1
+	go test -v -race -run ^TestAutomationBenchmark$$ ./benchmark -count=1
 
 .PHONY: test_benchmark_automation
 test_benchmark_automation: test_need_operator_assets ## Run the automation benchmark tests


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/53220/eth-smoke-test-data-races
Adding the `--race` flag to Ginko to turn on the race detector for EVM and Solana smoke tests.