### PR TITLE
core/web: return best-effort ETHKeyResource instead of failing

### DIFF
--- a/core/assets/currencies.go
+++ b/core/assets/currencies.go
@@ -227,6 +227,9 @@ func (e *Eth) Cmp(y *Eth) int {
 }
 
 func (e *Eth) String() string {
+	if e == nil {
+		return "<nil>"
+	}
 	return format(e.ToInt(), 18)
 }
 

--- a/core/cmd/eth_keys_commands_test.go
+++ b/core/cmd/eth_keys_commands_test.go
@@ -10,6 +10,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/pkg/errors"
+
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/cmd"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
@@ -51,7 +53,7 @@ func TestEthKeysPresenter_RenderTable(t *testing.T) {
 			Disabled:       isDisabled,
 			CreatedAt:      createdAt,
 			UpdatedAt:      updatedAt,
-			MaxGasPriceWei: *maxGasPriceWei,
+			MaxGasPriceWei: maxGasPriceWei,
 		},
 	}
 
@@ -87,7 +89,7 @@ func TestClient_ListETHKeys(t *testing.T) {
 
 	ethClient := newEthMock(t)
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(big.NewInt(42), nil)
-	ethClient.On("GetLINKBalance", mock.Anything, mock.Anything, mock.Anything).Return(assets.NewLinkFromJuels(42), nil)
+	ethClient.On("GetLINKBalance", mock.Anything, mock.Anything, mock.Anything).Return(assets.NewLinkFromJuels(13), nil)
 	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].Enabled = ptr(true)
 		c.EVM[0].NonceAutoSync = ptr(false)
