### PR TITLE
BCF-2165:  mv cli config validate command

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -146,7 +146,7 @@ func NewApp(client *Client) *cli.App {
 		{
 			Name:        "config",
 			Usage:       "Commands for the node's configuration",
-			Subcommands: initRemoteConfigSubCmds(client, &opts),
+			Subcommands: initRemoteConfigSubCmds(client),
 		},
 		{
 			Name:        "jobs",

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -110,28 +110,14 @@ func initLocalSubCmds(client *Client, devMode bool) []cli.Command {
 			},
 		},
 		{
-			Name:   "status",
-			Usage:  "Displays the health of various services running inside the node.",
-			Action: client.Status,
-			Flags:  []cli.Flag{},
+			Name:   "validate",
+			Usage:  "Validate provided TOML config file, and print the full effective configuration, with defaults included",
+			Action: client.ConfigFileValidate,
 		},
-		{
-			Name:   "profile",
-			Usage:  "Collects profile metrics from the node.",
-			Action: client.Profile,
-			Flags: []cli.Flag{
-				cli.Uint64Flag{
-					Name:  "seconds, s",
-					Usage: "duration of profile capture",
-					Value: 8,
-				},
-				cli.StringFlag{
-					Name:  "output_dir, o",
-					Usage: "output directory of the captured profile",
-					Value: "/tmp/",
-				},
-			},
-		},
+		// status and profile for backward compatibilty
+		statusCliCmd(client, true),
+		profileCliCmd(client, true),
+
 		{
 			Name:        "db",
 			Usage:       "Commands for managing the database.",

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -134,7 +134,7 @@ func initLocalSubCmds(client *Client, devMode bool) []cli.Command {
 		},
 		{
 			Name:   "validate",
-			Usage:  "Validate provided TOML config file, and print the full effective configuration, with defaults included",
+			Usage:  "Validate the TOML configuration and secrets that are passed as flags to the `node` command. Prints the full effective configuration, with defaults included",
 			Action: client.ConfigFileValidate,
 		},
 		{

--- a/core/cmd/local_client.go
+++ b/core/cmd/local_client.go
@@ -607,22 +607,20 @@ func (ps HealthCheckPresenters) RenderTable(rt RendererTable) error {
 	return nil
 }
 
-// Status will display the health of various services
-func (cli *Client) Status(c *clipkg.Context) error {
-	resp, err := cli.HTTP.Get("/health?full=1", nil)
-	if err != nil {
-		return cli.errorOut(err)
-	}
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
-		}
-	}()
-
-	return cli.renderAPIResponse(resp, &HealthCheckPresenters{})
-}
-
 var errDBURLMissing = errors.New("You must set CL_DATABASE_URL env variable or provide a secrets TOML with Database.URL set. HINT: If you are running this to set up your local test database, try CL_DATABASE_URL=postgresql://postgres@localhost:5432/chainlink_test?sslmode=disable")
+
+// ConfigValidate validate the client configuration and pretty-prints results
+func (cli *Client) ConfigFileValidate(c *clipkg.Context) error {
+	cli.Config.LogConfiguration(func(params ...any) { fmt.Println(params...) })
+	err := cli.Config.Validate()
+	if err != nil {
+		fmt.Println("Invalid configuration:", err)
+		fmt.Println()
+		return cli.errorOut(errors.New("invalid configuration"))
+	}
+	fmt.Println("Valid configuration.")
+	return nil
+}
 
 // ResetDatabase drops, creates and migrates the database specified by CL_DATABASE_URL or Database.URL
 // in secrets TOML. This is useful to setup the database for testing

--- a/core/cmd/remote_client.go
+++ b/core/cmd/remote_client.go
@@ -73,6 +73,14 @@ func initRemoteConfigSubCmds(client *Client) []cli.Command {
 				},
 			},
 		},
+		{
+			Name:  "validate",
+			Usage: "DEPRECIATED. Use `chainlink node validate`",
+			Before: func(ctx *clipkg.Context) error {
+				return client.errorOut(fmt.Errorf("Depreciated, use `chainlink node validate`"))
+			},
+			Hidden: true,
+		},
 	}
 }
 

--- a/core/cmd/remote_client.go
+++ b/core/cmd/remote_client.go
@@ -74,23 +74,8 @@ func initRemoteConfigSubCmds(client *Client, opts *chainlink.GeneralConfigOpts) 
 				},
 			},
 		},
