### PR TITLE
make feeds manager plugin optional in gql

### DIFF
--- a/core/web/schema/type/feeds_manager.graphql
+++ b/core/web/schema/type/feeds_manager.graphql
@@ -51,7 +51,7 @@ type OCR2JobConfig {
 	multiaddr: String
 	p2pPeerID: String
 	keyBundleID: String
-	plugins: Plugins!
+	plugins: Plugins
 }
 
 # FeedsManagerPayload defines the response to fetch a single feeds manager by id


### PR DESCRIPTION
This is breaking the frontend schema until fully implemented 