### PR TITLE
Telem services have documented health checks

### DIFF
--- a/core/services/promreporter/prom_reporter.go
+++ b/core/services/promreporter/prom_reporter.go
@@ -130,7 +130,7 @@ func (pr *promReporter) Name() string {
 }
 
 func (pr *promReporter) HealthReport() map[string]error {
-	return map[string]error{pr.Name(): pr.Healthy()}
+	return map[string]error{pr.Name(): pr.StartStopOnce.Healthy()}
 }
 
 func (pr *promReporter) OnNewLongestChain(ctx context.Context, head *evmtypes.Head) {

--- a/core/services/synchronization/explorer_client.go
+++ b/core/services/synchronization/explorer_client.go
@@ -173,6 +173,7 @@ func (ec *explorerClient) Send(ctx context.Context, data []byte, messageTypes ..
 		err := fmt.Errorf("send on explorer client received unsupported message type %d", messageType)
 		ec.SvcErrBuffer.Append(err)
 		ec.lggr.Critical(err.Error())
+		return
 	}
 	select {
 	case send <- data:

--- a/core/services/synchronization/explorer_client.go
+++ b/core/services/synchronization/explorer_client.go
@@ -150,7 +150,7 @@ func (ec *explorerClient) Name() string {
 
 func (ec *explorerClient) HealthReport() map[string]error {
 	return map[string]error{
-		ec.Name(): errors.Join(ec.StartStopOnce.Healthy(), ec.SvcErrBuffer.Flush()),
+		ec.Name(): ec.SvcErrBuffer.Flush(),
 	}
 }
 

--- a/core/services/synchronization/explorer_client.go
+++ b/core/services/synchronization/explorer_client.go
@@ -150,7 +150,7 @@ func (ec *explorerClient) Name() string {
 
 func (ec *explorerClient) HealthReport() map[string]error {
 	return map[string]error{
-		ec.Name(): ec.SvcErrBuffer.Flush(),
+		ec.Name(): ec.StartStopOnce.Healthy(),
 	}
 }
 

--- a/core/services/synchronization/explorer_client_test.go
+++ b/core/services/synchronization/explorer_client_test.go
@@ -114,9 +114,8 @@ func TestWebSocketClient_Send_Unsupported(t *testing.T) {
 	explorerClient := newTestExplorerClient(t, wsserver.URL)
 	require.NoError(t, explorerClient.Start(testutils.Context(t)))
 
-	assert.PanicsWithValue(t, "send on explorer client received unsupported message type -1", func() {
-		explorerClient.Send(testutils.Context(t), []byte(`{"hello": "world"}`), -1)
-	})
+	explorerClient.Send(testutils.Context(t), []byte(`{"hello": "world"}`), -1)
+	require.Contains(t, explorerClient.HealthReport()[explorerClient.Name()].Error(), "send on explorer client received unsupported message type -1")
 	require.NoError(t, explorerClient.Close())
 }
 

--- a/core/services/synchronization/telemetry_ingress_batch_client.go
+++ b/core/services/synchronization/telemetry_ingress_batch_client.go
@@ -166,7 +166,7 @@ func (tc *telemetryIngressBatchClient) Name() string {
 }
 
 func (tc *telemetryIngressBatchClient) HealthReport() map[string]error {
-	return map[string]error{tc.Name(): errors.Join(tc.StartStopOnce.Healthy(), tc.SvcErrBuffer.Flush())}
+	return map[string]error{tc.Name(): tc.StartStopOnce.Healthy()}
 }
 
 // getCSAPrivateKey gets the client's CSA private key

--- a/core/services/synchronization/telemetry_ingress_batch_worker.go
+++ b/core/services/synchronization/telemetry_ingress_batch_worker.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/smartcontractkit/chainlink/core/logger"
+	"github.com/smartcontractkit/chainlink/core/services"
 	telemPb "github.com/smartcontractkit/chainlink/core/services/synchronization/telem"
 	"github.com/smartcontractkit/chainlink/core/utils"
 )
@@ -13,6 +14,8 @@ import (
 // telemetryIngressBatchWorker pushes telemetry in batches to the ingress server via wsrpc.
 // A worker is created per ContractID.
 type telemetryIngressBatchWorker struct {
+	services.ServiceCtx
+
 	telemMaxBatchSize uint
 	telemSendInterval time.Duration
 	telemSendTimeout  time.Duration

--- a/core/services/synchronization/telemetry_ingress_client.go
+++ b/core/services/synchronization/telemetry_ingress_client.go
@@ -114,7 +114,7 @@ func (tc *telemetryIngressClient) Name() string {
 }
 
 func (tc *telemetryIngressClient) HealthReport() map[string]error {
-	return map[string]error{tc.Name(): tc.Healthy()}
+	return map[string]error{tc.Name(): errors.Join(tc.StartStopOnce.Healthy(), tc.SvcErrBuffer.Flush())}
 }
 
 func (tc *telemetryIngressClient) connect(ctx context.Context, clientPrivKey []byte) {
@@ -127,8 +127,12 @@ func (tc *telemetryIngressClient) connect(ctx context.Context, clientPrivKey []b
 
 		conn, err := wsrpc.DialWithContext(ctx, tc.url.String(), wsrpc.WithTransportCreds(clientPrivKey, serverPubKey))
 		if err != nil {
-			tc.lggr.Errorf("Error connecting to telemetry ingress server: %v", err)
-			return
+			if ctx.Err() != nil {
+				tc.lggr.Warnw("gave up connecting to telemetry endpoint", "err", err)
+			} else {
+				tc.lggr.Criticalw("telemetry endpoint dial errored unexpectedly", "err", err)
+				tc.SvcErrBuffer.Append(err)
+			}
 		}
 		defer conn.Close()
 

--- a/core/services/synchronization/telemetry_ingress_client.go
+++ b/core/services/synchronization/telemetry_ingress_client.go
@@ -114,7 +114,7 @@ func (tc *telemetryIngressClient) Name() string {
 }
 
 func (tc *telemetryIngressClient) HealthReport() map[string]error {
-	return map[string]error{tc.Name(): errors.Join(tc.StartStopOnce.Healthy(), tc.SvcErrBuffer.Flush())}
+	return map[string]error{tc.Name(): tc.StartStopOnce.Healthy()}
 }
 
 func (tc *telemetryIngressClient) connect(ctx context.Context, clientPrivKey []byte) {

--- a/core/utils/mailbox_prom.go
+++ b/core/utils/mailbox_prom.go
@@ -51,7 +51,7 @@ func (m *MailboxMonitor) Close() error {
 }
 
 func (m *MailboxMonitor) HealthReport() map[string]error {
-	return map[string]error{m.Name(): m.Healthy()}
+	return map[string]error{m.Name(): m.StartStopOnce.Healthy()}
 }
 
 func (m *MailboxMonitor) monitorLoop(c <-chan time.Time) {

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -986,7 +986,7 @@ func (once *StartStopOnce) Ready() error {
 func (once *StartStopOnce) Healthy() error {
 	state := once.State()
 	if state == StartStopOnce_Started {
-		return nil
+		return once.SvcErrBuffer.Flush()
 	}
 	return &errNotStarted{state: state}
 }

--- a/core/utils/utils_test.go
+++ b/core/utils/utils_test.go
@@ -1037,4 +1037,12 @@ func TestErrorBuffer(t *testing.T) {
 		assert.Equal(t, err1.Error(), errs[0].Error())
 	})
 
+	t.Run("flushing an empty err buffer is a nil error", func(t *testing.T) {
+		t.Parallel()
+		buff := utils.ErrorBuffer{}
+
+		combined := buff.Flush()
+		require.Nil(t, combined)
+	})
+
 }


### PR DESCRIPTION
This PR:
- tracks crits in telem services and report them in healthReport calls
- removes an unwanted panic in explorer, replace it with crit and returns


ctx for reviewers:
- `Healthy()` impl is going away from all services and `HealthReport()` will be used instead
- The only exception is `(once *StartStopOnce) Healthy()` that's going to serve as the baseline of service health.