### PR TITLE
format comments for make help

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -130,11 +130,11 @@ test_perf: ## Run core node performance tests.
 	--progress $(args) ./integration-tests/performance
 
 .PHONY: test_chaos
-test_chaos: # run core node chaos tests.
+test_chaos: ## Run core node chaos tests.
 	ginkgo -r --focus @chaos --nodes 5 ./integration-tests/chaos
 
 .PHONY: config-docs
-config-docs: # Generate core node configuration documentation
+config-docs: ## Generate core node configuration documentation
 	go run ./internal/config/docs/main.go > ./docs/CONFIG.md
 
 help:


### PR DESCRIPTION
`make help` only lists commands with a double `##` comment.