### PR TITLE
Services implement HealthReport 

### DIFF
--- a/core/chains/evm/chain.go
+++ b/core/chains/evm/chain.go
@@ -276,6 +276,14 @@ func (c *chain) Healthy() (merr error) {
 	return
 }
 
+func (c *chain) Name() string {
+	return c.logger.Name()
+}
+
+func (c *chain) HealthReport() map[string]error {
+	return map[string]error{c.Name(): c.Healthy()}
+}
+
 func (c *chain) ID() *big.Int                        { return c.id }
 func (c *chain) Client() evmclient.Client            { return c.client }
 func (c *chain) Config() evmconfig.ChainScopedConfig { return c.cfg }

--- a/core/chains/evm/chain_set.go
+++ b/core/chains/evm/chain_set.go
@@ -126,6 +126,15 @@ func (cll *chainSet) Healthy() (err error) {
 	}
 	return
 }
+
+func (cll *chainSet) Name() string {
+	return cll.logger.Name()
+}
+
+func (cll *chainSet) HealthReport() map[string]error {
+	return map[string]error{cll.Name(): cll.Healthy()}
+}
+
 func (cll *chainSet) Ready() (err error) {
 	for _, c := range cll.Chains() {
 		err = multierr.Combine(err, c.Ready())

--- a/core/chains/evm/gas/block_history_estimator.go
+++ b/core/chains/evm/gas/block_history_estimator.go
@@ -218,6 +218,13 @@ func (b *BlockHistoryEstimator) Close() error {
 	})
 }
 
+func (b *BlockHistoryEstimator) Name() string {
+	return b.logger.Name()
+}
+func (b *BlockHistoryEstimator) HealthReport() map[string]error {
+	return map[string]error{b.Name(): b.Healthy()}
+}
+
 func (b *BlockHistoryEstimator) GetLegacyGas(_ context.Context, _ []byte, gasLimit uint32, maxGasPriceWei *assets.Wei, _ ...Opt) (gasPrice *assets.Wei, chainSpecificGasLimit uint32, err error) {
 	ok := b.IfStarted(func() {
 		chainSpecificGasLimit = applyMultiplier(gasLimit, b.config.EvmGasLimitMultiplier())

--- a/core/chains/evm/headtracker/head_broadcaster.go
+++ b/core/chains/evm/headtracker/head_broadcaster.go
@@ -71,6 +71,13 @@ func (hb *headBroadcaster) Close() error {
 	})
 }
 
+func (hb *headBroadcaster) Name() string {
+	return hb.logger.Name()
+}
+func (hb *headBroadcaster) HealthReport() map[string]error {
+	return map[string]error{hb.Name(): hb.Healthy()}
+}
+
 func (hb *headBroadcaster) BroadcastNewLongestChain(head *evmtypes.Head) {
 	hb.mailbox.Deliver(head)
 }

--- a/core/chains/evm/headtracker/head_tracker.go
+++ b/core/chains/evm/headtracker/head_tracker.go
@@ -146,6 +146,14 @@ func (ht *headTracker) Healthy() error {
 	return nil
 }
 
+func (ht *headTracker) Name() string {
+	return ht.log.Name()
+}
+
+func (ht *headTracker) HealthReport() map[string]error {
+	return map[string]error{ht.Name(): ht.Healthy()}
+}
+
 func (ht *headTracker) Backfill(ctx context.Context, headWithChain *evmtypes.Head, depth uint) (err error) {
 	if uint(headWithChain.ChainLength()) >= depth {
 		return nil
@@ -346,11 +354,13 @@ var NullTracker httypes.HeadTracker = &nullTracker{}
 
 type nullTracker struct{}
 
-func (*nullTracker) Start(context.Context) error { return nil }
-func (*nullTracker) Close() error                { return nil }
-func (*nullTracker) Ready() error                { return nil }
-func (*nullTracker) Healthy() error              { return nil }
-func (*nullTracker) SetLogLevel(zapcore.Level)   {}
+func (*nullTracker) Start(context.Context) error    { return nil }
+func (*nullTracker) Close() error                   { return nil }
+func (*nullTracker) Ready() error                   { return nil }
+func (*nullTracker) Healthy() error                 { return nil }
+func (*nullTracker) HealthReport() map[string]error { return map[string]error{} }
+func (*nullTracker) Name() string                   { return "" }
+func (*nullTracker) SetLogLevel(zapcore.Level)      {}
 func (*nullTracker) Backfill(ctx context.Context, headWithChain *evmtypes.Head, depth uint) (err error) {
 	return nil
 }

--- a/core/chains/evm/headtracker/mocks/head_broadcaster.go
+++ b/core/chains/evm/headtracker/mocks/head_broadcaster.go
@@ -35,6 +35,22 @@ func (_m *HeadBroadcaster) Close() error {
 	return r0
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *HeadBroadcaster) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *HeadBroadcaster) Healthy() error {
 	ret := _m.Called()
@@ -44,6 +60,20 @@ func (_m *HeadBroadcaster) Healthy() error {
 		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Name provides a mock function with given fields:
+func (_m *HeadBroadcaster) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/core/chains/evm/headtracker/mocks/head_tracker.go
+++ b/core/chains/evm/headtracker/mocks/head_tracker.go
@@ -43,6 +43,22 @@ func (_m *HeadTracker) Close() error {
 	return r0
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *HeadTracker) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *HeadTracker) Healthy() error {
 	ret := _m.Called()
@@ -68,6 +84,20 @@ func (_m *HeadTracker) LatestChain() *types.Head {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*types.Head)
 		}
+	}
+
+	return r0
+}
+
+// Name provides a mock function with given fields:
+func (_m *HeadTracker) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/core/chains/evm/log/broadcaster.go
+++ b/core/chains/evm/log/broadcaster.go
@@ -215,6 +215,14 @@ func (b *broadcaster) Close() error {
 	})
 }
 