-		{
-			Name:   "validate",
-			Usage:  "Validate provided TOML config file, and print the full effective configuration, with defaults included",
-			Action: client.ConfigFileValidate,
-			Flags: []cli.Flag{cli.StringSliceFlag{
-				Name:  "config, c",
-				Usage: "TOML configuration file(s) via flag, or raw TOML via env var. If used, legacy env vars must not be set. Multiple files can be used (-c configA.toml -c configB.toml), and they are applied in order with duplicated fields overriding any earlier values. If the 'CL_CONFIG' env var is specified, it is always processed last with the effect of being the final override. [$CL_CONFIG]",
-			},
-				cli.StringFlag{
-					Name:  "secrets, s",
-					Usage: "TOML configuration file for secrets. Must be set if and only if config is set.",
-				},
-			},
-			Before: func(c *cli.Context) error {
-				return client.setConfigFromFlags(opts, c)
-			},
-		},
+		statusCliCmd(client, false),
+		profileCliCmd(client, false),
 	}
 }
 
@@ -99,6 +84,37 @@ var (
 	errForbidden    = errors.New(http.StatusText(http.StatusForbidden))
 	errBadRequest   = errors.New(http.StatusText(http.StatusBadRequest))
 )
+
+func statusCliCmd(client *Client, hidden bool) cli.Command {
+	return cli.Command{
+		Name:   "status",
+		Usage:  "Displays the health of various services running inside the node.",
+		Action: client.Status,
+		Flags:  []cli.Flag{},
+		Hidden: hidden,
+	}
+}
+
+func profileCliCmd(client *Client, hidden bool) cli.Command {
+	return cli.Command{
+		Name:   "profile",
+		Usage:  "Collects profile metrics from the node.",
+		Action: client.Profile,
+		Flags: []cli.Flag{
+			cli.Uint64Flag{
+				Name:  "seconds, s",
+				Usage: "duration of profile capture",
+				Value: 8,
+			},
+			cli.StringFlag{
+				Name:  "output_dir, o",
+				Usage: "output directory of the captured profile",
+				Value: "/tmp/",
+			},
+		},
+		Hidden: hidden,
+	}
+}
 
 // CreateExternalInitiator adds an external initiator
 func (cli *Client) CreateExternalInitiator(c *clipkg.Context) (err error) {

--- a/core/cmd/remote_client.go
+++ b/core/cmd/remote_client.go
@@ -75,7 +75,7 @@ func initRemoteConfigSubCmds(client *Client) []cli.Command {
 		},
 		{
 			Name:  "validate",
-			Usage: "DEPRECIATED. Use `chainlink node validate`",
+			Usage: "DEPRECATED. Use `chainlink node validate`",
 			Before: func(ctx *clipkg.Context) error {
 				return client.errorOut(fmt.Errorf("Depreciated, use `chainlink node validate`"))
 			},

--- a/core/cmd/remote_client.go
+++ b/core/cmd/remote_client.go
@@ -73,8 +73,6 @@ func initRemoteConfigSubCmds(client *Client) []cli.Command {
 				},
 			},
 		},
-		statusCliCmd(client, false),
-		profileCliCmd(client, false),
 	}
 }
 
@@ -83,37 +81,6 @@ var (
 	errForbidden    = errors.New(http.StatusText(http.StatusForbidden))
 	errBadRequest   = errors.New(http.StatusText(http.StatusBadRequest))
 )
-
-func statusCliCmd(client *Client, hidden bool) cli.Command {
-	return cli.Command{
-		Name:   "status",
-		Usage:  "Displays the health of various services running inside the node.",
-		Action: client.Status,
-		Flags:  []cli.Flag{},
-		Hidden: hidden,
-	}
-}
-
-func profileCliCmd(client *Client, hidden bool) cli.Command {
-	return cli.Command{
-		Name:   "profile",
-		Usage:  "Collects profile metrics from the node.",
-		Action: client.Profile,
-		Flags: []cli.Flag{
-			cli.Uint64Flag{
-				Name:  "seconds, s",
-				Usage: "duration of profile capture",
-				Value: 8,
-			},
-			cli.StringFlag{
-				Name:  "output_dir, o",
-				Usage: "output directory of the captured profile",
-				Value: "/tmp/",
-			},
-		},
-		Hidden: hidden,
-	}
-}
 
 // CreateExternalInitiator adds an external initiator
 func (cli *Client) CreateExternalInitiator(c *clipkg.Context) (err error) {
@@ -273,21 +240,6 @@ func (cli *Client) ChangePassword(c *clipkg.Context) (err error) {
 		return cli.printResponseBody(resp)
 	}
 	return nil
-}
-
-// Status will display the health of various services
-func (cli *Client) Status(c *clipkg.Context) error {
-	resp, err := cli.HTTP.Get("/health?full=1", nil)
-	if err != nil {
-		return cli.errorOut(err)
-	}
-	defer func() {
-		if cerr := resp.Body.Close(); cerr != nil {
-			err = multierr.Append(err, cerr)
-		}
-	}()
-
-	return cli.renderAPIResponse(resp, &HealthCheckPresenters{})
 }
 
 // Profile will collect pprof metrics and store them in a folder.

