### PR TITLE
Add error buffer util

### DIFF
--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -1147,15 +1147,11 @@ func (eb *ErrorBuffer) Append(incoming error) {
 	eb.buffer = append(eb.buffer, incoming)
 }
 
-type joinedError interface {
-	Unwrap() []error
-}
-
 // UnwrapError returns a list of underlying errors if passed error implements joinedError or return the err in a single-element list otherwise.
 //
 //nolint:errorlint // error type checks will fail on wrapped errors. Disabled since we are not doing checks on error types.
 func UnwrapError(err error) []error {
-	joined, ok := err.(joinedError)
+	joined, ok := err.(interface{ Unwrap() []error })
 	if !ok {
 		return []error{err}
 	}

--- a/core/utils/utils_test.go
+++ b/core/utils/utils_test.go
@@ -983,3 +983,57 @@ func TestTryParseHex(t *testing.T) {
 		assert.Equal(t, []byte{0x1, 0x23}, b)
 	})
 }
+
+func TestErrorBuffer(t *testing.T) {
+	t.Parallel()
+
+	err1 := errors.New("err1")
+	err2 := errors.New("err2")
+	err3 := errors.New("err3")
+
+	t.Run("happy path", func(t *testing.T) {
+		t.Parallel()
+		buff := utils.ErrorBuffer{}
+		buff.Append(err1)
+		buff.Append(err2)
+		combined := buff.Flush()
+		errs := utils.UnwrapError(combined)
+		assert.Equal(t, 2, len(errs))
+		assert.Equal(t, err1.Error(), errs[0].Error())
+		assert.Equal(t, err2.Error(), errs[1].Error())
+	})
+
+	t.Run("ovewrite oldest error when cap exceeded", func(t *testing.T) {
+		t.Parallel()
+		buff := utils.ErrorBuffer{Cap: 2}
+		buff.Append(err1)
+		buff.Append(err2)
+		buff.Append(err3)
+		combined := buff.Flush()
+		errs := utils.UnwrapError(combined)
+		assert.Equal(t, 2, len(errs))
+		assert.Equal(t, err2.Error(), errs[0].Error())
+		assert.Equal(t, err3.Error(), errs[1].Error())
+	})
+
+	t.Run("does not overwrite the buffer if cap == 0", func(t *testing.T) {
+		t.Parallel()
+		buff := utils.ErrorBuffer{}
+		for i := 1; i <= 20; i++ {
+			buff.Append(errors.Errorf("err#%d", i))
+		}
+
+		combined := buff.Flush()
+		errs := utils.UnwrapError(combined)
+		assert.Equal(t, 20, len(errs))
+		assert.Equal(t, "err#20", errs[19].Error())
+	})
+
+	t.Run("UnwrapError returns the a single element err array if passed err is not a joinedError", func(t *testing.T) {
+		t.Parallel()
+		errs := utils.UnwrapError(err1)
+		assert.Equal(t, 1, len(errs))
+		assert.Equal(t, err1.Error(), errs[0].Error())
+	})
+
+}


### PR DESCRIPTION
This util makes use of the go1.20 error changes and expose a ring buffer interface for errors. This can be useful for tracking latest K crits on a service. Next steps is including this as part of startstoponce iface

Example Usage
```
		buff := utils.ErrorBuffer{Cap: 2}
		buff.Append(err1)
		buff.Append(err2)
		combined := buff.Flush() // []error
		errs := utils.UnwrapError(combined) // if combined is a joinedErr, return combined.Unwrap() otherwise return []error{combined}
```

[Go errors @1.20](https://pkg.go.dev/errors@go1.20)