### PR TITLE
core/utils: return error from FileExists

### DIFF
--- a/core/services/chainlink/secret_generator.go
+++ b/core/services/chainlink/secret_generator.go
@@ -23,7 +23,9 @@ type FilePersistedSecretGenerator struct{}
 
 func (f FilePersistedSecretGenerator) Generate(rootDir string) ([]byte, error) {
 	sessionPath := filepath.Join(rootDir, "secret")
-	if utils.FileExists(sessionPath) {
+	if exists, err := utils.FileExists(sessionPath); err != nil {
+		return nil, err
+	} else if exists {
 		data, err := os.ReadFile(sessionPath)
 		if err != nil {
 			return data, err

--- a/core/utils/files.go
+++ b/core/utils/files.go
@@ -13,11 +13,14 @@ import (
 )
 
 // FileExists returns true if a file at the passed string exists.
-func FileExists(name string) bool {
-	if _, err := os.Stat(name); os.IsNotExist(err) {
-		return false
+func FileExists(name string) (bool, error) {
+	if _, err := os.Stat(name); err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, errors.Wrapf(err, "failed to check if file exists %q", name)
 	}
-	return true
+	return true, nil
 }
 
 // TooPermissive checks if the file has more than the allowed permissions

--- a/core/utils/files_test.go
+++ b/core/utils/files_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func tempFileName() string {
@@ -19,10 +20,12 @@ func tempFileName() string {
 func TestFileExists(t *testing.T) {
 	t.Parallel()
 
-	exists := FileExists(tempFileName())
+	exists, err := FileExists(tempFileName())
+	require.NoError(t, err)
 	assert.False(t, exists)
 
-	exists = FileExists(os.Args[0])
+	exists, err = FileExists(os.Args[0])
+	require.NoError(t, err)
 	assert.True(t, exists)
 }
 


### PR DESCRIPTION
`utils.FileExists` was assuming that `!os.IsNotExist(err)` implies that a file exists, but the check could have failed in other ways which doesn't tell us anything about whether it exists. Just return the error instead, so the root cause can be uncovered.