### PR TITLE
use omitempty and drop pointers to reduce boilerplate

### DIFF
--- a/core/chains/evm/config/config_test.go
+++ b/core/chains/evm/config/config_test.go
@@ -278,7 +278,7 @@ func Test_chainScopedConfig_Validate(t *testing.T) {
 		t.Run("custom", func(t *testing.T) {
 			cfg := configWithChain(t, 0, &v2.Chain{
 				ChainType: ptr(string(config.ChainArbitrum)),
-				GasEstimator: &v2.GasEstimator{
+				GasEstimator: v2.GasEstimator{
 					Mode: ptr("BlockHistory"),
 				},
 			})
@@ -286,9 +286,9 @@ func Test_chainScopedConfig_Validate(t *testing.T) {
 		})
 		t.Run("mainnet", func(t *testing.T) {
 			cfg := configWithChain(t, 42161, &v2.Chain{
-				GasEstimator: &v2.GasEstimator{
+				GasEstimator: v2.GasEstimator{
 					Mode: ptr("BlockHistory"),
-					BlockHistory: &v2.BlockHistoryEstimator{
+					BlockHistory: v2.BlockHistoryEstimator{
 						BlockHistorySize: ptr[uint16](1),
 					},
 				},
@@ -297,7 +297,7 @@ func Test_chainScopedConfig_Validate(t *testing.T) {
 		})
 		t.Run("testnet", func(t *testing.T) {
 			cfg := configWithChain(t, 421611, &v2.Chain{
-				GasEstimator: &v2.GasEstimator{
+				GasEstimator: v2.GasEstimator{
 					Mode: ptr("L2Suggested"),
 				},
 			})
@@ -309,7 +309,7 @@ func Test_chainScopedConfig_Validate(t *testing.T) {
 		t.Run("custom", func(t *testing.T) {
 			cfg := configWithChain(t, 0, &v2.Chain{
 				ChainType: ptr(string(config.ChainOptimism)),
-				GasEstimator: &v2.GasEstimator{
+				GasEstimator: v2.GasEstimator{
 					Mode: ptr("BlockHistory"),
 				},
 			})
@@ -317,7 +317,7 @@ func Test_chainScopedConfig_Validate(t *testing.T) {
 		})
 		t.Run("mainnet", func(t *testing.T) {
 			cfg := configWithChain(t, 10, &v2.Chain{
-				GasEstimator: &v2.GasEstimator{
+				GasEstimator: v2.GasEstimator{
 					Mode: ptr("FixedPrice"),
 				},
 			})
@@ -325,7 +325,7 @@ func Test_chainScopedConfig_Validate(t *testing.T) {
 		})
 		t.Run("testnet", func(t *testing.T) {
 			cfg := configWithChain(t, 69, &v2.Chain{
-				GasEstimator: &v2.GasEstimator{
+				GasEstimator: v2.GasEstimator{
 					Mode: ptr("BlockHistory"),
 				},
 			})

--- a/core/chains/evm/config/v2/config.go
+++ b/core/chains/evm/config/v2/config.go
@@ -164,9 +164,6 @@ type EVMConfig struct {
 	Nodes EVMNodes
 }
 
-// Ensure that the embedded struct will be validated (w/o requiring a pointer receiver).
-var _ v2.Validated = Chain{}
-
 func (c *EVMConfig) SetFromDB(ch types.DBChain, nodes []types.Node) error {
 	c.ChainID = &ch.ID
 	c.Enabled = &ch.Enabled
@@ -224,6 +221,8 @@ func (c *EVMConfig) ValidateConfig() (err error) {
 		}
 	}
 
+	err = multierr.Append(err, c.Chain.ValidateConfig())
+
 	return
 }
 
@@ -245,24 +244,17 @@ type Chain struct {
 	RPCDefaultBatchSize      *uint32
 	RPCBlockQueryDelay       *uint16
 
-	Transactions *Transactions
-
-	BalanceMonitor *BalanceMonitor
-
-	GasEstimator *GasEstimator
-
-	HeadTracker *HeadTracker
-
-	KeySpecific KeySpecificConfig `toml:",omitempty"`
-
-	NodePool *NodePool
-
-	OCR *OCR
-
-	OCR2 *OCR2
+	Transactions   Transactions      `toml:",omitempty"`
+	BalanceMonitor BalanceMonitor    `toml:",omitempty"`
+	GasEstimator   GasEstimator      `toml:",omitempty"`
+	HeadTracker    HeadTracker       `toml:",omitempty"`
+	KeySpecific    KeySpecificConfig `toml:",omitempty"`
+	NodePool       NodePool          `toml:",omitempty"`
+	OCR            OCR               `toml:",omitempty"`
+	OCR2           OCR2              `toml:",omitempty"`
 }
 
-func (c Chain) ValidateConfig() (err error) {
+func (c *Chain) ValidateConfig() (err error) {
 	var chainType config.ChainType
 	if c.ChainType != nil {
 		chainType = config.ChainType(*c.ChainType)
@@ -414,16 +406,11 @@ func (t *Transactions) setFrom(f *Transactions) {
 }
 
 type OCR2 struct {
-	Automation *Automation
+	Automation Automation `toml:",omitempty"`
 }
 
 func (o *OCR2) setFrom(f *OCR2) {
-	if f.Automation != nil {
-		if o.Automation == nil {
-			o.Automation = &Automation{}
-		}
-		o.Automation.setFrom(f.Automation)
-	}
+	o.Automation.setFrom(&f.Automation)
 }
 
 type Automation struct {
@@ -470,7 +457,7 @@ type GasEstimator struct {
 	TipCapDefault *assets.Wei
 	TipCapMin     *assets.Wei
 
-	BlockHistory *BlockHistoryEstimator
+	BlockHistory BlockHistoryEstimator `toml:",omitempty"`
 }
 
 func (e *GasEstimator) ValidateConfig() (err error) {
@@ -561,12 +548,7 @@ func (e *GasEstimator) setFrom(f *GasEstimator) {
 		e.PriceMin = v
 	}
 	e.LimitJobType.setFrom(&f.LimitJobType)
-	if f.BlockHistory != nil {
-		if e.BlockHistory == nil {
-			e.BlockHistory = &BlockHistoryEstimator{}
-		}
-		e.BlockHistory.setFrom(f.BlockHistory)
-	}
+	e.BlockHistory.setFrom(&f.BlockHistory)
 }
 
 type GasLimitJobType struct {
@@ -642,11 +624,17 @@ func (ks KeySpecificConfig) ValidateConfig() (err error) {
 
 type KeySpecific struct {
 	Key          *ethkey.EIP55Address
-	GasEstimator *KeySpecificGasEstimator
+	GasEstimator KeySpecificGasEstimator `toml:",omitempty"`
 }
 
 type KeySpecificGasEstimator struct {
 	PriceMax *assets.Wei
+}
+
+func (e *KeySpecificGasEstimator) setFrom(f *KeySpecificGasEstimator) {
+	if v := f.PriceMax; v != nil {
+		e.PriceMax = v
+	}
 }
 
 type HeadTracker struct {
@@ -715,15 +703,9 @@ func (c *Chain) SetFromDB(cfg *types.ChainCfg) error {
 		c.ChainType = &cfg.ChainType.String
 	}
 	if cfg.EthTxReaperThreshold != nil {
-		if c.Transactions == nil {
-			c.Transactions = &Transactions{}
-		}
 		c.Transactions.ReaperThreshold = cfg.EthTxReaperThreshold
 	}
 	if cfg.EthTxResendAfterThreshold != nil {
-		if c.Transactions == nil {
-			c.Transactions = &Transactions{}
-		}
 		c.Transactions.ResendAfterThreshold = cfg.EthTxResendAfterThreshold
 	}
 	if cfg.EvmFinalityDepth.Valid {
@@ -731,23 +713,14 @@ func (c *Chain) SetFromDB(cfg *types.ChainCfg) error {
 		c.FinalityDepth = &v
 	}
 	if cfg.EvmHeadTrackerHistoryDepth.Valid {
-		if c.HeadTracker == nil {
-			c.HeadTracker = &HeadTracker{}
-		}
 		v := uint32(cfg.EvmHeadTrackerHistoryDepth.Int64)
 		c.HeadTracker.HistoryDepth = &v
 	}
 	if cfg.EvmHeadTrackerMaxBufferSize.Valid {
-		if c.HeadTracker == nil {
-			c.HeadTracker = &HeadTracker{}
-		}
 		v := uint32(cfg.EvmHeadTrackerMaxBufferSize.Int64)
 		c.HeadTracker.MaxBufferSize = &v
 	}
 	if i := cfg.EvmHeadTrackerSamplingInterval; i != nil {
-		if c.HeadTracker == nil {
-			c.HeadTracker = &HeadTracker{}
-		}
 		c.HeadTracker.SamplingInterval = cfg.EvmHeadTrackerSamplingInterval
 	}
 	if cfg.EvmLogBackfillBatchSize.Valid {
@@ -759,9 +732,6 @@ func (c *Chain) SetFromDB(cfg *types.ChainCfg) error {
 		c.NonceAutoSync = &cfg.EvmNonceAutoSync.Bool
 	}
 	if cfg.EvmUseForwarders.Valid {
-		if c.Transactions == nil {
-			c.Transactions = &Transactions{}
-		}
 		c.Transactions.ForwardersEnabled = &cfg.EvmUseForwarders.Bool
 	}
 	if cfg.EvmRPCDefaultBatchSize.Valid {
@@ -782,27 +752,15 @@ func (c *Chain) SetFromDB(cfg *types.ChainCfg) error {
 		c.FlagsContractAddress = &v
 	}
 	if cfg.GasEstimatorMode.Valid {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		c.GasEstimator.Mode = &cfg.GasEstimatorMode.String
 	}
 	if cfg.EvmMaxGasPriceWei != nil {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		c.GasEstimator.PriceMax = cfg.EvmMaxGasPriceWei
 	}
 	if cfg.EvmEIP1559DynamicFees.Valid {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		c.GasEstimator.EIP1559DynamicFees = &cfg.EvmEIP1559DynamicFees.Bool
 	}
 	if cfg.EvmGasPriceDefault != nil {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		c.GasEstimator.PriceDefault = cfg.EvmGasPriceDefault
 	}
 	if cfg.EvmGasLimitMultiplier.Valid {
@@ -810,98 +768,55 @@ func (c *Chain) SetFromDB(cfg *types.ChainCfg) error {
 		c.GasEstimator.LimitMultiplier = &v
 	}
 	if cfg.EvmGasTipCapDefault != nil {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		c.GasEstimator.TipCapDefault = cfg.EvmGasTipCapDefault
 	}
 	if cfg.EvmGasTipCapMinimum != nil {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		c.GasEstimator.TipCapMin = cfg.EvmGasTipCapMinimum
 	}
 	if cfg.EvmGasBumpPercent.Valid {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		v := uint16(cfg.EvmGasBumpPercent.Int64)
 		c.GasEstimator.BumpPercent = &v
 	}
 	if cfg.EvmGasBumpTxDepth.Valid {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		v := uint16(cfg.EvmGasBumpTxDepth.Int64)
 		c.GasEstimator.BumpTxDepth = &v
 	}
 	if cfg.EvmGasBumpWei != nil {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		c.GasEstimator.BumpMin = cfg.EvmGasBumpWei
 	}
 	if cfg.EvmGasFeeCapDefault != nil {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		c.GasEstimator.FeeCapDefault = cfg.EvmGasFeeCapDefault
 	}
 	if cfg.EvmGasLimitDefault.Valid {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		v := uint32(cfg.EvmGasLimitDefault.Int64)
 		c.GasEstimator.LimitDefault = &v
 	}
 	if cfg.EvmGasLimitMax.Valid {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		v := uint32(cfg.EvmGasLimitMax.Int64)
 		c.GasEstimator.LimitMax = &v
 	}
 	if cfg.EvmGasLimitOCRJobType.Valid {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		v := uint32(cfg.EvmGasLimitOCRJobType.Int64)
 		c.GasEstimator.LimitJobType.OCR = &v
 	}
 	if cfg.EvmGasLimitDRJobType.Valid {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		v := uint32(cfg.EvmGasLimitDRJobType.Int64)
 		c.GasEstimator.LimitJobType.DR = &v
 	}
 	if cfg.EvmGasLimitVRFJobType.Valid {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		v := uint32(cfg.EvmGasLimitVRFJobType.Int64)
 		c.GasEstimator.LimitJobType.VRF = &v
 	}
 	if cfg.EvmGasLimitFMJobType.Valid {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		v := uint32(cfg.EvmGasLimitFMJobType.Int64)
 		c.GasEstimator.LimitJobType.FM = &v
 	}
 	if cfg.EvmGasLimitKeeperJobType.Valid {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
 		v := uint32(cfg.EvmGasLimitKeeperJobType.Int64)
 		c.GasEstimator.LimitJobType.Keeper = &v
 	}
 
 	if cfg.BlockHistoryEstimatorBlockHistorySize.Valid || cfg.BlockHistoryEstimatorEIP1559FeeCapBufferBlocks.Valid {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
-		c.GasEstimator.BlockHistory = &BlockHistoryEstimator{}
 		if cfg.BlockHistoryEstimatorBlockHistorySize.Valid {
 			v := uint16(cfg.BlockHistoryEstimatorBlockHistorySize.Int64)
 			c.GasEstimator.BlockHistory.BlockHistorySize = &v
@@ -919,7 +834,7 @@ func (c *Chain) SetFromDB(cfg *types.ChainCfg) error {
 		v := ethkey.EIP55AddressFromAddress(a)
 		c.KeySpecific = append(c.KeySpecific, KeySpecific{
 			Key: &v,
-			GasEstimator: &KeySpecificGasEstimator{
+			GasEstimator: KeySpecificGasEstimator{
 				PriceMax: kcfg.EvmMaxGasPriceWei,
 			},
 		})

--- a/core/chains/evm/config/v2/defaults.go
+++ b/core/chains/evm/config/v2/defaults.go
@@ -151,57 +151,23 @@ func (c *Chain) SetFrom(f *Chain) {
 	if v := f.RPCBlockQueryDelay; v != nil {
 		c.RPCBlockQueryDelay = v
 	}
-	if f.Transactions != nil {
-		if c.Transactions == nil {
-			c.Transactions = &Transactions{}
-		}
-		c.Transactions.setFrom(f.Transactions)
-	}
-	if f.BalanceMonitor != nil {
-		if c.BalanceMonitor == nil {
-			c.BalanceMonitor = &BalanceMonitor{}
-		}
-		c.BalanceMonitor.setFrom(f.BalanceMonitor)
-	}
-	if g := f.GasEstimator; g != nil {
-		if c.GasEstimator == nil {
-			c.GasEstimator = &GasEstimator{}
-		}
-		c.GasEstimator.setFrom(f.GasEstimator)
-	}
+
+	c.Transactions.setFrom(&f.Transactions)
+	c.BalanceMonitor.setFrom(&f.BalanceMonitor)
+	c.GasEstimator.setFrom(&f.GasEstimator)
+
 	if ks := f.KeySpecific; ks != nil {
 		for _, v := range ks {
 			if i := slices.IndexFunc(c.KeySpecific, func(k KeySpecific) bool { return k.Key == v.Key }); i == -1 {
 				c.KeySpecific = append(c.KeySpecific, v)
 			} else {
-				if v := v.GasEstimator; v != nil {
-					c.KeySpecific[i].GasEstimator = v
-				}
+				c.KeySpecific[i].GasEstimator.setFrom(&v.GasEstimator)
 			}
 		}
 	}
-	if f.HeadTracker != nil {
-		if c.HeadTracker == nil {
-			c.HeadTracker = &HeadTracker{}
-		}
-		c.HeadTracker.setFrom(f.HeadTracker)
-	}
-	if f.NodePool != nil {
-		if c.NodePool == nil {
-			c.NodePool = &NodePool{}
-		}
-		c.NodePool.setFrom(f.NodePool)
-	}
-	if f.OCR != nil {
-		if c.OCR == nil {
-			c.OCR = &OCR{}
-		}
-		c.OCR.setFrom(f.OCR)
-	}
-	if f.OCR2 != nil {
-		if c.OCR2 == nil {
-			c.OCR2 = &OCR2{}
-		}
-		c.OCR2.setFrom(f.OCR2)
-	}
+
+	c.HeadTracker.setFrom(&f.HeadTracker)
+	c.NodePool.setFrom(&f.NodePool)
+	c.OCR.setFrom(&f.OCR)
+	c.OCR2.setFrom(&f.OCR2)
 }

--- a/core/chains/evm/config/v2_helpers_test.go
+++ b/core/chains/evm/config/v2_helpers_test.go
@@ -41,7 +41,7 @@ func (set chainSpecificConfigDefaultSet) asV2() v2.Chain {
 		OperatorFactoryAddress:   asEIP155Address(set.operatorFactoryAddress),
 		RPCDefaultBatchSize:      ptr(set.rpcDefaultBatchSize),
 		RPCBlockQueryDelay:       ptr(set.blockHistoryEstimatorBlockDelay),
-		Transactions: &v2.Transactions{
+		Transactions: v2.Transactions{
 			ForwardersEnabled:    ptr(set.useForwarders),
 			MaxInFlight:          ptr(set.maxInFlightTransactions),
 			MaxQueued:            ptr(uint32(set.maxQueuedTransactions)),
@@ -49,10 +49,10 @@ func (set chainSpecificConfigDefaultSet) asV2() v2.Chain {
 			ReaperThreshold:      models.MustNewDuration(set.ethTxReaperThreshold),
 			ResendAfterThreshold: models.MustNewDuration(set.ethTxResendAfterThreshold),
 		},
-		BalanceMonitor: &v2.BalanceMonitor{
+		BalanceMonitor: v2.BalanceMonitor{
 			Enabled: ptr(set.balanceMonitorEnabled),
 		},
-		GasEstimator: &v2.GasEstimator{
+		GasEstimator: v2.GasEstimator{
 			Mode:               ptr(set.gasEstimatorMode),
 			EIP1559DynamicFees: ptr(set.eip1559DynamicFees),
 			BumpMin:            &set.gasBumpWei,
@@ -76,7 +76,7 @@ func (set chainSpecificConfigDefaultSet) asV2() v2.Chain {
 				FM:     set.gasLimitFMJobType,
 				Keeper: set.gasLimitKeeperJobType,
 			},
-			BlockHistory: &v2.BlockHistoryEstimator{
+			BlockHistory: v2.BlockHistoryEstimator{
 				BatchSize:                ptr(set.blockHistoryEstimatorBatchSize),
 				BlockHistorySize:         ptr(set.blockHistoryEstimatorBlockHistorySize),
 				CheckInclusionBlocks:     ptr(set.blockHistoryEstimatorCheckInclusionBlocks),
@@ -84,25 +84,25 @@ func (set chainSpecificConfigDefaultSet) asV2() v2.Chain {
 				TransactionPercentile:    ptr(set.blockHistoryEstimatorTransactionPercentile),
 			},
 		},
-		HeadTracker: &v2.HeadTracker{
+		HeadTracker: v2.HeadTracker{
 			HistoryDepth:     ptr(set.headTrackerHistoryDepth),
 			MaxBufferSize:    ptr(set.headTrackerMaxBufferSize),
 			SamplingInterval: models.MustNewDuration(set.headTrackerSamplingInterval),
 		},
 		KeySpecific: nil,
-		NodePool: &v2.NodePool{
+		NodePool: v2.NodePool{
 			PollFailureThreshold: ptr(set.nodePollFailureThreshold),
 			PollInterval:         models.MustNewDuration(set.nodePollInterval),
 			SelectionMode:        ptr(set.nodeSelectionMode),
 		},
-		OCR: &v2.OCR{
+		OCR: v2.OCR{
 			ContractConfirmations:              ptr(set.ocrContractConfirmations),
 			ContractTransmitterTransmitTimeout: models.MustNewDuration(set.ocrContractTransmitterTransmitTimeout),
 			DatabaseTimeout:                    models.MustNewDuration(set.ocrDatabaseTimeout),
 			ObservationGracePeriod:             models.MustNewDuration(set.ocrObservationGracePeriod),
 		},
-		OCR2: &v2.OCR2{
-			Automation: &v2.Automation{
+		OCR2: v2.OCR2{
+			Automation: v2.Automation{
 				GasLimit: ptr(set.ocr2AutomationGasLimit),
 			},
 		},
@@ -110,37 +110,11 @@ func (set chainSpecificConfigDefaultSet) asV2() v2.Chain {
 	if *c.ChainType == "" {
 		c.ChainType = nil
 	}
-	if isZeroPtr(c.BalanceMonitor) {
-		c.BalanceMonitor = nil
-	}
-	if isZeroPtr(c.GasEstimator.BlockHistory) {
-		c.GasEstimator.BlockHistory = nil
-	}
-	if isZeroPtr(c.GasEstimator) {
-		c.GasEstimator = nil
-	}
-	if isZeroPtr(c.HeadTracker) {
-		c.HeadTracker = nil
-	}
-	if isZeroPtr(c.NodePool) {
-		c.NodePool = nil
-	}
-	if isZeroPtr(c.OCR) {
-		c.OCR = nil
-	}
-	if isZeroPtr(c.OCR2) {
-		c.OCR2 = nil
-	}
 	return c
 }
 
 func ptr[T any](v T) *T {
 	return &v
-}
-
-func isZeroPtr[T comparable](p *T) bool {
-	var t T
-	return p == nil || *p == t
 }
 
 func asEIP155Address(s string) *ethkey.EIP55Address {

--- a/core/config/v2/docs/docs_test.go
+++ b/core/config/v2/docs/docs_test.go
@@ -51,7 +51,7 @@ func TestDoc(t *testing.T) {
 		// clean up KeySpecific as a special case
 		require.Equal(t, 1, len(docDefaults.KeySpecific))
 		ks := evmcfg.KeySpecific{Key: new(ethkey.EIP55Address),
-			GasEstimator: &evmcfg.KeySpecificGasEstimator{PriceMax: new(assets.Wei)}}
+			GasEstimator: evmcfg.KeySpecificGasEstimator{PriceMax: new(assets.Wei)}}
 		require.Equal(t, ks, docDefaults.KeySpecific[0])
 		docDefaults.KeySpecific = nil
 

--- a/core/config/v2/types.go
+++ b/core/config/v2/types.go
@@ -38,35 +38,21 @@ type Core struct {
 	RootDir             *string
 	ShutdownGracePeriod *models.Duration
 
-	Feature *Feature
-
-	Database *Database
-
-	TelemetryIngress *TelemetryIngress
-
-	AuditLogger *audit.AuditLoggerConfig
-
-	Log *Log
-
-	WebServer *WebServer
-
-	JobPipeline *JobPipeline
-
-	FluxMonitor *FluxMonitor
-
-	OCR2 *OCR2
-
-	OCR *OCR
-
-	P2P *P2P
-
-	Keeper *Keeper
-
-	AutoPprof *AutoPprof
-
-	Pyroscope *Pyroscope
-
-	Sentry *Sentry
+	Feature          Feature                 `toml:",omitempty"`
+	Database         Database                `toml:",omitempty"`
+	TelemetryIngress TelemetryIngress        `toml:",omitempty"`
+	AuditLogger      audit.AuditLoggerConfig `toml:",omitempty"`
+	Log              Log                     `toml:",omitempty"`
+	WebServer        WebServer               `toml:",omitempty"`
+	JobPipeline      JobPipeline             `toml:",omitempty"`
+	FluxMonitor      FluxMonitor             `toml:",omitempty"`
+	OCR2             OCR2                    `toml:",omitempty"`
+	OCR              OCR                     `toml:",omitempty"`
+	P2P              P2P                     `toml:",omitempty"`
+	Keeper           Keeper                  `toml:",omitempty"`
+	AutoPprof        AutoPprof               `toml:",omitempty"`
+	Pyroscope        Pyroscope               `toml:",omitempty"`
+	Sentry           Sentry                  `toml:",omitempty"`
 }
 
 var (
@@ -87,7 +73,7 @@ func CoreDefaults() (c Core) {
 	return
 }
 
-// SetFrom updates c with any non-nil values from f.
+// SetFrom updates c with any non-nil values from f. (currently TOML field only!)
 func (c *Core) SetFrom(f *Core) {
 	if v := f.ExplorerURL; v != nil {
 		c.ExplorerURL = f.ExplorerURL
@@ -102,111 +88,24 @@ func (c *Core) SetFrom(f *Core) {
 		c.ShutdownGracePeriod = v
 	}
 
-	if f.AuditLogger != nil {
-		if c.AuditLogger == nil {
-			c.AuditLogger = &audit.AuditLoggerConfig{}
-		}
-		c.AuditLogger.SetFrom(f.AuditLogger)
-	}
+	c.Feature.setFrom(&f.Feature)
+	c.Database.setFrom(&f.Database)
+	c.TelemetryIngress.setFrom(&f.TelemetryIngress)
+	c.AuditLogger.SetFrom(&f.AuditLogger)
+	c.Log.setFrom(&f.Log)
 
-	if f.Feature != nil {
-		if c.Feature == nil {
-			c.Feature = &Feature{}
-		}
-		c.Feature.setFrom(f.Feature)
-	}
+	c.WebServer.setFrom(&f.WebServer)
+	c.JobPipeline.setFrom(&f.JobPipeline)
 
-	if f.Database != nil {
-		if c.Database == nil {
-			c.Database = &Database{}
-		}
-		c.Database.setFrom(f.Database)
+	c.FluxMonitor.setFrom(&f.FluxMonitor)
+	c.OCR2.setFrom(&f.OCR2)
+	c.OCR.setFrom(&f.OCR)
+	c.P2P.setFrom(&f.P2P)
+	c.Keeper.setFrom(&f.Keeper)
 
-	}
-
-	if f.TelemetryIngress != nil {
-		if c.TelemetryIngress == nil {
-			c.TelemetryIngress = &TelemetryIngress{}
-		}
-		c.TelemetryIngress.setFrom(f.TelemetryIngress)
-	}
-
-	if f.Log != nil {
-		if c.Log == nil {
-			c.Log = &Log{}
-		}
-		c.Log.setFrom(f.Log)
-	}
-
-	if f.WebServer != nil {
-		if c.WebServer == nil {
-			c.WebServer = &WebServer{}
-		}
-		c.WebServer.setFrom(f.WebServer)
-	}
-
-	if f.JobPipeline != nil {
-		if c.JobPipeline == nil {
-			c.JobPipeline = &JobPipeline{}
-		}
-		c.JobPipeline.setFrom(f.JobPipeline)
-	}
-
-	if f.FluxMonitor != nil {
-		if c.FluxMonitor == nil {
-			c.FluxMonitor = &FluxMonitor{}
-		}
-		c.FluxMonitor.setFrom(f.FluxMonitor)
-	}
-
-	if f.OCR2 != nil {
-		if c.OCR2 == nil {
-			c.OCR2 = &OCR2{}
-		}
-		c.OCR2.setFrom(f.OCR2)
-	}
-
-	if f.OCR != nil {
-		if c.OCR == nil {
-			c.OCR = &OCR{}
-		}
-		c.OCR.setFrom(f.OCR)
-	}
-
-	if f.P2P != nil {
-		if c.P2P == nil {
-			c.P2P = &P2P{}
-		}
-		c.P2P.setFrom(f.P2P)
-	}
-
-	if f.Keeper != nil {
-		if c.Keeper == nil {
-			c.Keeper = &Keeper{}
-		}
-		c.Keeper.setFrom(f.Keeper)
-	}
-
-	if f.AutoPprof != nil {
-		if c.AutoPprof == nil {
-			c.AutoPprof = &AutoPprof{}
-		}
-		c.AutoPprof.setFrom(f.AutoPprof)
-	}
-
-	if f.Pyroscope != nil {
-		if c.Pyroscope == nil {
-			c.Pyroscope = &Pyroscope{}
-		}
-		c.Pyroscope.setFrom(f.Pyroscope)
-	}
-
-	if f.Sentry != nil {
-		if c.Sentry == nil {
-			c.Sentry = &Sentry{}
-		}
-		c.Sentry.setFrom(f.Sentry)
-	}
+	c.AutoPprof.setFrom(&f.AutoPprof)
+	c.Pyroscope.setFrom(&f.Pyroscope)
+	c.Sentry.setFrom(&f.Sentry)
 }
 
 type Secrets struct {
@@ -286,11 +185,9 @@ type Database struct {
 	MaxOpenConns                  *int64
 	MigrateOnStartup              *bool
 
-	Backup *DatabaseBackup
-
-	Listener *DatabaseListener
-
-	Lock *DatabaseLock
+	Backup   DatabaseBackup   `toml:",omitempty"`
+	Listener DatabaseListener `toml:",omitempty"`
+	Lock     DatabaseLock     `toml:",omitempty"`
 }
 
 func (d *Database) LockingMode() string {
@@ -320,25 +217,9 @@ func (d *Database) setFrom(f *Database) {
 		d.MaxOpenConns = v
 	}
 
-	if f.Backup != nil {
-		if d.Backup == nil {
-			d.Backup = &DatabaseBackup{}
-		}
-		d.Backup.setFrom(f.Backup)
-	}
-	if f.Listener != nil {
-		if d.Listener == nil {
-			d.Listener = &DatabaseListener{}
-		}
-		d.Listener.setFrom(f.Listener)
-	}
-
-	if f.Lock != nil {
-		if d.Lock == nil {
-			d.Lock = &DatabaseLock{}
-		}
-		d.Lock.setFrom(f.Lock)
-	}
+	d.Backup.setFrom(&f.Backup)
+	d.Listener.setFrom(&f.Listener)
+	d.Lock.setFrom(&f.Lock)
 }
 
 type DatabaseListener struct {
@@ -456,7 +337,7 @@ type Log struct {
 	SQL             bool `toml:"-"`
 	UnixTS          *bool
 
-	File *LogFile
+	File LogFile `toml:",omitempty"`
 }
 
 func (l *Log) setFrom(f *Log) {
@@ -469,12 +350,7 @@ func (l *Log) setFrom(f *Log) {
 	if v := f.UnixTS; v != nil {
 		l.UnixTS = v
 	}
-	if f.File != nil {
-		if l.File == nil {
-			l.File = &LogFile{}
-		}
-		l.File.setFrom(f.File)
-	}
+	l.File.setFrom(&f.File)
 }
 
 type LogFile struct {
@@ -508,11 +384,9 @@ type WebServer struct {
 	SessionTimeout          *models.Duration
 	SessionReaperExpiration *models.Duration
 
-	MFA *WebServerMFA
-
-	RateLimit *WebServerRateLimit
-
-	TLS *WebServerTLS
+	MFA       WebServerMFA       `toml:",omitempty"`
+	RateLimit WebServerRateLimit `toml:",omitempty"`
+	TLS       WebServerTLS       `toml:",omitempty"`
 }
 
 func (w *WebServer) setFrom(f *WebServer) {
@@ -537,24 +411,10 @@ func (w *WebServer) setFrom(f *WebServer) {
 	if v := f.SessionReaperExpiration; v != nil {
 		w.SessionReaperExpiration = v
 	}
-	if f.MFA != nil {
-		if w.MFA == nil {
-			w.MFA = &WebServerMFA{}
-		}
-		w.MFA.setFrom(f.MFA)
-	}
-	if f.RateLimit != nil {
-		if w.RateLimit == nil {
-			w.RateLimit = &WebServerRateLimit{}
-		}
-		w.RateLimit.setFrom(f.RateLimit)
-	}
-	if f.TLS != nil {
-		if w.TLS == nil {
-			w.TLS = &WebServerTLS{}
-		}
-		w.TLS.setFrom(f.TLS)
-	}
+
+	w.MFA.setFrom(&f.MFA)
+	w.RateLimit.setFrom(&f.RateLimit)
+	w.TLS.setFrom(&f.TLS)
 }
 
 type WebServerMFA struct {
@@ -626,7 +486,7 @@ type JobPipeline struct {
 	ReaperThreshold           *models.Duration
 	ResultWriteQueueDepth     *uint32
 
-	HTTPRequest *JobPipelineHTTPRequest
+	HTTPRequest JobPipelineHTTPRequest `toml:",omitempty"`
 }
 
 func (j *JobPipeline) setFrom(f *JobPipeline) {
@@ -645,12 +505,8 @@ func (j *JobPipeline) setFrom(f *JobPipeline) {
 	if v := f.ResultWriteQueueDepth; v != nil {
 		j.ResultWriteQueueDepth = v
 	}
-	if f.HTTPRequest != nil {
-		if j.HTTPRequest == nil {
-			j.HTTPRequest = &JobPipelineHTTPRequest{}
-		}
-		j.HTTPRequest.setFrom(f.HTTPRequest)
-	}
+	j.HTTPRequest.setFrom(&f.HTTPRequest)
+
 }
 
 type JobPipelineHTTPRequest struct {
@@ -768,9 +624,8 @@ type P2P struct {
 	PeerID                    *p2pkey.PeerID
 	TraceLogging              *bool
 
-	V1 *P2PV1
-
-	V2 *P2PV2
+	V1 P2PV1 `toml:",omitempty"`
+	V2 P2PV2 `toml:",omitempty"`
 }
 
 func (p *P2P) NetworkStack() ocrnetworking.NetworkingStack {
@@ -799,18 +654,9 @@ func (p *P2P) setFrom(f *P2P) {
 	if v := f.TraceLogging; v != nil {
 		p.TraceLogging = v
 	}
-	if f.V1 != nil {
-		if p.V1 == nil {
-			p.V1 = &P2PV1{}
-		}
-		p.V1.setFrom(f.V1)
-	}
-	if f.V2 != nil {
-		if p.V2 == nil {
-			p.V2 = &P2PV2{}
-		}
-		p.V2.setFrom(f.V2)
-	}
+
+	p.V1.setFrom(&f.V1)
+	p.V2.setFrom(&f.V2)
 }
 
 type P2PV1 struct {
@@ -911,7 +757,7 @@ type Keeper struct {
 	TurnFlagEnabled              *bool
 	UpkeepCheckGasPriceEnabled   *bool
 
-	Registry *KeeperRegistry
+	Registry KeeperRegistry `toml:",omitempty"`
 }
 
 func (k *Keeper) setFrom(f *Keeper) {
@@ -939,12 +785,9 @@ func (k *Keeper) setFrom(f *Keeper) {
 	if v := f.UpkeepCheckGasPriceEnabled; v != nil {
 		k.UpkeepCheckGasPriceEnabled = v
 	}
-	if f.Registry != nil {
-		if k.Registry == nil {
-			k.Registry = &KeeperRegistry{}
-		}
-		k.Registry.setFrom(f.Registry)
-	}
+
+	k.Registry.setFrom(&f.Registry)
+
 }
 
 type KeeperRegistry struct {

--- a/core/services/chainlink/config_dump.go
+++ b/core/services/chainlink/config_dump.go
@@ -174,9 +174,6 @@ func (c *Config) loadChainsAndNodes(dbData dbData) error {
 func (c *Config) loadLegacyEVMEnv() {
 	if e := envvar.NewBool("BalanceMonitorEnabled").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].BalanceMonitor == nil {
-				c.EVM[i].BalanceMonitor = &evmcfg.BalanceMonitor{}
-			}
 			c.EVM[i].BalanceMonitor.Enabled = e
 		}
 	}
@@ -198,27 +195,18 @@ func (c *Config) loadLegacyEVMEnv() {
 	if e := envvar.NewDuration("EthTxReaperInterval").ParsePtr(); e != nil {
 		d := models.MustNewDuration(*e)
 		for i := range c.EVM {
-			if c.EVM[i].Transactions == nil {
-				c.EVM[i].Transactions = &evmcfg.Transactions{}
-			}
 			c.EVM[i].Transactions.ReaperInterval = d
 		}
 	}
 	if e := envvar.NewDuration("EthTxReaperThreshold").ParsePtr(); e != nil {
 		d := models.MustNewDuration(*e)
 		for i := range c.EVM {
-			if c.EVM[i].Transactions == nil {
-				c.EVM[i].Transactions = &evmcfg.Transactions{}
-			}
 			c.EVM[i].Transactions.ReaperThreshold = d
 		}
 	}
 	if e := envvar.NewDuration("EthTxResendAfterThreshold").ParsePtr(); e != nil {
 		d := models.MustNewDuration(*e)
 		for i := range c.EVM {
-			if c.EVM[i].Transactions == nil {
-				c.EVM[i].Transactions = &evmcfg.Transactions{}
-			}
 			c.EVM[i].Transactions.ResendAfterThreshold = d
 		}
 	}
@@ -229,26 +217,17 @@ func (c *Config) loadLegacyEVMEnv() {
 	}
 	if e := envvar.NewUint32("EvmHeadTrackerHistoryDepth").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].HeadTracker == nil {
-				c.EVM[i].HeadTracker = &evmcfg.HeadTracker{}
-			}
 			c.EVM[i].HeadTracker.HistoryDepth = e
 		}
 	}
 	if e := envvar.NewUint32("EvmHeadTrackerMaxBufferSize").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].HeadTracker == nil {
-				c.EVM[i].HeadTracker = &evmcfg.HeadTracker{}
-			}
 			c.EVM[i].HeadTracker.MaxBufferSize = e
 		}
 	}
 	if e := envvar.NewDuration("EvmHeadTrackerSamplingInterval").ParsePtr(); e != nil {
 		d := models.MustNewDuration(*e)
 		for i := range c.EVM {
-			if c.EVM[i].HeadTracker == nil {
-				c.EVM[i].HeadTracker = &evmcfg.HeadTracker{}
-			}
 			c.EVM[i].HeadTracker.SamplingInterval = d
 		}
 	}
@@ -314,191 +293,117 @@ func (c *Config) loadLegacyEVMEnv() {
 	}
 	if e := envvar.NewUint32("NodePollFailureThreshold").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].NodePool == nil {
-				c.EVM[i].NodePool = &evmcfg.NodePool{}
-			}
 			c.EVM[i].NodePool.PollFailureThreshold = e
 		}
 	}
 	if e := envvar.NewDuration("NodePollInterval").ParsePtr(); e != nil {
 		d := models.MustNewDuration(*e)
 		for i := range c.EVM {
-			if c.EVM[i].NodePool == nil {
-				c.EVM[i].NodePool = &evmcfg.NodePool{}
-			}
 			c.EVM[i].NodePool.PollInterval = d
 		}
 	}
 	if e := envvar.NewString("NodeSelectionMode").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].NodePool == nil {
-				c.EVM[i].NodePool = &evmcfg.NodePool{}
-			}
 			c.EVM[i].NodePool.SelectionMode = e
-		}
-	}
-	for i := range c.EVM {
-		if isZeroPtr(c.EVM[i].NodePool) {
-			c.EVM[i].NodePool = nil
 		}
 	}
 	if e := envvar.NewBool("EvmEIP1559DynamicFees").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.EIP1559DynamicFees = e
 		}
 	}
 	if e := envvar.NewUint16("EvmGasBumpPercent").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.BumpPercent = e
 		}
 	}
 	if e := envvar.NewUint32("EvmGasBumpThreshold").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.BumpThreshold = e
 		}
 	}
 	if e := envvar.New("EvmGasBumpWei", parse.BigInt).ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.BumpMin = assets.NewWei(*e)
 		}
 	}
 	if e := envvar.New("EvmGasFeeCapDefault", parse.BigInt).ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.FeeCapDefault = assets.NewWei(*e)
 		}
 	}
 	if e := envvar.NewUint32("EvmGasLimitDefault").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.LimitDefault = e
 		}
 	}
 	if e := envvar.NewUint32("EvmGasLimitMax").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.LimitMax = e
 		}
 	}
 	if e := envvar.NewUint32("EvmGasLimitOCRJobType").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.LimitJobType.OCR = e
 		}
 	}
 	if e := envvar.NewUint32("EvmGasLimitDRJobType").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.LimitJobType.DR = e
 		}
 	}
 	if e := envvar.NewUint32("EvmGasLimitVRFJobType").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.LimitJobType.VRF = e
 		}
 	}
 	if e := envvar.NewUint32("EvmGasLimitFMJobType").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.LimitJobType.FM = e
 		}
 	}
 	if e := envvar.NewUint32("EvmGasLimitKeeperJobType").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.LimitJobType.Keeper = e
 		}
 	}
 	if e := envvar.New("EvmGasLimitMultiplier", decimal.NewFromString).ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.LimitMultiplier = e
 		}
 	}
 	if e := envvar.NewUint32("EvmGasLimitTransfer").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.LimitTransfer = e
 		}
 	}
 	if e := envvar.New("EvmGasPriceDefault", parse.BigInt).ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.PriceDefault = assets.NewWei(*e)
 		}
 	}
 	if e := envvar.New("EvmGasTipCapDefault", parse.BigInt).ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.TipCapDefault = assets.NewWei(*e)
 		}
 	}
 	if e := envvar.New("EvmGasTipCapMinimum", parse.BigInt).ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.TipCapMin = assets.NewWei(*e)
 		}
 	}
 	if e := envvar.New("EvmMaxGasPriceWei", parse.BigInt).ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.PriceMax = assets.NewWei(*e)
 		}
 	}
 	if e := envvar.New("EvmMinGasPriceWei", parse.BigInt).ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.PriceMin = assets.NewWei(*e)
 		}
 	}
 	if e := envvar.NewString("GasEstimatorMode").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.Mode = e
 		}
 	} else if e, ok := os.LookupEnv("GAS_UPDATER_ENABLED"); ok && e != "" {
@@ -507,40 +412,22 @@ func (c *Config) loadLegacyEVMEnv() {
 			v = "BlockHistory"
 		}
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.Mode = &v
 		}
 	}
 	if e := envvar.NewUint16("EvmGasBumpTxDepth").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
 			c.EVM[i].GasEstimator.BumpTxDepth = e
 		}
 	}
 	if e := envvar.NewUint32("BlockHistoryEstimatorBatchSize").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
-			if c.EVM[i].GasEstimator.BlockHistory == nil {
-				c.EVM[i].GasEstimator.BlockHistory = &evmcfg.BlockHistoryEstimator{}
-			}
 			c.EVM[i].GasEstimator.BlockHistory.BatchSize = e
 		}
 	} else if s, ok := os.LookupEnv("GAS_UPDATER_BATCH_SIZE"); ok {
 		l, err := parse.Uint32(s)
 		if err == nil {
 			for i := range c.EVM {
-				if c.EVM[i].GasEstimator == nil {
-					c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-				}
-				if c.EVM[i].GasEstimator.BlockHistory == nil {
-					c.EVM[i].GasEstimator.BlockHistory = &evmcfg.BlockHistoryEstimator{}
-				}
 				c.EVM[i].GasEstimator.BlockHistory.BatchSize = &l
 			}
 		}
@@ -559,108 +446,50 @@ func (c *Config) loadLegacyEVMEnv() {
 	}
 	if e := envvar.NewUint16("BlockHistoryEstimatorBlockHistorySize").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
-			if c.EVM[i].GasEstimator.BlockHistory == nil {
-				c.EVM[i].GasEstimator.BlockHistory = &evmcfg.BlockHistoryEstimator{}
-			}
 			c.EVM[i].GasEstimator.BlockHistory.BlockHistorySize = e
 		}
 	} else if s, ok := os.LookupEnv("GAS_UPDATER_BLOCK_HISTORY_SIZE"); ok {
 		l, err := parse.Uint16(s)
 		if err == nil {
 			for i := range c.EVM {
-				if c.EVM[i].GasEstimator == nil {
-					c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-				}
-				if c.EVM[i].GasEstimator.BlockHistory == nil {
-					c.EVM[i].GasEstimator.BlockHistory = &evmcfg.BlockHistoryEstimator{}
-				}
 				c.EVM[i].GasEstimator.BlockHistory.BlockHistorySize = &l
 			}
 		}
 	}
 	if e := envvar.NewUint16("BlockHistoryEstimatorCheckInclusionBlocks").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
-			if c.EVM[i].GasEstimator.BlockHistory == nil {
-				c.EVM[i].GasEstimator.BlockHistory = &evmcfg.BlockHistoryEstimator{}
-			}
 			c.EVM[i].GasEstimator.BlockHistory.CheckInclusionBlocks = e
 		}
 	}
 	if e := envvar.NewUint16("BlockHistoryEstimatorCheckInclusionPercentile").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
