### PR TITLE
sonar-project.properties: ignore some rules

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,3 +12,42 @@ sonar.cpd.exclusions=**/contracts/**/*.sol
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go, **/*.test.ts
 sonar.test.exclusions=**/integration-tests/**/*
+
+# Ignored Rules
+sonar.issue.ignore.multicriteria=e1,e2,e3,e4,e5,e6
+# https://rules.sonarsource.com/plsql/RSPEC-1590
+# > "DELETE" and "UPDATE" statements should contain "WHERE" clauses
+# This incorrectly matches on too many schema managment statements to be useful.
+sonar.issue.ignore.multicriteria.e1.ruleKey=plsql:DeleteOrUpdateWithoutWhereCheck
+sonar.issue.ignore.multicriteria.e1.resourceKey=**/*
+# https://rules.sonarsource.com/plsql/RSPEC-2545
+# > Size should be specified for string variables
+# Omitting aparently does not in fact cause an exception as claimed.
+sonar.issue.ignore.multicriteria.e2.ruleKey=plsql:SizeConstraintMissingCheck
+sonar.issue.ignore.multicriteria.e2.resourceKey=**/*
+# https://rules.sonarsource.com/go/RSPEC-126
+# > "if ... else if" constructs should end with "else" clauses
+# This is misguided and also in conflict with other rules (increases complexity/indentation).
+#
+# See CockroachDB's guide for some examples and justification of why the *opposite* is preferred:
+# https://wiki.crdb.io/wiki/spaces/CRDB/pages/181371303/Go+Golang+coding+guidelines#Reduce-Nesting
+# https://wiki.crdb.io/wiki/spaces/CRDB/pages/181371303/Go+Golang+coding+guidelines#Unnecessary-Else
+sonar.issue.ignore.multicriteria.e3.ruleKey=go:S126
+sonar.issue.ignore.multicriteria.e3.resourceKey=**/*
+# https://rules.sonarsource.com/go/RSPEC-131
+# > "switch" statements should have "default" clauses
+# This is too blunt of a rule to apply generally, for similar reason to S126, and is also already covered in
+# more sophisticated ways by golangci-lint tools.
+sonar.issue.ignore.multicriteria.e4.ruleKey=go:S131
+sonar.issue.ignore.multicriteria.e4.resourceKey=**/*
+# https://rules.sonarsource.com/go/RSPEC-1186
+# > Functions should not be empty
+# This is too general to be helpful. Context from receiver type, func/method name or godoc are sufficient and preferred.
+sonar.issue.ignore.multicriteria.e5.ruleKey=go:S1186
+sonar.issue.ignore.multicriteria.e5.resourceKey=**/*
+# https://rules.sonarsource.com/go/RSPEC-1821
+# > "switch" statements should not be nested
+# Nested switch statements are not problematic on their own, especially in Go, and complex or over-indented cases are covered by other rules.
+# > Go's switch is like the one in C, C++, Java, JavaScript, and PHP, except that Go only runs the selected case, not all the cases that follow.
+sonar.issue.ignore.multicriteria.e6.ruleKey=go:S1821
+sonar.issue.ignore.multicriteria.e6.resourceKey=**/*


### PR DESCRIPTION
This change proposes ignoring some sonar rules globally.
https://sonarqube.main.prod.cldev.sh/dashboard?branch=sonar-ignore&id=smartcontractkit_chainlink
We may not actually merge this to apply the change, but it demonstrates the effects for review.