### PR TITLE
chore: update shell.nix and flake.lock tooling, documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,31 +244,31 @@ yarn test
 
 Go generate is used to generate mocks in this project. Mocks are generated with [mockery](https://github.com/vektra/mockery) and live in core/internal/mocks.
 
-### Nix Flake
+### Nix
 
-A [flake](https://nixos.wiki/wiki/Flakes) is provided for use with the [Nix
-package manager](https://nixos.org/). It defines a declarative, reproducible
-development environment.
+A [shell.nix](https://nixos.wiki/wiki/Development_environment_with_nix-shell) is provided for use with the [Nix package manager](https://nixos.org/), with optional [flakes](https://nixos.wiki/wiki/Flakes) support. It defines a declarative, reproducible development environment. Flakes version use deterministic, frozen (`flake.lock`) dependencies, while non-flakes shell will use your channel's packages versions.
 
 To use it:
 
-1. [Nix has to be installed with flake support](https://nixos.wiki/wiki/Flakes#Installing_flakes).
-2. Run `nix develop`. You will be put in shell containing all the dependencies.
-   Alternatively, a `direnv` integration exists to automatically change the
-   environment when `cd`-ing into the folder.
+1. Install [nix package manager](https://nixos.org/download.html) in your system.
+  - Optionally, enable [flakes support](https://nixos.wiki/wiki/Flakes#Enable_flakes)
+2. Run `nix-shell`. You will be put in shell containing all the dependencies.
+  - To use the flakes version, run `nix develop` instead of `nix-shell`. Optionally, `nix develop --command $SHELL` will make use of your current shell instead of the default (bash).
+  - You can use `direnv` to enable it automatically when `cd`-ing into the folder; for that, enable [nix-direnv](https://github.com/nix-community/nix-direnv) and `use nix` or `use flake` on it.
 3. Create a local postgres database:
 
-```
-cd $PGDATA/
+```sh
+mkdir -p $PGDATA && cd $PGDATA/
 initdb
-pg_ctl -l $PGDATA/postgres.log -o "--unix_socket_directories='$PWD'" start
+pg_ctl -l postgres.log -o "--unix_socket_directories='$PWD'" start
 createdb chainlink_test -h localhost
-createuser --superuser --no-password chainlink -h localhost
+createuser --superuser --password chainlink -h localhost
+# then type a test password, e.g.: chainlink, and set it in shell.nix DATABASE_URL
 ```
 
-4. Start postgres, `pg_ctl -l $PGDATA/postgres.log -o "--unix_socket_directories='$PWD'" start`
-
-Now you can run tests or compile code as usual.
+4. When re-entering project, you can restart postgres: `cd $PGDATA; pg_ctl -l postgres.log -o "--unix_socket_directories='$PWD'" start`
+  Now you can run tests or compile code as usual.
+5. When you're done, stop it: `cd $PGDATA; pg_ctl -o "--unix_socket_directories='$PWD'" stop`
 
 ### Tips
 

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1631561581,
-        "narHash": "sha256-3VQMV5zvxaVLvqqUrNz3iJelLw30mIVSfZmAaauM3dA=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e5bf3925f6fbdfaf50a2a7ca0be2879c4261d19",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1633351077,
-        "narHash": "sha256-z38JG4Bb0GtM1aF1pANVdp1dniMP23Yb3HnRoJRy2uU=",
+        "lastModified": 1666109165,
+        "narHash": "sha256-BMLyNVkr0oONuq3lKlFCRVuYqF75CO68Z8EoCh81Zdk=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "14aef06d9b3ad1d07626bdbb16083b83f92dc6c1",
+        "rev": "32096899af23d49010bd8cf6a91695888d9d9e73",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,5 +1,5 @@
 {
-  description = "Hello world";
+  description = "Chainlink development shell";
 
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
@@ -10,9 +10,9 @@
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs { inherit system; overlays = [ ]; };
-      in rec {
-        # packages.hello = 
-        # defaultPackage = packages.hello;
-        devShell = pkgs.callPackage ./shell.nix {};
+      in
+      rec {
+        devShell = pkgs.callPackage ./shell.nix { };
+        formatter = pkgs.nixpkgs-fmt;
       });
 }

--- a/operator_ui/install.sh
+++ b/operator_ui/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 # Dependencies:

--- a/shell.nix
+++ b/shell.nix
@@ -1,32 +1,49 @@
-{ stdenv, pkgs }:
+{ pkgs ? import <nixpkgs> { } }:
+with pkgs;
+let
+  go = go_1_19;
+  postgresql = postgresql_14;
+  nodejs = nodejs-16_x;
+  nodePackages = pkgs.nodePackages.override { inherit nodejs; };
+in
+mkShell {
+  nativeBuildInputs = [
+    go
 
-pkgs.mkShell {
-  nativeBuildInputs = with pkgs; [
-    go_1_17
-
-    postgresql_13
+    postgresql
     python3
     python3Packages.pip
     curl
-    nodejs-16_x
+    nodejs
+    nodePackages.pnpm
     # TODO: compiler / gcc for secp compilation
-    nodePackages.ganache-cli
+    nodePackages.ganache
     # py3: web3 slither-analyzer crytic-compile
     # echidna
-    # go-ethereum # geth
+    go-ethereum # geth
     # parity # openethereum
-    # go-mockery
+    go-mockery
 
     # tooling
-    goimports
+    gotools
     gopls
     delve
     golangci-lint
 
     # gofuzz
+  ] ++ lib.optionals stdenv.isLinux [
+    # some dependencies needed for node-gyp on yarn install
+    pkg-config
+    libudev-zero
+    libusb1
   ];
-  LD_LIBRARY_PATH="${stdenv.cc.cc.lib}/lib64:$LD_LIBRARY_PATH";
-  GOROOT="${pkgs.go_1_17}/share/go";
+  LD_LIBRARY_PATH = "${stdenv.cc.cc.lib}/lib64:$LD_LIBRARY_PATH";
+  GOROOT = "${go}/share/go";
 
-  PGDATA="db";
+  PGDATA = "db";
+  DATABASE_URL = "postgresql://chainlink:chainlink@localhost:5432/chainlink_test?sslmode=disable";
+  shellHook = ''
+    export GOPATH=$HOME/go
+    export PATH=$GOPATH/bin:$PATH
+  '';
 }

--- a/shell.nix
+++ b/shell.nix
@@ -29,6 +29,7 @@ mkShell {
     gopls
     delve
     golangci-lint
+    github-cli
 
     # gofuzz
   ] ++ lib.optionals stdenv.isLinux [


### PR DESCRIPTION
This should work with current version of nixpkgs repositories. Could not test integration tests, but basic development dependencies and tests are working on this version of `shell.nix`.
Same PR as #7662 , re-created from upstream branch instead of personal fork to be able to run CI.