### PR TITLE
core/logger: cleanup

### DIFF
--- a/core/chains/evm/gas/cmd/arbgas/main.go
+++ b/core/chains/evm/gas/cmd/arbgas/main.go
@@ -26,7 +26,7 @@ func main() {
 	lggr.SetLogLevel(zapcore.DebugLevel)
 
 	ctx := context.Background()
-	withEstimator(ctx, lggr, url, func(e gas.Estimator) {
+	withEstimator(ctx, logger.Sugared(lggr), url, func(e gas.Estimator) {
 		printGetLegacyGas(ctx, e, make([]byte, 10), 500_000, assets.GWei(1))
 		printGetLegacyGas(ctx, e, make([]byte, 10), 500_000, assets.GWei(1), gas.OptForceRefetch)
 		printGetLegacyGas(ctx, e, make([]byte, 10), max, assets.GWei(1))
@@ -45,7 +45,7 @@ func printGetLegacyGas(ctx context.Context, e gas.Estimator, calldata []byte, l2
 
 const max = 50_000_000
 
-func withEstimator(ctx context.Context, lggr logger.Logger, url string, f func(e gas.Estimator)) {
+func withEstimator(ctx context.Context, lggr logger.SugaredLogger, url string, f func(e gas.Estimator)) {
 	rc, err := rpc.Dial(url)
 	if err != nil {
 		log.Fatal(err)
@@ -58,7 +58,7 @@ func withEstimator(ctx context.Context, lggr logger.Logger, url string, f func(e
 	if err != nil {
 		log.Fatal(err)
 	}
-	defer lggr.ErrorIfClosing(e, "ArbitrumEstimator")
+	defer lggr.ErrorIfFn(e.Close, "Error closing ArbitrumEstimator")
 
 	f(e)
 }

--- a/core/cmd/client.go
+++ b/core/cmd/client.go
@@ -609,13 +609,13 @@ type ClientOpts struct {
 type SessionCookieAuthenticator struct {
 	config ClientOpts
 	store  CookieStore
-	lggr   logger.Logger
+	lggr   logger.SugaredLogger
 }
 
 // NewSessionCookieAuthenticator creates a SessionCookieAuthenticator using the passed config
 // and builder.
 func NewSessionCookieAuthenticator(config ClientOpts, store CookieStore, lggr logger.Logger) CookieAuthenticator {
-	return &SessionCookieAuthenticator{config: config, store: store, lggr: lggr}
+	return &SessionCookieAuthenticator{config: config, store: store, lggr: logger.Sugared(lggr)}
 }
 
 // Cookie Returns the previously saved authentication cookie.
@@ -642,7 +642,7 @@ func (t *SessionCookieAuthenticator) Authenticate(sessionRequest sessions.Sessio
 	if err != nil {
 		return nil, err
 	}
-	defer t.lggr.ErrorIfClosing(resp.Body, "Authenticate response body")
+	defer t.lggr.ErrorIfFn(resp.Body.Close, "Error closing Authenticate response body")
 
 	_, err = parseResponse(resp)
 	if err != nil {

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -58,7 +58,7 @@ func (cli *Client) RunNode(c *clipkg.Context) error {
 }
 
 func (cli *Client) runNode(c *clipkg.Context) error {
-	lggr := cli.Logger.Named("RunNode")
+	lggr := logger.Sugared(cli.Logger.Named("RunNode"))
 
 	var pwd, vrfpwd *string
 	if passwordFile := c.String("password"); passwordFile != "" {
@@ -134,7 +134,7 @@ func (cli *Client) runNode(c *clipkg.Context) error {
 		// If not successful, we know neither locks nor connection remains opened
 		return cli.errorOut(errors.Wrap(err, "opening db"))
 	}
-	defer lggr.ErrorIfClosing(ldb, "db")
+	defer lggr.ErrorIfFn(ldb.Close, "Error closing db")
 
 	// From now on, DB locks and DB connection will be released on every return.
 	// Keep watching on logger.Fatal* calls and os.Exit(), because defer will not be executed.
@@ -355,12 +355,12 @@ func (cli *Client) RebroadcastTransactions(c *clipkg.Context) (err error) {
 		}
 	}
 
-	lggr := cli.Logger.Named("RebroadcastTransactions")
+	lggr := logger.Sugared(cli.Logger.Named("RebroadcastTransactions"))
 	db, err := pg.OpenUnlockedDB(cli.Config)
 	if err != nil {
 		return cli.errorOut(errors.Wrap(err, "opening DB"))
 	}
-	defer lggr.ErrorIfClosing(db, "db")
+	defer lggr.ErrorIfFn(db.Close, "Error closing db")
 
 	app, err := cli.AppFactory.NewApplication(context.TODO(), cli.Config, lggr, db)
 	if err != nil {

--- a/core/cmd/local_client_test.go
+++ b/core/cmd/local_client_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"math/big"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -391,8 +390,7 @@ func TestClient_DiskMaxSizeBeforeRotateOptionDisablesAsExpected(t *testing.T) {
 			// Tries to create a log file by logging. The log file won't be created if there's no logging happening.
 			lggr.Debug("Trying to create a log file by logging.")
 
-			filepath := filepath.Join(cfg.Dir, logger.LogsFile)
-			_, err := os.Stat(filepath)
+			_, err := os.Stat(cfg.LogsFile())
 			require.Equal(t, os.IsNotExist(err), !tt.fileShouldExist)
 		})
 	}

--- a/core/cmd/ocr2vrf_configure_commands.go
+++ b/core/cmd/ocr2vrf_configure_commands.go
@@ -156,7 +156,7 @@ func (cli *Client) ConfigureOCR2VRFNode(c *clipkg.Context, owner *bind.TransactO
 	if err = ldb.Open(rootCtx); err != nil {
 		return nil, cli.errorOut(errors.Wrap(err, "opening db"))
 	}
-	defer lggr.ErrorIfClosing(ldb, "db")
+	defer lggr.ErrorIfFn(ldb.Close, "Error closing db")
 
 	app, err := cli.AppFactory.NewApplication(rootCtx, cli.Config, lggr, ldb.DB())
 	if err != nil {

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -13,7 +13,6 @@ import (
 	"net/http/httptest"
 	"net/url"
 	"os"
-	"path/filepath"
 	"reflect"
 	"testing"
 	"time"
@@ -851,13 +850,6 @@ func ParseJSONAPIResponseMetaCount(input []byte) (int, error) {
 	var metaCount int
 	err = json.Unmarshal(*meta["count"], &metaCount)
 	return metaCount, err
-}
-
-// ReadLogs returns the contents of the applications log file as a string
-func ReadLogs(dir string) (string, error) {
-	logFile := filepath.Join(dir, logger.LogsFile)
-	b, err := os.ReadFile(logFile)
-	return string(b), err
 }
 
 func CreateJobViaWeb(t testing.TB, app *TestApplication, request []byte) job.Job {

--- a/core/internal/cltest/simulated_backend.go
+++ b/core/internal/cltest/simulated_backend.go
@@ -23,7 +23,7 @@ func NewSimulatedBackend(t *testing.T, alloc core.GenesisAlloc, gasLimit uint32)
 	// NOTE: Make sure to finish closing any application/client before
 	// backend.Close or they can hang
 	t.Cleanup(func() {
-		logger.TestLogger(t).ErrorIfClosing(backend, "simulated backend")
+		logger.TestLogger(t).ErrorIfFn(backend.Close, "Error closing simulated backend")
 	})
 	return backend
 }

--- a/core/internal/mocks/application.go
+++ b/core/internal/mocks/application.go
@@ -259,15 +259,15 @@ func (_m *Application) GetKeyStore() keystore.Master {
 }
 
 // GetLogger provides a mock function with given fields:
-func (_m *Application) GetLogger() logger.Logger {
+func (_m *Application) GetLogger() logger.SugaredLogger {
 	ret := _m.Called()
 
-	var r0 logger.Logger
-	if rf, ok := ret.Get(0).(func() logger.Logger); ok {
+	var r0 logger.SugaredLogger
+	if rf, ok := ret.Get(0).(func() logger.SugaredLogger); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(logger.Logger)
+			r0 = ret.Get(0).(logger.SugaredLogger)
 		}
 	}
 

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 
 	"github.com/fatih/color"
 	"go.uber.org/zap"
@@ -15,8 +16,8 @@ import (
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
-// LogsFile describes the logs file name
-const LogsFile = "chainlink_debug.log"
+// logsFile describes the logs file name
+const logsFile = "chainlink_debug.log"
 
 func init() {
 	err := zap.RegisterSink("pretty", prettyConsoleSink(os.Stderr))
@@ -256,6 +257,10 @@ func (c Config) DebugLogsToDisk() bool {
 // RequiredDiskSpace returns the required disk space in order to allow debug logs to be stored in disk
 func (c Config) RequiredDiskSpace() utils.FileSize {
 	return utils.FileSize(c.FileMaxSizeMB * utils.MB * (c.FileMaxBackups + 1))
+}
+
+func (c Config) LogsFile() string {
+	return filepath.Join(c.Dir, logsFile)
 }
 
 // InitColor explicitly sets the global color.NoColor option.

--- a/core/logger/logger_unix.go
+++ b/core/logger/logger_unix.go
@@ -11,6 +11,6 @@ func registerOSSinks() error {
 
 // logFileURI returns the full path to the file the
 // NewLogger logs to, and uses zap's built in default file sink.
-func logFileURI(configRootDir string) string {
-	return filepath.ToSlash(filepath.Join(configRootDir, LogsFile))
+func (c Config) logFileURI() string {
+	return filepath.ToSlash(c.LogsFile())
 }

--- a/core/logger/logger_windows.go
+++ b/core/logger/logger_windows.go
@@ -15,8 +15,8 @@ import (
 // directory, with a custom scheme winfile:/// specifically tailored for
 // Windows to get around their handling of the file:// schema in uber.org/zap.
 // https://github.com/uber-go/zap/issues/621
-func logFileURI(configRootDir string) string {
-	return "winfile:///" + filepath.ToSlash(filepath.Join(configRootDir, LogsFile))
+func (c Config) logFileURI() string {
+	return "winfile:///" + filepath.ToSlash(c.LogsFile())
 }
 
 func registerOSSinks() error {

--- a/core/logger/sugared.go
+++ b/core/logger/sugared.go
@@ -3,11 +3,16 @@ package logger
 // SugaredLogger extends the base Logger interface with syntactic sugar, similar to zap.SugaredLogger.
 type SugaredLogger interface {
 	Logger
+	// AssumptionViolation variants log at error level with the message prefix "AssumptionViolation: ".
 	AssumptionViolation(args ...interface{})
 	AssumptionViolationf(format string, vals ...interface{})
 	AssumptionViolationw(msg string, keyvals ...interface{})
-	ErrorIf(error, string)
-	ErrorIfFn(func() error, string)
+	// ErrorIf logs the error if present.
+	ErrorIf(err error, msg string)
+	// ErrorIfFn calls fn() and logs any returned error along with msg.
+	// Unlike ErrorIf, this can be deffered inline, since the function call is delayed.
+	//  defer l.ErrorIfFn(db.Close, "Error closing db")
+	ErrorIfFn(fn func() error, msg string)
 }
 
 // Sugared returns a new SugaredLogger wrapping the given Logger.

--- a/core/logger/zap_disk_logging.go
+++ b/core/logger/zap_disk_logging.go
@@ -55,7 +55,7 @@ func (cfg zapDiskLoggerConfig) newDiskCore(diskLogLevel zap.AtomicLevel) (zapcor
 	var (
 		encoder = zapcore.NewConsoleEncoder(makeEncoderConfig(cfg.local))
 		sink    = zapcore.AddSync(&lumberjack.Logger{
-			Filename:   logFileURI(cfg.local.Dir),
+			Filename:   cfg.local.logFileURI(),
 			MaxSize:    cfg.local.FileMaxSizeMB,
 			MaxAge:     cfg.local.FileMaxAgeDays,
 			MaxBackups: cfg.local.FileMaxBackups,

--- a/core/logger/zap_test.go
+++ b/core/logger/zap_test.go
@@ -3,7 +3,6 @@ package logger
 import (
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -81,7 +80,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 
 		lggr.Debug("trying to write to disk when the disk logs should not be created")
 
-		logFile := filepath.Join(zapCfg.local.Dir, LogsFile)
+		logFile := zapCfg.local.LogsFile()
 		_, err = os.ReadFile(logFile)
 
 		require.Error(t, err)
@@ -112,7 +111,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 
 		lggr.Debug("trying to write to disk when the disk logs should not be created - generic error")
 
-		logFile := filepath.Join(zapCfg.local.Dir, LogsFile)
+		logFile := zapCfg.local.LogsFile()
 		_, err = os.ReadFile(logFile)
 
 		require.Error(t, err)
@@ -149,7 +148,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 		lggr.Debug("writing to disk on test again")
 		lggr.Warn("writing to disk on test again")
 
-		logFile := filepath.Join(zapCfg.local.Dir, LogsFile)
+		logFile := zapCfg.local.LogsFile()
 		b, err := os.ReadFile(logFile)
 		assert.NoError(t, err)
 
@@ -199,7 +198,7 @@ func TestZapLogger_OutOfDiskSpace(t *testing.T) {
 
 		lggr.Debug("test again")
 
-		logFile := filepath.Join(zapCfg.local.Dir, LogsFile)
+		logFile := zapCfg.local.LogsFile()
 		b, err := os.ReadFile(logFile)
 		assert.NoError(t, err)
 
@@ -271,12 +270,12 @@ func TestZapLogger_LogCaller(t *testing.T) {
 	pollChan <- time.Now()
 	<-zapCfg.testDiskLogLvlChan
 
-	logFile := filepath.Join(zapCfg.local.Dir, LogsFile)
+	logFile := zapCfg.local.LogsFile()
 	b, err := os.ReadFile(logFile)
 	assert.NoError(t, err)
 
 	logs := string(b)
 	lines := strings.Split(logs, "\n")
 
-	require.Contains(t, lines[0], "logger/zap_test.go:269")
+	require.Contains(t, lines[0], "logger/zap_test.go:268")
 }

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -67,7 +67,7 @@ import (
 type Application interface {
 	Start(ctx context.Context) error
 	Stop() error
-	GetLogger() logger.Logger
+	GetLogger() logger.SugaredLogger
 	GetAuditLogger() audit.AuditLogger
 	GetHealthChecker() services.Checker
 	GetSqlxDB() *sqlx.DB
@@ -135,7 +135,7 @@ type ChainlinkApplication struct {
 	srvcs                    []services.ServiceCtx
 	HealthChecker            services.Checker
 	Nurse                    *services.Nurse
-	logger                   logger.Logger
+	logger                   logger.SugaredLogger
 	AuditLogger              audit.AuditLogger
 	closeLogger              func() error
 	sqlxDB                   *sqlx.DB
@@ -201,7 +201,7 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 	eventBroadcaster := opts.EventBroadcaster
 	mailMon := opts.MailMon
 	externalInitiatorManager := opts.ExternalInitiatorManager
-	globalLogger := opts.Logger
+	globalLogger := logger.Sugared(opts.Logger)
 	keyStore := opts.KeyStore
 	restrictedHTTPClient := opts.RestrictedHTTPClient
 	unrestrictedHTTPClient := opts.UnrestrictedHTTPClient
@@ -620,7 +620,7 @@ func (app *ChainlinkApplication) GetKeyStore() keystore.Master {
 	return app.KeyStore
 }
 
-func (app *ChainlinkApplication) GetLogger() logger.Logger {
+func (app *ChainlinkApplication) GetLogger() logger.SugaredLogger {
 	return app.logger
 }
 

--- a/core/services/fluxmonitorv2/flux_monitor.go
+++ b/core/services/fluxmonitorv2/flux_monitor.go
@@ -75,7 +75,7 @@ type FluxMonitor struct {
 	logBroadcaster    log.Broadcaster
 	chainID           *big.Int
 
-	logger logger.Logger
+	logger logger.SugaredLogger
 
 	backlog       *utils.BoundedPriorityQueue[log.Broadcast]
 	chProcessLogs chan struct{}
@@ -125,7 +125,7 @@ func NewFluxMonitor(
 		flags:             flags,
 		logBroadcaster:    logBroadcaster,
 		fluxAggregator:    fluxAggregator,
-		logger:            fmLogger,
+		logger:            logger.Sugared(fmLogger),
 		chainID:           chainID,
 		backlog: utils.NewBoundedPriorityQueue[log.Broadcast](map[uint]int{
 			// We want reconnecting nodes to be able to submit to a round
@@ -194,7 +194,7 @@ func NewFromJobSpec(
 	)
 
 	flags, err := NewFlags(cfg.FlagsContractAddress(), ethClient)
-	lggr.ErrorIf(err,
+	logger.Sugared(lggr).ErrorIf(err,
 		fmt.Sprintf(
 			"Error creating Flags contract instance, check address: %s",
 			cfg.FlagsContractAddress(),

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -83,7 +83,7 @@ type orm struct {
 	chainSet    evm.ChainSet
 	keyStore    keystore.Master
 	pipelineORM pipeline.ORM
-	lggr        logger.Logger
+	lggr        logger.SugaredLogger
 	cfg         pg.QConfig
 	bridgeORM   bridges.ORM
 }
@@ -99,7 +99,7 @@ func NewORM(
 	lggr logger.Logger,
 	cfg pg.QConfig,
 ) *orm {
-	namedLogger := lggr.Named("JobORM")
+	namedLogger := logger.Sugared(lggr.Named("JobORM"))
 	return &orm{
 		q:           pg.NewQ(db, namedLogger, cfg),
 		chainSet:    chainSet,

--- a/core/services/ocr/database.go
+++ b/core/services/ocr/database.go
@@ -23,7 +23,7 @@ import (
 type db struct {
 	q            pg.Q
 	oracleSpecID int32
-	lggr         logger.Logger
+	lggr         logger.SugaredLogger
 }
 
 var (
@@ -38,7 +38,7 @@ func NewDB(sqlxDB *sqlx.DB, oracleSpecID int32, lggr logger.Logger, cfg pg.QConf
 	return &db{
 		q:            pg.NewQ(sqlxDB, namedLogger, cfg),
 		oracleSpecID: oracleSpecID,
-		lggr:         lggr,
+		lggr:         logger.Sugared(lggr),
 	}
 }
 
@@ -224,7 +224,7 @@ WHERE ocr_oracle_spec_id = $1 AND config_digest = $2
 	if err != nil {
 		return nil, errors.Wrap(err, "PendingTransmissionsWithConfigDigest failed to query rows")
 	}
-	defer d.lggr.ErrorIfClosing(rows, "ocr_pending_transmissions rows")
+	defer d.lggr.ErrorIfFn(rows.Close, "Error closing ocr_pending_transmissions rows")
 
 	m := make(map[ocrtypes.PendingTransmissionKey]ocrtypes.PendingTransmission)
 

--- a/core/services/ocr2/database.go
+++ b/core/services/ocr2/database.go
@@ -19,7 +19,7 @@ import (
 type db struct {
 	q            pg.Q
 	oracleSpecID int32
-	lggr         logger.Logger
+	lggr         logger.SugaredLogger
 }
 
 var (
@@ -33,7 +33,7 @@ func NewDB(sqlxDB *sqlx.DB, oracleSpecID int32, lggr logger.Logger, cfg pg.QConf
 	return &db{
 		q:            pg.NewQ(sqlxDB, namedLogger, cfg),
 		oracleSpecID: oracleSpecID,
-		lggr:         lggr,
+		lggr:         logger.Sugared(lggr),
 	}
 }
 
@@ -279,7 +279,7 @@ func (d *db) PendingTransmissionsWithConfigDigest(ctx context.Context, cd ocrtyp
 	if err != nil {
 		return nil, errors.Wrap(err, "PendingTransmissionsWithConfigDigest failed to query rows")
 	}
-	defer d.lggr.ErrorIfClosing(rows, "ocr2_pending_transmissions rows")
+	defer d.lggr.ErrorIfFn(rows.Close, "Error closing ocr2_pending_transmissions rows")
 
 	m := make(map[ocrtypes.ReportTimestamp]ocrtypes.PendingTransmission)
 

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -127,11 +127,11 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 		return nil, errors.Errorf("%s relay does not exist is it enabled?", spec.Relay)
 	}
 
-	lggr := d.lggr.Named("OCR").With(
+	lggr := logger.Sugared(d.lggr.Named("OCR").With(
 		"contractID", spec.ContractID,
 		"jobName", jb.Name.ValueOrZero(),
 		"jobID", jb.ID,
-	)
+	))
 
 	if spec.Relay == relay.EVM {
 		chainIDInterface, ok := spec.RelayConfig["chainID"]

--- a/core/services/ocrbootstrap/delegate.go
+++ b/core/services/ocrbootstrap/delegate.go
@@ -20,7 +20,7 @@ type Delegate struct {
 	jobORM            job.ORM
 	peerWrapper       *ocrcommon.SingletonPeerWrapper
 	cfg               validate.Config
-	lggr              logger.Logger
+	lggr              logger.SugaredLogger
 	relayers          map[relay.Network]types.Relayer
 	isNewlyCreatedJob bool
 }
@@ -38,7 +38,7 @@ func NewDelegateBootstrap(
 		db:          db,
 		jobORM:      jobORM,
 		peerWrapper: peerWrapper,
-		lggr:        lggr,
+		lggr:        logger.Sugared(lggr),
 		cfg:         cfg,
 		relayers:    relayers,
 	}

--- a/core/services/ocrcommon/peerstore.go
+++ b/core/services/ocrcommon/peerstore.go
@@ -38,7 +38,7 @@ type (
 		ctx           context.Context
 		ctxCancel     context.CancelFunc
 		chDone        chan struct{}
-		lggr          logger.Logger
+		lggr          logger.SugaredLogger
 	}
 )
 
@@ -58,7 +58,7 @@ func NewPeerstoreWrapper(db *sqlx.DB, writeInterval time.Duration, peerID p2pkey
 		ctx,
 		cancel,
 		make(chan struct{}),
-		namedLogger,
+		logger.Sugared(namedLogger),
 	}, nil
 }
 
@@ -123,7 +123,7 @@ func (p *Pstorewrapper) getPeers() (peers []P2PPeer, err error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "error querying peers")
 	}
-	defer p.lggr.ErrorIfClosing(rows, "p2p_peers rows")
+	defer p.lggr.ErrorIfFn(rows.Close, "Error closing p2p_peers rows")
 
 	peers = make([]P2PPeer, 0)
 

--- a/core/services/relay/evm/request_round_tracker.go
+++ b/core/services/relay/evm/request_round_tracker.go
@@ -30,7 +30,7 @@ type RequestRoundTracker struct {
 	contractFilterer *ocr2aggregator.OCR2AggregatorFilterer
 	logBroadcaster   log.Broadcaster
 	jobID            int32
-	lggr             logger.Logger
+	lggr             logger.SugaredLogger
 	odb              RequestRoundDB
 	q                pg.Q
 	blockTranslator  ocrcommon.BlockTranslator
@@ -64,7 +64,7 @@ func NewRequestRoundTracker(
 		contractFilterer: contractFilterer,
 		logBroadcaster:   logBroadcaster,
 		jobID:            jobID,
-		lggr:             lggr,
+		lggr:             logger.Sugared(lggr),
 		odb:              odb,
 		q:                pg.NewQ(db, lggr, chain),
 		blockTranslator:  ocrcommon.NewBlockTranslator(chain, ethClient, lggr),

--- a/core/services/vrf/delegate.go
+++ b/core/services/vrf/delegate.go
@@ -159,7 +159,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 		if _, ok := task.(*pipeline.VRFTask); ok {
 			return []job.ServiceCtx{&listenerV1{
 				cfg:             chain.Config(),
-				l:               lV1,
+				l:               logger.Sugared(lV1),
 				headBroadcaster: chain.HeadBroadcaster(),
 				logBroadcaster:  chain.LogBroadcaster(),
 				q:               d.q,

--- a/core/services/vrf/listener_v1.go
+++ b/core/services/vrf/listener_v1.go
@@ -45,7 +45,7 @@ type listenerV1 struct {
 	utils.StartStopOnce
 
 	cfg             Config
-	l               logger.Logger
+	l               logger.SugaredLogger
 	logBroadcaster  log.Broadcaster
 	coordinator     *solidity_vrf_coordinator_interface.VRFCoordinator
 	pipelineRunner  pipeline.Runner

--- a/core/services/vrf/listener_v2.go
+++ b/core/services/vrf/listener_v2.go
@@ -96,7 +96,7 @@ func newListenerV2(
 ) *listenerV2 {
 	return &listenerV2{
 		cfg:                cfg,
-		l:                  l,
+		l:                  logger.Sugared(l),
 		ethClient:          ethClient,
 		chainID:            chainID,
 		logBroadcaster:     logBroadcaster,
@@ -147,7 +147,7 @@ type vrfPipelineResult struct {
 type listenerV2 struct {
 	utils.StartStopOnce
 	cfg            Config
-	l              logger.Logger
+	l              logger.SugaredLogger
 	ethClient      evmclient.Client
 	chainID        *big.Int
 	logBroadcaster log.Broadcaster

--- a/core/utils/http/http.go
+++ b/core/utils/http/http.go
@@ -61,7 +61,7 @@ func (h *HTTPRequest) SendRequest() (responseBody []byte, statusCode int, header
 		h.Logger.Warnw("http adapter got error", "error", err)
 		return nil, 0, nil, err
 	}
-	defer h.Logger.ErrorIfClosing(r.Body, "SendRequest response body")
+	defer logger.Sugared(h.Logger).ErrorIfFn(r.Body.Close, "Error closing SendRequest response body")
 
 	statusCode = r.StatusCode
 	elapsed := time.Since(start)

--- a/core/web/csa_keys_controller.go
+++ b/core/web/csa_keys_controller.go
@@ -55,7 +55,7 @@ func (ctrl *CSAKeysController) Create(c *gin.Context) {
 
 // Import imports a CSA key
 func (ctrl *CSAKeysController) Import(c *gin.Context) {
-	defer ctrl.App.GetLogger().ErrorIfClosing(c.Request.Body, "Import request body")
+	defer ctrl.App.GetLogger().ErrorIfFn(c.Request.Body.Close, "Error closing Import request body")
 
 	bytes, err := io.ReadAll(c.Request.Body)
 	if err != nil {
@@ -79,7 +79,7 @@ func (ctrl *CSAKeysController) Import(c *gin.Context) {
 
 // Export exports a key
 func (ctrl *CSAKeysController) Export(c *gin.Context) {
-	defer ctrl.App.GetLogger().ErrorIfClosing(c.Request.Body, "Export request body")
+	defer ctrl.App.GetLogger().ErrorIfFn(c.Request.Body.Close, "Error closing Export request body")
 
 	keyID := c.Param("ID")
 	newPassword := c.Query("newpassword")

--- a/core/web/eth_keys_controller.go
+++ b/core/web/eth_keys_controller.go
@@ -246,7 +246,7 @@ func (ekc *ETHKeysController) Delete(c *gin.Context) {
 // Import imports a key
 func (ekc *ETHKeysController) Import(c *gin.Context) {
 	ethKeyStore := ekc.app.GetKeyStore().Eth()
-	defer ekc.app.GetLogger().ErrorIfClosing(c.Request.Body, "Import request body")
+	defer ekc.app.GetLogger().ErrorIfFn(c.Request.Body.Close, "Error closing Import request body")
 
 	bytes, err := io.ReadAll(c.Request.Body)
 	if err != nil {
@@ -292,7 +292,7 @@ func (ekc *ETHKeysController) Import(c *gin.Context) {
 }
 
 func (ekc *ETHKeysController) Export(c *gin.Context) {
-	defer ekc.app.GetLogger().ErrorIfClosing(c.Request.Body, "Export request body")
+	defer ekc.app.GetLogger().ErrorIfFn(c.Request.Body.Close, "Error closing Export request body")
 
 	id := c.Param("address")
 	newPassword := c.Query("newpassword")
@@ -314,7 +314,7 @@ func (ekc *ETHKeysController) Export(c *gin.Context) {
 // Chain updates settings for a given chain for the key
 func (ekc *ETHKeysController) Chain(c *gin.Context) {
 	kst := ekc.app.GetKeyStore().Eth()
-	defer ekc.app.GetLogger().ErrorIfClosing(c.Request.Body, "Import request body")
+	defer ekc.app.GetLogger().ErrorIfFn(c.Request.Body.Close, "Error closing Import request body")
 
 	addressHex := c.Query("address")
 	addressBytes, err := hexutil.Decode(addressHex)

--- a/core/web/keys_controller.go
+++ b/core/web/keys_controller.go
@@ -37,7 +37,7 @@ type KeysController interface {
 
 type keysController[K keystore.Key, R jsonapi.EntityNamer] struct {
 	ks           Keystore[K]
-	lggr         logger.Logger
+	lggr         logger.SugaredLogger
 	auditLogger  audit.AuditLogger
 	typ          string
 	resourceName string
@@ -54,7 +54,7 @@ func NewKeysController[K keystore.Key, R jsonapi.EntityNamer](ks Keystore[K], lg
 	}
 	return &keysController[K, R]{
 		ks:           ks,
-		lggr:         lggr,
+		lggr:         logger.Sugared(lggr),
 		auditLogger:  auditLogger,
 		typ:          typ,
 		resourceName: resourceName,
@@ -109,7 +109,7 @@ func (kc *keysController[K, R]) Delete(c *gin.Context) {
 }
 
 func (kc *keysController[K, R]) Import(c *gin.Context) {
-	defer kc.lggr.ErrorIfClosing(c.Request.Body, "Import ")
+	defer kc.lggr.ErrorIfFn(c.Request.Body.Close, "Error closing Import request body")
 
 	bytes, err := io.ReadAll(c.Request.Body)
 	if err != nil {
@@ -132,7 +132,7 @@ func (kc *keysController[K, R]) Import(c *gin.Context) {
 }
 
 func (kc *keysController[K, R]) Export(c *gin.Context) {
-	defer kc.lggr.ErrorIfClosing(c.Request.Body, "Export request body")
+	defer kc.lggr.ErrorIfFn(c.Request.Body.Close, "Error closing Export request body")
 
 	keyID := c.Param("ID")
 	newPassword := c.Query("newpassword")

--- a/core/web/middleware.go
+++ b/core/web/middleware.go
@@ -91,14 +91,14 @@ func (e *EmbedFileSystem) Open(name string) (http.File, error) {
 // existence of the file
 type gzipFileHandler struct {
 	root ServeFileSystem
-	lggr logger.Logger
+	lggr logger.SugaredLogger
 }
 
 // GzipFileServer is a drop-in replacement for Go's standard http.FileServer
 // which adds support for static resources precompressed with gzip, at
 // the cost of removing the support for directory browsing.
 func GzipFileServer(root ServeFileSystem, lggr logger.Logger) http.Handler {
-	return &gzipFileHandler{root, lggr.Named("GzipFilehandler")}
+	return &gzipFileHandler{root, logger.Sugared(lggr.Named("GzipFilehandler"))}
 }
 
 func (f *gzipFileHandler) openAndStat(path string) (http.File, os.FileInfo, error) {
@@ -216,7 +216,7 @@ func (f *gzipFileHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Find the best acceptable file, including trying uncompressed
 	if file, info, err := f.findBestFile(w, r, fpath); err == nil {
 		http.ServeContent(w, r, fpath, info.ModTime(), file)
-		f.lggr.ErrorIfClosing(file, "file")
+		f.lggr.ErrorIfFn(file.Close, "Error closing file")
 		return
 	}
 

--- a/core/web/ocr2_keys_controller.go
+++ b/core/web/ocr2_keys_controller.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/gin-gonic/gin"
 	"github.com/pkg/errors"
+
 	"github.com/smartcontractkit/chainlink/core/logger/audit"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/services/keystore/chaintype"
@@ -79,7 +80,7 @@ func (ocr2kc *OCR2KeysController) Delete(c *gin.Context) {
 // Example:
 // "Post <application>/keys/ocr/import"
 func (ocr2kc *OCR2KeysController) Import(c *gin.Context) {
-	defer ocr2kc.App.GetLogger().ErrorIfClosing(c.Request.Body, "Import request body")
+	defer ocr2kc.App.GetLogger().ErrorIfFn(c.Request.Body.Close, "Error closing Import request body")
 
 	bytes, err := io.ReadAll(c.Request.Body)
 	if err != nil {
@@ -109,7 +110,7 @@ func (ocr2kc *OCR2KeysController) Import(c *gin.Context) {
 // Example:
 // "Post <application>/keys/ocr/export"
 func (ocr2kc *OCR2KeysController) Export(c *gin.Context) {
-	defer ocr2kc.App.GetLogger().ErrorIfClosing(c.Request.Body, "Export response body")
+	defer ocr2kc.App.GetLogger().ErrorIfFn(c.Request.Body.Close, "Error closing Export response body")
 
 	stringID := c.Param("ID")
 	newPassword := c.Query("newpassword")

--- a/core/web/ocr_keys_controller.go
+++ b/core/web/ocr_keys_controller.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
+
 	"github.com/smartcontractkit/chainlink/core/logger/audit"
 	"github.com/smartcontractkit/chainlink/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/core/web/presenters"
@@ -69,7 +70,7 @@ func (ocrkc *OCRKeysController) Delete(c *gin.Context) {
 // Example:
 // "Post <application>/keys/ocr/import"
 func (ocrkc *OCRKeysController) Import(c *gin.Context) {
-	defer ocrkc.App.GetLogger().ErrorIfClosing(c.Request.Body, "Import request body")
+	defer ocrkc.App.GetLogger().ErrorIfFn(c.Request.Body.Close, "Error closing Import request body")
 
 	bytes, err := io.ReadAll(c.Request.Body)
 	if err != nil {
@@ -96,7 +97,7 @@ func (ocrkc *OCRKeysController) Import(c *gin.Context) {
 // Example:
 // "Post <application>/keys/ocr/export"
 func (ocrkc *OCRKeysController) Export(c *gin.Context) {
-	defer ocrkc.App.GetLogger().ErrorIfClosing(c.Request.Body, "Export response body")
+	defer ocrkc.App.GetLogger().ErrorIfFn(c.Request.Body.Close, "Error closing Export response body")
 
 	stringID := c.Param("ID")
 	newPassword := c.Query("newpassword")

--- a/core/web/p2p_keys_controller.go
+++ b/core/web/p2p_keys_controller.go
@@ -82,7 +82,7 @@ func (p2pkc *P2PKeysController) Delete(c *gin.Context) {
 // Example:
 // "Post <application>/keys/p2p/import"
 func (p2pkc *P2PKeysController) Import(c *gin.Context) {
-	defer p2pkc.App.GetLogger().ErrorIfClosing(c.Request.Body, "Import ")
+	defer p2pkc.App.GetLogger().ErrorIfFn(c.Request.Body.Close, "Error closing Import request body")
 
 	bytes, err := io.ReadAll(c.Request.Body)
 	if err != nil {
@@ -111,7 +111,7 @@ func (p2pkc *P2PKeysController) Import(c *gin.Context) {
 // Example:
 // "Post <application>/keys/p2p/export"
 func (p2pkc *P2PKeysController) Export(c *gin.Context) {
-	defer p2pkc.App.GetLogger().ErrorIfClosing(c.Request.Body, "Export request body")
+	defer p2pkc.App.GetLogger().ErrorIfFn(c.Request.Body.Close, "Error closing Export request body")
 
 	keyID, err := p2pkey.MakePeerID(c.Param("ID"))
 	if err != nil {

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -447,7 +447,7 @@ var indexRateLimitPeriod = 1 * time.Minute
 
 // guiAssetRoutes serves the operator UI static files and index.html. Rate
 // limiting is disabled when in dev mode.
-func guiAssetRoutes(engine *gin.Engine, devMode bool, lggr logger.Logger) {
+func guiAssetRoutes(engine *gin.Engine, devMode bool, lggr logger.SugaredLogger) {
 	// Serve static files
 	var assetsRouterHandlers []gin.HandlerFunc
 	if !devMode {
@@ -504,7 +504,7 @@ func guiAssetRoutes(engine *gin.Engine, devMode bool, lggr logger.Logger) {
 			}
 			return
 		}
-		defer lggr.ErrorIfClosing(file, "file")
+		defer lggr.ErrorIfFn(file.Close, "Error closing file")
 
 		http.ServeContent(c.Writer, c.Request, path, time.Time{}, file)
 	})

--- a/core/web/vrf_keys_controller.go
+++ b/core/web/vrf_keys_controller.go
@@ -77,7 +77,7 @@ func (vrfkc *VRFKeysController) Delete(c *gin.Context) {
 // Example:
 // "Post <application>/keys/vrf/import"
 func (vrfkc *VRFKeysController) Import(c *gin.Context) {
-	defer vrfkc.App.GetLogger().ErrorIfClosing(c.Request.Body, "Import request body")
+	defer vrfkc.App.GetLogger().ErrorIfFn(c.Request.Body.Close, "Error closing Import request body")
 
 	bytes, err := io.ReadAll(c.Request.Body)
 	if err != nil {
@@ -105,7 +105,7 @@ func (vrfkc *VRFKeysController) Import(c *gin.Context) {
 // Example:
 // "Post <application>/keys/vrf/export/:keyID"
 func (vrfkc *VRFKeysController) Export(c *gin.Context) {
-	defer vrfkc.App.GetLogger().ErrorIfClosing(c.Request.Body, "Export request body")
+	defer vrfkc.App.GetLogger().ErrorIfFn(c.Request.Body.Close, "Error closing Export request body")
 
 	keyID := c.Param("keyID")
 	// New password to re-encrypt the export with


### PR DESCRIPTION
- convert deprecated `Logger.ErrorIf*` uses to `SugaredLogger`
- add `Config.LogsFiles`; unexport `logsFile`