### PR TITLE
core/cmd: only run fallback API initializer when file not present (#8718)

### DIFF
--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -377,14 +377,16 @@ func (cli *Client) runNode(c *clipkg.Context) error {
 	}
 
 	var user sessions.User
-	if _, err = NewFileAPIInitializer(c.String("api")).Initialize(sessionORM, lggr); err != nil && !errors.Is(err, ErrNoCredentialFile) {
-		return errors.Wrap(err, "error creating api initializer")
-	}
-	if user, err = cli.FallbackAPIInitializer.Initialize(sessionORM, lggr); err != nil {
-		if errors.Is(err, ErrorNoAPICredentialsAvailable) {
-			return errors.WithStack(err)
+	if user, err = NewFileAPIInitializer(c.String("api")).Initialize(sessionORM, lggr); err != nil {
+		if !errors.Is(err, ErrNoCredentialFile) {
+			return errors.Wrap(err, "error creating api initializer")
 		}
-		return errors.Wrap(err, "error creating fallback initializer")
+		if user, err = cli.FallbackAPIInitializer.Initialize(sessionORM, lggr); err != nil {
+			if errors.Is(err, ErrorNoAPICredentialsAvailable) {
+				return errors.WithStack(err)
+			}
+			return errors.Wrap(err, "error creating fallback initializer")
+		}
 	}
 
 	lggr.Info("API exposed for user ", user.Email)


### PR DESCRIPTION
(cherry picked from commit 5622de9fec4d459d5c2a8fc2fddd9c6d78119404)