### PR TITLE
TT-65 Soak/Benchmark support branch names with /

### DIFF
--- a/.github/workflows/automation-benchmark-tests.yml
+++ b/.github/workflows/automation-benchmark-tests.yml
@@ -59,7 +59,6 @@ jobs:
       SLACK_API_KEY: ${{ secrets.QA_SLACK_API_KEY }}
       SLACK_CHANNEL: C03KJ5S7KEK
       TEST_INPUTS: ${{ inputs.TestInputs }}
-      TEST_TRIGGERED_BY: automation-benchmark
       CHAINLINK_ENV_USER: ${{ github.actor }}
       REF_NAME: ${{ github.head_ref || github.ref_name }}
       ENV_JOB_IMAGE_BASE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests
@@ -68,12 +67,17 @@ jobs:
         id: push
         shell: bash
         run: |
+          echo "### chainlink image used for this test run :link:" >>$GITHUB_STEP_SUMMARY
+          echo "`${{ inputs.chainlinkVersion }}`" >>$GITHUB_STEP_SUMMARY
+          echo "### chainlink-tests image tag for this test run :ship:" >>$GITHUB_STEP_SUMMARY
           if [ "${{ env.REF_NAME }}" != "develop" ]; then
             # use sha if not on develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:benchmark.${{ github.sha }}" >>$GITHUB_OUTPUT
+            echo "`benchmark.${{ github.sha }}`" >>$GITHUB_STEP_SUMMARY
           else
             # default to develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:develop" >>$GITHUB_OUTPUT
+            echo "`develop`" >>$GITHUB_STEP_SUMMARY
           fi
       - name: Add mask
         run: |
@@ -117,7 +121,6 @@ jobs:
           test_download_vendor_packages_command: make gomod
           cl_repo: ${{ inputs.chainlinkImage }}
           cl_image_tag: ${{ inputs.chainlinkVersion }}
-          triggered_by: ${{ env.TEST_TRIGGERED_BY }}
           token: ${{ secrets.GITHUB_TOKEN }}
           should_cleanup: false
           go_mod_path: ./integration-tests/go.mod

--- a/.github/workflows/automation-benchmark-tests.yml
+++ b/.github/workflows/automation-benchmark-tests.yml
@@ -68,16 +68,16 @@ jobs:
         shell: bash
         run: |
           echo "### chainlink image used for this test run :link:" >>$GITHUB_STEP_SUMMARY
-          echo "`${{ inputs.chainlinkVersion }}`" >>$GITHUB_STEP_SUMMARY
+          echo "tag: `${{ inputs.chainlinkVersion }}`" >>$GITHUB_STEP_SUMMARY
           echo "### chainlink-tests image tag for this test run :ship:" >>$GITHUB_STEP_SUMMARY
           if [ "${{ env.REF_NAME }}" != "develop" ]; then
             # use sha if not on develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:benchmark.${{ github.sha }}" >>$GITHUB_OUTPUT
-            echo "`benchmark.${{ github.sha }}`" >>$GITHUB_STEP_SUMMARY
+            echo "tag: `benchmark.${{ github.sha }}`" >>$GITHUB_STEP_SUMMARY
           else
             # default to develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:develop" >>$GITHUB_OUTPUT
-            echo "`develop`" >>$GITHUB_STEP_SUMMARY
+            echo "tag: `develop`" >>$GITHUB_STEP_SUMMARY
           fi
       - name: Add mask
         run: |

--- a/.github/workflows/automation-benchmark-tests.yml
+++ b/.github/workflows/automation-benchmark-tests.yml
@@ -68,16 +68,16 @@ jobs:
         shell: bash
         run: |
           echo "### chainlink image used for this test run :link:" >>$GITHUB_STEP_SUMMARY
-          echo "${{ inputs.chainlinkVersion }}" >>$GITHUB_STEP_SUMMARY
+          echo "\`${{ inputs.chainlinkVersion }}\`" >>$GITHUB_STEP_SUMMARY
           echo "### chainlink-tests image tag for this test run :ship:" >>$GITHUB_STEP_SUMMARY
           if [ "${{ env.REF_NAME }}" != "develop" ]; then
             # use sha if not on develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:benchmark.${{ github.sha }}" >>$GITHUB_OUTPUT
