### PR TITLE
Change FunctionsClient values to internal for use in Automation

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Unreleased
 
-...
+### Changed
+- Change Functions Client variables to internal for use when integrating Automation
 
 ## 0.6.1 - 2023-02-06
 

--- a/contracts/src/v0.8/dev/functions/FunctionsClient.sol
+++ b/contracts/src/v0.8/dev/functions/FunctionsClient.sol
@@ -10,8 +10,8 @@ import "../interfaces/FunctionsOracleInterface.sol";
  * @notice Contract writers can inherit this contract in order to create Chainlink Functions requests
  */
 abstract contract FunctionsClient is FunctionsClientInterface {
-  FunctionsOracleInterface private s_oracle;
-  mapping(bytes32 => address) private s_pendingRequests;
+  FunctionsOracleInterface internal s_oracle;
+  mapping(bytes32 => address) internal s_pendingRequests;
 
   event RequestSent(bytes32 indexed id);
   event RequestFulfilled(bytes32 indexed id);


### PR DESCRIPTION
Credit to @KuphJr

> These should be internal, not private as it allows a FunctionsConsumer contract to use these values directly. This is necessary for AutomatedFunctionsConsumer to avoid running the expensive encodeCBOR for every request triggered by Automation.