### PR TITLE
(docs): Update relative URLs in contracts README to be Github links

### DIFF
--- a/contracts/README.md
+++ b/contracts/README.md
@@ -51,10 +51,10 @@ $ pnpm test
 
 ## Contributing
 
-Please try to adhere to [Solidity Style Guide](./STYLE.md).
+Please try to adhere to [Solidity Style Guide](https://github.com/smartcontractkit/chainlink/blob/develop/contracts/STYLE.md).
 
 Contributions are welcome! Please refer to
-[Chainlink's contributing guidelines](../docs/CONTRIBUTING.md) for detailed
+[Chainlink's contributing guidelines](https://github.com/smartcontractkit/chainlink/blob/develop/docs/CONTRIBUTING.md) for detailed
 contribution information.
 
 Thank you!


### PR DESCRIPTION
This changelog is used on [NPM](https://www.npmjs.com/package/@chainlink/contracts) which requires absolute URL's to markdown files.