### PR TITLE
core/services/pipeline: reject empty/blank pipelines

### DIFF
--- a/core/cmd/jobs_commands.go
+++ b/core/cmd/jobs_commands.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	"github.com/pkg/errors"
@@ -52,7 +53,7 @@ func initJobsSubCmds(client *Client) []cli.Command {
 	}
 }
 
-// JobRenderer wraps the JSONAPI Job Resource and adds rendering functionality
+// JobPresenter wraps the JSONAPI Job Resource and adds rendering functionality
 type JobPresenter struct {
 	JAID // This is needed to render the id for a JSONAPI Resource as normal JSON
 	presenters.JobResource
@@ -89,7 +90,10 @@ func (p JobPresenter) toRow(task string) []string {
 
 // GetTasks extracts the tasks from the dependency graph
 func (p JobPresenter) GetTasks() ([]string, error) {
-	types := []string{}
+	if strings.TrimSpace(p.PipelineSpec.DotDAGSource) == "" {
+		return nil, nil
+	}
+	var types []string
 	pipeline, err := pipeline.Parse(p.PipelineSpec.DotDAGSource)
 	if err != nil {
 		return nil, err

--- a/core/services/directrequest/validate_test.go
+++ b/core/services/directrequest/validate_test.go
@@ -47,8 +47,6 @@ func TestValidatedDirectRequestSpec_MinIncomingConfirmations(t *testing.T) {
 		type                = "directrequest"
 		schemaVersion       = 1
 		name                = "example eth request event spec"
-		observationSource   = """
-		"""
 		`
 
 		s, err := ValidatedDirectRequestSpec(toml)
@@ -65,8 +63,6 @@ func TestValidatedDirectRequestSpec_MinIncomingConfirmations(t *testing.T) {
 		schemaVersion       = 1
 		name                = "example eth request event spec"
 		minIncomingConfirmations = 100
-		observationSource   = """
-		"""
 		`
 
 		s, err := ValidatedDirectRequestSpec(toml)

--- a/core/services/job/job_orm_test.go
+++ b/core/services/job/job_orm_test.go
@@ -612,8 +612,15 @@ func TestORM_CreateJob_OCR2_DuplicatedContractAddress(t *testing.T) {
 	jb, err := ocr2validate.ValidatedOracleSpecToml(config, testspecs.OCR2EVMSpecMinimal)
 	require.NoError(t, err)
 
+	const juelsPerFeeCoinSource = `
+	ds          [type=http method=GET url="https://chain.link/ETH-USD"];
+	ds_parse    [type=jsonparse path="data.price" separator="."];
+	ds_multiply [type=multiply times=100];
+	ds -> ds_parse -> ds_multiply;`
+
 	jb.Name = null.StringFrom("Job 1")
 	jb.OCR2OracleSpec.TransmitterID = null.StringFrom(address.String())
+	jb.OCR2OracleSpec.PluginConfig["juelsPerFeeCoinSource"] = juelsPerFeeCoinSource
 
 	err = jobORM.CreateJob(&jb)
 	require.NoError(t, err)
@@ -623,6 +630,7 @@ func TestORM_CreateJob_OCR2_DuplicatedContractAddress(t *testing.T) {
 
 	jb2.Name = null.StringFrom("Job with same chain id & contract address")
 	jb2.OCR2OracleSpec.TransmitterID = null.StringFrom(address.String())
+	jb.OCR2OracleSpec.PluginConfig["juelsPerFeeCoinSource"] = juelsPerFeeCoinSource
 
 	err = jobORM.CreateJob(&jb2)
 	require.Error(t, err)
@@ -631,8 +639,8 @@ func TestORM_CreateJob_OCR2_DuplicatedContractAddress(t *testing.T) {
 	require.NoError(t, err)
 	jb3.Name = null.StringFrom("Job with different chain id & same contract address")
 	jb3.OCR2OracleSpec.TransmitterID = null.StringFrom(address.String())
-
 	jb3.OCR2OracleSpec.RelayConfig["chainID"] = customChainID.Int64()
+	jb.OCR2OracleSpec.PluginConfig["juelsPerFeeCoinSource"] = juelsPerFeeCoinSource
 
 	err = jobORM.CreateJob(&jb3)
 	require.Error(t, err)

--- a/core/services/job/validate_test.go
+++ b/core/services/job/validate_test.go
@@ -57,7 +57,6 @@ schemaVersion=1
 			spec: `
 type="vrf"
 schemaVersion=1
-observationSource=""
 `,
 			assertion: func(t *testing.T, err error) {
 				require.True(t, errors.Is(errors.Cause(err), ErrNoPipelineSpec))

--- a/core/services/ocr2/plugins/median/config/config_test.go
+++ b/core/services/ocr2/plugins/median/config/config_test.go
@@ -1,0 +1,22 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidatePluginConfig(t *testing.T) {
+	for _, s := range []struct {
+		name     string
+		pipeline string
+	}{
+		{"empty", ""},
+		{"blank", " "},
+		{"foo", "foo"},
+	} {
+		t.Run(s.name, func(t *testing.T) {
+			assert.Error(t, ValidatePluginConfig(PluginConfig{JuelsPerFeeCoinPipeline: s.pipeline}))
+		})
+	}
+}

--- a/core/services/pipeline/graph.go
+++ b/core/services/pipeline/graph.go
@@ -209,6 +209,9 @@ func (p *Pipeline) ByDotID(id string) Task {
 }
 
 func Parse(text string) (*Pipeline, error) {
+	if strings.TrimSpace(text) == "" {
+		return nil, errors.New("empty pipeline")
+	}
 	g := NewGraph()
 	err := g.UnmarshalText([]byte(text))
 

--- a/core/services/pipeline/graph_test.go
+++ b/core/services/pipeline/graph_test.go
@@ -3,6 +3,7 @@ package pipeline_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"gonum.org/v1/gonum/graph"
 
@@ -248,4 +249,21 @@ func TestGraph_ImplicitDependencies(t *testing.T) {
 	require.True(t, g.HasEdgeFromTo(nodes["a"], nodes["b"]))
 	require.True(t, g.HasEdgeFromTo(nodes["b"], nodes["c"]))
 	require.True(t, g.HasEdgeFromTo(nodes["c"], nodes["d"]))
+}
+
+func TestParse(t *testing.T) {
+	for _, s := range []struct {
+		name     string
+		pipeline string
+	}{
+		{"empty", ""},
+		{"blank", " "},
+		{"foo", "foo"},
+	} {
+		t.Run(s.name, func(t *testing.T) {
+			_, err := pipeline.Parse(s.pipeline)
+			assert.Error(t, err)
+		})
+	}
+
 }

--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -35,8 +35,8 @@ type Runner interface {
 	Run(ctx context.Context, run *Run, l logger.Logger, saveSuccessfulTaskRuns bool, fn func(tx pg.Queryer) error) (incomplete bool, err error)
 	ResumeRun(taskID uuid.UUID, value interface{}, err error) error
 
-	// We expect spec.JobID and spec.JobName to be set for logging/prometheus.
 	// ExecuteRun executes a new run in-memory according to a spec and returns the results.
+	// We expect spec.JobID and spec.JobName to be set for logging/prometheus.
 	ExecuteRun(ctx context.Context, spec Spec, vars Vars, l logger.Logger) (run Run, trrs TaskRunResults, err error)
 	// InsertFinishedRun saves the run results in the database.
 	InsertFinishedRun(run *Run, saveSuccessfulTaskRuns bool, qopts ...pg.QOpt) error

--- a/core/services/vrf/listener_v2.go
+++ b/core/services/vrf/listener_v2.go
@@ -1041,13 +1041,14 @@ func (lsn *listenerV2) simulateFulfillment(
 
 		return res
 	}
-	if len(trrs.FinalResult(lg).Values) != 1 {
-		res.err = errors.Errorf("unexpected number of outputs, expected 1, was %d", len(trrs.FinalResult(lg).Values))
+	finalResult := trrs.FinalResult(lg)
+	if len(finalResult.Values) != 1 {
+		res.err = errors.Errorf("unexpected number of outputs, expected 1, was %d", len(finalResult.Values))
 		return res
 	}
 
 	// Run succeeded, we expect a byte array representing the billing amount
-	b, ok := trrs.FinalResult(lg).Values[0].([]uint8)
+	b, ok := finalResult.Values[0].([]uint8)
 	if !ok {
 		res.err = errors.New("expected []uint8 final result")
 		return res


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCF-2166
Add some validation to `pipeline.Parse` to reject empty/blank pipelines instead of running them as no-ops and leading to `FinalResult` lookup failure.