### PR TITLE
core/services/chainlink: make legacy env invalid with v2

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -49,6 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       DATABASE_URL: postgresql://postgres:postgres@localhost:5432/chainlink_test?sslmode=disable
+      CL_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/chainlink_test?sslmode=disable
       LOG_LEVEL: debug
     services:
       postgres:

--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -36,7 +36,9 @@ func isDevMode() bool {
 	var clDev string
 	v1, v2 := os.Getenv("CHAINLINK_DEV"), os.Getenv("CL_DEV")
 	if v1 != "" && v2 != "" {
-		panic("you may only set one of CHAINLINK_DEV and CL_DEV environment variables, not both")
+		if v1 != v2 {
+			panic("you may only set one of CHAINLINK_DEV and CL_DEV environment variables, not both")
+		}
 	} else if v1 == "" {
 		clDev = v2
 	} else if v2 == "" {
@@ -134,8 +136,6 @@ func NewApp(client *Client) *cli.App {
 			} else {
 				client.Config = cfg
 			}
-			//TODO error if any legacy env vars set https://app.shortcut.com/chainlinklabs/story/23679/prefix-all-env-vars-with-cl
-			//TODO note that empty string is NOT OK since it is sometimes meaningful - must use os.LookupEnv()
 		} else {
 			// Legacy ENV
 			if c.IsSet("secrets") {

--- a/core/cmd/cfgtest/app_test.go
+++ b/core/cmd/cfgtest/app_test.go
@@ -27,7 +27,7 @@ func TestDefaultConfig(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	chainID := utils.NewBigI(42991337)
 
-	newGeneral, err := chainlink.GeneralConfigOpts{}.New(lggr)
+	newGeneral, err := chainlink.GeneralConfigOpts{SkipEnv: true}.New(lggr)
 	require.NoError(t, err)
 	legacyGeneral := config.NewGeneralConfig(lggr)
 

--- a/core/internal/testutils/configtest/v2/general_config.go
+++ b/core/internal/testutils/configtest/v2/general_config.go
@@ -10,7 +10,6 @@ import (
 	evmclient "github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	evmcfg "github.com/smartcontractkit/chainlink/core/chains/evm/config/v2"
 	"github.com/smartcontractkit/chainlink/core/config"
-	"github.com/smartcontractkit/chainlink/core/config/envvar"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
@@ -41,11 +40,6 @@ func NewGeneralConfig(t testing.TB, overrideFn func(*chainlink.Config, *chainlin
 
 // overrides applies some test config settings and adds a default chain with evmclient.NullClientChainID.
 func overrides(c *chainlink.Config, s *chainlink.Secrets) {
-	var emptyURL models.SecretURL
-	if s.Database.URL == nil || *s.Database.URL == emptyURL {
-		// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
-		s.Database.URL = models.NewSecretURL((*models.URL)(envvar.DatabaseURL.ParsePtr()))
-	}
 	s.Password.Keystore = models.NewSecret("dummy-to-pass-validation")
 
 	c.DevMode = true

--- a/core/internal/testutils/pgtest/txdb.go
+++ b/core/internal/testutils/pgtest/txdb.go
@@ -51,10 +51,7 @@ func init() {
 	} else if v1 == "" {
 		dbURL = v2
 		which = "CL_DATABASE_URL"
-	} else if v2 == "" {
-		dbURL = v1
-		which = "DATABASE_URL"
-	} else if v1 == v2 {
+	} else if v2 == "" || v1 == v2 {
 		dbURL = v1
 		which = "DATABASE_URL"
 	} else {

--- a/core/internal/testutils/pgtest/txdb.go
+++ b/core/internal/testutils/pgtest/txdb.go
@@ -54,6 +54,9 @@ func init() {
 	} else if v2 == "" {
 		dbURL = v1
 		which = "DATABASE_URL"
+	} else if v1 == v2 {
+		dbURL = v1
+		which = "DATABASE_URL"
 	} else {
 		panic("you must only set one of DATABASE_URL and CL_DATABASE_URL environment variables, not both")
 	}

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -30,7 +30,9 @@ func init() {
 	// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 	var logColor string
 	if v1, v2 := os.Getenv("LOG_COLOR"), os.Getenv("CL_LOG_COLOR"); v1 != "" && v2 != "" {
-		panic("you may only set one of LOG_COLOR and CL_LOG_COLOR environment variables, not both")
+		if v1 != v2 {
+			panic("you may only set one of LOG_COLOR and CL_LOG_COLOR environment variables, not both")
+		}
 	} else if v1 == "" {
 		logColor = v2
 	} else if v2 == "" {

--- a/core/main.go
+++ b/core/main.go
@@ -30,7 +30,9 @@ func isDevMode() bool {
 	var clDev string
 	v1, v2 := os.Getenv("CHAINLINK_DEV"), os.Getenv("CL_DEV")
 	if v1 != "" && v2 != "" {
-		panic("you may only set one of CHAINLINK_DEV and CL_DEV environment variables, not both")
+		if v1 != v2 {
+			panic("you may only set one of CHAINLINK_DEV and CL_DEV environment variables, not both")
+		}
 	} else if v1 == "" {
 		clDev = v2
 	} else if v2 == "" {

--- a/core/services/chainlink/config.go
+++ b/core/services/chainlink/config.go
@@ -101,15 +101,16 @@ func (s *Secrets) Validate() error {
 	return config.Validate(s)
 }
 
-// setOverrides overrides fields with values from ENV vars and password files.
-func (s *Secrets) setOverrides(keystorePasswordFileName, vrfPasswordFileName *string) error {
-	// Override DB and Explorer secrets from ENV vars, if present
+// setEnv overrides fields from ENV vars, if present.
+func (s *Secrets) setEnv() error {
 	if dbURL := config.EnvDatabaseURL.Get(); dbURL != "" {
+		s.Database.URL = new(models.SecretURL)
 		if err := s.Database.URL.UnmarshalText([]byte(dbURL)); err != nil {
 			return err
 		}
 	}
 	if dbBackupUrl := config.EnvDatabaseBackupURL.Get(); dbBackupUrl != "" {
+		s.Database.BackupURL = new(models.SecretURL)
 		if err := s.Database.BackupURL.UnmarshalText([]byte(dbBackupUrl)); err != nil {
 			return err
 		}
@@ -132,8 +133,11 @@ func (s *Secrets) setOverrides(keystorePasswordFileName, vrfPasswordFileName *st
 	if pyroscopeAuthToken := config.EnvPyroscopeAuthToken.Get(); pyroscopeAuthToken != "" {
 		s.Pyroscope.AuthToken = &pyroscopeAuthToken
 	}
+	return nil
+}
 
-	// Override Keystore and VRF passwords from corresponding files, if present
+// setPasswords overrides Keystore and VRF passwords, if present.
+func (s *Secrets) setPasswords(keystorePasswordFileName, vrfPasswordFileName *string) error {
 	if keystorePasswordFileName != nil {
 		keystorePwd, err := utils.PasswordFromFile(*keystorePasswordFileName)
 		if err != nil {

--- a/core/store/migrate/migrate.go
+++ b/core/store/migrate/migrate.go
@@ -31,7 +31,9 @@ func init() {
 	// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 	var logMigrations string
 	if v1, v2 := os.Getenv("LOG_SQL_MIGRATIONS"), os.Getenv("CL_LOG_SQL_MIGRATIONS"); v1 != "" && v2 != "" {
-		panic("you may only set one of LOG_SQL_MIGRATIONS and CL_LOG_SQL_MIGRATIONS environment variables, not both")
+		if v1 != v2 {
+			panic("you may only set one of LOG_SQL_MIGRATIONS and CL_LOG_SQL_MIGRATIONS environment variables, not both")
+		}
 	} else if v1 == "" {
 		logMigrations = v2
 	} else if v2 == "" {


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/23679/prefix-all-env-vars-with-cl

- Fail validation when running config v2 with leftover legacy environment variables (unless exactly equal value to v2 equivalent, to support the transition period where tests run with both).
- Set `CL_DATABASE_URL` in CI