### PR TITLE
ci-core: increase scheduled race timeout and count

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -100,7 +100,9 @@ jobs:
         run: ./chainlink.test local db preparetest
       - name: Increase Race Timeout
         if: github.event.schedule != ''
-        run: echo "TIMEOUT=5m" >> $GITHUB_ENV
+        run: |
+          echo "TIMEOUT=10m" >> $GITHUB_ENV
+          echo "COUNT=50" >> $GITHUB_ENV
       - name: Run tests
         run: ./tools/bin/${{ matrix.cmd }} "${{ matrix.shard.pkgs }}"
       - name: Store logs artifacts on failure

--- a/tools/bin/go_core_race_tests
+++ b/tools/bin/go_core_race_tests
@@ -2,8 +2,9 @@
 set -ex
 
 TIMEOUT="${TIMEOUT:-30s}"
+COUNT="${COUNT:-10}"
 GO_LDFLAGS=$(bash tools/bin/ldflags)
-GORACE="log_path=$PWD/race" LOG_LEVEL=panic go test -race -ldflags "$GO_LDFLAGS" -shuffle on -timeout "$TIMEOUT" -count 10 $1 | tee ./output.txt
+GORACE="log_path=$PWD/race" LOG_LEVEL=panic go test -race -ldflags "$GO_LDFLAGS" -shuffle on -timeout "$TIMEOUT" -count "$COUNT" $1 | tee ./output.txt
 EXITCODE=${PIPESTATUS[0]}
 # Fail if any race logs are present.
 if ls race.* &>/dev/null


### PR DESCRIPTION
With Go 1.19 and the sharded CI workflow, the scheduled race detector run has decreased from ~1hr to ~20m. Since our intention here is to "soak" for an extended period of time, we can re-tune these runs to get increased coverage.

The `timeout` was already parameterized, so trying that first: `5m`->`10m`. (result: `20m`->`27m` total runtime)

However, not as many packages are hitting the `timeout` as before (in fact, some whole shards are <`5m`), so we may also want to bump the `count` which is currently fixed: `-count 10`. (`10`->`50` result: `27m`->`40m`)