### PR TITLE
linter cleanup

### DIFF
--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -248,8 +248,6 @@ func (lp *logPoller) Replay(ctx context.Context, fromBlock int64) error {
 	case <-ctx.Done():
 		return ErrReplayAbortedByClient
 	}
-	// Should never reach here.
-	return nil
 }
 
 func (lp *logPoller) Start(parentCtx context.Context) error {

--- a/core/scripts/ocr2vrf/main.go
+++ b/core/scripts/ocr2vrf/main.go
@@ -225,7 +225,7 @@ func main() {
 			},
 		}
 
-		setVRFBeaconConfig(e, *beaconAddress, commands)
+		commands.setVRFBeaconConfig(e, *beaconAddress)
 	case "coordinator-set-producer":
 		cmd := flag.NewFlagSet("coordinator-set-producer", flag.ExitOnError)
 		coordinatorAddress := cmd.String("coordinator-address", "", "VRF coordinator contract address")

--- a/core/scripts/ocr2vrf/util.go
+++ b/core/scripts/ocr2vrf/util.go
@@ -70,6 +70,7 @@ func setAuthorizedSenders(e helpers.Environment, forwarder common.Address, sende
 	f, err := authorized_forwarder.NewAuthorizedForwarder(forwarder, e.Ec)
 	helpers.PanicErr(err)
 	tx, err := f.SetAuthorizedSenders(e.Owner, senders)
+	helpers.PanicErr(err)
 	helpers.ConfirmTXMined(context.Background(), e.Ec, tx, e.ChainID)
 }
 
@@ -181,7 +182,7 @@ func setDKGConfig(e helpers.Environment, dkgAddress string, c dkgSetConfigArgs) 
 	helpers.ConfirmTXMined(context.Background(), e.Ec, tx, e.ChainID)
 }
 
-func setVRFBeaconConfig(e helpers.Environment, vrfBeaconAddr string, c vrfBeaconSetConfigArgs) {
+func (c *vrfBeaconSetConfigArgs) setVRFBeaconConfig(e helpers.Environment, vrfBeaconAddr string) {
 	oracleIdentities := toOraclesIdentityList(
 		helpers.ParseAddressSlice(c.onchainPubKeys),
 		strings.Split(c.offchainPubKeys, ","),


### PR DESCRIPTION
```
core/scripts/ocr2vrf/main.go:228:41: copylocks: call of setVRFBeaconConfig copies lock value: github.com/smartcontractkit/chainlink/core/scripts/ocr2vrf.vrfBeaconSetConfigArgs contains github.com/smartcontractkit/ocr2vrf/internal/vrf/protobuf.CoordinatorConfig contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
		setVRFBeaconConfig(e, *beaconAddress, commands)
		                                      ^
core/scripts/ocr2vrf/util.go:184:72: copylocks: setVRFBeaconConfig passes lock by value: github.com/smartcontractkit/chainlink/core/scripts/ocr2vrf.vrfBeaconSetConfigArgs contains github.com/smartcontractkit/ocr2vrf/internal/vrf/protobuf.CoordinatorConfig contains google.golang.org/protobuf/internal/impl.MessageState contains sync.Mutex (govet)
func setVRFBeaconConfig(e helpers.Environment, vrfBeaconAddr string, c vrfBeaconSetConfigArgs) {
                                                                       ^
core/chains/evm/logpoller/log_poller.go:252:2: unreachable: unreachable code (govet)
	return nil
	^
core/scripts/ocr2vrf/util.go:72:6: ineffectual assignment to err (ineffassign)
	tx, err := f.SetAuthorizedSenders(e.Owner, senders)
	    ^
```