### PR TITLE
Add stale PR management to core chainlink

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,15 @@
+name: 'Close stale issues and PRs'
+on:
+  schedule:
+    - cron: "0 0 * * *" # Will be triggered every day at midnight UTC
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@5ebf00ea0e4c1561e9b43a292ed34424fb1d4578 # v6.0.1
+        with:
+          exempt-all-pr-assignees: true
+          stale-pr-message: 'This PR is stale because it has been open 60 days with no activity. Remove stale label or comment or this will be closed in 7 days.'
+          days-before-issue-stale: -1 # disables marking issues as stale automatically. Issues can still be marked as stale manually, in which the closure policy applies.
+


### PR DESCRIPTION
This PR adds stale PRs management policies as following:
- Workflow is triggered daily midnight UTC
- A PR with more than 60 days of inactivity will be marked as stale
- A PR that's stale for more than 7 days will be automatically closed
- Issues are exempt from auto marking as stale but issues with manually added 'stale' label are eligible for auto closure after 7 days.
- PRs with assignees are exempt from auto stale marking, it's the responsibility of the assignee to get the PR progressed either with review/merge or closure.