### PR TITLE
bump golangci-lint to 1.51.1 and run with go 1.20

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -70,7 +70,8 @@ jobs:
       - uses: actions/setup-go@v3
         if: needs.init.outputs.on_trigger_lint == 'true'
         with:
-          go-version-file: 'go.mod'
+#          go-version-file: 'go.mod'
+          go-version: '1.20' # remove after bumping go.mod
       - name: golangci-lint
         if: needs.init.outputs.on_trigger_lint == 'true'
         ##
@@ -79,7 +80,7 @@ jobs:
         ##
         uses: smartcontractkit/golangci-lint-action@54ab6c5f11d66a92d14c3f7cc41ea13f676644bd # feature/multiple-output-formats-backup
         with:
-          version: v1.50.1
+          version: v1.51.1
           only-new-issues: ${{ github.event.schedule == '' }} # show only new issues, unless it's a scheduled run
           allow-extra-out-format-args: true
           args: --out-format checkstyle:golangci-lint-report.xml


### PR DESCRIPTION
Running the linter with Go 1.20 is a workaround for an unexplained crash (exit code 3) on some changes.