### PR TITLE
new config: convert more tests

### DIFF
--- a/core/chains/evm/config/config_test.go
+++ b/core/chains/evm/config/config_test.go
@@ -10,138 +10,171 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
 	evmconfig "github.com/smartcontractkit/chainlink/core/chains/evm/config"
 	v2 "github.com/smartcontractkit/chainlink/core/chains/evm/config/v2"
-	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/config"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
-	configtest2 "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
+	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
-	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
+	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
 func TestChainScopedConfig(t *testing.T) {
-	orm := make(fakeChainConfigORM)
-	chainID := big.NewInt(rand.Int63())
-	gcfg := configtest.NewTestGeneralConfig(t)
-	lggr := logger.TestLogger(t).With("evmChainID", chainID.String())
-	cfg := evmconfig.NewChainScopedConfig(chainID, evmtypes.ChainCfg{
-		KeySpecific:       make(map[string]evmtypes.ChainCfg),
-		EvmMaxGasPriceWei: assets.NewWeiI(100000000000000),
-	}, orm, lggr, gcfg)
+	t.Parallel()
+	gcfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		id := utils.NewBig(big.NewInt(rand.Int63()))
+		c.EVM[0] = &v2.EVMConfig{
+			ChainID: id,
+			Chain: v2.DefaultsFrom(id, &v2.Chain{
+				GasEstimator: v2.GasEstimator{PriceMax: assets.NewWeiI(100000000000000)},
+			}),
+		}
+	})
+	cfg := evmtest.NewChainScopedConfig(t, gcfg)
 
