### PR TITLE
Fix evm chain shutdown bug

### DIFF
--- a/core/chains/evm/chain_set.go
+++ b/core/chains/evm/chain_set.go
@@ -20,7 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
-	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/config"
 	cfgv2 "github.com/smartcontractkit/chainlink/core/config/v2"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -314,7 +313,7 @@ func (cll *chainSet) ORM() types.ORM {
 	return cll.opts.ORM
 }
 
-func (cll *chainSet) GetNodes(ctx context.Context, offset, limit int) (nodes []evmtypes.Node, count int, err error) {
+func (cll *chainSet) GetNodes(ctx context.Context, offset, limit int) (nodes []types.Node, count int, err error) {
 	nodes, count, err = cll.opts.ORM.Nodes(offset, limit, pg.WithParentCtx(ctx))
 	if err != nil {
 		err = errors.Wrap(err, "GetNodes failed to load nodes from DB")
@@ -326,7 +325,7 @@ func (cll *chainSet) GetNodes(ctx context.Context, offset, limit int) (nodes []e
 	return
 }
 
-func (cll *chainSet) GetNodesForChain(ctx context.Context, chainID utils.Big, offset, limit int) (nodes []evmtypes.Node, count int, err error) {
+func (cll *chainSet) GetNodesForChain(ctx context.Context, chainID utils.Big, offset, limit int) (nodes []types.Node, count int, err error) {
 	nodes, count, err = cll.opts.ORM.NodesForChain(chainID, offset, limit, pg.WithParentCtx(ctx))
 	if err != nil {
 		err = errors.Wrap(err, "GetNodesForChain failed to load nodes from DB")
@@ -338,7 +337,7 @@ func (cll *chainSet) GetNodesForChain(ctx context.Context, chainID utils.Big, of
 	return
 }
 
-func (cll *chainSet) GetNodesByChainIDs(ctx context.Context, chainIDs []utils.Big) (nodes []evmtypes.Node, err error) {
+func (cll *chainSet) GetNodesByChainIDs(ctx context.Context, chainIDs []utils.Big) (nodes []types.Node, err error) {
 	nodes, err = cll.opts.ORM.GetNodesByChainIDs(chainIDs, pg.WithParentCtx(ctx))
 	if err != nil {
 		err = errors.Wrap(err, "GetNodesForChain failed to load nodes from DB")
@@ -364,7 +363,7 @@ func (cll *chainSet) DeleteNode(ctx context.Context, id int32) error {
 	return cll.opts.ORM.DeleteNode(id, pg.WithParentCtx(ctx))
 }
 
-func (cll *chainSet) addStateToNode(n *evmtypes.Node) {
+func (cll *chainSet) addStateToNode(n *types.Node) {
 	cll.chainsMu.RLock()
 	chain, exists := cll.chains[n.EVMChainID.String()]
 	cll.chainsMu.RUnlock()

--- a/core/chains/evm/chain_set.go
+++ b/core/chains/evm/chain_set.go
@@ -180,6 +180,7 @@ func (cll *chainSet) initializeChain(ctx context.Context, dbchain *types.DBChain
 	if err = chain.Start(ctx); err != nil {
 		return errors.Wrapf(err, "initializeChain: failed to start chain %s", dbchain.ID.String())
 	}
+	cll.startedChains = append(cll.startedChains, chain)
 	cll.chains[cid] = chain
 	return nil
 }

--- a/core/chains/evm/chain_set_test.go
+++ b/core/chains/evm/chain_set_test.go
@@ -90,7 +90,7 @@ func TestAddClose(t *testing.T) {
 	kst := cltest.NewKeyStore(t, db, cfg)
 	require.NoError(t, kst.Unlock(cltest.Password))
 
-	genEthClient := func(c types.DBChain) evmclient.Client {
+	genEthClient := func() evmclient.Client {
 		return cltest.NewEthMocksWithStartupAssertions(t)
 	}
 


### PR DESCRIPTION
    Fixes a bug where Close() was not getting called on newly added evm chains

This was causing these 2 tests to FAIL, whenever they take more than 2s to complete:

    go test ./core/web/ -run Test_EVMChainsController_Create -count 100
    go test ./core/web/ -run Test_EVMChainsController_Update -count 10