### PR TITLE
Extend Nethermind error messages

### DIFF
--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -167,13 +167,16 @@ var klaytn = ClientErrors{
 // Nethermind
 // All errors: https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.TxPool/AcceptTxResult.cs
 // All filters: https://github.com/NethermindEth/nethermind/tree/9b68ec048c65f4b44fb863164c0dec3f7780d820/src/Nethermind/Nethermind.TxPool/Filters
-var nethermindFatal = regexp.MustCompile(`(: |^)(SenderIsContract|Invalid|Int256Overflow|FailedToResolveSender|GasLimitExceeded)$`)
+var nethermindFatal = regexp.MustCompile(`(: |^)(SenderIsContract|Invalid(, transaction Hash is null)?|Int256Overflow|FailedToResolveSender|GasLimitExceeded(, Gas limit: \d+, gas limit of rejected tx: \d+)?|NonceGap(, Future nonce. Expected nonce: \d+)?)$`)
 var nethermind = ClientErrors{
 	// OldNonce: The EOA (externally owned account) that signed this transaction (sender) has already signed and executed a transaction with the same nonce.
-	NonceTooLow: regexp.MustCompile(`(: |^)OldNonce$`),
+	NonceTooLow: regexp.MustCompile(`(: |^)OldNonce(, Current nonce: \d+, nonce of rejected tx: \d+)?$`),
 
 	// FeeTooLow/FeeTooLowToCompete: Fee paid by this transaction is not enough to be accepted in the mempool.
-	TerminallyUnderpriced: regexp.MustCompile(`(: |^)(FeeTooLow|FeeTooLowToCompete)$`),
+	TerminallyUnderpriced: regexp.MustCompile(`(: |^)(FeeTooLow(, MaxFeePerGas too low. MaxFeePerGas: \d+, BaseFee: \d+, MaxPriorityFeePerGas:\d+, Block number: \d+|` +
+		`, EffectivePriorityFeePerGas too low \d+ < \d+, BaseFee: \d+|` +
+		`, FeePerGas needs to be higher than \d+ to be added to the TxPool. Affordable FeePerGas of rejected tx: \d+.)?|` +
+		`FeeTooLowToCompete)$`),
 
 	// AlreadyKnown: A transaction with the same hash has already been added to the pool in the past.
 	// OwnNonceAlreadyUsed: A transaction with same nonce has been signed locally already and is awaiting in the pool.

--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -36,6 +36,9 @@ func (s *SendError) CauseStr() string {
 
 const (
 	NonceTooLow = iota
+	// Nethermind specific error. Nethermind throws a NonceGap error when the tx nonce is greater than current_nonce + tx_count_in_mempool, instead of keeping the tx in mempool.
+	// See: https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.TxPool/Filters/GapNonceFilter.cs
+	NonceTooHigh
 	ReplacementTransactionUnderpriced
 	LimitReached
 	TransactionAlreadyInMempool
@@ -167,10 +170,11 @@ var klaytn = ClientErrors{
 // Nethermind
 // All errors: https://github.com/NethermindEth/nethermind/blob/master/src/Nethermind/Nethermind.TxPool/AcceptTxResult.cs
 // All filters: https://github.com/NethermindEth/nethermind/tree/9b68ec048c65f4b44fb863164c0dec3f7780d820/src/Nethermind/Nethermind.TxPool/Filters
-var nethermindFatal = regexp.MustCompile(`(: |^)(SenderIsContract|Invalid(, transaction Hash is null)?|Int256Overflow|FailedToResolveSender|GasLimitExceeded(, Gas limit: \d+, gas limit of rejected tx: \d+)?|NonceGap(, Future nonce. Expected nonce: \d+)?)$`)
+var nethermindFatal = regexp.MustCompile(`(: |^)(SenderIsContract|Invalid(, transaction Hash is null)?|Int256Overflow|FailedToResolveSender|GasLimitExceeded(, Gas limit: \d+, gas limit of rejected tx: \d+)?)$`)
 var nethermind = ClientErrors{
 	// OldNonce: The EOA (externally owned account) that signed this transaction (sender) has already signed and executed a transaction with the same nonce.
-	NonceTooLow: regexp.MustCompile(`(: |^)OldNonce(, Current nonce: \d+, nonce of rejected tx: \d+)?$`),
+	NonceTooLow:  regexp.MustCompile(`(: |^)OldNonce(, Current nonce: \d+, nonce of rejected tx: \d+)?$`),
+	NonceTooHigh: regexp.MustCompile(`(: |^)NonceGap(, Future nonce. Expected nonce: \d+)?$`),
 
 	// FeeTooLow/FeeTooLowToCompete: Fee paid by this transaction is not enough to be accepted in the mempool.
 	TerminallyUnderpriced: regexp.MustCompile(`(: |^)(FeeTooLow(, MaxFeePerGas too low. MaxFeePerGas: \d+, BaseFee: \d+, MaxPriorityFeePerGas:\d+, Block number: \d+|` +
@@ -222,6 +226,10 @@ func (s *SendError) IsReplacementUnderpriced() bool {
 
 func (s *SendError) IsNonceTooLowError() bool {
 	return s.is(NonceTooLow)
+}
+
+func (s *SendError) IsNonceTooHighError() bool {
+	return s.is(NonceTooHigh)
 }
 
 // IsTransactionAlreadyMined - Harmony returns this error if the transaction has already been mined

--- a/core/chains/evm/client/errors_test.go
+++ b/core/chains/evm/client/errors_test.go
@@ -40,6 +40,7 @@ func Test_Eth_Errors(t *testing.T) {
 			{"invalid transaction: nonce too low", true, "Optimism"},
 			{"call failed: nonce too low: address 0x0499BEA33347cb62D79A9C0b1EDA01d8d329894c current nonce (5833) > tx nonce (5511)", true, "Avalanche"},
 			{"call failed: OldNonce", true, "Nethermind"},
+			{"call failed: OldNonce, Current nonce: 22, nonce of rejected tx: 17", true, "Nethermind"},
 		}
 
 		for _, test := range tests {
@@ -128,6 +129,9 @@ func Test_Eth_Errors(t *testing.T) {
 			{"Transaction gas price is too low. It does not satisfy your node's minimal gas price (minimal: 100 got: 50). Try increasing the gas price.", true, "Parity"},
 			{"gas price too low", true, "Arbitrum"},
 			{"FeeTooLow", true, "Nethermind"},
+			{"FeeTooLow, MaxFeePerGas too low. MaxFeePerGas: 50, BaseFee: 100, MaxPriorityFeePerGas:200, Block number: 5", true, "Nethermind"},
+			{"FeeTooLow, EffectivePriorityFeePerGas too low 10 < 20, BaseFee: 30", true, "Nethermind"},
+			{"FeeTooLow, FeePerGas needs to be higher than 100 to be added to the TxPool. Affordable FeePerGas of rejected tx: 50.", true, "Nethermind"},
 			{"FeeTooLowToCompete", true, "Nethermind"},
 			{"transaction underpriced", true, "Klaytn"},
 			{"intrinsic gas too low", true, "Klaytn"},
@@ -307,9 +311,13 @@ func Test_Eth_Errors_Fatal(t *testing.T) {
 
 		{"call failed: SenderIsContract", true, "Nethermind"},
 		{"call failed: Invalid", true, "Nethermind"},
+		{"call failed: Invalid, transaction Hash is null", true, "Nethermind"},
 		{"call failed: Int256Overflow", true, "Nethermind"},
 		{"call failed: FailedToResolveSender", true, "Nethermind"},
 		{"call failed: GasLimitExceeded", true, "Nethermind"},
+		{"call failed: GasLimitExceeded, Gas limit: 100, gas limit of rejected tx: 150", true, "Nethermind"},
+		{"call failed: NonceGap", true, "Nethermind"},
+		{"call failed: NonceGap, Future nonce. Expected nonce: 10", true, "Nethermind"},
 
 		{"invalid shard", true, "Harmony"},
 		{"`to` address of transaction in blacklist", true, "Harmony"},

--- a/core/chains/evm/client/errors_test.go
+++ b/core/chains/evm/client/errors_test.go
@@ -53,6 +53,21 @@ func Test_Eth_Errors(t *testing.T) {
 		}
 	})
 
+	t.Run("IsNonceTooHigh", func(t *testing.T) {
+
+		tests := []errorCase{
+			{"call failed: NonceGap", true, "Nethermind"},
+			{"call failed: NonceGap, Future nonce. Expected nonce: 10", true, "Nethermind"},
+		}
+
+		for _, test := range tests {
+			err = evmclient.NewSendErrorS(test.message)
+			assert.Equal(t, err.IsNonceTooHighError(), test.expect)
+			err = newSendErrorWrapped(test.message)
+			assert.Equal(t, err.IsNonceTooHighError(), test.expect)
+		}
+	})
+
 	t.Run("IsTransactionAlreadyMined", func(t *testing.T) {
 		assert.False(t, randomError.IsTransactionAlreadyMined())
 
@@ -316,8 +331,6 @@ func Test_Eth_Errors_Fatal(t *testing.T) {
 		{"call failed: FailedToResolveSender", true, "Nethermind"},
 		{"call failed: GasLimitExceeded", true, "Nethermind"},
 		{"call failed: GasLimitExceeded, Gas limit: 100, gas limit of rejected tx: 150", true, "Nethermind"},
-		{"call failed: NonceGap", true, "Nethermind"},
-		{"call failed: NonceGap, Future nonce. Expected nonce: 10", true, "Nethermind"},
 
 		{"invalid shard", true, "Harmony"},
 		{"`to` address of transaction in blacklist", true, "Harmony"},

--- a/core/chains/evm/txmgr/eth_broadcaster_test.go
+++ b/core/chains/evm/txmgr/eth_broadcaster_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"math/big"
 	"math/rand"
+	"strconv"
 	"testing"
 	"time"
 
@@ -1593,6 +1594,44 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 	})
 
 	pgtest.MustExec(t, db, `DELETE FROM eth_txes`)
+
+	t.Run("eth tx is left in progress if nonce is too high", func(t *testing.T) {
+		localNextNonce := getLocalNextNonce(t, ethKeyStore, fromAddress)
+		nonceGapError := "NonceGap, Future nonce. Expected nonce: " + strconv.FormatUint(localNextNonce, 10)
+		etx := txmgr.EthTx{
+			FromAddress:    fromAddress,
+			ToAddress:      toAddress,
+			EncodedPayload: encodedPayload,
+			Value:          value,
+			GasLimit:       gasLimit,
+			State:          txmgr.EthTxUnstarted,
+		}
+		require.NoError(t, borm.InsertEthTx(&etx))
+
+		ethClient.On("SendTransaction", mock.Anything, mock.MatchedBy(func(tx *gethTypes.Transaction) bool {
+			return tx.Nonce() == localNextNonce
+		})).Return(errors.New(nonceGapError)).Once()
+
+		err, retryable := eb.ProcessUnstartedEthTxs(testutils.Context(t), keyState)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), nonceGapError)
+		assert.True(t, retryable)
+
+		etx, err = borm.FindEthTxWithAttempts(etx.ID)
+		require.NoError(t, err)
+
+		assert.Nil(t, etx.BroadcastAt)
+		assert.Nil(t, etx.InitialBroadcastAt)
+		require.NotNil(t, etx.Nonce)
+		assert.False(t, etx.Error.Valid)
+		assert.Equal(t, txmgr.EthTxInProgress, etx.State)
+		require.Len(t, etx.EthTxAttempts, 1)
+		attempt := etx.EthTxAttempts[0]
+		assert.Equal(t, txmgr.EthTxAttemptInProgress, attempt.State)
+		assert.Nil(t, attempt.BroadcastBeforeBlockNum)
+
+		pgtest.MustExec(t, db, `DELETE FROM eth_txes`)
+	})
 
 	t.Run("eth node returns underpriced transaction and bumping gas doesn't increase it in EIP-1559 mode", func(t *testing.T) {
 		// This happens if a transaction's gas price is below the minimum


### PR DESCRIPTION
On this PR(https://github.com/NethermindEth/nethermind/pull/3626) Nethermind extended its error messages. This PR adds the new regexes and test cases.