### PR TITLE
Add an earlier error for an incorrect forwarder vrf config, and fix a string conversion for our ocr2vrf script.

### DIFF
--- a/core/scripts/ocr2vrf/setup_ocr2vrf.go
+++ b/core/scripts/ocr2vrf/setup_ocr2vrf.go
@@ -11,7 +11,6 @@ import (
 	"github.com/shopspring/decimal"
 	"github.com/urfave/cli"
 
-	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
 )
@@ -35,7 +34,7 @@ func setupOCR2VRFNodes(e helpers.Environment) {
 	useForwarder := fs.Bool("use-forwarder", false, "boolean to use the forwarder")
 	confDelays := fs.String("conf-delays", "1,2,3,4,5,6,7,8", "8 confirmation delays")
 	lookbackBlocks := fs.Int64("lookback-blocks", 1000, "lookback blocks")
-	weiPerUnitLink := fs.String("wei-per-unit-link", assets.GWei(60_000_000).String(), "wei per unit link price for feed")
+	weiPerUnitLink := fs.String("wei-per-unit-link", "6e16", "wei per unit link price for feed")
 	beaconPeriodBlocks := fs.Int64("beacon-period-blocks", 3, "beacon period in blocks")
 
 	apiFile := fs.String("api", "../../../tools/secrets/apicredentials", "api credentials file")

--- a/core/scripts/vrfv2/testnet/super_scripts.go
+++ b/core/scripts/vrfv2/testnet/super_scripts.go
@@ -62,10 +62,10 @@ func deployUniverse(e helpers.Environment) {
 	// required flags
 	linkAddress := deployCmd.String("link-address", "", "address of link token")
 	linkEthAddress := deployCmd.String("link-eth-feed", "", "address of link eth feed")
-	subscriptionBalanceString := deployCmd.String("subscription-balance", assets.Ether(10).String(), "amount to fund subscription")
+	subscriptionBalanceString := deployCmd.String("subscription-balance", "1e19", "amount to fund subscription")
 
 	// optional flags
-	fallbackWeiPerUnitLinkString := deployCmd.String("fallback-wei-per-unit-link", assets.GWei(60_000_000).String(), "fallback wei/link ratio")
+	fallbackWeiPerUnitLinkString := deployCmd.String("fallback-wei-per-unit-link", "6e16", "fallback wei/link ratio")
 	registerKeyUncompressedPubKey := deployCmd.String("uncompressed-pub-key", "", "uncompressed public key")
 	registerKeyOracleAddress := deployCmd.String("oracle-address", "", "oracle sender address")
 	minConfs := deployCmd.Int("min-confs", 3, "min confs")

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -163,6 +163,18 @@ func newContractTransmitter(lggr logger.Logger, rargs relaytypes.RelayArgs, tran
 			fromAddresses = append(fromAddresses, common.HexToAddress(s))
 		}
 	} else {
+		// Ensure the transmitter is contained in the sending keys slice.
+		var transmitterFoundLocally bool
+		for _, s := range sendingKeys {
+			if s == effectiveTransmitterAddress.String() {
+				transmitterFoundLocally = true
+				break
+			}
+		}
+		if !transmitterFoundLocally {
+			return nil, errors.New("the transmitter was not found in the list of sending keys, perhaps EvmUseForwarders needs to be enabled")
+		}
+
 		// If not using the forwarder, the effectiveTransmitterAddress (TransmitterID) is used as the from address.
 		fromAddresses = append(fromAddresses, effectiveTransmitterAddress)
 	}


### PR DESCRIPTION
- When a node operator is running a VRF job that has been set up for use with a transaction forwarder, but the operator has not specified `ETH_USE_FORWARDERS`, the job will run but its transmissions will fail:
```2022-10-14T13:21:33.967-0700 [ERROR] eventTTransmitTimeout: ContractTransmitter.Transmit error protocol/transmission.go:325     configDigest=0001bac290239319a0c066a8dd71bc577aac4d149d7b1f1c1a58b490efe5f8ee dkgContractID=0x9D1f7E9e03D0A8316Ec6161F07e3263BE542e40e error=failed to send Eth transaction: Skipped OCR transmission: cannot send transaction from 0x2C7f4FE6B03771bC62cd37057Acc256373CE1ad9 on chain ID 5: no eth key exists with address 0x2C7f4FE6B03771bC62cd37057Acc256373CE1ad9 errorVerbose=no eth key exists with address 0x2C7f4FE6B03771bC62cd37057Acc256373CE1ad9```
- This is correct behavior, technically, but we'd like this failure to occur earlier.
- This PR makes the job error out in the job spawner before even running for the above case, and gives the operator a clearer idea of what is wrong:
![Screen Shot 2022-10-17 at 11 15 47 AM](https://user-images.githubusercontent.com/104409744/196216820-9a42a3f2-c841-45a6-8d26-c40712e4e015.png)
- The change has been tested locally, though I am happy to add an integration test for the given flow if needed.
- Also changed our string formatting for `assets.Ether` in our super scripts, as a package update has broken the way we used them.