### PR TITLE
TOML config: convert more tests

### DIFF
--- a/core/chains/evm/chain_set.go
+++ b/core/chains/evm/chain_set.go
@@ -475,11 +475,17 @@ func NewTOMLChainSet(ctx context.Context, opts ChainSetOpts, chains []*v2.EVMCon
 	if err := opts.check(); err != nil {
 		return nil, err
 	}
+	var enabled []*v2.EVMConfig
+	for i := range chains {
+		if e := chains[i].Enabled; e != nil && *e {
+			enabled = append(enabled, chains[i])
+		}
+	}
 	opts.Logger = opts.Logger.Named("EVM")
 	defaultChainID := opts.Config.DefaultChainID()
-	if defaultChainID == nil && len(chains) >= 1 {
-		defaultChainID = chains[0].ChainID.ToInt()
-		if len(chains) > 1 {
+	if defaultChainID == nil && len(enabled) >= 1 {
+		defaultChainID = enabled[0].ChainID.ToInt()
+		if len(enabled) > 1 {
 			opts.Logger.Debugf("Multiple chains present, default chain: %s", defaultChainID.String())
 		}
 	}
@@ -487,10 +493,10 @@ func NewTOMLChainSet(ctx context.Context, opts ChainSetOpts, chains []*v2.EVMCon
 	cll := newChainSet(opts)
 	cll.defaultID = defaultChainID
 	cll.immutable = true
-	for i := range chains {
-		cid := chains[i].ChainID.String()
+	for i := range enabled {
+		cid := enabled[i].ChainID.String()
 		cll.logger.Infow(fmt.Sprintf("Loading chain %s", cid), "evmChainID", cid)
-		chain, err2 := newTOMLChain(ctx, chains[i], opts)
+		chain, err2 := newTOMLChain(ctx, enabled[i], opts)
 		if err2 != nil {
 			err = multierr.Combine(err, err2)
 			continue

--- a/core/chains/evm/config/v2/config.go
+++ b/core/chains/evm/config/v2/config.go
@@ -76,21 +76,26 @@ func (cs EVMConfigs) Chains(ids ...utils.Big) (chains []types.DBChain) {
 		if ch == nil {
 			continue
 		}
-		var match bool
-		for _, id := range ids {
-			if id.Cmp(ch.ChainID) == 0 {
-				match = true
-				break
+		if len(ids) > 0 {
+			var match bool
+			for _, id := range ids {
+				if id.Cmp(ch.ChainID) == 0 {
+					match = true
+					break
+				}
+			}
+			if !match {
+				continue
 			}
 		}
-		if !match {
-			continue
+		dbc := types.DBChain{
+			ID:  *ch.ChainID,
+			Cfg: ch.asV1(),
 		}
-		chains = append(chains, types.DBChain{
-			ID:      *ch.ChainID,
-			Enabled: *ch.Enabled,
-			Cfg:     ch.asV1(),
-		})
+		if ch.Enabled != nil && *ch.Enabled {
+			dbc.Enabled = true
+		}
+		chains = append(chains, dbc)
 	}
 	return
 }
@@ -303,9 +308,9 @@ func (c Chain) ValidateConfig() (err error) {
 
 func (c *Chain) asV1() *types.ChainCfg {
 	cfg := types.ChainCfg{
-		BlockHistoryEstimatorBlockDelay:                null.Int{},
-		BlockHistoryEstimatorBlockHistorySize:          null.Int{},
-		BlockHistoryEstimatorEIP1559FeeCapBufferBlocks: null.Int{},
+		BlockHistoryEstimatorBlockDelay:                nullIntFromPtr(c.RPCBlockQueryDelay),
+		BlockHistoryEstimatorBlockHistorySize:          nullIntFromPtr(c.GasEstimator.BlockHistory.BlockHistorySize),
+		BlockHistoryEstimatorEIP1559FeeCapBufferBlocks: nullIntFromPtr(c.GasEstimator.BlockHistory.EIP1559FeeCapBufferBlocks),
 		ChainType:                      null.StringFromPtr(c.ChainType),
 		EthTxReaperThreshold:           c.Transactions.ReaperThreshold,
 		EthTxResendAfterThreshold:      c.Transactions.ResendAfterThreshold,
@@ -987,4 +992,11 @@ func (n *Node) SetFromDB(db types.Node) (err error) {
 		n.SendOnly = &db.SendOnly
 	}
 	return
+}
+
+func nullIntFromPtr[I constraints.Integer](i *I) null.Int {
+	if i == nil {
+		return null.Int{}
+	}
+	return null.IntFrom(int64(*i))
 }

--- a/core/chains/evm/config/v2/defaults.go
+++ b/core/chains/evm/config/v2/defaults.go
@@ -81,6 +81,15 @@ func Defaults(chainID *utils.Big) (c Chain, name string) {
 	return
 }
 
+// DefaultsFrom returns a Chain based on the defaults for chainID and fields from with.
+func DefaultsFrom(chainID *utils.Big, with *Chain) Chain {
+	c, _ := Defaults(chainID)
+	if with != nil {
+		c.SetFrom(with)
+	}
+	return c
+}
+
 func ChainTypeForID(chainID *utils.Big) (config.ChainType, bool) {
 	s := chainID.String()
 	if d, ok := defaults[s]; ok {

--- a/core/chains/evm/log/helpers_test.go
+++ b/core/chains/evm/log/helpers_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
-	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/sqlx"
 
@@ -27,14 +26,16 @@ import (
 	logmocks "github.com/smartcontractkit/chainlink/core/chains/evm/log/mocks"
 	evmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/mocks"
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
+	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/flux_aggregator_wrapper"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest2 "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
@@ -45,7 +46,7 @@ type broadcasterHelper struct {
 	lb           log.BroadcasterInTest
 	db           *sqlx.DB
 	mockEth      *evmtest.MockEth
-	globalConfig *configtest.TestGeneralConfig
+	globalConfig config.BasicConfig
 	config       evmconfig.ChainScopedConfig
 
 	// each received channel corresponds to one eth subscription
@@ -54,8 +55,8 @@ type broadcasterHelper struct {
 	pipelineHelper cltest.JobPipelineV2TestHelper
 }
 
-func newBroadcasterHelper(t *testing.T, blockHeight int64, timesSubscribe int) *broadcasterHelper {
-	return broadcasterHelperCfg{}.new(t, blockHeight, timesSubscribe, nil)
+func newBroadcasterHelper(t *testing.T, blockHeight int64, timesSubscribe int, overridesFn func(*chainlink.Config, *chainlink.Secrets)) *broadcasterHelper {
+	return broadcasterHelperCfg{}.new(t, blockHeight, timesSubscribe, nil, overridesFn)
 }
 
 type broadcasterHelperCfg struct {
@@ -63,7 +64,7 @@ type broadcasterHelperCfg struct {
 	db              *sqlx.DB
 }
 
-func (c broadcasterHelperCfg) new(t *testing.T, blockHeight int64, timesSubscribe int, filterLogsResult []types.Log) *broadcasterHelper {
+func (c broadcasterHelperCfg) new(t *testing.T, blockHeight int64, timesSubscribe int, filterLogsResult []types.Log, overridesFn func(*chainlink.Config, *chainlink.Secrets)) *broadcasterHelper {
 	if c.db == nil {
 		// ensure we check before registering any mock Cleanup assertions
 		testutils.SkipShortDB(t)
@@ -77,25 +78,32 @@ func (c broadcasterHelperCfg) new(t *testing.T, blockHeight int64, timesSubscrib
 
 	chchRawLogs := make(chan evmtest.RawSub[types.Log], timesSubscribe)
 	mockEth := newMockEthClient(t, chchRawLogs, blockHeight, expectedCalls)
-	helper := c.newWithEthClient(t, mockEth.EthClient)
+	helper := c.newWithEthClient(t, mockEth.EthClient, overridesFn)
 	helper.chchRawLogs = chchRawLogs
 	helper.mockEth = mockEth
-	helper.globalConfig.Overrides.GlobalEvmFinalityDepth = null.IntFrom(10)
 	return helper
 }
 
-func newBroadcasterHelperWithEthClient(t *testing.T, ethClient evmclient.Client, highestSeenHead *evmtypes.Head) *broadcasterHelper {
-	return broadcasterHelperCfg{highestSeenHead: highestSeenHead}.newWithEthClient(t, ethClient)
+func newBroadcasterHelperWithEthClient(t *testing.T, ethClient evmclient.Client, highestSeenHead *evmtypes.Head, overridesFn func(*chainlink.Config, *chainlink.Secrets)) *broadcasterHelper {
+	return broadcasterHelperCfg{highestSeenHead: highestSeenHead}.newWithEthClient(t, ethClient, overridesFn)
 }
 
-func (c broadcasterHelperCfg) newWithEthClient(t *testing.T, ethClient evmclient.Client) *broadcasterHelper {
+func (c broadcasterHelperCfg) newWithEthClient(t *testing.T, ethClient evmclient.Client, overridesFn func(*chainlink.Config, *chainlink.Secrets)) *broadcasterHelper {
 	if c.db == nil {
 		c.db = pgtest.NewSqlxDB(t)
 	}
 
-	globalConfig := cltest.NewTestGeneralConfig(t)
-	globalConfig.Overrides.LogSQL = null.BoolFrom(true)
-	config := evmtest.NewLegacyChainScopedConfig(t, globalConfig)
+	globalConfig := configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		cltest.TestOverrides(c, s)
+		c.Log.SQL = true
+		finality := uint32(10)
+		c.EVM[0].FinalityDepth = &finality
+
+		if overridesFn != nil {
+			overridesFn(c, s)
+		}
+	})
+	config := evmtest.NewChainScopedConfig(t, globalConfig)
 	lggr := logger.TestLogger(t)
 
 	orm := log.NewORM(c.db, lggr, config, cltest.FixtureChainID)
@@ -103,7 +111,7 @@ func (c broadcasterHelperCfg) newWithEthClient(t *testing.T, ethClient evmclient
 
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{
 		Client:         ethClient,
-		GeneralConfig:  config,
+		GeneralConfig:  globalConfig,
 		DB:             c.db,
 		LogBroadcaster: &log.NullBroadcaster{},
 	})

--- a/core/chains/evm/log/integration_test.go
+++ b/core/chains/evm/log/integration_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/atomic"
-	"gopkg.in/guregu/null.v4"
 
 	httypes "github.com/smartcontractkit/chainlink/core/chains/evm/headtracker/types"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/log"
@@ -27,6 +26,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
@@ -34,7 +34,7 @@ func TestBroadcaster_AwaitsInitialSubscribersOnStartup(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	const blockHeight int64 = 123
-	helper := newBroadcasterHelper(t, blockHeight, 1)
+	helper := newBroadcasterHelper(t, blockHeight, 1, nil)
 	helper.lb.AddDependents(2)
 
 	var listener = helper.newLogListenerWithJob("A")
@@ -80,7 +80,7 @@ func TestBroadcaster_ResubscribesOnAddOrRemoveContract(t *testing.T) {
 
 	chchRawLogs := make(chan evmtest.RawSub[types.Log], backfillTimes)
 	mockEth := newMockEthClient(t, chchRawLogs, blockHeight, expectedCalls)
-	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight))
+	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight), nil)
 	helper.mockEth = mockEth
 
 	blockBackfillDepth := helper.config.BlockBackfillDepth()
@@ -146,7 +146,7 @@ func TestBroadcaster_BackfillOnNodeStartAndOnReplay(t *testing.T) {
 
 	chchRawLogs := make(chan evmtest.RawSub[types.Log], backfillTimes)
 	mockEth := newMockEthClient(t, chchRawLogs, blockHeight, expectedCalls)
-	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight))
+	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight), nil)
 	helper.mockEth = mockEth
 
 	maxNumConfirmations := int64(10)
@@ -205,7 +205,7 @@ func TestBroadcaster_ReplaysLogs(t *testing.T) {
 		FilterLogs:       4,
 		FilterLogsResult: sentLogs,
 	})
-	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(blockHeight))
+	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(blockHeight), nil)
 	helper.mockEth = mockEth
 
 	listener := helper.newLogListenerWithJob("listener")
@@ -285,8 +285,9 @@ func TestBroadcaster_BackfillUnconsumedAfterCrash(t *testing.T) {
 	contract2.On("ParseLog", log2).Return(flux_aggregator_wrapper.FluxAggregatorAnswerUpdated{}, nil)
 
 	// Pool two logs from subscription, then shut down
-	helper := helperCfg.new(t, 0, 1, logs)
-	helper.globalConfig.Overrides.GlobalEvmFinalityDepth = null.IntFrom(confs)
+	helper := helperCfg.new(t, 0, 1, logs, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].FinalityDepth = ptr[uint32](confs)
+	})
 	listener := helper.newLogListenerWithJob("one")
 	listener.SkipMarkingConsumed(true)
 	listener2 := helper.newLogListenerWithJob("two")
@@ -329,8 +330,9 @@ func TestBroadcaster_BackfillUnconsumedAfterCrash(t *testing.T) {
 	helper.requireBroadcastCount(0)
 
 	// Backfill pool with both, then broadcast one, but don't consume
-	helper = helperCfg.new(t, 2, 1, logs)
-	helper.globalConfig.Overrides.GlobalEvmFinalityDepth = null.IntFrom(confs)
+	helper = helperCfg.new(t, 2, 1, logs, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].FinalityDepth = ptr[uint32](confs)
+	})
 	listener = helper.newLogListenerWithJob("one")
 	listener.SkipMarkingConsumed(true)
 	listener2 = helper.newLogListenerWithJob("two")
@@ -369,8 +371,9 @@ func TestBroadcaster_BackfillUnconsumedAfterCrash(t *testing.T) {
 	require.False(t, c)
 
 	// Backfill pool and broadcast two, but only consume one
-	helper = helperCfg.new(t, 4, 1, logs)
-	helper.globalConfig.Overrides.GlobalEvmFinalityDepth = null.IntFrom(confs)
+	helper = helperCfg.new(t, 4, 1, logs, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].FinalityDepth = ptr[uint32](confs)
+	})
 	listener = helper.newLogListenerWithJob("one")
 	listener2 = helper.newLogListenerWithJob("two")
 	listener2.SkipMarkingConsumed(true)
@@ -410,8 +413,9 @@ func TestBroadcaster_BackfillUnconsumedAfterCrash(t *testing.T) {
 	require.False(t, c)
 
 	// Backfill pool, broadcast and consume one
-	helper = helperCfg.new(t, 7, 1, logs[1:])
-	helper.globalConfig.Overrides.GlobalEvmFinalityDepth = null.IntFrom(confs)
+	helper = helperCfg.new(t, 7, 1, logs[1:], func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].FinalityDepth = ptr[uint32](confs)
+	})
 	listener = helper.newLogListenerWithJob("one")
 	listener2 = helper.newLogListenerWithJob("two")
 	func() {
@@ -451,6 +455,7 @@ func TestBroadcaster_ShallowBackfillOnNodeStart(t *testing.T) {
 	const (
 		lastStoredBlockHeight       = 100
 		blockHeight           int64 = 125
+		backfillDepth               = 15
 	)
 
 	backfillTimes := 1
@@ -462,13 +467,11 @@ func TestBroadcaster_ShallowBackfillOnNodeStart(t *testing.T) {
 
 	chchRawLogs := make(chan evmtest.RawSub[types.Log], backfillTimes)
 	mockEth := newMockEthClient(t, chchRawLogs, blockHeight, expectedCalls)
-	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight))
+	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight), func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].BlockBackfillSkip = ptr(true)
+		c.EVM[0].BlockBackfillDepth = ptr[uint32](15)
+	})
 	helper.mockEth = mockEth
-
-	backfillDepth := 15
-
-	helper.globalConfig.Overrides.BlockBackfillSkip = null.BoolFrom(true)
-	helper.globalConfig.Overrides.BlockBackfillDepth = null.IntFrom(int64(backfillDepth))
 
 	var backfillCount atomic.Int64
 
@@ -514,11 +517,12 @@ func TestBroadcaster_BackfillInBatches(t *testing.T) {
 
 	chchRawLogs := make(chan evmtest.RawSub[types.Log], backfillTimes)
 	mockEth := newMockEthClient(t, chchRawLogs, blockHeight, expectedCalls)
-	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight))
+	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight), func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].LogBackfillBatchSize = ptr(uint32(batchSize))
+	})
 	helper.mockEth = mockEth
 
 	blockBackfillDepth := helper.config.BlockBackfillDepth()
-	helper.globalConfig.Overrides.GlobalEvmLogBackfillBatchSize = null.IntFrom(batchSize)
 
 	var backfillCount atomic.Int64
 
@@ -586,10 +590,10 @@ func TestBroadcaster_BackfillALargeNumberOfLogs(t *testing.T) {
 
 	chchRawLogs := make(chan evmtest.RawSub[types.Log], backfillTimes)
 	mockEth := newMockEthClient(t, chchRawLogs, blockHeight, expectedCalls)
-	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight))
+	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight), func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].LogBackfillBatchSize = ptr(batchSize)
+	})
 	helper.mockEth = mockEth
