### PR TITLE
core/cmd: use StringSliceFlag for -config; fix toml -config docs (#7921, #7927) [1.10]

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -72,7 +72,7 @@ func NewApp(client *Client) *cli.App {
 		cli.StringSliceFlag{
 			Name:   "config, c",
 			Hidden: !devMode,
-			Usage:  "EXPERIMENTAL: TOML configuration file(s) via flag, or raw TOML via env var. If used, legacy env vars must not be set. Multiple files must be comma separated (-c configA.toml,configB.toml), and they are applied in order with duplicated fields overriding any earlier values.",
+			Usage:  "EXPERIMENTAL: TOML configuration file(s) via flag, or raw TOML via env var. If used, legacy env vars must not be set. Multiple files can be used (-c configA.toml -c configB.toml), and they are applied in order with duplicated fields overriding any earlier values.",
 			EnvVar: "CL_CONFIG",
 		},
 		cli.StringFlag{

--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -69,7 +69,7 @@ func NewApp(client *Client) *cli.App {
 			Name:  "insecure-skip-verify",
 			Usage: "optional, applies only in client mode when making remote API calls. If turned on, SSL certificate verification will be disabled. This is mostly useful for people who want to use Chainlink with a self-signed TLS certificate",
 		},
-		cli.StringFlag{
+		cli.StringSliceFlag{
 			Name:   "config, c",
 			Hidden: !devMode,
 			Usage:  "EXPERIMENTAL: TOML configuration file(s) via flag, or raw TOML via env var. If used, legacy env vars must not be set. Multiple files must be comma separated (-c configA.toml,configB.toml), and they are applied in order with duplicated fields overriding any earlier values.",


### PR DESCRIPTION
(cherry picked from commit 6634591acbb6dfd0eaf9fee30536e8419732b38d) #7921

(cherry picked from commit 8e785f40f475f3a1a486bbdf810fb8471e0d0091) #7927