### PR TITLE
core/services/chainlink: ensure Root exists with TOML config

### DIFF
--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -164,6 +164,10 @@ func (o *GeneralConfigOpts) init() (*generalConfig, error) {
 		cfg.logLevelDefault = zapcore.Level(*lvl)
 	}
 
+	if err2 := utils.EnsureDirAndMaxPerms(cfg.RootDir(), os.FileMode(0700)); err2 != nil {
+		return nil, fmt.Errorf(`failed to create root directory %q: %w`, cfg.RootDir(), err2)
+	}
+
 	return cfg, nil
 }
 


### PR DESCRIPTION
The legacy config constructor ensures that the `Root` dir exists - new TOML config should do the same.