### PR TITLE
core/services/pg: higher log levels for slower queries

### DIFF
--- a/core/services/pg/q.go
+++ b/core/services/pg/q.go
@@ -34,17 +34,17 @@ import (
 //
 // A sample ORM method looks like this:
 //
-// 	func (o *orm) GetFoo(id int64, qopts ...pg.QOpt) (Foo, error) {
-// 		q := pg.NewQ(q, qopts...)
-// 		return q.Exec(...)
-// 	}
+//	func (o *orm) GetFoo(id int64, qopts ...pg.QOpt) (Foo, error) {
+//		q := pg.NewQ(q, qopts...)
+//		return q.Exec(...)
+//	}
 //
 // Now you can call it like so:
 //
-// 	orm.GetFoo(1) // will automatically have default query timeout context set
-// 	orm.GetFoo(1, pg.WithParentCtx(ctx)) // will wrap the supplied parent context with the default query context
-// 	orm.GetFoo(1, pg.WithQueryer(tx)) // allows to pass in a running transaction or anything else that implements Queryer
-// 	orm.GetFoo(q, pg.WithQueryer(tx), pg.WithParentCtx(ctx)) // options can be combined
+//	orm.GetFoo(1) // will automatically have default query timeout context set
+//	orm.GetFoo(1, pg.WithParentCtx(ctx)) // will wrap the supplied parent context with the default query context
+//	orm.GetFoo(1, pg.WithQueryer(tx)) // allows to pass in a running transaction or anything else that implements Queryer
+//	orm.GetFoo(q, pg.WithQueryer(tx), pg.WithParentCtx(ctx)) // options can be combined
 type QOpt func(*Q)
 
 type LogConfig interface {
@@ -171,12 +171,12 @@ func (q Q) Transaction(fc func(q Queryer) error, txOpts ...TxOptions) error {
 
 // CAUTION: A subtle problem lurks here, because the following code is buggy:
 //
-//     ctx, cancel := context.WithCancel(context.Background())
-//     rows, err := db.QueryContext(ctx, "SELECT foo")
-//     cancel() // canceling here "poisons" the scan below
-//     for rows.Next() {
-//       rows.Scan(...)
-//     }
+//	ctx, cancel := context.WithCancel(context.Background())
+//	rows, err := db.QueryContext(ctx, "SELECT foo")
+//	cancel() // canceling here "poisons" the scan below
+//	for rows.Next() {
+//	  rows.Scan(...)
+//	}
 //
 // We must cancel the context only after we have completely finished using the
 // returned rows or result from the query/exec
@@ -308,6 +308,8 @@ func (q *queryLogger) withLogError(err error) error {
 	return err
 }
 
+// postSqlLog logs about context cancellation and timing after a query returns.
+// Queries which use their full timeout log critical level. More than 50% log error, and 10% warn.
 func (q *queryLogger) postSqlLog(ctx context.Context, begin time.Time) {
 	elapsed := time.Since(begin)
 	if ctx.Err() != nil {
@@ -318,8 +320,11 @@ func (q *queryLogger) postSqlLog(ctx context.Context, begin time.Time) {
 	if timeout <= 0 {
 		timeout = DefaultQueryTimeout
 	}
-	slowThreshold := timeout / 10
-	if slowThreshold > 0 && elapsed > slowThreshold {
+	if elapsed >= timeout {
+		q.logger.Criticalw("SLOW SQL QUERY", "ms", elapsed.Milliseconds(), "timeout", timeout.Milliseconds(), "sql", q)
+	} else if errThreshold := timeout / 5; errThreshold > 0 && elapsed > errThreshold {
+		q.logger.Errorw("SLOW SQL QUERY", "ms", elapsed.Milliseconds(), "timeout", timeout.Milliseconds(), "sql", q)
+	} else if warnThreshold := timeout / 10; warnThreshold > 0 && elapsed > warnThreshold {
 		q.logger.Warnw("SLOW SQL QUERY", "ms", elapsed.Milliseconds(), "timeout", timeout.Milliseconds(), "sql", q)
 	}
 }


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/53393/slow-sql-query-log-higher-level-than-warn-for-timeouts