### PR TITLE
Replace header type calls with head

### DIFF
--- a/core/chains/evm/client/simulated_backend_client.go
+++ b/core/chains/evm/client/simulated_backend_client.go
@@ -515,8 +515,18 @@ func (c *SimulatedBackendClient) BatchCallContextAll(ctx context.Context, b []rp
 
 // SuggestGasTipCap suggests a gas tip cap.
 func (c *SimulatedBackendClient) SuggestGasTipCap(ctx context.Context) (tipCap *big.Int, err error) {
-	return nil, nil
+	return c.b.SuggestGasTipCap(ctx)
+}
+
+func (c *SimulatedBackendClient) Backend() *backends.SimulatedBackend {
+	return c.b
 }
 
 // NodeStates implements evmclient.Client
 func (c *SimulatedBackendClient) NodeStates() map[string]string { return nil }
+
+// Commit imports all the pending transactions as a single block and starts a
+// fresh new state.
+func (c *SimulatedBackendClient) Commit() common.Hash {
+	return c.b.Commit()
+}

--- a/core/chains/evm/txmgr/transmitchecker_test.go
+++ b/core/chains/evm/txmgr/transmitchecker_test.go
@@ -310,9 +310,9 @@ func TestTransmitCheckers(t *testing.T) {
 					return [32]byte{1}, nil
 				}
 			},