-            echo "benchmark.${{ github.sha }}" >>$GITHUB_STEP_SUMMARY
+            echo "\`benchmark.${{ github.sha }}\`" >>$GITHUB_STEP_SUMMARY
           else
             # default to develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:develop" >>$GITHUB_OUTPUT
-            echo "develop" >>$GITHUB_STEP_SUMMARY
+            echo "\`develop\`" >>$GITHUB_STEP_SUMMARY
           fi
       - name: Add mask
         run: |

--- a/.github/workflows/automation-benchmark-tests.yml
+++ b/.github/workflows/automation-benchmark-tests.yml
@@ -68,16 +68,16 @@ jobs:
         shell: bash
         run: |
           echo "### chainlink image used for this test run :link:" >>$GITHUB_STEP_SUMMARY
-          echo "tag: `${{ inputs.chainlinkVersion }}`" >>$GITHUB_STEP_SUMMARY
+          echo "${{ inputs.chainlinkVersion }}" >>$GITHUB_STEP_SUMMARY
           echo "### chainlink-tests image tag for this test run :ship:" >>$GITHUB_STEP_SUMMARY
           if [ "${{ env.REF_NAME }}" != "develop" ]; then
             # use sha if not on develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:benchmark.${{ github.sha }}" >>$GITHUB_OUTPUT
-            echo "tag: `benchmark.${{ github.sha }}`" >>$GITHUB_STEP_SUMMARY
+            echo "benchmark.${{ github.sha }}" >>$GITHUB_STEP_SUMMARY
           else
             # default to develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:develop" >>$GITHUB_OUTPUT
-            echo "tag: `develop`" >>$GITHUB_STEP_SUMMARY
+            echo "develop" >>$GITHUB_STEP_SUMMARY
           fi
       - name: Add mask
         run: |

--- a/.github/workflows/automation-benchmark-tests.yml
+++ b/.github/workflows/automation-benchmark-tests.yml
@@ -44,9 +44,6 @@ on:
         required: false
         type: string
 
-env:
-  REF_NAME: ${{ github.head_ref || github.ref_name }}
-
 jobs:
   automation_benchmark:
     environment: integration
@@ -64,8 +61,20 @@ jobs:
       TEST_INPUTS: ${{ inputs.TestInputs }}
       TEST_TRIGGERED_BY: automation-benchmark
       CHAINLINK_ENV_USER: ${{ github.actor }}
-      ENV_JOB_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests:${{ github.head_ref || github.ref_name }}
+      REF_NAME: ${{ github.head_ref || github.ref_name }}
+      ENV_JOB_IMAGE_BASE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests
     steps:
+      - name: Setup Push Tag
+        id: push
+        shell: bash
+        run: |
+          if [ "${{ env.REF_NAME }}" != "develop" ]; then
+            # use sha if not on develop
+            echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:benchmark.${{ github.sha }}" >>$GITHUB_OUTPUT
+          else
+            # default to develop
+            echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:develop" >>$GITHUB_OUTPUT
+          fi
       - name: Add mask
         run: |
           EVM_URLS=$(jq -r '.inputs.wsURL' $GITHUB_EVENT_PATH)
@@ -88,7 +97,7 @@ jobs:
         if: ${{ env.REF_NAME != 'develop' }}
         uses: smartcontractkit/chainlink-github-actions/docker/build-push@ce87f8986ca18336cc5015df75916c2ec0a7c4b3 # v2.1.2
         with:
-          tags: ${{ env.ENV_JOB_IMAGE }}
+          tags: ${{ steps.push.outputs.tag }}
           file: ./integration-tests/test.Dockerfile
           build-args: |
             BASE_IMAGE=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/test-base-image
@@ -102,6 +111,7 @@ jobs:
           DETACH_RUNNER: true
           TEST_SUITE: benchmark
           TEST_ARGS: -test.timeout 720h
