### PR TITLE
fix deprecated ocr field bug

### DIFF
--- a/core/chains/evm/config/mocks/chain_scoped_config.go
+++ b/core/chains/evm/config/mocks/chain_scoped_config.go
@@ -2208,20 +2208,6 @@ func (_m *ChainScopedConfig) OCRBlockchainTimeout() time.Duration {
 	return r0
 }
 
-// OCRBootstrapCheckInterval provides a mock function with given fields:
-func (_m *ChainScopedConfig) OCRBootstrapCheckInterval() time.Duration {
-	ret := _m.Called()
-
-	var r0 time.Duration
-	if rf, ok := ret.Get(0).(func() time.Duration); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(time.Duration)
-	}
-
-	return r0
-}
-
 // OCRContractConfirmations provides a mock function with given fields:
 func (_m *ChainScopedConfig) OCRContractConfirmations() uint16 {
 	ret := _m.Called()
@@ -2278,20 +2264,6 @@ func (_m *ChainScopedConfig) OCRContractTransmitterTransmitTimeout() time.Durati
 	return r0
 }
 
-// OCRDHTLookupInterval provides a mock function with given fields:
-func (_m *ChainScopedConfig) OCRDHTLookupInterval() int {
-	ret := _m.Called()
-
-	var r0 int
-	if rf, ok := ret.Get(0).(func() int); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-
-	return r0
-}
-
 // OCRDatabaseTimeout provides a mock function with given fields:
 func (_m *ChainScopedConfig) OCRDatabaseTimeout() time.Duration {
 	ret := _m.Called()
@@ -2320,20 +2292,6 @@ func (_m *ChainScopedConfig) OCRDefaultTransactionQueueDepth() uint32 {
 	return r0
 }
 
-// OCRIncomingMessageBufferSize provides a mock function with given fields:
-func (_m *ChainScopedConfig) OCRIncomingMessageBufferSize() int {
-	ret := _m.Called()
-
-	var r0 int
-	if rf, ok := ret.Get(0).(func() int); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-
-	return r0
-}
-
 // OCRKeyBundleID provides a mock function with given fields:
 func (_m *ChainScopedConfig) OCRKeyBundleID() (string, error) {
 	ret := _m.Called()
@@ -2353,20 +2311,6 @@ func (_m *ChainScopedConfig) OCRKeyBundleID() (string, error) {
 	}
 
 	return r0, r1
-}
-
-// OCRNewStreamTimeout provides a mock function with given fields:
-func (_m *ChainScopedConfig) OCRNewStreamTimeout() time.Duration {
-	ret := _m.Called()
-
-	var r0 time.Duration
-	if rf, ok := ret.Get(0).(func() time.Duration); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(time.Duration)
-	}
-
-	return r0
 }
 
 // OCRObservationGracePeriod provides a mock function with given fields:
@@ -2392,20 +2336,6 @@ func (_m *ChainScopedConfig) OCRObservationTimeout() time.Duration {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(time.Duration)
-	}
-
-	return r0
-}
-
-// OCROutgoingMessageBufferSize provides a mock function with given fields:
-func (_m *ChainScopedConfig) OCROutgoingMessageBufferSize() int {
-	ret := _m.Called()
-
-	var r0 int
-	if rf, ok := ret.Get(0).(func() int); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int)
 	}
 
 	return r0

--- a/core/config/envvar/schema.go
+++ b/core/config/envvar/schema.go
@@ -268,11 +268,11 @@ type ConfigSchema struct {
 	P2PV2DeltaReconcile    models.Duration `env:"P2PV2_DELTA_RECONCILE" default:"1m"` //nodoc
 	P2PV2ListenAddresses   []string        `env:"P2PV2_LISTEN_ADDRESSES"`
 	// DEPRECATED
-	OCROutgoingMessageBufferSize int           `env:"OCR_OUTGOING_MESSAGE_BUFFER_SIZE" default:"10"` //nodoc
-	OCRIncomingMessageBufferSize int           `env:"OCR_INCOMING_MESSAGE_BUFFER_SIZE" default:"10"` //nodoc
-	OCRDHTLookupInterval         int           `env:"OCR_DHT_LOOKUP_INTERVAL" default:"10"`          //nodoc
-	OCRBootstrapCheckInterval    time.Duration `env:"OCR_BOOTSTRAP_CHECK_INTERVAL" default:"20s"`    //nodoc
-	OCRNewStreamTimeout          time.Duration `env:"OCR_NEW_STREAM_TIMEOUT" default:"10s"`          //nodoc
+	OCROutgoingMessageBufferSize int           `env:"OCR_OUTGOING_MESSAGE_BUFFER_SIZE"` //nodoc
+	OCRIncomingMessageBufferSize int           `env:"OCR_INCOMING_MESSAGE_BUFFER_SIZE"` //nodoc
+	OCRDHTLookupInterval         int           `env:"OCR_DHT_LOOKUP_INTERVAL"`          //nodoc
+	OCRBootstrapCheckInterval    time.Duration `env:"OCR_BOOTSTRAP_CHECK_INTERVAL"`     //nodoc
+	OCRNewStreamTimeout          time.Duration `env:"OCR_NEW_STREAM_TIMEOUT"`           //nodoc
 
 	// Keeper
 	KeeperCheckUpkeepGasPriceFeatureEnabled bool          `env:"KEEPER_CHECK_UPKEEP_GAS_PRICE_FEATURE_ENABLED" default:"false"` //nodoc

--- a/core/config/general_config.go
+++ b/core/config/general_config.go
@@ -391,19 +391,19 @@ EVM_ENABLED=false
 		return errors.Errorf("It is not permitted to set both ETH_URL (got %s) and EVM_NODES (got %s). Please set either one or the other", c.EthereumURL(), c.EthereumNodes())
 	}
 	// Warn on legacy OCR env vars
