### PR TITLE
core/cmd: fix and organize config commands

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -340,17 +340,17 @@ func NewApp(client *Client) *cli.App {
 			Subcommands: []cli.Command{
 				{
 					Name:   "dump",
-					Usage:  "LEGACY CONFIG (ENV) ONLY - Dump a TOML file equivalent to the current environment and database configuration",
+					Usage:  "Dump prints V2 TOML that is equivalent to the current environment and database configuration [Not supported with TOML]",
 					Action: client.ConfigDump,
 				},
 				{
 					Name:   "list",
-					Usage:  "LEGACY CONFIG (ENV) ONLY - Show the node's environment variables",
+					Usage:  "Show the node's environment variables [Not supported with TOML]",
 					Action: client.GetConfiguration,
 				},
 				{
 					Name:   "show",
-					Usage:  "V2 CONFIG (TOML) ONLY - Show the application configuration",
+					Usage:  "Show the application configuration [Only supported with TOML]",
 					Action: client.ConfigV2,
 					Flags: []cli.Flag{
 						cli.BoolFlag{
@@ -361,7 +361,7 @@ func NewApp(client *Client) *cli.App {
 				},
 				{
 					Name:   "setgasprice",
-					Usage:  "Set the default gas price to use for outgoing transactions",
+					Usage:  "Set the default gas price to use for outgoing transactions [Not supported with TOML]",
 					Action: client.SetEvmGasPriceDefault,
 					Flags: []cli.Flag{
 						cli.BoolFlag{
@@ -402,7 +402,7 @@ func NewApp(client *Client) *cli.App {
 				},
 				{
 					Name:   "validate",
-					Usage:  "Validate provided TOML config file",
+					Usage:  "Validate provided TOML config file, and print the full effective configuration, with defaults included [Only supported with TOML]",
 					Action: client.ConfigFileValidate,
 				},
 			},

--- a/core/cmd/renderer_test.go
+++ b/core/cmd/renderer_test.go
@@ -62,7 +62,7 @@ func TestRendererTable_RenderConfigurationV2(t *testing.T) {
 	client := app.NewHTTPClient(cltest.APIEmailAdmin)
 
 	t.Run("effective", func(t *testing.T) {
-		resp, cleanup := client.Get("/v2/config")
+		resp, cleanup := client.Get("/v2/config/v2")
 		t.Cleanup(cleanup)
 		var effective web.ConfigV2Resource
 		require.NoError(t, cltest.ParseJSONAPIResponse(t, resp, &effective))
@@ -71,7 +71,7 @@ func TestRendererTable_RenderConfigurationV2(t *testing.T) {
 	})
 
 	t.Run("user", func(t *testing.T) {
-		resp, cleanup := client.Get("/v2/config?userOnly=true")
+		resp, cleanup := client.Get("/v2/config/v2?userOnly=true")
 		t.Cleanup(cleanup)
 		var user web.ConfigV2Resource
 		require.NoError(t, cltest.ParseJSONAPIResponse(t, resp, &user))

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -163,13 +163,13 @@ func ExampleRun_config() {
 	//    core.test config command [command options] [arguments...]
 	//
 	// COMMANDS:
-	//    dump         LEGACY CONFIG (ENV) ONLY - Dump a TOML file equivalent to the current environment and database configuration
-	//    list         LEGACY CONFIG (ENV) ONLY - Show the node's environment variables
-	//    show         V2 CONFIG (TOML) ONLY - Show the application configuration
-	//    setgasprice  Set the default gas price to use for outgoing transactions
+	//    dump         Dump prints V2 TOML that is equivalent to the current environment and database configuration [Not supported with TOML]
+	//    list         Show the node's environment variables [Not supported with TOML]
+	//    show         Show the application configuration [Only supported with TOML]
+	//    setgasprice  Set the default gas price to use for outgoing transactions [Not supported with TOML]
 	//    loglevel     Set log level
 	//    logsql       Enable/disable sql statement logging
-	//    validate     Validate provided TOML config file
+	//    validate     Validate provided TOML config file, and print the full effective configuration, with defaults included [Only supported with TOML]
 	//
 	// OPTIONS:
 	//    --help, -h  show help

--- a/core/web/auth/auth_test.go
+++ b/core/web/auth/auth_test.go
@@ -210,7 +210,7 @@ var routesRolesMap = [...]routeRules{
 	{"POST", "/v2/transfers/solana", false, false, false},
 	{"GET", "/v2/config", true, true, true},
 	{"PATCH", "/v2/config", false, false, false},
-	{"GET", "/v2/config/v2", false, false, false},
+	{"GET", "/v2/config/v2", true, true, true},
 	{"GET", "/v2/tx_attempts", true, true, true},
 	{"GET", "/v2/tx_attempts/evm", true, true, true},
 	{"GET", "/v2/transactions/evm", true, true, true},

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -267,8 +267,8 @@ func v2Routes(app chainlink.Application, r *gin.RouterGroup) {
 		cc := ConfigController{app}
 		authv2.GET("/config", cc.Show)
 		authv2.PATCH("/config", auth.RequiresAdminRole(cc.Patch))
-		authv2.GET("/config/dump-v1-as-v2", auth.RequiresAdminRole(cc.Dump))
-		authv2.GET("/config/v2", auth.RequiresAdminRole(cc.Show))
+		authv2.GET("/config/dump-v1-as-v2", cc.Dump)
+		authv2.GET("/config/v2", cc.Show2)
 
 		tas := TxAttemptsController{app}
 		authv2.GET("/tx_attempts", paginatedRequest(tas.Index))

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -46,11 +46,26 @@ Multiple files can be used (`-c configA.toml -c configB.toml`), and will be appl
 Existing nodes can automatically generate their equivalent TOML configuration via the `config dump` subcommand.
 Secrets must be configured manually and passed via `-secrets <filename>` or equivalent environment variables.
 
+Format details: [CONFIG.md](../docs/CONFIG.md) • [SECRETS.md](../docs/SECRETS.md)
+
 **Note:** You _cannot_ mix legacy environment variables with TOML configuration. Leaving any legacy env vars set will fail validation and prevent boot.
 
-##### Detailed Docs
+##### Examples
 
-[CONFIG.md](../docs/CONFIG.md) • [SECRETS.md](../docs/SECRETS.md)
+Dump your current configuration as TOML.
+```bash
+chainlink config dump > config.toml
+```
+
+Inspect your full effective configuration, and ensure it is valid. This includes defaults.
+```bash
+chainlink --config config.toml --secrets secrets.toml config validate
+```
+
+Run the node.
+```bash
+chainlink -c config.toml -s secrets.toml node start
+```
 
 ### Fixed
 


### PR DESCRIPTION
Some of the `config` sub commands intended for only legacy or TOML could be executed partially for the other on accident due to the shared code/interfaces. Now we explicitly check the version and return an error instead.

Also, dump and show v2 were behind admin auth, even though they are just read-only views like the unauthed legacy list path.

```txt
$ chainlink config --help
NAME:
   chainlink config - Commands for the node's configuration

USAGE:
   chainlink config command [command options] [arguments...]

COMMANDS:
   dump         Dump prints V2 TOML that is equivalent to the current environment and database configuration [Not supported with TOML]
   list         Show the node's environment variables [Not supported with TOML]
   show         Show the application configuration [Only supported with TOML]
   setgasprice  Set the default gas price to use for outgoing transactions [Not supported with TOML]
   loglevel     Set log level
   logsql       Enable/disable sql statement logging
   validate     Validate provided TOML config file, and print the full effective configuration, with defaults included [Only supported with TOML]

OPTIONS:
   --help, -h  show help
```