### PR TITLE
core/config/v2: support multiple TOML config files

### DIFF
--- a/core/chains/evm/chain_set_test.go
+++ b/core/chains/evm/chain_set_test.go
@@ -94,7 +94,7 @@ func TestAddClose(t *testing.T) {
 		one := uint32(1)
 		c.EVM[0].MinIncomingConfirmations = &one
 		t := true
-		c.EVM = append(c.EVM, &v2.EVMConfig{ChainID: utils.NewBig(newId), Enabled: &t, Chain: v2.DefaultsFrom(nil, nil)})
+		c.EVM = append(c.EVM, &v2.EVMConfig{ChainID: utils.NewBig(newId), Enabled: &t, Chain: v2.Defaults(nil)})
 	})
 	db := pgtest.NewSqlxDB(t)
 	kst := cltest.NewKeyStore(t, db, cfg)

--- a/core/chains/evm/config/v2/config.go
+++ b/core/chains/evm/config/v2/config.go
@@ -11,6 +11,7 @@ import (
 	"github.com/shopspring/decimal"
 	"go.uber.org/multierr"
 	"golang.org/x/exp/constraints"
+	"golang.org/x/exp/slices"
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink/core/assets"
@@ -69,6 +70,20 @@ func (cs EVMConfigs) ValidateConfig() (err error) {
 		}
 	}
 	return