-	if c.OCRDHTLookupInterval() != 0 {
+	if c.ocrDHTLookupInterval() != 0 {
 		c.lggr.Error("OCR_DHT_LOOKUP_INTERVAL is deprecated, use P2P_DHT_LOOKUP_INTERVAL instead")
 	}
-	if c.OCRBootstrapCheckInterval() != 0 {
+	if c.ocrBootstrapCheckInterval() != 0 {
 		c.lggr.Error("OCR_BOOTSTRAP_CHECK_INTERVAL is deprecated, use P2P_BOOTSTRAP_CHECK_INTERVAL instead")
 	}
-	if c.OCRIncomingMessageBufferSize() != 0 {
+	if c.ocrIncomingMessageBufferSize() != 0 {
 		c.lggr.Error("OCR_INCOMING_MESSAGE_BUFFER_SIZE is deprecated, use P2P_INCOMING_MESSAGE_BUFFER_SIZE instead")
 	}
-	if c.OCROutgoingMessageBufferSize() != 0 {
+	if c.ocrOutgoingMessageBufferSize() != 0 {
 		c.lggr.Error("OCR_OUTGOING_MESSAGE_BUFFER_SIZE is deprecated, use P2P_OUTGOING_MESSAGE_BUFFER_SIZE instead")
 	}
-	if c.OCRNewStreamTimeout() != 0 {
+	if c.ocrNewStreamTimeout() != 0 {
 		c.lggr.Error("OCR_NEW_STREAM_TIMEOUT is deprecated, use P2P_NEW_STREAM_TIMEOUT instead")
 	}
 

--- a/core/config/mocks/general_config.go
+++ b/core/config/mocks/general_config.go
@@ -2626,20 +2626,6 @@ func (_m *GeneralConfig) OCRBlockchainTimeout() time.Duration {
 	return r0
 }
 
-// OCRBootstrapCheckInterval provides a mock function with given fields:
-func (_m *GeneralConfig) OCRBootstrapCheckInterval() time.Duration {
-	ret := _m.Called()
-
-	var r0 time.Duration
-	if rf, ok := ret.Get(0).(func() time.Duration); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(time.Duration)
-	}
-
-	return r0
-}
-
 // OCRContractPollInterval provides a mock function with given fields:
 func (_m *GeneralConfig) OCRContractPollInterval() time.Duration {
 	ret := _m.Called()
@@ -2668,20 +2654,6 @@ func (_m *GeneralConfig) OCRContractSubscribeInterval() time.Duration {
 	return r0
 }
 
-// OCRDHTLookupInterval provides a mock function with given fields:
-func (_m *GeneralConfig) OCRDHTLookupInterval() int {
-	ret := _m.Called()
-
-	var r0 int
-	if rf, ok := ret.Get(0).(func() int); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int)
-	}
-
-	return r0
-}
-
 // OCRDefaultTransactionQueueDepth provides a mock function with given fields:
 func (_m *GeneralConfig) OCRDefaultTransactionQueueDepth() uint32 {
 	ret := _m.Called()
@@ -2691,20 +2663,6 @@ func (_m *GeneralConfig) OCRDefaultTransactionQueueDepth() uint32 {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(uint32)
-	}
-
-	return r0
-}
-
-// OCRIncomingMessageBufferSize provides a mock function with given fields:
-func (_m *GeneralConfig) OCRIncomingMessageBufferSize() int {
-	ret := _m.Called()
-
-	var r0 int
-	if rf, ok := ret.Get(0).(func() int); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int)
 	}
 
 	return r0
@@ -2731,20 +2689,6 @@ func (_m *GeneralConfig) OCRKeyBundleID() (string, error) {
 	return r0, r1
 }
 
-// OCRNewStreamTimeout provides a mock function with given fields:
-func (_m *GeneralConfig) OCRNewStreamTimeout() time.Duration {
-	ret := _m.Called()
-
-	var r0 time.Duration
-	if rf, ok := ret.Get(0).(func() time.Duration); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(time.Duration)
-	}
-
-	return r0
-}
-
 // OCRObservationTimeout provides a mock function with given fields:
 func (_m *GeneralConfig) OCRObservationTimeout() time.Duration {
 	ret := _m.Called()
@@ -2754,20 +2698,6 @@ func (_m *GeneralConfig) OCRObservationTimeout() time.Duration {
 		r0 = rf()
 	} else {
 		r0 = ret.Get(0).(time.Duration)
-	}
-
-	return r0
-}
-
-// OCROutgoingMessageBufferSize provides a mock function with given fields:
-func (_m *GeneralConfig) OCROutgoingMessageBufferSize() int {
-	ret := _m.Called()
-
-	var r0 int
-	if rf, ok := ret.Get(0).(func() int); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(int)
 	}
 
 	return r0

--- a/core/config/p2p_config.go
+++ b/core/config/p2p_config.go
@@ -19,7 +19,6 @@ type P2PNetworking interface {
 	P2PPeerIDRaw() string
 	P2PIncomingMessageBufferSize() int
 	P2POutgoingMessageBufferSize() int
-	P2PDeprecated
 }
 
 // P2PNetworkingStack returns the preferred networking stack for libocr
@@ -57,50 +56,50 @@ func (c *generalConfig) P2PPeerIDRaw() string {
 }
 
 func (c *generalConfig) P2PIncomingMessageBufferSize() int {
-	if c.OCRIncomingMessageBufferSize() != 0 {
-		return c.OCRIncomingMessageBufferSize()
+	if c.ocrIncomingMessageBufferSize() != 0 {
+		return c.ocrIncomingMessageBufferSize()
 	}
 	return int(getEnvWithFallback(c, envvar.NewUint16("P2PIncomingMessageBufferSize")))
 }
 
 func (c *generalConfig) P2POutgoingMessageBufferSize() int {
-	if c.OCROutgoingMessageBufferSize() != 0 {
-		return c.OCROutgoingMessageBufferSize()
+	if c.ocrOutgoingMessageBufferSize() != 0 {
+		return c.ocrOutgoingMessageBufferSize()
 	}
 	return int(getEnvWithFallback(c, envvar.NewUint16("P2POutgoingMessageBufferSize")))
 }
 
 type P2PDeprecated interface {
 	// DEPRECATED - HERE FOR BACKWARDS COMPATIBILITY
-	OCRNewStreamTimeout() time.Duration
-	OCRBootstrapCheckInterval() time.Duration
-	OCRDHTLookupInterval() int
-	OCRIncomingMessageBufferSize() int
-	OCROutgoingMessageBufferSize() int
+	ocrNewStreamTimeout() time.Duration
+	ocrBootstrapCheckInterval() time.Duration
+	ocrDHTLookupInterval() int
+	ocrIncomingMessageBufferSize() int
+	ocrOutgoingMessageBufferSize() int
 }
 
 // DEPRECATED, do not use defaults, use only if specified and the
 // newer env vars is not
-func (c *generalConfig) OCRBootstrapCheckInterval() time.Duration {
-	return getEnvWithFallback(c, envvar.NewDuration("OCRBootstrapCheckInterval"))
+func (c *generalConfig) ocrBootstrapCheckInterval() time.Duration {
+	return c.viper.GetDuration("OCRBootstrapCheckInterval")
 }
 
 // DEPRECATED
-func (c *generalConfig) OCRDHTLookupInterval() int {
-	return int(getEnvWithFallback(c, envvar.NewInt64("OCRDHTLookupInterval")))
+func (c *generalConfig) ocrDHTLookupInterval() int {
+	return c.viper.GetInt("OCRDHTLookupInterval")
 }
 
 // DEPRECATED
-func (c *generalConfig) OCRNewStreamTimeout() time.Duration {
-	return getEnvWithFallback(c, envvar.NewDuration("OCRNewStreamTimeout"))
+func (c *generalConfig) ocrNewStreamTimeout() time.Duration {
+	return c.viper.GetDuration("OCRNewStreamTimeout")
 }
 
 // DEPRECATED
-func (c *generalConfig) OCRIncomingMessageBufferSize() int {
-	return int(getEnvWithFallback(c, envvar.NewInt64("OCRIncomingMessageBufferSize")))
+func (c *generalConfig) ocrIncomingMessageBufferSize() int {
+	return c.viper.GetInt("OCRIncomingMessageBufferSize")
 }
 
 // DEPRECATED
-func (c *generalConfig) OCROutgoingMessageBufferSize() int {
-	return int(getEnvWithFallback(c, envvar.NewInt64("OCROutgoingMessageBufferSize")))
+func (c *generalConfig) ocrOutgoingMessageBufferSize() int {
+	return c.viper.GetInt("OCROutgoingMessageBufferSize")
 }

--- a/core/config/p2p_v1_config.go
+++ b/core/config/p2p_v1_config.go
@@ -118,22 +118,22 @@ func (c *generalConfig) P2PDHTAnnouncementCounterUserPrefix() uint32 {
 
 // FIXME: Add comments to all of these
 func (c *generalConfig) P2PBootstrapCheckInterval() time.Duration {
-	if c.OCRBootstrapCheckInterval() != 0 {
-		return c.OCRBootstrapCheckInterval()
+	if c.ocrBootstrapCheckInterval() != 0 {
+		return c.ocrBootstrapCheckInterval()
 	}
 	return c.getWithFallback("P2PBootstrapCheckInterval", parse.Duration).(time.Duration)
 }
 
 func (c *generalConfig) P2PDHTLookupInterval() int {
-	if c.OCRDHTLookupInterval() != 0 {
-		return c.OCRDHTLookupInterval()
+	if c.ocrDHTLookupInterval() != 0 {
+		return c.ocrDHTLookupInterval()
 	}
 	return int(getEnvWithFallback(c, envvar.NewUint16("P2PDHTLookupInterval")))
 }
 
 func (c *generalConfig) P2PNewStreamTimeout() time.Duration {
-	if c.OCRNewStreamTimeout() != 0 {
-		return c.OCRNewStreamTimeout()
+	if c.ocrNewStreamTimeout() != 0 {
+		return c.ocrNewStreamTimeout()
 	}
 	return c.getWithFallback("P2PNewStreamTimeout", parse.Duration).(time.Duration)
 }

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -560,10 +560,6 @@ func (g *generalConfig) ORMMaxOpenConns() int {
 	return int(*g.c.Database.MaxOpenConns)
 }
 
-func (g *generalConfig) OCRBootstrapCheckInterval() time.Duration {
-	return g.c.P2P.V1.BootstrapCheckInterval.Duration()
-}
-
 func (g *generalConfig) OCRBlockchainTimeout() time.Duration {
 	return g.c.OCR.BlockchainTimeout.Duration()
 }
@@ -575,13 +571,6 @@ func (g *generalConfig) OCRContractPollInterval() time.Duration {
 func (g *generalConfig) OCRContractSubscribeInterval() time.Duration {
 	return g.c.OCR.ContractSubscribeInterval.Duration()
 }
-func (g *generalConfig) OCRDHTLookupInterval() int {
-	return int(*g.c.P2P.V1.DHTLookupInterval)
-}
-
-func (g *generalConfig) OCRIncomingMessageBufferSize() int {
-	return int(*g.c.P2P.IncomingMessageBufferSize)
-}
 
 func (g *generalConfig) OCRKeyBundleID() (string, error) {
 	b := g.c.OCR.KeyBundleID
@@ -589,14 +578,6 @@ func (g *generalConfig) OCRKeyBundleID() (string, error) {
 		return "", nil
 	}
 	return b.String(), nil
-}
-
-func (g *generalConfig) OCRNewStreamTimeout() time.Duration {
-	return g.c.P2P.V1.NewStreamTimeout.Duration()
-}
-
-func (g *generalConfig) OCROutgoingMessageBufferSize() int {
-	return int(*g.c.P2P.OutgoingMessageBufferSize)
 }
 
 func (g *generalConfig) OCRObservationTimeout() time.Duration {

--- a/core/services/ocr/config.go
+++ b/core/services/ocr/config.go
@@ -1,11 +1,10 @@
 package ocr
 
 import (
-	"github.com/smartcontractkit/chainlink/core/services/job"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
-)
 
-//go:generate mockery --name Config --output ../mocks/ --case=underscore
+	"github.com/smartcontractkit/chainlink/core/services/job"
+)
 
 // Config contains OCR configurations for a job.
 type Config interface {


### PR DESCRIPTION
In #7523 I revived some old deprecated OCR field default values by mistake. This PR reverts that change, drops the defaults, and tightens up the interface methods, which do not need to be included in the general/basic set, or even exported actually.