### PR TITLE
core/services/chainlink: dump explicit P2P.V1.Enabled = false if V2 only

### DIFF
--- a/core/services/chainlink/cfgtest/dump/full-custom.toml
+++ b/core/services/chainlink/cfgtest/dump/full-custom.toml
@@ -129,7 +129,6 @@ PeerID = '12D3KooWMk13oppZXmGdRZgaJBFDF6Tc5521YYxKjwkscLSEPrVW'
 TraceLogging = true
 
 [P2P.V1]
-Enabled = true
 AnnounceIP = '1.2.3.4'
 AnnouncePort = 57
 BootstrapCheckInterval = '1h0m0s'

--- a/core/services/chainlink/config_dump.go
+++ b/core/services/chainlink/config_dump.go
@@ -693,8 +693,8 @@ func (c *Config) loadLegacyCoreEnv() error {
 		NewStreamTimeout:                 envDuration("OCRNewStreamTimeout", "P2PNewStreamTimeout"),
 		PeerstoreWriteInterval:           envDuration("P2PPeerstoreWriteInterval"),
 	}
-	if (ns == v1 || ns == v1v2) && c.P2P.V1 != (config.P2PV1{}) {
-		c.P2P.V1.Enabled = ptr(true)
+	if ns == v2 {
+		c.P2P.V1.Enabled = ptr(false)
 	}
 
 	c.P2P.V2 = config.P2PV2{


### PR DESCRIPTION
The `P2P.V1.Enabled` logic incorrectly matched `V2`, by only setting explicit `true` values so that otherwise the default is used. The `V1.Enabled` default value is actually `true` already, so it needs to do the opposite and only set explicit `false` values.