### PR TITLE
fix: solidity-foundry.yml workflow

### DIFF
--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -24,7 +24,8 @@ jobs:
   tests:
     needs: [changes]
     name: Tests
-    runs-on: ubuntu-latest
+    # See https://github.com/foundry-rs/foundry/issues/3827
+    runs-on: ubuntu-22.04
 
     steps:
       - name: Collect Metrics


### PR DESCRIPTION
See https://github.com/foundry-rs/foundry/issues/3827, looks like the appropriate glibc is not found on `ubuntu-latest`.