+	overrides := func(c *chainlink.Config, s *chainlink.Secrets) {
+		id := utils.NewBig(big.NewInt(rand.Int63()))
+		c.EVM[0] = &v2.EVMConfig{
+			ChainID: id,
+			Chain: v2.DefaultsFrom(id, &v2.Chain{
+				GasEstimator: v2.GasEstimator{
+					PriceMax:     assets.NewWeiI(100000000000000),
+					PriceDefault: assets.NewWeiI(42000000000),
+				},
+			}),
+		}
+	}
 	t.Run("EvmGasPriceDefault", func(t *testing.T) {
-		t.Run("sets the gas price", func(t *testing.T) {
-			assert.Equal(t, assets.NewWeiI(20000000000), cfg.EvmGasPriceDefault())
+		assert.Equal(t, assets.NewWeiI(20000000000), cfg.EvmGasPriceDefault())
 
-			err := cfg.SetEvmGasPriceDefault(big.NewInt(42000000000))
-			assert.NoError(t, err)
-
-			assert.Equal(t, assets.NewWeiI(42000000000), cfg.EvmGasPriceDefault())
-
-			got, ok := orm.LoadString(*utils.NewBig(chainID), "EvmGasPriceDefault")
-			if assert.True(t, ok) {
-				assert.Equal(t, "42000000000", got)
-			}
-		})
-		t.Run("is not allowed to set gas price to below EvmMinGasPriceWei", func(t *testing.T) {
-			assert.Equal(t, assets.NewWeiI(1000000000), cfg.EvmMinGasPriceWei())
-
-			err := cfg.SetEvmGasPriceDefault(big.NewInt(1))
-			assert.EqualError(t, err, "cannot set default gas price to 1, it is below the minimum allowed value of 1 gwei")
-
-			assert.Equal(t, assets.NewWeiI(42000000000), cfg.EvmGasPriceDefault())
-		})
-		t.Run("is not allowed to set gas price to above EvmMaxGasPriceWei", func(t *testing.T) {
-			assert.Equal(t, assets.NewWeiI(100000000000000), cfg.EvmMaxGasPriceWei())
-
-			err := cfg.SetEvmGasPriceDefault(big.NewInt(999999999999999))
-			assert.EqualError(t, err, "cannot set default gas price to 999999999999999, it is above the maximum allowed value of 100 micro")
-
-			assert.Equal(t, assets.NewWeiI(42000000000), cfg.EvmGasPriceDefault())
-		})
+		gcfg2 := configtest.NewGeneralConfig(t, overrides)
+		cfg2 := evmtest.NewChainScopedConfig(t, gcfg2)
+		assert.Equal(t, assets.NewWeiI(42000000000), cfg2.EvmGasPriceDefault())
 	})
 
 	t.Run("KeySpecificMaxGasPriceWei", func(t *testing.T) {
 		addr := testutils.NewAddress()
 		randomOtherAddr := testutils.NewAddress()
-		otherKeySpecific := evmtypes.ChainCfg{EvmMaxGasPriceWei: assets.GWei(850)}
-		evmconfig.UpdatePersistedCfg(cfg, func(cfg *evmtypes.ChainCfg) {
-			cfg.KeySpecific[randomOtherAddr.Hex()] = otherKeySpecific
+		gcfg2 := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			overrides(c, s)
+			c.EVM[0].KeySpecific = v2.KeySpecificConfig{
+				{Key: ptr(ethkey.EIP55AddressFromAddress(randomOtherAddr)),
+					GasEstimator: v2.KeySpecificGasEstimator{
+						PriceMax: assets.GWei(850),
+					},
+				},
+			}
 		})
+		cfg2 := evmtest.NewChainScopedConfig(t, gcfg2)
 
 		t.Run("uses chain-specific default value when nothing is set", func(t *testing.T) {
-			assert.Equal(t, assets.NewWeiI(100000000000000), cfg.KeySpecificMaxGasPriceWei(addr))
+			assert.Equal(t, assets.NewWeiI(100000000000000), cfg2.KeySpecificMaxGasPriceWei(addr))
 		})
 
 		t.Run("uses chain-specific override value when that is set", func(t *testing.T) {
 			val := assets.NewWeiI(rand.Int63())
-			evmconfig.UpdatePersistedCfg(cfg, func(cfg *evmtypes.ChainCfg) {
-				cfg.EvmMaxGasPriceWei = val
+			gcfg3 := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				c.EVM[0].GasEstimator.PriceMax = val
 			})
+			cfg3 := evmtest.NewChainScopedConfig(t, gcfg3)
 
-			assert.Equal(t, val.String(), cfg.KeySpecificMaxGasPriceWei(addr).String())
+			assert.Equal(t, val.String(), cfg3.KeySpecificMaxGasPriceWei(addr).String())
 		})
 		t.Run("uses key-specific override value when set", func(t *testing.T) {
 			val := assets.GWei(250)
-			keySpecific := evmtypes.ChainCfg{EvmMaxGasPriceWei: val}
-			evmconfig.UpdatePersistedCfg(cfg, func(cfg *evmtypes.ChainCfg) {
-				cfg.KeySpecific[addr.Hex()] = keySpecific
+			gcfg3 := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				c.EVM[0].KeySpecific = v2.KeySpecificConfig{
+					{Key: ptr(ethkey.EIP55AddressFromAddress(addr)),
+						GasEstimator: v2.KeySpecificGasEstimator{
+							PriceMax: val,
+						},
+					},
+				}
 			})
+			cfg3 := evmtest.NewChainScopedConfig(t, gcfg3)
 
-			assert.Equal(t, val.String(), cfg.KeySpecificMaxGasPriceWei(addr).String())
+			assert.Equal(t, val.String(), cfg3.KeySpecificMaxGasPriceWei(addr).String())
 		})
 		t.Run("uses key-specific override value when set and lower than chain specific config", func(t *testing.T) {
 			keySpecificPrice := assets.GWei(900)
 			chainSpecificPrice := assets.GWei(1200)
-			evmconfig.UpdatePersistedCfg(cfg, func(cfg *evmtypes.ChainCfg) {
-				cfg.EvmMaxGasPriceWei = chainSpecificPrice
-				cfg.KeySpecific[addr.Hex()] = evmtypes.ChainCfg{EvmMaxGasPriceWei: keySpecificPrice}
+			gcfg3 := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				c.EVM[0].GasEstimator.PriceMax = chainSpecificPrice
+				c.EVM[0].KeySpecific = v2.KeySpecificConfig{
+					{Key: ptr(ethkey.EIP55AddressFromAddress(addr)),
+						GasEstimator: v2.KeySpecificGasEstimator{
+							PriceMax: keySpecificPrice,
+						},
+					},
+				}
 			})
+			cfg3 := evmtest.NewChainScopedConfig(t, gcfg3)
 
-			assert.Equal(t, keySpecificPrice.String(), cfg.KeySpecificMaxGasPriceWei(addr).String())
+			assert.Equal(t, keySpecificPrice.String(), cfg3.KeySpecificMaxGasPriceWei(addr).String())
 		})
 		t.Run("uses chain-specific value when higher than key-specific value", func(t *testing.T) {
 			keySpecificPrice := assets.GWei(1400)
 			chainSpecificPrice := assets.GWei(1200)
-			evmconfig.UpdatePersistedCfg(cfg, func(cfg *evmtypes.ChainCfg) {
-				cfg.EvmMaxGasPriceWei = chainSpecificPrice
-				cfg.KeySpecific[addr.Hex()] = evmtypes.ChainCfg{EvmMaxGasPriceWei: keySpecificPrice}
+			gcfg3 := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				c.EVM[0].GasEstimator.PriceMax = chainSpecificPrice
+				c.EVM[0].KeySpecific = v2.KeySpecificConfig{
+					{Key: ptr(ethkey.EIP55AddressFromAddress(addr)),
+						GasEstimator: v2.KeySpecificGasEstimator{
+							PriceMax: keySpecificPrice,
+						},
+					},
+				}
 			})
+			cfg3 := evmtest.NewChainScopedConfig(t, gcfg3)
 
-			assert.Equal(t, chainSpecificPrice.String(), cfg.KeySpecificMaxGasPriceWei(addr).String())
+			assert.Equal(t, chainSpecificPrice.String(), cfg3.KeySpecificMaxGasPriceWei(addr).String())
 		})
 		t.Run("uses key-specific override value when set and lower than global config", func(t *testing.T) {
 			keySpecificPrice := assets.GWei(900)
-			gcfg.Overrides.GlobalEvmMaxGasPriceWei = assets.GWei(1200)
-			evmconfig.UpdatePersistedCfg(cfg, func(cfg *evmtypes.ChainCfg) {
-				cfg.KeySpecific[addr.Hex()] = evmtypes.ChainCfg{EvmMaxGasPriceWei: keySpecificPrice}
+			gcfg3 := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				c.EVM[0].KeySpecific = v2.KeySpecificConfig{
+					{Key: ptr(ethkey.EIP55AddressFromAddress(addr)),
+						GasEstimator: v2.KeySpecificGasEstimator{
+							PriceMax: keySpecificPrice,
+						},
+					},
+				}
 			})
+			cfg3 := evmtest.NewChainScopedConfig(t, gcfg3)
 
-			assert.Equal(t, keySpecificPrice.String(), cfg.KeySpecificMaxGasPriceWei(addr).String())
+			assert.Equal(t, keySpecificPrice.String(), cfg3.KeySpecificMaxGasPriceWei(addr).String())
 		})
 		t.Run("uses global value when higher than key-specific value", func(t *testing.T) {
 			keySpecificPrice := assets.GWei(1400)
-			gcfg.Overrides.GlobalEvmMaxGasPriceWei = assets.GWei(1200)
-			evmconfig.UpdatePersistedCfg(cfg, func(cfg *evmtypes.ChainCfg) {
-				cfg.KeySpecific[addr.Hex()] = evmtypes.ChainCfg{EvmMaxGasPriceWei: keySpecificPrice}
+			chainSpecificPrice := assets.GWei(1200)
+			gcfg3 := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				c.EVM[0].GasEstimator.PriceMax = chainSpecificPrice
+				c.EVM[0].KeySpecific = v2.KeySpecificConfig{
+					{Key: ptr(ethkey.EIP55AddressFromAddress(addr)),
+						GasEstimator: v2.KeySpecificGasEstimator{
+							PriceMax: keySpecificPrice,
+						},
+					},
+				}
 			})
+			cfg3 := evmtest.NewChainScopedConfig(t, gcfg3)
 
-			assert.Equal(t, gcfg.Overrides.GlobalEvmMaxGasPriceWei.String(), cfg.KeySpecificMaxGasPriceWei(addr).String())
+			assert.Equal(t, chainSpecificPrice.String(), cfg3.KeySpecificMaxGasPriceWei(addr).String())
 		})
 		t.Run("uses global value when there is no key-specific price", func(t *testing.T) {
 			val := assets.NewWeiI(rand.Int63())
 			unsetAddr := testutils.NewAddress()
-			gcfg.Overrides.GlobalEvmMaxGasPriceWei = val
+			gcfg3 := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				c.EVM[0].GasEstimator.PriceMax = val
+			})
+			cfg3 := evmtest.NewChainScopedConfig(t, gcfg3)
 
-			assert.Equal(t, val.String(), cfg.KeySpecificMaxGasPriceWei(unsetAddr).String())
+			assert.Equal(t, val.String(), cfg3.KeySpecificMaxGasPriceWei(unsetAddr).String())
 		})
 	})
 