-			if c.EVM[i].GasEstimator.BlockHistory == nil {
-				c.EVM[i].GasEstimator.BlockHistory = &evmcfg.BlockHistoryEstimator{}
-			}
 			c.EVM[i].GasEstimator.BlockHistory.CheckInclusionPercentile = e
 		}
 	}
 	if e := envvar.NewUint16("BlockHistoryEstimatorEIP1559FeeCapBufferBlocks").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
-			if c.EVM[i].GasEstimator.BlockHistory == nil {
-				c.EVM[i].GasEstimator.BlockHistory = &evmcfg.BlockHistoryEstimator{}
-			}
 			c.EVM[i].GasEstimator.BlockHistory.EIP1559FeeCapBufferBlocks = e
 		}
 	}
 	if e := envvar.NewUint16("BlockHistoryEstimatorTransactionPercentile").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].GasEstimator == nil {
-				c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-			}
-			if c.EVM[i].GasEstimator.BlockHistory == nil {
-				c.EVM[i].GasEstimator.BlockHistory = &evmcfg.BlockHistoryEstimator{}
-			}
 			c.EVM[i].GasEstimator.BlockHistory.TransactionPercentile = e
 		}
 	} else if s, ok := os.LookupEnv("GAS_UPDATER_TRANSACTION_PERCENTILE"); ok {
 		l, err := parse.Uint16(s)
 		if err == nil {
 			for i := range c.EVM {
-				if c.EVM[i].GasEstimator == nil {
-					c.EVM[i].GasEstimator = &evmcfg.GasEstimator{}
-				}
-				if c.EVM[i].GasEstimator.BlockHistory == nil {
-					c.EVM[i].GasEstimator.BlockHistory = &evmcfg.BlockHistoryEstimator{}
-				}
 				c.EVM[i].GasEstimator.BlockHistory.TransactionPercentile = &l
-			}
-		}
-	}
-	for i := range c.EVM {
-		if c.EVM[i].GasEstimator != nil {
-			if isZeroPtr(c.EVM[i].GasEstimator.BlockHistory) {
-				c.EVM[i].GasEstimator.BlockHistory = nil
-			}
-			if isZeroPtr(c.EVM[i].GasEstimator) {
-				c.EVM[i].GasEstimator = nil
 			}
 		}
 	}
 	if e := envvar.NewUint32("EvmMaxInFlightTransactions").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].Transactions == nil {
-				c.EVM[i].Transactions = &evmcfg.Transactions{}
-			}
 			c.EVM[i].Transactions.MaxInFlight = e
 		}
 	}
 	if e := envvar.NewUint32("EvmMaxQueuedTransactions").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].Transactions == nil {
-				c.EVM[i].Transactions = &evmcfg.Transactions{}
-			}
 			c.EVM[i].Transactions.MaxInFlight = e
 		}
 	}
