### PR TITLE
core/services/synchronization: stop explorer client from spamming too fast

### DIFF
--- a/core/services/synchronization/explorer_client.go
+++ b/core/services/synchronization/explorer_client.go
@@ -258,11 +258,14 @@ func (ec *explorerClient) connectAndWritePump() {
 			ec.setStatus(ConnectionStatusConnected)
 
 			ec.lggr.Infow("Connected to explorer", "url", ec.url)
-			ec.sleeper.Reset()
+			start := time.Now()
 			ec.writePumpDone = make(chan struct{})
 			ec.wg.Add(1)
 			go ec.readPump()
 			ec.writePump()
+			if time.Since(start) > time.Second {
+				ec.sleeper.Reset()
+			}
 
 		case <-ec.chStop:
 			return


### PR DESCRIPTION
The backoff helper was always being reset, meaning the next call would never wait, even if we immediately fail right after resetting. Now we only reset if the connection lasted longer than a second.