### PR TITLE
core/chains/evm/client: ensure nodes closed on failed Dial to resolve race

### DIFF
--- a/core/chains/evm/client/pool.go
+++ b/core/chains/evm/client/pool.go
@@ -113,7 +113,7 @@ func (p *Pool) Dial(ctx context.Context) error {
 		var ms services.MultiStart
 		for _, n := range p.nodes {
 			if n.ChainID().Cmp(p.chainID) != 0 {
-				return errors.Errorf("node %s has chain ID %s which does not match pool chain ID of %s", n.String(), n.ChainID().String(), p.chainID.String())
+				return ms.CloseBecause(errors.Errorf("node %s has chain ID %s which does not match pool chain ID of %s", n.String(), n.ChainID().String(), p.chainID.String()))
 			}
 			rawNode, ok := n.(*node)
 			if ok {
@@ -130,7 +130,7 @@ func (p *Pool) Dial(ctx context.Context) error {
 		}
 		for _, s := range p.sendonlys {
 			if s.ChainID().Cmp(p.chainID) != 0 {
-				return errors.Errorf("sendonly node %s has chain ID %s which does not match pool chain ID of %s", s.String(), s.ChainID().String(), p.chainID.String())
+				return ms.CloseBecause(errors.Errorf("sendonly node %s has chain ID %s which does not match pool chain ID of %s", s.String(), s.ChainID().String(), p.chainID.String()))
 			}
 			if err := ms.Start(ctx, s); err != nil {
 				return err

--- a/core/services/multi.go
+++ b/core/services/multi.go
@@ -51,6 +51,11 @@ func (m *MultiStart) Close() (err error) {
 	return
 }
 
+// CloseBecause calls Close and returns reason along with any additional errors.
+func (m *MultiStart) CloseBecause(reason error) (err error) {
+	return multierr.Append(reason, m.Close())
+}
+
 // MultiClose is a utility for closing multiple services concurrently.
 type MultiClose []io.Closer
 


### PR DESCRIPTION
I added a `MultiStart` in #7765 to clean up orphaned nodes on failed start, but I overlooked these explicit error cases:
<details><summary>DATA RACE</summary>

```go
==================
WARNING: DATA RACE
Read at 0x00c002997703 by goroutine 41844:
  testing.(*common).logDepth()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:883 +0xc4
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:876 +0xa4
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:927 +0x6a
  testing.(*T).Logf()
      <autogenerated>:1 +0x75
  go.uber.org/zap/zaptest.testingWriter.Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/zaptest/logger.go:130 +0x12c
  go.uber.org/zap/zaptest.(*testingWriter).Write()
      <autogenerated>:1 +0x7e
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/zapcore/core.go:99 +0x199
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/zapcore/entry.go:255 +0x2ce
  go.uber.org/zap.(*SugaredLogger).log()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/sugar.go:287 +0x13a
  go.uber.org/zap.(*SugaredLogger).Debug()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/sugar.go:119 +0x85
  github.com/smartcontractkit/chainlink/core/logger.(*zapLogger).Debug()
      <autogenerated>:1 +0x29
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).aliveLoop()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node_lifecycle.go:126 +0xac7
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).declareAlive.func1.1()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node_fsm.go:128 +0x39

Previous write at 0x00c002997703 by goroutine 41831:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1433 +0x7e4
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.19.2/x64/src/runtime/panic.go:476 +0x32
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x47

Goroutine 41844 (running) created at:
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).declareAlive.func1()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node_fsm.go:128 +0x1b6
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).transitionToAlive()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node_fsm.go:145 +0x2f6
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).declareAlive()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node_fsm.go:125 +0x4a
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).start()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node.go:244 +0x4f2
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).Start.func1()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node.go:208 +0x4c
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:872 +0xe9
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*node).Start()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/node.go:207 +0x8b
  github.com/smartcontractkit/chainlink/core/services.(*MultiStart).start()
      /home/runner/work/chainlink/chainlink/core/services/multi.go:36 +0x64
  github.com/smartcontractkit/chainlink/core/services.(*MultiStart).Start()
      /home/runner/work/chainlink/chainlink/core/services/multi.go:27 +0x88e
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*Pool).Dial.func1()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/pool.go:127 +0x81c
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:872 +0xe9
  github.com/smartcontractkit/chainlink/core/chains/evm/client.(*Pool).Dial()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/pool.go:109 +0x7e
  github.com/smartcontractkit/chainlink/core/chains/evm/client_test.TestPool_Dial.func1()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/pool_test.go:166 +0x215
  testing.tRunner()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x47

Goroutine 41831 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x75d
  github.com/smartcontractkit/chainlink/core/chains/evm/client_test.TestPool_Dial()
      /home/runner/work/chainlink/chainlink/core/chains/evm/client/pool_test.go:154 +0x1ba4
  testing.tRunner()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x47
==================
```
</details>

Note: This is only a _data race_ in test, by logging after test completion. It would manifest as an orphaned goroutine in regular execution, and still only in the case of failed start.