### PR TITLE
run operator-ui on make chainlink-build

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -47,7 +47,7 @@ docker: operator-ui
 	-f core/chainlink.Dockerfile .
 
 .PHONY: chainlink-build
-chainlink-build: ## Build & install the chainlink binary.
+chainlink-build: operator-ui ## Build & install the chainlink binary.
 	go build $(GOFLAGS) -o chainlink ./core/
 	rm -f $(GOBIN)/chainlink
 	cp chainlink $(GOBIN)/chainlink


### PR DESCRIPTION
`make chainlink` and `make install-chainlink` ensure that operator-ui is up to date by calling `make operator-ui`. This change adds the same for `make chainlink-build`. Also, these three commands seem to have a lot of overlap and conflicting names - perhaps we could simplify some things here?