### PR TITLE
Fixes new job proposals not storing the name when received (#8699)

### DIFF
--- a/core/services/feeds/service.go
+++ b/core/services/feeds/service.go
@@ -1143,7 +1143,7 @@ func extractName(defn string) null.String {
 		Name null.String
 	}{}
 
-	if err := toml.Unmarshal([]byte(defn), spec); err != nil {
+	if err := toml.Unmarshal([]byte(defn), &spec); err != nil {
 		return null.StringFromPtr(nil)
 	}
 

--- a/core/services/feeds/service_test.go
+++ b/core/services/feeds/service_test.go
@@ -495,6 +495,7 @@ func Test_Service_ProposeJob(t *testing.T) {
 		}
 		jp = feeds.JobProposal{
 			FeedsManagerID: 1,
+			Name:           null.StringFrom("example flux monitor spec"),
 			RemoteUUID:     remoteUUID,
 			Status:         feeds.JobProposalStatusPending,
 		}


### PR DESCRIPTION
Job proposals were not deserializing the TOML data correctly, leading the job proposal name to be set to null. This fixes the issue by correctly using a pointer to the target struct, so that the value can be returned.