### PR TITLE
core/chains/evm: fix flakey TestAddClose

### DIFF
--- a/core/chains/evm/chain_set_test.go
+++ b/core/chains/evm/chain_set_test.go
@@ -112,7 +112,7 @@ func TestAddClose(t *testing.T) {
 
 	chains = chainSet.Chains()
 	require.Equal(t, 2, len(chains))
-	require.Equal(t, *newId, *chains[1].ID())
+	require.NotEqual(t, chains[0].ID().String(), chains[1].ID().String())
 
 	assert.NoError(t, chains[0].Ready())
 	assert.NoError(t, chains[1].Ready())


### PR DESCRIPTION
`Chains()` makes a slice from map iteration order, so this test would fail when the chains were swapped.
IIUC this line was just meant to ensure that another different chain was in fact added, so comparing the two should be sufficient.