### PR TITLE
core/chains/evm/client: handle nil total difficulty

### DIFF
--- a/core/chains/evm/client/node_lifecycle_test.go
+++ b/core/chains/evm/client/node_lifecycle_test.go
@@ -353,7 +353,7 @@ func TestUnit_NodeLifecycle_aliveLoop(t *testing.T) {
 		iN := NewNode(cfg, logger.TestLogger(t), *s.WSURL(), nil, "test node", 42, testutils.FixtureChainID)
 		n := iN.(*node)
 		n.nLiveNodes = func() (count int, blockNumber int64, totalDifficulty *utils.Big) {
-			return 2, highestHead.Load(), utils.NewBigI(0)
+			return 2, highestHead.Load(), nil
 		}
 
 		dial(t, n)
@@ -415,7 +415,7 @@ func TestUnit_NodeLifecycle_aliveLoop(t *testing.T) {
 		iN := NewNode(cfg, logger.TestLogger(t), *s.WSURL(), nil, "test node", 42, testutils.FixtureChainID)
 		n := iN.(*node)
 		n.nLiveNodes = func() (count int, blockNumber int64, totalDifficulty *utils.Big) {
-			return 2, highestHead.Load(), utils.NewBigI(0)
+			return 2, highestHead.Load(), nil
 		}
 
 		dial(t, n)
@@ -474,7 +474,7 @@ func TestUnit_NodeLifecycle_aliveLoop(t *testing.T) {
 		iN := NewNode(cfg, lggr, *s.WSURL(), nil, "test node", 42, testutils.FixtureChainID)
 		n := iN.(*node)
 		n.nLiveNodes = func() (count int, blockNumber int64, totalDifficulty *utils.Big) {
-			return 1, highestHead.Load(), utils.NewBigI(0)
+			return 1, highestHead.Load(), nil
 		}
 
 		dial(t, n)
@@ -660,7 +660,7 @@ func TestUnit_NodeLifecycle_outOfSyncLoop(t *testing.T) {
 		iN := NewNode(cfg, lggr, *s.WSURL(), nil, "test node", 0, testutils.FixtureChainID)
 		n := iN.(*node)
 		n.nLiveNodes = func() (count int, blockNumber int64, totalDifficulty *utils.Big) {
-			return 2, stall + int64(cfg.SyncThreshold), utils.NewBigI(0)
+			return 2, stall + int64(cfg.SyncThreshold), nil
 		}
 
 		start(t, n)

--- a/core/chains/evm/client/pool.go
+++ b/core/chains/evm/client/pool.go
@@ -143,14 +143,16 @@ func (p *Pool) Dial(ctx context.Context) error {
 }
 
 // nLiveNodes returns the number of currently alive nodes, as well as the highest block number and greatest total difficulty.
+// totalDifficulty will be 0 if all nodes return nil.
 func (p *Pool) nLiveNodes() (nLiveNodes int, blockNumber int64, totalDifficulty *utils.Big) {
+	totalDifficulty = utils.NewBigI(0)
 	for _, n := range p.nodes {
 		if s, num, td := n.StateAndLatest(); s == NodeStateAlive {
 			nLiveNodes++
 			if num > blockNumber {
 				blockNumber = num
 			}
-			if totalDifficulty == nil || td.Cmp(totalDifficulty) > 0 {
+			if td != nil && td.Cmp(totalDifficulty) > 0 {
 				totalDifficulty = td
 			}
 		}


### PR DESCRIPTION
Some chains return `nil` `totalDifficulty` instead of zero, which has to be accounted for, even when running in `RoundRobin`/`HighestHead`.