### PR TITLE
Avoid nonce-syncer stall if we enter retry loop (#8285)

### DIFF
--- a/core/chains/evm/txmgr/eth_broadcaster.go
+++ b/core/chains/evm/txmgr/eth_broadcaster.go
@@ -328,6 +328,7 @@ func (eb *EthBroadcaster) SyncNonce(ctx context.Context, k ethkey.State) {
 					}
 					continue
 				}
+				return
 			}
 		}
 	}


### PR DESCRIPTION
From: https://github.com/smartcontractkit/chainlink/pull/8285

* Avoid nonce-syncer stall if we enter retry loop

* Update core/chains/evm/txmgr/eth_broadcaster.go

Co-authored-by: Jordan Krage <jmank88@gmail.com>

* Fix

Co-authored-by: Jordan Krage <jmank88@gmail.com>
(cherry picked from commit 5ea4d1930e1dccba034e8a87312e850d8e13ab69)