### PR TITLE
Remove henrynguyen5 from CI/CD codeowners

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -58,7 +58,7 @@
 /core/internal @samsondav @jmank88
 
 # CI/CD
-/.github/** @alexroan @chainchad @HenryNguyen5 @javuto @jkongie @jmank88 @samsondav
+/.github/** @alexroan @chainchad @javuto @jkongie @jmank88 @samsondav
 /.github/workflows/integration-tests.yml @kalverra @tateexon @skudasov @anieeg
 /.github/workflows/integration-chaos-tests.yml @kalverra @tateexon @skudasov @anieeg
 /.github/workflows/performance-tests.yml @kalverra @tateexon @skudasov @anieeg


### PR DESCRIPTION
This contributed to noise more than anything, no notifications gave any
value since this codeowner rule was implmemented
