### PR TITLE
core/chains/evm/client: improve flakey TestUnit_NodeLifecycle_outOfSyncLoop

### DIFF
--- a/core/chains/evm/client/node_lifecycle_test.go
+++ b/core/chains/evm/client/node_lifecycle_test.go
@@ -686,12 +686,12 @@ func TestUnit_NodeLifecycle_outOfSyncLoop(t *testing.T) {
 		msg := makeNewHeadWSMessage(stall)
 		s.MustWriteBinaryMessageSync(t, msg)
 
-		testutils.WaitForLogMessage(t, observedLogs, msgInSync)
-
 		testutils.AssertEventually(t, func() bool {
 			s, n, td := n.StateAndLatest()
 			return s == NodeStateAlive && n != -1 && td != nil
 		})
+
+		testutils.WaitForLogMessage(t, observedLogs, msgInSync)
 	})
 
 	t.Run("if no live nodes are available, forcibly marks this one alive again", func(t *testing.T) {


### PR DESCRIPTION
This should improve a common flakey test.

The order of the checks doesn't matter for correctness, and after swapping them I haven't been able to reproduce the failure locally anymore :crossed_fingers:  