### PR TITLE
move P2P PeerID from V1 to shared

### DIFF
--- a/core/config/v2/docs/core.toml
+++ b/core/config/v2/docs/core.toml
@@ -324,6 +324,8 @@ IncomingMessageBufferSize = 10 # Default
 # IncomingMessageBufferSize to give the remote enough space to process
 # them all in case we regained connection and now send a bunch at once
 OutgoingMessageBufferSize = 10 # Default
+# PeerID is the default peer ID to use for OCR jobs. If unspecified, uses the first available peer ID.
+PeerID = '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw' # Example
 # TraceLogging enables trace level logging.
 TraceLogging = false # Default
 
@@ -366,8 +368,6 @@ ListenPort = 1337 # Example
 # it can't get a connection, but it is here anyway as a failsafe.
 # Set to 0 to disable any timeout on top of what libp2p gives us by default.
 NewStreamTimeout = '10s' # Default
-# PeerID is the default peer ID to use for OCR jobs. If unspecified, uses the first available peer ID.
-PeerID = '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw' # Example
 # **ADVANCED**
 # PeerstoreWriteInterval controls how often the peerstore for the OCR V1 networking stack is persisted to the database.
 PeerstoreWriteInterval = '5m' # Default

--- a/core/config/v2/types.go
+++ b/core/config/v2/types.go
@@ -763,9 +763,9 @@ func (o *OCR) setFrom(f *OCR) {
 }
 
 type P2P struct {
-	// V1 and V2
 	IncomingMessageBufferSize *int64
 	OutgoingMessageBufferSize *int64
+	PeerID                    *p2pkey.PeerID
 	TraceLogging              *bool
 
 	V1 *P2PV1
@@ -792,6 +792,9 @@ func (p *P2P) setFrom(f *P2P) {
 	}
 	if v := f.OutgoingMessageBufferSize; v != nil {
 		p.OutgoingMessageBufferSize = v
+	}
+	if v := f.PeerID; v != nil {
+		p.PeerID = v
 	}
 	if v := f.TraceLogging; v != nil {
 		p.TraceLogging = v
@@ -821,7 +824,6 @@ type P2PV1 struct {
 	ListenIP                         *net.IP
 	ListenPort                       *uint16
 	NewStreamTimeout                 *models.Duration
-	PeerID                           *p2pkey.PeerID
 	PeerstoreWriteInterval           *models.Duration
 }
 
@@ -863,9 +865,6 @@ func (p *P2PV1) setFrom(f *P2PV1) {
 	}
 	if v := f.NewStreamTimeout; v != nil {
 		p.NewStreamTimeout = v
-	}
-	if v := f.PeerID; v != nil {
-		p.PeerID = v
 	}
 	if v := f.PeerstoreWriteInterval; v != nil {
 		p.PeerstoreWriteInterval = v

--- a/core/services/chainlink/cfgtest/dump/full-custom.toml
+++ b/core/services/chainlink/cfgtest/dump/full-custom.toml
@@ -122,6 +122,7 @@ TransmitterAddress = '0xa0788FC17B1dEe36f057c42B6F373A34B014687e'
 [P2P]
 IncomingMessageBufferSize = 747
 OutgoingMessageBufferSize = 42
+PeerID = '12D3KooWMk13oppZXmGdRZgaJBFDF6Tc5521YYxKjwkscLSEPrVW'
 TraceLogging = true
 
 [P2P.V1]
@@ -135,7 +136,6 @@ DHTLookupInterval = 6
 ListenIP = '4.3.2.1'
 ListenPort = 4242
 NewStreamTimeout = '1m0s'
-PeerID = '12D3KooWMk13oppZXmGdRZgaJBFDF6Tc5521YYxKjwkscLSEPrVW'
 PeerstoreWriteInterval = '10m0s'
 
 [P2P.V2]

--- a/core/services/chainlink/config_dump.go
+++ b/core/services/chainlink/config_dump.go
@@ -856,6 +856,7 @@ func (c *Config) loadLegacyCoreEnv() {
 	c.P2P = &config.P2P{
 		IncomingMessageBufferSize: first(envvar.NewInt64("OCRIncomingMessageBufferSize"), envvar.NewInt64("P2PIncomingMessageBufferSize")),
 		OutgoingMessageBufferSize: first(envvar.NewInt64("OCROutgoingMessageBufferSize"), envvar.NewInt64("P2POutgoingMessageBufferSize")),
+		PeerID:                    envvar.New("P2PPeerID", p2pkey.MakePeerID).ParsePtr(),
 		TraceLogging:              envvar.NewBool("OCRTraceLogging").ParsePtr(),
 	}
 	p := envvar.New("P2PNetworkingStack", func(s string) (ns ocrnetworking.NetworkingStack, err error) {
@@ -880,7 +881,6 @@ func (c *Config) loadLegacyCoreEnv() {
 			ListenIP:                         envIP("P2PListenIP"),
 			ListenPort:                       envvar.NewUint16("P2PListenPort").ParsePtr(),
 			NewStreamTimeout:                 envDuration("OCRNewStreamTimeout", "P2PNewStreamTimeout"),
-			PeerID:                           envvar.New("P2PPeerID", p2pkey.MakePeerID).ParsePtr(),
 			PeerstoreWriteInterval:           envDuration("P2PPeerstoreWriteInterval"),
 		}
 	}

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -674,11 +674,11 @@ func (g *generalConfig) P2PNetworkingStackRaw() string {
 }
 
 func (g *generalConfig) P2PPeerID() p2pkey.PeerID {
-	return *g.c.P2P.V1.PeerID
+	return *g.c.P2P.PeerID
 }
 
 func (g *generalConfig) P2PPeerIDRaw() string {
-	return g.c.P2P.V1.PeerID.String()
+	return g.c.P2P.PeerID.String()
 }
 
 func (g *generalConfig) P2PIncomingMessageBufferSize() int {

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -353,6 +353,7 @@ func TestConfig_Marshal(t *testing.T) {
 	full.P2P = &config.P2P{
 		IncomingMessageBufferSize: ptr[int64](13),
 		OutgoingMessageBufferSize: ptr[int64](17),
+		PeerID:                    mustPeerID("12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw"),
 		TraceLogging:              ptr(true),
 		V1: &config.P2PV1{
 			Enabled:                          ptr(false),
@@ -365,7 +366,6 @@ func TestConfig_Marshal(t *testing.T) {
 			ListenIP:                         mustIP("4.3.2.1"),
 			ListenPort:                       ptr[uint16](9),
 			NewStreamTimeout:                 models.MustNewDuration(time.Second),
-			PeerID:                           mustPeerID("12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw"),
 			PeerstoreWriteInterval:           models.MustNewDuration(time.Minute),
 		},
 		V2: &config.P2PV2{
@@ -734,6 +734,7 @@ KeyBundleID = '7a5f66bbe6594259325bf2b4f5b1a9c900000000000000000000000000000000'
 		{"P2P", Config{Core: config.Core{P2P: full.P2P}}, `[P2P]
 IncomingMessageBufferSize = 13
 OutgoingMessageBufferSize = 17
+PeerID = '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw'
 TraceLogging = true
 
 [P2P.V1]
@@ -747,7 +748,6 @@ DHTLookupInterval = 9
 ListenIP = '4.3.2.1'
 ListenPort = 9
 NewStreamTimeout = '1s'
-PeerID = '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw'
 PeerstoreWriteInterval = '1m0s'
 
 [P2P.V2]

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -124,6 +124,7 @@ TransmitterAddress = ''
 [P2P]
 IncomingMessageBufferSize = 10
 OutgoingMessageBufferSize = 10
+PeerID = ''
 TraceLogging = false
 
 [P2P.V1]
@@ -137,7 +138,6 @@ DHTLookupInterval = 10
 ListenIP = '0.0.0.0'
 ListenPort = 0
 NewStreamTimeout = '10s'
-PeerID = ''
 PeerstoreWriteInterval = '5m0s'
 
 [P2P.V2]

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -124,6 +124,7 @@ TransmitterAddress = '0xa0788FC17B1dEe36f057c42B6F373A34B014687e'
 [P2P]
 IncomingMessageBufferSize = 13
 OutgoingMessageBufferSize = 17
+PeerID = '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw'
 TraceLogging = true
 
 [P2P.V1]
@@ -137,7 +138,6 @@ DHTLookupInterval = 9
 ListenIP = '4.3.2.1'
 ListenPort = 9
 NewStreamTimeout = '1s'
-PeerID = '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw'
 PeerstoreWriteInterval = '1m0s'
 
 [P2P.V2]

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -124,6 +124,7 @@ TransmitterAddress = ''
 [P2P]
 IncomingMessageBufferSize = 999
 OutgoingMessageBufferSize = 10
+PeerID = ''
 TraceLogging = false
 
 [P2P.V1]
@@ -137,7 +138,6 @@ DHTLookupInterval = 10
 ListenIP = '0.0.0.0'
 ListenPort = 0
 NewStreamTimeout = '10s'
-PeerID = ''
 PeerstoreWriteInterval = '5m0s'
 
 [P2P.V2]

--- a/core/services/ocrcommon/peer_wrapper_test.go
+++ b/core/services/ocrcommon/peer_wrapper_test.go
@@ -48,7 +48,7 @@ func Test_SingletonPeerWrapper_Start(t *testing.T) {
 
 		cfg = configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 			c.P2P.V1.Enabled = ptr(true)
-			c.P2P.V1.PeerID = ptr(k.PeerID())
+			c.P2P.PeerID = ptr(k.PeerID())
 		})
 		keyStore = cltest.NewKeyStore(t, db, cfg)
 
@@ -61,7 +61,7 @@ func Test_SingletonPeerWrapper_Start(t *testing.T) {
 	t.Run("with one p2p key and mismatching P2P_PEER_ID returns error", func(t *testing.T) {
 		cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 			c.P2P.V1.Enabled = ptr(true)
-			c.P2P.V1.PeerID = ptr(p2pkey.PeerID(peerID))
+			c.P2P.PeerID = ptr(p2pkey.PeerID(peerID))
 		})
 		keyStore := cltest.NewKeyStore(t, db, cfg)
 
@@ -80,7 +80,7 @@ func Test_SingletonPeerWrapper_Start(t *testing.T) {
 
 		cfg = configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 			c.P2P.V1.Enabled = ptr(true)
-			c.P2P.V1.PeerID = ptr(k2.PeerID())
+			c.P2P.PeerID = ptr(k2.PeerID())
 		})
 		keyStore = cltest.NewKeyStore(t, db, cfg)
 
@@ -93,7 +93,7 @@ func Test_SingletonPeerWrapper_Start(t *testing.T) {
 	t.Run("with multiple p2p keys and mismatching P2P_PEER_ID returns error", func(t *testing.T) {
 		cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 			c.P2P.V1.Enabled = ptr(true)
-			c.P2P.V1.PeerID = ptr(p2pkey.PeerID(peerID))
+			c.P2P.PeerID = ptr(p2pkey.PeerID(peerID))
 		})
 		keyStore := cltest.NewKeyStore(t, db, cfg)
 
@@ -117,7 +117,7 @@ func Test_SingletonPeerWrapper_Close(t *testing.T) {
 
 	cfg = configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.P2P.V2.Enabled = ptr(true)
-		c.P2P.V1.PeerID = ptr(k.PeerID())
+		c.P2P.PeerID = ptr(k.PeerID())
 		c.P2P.V2.DeltaDial = models.MustNewDuration(100 * time.Millisecond)
 		c.P2P.V2.DeltaReconcile = models.MustNewDuration(1 * time.Second)
 		c.P2P.V1.ListenPort = ptr[uint16](0)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -860,6 +860,7 @@ TransmitterAddress is the default sending address to use for OCR. If you have an
 [P2P]
 IncomingMessageBufferSize = 10 # Default
 OutgoingMessageBufferSize = 10 # Default
+PeerID = '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw' # Example
 TraceLogging = false # Default
 ```
 P2P supports multiple networking stack versions. You may configure `[P2P.V1]`, `[P2P.V2]`, or both to run simultaneously.
@@ -888,6 +889,12 @@ NOTE: OutgoingMessageBufferSize should be comfortably smaller than remote's
 IncomingMessageBufferSize to give the remote enough space to process
 them all in case we regained connection and now send a bunch at once
 
+### PeerID<a id='P2P-PeerID'></a>
+```toml
+PeerID = '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw' # Example
+```
+PeerID is the default peer ID to use for OCR jobs. If unspecified, uses the first available peer ID.
+
 ### TraceLogging<a id='P2P-TraceLogging'></a>
 ```toml
 TraceLogging = false # Default
@@ -907,7 +914,6 @@ DHTLookupInterval = 10 # Default
 ListenIP = '0.0.0.0' # Default
 ListenPort = 1337 # Example
 NewStreamTimeout = '10s' # Default
-PeerID = '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw' # Example
 PeerstoreWriteInterval = '5m' # Default
 ```
 
@@ -989,12 +995,6 @@ stream before we give up.
 We shouldn't hit this in practice since libp2p will give up fast if
 it can't get a connection, but it is here anyway as a failsafe.
 Set to 0 to disable any timeout on top of what libp2p gives us by default.
-
-### PeerID<a id='P2P-V1-PeerID'></a>
-```toml
-PeerID = '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw' # Example
-```
-PeerID is the default peer ID to use for OCR jobs. If unspecified, uses the first available peer ID.
 
 ### PeerstoreWriteInterval<a id='P2P-V1-PeerstoreWriteInterval'></a>
 :warning: **_ADVANCED_**: _Do not change this setting unless you know what you are doing._


### PR DESCRIPTION
Based on usage, it looks like `PeerID` should be shared, rather than `V1` specific.