### PR TITLE
fix for logging crits on failing to start job services

### DIFF
--- a/core/services/job/spawner.go
+++ b/core/services/job/spawner.go
@@ -211,8 +211,6 @@ func (js *spawner) StartService(ctx context.Context, jb Job) error {
 		err = ms.Start(ctx, srv)
 		if err != nil {
 			js.lggr.Critical("Error starting service for job", "jobID", jb.ID, "error", err)
-			werr := pkgerrors.Wrapf(err, "failed to start service for job %d", jb.ID)
-			js.SvcErrBuffer.Append(werr)
 			return err
 		}
 		aj.services = append(aj.services, srv)


### PR DESCRIPTION
Failing to start a job service does not leave the node in critical condition and should not be logged as critical