### PR TITLE
core/web: reduce router log level from info to debug

### DIFF
--- a/core/web/router.go
+++ b/core/web/router.go
@@ -532,7 +532,7 @@ func loggerFunc(lggr logger.Logger) gin.HandlerFunc {
 		c.Next()
 		end := time.Now()
 
-		lggr.Infow(fmt.Sprintf("%s %s", c.Request.Method, c.Request.URL.Path),
+		lggr.Debugw(fmt.Sprintf("%s %s", c.Request.Method, c.Request.URL.Path),
 			"method", c.Request.Method,
 			"status", c.Writer.Status(),
 			"path", c.Request.URL.Path,


### PR DESCRIPTION
Logging every web request at info level seems awfully noisy, and in practice I often have to filter these messages out to see past them.