### PR TITLE
tools/bin: simplify go_core_tests

### DIFF
--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -8,20 +8,8 @@ OUTPUT_FILE="./output.txt"
 echo "Failed tests and panics: ---------------------"
 echo ""
 GO_LDFLAGS=$(bash tools/bin/ldflags)
-go test -ldflags "$GO_LDFLAGS" -tags integration -p 3 -coverprofile=coverage.txt -covermode=atomic $1 | tee $OUTPUT_FILE | grep --line-buffered --line-number -e "\-\-\- FAIL" -e "FAIL\s"
+go test -ldflags "$GO_LDFLAGS" -tags integration -p 3 -coverprofile=coverage.txt -covermode=atomic $1 | tee $OUTPUT_FILE
 EXITCODE=${PIPESTATUS[0]}
-echo ""
-echo "----------------------------------------------"
-
-echo ""
-echo "(Note: panics abruptly end the test run and may appear out-of-place, not where they originate."
-echo "Finding their origin test may involve disabling parallelism)"
-echo ""
-echo "Potentially related:"
-echo ""
-
-grep --after-context=2 --group-separator=$'---' "panic: " $OUTPUT_FILE
-grep --group-separator=$'---' "driver: bad connection" $OUTPUT_FILE
 
 # Assert no known sensitive strings present in test logger output
 printf "\n----------------------------------------------\n\n"


### PR DESCRIPTION
Test logs used to be quite large, because many tests and node subsystems were logging to std out, directly or indirectly, so everything would show up all mixed together on failure. Because of this, the logs are rerouted to a file, and we grep for interesting bits to let through. However, all logs have been scoped to just test loggers for some time now, so there is no extra noise on failure, and we can remove these grep filters to just let everything through instead.
Note: the log file is still in place for now, but perhaps it is redundant and could be removed? (as long as we can still download the job logs? :thinking:)