### PR TITLE
core/chains/evm/client: fix test races by closing eth clients to prevent orphaned goroutines from logging after test is complete

### DIFF
--- a/core/chains/evm/client/client_test.go
+++ b/core/chains/evm/client/client_test.go
@@ -26,7 +26,6 @@ import (
 	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
@@ -38,7 +37,7 @@ func mustNewClientWithChainID(t *testing.T, wsURL string, chainID *big.Int, send
 	cfg := evmclient.TestNodeConfig{
 		SelectionMode: evmclient.NodeSelectionMode_RoundRobin,
 	}
-	c, err := evmclient.NewClientWithTestNode(cfg, logger.TestLogger(t), wsURL, nil, sendonlys, 42, chainID)
+	c, err := evmclient.NewClientWithTestNode(t, cfg, wsURL, nil, sendonlys, 42, chainID)
 	require.NoError(t, err)
 	return c
 }
@@ -263,7 +262,6 @@ func TestEthClient_HeaderByNumber(t *testing.T) {
 			ethClient := mustNewClient(t, wsURL)
 			err := ethClient.Dial(testutils.Context(t))
 			require.NoError(t, err)
-			defer ethClient.Close()
 
 			ctx, cancel := context.WithTimeout(testutils.Context(t), 5*time.Second)
 			defer cancel()
@@ -317,7 +315,6 @@ func TestEthClient_SendTransaction_WithSecondaryURLs(t *testing.T) {
 
 	sendonlyURL := *cltest.MustParseURL(t, ts.URL)
 	ethClient := mustNewClient(t, wsURL, sendonlyURL, sendonlyURL)
-	defer ethClient.Close()
 	err := ethClient.Dial(testutils.Context(t))
 	require.NoError(t, err)
 

--- a/core/chains/evm/client/helpers_test.go
+++ b/core/chains/evm/client/helpers_test.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"math/big"
 	"net/url"
+	"testing"
 	"time"
 
 	"github.com/pkg/errors"
+
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
@@ -22,7 +24,7 @@ func (tc TestNodeConfig) NodePollFailureThreshold() uint32       { return tc.Pol
 func (tc TestNodeConfig) NodePollInterval() time.Duration        { return tc.PollInterval }
 func (tc TestNodeConfig) NodeSelectionMode() string              { return tc.SelectionMode }
 
-func NewClientWithTestNode(cfg NodeConfig, lggr logger.Logger, rpcUrl string, rpcHTTPURL *url.URL, sendonlyRPCURLs []url.URL, id int32, chainID *big.Int) (*client, error) {
+func NewClientWithTestNode(t *testing.T, cfg NodeConfig, rpcUrl string, rpcHTTPURL *url.URL, sendonlyRPCURLs []url.URL, id int32, chainID *big.Int) (*client, error) {
 	parsed, err := url.ParseRequestURI(rpcUrl)
 	if err != nil {
 		return nil, err
@@ -32,6 +34,7 @@ func NewClientWithTestNode(cfg NodeConfig, lggr logger.Logger, rpcUrl string, rp
 		return nil, errors.Errorf("ethereum url scheme must be websocket: %s", parsed.String())
 	}
 
+	lggr := logger.TestLogger(t)
 	n := NewNode(cfg, lggr, *parsed, rpcHTTPURL, "eth-primary-0", id, chainID)
 	n.(*node).setLatestReceivedBlockNumber(0)
 	primaries := []Node{n}
@@ -46,7 +49,9 @@ func NewClientWithTestNode(cfg NodeConfig, lggr logger.Logger, rpcUrl string, rp
 	}
 
 	pool := NewPool(lggr, cfg, primaries, sendonlys, chainID)
-	return &client{logger: lggr, pool: pool}, nil
+	c := &client{logger: lggr, pool: pool}
+	t.Cleanup(c.Close)
+	return c, nil
 }
 
 func Wrap(err error, s string) error {


### PR DESCRIPTION
IIUC this race is an indirect effect of logging from an orphaned goroutine after a test has completed.

Only two usages of these helpers were closing their eth clients on defer or test cleanup. Now the cleanup is registered from the innermost helper instead.

```
==================
WARNING: DATA RACE
Read at 0x00c002b3cd43 by goroutine 6706:
  testing.(*common).logDepth()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:889 +0x4e7
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:876 +0xa4
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:927 +0x6a
  testing.(*T).Logf()
      <autogenerated>:1 +0x75
  go.uber.org/zap/zaptest.testingWriter.Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/zaptest/logger.go:130 +0x12c
  go.uber.org/zap/zaptest.(*testingWriter).Write()
      <autogenerated>:1 +0x7e
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/zapcore/core.go:99 +0x199
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/zapcore/entry.go:255 +0x2ce
  go.uber.org/zap.(*SugaredLogger).log()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/sugar.go:287 +0x13a
  go.uber.org/zap.(*SugaredLogger).Debug()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/sugar.go:119 +0x85
  github.com/smartcontractkit/chainlink/core/logger.(*zapLogger).Debug()
      <autogenerated>:1 +0x29
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).aliveLoop()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node_lifecycle.go:110 +0x5a7
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).declareAlive.func1.1()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node_fsm.go:128 +0x39

Previous write at 0x00c002b3cd43 by goroutine 6657:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1433 +0x7e4
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.19.2/x64/src/runtime/panic.go:476 +0x32
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x47

Goroutine 6706 (running) created at:
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).declareAlive.func1()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node_fsm.go:128 +0x1ba
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).transitionToAlive()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node_fsm.go:145 +0x304
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).declareAlive()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node_fsm.go:125 +0x4a
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).start()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node.go:243 +0x51b
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).Start.func1()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node.go:207 +0x4c
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:872 +0xe9
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).Start()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node.go:206 +0x94
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*Pool).Dial.func1()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/pool.go:125 +0x7e8
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:872 +0xe9
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*Pool).Dial()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/pool.go:108 +0x7e
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*client).Dial()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/client.go:120 +0x5c
  github.com/smartcontractkit/chainlink/core/chains/evm/client_test.TestEthClient_TransactionReceipt.func2()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/client_test.go:72 +0x25d
  testing.tRunner()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x47

Goroutine 6657 (finished) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x75d
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:109 +0x2e9
==================
```