### PR TITLE
enable CGO for chaos tests

### DIFF
--- a/.github/workflows/integration-chaos-tests.yml
+++ b/.github/workflows/integration-chaos-tests.yml
@@ -85,3 +85,4 @@ jobs:
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
+          CGO_ENABLED: 1


### PR DESCRIPTION
Attempting to fix chaos test failure:
https://github.com/smartcontractkit/chainlink/actions/runs/3109636078