### PR TITLE
Add async option to Replay()

### DIFF
--- a/core/chains/evm/logpoller/disabled.go
+++ b/core/chains/evm/logpoller/disabled.go
@@ -24,7 +24,7 @@ func (disabled) Ready() error { return ErrDisabled }
 
 func (disabled) Healthy() error { return ErrDisabled }
 
-func (disabled) Replay(ctx context.Context, fromBlock int64) error { return ErrDisabled }
+func (disabled) Replay(ctx context.Context, fromBlock int64, async bool) error { return ErrDisabled }
 
 func (disabled) RegisterFilter(filter Filter) (int, error) { return -1, ErrDisabled }
 

--- a/core/chains/evm/logpoller/doc.go
+++ b/core/chains/evm/logpoller/doc.go
@@ -16,5 +16,6 @@
 // despite node crashes and reorgs. The granularity of the filter is always at least one block (more when backfilling).
 // - After calling Replay(fromBlock), all blocks including that one to the latest chain tip will be polled
 // with the current filter. This can be used on first time job add to specify a start block from which you wish to capture
-// existing logs.
+// existing logs.  Replay also accepts an async param; if true it will return as soon as replay has been successfully initiated
+// instead of waiting for it to complete.
 package logpoller

--- a/core/chains/evm/logpoller/integration_test.go
+++ b/core/chains/evm/logpoller/integration_test.go
@@ -124,7 +124,7 @@ func TestLogPoller_Integration(t *testing.T) {
 	}
 	// The poller starts on a new chain at latest-finality (5 in this case),
 	// replay to ensure we get all the logs.
-	require.NoError(t, th.LogPoller.Replay(testutils.Context(t), 1))
+	require.NoError(t, th.LogPoller.Replay(testutils.Context(t), 1, false))
 
 	// We should immediately have all those Log1 logs.
 	logs, err := th.LogPoller.Logs(2, 7, EmitterABI.Events["Log1"].ID, th.EmitterAddress1)
@@ -137,10 +137,10 @@ func TestLogPoller_Integration(t *testing.T) {
 	})
 	require.NoError(t, err)
 	// Replay an invalid block should error
-	assert.Error(t, th.LogPoller.Replay(testutils.Context(t), 0))
-	assert.Error(t, th.LogPoller.Replay(testutils.Context(t), 20))
+	assert.Error(t, th.LogPoller.Replay(testutils.Context(t), 0, false))
+	assert.Error(t, th.LogPoller.Replay(testutils.Context(t), 20, false))
 	// Replay only from block 4, so we should see logs in block 4,5,6,7 (4 logs)
-	require.NoError(t, th.LogPoller.Replay(testutils.Context(t), 4))
+	require.NoError(t, th.LogPoller.Replay(testutils.Context(t), 4, false))
 
 	// We should immediately see 4 logs2 logs.
 	logs, err = th.LogPoller.Logs(2, 7, EmitterABI.Events["Log2"].ID, th.EmitterAddress1)
@@ -150,7 +150,7 @@ func TestLogPoller_Integration(t *testing.T) {
 	// Cancelling a replay should return an error synchronously.
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
-	assert.True(t, errors.Is(th.LogPoller.Replay(ctx, 4), logpoller.ErrReplayAbortedByClient))
+	assert.True(t, errors.Is(th.LogPoller.Replay(ctx, 4, false), logpoller.ErrReplayAbortedByClient))
 
 	require.NoError(t, th.LogPoller.Close())
 }

--- a/core/chains/evm/logpoller/mocks/log_poller.go
+++ b/core/chains/evm/logpoller/mocks/log_poller.go
@@ -409,13 +409,13 @@ func (_m *LogPoller) RegisterFilter(filter logpoller.Filter) (int, error) {
 	return r0, r1
 }
 