+          ENV_JOB_IMAGE: ${{ steps.push.outputs.tag }}
         with:
           test_command_to_run: cd integration-tests && go test -timeout 30m -v -run ^TestAutomationBenchmark$ ./benchmark -count=1
           test_download_vendor_packages_command: make gomod

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -66,6 +66,10 @@ jobs:
           push_tag: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink:latest.${{ github.sha }}
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+      - name: Print Chainlink Image Built
+        run: |
+          echo "### chainlink image used for this test run :link:" >>$GITHUB_STEP_SUMMARY
+          echo "`latest.${{ github.sha }}`" >>$GITHUB_STEP_SUMMARY
       - name: Collect Metrics
         if: always()
         id: collect-gha-metrics
@@ -108,6 +112,10 @@ jobs:
             SUITES="smoke soak chaos benchmark migration performance"
           AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+      - name: Print Image Built
+        run: |
+          echo "### chainlink-tests image tag for this test run :ship:" >>$GITHUB_STEP_SUMMARY
+          echo "`ci.${{ github.sha }}`" >>$GITHUB_STEP_SUMMARY
 
   eth-smoke-tests-matrix:
     environment: integration

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,12 +41,6 @@ jobs:
           hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
           this-job-name: Check Paths That Require Tests To Run
         continue-on-error: true
-      - name: Testing
-        run: |
-          echo "`single back tick`" >>$GITHUB_STEP_SUMMARY
-          echo "``double back tick``" >>$GITHUB_STEP_SUMMARY
-          echo "```triple back tick```" >>$GITHUB_STEP_SUMMARY
-          echo "\`escape back tick\`" >>$GITHUB_STEP_SUMMARY
     outputs:
       src: ${{ steps.changes.outputs.src }}
 
@@ -75,7 +69,7 @@ jobs:
       - name: Print Chainlink Image Built
         run: |
           echo "### chainlink image tag used for this test run :link:" >>$GITHUB_STEP_SUMMARY
-          echo "latest.${{ github.sha }}" >>$GITHUB_STEP_SUMMARY
+          echo "\`latest.${{ github.sha }}\`" >>$GITHUB_STEP_SUMMARY
       - name: Collect Metrics
         if: always()
         id: collect-gha-metrics
@@ -121,7 +115,7 @@ jobs:
       - name: Print Image Built
         run: |
           echo "### chainlink-tests image tag for this test run :ship:" >>$GITHUB_STEP_SUMMARY
-          echo "ci.${{ github.sha }}" >>$GITHUB_STEP_SUMMARY
+          echo "\`ci.${{ github.sha }}\`" >>$GITHUB_STEP_SUMMARY
 
   eth-smoke-tests-matrix:
     environment: integration
@@ -331,6 +325,10 @@ jobs:
             SUITES="smoke"
           AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+      - name: Print Solana Tests Image
+        run: |
+          echo "### chainlink-solana-tests image tag for this test run :ship:" >>$GITHUB_STEP_SUMMARY
+          echo "\`${{ env.SOLANA_REF }}\`" >>$GITHUB_STEP_SUMMARY
       - name: Run Tests
         if: needs.changes.outputs.src == 'true'
         uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@ce87f8986ca18336cc5015df75916c2ec0a7c4b3 # v2.1.2

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -41,6 +41,12 @@ jobs:
           hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
           this-job-name: Check Paths That Require Tests To Run
         continue-on-error: true
+      - name: Testing
+        run: |
+          echo "`single back tick`" >>$GITHUB_STEP_SUMMARY
+          echo "``double back tick``" >>$GITHUB_STEP_SUMMARY
+          echo "```triple back tick```" >>$GITHUB_STEP_SUMMARY
+          echo "\`escape back tick\`" >>$GITHUB_STEP_SUMMARY
     outputs:
       src: ${{ steps.changes.outputs.src }}
 
@@ -69,7 +75,7 @@ jobs:
       - name: Print Chainlink Image Built
         run: |
           echo "### chainlink image tag used for this test run :link:" >>$GITHUB_STEP_SUMMARY
