### PR TITLE
core: golangci-lint bump to 1.50.1; check many errors; add SugaredLogger.ErrorIf[Fn] variants to replace Logger.ErrorIf[Closing]

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -49,5 +49,5 @@ jobs:
         # any scheduled run or push, but skip PRs from release branches
         if: github.event.schedule != '' || github.event_name == 'push' || (github.event_name == 'pull_request' && !startsWith(github.head_ref, 'release/'))
         with:
-          version: v1.50.0
+          version: v1.50.1
           only-new-issues: ${{github.event.schedule == ''}} # show only new issues, unless it's a scheduled run

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -373,7 +373,7 @@ func TestClient_DiskMaxSizeBeforeRotateOptionDisablesAsExpected(t *testing.T) {
 			assert.NoError(t, os.MkdirAll(cfg.Dir, os.FileMode(0700)))
 
 			lggr, close := cfg.New()
-			defer close()
+			t.Cleanup(func() { assert.NoError(t, close()) })
 
 			// Tries to create a log file by logging. The log file won't be created if there's no logging happening.
 			lggr.Debug("Trying to create a log file by logging.")

--- a/core/cmd/ocr2vrf_configure_commands.go
+++ b/core/cmd/ocr2vrf_configure_commands.go
@@ -122,7 +122,7 @@ chainID                            = %d
 const forwarderAdditionalEOACount = 4
 
 func (cli *Client) ConfigureOCR2VRFNode(c *clipkg.Context, owner *bind.TransactOpts, ec *ethclient.Client) (*SetupOCR2VRFNodePayload, error) {
-	lggr := cli.Logger.Named("ConfigureOCR2VRFNode")
+	lggr := logger.Sugared(cli.Logger.Named("ConfigureOCR2VRFNode"))
 	err := cli.Config.Validate()
 	if err != nil {
 		return nil, cli.errorOut(errors.Wrap(err, "config validation failed"))
@@ -173,10 +173,13 @@ func (cli *Client) ConfigureOCR2VRFNode(c *clipkg.Context, owner *bind.TransactO
 	}
 
 	// Start application.
-	app.Start(rootCtx)
+	err = app.Start(rootCtx)
+	if err != nil {
+		return nil, cli.errorOut(err)
+	}
 
 	// Close application.
-	defer app.Stop()
+	defer lggr.ErrorIfFn(app.Stop, "Failed to Stop application")
 
 	// Initialize transmitter settings.
 	var sendingKeys []string

--- a/core/internal/features/ocr2/features_ocr2_test.go
+++ b/core/internal/features/ocr2/features_ocr2_test.go
@@ -306,7 +306,7 @@ fromBlock = %d
 			res.WriteHeader(http.StatusOK)
 			res.Write([]byte(`{"data":10}`))
 		}))
-		defer slowServers[i].Close()
+		t.Cleanup(slowServers[i].Close)
 		servers[i] = httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
 			b, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
@@ -320,12 +320,12 @@ fromBlock = %d
 			res.WriteHeader(http.StatusOK)
 			res.Write([]byte(`{"data":10}`))
 		}))
-		defer servers[i].Close()
+		t.Cleanup(servers[i].Close)
 		u, _ := url.Parse(servers[i].URL)