@@ -102,6 +104,61 @@ func TestClient_ListETHKeys(t *testing.T) {
 	require.Equal(t, 1, len(r.Renders))
 	balances := *r.Renders[0].(*cmd.EthKeyPresenters)
 	assert.Equal(t, app.Keys[0].Address.Hex(), balances[0].Address)
+	assert.Equal(t, "0.000000000000000042", balances[0].EthBalance.String())
+	assert.Equal(t, "13", balances[0].LinkBalance.String())
+}
+
+func TestClient_ListETHKeys_Error(t *testing.T) {
+	t.Parallel()
+
+	ethClient := newEthMock(t)
+	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("fake error"))
+	ethClient.On("GetLINKBalance", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("fake error"))
+	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].Enabled = ptr(true)
+		c.EVM[0].NonceAutoSync = ptr(false)
+		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
+	},
+		withKey(),
+		withMocks(ethClient),
+	)
+	client, r := app.NewClientAndRenderer()
+
+	assert.Nil(t, client.ListETHKeys(cltest.EmptyCLIContext()))
+	require.Equal(t, 1, len(r.Renders))
+	balances := *r.Renders[0].(*cmd.EthKeyPresenters)
+	assert.Equal(t, app.Keys[0].Address.Hex(), balances[0].Address)
+	assert.Nil(t, balances[0].EthBalance)
+	assert.Nil(t, balances[0].LinkBalance)
+}
+
+func TestClient_ListETHKeys_Disabled(t *testing.T) {
+	t.Parallel()
+
+	ethClient := newEthMock(t)
+	app := startNewApplicationV2(t, func(c *chainlink.Config, s *chainlink.Secrets) {
+		c.EVM[0].Enabled = ptr(false)
+	},
+		withKey(),
+		withMocks(ethClient),
+	)
+	client, r := app.NewClientAndRenderer()
+	keys, err := app.KeyStore.Eth().GetAll()
+	require.NoError(t, err)
+	require.Equal(t, 1, len(keys))
+	k := keys[0]
+
+	assert.Nil(t, client.ListETHKeys(cltest.EmptyCLIContext()))
+	require.Equal(t, 1, len(r.Renders))
+	balances := *r.Renders[0].(*cmd.EthKeyPresenters)
+	assert.Equal(t, app.Keys[0].Address.Hex(), balances[0].Address)
+	assert.Nil(t, balances[0].EthBalance)
+	assert.Nil(t, balances[0].LinkBalance)
+	assert.Nil(t, balances[0].MaxGasPriceWei)
+	assert.Equal(t, []string{
+		k.Address.String(), "0", "0", "<nil>", "0", "false",
+		balances[0].UpdatedAt.String(), balances[0].CreatedAt.String(), "<nil>",
+	}, balances[0].ToRow())
 }
 
 func TestClient_CreateETHKey(t *testing.T) {

--- a/core/web/eth_keys_controller.go
+++ b/core/web/eth_keys_controller.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/chains/evm"
+	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/logger/audit"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/keys/ethkey"
@@ -25,7 +26,15 @@ import (
 
 // ETHKeysController manages account keys
 type ETHKeysController struct {
-	App chainlink.Application
+	app  chainlink.Application
+	lggr logger.Logger
+}
+
+func NewETHKeysController(app chainlink.Application) *ETHKeysController {
+	return &ETHKeysController{
+		app:  app,
+		lggr: app.GetLogger().Named("ETHKeysController"),
+	}
 }
 
 // Index returns the node's Ethereum keys and the account balances of ETH & LINK.
@@ -33,7 +42,7 @@ type ETHKeysController struct {
 //
 //	"<application>/keys/eth"
 func (ekc *ETHKeysController) Index(c *gin.Context) {
-	ethKeyStore := ekc.App.GetKeyStore().Eth()
+	ethKeyStore := ekc.app.GetKeyStore().Eth()
 	var keys []ethkey.KeyV2
 	var err error
 	keys, err = ethKeyStore.GetAll()
@@ -55,15 +64,12 @@ func (ekc *ETHKeysController) Index(c *gin.Context) {
 			jsonAPIError(c, http.StatusInternalServerError, err)
 			return
 		}
-		r, err := presenters.NewETHKeyResource(key, state,
+
+		r := presenters.NewETHKeyResource(key, state,
 			ekc.setEthBalance(c.Request.Context(), state),
 			ekc.setLinkBalance(c.Request.Context(), state),
 			ekc.setKeyMaxGasPriceWei(state, key.Address),
 		)
-		if err != nil {
-			jsonAPIError(c, http.StatusInternalServerError, err)
-			return
-		}
 
 		resources = append(resources, *r)
 	}
@@ -80,9 +86,9 @@ func (ekc *ETHKeysController) Index(c *gin.Context) {
 //
 //	"<application>/keys/eth"
 func (ekc *ETHKeysController) Create(c *gin.Context) {
-	ethKeyStore := ekc.App.GetKeyStore().Eth()
+	ethKeyStore := ekc.app.GetKeyStore().Eth()
 
-	chain, err := getChain(ekc.App.GetChains().EVM, c.Query("evmChainID"))
+	chain, err := getChain(ekc.app.GetChains().EVM, c.Query("evmChainID"))
 	switch err {
 	case ErrInvalidChainID, ErrMultipleChains, ErrMissingChainID:
 		jsonAPIError(c, http.StatusUnprocessableEntity, err)
@@ -111,7 +117,7 @@ func (ekc *ETHKeysController) Create(c *gin.Context) {
 	if maxGasPriceGWei > 0 {
 		maxGasPriceWei := assets.GWei(maxGasPriceGWei)
 		updateMaxGasPrice := evm.UpdateKeySpecificMaxGasPrice(key.Address, maxGasPriceWei)
-		if err = ekc.App.GetChains().EVM.UpdateConfig(chain.ID(), updateMaxGasPrice); err != nil {
+		if err = ekc.app.GetChains().EVM.UpdateConfig(chain.ID(), updateMaxGasPrice); err != nil {
 			jsonAPIError(c, http.StatusInternalServerError, err)
 			return
 		}
@@ -122,17 +128,13 @@ func (ekc *ETHKeysController) Create(c *gin.Context) {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
 	}
-	r, err := presenters.NewETHKeyResource(key, state,
+	r := presenters.NewETHKeyResource(key, state,
 		ekc.setEthBalance(c.Request.Context(), state),
 		ekc.setLinkBalance(c.Request.Context(), state),
 		ekc.setKeyMaxGasPriceWei(state, key.Address),
 	)
-	if err != nil {
-		jsonAPIError(c, http.StatusInternalServerError, err)
-		return
-	}
 
-	ekc.App.GetAuditLogger().Audit(audit.KeyCreated, map[string]interface{}{
+	ekc.app.GetAuditLogger().Audit(audit.KeyCreated, map[string]interface{}{
 		"type": "ethereum",
 		"id":   key.ID(),
 	})
@@ -144,7 +146,7 @@ func (ekc *ETHKeysController) Create(c *gin.Context) {
 // Example:
 // "PUT <application>/keys/eth/:keyID?maxGasPriceGWei=12345"
 func (ekc *ETHKeysController) Update(c *gin.Context) {
-	ethKeyStore := ekc.App.GetKeyStore().Eth()
+	ethKeyStore := ekc.app.GetKeyStore().Eth()
 
 	if c.Query("maxGasPriceGWei") == "" {
 		jsonAPIError(c, http.StatusUnprocessableEntity, errors.New("no parameters passed to update"))
@@ -157,7 +159,7 @@ func (ekc *ETHKeysController) Update(c *gin.Context) {
 		return
 	}
 
-	chain, err := getChain(ekc.App.GetChains().EVM, c.Query("evmChainID"))
+	chain, err := getChain(ekc.app.GetChains().EVM, c.Query("evmChainID"))
 	if errors.Is(err, ErrInvalidChainID) || errors.Is(err, ErrMultipleChains) || errors.Is(err, ErrMissingChainID) {
 		jsonAPIError(c, http.StatusUnprocessableEntity, err)
 		return
@@ -181,22 +183,18 @@ func (ekc *ETHKeysController) Update(c *gin.Context) {
 
 	maxGasPriceWei := assets.GWei(maxGasPriceGWei)
 	updateMaxGasPrice := evm.UpdateKeySpecificMaxGasPrice(key.Address, maxGasPriceWei)
-	if err = ekc.App.GetChains().EVM.UpdateConfig((*big.Int)(&state.EVMChainID), updateMaxGasPrice); err != nil {
+	if err = ekc.app.GetChains().EVM.UpdateConfig((*big.Int)(&state.EVMChainID), updateMaxGasPrice); err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
 	}
 
-	r, err := presenters.NewETHKeyResource(key, state,
+	r := presenters.NewETHKeyResource(key, state,
 		ekc.setEthBalance(c.Request.Context(), state),
 		ekc.setLinkBalance(c.Request.Context(), state),
 		ekc.setKeyMaxGasPriceWei(state, key.Address),
 	)
-	if err != nil {
-		jsonAPIError(c, http.StatusInternalServerError, err)
-		return
-	}
 
-	ekc.App.GetAuditLogger().Audit(audit.KeyUpdated, map[string]interface{}{
+	ekc.app.GetAuditLogger().Audit(audit.KeyUpdated, map[string]interface{}{
 		"type": "ethereum",
 		"id":   keyID,
 	})
@@ -209,7 +207,7 @@ func (ekc *ETHKeysController) Update(c *gin.Context) {
 // "DELETE <application>/keys/eth/:keyID"
 // "DELETE <application>/keys/eth/:keyID?hard=true"
 func (ekc *ETHKeysController) Delete(c *gin.Context) {
-	ethKeyStore := ekc.App.GetKeyStore().Eth()
+	ethKeyStore := ekc.app.GetKeyStore().Eth()
 	var hardDelete bool
 	var err error
 
@@ -238,7 +236,7 @@ func (ekc *ETHKeysController) Delete(c *gin.Context) {
 		return
 	}
 
-	ekc.App.GetAuditLogger().Audit(audit.KeyDeleted, map[string]interface{}{
+	ekc.app.GetAuditLogger().Audit(audit.KeyDeleted, map[string]interface{}{
 		"type": "ethereum",
 		"id":   keyID,
 	})
@@ -247,8 +245,8 @@ func (ekc *ETHKeysController) Delete(c *gin.Context) {
 
 // Import imports a key
 func (ekc *ETHKeysController) Import(c *gin.Context) {
-	ethKeyStore := ekc.App.GetKeyStore().Eth()
-	defer ekc.App.GetLogger().ErrorIfClosing(c.Request.Body, "Import request body")
+	ethKeyStore := ekc.app.GetKeyStore().Eth()
+	defer ekc.app.GetLogger().ErrorIfClosing(c.Request.Body, "Import request body")
 
 	bytes, err := io.ReadAll(c.Request.Body)
 	if err != nil {
@@ -256,7 +254,7 @@ func (ekc *ETHKeysController) Import(c *gin.Context) {
 		return
 	}
 	oldPassword := c.Query("oldpassword")
-	chain, err := getChain(ekc.App.GetChains().EVM, c.Query("evmChainID"))
+	chain, err := getChain(ekc.app.GetChains().EVM, c.Query("evmChainID"))
 	switch err {
 	case ErrInvalidChainID, ErrMultipleChains, ErrMissingChainID:
 		jsonAPIError(c, http.StatusUnprocessableEntity, err)
@@ -280,16 +278,12 @@ func (ekc *ETHKeysController) Import(c *gin.Context) {
 		return
 	}
 
-	r, err := presenters.NewETHKeyResource(key, state,
+	r := presenters.NewETHKeyResource(key, state,
 		ekc.setEthBalance(c.Request.Context(), state),
 		ekc.setLinkBalance(c.Request.Context(), state),
 	)
-	if err != nil {
-		jsonAPIError(c, http.StatusInternalServerError, err)
-		return
-	}
 
-	ekc.App.GetAuditLogger().Audit(audit.KeyImported, map[string]interface{}{
+	ekc.app.GetAuditLogger().Audit(audit.KeyImported, map[string]interface{}{
 		"type": "ethereum",
 		"id":   key.ID(),
 	})
@@ -298,18 +292,18 @@ func (ekc *ETHKeysController) Import(c *gin.Context) {
 }
 
 func (ekc *ETHKeysController) Export(c *gin.Context) {
-	defer ekc.App.GetLogger().ErrorIfClosing(c.Request.Body, "Export request body")
+	defer ekc.app.GetLogger().ErrorIfClosing(c.Request.Body, "Export request body")
 
 	id := c.Param("address")
 	newPassword := c.Query("newpassword")
 
-	bytes, err := ekc.App.GetKeyStore().Eth().Export(id, newPassword)
+	bytes, err := ekc.app.GetKeyStore().Eth().Export(id, newPassword)
 	if err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
 	}
 
-	ekc.App.GetAuditLogger().Audit(audit.KeyExported, map[string]interface{}{
+	ekc.app.GetAuditLogger().Audit(audit.KeyExported, map[string]interface{}{
 		"type": "ethereum",
 		"id":   id,
 	})
@@ -319,8 +313,8 @@ func (ekc *ETHKeysController) Export(c *gin.Context) {
 
 // Chain updates settings for a given chain for the key
 func (ekc *ETHKeysController) Chain(c *gin.Context) {
-	kst := ekc.App.GetKeyStore().Eth()
-	defer ekc.App.GetLogger().ErrorIfClosing(c.Request.Body, "Import request body")
+	kst := ekc.app.GetKeyStore().Eth()
+	defer ekc.app.GetLogger().ErrorIfClosing(c.Request.Body, "Import request body")
 
 	addressHex := c.Query("address")
 	addressBytes, err := hexutil.Decode(addressHex)
@@ -331,7 +325,7 @@ func (ekc *ETHKeysController) Chain(c *gin.Context) {
 	address := common.BytesToAddress(addressBytes)
 
 	cid := c.Query("evmChainID")
-	chain, err := getChain(ekc.App.GetChains().EVM, cid)
+	chain, err := getChain(ekc.app.GetChains().EVM, cid)
 	if errors.Is(err, ErrInvalidChainID) || errors.Is(err, ErrMultipleChains) || errors.Is(err, ErrMissingChainID) {
 		jsonAPIError(c, http.StatusUnprocessableEntity, err)
 		return
@@ -404,14 +398,10 @@ func (ekc *ETHKeysController) Chain(c *gin.Context) {
 		return
 	}
 
-	r, err := presenters.NewETHKeyResource(key, state,
+	r := presenters.NewETHKeyResource(key, state,
 		ekc.setEthBalance(c.Request.Context(), state),
 		ekc.setLinkBalance(c.Request.Context(), state),
 	)
-	if err != nil {
-		jsonAPIError(c, http.StatusInternalServerError, err)
-		return
-	}
 
 	jsonAPIResponse(c, r, "account")
 }
@@ -421,24 +411,20 @@ func (ekc *ETHKeysController) Chain(c *gin.Context) {
 // resource.
 func (ekc *ETHKeysController) setEthBalance(ctx context.Context, state ethkey.State) presenters.NewETHKeyOption {
 	var bal *big.Int
-	chain, err := ekc.App.GetChains().EVM.Get(state.EVMChainID.ToInt())
-	if err == nil {
+	chainID := state.EVMChainID.ToInt()
+	chain, err := ekc.app.GetChains().EVM.Get(chainID)
+	if err != nil {
+		if !errors.Is(errors.Cause(err), evm.ErrNoChains) {
+			ekc.lggr.Errorw("Failed to get EVM Chain", "chainID", chainID, "address", state.Address, "error", err)
+		}
+	} else {
 		ethClient := chain.Client()
 		bal, err = ethClient.BalanceAt(ctx, state.Address.Address(), nil)
-	}
-	return func(r *presenters.ETHKeyResource) error {
-		if errors.Is(errors.Cause(err), evm.ErrNoChains) {
-			return nil
-		}
-
 		if err != nil {
-			return errors.Errorf("error calling getEthBalance on Ethereum node: %v", err)
+			ekc.lggr.Errorw("Failed to get ETH balance", "chainID", chainID, "address", state.Address, "error", err)
 		}
-
-		r.EthBalance = (*assets.Eth)(bal)
-
-		return nil
 	}
+	return presenters.SetETHKeyEthBalance((*assets.Eth)(bal))
 }
 
 // setLinkBalance is a custom functional option for NewEthKeyResource which
@@ -446,25 +432,21 @@ func (ekc *ETHKeysController) setEthBalance(ctx context.Context, state ethkey.St
 // resource.
 func (ekc *ETHKeysController) setLinkBalance(ctx context.Context, state ethkey.State) presenters.NewETHKeyOption {
 	var bal *assets.Link
-	chain, err := ekc.App.GetChains().EVM.Get(state.EVMChainID.ToInt())
-	if err == nil {
+	chainID := state.EVMChainID.ToInt()
+	chain, err := ekc.app.GetChains().EVM.Get(chainID)
+	if err != nil {
+		if !errors.Is(errors.Cause(err), evm.ErrNoChains) {
+			ekc.lggr.Errorw("Failed to get EVM Chain", "chainID", chainID, "error", err)
+		}
+	} else {
 		ethClient := chain.Client()
 		addr := common.HexToAddress(chain.Config().LinkContractAddress())
 		bal, err = ethClient.GetLINKBalance(ctx, addr, state.Address.Address())
-	}
-
-	return func(r *presenters.ETHKeyResource) error {
-		if errors.Is(errors.Cause(err), evm.ErrNoChains) {
-			return nil
-		}
 		if err != nil {
-			return errors.Errorf("error calling getLINKBalance on Ethereum node: %v", err)
+			ekc.lggr.Errorw("Failed to get LINK balance", "chainID", chainID, "address", state.Address, "error", err)
 		}
-
-		r.LinkBalance = bal
-
-		return nil
 	}
+	return presenters.SetETHKeyLinkBalance(bal)
 }
 
 // setKeyMaxGasPriceWei is a custom functional option for NewEthKeyResource which
@@ -472,21 +454,14 @@ func (ekc *ETHKeysController) setLinkBalance(ctx context.Context, state ethkey.S
 // resource.
 func (ekc *ETHKeysController) setKeyMaxGasPriceWei(state ethkey.State, keyAddress common.Address) presenters.NewETHKeyOption {
 	var price *assets.Wei
-	chain, err := ekc.App.GetChains().EVM.Get(state.EVMChainID.ToInt())
-	if err == nil {
+	chainID := state.EVMChainID.ToInt()
+	chain, err := ekc.app.GetChains().EVM.Get(chainID)
+	if err != nil {
+		if !errors.Is(errors.Cause(err), evm.ErrNoChains) {
+			ekc.lggr.Errorw("Failed to get EVM Chain", "chainID", chainID, "error", err)
+		}
+	} else {
 		price = chain.Config().KeySpecificMaxGasPriceWei(keyAddress)
 	}
-
-	return func(r *presenters.ETHKeyResource) error {
-		if errors.Is(errors.Cause(err), evm.ErrNoChains) {
-			return nil
-		}
-		if err != nil {
-			return errors.Errorf("error getting EVM Chain: %v", err)
-		}
-
-		r.MaxGasPriceWei = *utils.NewBig(price.ToInt())
-
-		return nil
-	}
+	return presenters.SetETHKeyMaxGasPriceWei(utils.NewBig(price.ToInt()))
 }

--- a/core/web/presenters/eth_key.go
+++ b/core/web/presenters/eth_key.go
@@ -20,7 +20,7 @@ type ETHKeyResource struct {
 	Disabled       bool         `json:"disabled"`
 	CreatedAt      time.Time    `json:"createdAt"`
 	UpdatedAt      time.Time    `json:"updatedAt"`
-	MaxGasPriceWei utils.Big    `json:"maxGasPriceWei"`
+	MaxGasPriceWei *utils.Big   `json:"maxGasPriceWei"`
 }
 
 // GetName implements the api2go EntityNamer interface
@@ -33,12 +33,12 @@ func (r ETHKeyResource) GetName() string {
 
 // NewETHKeyOption defines a functional option which allows customisation of the
 // EthKeyResource
-type NewETHKeyOption func(*ETHKeyResource) error
+type NewETHKeyOption func(*ETHKeyResource)
 
 // NewETHKeyResource constructs a new ETHKeyResource from a Key.
 //
 // Use the functional options to inject the ETH and LINK balances
-func NewETHKeyResource(k ethkey.KeyV2, state ethkey.State, opts ...NewETHKeyOption) (*ETHKeyResource, error) {
+func NewETHKeyResource(k ethkey.KeyV2, state ethkey.State, opts ...NewETHKeyOption) *ETHKeyResource {
 	r := &ETHKeyResource{
 		JAID:        NewJAID(k.Address.Hex()),
 		EVMChainID:  state.EVMChainID,
@@ -52,36 +52,26 @@ func NewETHKeyResource(k ethkey.KeyV2, state ethkey.State, opts ...NewETHKeyOpti
 	}
 
 	for _, opt := range opts {
-		err := opt(r)
-
-		if err != nil {
-			return nil, err
-		}
+		opt(r)
 	}
 
-	return r, nil
+	return r
 }
 
 func SetETHKeyEthBalance(ethBalance *assets.Eth) NewETHKeyOption {
-	return func(r *ETHKeyResource) error {
+	return func(r *ETHKeyResource) {
 		r.EthBalance = ethBalance
-
-		return nil
 	}
 }
 
 func SetETHKeyLinkBalance(linkBalance *assets.Link) NewETHKeyOption {
-	return func(r *ETHKeyResource) error {
+	return func(r *ETHKeyResource) {
 		r.LinkBalance = linkBalance
-
-		return nil
 	}
 }
 
-func SetETHKeyMaxGasPriceWei(maxGasPriceWei utils.Big) NewETHKeyOption {
-	return func(r *ETHKeyResource) error {
+func SetETHKeyMaxGasPriceWei(maxGasPriceWei *utils.Big) NewETHKeyOption {
+	return func(r *ETHKeyResource) {
 		r.MaxGasPriceWei = maxGasPriceWei
-
-		return nil
 	}
 }

--- a/core/web/presenters/eth_key_test.go
+++ b/core/web/presenters/eth_key_test.go
@@ -38,16 +38,15 @@ func TestETHKeyResource(t *testing.T) {
 		Disabled:   true,
 	}
 
-	r, err := NewETHKeyResource(key, state,
+	r := NewETHKeyResource(key, state,
 		SetETHKeyEthBalance(assets.NewEth(1)),
 		SetETHKeyLinkBalance(assets.NewLinkFromJuels(1)),
-		SetETHKeyMaxGasPriceWei(*utils.NewBigI(12345)),
+		SetETHKeyMaxGasPriceWei(utils.NewBigI(12345)),
 	)
-	require.NoError(t, err)
 
 	assert.Equal(t, assets.NewEth(1), r.EthBalance)
 	assert.Equal(t, assets.NewLinkFromJuels(1), r.LinkBalance)
-	assert.Equal(t, *utils.NewBigI(12345), r.MaxGasPriceWei)
+	assert.Equal(t, utils.NewBigI(12345), r.MaxGasPriceWei)
 
 	b, err := jsonapi.Marshal(r)
 	require.NoError(t, err)
@@ -74,12 +73,11 @@ func TestETHKeyResource(t *testing.T) {
 
 	assert.JSONEq(t, expected, string(b))
 
-	r, err = NewETHKeyResource(key, state,
-		SetETHKeyEthBalance(assets.NewEth(1)),
-		SetETHKeyLinkBalance(assets.NewLinkFromJuels(1)),
-		SetETHKeyMaxGasPriceWei(*utils.NewBigI(12345)),
+	r = NewETHKeyResource(key, state,
+		SetETHKeyEthBalance(nil),
+		SetETHKeyLinkBalance(nil),
+		SetETHKeyMaxGasPriceWei(nil),
 	)
-	require.NoError(t, err)
 	b, err = jsonapi.Marshal(r)
 	require.NoError(t, err)
 
@@ -92,12 +90,12 @@ func TestETHKeyResource(t *testing.T) {
 				"address":"%s",
 			  	"evmChainID":"42",
 			    "nextNonce": 99,
-				"ethBalance":"1",
-				"linkBalance":"1",
+				"ethBalance":null,
+				"linkBalance":null,
 				"disabled":true,
 				"createdAt":"2000-01-01T00:00:00Z",
 				"updatedAt":"2000-01-01T00:00:00Z",
-				"maxGasPriceWei":"12345"
+				"maxGasPriceWei":null
 			}
 		}
 	}`,

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -289,7 +289,7 @@ func v2Routes(app chainlink.Application, r *gin.RouterGroup) {
 		authv2.POST("/keys/csa/import", auth.RequiresAdminRole(csakc.Import))
 		authv2.POST("/keys/csa/export/:ID", auth.RequiresAdminRole(csakc.Export))
 
-		ekc := ETHKeysController{app}
+		ekc := NewETHKeysController(app)
 		authv2.GET("/keys/eth", ekc.Index)
 		authv2.POST("/keys/eth", auth.RequiresEditRole(ekc.Create))
 		authv2.PUT("/keys/eth/:keyID", auth.RequiresAdminRole(ekc.Update))


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/QA-197

Return a best-effort, partial result when unable to fill in ETHKeyResource completely, so that we are not blocked from reading local data when external resources are down.