### PR TITLE
Simplify median aggregation to avoid division

### DIFF
--- a/core/services/ocr2/plugins/directrequestocr/aggregation.go
+++ b/core/services/ocr2/plugins/directrequestocr/aggregation.go
@@ -3,7 +3,6 @@ package directrequestocr
 import (
 	"bytes"
 	"fmt"
-	"math/big"
 	"sort"
 
 	"github.com/smartcontractkit/chainlink/core/services/ocr2/plugins/directrequestocr/config"
@@ -83,24 +82,5 @@ func aggregateMedian(items [][]byte) []byte {
 		}
 		return bytes.Compare(items[i], items[j]) < 0
 	})
-	if len(items)%2 == 1 {
-		return items[len(items)/2]
-	}
-	return average(items[len(items)/2-1], items[len(items)/2])
-}
-
-func average(v1 []byte, v2 []byte) []byte {
-	if bytes.Equal(v1, v2) {
-		return v1
-	}
-	var val1, val2, res big.Int
-	val1.SetBytes(v1)
-	val2.SetBytes(v2)
-	res.Add(&val1, &val2)
-	res.Div(&res, big.NewInt(2))
-	if len(v1) == len(v2) {
-		// Align to the same length as inputs
-		return res.FillBytes(make([]byte, len(v1)))
-	}
-	return res.Bytes()
+	return items[(len(items)-1)/2]
 }

--- a/core/services/ocr2/plugins/directrequestocr/aggregation_test.go
+++ b/core/services/ocr2/plugins/directrequestocr/aggregation_test.go
@@ -89,7 +89,7 @@ func TestAggregate_Successful(t *testing.T) {
 				req(21, []byte{5, 100}, []byte{}),
 				req(21, []byte{12, 2}, []byte{}),
 			},
-			req(21, []byte{10, 134}, []byte{}),
+			req(21, []byte{9, 11}, []byte{}),
 		},
 		{
 			"Median Even Aligned",
@@ -100,7 +100,7 @@ func TestAggregate_Successful(t *testing.T) {
 				req(21, []byte{0, 0, 5, 100}, []byte{}),
 				req(21, []byte{0, 0, 12, 2}, []byte{}),
 			},
-			req(21, []byte{0, 0, 10, 134}, []byte{}),
+			req(21, []byte{0, 0, 9, 11}, []byte{}),
 		},
 	}
 


### PR DESCRIPTION
Average doesn't make sense for non-numerical values and sometimes returns weird results when users attempt to encode arrays. Let's simplify and just take the middle value, even for an even number of observations.