@@ -151,19 +184,14 @@ func TestChainScopedConfig(t *testing.T) {
 		})
 
 		t.Run("uses chain-specific override value when that is set", func(t *testing.T) {
-			val := testutils.NewAddress().String()
-			evmconfig.UpdatePersistedCfg(cfg, func(cfg *evmtypes.ChainCfg) {
-				cfg.LinkContractAddress = null.StringFrom(val)
+			val := testutils.NewAddress()
+
+			gcfg3 := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				c.EVM[0].LinkContractAddress = ptr(ethkey.EIP55AddressFromAddress(val))
 			})
+			cfg3 := evmtest.NewChainScopedConfig(t, gcfg3)
 
-			assert.Equal(t, val, cfg.LinkContractAddress())
-		})
-
-		t.Run("uses global value when that is set", func(t *testing.T) {
-			val := testutils.NewAddress().String()
-			gcfg.Overrides.LinkContractAddress = null.StringFrom(val)
-
-			assert.Equal(t, val, cfg.LinkContractAddress())
+			assert.Equal(t, val.String(), cfg3.LinkContractAddress())
 		})
 	})
 
@@ -173,26 +201,21 @@ func TestChainScopedConfig(t *testing.T) {
 		})
 
 		t.Run("uses chain-specific override value when that is set", func(t *testing.T) {
-			val := testutils.NewAddress().String()
-			evmconfig.UpdatePersistedCfg(cfg, func(cfg *evmtypes.ChainCfg) {
-				cfg.OperatorFactoryAddress = null.StringFrom(val)
+			val := testutils.NewAddress()
+
+			gcfg3 := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+				c.EVM[0].OperatorFactoryAddress = ptr(ethkey.EIP55AddressFromAddress(val))
 			})
+			cfg3 := evmtest.NewChainScopedConfig(t, gcfg3)
 
-			assert.Equal(t, val, cfg.OperatorFactoryAddress())
-		})
-
-		t.Run("uses global value when that is set", func(t *testing.T) {
-			val := testutils.NewAddress().String()
-			gcfg.Overrides.OperatorFactoryAddress = null.StringFrom(val)
-
-			assert.Equal(t, val, cfg.OperatorFactoryAddress())
+			assert.Equal(t, val.String(), cfg3.OperatorFactoryAddress())
 		})
 	})
 }
 
 func TestChainScopedConfig_BSCDefaults(t *testing.T) {
 	chainID := big.NewInt(56)
-	gcfg := configtest2.NewGeneralConfig(t, func(c *chainlink.Config, secrets *chainlink.Secrets) {
+	gcfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, secrets *chainlink.Secrets) {
 		id := utils.NewBig(chainID)
 		cfg, _ := v2.Defaults(id)
 		c.EVM[0] = &v2.EVMConfig{
@@ -244,7 +267,7 @@ func TestChainScopedConfig_Profiles(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			gcfg := configtest2.NewGeneralConfig(t, func(c *chainlink.Config, secrets *chainlink.Secrets) {
+			gcfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, secrets *chainlink.Secrets) {
 				id := utils.NewBigI(tt.chainID)
 				cfg, _ := v2.Defaults(id)
 				c.EVM[0] = &v2.EVMConfig{
@@ -268,7 +291,7 @@ func TestChainScopedConfig_Profiles(t *testing.T) {
 
 func Test_chainScopedConfig_Validate(t *testing.T) {
 	configWithChain := func(t *testing.T, id int64, chain *v2.Chain) config.GeneralConfig {
-		return configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		return configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 			chainID := utils.NewBigI(id)
 			c.EVM[0] = &v2.EVMConfig{ChainID: chainID, Enabled: ptr(true), Chain: v2.DefaultsFrom(chainID, chain),
 				Nodes: v2.EVMNodes{{Name: ptr("fake"), HTTPURL: models.MustParseURL("http://foo.test")}}}
@@ -344,35 +367,6 @@ func Test_chainScopedConfig_Validate(t *testing.T) {
 			assert.Error(t, cfg.Validate())
 		})
 	})
-}
-
-type fakeChainConfigORM map[string]map[string]string
-
-func (f fakeChainConfigORM) LoadString(chainID utils.Big, key string) (val string, ok bool) {
-	var m map[string]string
-	m, ok = f[chainID.String()]
-	if ok {
-		val, ok = m[key]
-	}
-	return
-}
-
-func (f fakeChainConfigORM) StoreString(chainID utils.Big, key, val string) error {
-	m, ok := f[chainID.String()]
-	if !ok {
-		m = make(map[string]string)
-		f[chainID.String()] = m
-	}
-	m[key] = val
-	return nil
-}
-
-func (f fakeChainConfigORM) Clear(chainID utils.Big, key string) error {
-	m, ok := f[chainID.String()]
-	if ok {
-		delete(m, key)
-	}
-	return nil
 }
 
 func ptr[T any](t T) *T { return &t }

--- a/core/chains/evm/config/helpers_test.go
+++ b/core/chains/evm/config/helpers_test.go
@@ -2,6 +2,7 @@ package config
 
 import "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 
+// Deprecated: https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func UpdatePersistedCfg(cfg ChainScopedConfig, updateFn func(*types.ChainCfg)) {
 	c := cfg.(*chainScopedConfig)
 	c.persistMu.Lock()

--- a/core/chains/evm/txmgr/eth_broadcaster_test.go
+++ b/core/chains/evm/txmgr/eth_broadcaster_test.go
@@ -29,7 +29,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest/heavyweight"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
-	legacy "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest"
 	configtest "github.com/smartcontractkit/chainlink/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
@@ -45,7 +44,7 @@ import (
 
 func TestEthBroadcaster_ProcessUnstartedEthTxs_Success(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
-	cfg := legacy.NewTestGeneralConfig(t)
+	cfg := configtest.NewTestGeneralConfig(t)
 	borm := cltest.NewTxmORM(t, db, cfg)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 	keyState, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
@@ -253,13 +252,17 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Success(t *testing.T) {
 		require.Len(t, attempt.EthReceipts, 0)
 	})
 
-	t.Run("sends transactions with type 0x2 in EIP-1559 mode", func(t *testing.T) {
-		cfg.Overrides.GlobalEvmEIP1559DynamicFees = null.BoolFrom(true)
-		rnd := int64(1000000000 + rand.Intn(5000))
-		cfg.Overrides.GlobalEvmGasTipCapDefault = assets.NewWeiI(rnd)
-		cfg.Overrides.GlobalEvmGasFeeCapDefault = assets.NewWeiI(rnd + 1)
-		cfg.Overrides.GlobalEvmMaxGasPriceWei = assets.NewWeiI(rnd + 2)
+	rnd := int64(1000000000 + rand.Intn(5000))
+	cfg = configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].GasEstimator.EIP1559DynamicFees = ptr(true)
+		c.EVM[0].GasEstimator.TipCapDefault = assets.NewWeiI(rnd)
+		c.EVM[0].GasEstimator.FeeCapDefault = assets.NewWeiI(rnd + 1)
+		c.EVM[0].GasEstimator.PriceMax = assets.NewWeiI(rnd + 2)
+	})
+	evmcfg = evmtest.NewChainScopedConfig(t, cfg)
+	eb = cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg, []ethkey.State{keyState}, checkerFactory)
 
+	t.Run("sends transactions with type 0x2 in EIP-1559 mode", func(t *testing.T) {
 		eipTxWithoutAl := txmgr.EthTx{
 			FromAddress:    fromAddress,
 			ToAddress:      toAddress,
@@ -969,7 +972,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 	encodedPayload := []byte{0, 1}
 
 	db := pgtest.NewSqlxDB(t)
-	cfg := cltest.NewTestGeneralConfig(t)
+	cfg := configtest.NewTestGeneralConfig(t)
 	borm := cltest.NewTxmORM(t, db, cfg)
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
@@ -1518,14 +1521,11 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 		// In this scenario the node operator REALLY fucked up and set the bump
 		// to zero (even though that should not be possible due to config
 		// validation)
-		oldGasBumpWei := evmcfg.EvmGasBumpWei()
-		oldGasBumpPercent := evmcfg.EvmGasBumpPercent()
-		cfg.Overrides.GlobalEvmGasBumpWei = assets.NewWeiI(0)
-		cfg.Overrides.GlobalEvmGasBumpPercent = null.IntFrom(0)
-		defer func() {
-			cfg.Overrides.GlobalEvmGasBumpWei = oldGasBumpWei
-			cfg.Overrides.GlobalEvmGasBumpPercent = null.IntFrom(int64(oldGasBumpPercent))
-		}()
+		evmcfg2 := evmtest.NewChainScopedConfig(t, configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.EVM[0].GasEstimator.BumpMin = assets.NewWeiI(0)
+			c.EVM[0].GasEstimator.BumpPercent = ptr[uint16](0)
+		}))
+		eb2 := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg2, []ethkey.State{keyState}, &testCheckerFactory{})
 
 		etx := txmgr.EthTx{
 			FromAddress:    fromAddress,
@@ -1539,11 +1539,11 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 
 		// First was underpriced
 		ethClient.On("SendTransaction", mock.Anything, mock.MatchedBy(func(tx *gethTypes.Transaction) bool {
-			return tx.Nonce() == localNextNonce && tx.GasPrice().Cmp(evmcfg.EvmGasPriceDefault().ToInt()) == 0
+			return tx.Nonce() == localNextNonce && tx.GasPrice().Cmp(evmcfg2.EvmGasPriceDefault().ToInt()) == 0
 		})).Return(errors.New(underpricedError)).Once()
 
 		// Do the thing
-		err, retryable := eb.ProcessUnstartedEthTxs(testutils.Context(t), keyState)
+		err, retryable := eb2.ProcessUnstartedEthTxs(testutils.Context(t), keyState)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "bumped gas price of 20 gwei is equal to original gas price of 20 gwei. ACTION REQUIRED: This is a configuration error, you must increase either ETH_GAS_BUMP_PERCENT or ETH_GAS_BUMP_WEI")
 		assert.True(t, retryable)
@@ -1590,7 +1590,6 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 	})
 
 	pgtest.MustExec(t, db, `DELETE FROM eth_txes`)
-	cfg.Overrides.GlobalEvmEIP1559DynamicFees = null.BoolFrom(true)
 
 	t.Run("eth node returns underpriced transaction and bumping gas doesn't increase it in EIP-1559 mode", func(t *testing.T) {
 		// This happens if a transaction's gas price is below the minimum
@@ -1600,14 +1599,12 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 		// In this scenario the node operator REALLY fucked up and set the bump
 		// to zero (even though that should not be possible due to config
 		// validation)
-		oldGasBumpWei := evmcfg.EvmGasBumpWei()
-		oldGasBumpPercent := evmcfg.EvmGasBumpPercent()
-		cfg.Overrides.GlobalEvmGasBumpWei = assets.NewWeiI(0)
-		cfg.Overrides.GlobalEvmGasBumpPercent = null.IntFrom(0)
-		defer func() {
-			cfg.Overrides.GlobalEvmGasBumpWei = oldGasBumpWei
-			cfg.Overrides.GlobalEvmGasBumpPercent = null.IntFrom(int64(oldGasBumpPercent))
-		}()
+		evmcfg2 := evmtest.NewChainScopedConfig(t, configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.EVM[0].GasEstimator.EIP1559DynamicFees = ptr(true)
+			c.EVM[0].GasEstimator.BumpMin = assets.NewWeiI(0)
+			c.EVM[0].GasEstimator.BumpPercent = ptr[uint16](0)
+		}))
+		eb2 := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg2, []ethkey.State{keyState}, &testCheckerFactory{})
 
 		etx := txmgr.EthTx{
 			FromAddress:    fromAddress,
@@ -1626,7 +1623,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 		})).Return(errors.New(underpricedError)).Once()
 
 		// Check gas tip cap verification
-		err, retryable := eb.ProcessUnstartedEthTxs(testutils.Context(t), keyState)
+		err, retryable := eb2.ProcessUnstartedEthTxs(testutils.Context(t), keyState)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "bumped gas tip cap of 1 wei is less than or equal to original gas tip cap of 1 wei")
 		assert.True(t, retryable)