-          echo "tag: `latest.${{ github.sha }}`" >>$GITHUB_STEP_SUMMARY
+          echo "latest.${{ github.sha }}" >>$GITHUB_STEP_SUMMARY
       - name: Collect Metrics
         if: always()
         id: collect-gha-metrics
@@ -115,7 +121,7 @@ jobs:
       - name: Print Image Built
         run: |
           echo "### chainlink-tests image tag for this test run :ship:" >>$GITHUB_STEP_SUMMARY
-          echo "`ci.${{ github.sha }}`" >>$GITHUB_STEP_SUMMARY
+          echo "ci.${{ github.sha }}" >>$GITHUB_STEP_SUMMARY
 
   eth-smoke-tests-matrix:
     environment: integration

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -122,7 +122,6 @@ jobs:
       SELECTED_NETWORKS: SIMULATED,SIMULATED_1,SIMULATED_2
       CHAINLINK_COMMIT_SHA: ${{ github.sha }}
       CHAINLINK_ENV_USER: ${{ github.actor }}
-      TEST_TRIGGERED_BY: core-CI-eth
       TEST_LOG_LEVEL: debug
     strategy:
       fail-fast: false
@@ -180,7 +179,6 @@ jobs:
           cl_image_tag: latest.${{ github.sha }}
           artifacts_location: ./integration-tests/smoke/logs
           publish_check_name: EVM Smoke Test Results ${{ matrix.product.name }}