-			HeaderByNumber: func(ctx context.Context, n *big.Int) (*types.Header, error) {
-				return &types.Header{
-					Number: big.NewInt(1),
+			HeadByNumber: func(ctx context.Context, n *big.Int) (*evmtypes.Head, error) {
+				return &evmtypes.Head{
+					Number: 1,
 				}, nil
 			},
 			RequestBlockNumber: big.NewInt(1),
@@ -335,7 +335,7 @@ func TestTransmitCheckers(t *testing.T) {
 		})
 
 		t.Run("can't get header", func(t *testing.T) {
-			checker.HeaderByNumber = func(ctx context.Context, n *big.Int) (*types.Header, error) {
+			checker.HeadByNumber = func(ctx context.Context, n *big.Int) (*evmtypes.Head, error) {
 				return nil, errors.New("can't get head")
 			}
 			tx, attempt := newTx(t, big.NewInt(3))
@@ -343,9 +343,9 @@ func TestTransmitCheckers(t *testing.T) {
 		})
 
 		t.Run("nil request block number", func(t *testing.T) {
-			checker.HeaderByNumber = func(ctx context.Context, n *big.Int) (*types.Header, error) {
-				return &types.Header{
-					Number: big.NewInt(1),
+			checker.HeadByNumber = func(ctx context.Context, n *big.Int) (*evmtypes.Head, error) {
+				return &evmtypes.Head{
+					Number: 1,
 				}, nil
 			}
 			checker.RequestBlockNumber = nil

--- a/core/services/keeper/registry1_1_synchronizer_test.go
+++ b/core/services/keeper/registry1_1_synchronizer_test.go
@@ -13,6 +13,7 @@ import (
 
 	logmocks "github.com/smartcontractkit/chainlink/core/chains/evm/log/mocks"
 	evmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/mocks"
+	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	registry1_1 "github.com/smartcontractkit/chainlink/core/gethwrappers/generated/keeper_registry_wrapper1_1"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
@@ -56,8 +57,8 @@ func mockRegistry1_1(
 ) {
 	registryMock := cltest.NewContractMockReceiver(t, ethMock, keeper.Registry1_1ABI, contractAddress)
 
-	ethMock.On("HeaderByNumber", mock.Anything, mock.Anything).
-		Return(&types.Header{Number: big.NewInt(10)}, nil)
+	ethMock.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&evmtypes.Head{Number: 10}, nil)
 	registryMock.MockResponse("getConfig", config).Once()
 	registryMock.MockResponse("getKeeperList", keeperList).Once()
 	registryMock.MockResponse("getCanceledUpkeepList", cancelledUpkeeps).Once()

--- a/core/services/keeper/registry1_2_synchronizer_test.go
+++ b/core/services/keeper/registry1_2_synchronizer_test.go
@@ -13,6 +13,7 @@ import (
 
 	logmocks "github.com/smartcontractkit/chainlink/core/chains/evm/log/mocks"
 	evmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/mocks"
+	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	registry1_2 "github.com/smartcontractkit/chainlink/core/gethwrappers/generated/keeper_registry_wrapper1_2"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
@@ -77,8 +78,8 @@ func mockRegistry1_2(
 		Config:  config,
 		Keepers: keeperList,
 	}
-	ethMock.On("HeaderByNumber", mock.Anything, mock.Anything).
-		Return(&types.Header{Number: big.NewInt(10)}, nil)
+	ethMock.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&evmtypes.Head{Number: 10}, nil)
 	if getStateTime > 0 {
 		registryMock.MockResponse("getState", getState).Times(getStateTime)
 	}

--- a/core/services/keeper/registry1_3_synchronizer_test.go
+++ b/core/services/keeper/registry1_3_synchronizer_test.go
@@ -17,6 +17,7 @@ import (
 
 	logmocks "github.com/smartcontractkit/chainlink/core/chains/evm/log/mocks"
 	evmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/mocks"
+	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/evmtest"
@@ -79,8 +80,8 @@ func mockRegistry1_3(
 		Config:  config,
 		Keepers: keeperList,
 	}
-	ethMock.On("HeaderByNumber", mock.Anything, mock.Anything).
-		Return(&types.Header{Number: big.NewInt(10)}, nil)
+	ethMock.On("HeadByNumber", mock.Anything, (*big.Int)(nil)).
+		Return(&evmtypes.Head{Number: 10}, nil)
 	if getStateTime > 0 {
 		registryMock.MockResponse("getState", getState).Times(getStateTime)
 	}

--- a/core/services/keeper/upkeep_executer.go
+++ b/core/services/keeper/upkeep_executer.go
@@ -237,11 +237,11 @@ func (ex *UpkeepExecuter) execute(upkeep UpkeepRegistration, head *evmtypes.Head
 
 func (ex *UpkeepExecuter) turnBlockHashBinary(registry Registry, head *evmtypes.Head, lookback int64) (string, error) {
 	turnBlock := head.Number - (head.Number % int64(registry.BlockCountPerTurn)) - lookback
-	block, err := ex.ethClient.HeaderByNumber(context.Background(), big.NewInt(turnBlock))
+	block, err := ex.ethClient.HeadByNumber(context.Background(), big.NewInt(turnBlock))
 	if err != nil {
 		return "", err
 	}
-	hashAtHeight := block.Hash()
+	hashAtHeight := block.Hash
 	binaryString := fmt.Sprintf("%b", hashAtHeight.Big())
 	return binaryString, nil
 }

--- a/core/services/keeper/upkeep_executer_test.go
+++ b/core/services/keeper/upkeep_executer_test.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/onsi/gomega"
 	"github.com/smartcontractkit/sqlx"
 	"github.com/stretchr/testify/assert"
@@ -74,8 +73,7 @@ func setup(t *testing.T, estimator *gasmocks.Estimator, overrideFn func(c *chain
 	db := pgtest.NewSqlxDB(t)
 	keyStore := cltest.NewKeyStore(t, db, cfg)
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	block := &types.Header{Number: big.NewInt(1)}
-	ethClient.On("HeaderByNumber", mock.Anything, mock.Anything).Maybe().Return(block, nil)
+	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Maybe().Return(&evmtypes.Head{Number: 1, Hash: utils.NewHash()}, nil)
 	txm := txmmocks.NewTxManager(t)
 	txm.On("GetGasEstimator").Return(estimator)
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{TxManager: txm, DB: db, Client: ethClient, KeyStore: keyStore.Eth(), GeneralConfig: cfg})


### PR DESCRIPTION
More context on this: https://app.shortcut.com/chainlinklabs/story/55510/remove-headerbyxx-in-evm-client
