### PR TITLE
logpoller:  async replay

### DIFF
--- a/core/chains/evm/logpoller/helper_test.go
+++ b/core/chains/evm/logpoller/helper_test.go
@@ -106,7 +106,7 @@ func (lp *logPoller) WaitForReplayComplete() error {
 	case err := <-lp.replayComplete:
 		return err
 	case <-lp.ctx.Done():
-		return errors.New("Logpoller received shutdown signal while waiting for replay to complete")
+		return errors.Wrap(lp.ctx.Err(), "Logpoller received shutdown signal while waiting for replay to complete")
 	}
 }
 

--- a/core/internal/mocks/application.go
+++ b/core/internal/mocks/application.go
@@ -368,13 +368,13 @@ func (_m *Application) PipelineORM() pipeline.ORM {
 	return r0
 }
 
-// ReplayFromBlock provides a mock function with given fields: chainID, number, forceBroadcast
-func (_m *Application) ReplayFromBlock(chainID *big.Int, number uint64, forceBroadcast bool) error {
-	ret := _m.Called(chainID, number, forceBroadcast)
+// ReplayFromBlock provides a mock function with given fields: ctx, chainID, number, forceBroadcast
+func (_m *Application) ReplayFromBlock(ctx context.Context, chainID *big.Int, number uint64, forceBroadcast bool) error {
+	ret := _m.Called(ctx, chainID, number, forceBroadcast)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(*big.Int, uint64, bool) error); ok {
-		r0 = rf(chainID, number, forceBroadcast)
+	if rf, ok := ret.Get(0).(func(context.Context, *big.Int, uint64, bool) error); ok {
+		r0 = rf(ctx, chainID, number, forceBroadcast)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -103,7 +103,7 @@ type Application interface {
 
 	// ReplayFromBlock replays logs from on or after the given block number. If forceBroadcast is
 	// set to true, consumers will reprocess data even if it has already been processed.
-	ReplayFromBlock(chainID *big.Int, number uint64, forceBroadcast bool) error
+	ReplayFromBlock(ctx context.Context, chainID *big.Int, number uint64, forceBroadcast bool) error
 
 	// ID is unique to this particular application instance
 	ID() uuid.UUID
@@ -774,14 +774,14 @@ func (app *ChainlinkApplication) GetFeedsService() feeds.Service {
 }
 
 // ReplayFromBlock implements the Application interface.
-func (app *ChainlinkApplication) ReplayFromBlock(chainID *big.Int, number uint64, forceBroadcast bool) error {
+func (app *ChainlinkApplication) ReplayFromBlock(ctx context.Context, chainID *big.Int, number uint64, forceBroadcast bool) error {
 	chain, err := app.Chains.EVM.Get(chainID)
 	if err != nil {
 		return err
 	}
 	chain.LogBroadcaster().ReplayFromBlock(int64(number), forceBroadcast)
 	if app.Config.FeatureLogPoller() {
-		if err := chain.LogPoller().Replay(context.Background(), int64(number)); err != nil {
+		if err := chain.LogPoller().Replay(ctx, int64(number)); err != nil {
 			return err
 		}
 	}

--- a/core/web/replay_controller.go
+++ b/core/web/replay_controller.go
@@ -17,7 +17,8 @@ type ReplayController struct {
 
 // ReplayFromBlock causes the node to process blocks again from the given block number
 // Example:
-//  "<application>/v2/replay_from_block/:number"
+//
+//	"<application>/v2/replay_from_block/:number"
 func (bdc *ReplayController) ReplayFromBlock(c *gin.Context) {
 	if c.Param("number") == "" {
 		jsonAPIError(c, http.StatusUnprocessableEntity, errors.New("missing 'number' parameter"))
@@ -58,7 +59,7 @@ func (bdc *ReplayController) ReplayFromBlock(c *gin.Context) {
 	}
 	chainID := chain.ID()
 
-	if err := bdc.App.ReplayFromBlock(chainID, uint64(blockNumber), force); err != nil {
+	if err := bdc.App.ReplayFromBlock(c.Request.Context(), chainID, uint64(blockNumber), force); err != nil {
 		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
 	}


### PR DESCRIPTION
Convert lp.Replay() to async
- Use request context instead of ctx.Background while waiting for log poller to accept replay
- Use lp.ctx in run() instead of ctx.Background for replay