### PR TITLE
Add errbuff to all util.startstoponce services

### DIFF
--- a/core/utils/utils_test.go
+++ b/core/utils/utils_test.go
@@ -1005,7 +1005,8 @@ func TestErrorBuffer(t *testing.T) {
 
 	t.Run("ovewrite oldest error when cap exceeded", func(t *testing.T) {
 		t.Parallel()
-		buff := utils.ErrorBuffer{Cap: 2}
+		buff := utils.ErrorBuffer{}
+		buff.SetCap(2)
 		buff.Append(err1)
 		buff.Append(err2)
 		buff.Append(err3)


### PR DESCRIPTION
This PR adds errbuffer to all util.startstoponce making it available to all services to use.

```
func benchmarkErrorBuffer(cap int, b *testing.B) {
	errbuff := utils.ErrorBuffer{}
	errbuff.SetCap(cap)
	for n := 1; n <= b.N; n++ {
		errbuff.Append(errors.New(fmt.Sprintf("err#%d", n)))
	}
    _ = errbuff.Flush().Error()
}

func BenchmarkErrorBufferDefault(b *testing.B) { benchmarkErrorBuffer(utils.DefaultErrorBufferCap, b) }
func BenchmarkErrorBuffer10(b *testing.B)      { benchmarkErrorBuffer(10, b) }
func BenchmarkErrorBuffer100(b *testing.B)     { benchmarkErrorBuffer(100, b) }
func BenchmarkErrorBuffer500(b *testing.B)     { benchmarkErrorBuffer(500, b) }


~ /usr/bin/go test -benchmem -run=^ -bench ^BenchmarkErrorBuffer github.com/smartcontractkit/chainlink/core/utils                       ✔   13s  19:10:03 
cltest random seed: 1678212606777074429
goos: linux
goarch: amd64
pkg: github.com/smartcontractkit/chainlink/core/utils
cpu: REDACTED
BenchmarkErrorBufferDefault-8            1566470               742.7 ns/op           356 B/op          5 allocs/op
BenchmarkErrorBuffer10-8                 1564142               850.4 ns/op           359 B/op          5 allocs/op
BenchmarkErrorBuffer100-8                1000000              1065 ns/op             359 B/op          5 allocs/op
BenchmarkErrorBuffer500-8                1000000              1049 ns/op             366 B/op          5 allocs/op
PASS
ok      github.com/smartcontractkit/chainlink/core/utils        9.466s
~ /usr/bin/go test -benchmem -run=^ -bench ^BenchmarkErrorBuffer github.com/smartcontractkit/chainlink/core/utils                       ✔   11s  19:10:16 
cltest random seed: 1678212620876404710
goos: linux
goarch: amd64
pkg: github.com/smartcontractkit/chainlink/core/utils
cpu: REDACTED
BenchmarkErrorBufferDefault-8            1624514               736.4 ns/op           356 B/op          5 allocs/op
BenchmarkErrorBuffer10-8                 1581696               947.5 ns/op           359 B/op          5 allocs/op
BenchmarkErrorBuffer100-8                1000000              1027 ns/op             359 B/op          5 allocs/op
BenchmarkErrorBuffer500-8                1000000              1039 ns/op             366 B/op          5 allocs/op
PASS
ok      github.com/smartcontractkit/chainlink/core/utils        9.579s
```


- Next steps is to to utilize this in services for health reporting, using this as one of the signals for system health.
ErrBuff should emit errors only classified as crits
- Guidance is, any service that does expose Start()/Stop() interface should move to use startstoponce util
