### PR TITLE
core/config/v2/docs: document secrets

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -148,7 +148,7 @@ test_chaos: test_need_operator_assets ## Run core node chaos tests.
 
 .PHONY: config-docs
 config-docs: ## Generate core node configuration documentation
-	go run ./core/config/v2/docs/cmd/generate/main.go > ./docs/CONFIG.md
+	go run ./core/config/v2/docs/cmd/generate/main.go -o ./docs/
 
 .PHONY: golangci-lint
 golangci-lint: ## Run golangci-lint for all issues.

--- a/config_docs_test.go
+++ b/config_docs_test.go
@@ -9,12 +9,19 @@ import (
 	"github.com/smartcontractkit/chainlink/core/config/v2/docs"
 )
 
-//go:embed docs/CONFIG.md
-var markdown string
+var (
+	//go:embed docs/CONFIG.md
+	configMD string
+	//go:embed docs/SECRETS.md
+	secretsMD string
+)
 
 func TestConfigDocs(t *testing.T) {
-	got, err := docs.GenerateDocs()
+	config, err := docs.GenerateConfig()
 	assert.NoError(t, err, "invalid config docs")
-	assert.Equal(t, markdown, got, "docs/CONFIG.md is out of date. Run 'make config-docs' to regenerate.")
+	assert.Equal(t, configMD, config, "docs/CONFIG.md is out of date. Run 'make config-docs' to regenerate.")
 
+	secrets, err := docs.GenerateSecrets()
+	assert.NoError(t, err, "invalid secrets docs")
+	assert.Equal(t, secretsMD, secrets, "docs/SECRETS.md is out of date. Run 'make config-docs' to regenerate.")
 }

--- a/core/config/v2/docs/cmd/generate/main.go
+++ b/core/config/v2/docs/cmd/generate/main.go
@@ -1,19 +1,37 @@
 // Docs prints core node documentation and/or a list of errors.
-// The docs are Markdown generated from Toml - see config.GenerateDocs.
+// The docs are Markdown generated from Toml - see config.GenerateConfig & config.GenerateSecrets.
 package main
 
 import (
+	"flag"
 	"fmt"
 	"os"
+	"path"
 
 	"github.com/smartcontractkit/chainlink/core/config/v2/docs"
 )
 
+var outDir = flag.String("o", "", "output directory")
+
 func main() {
-	s, err := docs.GenerateDocs()
-	fmt.Print(s)
+	flag.Parse()
+
+	c, err := docs.GenerateConfig()
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "invalid config docs: %v\n", err)
+		os.Exit(1)
+	}
+	s, err := docs.GenerateSecrets()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "invalid secrets docs: %v\n", err)
+		os.Exit(1)
+	}
+	if err = os.WriteFile(path.Join(*outDir, "CONFIG.md"), []byte(c), 0600); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write config docs: %v\n", err)
+		os.Exit(1)
+	}
+	if err = os.WriteFile(path.Join(*outDir, "SECRETS.md"), []byte(s), 0600); err != nil {
+		fmt.Fprintf(os.Stderr, "failed to write secrets docs: %v\n", err)
 		os.Exit(1)
 	}
 }