-
-	helper.globalConfig.Overrides.GlobalEvmLogBackfillBatchSize = null.IntFrom(int64(batchSize))
 
 	var backfillCount atomic.Int64
 
@@ -611,7 +615,7 @@ func TestBroadcaster_BackfillALargeNumberOfLogs(t *testing.T) {
 
 func TestBroadcaster_BroadcastsToCorrectRecipients(t *testing.T) {
 	const blockHeight int64 = 0
-	helper := newBroadcasterHelper(t, blockHeight, 1)
+	helper := newBroadcasterHelper(t, blockHeight, 1, nil)
 
 	contract1, err := flux_aggregator_wrapper.NewFluxAggregator(testutils.NewAddress(), nil)
 	require.NoError(t, err)
@@ -675,7 +679,7 @@ func TestBroadcaster_BroadcastsToCorrectRecipients(t *testing.T) {
 
 func TestBroadcaster_BroadcastsAtCorrectHeights(t *testing.T) {
 	const blockHeight int64 = 0
-	helper := newBroadcasterHelper(t, blockHeight, 1)
+	helper := newBroadcasterHelper(t, blockHeight, 1, nil)
 	helper.start()
 
 	contract1, err := flux_aggregator_wrapper.NewFluxAggregator(testutils.NewAddress(), nil)
@@ -756,8 +760,9 @@ func TestBroadcaster_BroadcastsAtCorrectHeights(t *testing.T) {
 
 func TestBroadcaster_DeletesOldLogsAfterNumberOfHeads(t *testing.T) {
 	const blockHeight int64 = 0
-	helper := newBroadcasterHelper(t, blockHeight, 1)
-	helper.globalConfig.Overrides.GlobalEvmFinalityDepth = null.IntFrom(1)
+	helper := newBroadcasterHelper(t, blockHeight, 1, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].FinalityDepth = ptr[uint32](1)
+	})
 	helper.start()
 	defer helper.stop()
 
@@ -821,8 +826,9 @@ func TestBroadcaster_DeletesOldLogsAfterNumberOfHeads(t *testing.T) {
 
 func TestBroadcaster_DeletesOldLogsOnlyAfterFinalityDepth(t *testing.T) {
 	const blockHeight int64 = 0
-	helper := newBroadcasterHelper(t, blockHeight, 1)
-	helper.globalConfig.Overrides.GlobalEvmFinalityDepth = null.IntFrom(4)
+	helper := newBroadcasterHelper(t, blockHeight, 1, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].FinalityDepth = ptr[uint32](4)
+	})
 	helper.start()
 	defer helper.stop()
 
@@ -886,8 +892,9 @@ func TestBroadcaster_DeletesOldLogsOnlyAfterFinalityDepth(t *testing.T) {
 
 func TestBroadcaster_FilterByTopicValues(t *testing.T) {
 	const blockHeight int64 = 0
-	helper := newBroadcasterHelper(t, blockHeight, 1)
-	helper.globalConfig.Overrides.GlobalEvmFinalityDepth = null.IntFrom(3)
+	helper := newBroadcasterHelper(t, blockHeight, 1, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].FinalityDepth = ptr[uint32](3)
+	})
 	helper.start()
 	defer helper.stop()
 
@@ -970,8 +977,9 @@ func TestBroadcaster_FilterByTopicValues(t *testing.T) {
 
 func TestBroadcaster_BroadcastsWithOneDelayedLog(t *testing.T) {
 	const blockHeight int64 = 0
-	helper := newBroadcasterHelper(t, blockHeight, 1)
-	helper.globalConfig.Overrides.GlobalEvmFinalityDepth = null.IntFrom(2)
+	helper := newBroadcasterHelper(t, blockHeight, 1, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].FinalityDepth = ptr[uint32](2)
+	})
 	helper.start()
 
 	contract1, err := flux_aggregator_wrapper.NewFluxAggregator(testutils.NewAddress(), nil)
@@ -1018,7 +1026,7 @@ func TestBroadcaster_BroadcastsWithOneDelayedLog(t *testing.T) {
 
 func TestBroadcaster_BroadcastsAtCorrectHeightsWithLogsEarlierThanHeads(t *testing.T) {
 	const blockHeight int64 = 0
-	helper := newBroadcasterHelper(t, blockHeight, 1)
+	helper := newBroadcasterHelper(t, blockHeight, 1, nil)
 	helper.start()
 
 	contract1, err := flux_aggregator_wrapper.NewFluxAggregator(testutils.NewAddress(), nil)
@@ -1064,8 +1072,9 @@ func TestBroadcaster_BroadcastsAtCorrectHeightsWithLogsEarlierThanHeads(t *testi
 
 func TestBroadcaster_BroadcastsAtCorrectHeightsWithHeadsEarlierThanLogs(t *testing.T) {
 	const blockHeight int64 = 0
-	helper := newBroadcasterHelper(t, blockHeight, 1)
-	helper.globalConfig.Overrides.GlobalEvmFinalityDepth = null.IntFrom(2)
+	helper := newBroadcasterHelper(t, blockHeight, 1, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].FinalityDepth = ptr[uint32](2)
+	})
 	helper.start()
 
 	contract1, err := flux_aggregator_wrapper.NewFluxAggregator(testutils.NewAddress(), nil)
@@ -1196,7 +1205,7 @@ func TestBroadcaster_Register_ResubscribesToMostRecentlySeenBlock(t *testing.T) 
 		Return(nil, nil).
 		Once()
 
-	helper := newBroadcasterHelperWithEthClient(t, ethClient, nil)
+	helper := newBroadcasterHelperWithEthClient(t, ethClient, nil, nil)
 	helper.lb.AddDependents(1)
 	helper.start()
 	defer helper.stop()
@@ -1342,10 +1351,11 @@ func TestBroadcaster_ReceivesAllLogsWhenResubscribing(t *testing.T) {
 	for _, test := range tests {
 		test := test
 		t.Run(test.name, func(t *testing.T) {
-			helper := newBroadcasterHelper(t, test.blockHeight1, 2)
-			var backfillDepth int64 = 5
-			// something other than default
-			helper.globalConfig.Overrides.BlockBackfillDepth = null.IntFrom(int64(backfillDepth))
+			const backfillDepth = 5
+			helper := newBroadcasterHelper(t, test.blockHeight1, 2, func(c *chainlink.Config, s *chainlink.Secrets) {
+				// something other than default
+				c.EVM[0].BlockBackfillDepth = ptr[uint32](backfillDepth)
+			})
 
 			helper.start()
 			defer helper.stop()
@@ -1498,7 +1508,7 @@ func TestBroadcaster_AppendLogChannel(t *testing.T) {
 
 func TestBroadcaster_InjectsBroadcastRecordFunctions(t *testing.T) {
 	const blockHeight int64 = 0
-	helper := newBroadcasterHelper(t, blockHeight, 1)
+	helper := newBroadcasterHelper(t, blockHeight, 1, nil)
 	helper.start()
 	defer helper.stop()
 
@@ -1534,7 +1544,7 @@ func TestBroadcaster_ProcessesLogsFromReorgsAndMissedHead(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	const startBlockHeight int64 = 0
-	helper := newBroadcasterHelper(t, startBlockHeight, 1)
+	helper := newBroadcasterHelper(t, startBlockHeight, 1, nil)
 	helper.start()
 	defer helper.stop()
 
@@ -1617,7 +1627,7 @@ func TestBroadcaster_BackfillsForNewListeners(t *testing.T) {
 	g := gomega.NewWithT(t)
 
 	const blockHeight int64 = 0
-	helper := newBroadcasterHelper(t, blockHeight, 2)
+	helper := newBroadcasterHelper(t, blockHeight, 2, nil)
 	helper.mockEth.EthClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(&evmtypes.Head{Number: blockHeight}, nil).Times(1)
 	helper.mockEth.EthClient.On("FilterLogs", mock.Anything, mock.Anything).Return(nil, nil).Times(1)
 
@@ -1691,7 +1701,7 @@ func TestBroadcaster_BroadcastsWithZeroConfirmations(t *testing.T) {
 	ethClient.On("FilterLogs", mock.Anything, mock.Anything).
 		Return(nil, nil)
 
-	helper := newBroadcasterHelperWithEthClient(t, ethClient, nil)
+	helper := newBroadcasterHelperWithEthClient(t, ethClient, nil, nil)
 	helper.start()
 	defer helper.stop()
 
@@ -1771,3 +1781,5 @@ func TestBroadcaster_BroadcastsWithZeroConfirmations(t *testing.T) {
 		return len(listener1.getUniqueLogs()) == len(addr1SentLogs) && len(listener2.getUniqueLogs()) == len(addr1SentLogs)
 	}, 1*time.Second, cltest.DBPollingInterval).Should(gomega.BeTrue())
 }
+
+func ptr[T any](t T) *T { return &t }

--- a/core/chains/evm/types/types.go
+++ b/core/chains/evm/types/types.go
@@ -53,6 +53,7 @@ type ORM interface {
 	ChainConfigORM
 
 	SetupNodes([]Node, []utils.Big) error
+	EnsureChains([]utils.Big, ...pg.QOpt) error
 }
 
 // https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config

--- a/core/chains/orm.go
+++ b/core/chains/orm.go
@@ -44,6 +44,7 @@ type ORM[I ID, C Config, N Node] interface {
 	// All existing nodes are dropped, and any missing chains are automatically created.
 	// Then all nodes are inserted, and conflicts are ignored.
 	SetupNodes(nodes []N, chainIDs []I) error
+	EnsureChains([]I, ...pg.QOpt) error
 }
 
 type orm[I ID, C Config, N Node] struct {
@@ -69,7 +70,7 @@ func (o orm[I, C, N]) SetupNodes(nodes []N, ids []I) error {
 			return err
 		}
 
-		if err := o.ensureChains(ids, tx); err != nil {
+		if err := o.EnsureChains(ids, tx); err != nil {
 			return err
 		}
 
@@ -126,7 +127,7 @@ func (o *chainsORM[I, C]) CreateChain(id I, config C, qopts ...pg.QOpt) (chain D
 	return
 }
 
-func (o *chainsORM[I, C]) ensureChains(ids []I, qopts ...pg.QOpt) (err error) {
+func (o *chainsORM[I, C]) EnsureChains(ids []I, qopts ...pg.QOpt) (err error) {
 	named := make([]struct{ ID I }, len(ids))
 	for i, id := range ids {
 		named[i].ID = id

--- a/core/chains/solana/chain_set.go
+++ b/core/chains/solana/chain_set.go
@@ -96,6 +96,9 @@ func NewChainSetImmut(opts ChainSetOpts, cfgs SolanaConfigs) (ChainSet, error) {
 	solChains := map[string]solana.Chain{}
 	var err error
 	for _, chain := range cfgs {
+		if chain.Enabled == nil || !*chain.Enabled {
+			continue
+		}
 		var err2 error
 		solChains[*chain.ChainID], err2 = opts.NewTOMLChain(chain)
 		if err2 != nil {

--- a/core/chains/solana/chain_test.go
+++ b/core/chains/solana/chain_test.go
@@ -269,4 +269,5 @@ func (m *mockORM) Nodes(offset, limit int, qopts ...pg.QOpt) (nodes []db.Node, c
 	panic("unimplemented")
 }
 
-func (m *mockORM) SetupNodes([]db.Node, []string) error { panic("unimplemented") }
+func (m *mockORM) SetupNodes([]db.Node, []string) error    { panic("unimplemented") }
+func (m *mockORM) EnsureChains([]string, ...pg.QOpt) error { panic("unimplemented") }

--- a/core/chains/solana/config.go
+++ b/core/chains/solana/config.go
@@ -53,15 +53,17 @@ func (cs SolanaConfigs) Chains(ids ...string) (chains []DBChain) {
 		if ch == nil {
 			continue
 		}
-		var match bool
-		for _, id := range ids {
-			if id == *ch.ChainID {
-				match = true
-				break
+		if len(ids) > 0 {
+			var match bool
+			for _, id := range ids {
+				if id == *ch.ChainID {
+					match = true
+					break
+				}
 			}
-		}
-		if !match {
-			continue
+			if !match {
+				continue
+			}
 		}
 		chains = append(chains, ch.AsV1())
 	}

--- a/core/chains/solana/orm.go
+++ b/core/chains/solana/orm.go
@@ -30,6 +30,7 @@ type ORM interface {
 	NodesForChain(chainID string, offset, limit int, qopts ...pg.QOpt) (nodes []soldb.Node, count int, err error)
 
 	SetupNodes([]soldb.Node, []string) error
+	EnsureChains([]string, ...pg.QOpt) error
 
 	StoreString(chainID string, key, val string) error
 	Clear(chainID string, key string) error

--- a/core/chains/starknet/chain_set.go
+++ b/core/chains/starknet/chain_set.go
@@ -91,6 +91,9 @@ func NewChainSetImmut(opts ChainSetOpts, cfgs StarknetConfigs) (ChainSet, error)
 	stkChains := map[string]starkchain.Chain{}
 	var err error
 	for _, chain := range cfgs {
+		if chain.Enabled == nil || !*chain.Enabled {
+			continue
+		}
 		var err2 error
 		stkChains[*chain.ChainID], err2 = opts.NewTOMLChain(chain)
 		if err2 != nil {

--- a/core/chains/starknet/chain_set.go
+++ b/core/chains/starknet/chain_set.go
@@ -18,7 +18,7 @@ import (
 )
 
 type ChainSetOpts struct {
-	Config   coreconfig.GeneralConfig
+	Config   coreconfig.BasicConfig
 	Logger   logger.Logger
 	KeyStore keystore.StarkNet
 	ORM      types.ORM

--- a/core/chains/starknet/config.go
+++ b/core/chains/starknet/config.go
@@ -55,15 +55,17 @@ func (cs StarknetConfigs) Chains(ids ...string) (chains []types.DBChain) {
 		if ch == nil {
 			continue
 		}
-		var match bool
-		for _, id := range ids {
-			if id == *ch.ChainID {
-				match = true
-				break
+		if len(ids) > 0 {
+			var match bool
+			for _, id := range ids {
+				if id == *ch.ChainID {
+					match = true
+					break
+				}
 			}
-		}
-		if !match {
-			continue
+			if !match {
+				continue
+			}
 		}
 		chains = append(chains, ch.AsV1())
 	}

--- a/core/chains/starknet/types/types.go
+++ b/core/chains/starknet/types/types.go
@@ -24,6 +24,7 @@ type ORM interface {
 	NodesForChain(chainID string, offset, limit int, qopts ...pg.QOpt) (nodes []db.Node, count int, err error)
 
 	SetupNodes([]db.Node, []string) error
+	EnsureChains([]string, ...pg.QOpt) error
 
 	StoreString(chainID string, key, val string) error
 	Clear(chainID string, key string) error

--- a/core/chains/terra/chain_set.go
+++ b/core/chains/terra/chain_set.go
@@ -28,7 +28,7 @@ var (
 
 // ChainSetOpts holds options for configuring a ChainSet.
 type ChainSetOpts struct {
-	Config           coreconfig.GeneralConfig
+	Config           coreconfig.BasicConfig
 	Logger           logger.Logger
 	DB               *sqlx.DB
 	KeyStore         keystore.Terra

--- a/core/chains/terra/chain_set.go
+++ b/core/chains/terra/chain_set.go
@@ -114,6 +114,9 @@ func NewChainSetImmut(opts ChainSetOpts, cfgs TerraConfigs) (ChainSet, error) {
 	solChains := map[string]terra.Chain{}
 	var err error
 	for _, chain := range cfgs {
+		if chain.Enabled == nil || !*chain.Enabled {
+			continue
+		}
 		var err2 error
 		solChains[*chain.ChainID], err2 = opts.NewTOMLChain(chain)
 		if err2 != nil {

--- a/core/chains/terra/config.go
+++ b/core/chains/terra/config.go
@@ -56,15 +56,17 @@ func (cs TerraConfigs) Chains(ids ...string) (chains []types.DBChain) {
 		if ch == nil {
 			continue
 		}
-		var match bool
-		for _, id := range ids {
-			if id == *ch.ChainID {
-				match = true
-				break
+		if len(ids) > 0 {
+			var match bool
+			for _, id := range ids {
+				if id == *ch.ChainID {
+					match = true
+					break
+				}
 			}
-		}
-		if !match {
-			continue
+			if !match {
+				continue
+			}
 		}
 		chains = append(chains, ch.AsV1())
 	}

--- a/core/chains/terra/types/types.go
+++ b/core/chains/terra/types/types.go
@@ -25,6 +25,7 @@ type ORM interface {
 	NodesForChain(chainID string, offset, limit int, qopts ...pg.QOpt) (nodes []db.Node, count int, err error)
 
 	SetupNodes([]db.Node, []string) error
+	EnsureChains([]string, ...pg.QOpt) error
 
 	StoreString(chainID string, key, val string) error
 	Clear(chainID string, key string) error

--- a/core/cmd/cfgtest/app_test.go
+++ b/core/cmd/cfgtest/app_test.go
@@ -51,10 +51,9 @@ func TestDefaultConfig(t *testing.T) {
 		}
 		assertMethodsReturnEqual[config.GeneralConfig](t, configtest.NewTestGeneralConfig(t), configtest2.NewTestGeneralConfig(t), testRoot)
 	})
-	newChain, _ := evmcfg2.Defaults(chainID)
 	evmCfg := evmcfg2.EVMConfig{
 		ChainID: chainID,
-		Chain:   newChain,
+		Chain:   evmcfg2.DefaultsFrom(chainID, nil),
 	}
 	newConfig := evmcfg2.NewTOMLChainScopedConfig(newGeneral, &evmCfg, lggr)
 	legacyConfig := evmcfg.NewChainScopedConfig(chainID.ToInt(), evmtypes.ChainCfg{}, nil, lggr, legacyGeneral)

--- a/core/cmd/client.go
+++ b/core/cmd/client.go
@@ -150,8 +150,10 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg config.Gene
 			for _, c := range h.EVMConfigs() {
 				ids = append(ids, *c.ChainID)
 			}
-			if err = evm.NewORM(db, appLggr, cfg).EnsureChains(ids); err != nil {
-				return nil, errors.Wrap(err, "failed to setup EVM chains")
+			if len(ids) > 0 {
+				if err = evm.NewORM(db, appLggr, cfg).EnsureChains(ids); err != nil {
+					return nil, errors.Wrap(err, "failed to setup EVM chains")
+				}
 			}
 		} else {
 			if err = evm.ClobberDBFromEnv(db, cfg, appLggr); err != nil {
@@ -189,8 +191,10 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg config.Gene
 			for _, c := range cfgs {
 				ids = append(ids, *c.ChainID)
 			}
-			if err = terra.NewORM(db, terraLggr, cfg).EnsureChains(ids); err != nil {
-				return nil, errors.Wrap(err, "failed to setup Terra chains")
+			if len(ids) > 0 {
+				if err = terra.NewORM(db, terraLggr, cfg).EnsureChains(ids); err != nil {
+					return nil, errors.Wrap(err, "failed to setup Terra chains")
+				}
 			}
 			opts.ORM = terra.NewORMImmut(cfgs)
 			chains.Terra, err = terra.NewChainSetImmut(opts, cfgs)
@@ -222,8 +226,10 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg config.Gene
 			for _, c := range cfgs {
 				ids = append(ids, *c.ChainID)
 			}
-			if err = solana.NewORM(db, solLggr, cfg).EnsureChains(ids); err != nil {
-				return nil, errors.Wrap(err, "failed to setup Solana chains")
+			if len(ids) > 0 {
+				if err = solana.NewORM(db, solLggr, cfg).EnsureChains(ids); err != nil {
+					return nil, errors.Wrap(err, "failed to setup Solana chains")
+				}
 			}
 			opts.ORM = solana.NewORMImmut(cfgs)
 			chains.Solana, err = solana.NewChainSetImmut(opts, cfgs)
@@ -254,8 +260,10 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg config.Gene
 			for _, c := range cfgs {
 				ids = append(ids, *c.ChainID)
 			}
-			if err = starknet.NewORM(db, starkLggr, cfg).EnsureChains(ids); err != nil {
-				return nil, errors.Wrap(err, "failed to setup StarkNet chains")
+			if len(ids) > 0 {
+				if err = starknet.NewORM(db, starkLggr, cfg).EnsureChains(ids); err != nil {
+					return nil, errors.Wrap(err, "failed to setup StarkNet chains")
+				}
 			}
 			opts.ORM = starknet.NewORMImmut(cfgs)
 			chains.StarkNet, err = starknet.NewChainSetImmut(opts, cfgs)

--- a/core/cmd/client.go
+++ b/core/cmd/client.go
@@ -28,6 +28,7 @@ import (
 	"github.com/smartcontractkit/sqlx"
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
+	v2 "github.com/smartcontractkit/chainlink/core/chains/evm/config/v2"
 	"github.com/smartcontractkit/chainlink/core/chains/solana"
 	"github.com/smartcontractkit/chainlink/core/chains/starknet"
 	"github.com/smartcontractkit/chainlink/core/chains/terra"
@@ -144,8 +145,18 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg config.Gene
 
 	// Upsert EVM chains/nodes from ENV, necessary for backwards compatibility
 	if cfg.EVMEnabled() {
-		if err = evm.ClobberDBFromEnv(db, cfg, appLggr); err != nil {
-			return nil, err
+		if h, ok := cfg.(v2.HasEVMConfigs); ok {
+			var ids []utils.Big
+			for _, c := range h.EVMConfigs() {
+				ids = append(ids, *c.ChainID)
+			}
+			if err = evm.NewORM(db, appLggr, cfg).EnsureChains(ids); err != nil {
+				return nil, errors.Wrap(err, "failed to setup EVM chains")
+			}
+		} else {
+			if err = evm.ClobberDBFromEnv(db, cfg, appLggr); err != nil {
+				return nil, err
+			}
 		}
 	}
 
@@ -165,9 +176,6 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg config.Gene
 
 	if cfg.TerraEnabled() {
 		terraLggr := appLggr.Named("Terra")
-		if err = terra.SetupNodes(db, cfg, terraLggr); err != nil {
-			return nil, errors.Wrap(err, "failed to setup Terra nodes")
-		}
 		opts := terra.ChainSetOpts{
 			Config:           cfg,
 			Logger:           terraLggr,
@@ -177,10 +185,20 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg config.Gene
 		}
 		if newCfg, ok := cfg.(interface{ TerraConfigs() terra.TerraConfigs }); ok {
 			cfgs := newCfg.TerraConfigs()
+			var ids []string
+			for _, c := range cfgs {
+				ids = append(ids, *c.ChainID)
+			}
+			if err = terra.NewORM(db, terraLggr, cfg).EnsureChains(ids); err != nil {
+				return nil, errors.Wrap(err, "failed to setup Terra chains")
+			}
 			opts.ORM = terra.NewORMImmut(cfgs)
 			chains.Terra, err = terra.NewChainSetImmut(opts, cfgs)
 
 		} else {
+			if err = terra.SetupNodes(db, cfg, terraLggr); err != nil {
+				return nil, errors.Wrap(err, "failed to setup Terra nodes")
+			}
 			opts.ORM = terra.NewORM(db, terraLggr, cfg)
 			chains.Terra, err = terra.NewChainSet(opts)
 		}
@@ -191,9 +209,6 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg config.Gene
 
 	if cfg.SolanaEnabled() {
 		solLggr := appLggr.Named("Solana")
-		if err = solana.SetupNodes(db, cfg, solLggr); err != nil {
-			return nil, errors.Wrap(err, "failed to setup Solana nodes")
-		}
 		opts := solana.ChainSetOpts{
 			Logger:   solLggr,
 			DB:       db,
@@ -203,9 +218,19 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg config.Gene
 			SolanaConfigs() solana.SolanaConfigs
 		}); ok {
 			cfgs := newCfg.SolanaConfigs()
+			var ids []string
+			for _, c := range cfgs {
+				ids = append(ids, *c.ChainID)
+			}
+			if err = solana.NewORM(db, solLggr, cfg).EnsureChains(ids); err != nil {
+				return nil, errors.Wrap(err, "failed to setup Solana chains")
+			}
 			opts.ORM = solana.NewORMImmut(cfgs)
 			chains.Solana, err = solana.NewChainSetImmut(opts, cfgs)
 		} else {
+			if err = solana.SetupNodes(db, cfg, solLggr); err != nil {
+				return nil, errors.Wrap(err, "failed to setup Solana nodes")
+			}
 			opts.ORM = solana.NewORM(db, solLggr, cfg)
 			chains.Solana, err = solana.NewChainSet(opts)
 		}
@@ -216,9 +241,6 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg config.Gene
 
 	if cfg.StarkNetEnabled() {
 		starkLggr := appLggr.Named("StarkNet")
-		if err = starknet.SetupNodes(db, cfg, starkLggr); err != nil {
-			return nil, errors.Wrap(err, "failed to setup StarkNet nodes")
-		}
 		opts := starknet.ChainSetOpts{
 			Config:   cfg,
 			Logger:   starkLggr,
@@ -228,9 +250,19 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg config.Gene
 			StarknetConfigs() starknet.StarknetConfigs
 		}); ok {
 			cfgs := newCfg.StarknetConfigs()
+			var ids []string
+			for _, c := range cfgs {
+				ids = append(ids, *c.ChainID)
+			}
+			if err = starknet.NewORM(db, starkLggr, cfg).EnsureChains(ids); err != nil {
+				return nil, errors.Wrap(err, "failed to setup StarkNet chains")
+			}
 			opts.ORM = starknet.NewORMImmut(cfgs)
 			chains.StarkNet, err = starknet.NewChainSetImmut(opts, cfgs)
 		} else {
+			if err = starknet.SetupNodes(db, cfg, starkLggr); err != nil {
+				return nil, errors.Wrap(err, "failed to setup StarkNet nodes")
+			}
 			opts.ORM = starknet.NewORM(db, starkLggr, cfg)
 			chains.StarkNet, err = starknet.NewChainSet(opts)
 		}

--- a/core/cmd/key_store_authenticator.go
+++ b/core/cmd/key_store_authenticator.go
@@ -18,7 +18,7 @@ type TerminalKeyStoreAuthenticator struct {
 	Prompter Prompter
 }
 
-func (auth TerminalKeyStoreAuthenticator) authenticate(c *clipkg.Context, keyStore keystore.Master, cfg config.GeneralConfig) error {
+func (auth TerminalKeyStoreAuthenticator) authenticate(c *clipkg.Context, keyStore keystore.Master, cfg config.BasicConfig) error {
 	isEmpty, err := keyStore.IsEmpty()
 	if err != nil {
 		return errors.Wrap(err, "error determining if keystore is empty")

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -30,7 +30,6 @@ import (
 	"github.com/smartcontractkit/sqlx"
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
-	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
@@ -487,7 +486,7 @@ func (cli *Client) ResetDatabase(c *clipkg.Context) error {
 	if err := migrateDB(cfg, lggr); err != nil {
 		return cli.errorOut(err)
 	}
-	schema, err := dumpSchema(cfg)
+	schema, err := dumpSchema(parsed)
 	if err != nil {
 		return cli.errorOut(err)
 	}
@@ -496,7 +495,7 @@ func (cli *Client) ResetDatabase(c *clipkg.Context) error {
 	if err := downAndUpDB(cfg, lggr, baseVersionID); err != nil {
 		return cli.errorOut(err)
 	}
-	if err := checkSchema(cfg, schema); err != nil {
+	if err := checkSchema(parsed, schema); err != nil {
 		return cli.errorOut(err)
 	}
 	return nil
@@ -526,7 +525,7 @@ func (cli *Client) PrepareTestDatabase(c *clipkg.Context) error {
 	if userOnly {
 		fixturePath = "../store/fixtures/users_only_fixture.sql"
 	}
-	if err := insertFixtures(cfg, fixturePath); err != nil {
+	if err := insertFixtures(dbUrl, fixturePath); err != nil {
 		return cli.errorOut(err)
 	}
 
@@ -540,7 +539,7 @@ func (cli *Client) PrepareTestDatabaseUserOnly(c *clipkg.Context) error {
 		return cli.errorOut(err)
 	}
 	cfg := cli.Config
-	if err := insertFixtures(cfg, "../store/fixtures/users_only_fixtures.sql"); err != nil {
+	if err := insertFixtures(cfg.DatabaseURL(), "../store/fixtures/users_only_fixtures.sql"); err != nil {
 		return cli.errorOut(err)
 	}
 	return nil
@@ -719,8 +718,7 @@ func downAndUpDB(cfg dbConfig, lggr logger.Logger, baseVersionID int64) error {
 	return db.Close()
 }
 
-func dumpSchema(cfg config.BasicConfig) (string, error) {
-	dbURL := cfg.DatabaseURL()
+func dumpSchema(dbURL url.URL) (string, error) {
 	args := []string{
 		dbURL.String(),
 		"--schema-only",
@@ -736,8 +734,8 @@ func dumpSchema(cfg config.BasicConfig) (string, error) {
 	return string(schema), nil
 }
 
-func checkSchema(cfg config.BasicConfig, prevSchema string) error {
-	newSchema, err := dumpSchema(cfg)
+func checkSchema(dbURL url.URL, prevSchema string) error {
+	newSchema, err := dumpSchema(dbURL)
 	if err != nil {
 		return err
 	}
@@ -749,8 +747,7 @@ func checkSchema(cfg config.BasicConfig, prevSchema string) error {
 	return nil
 }
 
-func insertFixtures(config config.BasicConfig, pathToFixtures string) (err error) {
-	dbURL := config.DatabaseURL()
+func insertFixtures(dbURL url.URL, pathToFixtures string) (err error) {
 	db, err := sql.Open(string(dialects.Postgres), dbURL.String())
 	if err != nil {
 		return fmt.Errorf("unable to open postgres database for creating test db: %+v", err)

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -719,7 +719,7 @@ func downAndUpDB(cfg dbConfig, lggr logger.Logger, baseVersionID int64) error {
 	return db.Close()
 }
 
-func dumpSchema(cfg config.GeneralConfig) (string, error) {
+func dumpSchema(cfg config.BasicConfig) (string, error) {
 	dbURL := cfg.DatabaseURL()
 	args := []string{
 		dbURL.String(),
@@ -736,7 +736,7 @@ func dumpSchema(cfg config.GeneralConfig) (string, error) {
 	return string(schema), nil
 }
 
-func checkSchema(cfg config.GeneralConfig, prevSchema string) error {
+func checkSchema(cfg config.BasicConfig, prevSchema string) error {
 	newSchema, err := dumpSchema(cfg)
 	if err != nil {
 		return err
@@ -749,7 +749,7 @@ func checkSchema(cfg config.GeneralConfig, prevSchema string) error {
 	return nil
 }
 
-func insertFixtures(config config.GeneralConfig, pathToFixtures string) (err error) {
+func insertFixtures(config config.BasicConfig, pathToFixtures string) (err error) {
 	dbURL := config.DatabaseURL()
 	db, err := sql.Open(string(dialects.Postgres), dbURL.String())
 	if err != nil {

--- a/core/cmd/ocr2_keys_commands_test.go
+++ b/core/cmd/ocr2_keys_commands_test.go
@@ -7,15 +7,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli"
+
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/core/utils"
 	"github.com/smartcontractkit/chainlink/core/web/presenters"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli"
 )
 
 func TestOCR2KeyBundlePresenter_RenderTable(t *testing.T) {
@@ -67,7 +68,7 @@ func TestOCR2KeyBundlePresenter_RenderTable(t *testing.T) {
 func TestClient_OCR2Keys(t *testing.T) {
 	t.Parallel()
 
-	app := startNewApplication(t)
+	app := startNewApplicationV2(t, nil)
 	ks := app.GetKeyStore().OCR2()
 	cleanup := func() {
 		keys, err := app.GetKeyStore().OCR2().GetAll()

--- a/core/cmd/ocr_keys_commands_test.go
+++ b/core/cmd/ocr_keys_commands_test.go
@@ -66,7 +66,7 @@ func TestOCRKeyBundlePresenter_RenderTable(t *testing.T) {
 func TestClient_ListOCRKeyBundles(t *testing.T) {
 	t.Parallel()
 
-	app := startNewApplication(t)
+	app := startNewApplicationV2(t, nil)
 	client, r := app.NewClientAndRenderer()
 
 	key, err := app.GetKeyStore().OCR().Create()
@@ -83,7 +83,7 @@ func TestClient_ListOCRKeyBundles(t *testing.T) {
 func TestClient_CreateOCRKeyBundle(t *testing.T) {
 	t.Parallel()
 
-	app := startNewApplication(t)
+	app := startNewApplicationV2(t, nil)
 	client, r := app.NewClientAndRenderer()
 
 	requireOCRKeyCount(t, app, 0)
@@ -102,7 +102,7 @@ func TestClient_CreateOCRKeyBundle(t *testing.T) {
 func TestClient_DeleteOCRKeyBundle(t *testing.T) {
 	t.Parallel()
 
-	app := startNewApplication(t)
+	app := startNewApplicationV2(t, nil)
 	client, r := app.NewClientAndRenderer()
 
 	key, err := app.GetKeyStore().OCR().Create()
@@ -126,7 +126,7 @@ func TestClient_DeleteOCRKeyBundle(t *testing.T) {
 func TestClient_ImportExportOCRKey(t *testing.T) {
 	defer deleteKeyExportFile(t)
 
-	app := startNewApplication(t)
+	app := startNewApplicationV2(t, nil)
 	client, _ := app.NewClientAndRenderer()
 
 	require.NoError(t, app.KeyStore.OCR().Add(cltest.DefaultOCRKey))

--- a/core/cmd/p2p_keys_commands_test.go
+++ b/core/cmd/p2p_keys_commands_test.go
@@ -7,15 +7,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli"
+
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/p2pkey"
 	"github.com/smartcontractkit/chainlink/core/utils"
 	"github.com/smartcontractkit/chainlink/core/web/presenters"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
-	"github.com/urfave/cli"
 )
 
 func TestP2PKeyPresenter_RenderTable(t *testing.T) {
@@ -60,7 +61,7 @@ func TestP2PKeyPresenter_RenderTable(t *testing.T) {
 func TestClient_ListP2PKeys(t *testing.T) {
 	t.Parallel()
 
-	app := startNewApplication(t)
+	app := startNewApplicationV2(t, nil)
 	key, err := app.GetKeyStore().P2P().Create()
 	require.NoError(t, err)
 
@@ -77,7 +78,7 @@ func TestClient_ListP2PKeys(t *testing.T) {
 func TestClient_CreateP2PKey(t *testing.T) {
 	t.Parallel()
 
-	app := startNewApplication(t)
+	app := startNewApplicationV2(t, nil)
 	client, _ := app.NewClientAndRenderer()
 
 	require.NoError(t, client.CreateP2PKey(nilContext))
@@ -91,7 +92,7 @@ func TestClient_CreateP2PKey(t *testing.T) {
 func TestClient_DeleteP2PKey(t *testing.T) {
 	t.Parallel()
 
-	app := startNewApplication(t)
+	app := startNewApplicationV2(t, nil)
 	client, _ := app.NewClientAndRenderer()
 
 	key, err := app.GetKeyStore().P2P().Create()
@@ -115,7 +116,7 @@ func TestClient_ImportExportP2PKeyBundle(t *testing.T) {
 
 	defer deleteKeyExportFile(t)
 
-	app := startNewApplication(t)
+	app := startNewApplicationV2(t, nil)
 	client, _ := app.NewClientAndRenderer()
 	_, err := app.GetKeyStore().P2P().Create()
 	require.NoError(t, err)

--- a/core/cmd/solana_keys_commands_test.go
+++ b/core/cmd/solana_keys_commands_test.go
@@ -55,7 +55,7 @@ func TestSolanaKeyPresenter_RenderTable(t *testing.T) {
 }
 
 func TestClient_SolanaKeys(t *testing.T) {
-	app := startNewApplication(t)
+	app := startNewApplicationV2(t, nil)
 	ks := app.GetKeyStore().Solana()
 	cleanup := func() {
 		keys, err := ks.GetAll()

--- a/core/cmd/starknet_keys_commands_test.go
+++ b/core/cmd/starknet_keys_commands_test.go
@@ -58,7 +58,7 @@ func TestStarkNetKeyPresenter_RenderTable(t *testing.T) {
 }
 
 func TestClient_StarkNetKeys(t *testing.T) {
-	app := startNewApplication(t)
+	app := startNewApplicationV2(t, nil)
 	ks := app.GetKeyStore().StarkNet()
 	cleanup := func() {
 		keys, err := ks.GetAll()

--- a/core/cmd/terra_chains_commands_test.go
+++ b/core/cmd/terra_chains_commands_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
 	"github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
+	"github.com/smartcontractkit/chainlink/core/chains/terra"
 
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
@@ -22,29 +23,26 @@ import (
 func TestClient_IndexTerraChains(t *testing.T) {
 	t.Parallel()
 
-	app := terraStartNewApplication(t)
+	chainID := terratest.RandomChainID()
+	chain := terra.TerraConfig{
+		ChainID: ptr(chainID),
+		Enabled: ptr(true),
+	}
+	app := terraStartNewApplication(t, &chain)
 	client, r := app.NewClientAndRenderer()
-
-	ter := app.Chains.Terra
-	_, initialCount, err := ter.Index(0, 25)
-	require.NoError(t, err)
-
-	ctx := testutils.Context(t)
-	chain, err := ter.Add(ctx, terratest.RandomChainID(), nil)
-	require.NoError(t, err)
 
 	require.Nil(t, cmd.TerraChainClient(client).IndexChains(cltest.EmptyCLIContext()))
 	chains := *r.Renders[0].(*cmd.TerraChainPresenters)
-	require.Len(t, chains, initialCount+1)
-	c := chains[initialCount]
-	assert.Equal(t, chain.ID, c.ID)
+	require.Len(t, chains, 1)
+	c := chains[0]
+	assert.Equal(t, chainID, c.ID)
 	assertTableRenders(t, r)
 }
 
 func TestClient_CreateTerraChain(t *testing.T) {
 	t.Parallel()
 
-	app := terraStartNewApplication(t)
+	app := terraStartNewLegacyApplication(t)
 	client, r := app.NewClientAndRenderer()
 
 	ter := app.Chains.Terra
@@ -71,7 +69,7 @@ func TestClient_CreateTerraChain(t *testing.T) {
 func TestClient_RemoveTerraChain(t *testing.T) {
 	t.Parallel()
 
-	app := terraStartNewApplication(t)
+	app := terraStartNewLegacyApplication(t)
 	client, r := app.NewClientAndRenderer()
 
 	ter := app.Chains.Terra
@@ -102,7 +100,7 @@ func TestClient_RemoveTerraChain(t *testing.T) {
 func TestClient_ConfigureTerraChain(t *testing.T) {
 	t.Parallel()
 
-	app := terraStartNewApplication(t)
+	app := terraStartNewLegacyApplication(t)
 	client, r := app.NewClientAndRenderer()
 
 	ter := app.Chains.Terra
@@ -148,3 +146,5 @@ func TestClient_ConfigureTerraChain(t *testing.T) {
 	assert.Equal(t, original.ConfirmPollPeriod, ch.Cfg.ConfirmPollPeriod)
 	assertTableRenders(t, r)
 }
+
+func ptr[T any](t T) *T { return &t }

--- a/core/cmd/terra_commands_test.go
+++ b/core/cmd/terra_commands_test.go
@@ -14,7 +14,7 @@ import (
 func TestClient_TerraInit(t *testing.T) {
 	t.Parallel()
 
-	app := terraStartNewApplication(t)
+	app := terraStartNewLegacyApplication(t)
 	client, r := app.NewClientAndRenderer()
 
 	newNode := types.NewNode{

--- a/core/cmd/terra_keys_commands_test.go
+++ b/core/cmd/terra_keys_commands_test.go
@@ -55,7 +55,7 @@ func TestTerraKeyPresenter_RenderTable(t *testing.T) {
 }
 
 func TestClient_TerraKeys(t *testing.T) {
-	app := startNewApplication(t)
+	app := startNewApplicationV2(t, nil)
 	ks := app.GetKeyStore().Terra()
 	cleanup := func() {
 		keys, err := ks.GetAll()

--- a/core/cmd/terra_node_commands_test.go
+++ b/core/cmd/terra_node_commands_test.go
@@ -2,6 +2,7 @@ package cmd_test
 
 import (
 	"flag"
+	"net/url"
 	"strconv"
 	"testing"
 
@@ -10,7 +11,10 @@ import (
 	"github.com/urfave/cli"
 	"gopkg.in/guregu/null.v4"
 
+	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	tercfg "github.com/smartcontractkit/chainlink-terra/pkg/terra/config"
 	"github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 
 	"github.com/smartcontractkit/chainlink/core/chains/terra"
 	"github.com/smartcontractkit/chainlink/core/chains/terra/types"
@@ -27,7 +31,17 @@ func mustInsertTerraChain(t *testing.T, ter terra.ChainSet, id string) types.DBC
 	return chain
 }
 
-func terraStartNewApplication(t *testing.T) *cltest.TestApplication {
+func terraStartNewApplication(t *testing.T, cfgs ...*terra.TerraConfig) *cltest.TestApplication {
+	for i := range cfgs {
+		cfgs[i].SetDefaults()
+	}
+	return startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.Terra = cfgs
+		c.EVM = nil
+	})
+}
+
+func terraStartNewLegacyApplication(t *testing.T) *cltest.TestApplication {
 	return startNewApplication(t, withConfigSet(func(c *configtest.TestGeneralConfig) {
 		c.Overrides.TerraEnabled = null.BoolFrom(true)
 		c.Overrides.EVMEnabled = null.BoolFrom(false)
@@ -38,40 +52,35 @@ func terraStartNewApplication(t *testing.T) *cltest.TestApplication {
 func TestClient_IndexTerraNodes(t *testing.T) {
 	t.Parallel()
 
-	app := terraStartNewApplication(t)
-	client, r := app.NewClientAndRenderer()
-
-	ter := app.Chains.Terra
-	_, initialCount, err := ter.Index(0, 25)
-	require.NoError(t, err)
 	chainID := terratest.RandomChainID()
-	_ = mustInsertTerraChain(t, ter, chainID)
-
-	params := db.Node{
-		Name:          "second",
-		TerraChainID:  chainID,
-		TendermintURL: "http://tender.mint.test/bombay-12",
+	node := tercfg.Node{
+		Name:          ptr("second"),
+		TendermintURL: utils.MustParseURL("http://tender.mint.test/bombay-12"),
 	}
-	ctx := testutils.Context(t)
-	node, err := ter.CreateNode(ctx, params)
-	require.NoError(t, err)
+	chain := terra.TerraConfig{
+		ChainID: ptr(chainID),
+		Enabled: ptr(true),
+		Nodes:   terra.TerraNodes{&node},
+	}
+	app := terraStartNewApplication(t, &chain)
+	client, r := app.NewClientAndRenderer()
 
 	require.Nil(t, cmd.NewTerraNodeClient(client).IndexNodes(cltest.EmptyCLIContext()))
 	require.NotEmpty(t, r.Renders)
 	nodes := *r.Renders[0].(*cmd.TerraNodePresenters)
-	require.Len(t, nodes, initialCount+1)
-	n := nodes[initialCount]
-	assert.Equal(t, strconv.FormatInt(int64(node.ID), 10), n.ID)
-	assert.Equal(t, params.Name, n.Name)
-	assert.Equal(t, params.TerraChainID, n.TerraChainID)
-	assert.Equal(t, params.TendermintURL, n.TendermintURL)
+	require.Len(t, nodes, 1)
+	n := nodes[0]
+	assert.Equal(t, "0", n.ID)
+	assert.Equal(t, *node.Name, n.Name)
+	assert.Equal(t, *chain.ChainID, n.TerraChainID)
+	assert.Equal(t, (*url.URL)(node.TendermintURL).String(), n.TendermintURL)
 	assertTableRenders(t, r)
 }
 
 func TestClient_CreateTerraNode(t *testing.T) {
 	t.Parallel()
 
-	app := terraStartNewApplication(t)
+	app := terraStartNewLegacyApplication(t)
 	client, r := app.NewClientAndRenderer()
 
 	ter := app.Chains.Terra
@@ -123,7 +132,7 @@ func TestClient_CreateTerraNode(t *testing.T) {
 func TestClient_RemoveTerraNode(t *testing.T) {
 	t.Parallel()
 
-	app := terraStartNewApplication(t)
+	app := terraStartNewLegacyApplication(t)
 	client, r := app.NewClientAndRenderer()
 
 	ter := app.Chains.Terra

--- a/core/cmd/vrf_keys_commands_test.go
+++ b/core/cmd/vrf_keys_commands_test.go
@@ -6,14 +6,16 @@ import (
 	"os"
 	"testing"
 
+	"github.com/urfave/cli"
+
 	"github.com/smartcontractkit/chainlink/core/utils"
 	"github.com/smartcontractkit/chainlink/core/web/presenters"
-	"github.com/urfave/cli"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestVRFKeyPresenter_RenderTable(t *testing.T) {
@@ -69,7 +71,7 @@ func TestClientVRF_CRUD(t *testing.T) {
 
 	// Test application boots with vrf password loaded in memory.
 	// i.e. as if a user had booted with --vrfpassword=<vrfPasswordFilePath>
-	app := startNewApplication(t)
+	app := startNewApplicationV2(t, nil)
 	client, r := app.NewClientAndRenderer()
 
 	require.NoError(t, client.ListVRFKeys(cltest.EmptyCLIContext()))

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -431,12 +431,14 @@ func NewApplicationWithConfig(t testing.TB, cfg config.GeneralConfig, flagsAndDe
 		for _, c := range h.EVMConfigs() {
 			ids = append(ids, *c.ChainID)
 		}
-		o := chainORM
-		if o == nil {
-			o = evm.NewORM(db, lggr, cfg)
-		}
-		if err = o.EnsureChains(ids); err != nil {
-			t.Fatal(err)
+		if len(ids) > 0 {
+			o := chainORM
+			if o == nil {
+				o = evm.NewORM(db, lggr, cfg)
+			}
+			if err = o.EnsureChains(ids); err != nil {
+				t.Fatal(err)
+			}
 		}
 	}
 	var chains chainlink.Chains
@@ -474,8 +476,10 @@ func NewApplicationWithConfig(t testing.TB, cfg config.GeneralConfig, flagsAndDe
 			for _, c := range cfgs {
 				ids = append(ids, *c.ChainID)
 			}
-			if err = terra.NewORM(db, terraLggr, cfg).EnsureChains(ids); err != nil {
-				t.Fatal(err)
+			if len(ids) > 0 {
+				if err = terra.NewORM(db, terraLggr, cfg).EnsureChains(ids); err != nil {
+					t.Fatal(err)
+				}
 			}
 		} else {
 			opts.ORM = terra.NewORM(db, terraLggr, cfg)
@@ -502,8 +506,10 @@ func NewApplicationWithConfig(t testing.TB, cfg config.GeneralConfig, flagsAndDe
 			for _, c := range cfgs {
 				ids = append(ids, *c.ChainID)
 			}
-			if err = solana.NewORM(db, solLggr, cfg).EnsureChains(ids); err != nil {
-				t.Fatal(err)
+			if len(ids) > 0 {
+				if err = solana.NewORM(db, solLggr, cfg).EnsureChains(ids); err != nil {
+					t.Fatal(err)
+				}
 			}
 		} else {
 			opts.ORM = solana.NewORM(db, solLggr, cfg)
@@ -530,8 +536,10 @@ func NewApplicationWithConfig(t testing.TB, cfg config.GeneralConfig, flagsAndDe
 			for _, c := range cfgs {
 				ids = append(ids, *c.ChainID)
 			}
-			if err = starknet.NewORM(db, starkLggr, cfg).EnsureChains(ids); err != nil {
-				t.Fatal(err)
+			if len(ids) > 0 {
+				if err = starknet.NewORM(db, starkLggr, cfg).EnsureChains(ids); err != nil {
+					t.Fatal(err)
+				}
 			}
 		} else {
 			opts.ORM = starknet.NewORM(db, starkLggr, cfg)

--- a/core/internal/cltest/simulated_backend.go
+++ b/core/internal/cltest/simulated_backend.go
@@ -95,11 +95,10 @@ func NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(
 // or replaces the null chain (client.NullClientChainID) if that is the only entry.
 func OverrideSimulated(c *chainlink.Config, s *chainlink.Secrets) {
 	chainID := utils.NewBig(testutils.SimulatedChainID)
-	chain, _ := evmcfg.Defaults(chainID)
 	enabled := true
 	cfg := evmcfg.EVMConfig{
 		ChainID: chainID,
-		Chain:   chain,
+		Chain:   evmcfg.DefaultsFrom(chainID, nil),
 		Enabled: &enabled,
 		Nodes:   evmcfg.EVMNodes{{}},
 	}

--- a/core/internal/cltest/simulated_backend.go
+++ b/core/internal/cltest/simulated_backend.go
@@ -69,7 +69,7 @@ func NewApplicationWithConfigAndKeyOnSimulatedBlockchain(
 }
 
 // NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain is like NewApplicationWithConfigAndKeyOnSimulatedBlockchain
-// but cfg should be v2, and cltest.OverrideSimulated used.
+// but cfg should be v2, and cltest.OverrideSimulated used to include the simulated chain (testutils.SimulatedChainID).
 func NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(
 	t testing.TB,
 	cfg coreconfig.GeneralConfig,
@@ -91,7 +91,8 @@ func NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(
 	return NewApplicationWithConfigAndKey(t, cfg, flagsAndDeps...)
 }
 
-// OverrideSimulated is a config override func that appends the simulated chain, or replaces the null chain if that is the only entry.
+// OverrideSimulated is a config override func that appends the simulated chain (testutils.SimulatedChainID),
+// or replaces the null chain (client.NullClientChainID) if that is the only entry.
 func OverrideSimulated(c *chainlink.Config, s *chainlink.Secrets) {
 	chainID := utils.NewBig(testutils.SimulatedChainID)
 	chain, _ := evmcfg.Defaults(chainID)

--- a/core/internal/features/features_test.go
+++ b/core/internal/features/features_test.go
@@ -254,7 +254,7 @@ func TestIntegration_AuthToken(t *testing.T) {
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
 
-	app := cltest.NewApplication(t, ethClient)
+	app := cltest.NewLegacyApplication(t, ethClient)
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	// set up user

--- a/core/internal/features/features_test.go
+++ b/core/internal/features/features_test.go
@@ -455,10 +455,16 @@ func TestIntegration_DirectRequest(t *testing.T) {
 	}
 }
 
-func setupAppForEthTx(t *testing.T, cfg *configtest.TestGeneralConfig, operatorContracts OperatorContracts) (app *cltest.TestApplication, sendingAddress common.Address, o *observer.ObservedLogs) {
+func setupAppForEthTx(t *testing.T, operatorContracts OperatorContracts) (app *cltest.TestApplication, sendingAddress common.Address, o *observer.ObservedLogs) {
 	b := operatorContracts.sim
 	lggr, o := logger.TestLoggerObserved(t, zapcore.DebugLevel)
-	app = cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, cfg, b, lggr)
+
+	cfg := configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		cltest.TestOverrides(c, s)
+		cltest.OverrideSimulated(c, s)
+		c.Database.Listener.FallbackPollInterval = models.MustNewDuration(100 * time.Millisecond)
+	})
+	app = cltest.NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(t, cfg, b, lggr)
 	b.Commit()
 
 	sendingKeys, err := app.KeyStore.Eth().EnabledKeysForChain(testutils.SimulatedChainID)
@@ -484,13 +490,11 @@ func setupAppForEthTx(t *testing.T, cfg *configtest.TestGeneralConfig, operatorC
 }
 
 func TestIntegration_AsyncEthTx(t *testing.T) {
-	cfg := cltest.NewTestGeneralConfig(t)
-	cfg.Overrides.SetTriggerFallbackDBPollInterval(100 * time.Millisecond)
 	operatorContracts := setupOperatorContracts(t)
 	b := operatorContracts.sim
 
 	t.Run("with FailOnRevert enabled, run succeeds when transaction is successful", func(t *testing.T) {
-		app, sendingAddr, o := setupAppForEthTx(t, cfg, operatorContracts)
+		app, sendingAddr, o := setupAppForEthTx(t, operatorContracts)
 		tomlSpec := `
 type            = "webhook"
 schemaVersion   = 1
@@ -535,7 +539,7 @@ observationSource   = """
 	})
 
 	t.Run("with FailOnRevert enabled, run fails with transaction reverted error", func(t *testing.T) {
-		app, sendingAddr, o := setupAppForEthTx(t, cfg, operatorContracts)
+		app, sendingAddr, o := setupAppForEthTx(t, operatorContracts)
 		tomlSpec := `
 type            = "webhook"
 schemaVersion   = 1
@@ -572,7 +576,7 @@ observationSource   = """
 	})
 
 	t.Run("with FailOnRevert disabled, run succeeds with output being reverted receipt", func(t *testing.T) {
-		app, sendingAddr, o := setupAppForEthTx(t, cfg, operatorContracts)
+		app, sendingAddr, o := setupAppForEthTx(t, operatorContracts)
 		tomlSpec := `
 type            = "webhook"
 schemaVersion   = 1

--- a/core/internal/testutils/configtest/general_config.go
+++ b/core/internal/testutils/configtest/general_config.go
@@ -46,7 +46,6 @@ type GeneralConfigOverrides struct {
 	DatabaseLockingMode                     null.String
 	DefaultChainID                          *big.Int
 	DefaultHTTPTimeout                      *time.Duration
-	HTTPServerWriteTimeout                  *time.Duration
 	Dev                                     null.Bool
 	ShutdownGracePeriod                     *time.Duration
 	Dialect                                 dialects.DialectName
@@ -171,11 +170,6 @@ func (o *GeneralConfigOverrides) SetOCRObservationTimeout(d time.Duration) {
 // SetDefaultHTTPTimeout sets test override value for DefaultHTTPTimeout
 func (o *GeneralConfigOverrides) SetDefaultHTTPTimeout(d time.Duration) {
 	o.DefaultHTTPTimeout = &d
-}
-
-// SetHTTPServerWriteTimeout sets test override value for HTTPServerWriteTimeout
-func (o *GeneralConfigOverrides) SetHTTPServerWriteTimeout(d time.Duration) {
-	o.HTTPServerWriteTimeout = &d
 }
 
 // SetP2PV2DeltaDial sets test override value for P2PV2DeltaDial

--- a/core/internal/testutils/configtest/v2/general_config.go
+++ b/core/internal/testutils/configtest/v2/general_config.go
@@ -51,11 +51,10 @@ func overrides(c *chainlink.Config, s *chainlink.Secrets) {
 	c.WebServer.BridgeResponseURL = models.MustParseURL("http://localhost:6688")
 
 	chainID := utils.NewBigI(evmclient.NullClientChainID)
-	chain, _ := evmcfg.Defaults(chainID)
 	enabled := true
 	c.EVM = append(c.EVM, &evmcfg.EVMConfig{
 		ChainID: chainID,
-		Chain:   chain,
+		Chain:   evmcfg.DefaultsFrom(chainID, nil),
 		Enabled: &enabled,
 		Nodes:   evmcfg.EVMNodes{{}},
 	})

--- a/core/internal/testutils/configtest/v2/general_config.go
+++ b/core/internal/testutils/configtest/v2/general_config.go
@@ -16,11 +16,11 @@ import (
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
-// NewTestGeneralConfig returns a new config.GeneralConfig with default test overrides.
+// NewTestGeneralConfig returns a new config.GeneralConfig with default test overrides and one chain with evmclient.NullClientChainID.
 func NewTestGeneralConfig(t testing.TB) config.GeneralConfig { return NewGeneralConfig(t, nil) }
 
 // NewGeneralConfig returns a new config.GeneralConfig with overrides.
-// The default test overrides are applied before overrideFn.
+// The default test overrides are applied before overrideFn, and include one chain with evmclient.NullClientChainID.
 func NewGeneralConfig(t testing.TB, overrideFn func(*chainlink.Config, *chainlink.Secrets)) config.GeneralConfig {
 	tempDir := t.TempDir()
 	g, err := chainlink.GeneralConfigOpts{
@@ -36,6 +36,7 @@ func NewGeneralConfig(t testing.TB, overrideFn func(*chainlink.Config, *chainlin
 	return g
 }
 
+// overrides applies some test config settings and adds a default chain with evmclient.NullClientChainID.
 func overrides(c *chainlink.Config, s *chainlink.Secrets) {
 	c.DevMode = true
 	c.InsecureFastScrypt = ptr(true)

--- a/core/internal/testutils/evmtest/evmtest.go
+++ b/core/internal/testutils/evmtest/evmtest.go
@@ -42,10 +42,9 @@ func NewChainScopedConfig(t testing.TB, cfg config.GeneralConfig) evmconfig.Chai
 			evmCfg = cfgs.EVMConfigs()[0]
 		} else {
 			chainID := utils.NewBigI(0)
-			newChain, _ := v2.Defaults(chainID)
 			evmCfg = &v2.EVMConfig{
 				ChainID: chainID,
-				Chain:   newChain,
+				Chain:   v2.DefaultsFrom(chainID, nil),
 			}
 		}
 
@@ -310,6 +309,10 @@ func (mo *MockORM) NodesForChain(chainID utils.Big, offset int, limit int, qopts
 
 // NodesForChain implements evmtypes.ORM
 func (mo *MockORM) SetupNodes([]evmtypes.Node, []utils.Big) error {
+	panic("not implemented")
+}
+
+func (mo *MockORM) EnsureChains([]utils.Big, ...pg.QOpt) error {
 	panic("not implemented")
 }
 

--- a/core/internal/testutils/evmtest/v2/evmtest.go
+++ b/core/internal/testutils/evmtest/v2/evmtest.go
@@ -18,7 +18,6 @@ func ChainArbitrumRinkeby(t *testing.T) config.ChainScopedConfig { return scoped
 
 func scopedConfig(t *testing.T, chainID int64) config.ChainScopedConfig {
 	id := utils.NewBigI(chainID)
-	def, _ := v2.Defaults(id)
-	evmCfg := v2.EVMConfig{ChainID: id, Chain: def}
+	evmCfg := v2.EVMConfig{ChainID: id, Chain: v2.DefaultsFrom(id, nil)}
 	return v2.NewTOMLChainScopedConfig(configtest.NewTestGeneralConfig(t), &evmCfg, logger.TestLogger(t))
 }

--- a/core/services/chainlink/config.go
+++ b/core/services/chainlink/config.go
@@ -57,12 +57,9 @@ func (c *Config) setDefaults() {
 
 	for i := range c.EVM {
 		if input := c.EVM[i]; input == nil {
-			ch, _ := evmcfg.Defaults(nil)
-			c.EVM[i] = &evmcfg.EVMConfig{Chain: ch}
+			c.EVM[i] = &evmcfg.EVMConfig{Chain: evmcfg.DefaultsFrom(nil, nil)}
 		} else {
-			ch, _ := evmcfg.Defaults(input.ChainID)
-			ch.SetFrom(&input.Chain)
-			input.Chain = ch
+			input.Chain = evmcfg.DefaultsFrom(input.ChainID, &input.Chain)
 		}
 	}
 

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -16,6 +16,7 @@ import (
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink/core/bridges"
+	"github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
@@ -241,10 +242,12 @@ func TestORM_DeleteJob_DeletesAssociatedRecords(t *testing.T) {
 	require.NoError(t, keyStore.OCR().Add(cltest.DefaultOCRKey))
 	require.NoError(t, keyStore.P2P().Add(cltest.DefaultP2PKey))
 
-	pipelineORM := pipeline.NewORM(db, logger.TestLogger(t), config)
-	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: gcfg})
+	lggr := logger.TestLogger(t)
+	pipelineORM := pipeline.NewORM(db, lggr, config)
+	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: gcfg,
+		Client: client.NewNullClient(gcfg.DefaultChainID(), lggr)})
 	jobORM := job.NewTestORM(t, db, cc, pipelineORM, keyStore, config)
-	korm := keeper.NewORM(db, logger.TestLogger(t), nil, nil)
+	korm := keeper.NewORM(db, lggr, nil, nil)
 
 	t.Run("it deletes records for offchainreporting jobs", func(t *testing.T) {
 		_, bridge := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, config)

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -234,14 +234,15 @@ func TestORM(t *testing.T) {
 
 func TestORM_DeleteJob_DeletesAssociatedRecords(t *testing.T) {
 	t.Parallel()
-	config := evmtest.NewLegacyChainScopedConfig(t, cltest.NewTestGeneralConfig(t))
+	gcfg := cltest.NewTestGeneralConfigV2(t)
+	config := evmtest.NewChainScopedConfig(t, gcfg)
 	db := pgtest.NewSqlxDB(t)
 	keyStore := cltest.NewKeyStore(t, db, config)
 	require.NoError(t, keyStore.OCR().Add(cltest.DefaultOCRKey))
 	require.NoError(t, keyStore.P2P().Add(cltest.DefaultP2PKey))
 
 	pipelineORM := pipeline.NewORM(db, logger.TestLogger(t), config)
-	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: config})
+	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: gcfg})
 	jobORM := job.NewTestORM(t, db, cc, pipelineORM, keyStore, config)
 	korm := keeper.NewORM(db, logger.TestLogger(t), nil, nil)
 

--- a/core/services/pg/locked_db.go
+++ b/core/services/pg/locked_db.go
@@ -20,7 +20,7 @@ type LockedDB interface {
 }
 
 type lockedDb struct {
-	cfg          config.GeneralConfig
+	cfg          config.BasicConfig
 	lggr         logger.Logger
 	db           *sqlx.DB
 	leaseLock    LeaseLock
@@ -28,7 +28,7 @@ type lockedDb struct {
 }
 
 // NewLockedDB creates a new instance of LockedDB.
-func NewLockedDB(cfg config.GeneralConfig, lggr logger.Logger) LockedDB {
+func NewLockedDB(cfg config.BasicConfig, lggr logger.Logger) LockedDB {
 	return &lockedDb{
 		cfg:  cfg,
 		lggr: lggr.Named("LockedDB"),
@@ -38,7 +38,7 @@ func NewLockedDB(cfg config.GeneralConfig, lggr logger.Logger) LockedDB {
 // OpenUnlockedDB just opens DB connection, without any DB locks.
 // This should be used carefully, when we know we don't need any locks.
 // Currently this is used by RebroadcastTransactions command only.
-func OpenUnlockedDB(cfg config.GeneralConfig, lggr logger.Logger) (db *sqlx.DB, err error) {
+func OpenUnlockedDB(cfg config.BasicConfig, lggr logger.Logger) (db *sqlx.DB, err error) {
 	return openDB(cfg, lggr)
 }
 
@@ -123,7 +123,7 @@ func (l lockedDb) DB() *sqlx.DB {
 	return l.db
 }
 
-func openDB(cfg config.GeneralConfig, lggr logger.Logger) (db *sqlx.DB, err error) {
+func openDB(cfg config.BasicConfig, lggr logger.Logger) (db *sqlx.DB, err error) {
 	uri := cfg.DatabaseURL()
 	appid := cfg.AppID()
 	static.SetConsumerName(&uri, "App", &appid)

--- a/core/services/pg/locked_db.go
+++ b/core/services/pg/locked_db.go
@@ -2,14 +2,17 @@ package pg
 
 import (
 	"context"
+	"net/url"
+	"time"
 
 	"github.com/pkg/errors"
+	uuid "github.com/satori/go.uuid"
 
 	"github.com/smartcontractkit/sqlx"
 
-	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/static"
+	"github.com/smartcontractkit/chainlink/core/store/dialects"
 )
 
 // LockedDB bounds DB connection and DB locks.
@@ -19,8 +22,22 @@ type LockedDB interface {
 	DB() *sqlx.DB
 }
 
+type LockedDBConfig interface {
+	AdvisoryLockCheckInterval() time.Duration
+	AdvisoryLockID() int64
+	AppID() uuid.UUID
+	DatabaseLockingMode() string
+	DatabaseURL() url.URL
+	LeaseLockDuration() time.Duration
+	LeaseLockRefreshInterval() time.Duration
+	GetDatabaseDialectConfiguredOrDefault() dialects.DialectName
+	MigrateDatabase() bool
+	ORMMaxIdleConns() int
+	ORMMaxOpenConns() int
+}
+
 type lockedDb struct {
-	cfg          config.BasicConfig
+	cfg          LockedDBConfig
 	lggr         logger.Logger
 	db           *sqlx.DB
 	leaseLock    LeaseLock
@@ -28,7 +45,7 @@ type lockedDb struct {
 }
 
 // NewLockedDB creates a new instance of LockedDB.
-func NewLockedDB(cfg config.BasicConfig, lggr logger.Logger) LockedDB {
+func NewLockedDB(cfg LockedDBConfig, lggr logger.Logger) LockedDB {
 	return &lockedDb{
 		cfg:  cfg,
 		lggr: lggr.Named("LockedDB"),
@@ -38,7 +55,7 @@ func NewLockedDB(cfg config.BasicConfig, lggr logger.Logger) LockedDB {
 // OpenUnlockedDB just opens DB connection, without any DB locks.
 // This should be used carefully, when we know we don't need any locks.
 // Currently this is used by RebroadcastTransactions command only.
-func OpenUnlockedDB(cfg config.BasicConfig, lggr logger.Logger) (db *sqlx.DB, err error) {
+func OpenUnlockedDB(cfg LockedDBConfig, lggr logger.Logger) (db *sqlx.DB, err error) {
 	return openDB(cfg, lggr)
 }
 
@@ -123,7 +140,7 @@ func (l lockedDb) DB() *sqlx.DB {
 	return l.db
 }
 
-func openDB(cfg config.BasicConfig, lggr logger.Logger) (db *sqlx.DB, err error) {
+func openDB(cfg LockedDBConfig, lggr logger.Logger) (db *sqlx.DB, err error) {
 	uri := cfg.DatabaseURL()
 	appid := cfg.AppID()
 	static.SetConsumerName(&uri, "App", &appid)

--- a/core/web/evm_chains_controller_test.go
+++ b/core/web/evm_chains_controller_test.go
@@ -14,10 +14,15 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 
+	evmcfg "github.com/smartcontractkit/chainlink/core/chains/evm/config/v2"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/types"
+	corecfg "github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest2 "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/core/utils"
 	"github.com/smartcontractkit/chainlink/core/web"
 	"github.com/smartcontractkit/chainlink/core/web/presenters"
@@ -26,9 +31,9 @@ import (
 func Test_EVMChainsController_Create(t *testing.T) {
 	t.Parallel()
 
-	controller := setupEVMChainsControllerTest(t)
+	controller := setupEVMChainsControllerTestLegacy(t)
 
-	newChainId := *utils.NewBigI(42)
+	newChainId := utils.NewBig(testutils.NewRandomEVMChainID())
 
 	body, err := json.Marshal(web.NewCreateChainRequest(newChainId,
 		&types.ChainCfg{
@@ -44,7 +49,7 @@ func Test_EVMChainsController_Create(t *testing.T) {
 	require.Equal(t, http.StatusCreated, resp.StatusCode)
 
 	chainSet := controller.app.GetChains().EVM
-	dbChain, err := chainSet.ORM().Chain(newChainId)
+	dbChain, err := chainSet.ORM().Chain(*newChainId)
 	require.NoError(t, err)
 
 	resource := presenters.EVMChainResource{}
@@ -61,51 +66,44 @@ func Test_EVMChainsController_Create(t *testing.T) {
 func Test_EVMChainsController_Show(t *testing.T) {
 	t.Parallel()
 
-	validId := utils.NewBigI(12)
+	validId := utils.NewBig(testutils.NewRandomEVMChainID())
 
 	testCases := []struct {
 		name           string
 		inputId        string
 		wantStatusCode int
-		want           func(t *testing.T, app *cltest.TestApplication) *types.DBChain
+		want           *evmcfg.EVMConfig
 	}{
 		{
 			inputId: validId.String(),
 			name:    "success",
-			want: func(t *testing.T, app *cltest.TestApplication) *types.DBChain {
-				newChainConfig := types.ChainCfg{
-					BlockHistoryEstimatorBlockDelay:       null.IntFrom(23),
-					BlockHistoryEstimatorBlockHistorySize: null.IntFrom(50),
-					EvmEIP1559DynamicFees:                 null.BoolFrom(true),
-					MinIncomingConfirmations:              null.IntFrom(12),
-					LinkContractAddress:                   null.StringFrom(testutils.NewAddress().String()),
-				}
-
-				chain := types.DBChain{
-					ID:      *validId,
-					Enabled: true,
-					Cfg:     &newChainConfig,
-				}
-				evmtest.MustInsertChain(t, app.GetSqlxDB(), &chain)
-
-				return &chain
+			want: &evmcfg.EVMConfig{
+				ChainID: validId,
+				Enabled: ptr(true),
+				Chain: evmcfg.DefaultsFrom(nil, &evmcfg.Chain{
+					GasEstimator: &evmcfg.GasEstimator{
+						EIP1559DynamicFees: ptr(true),
+						BlockHistory: &evmcfg.BlockHistoryEstimator{
+							BlockHistorySize: ptr[uint16](50),
+						},
+					},
+					RPCBlockQueryDelay:       ptr[uint16](23),
+					MinIncomingConfirmations: ptr[uint32](12),
+					LinkContractAddress:      ptr(ethkey.EIP55AddressFromAddress(testutils.NewAddress())),
+				}),
 			},
 			wantStatusCode: http.StatusOK,
 		},
 		{
-			inputId: "invalidid",
-			name:    "invalid id",
-			want: func(t *testing.T, app *cltest.TestApplication) *types.DBChain {
-				return nil
-			},
+			inputId:        "invalidid",
+			name:           "invalid id",
+			want:           nil,
 			wantStatusCode: http.StatusUnprocessableEntity,
 		},
 		{
-			inputId: "234",
-			name:    "not found",
-			want: func(t *testing.T, app *cltest.TestApplication) *types.DBChain {
-				return nil
-			},
+			inputId:        "234",
+			name:           "not found",
+			want:           nil,
 			wantStatusCode: http.StatusBadRequest,
 		},
 	}
@@ -116,9 +114,14 @@ func Test_EVMChainsController_Show(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			controller := setupEVMChainsControllerTest(t)
+			controller := setupEVMChainsControllerTest(t, configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				cltest.TestOverrides(c, s)
+				if tc.want != nil {
+					c.EVM = evmcfg.EVMConfigs{tc.want}
+				}
+			}))
 
-			wantedResult := tc.want(t, controller.app)
+			wantedResult := tc.want
 			resp, cleanup := controller.client.Get(
 				fmt.Sprintf("/v2/chains/evm/%s", tc.inputId),
 			)
@@ -130,12 +133,12 @@ func Test_EVMChainsController_Show(t *testing.T) {
 				err := web.ParseJSONAPIResponse(cltest.ParseResponseBody(t, resp), &resource1)
 				require.NoError(t, err)
 
-				assert.Equal(t, resource1.ID, wantedResult.ID.String())
-				assert.Equal(t, resource1.Config.BlockHistoryEstimatorBlockDelay, wantedResult.Cfg.BlockHistoryEstimatorBlockDelay)
-				assert.Equal(t, resource1.Config.BlockHistoryEstimatorBlockHistorySize, wantedResult.Cfg.BlockHistoryEstimatorBlockHistorySize)
-				assert.Equal(t, resource1.Config.EvmEIP1559DynamicFees, wantedResult.Cfg.EvmEIP1559DynamicFees)
-				assert.Equal(t, resource1.Config.MinIncomingConfirmations, wantedResult.Cfg.MinIncomingConfirmations)
-				assert.Equal(t, resource1.Config.LinkContractAddress, wantedResult.Cfg.LinkContractAddress)
+				assert.Equal(t, resource1.ID, wantedResult.ChainID.String())
+				assert.Equal(t, resource1.Config.BlockHistoryEstimatorBlockDelay.Int64, int64(*wantedResult.Chain.RPCBlockQueryDelay))
+				assert.Equal(t, resource1.Config.BlockHistoryEstimatorBlockHistorySize.Int64, int64(*wantedResult.Chain.GasEstimator.BlockHistory.BlockHistorySize))
+				assert.Equal(t, resource1.Config.EvmEIP1559DynamicFees.Bool, *wantedResult.Chain.GasEstimator.EIP1559DynamicFees)
+				assert.Equal(t, resource1.Config.MinIncomingConfirmations.Int64, int64(*wantedResult.Chain.MinIncomingConfirmations))
+				assert.Equal(t, resource1.Config.LinkContractAddress.String, wantedResult.Chain.LinkContractAddress.String())
 			}
 		})
 	}
@@ -144,37 +147,40 @@ func Test_EVMChainsController_Show(t *testing.T) {
 func Test_EVMChainsController_Index(t *testing.T) {
 	t.Parallel()
 
-	controller := setupEVMChainsControllerTest(t)
-
-	newChains := []web.CreateChainRequest[utils.Big, *types.ChainCfg]{
+	newChains := evmcfg.EVMConfigs{
+		{ChainID: utils.NewBig(testutils.NewRandomEVMChainID()), Chain: evmcfg.DefaultsFrom(nil, nil)},
 		{
-			ID: *utils.NewBigI(24),
-			Config: &types.ChainCfg{
-				BlockHistoryEstimatorBlockDelay:       null.IntFrom(13),
-				BlockHistoryEstimatorBlockHistorySize: null.IntFrom(1),
-				EvmEIP1559DynamicFees:                 null.BoolFrom(true),
-				MinIncomingConfirmations:              null.IntFrom(120),
-			},
+			ChainID: utils.NewBig(testutils.NewRandomEVMChainID()),
+			Chain: evmcfg.DefaultsFrom(nil, &evmcfg.Chain{
+				RPCBlockQueryDelay: ptr[uint16](13),
+				GasEstimator: &evmcfg.GasEstimator{
+					EIP1559DynamicFees: ptr(true),
+					BlockHistory: &evmcfg.BlockHistoryEstimator{
+						BlockHistorySize: ptr[uint16](1),
+					},
+				},
+				MinIncomingConfirmations: ptr[uint32](120),
+			}),
 		},
 		{
-			ID: *utils.NewBigI(30),
-			Config: &types.ChainCfg{
-				BlockHistoryEstimatorBlockDelay:       null.IntFrom(5),
-				BlockHistoryEstimatorBlockHistorySize: null.IntFrom(2),
-				EvmEIP1559DynamicFees:                 null.BoolFrom(false),
-				MinIncomingConfirmations:              null.IntFrom(30),
-			},
+			ChainID: utils.NewBig(testutils.NewRandomEVMChainID()),
+			Chain: evmcfg.DefaultsFrom(nil, &evmcfg.Chain{
+				RPCBlockQueryDelay: ptr[uint16](5),
+				GasEstimator: &evmcfg.GasEstimator{
+					EIP1559DynamicFees: ptr(false),
+					BlockHistory: &evmcfg.BlockHistoryEstimator{
+						BlockHistorySize: ptr[uint16](2),
+					},
+				},
+				MinIncomingConfirmations: ptr[uint32](30),
+			}),
 		},
 	}
 
-	for _, newChain := range newChains {
-		ch := newChain
-		evmtest.MustInsertChain(t, controller.app.GetSqlxDB(), &types.DBChain{
-			ID:      ch.ID,
-			Enabled: true,
-			Cfg:     ch.Config,
-		})
-	}
+	controller := setupEVMChainsControllerTest(t, configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		cltest.TestOverrides(c, s)
+		c.EVM = append(c.EVM, newChains...)
+	}))
 
 	badResp, cleanup := controller.client.Get("/v2/chains/evm?size=asd")
 	t.Cleanup(cleanup)
@@ -188,8 +194,7 @@ func Test_EVMChainsController_Index(t *testing.T) {
 
 	metaCount, err := cltest.ParseJSONAPIResponseMetaCount(body)
 	require.NoError(t, err)
-	// fixtures.sql specifies two chains by default
-	require.Equal(t, 2+len(newChains), metaCount)
+	require.Equal(t, 1+len(newChains), metaCount)
 
 	var links jsonapi.Links
 
@@ -200,11 +205,11 @@ func Test_EVMChainsController_Index(t *testing.T) {
 	assert.Empty(t, links["prev"].Href)
 
 	assert.Len(t, links, 1)
-	assert.Equal(t, newChains[0].ID.String(), chains[2].ID)
-	assert.Equal(t, newChains[0].Config.BlockHistoryEstimatorBlockDelay, chains[2].Config.BlockHistoryEstimatorBlockDelay)
-	assert.Equal(t, newChains[0].Config.BlockHistoryEstimatorBlockHistorySize, chains[2].Config.BlockHistoryEstimatorBlockHistorySize)
-	assert.Equal(t, newChains[0].Config.EvmEIP1559DynamicFees, chains[2].Config.EvmEIP1559DynamicFees)
-	assert.Equal(t, newChains[0].Config.MinIncomingConfirmations, chains[2].Config.MinIncomingConfirmations)
+	assert.Equal(t, newChains[1].ChainID.String(), chains[2].ID)
+	assert.Equal(t, int64(*newChains[1].Chain.RPCBlockQueryDelay), chains[2].Config.BlockHistoryEstimatorBlockDelay.Int64)
+	assert.Equal(t, int64(*newChains[1].Chain.GasEstimator.BlockHistory.BlockHistorySize), chains[2].Config.BlockHistoryEstimatorBlockHistorySize.Int64)
+	assert.Equal(t, *newChains[1].Chain.GasEstimator.EIP1559DynamicFees, chains[2].Config.EvmEIP1559DynamicFees.Bool)
+	assert.Equal(t, int64(*newChains[1].Chain.MinIncomingConfirmations), chains[2].Config.MinIncomingConfirmations.Int64)
 
 	resp, cleanup = controller.client.Get(links["next"].Href)
 	t.Cleanup(cleanup)
@@ -217,11 +222,11 @@ func Test_EVMChainsController_Index(t *testing.T) {
 	assert.NotEmpty(t, links["prev"].Href)
 
 	assert.Len(t, links, 1)
-	assert.Equal(t, newChains[1].ID.String(), chains[0].ID)
-	assert.Equal(t, newChains[1].Config.BlockHistoryEstimatorBlockDelay, chains[0].Config.BlockHistoryEstimatorBlockDelay)
-	assert.Equal(t, newChains[1].Config.BlockHistoryEstimatorBlockHistorySize, chains[0].Config.BlockHistoryEstimatorBlockHistorySize)
-	assert.Equal(t, newChains[1].Config.EvmEIP1559DynamicFees, chains[0].Config.EvmEIP1559DynamicFees)
-	assert.Equal(t, newChains[1].Config.MinIncomingConfirmations, chains[0].Config.MinIncomingConfirmations)
+	assert.Equal(t, newChains[2].ChainID.String(), chains[0].ID)
+	assert.Equal(t, int64(*newChains[2].Chain.RPCBlockQueryDelay), chains[0].Config.BlockHistoryEstimatorBlockDelay.Int64)
+	assert.Equal(t, int64(*newChains[2].Chain.GasEstimator.BlockHistory.BlockHistorySize), chains[0].Config.BlockHistoryEstimatorBlockHistorySize.Int64)
+	assert.Equal(t, *newChains[2].Chain.GasEstimator.EIP1559DynamicFees, chains[0].Config.EvmEIP1559DynamicFees.Bool)
+	assert.Equal(t, int64(*newChains[2].Chain.MinIncomingConfirmations), chains[0].Config.MinIncomingConfirmations.Int64)
 }
 
 func Test_EVMChainsController_Update(t *testing.T) {
@@ -238,7 +243,7 @@ func Test_EVMChainsController_Update(t *testing.T) {
 		},
 	}
 
-	validId := utils.NewBigI(12)
+	validId := utils.NewBig(testutils.NewRandomEVMChainID())
 
 	testCases := []struct {
 		name              string
@@ -292,7 +297,7 @@ func Test_EVMChainsController_Update(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			controller := setupEVMChainsControllerTest(t)
+			controller := setupEVMChainsControllerTestLegacy(t)
 
 			beforeUpdate := tc.chainBeforeUpdate(t, controller.app)
 
@@ -326,7 +331,7 @@ func Test_EVMChainsController_Update(t *testing.T) {
 func Test_EVMChainsController_Delete(t *testing.T) {
 	t.Parallel()
 
-	controller := setupEVMChainsControllerTest(t)
+	controller := setupEVMChainsControllerTestLegacy(t)
 
 	newChainConfig := types.ChainCfg{
 		BlockHistoryEstimatorBlockDelay:       null.IntFrom(5),
@@ -335,7 +340,7 @@ func Test_EVMChainsController_Delete(t *testing.T) {
 		MinIncomingConfirmations:              null.IntFrom(30),
 	}
 
-	chainId := *utils.NewBigI(50)
+	chainId := *utils.NewBig(testutils.NewRandomEVMChainID())
 	chain := types.DBChain{
 		ID:      chainId,
 		Enabled: true,
@@ -391,10 +396,10 @@ type TestEVMChainsController struct {
 	client cltest.HTTPClientCleaner
 }
 
-func setupEVMChainsControllerTest(t *testing.T) *TestEVMChainsController {
+func setupEVMChainsControllerTest(t *testing.T, cfg corecfg.GeneralConfig) *TestEVMChainsController {
 	// Using this instead of `NewApplicationEVMDisabled` since we need the chain set to be loaded in the app
 	// for the sake of the API endpoints to work properly
-	app := cltest.NewApplication(t)
+	app := cltest.NewApplicationWithConfig(t, cfg)
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	client := app.NewHTTPClient(cltest.APIEmailAdmin)
@@ -404,3 +409,20 @@ func setupEVMChainsControllerTest(t *testing.T) *TestEVMChainsController {
 		client: client,
 	}
 }
+
+// setupEVMChainsControllerTestLegacy exists to support legacy-only tests until it is removed.
+func setupEVMChainsControllerTestLegacy(t *testing.T) *TestEVMChainsController {
+	// Using this instead of `NewApplicationEVMDisabled` since we need the chain set to be loaded in the app
+	// for the sake of the API endpoints to work properly
+	app := cltest.NewLegacyApplication(t)
+	require.NoError(t, app.Start(testutils.Context(t)))
+
+	client := app.NewHTTPClient(cltest.APIEmailAdmin)
+
+	return &TestEVMChainsController{
+		app:    app,
+		client: client,
+	}
+}
+
+func ptr[T any](t T) *T { return &t }

--- a/core/web/evm_forwarders_controller_test.go
+++ b/core/web/evm_forwarders_controller_test.go
@@ -11,8 +11,11 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	evmcfg "github.com/smartcontractkit/chainlink/core/chains/evm/config/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest2 "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/utils"
 	"github.com/smartcontractkit/chainlink/core/web"
 	"github.com/smartcontractkit/chainlink/core/web/presenters"
@@ -23,10 +26,13 @@ type TestEVMForwardersController struct {
 	client cltest.HTTPClientCleaner
 }
 
-func setupEVMForwardersControllerTest(t *testing.T) *TestEVMForwardersController {
+func setupEVMForwardersControllerTest(t *testing.T, overrideFn func(c *chainlink.Config, s *chainlink.Secrets)) *TestEVMForwardersController {
 	// Using this instead of `NewApplicationEVMDisabled` since we need the chain set to be loaded in the app
 	// for the sake of the API endpoints to work properly
-	app := cltest.NewApplication(t)
+	app := cltest.NewApplicationWithConfig(t, configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		cltest.TestOverrides(c, s)
+		overrideFn(c, s)
+	}))
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	client := app.NewHTTPClient(cltest.APIEmailAdmin)
@@ -40,18 +46,17 @@ func setupEVMForwardersControllerTest(t *testing.T) *TestEVMForwardersController
 func Test_EVMForwardersController_Track(t *testing.T) {
 	t.Parallel()
 
-	controller := setupEVMForwardersControllerTest(t)
-
-	// Setting up chain
-	chainId := testutils.NewRandomEVMChainID()
-	chainSet := controller.app.GetChains().EVM
-	dbChain, err := chainSet.ORM().CreateChain(utils.Big(*chainId), nil)
-	require.NoError(t, err)
+	chainId := utils.NewBig(testutils.NewRandomEVMChainID())
+	controller := setupEVMForwardersControllerTest(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM = evmcfg.EVMConfigs{
+			{ChainID: chainId, Enabled: ptr(true), Chain: evmcfg.DefaultsFrom(chainId, nil)},
+		}
+	})
 
 	// Build EVMForwarderRequest
 	address := common.HexToAddress("0x5431F5F973781809D18643b87B44921b11355d81")
 	body, err := json.Marshal(web.TrackEVMForwarderRequest{
-		EVMChainID: &dbChain.ID,
+		EVMChainID: chainId,
 		Address:    address,
 	},
 	)
@@ -71,29 +76,28 @@ func Test_EVMForwardersController_Track(t *testing.T) {
 func Test_EVMForwardersController_Index(t *testing.T) {
 	t.Parallel()
 
-	controller := setupEVMForwardersControllerTest(t)
-
-	// Setting up chain
-	chainId := testutils.NewRandomEVMChainID()
-	chainSet := controller.app.GetChains().EVM
-	dbChain, err := chainSet.ORM().CreateChain(utils.Big(*chainId), nil)
-	require.NoError(t, err)
+	chainId := utils.NewBig(testutils.NewRandomEVMChainID())
+	controller := setupEVMForwardersControllerTest(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM = evmcfg.EVMConfigs{
+			{ChainID: chainId, Enabled: ptr(true), Chain: evmcfg.DefaultsFrom(chainId, nil)},
+		}
+	})
 
 	// Build EVMForwarderRequest
 	fwdrs := []web.TrackEVMForwarderRequest{
 		{
-			EVMChainID: &dbChain.ID,
+			EVMChainID: chainId,
 			Address:    common.HexToAddress("0x5431F5F973781809D18643b87B44921b11355d81"),
 		},
 		{
-			EVMChainID: &dbChain.ID,
+			EVMChainID: chainId,
 			Address:    common.HexToAddress("0x5431F5F973781809D18643b87B44921b11355d82"),
 		},
 	}
 	for _, fwdr := range fwdrs {
 
 		body, err := json.Marshal(web.TrackEVMForwarderRequest{
-			EVMChainID: &dbChain.ID,
+			EVMChainID: chainId,
 			Address:    fwdr.Address,
 		},
 		)

--- a/core/web/features_controller_test.go
+++ b/core/web/features_controller_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest2 "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/web"
 	"github.com/smartcontractkit/chainlink/core/web/presenters"
 
@@ -14,7 +16,13 @@ import (
 )
 
 func Test_FeaturesController_List(t *testing.T) {
-	_, client := setupFeaturesControllerTest(t)
+	app := cltest.NewApplicationWithConfig(t, configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		cltest.TestOverrides(c, s)
+		csa := true
+		c.Feature.UICSAKeys = &csa
+	}))
+	require.NoError(t, app.Start(testutils.Context(t)))
+	client := app.NewHTTPClient(cltest.APIEmailAdmin)
 
 	resp, cleanup := client.Get("/v2/features")
 	t.Cleanup(cleanup)
@@ -30,14 +38,4 @@ func Test_FeaturesController_List(t *testing.T) {
 
 	assert.Equal(t, "feeds_manager", resources[1].ID)
 	assert.False(t, resources[1].Enabled)
-}
-
-func setupFeaturesControllerTest(t *testing.T) (*cltest.TestApplication, cltest.HTTPClientCleaner) {
-	t.Setenv("FEATURE_UI_CSA_KEYS", "true")
-
-	app := cltest.NewApplication(t)
-	require.NoError(t, app.Start(testutils.Context(t)))
-	client := app.NewHTTPClient(cltest.APIEmailAdmin)
-
-	return app, client
 }

--- a/core/web/resolver/features.go
+++ b/core/web/resolver/features.go
@@ -3,10 +3,10 @@ package resolver
 import "github.com/smartcontractkit/chainlink/core/config"
 
 type FeaturesResolver struct {
-	cfg config.GeneralConfig
+	cfg config.FeatureFlags
 }
 
-func NewFeaturesResolver(cfg config.GeneralConfig) *FeaturesResolver {
+func NewFeaturesResolver(cfg config.FeatureFlags) *FeaturesResolver {
 	return &FeaturesResolver{cfg: cfg}
 }
 
@@ -21,10 +21,10 @@ func (r *FeaturesResolver) FeedsManager() bool {
 }
 
 type FeaturesPayloadResolver struct {
-	cfg config.GeneralConfig
+	cfg config.FeatureFlags
 }
 
-func NewFeaturesPayloadResolver(cfg config.GeneralConfig) *FeaturesPayloadResolver {
+func NewFeaturesPayloadResolver(cfg config.FeatureFlags) *FeaturesPayloadResolver {
 	return &FeaturesPayloadResolver{cfg: cfg}
 }
 

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -443,7 +443,7 @@ var indexRateLimitPeriod = 1 * time.Minute
 
 // guiAssetRoutes serves the operator UI static files and index.html. Rate
 // limiting is disabled when in dev mode.
-func guiAssetRoutes(engine *gin.Engine, config config.GeneralConfig, lggr logger.Logger) {
+func guiAssetRoutes(engine *gin.Engine, config config.BasicConfig, lggr logger.Logger) {
 	// Serve static files
 	var assetsRouterHandlers []gin.HandlerFunc
 	if !config.Dev() {

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -30,7 +30,6 @@ import (
 	"github.com/ulule/limiter/drivers/store/memory"
 	"github.com/unrolled/secure"
 
-	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/web/auth"
@@ -80,7 +79,7 @@ func Router(app chainlink.Application, prometheus *ginprom.Prometheus) *gin.Engi
 	sessionRoutes(app, api)
 	v2Routes(app, api)
 
-	guiAssetRoutes(engine, config, app.GetLogger())
+	guiAssetRoutes(engine, config.Dev(), app.GetLogger())
 
 	api.POST("/query",
 		auth.AuthenticateGQL(app.SessionORM(), app.GetLogger().Named("GQLHandler")),
@@ -443,10 +442,10 @@ var indexRateLimitPeriod = 1 * time.Minute
 
 // guiAssetRoutes serves the operator UI static files and index.html. Rate
 // limiting is disabled when in dev mode.
-func guiAssetRoutes(engine *gin.Engine, config config.BasicConfig, lggr logger.Logger) {
+func guiAssetRoutes(engine *gin.Engine, devMode bool, lggr logger.Logger) {
 	// Serve static files
 	var assetsRouterHandlers []gin.HandlerFunc
-	if !config.Dev() {
+	if !devMode {
 		assetsRouterHandlers = append(assetsRouterHandlers, rateLimiter(
 			staticAssetsRateLimitPeriod,
 			staticAssetsRateLimit,
@@ -466,7 +465,7 @@ func guiAssetRoutes(engine *gin.Engine, config config.BasicConfig, lggr logger.L
 
 	// Serve the index HTML file unless it is an api path
 	var noRouteHandlers []gin.HandlerFunc
-	if !config.Dev() {
+	if !devMode {
 		noRouteHandlers = append(noRouteHandlers, rateLimiter(
 			indexRateLimitPeriod,
 			indexRateLimit,


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/46224/convert-replace-uses-of-testgeneralconfig-generalconfigoverrides-to-new-config-types

Convert some tests to new config, and decouple some interface types. One of these tests revealed the need to maintain some legacy DB state when using new config, in order for foreign keys to continue to function properly, so this also updates the startup logic to ensure that any used chains exist.