### PR TITLE
core/services/keeper: fix race by unsubscribing before signaling done

### DIFF
--- a/core/services/keeper/registry_synchronizer_core.go
+++ b/core/services/keeper/registry_synchronizer_core.go
@@ -96,8 +96,8 @@ func (rs *RegistrySynchronizer) Start(context.Context) error {
 		lbUnsubscribe := rs.logBroadcaster.Register(rs, *logListenerOpts)
 
 		go func() {
-			defer lbUnsubscribe()
 			defer rs.wgDone.Done()
+			defer lbUnsubscribe()
 			<-rs.chStop
 		}()
 		return nil


### PR DESCRIPTION
CI flagged a race in the shutdown logic of `RegistrySynchronizer`:
```go
==================
WARNING: DATA RACE
Read at 0x00c022038d43 by goroutine 81182:
  testing.(*common).logDepth()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:889 +0x4e7
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:876 +0xa4
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:927 +0x6a
  testing.(*T).Logf()
      <autogenerated>:1 +0x75
  go.uber.org/zap/zaptest.testingWriter.Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/zaptest/logger.go:130 +0x12c
  go.uber.org/zap/zaptest.(*testingWriter).Write()
      <autogenerated>:1 +0x7e
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/zapcore/core.go:99 +0x199
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/zapcore/entry.go:255 +0x2ce
  go.uber.org/zap.(*SugaredLogger).log()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/sugar.go:287 +0x13a
  go.uber.org/zap.(*SugaredLogger).Debugf()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.23.0/sugar.go:155 +0xa4
  github.com/smartcontractkit/chainlink/core/logger.(*zapLogger).Debugf()
      <autogenerated>:1 +0x29
  github.com/smartcontractkit/chainlink/core/chains/evm/log.(*broadcaster).Register.func1.1()
      /home/runner/work/chainlink-internal/chainlink-internal/core/chains/evm/log/broadcaster.go:263 +0x146
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.19.2/x64/src/runtime/panic.go:476 +0x32

Previous write at 0x00c022038d43 by goroutine 80967:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1433 +0x7e4
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.19.2/x64/src/runtime/panic.go:476 +0x32
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x47

Goroutine 81182 (running) created at:
  github.com/smartcontractkit/chainlink/core/services/keeper.(*RegistrySynchronizer).Start.func1()
      /home/runner/work/chainlink-internal/chainlink-internal/core/services/keeper/registry_synchronizer_core.go:98 +0x4c5
  github.com/smartcontractkit/chainlink/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink-internal/chainlink-internal/core/utils/utils.go:872 +0xe9
  github.com/smartcontractkit/chainlink/core/services/keeper.(*RegistrySynchronizer).Start()
      /home/runner/work/chainlink-internal/chainlink-internal/core/services/keeper/registry_synchronizer_core.go:76 +0x5e
  github.com/smartcontractkit/chainlink/core/services.(*MultiStart).start()
      /home/runner/work/chainlink-internal/chainlink-internal/core/services/multi.go:36 +0x64
  github.com/smartcontractkit/chainlink/core/services.(*MultiStart).Start()
      /home/runner/work/chainlink-internal/chainlink-internal/core/services/multi.go:27 +0x137a
  github.com/smartcontractkit/chainlink/core/services/job.(*spawner).StartService()
      /home/runner/work/chainlink-internal/chainlink-internal/core/services/job/spawner.go:200 +0x1314
  github.com/smartcontractkit/chainlink/core/services/keeper_test.TestKeeperForwarderEthIntegration.func1()
      /home/runner/work/chainlink-internal/chainlink-internal/core/services/keeper/integration_test.go:464 +0x2410
  testing.tRunner()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1446 +0x216
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x47

Goroutine 80967 (finished) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1493 +0x75d
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1846 +0x99
  testing.tRunner()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1446 +0x216
  testing.runTests()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1844 +0x7ec
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.19.2/x64/src/testing/testing.go:1726 +0xa84
  main.main()
      _testmain.go:177 +0x2e9
==================
```
https://github.com/smartcontractkit/chainlink/actions/runs/3390237092