### PR TITLE
chainlink: changes error log to info log on FeedsService failure

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -511,8 +511,8 @@ func (app *ChainlinkApplication) Start(ctx context.Context) error {
 
 	if app.FeedsService != nil {
 		if err := app.FeedsService.Start(ctx); err != nil {
-			app.logger.Errorf("[Feeds Service] Failed to start %v", err)
-			app.FeedsService = &feeds.NullService{} // so we don't try to Close() later
+			app.logger.Infof("[Feeds Service] Failed to start: %v", err)
+			app.FeedsService = &feeds.NullService{} // Ensure that we have an error free Close().
 		}
 	}
 


### PR DESCRIPTION
Changes error log to info log on FeedsService start up failure. FeedsManager is enabled by default as of v1.13.0 but it is possible that a node operator has not registered a manager server. This change logs any start up errors at the info level instead of the error level.