### PR TITLE
[DR-OCR] Cleanup in data model and ORM

### DIFF
--- a/core/services/directrequestocr/mocks/orm.go
+++ b/core/services/directrequestocr/mocks/orm.go
@@ -7,6 +7,8 @@ import (
 	directrequestocr "github.com/smartcontractkit/chainlink/core/services/directrequestocr"
 	mock "github.com/stretchr/testify/mock"
 
+	pg "github.com/smartcontractkit/chainlink/core/services/pg"
+
 	time "time"
 )
 
@@ -15,34 +17,41 @@ type ORM struct {
 	mock.Mock
 }
 
-// CreateRequest provides a mock function with given fields: contractRequestID, receivedAt, requestTxHash
-func (_m *ORM) CreateRequest(contractRequestID [32]byte, receivedAt time.Time, requestTxHash *common.Hash) (int64, error) {
-	ret := _m.Called(contractRequestID, receivedAt, requestTxHash)
+// CreateRequest provides a mock function with given fields: requestID, receivedAt, requestTxHash, qopts
+func (_m *ORM) CreateRequest(requestID directrequestocr.RequestID, receivedAt time.Time, requestTxHash *common.Hash, qopts ...pg.QOpt) error {
+	_va := make([]interface{}, len(qopts))
+	for _i := range qopts {
+		_va[_i] = qopts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, requestID, receivedAt, requestTxHash)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
-	var r0 int64
-	if rf, ok := ret.Get(0).(func([32]byte, time.Time, *common.Hash) int64); ok {
-		r0 = rf(contractRequestID, receivedAt, requestTxHash)
+	var r0 error
+	if rf, ok := ret.Get(0).(func(directrequestocr.RequestID, time.Time, *common.Hash, ...pg.QOpt) error); ok {
+		r0 = rf(requestID, receivedAt, requestTxHash, qopts...)
 	} else {
-		r0 = ret.Get(0).(int64)
+		r0 = ret.Error(0)
 	}
 
-	var r1 error
-	if rf, ok := ret.Get(1).(func([32]byte, time.Time, *common.Hash) error); ok {
-		r1 = rf(contractRequestID, receivedAt, requestTxHash)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
+	return r0
 }
 
-// FindById provides a mock function with given fields: contractRequestID
-func (_m *ORM) FindById(contractRequestID [32]byte) (*directrequestocr.Request, error) {
-	ret := _m.Called(contractRequestID)
+// FindById provides a mock function with given fields: requestID, qopts
+func (_m *ORM) FindById(requestID directrequestocr.RequestID, qopts ...pg.QOpt) (*directrequestocr.Request, error) {
+	_va := make([]interface{}, len(qopts))
+	for _i := range qopts {
+		_va[_i] = qopts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, requestID)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 *directrequestocr.Request
-	if rf, ok := ret.Get(0).(func([32]byte) *directrequestocr.Request); ok {
-		r0 = rf(contractRequestID)
+	if rf, ok := ret.Get(0).(func(directrequestocr.RequestID, ...pg.QOpt) *directrequestocr.Request); ok {
+		r0 = rf(requestID, qopts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*directrequestocr.Request)
@@ -50,8 +59,8 @@ func (_m *ORM) FindById(contractRequestID [32]byte) (*directrequestocr.Request, 
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func([32]byte) error); ok {
-		r1 = rf(contractRequestID)
+	if rf, ok := ret.Get(1).(func(directrequestocr.RequestID, ...pg.QOpt) error); ok {
+		r1 = rf(requestID, qopts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -59,13 +68,20 @@ func (_m *ORM) FindById(contractRequestID [32]byte) (*directrequestocr.Request, 
 	return r0, r1
 }
 
-// FindOldestEntriesByState provides a mock function with given fields: state, limit
-func (_m *ORM) FindOldestEntriesByState(state directrequestocr.RequestState, limit uint32) ([]directrequestocr.Request, error) {
-	ret := _m.Called(state, limit)
+// FindOldestEntriesByState provides a mock function with given fields: state, limit, qopts
+func (_m *ORM) FindOldestEntriesByState(state directrequestocr.RequestState, limit uint32, qopts ...pg.QOpt) ([]directrequestocr.Request, error) {
+	_va := make([]interface{}, len(qopts))
+	for _i := range qopts {
+		_va[_i] = qopts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, state, limit)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 []directrequestocr.Request
-	if rf, ok := ret.Get(0).(func(directrequestocr.RequestState, uint32) []directrequestocr.Request); ok {
-		r0 = rf(state, limit)
+	if rf, ok := ret.Get(0).(func(directrequestocr.RequestState, uint32, ...pg.QOpt) []directrequestocr.Request); ok {
+		r0 = rf(state, limit, qopts...)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]directrequestocr.Request)
@@ -73,8 +89,8 @@ func (_m *ORM) FindOldestEntriesByState(state directrequestocr.RequestState, lim
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func(directrequestocr.RequestState, uint32) error); ok {
-		r1 = rf(state, limit)
+	if rf, ok := ret.Get(1).(func(directrequestocr.RequestState, uint32, ...pg.QOpt) error); ok {
+		r1 = rf(state, limit, qopts...)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -82,13 +98,20 @@ func (_m *ORM) FindOldestEntriesByState(state directrequestocr.RequestState, lim
 	return r0, r1
 }
 
-// SetError provides a mock function with given fields: id, runID, errorType, computationError, readyAt
-func (_m *ORM) SetError(id int64, runID int64, errorType directrequestocr.ErrType, computationError string, readyAt time.Time) error {
-	ret := _m.Called(id, runID, errorType, computationError, readyAt)
+// SetError provides a mock function with given fields: requestID, runID, errorType, computationError, readyAt, qopts
+func (_m *ORM) SetError(requestID directrequestocr.RequestID, runID int64, errorType directrequestocr.ErrType, computationError []byte, readyAt time.Time, qopts ...pg.QOpt) error {
+	_va := make([]interface{}, len(qopts))
+	for _i := range qopts {
+		_va[_i] = qopts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, requestID, runID, errorType, computationError, readyAt)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(int64, int64, directrequestocr.ErrType, string, time.Time) error); ok {
-		r0 = rf(id, runID, errorType, computationError, readyAt)
+	if rf, ok := ret.Get(0).(func(directrequestocr.RequestID, int64, directrequestocr.ErrType, []byte, time.Time, ...pg.QOpt) error); ok {
+		r0 = rf(requestID, runID, errorType, computationError, readyAt, qopts...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -96,13 +119,20 @@ func (_m *ORM) SetError(id int64, runID int64, errorType directrequestocr.ErrTyp
 	return r0
 }
 
-// SetResult provides a mock function with given fields: id, runID, computationResult, readyAt
-func (_m *ORM) SetResult(id int64, runID int64, computationResult []byte, readyAt time.Time) error {
-	ret := _m.Called(id, runID, computationResult, readyAt)
+// SetResult provides a mock function with given fields: requestID, runID, computationResult, readyAt, qopts
+func (_m *ORM) SetResult(requestID directrequestocr.RequestID, runID int64, computationResult []byte, readyAt time.Time, qopts ...pg.QOpt) error {
+	_va := make([]interface{}, len(qopts))
+	for _i := range qopts {
+		_va[_i] = qopts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, requestID, runID, computationResult, readyAt)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(int64, int64, []byte, time.Time) error); ok {
-		r0 = rf(id, runID, computationResult, readyAt)
+	if rf, ok := ret.Get(0).(func(directrequestocr.RequestID, int64, []byte, time.Time, ...pg.QOpt) error); ok {
+		r0 = rf(requestID, runID, computationResult, readyAt, qopts...)
 	} else {
 		r0 = ret.Error(0)
 	}
@@ -110,20 +140,27 @@ func (_m *ORM) SetResult(id int64, runID int64, computationResult []byte, readyA
 	return r0
 }
 
-// SetState provides a mock function with given fields: contractRequestID, state
-func (_m *ORM) SetState(contractRequestID [32]byte, state directrequestocr.RequestState) (directrequestocr.RequestState, error) {
-	ret := _m.Called(contractRequestID, state)
+// SetState provides a mock function with given fields: requestID, state, qopts
+func (_m *ORM) SetState(requestID directrequestocr.RequestID, state directrequestocr.RequestState, qopts ...pg.QOpt) (directrequestocr.RequestState, error) {
+	_va := make([]interface{}, len(qopts))
+	for _i := range qopts {
+		_va[_i] = qopts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, requestID, state)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 directrequestocr.RequestState
-	if rf, ok := ret.Get(0).(func([32]byte, directrequestocr.RequestState) directrequestocr.RequestState); ok {
-		r0 = rf(contractRequestID, state)
+	if rf, ok := ret.Get(0).(func(directrequestocr.RequestID, directrequestocr.RequestState, ...pg.QOpt) directrequestocr.RequestState); ok {
+		r0 = rf(requestID, state, qopts...)
 	} else {
 		r0 = ret.Get(0).(directrequestocr.RequestState)
 	}
 
 	var r1 error
-	if rf, ok := ret.Get(1).(func([32]byte, directrequestocr.RequestState) error); ok {
-		r1 = rf(contractRequestID, state)
+	if rf, ok := ret.Get(1).(func(directrequestocr.RequestID, directrequestocr.RequestState, ...pg.QOpt) error); ok {
+		r1 = rf(requestID, state, qopts...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/services/directrequestocr/models.go
+++ b/core/services/directrequestocr/models.go
@@ -1,6 +1,7 @@
 package directrequestocr
 
 import (
+	"encoding/hex"
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
@@ -24,21 +25,25 @@ const (
 	USER_EXCEPTION
 )
 
+type RequestID [32]byte
+
 type Request struct {
-	ID                int64
-	ContractRequestID [32]byte
-	RunID             int64
-	ReceivedAt        time.Time
-	RequestTxHash     *common.Hash
-	State             RequestState
-	ResultReadyAt     time.Time
-	Result            []byte
-	ErrorType         ErrType
-	Error             string
+	ID            int64
+	RequestID     RequestID
+	RunID         int64
+	ReceivedAt    time.Time
+	RequestTxHash *common.Hash
+	State         RequestState
+	ResultReadyAt time.Time
+	Result        []byte
+	ErrorType     ErrType
+	Error         []byte
 	// True if this node submitted an observation for this request in any OCR rounds.
 	IsOCRParticipant  bool
 	TransmittedResult []byte
-	TransmittedError  string
+	TransmittedError  []byte
+	OnChainResult     []byte
+	OnChainError      []byte
 }
 
 func (s RequestState) String() string {
@@ -67,4 +72,8 @@ func (e ErrType) String() string {
 		return "UserException"
 	}
 	return "unknown"
+}
+
+func (r RequestID) String() string {
+	return hex.EncodeToString(r[:])
 }

--- a/core/services/directrequestocr/orm.go
+++ b/core/services/directrequestocr/orm.go
@@ -7,113 +7,108 @@ import (
 	"time"
 
 	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink/core/services/pg"
 )
 
 //go:generate mockery --quiet --name ORM --output ./mocks/ --case=underscore
 
 type ORM interface {
-	CreateRequest(contractRequestID [32]byte, receivedAt time.Time, requestTxHash *common.Hash) (int64, error)
+	CreateRequest(requestID RequestID, receivedAt time.Time, requestTxHash *common.Hash, qopts ...pg.QOpt) error
 
-	SetResult(id int64, runID int64, computationResult []byte, readyAt time.Time) error
-	SetError(id int64, runID int64, errorType ErrType, computationError string, readyAt time.Time) error
-	SetState(contractRequestID [32]byte, state RequestState) (RequestState, error)
+	SetResult(requestID RequestID, runID int64, computationResult []byte, readyAt time.Time, qopts ...pg.QOpt) error
+	SetError(requestID RequestID, runID int64, errorType ErrType, computationError []byte, readyAt time.Time, qopts ...pg.QOpt) error
+	SetState(requestID RequestID, state RequestState, qopts ...pg.QOpt) (RequestState, error)
 
-	FindOldestEntriesByState(state RequestState, limit uint32) ([]Request, error)
-	FindById(contractRequestID [32]byte) (*Request, error)
+	FindOldestEntriesByState(state RequestState, limit uint32, qopts ...pg.QOpt) ([]Request, error)
+	FindById(requestID RequestID, qopts ...pg.QOpt) (*Request, error)
 
-	// TODO include QOpts or context when moving to the DB ORM
 	// TODO add jobID or contract address when moving to the DB ORM
 	// TODO add state transition validation
 	// https://app.shortcut.com/chainlinklabs/story/54049/database-table-in-core-node
 }
 
 type inmemoryorm struct {
-	counter                int64
-	db                     map[int64]Request
-	contractRequestIDIndex map[[32]byte]int64
-	mutex                  *sync.Mutex
+	counter int64
+	db      map[[32]byte]Request
+	mutex   *sync.Mutex
 }
 
 var _ ORM = (*inmemoryorm)(nil)
 
 func NewInMemoryORM() *inmemoryorm {
 	return &inmemoryorm{
-		counter:                0,
-		db:                     make(map[int64]Request),
-		contractRequestIDIndex: make(map[[32]byte]int64),
-		mutex:                  &sync.Mutex{},
+		counter: 0,
+		db:      make(map[[32]byte]Request),
+		mutex:   &sync.Mutex{},
 	}
 }
 
-func (o *inmemoryorm) CreateRequest(contractRequestID [32]byte, receivedAt time.Time, requestTxHash *common.Hash) (int64, error) {
+func (o *inmemoryorm) CreateRequest(requestID RequestID, receivedAt time.Time, requestTxHash *common.Hash, qopts ...pg.QOpt) error {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
-	if dbID, ok := o.contractRequestIDIndex[contractRequestID]; ok {
-		return dbID, fmt.Errorf("Request already exists! DBID: %v", dbID)
+	if _, ok := o.db[requestID]; ok {
+		return fmt.Errorf("request already exists")
 	}
 
 	o.counter++
 	newEntry := Request{
-		ID:                o.counter,
-		ContractRequestID: contractRequestID,
-		ReceivedAt:        receivedAt,
-		RequestTxHash:     requestTxHash,
-		State:             IN_PROGRESS,
+		ID:            o.counter,
+		RequestID:     requestID,
+		ReceivedAt:    receivedAt,
+		RequestTxHash: requestTxHash,
+		State:         IN_PROGRESS,
 	}
-	o.db[o.counter] = newEntry
-	o.contractRequestIDIndex[contractRequestID] = o.counter
-	return o.counter, nil
+	o.db[requestID] = newEntry
+	return nil
 }
 
-func (o *inmemoryorm) SetResult(id int64, runID int64, computationResult []byte, readyAt time.Time) error {
+func (o *inmemoryorm) SetResult(requestID RequestID, runID int64, computationResult []byte, readyAt time.Time, qopts ...pg.QOpt) error {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
-	if val, ok := o.db[id]; ok {
+	if val, ok := o.db[requestID]; ok {
 		val.RunID = runID
 		val.ErrorType = NONE
 		val.Result = computationResult
-		val.Error = ""
+		val.Error = []byte{}
 		val.State = RESULT_READY
 		val.ResultReadyAt = readyAt
-		o.db[id] = val
+		o.db[requestID] = val
 		return nil
 	}
-	return fmt.Errorf("can't find entry with dbid: %v", id)
+	return fmt.Errorf("can't find entry with requestID: %v", requestID)
 }
 
-func (o *inmemoryorm) SetError(id int64, runID int64, errorType ErrType, computationError string, readyAt time.Time) error {
+func (o *inmemoryorm) SetError(requestID RequestID, runID int64, errorType ErrType, computationError []byte, readyAt time.Time, qopts ...pg.QOpt) error {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
-	if val, ok := o.db[id]; ok {
+	if val, ok := o.db[requestID]; ok {
 		val.RunID = runID
 		val.ErrorType = errorType
 		val.Error = computationError
 		val.State = RESULT_READY
 		val.Result = []byte{}
 		val.ResultReadyAt = readyAt
-		o.db[id] = val
+		o.db[requestID] = val
 		return nil
 	}
-	return fmt.Errorf("can't find entry with dbid: %v", id)
+	return fmt.Errorf("can't find entry with requestID: %v", requestID)
 }
 
-func (o *inmemoryorm) SetState(contractRequestID [32]byte, state RequestState) (RequestState, error) {
+func (o *inmemoryorm) SetState(requestID RequestID, state RequestState, qopts ...pg.QOpt) (RequestState, error) {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
 	prevState := IN_PROGRESS
-	if dbid, ok := o.contractRequestIDIndex[contractRequestID]; ok {
-		if val, ok := o.db[dbid]; ok {
-			prevState = val.State
-			val.State = state
-			o.db[dbid] = val
-			return prevState, nil
-		}
-		return prevState, fmt.Errorf("can't find entry with dbid: %v", dbid)
+	if val, ok := o.db[requestID]; ok {
+		prevState = val.State
+		val.State = state
+		o.db[requestID] = val
+		return prevState, nil
 	}
-	return prevState, fmt.Errorf("can't find entry with id: %v", contractRequestID)
+	return prevState, fmt.Errorf("can't find entry with requestID: %v", requestID)
 }
 
-func (o *inmemoryorm) FindOldestEntriesByState(state RequestState, limit uint32) ([]Request, error) {
+func (o *inmemoryorm) FindOldestEntriesByState(state RequestState, limit uint32, qopts ...pg.QOpt) ([]Request, error) {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
 	var result []Request
@@ -132,16 +127,13 @@ func (o *inmemoryorm) FindOldestEntriesByState(state RequestState, limit uint32)
 	return result, nil
 }
 
-func (o *inmemoryorm) FindById(contractRequestID [32]byte) (*Request, error) {
+func (o *inmemoryorm) FindById(requestID RequestID, qopts ...pg.QOpt) (*Request, error) {
 	o.mutex.Lock()
 	defer o.mutex.Unlock()
-	if dbid, ok := o.contractRequestIDIndex[contractRequestID]; ok {
-		if val, ok := o.db[dbid]; ok {
-			return &val, nil
-		}
-		return nil, fmt.Errorf("can't find entry with dbid: %v", dbid)
+	if val, ok := o.db[requestID]; ok {
+		return &val, nil
 	}
-	return nil, fmt.Errorf("can't find entry with id: %v", contractRequestID)
+	return nil, fmt.Errorf("can't find entry with dbid: %v", requestID)
 }
 
 // TODO actual DB: https://app.shortcut.com/chainlinklabs/story/54049/database-table-in-core-node

--- a/core/services/directrequestocr/orm_test.go
+++ b/core/services/directrequestocr/orm_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/directrequestocr"
 )
 
-func intToByte32(id uint) [32]byte {
+func reqID(id uint) directrequestocr.RequestID {
 	byteArr := (*[32]byte)([]byte(fmt.Sprintf("%032d\n", id)))
 	return *byteArr
 }
@@ -20,36 +20,35 @@ func TestDROCROrm_CreateRequestDuplicate(t *testing.T) {
 	t.Parallel()
 
 	orm := directrequestocr.NewInMemoryORM()
-	id := intToByte32(420)
+	id := reqID(420)
 	txHash := common.HexToHash("0xabc")
 
-	dbId1, err := orm.CreateRequest(id, time.Now(), &txHash)
+	err := orm.CreateRequest(id, time.Now(), &txHash)
 	require.NoError(t, err)
-	dbId2, err := orm.CreateRequest(id, time.Now(), &txHash)
+	err = orm.CreateRequest(id, time.Now(), &txHash)
 	require.NotNil(t, err)
-	require.Equal(t, dbId1, dbId2, "incorrect DBID of existing request")
 }
 
 func TestDROCROrm_FindOldestEntriesByStateWithLimit(t *testing.T) {
 	t.Parallel()
 
 	orm := directrequestocr.NewInMemoryORM()
-	id1, id2, id3 := intToByte32(101), intToByte32(102), intToByte32(103)
+	id1, id2, id3 := reqID(101), reqID(102), reqID(103)
 	txHash := common.HexToHash("0xabc")
 	ts := time.Now()
 
-	dbId2, err := orm.CreateRequest(id2, ts.Add(time.Minute*2), &txHash)
+	err := orm.CreateRequest(id2, ts.Add(time.Minute*2), &txHash)
 	require.NoError(t, err)
-	_, err = orm.CreateRequest(id3, ts.Add(time.Minute*3), &txHash)
+	err = orm.CreateRequest(id3, ts.Add(time.Minute*3), &txHash)
 	require.NoError(t, err)
-	dbId1, err := orm.CreateRequest(id1, ts.Add(time.Minute*1), &txHash)
+	err = orm.CreateRequest(id1, ts.Add(time.Minute*1), &txHash)
 	require.NoError(t, err)
 
 	result, err := orm.FindOldestEntriesByState(directrequestocr.IN_PROGRESS, 2)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(result), "incorrect result length")
-	require.Equal(t, dbId1, result[0].ID, "incorrect item in results")
-	require.Equal(t, dbId2, result[1].ID, "incorrect item in results")
+	require.Equal(t, id1, result[0].RequestID, "incorrect item in results")
+	require.Equal(t, id2, result[1].RequestID, "incorrect item in results")
 
 	result, err = orm.FindOldestEntriesByState(directrequestocr.IN_PROGRESS, 20)
 	require.NoError(t, err)

--- a/core/services/ocr2/plugins/directrequestocr/reporting.go
+++ b/core/services/ocr2/plugins/directrequestocr/reporting.go
@@ -83,7 +83,7 @@ func (r *directRequestReporting) Query(ctx context.Context, ts types.ReportTimes
 	queryProto := Query{}
 	for _, result := range results {
 		result := result
-		queryProto.RequestIDs = append(queryProto.RequestIDs, result.ContractRequestID[:])
+		queryProto.RequestIDs = append(queryProto.RequestIDs, result.RequestID[:])
 	}
 	r.logger.Debug("directRequestReporting Query phase done", commontypes.LogFields{
 		"epoch":    ts.Epoch,
@@ -128,9 +128,9 @@ func (r *directRequestReporting) Observation(ctx context.Context, ts types.Repor
 		}
 		if localResult.State == directrequestocr.RESULT_READY {
 			resultProto := ProcessedRequest{
-				RequestID: localResult.ContractRequestID[:],
+				RequestID: localResult.RequestID[:],
 				Result:    localResult.Result,
-				Error:     []byte(localResult.Error),
+				Error:     localResult.Error,
 			}
 			observationProto.ProcessedRequests = append(observationProto.ProcessedRequests, &resultProto)
 		}


### PR DESCRIPTION
1. Change error type from string to bytes
2. Use only requestID to identify requests everywhere
3. Add pg.QOpt params