@@ -671,15 +500,7 @@ func (c *Config) loadLegacyEVMEnv() {
 	}
 	if e := envvar.NewBool("EvmUseForwarders").ParsePtr(); e != nil {
 		for i := range c.EVM {
-			if c.EVM[i].Transactions == nil {
-				c.EVM[i].Transactions = &evmcfg.Transactions{}
-			}
 			c.EVM[i].Transactions.ForwardersEnabled = e
-		}
-	}
-	for i := range c.EVM {
-		if isZeroPtr(c.EVM[i].Transactions) {
-			c.EVM[i].Transactions = nil
 		}
 	}
 }
@@ -691,61 +512,41 @@ func (c *Config) loadLegacyCoreEnv() {
 	c.RootDir = envvar.RootDir.ParsePtr()
 	c.ShutdownGracePeriod = envDuration("ShutdownGracePeriod")
 
-	c.Feature = &config.Feature{
+	c.Feature = config.Feature{
 		FeedsManager: envvar.NewBool("FeatureFeedsManager").ParsePtr(),
 	}
-	if isZeroPtr(c.Feature) {
-		c.Feature = nil
-	}
-
-	c.AuditLogger = &audit.AuditLoggerConfig{
+	c.AuditLogger = audit.AuditLoggerConfig{
 		Enabled:        envvar.NewBool("AuditLoggerEnabled").ParsePtr(),
 		ForwardToUrl:   envURL("AuditLoggerForwardToUrl"),
 		JsonWrapperKey: envvar.NewString("AuditLoggerJsonWrapperKey").ParsePtr(),
 		Headers:        audit.AuditLoggerHeaders.ParsePtr(),
 	}
 
-	if isZeroPtr(c.AuditLogger) {
-		c.AuditLogger = nil
-	}
-
-	c.Database = &config.Database{
+	c.Database = config.Database{
 		DefaultIdleInTxSessionTimeout: mustParseDuration(os.Getenv("DATABASE_DEFAULT_IDLE_IN_TX_SESSION_TIMEOUT")),
 		DefaultLockTimeout:            mustParseDuration(os.Getenv("DATABASE_DEFAULT_LOCK_TIMEOUT")),
 		DefaultQueryTimeout:           mustParseDuration(os.Getenv("DATABASE_DEFAULT_QUERY_TIMEOUT")),
 		MigrateOnStartup:              envvar.NewBool("MigrateDatabase").ParsePtr(),
 		MaxIdleConns:                  envvar.NewInt64("ORMMaxIdleConns").ParsePtr(),
 		MaxOpenConns:                  envvar.NewInt64("ORMMaxOpenConns").ParsePtr(),
-		Listener: &config.DatabaseListener{
+		Listener: config.DatabaseListener{
 			MaxReconnectDuration: envDuration("DatabaseListenerMaxReconnectDuration"),
 			MinReconnectInterval: envDuration("DatabaseListenerMinReconnectInterval"),
 			FallbackPollInterval: envDuration("TriggerFallbackDBPollInterval"),
 		},
-		Lock: &config.DatabaseLock{
+		Lock: config.DatabaseLock{
 			LeaseDuration:        envDuration("LeaseLockDuration"),
 			LeaseRefreshInterval: envDuration("LeaseLockRefreshInterval"),
 		},
-		Backup: &config.DatabaseBackup{
+		Backup: config.DatabaseBackup{
 			Dir:              envvar.NewString("DatabaseBackupDir").ParsePtr(),
 			Frequency:        envDuration("DatabaseBackupFrequency"),
 			Mode:             legacy.DatabaseBackupModeEnvVar.ParsePtr(),
 			OnVersionUpgrade: envvar.NewBool("DatabaseBackupOnVersionUpgrade").ParsePtr(),
 		},
 	}
-	if isZeroPtr(c.Database.Listener) {
-		c.Database.Listener = nil
-	}
-	if isZeroPtr(c.Database.Lock) {
-		c.Database.Lock = nil
-	}
-	if isZeroPtr(c.Database.Backup) {
-		c.Database.Backup = nil
-	}
-	if isZeroPtr(c.Database) {
-		c.Database = nil
-	}
 
-	c.TelemetryIngress = &config.TelemetryIngress{
+	c.TelemetryIngress = config.TelemetryIngress{
 		UniConn:      envvar.NewBool("TelemetryIngressUniConn").ParsePtr(),
 		Logging:      envvar.NewBool("TelemetryIngressLogging").ParsePtr(),
 		ServerPubKey: envvar.NewString("TelemetryIngressServerPubKey").ParsePtr(),
@@ -756,29 +557,20 @@ func (c *Config) loadLegacyCoreEnv() {
 		SendTimeout:  envDuration("TelemetryIngressSendTimeout"),
 		UseBatchSend: envvar.NewBool("TelemetryIngressUseBatchSend").ParsePtr(),
 	}
-	if isZeroPtr(c.TelemetryIngress) {
-		c.TelemetryIngress = nil
-	}
 
-	c.Log = &config.Log{
+	c.Log = config.Log{
 		DatabaseQueries: envvar.NewBool("LogSQL").ParsePtr(),
 		JSONConsole:     envvar.JSONConsole.ParsePtr(),
 		UnixTS:          envvar.LogUnixTS.ParsePtr(),
-		File: &config.LogFile{
+		File: config.LogFile{
 			Dir:        envvar.NewString("LogFileDir").ParsePtr(),
 			MaxSize:    envvar.LogFileMaxSize.ParsePtr(),
 			MaxAgeDays: envvar.LogFileMaxAge.ParsePtr(),
 			MaxBackups: envvar.LogFileMaxBackups.ParsePtr(),
 		},
 	}
-	if isZeroPtr(c.Log.File) {
-		c.Log.File = nil
-	}
-	if isZeroPtr(c.Log) {
-		c.Log = nil
-	}
 
-	c.WebServer = &config.WebServer{
+	c.WebServer = config.WebServer{
 		AllowOrigins:            envvar.NewString("AllowOrigins").ParsePtr(),
 		BridgeResponseURL:       envURL("BridgeResponseURL"),
 		HTTPWriteTimeout:        envDuration("HTTPServerWriteTimeout"),
@@ -786,17 +578,17 @@ func (c *Config) loadLegacyCoreEnv() {
 		SecureCookies:           envvar.NewBool("SecureCookies").ParsePtr(),
 		SessionTimeout:          envDuration("SessionTimeout"),
 		SessionReaperExpiration: envDuration("ReaperExpiration"),
-		MFA: &config.WebServerMFA{
+		MFA: config.WebServerMFA{
 			RPID:     envvar.NewString("RPID").ParsePtr(),
 			RPOrigin: envvar.NewString("RPOrigin").ParsePtr(),
 		},
-		RateLimit: &config.WebServerRateLimit{
+		RateLimit: config.WebServerRateLimit{
 			Authenticated:         envvar.NewInt64("AuthenticatedRateLimit").ParsePtr(),
 			AuthenticatedPeriod:   envDuration("AuthenticatedRateLimitPeriod"),
 			Unauthenticated:       envvar.NewInt64("UnAuthenticatedRateLimit").ParsePtr(),
 			UnauthenticatedPeriod: envDuration("UnAuthenticatedRateLimitPeriod"),
 		},
-		TLS: &config.WebServerTLS{
+		TLS: config.WebServerTLS{
 			CertPath:      envvar.NewString("TLSCertPath").ParsePtr(),
 			Host:          envvar.NewString("TLSHost").ParsePtr(),
 			KeyPath:       envvar.NewString("TLSKeyPath").ParsePtr(),
@@ -804,26 +596,14 @@ func (c *Config) loadLegacyCoreEnv() {
 			ForceRedirect: envvar.NewBool("TLSRedirect").ParsePtr(),
 		},
 	}
-	if isZeroPtr(c.WebServer.MFA) {
-		c.WebServer.MFA = nil
-	}
-	if isZeroPtr(c.WebServer.RateLimit) {
-		c.WebServer.RateLimit = nil
-	}
-	if isZeroPtr(c.WebServer.TLS) {
-		c.WebServer.TLS = nil
-	}
-	if isZeroPtr(c.WebServer) {
-		c.WebServer = nil
-	}
 
-	c.JobPipeline = &config.JobPipeline{
+	c.JobPipeline = config.JobPipeline{
 		ExternalInitiatorsEnabled: envvar.NewBool("FeatureExternalInitiators").ParsePtr(),
 		MaxRunDuration:            envDuration("JobPipelineMaxRunDuration"),
 		ReaperInterval:            envDuration("JobPipelineReaperInterval"),
 		ReaperThreshold:           envDuration("JobPipelineReaperThreshold"),
 		ResultWriteQueueDepth:     envvar.NewUint32("JobPipelineResultWriteQueueDepth").ParsePtr(),
-		HTTPRequest: &config.JobPipelineHTTPRequest{
+		HTTPRequest: config.JobPipelineHTTPRequest{
 			DefaultTimeout: envDuration("DefaultHTTPTimeout"),
 		},
 	}
@@ -831,22 +611,13 @@ func (c *Config) loadLegacyCoreEnv() {
 		b := utils.FileSize(*p)
 		c.JobPipeline.HTTPRequest.MaxSize = &b
 	}
-	if isZeroPtr(c.JobPipeline.HTTPRequest) {
-		c.JobPipeline.HTTPRequest = nil
-	}
-	if isZeroPtr(c.JobPipeline) {
-		c.JobPipeline = nil
-	}
 
-	c.FluxMonitor = &config.FluxMonitor{
+	c.FluxMonitor = config.FluxMonitor{
 		DefaultTransactionQueueDepth: envvar.NewUint32("FMDefaultTransactionQueueDepth").ParsePtr(),
 		SimulateTransactions:         envvar.NewBool("FMSimulateTransactions").ParsePtr(),
 	}
-	if isZeroPtr(c.FluxMonitor) {
-		c.FluxMonitor = nil
-	}
 
-	c.OCR2 = &config.OCR2{
+	c.OCR2 = config.OCR2{
 		Enabled:                            envvar.NewBool("FeatureOffchainReporting2").ParsePtr(),
 		ContractConfirmations:              envvar.NewUint32("OCR2ContractConfirmations").ParsePtr(),
 		BlockchainTimeout:                  envDuration("OCR2BlockchainTimeout"),
@@ -856,11 +627,8 @@ func (c *Config) loadLegacyCoreEnv() {
 		DatabaseTimeout:                    envDuration("OCR2DatabaseTimeout"),
 		KeyBundleID:                        envvar.New("OCR2KeyBundleID", models.Sha256HashFromHex).ParsePtr(),
 	}
-	if isZeroPtr(c.OCR2) {
-		c.OCR2 = nil
-	}
 
-	c.OCR = &config.OCR{
+	c.OCR = config.OCR{
 		Enabled:                      envvar.NewBool("FeatureOffchainReporting").ParsePtr(),
 		ObservationTimeout:           envDuration("OCRObservationTimeout"),
 		BlockchainTimeout:            envDuration("OCRBlockchainTimeout"),
@@ -871,11 +639,8 @@ func (c *Config) loadLegacyCoreEnv() {
 		SimulateTransactions:         envvar.NewBool("OCRSimulateTransactions").ParsePtr(),
 		TransmitterAddress:           envvar.New("OCRTransmitterAddress", ethkey.NewEIP55Address).ParsePtr(),
 	}
-	if isZeroPtr(c.OCR) {
-		c.OCR = nil
-	}
 
-	c.P2P = &config.P2P{
+	c.P2P = config.P2P{
 		IncomingMessageBufferSize: first(envvar.NewInt64("OCRIncomingMessageBufferSize"), envvar.NewInt64("P2PIncomingMessageBufferSize")),
 		OutgoingMessageBufferSize: first(envvar.NewInt64("OCROutgoingMessageBufferSize"), envvar.NewInt64("P2POutgoingMessageBufferSize")),
 		PeerID:                    envvar.New("P2PPeerID", p2pkey.MakePeerID).ParsePtr(),
@@ -890,56 +655,37 @@ func (c *Config) loadLegacyCoreEnv() {
 		p = &v1 // legacy default
 	}
 	ns := *p
-	t := true
-	if ns == v1 || ns == v1v2 {
-		c.P2P.V1 = &config.P2PV1{
-			Enabled:                          &t,
-			AnnounceIP:                       envIP("P2PAnnounceIP"),
-			AnnouncePort:                     envvar.NewUint16("P2PAnnouncePort").ParsePtr(),
-			BootstrapCheckInterval:           envDuration("OCRBootstrapCheckInterval", "P2PBootstrapCheckInterval"),
-			DefaultBootstrapPeers:            envStringSlice("P2PBootstrapPeers"),
-			DHTAnnouncementCounterUserPrefix: envvar.NewUint32("P2PDHTAnnouncementCounterUserPrefix").ParsePtr(),
-			DHTLookupInterval:                first(envvar.NewInt64("OCRDHTLookupInterval"), envvar.NewInt64("P2PDHTLookupInterval")),
-			ListenIP:                         envIP("P2PListenIP"),
-			ListenPort:                       envvar.NewUint16("P2PListenPort").ParsePtr(),
-			NewStreamTimeout:                 envDuration("OCRNewStreamTimeout", "P2PNewStreamTimeout"),
-			PeerstoreWriteInterval:           envDuration("P2PPeerstoreWriteInterval"),
-		}
+	c.P2P.V1 = config.P2PV1{
+		AnnounceIP:                       envIP("P2PAnnounceIP"),
+		AnnouncePort:                     envvar.NewUint16("P2PAnnouncePort").ParsePtr(),
+		BootstrapCheckInterval:           envDuration("OCRBootstrapCheckInterval", "P2PBootstrapCheckInterval"),
+		DefaultBootstrapPeers:            envStringSlice("P2PBootstrapPeers"),
+		DHTAnnouncementCounterUserPrefix: envvar.NewUint32("P2PDHTAnnouncementCounterUserPrefix").ParsePtr(),
+		DHTLookupInterval:                first(envvar.NewInt64("OCRDHTLookupInterval"), envvar.NewInt64("P2PDHTLookupInterval")),
+		ListenIP:                         envIP("P2PListenIP"),
+		ListenPort:                       envvar.NewUint16("P2PListenPort").ParsePtr(),
+		NewStreamTimeout:                 envDuration("OCRNewStreamTimeout", "P2PNewStreamTimeout"),
+		PeerstoreWriteInterval:           envDuration("P2PPeerstoreWriteInterval"),
 	}
-	if ns == v2 || ns == v1v2 {
-		c.P2P.V2 = &config.P2PV2{
-			Enabled:           &t,
-			AnnounceAddresses: envStringSlice("P2PV2AnnounceAddresses"),
-			DefaultBootstrappers: envSlice("P2PV2Bootstrappers", func(v *ocrcommontypes.BootstrapperLocator, b []byte) error {
-				fmt.Println("TEST", string(b))
-				return v.UnmarshalText(b)
-			}),
-			DeltaDial:       envDuration("P2PV2DeltaDial"),
-			DeltaReconcile:  envDuration("P2PV2DeltaReconcile"),
-			ListenAddresses: envStringSlice("P2PV2ListenAddresses"),
-		}
+	if (ns == v1 || ns == v1v2) && c.P2P.V1 != (config.P2PV1{}) {
+		c.P2P.V1.Enabled = ptr(true)
 	}
 
-	v1Enabled := c.P2P.V1.Enabled != nil && *c.P2P.V1.Enabled
-	if v1Enabled {
-		// exclude from check
-		c.P2P.V1.Enabled = nil
+	c.P2P.V2 = config.P2PV2{
+		AnnounceAddresses: envStringSlice("P2PV2AnnounceAddresses"),
+		DefaultBootstrappers: envSlice("P2PV2Bootstrappers", func(v *ocrcommontypes.BootstrapperLocator, b []byte) error {
+			fmt.Println("TEST", string(b))
+			return v.UnmarshalText(b)
+		}),
+		DeltaDial:       envDuration("P2PV2DeltaDial"),
+		DeltaReconcile:  envDuration("P2PV2DeltaReconcile"),
+		ListenAddresses: envStringSlice("P2PV2ListenAddresses"),
 	}
-	if isZeroPtr(c.P2P.V1) {
-		c.P2P.V1 = nil
-	} else if v1Enabled {
-		// restore
-		c.P2P.V1.Enabled = &t
-	}
-
-	if isZeroPtr(c.P2P.V2) {
-		c.P2P.V2 = nil
-	}
-	if isZeroPtr(c.P2P) {
-		c.P2P = nil
+	if (ns == v2 || ns == v1v2) && c.P2P.V2 != (config.P2PV2{}) {
+		c.P2P.V2.Enabled = ptr(true)
 	}
 
-	c.Keeper = &config.Keeper{
+	c.Keeper = config.Keeper{
 		DefaultTransactionQueueDepth: envvar.NewUint32("KeeperDefaultTransactionQueueDepth").ParsePtr(),
 		GasPriceBufferPercent:        envvar.NewUint16("KeeperGasPriceBufferPercent").ParsePtr(),
 		GasTipCapBufferPercent:       envvar.NewUint16("KeeperGasTipCapBufferPercent").ParsePtr(),
@@ -948,7 +694,7 @@ func (c *Config) loadLegacyCoreEnv() {
 		TurnLookBack:                 envvar.NewInt64("KeeperTurnLookBack").ParsePtr(),
 		TurnFlagEnabled:              envvar.NewBool("KeeperTurnFlagEnabled").ParsePtr(),
 		UpkeepCheckGasPriceEnabled:   envvar.NewBool("KeeperCheckUpkeepGasPriceFeatureEnabled").ParsePtr(),
-		Registry: &config.KeeperRegistry{
+		Registry: config.KeeperRegistry{
 			CheckGasOverhead:    envvar.NewUint32("KeeperRegistryCheckGasOverhead").ParsePtr(),
 			PerformGasOverhead:  envvar.NewUint32("KeeperRegistryPerformGasOverhead").ParsePtr(),
 			MaxPerformDataSize:  envvar.NewUint32("KeeperRegistryMaxPerformDataSize").ParsePtr(),
@@ -956,14 +702,8 @@ func (c *Config) loadLegacyCoreEnv() {
 			SyncUpkeepQueueSize: envvar.KeeperRegistrySyncUpkeepQueueSize.ParsePtr(),
 		},
 	}
-	if isZeroPtr(c.Keeper.Registry) {
-		c.Keeper.Registry = nil
-	}
-	if isZeroPtr(c.Keeper) {
-		c.Keeper = nil
-	}
 
-	c.AutoPprof = &config.AutoPprof{
+	c.AutoPprof = config.AutoPprof{
 		Enabled:              envvar.NewBool("AutoPprofEnabled").ParsePtr(),
 		ProfileRoot:          envvar.NewString("AutoPprofProfileRoot").ParsePtr(),
 		PollInterval:         envDuration("AutoPprofPollInterval"),
@@ -977,21 +717,15 @@ func (c *Config) loadLegacyCoreEnv() {
 		MemThreshold:         envvar.New("AutoPprofMemThreshold", parse.FileSize).ParsePtr(),
 		GoroutineThreshold:   envvar.NewInt64("AutoPprofGoroutineThreshold").ParsePtr(),
 	}
-	if isZeroPtr(c.AutoPprof) {
-		c.AutoPprof = nil
-	}
 
-	c.Pyroscope = &config.Pyroscope{
+	c.Pyroscope = config.Pyroscope{
 		AuthToken:     envvar.NewString("PyroscopeAuthToken").ParsePtr(),
 		ServerAddress: envvar.NewString("PyroscopeServerAddress").ParsePtr(),
 		Environment:   envvar.NewString("PyroscopeEnvironment").ParsePtr(),
 	}
-	if isZeroPtr(c.Pyroscope) {
-		c.Pyroscope = nil
-	}
 
 	if dsn := os.Getenv("SENTRY_DSN"); dsn != "" {
-		c.Sentry = &config.Sentry{DSN: &dsn}
+		c.Sentry = config.Sentry{DSN: &dsn}
 		if debug := os.Getenv("SENTRY_DEBUG") == "true"; debug {
 			c.Sentry.Debug = &debug
 		}
@@ -1076,11 +810,6 @@ func envSlice[T any](s string, parse func(*T, []byte) error) *[]T {
 	}).ParsePtr()
 }
 
-func isZeroPtr[T comparable](p *T) bool {
-	var t T
-	return p == nil || *p == t
-}
-
 func mustParseDuration(s string) *models.Duration {
 	if s == "" {
 		return nil
@@ -1091,3 +820,5 @@ func mustParseDuration(s string) *models.Duration {
 	}
 	return &d
 }
+
+func ptr[T any](t T) *T { return &t }

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -755,74 +755,51 @@ func (g *generalConfig) P2PPeerstoreWriteInterval() time.Duration {
 }
 
 func (g *generalConfig) P2PV2AnnounceAddresses() []string {
-	if p := g.c.P2P; p != nil {
-		if v2 := p.V2; v2 != nil {
-			if v := v2.AnnounceAddresses; v != nil {
-				return *v
-			}
-		}
+	if v := g.c.P2P.V2.AnnounceAddresses; v != nil {
+		return *v
 	}
 	return nil
 }
 
 func (g *generalConfig) P2PV2Bootstrappers() (locators []commontypes.BootstrapperLocator) {
-	if p := g.c.P2P; p != nil {
-		if v2 := p.V2; v2 != nil {
-			if v := v2.DefaultBootstrappers; v != nil {
-				return *v
-			}
-		}
+	if v := g.c.P2P.V2.DefaultBootstrappers; v != nil {
+		return *v
 	}
 	return nil
 }
 
 func (g *generalConfig) P2PV2BootstrappersRaw() (s []string) {
-	if p := g.c.P2P; p != nil {
-		if v2 := p.V2; v2 != nil {
-			if v := v2.DefaultBootstrappers; v != nil {
-				for _, b := range *v {
-					t, err := b.MarshalText()
-					if err != nil {
-						// log panic matches old behavior - only called for UI presentation
-						panic(fmt.Sprintf("Failed to marshal bootstrapper: %v", err))
-					}
-					s = append(s, string(t))
-				}
+	if v := g.c.P2P.V2.DefaultBootstrappers; v != nil {
+		for _, b := range *v {
+			t, err := b.MarshalText()
+			if err != nil {
+				// log panic matches old behavior - only called for UI presentation
+				panic(fmt.Sprintf("Failed to marshal bootstrapper: %v", err))
 			}
+			s = append(s, string(t))
 		}
 	}
 	return
 }
 
 func (g *generalConfig) P2PV2DeltaDial() models.Duration {
-	if p := g.c.P2P; p != nil {
-		if v2 := p.V2; v2 != nil {
-			if v := v2.DeltaDial; v != nil {
-				return *v
-			}
-		}
+	if v := g.c.P2P.V2.DeltaDial; v != nil {
+		return *v
 	}
 	return models.Duration{}
 }
 
 func (g *generalConfig) P2PV2DeltaReconcile() models.Duration {
-	if p := g.c.P2P; p != nil {
-		if v2 := p.V2; v2 != nil {
-			if v := v2.DeltaReconcile; v != nil {
-				return *v
-			}
-		}
+	if v := g.c.P2P.V2.DeltaReconcile; v != nil {
+		return *v
+
 	}
 	return models.Duration{}
 }
 
 func (g *generalConfig) P2PV2ListenAddresses() []string {
-	if p := g.c.P2P; p != nil {
-		if v2 := p.V2; v2 != nil {
-			if v := v2.ListenAddresses; v != nil {
-				return *v
-			}
-		}
+	if v := g.c.P2P.V2.ListenAddresses; v != nil {
+		return *v
 	}
 	return nil
 }

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -51,7 +51,7 @@ var (
 		Core: config.Core{
 			RootDir: ptr("my/root/dir"),
 
-			AuditLogger: &audit.AuditLoggerConfig{
+			AuditLogger: audit.AuditLoggerConfig{
 				Enabled:      ptr(true),
 				ForwardToUrl: mustURL("http://localhost:9898"),
 				Headers: ptr(audit.ServiceHeaders{
@@ -67,34 +67,34 @@ var (
 				JsonWrapperKey: ptr("event"),
 			},
 
-			Database: &config.Database{
-				Listener: &config.DatabaseListener{
+			Database: config.Database{
+				Listener: config.DatabaseListener{
 					FallbackPollInterval: models.MustNewDuration(2 * time.Minute),
 				},
 			},
-			Log: &config.Log{
+			Log: config.Log{
 				JSONConsole: ptr(true),
 			},
-			JobPipeline: &config.JobPipeline{
-				HTTPRequest: &config.JobPipelineHTTPRequest{
+			JobPipeline: config.JobPipeline{
+				HTTPRequest: config.JobPipelineHTTPRequest{
 					DefaultTimeout: models.MustNewDuration(30 * time.Second),
 				},
 			},
-			OCR2: &config.OCR2{
+			OCR2: config.OCR2{
 				Enabled:         ptr(true),
 				DatabaseTimeout: models.MustNewDuration(20 * time.Second),
 			},
-			OCR: &config.OCR{
+			OCR: config.OCR{
 				Enabled:           ptr(true),
 				BlockchainTimeout: models.MustNewDuration(5 * time.Second),
 			},
-			P2P: &config.P2P{
+			P2P: config.P2P{
 				IncomingMessageBufferSize: ptr[int64](999),
 			},
-			Keeper: &config.Keeper{
+			Keeper: config.Keeper{
 				GasPriceBufferPercent: ptr[uint16](10),
 			},
-			AutoPprof: &config.AutoPprof{
+			AutoPprof: config.AutoPprof{
 				CPUProfileRate: ptr[int64](7),
 			},
 		},
@@ -118,7 +118,7 @@ var (
 			{
 				ChainID: utils.NewBigI(42),
 				Chain: evmcfg.Chain{
-					GasEstimator: &evmcfg.GasEstimator{
+					GasEstimator: evmcfg.GasEstimator{
 						PriceDefault: assets.NewWeiI(math.MaxInt64),
 					},
 				},
@@ -131,7 +131,7 @@ var (
 			{
 				ChainID: utils.NewBigI(137),
 				Chain: evmcfg.Chain{
-					GasEstimator: &evmcfg.GasEstimator{
+					GasEstimator: evmcfg.GasEstimator{
 						Mode: ptr("FixedPrice"),
 					},
 				},
@@ -230,19 +230,19 @@ func TestConfig_Marshal(t *testing.T) {
 		{Header: "Authorization", Value: "token"},
 		{Header: "X-SomeOther-Header", Value: "value with spaces | and a bar+*"},
 	}
-	full.AuditLogger = &audit.AuditLoggerConfig{
+	full.AuditLogger = audit.AuditLoggerConfig{
 		Enabled:        ptr(true),
 		ForwardToUrl:   mustURL("http://localhost:9898"),
 		Headers:        ptr(serviceHeaders),
 		JsonWrapperKey: ptr("event"),
 	}
 
-	full.Feature = &config.Feature{
+	full.Feature = config.Feature{
 		FeedsManager: ptr(true),
 		LogPoller:    ptr(true),
 		UICSAKeys:    ptr(true),
 	}
-	full.Database = &config.Database{
+	full.Database = config.Database{
 		DefaultIdleInTxSessionTimeout: models.MustNewDuration(time.Minute),
 		DefaultLockTimeout:            models.MustNewDuration(time.Hour),
 		DefaultQueryTimeout:           models.MustNewDuration(time.Second),
@@ -250,23 +250,23 @@ func TestConfig_Marshal(t *testing.T) {
 		MigrateOnStartup: ptr(true),
 		MaxIdleConns:     ptr[int64](7),
 		MaxOpenConns:     ptr[int64](13),
-		Listener: &config.DatabaseListener{
+		Listener: config.DatabaseListener{
 			MaxReconnectDuration: models.MustNewDuration(time.Minute),
 			MinReconnectInterval: models.MustNewDuration(5 * time.Minute),
 			FallbackPollInterval: models.MustNewDuration(2 * time.Minute),
 		},
-		Lock: &config.DatabaseLock{
+		Lock: config.DatabaseLock{
 			LeaseDuration:        &minute,
 			LeaseRefreshInterval: &second,
 		},
-		Backup: &config.DatabaseBackup{
+		Backup: config.DatabaseBackup{
 			Dir:              ptr("test/backup/dir"),
 			Frequency:        &hour,
 			Mode:             &legacy.DatabaseBackupModeFull,
 			OnVersionUpgrade: ptr(true),
 		},
 	}
-	full.TelemetryIngress = &config.TelemetryIngress{
+	full.TelemetryIngress = config.TelemetryIngress{
 		UniConn:      ptr(true),
 		Logging:      ptr(true),
 		ServerPubKey: ptr("test-pub-key"),
@@ -277,18 +277,18 @@ func TestConfig_Marshal(t *testing.T) {
 		SendTimeout:  models.MustNewDuration(5 * time.Second),
 		UseBatchSend: ptr(true),
 	}
-	full.Log = &config.Log{
+	full.Log = config.Log{
 		JSONConsole:     ptr(true),
 		DatabaseQueries: ptr(true),
 		UnixTS:          ptr(true),
-		File: &config.LogFile{
+		File: config.LogFile{
 			Dir:        ptr("log/file/dir"),
 			MaxSize:    ptr[utils.FileSize](100 * utils.GB),
 			MaxAgeDays: ptr[int64](17),
 			MaxBackups: ptr[int64](9),
 		},
 	}
-	full.WebServer = &config.WebServer{
+	full.WebServer = config.WebServer{
 		AllowOrigins:            ptr("*"),
 		BridgeResponseURL:       mustURL("https://bridge.response"),
 		HTTPWriteTimeout:        models.MustNewDuration(time.Minute),
@@ -296,17 +296,17 @@ func TestConfig_Marshal(t *testing.T) {
 		SecureCookies:           ptr(true),
 		SessionTimeout:          models.MustNewDuration(time.Hour),
 		SessionReaperExpiration: models.MustNewDuration(7 * 24 * time.Hour),
-		MFA: &config.WebServerMFA{
+		MFA: config.WebServerMFA{
 			RPID:     ptr("test-rpid"),
 			RPOrigin: ptr("test-rp-origin"),
 		},
-		RateLimit: &config.WebServerRateLimit{
+		RateLimit: config.WebServerRateLimit{
 			Authenticated:         ptr[int64](42),
 			AuthenticatedPeriod:   models.MustNewDuration(time.Second),
 			Unauthenticated:       ptr[int64](7),
 			UnauthenticatedPeriod: models.MustNewDuration(time.Minute),
 		},
-		TLS: &config.WebServerTLS{
+		TLS: config.WebServerTLS{
 			CertPath:      ptr("tls/cert/path"),
 			Host:          ptr("tls-host"),
 			KeyPath:       ptr("tls/key/path"),
@@ -314,22 +314,22 @@ func TestConfig_Marshal(t *testing.T) {
 			ForceRedirect: ptr(true),
 		},
 	}
-	full.JobPipeline = &config.JobPipeline{
+	full.JobPipeline = config.JobPipeline{
 		ExternalInitiatorsEnabled: ptr(true),
 		MaxRunDuration:            models.MustNewDuration(time.Hour),
 		ReaperInterval:            models.MustNewDuration(4 * time.Hour),
 		ReaperThreshold:           models.MustNewDuration(7 * 24 * time.Hour),
 		ResultWriteQueueDepth:     ptr[uint32](10),
-		HTTPRequest: &config.JobPipelineHTTPRequest{
+		HTTPRequest: config.JobPipelineHTTPRequest{
 			MaxSize:        ptr[utils.FileSize](100 * utils.MB),
 			DefaultTimeout: models.MustNewDuration(time.Minute),
 		},
 	}
-	full.FluxMonitor = &config.FluxMonitor{
+	full.FluxMonitor = config.FluxMonitor{
 		DefaultTransactionQueueDepth: ptr[uint32](100),
 		SimulateTransactions:         ptr(true),
 	}
-	full.OCR2 = &config.OCR2{
+	full.OCR2 = config.OCR2{
 		Enabled:                            ptr(true),
 		ContractConfirmations:              ptr[uint32](11),
 		BlockchainTimeout:                  models.MustNewDuration(3 * time.Second),
@@ -339,7 +339,7 @@ func TestConfig_Marshal(t *testing.T) {
 		DatabaseTimeout:                    models.MustNewDuration(8 * time.Second),
 		KeyBundleID:                        ptr(models.MustSha256HashFromHex("7a5f66bbe6594259325bf2b4f5b1a9c9")),
 	}
-	full.OCR = &config.OCR{
+	full.OCR = config.OCR{
 		Enabled:                      ptr(true),
 		ObservationTimeout:           models.MustNewDuration(11 * time.Second),
 		BlockchainTimeout:            models.MustNewDuration(3 * time.Second),
@@ -350,12 +350,12 @@ func TestConfig_Marshal(t *testing.T) {
 		SimulateTransactions:         ptr(true),
 		TransmitterAddress:           ptr(ethkey.MustEIP55Address("0xa0788FC17B1dEe36f057c42B6F373A34B014687e")),
 	}
-	full.P2P = &config.P2P{
+	full.P2P = config.P2P{
 		IncomingMessageBufferSize: ptr[int64](13),
 		OutgoingMessageBufferSize: ptr[int64](17),
 		PeerID:                    mustPeerID("12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw"),
 		TraceLogging:              ptr(true),
-		V1: &config.P2PV1{
+		V1: config.P2PV1{
 			Enabled:                          ptr(false),
 			AnnounceIP:                       mustIP("1.2.3.4"),
 			AnnouncePort:                     ptr[uint16](1234),
@@ -368,7 +368,7 @@ func TestConfig_Marshal(t *testing.T) {
 			NewStreamTimeout:                 models.MustNewDuration(time.Second),
 			PeerstoreWriteInterval:           models.MustNewDuration(time.Minute),
 		},
-		V2: &config.P2PV2{
+		V2: config.P2PV2{
 			Enabled:           ptr(true),
 			AnnounceAddresses: &[]string{"a", "b", "c"},
 			DefaultBootstrappers: &[]ocrcommontypes.BootstrapperLocator{
@@ -380,7 +380,7 @@ func TestConfig_Marshal(t *testing.T) {
 			ListenAddresses: &[]string{"foo", "bar"},
 		},
 	}
-	full.Keeper = &config.Keeper{
+	full.Keeper = config.Keeper{
 		DefaultTransactionQueueDepth: ptr[uint32](17),
 		GasPriceBufferPercent:        ptr[uint16](12),
 		GasTipCapBufferPercent:       ptr[uint16](43),
@@ -389,7 +389,7 @@ func TestConfig_Marshal(t *testing.T) {
 		TurnLookBack:                 ptr[int64](91),
 		TurnFlagEnabled:              ptr(true),
 		UpkeepCheckGasPriceEnabled:   ptr(true),
-		Registry: &config.KeeperRegistry{
+		Registry: config.KeeperRegistry{
 			CheckGasOverhead:    ptr[uint32](90),
 			PerformGasOverhead:  ptr[uint32](math.MaxUint32),
 			SyncInterval:        models.MustNewDuration(time.Hour),
@@ -397,7 +397,7 @@ func TestConfig_Marshal(t *testing.T) {
 			MaxPerformDataSize:  ptr[uint32](5000),
 		},
 	}
-	full.AutoPprof = &config.AutoPprof{
+	full.AutoPprof = config.AutoPprof{
 		Enabled:              ptr(true),
 		ProfileRoot:          ptr("prof/root"),
 		PollInterval:         models.MustNewDuration(time.Minute),
@@ -411,12 +411,12 @@ func TestConfig_Marshal(t *testing.T) {
 		MemThreshold:         ptr[utils.FileSize](utils.GB),
 		GoroutineThreshold:   ptr[int64](999),
 	}
-	full.Pyroscope = &config.Pyroscope{
+	full.Pyroscope = config.Pyroscope{
 		AuthToken:     ptr("pyroscope-token"),
 		ServerAddress: ptr("http://localhost:4040"),
 		Environment:   ptr("tests"),
 	}
-	full.Sentry = &config.Sentry{
+	full.Sentry = config.Sentry{
 		Debug:       ptr(true),
 		DSN:         ptr("sentry-dsn"),
 		Environment: ptr("dev"),
@@ -427,7 +427,7 @@ func TestConfig_Marshal(t *testing.T) {
 			ChainID: utils.NewBigI(1),
 			Enabled: ptr(false),
 			Chain: evmcfg.Chain{
-				BalanceMonitor: &evmcfg.BalanceMonitor{
+				BalanceMonitor: evmcfg.BalanceMonitor{
 					Enabled: ptr(true),
 				},
 				BlockBackfillDepth:   ptr[uint32](100),
@@ -436,7 +436,7 @@ func TestConfig_Marshal(t *testing.T) {
 				FinalityDepth:        ptr[uint32](42),
 				FlagsContractAddress: mustAddress("0xae4E781a6218A8031764928E88d457937A954fC3"),
 
-				GasEstimator: &evmcfg.GasEstimator{
+				GasEstimator: evmcfg.GasEstimator{
 					Mode:               ptr("L2Suggested"),
 					EIP1559DynamicFees: ptr(true),
 					BumpPercent:        ptr[uint16](10),
@@ -462,7 +462,7 @@ func TestConfig_Marshal(t *testing.T) {
 						Keeper: ptr[uint32](1005),
 					},
 
-					BlockHistory: &evmcfg.BlockHistoryEstimator{
+					BlockHistory: evmcfg.BlockHistoryEstimator{
 						BatchSize:                 ptr[uint32](17),
 						BlockHistorySize:          ptr[uint16](12),
 						CheckInclusionBlocks:      ptr[uint16](18),
@@ -475,7 +475,7 @@ func TestConfig_Marshal(t *testing.T) {
 				KeySpecific: []evmcfg.KeySpecific{
 					{
 						Key: mustAddress("0x2a3e23c6f242F5345320814aC8a1b4E58707D292"),
-						GasEstimator: &evmcfg.KeySpecificGasEstimator{
+						GasEstimator: evmcfg.KeySpecificGasEstimator{
 							PriceMax: assets.NewWei(utils.HexToBig("FFFFFFFFFFFFFFFFFFFFFFFF")),
 						},
 					},
@@ -493,7 +493,7 @@ func TestConfig_Marshal(t *testing.T) {
 				RPCDefaultBatchSize:      ptr[uint32](17),
 				RPCBlockQueryDelay:       ptr[uint16](10),
 
-				Transactions: &evmcfg.Transactions{
+				Transactions: evmcfg.Transactions{
 					MaxInFlight:          ptr[uint32](19),
 					MaxQueued:            ptr[uint32](99),
 					ReaperInterval:       &minute,
@@ -502,25 +502,25 @@ func TestConfig_Marshal(t *testing.T) {
 					ForwardersEnabled:    ptr(true),
 				},
 
-				HeadTracker: &evmcfg.HeadTracker{
+				HeadTracker: evmcfg.HeadTracker{
 					HistoryDepth:     ptr[uint32](15),
 					MaxBufferSize:    ptr[uint32](17),
 					SamplingInterval: &hour,
 				},
 
-				NodePool: &evmcfg.NodePool{
+				NodePool: evmcfg.NodePool{
 					PollFailureThreshold: ptr[uint32](5),
 					PollInterval:         &minute,
 					SelectionMode:        &selectionMode,
 				},
-				OCR: &evmcfg.OCR{
+				OCR: evmcfg.OCR{
 					ContractConfirmations:              ptr[uint16](11),
 					ContractTransmitterTransmitTimeout: &minute,
 					DatabaseTimeout:                    &second,
 					ObservationGracePeriod:             &second,
 				},
-				OCR2: &evmcfg.OCR2{
-					Automation: &evmcfg.Automation{
+				OCR2: evmcfg.OCR2{
+					Automation: evmcfg.Automation{
 						GasLimit: ptr[uint32](540),
 					},
 				},
@@ -1124,10 +1124,6 @@ func mustIP(s string) *net.IP {
 		panic(err)
 	}
 	return &ip
-}
-
-func ptr[T any](v T) *T {
-	return &v
 }
 
 var (

--- a/core/web/evm_chains_controller_test.go
+++ b/core/web/evm_chains_controller_test.go
@@ -81,9 +81,9 @@ func Test_EVMChainsController_Show(t *testing.T) {
 				ChainID: validId,
 				Enabled: ptr(true),
 				Chain: evmcfg.DefaultsFrom(nil, &evmcfg.Chain{
-					GasEstimator: &evmcfg.GasEstimator{
+					GasEstimator: evmcfg.GasEstimator{
 						EIP1559DynamicFees: ptr(true),
-						BlockHistory: &evmcfg.BlockHistoryEstimator{
+						BlockHistory: evmcfg.BlockHistoryEstimator{
 							BlockHistorySize: ptr[uint16](50),
 						},
 					},
@@ -152,9 +152,9 @@ func Test_EVMChainsController_Index(t *testing.T) {
 			ChainID: utils.NewBig(testutils.NewRandomEVMChainID()),
 			Chain: evmcfg.DefaultsFrom(nil, &evmcfg.Chain{
 				RPCBlockQueryDelay: ptr[uint16](13),
-				GasEstimator: &evmcfg.GasEstimator{
+				GasEstimator: evmcfg.GasEstimator{
 					EIP1559DynamicFees: ptr(true),
-					BlockHistory: &evmcfg.BlockHistoryEstimator{
+					BlockHistory: evmcfg.BlockHistoryEstimator{
 						BlockHistorySize: ptr[uint16](1),
 					},
 				},
@@ -165,9 +165,9 @@ func Test_EVMChainsController_Index(t *testing.T) {
 			ChainID: utils.NewBig(testutils.NewRandomEVMChainID()),
 			Chain: evmcfg.DefaultsFrom(nil, &evmcfg.Chain{
 				RPCBlockQueryDelay: ptr[uint16](5),
-				GasEstimator: &evmcfg.GasEstimator{
+				GasEstimator: evmcfg.GasEstimator{
 					EIP1559DynamicFees: ptr(false),
-					BlockHistory: &evmcfg.BlockHistoryEstimator{
+					BlockHistory: evmcfg.BlockHistoryEstimator{
 						BlockHistorySize: ptr[uint16](2),
 					},
 				},


### PR DESCRIPTION
We still need to use pointers for individual _fields_ in order to distinguish between empty/zero user input v.s. unset. However, we can leverage `omitempty` on the nested structs to reduce a ton of boilerplate and nil pointer risk.