### PR TITLE
CCIP 393: Linking CCIP messages to transaction hashes in logs

### DIFF
--- a/core/chains/evm/txmgr/models.go
+++ b/core/chains/evm/txmgr/models.go
@@ -55,6 +55,11 @@ type EthTxMeta struct {
 	// Used only for forwarded txs, tracks the original destination address.
 	// When this is set, it indicates tx is forwarded through To address.
 	FwdrDestAddress *common.Address `json:"ForwarderDestAddress,omitempty"`
+
+	// MessageIDs is used by CCIP for tx to executed messages correlation in logs
+	MessageIDs []string `json:"MessageIDs,omitempty"`
+	// SeqNumbers is used by CCIP for tx to committed sequence numbers correlation in logs
+	SeqNumbers []uint64 `json:"SeqNumbers,omitempty"`
 }
 
 // TransmitCheckerSpec defines the check that should be performed before a transaction is submitted
@@ -261,6 +266,16 @@ func (e EthTx) GetLogger(lgr logger.Logger) logger.Logger {
 
 		if meta.FwdrDestAddress != nil {
 			lgr = lgr.With("FwdrDestAddress", *meta.FwdrDestAddress)
+		}
+
+		if len(meta.MessageIDs) > 0 {
+			for _, mid := range meta.MessageIDs {
+				lgr = lgr.With("messageID", mid)
+			}
+		}
+
+		if len(meta.SeqNumbers) > 1 {
+			lgr = lgr.With("SeqNumbersMin", meta.SeqNumbers[0], "SeqNumbersMax", meta.SeqNumbers[1])
 		}
 	}
 

--- a/core/services/ocrcommon/transmitter.go
+++ b/core/services/ocrcommon/transmitter.go
@@ -21,7 +21,7 @@ type txManager interface {
 }
 
 type Transmitter interface {
-	CreateEthTransaction(ctx context.Context, toAddress common.Address, payload []byte) error
+	CreateEthTransaction(ctx context.Context, toAddress common.Address, payload []byte, txMeta *txmgr.EthTxMeta) error
 	FromAddress() common.Address
 }
 
@@ -65,7 +65,7 @@ func NewTransmitter(
 	}, nil
 }
 
-func (t *transmitter) CreateEthTransaction(ctx context.Context, toAddress common.Address, payload []byte) error {
+func (t *transmitter) CreateEthTransaction(ctx context.Context, toAddress common.Address, payload []byte, txMeta *txmgr.EthTxMeta) error {
 
 	roundRobinFromAddress, err := t.keystore.GetRoundRobinAddress(t.chainID, t.fromAddresses...)
 	if err != nil {
@@ -80,6 +80,7 @@ func (t *transmitter) CreateEthTransaction(ctx context.Context, toAddress common
 		ForwarderAddress: t.forwarderAddress(),
 		Strategy:         t.strategy,
 		Checker:          t.checker,
+		Meta:             txMeta,
 	}, pg.WithParentCtx(ctx))
 	return errors.Wrap(err, "skipped OCR transmission")
 }

--- a/core/services/ocrcommon/transmitter_pipeline.go
+++ b/core/services/ocrcommon/transmitter_pipeline.go
@@ -64,7 +64,7 @@ func NewPipelineTransmitter(
 	}
 }
 
