### PR TITLE
Log poller DB optimizations

### DIFF
--- a/core/chains/evm/forwarders/forwarder_manager.go
+++ b/core/chains/evm/forwarders/forwarder_manager.go
@@ -224,6 +224,11 @@ func (f *FwdMgr) runLoop() {
 		select {
 		case <-tick:
 			addrs := f.collectAddresses()
+			if len(addrs) == 0 {
+				f.logger.Debug("Skipping log syncing, no forwarders tracked.")
+				continue
+			}
+
 			logs, err := f.logpoller.LatestLogEventSigsAddrsWithConfs(
 				f.latestBlock,
 				[]common.Hash{authChangedTopic},

--- a/core/chains/evm/logpoller/integration_test.go
+++ b/core/chains/evm/logpoller/integration_test.go
@@ -32,7 +32,7 @@ func logRuntime(t *testing.T, start time.Time) {
 }
 
 func TestPopulateLoadedDB(t *testing.T) {
-	t.Skip("only for local load testing and query analysis")
+	//t.Skip("only for local load testing and query analysis")
 	lggr := logger.TestLogger(t)
 	_, db := heavyweight.FullTestDB(t, "logs_scale")
 	chainID := big.NewInt(137)
@@ -57,7 +57,7 @@ func TestPopulateLoadedDB(t *testing.T) {
 				LogIndex:    1,
 				BlockHash:   common.HexToHash(fmt.Sprintf("0x%d", i+(1000*j))),
 				BlockNumber: int64(i + (1000 * j)),
-				EventSig:    event1[:],
+				EventSig:    event1,
 				Topics:      [][]byte{event1[:], logpoller.EvmWord(uint64(i + 1000*j)).Bytes()},
 				Address:     addr,
 				TxHash:      common.HexToHash("0x1234"),

--- a/core/chains/evm/logpoller/integration_test.go
+++ b/core/chains/evm/logpoller/integration_test.go
@@ -32,7 +32,7 @@ func logRuntime(t *testing.T, start time.Time) {
 }
 
 func TestPopulateLoadedDB(t *testing.T) {
-	//t.Skip("only for local load testing and query analysis")
+	t.Skip("only for local load testing and query analysis")
 	lggr := logger.TestLogger(t)
 	_, db := heavyweight.FullTestDB(t, "logs_scale")
 	chainID := big.NewInt(137)
@@ -68,7 +68,7 @@ func TestPopulateLoadedDB(t *testing.T) {
 	}
 	func() {
 		defer logRuntime(t, time.Now())
-		_, err := o.SelectLogsByBlockRangeFilter(750000, 800000, address1, event1[:])
+		_, err := o.SelectLogsByBlockRangeFilter(750000, 800000, address1, event1)
 		require.NoError(t, err)
 	}()
 	func() {
@@ -81,7 +81,7 @@ func TestPopulateLoadedDB(t *testing.T) {
 	require.NoError(t, o.InsertBlock(common.HexToHash("0x10"), 1000000))
 	func() {
 		defer logRuntime(t, time.Now())
-		lgs, err := o.SelectDataWordRange(address1, event1[:], 0, logpoller.EvmWord(500000), logpoller.EvmWord(500020), 0)
+		lgs, err := o.SelectDataWordRange(address1, event1, 0, logpoller.EvmWord(500000), logpoller.EvmWord(500020), 0)
 		require.NoError(t, err)
 		// 10 since every other log is for address1
 		assert.Equal(t, 10, len(lgs))
@@ -89,14 +89,14 @@ func TestPopulateLoadedDB(t *testing.T) {
 
 	func() {
 		defer logRuntime(t, time.Now())
-		lgs, err := o.SelectIndexedLogs(address2, event1[:], 1, []common.Hash{logpoller.EvmWord(500000), logpoller.EvmWord(500020)}, 0)
+		lgs, err := o.SelectIndexedLogs(address2, event1, 1, []common.Hash{logpoller.EvmWord(500000), logpoller.EvmWord(500020)}, 0)
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(lgs))
 	}()
 
 	func() {
 		defer logRuntime(t, time.Now())
-		lgs, err := o.SelectIndexLogsTopicRange(address1, event1[:], 1, logpoller.EvmWord(500000), logpoller.EvmWord(500020), 0)
+		lgs, err := o.SelectIndexLogsTopicRange(address1, event1, 1, logpoller.EvmWord(500000), logpoller.EvmWord(500020), 0)
 		require.NoError(t, err)
 		assert.Equal(t, 10, len(lgs))
 	}()

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -613,40 +613,36 @@ func (lp *logPoller) findBlockAfterLCA(ctx context.Context, current *types.Heade
 // Logs returns logs matching topics and address (exactly) in the given block range,
 // which are canonical at time of query.
 func (lp *logPoller) Logs(start, end int64, eventSig common.Hash, address common.Address, qopts ...pg.QOpt) ([]Log, error) {
-	return lp.orm.SelectLogsByBlockRangeFilter(start, end, address, eventSig[:], qopts...)
+	return lp.orm.SelectLogsByBlockRangeFilter(start, end, address, eventSig, qopts...)
 }
 
 func (lp *logPoller) LogsWithSigs(start, end int64, eventSigs []common.Hash, address common.Address, qopts ...pg.QOpt) ([]Log, error) {
-	sigs := make([][]byte, 0, len(eventSigs))
-	for _, sig := range eventSigs {
-		sigs = append(sigs, sig.Bytes())
-	}
-	return lp.orm.SelectLogsWithSigsByBlockRangeFilter(start, end, address, sigs, qopts...)
+	return lp.orm.SelectLogsWithSigsByBlockRangeFilter(start, end, address, eventSigs, qopts...)
 }
 
 // IndexedLogs finds all the logs that have a topic value in topicValues at index topicIndex.
 func (lp *logPoller) IndexedLogs(eventSig common.Hash, address common.Address, topicIndex int, topicValues []common.Hash, confs int, qopts ...pg.QOpt) ([]Log, error) {
-	return lp.orm.SelectIndexedLogs(address, eventSig[:], topicIndex, topicValues, confs, qopts...)
+	return lp.orm.SelectIndexedLogs(address, eventSig, topicIndex, topicValues, confs, qopts...)
 }
 
 // LogsDataWordGreaterThan note index is 0 based.
 func (lp *logPoller) LogsDataWordGreaterThan(eventSig common.Hash, address common.Address, wordIndex int, wordValueMin common.Hash, confs int, qopts ...pg.QOpt) ([]Log, error) {
-	return lp.orm.SelectDataWordGreaterThan(address, eventSig[:], wordIndex, wordValueMin, confs, qopts...)
+	return lp.orm.SelectDataWordGreaterThan(address, eventSig, wordIndex, wordValueMin, confs, qopts...)
 }
 
 // LogsDataWordRange note index is 0 based.
 func (lp *logPoller) LogsDataWordRange(eventSig common.Hash, address common.Address, wordIndex int, wordValueMin, wordValueMax common.Hash, confs int, qopts ...pg.QOpt) ([]Log, error) {
-	return lp.orm.SelectDataWordRange(address, eventSig[:], wordIndex, wordValueMin, wordValueMax, confs, qopts...)
+	return lp.orm.SelectDataWordRange(address, eventSig, wordIndex, wordValueMin, wordValueMax, confs, qopts...)
 }
 
 // IndexedLogsTopicGreaterThan finds all the logs that have a topic value greater than topicValueMin at index topicIndex.
 // Only works for integer topics.
 func (lp *logPoller) IndexedLogsTopicGreaterThan(eventSig common.Hash, address common.Address, topicIndex int, topicValueMin common.Hash, confs int, qopts ...pg.QOpt) ([]Log, error) {
-	return lp.orm.SelectIndexLogsTopicGreaterThan(address, eventSig[:], topicIndex, topicValueMin, confs, qopts...)
+	return lp.orm.SelectIndexLogsTopicGreaterThan(address, eventSig, topicIndex, topicValueMin, confs, qopts...)
 }
 
 func (lp *logPoller) IndexedLogsTopicRange(eventSig common.Hash, address common.Address, topicIndex int, topicValueMin common.Hash, topicValueMax common.Hash, confs int, qopts ...pg.QOpt) ([]Log, error) {
-	return lp.orm.SelectIndexLogsTopicRange(address, eventSig[:], topicIndex, topicValueMin, topicValueMax, confs, qopts...)
+	return lp.orm.SelectIndexLogsTopicRange(address, eventSig, topicIndex, topicValueMin, topicValueMax, confs, qopts...)
 }
 
 // LatestBlock returns the latest block the log poller is on. It tracks blocks to be able

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -346,7 +346,7 @@ func convertLogs(chainID *big.Int, logs []types.Log) []Log {
 			// We assume block numbers fit in int64
 			// in many places.
 			BlockNumber: int64(l.BlockNumber),
-			EventSig:    l.Topics[0].Bytes(), // First topic is always event signature.
+			EventSig:    l.Topics[0], // First topic is always event signature.
 			Topics:      convertTopics(l.Topics),
 			Address:     l.Address,
 			TxHash:      l.TxHash,

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -40,7 +40,7 @@ func GenLog(chainID *big.Int, logIndex int64, blockNum int64, blockHash string, 
 		LogIndex:    logIndex,
 		BlockHash:   common.HexToHash(blockHash),
 		BlockNumber: blockNum,
-		EventSig:    topic1,
+		EventSig:    common.BytesToHash(topic1),
 		Topics:      [][]byte{topic1},
 		Address:     address,
 		TxHash:      common.HexToHash("0x1234"),
@@ -599,6 +599,7 @@ func benchmarkFilter(b *testing.B, nFilters, nAddresses, nEvents int) {
 		_, err := lp.RegisterFilter(Filter{EventSigs: events, Addresses: addresses})
 		require.NoError(b, err)
 	}
+	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		lp.filter(nil, nil, nil)
 	}

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -399,7 +399,7 @@ func TestLogPoller_Logs(t *testing.T) {
 	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000005", lgs[5].BlockHash.String())
 
 	// Filter by Address and topic
-	lgs, err = th.ORM.SelectLogsByBlockRangeFilter(1, 3, address1, event1[:])
+	lgs, err = th.ORM.SelectLogsByBlockRangeFilter(1, 3, address1, event1)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(lgs))
 	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000003", lgs[0].BlockHash.String())
@@ -409,7 +409,7 @@ func TestLogPoller_Logs(t *testing.T) {
 	assert.Equal(t, address1, lgs[1].Address)
 
 	// Filter by block
-	lgs, err = th.ORM.SelectLogsByBlockRangeFilter(2, 2, address2, event1[:])
+	lgs, err = th.ORM.SelectLogsByBlockRangeFilter(2, 2, address2, event1)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(lgs))
 	assert.Equal(t, "0x0000000000000000000000000000000000000000000000000000000000000004", lgs[0].BlockHash.String())

--- a/core/chains/evm/logpoller/models.go
+++ b/core/chains/evm/logpoller/models.go
@@ -26,7 +26,7 @@ type Log struct {
 	BlockHash   common.Hash
 	BlockNumber int64
 	Topics      pq.ByteaArray
-	EventSig    []byte
+	EventSig    common.Hash
 	Address     common.Address
 	TxHash      common.Hash
 	Data        []byte

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -504,28 +504,17 @@ func BenchmarkLogs(b *testing.B) {
 			LogIndex:    int64(i),
 			BlockHash:   common.HexToHash("0x1"),
 			BlockNumber: 1,
-<<<<<<< Updated upstream
 			EventSig:    EmitterABI.Events["Log1"].ID,
-=======
-			EventSig:    EmitterABI.Events["Log1"].ID.Bytes(),
->>>>>>> Stashed changes
 			Topics:      [][]byte{},
 			Address:     addr,
 			TxHash:      common.HexToHash("0x1234"),
 			Data:        common.HexToHash(fmt.Sprintf("0x%d", i)).Bytes(),
 		})
 	}
-<<<<<<< Updated upstream
-	o.InsertLogs(lgs)
-	b.ResetTimer()
-	for n := 0; n < b.N; n++ {
-		o.SelectDataWordRange(addr, EmitterABI.Events["Log1"].ID, 0, EvmWord(8000), EvmWord(8002), 0)
-=======
 	require.NoError(b, o.InsertLogs(lgs))
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
-		_, err := o.SelectDataWordRange(addr, EmitterABI.Events["Log1"].ID.Bytes(), 0, EvmWord(8000), EvmWord(8002), 0)
+		_, err := o.SelectDataWordRange(addr, EmitterABI.Events["Log1"].ID, 0, EvmWord(8000), EvmWord(8002), 0)
 		require.NoError(b, err)
->>>>>>> Stashed changes
 	}
 }

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -504,16 +504,28 @@ func BenchmarkLogs(b *testing.B) {
 			LogIndex:    int64(i),
 			BlockHash:   common.HexToHash("0x1"),
 			BlockNumber: 1,
+<<<<<<< Updated upstream
 			EventSig:    EmitterABI.Events["Log1"].ID,
+=======
+			EventSig:    EmitterABI.Events["Log1"].ID.Bytes(),
+>>>>>>> Stashed changes
 			Topics:      [][]byte{},
 			Address:     addr,
 			TxHash:      common.HexToHash("0x1234"),
 			Data:        common.HexToHash(fmt.Sprintf("0x%d", i)).Bytes(),
 		})
 	}
+<<<<<<< Updated upstream
 	o.InsertLogs(lgs)
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		o.SelectDataWordRange(addr, EmitterABI.Events["Log1"].ID, 0, EvmWord(8000), EvmWord(8002), 0)
+=======
+	require.NoError(b, o.InsertLogs(lgs))
+	b.ResetTimer()
+	for n := 0; n < b.N; n++ {
+		_, err := o.SelectDataWordRange(addr, EmitterABI.Events["Log1"].ID.Bytes(), 0, EvmWord(8000), EvmWord(8002), 0)
+		require.NoError(b, err)
+>>>>>>> Stashed changes
 	}
 }

--- a/core/internal/testutils/pgtest/pgtest.go
+++ b/core/internal/testutils/pgtest/pgtest.go
@@ -31,7 +31,7 @@ func NewSqlDB(t *testing.T) *sql.DB {
 	return db
 }
 
-func NewSqlxDB(t *testing.T) *sqlx.DB {
+func NewSqlxDB(t testing.TB) *sqlx.DB {
 	testutils.SkipShortDB(t)
 	db, err := sqlx.Open("txdb", uuid.NewV4().String())
 	require.NoError(t, err)

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
@@ -611,8 +611,8 @@ func (c *coordinator) unmarshalLogs(
 ) {
 	for _, lg := range logs {
 		rawLog := toGethLog(lg)
-		switch {
-		case lg.EventSig == c.randomnessRequestedTopic:
+		switch lg.EventSig {
+		case c.randomnessRequestedTopic:
 			unpacked, err2 := c.onchainRouter.ParseLog(rawLog)
 			if err2 != nil {
 				// should never happen
@@ -626,7 +626,7 @@ func (c *coordinator) unmarshalLogs(
 				return
 			}
 			randomnessRequestedLogs = append(randomnessRequestedLogs, rr)
-		case lg.EventSig == c.randomnessFulfillmentRequestedTopic:
+		case c.randomnessFulfillmentRequestedTopic:
 			unpacked, err2 := c.onchainRouter.ParseLog(rawLog)
 			if err2 != nil {
 				// should never happen
@@ -640,7 +640,7 @@ func (c *coordinator) unmarshalLogs(
 				return
 			}
 			randomnessFulfillmentRequestedLogs = append(randomnessFulfillmentRequestedLogs, rfr)
-		case lg.EventSig == c.randomWordsFulfilledTopic:
+		case c.randomWordsFulfilledTopic:
 			unpacked, err2 := c.onchainRouter.ParseLog(rawLog)
 			if err2 != nil {
 				// should never happen
@@ -654,7 +654,7 @@ func (c *coordinator) unmarshalLogs(
 				return
 			}
 			randomWordsFulfilledLogs = append(randomWordsFulfilledLogs, rwf)
-		case lg.EventSig == c.newTransmissionTopic:
+		case c.newTransmissionTopic:
 			unpacked, err2 := c.onchainRouter.ParseLog(rawLog)
 			if err2 != nil {
 				// should never happen

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
@@ -612,7 +612,7 @@ func (c *coordinator) unmarshalLogs(
 	for _, lg := range logs {
 		rawLog := toGethLog(lg)
 		switch {
-		case bytes.Equal(lg.EventSig, c.randomnessRequestedTopic[:]):
+		case lg.EventSig == c.randomnessRequestedTopic:
 			unpacked, err2 := c.onchainRouter.ParseLog(rawLog)
 			if err2 != nil {
 				// should never happen
@@ -626,7 +626,7 @@ func (c *coordinator) unmarshalLogs(
 				return
 			}
 			randomnessRequestedLogs = append(randomnessRequestedLogs, rr)
-		case bytes.Equal(lg.EventSig, c.randomnessFulfillmentRequestedTopic[:]):
+		case lg.EventSig == c.randomnessFulfillmentRequestedTopic:
 			unpacked, err2 := c.onchainRouter.ParseLog(rawLog)
 			if err2 != nil {
 				// should never happen
@@ -640,7 +640,7 @@ func (c *coordinator) unmarshalLogs(
 				return
 			}
 			randomnessFulfillmentRequestedLogs = append(randomnessFulfillmentRequestedLogs, rfr)
-		case bytes.Equal(lg.EventSig, c.randomWordsFulfilledTopic[:]):
+		case lg.EventSig == c.randomWordsFulfilledTopic:
 			unpacked, err2 := c.onchainRouter.ParseLog(rawLog)
 			if err2 != nil {
 				// should never happen
@@ -654,7 +654,7 @@ func (c *coordinator) unmarshalLogs(
 				return
 			}
 			randomWordsFulfilledLogs = append(randomWordsFulfilledLogs, rwf)
-		case bytes.Equal(lg.EventSig, c.newTransmissionTopic[:]):
+		case lg.EventSig == c.newTransmissionTopic:
 			unpacked, err2 := c.onchainRouter.ParseLog(rawLog)
 			if err2 != nil {
 				// should never happen
@@ -668,7 +668,7 @@ func (c *coordinator) unmarshalLogs(
 			}
 			newTransmissionLogs = append(newTransmissionLogs, nt)
 		default:
-			c.lggr.Error(fmt.Sprintf("Unexpected event sig: %s", hexutil.Encode(lg.EventSig)))
+			c.lggr.Error(fmt.Sprintf("Unexpected event sig: %s", lg.EventSig))
 			c.lggr.Error(fmt.Sprintf("expected one of: %s %s %s %s",
 				hexutil.Encode(c.randomnessRequestedTopic[:]), hexutil.Encode(c.randomnessFulfillmentRequestedTopic[:]),
 				hexutil.Encode(c.randomWordsFulfilledTopic[:]), hexutil.Encode(c.newTransmissionTopic[:])))

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator_test.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator_test.go
@@ -1200,13 +1200,13 @@ func newRandomnessRequestedLog(
 	}}
 	topicData, err := indexedArgs.Pack(nextBeaconOutputHeight)
 	require.NoError(t, err)
-	topic0 := vrfCoordinatorABI.Events[randomnessRequestedEvent].ID.Bytes()
+	topic0 := vrfCoordinatorABI.Events[randomnessRequestedEvent].ID
 	lg := logpoller.Log{
 		Address: coordinatorAddress,
 		Data:    logData,
 		Topics: [][]byte{
 			// first topic is the event signature
-			topic0,
+			topic0.Bytes(),
 			// second topic is nextBeaconOutputHeight since it's indexed
 			topicData,
 		},
@@ -1247,13 +1247,13 @@ func newRandomnessFulfillmentRequestedLog(
 	packed, err := vrfCoordinatorABI.Events[randomnessFulfillmentRequestedEvent].Inputs.Pack(
 		e.NextBeaconOutputHeight, e.ConfDelay, e.SubID, e.Callback)
 	require.NoError(t, err)
-	topic0 := vrfCoordinatorABI.Events[randomnessFulfillmentRequestedEvent].ID.Bytes()
+	topic0 := vrfCoordinatorABI.Events[randomnessFulfillmentRequestedEvent].ID
 	return logpoller.Log{
 		Address:  coordinatorAddress,
 		Data:     packed,
 		EventSig: topic0,
 		Topics: [][]byte{
-			topic0,
+			topic0.Bytes(),
 		},
 		BlockNumber: int64(requestBlock),
 	}
@@ -1277,12 +1277,12 @@ func newRandomWordsFulfilledLog(
 	packed, err := vrfCoordinatorABI.Events[randomWordsFulfilledEvent].Inputs.Pack(
 		e.RequestIDs, e.SuccessfulFulfillment, e.TruncatedErrorData)
 	require.NoError(t, err)
-	topic0 := vrfCoordinatorABI.Events[randomWordsFulfilledEvent].ID.Bytes()
+	topic0 := vrfCoordinatorABI.Events[randomWordsFulfilledEvent].ID
 	return logpoller.Log{
 		Address:  coordinatorAddress,
 		Data:     packed,
 		EventSig: topic0,
-		Topics:   [][]byte{topic0},
+		Topics:   [][]byte{topic0.Bytes()},
 	}
 }
 
@@ -1341,12 +1341,12 @@ func newNewTransmissionLog(
 	epochAndRoundPacked, err := indexedArgs.Pack(e.EpochAndRound)
 	require.NoError(t, err)
 
-	topic0 := vrfBeaconABI.Events[newTransmissionEvent].ID.Bytes()
+	topic0 := vrfBeaconABI.Events[newTransmissionEvent].ID
 	return logpoller.Log{
 		Address: beaconAddress,
 		Data:    nonIndexedData,
 		Topics: [][]byte{
-			topic0,
+			topic0.Bytes(),
 			aggregatorPacked,
 			epochAndRoundPacked,
 		},

--- a/core/services/pg/q.go
+++ b/core/services/pg/q.go
@@ -293,8 +293,8 @@ func sprintQ(query string, args []interface{}) string {
 			pairs = append(pairs, fmt.Sprintf("$%d", i+1), fmt.Sprintf("'\\x%x'", v.Bytes()))
 		case pq.ByteaArray:
 			s := fmt.Sprintf("('\\x%x'", v[0])
-			for i := 0; i < len(v); i++ {
-				s += fmt.Sprintf(",'\\x%x'", v[i])
+			for j := 1; j < len(v); j++ {
+				s += fmt.Sprintf(",'\\x%x'", v[j])
 			}
 			pairs = append(pairs, fmt.Sprintf("$%d", i+1), fmt.Sprintf("%s)", s))
 		default:

--- a/core/services/pg/q.go
+++ b/core/services/pg/q.go
@@ -297,7 +297,7 @@ func sprintQ(query string, args []interface{}) string {
 			for j := 1; j < len(v); j++ {
 				fmt.Fprintf(&s, ",'\\x%x'", v[j])
 			}
-			pairs = append(pairs, fmt.Sprintf("$%d", i+1), fmt.Sprintf("%s)", s))
+			pairs = append(pairs, fmt.Sprintf("$%d", i+1), fmt.Sprintf("%s)", s.String()))
 		default:
 			pairs = append(pairs, fmt.Sprintf("$%d", i+1), fmt.Sprintf("%v", arg))
 		}

--- a/core/services/pg/q.go
+++ b/core/services/pg/q.go
@@ -292,9 +292,10 @@ func sprintQ(query string, args []interface{}) string {
 		case common.Hash:
 			pairs = append(pairs, fmt.Sprintf("$%d", i+1), fmt.Sprintf("'\\x%x'", v.Bytes()))
 		case pq.ByteaArray:
-			s := fmt.Sprintf("('\\x%x'", v[0])
+			var s strings.Builder
+			fmt.Fprintf(&s, "('\\x%x'", v[0])
 			for j := 1; j < len(v); j++ {
-				s += fmt.Sprintf(",'\\x%x'", v[j])
+				fmt.Fprintf(&s, ",'\\x%x'", v[j])
 			}
 			pairs = append(pairs, fmt.Sprintf("$%d", i+1), fmt.Sprintf("%s)", s))
 		default:

--- a/core/services/pg/q_test.go
+++ b/core/services/pg/q_test.go
@@ -3,6 +3,7 @@ package pg
 import (
 	"testing"
 
+	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
 )
 
@@ -33,10 +34,14 @@ func Test_sprintQ(t *testing.T) {
 			"SELECT $1 FROM table LIMIT $2;",
 			[]interface{}{"foo", Limit(-1)},
 			"SELECT foo FROM table LIMIT NULL;"},
-		{"bytes",
+		{"bytea",
 			"SELECT $1 FROM table WHERE b = $2;",
 			[]interface{}{"foo", []byte{0x0a}},
 			"SELECT foo FROM table WHERE b = '\\x0a';"},
+		{"bytea[]",
+			"SELECT $1 FROM table WHERE b = $2;",
+			[]interface{}{"foo", pq.ByteaArray([][]byte{{0xa}, {0xb}})},
+			"SELECT foo FROM table WHERE b = ('\\x0a', '\\x0b');"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := sprintQ(tt.query, tt.args)

--- a/core/services/pg/q_test.go
+++ b/core/services/pg/q_test.go
@@ -33,6 +33,10 @@ func Test_sprintQ(t *testing.T) {
 			"SELECT $1 FROM table LIMIT $2;",
 			[]interface{}{"foo", Limit(-1)},
 			"SELECT foo FROM table LIMIT NULL;"},
+		{"bytes",
+			"SELECT $1 FROM table WHERE b = $2;",
+			[]interface{}{"foo", []byte{0x0a}},
+			"SELECT foo FROM table WHERE b = '\\x0a';"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := sprintQ(tt.query, tt.args)

--- a/core/services/pg/q_test.go
+++ b/core/services/pg/q_test.go
@@ -41,7 +41,7 @@ func Test_sprintQ(t *testing.T) {
 		{"bytea[]",
 			"SELECT $1 FROM table WHERE b = $2;",
 			[]interface{}{"foo", pq.ByteaArray([][]byte{{0xa}, {0xb}})},
-			"SELECT foo FROM table WHERE b = ('\\x0a', '\\x0b');"},
+			"SELECT foo FROM table WHERE b = ('\\x0a','\\x0b');"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			got := sprintQ(tt.query, tt.args)

--- a/core/store/migrate/migrations/0117_add_log_poller_idx.sql
+++ b/core/store/migrate/migrations/0117_add_log_poller_idx.sql
@@ -3,5 +3,5 @@ CREATE INDEX logs_idx_block_number ON logs using brin(block_number);
 CREATE INDEX logs_idx_evm_id_event_address_block ON logs using btree (evm_chain_id,event_sig,address,block_number);
 
 -- +goose Down
-DROP INDEX logs_idx_block_number;
-DROP INDEX logs_idx_evm_id_event_address_block;
+DROP INDEX IF EXISTS logs_idx_block_number;
+DROP INDEX IF EXISTS logs_idx_evm_id_event_address_block;

--- a/core/store/migrate/migrations/0120_log_poller_data_idx.sql
+++ b/core/store/migrate/migrations/0120_log_poller_data_idx.sql
@@ -10,5 +10,5 @@ CREATE INDEX logs_idx_topic_three ON logs (encode(topics[3], 'hex'));
 CREATE INDEX logs_idx_topic_four ON logs (encode(topics[4], 'hex'));
 
 -- +goose Down
-DROP INDEX logs_idx_data_word_one, logs_idx_data_word_two, logs_idx_data_word_three;
-DROP INDEX logs_idx_topic_two, logs_idx_topic_three, logs_idx_topic_four;
+DROP INDEX IF EXISTS logs_idx_data_word_one, logs_idx_data_word_two, logs_idx_data_word_three;
+DROP INDEX IF EXISTS logs_idx_topic_two, logs_idx_topic_three, logs_idx_topic_four;

--- a/core/store/migrate/migrations/0144_optimize_lp.sql
+++ b/core/store/migrate/migrations/0144_optimize_lp.sql
@@ -12,7 +12,7 @@ CREATE INDEX logs_idx_topic_four ON logs ((topics[4]));
 
 DROP INDEX logs_idx_evm_id_event_address_block;
 DROP INDEX logs_idx_block_number;
-ALTER TABLE log_poller_blocks ADD CONSTRAINT block_hash_uniq UNIQUE(block_hash);
+ALTER TABLE log_poller_blocks ADD CONSTRAINT block_hash_uniq UNIQUE(evm_chain_id,block_hash);
 --
 -- +goose Down
 DROP INDEX IF EXISTS logs_idx_data_word_one, logs_idx_data_word_two, logs_idx_data_word_three, logs_idx_topic_two, logs_idx_topic_three, logs_idx_topic_four;

--- a/core/store/migrate/migrations/0144_optimize_lp.sql
+++ b/core/store/migrate/migrations/0144_optimize_lp.sql
@@ -1,0 +1,21 @@
+-- +goose Up
+-- Rebuild the indexes without the hex encoding. Its not required postgres can handle bytea comparisons.
+DROP INDEX logs_idx_data_word_one, logs_idx_data_word_two, logs_idx_data_word_three, logs_idx_topic_two, logs_idx_topic_three, logs_idx_topic_four;
+CREATE INDEX logs_idx_data_word_one ON logs (substring(data from 1 for 32));
+CREATE INDEX logs_idx_data_word_two ON logs (substring(data from 33 for 32));
+CREATE INDEX logs_idx_data_word_three ON logs (substring(data from 65 for 32));
+
+-- You can only index 3 event arguments. First topic is the event sig which we already have indexed separately.
+CREATE INDEX logs_idx_topic_two ON logs ((topics[2]));
+CREATE INDEX logs_idx_topic_three ON logs ((topics[3]));
+CREATE INDEX logs_idx_topic_four ON logs ((topics[4]));
+
+DROP INDEX logs_idx_evm_id_event_address_block;
+DROP INDEX logs_idx_block_number;
+ALTER TABLE log_poller_blocks ADD CONSTRAINT block_hash_uniq UNIQUE(block_hash);
+--
+-- +goose Down
+DROP INDEX IF EXISTS logs_idx_data_word_one, logs_idx_data_word_two, logs_idx_data_word_three, logs_idx_topic_two, logs_idx_topic_three, logs_idx_topic_four;
+CREATE INDEX logs_idx_block_number ON logs using brin(block_number);
+CREATE INDEX logs_idx_evm_id_event_address_block ON logs using btree (evm_chain_id,event_sig,address,block_number);
+ALTER TABLE log_poller_blocks DROP CONSTRAINT IF EXISTS block_hash_uniq;


### PR DESCRIPTION
- Hex encoding not needed, postgres supports bytea comparisons, this doesn't appear to improve BenchmarkLogs or TestPopulateLoadedDB query time, but it does simplify the code.
- logs_idx_evm_id_event_address_block and  logs_idx_block_number indexes are not needed. The logs_idx covers them. No query speed difference in TestPopulateLoadedDB with them removed.
- Add typing for eventSig
- Fix query printing in debug sql