+func (b *broadcaster) Name() string {
+	return b.logger.Name()
+}
+
+func (b *broadcaster) HealthReport() map[string]error {
+	return map[string]error{b.Name(): b.Healthy()}
+}
+
 func (b *broadcaster) awaitInitialSubscribers() {
 	defer b.wgDone.Done()
 	b.logger.Debug("Starting to await initial subscribers until all dependents are ready...")
@@ -778,11 +786,14 @@ func (n *NullBroadcaster) AwaitDependents() <-chan struct{} {
 // DependentReady does noop for NullBroadcaster.
 func (n *NullBroadcaster) DependentReady() {}
 
+func (n *NullBroadcaster) Name() string { return "" }
+
 // Start does noop for NullBroadcaster.
 func (n *NullBroadcaster) Start(context.Context) error                       { return nil }
 func (n *NullBroadcaster) Close() error                                      { return nil }
 func (n *NullBroadcaster) Healthy() error                                    { return nil }
 func (n *NullBroadcaster) Ready() error                                      { return nil }
+func (n *NullBroadcaster) HealthReport() map[string]error                    { return nil }
 func (n *NullBroadcaster) OnNewLongestChain(context.Context, *evmtypes.Head) {}
 func (n *NullBroadcaster) Pause()                                            {}
 func (n *NullBroadcaster) Resume()                                           {}

--- a/core/chains/evm/log/mocks/broadcaster.go
+++ b/core/chains/evm/log/mocks/broadcaster.go
@@ -58,6 +58,22 @@ func (_m *Broadcaster) DependentReady() {
 	_m.Called()
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *Broadcaster) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *Broadcaster) Healthy() error {
 	ret := _m.Called()
@@ -123,6 +139,20 @@ func (_m *Broadcaster) MarkManyConsumed(lbs []log.Broadcast, qopts ...pg.QOpt) e
 		r0 = rf(lbs, qopts...)
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Name provides a mock function with given fields:
+func (_m *Broadcaster) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/core/chains/evm/logpoller/disabled.go
+++ b/core/chains/evm/logpoller/disabled.go
@@ -16,6 +16,8 @@ var (
 
 type disabled struct{}
 
+func (disabled) Name() string { return "disabledLogPoller" }
+
 func (disabled) Start(ctx context.Context) error { return ErrDisabled }
 
 func (disabled) Close() error { return ErrDisabled }
@@ -23,6 +25,10 @@ func (disabled) Close() error { return ErrDisabled }
 func (disabled) Ready() error { return ErrDisabled }
 
 func (disabled) Healthy() error { return ErrDisabled }
+
+func (disabled) HealthReport() map[string]error {
+	return map[string]error{"disabledLogPoller": ErrDisabled}
+}
 
 func (disabled) Replay(ctx context.Context, fromBlock int64) error { return ErrDisabled }
 

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -341,6 +341,14 @@ func (lp *logPoller) Close() error {
 	})
 }
 
+func (lp *logPoller) Name() string {
+	return lp.lggr.Name()
+}
+
+func (lp *logPoller) HealthReport() map[string]error {
+	return map[string]error{lp.Name(): lp.Healthy()}
+}
+
 func (lp *logPoller) getReplayFromBlock(ctx context.Context, requested int64) (int64, error) {
 	lastProcessed, err := lp.orm.SelectLatestBlock(pg.WithParentCtx(ctx))
 	if err != nil {

--- a/core/chains/evm/logpoller/mocks/log_poller.go
+++ b/core/chains/evm/logpoller/mocks/log_poller.go
@@ -66,6 +66,22 @@ func (_m *LogPoller) GetBlocksRange(ctx context.Context, numbers []uint64, qopts
 	return r0, r1
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *LogPoller) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *LogPoller) Healthy() error {
 	ret := _m.Called()
@@ -405,6 +421,20 @@ func (_m *LogPoller) LogsWithSigs(start int64, end int64, eventSigs []common.Has
 	}
 
 	return r0, r1
+}
+
+// Name provides a mock function with given fields:
+func (_m *LogPoller) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
 }
 
 // Ready provides a mock function with given fields:

--- a/core/chains/evm/mocks/balance_monitor.go
+++ b/core/chains/evm/mocks/balance_monitor.go
@@ -48,6 +48,22 @@ func (_m *BalanceMonitor) GetEthBalance(_a0 common.Address) *assets.Eth {
 	return r0
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *BalanceMonitor) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *BalanceMonitor) Healthy() error {
 	ret := _m.Called()
@@ -57,6 +73,20 @@ func (_m *BalanceMonitor) Healthy() error {
 		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Name provides a mock function with given fields:
+func (_m *BalanceMonitor) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/core/chains/evm/mocks/chain.go
+++ b/core/chains/evm/mocks/chain.go
@@ -126,6 +126,22 @@ func (_m *Chain) HeadTracker() types.HeadTracker {
 	return r0
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *Chain) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *Chain) Healthy() error {
 	ret := _m.Called()
@@ -199,6 +215,20 @@ func (_m *Chain) Logger() logger.Logger {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(logger.Logger)
 		}
+	}
+
+	return r0
+}
+
+// Name provides a mock function with given fields:
+func (_m *Chain) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/core/chains/evm/mocks/chain_set.go
+++ b/core/chains/evm/mocks/chain_set.go
@@ -296,6 +296,22 @@ func (_m *ChainSet) GetNodesForChain(ctx context.Context, chainID utils.Big, off
 	return r0, r1, r2
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *ChainSet) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *ChainSet) Healthy() error {
 	ret := _m.Called()
@@ -341,6 +357,20 @@ func (_m *ChainSet) Index(offset int, limit int) ([]chains.DBChain[utils.Big, *t
 	}
 
 	return r0, r1, r2
+}
+
+// Name provides a mock function with given fields:
+func (_m *ChainSet) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
+	}
+
+	return r0
 }
 
 // ORM provides a mock function with given fields:

