### PR TITLE
core/services/job: return errors from spawner.StartService

### DIFF
--- a/core/cmd/jobs_commands_test.go
+++ b/core/cmd/jobs_commands_test.go
@@ -336,10 +336,14 @@ func TestClient_CreateJobV2(t *testing.T) {
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.Database.Listener.FallbackPollInterval = models.MustNewDuration(100 * time.Millisecond)
 		c.OCR.Enabled = ptr(true)
+		c.P2P.V1.Enabled = ptr(true)
+		c.P2P.PeerID = &cltest.DefaultP2PPeerID
 		c.EVM[0].Enabled = ptr(true)
 		c.EVM[0].NonceAutoSync = ptr(false)
 		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
 		c.EVM[0].GasEstimator.Mode = ptr("FixedPrice")
+	}, func(opts *startOptions) {
+		opts.FlagsAndDeps = append(opts.FlagsAndDeps, cltest.DefaultP2PKey)
 	})
 	client, r := app.NewClientAndRenderer()
 

--- a/core/cmd/remote_client_test.go
+++ b/core/cmd/remote_client_test.go
@@ -615,12 +615,15 @@ func TestClient_RunOCRJob_HappyPath(t *testing.T) {
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].Enabled = ptr(true)
 		c.OCR.Enabled = ptr(true)
+		c.P2P.V1.Enabled = ptr(true)
+		c.P2P.PeerID = &cltest.DefaultP2PPeerID
 		c.EVM[0].GasEstimator.Mode = ptr("FixedPrice")
+	}, func(opts *startOptions) {
+		opts.FlagsAndDeps = append(opts.FlagsAndDeps, cltest.DefaultP2PKey)
 	})
 	client, _ := app.NewClientAndRenderer()
 
 	require.NoError(t, app.KeyStore.OCR().Add(cltest.DefaultOCRKey))
-	require.NoError(t, app.KeyStore.P2P().Add(cltest.DefaultP2PKey))
 
 	_, bridge := cltest.MustCreateBridge(t, app.GetSqlxDB(), cltest.BridgeOpts{}, app.GetConfig())
 	_, bridge2 := cltest.MustCreateBridge(t, app.GetSqlxDB(), cltest.BridgeOpts{}, app.GetConfig())

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -313,6 +313,8 @@ func NewApplicationWithConfigAndKey(t testing.TB, c config.GeneralConfig, flagsA
 		switch v := dep.(type) {
 		case ethkey.KeyV2:
 			app.Key = v
+		case p2pkey.KeyV2:
+			require.NoError(t, app.GetKeyStore().P2P().Add(v))
 		case evmtypes.DBChain:
 			chainID = v.ID
 		case *utils.Big:

--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -12,10 +12,8 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	uuid "github.com/satori/go.uuid"
-	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
-	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ocrkey"
-	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/p2pkey"
-	"github.com/smartcontractkit/chainlink/core/utils/crypto"
+
+	"github.com/smartcontractkit/sqlx"
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
 	"github.com/smartcontractkit/chainlink/core/logger"
@@ -23,10 +21,13 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/fluxmonitorv2"
 	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
+	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
+	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ocrkey"
+	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/p2pkey"
 	"github.com/smartcontractkit/chainlink/core/services/ocr"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/utils"
-	"github.com/smartcontractkit/sqlx"
+	"github.com/smartcontractkit/chainlink/core/utils/crypto"
 )
 
 //go:generate mockery --name Service --output ./mocks/ --case=underscore

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -92,9 +92,6 @@ func (d Delegate) JobType() job.Type {
 	return job.OffchainReporting2
 }
 
-func (Delegate) OnJobCreated(spec job.Job) {}
-func (Delegate) OnJobDeleted(spec job.Job) {}
-
 func (Delegate) AfterJobCreated(spec job.Job)  {}
 func (Delegate) BeforeJobDeleted(spec job.Job) {}
 

--- a/core/services/pg/q.go
+++ b/core/services/pg/q.go
@@ -98,14 +98,6 @@ func WithLongQueryTimeout() func(q *Q) {
 	}
 }
 
-// MergeCtx allows callers to combine a ctx with a previously set parent context
-// Responsibility for cancelling the passed context lies with caller
-func MergeCtx(fn func(parentCtx context.Context) context.Context) func(q *Q) {
-	return func(q *Q) {
-		q.ParentCtx = fn(q.ParentCtx)
-	}
-}
-
 var _ Queryer = Q{}
 
 // Q wraps an underlying queryer (either a *sqlx.DB or a *sqlx.Tx)

--- a/core/web/pipeline_runs_controller_test.go
+++ b/core/web/pipeline_runs_controller_test.go
@@ -248,10 +248,11 @@ func setupPipelineRunsControllerTests(t *testing.T) (cltest.HTTPClientCleaner, i
 	cfg := cltest.NewTestGeneralConfig(t)
 	cfg.Overrides.EVMRPCEnabled = null.BoolFrom(false)
 	cfg.Overrides.FeatureOffchainReporting = null.BoolFrom(true)
-	app := cltest.NewApplicationWithConfig(t, cfg, ethClient)
+	cfg.Overrides.P2PEnabled = null.BoolFrom(true)
+	cfg.Overrides.P2PPeerID = cltest.DefaultP2PPeerID
+	app := cltest.NewApplicationWithConfigAndKey(t, cfg, ethClient, cltest.DefaultP2PKey)
 	require.NoError(t, app.Start(testutils.Context(t)))
 	require.NoError(t, app.KeyStore.OCR().Add(cltest.DefaultOCRKey))
-	require.NoError(t, app.KeyStore.P2P().Add(cltest.DefaultP2PKey))
 	client := app.NewHTTPClient(cltest.APIEmailAdmin)
 
 	key, _ := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())


### PR DESCRIPTION
Return an error when a job's services fail to start, and adjust tests affected by the change.