### PR TITLE
Revert db migration 0146

### DIFF
--- a/core/store/migrate/migrations/0146_unique_contract_address_per_chain.sql
+++ b/core/store/migrate/migrations/0146_unique_contract_address_per_chain.sql
@@ -1,15 +1,10 @@
 -- +goose Up
-DROP INDEX IF EXISTS unique_contract_addr_per_chain;
-DROP INDEX IF EXISTS unique_contract_addr;
-CREATE FUNCTION wildcard_cmp(INTEGER, INTEGER) RETURNS INTEGER AS $$ SELECT CASE $1 = -1 OR $2 = -1 WHEN TRUE THEN 0 ELSE ($1-$2) END$$ PARALLEL SAFE IMMUTABLE LANGUAGE SQL;
-CREATE OPERATOR CLASS wildcard_cmp FOR TYPE INTEGER USING BTREE AS FUNCTION 1 wildcard_cmp (INTEGER, INTEGER), OPERATOR 1 <, OPERATOR 2 <=, OPERATOR 3 =, OPERATOR 4 >=, OPERATOR 5 >;
--- Remove all but most recently added contract_address for each chain, before creating UNIQUE constraint
-DELETE FROM ocr_oracle_specs WHERE id IN (SELECT id FROM (SELECT id, MAX(id) OVER(PARTITION BY evm_chain_id, contract_address ORDER BY id) AS max FROM ocr_oracle_specs) x WHERE id != max);
-CREATE UNIQUE INDEX ocr_oracle_specs_unique_contract_addr ON ocr_oracle_specs (COALESCE(evm_chain_id::INTEGER, -1) wildcard_cmp, contract_address);
+
+-- no-op
 
 -- +goose Down
 DROP INDEX IF EXISTS ocr_oracle_specs_unique_contract_addr;
 DROP OPERATOR CLASS IF EXISTS wildcard_cmp USING BTREE CASCADE;
 DROP FUNCTION IF EXISTS wildcard_cmp(INTEGER, INTEGER) CASCADE;
-CREATE UNIQUE INDEX unique_contract_addr ON ocr_oracle_specs (contract_address) WHERE evm_chain_id IS NULL;
-CREATE UNIQUE INDEX unique_contract_addr_per_chain ON ocr_oracle_specs (contract_address, evm_chain_id) WHERE evm_chain_id IS NOT NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS unique_contract_addr ON ocr_oracle_specs (contract_address) WHERE evm_chain_id IS NULL;
+CREATE UNIQUE INDEX IF NOT EXISTS unique_contract_addr_per_chain ON ocr_oracle_specs (contract_address, evm_chain_id) WHERE evm_chain_id IS NOT NULL;

--- a/core/store/migrate/migrations/0146_unique_contract_address_per_chain.sql
+++ b/core/store/migrate/migrations/0146_unique_contract_address_per_chain.sql
@@ -1,6 +1,6 @@
 -- +goose Up
-
--- no-op
+--- Remove all but most recently added contract_address for each chain. We will no longer allow duplicates, but enforcing that with a db constraint requires CREATE OPERATOR (admin) privilege
+DELETE FROM ocr_oracle_specs WHERE id IN (SELECT id FROM (SELECT id, MAX(id) OVER(PARTITION BY evm_chain_id, contract_address ORDER BY id) AS max FROM ocr_oracle_specs) x WHERE id != max);
 
 -- +goose Down
 DROP INDEX IF EXISTS ocr_oracle_specs_unique_contract_addr;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -71,7 +71,7 @@ To disable connectivity checking completely, set `BLOCK_HISTORY_ESTIMATOR_CHECK_
 - EVMChainID field will be auto-added with default chain id to job specs of newly created OCR jobs, if not explicitly included.
   - Old OCR jobs missing EVMChainID will continue to run on any chain ETH_CHAIN_ID is set to (or first chain if unset), which may be changed after a restart.
   - Newly created OCR jobs will only run on a single fixed chain, unaffected by changes to ETH_CHAIN_ID after the job is added.
-  - It's no longer possible to end up with multiple OCR jobs for a single contract running on the same chain; one job per contract per chain is strictly enforced.
+  - It should no longer be possible to end up with multiple OCR jobs for a single contract running on the same chain; only one job per contract per chain is allowed
   - If there are any existing duplicate jobs (per contract per chain), all but the job with the latest creation date will be pruned during upgrade.
 
 <!-- unreleasedstop -->


### PR DESCRIPTION
CREATE OPERATOR requires db admin level permissions, which is slightly higher than our existing requirements.  Removing this to avoid error during upgrade on nodes running with more restricted db permissions.

upgrading from 145 to 146 will now be a no-op, while downgrading from 147 to 146 will be a no-op unless 146 from a previous commit has been applied, in which case it should gracefully downgrade to 145