### PR TITLE
Exlcude Bedrock special transaction type

### DIFF
--- a/core/chains/evm/gas/chain_specific.go
+++ b/core/chains/evm/gas/chain_specific.go
@@ -18,5 +18,15 @@ func chainSpecificIsUsable(tx evmtypes.Transaction, cfg Config) bool {
 			return false
 		}
 	}
+	if cfg.ChainType() == config.ChainOptimismBedrock {
+		// This is a special deposit transaction type introduced in Bedrock upgrade.
+		// This is a system transaction that it will occur at least one time per block.
+		// We should discard this type before even processing it to avoid flooding the
+		// logs with warnings.
+		// https://github.com/ethereum-optimism/optimism/blob/develop/specs/deposits.md
+		if tx.Type == 0x7e {
+			return false
+		}
+	}
 	return true
 }


### PR DESCRIPTION
Bedrock introduces a special transaction type that should be discarded before even processing it.