### PR TITLE
.github/workflows: print lint report artifact

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -87,6 +87,9 @@ jobs:
           only-new-issues: ${{ github.event.schedule == '' }} # show only new issues, unless it's a scheduled run
           allow-extra-out-format-args: true
           args: --out-format checkstyle:golangci-lint-report.xml
+      - name: Print lint report artifact
+        if: always()
+        run: cat golangci-lint-report.xml
       - name: Store lint report artifact
         if: always()
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0


### PR DESCRIPTION
The linter artifacts are not available on the summary screen until after the workflow completes. This PR adds a step to print them out in-line, so that they can be viewed immeadiately.