### PR TITLE
Fix: Confirmed and final tx hash on the Transaction page

### DIFF
--- a/core/chains/evm/txmgr/orm.go
+++ b/core/chains/evm/txmgr/orm.go
@@ -164,7 +164,7 @@ func (o *orm) FindEthTxAttempt(hash common.Hash) (*EthTxAttempt, error) {
 func (o *orm) FindEthTxAttemptsByEthTxIDs(ids []int64) ([]EthTxAttempt, error) {
 	var attempts []EthTxAttempt
 
-	sql := `SELECT * FROM eth_tx_attempts WHERE eth_tx_id = ANY($1)`
+	sql := `SELECT * FROM eth_tx_attempts WHERE eth_tx_id = ANY($1) ORDER BY id desc`
 	if err := o.q.Select(&attempts, sql, ids); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Issue Fix: The tx hash on the Transaction page ought to represent the final, confirmed attempt tx hash

https://app.shortcut.com/chainlinklabs/story/54605/the-tx-hash-on-the-transaction-page-ought-to-represent-the-final-confirmed-attempt-tx-hash