### PR TITLE
.github: ensure failure log artifacts are uploaded

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -90,6 +90,7 @@ jobs:
       - name: Run tests
         run: ./tools/bin/${{ matrix.cmd }} "${{ matrix.split.pkgs }}"
       - name: Store logs artifacts
+        if: always()
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
           name: ${{ matrix.cmd }}_${{ matrix.split.idx }}_logs


### PR DESCRIPTION
#7860 removed an `if: failure()` to get coverage data on success, but that inadvertently disabled upload on failure. We can have both with `always()`.