### PR TITLE
core/services/chainlink: clean up service naming

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -16,10 +16,11 @@ import (
 	"go.uber.org/multierr"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/sqlx"
+
 	pkgsolana "github.com/smartcontractkit/chainlink-solana/pkg/solana"
 	starknetrelay "github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink"
 	pkgterra "github.com/smartcontractkit/chainlink-terra/pkg/terra"
-	"github.com/smartcontractkit/sqlx"
 
 	relaytypes "github.com/smartcontractkit/chainlink-relay/pkg/types"
 
@@ -129,7 +130,7 @@ type ChainlinkApplication struct {
 	SessionReaper            utils.SleeperTask
 	shutdownOnce             sync.Once
 	explorerClient           synchronization.ExplorerClient
-	subservices              []services.ServiceCtx
+	srvcs                    []services.ServiceCtx
 	HealthChecker            services.Checker
 	Nurse                    *services.Nurse
 	logger                   logger.Logger
@@ -187,7 +188,7 @@ func (c *Chains) services() (s []services.ServiceCtx) {
 // be used by the node.
 // TODO: Inject more dependencies here to save booting up useless stuff in tests
 func NewApplication(opts ApplicationOpts) (Application, error) {
-	var subservices []services.ServiceCtx
+	var srvcs []services.ServiceCtx
 	db := opts.SqlxDB
 	cfg := opts.Config
 	keyStore := opts.KeyStore
@@ -251,7 +252,7 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 			monitoringEndpointGen = telemetry.NewIngressAgentWrapper(telemetryIngressClient)
 		}
 	}
-	subservices = append(subservices, explorerClient, telemetryIngressClient, telemetryIngressBatchClient)
+	srvcs = append(srvcs, explorerClient, telemetryIngressClient, telemetryIngressBatchClient)
 
 	if cfg.DatabaseBackupMode() != config.DatabaseBackupModeNone && cfg.DatabaseBackupFrequency() > 0 {
 		globalLogger.Infow("DatabaseBackup: periodic database backups are enabled", "frequency", cfg.DatabaseBackupFrequency())
@@ -260,15 +261,15 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "NewApplication: failed to initialize database backup")
 		}
-		subservices = append(subservices, databaseBackup)
+		srvcs = append(srvcs, databaseBackup)
 	} else {
 		globalLogger.Info("DatabaseBackup: periodic database backups are disabled. To enable automatic backups, set DATABASE_BACKUP_MODE=lite or DATABASE_BACKUP_MODE=full")
 	}
 
-	subservices = append(subservices, eventBroadcaster)
-	subservices = append(subservices, chains.services()...)
+	srvcs = append(srvcs, eventBroadcaster)
+	srvcs = append(srvcs, chains.services()...)
 	promReporter := promreporter.NewPromReporter(db.DB, globalLogger)
-	subservices = append(subservices, promReporter)
+	srvcs = append(srvcs, promReporter)
 
 	var (
 		pipelineORM    = pipeline.NewORM(db, globalLogger, cfg)
@@ -341,7 +342,7 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 			return nil, err
 		}
 		peerWrapper = ocrcommon.NewSingletonPeerWrapper(keyStore, cfg, db, globalLogger)
-		subservices = append(subservices, peerWrapper)
+		srvcs = append(srvcs, peerWrapper)
 	} else {
 		globalLogger.Debug("P2P stack disabled")
 	}
@@ -367,22 +368,22 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 		if cfg.EVMEnabled() {
 			evmRelayer := evmrelay.NewRelayer(db, chains.EVM, globalLogger.Named("EVM"))
 			relayers[relay.EVM] = evmRelayer
-			subservices = append(subservices, evmRelayer)
+			srvcs = append(srvcs, evmRelayer)
 		}
 		if cfg.SolanaEnabled() {
 			solanaRelayer := pkgsolana.NewRelayer(globalLogger.Named("Solana.Relayer"), chains.Solana)
 			relayers[relay.Solana] = solanaRelayer
-			subservices = append(subservices, solanaRelayer)
+			srvcs = append(srvcs, solanaRelayer)
 		}
 		if cfg.TerraEnabled() {
 			terraRelayer := pkgterra.NewRelayer(globalLogger.Named("Terra.Relayer"), chains.Terra)
 			relayers[relay.Terra] = terraRelayer
-			subservices = append(subservices, terraRelayer)
+			srvcs = append(srvcs, terraRelayer)
 		}
 		if cfg.StarkNetEnabled() {
 			starknetRelayer := starknetrelay.NewRelayer(globalLogger.Named("StarkNet.Relayer"), chains.StarkNet)
 			relayers[relay.StarkNet] = starknetRelayer
-			subservices = append(subservices, starknetRelayer)
+			srvcs = append(srvcs, starknetRelayer)
 		}
 		delegates[job.OffchainReporting2] = ocr2.NewDelegate(
 			db,
@@ -415,13 +416,13 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 		lbs = append(lbs, c.LogBroadcaster())
 	}
 	jobSpawner := job.NewSpawner(jobORM, cfg, delegates, db, globalLogger, lbs)
-	subservices = append(subservices, jobSpawner, pipelineRunner)
+	srvcs = append(srvcs, jobSpawner, pipelineRunner)
 
 	// We start the log poller after the job spawner
 	// so jobs have a chance to apply their initial log filters.
 	if cfg.FeatureLogPoller() {
 		for _, c := range chains.EVM.Chains() {
-			subservices = append(subservices, c.LogPoller())
+			srvcs = append(srvcs, c.LogPoller())
 		}
 	}
 
@@ -467,12 +468,11 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 
 		sqlxDB: opts.SqlxDB,
 
-		// NOTE: Can keep things clean by putting more things in subservices
-		// instead of manually start/closing
-		subservices: subservices,
+		// NOTE: Can keep things clean by putting more things in srvcs instead of manually start/closing
+		srvcs: srvcs,
 	}
 
-	for _, service := range app.subservices {
+	for _, service := range app.srvcs {
 		checkable := service.(services.Checkable)
 		if err := app.HealthChecker.Register(reflect.TypeOf(service).String(), checkable); err != nil {
 			return nil, err
@@ -505,14 +505,14 @@ func (app *ChainlinkApplication) Start(ctx context.Context) error {
 		}
 	}
 
-	for _, subservice := range app.subservices {
+	for _, service := range app.srvcs {
 		if ctx.Err() != nil {
 			return errors.Wrap(ctx.Err(), "aborting start")
 		}
 
-		app.logger.Debugw("Starting service...", "serviceType", reflect.TypeOf(subservice))
+		app.logger.Debugw("Starting service...", "serviceType", reflect.TypeOf(service))
 
-		if err := subservice.Start(ctx); err != nil {
+		if err := service.Start(ctx); err != nil {
 			return err
 		}
 	}
@@ -558,8 +558,8 @@ func (app *ChainlinkApplication) stop() (err error) {
 		app.logger.Info("Gracefully exiting...")
 
 		// Stop services in the reverse order from which they were started
-		for i := len(app.subservices) - 1; i >= 0; i-- {
-			service := app.subservices[i]
+		for i := len(app.srvcs) - 1; i >= 0; i-- {
+			service := app.srvcs[i]
 			app.logger.Debugw("Closing service...", "serviceType", reflect.TypeOf(service))
 			err = multierr.Append(err, service.Close())
 		}


### PR DESCRIPTION
Application level services (`services.ServiceCtx`) are referred to with a mix of `service` and `subservice`. This change removes the `subservice` cases so they are unambiguously referred to as `service`s, reserving the term `subservice` for internal components of a `service`.