### PR TITLE
draft: allow memory bytes in upKeep registeration

### DIFF
--- a/contracts/src/v0.8/dev/keeper2_0/KeeperRegistrar2_0.sol
+++ b/contracts/src/v0.8/dev/keeper2_0/KeeperRegistrar2_0.sol
@@ -132,11 +132,11 @@ contract KeeperRegistrar2_0 is TypeAndVersionInterface, ConfirmedOwner, ERC677Re
    */
   function register(
     string memory name,
-    bytes calldata encryptedEmail,
+    bytes memory encryptedEmail,
     address upkeepContract,
     uint32 gasLimit,
     address adminAddress,
-    bytes calldata checkData,
+    bytes memory checkData,
     uint96 amount,
     address sender
   ) external onlyLINK {
@@ -155,11 +155,11 @@ contract KeeperRegistrar2_0 is TypeAndVersionInterface, ConfirmedOwner, ERC677Re
    */
   function registerUpkeep(
     string memory name,
-    bytes calldata encryptedEmail,
+    bytes memory encryptedEmail,
     address upkeepContract,
     uint32 gasLimit,
     address adminAddress,
-    bytes calldata checkData,
+    bytes memory checkData,
     uint96 amount
   ) external returns (uint256) {
     if (amount < s_config.minLINKJuels) {
@@ -326,11 +326,11 @@ contract KeeperRegistrar2_0 is TypeAndVersionInterface, ConfirmedOwner, ERC677Re
    */
   function _register(
     string memory name,
-    bytes calldata encryptedEmail,
+    bytes memory encryptedEmail,
     address upkeepContract,
     uint32 gasLimit,
     address adminAddress,
-    bytes calldata checkData,
+    bytes memory checkData,
     uint96 amount,
     address sender
   ) private returns (uint256) {
@@ -363,7 +363,7 @@ contract KeeperRegistrar2_0 is TypeAndVersionInterface, ConfirmedOwner, ERC677Re
     address upkeepContract,
     uint32 gasLimit,
     address adminAddress,
-    bytes calldata checkData,
+    bytes memory checkData,
     uint96 amount,
     bytes32 hash
   ) private returns (uint256) {


### PR DESCRIPTION
I don't know whether it's a appropriate to make a feature request here but just open an issue first.

## Change Requested

pass `encryptedEmail` and `checkData` in memory rather calldata

## What it resolve

Marking bytes as calldata is a good way to save gas. However, it prevent deeper contract call as you have to pass the data from txs sender.

## When this case

There is a factory contract to create contracts which need keepUp. When contract is created, it's better to register keepUp in the same txs. For integrating with the current keepUp keeperregistrar, I have to pass a `0x `calldata bytes as encryptedEmail and can't set `checkData` according to the logic of the factory contract.

## Other solution

Create a new function to accept memory bytes rather than change current function