--- a/core/cmd/remote_client.go
+++ b/core/cmd/remote_client.go
@@ -77,7 +77,7 @@ func initRemoteConfigSubCmds(client *Client) []cli.Command {
 			Name:  "validate",
 			Usage: "DEPRECATED. Use `chainlink node validate`",
 			Before: func(ctx *clipkg.Context) error {
-				return client.errorOut(fmt.Errorf("Depreciated, use `chainlink node validate`"))
+				return client.errorOut(fmt.Errorf("Deprecated, use `chainlink node validate`"))
 			},
 			Hidden: true,
 		},

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -164,8 +164,6 @@ func ExampleRun_config() {
 	//    show      Show the application configuration
 	//    loglevel  Set log level
 	//    logsql    Enable/disable SQL statement logging
-	//    status    Displays the health of various services running inside the node.
-	//    profile   Collects profile metrics from the node.
 	//
 	// OPTIONS:
 	//    --help, -h  show help
@@ -449,6 +447,8 @@ func ExampleRun_node() {
 	// COMMANDS:
 	//    start, node, n            Run the Chainlink node
 	//    rebroadcast-transactions  Manually rebroadcast txs matching nonce range with the specified gas price. This is useful in emergencies e.g. high gas prices and/or network congestion to forcibly clear out the pending TX queue
+	//    status                    Displays the health of various services running inside the node.
+	//    profile                   Collects profile metrics from the node.
 	//    validate                  Validate provided TOML config file, and print the full effective configuration, with defaults included
 	//    db                        Commands for managing the database.
 	//

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -164,7 +164,8 @@ func ExampleRun_config() {
 	//    show      Show the application configuration
 	//    loglevel  Set log level
 	//    logsql    Enable/disable SQL statement logging
-	//    validate  Validate provided TOML config file, and print the full effective configuration, with defaults included
+	//    status    Displays the health of various services running inside the node.
+	//    profile   Collects profile metrics from the node.
 	//
 	// OPTIONS:
 	//    --help, -h  show help
@@ -448,8 +449,7 @@ func ExampleRun_node() {
 	// COMMANDS:
 	//    start, node, n            Run the Chainlink node
 	//    rebroadcast-transactions  Manually rebroadcast txs matching nonce range with the specified gas price. This is useful in emergencies e.g. high gas prices and/or network congestion to forcibly clear out the pending TX queue
-	//    status                    Displays the health of various services running inside the node.
-	//    profile                   Collects profile metrics from the node.
+	//    validate                  Validate provided TOML config file, and print the full effective configuration, with defaults included
 	//    db                        Commands for managing the database.
 	//
 	// OPTIONS:

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -449,7 +449,7 @@ func ExampleRun_node() {
 	//    rebroadcast-transactions  Manually rebroadcast txs matching nonce range with the specified gas price. This is useful in emergencies e.g. high gas prices and/or network congestion to forcibly clear out the pending TX queue
 	//    status                    Displays the health of various services running inside the node.
 	//    profile                   Collects profile metrics from the node.
-	//    validate                  Validate provided TOML config file, and print the full effective configuration, with defaults included
+	//    validate                  Validate the TOML configuration and secrets that are passed as flags to the `node` command. Prints the full effective configuration, with defaults included
 	//    db                        Commands for managing the database.
 	//
 	// OPTIONS:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - TOML configuration and secrets are now scoped to `chainlink node` command rather than being global flags.
+- TOML configuration validation has been moved from `chainlink config validate` to `chainlink node validate`.
 
 ### Removed
 


### PR DESCRIPTION
 Move `validate` command to `chainlink node validate`. This is a breaking change.

This choice is motivated because `validate` necessarily requires configuration for it do to anything meaningful. A previous recent change, which has not be released, explicitly plumbed special handling for config and secret args to `validate`. 

It's much simpler to move `validate` because now configuration and secrets are scoped to `chainlink node` and therefore no special handling is required.