### PR TITLE
VRF-367 Fix use of getRoundRobinAddress in VRF listener (#8653)

### DIFF
--- a/core/services/vrf/integration_v2_test.go
+++ b/core/services/vrf/integration_v2_test.go
@@ -1989,9 +1989,11 @@ func TestMaliciousConsumer(t *testing.T) {
 	s := testspecs.GenerateVRFSpec(testspecs.VRFSpecParams{
 		JobID:                    jid.String(),
 		Name:                     "vrf-primary",
+		FromAddresses:            []string{key.Address.String()},
 		CoordinatorAddress:       uni.rootContractAddress.String(),
 		BatchCoordinatorAddress:  uni.batchCoordinatorContractAddress.String(),
 		MinIncomingConfirmations: incomingConfs,
+		GasLanePrice:             assets.GWei(1),
 		PublicKey:                vrfkey.PublicKey.String(),
 		V2:                       true,
 	}).Toml()

--- a/core/services/vrf/listener_v2_types.go
+++ b/core/services/vrf/listener_v2_types.go
@@ -101,7 +101,6 @@ func (b *batchFulfillments) addRun(result vrfPipelineResult) {
 func (lsn *listenerV2) processBatch(
 	l logger.Logger,
 	subID uint64,
-	fromAddress common.Address,
 	startBalanceNoReserveLink *big.Int,
 	maxCallbackGasLimit uint32,
 	batch *batchFulfillment,
@@ -125,9 +124,18 @@ func (lsn *listenerV2) processBatch(
 		maxCallbackGasLimit,
 		float64(lsn.job.VRFSpec.BatchFulfillmentGasMultiplier),
 	)
+
+	fromAddresses := lsn.fromAddresses()
+	fromAddress, err := lsn.gethks.GetRoundRobinAddress(lsn.chainID, fromAddresses...)
+	if err != nil {
+		l.Errorw("Couldn't get next from address", "err", err)
+		return
+	}
+
 	ll := l.With("numRequestsInBatch", len(batch.reqIDs),
 		"requestIDs", batch.reqIDs,
 		"batchSumGasLimit", batch.totalGasLimit,
+		"fromAddress", fromAddress,
 		"linkBalance", startBalanceNoReserveLink,
 		"totalGasLimitBumped", totalGasLimitBumped,
 		"gasMultiplier", lsn.job.VRFSpec.BatchFulfillmentGasMultiplier,

--- a/core/services/vrf/validate.go
+++ b/core/services/vrf/validate.go
@@ -86,6 +86,12 @@ func ValidatedVRFSpec(tomlString string) (job.Job, error) {
 		if t.Type() == pipeline.TaskTypeVRF || t.Type() == pipeline.TaskTypeVRFV2 {
 			foundVRFTask = true
 		}
+
+		if t.Type() == pipeline.TaskTypeVRFV2 {
+			if len(spec.FromAddresses) == 0 {
+				return jb, errors.Wrap(ErrKeyNotSet, "fromAddreses needs to have a non-zero length")
+			}
+		}
 	}
 	if !foundVRFTask {
 		return jb, errors.Wrapf(ErrKeyNotSet, "invalid pipeline, expected a vrf task")

--- a/core/services/vrf/validate_test.go
+++ b/core/services/vrf/validate_test.go
@@ -93,6 +93,42 @@ decode_log->vrf->encode_tx->submit_tx
 			},
 		},
 		{
+			name: "missing fromAddresses",
+			toml: `
+type            = "vrf"
+schemaVersion   = 1
+minIncomingConfirmations = 10
+publicKey = "0x79BE667EF9DCBBAC55A06295CE870B07029BFCDB2DCE28D959F2815B16F8179800"
+coordinatorAddress = "0xB3b7874F13387D44a3398D298B075B7A3505D8d4"
+requestTimeout = "168h" # 7 days
+chunkSize = 25
+backoffInitialDelay = "1m"
+backoffMaxDelay = "2h"
+observationSource = """
+decode_log   [type=ethabidecodelog
+				abi="RandomnessRequest(bytes32 keyHash,uint256 seed,bytes32 indexed jobID,address sender,uint256 fee,bytes32 requestID)"
+				data="$(jobRun.logData)"
+				topics="$(jobRun.logTopics)"]
+vrf          [type=vrfv2
+				publicKey="$(jobSpec.publicKey)"
+				requestBlockHash="$(jobRun.logBlockHash)"
+				requestBlockNumber="$(jobRun.logBlockNumber)"
+				topics="$(jobRun.logTopics)"]
+encode_tx    [type=ethabiencode
+				abi="fulfillRandomnessRequest(bytes proof)"
+				data="{\\"proof\\": $(vrf)}"]
+submit_tx  [type=ethtx to="%s"
+			data="$(encode_tx)"
+			txMeta="{\\"requestTxHash\\": $(jobRun.logTxHash),\\"requestID\\": $(decode_log.requestID),\\"jobID\\": $(jobSpec.databaseID)}"]
+decode_log->vrf->encode_tx->submit_tx
+"""
+			`,
+			assertion: func(t *testing.T, s job.Job, err error) {
+				require.Error(t, err)
+				require.True(t, errors.Is(ErrKeyNotSet, errors.Cause(err)))
+			},
+		},
+		{
 			name: "missing coordinator address",
 			toml: `
 type            = "vrf"

--- a/core/testdata/testspecs/v2_specs.go
+++ b/core/testdata/testspecs/v2_specs.go
@@ -264,6 +264,7 @@ func GenerateVRFSpec(params VRFSpecParams) VRFSpec {
 	if params.BatchCoordinatorAddress != "" {
 		batchCoordinatorAddress = params.BatchCoordinatorAddress
 	}
+
 	batchFulfillmentGasMultiplier := 1.0
 	if params.BatchFulfillmentGasMultiplier >= 1.0 {
 		batchFulfillmentGasMultiplier = params.BatchFulfillmentGasMultiplier

--- a/integration-tests/actions/vrfv2_helpers.go
+++ b/integration-tests/actions/vrfv2_helpers.go
@@ -69,7 +69,7 @@ func CreateVRFV2Jobs(
 		job, err := n.MustCreateJob(&client.VRFV2JobSpec{
 			Name:                     fmt.Sprintf("vrf-%s", jobUUID),
 			CoordinatorAddress:       coordinator.Address(),
-			FromAddress:              oracleAddr,
+			FromAddresses:            []string{oracleAddr},
 			EVMChainID:               c.GetChainID().String(),
 			MinIncomingConfirmations: minIncomingConfirmations,
 			PublicKey:                pubKeyCompressed,

--- a/integration-tests/client/chainlink_models.go
+++ b/integration-tests/client/chainlink_models.go
@@ -1024,7 +1024,7 @@ type VRFV2JobSpec struct {
 	ExternalJobID            string        `toml:"externalJobID"`
 	ObservationSource        string        `toml:"observationSource"` // List of commands for the Chainlink node
 	MinIncomingConfirmations int           `toml:"minIncomingConfirmations"`
-	FromAddress              string        `toml:"fromAddress"`
+	FromAddresses            []string      `toml:"fromAddresses"`
 	EVMChainID               string        `toml:"evmChainID"`
 	BatchFulfillmentEnabled  bool          `toml:"batchFulfillmentEnabled"`
 	BackOffInitialDelay      time.Duration `toml:"backOffInitialDelay"`
@@ -1041,7 +1041,7 @@ type                     = "vrf"
 schemaVersion            = 1
 name                     = "{{.Name}}"
 coordinatorAddress       = "{{.CoordinatorAddress}}"
-fromAddress              = "{{.FromAddress}}"
+fromAddresses            = [{{range .FromAddresses}}"{{.}}",{{end}}]
 evmChainID               = "{{.EVMChainID}}"
 minIncomingConfirmations = {{.MinIncomingConfirmations}}
 publicKey                = "{{.PublicKey}}"

--- a/integration-tests/smoke/vrfv2_test.go
+++ b/integration-tests/smoke/vrfv2_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/rs/zerolog"
 	"github.com/smartcontractkit/chainlink-testing-framework/utils"
 	"go.uber.org/zap/zapcore"
 

--- a/integration-tests/smoke/vrfv2_test.go
+++ b/integration-tests/smoke/vrfv2_test.go
@@ -8,15 +8,17 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rs/zerolog"
 	"github.com/smartcontractkit/chainlink-testing-framework/utils"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
+
 	"github.com/smartcontractkit/chainlink-env/environment"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/chainlink"
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
 	"github.com/smartcontractkit/chainlink-testing-framework/contracts/ethereum"
-	"github.com/stretchr/testify/require"
 
 	eth "github.com/smartcontractkit/chainlink-env/pkg/helm/ethereum"
 
@@ -117,7 +119,7 @@ func TestVRFv2Basic(t *testing.T) {
 		job, err = n.MustCreateJob(&client.VRFV2JobSpec{
 			Name:                     fmt.Sprintf("vrf-%s", jobUUID),
 			CoordinatorAddress:       coordinator.Address(),
-			FromAddress:              oracleAddr,
+			FromAddresses:            []string{oracleAddr},
 			EVMChainID:               fmt.Sprint(chainClient.GetNetworkConfig().ChainID),
 			MinIncomingConfirmations: minimumConfirmations,
 			PublicKey:                pubKeyCompressed,


### PR DESCRIPTION
* VRF-367 Fix use of getRoundRobinAddress in VRF listener

related PR in `develop` branch: https://github.com/smartcontractkit/chainlink/pull/8653 