### PR TITLE
core/services/pg: report database stats via prometheus

### DIFF
--- a/core/services/pg/stats.go
+++ b/core/services/pg/stats.go
@@ -1,0 +1,43 @@
+package pg
+
+import (
+	"database/sql"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+const dbStatsInternal = 10 * time.Second
+
+var (
+	promDBConnsMax = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "db_conns_max",
+		Help: "Maximum number of open connections to the database.",
+	})
+	promDBConnsOpen = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "db_conns_open",
+		Help: "The number of established connections both in use and idle.",
+	})
+	promDBConnsInUse = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "db_conns_used",
+		Help: "The number of connections currently in use.",
+	})
+	promDBWaitCount = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "db_wait_count",
+		Help: "The total number of connections waited for.",
+	})
+	promDBWaitDuration = promauto.NewGauge(prometheus.GaugeOpts{
+		Name: "db_wait_time_seconds",
+		Help: "The total time blocked waiting for a new connection.",
+	})
+)
+
+func publishStats(stats sql.DBStats) {
+	promDBConnsMax.Set(float64(stats.MaxOpenConnections))
+	promDBConnsOpen.Set(float64(stats.OpenConnections))
+	promDBConnsInUse.Set(float64(stats.InUse))
+
+	promDBWaitCount.Set(float64(stats.WaitCount))
+	promDBWaitDuration.Set(stats.WaitDuration.Seconds())
+}


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/54731/export-sql-database-stats-via-prometheus
```
# HELP db_conns_max Maximum number of open connections to the database.
# TYPE db_conns_max gauge
db_conns_max 20
# HELP db_conns_open The number of established connections both in use and idle.
# TYPE db_conns_open gauge
db_conns_open 5
# HELP db_conns_used The number of connections currently in use.
# TYPE db_conns_used gauge
db_conns_used 2
# HELP db_wait_count The total number of connections waited for.
# TYPE db_wait_count gauge
db_wait_count 0
# HELP db_wait_time_seconds The total time blocked waiting for a new connection.
# TYPE db_wait_time_seconds gauge
db_wait_time_seconds 0
```