### PR TITLE
Apply "integration" build tag to VRF Integration tests.

### DIFF
--- a/core/services/ocr2/plugins/ocr2vrf/internal/ocr2vrf_integration_test.go
+++ b/core/services/ocr2/plugins/ocr2vrf/internal/ocr2vrf_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -299,10 +300,16 @@ func setupNodeOCR2(
 }
 
 func TestIntegration_OCR2VRF_ForwarderFlow(t *testing.T) {
+	if os.Getenv("CI") == "" && os.Getenv("VRF_LOCAL_TESTING") == "" {
+		t.Skip("Skipping test locally.")
+	}
 	runOCR2VRFTest(t, true)
 }
 
 func TestIntegration_OCR2VRF(t *testing.T) {
+	if os.Getenv("CI") == "" && os.Getenv("VRF_LOCAL_TESTING") == "" {
+		t.Skip("Skipping test locally.")
+	}
 	runOCR2VRFTest(t, false)
 }
 

--- a/core/services/ocr2/plugins/ocr2vrf/internal/ocr2vrf_integration_test.go
+++ b/core/services/ocr2/plugins/ocr2vrf/internal/ocr2vrf_integration_test.go
@@ -1,3 +1,5 @@
+//go:build integration
+
 package internal_test
 
 import (
@@ -8,7 +10,6 @@ import (
 	"fmt"
 	"math/big"
 	"net"
-	"os"
 	"testing"
 	"time"
 
@@ -56,6 +57,9 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
+
+// Note: these are using the "integration" build tag.
+// To run, use: go test -tags integration
 
 type ocr2vrfUniverse struct {
 	owner   *bind.TransactOpts
@@ -300,16 +304,10 @@ func setupNodeOCR2(
 }
 
 func TestIntegration_OCR2VRF_ForwarderFlow(t *testing.T) {
-	if os.Getenv("CI") == "" && os.Getenv("VRF_LOCAL_TESTING") == "" {
-		t.Skip("Skipping test locally.")
-	}
 	runOCR2VRFTest(t, true)
 }
 
 func TestIntegration_OCR2VRF(t *testing.T) {
-	if os.Getenv("CI") == "" && os.Getenv("VRF_LOCAL_TESTING") == "" {
-		t.Skip("Skipping test locally.")
-	}
 	runOCR2VRFTest(t, false)
 }
 


### PR DESCRIPTION
These tests fail locally with parallelism on. Per [this link](https://github.blog/changelog/2020-04-15-github-actions-sets-the-ci-environment-variable-to-true/), the CI enables the "CI" envar for its tests by default, so these tests can be restricted to CI only, unless the VRF_LOCAL_TESTING override is enabled.