### PR TITLE
[Functions] Logging improvements

### DIFF
--- a/core/services/directrequestocr/drlistener.go
+++ b/core/services/directrequestocr/drlistener.go
@@ -315,16 +315,12 @@ func (l *DRListener) setError(ctx context.Context, requestId RequestID, runId in
 
 func (l *DRListener) handleOracleRequest(request *ocr2dr_oracle.OCR2DROracleOracleRequest, lb log.Broadcast) {
 	defer l.shutdownWaitGroup.Done()
-	l.logger.Infow("oracle request received",
-		"requestID", formatRequestId(request.RequestId),
-		"data", fmt.Sprintf("%0x", request.Data),
-	)
+	l.logger.Infow("oracle request received", "requestID", formatRequestId(request.RequestId))
 
 	promRequestDataSize.WithLabelValues(l.oracleHexAddr).Observe(float64(len(request.Data)))
 
 	requestData := make(map[string]interface{})
 	requestData["requestId"] = formatRequestId(request.RequestId)
-	requestData["data"] = fmt.Sprintf("0x%x", request.Data)
 	meta := make(map[string]interface{})
 	meta["oracleRequest"] = requestData
 
@@ -379,7 +375,8 @@ func (l *DRListener) handleOracleRequest(request *ocr2dr_oracle.OCR2DROracleOrac
 
 	computationResult, errResult := l.jobORM.FindTaskResultByRunIDAndTaskName(run.ID, ParseResultTaskName, pg.WithParentCtx(ctx))
 	if errResult != nil {
-		// Internal problem: Can't find parsed computation results
+		// Internal problem: Can't find computation results
+		l.logger.Errorw("internal error: can't retrieve computation results field", "requestID", formatRequestId(request.RequestId))
 		l.setError(ctx, request.RequestId, run.ID, INTERNAL_ERROR, []byte(errResult.Error()))
 		return
 	}
@@ -391,7 +388,8 @@ func (l *DRListener) handleOracleRequest(request *ocr2dr_oracle.OCR2DROracleOrac
 
 	computationError, errErr := l.jobORM.FindTaskResultByRunIDAndTaskName(run.ID, ParseErrorTaskName, pg.WithParentCtx(ctx))
 	if errErr != nil {
-		// Internal problem: Can't find parsed computation error
+		// Internal problem: Can't find computation errors
+		l.logger.Errorw("internal error: can't retrieve computation error field", "requestID", formatRequestId(request.RequestId))
 		l.setError(ctx, request.RequestId, run.ID, INTERNAL_ERROR, []byte(errErr.Error()))
 		return
 	}
@@ -405,11 +403,13 @@ func (l *DRListener) handleOracleRequest(request *ocr2dr_oracle.OCR2DROracleOrac
 		if len(computationResult) != 0 {
 			l.logger.Warnw("both result and error are non-empty - using error", "requestID", formatRequestId(request.RequestId))
 		}
+		l.logger.Debugw("saving computation error", "requestID", formatRequestId(request.RequestId))
 		l.setError(ctx, request.RequestId, run.ID, USER_ERROR, computationError)
 		promComputationErrorSize.WithLabelValues(l.oracleHexAddr).Set(float64(len(computationError)))
 	} else {
 		promRequestComputationSuccess.WithLabelValues(l.oracleHexAddr).Inc()
 		promComputationResultSize.WithLabelValues(l.oracleHexAddr).Set(float64(len(computationResult)))
+		l.logger.Debugw("saving computation result", "requestID", formatRequestId(request.RequestId))
 		if err2 := l.pluginORM.SetResult(request.RequestId, run.ID, computationResult, time.Now(), pg.WithParentCtx(ctx)); err2 != nil {
 			l.logger.Errorw("call to SetResult failed", "requestID", formatRequestId(request.RequestId), "err", err2)
 		}

--- a/core/services/ocr2/plugins/directrequestocr/reporting.go
+++ b/core/services/ocr2/plugins/directrequestocr/reporting.go
@@ -285,6 +285,12 @@ func (r *functionsReporting) Report(ctx context.Context, ts types.ReportTimestam
 			})
 			continue
 		}
+		r.logger.Debug("FunctionsReporting Report: aggregated successfully", commontypes.LogFields{
+			"epoch":         ts.Epoch,
+			"round":         ts.Round,
+			"requestID":     reqId,
+			"nObservations": len(observations),
+		})
 		allAggregated = append(allAggregated, aggregated)
 		allIdStrs = append(allIdStrs, reqId)
 	}


### PR DESCRIPTION
- Remove request.data from pipeline logs. It's a large byte array that can be extracted from the on-chain event if needed.
- Log on every result/error setter
- Log how many observations were used when aggregating results in OCR