-		apps[i].BridgeORM().CreateBridgeType(&bridges.BridgeType{
+		require.NoError(t, apps[i].BridgeORM().CreateBridgeType(&bridges.BridgeType{
 			Name: bridges.BridgeName(fmt.Sprintf("bridge%d", i)),
 			URL:  models.WebURL(*u),
-		})
+		}))
 
 		ocrJob, err := validate.ValidatedOracleSpecToml(apps[i].Config, fmt.Sprintf(`
 type               = "offchainreporting2"
@@ -583,10 +583,10 @@ chainID 			= 1337
 		}))
 		t.Cleanup(servers[i].Close)
 		u, _ := url.Parse(servers[i].URL)
-		apps[i].BridgeORM().CreateBridgeType(&bridges.BridgeType{
+		require.NoError(t, apps[i].BridgeORM().CreateBridgeType(&bridges.BridgeType{
 			Name: bridges.BridgeName(fmt.Sprintf("bridge%d", i)),
 			URL:  models.WebURL(*u),
-		})
+		}))
 
 		ocrJob, err := validate.ValidatedOracleSpecToml(apps[i].Config, fmt.Sprintf(`
 type               = "offchainreporting2"

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -108,9 +108,11 @@ type Logger interface {
 	Fatalw(msg string, keysAndValues ...interface{})
 
 	// ErrorIf logs the error if present.
+	// Deprecated: use SugaredLogger.ErrorIf
 	ErrorIf(err error, msg string)
 
 	// ErrorIfClosing calls c.Close() and logs any returned error along with name.
+	// Deprecated: use SugaredLogger.ErrorIfFn with c.Close
 	ErrorIfClosing(c io.Closer, name string)
 
 	// Sync flushes any buffered log entries.

--- a/core/logger/sugared.go
+++ b/core/logger/sugared.go
@@ -6,8 +6,11 @@ type SugaredLogger interface {
 	AssumptionViolation(args ...interface{})
 	AssumptionViolationf(format string, vals ...interface{})
 	AssumptionViolationw(msg string, keyvals ...interface{})
+	ErrorIf(error, string)
+	ErrorIfFn(func() error, string)
 }
 
+// Sugared returns a new SugaredLogger wrapping the given Logger.
 func Sugared(l Logger) SugaredLogger {
 	return &sugared{
 		Logger: l,
@@ -33,4 +36,16 @@ func (s *sugared) AssumptionViolationf(format string, vals ...interface{}) {
 // AssumptionViolationw wraps Errorw logs with assumption violation tag.
 func (s *sugared) AssumptionViolationw(msg string, keyvals ...interface{}) {
 	s.h.Errorw("AssumptionViolation: "+msg, keyvals...)
+}
+
+func (s *sugared) ErrorIf(err error, msg string) {
+	if err != nil {
+		s.h.Errorw(msg, "err", err)
+	}
+}
+
+func (s *sugared) ErrorIfFn(fn func() error, msg string) {
+	if err := fn(); err != nil {
+		s.h.Errorw(msg, "err", err)
+	}
 }

--- a/core/scripts/chaincli/handler/bootstrap.go
+++ b/core/scripts/chaincli/handler/bootstrap.go
@@ -27,7 +27,7 @@ chainID = %d`
 // StartBootstrapNode starts the ocr2 bootstrap node with the given contract address
 func (h *baseHandler) StartBootstrapNode(ctx context.Context, addr string, uiPort, p2pv2Port int) {
 	lggr, closeLggr := logger.NewLogger()
-	defer closeLggr()
+	logger.Sugared(lggr).ErrorIfFn(closeLggr, "Failed to close logger")
 
 	const containerName = "bootstrap"
 	urlRaw, _, err := h.launchChainlinkNode(

--- a/core/scripts/chaincli/handler/jobs.go
+++ b/core/scripts/chaincli/handler/jobs.go
@@ -13,7 +13,7 @@ func (k *Keeper) CreateJob(ctx context.Context) {
 
 func (k *Keeper) createJobs() {
 	lggr, closeLggr := logger.NewLogger()
-	defer closeLggr()
+	logger.Sugared(lggr).ErrorIfFn(closeLggr, "Failed to close logger")
 
 	// Create Keeper Jobs on Nodes for Registry
 	for i, keeperAddr := range k.cfg.Keepers {

--- a/core/scripts/chaincli/handler/keeper.go
+++ b/core/scripts/chaincli/handler/keeper.go
@@ -44,7 +44,7 @@ func NewKeeper(cfg *config.Config) *Keeper {
 // DeployKeepers contains a logic to deploy keepers.
 func (k *Keeper) DeployKeepers(ctx context.Context) {
 	lggr, closeLggr := logger.NewLogger()
-	defer closeLggr()
+	logger.Sugared(lggr).ErrorIfFn(closeLggr, "Failed to close logger")
 
 	keepers, owners := k.keepers()
 	upkeepCount, registryAddr, deployer := k.prepareRegistry(ctx)
@@ -434,7 +434,7 @@ func (k *Keeper) keepers() ([]common.Address, []common.Address) {
 // createKeeperJobOnExistingNode connect to existing node to create keeper job
 func (k *Keeper) createKeeperJobOnExistingNode(urlStr, email, password, registryAddr, nodeAddr string) error {
 	lggr, closeLggr := logger.NewLogger()
-	defer closeLggr()
+	logger.Sugared(lggr).ErrorIfFn(closeLggr, "Failed to close logger")
 
 	cl, err := authenticate(urlStr, email, password, lggr)
 	if err != nil {

--- a/core/scripts/chaincli/handler/keeper_launch.go
+++ b/core/scripts/chaincli/handler/keeper_launch.go
@@ -40,7 +40,7 @@ type startedNodeData struct {
 // 7. withdraw funds after tests are done -> TODO: wait until tests are done instead of cancel manually
 func (k *Keeper) LaunchAndTest(ctx context.Context, withdraw bool, printLogs bool) {
 	lggr, closeLggr := logger.NewLogger()
-	defer closeLggr()
+	logger.Sugared(lggr).ErrorIfFn(closeLggr, "Failed to close logger")
 
 	var extraEvars []string
 	if k.cfg.OCR2Keepers {

--- a/core/services/blockhashstore/delegate_test.go
+++ b/core/services/blockhashstore/delegate_test.go
@@ -116,12 +116,13 @@ func TestDelegate_ServicesForSpec(t *testing.T) {
 	})
 
 	t.Run("missing EnabledKeysForChain", func(t *testing.T) {
-		testData.ethKeyStore.Delete(testData.sendingKey.ID())
+		_, err := testData.ethKeyStore.Delete(testData.sendingKey.ID())
+		require.NoError(t, err)
 
 		spec := job.Job{BlockhashStoreSpec: &job.BlockhashStoreSpec{
 			WaitBlocks: defaultWaitBlocks,
 		}}
-		_, err := delegate.ServicesForSpec(spec)
+		_, err = delegate.ServicesForSpec(spec)
 		assert.Error(t, err)
 	})
 }

--- a/core/services/directrequest/delegate_test.go
+++ b/core/services/directrequest/delegate_test.go
@@ -220,7 +220,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 			Run(func(args mock.Arguments) {
 				runBeganAwaiter.ItHappened()
 				fn := args.Get(4).(func(pg.Queryer) error)
-				fn(nil)
+				require.NoError(t, fn(nil))
 			}).Once().Return(false, nil)
 
 		// but should after this one, as the head Number is larger
@@ -383,7 +383,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		uni.runner.On("Run", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 			runBeganAwaiter.ItHappened()
 			fn := args.Get(4).(func(pg.Queryer) error)
-			fn(nil)
+			require.NoError(t, fn(nil))
 		}).Once().Return(false, nil)
 
 		err := uni.service.Start(testutils.Context(t))
@@ -479,7 +479,7 @@ func TestDelegate_ServicesListenerHandleLog(t *testing.T) {
 		uni.runner.On("Run", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 			runBeganAwaiter.ItHappened()
 			fn := args.Get(4).(func(pg.Queryer) error)
-			fn(nil)
+			require.NoError(t, fn(nil))
 		}).Once().Return(false, nil)
 
 		err := uni.service.Start(testutils.Context(t))

--- a/core/services/fluxmonitorv2/flux_monitor_test.go
+++ b/core/services/fluxmonitorv2/flux_monitor_test.go
@@ -1225,7 +1225,7 @@ func TestFluxMonitor_UsesPreviousRoundStateOnStartup_RoundTimeout(t *testing.T) 
 				Run(func(mock.Arguments) { close(chRoundState) }).
 				Maybe()
 
-			fm.Start(testutils.Context(t))
+			require.NoError(t, fm.Start(testutils.Context(t)))
 
 			if test.expectedToSubmit {
 				g.Eventually(chRoundState).Should(gomega.BeClosed())
@@ -1233,7 +1233,7 @@ func TestFluxMonitor_UsesPreviousRoundStateOnStartup_RoundTimeout(t *testing.T) 
 				g.Consistently(chRoundState).ShouldNot(gomega.BeClosed())
 			}
 
-			fm.Close()
+			require.NoError(t, fm.Close())
 		})
 	}
 }
@@ -1381,7 +1381,7 @@ func TestFluxMonitor_RoundTimeoutCausesPoll_timesOutNotZero(t *testing.T) {
 		Run(func(mock.Arguments) { close(chRoundState2) }).
 		Once()
 
-	fm.Start(testutils.Context(t))
+	require.NoError(t, fm.Start(testutils.Context(t)))
 
 	tm.logBroadcaster.On("WasAlreadyConsumed", mock.Anything, mock.Anything).Return(false, nil)
 	tm.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
@@ -1397,7 +1397,7 @@ func TestFluxMonitor_RoundTimeoutCausesPoll_timesOutNotZero(t *testing.T) {
 	g.Eventually(chRoundState2).Should(gomega.BeClosed())
 
 	time.Sleep(time.Duration(2*timeout) * time.Second)
-	fm.Close()
+	require.NoError(t, fm.Close())
 }
 
 func TestFluxMonitor_ConsumeLogBroadcast(t *testing.T) {

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -550,7 +550,7 @@ func TestORM_CreateJob_OCR_DuplicatedContractAddress(t *testing.T) {
 		assert.Equal(t, fmt.Sprintf("CreateJobFailed: a job with contract address %s already exists for chain ID %d", jb4.OCROracleSpec.ContractAddress, jb4.OCROracleSpec.EVMChainID.ToInt()), err.Error())
 	})
 
-	jobORM.DeleteJob(jb.ID)
+	require.NoError(t, jobORM.DeleteJob(jb.ID))
 
 	t.Run("with a set chain id", func(t *testing.T) {
 		err = jobORM.CreateJob(&jb4) // Add job with custom chain id

--- a/core/services/job/runner_integration_test.go
+++ b/core/services/job/runner_integration_test.go
@@ -73,8 +73,8 @@ func TestRunner(t *testing.T) {
 	runner := pipeline.NewRunner(pipelineORM, btORM, config, cc, nil, nil, logger.TestLogger(t), c, c)
 	jobORM := NewTestORM(t, db, cc, pipelineORM, btORM, keyStore, config)
 
-	runner.Start(testutils.Context(t))
-	defer runner.Close()
+	require.NoError(t, runner.Start(testutils.Context(t)))
+	t.Cleanup(func() { assert.NoError(t, runner.Close()) })
 
 	_, transmitterAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
 	require.NoError(t, keyStore.OCR().Add(cltest.DefaultOCRKey))

--- a/core/services/ocr2/plugins/directrequestocr/test/internal/testutils.go
+++ b/core/services/ocr2/plugins/directrequestocr/test/internal/testutils.go
@@ -25,11 +25,11 @@ import (
 	"github.com/smartcontractkit/chainlink/core/assets"
 	"github.com/smartcontractkit/chainlink/core/bridges"
 	"github.com/smartcontractkit/chainlink/core/config"
+	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/link_token_interface"
+	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/mock_v3_aggregator_contract"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/ocr2dr_client_example"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/ocr2dr_oracle"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/ocr2dr_registry"
-	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/link_token_interface"
-	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/mock_v3_aggregator_contract"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/core/internal/cltest/heavyweight"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
@@ -104,11 +104,11 @@ func SetOracleConfig(t *testing.T, owner *bind.TransactOpts, oracleContract *ocr
 }
 
 func SetRegistryConfig(t *testing.T, owner *bind.TransactOpts, registryContract *ocr2dr_registry.OCR2DRRegistry, oracleContractAddress common.Address) {
-	var maxGasLimit =  uint32(1_000_000)
-	var stalenessSeconds =  uint32(86_400)
-	var gasAfterPaymentCalculation = big.NewInt(21_000 + 5_000 + 2_100 + 20_000 + 2 * 2_100 - 15_000 + 7_315)
-	var weiPerUnitLink =  big.NewInt(5000000000000000)
-	var gasOverhead =  uint32(500_000)
+	var maxGasLimit = uint32(1_000_000)
+	var stalenessSeconds = uint32(86_400)
+	var gasAfterPaymentCalculation = big.NewInt(21_000 + 5_000 + 2_100 + 20_000 + 2*2_100 - 15_000 + 7_315)
+	var weiPerUnitLink = big.NewInt(5000000000000000)
+	var gasOverhead = uint32(500_000)
 
 	_, err := registryContract.SetConfig(
 		owner,
@@ -142,9 +142,10 @@ func CreateAndFundSubscriptions(t *testing.T, owner *bind.TransactOpts, linkToke
 
 	data, err := utils.ABIEncode(`[{"type":"uint64"}]`, subscriptionID)
 	require.NoError(t, err)
-	
+
 	amount := big.NewInt(0).Mul(big.NewInt(int64(numContracts)), big.NewInt(2e18)) // 2 LINK per client
-	linkToken.TransferAndCall(owner, registryContractAddress, amount, data)
+	_, err = linkToken.TransferAndCall(owner, registryContractAddress, amount, data)
+	require.NoError(t, err)
 
 	time.Sleep(1000 * time.Millisecond)
 
@@ -180,7 +181,7 @@ func StartNewChainWithContracts(t *testing.T, nClients int) (*bind.TransactOpts,
 	linkEthFeedAddr, _, _, err := mock_v3_aggregator_contract.DeployMockV3AggregatorContract(owner, b, 0, big.NewInt(5021530000000000))
 	require.NoError(t, err)
 
-	registryAddress, _, registryContract, err := ocr2dr_registry.DeployOCR2DRRegistry(owner, b, linkAddr,linkEthFeedAddr )
+	registryAddress, _, registryContract, err := ocr2dr_registry.DeployOCR2DRRegistry(owner, b, linkAddr, linkEthFeedAddr)
 	require.NoError(t, err)
 
 	ocrContractAddress, _, ocrContract, err := ocr2dr_oracle.DeployOCR2DROracle(owner, b)
@@ -319,10 +320,10 @@ func AddBootstrapJob(t *testing.T, app *cltest.TestApplication, contractAddress 
 func AddOCR2Job(t *testing.T, app *cltest.TestApplication, contractAddress common.Address, keyBundleID string, transmitter common.Address, bridgeURL string) job.Job {
 	u, err := url.Parse(bridgeURL)
 	require.NoError(t, err)
-	app.BridgeORM().CreateBridgeType(&bridges.BridgeType{
-		Name: bridges.BridgeName("ea_bridge"),
+	require.NoError(t, app.BridgeORM().CreateBridgeType(&bridges.BridgeType{
+		Name: "ea_bridge",
 		URL:  models.WebURL(*u),
-	})
+	}))
 	job, err := validate.ValidatedOracleSpecToml(app.Config, fmt.Sprintf(`
 		type               = "offchainreporting2"
 		name               = "dr-ocr-node"

--- a/core/sessions/reaper_test.go
+++ b/core/sessions/reaper_test.go
@@ -36,7 +36,9 @@ func TestSessionReaper_ReapSessions(t *testing.T) {
 	orm := sessions.NewORM(db, config.SessionTimeout().Duration(), lggr, pgtest.NewQConfig(true), audit.NoopLogger)
 
 	r := sessions.NewSessionReaper(db.DB, config, lggr)
-	defer r.Stop()
+	t.Cleanup(func() {
+		assert.NoError(t, r.Stop())
+	})
 
 	tests := []struct {
 		name     string

--- a/core/web/dkgsign_keys_controller_test.go
+++ b/core/web/dkgsign_keys_controller_test.go
@@ -101,7 +101,7 @@ func setupDKGSignKeysControllerTests(t *testing.T) (cltest.HTTPClientCleaner, ke
 
 	app := cltest.NewApplication(t)
 	require.NoError(t, app.Start(testutils.Context(t)))
-	app.KeyStore.DKGSign().Add(cltest.DefaultDKGSignKey)
+	require.NoError(t, app.KeyStore.DKGSign().Add(cltest.DefaultDKGSignKey))
 
 	client := app.NewHTTPClient(cltest.APIEmailAdmin)
 

--- a/core/web/jobs_controller_test.go
+++ b/core/web/jobs_controller_test.go
@@ -78,7 +78,7 @@ func TestJobsController_Create_ValidationFailure_OffchainReportingSpec(t *testin
 				address = cltest.NewEIP55Address()
 			}
 
-			ta.KeyStore.OCR().Add(cltest.DefaultOCRKey)
+			require.NoError(t, ta.KeyStore.OCR().Add(cltest.DefaultOCRKey))
 
 			sp := cltest.MinimalOCRNonBootstrapSpec(contractAddress, address, tc.pid, tc.kb)
 			body, _ := json.Marshal(web.CreateJobRequest{

--- a/core/web/p2p_keys_controller_test.go
+++ b/core/web/p2p_keys_controller_test.go
@@ -62,7 +62,7 @@ func TestP2PKeysController_Create_HappyPath(t *testing.T) {
 	assert.Equal(t, keys[0].PeerID().String(), resource.PeerID)
 
 	var peerID p2pkey.PeerID
-	peerID.UnmarshalText([]byte(resource.PeerID))
+	require.NoError(t, peerID.UnmarshalText([]byte(resource.PeerID)))
 	_, err = keyStore.P2P().Get(peerID)
 	require.NoError(t, err)
 }


### PR DESCRIPTION
1. Bump `golangci-lint` from `v1.50.0` to [`v1.50.1`](https://github.com/golangci/golangci-lint/releases/tag/v1.50.1)
2. Fix many outstanding `errcheck` issues
3. Add `SugaredLogger.ErrorIf` and `ErrorFn` to replace `Logger.ErrorIf` and `ErrorIfClosing` (which are now marked deprecated). Eventually removing those `Logger` methods (`v2`?) reduces API surface and duplication across all of the `Logger` wrappers.