### PR TITLE
Don't build solana image and try to download artifacts on workflow runs that shouldn't run tests

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -354,13 +354,13 @@ jobs:
           repository: smartcontractkit/chainlink-solana
           ref: ${{ needs.get_solana_sha.outputs.sha }}
       - name: Download Artifacts
-        if: ${{ needs.get_solana_sha.outputs.sha != 'develop' }}
+        if: ${{ needs.changes.outputs.src == 'true' && needs.get_solana_sha.outputs.sha != 'develop' }}
         uses: actions/download-artifact@v3
         with:
           name: artifacts
           path: ${{ env.CONTRACT_ARTIFACTS_PATH }}
       - name: Build Test Runner
-        if: ${{ needs.get_solana_sha.outputs.sha != 'develop' }}
+        if: ${{ needs.changes.outputs.src == 'true' && needs.get_solana_sha.outputs.sha != 'develop' }}
         uses: smartcontractkit/chainlink-github-actions/docker/build-push@09358ba70818d6252aa3f7b8ba6022192f716e71 # v2.1.3
         with:
           tags: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests:solana.${{ needs.get_solana_sha.outputs.sha }}


### PR DESCRIPTION
This fixes the path where the tests shouldn't run but we were still trying to build the image and we shouldn't have