### PR TITLE
refactor sentry config

### DIFF
--- a/core/chains/evm/config/mocks/chain_scoped_config.go
+++ b/core/chains/evm/config/mocks/chain_scoped_config.go
@@ -3100,6 +3100,62 @@ func (_m *ChainScopedConfig) SecureCookies() bool {
 	return r0
 }
 
+// SentryDSN provides a mock function with given fields:
+func (_m *ChainScopedConfig) SentryDSN() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// SentryDebug provides a mock function with given fields:
+func (_m *ChainScopedConfig) SentryDebug() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// SentryEnvironment provides a mock function with given fields:
+func (_m *ChainScopedConfig) SentryEnvironment() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// SentryRelease provides a mock function with given fields:
+func (_m *ChainScopedConfig) SentryRelease() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // SessionOptions provides a mock function with given fields:
 func (_m *ChainScopedConfig) SessionOptions() sessions.Options {
 	ret := _m.Called()

--- a/core/config/general_config.go
+++ b/core/config/general_config.go
@@ -165,6 +165,10 @@ type BasicConfig interface {
 	ReaperExpiration() models.Duration
 	RootDir() string
 	SecureCookies() bool
+	SentryDSN() string
+	SentryDebug() bool
+	SentryEnvironment() string
+	SentryRelease() string
 	SessionOptions() sessions.Options
 	SessionTimeout() models.Duration
 	SolanaNodes() string
@@ -1177,6 +1181,22 @@ func (c *generalConfig) SecureCookies() bool {
 // SessionTimeout is the maximum duration that a user session can persist without any activity.
 func (c *generalConfig) SessionTimeout() models.Duration {
 	return models.MustMakeDuration(getEnvWithFallback(c, envvar.NewDuration("SessionTimeout")))
+}
+
+func (c *generalConfig) SentryDSN() string {
+	return os.Getenv("SENTRY_DSN")
+}
+
+func (c *generalConfig) SentryDebug() bool {
+	return os.Getenv("SENTRY_DEBUG") == "true"
+}
+
+func (c *generalConfig) SentryEnvironment() string {
+	return os.Getenv("SENTRY_ENVIRONMENT")
+}
+
+func (c *generalConfig) SentryRelease() string {
+	return os.Getenv("SENTRY_RELEASE")
 }
 
 // TLSCertPath represents the file system location of the TLS certificate

--- a/core/config/mocks/general_config.go
+++ b/core/config/mocks/general_config.go
@@ -3455,6 +3455,62 @@ func (_m *GeneralConfig) SecureCookies() bool {
 	return r0
 }
 
+// SentryDSN provides a mock function with given fields:
+func (_m *GeneralConfig) SentryDSN() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// SentryDebug provides a mock function with given fields:
+func (_m *GeneralConfig) SentryDebug() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
+}
+
+// SentryEnvironment provides a mock function with given fields:
+func (_m *GeneralConfig) SentryEnvironment() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
+// SentryRelease provides a mock function with given fields:
+func (_m *GeneralConfig) SentryRelease() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
+}
+
 // SessionOptions provides a mock function with given fields:
 func (_m *GeneralConfig) SessionOptions() sessions.Options {
 	ret := _m.Called()

--- a/core/config/v2/docs/core.toml
+++ b/core/config/v2/docs/core.toml
@@ -477,6 +477,6 @@ Debug = false # Default
 # DSN is the data source name where events will be sent. Sentry is completely disabled if this is left blank.
 DSN = 'sentry-dsn' # Example
 # Environment overrides the Sentry environment to the given value. Otherwise autodetects between dev/prod.
-Environment = 'prod' # Default
+Environment = 'my-custom-env' # Example
 # Release overrides the Sentry release to the given value. Otherwise uses the compiled-in version number.
 Release = 'v1.2.3' # Example

--- a/core/logger/sentry.go
+++ b/core/logger/sentry.go
@@ -3,14 +3,10 @@ package logger
 import (
 	"fmt"
 	"io"
-	"log"
-	"os"
 	"time"
 
 	"github.com/getsentry/sentry-go"
 	"go.uber.org/zap/zapcore"
-
-	"github.com/smartcontractkit/chainlink/core/static"
 )
 
 const (
@@ -20,48 +16,6 @@ const (
 
 	loggerContextName = "Logger"
 )
-
-func init() {
-	// If SENTRY_DSN is set at runtime, sentry will be enabled and send metrics to this URL
-	sentrydsn := os.Getenv("SENTRY_DSN")
-	if sentrydsn == "" {
-		// Do not initialize sentry at all if the DSN is missing
-		return
-	}
-
-	// If SENTRY_ENVIRONMENT is set, it will override everything. Otherwise infers from CHAINLINK_DEV.
-	var sentryenv string
-	if env := os.Getenv("SENTRY_ENVIRONMENT"); env != "" {
-		sentryenv = env
-	} else if os.Getenv("CHAINLINK_DEV") == "true" {
-		sentryenv = "dev"
-	} else {
-		sentryenv = "prod"
-	}
-
-	// If SENTRY_RELEASE is set, it will override everything. Otherwise, static.Version will be used.
-	var sentryrelease string
-	if release := os.Getenv("SENTRY_RELEASE"); release != "" {
-		sentryrelease = release
-	} else {
-		sentryrelease = static.Version
-	}
-
-	// Set SENTRY_DEBUG=true to enable printing of SDK debug messages
-	sentrydebug := os.Getenv("SENTRY_DEBUG") == "true"
-
-	err := sentry.Init(sentry.ClientOptions{
-		// AttachStacktrace is needed to send stacktrace alongside panics
-		AttachStacktrace: true,
-		Dsn:              sentrydsn,
-		Environment:      sentryenv,
-		Release:          sentryrelease,
-		Debug:            sentrydebug,
-	})
-	if err != nil {
-		log.Fatalf("sentry.Init: %s", err)
-	}
-}
 
 type sentryLogger struct {
 	h Logger

--- a/core/services/chainlink/config_dump.go
+++ b/core/services/chainlink/config_dump.go
@@ -725,16 +725,16 @@ func (c *Config) loadLegacyCoreEnv() {
 	}
 
 	if dsn := os.Getenv("SENTRY_DSN"); dsn != "" {
-		c.Sentry = config.Sentry{DSN: &dsn}
-		if debug := os.Getenv("SENTRY_DEBUG") == "true"; debug {
-			c.Sentry.Debug = &debug
-		}
-		if env := os.Getenv("SENTRY_ENVIRONMENT"); env != "" {
-			c.Sentry.Environment = &env
-		}
-		if env := os.Getenv("SENTRY_RELEASE"); env != "" {
-			c.Sentry.Release = &env
-		}
+		c.Sentry.DSN = &dsn
+	}
+	if debug := os.Getenv("SENTRY_DEBUG") == "true"; debug {
+		c.Sentry.Debug = &debug
+	}
+	if env := os.Getenv("SENTRY_ENVIRONMENT"); env != "" {
+		c.Sentry.Environment = &env
+	}
+	if rel := os.Getenv("SENTRY_RELEASE"); rel != "" {
+		c.Sentry.Release = &rel
 	}
 }
 

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -845,6 +845,22 @@ func (g *generalConfig) SessionTimeout() models.Duration {
 	return models.MustMakeDuration(g.c.WebServer.SessionTimeout.Duration())
 }
 
+func (g *generalConfig) SentryDSN() string {
+	return *g.c.Sentry.DSN
+}
+
+func (g *generalConfig) SentryDebug() bool {
+	return *g.c.Sentry.Debug
+}
+
+func (g *generalConfig) SentryEnvironment() string {
+	return *g.c.Sentry.Environment
+}
+
+func (g *generalConfig) SentryRelease() string {
+	return *g.c.Sentry.Release
+}
+
 func (g *generalConfig) TLSCertPath() string {
 	return *g.c.WebServer.TLS.CertPath
 }

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -187,5 +187,5 @@ Environment = 'mainnet'
 [Sentry]
 Debug = false
 DSN = ''
-Environment = 'prod'
+Environment = ''
 Release = ''

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -187,7 +187,7 @@ Environment = 'mainnet'
 [Sentry]
 Debug = false
 DSN = ''
-Environment = 'prod'
+Environment = ''
 Release = ''
 
 [[EVM]]

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -1300,7 +1300,7 @@ Environment sets the target environment tag in which profiles will be added to.
 [Sentry]
 Debug = false # Default
 DSN = 'sentry-dsn' # Example
-Environment = 'prod' # Default
+Environment = 'my-custom-env' # Example
 Release = 'v1.2.3' # Example
 ```
 
@@ -1320,7 +1320,7 @@ DSN is the data source name where events will be sent. Sentry is completely disa
 
 ### Environment<a id='Sentry-Environment'></a>
 ```toml
-Environment = 'prod' # Default
+Environment = 'my-custom-env' # Example
 ```
 Environment overrides the Sentry environment to the given value. Otherwise autodetects between dev/prod.
 

--- a/tools/bin/ldflags
+++ b/tools/bin/ldflags
@@ -5,4 +5,4 @@ cd "$(dirname "$0")"
 COMMIT_SHA=${COMMIT_SHA:-$(git rev-parse HEAD)}
 VERSION=${VERSION:-$(cat "../../VERSION")}
 
-echo "-X github.com/smartcontractkit/chainlink/core/static.Version=$VERSION -X github.com/smartcontractkit/chainlink/core/static.Sha=$COMMIT_SHA -X github.com/smartcontractkit/chainlink/core/static.SentryDSN=$SENTRY_DSN"
+echo "-X github.com/smartcontractkit/chainlink/core/static.Version=$VERSION -X github.com/smartcontractkit/chainlink/core/static.Sha=$COMMIT_SHA"


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/23679/prefix-all-env-vars-with-cl

Refactor sentry init to read from config instead of direct env vars.