--- a/core/chains/evm/monitor/balance.go
+++ b/core/chains/evm/monitor/balance.go
@@ -88,12 +88,12 @@ func (bm *balanceMonitor) Healthy() error {
 	return nil
 }
 
-func (b *balanceMonitor) Name() string {
-	return b.logger.Name()
+func (bm *balanceMonitor) Name() string {
+	return bm.logger.Name()
 }
 
-func (b *balanceMonitor) HealthReport() map[string]error {
-	return map[string]error{b.Name(): b.Healthy()}
+func (bm *balanceMonitor) HealthReport() map[string]error {
+	return map[string]error{bm.Name(): bm.Healthy()}
 }
 
 // OnNewLongestChain checks the balance for each key

--- a/core/chains/evm/monitor/balance.go
+++ b/core/chains/evm/monitor/balance.go
@@ -88,6 +88,14 @@ func (bm *balanceMonitor) Healthy() error {
 	return nil
 }
 
+func (b *balanceMonitor) Name() string {
+	return b.logger.Name()
+}
+
+func (b *balanceMonitor) HealthReport() map[string]error {
+	return map[string]error{b.Name(): b.Healthy()}
+}
+
 // OnNewLongestChain checks the balance for each key
 func (bm *balanceMonitor) OnNewLongestChain(_ context.Context, head *evmtypes.Head) {
 	ok := bm.IfStarted(func() {

--- a/core/chains/evm/txmgr/eth_confirmer.go
+++ b/core/chains/evm/txmgr/eth_confirmer.go
@@ -195,6 +195,14 @@ func (ec *EthConfirmer) Close() error {
 	})
 }
 
+func (ec *EthConfirmer) Name() string {
+	return ec.lggr.Name()
+}
+
+func (ec *EthConfirmer) HealthReport() map[string]error {
+	return map[string]error{ec.Name(): ec.Healthy()}
+}
+
 func (ec *EthConfirmer) runLoop() {
 	defer ec.wg.Done()
 	for {

--- a/core/chains/evm/txmgr/mocks/tx_manager.go
+++ b/core/chains/evm/txmgr/mocks/tx_manager.go
@@ -114,6 +114,22 @@ func (_m *TxManager) GetGasEstimator() gas.Estimator {
 	return r0
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *TxManager) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *TxManager) Healthy() error {
 	ret := _m.Called()
@@ -123,6 +139,20 @@ func (_m *TxManager) Healthy() error {
 		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Name provides a mock function with given fields:
+func (_m *TxManager) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/core/chains/evm/txmgr/txmgr.go
+++ b/core/chains/evm/txmgr/txmgr.go
@@ -278,6 +278,14 @@ func (b *Txm) Close() (merr error) {
 	})
 }
 
+func (b *Txm) Name() string {
+	return b.logger.Name()
+}
+
+func (b *Txm) HealthReport() map[string]error {
+	return map[string]error{b.Name(): b.Healthy()}
+}
+
 func (b *Txm) runLoop(eb *EthBroadcaster, ec *EthConfirmer, keyStates []ethkey.State) {
 	// eb, ec and keyStates can all be modified by the runloop.
 	// This is concurrent-safe because the runloop ensures serial access.
@@ -735,5 +743,7 @@ func (n *NullTxManager) SendEther(chainID *big.Int, from, to common.Address, val
 }
 func (n *NullTxManager) Healthy() error                           { return nil }
 func (n *NullTxManager) Ready() error                             { return nil }
+func (n *NullTxManager) Name() string                             { return "" }
+func (n *NullTxManager) HealthReport() map[string]error           { return nil }
 func (n *NullTxManager) GetGasEstimator() gas.Estimator           { return nil }
 func (n *NullTxManager) RegisterResumeCallback(fn ResumeCallback) {}

--- a/core/chains/solana/monitor/balance.go
+++ b/core/chains/solana/monitor/balance.go
@@ -57,6 +57,10 @@ type balanceMonitor struct {
 	stop, done chan struct{}
 }
 
+func (b *balanceMonitor) Name() string {
+	return b.lggr.Name()
+}
+
 func (b *balanceMonitor) Start(context.Context) error {
 	return b.StartOnce("SolanaBalanceMonitor", func() error {
 		go b.monitor()
@@ -70,6 +74,10 @@ func (b *balanceMonitor) Close() error {
 		<-b.done
 		return nil
 	})
+}
+
+func (b *balanceMonitor) HealthReport() map[string]error {
+	return map[string]error{b.Name(): b.Healthy()}
 }
 
 func (b *balanceMonitor) monitor() {

--- a/core/chains/solana/soltxm/txm.go
+++ b/core/chains/solana/soltxm/txm.go
@@ -521,6 +521,7 @@ func (txm *Txm) Close() error {
 		return txm.fee.Close()
 	})
 }
+func (txm *Txm) Name() string { return "solanatxm" }
 
 // Healthy service is healthy
 func (txm *Txm) Healthy() error {
@@ -531,3 +532,5 @@ func (txm *Txm) Healthy() error {
 func (txm *Txm) Ready() error {
 	return nil
 }
+
+func (txm *Txm) HealthReport() map[string]error { return map[string]error{} }

--- a/core/chains/solana/soltxm/txm.go
+++ b/core/chains/solana/soltxm/txm.go
@@ -533,4 +533,4 @@ func (txm *Txm) Ready() error {
 	return nil
 }
 
-func (txm *Txm) HealthReport() map[string]error { return map[string]error{} }
+func (txm *Txm) HealthReport() map[string]error { return map[string]error{txm.Name(): txm.Healthy()} }

--- a/core/chains/starknet/chain.go
+++ b/core/chains/starknet/chain.go
@@ -54,6 +54,10 @@ func newChain(id string, cfg config.Config, ks keystore.StarkNet, orm types.ORM,
 	return ch, nil
 }
 
+func (c *chain) Name() string {
+	return c.lggr.Name()
+}
+
 func (c *chain) Config() config.Config {
 	return c.cfg
 }
@@ -107,10 +111,6 @@ func (c *chain) getClient() (*starknet.Client, error) {
 	}
 	c.lggr.Debugw("Created client", "name", node.Name, "starknet-url", node.URL)
 	return client, nil
-}
-
-func (c *chain) Name() string {
-	return c.lggr.Name()
 }
 
 func (c *chain) Start(ctx context.Context) error {

--- a/core/chains/starknet/chain_set.go
+++ b/core/chains/starknet/chain_set.go
@@ -24,6 +24,10 @@ type ChainSetOpts struct {
 	ORM      types.ORM
 }
 
+func (o *ChainSetOpts) Name() string {
+	return o.Logger.Name()
+}
+
 func (o *ChainSetOpts) Validate() (err error) {
 	required := func(s string) error {
 		return errors.Errorf("%s is required", s)

--- a/core/logger/audit/audit_logger.go
+++ b/core/logger/audit/audit_logger.go
@@ -309,6 +309,14 @@ func (l *AuditLoggerService) Healthy() error {
 	return nil
 }
 
+func (l *AuditLoggerService) Name() string {
+	return l.logger.Name()
+}
+
+func (l *AuditLoggerService) HealthReport() map[string]error {
+	return map[string]error{l.logger.Name(): l.Healthy()}
+}
+
 func (l *AuditLoggerService) Ready() error {
 	if !l.enabled {
 		return errors.New("the audit logger is not enabled")

--- a/core/services/checkable.go
+++ b/core/services/checkable.go
@@ -9,4 +9,7 @@ type Checkable interface {
 	Ready() error
 	// Healthy should return nil if healthy, or an error message otherwise.
 	Healthy() error
+	// HealthReport returns a full health report of the callee including it's dependencies.
+	// key is the dep name, value is nil if healthy, or error message otherwise.
+	HealthReport() map[string]error
 }

--- a/core/services/health_test.go
+++ b/core/services/health_test.go
@@ -29,6 +29,13 @@ func (b boolCheck) Healthy() error {
 	return ErrUnhealthy
 }
 
+func (b boolCheck) HealthReport() map[string]error {
+	if b {
+		return map[string]error{"boolCheck": nil}
+	}
+	return map[string]error{"boolCheck": ErrUnhealthy}
+}
+
 func TestCheck(t *testing.T) {
 	for i, test := range []struct {
 		checks   []services.Checkable

--- a/core/services/job/mocks/spawner.go
+++ b/core/services/job/mocks/spawner.go
@@ -88,6 +88,22 @@ func (_m *Spawner) DeleteJob(jobID int32, qopts ...pg.QOpt) error {
 	return r0
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *Spawner) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *Spawner) Healthy() error {
 	ret := _m.Called()
@@ -97,6 +113,20 @@ func (_m *Spawner) Healthy() error {
 		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Name provides a mock function with given fields:
+func (_m *Spawner) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/core/services/job/spawner.go
+++ b/core/services/job/spawner.go
@@ -115,7 +115,7 @@ func (js *spawner) Name() string {
 }
 
 func (js *spawner) HealthReport() map[string]error {
-	return map[string]error{}
+	return map[string]error{js.Name(): js.Healthy()}
 }
 
 func (js *spawner) startAllServices(ctx context.Context) {

--- a/core/services/job/spawner.go
+++ b/core/services/job/spawner.go
@@ -110,6 +110,14 @@ func (js *spawner) Close() error {
 	})
 }
 
+func (js *spawner) Name() string {
+	return js.lggr.Name()
+}
+
+func (js *spawner) HealthReport() map[string]error {
+	return map[string]error{}
+}
+
 func (js *spawner) startAllServices(ctx context.Context) {
 	// TODO: rename to find AllJobs
 	specs, _, err := js.orm.FindJobs(0, math.MaxUint32)

--- a/core/services/ocrcommon/peer_wrapper.go
+++ b/core/services/ocrcommon/peer_wrapper.go
@@ -217,6 +217,14 @@ func (p *SingletonPeerWrapper) Close() error {
 	})
 }
 
+func (p *SingletonPeerWrapper) Name() string {
+	return p.lggr.Name()
+}
+
+func (p *SingletonPeerWrapper) HealthReport() map[string]error {
+	return map[string]error{}
+}
+
 func (p *SingletonPeerWrapper) Config() PeerWrapperConfig {
 	return p.config
 }

--- a/core/services/ocrcommon/peer_wrapper.go
+++ b/core/services/ocrcommon/peer_wrapper.go
@@ -222,7 +222,7 @@ func (p *SingletonPeerWrapper) Name() string {
 }
 
 func (p *SingletonPeerWrapper) HealthReport() map[string]error {
-	return map[string]error{}
+	return map[string]error{p.Name(): p.Healthy()}
 }
 
 func (p *SingletonPeerWrapper) Config() PeerWrapperConfig {

--- a/core/services/periodicbackup/backup.go
+++ b/core/services/periodicbackup/backup.go
@@ -127,6 +127,13 @@ func (backup *databaseBackup) Close() error {
 	})
 }
 
+func (b *databaseBackup) Name() string {
+	return b.logger.Name()
+}
+func (b *databaseBackup) HealthReport() map[string]error {
+	return map[string]error{b.Name(): b.Healthy()}
+}
+
 func (backup *databaseBackup) frequencyIsTooSmall() bool {
 	return backup.frequency < minBackupFrequency
 }

--- a/core/services/periodicbackup/backup.go
+++ b/core/services/periodicbackup/backup.go
@@ -127,11 +127,12 @@ func (backup *databaseBackup) Close() error {
 	})
 }
 
-func (b *databaseBackup) Name() string {
-	return b.logger.Name()
+func (backup *databaseBackup) Name() string {
+	return backup.logger.Name()
 }
-func (b *databaseBackup) HealthReport() map[string]error {
-	return map[string]error{b.Name(): b.Healthy()}
+
+func (backup *databaseBackup) HealthReport() map[string]error {
+	return map[string]error{backup.Name(): backup.Healthy()}
 }
 
 func (backup *databaseBackup) frequencyIsTooSmall() bool {

--- a/core/services/pg/event_broadcaster.go
+++ b/core/services/pg/event_broadcaster.go
@@ -124,6 +124,14 @@ func (b *eventBroadcaster) Close() error {
 	})
 }
 
+func (b *eventBroadcaster) Name() string {
+	return b.lggr.Name()
+}
+
+func (b *eventBroadcaster) HealthReport() map[string]error {
+	return map[string]error{b.Name(): b.Healthy()}
+}
+
 func (b *eventBroadcaster) runLoop() {
 	defer close(b.chDone)
 	for {
@@ -305,6 +313,8 @@ func NewNullEventBroadcaster() *NullEventBroadcaster {
 
 var _ EventBroadcaster = &NullEventBroadcaster{}
 
+func (*NullEventBroadcaster) Name() string { return "" }
+
 // Start does no-op.
 func (*NullEventBroadcaster) Start(context.Context) error { return nil }
 
@@ -316,6 +326,9 @@ func (*NullEventBroadcaster) Ready() error { return nil }
 
 // Healthy does no-op.
 func (*NullEventBroadcaster) Healthy() error { return nil }
+
+// HealthReport does no-op
+func (*NullEventBroadcaster) HealthReport() map[string]error { return map[string]error{} }
 
 func (ne *NullEventBroadcaster) Subscribe(channel, payloadFilter string) (Subscription, error) {
 	return ne.Sub, nil

--- a/core/services/pg/mocks/event_broadcaster.go
+++ b/core/services/pg/mocks/event_broadcaster.go
@@ -28,6 +28,22 @@ func (_m *EventBroadcaster) Close() error {
 	return r0
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *EventBroadcaster) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *EventBroadcaster) Healthy() error {
 	ret := _m.Called()
@@ -37,6 +53,20 @@ func (_m *EventBroadcaster) Healthy() error {
 		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Name provides a mock function with given fields:
+func (_m *EventBroadcaster) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/core/services/pipeline/mocks/orm.go
+++ b/core/services/pipeline/mocks/orm.go
@@ -194,6 +194,22 @@ func (_m *ORM) GetUnfinishedRuns(_a0 context.Context, _a1 time.Time, _a2 func(pi
 	return r0
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *ORM) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *ORM) Healthy() error {
 	ret := _m.Called()
@@ -266,6 +282,20 @@ func (_m *ORM) InsertRun(run *pipeline.Run, qopts ...pg.QOpt) error {
 		r0 = rf(run, qopts...)
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Name provides a mock function with given fields:
+func (_m *ORM) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/core/services/pipeline/mocks/runner.go
+++ b/core/services/pipeline/mocks/runner.go
@@ -98,6 +98,22 @@ func (_m *Runner) ExecuteRun(ctx context.Context, spec pipeline.Spec, vars pipel
 	return r0, r1, r2
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *Runner) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *Runner) Healthy() error {
 	ret := _m.Called()
@@ -149,6 +165,20 @@ func (_m *Runner) InsertFinishedRuns(runs []*pipeline.Run, saveSuccessfulTaskRun
 		r0 = rf(runs, saveSuccessfulTaskRuns, qopts...)
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Name provides a mock function with given fields:
+func (_m *Runner) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/core/services/pipeline/orm.go
+++ b/core/services/pipeline/orm.go
@@ -148,6 +148,14 @@ func (o *orm) Close() error {
 	})
 }
 
+func (o *orm) Name() string {
+	return o.lggr.Name()
+}
+
+func (o *orm) HealthReport() map[string]error {
+	return map[string]error{o.Name(): o.Healthy()}
+}
+
 func (o *orm) CreateSpec(pipeline Pipeline, maxTaskDuration models.Interval, qopts ...pg.QOpt) (id int32, err error) {
 	q := o.q.WithOpts(qopts...)
 	sql := `INSERT INTO pipeline_specs (dot_dag_source, max_task_duration, created_at)

--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -142,6 +142,14 @@ func (r *runner) Close() error {
 	})
 }
 
+func (r *runner) Name() string {
+	return r.lggr.Name()
+}
+
+func (r *runner) HealthReport() map[string]error {
+	return map[string]error{}
+}
+
 func (r *runner) destroy() {
 	err := r.runReaperWorker.Stop()
 	if err != nil {

--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -147,7 +147,7 @@ func (r *runner) Name() string {
 }
 
 func (r *runner) HealthReport() map[string]error {
-	return map[string]error{}
+	return map[string]error{r.Name(): r.Healthy()}
 }
 
 func (r *runner) destroy() {

--- a/core/services/promreporter/prom_reporter.go
+++ b/core/services/promreporter/prom_reporter.go
@@ -130,7 +130,7 @@ func (pr *promReporter) Name() string {
 }
 
 func (pr *promReporter) HealthReport() map[string]error {
-	return map[string]error{}
+	return map[string]error{pr.Name(): pr.Healthy()}
 }
 
 func (pr *promReporter) OnNewLongestChain(ctx context.Context, head *evmtypes.Head) {

--- a/core/services/promreporter/prom_reporter.go
+++ b/core/services/promreporter/prom_reporter.go
@@ -125,6 +125,13 @@ func (pr *promReporter) Close() error {
 		return nil
 	})
 }
+func (pr *promReporter) Name() string {
+	return pr.lggr.Name()
+}
+
+func (pr *promReporter) HealthReport() map[string]error {
+	return map[string]error{}
+}
 
 func (pr *promReporter) OnNewLongestChain(ctx context.Context, head *evmtypes.Head) {
 	pr.newHeads.Deliver(head)

--- a/core/services/relay/evm/contract_transmitter.go
+++ b/core/services/relay/evm/contract_transmitter.go
@@ -172,5 +172,7 @@ func (oc *contractTransmitter) Start(ctx context.Context) error { return nil }
 func (oc *contractTransmitter) Close() error                    { return nil }
 
 // Has no state/lifecycle so it's always healthy and ready
-func (oc *contractTransmitter) Healthy() error { return nil }
-func (oc *contractTransmitter) Ready() error   { return nil }
+func (oc *contractTransmitter) Healthy() error                 { return nil }
+func (oc *contractTransmitter) Ready() error                   { return nil }
+func (oc *contractTransmitter) HealthReport() map[string]error { return map[string]error{} }
+func (oc *contractTransmitter) Name() string                   { return "" }

--- a/core/services/relay/evm/contract_transmitter.go
+++ b/core/services/relay/evm/contract_transmitter.go
@@ -172,7 +172,9 @@ func (oc *contractTransmitter) Start(ctx context.Context) error { return nil }
 func (oc *contractTransmitter) Close() error                    { return nil }
 
 // Has no state/lifecycle so it's always healthy and ready
-func (oc *contractTransmitter) Healthy() error                 { return nil }
-func (oc *contractTransmitter) Ready() error                   { return nil }
-func (oc *contractTransmitter) HealthReport() map[string]error { return map[string]error{} }
-func (oc *contractTransmitter) Name() string                   { return "" }
+func (oc *contractTransmitter) Healthy() error { return nil }
+func (oc *contractTransmitter) Ready() error   { return nil }
+func (oc *contractTransmitter) HealthReport() map[string]error {
+	return map[string]error{oc.Name(): oc.Healthy()}
+}
+func (oc *contractTransmitter) Name() string { return "" }

--- a/core/services/relay/evm/mercury/transmitter.go
+++ b/core/services/relay/evm/mercury/transmitter.go
@@ -57,6 +57,13 @@ func (mt *mercuryTransmitter) Start(ctx context.Context) error { return mt.rpcCl
 func (mt *mercuryTransmitter) Close() error                    { return mt.rpcClient.Close() }
 func (mt *mercuryTransmitter) Healthy() error                  { return mt.rpcClient.Healthy() }
 func (mt *mercuryTransmitter) Ready() error                    { return mt.rpcClient.Ready() }
+func (mt *mercuryTransmitter) Name() string {
+	return mt.lggr.Name()
+}
+
+func (mt *mercuryTransmitter) HealthReport() map[string]error {
+	return map[string]error{mt.Name(): mt.Healthy()}
+}
 
 // Transmit sends the report to the on-chain smart contract's Transmit method.
 func (mt *mercuryTransmitter) Transmit(ctx context.Context, reportCtx ocrtypes.ReportContext, report ocrtypes.Report, signatures []ocrtypes.AttributedOnchainSignature) error {

--- a/core/services/relay/evm/mercury/transmitter_test.go
+++ b/core/services/relay/evm/mercury/transmitter_test.go
@@ -19,10 +19,12 @@ type MockWSRPCClient struct {
 	transmit func(ctx context.Context, in *report.ReportRequest) (*report.ReportResponse, error)
 }
 
-func (m MockWSRPCClient) Start(context.Context) error { return nil }
-func (m MockWSRPCClient) Close() error                { return nil }
-func (m MockWSRPCClient) Healthy() error              { return nil }
-func (m MockWSRPCClient) Ready() error                { return nil }
+func (m MockWSRPCClient) Name() string                   { return "" }
+func (m MockWSRPCClient) Start(context.Context) error    { return nil }
+func (m MockWSRPCClient) Close() error                   { return nil }
+func (m MockWSRPCClient) Healthy() error                 { return nil }
+func (m MockWSRPCClient) HealthReport() map[string]error { return map[string]error{} }
+func (m MockWSRPCClient) Ready() error                   { return nil }
 func (m MockWSRPCClient) Transmit(ctx context.Context, in *report.ReportRequest) (*report.ReportResponse, error) {
 	return m.transmit(ctx, in)
 }

--- a/core/services/relay/evm/mercury/wsrpc/client.go
+++ b/core/services/relay/evm/mercury/wsrpc/client.go
@@ -66,8 +66,9 @@ func (w *client) Close() error {
 }
 
 func (w *client) Name() string {
-	return w.Name()
+	return "EVM.Mercury.WSRPCClient"
 }
+
 func (w *client) HealthReport() map[string]error {
 	return map[string]error{w.Name(): w.Healthy()}
 }

--- a/core/services/relay/evm/mercury/wsrpc/client.go
+++ b/core/services/relay/evm/mercury/wsrpc/client.go
@@ -65,6 +65,13 @@ func (w *client) Close() error {
 	})
 }
 
+func (w *client) Name() string {
+	return w.Name()
+}
+func (w *client) HealthReport() map[string]error {
+	return map[string]error{w.Name(): w.Healthy()}
+}
+
 func (w *client) Transmit(ctx context.Context, in *report.ReportRequest) (rr *report.ReportResponse, err error) {
 	ok := w.IfStarted(func() {
 		rr, err = w.client.Transmit(ctx, in)

--- a/core/services/service.go
+++ b/core/services/service.go
@@ -81,5 +81,8 @@ type ServiceCtx interface {
 	// again, you need to build a new Service to do so.
 	Close() error
 
+	// Name returns the fully qualified name of the service
+	Name() string
+
 	Checkable
 }

--- a/core/services/synchronization/explorer_client.go
+++ b/core/services/synchronization/explorer_client.go
@@ -58,6 +58,9 @@ type ExplorerClient interface {
 
 type NoopExplorerClient struct{}
 
+func (NoopExplorerClient) HealthReport() map[string]error { return map[string]error{} }
+func (NoopExplorerClient) Name() string                   { return "" }
+
 // Url always returns underlying url.
 func (NoopExplorerClient) Url() url.URL { return url.URL{} }
 
@@ -140,6 +143,14 @@ func (ec *explorerClient) Start(context.Context) error {
 		go ec.connectAndWritePump()
 		return nil
 	})
+}
+
+func (ec *explorerClient) Name() string {
+	return ec.lggr.Name()
+}
+
+func (ec *explorerClient) HealthReport() map[string]error {
+	return map[string]error{ec.Name(): ec.Healthy()}
 }
 
 // Send sends data asynchronously across the websocket if it's open, or

--- a/core/services/synchronization/mocks/explorer_client.go
+++ b/core/services/synchronization/mocks/explorer_client.go
@@ -32,6 +32,22 @@ func (_m *ExplorerClient) Close() error {
 	return r0
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *ExplorerClient) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *ExplorerClient) Healthy() error {
 	ret := _m.Called()
@@ -41,6 +57,20 @@ func (_m *ExplorerClient) Healthy() error {
 		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Name provides a mock function with given fields:
+func (_m *ExplorerClient) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/core/services/synchronization/mocks/telemetry_ingress_batch_client.go
+++ b/core/services/synchronization/mocks/telemetry_ingress_batch_client.go
@@ -28,6 +28,22 @@ func (_m *TelemetryIngressBatchClient) Close() error {
 	return r0
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *TelemetryIngressBatchClient) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *TelemetryIngressBatchClient) Healthy() error {
 	ret := _m.Called()
@@ -37,6 +53,20 @@ func (_m *TelemetryIngressBatchClient) Healthy() error {
 		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Name provides a mock function with given fields:
+func (_m *TelemetryIngressBatchClient) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/core/services/synchronization/mocks/telemetry_ingress_client.go
+++ b/core/services/synchronization/mocks/telemetry_ingress_client.go
@@ -28,6 +28,22 @@ func (_m *TelemetryIngressClient) Close() error {
 	return r0
 }
 
+// HealthReport provides a mock function with given fields:
+func (_m *TelemetryIngressClient) HealthReport() map[string]error {
+	ret := _m.Called()
+
+	var r0 map[string]error
+	if rf, ok := ret.Get(0).(func() map[string]error); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(map[string]error)
+		}
+	}
+
+	return r0
+}
+
 // Healthy provides a mock function with given fields:
 func (_m *TelemetryIngressClient) Healthy() error {
 	ret := _m.Called()
@@ -37,6 +53,20 @@ func (_m *TelemetryIngressClient) Healthy() error {
 		r0 = rf()
 	} else {
 		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
+// Name provides a mock function with given fields:
+func (_m *TelemetryIngressClient) Name() string {
+	ret := _m.Called()
+
+	var r0 string
+	if rf, ok := ret.Get(0).(func() string); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(string)
 	}
 
 	return r0

--- a/core/services/synchronization/telemetry_ingress_batch_client.go
+++ b/core/services/synchronization/telemetry_ingress_batch_client.go
@@ -43,7 +43,9 @@ func (NoopTelemetryIngressBatchClient) Close() error { return nil }
 func (NoopTelemetryIngressBatchClient) Send(TelemPayload) {}
 
 // Healthy is a no-op
-func (NoopTelemetryIngressBatchClient) Healthy() error { return nil }
+func (NoopTelemetryIngressBatchClient) Healthy() error                 { return nil }
+func (NoopTelemetryIngressBatchClient) HealthReport() map[string]error { return map[string]error{} }
+func (NoopTelemetryIngressBatchClient) Name() string                   { return "" }
 
 // Ready is a no-op
 func (NoopTelemetryIngressBatchClient) Ready() error { return nil }
@@ -156,6 +158,14 @@ func (tc *telemetryIngressBatchClient) Close() error {
 		}
 		return nil
 	})
+}
+
+func (tc *telemetryIngressBatchClient) Name() string {
+	return tc.lggr.Name()
+}
+
+func (tc *telemetryIngressBatchClient) HealthReport() map[string]error {
+	return map[string]error{tc.Name(): tc.Healthy()}
 }
 
 // getCSAPrivateKey gets the client's CSA private key

--- a/core/services/synchronization/telemetry_ingress_client.go
+++ b/core/services/synchronization/telemetry_ingress_client.go
@@ -43,6 +43,9 @@ func (NoopTelemetryIngressClient) Send(TelemPayload) {}
 // Healthy is a no-op
 func (NoopTelemetryIngressClient) Healthy() error { return nil }
 
+func (NoopTelemetryIngressClient) HealthReport() map[string]error { return map[string]error{} }
+func (NoopTelemetryIngressClient) Name() string                   { return "" }
+
 // Ready is a no-op
 func (NoopTelemetryIngressClient) Ready() error { return nil }
 
@@ -104,6 +107,14 @@ func (tc *telemetryIngressClient) Close() error {
 		tc.wgDone.Wait()
 		return nil
 	})
+}
+
+func (tc *telemetryIngressClient) Name() string {
+	return tc.lggr.Name()
+}
+
+func (tc *telemetryIngressClient) HealthReport() map[string]error {
+	return map[string]error{tc.Name(): tc.Healthy()}
 }
 
 func (tc *telemetryIngressClient) connect(ctx context.Context, clientPrivKey []byte) {

--- a/core/utils/mailbox_prom.go
+++ b/core/utils/mailbox_prom.go
@@ -32,6 +32,8 @@ func NewMailboxMonitor(appID string) *MailboxMonitor {
 	return &MailboxMonitor{appID: appID}
 }
 
+func (m *MailboxMonitor) Name() string { return "MailboxMonitor" }
+
 func (m *MailboxMonitor) Start(context.Context) error {
 	return m.StartOnce("MailboxMonitor", func() error {
 		t := time.NewTicker(WithJitter(mailboxPromInterval))
@@ -46,6 +48,10 @@ func (m *MailboxMonitor) Close() error {
 		m.stop()
 		return nil
 	})
+}
+
+func (m *MailboxMonitor) HealthReport() map[string]error {
+	return map[string]error{m.Name(): m.Healthy()}
 }
 
 func (m *MailboxMonitor) monitorLoop(c <-chan time.Time) {


### PR DESCRIPTION
This PR implements HealthReport for all services in core node.
Current implementation for HealthReport is a drop in replacement for Healthy()

This code is not used yet, it doesn't make sense to add unit tests in the current state since all the logic within HealthReport is going to be modified to incl more granular checks.

Next steps:
- Go over srvcs
- Define Healthy() correctly per service
- Implement HealthReport to return health status for the service as well
  as it's subservices.