### PR TITLE
core/utils/http: permit connections when ip lookup fails

### DIFF
--- a/core/utils/http/http_allowed_ips.go
+++ b/core/utils/http/http_allowed_ips.go
@@ -33,7 +33,7 @@ func init() {
 	}
 }
 
-func isRestrictedIP(ip net.IP, cfg httpClientConfig, lggr logger.Logger) bool {
+func isRestrictedIP(ip net.IP, cfg httpClientConfig) (bool, error) {
 	if !ip.IsGlobalUnicast() ||
 		ip.IsLoopback() ||
 		ip.IsLinkLocalUnicast() ||
@@ -45,22 +45,21 @@ func isRestrictedIP(ip net.IP, cfg httpClientConfig, lggr logger.Logger) bool {
 		ip.Equal(net.IPv4allrouter) ||
 		ip.Equal(net.IPv4zero) ||
 		ip.IsMulticast() {
-		return true
+		return true, nil
 	}
 
 	for _, block := range privateIPBlocks {
 		if block.Contains(ip) {
-			return true
+			return true, nil
 		}
 	}
 
 	blacklisted, err := isBlacklistedIP(ip, cfg)
 	if err != nil {
-		lggr.Errorw("Failed to check IP blacklist status, this IP will be blocked", "err", err, "ip", ip)
-		return true
+		return false, errors.Wrapf(err, "failed to check IP blacklist status")
 	}
 
-	return blacklisted
+	return blacklisted, nil
 }
 
 func isBlacklistedIP(ip net.IP, cfg httpClientConfig) (bool, error) {
@@ -68,7 +67,7 @@ func isBlacklistedIP(ip net.IP, cfg httpClientConfig) (bool, error) {
 	if dbURL.String() == "" {
 		return false, nil
 	}
-	ips, err := net.LookupIP(dbURL.String())
+	ips, err := net.LookupIP(dbURL.Host)
 	if err != nil {
 		return true, errors.Wrapf(err, "failed to lookup IP for DB URL")
 	}
@@ -99,7 +98,9 @@ func makeRestrictedDialContext(cfg httpClientConfig, lggr logger.Logger) func(co
 			// If a connection could be established, ensure it's not local or private
 			a, _ := con.RemoteAddr().(*net.TCPAddr)
 
-			if isRestrictedIP(a.IP, cfg, lggr) {
+			if restrict, rerr := isRestrictedIP(a.IP, cfg); rerr != nil {
+				lggr.Errorw("Restricted IP check failed, this IP will be allowed", "ip", a.IP, "err", rerr)
+			} else if restrict {
 				return nil, multierr.Combine(
 					errors.Wrapf(ErrDisallowedIP, "disallowed IP %s. Connections to local/private and multicast networks are disabled by default for security reasons", a.IP.String()),
 					con.Close())


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/52346