### PR TITLE
Add unregister to lp

### DIFF
--- a/core/chains/evm/forwarders/forwarder_manager.go
+++ b/core/chains/evm/forwarders/forwarder_manager.go
@@ -197,8 +197,8 @@ func (f *FwdMgr) subscribeForwardersLogs(fwdrs []Forwarder) error {
 func (f *FwdMgr) subscribeSendersChangedLogs(addr common.Address) error {
 	_, err := f.logpoller.RegisterFilter(
 		evmlogpoller.Filter{
-			[]common.Hash{authChangedTopic},
-			[]common.Address{addr},
+			EventSigs: []common.Hash{authChangedTopic},
+			Addresses: []common.Address{addr},
 		})
 	return err
 }

--- a/core/chains/evm/forwarders/forwarder_manager.go
+++ b/core/chains/evm/forwarders/forwarder_manager.go
@@ -195,9 +195,12 @@ func (f *FwdMgr) subscribeForwardersLogs(fwdrs []Forwarder) error {
 }
 
 func (f *FwdMgr) subscribeSendersChangedLogs(addr common.Address) error {
-	return f.logpoller.MergeFilter(
-		[]common.Hash{authChangedTopic},
-		[]common.Address{addr})
+	_, err := f.logpoller.RegisterFilter(
+		evmlogpoller.Filter{
+			[]common.Hash{authChangedTopic},
+			[]common.Address{addr},
+		})
+	return err
 }
 
 func (f *FwdMgr) setCachedSenders(addr common.Address, senders []common.Address) {

--- a/core/chains/evm/logpoller/doc.go
+++ b/core/chains/evm/logpoller/doc.go
@@ -12,7 +12,7 @@
 // that means that querying unfinalized logs may change between queries but finalized logs remain stable.
 // The threshold between unfinalized and finalized logs is the finalityDepth parameter, chosen such that with
 // exceedingly high probability logs finalityDepth deep cannot be reorged.
-// - After calling MergeFilter with a particular event, it will never miss logs for that event
+// - After calling RegisterFilter with a particular event, it will never miss logs for that event
 // despite node crashes and reorgs. The granularity of the filter is always at least one block (more when backfilling).
 // - After calling Replay(fromBlock), all blocks including that one to the latest chain tip will be polled
 // with the current filter. This can be used on first time job add to specify a start block from which you wish to capture

--- a/core/chains/evm/logpoller/integration_test.go
+++ b/core/chains/evm/logpoller/integration_test.go
@@ -106,7 +106,8 @@ func TestLogPoller_Integration(t *testing.T) {
 	th := logpoller.SetupTH(t, 2, 3, 2)
 	th.Client.Commit() // Block 2. Ensure we have finality number of blocks
 
-	require.NoError(t, th.LogPoller.MergeFilter([]common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{th.EmitterAddress1}))
+	_, err := th.LogPoller.RegisterFilter(logpoller.Filter{[]common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{th.EmitterAddress1}})
+	require.NoError(t, err)
 	require.NoError(t, th.LogPoller.Start(testutils.Context(t)))
 
 	// Emit some logs in blocks 3->7.
@@ -126,7 +127,11 @@ func TestLogPoller_Integration(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, 5, len(logs))
 	// Now let's update the filter and replay to get Log2 logs.
-	require.NoError(t, th.LogPoller.MergeFilter([]common.Hash{EmitterABI.Events["Log2"].ID}, []common.Address{th.EmitterAddress1}))
+	_, err = th.LogPoller.RegisterFilter(logpoller.Filter{
+		[]common.Hash{EmitterABI.Events["Log2"].ID},
+		[]common.Address{th.EmitterAddress1},
+	})
+	require.NoError(t, err)
 	// Replay an invalid block should error
 	assert.Error(t, th.LogPoller.Replay(testutils.Context(t), 0))
 	assert.Error(t, th.LogPoller.Replay(testutils.Context(t), 20))

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -30,7 +30,8 @@ import (
 type LogPoller interface {
 	services.ServiceCtx
 	Replay(ctx context.Context, fromBlock int64) error
-	MergeFilter(eventSigs []common.Hash, addresses []common.Address) error
+	RegisterFilter(filter Filter) (int, error)
+	UnregisterFilter(filterID int) error
 	LatestBlock(qopts ...pg.QOpt) (int64, error)
 	GetBlocks(ctx context.Context, numbers []uint64, qopts ...pg.QOpt) ([]LogPollerBlock, error)
 
@@ -64,9 +65,11 @@ type logPoller struct {
 	backfillBatchSize int64         // batch size to use when backfilling finalized logs
 	rpcBatchSize      int64         // batch size to use for fallback RPC calls made in GetBlocks
 
-	filterMu  sync.RWMutex
-	addresses map[common.Address]struct{}
-	eventSigs map[common.Hash]struct{}
+	filterMu        sync.RWMutex
+	currentFilterID int
+	filters         map[int]Filter
+	//Addresses map[common.Address]struct{}
+	//EventSigs map[common.Hash]struct{}
 
 	replayStart    chan ReplayRequest
 	replayComplete chan error
@@ -101,39 +104,59 @@ func NewLogPoller(orm *ORM, ec client.Client, lggr logger.Logger, pollPeriod tim
 		finalityDepth:     finalityDepth,
 		backfillBatchSize: backfillBatchSize,
 		rpcBatchSize:      rpcBatchSize,
-		addresses:         make(map[common.Address]struct{}),
-		eventSigs:         make(map[common.Hash]struct{}),
+		filters:           make(map[int]Filter),
 	}
 }
 
-// MergeFilter adds the provided eventSigs and addresses to the log poller's log filter query.
-// If an event matching any of the given event signatures is emitted from any of the provided addresses,
+type Filter struct {
+	EventSigs []common.Hash
+	Addresses []common.Address
+}
+
+// RegisterFilter adds the provided EventSigs and Addresses to the log poller's log filter query.
+// If any eventSig is emitted from any address, it will be captured by the log poller.
+// If an event matching any of the given event signatures is emitted from any of the provided Addresses,
 // the log poller will pick those up and save them. For topic specific queries see content based querying.
 // Clients may choose to MergeFilter and then Replay in order to ensure desired logs are present.
 // NOTE: due to constraints of the eth filter, there is "leakage" between successive MergeFilter calls, for example
 // MergeFilter(event1, addr1)
 // MergeFilter(event2, addr2)
 // will result in the poller saving (event1, addr2) or (event2, addr1) as well, should it exist.
-// Generally speaking this is harmless. We enforce that eventSigs and addresses are non-empty,
+// Generally speaking this is harmless. We enforce that EventSigs and Addresses are non-empty,
 // which means that anonymous events are not supported and log.Topics >= 1 always (log.Topics[0] is the event signature).
-func (lp *logPoller) MergeFilter(eventSigs []common.Hash, addresses []common.Address) error {
+// It returns an ID which can be used to unregister.
+func (lp *logPoller) RegisterFilter(filter Filter) (int, error) {
 	lp.filterMu.Lock()
 	defer lp.filterMu.Unlock()
-	// Add any valid unique eventSigs or addresses.
-	for _, eventSig := range eventSigs {
-		// Force specification of both address and eventSig to avoid
-		// events from unknown addresses.
+	if len(filter.Addresses) == 0 {
+		return 0, errors.Errorf("at least one address must be specified")
+	}
+	if len(filter.EventSigs) == 0 {
+		return 0, errors.Errorf("at least one event must be specified")
+	}
+	for _, eventSig := range filter.EventSigs {
 		if eventSig == [common.HashLength]byte{} {
-			return errors.Errorf("empty event sig")
+			return 0, errors.Errorf("empty event sig")
 		}
-		lp.eventSigs[eventSig] = struct{}{}
 	}
-	for _, addr := range addresses {
+	for _, addr := range filter.Addresses {
 		if addr == [common.AddressLength]byte{} {
-			return errors.Errorf("empty address")
+			return 0, errors.Errorf("empty address")
 		}
-		lp.addresses[addr] = struct{}{}
 	}
+	lp.currentFilterID++
+	lp.filters[lp.currentFilterID] = filter
+	return lp.currentFilterID, nil
+}
+
+func (lp *logPoller) UnregisterFilter(filterID int) error {
+	lp.filterMu.Lock()
+	defer lp.filterMu.Unlock()
+	_, ok := lp.filters[filterID]
+	if !ok {
+		return errors.Errorf("filter %d doesn't exist", filterID)
+	}
+	delete(lp.filters, filterID)
 	return nil
 }
 
@@ -141,16 +164,27 @@ func (lp *logPoller) filter(from, to *big.Int, bh *common.Hash) ethereum.FilterQ
 	lp.filterMu.Lock()
 	defer lp.filterMu.Unlock()
 	var (
-		addresses []common.Address
-		eventSigs []common.Hash
+		addresses  []common.Address
+		eventSigs  []common.Hash
+		addressMp  = make(map[common.Address]struct{})
+		eventSigMp = make(map[common.Hash]struct{})
 	)
-	for addr := range lp.addresses {
+	// Merge filters.
+	for _, filter := range lp.filters {
+		for _, addr := range filter.Addresses {
+			addressMp[addr] = struct{}{}
+		}
+		for _, eventSig := range filter.EventSigs {
+			eventSigMp[eventSig] = struct{}{}
+		}
+	}
+	for addr := range addressMp {
 		addresses = append(addresses, addr)
 	}
 	sort.Slice(addresses, func(i, j int) bool {
 		return bytes.Compare(addresses[i][:], addresses[j][:]) < 0
 	})
-	for eventSig := range lp.eventSigs {
+	for eventSig := range eventSigMp {
 		eventSigs = append(eventSigs, eventSig)
 	}
 	sort.Slice(eventSigs, func(i, j int) bool {
@@ -566,35 +600,13 @@ func (lp *logPoller) findBlockAfterLCA(ctx context.Context, current *types.Heade
 	return nil, errors.New("Reorg greater than finality depth")
 }
 
-func (lp *logPoller) assertInFilter(eventSigs []common.Hash, addresses []common.Address) error {
-	lp.filterMu.RLock()
-	defer lp.filterMu.RUnlock()
-	for _, eventSig := range eventSigs {
-		if _, ok := lp.eventSigs[eventSig]; !ok {
-			return errors.Errorf("eventSig %x not registered", eventSig)
-		}
-	}
-	for _, addr := range addresses {
-		if _, ok := lp.addresses[addr]; !ok {
-			return errors.Errorf("address %x not registered", addr)
-		}
-	}
-	return nil
-}
-
 // Logs returns logs matching topics and address (exactly) in the given block range,
 // which are canonical at time of query.
 func (lp *logPoller) Logs(start, end int64, eventSig common.Hash, address common.Address, qopts ...pg.QOpt) ([]Log, error) {
-	if err := lp.assertInFilter([]common.Hash{eventSig}, []common.Address{address}); err != nil {
-		return nil, err
-	}
 	return lp.orm.SelectLogsByBlockRangeFilter(start, end, address, eventSig[:], qopts...)
 }
 
 func (lp *logPoller) LogsWithSigs(start, end int64, eventSigs []common.Hash, address common.Address, qopts ...pg.QOpt) ([]Log, error) {
-	if err := lp.assertInFilter(eventSigs, []common.Address{address}); err != nil {
-		return nil, err
-	}
 	sigs := make([][]byte, 0, len(eventSigs))
 	for _, sig := range eventSigs {
 		sigs = append(sigs, sig.Bytes())
@@ -604,41 +616,26 @@ func (lp *logPoller) LogsWithSigs(start, end int64, eventSigs []common.Hash, add
 
 // IndexedLogs finds all the logs that have a topic value in topicValues at index topicIndex.
 func (lp *logPoller) IndexedLogs(eventSig common.Hash, address common.Address, topicIndex int, topicValues []common.Hash, confs int, qopts ...pg.QOpt) ([]Log, error) {
-	if err := lp.assertInFilter([]common.Hash{eventSig}, []common.Address{address}); err != nil {
-		return nil, err
-	}
 	return lp.orm.SelectIndexedLogs(address, eventSig[:], topicIndex, topicValues, confs, qopts...)
 }
 
 // LogsDataWordGreaterThan note index is 0 based.
 func (lp *logPoller) LogsDataWordGreaterThan(eventSig common.Hash, address common.Address, wordIndex int, wordValueMin common.Hash, confs int, qopts ...pg.QOpt) ([]Log, error) {
-	if err := lp.assertInFilter([]common.Hash{eventSig}, []common.Address{address}); err != nil {
-		return nil, err
-	}
 	return lp.orm.SelectDataWordGreaterThan(address, eventSig[:], wordIndex, wordValueMin, confs, qopts...)
 }
 
 // LogsDataWordRange note index is 0 based.
 func (lp *logPoller) LogsDataWordRange(eventSig common.Hash, address common.Address, wordIndex int, wordValueMin, wordValueMax common.Hash, confs int, qopts ...pg.QOpt) ([]Log, error) {
-	if err := lp.assertInFilter([]common.Hash{eventSig}, []common.Address{address}); err != nil {
-		return nil, err
-	}
 	return lp.orm.SelectDataWordRange(address, eventSig[:], wordIndex, wordValueMin, wordValueMax, confs, qopts...)
 }
 
 // IndexedLogsTopicGreaterThan finds all the logs that have a topic value greater than topicValueMin at index topicIndex.
 // Only works for integer topics.
 func (lp *logPoller) IndexedLogsTopicGreaterThan(eventSig common.Hash, address common.Address, topicIndex int, topicValueMin common.Hash, confs int, qopts ...pg.QOpt) ([]Log, error) {
-	if err := lp.assertInFilter([]common.Hash{eventSig}, []common.Address{address}); err != nil {
-		return nil, err
-	}
 	return lp.orm.SelectIndexLogsTopicGreaterThan(address, eventSig[:], topicIndex, topicValueMin, confs, qopts...)
 }
 
 func (lp *logPoller) IndexedLogsTopicRange(eventSig common.Hash, address common.Address, topicIndex int, topicValueMin common.Hash, topicValueMax common.Hash, confs int, qopts ...pg.QOpt) ([]Log, error) {
-	if err := lp.assertInFilter([]common.Hash{eventSig}, []common.Address{address}); err != nil {
-		return nil, err
-	}
 	return lp.orm.SelectIndexLogsTopicRange(address, eventSig[:], topicIndex, topicValueMin, topicValueMax, confs, qopts...)
 }
 
@@ -659,16 +656,10 @@ func (lp *logPoller) BlockByNumber(n int64, qopts ...pg.QOpt) (*LogPollerBlock, 
 
 // LatestLogByEventSigWithConfs finds the latest log that has confs number of blocks on top of the log.
 func (lp *logPoller) LatestLogByEventSigWithConfs(eventSig common.Hash, address common.Address, confs int, qopts ...pg.QOpt) (*Log, error) {
-	if err := lp.assertInFilter([]common.Hash{eventSig}, []common.Address{address}); err != nil {
-		return nil, err
-	}
 	return lp.orm.SelectLatestLogEventSigWithConfs(eventSig, address, confs, qopts...)
 }
 
 func (lp *logPoller) LatestLogEventSigsAddrsWithConfs(fromBlock int64, eventSigs []common.Hash, addresses []common.Address, confs int, qopts ...pg.QOpt) ([]Log, error) {
-	if err := lp.assertInFilter(eventSigs, addresses); err != nil {
-		return nil, err
-	}
 	return lp.orm.SelectLatestLogEventSigsAddrsWithConfs(fromBlock, addresses, eventSigs, confs, qopts...)
 }
 

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -438,9 +438,6 @@ func TestLogPoller_RegisterFilter(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []common.Address{a1, a2}, lp.Filter().Addresses)
 	assert.Equal(t, [][]common.Hash{{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}}, lp.Filter().Topics)
-
-	_, err = lp.Logs(1, 1, EmitterABI.Events["Log1"].ID, common.HexToAddress("0x2ab9a2dc53736b361b72d900cdf9f78f9406fbbd"))
-	require.Error(t, err)
 }
 
 func TestLogPoller_GetBlocks(t *testing.T) {

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -174,9 +174,11 @@ func TestLogPoller_PollAndSaveLogs(t *testing.T) {
 	th := SetupTH(t, 2, 3, 2)
 
 	// Set up a log poller listening for log emitter logs.
-	require.NoError(t, th.LogPoller.MergeFilter([]common.Hash{
-		EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{th.EmitterAddress1, th.EmitterAddress2},
-	))
+	_, err := th.LogPoller.RegisterFilter(Filter{
+		[]common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID},
+		[]common.Address{th.EmitterAddress1, th.EmitterAddress2},
+	})
+	require.NoError(t, err)
 
 	b, err := th.Client.BlockByNumber(testutils.Context(t), nil)
 	require.NoError(t, err)
@@ -385,7 +387,7 @@ func TestLogPoller_Logs(t *testing.T) {
 		GenLog(th.ChainID, 2, 3, "0x5", event2[:], address2),
 	}))
 
-	// Select for all addresses
+	// Select for all Addresses
 	lgs, err := th.ORM.SelectLogsByBlockRange(1, 3)
 	require.NoError(t, err)
 	require.Equal(t, 6, len(lgs))
@@ -416,36 +418,38 @@ func TestLogPoller_Logs(t *testing.T) {
 	assert.Equal(t, event1.Bytes(), lgs[0].Topics[0])
 }
 
-func TestLogPoller_MergeFilter(t *testing.T) {
+func TestLogPoller_RegisterFilter(t *testing.T) {
 	lp := NewLogPoller(nil, nil, nil, 15*time.Second, 1, 1, 2)
 	a1 := common.HexToAddress("0x2ab9a2dc53736b361b72d900cdf9f78f9406fbbb")
 	a2 := common.HexToAddress("0x2ab9a2dc53736b361b72d900cdf9f78f9406fbbc")
-	require.NoError(t, lp.MergeFilter([]common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{a1}))
+	_, err := lp.RegisterFilter(Filter{[]common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{a1}})
+	require.NoError(t, err)
 	assert.Equal(t, []common.Address{a1}, lp.Filter().Addresses)
 	assert.Equal(t, [][]common.Hash{{EmitterABI.Events["Log1"].ID}}, lp.Filter().Topics)
 
-	// Should de-dupe eventSigs
-	require.NoError(t, lp.MergeFilter([]common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}))
+	// Should de-dupe EventSigs
+	_, err = lp.RegisterFilter(Filter{[]common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}})
+	require.NoError(t, err)
 	assert.Equal(t, []common.Address{a1, a2}, lp.Filter().Addresses)
 	assert.Equal(t, [][]common.Hash{{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}}, lp.Filter().Topics)
 
-	// Should de-dupe addresses
-	require.NoError(t, lp.MergeFilter([]common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}))
+	// Should de-dupe Addresses
+	_, err = lp.RegisterFilter(Filter{[]common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}})
+	require.NoError(t, err)
 	assert.Equal(t, []common.Address{a1, a2}, lp.Filter().Addresses)
 	assert.Equal(t, [][]common.Hash{{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}}, lp.Filter().Topics)
 
-	require.Error(t, lp.assertInFilter([]common.Hash{common.HexToHash("0xd8d7ecc4800d25fa53ce0372f13a416d98907a7ef3d8d3bdd79cf4fe75529c65")}, []common.Address{a1}))
-	require.Error(t, lp.assertInFilter([]common.Hash{common.HexToHash("0xd8d7ecc4800d25fa53ce0372f13a416d98907a7ef3d8d3bdd79cf4fe75529c65")}, []common.Address{a1}))
-	_, err := lp.Logs(1, 1, EmitterABI.Events["Log1"].ID, common.HexToAddress("0x2ab9a2dc53736b361b72d900cdf9f78f9406fbbd"))
+	_, err = lp.Logs(1, 1, EmitterABI.Events["Log1"].ID, common.HexToAddress("0x2ab9a2dc53736b361b72d900cdf9f78f9406fbbd"))
 	require.Error(t, err)
 }
 
 func TestLogPoller_GetBlocks(t *testing.T) {
 	th := SetupTH(t, 2, 3, 2)
 
-	require.NoError(t, th.LogPoller.MergeFilter([]common.Hash{
-		EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{th.EmitterAddress1, th.EmitterAddress2},
-	))
+	_, err := th.LogPoller.RegisterFilter(Filter{[]common.Hash{
+		EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{th.EmitterAddress1, th.EmitterAddress2}},
+	)
+	require.NoError(t, err)
 
 	// LP retrieves block 1
 	blockNums := []uint64{1}

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -445,6 +445,12 @@ func TestLogPoller_RegisterFilter(t *testing.T) {
 	assert.Equal(t, []common.Address{a1, a2}, lp.Filter().Addresses)
 	assert.Equal(t, [][]common.Hash{{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}}, lp.Filter().Topics)
 
+	// Address required.
+	_, err = lp.RegisterFilter(Filter{[]common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{}})
+	require.Error(t, err)
+	// Event required
+	_, err = lp.RegisterFilter(Filter{[]common.Hash{}, []common.Address{a1}})
+	require.Error(t, err)
 	// ID should increment
 	id1, err := lp.RegisterFilter(Filter{[]common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}})
 	require.NoError(t, err)

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -438,6 +438,18 @@ func TestLogPoller_RegisterFilter(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, []common.Address{a1, a2}, lp.Filter().Addresses)
 	assert.Equal(t, [][]common.Hash{{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}}, lp.Filter().Topics)
+
+	// ID should increment
+	id1, err := lp.RegisterFilter(Filter{[]common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}})
+	require.NoError(t, err)
+	id2, err := lp.RegisterFilter(Filter{[]common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}})
+	require.NoError(t, err)
+	assert.Equal(t, id1+1, id2)
+	// Removing non-existence filterID should error.
+	err = lp.UnregisterFilter(id1)
+	require.NoError(t, err)
+	err = lp.UnregisterFilter(id1)
+	require.Error(t, err)
 }
 
 func TestLogPoller_GetBlocks(t *testing.T) {

--- a/core/chains/evm/logpoller/mocks/log_poller.go
+++ b/core/chains/evm/logpoller/mocks/log_poller.go
@@ -374,20 +374,6 @@ func (_m *LogPoller) LogsWithSigs(start int64, end int64, eventSigs []common.Has
 	return r0, r1
 }
 
-// MergeFilter provides a mock function with given fields: eventSigs, addresses
-func (_m *LogPoller) MergeFilter(eventSigs []common.Hash, addresses []common.Address) error {
-	ret := _m.Called(eventSigs, addresses)
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func([]common.Hash, []common.Address) error); ok {
-		r0 = rf(eventSigs, addresses)
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Ready provides a mock function with given fields:
 func (_m *LogPoller) Ready() error {
 	ret := _m.Called()
@@ -400,6 +386,27 @@ func (_m *LogPoller) Ready() error {
 	}
 
 	return r0
+}
+
+// RegisterFilter provides a mock function with given fields: filter
+func (_m *LogPoller) RegisterFilter(filter logpoller.Filter) (int, error) {
+	ret := _m.Called(filter)
+
+	var r0 int
+	if rf, ok := ret.Get(0).(func(logpoller.Filter) int); ok {
+		r0 = rf(filter)
+	} else {
+		r0 = ret.Get(0).(int)
+	}
+
+	var r1 error
+	if rf, ok := ret.Get(1).(func(logpoller.Filter) error); ok {
+		r1 = rf(filter)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
 }
 
 // Replay provides a mock function with given fields: ctx, fromBlock
@@ -423,6 +430,20 @@ func (_m *LogPoller) Start(_a0 context.Context) error {
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
 		r0 = rf(_a0)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// UnregisterFilter provides a mock function with given fields: filterID
+func (_m *LogPoller) UnregisterFilter(filterID int) error {
+	ret := _m.Called(filterID)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(int) error); ok {
+		r0 = rf(filterID)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -155,7 +155,7 @@ func (o *ORM) SelectLogsWithSigsByBlockRangeFilter(start, end int64, address com
 		"end":       end,
 		"chainid":   utils.NewBig(o.chainID),
 		"address":   address,
-		"eventSigs": eventSigs,
+		"EventSigs": eventSigs,
 	}
 	query, args, err := sqlx.Named(
 		`
@@ -165,7 +165,7 @@ FROM logs
 WHERE logs.block_number BETWEEN :start AND :end
 	AND logs.evm_chain_id = :chainid
 	AND logs.address = :address
-	AND logs.event_sig IN (:eventSigs)
+	AND logs.event_sig IN (:EventSigs)
 ORDER BY (logs.block_number, logs.log_index)`, a)
 	if err != nil {
 		return nil, errors.Wrap(err, "sqlx Named")
@@ -216,7 +216,7 @@ WHERE evm_chain_id = :chainid
 	return blocks, err
 }
 
-// SelectLatestLogEventSigsAddrsWithConfs finds the latest log by (address, event) combination that matches a list of addresses and list of events
+// SelectLatestLogEventSigsAddrsWithConfs finds the latest log by (address, event) combination that matches a list of Addresses and list of events
 func (o *ORM) SelectLatestLogEventSigsAddrsWithConfs(fromBlock int64, addresses []common.Address, eventSigs []common.Hash, confs int, qopts ...pg.QOpt) ([]Log, error) {
 	var logs []Log
 

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
@@ -120,12 +120,12 @@ func New(
 
 	// Add log filters for the log poller so that it can poll and find the logs that
 	// we need.
-	err = logPoller.MergeFilter([]common.Hash{
+	_, err = logPoller.RegisterFilter(logpoller.Filter{[]common.Hash{
 		t.randomnessRequestedTopic,
 		t.randomnessFulfillmentRequestedTopic,
 		t.randomWordsFulfilledTopic,
 		t.configSetTopic,
-		t.newTransmissionTopic}, []common.Address{beaconAddress, coordinatorAddress, dkgAddress})
+		t.newTransmissionTopic}, []common.Address{beaconAddress, coordinatorAddress, dkgAddress}})
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
@@ -120,12 +120,13 @@ func New(
 
 	// Add log filters for the log poller so that it can poll and find the logs that
 	// we need.
-	_, err = logPoller.RegisterFilter(logpoller.Filter{[]common.Hash{
-		t.randomnessRequestedTopic,
-		t.randomnessFulfillmentRequestedTopic,
-		t.randomWordsFulfilledTopic,
-		t.configSetTopic,
-		t.newTransmissionTopic}, []common.Address{beaconAddress, coordinatorAddress, dkgAddress}})
+	_, err = logPoller.RegisterFilter(logpoller.Filter{
+		EventSigs: []common.Hash{
+			t.randomnessRequestedTopic,
+			t.randomnessFulfillmentRequestedTopic,
+			t.randomWordsFulfilledTopic,
+			t.configSetTopic,
+			t.newTransmissionTopic}, Addresses: []common.Address{beaconAddress, coordinatorAddress, dkgAddress}})
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/relay/evm/config_poller.go
+++ b/core/services/relay/evm/config_poller.go
@@ -139,7 +139,7 @@ type ConfigPoller struct {
 }
 
 func NewConfigPoller(lggr logger.Logger, destChainPoller logpoller.LogPoller, addr common.Address) (*ConfigPoller, error) {
-	_, err := destChainPoller.RegisterFilter(logpoller.Filter{[]common.Hash{ConfigSet}, []common.Address{addr}});
+	_, err := destChainPoller.RegisterFilter(logpoller.Filter{EventSigs: []common.Hash{ConfigSet}, Addresses: []common.Address{addr}})
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/relay/evm/config_poller.go
+++ b/core/services/relay/evm/config_poller.go
@@ -139,7 +139,8 @@ type ConfigPoller struct {
 }
 
 func NewConfigPoller(lggr logger.Logger, destChainPoller logpoller.LogPoller, addr common.Address) (*ConfigPoller, error) {
-	if err := destChainPoller.MergeFilter([]common.Hash{ConfigSet}, []common.Address{addr}); err != nil {
+	_, err := destChainPoller.RegisterFilter(logpoller.Filter{[]common.Hash{ConfigSet}, []common.Address{addr}});
+	if err != nil {
 		return nil, err
 	}
 	return &ConfigPoller{
@@ -154,7 +155,7 @@ func (lp *ConfigPoller) Notify() <-chan struct{} {
 }
 
 func (lp *ConfigPoller) LatestConfigDetails(ctx context.Context) (changedInBlock uint64, configDigest ocrtypes.ConfigDigest, err error) {
-	latest, err := lp.destChainLogPoller.LatestLogByEventSigWithConfs(ConfigSet, lp.addr, 0, pg.WithParentCtx(ctx))
+	latest, err := lp.destChainLogPoller.LatestLogByEventSigWithConfs(ConfigSet, lp.addr, 1, pg.WithParentCtx(ctx))
 	if err != nil {
 		// If contract is not configured, we will not have the log.
 		if errors.Is(err, sql.ErrNoRows) {

--- a/core/services/relay/evm/contract_transmitter.go
+++ b/core/services/relay/evm/contract_transmitter.go
@@ -48,7 +48,7 @@ func NewOCRContractTransmitter(
 	if !ok {
 		return nil, errors.New("invalid ABI, missing transmitted")
 	}
-	_, err := lp.RegisterFilter(logpoller.Filter{[]common.Hash{transmitted.ID}, []common.Address{address}})
+	_, err := lp.RegisterFilter(logpoller.Filter{EventSigs: []common.Hash{transmitted.ID}, Addresses: []common.Address{address}})
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/relay/evm/contract_transmitter.go
+++ b/core/services/relay/evm/contract_transmitter.go
@@ -48,7 +48,8 @@ func NewOCRContractTransmitter(
 	if !ok {
 		return nil, errors.New("invalid ABI, missing transmitted")
 	}
-	if err := lp.MergeFilter([]common.Hash{transmitted.ID}, []common.Address{address}); err != nil {
+	_, err := lp.RegisterFilter(logpoller.Filter{[]common.Hash{transmitted.ID}, []common.Address{address}})
+	if err != nil {
 		return nil, err
 	}
 	return &ContractTransmitter{

--- a/core/services/relay/evm/contract_transmitter_test.go
+++ b/core/services/relay/evm/contract_transmitter_test.go
@@ -32,7 +32,7 @@ func TestContractTransmitter(t *testing.T) {
 			"0000000000000000000000000000000000000000000000000000000000000002") // epoch
 	c.On("CallContract", mock.Anything, mock.Anything, mock.Anything).Return(digestAndEpochDontScanLogs, nil).Once()
 	contractABI, _ := abi.JSON(strings.NewReader(ocr2aggregator.OCR2AggregatorABI))
-	lp.On("MergeFilter", mock.Anything, mock.Anything).Return(nil)
+	lp.On("RegisterFilter", mock.Anything, mock.Anything).Return(nil)
 	ot, err := NewOCRContractTransmitter(gethcommon.Address{}, c, contractABI, nil, lp, lggr)
 	require.NoError(t, err)
 	digest, epoch, err := ot.LatestConfigDigestAndEpoch(testutils.Context(t))

--- a/core/services/relay/evm/contract_transmitter_test.go
+++ b/core/services/relay/evm/contract_transmitter_test.go
@@ -32,7 +32,7 @@ func TestContractTransmitter(t *testing.T) {
 			"0000000000000000000000000000000000000000000000000000000000000002") // epoch
 	c.On("CallContract", mock.Anything, mock.Anything, mock.Anything).Return(digestAndEpochDontScanLogs, nil).Once()
 	contractABI, _ := abi.JSON(strings.NewReader(ocr2aggregator.OCR2AggregatorABI))
-	lp.On("RegisterFilter", mock.Anything, mock.Anything).Return(nil)
+	lp.On("RegisterFilter", mock.Anything, mock.Anything).Return(1, nil)
 	ot, err := NewOCRContractTransmitter(gethcommon.Address{}, c, contractABI, nil, lp, lggr)
 	require.NoError(t, err)
 	digest, epoch, err := ot.LatestConfigDigestAndEpoch(testutils.Context(t))


### PR DESCRIPTION
Optimizations:
- Clients may choose to unregister to stop capturing logs, for example upon job delete (but not node shutdown) 
- Benchmark the filter merging and cache it to improve perf
