### PR TITLE
Fix bug in pipeline_runs COUNT() query

### DIFF
--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -1032,7 +1032,7 @@ func Test_FindPipelineRunIDsByJobID(t *testing.T) {
 	}
 
 	// Creation of job runs above cannot run in parallel, otherwise run ids are unpredictable
-	t.Parallel()
+	//t.Parallel()
 
 	t.Run("with no pipeline runs", func(t *testing.T) {
 		runIDs, err := orm.FindPipelineRunIDsByJobID(jb.ID, 0, 10)
@@ -1066,6 +1066,28 @@ func Test_FindPipelineRunIDsByJobID(t *testing.T) {
 		require.NoError(t, err)
 		require.Len(t, runIDs, 100)
 		assert.Equal(t, int64(67*(len(jobs)-1)), runIDs[12]-runIDs[79])
+	})
+
+	for i := 0; i < 2100; i++ {
+		mustInsertPipelineRun(t, pipelineORM, jb)
+	}
+
+	// There is a COUNT query which doesn't run unless the query for the most recent 1000 rows
+	//  returns empty.  This can happen if the job id being requested hasn't run in a while,
+	//  but many other jobs have run since.
+	t.Run("with first batch empty, over limit", func(t *testing.T) {
+		runIDs, err := orm.FindPipelineRunIDsByJobID(jobs[3].ID, 0, 25)
+		require.NoError(t, err)
+		require.Len(t, runIDs, 25)
+		assert.Equal(t, int64(16*(len(jobs)-1)), runIDs[7]-runIDs[23])
+	})
+
+	// Same as previous, but where there are fewer matching jobs than the limit
+	t.Run("with first batch empty, under limit", func(t *testing.T) {
+		runIDs, err := orm.FindPipelineRunIDsByJobID(jobs[3].ID, 143, 190)
+		require.NoError(t, err)
+		require.Len(t, runIDs, 107)
+		assert.Equal(t, int64(16*(len(jobs)-1)), runIDs[7]-runIDs[23])
 	})
 }
 

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -1031,9 +1031,6 @@ func Test_FindPipelineRunIDsByJobID(t *testing.T) {
 		}
 	}
 
-	// Creation of job runs above cannot run in parallel, otherwise run ids are unpredictable
-	//t.Parallel()
-
 	t.Run("with no pipeline runs", func(t *testing.T) {
 		runIDs, err := orm.FindPipelineRunIDsByJobID(jb.ID, 0, 10)
 		require.NoError(t, err)

--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -903,19 +903,19 @@ func (o *orm) loadPipelineRunIDs(jobID *int32, offset, limit int, tx pg.Queryer)
 				// If we're already receiving rows back, then we no longer need an offset
 				offset = 0
 			} else {
-				var skipped int
+				var skipped []int
 				// If no rows were returned, we need to know whether there were any ids skipped
 				//  in this batch due to the offset, and reduce it for the next batch
 				err = tx.Select(&skipped,
 					fmt.Sprintf(
-						`SELECT COUNT(p.id) FROM pipeline_runs AS p %s p.id >= $2 AND p.id <= $3`, filter,
-					),
+						`SELECT COUNT(p.id) FROM pipeline_runs AS p %s p.id >= $1 AND p.id <= $2`, filter,
+					), minID, maxID,
 				)
 				if err != nil {
 					err = errors.Wrap(err, "error loading from pipeline_runs")
 					return
 				}
-				offset -= skipped
+				offset -= skipped[0]
 				if offset < 0 { // sanity assertion, if this ever happened it would probably mean db corruption or pg bug
 					lggr.AssumptionViolationw("offset < 0 while reading pipeline_runs")
 					err = errors.Wrap(err, "internal db error while reading pipeline_runs")

--- a/core/services/pipeline/orm.go
+++ b/core/services/pipeline/orm.go
@@ -493,7 +493,7 @@ WHERE pipeline_runs.id = batched_pipeline_runs.id`,
 
 	deleteTS := time.Now()
 
-	o.lggr.Debugw("pipeline_runs reaper DELETE query completed", "rows_deleted", rowsDeleted, "duration", deleteTS.Sub(start))
+	o.lggr.Debugw("pipeline_runs reaper DELETE query completed", "rowsDeleted", rowsDeleted, "duration", deleteTS.Sub(start))
 	defer func(start time.Time) {
 		o.lggr.Debugw("pipeline_runs reaper VACUUM ANALYZE query completed", "duration", time.Since(start))
 	}(deleteTS)

--- a/core/services/pipeline/orm.go
+++ b/core/services/pipeline/orm.go
@@ -458,6 +458,8 @@ func (o *orm) DeleteRunsOlderThan(ctx context.Context, threshold time.Duration) 
 
 	queryThreshold := start.Add(-threshold)
 
+	rowsDeleted := int64(0)
+
 	err := pg.Batch(func(_, limit uint) (count uint, err error) {
 		result, cancel, err := q.ExecQIter(`
 WITH batched_pipeline_runs AS (
@@ -481,6 +483,7 @@ WHERE pipeline_runs.id = batched_pipeline_runs.id`,
 		if err != nil {
 			return count, errors.Wrap(err, "DeleteRunsOlderThan failed to get rows affected")
 		}
+		rowsDeleted += rowsAffected
 
 		return uint(rowsAffected), err
 	})
@@ -490,7 +493,7 @@ WHERE pipeline_runs.id = batched_pipeline_runs.id`,
 
 	deleteTS := time.Now()
 
-	o.lggr.Debugw("pipeline_runs reaper DELETE query completed", "duration", deleteTS.Sub(start))
+	o.lggr.Debugw("pipeline_runs reaper DELETE query completed", "rows_deleted", rowsDeleted, "duration", deleteTS.Sub(start))
 	defer func(start time.Time) {
 		o.lggr.Debugw("pipeline_runs reaper VACUUM ANALYZE query completed", "duration", time.Since(start))
 	}(deleteTS)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Removed `KEEPER_TURN_FLAG_ENABLED` as all networks/nodes have switched this to `true` now. The variable should be completely removed my NOPs.
 - Removed `Keeper.UpkeepCheckGasPriceEnabled` config (`KEEPER_CHECK_UPKEEP_GAS_PRICE_FEATURE_ENABLED` in old env var configuration) as this feature is deprecated now. The variable should be completely removed by NOPs.
 
+### Fixed
+
+- Fixed (SQLSTATE 42P18) error on Job Runs page, when attempting to view specific older or infrequenty run jobs
 <!-- unreleasedstop -->
 
 ## 1.11.0 - 2022-12-12


### PR DESCRIPTION
    Also added 2 tests for it. This was untested before, since it only gets
    run if the job you're searching for was not one of the most recent 1000
    job runs to complete.