### PR TITLE
core/services/chainlink: dump LogPoller and UICSAKeys Feature flags [1.12.1]

### DIFF
--- a/core/services/chainlink/cfgtest/dump/full-custom.toml
+++ b/core/services/chainlink/cfgtest/dump/full-custom.toml
@@ -5,6 +5,8 @@ ShutdownGracePeriod = '10s'
 
 [Feature]
 FeedsManager = true
+LogPoller = true
+UICSAKeys = true
 
 [Database]
 DefaultIdleInTxSessionTimeout = '1h0m0s'

--- a/core/services/chainlink/config_dump.go
+++ b/core/services/chainlink/config_dump.go
@@ -520,6 +520,8 @@ func (c *Config) loadLegacyCoreEnv() error {
 
 	c.Feature = config.Feature{
 		FeedsManager: envvar.NewBool("FeatureFeedsManager").ParsePtr(),
+		LogPoller:    envvar.NewBool("FeatureLogPoller").ParsePtr(),
+		UICSAKeys:    envvar.NewBool("FeatureUICSAKeys").ParsePtr(),
 	}
 	c.AuditLogger = audit.AuditLoggerConfig{
 		Enabled:        envvar.NewBool("AuditLoggerEnabled").ParsePtr(),


### PR DESCRIPTION
#8508

(cherry picked from commit 3442b87490c892522e564369a43e1b7b1baef704)