### PR TITLE
Fix CHANGELOG checker

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -21,7 +21,7 @@ jobs:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
           pattern: '^docs/CHANGELOG.*$'
       - name: Make a comment
-        uses: unsplash/comment-on-pr@b5610c6125a7197eaec80072ea35ef53e1fc6035 # Version v1.3.1
+        uses: unsplash/comment-on-pr@ffe8f97ccc63ce12c3c23c6885b169db67958d3b # Version 1.3.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: contains(steps.changedfiles.outputs.files_updated, 'CHANGELOG') != true && contains(steps.changedfiles.outputs.files_created, 'CHANGELOG') != true


### PR DESCRIPTION
Dependabot recently updated version of the comment-on-pr github action from verison 1.3.0 to 1.3.1, but this version is completely broken.
Our changelog checker hasn't been able to run since.

Looks like it's already been fixed on master (see: https://github.com/unsplash/comment-on-pr/pull/52) but for some reason the tag hasn't been moved.
Rolling back to 1.3.0 instead to have an official release version.