--- a/core/config/v2/docs/docs.go
+++ b/core/config/v2/docs/docs.go
@@ -20,6 +20,8 @@ const (
 )
 
 var (
+	//go:embed secrets.toml
+	secretsTOML string
 	//go:embed core.toml
 	coreTOML string
 	//go:embed chains-evm.toml
@@ -34,18 +36,35 @@ var (
 	docsTOML = coreTOML + chainsEVMTOML + chainsSolanaTOML + chainsStarknetTOML + chainsTerraTOML
 )
 
-// GenerateDocs returns MarkDown documentation generated from core.toml & chains-*.toml.
-func GenerateDocs() (string, error) {
-	return generateDocs(docsTOML)
+// GenerateConfig returns MarkDown documentation generated from core.toml & chains-*.toml.
+func GenerateConfig() (string, error) {
+	return generateDocs(docsTOML, `[//]: # (Documentation generated from docs/*.toml - DO NOT EDIT.)
+
+This document describes the TOML format for configuration.
+
+See also [SECRETS.md](secrets.md)
+`)
+}
+
+// GenerateSecrets returns MarkDown documentation generated from secrets.toml.
+func GenerateSecrets() (string, error) {
+	return generateDocs(secretsTOML, `[//]: # (Documentation generated from docs/secrets.toml - DO NOT EDIT.)
+
+This document describes the TOML format for secrets.
+
+Each secret has an alternative corresponding environment variable.
+
+See also [CONFIG.md](config.md)
+`)
 }
 
 // generateDocs returns MarkDown documentation generated from the TOML string.
-func generateDocs(toml string) (string, error) {
+func generateDocs(toml, header string) (string, error) {
 	items, err := parseTOMLDocs(toml)
 	var sb strings.Builder
 
-	sb.WriteString(`[//]: # (Documentation generated from docs/*.toml - DO NOT EDIT.)
-
+	sb.WriteString(header)
+	sb.WriteString(`
 ## Table of contents
 
 `)
@@ -234,6 +253,10 @@ func parseTOMLDocs(s string) (items []fmt.Stringer, err error) {
 			currentTable.codes = append(currentTable.codes, kv.code)
 			desc = nil
 		}
+	}
+	if len(globalTable.codes) == 0 {
+		//drop it
+		items = items[1:]
 	}
 	if len(desc) > 0 {
 		items = append(items, desc)

--- a/core/config/v2/docs/docs_test.go
+++ b/core/config/v2/docs/docs_test.go
@@ -120,7 +120,8 @@ var (
 )
 
 func Test_generateDocs(t *testing.T) {
-	got, err := generateDocs(exampleTOML)
+	got, err := generateDocs(exampleTOML, `[//]: # (Generated - DO NOT EDIT.)
+`)
 	require.NoError(t, err)
 	assert.Equal(t, exampleMarkdown, got)
 }

--- a/core/config/v2/docs/secrets.toml
+++ b/core/config/v2/docs/secrets.toml
@@ -1,0 +1,41 @@
+[Database]
+# URL is the PostgreSQL URI to connect to your database. Chainlink nodes require Postgres versions >= 11. See
+# [Running a Chainlink Node](https://docs.chain.link/docs/running-a-chainlink-node/#set-the-remote-database_url-config) for an example.
+#
+# Environment variable: `CL_DATABASE_URL`
+URL = "postgresql://user:pass@localhost:5432/dbname?sslmode=disable" # Example
+# BackupURL is where the automatic database backup will pull from, rather than the main DATABASE_URL. It is recommended
+# to set this value to a read replica if you have one to avoid excessive load on the main database.
+#
+# Environment variable: `CL_DATABASE_BACKUP_URL`
+BackupURL = "postgresql://user:pass@localhost:5432/backupdbname?sslmode=disable" # Example
+# AllowSimplePasswords skips the password complexity check normally enforced on URL & BackupURL.
+#
+# TODO need an env var?
+AllowSimplePasswords = false # Default
+
+[Explorer]
+# AccessKey is the access key for authenticating with the Explorer.
+#
+# Environment variable: `CL_EXPLORER_ACCESS_KEY`
+AccessKey = "access_key" # Example
+# Secret is the secret for authenticating with the Explorer.
+#
+# Environment variable: `CL_EXPLORER_SECRET`
+Secret = "secret" # Example
+
+[Password]
+# Keystore is the password for the node's account.
+#
+# Environment variable: `CL_PASSWORD_KEYSTORE`
+Keystore = "keystore_pass" # Example
+# VRF is the password for the vrf keys.
+#
+# Environment variable: `CL_PASSWORD_VRF`
+VRF = "VRF_pass" # Example
+
+[Pyroscope]
+# AuthToken is the API key for the Pyroscope server.
+#
+# Environment variable: `CL_PYROSCOPE_AUTH_TOKEN`
+AuthToken = "pyroscope-token" # Example

--- a/core/config/v2/docs/secrets.toml
+++ b/core/config/v2/docs/secrets.toml
@@ -8,10 +8,10 @@ URL = "postgresql://user:pass@localhost:5432/dbname?sslmode=disable" # Example
 # to set this value to a read replica if you have one to avoid excessive load on the main database.
 #
 # Environment variable: `CL_DATABASE_BACKUP_URL`
-BackupURL = "postgresql://user:pass@localhost:5432/backupdbname?sslmode=disable" # Example
+BackupURL = "postgresql://user:pass@read-replica.example.com:5432/dbname?sslmode=disable" # Example
 # AllowSimplePasswords skips the password complexity check normally enforced on URL & BackupURL.
 #
-# TODO need an env var?
+# Environment variable: `CL_DATABASE_ALLOW_SIMPLE_PASSWORDS`
 AllowSimplePasswords = false # Default
 
 [Explorer]

--- a/core/config/v2/docs/testdata/example.md
+++ b/core/config/v2/docs/testdata/example.md
@@ -1,4 +1,4 @@
-[//]: # (Documentation generated from docs/*.toml - DO NOT EDIT.)
+[//]: # (Generated - DO NOT EDIT.)
 
 ## Table of contents
 

--- a/core/config/v2/env.go
+++ b/core/config/v2/env.go
@@ -11,13 +11,14 @@ var (
 	EnvConfig = Env("CL_CONFIG")
 	EnvDev    = Env("CL_DEV")
 
-	EnvDatabaseURL        = EnvSecret("CL_DATABASE_URL")
-	EnvDatabaseBackupURL  = EnvSecret("CL_DATABASE_BACKUP_URL")
-	EnvExplorerAccessKey  = EnvSecret("CL_EXPLORER_ACCESS_KEY")
-	EnvExplorerSecret     = EnvSecret("CL_EXPLORER_SECRET")
-	EnvPasswordKeystore   = EnvSecret("CL_PASSWORD_KEYSTORE")
-	EnvPasswordVRF        = EnvSecret("CL_PASSWORD_VRF")
-	EnvPyroscopeAuthToken = EnvSecret("CL_PYROSCOPE_AUTH_TOKEN")
+	EnvDatabaseAllowSimplePasswords = Env("CL_DATABASE_ALLOW_SIMPLE_PASSWORDS")
+	EnvDatabaseURL                  = EnvSecret("CL_DATABASE_URL")
+	EnvDatabaseBackupURL            = EnvSecret("CL_DATABASE_BACKUP_URL")
+	EnvExplorerAccessKey            = EnvSecret("CL_EXPLORER_ACCESS_KEY")
+	EnvExplorerSecret               = EnvSecret("CL_EXPLORER_SECRET")
+	EnvPasswordKeystore             = EnvSecret("CL_PASSWORD_KEYSTORE")
+	EnvPasswordVRF                  = EnvSecret("CL_PASSWORD_VRF")
+	EnvPyroscopeAuthToken           = EnvSecret("CL_PYROSCOPE_AUTH_TOKEN")
 )
 
 type Env string

--- a/core/services/chainlink/config.go
+++ b/core/services/chainlink/config.go
@@ -114,6 +114,9 @@ func (s *Secrets) setOverrides(keystorePasswordFileName, vrfPasswordFileName *st
 			return err
 		}
 	}
+	if config.EnvDatabaseAllowSimplePasswords.IsTrue() {
+		s.Database.AllowSimplePasswords = true
+	}
 	if explorerKey := config.EnvExplorerAccessKey.Get(); explorerKey != "" {
 		s.Explorer.AccessKey = &explorerKey
 	}

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1,5 +1,9 @@
 [//]: # (Documentation generated from docs/*.toml - DO NOT EDIT.)
 
+This document describes the TOML format for configuration.
+
+See also [SECRETS.md](secrets.md)
+
 ## Table of contents
 
 - [Global](#Global)

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -17,7 +17,7 @@ See also [CONFIG.md](config.md)
 ```toml
 [Database]
 URL = "postgresql://user:pass@localhost:5432/dbname?sslmode=disable" # Example
-BackupURL = "postgresql://user:pass@localhost:5432/backupdbname?sslmode=disable" # Example
+BackupURL = "postgresql://user:pass@read-replica.example.com:5432/dbname?sslmode=disable" # Example
 AllowSimplePasswords = false # Default
 ```
 
@@ -33,7 +33,7 @@ Environment variable: `CL_DATABASE_URL`
 
 ### BackupURL<a id='Database-BackupURL'></a>
 ```toml
-BackupURL = "postgresql://user:pass@localhost:5432/backupdbname?sslmode=disable" # Example
+BackupURL = "postgresql://user:pass@read-replica.example.com:5432/dbname?sslmode=disable" # Example
 ```
 BackupURL is where the automatic database backup will pull from, rather than the main DATABASE_URL. It is recommended
 to set this value to a read replica if you have one to avoid excessive load on the main database.
@@ -46,7 +46,7 @@ AllowSimplePasswords = false # Default
 ```
 AllowSimplePasswords skips the password complexity check normally enforced on URL & BackupURL.
 
-TODO need an env var?
+Environment variable: `CL_DATABASE_ALLOW_SIMPLE_PASSWORDS`
 
 ## Explorer<a id='Explorer'></a>
 ```toml
@@ -107,7 +107,7 @@ AuthToken = "pyroscope-token" # Example
 ```toml
 AuthToken = "pyroscope-token" # Example
 ```
-AuthToken is the API key for the Pyroscope.ServerAddress.
+AuthToken is the API key for the Pyroscope server.
 
 Environment variable: `CL_PYROSCOPE_AUTH_TOKEN`
 

--- a/docs/SECRETS.md
+++ b/docs/SECRETS.md
@@ -1,0 +1,113 @@
+[//]: # (Documentation generated from docs/secrets.toml - DO NOT EDIT.)
+
+This document describes the TOML format for secrets.
+
+Each secret has an alternative corresponding environment variable.
+
+See also [CONFIG.md](config.md)
+
+## Table of contents
+
+- [Database](#Database)
+- [Explorer](#Explorer)
+- [Password](#Password)
+- [Pyroscope](#Pyroscope)
+
+## Database<a id='Database'></a>
+```toml
+[Database]
+URL = "postgresql://user:pass@localhost:5432/dbname?sslmode=disable" # Example
+BackupURL = "postgresql://user:pass@localhost:5432/backupdbname?sslmode=disable" # Example
+AllowSimplePasswords = false # Default
+```
+
+
+### URL<a id='Database-URL'></a>
+```toml
+URL = "postgresql://user:pass@localhost:5432/dbname?sslmode=disable" # Example
+```
+URL is the PostgreSQL URI to connect to your database. Chainlink nodes require Postgres versions >= 11. See
+[Running a Chainlink Node](https://docs.chain.link/docs/running-a-chainlink-node/#set-the-remote-database_url-config) for an example.
+
+Environment variable: `CL_DATABASE_URL`
+
+### BackupURL<a id='Database-BackupURL'></a>
+```toml
+BackupURL = "postgresql://user:pass@localhost:5432/backupdbname?sslmode=disable" # Example
+```
+BackupURL is where the automatic database backup will pull from, rather than the main DATABASE_URL. It is recommended
+to set this value to a read replica if you have one to avoid excessive load on the main database.
+
+Environment variable: `CL_DATABASE_BACKUP_URL`
+
+### AllowSimplePasswords<a id='Database-AllowSimplePasswords'></a>
+```toml
+AllowSimplePasswords = false # Default
+```
+AllowSimplePasswords skips the password complexity check normally enforced on URL & BackupURL.
+
+TODO need an env var?
+
+## Explorer<a id='Explorer'></a>
+```toml
+[Explorer]
+AccessKey = "access_key" # Example
+Secret = "secret" # Example
+```
+
+
+### AccessKey<a id='Explorer-AccessKey'></a>
+```toml
+AccessKey = "access_key" # Example
+```
+AccessKey is the access key for authenticating with the Explorer.
+
+Environment variable: `CL_EXPLORER_ACCESS_KEY`
+
+### Secret<a id='Explorer-Secret'></a>
+```toml
+Secret = "secret" # Example
+```
+Secret is the secret for authenticating with the Explorer.
+
+Environment variable: `CL_EXPLORER_SECRET`
+
+## Password<a id='Password'></a>
+```toml
+[Password]
+Keystore = "keystore_pass" # Example
+VRF = "VRF_pass" # Example
+```
+
+
+### Keystore<a id='Password-Keystore'></a>
+```toml
+Keystore = "keystore_pass" # Example
+```
+Keystore is the password for the node's account.
+
+Environment variable: `CL_PASSWORD_KEYSTORE`
+
+### VRF<a id='Password-VRF'></a>
+```toml
+VRF = "VRF_pass" # Example
+```
+VRF is the password for the vrf keys.
+
+Environment variable: `CL_PASSWORD_VRF`
+
+## Pyroscope<a id='Pyroscope'></a>
+```toml
+[Pyroscope]
+AuthToken = "pyroscope-token" # Example
+```
+
+
+### AuthToken<a id='Pyroscope-AuthToken'></a>
+```toml
+AuthToken = "pyroscope-token" # Example
+```
+AuthToken is the API key for the Pyroscope.ServerAddress.
+
+Environment variable: `CL_PYROSCOPE_AUTH_TOKEN`
+


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/54383/document-secrets-toml

This PR documents the `secrets.toml` fields and their environment variable alternatives by adding a second generated file `docs/SECRETS.md` alongside `docs/CONFIG.md`. Two files is simpler for a variety of reasons, and we can still link between them. We could try to combine them if there is a compelling reason, but it would be a much larger refactor.