### PR TITLE
Chaos and Smoke Collide in docker image tag name

### DIFF
--- a/.github/workflows/integration-chaos-tests.yml
+++ b/.github/workflows/integration-chaos-tests.yml
@@ -9,7 +9,7 @@ on:
 env:
   REF_NAME: ${{ github.head_ref || github.ref_name }}
   DEVELOP_REF: develop
-  BUILD_SHA_REF: ci.${{ github.sha }}
+  BUILD_SHA_REF: chaos.${{ github.sha }}
   CHAINLINK_ECR_BASE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink
   ENV_JOB_IMAGE_BASE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests
   TEST_SUITE: chaos


### PR DESCRIPTION
This fixes a race between chaos tests and smoke tests where they build different test images but would push the same name to ecr. This is only an issue on tag creation for releases. This fixes it so they use unique names and will no longer collide.