### PR TITLE
Clear all logs after LCA during reorg

### DIFF
--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -79,21 +79,9 @@ func (o *ORM) SelectLatestLogEventSigWithConfs(eventSig common.Hash, address com
 	return &l, nil
 }
 
-func (o *ORM) DeleteRangeBlocks(start, end int64, qopts ...pg.QOpt) error {
-	q := o.q.WithOpts(qopts...)
-	_, err := q.Exec(`DELETE FROM log_poller_blocks WHERE block_number >= $1 AND block_number <= $2 AND evm_chain_id = $3`, start, end, utils.NewBig(o.chainID))
-	return err
-}
-
 func (o *ORM) DeleteBlocksAfter(start int64, qopts ...pg.QOpt) error {
 	q := o.q.WithOpts(qopts...)
 	_, err := q.Exec(`DELETE FROM log_poller_blocks WHERE block_number >= $1 AND evm_chain_id = $2`, start, utils.NewBig(o.chainID))
-	return err
-}
-
-func (o *ORM) DeleteLogs(start, end int64, qopts ...pg.QOpt) error {
-	q := o.q.WithOpts(qopts...)
-	_, err := q.Exec(`DELETE FROM logs WHERE block_number >= $1 AND block_number <= $2 AND evm_chain_id = $3`, start, end, utils.NewBig(o.chainID))
 	return err
 }
 

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -85,9 +85,21 @@ func (o *ORM) DeleteRangeBlocks(start, end int64, qopts ...pg.QOpt) error {
 	return err
 }
 
+func (o *ORM) DeleteBlocksAfter(start int64, qopts ...pg.QOpt) error {
+	q := o.q.WithOpts(qopts...)
+	_, err := q.Exec(`DELETE FROM log_poller_blocks WHERE block_number >= $1 AND evm_chain_id = $2`, start, utils.NewBig(o.chainID))
+	return err
+}
+
 func (o *ORM) DeleteLogs(start, end int64, qopts ...pg.QOpt) error {
 	q := o.q.WithOpts(qopts...)
 	_, err := q.Exec(`DELETE FROM logs WHERE block_number >= $1 AND block_number <= $2 AND evm_chain_id = $3`, start, end, utils.NewBig(o.chainID))
+	return err
+}
+
+func (o *ORM) DeleteLogsAfter(start int64, qopts ...pg.QOpt) error {
+	q := o.q.WithOpts(qopts...)
+	_, err := q.Exec(`DELETE FROM logs WHERE block_number >= $1 AND evm_chain_id = $2`, start, utils.NewBig(o.chainID))
 	return err
 }
 


### PR DESCRIPTION
Fixes edge case: during a replay the specified currentBlockNumber which may not be the latest in the db and so if there is a reorg we can't use it as the upper bound of non-canonical blocks/logs to remove. 