### PR TITLE
Validate the bridges exist before replacing a job with FMS

### DIFF
--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -582,6 +582,13 @@ func (s *service) ApproveSpec(ctx context.Context, id int64, force bool) error {
 		return errors.Wrap(err, "could not generate job from spec")
 	}
 
+	// Check that the bridges exist
+	if err = s.jobORM.AssertBridgesExist(j.Pipeline); err != nil {
+		s.lggr.Errorw("Failed to approve job spec due to bridge check", "err", err.Error())
+
+		return errors.Wrap(err, "failed to approve job spec due to bridge check")
+	}
+
 	var address ethkey.EIP55Address
 	switch j.Type {
 	case job.OffchainReporting:
@@ -804,6 +811,7 @@ func (s *service) Unsafe_SetConnectionsManager(connMgr ConnectionsManager) {
 	s.connMgr = connMgr
 }
 
+// generateJob validates and generates a job from a spec.
 func (s *service) generateJob(spec string) (*job.Job, error) {
 	jobType, err := job.ValidateSpec(spec)
 	if err != nil {

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -1252,7 +1252,7 @@ answer1 [type=median index=0];
 				svc.jobORM.On("AssertBridgesExist", mock.IsType(pipeline.Pipeline{})).Return(errors.New("bridges do not exist"))
 			},
 			id:      spec.ID,
-			wantErr: "bridges do not exist",
+			wantErr: "failed to approve job spec due to bridge check: bridges do not exist",
 		},
 		{
 			name: "rpc client not connected",

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ocrkey"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/p2pkey"
 	ksmocks "github.com/smartcontractkit/chainlink/core/services/keystore/mocks"
+	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/core/services/versioning"
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils/crypto"
@@ -1054,6 +1055,7 @@ answer1 [type=median index=0];
 				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
 				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
+				svc.jobORM.On("AssertBridgesExist", mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobIDByAddress", address, mock.Anything).Return(int32(0), sql.ErrNoRows)
 
@@ -1090,6 +1092,7 @@ answer1 [type=median index=0];
 				svc.orm.On("GetSpec", cancelledSpec.ID, mock.Anything).Return(cancelledSpec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
 				svc.orm.On("GetLatestSpec", cancelledSpec.JobProposalID).Return(cancelledSpec, nil)
+				svc.jobORM.On("AssertBridgesExist", mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobIDByAddress", address, mock.Anything).Return(int32(0), sql.ErrNoRows)
 
@@ -1150,6 +1153,7 @@ answer1 [type=median index=0];
 				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
 				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
+				svc.jobORM.On("AssertBridgesExist", mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobIDByAddress", address, mock.Anything).Return(j.ID, nil)
 			},
@@ -1164,6 +1168,7 @@ answer1 [type=median index=0];
 				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
 				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
+				svc.jobORM.On("AssertBridgesExist", mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobIDByAddress", address, mock.Anything).Return(j.ID, nil)
 				svc.spawner.On("DeleteJob", j.ID, mock.Anything).Return(nil)
@@ -1238,6 +1243,18 @@ answer1 [type=median index=0];
 			wantErr: "orm: job proposal: Not Found",
 		},
 		{
+			name:        "bridges do not exist",
+			httpTimeout: models.MustNewDuration(1 * time.Minute),
+			before: func(svc *TestService) {
+				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
+				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
+				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
+				svc.jobORM.On("AssertBridgesExist", mock.IsType(pipeline.Pipeline{})).Return(errors.New("bridges do not exist"))
+			},
+			id:      spec.ID,
+			wantErr: "bridges do not exist",
+		},
+		{
 			name: "rpc client not connected",
 			before: func(svc *TestService) {
 				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
@@ -1255,6 +1272,7 @@ answer1 [type=median index=0];
 				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
 				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
+				svc.jobORM.On("AssertBridgesExist", mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobIDByAddress", address, mock.Anything).Return(int32(0), sql.ErrNoRows)
 
@@ -1278,6 +1296,7 @@ answer1 [type=median index=0];
 				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
 				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
+				svc.jobORM.On("AssertBridgesExist", mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobIDByAddress", address, mock.Anything).Return(int32(0), sql.ErrNoRows)
 
@@ -1307,6 +1326,7 @@ answer1 [type=median index=0];
 				svc.orm.On("GetSpec", spec.ID, mock.Anything).Return(spec, nil)
 				svc.orm.On("GetJobProposal", jp.ID, mock.Anything).Return(jp, nil)
 				svc.connMgr.On("GetClient", jp.FeedsManagerID).Return(svc.fmsClient, nil)
+				svc.jobORM.On("AssertBridgesExist", mock.IsType(pipeline.Pipeline{})).Return(nil)
 
 				svc.jobORM.On("FindJobIDByAddress", address, mock.Anything).Return(int32(0), sql.ErrNoRows)
 

--- a/core/services/job/mocks/orm.go
+++ b/core/services/job/mocks/orm.go
@@ -22,6 +22,20 @@ type ORM struct {
 	mock.Mock
 }
 
+// AssertBridgesExist provides a mock function with given fields: p
+func (_m *ORM) AssertBridgesExist(p pipeline.Pipeline) error {
+	ret := _m.Called(p)
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func(pipeline.Pipeline) error); ok {
+		r0 = rf(p)
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // Close provides a mock function with given fields:
 func (_m *ORM) Close() error {
 	ret := _m.Called()

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -72,6 +72,7 @@ type ORM interface {
 	FindJobWithoutSpecErrors(id int32) (jb Job, err error)
 
 	FindTaskResultByRunIDAndTaskName(runID int64, taskName string) ([]byte, error)
+	AssertBridgesExist(p pipeline.Pipeline) error
 }
 
 type ORMConfig interface {
@@ -114,7 +115,7 @@ func (o *orm) Close() error {
 	return nil
 }
 
-func (o *orm) assertBridgesExist(p pipeline.Pipeline) error {
+func (o *orm) AssertBridgesExist(p pipeline.Pipeline) error {
 	var bridgeNames = make(map[bridges.BridgeName]struct{})
 	var uniqueBridges []bridges.BridgeName
 	for _, task := range p.Tasks {
@@ -147,7 +148,7 @@ func (o *orm) assertBridgesExist(p pipeline.Pipeline) error {
 func (o *orm) CreateJob(jb *Job, qopts ...pg.QOpt) error {
 	q := o.q.WithOpts(qopts...)
 	p := jb.Pipeline
-	if err := o.assertBridgesExist(p); err != nil {
+	if err := o.AssertBridgesExist(p); err != nil {
 		return err
 	}
 
@@ -274,7 +275,7 @@ func (o *orm) CreateJob(jb *Job, qopts ...pg.QOpt) error {
 				if err != nil {
 					return err
 				}
-				if err2 := o.assertBridgesExist(*feePipeline); err2 != nil {
+				if err2 := o.AssertBridgesExist(*feePipeline); err2 != nil {
 					return err2
 				}
 			}
@@ -312,14 +313,14 @@ func (o *orm) CreateJob(jb *Job, qopts ...pg.QOpt) error {
 		case VRF:
 			var specID int32
 			sql := `INSERT INTO vrf_specs (
-				coordinator_address, public_key, min_incoming_confirmations, 
-				evm_chain_id, from_addresses, poll_period, requested_confs_delay, 
-				request_timeout, chunk_size, batch_coordinator_address, batch_fulfillment_enabled, 
+				coordinator_address, public_key, min_incoming_confirmations,
+				evm_chain_id, from_addresses, poll_period, requested_confs_delay,
+				request_timeout, chunk_size, batch_coordinator_address, batch_fulfillment_enabled,
 				batch_fulfillment_gas_multiplier, backoff_initial_delay, backoff_max_delay, gas_lane_price,
 				created_at, updated_at)
 			VALUES (
-				:coordinator_address, :public_key, :min_incoming_confirmations, 
-				:evm_chain_id, :from_addresses, :poll_period, :requested_confs_delay, 
+				:coordinator_address, :public_key, :min_incoming_confirmations,
+				:evm_chain_id, :from_addresses, :poll_period, :requested_confs_delay,
 				:request_timeout, :chunk_size, :batch_coordinator_address, :batch_fulfillment_enabled,
 				:batch_fulfillment_gas_multiplier, :backoff_initial_delay, :backoff_max_delay, :gas_lane_price,
 				NOW(), NOW())
@@ -370,10 +371,10 @@ func (o *orm) CreateJob(jb *Job, qopts ...pg.QOpt) error {
 		case Bootstrap:
 			var specID int32
 			sql := `INSERT INTO bootstrap_specs (contract_id, relay, relay_config, monitoring_endpoint,
-					blockchain_timeout, contract_config_tracker_poll_interval, 
+					blockchain_timeout, contract_config_tracker_poll_interval,
 					contract_config_confirmations, created_at, updated_at)
-			VALUES (:contract_id, :relay, :relay_config, :monitoring_endpoint, 
-					:blockchain_timeout, :contract_config_tracker_poll_interval, 
+			VALUES (:contract_id, :relay, :relay_config, :monitoring_endpoint,
+					:blockchain_timeout, :contract_config_tracker_poll_interval,
 					:contract_config_confirmations, NOW(), NOW())
 			RETURNING id;`
 			if err := pg.PrepareQueryRowx(tx, sql, &specID, jb.BootstrapSpec); err != nil {


### PR DESCRIPTION
When a new job proposal is received and an existing unmanaged job is running with the same contract address, the node will delete the running job and start the new managed job received from FMS. If the new job does not have the correct bridges set up, it would rollback the transaction, causing the unmanaged job to be removed from the runner but still exist in the DB.

This change fixes this by validating the bridges exist for the managed job before attempting to delete the existing unmanaged job.