### PR TITLE
Shut down OCR peer cleanly

### DIFF
--- a/core/services/ocr/delegate.go
+++ b/core/services/ocr/delegate.go
@@ -166,7 +166,7 @@ func (d Delegate) ServicesForSpec(jb job.Job) (services []job.ServiceCtx, err er
 	if concreteSpec.IsBootstrapPeer {
 		var bootstrapper *ocr.BootstrapNode
 		bootstrapper, err = ocr.NewBootstrapNode(ocr.BootstrapNodeArgs{
-			BootstrapperFactory:   peerWrapper.Peer,
+			BootstrapperFactory:   peerWrapper.Peer1,
 			V1Bootstrappers:       v1BootstrapPeers,
 			V2Bootstrappers:       v2Bootstrappers,
 			ContractConfigTracker: tracker,
@@ -279,7 +279,7 @@ func (d Delegate) ServicesForSpec(jb job.Job) (services []job.ServiceCtx, err er
 			ContractTransmitter:          contractTransmitter,
 			ContractConfigTracker:        tracker,
 			PrivateKeys:                  ocrkey,
-			BinaryNetworkEndpointFactory: peerWrapper.Peer,
+			BinaryNetworkEndpointFactory: peerWrapper.Peer1,
 			Logger:                       ocrLogger,
 			V1Bootstrappers:              v1BootstrapPeers,
 			V2Bootstrappers:              v2Bootstrappers,

--- a/core/services/ocrcommon/peer_wrapper.go
+++ b/core/services/ocrcommon/peer_wrapper.go
@@ -2,9 +2,10 @@ package ocrcommon
 
 import (
 	"context"
+	"io"
+	"reflect"
 
 	p2ppeerstore "github.com/libp2p/go-libp2p-core/peerstore"
-
 	"github.com/smartcontractkit/sqlx"
 
 	"github.com/smartcontractkit/chainlink/core/config"
@@ -13,7 +14,7 @@ import (
 	"github.com/pkg/errors"
 	ocrnetworking "github.com/smartcontractkit/libocr/networking"
 	ocrnetworkingtypes "github.com/smartcontractkit/libocr/networking/types"
-	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
+	ocr1types "github.com/smartcontractkit/libocr/offchainreporting/types"
 	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2/types"
 	"go.uber.org/multierr"
 
@@ -33,12 +34,12 @@ type PeerWrapperConfig interface {
 }
 
 type (
-	peerAdapter struct {
-		ocrtypes.BinaryNetworkEndpointFactory
-		ocrtypes.BootstrapperFactory
+	peerAdapterOCR1 struct {
+		ocr1types.BinaryNetworkEndpointFactory
+		ocr1types.BootstrapperFactory
 	}
 
-	peerAdapter2 struct {
+	peerAdapterOCR2 struct {
 		ocr2types.BinaryNetworkEndpointFactory
 		ocr2types.BootstrapperFactory
 	}
@@ -53,11 +54,14 @@ type (
 		PeerID        p2pkey.PeerID
 		pstoreWrapper *Pstorewrapper
 
-		// V1V2 adapter
-		Peer *peerAdapter
+		// Used at shutdown to stop all of this peer's goroutines
+		peerCloser io.Closer
 
-		// V2 peer
-		Peer2 *peerAdapter2
+		// OCR1 peer adapter
+		Peer1 *peerAdapterOCR1
+
+		// OCR2 peer adapter
+		Peer2 *peerAdapterOCR2
 	}
 )
 
@@ -193,14 +197,15 @@ func (p *SingletonPeerWrapper) Start(context.Context) error {
 		if err != nil {
 			return errors.Wrap(err, "error calling NewPeer")
 		}
-		p.Peer = &peerAdapter{
+		p.Peer1 = &peerAdapterOCR1{
 			peer.OCR1BinaryNetworkEndpointFactory(),
 			peer.OCR1BootstrapperFactory(),
 		}
-		p.Peer2 = &peerAdapter2{
+		p.Peer2 = &peerAdapterOCR2{
 			peer.OCR2BinaryNetworkEndpointFactory(),
 			peer.OCR2BootstrapperFactory(),
 		}
+		p.peerCloser = peer
 		return nil
 	})
 }
@@ -208,6 +213,9 @@ func (p *SingletonPeerWrapper) Start(context.Context) error {
 // Close closes the peer and peerstore
 func (p *SingletonPeerWrapper) Close() error {
 	return p.StopOnce("SingletonPeerWrapper", func() (err error) {
+		if !reflect.ValueOf(p.peerCloser).IsNil() {
+			err = p.peerCloser.Close()
+		}
 		if p.pstoreWrapper != nil {
 			err = multierr.Combine(err, p.pstoreWrapper.Close())
 		}

--- a/core/services/ocrcommon/peer_wrapper.go
+++ b/core/services/ocrcommon/peer_wrapper.go
@@ -3,7 +3,6 @@ package ocrcommon
 import (
 	"context"
 	"io"
-	"reflect"
 
 	p2ppeerstore "github.com/libp2p/go-libp2p-core/peerstore"
 	"github.com/smartcontractkit/sqlx"
@@ -213,7 +212,7 @@ func (p *SingletonPeerWrapper) Start(context.Context) error {
 // Close closes the peer and peerstore
 func (p *SingletonPeerWrapper) Close() error {
 	return p.StopOnce("SingletonPeerWrapper", func() (err error) {
-		if !reflect.ValueOf(p.peerCloser).IsNil() {
+		if p.peerCloser != nil {
 			err = p.peerCloser.Close()
 		}
 		if p.pstoreWrapper != nil {

--- a/core/services/ocrcommon/peer_wrapper_test.go
+++ b/core/services/ocrcommon/peer_wrapper_test.go
@@ -1,11 +1,22 @@
 package ocrcommon_test
 
 import (
+	"fmt"
 	"testing"
+	"time"
 
-	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/services/ocrcommon"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/libocr/networking"
 	"gopkg.in/guregu/null.v4"
+
+	"github.com/smartcontractkit/chainlink/core/internal/cltest/heavyweight"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/core/services/keystore/chaintype"
+	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
+	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ocr2key"
+	"github.com/smartcontractkit/chainlink/core/services/ocrcommon"
 
 	p2ppeer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
@@ -17,6 +28,54 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/p2pkey"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
+
+func setupV2Networking(
+	t *testing.T,
+	port int64,
+	dbName string,
+	nodeKey ethkey.KeyV2,
+	backend *backends.SimulatedBackend,
+) (chainlink.Application, string, common.Address, ocr2key.KeyBundle, *configtest.TestGeneralConfig) {
+	p2paddresses := []string{
+		fmt.Sprintf("127.0.0.1:%d", port),
+	}
+	config, _ := heavyweight.FullTestDB(t, fmt.Sprintf("%s%d", dbName, port))
+	config.Overrides.FeatureOffchainReporting = null.BoolFrom(false)
+	config.Overrides.FeatureOffchainReporting2 = null.BoolFrom(true)
+	config.Overrides.FeatureLogPoller = null.BoolFrom(true)
+	config.Overrides.GlobalGasEstimatorMode = null.NewString("FixedPrice", true)
+	config.Overrides.P2PEnabled = null.BoolFrom(true)
+	config.Overrides.SetP2PV2DeltaDial(500 * time.Millisecond)
+	config.Overrides.SetP2PV2DeltaReconcile(5 * time.Second)
+	config.Overrides.P2PListenPort = null.NewInt(0, true)
+	config.Overrides.P2PV2ListenAddresses = p2paddresses
+	config.Overrides.P2PV2AnnounceAddresses = p2paddresses
+	config.Overrides.P2PNetworkingStack = networking.NetworkingStackV2
+	config.Overrides.GlobalEvmGasLimitOCRJobType = null.IntFrom(5300000)
+
+	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, config, backend, nodeKey)
+
+	require.NoError(t, app.GetKeyStore().Unlock(testutils.Password))
+	_, err := app.GetKeyStore().P2P().Create()
+	require.NoError(t, err)
+	p2pIDs, err := app.GetKeyStore().P2P().GetAll()
+	require.NoError(t, err)
+	require.Len(t, p2pIDs, 1)
+	peerID := p2pIDs[0].PeerID()
+	config.Overrides.P2PPeerID = peerID
+
+	kb, err := app.GetKeyStore().OCR2().Create(chaintype.EVM)
+	require.NoError(t, err)
+
+	err = app.Start(testutils.Context(t))
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		err := app.Stop()
+		require.NoError(t, err)
+	})
+	return app, peerID.Raw(), nodeKey.Address, kb, config
+}
 
 func Test_SingletonPeerWrapper_Start(t *testing.T) {
 	t.Parallel()
@@ -90,4 +149,45 @@ func Test_SingletonPeerWrapper_Start(t *testing.T) {
 
 		require.Contains(t, pw.Start(testutils.Context(t)).Error(), "unable to find P2P key with id")
 	})
+}
+
+func Test_SingletonPeerWrapper_Close(t *testing.T) {
+	t.Parallel()
+
+	cfg := configtest.NewTestGeneralConfigWithOverrides(t, configtest.GeneralConfigOverrides{
+		P2PEnabled: null.BoolFrom(true),
+	})
+	db := pgtest.NewSqlxDB(t)
+
+	require.NoError(t, utils.JustError(db.Exec(`DELETE FROM encrypted_key_rings`)))
+
+	keyStore := cltest.NewKeyStore(t, db, cfg)
+	k, err := keyStore.P2P().Create()
+	require.NoError(t, err)
+
+	p2paddresses := []string{
+		"127.0.0.1:17193",
+	}
+
+	cfg.Overrides.P2PPeerID = k.PeerID()
+	cfg.Overrides.P2PNetworkingStack = networking.NetworkingStackV2
+	cfg.Overrides.P2PEnabled = null.BoolFrom(true)
+	cfg.Overrides.SetP2PV2DeltaDial(100 * time.Millisecond)
+	cfg.Overrides.SetP2PV2DeltaReconcile(1 * time.Second)
+	cfg.Overrides.P2PListenPort = null.NewInt(0, true)
+	cfg.Overrides.P2PV2ListenAddresses = p2paddresses
+	cfg.Overrides.P2PV2AnnounceAddresses = p2paddresses
+
+	pw := ocrcommon.NewSingletonPeerWrapper(keyStore, cfg, db, logger.TestLogger(t))
+
+	require.NoError(t, pw.Start(testutils.Context(t)))
+	require.True(t, pw.IsStarted(), "Should have started successfully")
+	pw.Close()
+
+	/* If peer is still stuck in listenLoop, we will get a bind error trying to start on the same port */
+	require.False(t, pw.IsStarted())
+	pw = ocrcommon.NewSingletonPeerWrapper(keyStore, cfg, db, logger.TestLogger(t))
+	require.NoError(t, pw.Start(testutils.Context(t)), "Should have shut down gracefully, and be able to re-use same port")
+	require.True(t, pw.IsStarted(), "Should have started successfully")
+	pw.Close()
 }


### PR DESCRIPTION
The `TestIntegration_OCR2VRF` integration test was failing once in a while, and consistently on the command line when run like this:
```
go test -v ./core/services/ocr2/plugins/ocr2vrf/internal/... -count 2
```
This was due to `peer.Close()` not getting called by `SingletonPeerWrapper.Close()` on shutdown.

This bug affects the gracefulness of both the OCR and OCR2 peer shutdown process, but for some reason was easier to notice in this specific test.

I've added a more consistent test for graceful shutdown of `SingletonPeerWrapper`, which will fail consistently on develop branches but passes on this branch.