### PR TITLE
toml config: use from tests

### DIFF
--- a/core/chains/evm/config/v2/chain_scoped.go
+++ b/core/chains/evm/config/v2/chain_scoped.go
@@ -154,38 +154,23 @@ func (c *ChainScoped) EvmGasLimitTransfer() uint32 {
 }
 
 func (c *ChainScoped) EvmGasLimitOCRJobType() *uint32 {
-	if t := c.cfg.GasEstimator.LimitJobType; t != nil {
-		return t.OCR
-	}
-	return nil
+	return c.cfg.GasEstimator.LimitJobType.OCR
 }
 
 func (c *ChainScoped) EvmGasLimitDRJobType() *uint32 {
-	if t := c.cfg.GasEstimator.LimitJobType; t != nil {
-		return t.DR
-	}
-	return nil
+	return c.cfg.GasEstimator.LimitJobType.DR
 }
 
 func (c *ChainScoped) EvmGasLimitVRFJobType() *uint32 {
-	if t := c.cfg.GasEstimator.LimitJobType; t != nil {
-		return t.VRF
-	}
-	return nil
+	return c.cfg.GasEstimator.LimitJobType.VRF
 }
 
 func (c *ChainScoped) EvmGasLimitFMJobType() *uint32 {
-	if t := c.cfg.GasEstimator.LimitJobType; t != nil {
-		return t.FM
-	}
-	return nil
+	return c.cfg.GasEstimator.LimitJobType.FM
 }
 
 func (c *ChainScoped) EvmGasLimitKeeperJobType() *uint32 {
-	if t := c.cfg.GasEstimator.LimitJobType; t != nil {
-		return t.Keeper
-	}
-	return nil
+	return c.cfg.GasEstimator.LimitJobType.Keeper
 }
 
 func (c *ChainScoped) EvmGasPriceDefault() *big.Int {

--- a/core/chains/evm/config/v2/config.go
+++ b/core/chains/evm/config/v2/config.go
@@ -427,7 +427,7 @@ type GasEstimator struct {
 	LimitMax        *uint32
 	LimitMultiplier *decimal.Decimal
 	LimitTransfer   *uint32
-	LimitJobType    *GasLimitJobType
+	LimitJobType    GasLimitJobType `toml:",omitempty"`
 
 	BumpMin       *utils.Wei
 	BumpPercent   *uint16
@@ -530,12 +530,7 @@ func (e *GasEstimator) setFrom(f *GasEstimator) {
 	if v := f.PriceMin; v != nil {
 		e.PriceMin = v
 	}
-	if v := f.LimitJobType; v != nil {
-		if e.LimitJobType == nil {
-			e.LimitJobType = &GasLimitJobType{}
-		}
-		e.LimitJobType.setFrom(f.LimitJobType)
-	}
+	e.LimitJobType.setFrom(&f.LimitJobType)
 	if f.BlockHistory != nil {
 		if e.BlockHistory == nil {
 			e.BlockHistory = &BlockHistoryEstimator{}
@@ -832,18 +827,12 @@ func (c *Chain) SetFromDB(cfg *types.ChainCfg) error {
 		if c.GasEstimator == nil {
 			c.GasEstimator = &GasEstimator{}
 		}
-		if c.GasEstimator.LimitJobType == nil {
-			c.GasEstimator.LimitJobType = &GasLimitJobType{}
-		}
 		v := uint32(cfg.EvmGasLimitOCRJobType.Int64)
 		c.GasEstimator.LimitJobType.OCR = &v
 	}
 	if cfg.EvmGasLimitDRJobType.Valid {
 		if c.GasEstimator == nil {
 			c.GasEstimator = &GasEstimator{}
-		}
-		if c.GasEstimator.LimitJobType == nil {
-			c.GasEstimator.LimitJobType = &GasLimitJobType{}
 		}
 		v := uint32(cfg.EvmGasLimitDRJobType.Int64)
 		c.GasEstimator.LimitJobType.DR = &v
@@ -852,9 +841,6 @@ func (c *Chain) SetFromDB(cfg *types.ChainCfg) error {
 		if c.GasEstimator == nil {
 			c.GasEstimator = &GasEstimator{}
 		}
-		if c.GasEstimator.LimitJobType == nil {
-			c.GasEstimator.LimitJobType = &GasLimitJobType{}
-		}
 		v := uint32(cfg.EvmGasLimitVRFJobType.Int64)
 		c.GasEstimator.LimitJobType.VRF = &v
 	}
@@ -862,18 +848,12 @@ func (c *Chain) SetFromDB(cfg *types.ChainCfg) error {
 		if c.GasEstimator == nil {
 			c.GasEstimator = &GasEstimator{}
 		}
-		if c.GasEstimator.LimitJobType == nil {
-			c.GasEstimator.LimitJobType = &GasLimitJobType{}
-		}
 		v := uint32(cfg.EvmGasLimitFMJobType.Int64)
 		c.GasEstimator.LimitJobType.FM = &v
 	}
 	if cfg.EvmGasLimitKeeperJobType.Valid {
 		if c.GasEstimator == nil {
 			c.GasEstimator = &GasEstimator{}
-		}
-		if c.GasEstimator.LimitJobType == nil {
-			c.GasEstimator.LimitJobType = &GasLimitJobType{}
 		}
 		v := uint32(cfg.EvmGasLimitKeeperJobType.Int64)
 		c.GasEstimator.LimitJobType.Keeper = &v

--- a/core/chains/evm/config/v2_helpers_test.go
+++ b/core/chains/evm/config/v2_helpers_test.go
@@ -70,7 +70,7 @@ func (set chainSpecificConfigDefaultSet) asV2() v2.Chain {
 			PriceDefault:       utils.NewWei(&set.gasPriceDefault),
 			PriceMax:           utils.NewWei(&set.maxGasPriceWei),
 			PriceMin:           utils.NewWei(&set.minGasPriceWei),
-			LimitJobType: &v2.GasLimitJobType{
+			LimitJobType: v2.GasLimitJobType{
 				OCR:    set.gasLimitOCRJobType,
 				DR:     set.gasLimitDRJobType,
 				VRF:    set.gasLimitVRFJobType,
@@ -106,9 +106,6 @@ func (set chainSpecificConfigDefaultSet) asV2() v2.Chain {
 	}
 	if isZeroPtr(c.BalanceMonitor) {
 		c.BalanceMonitor = nil
-	}
-	if isZeroPtr(c.GasEstimator.LimitJobType) {
-		c.GasEstimator.LimitJobType = nil
 	}
 	if isZeroPtr(c.GasEstimator.BlockHistory) {
 		c.GasEstimator.BlockHistory = nil

--- a/core/chains/evm/forwarders/forwarder_manager_test.go
+++ b/core/chains/evm/forwarders/forwarder_manager_test.go
@@ -18,7 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/authorized_receiver"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/operator_wrapper"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"

--- a/core/chains/evm/log/helpers_test.go
+++ b/core/chains/evm/log/helpers_test.go
@@ -95,7 +95,7 @@ func (c broadcasterHelperCfg) newWithEthClient(t *testing.T, ethClient evmclient
 
 	globalConfig := cltest.NewTestGeneralConfig(t)
 	globalConfig.Overrides.LogSQL = null.BoolFrom(true)
-	config := evmtest.NewChainScopedConfig(t, globalConfig)
+	config := evmtest.NewLegacyChainScopedConfig(t, globalConfig)
 	lggr := logger.TestLogger(t)
 
 	orm := log.NewORM(c.db, lggr, config, cltest.FixtureChainID)

--- a/core/chains/evm/txmgr/eth_resender_test.go
+++ b/core/chains/evm/txmgr/eth_resender_test.go
@@ -8,6 +8,11 @@ import (
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/rpc"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/guregu/null.v4"
+
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
@@ -15,20 +20,16 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/utils"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/mock"
-	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v4"
 )
 
 func Test_EthResender_FindEthTxAttemptsRequiringResend(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := configtest.NewTestGeneralConfig(t)
-	borm := cltest.NewTxmORM(t, db, cfg)
+	logCfg := pgtest.NewPGCfg(true)
+	borm := cltest.NewTxmORM(t, db, logCfg)
 
-	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
+	ethKeyStore := cltest.NewKeyStore(t, db, logCfg).Eth()
 
 	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 

--- a/core/chains/evm/txmgr/txmgr_test.go
+++ b/core/chains/evm/txmgr/txmgr_test.go
@@ -26,7 +26,7 @@ import (
 	txmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/txmgr/mocks"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"

--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -95,7 +95,12 @@ func NewApp(client *Client) *cli.App {
 				vrfPasswordFileName = &s
 			}
 			var err error
-			client.Config, err = chainlink.NewTOMLGeneralConfig(client.Logger, configTOML, secretsTOML, keystorePasswordFileName, vrfPasswordFileName)
+			client.Config, err = chainlink.GeneralConfigTOML{
+				Config:                   configTOML,
+				Secrets:                  secretsTOML,
+				KeystorePasswordFileName: keystorePasswordFileName,
+				VRFPasswordFileName:      vrfPasswordFileName,
+			}.New(client.Logger)
 			if err != nil {
 				return err
 			}

--- a/core/cmd/cfgtest/app_test.go
+++ b/core/cmd/cfgtest/app_test.go
@@ -61,7 +61,7 @@ func assertMethodsReturnEqual[M any](t *testing.T, a, b M) {
 				t.Skip("irrelevant")
 			case "P2PListenPort", "AppID":
 				t.Skip("randomized")
-			case "EVMEnabled", "P2PNetworkingStack", "P2PNetworkingStackRaw", "P2PEnabled", "BlockEmissionIdleWarningThreshold":
+			case "EVMEnabled", "EVMRPCEnabled", "P2PNetworkingStack", "P2PNetworkingStackRaw", "P2PEnabled", "BlockEmissionIdleWarningThreshold":
 				t.Skip("default redefined") // see core/cmd/chainlink/TestTOMLGeneralConfig_Defaults
 			}
 

--- a/core/cmd/cfgtest/app_test.go
+++ b/core/cmd/cfgtest/app_test.go
@@ -62,7 +62,7 @@ func assertMethodsReturnEqual[M any](t *testing.T, a, b M) {
 			case "P2PListenPort", "AppID":
 				t.Skip("randomized")
 			case "EVMEnabled", "P2PNetworkingStack", "P2PNetworkingStackRaw", "P2PEnabled", "BlockEmissionIdleWarningThreshold":
-				t.Skip("default redefined")
+				t.Skip("default redefined") // see core/cmd/chainlink/TestTOMLGeneralConfig_Defaults
 			}
 
 			defer func() {

--- a/core/cmd/cfgtest/app_test.go
+++ b/core/cmd/cfgtest/app_test.go
@@ -7,12 +7,15 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 
 	evmcfg "github.com/smartcontractkit/chainlink/core/chains/evm/config"
 	evmcfg2 "github.com/smartcontractkit/chainlink/core/chains/evm/config/v2"
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/config"
 	cfg2 "github.com/smartcontractkit/chainlink/core/config/v2"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest2 "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink/cfgtest"
@@ -24,12 +27,28 @@ func TestDefaultConfig(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	chainID := utils.NewBigI(42991337)
 
-	newGeneral, err := chainlink.NewTOMLGeneralConfig(lggr, "", "", nil, nil)
+	newGeneral, err := chainlink.GeneralConfigTOML{}.New(lggr)
 	require.NoError(t, err)
 	legacyGeneral := config.NewGeneralConfig(lggr)
 
+	// we expect a mismatch on some methods with redefined defaults
+	redefined := []string{"BlockEmissionIdleWarningThreshold", "DatabaseLockingMode", "EVMEnabled", "EVMRPCEnabled"}
+
 	t.Run("general", func(t *testing.T) {
-		assertMethodsReturnEqual[config.GeneralConfig](t, legacyGeneral, newGeneral)
+		assertMethodsReturnEqual[config.GeneralConfig](t, legacyGeneral, newGeneral, redefined)
+	})
+	t.Run("general-test", func(t *testing.T) {
+		// Legacy overrides root with random, but none of these others picked that up.
+		// New uses test temp dir and inherits as expected.
+		testRoot := []string{
+			"AutoPprofProfileRoot",
+			"CertFile",
+			"KeyFile",
+			"LogFileDir",
+			"RootDir",
+			"TLSDir",
+		}
+		assertMethodsReturnEqual[config.GeneralConfig](t, configtest.NewTestGeneralConfig(t), configtest2.NewTestGeneralConfig(t), testRoot)
 	})
 	newChain, _ := evmcfg2.Defaults(chainID)
 	evmCfg := evmcfg2.EVMConfig{
@@ -40,13 +59,13 @@ func TestDefaultConfig(t *testing.T) {
 	legacyConfig := evmcfg.NewChainScopedConfig(chainID.ToInt(), evmtypes.ChainCfg{}, nil, lggr, legacyGeneral)
 
 	t.Run("chain-scoped", func(t *testing.T) {
-		assertMethodsReturnEqual[evmcfg.ChainScopedOnlyConfig](t, legacyConfig, newConfig)
+		assertMethodsReturnEqual[evmcfg.ChainScopedOnlyConfig](t, legacyConfig, newConfig, redefined)
 	})
 }
 
 // assertMethodsReturnEqual calls each method from M on a and b, and asserts the returned values are equal.
 // Methods which accept arguments are skipped, allowe with a few other special cases.
-func assertMethodsReturnEqual[M any](t *testing.T, a, b M) {
+func assertMethodsReturnEqual[M any](t *testing.T, a, b M, redefined []string) {
 	av, bv := reflect.ValueOf(a), reflect.ValueOf(b)
 	to := reflect.TypeOf((*M)(nil)).Elem()
 	for i := 0; i < to.NumMethod(); i++ {
@@ -61,7 +80,8 @@ func assertMethodsReturnEqual[M any](t *testing.T, a, b M) {
 				t.Skip("irrelevant")
 			case "P2PListenPort", "AppID":
 				t.Skip("randomized")
-			case "EVMEnabled", "EVMRPCEnabled", "P2PNetworkingStack", "P2PNetworkingStackRaw", "P2PEnabled", "BlockEmissionIdleWarningThreshold":
+			}
+			if slices.Contains(redefined, name) {
 				t.Skip("default redefined") // see core/cmd/chainlink/TestTOMLGeneralConfig_Defaults
 			}
 
@@ -107,7 +127,6 @@ func assertMethodsReturnEqual[M any](t *testing.T, a, b M) {
 					continue
 				}
 				assert.Equal(t, ai, bi, "%dth return arg", i)
-
 			}
 		})
 	}

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -652,7 +652,7 @@ func newConnection(cfg dbConfig, lggr logger.Logger) (*sqlx.DB, error) {
 		MaxOpenConns: cfg.ORMMaxOpenConns(),
 		MaxIdleConns: cfg.ORMMaxIdleConns(),
 	}
-	db, err := pg.NewConnection(parsed.String(), string(cfg.GetDatabaseDialectConfiguredOrDefault()), config)
+	db, err := pg.NewConnection(parsed.String(), cfg.GetDatabaseDialectConfiguredOrDefault(), config)
 	return db, err
 }
 

--- a/core/cmd/renderer_test.go
+++ b/core/cmd/renderer_test.go
@@ -36,7 +36,7 @@ func TestRendererJSON_RenderVRFKeys(t *testing.T) {
 func TestRendererTable_RenderConfiguration(t *testing.T) {
 	t.Parallel()
 
-	app := cltest.NewApplicationEVMDisabled(t)
+	app := cltest.NewLegacyApplicationEVMDisabled(t)
 	require.NoError(t, app.Start(testutils.Context(t)))
 	client := app.NewHTTPClient(cltest.APIEmailAdmin)
 

--- a/core/config/envvar/envvar.go
+++ b/core/config/envvar/envvar.go
@@ -13,13 +13,14 @@ import (
 	"github.com/smartcontractkit/chainlink/core/config/parse"
 )
 
-//nolint
+// nolint
 var (
 	AdvisoryLockID                    = NewInt64("AdvisoryLockID")
 	AuthenticatedRateLimitPeriod      = NewDuration("AuthenticatedRateLimitPeriod")
 	AutoPprofPollInterval             = NewDuration("AutoPprofPollInterval")
 	AutoPprofGatherDuration           = NewDuration("AutoPprofGatherDuration")
 	AutoPprofGatherTraceDuration      = NewDuration("AutoPprofGatherTraceDuration")
+	DatabaseURL                       = New("DatabaseURL", parse.DatabaseURL) //TODO move to v2.CL*?
 	BlockBackfillDepth                = NewUint64("BlockBackfillDepth")
 	HTTPServerWriteTimeout            = NewDuration("HTTPServerWriteTimeout")
 	JobPipelineMaxRunDuration         = NewDuration("JobPipelineMaxRunDuration")

--- a/core/config/parse/parsers.go
+++ b/core/config/parse/parsers.go
@@ -9,10 +9,12 @@ import (
 	"strconv"
 	"time"
 
-	homedir "github.com/mitchellh/go-homedir"
+	"github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
+	"github.com/smartcontractkit/chainlink/core/static"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
@@ -99,4 +101,16 @@ func HomeDir(str string) (string, error) {
 		return "", err
 	}
 	return filepath.ToSlash(exp), nil
+}
+
+func DatabaseURL(s string) (url.URL, error) {
+	uri, err := url.Parse(s)
+	if err != nil {
+		return url.URL{}, errors.Wrapf(err, "invalid database url %s", s)
+	}
+	if uri.String() == "" {
+		return *uri, nil
+	}
+	static.SetConsumerName(uri, "Default", nil)
+	return *uri, nil
 }

--- a/core/config/v2/docs/core.toml
+++ b/core/config/v2/docs/core.toml
@@ -319,7 +319,7 @@ TraceLogging = false # Default
 
 [P2P.V1]
 # Enabled enables P2P V1.
-Enabled = false # Default
+Enabled = true # Default
 # AnnounceIP should be set as the externally reachable IP address of the Chainlink node.
 AnnounceIP = '1.2.3.4' # Example
 # AnnouncePort should be set as the externally reachable port of the Chainlink node.

--- a/core/config/v2/docs/docs_test.go
+++ b/core/config/v2/docs/docs_test.go
@@ -61,7 +61,7 @@ func TestDoc(t *testing.T) {
 		require.Zero(t, *docDefaults.GasEstimator.LimitJobType.Keeper)
 		require.Zero(t, *docDefaults.GasEstimator.LimitJobType.VRF)
 		require.Zero(t, *docDefaults.GasEstimator.LimitJobType.FM)
-		docDefaults.GasEstimator.LimitJobType = nil
+		docDefaults.GasEstimator.LimitJobType = evmcfg.GasLimitJobType{}
 
 		// EIP1559FeeCapBufferBlocks doesn't have a constant default - it is derived from another field
 		require.Zero(t, *docDefaults.GasEstimator.BlockHistory.EIP1559FeeCapBufferBlocks)

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -59,6 +59,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/config/envvar"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest2 "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	clhttptest "github.com/smartcontractkit/chainlink/core/internal/testutils/httptest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/keystest"
@@ -242,6 +243,7 @@ func NewWSServer(t *testing.T, chainID *big.Int, callback testutils.JSONRPCHandl
 	return server.WSURL().String()
 }
 
+// Deprecated: use NewTestGeneralConfigV2
 func NewTestGeneralConfig(t testing.TB) *configtest.TestGeneralConfig {
 	shutdownGracePeriod := testutils.DefaultWaitTimeout
 	reaperInterval := time.Duration(0) // disable reaper
@@ -255,9 +257,32 @@ func NewTestGeneralConfig(t testing.TB) *configtest.TestGeneralConfig {
 	return configtest.NewTestGeneralConfigWithOverrides(t, overrides)
 }
 
+// NewTestGeneralConfigV2 is like NewTestGeneralConfig but uses configtest/v2.
+func NewTestGeneralConfigV2(t testing.TB) config.GeneralConfig {
+	return configtest2.NewGeneralConfig(t, TestOverrides)
+}
+
+// TestOverrides are the default overrides used by NewTestGeneralConfigV2.
+func TestOverrides(c *chainlink.Config, s *chainlink.Secrets) {
+	c.ShutdownGracePeriod = models.MustNewDuration(testutils.DefaultWaitTimeout)
+	c.JobPipeline.ReaperInterval = models.MustNewDuration(0)
+	enabled := false
+	c.P2P.V1.Enabled = &enabled
+	c.P2P.V2.Enabled = &enabled
+}
+
 // NewApplicationEVMDisabled creates a new application with default config but EVM disabled
 // Useful for testing controllers
 func NewApplicationEVMDisabled(t *testing.T) *TestApplication {
+	t.Helper()
+
+	c := NewTestGeneralConfigV2(t)
+
+	return NewApplicationWithConfig(t, c)
+}
+
+// Deprecated: use NewApplicationEVMDisabled
+func NewLegacyApplicationEVMDisabled(t *testing.T) *TestApplication {
 	t.Helper()
 
 	c := NewTestGeneralConfig(t)
@@ -299,6 +324,8 @@ func NewApplicationWithConfigAndKey(t testing.TB, c config.GeneralConfig, flagsA
 			app.Key = v
 		case evmtypes.DBChain:
 			chainID = v.ID
+		case *utils.Big:
+			chainID = *v
 		}
 	}
 	if app.Key.Address == utils.ZeroAddress {
@@ -335,7 +362,7 @@ func NewApplicationWithConfig(t testing.TB, cfg config.GeneralConfig, flagsAndDe
 	var eventBroadcaster pg.EventBroadcaster = pg.NewNullEventBroadcaster()
 
 	url := cfg.DatabaseURL()
-	db, err := pg.NewConnection(url.String(), string(cfg.GetDatabaseDialectConfiguredOrDefault()), pg.Config{
+	db, err := pg.NewConnection(url.String(), cfg.GetDatabaseDialectConfiguredOrDefault(), pg.Config{
 		Logger:       lggr,
 		MaxOpenConns: cfg.ORMMaxOpenConns(),
 		MaxIdleConns: cfg.ORMMaxIdleConns(),
@@ -1590,7 +1617,7 @@ func AssertPipelineTaskRunsErrored(t testing.TB, runs []pipeline.TaskRun) {
 }
 
 func NewTestChainScopedConfig(t testing.TB) evmconfig.ChainScopedConfig {
-	cfg := NewTestGeneralConfig(t)
+	cfg := NewTestGeneralConfigV2(t)
 	return evmtest.NewChainScopedConfig(t, cfg)
 }
 

--- a/core/internal/cltest/heavyweight/orm.go
+++ b/core/internal/cltest/heavyweight/orm.go
@@ -49,15 +49,14 @@ func prepareFullTestDB(t *testing.T, name string, empty bool, loadFixtures bool)
 		t.Fatal("could not load fixtures into an empty DB")
 	}
 
-	overrides := configtest.GeneralConfigOverrides{}
-	gcfg := configtest.NewTestGeneralConfigWithOverrides(t, overrides)
+	gcfg := configtest.NewTestGeneralConfig(t)
 	gcfg.Overrides.Dialect = dialects.Postgres
 
 	require.NoError(t, os.MkdirAll(gcfg.RootDir(), 0700))
 	migrationTestDBURL, err := dropAndCreateThrowawayTestDB(gcfg.DatabaseURL(), name, empty)
 	require.NoError(t, err)
 	lggr := logger.TestLogger(t)
-	db, err := pg.NewConnection(migrationTestDBURL, string(dialects.Postgres), pg.Config{
+	db, err := pg.NewConnection(migrationTestDBURL, dialects.Postgres, pg.Config{
 		Logger:       lggr,
 		MaxOpenConns: gcfg.ORMMaxOpenConns(),
 		MaxIdleConns: gcfg.ORMMaxIdleConns(),

--- a/core/internal/cltest/simulated_backend.go
+++ b/core/internal/cltest/simulated_backend.go
@@ -8,14 +8,18 @@ import (
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/core"
 	uuid "github.com/satori/go.uuid"
+	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/client"
+	evmcfg "github.com/smartcontractkit/chainlink/core/chains/evm/config/v2"
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
+	coreconfig "github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
@@ -30,6 +34,7 @@ func NewSimulatedBackend(t *testing.T, alloc core.GenesisAlloc, gasLimit uint32)
 	return backend
 }
 
+// Deprecated: use NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain
 func NewApplicationWithConfigAndKeyOnSimulatedBlockchain(
 	t testing.TB,
 	cfg *configtest.TestGeneralConfig,
@@ -61,6 +66,47 @@ func NewApplicationWithConfigAndKeyOnSimulatedBlockchain(
 
 	//  app.Stop() will call client.Close on the simulated backend
 	return NewApplicationWithConfigAndKey(t, cfg, flagsAndDeps...)
+}
+
+// NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain is like NewApplicationWithConfigAndKeyOnSimulatedBlockchain
+// but cfg should be v2, and cltest.OverrideSimulated used.
+func NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(
+	t testing.TB,
+	cfg coreconfig.GeneralConfig,
+	backend *backends.SimulatedBackend,
+	flagsAndDeps ...interface{},
+) *TestApplication {
+	if bid := backend.Blockchain().Config().ChainID; bid.Cmp(testutils.SimulatedChainID) != 0 {
+		t.Fatalf("expected backend chain ID to be %s but it was %s", testutils.SimulatedChainID.String(), bid.String())
+	}
+	defID := cfg.DefaultChainID()
+	require.Zero(t, defID.Cmp(testutils.SimulatedChainID))
+	chainID := utils.NewBig(testutils.SimulatedChainID)
+	client := client.NewSimulatedBackendClient(t, backend, testutils.SimulatedChainID)
+	eventBroadcaster := pg.NewEventBroadcaster(cfg.DatabaseURL(), 0, 0, logger.TestLogger(t), uuid.NewV4())
+
+	flagsAndDeps = append(flagsAndDeps, client, eventBroadcaster, chainID)
+
+	//  app.Stop() will call client.Close on the simulated backend
+	return NewApplicationWithConfigAndKey(t, cfg, flagsAndDeps...)
+}
+
+// OverrideSimulated is a config override func that appends the simulated chain, or replaces the null chain if that is the only entry.
+func OverrideSimulated(c *chainlink.Config, s *chainlink.Secrets) {
+	chainID := utils.NewBig(testutils.SimulatedChainID)
+	chain, _ := evmcfg.Defaults(chainID)
+	enabled := true
+	cfg := evmcfg.EVMConfig{
+		ChainID: chainID,
+		Chain:   chain,
+		Enabled: &enabled,
+		Nodes:   evmcfg.EVMNodes{{}},
+	}
+	if len(c.EVM) == 1 && c.EVM[0].ChainID.Cmp(utils.NewBigI(client.NullClientChainID)) == 0 {
+		c.EVM[0] = &cfg
+	} else {
+		c.EVM = append(c.EVM, &cfg)
+	}
 }
 
 // Mine forces the simulated backend to produce a new block every 2 seconds

--- a/core/internal/testutils/configtest/general_config.go
+++ b/core/internal/testutils/configtest/general_config.go
@@ -197,6 +197,8 @@ type TestGeneralConfig struct {
 	Overrides GeneralConfigOverrides
 }
 
+// TODO how to wedge in new config w/o import cycle...
+// TODO use v2.NewTestGeneralConfig instead
 func NewTestGeneralConfig(t *testing.T) *TestGeneralConfig {
 	return NewTestGeneralConfigWithOverrides(t, GeneralConfigOverrides{})
 }

--- a/core/internal/testutils/configtest/general_config.go
+++ b/core/internal/testutils/configtest/general_config.go
@@ -197,12 +197,11 @@ type TestGeneralConfig struct {
 	Overrides GeneralConfigOverrides
 }
 
-// TODO how to wedge in new config w/o import cycle...
-// TODO use v2.NewTestGeneralConfig instead
 func NewTestGeneralConfig(t *testing.T) *TestGeneralConfig {
 	return NewTestGeneralConfigWithOverrides(t, GeneralConfigOverrides{})
 }
 
+// Deprecated: see v2.TOML
 func NewTestGeneralConfigWithOverrides(t testing.TB, overrides GeneralConfigOverrides) *TestGeneralConfig {
 	cfg := config.NewGeneralConfig(logger.TestLogger(t))
 	return &TestGeneralConfig{
@@ -332,7 +331,7 @@ func (c *TestGeneralConfig) GetDatabaseDialectConfiguredOrDefault() dialects.Dia
 	}
 	// Always return txdb for tests, if you want a non-transactional database
 	// you must set an override explicitly
-	return "txdb"
+	return dialects.TransactionWrappedPostgres
 }
 
 func (c *TestGeneralConfig) DatabaseURL() url.URL {

--- a/core/internal/testutils/configtest/v2/general_config.go
+++ b/core/internal/testutils/configtest/v2/general_config.go
@@ -2,26 +2,62 @@ package v2
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
+	evmclient "github.com/smartcontractkit/chainlink/core/chains/evm/client"
+	evmcfg "github.com/smartcontractkit/chainlink/core/chains/evm/config/v2"
 	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/core/store/dialects"
+	"github.com/smartcontractkit/chainlink/core/store/models"
+	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
-// TODO doc
-func NewTestGeneralConfig(t *testing.T) config.GeneralConfig { return TOML{}.NewGeneralConfig(t) }
+// NewTestGeneralConfig returns a new config.GeneralConfig with default test overrides.
+func NewTestGeneralConfig(t testing.TB) config.GeneralConfig { return NewGeneralConfig(t, nil) }
 
-// TODO doc
-type TOML struct {
-	Config  string
-	Secrets string
-}
-
-// TODO doc
-func (c TOML) NewGeneralConfig(t *testing.T) config.GeneralConfig {
-	g, err := chainlink.NewTOMLGeneralConfig(logger.TestLogger(t), c.Config, c.Secrets, nil, nil)
+// NewGeneralConfig returns a new config.GeneralConfig with overrides.
+// The default test overrides are applied before overrideFn.
+func NewGeneralConfig(t testing.TB, overrideFn func(*chainlink.Config, *chainlink.Secrets)) config.GeneralConfig {
+	tempDir := t.TempDir()
+	g, err := chainlink.GeneralConfigOpts{
+		OverrideFn: func(c *chainlink.Config, s *chainlink.Secrets) {
+			overrides(c, s)
+			c.RootDir = &tempDir
+			if fn := overrideFn; fn != nil {
+				fn(c, s)
+			}
+		},
+	}.New(logger.TestLogger(t))
 	require.NoError(t, err)
 	return g
 }
+
+func overrides(c *chainlink.Config, s *chainlink.Secrets) {
+	c.DevMode = true
+	c.InsecureFastScrypt = ptr(true)
+
+	c.Database.Dialect = dialects.TransactionWrappedPostgres
+	c.Database.Lock.Mode = "none"
+	c.Database.MaxIdleConns = ptr[int64](20)
+	c.Database.MaxOpenConns = ptr[int64](20)
+	c.Database.MigrateOnStartup = ptr(false)
+
+	c.WebServer.SessionTimeout = models.MustNewDuration(2 * time.Minute)
+	c.WebServer.BridgeResponseURL = models.MustParseURL("http://localhost:6688")
+
+	chainID := utils.NewBigI(evmclient.NullClientChainID)
+	chain, _ := evmcfg.Defaults(chainID)
+	enabled := true
+	c.EVM = append(c.EVM, &evmcfg.EVMConfig{
+		ChainID: chainID,
+		Chain:   chain,
+		Enabled: &enabled,
+		Nodes:   evmcfg.EVMNodes{{}},
+	})
+}
+
+func ptr[T any](v T) *T { return &v }

--- a/core/internal/testutils/configtest/v2/general_config.go
+++ b/core/internal/testutils/configtest/v2/general_config.go
@@ -1,0 +1,27 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/core/config"
+	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
+)
+
+// TODO doc
+func NewTestGeneralConfig(t *testing.T) config.GeneralConfig { return TOML{}.NewGeneralConfig(t) }
+
+// TODO doc
+type TOML struct {
+	Config  string
+	Secrets string
+}
+
+// TODO doc
+func (c TOML) NewGeneralConfig(t *testing.T) config.GeneralConfig {
+	g, err := chainlink.NewTOMLGeneralConfig(logger.TestLogger(t), c.Config, c.Secrets, nil, nil)
+	require.NoError(t, err)
+	return g
+}

--- a/core/internal/testutils/evmtest/evmtest.go
+++ b/core/internal/testutils/evmtest/evmtest.go
@@ -38,7 +38,13 @@ import (
 
 func NewChainScopedConfig(t testing.TB, cfg config.GeneralConfig) evmconfig.ChainScopedConfig {
 	if _, ok := cfg.(v2.HasEVMConfigs); ok {
-		return v2.NewTOMLChainScopedConfig(cfg, &v2.EVMConfig{ChainID: utils.NewBigI(0)}, logger.TestLogger(t))
+		chainID := utils.NewBigI(0)
+		newChain, _ := v2.Defaults(chainID)
+		evmCfg := v2.EVMConfig{
+			ChainID: chainID,
+			Chain:   newChain,
+		}
+		return v2.NewTOMLChainScopedConfig(cfg, &evmCfg, logger.TestLogger(t))
 	}
 	return evmconfig.NewChainScopedConfig(big.NewInt(0), evmtypes.ChainCfg{}, nil, logger.TestLogger(t), cfg)
 }
@@ -51,7 +57,7 @@ type TestChainOpts struct {
 	Client         evmclient.Client
 	LogBroadcaster log.Broadcaster
 	GeneralConfig  config.GeneralConfig
-	ChainCfg       evmtypes.ChainCfg
+	ChainCfg       evmtypes.ChainCfg // Deprecated
 	HeadTracker    httypes.HeadTracker
 	DB             *sqlx.DB
 	TxManager      txmgr.TxManager

--- a/core/internal/testutils/evmtest/v2/evmtest.go
+++ b/core/internal/testutils/evmtest/v2/evmtest.go
@@ -1,0 +1,24 @@
+package v2
+
+import (
+	"testing"
+
+	"github.com/smartcontractkit/chainlink/core/chains/evm/config"
+	v2 "github.com/smartcontractkit/chainlink/core/chains/evm/config/v2"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/utils"
+)
+
+func ChainEthMainnet(t *testing.T) config.ChainScopedConfig      { return scopedConfig(t, 1) }
+func ChainOptimismMainnet(t *testing.T) config.ChainScopedConfig { return scopedConfig(t, 10) }
+func ChainOptimismKovan(t *testing.T) config.ChainScopedConfig   { return scopedConfig(t, 69) }
+func ChainArbitrumMainnet(t *testing.T) config.ChainScopedConfig { return scopedConfig(t, 42161) }
+func ChainArbitrumRinkeby(t *testing.T) config.ChainScopedConfig { return scopedConfig(t, 421611) }
+
+func scopedConfig(t *testing.T, chainID int64) config.ChainScopedConfig {
+	id := utils.NewBigI(chainID)
+	def, _ := v2.Defaults(id)
+	evmCfg := v2.EVMConfig{ChainID: id, Chain: def}
+	return v2.NewTOMLChainScopedConfig(configtest.NewTestGeneralConfig(t), &evmCfg, logger.TestLogger(t))
+}

--- a/core/internal/testutils/pgtest/pgtest.go
+++ b/core/internal/testutils/pgtest/pgtest.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
+	"github.com/smartcontractkit/chainlink/core/store/dialects"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
@@ -24,7 +25,7 @@ func (p PGCfg) LogSQL() bool            { return p.logSQL }
 
 func NewSqlDB(t *testing.T) *sql.DB {
 	testutils.SkipShortDB(t)
-	db, err := sql.Open("txdb", uuid.NewV4().String())
+	db, err := sql.Open(string(dialects.TransactionWrappedPostgres), uuid.NewV4().String())
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, db.Close()) })
 
@@ -33,7 +34,7 @@ func NewSqlDB(t *testing.T) *sql.DB {
 
 func NewSqlxDB(t testing.TB) *sqlx.DB {
 	testutils.SkipShortDB(t)
-	db, err := sqlx.Open("txdb", uuid.NewV4().String())
+	db, err := sqlx.Open(string(dialects.TransactionWrappedPostgres), uuid.NewV4().String())
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, db.Close()) })
 

--- a/core/internal/testutils/pgtest/txdb.go
+++ b/core/internal/testutils/pgtest/txdb.go
@@ -15,6 +15,8 @@ import (
 
 	"github.com/smartcontractkit/sqlx"
 	"go.uber.org/multierr"
+
+	"github.com/smartcontractkit/chainlink/core/store/dialects"
 )
 
 // txdb is a simplified version of https://github.com/DATA-DOG/go-txdb
@@ -59,11 +61,12 @@ func init() {
 		msg := fmt.Sprintf("cannot run tests against database named `%s`. Note that the test database MUST end in `_test` to differentiate from a possible production DB. HINT: Try DATABASE_URL=postgresql://postgres@localhost:5432/chainlink_test?sslmode=disable", parsed.Path[1:])
 		panic(msg)
 	}
-	sql.Register("txdb", &txDriver{
+	name := string(dialects.TransactionWrappedPostgres)
+	sql.Register(name, &txDriver{
 		dbURL: dbURL,
 		conns: make(map[string]*conn),
 	})
-	sqlx.BindDriver("txdb", sqlx.DOLLAR)
+	sqlx.BindDriver(name, sqlx.DOLLAR)
 }
 
 var _ driver.Conn = &conn{}

--- a/core/services/chainlink/config_dump.go
+++ b/core/services/chainlink/config_dump.go
@@ -402,9 +402,6 @@ func (c *Config) loadLegacyEVMEnv() {
 			if c.EVM[i].GasEstimator == nil {
 				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
 			}
-			if c.EVM[i].GasEstimator.LimitJobType == nil {
-				c.EVM[i].GasEstimator.LimitJobType = &evmcfg.GasLimitJobType{}
-			}
 			c.EVM[i].GasEstimator.LimitJobType.OCR = e
 		}
 	}
@@ -412,9 +409,6 @@ func (c *Config) loadLegacyEVMEnv() {
 		for i := range c.EVM {
 			if c.EVM[i].GasEstimator == nil {
 				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
-			if c.EVM[i].GasEstimator.LimitJobType == nil {
-				c.EVM[i].GasEstimator.LimitJobType = &evmcfg.GasLimitJobType{}
 			}
 			c.EVM[i].GasEstimator.LimitJobType.DR = e
 		}
@@ -424,9 +418,6 @@ func (c *Config) loadLegacyEVMEnv() {
 			if c.EVM[i].GasEstimator == nil {
 				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
 			}
-			if c.EVM[i].GasEstimator.LimitJobType == nil {
-				c.EVM[i].GasEstimator.LimitJobType = &evmcfg.GasLimitJobType{}
-			}
 			c.EVM[i].GasEstimator.LimitJobType.VRF = e
 		}
 	}
@@ -435,9 +426,6 @@ func (c *Config) loadLegacyEVMEnv() {
 			if c.EVM[i].GasEstimator == nil {
 				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
 			}
-			if c.EVM[i].GasEstimator.LimitJobType == nil {
-				c.EVM[i].GasEstimator.LimitJobType = &evmcfg.GasLimitJobType{}
-			}
 			c.EVM[i].GasEstimator.LimitJobType.FM = e
 		}
 	}
@@ -445,9 +433,6 @@ func (c *Config) loadLegacyEVMEnv() {
 		for i := range c.EVM {
 			if c.EVM[i].GasEstimator == nil {
 				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
-			if c.EVM[i].GasEstimator.LimitJobType == nil {
-				c.EVM[i].GasEstimator.LimitJobType = &evmcfg.GasLimitJobType{}
 			}
 			c.EVM[i].GasEstimator.LimitJobType.Keeper = e
 		}
@@ -634,9 +619,6 @@ func (c *Config) loadLegacyEVMEnv() {
 		if c.EVM[i].GasEstimator != nil {
 			if isZeroPtr(c.EVM[i].GasEstimator.BlockHistory) {
 				c.EVM[i].GasEstimator.BlockHistory = nil
-			}
-			if isZeroPtr(c.EVM[i].GasEstimator.LimitJobType) {
-				c.EVM[i].GasEstimator.LimitJobType = nil
 			}
 			if isZeroPtr(c.EVM[i].GasEstimator) {
 				c.EVM[i].GasEstimator = nil

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -59,6 +59,7 @@ type generalConfig struct {
 	logMu           sync.RWMutex
 }
 
+// TODO doc
 func NewTOMLGeneralConfig(lggr logger.Logger, configToml string, secretsToml string, keystorePasswordFileName, vrfPasswordFileName *string) (coreconfig.GeneralConfig, error) {
 	var c Config
 	err := v2.DecodeTOML(strings.NewReader(configToml), &c)

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -43,7 +43,7 @@ type generalConfig struct {
 	inputTOML     string // user input, normalized via de/re-serialization
 	effectiveTOML string // with default values included
 
-	c       *Config // all fields non-nil
+	c       *Config // all fields non-nil (unless the legacy method signature return a pointer)
 	secrets *Secrets
 
 	// state
@@ -154,6 +154,27 @@ func (g *generalConfig) EVMEnabled() bool {
 		}
 	}
 	return false
+}
+
+func (g *generalConfig) EVMRPCEnabled() bool {
+	for _, c := range g.c.EVM {
+		if e := c.Enabled; e != nil && *e {
+			if len(c.Nodes) > 0 {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func (g *generalConfig) DefaultChainID() *big.Int {
+	for _, c := range g.c.EVM {
+		if e := c.Enabled; e != nil && *e {
+			return (*big.Int)(c.ChainID)
+		}
+	}
+	return nil
+
 }
 
 func (g *generalConfig) KeeperCheckUpkeepGasPriceFeatureEnabled() bool {

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/gin-gonic/contrib/sessions"
 	"github.com/pkg/errors"
-	uuid "github.com/satori/go.uuid"
 	"go.uber.org/multierr"
 	"go.uber.org/zap/zapcore"
 
@@ -26,6 +25,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/chains/starknet"
 	"github.com/smartcontractkit/chainlink/core/chains/terra"
 	coreconfig "github.com/smartcontractkit/chainlink/core/config"
+	"github.com/smartcontractkit/chainlink/core/config/envvar"
 	"github.com/smartcontractkit/chainlink/core/config/parse"
 	v2 "github.com/smartcontractkit/chainlink/core/config/v2"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -46,49 +46,92 @@ type generalConfig struct {
 	c       *Config // all fields non-nil (unless the legacy method signature return a pointer)
 	secrets *Secrets
 
-	// state
-	appID     uuid.UUID
+	logLevelDefault zapcore.Level
+
 	appIDOnce sync.Once
 
 	randomP2PPort     uint16
 	randomP2PPortOnce sync.Once
 
-	logLevelDefault zapcore.Level
-	logLevel        zapcore.Level
-	logSQL          bool
-	logMu           sync.RWMutex
+	logMu sync.RWMutex // for the mutable fields Log.Level & Log.SQL
 }
 
-// TODO doc
-func NewTOMLGeneralConfig(lggr logger.Logger, configToml string, secretsToml string, keystorePasswordFileName, vrfPasswordFileName *string) (coreconfig.GeneralConfig, error) {
-	var c Config
-	err := v2.DecodeTOML(strings.NewReader(configToml), &c)
+// GeneralConfigTOML holds TOML configuration options for creating a coreconfig.GeneralConfig via New().
+//
+// See GeneralConfigOpts to initilize from go types.
+type GeneralConfigTOML struct {
+	Config, Secrets string
+
+	KeystorePasswordFileName, VRFPasswordFileName *string
+
+	OverrideFn func(*Config, *Secrets) // tests only
+}
+
+// New returns a coreconfig.GeneralConfig from the parsed TOML.
+func (t GeneralConfigTOML) New(lggr logger.Logger) (coreconfig.GeneralConfig, error) {
+	o := GeneralConfigOpts{
+		KeystorePasswordFileName: t.KeystorePasswordFileName,
+		VRFPasswordFileName:      t.VRFPasswordFileName,
+		OverrideFn:               t.OverrideFn,
+	}
+	err := v2.DecodeTOML(strings.NewReader(t.Config), &o.Config)
 	if err != nil {
 		return nil, err
 	}
-	input, err := c.TOMLString()
+	err = v2.DecodeTOML(strings.NewReader(t.Secrets), &o.Secrets)
+	if err != nil {
+		return nil, err
+	}
+	return o.New(lggr)
+}
+
+// GeneralConfigOpts holds configuration options for creating a coreconfig.GeneralConfig via New().
+//
+// See GeneralConfigTOML to inialize from TOML.
+type GeneralConfigOpts struct {
+	Config
+	Secrets
+
+	KeystorePasswordFileName, VRFPasswordFileName *string
+
+	// OverrideFn is a *test-only* hook to override effective values.
+	OverrideFn func(*Config, *Secrets)
+}
+
+// New returns a coreconfig.GeneralConfig for the given options.
+func (o GeneralConfigOpts) New(lggr logger.Logger) (coreconfig.GeneralConfig, error) {
+	input, err := o.Config.TOMLString()
 	if err != nil {
 		return nil, err
 	}
 
-	c.setDefaults()
+	o.Config.setDefaults()
 
-	effective, err := c.TOMLString()
+	//TODO setEnv() helper; https://app.shortcut.com/chainlinklabs/story/23679/prefix-all-env-vars-with-cl
+	o.Config.DevMode = v2.CLDev
+	if p := envvar.LogLevel.ParsePtr(); p != nil {
+		o.Config.Log.Level = *p
+	}
+
+	err = o.Secrets.SetOverrides(o.KeystorePasswordFileName, o.VRFPasswordFileName)
 	if err != nil {
 		return nil, err
 	}
 
-	var s Secrets
-	err = v2.DecodeTOML(strings.NewReader(secretsToml), &s)
-	if err != nil {
-		return nil, err
+	if fn := o.OverrideFn; fn != nil {
+		fn(&o.Config, &o.Secrets)
 	}
-	err = s.SetOverrides(keystorePasswordFileName, vrfPasswordFileName)
+
+	effective, err := o.Config.TOMLString()
 	if err != nil {
 		return nil, err
 	}
 
-	return &generalConfig{lggr: lggr, c: &c, inputTOML: input, effectiveTOML: effective, secrets: &s}, nil
+	return &generalConfig{
+		lggr:      lggr,
+		inputTOML: input, effectiveTOML: effective,
+		c: &o.Config, secrets: &o.Secrets,
+		logLevelDefault: o.Config.Log.Level}, nil
 }
 
 func (g *generalConfig) EVMConfigs() evmcfg.EVMConfigs {
@@ -117,7 +160,7 @@ func (g *generalConfig) LogConfiguration(log coreconfig.LogFn) {
 }
 
 func (g *generalConfig) Dev() bool {
-	return v2.CLDev
+	return g.c.DevMode
 }
 
 func (g *generalConfig) FeatureExternalInitiators() bool {
@@ -175,7 +218,47 @@ func (g *generalConfig) DefaultChainID() *big.Int {
 		}
 	}
 	return nil
+}
 
+func (g *generalConfig) EthereumHTTPURL() *url.URL {
+	for _, c := range g.c.EVM {
+		if e := c.Enabled; e != nil && *e {
+			for _, n := range c.Nodes {
+				if n.SendOnly == nil || !*n.SendOnly {
+					return (*url.URL)(n.HTTPURL)
+				}
+			}
+		}
+	}
+	return nil
+
+}
+func (g *generalConfig) EthereumSecondaryURLs() (us []url.URL) {
+	for _, c := range g.c.EVM {
+		if e := c.Enabled; e != nil && *e {
+			for _, n := range c.Nodes {
+				if n.HTTPURL != nil {
+					us = append(us, (url.URL)(*n.HTTPURL))
+				}
+			}
+		}
+	}
+	return nil
+
+}
+func (g *generalConfig) EthereumURL() string {
+	for _, c := range g.c.EVM {
+		if e := c.Enabled; e != nil && *e {
+			for _, n := range c.Nodes {
+				if n.SendOnly == nil || !*n.SendOnly {
+					if n.WSURL != nil {
+						return n.WSURL.String()
+					}
+				}
+			}
+		}
+	}
+	return ""
 }
 
 func (g *generalConfig) KeeperCheckUpkeepGasPriceFeatureEnabled() bool {
@@ -347,7 +430,7 @@ func (g *generalConfig) FMSimulateTransactions() bool {
 }
 
 func (g *generalConfig) GetDatabaseDialectConfiguredOrDefault() dialects.DialectName {
-	panic(v2.ErrUnsupported)
+	return g.c.Database.Dialect
 }
 
 func (g *generalConfig) HTTPServerWriteTimeout() time.Duration {

--- a/core/services/chainlink/config_general_deprecated.go
+++ b/core/services/chainlink/config_general_deprecated.go
@@ -10,6 +10,6 @@ func (g *generalConfig) AdvisoryLockCheckInterval() time.Duration { panic(config
 
 func (g *generalConfig) AdvisoryLockID() int64 { panic(config.ErrUnsupported) }
 
-func (g *generalConfig) DatabaseLockingMode() string { panic(config.ErrUnsupported) }
+func (g *generalConfig) DatabaseLockingMode() string { return g.c.Database.LockingMode() }
 
 func (g *generalConfig) GetAdvisoryLockIDConfiguredOrDefault() int64 { panic(config.ErrUnsupported) }

--- a/core/services/chainlink/config_general_global.go
+++ b/core/services/chainlink/config_general_global.go
@@ -8,8 +8,6 @@ import (
 	v2 "github.com/smartcontractkit/chainlink/core/config/v2"
 )
 
-func (g *generalConfig) EVMRPCEnabled() bool { panic(v2.ErrUnsupported) }
-
 func (g *generalConfig) GlobalBalanceMonitorEnabled() (bool, bool) { panic(v2.ErrUnsupported) }
 func (g *generalConfig) GlobalBlockEmissionIdleWarningThreshold() (time.Duration, bool) {
 	panic(v2.ErrUnsupported)

--- a/core/services/chainlink/config_general_setup.go
+++ b/core/services/chainlink/config_general_setup.go
@@ -1,13 +1,11 @@
 package chainlink
 
 import (
-	"math/big"
 	"net/url"
 
 	v2 "github.com/smartcontractkit/chainlink/core/config/v2"
 )
 
-func (g *generalConfig) DefaultChainID() *big.Int         { panic(v2.ErrUnsupported) }
 func (g *generalConfig) EthereumHTTPURL() *url.URL        { panic(v2.ErrUnsupported) }
 func (g *generalConfig) EthereumNodes() string            { panic(v2.ErrUnsupported) }
 func (g *generalConfig) EthereumSecondaryURLs() []url.URL { panic(v2.ErrUnsupported) }

--- a/core/services/chainlink/config_general_setup.go
+++ b/core/services/chainlink/config_general_setup.go
@@ -1,16 +1,10 @@
 package chainlink
 
 import (
-	"net/url"
-
 	v2 "github.com/smartcontractkit/chainlink/core/config/v2"
 )
 
-func (g *generalConfig) EthereumHTTPURL() *url.URL        { panic(v2.ErrUnsupported) }
-func (g *generalConfig) EthereumNodes() string            { panic(v2.ErrUnsupported) }
-func (g *generalConfig) EthereumSecondaryURLs() []url.URL { panic(v2.ErrUnsupported) }
-func (g *generalConfig) EthereumURL() string              { panic(v2.ErrUnsupported) }
-
+func (g *generalConfig) EthereumNodes() string { panic(v2.ErrUnsupported) }
 func (g *generalConfig) SolanaNodes() string   { panic(v2.ErrUnsupported) }
 func (g *generalConfig) TerraNodes() string    { panic(v2.ErrUnsupported) }
 func (g *generalConfig) StarkNetNodes() string { panic(v2.ErrUnsupported) }

--- a/core/services/chainlink/config_general_state.go
+++ b/core/services/chainlink/config_general_state.go
@@ -7,9 +7,12 @@ import (
 
 func (g *generalConfig) AppID() uuid.UUID {
 	g.appIDOnce.Do(func() {
-		g.appID = uuid.NewV4()
+		if g.c.AppID != (uuid.UUID{}) {
+			return // already set (e.g. test override)
+		}
+		g.c.AppID = uuid.NewV4() // randomize
 	})
-	return g.appID
+	return g.c.AppID
 }
 
 func (g *generalConfig) DefaultLogLevel() zapcore.Level {
@@ -18,27 +21,27 @@ func (g *generalConfig) DefaultLogLevel() zapcore.Level {
 
 func (g *generalConfig) LogLevel() (ll zapcore.Level) {
 	g.logMu.RLock()
-	ll = g.logLevelDefault
+	ll = g.c.Log.Level
 	g.logMu.RUnlock()
 	return
 }
 
 func (g *generalConfig) SetLogLevel(lvl zapcore.Level) error {
 	g.logMu.Lock()
-	g.logLevel = lvl
+	g.c.Log.Level = lvl
 	g.logMu.Unlock()
 	return nil
 }
 
 func (g *generalConfig) LogSQL() (sql bool) {
 	g.logMu.RLock()
-	sql = g.logSQL
+	sql = g.c.Log.SQL
 	g.logMu.RUnlock()
 	return
 }
 
 func (g *generalConfig) SetLogSQL(logSQL bool) {
 	g.logMu.Lock()
-	g.logSQL = logSQL
+	g.c.Log.SQL = logSQL
 	g.logMu.Unlock()
 }

--- a/core/services/chainlink/config_general_test.go
+++ b/core/services/chainlink/config_general_test.go
@@ -1,0 +1,36 @@
+package chainlink
+
+import (
+	"net/url"
+	"testing"
+	"time"
+
+	ocrnetworking "github.com/smartcontractkit/libocr/networking"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v2 "github.com/smartcontractkit/chainlink/core/config/v2"
+	"github.com/smartcontractkit/chainlink/core/logger"
+)
+
+func TestTOMLGeneralConfig_Defaults(t *testing.T) {
+	config, err := NewTOMLGeneralConfig(logger.TestLogger(t), "", "", nil, nil)
+	require.NoError(t, err)
+	assert.PanicsWithError(t, v2.ErrUnsupported.Error(), func() {
+		_ = config.BlockBackfillDepth()
+	})
+	assert.PanicsWithError(t, v2.ErrUnsupported.Error(), func() {
+		_ = config.BlockBackfillSkip()
+	})
+	assert.Equal(t, (*url.URL)(nil), config.BridgeResponseURL())
+	assert.Nil(t, config.DefaultChainID())
+	assert.False(t, config.EVMRPCEnabled())
+	assert.False(t, config.EVMEnabled())
+	assert.False(t, config.TerraEnabled())
+	assert.False(t, config.SolanaEnabled())
+	assert.False(t, config.StarkNetEnabled())
+	assert.Equal(t, false, config.FeatureExternalInitiators())
+	assert.Equal(t, 15*time.Minute, config.SessionTimeout().Duration())
+	assert.Equal(t, ocrnetworking.NetworkingStack(0), config.P2PNetworkingStack())
+	assert.False(t, config.P2PEnabled())
+}

--- a/core/services/chainlink/config_general_test.go
+++ b/core/services/chainlink/config_general_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	ocrnetworking "github.com/smartcontractkit/libocr/networking"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -14,7 +13,7 @@ import (
 )
 
 func TestTOMLGeneralConfig_Defaults(t *testing.T) {
-	config, err := NewTOMLGeneralConfig(logger.TestLogger(t), "", "", nil, nil)
+	config, err := GeneralConfigTOML{}.New(logger.TestLogger(t))
 	require.NoError(t, err)
 	assert.PanicsWithError(t, v2.ErrUnsupported.Error(), func() {
 		_ = config.BlockBackfillDepth()
@@ -31,6 +30,4 @@ func TestTOMLGeneralConfig_Defaults(t *testing.T) {
 	assert.False(t, config.StarkNetEnabled())
 	assert.Equal(t, false, config.FeatureExternalInitiators())
 	assert.Equal(t, 15*time.Minute, config.SessionTimeout().Duration())
-	assert.Equal(t, ocrnetworking.NetworkingStack(0), config.P2PNetworkingStack())
-	assert.False(t, config.P2PEnabled())
 }

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -425,7 +425,7 @@ func TestConfig_Marshal(t *testing.T) {
 					PriceMax:           utils.NewBig(utils.HexToBig("FFFFFFFFFFFF")).Wei(),
 					PriceMin:           utils.NewBigI(13).Wei(),
 
-					LimitJobType: &evmcfg.GasLimitJobType{
+					LimitJobType: evmcfg.GasLimitJobType{
 						OCR:    ptr[uint32](1001),
 						DR:     ptr[uint32](1002),
 						VRF:    ptr[uint32](1003),

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -121,7 +121,7 @@ OutgoingMessageBufferSize = 10
 TraceLogging = false
 
 [P2P.V1]
-Enabled = false
+Enabled = true
 AnnounceIP = ''
 AnnouncePort = 0
 BootstrapCheckInterval = '20s'

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -121,7 +121,7 @@ OutgoingMessageBufferSize = 10
 TraceLogging = false
 
 [P2P.V1]
-Enabled = false
+Enabled = true
 AnnounceIP = ''
 AnnouncePort = 0
 BootstrapCheckInterval = '20s'

--- a/core/services/cron/cron_test.go
+++ b/core/services/cron/cron_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"

--- a/core/services/directrequest/delegate_test.go
+++ b/core/services/directrequest/delegate_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/log"
 	log_mocks "github.com/smartcontractkit/chainlink/core/chains/evm/log/mocks"
+	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/operator_wrapper"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
@@ -66,7 +67,7 @@ type DirectRequestUniverse struct {
 	cleanup        func()
 }
 
-func NewDirectRequestUniverseWithConfig(t *testing.T, cfg *configtest.TestGeneralConfig, specF func(spec *job.Job)) *DirectRequestUniverse {
+func NewDirectRequestUniverseWithConfig(t *testing.T, cfg config.GeneralConfig, specF func(spec *job.Job)) *DirectRequestUniverse {
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	broadcaster := log_mocks.NewBroadcaster(t)
 	runner := pipeline_mocks.NewRunner(t)

--- a/core/services/directrequest/delegate_test.go
+++ b/core/services/directrequest/delegate_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/log"
@@ -21,10 +20,11 @@ import (
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/operator_wrapper"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/directrequest"
 	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
@@ -36,8 +36,9 @@ func TestDelegate_ServicesForSpec(t *testing.T) {
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	runner := pipeline_mocks.NewRunner(t)
 	db := pgtest.NewSqlxDB(t)
-	cfg := configtest.NewTestGeneralConfig(t)
-	cfg.Overrides.GlobalMinIncomingConfirmations = null.IntFrom(1)
+	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].MinIncomingConfirmations = ptr[uint32](1)
+	})
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: cfg, Client: ethClient})
 
 	lggr := logger.TestLogger(t)
@@ -112,8 +113,9 @@ func NewDirectRequestUniverseWithConfig(t *testing.T, cfg config.GeneralConfig, 
 }
 
 func NewDirectRequestUniverse(t *testing.T) *DirectRequestUniverse {
-	cfg := configtest.NewTestGeneralConfig(t)
-	cfg.Overrides.GlobalMinIncomingConfirmations = null.IntFrom(1)
+	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].MinIncomingConfirmations = ptr[uint32](1)
+	})
 	return NewDirectRequestUniverseWithConfig(t, cfg, nil)
 }
 
@@ -343,9 +345,10 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 	})
 
 	t.Run("Log has sufficient funds", func(t *testing.T) {
-		cfg := configtest.NewTestGeneralConfig(t)
-		cfg.Overrides.GlobalMinIncomingConfirmations = null.IntFrom(1)
-		cfg.Overrides.GlobalMinimumContractPayment = assets.NewLinkFromJuels(100)
+		cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.EVM[0].MinIncomingConfirmations = ptr[uint32](1)
+			c.EVM[0].MinContractPayment = assets.NewLinkFromJuels(100)
+		})
 		uni := NewDirectRequestUniverseWithConfig(t, cfg, nil)
 		defer uni.Cleanup()
 
@@ -393,9 +396,10 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 	})
 
 	t.Run("Log has insufficient funds", func(t *testing.T) {
-		cfg := configtest.NewTestGeneralConfig(t)
-		cfg.Overrides.GlobalMinIncomingConfirmations = null.IntFrom(1)
-		cfg.Overrides.GlobalMinimumContractPayment = assets.NewLinkFromJuels(100)
+		cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.EVM[0].MinIncomingConfirmations = ptr[uint32](1)
+			c.EVM[0].MinContractPayment = assets.NewLinkFromJuels(100)
+		})
 		uni := NewDirectRequestUniverseWithConfig(t, cfg, nil)
 		defer uni.Cleanup()
 
@@ -431,9 +435,10 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 
 	t.Run("requesters is specified and log is requested by a whitelisted address", func(t *testing.T) {
 		requester := testutils.NewAddress()
-		cfg := configtest.NewTestGeneralConfig(t)
-		cfg.Overrides.GlobalMinIncomingConfirmations = null.IntFrom(1)
-		cfg.Overrides.GlobalMinimumContractPayment = assets.NewLinkFromJuels(100)
+		cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.EVM[0].MinIncomingConfirmations = ptr[uint32](1)
+			c.EVM[0].MinContractPayment = assets.NewLinkFromJuels(100)
+		})
 		uni := NewDirectRequestUniverseWithConfig(t, cfg, func(jb *job.Job) {
 			jb.DirectRequestSpec.Requesters = []common.Address{testutils.NewAddress(), requester}
 		})
@@ -488,9 +493,10 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 
 	t.Run("requesters is specified and log is requested by a non-whitelisted address", func(t *testing.T) {
 		requester := testutils.NewAddress()
-		cfg := configtest.NewTestGeneralConfig(t)
-		cfg.Overrides.GlobalMinIncomingConfirmations = null.IntFrom(1)
-		cfg.Overrides.GlobalMinimumContractPayment = assets.NewLinkFromJuels(100)
+		cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.EVM[0].MinIncomingConfirmations = ptr[uint32](1)
+			c.EVM[0].MinContractPayment = assets.NewLinkFromJuels(100)
+		})
 		uni := NewDirectRequestUniverseWithConfig(t, cfg, func(jb *job.Job) {
 			jb.DirectRequestSpec.Requesters = []common.Address{testutils.NewAddress(), testutils.NewAddress()}
 		})
@@ -527,3 +533,5 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		uni.service.Close()
 	})
 }
+
+func ptr[T any](t T) *T { return &t }

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
+	"github.com/smartcontractkit/chainlink/core/chains/evm/client"
+	"github.com/smartcontractkit/chainlink/core/chains/evm/headtracker"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
@@ -91,15 +93,19 @@ func setupTestService(t *testing.T) *TestService {
 		cfg          = mocks.NewConfig(t)
 	)
 
+	lggr := logger.TestLogger(t)
+
 	db := pgtest.NewSqlxDB(t)
 	gcfg := configtest.NewTestGeneralConfig(t)
-	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{GeneralConfig: gcfg})
+	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{GeneralConfig: gcfg,
+		Client:      client.NewNullClient(gcfg.DefaultChainID(), lggr),
+		HeadTracker: headtracker.NullTracker})
 	keyStore := new(ksmocks.Master)
 	keyStore.On("CSA").Return(csaKeystore)
 	keyStore.On("P2P").Return(p2pKeystore)
 	keyStore.On("OCR").Return(ocr1Keystore)
 	keyStore.On("OCR2").Return(ocr2Keystore)
-	svc := feeds.NewService(orm, jobORM, db, spawner, keyStore, cfg, cc, logger.TestLogger(t), "1.0.0")
+	svc := feeds.NewService(orm, jobORM, db, spawner, keyStore, cfg, cc, lggr, "1.0.0")
 	svc.SetConnectionsManager(connMgr)
 
 	return &TestService{

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -93,7 +93,6 @@ func setupTestService(t *testing.T) *TestService {
 
 	db := pgtest.NewSqlxDB(t)
 	gcfg := configtest.NewTestGeneralConfig(t)
-	gcfg.Overrides.EVMRPCEnabled = null.BoolFrom(false)
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{GeneralConfig: gcfg})
 	keyStore := new(ksmocks.Master)
 	keyStore.On("CSA").Return(csaKeystore)

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -234,7 +234,7 @@ func TestORM(t *testing.T) {
 
 func TestORM_DeleteJob_DeletesAssociatedRecords(t *testing.T) {
 	t.Parallel()
-	config := evmtest.NewChainScopedConfig(t, cltest.NewTestGeneralConfig(t))
+	config := evmtest.NewLegacyChainScopedConfig(t, cltest.NewTestGeneralConfig(t))
 	db := pgtest.NewSqlxDB(t)
 	keyStore := cltest.NewKeyStore(t, db, config)
 	require.NoError(t, keyStore.OCR().Add(cltest.DefaultOCRKey))
@@ -330,7 +330,7 @@ func TestORM_DeleteJob_DeletesAssociatedRecords(t *testing.T) {
 }
 
 func TestORM_CreateJob_VRFV2(t *testing.T) {
-	config := evmtest.NewChainScopedConfig(t, cltest.NewTestGeneralConfig(t))
+	config := evmtest.NewLegacyChainScopedConfig(t, cltest.NewTestGeneralConfig(t))
 	db := pgtest.NewSqlxDB(t)
 	keyStore := cltest.NewKeyStore(t, db, config)
 	require.NoError(t, keyStore.OCR().Add(cltest.DefaultOCRKey))
@@ -405,7 +405,7 @@ func TestORM_CreateJob_VRFV2(t *testing.T) {
 }
 
 func TestORM_CreateJob_OCRBootstrap(t *testing.T) {
-	config := evmtest.NewChainScopedConfig(t, cltest.NewTestGeneralConfig(t))
+	config := evmtest.NewLegacyChainScopedConfig(t, cltest.NewTestGeneralConfig(t))
 	db := pgtest.NewSqlxDB(t)
 	keyStore := cltest.NewKeyStore(t, db, config)
 	require.NoError(t, keyStore.OCR().Add(cltest.DefaultOCRKey))
@@ -431,7 +431,7 @@ func TestORM_CreateJob_OCRBootstrap(t *testing.T) {
 }
 
 func TestORM_CreateJob_OCR_DuplicatedContractAddress(t *testing.T) {
-	config := evmtest.NewChainScopedConfig(t, cltest.NewTestGeneralConfig(t))
+	config := evmtest.NewLegacyChainScopedConfig(t, cltest.NewTestGeneralConfig(t))
 	db := pgtest.NewSqlxDB(t)
 	keyStore := cltest.NewKeyStore(t, db, config)
 	require.NoError(t, keyStore.OCR().Add(cltest.DefaultOCRKey))

--- a/core/services/keystore/csa_test.go
+++ b/core/services/keystore/csa_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/csakey"

--- a/core/services/keystore/dkgencrypt_test.go
+++ b/core/services/keystore/dkgencrypt_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/dkgencryptkey"

--- a/core/services/keystore/dkgsign_test.go
+++ b/core/services/keystore/dkgsign_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/dkgsignkey"

--- a/core/services/keystore/eth_internal_test.go
+++ b/core/services/keystore/eth_internal_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
@@ -15,9 +14,8 @@ import (
 
 func Test_EthKeyStore(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := configtest.NewTestGeneralConfig(t)
 
-	keyStore := ExposedNewMaster(t, db, cfg)
+	keyStore := ExposedNewMaster(t, db, pgtest.NewPGCfg(true))
 	err := keyStore.Unlock(testutils.Password)
 	require.NoError(t, err)
 	ks := keyStore.Eth()

--- a/core/services/keystore/eth_test.go
+++ b/core/services/keystore/eth_test.go
@@ -17,7 +17,7 @@ import (
 	evmclient "github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"

--- a/core/services/keystore/master_test.go
+++ b/core/services/keystore/master_test.go
@@ -4,11 +4,12 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
-	"github.com/stretchr/testify/require"
 )
 
 func TestMasterKeystore_Unlock_Save(t *testing.T) {

--- a/core/services/keystore/ocr2_test.go
+++ b/core/services/keystore/ocr2_test.go
@@ -3,12 +3,11 @@ package keystore_test
 import (
 	"testing"
 
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/chaintype"

--- a/core/services/keystore/ocr_test.go
+++ b/core/services/keystore/ocr_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ocrkey"

--- a/core/services/keystore/p2p_test.go
+++ b/core/services/keystore/p2p_test.go
@@ -4,17 +4,16 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/smartcontractkit/chainlink/core/services/ocrcommon"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/p2pkey"
+	"github.com/smartcontractkit/chainlink/core/services/ocrcommon"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 

--- a/core/services/keystore/solana_test.go
+++ b/core/services/keystore/solana_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/solkey"

--- a/core/services/keystore/starknet_test.go
+++ b/core/services/keystore/starknet_test.go
@@ -8,7 +8,7 @@ import (
 
 	starkkey "github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/keys"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/utils"

--- a/core/services/keystore/terra_test.go
+++ b/core/services/keystore/terra_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/terrakey"

--- a/core/services/keystore/vrf_test.go
+++ b/core/services/keystore/vrf_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/vrfkey"

--- a/core/services/ocr/contract_tracker_test.go
+++ b/core/services/ocr/contract_tracker_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/offchain_aggregator_wrapper"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"

--- a/core/services/ocr/contract_tracker_test.go
+++ b/core/services/ocr/contract_tracker_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
+	v2 "github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/ocr"
@@ -102,7 +103,7 @@ func Test_OCRContractTracker_LatestBlockHeight(t *testing.T) {
 	t.Parallel()
 
 	t.Run("on L2 chains, always returns 0", func(t *testing.T) {
-		uni := newContractTrackerUni(t, evmtest.ChainOptimismMainnet(t))
+		uni := newContractTrackerUni(t, v2.ChainOptimismMainnet(t))
 		l, err := uni.tracker.LatestBlockHeight(testutils.Context(t))
 		require.NoError(t, err)
 

--- a/core/services/ocr/helpers_internal_test.go
+++ b/core/services/ocr/helpers_internal_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/smartcontractkit/sqlx"
 
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
@@ -14,5 +14,5 @@ func (c *ConfigOverriderImpl) ExportedUpdateFlagsStatus() error {
 }
 
 func NewTestDB(t *testing.T, sqldb *sqlx.DB, oracleSpecID int32) *db {
-	return NewDB(sqldb, oracleSpecID, logger.TestLogger(t), configtest.NewTestGeneralConfig(t))
+	return NewDB(sqldb, oracleSpecID, logger.TestLogger(t), pgtest.NewPGCfg(true))
 }

--- a/core/services/ocr2/database_test.go
+++ b/core/services/ocr2/database_test.go
@@ -13,7 +13,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/job"

--- a/core/services/ocrcommon/block_translator_test.go
+++ b/core/services/ocrcommon/block_translator_test.go
@@ -4,12 +4,13 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
+	v2 "github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest/v2"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/ocrcommon"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func Test_BlockTranslator(t *testing.T) {
@@ -20,7 +21,7 @@ func Test_BlockTranslator(t *testing.T) {
 	lggr := logger.TestLogger(t)
 
 	t.Run("for L1 chains, returns the block changed argument", func(t *testing.T) {
-		bt := ocrcommon.NewBlockTranslator(evmtest.ChainEthMainnet(t), ethClient, lggr)
+		bt := ocrcommon.NewBlockTranslator(v2.ChainEthMainnet(t), ethClient, lggr)
 
 		from, to := bt.NumberToQueryRange(ctx, 42)
 
@@ -29,22 +30,22 @@ func Test_BlockTranslator(t *testing.T) {
 	})
 
 	t.Run("for optimism, uses the default translator", func(t *testing.T) {
-		bt := ocrcommon.NewBlockTranslator(evmtest.ChainOptimismMainnet(t), ethClient, lggr)
+		bt := ocrcommon.NewBlockTranslator(v2.ChainOptimismMainnet(t), ethClient, lggr)
 		from, to := bt.NumberToQueryRange(ctx, 42)
 		assert.Equal(t, big.NewInt(42), from)
 		assert.Equal(t, big.NewInt(42), to)
 
-		bt = ocrcommon.NewBlockTranslator(evmtest.ChainOptimismKovan(t), ethClient, lggr)
+		bt = ocrcommon.NewBlockTranslator(v2.ChainOptimismKovan(t), ethClient, lggr)
 		from, to = bt.NumberToQueryRange(ctx, 42)
 		assert.Equal(t, big.NewInt(42), from)
 		assert.Equal(t, big.NewInt(42), to)
 	})
 
 	t.Run("for arbitrum, returns the ArbitrumBlockTranslator", func(t *testing.T) {
-		bt := ocrcommon.NewBlockTranslator(evmtest.ChainArbitrumMainnet(t), ethClient, lggr)
+		bt := ocrcommon.NewBlockTranslator(v2.ChainArbitrumMainnet(t), ethClient, lggr)
 		assert.IsType(t, &ocrcommon.ArbitrumBlockTranslator{}, bt)
 
-		bt = ocrcommon.NewBlockTranslator(evmtest.ChainArbitrumRinkeby(t), ethClient, lggr)
+		bt = ocrcommon.NewBlockTranslator(v2.ChainArbitrumRinkeby(t), ethClient, lggr)
 		assert.IsType(t, &ocrcommon.ArbitrumBlockTranslator{}, bt)
 	})
 }

--- a/core/services/pg/connection.go
+++ b/core/services/pg/connection.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/sqlx"
 
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/store/dialects"
 )
 
 type Config struct {
@@ -18,8 +19,8 @@ type Config struct {
 	MaxIdleConns int
 }
 
-func NewConnection(uri string, dialect string, config Config) (db *sqlx.DB, err error) {
-	if dialect == "txdb" {
+func NewConnection(uri string, dialect dialects.DialectName, config Config) (db *sqlx.DB, err error) {
+	if dialect == dialects.TransactionWrappedPostgres {
 		// Dbtx uses the uri as a unique identifier for each transaction. Each ORM
 		// should be encapsulated in it's own transaction, and thus needs its own
 		// unique id.
@@ -31,7 +32,7 @@ func NewConnection(uri string, dialect string, config Config) (db *sqlx.DB, err 
 	}
 
 	// Initialize sql/sqlx
-	db, err = sqlx.Open(dialect, uri)
+	db, err = sqlx.Open(string(dialect), uri)
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/pg/locked_db.go
+++ b/core/services/pg/locked_db.go
@@ -5,10 +5,11 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/smartcontractkit/sqlx"
+
 	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/static"
-	"github.com/smartcontractkit/sqlx"
 )
 
 // LockedDB bounds DB connection and DB locks.
@@ -127,7 +128,7 @@ func openDB(cfg config.GeneralConfig, lggr logger.Logger) (db *sqlx.DB, err erro
 	appid := cfg.AppID()
 	static.SetConsumerName(&uri, "App", &appid)
 	dialect := cfg.GetDatabaseDialectConfiguredOrDefault()
-	db, err = NewConnection(uri.String(), string(dialect), Config{
+	db, err = NewConnection(uri.String(), dialect, Config{
 		Logger:       lggr,
 		MaxOpenConns: cfg.ORMMaxOpenConns(),
 		MaxIdleConns: cfg.ORMMaxIdleConns(),

--- a/core/services/pipeline/task.eth_call_test.go
+++ b/core/services/pipeline/task.eth_call_test.go
@@ -10,17 +10,18 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
+	"github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	evmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/mocks"
 	txmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/txmgr/mocks"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	keystoremocks "github.com/smartcontractkit/chainlink/core/services/keystore/mocks"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	pipelinemocks "github.com/smartcontractkit/chainlink/core/services/pipeline/mocks"
@@ -245,9 +246,11 @@ func TestETHCallTask(t *testing.T) {
 			config := pipelinemocks.NewConfig(t)
 			test.setupClientMocks(ethClient, config)
 
-			cfg := configtest.NewTestGeneralConfig(t)
-			cfg.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(int64(gasLimit))
-			cfg.Overrides.GlobalEvmGasLimitDRJobType = null.IntFrom(int64(drJobTypeGasLimit))
+			cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				c.EVM[0].GasEstimator.LimitDefault = ptr(gasLimit)
+				c.EVM[0].GasEstimator.LimitJobType.DR = ptr(drJobTypeGasLimit)
+			})
+			lggr := logger.TestLogger(t)
 
 			keyStore := keystoremocks.NewEth(t)
 			txManager := txmmocks.NewTxManager(t)
@@ -255,14 +258,15 @@ func TestETHCallTask(t *testing.T) {
 
 			var cc evm.ChainSet
 			if test.expectedErrorCause != nil || test.expectedErrorContains != "" {
-				cc = evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: cfg, TxManager: txManager, KeyStore: keyStore})
+				cc = evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: cfg,
+					Client: client.NewNullClient(big.NewInt(0), lggr), TxManager: txManager, KeyStore: keyStore})
 			} else {
 				cc = cltest.NewChainSetMockWithOneChain(t, ethClient, evmtest.NewChainScopedConfig(t, cfg))
 			}
 
 			task.HelperSetDependencies(cc, cfg, test.specGasLimit, pipeline.DirectRequestJobType)
 
-			result, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), test.vars, test.inputs)
+			result, runInfo := task.Run(testutils.Context(t), lggr, test.vars, test.inputs)
 			assert.False(t, runInfo.IsPending)
 			assert.False(t, runInfo.IsRetryable)
 

--- a/core/services/pipeline/task.eth_tx_test.go
+++ b/core/services/pipeline/task.eth_tx_test.go
@@ -1,6 +1,7 @@
 package pipeline_test
 
 import (
+	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -10,14 +11,16 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 
+	"github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	txmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/txmgr/mocks"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	clnull "github.com/smartcontractkit/chainlink/core/null"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	keystoremocks "github.com/smartcontractkit/chainlink/core/services/keystore/mocks"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 )
@@ -27,7 +30,7 @@ func TestETHTxTask(t *testing.T) {
 	reqID := common.HexToHash("0x5198616554d738d9485d1a7cf53b2f33e09c3bbc8fe9ac0020bd672cd2bc15d2")
 	reqTxHash := common.HexToHash("0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8")
 	specGasLimit := uint32(123)
-	const defaultGasLimit int64 = 999
+	const defaultGasLimit uint32 = 999
 	const drJobTypeGasLimit uint32 = 789
 
 	tests := []struct {
@@ -44,7 +47,7 @@ func TestETHTxTask(t *testing.T) {
 		forwardingAllowed     bool
 		vars                  pipeline.Vars
 		inputs                []pipeline.Result
-		setupClientMocks      func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager)
+		setupClientMocks      func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager)
 		expected              interface{}
 		expectedErrorCause    error
 		expectedErrorContains string
@@ -64,8 +67,7 @@ func TestETHTxTask(t *testing.T) {
 			false,
 			pipeline.NewVarsFrom(nil),
 			nil,
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
-				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
 				from := common.HexToAddress("0x882969652440ccf14a5dbb9bd53eb21cb1e11e5c")
 				to := common.HexToAddress("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF")
 				data := []byte("foobar")
@@ -116,8 +118,7 @@ func TestETHTxTask(t *testing.T) {
 				"requestTxHash": common.HexToHash("0xc524fafafcaec40652b1f84fca09c231185437d008d195fccf2f51e64b7062f8"),
 			}),
 			nil,
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
-				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
 				from := common.HexToAddress("0x882969652440ccf14a5dbb9bd53eb21cb1e11e5c")
 				to := common.HexToAddress("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF")
 				data := []byte("foobar")
@@ -164,8 +165,7 @@ func TestETHTxTask(t *testing.T) {
 				},
 			}),
 			nil,
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
-				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
 				from := common.HexToAddress("0x882969652440ccf14a5dbb9bd53eb21cb1e11e5c")
 				to := common.HexToAddress("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF")
 				data := []byte("foobar")
@@ -212,8 +212,7 @@ func TestETHTxTask(t *testing.T) {
 				},
 			}),
 			nil,
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
-				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
 				from := common.HexToAddress("0x882969652440ccf14a5dbb9bd53eb21cb1e11e5c")
 				to := common.HexToAddress("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF")
 				data := []byte("foobar")
@@ -250,8 +249,7 @@ func TestETHTxTask(t *testing.T) {
 			false,
 			pipeline.NewVarsFrom(nil),
 			nil,
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
-				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
 				from := common.HexToAddress("0x882969652440ccf14a5dbb9bd53eb21cb1e11e5c")
 				to := common.HexToAddress("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF")
 				data := []byte("foobar")
@@ -283,8 +281,7 @@ func TestETHTxTask(t *testing.T) {
 			false,
 			pipeline.NewVarsFrom(nil),
 			nil,
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
-				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
 				from := common.HexToAddress("0x882969652440ccf14a5dbb9bd53eb21cb1e11e5c")
 				to := common.HexToAddress("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF")
 				data := []byte("foobar")
@@ -320,8 +317,7 @@ func TestETHTxTask(t *testing.T) {
 			false,
 			pipeline.NewVarsFrom(nil),
 			nil,
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
-				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
 				from := common.HexToAddress("0x882969652440ccf14a5dbb9bd53eb21cb1e11e5c")
 				to := common.HexToAddress("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF")
 				data := []byte("foobar")
@@ -367,8 +363,8 @@ func TestETHTxTask(t *testing.T) {
 				},
 			}),
 			nil,
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
-				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
+
 				keyStore.On("GetRoundRobinAddress", testutils.FixtureChainID).Return(nil, errors.New("uh oh"))
 			},
 			nil, pipeline.ErrTaskRunFailed, "while querying keystore", pipeline.RunInfo{IsRetryable: true},
@@ -387,8 +383,7 @@ func TestETHTxTask(t *testing.T) {
 			false,
 			pipeline.NewVarsFrom(nil),
 			nil,
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
-				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
 				from := common.HexToAddress("0x882969652440ccf14a5dbb9bd53eb21cb1e11e5c")
 				to := common.HexToAddress("0xDeaDbeefdEAdbeefdEadbEEFdeadbeEFdEaDbeeF")
 				data := []byte("foobar")
@@ -425,9 +420,7 @@ func TestETHTxTask(t *testing.T) {
 			false,
 			pipeline.NewVarsFrom(nil),
 			nil,
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
-				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
-			},
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {},
 			nil, pipeline.ErrBadInput, "txMeta", pipeline.RunInfo{},
 		},
 		{
@@ -444,9 +437,7 @@ func TestETHTxTask(t *testing.T) {
 			false,
 			pipeline.NewVarsFrom(nil),
 			nil,
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
-				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
-			},
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {},
 			nil, pipeline.ErrBadInput, "txMeta", pipeline.RunInfo{},
 		},
 		{
@@ -463,9 +454,7 @@ func TestETHTxTask(t *testing.T) {
 			false,
 			pipeline.NewVarsFrom(nil),
 			nil,
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
-				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
-			},
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {},
 			nil, pipeline.ErrParameterEmpty, "to", pipeline.RunInfo{},
 		},
 		{
@@ -482,8 +471,7 @@ func TestETHTxTask(t *testing.T) {
 			false,
 			pipeline.NewVarsFrom(nil),
 			[]pipeline.Result{{Error: errors.New("uh oh")}},
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
-			},
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {},
 			nil, pipeline.ErrTooManyErrors, "task inputs", pipeline.RunInfo{},
 		},
 		{
@@ -500,8 +488,7 @@ func TestETHTxTask(t *testing.T) {
 			false,
 			pipeline.NewVarsFrom(nil),
 			nil,
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
-				config.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(999)
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
 				from := common.HexToAddress("0x882969652440ccf14a5dbb9bd53eb21cb1e11e5c")
 				keyStore.On("GetRoundRobinAddress", testutils.FixtureChainID, from).Return(from, nil)
 				txManager.On("CreateEthTransaction", mock.MatchedBy(func(tx txmgr.NewTx) bool {
@@ -533,7 +520,7 @@ func TestETHTxTask(t *testing.T) {
 				"evmChainID":    "123",
 			}),
 			nil,
-			func(config *configtest.TestGeneralConfig, keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
+			func(keyStore *keystoremocks.Eth, txManager *txmmocks.TxManager) {
 			},
 			nil, nil, "chain not found", pipeline.RunInfo{IsRetryable: true},
 		},
@@ -559,16 +546,20 @@ func TestETHTxTask(t *testing.T) {
 			keyStore := keystoremocks.NewEth(t)
 			txManager := txmmocks.NewTxManager(t)
 			db := pgtest.NewSqlxDB(t)
-			cfg := configtest.NewTestGeneralConfig(t)
-			cfg.Overrides.GlobalEvmGasLimitDefault = null.IntFrom(defaultGasLimit)
-			cfg.Overrides.GlobalEvmGasLimitDRJobType = null.IntFrom(int64(drJobTypeGasLimit))
+			cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				c.EVM[0].GasEstimator.LimitDefault = ptr(defaultGasLimit)
+				c.EVM[0].GasEstimator.LimitJobType.DR = ptr(drJobTypeGasLimit)
+			})
+			lggr := logger.TestLogger(t)
 
-			cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: cfg, TxManager: txManager, KeyStore: keyStore})
+			cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: cfg,
+				Client:    client.NewNullClient(big.NewInt(0), lggr),
+				TxManager: txManager, KeyStore: keyStore})
 
-			test.setupClientMocks(cfg, keyStore, txManager)
+			test.setupClientMocks(keyStore, txManager)
 			task.HelperSetDependencies(cc, keyStore, test.specGasLimit, pipeline.DirectRequestJobType)
 
-			result, runInfo := task.Run(testutils.Context(t), logger.TestLogger(t), test.vars, test.inputs)
+			result, runInfo := task.Run(testutils.Context(t), lggr, test.vars, test.inputs)
 			assert.Equal(t, test.expectedRunInfo, runInfo)
 
 			if test.expectedErrorCause != nil || test.expectedErrorContains != "" {
@@ -586,3 +577,5 @@ func TestETHTxTask(t *testing.T) {
 		})
 	}
 }
+
+func ptr[T any](t T) *T { return &t }

--- a/core/services/relay/evm/request_round_tracker_test.go
+++ b/core/services/relay/evm/request_round_tracker_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	offchain_aggregator_wrapper "github.com/smartcontractkit/chainlink/core/internal/gethwrappers2/generated/offchainaggregator"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"

--- a/core/services/vrf/delegate_test.go
+++ b/core/services/vrf/delegate_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	txmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/txmgr/mocks"
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
+	corecfg "github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/solidity_vrf_coordinator_interface"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
@@ -55,7 +56,7 @@ type vrfUniverse struct {
 	cid       big.Int
 }
 
-func buildVrfUni(t *testing.T, db *sqlx.DB, cfg *configtest.TestGeneralConfig) vrfUniverse {
+func buildVrfUni(t *testing.T, db *sqlx.DB, cfg corecfg.GeneralConfig) vrfUniverse {
 	// Mock all chain interactions
 	lb := log_mocks.NewBroadcaster(t)
 	lb.On("AddDependents", 1).Maybe()

--- a/core/store/migrate/migrate_test.go
+++ b/core/store/migrate/migrate_test.go
@@ -11,7 +11,7 @@ import (
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest/heavyweight"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"

--- a/core/store/models/common.go
+++ b/core/store/models/common.go
@@ -519,6 +519,14 @@ func ParseURL(s string) (*URL, error) {
 	return (*URL)(u), nil
 }
 
+func MustParseURL(s string) *URL {
+	u, err := ParseURL(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
 func (u *URL) String() string {
 	return (*url.URL)(u).String()
 }

--- a/core/web/config_controller_test.go
+++ b/core/web/config_controller_test.go
@@ -17,7 +17,7 @@ import (
 func TestConfigController_Show(t *testing.T) {
 	t.Parallel()
 
-	app := cltest.NewApplicationEVMDisabled(t)
+	app := cltest.NewLegacyApplicationEVMDisabled(t)
 	require.NoError(t, app.Start(testutils.Context(t)))
 	client := app.NewHTTPClient(cltest.APIEmailAdmin)
 
@@ -34,5 +34,5 @@ func TestConfigController_Show(t *testing.T) {
 	assert.Equal(t, "", cp.TLSHost)
 	assert.Len(t, cp.EthereumURL, 0)
 	assert.Equal(t, big.NewInt(evmclient.NullClientChainID).String(), cp.DefaultChainID)
-	assert.Equal(t, cltest.NewTestGeneralConfig(t).BlockBackfillDepth(), cp.BlockBackfillDepth)
+	assert.Equal(t, app.Config.BlockBackfillDepth(), cp.BlockBackfillDepth)
 }

--- a/core/web/external_initiators_controller_test.go
+++ b/core/web/external_initiators_controller_test.go
@@ -129,7 +129,7 @@ func TestExternalInitiatorsController_Index(t *testing.T) {
 func TestExternalInitiatorsController_Create_success(t *testing.T) {
 	t.Parallel()
 
-	app := cltest.NewApplicationEVMDisabled(t)
+	app := cltest.NewLegacyApplicationEVMDisabled(t)
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	client := app.NewHTTPClient(cltest.APIEmailAdmin)
@@ -154,7 +154,7 @@ func TestExternalInitiatorsController_Create_success(t *testing.T) {
 func TestExternalInitiatorsController_Create_without_URL(t *testing.T) {
 	t.Parallel()
 
-	app := cltest.NewApplicationEVMDisabled(t)
+	app := cltest.NewLegacyApplicationEVMDisabled(t)
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	client := app.NewHTTPClient(cltest.APIEmailAdmin)
@@ -179,7 +179,7 @@ func TestExternalInitiatorsController_Create_without_URL(t *testing.T) {
 func TestExternalInitiatorsController_Create_invalid(t *testing.T) {
 	t.Parallel()
 
-	app := cltest.NewApplicationEVMDisabled(t)
+	app := cltest.NewLegacyApplicationEVMDisabled(t)
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	client := app.NewHTTPClient(cltest.APIEmailAdmin)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -862,7 +862,7 @@ TraceLogging enables trace level logging.
 ## P2P.V1<a id='P2P-V1'></a>
 ```toml
 [P2P.V1]
-Enabled = false # Default
+Enabled = true # Default
 AnnounceIP = '1.2.3.4' # Example
 AnnouncePort = 1337 # Example
 BootstrapCheckInterval = '20s' # Default
@@ -879,7 +879,7 @@ PeerstoreWriteInterval = '5m' # Default
 
 ### Enabled<a id='P2P-V1-Enabled'></a>
 ```toml
-Enabled = false # Default
+Enabled = true # Default
 ```
 Enabled enables P2P V1.
 


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/46224/convert-replace-uses-of-testgeneralconfig-generalconfigoverrides-to-new-config-types

This PR introduces an override API for new config and begins swapping over some legacy test configs (100s?).