### PR TITLE
Use CGO with GoReleaser

### DIFF
--- a/.goreleaser.develop.yaml
+++ b/.goreleaser.develop.yaml
@@ -26,7 +26,7 @@ builds:
     hooks:
       post: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }} {{ .Os }} {{ .Arch }}
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
       - CC=$ZIG_EXEC cc -target aarch64-linux-gnu
       - CCX=$ZIG_EXEC c++ -target aarch64-linux-gnu
     flags:
@@ -46,7 +46,7 @@ builds:
     hooks:
       post: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }} {{ .Os }} {{ .Arch }}
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
       - CC=$ZIG_EXEC cc -target x86_64-linux-gnu
       - CCX=$ZIG_EXEC c++ -target x86_64-linux-gnu
     flags:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -26,7 +26,7 @@ builds:
     hooks:
       post: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }} {{ .Os }} {{ .Arch }}
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
       - CC=$ZIG_EXEC cc -target aarch64-linux-gnu
       - CCX=$ZIG_EXEC c++ -target aarch64-linux-gnu
     flags:
@@ -46,7 +46,7 @@ builds:
     hooks:
       post: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }} {{ .Os }} {{ .Arch }}
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
       - CC=$ZIG_EXEC cc -target x86_64-linux-gnu
       - CCX=$ZIG_EXEC c++ -target x86_64-linux-gnu
     flags:
@@ -66,7 +66,7 @@ builds:
     hooks:
       post: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }} {{ .Os }} {{ .Arch }}
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
       - CC=$ZIG_EXEC cc -target aarch64-macos $ZIG_FLAGS_DARWIN
       - CCX=$ZIG_EXEC c++ -target aarch64-macos $ZIG_FLAGS_DARWIN
     flags:
@@ -86,7 +86,7 @@ builds:
     hooks:
       post: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }} {{ .Os }} {{ .Arch }}
     env:
-      - CGO_ENABLED=0
+      - CGO_ENABLED=1
       - CC=$ZIG_EXEC cc -target x86_64-macos $ZIG_FLAGS_DARWIN
       - CCX=$ZIG_EXEC c++ -target x86_64-macos $ZIG_FLAGS_DARWIN
     flags:


### PR DESCRIPTION
CGO was disabled in [#8532](https://github.com/smartcontractkit/chainlink/pull/8532) but it's needed to avoid:

```
panic: ScalarMult is not available when secp256k1 is built without cgo [recovered]
	panic: ScalarMult is not available when secp256k1 is built without cgo
github.com/smartcontractkit/chainlink/core/recovery.ReportPanics.func1()
panic({0xffffb29d6e60, 0xffffb2def2c0})
	runtime/panic.go:884 +0x213
github.com/smartcontractkit/chainlink/core/recovery.ReportPanics(0xc0000061a0?)
```