@@ -1652,28 +1649,38 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 		require.NoError(t, borm.InsertEthTx(&etx))
 
 		// Check gas tip cap verification
-		cfg.Overrides.GlobalEvmGasTipCapDefault = assets.NewWeiI(0)
-		err, retryable := eb.ProcessUnstartedEthTxs(testutils.Context(t), keyState)
+		evmcfg2 := evmtest.NewChainScopedConfig(t, configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.EVM[0].GasEstimator.EIP1559DynamicFees = ptr(true)
+			c.EVM[0].GasEstimator.TipCapDefault = assets.NewWeiI(0)
+		}))
+		eb2 := cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg2, []ethkey.State{keyState}, &testCheckerFactory{})
+
+		err, retryable := eb2.ProcessUnstartedEthTxs(testutils.Context(t), keyState)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "specified gas tip cap of 0 is below min configured gas tip of 1 wei for key")
 		assert.True(t, retryable)
 
 		gasTipCapDefault := assets.NewWeiI(42)
-		cfg.Overrides.GlobalEvmGasTipCapDefault = gasTipCapDefault
+
+		evmcfg2 = evmtest.NewChainScopedConfig(t, configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+			c.EVM[0].GasEstimator.EIP1559DynamicFees = ptr(true)
+			c.EVM[0].GasEstimator.TipCapDefault = gasTipCapDefault
+		}))
+		eb2 = cltest.NewEthBroadcaster(t, db, ethClient, ethKeyStore, evmcfg2, []ethkey.State{keyState}, &testCheckerFactory{})
 		// Second was underpriced but above minimum
 		ethClient.On("SendTransaction", mock.Anything, mock.MatchedBy(func(tx *gethTypes.Transaction) bool {
 			return tx.Nonce() == localNextNonce && tx.GasTipCap().Cmp(gasTipCapDefault.ToInt()) == 0
 		})).Return(errors.New(underpricedError)).Once()
 		// Resend at the bumped price
 		ethClient.On("SendTransaction", mock.Anything, mock.MatchedBy(func(tx *gethTypes.Transaction) bool {
-			return tx.Nonce() == localNextNonce && tx.GasTipCap().Cmp(big.NewInt(0).Add(gasTipCapDefault.ToInt(), evmcfg.EvmGasBumpWei().ToInt())) == 0
+			return tx.Nonce() == localNextNonce && tx.GasTipCap().Cmp(big.NewInt(0).Add(gasTipCapDefault.ToInt(), evmcfg2.EvmGasBumpWei().ToInt())) == 0
 		})).Return(errors.New(underpricedError)).Once()
 		// Final bump succeeds
 		ethClient.On("SendTransaction", mock.Anything, mock.MatchedBy(func(tx *gethTypes.Transaction) bool {
-			return tx.Nonce() == localNextNonce && tx.GasTipCap().Cmp(big.NewInt(0).Add(gasTipCapDefault.ToInt(), big.NewInt(0).Mul(evmcfg.EvmGasBumpWei().ToInt(), big.NewInt(2)))) == 0
+			return tx.Nonce() == localNextNonce && tx.GasTipCap().Cmp(big.NewInt(0).Add(gasTipCapDefault.ToInt(), big.NewInt(0).Mul(evmcfg2.EvmGasBumpWei().ToInt(), big.NewInt(2)))) == 0
 		})).Return(nil).Once()
 
