### PR TITLE
Per service prom health metrics

### DIFF
--- a/core/chains/chain_set.go
+++ b/core/chains/chain_set.go
@@ -179,5 +179,11 @@ func (c *chainSet[I, C, N, S]) Name() string {
 }
 
 func (c *chainSet[I, C, N, S]) HealthReport() map[string]error {
-	return map[string]error{c.Name(): c.Healthy()}
+	report := map[string]error{c.Name(): c.StartStopOnce.Healthy()}
+	c.chainsMu.RLock()
+	defer c.chainsMu.RUnlock()
+	for _, c := range c.chains {
+		utils.MergeMaps(report, c.HealthReport())
+	}
+	return report
 }

--- a/core/chains/chain_set.go
+++ b/core/chains/chain_set.go
@@ -40,6 +40,10 @@ type ChainSet[I ID, C Config, N Node, S ChainService[C]] interface {
 	Name() string
 	HealthReport() map[string]error
 
+	// FIXME: for backward compat we will leave this until relayer libs remove Healthy refs
+	// https://smartcontract-it.atlassian.net/browse/BCF-2140
+	Healthy() error
+
 	DBChainSet[I, C]
 
 	DBNodeSet[I, N]
@@ -164,14 +168,10 @@ func (c *chainSet[I, C, N, S]) Ready() (err error) {
 	return
 }
 
-func (c *chainSet[I, C, N, S]) Healthy() (err error) {
-	err = c.StartStopOnce.Healthy()
-	c.chainsMu.RLock()
-	defer c.chainsMu.RUnlock()
-	for _, c := range c.chains {
-		err = multierr.Combine(err, c.Healthy())
-	}
-	return
+// FIXME: for backward compat we will leave this until relayer libs remove Healthy refs
+// https://smartcontract-it.atlassian.net/browse/BCF-2140
+func (c *chainSet[I, C, N, S]) Healthy() error {
+	return nil
 }
 
 func (c *chainSet[I, C, N, S]) Name() string {

--- a/core/chains/chain_set.go
+++ b/core/chains/chain_set.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
+	"golang.org/x/exp/maps"
 
 	"github.com/smartcontractkit/chainlink/core/logger"
 	"github.com/smartcontractkit/chainlink/core/services"
@@ -183,7 +184,7 @@ func (c *chainSet[I, C, N, S]) HealthReport() map[string]error {
 	c.chainsMu.RLock()
 	defer c.chainsMu.RUnlock()
 	for _, c := range c.chains {
-		utils.MergeMaps(report, c.HealthReport())
+		maps.Copy(report, c.HealthReport())
 	}
 	return report
 }

--- a/core/chains/evm/chain.go
+++ b/core/chains/evm/chain.go
@@ -257,13 +257,13 @@ func (c *chain) HealthReport() map[string]error {
 	report := map[string]error{
 		c.Name(): c.StartStopOnce.Healthy(),
 	}
-	report = utils.MergeMaps(report, c.txm.HealthReport())
-	report = utils.MergeMaps(report, c.headBroadcaster.HealthReport())
-	report = utils.MergeMaps(report, c.headTracker.HealthReport())
-	report = utils.MergeMaps(report, c.logBroadcaster.HealthReport())
+	utils.MergeMaps(report, c.txm.HealthReport())
+	utils.MergeMaps(report, c.headBroadcaster.HealthReport())
+	utils.MergeMaps(report, c.headTracker.HealthReport())
+	utils.MergeMaps(report, c.logBroadcaster.HealthReport())
 
 	if c.balanceMonitor != nil {
-		report = utils.MergeMaps(report, c.balanceMonitor.HealthReport())
+		utils.MergeMaps(report, c.balanceMonitor.HealthReport())
 	}
 
 	return report

--- a/core/chains/evm/chain.go
+++ b/core/chains/evm/chain.go
@@ -254,7 +254,19 @@ func (c *chain) Name() string {
 }
 
 func (c *chain) HealthReport() map[string]error {
-	return map[string]error{c.Name(): c.Healthy()}
+	report := map[string]error{
+		c.Name(): c.StartStopOnce.Healthy(),
+	}
+	report = utils.MergeMaps(report, c.txm.HealthReport())
+	report = utils.MergeMaps(report, c.headBroadcaster.HealthReport())
+	report = utils.MergeMaps(report, c.headTracker.HealthReport())
+	report = utils.MergeMaps(report, c.logBroadcaster.HealthReport())
+
+	if c.balanceMonitor != nil {
+		report = utils.MergeMaps(report, c.balanceMonitor.HealthReport())
+	}
+
+	return report
 }
 
 func (c *chain) ID() *big.Int                             { return c.id }

--- a/core/chains/evm/chain.go
+++ b/core/chains/evm/chain.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
+	"golang.org/x/exp/maps"
 
 	evmclient "github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	evmconfig "github.com/smartcontractkit/chainlink/core/chains/evm/config"
@@ -243,13 +244,13 @@ func (c *chain) HealthReport() map[string]error {
 	report := map[string]error{
 		c.Name(): c.StartStopOnce.Healthy(),
 	}
-	utils.MergeMaps(report, c.txm.HealthReport())
-	utils.MergeMaps(report, c.headBroadcaster.HealthReport())
-	utils.MergeMaps(report, c.headTracker.HealthReport())
-	utils.MergeMaps(report, c.logBroadcaster.HealthReport())
+	maps.Copy(report, c.txm.HealthReport())
+	maps.Copy(report, c.headBroadcaster.HealthReport())
+	maps.Copy(report, c.headTracker.HealthReport())
+	maps.Copy(report, c.logBroadcaster.HealthReport())
 
 	if c.balanceMonitor != nil {
-		utils.MergeMaps(report, c.balanceMonitor.HealthReport())
+		maps.Copy(report, c.balanceMonitor.HealthReport())
 	}
 
 	return report

--- a/core/chains/evm/chain.go
+++ b/core/chains/evm/chain.go
@@ -235,20 +235,6 @@ func (c *chain) Ready() (merr error) {
 	return
 }
 
-func (c *chain) Healthy() (merr error) {
-	merr = multierr.Combine(
-		c.StartStopOnce.Healthy(),
-		c.txm.Healthy(),
-		c.headBroadcaster.Healthy(),
-		c.headTracker.Healthy(),
-		c.logBroadcaster.Healthy(),
-	)
-	if c.balanceMonitor != nil {
-		merr = multierr.Combine(merr, c.balanceMonitor.Healthy())
-	}
-	return
-}
-
 func (c *chain) Name() string {
 	return c.logger.Name()
 }

--- a/core/chains/evm/chain.go
+++ b/core/chains/evm/chain.go
@@ -77,7 +77,7 @@ func newTOMLChain(ctx context.Context, chain *v2.EVMConfig, opts ChainSetOpts) (
 
 func newChain(ctx context.Context, cfg evmconfig.ChainScopedConfig, nodes []*v2.Node, opts ChainSetOpts) (*chain, error) {
 	chainID := cfg.ChainID()
-	l := opts.Logger.With("evmChainID", chainID.String())
+	l := opts.Logger.Named(chainID.String()).With("evmChainID", chainID.String())
 	var client evmclient.Client
 	if !cfg.EVMRPCEnabled() {
 		client = evmclient.NewNullClient(chainID, l)

--- a/core/chains/evm/chain_set.go
+++ b/core/chains/evm/chain_set.go
@@ -106,7 +106,7 @@ func (cll *chainSet) Name() string {
 func (cll *chainSet) HealthReport() map[string]error {
 	report := map[string]error{}
 	for _, c := range cll.Chains() {
-		report = utils.MergeMaps(report, c.HealthReport())
+		utils.MergeMaps(report, c.HealthReport())
 	}
 	return report
 }

--- a/core/chains/evm/chain_set.go
+++ b/core/chains/evm/chain_set.go
@@ -92,12 +92,6 @@ func (cll *chainSet) Close() (err error) {
 	}
 	return
 }
-func (cll *chainSet) Healthy() (err error) {
-	for _, c := range cll.Chains() {
-		err = multierr.Combine(err, c.Healthy())
-	}
-	return
-}
 
 func (cll *chainSet) Name() string {
 	return cll.logger.Name()

--- a/core/chains/evm/chain_set.go
+++ b/core/chains/evm/chain_set.go
@@ -104,7 +104,11 @@ func (cll *chainSet) Name() string {
 }
 
 func (cll *chainSet) HealthReport() map[string]error {
-	return map[string]error{cll.Name(): cll.Healthy()}
+	report := map[string]error{}
+	for _, c := range cll.Chains() {
+		report = utils.MergeMaps(report, c.HealthReport())
+	}
+	return report
 }
 
 func (cll *chainSet) Ready() (err error) {

--- a/core/chains/evm/chain_set.go
+++ b/core/chains/evm/chain_set.go
@@ -9,6 +9,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/sqlx"
 	"go.uber.org/multierr"
+	"golang.org/x/exp/maps"
 
 	"github.com/smartcontractkit/chainlink/core/chains"
 	"github.com/smartcontractkit/chainlink/core/chains/evm/client"
@@ -100,7 +101,7 @@ func (cll *chainSet) Name() string {
 func (cll *chainSet) HealthReport() map[string]error {
 	report := map[string]error{}
 	for _, c := range cll.Chains() {
-		utils.MergeMaps(report, c.HealthReport())
+		maps.Copy(report, c.HealthReport())
 	}
 	return report
 }

--- a/core/chains/evm/gas/block_history_estimator.go
+++ b/core/chains/evm/gas/block_history_estimator.go
@@ -73,7 +73,6 @@ var (
 
 const BumpingHaltedLabel = "Tx gas bumping halted since price exceeds current block prices by significant margin; tx will continue to be rebroadcasted but your node, RPC, or the chain might be experiencing connectivity issues; please investigate and fix ASAP"
 
-
 var _ EvmEstimator = &BlockHistoryEstimator{}
 
 //go:generate mockery --quiet --name Config --output ./mocks/ --case=underscore
@@ -222,7 +221,7 @@ func (b *BlockHistoryEstimator) Name() string {
 	return b.logger.Name()
 }
 func (b *BlockHistoryEstimator) HealthReport() map[string]error {
-	return map[string]error{b.Name(): b.Healthy()}
+	return map[string]error{b.Name(): b.StartStopOnce.Healthy()}
 }
 
 func (b *BlockHistoryEstimator) GetLegacyGas(_ context.Context, _ []byte, gasLimit uint32, maxGasPriceWei *assets.Wei, _ ...txmgrtypes.Opt) (gasPrice *assets.Wei, chainSpecificGasLimit uint32, err error) {
@@ -269,6 +268,7 @@ func (b *BlockHistoryEstimator) BumpLegacyGas(_ context.Context, originalGasPric
 		if err = b.checkConnectivity(attempts); err != nil {
 			if errors.Is(err, ErrConnectivity) {
 				b.logger.Criticalw(BumpingHaltedLabel, "err", err)
+				b.SvcErrBuffer.Append(err)
 				promBlockHistoryEstimatorConnectivityFailureCount.WithLabelValues(b.chainID.String(), "legacy").Inc()
 			}
 			return nil, 0, err
@@ -443,6 +443,7 @@ func (b *BlockHistoryEstimator) BumpDynamicFee(_ context.Context, originalFee Dy
 		if err = b.checkConnectivity(attempts); err != nil {
 			if errors.Is(err, ErrConnectivity) {
 				b.logger.Criticalw(BumpingHaltedLabel, "err", err)
+				b.SvcErrBuffer.Append(err)
 				promBlockHistoryEstimatorConnectivityFailureCount.WithLabelValues(b.chainID.String(), "eip1559").Inc()
 			}
 			return bumped, 0, err

--- a/core/chains/evm/headtracker/head_broadcaster.go
+++ b/core/chains/evm/headtracker/head_broadcaster.go
@@ -75,7 +75,7 @@ func (hb *headBroadcaster) Name() string {
 	return hb.logger.Name()
 }
 func (hb *headBroadcaster) HealthReport() map[string]error {
-	return map[string]error{hb.Name(): hb.Healthy()}
+	return map[string]error{hb.Name(): hb.StartStopOnce.Healthy()}
 }
 
 func (hb *headBroadcaster) BroadcastNewLongestChain(head *evmtypes.Head) {

--- a/core/chains/evm/headtracker/head_listener.go
+++ b/core/chains/evm/headtracker/head_listener.go
@@ -49,6 +49,10 @@ func NewHeadListener(lggr logger.Logger, ethClient evmclient.Client, config Conf
 	}
 }
 
+func (hl *headListener) Name() string {
+	return hl.logger.Name()
+}
+
 func (hl *headListener) ListenForNewHeads(handleNewHead httypes.NewHeadHandler, done func()) {
 	defer done()
 	defer hl.unsubscribe()
@@ -78,6 +82,17 @@ func (hl *headListener) ReceivingHeads() bool {
 
 func (hl *headListener) Connected() bool {
 	return hl.connected.Load()
+}
+
+func (hl *headListener) HealthReport() map[string]error {
+	var err error
+	if !hl.ReceivingHeads() {
+		err = errors.New("Listener is not receiving heads")
+	}
+	if !hl.Connected() {
+		err = errors.New("Listener is not connected")
+	}
+	return map[string]error{hl.Name(): err}
 }
 
 func (hl *headListener) receiveHeaders(ctx context.Context, handleNewHead httypes.NewHeadHandler) error {

--- a/core/chains/evm/headtracker/head_tracker.go
+++ b/core/chains/evm/headtracker/head_tracker.go
@@ -151,7 +151,7 @@ func (ht *headTracker) Name() string {
 }
 
 func (ht *headTracker) HealthReport() map[string]error {
-	return map[string]error{ht.Name(): ht.Healthy()}
+	return map[string]error{ht.Name(): ht.StartStopOnce.Healthy()}
 }
 
 func (ht *headTracker) Backfill(ctx context.Context, headWithChain *evmtypes.Head, depth uint) (err error) {
@@ -220,6 +220,7 @@ func (ht *headTracker) handleNewHead(ctx context.Context, head *evmtypes.Head) e
 		if head.Number < prevHead.Number-int64(ht.config.EvmFinalityDepth()) {
 			promOldHead.WithLabelValues(ht.chainID.String()).Inc()
 			ht.log.Criticalf("Got very old block with number %d (highest seen was %d). This is a problem and either means a very deep re-org occurred, one of the RPC nodes has gotten far out of sync, or the chain went backwards in block numbers. This node may not function correctly without manual intervention.", head.Number, prevHead.Number)
+			ht.SvcErrBuffer.Append(errors.New("got very old block"))
 		}
 	}
 	return nil

--- a/core/chains/evm/headtracker/head_tracker.go
+++ b/core/chains/evm/headtracker/head_tracker.go
@@ -136,22 +136,16 @@ func (ht *headTracker) Close() error {
 	})
 }
 
-func (ht *headTracker) Healthy() error {
-	if !ht.headListener.ReceivingHeads() {
-		return errors.New("Listener is not receiving heads")
-	}
-	if !ht.headListener.Connected() {
-		return errors.New("Listener is not connected")
-	}
-	return nil
-}
-
 func (ht *headTracker) Name() string {
 	return ht.log.Name()
 }
 
 func (ht *headTracker) HealthReport() map[string]error {
-	return map[string]error{ht.Name(): ht.StartStopOnce.Healthy()}
+	report := map[string]error{
+		ht.Name(): ht.StartStopOnce.Healthy(),
+	}
+	utils.MergeMaps(report, ht.headListener.HealthReport())
+	return report
 }
 
 func (ht *headTracker) Backfill(ctx context.Context, headWithChain *evmtypes.Head, depth uint) (err error) {
@@ -358,7 +352,6 @@ type nullTracker struct{}
 func (*nullTracker) Start(context.Context) error    { return nil }
 func (*nullTracker) Close() error                   { return nil }
 func (*nullTracker) Ready() error                   { return nil }
-func (*nullTracker) Healthy() error                 { return nil }
 func (*nullTracker) HealthReport() map[string]error { return map[string]error{} }
 func (*nullTracker) Name() string                   { return "" }
 func (*nullTracker) SetLogLevel(zapcore.Level)      {}

--- a/core/chains/evm/headtracker/head_tracker.go
+++ b/core/chains/evm/headtracker/head_tracker.go
@@ -11,6 +11,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/zap/zapcore"
+	"golang.org/x/exp/maps"
 
 	evmclient "github.com/smartcontractkit/chainlink/core/chains/evm/client"
 	httypes "github.com/smartcontractkit/chainlink/core/chains/evm/headtracker/types"
@@ -144,7 +145,7 @@ func (ht *headTracker) HealthReport() map[string]error {
 	report := map[string]error{
 		ht.Name(): ht.StartStopOnce.Healthy(),
 	}
-	utils.MergeMaps(report, ht.headListener.HealthReport())
+	maps.Copy(report, ht.headListener.HealthReport())
 	return report
 }
 

--- a/core/chains/evm/headtracker/mocks/head_broadcaster.go
+++ b/core/chains/evm/headtracker/mocks/head_broadcaster.go
@@ -51,20 +51,6 @@ func (_m *HeadBroadcaster) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *HeadBroadcaster) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Name provides a mock function with given fields:
 func (_m *HeadBroadcaster) Name() string {
 	ret := _m.Called()

--- a/core/chains/evm/headtracker/mocks/head_tracker.go
+++ b/core/chains/evm/headtracker/mocks/head_tracker.go
@@ -59,20 +59,6 @@ func (_m *HeadTracker) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *HeadTracker) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // LatestChain provides a mock function with given fields:
 func (_m *HeadTracker) LatestChain() *types.Head {
 	ret := _m.Called()

--- a/core/chains/evm/headtracker/types/types.go
+++ b/core/chains/evm/headtracker/types/types.go
@@ -70,4 +70,6 @@ type HeadListener interface {
 	ReceivingHeads() bool
 	// Connected returns true if the listener is connected (thread safe)
 	Connected() bool
+	// HealthReport returns report of errors within HeadListener
+	HealthReport() map[string]error
 }

--- a/core/chains/evm/log/broadcaster.go
+++ b/core/chains/evm/log/broadcaster.go
@@ -220,7 +220,7 @@ func (b *broadcaster) Name() string {
 }
 
 func (b *broadcaster) HealthReport() map[string]error {
-	return map[string]error{b.Name(): b.Healthy()}
+	return map[string]error{b.Name(): b.StartStopOnce.Healthy()}
 }
 
 func (b *broadcaster) awaitInitialSubscribers() {
@@ -789,7 +789,7 @@ func (n *NullBroadcaster) AwaitDependents() <-chan struct{} {
 // DependentReady does noop for NullBroadcaster.
 func (n *NullBroadcaster) DependentReady() {}
 
-func (n *NullBroadcaster) Name() string { return "" }
+func (n *NullBroadcaster) Name() string { return "NullBroadcaster" }
 
 // Start does noop for NullBroadcaster.
 func (n *NullBroadcaster) Start(context.Context) error                       { return nil }

--- a/core/chains/evm/log/broadcaster.go
+++ b/core/chains/evm/log/broadcaster.go
@@ -794,7 +794,6 @@ func (n *NullBroadcaster) Name() string { return "NullBroadcaster" }
 // Start does noop for NullBroadcaster.
 func (n *NullBroadcaster) Start(context.Context) error                       { return nil }
 func (n *NullBroadcaster) Close() error                                      { return nil }
-func (n *NullBroadcaster) Healthy() error                                    { return nil }
 func (n *NullBroadcaster) Ready() error                                      { return nil }
 func (n *NullBroadcaster) HealthReport() map[string]error                    { return nil }
 func (n *NullBroadcaster) OnNewLongestChain(context.Context, *evmtypes.Head) {}

--- a/core/chains/evm/log/mocks/broadcaster.go
+++ b/core/chains/evm/log/mocks/broadcaster.go
@@ -74,20 +74,6 @@ func (_m *Broadcaster) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *Broadcaster) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // IsConnected provides a mock function with given fields:
 func (_m *Broadcaster) IsConnected() bool {
 	ret := _m.Called()

--- a/core/chains/evm/logpoller/disabled.go
+++ b/core/chains/evm/logpoller/disabled.go
@@ -24,8 +24,6 @@ func (disabled) Close() error { return ErrDisabled }
 
 func (disabled) Ready() error { return ErrDisabled }
 
-func (disabled) Healthy() error { return ErrDisabled }
-
 func (disabled) HealthReport() map[string]error {
 	return map[string]error{"disabledLogPoller": ErrDisabled}
 }

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -349,7 +349,7 @@ func (lp *logPoller) Name() string {
 }
 
 func (lp *logPoller) HealthReport() map[string]error {
-	return map[string]error{lp.Name(): lp.Healthy()}
+	return map[string]error{lp.Name(): lp.StartStopOnce.Healthy()}
 }
 
 func (lp *logPoller) getReplayFromBlock(ctx context.Context, requested int64) (int64, error) {
@@ -832,7 +832,9 @@ func (lp *logPoller) findBlockAfterLCA(ctx context.Context, current *evmtypes.He
 		}
 	}
 	lp.lggr.Criticalw("Reorg greater than finality depth detected", "max reorg depth", lp.finalityDepth-1)
-	return nil, errors.New("Reorg greater than finality depth")
+	rerr := errors.New("Reorg greater than finality depth")
+	lp.SvcErrBuffer.Append(rerr)
+	return nil, rerr
 }
 
 // pruneOldBlocks removes blocks that are > lp.ancientBlockDepth behind the head.

--- a/core/chains/evm/logpoller/mocks/log_poller.go
+++ b/core/chains/evm/logpoller/mocks/log_poller.go
@@ -82,20 +82,6 @@ func (_m *LogPoller) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *LogPoller) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // IndexedLogs provides a mock function with given fields: eventSig, address, topicIndex, topicValues, confs, qopts
 func (_m *LogPoller) IndexedLogs(eventSig common.Hash, address common.Address, topicIndex int, topicValues []common.Hash, confs int, qopts ...pg.QOpt) ([]logpoller.Log, error) {
 	_va := make([]interface{}, len(qopts))

--- a/core/chains/evm/mocks/balance_monitor.go
+++ b/core/chains/evm/mocks/balance_monitor.go
@@ -64,20 +64,6 @@ func (_m *BalanceMonitor) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *BalanceMonitor) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Name provides a mock function with given fields:
 func (_m *BalanceMonitor) Name() string {
 	ret := _m.Called()

--- a/core/chains/evm/mocks/chain.go
+++ b/core/chains/evm/mocks/chain.go
@@ -140,20 +140,6 @@ func (_m *Chain) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *Chain) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // ID provides a mock function with given fields:
 func (_m *Chain) ID() *big.Int {
 	ret := _m.Called()

--- a/core/chains/evm/mocks/chain_set.go
+++ b/core/chains/evm/mocks/chain_set.go
@@ -226,20 +226,6 @@ func (_m *ChainSet) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *ChainSet) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Index provides a mock function with given fields: offset, limit
 func (_m *ChainSet) Index(offset int, limit int) ([]chains.DBChain[utils.Big, *types.ChainCfg], int, error) {
 	ret := _m.Called(offset, limit)

--- a/core/chains/evm/monitor/balance.go
+++ b/core/chains/evm/monitor/balance.go
@@ -84,10 +84,6 @@ func (bm *balanceMonitor) Ready() error {
 	return nil
 }
 
-func (bm *balanceMonitor) Healthy() error {
-	return nil
-}
-
 func (bm *balanceMonitor) Name() string {
 	return bm.logger.Name()
 }
@@ -223,7 +219,6 @@ func (*NullBalanceMonitor) GetEthBalance(gethCommon.Address) *assets.Eth {
 func (*NullBalanceMonitor) Start(context.Context) error                                { return nil }
 func (*NullBalanceMonitor) Close() error                                               { return nil }
 func (*NullBalanceMonitor) Ready() error                                               { return nil }
-func (*NullBalanceMonitor) Healthy() error                                             { return nil }
 func (*NullBalanceMonitor) OnNewLongestChain(ctx context.Context, head *evmtypes.Head) {}
 
 func ApproximateFloat64(e *assets.Eth) (float64, error) {

--- a/core/chains/evm/monitor/balance.go
+++ b/core/chains/evm/monitor/balance.go
@@ -93,7 +93,7 @@ func (bm *balanceMonitor) Name() string {
 }
 
 func (bm *balanceMonitor) HealthReport() map[string]error {
-	return map[string]error{bm.Name(): bm.Healthy()}
+	return map[string]error{bm.Name(): bm.StartStopOnce.Healthy()}
 }
 
 // OnNewLongestChain checks the balance for each key

--- a/core/chains/evm/txmgr/eth_broadcaster.go
+++ b/core/chains/evm/txmgr/eth_broadcaster.go
@@ -182,6 +182,14 @@ func (eb *EthBroadcaster) Close() error {
 	})
 }
 
+func (eb *EthBroadcaster) Name() string {
+	return eb.logger.Name()
+}
+
+func (eb *EthBroadcaster) HealthReport() map[string]error {
+	return map[string]error{eb.Name(): eb.StartStopOnce.Healthy()}
+}
+
 // Trigger forces the monitor for a particular address to recheck for new eth_txes
 // Logs error and does nothing if address was not registered on startup
 func (eb *EthBroadcaster) Trigger(addr gethCommon.Address) {

--- a/core/chains/evm/txmgr/eth_broadcaster.go
+++ b/core/chains/evm/txmgr/eth_broadcaster.go
@@ -319,6 +319,7 @@ func (eb *EthBroadcaster) SyncNonce(ctx context.Context, k ethkey.State) {
 				if err := syncer.Sync(ctx, k); err != nil {
 					if attempt > 5 {
 						eb.logger.Criticalw("Failed to sync with on-chain nonce", "address", k.Address, "attempt", attempt, "err", err)
+						eb.SvcErrBuffer.Append(err)
 					} else {
 						eb.logger.Warnw("Failed to sync with on-chain nonce", "address", k.Address, "attempt", attempt, "err", err)
 					}
@@ -476,6 +477,7 @@ func (eb *EthBroadcaster) handleInProgressEthTx(ctx context.Context, etx EthTx, 
 
 	if sendError.Fatal() {
 		lgr.Criticalw("Fatal error sending transaction", "err", sendError, "etx", etx)
+		eb.SvcErrBuffer.Append(sendError)
 		etx.Error = null.StringFrom(sendError.Error())
 		// Attempt is thrown away in this case; we don't need it since it never got accepted by a node
 		return eb.saveFatallyErroredTransaction(lgr, &etx), true
@@ -562,6 +564,7 @@ func (eb *EthBroadcaster) handleInProgressEthTx(ctx context.Context, etx EthTx, 
 			"ACTION REQUIRED: Chainlink wallet with address 0x%x is OUT OF FUNDS",
 			attempt.Hash, attempt.TxType, sendError.Error(), etx.FromAddress,
 		), "err", sendError)
+		eb.SvcErrBuffer.Append(sendError)
 		// NOTE: This bails out of the entire cycle and essentially "blocks" on
 		// any transaction that gets insufficient_eth. This is OK if a
 		// transaction with a large VALUE blocks because this always comes last
@@ -610,6 +613,7 @@ func (eb *EthBroadcaster) handleInProgressEthTx(ctx context.Context, etx EthTx, 
 			"err", sendError,
 			"id", "RPCTxFeeCapExceeded",
 		)
+		eb.SvcErrBuffer.Append(sendError)
 		// Note that we may have broadcast to multiple nodes and had it
 		// accepted by one of them! It is not guaranteed that all nodes share
 		// the same tx fee cap. That is why we must treat this as an unknown
@@ -620,6 +624,7 @@ func (eb *EthBroadcaster) handleInProgressEthTx(ctx context.Context, etx EthTx, 
 		// forever until the issue is resolved.
 	} else {
 		lgr.Criticalw("Unknown error occurred while handling eth_tx queue in ProcessUnstartedEthTxs. This chain/RPC client may not be supported. Urgent resolution required, Chainlink is currently operating in a degraded state and may miss transactions", "err", sendError, "etx", etx, "attempt", attempt)
+		eb.SvcErrBuffer.Append(sendError)
 	}
 
 	nextNonce, err := eb.ethClient.PendingNonceAt(ctx, etx.FromAddress)

--- a/core/chains/evm/txmgr/mocks/tx_manager.go
+++ b/core/chains/evm/txmgr/mocks/tx_manager.go
@@ -132,20 +132,6 @@ func (_m *TxManager) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *TxManager) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Name provides a mock function with given fields:
 func (_m *TxManager) Name() string {
 	ret := _m.Called()

--- a/core/chains/evm/txmgr/txmgr.go
+++ b/core/chains/evm/txmgr/txmgr.go
@@ -665,7 +665,6 @@ func (n *NullTxManager) Reset(f func(), addr common.Address, abandon bool) error
 func (n *NullTxManager) SendEther(chainID *big.Int, from, to common.Address, value assets.Eth, gasLimit uint32) (etx EthTx, err error) {
 	return etx, errors.New(n.ErrMsg)
 }
-func (n *NullTxManager) Healthy() error                 { return nil }
 func (n *NullTxManager) Ready() error                   { return nil }
 func (n *NullTxManager) Name() string                   { return "NullTxManager" }
 func (n *NullTxManager) HealthReport() map[string]error { return map[string]error{} }

--- a/core/chains/evm/txmgr/txmgr.go
+++ b/core/chains/evm/txmgr/txmgr.go
@@ -284,6 +284,8 @@ func (b *Txm) Name() string {
 }
 
 func (b *Txm) HealthReport() map[string]error {
+	report := map[string]error{b.Name(): b.StartStopOnce.Healthy()}
+	utils.MergeMaps(report, b.eb)
 	return map[string]error{b.Name(): b.StartStopOnce.Healthy()}
 }
 

--- a/core/chains/evm/txmgr/txmgr.go
+++ b/core/chains/evm/txmgr/txmgr.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pkg/errors"
 	uuid "github.com/satori/go.uuid"
 	"github.com/smartcontractkit/sqlx"
+	"golang.org/x/exp/maps"
 
 	txmgrtypes "github.com/smartcontractkit/chainlink/common/txmgr/types"
 	"github.com/smartcontractkit/chainlink/core/assets"
@@ -291,12 +292,12 @@ func (b *Txm) HealthReport() map[string]error {
 
 	// only query if txm started properly
 	b.IfStarted(func() {
-		utils.MergeMaps(report, b.ethBroadcaster.HealthReport())
-		utils.MergeMaps(report, b.ethConfirmer.HealthReport())
+		maps.Copy(report, b.ethBroadcaster.HealthReport())
+		maps.Copy(report, b.ethConfirmer.HealthReport())
 	})
 
 	if b.config.EvmUseForwarders() {
-		utils.MergeMaps(report, b.fwdMgr.HealthReport())
+		maps.Copy(report, b.fwdMgr.HealthReport())
 	}
 	return report
 }

--- a/core/chains/solana/chain.go
+++ b/core/chains/solana/chain.go
@@ -12,6 +12,7 @@ import (
 	"github.com/gagliardetto/solana-go/rpc"
 	"github.com/pkg/errors"
 	"go.uber.org/multierr"
+	"golang.org/x/exp/maps"
 
 	"github.com/smartcontractkit/chainlink-solana/pkg/solana"
 	solanaclient "github.com/smartcontractkit/chainlink-solana/pkg/solana/client"
@@ -318,6 +319,6 @@ func (c *chain) Ready() error {
 
 func (c *chain) HealthReport() map[string]error {
 	report := map[string]error{c.Name(): c.StartStopOnce.Healthy()}
-	utils.MergeMaps(report, c.txm.HealthReport())
+	maps.Copy(report, c.txm.HealthReport())
 	return report
 }

--- a/core/chains/solana/chain.go
+++ b/core/chains/solana/chain.go
@@ -316,13 +316,8 @@ func (c *chain) Ready() error {
 	)
 }
 
-func (c *chain) Healthy() error {
-	return multierr.Combine(
-		c.StartStopOnce.Healthy(),
-		c.txm.Healthy(),
-	)
-}
-
 func (c *chain) HealthReport() map[string]error {
-	return map[string]error{c.Name(): c.Healthy()}
+	report := map[string]error{c.Name(): c.StartStopOnce.Healthy()}
+	utils.MergeMaps(report, c.txm.HealthReport())
+	return report
 }

--- a/core/chains/starknet/chain.go
+++ b/core/chains/starknet/chain.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
+	"golang.org/x/exp/maps"
 
 	starkChain "github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/chain"
 	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/config"
@@ -131,6 +132,6 @@ func (c *chain) Ready() error {
 
 func (c *chain) HealthReport() map[string]error {
 	report := map[string]error{c.Name(): c.StartStopOnce.Healthy()}
-	utils.MergeMaps(report, c.txm.HealthReport())
+	maps.Copy(report, c.txm.HealthReport())
 	return report
 }

--- a/core/chains/starknet/chain.go
+++ b/core/chains/starknet/chain.go
@@ -129,10 +129,8 @@ func (c *chain) Ready() error {
 	return c.StartStopOnce.Ready()
 }
 
-func (c *chain) Healthy() error {
-	return c.StartStopOnce.Healthy()
-}
-
 func (c *chain) HealthReport() map[string]error {
-	return map[string]error{c.Name(): c.Healthy()}
+	report := map[string]error{c.Name(): c.StartStopOnce.Healthy()}
+	utils.MergeMaps(report, c.txm.HealthReport())
+	return report
 }

--- a/core/logger/audit/audit_logger.go
+++ b/core/logger/audit/audit_logger.go
@@ -295,9 +295,7 @@ func (l *AuditLoggerService) HealthReport() map[string]error {
 	var err error
 	if !l.enabled {
 		err = errors.New("the audit logger is not enabled")
-	}
-
-	if len(l.loggingChannel) == bufferCapacity {
+	} else if len(l.loggingChannel) == bufferCapacity {
 		err = errors.New("buffer is full")
 	}
 	return map[string]error{l.Name(): err}

--- a/core/logger/audit/audit_logger.go
+++ b/core/logger/audit/audit_logger.go
@@ -287,24 +287,20 @@ func (l *AuditLoggerService) Close() error {
 	return nil
 }
 
-func (l *AuditLoggerService) Healthy() error {
-	if !l.enabled {
-		return errors.New("the audit logger is not enabled")
-	}
-
-	if len(l.loggingChannel) == bufferCapacity {
-		return errors.New("buffer is full")
-	}
-
-	return nil
-}
-
 func (l *AuditLoggerService) Name() string {
 	return l.logger.Name()
 }
 
 func (l *AuditLoggerService) HealthReport() map[string]error {
-	return map[string]error{l.logger.Name(): l.Healthy()}
+	var err error
+	if !l.enabled {
+		err = errors.New("the audit logger is not enabled")
+	}
+
+	if len(l.loggingChannel) == bufferCapacity {
+		err = errors.New("buffer is full")
+	}
+	return map[string]error{l.Name(): err}
 }
 
 func (l *AuditLoggerService) Ready() error {

--- a/core/logger/audit/audit_logger_test.go
+++ b/core/logger/audit/audit_logger_test.go
@@ -98,7 +98,7 @@ func TestCheckLoginAuditLog(t *testing.T) {
 	auditLoggerTestConfig := Config{}
 
 	// Create new AuditLoggerService
-	auditLogger, err := audit.NewAuditLogger(logger, &auditLoggerTestConfig)
+	auditLogger, err := audit.NewAuditLogger(logger.Named("AuditLogger"), &auditLoggerTestConfig)
 	assert.NoError(t, err)
 
 	// Cast to concrete type so we can swap out the internals

--- a/core/logger/test_logger.go
+++ b/core/logger/test_logger.go
@@ -42,5 +42,5 @@ func testLogger(tb testing.TB, core zapcore.Core) SugaredLogger {
 		level:         a,
 		SugaredLogger: zaptest.NewLogger(tb, opts...).Sugar(),
 	}
-	return Sugared(l.Named("TestLogger"))
+	return Sugared(l)
 }

--- a/core/logger/test_logger.go
+++ b/core/logger/test_logger.go
@@ -42,5 +42,5 @@ func testLogger(tb testing.TB, core zapcore.Core) SugaredLogger {
 		level:         a,
 		SugaredLogger: zaptest.NewLogger(tb, opts...).Sugar(),
 	}
-	return Sugared(l)
+	return Sugared(l.Named("TestLogger"))
 }

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -484,7 +484,16 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 
 	for _, service := range app.srvcs {
 		checkable := service.(services.Checkable)
-		if err := app.HealthChecker.Register(reflect.TypeOf(service).String(), checkable); err != nil {
+		if err := app.HealthChecker.Register(service.Name(), checkable); err != nil {
+			return nil, err
+		}
+	}
+
+	// FIX ME: we should add chains exactly once, while also adding relayers and their services separately
+	// atm relayers are only added when OCR2 is enabled.
+	for _, service := range app.Chains.services() {
+		checkable := service.(services.Checkable)
+		if err := app.HealthChecker.Register(service.Name(), checkable); err != nil {
 			return nil, err
 		}
 	}

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -489,12 +489,14 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 		}
 	}
 
-	// FIX ME: we should add chains exactly once, while also adding relayers and their services separately
-	// atm relayers are only added when OCR2 is enabled.
-	for _, service := range app.Chains.services() {
-		checkable := service.(services.Checkable)
-		if err := app.HealthChecker.Register(service.Name(), checkable); err != nil {
-			return nil, err
+	// To avoid subscribing chain services twice, we only subscribe them if OCR2 is not enabled.
+	// If it's enabled, they are going to be registered with relayers by default.
+	if !cfg.FeatureOffchainReporting2() {
+		for _, service := range app.Chains.services() {
+			checkable := service.(services.Checkable)
+			if err := app.HealthChecker.Register(service.Name(), checkable); err != nil {
+				return nil, err
+			}
 		}
 	}
 

--- a/core/services/checkable.go
+++ b/core/services/checkable.go
@@ -7,8 +7,6 @@ package services
 type Checkable interface {
 	// Ready should return nil if ready, or an error message otherwise.
 	Ready() error
-	// Healthy should return nil if healthy, or an error message otherwise.
-	Healthy() error
 	// HealthReport returns a full health report of the callee including it's dependencies.
 	// key is the dep name, value is nil if healthy, or error message otherwise.
 	HealthReport() map[string]error

--- a/core/services/health.go
+++ b/core/services/health.go
@@ -35,17 +35,13 @@ type (
 		srvMutex   sync.RWMutex
 		services   map[string]Checkable
 		stateMutex sync.RWMutex
-		state      map[string]State
+		healthy    map[string]error
+		ready      map[string]error
 
 		chStop chan struct{}
 		chDone chan struct{}
 
 		utils.StartStopOnce
-	}
-
-	State struct {
-		ready   error
-		healthy error
 	}
 
 	Status string
@@ -86,7 +82,8 @@ var (
 func NewChecker() Checker {
 	c := &checker{
 		services: make(map[string]Checkable, 10),
-		state:    make(map[string]State, 10),
+		healthy:  make(map[string]error, 10),
+		ready:    make(map[string]error, 10),
 		chStop:   make(chan struct{}),
 		chDone:   make(chan struct{}),
 	}
@@ -132,7 +129,8 @@ func (c *checker) run() {
 }
 
 func (c *checker) update() {
-	state := make(map[string]State, len(c.services))
+	healthy := make(map[string]error)
+	ready := make(map[string]error)
 
 	c.srvMutex.RLock()
 	// copy services into a new map to avoid lock contention while doing checks
@@ -144,22 +142,27 @@ func (c *checker) update() {
 
 	// now, do all the checks
 	for name, s := range services {
-		ready := s.Ready()
-		healthy := s.Healthy()
+		ready[name] = s.Ready()
+		hr := s.HealthReport()
+		for n, err := range hr {
+			healthy[n] = err
+		}
 
-		state[name] = State{ready, healthy}
 	}
 
 	// we use a separate lock to avoid holding the lock over state while talking
 	// to services
 	c.stateMutex.Lock()
 	defer c.stateMutex.Unlock()
+	for name, r := range ready {
+		c.ready[name] = r
+	}
 
-	for name, state := range state {
-		c.state[name] = state
+	for name, h := range healthy {
+		c.healthy[name] = h
 
 		value := 0
-		if state.healthy == nil {
+		if h == nil {
 			value = 1
 		}
 
@@ -199,10 +202,10 @@ func (c *checker) IsReady() (ready bool, errors map[string]error) {
 	ready = true
 	errors = make(map[string]error, len(c.services))
 
-	for name, state := range c.state {
-		errors[name] = state.ready
+	for name, state := range c.ready {
+		errors[name] = state
 
-		if state.ready != nil {
+		if state != nil {
 			ready = false
 		}
 	}
@@ -217,10 +220,10 @@ func (c *checker) IsHealthy() (healthy bool, errors map[string]error) {
 	healthy = true
 	errors = make(map[string]error, len(c.services))
 
-	for name, state := range c.state {
-		errors[name] = state.healthy
+	for name, state := range c.healthy {
+		errors[name] = state
 
-		if state.healthy != nil {
+		if state != nil {
 			healthy = false
 		}
 	}

--- a/core/services/health_test.go
+++ b/core/services/health_test.go
@@ -13,27 +13,30 @@ import (
 
 var ErrUnhealthy = errors.New("Unhealthy")
 
-type boolCheck bool
+type boolCheck struct {
+	name    string
+	healthy bool
+}
 
 func (b boolCheck) Ready() error {
-	if b {
+	if b.healthy {
 		return nil
 	}
 	return errors.New("Not ready")
 }
 
 func (b boolCheck) Healthy() error {
-	if b {
+	if b.healthy {
 		return nil
 	}
 	return ErrUnhealthy
 }
 
 func (b boolCheck) HealthReport() map[string]error {
-	if b {
-		return map[string]error{"boolCheck": nil}
+	if b.healthy {
+		return map[string]error{b.name: nil}
 	}
-	return map[string]error{"boolCheck": ErrUnhealthy}
+	return map[string]error{b.name: ErrUnhealthy}
 }
 
 func TestCheck(t *testing.T) {
@@ -44,13 +47,13 @@ func TestCheck(t *testing.T) {
 	}{
 		{[]services.Checkable{}, true, map[string]error{}},
 
-		{[]services.Checkable{boolCheck(true)}, true, map[string]error{"0": nil}},
+		{[]services.Checkable{boolCheck{"0", true}}, true, map[string]error{"0": nil}},
 
-		{[]services.Checkable{boolCheck(true), boolCheck(true)}, true, map[string]error{"0": nil, "1": nil}},
+		{[]services.Checkable{boolCheck{"0", true}, boolCheck{"1", true}}, true, map[string]error{"0": nil, "1": nil}},
 
-		{[]services.Checkable{boolCheck(true), boolCheck(false)}, false, map[string]error{"0": nil, "1": ErrUnhealthy}},
+		{[]services.Checkable{boolCheck{"0", true}, boolCheck{"1", false}}, false, map[string]error{"0": nil, "1": ErrUnhealthy}},
 
-		{[]services.Checkable{boolCheck(true), boolCheck(false), boolCheck(false)}, false, map[string]error{
+		{[]services.Checkable{boolCheck{"0", true}, boolCheck{"1", false},boolCheck{"2", false}}, false, map[string]error{
 			"0": nil,
 			"1": ErrUnhealthy,
 			"2": ErrUnhealthy,

--- a/core/services/health_test.go
+++ b/core/services/health_test.go
@@ -25,13 +25,6 @@ func (b boolCheck) Ready() error {
 	return errors.New("Not ready")
 }
 
-func (b boolCheck) Healthy() error {
-	if b.healthy {
-		return nil
-	}
-	return ErrUnhealthy
-}
-
 func (b boolCheck) HealthReport() map[string]error {
 	if b.healthy {
 		return map[string]error{b.name: nil}
@@ -53,7 +46,7 @@ func TestCheck(t *testing.T) {
 
 		{[]services.Checkable{boolCheck{"0", true}, boolCheck{"1", false}}, false, map[string]error{"0": nil, "1": ErrUnhealthy}},
 
-		{[]services.Checkable{boolCheck{"0", true}, boolCheck{"1", false},boolCheck{"2", false}}, false, map[string]error{
+		{[]services.Checkable{boolCheck{"0", true}, boolCheck{"1", false}, boolCheck{"2", false}}, false, map[string]error{
 			"0": nil,
 			"1": ErrUnhealthy,
 			"2": ErrUnhealthy,

--- a/core/services/job/mocks/spawner.go
+++ b/core/services/job/mocks/spawner.go
@@ -104,20 +104,6 @@ func (_m *Spawner) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *Spawner) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Name provides a mock function with given fields:
 func (_m *Spawner) Name() string {
 	ret := _m.Called()

--- a/core/services/ocr2/plugins/ocr2keeper/evm/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm/registry.go
@@ -173,6 +173,10 @@ func (r *EvmRegistry) IdentifierFromKey(key types.UpkeepKey) (types.UpkeepIdenti
 	return id.Bytes(), nil
 }
 
+func (r *EvmRegistry) Name() string {
+	return r.lggr.Name()
+}
+
 func (r *EvmRegistry) Start(ctx context.Context) error {
 	return r.sync.StartOnce("AutomationRegistry", func() error {
 		r.mu.Lock()
@@ -266,14 +270,14 @@ func (r *EvmRegistry) Ready() error {
 	return r.sync.Ready()
 }
 
-func (r *EvmRegistry) Healthy() error {
+func (r *EvmRegistry) HealthReport() map[string]error {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
 	if r.runState > 1 {
-		return fmt.Errorf("failed run state: %w", r.runError)
+		r.sync.SvcErrBuffer.Append(fmt.Errorf("failed run state: %w", r.runError))
 	}
-	return r.sync.Healthy()
+	return map[string]error{r.Name(): r.sync.Healthy()}
 }
 
 func (r *EvmRegistry) initialize() error {

--- a/core/services/ocr2/plugins/ocr2keeper/log_provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/log_provider.go
@@ -97,6 +97,10 @@ func NewLogProvider(
 	}, nil
 }
 
+func (c *LogProvider) Name() string {
+	return c.logger.Name()
+}
+
 func (c *LogProvider) Start(ctx context.Context) error {
 	return c.sync.StartOnce("AutomationLogProvider", func() error {
 		c.mu.Lock()
@@ -130,14 +134,14 @@ func (c *LogProvider) Ready() error {
 	return c.sync.Ready()
 }
 
-func (c *LogProvider) Healthy() error {
+func (c *LogProvider) HealthReport() map[string]error {
 	c.mu.RLock()
 	defer c.mu.RUnlock()
 
 	if c.runState > 1 {
-		return fmt.Errorf("failed run state: %w", c.runError)
+		c.sync.SvcErrBuffer.Append(fmt.Errorf("failed run state: %w", c.runError))
 	}
-	return c.sync.Healthy()
+	return map[string]error{c.Name(): c.sync.Healthy()}
 }
 
 func (c *LogProvider) PerformLogs(ctx context.Context) ([]plugintypes.PerformLog, error) {

--- a/core/services/pg/event_broadcaster.go
+++ b/core/services/pg/event_broadcaster.go
@@ -324,9 +324,6 @@ func (*NullEventBroadcaster) Close() error { return nil }
 // Ready does no-op.
 func (*NullEventBroadcaster) Ready() error { return nil }
 
-// Healthy does no-op.
-func (*NullEventBroadcaster) Healthy() error { return nil }
-
 // HealthReport does no-op
 func (*NullEventBroadcaster) HealthReport() map[string]error { return map[string]error{} }
 

--- a/core/services/pg/event_broadcaster.go
+++ b/core/services/pg/event_broadcaster.go
@@ -313,7 +313,7 @@ func NewNullEventBroadcaster() *NullEventBroadcaster {
 
 var _ EventBroadcaster = &NullEventBroadcaster{}
 
-func (*NullEventBroadcaster) Name() string { return "" }
+func (*NullEventBroadcaster) Name() string { return "NullEventBroadcaster" }
 
 // Start does no-op.
 func (*NullEventBroadcaster) Start(context.Context) error { return nil }

--- a/core/services/pg/mocks/event_broadcaster.go
+++ b/core/services/pg/mocks/event_broadcaster.go
@@ -44,20 +44,6 @@ func (_m *EventBroadcaster) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *EventBroadcaster) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Name provides a mock function with given fields:
 func (_m *EventBroadcaster) Name() string {
 	ret := _m.Called()

--- a/core/services/pipeline/mocks/orm.go
+++ b/core/services/pipeline/mocks/orm.go
@@ -210,20 +210,6 @@ func (_m *ORM) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *ORM) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // InsertFinishedRun provides a mock function with given fields: run, saveSuccessfulTaskRuns, qopts
 func (_m *ORM) InsertFinishedRun(run *pipeline.Run, saveSuccessfulTaskRuns bool, qopts ...pg.QOpt) error {
 	_va := make([]interface{}, len(qopts))

--- a/core/services/pipeline/mocks/runner.go
+++ b/core/services/pipeline/mocks/runner.go
@@ -114,20 +114,6 @@ func (_m *Runner) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *Runner) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // InsertFinishedRun provides a mock function with given fields: run, saveSuccessfulTaskRuns, qopts
 func (_m *Runner) InsertFinishedRun(run *pipeline.Run, saveSuccessfulTaskRuns bool, qopts ...pg.QOpt) error {
 	_va := make([]interface{}, len(qopts))

--- a/core/services/relay/evm/contract_transmitter.go
+++ b/core/services/relay/evm/contract_transmitter.go
@@ -66,7 +66,7 @@ func NewOCRContractTransmitter(
 		transmittedEventSig: transmitted.ID,
 		lp:                  lp,
 		contractReader:      caller,
-		lggr:                lggr,
+		lggr:                lggr.Named("OCRContractTransmitter"),
 	}, nil
 }
 
@@ -177,4 +177,4 @@ func (oc *contractTransmitter) Ready() error   { return nil }
 func (oc *contractTransmitter) HealthReport() map[string]error {
 	return map[string]error{oc.Name(): oc.Healthy()}
 }
-func (oc *contractTransmitter) Name() string { return "" }
+func (oc *contractTransmitter) Name() string { return oc.lggr.Name() }

--- a/core/services/relay/evm/contract_transmitter.go
+++ b/core/services/relay/evm/contract_transmitter.go
@@ -172,9 +172,8 @@ func (oc *contractTransmitter) Start(ctx context.Context) error { return nil }
 func (oc *contractTransmitter) Close() error                    { return nil }
 
 // Has no state/lifecycle so it's always healthy and ready
-func (oc *contractTransmitter) Healthy() error { return nil }
-func (oc *contractTransmitter) Ready() error   { return nil }
+func (oc *contractTransmitter) Ready() error { return nil }
 func (oc *contractTransmitter) HealthReport() map[string]error {
-	return map[string]error{oc.Name(): oc.Healthy()}
+	return map[string]error{oc.Name(): nil}
 }
 func (oc *contractTransmitter) Name() string { return oc.lggr.Name() }

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -17,6 +17,7 @@ import (
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2/types"
 	"github.com/smartcontractkit/sqlx"
 	"go.uber.org/multierr"
+	"golang.org/x/exp/maps"
 
 	relaytypes "github.com/smartcontractkit/chainlink-relay/pkg/types"
 
@@ -444,7 +445,7 @@ func (p *medianProvider) Healthy() error {
 
 func (p *medianProvider) HealthReport() map[string]error {
 	report := p.configWatcher.HealthReport()
-	utils.MergeMaps(report, p.contractTransmitter.HealthReport())
+	maps.Copy(report, p.contractTransmitter.HealthReport())
 	return report
 }
 

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -83,7 +83,7 @@ func (r *Relayer) Healthy() error {
 }
 
 func (r *Relayer) HealthReport() map[string]error {
-	return map[string]error{r.Name(): r.Healthy()}
+	return r.chainSet.HealthReport()
 }
 
 // This is a stub, to be added in smartcontractkit/chainlink#8340
@@ -174,7 +174,7 @@ func (c *configWatcher) Close() error {
 }
 
 func (c *configWatcher) HealthReport() map[string]error {
-	return map[string]error{c.Name(): c.Healthy()}
+	return map[string]error{c.Name(): c.StartStopOnce.Healthy()}
 }
 
 func (c *configWatcher) OffchainConfigDigester() ocrtypes.OffchainConfigDigester {

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -77,7 +77,8 @@ func (r *Relayer) Ready() error {
 	return nil
 }
 
-// Healthy does noop: always healthy
+// FIXME: for backward compat we will leave this until relayer libs remove Healthy refs
+// https://smartcontract-it.atlassian.net/browse/BCF-2140
 func (r *Relayer) Healthy() error {
 	return nil
 }
@@ -435,12 +436,16 @@ func (p *medianProvider) Ready() error {
 	return multierr.Combine(p.configWatcher.Ready(), p.contractTransmitter.Ready())
 }
 
+// FIXME: for backward compat we will leave this until relayer libs remove Healthy refs
+// https://smartcontract-it.atlassian.net/browse/BCF-2140
 func (p *medianProvider) Healthy() error {
-	return multierr.Combine(p.configWatcher.Healthy(), p.contractTransmitter.Healthy())
+	return nil
 }
 
 func (p *medianProvider) HealthReport() map[string]error {
-	return map[string]error{p.Name(): p.Healthy()}
+	report := p.configWatcher.HealthReport()
+	utils.MergeMaps(report, p.contractTransmitter.HealthReport())
+	return report
 }
 
 func (p *medianProvider) ContractTransmitter() ocrtypes.ContractTransmitter {

--- a/core/services/relay/evm/mercury/transmitter.go
+++ b/core/services/relay/evm/mercury/transmitter.go
@@ -55,14 +55,13 @@ func NewTransmitter(lggr logger.Logger, rpcClient wsrpc.Client, fromAccount comm
 
 func (mt *mercuryTransmitter) Start(ctx context.Context) error { return mt.rpcClient.Start(ctx) }
 func (mt *mercuryTransmitter) Close() error                    { return mt.rpcClient.Close() }
-func (mt *mercuryTransmitter) Healthy() error                  { return mt.rpcClient.Healthy() }
 func (mt *mercuryTransmitter) Ready() error                    { return mt.rpcClient.Ready() }
 func (mt *mercuryTransmitter) Name() string {
 	return mt.lggr.Name()
 }
 
 func (mt *mercuryTransmitter) HealthReport() map[string]error {
-	return map[string]error{mt.Name(): mt.Healthy()}
+	return mt.rpcClient.HealthReport()
 }
 
 // Transmit sends the report to the on-chain smart contract's Transmit method.

--- a/core/services/relay/evm/mercury/transmitter_test.go
+++ b/core/services/relay/evm/mercury/transmitter_test.go
@@ -22,7 +22,6 @@ type MockWSRPCClient struct {
 func (m MockWSRPCClient) Name() string                   { return "" }
 func (m MockWSRPCClient) Start(context.Context) error    { return nil }
 func (m MockWSRPCClient) Close() error                   { return nil }
-func (m MockWSRPCClient) Healthy() error                 { return nil }
 func (m MockWSRPCClient) HealthReport() map[string]error { return map[string]error{} }
 func (m MockWSRPCClient) Ready() error                   { return nil }
 func (m MockWSRPCClient) Transmit(ctx context.Context, in *report.ReportRequest) (*report.ReportResponse, error) {

--- a/core/services/synchronization/explorer_client.go
+++ b/core/services/synchronization/explorer_client.go
@@ -72,9 +72,6 @@ func (NoopExplorerClient) Start(context.Context) error { return nil }
 // Close is a no-op
 func (NoopExplorerClient) Close() error { return nil }
 
-// Healthy is a no-op
-func (NoopExplorerClient) Healthy() error { return nil }
-
 // Ready is a no-op
 func (NoopExplorerClient) Ready() error { return nil }
 

--- a/core/services/synchronization/explorer_client.go
+++ b/core/services/synchronization/explorer_client.go
@@ -58,7 +58,7 @@ type ExplorerClient interface {
 type NoopExplorerClient struct{}
 
 func (NoopExplorerClient) HealthReport() map[string]error { return map[string]error{} }
-func (NoopExplorerClient) Name() string                   { return "" }
+func (NoopExplorerClient) Name() string                   { return "NoopExplorerClient" }
 
 // Url always returns underlying url.
 func (NoopExplorerClient) Url() url.URL { return url.URL{} }

--- a/core/services/synchronization/mocks/explorer_client.go
+++ b/core/services/synchronization/mocks/explorer_client.go
@@ -48,20 +48,6 @@ func (_m *ExplorerClient) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *ExplorerClient) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Name provides a mock function with given fields:
 func (_m *ExplorerClient) Name() string {
 	ret := _m.Called()

--- a/core/services/synchronization/mocks/telemetry_ingress_batch_client.go
+++ b/core/services/synchronization/mocks/telemetry_ingress_batch_client.go
@@ -44,20 +44,6 @@ func (_m *TelemetryIngressBatchClient) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *TelemetryIngressBatchClient) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Name provides a mock function with given fields:
 func (_m *TelemetryIngressBatchClient) Name() string {
 	ret := _m.Called()

--- a/core/services/synchronization/mocks/telemetry_ingress_client.go
+++ b/core/services/synchronization/mocks/telemetry_ingress_client.go
@@ -44,20 +44,6 @@ func (_m *TelemetryIngressClient) HealthReport() map[string]error {
 	return r0
 }
 
-// Healthy provides a mock function with given fields:
-func (_m *TelemetryIngressClient) Healthy() error {
-	ret := _m.Called()
-
-	var r0 error
-	if rf, ok := ret.Get(0).(func() error); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Error(0)
-	}
-
-	return r0
-}
-
 // Name provides a mock function with given fields:
 func (_m *TelemetryIngressClient) Name() string {
 	ret := _m.Called()

--- a/core/services/synchronization/telemetry_ingress_batch_client.go
+++ b/core/services/synchronization/telemetry_ingress_batch_client.go
@@ -45,7 +45,7 @@ func (NoopTelemetryIngressBatchClient) Send(TelemPayload) {}
 // Healthy is a no-op
 func (NoopTelemetryIngressBatchClient) Healthy() error                 { return nil }
 func (NoopTelemetryIngressBatchClient) HealthReport() map[string]error { return map[string]error{} }
-func (NoopTelemetryIngressBatchClient) Name() string                   { return "" }
+func (NoopTelemetryIngressBatchClient) Name() string                   { return "NoopTelemetryIngressBatchClient" }
 
 // Ready is a no-op
 func (NoopTelemetryIngressBatchClient) Ready() error { return nil }

--- a/core/services/synchronization/telemetry_ingress_batch_client.go
+++ b/core/services/synchronization/telemetry_ingress_batch_client.go
@@ -43,7 +43,6 @@ func (NoopTelemetryIngressBatchClient) Close() error { return nil }
 func (NoopTelemetryIngressBatchClient) Send(TelemPayload) {}
 
 // Healthy is a no-op
-func (NoopTelemetryIngressBatchClient) Healthy() error                 { return nil }
 func (NoopTelemetryIngressBatchClient) HealthReport() map[string]error { return map[string]error{} }
 func (NoopTelemetryIngressBatchClient) Name() string                   { return "NoopTelemetryIngressBatchClient" }
 

--- a/core/services/synchronization/telemetry_ingress_client.go
+++ b/core/services/synchronization/telemetry_ingress_client.go
@@ -40,9 +40,6 @@ func (NoopTelemetryIngressClient) Close() error { return nil }
 // Send is a no-op
 func (NoopTelemetryIngressClient) Send(TelemPayload) {}
 
-// Healthy is a no-op
-func (NoopTelemetryIngressClient) Healthy() error { return nil }
-
 func (NoopTelemetryIngressClient) HealthReport() map[string]error { return map[string]error{} }
 func (NoopTelemetryIngressClient) Name() string                   { return "NoopTelemetryIngressClient" }
 

--- a/core/services/synchronization/telemetry_ingress_client.go
+++ b/core/services/synchronization/telemetry_ingress_client.go
@@ -44,7 +44,7 @@ func (NoopTelemetryIngressClient) Send(TelemPayload) {}
 func (NoopTelemetryIngressClient) Healthy() error { return nil }
 
 func (NoopTelemetryIngressClient) HealthReport() map[string]error { return map[string]error{} }
-func (NoopTelemetryIngressClient) Name() string                   { return "" }
+func (NoopTelemetryIngressClient) Name() string                   { return "NoopTelemetryIngressClient" }
 
 // Ready is a no-op
 func (NoopTelemetryIngressClient) Ready() error { return nil }

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -1179,13 +1179,12 @@ func UnwrapError(err error) []error {
 	return joined.Unwrap()
 }
 
-func MergeMaps[K comparable, V any](m1 map[K]V, m2 map[K]V) map[K]V {
-	merged := make(map[K]V)
-	for key, value := range m1 {
-		merged[key] = value
-	}
+func MergeMaps[K comparable, V any](m1 map[K]V, m2 map[K]V) {
 	for key, value := range m2 {
-		merged[key] = value
+		// don't override main map keys.
+		if _, ok := m1[key]; ok {
+			continue
+		}
+		m1[key] = value
 	}
-	return merged
 }

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -1178,3 +1178,14 @@ func UnwrapError(err error) []error {
 	}
 	return joined.Unwrap()
 }
+
+func MergeMaps[K comparable, V any](m1 map[K]V, m2 map[K]V) map[K]V {
+	merged := make(map[K]V)
+	for key, value := range m1 {
+		merged[key] = value
+	}
+	for key, value := range m2 {
+		merged[key] = value
+	}
+	return merged
+}

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -1178,13 +1178,3 @@ func UnwrapError(err error) []error {
 	}
 	return joined.Unwrap()
 }
-
-func MergeMaps[K comparable, V any](m1 map[K]V, m2 map[K]V) {
-	for key, value := range m2 {
-		// don't override main map keys.
-		if _, ok := m1[key]; ok {
-			continue
-		}
-		m1[key] = value
-	}
-}


### PR DESCRIPTION
This PR:
- Implements health reporting in EVM services
- Moves health checker to use HealthReports instead of Healthy calls
- Removes most* healthy() calls without breaking relayer type dep
- Adds chainID to EVM chain name/lggr

Pending work in follow up PRs:
1- embedd gasestimators into txmgr healthreport
2- pass HC to ocr2 job delegates, opening up hc registration to job services.
3- Clean up relayer iface, update core and clean Healthy declarations