### PR TITLE
Add transaction forwarder integration to ocr2vrf (do not merge).

### DIFF
--- a/core/scripts/ocr2vrf/setup_ocr2vrf.go
+++ b/core/scripts/ocr2vrf/setup_ocr2vrf.go
@@ -32,8 +32,9 @@ func setupOCR2VRFNodes(e helpers.Environment) {
 	keyID := fs.String("key-id", "aee00d81f822f882b6fe28489822f59ebb21ea95c0ae21d9f67c0239461148fc", "key ID")
 	linkAddress := fs.String("link-address", "", "LINK token address")
 	linkEthFeed := fs.String("link-eth-feed", "", "LINK-ETH feed address")
+	useForwarder := fs.Bool("use-forwarder", false, "boolean to use the forwarder")
 	confDelays := fs.String("conf-delays", "1,2,3,4,5,6,7,8", "8 confirmation delays")
-	lookbackBlocks := fs.Int64("lookback-blocks", 1000, "lookback blocks")
+	lookbackBlocks := fs.Int64("lookback-blocks", 20, "lookback blocks")
 	weiPerUnitLink := fs.String("wei-per-unit-link", assets.GWei(60_000_000).String(), "wei per unit link price for feed")
 	beaconPeriodBlocks := fs.Int64("beacon-period-blocks", 3, "beacon period in blocks")
 
@@ -95,6 +96,21 @@ func setupOCR2VRFNodes(e helpers.Environment) {
 	fmt.Println("Deploying beacon consumer...")
 	consumerAddress := deployVRFBeaconCoordinatorConsumer(e, vrfCoordinatorAddress.String(), false, big.NewInt(*beaconPeriodBlocks))
 
+	var forwarderAddresses []common.Address
+	var forwarderAddressesStrings []string
+	// If using the forwarder, set up a forwarder for each node.
+	if *useForwarder {
+		fmt.Println("Deploying transaction forwarders...")
+		for i := 0; i < *nodeCount-1; i++ {
+			// Deploy an authorized forwarder, and add it to the list of forwarders.
+			f := deployAuthorizedForwarder(e, link, e.Owner.From)
+			forwarderAddresses = append(forwarderAddresses, f)
+			forwarderAddressesStrings = append(forwarderAddressesStrings, f.String())
+		}
+	}
+
+	fmt.Printf("ForwarderAddresses : %v", forwarderAddressesStrings)
+
 	fmt.Println("Configuring nodes with OCR2VRF jobs...")
 	var (
 		onChainPublicKeys  []string
@@ -104,6 +120,7 @@ func setupOCR2VRFNodes(e helpers.Environment) {
 		transmitters       []string
 		dkgEncrypters      []string
 		dkgSigners         []string
+		sendingKeys        [][]string
 	)
 	for i := 0; i < *nodeCount; i++ {
 		flagSet := flag.NewFlagSet("run-ocr2vrf-job-creation", flag.ExitOnError)
@@ -128,6 +145,12 @@ func setupOCR2VRFNodes(e helpers.Environment) {
 		flagSet.Int64("lookback-blocks", *lookbackBlocks, "lookback blocks")
 		flagSet.String("confirmation-delays", *confDelays, "confirmation delays")
 
+		// Apply forwarder args if using the forwarder.
+		if i > 0 && *useForwarder {
+			flagSet.Bool("use-forwarder", *useForwarder, "use a transaction forwarder")
+			flagSet.String("forwarder-address", forwarderAddressesStrings[i-1], "transaction forwarder address")
+		}
+
 		flagSet.Bool("dangerWillRobinson", true, "for resetting databases")
 		flagSet.Bool("isBootstrapper", i == 0, "is first node")
 		bootstrapperPeerID := ""
@@ -149,9 +172,37 @@ func setupOCR2VRFNodes(e helpers.Environment) {
 		transmitters = append(transmitters, payload.Transmitter)
 		dkgEncrypters = append(dkgEncrypters, payload.DkgEncrypt)
 		dkgSigners = append(dkgSigners, payload.DkgSign)
+		sendingKeys = append(sendingKeys, payload.SendingKeys)
 	}
 
-	helpers.FundNodes(e, transmitters, big.NewInt(*fundingAmount))
+	var nodesToFund []string
+	copy(nodesToFund, transmitters)
+
+	// If using the forwarder, set up a forwarder for each node.
+	if *useForwarder {
+		fmt.Println("Setting authorized senders...")
+		for i, f := range forwarderAddresses {
+
+			// Convert the sending strings for a transmitter to addresses.
+			var sendinKeysAddresses []common.Address
+			sendingKeysStrings := sendingKeys[i+1]
+			for _, s := range sendingKeysStrings {
+				sendinKeysAddresses = append(sendinKeysAddresses, common.HexToAddress(s))
+			}
+
+			// Set authorized senders for the corresponding forwarder.
+			setAuthorizedSenders(e, f, sendinKeysAddresses)
+
+			// Fund the sending keys.
+			nodesToFund = append(nodesToFund, sendingKeysStrings...)
+
+			// Set the authorized forwarder as the OCR transmitter.
+			transmitters[i+1] = f.String()
+		}
+	}
+
+	fmt.Println("Funding transmitters...")
+	helpers.FundNodes(e, nodesToFund, big.NewInt(*fundingAmount))
 
 	fmt.Println("Generated dkg setConfig command:")
 	dkgCommand := fmt.Sprintf(

--- a/core/scripts/ocr2vrf/util.go
+++ b/core/scripts/ocr2vrf/util.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/config"
+	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/authorized_forwarder"
 	dkgContract "github.com/smartcontractkit/chainlink/core/gethwrappers/ocr2vrf/generated/dkg"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/ocr2vrf/generated/vrf_beacon"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/ocr2vrf/generated/vrf_beacon_consumer"
@@ -43,6 +44,19 @@ func deployVRFCoordinator(e helpers.Environment, beaconPeriodBlocks *big.Int, li
 	_, tx, _, err := vrf_coordinator.DeployVRFCoordinator(e.Owner, e.Ec, beaconPeriodBlocks, common.HexToAddress(linkAddress))
 	helpers.PanicErr(err)
 	return helpers.ConfirmContractDeployed(context.Background(), e.Ec, tx, e.ChainID)
+}
+
+func deployAuthorizedForwarder(e helpers.Environment, link common.Address, owner common.Address) common.Address {
+	_, tx, _, err := authorized_forwarder.DeployAuthorizedForwarder(e.Owner, e.Ec, link, owner, common.Address{}, []byte{})
+	helpers.PanicErr(err)
+	return helpers.ConfirmContractDeployed(context.Background(), e.Ec, tx, e.ChainID)
+}
+
+func setAuthorizedSenders(e helpers.Environment, forwarder common.Address, senders []common.Address) {
+	f, err := authorized_forwarder.NewAuthorizedForwarder(forwarder, e.Ec)
+	helpers.PanicErr(err)
+	tx, err := f.SetAuthorizedSenders(e.Owner, senders)
+	helpers.ConfirmTXMined(context.Background(), e.Ec, tx, e.ChainID)
 }
 
 func deployVRFBeacon(e helpers.Environment, coordinatorAddress, linkAddress, dkgAddress, keyID string) common.Address {

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -180,7 +180,8 @@ func (o *orm) CreateJob(jb *Job, qopts ...pg.QOpt) error {
 			if jb.OCROracleSpec.TransmitterAddress != nil {
 				_, err := o.keyStore.Eth().Get(jb.OCROracleSpec.TransmitterAddress.Hex())
 				if err != nil {
-					return errors.Wrapf(ErrNoSuchTransmitterKey, "%v", jb.OCROracleSpec.TransmitterAddress)
+					// TODO: A case for this logic needs to be added, that allows for forwarders.
+					// 	return errors.Wrapf(ErrNoSuchTransmitterKey, "%v", jb.OCROracleSpec.TransmitterAddress)
 				}
 			}
 
@@ -229,20 +230,21 @@ func (o *orm) CreateJob(jb *Job, qopts ...pg.QOpt) error {
 			}
 			if jb.OCR2OracleSpec.TransmitterID.Valid {
 				switch jb.OCR2OracleSpec.Relay {
+				// TODO: A case for this logic needs to be added, that allows for forwarders.
 				case relay.EVM:
 					_, err := o.keyStore.Eth().Get(jb.OCR2OracleSpec.TransmitterID.String)
 					if err != nil {
-						return errors.Wrapf(ErrNoSuchTransmitterKey, "%v", jb.OCR2OracleSpec.TransmitterID)
+						// return errors.Wrapf(ErrNoSuchTransmitterKey, "%v", jb.OCR2OracleSpec.TransmitterID)
 					}
 				case relay.Solana:
 					_, err := o.keyStore.Solana().Get(jb.OCR2OracleSpec.TransmitterID.String)
 					if err != nil {
-						return errors.Wrapf(ErrNoSuchTransmitterKey, "%v", jb.OCR2OracleSpec.TransmitterID)
+						// return errors.Wrapf(ErrNoSuchTransmitterKey, "%v", jb.OCR2OracleSpec.TransmitterID)
 					}
 				case relay.Terra:
 					_, err := o.keyStore.Terra().Get(jb.OCR2OracleSpec.TransmitterID.String)
 					if err != nil {
-						return errors.Wrapf(ErrNoSuchTransmitterKey, "%v", jb.OCR2OracleSpec.TransmitterID)
+						// return errors.Wrapf(ErrNoSuchTransmitterKey, "%v", jb.OCR2OracleSpec.TransmitterID)
 					}
 				}
 			}

--- a/core/services/ocr2/plugins/dkg/config/config.go
+++ b/core/services/ocr2/plugins/dkg/config/config.go
@@ -11,6 +11,8 @@ type PluginConfig struct {
 	EncryptionPublicKey string `json:"encryptionPublicKey"`
 	SigningPublicKey    string `json:"signingPublicKey"`
 	KeyID               string `json:"keyID"`
+	UseForwarder        bool   `json:"useForwarder"`
+	SendingKeys         string `json:"sendingKeys"`
 }
 
 // ValidatePluginConfig validates that the given DKG plugin configuration is correct.

--- a/core/services/ocr2/plugins/ocr2vrf/config/config.go
+++ b/core/services/ocr2/plugins/ocr2vrf/config/config.go
@@ -26,6 +26,8 @@ type PluginConfig struct {
 	VRFCoordinatorAddress string `json:"vrfCoordinatorAddress"`
 	LinkEthFeedAddress    string `json:"linkEthFeedAddress"`
 	LookbackBlocks        int64  `json:"lookbackBlocks"`
+	UseForwarder          bool   `json:"useForwarder"`
+	SendingKeys           string `json:"sendingKeys"`
 }
 
 // ValidatePluginConfig validates that the given OCR2VRF plugin configuration is correct.


### PR DESCRIPTION
This PR integrates the transaction forwarder with OCR2VRF. 

- `NewOCRContractTransmitter` is not compatible with multiple sending keys, but it is used by potentially many ocr instances in-development. So, I have created `newContractTransmitterWithForwarder` and `NewTransmitterWithForwarder` that are compatible with the forwarder and don't interrupt current the current compatibility of `NewTransmitter`.

- Currently, the OCR job spec does only allows for the transmitterID to be a local sending key (see `core/services/job/orm.go`). I have manually commented out this logic, but a better solution needs to be implemented before this PR can be merged.

- The implementation is automated, and adds all local sending keys to the job spec of a node. The node then picks up those sending keys, and uses them in a round-robin fashion to send transactions through the forwarder. This is somewhat brittle (you cannot add/remove the sending keys the job uses while the node is running), but seems to be the preferred approach.