-// Replay provides a mock function with given fields: ctx, fromBlock
-func (_m *LogPoller) Replay(ctx context.Context, fromBlock int64) error {
-	ret := _m.Called(ctx, fromBlock)
+// Replay provides a mock function with given fields: ctx, fromBlock, async
+func (_m *LogPoller) Replay(ctx context.Context, fromBlock int64, async bool) error {
+	ret := _m.Called(ctx, fromBlock, async)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(context.Context, int64) error); ok {
-		r0 = rf(ctx, fromBlock)
+	if rf, ok := ret.Get(0).(func(context.Context, int64, bool) error); ok {
+		r0 = rf(ctx, fromBlock, async)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -284,7 +284,7 @@ func NewApp(client *Client) *cli.App {
 			Subcommands: []cli.Command{
 				{
 					Name:   "replay",
-					Usage:  "Replays block data from the given number",
+					Usage:  "Initiates a (background) replay of block data from the given number.",
 					Action: client.ReplayFromBlock,
 					Flags: []cli.Flag{
 						cli.IntFlag{

--- a/core/internal/features/ocr2/features_ocr2_test.go
+++ b/core/internal/features/ocr2/features_ocr2_test.go
@@ -646,9 +646,9 @@ juelsPerFeeCoinSource = """
 
 	// Once all the jobs are added, replay to ensure we have the configSet logs.
 	for _, app := range apps {
-		require.NoError(t, app.Chains.EVM.Chains()[0].LogPoller().Replay(testutils.Context(t), blockBeforeConfig.Number().Int64()))
+		require.NoError(t, app.Chains.EVM.Chains()[0].LogPoller().Replay(testutils.Context(t), blockBeforeConfig.Number().Int64(), false))
 	}
-	require.NoError(t, bootstrapNode.app.Chains.EVM.Chains()[0].LogPoller().Replay(testutils.Context(t), blockBeforeConfig.Number().Int64()))
+	require.NoError(t, bootstrapNode.app.Chains.EVM.Chains()[0].LogPoller().Replay(testutils.Context(t), blockBeforeConfig.Number().Int64(), false))
 
 	// Assert that all the OCR jobs get a run with valid values eventually.
 	var wg sync.WaitGroup

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -783,7 +783,7 @@ func (app *ChainlinkApplication) ReplayFromBlock(chainID *big.Int, number uint64
 	}
 	chain.LogBroadcaster().ReplayFromBlock(int64(number), forceBroadcast)
 	if app.Config.FeatureLogPoller() {
-		if err := chain.LogPoller().Replay(context.Background(), int64(number)); err != nil {
+		if err := chain.LogPoller().Replay(context.Background(), int64(number), false); err != nil {
 			return err
 		}
 	}

--- a/core/services/relay/evm/config_poller_test.go
+++ b/core/services/relay/evm/config_poller_test.go
@@ -81,7 +81,7 @@ func TestConfigPoller(t *testing.T) {
 	latest, err := b.BlockByNumber(testutils.Context(t), nil)
 	require.NoError(t, err)
 	// Ensure we capture this config set log.
-	require.NoError(t, lp.Replay(testutils.Context(t), latest.Number().Int64()-1))
+	require.NoError(t, lp.Replay(testutils.Context(t), latest.Number().Int64()-1, false))
 
 	// Send blocks until we see the config updated.
 	var configBlock uint64

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -30,7 +30,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/core/services/relay/evm/mercury"
 	"github.com/smartcontractkit/chainlink/core/services/relay/evm/mercury/wsrpc"
-	types "github.com/smartcontractkit/chainlink/core/services/relay/evm/types"
+	"github.com/smartcontractkit/chainlink/core/services/relay/evm/types"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
 
@@ -137,7 +137,7 @@ func (c *configWatcher) Start(ctx context.Context) error {
 			go func() {
 				defer c.wg.Done()
 				c.lggr.Infow("starting replay for config", "fromBlock", c.fromBlock)
-				if err := c.configPoller.destChainLogPoller.Replay(c.replayCtx, int64(c.fromBlock)); err != nil {
+				if err := c.configPoller.destChainLogPoller.Replay(c.replayCtx, int64(c.fromBlock), false); err != nil {
 					c.lggr.Errorf("error replaying for config", "err", err)
 				} else {
 					c.lggr.Infow("completed replaying for config", "fromBlock", c.fromBlock)


### PR DESCRIPTION
This is an alternative to https://github.com/smartcontractkit/chainlink/pull/8192

Instead of making lp.Replay() inherently async, this leaves it synchronous, but accepts an optional param to return as soon as the replay has been started.  This fixes a UI issue with the CLI where the client will keep waiting for the replay, even though it happens in the background and cannot be cancelled by the web client.  The problem with what's in develop branch is that the client may wait for a while during the replay, then get disconnected due to a timeout--this creates unnecessary confusion over whether the replay is still continuing or has been aborted.  Either way, it should still continue.