-func (t *pipelineTransmitter) CreateEthTransaction(ctx context.Context, toAddress common.Address, payload []byte) error {
+func (t *pipelineTransmitter) CreateEthTransaction(ctx context.Context, toAddress common.Address, payload []byte, _ *txmgr.EthTxMeta) error {
 	// t.strategy is ignored currently as pipeline does not support passing this (sc-55115)
 	vars := pipeline.NewVarsFrom(map[string]interface{}{
 		"jobSpec": map[string]interface{}{

--- a/core/services/ocrcommon/transmitter_pipeline_test.go
+++ b/core/services/ocrcommon/transmitter_pipeline_test.go
@@ -73,5 +73,5 @@ func Test_PipelineTransmitter_CreateEthTransaction(t *testing.T) {
 			run.State = pipeline.RunStatusCompleted
 		}).Once()
 
-	require.NoError(t, transmitter.CreateEthTransaction(testutils.Context(t), toAddress, payload))
+	require.NoError(t, transmitter.CreateEthTransaction(testutils.Context(t), toAddress, payload, nil))
 }

--- a/core/services/ocrcommon/transmitter_test.go
+++ b/core/services/ocrcommon/transmitter_test.go
@@ -59,7 +59,7 @@ func Test_DefaultTransmitter_CreateEthTransaction(t *testing.T) {
 		Meta:           nil,
 		Strategy:       strategy,
 	}, mock.Anything).Return(txmgr.EthTx{}, nil).Once()
-	require.NoError(t, transmitter.CreateEthTransaction(testutils.Context(t), toAddress, payload))
+	require.NoError(t, transmitter.CreateEthTransaction(testutils.Context(t), toAddress, payload, nil))
 }
 
 func Test_DefaultTransmitter_Forwarding_Enabled_CreateEthTransaction(t *testing.T) {
@@ -108,8 +108,8 @@ func Test_DefaultTransmitter_Forwarding_Enabled_CreateEthTransaction(t *testing.
 		Meta:           nil,
 		Strategy:       strategy,
 	}, mock.Anything).Return(txmgr.EthTx{}, nil).Once()
-	require.NoError(t, transmitter.CreateEthTransaction(testutils.Context(t), toAddress, payload))
-	require.NoError(t, transmitter.CreateEthTransaction(testutils.Context(t), toAddress, payload))
+	require.NoError(t, transmitter.CreateEthTransaction(testutils.Context(t), toAddress, payload, nil))
+	require.NoError(t, transmitter.CreateEthTransaction(testutils.Context(t), toAddress, payload, nil))
 }
 
 func Test_DefaultTransmitter_Forwarding_Enabled_CreateEthTransaction_Round_Robin_Error(t *testing.T) {
@@ -140,7 +140,7 @@ func Test_DefaultTransmitter_Forwarding_Enabled_CreateEthTransaction_Round_Robin
 		ethKeyStore,
 	)
 	require.NoError(t, err)
-	require.Error(t, transmitter.CreateEthTransaction(testutils.Context(t), toAddress, payload))
+	require.Error(t, transmitter.CreateEthTransaction(testutils.Context(t), toAddress, payload, nil))
 }
 
 func Test_DefaultTransmitter_Forwarding_Enabled_CreateEthTransaction_No_Keystore_Error(t *testing.T) {

--- a/core/services/relay/evm/contract_transmitter_test.go
+++ b/core/services/relay/evm/contract_transmitter_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/chains/evm/logpoller"
 	lpmocks "github.com/smartcontractkit/chainlink/core/chains/evm/logpoller/mocks"
 	evmmocks "github.com/smartcontractkit/chainlink/core/chains/evm/mocks"
+	"github.com/smartcontractkit/chainlink/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/core/logger"
 )
@@ -25,7 +26,7 @@ var sampleAddress = testutils.NewAddress()
 
 type mockTransmitter struct{}
 
-func (mockTransmitter) CreateEthTransaction(ctx context.Context, toAddress gethcommon.Address, payload []byte) error {
+func (mockTransmitter) CreateEthTransaction(ctx context.Context, toAddress gethcommon.Address, payload []byte, _ *txmgr.EthTxMeta) error {
 	return nil
 }
 func (mockTransmitter) FromAddress() gethcommon.Address { return sampleAddress }
@@ -44,7 +45,7 @@ func TestContractTransmitter(t *testing.T) {
 	c.On("CallContract", mock.Anything, mock.Anything, mock.Anything).Return(digestAndEpochDontScanLogs, nil).Once()
 	contractABI, _ := abi.JSON(strings.NewReader(ocr2aggregator.OCR2AggregatorABI))
 	lp.On("RegisterFilter", mock.Anything).Return(nil)
-	ot, err := NewOCRContractTransmitter(gethcommon.Address{}, c, contractABI, mockTransmitter{}, lp, lggr)
+	ot, err := NewOCRContractTransmitter(gethcommon.Address{}, c, contractABI, mockTransmitter{}, lp, lggr, nil)
 	require.NoError(t, err)
 	digest, epoch, err := ot.LatestConfigDigestAndEpoch(testutils.Context(t))
 	require.NoError(t, err)

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -341,6 +341,7 @@ func newContractTransmitter(lggr logger.Logger, rargs relaytypes.RelayArgs, tran
 		transmitter,
 		configWatcher.chain.LogPoller(),
 		lggr,
+		nil,
 	)
 }
 
@@ -388,6 +389,7 @@ func newPipelineContractTransmitter(lggr logger.Logger, rargs relaytypes.RelayAr
 		),
 		configWatcher.chain.LogPoller(),
 		lggr,
+		nil,
 	)
 }
 


### PR DESCRIPTION
This is an upstream PR for CCIP, for more information see https://github.com/smartcontractkit/chainlink-ccip/pull/616

**Changes**

- added new fields on tx meta for msg ids and seq numbers
- added `ReportToEthMetadata` to aid in custom tx metadata based on report