### PR TITLE
[Functions] Call markLogConsumed earlier

### DIFF
--- a/core/services/directrequestocr/drlistener_test.go
+++ b/core/services/directrequestocr/drlistener_test.go
@@ -126,8 +126,6 @@ func PrepareAndStartDRListener(t *testing.T, expectPipelineRun bool) (*DRListene
 		Return(false, nil).
 		Run(func(args mock.Arguments) {
 			runBeganAwaiter.ItHappened()
-			fn := args.Get(4).(func(pg.Queryer) error)
-			require.NoError(t, fn(nil))
 		}).Once()
 
 	return uni, log, runBeganAwaiter


### PR DESCRIPTION
If pipeline execution takes a long time, log broadcaster can send the same log multiple times. Let's mark it as consumed as soon as we successfully write it to the DB.