### PR TITLE
BCF-1797 Better defaults for nurse.

### DIFF
--- a/core/config/general_config.go
+++ b/core/config/general_config.go
@@ -559,7 +559,7 @@ func (c *generalConfig) AutoPprofEnabled() bool {
 func (c *generalConfig) AutoPprofProfileRoot() string {
 	root := c.viper.GetString(envvar.Name("AutoPprofProfileRoot"))
 	if root == "" {
-		return c.RootDir()
+		return filepath.Join(c.RootDir(), "pprof")
 	}
 	return root
 }

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -473,7 +473,7 @@ func (g *generalConfig) AutoPprofPollInterval() models.Duration {
 func (g *generalConfig) AutoPprofProfileRoot() string {
 	s := *g.c.AutoPprof.ProfileRoot
 	if s == "" {
-		s = g.RootDir()
+		s = filepath.Join(g.RootDir(), "pprof")
 	}
 	return s
 }


### PR DESCRIPTION
The nurse code changes sets permissions on the dir where it stores profiles. That caused problems because the default dir was the RootDir.

Give the pprrof a subdir in RootDir by default.