### PR TITLE
core/services/pg: defend against pg listener race

### DIFF
--- a/core/services/pg/event_broadcaster.go
+++ b/core/services/pg/event_broadcaster.go
@@ -80,6 +80,12 @@ func (b *eventBroadcaster) Start(context.Context) error {
 		}
 		b.db = db
 		b.listener = pq.NewListener(b.uri, b.minReconnectInterval, b.maxReconnectDuration, func(ev pq.ListenerEventType, err error) {
+			// sanity check since these can still be called after closing the listener
+			select {
+			case <-b.chStop:
+				return
+			default:
+			}
 			// These are always connection-related events, and the pq library
 			// automatically handles reconnecting to the DB. Therefore, we do not
 			// need to terminate, but rather simply log these events for node


### PR DESCRIPTION
Some tests race with postgres listeners being called (and logging) after the test has returned. It looks like we close the listener in all cases that I can find, but from the docs on `Close()`/`UnlistenAll()`: `Note that you might still get notifications for any of the deleted channels even after UnlistenAll has returned.` We can defensively check if `chStop` is closed from inside the listener at least.
```
==================
WARNING: DATA RACE
Read at 0x00c0021d2ba3 by goroutine 1059:
  testing.(*common).logDepth()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:889 +0x4e7
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:876 +0xa4
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:927 +0x6a
  testing.(*T).Logf()
      <autogenerated>:1 +0x75
  go.uber.org/zap/zaptest.testingWriter.Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/zaptest/logger.go:130 +0x12c
  go.uber.org/zap/zaptest.(*testingWriter).Write()
      <autogenerated>:1 +0x7e
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/zapcore/core.go:99 +0x199
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/zapcore/entry.go:255 +0x2ce
  go.uber.org/zap.(*SugaredLogger).log()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/sugar.go:287 +0x13a
  go.uber.org/zap.(*SugaredLogger).Debug()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/sugar.go:119 +0x85
  github.com/smartcontractkit/chainlink/core/logger.(*zapLogger).Debug()
      <autogenerated>:1 +0x29
  github.com/smartcontractkit/chainlink/core/services/pg.(*eventBroadcaster).Start.func1.1()
      /home/runner/work/chainlink/chainlink/core/services/pg/event_broadcaster.go:89 +0x1fa
  github.com/lib/pq.(*Listener).emitEvent()
      /home/runner/go/pkg/mod/github.com/lib/pq@v1.10.7/notify.go:797 +0x1a4
  github.com/lib/pq.(*Listener).listenerConnLoop()
      /home/runner/go/pkg/mod/github.com/lib/pq@v1.10.7/notify.go:827 +0x14e
  github.com/lib/pq.(*Listener).listenerMain()
      /home/runner/go/pkg/mod/github.com/lib/pq@v1.10.7/notify.go:856 +0x2e
  github.com/lib/pq.NewDialListener.func1()
      /home/runner/go/pkg/mod/github.com/lib/pq@v1.10.7/notify.go:525 +0x39

Previous write at 0x00c0021d2ba3 by goroutine 1028:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1433 +0x7e4
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.19.2/x64/src/runtime/panic.go:476 +0x32
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x47

Goroutine 1059 (running) created at:
  github.com/lib/pq.NewDialListener()
      /home/runner/go/pkg/mod/github.com/lib/pq@v1.10.7/notify.go:525 +0x39a
  github.com/lib/pq.NewListener()
      /home/runner/go/pkg/mod/github.com/lib/pq@v1.10.7/notify.go:502 +0x1f1
  github.com/smartcontractkit/chainlink/core/services/pg.(*eventBroadcaster).Start.func1()
      /home/runner/work/chainlink/chainlink/core/services/pg/event_broadcaster.go:82 +0xbd
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:872 +0xe9
  github.com/smartcontractkit/chainlink/core/services/pg.(*eventBroadcaster).Start()
      /home/runner/work/chainlink/chainlink/core/services/pg/event_broadcaster.go:74 +0x5c
  github.com/smartcontractkit/chainlink/core/chains/evm/txmgr_test.TestEthBroadcaster_ProcessUnstartedEthTxs_Errors.func2.2.2.3()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txmgr/eth_broadcaster_test.go:1131 +0x1f7
  testing.tRunner()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x47

Goroutine 1028 (finished) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x75d
  github.com/smartcontractkit/chainlink/core/chains/evm/txmgr_test.TestEthBroadcaster_ProcessUnstartedEthTxs_Errors.func2()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txmgr/eth_broadcaster_test.go:1076 +0xa68
  testing.tRunner()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x47
==================
```