-		err, retryable = eb.ProcessUnstartedEthTxs(testutils.Context(t), keyState)
+		err, retryable = eb2.ProcessUnstartedEthTxs(testutils.Context(t), keyState)
 		require.NoError(t, err)
 		assert.False(t, retryable)
 

--- a/core/cmd/solana_node_commands_test.go
+++ b/core/cmd/solana_node_commands_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 )
 
+// Deprecated: https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func mustInsertSolanaChain(t *testing.T, sol solana.ChainSet, id string) solana.DBChain {
 	chain, err := sol.Add(testutils.Context(t), id, nil)
 	require.NoError(t, err)
@@ -41,7 +42,7 @@ func solanaStartNewApplication(t *testing.T, cfgs ...*solana.SolanaConfig) *clte
 	})
 }
 
-// https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
+// Deprecated: https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func solanaStartNewLegacyApplication(t *testing.T) *cltest.TestApplication {
 	return startNewApplication(t, withConfigSet(func(c *configtest.TestGeneralConfig) {
 		c.Overrides.SolanaEnabled = null.BoolFrom(true)

--- a/core/internal/testutils/configtest/general_config.go
+++ b/core/internal/testutils/configtest/general_config.go
@@ -195,13 +195,14 @@ type TestGeneralConfig struct {
 	Overrides GeneralConfigOverrides
 }
 
+// Deprecated: see v2.NewTestGeneralConfig
 // NewTestGeneralConfig returns a legacy *TestGeneralConfig. Use v2.NewTestGeneralConfig instead.
 // https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func NewTestGeneralConfig(t *testing.T) *TestGeneralConfig {
 	return NewTestGeneralConfigWithOverrides(t, GeneralConfigOverrides{})
 }
 
-// Deprecated: see v2.TOML
+// Deprecated: see v2.NewGeneralConfig
 // https://app.shortcut.com/chainlinklabs/story/33622/remove-legacy-config
 func NewTestGeneralConfigWithOverrides(t testing.TB, overrides GeneralConfigOverrides) *TestGeneralConfig {
 	cfg := config.NewGeneralConfig(logger.TestLogger(t))


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/46224/convert-replace-uses-of-testgeneralconfig-generalconfigoverrides-to-new-config-types

This might be the last of them....the only remaining usages that I see are legacy-only tests that will be removed.