### PR TITLE
Fixes job replacement for legacy jobs with no evm chain id association

### DIFF
--- a/core/services/job/orm.go
+++ b/core/services/job/orm.go
@@ -766,8 +766,8 @@ func (o *orm) FindJobIDByAddress(address ethkey.EIP55Address, evmChainID *utils.
 		stmt := `
 SELECT jobs.id
 FROM jobs
-LEFT JOIN ocr_oracle_specs ocrspec on ocrspec.contract_address = $1 AND ocrspec.evm_chain_id = $2 AND ocrspec.id = jobs.ocr_oracle_spec_id
-LEFT JOIN flux_monitor_specs fmspec on fmspec.contract_address = $1 AND fmspec.evm_chain_id = $2 AND fmspec.id = jobs.flux_monitor_spec_id
+LEFT JOIN ocr_oracle_specs ocrspec on ocrspec.contract_address = $1 AND (ocrspec.evm_chain_id = $2 OR ocrspec.evm_chain_id IS NULL) AND ocrspec.id = jobs.ocr_oracle_spec_id
+LEFT JOIN flux_monitor_specs fmspec on fmspec.contract_address = $1 AND (fmspec.evm_chain_id = $2 OR fmspec.evm_chain_id IS NULL) AND fmspec.id = jobs.flux_monitor_spec_id
 WHERE ocrspec.id IS NOT NULL OR fmspec.id IS NOT NULL
 `
 		err = tx.Get(&jobID, stmt, address, evmChainID)


### PR DESCRIPTION
For very old jobs, the `evm_chain_id` column is set to `NULL` which causes `FindJobByAddress` to fail because it requires both the contract address and evm chain id to match.

Any new jobs since the introduction of the `evm_chain_id` column, automatically inserts this value from either the job spec `EVMChainID` field or the default chain id value set in the env var.

This change updates the query to allow for a match on a NULL value in the `evm_chain_id` column. Since there is a partial unique constraint on a contract address with a NULL evm chain id, we can safely add this OR condition to the orm method and be sure it will only return a single record.