### PR TITLE
Remove redundant logpoller test

### DIFF
--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -9,7 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/common"
@@ -29,7 +28,6 @@ import (
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/smartcontractkit/chainlink/core/chains/evm/client"
-	evmtypes "github.com/smartcontractkit/chainlink/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/core/gethwrappers/generated/log_emitter"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils/pgtest"
@@ -683,98 +681,6 @@ func TestLogPoller_LoadFilters(t *testing.T) {
 	require.True(t, ok)
 	assert.True(t, filter.contains(&filter3))
 	assert.True(t, filter3.contains(&filter))
-}
-
-func TestLogPoller_convertLogs(t *testing.T) {
-	t.Parallel()
-	ctx := testutils.Context(t)
-	th := SetupTH(t, 2, 3, 2)
-
-	addresses := []common.Address{th.EmitterAddress1, th.EmitterAddress2}
-	topics := []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}
-
-	err := th.LogPoller.RegisterFilter(Filter{"convertLogs", topics, addresses})
-	require.NoError(t, err)
-
-	blk, err := th.Client.BlockByNumber(ctx, nil)
-	require.NoError(t, err)
-	require.Equal(t, big.NewInt(1), blk.Number())
-	start := blk.Time()
-
-	// There is automatically a 10s delay between each block.  To make sure it's including the correct block timestamps,
-	// we introduce irregularities by inserting two additional block delays. We can't control the block times for
-	// blocks produced by the log emitter, but we can adjust the time on empty blocks in between.  Simulated time
-	// sequence:  [ #1 ] ..(10s + delay1).. [ #2 ] ..10s.. [ #3 (LOG1) ] ..(10s + delay2).. [ #4 ] ..10s.. [ #5 (LOG2) ]
-	const delay1 = 589
-	const delay2 = 643
-	time1 := start + 20 + delay1
-	time2 := time1 + 20 + delay2
-
-	require.NoError(t, th.Client.AdjustTime(delay1*time.Second))
-	hash := th.Client.Commit()
-
-	blk, err = th.Client.BlockByHash(ctx, hash)
-	require.NoError(t, err)
-	require.Equal(t, big.NewInt(2), blk.Number())
-	assert.Equal(t, time1-10, blk.Time())
-
-	_, err = th.Emitter1.EmitLog1(th.Owner, []*big.Int{big.NewInt(1)})
-	require.NoError(t, err)
-	hash = th.Client.Commit()
-
-	blk, err = th.Client.BlockByHash(ctx, hash)
-	require.NoError(t, err)
-	require.Equal(t, big.NewInt(3), blk.Number())
-	assert.Equal(t, time1, blk.Time())
-
-	require.NoError(t, th.Client.AdjustTime(delay2*time.Second))
-	th.Client.Commit()
-	_, err = th.Emitter2.EmitLog2(th.Owner, []*big.Int{big.NewInt(2)})
-	require.NoError(t, err)
-	hash = th.Client.Commit()
-
-	blk, err = th.Client.BlockByHash(ctx, hash)
-	require.NoError(t, err)
-	require.Equal(t, big.NewInt(5), blk.Number())
-	assert.Equal(t, time2, blk.Time())
-
-	query := ethereum.FilterQuery{
-		FromBlock: big.NewInt(2),
-		ToBlock:   big.NewInt(5),
-		Topics:    [][]common.Hash{topics},
-		Addresses: []common.Address{th.EmitterAddress1, th.EmitterAddress2}}
-
-	gethLogs, err := th.Client.FilterLogs(ctx, query)
-	require.NoError(t, err)
-	require.Len(t, gethLogs, 2)
-
-	blocks, err := th.LogPoller.blocksFromLogs(ctx, gethLogs)
-	require.NoError(t, err)
-	require.Len(t, blocks, 2)
-
-	logs := th.LogPoller.ConvertLogs(gethLogs, blocks)
-	require.Len(t, logs, 2)
-
-	val, err := logs[0].Topics.Value()
-	require.NoError(t, err)
-	s, ok := val.(string)
-	require.True(t, ok)
-	var topics0 evmtypes.HashArray
-	require.NoError(t, topics0.Scan(s))
-
-	val, err = logs[1].Topics.Value()
-	require.NoError(t, err)
-	s, ok = val.(string)
-	require.True(t, ok)
-	var topics1 evmtypes.HashArray
-	require.NoError(t, topics1.Scan(s))
-
-	assert.Equal(t, time.Unix(big.NewInt(int64(time1)).Int64(), 0).UTC(), logs[0].BlockTimestamp)
-	assert.Equal(t, addresses[0], logs[0].Address)
-	assert.Equal(t, topics[0], topics0[0])
-	assert.Equal(t, time.Unix(big.NewInt(int64(time2)).Int64(), 0).UTC(), logs[1].BlockTimestamp)
-	assert.Equal(t, addresses[1], logs[1].Address)
-	assert.Equal(t, topics[1], topics1[0])
 }
 
 type ConvertLogsTestCases struct {


### PR DESCRIPTION
This test was moved into a new location and renamed as Test_LogPoller_Blocktimestamps.  Accidentally ended up in both locations:
https://github.com/smartcontractkit/chainlink/pull/8616/commits/43cebc5defaf158f87c392e48c4f00edeb91dd4e#diff-6030192ba9bd3198048047f56f2234fc6ef75f0dfc5be29cc12ce7be1c48c480R299-R390

