### PR TITLE
feature: remove setMaxGasPriceGwei() from VRF

### DIFF
--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -443,19 +443,11 @@ type VRFSpec struct {
 	RequestedConfsDelay      int64         `toml:"requestedConfsDelay"` // For v2 jobs. Optional, defaults to 0 if not provided.
 	RequestTimeout           time.Duration `toml:"requestTimeout"`      // Optional, defaults to 24hr if not provided.
 
-	// MaxGasPriceGwei sets the maximum gas price in gwei on the addresses
-	// specified in VRFSpec.FromAddresses.
-	//
-	// This is optional. If this is not set, then the job will not attempt to set any
-	// key specific gas prices on the addresses specified in VRFSpec.FromAddresses,
-	// and as a result, will use any previously set key specific max gas price (i.e, set via CLI or REST API)
-	// or the global max gas price if a key-specific gas price is not set.
+	// MaxGasPriceGwei specifies the maximum gas price in gwei for this VRF
+	// job. It is for documentation purposes _only_ and does not set any actual
+	// gas price on any keys. That must be done through key-specific configuration.
 	//
 	// This is essentially the "gas lane" gas price.
-	//
-	// This will end up overriding any previously set key-specific gas prices
-	// set via CLI and/or REST API. However, environment variables can end up
-	// taking precedence depending on their values relative to the key-specific prices.
 	//
 	// V2 only.
 	MaxGasPriceGWei *uint32 `toml:"maxGasPriceGWei" db:"max_gas_price_gwei"`

--- a/core/services/vrf/delegate.go
+++ b/core/services/vrf/delegate.go
@@ -21,7 +21,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/job"
 	"github.com/smartcontractkit/chainlink/core/services/keystore"
-	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/core/services/pg"
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/core/utils"
@@ -114,17 +113,6 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 	)
 	lV1 := l.Named("VRFListener")
 	lV2 := l.Named("VRFListenerV2")
-
-	// This is not a terminal error, but it isn't ideal.
-	// We can operate under these potentially degraded conditions, however.
-	err = setMaxGasPriceGWei(
-		toAddrSlice(jb.VRFSpec.FromAddresses),
-		jb.VRFSpec.MaxGasPriceGWei,
-		d.cc,
-		chain.ID())
-	if err != nil {
-		l.With("err", err).Warn("unable to set max gas price gwei on from addresses, continuing anyway")
-	}
 
 	for _, task := range pl.Tasks {
 		if _, ok := task.(*pipeline.VRFTaskV2); ok {
@@ -282,30 +270,4 @@ GROUP BY meta->'RequestID'
 		return nil, err
 	}
 	return counts, nil
-}
-
-// setMaxGasPriceGWei attempts to set the max gas price for each key in the fromAddresses slice
-// of the VRF job spec to the given maxGasPriceGWei parameter.
-// If maxGasPriceGWei is nil, this is a no-op.
-func setMaxGasPriceGWei(fromAddresses []common.Address, maxGasPriceGWei *uint32, keyUpdater keyConfigUpdater, chainID *big.Int) error {
-	if maxGasPriceGWei == nil {
-		return nil
-	}
-
-	for _, addr := range fromAddresses {
-		updater := evm.UpdateKeySpecificMaxGasPrice(addr, assets.GWei(int64(*maxGasPriceGWei)))
-		err := keyUpdater.UpdateConfig(chainID, updater)
-		if err != nil {
-			return errors.Wrap(err, "update key specific max gas price")
-		}
-	}
-
-	return nil
-}
-
-func toAddrSlice(addrs []ethkey.EIP55Address) (r []common.Address) {
-	for _, a := range addrs {
-		r = append(r, a.Address())
-	}
-	return
 }

--- a/core/services/vrf/listener_v2.go
+++ b/core/services/vrf/listener_v2.go
@@ -577,12 +577,6 @@ func (lsn *listenerV2) processRequestsPerSubBatch(
 		}
 
 		fromAddresses := lsn.fromAddresses()
-		err = setMaxGasPriceGWei(fromAddresses, lsn.job.VRFSpec.MaxGasPriceGWei, lsn.keyUpdater, lsn.chainID)
-		if err != nil {
-			l.Warnw("Couldn't set max gas price gwei on configured from addresses, processing anyway",
-				"err", err, "fromAddresses", fromAddresses)
-		}
-
 		fromAddress, err := lsn.gethks.GetRoundRobinAddress(lsn.chainID, fromAddresses...)
 		if err != nil {
 			l.Errorw("Couldn't get next from address", "err", err)
@@ -735,12 +729,6 @@ func (lsn *listenerV2) processRequestsPerSub(
 		}
 
 		fromAddresses := lsn.fromAddresses()
-		err = setMaxGasPriceGWei(fromAddresses, lsn.job.VRFSpec.MaxGasPriceGWei, lsn.keyUpdater, lsn.chainID)
-		if err != nil {
-			l.Warnw("Couldn't set max gas price gwei on configured from addresses, processing anyway",
-				"err", err, "fromAddresses", fromAddresses)
-		}
-
 		fromAddress, err := lsn.gethks.GetRoundRobinAddress(lsn.chainID, fromAddresses...)
 		if err != nil {
 			l.Errorw("Couldn't get next from address", "err", err)


### PR DESCRIPTION
This is a mis-use of the `UpdateKeySpecificMaxGasPrice` API.

The `maxGasPriceGWei` field on the VRF job spec remains, but it's for documentation purposes only (i.e to document the fact that the VRF job's maximum gas price is supposed to be that much).