### PR TITLE
Use default gas price and tip cap when there are no valid transactions

### DIFF
--- a/core/chains/evm/gas/helpers_test.go
+++ b/core/chains/evm/gas/helpers_test.go
@@ -87,6 +87,7 @@ type MockConfig struct {
 	EvmGasTipCapMinimumF                            *assets.Wei
 	EvmMaxGasPriceWeiF                              *assets.Wei
 	EvmMinGasPriceWeiF                              *assets.Wei
+	EvmGasPriceDefaultF                             *assets.Wei
 }
 
 func NewMockConfig() *MockConfig {
@@ -158,7 +159,7 @@ func (m *MockConfig) EvmGasLimitMultiplier() float32 {
 }
 
 func (m *MockConfig) EvmGasPriceDefault() *assets.Wei {
-	panic("not implemented") // TODO: Implement
+	return m.EvmGasPriceDefaultF
 }
 
 func (m *MockConfig) EvmGasTipCapDefault() *assets.Wei {

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -1094,9 +1094,13 @@ func Head(val interface{}) *evmtypes.Head {
 
 // LegacyTransactionsFromGasPrices returns transactions matching the given gas prices
 func LegacyTransactionsFromGasPrices(gasPrices ...int64) []gas.Transaction {
+	return LegacyTransactionsFromGasPricesTxType(0x0, gasPrices...)
+}
+
+func LegacyTransactionsFromGasPricesTxType(code gas.TxType, gasPrices ...int64) []gas.Transaction {
 	txs := make([]gas.Transaction, len(gasPrices))
 	for i, gasPrice := range gasPrices {
-		txs[i] = gas.Transaction{Type: 0x0, GasPrice: assets.NewWeiI(gasPrice), GasLimit: 42}
+		txs[i] = gas.Transaction{Type: code, GasPrice: assets.NewWeiI(gasPrice), GasLimit: 42}
 	}
 	return txs
 }
@@ -1104,9 +1108,13 @@ func LegacyTransactionsFromGasPrices(gasPrices ...int64) []gas.Transaction {
 // DynamicFeeTransactionsFromTipCaps returns EIP-1559 transactions with the
 // given TipCaps (FeeCap is arbitrary)
 func DynamicFeeTransactionsFromTipCaps(tipCaps ...int64) []gas.Transaction {
+	return DynamicFeeTransactionsFromTipCapsTxType(0x02, tipCaps...)
+}
+
+func DynamicFeeTransactionsFromTipCapsTxType(code gas.TxType, tipCaps ...int64) []gas.Transaction {
 	txs := make([]gas.Transaction, len(tipCaps))
 	for i, tipCap := range tipCaps {
-		txs[i] = gas.Transaction{Type: 0x2, MaxPriorityFeePerGas: assets.NewWeiI(tipCap), GasLimit: 42, MaxFeePerGas: assets.GWei(5000)}
+		txs[i] = gas.Transaction{Type: code, MaxPriorityFeePerGas: assets.NewWeiI(tipCap), GasLimit: 42, MaxFeePerGas: assets.GWei(5000)}
 	}
 	return txs
 }


### PR DESCRIPTION
Fallback to the default gas price or tip cap when the block history estimator doesn't have enough valid transactions to make an estimation. 