### PR TITLE
fix flaky keepers test

### DIFF
--- a/core/services/keeper/integration_test.go
+++ b/core/services/keeper/integration_test.go
@@ -314,7 +314,7 @@ func TestKeeperEthIntegration(t *testing.T) {
 			runs, err := app.PipelineORM().GetAllRuns()
 			require.NoError(t, err)
 			// Since we set grace period to 0, we can have more than 1 pipeline run per perform
-			// This happens in case we start a pipeline run before previous perform tx is commited to chain
+			// This happens in case we start a pipeline run before previous perform tx is committed to chain
 			require.GreaterOrEqual(t, 3, len(runs))
 			prr := webpresenters.NewPipelineRunResource(runs[0], logger.TestLogger(t))
 			require.Equal(t, 1, len(prr.Outputs))

--- a/core/services/keeper/integration_test.go
+++ b/core/services/keeper/integration_test.go
@@ -315,7 +315,7 @@ func TestKeeperEthIntegration(t *testing.T) {
 			require.NoError(t, err)
 			// Since we set grace period to 0, we can have more than 1 pipeline run per perform
 			// This happens in case we start a pipeline run before previous perform tx is committed to chain
-			require.GreaterOrEqual(t, 3, len(runs))
+			require.GreaterOrEqual(t, len(runs), 3)
 			prr := webpresenters.NewPipelineRunResource(runs[0], logger.TestLogger(t))
 			require.Equal(t, 1, len(prr.Outputs))
 			require.Nil(t, prr.Outputs[0])

--- a/core/services/keeper/integration_test.go
+++ b/core/services/keeper/integration_test.go
@@ -314,7 +314,7 @@ func TestKeeperEthIntegration(t *testing.T) {
 			runs, err := app.PipelineORM().GetAllRuns()
 			require.NoError(t, err)
 			// Since we set grace period to 0, we can have more than 1 pipeline run per perform
-			// This happens in case we start a pipeline run before previous
+			// This happens in case we start a pipeline run before previous perform tx is commited to chain
 			require.GreaterOrEqual(t, 3, len(runs))
 			prr := webpresenters.NewPipelineRunResource(runs[0], logger.TestLogger(t))
 			require.Equal(t, 1, len(prr.Outputs))

--- a/core/services/keeper/integration_test.go
+++ b/core/services/keeper/integration_test.go
@@ -313,7 +313,9 @@ func TestKeeperEthIntegration(t *testing.T) {
 			})
 			runs, err := app.PipelineORM().GetAllRuns()
 			require.NoError(t, err)
-			require.Equal(t, 3, len(runs))
+			// Since we set grace period to 0, we can have more than 1 pipeline run per perform
+			// This happens in case we start a pipeline run before previous
+			require.GreaterOrEqual(t, 3, len(runs))
 			prr := webpresenters.NewPipelineRunResource(runs[0], logger.TestLogger(t))
 			require.Equal(t, 1, len(prr.Outputs))
 			require.Nil(t, prr.Outputs[0])


### PR DESCRIPTION
We sometimes get more than 3 pipeline runs which is normal because we set grace period to 0. This can happen when we start a new run before test competes / we receive a log so it's flaky