### PR TITLE
core/chains/evm/client: save latest received head info from out of sync loop

### DIFF
--- a/core/chains/evm/client/node_lifecycle.go
+++ b/core/chains/evm/client/node_lifecycle.go
@@ -311,6 +311,7 @@ func (n *node) outOfSyncLoop(isOutOfSync func(num int64, td *utils.Big) bool) {
 				n.declareUnreachable()
 				return
 			}
+			n.setLatestReceived(head.Number, head.TotalDifficulty)
 			if !isOutOfSync(head.Number, head.TotalDifficulty) {
 				// back in-sync! flip back into alive loop
 				lggr.Infow(fmt.Sprintf("%s: %s. Node was out-of-sync for %s", msgInSync, n.String(), time.Since(outOfSyncAt)), "blockNumber", head.Number, "totalDifficulty", head.TotalDifficulty, "nodeState", n.State())

--- a/core/chains/evm/client/node_lifecycle_test.go
+++ b/core/chains/evm/client/node_lifecycle_test.go
@@ -631,7 +631,8 @@ func TestUnit_NodeLifecycle_outOfSyncLoop(t *testing.T) {
 		testutils.WaitForLogMessage(t, observedLogs, msgInSync)
 
 		testutils.AssertEventually(t, func() bool {
-			return n.State() == NodeStateAlive
+			s, n, td := n.StateAndLatest()
+			return s == NodeStateAlive && n != -1 && td != nil
 		})
 	})
 
@@ -688,7 +689,8 @@ func TestUnit_NodeLifecycle_outOfSyncLoop(t *testing.T) {
 		testutils.WaitForLogMessage(t, observedLogs, msgInSync)
 
 		testutils.AssertEventually(t, func() bool {
-			return n.State() == NodeStateAlive
+			s, n, td := n.StateAndLatest()
+			return s == NodeStateAlive && n != -1 && td != nil
 		})
 	})
 


### PR DESCRIPTION
Before this change, the latest received head info (block and totalDifficulty) would only be saved from the `aliveLoop`, now it is updated from the `outOfSyncLoop` as well, where we also receive heads. This ensures that the information is up to date when we resume the `aliveLoop`, which prevents a possible mistaken transition back out-of-sync (when `SyncThreshold` != 0), if the poll chan triggers before the next head arrives.