### PR TITLE
convert tests to new config

### DIFF
--- a/core/bridges/orm_test.go
+++ b/core/bridges/orm_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/auth"
 	"github.com/smartcontractkit/chainlink/core/bridges"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
@@ -17,7 +18,7 @@ import (
 func setupORM(t *testing.T) (*sqlx.DB, bridges.ORM) {
 	t.Helper()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	db := pgtest.NewSqlxDB(t)
 	orm := bridges.NewORM(db, logger.TestLogger(t), cfg)
 

--- a/core/chains/evm/chain_set.go
+++ b/core/chains/evm/chain_set.go
@@ -176,6 +176,7 @@ func (cll *chainSet) Default() (Chain, error) {
 }
 
 // Requires a lock on chainsMu
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func (cll *chainSet) initializeChain(ctx context.Context, dbchain *types.DBChain) error {
 	// preload nodes
 	nodes, _, err := cll.opts.ORM.NodesForChain(dbchain.ID, 0, math.MaxInt)
@@ -414,6 +415,7 @@ type ChainSetOpts struct {
 	GenTxManager      func(*big.Int) txmgr.TxManager
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func LoadChainSet(ctx context.Context, opts ChainSetOpts) (ChainSet, error) {
 	if err := opts.check(); err != nil {
 		return nil, err

--- a/core/chains/evm/headtracker/head_broadcaster_test.go
+++ b/core/chains/evm/headtracker/head_broadcaster_test.go
@@ -16,9 +16,12 @@ import (
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
@@ -38,9 +41,9 @@ func TestHeadBroadcaster_Subscribe(t *testing.T) {
 	t.Parallel()
 	g := gomega.NewWithT(t)
 
-	cfg := cltest.NewTestGeneralConfig(t)
-	var d time.Duration
-	cfg.Overrides.GlobalEvmHeadTrackerSamplingInterval = &d
+	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].HeadTracker.SamplingInterval = &models.Duration{}
+	})
 	evmCfg := evmtest.NewChainScopedConfig(t, cfg)
 	db := pgtest.NewSqlxDB(t)
 	logger := logger.TestLogger(t)

--- a/core/chains/evm/headtracker/head_listener_test.go
+++ b/core/chains/evm/headtracker/head_listener_test.go
@@ -17,8 +17,11 @@ import (
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/core/store/models"
 )
 
 func Test_HeadListener_HappyPath(t *testing.T) {
@@ -34,9 +37,10 @@ func Test_HeadListener_HappyPath(t *testing.T) {
 
 	lggr := logger.TestLogger(t)
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	cfg := cltest.NewTestGeneralConfig(t)
-	zero := time.Duration(0) // no need to test head timeouts here
-	cfg.Overrides.NodeNoNewHeadsThreshold = &zero
+	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		// no need to test head timeouts here
+		c.EVM[0].NoNewHeadsThreshold = &models.Duration{}
+	})
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 	chStop := make(chan struct{})
 	hl := headtracker.NewHeadListener(lggr, ethClient, evmcfg, chStop)
@@ -94,9 +98,10 @@ func Test_HeadListener_NotReceivingHeads(t *testing.T) {
 
 	lggr := logger.TestLogger(t)
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	cfg := cltest.NewTestGeneralConfig(t)
-	idleDuration := time.Second
-	cfg.Overrides.GlobalBlockEmissionIdleWarningThreshold = &idleDuration
+
+	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].NoNewHeadsThreshold = models.MustNewDuration(time.Second)
+	})
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 	evmcfg.BlockEmissionIdleWarningThreshold()
 	chStop := make(chan struct{})
@@ -136,7 +141,7 @@ func Test_HeadListener_NotReceivingHeads(t *testing.T) {
 
 	require.True(t, hl.ReceivingHeads())
 
-	time.Sleep(idleDuration * 2)
+	time.Sleep(time.Second * 2)
 
 	require.False(t, hl.ReceivingHeads())
 
@@ -159,7 +164,7 @@ func Test_HeadListener_SubscriptionErr(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			l := logger.TestLogger(t)
 			ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-			cfg := cltest.NewTestGeneralConfig(t)
+			cfg := configtest.NewGeneralConfig(t, nil)
 			evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 			chStop := make(chan struct{})
 			hl := headtracker.NewHeadListener(l, ethClient, evmcfg, chStop)

--- a/core/chains/evm/headtracker/head_saver_test.go
+++ b/core/chains/evm/headtracker/head_saver_test.go
@@ -10,6 +10,7 @@ import (
 	httypes "github.com/smartcontractkit/chainlink/core/chains/evm/headtracker/types"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
@@ -17,7 +18,7 @@ import (
 func configureSaver(t *testing.T) (httypes.HeadSaver, headtracker.ORM) {
 	db := pgtest.NewSqlxDB(t)
 	lggr := logger.TestLogger(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	htCfg := htmocks.NewConfig(t)
 	htCfg.On("EvmHeadTrackerHistoryDepth").Return(uint32(6))
 	htCfg.On("EvmFinalityDepth").Return(uint32(1))

--- a/core/chains/evm/headtracker/head_tracker_test.go
+++ b/core/chains/evm/headtracker/head_tracker_test.go
@@ -8,18 +8,20 @@ import (
 	"testing"
 	"time"
 
+	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/core/store/models"
 
 	"github.com/ethereum/go-ethereum"
 	gethCommon "github.com/ethereum/go-ethereum/common"
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/onsi/gomega"
+	"github.com/smartcontractkit/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v4"
-
-	"github.com/smartcontractkit/sqlx"
 
 	evmclient "github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/headtracker"
@@ -27,7 +29,6 @@ import (
 	httypes "github.com/smartcontractkit/chainlink/core/chains/evm/headtracker/types"
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -46,7 +47,7 @@ func TestHeadTracker_New(t *testing.T) {
 
 	db := pgtest.NewSqlxDB(t)
 	logger := logger.TestLogger(t)
-	config := cltest.NewTestGeneralConfig(t)
+	config := configtest.NewGeneralConfig(t, nil)
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	ethClient.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Return(cltest.Head(0), nil)
 
@@ -407,14 +408,12 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingEnabled(t *testing.T)
 	db := pgtest.NewSqlxDB(t)
 	logger := logger.TestLogger(t)
 
-	config := cltest.NewTestGeneralConfig(t)
-	config.Overrides.GlobalEvmFinalityDepth = null.IntFrom(50)
-	// Need to set the buffer to something large since we inject a lot of heads at once and otherwise they will be dropped
-	config.Overrides.GlobalEvmHeadTrackerMaxBufferSize = null.IntFrom(100)
-
-	// Head sampling enabled
-	d := 2500 * time.Millisecond
-	config.Overrides.GlobalEvmHeadTrackerSamplingInterval = &d
+	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].FinalityDepth = ptr[uint32](50)
+		// Need to set the buffer to something large since we inject a lot of heads at once and otherwise they will be dropped
+		c.EVM[0].HeadTracker.MaxBufferSize = ptr[uint32](100)
+		c.EVM[0].HeadTracker.SamplingInterval = models.MustNewDuration(2500 * time.Millisecond)
+	})
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -540,12 +539,12 @@ func TestHeadTracker_SwitchesToLongestChainWithHeadSamplingDisabled(t *testing.T
 	db := pgtest.NewSqlxDB(t)
 	logger := logger.TestLogger(t)
 
-	config := cltest.NewTestGeneralConfig(t)
-	config.Overrides.GlobalEvmFinalityDepth = null.IntFrom(50)
-	// Need to set the buffer to something large since we inject a lot of heads at once and otherwise they will be dropped
-	config.Overrides.GlobalEvmHeadTrackerMaxBufferSize = null.IntFrom(100)
-	d := 0 * time.Second
-	config.Overrides.GlobalEvmHeadTrackerSamplingInterval = &d
+	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].FinalityDepth = ptr[uint32](50)
+		// Need to set the buffer to something large since we inject a lot of heads at once and otherwise they will be dropped
+		c.EVM[0].HeadTracker.MaxBufferSize = ptr[uint32](100)
+		c.EVM[0].HeadTracker.SamplingInterval = models.MustNewDuration(0)
+	})
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -769,7 +768,7 @@ func TestHeadTracker_Backfill(t *testing.T) {
 
 	t.Run("does nothing if all the heads are in database", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
-		cfg := cltest.NewTestGeneralConfig(t)
+		cfg := configtest.NewGeneralConfig(t, nil)
 		logger := logger.TestLogger(t)
 		orm := headtracker.NewORM(db, logger, cfg, cltest.FixtureChainID)
 		for i := range heads {
@@ -786,7 +785,7 @@ func TestHeadTracker_Backfill(t *testing.T) {
 
 	t.Run("fetches a missing head", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
-		cfg := cltest.NewTestGeneralConfig(t)
+		cfg := configtest.NewGeneralConfig(t, nil)
 		logger := logger.TestLogger(t)
 		orm := headtracker.NewORM(db, logger, cfg, cltest.FixtureChainID)
 		for i := range heads {
@@ -822,7 +821,7 @@ func TestHeadTracker_Backfill(t *testing.T) {
 
 	t.Run("fetches only heads that are missing", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
-		cfg := cltest.NewTestGeneralConfig(t)
+		cfg := configtest.NewGeneralConfig(t, nil)
 		logger := logger.TestLogger(t)
 		orm := headtracker.NewORM(db, logger, cfg, cltest.FixtureChainID)
 		for i := range heads {
@@ -855,7 +854,7 @@ func TestHeadTracker_Backfill(t *testing.T) {
 
 	t.Run("does not backfill if chain length is already greater than or equal to depth", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
-		cfg := cltest.NewTestGeneralConfig(t)
+		cfg := configtest.NewGeneralConfig(t, nil)
 		logger := logger.TestLogger(t)
 		orm := headtracker.NewORM(db, logger, cfg, cltest.FixtureChainID)
 		for i := range heads {
@@ -876,7 +875,7 @@ func TestHeadTracker_Backfill(t *testing.T) {
 
 	t.Run("only backfills to height 0 if chain length would otherwise cause it to try and fetch a negative head", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
-		cfg := cltest.NewTestGeneralConfig(t)
+		cfg := configtest.NewGeneralConfig(t, nil)
 		logger := logger.TestLogger(t)
 		orm := headtracker.NewORM(db, logger, cfg, cltest.FixtureChainID)
 
@@ -901,7 +900,7 @@ func TestHeadTracker_Backfill(t *testing.T) {
 
 	t.Run("abandons backfill and returns error if the eth node returns not found", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
-		cfg := cltest.NewTestGeneralConfig(t)
+		cfg := configtest.NewGeneralConfig(t, nil)
 		logger := logger.TestLogger(t)
 		orm := headtracker.NewORM(db, logger, cfg, cltest.FixtureChainID)
 		for i := range heads {
@@ -932,7 +931,7 @@ func TestHeadTracker_Backfill(t *testing.T) {
 
 	t.Run("abandons backfill and returns error if the context time budget is exceeded", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
-		cfg := cltest.NewTestGeneralConfig(t)
+		cfg := configtest.NewGeneralConfig(t, nil)
 		logger := logger.TestLogger(t)
 		orm := headtracker.NewORM(db, logger, cfg, cltest.FixtureChainID)
 		for i := range heads {
@@ -972,7 +971,7 @@ func createHeadTracker(t *testing.T, ethClient evmclient.Client, config headtrac
 	}
 }
 
-func createHeadTrackerWithNeverSleeper(t *testing.T, ethClient evmclient.Client, cfg *configtest.TestGeneralConfig, orm headtracker.ORM) *headTrackerUniverse {
+func createHeadTrackerWithNeverSleeper(t *testing.T, ethClient evmclient.Client, cfg config.GeneralConfig, orm headtracker.ORM) *headTrackerUniverse {
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 	lggr := logger.TestLogger(t)
 	hb := headtracker.NewHeadBroadcaster(lggr)
@@ -1041,3 +1040,5 @@ func (u *headTrackerUniverse) Stop(t *testing.T) {
 	require.NoError(t, u.headBroadcaster.Close())
 	require.NoError(t, u.headTracker.Close())
 }
+
+func ptr[T any](t T) *T { return &t }

--- a/core/chains/evm/headtracker/orm_test.go
+++ b/core/chains/evm/headtracker/orm_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -21,7 +22,7 @@ func TestORM_IdempotentInsertHead(t *testing.T) {
 
 	db := pgtest.NewSqlxDB(t)
 	logger := logger.TestLogger(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	orm := headtracker.NewORM(db, logger, cfg, cltest.FixtureChainID)
 
 	// Returns nil when inserting first head
@@ -47,7 +48,7 @@ func TestORM_TrimOldHeads(t *testing.T) {
 
 	db := pgtest.NewSqlxDB(t)
 	logger := logger.TestLogger(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	orm := headtracker.NewORM(db, logger, cfg, cltest.FixtureChainID)
 
 	for i := 0; i < 10; i++ {
@@ -72,7 +73,7 @@ func TestORM_HeadByHash(t *testing.T) {
 
 	db := pgtest.NewSqlxDB(t)
 	logger := logger.TestLogger(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	orm := headtracker.NewORM(db, logger, cfg, cltest.FixtureChainID)
 
 	var hash common.Hash
@@ -95,7 +96,7 @@ func TestORM_HeadByHash_NotFound(t *testing.T) {
 
 	db := pgtest.NewSqlxDB(t)
 	logger := logger.TestLogger(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	orm := headtracker.NewORM(db, logger, cfg, cltest.FixtureChainID)
 
 	hash := cltest.Head(123).Hash
@@ -110,7 +111,7 @@ func TestORM_LatestHeads_NoRows(t *testing.T) {
 
 	db := pgtest.NewSqlxDB(t)
 	logger := logger.TestLogger(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	orm := headtracker.NewORM(db, logger, cfg, cltest.FixtureChainID)
 
 	heads, err := orm.LatestHeads(testutils.Context(t), 100)

--- a/core/chains/evm/log/integration_test.go
+++ b/core/chains/evm/log/integration_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/flux_aggregator_wrapper"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -262,7 +263,7 @@ func TestBroadcaster_ReplaysLogs(t *testing.T) {
 func TestBroadcaster_BackfillUnconsumedAfterCrash(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
 	lggr := logger.TestLogger(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 
 	orm := log.NewORM(db, lggr, cfg, cltest.FixtureChainID)
 

--- a/core/chains/evm/log/orm_test.go
+++ b/core/chains/evm/log/orm_test.go
@@ -12,13 +12,14 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm/log"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
 func TestORM_broadcasts(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	lggr := logger.TestLogger(t)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
@@ -132,7 +133,7 @@ func TestORM_broadcasts(t *testing.T) {
 
 func TestORM_pending(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	lggr := logger.TestLogger(t)
 	orm := log.NewORM(db, lggr, cfg, cltest.FixtureChainID)
 
@@ -158,7 +159,7 @@ func TestORM_pending(t *testing.T) {
 
 func TestORM_MarkUnconsumed(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	lggr := logger.TestLogger(t)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
@@ -257,7 +258,7 @@ func TestORM_Reinitialize(t *testing.T) {
 		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			db := pgtest.NewSqlxDB(t)
-			cfg := cltest.NewTestGeneralConfig(t)
+			cfg := configtest.NewGeneralConfig(t, nil)
 			lggr := logger.TestLogger(t)
 			orm := log.NewORM(db, lggr, cfg, cltest.FixtureChainID)
 

--- a/core/chains/evm/monitor/balance_test.go
+++ b/core/chains/evm/monitor/balance_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/chains/evm/monitor"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
@@ -33,7 +34,7 @@ func newEthClientMock(t *testing.T) *evmmocks.Client {
 func TestBalanceMonitor_Start(t *testing.T) {
 	t.Parallel()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 
 	t.Run("updates balance from nil for multiple keys", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
@@ -138,7 +139,7 @@ func TestBalanceMonitor_Start(t *testing.T) {
 func TestBalanceMonitor_OnNewLongestChain_UpdatesBalance(t *testing.T) {
 	t.Parallel()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 
 	t.Run("updates balance for multiple keys", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
@@ -199,7 +200,7 @@ func TestBalanceMonitor_FewerRPCCallsWhenBehind(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
 	cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)

--- a/core/chains/evm/txmgr/eth_confirmer_test.go
+++ b/core/chains/evm/txmgr/eth_confirmer_test.go
@@ -1319,7 +1319,7 @@ func TestEthConfirmer_FindEthTxsRequiringResubmissionDueToInsufficientEth(t *tes
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	borm := cltest.NewTxmORM(t, db, cfg)
 	q := pg.NewQ(db, logger.TestLogger(t), cfg)
 

--- a/core/chains/evm/txmgr/nonce_syncer_test.go
+++ b/core/chains/evm/txmgr/nonce_syncer_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -24,7 +25,7 @@ func Test_NonceSyncer_SyncAll(t *testing.T) {
 	t.Run("returns error if PendingNonceAt fails", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
 		ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-		cfg := cltest.NewTestGeneralConfig(t)
+		cfg := configtest.NewGeneralConfig(t, nil)
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
 		_, from := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
@@ -49,7 +50,7 @@ func Test_NonceSyncer_SyncAll(t *testing.T) {
 	t.Run("does nothing if chain nonce reflects local nonce", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
 		ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-		cfg := cltest.NewTestGeneralConfig(t)
+		cfg := configtest.NewGeneralConfig(t, nil)
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
 		_, from := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
@@ -71,7 +72,7 @@ func Test_NonceSyncer_SyncAll(t *testing.T) {
 
 	t.Run("does nothing if chain nonce is behind local nonce", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
-		cfg := cltest.NewTestGeneralConfig(t)
+		cfg := configtest.NewGeneralConfig(t, nil)
 
 		ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
@@ -95,7 +96,7 @@ func Test_NonceSyncer_SyncAll(t *testing.T) {
 
 	t.Run("fast forwards if chain nonce is ahead of local nonce", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
-		cfg := cltest.NewTestGeneralConfig(t)
+		cfg := configtest.NewGeneralConfig(t, nil)
 
 		ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
@@ -122,7 +123,7 @@ func Test_NonceSyncer_SyncAll(t *testing.T) {
 
 	t.Run("counts 'in_progress' eth_tx as bumping the local next nonce by 1", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
-		cfg := cltest.NewTestGeneralConfig(t)
+		cfg := configtest.NewGeneralConfig(t, nil)
 		borm := cltest.NewTxmORM(t, db, cfg)
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 

--- a/core/chains/evm/txmgr/orm_test.go
+++ b/core/chains/evm/txmgr/orm_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
@@ -15,7 +16,7 @@ import (
 
 func TestORM_EthTransactionsWithAttempts(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	orm := cltest.NewTxmORM(t, db, cfg)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
@@ -63,7 +64,7 @@ func TestORM_EthTransactionsWithAttempts(t *testing.T) {
 
 func TestORM_EthTransactions(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	orm := cltest.NewTxmORM(t, db, cfg)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
@@ -105,7 +106,7 @@ func TestORM(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	keyStore := cltest.NewKeyStore(t, db, cfg)
 	orm := cltest.NewTxmORM(t, db, cfg)
 	_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth(), 0)

--- a/core/chains/evm/txmgr/reaper_test.go
+++ b/core/chains/evm/txmgr/reaper_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr/mocks"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/utils"
@@ -29,7 +30,7 @@ func TestReaper_ReapEthTxes(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	borm := cltest.NewTxmORM(t, db, cfg)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 

--- a/core/chains/evm/txmgr/strategies_test.go
+++ b/core/chains/evm/txmgr/strategies_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 )
 
@@ -38,7 +39,7 @@ func Test_DropOldestStrategy_PruneQueue(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	borm := cltest.NewTxmORM(t, db, cfg)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 

--- a/core/chains/evm/types/models_test.go
+++ b/core/chains/evm/types/models_test.go
@@ -20,6 +20,7 @@ import (
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/null"
 	"github.com/smartcontractkit/chainlink/core/utils"
@@ -89,7 +90,7 @@ func TestEthTx_GetID(t *testing.T) {
 
 func TestEthTxAttempt_GetSignedTx(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
 	tx := gethTypes.NewTransaction(uint64(42), testutils.NewAddress(), big.NewInt(142), 242, big.NewInt(342), []byte{1, 2, 3})

--- a/core/cmd/client_test.go
+++ b/core/cmd/client_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/logger/audit"
@@ -136,7 +137,7 @@ func TestTerminalAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			db := pgtest.NewSqlxDB(t)
-			orm := sessions.NewORM(db, time.Minute, logger.TestLogger(t), cltest.NewTestGeneralConfig(t), audit.NoopLogger)
+			orm := sessions.NewORM(db, time.Minute, logger.TestLogger(t), pgtest.NewPGCfg(true), audit.NoopLogger)
 
 			mock := &cltest.MockCountingPrompter{T: t, EnteredStrings: test.enteredStrings, NotTerminal: !test.isTerminal}
 			tai := cmd.NewPromptingAPIInitializer(mock, logger.TestLogger(t))
@@ -165,7 +166,7 @@ func TestTerminalAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 
 func TestTerminalAPIInitializer_InitializeWithExistingAPIUser(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	orm := sessions.NewORM(db, time.Minute, logger.TestLogger(t), cfg, audit.NoopLogger)
 
 	// Clear out fixture users/users created from the other test cases
@@ -202,7 +203,7 @@ func TestFileAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			db := pgtest.NewSqlxDB(t)
-			orm := sessions.NewORM(db, time.Minute, logger.TestLogger(t), cltest.NewTestGeneralConfig(t), audit.NoopLogger)
+			orm := sessions.NewORM(db, time.Minute, logger.TestLogger(t), pgtest.NewPGCfg(true), audit.NoopLogger)
 
 			// Clear out fixture users/users created from the other test cases
 			// This asserts that on initial run with an empty users table that the credentials file will instantiate and
@@ -226,7 +227,7 @@ func TestFileAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 
 func TestFileAPIInitializer_InitializeWithExistingAPIUser(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	orm := sessions.NewORM(db, time.Minute, logger.TestLogger(t), cfg, audit.NoopLogger)
 
 	tests := []struct {

--- a/core/cmd/eth_keys_commands_test.go
+++ b/core/cmd/eth_keys_commands_test.go
@@ -146,6 +146,7 @@ func TestClient_CreateETHKey(t *testing.T) {
 	require.Equal(t, 3, len(keys))
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func TestClient_UpdateETHKey(t *testing.T) {
 	t.Parallel()
 

--- a/core/cmd/evm_chains_commands_test.go
+++ b/core/cmd/evm_chains_commands_test.go
@@ -42,6 +42,7 @@ func TestClient_IndexEVMChains(t *testing.T) {
 	assertTableRenders(t, r)
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func TestClient_CreateEVMChain(t *testing.T) {
 	t.Parallel()
 
@@ -75,6 +76,7 @@ func TestClient_CreateEVMChain(t *testing.T) {
 	assertTableRenders(t, r)
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func TestClient_RemoveEVMChain(t *testing.T) {
 	t.Parallel()
 
@@ -111,6 +113,7 @@ func TestClient_RemoveEVMChain(t *testing.T) {
 	assertTableRenders(t, r)
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func TestClient_ConfigureEVMChain(t *testing.T) {
 	t.Parallel()
 

--- a/core/cmd/evm_node_commands_test.go
+++ b/core/cmd/evm_node_commands_test.go
@@ -68,6 +68,7 @@ func TestClient_IndexEVMNodes(t *testing.T) {
 	assertTableRenders(t, r)
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func TestClient_CreateEVMNode(t *testing.T) {
 	t.Parallel()
 
@@ -120,6 +121,7 @@ func TestClient_CreateEVMNode(t *testing.T) {
 	assertTableRenders(t, r)
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func TestClient_RemoveEVMNode(t *testing.T) {
 	t.Parallel()
 

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest/heavyweight"
 	"github.com/smartcontractkit/chainlink/core/internal/mocks"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -24,6 +25,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/sessions"
 	"github.com/smartcontractkit/chainlink/core/store/dialects"
+	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
@@ -51,8 +53,7 @@ func TestClient_RunNodeShowsEnv(t *testing.T) {
 	require.NoError(t, cfg.SetLogLevel(zapcore.DebugLevel))
 
 	db := pgtest.NewSqlxDB(t)
-	pCfg := cltest.NewTestGeneralConfig(t)
-	sessionORM := sessions.NewORM(db, time.Minute, lggr, pCfg, audit.NoopLogger)
+	sessionORM := sessions.NewORM(db, time.Minute, lggr, cfg, audit.NoopLogger)
 	keyStore := cltest.NewKeyStore(t, db, cfg)
 	_, err := keyStore.Eth().Create(&cltest.FixtureChainID)
 	require.NoError(t, err)
@@ -222,10 +223,14 @@ func TestClient_RunNodeWithPasswords(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cfg := cltest.NewTestGeneralConfig(t)
+			cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				s.KeystorePassword = ptr("dummy")
+				c.EVM[0].Nodes[0].Name = ptr("fake")
+				c.EVM[0].Nodes[0].HTTPURL = models.MustParseURL("http://fake.com")
+			})
 			db := pgtest.NewSqlxDB(t)
 			keyStore := cltest.NewKeyStore(t, db, cfg)
-			sessionORM := sessions.NewORM(db, time.Minute, logger.TestLogger(t), cltest.NewTestGeneralConfig(t), audit.NoopLogger)
+			sessionORM := sessions.NewORM(db, time.Minute, logger.TestLogger(t), cfg, audit.NoopLogger)
 
 			// Purge the fixture users to test assumption of single admin
 			// initialUser user created above
@@ -285,9 +290,13 @@ func TestClient_RunNodeWithAPICredentialsFile(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			cfg := cltest.NewTestGeneralConfig(t)
+			cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				s.KeystorePassword = ptr("16charlengthp4SsW0rD1!@#_")
+				c.EVM[0].Nodes[0].Name = ptr("fake")
+				c.EVM[0].Nodes[0].HTTPURL = models.MustParseURL("http://fake.com")
+			})
 			db := pgtest.NewSqlxDB(t)
-			sessionORM := sessions.NewORM(db, time.Minute, logger.TestLogger(t), cltest.NewTestGeneralConfig(t), audit.NoopLogger)
+			sessionORM := sessions.NewORM(db, time.Minute, logger.TestLogger(t), cfg, audit.NoopLogger)
 
 			// Clear out fixture users/users created from the other test cases
 			// This asserts that on initial run with an empty users table that the credentials file will instantiate and
@@ -328,16 +337,12 @@ func TestClient_RunNodeWithAPICredentialsFile(t *testing.T) {
 
 			set := flag.NewFlagSet("test", 0)
 			set.String("api", test.apiFile, "")
-			set.String("password", "../internal/fixtures/correct_password.txt", "")
 			set.Bool("bypass-version-check", true, "")
 			c := cli.NewContext(nil, set, nil)
 
 			if test.wantError {
 				err = client.RunNode(c)
-				assert.Error(t, err)
-				if err != nil {
-					assert.Contains(t, err.Error(), "error creating api initializer: open doesntexist.txt: no such file or directory")
-				}
+				assert.ErrorContains(t, err, "error creating api initializer: open doesntexist.txt: no such file or directory")
 			} else {
 				assert.NoError(t, client.RunNode(c))
 			}

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -63,7 +63,6 @@ func startNewApplicationV2(t *testing.T, overrideFn func(c *chainlink.Config, s 
 	}
 
 	config := configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-		cltest.TestOverrides(c, s)
 		c.JobPipeline.HTTPRequest.DefaultTimeout = models.MustNewDuration(30 * time.Millisecond)
 		f := false
 		c.EVM[0].Enabled = &f
@@ -81,6 +80,7 @@ func startNewApplicationV2(t *testing.T, overrideFn func(c *chainlink.Config, s 
 	return app
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func startNewApplication(t *testing.T, setup ...func(opts *startOptions)) *cltest.TestApplication {
 	t.Helper()
 
@@ -502,6 +502,7 @@ func TestClient_Profile(t *testing.T) {
 	require.NoError(t, err)
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func TestClient_SetDefaultGasPrice(t *testing.T) {
 	t.Parallel()
 
@@ -593,6 +594,7 @@ func TestClient_GetConfiguration(t *testing.T) {
 	assert.Equal(t, cp.EnvPrinter.SessionTimeout, cfg.SessionTimeout())
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func TestClient_ConfigDump(t *testing.T) {
 	t.Parallel()
 

--- a/core/cmd/solana_chains_commands_test.go
+++ b/core/cmd/solana_chains_commands_test.go
@@ -38,6 +38,7 @@ func TestClient_IndexSolanaChains(t *testing.T) {
 	assertTableRenders(t, r)
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func TestClient_CreateSolanaChain(t *testing.T) {
 	t.Parallel()
 
@@ -65,6 +66,7 @@ func TestClient_CreateSolanaChain(t *testing.T) {
 	assertTableRenders(t, r)
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func TestClient_RemoveSolanaChain(t *testing.T) {
 	t.Parallel()
 
@@ -96,6 +98,7 @@ func TestClient_RemoveSolanaChain(t *testing.T) {
 	assertTableRenders(t, r)
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func TestClient_ConfigureSolanaChain(t *testing.T) {
 	t.Parallel()
 

--- a/core/cmd/solana_node_commands_test.go
+++ b/core/cmd/solana_node_commands_test.go
@@ -41,6 +41,7 @@ func solanaStartNewApplication(t *testing.T, cfgs ...*solana.SolanaConfig) *clte
 	})
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func solanaStartNewLegacyApplication(t *testing.T) *cltest.TestApplication {
 	return startNewApplication(t, withConfigSet(func(c *configtest.TestGeneralConfig) {
 		c.Overrides.SolanaEnabled = null.BoolFrom(true)

--- a/core/cmd/terra_chains_commands_test.go
+++ b/core/cmd/terra_chains_commands_test.go
@@ -39,6 +39,7 @@ func TestClient_IndexTerraChains(t *testing.T) {
 	assertTableRenders(t, r)
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func TestClient_CreateTerraChain(t *testing.T) {
 	t.Parallel()
 
@@ -66,6 +67,7 @@ func TestClient_CreateTerraChain(t *testing.T) {
 	assertTableRenders(t, r)
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func TestClient_RemoveTerraChain(t *testing.T) {
 	t.Parallel()
 
@@ -97,6 +99,7 @@ func TestClient_RemoveTerraChain(t *testing.T) {
 	assertTableRenders(t, r)
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func TestClient_ConfigureTerraChain(t *testing.T) {
 	t.Parallel()
 

--- a/core/cmd/terra_node_commands_test.go
+++ b/core/cmd/terra_node_commands_test.go
@@ -41,6 +41,7 @@ func terraStartNewApplication(t *testing.T, cfgs ...*terra.TerraConfig) *cltest.
 	})
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func terraStartNewLegacyApplication(t *testing.T) *cltest.TestApplication {
 	return startNewApplication(t, withConfigSet(func(c *configtest.TestGeneralConfig) {
 		c.Overrides.TerraEnabled = null.BoolFrom(true)

--- a/core/internal/cltest/job_factories.go
+++ b/core/internal/cltest/job_factories.go
@@ -4,16 +4,17 @@ import (
 	"fmt"
 	"testing"
 
+	uuid "github.com/satori/go.uuid"
+	"github.com/smartcontractkit/sqlx"
+	"github.com/stretchr/testify/require"
+
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/p2pkey"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
-	"github.com/smartcontractkit/sqlx"
-
-	uuid "github.com/satori/go.uuid"
-	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -56,9 +57,10 @@ func MustInsertWebhookSpec(t *testing.T, db *sqlx.DB) (job.Job, job.WebhookSpec)
 }
 
 func getORMs(t *testing.T, db *sqlx.DB) (jobORM job.ORM, pipelineORM pipeline.ORM) {
-	config := NewTestGeneralConfig(t)
+	config := configtest.NewTestGeneralConfig(t)
 	keyStore := NewKeyStore(t, db, config)
-	pipelineORM = pipeline.NewORM(db, logger.TestLogger(t), config)
+	lggr := logger.TestLogger(t)
+	pipelineORM = pipeline.NewORM(db, lggr, config)
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: config})
 	jobORM = job.NewORM(db, cc, pipelineORM, keyStore, logger.TestLogger(t), config)
 	t.Cleanup(func() { jobORM.Close() })

--- a/core/internal/cltest/simulated_backend.go
+++ b/core/internal/cltest/simulated_backend.go
@@ -13,13 +13,11 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/client"
-	evmcfg "github.com/smartcontractkit/chainlink/core/chains/evm/config/v2"
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	coreconfig "github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
-	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
@@ -35,6 +33,7 @@ func NewSimulatedBackend(t *testing.T, alloc core.GenesisAlloc, gasLimit uint32)
 }
 
 // Deprecated: use NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func NewApplicationWithConfigAndKeyOnSimulatedBlockchain(
 	t testing.TB,
 	cfg *configtest.TestGeneralConfig,
@@ -69,7 +68,7 @@ func NewApplicationWithConfigAndKeyOnSimulatedBlockchain(
 }
 
 // NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain is like NewApplicationWithConfigAndKeyOnSimulatedBlockchain
-// but cfg should be v2, and cltest.OverrideSimulated used to include the simulated chain (testutils.SimulatedChainID).
+// but cfg should be v2, and configtest.NewGeneralConfigSimulated used to include the simulated chain (testutils.SimulatedChainID).
 func NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(
 	t testing.TB,
 	cfg coreconfig.GeneralConfig,
@@ -89,24 +88,6 @@ func NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(
 
 	//  app.Stop() will call client.Close on the simulated backend
 	return NewApplicationWithConfigAndKey(t, cfg, flagsAndDeps...)
-}
-
-// OverrideSimulated is a config override func that appends the simulated chain (testutils.SimulatedChainID),
-// or replaces the null chain (client.NullClientChainID) if that is the only entry.
-func OverrideSimulated(c *chainlink.Config, s *chainlink.Secrets) {
-	chainID := utils.NewBig(testutils.SimulatedChainID)
-	enabled := true
-	cfg := evmcfg.EVMConfig{
-		ChainID: chainID,
-		Chain:   evmcfg.DefaultsFrom(chainID, nil),
-		Enabled: &enabled,
-		Nodes:   evmcfg.EVMNodes{{}},
-	}
-	if len(c.EVM) == 1 && c.EVM[0].ChainID.Cmp(utils.NewBigI(client.NullClientChainID)) == 0 {
-		c.EVM[0] = &cfg
-	} else {
-		c.EVM = append(c.EVM, &cfg)
-	}
 }
 
 // Mine forces the simulated backend to produce a new block every 2 seconds

--- a/core/internal/features/features_test.go
+++ b/core/internal/features/features_test.go
@@ -42,6 +42,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/auth"
 	"github.com/smartcontractkit/chainlink/core/bridges"
+	"github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/forwarders"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/gas"
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
@@ -79,9 +80,10 @@ func TestIntegration_ExternalInitiatorV2(t *testing.T) {
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
 
-	cfg := cltest.NewTestGeneralConfig(t)
-	cfg.Overrides.FeatureExternalInitiators = null.BoolFrom(true)
-	cfg.Overrides.SetTriggerFallbackDBPollInterval(10 * time.Millisecond)
+	cfg := configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.JobPipeline.ExternalInitiatorsEnabled = ptr(true)
+		c.Database.Listener.FallbackPollInterval = models.MustNewDuration(10 * time.Millisecond)
+	})
 
 	app := cltest.NewApplicationWithConfig(t, cfg, ethClient, cltest.UseRealExternalInitiatorManager)
 	require.NoError(t, app.Start(testutils.Context(t)))
@@ -252,9 +254,7 @@ observationSource   = """
 func TestIntegration_AuthToken(t *testing.T) {
 	t.Parallel()
 
-	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
-
-	app := cltest.NewLegacyApplication(t, ethClient)
+	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	// set up user
@@ -264,13 +264,12 @@ func TestIntegration_AuthToken(t *testing.T) {
 	require.NoError(t, orm.CreateUser(&mockUser))
 	require.NoError(t, orm.SetAuthToken(&mockUser, &apiToken))
 
-	url := app.Server.URL + "/v2/config"
+	url := app.Server.URL + "/users"
 	headers := make(map[string]string)
 	headers[webauth.APIKey] = cltest.APIKey
 	headers[webauth.APISecret] = cltest.APISecret
-	buf := bytes.NewBufferString(`{"ethGasPriceDefault":150000000000}`)
 
-	resp, cleanup := cltest.UnauthenticatedPatch(t, url, buf, headers)
+	resp, cleanup := cltest.UnauthenticatedGet(t, url, headers)
 	defer cleanup()
 	cltest.AssertServerResponse(t, resp, http.StatusOK)
 }
@@ -350,9 +349,7 @@ func TestIntegration_DirectRequest(t *testing.T) {
 			t.Parallel()
 			// Simulate a consumer contract calling to obtain ETH quotes in 3 different currencies
 			// in a single callback.
-			config := configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-				cltest.TestOverrides(c, s)
-				cltest.OverrideSimulated(c, s)
+			config := configtest2.NewGeneralConfigSimulated(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 				c.Database.Listener.FallbackPollInterval = models.MustNewDuration(100 * time.Millisecond)
 				c.EVM[0].GasEstimator.EIP1559DynamicFees = ptr(true)
 			})
@@ -459,9 +456,7 @@ func setupAppForEthTx(t *testing.T, operatorContracts OperatorContracts) (app *c
 	b := operatorContracts.sim
 	lggr, o := logger.TestLoggerObserved(t, zapcore.DebugLevel)
 
-	cfg := configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-		cltest.TestOverrides(c, s)
-		cltest.OverrideSimulated(c, s)
+	cfg := configtest2.NewGeneralConfigSimulated(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.Database.Listener.FallbackPollInterval = models.MustNewDuration(100 * time.Millisecond)
 	})
 	app = cltest.NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(t, cfg, b, lggr)
@@ -1282,41 +1277,43 @@ observationSource = """
 func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 	t.Parallel()
 
-	var initialDefaultGasPrice int64 = 5000000000
-	maxGasPrice := assets.NewWeiI(50000000000)
-	cfg := cltest.NewTestGeneralConfig(t)
-	cfg.Overrides.GlobalBalanceMonitorEnabled = null.BoolFrom(false)
-	cfg.Overrides.GlobalBlockHistoryEstimatorCheckInclusionBlocks = null.IntFrom(0)
+	var initialDefaultGasPrice int64 = 5_000_000_000
+	maxGasPrice := assets.NewWeiI(10 * initialDefaultGasPrice)
 
-	ethClient := cltest.NewEthMocksWithDefaultChain(t)
+	cfg := configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
+		c.EVM[0].GasEstimator.BlockHistory.CheckInclusionBlocks = ptr[uint16](0)
+		c.EVM[0].GasEstimator.PriceDefault = assets.NewWeiI(initialDefaultGasPrice)
+		c.EVM[0].GasEstimator.Mode = ptr("BlockHistory")
+		c.EVM[0].RPCBlockQueryDelay = ptr[uint16](0)
+		c.EVM[0].GasEstimator.BlockHistory.BlockHistorySize = ptr[uint16](2)
+		c.EVM[0].FinalityDepth = ptr[uint32](3)
+	})
+
+	ethClient := cltest.NewEthMocks(t)
+	ethClient.On("ChainID").Return(big.NewInt(client.NullClientChainID)).Maybe()
 	chchNewHeads := make(chan evmtest.RawSub[*evmtypes.Head], 1)
 
 	db := pgtest.NewSqlxDB(t)
 	kst := cltest.NewKeyStore(t, db, cfg)
 	require.NoError(t, kst.Unlock(cltest.Password))
 
-	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, KeyStore: kst.Eth(), Client: ethClient, GeneralConfig: cfg, ChainCfg: evmtypes.ChainCfg{
-		EvmGasPriceDefault:                    assets.NewWeiI(initialDefaultGasPrice),
-		GasEstimatorMode:                      null.StringFrom("BlockHistory"),
-		BlockHistoryEstimatorBlockDelay:       null.IntFrom(0),
-		BlockHistoryEstimatorBlockHistorySize: null.IntFrom(2),
-		EvmFinalityDepth:                      null.IntFrom(3),
-	}})
+	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, KeyStore: kst.Eth(), Client: ethClient, GeneralConfig: cfg})
 
 	b41 := gas.Block{
 		Number:       41,
 		Hash:         utils.NewHash(),
-		Transactions: cltest.LegacyTransactionsFromGasPrices(41000000000, 41500000000),
+		Transactions: cltest.LegacyTransactionsFromGasPrices(41_000_000_000, 41_500_000_000),
 	}
 	b42 := gas.Block{
 		Number:       42,
 		Hash:         utils.NewHash(),
-		Transactions: cltest.LegacyTransactionsFromGasPrices(44000000000, 45000000000),
+		Transactions: cltest.LegacyTransactionsFromGasPrices(44_000_000_000, 45_000_000_000),
 	}
 	b43 := gas.Block{
 		Number:       43,
 		Hash:         utils.NewHash(),
-		Transactions: cltest.LegacyTransactionsFromGasPrices(48000000000, 49000000000, 31000000000),
+		Transactions: cltest.LegacyTransactionsFromGasPrices(48_000_000_000, 49_000_000_000, 31_000_000_000),
 	}
 
 	evmChainID := utils.NewBig(cfg.DefaultChainID())
@@ -1363,7 +1360,7 @@ func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 
 	chain := evmtest.MustGetDefaultChain(t, cc)
 	estimator := chain.TxManager().GetGasEstimator()
-	gasPrice, gasLimit, err := estimator.GetLegacyGas(nil, 500000, maxGasPrice)
+	gasPrice, gasLimit, err := estimator.GetLegacyGas(nil, 500_000, maxGasPrice)
 	require.NoError(t, err)
 	assert.Equal(t, uint32(500000), gasLimit)
 	assert.Equal(t, "41.5 gwei", gasPrice.String())

--- a/core/internal/testutils/configtest/general_config.go
+++ b/core/internal/testutils/configtest/general_config.go
@@ -137,7 +137,6 @@ type GeneralConfigOverrides struct {
 
 	// P2P v1 and V2
 	P2PPeerID          p2pkey.PeerID
-	P2PPeerIDError     error
 	P2PNetworkingStack ocrnetworking.NetworkingStack
 
 	// P2P v1
@@ -193,11 +192,14 @@ type TestGeneralConfig struct {
 	Overrides GeneralConfigOverrides
 }
 
+// NewTestGeneralConfig returns a legacy *TestGeneralConfig. Use v2.NewTestGeneralConfig instead.
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func NewTestGeneralConfig(t *testing.T) *TestGeneralConfig {
 	return NewTestGeneralConfigWithOverrides(t, GeneralConfigOverrides{})
 }
 
 // Deprecated: see v2.TOML
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func NewTestGeneralConfigWithOverrides(t testing.TB, overrides GeneralConfigOverrides) *TestGeneralConfig {
 	cfg := config.NewGeneralConfig(logger.TestLogger(t))
 	return &TestGeneralConfig{

--- a/core/internal/testutils/configtest/v2/general_config.go
+++ b/core/internal/testutils/configtest/v2/general_config.go
@@ -6,9 +6,11 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	evmclient "github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	evmcfg "github.com/smartcontractkit/chainlink/core/chains/evm/config/v2"
 	"github.com/smartcontractkit/chainlink/core/config"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/store/dialects"
@@ -38,14 +40,22 @@ func NewGeneralConfig(t testing.TB, overrideFn func(*chainlink.Config, *chainlin
 
 // overrides applies some test config settings and adds a default chain with evmclient.NullClientChainID.
 func overrides(c *chainlink.Config, s *chainlink.Secrets) {
+	s.KeystorePassword = ptr("dummy-to-pass-validation")
+
 	c.DevMode = true
 	c.InsecureFastScrypt = ptr(true)
+	c.ShutdownGracePeriod = models.MustNewDuration(testutils.DefaultWaitTimeout)
 
 	c.Database.Dialect = dialects.TransactionWrappedPostgres
 	c.Database.Lock.Mode = "none"
 	c.Database.MaxIdleConns = ptr[int64](20)
 	c.Database.MaxOpenConns = ptr[int64](20)
 	c.Database.MigrateOnStartup = ptr(false)
+
+	c.JobPipeline.ReaperInterval = models.MustNewDuration(0)
+
+	c.P2P.V1.Enabled = ptr(false)
+	c.P2P.V2.Enabled = ptr(false)
 
 	c.WebServer.SessionTimeout = models.MustNewDuration(2 * time.Minute)
 	c.WebServer.BridgeResponseURL = models.MustParseURL("http://localhost:6688")
@@ -58,6 +68,36 @@ func overrides(c *chainlink.Config, s *chainlink.Secrets) {
 		Enabled: &enabled,
 		Nodes:   evmcfg.EVMNodes{{}},
 	})
+}
+
+// NewGeneralConfigSimulated returns a new config.GeneralConfig with overrides, including the simulated EVM chain.
+// The default test overrides are applied before overrideFn.
+// The simulated chain (testutils.SimulatedChainID) replaces the null chain (evmclient.NullClientChainID).
+func NewGeneralConfigSimulated(t testing.TB, overrideFn func(*chainlink.Config, *chainlink.Secrets)) config.GeneralConfig {
+	return NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		simulated(c, s)
+		if fn := overrideFn; fn != nil {
+			fn(c, s)
+		}
+	})
+}
+
+// simulated is a config override func that appends the simulated EVM chain (testutils.SimulatedChainID),
+// or replaces the null chain (client.NullClientChainID) if that is the only entry.
+func simulated(c *chainlink.Config, s *chainlink.Secrets) {
+	chainID := utils.NewBig(testutils.SimulatedChainID)
+	enabled := true
+	cfg := evmcfg.EVMConfig{
+		ChainID: chainID,
+		Chain:   evmcfg.DefaultsFrom(chainID, nil),
+		Enabled: &enabled,
+		Nodes:   evmcfg.EVMNodes{{}},
+	}
+	if len(c.EVM) == 1 && c.EVM[0].ChainID.Cmp(utils.NewBigI(client.NullClientChainID)) == 0 {
+		c.EVM[0] = &cfg // replace null, if only entry
+	} else {
+		c.EVM = append(c.EVM, &cfg)
+	}
 }
 
 func ptr[T any](v T) *T { return &v }

--- a/core/internal/testutils/solanatest/solanatest.go
+++ b/core/internal/testutils/solanatest/solanatest.go
@@ -11,6 +11,7 @@ import (
 )
 
 // MustInsertChain inserts chain in to db, or fails the test.
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func MustInsertChain(t testing.TB, db *sqlx.DB, chain *db.Chain) {
 	query, args, e := db.BindNamed(`
 INSERT INTO solana_chains (id, cfg, enabled, created_at, updated_at) VALUES (:id, :cfg, :enabled, NOW(), NOW()) RETURNING *;`, chain)

--- a/core/internal/testutils/terratest/terratest.go
+++ b/core/internal/testutils/terratest/terratest.go
@@ -12,6 +12,7 @@ import (
 )
 
 // MustInsertChain inserts chain in to db, or fails the test.
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func MustInsertChain(t testing.TB, db *sqlx.DB, chain *db.Chain) {
 	query, args, e := db.BindNamed(`
 INSERT INTO terra_chains (id, cfg, enabled, created_at, updated_at) VALUES (:id, :cfg, :enabled, NOW(), NOW()) RETURNING *;`, chain)

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -7,11 +7,11 @@ import (
 	"io"
 	"testing"
 
-	"gopkg.in/guregu/null.v4"
-
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/static"
 )
 
@@ -22,9 +22,12 @@ func init() {
 
 func Run(args ...string) {
 	t := &testing.T{}
-	tc := cltest.NewTestGeneralConfig(t)
-	tc.SetRootDir("/foo")
-	tc.Overrides.Dev = null.BoolFrom(false)
+
+	tc := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.DevMode = false
+		foo := "foo"
+		c.RootDir = &foo
+	})
 	lggr := logger.TestLogger(t)
 	testClient := &cmd.Client{
 		Renderer:               cmd.RendererTable{Writer: io.Discard},

--- a/core/services/blockhashstore/delegate_test.go
+++ b/core/services/blockhashstore/delegate_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/chains/evm/mocks"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -46,7 +47,7 @@ func createTestDelegate(t *testing.T) (*blockhashstore.Delegate, *testData) {
 
 	lggr, logs := logger.TestLoggerObserved(t, zapcore.DebugLevel)
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	db := pgtest.NewSqlxDB(t)
 	kst := cltest.NewKeyStore(t, db, cfg).Eth()
 	sendingKey, _ := cltest.MustAddRandomKeyToKeystore(t, kst)

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -152,7 +152,8 @@ func (g *generalConfig) TerraConfigs() terra.TerraConfigs {
 }
 
 func (g *generalConfig) Validate() error {
-	return multierr.Combine(g.c.Validate(), g.secrets.Validate())
+	_, err := utils.MultiErrorList(multierr.Combine(g.c.Validate(), g.secrets.Validate()))
+	return err
 }
 
 func (g *generalConfig) LogConfiguration(log coreconfig.LogFn) {

--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/smartcontractkit/sqlx"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -42,8 +43,7 @@ func setupORM(t *testing.T) *TestORM {
 	var (
 		db   = pgtest.NewSqlxDB(t)
 		lggr = logger.TestLogger(t)
-		cfg  = cltest.NewTestGeneralConfig(t)
-		orm  = feeds.NewORM(db, lggr, cfg)
+		orm  = feeds.NewORM(db, lggr, pgtest.NewPGCfg(true))
 	)
 
 	return &TestORM{ORM: orm, db: db}
@@ -1009,7 +1009,7 @@ func createJob(t *testing.T, db *sqlx.DB, externalJobID uuid.UUID) *job.Job {
 	t.Helper()
 
 	var (
-		config      = cltest.NewTestGeneralConfig(t)
+		config      = configtest.NewGeneralConfig(t, nil)
 		keyStore    = cltest.NewKeyStore(t, db, config)
 		lggr        = logger.TestLogger(t)
 		pipelineORM = pipeline.NewORM(db, lggr, config)

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
-	"github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/headtracker"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
@@ -98,7 +97,6 @@ func setupTestService(t *testing.T) *TestService {
 	db := pgtest.NewSqlxDB(t)
 	gcfg := configtest.NewTestGeneralConfig(t)
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{GeneralConfig: gcfg,
-		Client:      client.NewNullClient(gcfg.DefaultChainID(), lggr),
 		HeadTracker: headtracker.NullTracker})
 	keyStore := new(ksmocks.Master)
 	keyStore.On("CSA").Return(csaKeystore)

--- a/core/services/fluxmonitorv2/flux_monitor_test.go
+++ b/core/services/fluxmonitorv2/flux_monitor_test.go
@@ -179,7 +179,7 @@ func setup(t *testing.T, db *sqlx.DB, optionFns ...func(*setupOptions)) (*fluxmo
 		tm.pipelineRunner,
 		job.Job{},
 		pipelineSpec,
-		pg.NewQ(db, lggr, cltest.NewTestGeneralConfig(t)),
+		pg.NewQ(db, lggr, pgtest.NewPGCfg(true)),
 		options.orm,
 		tm.jobORM,
 		tm.pipelineORM,
@@ -265,8 +265,7 @@ func withORM(orm fluxmonitorv2.ORM) func(*setupOptions) {
 // setupStoreWithKey setups a new store and adds a key to the keystore
 func setupStoreWithKey(t *testing.T) (*sqlx.DB, common.Address) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
-	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
+	ethKeyStore := cltest.NewKeyStore(t, db, pgtest.NewPGCfg(true)).Eth()
 	_, nodeAddr := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
 
 	return db, nodeAddr
@@ -729,7 +728,6 @@ func TestFluxMonitor_TriggerIdleTimeThreshold(t *testing.T) {
 	}
 
 	db, nodeAddr := setupStoreWithKey(t)
-	cfg := cltest.NewTestGeneralConfig(t)
 	oracles := []common.Address{nodeAddr, testutils.NewAddress()}
 
 	for _, tc := range testCases {
@@ -738,7 +736,7 @@ func TestFluxMonitor_TriggerIdleTimeThreshold(t *testing.T) {
 			t.Parallel()
 
 			var (
-				orm = newORM(t, db, cfg, nil)
+				orm = newORM(t, db, pgtest.NewPGCfg(true), nil)
 			)
 
 			fm, tm := setup(t, db, disablePollTicker(true), disableIdleTimer(tc.idleTimerDisabled), setIdleTimerPeriod(tc.idleDuration), withORM(orm))
@@ -1129,11 +1127,10 @@ func TestFluxMonitor_RoundTimeoutCausesPoll_timesOutAtZero(t *testing.T) {
 
 	g := gomega.NewWithT(t)
 	db, nodeAddr := setupStoreWithKey(t)
-	cfg := cltest.NewTestGeneralConfig(t)
 
 	var (
 		oracles = []common.Address{nodeAddr, testutils.NewAddress()}
-		orm     = newORM(t, db, cfg, nil)
+		orm     = newORM(t, db, pgtest.NewPGCfg(true), nil)
 	)
 
 	fm, tm := setup(t, db, disablePollTicker(true), disableIdleTimer(true), withORM(orm))
@@ -1466,9 +1463,8 @@ func TestFluxMonitor_DoesNotDoubleSubmit(t *testing.T) {
 		)
 
 		const (
-			olderRoundID = 2
-			roundID      = 3
-			answer       = 100
+			roundID = 3
+			answer  = 100
 		)
 
 		tm.keyStore.On("EnabledKeysForChain", testutils.FixtureChainID).Return([]ethkey.KeyV2{{Address: nodeAddr}}, nil).Once()
@@ -1638,7 +1634,7 @@ func TestFluxMonitor_DoesNotDoubleSubmit(t *testing.T) {
 			Once()
 
 		tm.fluxAggregator.On("GetOracles", nilOpts).Return(oracles, nil)
-		fm.SetOracleAddress()
+		require.NoError(t, fm.SetOracleAddress())
 		fm.ExportedPollIfEligible(0, 0)
 
 		// Now fire off the NewRound log and ensure it does not respond this time
@@ -1733,7 +1729,7 @@ func TestFluxMonitor_DoesNotDoubleSubmit(t *testing.T) {
 			Once()
 
 		tm.fluxAggregator.On("GetOracles", nilOpts).Return(oracles, nil)
-		fm.SetOracleAddress()
+		require.NoError(t, fm.SetOracleAddress())
 		fm.ExportedPollIfEligible(0, 0)
 
 		// Now fire off the NewRound log and ensure it does not respond this time
@@ -1920,7 +1916,7 @@ func TestFluxMonitor_DrumbeatTicker(t *testing.T) {
 		Return(flux_aggregator_wrapper.OracleRoundState{RoundId: 4, EligibleToSubmit: false, LatestSubmission: answerBigInt, StartedAt: now()}, nil).
 		Maybe()
 
-	fm.Start(testutils.Context(t))
+	require.NoError(t, fm.Start(testutils.Context(t)))
 	defer fm.Close()
 
 	waitTime := 15 * time.Second

--- a/core/services/fluxmonitorv2/key_store_test.go
+++ b/core/services/fluxmonitorv2/key_store_test.go
@@ -15,7 +15,7 @@ func TestKeyStore_EnabledKeysForChain(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := pgtest.NewPGCfg(true)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
 	ks := fluxmonitorv2.NewKeyStore(ethKeyStore)
@@ -40,7 +40,7 @@ func TestKeyStore_GetRoundRobinAddress(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := pgtest.NewPGCfg(true)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
 	_, k0Address := cltest.MustInsertRandomKey(t, ethKeyStore, 0)

--- a/core/services/fluxmonitorv2/orm_test.go
+++ b/core/services/fluxmonitorv2/orm_test.go
@@ -13,6 +13,7 @@ import (
 	txmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/txmgr/mocks"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -25,7 +26,7 @@ func TestORM_MostRecentFluxMonitorRoundID(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := pgtest.NewPGCfg(true)
 	orm := newORM(t, db, cfg, nil)
 
 	address := testutils.NewAddress()
@@ -79,7 +80,7 @@ func TestORM_MostRecentFluxMonitorRoundID(t *testing.T) {
 func TestORM_UpdateFluxMonitorRoundStats(t *testing.T) {
 	t.Parallel()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	db := pgtest.NewSqlxDB(t)
 
 	keyStore := cltest.NewKeyStore(t, db, cfg)
@@ -164,7 +165,7 @@ func TestORM_CreateEthTransaction(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := pgtest.NewPGCfg(true)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
 	strategy := txmmocks.NewTxStrategy(t)

--- a/core/services/job/job_pipeline_orm_integration_test.go
+++ b/core/services/job/job_pipeline_orm_integration_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
-	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 )
@@ -149,7 +148,7 @@ func TestPipelineORM_Integration(t *testing.T) {
 		cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{Client: evmtest.NewEthClientMockWithDefaultChain(t), DB: db, GeneralConfig: config})
 		runner := pipeline.NewRunner(orm, config, cc, nil, nil, lggr, nil, nil)
 		defer runner.Close()
-		jobORM := job.NewTestORM(t, db, cc, orm, keyStore, cfg)
+		jobORM := NewTestORM(t, db, cc, orm, keyStore, cfg)
 
 		dbSpec := makeVoterTurnoutOCRJobSpec(t, transmitterAddress, bridge.Name.String(), bridge2.Name.String())
 

--- a/core/services/job/orm_test.go
+++ b/core/services/job/orm_test.go
@@ -1,26 +1,26 @@
-package job
+package job_test
 
 import (
 	"testing"
 
+	"github.com/smartcontractkit/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v4"
-
-	"github.com/smartcontractkit/sqlx"
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	clnull "github.com/smartcontractkit/chainlink/core/null"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 )
 
-func NewTestORM(t *testing.T, db *sqlx.DB, chainSet evm.ChainSet, pipelineORM pipeline.ORM, keyStore keystore.Master, cfg pg.LogConfig) ORM {
-	o := NewORM(db, chainSet, pipelineORM, keyStore, logger.TestLogger(t), cfg)
+func NewTestORM(t *testing.T, db *sqlx.DB, chainSet evm.ChainSet, pipelineORM pipeline.ORM, keyStore keystore.Master, cfg pg.LogConfig) job.ORM {
+	o := job.NewORM(db, chainSet, pipelineORM, keyStore, logger.TestLogger(t), cfg)
 	t.Cleanup(func() { o.Close() })
 	return o
 }
@@ -30,9 +30,9 @@ func TestLoadEnvConfigVarsLocalOCR(t *testing.T) {
 
 	config := configtest.NewTestGeneralConfig(t)
 	chainConfig := evmtest.NewChainScopedConfig(t, config)
-	jobSpec := &OCROracleSpec{}
+	jobSpec := &job.OCROracleSpec{}
 
-	jobSpec = LoadEnvConfigVarsLocalOCR(chainConfig, *jobSpec)
+	jobSpec = job.LoadEnvConfigVarsLocalOCR(chainConfig, *jobSpec)
 
 	require.True(t, jobSpec.ObservationTimeoutEnv)
 	require.True(t, jobSpec.BlockchainTimeoutEnv)
@@ -47,22 +47,24 @@ func TestLoadEnvConfigVarsLocalOCR(t *testing.T) {
 func TestLoadEnvConfigVarsDR(t *testing.T) {
 	t.Parallel()
 
-	config := configtest.NewTestGeneralConfig(t)
-	config.Overrides.GlobalMinIncomingConfirmations = null.IntFrom(100)
+	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		hundred := uint32(100)
+		c.EVM[0].MinIncomingConfirmations = &hundred
+	})
 	chainConfig := evmtest.NewChainScopedConfig(t, config)
 
-	jobSpec10 := DirectRequestSpec{
+	jobSpec10 := job.DirectRequestSpec{
 		MinIncomingConfirmations: clnull.Uint32From(10),
 	}
 
-	drs10 := LoadEnvConfigVarsDR(chainConfig, jobSpec10)
+	drs10 := job.LoadEnvConfigVarsDR(chainConfig, jobSpec10)
 	assert.True(t, drs10.MinIncomingConfirmationsEnv)
 
-	jobSpec200 := DirectRequestSpec{
+	jobSpec200 := job.DirectRequestSpec{
 		MinIncomingConfirmations: clnull.Uint32From(200),
 	}
 
-	drs200 := LoadEnvConfigVarsDR(chainConfig, jobSpec200)
+	drs200 := job.LoadEnvConfigVarsDR(chainConfig, jobSpec200)
 	assert.False(t, drs200.MinIncomingConfirmationsEnv)
 	assert.True(t, drs200.MinIncomingConfirmations.Valid)
 	assert.Equal(t, uint32(200), drs200.MinIncomingConfirmations.Uint32)

--- a/core/services/job/runner_integration_test.go
+++ b/core/services/job/runner_integration_test.go
@@ -66,7 +66,7 @@ func TestRunner(t *testing.T) {
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, Client: ethClient, GeneralConfig: config})
 	c := clhttptest.NewTestLocalOnlyHTTPClient()
 	runner := pipeline.NewRunner(pipelineORM, config, cc, nil, nil, logger.TestLogger(t), c, c)
-	jobORM := job.NewTestORM(t, db, cc, pipelineORM, keyStore, config)
+	jobORM := NewTestORM(t, db, cc, pipelineORM, keyStore, config)
 
 	runner.Start(testutils.Context(t))
 	defer runner.Close()
@@ -896,7 +896,7 @@ func TestRunner_Success_Callback_AsyncJob(t *testing.T) {
 		_ = cltest.CreateJobRunViaExternalInitiatorV2(t, app, jobUUID, *eia, cltest.MustJSONMarshal(t, eiRequest))
 
 		pipelineORM := pipeline.NewORM(app.GetSqlxDB(), logger.TestLogger(t), cfg)
-		jobORM := job.NewTestORM(t, app.GetSqlxDB(), cc, pipelineORM, app.KeyStore, cfg)
+		jobORM := NewTestORM(t, app.GetSqlxDB(), cc, pipelineORM, app.KeyStore, cfg)
 
 		// Trigger v2/resume
 		select {
@@ -1071,7 +1071,7 @@ func TestRunner_Error_Callback_AsyncJob(t *testing.T) {
 		_ = cltest.CreateJobRunViaExternalInitiatorV2(t, app, jobUUID, *eia, cltest.MustJSONMarshal(t, eiRequest))
 
 		pipelineORM := pipeline.NewORM(app.GetSqlxDB(), logger.TestLogger(t), cfg)
-		jobORM := job.NewTestORM(t, app.GetSqlxDB(), cc, pipelineORM, app.KeyStore, cfg)
+		jobORM := NewTestORM(t, app.GetSqlxDB(), cc, pipelineORM, app.KeyStore, cfg)
 
 		// Trigger v2/resume
 		select {

--- a/core/services/job/spawner_test.go
+++ b/core/services/job/spawner_test.go
@@ -73,7 +73,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 
 	t.Run("should respect its dependents", func(t *testing.T) {
 		lggr := logger.TestLogger(t)
-		orm := job.NewTestORM(t, db, cc, pipeline.NewORM(db, lggr, config), keyStore, config)
+		orm := NewTestORM(t, db, cc, pipeline.NewORM(db, lggr, config), keyStore, config)
 		a := utils.NewDependentAwaiter()
 		a.AddDependents(1)
 		spawner := job.NewSpawner(orm, config, map[job.Type]job.Delegate{}, db, lggr, []utils.DependentAwaiter{a})
@@ -96,7 +96,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 		jobB := makeOCRJobSpec(t, address, bridge.Name.String(), bridge2.Name.String())
 
 		lggr := logger.TestLogger(t)
-		orm := job.NewTestORM(t, db, cc, pipeline.NewORM(db, lggr, config), keyStore, config)
+		orm := NewTestORM(t, db, cc, pipeline.NewORM(db, lggr, config), keyStore, config)
 		eventuallyA := cltest.NewAwaiter()
 		serviceA1 := mocks.NewServiceCtx(t)
 		serviceA2 := mocks.NewServiceCtx(t)
@@ -158,7 +158,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 		serviceA2.On("Start", mock.Anything).Return(nil).Once().Run(func(mock.Arguments) { eventually.ItHappened() })
 
 		lggr := logger.TestLogger(t)
-		orm := job.NewTestORM(t, db, cc, pipeline.NewORM(db, lggr, config), keyStore, config)
+		orm := NewTestORM(t, db, cc, pipeline.NewORM(db, lggr, config), keyStore, config)
 		d := ocr.NewDelegate(nil, orm, nil, nil, nil, monitoringEndpoint, cc, logger.TestLogger(t), config)
 		delegateA := &delegate{jobA.Type, []job.ServiceCtx{serviceA1, serviceA2}, 0, nil, d}
 		spawner := job.NewSpawner(orm, config, map[job.Type]job.Delegate{
@@ -192,7 +192,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 		serviceA2.On("Start", mock.Anything).Return(nil).Once().Run(func(mock.Arguments) { eventuallyStart.ItHappened() })
 
 		lggr := logger.TestLogger(t)
-		orm := job.NewTestORM(t, db, cc, pipeline.NewORM(db, lggr, config), keyStore, config)
+		orm := NewTestORM(t, db, cc, pipeline.NewORM(db, lggr, config), keyStore, config)
 		d := ocr.NewDelegate(nil, orm, nil, nil, nil, monitoringEndpoint, cc, logger.TestLogger(t), config)
 		delegateA := &delegate{jobA.Type, []job.ServiceCtx{serviceA1, serviceA2}, 0, nil, d}
 		spawner := job.NewSpawner(orm, config, map[job.Type]job.Delegate{

--- a/core/services/keeper/orm_test.go
+++ b/core/services/keeper/orm_test.go
@@ -16,6 +16,7 @@ import (
 	evmconfig "github.com/smartcontractkit/chainlink/core/chains/evm/config"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -35,7 +36,7 @@ func setupKeeperDB(t *testing.T) (
 	evmconfig.ChainScopedConfig,
 	keeper.ORM,
 ) {
-	gcfg := cltest.NewTestGeneralConfig(t)
+	gcfg := configtest.NewGeneralConfig(t, nil)
 	db := pgtest.NewSqlxDB(t)
 	cfg := evmtest.NewChainScopedConfig(t, gcfg)
 	orm := keeper.NewORM(db, logger.TestLogger(t), cfg, txmgr.SendEveryStrategy{})

--- a/core/services/keeper/registry1_1_synchronizer_test.go
+++ b/core/services/keeper/registry1_1_synchronizer_test.go
@@ -16,6 +16,7 @@ import (
 	registry1_1 "github.com/smartcontractkit/chainlink/core/gethwrappers/generated/keeper_registry_wrapper1_1"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -225,7 +226,7 @@ func Test_RegistrySynchronizer1_1_ConfigSetLog(t *testing.T) {
 	registryMock.MockResponse("getKeeperList", []common.Address{fromAddress}).Once()
 	registryMock.MockResponse("getConfig", newConfig).Once()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_1.KeeperRegistryConfigSet{}
@@ -273,7 +274,7 @@ func Test_RegistrySynchronizer1_1_KeepersUpdatedLog(t *testing.T) {
 	registryMock.MockResponse("getConfig", registryConfig1_1).Once()
 	registryMock.MockResponse("getKeeperList", addresses).Once()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_1.KeeperRegistryKeepersUpdated{}
@@ -314,7 +315,7 @@ func Test_RegistrySynchronizer1_1_UpkeepCanceledLog(t *testing.T) {
 	cltest.WaitForCount(t, db, "keeper_registries", 1)
 	cltest.WaitForCount(t, db, "upkeep_registrations", 3)
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_1.KeeperRegistryUpkeepCanceled{Id: big.NewInt(1)}
@@ -356,7 +357,7 @@ func Test_RegistrySynchronizer1_1_UpkeepRegisteredLog(t *testing.T) {
 	registryMock := cltest.NewContractMockReceiver(t, ethMock, keeper.Registry1_1ABI, contractAddress)
 	registryMock.MockResponse("getUpkeep", upkeepConfig1_1).Once()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_1.KeeperRegistryUpkeepRegistered{Id: big.NewInt(1)}
@@ -399,7 +400,7 @@ func Test_RegistrySynchronizer1_1_UpkeepPerformedLog(t *testing.T) {
 
 	pgtest.MustExec(t, db, `UPDATE upkeep_registrations SET last_run_block_height = 100`)
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash, BlockNumber: 200}
 	log := registry1_1.KeeperRegistryUpkeepPerformed{Id: big.NewInt(0), From: fromAddress}

--- a/core/services/keeper/registry1_2_synchronizer_test.go
+++ b/core/services/keeper/registry1_2_synchronizer_test.go
@@ -16,6 +16,7 @@ import (
 	registry1_2 "github.com/smartcontractkit/chainlink/core/gethwrappers/generated/keeper_registry_wrapper1_2"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -248,7 +249,7 @@ func Test_RegistrySynchronizer1_2_ConfigSetLog(t *testing.T) {
 		Keepers: []common.Address{fromAddress},
 	}).Once()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_2.KeeperRegistryConfigSet{}
@@ -300,7 +301,7 @@ func Test_RegistrySynchronizer1_2_KeepersUpdatedLog(t *testing.T) {
 		Keepers: addresses,
 	}).Once()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_2.KeeperRegistryKeepersUpdated{}
@@ -343,7 +344,7 @@ func Test_RegistrySynchronizer1_2_UpkeepCanceledLog(t *testing.T) {
 	cltest.WaitForCount(t, db, "keeper_registries", 1)
 	cltest.WaitForCount(t, db, "upkeep_registrations", 3)
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_2.KeeperRegistryUpkeepCanceled{Id: big.NewInt(3)}
@@ -386,7 +387,7 @@ func Test_RegistrySynchronizer1_2_UpkeepRegisteredLog(t *testing.T) {
 	registryMock := cltest.NewContractMockReceiver(t, ethMock, keeper.Registry1_2ABI, contractAddress)
 	registryMock.MockResponse("getUpkeep", upkeepConfig1_2).Once()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_2.KeeperRegistryUpkeepRegistered{Id: big.NewInt(420)}
@@ -430,7 +431,7 @@ func Test_RegistrySynchronizer1_2_UpkeepPerformedLog(t *testing.T) {
 
 	pgtest.MustExec(t, db, `UPDATE upkeep_registrations SET last_run_block_height = 100`)
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash, BlockNumber: 200}
 	log := registry1_2.KeeperRegistryUpkeepPerformed{Id: big.NewInt(3), From: fromAddress}
@@ -496,7 +497,7 @@ func Test_RegistrySynchronizer1_2_UpkeepGasLimitSetLog(t *testing.T) {
 	newConfig.ExecuteGas = 4_000_000 // change from default
 	registryMock.MockResponse("getUpkeep", newConfig).Once()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_2.KeeperRegistryUpkeepGasLimitSet{Id: big.NewInt(3), GasLimit: big.NewInt(4_000_000)}
@@ -539,7 +540,7 @@ func Test_RegistrySynchronizer1_2_UpkeepReceivedLog(t *testing.T) {
 	registryMock := cltest.NewContractMockReceiver(t, ethMock, keeper.Registry1_2ABI, contractAddress)
 	registryMock.MockResponse("getUpkeep", upkeepConfig1_2).Once()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_2.KeeperRegistryUpkeepReceived{Id: big.NewInt(420)}
@@ -579,7 +580,7 @@ func Test_RegistrySynchronizer1_2_UpkeepMigratedLog(t *testing.T) {
 	cltest.WaitForCount(t, db, "keeper_registries", 1)
 	cltest.WaitForCount(t, db, "upkeep_registrations", 3)
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_2.KeeperRegistryUpkeepMigrated{Id: big.NewInt(3)}

--- a/core/services/keeper/registry1_3_synchronizer_test.go
+++ b/core/services/keeper/registry1_3_synchronizer_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	registry1_3 "github.com/smartcontractkit/chainlink/core/gethwrappers/generated/keeper_registry_wrapper1_3"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	logmocks "github.com/smartcontractkit/chainlink/core/chains/evm/log/mocks"
@@ -253,7 +254,7 @@ func Test_RegistrySynchronizer1_3_ConfigSetLog(t *testing.T) {
 		Keepers: []common.Address{fromAddress},
 	}).Once()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_3.KeeperRegistryConfigSet{}
@@ -305,7 +306,7 @@ func Test_RegistrySynchronizer1_3_KeepersUpdatedLog(t *testing.T) {
 		Keepers: addresses,
 	}).Once()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_3.KeeperRegistryKeepersUpdated{}
@@ -348,7 +349,7 @@ func Test_RegistrySynchronizer1_3_UpkeepCanceledLog(t *testing.T) {
 	cltest.WaitForCount(t, db, "keeper_registries", 1)
 	cltest.WaitForCount(t, db, "upkeep_registrations", 3)
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_3.KeeperRegistryUpkeepCanceled{Id: big.NewInt(3)}
@@ -391,7 +392,7 @@ func Test_RegistrySynchronizer1_3_UpkeepRegisteredLog(t *testing.T) {
 	registryMock := cltest.NewContractMockReceiver(t, ethMock, keeper.Registry1_3ABI, contractAddress)
 	registryMock.MockResponse("getUpkeep", upkeepConfig1_3).Once()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_3.KeeperRegistryUpkeepRegistered{Id: big.NewInt(420)}
@@ -435,7 +436,7 @@ func Test_RegistrySynchronizer1_3_UpkeepPerformedLog(t *testing.T) {
 
 	pgtest.MustExec(t, db, `UPDATE upkeep_registrations SET last_run_block_height = 100`)
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash, BlockNumber: 200}
 	log := registry1_3.KeeperRegistryUpkeepPerformed{Id: big.NewInt(3), From: fromAddress}
@@ -501,7 +502,7 @@ func Test_RegistrySynchronizer1_3_UpkeepGasLimitSetLog(t *testing.T) {
 	newConfig.ExecuteGas = 4_000_000 // change from default
 	registryMock.MockResponse("getUpkeep", newConfig).Once()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_3.KeeperRegistryUpkeepGasLimitSet{Id: big.NewInt(3), GasLimit: big.NewInt(4_000_000)}
@@ -544,7 +545,7 @@ func Test_RegistrySynchronizer1_3_UpkeepReceivedLog(t *testing.T) {
 	registryMock := cltest.NewContractMockReceiver(t, ethMock, keeper.Registry1_3ABI, contractAddress)
 	registryMock.MockResponse("getUpkeep", upkeepConfig1_3).Once()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_3.KeeperRegistryUpkeepReceived{Id: big.NewInt(420)}
@@ -584,7 +585,7 @@ func Test_RegistrySynchronizer1_3_UpkeepMigratedLog(t *testing.T) {
 	cltest.WaitForCount(t, db, "keeper_registries", 1)
 	cltest.WaitForCount(t, db, "upkeep_registrations", 3)
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_3.KeeperRegistryUpkeepMigrated{Id: big.NewInt(3)}
@@ -626,7 +627,7 @@ func Test_RegistrySynchronizer1_3_UpkeepPausedLog_UpkeepUnpausedLog(t *testing.T
 	cltest.WaitForCount(t, db, "keeper_registries", 1)
 	cltest.WaitForCount(t, db, "upkeep_registrations", 3)
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	log := registry1_3.KeeperRegistryUpkeepPaused{Id: upkeepId}
@@ -642,7 +643,7 @@ func Test_RegistrySynchronizer1_3_UpkeepPausedLog_UpkeepUnpausedLog(t *testing.T
 
 	cltest.WaitForCount(t, db, "upkeep_registrations", 2)
 
-	cfg = cltest.NewTestGeneralConfig(t)
+	cfg = configtest.NewGeneralConfig(t, nil)
 	head = cltest.MustInsertHead(t, db, cfg, 2)
 	rawLog = types.Log{BlockHash: head.Hash}
 	unpausedlog := registry1_3.KeeperRegistryUpkeepUnpaused{Id: upkeepId}
@@ -696,7 +697,7 @@ func Test_RegistrySynchronizer1_3_UpkeepCheckDataUpdatedLog(t *testing.T) {
 	cltest.WaitForCount(t, db, "keeper_registries", 1)
 	cltest.WaitForCount(t, db, "upkeep_registrations", 1)
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	head := cltest.MustInsertHead(t, db, cfg, 1)
 	rawLog := types.Log{BlockHash: head.Hash}
 	_ = logmocks.NewBroadcast(t)

--- a/core/services/keeper/registry_synchronizer_helper_test.go
+++ b/core/services/keeper/registry_synchronizer_helper_test.go
@@ -14,6 +14,7 @@ import (
 	evmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/mocks"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -37,7 +38,7 @@ func setupRegistrySync(t *testing.T, version keeper.RegistryVersion) (
 	lbMock := logmocks.NewBroadcaster(t)
 	lbMock.On("AddDependents", 1).Maybe()
 	j := cltest.MustInsertKeeperJob(t, db, korm, cltest.NewEIP55Address(), cltest.NewEIP55Address())
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, Client: ethClient, LogBroadcaster: lbMock, GeneralConfig: cfg})
 	ch := evmtest.MustGetDefaultChain(t, cc)
 	keyStore := cltest.NewKeyStore(t, db, cfg)

--- a/core/services/keystore/eth_test.go
+++ b/core/services/keystore/eth_test.go
@@ -149,7 +149,7 @@ func Test_EthKeyStore_GetRoundRobinAddress(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 
 	keyStore := cltest.NewKeyStore(t, db, cfg)
 	ethKeyStore := keyStore.Eth()

--- a/core/services/ocr2/plugins/dkg/config/config_test.go
+++ b/core/services/ocr2/plugins/dkg/config/config_test.go
@@ -1,20 +1,21 @@
 package config_test
 
 import (
+	"encoding/hex"
 	"testing"
 
-	"encoding/hex"
+	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/services/ocr2/plugins/dkg/config"
-	"github.com/stretchr/testify/require"
 )
 
 func TestValidatePluginConfig(t *testing.T) {
 	t.Parallel()
 
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	db := pgtest.NewSqlxDB(t)
 	kst := cltest.NewKeyStore(t, db, cfg)
 

--- a/core/services/ocrcommon/peer_wrapper_test.go
+++ b/core/services/ocrcommon/peer_wrapper_test.go
@@ -4,29 +4,24 @@ import (
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/libocr/networking"
-	"gopkg.in/guregu/null.v4"
-
-	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/services/ocrcommon"
-
 	p2ppeer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/p2pkey"
+	"github.com/smartcontractkit/chainlink/core/services/ocrcommon"
+	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
 func Test_SingletonPeerWrapper_Start(t *testing.T) {
 	t.Parallel()
 
-	cfg := configtest.NewTestGeneralConfigWithOverrides(t, configtest.GeneralConfigOverrides{
-		P2PEnabled: null.BoolFrom(true),
-	})
 	db := pgtest.NewSqlxDB(t)
 
 	require.NoError(t, utils.JustError(db.Exec(`DELETE FROM encrypted_key_rings`)))
@@ -35,21 +30,27 @@ func Test_SingletonPeerWrapper_Start(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("with no p2p keys returns error", func(t *testing.T) {
+		cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.P2P.V1.Enabled = ptr(true)
+		})
 		keyStore := cltest.NewKeyStore(t, db, cfg)
 		pw := ocrcommon.NewSingletonPeerWrapper(keyStore, cfg, db, logger.TestLogger(t))
 		require.Contains(t, pw.Start(testutils.Context(t)).Error(), "No P2P keys found in keystore. Peer wrapper will not be fully initialized")
 	})
 
-	var k p2pkey.KeyV2
-
 	t.Run("with one p2p key and matching P2P_PEER_ID returns nil", func(t *testing.T) {
+		cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.P2P.V1.Enabled = ptr(true)
+		})
 		keyStore := cltest.NewKeyStore(t, db, cfg)
-		k, err = keyStore.P2P().Create()
+		k, err := keyStore.P2P().Create()
 		require.NoError(t, err)
 
-		cfg.Overrides.P2PPeerID = k.PeerID()
-
-		require.NoError(t, err)
+		cfg = configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.P2P.V1.Enabled = ptr(true)
+			c.P2P.V1.PeerID = ptr(k.PeerID())
+		})
+		keyStore = cltest.NewKeyStore(t, db, cfg)
 
 		pw := ocrcommon.NewSingletonPeerWrapper(keyStore, cfg, db, logger.TestLogger(t))
 
@@ -58,25 +59,30 @@ func Test_SingletonPeerWrapper_Start(t *testing.T) {
 	})
 
 	t.Run("with one p2p key and mismatching P2P_PEER_ID returns error", func(t *testing.T) {
+		cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.P2P.V1.Enabled = ptr(true)
+			c.P2P.V1.PeerID = ptr(p2pkey.PeerID(peerID))
+		})
 		keyStore := cltest.NewKeyStore(t, db, cfg)
-
-		cfg.Overrides.P2PPeerID = p2pkey.PeerID(peerID)
 
 		pw := ocrcommon.NewSingletonPeerWrapper(keyStore, cfg, db, logger.TestLogger(t))
 
 		require.Contains(t, pw.Start(testutils.Context(t)).Error(), "unable to find P2P key with id")
 	})
 
-	var k2 p2pkey.KeyV2
-
 	t.Run("with multiple p2p keys and valid P2P_PEER_ID returns nil", func(t *testing.T) {
+		cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.P2P.V1.Enabled = ptr(true)
+		})
 		keyStore := cltest.NewKeyStore(t, db, cfg)
-		k2, err = keyStore.P2P().Create()
+		k2, err := keyStore.P2P().Create()
 		require.NoError(t, err)
 
-		cfg.Overrides.P2PPeerID = k2.PeerID()
-
-		require.NoError(t, err)
+		cfg = configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.P2P.V1.Enabled = ptr(true)
+			c.P2P.V1.PeerID = ptr(k2.PeerID())
+		})
+		keyStore = cltest.NewKeyStore(t, db, cfg)
 
 		pw := ocrcommon.NewSingletonPeerWrapper(keyStore, cfg, db, logger.TestLogger(t))
 
@@ -85,9 +91,11 @@ func Test_SingletonPeerWrapper_Start(t *testing.T) {
 	})
 
 	t.Run("with multiple p2p keys and mismatching P2P_PEER_ID returns error", func(t *testing.T) {
+		cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.P2P.V1.Enabled = ptr(true)
+			c.P2P.V1.PeerID = ptr(p2pkey.PeerID(peerID))
+		})
 		keyStore := cltest.NewKeyStore(t, db, cfg)
-
-		cfg.Overrides.P2PPeerID = p2pkey.PeerID(peerID)
 
 		pw := ocrcommon.NewSingletonPeerWrapper(keyStore, cfg, db, logger.TestLogger(t))
 
@@ -98,29 +106,30 @@ func Test_SingletonPeerWrapper_Start(t *testing.T) {
 func Test_SingletonPeerWrapper_Close(t *testing.T) {
 	t.Parallel()
 
-	cfg := configtest.NewTestGeneralConfigWithOverrides(t, configtest.GeneralConfigOverrides{
-		P2PEnabled: null.BoolFrom(true),
-	})
 	db := pgtest.NewSqlxDB(t)
 
 	require.NoError(t, utils.JustError(db.Exec(`DELETE FROM encrypted_key_rings`)))
 
+	cfg := configtest.NewGeneralConfig(t, nil)
 	keyStore := cltest.NewKeyStore(t, db, cfg)
 	k, err := keyStore.P2P().Create()
 	require.NoError(t, err)
 
-	p2paddresses := []string{
-		"127.0.0.1:17193",
-	}
+	cfg = configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.P2P.V2.Enabled = ptr(true)
+		c.P2P.V1.PeerID = ptr(k.PeerID())
+		c.P2P.V2.DeltaDial = models.MustNewDuration(100 * time.Millisecond)
+		c.P2P.V2.DeltaReconcile = models.MustNewDuration(1 * time.Second)
+		c.P2P.V1.ListenPort = ptr[uint16](0)
 
-	cfg.Overrides.P2PPeerID = k.PeerID()
-	cfg.Overrides.P2PNetworkingStack = networking.NetworkingStackV2
-	cfg.Overrides.P2PEnabled = null.BoolFrom(true)
-	cfg.Overrides.SetP2PV2DeltaDial(100 * time.Millisecond)
-	cfg.Overrides.SetP2PV2DeltaReconcile(1 * time.Second)
-	cfg.Overrides.P2PListenPort = null.NewInt(0, true)
-	cfg.Overrides.P2PV2ListenAddresses = p2paddresses
-	cfg.Overrides.P2PV2AnnounceAddresses = p2paddresses
+		p2paddresses := []string{
+			"127.0.0.1:17193",
+		}
+		c.P2P.V2.ListenAddresses = ptr(p2paddresses)
+		c.P2P.V2.AnnounceAddresses = ptr(p2paddresses)
+
+	})
+	keyStore = cltest.NewKeyStore(t, db, cfg)
 
 	pw := ocrcommon.NewSingletonPeerWrapper(keyStore, cfg, db, logger.TestLogger(t))
 
@@ -135,3 +144,5 @@ func Test_SingletonPeerWrapper_Close(t *testing.T) {
 	require.True(t, pw.IsStarted(), "Should have started successfully")
 	pw.Close()
 }
+
+func ptr[T any](t T) *T { return &t }

--- a/core/services/pg/locked_db_test.go
+++ b/core/services/pg/locked_db_test.go
@@ -4,19 +4,22 @@ import (
 	"context"
 	"testing"
 
-	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 
 	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v4"
 )
+
+func lease(c *chainlink.Config, s *chainlink.Secrets) {
+	c.Database.Lock.Mode = "lease"
+}
 
 func TestLockedDB_HappyPath(t *testing.T) {
 	testutils.SkipShortDB(t)
-	config := cltest.NewTestGeneralConfig(t)
-	config.Overrides.DatabaseLockingMode = null.StringFrom("dual")
+	config := configtest.NewGeneralConfig(t, lease)
 	lggr := logger.TestLogger(t)
 	ldb := pg.NewLockedDB(config, lggr)
 
@@ -31,8 +34,7 @@ func TestLockedDB_HappyPath(t *testing.T) {
 
 func TestLockedDB_ContextCancelled(t *testing.T) {
 	testutils.SkipShortDB(t)
-	config := cltest.NewTestGeneralConfig(t)
-	config.Overrides.DatabaseLockingMode = null.StringFrom("dual")
+	config := configtest.NewGeneralConfig(t, lease)
 	lggr := logger.TestLogger(t)
 	ldb := pg.NewLockedDB(config, lggr)
 
@@ -45,8 +47,7 @@ func TestLockedDB_ContextCancelled(t *testing.T) {
 
 func TestLockedDB_OpenTwice(t *testing.T) {
 	testutils.SkipShortDB(t)
-	config := cltest.NewTestGeneralConfig(t)
-	config.Overrides.DatabaseLockingMode = null.StringFrom("lease")
+	config := configtest.NewGeneralConfig(t, lease)
 	lggr := logger.TestLogger(t)
 	ldb := pg.NewLockedDB(config, lggr)
 
@@ -61,8 +62,7 @@ func TestLockedDB_OpenTwice(t *testing.T) {
 
 func TestLockedDB_TwoInstances(t *testing.T) {
 	testutils.SkipShortDB(t)
-	config := cltest.NewTestGeneralConfig(t)
-	config.Overrides.DatabaseLockingMode = null.StringFrom("dual")
+	config := configtest.NewGeneralConfig(t, lease)
 	lggr := logger.TestLogger(t)
 
 	ldb1 := pg.NewLockedDB(config, lggr)
@@ -83,7 +83,7 @@ func TestLockedDB_TwoInstances(t *testing.T) {
 
 func TestOpenUnlockedDB(t *testing.T) {
 	testutils.SkipShortDB(t)
-	config := cltest.NewTestGeneralConfig(t)
+	config := configtest.NewGeneralConfig(t, nil)
 	lggr := logger.TestLogger(t)
 
 	db1, err1 := pg.OpenUnlockedDB(config, lggr)

--- a/core/services/pipeline/task.eth_call_test.go
+++ b/core/services/pipeline/task.eth_call_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
-	"github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	evmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/mocks"
 	txmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/txmgr/mocks"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
@@ -258,8 +257,7 @@ func TestETHCallTask(t *testing.T) {
 
 			var cc evm.ChainSet
 			if test.expectedErrorCause != nil || test.expectedErrorContains != "" {
-				cc = evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: cfg,
-					Client: client.NewNullClient(big.NewInt(0), lggr), TxManager: txManager, KeyStore: keyStore})
+				cc = evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: cfg, TxManager: txManager, KeyStore: keyStore})
 			} else {
 				cc = cltest.NewChainSetMockWithOneChain(t, ethClient, evmtest.NewChainScopedConfig(t, cfg))
 			}

--- a/core/services/pipeline/task.eth_tx_test.go
+++ b/core/services/pipeline/task.eth_tx_test.go
@@ -1,7 +1,6 @@
 package pipeline_test
 
 import (
-	"math/big"
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -11,7 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 
-	"github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	txmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/txmgr/mocks"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
@@ -553,7 +551,6 @@ func TestETHTxTask(t *testing.T) {
 			lggr := logger.TestLogger(t)
 
 			cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: cfg,
-				Client:    client.NewNullClient(big.NewInt(0), lggr),
 				TxManager: txManager, KeyStore: keyStore})
 
 			test.setupClientMocks(keyStore, txManager)

--- a/core/services/promreporter/prom_reporter_test.go
+++ b/core/services/promreporter/prom_reporter_test.go
@@ -7,6 +7,7 @@ import (
 
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/services/promreporter"
 
 	"github.com/stretchr/testify/mock"
@@ -54,7 +55,7 @@ func Test_PromReporter_OnNewLongestChain(t *testing.T) {
 
 	t.Run("with unconfirmed eth_txes", func(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
-		cfg := cltest.NewTestGeneralConfig(t)
+		cfg := configtest.NewGeneralConfig(t, nil)
 		borm := cltest.NewTxmORM(t, db, cfg)
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 		_, fromAddress := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)

--- a/core/services/vrf/integration_v2_test.go
+++ b/core/services/vrf/integration_v2_test.go
@@ -45,6 +45,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest/heavyweight"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
@@ -1896,8 +1897,8 @@ func TestRequestCost(t *testing.T) {
 	carolContract := uni.consumerContracts[0]
 	carolContractAddress := uni.consumerContractAddresses[0]
 
-	cfg := cltest.NewTestGeneralConfig(t)
-	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, cfg, uni.backend, key)
+	cfg := configtest.NewGeneralConfigSimulated(t, nil)
+	app := cltest.NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(t, cfg, uni.backend, key)
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	vrfkey, err := app.GetKeyStore().VRF().Create()
@@ -1939,8 +1940,8 @@ func TestMaxConsumersCost(t *testing.T) {
 	carolContract := uni.consumerContracts[0]
 	carolContractAddress := uni.consumerContractAddresses[0]
 
-	cfg := cltest.NewTestGeneralConfig(t)
-	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, cfg, uni.backend, key)
+	cfg := configtest.NewGeneralConfigSimulated(t, nil)
+	app := cltest.NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(t, cfg, uni.backend, key)
 	require.NoError(t, app.Start(testutils.Context(t)))
 	_, err := carolContract.TestCreateSubscriptionAndFund(carol,
 		big.NewInt(1000000000000000000)) // 0.1 LINK
@@ -1974,8 +1975,8 @@ func TestFulfillmentCost(t *testing.T) {
 	carolContract := uni.consumerContracts[0]
 	carolContractAddress := uni.consumerContractAddresses[0]
 
-	cfg := cltest.NewTestGeneralConfig(t)
-	app := cltest.NewApplicationWithConfigAndKeyOnSimulatedBlockchain(t, cfg, uni.backend, key)
+	cfg := configtest.NewGeneralConfigSimulated(t, nil)
+	app := cltest.NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(t, cfg, uni.backend, key)
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	vrfkey, err := app.GetKeyStore().VRF().Create()

--- a/core/services/vrf/proof/proof_response_test.go
+++ b/core/services/vrf/proof/proof_response_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/solidity_vrf_verifier_wrapper"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	proof2 "github.com/smartcontractkit/chainlink/core/services/vrf/proof"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -22,7 +23,7 @@ import (
 
 func TestMarshaledProof(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewGeneralConfig(t, nil)
 	keyStore := cltest.NewKeyStore(t, db, cfg)
 	key := cltest.DefaultVRFKey
 	require.NoError(t, keyStore.VRF().Add(key))

--- a/core/services/webhook/authorizer_test.go
+++ b/core/services/webhook/authorizer_test.go
@@ -34,8 +34,7 @@ func (eiDisabledCfg) FeatureExternalInitiators() bool { return false }
 
 func Test_Authorizer(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
-	borm := newBridgeORM(t, db, cfg)
+	borm := newBridgeORM(t, db, pgtest.NewPGCfg(true))
 
 	eiFoo := cltest.MustInsertExternalInitiator(t, borm)
 	eiBar := cltest.MustInsertExternalInitiator(t, borm)

--- a/core/services/webhook/external_initiator_manager_test.go
+++ b/core/services/webhook/external_initiator_manager_test.go
@@ -22,7 +22,7 @@ import (
 
 func Test_ExternalInitiatorManager_Load(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := pgtest.NewPGCfg(true)
 	borm := newBridgeORM(t, db, cfg)
 
 	eiFoo := cltest.MustInsertExternalInitiator(t, borm)
@@ -58,7 +58,7 @@ func Test_ExternalInitiatorManager_Load(t *testing.T) {
 
 func Test_ExternalInitiatorManager_Notify(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := pgtest.NewPGCfg(true)
 	borm := newBridgeORM(t, db, cfg)
 
 	eiWithURL := cltest.MustInsertExternalInitiatorWithOpts(t, borm, cltest.ExternalInitiatorOpts{
@@ -97,7 +97,7 @@ func Test_ExternalInitiatorManager_Notify(t *testing.T) {
 
 func Test_ExternalInitiatorManager_DeleteJob(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := pgtest.NewPGCfg(true)
 	borm := newBridgeORM(t, db, cfg)
 
 	eiWithURL := cltest.MustInsertExternalInitiatorWithOpts(t, borm, cltest.ExternalInitiatorOpts{

--- a/core/sessions/orm_test.go
+++ b/core/sessions/orm_test.go
@@ -24,9 +24,8 @@ import (
 func setupORM(t *testing.T) (*sqlx.DB, sessions.ORM) {
 	t.Helper()
 
-	cfg := cltest.NewTestGeneralConfig(t)
 	db := pgtest.NewSqlxDB(t)
-	orm := sessions.NewORM(db, time.Minute, logger.TestLogger(t), cfg, &audit.AuditLoggerService{})
+	orm := sessions.NewORM(db, time.Minute, logger.TestLogger(t), pgtest.NewPGCfg(true), &audit.AuditLoggerService{})
 
 	return db, orm
 }
@@ -68,7 +67,7 @@ func TestORM_AuthorizedUserWithSession(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			db := pgtest.NewSqlxDB(t)
-			orm := sessions.NewORM(db, test.sessionDuration, logger.TestLogger(t), cltest.NewTestGeneralConfig(t), &audit.AuditLoggerService{})
+			orm := sessions.NewORM(db, test.sessionDuration, logger.TestLogger(t), pgtest.NewPGCfg(true), &audit.AuditLoggerService{})
 
 			user := cltest.MustNewUser(t, "have@email", cltest.Password)
 			require.NoError(t, orm.CreateUser(&user))

--- a/core/sessions/reaper_test.go
+++ b/core/sessions/reaper_test.go
@@ -33,8 +33,7 @@ func TestSessionReaper_ReapSessions(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
 	config := sessionReaperConfig{}
 	lggr := logger.TestLogger(t)
-	cfg := cltest.NewTestGeneralConfig(t)
-	orm := sessions.NewORM(db, config.SessionTimeout().Duration(), lggr, cfg, audit.NoopLogger)
+	orm := sessions.NewORM(db, config.SessionTimeout().Duration(), lggr, pgtest.NewPGCfg(true), audit.NoopLogger)
 
 	r := sessions.NewSessionReaper(db.DB, config, lggr)
 	defer r.Stop()

--- a/core/web/bridge_types_controller_test.go
+++ b/core/web/bridge_types_controller_test.go
@@ -115,7 +115,7 @@ func TestValidateBridgeNotExist(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := pgtest.NewPGCfg(true)
 	orm := bridges.NewORM(db, logger.TestLogger(t), cfg)
 
 	// Create a duplicate

--- a/core/web/eth_keys_controller_test.go
+++ b/core/web/eth_keys_controller_test.go
@@ -9,7 +9,9 @@ import (
 	evmMocks "github.com/smartcontractkit/chainlink/core/chains/evm/mocks"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
 	webpresenters "github.com/smartcontractkit/chainlink/core/web/presenters"
 
@@ -23,10 +25,11 @@ func TestETHKeysController_Index_Success(t *testing.T) {
 	t.Parallel()
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
-	cfg := cltest.NewTestGeneralConfig(t)
-	cfg.Overrides.Dev = null.BoolFrom(true)
-	cfg.Overrides.GlobalEvmNonceAutoSync = null.BoolFrom(false)
-	cfg.Overrides.GlobalBalanceMonitorEnabled = null.BoolFrom(false)
+	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.DevMode = false
+		c.EVM[0].NonceAutoSync = ptr(false)
+		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
+	})
 	app := cltest.NewApplicationWithConfig(t, cfg, ethClient)
 
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
@@ -75,11 +78,12 @@ func TestETHKeysController_Index_NotDev(t *testing.T) {
 	t.Parallel()
 
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
-	cfg := cltest.NewTestGeneralConfig(t)
-	cfg.Overrides.Dev = null.BoolFrom(false)
-	cfg.Overrides.GlobalEvmNonceAutoSync = null.BoolFrom(false)
-	cfg.Overrides.GlobalBalanceMonitorEnabled = null.BoolFrom(false)
-	cfg.Overrides.GlobalGasEstimatorMode = null.StringFrom("FixedPrice")
+
+	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].NonceAutoSync = ptr(false)
+		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
+		c.EVM[0].GasEstimator.Mode = ptr("FixedPrice")
+	})
 
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(256), nil).Once()
 	ethClient.On("GetLINKBalance", mock.Anything, mock.Anything, mock.Anything).Return(assets.NewLinkFromJuels(256), nil).Once()
@@ -128,8 +132,9 @@ func TestETHKeysController_Index_NoAccounts(t *testing.T) {
 func TestETHKeysController_CreateSuccess(t *testing.T) {
 	t.Parallel()
 
-	config := cltest.NewTestGeneralConfig(t)
-	config.Overrides.GlobalBalanceMonitorEnabled = null.BoolFrom(false)
+	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
+	})
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	app := cltest.NewApplicationWithConfigAndKey(t, config, ethClient)
 

--- a/core/web/evm_chains_controller_test.go
+++ b/core/web/evm_chains_controller_test.go
@@ -19,7 +19,7 @@ import (
 	corecfg "github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	configtest2 "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
@@ -114,8 +114,7 @@ func Test_EVMChainsController_Show(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			controller := setupEVMChainsControllerTest(t, configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-				cltest.TestOverrides(c, s)
+			controller := setupEVMChainsControllerTest(t, configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 				if tc.want != nil {
 					c.EVM = evmcfg.EVMConfigs{tc.want}
 				}
@@ -177,8 +176,7 @@ func Test_EVMChainsController_Index(t *testing.T) {
 		},
 	}
 
-	controller := setupEVMChainsControllerTest(t, configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-		cltest.TestOverrides(c, s)
+	controller := setupEVMChainsControllerTest(t, configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM = append(c.EVM, newChains...)
 	}))
 
@@ -414,7 +412,7 @@ func setupEVMChainsControllerTest(t *testing.T, cfg corecfg.GeneralConfig) *Test
 func setupEVMChainsControllerTestLegacy(t *testing.T) *TestEVMChainsController {
 	// Using this instead of `NewApplicationEVMDisabled` since we need the chain set to be loaded in the app
 	// for the sake of the API endpoints to work properly
-	app := cltest.NewLegacyApplication(t)
+	app := cltest.NewApplicationWithConfig(t, cltest.NewTestGeneralConfig(t))
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	client := app.NewHTTPClient(cltest.APIEmailAdmin)

--- a/core/web/evm_forwarders_controller_test.go
+++ b/core/web/evm_forwarders_controller_test.go
@@ -14,7 +14,7 @@ import (
 	evmcfg "github.com/smartcontractkit/chainlink/core/chains/evm/config/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	configtest2 "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/utils"
 	"github.com/smartcontractkit/chainlink/core/web"
@@ -29,10 +29,7 @@ type TestEVMForwardersController struct {
 func setupEVMForwardersControllerTest(t *testing.T, overrideFn func(c *chainlink.Config, s *chainlink.Secrets)) *TestEVMForwardersController {
 	// Using this instead of `NewApplicationEVMDisabled` since we need the chain set to be loaded in the app
 	// for the sake of the API endpoints to work properly
-	app := cltest.NewApplicationWithConfig(t, configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-		cltest.TestOverrides(c, s)
-		overrideFn(c, s)
-	}))
+	app := cltest.NewApplicationWithConfig(t, configtest.NewGeneralConfig(t, overrideFn))
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	client := app.NewHTTPClient(cltest.APIEmailAdmin)

--- a/core/web/external_initiators_controller_test.go
+++ b/core/web/external_initiators_controller_test.go
@@ -24,7 +24,7 @@ func TestValidateExternalInitiator(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := pgtest.NewPGCfg(true)
 	orm := bridges.NewORM(db, logger.TestLogger(t), cfg)
 
 	url := cltest.WebURL(t, "https://a.web.url")

--- a/core/web/features_controller_test.go
+++ b/core/web/features_controller_test.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	configtest2 "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/web"
 	"github.com/smartcontractkit/chainlink/core/web/presenters"
@@ -16,8 +16,7 @@ import (
 )
 
 func Test_FeaturesController_List(t *testing.T) {
-	app := cltest.NewApplicationWithConfig(t, configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-		cltest.TestOverrides(c, s)
+	app := cltest.NewApplicationWithConfig(t, configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		csa := true
 		c.Feature.UICSAKeys = &csa
 	}))

--- a/core/web/resolver/config_test.go
+++ b/core/web/resolver/config_test.go
@@ -97,7 +97,6 @@ func TestResolver_Config(t *testing.T) {
 					P2PBootstrapPeers:                    nil,
 					P2PListenPort:                        null.IntFrom(1),
 					P2PPeerID:                            "",
-					P2PPeerIDError:                       nil,
 					TriggerFallbackDBPollInterval:        nil,
 				})
 				cfg.SetRootDir("/tmp/chainlink_test/gql-test")

--- a/core/web/terra_chains_controller_test.go
+++ b/core/web/terra_chains_controller_test.go
@@ -12,20 +12,26 @@ import (
 
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/pkg/errors"
-	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 
+	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	tercfg "github.com/smartcontractkit/chainlink-terra/pkg/terra/config"
 	"github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
 
+	"github.com/smartcontractkit/chainlink/core/chains/terra"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/terratest"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/web"
 	"github.com/smartcontractkit/chainlink/core/web/presenters"
 )
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func Test_TerraChainsController_Create(t *testing.T) {
 	t.Parallel()
 
@@ -81,17 +87,14 @@ func Test_TerraChainsController_Show(t *testing.T) {
 			inputId: validId,
 			name:    "success",
 			want: func(t *testing.T, app *cltest.TestApplication) *db.Chain {
-				newChainConfig := db.ChainCfg{
-					FallbackGasPriceULuna: null.StringFrom("9.999"),
-					GasLimitMultiplier:    null.FloatFrom(1.55555),
-				}
-
 				chain := db.Chain{
 					ID:      validId,
 					Enabled: true,
-					Cfg:     newChainConfig,
+					Cfg: db.ChainCfg{
+						FallbackGasPriceULuna: null.StringFrom("9.999"),
+						GasLimitMultiplier:    null.FloatFrom(1.55555),
+					},
 				}
-				terratest.MustInsertChain(t, app.GetSqlxDB(), &chain)
 
 				return &chain
 			},
@@ -113,7 +116,11 @@ func Test_TerraChainsController_Show(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			controller := setupTerraChainsControllerTest(t)
+			controller := setupTerraChainsControllerTestV2(t, &terra.TerraConfig{ChainID: ptr(validId), Enabled: ptr(true),
+				Chain: tercfg.Chain{
+					FallbackGasPriceULuna: ptr(decimal.RequireFromString("9.999")),
+					GasLimitMultiplier:    ptr(decimal.RequireFromString("1.55555")),
+				}})
 
 			wantedResult := tc.want(t, controller.app)
 			resp, cleanup := controller.client.Get(
@@ -138,31 +145,21 @@ func Test_TerraChainsController_Show(t *testing.T) {
 func Test_TerraChainsController_Index(t *testing.T) {
 	t.Parallel()
 
-	controller := setupTerraChainsControllerTest(t)
-
-	newChains := []web.CreateChainRequest[string, *db.ChainCfg]{
-		{
-			ID: fmt.Sprintf("ChainlinktestA-%d", rand.Int31n(999999)),
-			Config: &db.ChainCfg{
-				FallbackGasPriceULuna: null.StringFrom("9.999"),
-			},
-		},
-		{
-			ID: fmt.Sprintf("ChainlinktestB-%d", rand.Int31n(999999)),
-			Config: &db.ChainCfg{
-				GasLimitMultiplier: null.FloatFrom(1.55555),
-			},
+	chainA := &terra.TerraConfig{
+		ChainID: ptr(fmt.Sprintf("ChainlinktestA-%d", rand.Int31n(999999))),
+		Enabled: ptr(true),
+		Chain: tercfg.Chain{
+			FallbackGasPriceULuna: ptr(decimal.RequireFromString("9.999")),
 		},
 	}
-
-	for _, newChain := range newChains {
-		ch := newChain
-		terratest.MustInsertChain(t, controller.app.GetSqlxDB(), &db.Chain{
-			ID:      ch.ID,
-			Enabled: true,
-			Cfg:     *ch.Config,
-		})
+	chainB := &terra.TerraConfig{
+		ChainID: ptr(fmt.Sprintf("ChainlinktestB-%d", rand.Int31n(999999))),
+		Enabled: ptr(true),
+		Chain: tercfg.Chain{
+			GasLimitMultiplier: ptr(decimal.RequireFromString("1.55555")),
+		},
 	}
+	controller := setupTerraChainsControllerTestV2(t, chainA, chainB)
 
 	badResp, cleanup := controller.client.Get("/v2/chains/terra?size=asd")
 	t.Cleanup(cleanup)
@@ -176,20 +173,20 @@ func Test_TerraChainsController_Index(t *testing.T) {
 
 	metaCount, err := cltest.ParseJSONAPIResponseMetaCount(body)
 	require.NoError(t, err)
-	require.Equal(t, len(newChains), metaCount)
+	require.Equal(t, 2, metaCount)
 
 	var links jsonapi.Links
 
-	chains := []presenters.TerraChainResource{}
+	var chains []presenters.TerraChainResource
 	err = web.ParsePaginatedResponse(body, &chains, &links)
 	assert.NoError(t, err)
 	assert.NotEmpty(t, links["next"].Href)
 	assert.Empty(t, links["prev"].Href)
 
 	assert.Len(t, links, 1)
-	assert.Equal(t, newChains[0].ID, chains[0].ID)
-	assert.Equal(t, newChains[0].Config.FallbackGasPriceULuna, chains[0].Config.FallbackGasPriceULuna)
-	assert.Equal(t, newChains[0].Config.GasLimitMultiplier, chains[0].Config.GasLimitMultiplier)
+	assert.Equal(t, *chainA.ChainID, chains[0].ID)
+	assert.Equal(t, chainA.Chain.FallbackGasPriceULuna.String(), chains[0].Config.FallbackGasPriceULuna.String)
+	assert.Equal(t, chainA.Chain.GasLimitMultiplier.InexactFloat64(), chains[0].Config.GasLimitMultiplier.Float64)
 
 	resp, cleanup = controller.client.Get(links["next"].Href)
 	t.Cleanup(cleanup)
@@ -202,11 +199,12 @@ func Test_TerraChainsController_Index(t *testing.T) {
 	assert.NotEmpty(t, links["prev"].Href)
 
 	assert.Len(t, links, 1)
-	assert.Equal(t, newChains[1].ID, chains[0].ID)
-	assert.Equal(t, newChains[1].Config.FallbackGasPriceULuna, chains[0].Config.FallbackGasPriceULuna)
-	assert.Equal(t, newChains[1].Config.GasLimitMultiplier, chains[0].Config.GasLimitMultiplier)
+	assert.Equal(t, *chainB.ChainID, chains[0].ID)
+	assert.Equal(t, chainB.Chain.FallbackGasPriceULuna.String(), chains[0].Config.FallbackGasPriceULuna.String)
+	assert.Equal(t, chainB.Chain.GasLimitMultiplier.InexactFloat64(), chains[0].Config.GasLimitMultiplier.Float64)
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func Test_TerraChainsController_Update(t *testing.T) {
 	t.Parallel()
 
@@ -290,6 +288,7 @@ func Test_TerraChainsController_Update(t *testing.T) {
 	}
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func Test_TerraChainsController_Delete(t *testing.T) {
 	t.Parallel()
 
@@ -345,11 +344,31 @@ type TestTerraChainsController struct {
 	client cltest.HTTPClientCleaner
 }
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func setupTerraChainsControllerTest(t *testing.T) *TestTerraChainsController {
 	cfg := cltest.NewTestGeneralConfig(t)
 	cfg.Overrides.TerraEnabled = null.BoolFrom(true)
 	cfg.Overrides.EVMEnabled = null.BoolFrom(false)
 	cfg.Overrides.EVMRPCEnabled = null.BoolFrom(false)
+	app := cltest.NewApplicationWithConfig(t, cfg)
+	require.NoError(t, app.Start(testutils.Context(t)))
+
+	client := app.NewHTTPClient(cltest.APIEmailAdmin)
+
+	return &TestTerraChainsController{
+		app:    app,
+		client: client,
+	}
+}
+
+func setupTerraChainsControllerTestV2(t *testing.T, cfgs ...*terra.TerraConfig) *TestTerraChainsController {
+	for i := range cfgs {
+		cfgs[i].SetDefaults()
+	}
+	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.Terra = cfgs
+		c.EVM = nil
+	})
 	app := cltest.NewApplicationWithConfig(t, cfg)
 	require.NoError(t, app.Start(testutils.Context(t)))
 


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/46224/convert-replace-uses-of-testgeneralconfig-generalconfigoverrides-to-new-config-types
- [x] convert more tests to new config
- [x] move some helpers from `package cltest` to `configtest/v2` to reduce imports
- [x] combine defaults sets in to one to reduce API surface?