### PR TITLE
Restore global unique contract_address db constraint on ocr2_oracle_specs

### DIFF
--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -620,11 +620,21 @@ func TestORM_CreateJob_OCR2_DuplicatedContractAddress(t *testing.T) {
 
 	jb2, err := ocr2validate.ValidatedOracleSpecToml(config, testspecs.OCR2EVMSpecMinimal)
 	require.NoError(t, err)
-	
-	jb2.Name = null.StringFrom("Job 2")
+
+	jb2.Name = null.StringFrom("Job with same chain id & contract address")
 	jb2.OCR2OracleSpec.TransmitterID = null.StringFrom(address.String())
 
 	err = jobORM.CreateJob(&jb2)
+	require.Error(t, err)
+
+	jb3, err := ocr2validate.ValidatedOracleSpecToml(config, testspecs.OCR2EVMSpecMinimal)
+	require.NoError(t, err)
+	jb3.Name = null.StringFrom("Job with different chain id & same contract address")
+	jb3.OCR2OracleSpec.TransmitterID = null.StringFrom(address.String())
+
+	jb3.OCR2OracleSpec.RelayConfig["chainID"] = customChainID.Int64()
+
+	err = jobORM.CreateJob(&jb3)
 	require.Error(t, err)
 }
 

--- a/core/services/job/util.go
+++ b/core/services/job/util.go
@@ -11,35 +11,22 @@ import (
 
 var (
 	ErrNoChainFromSpec       = fmt.Errorf("could not get chain from spec")
-	ErrInvalidChainFromSpec  = fmt.Errorf("could not parse chain id")
 	ErrNoSendingKeysFromSpec = fmt.Errorf("could not get sending keys from spec")
 )
 
 // EVMChainForJob parses the job spec and retrieves the evm chain found.
 func EVMChainForJob(job *Job, set evm.ChainSet) (evm.Chain, error) {
-	chainID, err := EVMChainIDForJobSpec(job.OCR2OracleSpec)
-	if err != nil {
-		return nil, err
+	chainIDInterface, ok := job.OCR2OracleSpec.RelayConfig["chainID"]
+	if !ok {
+		return nil, fmt.Errorf("%w: chainID must be provided in relay config", ErrNoChainFromSpec)
 	}
+	chainID := chainIDInterface.(int64)
 	chain, err := set.Get(big.NewInt(chainID))
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrNoChainFromSpec, err)
 	}
 
 	return chain, nil
-}
-
-// EVMChainIDForJob parses the job spec and retrieves the evm chain id found
-func EVMChainIDForJobSpec(spec *OCR2OracleSpec) (chainID int64, err error) {
-	chainIDInterface, ok := spec.RelayConfig["chainID"]
-	if !ok {
-		return 0, fmt.Errorf("%w: chainID must be provided in relay config", ErrNoChainFromSpec)
-	}
-	chainID, ok = chainIDInterface.(int64)
-	if !ok {
-		return 0, fmt.Errorf("%w: invalid chainID field in relay config, must be int64", ErrInvalidChainFromSpec)
-	}
-	return
 }
 
 // SendingKeysForJob parses the job spec and retrieves the sending keys found.

--- a/core/store/migrate/migrations/0154_ocr2_restore_global_constraint.sql
+++ b/core/store/migrate/migrations/0154_ocr2_restore_global_constraint.sql
@@ -1,0 +1,4 @@
+-- +goose Up
+ALTER TABLE ocr2_oracle_specs ADD CONSTRAINT offchainreporting2_oracle_specs_unique_contract_addr UNIQUE (contract_id);
+-- +goose Down
+ALTER TABLE ocr2_oracle_specs DROP CONSTRAINT offchainreporting2_oracle_specs_unique_contract_addr;

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -53,8 +53,6 @@ Secrets must be configured manually and passed via `-secrets <filename>` or equi
 
 ### Updated
 
-- OCR2 jobs may now re-use the same contract address on multiple chains.
-
 - `NODE_NO_NEW_HEADS_THRESHOLD=0` no longer requires `NODE_SELECTION_MODE=RoundRobin`. 
 
 <!-- unreleasedstop -->


### PR DESCRIPTION
Keeping unit test, but now expecting an error when attempting to add job with same contract address on a different chain.