### PR TITLE
core/chains/evm/txmgr: skip disabled keys from nonce syncer (#7496) [1.8.1]

### DIFF
--- a/core/chains/evm/txmgr/nonce_syncer.go
+++ b/core/chains/evm/txmgr/nonce_syncer.go
@@ -81,7 +81,7 @@ func NewNonceSyncer(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig, ethClient
 	}
 }
 
-// SyncAll syncs nonces for all keys in parallel
+// SyncAll syncs nonces for all enabled keys in parallel
 //
 // This should only be called once, before the EthBroadcaster has started.
 // Calling it later is not safe and could lead to races.
@@ -89,8 +89,11 @@ func (s NonceSyncer) SyncAll(ctx context.Context, keyStates []ethkey.State) (mer
 	var wg sync.WaitGroup
 	var errMu sync.Mutex
 
-	wg.Add(len(keyStates))
 	for _, keyState := range keyStates {
+		if keyState.Disabled {
+			continue
+		}
+		wg.Add(1)
 		go func(k ethkey.State) {
 			defer wg.Done()
 			if err := s.fastForwardNonceIfNecessary(ctx, k.Address.Address()); err != nil {


### PR DESCRIPTION
(cherry picked from commit 5d43fa61535f24c52db7184e584be2b338ec9cfb) #7496