### PR TITLE
Remove alexroan from CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -51,7 +51,7 @@
 /operator-ui/ @DeividasK @jkongie
 
 # Contracts
-/contracts/ @alexroan @se3000 @connorwstein
+/contracts/ @se3000 @connorwstein
 /contracts/**/*Keeper* @smartcontractkit/keepers
 /contracts/**/*Upkeep* @smartcontractkit/keepers
 
@@ -61,7 +61,7 @@
 /integration-tests/**/*automation* @smartcontractkit/keepers
 
 # CI/CD
-/.github/** @alexroan @chainchad @javuto @jkongie @jmank88 @samsondav
+/.github/** @chainchad @javuto @jkongie @jmank88 @samsondav
 /.github/workflows/integration-tests.yml @smartcontractkit/test-tooling-team
 /.github/workflows/integration-chaos-tests.yml @smartcontractkit/test-tooling-team
 /.github/workflows/integration-tests-publish.yml @smartcontractkit/test-tooling-team


### PR DESCRIPTION
Fixing the below errors:


Unknown owner on line 55: make sure @alexroan exists and has write access to the repository
/contracts/ @alexroan @se3000 @connorwstein
Unknown owner on line 65: make sure @alexroan exists and has write access to the repository
/.github/** @alexroan @chainchad @javuto @jkongie @jmank88 @samsondav