### PR TITLE
core/internal/cltest: mock SubscribeFilterLogs for callers of NewEthMocksWithStartupAssertions

### DIFF
--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"math/big"
@@ -585,6 +586,7 @@ func NewEthMocksWithStartupAssertions(t testing.TB) *evmMocks.Client {
 	c.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).Maybe().Return(Head(0), nil)
 	c.On("ChainID").Maybe().Return(&FixtureChainID)
 	c.On("CallContract", mock.Anything, mock.Anything, mock.Anything).Maybe().Return([]byte{}, nil)
+	c.On("SubscribeFilterLogs", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(nil, errors.New("mocked"))
 	c.On("CodeAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return([]byte{}, nil)
 	c.On("Close").Maybe().Return()
 


### PR DESCRIPTION
This fixes a test flake that I recently introduced in `TestPipelineRunsController_Show_HappyPath`, and maybe other users of `NewEthMocksWithStartupAssertions`. In #7705 I added `CallContract` and `CodeAt` but sometimes `SubscribeFilterLogs` is called too. We don't need to mock anything real - just not crash.

[Here is an example](https://github.com/smartcontractkit/chainlink/actions/runs/3305180032) of the test failing, with a bonus race detected inside of mockery when trying to print the atomic internals of a `context.Context` (:roll_eyes: haven't seen that one in a while....)