### PR TITLE
QA-79 Use the single source of truth from the solana repo for the projectserum version

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -132,7 +132,21 @@ jobs:
           triggered_by: ${{ env.TEST_TRIGGERED_BY }}
 
   ### Solana Section
-
+  get_projectserum_version:
+    name: Get ProjectSerum Version
+    environment: integration
+    runs-on: ubuntu-latest
+    outputs:
+      projectserum_version: ${{ steps.psversion.outputs.projectserum_version }}
+    steps:
+      - name: Checkout the solana repo
+        uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # v3.0.2
+        with:
+          repository: smartcontractkit/chainlink-solana
+          ref: ${{ env.solana_sha }}
+      - name: Get ProjectSerum Version
+        id: psversion
+        uses: smartcontractkit/chainlink-solana/.github/actions/projectserum_version@4b971869e26b79c7ce3fb7c98005cc2e3f350915 # stable action on Oct 12 2022
   solana-build-contracts:
     environment: integration
     permissions:
@@ -142,9 +156,9 @@ jobs:
       contents: read
     name: Solana Build Artifacts
     runs-on: ubuntu-latest
-    needs: [changes]
+    needs: [changes,get_projectserum_version]
     container:
-      image: projectserum/build:v0.25.0
+      image: projectserum/build:${{ needs.get_projectserum_version.outputs.projectserum_version }}
       env:
         RUSTUP_HOME: "/root/.rustup"
         FORCE_COLOR: 1
@@ -164,7 +178,7 @@ jobs:
           ref: ${{ env.solana_sha }}
       - name: Build contracts
         if: needs.changes.outputs.src == 'true'
-        uses: smartcontractkit/chainlink-solana/.github/actions/build_contract_artifacts@afe9aa36cda33d0098c99fb3ea41b3f0bf9e7fb4 # stable action on Oct 07 2022
+        uses: smartcontractkit/chainlink-solana/.github/actions/build_contract_artifacts@4b971869e26b79c7ce3fb7c98005cc2e3f350915 # stable action on Oct 12 2022
         with:
           ref: ${{ env.solana_sha }}
 


### PR DESCRIPTION
This removes the need to update this version in this repo when it is updated in the solana repo