### PR TITLE
feeds: update count of pending job proposals

### DIFF
--- a/core/services/feeds/orm.go
+++ b/core/services/feeds/orm.go
@@ -319,10 +319,10 @@ func (o *orm) CountJobProposals() (count int64, err error) {
 func (o *orm) CountJobProposalsByStatus() (counts *JobProposalCounts, err error) {
 	stmt := `
 SELECT 
-	COUNT(*) filter (where job_proposals.status = 'pending') as pending,
-	COUNT(*) filter (where job_proposals.status = 'approved') as approved,
-	COUNT(*) filter (where job_proposals.status = 'rejected') as rejected,
-	COUNT(*) filter (where job_proposals.status = 'cancelled') as cancelled
+	COUNT(*) filter (where job_proposals.status = 'pending' OR job_proposals.pending_update = TRUE) as pending,
+	COUNT(*) filter (where job_proposals.status = 'approved' AND job_proposals.pending_update = FALSE) as approved,
+	COUNT(*) filter (where job_proposals.status = 'rejected' AND job_proposals.pending_update = FALSE) as rejected,
+	COUNT(*) filter (where job_proposals.status = 'cancelled' AND job_proposals.pending_update = FALSE) as cancelled
 FROM job_proposals;
 	`
 

--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -546,24 +546,62 @@ func Test_ORM_ListJobProposals(t *testing.T) {
 func Test_ORM_CountJobProposalsByStatus(t *testing.T) {
 	t.Parallel()
 
-	orm := setupORM(t)
-	fmID := createFeedsManager(t, orm)
-	uuid := uuid.NewV4()
+	var (
+		orm  = setupORM(t)
+		fmID = createFeedsManager(t, orm)
 
-	jp := &feeds.JobProposal{
-		RemoteUUID:     uuid,
+		// Set initial values for job proposal counts
+		wantApproved, wantRejected int64
+		wantPending, wantCancelled = int64(1), int64(1)
+	)
+
+	// Create a pending job proposal.
+	_, err := orm.CreateJobProposal(&feeds.JobProposal{
+		RemoteUUID:     uuid.NewV4(),
 		Status:         feeds.JobProposalStatusPending,
 		FeedsManagerID: fmID,
-	}
-
-	_, err := orm.CreateJobProposal(jp)
+	})
 	require.NoError(t, err)
 
+	// Create a cancelled job proposal.
+	cancelledUUID := uuid.NewV4()
+	_, err = orm.CreateJobProposal(&feeds.JobProposal{
+		RemoteUUID:     cancelledUUID,
+		Status:         feeds.JobProposalStatusCancelled,
+		FeedsManagerID: fmID,
+	})
+	require.NoError(t, err)
+
+	// Get the initial count and assert against expected values.
 	counts, err := orm.CountJobProposalsByStatus()
 	require.NoError(t, err)
 
-	wantPending := int64(1)
-	var wantApproved, wantRejected, wantCancelled int64
+	assert.Equal(t, wantPending, counts.Pending)
+	assert.Equal(t, wantApproved, counts.Approved)
+	assert.Equal(t, wantRejected, counts.Rejected)
+	assert.Equal(t, wantCancelled, counts.Cancelled)
+
+	// Upsert the cancelled job proposal to rejected
+	// which changes pending_update to TRUE, but leaves status as
+	// cancelled.
+	id, err := orm.UpsertJobProposal(&feeds.JobProposal{
+		RemoteUUID:     cancelledUUID,
+		Status:         feeds.JobProposalStatusRejected,
+		FeedsManagerID: fmID,
+	})
+	require.NoError(t, err)
+
+	// Assert that the upserted job proposal is now pending update.
+	jp, err := orm.GetJobProposal(id)
+	require.NoError(t, err)
+	assert.Equal(t, true, jp.PendingUpdate)
+
+	// Get final counts of job proposals and make assertions.
+	counts, err = orm.CountJobProposalsByStatus()
+	require.NoError(t, err)
+
+	wantPending = 2 // One pending + one pending update
+	wantCancelled = 0
 	assert.Equal(t, wantPending, counts.Pending)
 	assert.Equal(t, wantApproved, counts.Approved)
 	assert.Equal(t, wantRejected, counts.Rejected)
@@ -1072,6 +1110,8 @@ func createJob(t *testing.T, db *sqlx.DB, externalJobID uuid.UUID) *job.Job {
 }
 
 func createJobProposal(t *testing.T, orm feeds.ORM, status feeds.JobProposalStatus, fmID int64) int64 {
+	t.Helper()
+
 	id, err := orm.CreateJobProposal(&feeds.JobProposal{
 		RemoteUUID:     uuid.NewV4(),
 		Status:         status,


### PR DESCRIPTION
This PR ensures that when a job proposal is re-proposed that it now contributes to the status `pending` in the `feeds_job_proposal_count gauge`.  The proposal will be counted only as `pending` until the pending update is resolved.
