### PR TITLE
Added contract functions required to get array of requestIds to time out

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ### Changed
 
+## 0.6.2 - 2023-02-06
+
+### Added
+
+- Added `getLatestNonce` and `checkRequestIdsToTimeout` to FunctionsBillingRegistry.sol enabling users to search for requestIds which hae expired
+
+### Changed
+
 - Change Functions Client variables to internal for use when integrating Automation (#8429)
 - Make Functions Billing Registry and Functions Oracle upgradable using the transparent proxy pattern (#8371)
 - Update dependency hardhat from version 2.10.1 to 2.12.7 (#8464)

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chainlink/contracts",
-  "version": "0.6.1",
+  "version": "0.6.2",
   "description": "Chainlink smart contracts",
   "author": "Chainlink devs",
   "license": "MIT",

--- a/contracts/src/v0.8/dev/functions/FunctionsBillingRegistry.sol
+++ b/contracts/src/v0.8/dev/functions/FunctionsBillingRegistry.sol
@@ -838,6 +838,39 @@ contract FunctionsBillingRegistry is
   }
 
   /**
+   * @notice Gets the latest nonce for a particular consumer contract and subscription
+   * @return Most recent nonce
+   */
+  function getLatestNonce(
+    address consumer,
+    uint64 subscriptionId
+  ) external view onlySubOwner(subscriptionId) returns (uint64) {
+    return s_consumers(consumer, subscriptionId);
+  }
+
+  /**
+   * @notice Checks which requestIds are expired and need to be timed out
+   * @param requestIds Array of requestIds to check
+   * @return Boolean array indicating if the corresponding requestId should be timed out
+   */
+  function checkRequestIdsToTimeout(bytes32[] requestIds) external view returns (bool[]) {
+    bool[] requestIdsToTimeout = new bool[](requestIds.length);
+
+    for (uint256 i = 0; i < requestIds.length; i++) {
+      uint256 requestStartTime = s_requestCommitments[requestId].timestamp;
+      requestIdsToTimeout[i] = (
+        // Checks if the request actually exists
+        requestStartTime > 0 &&
+        // Checks if the request is expired
+        block.timestamp > requestStartTime + s_config.requestTimeoutSeconds
+      );
+    }
+
+    return isRequestIdExpired;
+  }
+
+
+  /**
    * @dev The allow list is kept on the Oracle contract. This modifier checks if a user is authorized from there.
    */
   modifier onlyAuthorizedUsers() {

--- a/contracts/src/v0.8/dev/functions/FunctionsBillingRegistry.sol
+++ b/contracts/src/v0.8/dev/functions/FunctionsBillingRegistry.sol
@@ -845,7 +845,7 @@ contract FunctionsBillingRegistry is
     address consumer,
     uint64 subscriptionId
   ) external view onlySubOwner(subscriptionId) returns (uint64) {
-    return s_consumers(consumer, subscriptionId);
+    return s_consumers[consumer][subscriptionId];
   }
 
   /**
@@ -853,11 +853,13 @@ contract FunctionsBillingRegistry is
    * @param requestIds Array of requestIds to check
    * @return Boolean array indicating if the corresponding requestId should be timed out
    */
-  function checkRequestIdsToTimeout(bytes32[] requestIds) external view returns (bool[]) {
-    bool[] requestIdsToTimeout = new bool[](requestIds.length);
+  function checkRequestIdsToTimeout(
+    bytes32[] calldata requestIds
+  ) external view returns (bool[] memory) {
+    bool[] memory requestIdsToTimeout = new bool[](requestIds.length);
 
     for (uint256 i = 0; i < requestIds.length; i++) {
-      uint256 requestStartTime = s_requestCommitments[requestId].timestamp;
+      uint256 requestStartTime = s_requestCommitments[requestIds[i]].timestamp;
       requestIdsToTimeout[i] = (
         // Checks if the request actually exists
         requestStartTime > 0 &&
@@ -866,7 +868,7 @@ contract FunctionsBillingRegistry is
       );
     }
 
-    return isRequestIdExpired;
+    return requestIdsToTimeout;
   }
 
 


### PR DESCRIPTION
`getLatestNonce` gets the latest nonce for a particular consumer contract and subscription.  This can be used off-chain to generate all past requestIds by looping from 1 to the latest nonce.

```
  const encodedBytes = ethers.utils.defaultAbiCoder.encode(
    [ "address", "address", "uint64", "uint64" ],
    [ donAddress, consumerAddress, subscriptionId, nonce ]
  )

  return ethers.utils.keccak256(encodedBytes)
  ```
  
  `checkRequestIdsToTimeout` allows the array of generated requestIds to be checked to see if they need to be timed out.