### PR TITLE
Forwarder<=>EOA on Job level instead of Txm - OCR/OCR2

### DIFF
--- a/core/internal/features_ocr2_test.go
+++ b/core/internal/features_ocr2_test.go
@@ -35,6 +35,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/bridges"
+	"github.com/smartcontractkit/chainlink/core/chains/evm/forwarders"
+	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/authorized_forwarder"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/link_token_interface"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest/heavyweight"
@@ -46,12 +48,14 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/ocrbootstrap"
 	"github.com/smartcontractkit/chainlink/core/services/relay/evm"
 	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
 type ocr2Node struct {
 	app         *cltest.TestApplication
 	peerID      string
 	transmitter common.Address
+	forwarder   common.Address
 	keybundle   ocr2key.KeyBundle
 	config      *configtest.TestGeneralConfig
 }
@@ -100,6 +104,7 @@ func setupNodeOCR2(
 	owner *bind.TransactOpts,
 	port uint16,
 	dbName string,
+	useForwarder bool,
 	b *backends.SimulatedBackend,
 ) *ocr2Node {
 	config, _ := heavyweight.FullTestDB(t, fmt.Sprintf("%s%d", dbName, port))
@@ -111,6 +116,7 @@ func setupNodeOCR2(
 	config.Overrides.P2PEnabled = null.BoolFrom(true)
 	config.Overrides.P2PNetworkingStack = ocrnetworking.NetworkingStackV2
 	config.Overrides.P2PListenPort = null.NewInt(0, true)
+	config.Overrides.GlobalEvmUseForwarders = null.BoolFrom(useForwarder)
 	config.Overrides.SetP2PV2DeltaDial(500 * time.Millisecond)
 	config.Overrides.SetP2PV2DeltaReconcile(5 * time.Second)
 	p2paddresses := []string{
@@ -155,10 +161,30 @@ func setupNodeOCR2(
 	kb, err := app.GetKeyStore().OCR2().Create("evm")
 	require.NoError(t, err)
 
+	forwarder := common.Address{}
+	if useForwarder {
+		// deploy a forwarder
+		faddr, _, authorizedForwarder, err := authorized_forwarder.DeployAuthorizedForwarder(owner, b, common.Address{}, owner.From, common.Address{}, []byte{})
+		require.NoError(t, err)
+
+		// set EOA as an authorized sender for the forwarder
+		_, err = authorizedForwarder.SetAuthorizedSenders(owner, []common.Address{transmitter})
+		require.NoError(t, err)
+		b.Commit()
+
+		// add forwarder address to be tracked in db
+		forwarderORM := forwarders.NewORM(app.GetSqlxDB(), logger.TestLogger(t), config)
+		chainID := utils.Big(*b.Blockchain().Config().ChainID)
+		_, err = forwarderORM.CreateForwarder(faddr, chainID)
+		require.NoError(t, err)
+
+		forwarder = faddr
+	}
 	return &ocr2Node{
 		app:         app,
 		peerID:      peerID.Raw(),
 		transmitter: transmitter,
+		forwarder:   forwarder,
 		keybundle:   kb,
 		config:      config,
 	}
@@ -171,7 +197,7 @@ func TestIntegration_OCR2(t *testing.T) {
 	// Note it's plausible these ports could be occupied on a CI machine.
 	// May need a port randomize + retry approach if we observe collisions.
 	bootstrapNodePort := uint16(29999)
-	bootstrapNode := setupNodeOCR2(t, owner, bootstrapNodePort, "bootstrap", b)
+	bootstrapNode := setupNodeOCR2(t, owner, bootstrapNodePort, "bootstrap", false /* useForwarders */, b)
 
 	var (
 		oracles      []confighelper2.OracleIdentityExtra
@@ -180,7 +206,7 @@ func TestIntegration_OCR2(t *testing.T) {
 		apps         []*cltest.TestApplication
 	)
 	for i := uint16(0); i < 4; i++ {
-		node := setupNodeOCR2(t, owner, bootstrapNodePort+1+i, fmt.Sprintf("oracle%d", i), b)
+		node := setupNodeOCR2(t, owner, bootstrapNodePort+1+i, fmt.Sprintf("oracle%d", i), false /* useForwarders */, b)
 		// Supply the bootstrap IP and port as a V2 peer address
 		node.config.Overrides.P2PV2Bootstrappers = []commontypes.BootstrapperLocator{
 			{PeerID: bootstrapNode.peerID, Addrs: []string{
@@ -314,6 +340,275 @@ relay              = "evm"
 schemaVersion      = 1
 pluginType         = "median"
 name               = "web oracle spec"
+contractID         = "%s"
+ocrKeyBundleID     = "%s"
+transmitterID      = "%s"
+contractConfigConfirmations = 1
+contractConfigTrackerPollInterval = "1s"
+observationSource  = """
+    // data source 1
+    ds1          [type=bridge name="%s"];
+    ds1_parse    [type=jsonparse path="data"];
+    ds1_multiply [type=multiply times=%d];
+
+    // data source 2
+    ds2          [type=http method=GET url="%s"];
+    ds2_parse    [type=jsonparse path="data"];
+    ds2_multiply [type=multiply times=%d];
+
+    ds1 -> ds1_parse -> ds1_multiply -> answer1;
+    ds2 -> ds2_parse -> ds2_multiply -> answer1;
+
+	answer1 [type=median index=0];
+"""
+[relayConfig]
+chainID = 1337
+[pluginConfig]
+juelsPerFeeCoinSource = """
+		// data source 1
+		ds1          [type=bridge name="%s"];
+		ds1_parse    [type=jsonparse path="data"];
+		ds1_multiply [type=multiply times=%d];
+
+		// data source 2
+		ds2          [type=http method=GET url="%s"];
+		ds2_parse    [type=jsonparse path="data"];
+		ds2_multiply [type=multiply times=%d];
+
+		ds1 -> ds1_parse -> ds1_multiply -> answer1;
+		ds2 -> ds2_parse -> ds2_multiply -> answer1;
+
+	answer1 [type=median index=0];
+"""
+`, ocrContractAddress, kbs[i].ID(), transmitters[i], fmt.Sprintf("bridge%d", i), i, slowServers[i].URL, i, fmt.Sprintf("bridge%d", i), i, slowServers[i].URL, i))
+		require.NoError(t, err)
+		err = apps[i].AddJobV2(testutils.Context(t), &ocrJob)
+		require.NoError(t, err)
+		jids = append(jids, ocrJob.ID)
+	}
+
+	// Once all the jobs are added, replay to ensure we have the configSet logs.
+	for _, app := range apps {
+		require.NoError(t, app.Chains.EVM.Chains()[0].LogPoller().Replay(testutils.Context(t), blockBeforeConfig.Number().Int64()))
+	}
+	require.NoError(t, bootstrapNode.app.Chains.EVM.Chains()[0].LogPoller().Replay(testutils.Context(t), blockBeforeConfig.Number().Int64()))
+
+	// Assert that all the OCR jobs get a run with valid values eventually.
+	var wg sync.WaitGroup
+	for i := 0; i < 4; i++ {
+		ic := i
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// Want at least 2 runs so we see all the metadata.
+			pr := cltest.WaitForPipelineComplete(t, ic, jids[ic], 2, 7, apps[ic].JobORM(), 2*time.Minute, 5*time.Second)
+			jb, err := pr[0].Outputs.MarshalJSON()
+			require.NoError(t, err)
+			assert.Equal(t, []byte(fmt.Sprintf("[\"%d\"]", 10*ic)), jb, "pr[0] %+v pr[1] %+v", pr[0], pr[1])
+			require.NoError(t, err)
+		}()
+	}
+	wg.Wait()
+
+	// 4 oracles reporting 0, 10, 20, 30. Answer should be 20 (results[4/2]).
+	gomega.NewGomegaWithT(t).Eventually(func() string {
+		answer, err := ocrContract.LatestAnswer(nil)
+		require.NoError(t, err)
+		return answer.String()
+	}, 1*time.Minute, 200*time.Millisecond).Should(gomega.Equal("20"))
+
+	for _, app := range apps {
+		jobs, _, err := app.JobORM().FindJobs(0, 1000)
+		require.NoError(t, err)
+		// No spec errors
+		for _, j := range jobs {
+			ignore := 0
+			for i := range j.JobSpecErrors {
+				// Non-fatal timing related error, ignore for testing.
+				if strings.Contains(j.JobSpecErrors[i].Description, "leader's phase conflicts tGrace timeout") {
+					ignore++
+				}
+			}
+			require.Len(t, j.JobSpecErrors, ignore)
+		}
+	}
+	em := map[string]struct{}{}
+	metaLock.Lock()
+	maps.Copy(em, expectedMeta)
+	metaLock.Unlock()
+	assert.Len(t, em, 0, "expected metadata %v", em)
+
+	// Assert we can read the latest config digest and epoch after a report has been submitted.
+	contractABI, err := abi.JSON(strings.NewReader(ocr2aggregator.OCR2AggregatorABI))
+	require.NoError(t, err)
+	ct, err := evm.NewOCRContractTransmitter(ocrContractAddress, apps[0].Chains.EVM.Chains()[0].Client(), contractABI, nil, apps[0].Chains.EVM.Chains()[0].LogPoller(), lggr)
+	require.NoError(t, err)
+	configDigest, epoch, err := ct.LatestConfigDigestAndEpoch(testutils.Context(t))
+	require.NoError(t, err)
+	details, err := ocrContract.LatestConfigDetails(nil)
+	require.NoError(t, err)
+	assert.True(t, bytes.Equal(configDigest[:], details.ConfigDigest[:]))
+	digestAndEpoch, err := ocrContract.LatestConfigDigestAndEpoch(nil)
+	require.NoError(t, err)
+	assert.Equal(t, digestAndEpoch.Epoch, epoch)
+}
+
+func TestIntegration_OCR2_ForwarderFlow(t *testing.T) {
+	owner, b, ocrContractAddress, ocrContract := setupOCR2Contracts(t)
+
+	lggr := logger.TestLogger(t)
+	// Note it's plausible these ports could be occupied on a CI machine.
+	// May need a port randomize + retry approach if we observe collisions.
+	bootstrapNodePort := uint16(29999)
+	bootstrapNode := setupNodeOCR2(t, owner, bootstrapNodePort, "bootstrap", true /* useForwarders */, b)
+
+	var (
+		oracles            []confighelper2.OracleIdentityExtra
+		transmitters       []common.Address
+		forwarderContracts []common.Address
+		kbs                []ocr2key.KeyBundle
+		apps               []*cltest.TestApplication
+	)
+	for i := uint16(0); i < 4; i++ {
+		node := setupNodeOCR2(t, owner, bootstrapNodePort+1+i, fmt.Sprintf("oracle%d", i), true /* useForwarders */, b)
+		// Supply the bootstrap IP and port as a V2 peer address
+		node.config.Overrides.P2PV2Bootstrappers = []commontypes.BootstrapperLocator{
+			{PeerID: bootstrapNode.peerID, Addrs: []string{
+				fmt.Sprintf("127.0.0.1:%d", bootstrapNodePort),
+			}},
+		}
+
+		kbs = append(kbs, node.keybundle)
+		apps = append(apps, node.app)
+		forwarderContracts = append(forwarderContracts, node.forwarder)
+		transmitters = append(transmitters, node.transmitter)
+
+		oracles = append(oracles, confighelper2.OracleIdentityExtra{
+			OracleIdentity: confighelper2.OracleIdentity{
+				OnchainPublicKey:  node.keybundle.PublicKey(),
+				TransmitAccount:   ocrtypes2.Account(node.forwarder.String()),
+				OffchainPublicKey: node.keybundle.OffchainPublicKey(),
+				PeerID:            node.peerID,
+			},
+			ConfigEncryptionPublicKey: node.keybundle.ConfigEncryptionPublicKey(),
+		})
+	}
+
+	tick := time.NewTicker(1 * time.Second)
+	defer tick.Stop()
+	go func() {
+		for range tick.C {
+			b.Commit()
+		}
+	}()
+
+	lggr.Debugw("Setting Payees on OraclePlugin Contract", "transmitters", forwarderContracts)
+	_, err := ocrContract.SetPayees(
+		owner,
+		forwarderContracts,
+		transmitters,
+	)
+	require.NoError(t, err)
+	blockBeforeConfig, err := b.BlockByNumber(testutils.Context(t), nil)
+	require.NoError(t, err)
+	signers, effectiveTransmitters, threshold, onchainConfig, encodedConfigVersion, encodedConfig, err := confighelper2.ContractSetConfigArgsForEthereumIntegrationTest(
+		oracles,
+		1,
+		1000000000/100, // threshold PPB
+	)
+	require.NoError(t, err)
+
+	lggr.Debugw("Setting Config on Oracle Contract",
+		"signers", signers,
+		"transmitters", transmitters,
+		"effectiveTransmitters", effectiveTransmitters,
+		"threshold", threshold,
+		"onchainConfig", onchainConfig,
+		"encodedConfigVersion", encodedConfigVersion,
+	)
+	_, err = ocrContract.SetConfig(
+		owner,
+		signers,
+		effectiveTransmitters,
+		threshold,
+		onchainConfig,
+		encodedConfigVersion,
+		encodedConfig,
+	)
+	require.NoError(t, err)
+	b.Commit()
+
+	err = bootstrapNode.app.Start(testutils.Context(t))
+	require.NoError(t, err)
+	defer bootstrapNode.app.Stop()
+
+	chainSet := bootstrapNode.app.GetChains().EVM
+	require.NotNil(t, chainSet)
+	ocrJob, err := ocrbootstrap.ValidatedBootstrapSpecToml(fmt.Sprintf(`
+type				= "bootstrap"
+name				= "bootstrap"
+relay				= "evm"
+schemaVersion		= 1
+forwardingAllowed   = true
+contractID			= "%s"
+[relayConfig]
+chainID 			= 1337
+`, ocrContractAddress))
+	require.NoError(t, err)
+	err = bootstrapNode.app.AddJobV2(testutils.Context(t), &ocrJob)
+	require.NoError(t, err)
+
+	var jids []int32
+	var servers, slowServers = make([]*httptest.Server, 4), make([]*httptest.Server, 4)
+	// We expect metadata of:
+	//  latestAnswer:nil // First call
+	//  latestAnswer:0
+	//  latestAnswer:10
+	//  latestAnswer:20
+	//  latestAnswer:30
+	var metaLock sync.Mutex
+	expectedMeta := map[string]struct{}{
+		"0": {}, "10": {}, "20": {}, "30": {},
+	}
+	for i := 0; i < 4; i++ {
+		err = apps[i].Start(testutils.Context(t))
+		require.NoError(t, err)
+		defer apps[i].Stop()
+
+		// API speed is > observation timeout set in ContractSetConfigArgsForIntegrationTest
+		slowServers[i] = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			time.Sleep(5 * time.Second)
+			res.WriteHeader(http.StatusOK)
+			res.Write([]byte(`{"data":10}`))
+		}))
+		defer slowServers[i].Close()
+		servers[i] = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+			b, err := ioutil.ReadAll(req.Body)
+			require.NoError(t, err)
+			var m bridges.BridgeMetaDataJSON
+			require.NoError(t, json.Unmarshal(b, &m))
+			if m.Meta.LatestAnswer != nil && m.Meta.UpdatedAt != nil {
+				metaLock.Lock()
+				delete(expectedMeta, m.Meta.LatestAnswer.String())
+				metaLock.Unlock()
+			}
+			res.WriteHeader(http.StatusOK)
+			res.Write([]byte(`{"data":10}`))
+		}))
+		defer servers[i].Close()
+		u, _ := url.Parse(servers[i].URL)
+		apps[i].BridgeORM().CreateBridgeType(&bridges.BridgeType{
+			Name: bridges.BridgeName(fmt.Sprintf("bridge%d", i)),
+			URL:  models.WebURL(*u),
+		})
+
+		ocrJob, err := validate.ValidatedOracleSpecToml(apps[i].Config, fmt.Sprintf(`
+type               = "offchainreporting2"
+relay              = "evm"
+schemaVersion      = 1
+pluginType         = "median"
+name               = "web oracle spec"
+forwardingAllowed  = true
 contractID         = "%s"
 ocrKeyBundleID     = "%s"
 transmitterID      = "%s"

--- a/core/internal/features_ocr2_test.go
+++ b/core/internal/features_ocr2_test.go
@@ -206,6 +206,7 @@ func TestIntegration_OCR2(t *testing.T) {
 		apps         []*cltest.TestApplication
 	)
 	for i := uint16(0); i < 4; i++ {
+
 		node := setupNodeOCR2(t, owner, bootstrapNodePort+1+i, fmt.Sprintf("oracle%d", i), false /* useForwarders */, b)
 		// Supply the bootstrap IP and port as a V2 peer address
 		node.config.Overrides.P2PV2Bootstrappers = []commontypes.BootstrapperLocator{
@@ -459,7 +460,7 @@ func TestIntegration_OCR2_ForwarderFlow(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	// Note it's plausible these ports could be occupied on a CI machine.
 	// May need a port randomize + retry approach if we observe collisions.
-	bootstrapNodePort := uint16(29999)
+	bootstrapNodePort := uint16(29898)
 	bootstrapNode := setupNodeOCR2(t, owner, bootstrapNodePort, "bootstrap", true /* useForwarders */, b)
 
 	var (

--- a/core/internal/features_test.go
+++ b/core/internal/features_test.go
@@ -43,8 +43,10 @@ import (
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/auth"
 	"github.com/smartcontractkit/chainlink/core/bridges"
+	"github.com/smartcontractkit/chainlink/core/chains/evm/forwarders"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/gas"
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
+	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/authorized_forwarder"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/consumer_wrapper"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/flags_wrapper"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/link_token_interface"
@@ -713,6 +715,94 @@ func setupNode(t *testing.T, owner *bind.TransactOpts, portV1, portV2 int, dbNam
 	return app, peerID.Raw(), transmitter, key, config
 }
 
+func setupForwarderEnabledNode(
+	t *testing.T,
+	owner *bind.TransactOpts,
+	portV1,
+	portV2 int,
+	dbName string,
+	b *backends.SimulatedBackend,
+	ns ocrnetworking.NetworkingStack) (
+	*cltest.TestApplication,
+	string,
+	common.Address,
+	common.Address,
+	ocrkey.KeyV2,
+	*configtest.TestGeneralConfig) {
+	config, _ := heavyweight.FullTestDB(t, fmt.Sprintf("%s%d", dbName, portV1))
+	config.Overrides.Dev = null.BoolFrom(true) // Disables ocr spec validation so we can have fast polling for the test.
+	config.Overrides.FeatureOffchainReporting = null.BoolFrom(true)
+	config.Overrides.FeatureOffchainReporting2 = null.BoolFrom(true)
+	config.Overrides.P2PEnabled = null.BoolFrom(true)
+	config.Overrides.GlobalEvmUseForwarders = null.BoolFrom(true)
+
+	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, b)
+	_, err := app.GetKeyStore().P2P().Create()
+	require.NoError(t, err)
+	p2pIDs, err := app.GetKeyStore().P2P().GetAll()
+	require.NoError(t, err)
+	require.Len(t, p2pIDs, 1)
+	peerID := p2pIDs[0].PeerID()
+
+	config.Overrides.P2PPeerID = peerID
+	config.Overrides.P2PNetworkingStack = ns
+	// We want to quickly poll for the bootstrap node to come up, but if we poll too quickly
+	// we'll flood it with messages and slow things down. 5s is about how long it takes the
+	// bootstrap node to come up.
+	config.Overrides.SetOCRBootstrapCheckInterval(5 * time.Second)
+	// GracePeriod < ObservationTimeout
+	config.Overrides.GlobalOCRObservationGracePeriod = 100 * time.Millisecond
+	dr := 5 * time.Second
+	switch ns {
+	case ocrnetworking.NetworkingStackV1:
+		config.Overrides.P2PListenPort = null.IntFrom(int64(portV1))
+	case ocrnetworking.NetworkingStackV2:
+		config.Overrides.P2PV2ListenAddresses = []string{fmt.Sprintf("127.0.0.1:%d", portV2)}
+		config.Overrides.P2PV2DeltaReconcile = &dr
+	case ocrnetworking.NetworkingStackV1V2:
+		// Note v1 and v2 ports must be distinct,
+		// v1v2 mode will listen on both.
+		config.Overrides.P2PListenPort = null.IntFrom(int64(portV1))
+		config.Overrides.P2PV2DeltaReconcile = &dr
+		config.Overrides.P2PV2ListenAddresses = []string{fmt.Sprintf("127.0.0.1:%d", portV2)}
+	}
+
+	sendingKeys, err := app.KeyStore.Eth().EnabledKeysForChain(testutils.SimulatedChainID)
+	require.NoError(t, err)
+	transmitter := sendingKeys[0].Address
+
+	// Fund the transmitter address with some ETH
+	n, err := b.NonceAt(testutils.Context(t), owner.From, nil)
+	require.NoError(t, err)
+
+	tx := types.NewTransaction(n, transmitter, assets.Ether(100), 21000, big.NewInt(1000000000), nil)
+	signedTx, err := owner.Signer(owner.From, tx)
+	require.NoError(t, err)
+	err = b.SendTransaction(testutils.Context(t), signedTx)
+	require.NoError(t, err)
+	b.Commit()
+
+	key, err := app.GetKeyStore().OCR().Create()
+	require.NoError(t, err)
+
+	// deploy a forwarder
+	forwarder, _, authorizedForwarder, err := authorized_forwarder.DeployAuthorizedForwarder(owner, b, common.Address{}, owner.From, common.Address{}, []byte{})
+	require.NoError(t, err)
+
+	// set EOA as an authorized sender for the forwarder
+	_, err = authorizedForwarder.SetAuthorizedSenders(owner, []common.Address{transmitter})
+	require.NoError(t, err)
+	b.Commit()
+
+	// add forwarder address to be tracked in db
+	forwarderORM := forwarders.NewORM(app.GetSqlxDB(), logger.TestLogger(t), config)
+	chainID := utils.Big(*b.Blockchain().Config().ChainID)
+	_, err = forwarderORM.CreateForwarder(forwarder, chainID)
+	require.NoError(t, err)
+
+	return app, peerID.Raw(), transmitter, forwarder, key, config
+}
+
 func TestIntegration_OCR(t *testing.T) {
 	testutils.SkipShort(t, "long test")
 	tests := []struct {
@@ -947,6 +1037,238 @@ observationSource = """
 			assert.Len(t, expectedMeta, 0, "expected metadata %v", expectedMeta)
 		})
 	}
+}
+
+func TestIntegration_OCR_ForwarderFlow(t *testing.T) {
+	testutils.SkipShort(t, "long test")
+	numOracles := 4
+	t.Run("ocr_forwarder_flow", func(t *testing.T) {
+		bootstrapNodePortV1 := 20000
+		bootstrapNodePortV2 := 20000 + numOracles + 1
+		g := gomega.NewWithT(t)
+		owner, b, ocrContractAddress, ocrContract, flagsContract, flagsContractAddress := setupOCRContracts(t)
+
+		// Note it's plausible these ports could be occupied on a CI machine.
+		// May need a port randomize + retry approach if we observe collisions.
+		appBootstrap, bootstrapPeerID, _, _, _ := setupNode(t, owner, bootstrapNodePortV1, bootstrapNodePortV2, fmt.Sprintf("b_%d", 1), b, ocrnetworking.NetworkingStackV2)
+		// bootstrapCfg.Overrides.GlobalEvmUseForwarders = null.BoolFrom(true)
+
+		var (
+			oracles             []confighelper.OracleIdentityExtra
+			transmitters        []common.Address
+			forwardersContracts []common.Address
+			keys                []ocrkey.KeyV2
+			apps                []*cltest.TestApplication
+		)
+		for i := 0; i < numOracles; i++ {
+			portV1 := bootstrapNodePortV1 + i + 1
+			portV2 := bootstrapNodePortV2 + i + 1
+			app, peerID, transmitter, forwarder, key, cfg := setupForwarderEnabledNode(t, owner, portV1, portV2, fmt.Sprintf("o%d_%d", i, 1), b, ocrnetworking.NetworkingStackV2)
+			cfg.Overrides.GlobalFlagsContractAddress = null.StringFrom(flagsContractAddress.String())
+			cfg.Overrides.GlobalEvmEIP1559DynamicFees = null.BoolFrom(true)
+
+			// cfg.Overrides.GlobalEvmUseForwarders = null.BoolFrom(true)
+			if ocrnetworking.NetworkingStackV2 != ocrnetworking.NetworkingStackV1 {
+				cfg.Overrides.P2PV2Bootstrappers = []ocrcommontypes.BootstrapperLocator{
+					{
+						PeerID: bootstrapPeerID,
+						Addrs:  []string{fmt.Sprintf("127.0.0.1:%d", bootstrapNodePortV2)},
+					},
+				}
+			}
+
+			keys = append(keys, key)
+			apps = append(apps, app)
+			forwardersContracts = append(forwardersContracts, forwarder)
+			transmitters = append(transmitters, transmitter)
+
+			oracles = append(oracles, confighelper.OracleIdentityExtra{
+				OracleIdentity: confighelper.OracleIdentity{
+					OnChainSigningAddress: ocrtypes.OnChainSigningAddress(key.OnChainSigning.Address()),
+					TransmitAddress:       forwarder,
+					OffchainPublicKey:     ocrtypes.OffchainPublicKey(key.PublicKeyOffChain()),
+					PeerID:                peerID,
+				},
+				SharedSecretEncryptionPublicKey: ocrtypes.SharedSecretEncryptionPublicKey(key.PublicKeyConfig()),
+			})
+		}
+
+		stopBlocks := utils.FiniteTicker(time.Second, func() {
+			b.Commit()
+		})
+		defer stopBlocks()
+
+		_, err := ocrContract.SetPayees(owner,
+			forwardersContracts,
+			transmitters,
+		)
+		require.NoError(t, err)
+		b.Commit()
+
+		signers, effectiveTransmitters, threshold, encodedConfigVersion, encodedConfig, err := confighelper.ContractSetConfigArgsForIntegrationTest(
+			oracles,
+			1,
+			1000000000/100, // threshold PPB
+		)
+		require.NoError(t, err)
+		_, err = ocrContract.SetConfig(owner,
+			signers,
+			effectiveTransmitters, // forwarder Addresses
+			threshold,
+			encodedConfigVersion,
+			encodedConfig,
+		)
+		require.NoError(t, err)
+		b.Commit()
+
+		err = appBootstrap.Start(testutils.Context(t))
+		require.NoError(t, err)
+
+		// set forwardingAllowed = true
+		jb, err := ocr.ValidatedOracleSpecToml(appBootstrap.GetChains().EVM, fmt.Sprintf(`
+type               = "offchainreporting"
+schemaVersion      = 1
+name               = "boot"
+contractAddress    = "%s"
+forwardingAllowed  = true
+isBootstrapPeer    = true
+`, ocrContractAddress))
+		require.NoError(t, err)
+		jb.Name = null.NewString("boot", true)
+		err = appBootstrap.AddJobV2(testutils.Context(t), &jb)
+		require.NoError(t, err)
+
+		// Raising flags to initiate hibernation
+		_, err = flagsContract.RaiseFlag(owner, ocrContractAddress)
+		require.NoError(t, err, "failed to raise flag for ocrContractAddress")
+		_, err = flagsContract.RaiseFlag(owner, utils.ZeroAddress)
+		require.NoError(t, err, "failed to raise flag for ZeroAddress")
+
+		b.Commit()
+
+		var jids []int32
+		var servers, slowServers = make([]*httptest.Server, 4), make([]*httptest.Server, 4)
+		// We expect metadata of:
+		//  latestAnswer:nil // First call
+		//  latestAnswer:0
+		//  latestAnswer:10
+		//  latestAnswer:20
+		//  latestAnswer:30
+		var metaLock sync.Mutex
+		expectedMeta := map[string]struct{}{
+			"0": {}, "10": {}, "20": {}, "30": {},
+		}
+		for i := 0; i < numOracles; i++ {
+			err = apps[i].Start(testutils.Context(t))
+			require.NoError(t, err)
+
+			// Since this API speed is > ObservationTimeout we should ignore it and still produce values.
+			slowServers[i] = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+				time.Sleep(5 * time.Second)
+				res.WriteHeader(http.StatusOK)
+				res.Write([]byte(`{"data":10}`))
+			}))
+			defer slowServers[i].Close()
+			servers[i] = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+				b, err := ioutil.ReadAll(req.Body)
+				require.NoError(t, err)
+				var m bridges.BridgeMetaDataJSON
+				require.NoError(t, json.Unmarshal(b, &m))
+				if m.Meta.LatestAnswer != nil && m.Meta.UpdatedAt != nil {
+					metaLock.Lock()
+					delete(expectedMeta, m.Meta.LatestAnswer.String())
+					metaLock.Unlock()
+				}
+				res.WriteHeader(http.StatusOK)
+				res.Write([]byte(`{"data":10}`))
+			}))
+			defer servers[i].Close()
+			u, _ := url.Parse(servers[i].URL)
+			err := apps[i].BridgeORM().CreateBridgeType(&bridges.BridgeType{
+				Name: bridges.BridgeName(fmt.Sprintf("bridge%d", i)),
+				URL:  models.WebURL(*u),
+			})
+			require.NoError(t, err)
+
+			// Note we need: observationTimeout + observationGracePeriod + DeltaGrace (500ms) < DeltaRound (1s)
+			// So 200ms + 200ms + 500ms < 1s
+			// forwardingAllowed = true
+			jb, err := ocr.ValidatedOracleSpecToml(apps[i].GetChains().EVM, fmt.Sprintf(`
+type               = "offchainreporting"
+schemaVersion      = 1
+name               = "web oracle spec"
+contractAddress    = "%s"
+forwardingAllowed  = true
+isBootstrapPeer    = false
+p2pBootstrapPeers  = [
+    "/ip4/127.0.0.1/tcp/%d/p2p/%s"
+]
+keyBundleID        = "%s"
+transmitterAddress = "%s"
+observationTimeout = "100ms"
+contractConfigConfirmations = 1
+contractConfigTrackerPollInterval = "1s"
+observationSource = """
+    // data source 1
+    ds1          [type=bridge name="%s"];
+    ds1_parse    [type=jsonparse path="data"];
+    ds1_multiply [type=multiply times=%d];
+
+    // data source 2
+    ds2          [type=http method=GET url="%s"];
+    ds2_parse    [type=jsonparse path="data"];
+    ds2_multiply [type=multiply times=%d];
+
+    ds1 -> ds1_parse -> ds1_multiply -> answer1;
+    ds2 -> ds2_parse -> ds2_multiply -> answer1;
+
+	answer1 [type=median index=0];
+"""
+`, ocrContractAddress, bootstrapNodePortV1, bootstrapPeerID, keys[i].ID(), transmitters[i], fmt.Sprintf("bridge%d", i), i, slowServers[i].URL, i))
+			require.NoError(t, err)
+			jb.Name = null.NewString("testocr", true)
+			err = apps[i].AddJobV2(testutils.Context(t), &jb)
+			require.NoError(t, err)
+			jids = append(jids, jb.ID)
+		}
+
+		// Assert that all the OCR jobs get a run with valid values eventually.
+		for i := 0; i < numOracles; i++ {
+			// Want at least 2 runs so we see all the metadata.
+			pr := cltest.WaitForPipelineComplete(t, i, jids[i],
+				2, 7, apps[i].JobORM(), time.Minute, time.Second)
+			jb, err := pr[0].Outputs.MarshalJSON()
+			require.NoError(t, err)
+			assert.Equal(t, []byte(fmt.Sprintf("[\"%d\"]", 10*i)), jb, "pr[0] %+v pr[1] %+v", pr[0], pr[1])
+			require.NoError(t, err)
+		}
+
+		// 4 oracles reporting 0, 10, 20, 30. Answer should be 20 (results[4/2]).
+		g.Eventually(func() string {
+			answer, err := ocrContract.LatestAnswer(nil)
+			require.NoError(t, err)
+			return answer.String()
+		}, testutils.WaitTimeout(t), cltest.DBPollingInterval).Should(gomega.Equal("20"))
+
+		for _, app := range apps {
+			jobs, _, err := app.JobORM().FindJobs(0, 1000)
+			require.NoError(t, err)
+			// No spec errors
+			for _, j := range jobs {
+				ignore := 0
+				for i := range j.JobSpecErrors {
+					// Non-fatal timing related error, ignore for testing.
+					if strings.Contains(j.JobSpecErrors[i].Description, "leader's phase conflicts tGrace timeout") {
+						ignore++
+					}
+				}
+				require.Len(t, j.JobSpecErrors, ignore)
+			}
+		}
+		metaLock.Lock()
+		defer metaLock.Unlock()
+		assert.Len(t, expectedMeta, 0, "expected metadata %v", expectedMeta)
+	})
 }
 
 func TestIntegration_BlockHistoryEstimator(t *testing.T) {

--- a/core/services/ocr/contract_transmitter.go
+++ b/core/services/ocr/contract_transmitter.go
@@ -22,12 +22,13 @@ var (
 
 type (
 	OCRContractTransmitter struct {
-		contractAddress gethCommon.Address
-		contractABI     abi.ABI
-		transmitter     ocrcommon.Transmitter
-		contractCaller  *offchainaggregator.OffchainAggregatorCaller
-		tracker         *OCRContractTracker
-		chainID         *big.Int
+		contractAddress             gethCommon.Address
+		contractABI                 abi.ABI
+		transmitter                 ocrcommon.Transmitter
+		contractCaller              *offchainaggregator.OffchainAggregatorCaller
+		tracker                     *OCRContractTracker
+		chainID                     *big.Int
+		effectiveTransmitterAddress gethCommon.Address
 	}
 )
 
@@ -39,14 +40,16 @@ func NewOCRContractTransmitter(
 	logBroadcaster log.Broadcaster,
 	tracker *OCRContractTracker,
 	chainID *big.Int,
+	effectiveTransmitterAddress gethCommon.Address,
 ) *OCRContractTransmitter {
 	return &OCRContractTransmitter{
-		contractAddress: address,
-		contractABI:     contractABI,
-		transmitter:     transmitter,
-		contractCaller:  contractCaller,
-		tracker:         tracker,
-		chainID:         chainID,
+		contractAddress:             address,
+		contractABI:                 contractABI,
+		transmitter:                 transmitter,
+		contractCaller:              contractCaller,
+		tracker:                     tracker,
+		chainID:                     chainID,
+		effectiveTransmitterAddress: effectiveTransmitterAddress,
 	}
 }
 
@@ -69,7 +72,7 @@ func (oc *OCRContractTransmitter) LatestTransmissionDetails(ctx context.Context)
 }
 
 func (oc *OCRContractTransmitter) FromAddress() gethCommon.Address {
-	return oc.transmitter.FromAddress()
+	return oc.effectiveTransmitterAddress
 }
 
 func (oc *OCRContractTransmitter) ChainID() *big.Int {

--- a/core/services/ocr/contract_transmitter_test.go
+++ b/core/services/ocr/contract_transmitter_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/services/ocr"
 	"github.com/smartcontractkit/libocr/gethwrappers/offchainaggregator"
@@ -25,6 +26,7 @@ func Test_ContractTransmitter_ChainID(t *testing.T) {
 		nil,
 		nil,
 		chainID,
+		common.Address{},
 	)
 
 	assert.Equal(t, chainID, ct.ChainID())

--- a/core/services/ocr/delegate.go
+++ b/core/services/ocr/delegate.go
@@ -222,14 +222,27 @@ func (d Delegate) ServicesForSpec(jb job.Job) (services []job.ServiceCtx, err er
 		}
 		gasLimit := pipeline.SelectGasLimit(chain.Config(), jb.Type.String(), jsGasLimit)
 
+		// effectiveTransmitterAddress is the transmitter address registered on the ocr contract. This is by default the EOA account on the node.
+		// In the case of forwarding, the transmitter address is the forwarder contract deployed onchain between EOA and OCR contract.
+		effectiveTransmitterAddress := concreteSpec.TransmitterAddress.Address()
+		if jb.ForwardingAllowed {
+			fwdrAddress, fwderr := chain.TxManager().GetForwarderForEOA(concreteSpec.TransmitterAddress.Address())
+			if fwderr == nil {
+				effectiveTransmitterAddress = fwdrAddress
+			} else {
+				lggr.Warnw("Skipping forwarding for job, will fallback to default behavior", "job", jb.Name, "err", fwderr)
+			}
+		}
+
 		contractTransmitter := NewOCRContractTransmitter(
 			concreteSpec.ContractAddress.Address(),
 			contractCaller,
 			contractABI,
-			ocrcommon.NewTransmitter(chain.TxManager(), concreteSpec.TransmitterAddress.Address(), gasLimit, jb.ForwardingAllowed, strategy, checker),
+			ocrcommon.NewTransmitter(chain.TxManager(), concreteSpec.TransmitterAddress.Address(), gasLimit, effectiveTransmitterAddress, strategy, checker),
 			chain.LogBroadcaster(),
 			tracker,
 			chain.ID(),
+			effectiveTransmitterAddress,
 		)
 
 		runResults := make(chan pipeline.Run, chain.Config().JobPipelineResultWriteQueueDepth())

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -12,6 +12,7 @@ import (
 	dkgpkg "github.com/smartcontractkit/ocr2vrf/dkg"
 	"github.com/smartcontractkit/ocr2vrf/ocr2vrf"
 	"github.com/smartcontractkit/sqlx"
+	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink-relay/pkg/types"
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
@@ -105,6 +106,35 @@ func (d Delegate) ServicesForSpec(jobSpec job.Job) ([]job.ServiceCtx, error) {
 		return nil, errors.Errorf("%s relay does not exist is it enabled?", spec.Relay)
 	}
 
+	chainIDInterface, ok := jobSpec.OCR2OracleSpec.RelayConfig["chainID"]
+	if !ok {
+		return nil, errors.New("chainID must be provided in relay config")
+	}
+	chainID := int64(chainIDInterface.(float64))
+	chain, err2 := d.chainSet.Get(big.NewInt(chainID))
+	if err2 != nil {
+		return nil, errors.Wrap(err2, "get chainset")
+	}
+
+	lggr := d.lggr.Named("OCR").With(
+		"contractID", spec.ContractID,
+		"jobName", jobSpec.Name.ValueOrZero(),
+		"jobID", jobSpec.ID,
+	)
+
+	// effectiveTransmitterAddress is the transmitter address registered on the ocr contract. This is by default the EOA account on the node.
+	// In the case of forwarding, the transmitter address is the forwarder contract deployed onchain between EOA and OCR contract.
+	effectiveTransmitterAddress := spec.TransmitterID
+	if jobSpec.ForwardingAllowed {
+		fwdrAddress, fwderr := chain.TxManager().GetForwarderForEOA(common.HexToAddress(jobSpec.OCR2OracleSpec.TransmitterID.String))
+		if fwderr == nil {
+			effectiveTransmitterAddress = null.StringFrom(fwdrAddress.String())
+		} else {
+			lggr.Warnw("Skipping forwarding for job, will fallback to default behavior", "job", jobSpec.Name, "err", fwderr)
+		}
+	}
+	spec.RelayConfig["effectiveTransmitterAddress"] = effectiveTransmitterAddress
+
 	ocrDB := NewDB(d.db, spec.ID, d.lggr, d.cfg)
 	peerWrapper := d.peerWrapper
 	if peerWrapper == nil {
@@ -113,11 +143,6 @@ func (d Delegate) ServicesForSpec(jobSpec job.Job) ([]job.ServiceCtx, error) {
 		return nil, errors.New("peerWrapper is not started. OCR2 jobs require a started and running peer. Did you forget to specify P2P_LISTEN_PORT?")
 	}
 
-	lggr := d.lggr.Named("OCR").With(
-		"contractID", spec.ContractID,
-		"jobName", jobSpec.Name.ValueOrZero(),
-		"jobID", jobSpec.ID,
-	)
 	ocrLogger := logger.NewOCRWrapper(lggr, true, func(msg string) {
 		d.lggr.ErrorIf(d.jobORM.RecordError(jobSpec.ID, msg), "unable to record error")
 	})
@@ -159,11 +184,10 @@ func (d Delegate) ServicesForSpec(jobSpec job.Job) ([]job.ServiceCtx, error) {
 	case job.Median:
 		medianProvider, err2 := relayer.NewMedianProvider(
 			types.RelayArgs{
-				ExternalJobID:     jobSpec.ExternalJobID,
-				JobID:             spec.ID,
-				ContractID:        spec.ContractID,
-				RelayConfig:       spec.RelayConfig.Bytes(),
-				ForwardingAllowed: jobSpec.ForwardingAllowed,
+				ExternalJobID: jobSpec.ExternalJobID,
+				JobID:         spec.ID,
+				ContractID:    spec.ContractID,
+				RelayConfig:   spec.RelayConfig.Bytes(),
 			}, types.PluginArgs{
 				TransmitterID: spec.TransmitterID.String,
 				PluginConfig:  spec.PluginConfig.Bytes(),
@@ -174,23 +198,13 @@ func (d Delegate) ServicesForSpec(jobSpec job.Job) ([]job.ServiceCtx, error) {
 		ocr2Provider = medianProvider
 		pluginOracle, err = median.NewMedian(jobSpec, medianProvider, d.pipelineRunner, runResults, lggr, ocrLogger)
 	case job.DKG:
-		chainIDInterface, ok := jobSpec.OCR2OracleSpec.RelayConfig["chainID"]
-		if !ok {
-			return nil, errors.New("chainID must be provided in relay config")
-		}
-		chainID := int64(chainIDInterface.(float64))
-		chain, err2 := d.chainSet.Get(big.NewInt(chainID))
-		if err2 != nil {
-			return nil, errors.Wrap(err2, "get chainset")
-		}
 		ocr2vrfRelayer := evmrelay.NewOCR2VRFRelayer(d.db, chain, lggr.Named("OCR2VRFRelayer"))
 		dkgProvider, err2 := ocr2vrfRelayer.NewDKGProvider(
 			types.RelayArgs{
-				ExternalJobID:     jobSpec.ExternalJobID,
-				JobID:             spec.ID,
-				ContractID:        spec.ContractID,
-				RelayConfig:       spec.RelayConfig.Bytes(),
-				ForwardingAllowed: jobSpec.ForwardingAllowed,
+				ExternalJobID: jobSpec.ExternalJobID,
+				JobID:         spec.ID,
+				ContractID:    spec.ContractID,
+				RelayConfig:   spec.RelayConfig.Bytes(),
 			}, types.PluginArgs{
 				TransmitterID: spec.TransmitterID.String,
 				PluginConfig:  spec.PluginConfig.Bytes(),
@@ -211,16 +225,6 @@ func (d Delegate) ServicesForSpec(jobSpec job.Job) ([]job.ServiceCtx, error) {
 			return nil, errors.Wrap(err, "error while instantiating DKG")
 		}
 	case job.OCR2VRF:
-		chainIDInterface, ok := jobSpec.OCR2OracleSpec.RelayConfig["chainID"]
-		if !ok {
-			return nil, errors.New("chainID must be provided in relay config")
-		}
-		chainID := int64(chainIDInterface.(float64))
-		chain, err2 := d.chainSet.Get(big.NewInt(chainID))
-		if err2 != nil {
-			return nil, errors.Wrap(err2, "get chainset")
-		}
-
 		var cfg ocr2vrfconfig.PluginConfig
 		err2 = json.Unmarshal(spec.PluginConfig.Bytes(), &cfg)
 		if err2 != nil {
@@ -236,11 +240,10 @@ func (d Delegate) ServicesForSpec(jobSpec job.Job) ([]job.ServiceCtx, error) {
 
 		vrfProvider, err2 := ocr2vrfRelayer.NewOCR2VRFProvider(
 			types.RelayArgs{
-				ExternalJobID:     jobSpec.ExternalJobID,
-				JobID:             spec.ID,
-				ContractID:        spec.ContractID,
-				RelayConfig:       spec.RelayConfig.Bytes(),
-				ForwardingAllowed: jobSpec.ForwardingAllowed,
+				ExternalJobID: jobSpec.ExternalJobID,
+				JobID:         spec.ID,
+				ContractID:    spec.ContractID,
+				RelayConfig:   spec.RelayConfig.Bytes(),
 			}, types.PluginArgs{
 				TransmitterID: spec.TransmitterID.String,
 				PluginConfig:  spec.PluginConfig.Bytes(),
@@ -251,11 +254,10 @@ func (d Delegate) ServicesForSpec(jobSpec job.Job) ([]job.ServiceCtx, error) {
 
 		dkgProvider, err2 := ocr2vrfRelayer.NewDKGProvider(
 			types.RelayArgs{
-				ExternalJobID:     jobSpec.ExternalJobID,
-				JobID:             spec.ID,
-				ContractID:        cfg.DKGContractAddress,
-				RelayConfig:       spec.RelayConfig.Bytes(),
-				ForwardingAllowed: jobSpec.ForwardingAllowed,
+				ExternalJobID: jobSpec.ExternalJobID,
+				JobID:         spec.ID,
+				ContractID:    cfg.DKGContractAddress,
+				RelayConfig:   spec.RelayConfig.Bytes(),
 			}, types.PluginArgs{
 				TransmitterID: spec.TransmitterID.String,
 				PluginConfig:  spec.PluginConfig.Bytes(),

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -126,7 +126,7 @@ func (d Delegate) ServicesForSpec(jobSpec job.Job) ([]job.ServiceCtx, error) {
 	// In the case of forwarding, the transmitter address is the forwarder contract deployed onchain between EOA and OCR contract.
 	effectiveTransmitterAddress := spec.TransmitterID
 	if jobSpec.ForwardingAllowed {
-		fwdrAddress, fwderr := chain.TxManager().GetForwarderForEOA(common.HexToAddress(jobSpec.OCR2OracleSpec.TransmitterID.String))
+		fwdrAddress, fwderr := chain.TxManager().GetForwarderForEOA(common.HexToAddress(spec.TransmitterID.String))
 		if fwderr == nil {
 			effectiveTransmitterAddress = null.StringFrom(fwdrAddress.String())
 		} else {

--- a/core/services/ocrcommon/transmitter.go
+++ b/core/services/ocrcommon/transmitter.go
@@ -20,38 +20,46 @@ type Transmitter interface {
 }
 
 type transmitter struct {
-	txm               txManager
-	fromAddress       common.Address
-	gasLimit          uint32
-	forwardingAllowed bool
-	strategy          txmgr.TxStrategy
-	checker           txmgr.TransmitCheckerSpec
+	txm                         txManager
+	fromAddress                 common.Address
+	gasLimit                    uint32
+	effectiveTransmitterAddress common.Address
+	strategy                    txmgr.TxStrategy
+	checker                     txmgr.TransmitCheckerSpec
 }
 
 // NewTransmitter creates a new eth transmitter
-func NewTransmitter(txm txManager, fromAddress common.Address, gasLimit uint32, forwardingAllowed bool, strategy txmgr.TxStrategy, checker txmgr.TransmitCheckerSpec) Transmitter {
+func NewTransmitter(txm txManager, fromAddress common.Address, gasLimit uint32, effectiveTransmitterAddress common.Address, strategy txmgr.TxStrategy, checker txmgr.TransmitCheckerSpec) Transmitter {
 	return &transmitter{
-		txm:               txm,
-		fromAddress:       fromAddress,
-		gasLimit:          gasLimit,
-		forwardingAllowed: forwardingAllowed,
-		strategy:          strategy,
-		checker:           checker,
+		txm:                         txm,
+		fromAddress:                 fromAddress,
+		gasLimit:                    gasLimit,
+		effectiveTransmitterAddress: effectiveTransmitterAddress,
+		strategy:                    strategy,
+		checker:                     checker,
 	}
 }
 
 func (t *transmitter) CreateEthTransaction(ctx context.Context, toAddress common.Address, payload []byte) error {
 	_, err := t.txm.CreateEthTransaction(txmgr.NewTx{
-		FromAddress:    t.fromAddress,
-		ToAddress:      toAddress,
-		EncodedPayload: payload,
-		GasLimit:       t.gasLimit,
-		Strategy:       t.strategy,
-		Checker:        t.checker,
+		FromAddress:      t.fromAddress,
+		ToAddress:        toAddress,
+		EncodedPayload:   payload,
+		GasLimit:         t.gasLimit,
+		ForwarderAddress: t.forwarderAddress(),
+		Strategy:         t.strategy,
+		Checker:          t.checker,
 	}, pg.WithParentCtx(ctx))
 	return errors.Wrap(err, "Skipped OCR transmission")
 }
 
 func (t *transmitter) FromAddress() common.Address {
 	return t.fromAddress
+}
+
+func (t *transmitter) forwarderAddress() common.Address {
+	if t.effectiveTransmitterAddress != t.fromAddress {
+		return t.effectiveTransmitterAddress
+	}
+	return common.Address{}
 }

--- a/core/services/ocrcommon/transmitter.go
+++ b/core/services/ocrcommon/transmitter.go
@@ -54,7 +54,7 @@ func (t *transmitter) CreateEthTransaction(ctx context.Context, toAddress common
 }
 
 func (t *transmitter) FromAddress() common.Address {
-	return t.fromAddress
+	return t.effectiveTransmitterAddress
 }
 
 func (t *transmitter) forwarderAddress() common.Address {

--- a/core/services/ocrcommon/transmitter_test.go
+++ b/core/services/ocrcommon/transmitter_test.go
@@ -24,13 +24,13 @@ func Test_Transmitter_CreateEthTransaction(t *testing.T) {
 	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
 
 	gasLimit := uint32(1000)
-	forwardingAllowed := false
+	effectiveTransmitterAddress := fromAddress
 	toAddress := testutils.NewAddress()
 	payload := []byte{1, 2, 3}
 	txm := txmmocks.NewTxManager(t)
 	strategy := txmmocks.NewTxStrategy(t)
 
-	transmitter := ocrcommon.NewTransmitter(txm, fromAddress, gasLimit, forwardingAllowed, strategy, txmgr.TransmitCheckerSpec{})
+	transmitter := ocrcommon.NewTransmitter(txm, fromAddress, gasLimit, effectiveTransmitterAddress, strategy, txmgr.TransmitCheckerSpec{})
 
 	txm.On("CreateEthTransaction", txmgr.NewTx{
 		FromAddress:    fromAddress,


### PR DESCRIPTION
This change does the following:

Move the forwarder matching query to job level, while still make
forwarding logic txm abstraction
rationale: Many services gate their execution logic by onchain auth
lists check, they will fail to check fromAddress auth, and therefore won't
work"

Add integration tests exercising forwarder flow for both ocr/ocr2

Simplify how we are propagating the forwardingAllowed attribute

This is PR2/3 working on this theme of pulling forwarder check to the job level
Related PRs: https://github.com/smartcontractkit/chainlink/pull/7475