### PR TITLE
tools/bin: rm -p 3 limit from tests

### DIFF
--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -8,7 +8,7 @@ OUTPUT_FILE="./output.txt"
 echo "Failed tests and panics: ---------------------"
 echo ""
 GO_LDFLAGS=$(bash tools/bin/ldflags)
-go test -ldflags "$GO_LDFLAGS" -tags integration -p 3 -coverprofile=coverage.txt -covermode=atomic ./... | tee $OUTPUT_FILE | grep --line-buffered --line-number -e "\-\-\- FAIL" -e "FAIL\s"
+go test -ldflags "$GO_LDFLAGS" -tags integration -coverprofile=coverage.txt -covermode=atomic ./... | tee $OUTPUT_FILE | grep --line-buffered --line-number -e "\-\-\- FAIL" -e "FAIL\s"
 EXITCODE=${PIPESTATUS[0]}
 echo ""
 echo "----------------------------------------------"


### PR DESCRIPTION
Trying to remove `-p 3` limit from test again:
- originally removed in #6856
- then restored in #7184

The same cross-package Solana integration test is failing again:
```
36:--- FAIL: TestTxm_Integration (30.02s)
88:FAIL	github.com/smartcontractkit/chainlink/core/chains/solana/soltxm	129.167s
```