-          triggered_by: ${{ env.TEST_TRIGGERED_BY }}-${{ matrix.product.name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
@@ -198,12 +196,6 @@ jobs:
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
 
-      ## Run Cleanup regardless
-      - name: cleanup
-        if: always()
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/cleanup@ce87f8986ca18336cc5015df75916c2ec0a7c4b3 # v2.1.2
-        with:
-          triggered_by: ${{ env.TEST_TRIGGERED_BY }}-${{ matrix.product.name }}
       - name: Upload test log
         uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
         if: failure()
@@ -367,7 +359,6 @@ jobs:
       SELECTED_NETWORKS: ${{ matrix.testnet }}
       CHAINLINK_COMMIT_SHA: ${{ github.sha }}
       CHAINLINK_ENV_USER: ${{ github.actor }}
-      TEST_TRIGGERED_BY: testnet-ci
       TEST_LOG_LEVEL: debug
       EVM_KEYS: ${{ secrets.QA_EVM_KEYS }}
       TEST_EVM_KEYS: ${{ secrets.QA_EVM_KEYS }}
@@ -408,13 +399,11 @@ jobs:
           cl_image_tag: latest.${{ github.sha }}
           artifacts_location: ./integration-tests/smoke/logs
           publish_check_name: ${{ matrix.testnet }} OCR Smoke Test Results
-          triggered_by: ${{ env.TEST_TRIGGERED_BY }}-${{ matrix.testnet }}
           token: ${{ secrets.GITHUB_TOKEN }}
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
-          should_cleanup: false
 
       - name: Collect Metrics
         if: always()

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -68,8 +68,8 @@ jobs:
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
       - name: Print Chainlink Image Built
         run: |
-          echo "### chainlink image used for this test run :link:" >>$GITHUB_STEP_SUMMARY
-          echo "`latest.${{ github.sha }}`" >>$GITHUB_STEP_SUMMARY
+          echo "### chainlink image tag used for this test run :link:" >>$GITHUB_STEP_SUMMARY
+          echo "tag: `latest.${{ github.sha }}`" >>$GITHUB_STEP_SUMMARY
       - name: Collect Metrics
         if: always()
         id: collect-gha-metrics

--- a/.github/workflows/on-demand-ocr-soak-test.yml
+++ b/.github/workflows/on-demand-ocr-soak-test.yml
@@ -92,16 +92,16 @@ jobs:
         shell: bash
         run: |
           echo "### chainlink image used for this test run :link:" >>$GITHUB_STEP_SUMMARY
-          echo "${{ inputs.chainlinkVersion }}" >>$GITHUB_STEP_SUMMARY
+          echo "\`${{ inputs.chainlinkVersion }}\`" >>$GITHUB_STEP_SUMMARY
           echo "### chainlink-tests image tag for this test run :ship:" >>$GITHUB_STEP_SUMMARY
           if [ "${{ env.REF_NAME }}" != "develop" ]; then
             # use sha if not on develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:soak.${{ github.sha }}" >>$GITHUB_OUTPUT
-            echo "soak.${{ github.sha }}" >>$GITHUB_STEP_SUMMARY
+            echo "\`soak.${{ github.sha }}\`" >>$GITHUB_STEP_SUMMARY
           else
             # default to develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:develop" >>$GITHUB_OUTPUT
-            echo "develop" >>$GITHUB_STEP_SUMMARY
+            echo "\`develop\`" >>$GITHUB_STEP_SUMMARY
           fi
       - name: build test runner
         if: ${{ env.REF_NAME != 'develop' }}

--- a/.github/workflows/on-demand-ocr-soak-test.yml
+++ b/.github/workflows/on-demand-ocr-soak-test.yml
@@ -61,7 +61,6 @@ jobs:
     env:
       CHAINLINK_COMMIT_SHA: ${{ inputs.chainlinkVersion }}
       CHAINLINK_ENV_USER: ${{ github.actor }}
-      TEST_TRIGGERED_BY: ocr-on-demand
       SELECTED_NETWORKS: ${{ inputs.network }}
       EVM_KEYS: ${{ inputs.fundingPrivateKey }}
       EVM_URLS: ${{ inputs.wsURL }}
@@ -92,12 +91,17 @@ jobs:
         id: push
         shell: bash
         run: |
+          echo "### chainlink image used for this test run :link:" >>$GITHUB_STEP_SUMMARY
+          echo "`${{ inputs.chainlinkVersion }}`" >>$GITHUB_STEP_SUMMARY
+          echo "### chainlink-tests image tag for this test run :ship:" >>$GITHUB_STEP_SUMMARY
           if [ "${{ env.REF_NAME }}" != "develop" ]; then
             # use sha if not on develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:soak.${{ github.sha }}" >>$GITHUB_OUTPUT
+            echo "`soak.${{ github.sha }}`" >>$GITHUB_STEP_SUMMARY
           else
             # default to develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:develop" >>$GITHUB_OUTPUT
+            echo "`develop`" >>$GITHUB_STEP_SUMMARY
           fi
       - name: build test runner
         if: ${{ env.REF_NAME != 'develop' }}
@@ -123,7 +127,6 @@ jobs:
           test_download_vendor_packages_command: make gomod
           cl_repo: ${{ inputs.chainlinkImage }}
           cl_image_tag: ${{ inputs.chainlinkVersion }}
-          triggered_by: ${{ env.TEST_TRIGGERED_BY }}
           token: ${{ secrets.GITHUB_TOKEN }}
           should_cleanup: false
           go_mod_path: ./integration-tests/go.mod

--- a/.github/workflows/on-demand-ocr-soak-test.yml
+++ b/.github/workflows/on-demand-ocr-soak-test.yml
@@ -92,16 +92,16 @@ jobs:
         shell: bash
         run: |
           echo "### chainlink image used for this test run :link:" >>$GITHUB_STEP_SUMMARY
-          echo "tag: `${{ inputs.chainlinkVersion }}`" >>$GITHUB_STEP_SUMMARY
+          echo "${{ inputs.chainlinkVersion }}" >>$GITHUB_STEP_SUMMARY
           echo "### chainlink-tests image tag for this test run :ship:" >>$GITHUB_STEP_SUMMARY
           if [ "${{ env.REF_NAME }}" != "develop" ]; then
             # use sha if not on develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:soak.${{ github.sha }}" >>$GITHUB_OUTPUT
-            echo "tag: `soak.${{ github.sha }}`" >>$GITHUB_STEP_SUMMARY
+            echo "soak.${{ github.sha }}" >>$GITHUB_STEP_SUMMARY
           else
             # default to develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:develop" >>$GITHUB_OUTPUT
-            echo "tag: `develop`" >>$GITHUB_STEP_SUMMARY
+            echo "develop" >>$GITHUB_STEP_SUMMARY
           fi
       - name: build test runner
         if: ${{ env.REF_NAME != 'develop' }}

--- a/.github/workflows/on-demand-ocr-soak-test.yml
+++ b/.github/workflows/on-demand-ocr-soak-test.yml
@@ -92,16 +92,16 @@ jobs:
         shell: bash
         run: |
           echo "### chainlink image used for this test run :link:" >>$GITHUB_STEP_SUMMARY
-          echo "`${{ inputs.chainlinkVersion }}`" >>$GITHUB_STEP_SUMMARY
+          echo "tag: `${{ inputs.chainlinkVersion }}`" >>$GITHUB_STEP_SUMMARY
           echo "### chainlink-tests image tag for this test run :ship:" >>$GITHUB_STEP_SUMMARY
           if [ "${{ env.REF_NAME }}" != "develop" ]; then
             # use sha if not on develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:soak.${{ github.sha }}" >>$GITHUB_OUTPUT
-            echo "`soak.${{ github.sha }}`" >>$GITHUB_STEP_SUMMARY
+            echo "tag: `soak.${{ github.sha }}`" >>$GITHUB_STEP_SUMMARY
           else
             # default to develop
             echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:develop" >>$GITHUB_OUTPUT
-            echo "`develop`" >>$GITHUB_STEP_SUMMARY
+            echo "tag: `develop`" >>$GITHUB_STEP_SUMMARY
           fi
       - name: build test runner
         if: ${{ env.REF_NAME != 'develop' }}

--- a/.github/workflows/on-demand-ocr-soak-test.yml
+++ b/.github/workflows/on-demand-ocr-soak-test.yml
@@ -48,9 +48,6 @@ on:
         required: false
         default: 1m
 
-env:
-  REF_NAME: ${{ github.head_ref || github.ref_name }}
-
 jobs:
   ocr_soak_test:
     name: ${{ inputs.network }} OCR Soak Test
@@ -76,7 +73,8 @@ jobs:
       OCR_CHAINLINK_NODE_FUNDING: ${{ inputs.chainlinkNodeFunding }}
       OCR_TIME_BETWEEN_ROUNDS: ${{ inputs.timeBetweenRounds }}
       TEST_LOG_LEVEL: debug
-      ENV_JOB_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests:${{ github.head_ref || github.ref_name }}
+      REF_NAME: ${{ github.head_ref || github.ref_name }}
+      ENV_JOB_IMAGE_BASE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests
     steps:
       - name: Collect Metrics
         id: collect-gha-metrics
@@ -90,11 +88,22 @@ jobs:
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
         with:
           ref: ${{ env.REF_NAME }}
+      - name: Setup Push Tag
+        id: push
+        shell: bash
+        run: |
+          if [ "${{ env.REF_NAME }}" != "develop" ]; then
+            # use sha if not on develop
+            echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:soak.${{ github.sha }}" >>$GITHUB_OUTPUT
+          else
+            # default to develop
+            echo "tag=${{ env.ENV_JOB_IMAGE_BASE }}:develop" >>$GITHUB_OUTPUT
+          fi
       - name: build test runner
         if: ${{ env.REF_NAME != 'develop' }}
         uses: smartcontractkit/chainlink-github-actions/docker/build-push@ce87f8986ca18336cc5015df75916c2ec0a7c4b3 # v2.1.2
         with:
-          tags: ${{ env.ENV_JOB_IMAGE }}
+          tags: ${{ steps.push.outputs.tag }}
           file: ./integration-tests/test.Dockerfile
           build-args: |
             BASE_IMAGE=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/test-base-image
@@ -108,6 +117,7 @@ jobs:
           DETACH_RUNNER: true
           TEST_SUITE: soak
           TEST_ARGS: -test.timeout 900h
+          ENV_JOB_IMAGE: ${{ steps.push.outputs.tag }}
         with:
           test_command_to_run: cd ./integration-tests && go test -v -count=1 -run ^TestOCRSoak$ ./soak
           test_download_vendor_packages_command: make gomod


### PR DESCRIPTION
Switch to using the commit sha instead of the branch name for the docker image tag. Removes the worry that we have characters that are not valid in the name.