### PR TITLE
core/services/ocr2/plugins: Skip VRF tests locally

### DIFF
--- a/core/services/ocr2/plugins/ocr2vrf/internal/ocr2vrf_integration_test.go
+++ b/core/services/ocr2/plugins/ocr2vrf/internal/ocr2vrf_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/big"
 	"net"
+	"os"
 	"testing"
 	"time"
 
@@ -304,10 +305,16 @@ func setupNodeOCR2(
 }
 
 func TestIntegration_OCR2VRF_ForwarderFlow(t *testing.T) {
+	if os.Getenv("CI") == "" && os.Getenv("VRF_LOCAL_TESTING") == "" {
+		t.Skip("Skipping test locally.")
+	}
 	runOCR2VRFTest(t, true)
 }
 
 func TestIntegration_OCR2VRF(t *testing.T) {
+	if os.Getenv("CI") == "" && os.Getenv("VRF_LOCAL_TESTING") == "" {
+		t.Skip("Skipping test locally.")
+	}
 	runOCR2VRFTest(t, false)
 }
 

--- a/core/services/ocr2/plugins/ocr2vrf/internal/ocr2vrf_integration_test.go
+++ b/core/services/ocr2/plugins/ocr2vrf/internal/ocr2vrf_integration_test.go
@@ -1,5 +1,3 @@
-//go:build integration
-
 package internal_test
 
 import (
@@ -58,9 +56,6 @@ import (
 	"github.com/smartcontractkit/chainlink/core/store/models"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
-
-// Note: these are using the "integration" build tag.
-// To run, use: go test -tags integration
 
 type ocr2vrfUniverse struct {
 	owner   *bind.TransactOpts


### PR DESCRIPTION
Unless VRF_LOCAL_TESTING is set.

Cherry picked from [`4c1df44` (#8162)](https://github.com/smartcontractkit/chainlink/pull/8162/commits/4c1df447e34ac27afbc1402505585cd2c14f827f)