### PR TITLE
Fixed `JSONWithVarExprs`

### DIFF
--- a/core/services/pipeline/getters.go
+++ b/core/services/pipeline/getters.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"strings"
@@ -107,11 +108,19 @@ func JSONWithVarExprs(jsExpr string, vars Vars, allowErrors bool) GetterFunc {
 			keypathStr := strings.TrimSpace(string(expr[2 : len(expr)-1]))
 			return []byte(fmt.Sprintf(`{ "%s": "%s" }`, chainlinkKeyPath, keypathStr))
 		})
+
 		var val interface{}
-		err := json.Unmarshal(replaced, &val)
-		if err != nil {
+		jd := json.NewDecoder(bytes.NewReader(replaced))
+		jd.UseNumber()
+		if err := jd.Decode(&val); err != nil {
 			return nil, errors.Wrapf(ErrBadInput, "while unmarshalling JSON: %v; js: %s", err, string(replaced))
 		}
+		reinterpreted, err := reinterpetJsonNumbers(val)
+		if err != nil {
+			return nil, errors.Wrapf(ErrBadInput, "while processing json.Number: %v; js: %s", err, string(replaced))
+		}
+		val = reinterpreted
+
 		return mapGoValue(val, func(val interface{}) (interface{}, error) {
 			if m, is := val.(map[string]interface{}); is {
 				maybeKeypath, exists := m[chainlinkKeyPath]

--- a/core/services/pipeline/getters_test.go
+++ b/core/services/pipeline/getters_test.go
@@ -1,6 +1,7 @@
 package pipeline_test
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -64,6 +65,9 @@ func TestGetters_JSONWithVarExprs(t *testing.T) {
 	errVal, err := vars.Get("err")
 	require.NoError(t, err)
 
+	big, ok := new(big.Int).SetString("314159265358979323846264338327950288419716939937510582097494459", 10)
+	require.True(t, ok)
+
 	tests := []struct {
 		json        string
 		field       string
@@ -80,6 +84,10 @@ func TestGetters_JSONWithVarExprs(t *testing.T) {
 		{`{}`, "", map[string]interface{}{}, nil, false},
 		{`{ "e": $(err) }`, "e", errVal, nil, true},
 		{`null`, "", nil, nil, false},
+		{`{ "x": 314159265358979323846264338327950288419716939937510582097494459 }`, "x", big, nil, false},
+		{`{ "x": 3141592653589 }`, "x", int64(3141592653589), nil, false},
+		{`{ "x": 18446744073709551615 }`, "x", uint64(18446744073709551615), nil, false},
+		{`{ "x": 3141592653589.567 }`, "x", float64(3141592653589.567), nil, false},
 		// errors
 		{`  `, "", nil, pipeline.ErrParameterEmpty, false},
 		{`{ "x": $(missing) }`, "x", nil, pipeline.ErrKeypathNotFound, false},

--- a/core/services/pipeline/task.merge_test.go
+++ b/core/services/pipeline/task.merge_test.go
@@ -49,7 +49,7 @@ func TestMergeTask(t *testing.T) {
 			pipeline.NewVarsFrom(nil),
 			[]pipeline.Result{{Value: `{"ignored": true}`}},
 			map[string]interface{}{
-				"foo":     float64(42),
+				"foo":     int64(42),
 				"qux":     nil,
 				"flibber": nil,
 			},
@@ -64,7 +64,7 @@ func TestMergeTask(t *testing.T) {
 			[]pipeline.Result{{Value: `{"ignored": true}`}},
 			map[string]interface{}{
 				"foo":     "baz",
-				"qux":     float64(99),
+				"qux":     int64(99),
 				"bar":     nil,
 				"flibber": nil,
 			},
@@ -133,7 +133,7 @@ func TestMergeTask(t *testing.T) {
 			}),
 			[]pipeline.Result{},
 			map[string]interface{}{
-				"foo":     float64(42),
+				"foo":     int64(42),
 				"bar":     nil,
 				"flibber": "this is a string",
 			},
@@ -149,7 +149,7 @@ func TestMergeTask(t *testing.T) {
 			}),
 			[]pipeline.Result{},
 			map[string]interface{}{
-				"foo":     float64(42),
+				"foo":     int64(42),
 				"bar":     nil,
 				"flibber": "this is a string",
 			},


### PR DESCRIPTION
Fixes https://app.shortcut.com/chainlinklabs/story/53218/big-int-with-lost-precision-is-sent-in-transaction-data

This is a quick fix, which does not assume an in-depth rework of pipeline parts.
