### PR TITLE
core/cmd: parse and print http errors

### DIFF
--- a/core/cmd/blocks_commands.go
+++ b/core/cmd/blocks_commands.go
@@ -71,11 +71,7 @@ func (cli *Client) ReplayFromBlock(c *clipkg.Context) (err error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		bytes, err2 := cli.parseResponse(resp)
-		if err2 != nil {
-			return errors.Wrap(err2, "parseResponse error")
-		}
-		return cli.errorOut(errors.New(string(bytes)))
+		return cli.errorOut(fmt.Errorf("error replaying: %w", httpError(resp)))
 	}
 
 	err = cli.printResponseBody(resp)

--- a/core/cmd/csa_keys_commands.go
+++ b/core/cmd/csa_keys_commands.go
@@ -218,7 +218,7 @@ func (cli *Client) ExportCSAKey(c *cli.Context) (err error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return cli.errorOut(errors.New("Error exporting"))
+		return cli.errorOut(fmt.Errorf("error exporting: %w", httpError(resp)))
 	}
 
 	keyJSON, err := io.ReadAll(resp.Body)

--- a/core/cmd/errors.go
+++ b/core/cmd/errors.go
@@ -1,0 +1,15 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+)
+
+func httpError(resp *http.Response) error {
+	errResult, err2 := io.ReadAll(resp.Body)
+	if err2 != nil {
+		return fmt.Errorf("status %d %q: error reading body %w", resp.StatusCode, http.StatusText(resp.StatusCode), err2)
+	}
+	return fmt.Errorf("status %d %q: %s", resp.StatusCode, http.StatusText(resp.StatusCode), string(errResult))
+}

--- a/core/cmd/eth_keys_commands.go
+++ b/core/cmd/eth_keys_commands.go
@@ -335,7 +335,7 @@ func (cli *Client) ExportETHKey(c *cli.Context) (err error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return cli.errorOut(errors.New("Error exporting"))
+		return cli.errorOut(fmt.Errorf("error exporting: %w", httpError(resp)))
 	}
 
 	keyJSON, err := io.ReadAll(resp.Body)
@@ -391,11 +391,7 @@ func (cli *Client) UpdateChainEVMKey(c *cli.Context) (err error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		resp, err := io.ReadAll(resp.Body)
-		if err != nil {
-			return cli.errorOut(errors.Errorf("Error resetting key: %s", err.Error()))
-		}
-		return cli.errorOut(errors.Errorf("Error resetting key: %s", resp))
+		return cli.errorOut(fmt.Errorf("error resetting key: %w", httpError(resp)))
 	}
 
 	return cli.renderAPIResponse(resp, &EthKeyPresenter{}, "🔑 Updated ETH key")

--- a/core/cmd/keys_commands.go
+++ b/core/cmd/keys_commands.go
@@ -238,7 +238,7 @@ func (cli *keysClient[K, P, P2]) ExportKey(c *cli.Context) (err error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return cli.errorOut(errors.New("Error exporting"))
+		return cli.errorOut(fmt.Errorf("error exporting: %w", httpError(resp)))
 	}
 
 	keyJSON, err := io.ReadAll(resp.Body)

--- a/core/cmd/ocr2_keys_commands.go
+++ b/core/cmd/ocr2_keys_commands.go
@@ -265,7 +265,7 @@ func (cli *Client) ExportOCR2Key(c *cli.Context) (err error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return cli.errorOut(errors.New("Error exporting"))
+		return cli.errorOut(fmt.Errorf("error exporting: %w", httpError(resp)))
 	}
 
 	keyJSON, err := io.ReadAll(resp.Body)

--- a/core/cmd/ocr_keys_commands.go
+++ b/core/cmd/ocr_keys_commands.go
@@ -257,7 +257,7 @@ func (cli *Client) ExportOCRKey(c *cli.Context) (err error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return cli.errorOut(errors.New("Error exporting"))
+		return cli.errorOut(fmt.Errorf("error exporting: %w", httpError(resp)))
 	}
 
 	keyJSON, err := io.ReadAll(resp.Body)

--- a/core/cmd/p2p_keys_commands.go
+++ b/core/cmd/p2p_keys_commands.go
@@ -253,7 +253,7 @@ func (cli *Client) ExportP2PKey(c *cli.Context) (err error) {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		return cli.errorOut(errors.New("Error exporting"))
+		return cli.errorOut(fmt.Errorf("error exporting: %w", httpError(resp)))
 	}
 
 	keyJSON, err := io.ReadAll(resp.Body)

--- a/core/cmd/vrf_keys_commands.go
+++ b/core/cmd/vrf_keys_commands.go
@@ -206,11 +206,7 @@ func (cli *Client) ExportVRFKey(c *cli.Context) error {
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		errResult, err2 := io.ReadAll(resp.Body)
-		if err2 != nil {
-			return cli.errorOut(errors.Errorf("error exporting status code %d error reading body %s", resp.StatusCode, err2))
-		}
-		return cli.errorOut(errors.Errorf("error exporting status code %d body %s", resp.StatusCode, string(errResult)))
+		return cli.errorOut(fmt.Errorf("error exporting: %w", httpError(resp)))
 	}
 
 	keyJSON, err := io.ReadAll(resp.Body)


### PR DESCRIPTION
Many commands (mostly key export) return a generic error in the case of non-200 status codes. This PR generalizes the vrf key logic which prints out the status code and the respond body. It may be appropriate to parse (or try at least) the response as json via `parseResponse`/`parseErrorResponseBody` too.