### PR TITLE
TOML config: env vars

### DIFF
--- a/core/bridges/orm.go
+++ b/core/bridges/orm.go
@@ -37,7 +37,7 @@ type orm struct {
 
 var _ ORM = (*orm)(nil)
 
-func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) ORM {
+func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) ORM {
 	namedLogger := lggr.Named("BridgeORM")
 	return &orm{q: pg.NewQ(db, namedLogger, cfg)}
 }

--- a/core/chains/evm/config/config_test.go
+++ b/core/chains/evm/config/config_test.go
@@ -254,15 +254,15 @@ func TestChainScopedConfig_Profiles(t *testing.T) {
 	}
 }
 
-func configWithChain(t *testing.T, id int64, chain *v2.Chain) config.GeneralConfig {
-	return configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-		chainID := utils.NewBigI(id)
-		c.EVM[0] = &v2.EVMConfig{ChainID: chainID, Enabled: ptr(true), Chain: v2.DefaultsFrom(chainID, chain),
-			Nodes: v2.EVMNodes{{Name: ptr("fake"), HTTPURL: models.MustParseURL("http://foo.test")}}}
-	})
-}
-
 func Test_chainScopedConfig_Validate(t *testing.T) {
+	configWithChain := func(t *testing.T, id int64, chain *v2.Chain) config.GeneralConfig {
+		return configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			chainID := utils.NewBigI(id)
+			c.EVM[0] = &v2.EVMConfig{ChainID: chainID, Enabled: ptr(true), Chain: v2.DefaultsFrom(chainID, chain),
+				Nodes: v2.EVMNodes{{Name: ptr("fake"), HTTPURL: models.MustParseURL("http://foo.test")}}}
+		})
+	}
+
 	// Validate built-in
 	for id := range evmconfig.ChainSpecificConfigDefaultSets() {
 		id := id

--- a/core/chains/evm/config/mocks/chain_scoped_config.go
+++ b/core/chains/evm/config/mocks/chain_scoped_config.go
@@ -679,6 +679,48 @@ func (_m *ChainScopedConfig) DatabaseBackupURL() *url.URL {
 	return r0
 }
 
+// DatabaseDefaultIdleInTxSessionTimeout provides a mock function with given fields:
+func (_m *ChainScopedConfig) DatabaseDefaultIdleInTxSessionTimeout() time.Duration {
+	ret := _m.Called()
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
+// DatabaseDefaultLockTimeout provides a mock function with given fields:
+func (_m *ChainScopedConfig) DatabaseDefaultLockTimeout() time.Duration {
+	ret := _m.Called()
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
+// DatabaseDefaultQueryTimeout provides a mock function with given fields:
+func (_m *ChainScopedConfig) DatabaseDefaultQueryTimeout() time.Duration {
+	ret := _m.Called()
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
 // DatabaseListenerMaxReconnectDuration provides a mock function with given fields:
 func (_m *ChainScopedConfig) DatabaseListenerMaxReconnectDuration() time.Duration {
 	ret := _m.Called()

--- a/core/chains/evm/forwarders/forwarder_manager.go
+++ b/core/chains/evm/forwarders/forwarder_manager.go
@@ -19,6 +19,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/authorized_receiver"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/offchain_aggregator_wrapper"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
@@ -27,7 +28,7 @@ var authChangedTopic = authorized_receiver.AuthorizedReceiverAuthorizedSendersCh
 
 type Config interface {
 	gas.Config
-	LogSQL() bool
+	pg.QConfig
 }
 
 type FwdMgr struct {

--- a/core/chains/evm/forwarders/forwarder_manager_test.go
+++ b/core/chains/evm/forwarders/forwarder_manager_test.go
@@ -56,7 +56,7 @@ func TestFwdMgr_MaybeForwardTransaction(t *testing.T) {
 	t.Log(authorized)
 
 	evmClient := client.NewSimulatedBackendClient(t, ec, testutils.FixtureChainID)
-	lp := logpoller.NewLogPoller(logpoller.NewORM(testutils.FixtureChainID, db, lggr, pgtest.NewPGCfg(true)), evmClient, lggr, 100*time.Millisecond, 2, 3, 2, 1000)
+	lp := logpoller.NewLogPoller(logpoller.NewORM(testutils.FixtureChainID, db, lggr, pgtest.NewQConfig(true)), evmClient, lggr, 100*time.Millisecond, 2, 3, 2, 1000)
 	fwdMgr := forwarders.NewFwdMgr(db, evmClient, lp, lggr, evmcfg)
 	fwdMgr.ORM = forwarders.NewORM(db, logger.TestLogger(t), cfg)
 
@@ -96,7 +96,7 @@ func TestFwdMgr_AccountUnauthorizedToForward_SkipsForwarding(t *testing.T) {
 	ec.Commit()
 
 	evmClient := client.NewSimulatedBackendClient(t, ec, testutils.FixtureChainID)
-	lp := logpoller.NewLogPoller(logpoller.NewORM(testutils.FixtureChainID, db, lggr, pgtest.NewPGCfg(true)), evmClient, lggr, 100*time.Millisecond, 2, 3, 2, 1000)
+	lp := logpoller.NewLogPoller(logpoller.NewORM(testutils.FixtureChainID, db, lggr, pgtest.NewQConfig(true)), evmClient, lggr, 100*time.Millisecond, 2, 3, 2, 1000)
 	fwdMgr := forwarders.NewFwdMgr(db, evmClient, lp, lggr, evmcfg)
 	fwdMgr.ORM = forwarders.NewORM(db, logger.TestLogger(t), cfg)
 

--- a/core/chains/evm/forwarders/orm.go
+++ b/core/chains/evm/forwarders/orm.go
@@ -26,7 +26,7 @@ type orm struct {
 
 var _ ORM = (*orm)(nil)
 
-func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) *orm {
+func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) *orm {
 	return &orm{pg.NewQ(db, lggr, cfg)}
 }
 

--- a/core/chains/evm/headtracker/orm.go
+++ b/core/chains/evm/headtracker/orm.go
@@ -35,7 +35,7 @@ type orm struct {
 	chainID utils.Big
 }
 
-func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig, chainID big.Int) ORM {
+func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig, chainID big.Int) ORM {
 	return &orm{pg.NewQ(db, lggr.Named("HeadTrackerORM"), cfg), utils.Big(chainID)}
 }
 

--- a/core/chains/evm/legacy.go
+++ b/core/chains/evm/legacy.go
@@ -14,6 +14,7 @@ import (
 
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
@@ -23,7 +24,7 @@ type LegacyEthNodeConfig interface {
 	EthereumHTTPURL() *url.URL
 	EthereumSecondaryURLs() []url.URL
 	EthereumNodes() string
-	LogSQL() bool
+	pg.QConfig
 }
 
 const missingEthChainIDMsg = `missing ETH_CHAIN_ID; this env var is required if ETH_URL is set

--- a/core/chains/evm/legacy_test.go
+++ b/core/chains/evm/legacy_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
 type legacyEthNodeConfig struct {
@@ -23,6 +24,7 @@ type legacyEthNodeConfig struct {
 	ethereumHTTPURL       *url.URL
 	ethereumSecondaryURLs []url.URL
 	evmNodes              string
+	pg.QConfig
 }
 
 func (c legacyEthNodeConfig) DefaultChainID() *big.Int {
@@ -45,8 +47,6 @@ func (c legacyEthNodeConfig) EthereumNodes() string {
 	return c.evmNodes
 }
 
-func (c legacyEthNodeConfig) LogSQL() bool { return false }
-
 func Test_ClobberDBFromEnv(t *testing.T) {
 	var fixtureChains int64 = 2
 	var fixtureNodes int64 = 1
@@ -59,6 +59,7 @@ func Test_ClobberDBFromEnv(t *testing.T) {
 			ethereumURL:           "ws://example.com/foo/ws",
 			ethereumHTTPURL:       cltest.MustParseURL(t, "http://example.com/foo"),
 			ethereumSecondaryURLs: []url.URL{*cltest.MustParseURL(t, "http://secondary1.example/foo"), *cltest.MustParseURL(t, "https://secondary2.example/bar")},
+			QConfig:               pgtest.NewQConfig(false),
 		}
 
 		err := evm.ClobberDBFromEnv(db, cfg, logger.TestLogger(t))
@@ -104,6 +105,7 @@ func Test_ClobberDBFromEnv(t *testing.T) {
 			ethereumURL:           "ws://example.com/foo/ws",
 			ethereumHTTPURL:       cltest.MustParseURL(t, "http://example.com/foo"),
 			ethereumSecondaryURLs: []url.URL{*cltest.MustParseURL(t, "http://example.com/foo"), *cltest.MustParseURL(t, "https://secondary2.example/bar")},
+			QConfig:               pgtest.NewQConfig(false),
 		}
 
 		lggr, observedLogs := logger.TestLoggerObserved(t, zap.ErrorLevel)
@@ -184,6 +186,7 @@ func TestSetupNodes(t *testing.T) {
 
 	cfg := legacyEthNodeConfig{
 		evmNodes: s,
+		QConfig:  pgtest.NewQConfig(false),
 	}
 
 	err := evm.SetupNodes(db, cfg, logger.TestLogger(t))

--- a/core/chains/evm/log/orm.go
+++ b/core/chains/evm/log/orm.go
@@ -53,7 +53,7 @@ type orm struct {
 
 var _ ORM = (*orm)(nil)
 
-func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig, evmChainID big.Int) *orm {
+func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig, evmChainID big.Int) *orm {
 	return &orm{pg.NewQ(db, lggr, cfg), *utils.NewBig(&evmChainID)}
 }
 

--- a/core/chains/evm/logpoller/helper_test.go
+++ b/core/chains/evm/logpoller/helper_test.go
@@ -40,7 +40,7 @@ func SetupTH(t *testing.T, finalityDepth, backfillBatchSize, rpcBatchSize int64)
 	db := pgtest.NewSqlxDB(t)
 	require.NoError(t, utils.JustError(db.Exec(`SET CONSTRAINTS log_poller_blocks_evm_chain_id_fkey DEFERRED`)))
 	require.NoError(t, utils.JustError(db.Exec(`SET CONSTRAINTS logs_evm_chain_id_fkey DEFERRED`)))
-	o := NewORM(chainID, db, lggr, pgtest.NewPGCfg(true))
+	o := NewORM(chainID, db, lggr, pgtest.NewQConfig(true))
 	owner := testutils.MustNewSimTransactor(t)
 	ec := backends.NewSimulatedBackend(map[common.Address]core.GenesisAccount{
 		owner.From: {

--- a/core/chains/evm/logpoller/integration_test.go
+++ b/core/chains/evm/logpoller/integration_test.go
@@ -38,7 +38,7 @@ func TestPopulateLoadedDB(t *testing.T) {
 	chainID := big.NewInt(137)
 	_, err := db.Exec(`INSERT INTO evm_chains (id, created_at, updated_at) VALUES ($1, NOW(), NOW())`, utils.NewBig(chainID))
 	require.NoError(t, err)
-	o := logpoller.NewORM(big.NewInt(137), db, lggr, pgtest.NewPGCfg(true))
+	o := logpoller.NewORM(big.NewInt(137), db, lggr, pgtest.NewQConfig(true))
 	event1 := EmitterABI.Events["Log1"].ID
 	address1 := common.HexToAddress("0x2ab9a2Dc53736b361b72d900CdF9F78F9406fbbb")
 	address2 := common.HexToAddress("0x6E225058950f237371261C985Db6bDe26df2200E")

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -100,7 +100,7 @@ func TestLogPoller_SynchronizedWithGeth(t *testing.T) {
 		t.Log("Starting test", mineOrReorg)
 		chainID := testutils.NewRandomEVMChainID()
 		// Set up a test chain with a log emitting contract deployed.
-		orm := NewORM(chainID, db, lggr, pgtest.NewPGCfg(true))
+		orm := NewORM(chainID, db, lggr, pgtest.NewQConfig(true))
 		// Note this property test is run concurrently and the sim is not threadsafe.
 		ec := backends.NewSimulatedBackend(map[common.Address]core.GenesisAccount{
 			owner.From: {

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -20,7 +20,7 @@ type ORM struct {
 }
 
 // NewORM creates an ORM scoped to chainID.
-func NewORM(chainID *big.Int, db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) *ORM {
+func NewORM(chainID *big.Int, db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) *ORM {
 	namedLogger := lggr.Named("ORM")
 	q := pg.NewQ(db, namedLogger, cfg)
 	return &ORM{

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -23,8 +23,8 @@ func setup(t testing.TB) (*ORM, *ORM) {
 	lggr := logger.TestLogger(t)
 	require.NoError(t, utils.JustError(db.Exec(`SET CONSTRAINTS log_poller_blocks_evm_chain_id_fkey DEFERRED`)))
 	require.NoError(t, utils.JustError(db.Exec(`SET CONSTRAINTS logs_evm_chain_id_fkey DEFERRED`)))
-	o1 := NewORM(big.NewInt(137), db, lggr, pgtest.NewPGCfg(true))
-	o2 := NewORM(big.NewInt(138), db, lggr, pgtest.NewPGCfg(true))
+	o1 := NewORM(big.NewInt(137), db, lggr, pgtest.NewQConfig(true))
+	o2 := NewORM(big.NewInt(138), db, lggr, pgtest.NewQConfig(true))
 	return o1, o2
 }
 

--- a/core/chains/evm/orm.go
+++ b/core/chains/evm/orm.go
@@ -11,7 +11,7 @@ import (
 )
 
 // NewORM returns a new EVM ORM
-func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) types.ORM {
+func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) types.ORM {
 	q := pg.NewQ(db, lggr.Named("EVMORM"), cfg)
 	return chains.NewORM[utils.Big, *types.ChainCfg, types.Node](q, "evm", "ws_url", "http_url", "send_only")
 }

--- a/core/chains/evm/orm_test.go
+++ b/core/chains/evm/orm_test.go
@@ -20,7 +20,7 @@ func setupORM(t *testing.T) (*sqlx.DB, types.ORM) {
 	t.Helper()
 
 	db := pgtest.NewSqlxDB(t)
-	orm := evm.NewORM(db, logger.TestLogger(t), pgtest.PGCfg{})
+	orm := evm.NewORM(db, logger.TestLogger(t), pgtest.NewQConfig(true))
 
 	return db, orm
 }

--- a/core/chains/evm/txmgr/eth_resender_test.go
+++ b/core/chains/evm/txmgr/eth_resender_test.go
@@ -26,7 +26,7 @@ func Test_EthResender_FindEthTxAttemptsRequiringResend(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	logCfg := pgtest.NewPGCfg(true)
+	logCfg := pgtest.NewQConfig(true)
 	borm := cltest.NewTxmORM(t, db, logCfg)
 
 	ethKeyStore := cltest.NewKeyStore(t, db, logCfg).Eth()

--- a/core/chains/evm/txmgr/mocks/config.go
+++ b/core/chains/evm/txmgr/mocks/config.go
@@ -130,6 +130,20 @@ func (_m *Config) ChainType() config.ChainType {
 	return r0
 }
 
+// DatabaseDefaultQueryTimeout provides a mock function with given fields:
+func (_m *Config) DatabaseDefaultQueryTimeout() time.Duration {
+	ret := _m.Called()
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
 // EthTxReaperInterval provides a mock function with given fields:
 func (_m *Config) EthTxReaperInterval() time.Duration {
 	ret := _m.Called()

--- a/core/chains/evm/txmgr/nonce_syncer.go
+++ b/core/chains/evm/txmgr/nonce_syncer.go
@@ -69,7 +69,7 @@ type (
 )
 
 // NewNonceSyncer returns a new syncer
-func NewNonceSyncer(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig, ethClient evmclient.Client, kst NonceSyncerKeyStore) *NonceSyncer {
+func NewNonceSyncer(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig, ethClient evmclient.Client, kst NonceSyncerKeyStore) *NonceSyncer {
 	lggr = lggr.Named("NonceSyncer")
 	q := pg.NewQ(db, lggr, cfg)
 	return &NonceSyncer{

--- a/core/chains/evm/txmgr/orm.go
+++ b/core/chains/evm/txmgr/orm.go
@@ -34,7 +34,7 @@ type orm struct {
 
 var _ ORM = (*orm)(nil)
 
-func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) ORM {
+func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) ORM {
 	namedLogger := lggr.Named("TxmORM")
 	q := pg.NewQ(db, namedLogger, cfg)
 	return &orm{q, namedLogger}

--- a/core/chains/evm/txmgr/strategies.go
+++ b/core/chains/evm/txmgr/strategies.go
@@ -1,6 +1,9 @@
 package txmgr
 
 import (
+	"context"
+	"time"
+
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 
@@ -8,6 +11,7 @@ import (
 )
 
 // TxStrategy controls how txes are queued and sent
+//
 //go:generate mockery --name TxStrategy --output ./mocks/ --case=underscore --structname TxStrategy --filename tx_strategy.go
 type TxStrategy interface {
 	// Subject will be saved to eth_txes.subject if not null
@@ -20,9 +24,9 @@ var _ TxStrategy = SendEveryStrategy{}
 
 // NewQueueingTxStrategy creates a new TxStrategy that drops the oldest transactions after the
 // queue size is exceeded if a queue size is specified, and otherwise does not drop transactions.
-func NewQueueingTxStrategy(subject uuid.UUID, queueSize uint32) (strategy TxStrategy) {
+func NewQueueingTxStrategy(subject uuid.UUID, queueSize uint32, queryTimeout time.Duration) (strategy TxStrategy) {
 	if queueSize > 0 {
-		strategy = NewDropOldestStrategy(subject, queueSize)
+		strategy = NewDropOldestStrategy(subject, queueSize, queryTimeout)
 	} else {
 		strategy = SendEveryStrategy{}
 	}
@@ -45,14 +49,15 @@ var _ TxStrategy = DropOldestStrategy{}
 // DropOldestStrategy will send the newest N transactions, older ones will be
 // removed from the queue
 type DropOldestStrategy struct {
-	subject   uuid.UUID
-	queueSize uint32
+	subject      uuid.UUID
+	queueSize    uint32
+	queryTimeout time.Duration
 }
 
 // NewDropOldestStrategy creates a new TxStrategy that drops the oldest transactions after the
 // queue size is exceeded.
-func NewDropOldestStrategy(subject uuid.UUID, queueSize uint32) DropOldestStrategy {
-	return DropOldestStrategy{subject, queueSize}
+func NewDropOldestStrategy(subject uuid.UUID, queueSize uint32, queryTimeout time.Duration) DropOldestStrategy {
+	return DropOldestStrategy{subject, queueSize, queryTimeout}
 }
 
 func (s DropOldestStrategy) Subject() uuid.NullUUID {
@@ -60,7 +65,7 @@ func (s DropOldestStrategy) Subject() uuid.NullUUID {
 }
 
 func (s DropOldestStrategy) PruneQueue(q pg.Queryer) (n int64, err error) {
-	ctx, cancel := pg.DefaultQueryCtx()
+	ctx, cancel := context.WithTimeout(context.Background(), s.queryTimeout)
 	defer cancel()
 	res, err := q.ExecContext(ctx, `
 DELETE FROM eth_txes

--- a/core/chains/evm/txmgr/strategies_test.go
+++ b/core/chains/evm/txmgr/strategies_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
 func Test_SendEveryStrategy(t *testing.T) {
@@ -29,7 +30,7 @@ func Test_DropOldestStrategy_Subject(t *testing.T) {
 	t.Parallel()
 
 	subject := uuid.NewV4()
-	s := txmgr.NewDropOldestStrategy(subject, 1)
+	s := txmgr.NewDropOldestStrategy(subject, 1, pg.DefaultQueryTimeout)
 
 	assert.True(t, s.Subject().Valid)
 	assert.Equal(t, subject, s.Subject().UUID)
@@ -66,7 +67,7 @@ func Test_DropOldestStrategy_PruneQueue(t *testing.T) {
 	}
 
 	t.Run("with queue size of 2, removes everything except the newest two transactions for the given subject, ignoring fromAddress", func(t *testing.T) {
-		s := txmgr.NewDropOldestStrategy(subj1, 2)
+		s := txmgr.NewDropOldestStrategy(subj1, 2, pg.DefaultQueryTimeout)
 
 		n, err := s.PruneQueue(db)
 		require.NoError(t, err)

--- a/core/chains/evm/txmgr/txmgr.go
+++ b/core/chains/evm/txmgr/txmgr.go
@@ -37,6 +37,7 @@ import (
 //go:generate mockery --recursive --name Config --output ./mocks/ --case=underscore --structname Config --filename config.go
 type Config interface {
 	gas.Config
+	pg.QConfig
 	EthTxReaperInterval() time.Duration
 	EthTxReaperThreshold() time.Duration
 	EthTxResendAfterThreshold() time.Duration
@@ -50,7 +51,6 @@ type Config interface {
 	EvmRPCDefaultBatchSize() uint32
 	KeySpecificMaxGasPriceWei(addr common.Address) *assets.Wei
 	TriggerFallbackDBPollInterval() time.Duration
-	LogSQL() bool
 }
 
 // KeyStore encompasses the subset of keystore used by txmgr

--- a/core/chains/evm/txmgr/txmgr_test.go
+++ b/core/chains/evm/txmgr/txmgr_test.go
@@ -53,7 +53,7 @@ func TestTxm_SendEther_DoesNotSendToZero(t *testing.T) {
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	lggr := logger.TestLogger(t)
 	checkerFactory := &testCheckerFactory{}
-	lp := logpoller.NewLogPoller(logpoller.NewORM(testutils.FixtureChainID, db, lggr, pgtest.NewPGCfg(true)), ethClient, lggr, 100*time.Millisecond, 2, 3, 2, 1000)
+	lp := logpoller.NewLogPoller(logpoller.NewORM(testutils.FixtureChainID, db, lggr, pgtest.NewQConfig(true)), ethClient, lggr, 100*time.Millisecond, 2, 3, 2, 1000)
 	txm := txmgr.NewTxm(db, ethClient, config, nil, nil, lggr, checkerFactory, lp)
 
 	_, err := txm.SendEther(big.NewInt(0), from, to, *value, 21000)
@@ -218,7 +218,7 @@ func TestTxm_CreateEthTransaction(t *testing.T) {
 
 	lggr := logger.TestLogger(t)
 	checkerFactory := &testCheckerFactory{}
-	lp := logpoller.NewLogPoller(logpoller.NewORM(testutils.FixtureChainID, db, lggr, pgtest.NewPGCfg(true)), ethClient, lggr, 100*time.Millisecond, 2, 3, 2, 1000)
+	lp := logpoller.NewLogPoller(logpoller.NewORM(testutils.FixtureChainID, db, lggr, pgtest.NewQConfig(true)), ethClient, lggr, 100*time.Millisecond, 2, 3, 2, 1000)
 	txm := txmgr.NewTxm(db, ethClient, config, kst.Eth(), nil, lggr, checkerFactory, lp)
 
 	t.Run("with queue under capacity inserts eth_tx", func(t *testing.T) {
@@ -473,6 +473,7 @@ func newMockConfig(t *testing.T) *txmmocks.Config {
 	cfg.On("EvmMinGasPriceWei").Return(assets.NewWeiI(42)).Maybe().Once()
 	cfg.On("EvmUseForwarders").Return(true).Maybe()
 	cfg.On("LogSQL").Maybe().Return(false)
+	cfg.On("DatabaseDefaultQueryTimeout").Return(pg.DefaultQueryTimeout).Maybe()
 
 	return cfg
 }
@@ -498,7 +499,7 @@ func TestTxm_CreateEthTransaction_OutOfEth(t *testing.T) {
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	lggr := logger.TestLogger(t)
-	lp := logpoller.NewLogPoller(logpoller.NewORM(testutils.FixtureChainID, db, lggr, pgtest.NewPGCfg(true)), ethClient, lggr, 100*time.Millisecond, 2, 3, 2, 1000)
+	lp := logpoller.NewLogPoller(logpoller.NewORM(testutils.FixtureChainID, db, lggr, pgtest.NewQConfig(true)), ethClient, lggr, 100*time.Millisecond, 2, 3, 2, 1000)
 	kst := cltest.NewKeyStore(t, db, cfg)
 	txm := txmgr.NewTxm(db, ethClient, config, kst.Eth(), nil, lggr, &testCheckerFactory{}, lp)
 
@@ -594,7 +595,7 @@ func TestTxm_Lifecycle(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	checkerFactory := &testCheckerFactory{}
 
-	lp := logpoller.NewLogPoller(logpoller.NewORM(testutils.FixtureChainID, db, lggr, pgtest.NewPGCfg(true)), ethClient, lggr, 100*time.Millisecond, 2, 3, 2, 1000)
+	lp := logpoller.NewLogPoller(logpoller.NewORM(testutils.FixtureChainID, db, lggr, pgtest.NewQConfig(true)), ethClient, lggr, 100*time.Millisecond, 2, 3, 2, 1000)
 	txm := txmgr.NewTxm(db, ethClient, config, kst, eventBroadcaster, lggr, checkerFactory, lp)
 
 	head := cltest.Head(42)

--- a/core/chains/solana/legacy.go
+++ b/core/chains/solana/legacy.go
@@ -9,13 +9,13 @@ import (
 	"github.com/smartcontractkit/sqlx"
 
 	solanadb "github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
-
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
 type SetupConfig interface {
 	SolanaNodes() string
-	LogSQL() bool
+	pg.QConfig
 }
 
 // SetupNodes is a hack/shim method to allow node operators to specify multiple nodes via ENV.

--- a/core/chains/solana/legacy_test.go
+++ b/core/chains/solana/legacy_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	solanadb "github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 
 	"github.com/smartcontractkit/chainlink/core/chains/solana"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
@@ -48,6 +49,7 @@ func TestSetupNodes(t *testing.T) {
 
 	cfg := config{
 		solanaNodes: s,
+		QConfig:     pgtest.NewQConfig(false),
 	}
 
 	err := solana.SetupNodes(db, cfg, logger.TestLogger(t))
@@ -70,10 +72,9 @@ func TestSetupNodes(t *testing.T) {
 
 type config struct {
 	solanaNodes string
+	pg.QConfig
 }
 
 func (c config) SolanaNodes() string {
 	return c.solanaNodes
 }
-
-func (c config) LogSQL() bool { return false }

--- a/core/chains/solana/orm.go
+++ b/core/chains/solana/orm.go
@@ -40,7 +40,7 @@ var _ chains.ORM[string, *soldb.ChainCfg, soldb.Node] = (ORM)(nil)
 
 // NewORM returns an ORM backed by db.
 // https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
-func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) ORM {
+func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) ORM {
 	q := pg.NewQ(db, lggr.Named("ORM"), cfg)
 	return chains.NewORM[string, *soldb.ChainCfg, soldb.Node](q, "solana", "solana_url")
 }

--- a/core/chains/solana/orm_test.go
+++ b/core/chains/solana/orm_test.go
@@ -21,7 +21,7 @@ func setupORM(t *testing.T) (*sqlx.DB, solana.ORM) {
 	t.Helper()
 
 	db := pgtest.NewSqlxDB(t)
-	orm := solana.NewORM(db, logger.TestLogger(t), pgtest.NewPGCfg(true))
+	orm := solana.NewORM(db, logger.TestLogger(t), pgtest.NewQConfig(true))
 
 	return db, orm
 }

--- a/core/chains/starknet/legacy.go
+++ b/core/chains/starknet/legacy.go
@@ -9,13 +9,14 @@ import (
 	"github.com/smartcontractkit/sqlx"
 
 	starknetdb "github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/db"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
 type SetupConfig interface {
 	StarkNetNodes() string
-	LogSQL() bool
+	pg.QConfig
 }
 
 // SetupNodes is a hack/shim method to allow node operators to specify multiple nodes via ENV.

--- a/core/chains/starknet/orm.go
+++ b/core/chains/starknet/orm.go
@@ -12,7 +12,7 @@ import (
 )
 
 // https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
-func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) types.ORM {
+func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) types.ORM {
 	q := pg.NewQ(db, lggr.Named("ORM"), cfg)
 	return chains.NewORM[string, *starknetdb.ChainCfg, starknetdb.Node](q, "starknet", "url")
 }

--- a/core/chains/starknet/orm_test.go
+++ b/core/chains/starknet/orm_test.go
@@ -22,7 +22,7 @@ func setupORM(t *testing.T) (*sqlx.DB, types.ORM) {
 	t.Helper()
 
 	db := pgtest.NewSqlxDB(t)
-	orm := starknet.NewORM(db, logger.TestLogger(t), pgtest.NewPGCfg(true))
+	orm := starknet.NewORM(db, logger.TestLogger(t), pgtest.NewQConfig(true))
 
 	return db, orm
 }

--- a/core/chains/terra/chain.go
+++ b/core/chains/terra/chain.go
@@ -52,7 +52,7 @@ type chain struct {
 	lggr           logger.Logger
 }
 
-func newChain(id string, cfg terra.Config, db *sqlx.DB, ks keystore.Terra, logCfg pg.LogConfig, eb pg.EventBroadcaster, orm types.ORM, lggr logger.Logger) (*chain, error) {
+func newChain(id string, cfg terra.Config, db *sqlx.DB, ks keystore.Terra, logCfg pg.QConfig, eb pg.EventBroadcaster, orm types.ORM, lggr logger.Logger) (*chain, error) {
 	lggr = lggr.With("terraChainID", id)
 	var ch = chain{
 		id:   id,

--- a/core/chains/terra/legacy.go
+++ b/core/chains/terra/legacy.go
@@ -9,13 +9,14 @@ import (
 	"github.com/smartcontractkit/sqlx"
 
 	terradb "github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
 type SetupConfig interface {
 	TerraNodes() string
-	LogSQL() bool
+	pg.QConfig
 }
 
 // SetupNodes is a hack/shim method to allow node operators to specify multiple nodes via ENV.

--- a/core/chains/terra/legacy_test.go
+++ b/core/chains/terra/legacy_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	terradb "github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 
 	"github.com/smartcontractkit/chainlink/core/chains/terra"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
@@ -48,6 +49,7 @@ func TestSetupNodes(t *testing.T) {
 
 	cfg := config{
 		terraNodes: s,
+		QConfig:    pgtest.NewQConfig(false),
 	}
 
 	err := terra.SetupNodes(db, cfg, logger.TestLogger(t))
@@ -70,10 +72,9 @@ func TestSetupNodes(t *testing.T) {
 
 type config struct {
 	terraNodes string
+	pg.QConfig
 }
 
 func (c config) TerraNodes() string {
 	return c.terraNodes
 }
-
-func (c config) LogSQL() bool { return false }

--- a/core/chains/terra/orm.go
+++ b/core/chains/terra/orm.go
@@ -13,7 +13,7 @@ import (
 
 // NewORM returns an ORM backed by db.
 // https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
-func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) types.ORM {
+func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) types.ORM {
 	q := pg.NewQ(db, lggr.Named("ORM"), cfg)
 	return chains.NewORM[string, *terradb.ChainCfg, terradb.Node](q, "terra", "tendermint_url")
 }

--- a/core/chains/terra/orm_test.go
+++ b/core/chains/terra/orm_test.go
@@ -22,7 +22,7 @@ func setupORM(t *testing.T) (*sqlx.DB, types.ORM) {
 	t.Helper()
 
 	db := pgtest.NewSqlxDB(t)
-	orm := terra.NewORM(db, logger.TestLogger(t), pgtest.NewPGCfg(true))
+	orm := terra.NewORM(db, logger.TestLogger(t), pgtest.NewQConfig(true))
 
 	return db, orm
 }

--- a/core/chains/terra/terratxm/orm.go
+++ b/core/chains/terra/terratxm/orm.go
@@ -5,9 +5,10 @@ import (
 
 	"github.com/pkg/errors"
 
+	"github.com/smartcontractkit/sqlx"
+
 	"github.com/smartcontractkit/chainlink-terra/pkg/terra"
 	"github.com/smartcontractkit/chainlink-terra/pkg/terra/db"
-	"github.com/smartcontractkit/sqlx"
 
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
@@ -20,7 +21,7 @@ type ORM struct {
 }
 
 // NewORM creates an ORM scoped to chainID.
-func NewORM(chainID string, db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) *ORM {
+func NewORM(chainID string, db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) *ORM {
 	namedLogger := lggr.Named("ORM")
 	q := pg.NewQ(db, namedLogger, cfg)
 	return &ORM{

--- a/core/chains/terra/terratxm/orm_test.go
+++ b/core/chains/terra/terratxm/orm_test.go
@@ -20,7 +20,7 @@ import (
 func TestORM(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
 	lggr := logger.TestLogger(t)
-	logCfg := pgtest.NewPGCfg(true)
+	logCfg := pgtest.NewQConfig(true)
 	chainID := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))
 	_, err := terra.NewORM(db, lggr, logCfg).CreateChain(chainID, nil)
 	require.NoError(t, err)

--- a/core/chains/terra/terratxm/txm.go
+++ b/core/chains/terra/terratxm/txm.go
@@ -49,7 +49,7 @@ type Txm struct {
 }
 
 // NewTxm creates a txm. Uses simulation so should only be used to send txes to trusted contracts i.e. OCR.
-func NewTxm(db *sqlx.DB, tc func() (terraclient.ReaderWriter, error), gpe terraclient.ComposedGasPriceEstimator, chainID string, cfg terra.Config, ks keystore.Terra, lggr logger.Logger, logCfg pg.LogConfig, eb pg.EventBroadcaster) *Txm {
+func NewTxm(db *sqlx.DB, tc func() (terraclient.ReaderWriter, error), gpe terraclient.ComposedGasPriceEstimator, chainID string, cfg terra.Config, ks keystore.Terra, lggr logger.Logger, logCfg pg.QConfig, eb pg.EventBroadcaster) *Txm {
 	lggr = lggr.Named("Txm")
 	return &Txm{
 		starter: utils.StartStopOnce{},

--- a/core/chains/terra/terratxm/txm_internal_test.go
+++ b/core/chains/terra/terratxm/txm_internal_test.go
@@ -46,7 +46,7 @@ func newReaderWriterMock(t *testing.T) *tcmocks.ReaderWriter {
 func TestTxm(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
 	lggr := testutils.LoggerAssertMaxLevel(t, zapcore.ErrorLevel)
-	ks := keystore.New(db, utils.FastScryptParams, lggr, pgtest.NewPGCfg(true))
+	ks := keystore.New(db, utils.FastScryptParams, lggr, pgtest.NewQConfig(true))
 	require.NoError(t, ks.Unlock("blah"))
 	k1, err := ks.Terra().Create()
 	require.NoError(t, err)
@@ -60,7 +60,7 @@ func TestTxm(t *testing.T) {
 	require.NoError(t, err)
 	contract2, err := cosmostypes.AccAddressFromBech32("terra1mx72uukvzqtzhc6gde7shrjqfu5srk22v7gmww")
 	require.NoError(t, err)
-	logCfg := pgtest.NewPGCfg(true)
+	logCfg := pgtest.NewQConfig(true)
 	chainID := fmt.Sprintf("Chainlinktest-%d", rand.Int31n(999999))
 	terratest.MustInsertChain(t, db, &Chain{ID: chainID})
 	require.NoError(t, err)
@@ -112,7 +112,7 @@ func TestTxm(t *testing.T) {
 	t.Run("two msgs different accounts", func(t *testing.T) {
 		tc := newReaderWriterMock(t)
 		tcFn := func() (terraclient.ReaderWriter, error) { return tc, nil }
-		txm := NewTxm(db, tcFn, *gpe, chainID, cfg, ks.Terra(), lggr, pgtest.NewPGCfg(true), nil)
+		txm := NewTxm(db, tcFn, *gpe, chainID, cfg, ks.Terra(), lggr, pgtest.NewQConfig(true), nil)
 
 		id1, err := txm.Enqueue(contract.String(), generateExecuteMsg(t, []byte(`0`), sender1, contract))
 		require.NoError(t, err)
@@ -167,7 +167,7 @@ func TestTxm(t *testing.T) {
 	t.Run("two msgs different contracts", func(t *testing.T) {
 		tc := newReaderWriterMock(t)
 		tcFn := func() (terraclient.ReaderWriter, error) { return tc, nil }
-		txm := NewTxm(db, tcFn, *gpe, chainID, cfg, ks.Terra(), lggr, pgtest.NewPGCfg(true), nil)
+		txm := NewTxm(db, tcFn, *gpe, chainID, cfg, ks.Terra(), lggr, pgtest.NewQConfig(true), nil)
 
 		id1, err := txm.Enqueue(contract.String(), generateExecuteMsg(t, []byte(`0`), sender1, contract))
 		require.NoError(t, err)
@@ -231,7 +231,7 @@ func TestTxm(t *testing.T) {
 		}, errors.New("not found")).Twice()
 		cfg := terra.NewConfig(ChainCfg{}, lggr)
 		tcFn := func() (terraclient.ReaderWriter, error) { return tc, nil }
-		txm := NewTxm(db, tcFn, *gpe, chainID, cfg, ks.Terra(), lggr, pgtest.NewPGCfg(true), nil)
+		txm := NewTxm(db, tcFn, *gpe, chainID, cfg, ks.Terra(), lggr, pgtest.NewQConfig(true), nil)
 		i, err := txm.orm.InsertMsg("blah", "", []byte{0x01})
 		require.NoError(t, err)
 		txh := "0x123"
@@ -261,7 +261,7 @@ func TestTxm(t *testing.T) {
 			TxResponse: &cosmostypes.TxResponse{TxHash: txHash3},
 		}, nil).Once()
 		tcFn := func() (terraclient.ReaderWriter, error) { return tc, nil }
-		txm := NewTxm(db, tcFn, *gpe, chainID, cfg, ks.Terra(), lggr, pgtest.NewPGCfg(true), nil)
+		txm := NewTxm(db, tcFn, *gpe, chainID, cfg, ks.Terra(), lggr, pgtest.NewQConfig(true), nil)
 
 		// Insert and broadcast 3 msgs with different txhashes.
 		id1, err := txm.orm.InsertMsg("blah", "", []byte{0x01})
@@ -302,7 +302,7 @@ func TestTxm(t *testing.T) {
 			MaxMsgsPerBatch: null.IntFrom(2),
 			TxMsgTimeout:    &timeout,
 		}, lggr)
-		txm := NewTxm(db, tcFn, *gpe, chainID, cfgShortExpiry, ks.Terra(), lggr, pgtest.NewPGCfg(true), nil)
+		txm := NewTxm(db, tcFn, *gpe, chainID, cfgShortExpiry, ks.Terra(), lggr, pgtest.NewQConfig(true), nil)
 
 		// Send a single one expired
 		id1, err := txm.orm.InsertMsg("blah", "", []byte{0x03})
@@ -345,7 +345,7 @@ func TestTxm(t *testing.T) {
 		cfg := terra.NewConfig(ChainCfg{
 			MaxMsgsPerBatch: null.IntFrom(2),
 		}, lggr)
-		txm := NewTxm(db, tcFn, *gpe, chainID, cfg, ks.Terra(), lggr, pgtest.NewPGCfg(true), nil)
+		txm := NewTxm(db, tcFn, *gpe, chainID, cfg, ks.Terra(), lggr, pgtest.NewQConfig(true), nil)
 
 		// Leftover started is processed
 		msg1 := generateExecuteMsg(t, []byte{0x03}, sender1, contract)

--- a/core/chains/terra/terratxm/txm_test.go
+++ b/core/chains/terra/terratxm/txm_test.go
@@ -13,11 +13,12 @@ import (
 	"github.com/onsi/gomega"
 	uuid "github.com/satori/go.uuid"
 	"github.com/shopspring/decimal"
-	terraclient "github.com/smartcontractkit/chainlink-terra/pkg/terra/client"
-	tercfg "github.com/smartcontractkit/chainlink-terra/pkg/terra/config"
 	"github.com/smartcontractkit/terra.go/msg"
 	"github.com/stretchr/testify/require"
 	wasmtypes "github.com/terra-money/core/x/wasm/types"
+
+	terraclient "github.com/smartcontractkit/chainlink-terra/pkg/terra/client"
+	tercfg "github.com/smartcontractkit/chainlink-terra/pkg/terra/config"
 
 	"github.com/smartcontractkit/chainlink/core/chains/terra"
 	"github.com/smartcontractkit/chainlink/core/chains/terra/terratxm"
@@ -45,7 +46,7 @@ func TestTxm_Integration(t *testing.T) {
 		c.Terra = terra.TerraConfigs{&chain}
 	})
 	lggr := logger.TestLogger(t)
-	logCfg := pgtest.NewPGCfg(true)
+	logCfg := pgtest.NewQConfig(true)
 	gpe := terraclient.NewMustGasPriceEstimator([]terraclient.GasPricesEstimator{
 		terraclient.NewFixedGasPriceEstimator(map[string]sdk.DecCoin{
 			"uluna": fallbackGasPrice,
@@ -55,7 +56,7 @@ func TestTxm_Integration(t *testing.T) {
 	eb := pg.NewEventBroadcaster(cfg.DatabaseURL(), 0, 0, lggr, uuid.NewV4())
 	require.NoError(t, eb.Start(testutils.Context(t)))
 	t.Cleanup(func() { require.NoError(t, eb.Close()) })
-	ks := keystore.New(db, utils.FastScryptParams, lggr, pgtest.NewPGCfg(true))
+	ks := keystore.New(db, utils.FastScryptParams, lggr, pgtest.NewQConfig(true))
 	accounts, testdir, tendermintURL := terraclient.SetupLocalTerraNode(t, "42")
 	tc, err := terraclient.NewClient("42", tendermintURL, terra.DefaultRequestTimeout, lggr)
 	require.NoError(t, err)
@@ -82,7 +83,7 @@ func TestTxm_Integration(t *testing.T) {
 
 	tcFn := func() (terraclient.ReaderWriter, error) { return tc, nil }
 	// Start txm
-	txm := terratxm.NewTxm(db, tcFn, *gpe, chainID, &chain, ks.Terra(), lggr, pgtest.NewPGCfg(true), eb)
+	txm := terratxm.NewTxm(db, tcFn, *gpe, chainID, &chain, ks.Terra(), lggr, pgtest.NewQConfig(true), eb)
 	require.NoError(t, txm.Start(testutils.Context(t)))
 
 	// Change the contract state

--- a/core/cmd/cfgtest/app_test.go
+++ b/core/cmd/cfgtest/app_test.go
@@ -27,7 +27,7 @@ func TestDefaultConfig(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	chainID := utils.NewBigI(42991337)
 
-	newGeneral, err := chainlink.GeneralConfigTOML{}.New(lggr)
+	newGeneral, err := chainlink.GeneralConfigOpts{}.New(lggr)
 	require.NoError(t, err)
 	legacyGeneral := config.NewGeneralConfig(lggr)
 
@@ -40,6 +40,7 @@ func TestDefaultConfig(t *testing.T) {
 	t.Run("general-test", func(t *testing.T) {
 		assertMethodsReturnEqual[config.GeneralConfig](t, configtest.NewTestGeneralConfig(t), configtest2.NewTestGeneralConfig(t),
 			"KeystorePassword", // new has a dummy value to pass validation
+			"DatabaseURL",      // new has a dummy value to pass validation
 
 			// Legacy package cltest defaults that were made standard.
 			"JobPipelineReaperInterval",

--- a/core/cmd/client_test.go
+++ b/core/cmd/client_test.go
@@ -137,17 +137,18 @@ func TestTerminalAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			db := pgtest.NewSqlxDB(t)
-			orm := sessions.NewORM(db, time.Minute, logger.TestLogger(t), pgtest.NewPGCfg(true), audit.NoopLogger)
+			lggr := logger.TestLogger(t)
+			orm := sessions.NewORM(db, time.Minute, lggr, pgtest.NewQConfig(true), audit.NoopLogger)
 
 			mock := &cltest.MockCountingPrompter{T: t, EnteredStrings: test.enteredStrings, NotTerminal: !test.isTerminal}
-			tai := cmd.NewPromptingAPIInitializer(mock, logger.TestLogger(t))
+			tai := cmd.NewPromptingAPIInitializer(mock)
 
 			// Clear out fixture users/users created from the other test cases
 			// This asserts that on initial run with an empty users table that the credentials file will instantiate and
 			// create/run with a new admin user
 			pgtest.MustExec(t, db, "DELETE FROM users;")
 
-			user, err := tai.Initialize(orm)
+			user, err := tai.Initialize(orm, lggr)
 			if test.isError {
 				assert.Error(t, err)
 			} else {
@@ -167,7 +168,8 @@ func TestTerminalAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 func TestTerminalAPIInitializer_InitializeWithExistingAPIUser(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
 	cfg := configtest.NewGeneralConfig(t, nil)
-	orm := sessions.NewORM(db, time.Minute, logger.TestLogger(t), cfg, audit.NoopLogger)
+	lggr := logger.TestLogger(t)
+	orm := sessions.NewORM(db, time.Minute, lggr, cfg, audit.NoopLogger)
 
 	// Clear out fixture users/users created from the other test cases
 	// This asserts that on initial run with an empty users table that the credentials file will instantiate and
@@ -179,10 +181,10 @@ func TestTerminalAPIInitializer_InitializeWithExistingAPIUser(t *testing.T) {
 	require.NoError(t, orm.CreateUser(&initialUser))
 
 	mock := &cltest.MockCountingPrompter{T: t}
-	tai := cmd.NewPromptingAPIInitializer(mock, logger.TestLogger(t))
+	tai := cmd.NewPromptingAPIInitializer(mock)
 
 	// If there is an existing user, and we are in the Terminal prompt, no input prompts required
-	user, err := tai.Initialize(orm)
+	user, err := tai.Initialize(orm, lggr)
 	assert.NoError(t, err)
 	assert.Equal(t, 0, mock.Count)
 
@@ -203,15 +205,16 @@ func TestFileAPIInitializer_InitializeWithoutAPIUser(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			db := pgtest.NewSqlxDB(t)
-			orm := sessions.NewORM(db, time.Minute, logger.TestLogger(t), pgtest.NewPGCfg(true), audit.NoopLogger)
+			lggr := logger.TestLogger(t)
+			orm := sessions.NewORM(db, time.Minute, lggr, pgtest.NewQConfig(true), audit.NoopLogger)
 
 			// Clear out fixture users/users created from the other test cases
 			// This asserts that on initial run with an empty users table that the credentials file will instantiate and
 			// create/run with a new admin user
 			pgtest.MustExec(t, db, "DELETE FROM users;")
 
-			tfi := cmd.NewFileAPIInitializer(test.file, logger.TestLogger(t))
-			user, err := tfi.Initialize(orm)
+			tfi := cmd.NewFileAPIInitializer(test.file)
+			user, err := tfi.Initialize(orm, lggr)
 			if test.wantError {
 				assert.Error(t, err)
 			} else {
@@ -241,8 +244,9 @@ func TestFileAPIInitializer_InitializeWithExistingAPIUser(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			tfi := cmd.NewFileAPIInitializer(test.file, logger.TestLogger(t))
-			user, err := tfi.Initialize(orm)
+			lggr := logger.TestLogger(t)
+			tfi := cmd.NewFileAPIInitializer(test.file)
+			user, err := tfi.Initialize(orm, lggr)
 			if test.wantError {
 				assert.Error(t, err)
 			} else {

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -74,23 +74,9 @@ func TestClient_RunNodeShowsEnv(t *testing.T) {
 	err = logFileSize.UnmarshalText([]byte("100mb"))
 	assert.NoError(t, err)
 
-	lcfg := logger.Config{
-		LogLevel:      zapcore.DebugLevel,
-		FileMaxSizeMB: int(logFileSize / utils.MB),
-		Dir:           t.TempDir(),
-	}
-
-	tmpFile, err := os.CreateTemp(lcfg.Dir, "*")
-	assert.NoError(t, err)
-	defer tmpFile.Close()
-
-	newLogger, closeLogger := lcfg.New()
-
 	runner := cltest.BlockedRunner{Done: make(chan struct{})}
 	client := cmd.Client{
 		Config:                 cfg,
-		Logger:                 newLogger,
-		CloseLogger:            closeLogger,
 		AppFactory:             cltest.InstanceAppFactory{App: app},
 		FallbackAPIInitializer: cltest.NewMockAPIInitializer(t),
 		Runner:                 runner,
@@ -204,7 +190,7 @@ CHAINLINK_TLS_HOST:
 CHAINLINK_TLS_PORT: 6689
 CHAINLINK_TLS_REDIRECT: false`, cfg.RootDir())
 
-	logs, err := cltest.ReadLogs(lcfg.Dir)
+	logs, err := cltest.ReadLogs(cfg.LogFileDir())
 	assert.NoError(t, err)
 
 	require.Contains(t, logs, expected, fmt.Sprintf("Expected to find:\n\n%s\n\nWithin:\n\n%s\n\nDiff:\n\n%s", expected, logs, diff.Diff(expected, logs)))
@@ -224,7 +210,7 @@ func TestClient_RunNodeWithPasswords(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-				s.KeystorePassword = ptr("dummy")
+				s.Password.Keystore = models.NewSecret("dummy")
 				c.EVM[0].Nodes[0].Name = ptr("fake")
 				c.EVM[0].Nodes[0].HTTPURL = models.MustParseURL("http://fake.com")
 			})
@@ -258,7 +244,6 @@ func TestClient_RunNodeWithPasswords(t *testing.T) {
 				Runner:                 cltest.EmptyRunner{},
 				AppFactory:             cltest.InstanceAppFactory{App: app},
 				Logger:                 lggr,
-				CloseLogger:            lggr.Sync,
 			}
 
 			set := flag.NewFlagSet("test", 0)
@@ -291,7 +276,7 @@ func TestClient_RunNodeWithAPICredentialsFile(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
-				s.KeystorePassword = ptr("16charlengthp4SsW0rD1!@#_")
+				s.Password.Keystore = models.NewSecret("16charlengthp4SsW0rD1!@#_")
 				c.EVM[0].Nodes[0].Name = ptr("fake")
 				c.EVM[0].Nodes[0].HTTPURL = models.MustParseURL("http://fake.com")
 			})
@@ -332,7 +317,6 @@ func TestClient_RunNodeWithAPICredentialsFile(t *testing.T) {
 				FallbackAPIInitializer: apiPrompt,
 				Runner:                 cltest.EmptyRunner{},
 				Logger:                 lggr,
-				CloseLogger:            lggr.Sync,
 			}
 
 			set := flag.NewFlagSet("test", 0)
@@ -432,7 +416,6 @@ func TestClient_RebroadcastTransactions_Txm(t *testing.T) {
 		FallbackAPIInitializer: cltest.NewMockAPIInitializer(t),
 		Runner:                 cltest.EmptyRunner{},
 		Logger:                 lggr,
-		CloseLogger:            lggr.Sync,
 	}
 
 	for i := beginningNonce; i <= endingNonce; i++ {
@@ -502,7 +485,6 @@ func TestClient_RebroadcastTransactions_OutsideRange_Txm(t *testing.T) {
 				FallbackAPIInitializer: cltest.NewMockAPIInitializer(t),
 				Runner:                 cltest.EmptyRunner{},
 				Logger:                 lggr,
-				CloseLogger:            lggr.Sync,
 			}
 
 			for i := beginningNonce; i <= endingNonce; i++ {

--- a/core/cmd/ocr2vrf_configure_commands.go
+++ b/core/cmd/ocr2vrf_configure_commands.go
@@ -138,7 +138,7 @@ func (cli *Client) ConfigureOCR2VRFNode(c *clipkg.Context) (*SetupOCR2VRFNodePay
 	}
 	defer lggr.ErrorIfClosing(ldb, "db")
 
-	app, err := cli.AppFactory.NewApplication(rootCtx, cli.Config, ldb.DB())
+	app, err := cli.AppFactory.NewApplication(rootCtx, cli.Config, lggr, ldb.DB())
 	if err != nil {
 		return nil, cli.errorOut(errors.Wrap(err, "fatal error instantiating application"))
 	}

--- a/core/cmd/terra_transaction_commands_test.go
+++ b/core/cmd/terra_transaction_commands_test.go
@@ -63,7 +63,7 @@ func TestClient_SendTerraCoins(t *testing.T) {
 	}, time.Minute, 5*time.Second)
 
 	db := app.GetSqlxDB()
-	orm := terratxm.NewORM(chainID, db, logger.TestLogger(t), pgtest.NewPGCfg(true))
+	orm := terratxm.NewORM(chainID, db, logger.TestLogger(t), pgtest.NewQConfig(true))
 
 	client, r := app.NewClientAndRenderer()
 	cliapp := cli.NewApp()

--- a/core/config/envvar/envvar.go
+++ b/core/config/envvar/envvar.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/config/parse"
 )
 
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 // nolint
 var (
 	AdvisoryLockID                    = NewInt64("AdvisoryLockID")
@@ -20,7 +21,7 @@ var (
 	AutoPprofPollInterval             = NewDuration("AutoPprofPollInterval")
 	AutoPprofGatherDuration           = NewDuration("AutoPprofGatherDuration")
 	AutoPprofGatherTraceDuration      = NewDuration("AutoPprofGatherTraceDuration")
-	DatabaseURL                       = New("DatabaseURL", parse.DatabaseURL) //TODO move to v2.CL*?
+	DatabaseURL                       = New("DatabaseURL", parse.DatabaseURL)
 	BlockBackfillDepth                = NewUint64("BlockBackfillDepth")
 	HTTPServerWriteTimeout            = NewDuration("HTTPServerWriteTimeout")
 	JobPipelineMaxRunDuration         = NewDuration("JobPipelineMaxRunDuration")
@@ -33,6 +34,7 @@ var (
 	KeeperRegistrySyncInterval        = NewDuration("KeeperRegistrySyncInterval")
 	KeeperRegistrySyncUpkeepQueueSize = NewUint32("KeeperRegistrySyncUpkeepQueueSize")
 	LogLevel                          = New[zapcore.Level]("LogLevel", parse.LogLevel)
+	LogSQL                            = NewBool("LogSQL")
 	RootDir                           = New[string]("RootDir", parse.HomeDir)
 	JSONConsole                       = NewBool("JSONConsole")
 	LogFileMaxSize                    = New("LogFileMaxSize", parse.FileSize)

--- a/core/config/general_config.go
+++ b/core/config/general_config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/config/parse"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/logger/audit"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/static"
 	"github.com/smartcontractkit/chainlink/core/store/dialects"
 	"github.com/smartcontractkit/chainlink/core/store/models"
@@ -98,6 +99,9 @@ type BasicConfig interface {
 	DatabaseBackupMode() DatabaseBackupMode
 	DatabaseBackupOnVersionUpgrade() bool
 	DatabaseBackupURL() *url.URL
+	DatabaseDefaultIdleInTxSessionTimeout() time.Duration
+	DatabaseDefaultLockTimeout() time.Duration
+	DatabaseDefaultQueryTimeout() time.Duration
 	DatabaseListenerMaxReconnectDuration() time.Duration
 	DatabaseListenerMinReconnectInterval() time.Duration
 	DatabaseLockingMode() string
@@ -670,6 +674,18 @@ func (c *generalConfig) DatabaseBackupOnVersionUpgrade() bool {
 // DatabaseBackupDir configures the directory for saving the backup file, if it's to be different from default one located in the RootDir
 func (c *generalConfig) DatabaseBackupDir() string {
 	return c.viper.GetString(envvar.Name("DatabaseBackupDir"))
+}
+
+func (c *generalConfig) DatabaseDefaultIdleInTxSessionTimeout() time.Duration {
+	return pg.DefaultIdleInTxSessionTimeout
+}
+
+func (c *generalConfig) DatabaseDefaultLockTimeout() time.Duration {
+	return pg.DefaultLockTimeout
+}
+
+func (c *generalConfig) DatabaseDefaultQueryTimeout() time.Duration {
+	return pg.DefaultQueryTimeout
 }
 
 // DatabaseURL configures the URL for chainlink to connect to. This must be

--- a/core/config/mocks/general_config.go
+++ b/core/config/mocks/general_config.go
@@ -514,6 +514,48 @@ func (_m *GeneralConfig) DatabaseBackupURL() *url.URL {
 	return r0
 }
 
+// DatabaseDefaultIdleInTxSessionTimeout provides a mock function with given fields:
+func (_m *GeneralConfig) DatabaseDefaultIdleInTxSessionTimeout() time.Duration {
+	ret := _m.Called()
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
+// DatabaseDefaultLockTimeout provides a mock function with given fields:
+func (_m *GeneralConfig) DatabaseDefaultLockTimeout() time.Duration {
+	ret := _m.Called()
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
+// DatabaseDefaultQueryTimeout provides a mock function with given fields:
+func (_m *GeneralConfig) DatabaseDefaultQueryTimeout() time.Duration {
+	ret := _m.Called()
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
 // DatabaseListenerMaxReconnectDuration provides a mock function with given fields:
 func (_m *GeneralConfig) DatabaseListenerMaxReconnectDuration() time.Duration {
 	ret := _m.Called()

--- a/core/config/v2/docs/core.toml
+++ b/core/config/v2/docs/core.toml
@@ -23,6 +23,8 @@ DefaultIdleInTxSessionTimeout = '1h' # Default
 DefaultLockTimeout = '15s' # Default
 # DefaultQueryTimeout is the maximum time allowed for standard queries before timing out.
 DefaultQueryTimeout = '10s' # Default
+# LogQueries tells the Chainlink node to log database queries made using the default logger. SQL statements will be logged at `debug` level. Not all statements can be logged. The best way to get a true log of all SQL statements is to enable SQL statement logging on Postgres.
+LogQueries = false # Default
 # MaxIdleConns configures the maximum number of idle database connections that the Chainlink node will keep open. Think of this as the baseline number of database connections per Chainlink node instance. Increasing this number can help to improve performance under database-heavy workloads.
 #
 # Postgres has connection limits, so you must use cation when increasing this value. If you are running several instances of a Chainlink node or another application on a single database server, you might run out of Postgres connection slots if you raise this value too high.
@@ -116,8 +118,17 @@ JsonWrapperKey = 'event' # Example
 Headers = ['Authorization: token', 'X-SomeOther-Header: value with spaces | and a bar+*'] # Example
 
 [Log]
-# DatabaseQueries tells the Chainlink node to log database queries made using the default logger. SQL statements will be logged at `debug` level. Not all statements can be logged. The best way to get a true log of all SQL statements is to enable SQL statement logging on Postgres.
-DatabaseQueries = false # Default
+# Level determines both what is printed on the screen and what is written to the log file.
+#
+# The available levels are:
+#  - "debug": Useful for forensic debugging of issues.
+#  - "info": High-level informational messages. (default)
+#  - "warn": A mild error occurred that might require non-urgent action. Check these warnings semi-regularly to see if any of them require attention. These warnings usually happen due to factors outside of the control of the node operator. Examples: Unexpected responses from a remote API or misleading networking errors.
+#  - "error": An unexpected error occurred during the regular operation of a well-maintained node. Node operators might need to take action to remedy this error. Check these regularly to see if any of them require attention. Examples: Use of deprecated configuration options or incorrectly configured settings that cause a job to fail.
+#  - "crit": A critical error occurred. The node might be unable to function. Node operators should take immediate action to fix these errors. Examples: The node could not boot because a network socket could not be opened or the database became inaccessible.
+#  - "panic": An exceptional error occurred that could not be handled. If the node is unresponsive, node operators should try to restart their nodes and notify the Chainlink team of a potential bug.
+#  - "fatal": The node encountered an unrecoverable problem and had to exit.
+Level = 'info' # Default
 # JSONConsole enables JSON logging. Otherwise, the log is saved in a human-friendly console format.
 JSONConsole = false # Default
 # UnixTS enables legacy unix timestamps.
@@ -456,8 +467,6 @@ GoroutineThreshold = 5000 # Default
 [Pyroscope]
 # ServerAddress sets the address that will receive the profile logs. It enables the profiling service.
 ServerAddress = 'http://localhost:4040' # Example
-# AuthToken sets the needed Auth Token on Server Addresses that require an Auth Token.
-AuthToken = 'randomly-oauth-generated-token' # Example
 # Environment sets the target environment tag in which profiles will be added to.
 Environment = 'mainnet' # Default
 

--- a/core/config/v2/env.go
+++ b/core/config/v2/env.go
@@ -3,9 +3,29 @@ package v2
 import (
 	"os"
 	"strings"
+
+	"github.com/smartcontractkit/chainlink/core/store/models"
 )
 
 var (
-	CLConfig = os.Getenv("CL_CONFIG")
-	CLDev    = "true" == strings.ToLower(os.Getenv("CL_DEV"))
+	EnvConfig = Env("CL_CONFIG")
+	EnvDev    = Env("CL_DEV")
+
+	EnvDatabaseURL        = EnvSecret("CL_DATABASE_URL")
+	EnvDatabaseBackupURL  = EnvSecret("CL_DATABASE_BACKUP_URL")
+	EnvExplorerAccessKey  = EnvSecret("CL_EXPLORER_ACCESS_KEY")
+	EnvExplorerSecret     = EnvSecret("CL_EXPLORER_SECRET")
+	EnvPasswordKeystore   = EnvSecret("CL_PASSWORD_KEYSTORE")
+	EnvPasswordVRF        = EnvSecret("CL_PASSWORD_VRF")
+	EnvPyroscopeAuthToken = EnvSecret("CL_PYROSCOPE_AUTH_TOKEN")
 )
+
+type Env string
+
+func (e Env) Get() string { return os.Getenv(string(e)) }
+
+func (e Env) IsTrue() bool { return strings.ToLower(e.Get()) == "true" }
+
+type EnvSecret string
+
+func (e EnvSecret) Get() models.Secret { return models.Secret(os.Getenv(string(e))) }

--- a/core/config/v2/types.go
+++ b/core/config/v2/types.go
@@ -31,8 +31,8 @@ var ErrUnsupported = errors.New("unsupported with config v2")
 // Core holds the core configuration. See chainlink.Config for more information.
 type Core struct {
 	// General/misc
-	AppID               uuid.UUID `toml:"-"`
-	DevMode             bool      `toml:"-"`
+	AppID               uuid.UUID `toml:"-"` // random or test
+	DevMode             bool      `toml:"-"` // from environment
 	ExplorerURL         *models.URL
 	InsecureFastScrypt  *bool
 	RootDir             *string
@@ -109,53 +109,57 @@ func (c *Core) SetFrom(f *Core) {
 }
 
 type Secrets struct {
-	DatabaseURL       *models.URL
-	DatabaseBackupURL *models.URL
-
-	ExplorerAccessKey *string
-	ExplorerSecret    *string
-
-	KeystorePassword *string
-	VRFPassword      *string
-}
-
-func (s *Secrets) ValidateConfig() (err error) {
-	if s.DatabaseURL == nil || (*url.URL)(s.DatabaseURL).String() == "" {
-		err = multierr.Append(err, ErrEmpty{Name: "DatabaseURL", Msg: "must be provided and non-empty"})
-	} else {
-		if verr := config.ValidateDBURL((url.URL)(*s.DatabaseURL)); verr != nil {
-			err = multierr.Append(err, ErrInvalid{Name: "DatabaseURL", Value: "*****", Msg: dbURLPasswordComplexity(verr)})
-		}
-	}
-	if s.DatabaseBackupURL != nil {
-		if verr := config.ValidateDBURL((url.URL)(*s.DatabaseBackupURL)); verr != nil {
-			err = multierr.Append(err, ErrInvalid{Name: "DatabaseBackupURL", Value: "*****", Msg: dbURLPasswordComplexity(verr)})
-		}
-	}
-	if s.KeystorePassword == nil || *s.KeystorePassword == "" {
-		err = multierr.Append(err, ErrEmpty{Name: "KeystorePassword", Msg: "must be provided and non-empty"})
-	}
-	return err
+	Database  DatabaseSecrets  `toml:",omitempty"`
+	Explorer  ExplorerSecrets  `toml:",omitempty"`
+	Password  Passwords        `toml:",omitempty"`
+	Pyroscope PyroscopeSecrets `toml:",omitempty"`
 }
 
 func dbURLPasswordComplexity(err error) string {
 	return fmt.Sprintf("missing or insufficiently complex password: %s. Database should be secured by a password matching the following complexity requirements: "+utils.PasswordComplexityRequirements, err)
 }
 
-func (s *Secrets) String() string {
-	return "<hidden>"
+type DatabaseSecrets struct {
+	URL                  *models.SecretURL
+	BackupURL            *models.SecretURL
+	AllowSimplePasswords bool
 }
 
-func (s *Secrets) GoString() string {
-	return "<hidden>"
+func (d *DatabaseSecrets) ValidateConfig() (err error) {
+	if d.URL == nil || (*url.URL)(d.URL).String() == "" {
+		err = multierr.Append(err, ErrEmpty{Name: "URL", Msg: "must be provided and non-empty"})
+	} else if !d.AllowSimplePasswords {
+		if verr := config.ValidateDBURL((url.URL)(*d.URL)); verr != nil {
+			err = multierr.Append(err, ErrInvalid{Name: "URL", Value: "*****", Msg: dbURLPasswordComplexity(verr)})
+		}
+	}
+	if d.BackupURL != nil && !d.AllowSimplePasswords {
+		if verr := config.ValidateDBURL((url.URL)(*d.BackupURL)); verr != nil {
+			err = multierr.Append(err, ErrInvalid{Name: "BackupURL", Value: "*****", Msg: dbURLPasswordComplexity(verr)})
+		}
+	}
+	return err
 }
 
-func (s *Secrets) MarshalJSON() ([]byte, error) {
-	return []byte("{}"), nil
+type ExplorerSecrets struct {
+	AccessKey *models.Secret
+	Secret    *models.Secret
 }
 
-func (s *Secrets) MarshalText() ([]byte, error) {
-	return []byte("<hidden>"), nil
+type Passwords struct {
+	Keystore *models.Secret
+	VRF      *models.Secret
+}
+
+func (p *Passwords) ValidateConfig() (err error) {
+	if p.Keystore == nil || *p.Keystore == "" {
+		err = multierr.Append(err, ErrEmpty{Name: "Keystore", Msg: "must be provided and non-empty"})
+	}
+	return err
+}
+
+type PyroscopeSecrets struct {
+	AuthToken *models.Secret
 }
 
 type Feature struct {
@@ -181,6 +185,7 @@ type Database struct {
 	DefaultLockTimeout            *models.Duration
 	DefaultQueryTimeout           *models.Duration
 	Dialect                       dialects.DialectName `toml:"-"`
+	LogQueries                    *bool
 	MaxIdleConns                  *int64
 	MaxOpenConns                  *int64
 	MigrateOnStartup              *bool
@@ -206,6 +211,9 @@ func (d *Database) setFrom(f *Database) {
 	}
 	if v := f.DefaultQueryTimeout; v != nil {
 		d.DefaultQueryTimeout = v
+	}
+	if v := f.LogQueries; v != nil {
+		d.LogQueries = v
 	}
 	if v := f.MigrateOnStartup; v != nil {
 		d.MigrateOnStartup = v
@@ -330,19 +338,49 @@ func (t *TelemetryIngress) setFrom(f *TelemetryIngress) {
 	}
 }
 
+// LogLevel replaces dpanic with crit/CRIT
+type LogLevel zapcore.Level
+
+func (l LogLevel) String() string {
+	zl := zapcore.Level(l)
+	if zl == zapcore.DPanicLevel {
+		return "crit"
+	}
+	return zl.String()
+}
+
+func (l LogLevel) CapitalString() string {
+	zl := zapcore.Level(l)
+	if zl == zapcore.DPanicLevel {
+		return "CRIT"
+	}
+	return zl.CapitalString()
+}
+
+func (l LogLevel) MarshalText() ([]byte, error) {
+	return []byte(l.String()), nil
+}
+
+func (l *LogLevel) UnmarshalText(text []byte) error {
+	switch string(text) {
+	case "crit", "CRIT":
+		*l = LogLevel(zapcore.DPanicLevel)
+		return nil
+	}
+	return (*zapcore.Level)(l).UnmarshalText(text)
+}
+
 type Log struct {
-	DatabaseQueries *bool
-	Level           zapcore.Level `toml:"-"`
-	JSONConsole     *bool
-	SQL             bool `toml:"-"`
-	UnixTS          *bool
+	Level       *LogLevel
+	JSONConsole *bool
+	UnixTS      *bool
 
 	File LogFile `toml:",omitempty"`
 }
 
 func (l *Log) setFrom(f *Log) {
-	if v := f.DatabaseQueries; v != nil {
-		l.DatabaseQueries = v
+	if v := f.Level; v != nil {
+		l.Level = v
 	}
 	if v := f.JSONConsole; v != nil {
 		l.JSONConsole = v
@@ -871,16 +909,11 @@ func (p *AutoPprof) setFrom(f *AutoPprof) {
 }
 
 type Pyroscope struct {
-	//TODO enabled?
-	AuthToken     *string //TODO move to secrets? https://app.shortcut.com/chainlinklabs/story/54383/document-secrets-toml
 	ServerAddress *string
 	Environment   *string
 }
 
 func (p *Pyroscope) setFrom(f *Pyroscope) {
-	if v := f.AuthToken; v != nil {
-		p.AuthToken = v
-	}
 	if v := f.ServerAddress; v != nil {
 		p.ServerAddress = v
 	}

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -91,7 +91,7 @@ func NewBridgeType(t testing.TB, opts BridgeOpts) (*bridges.BridgeTypeAuthentica
 // MustCreateBridge creates a bridge
 // Be careful not to specify a name here unless you ABSOLUTELY need to
 // This is because name is a unique index and identical names used across transactional tests will lock/deadlock
-func MustCreateBridge(t testing.TB, db *sqlx.DB, opts BridgeOpts, cfg pg.LogConfig) (bta *bridges.BridgeTypeAuthentication, bt *bridges.BridgeType) {
+func MustCreateBridge(t testing.TB, db *sqlx.DB, opts BridgeOpts, cfg pg.QConfig) (bta *bridges.BridgeTypeAuthentication, bt *bridges.BridgeType) {
 	bta, bt = NewBridgeType(t, opts)
 	orm := bridges.NewORM(db, logger.TestLogger(t), cfg)
 	err := orm.CreateBridgeType(bt)
@@ -476,7 +476,7 @@ func MustGenerateRandomKeyState(t testing.TB) ethkey.State {
 	return ethkey.State{Address: NewEIP55Address()}
 }
 
-func MustInsertHead(t *testing.T, db *sqlx.DB, cfg pg.LogConfig, number int64) evmtypes.Head {
+func MustInsertHead(t *testing.T, db *sqlx.DB, cfg pg.QConfig, number int64) evmtypes.Head {
 	h := evmtypes.NewHead(big.NewInt(number), utils.NewHash(), utils.NewHash(), 0, utils.NewBig(&FixtureChainID))
 	horm := headtracker.NewORM(db, logger.TestLogger(t), cfg, FixtureChainID)
 

--- a/core/internal/cltest/heavyweight/orm.go
+++ b/core/internal/cltest/heavyweight/orm.go
@@ -23,7 +23,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	configtest2 "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/store/dialects"
@@ -50,12 +49,7 @@ func prepareFullTestDB(t *testing.T, name string, empty bool, loadFixtures bool)
 	require.NoError(t, os.MkdirAll(gcfg.RootDir(), 0700))
 	migrationTestDBURL, err := dropAndCreateThrowawayTestDB(gcfg.DatabaseURL(), name, empty)
 	require.NoError(t, err)
-	lggr := logger.TestLogger(t)
-	db, err := pg.NewConnection(migrationTestDBURL, dialects.Postgres, pg.Config{
-		Logger:       lggr,
-		MaxOpenConns: gcfg.ORMMaxOpenConns(),
-		MaxIdleConns: gcfg.ORMMaxIdleConns(),
-	})
+	db, err := pg.NewConnection(migrationTestDBURL, dialects.Postgres, gcfg)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, db.Close())
@@ -111,12 +105,7 @@ func prepareFullTestDBV2(t *testing.T, name string, empty bool, loadFixtures boo
 	require.NoError(t, os.MkdirAll(gcfg.RootDir(), 0700))
 	migrationTestDBURL, err := dropAndCreateThrowawayTestDB(gcfg.DatabaseURL(), name, empty)
 	require.NoError(t, err)
-	lggr := logger.TestLogger(t)
-	db, err := pg.NewConnection(migrationTestDBURL, dialects.Postgres, pg.Config{
-		Logger:       lggr,
-		MaxOpenConns: gcfg.ORMMaxOpenConns(),
-		MaxIdleConns: gcfg.ORMMaxIdleConns(),
-	})
+	db, err := pg.NewConnection(migrationTestDBURL, dialects.Postgres, gcfg)
 	require.NoError(t, err)
 	t.Cleanup(func() {
 		assert.NoError(t, db.Close())
@@ -125,7 +114,7 @@ func prepareFullTestDBV2(t *testing.T, name string, empty bool, loadFixtures boo
 
 	gcfg = configtest2.NewGeneralConfigSimulated(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.Database.Dialect = dialects.Postgres
-		s.DatabaseURL = models.MustParseURL(migrationTestDBURL)
+		s.Database.URL = models.MustSecretURL(migrationTestDBURL)
 		if overrideFn != nil {
 			overrideFn(c, s)
 		}

--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -102,7 +102,7 @@ type InstanceAppFactory struct {
 }
 
 // NewApplication creates a new application with specified config
-func (f InstanceAppFactory) NewApplication(context.Context, config.GeneralConfig, *sqlx.DB) (chainlink.Application, error) {
+func (f InstanceAppFactory) NewApplication(context.Context, config.GeneralConfig, logger.Logger, *sqlx.DB) (chainlink.Application, error) {
 	return f.App, nil
 }
 
@@ -110,7 +110,7 @@ type seededAppFactory struct {
 	Application chainlink.Application
 }
 
-func (s seededAppFactory) NewApplication(context.Context, config.GeneralConfig, *sqlx.DB) (chainlink.Application, error) {
+func (s seededAppFactory) NewApplication(context.Context, config.GeneralConfig, logger.Logger, *sqlx.DB) (chainlink.Application, error) {
 	return noopStopApplication{s.Application}, nil
 }
 
@@ -371,7 +371,7 @@ func NewMockAPIInitializer(t testing.TB) *MockAPIInitializer {
 	return &MockAPIInitializer{t: t}
 }
 
-func (m *MockAPIInitializer) Initialize(orm sessions.ORM) (sessions.User, error) {
+func (m *MockAPIInitializer) Initialize(orm sessions.ORM, lggr logger.Logger) (sessions.User, error) {
 	if user, err := orm.FindUser(APIEmailAdmin); err == nil {
 		return user, err
 	}

--- a/core/internal/testutils/configtest/v2/general_config.go
+++ b/core/internal/testutils/configtest/v2/general_config.go
@@ -10,6 +10,7 @@ import (
 	evmclient "github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	evmcfg "github.com/smartcontractkit/chainlink/core/chains/evm/config/v2"
 	"github.com/smartcontractkit/chainlink/core/config"
+	"github.com/smartcontractkit/chainlink/core/config/envvar"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
@@ -40,7 +41,12 @@ func NewGeneralConfig(t testing.TB, overrideFn func(*chainlink.Config, *chainlin
 
 // overrides applies some test config settings and adds a default chain with evmclient.NullClientChainID.
 func overrides(c *chainlink.Config, s *chainlink.Secrets) {
-	s.KeystorePassword = ptr("dummy-to-pass-validation")
+	var emptyURL models.SecretURL
+	if s.Database.URL == nil || *s.Database.URL == emptyURL {
+		// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
+		s.Database.URL = models.NewSecretURL((*models.URL)(envvar.DatabaseURL.ParsePtr()))
+	}
+	s.Password.Keystore = models.NewSecret("dummy-to-pass-validation")
 
 	c.DevMode = true
 	c.InsecureFastScrypt = ptr(true)

--- a/core/internal/testutils/pgtest/pgtest.go
+++ b/core/internal/testutils/pgtest/pgtest.go
@@ -3,6 +3,7 @@ package pgtest
 import (
 	"database/sql"
 	"testing"
+	"time"
 
 	uuid "github.com/satori/go.uuid"
 	"github.com/scylladb/go-reflectx"
@@ -16,12 +17,21 @@ import (
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
-var _ pg.LogConfig = PGCfg{}
+var _ pg.QConfig = &qConfig{}
 
-type PGCfg struct{ logSQL bool }
+// qConfig implements pg.QCOnfig
+type qConfig struct {
+	logSQL              bool
+	defaultQueryTimeout time.Duration
+}
 
-func NewPGCfg(logSQL bool) pg.LogConfig { return PGCfg{logSQL} }
-func (p PGCfg) LogSQL() bool            { return p.logSQL }
+func NewQConfig(logSQL bool) pg.QConfig {
+	return &qConfig{logSQL, pg.DefaultQueryTimeout}
+}
+
+func (p *qConfig) LogSQL() bool { return p.logSQL }
+
+func (p *qConfig) DatabaseDefaultQueryTimeout() time.Duration { return p.defaultQueryTimeout }
 
 func NewSqlDB(t *testing.T) *sql.DB {
 	testutils.SkipShortDB(t)

--- a/core/internal/testutils/pgtest/txdb.go
+++ b/core/internal/testutils/pgtest/txdb.go
@@ -44,9 +44,18 @@ func init() {
 		// -short tests don't need a DB
 		return
 	}
-	dbURL := os.Getenv("DATABASE_URL")
-	if dbURL == "" {
-		panic("you must provide a DATABASE_URL environment variable")
+	var dbURL, which string
+	v1, v2 := os.Getenv("DATABASE_URL"), os.Getenv("CL_DATABASE_URL")
+	if v1 == "" && v2 == "" {
+		panic("you must provide a DATABASE_URL or CL_DATABASE_URL environment variable")
+	} else if v1 == "" {
+		dbURL = v2
+		which = "CL_DATABASE_URL"
+	} else if v2 == "" {
+		dbURL = v1
+		which = "DATABASE_URL"
+	} else {
+		panic("you must only set one of DATABASE_URL and CL_DATABASE_URL environment variables, not both")
 	}
 
 	parsed, err := url.Parse(dbURL)
@@ -54,11 +63,11 @@ func init() {
 		panic(err)
 	}
 	if parsed.Path == "" {
-		msg := fmt.Sprintf("invalid DATABASE_URL: `%s`. You must set DATABASE_URL env var to point to your test database. Note that the test database MUST end in `_test` to differentiate from a possible production DB. HINT: Try DATABASE_URL=postgresql://postgres@localhost:5432/chainlink_test?sslmode=disable", parsed.String())
+		msg := fmt.Sprintf("invalid %s: `%s`. You must set %s env var to point to your test database. Note that the test database MUST end in `_test` to differentiate from a possible production DB. HINT: Try %s=postgresql://postgres@localhost:5432/chainlink_test?sslmode=disable", which, parsed.String(), which, which)
 		panic(msg)
 	}
 	if !strings.HasSuffix(parsed.Path, "_test") {
-		msg := fmt.Sprintf("cannot run tests against database named `%s`. Note that the test database MUST end in `_test` to differentiate from a possible production DB. HINT: Try DATABASE_URL=postgresql://postgres@localhost:5432/chainlink_test?sslmode=disable", parsed.Path[1:])
+		msg := fmt.Sprintf("cannot run tests against database named `%s`. Note that the test database MUST end in `_test` to differentiate from a possible production DB. HINT: Try %s=postgresql://postgres@localhost:5432/chainlink_test?sslmode=disable", parsed.Path[1:], which)
 		panic(msg)
 	}
 	name := string(dialects.TransactionWrappedPostgres)

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -27,7 +27,16 @@ func init() {
 	if err != nil {
 		log.Fatalf("failed to register os specific sinks %+v", err)
 	}
-	if os.Getenv("LOG_COLOR") != "true" {
+	// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
+	var logColor string
+	if v1, v2 := os.Getenv("LOG_COLOR"), os.Getenv("CL_LOG_COLOR"); v1 != "" && v2 != "" {
+		panic("you may only set one of LOG_COLOR and CL_LOG_COLOR environment variables, not both")
+	} else if v1 == "" {
+		logColor = v2
+	} else if v2 == "" {
+		logColor = v1
+	}
+	if logColor != "true" {
 		InitColor(false)
 	}
 }
@@ -134,6 +143,7 @@ func verShaNameStatic() string {
 
 // NewLogger returns a new Logger configured from environment variables, and logs any parsing errors.
 // Tests should use TestLogger.
+// Deprecated: This depends on legacy environment variables.
 func NewLogger() (Logger, func() error) {
 	var c Config
 	var parseErrs []string
@@ -144,7 +154,6 @@ func NewLogger() (Logger, func() error) {
 	if invalid != "" {
 		parseErrs = append(parseErrs, invalid)
 	}
-
 	c.Dir = os.Getenv("LOG_FILE_DIR")
 	if c.Dir == "" {
 		var invalid2 string

--- a/core/logger/test_logger.go
+++ b/core/logger/test_logger.go
@@ -7,19 +7,21 @@ import (
 	"go.uber.org/zap/zapcore"
 	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
-
-	"github.com/smartcontractkit/chainlink/core/config/envvar"
 )
 
 // TestLogger creates a logger that directs output to PrettyConsole configured
 // for test output, and to the buffer testMemoryLog. t is optional.
-// Log level is derived from the LOG_LEVEL env var.
+// Log level is DEBUG by default.
+//
+// Note: It is not necessary to Sync().
 func TestLogger(tb testing.TB) SugaredLogger {
 	return testLogger(tb, nil)
 }
 
 // TestLoggerObserved creates a logger with an observer that can be used to
 // test emitted logs at the given level or above
+//
+// Note: It is not necessary to Sync().
 func TestLoggerObserved(tb testing.TB, lvl zapcore.Level) (Logger, *observer.ObservedLogs) {
 	observedZapCore, observedLogs := observer.New(lvl)
 	return testLogger(tb, observedZapCore), observedLogs
@@ -27,8 +29,7 @@ func TestLoggerObserved(tb testing.TB, lvl zapcore.Level) (Logger, *observer.Obs
 
 // testLogger returns a new SugaredLogger for tests. core is optional.
 func testLogger(tb testing.TB, core zapcore.Core) SugaredLogger {
-	ll, invalid := envvar.LogLevel.Parse()
-	a := zap.NewAtomicLevelAt(ll)
+	a := zap.NewAtomicLevelAt(zap.DebugLevel)
 	opts := []zaptest.LoggerOption{zaptest.Level(a)}
 	zapOpts := []zap.Option{zap.AddCaller(), zap.AddStacktrace(zapcore.ErrorLevel)}
 	if core != nil {
@@ -40,9 +41,6 @@ func testLogger(tb testing.TB, core zapcore.Core) SugaredLogger {
 	l := &zapLogger{
 		level:         a,
 		SugaredLogger: zaptest.NewLogger(tb, opts...).Sugar(),
-	}
-	if invalid != "" {
-		l.Error(invalid)
 	}
 	if tb == nil {
 		return Sugared(l)

--- a/core/main.go
+++ b/core/main.go
@@ -4,11 +4,11 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"strings"
 
 	"github.com/Masterminds/semver/v3"
 
 	"github.com/smartcontractkit/chainlink/core/cmd"
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/recovery"
 	"github.com/smartcontractkit/chainlink/core/static"
 )
@@ -16,13 +16,27 @@ import (
 func init() {
 	// check version
 	if static.Version == static.Unset {
-		if os.Getenv("CHAINLINK_DEV") == "true" {
+		if isDevMode() {
 			return
 		}
-		log.Println(`Version was unset but CHAINLINK_DEV was not set to "true". Chainlink should be built with static.Version set to a valid semver for production builds.`)
+		log.Println(`Version was unset but dev mode is enabled. Chainlink should be built with static.Version set to a valid semver for production builds.`)
 	} else if _, err := semver.NewVersion(static.Version); err != nil {
 		panic(fmt.Sprintf("Version invalid: %q is not valid semver", static.Version))
 	}
+}
+
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
+func isDevMode() bool {
+	var clDev string
+	v1, v2 := os.Getenv("CHAINLINK_DEV"), os.Getenv("CL_DEV")
+	if v1 != "" && v2 != "" {
+		panic("you may only set one of CHAINLINK_DEV and CL_DEV environment variables, not both")
+	} else if v1 == "" {
+		clDev = v2
+	} else if v2 == "" {
+		clDev = v1
+	}
+	return strings.ToLower(clDev) == "true"
 }
 
 func main() {
@@ -34,23 +48,19 @@ func main() {
 // run the CLI, providing further command instructions by default.
 func run(client *cmd.Client, args ...string) {
 	app := cmd.NewApp(client)
-	client.Logger.ErrorIf(app.Run(args), "Error running app")
-	if err := client.CloseLogger(); err != nil {
-		log.Fatal(err)
+	if err := app.Run(args); err != nil {
+		log.Fatal("Error running app:", err)
 	}
 }
 
 // newProductionClient configures an instance of the CLI to be used in production.
 func newProductionClient() *cmd.Client {
-	lggr, closeLggr := logger.NewLogger()
 	prompter := cmd.NewTerminalPrompter()
 	return &cmd.Client{
 		Renderer:                       cmd.RendererTable{Writer: os.Stdout},
-		Logger:                         lggr,
-		CloseLogger:                    closeLggr,
 		AppFactory:                     cmd.ChainlinkAppFactory{},
 		KeyStoreAuthenticator:          cmd.TerminalKeyStoreAuthenticator{Prompter: prompter},
-		FallbackAPIInitializer:         cmd.NewPromptingAPIInitializer(prompter, lggr),
+		FallbackAPIInitializer:         cmd.NewPromptingAPIInitializer(prompter),
 		Runner:                         cmd.ChainlinkRunner{},
 		PromptingSessionRequestBuilder: cmd.NewPromptingSessionRequestBuilder(prompter),
 		ChangePasswordPrompter:         cmd.NewChangePasswordPrompter(),

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -33,7 +33,6 @@ func Run(args ...string) {
 		Renderer:               cmd.RendererTable{Writer: io.Discard},
 		Config:                 tc,
 		Logger:                 lggr,
-		CloseLogger:            lggr.Sync,
 		AppFactory:             cmd.ChainlinkAppFactory{},
 		FallbackAPIInitializer: cltest.NewMockAPIInitializer(t),
 		Runner:                 cmd.ChainlinkRunner{},

--- a/core/scripts/ocr2vrf/util.go
+++ b/core/scripts/ocr2vrf/util.go
@@ -24,7 +24,6 @@ import (
 	"go.dedis.ch/kyber/v3/pairing"
 
 	"github.com/smartcontractkit/chainlink/core/cmd"
-	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/authorized_forwarder"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/link_token_interface"
 	dkgContract "github.com/smartcontractkit/chainlink/core/gethwrappers/ocr2vrf/generated/dkg"
@@ -32,7 +31,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/ocr2vrf/generated/vrf_beacon"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/ocr2vrf/generated/vrf_beacon_consumer"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/ocr2vrf/generated/vrf_coordinator"
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/utils"
 
 	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
@@ -487,18 +485,12 @@ func resetDatabase(client *cmd.Client, context *cli.Context, index int, database
 }
 
 func newSetupClient() *cmd.Client {
-	lggr, closeLggr := logger.NewLogger()
-	cfg := config.NewGeneralConfig(lggr)
-
 	prompter := cmd.NewTerminalPrompter()
 	return &cmd.Client{
 		Renderer:                       cmd.RendererTable{Writer: os.Stdout},
-		Config:                         cfg,
-		Logger:                         lggr,
-		CloseLogger:                    closeLggr,
 		AppFactory:                     cmd.ChainlinkAppFactory{},
 		KeyStoreAuthenticator:          cmd.TerminalKeyStoreAuthenticator{Prompter: prompter},
-		FallbackAPIInitializer:         cmd.NewPromptingAPIInitializer(prompter, lggr),
+		FallbackAPIInitializer:         cmd.NewPromptingAPIInitializer(prompter),
 		Runner:                         cmd.ChainlinkRunner{},
 		PromptingSessionRequestBuilder: cmd.NewPromptingSessionRequestBuilder(prompter),
 		ChangePasswordPrompter:         cmd.NewChangePasswordPrompter(),

--- a/core/scripts/vrfv2/testnet/main.go
+++ b/core/scripts/vrfv2/testnet/main.go
@@ -32,6 +32,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/vrf_load_test_external_sub_owner"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/vrf_single_consumer_example"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/vrfv2_wrapper_consumer_example"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
@@ -42,12 +43,6 @@ import (
 var (
 	batchCoordinatorV2ABI = evmtypes.MustGetABI(batch_vrf_coordinator_v2.BatchVRFCoordinatorV2ABI)
 )
-
-type logconfig struct{}
-
-func (c logconfig) LogSQL() bool {
-	return false
-}
 
 func main() {
 	e := helpers.SetupEnv(false)
@@ -178,7 +173,7 @@ func main() {
 		db := sqlx.MustOpen("postgres", *dbURL)
 		lggr, _ := logger.NewLogger()
 
-		keyStore := keystore.New(db, utils.DefaultScryptParams, lggr, logconfig{})
+		keyStore := keystore.New(db, utils.DefaultScryptParams, lggr, pgtest.NewQConfig(false))
 		err = keyStore.Unlock(*keystorePassword)
 		helpers.PanicErr(err)
 
@@ -270,7 +265,7 @@ func main() {
 		db := sqlx.MustOpen("postgres", *dbURL)
 		lggr, _ := logger.NewLogger()
 
-		keyStore := keystore.New(db, utils.DefaultScryptParams, lggr, logconfig{})
+		keyStore := keystore.New(db, utils.DefaultScryptParams, lggr, pgtest.NewQConfig(false))
 		err = keyStore.Unlock(*keystorePassword)
 		helpers.PanicErr(err)
 

--- a/core/services/blockhashstore/bhs.go
+++ b/core/services/blockhashstore/bhs.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -20,6 +21,7 @@ var _ BHS = &BulletproofBHS{}
 
 type bpBHSConfig interface {
 	EvmGasLimitDefault() uint32
+	DatabaseDefaultQueryTimeout() time.Duration
 }
 
 // BulletproofBHS is an implementation of BHS that writes "store" transactions to a bulletproof
@@ -70,7 +72,7 @@ func (c *BulletproofBHS) Store(ctx context.Context, blockNum uint64) error {
 
 		// Set a queue size of 256. At most we store the blockhash of every block, and only the
 		// latest 256 can possibly be stored.
-		Strategy: txmgr.NewQueueingTxStrategy(c.jobID, 256),
+		Strategy: txmgr.NewQueueingTxStrategy(c.jobID, 256, c.config.DatabaseDefaultQueryTimeout()),
 	}, pg.WithParentCtx(ctx))
 	if err != nil {
 		return errors.Wrap(err, "creating transaction")

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -148,11 +148,11 @@ type ChainlinkApplication struct {
 
 type ApplicationOpts struct {
 	Config                   config.GeneralConfig
+	Logger                   logger.Logger
 	EventBroadcaster         pg.EventBroadcaster
 	SqlxDB                   *sqlx.DB
 	KeyStore                 keystore.Master
 	Chains                   Chains
-	Logger                   logger.Logger
 	AuditLogger              audit.AuditLogger
 	CloseLogger              func() error
 	ExternalInitiatorManager webhook.ExternalInitiatorManager

--- a/core/services/chainlink/cfgtest/dump/full-custom.toml
+++ b/core/services/chainlink/cfgtest/dump/full-custom.toml
@@ -10,6 +10,7 @@ FeedsManager = true
 DefaultIdleInTxSessionTimeout = '1h0m0s'
 DefaultLockTimeout = '1m0s'
 DefaultQueryTimeout = '1s'
+LogQueries = true
 MaxIdleConns = 5
 MaxOpenConns = 12
 MigrateOnStartup = false
@@ -47,7 +48,7 @@ JsonWrapperKey = 'event'
 Headers = ['Authorization: token', 'X-SomeOther-Header: value with spaces | and a bar+*']
 
 [Log]
-DatabaseQueries = true
+Level = 'warn'
 JSONConsole = true
 UnixTS = true
 
@@ -178,7 +179,6 @@ MemThreshold = '1.00gb'
 GoroutineThreshold = 50
 
 [Pyroscope]
-AuthToken = 'pyroscope-token'
 ServerAddress = 'http://localhost:4040'
 Environment = 'tests'
 

--- a/core/services/chainlink/config_dump.go
+++ b/core/services/chainlink/config_dump.go
@@ -526,6 +526,7 @@ func (c *Config) loadLegacyCoreEnv() {
 		DefaultIdleInTxSessionTimeout: mustParseDuration(os.Getenv("DATABASE_DEFAULT_IDLE_IN_TX_SESSION_TIMEOUT")),
 		DefaultLockTimeout:            mustParseDuration(os.Getenv("DATABASE_DEFAULT_LOCK_TIMEOUT")),
 		DefaultQueryTimeout:           mustParseDuration(os.Getenv("DATABASE_DEFAULT_QUERY_TIMEOUT")),
+		LogQueries:                    envvar.LogSQL.ParsePtr(),
 		MigrateOnStartup:              envvar.NewBool("MigrateDatabase").ParsePtr(),
 		MaxIdleConns:                  envvar.NewInt64("ORMMaxIdleConns").ParsePtr(),
 		MaxOpenConns:                  envvar.NewInt64("ORMMaxOpenConns").ParsePtr(),
@@ -559,9 +560,9 @@ func (c *Config) loadLegacyCoreEnv() {
 	}
 
 	c.Log = config.Log{
-		DatabaseQueries: envvar.NewBool("LogSQL").ParsePtr(),
-		JSONConsole:     envvar.JSONConsole.ParsePtr(),
-		UnixTS:          envvar.LogUnixTS.ParsePtr(),
+		Level:       (*config.LogLevel)(envvar.LogLevel.ParsePtr()),
+		JSONConsole: envvar.JSONConsole.ParsePtr(),
+		UnixTS:      envvar.LogUnixTS.ParsePtr(),
 		File: config.LogFile{
 			Dir:        envvar.NewString("LogFileDir").ParsePtr(),
 			MaxSize:    envvar.LogFileMaxSize.ParsePtr(),
@@ -719,7 +720,6 @@ func (c *Config) loadLegacyCoreEnv() {
 	}
 
 	c.Pyroscope = config.Pyroscope{
-		AuthToken:     envvar.NewString("PyroscopeAuthToken").ParsePtr(),
 		ServerAddress: envvar.NewString("PyroscopeServerAddress").ParsePtr(),
 		Environment:   envvar.NewString("PyroscopeEnvironment").ParsePtr(),
 	}

--- a/core/services/chainlink/config_general_secrets.go
+++ b/core/services/chainlink/config_general_secrets.go
@@ -3,40 +3,47 @@ package chainlink
 import "net/url"
 
 func (g *generalConfig) DatabaseURL() url.URL {
-	if g.secrets.DatabaseURL == nil {
+	if g.secrets.Database.URL == nil {
 		return url.URL{}
 	}
-	return *(*url.URL)(g.secrets.DatabaseURL)
+	return *(*url.URL)(g.secrets.Database.URL)
 }
 
 func (g *generalConfig) DatabaseBackupURL() *url.URL {
-	return (*url.URL)(g.secrets.DatabaseBackupURL)
+	return (*url.URL)(g.secrets.Database.BackupURL)
 }
 
 func (g *generalConfig) ExplorerAccessKey() string {
-	if g.secrets.ExplorerAccessKey == nil {
+	if g.secrets.Explorer.AccessKey == nil {
 		return ""
 	}
-	return *g.secrets.ExplorerAccessKey
+	return string(*g.secrets.Explorer.AccessKey)
 }
 
 func (g *generalConfig) ExplorerSecret() string {
-	if g.secrets.ExplorerSecret == nil {
+	if g.secrets.Explorer.Secret == nil {
 		return ""
 	}
-	return *g.secrets.ExplorerSecret
+	return string(*g.secrets.Explorer.Secret)
 }
 
 func (g *generalConfig) KeystorePassword() string {
-	if g.secrets.KeystorePassword == nil {
+	if g.secrets.Password.Keystore == nil {
 		return ""
 	}
-	return *g.secrets.KeystorePassword
+	return string(*g.secrets.Password.Keystore)
 }
 
 func (g *generalConfig) VRFPassword() string {
-	if g.secrets.VRFPassword == nil {
+	if g.secrets.Password.VRF == nil {
 		return ""
 	}
-	return *g.secrets.VRFPassword
+	return string(*g.secrets.Password.VRF)
+}
+
+func (g *generalConfig) PyroscopeAuthToken() string {
+	if g.secrets.Pyroscope.AuthToken == nil {
+		return ""
+	}
+	return string(*g.secrets.Pyroscope.AuthToken)
 }

--- a/core/services/chainlink/config_general_state.go
+++ b/core/services/chainlink/config_general_state.go
@@ -3,6 +3,8 @@ package chainlink
 import (
 	uuid "github.com/satori/go.uuid"
 	"go.uber.org/zap/zapcore"
+
+	v2 "github.com/smartcontractkit/chainlink/core/config/v2"
 )
 
 func (g *generalConfig) AppID() uuid.UUID {
@@ -21,27 +23,27 @@ func (g *generalConfig) DefaultLogLevel() zapcore.Level {
 
 func (g *generalConfig) LogLevel() (ll zapcore.Level) {
 	g.logMu.RLock()
-	ll = g.c.Log.Level
+	ll = zapcore.Level(*g.c.Log.Level)
 	g.logMu.RUnlock()
 	return
 }
 
 func (g *generalConfig) SetLogLevel(lvl zapcore.Level) error {
 	g.logMu.Lock()
-	g.c.Log.Level = lvl
+	g.c.Log.Level = (*v2.LogLevel)(&lvl)
 	g.logMu.Unlock()
 	return nil
 }
 
 func (g *generalConfig) LogSQL() (sql bool) {
 	g.logMu.RLock()
-	sql = g.c.Log.SQL
+	sql = *g.c.Database.LogQueries
 	g.logMu.RUnlock()
 	return
 }
 
 func (g *generalConfig) SetLogSQL(logSQL bool) {
 	g.logMu.Lock()
-	g.c.Log.SQL = logSQL
+	g.c.Database.LogQueries = &logSQL
 	g.logMu.Unlock()
 }

--- a/core/services/chainlink/config_general_test.go
+++ b/core/services/chainlink/config_general_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestTOMLGeneralConfig_Defaults(t *testing.T) {
-	config, err := GeneralConfigTOML{}.New(logger.TestLogger(t))
+	config, err := GeneralConfigOpts{}.New(logger.TestLogger(t))
 	require.NoError(t, err)
 	assert.PanicsWithError(t, v2.ErrUnsupported.Error(), func() {
 		_ = config.BlockBackfillDepth()

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -12,6 +12,7 @@ UICSAKeys = false
 DefaultIdleInTxSessionTimeout = '1h0m0s'
 DefaultLockTimeout = '15s'
 DefaultQueryTimeout = '10s'
+LogQueries = false
 MaxIdleConns = 10
 MaxOpenConns = 20
 MigrateOnStartup = true
@@ -49,7 +50,7 @@ JsonWrapperKey = ''
 Headers = []
 
 [Log]
-DatabaseQueries = false
+Level = 'info'
 JSONConsole = false
 UnixTS = false
 
@@ -180,7 +181,6 @@ MemThreshold = '4.00gb'
 GoroutineThreshold = 5000
 
 [Pyroscope]
-AuthToken = ''
 ServerAddress = ''
 Environment = 'mainnet'
 

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -12,6 +12,7 @@ UICSAKeys = true
 DefaultIdleInTxSessionTimeout = '1m0s'
 DefaultLockTimeout = '1h0m0s'
 DefaultQueryTimeout = '1s'
+LogQueries = true
 MaxIdleConns = 7
 MaxOpenConns = 13
 MigrateOnStartup = true
@@ -49,7 +50,7 @@ JsonWrapperKey = 'event'
 Headers = ['Authorization: token', 'X-SomeOther-Header: value with spaces | and a bar+*']
 
 [Log]
-DatabaseQueries = true
+Level = 'crit'
 JSONConsole = true
 UnixTS = true
 
@@ -180,7 +181,6 @@ MemThreshold = '1.00gb'
 GoroutineThreshold = 999
 
 [Pyroscope]
-AuthToken = 'pyroscope-token'
 ServerAddress = 'http://localhost:4040'
 Environment = 'tests'
 

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -12,6 +12,7 @@ UICSAKeys = false
 DefaultIdleInTxSessionTimeout = '1h0m0s'
 DefaultLockTimeout = '15s'
 DefaultQueryTimeout = '10s'
+LogQueries = false
 MaxIdleConns = 10
 MaxOpenConns = 20
 MigrateOnStartup = true
@@ -49,7 +50,7 @@ JsonWrapperKey = 'event'
 Headers = ['Authorization: token', 'X-SomeOther-Header: value with spaces | and a bar+*']
 
 [Log]
-DatabaseQueries = false
+Level = 'panic'
 JSONConsole = true
 UnixTS = false
 
@@ -180,7 +181,6 @@ MemThreshold = '4.00gb'
 GoroutineThreshold = 5000
 
 [Pyroscope]
-AuthToken = ''
 ServerAddress = ''
 Environment = 'mainnet'
 

--- a/core/services/chainlink/testdata/config-multi-chain.toml
+++ b/core/services/chainlink/testdata/config-multi-chain.toml
@@ -11,6 +11,7 @@ JsonWrapperKey = 'event'
 Headers = ['Authorization: token', 'X-SomeOther-Header: value with spaces | and a bar+*']
 
 [Log]
+Level = 'panic'
 JSONConsole = true
 
 [JobPipeline]

--- a/core/services/chainlink/testdata/secrets-full-redacted.toml
+++ b/core/services/chainlink/testdata/secrets-full-redacted.toml
@@ -1,0 +1,15 @@
+[Database]
+URL = 'xxxxx'
+BackupURL = 'xxxxx'
+AllowSimplePasswords = false
+
+[Explorer]
+AccessKey = 'xxxxx'
+Secret = 'xxxxx'
+
+[Password]
+Keystore = 'xxxxx'
+VRF = 'xxxxx'
+
+[Pyroscope]
+AuthToken = 'xxxxx'

--- a/core/services/chainlink/testdata/secrets-multi-redacted.toml
+++ b/core/services/chainlink/testdata/secrets-multi-redacted.toml
@@ -1,0 +1,10 @@
+[Database]
+URL = 'xxxxx'
+AllowSimplePasswords = false
+
+[Explorer]
+AccessKey = 'xxxxx'
+Secret = 'xxxxx'
+
+[Password]
+Keystore = 'xxxxx'

--- a/core/services/chainlink/testdata/secrets-multi.toml
+++ b/core/services/chainlink/testdata/secrets-multi.toml
@@ -1,6 +1,5 @@
 [Database]
 URL = "postgresql://user:pass@localhost:5432/dbname?sslmode=disable"
-BackupURL = "postgresql://user:pass@localhost:5432/backupdbname?sslmode=disable"
 
 [Explorer]
 AccessKey = "access_key"
@@ -8,7 +7,3 @@ Secret = "secret"
 
 [Password]
 Keystore = "keystore_pass"
-VRF = "VRF_pass"
-
-[Pyroscope]
-AuthToken = "pyroscope-token"

--- a/core/services/feeds/config.go
+++ b/core/services/feeds/config.go
@@ -3,6 +3,7 @@ package feeds
 import (
 	"time"
 
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 )
 
@@ -20,5 +21,5 @@ type Config interface {
 	OCRDatabaseTimeout() time.Duration
 	OCRObservationTimeout() time.Duration
 	OCRObservationGracePeriod() time.Duration
-	LogSQL() bool
+	pg.QConfig
 }

--- a/core/services/feeds/mocks/config.go
+++ b/core/services/feeds/mocks/config.go
@@ -14,6 +14,20 @@ type Config struct {
 	mock.Mock
 }
 
+// DatabaseDefaultQueryTimeout provides a mock function with given fields:
+func (_m *Config) DatabaseDefaultQueryTimeout() time.Duration {
+	ret := _m.Called()
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
 // DefaultHTTPTimeout provides a mock function with given fields:
 func (_m *Config) DefaultHTTPTimeout() models.Duration {
 	ret := _m.Called()

--- a/core/services/feeds/orm.go
+++ b/core/services/feeds/orm.go
@@ -9,9 +9,10 @@ import (
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 
+	"github.com/smartcontractkit/sqlx"
+
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
-	"github.com/smartcontractkit/sqlx"
 )
 
 //go:generate mockery --name ORM --output ./mocks/ --case=underscore
@@ -59,7 +60,7 @@ type orm struct {
 	q pg.Q
 }
 
-func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) *orm {
+func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) *orm {
 	return &orm{
 		q: pg.NewQ(db, lggr, cfg),
 	}

--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -44,7 +44,7 @@ func setupORM(t *testing.T) *TestORM {
 	var (
 		db   = pgtest.NewSqlxDB(t)
 		lggr = logger.TestLogger(t)
-		orm  = feeds.NewORM(db, lggr, pgtest.NewPGCfg(true))
+		orm  = feeds.NewORM(db, lggr, pgtest.NewQConfig(true))
 	)
 
 	return &TestORM{ORM: orm, db: db}

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/feeds"
 	"github.com/smartcontractkit/chainlink/core/services/feeds/mocks"
 	"github.com/smartcontractkit/chainlink/core/services/feeds/proto"
@@ -74,11 +75,14 @@ type TestService struct {
 	p2pKeystore  *ksmocks.P2P
 	ocr1Keystore *ksmocks.OCR
 	ocr2Keystore *ksmocks.OCR2
-	cfg          *mocks.Config
 	cc           evm.ChainSet
 }
 
 func setupTestService(t *testing.T) *TestService {
+	return setupTestServiceCfg(t, nil)
+}
+
+func setupTestServiceCfg(t *testing.T, overrideCfg func(c *chainlink.Config, s *chainlink.Secrets)) *TestService {
 	var (
 		orm          = mocks.NewORM(t)
 		jobORM       = jobmocks.NewORM(t)
@@ -89,13 +93,13 @@ func setupTestService(t *testing.T) *TestService {
 		p2pKeystore  = ksmocks.NewP2P(t)
 		ocr1Keystore = ksmocks.NewOCR(t)
 		ocr2Keystore = ksmocks.NewOCR2(t)
-		cfg          = mocks.NewConfig(t)
 	)
 
 	lggr := logger.TestLogger(t)
 
 	db := pgtest.NewSqlxDB(t)
-	gcfg := configtest.NewTestGeneralConfig(t)
+	gcfg := configtest.NewGeneralConfig(t, overrideCfg)
+	scopedConfig := evmtest.NewChainScopedConfig(t, gcfg)
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{GeneralConfig: gcfg,
 		HeadTracker: headtracker.NullTracker})
 	keyStore := new(ksmocks.Master)
@@ -103,7 +107,7 @@ func setupTestService(t *testing.T) *TestService {
 	keyStore.On("P2P").Return(p2pKeystore)
 	keyStore.On("OCR").Return(ocr1Keystore)
 	keyStore.On("OCR2").Return(ocr2Keystore)
-	svc := feeds.NewService(orm, jobORM, db, spawner, keyStore, cfg, cc, lggr, "1.0.0")
+	svc := feeds.NewService(orm, jobORM, db, spawner, keyStore, scopedConfig, cc, lggr, "1.0.0")
 	svc.SetConnectionsManager(connMgr)
 
 	return &TestService{
@@ -117,7 +121,6 @@ func setupTestService(t *testing.T) *TestService {
 		p2pKeystore:  p2pKeystore,
 		ocr1Keystore: ocr1Keystore,
 		ocr2Keystore: ocr2Keystore,
-		cfg:          cfg,
 		cc:           cc,
 	}
 }
@@ -485,7 +488,6 @@ func Test_Service_ProposeJob(t *testing.T) {
 		{
 			name: "Create success",
 			before: func(svc *TestService) {
-				svc.cfg.On("DefaultHTTPTimeout").Return(httpTimeout)
 				svc.orm.On("GetJobProposalByRemoteUUID", jp.RemoteUUID).Return(new(feeds.JobProposal), sql.ErrNoRows)
 				svc.orm.On("UpsertJobProposal", &jp, mock.Anything).Return(id, nil)
 				svc.orm.On("CreateSpec", spec, mock.Anything).Return(int64(100), nil)
@@ -496,7 +498,6 @@ func Test_Service_ProposeJob(t *testing.T) {
 		{
 			name: "Update success",
 			before: func(svc *TestService) {
-				svc.cfg.On("DefaultHTTPTimeout").Return(httpTimeout)
 				svc.orm.
 					On("GetJobProposalByRemoteUUID", jp.RemoteUUID).
 					Return(&feeds.JobProposal{
@@ -517,10 +518,8 @@ func Test_Service_ProposeJob(t *testing.T) {
 			wantErr: "invalid job type",
 		},
 		{
-			name: "must be an ocr job to include bootstraps",
-			before: func(svc *TestService) {
-				svc.cfg.On("DefaultHTTPTimeout").Return(httpTimeout)
-			},
+			name:   "must be an ocr job to include bootstraps",
+			before: func(svc *TestService) {},
 			args: &feeds.ProposeJobArgs{
 				Spec:       TestSpec,
 				Multiaddrs: pq.StringArray{"/dns4/example.com"},
@@ -530,7 +529,6 @@ func Test_Service_ProposeJob(t *testing.T) {
 		{
 			name: "ensure an upsert validates the job proposal belongs to the feeds manager",
 			before: func(svc *TestService) {
-				svc.cfg.On("DefaultHTTPTimeout").Return(httpTimeout)
 				svc.orm.
 					On("GetJobProposalByRemoteUUID", jp.RemoteUUID).
 					Return(&feeds.JobProposal{
@@ -544,7 +542,6 @@ func Test_Service_ProposeJob(t *testing.T) {
 		{
 			name: "spec version already exists",
 			before: func(svc *TestService) {
-				svc.cfg.On("DefaultHTTPTimeout").Return(httpTimeout)
 				svc.orm.
 					On("GetJobProposalByRemoteUUID", jp.RemoteUUID).
 					Return(&feeds.JobProposal{
@@ -560,7 +557,6 @@ func Test_Service_ProposeJob(t *testing.T) {
 		{
 			name: "upsert error",
 			before: func(svc *TestService) {
-				svc.cfg.On("DefaultHTTPTimeout").Return(httpTimeout)
 				svc.orm.On("GetJobProposalByRemoteUUID", jp.RemoteUUID).Return(new(feeds.JobProposal), sql.ErrNoRows)
 				svc.orm.On("UpsertJobProposal", &jp, mock.Anything).Return(int64(0), errors.New("orm error"))
 			},
@@ -570,7 +566,6 @@ func Test_Service_ProposeJob(t *testing.T) {
 		{
 			name: "Create spec error",
 			before: func(svc *TestService) {
-				svc.cfg.On("DefaultHTTPTimeout").Return(httpTimeout)
 				svc.orm.On("GetJobProposalByRemoteUUID", jp.RemoteUUID).Return(new(feeds.JobProposal), sql.ErrNoRows)
 				svc.orm.On("UpsertJobProposal", &jp, mock.Anything).Return(id, nil)
 				svc.orm.On("CreateSpec", spec, mock.Anything).Return(int64(0), errors.New("orm error"))
@@ -586,7 +581,9 @@ func Test_Service_ProposeJob(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			svc := setupTestService(t)
+			svc := setupTestServiceCfg(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				c.JobPipeline.HTTPRequest.DefaultTimeout = &httpTimeout
+			})
 			if tc.before != nil {
 				tc.before(svc)
 			}
@@ -1043,17 +1040,17 @@ answer1 [type=median index=0];
 	)
 
 	testCases := []struct {
-		name    string
-		before  func(svc *TestService)
-		id      int64
-		force   bool
-		wantErr string
+		name        string
+		httpTimeout *models.Duration
+		before      func(svc *TestService)
+		id          int64
+		force       bool
+		wantErr     string
 	}{
 		{
-			name: "pending job success",
+			name:        "pending job success",
+			httpTimeout: models.MustNewDuration(1 * time.Minute),
 			before: func(svc *TestService) {
-				svc.cfg.On("DefaultHTTPTimeout").Return(models.MakeDuration(1 * time.Minute))
-
 				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
 				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
@@ -1086,10 +1083,9 @@ answer1 [type=median index=0];
 			force: false,
 		},
 		{
-			name: "cancelled spec success when it is the latest spec",
+			name:        "cancelled spec success when it is the latest spec",
+			httpTimeout: models.MustNewDuration(1 * time.Minute),
 			before: func(svc *TestService) {
-				svc.cfg.On("DefaultHTTPTimeout").Return(models.MakeDuration(1 * time.Minute))
-
 				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
 				svc.orm.On("GetSpec", cancelledSpec.ID, mock.Anything).Return(cancelledSpec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
@@ -1148,10 +1144,9 @@ answer1 [type=median index=0];
 			wantErr: "cannot approve a rejected spec",
 		},
 		{
-			name: "already existing job replacement error",
+			name:        "already existing job replacement error",
+			httpTimeout: models.MustNewDuration(1 * time.Minute),
 			before: func(svc *TestService) {
-				svc.cfg.On("DefaultHTTPTimeout").Return(models.MakeDuration(1 * time.Minute))
-
 				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
 				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
@@ -1163,10 +1158,9 @@ answer1 [type=median index=0];
 			wantErr: "could not approve job proposal: a job for this contract address already exists - please use the 'force' option to replace it",
 		},
 		{
-			name: "already existing job replacement success if forced",
+			name:        "already existing job replacement success if forced",
+			httpTimeout: models.MustNewDuration(1 * time.Minute),
 			before: func(svc *TestService) {
-				svc.cfg.On("DefaultHTTPTimeout").Return(models.MakeDuration(1 * time.Minute))
-
 				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
 				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
@@ -1255,10 +1249,9 @@ answer1 [type=median index=0];
 			wantErr: "fms rpc client: Not Connected",
 		},
 		{
-			name: "create job error",
+			name:        "create job error",
+			httpTimeout: models.MustNewDuration(1 * time.Minute),
 			before: func(svc *TestService) {
-				svc.cfg.On("DefaultHTTPTimeout").Return(models.MakeDuration(1 * time.Minute))
-
 				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
 				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
@@ -1279,10 +1272,9 @@ answer1 [type=median index=0];
 			wantErr: "could not approve job proposal: could not save",
 		},
 		{
-			name: "approve spec orm error",
+			name:        "approve spec orm error",
+			httpTimeout: models.MustNewDuration(1 * time.Minute),
 			before: func(svc *TestService) {
-				svc.cfg.On("DefaultHTTPTimeout").Return(models.MakeDuration(1 * time.Minute))
-
 				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
 				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
@@ -1309,10 +1301,9 @@ answer1 [type=median index=0];
 			wantErr: "could not approve job proposal: failure",
 		},
 		{
-			name: "fms call error",
+			name:        "fms call error",
+			httpTimeout: models.MustNewDuration(1 * time.Minute),
 			before: func(svc *TestService) {
-				svc.cfg.On("DefaultHTTPTimeout").Return(models.MakeDuration(1 * time.Minute))
-
 				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
 				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
@@ -1350,7 +1341,11 @@ answer1 [type=median index=0];
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
-			svc := setupTestService(t)
+			svc := setupTestServiceCfg(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				if tc.httpTimeout != nil {
+					c.JobPipeline.HTTPRequest.DefaultTimeout = tc.httpTimeout
+				}
+			})
 
 			if tc.before != nil {
 				tc.before(svc)

--- a/core/services/fluxmonitorv2/config.go
+++ b/core/services/fluxmonitorv2/config.go
@@ -4,6 +4,7 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 )
 
@@ -16,7 +17,7 @@ type Config interface {
 	EvmGasLimitFMJobType() *uint32
 	EvmMaxQueuedTransactions() uint64
 	FMDefaultTransactionQueueDepth() uint32
-	LogSQL() bool
+	pg.QConfig
 }
 
 // MinimumPollingInterval returns the minimum duration between polling ticks

--- a/core/services/fluxmonitorv2/delegate.go
+++ b/core/services/fluxmonitorv2/delegate.go
@@ -63,7 +63,8 @@ func (d *Delegate) ServicesForSpec(jb job.Job) (services []job.ServiceCtx, err e
 	if err != nil {
 		return nil, err
 	}
-	strategy := txmgr.NewQueueingTxStrategy(jb.ExternalJobID, chain.Config().FMDefaultTransactionQueueDepth())
+	cfg := chain.Config()
+	strategy := txmgr.NewQueueingTxStrategy(jb.ExternalJobID, cfg.FMDefaultTransactionQueueDepth(), cfg.DatabaseDefaultQueryTimeout())
 	var checker txmgr.TransmitCheckerSpec
 	if chain.Config().FMSimulateTransactions() {
 		checker.CheckerType = txmgr.TransmitCheckerTypeSimulate

--- a/core/services/fluxmonitorv2/flux_monitor_test.go
+++ b/core/services/fluxmonitorv2/flux_monitor_test.go
@@ -47,7 +47,7 @@ const oracleCount uint8 = 17
 
 type answerSet struct{ latestAnswer, polledAnswer int64 }
 
-func newORM(t *testing.T, db *sqlx.DB, cfg pg.LogConfig, txm txmgr.TxManager) fluxmonitorv2.ORM {
+func newORM(t *testing.T, db *sqlx.DB, cfg pg.QConfig, txm txmgr.TxManager) fluxmonitorv2.ORM {
 	return fluxmonitorv2.NewORM(db, logger.TestLogger(t), cfg, txm, txmgr.SendEveryStrategy{}, txmgr.TransmitCheckerSpec{})
 }
 
@@ -179,7 +179,7 @@ func setup(t *testing.T, db *sqlx.DB, optionFns ...func(*setupOptions)) (*fluxmo
 		tm.pipelineRunner,
 		job.Job{},
 		pipelineSpec,
-		pg.NewQ(db, lggr, pgtest.NewPGCfg(true)),
+		pg.NewQ(db, lggr, pgtest.NewQConfig(true)),
 		options.orm,
 		tm.jobORM,
 		tm.pipelineORM,
@@ -265,7 +265,7 @@ func withORM(orm fluxmonitorv2.ORM) func(*setupOptions) {
 // setupStoreWithKey setups a new store and adds a key to the keystore
 func setupStoreWithKey(t *testing.T) (*sqlx.DB, common.Address) {
 	db := pgtest.NewSqlxDB(t)
-	ethKeyStore := cltest.NewKeyStore(t, db, pgtest.NewPGCfg(true)).Eth()
+	ethKeyStore := cltest.NewKeyStore(t, db, pgtest.NewQConfig(true)).Eth()
 	_, nodeAddr := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
 
 	return db, nodeAddr
@@ -736,7 +736,7 @@ func TestFluxMonitor_TriggerIdleTimeThreshold(t *testing.T) {
 			t.Parallel()
 
 			var (
-				orm = newORM(t, db, pgtest.NewPGCfg(true), nil)
+				orm = newORM(t, db, pgtest.NewQConfig(true), nil)
 			)
 
 			fm, tm := setup(t, db, disablePollTicker(true), disableIdleTimer(tc.idleTimerDisabled), setIdleTimerPeriod(tc.idleDuration), withORM(orm))
@@ -1130,7 +1130,7 @@ func TestFluxMonitor_RoundTimeoutCausesPoll_timesOutAtZero(t *testing.T) {
 
 	var (
 		oracles = []common.Address{nodeAddr, testutils.NewAddress()}
-		orm     = newORM(t, db, pgtest.NewPGCfg(true), nil)
+		orm     = newORM(t, db, pgtest.NewQConfig(true), nil)
 	)
 
 	fm, tm := setup(t, db, disablePollTicker(true), disableIdleTimer(true), withORM(orm))

--- a/core/services/fluxmonitorv2/integrations_test.go
+++ b/core/services/fluxmonitorv2/integrations_test.go
@@ -404,7 +404,7 @@ func assertPipelineRunCreated(t *testing.T, db *sqlx.DB, roundID int64, result i
 	return run
 }
 
-func checkLogWasConsumed(t *testing.T, fa fluxAggregatorUniverse, db *sqlx.DB, pipelineSpecID int32, blockNumber uint64, cfg pg.LogConfig) {
+func checkLogWasConsumed(t *testing.T, fa fluxAggregatorUniverse, db *sqlx.DB, pipelineSpecID int32, blockNumber uint64, cfg pg.QConfig) {
 	t.Helper()
 	lggr := logger.TestLogger(t)
 	lggr.Infof("Waiting for log on block: %v, job id: %v", blockNumber, pipelineSpecID)

--- a/core/services/fluxmonitorv2/key_store_test.go
+++ b/core/services/fluxmonitorv2/key_store_test.go
@@ -15,7 +15,7 @@ func TestKeyStore_EnabledKeysForChain(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := pgtest.NewPGCfg(true)
+	cfg := pgtest.NewQConfig(true)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
 	ks := fluxmonitorv2.NewKeyStore(ethKeyStore)
@@ -40,7 +40,7 @@ func TestKeyStore_GetRoundRobinAddress(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := pgtest.NewPGCfg(true)
+	cfg := pgtest.NewQConfig(true)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
 	_, k0Address := cltest.MustInsertRandomKey(t, ethKeyStore, 0)

--- a/core/services/fluxmonitorv2/orm.go
+++ b/core/services/fluxmonitorv2/orm.go
@@ -6,10 +6,11 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 
+	"github.com/smartcontractkit/sqlx"
+
 	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
-	"github.com/smartcontractkit/sqlx"
 )
 
 type transmitter interface {
@@ -37,7 +38,7 @@ type orm struct {
 }
 
 // NewORM initializes a new ORM
-func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig, txm transmitter, strategy txmgr.TxStrategy, checker txmgr.TransmitCheckerSpec) ORM {
+func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig, txm transmitter, strategy txmgr.TxStrategy, checker txmgr.TransmitCheckerSpec) ORM {
 	namedLogger := lggr.Named("FluxMonitorORM")
 	q := pg.NewQ(db, namedLogger, cfg)
 	return &orm{

--- a/core/services/fluxmonitorv2/orm_test.go
+++ b/core/services/fluxmonitorv2/orm_test.go
@@ -27,7 +27,7 @@ func TestORM_MostRecentFluxMonitorRoundID(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := pgtest.NewPGCfg(true)
+	cfg := pgtest.NewQConfig(true)
 	orm := newORM(t, db, cfg, nil)
 
 	address := testutils.NewAddress()
@@ -167,7 +167,7 @@ func TestORM_CreateEthTransaction(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := pgtest.NewPGCfg(true)
+	cfg := pgtest.NewQConfig(true)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
 	strategy := txmmocks.NewTxStrategy(t)

--- a/core/services/job/common.go
+++ b/core/services/job/common.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"net/url"
 	"time"
+
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
 //go:generate mockery --name Service --output ./mocks/ --case=underscore
@@ -23,7 +25,7 @@ type ServiceCtx interface {
 type Config interface {
 	DatabaseURL() url.URL
 	TriggerFallbackDBPollInterval() time.Duration
-	LogSQL() bool
+	pg.QConfig
 }
 
 // ServiceAdapter is a helper introduced for transitioning from Service to ServiceCtx.

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -252,7 +252,8 @@ func TestORM_DeleteJob_DeletesAssociatedRecords(t *testing.T) {
 	bridgesORM := bridges.NewORM(db, lggr, config)
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, GeneralConfig: config})
 	jobORM := NewTestORM(t, db, cc, pipelineORM, bridgesORM, keyStore, config)
-	korm := keeper.NewORM(db, lggr, nil, nil)
+	scopedConfig := evmtest.NewChainScopedConfig(t, config)
+	korm := keeper.NewORM(db, logger.TestLogger(t), scopedConfig, nil)
 
 	t.Run("it deletes records for offchainreporting jobs", func(t *testing.T) {
 		_, bridge := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, config)

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -74,12 +74,17 @@ type ORM interface {
 	FindTaskResultByRunIDAndTaskName(runID int64, taskName string) ([]byte, error)
 }
 
+type ORMConfig interface {
+	DatabaseDefaultQueryTimeout() time.Duration
+}
+
 type orm struct {
 	q           pg.Q
 	chainSet    evm.ChainSet
 	keyStore    keystore.Master
 	pipelineORM pipeline.ORM
 	lggr        logger.Logger
+	cfg         pg.QConfig
 	bridgeORM   bridges.ORM
 }
 
@@ -92,7 +97,7 @@ func NewORM(
 	bridgeORM bridges.ORM,
 	keyStore keystore.Master, // needed to validation key properties on new job creation
 	lggr logger.Logger,
-	cfg pg.LogConfig,
+	cfg pg.QConfig,
 ) *orm {
 	namedLogger := lggr.Named("JobORM")
 	return &orm{
@@ -102,6 +107,7 @@ func NewORM(
 		pipelineORM: pipelineORM,
 		bridgeORM:   bridgeORM,
 		lggr:        namedLogger,
+		cfg:         cfg,
 	}
 }
 func (o *orm) Close() error {
@@ -710,7 +716,7 @@ func LoadEnvConfigVarsOCR(cfg OCRSpecConfig, p2pStore keystore.P2P, os OCROracle
 }
 
 func (o *orm) FindJobTx(id int32) (Job, error) {
-	ctx, cancel := pg.DefaultQueryCtx()
+	ctx, cancel := context.WithTimeout(context.Background(), o.cfg.DatabaseDefaultQueryTimeout())
 	defer cancel()
 	return o.FindJob(ctx, id)
 }

--- a/core/services/job/orm_test.go
+++ b/core/services/job/orm_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 )
 
-func NewTestORM(t *testing.T, db *sqlx.DB, chainSet evm.ChainSet, pipelineORM pipeline.ORM, bridgeORM bridges.ORM, keyStore keystore.Master, cfg pg.LogConfig) job.ORM {
+func NewTestORM(t *testing.T, db *sqlx.DB, chainSet evm.ChainSet, pipelineORM pipeline.ORM, bridgeORM bridges.ORM, keyStore keystore.Master, cfg pg.QConfig) job.ORM {
 	o := job.NewORM(db, chainSet, pipelineORM, bridgeORM, keyStore, logger.TestLogger(t), cfg)
 	t.Cleanup(func() { o.Close() })
 	return o

--- a/core/services/keeper/common.go
+++ b/core/services/keeper/common.go
@@ -10,6 +10,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/keeper_registry_wrapper1_1"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/keeper_registry_wrapper1_2"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/keeper_registry_wrapper1_3"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
 var Registry1_1ABI = types.MustGetABI(keeper_registry_wrapper1_1.KeeperRegistryABI)
@@ -32,7 +33,7 @@ type Config interface {
 	KeeperCheckUpkeepGasPriceFeatureEnabled() bool
 	KeeperTurnLookBack() int64
 	KeeperTurnFlagEnabled() bool
-	LogSQL() bool
+	pg.QConfig
 }
 
 type RegistryGasChecker interface {

--- a/core/services/keeper/delegate.go
+++ b/core/services/keeper/delegate.go
@@ -59,7 +59,8 @@ func (d *Delegate) ServicesForSpec(spec job.Job) (services []job.ServiceCtx, err
 	}
 	registryAddress := spec.KeeperSpec.ContractAddress
 
-	strategy := txmgr.NewQueueingTxStrategy(spec.ExternalJobID, chain.Config().KeeperDefaultTransactionQueueDepth())
+	cfg := chain.Config()
+	strategy := txmgr.NewQueueingTxStrategy(spec.ExternalJobID, cfg.KeeperDefaultTransactionQueueDepth(), cfg.DatabaseDefaultQueryTimeout())
 	orm := NewORM(d.db, d.logger, chain.Config(), strategy)
 	svcLogger := d.logger.With(
 		"jobID", spec.ID,

--- a/core/services/keeper/integration_test.go
+++ b/core/services/keeper/integration_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest/heavyweight"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
+	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/job"
@@ -245,7 +246,8 @@ func TestKeeperEthIntegration(t *testing.T) {
 				c.EVM[0].MinIncomingConfirmations = ptr[uint32](1)    // disable reorg protection for this test
 				c.EVM[0].HeadTracker.MaxBufferSize = ptr[uint32](100) // helps prevent missed heads
 			})
-			korm := keeper.NewORM(db, logger.TestLogger(t), nil, nil)
+			scopedConfig := evmtest.NewChainScopedConfig(t, config)
+			korm := keeper.NewORM(db, logger.TestLogger(t), scopedConfig, nil)
 
 			app := cltest.NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(t, config, backend, nodeKey)
 			require.NoError(t, app.Start(testutils.Context(t)))
@@ -403,7 +405,8 @@ func TestKeeperForwarderEthIntegration(t *testing.T) {
 			c.EVM[0].HeadTracker.MaxBufferSize = ptr[uint32](100) // helps prevent missed heads
 			c.EVM[0].Transactions.ForwardersEnabled = ptr(true)   // Enable Operator Forwarder flow
 		})
-		korm := keeper.NewORM(db, logger.TestLogger(t), nil, nil)
+		scopedConfig := evmtest.NewChainScopedConfig(t, config)
+		korm := keeper.NewORM(db, logger.TestLogger(t), scopedConfig, nil)
 
 		app := cltest.NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(t, config, backend, nodeKey)
 		require.NoError(t, app.Start(testutils.Context(t)))
@@ -546,7 +549,8 @@ func TestMaxPerformDataSize(t *testing.T) {
 			c.EVM[0].MinIncomingConfirmations = ptr[uint32](1)    // disable reorg protection for this test
 			c.EVM[0].HeadTracker.MaxBufferSize = ptr[uint32](100) // helps prevent missed heads
 		})
-		korm := keeper.NewORM(db, logger.TestLogger(t), nil, nil)
+		scopedConfig := evmtest.NewChainScopedConfig(t, config)
+		korm := keeper.NewORM(db, logger.TestLogger(t), scopedConfig, nil)
 
 		app := cltest.NewApplicationWithConfigV2AndKeyOnSimulatedBlockchain(t, config, backend, nodeKey)
 		require.NoError(t, app.Start(testutils.Context(t)))

--- a/core/services/keeper/registry1_1_synchronizer_test.go
+++ b/core/services/keeper/registry1_1_synchronizer_test.go
@@ -69,7 +69,8 @@ func mockRegistry1_1(
 
 func Test_LogListenerOpts1_1(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	korm := keeper.NewORM(db, logger.TestLogger(t), nil, nil)
+	scopedConfig := evmtest.NewChainScopedConfig(t, configtest.NewGeneralConfig(t, nil))
+	korm := keeper.NewORM(db, logger.TestLogger(t), scopedConfig, nil)
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	j := cltest.MustInsertKeeperJob(t, db, korm, cltest.NewEIP55Address(), cltest.NewEIP55Address())
 

--- a/core/services/keeper/registry1_2_synchronizer_test.go
+++ b/core/services/keeper/registry1_2_synchronizer_test.go
@@ -92,7 +92,8 @@ func mockRegistry1_2(
 
 func Test_LogListenerOpts1_2(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	korm := keeper.NewORM(db, logger.TestLogger(t), nil, nil)
+	scopedConfig := evmtest.NewChainScopedConfig(t, configtest.NewGeneralConfig(t, nil))
+	korm := keeper.NewORM(db, logger.TestLogger(t), scopedConfig, nil)
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	j := cltest.MustInsertKeeperJob(t, db, korm, cltest.NewEIP55Address(), cltest.NewEIP55Address())
 

--- a/core/services/keeper/registry1_3_synchronizer_test.go
+++ b/core/services/keeper/registry1_3_synchronizer_test.go
@@ -94,7 +94,8 @@ func mockRegistry1_3(
 
 func Test_LogListenerOpts1_3(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	korm := keeper.NewORM(db, logger.TestLogger(t), nil, nil)
+	scopedConfig := evmtest.NewChainScopedConfig(t, configtest.NewGeneralConfig(t, nil))
+	korm := keeper.NewORM(db, logger.TestLogger(t), scopedConfig, nil)
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	j := cltest.MustInsertKeeperJob(t, db, korm, cltest.NewEIP55Address(), cltest.NewEIP55Address())
 

--- a/core/services/keeper/registry_synchronizer_helper_test.go
+++ b/core/services/keeper/registry_synchronizer_helper_test.go
@@ -33,12 +33,13 @@ func setupRegistrySync(t *testing.T, version keeper.RegistryVersion) (
 	job.Job,
 ) {
 	db := pgtest.NewSqlxDB(t)
-	korm := keeper.NewORM(db, logger.TestLogger(t), nil, nil)
+	cfg := configtest.NewGeneralConfig(t, nil)
+	scopedConfig := evmtest.NewChainScopedConfig(t, cfg)
+	korm := keeper.NewORM(db, logger.TestLogger(t), scopedConfig, nil)
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	lbMock := logmocks.NewBroadcaster(t)
 	lbMock.On("AddDependents", 1).Maybe()
 	j := cltest.MustInsertKeeperJob(t, db, korm, cltest.NewEIP55Address(), cltest.NewEIP55Address())
-	cfg := configtest.NewGeneralConfig(t, nil)
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{DB: db, Client: ethClient, LogBroadcaster: lbMock, GeneralConfig: cfg})
 	ch := evmtest.MustGetDefaultChain(t, cc)
 	keyStore := cltest.NewKeyStore(t, db, cfg)

--- a/core/services/keystore/eth_internal_test.go
+++ b/core/services/keystore/eth_internal_test.go
@@ -15,7 +15,7 @@ import (
 func Test_EthKeyStore(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
 
-	keyStore := ExposedNewMaster(t, db, pgtest.NewPGCfg(true))
+	keyStore := ExposedNewMaster(t, db, pgtest.NewQConfig(true))
 	err := keyStore.Unlock(testutils.Password)
 	require.NoError(t, err)
 	ks := keyStore.Eth()

--- a/core/services/keystore/helpers_test.go
+++ b/core/services/keystore/helpers_test.go
@@ -5,11 +5,12 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/sqlx"
+
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/utils"
-	"github.com/smartcontractkit/sqlx"
 )
 
 func mustNewEthKey(t *testing.T) *ethkey.KeyV2 {
@@ -18,7 +19,7 @@ func mustNewEthKey(t *testing.T) *ethkey.KeyV2 {
 	return &key
 }
 
-func ExposedNewMaster(t *testing.T, db *sqlx.DB, cfg pg.LogConfig) *master {
+func ExposedNewMaster(t *testing.T, db *sqlx.DB, cfg pg.QConfig) *master {
 	return newMaster(db, utils.FastScryptParams, logger.TestLogger(t), cfg)
 }
 

--- a/core/services/keystore/master.go
+++ b/core/services/keystore/master.go
@@ -67,11 +67,11 @@ type master struct {
 	dkgEncrypt *dkgEncrypt
 }
 
-func New(db *sqlx.DB, scryptParams utils.ScryptParams, lggr logger.Logger, cfg pg.LogConfig) Master {
+func New(db *sqlx.DB, scryptParams utils.ScryptParams, lggr logger.Logger, cfg pg.QConfig) Master {
 	return newMaster(db, scryptParams, lggr, cfg)
 }
 
-func newMaster(db *sqlx.DB, scryptParams utils.ScryptParams, lggr logger.Logger, cfg pg.LogConfig) *master {
+func newMaster(db *sqlx.DB, scryptParams utils.ScryptParams, lggr logger.Logger, cfg pg.QConfig) *master {
 	km := &keyManager{
 		orm:          NewORM(db, lggr, cfg),
 		scryptParams: scryptParams,

--- a/core/services/keystore/orm.go
+++ b/core/services/keystore/orm.go
@@ -17,7 +17,7 @@ import (
 	"github.com/smartcontractkit/sqlx"
 )
 
-func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) ksORM {
+func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) ksORM {
 	namedLogger := lggr.Named("KeystoreORM")
 	return ksORM{
 		q:    pg.NewQ(db, namedLogger, cfg),

--- a/core/services/keystore/orm_test.go
+++ b/core/services/keystore/orm_test.go
@@ -22,7 +22,7 @@ import (
 
 func Test_ORM(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := pgtest.NewPGCfg(false)
+	cfg := pgtest.NewQConfig(false)
 
 	orm := keystore.NewORM(db, logger.TestLogger(t), cfg)
 

--- a/core/services/ocr/config.go
+++ b/core/services/ocr/config.go
@@ -4,11 +4,12 @@ import (
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
 
 	"github.com/smartcontractkit/chainlink/core/services/job"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
 // Config contains OCR configurations for a job.
 type Config interface {
-	LogSQL() bool
+	pg.QConfig
 }
 
 func toLocalConfig(cfg ValidationConfig, spec job.OCROracleSpec) ocrtypes.LocalConfig {

--- a/core/services/ocr/database.go
+++ b/core/services/ocr/database.go
@@ -11,12 +11,13 @@ import (
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
 
-	"github.com/smartcontractkit/chainlink/core/logger"
-	"github.com/smartcontractkit/chainlink/core/services/pg"
-	"github.com/smartcontractkit/chainlink/core/utils"
 	"github.com/smartcontractkit/libocr/gethwrappers/offchainaggregator"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting/types"
 	"github.com/smartcontractkit/sqlx"
+
+	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
+	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
 type db struct {
@@ -31,7 +32,7 @@ var (
 )
 
 // NewDB returns a new DB scoped to this oracleSpecID
-func NewDB(sqlxDB *sqlx.DB, oracleSpecID int32, lggr logger.Logger, cfg pg.LogConfig) *db {
+func NewDB(sqlxDB *sqlx.DB, oracleSpecID int32, lggr logger.Logger, cfg pg.QConfig) *db {
 	namedLogger := lggr.Named("OCR.DB")
 
 	return &db{

--- a/core/services/ocr/delegate.go
+++ b/core/services/ocr/delegate.go
@@ -206,7 +206,8 @@ func (d Delegate) ServicesForSpec(jb job.Job) (services []job.ServiceCtx, err er
 			return nil, errors.Wrap(err, "could not get contract ABI JSON")
 		}
 
-		strategy := txmgr.NewQueueingTxStrategy(jb.ExternalJobID, chain.Config().OCRDefaultTransactionQueueDepth())
+		cfg := chain.Config()
+		strategy := txmgr.NewQueueingTxStrategy(jb.ExternalJobID, cfg.OCRDefaultTransactionQueueDepth(), cfg.DatabaseDefaultQueryTimeout())
 
 		var checker txmgr.TransmitCheckerSpec
 		if chain.Config().OCRSimulateTransactions() {

--- a/core/services/ocr/helpers_internal_test.go
+++ b/core/services/ocr/helpers_internal_test.go
@@ -14,5 +14,5 @@ func (c *ConfigOverriderImpl) ExportedUpdateFlagsStatus() error {
 }
 
 func NewTestDB(t *testing.T, sqldb *sqlx.DB, oracleSpecID int32) *db {
-	return NewDB(sqldb, oracleSpecID, logger.TestLogger(t), pgtest.NewPGCfg(true))
+	return NewDB(sqldb, oracleSpecID, logger.TestLogger(t), pgtest.NewQConfig(true))
 }

--- a/core/services/ocr2/database.go
+++ b/core/services/ocr2/database.go
@@ -27,7 +27,7 @@ var (
 )
 
 // NewDB returns a new DB scoped to this oracleSpecID
-func NewDB(sqlxDB *sqlx.DB, oracleSpecID int32, lggr logger.Logger, cfg pg.LogConfig) *db {
+func NewDB(sqlxDB *sqlx.DB, oracleSpecID int32, lggr logger.Logger, cfg pg.QConfig) *db {
 	namedLogger := lggr.Named("OCR2.DB")
 
 	return &db{

--- a/core/services/ocr2/mocks/config.go
+++ b/core/services/ocr2/mocks/config.go
@@ -13,6 +13,20 @@ type Config struct {
 	mock.Mock
 }
 
+// DatabaseDefaultQueryTimeout provides a mock function with given fields:
+func (_m *Config) DatabaseDefaultQueryTimeout() time.Duration {
+	ret := _m.Called()
+
+	var r0 time.Duration
+	if rf, ok := ret.Get(0).(func() time.Duration); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(time.Duration)
+	}
+
+	return r0
+}
+
 // Dev provides a mock function with given fields:
 func (_m *Config) Dev() bool {
 	ret := _m.Called()

--- a/core/services/ocr2/validate/config.go
+++ b/core/services/ocr2/validate/config.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/services/job"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
 //go:generate mockery --name Config --output ../mocks/ --case=underscore
@@ -14,8 +15,8 @@ import (
 // Config contains OCR2 configurations for a job.
 type Config interface {
 	config.OCR2Config
+	pg.QConfig
 	Dev() bool
-	LogSQL() bool
 	JobPipelineResultWriteQueueDepth() uint64
 }
 

--- a/core/services/ocrcommon/config.go
+++ b/core/services/ocrcommon/config.go
@@ -10,10 +10,11 @@ import (
 	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/p2pkey"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
 type Config interface {
-	LogSQL() bool
+	pg.QConfig
 	EvmGasLimitDefault() uint32
 	JobPipelineResultWriteQueueDepth() uint64
 	OCRBlockchainTimeout() time.Duration

--- a/core/services/ocrcommon/peer_wrapper.go
+++ b/core/services/ocrcommon/peer_wrapper.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/sqlx"
 
 	"github.com/smartcontractkit/chainlink/core/config"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 
 	p2ppeer "github.com/libp2p/go-libp2p-core/peer"
 	"github.com/pkg/errors"
@@ -27,8 +28,8 @@ type PeerWrapperConfig interface {
 	config.P2PNetworking
 	config.P2PV1Networking
 	config.P2PV2Networking
+	pg.QConfig
 	OCRTraceLogging() bool
-	LogSQL() bool
 	FeatureOffchainReporting() bool
 }
 

--- a/core/services/ocrcommon/peerstore.go
+++ b/core/services/ocrcommon/peerstore.go
@@ -44,7 +44,7 @@ type (
 
 // NewPeerstoreWrapper creates a new database-backed peerstore wrapper scoped to the given jobID
 // Multiple peerstore wrappers should not be instantiated with the same jobID
-func NewPeerstoreWrapper(db *sqlx.DB, writeInterval time.Duration, peerID p2pkey.PeerID, lggr logger.Logger, cfg pg.LogConfig) (*Pstorewrapper, error) {
+func NewPeerstoreWrapper(db *sqlx.DB, writeInterval time.Duration, peerID p2pkey.PeerID, lggr logger.Logger, cfg pg.QConfig) (*Pstorewrapper, error) {
 	ctx, cancel := context.WithCancel(context.Background())
 	namedLogger := lggr.Named("PeerStore")
 	q := pg.NewQ(db, namedLogger, cfg)

--- a/core/services/pg/advisory_lock.go
+++ b/core/services/pg/advisory_lock.go
@@ -20,20 +20,27 @@ type AdvisoryLock interface {
 	Release()
 }
 
+type AdvisoryLockConfig interface {
+	AdvisoryLockID() int64
+	AdvisoryLockCheckInterval() time.Duration
+	DatabaseDefaultQueryTimeout() time.Duration
+}
+
 // advisoryLock implements the Locker interface.
 type advisoryLock struct {
-	id            int64
-	db            *sqlx.DB
-	conn          *sqlx.Conn
-	checkInterval time.Duration
-	logger        logger.Logger
-	stop          func()
-	wgReleased    sync.WaitGroup
+	id         int64
+	db         *sqlx.DB
+	conn       *sqlx.Conn
+	cfg        AdvisoryLockConfig
+	logger     logger.Logger
+	stop       func()
+	wgReleased sync.WaitGroup
 }
 
 // NewAdvisoryLock returns an advisoryLocker
-func NewAdvisoryLock(db *sqlx.DB, id int64, lggr logger.Logger, checkInterval time.Duration) AdvisoryLock {
-	return &advisoryLock{id, db, nil, checkInterval, lggr.Named("AdvisoryLock").With("advisoryLockID", id), func() {}, sync.WaitGroup{}}
+func NewAdvisoryLock(db *sqlx.DB, lggr logger.Logger, cfg AdvisoryLockConfig) AdvisoryLock {
+	id := cfg.AdvisoryLockID()
+	return &advisoryLock{id, db, nil, cfg, lggr.Named("AdvisoryLock").With("advisoryLockID", id), func() {}, sync.WaitGroup{}}
 }
 
 // TakeAndHold will block and wait indefinitely until it can get its first lock or ctx is cancelled.
@@ -48,7 +55,7 @@ func (l *advisoryLock) TakeAndHold(ctx context.Context) (err error) {
 		var err error
 
 		err = func() error {
-			qctx, cancel := DefaultQueryCtxWithParent(ctx)
+			qctx, cancel := context.WithTimeout(ctx, l.cfg.DatabaseDefaultQueryTimeout())
 			defer cancel()
 			if l.conn == nil {
 				if err = l.checkoutConn(qctx); err != nil {
@@ -85,7 +92,7 @@ func (l *advisoryLock) TakeAndHold(ctx context.Context) (err error) {
 				err = multierr.Combine(err, l.conn.Close())
 			}
 			return err
-		case <-time.After(utils.WithJitter(l.checkInterval)):
+		case <-time.After(utils.WithJitter(l.cfg.AdvisoryLockCheckInterval())):
 		}
 	}
 
@@ -139,7 +146,7 @@ const checkAdvisoryLockStmt = `SELECT EXISTS (SELECT 1 FROM pg_locks WHERE lockt
 func (l *advisoryLock) loop(ctx context.Context) {
 	defer l.wgReleased.Done()
 
-	check := time.NewTicker(utils.WithJitter(l.checkInterval))
+	check := time.NewTicker(utils.WithJitter(l.cfg.AdvisoryLockCheckInterval()))
 	defer check.Stop()
 
 	stats := time.NewTicker(dbStatsInternal)
@@ -150,7 +157,7 @@ func (l *advisoryLock) loop(ctx context.Context) {
 		case <-stats.C:
 			publishStats(l.db.Stats())
 		case <-ctx.Done():
-			qctx, cancel := DefaultQueryCtx()
+			qctx, cancel := context.WithTimeout(context.Background(), l.cfg.DatabaseDefaultQueryTimeout())
 			err := multierr.Combine(
 				utils.JustError(l.conn.ExecContext(qctx, `SELECT pg_advisory_unlock($1)`, l.id)),
 				l.conn.Close(),
@@ -163,7 +170,7 @@ func (l *advisoryLock) loop(ctx context.Context) {
 		case <-check.C:
 			var gotLock bool
 
-			qctx, cancel := DefaultQueryCtxWithParent(ctx)
+			qctx, cancel := context.WithTimeout(ctx, l.cfg.DatabaseDefaultQueryTimeout())
 			l.logger.Trace("Checking advisory lock")
 			err := l.conn.QueryRowContext(qctx, checkAdvisoryLockStmt, l.id).Scan(&gotLock)
 			if errors.Is(err, sql.ErrConnDone) {
@@ -183,7 +190,7 @@ func (l *advisoryLock) loop(ctx context.Context) {
 				}
 				l.logger.Fatal("Another node has taken the advisory lock, exiting immediately")
 			}
-			check.Reset(utils.WithJitter(l.checkInterval))
+			check.Reset(utils.WithJitter(l.cfg.AdvisoryLockCheckInterval()))
 		}
 	}
 }

--- a/core/services/pg/advisory_lock_test.go
+++ b/core/services/pg/advisory_lock_test.go
@@ -12,13 +12,12 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest/heavyweight"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
-func newAdvisoryLock(t *testing.T, db *sqlx.DB, cfg *configtest.TestGeneralConfig) pg.AdvisoryLock {
-	return pg.NewAdvisoryLock(db, cfg.AdvisoryLockID(), logger.TestLogger(t), cfg.AdvisoryLockCheckInterval())
+func newAdvisoryLock(t *testing.T, db *sqlx.DB, cfg pg.AdvisoryLockConfig) pg.AdvisoryLock {
+	return pg.NewAdvisoryLock(db, logger.TestLogger(t), cfg)
 }
 
 // https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
@@ -75,7 +74,7 @@ func Test_AdvisoryLock(t *testing.T) {
 		advLock := newAdvisoryLock(t, db, cfg)
 
 		// simulate another application holding advisory lock to force it to retry
-		ctx, cancel := pg.DefaultQueryCtx()
+		ctx, cancel := context.WithTimeout(testutils.Context(t), cfg.DatabaseDefaultQueryTimeout())
 		defer cancel()
 		conn, err := db.Conn(ctx)
 		require.NoError(t, err)

--- a/core/services/pg/connection.go
+++ b/core/services/pg/connection.go
@@ -2,6 +2,7 @@ package pg
 
 import (
 	"fmt"
+	"time"
 
 	// need to make sure pgx driver is registered before opening connection
 	_ "github.com/jackc/pgx/v4/stdlib"
@@ -9,17 +10,17 @@ import (
 	"github.com/scylladb/go-reflectx"
 	"github.com/smartcontractkit/sqlx"
 
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/store/dialects"
 )
 
-type Config struct {
-	Logger       logger.Logger
-	MaxOpenConns int
-	MaxIdleConns int
+type ConnectionConfig interface {
+	DatabaseDefaultIdleInTxSessionTimeout() time.Duration
+	DatabaseDefaultLockTimeout() time.Duration
+	ORMMaxOpenConns() int
+	ORMMaxIdleConns() int
 }
 
-func NewConnection(uri string, dialect dialects.DialectName, config Config) (db *sqlx.DB, err error) {
+func NewConnection(uri string, dialect dialects.DialectName, config ConnectionConfig) (db *sqlx.DB, err error) {
 	if dialect == dialects.TransactionWrappedPostgres {
 		// Dbtx uses the uri as a unique identifier for each transaction. Each ORM
 		// should be encapsulated in it's own transaction, and thus needs its own
@@ -39,12 +40,15 @@ func NewConnection(uri string, dialect dialects.DialectName, config Config) (db 
 	db.MapperFunc(reflectx.CamelToSnakeASCII)
 
 	// Set default connection options
-	stmt := fmt.Sprintf(`SET TIME ZONE 'UTC'; SET lock_timeout = %d; SET idle_in_transaction_session_timeout = %d; SET default_transaction_isolation = %q`, DefaultLockTimeout.Milliseconds(), DefaultIdleInTxSessionTimeout.Milliseconds(), DefaultIsolation.String())
+	lockTimeout := config.DatabaseDefaultLockTimeout().Milliseconds()
+	idleInTxSessionTimeout := config.DatabaseDefaultIdleInTxSessionTimeout().Milliseconds()
+	stmt := fmt.Sprintf(`SET TIME ZONE 'UTC'; SET lock_timeout = %d; SET idle_in_transaction_session_timeout = %d; SET default_transaction_isolation = %q`,
+		lockTimeout, idleInTxSessionTimeout, DefaultIsolation.String())
 	if _, err = db.Exec(stmt); err != nil {
 		return nil, err
 	}
-	db.SetMaxOpenConns(config.MaxOpenConns)
-	db.SetMaxIdleConns(config.MaxIdleConns)
+	db.SetMaxOpenConns(config.ORMMaxOpenConns())
+	db.SetMaxIdleConns(config.ORMMaxIdleConns())
 
 	return db, nil
 }

--- a/core/services/pg/lease_lock.go
+++ b/core/services/pg/lease_lock.go
@@ -55,25 +55,32 @@ type LeaseLock interface {
 	Release()
 }
 
+type LeaseLockConfig interface {
+	DatabaseDefaultQueryTimeout() time.Duration
+	LeaseLockDuration() time.Duration
+	LeaseLockRefreshInterval() time.Duration
+}
+
 var _ LeaseLock = &leaseLock{}
 
 type leaseLock struct {
-	id              uuid.UUID
-	db              *sqlx.DB
-	conn            *sqlx.Conn
-	refreshInterval time.Duration
-	leaseDuration   time.Duration
-	logger          logger.Logger
-	stop            func()
-	wgReleased      sync.WaitGroup
+	id         uuid.UUID
+	db         *sqlx.DB
+	conn       *sqlx.Conn
+	cfg        LeaseLockConfig
+	logger     logger.Logger
+	stop       func()
+	wgReleased sync.WaitGroup
 }
 
 // NewLeaseLock creates a "leaseLock" - an entity that tries to take an exclusive lease on the database
-func NewLeaseLock(db *sqlx.DB, appID uuid.UUID, lggr logger.Logger, refreshInterval, leaseDuration time.Duration) LeaseLock {
+func NewLeaseLock(db *sqlx.DB, appID uuid.UUID, lggr logger.Logger, cfg LeaseLockConfig) LeaseLock {
+	refreshInterval := cfg.LeaseLockRefreshInterval()
+	leaseDuration := cfg.LeaseLockDuration()
 	if refreshInterval > leaseDuration/2 {
 		panic("refresh interval must be <= half the lease duration")
 	}
-	return &leaseLock{appID, db, nil, refreshInterval, leaseDuration, lggr.Named("LeaseLock").With("appID", appID), func() {}, sync.WaitGroup{}}
+	return &leaseLock{appID, db, nil, cfg, lggr.Named("LeaseLock").With("appID", appID), func() {}, sync.WaitGroup{}}
 }
 
 // TakeAndHold will block and wait indefinitely until it can get its first lock or ctx is cancelled.
@@ -89,7 +96,7 @@ func (l *leaseLock) TakeAndHold(ctx context.Context) (err error) {
 		var err error
 
 		err = func() error {
-			qctx, cancel := DefaultQueryCtxWithParent(ctx)
+			qctx, cancel := context.WithTimeout(ctx, l.cfg.DatabaseDefaultQueryTimeout())
 			defer cancel()
 			if l.conn == nil {
 				if err = l.checkoutConn(qctx); err != nil {
@@ -127,7 +134,7 @@ func (l *leaseLock) TakeAndHold(ctx context.Context) (err error) {
 				err = multierr.Combine(err, l.conn.Close())
 			}
 			return err
-		case <-time.After(utils.WithJitter(l.refreshInterval)):
+		case <-time.After(utils.WithJitter(l.cfg.LeaseLockRefreshInterval())):
 		}
 	}
 	l.logger.Debug("Got exclusive lease on database")
@@ -171,9 +178,10 @@ func (l *leaseLock) setInitialTimeouts(ctx context.Context) error {
 	// occurring where we get stuck waiting for the table lock, or hang during
 	// the transaction - we do not want to leave rows locked if this process is
 	// dead
+	ms := l.cfg.LeaseLockDuration().Milliseconds()
 	return multierr.Combine(
-		utils.JustError(l.conn.ExecContext(ctx, fmt.Sprintf(`SET SESSION lock_timeout = %d`, l.leaseDuration.Milliseconds()))),
-		utils.JustError(l.conn.ExecContext(ctx, fmt.Sprintf(`SET SESSION idle_in_transaction_session_timeout = %d`, l.leaseDuration.Milliseconds()))),
+		utils.JustError(l.conn.ExecContext(ctx, fmt.Sprintf(`SET SESSION lock_timeout = %d`, ms))),
+		utils.JustError(l.conn.ExecContext(ctx, fmt.Sprintf(`SET SESSION idle_in_transaction_session_timeout = %d`, ms))),
 	)
 }
 
@@ -186,7 +194,7 @@ func (l *leaseLock) logRetry(count int) {
 func (l *leaseLock) loop(ctx context.Context) {
 	defer l.wgReleased.Done()
 
-	refresh := time.NewTicker(l.refreshInterval)
+	refresh := time.NewTicker(l.cfg.LeaseLockRefreshInterval())
 	defer refresh.Stop()
 
 	stats := time.NewTicker(dbStatsInternal)
@@ -197,7 +205,7 @@ func (l *leaseLock) loop(ctx context.Context) {
 		case <-stats.C:
 			publishStats(l.db.Stats())
 		case <-ctx.Done():
-			qctx, cancel := DefaultQueryCtx()
+			qctx, cancel := context.WithTimeout(context.Background(), l.cfg.DatabaseDefaultQueryTimeout())
 			err := multierr.Combine(
 				utils.JustError(l.conn.ExecContext(qctx, `UPDATE lease_lock SET expires_at=NOW() WHERE client_id = $1 AND expires_at > NOW()`, l.id)),
 				l.conn.Close(),
@@ -208,7 +216,7 @@ func (l *leaseLock) loop(ctx context.Context) {
 			}
 			return
 		case <-refresh.C:
-			qctx, cancel := context.WithTimeout(ctx, l.leaseDuration)
+			qctx, cancel := context.WithTimeout(ctx, l.cfg.LeaseLockDuration())
 			gotLease, err := l.getLease(qctx, false)
 			if errors.Is(err, sql.ErrConnDone) {
 				l.logger.Warnw("DB connection was unexpectedly closed; checking out a new one", "err", err)
@@ -243,7 +251,7 @@ var initialSQL = []string{
 // If some other error occurred, returns the error
 func (l *leaseLock) getLease(ctx context.Context, isInitial bool) (gotLease bool, err error) {
 	l.logger.Trace("Refreshing database lease")
-	leaseDuration := fmt.Sprintf("%f seconds", l.leaseDuration.Seconds())
+	leaseDuration := fmt.Sprintf("%f seconds", l.cfg.LeaseLockDuration().Seconds())
 
 	// NOTE: Uses database time for all calculations since it's conceivable
 	// that node local times might be skewed compared to each other

--- a/core/services/pg/lease_lock_test.go
+++ b/core/services/pg/lease_lock_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func newLeaseLock(t *testing.T, db *sqlx.DB, cfg config.GeneralConfig) pg.LeaseLock {
-	return pg.NewLeaseLock(db, uuid.NewV4(), logger.TestLogger(t), cfg.LeaseLockRefreshInterval(), cfg.LeaseLockDuration())
+	return pg.NewLeaseLock(db, uuid.NewV4(), logger.TestLogger(t), cfg)
 }
 
 func Test_LeaseLock(t *testing.T) {

--- a/core/services/pg/locked_db.go
+++ b/core/services/pg/locked_db.go
@@ -23,17 +23,17 @@ type LockedDB interface {
 }
 
 type LockedDBConfig interface {
+	ConnectionConfig
 	AdvisoryLockCheckInterval() time.Duration
 	AdvisoryLockID() int64
 	AppID() uuid.UUID
 	DatabaseLockingMode() string
 	DatabaseURL() url.URL
+	DatabaseDefaultQueryTimeout() time.Duration
 	LeaseLockDuration() time.Duration
 	LeaseLockRefreshInterval() time.Duration
 	GetDatabaseDialectConfiguredOrDefault() dialects.DialectName
 	MigrateDatabase() bool
-	ORMMaxIdleConns() int
-	ORMMaxOpenConns() int
 }
 
 type lockedDb struct {
@@ -55,8 +55,8 @@ func NewLockedDB(cfg LockedDBConfig, lggr logger.Logger) LockedDB {
 // OpenUnlockedDB just opens DB connection, without any DB locks.
 // This should be used carefully, when we know we don't need any locks.
 // Currently this is used by RebroadcastTransactions command only.
-func OpenUnlockedDB(cfg LockedDBConfig, lggr logger.Logger) (db *sqlx.DB, err error) {
-	return openDB(cfg, lggr)
+func OpenUnlockedDB(cfg LockedDBConfig) (db *sqlx.DB, err error) {
+	return openDB(cfg)
 }
 
 // Open function connects to DB and acquires DB locks based on configuration.
@@ -70,7 +70,7 @@ func (l *lockedDb) Open(ctx context.Context) (err error) {
 	}
 
 	// Step 1: open DB connection
-	l.db, err = openDB(l.cfg, l.lggr)
+	l.db, err = openDB(l.cfg)
 	if err != nil {
 		// l.db will be nil in case of error
 		return errors.Wrap(err, "failed to open db")
@@ -89,7 +89,7 @@ func (l *lockedDb) Open(ctx context.Context) (err error) {
 	// Take the lease before any other DB operations
 	switch lockingMode {
 	case "lease", "dual":
-		l.leaseLock = NewLeaseLock(l.db, l.cfg.AppID(), l.lggr, l.cfg.LeaseLockRefreshInterval(), l.cfg.LeaseLockDuration())
+		l.leaseLock = NewLeaseLock(l.db, l.cfg.AppID(), l.lggr, l.cfg)
 		if err = l.leaseLock.TakeAndHold(ctx); err != nil {
 			defer revert()
 			return errors.Wrap(err, "failed to take initial lease on database")
@@ -99,7 +99,7 @@ func (l *lockedDb) Open(ctx context.Context) (err error) {
 	// Try to acquire an advisory lock to prevent multiple nodes starting at the same time
 	switch lockingMode {
 	case "advisorylock", "dual":
-		l.advisoryLock = NewAdvisoryLock(l.db, l.cfg.AdvisoryLockID(), l.lggr, l.cfg.AdvisoryLockCheckInterval())
+		l.advisoryLock = NewAdvisoryLock(l.db, l.lggr, l.cfg)
 		if err = l.advisoryLock.TakeAndHold(ctx); err != nil {
 			defer revert()
 			return errors.Wrap(err, "error acquiring lock")
@@ -140,15 +140,11 @@ func (l lockedDb) DB() *sqlx.DB {
 	return l.db
 }
 
-func openDB(cfg LockedDBConfig, lggr logger.Logger) (db *sqlx.DB, err error) {
+func openDB(cfg LockedDBConfig) (db *sqlx.DB, err error) {
 	uri := cfg.DatabaseURL()
 	appid := cfg.AppID()
 	static.SetConsumerName(&uri, "App", &appid)
 	dialect := cfg.GetDatabaseDialectConfiguredOrDefault()
-	db, err = NewConnection(uri.String(), dialect, Config{
-		Logger:       lggr,
-		MaxOpenConns: cfg.ORMMaxOpenConns(),
-		MaxIdleConns: cfg.ORMMaxIdleConns(),
-	})
+	db, err = NewConnection(uri.String(), dialect, cfg)
 	return
 }

--- a/core/services/pg/locked_db_test.go
+++ b/core/services/pg/locked_db_test.go
@@ -84,14 +84,13 @@ func TestLockedDB_TwoInstances(t *testing.T) {
 func TestOpenUnlockedDB(t *testing.T) {
 	testutils.SkipShortDB(t)
 	config := configtest.NewGeneralConfig(t, nil)
-	lggr := logger.TestLogger(t)
 
-	db1, err1 := pg.OpenUnlockedDB(config, lggr)
+	db1, err1 := pg.OpenUnlockedDB(config)
 	require.NoError(t, err1)
 	require.NotNil(t, db1)
 
 	// should not block the second connection
-	db2, err2 := pg.OpenUnlockedDB(config, lggr)
+	db2, err2 := pg.OpenUnlockedDB(config)
 	require.NoError(t, err2)
 	require.NotNil(t, db2)
 

--- a/core/services/pg/q.go
+++ b/core/services/pg/q.go
@@ -58,10 +58,6 @@ var promSQLQueryTime = promauto.NewHistogram(prometheus.HistogramOpts{
 //	orm.GetFoo(q, pg.WithQueryer(tx), pg.WithParentCtx(ctx)) // options can be combined
 type QOpt func(*Q)
 
-type LogConfig interface {
-	LogSQL() bool
-}
-
 // WithQueryer sets the queryer
 func WithQueryer(queryer Queryer) func(q *Q) {
 	return func(q *Q) {
@@ -94,11 +90,16 @@ func WithParentCtxInheritTimeout(ctx context.Context) func(q *Q) {
 // Some queries need to take longer when operating over big chunks of data, like deleting jobs, but we need to keep some upper bound timeout
 func WithLongQueryTimeout() func(q *Q) {
 	return func(q *Q) {
-		q.QueryTimeout = LongQueryTimeout
+		q.QueryTimeout = longQueryTimeout
 	}
 }
 
 var _ Queryer = Q{}
+
+type QConfig interface {
+	LogSQL() bool
+	DatabaseDefaultQueryTimeout() time.Duration
+}
 
 // Q wraps an underlying queryer (either a *sqlx.DB or a *sqlx.Tx)
 //
@@ -118,11 +119,11 @@ type Q struct {
 	ParentCtx    context.Context
 	db           *sqlx.DB
 	logger       logger.Logger
-	config       LogConfig
+	config       QConfig
 	QueryTimeout time.Duration
 }
 
-func NewQ(db *sqlx.DB, logger logger.Logger, config LogConfig, qopts ...QOpt) (q Q) {
+func NewQ(db *sqlx.DB, logger logger.Logger, config QConfig, qopts ...QOpt) (q Q) {
 	for _, opt := range qopts {
 		opt(&q)
 	}
@@ -152,18 +153,15 @@ func (q Q) WithOpts(qopts ...QOpt) Q {
 }
 
 func (q Q) Context() (context.Context, context.CancelFunc) {
-	if q.QueryTimeout > 0 {
-		ctx := q.ParentCtx
-		if ctx == nil {
-			ctx = context.Background()
-		}
-		return context.WithTimeout(ctx, q.QueryTimeout)
+	ctx := q.ParentCtx
+	if ctx == nil {
+		ctx = context.Background()
 	}
-
-	if q.ParentCtx == nil {
-		return DefaultQueryCtx()
+	timeout := q.QueryTimeout
+	if q.QueryTimeout <= 0 {
+		timeout = q.config.DatabaseDefaultQueryTimeout()
 	}
-	return DefaultQueryCtxWithParent(q.ParentCtx)
+	return context.WithTimeout(ctx, timeout)
 }
 
 func (q Q) Transaction(fc func(q Queryer) error, txOpts ...TxOptions) error {

--- a/core/services/pg/sqlx.go
+++ b/core/services/pg/sqlx.go
@@ -7,8 +7,9 @@ import (
 	"github.com/pkg/errors"
 	mapper "github.com/scylladb/go-reflectx"
 
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/sqlx"
+
+	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
 //go:generate mockery --name Queryer --output ./mocks/ --case=underscore
@@ -33,12 +34,6 @@ func WrapDbWithSqlx(rdb *sql.DB) *sqlx.DB {
 	db := sqlx.NewDb(rdb, "postgres")
 	db.MapperFunc(mapper.CamelToSnakeASCII)
 	return db
-}
-
-func SqlxTransactionWithDefaultCtx(q Queryer, lggr logger.Logger, fc func(q Queryer) error, txOpts ...TxOptions) (err error) {
-	ctx, cancel := DefaultQueryCtx()
-	defer cancel()
-	return SqlxTransaction(ctx, q, lggr, fc, txOpts...)
 }
 
 func SqlxTransaction(ctx context.Context, q Queryer, lggr logger.Logger, fc func(q Queryer) error, txOpts ...TxOptions) (err error) {

--- a/core/services/pg/transaction.go
+++ b/core/services/pg/transaction.go
@@ -8,9 +8,10 @@ import (
 
 	"github.com/getsentry/sentry-go"
 	"github.com/pkg/errors"
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/sqlx"
 	"go.uber.org/multierr"
+
+	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
 type TxOptions struct {

--- a/core/services/pg/utils.go
+++ b/core/services/pg/utils.go
@@ -1,7 +1,6 @@
 package pg
 
 import (
-	"context"
 	"database/sql/driver"
 	"fmt"
 	"os"
@@ -38,11 +37,13 @@ func init() {
 	}
 }
 
+// unexport and make constant after legacy config is removed
+// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 var (
 	// DefaultQueryTimeout is a reasonable upper bound for how long a SQL query should take
 	DefaultQueryTimeout = 10 * time.Second
-	// LongQueryTimeout is a bigger upper bound for how long a SQL query should take
-	LongQueryTimeout = 1 * time.Minute
+	// longQueryTimeout is a bigger upper bound for how long a SQL query should take
+	longQueryTimeout = 1 * time.Minute
 	// DefaultLockTimeout controls the max time we will wait for any kind of database lock.
 	// It's good to set this to _something_ because waiting for locks forever is really bad.
 	DefaultLockTimeout = 15 * time.Second
@@ -50,17 +51,6 @@ var (
 	// It's good to set this to _something_ because leaving transactions open forever is really bad.
 	DefaultIdleInTxSessionTimeout = 1 * time.Hour
 )
-
-// DefaultQueryCtx returns a context with a sensible sanity limit timeout for SQL queries
-func DefaultQueryCtx() (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.Background(), DefaultQueryTimeout)
-}
-
-// DefaultQueryCtxWithParent returns a context with a sensible sanity limit timeout for
-// SQL queries with the given parent context
-func DefaultQueryCtxWithParent(ctx context.Context) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(ctx, DefaultQueryTimeout)
-}
 
 var _ driver.Valuer = Limit(-1)
 

--- a/core/services/pipeline/orm.go
+++ b/core/services/pipeline/orm.go
@@ -95,7 +95,7 @@ type orm struct {
 
 var _ ORM = (*orm)(nil)
 
-func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.LogConfig) *orm {
+func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) *orm {
 	return &orm{pg.NewQ(db, lggr, cfg), lggr}
 }
 

--- a/core/services/pipeline/orm_test.go
+++ b/core/services/pipeline/orm_test.go
@@ -31,7 +31,7 @@ func setupORM(t *testing.T, name string) (db *sqlx.DB, orm pipeline.ORM) {
 	} else {
 		db = pgtest.NewSqlxDB(t)
 	}
-	orm = pipeline.NewORM(db, logger.TestLogger(t), pgtest.NewPGCfg(true))
+	orm = pipeline.NewORM(db, logger.TestLogger(t), pgtest.NewQConfig(true))
 
 	return
 }

--- a/core/services/pipeline/test_helpers_test.go
+++ b/core/services/pipeline/test_helpers_test.go
@@ -39,7 +39,7 @@ func fakeExternalAdapter(t *testing.T, expectedRequest, response interface{}) ht
 	})
 }
 
-func makeBridge(t *testing.T, db *sqlx.DB, expectedRequest, response interface{}, cfg pg.LogConfig) (*httptest.Server, bridges.BridgeType) {
+func makeBridge(t *testing.T, db *sqlx.DB, expectedRequest, response interface{}, cfg pg.QConfig) (*httptest.Server, bridges.BridgeType) {
 	t.Helper()
 
 	server := httptest.NewServer(fakeExternalAdapter(t, expectedRequest, response))

--- a/core/services/relay/evm/config_poller_test.go
+++ b/core/services/relay/evm/config_poller_test.go
@@ -55,7 +55,7 @@ func TestConfigPoller(t *testing.T) {
 	b.Commit()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := pgtest.NewPGCfg(false)
+	cfg := pgtest.NewQConfig(false)
 	ethClient := evmclient.NewSimulatedBackendClient(t, b, big.NewInt(1337))
 	lggr := logger.TestLogger(t)
 	ctx := testutils.Context(t)

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -179,7 +179,8 @@ func newContractTransmitter(lggr logger.Logger, rargs relaytypes.RelayArgs, tran
 		fromAddresses = append(fromAddresses, effectiveTransmitterAddress)
 	}
 
-	strategy := txm.NewQueueingTxStrategy(rargs.ExternalJobID, configWatcher.chain.Config().OCRDefaultTransactionQueueDepth())
+	scoped := configWatcher.chain.Config()
+	strategy := txm.NewQueueingTxStrategy(rargs.ExternalJobID, scoped.OCRDefaultTransactionQueueDepth(), scoped.DatabaseDefaultQueryTimeout())
 
 	var checker txm.TransmitCheckerSpec
 	if configWatcher.chain.Config().OCRSimulateTransactions() {
@@ -209,7 +210,8 @@ func newPipelineContractTransmitter(lggr logger.Logger, rargs relaytypes.RelayAr
 
 	effectiveTransmitterAddress := common.HexToAddress(relayConfig.EffectiveTransmitterAddress.String)
 	transmitterAddress := common.HexToAddress(transmitterID)
-	strategy := txm.NewQueueingTxStrategy(rargs.ExternalJobID, configWatcher.chain.Config().OCRDefaultTransactionQueueDepth())
+	scoped := configWatcher.chain.Config()
+	strategy := txm.NewQueueingTxStrategy(rargs.ExternalJobID, scoped.OCRDefaultTransactionQueueDepth(), scoped.DatabaseDefaultQueryTimeout())
 
 	var checker txm.TransmitCheckerSpec
 	if configWatcher.chain.Config().OCRSimulateTransactions() {

--- a/core/services/relay/evm/request_round_db_test.go
+++ b/core/services/relay/evm/request_round_db_test.go
@@ -37,7 +37,8 @@ func Test_DB_LatestRoundRequested(t *testing.T) {
 	}
 
 	t.Run("saves latest round requested", func(t *testing.T) {
-		err := pg.SqlxTransactionWithDefaultCtx(sqlDB, logger.TestLogger(t), func(q pg.Queryer) error {
+		ctx := testutils.Context(t)
+		err := pg.SqlxTransaction(ctx, sqlDB, logger.TestLogger(t), func(q pg.Queryer) error {
 			return db.SaveLatestRoundRequested(q, rr)
 		})
 		require.NoError(t, err)
@@ -53,7 +54,7 @@ func Test_DB_LatestRoundRequested(t *testing.T) {
 			Raw:          rawLog,
 		}
 
-		err = pg.SqlxTransactionWithDefaultCtx(sqlDB, logger.TestLogger(t), func(q pg.Queryer) error {
+		err = pg.SqlxTransaction(ctx, sqlDB, logger.TestLogger(t), func(q pg.Queryer) error {
 			return db.SaveLatestRoundRequested(q, rr)
 		})
 		require.NoError(t, err)

--- a/core/services/versioning/orm_test.go
+++ b/core/services/versioning/orm_test.go
@@ -9,12 +9,13 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/static"
 )
 
 func TestORM_NodeVersion_UpsertNodeVersion(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	orm := NewORM(db, logger.TestLogger(t))
+	orm := NewORM(db, logger.TestLogger(t), pg.DefaultQueryTimeout)
 
 	err := orm.UpsertNodeVersion(NewNodeVersion("9.9.8"))
 	require.NoError(t, err)
@@ -62,7 +63,7 @@ func Test_Version_CheckVersion(t *testing.T) {
 
 	lggr := logger.TestLogger(t)
 
-	orm := NewORM(db, lggr)
+	orm := NewORM(db, lggr, pg.DefaultQueryTimeout)
 
 	err := orm.UpsertNodeVersion(NewNodeVersion("9.9.8"))
 	require.NoError(t, err)
@@ -96,7 +97,7 @@ func Test_Version_CheckVersion(t *testing.T) {
 
 func TestORM_NodeVersion_FindLatestNodeVersion(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	orm := NewORM(db, logger.TestLogger(t))
+	orm := NewORM(db, logger.TestLogger(t), pg.DefaultQueryTimeout)
 
 	// Not Found
 	_, err := orm.FindLatestNodeVersion()

--- a/core/services/vrf/delegate.go
+++ b/core/services/vrf/delegate.go
@@ -56,7 +56,7 @@ func NewDelegate(
 	porm pipeline.ORM,
 	chainSet evm.ChainSet,
 	lggr logger.Logger,
-	cfg pg.LogConfig) *Delegate {
+	cfg pg.QConfig) *Delegate {
 	return &Delegate{
 		q:    pg.NewQ(db, lggr, cfg),
 		ks:   ks,

--- a/core/services/vrf/listener_v2_test.go
+++ b/core/services/vrf/listener_v2_test.go
@@ -72,18 +72,12 @@ func addConfirmedEthTx(t *testing.T, db *sqlx.DB, from common.Address, maxLink s
 	require.NoError(t, err)
 }
 
-// cannot import cltest, because of circular imports
-type config struct{}
-
-func (c *config) LogSQL() bool {
-	return false
-}
-
 func TestMaybeSubtractReservedLink(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
 	lggr := logger.TestLogger(t)
-	q := pg.NewQ(db, lggr, &config{})
-	ks := keystore.New(db, utils.FastScryptParams, lggr, &config{})
+	cfg := pgtest.NewQConfig(false)
+	q := pg.NewQ(db, lggr, cfg)
+	ks := keystore.New(db, utils.FastScryptParams, lggr, cfg)
 	require.NoError(t, ks.Unlock("blah"))
 	chainID := uint64(1337)
 	k, err := ks.Eth().Create(big.NewInt(int64(chainID)))

--- a/core/services/webhook/authorizer_test.go
+++ b/core/services/webhook/authorizer_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/sessions"
 )
 
-func newBridgeORM(t *testing.T, db *sqlx.DB, cfg pg.LogConfig) bridges.ORM {
+func newBridgeORM(t *testing.T, db *sqlx.DB, cfg pg.QConfig) bridges.ORM {
 	return bridges.NewORM(db, logger.TestLogger(t), cfg)
 }
 
@@ -34,7 +34,7 @@ func (eiDisabledCfg) FeatureExternalInitiators() bool { return false }
 
 func Test_Authorizer(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	borm := newBridgeORM(t, db, pgtest.NewPGCfg(true))
+	borm := newBridgeORM(t, db, pgtest.NewQConfig(true))
 
 	eiFoo := cltest.MustInsertExternalInitiator(t, borm)
 	eiBar := cltest.MustInsertExternalInitiator(t, borm)

--- a/core/services/webhook/external_initiator_manager.go
+++ b/core/services/webhook/external_initiator_manager.go
@@ -42,7 +42,7 @@ type externalInitiatorManager struct {
 var _ ExternalInitiatorManager = (*externalInitiatorManager)(nil)
 
 // NewExternalInitiatorManager returns the concrete externalInitiatorManager
-func NewExternalInitiatorManager(db *sqlx.DB, httpclient HTTPClient, lggr logger.Logger, cfg pg.LogConfig) *externalInitiatorManager {
+func NewExternalInitiatorManager(db *sqlx.DB, httpclient HTTPClient, lggr logger.Logger, cfg pg.QConfig) *externalInitiatorManager {
 	namedLogger := lggr.Named("ExternalInitiatorManager")
 	return &externalInitiatorManager{
 		q:          pg.NewQ(db, namedLogger, cfg),

--- a/core/services/webhook/external_initiator_manager_test.go
+++ b/core/services/webhook/external_initiator_manager_test.go
@@ -22,7 +22,7 @@ import (
 
 func Test_ExternalInitiatorManager_Load(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := pgtest.NewPGCfg(true)
+	cfg := pgtest.NewQConfig(true)
 	borm := newBridgeORM(t, db, cfg)
 
 	eiFoo := cltest.MustInsertExternalInitiator(t, borm)
@@ -58,7 +58,7 @@ func Test_ExternalInitiatorManager_Load(t *testing.T) {
 
 func Test_ExternalInitiatorManager_Notify(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := pgtest.NewPGCfg(true)
+	cfg := pgtest.NewQConfig(true)
 	borm := newBridgeORM(t, db, cfg)
 
 	eiWithURL := cltest.MustInsertExternalInitiatorWithOpts(t, borm, cltest.ExternalInitiatorOpts{
@@ -97,7 +97,7 @@ func Test_ExternalInitiatorManager_Notify(t *testing.T) {
 
 func Test_ExternalInitiatorManager_DeleteJob(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := pgtest.NewPGCfg(true)
+	cfg := pgtest.NewQConfig(true)
 	borm := newBridgeORM(t, db, cfg)
 
 	eiWithURL := cltest.MustInsertExternalInitiatorWithOpts(t, borm, cltest.ExternalInitiatorOpts{

--- a/core/sessions/orm.go
+++ b/core/sessions/orm.go
@@ -51,7 +51,7 @@ type orm struct {
 
 var _ ORM = (*orm)(nil)
 
-func NewORM(db *sqlx.DB, sd time.Duration, lggr logger.Logger, cfg pg.LogConfig, auditLogger audit.AuditLogger) ORM {
+func NewORM(db *sqlx.DB, sd time.Duration, lggr logger.Logger, cfg pg.QConfig, auditLogger audit.AuditLogger) ORM {
 	namedLogger := lggr.Named("SessionsORM")
 	return &orm{
 		q:               pg.NewQ(db, namedLogger, cfg),

--- a/core/sessions/orm_test.go
+++ b/core/sessions/orm_test.go
@@ -25,7 +25,7 @@ func setupORM(t *testing.T) (*sqlx.DB, sessions.ORM) {
 	t.Helper()
 
 	db := pgtest.NewSqlxDB(t)
-	orm := sessions.NewORM(db, time.Minute, logger.TestLogger(t), pgtest.NewPGCfg(true), &audit.AuditLoggerService{})
+	orm := sessions.NewORM(db, time.Minute, logger.TestLogger(t), pgtest.NewQConfig(true), &audit.AuditLoggerService{})
 
 	return db, orm
 }
@@ -67,7 +67,7 @@ func TestORM_AuthorizedUserWithSession(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			db := pgtest.NewSqlxDB(t)
-			orm := sessions.NewORM(db, test.sessionDuration, logger.TestLogger(t), pgtest.NewPGCfg(true), &audit.AuditLoggerService{})
+			orm := sessions.NewORM(db, test.sessionDuration, logger.TestLogger(t), pgtest.NewQConfig(true), &audit.AuditLoggerService{})
 
 			user := cltest.MustNewUser(t, "have@email", cltest.Password)
 			require.NoError(t, orm.CreateUser(&user))

--- a/core/sessions/reaper_test.go
+++ b/core/sessions/reaper_test.go
@@ -33,7 +33,7 @@ func TestSessionReaper_ReapSessions(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
 	config := sessionReaperConfig{}
 	lggr := logger.TestLogger(t)
-	orm := sessions.NewORM(db, config.SessionTimeout().Duration(), lggr, pgtest.NewPGCfg(true), audit.NoopLogger)
+	orm := sessions.NewORM(db, config.SessionTimeout().Duration(), lggr, pgtest.NewQConfig(true), audit.NoopLogger)
 
 	r := sessions.NewSessionReaper(db.DB, config, lggr)
 	defer r.Stop()

--- a/core/store/migrate/migrate.go
+++ b/core/store/migrate/migrate.go
@@ -12,7 +12,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/pressly/goose/v3"
 	"github.com/smartcontractkit/sqlx"
-	null "gopkg.in/guregu/null.v4"
+	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
@@ -28,8 +28,16 @@ func init() {
 	goose.SetBaseFS(embedMigrations)
 	goose.SetSequential(true)
 	goose.SetTableName("goose_migrations")
-
-	verbose, _ := strconv.ParseBool(os.Getenv("LOG_SQL_MIGRATIONS"))
+	// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
+	var logMigrations string
+	if v1, v2 := os.Getenv("LOG_SQL_MIGRATIONS"), os.Getenv("CL_LOG_SQL_MIGRATIONS"); v1 != "" && v2 != "" {
+		panic("you may only set one of LOG_SQL_MIGRATIONS and CL_LOG_SQL_MIGRATIONS environment variables, not both")
+	} else if v1 == "" {
+		logMigrations = v2
+	} else if v2 == "" {
+		logMigrations = v1
+	}
+	verbose, _ := strconv.ParseBool(logMigrations)
 	goose.SetVerbose(verbose)
 }
 

--- a/core/store/models/secrets.go
+++ b/core/store/models/secrets.go
@@ -1,0 +1,53 @@
+package models
+
+import (
+	"encoding"
+	"fmt"
+)
+
+const redacted = "xxxxx"
+
+var (
+	_ fmt.Stringer           = (*Secret)(nil)
+	_ encoding.TextMarshaler = (*Secret)(nil)
+)
+
+// Secret is a string that formats and encodes redacted, as "xxxxx".
+//
+// Use Value to get the actual secret.
+type Secret string
+
+func NewSecret(s string) *Secret { return (*Secret)(&s) }
+
+func (s Secret) String() string { return redacted }
+
+func (s Secret) GoString() string { return redacted }
+
+func (s Secret) MarshalText() ([]byte, error) { return []byte(redacted), nil }
+
+var (
+	_ fmt.Stringer             = (*SecretURL)(nil)
+	_ encoding.TextMarshaler   = (*SecretURL)(nil)
+	_ encoding.TextUnmarshaler = (*SecretURL)(nil)
+)
+
+// SecretURL is a URL that formats and encodes redacted, as "xxxxx".
+type SecretURL URL
+
+func NewSecretURL(u *URL) *SecretURL { return (*SecretURL)(u) }
+
+func MustSecretURL(u string) *SecretURL { return NewSecretURL(MustParseURL(u)) }
+
+func (s *SecretURL) String() string { return redacted }
+
+func (s *SecretURL) GoString() string { return redacted }
+
+func (s *SecretURL) MarshalText() ([]byte, error) { return []byte(redacted), nil }
+
+func (s *SecretURL) UnmarshalText(text []byte) error {
+	if err := (*URL)(s).UnmarshalText(text); err != nil {
+		//opt: if errors.Is(url.Error), just redact the err.URL field?
+		return fmt.Errorf("failed to parse url: %s", redacted)
+	}
+	return nil
+}

--- a/core/store/models/secrets_test.go
+++ b/core/store/models/secrets_test.go
@@ -1,0 +1,37 @@
+package models
+
+import (
+	"encoding"
+	"encoding/json"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSecret(t *testing.T) {
+	type secret interface {
+		fmt.Stringer
+		encoding.TextMarshaler
+	}
+	for _, v := range []secret{
+		Secret("secret"),
+		MustSecretURL("http://secret.url"),
+	} {
+		t.Run(fmt.Sprintf("%T", v), func(t *testing.T) {
+			assert.Equal(t, redacted, v.String())
+			got, err := v.MarshalText()
+			if assert.NoError(t, err) {
+				assert.Equal(t, redacted, string(got))
+			}
+			assert.Equal(t, redacted, fmt.Sprint(v))
+			assert.Equal(t, redacted, fmt.Sprintf("%s", v)) //nolint:gosimple
+			assert.Equal(t, redacted, fmt.Sprintf("%v", v))
+			assert.Equal(t, redacted, fmt.Sprintf("%#v", v))
+			got, err = json.Marshal(v)
+			if assert.NoError(t, err) {
+				assert.Equal(t, fmt.Sprintf(`"%s"`, redacted), string(got))
+			}
+		})
+	}
+}

--- a/core/web/bridge_types_controller_test.go
+++ b/core/web/bridge_types_controller_test.go
@@ -115,7 +115,7 @@ func TestValidateBridgeNotExist(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := pgtest.NewPGCfg(true)
+	cfg := pgtest.NewQConfig(true)
 	orm := bridges.NewORM(db, logger.TestLogger(t), cfg)
 
 	// Create a duplicate

--- a/core/web/external_initiators_controller_test.go
+++ b/core/web/external_initiators_controller_test.go
@@ -24,7 +24,7 @@ func TestValidateExternalInitiator(t *testing.T) {
 	t.Parallel()
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := pgtest.NewPGCfg(true)
+	cfg := pgtest.NewQConfig(true)
 	orm := bridges.NewORM(db, logger.TestLogger(t), cfg)
 
 	url := cltest.WebURL(t, "https://a.web.url")

--- a/core/web/jobs_controller_test.go
+++ b/core/web/jobs_controller_test.go
@@ -606,7 +606,7 @@ func runDirectRequestJobSpecAssertions(t *testing.T, ereJobSpecFromFile job.Job,
 	assert.Contains(t, ereJobSpecFromServer.DirectRequestSpec.UpdatedAt.String(), "20")
 }
 
-func setupBridges(t *testing.T, db *sqlx.DB, cfg pg.LogConfig) (b1, b2 string) {
+func setupBridges(t *testing.T, db *sqlx.DB, cfg pg.QConfig) (b1, b2 string) {
 	_, bridge := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, cfg)
 	_, bridge2 := cltest.MustCreateBridge(t, db, cltest.BridgeOpts{}, cfg)
 	return bridge.Name.String(), bridge2.Name.String()

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -115,6 +115,7 @@ UICSAKeys enables CSA Keys in the UI.
 DefaultIdleInTxSessionTimeout = '1h' # Default
 DefaultLockTimeout = '15s' # Default
 DefaultQueryTimeout = '10s' # Default
+LogQueries = false # Default
 MaxIdleConns = 10 # Default
 MaxOpenConns = 20 # Default
 MigrateOnStartup = true # Default
@@ -138,6 +139,12 @@ DefaultLockTimeout is the maximum time allowed for a query stuck waiting to take
 DefaultQueryTimeout = '10s' # Default
 ```
 DefaultQueryTimeout is the maximum time allowed for standard queries before timing out.
+
+### LogQueries<a id='Database-LogQueries'></a>
+```toml
+LogQueries = false # Default
+```
+LogQueries tells the Chainlink node to log database queries made using the default logger. SQL statements will be logged at `debug` level. Not all statements can be logged. The best way to get a true log of all SQL statements is to enable SQL statement logging on Postgres.
 
 ### MaxIdleConns<a id='Database-MaxIdleConns'></a>
 ```toml
@@ -372,17 +379,26 @@ Headers is the set of headers you wish to pass along with each request
 ## Log<a id='Log'></a>
 ```toml
 [Log]
-DatabaseQueries = false # Default
+Level = 'info' # Default
 JSONConsole = false # Default
 UnixTS = false # Default
 ```
 
 
-### DatabaseQueries<a id='Log-DatabaseQueries'></a>
+### Level<a id='Log-Level'></a>
 ```toml
-DatabaseQueries = false # Default
+Level = 'info' # Default
 ```
-DatabaseQueries tells the Chainlink node to log database queries made using the default logger. SQL statements will be logged at `debug` level. Not all statements can be logged. The best way to get a true log of all SQL statements is to enable SQL statement logging on Postgres.
+Level determines both what is printed on the screen and what is written to the log file.
+
+The available levels are:
+- "debug": Useful for forensic debugging of issues.
+- "info": High-level informational messages. (default)
+- "warn": A mild error occurred that might require non-urgent action. Check these warnings semi-regularly to see if any of them require attention. These warnings usually happen due to factors outside of the control of the node operator. Examples: Unexpected responses from a remote API or misleading networking errors.
+- "error": An unexpected error occurred during the regular operation of a well-maintained node. Node operators might need to take action to remedy this error. Check these regularly to see if any of them require attention. Examples: Use of deprecated configuration options or incorrectly configured settings that cause a job to fail.
+- "crit": A critical error occurred. The node might be unable to function. Node operators should take immediate action to fix these errors. Examples: The node could not boot because a network socket could not be opened or the database became inaccessible.
+- "panic": An exceptional error occurred that could not be handled. If the node is unresponsive, node operators should try to restart their nodes and notify the Chainlink team of a potential bug.
+- "fatal": The node encountered an unrecoverable problem and had to exit.
 
 ### JSONConsole<a id='Log-JSONConsole'></a>
 ```toml
@@ -1259,7 +1275,6 @@ GoroutineThreshold is the maximum number of actively-running goroutines the node
 ```toml
 [Pyroscope]
 ServerAddress = 'http://localhost:4040' # Example
-AuthToken = 'randomly-oauth-generated-token' # Example
 Environment = 'mainnet' # Default
 ```
 
@@ -1269,12 +1284,6 @@ Environment = 'mainnet' # Default
 ServerAddress = 'http://localhost:4040' # Example
 ```
 ServerAddress sets the address that will receive the profile logs. It enables the profiling service.
-
-### AuthToken<a id='Pyroscope-AuthToken'></a>
-```toml
-AuthToken = 'randomly-oauth-generated-token' # Example
-```
-AuthToken sets the needed Auth Token on Server Addresses that require an Auth Token.
 
 ### Environment<a id='Pyroscope-Environment'></a>
 ```toml


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/23679/prefix-all-env-vars-with-cl

- [x] Add 'secret' string and url types
- [x] Read database connection params from config
- [x] `DefaultQueryTImeout` from config
- [x] Unify `LOG_SQL` and `Log.DatabaseQueries` as `Database.LogQueries`
- [x] `LOG_SQL_MIGRATIONS` -> `CL_*` completely undocumented; controls goose verbosity
- [x] `LOG_COLOR` -> `CL_*` also undocumented
- [x] Move `Pyroscope.AuthToken` to secrets
- [x] Log (redacted) secrets to show if set
- [x] `SKIP_DATABASE_PASSWORD_COMPLEXITY_CHECK` support via toml, and make strict validation error not just error level log
- [x] `LOG_LEVEL` move to TOML `Log.Level` only
- [ ] ~document secrets~ follow up PR