### PR TITLE
[Functions] Adjust default job spec config

### DIFF
--- a/core/scripts/functions/templates/oracle.toml
+++ b/core/scripts/functions/templates/oracle.toml
@@ -25,8 +25,8 @@ decode_log -> decode_cbor -> run_computation -> parse_result -> parse_error
 chainID = {{chain_id}}
 
 [pluginConfig]
-minIncomingConfirmations = 2
-requestTimeoutBatchLookupSize = 5
-requestTimeoutCheckFrequencySec = 30
-requestTimeoutSec = 1_200
+minIncomingConfirmations = 3
+requestTimeoutSec = 300
+requestTimeoutCheckFrequencySec = 10
+requestTimeoutBatchLookupSize = 20
 listenerEventHandlerTimeoutSec = 120

--- a/core/services/ocr2/plugins/directrequestocr/test/internal/testutils.go
+++ b/core/services/ocr2/plugins/directrequestocr/test/internal/testutils.go
@@ -362,7 +362,10 @@ func AddOCR2Job(t *testing.T, app *cltest.TestApplication, contractAddress commo
 
 		[pluginConfig]
 		minIncomingConfirmations = 3
-		listenerEventHandlerTimeoutSec = 40
+		requestTimeoutSec = 300
+		requestTimeoutCheckFrequencySec = 10
+		requestTimeoutBatchLookupSize = 20
+		listenerEventHandlerTimeoutSec = 120
 	`, contractAddress, keyBundleID, transmitter))
 	require.NoError(t, err)
 	err = app.AddJobV2(testutils.Context(t), &job)


### PR DESCRIPTION
Set block confirmations to 3 and set slightly tighter timeout values. At some point we need to move them out to an external JSON config file. Having said that, I don't expect those values to change very often.