### PR TITLE
Add null checks for EffectiveTransmitterAddress

### DIFF
--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -193,6 +193,9 @@ func newContractTransmitter(lggr logger.Logger, rargs relaytypes.RelayArgs, tran
 	}
 	var fromAddresses []common.Address
 	sendingKeys := relayConfig.SendingKeys
+	if !relayConfig.EffectiveTransmitterAddress.Valid {
+		return nil, errors.New("EffectiveTransmitterAddress must be specified")
+	}
 	effectiveTransmitterAddress := common.HexToAddress(relayConfig.EffectiveTransmitterAddress.String)
 	useForwarders := configWatcher.chain.Config().EvmUseForwarders()
 
@@ -256,6 +259,9 @@ func newPipelineContractTransmitter(lggr logger.Logger, rargs relaytypes.RelayAr
 		return nil, err
 	}
 
+	if !relayConfig.EffectiveTransmitterAddress.Valid {
+		return nil, errors.New("EffectiveTransmitterAddress must be specified")
+	}
 	effectiveTransmitterAddress := common.HexToAddress(relayConfig.EffectiveTransmitterAddress.String)
 	transmitterAddress := common.HexToAddress(transmitterID)
 	scoped := configWatcher.chain.Config()


### PR DESCRIPTION
Context: EffectiveTransmitterAddress is not expected to be null in any evm implementation.