+}
+
+func (cs *EVMConfigs) SetFrom(fs *EVMConfigs) {
+	for _, f := range *fs {
+		if f.ChainID == nil {
+			*cs = append(*cs, f)
+		} else if i := slices.IndexFunc(*cs, func(c *EVMConfig) bool {
+			return c.ChainID != nil && c.ChainID.Cmp(f.ChainID) == 0
+		}); i == -1 {
+			*cs = append(*cs, f)
+		} else {
+			(*cs)[i].SetFrom(f)
+		}
+	}
 }
 
 func (cs EVMConfigs) Chains(ids ...utils.Big) (chains []types.DBChain) {
@@ -162,6 +177,20 @@ func (cs EVMConfigs) NodesByID(chainIDs ...utils.Big) (ns []types.Node) {
 
 type EVMNodes []*Node
 
+func (ns *EVMNodes) SetFrom(fs *EVMNodes) {
+	for _, f := range *fs {
+		if f.Name == nil {
+			*ns = append(*ns, f)
+		} else if i := slices.IndexFunc(*ns, func(n *Node) bool {
+			return n.Name != nil && *n.Name == *f.Name
+		}); i == -1 {
+			*ns = append(*ns, f)
+		} else {
+			(*ns)[i].SetFrom(f)
+		}
+	}
+}
+
 type EVMConfig struct {
 	ChainID *utils.Big
 	Enabled *bool
@@ -171,6 +200,17 @@ type EVMConfig struct {
 
 func (c *EVMConfig) IsEnabled() bool {
 	return c.Enabled == nil || *c.Enabled
+}
+
+func (c *EVMConfig) SetFrom(f *EVMConfig) {
+	if f.ChainID != nil {
+		c.ChainID = f.ChainID
+	}
+	if f.Enabled != nil {
+		c.Enabled = f.Enabled
+	}
+	c.Chain.SetFrom(&f.Chain)
+	c.Nodes.SetFrom(&f.Nodes)
 }
 
 func (c *EVMConfig) SetFromDB(ch types.DBChain, nodes []types.Node) error {
@@ -924,6 +964,21 @@ func (n *Node) ValidateConfig() (err error) {
 	}
 
 	return
+}
+
+func (n *Node) SetFrom(f *Node) {
+	if f.Name != nil {
+		n.Name = f.Name
+	}
+	if f.WSURL != nil {
+		n.WSURL = f.WSURL
+	}
+	if f.HTTPURL != nil {
+		n.HTTPURL = f.HTTPURL
+	}
+	if f.SendOnly != nil {
+		n.SendOnly = f.SendOnly
+	}
 }
 
 func (n *Node) SetFromDB(db types.Node) (err error) {

--- a/core/chains/evm/config/v2/defaults.go
+++ b/core/chains/evm/config/v2/defaults.go
@@ -67,8 +67,8 @@ func init() {
 	})
 }
 
-// Defaults returns the default Chain values, optionally for the given chainID, as well as a name if the chainID is known.
-func Defaults(chainID *utils.Big) (c Chain, name string) {
+// DefaultsNamed returns the default Chain values, optionally for the given chainID, as well as a name if the chainID is known.
+func DefaultsNamed(chainID *utils.Big) (c Chain, name string) {
 	c.SetFrom(&fallback)
 	if chainID == nil {
 		return
@@ -81,11 +81,12 @@ func Defaults(chainID *utils.Big) (c Chain, name string) {
 	return
 }
 
-// DefaultsFrom returns a Chain based on the defaults for chainID and fields from with.
-func DefaultsFrom(chainID *utils.Big, with *Chain) Chain {
-	c, _ := Defaults(chainID)
-	if with != nil {
-		c.SetFrom(with)
+// Defaults returns a Chain based on the defaults for chainID and fields from with, applied in order so later Chains
+// override earlier ones.
+func Defaults(chainID *utils.Big, with ...*Chain) Chain {
+	c, _ := DefaultsNamed(chainID)
+	for _, w := range with {
+		c.SetFrom(w)
 	}
 	return c
 }

--- a/core/chains/evm/config/v2_defaults_test.go
+++ b/core/chains/evm/config/v2_defaults_test.go
@@ -18,7 +18,7 @@ import (
 func Test_v2Config_SetDefaults(t *testing.T) {
 	var fallbackTOML []byte
 	t.Run("fallback", func(t *testing.T) {
-		got, name := v2.Defaults(nil)
+		got, name := v2.DefaultsNamed(nil)
 		assert.Empty(t, name)
 		exp := config.FallbackDefaultsAsV2()
 
@@ -29,13 +29,13 @@ func Test_v2Config_SetDefaults(t *testing.T) {
 		require.NoError(t, err)
 	})
 	for id, exp := range config.ChainSpecificConfigDefaultsAsV2() {
-		got, name := v2.Defaults(utils.NewBigI(id))
+		got, name := v2.DefaultsNamed(utils.NewBigI(id))
 		t.Run(fmt.Sprintf("%d:%s", id, name), func(t *testing.T) {
 			assertChainsEqual(t, exp, got)
 		})
 	}
 	t.Run("fallback-unchanged", func(t *testing.T) {
-		got, _ := v2.Defaults(nil)
+		got, _ := v2.DefaultsNamed(nil)
 		gotTOML, err := toml.Marshal(got)
 		require.NoError(t, err)
 		assert.Equal(t, fallbackTOML, gotTOML)

--- a/core/cmd/cfgtest/app_test.go
+++ b/core/cmd/cfgtest/app_test.go
@@ -62,7 +62,7 @@ func TestDefaultConfig(t *testing.T) {
 	})
 	evmCfg := evmcfg2.EVMConfig{
 		ChainID: chainID,
-		Chain:   evmcfg2.DefaultsFrom(chainID, nil),
+		Chain:   evmcfg2.Defaults(chainID),
 	}
 	newConfig := evmcfg2.NewTOMLChainScopedConfig(newGeneral, &evmCfg, lggr)
 	legacyConfig := evmcfg.NewChainScopedConfig(chainID.ToInt(), evmtypes.ChainCfg{}, nil, lggr, legacyGeneral)

--- a/core/cmd/evm_node_commands_test.go
+++ b/core/cmd/evm_node_commands_test.go
@@ -49,7 +49,7 @@ func TestClient_IndexEVMNodes(t *testing.T) {
 	}
 	chain := evmcfg.EVMConfig{
 		ChainID: chainID,
-		Chain:   evmcfg.DefaultsFrom(chainID, nil),
+		Chain:   evmcfg.Defaults(chainID),
 		Nodes:   evmcfg.EVMNodes{&node},
 	}
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {

--- a/core/config/v2/docs/docs_test.go
+++ b/core/config/v2/docs/docs_test.go
@@ -42,7 +42,7 @@ func TestDoc(t *testing.T) {
 	require.NoError(t, cfgtest.DocDefaultsOnly(strings.NewReader(docsTOML), &defaults, config.DecodeTOML))
 
 	t.Run("EVM", func(t *testing.T) {
-		fallbackDefaults, _ := evmcfg.Defaults(nil)
+		fallbackDefaults := evmcfg.Defaults(nil)
 		docDefaults := defaults.EVM[0].Chain
 
 		require.Equal(t, "", *docDefaults.ChainType)

--- a/core/config/v2/docs/extended.go
+++ b/core/config/v2/docs/extended.go
@@ -14,7 +14,7 @@ import (
 func evmChainDefaults() (string, error) {
 	var sb strings.Builder
 	for _, id := range evmcfg.DefaultIDs {
-		config, name := evmcfg.Defaults(id)
+		config, name := evmcfg.DefaultsNamed(id)
 		fmt.Fprintf(&sb, "\n<details><summary>%s (%s)<a id='EVM-%s'></a></summary><p>\n\n", name, id, id)
 		sb.WriteString("```toml\n")
 		b, err := toml.Marshal(config)

--- a/core/internal/testutils/configtest/v2/general_config.go
+++ b/core/internal/testutils/configtest/v2/general_config.go
@@ -64,7 +64,7 @@ func overrides(c *chainlink.Config, s *chainlink.Secrets) {
 	enabled := true
 	c.EVM = append(c.EVM, &evmcfg.EVMConfig{
 		ChainID: chainID,
-		Chain:   evmcfg.DefaultsFrom(chainID, nil),
+		Chain:   evmcfg.Defaults(chainID),
 		Enabled: &enabled,
 		Nodes:   evmcfg.EVMNodes{{}},
 	})
@@ -89,7 +89,7 @@ func simulated(c *chainlink.Config, s *chainlink.Secrets) {
 	enabled := true
 	cfg := evmcfg.EVMConfig{
 		ChainID: chainID,
-		Chain:   evmcfg.DefaultsFrom(chainID, nil),
+		Chain:   evmcfg.Defaults(chainID),
 		Enabled: &enabled,
 		Nodes:   evmcfg.EVMNodes{{}},
 	}

--- a/core/internal/testutils/evmtest/evmtest.go
+++ b/core/internal/testutils/evmtest/evmtest.go
@@ -44,7 +44,7 @@ func NewChainScopedConfig(t testing.TB, cfg config.GeneralConfig) evmconfig.Chai
 			chainID := utils.NewBigI(0)
 			evmCfg = &v2.EVMConfig{
 				ChainID: chainID,
-				Chain:   v2.DefaultsFrom(chainID, nil),
+				Chain:   v2.Defaults(chainID),
 			}
 		}
 

--- a/core/internal/testutils/evmtest/v2/evmtest.go
+++ b/core/internal/testutils/evmtest/v2/evmtest.go
@@ -18,6 +18,6 @@ func ChainArbitrumRinkeby(t *testing.T) config.ChainScopedConfig { return scoped
 
 func scopedConfig(t *testing.T, chainID int64) config.ChainScopedConfig {
 	id := utils.NewBigI(chainID)
-	evmCfg := v2.EVMConfig{ChainID: id, Chain: v2.DefaultsFrom(id, nil)}
+	evmCfg := v2.EVMConfig{ChainID: id, Chain: v2.Defaults(id)}
 	return v2.NewTOMLChainScopedConfig(configtest.NewTestGeneralConfig(t), &evmCfg, logger.TestLogger(t))
 }

--- a/core/services/chainlink/config.go
+++ b/core/services/chainlink/config.go
@@ -60,9 +60,9 @@ func (c *Config) setDefaults() {
 
 	for i := range c.EVM {
 		if input := c.EVM[i]; input == nil {
-			c.EVM[i] = &evmcfg.EVMConfig{Chain: evmcfg.DefaultsFrom(nil, nil)}
+			c.EVM[i] = &evmcfg.EVMConfig{Chain: evmcfg.Defaults(nil)}
 		} else {
-			input.Chain = evmcfg.DefaultsFrom(input.ChainID, &input.Chain)
+			input.Chain = evmcfg.Defaults(input.ChainID, &input.Chain)
 		}
 	}
 
@@ -86,6 +86,14 @@ func (c *Config) setDefaults() {
 		}
 		c.Terra[i].Chain.SetDefaults()
 	}
+}
+
+func (c *Config) SetFrom(f *Config) {
+	c.Core.SetFrom(&f.Core)
+	c.EVM.SetFrom(&f.EVM)
+	c.Solana.SetFrom(&f.Solana)
+	c.Starknet.SetFrom(&f.Starknet)
+	c.Terra.SetFrom(&f.Terra)
 }
 
 type Secrets struct {

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -82,13 +82,25 @@ type GeneralConfigOpts struct {
 
 // ParseTOML sets Config and Secrets from the given TOML strings.
 func (o *GeneralConfigOpts) ParseTOML(config, secrets string) (err error) {
-	if err2 := v2.DecodeTOML(strings.NewReader(config), &o.Config); err2 != nil {
-		err = multierr.Append(err, fmt.Errorf("failed to decode config TOML: %w", err2))
+	return multierr.Combine(o.ParseConfig(config), o.ParseSecrets(secrets))
+}
+
+// ParseConfig sets Config from the given TOML string, overriding any existing duplicate Config fields.
+func (o *GeneralConfigOpts) ParseConfig(config string) error {
+	var c Config
+	if err2 := v2.DecodeTOML(strings.NewReader(config), &c); err2 != nil {
+		return fmt.Errorf("failed to decode config TOML: %w", err2)
 	}
+	o.Config.SetFrom(&c)
+	return nil
+}
+
+// ParseSecrets sets Secrets from the given TOML string.
+func (o *GeneralConfigOpts) ParseSecrets(secrets string) (err error) {
 	if err2 := v2.DecodeTOML(strings.NewReader(secrets), &o.Secrets); err2 != nil {
-		err = multierr.Append(err, fmt.Errorf("failed to decode secrets TOML: %w", err2))
+		return fmt.Errorf("failed to decode secrets TOML: %w", err2)
 	}
-	return
+	return nil
 }
 
 // New returns a coreconfig.GeneralConfig for the given options.

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -1316,3 +1316,30 @@ func Test_validateEnv(t *testing.T) {
 	- environment variable ETH_GAS_BUMP_TX_DEPTH must not be set: unsupported with config v2
 	- environment variable GAS_UPDATER_ENABLED must not be set: unsupported with config v2`)
 }
+
+func TestConfig_SetFrom(t *testing.T) {
+	t.Parallel()
+	for _, tt := range []struct {
+		name string
+		exp  string
+		from []string
+	}{
+		{"empty", "", []string{""}},
+		{"empty-full", fullTOML, []string{"", fullTOML}},
+		{"empty-multi", multiChainTOML, []string{"", multiChainTOML}},
+		{"full-empty", fullTOML, []string{fullTOML, ""}},
+		{"multi-empty", multiChainTOML, []string{multiChainTOML, ""}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var c Config
+			for _, fs := range tt.from {
+				var f Config
+				require.NoError(t, config.DecodeTOML(strings.NewReader(fs), &f))
+				c.SetFrom(&f)
+			}
+			ts, err := c.TOMLString()
+			require.NoError(t, err)
+			assert.Equal(t, tt.exp, ts)
+		})
+	}
+}

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -453,7 +453,7 @@ func TestORM_CreateJob_OCR_DuplicatedContractAddress(t *testing.T) {
 		enabled := true
 		c.EVM = append(c.EVM, &evmcfg.EVMConfig{
 			ChainID: customChainID,
-			Chain:   evmcfg.DefaultsFrom(customChainID, nil),
+			Chain:   evmcfg.Defaults(customChainID),
 			Enabled: &enabled,
 			Nodes:   evmcfg.EVMNodes{{}},
 		})

--- a/core/web/evm_chains_controller_test.go
+++ b/core/web/evm_chains_controller_test.go
@@ -80,7 +80,7 @@ func Test_EVMChainsController_Show(t *testing.T) {
 			want: &evmcfg.EVMConfig{
 				ChainID: validId,
 				Enabled: ptr(true),
-				Chain: evmcfg.DefaultsFrom(nil, &evmcfg.Chain{
+				Chain: evmcfg.Defaults(nil, &evmcfg.Chain{
 					GasEstimator: evmcfg.GasEstimator{
 						EIP1559DynamicFees: ptr(true),
 						BlockHistory: evmcfg.BlockHistoryEstimator{
@@ -147,10 +147,10 @@ func Test_EVMChainsController_Index(t *testing.T) {
 	t.Parallel()
 
 	newChains := evmcfg.EVMConfigs{
-		{ChainID: utils.NewBig(testutils.NewRandomEVMChainID()), Chain: evmcfg.DefaultsFrom(nil, nil)},
+		{ChainID: utils.NewBig(testutils.NewRandomEVMChainID()), Chain: evmcfg.Defaults(nil)},
 		{
 			ChainID: utils.NewBig(testutils.NewRandomEVMChainID()),
-			Chain: evmcfg.DefaultsFrom(nil, &evmcfg.Chain{
+			Chain: evmcfg.Defaults(nil, &evmcfg.Chain{
 				RPCBlockQueryDelay: ptr[uint16](13),
 				GasEstimator: evmcfg.GasEstimator{
 					EIP1559DynamicFees: ptr(true),
@@ -163,7 +163,7 @@ func Test_EVMChainsController_Index(t *testing.T) {
 		},
 		{
 			ChainID: utils.NewBig(testutils.NewRandomEVMChainID()),
-			Chain: evmcfg.DefaultsFrom(nil, &evmcfg.Chain{
+			Chain: evmcfg.Defaults(nil, &evmcfg.Chain{
 				RPCBlockQueryDelay: ptr[uint16](5),
 				GasEstimator: evmcfg.GasEstimator{
 					EIP1559DynamicFees: ptr(false),

--- a/core/web/evm_forwarders_controller_test.go
+++ b/core/web/evm_forwarders_controller_test.go
@@ -46,7 +46,7 @@ func Test_EVMForwardersController_Track(t *testing.T) {
 	chainId := utils.NewBig(testutils.NewRandomEVMChainID())
 	controller := setupEVMForwardersControllerTest(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM = evmcfg.EVMConfigs{
-			{ChainID: chainId, Enabled: ptr(true), Chain: evmcfg.DefaultsFrom(chainId, nil)},
+			{ChainID: chainId, Enabled: ptr(true), Chain: evmcfg.Defaults(chainId)},
 		}
 	})
 
@@ -76,7 +76,7 @@ func Test_EVMForwardersController_Index(t *testing.T) {
 	chainId := utils.NewBig(testutils.NewRandomEVMChainID())
 	controller := setupEVMForwardersControllerTest(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM = evmcfg.EVMConfigs{
-			{ChainID: chainId, Enabled: ptr(true), Chain: evmcfg.DefaultsFrom(chainId, nil)},
+			{ChainID: chainId, Enabled: ptr(true), Chain: evmcfg.Defaults(chainId)},
 		}
 	})
 


### PR DESCRIPTION
https://app.shortcut.com/chainlinklabs/story/57552/toml-config-support-multiple-files

Adding support for multiple TOML config files, e.g.: `-config config1.toml,config2.toml`, with the last file taking precedence.