### PR TITLE
Cancelling a job proposal no longer causes the pending update to clear

### DIFF
--- a/core/services/feeds/orm.go
+++ b/core/services/feeds/orm.go
@@ -318,7 +318,7 @@ func (o *orm) CountJobProposals() (count int64, err error) {
 // CountJobProposals counts the number of job proposal records.
 func (o *orm) CountJobProposalsByStatus() (counts *JobProposalCounts, err error) {
 	stmt := `
-SELECT 
+SELECT
 	COUNT(*) filter (where job_proposals.status = 'pending') as pending,
 	COUNT(*) filter (where job_proposals.status = 'approved') as approved,
 	COUNT(*) filter (where job_proposals.status = 'rejected') as rejected,
@@ -491,7 +491,6 @@ RETURNING job_proposal_id;
 UPDATE job_proposals
 SET status = $1,
 	external_job_id = $2,
-	pending_update = FALSE,
 	updated_at = NOW()
 WHERE id = $3;
 `

--- a/core/services/feeds/orm_test.go
+++ b/core/services/feeds/orm_test.go
@@ -747,7 +747,6 @@ func Test_ORM_CancelSpec(t *testing.T) {
 	assert.Equal(t, jpID, actual.JobProposalID)
 	assert.Equal(t, uuid.NullUUID{Valid: false}, actualJP.ExternalJobID)
 	assert.Equal(t, feeds.JobProposalStatusCancelled, actualJP.Status)
-	assert.False(t, actualJP.PendingUpdate)
 }
 
 func Test_ORM_ExistsSpecByJobProposalIDAndVersion(t *testing.T) {


### PR DESCRIPTION
When there is a pending update on a job proposal, and a previous proposal spec was cancelled, the pending update flag was being cleared, causing the proposal spec to disappear from the 'Updates' tab in the UI.

This makes a change so that when cancelling the previously approved spec, the job proposal's updated status is no longer changed.