### PR TITLE
Fixing jsonparse task

### DIFF
--- a/core/services/pipeline/task.jsonparse.go
+++ b/core/services/pipeline/task.jsonparse.go
@@ -13,15 +13,14 @@ import (
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
 
-//
 // Return types:
-//     float64
-//     string
-//     bool
-//     map[string]interface{}
-//     []interface{}
-//     nil
 //
+//	float64
+//	string
+//	bool
+//	map[string]interface{}
+//	[]interface{}
+//	nil
 type JSONParseTask struct {
 	BaseTask  `mapstructure:",squash"`
 	Path      string `json:"path"`
@@ -110,12 +109,9 @@ func (t *JSONParseTask) Run(_ context.Context, l logger.Logger, vars Vars, input
 		}
 	}
 
-	switch val := decoded.(type) {
-	case json.Number:
-		decoded, err = getJsonNumberValue(val)
-		if err != nil {
-			return Result{Error: multierr.Combine(ErrBadInput, err)}, runInfo
-		}
+	decoded, err = reinterpetJsonNumbers(decoded)
+	if err != nil {
+		return Result{Error: multierr.Combine(ErrBadInput, err)}, runInfo
 	}
 
 	return Result{Value: decoded}, runInfo

--- a/core/services/pipeline/task.jsonparse_test.go
+++ b/core/services/pipeline/task.jsonparse_test.go
@@ -1,7 +1,6 @@
 package pipeline_test
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -192,7 +191,7 @@ func TestJSONParseTask(t *testing.T) {
 			"false",
 			pipeline.NewVarsFrom(nil),
 			[]pipeline.Result{{Value: `{"data": [[0, 1]]}`}},
-			[]interface{}{json.Number("0"), json.Number("1")},
+			[]interface{}{int64(0), int64(1)},
 			nil,
 			"",
 		},


### PR DESCRIPTION
Closes https://app.shortcut.com/chainlinklabs/story/56225/node-get-uint256-failing-during-ethabiencode-type-json-number-cannot-be-converted-to-decimal-decimal
Fixes https://github.com/smartcontractkit/chainlink/issues/7684
