### PR TITLE
hn/ocr2dr oracle pubkey

### DIFF
--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -207,6 +207,8 @@ jobs:
         uses: ./.github/actions/setup-nodejs
         with:
           prod: "true"
+      - name: Install diff-so-fancy
+        run: npm i -g diff-so-fancy
       - name: Setup Go
         if: ${{ needs.changes.outputs.changes == 'true' }}
         uses: ./.github/actions/setup-go
@@ -218,7 +220,7 @@ jobs:
         run: ./tools/ci/check_solc_hashes
       - name: Display git diff
         if: ${{ needs.changes.outputs.changes == 'true' }}
-        run: git diff --minimal
+        run: git diff --minimal --color --exit-code | diff-so-fancy
 
   lint:
     defaults:

--- a/contracts/src/v0.8/dev/interfaces/OCR2DRClientInterface.sol
+++ b/contracts/src/v0.8/dev/interfaces/OCR2DRClientInterface.sol
@@ -6,12 +6,12 @@ pragma solidity ^0.8.6;
  */
 interface OCR2DRClientInterface {
   /**
-   * @notice Returns DON public key used to encrypt secrets
+   * @notice Returns DON secp256k1 public key used to encrypt secrets
    * @dev All Oracles nodes have the corresponding private key
    * needed to decrypt the secrets encrypted with the public key
    * @return publicKey DON's public key
    */
-  function getDONPublicKey() external view returns (bytes32);
+  function getDONPublicKey() external view returns (bytes memory);
 
   /**
    * @notice OCR2DR response handler called by the designated oracle.

--- a/contracts/src/v0.8/dev/interfaces/OCR2DROracleInterface.sol
+++ b/contracts/src/v0.8/dev/interfaces/OCR2DROracleInterface.sol
@@ -6,12 +6,12 @@ pragma solidity ^0.8.6;
  */
 interface OCR2DROracleInterface {
   /**
-   * @notice Returns DON public key used to encrypt secrets
+   * @notice Returns DON secp256k1 public key used to encrypt secrets
    * @dev All Oracles nodes have the corresponding private key
    * needed to decrypt the secrets encrypted with the public key
    * @return publicKey DON's public key
    */
-  function getDONPublicKey() external view returns (bytes32);
+  function getDONPublicKey() external view returns (bytes memory);
 
   /**
    * @notice Sends a request (encoded as data) using the provided subscriptionId

--- a/contracts/src/v0.8/dev/ocr2dr/OCR2DRClient.sol
+++ b/contracts/src/v0.8/dev/ocr2dr/OCR2DRClient.sol
@@ -25,7 +25,7 @@ abstract contract OCR2DRClient is OCR2DRClientInterface {
   }
 
   /// @inheritdoc OCR2DRClientInterface
-  function getDONPublicKey() external view override returns (bytes32) {
+  function getDONPublicKey() external view override returns (bytes memory) {
     return s_oracle.getDONPublicKey();
   }
 

--- a/contracts/src/v0.8/dev/ocr2dr/OCR2DROracle.sol
+++ b/contracts/src/v0.8/dev/ocr2dr/OCR2DROracle.sol
@@ -24,11 +24,11 @@ contract OCR2DROracle is OCR2DROracleInterface, AuthorizedReceiver, ConfirmedOwn
 
   uint256 private constant MINIMUM_CONSUMER_GAS_LIMIT = 400000;
 
-  bytes32 private s_donPublicKey;
+  bytes private s_donPublicKey;
   uint256 private s_nonce;
   mapping(bytes32 => Commitment) private s_commitments;
 
-  constructor(address owner, bytes32 donPublicKey) ConfirmedOwner(owner) {
+  constructor(address owner, bytes memory donPublicKey) ConfirmedOwner(owner) {
     s_donPublicKey = donPublicKey;
   }
 
@@ -41,7 +41,7 @@ contract OCR2DROracle is OCR2DROracleInterface, AuthorizedReceiver, ConfirmedOwn
   }
 
   /// @inheritdoc OCR2DROracleInterface
-  function getDONPublicKey() external view override returns (bytes32) {
+  function getDONPublicKey() external view override returns (bytes memory) {
     return s_donPublicKey;
   }
 

--- a/contracts/src/v0.8/dev/ocr2dr/OCR2DROracleFactory.sol
+++ b/contracts/src/v0.8/dev/ocr2dr/OCR2DROracleFactory.sol
@@ -25,10 +25,10 @@ contract OCR2DROracleFactory {
 
   /**
    * @notice creates a new Oracle contract with the msg.sender as owner
-   * @param donPublicKey DON's public key used to encrypt user secrets
+   * @param donPublicKey DON's secp256k1 public key used to encrypt user secrets as an Uint8Array
    * @return address Address of a newly deployed oracle
    */
-  function deployNewOracle(bytes32 donPublicKey) external returns (address) {
+  function deployNewOracle(bytes calldata donPublicKey) external returns (address) {
     OCR2DROracle oracle = new OCR2DROracle(msg.sender, donPublicKey);
     s_created.add(address(oracle));
     emit OracleCreated(address(oracle), msg.sender, msg.sender);


### PR DESCRIPTION
- Change donPublicKey from bytes32 -> bytes to hold secp256k1 public key
- Display rich diff on failure of go wrappers
