### PR TITLE
Fix failed check existence of pipeline_spec while pruning runs

### DIFF
--- a/core/services/pipeline/orm.go
+++ b/core/services/pipeline/orm.go
@@ -686,7 +686,7 @@ LIMIT $3
 	if rowsAffected == 0 {
 		// check the spec still exists and garbage collect if necessary
 		var exists bool
-		if err := q.SelectContext(o.ctx, &exists, `SELECT EXISTS(SELECT * FROM pipeline_specs WHERE id = $1)`, pipelineSpecID); err != nil {
+		if err := q.GetContext(o.ctx, &exists, `SELECT EXISTS(SELECT * FROM pipeline_specs WHERE id = $1)`, pipelineSpecID); err != nil {
 			o.lggr.Errorw("Failed check existence of pipeline_spec while pruning runs", "err", err, "pipelineSpecID", pipelineSpecID)
 			return
 		}

--- a/core/services/pipeline/orm_test.go
+++ b/core/services/pipeline/orm_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/smartcontractkit/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink/core/bridges"
@@ -708,11 +709,18 @@ func Test_Prune(t *testing.T) {
 	cfg := configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.JobPipeline.MaxSuccessfulRuns = &n
 	})
-	lggr := logger.TestLogger(t)
+	lggr, observed := logger.TestLoggerObserved(t, zapcore.DebugLevel)
 	db := pgtest.NewSqlxDB(t)
 	porm := pipeline.NewORM(db, lggr, cfg)
 
 	ps1 := cltest.MustInsertPipelineSpec(t, db)
+
+	t.Run("when there are no runs to prune, does nothing", func(t *testing.T) {
+		porm.Prune(db, ps1.ID)
+
+		// no error logs; it did nothing
+		assert.Empty(t, observed.All())
+	})
 
 	// ps1 has:
 	// - 20 completed runs
@@ -753,5 +761,4 @@ func Test_Prune(t *testing.T) {
 	assert.Equal(t, 3, cnt)
 	cnt = pgtest.MustCount(t, db, "SELECT count(*) FROM pipeline_runs WHERE pipeline_spec_id = $1 AND state = $2", ps2.ID, pipeline.RunStatusSuspended)
 	assert.Equal(t, 3, cnt)
-
 }


### PR DESCRIPTION
Fixes: `[ERROR] Failed check existence of pipeline_spec while pruning runs pipeline/orm.go:690              err=expected slice but got bool logger=1.12.0@cf4531e.PipelineORM pipelineSpecID=51 `
