### PR TITLE
core/chains: simplify nodes

### DIFF
--- a/core/chains/chain_set.go
+++ b/core/chains/chain_set.go
@@ -25,17 +25,16 @@ type Chains[I ID] interface {
 	Index(offset, limit int) ([]ChainConfig, int, error)
 }
 
-// Nodes is a generic interface for Node configuration.
-type Nodes[I ID, N Node] interface {
-	GetNodes(ctx context.Context, offset, limit int) (nodes []N, count int, err error)
-	GetNodesForChain(ctx context.Context, chainID I, offset, limit int) (nodes []N, count int, err error)
+// Nodes is an interface for node configuration and state.
+type Nodes interface {
+	NodeStatuses(ctx context.Context, offset, limit int, chainIDs ...string) (nodes []NodeStatus, count int, err error)
 }
 
 // ChainSet manages a live set of ChainService instances.
-type ChainSet[I ID, N Node, S ChainService] interface {
+type ChainSet[I ID, S ChainService] interface {
 	services.ServiceCtx
 	Chains[I]
-	Nodes[I, N]
+	Nodes
 
 	Name() string
 	HealthReport() map[string]error
@@ -55,44 +54,38 @@ type ChainSetOpts[I ID, N Node] interface {
 	ConfigsAndLogger() (Configs[I, N], logger.Logger)
 }
 
-type chainSet[I ID, N Node, S ChainService] struct {
+type chainSet[N Node, S ChainService] struct {
 	utils.StartStopOnce
-	opts     ChainSetOpts[I, N]
-	formatID func(I) string
-	orm      Configs[I, N]
-	lggr     logger.Logger
-	chains   map[string]S
+	opts   ChainSetOpts[string, N]
+	orm    Configs[string, N]
+	lggr   logger.Logger
+	chains map[string]S
 }
 
 // NewChainSet returns a new immutable ChainSet for the given ChainSetOpts.
-func NewChainSet[I ID, N Node, S ChainService](chains map[string]S,
-	opts ChainSetOpts[I, N], formatID func(I) string,
-) (ChainSet[I, N, S], error) {
+func NewChainSet[N Node, S ChainService](
+	chains map[string]S,
+	opts ChainSetOpts[string, N],
+) (ChainSet[string, S], error) {
 	if err := opts.Validate(); err != nil {
 		return nil, err
 	}
 	cfgs, lggr := opts.ConfigsAndLogger()
-	cs := chainSet[I, N, S]{
-		opts:     opts,
-		formatID: formatID,
-		orm:      cfgs,
-		lggr:     lggr.Named("ChainSet"),
-		chains:   chains,
+	cs := chainSet[N, S]{
+		opts:   opts,
+		orm:    cfgs,
+		lggr:   lggr.Named("ChainSet"),
+		chains: chains,
 	}
 
 	return &cs, nil
 }
 
-func (c *chainSet[I, N, S]) Chain(ctx context.Context, id I) (s S, err error) {
-	sid := c.formatID(id)
-	if sid == "" {
-		err = ErrChainIDEmpty
-		return
-	}
+func (c *chainSet[N, S]) Chain(ctx context.Context, id string) (s S, err error) {
 	if err = c.StartStopOnce.Ready(); err != nil {
 		return
 	}
-	ch, ok := c.chains[sid]
+	ch, ok := c.chains[id]
 	if !ok {
 		err = ErrNotFound
 		return
@@ -100,7 +93,7 @@ func (c *chainSet[I, N, S]) Chain(ctx context.Context, id I) (s S, err error) {
 	return ch, nil
 }
 
-func (c *chainSet[I, N, S]) Show(id I) (cfg ChainConfig, err error) {
+func (c *chainSet[N, S]) Show(id string) (cfg ChainConfig, err error) {
 	var cs []ChainConfig
 	cs, _, err = c.orm.Chains(0, -1, id)
 	if err != nil {
@@ -119,19 +112,15 @@ func (c *chainSet[I, N, S]) Show(id I) (cfg ChainConfig, err error) {
 	return
 }
 
-func (c *chainSet[I, N, S]) Index(offset, limit int) ([]ChainConfig, int, error) {
+func (c *chainSet[N, S]) Index(offset, limit int) ([]ChainConfig, int, error) {
 	return c.orm.Chains(offset, limit)
 }
 
-func (c *chainSet[I, N, S]) GetNodes(ctx context.Context, offset, limit int) (nodes []N, count int, err error) {
-	return c.orm.Nodes(offset, limit)
+func (c *chainSet[N, S]) NodeStatuses(ctx context.Context, offset, limit int, chainIDs ...string) (nodes []NodeStatus, count int, err error) {
+	return c.orm.NodeStatusesPaged(offset, limit, chainIDs...)
 }
 
-func (c *chainSet[I, N, S]) GetNodesForChain(ctx context.Context, chainID I, offset, limit int) (nodes []N, count int, err error) {
-	return c.orm.NodesForChain(chainID, offset, limit)
-}
-
-func (c *chainSet[I, N, S]) Start(ctx context.Context) error {
+func (c *chainSet[N, S]) Start(ctx context.Context) error {
 	return c.StartOnce("ChainSet", func() error {
 		c.lggr.Debug("Starting")
 
@@ -146,7 +135,7 @@ func (c *chainSet[I, N, S]) Start(ctx context.Context) error {
 	})
 }
 
-func (c *chainSet[I, N, S]) Close() error {
+func (c *chainSet[N, S]) Close() error {
 	return c.StopOnce("ChainSet", func() (err error) {
 		c.lggr.Debug("Stopping")
 
@@ -157,7 +146,7 @@ func (c *chainSet[I, N, S]) Close() error {
 	})
 }
 
-func (c *chainSet[I, N, S]) Ready() (err error) {
+func (c *chainSet[N, S]) Ready() (err error) {
 	err = c.StartStopOnce.Ready()
 	for _, c := range c.chains {
 		err = multierr.Combine(err, c.Ready())
@@ -165,11 +154,11 @@ func (c *chainSet[I, N, S]) Ready() (err error) {
 	return
 }
 
-func (c *chainSet[I, N, S]) Name() string {
+func (c *chainSet[N, S]) Name() string {
 	return c.lggr.Name()
 }
 
-func (c *chainSet[I, N, S]) HealthReport() map[string]error {
+func (c *chainSet[N, S]) HealthReport() map[string]error {
 	report := map[string]error{c.Name(): c.StartStopOnce.Healthy()}
 	for _, c := range c.chains {
 		maps.Copy(report, c.HealthReport())

--- a/core/chains/config.go
+++ b/core/chains/config.go
@@ -13,10 +13,11 @@ type ChainConfigs[I ID] interface {
 }
 
 type NodeConfigs[I ID, N Node] interface {
-	GetNodesByChainIDs(chainIDs []I) (nodes []N, err error)
-	NodeNamed(string) (N, error)
-	Nodes(offset, limit int) (nodes []N, count int, err error)
-	NodesForChain(chainID I, offset, limit int) (nodes []N, count int, err error)
+	Node(name string) (N, error)
+	Nodes(chainID I) (nodes []N, err error)
+
+	NodeStatus(name string) (NodeStatus, error)
+	NodeStatusesPaged(offset, limit int, chainIDs ...string) (nodes []NodeStatus, count int, err error)
 }
 
 // Configs holds chain and node configurations.
@@ -29,6 +30,13 @@ type ChainConfig struct {
 	ID      string
 	Enabled bool
 	Cfg     string // TOML
+}
+
+type NodeStatus struct {
+	ChainID string
+	Name    string
+	Config  string // TOML
+	State   string
 }
 
 func EnsureChains[I ID](q pg.Q, prefix string, ids []I) (err error) {

--- a/core/chains/cosmos/chain.go
+++ b/core/chains/cosmos/chain.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
-	"math"
 	"math/big"
 	"time"
 
@@ -94,11 +93,11 @@ func (c *chain) Reader(name string) (cosmosclient.Reader, error) {
 func (c *chain) getClient(name string) (cosmosclient.ReaderWriter, error) {
 	var node db.Node
 	if name == "" { // Any node
-		nodes, cnt, err := c.cfgs.NodesForChain(c.id, 0, math.MaxInt)
+		nodes, err := c.cfgs.Nodes(c.id)
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to get nodes")
 		}
-		if cnt == 0 {
+		if len(nodes) == 0 {
 			return nil, errors.New("no nodes available")
 		}
 		nodeIndex, err := rand.Int(rand.Reader, big.NewInt(int64(len(nodes))))
@@ -108,7 +107,7 @@ func (c *chain) getClient(name string) (cosmosclient.ReaderWriter, error) {
 		node = nodes[nodeIndex.Int64()]
 	} else { // Named node
 		var err error
-		node, err = c.cfgs.NodeNamed(name)
+		node, err = c.cfgs.Node(name)
 		if err != nil {
 			return nil, errors.Wrapf(err, "failed to get node named %s", name)
 		}

--- a/core/chains/cosmos/chain_set.go
+++ b/core/chains/cosmos/chain_set.go
@@ -77,7 +77,7 @@ func (o *ChainSetOpts) NewTOMLChain(cfg *CosmosConfig) (adapters.Chain, error) {
 // ChainSet extends adapters.ChainSet with mutability and exposes the underlying Configs.
 type ChainSet interface {
 	adapters.ChainSet
-	chains.Nodes[string, db.Node]
+	chains.Nodes
 	chains.Chains[string]
 }
 
@@ -98,5 +98,5 @@ func NewChainSet(opts ChainSetOpts, cfgs CosmosConfigs) (ChainSet, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load some Cosmos chains")
 	}
-	return chains.NewChainSet[string, db.Node, adapters.Chain](solChains, &opts, func(s string) string { return s })
+	return chains.NewChainSet[db.Node, adapters.Chain](solChains, &opts)
 }

--- a/core/chains/cosmos/config.go
+++ b/core/chains/cosmos/config.go
@@ -105,41 +105,88 @@ func (cs CosmosConfigs) Node(name string) (n db.Node, err error) {
 			}
 		}
 	}
+	err = chains.ErrNotFound
 	return
 }
 
-func (cs CosmosConfigs) Nodes() (ns []db.Node) {
-	for i := range cs {
-		for _, n := range cs[i].Nodes {
-			if n == nil {
-				continue
-			}
-			ns = append(ns, legacyNode(n, *cs[i].ChainID))
+func (cs CosmosConfigs) nodes(chainID string) (ns CosmosNodes) {
+	for _, c := range cs {
+		if *c.ChainID == chainID {
+			return c.Nodes
 		}
 	}
-	return
+	return nil
 }
 
-func (cs CosmosConfigs) NodesByID(chainIDs ...string) (ns []db.Node) {
-	for i := range cs {
-		var match bool
-		for _, id := range chainIDs {
-			if id == *cs[i].ChainID {
-				match = true
-				break
-			}
-		}
-		if !match {
+func (cs CosmosConfigs) Nodes(chainID string) (ns []db.Node, err error) {
+	nodes := cs.nodes(chainID)
+	if nodes == nil {
+		err = chains.ErrNotFound
+		return
+	}
+	for _, n := range nodes {
+		if n == nil {
 			continue
 		}
+		ns = append(ns, legacyNode(n, chainID))
+	}
+	return
+
+}
+
+func (cs CosmosConfigs) NodeStatus(name string) (n chains.NodeStatus, err error) {
+	for i := range cs {
 		for _, n := range cs[i].Nodes {
+			if n.Name != nil && *n.Name == name {
+				return nodeStatus(n, *cs[i].ChainID)
+			}
+		}
+	}
+	err = chains.ErrNotFound
+	return
+}
+
+func (cs CosmosConfigs) NodeStatuses(chainIDs ...string) (ns []chains.NodeStatus, err error) {
+	if len(chainIDs) == 0 {
+		for i := range cs {
+			for _, n := range cs[i].Nodes {
+				if n == nil {
+					continue
+				}
+				n2, err := nodeStatus(n, *cs[i].ChainID)
+				if err != nil {
+					return nil, err
+				}
+				ns = append(ns, n2)
+			}
+		}
+		return
+	}
+	for _, id := range chainIDs {
+		for _, n := range cs.nodes(id) {
 			if n == nil {
 				continue
 			}
-			ns = append(ns, legacyNode(n, *cs[i].ChainID))
+			n2, err := nodeStatus(n, id)
+			if err != nil {
+				return nil, err
+			}
+			ns = append(ns, n2)
 		}
 	}
 	return
+}
+
+func nodeStatus(n *coscfg.Node, chainID string) (chains.NodeStatus, error) {
+	var s chains.NodeStatus
+	s.ChainID = chainID
+	s.Name = *n.Name
+	b, err := toml.Marshal(n)
+	if err != nil {
+		return chains.NodeStatus{}, err
+	}
+	s.Config = string(b)
+	return s, nil
 }
 
 type CosmosNodes []*coscfg.Node

--- a/core/chains/evm/chain_set.go
+++ b/core/chains/evm/chain_set.go
@@ -37,7 +37,7 @@ var _ ChainSet = &chainSet{}
 type ChainSet interface {
 	services.ServiceCtx
 	chains.Chains[utils.Big]
-	chains.Nodes[utils.Big, types.Node]
+	chains.Nodes
 
 	Get(id *big.Int) (Chain, error)
 
@@ -46,8 +46,6 @@ type ChainSet interface {
 	ChainCount() int
 
 	Configs() types.Configs
-
-	GetNodesByChainIDs(ctx context.Context, chainIDs []utils.Big) (nodes []types.Node, err error)
 }
 
 type chainSet struct {
@@ -85,6 +83,7 @@ func (cll *chainSet) Start(ctx context.Context) error {
 	cll.logger.Infow(fmt.Sprintf("EVM: Started %d/%d chains, default chain ID is %s", len(cll.startedChains), len(cll.Chains()), defChainID), "startedEvmChainIDs", evmChainIDs)
 	return nil
 }
+
 func (cll *chainSet) Close() (err error) {
 	cll.logger.Debug("EVM: stopping")
 	for _, c := range cll.startedChains {
@@ -188,20 +187,8 @@ func (cll *chainSet) Configs() types.Configs {
 	return cll.opts.Configs
 }
 
-func (cll *chainSet) GetNodes(ctx context.Context, offset, limit int) (nodes []types.Node, count int, err error) {
-	nodes, count, err = cll.opts.Configs.Nodes(offset, limit)
-	if err != nil {
-		err = errors.Wrap(err, "GetNodes failed to load nodes from DB")
-		return
-	}
-	for i := range nodes {
-		cll.addStateToNode(&nodes[i])
-	}
-	return
-}
-
-func (cll *chainSet) GetNodesForChain(ctx context.Context, chainID utils.Big, offset, limit int) (nodes []types.Node, count int, err error) {
-	nodes, count, err = cll.opts.Configs.NodesForChain(chainID, offset, limit)
+func (cll *chainSet) NodeStatuses(ctx context.Context, offset, limit int, chainIDs ...string) (nodes []chains.NodeStatus, count int, err error) {
+	nodes, count, err = cll.opts.Configs.NodeStatusesPaged(offset, limit, chainIDs...)
 	if err != nil {
 		err = errors.Wrap(err, "GetNodesForChain failed to load nodes from DB")
 		return
@@ -212,21 +199,9 @@ func (cll *chainSet) GetNodesForChain(ctx context.Context, chainID utils.Big, of
 	return
 }
 
-func (cll *chainSet) GetNodesByChainIDs(ctx context.Context, chainIDs []utils.Big) (nodes []types.Node, err error) {
-	nodes, err = cll.opts.Configs.GetNodesByChainIDs(chainIDs)
-	if err != nil {
-		err = errors.Wrap(err, "GetNodesForChain failed to load nodes from DB")
-		return
-	}
-	for i := range nodes {
-		cll.addStateToNode(&nodes[i])
-	}
-	return
-}
-
-func (cll *chainSet) addStateToNode(n *types.Node) {
+func (cll *chainSet) addStateToNode(n *chains.NodeStatus) {
 	cll.chainsMu.RLock()
-	chain, exists := cll.chains[n.EVMChainID.String()]
+	chain, exists := cll.chains[n.ChainID]
 	cll.chainsMu.RUnlock()
 	if !exists {
 		// The EVM chain is disabled

--- a/core/chains/evm/chain_set_test.go
+++ b/core/chains/evm/chain_set_test.go
@@ -20,7 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
-func TestAddClose(t *testing.T) {
+func TestChainSet(t *testing.T) {
 	t.Parallel()
 
 	newId := testutils.NewRandomEVMChainID()

--- a/core/chains/evm/config/v2/config.go
+++ b/core/chains/evm/config/v2/config.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"database/sql"
 	"fmt"
 	"net/url"
 
@@ -9,7 +8,6 @@ import (
 	"github.com/pelletier/go-toml/v2"
 	"github.com/shopspring/decimal"
 	"go.uber.org/multierr"
-	"golang.org/x/exp/constraints"
 	"golang.org/x/exp/slices"
 	"gopkg.in/guregu/null.v4"
 
@@ -124,7 +122,18 @@ func (cs EVMConfigs) Node(name string) (types.Node, error) {
 			}
 		}
 	}
-	return types.Node{}, sql.ErrNoRows
+	return types.Node{}, chains.ErrNotFound
+}
+
+func (cs EVMConfigs) NodeStatus(name string) (chains.NodeStatus, error) {
+	for i := range cs {
+		for _, n := range cs[i].Nodes {
+			if n.Name != nil && *n.Name == name {
+				return nodeStatus(n, cs[i].ChainID.String())
+			}
+		}
+	}
+	return chains.NodeStatus{}, chains.ErrNotFound
 }
 
 func legacyNode(n *Node, chainID *utils.Big) (v2 types.Node) {
@@ -142,35 +151,69 @@ func legacyNode(n *Node, chainID *utils.Big) (v2 types.Node) {
 	return
 }
 
-func (cs EVMConfigs) Nodes() (ns []types.Node) {
-	for i := range cs {
-		for _, n := range cs[i].Nodes {
-			if n == nil {
-				continue
-			}
-			ns = append(ns, legacyNode(n, cs[i].ChainID))
+func nodeStatus(n *Node, chainID string) (chains.NodeStatus, error) {
+	var s chains.NodeStatus
+	s.ChainID = chainID
+	s.Name = *n.Name
+	b, err := toml.Marshal(n)
+	if err != nil {
+		return chains.NodeStatus{}, err
+	}
+	s.Config = string(b)
+	return s, nil
+}
+
+func (cs EVMConfigs) nodes(chainID string) (ns EVMNodes) {
+	for _, c := range cs {
+		if c.ChainID.String() == chainID {
+			return c.Nodes
 		}
+	}
+	return nil
+}
+
+func (cs EVMConfigs) Nodes(chainID utils.Big) (ns []types.Node, err error) {
+	id := chainID.String()
+	nodes := cs.nodes(id)
+	if nodes == nil {
+		err = chains.ErrNotFound
+		return
+	}
+	for _, n := range nodes {
+		if n == nil {
+			continue
+		}
+		ns = append(ns, legacyNode(n, &chainID))
 	}
 	return
 }
 
-func (cs EVMConfigs) NodesByID(chainIDs ...utils.Big) (ns []types.Node) {
-	for i := range cs {
-		var match bool
-		for _, chainID := range chainIDs {
-			if chainID.Cmp(cs[i].ChainID) == 0 {
-				match = true
-				break
+func (cs EVMConfigs) NodeStatuses(chainIDs ...string) (ns []chains.NodeStatus, err error) {
+	if len(chainIDs) == 0 {
+		for i := range cs {
+			for _, n := range cs[i].Nodes {
+				if n == nil {
+					continue
+				}
+				n2, err := nodeStatus(n, cs[i].ChainID.String())
+				if err != nil {
+					return nil, err
+				}
+				ns = append(ns, n2)
 			}
 		}
-		if !match {
-			continue
-		}
-		for _, n := range cs[i].Nodes {
+		return
+	}
+	for _, id := range chainIDs {
+		for _, n := range cs.nodes(id) {
 			if n == nil {
 				continue
 			}
-			ns = append(ns, legacyNode(n, cs[i].ChainID))
+			n2, err := nodeStatus(n, id)
+			if err != nil {
+				return nil, err
+			}
+			ns = append(ns, n2)
 		}
 	}
 	return
@@ -730,11 +773,4 @@ func (n *Node) SetFrom(f *Node) {
 	if f.SendOnly != nil {
 		n.SendOnly = f.SendOnly
 	}
-}
-
-func nullIntFromPtr[I constraints.Integer](i *I) null.Int {
-	if i == nil {
-		return null.Int{}
-	}
-	return null.IntFrom(int64(*i))
 }

--- a/core/chains/evm/mocks/chain_set.go
+++ b/core/chains/evm/mocks/chain_set.go
@@ -134,98 +134,6 @@ func (_m *ChainSet) Get(id *big.Int) (evm.Chain, error) {
 	return r0, r1
 }
 
-// GetNodes provides a mock function with given fields: ctx, offset, limit
-func (_m *ChainSet) GetNodes(ctx context.Context, offset int, limit int) ([]types.Node, int, error) {
-	ret := _m.Called(ctx, offset, limit)
-
-	var r0 []types.Node
-	var r1 int
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, int, int) ([]types.Node, int, error)); ok {
-		return rf(ctx, offset, limit)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, int, int) []types.Node); ok {
-		r0 = rf(ctx, offset, limit)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]types.Node)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, int, int) int); ok {
-		r1 = rf(ctx, offset, limit)
-	} else {
-		r1 = ret.Get(1).(int)
-	}
-
-	if rf, ok := ret.Get(2).(func(context.Context, int, int) error); ok {
-		r2 = rf(ctx, offset, limit)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
-}
-
-// GetNodesByChainIDs provides a mock function with given fields: ctx, chainIDs
-func (_m *ChainSet) GetNodesByChainIDs(ctx context.Context, chainIDs []utils.Big) ([]types.Node, error) {
-	ret := _m.Called(ctx, chainIDs)
-
-	var r0 []types.Node
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, []utils.Big) ([]types.Node, error)); ok {
-		return rf(ctx, chainIDs)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, []utils.Big) []types.Node); ok {
-		r0 = rf(ctx, chainIDs)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]types.Node)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, []utils.Big) error); ok {
-		r1 = rf(ctx, chainIDs)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// GetNodesForChain provides a mock function with given fields: ctx, chainID, offset, limit
-func (_m *ChainSet) GetNodesForChain(ctx context.Context, chainID utils.Big, offset int, limit int) ([]types.Node, int, error) {
-	ret := _m.Called(ctx, chainID, offset, limit)
-
-	var r0 []types.Node
-	var r1 int
-	var r2 error
-	if rf, ok := ret.Get(0).(func(context.Context, utils.Big, int, int) ([]types.Node, int, error)); ok {
-		return rf(ctx, chainID, offset, limit)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, utils.Big, int, int) []types.Node); ok {
-		r0 = rf(ctx, chainID, offset, limit)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]types.Node)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, utils.Big, int, int) int); ok {
-		r1 = rf(ctx, chainID, offset, limit)
-	} else {
-		r1 = ret.Get(1).(int)
-	}
-
-	if rf, ok := ret.Get(2).(func(context.Context, utils.Big, int, int) error); ok {
-		r2 = rf(ctx, chainID, offset, limit)
-	} else {
-		r2 = ret.Error(2)
-	}
-
-	return r0, r1, r2
-}
-
 // HealthReport provides a mock function with given fields:
 func (_m *ChainSet) HealthReport() map[string]error {
 	ret := _m.Called()
@@ -287,6 +195,46 @@ func (_m *ChainSet) Name() string {
 	}
 
 	return r0
+}
+
+// NodeStatuses provides a mock function with given fields: ctx, offset, limit, chainIDs
+func (_m *ChainSet) NodeStatuses(ctx context.Context, offset int, limit int, chainIDs ...string) ([]chains.NodeStatus, int, error) {
+	_va := make([]interface{}, len(chainIDs))
+	for _i := range chainIDs {
+		_va[_i] = chainIDs[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, ctx, offset, limit)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
+
+	var r0 []chains.NodeStatus
+	var r1 int
+	var r2 error
+	if rf, ok := ret.Get(0).(func(context.Context, int, int, ...string) ([]chains.NodeStatus, int, error)); ok {
+		return rf(ctx, offset, limit, chainIDs...)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, int, int, ...string) []chains.NodeStatus); ok {
+		r0 = rf(ctx, offset, limit, chainIDs...)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]chains.NodeStatus)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, int, int, ...string) int); ok {
+		r1 = rf(ctx, offset, limit, chainIDs...)
+	} else {
+		r1 = ret.Get(1).(int)
+	}
+
+	if rf, ok := ret.Get(2).(func(context.Context, int, int, ...string) error); ok {
+		r2 = rf(ctx, offset, limit, chainIDs...)
+	} else {
+		r2 = ret.Error(2)
+	}
+
+	return r0, r1, r2
 }
 
 // Ready provides a mock function with given fields:

--- a/core/chains/evm/types/types.go
+++ b/core/chains/evm/types/types.go
@@ -22,15 +22,13 @@ type Configs interface {
 }
 
 type Node struct {
-	ID         int32
 	Name       string
 	EVMChainID utils.Big
-	WSURL      null.String `db:"ws_url"`
-	HTTPURL    null.String `db:"http_url"`
+	WSURL      null.String
+	HTTPURL    null.String
 	SendOnly   bool
-	// State doesn't exist in the DB, it's used to hold an in-memory state for
-	// rendering
-	State string `db:"-"`
+
+	State string
 }
 
 // Receipt represents an ethereum receipt.

--- a/core/chains/solana/chain_set.go
+++ b/core/chains/solana/chain_set.go
@@ -60,7 +60,7 @@ func (o *ChainSetOpts) NewTOMLChain(cfg *SolanaConfig) (solana.Chain, error) {
 type ChainSet interface {
 	solana.ChainSet
 	chains.Chains[string]
-	chains.Nodes[string, db.Node]
+	chains.Nodes
 }
 
 func NewChainSet(opts ChainSetOpts, cfgs SolanaConfigs) (ChainSet, error) {
@@ -80,5 +80,5 @@ func NewChainSet(opts ChainSetOpts, cfgs SolanaConfigs) (ChainSet, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load some Solana chains")
 	}
-	return chains.NewChainSet[string, db.Node, solana.Chain](solChains, &opts, func(s string) string { return s })
+	return chains.NewChainSet[db.Node, solana.Chain](solChains, &opts)
 }

--- a/core/chains/solana/chain_test.go
+++ b/core/chains/solana/chain_test.go
@@ -48,7 +48,7 @@ func TestSolanaChain_GetClient(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	testChain := chain{
 		id:          "devnet",
-		nodes:       solORM.NodesForChain,
+		nodes:       solORM.Nodes,
 		cfg:         config.NewConfig(db.ChainCfg{}, lggr),
 		lggr:        logger.TestLogger(t),
 		clientCache: map[string]*verifiedCachedClient{},
@@ -219,20 +219,18 @@ type mockConfigs struct {
 	nodesForChain []db.Node
 }
 
-func (m *mockConfigs) GetNodesByChainIDs(chainIDs []string) (nodes []db.Node, err error) {
-	panic("implement me")
-}
-
-func (m *mockConfigs) NodesForChain(chainID string, offset, limit int) (nodes []db.Node, count int, err error) {
-	return m.nodesForChain, len(m.nodesForChain), nil
+func (m *mockConfigs) Nodes(chainID string) (nodes []db.Node, err error) {
+	return m.nodesForChain, nil
 }
 
 func (m *mockConfigs) Chains(offset, limit int, ids ...string) ([]chains.ChainConfig, int, error) {
 	panic("unimplemented")
 }
 
-func (m *mockConfigs) NodeNamed(s string) (db.Node, error) { panic("unimplemented") }
+func (m *mockConfigs) Node(s string) (db.Node, error) { panic("unimplemented") }
 
-func (m *mockConfigs) Nodes(offset, limit int) (nodes []db.Node, count int, err error) {
+func (m *mockConfigs) NodeStatus(s string) (chains.NodeStatus, error) { panic("unimplemented") }
+
+func (m *mockConfigs) NodeStatusesPaged(offset, limit int, chainIDs ...string) (nodes []chains.NodeStatus, count int, err error) {
 	panic("unimplemented")
 }

--- a/core/chains/starknet/chain.go
+++ b/core/chains/starknet/chain.go
@@ -2,7 +2,6 @@ package starknet
 
 import (
 	"context"
-	"math"
 	"math/rand"
 	"time"
 
@@ -73,11 +72,11 @@ func (c *chain) Reader() (starknet.Reader, error) {
 func (c *chain) getClient() (*starknet.Client, error) {
 	var node db.Node
 	var client *starknet.Client
-	nodes, cnt, err := c.cfgs.NodesForChain(c.id, 0, math.MaxInt)
+	nodes, err := c.cfgs.Nodes(c.id)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to get nodes")
 	}
-	if cnt == 0 {
+	if len(nodes) == 0 {
 		return nil, errors.New("no nodes available")
 	}
 	rand.Seed(time.Now().Unix()) // seed randomness otherwise it will return the same each time

--- a/core/chains/starknet/chain_set.go
+++ b/core/chains/starknet/chain_set.go
@@ -62,7 +62,7 @@ func (o *ChainSetOpts) NewTOMLChain(cfg *StarknetConfig) (starkchain.Chain, erro
 type ChainSet interface {
 	starkchain.ChainSet
 	chains.Chains[string]
-	chains.Nodes[string, db.Node]
+	chains.Nodes
 }
 
 func NewChainSet(opts ChainSetOpts, cfgs StarknetConfigs) (ChainSet, error) {
@@ -82,5 +82,5 @@ func NewChainSet(opts ChainSetOpts, cfgs StarknetConfigs) (ChainSet, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load some Solana chains")
 	}
-	return chains.NewChainSet[string, db.Node, starkchain.Chain](stkChains, &opts, func(s string) string { return s })
+	return chains.NewChainSet[db.Node, starkchain.Chain](stkChains, &opts)
 }

--- a/core/chains/starknet/config.go
+++ b/core/chains/starknet/config.go
@@ -101,41 +101,87 @@ func (cs StarknetConfigs) Node(name string) (n db.Node, err error) {
 			}
 		}
 	}
+	err = chains.ErrNotFound
 	return
 }
 
-func (cs StarknetConfigs) Nodes() (ns []db.Node) {
-	for i := range cs {
-		for _, n := range cs[i].Nodes {
-			if n == nil {
-				continue
-			}
-			ns = append(ns, legacyNode(n, *cs[i].ChainID))
+func (cs StarknetConfigs) nodes(chainID string) (ns StarknetNodes) {
+	for _, c := range cs {
+		if *c.ChainID == chainID {
+			return c.Nodes
 		}
 	}
-	return
+	return nil
 }
 
-func (cs StarknetConfigs) NodesByID(chainIDs ...string) (ns []db.Node) {
-	for i := range cs {
-		var match bool
-		for _, id := range chainIDs {
-			if id == *cs[i].ChainID {
-				match = true
-				break
-			}
-		}
-		if !match {
+func (cs StarknetConfigs) Nodes(chainID string) (ns []db.Node, err error) {
+	nodes := cs.nodes(chainID)
+	if nodes == nil {
+		err = chains.ErrNotFound
+		return
+	}
+	for _, n := range nodes {
+		if n == nil {
 			continue
 		}
+		ns = append(ns, legacyNode(n, chainID))
+	}
+	return
+}
+
+func (cs StarknetConfigs) NodeStatus(name string) (n chains.NodeStatus, err error) {
+	for i := range cs {
 		for _, n := range cs[i].Nodes {
+			if n.Name != nil && *n.Name == name {
+				return nodeStatus(n, *cs[i].ChainID)
+			}
+		}
+	}
+	err = chains.ErrNotFound
+	return
+}
+
+func (cs StarknetConfigs) NodeStatuses(chainIDs ...string) (ns []chains.NodeStatus, err error) {
+	if len(chainIDs) == 0 {
+		for i := range cs {
+			for _, n := range cs[i].Nodes {
+				if n == nil {
+					continue
+				}
+				n2, err := nodeStatus(n, *cs[i].ChainID)
+				if err != nil {
+					return nil, err
+				}
+				ns = append(ns, n2)
+			}
+		}
+		return
+	}
+	for _, id := range chainIDs {
+		for _, n := range cs.nodes(id) {
 			if n == nil {
 				continue
 			}
-			ns = append(ns, legacyNode(n, *cs[i].ChainID))
+			n2, err := nodeStatus(n, id)
+			if err != nil {
+				return nil, err
+			}
+			ns = append(ns, n2)
 		}
 	}
 	return
+}
+
+func nodeStatus(n *stkcfg.Node, chainID string) (chains.NodeStatus, error) {
+	var s chains.NodeStatus
+	s.ChainID = chainID
+	s.Name = *n.Name
+	b, err := toml.Marshal(n)
+	if err != nil {
+		return chains.NodeStatus{}, err
+	}
+	s.Config = string(b)
+	return s, nil
 }
 
 type StarknetConfig struct {

--- a/core/cmd/cosmos_node_commands.go
+++ b/core/cmd/cosmos_node_commands.go
@@ -1,14 +1,6 @@
 package cmd
 
 import (
-	"errors"
-	"fmt"
-	"net/url"
-
-	"github.com/urfave/cli"
-
-	"github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/db"
-
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
 
@@ -19,22 +11,14 @@ type CosmosNodePresenter struct {
 
 // ToRow presents the CosmosNodeResource as a slice of strings.
 func (p *CosmosNodePresenter) ToRow() []string {
-	row := []string{
-		p.GetID(),
-		p.Name,
-		p.CosmosChainID,
-		p.TendermintURL,
-	}
-	return row
+	return []string{p.GetID(), p.Name, p.ChainID, p.State, p.Config}
 }
-
-var cosmosNodeHeaders = []string{"ID", "Name", "Chain ID", "Tendermint URL"}
 
 // RenderTable implements TableRenderer
 func (p CosmosNodePresenter) RenderTable(rt RendererTable) error {
 	var rows [][]string
 	rows = append(rows, p.ToRow())
-	renderList(cosmosNodeHeaders, rows, rt.Writer)
+	renderList(nodeHeaders, rows, rt.Writer)
 
 	return nil
 }
@@ -50,31 +34,11 @@ func (ps CosmosNodePresenters) RenderTable(rt RendererTable) error {
 		rows = append(rows, p.ToRow())
 	}
 
-	renderList(cosmosNodeHeaders, rows, rt.Writer)
+	renderList(nodeHeaders, rows, rt.Writer)
 
 	return nil
 }
 
 func NewCosmosNodeClient(c *Client) NodeClient {
-	createNode := func(c *cli.Context) (node db.Node, err error) {
-		node.Name = c.String("name")
-		node.CosmosChainID = c.String("chain-id")
-		node.TendermintURL = c.String("tendermint-url")
-
-		if node.Name == "" {
-			err = errors.New("missing --name")
-			return
-		}
-		if node.CosmosChainID == "" {
-			err = errors.New("missing --chain-id")
-			return
-		}
-
-		if _, err2 := url.Parse(node.TendermintURL); err2 != nil {
-			err = fmt.Errorf("invalid tendermint-url: %v", err2)
-			return
-		}
-		return
-	}
-	return newNodeClient[db.Node, CosmosNodePresenter, CosmosNodePresenters](c, "cosmos", createNode)
+	return newNodeClient[CosmosNodePresenters](c, "cosmos")
 }

--- a/core/cmd/cosmos_node_commands_test.go
+++ b/core/cmd/cosmos_node_commands_test.go
@@ -1,9 +1,9 @@
 package cmd_test
 
 import (
-	"net/url"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -49,9 +49,11 @@ func TestClient_IndexCosmosNodes(t *testing.T) {
 	nodes := *r.Renders[0].(*cmd.CosmosNodePresenters)
 	require.Len(t, nodes, 1)
 	n := nodes[0]
-	assert.Equal(t, "second", n.ID)
+	assert.Equal(t, chainID, n.ChainID)
+	assert.Equal(t, *node.Name, n.ID)
 	assert.Equal(t, *node.Name, n.Name)
-	assert.Equal(t, *chain.ChainID, n.CosmosChainID)
-	assert.Equal(t, (*url.URL)(node.TendermintURL).String(), n.TendermintURL)
+	wantConfig, err := toml.Marshal(node)
+	require.NoError(t, err)
+	assert.Equal(t, string(wantConfig), n.Config)
 	assertTableRenders(t, r)
 }

--- a/core/cmd/evm_node_commands.go
+++ b/core/cmd/evm_node_commands.go
@@ -1,13 +1,6 @@
 package cmd
 
 import (
-	"errors"
-
-	"github.com/urfave/cli"
-	"gopkg.in/guregu/null.v4"
-
-	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
 
@@ -18,24 +11,14 @@ type EVMNodePresenter struct {
 
 // ToRow presents the EVMNodeResource as a slice of strings.
 func (p *EVMNodePresenter) ToRow() []string {
-	row := []string{
-		p.GetID(),
-		p.Name,
-		p.EVMChainID.ToInt().String(),
-		p.WSURL.ValueOrZero(),
-		p.HTTPURL.ValueOrZero(),
-		p.State,
-	}
-	return row
+	return []string{p.GetID(), p.Name, p.ChainID, p.State, p.Config}
 }
-
-var evmNodeHeaders = []string{"ID", "Name", "Chain ID", "Websocket URL", "HTTP URL", "State"}
 
 // RenderTable implements TableRenderer
 func (p EVMNodePresenter) RenderTable(rt RendererTable) error {
 	var rows [][]string
 	rows = append(rows, p.ToRow())
-	renderList(evmNodeHeaders, rows, rt.Writer)
+	renderList(nodeHeaders, rows, rt.Writer)
 
 	return nil
 }
@@ -51,53 +34,11 @@ func (ps EVMNodePresenters) RenderTable(rt RendererTable) error {
 		rows = append(rows, p.ToRow())
 	}
 
-	renderList(evmNodeHeaders, rows, rt.Writer)
+	renderList(nodeHeaders, rows, rt.Writer)
 
 	return nil
 }
 
 func NewEVMNodeClient(c *Client) NodeClient {
-	createNode := func(c *cli.Context) (node evmtypes.Node, err error) {
-		name := c.String("name")
-		t := c.String("type")
-		ws := c.String("ws-url")
-		httpURLStr := c.String("http-url")
-		chainID := c.Int64("chain-id")
-
-		if name == "" {
-			err = errors.New("missing --name")
-			return
-		}
-		if chainID == 0 {
-			err = errors.New("missing --chain-id")
-			return
-		}
-		if t != "primary" && t != "sendonly" {
-			err = errors.New("invalid or unspecified --type, must be either primary or sendonly")
-			return
-		}
-		if t == "primary" && ws == "" {
-			err = errors.New("missing --ws-url")
-			return
-		}
-		var httpURL = null.NewString(httpURLStr, true)
-		if httpURLStr == "" {
-			httpURL = null.NewString(httpURLStr, false)
-		}
-
-		var wsURL null.String
-		if ws != "" {
-			wsURL = null.StringFrom(ws)
-		}
-
-		node = evmtypes.Node{
-			Name:       name,
-			EVMChainID: *utils.NewBigI(chainID),
-			WSURL:      wsURL,
-			HTTPURL:    httpURL,
-			SendOnly:   t == "sendonly",
-		}
-		return
-	}
-	return newNodeClient[evmtypes.Node, EVMNodePresenter, EVMNodePresenters](c, "evm", createNode)
+	return newNodeClient[EVMNodePresenters](c, "evm")
 }

--- a/core/cmd/evm_node_commands_test.go
+++ b/core/cmd/evm_node_commands_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -55,13 +56,17 @@ func TestClient_IndexEVMNodes(t *testing.T) {
 	require.Len(t, nodes, 2)
 	n1 := nodes[0]
 	n2 := nodes[1]
-	assert.Equal(t, "Test node 1", n1.ID)
+	assert.Equal(t, chainID.String(), n1.ChainID)
+	assert.Equal(t, *node1.Name, n1.ID)
 	assert.Equal(t, *node1.Name, n1.Name)
-	assert.Equal(t, node1.WSURL.String(), n1.WSURL.String)
-	assert.Equal(t, node1.HTTPURL.String(), n1.HTTPURL.String)
-	assert.Equal(t, "Test node 2", n2.ID)
+	wantConfig, err := toml.Marshal(node1)
+	require.NoError(t, err)
+	assert.Equal(t, string(wantConfig), n1.Config)
+	assert.Equal(t, chainID.String(), n2.ChainID)
+	assert.Equal(t, *node2.Name, n2.ID)
 	assert.Equal(t, *node2.Name, n2.Name)
-	assert.Equal(t, node2.WSURL.String(), n2.WSURL.String)
-	assert.Equal(t, node2.HTTPURL.String(), n2.HTTPURL.String)
+	wantConfig2, err := toml.Marshal(node2)
+	require.NoError(t, err)
+	assert.Equal(t, string(wantConfig2), n2.Config)
 	assertTableRenders(t, r)
 }

--- a/core/cmd/solana_node_commands.go
+++ b/core/cmd/solana_node_commands.go
@@ -1,13 +1,6 @@
 package cmd
 
 import (
-	"net/url"
-
-	"github.com/pkg/errors"
-	"github.com/urfave/cli"
-
-	"github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
-
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
 
@@ -18,22 +11,14 @@ type SolanaNodePresenter struct {
 
 // ToRow presents the SolanaNodeResource as a slice of strings.
 func (p *SolanaNodePresenter) ToRow() []string {
-	row := []string{
-		p.GetID(),
-		p.Name,
-		p.SolanaChainID,
-		p.SolanaURL,
-	}
-	return row
+	return []string{p.GetID(), p.Name, p.ChainID, p.State, p.Config}
 }
-
-var solanaNodeHeaders = []string{"ID", "Name", "Chain ID", "URL"}
 
 // RenderTable implements TableRenderer
 func (p SolanaNodePresenter) RenderTable(rt RendererTable) error {
 	var rows [][]string
 	rows = append(rows, p.ToRow())
-	renderList(solanaNodeHeaders, rows, rt.Writer)
+	renderList(nodeHeaders, rows, rt.Writer)
 
 	return nil
 }
@@ -49,31 +34,11 @@ func (ps SolanaNodePresenters) RenderTable(rt RendererTable) error {
 		rows = append(rows, p.ToRow())
 	}
 
-	renderList(solanaNodeHeaders, rows, rt.Writer)
+	renderList(nodeHeaders, rows, rt.Writer)
 
 	return nil
 }
 
 func NewSolanaNodeClient(c *Client) NodeClient {
-	createNode := func(c *cli.Context) (node db.Node, err error) {
-		node.Name = c.String("name")
-		node.SolanaChainID = c.String("chain-id")
-		node.SolanaURL = c.String("url")
-
-		if node.Name == "" {
-			err = errors.New("missing --name")
-			return
-		}
-		if node.SolanaChainID == "" {
-			err = errors.New("missing --chain-id")
-			return
-		}
-
-		if _, err2 := url.Parse(node.SolanaURL); err2 != nil {
-			err = errors.Errorf("invalid url: %v", err2)
-			return
-		}
-		return
-	}
-	return newNodeClient[db.Node, SolanaNodePresenter, SolanaNodePresenters](c, "solana", createNode)
+	return newNodeClient[SolanaNodePresenters](c, "solana")
 }

--- a/core/cmd/solana_node_commands_test.go
+++ b/core/cmd/solana_node_commands_test.go
@@ -1,9 +1,9 @@
 package cmd_test
 
 import (
-	"net/url"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -52,11 +52,17 @@ func TestClient_IndexSolanaNodes(t *testing.T) {
 	require.Len(t, nodes, 2)
 	n1 := nodes[0]
 	n2 := nodes[1]
-	assert.Equal(t, "first", n1.ID)
+	assert.Equal(t, id, n1.ChainID)
+	assert.Equal(t, *node1.Name, n1.ID)
 	assert.Equal(t, *node1.Name, n1.Name)
-	assert.Equal(t, (*url.URL)(node1.URL).String(), n1.SolanaURL)
-	assert.Equal(t, "second", n2.ID)
+	wantConfig, err := toml.Marshal(node1)
+	require.NoError(t, err)
+	assert.Equal(t, string(wantConfig), n1.Config)
+	assert.Equal(t, id, n2.ChainID)
+	assert.Equal(t, *node2.Name, n2.ID)
 	assert.Equal(t, *node2.Name, n2.Name)
-	assert.Equal(t, (*url.URL)(node2.URL).String(), n2.SolanaURL)
+	wantConfig2, err := toml.Marshal(node2)
+	require.NoError(t, err)
+	assert.Equal(t, string(wantConfig2), n2.Config)
 	assertTableRenders(t, r)
 }

--- a/core/cmd/starknet_node_commands.go
+++ b/core/cmd/starknet_node_commands.go
@@ -1,13 +1,6 @@
 package cmd
 
 import (
-	"net/url"
-
-	"github.com/pkg/errors"
-	"github.com/urfave/cli"
-
-	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/db"
-
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
 
@@ -18,22 +11,14 @@ type StarkNetNodePresenter struct {
 
 // ToRow presents the StarkNetNodeResource as a slice of strings.
 func (p *StarkNetNodePresenter) ToRow() []string {
-	row := []string{
-		p.GetID(),
-		p.Name,
-		p.ChainID,
-		p.URL,
-	}
-	return row
+	return []string{p.GetID(), p.Name, p.ChainID, p.State, p.Config}
 }
-
-var starknetNodeHeaders = []string{"ID", "Name", "Chain ID", "URL"}
 
 // RenderTable implements TableRenderer
 func (p StarkNetNodePresenter) RenderTable(rt RendererTable) error {
 	var rows [][]string
 	rows = append(rows, p.ToRow())
-	renderList(starknetNodeHeaders, rows, rt.Writer)
+	renderList(nodeHeaders, rows, rt.Writer)
 
 	return nil
 }
@@ -49,31 +34,11 @@ func (ps StarkNetNodePresenters) RenderTable(rt RendererTable) error {
 		rows = append(rows, p.ToRow())
 	}
 
-	renderList(starknetNodeHeaders, rows, rt.Writer)
+	renderList(nodeHeaders, rows, rt.Writer)
 
 	return nil
 }
 
 func NewStarkNetNodeClient(c *Client) NodeClient {
-	createNode := func(c *cli.Context) (node db.Node, err error) {
-		node.Name = c.String("name")
-		node.ChainID = c.String("chain-id")
-		node.URL = c.String("url")
-
-		if node.Name == "" {
-			err = errors.New("missing --name")
-			return
-		}
-		if node.ChainID == "" {
-			err = errors.New("missing --chain-id")
-			return
-		}
-
-		if _, err2 := url.Parse(node.URL); err2 != nil {
-			err = errors.Errorf("invalid url: %v", err2)
-			return
-		}
-		return
-	}
-	return newNodeClient[db.Node, StarkNetNodePresenter, StarkNetNodePresenters](c, "starknet", createNode)
+	return newNodeClient[StarkNetNodePresenters](c, "starknet")
 }

--- a/core/cmd/starknet_node_commands_test.go
+++ b/core/cmd/starknet_node_commands_test.go
@@ -1,9 +1,9 @@
 package cmd_test
 
 import (
-	"net/url"
 	"testing"
 
+	"github.com/pelletier/go-toml/v2"
 	"github.com/smartcontractkit/chainlink-relay/pkg/utils"
 	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/config"
 	"github.com/stretchr/testify/assert"
@@ -51,11 +51,17 @@ func TestClient_IndexStarkNetNodes(t *testing.T) {
 	require.Len(t, nodes, 2)
 	n1 := nodes[0]
 	n2 := nodes[1]
-	assert.Equal(t, "first", n1.ID)
+	assert.Equal(t, id, n1.ChainID)
+	assert.Equal(t, *node1.Name, n1.ID)
 	assert.Equal(t, *node1.Name, n1.Name)
-	assert.Equal(t, (*url.URL)(node1.URL).String(), n1.URL)
-	assert.Equal(t, "second", n2.ID)
+	wantConfig, err := toml.Marshal(node1)
+	require.NoError(t, err)
+	assert.Equal(t, string(wantConfig), n1.Config)
+	assert.Equal(t, id, n2.ChainID)
+	assert.Equal(t, *node2.Name, n2.ID)
 	assert.Equal(t, *node2.Name, n2.Name)
-	assert.Equal(t, (*url.URL)(node2.URL).String(), n2.URL)
+	wantConfig2, err := toml.Marshal(node2)
+	require.NoError(t, err)
+	assert.Equal(t, string(wantConfig2), n2.Config)
 	assertTableRenders(t, r)
 }

--- a/core/internal/testutils/evmtest/evmtest.go
+++ b/core/internal/testutils/evmtest/evmtest.go
@@ -1,17 +1,18 @@
 package evmtest
 
 import (
-	"database/sql"
 	"math/big"
 	"sync"
 	"sync/atomic"
 	"testing"
 
 	"github.com/ethereum/go-ethereum"
+	"github.com/pelletier/go-toml/v2"
 	"github.com/smartcontractkit/sqlx"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/exp/maps"
+	"golang.org/x/exp/slices"
+	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm"
@@ -133,102 +134,152 @@ func MustGetDefaultChain(t testing.TB, cc evm.ChainSet) evm.Chain {
 	return chain
 }
 
-type MockORM struct {
-	mu     sync.RWMutex
-	chains map[string]chains.ChainConfig
-	nodes  map[string][]evmtypes.Node
+type TestConfigs struct {
+	mu sync.RWMutex
+	v2.EVMConfigs
 }
 
-var _ evmtypes.Configs = &MockORM{}
+var _ evmtypes.Configs = &TestConfigs{}
 
-func NewMockORM(cs []chains.ChainConfig, nodes []evmtypes.Node) *MockORM {
-	mo := &MockORM{
-		chains: make(map[string]chains.ChainConfig),
-		nodes:  make(map[string][]evmtypes.Node),
-	}
-	mo.PutChains(cs...)
-	mo.AddNodes(nodes...)
-	return mo
+func NewTestConfigs(cs ...*v2.EVMConfig) *TestConfigs {
+	return &TestConfigs{EVMConfigs: v2.EVMConfigs(cs)}
 }
 
-func (mo *MockORM) PutChains(cs ...chains.ChainConfig) {
+func (mo *TestConfigs) PutChains(cs ...v2.EVMConfig) {
 	mo.mu.Lock()
 	defer mo.mu.Unlock()
-	for _, c := range cs {
-		mo.chains[c.ID] = c
+chains:
+	for i := range cs {
+		id := cs[i].ChainID.String()
+		for j, c2 := range mo.EVMConfigs {
+			if c2.ChainID.String() == id {
+				mo.EVMConfigs[j] = &cs[i] // replace
+				continue chains
+			}
+		}
+		mo.EVMConfigs = append(mo.EVMConfigs, &cs[i])
 	}
 }
 
-func (mo *MockORM) AddNodes(ns ...evmtypes.Node) {
-	for _, n := range ns {
-		id := n.EVMChainID.String()
-		mo.nodes[id] = append(mo.nodes[id], n)
-	}
-}
-
-func (mo *MockORM) Chains(offset int, limit int, ids ...utils.Big) (cs []chains.ChainConfig, count int, err error) {
+func (mo *TestConfigs) Chains(offset int, limit int, ids ...utils.Big) (cs []chains.ChainConfig, count int, err error) {
 	mo.mu.RLock()
 	defer mo.mu.RUnlock()
 	if len(ids) == 0 {
-		cs = maps.Values(mo.chains)
+		for _, c := range mo.EVMConfigs {
+			c2 := chains.ChainConfig{
+				ID:      c.ChainID.String(),
+				Enabled: c.IsEnabled(),
+			}
+			c2.Cfg, err = c.TOMLString()
+			if err != nil {
+				return
+			}
+			cs = append(cs, c2)
+		}
 		count = len(cs)
 		return
 	}
-	for _, id := range ids {
-		c, ok := mo.chains[id.String()]
-		if ok {
-			cs = append(cs, c)
+	for i := range mo.EVMConfigs {
+		c := mo.EVMConfigs[i]
+		if !slices.ContainsFunc(ids, func(id utils.Big) bool {
+			return id.Cmp(c.ChainID) == 0
+		}) {
+			continue
 		}
+		c2 := chains.ChainConfig{
+			ID:      c.ChainID.String(),
+			Enabled: c.IsEnabled(),
+		}
+		c2.Cfg, err = c.TOMLString()
+		if err != nil {
+			return
+		}
+		cs = append(cs, c2)
 	}
 	count = len(cs)
 	return
 }
 
 // Nodes implements evmtypes.Configs
-func (mo *MockORM) Nodes(offset int, limit int) (nodes []evmtypes.Node, cnt int, err error) {
+func (mo *TestConfigs) Nodes(chainID utils.Big) (nodes []evmtypes.Node, err error) {
 	mo.mu.RLock()
 	defer mo.mu.RUnlock()
-	for _, ns := range maps.Values(mo.nodes) {
-		nodes = append(nodes, ns...)
+
+	for i := range mo.EVMConfigs {
+		c := mo.EVMConfigs[i]
+		if chainID.Cmp(c.ChainID) == 0 {
+			for _, n := range c.Nodes {
+				nodes = append(nodes, legacyNode(n, c.ChainID))
+			}
+		}
+	}
+	err = chains.ErrNotFound
+	return
+}
+
+func (mo *TestConfigs) Node(name string) (evmtypes.Node, error) {
+	mo.mu.RLock()
+	defer mo.mu.RUnlock()
+
+	for i := range mo.EVMConfigs {
+		c := mo.EVMConfigs[i]
+		for _, n := range c.Nodes {
+			if *n.Name == name {
+				return legacyNode(n, c.ChainID), nil
+			}
+		}
+	}
+	return evmtypes.Node{}, chains.ErrNotFound
+}
+
+func (mo *TestConfigs) NodeStatusesPaged(offset int, limit int, chainIDs ...string) (nodes []chains.NodeStatus, cnt int, err error) {
+	mo.mu.RLock()
+	defer mo.mu.RUnlock()
+
+	for i := range mo.EVMConfigs {
+		c := mo.EVMConfigs[i]
+		id := c.ChainID.String()
+		if !slices.Contains(chainIDs, id) {
+			continue
+		}
+		for _, n := range c.Nodes {
+			var n2 chains.NodeStatus
+			n2, err = nodeStatus(n, id)
+			if err != nil {
+				return
+			}
+			nodes = append(nodes, n2)
+		}
 	}
 	cnt = len(nodes)
 	return
 }
 
-func (mo *MockORM) NodeNamed(name string) (evmtypes.Node, error) {
-	mo.mu.RLock()
-	defer mo.mu.RUnlock()
-	for _, ns := range maps.Values(mo.nodes) {
-		for _, n := range ns {
-			if n.Name == name {
-				return n, nil
-			}
-		}
+func legacyNode(n *v2.Node, chainID *utils.Big) (v2 evmtypes.Node) {
+	v2.Name = *n.Name
+	v2.EVMChainID = *chainID
+	if n.HTTPURL != nil {
+		v2.HTTPURL = null.StringFrom(n.HTTPURL.String())
 	}
-	return evmtypes.Node{}, sql.ErrNoRows
-}
-
-// GetNodesByChainIDs implements evmtypes.Configs
-func (mo *MockORM) GetNodesByChainIDs(chainIDs []utils.Big) (nodes []evmtypes.Node, err error) {
-	ids := map[string]struct{}{}
-	for _, chainID := range chainIDs {
-		ids[chainID.String()] = struct{}{}
+	if n.WSURL != nil {
+		v2.WSURL = null.StringFrom(n.WSURL.String())
 	}
-	mo.mu.RLock()
-	defer mo.mu.RUnlock()
-	for _, ns := range maps.Values(mo.nodes) {
-		for _, n := range ns {
-			if _, ok := ids[n.EVMChainID.String()]; ok {
-				nodes = append(nodes, n)
-			}
-		}
+	if n.SendOnly != nil {
+		v2.SendOnly = *n.SendOnly
 	}
 	return
 }
 
-// NodesForChain implements evmtypes.Configs
-func (mo *MockORM) NodesForChain(chainID utils.Big, offset int, limit int) ([]evmtypes.Node, int, error) {
-	panic("not implemented")
+func nodeStatus(n *v2.Node, chainID string) (chains.NodeStatus, error) {
+	var s chains.NodeStatus
+	s.ChainID = chainID
+	s.Name = *n.Name
+	b, err := toml.Marshal(n)
+	if err != nil {
+		return chains.NodeStatus{}, err
+	}
+	s.Config = string(b)
+	return s, nil
 }
 
 func NewEthClientMock(t *testing.T) *evmclimocks.Client {

--- a/core/services/ocrbootstrap/delegate.go
+++ b/core/services/ocrbootstrap/delegate.go
@@ -2,6 +2,7 @@ package ocrbootstrap
 
 import (
 	"github.com/pkg/errors"
+
 	ocr "github.com/smartcontractkit/libocr/offchainreporting2"
 	"github.com/smartcontractkit/sqlx"
 

--- a/core/web/chains_controller.go
+++ b/core/web/chains_controller.go
@@ -30,12 +30,12 @@ type chainsController[I chains.ID, R jsonapi.EntityNamer] struct {
 }
 
 type errChainDisabled struct {
-	name   string
-	envVar string
+	name    string
+	tomlKey string
 }
 
 func (e errChainDisabled) Error() string {
-	return fmt.Sprintf("%s is disabled: Set %s=true to enable", e.name, e.envVar)
+	return fmt.Sprintf("%s is disabled: Set %s=true to enable", e.name, e.tomlKey)
 }
 
 func newChainsController[I chains.ID, R jsonapi.EntityNamer](prefix string, chainSet chains.Chains[I], errNotEnabled error,

--- a/core/web/cosmos_nodes_controller.go
+++ b/core/web/cosmos_nodes_controller.go
@@ -1,18 +1,15 @@
 package web
 
 import (
-	"github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/db"
-
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
 
 // ErrCosmosNotEnabled is returned when COSMOS_ENABLED is not true.
-var ErrCosmosNotEnabled = errChainDisabled{name: "Cosmos", envVar: "COSMOS_ENABLED"}
+var ErrCosmosNotEnabled = errChainDisabled{name: "Cosmos", tomlKey: "Cosmos.Enabled"}
 
 func NewCosmosNodesController(app chainlink.Application) NodesController {
-	parse := func(s string) (string, error) { return s, nil }
-	return newNodesController[string, db.Node, presenters.CosmosNodeResource](
-		app.GetChains().Cosmos, ErrCosmosNotEnabled, parse, presenters.NewCosmosNodeResource, app.GetAuditLogger(),
+	return newNodesController[presenters.CosmosNodeResource](
+		app.GetChains().Cosmos, ErrCosmosNotEnabled, presenters.NewCosmosNodeResource, app.GetAuditLogger(),
 	)
 }

--- a/core/web/evm_chains_controller.go
+++ b/core/web/evm_chains_controller.go
@@ -6,7 +6,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
 
-var ErrEVMNotEnabled = errChainDisabled{name: "EVM", envVar: "EVM.Enabled"}
+var ErrEVMNotEnabled = errChainDisabled{name: "EVM", tomlKey: "EVM.Enabled"}
 
 func NewEVMChainsController(app chainlink.Application) ChainsController {
 	parse := func(s string) (id utils.Big, err error) {

--- a/core/web/evm_nodes_controller.go
+++ b/core/web/evm_nodes_controller.go
@@ -1,17 +1,11 @@
 package web
 
 import (
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
 
 func NewEVMNodesController(app chainlink.Application) NodesController {
-	parse := func(s string) (id utils.Big, err error) {
-		err = id.UnmarshalText([]byte(s))
-		return
-	}
-	return newNodesController[utils.Big, types.Node, presenters.EVMNodeResource](
-		app.GetChains().EVM, ErrEVMNotEnabled, parse, presenters.NewEVMNodeResource, app.GetAuditLogger())
+	return newNodesController[presenters.EVMNodeResource](
+		app.GetChains().EVM, ErrEVMNotEnabled, presenters.NewEVMNodeResource, app.GetAuditLogger())
 }

--- a/core/web/loader/node.go
+++ b/core/web/loader/node.go
@@ -5,9 +5,8 @@ import (
 
 	"github.com/graph-gophers/dataloader"
 
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
+	"github.com/smartcontractkit/chainlink/v2/core/chains"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 type nodeBatcher struct {
@@ -18,25 +17,21 @@ func (b *nodeBatcher) loadByChainIDs(ctx context.Context, keys dataloader.Keys) 
 	// Create a map for remembering the order of keys passed in
 	keyOrder := make(map[string]int, len(keys))
 	// Collect the keys to search for
-	var chainIDs []utils.Big
+	var ids []string
 	for ix, key := range keys {
-		id := utils.Big{}
-		if err := id.UnmarshalText([]byte(key.String())); err == nil {
-			chainIDs = append(chainIDs, id)
-		}
-
+		ids = append(ids, key.String())
 		keyOrder[key.String()] = ix
 	}
 
-	nodes, err := b.app.GetChains().EVM.GetNodesByChainIDs(ctx, chainIDs)
+	nodes, _, err := b.app.GetChains().EVM.NodeStatuses(ctx, 0, -1, ids...)
 	if err != nil {
 		return []*dataloader.Result{{Data: nil, Error: err}}
 	}
 
 	// Generate a map of nodes to chainIDs
-	nodesForChain := map[string][]types.Node{}
+	nodesForChain := map[string][]chains.NodeStatus{}
 	for _, n := range nodes {
-		nodesForChain[n.EVMChainID.String()] = append(nodesForChain[n.EVMChainID.String()], n)
+		nodesForChain[n.ChainID] = append(nodesForChain[n.ChainID], n)
 	}
 
 	// Construct the output array of dataloader results
@@ -52,7 +47,7 @@ func (b *nodeBatcher) loadByChainIDs(ctx context.Context, keys dataloader.Keys) 
 
 	// fill array positions without any nodes as an empty slice
 	for _, ix := range keyOrder {
-		results[ix] = &dataloader.Result{Data: []types.Node{}, Error: nil}
+		results[ix] = &dataloader.Result{Data: []chains.NodeStatus{}, Error: nil}
 	}
 
 	return results

--- a/core/web/nodes_controller.go
+++ b/core/web/nodes_controller.go
@@ -15,31 +15,28 @@ type NodesController interface {
 	Index(c *gin.Context, size, page, offset int)
 }
 
-type nodesController[I chains.ID, N chains.Node, R jsonapi.EntityNamer] struct {
-	nodeSet       chains.Nodes[I, N]
-	parseChainID  func(string) (I, error)
+type nodesController[R jsonapi.EntityNamer] struct {
+	nodeSet       chains.Nodes
 	errNotEnabled error
-	newResource   func(N) R
+	newResource   func(status chains.NodeStatus) R
 	auditLogger   audit.AuditLogger
 }
 
-func newNodesController[I chains.ID, N chains.Node, R jsonapi.EntityNamer](
-	nodeSet chains.Nodes[I, N],
+func newNodesController[R jsonapi.EntityNamer](
+	nodeSet chains.Nodes,
 	errNotEnabled error,
-	parseChainID func(string) (I, error),
-	newResource func(N) R,
+	newResource func(status chains.NodeStatus) R,
 	auditLogger audit.AuditLogger,
 ) NodesController {
-	return &nodesController[I, N, R]{
+	return &nodesController[R]{
 		nodeSet:       nodeSet,
 		errNotEnabled: errNotEnabled,
-		parseChainID:  parseChainID,
 		newResource:   newResource,
 		auditLogger:   auditLogger,
 	}
 }
 
-func (n *nodesController[I, N, R]) Index(c *gin.Context, size, page, offset int) {
+func (n *nodesController[R]) Index(c *gin.Context, size, page, offset int) {
 	if n.nodeSet == nil {
 		jsonAPIError(c, http.StatusBadRequest, n.errNotEnabled)
 		return
@@ -47,21 +44,16 @@ func (n *nodesController[I, N, R]) Index(c *gin.Context, size, page, offset int)
 
 	id := c.Param("ID")
 
-	var nodes []N
+	var nodes []chains.NodeStatus
 	var count int
 	var err error
 
 	if id == "" {
 		// fetch all nodes
-		nodes, count, err = n.nodeSet.GetNodes(c, offset, size)
+		nodes, count, err = n.nodeSet.NodeStatuses(c, offset, size)
 	} else {
 		// fetch nodes for chain ID
-		chainID, err2 := n.parseChainID(id)
-		if err2 != nil {
-			jsonAPIError(c, http.StatusBadRequest, err2)
-			return
-		}
-		nodes, count, err = n.nodeSet.GetNodesForChain(c, chainID, offset, size)
+		nodes, count, err = n.nodeSet.NodeStatuses(c, offset, size, id)
 	}
 
 	var resources []R

--- a/core/web/presenters/chain.go
+++ b/core/web/presenters/chain.go
@@ -5,3 +5,11 @@ type ChainResource struct {
 	Enabled bool   `json:"enabled"`
 	Config  string `json:"config"` // TOML
 }
+
+type NodeResource struct {
+	JAID
+	ChainID string `json:"chainID"`
+	Name    string `json:"name"`
+	Config  string `json:"config"` // TOML
+	State   string `json:"state"`
+}

--- a/core/web/presenters/cosmos_chain.go
+++ b/core/web/presenters/cosmos_chain.go
@@ -1,8 +1,6 @@
 package presenters
 
 import (
-	"github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/db"
-
 	"github.com/smartcontractkit/chainlink/v2/core/chains"
 )
 
@@ -27,10 +25,7 @@ func NewCosmosChainResource(chain chains.ChainConfig) CosmosChainResource {
 
 // CosmosNodeResource is a Cosmos node JSONAPI resource.
 type CosmosNodeResource struct {
-	JAID
-	Name          string `json:"name"`
-	CosmosChainID string `json:"cosmosChainID"`
-	TendermintURL string `json:"tendermintURL"`
+	NodeResource
 }
 
 // GetName implements the api2go EntityNamer interface
@@ -39,11 +34,12 @@ func (r CosmosNodeResource) GetName() string {
 }
 
 // NewCosmosNodeResource returns a new CosmosNodeResource for node.
-func NewCosmosNodeResource(node db.Node) CosmosNodeResource {
-	return CosmosNodeResource{
-		JAID:          NewJAID(node.Name),
-		Name:          node.Name,
-		CosmosChainID: node.CosmosChainID,
-		TendermintURL: node.TendermintURL,
-	}
+func NewCosmosNodeResource(node chains.NodeStatus) CosmosNodeResource {
+	return CosmosNodeResource{NodeResource{
+		JAID:    NewJAID(node.Name),
+		ChainID: node.ChainID,
+		Name:    node.Name,
+		State:   node.State,
+		Config:  node.Config,
+	}}
 }

--- a/core/web/presenters/evm_chain.go
+++ b/core/web/presenters/evm_chain.go
@@ -1,11 +1,7 @@
 package presenters
 
 import (
-	"gopkg.in/guregu/null.v4"
-
 	"github.com/smartcontractkit/chainlink/v2/core/chains"
-	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 // EVMChainResource is an EVM chain JSONAPI resource.
@@ -29,12 +25,7 @@ func NewEVMChainResource(chain chains.ChainConfig) EVMChainResource {
 
 // EVMNodeResource is an EVM node JSONAPI resource.
 type EVMNodeResource struct {
-	JAID
-	Name       string      `json:"name"`
-	EVMChainID utils.Big   `json:"evmChainID"`
-	WSURL      null.String `json:"wsURL"`
-	HTTPURL    null.String `json:"httpURL"`
-	State      string      `json:"state"`
+	NodeResource
 }
 
 // GetName implements the api2go EntityNamer interface
@@ -43,13 +34,12 @@ func (r EVMNodeResource) GetName() string {
 }
 
 // NewEVMNodeResource returns a new EVMNodeResource for node.
-func NewEVMNodeResource(node evmtypes.Node) EVMNodeResource {
-	return EVMNodeResource{
-		JAID:       NewJAID(node.Name),
-		Name:       node.Name,
-		EVMChainID: node.EVMChainID,
-		WSURL:      node.WSURL,
-		HTTPURL:    node.HTTPURL,
-		State:      node.State,
-	}
+func NewEVMNodeResource(node chains.NodeStatus) EVMNodeResource {
+	return EVMNodeResource{NodeResource{
+		JAID:    NewJAID(node.Name),
+		ChainID: node.ChainID,
+		Name:    node.Name,
+		State:   node.State,
+		Config:  node.Config,
+	}}
 }

--- a/core/web/presenters/solana_chain.go
+++ b/core/web/presenters/solana_chain.go
@@ -1,8 +1,6 @@
 package presenters
 
 import (
-	"github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
-
 	"github.com/smartcontractkit/chainlink/v2/core/chains"
 )
 
@@ -27,10 +25,7 @@ func NewSolanaChainResource(chain chains.ChainConfig) SolanaChainResource {
 
 // SolanaNodeResource is a Solana node JSONAPI resource.
 type SolanaNodeResource struct {
-	JAID
-	Name          string `json:"name"`
-	SolanaChainID string `json:"solanaChainID"`
-	SolanaURL     string `json:"solanaURL"`
+	NodeResource
 }
 
 // GetName implements the api2go EntityNamer interface
@@ -39,11 +34,12 @@ func (r SolanaNodeResource) GetName() string {
 }
 
 // NewSolanaNodeResource returns a new SolanaNodeResource for node.
-func NewSolanaNodeResource(node db.Node) SolanaNodeResource {
-	return SolanaNodeResource{
-		JAID:          NewJAID(node.Name),
-		Name:          node.Name,
-		SolanaChainID: node.SolanaChainID,
-		SolanaURL:     node.SolanaURL,
-	}
+func NewSolanaNodeResource(node chains.NodeStatus) SolanaNodeResource {
+	return SolanaNodeResource{NodeResource{
+		JAID:    NewJAID(node.Name),
+		ChainID: node.ChainID,
+		Name:    node.Name,
+		State:   node.State,
+		Config:  node.Config,
+	}}
 }

--- a/core/web/presenters/starknet_chain.go
+++ b/core/web/presenters/starknet_chain.go
@@ -1,8 +1,6 @@
 package presenters
 
 import (
-	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/db"
-
 	"github.com/smartcontractkit/chainlink/v2/core/chains"
 )
 
@@ -27,10 +25,7 @@ func NewStarkNetChainResource(chain chains.ChainConfig) StarkNetChainResource {
 
 // StarkNetNodeResource is a StarkNet node JSONAPI resource.
 type StarkNetNodeResource struct {
-	JAID
-	Name    string `json:"name"`
-	ChainID string `json:"chainID"`
-	URL     string `json:"url"`
+	NodeResource
 }
 
 // GetName implements the api2go EntityNamer interface
@@ -39,11 +34,12 @@ func (r StarkNetNodeResource) GetName() string {
 }
 
 // NewStarkNetNodeResource returns a new StarkNetNodeResource for node.
-func NewStarkNetNodeResource(node db.Node) StarkNetNodeResource {
-	return StarkNetNodeResource{
+func NewStarkNetNodeResource(node chains.NodeStatus) StarkNetNodeResource {
+	return StarkNetNodeResource{NodeResource{
 		JAID:    NewJAID(node.Name),
-		Name:    node.Name,
 		ChainID: node.ChainID,
-		URL:     node.URL,
-	}
+		Name:    node.Name,
+		State:   node.State,
+		Config:  node.Config,
+	}}
 }

--- a/core/web/resolver/eth_key_test.go
+++ b/core/web/resolver/eth_key_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/stretchr/testify/mock"
 
 	"github.com/smartcontractkit/chainlink/v2/core/assets"
-	"github.com/smartcontractkit/chainlink/v2/core/chains"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm"
+	v2 "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/v2"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
@@ -83,7 +83,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 				f.Mocks.scfg.On("KeySpecificMaxGasPriceWei", keys[0].Address).Return(assets.NewWeiI(1))
 				f.Mocks.chain.On("Config").Return(f.Mocks.scfg)
 				f.Mocks.chainSet.On("Get", states[0].EVMChainID.ToInt()).Return(f.Mocks.chain, nil)
-				f.Mocks.evmORM.PutChains(chains.ChainConfig{ID: chainID.String()})
+				f.Mocks.evmORM.PutChains(v2.EVMConfig{ChainID: &chainID})
 				f.Mocks.keystore.On("Eth").Return(f.Mocks.ethKs)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
 				f.App.On("EVMORM").Return(f.Mocks.evmORM)
@@ -129,7 +129,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 				f.Mocks.ethKs.On("Get", keys[0].Address.Hex()).Return(keys[0], nil)
 				f.Mocks.ethKs.On("GetAll").Return(keys, nil)
 				f.Mocks.chainSet.On("Get", states[0].EVMChainID.ToInt()).Return(f.Mocks.chain, evm.ErrNoChains)
-				f.Mocks.evmORM.PutChains(chains.ChainConfig{ID: chainID.String()})
+				f.Mocks.evmORM.PutChains(v2.EVMConfig{ChainID: &chainID})
 				f.Mocks.keystore.On("Eth").Return(f.Mocks.ethKs)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
 				f.App.On("EVMORM").Return(f.Mocks.evmORM)
@@ -286,7 +286,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 				f.App.On("GetChains").Return(chainlink.Chains{EVM: f.Mocks.chainSet})
 				f.Mocks.scfg.On("KeySpecificMaxGasPriceWei", keys[0].Address).Return(assets.NewWeiI(1))
 				f.Mocks.chain.On("Config").Return(f.Mocks.scfg)
-				f.Mocks.evmORM.PutChains(chains.ChainConfig{ID: chainID.String()})
+				f.Mocks.evmORM.PutChains(v2.EVMConfig{ChainID: &chainID})
 				f.App.On("EVMORM").Return(f.Mocks.evmORM)
 			},
 			query: query,
@@ -336,7 +336,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 				f.Mocks.scfg.On("KeySpecificMaxGasPriceWei", keys[0].Address).Return(assets.NewWeiI(1))
 				f.Mocks.chain.On("Config").Return(f.Mocks.scfg)
 				f.Mocks.chainSet.On("Get", states[0].EVMChainID.ToInt()).Return(f.Mocks.chain, nil)
-				f.Mocks.evmORM.PutChains(chains.ChainConfig{ID: chainID.String()})
+				f.Mocks.evmORM.PutChains(v2.EVMConfig{ChainID: &chainID})
 				f.Mocks.keystore.On("Eth").Return(f.Mocks.ethKs)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
 				f.App.On("EVMORM").Return(f.Mocks.evmORM)

--- a/core/web/resolver/eth_transaction_test.go
+++ b/core/web/resolver/eth_transaction_test.go
@@ -9,7 +9,7 @@ import (
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 
 	"github.com/smartcontractkit/chainlink/v2/core/assets"
-	"github.com/smartcontractkit/chainlink/v2/core/chains"
+	v2 "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/v2"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
@@ -80,7 +80,7 @@ func TestResolver_EthTransaction(t *testing.T) {
 					},
 				}, nil)
 				f.App.On("TxmORM").Return(f.Mocks.txmORM)
-				f.Mocks.evmORM.PutChains(chains.ChainConfig{ID: chainID.String()})
+				f.Mocks.evmORM.PutChains(v2.EVMConfig{ChainID: &chainID})
 				f.App.On("EVMORM").Return(f.Mocks.evmORM)
 			},
 			query:     query,
@@ -136,7 +136,7 @@ func TestResolver_EthTransaction(t *testing.T) {
 					},
 				}, nil)
 				f.App.On("TxmORM").Return(f.Mocks.txmORM)
-				f.Mocks.evmORM.PutChains(chains.ChainConfig{ID: chainID.String()})
+				f.Mocks.evmORM.PutChains(v2.EVMConfig{ChainID: &chainID})
 				f.App.On("EVMORM").Return(f.Mocks.evmORM)
 			},
 			query:     query,

--- a/core/web/resolver/node.go
+++ b/core/web/resolver/node.go
@@ -2,64 +2,87 @@ package resolver
 
 import (
 	"context"
+	"errors"
 
 	"github.com/graph-gophers/graphql-go"
+	"github.com/pelletier/go-toml/v2"
 
-	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
+	"github.com/smartcontractkit/chainlink/v2/core/chains"
+	v2 "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/v2"
 	"github.com/smartcontractkit/chainlink/v2/core/web/loader"
 )
 
 // NodeResolver resolves the Node type.
 type NodeResolver struct {
-	node types.Node
+	node   v2.Node
+	status chains.NodeStatus
 }
 
-func NewNode(node types.Node) *NodeResolver {
-	return &NodeResolver{node: node}
+func NewNode(status chains.NodeStatus) (nr *NodeResolver, warn error) {
+	nr = &NodeResolver{status: status}
+	warn = toml.Unmarshal([]byte(status.Config), &nr.node)
+	return
 }
 
-func NewNodes(nodes []types.Node) []*NodeResolver {
-	var resolvers []*NodeResolver
+func NewNodes(nodes []chains.NodeStatus) (resolvers []*NodeResolver, warns error) {
 	for _, n := range nodes {
-		resolvers = append(resolvers, NewNode(n))
+		nr, warn := NewNode(n)
+		if warn != nil {
+			warns = errors.Join(warns, warn)
+		}
+		resolvers = append(resolvers, nr)
 	}
 
-	return resolvers
+	return
+}
+
+func orZero[P any](s *P) P {
+	if s == nil {
+		var zero P
+		return zero
+	}
+	return *s
 }
 
 // ID resolves the node's unique identifier.
 func (r *NodeResolver) ID() graphql.ID {
-	return graphql.ID(r.node.Name)
+	return graphql.ID(r.Name())
 }
 
 // Name resolves the node's name field.
 func (r *NodeResolver) Name() string {
-	return r.node.Name
+	return orZero(r.node.Name)
 }
 
 // WSURL resolves the node's websocket url field.
 func (r *NodeResolver) WSURL() string {
-	return r.node.WSURL.String
+	if r.node.WSURL == nil {
+		return ""
+	}
+	return r.node.WSURL.String()
 }
 
 // HTTPURL resolves the node's http url field.
 func (r *NodeResolver) HTTPURL() string {
-	return r.node.HTTPURL.String
+	if r.node.HTTPURL == nil {
+		return ""
+	}
+	return r.node.HTTPURL.String()
 }
 
 // State resolves the node state
 func (r *NodeResolver) State() string {
-	return r.node.State
+	return r.status.State
 }
 
 // SendOnly resolves the node's sendOnly bool
 func (r *NodeResolver) SendOnly() bool {
-	return r.node.SendOnly
+	return orZero(r.node.SendOnly)
 }
 
 // Chain resolves the node's chain object field.
 func (r *NodeResolver) Chain(ctx context.Context) (*ChainResolver, error) {
-	chain, err := loader.GetChainByID(ctx, r.node.EVMChainID.String())
+	chain, err := loader.GetChainByID(ctx, r.status.ChainID)
 	if err != nil {
 		return nil, err
 	}
@@ -70,103 +93,41 @@ func (r *NodeResolver) Chain(ctx context.Context) (*ChainResolver, error) {
 // -- Node Query --
 
 type NodePayloadResolver struct {
-	node *types.Node
+	nr *NodeResolver
 	NotFoundErrorUnionType
 }
 
-func NewNodePayloadResolver(node *types.Node, err error) *NodePayloadResolver {
+func NewNodePayloadResolver(node *chains.NodeStatus, err error) (npr *NodePayloadResolver, warn error) {
 	e := NotFoundErrorUnionType{err: err, message: "node not found", isExpectedErrorFn: nil}
-
-	return &NodePayloadResolver{node: node, NotFoundErrorUnionType: e}
+	npr = &NodePayloadResolver{NotFoundErrorUnionType: e}
+	if node != nil {
+		npr.nr, warn = NewNode(*node)
+	}
+	return
 }
 
 // ToNode resolves the Node object to be returned if it is found
 func (r *NodePayloadResolver) ToNode() (*NodeResolver, bool) {
-	if r.node != nil {
-		return NewNode(*r.node), true
-	}
-
-	return nil, false
+	return r.nr, r.nr != nil
 }
 
 // -- Nodes Query --
 
 type NodesPayloadResolver struct {
-	nodes []types.Node
+	nrs   []*NodeResolver
 	total int32
 }
 
-func NewNodesPayload(nodes []types.Node, total int32) *NodesPayloadResolver {
-	return &NodesPayloadResolver{nodes: nodes, total: total}
+func NewNodesPayload(nodes []chains.NodeStatus, total int32) (npr *NodesPayloadResolver, warn error) {
+	npr = &NodesPayloadResolver{total: total}
+	npr.nrs, warn = NewNodes(nodes)
+	return
 }
 
 func (r *NodesPayloadResolver) Results() []*NodeResolver {
-	return NewNodes(r.nodes)
+	return r.nrs
 }
 
 func (r *NodesPayloadResolver) Metadata() *PaginationMetadataResolver {
 	return NewPaginationMetadata(r.total)
-}
-
-// -- CreateNode Mutation --
-
-type CreateNodePayloadResolver struct {
-	node *types.Node
-}
-
-func NewCreateNodePayloadResolver(node *types.Node) *CreateNodePayloadResolver {
-	return &CreateNodePayloadResolver{node: node}
-}
-
-func (r *CreateNodePayloadResolver) ToCreateNodeSuccess() (*CreateNodeSuccessResolve, bool) {
-	if r.node != nil {
-		return NewCreateNodeSuccessResolve(*r.node), true
-	}
-
-	return nil, false
-}
-
-type CreateNodeSuccessResolve struct {
-	node types.Node
-}
-
-func NewCreateNodeSuccessResolve(node types.Node) *CreateNodeSuccessResolve {
-	return &CreateNodeSuccessResolve{node}
-}
-
-func (r *CreateNodeSuccessResolve) Node() *NodeResolver {
-	return NewNode(r.node)
-}
-
-// -- DeleteNode Mutation --
-
-type DeleteNodePayloadResolver struct {
-	node *types.Node
-	NotFoundErrorUnionType
-}
-
-func NewDeleteNodePayloadResolver(node *types.Node, err error) *DeleteNodePayloadResolver {
-	e := NotFoundErrorUnionType{err: err, message: "node not found", isExpectedErrorFn: nil}
-
-	return &DeleteNodePayloadResolver{node: node, NotFoundErrorUnionType: e}
-}
-
-func (r *DeleteNodePayloadResolver) ToDeleteNodeSuccess() (*DeleteNodeSuccessResolver, bool) {
-	if r.node != nil {
-		return NewDeleteNodeSuccessResolver(r.node), true
-	}
-
-	return nil, false
-}
-
-type DeleteNodeSuccessResolver struct {
-	node *types.Node
-}
-
-func NewDeleteNodeSuccessResolver(node *types.Node) *DeleteNodeSuccessResolver {
-	return &DeleteNodeSuccessResolver{node: node}
-}
-
-func (r *DeleteNodeSuccessResolver) Node() *NodeResolver {
-	return NewNode(*r.node)
 }

--- a/core/web/resolver/query.go
+++ b/core/web/resolver/query.go
@@ -230,15 +230,23 @@ func (r *Resolver) Node(ctx context.Context, args struct{ ID graphql.ID }) (*Nod
 	}
 
 	name := string(args.ID)
-	node, err := r.App.EVMORM().NodeNamed(name)
+	node, err := r.App.EVMORM().NodeStatus(name)
 	if err != nil {
-		if errors.Is(err, sql.ErrNoRows) {
-			return NewNodePayloadResolver(nil, err), nil
+		if errors.Is(err, chains.ErrNotFound) {
+			npr, warn := NewNodePayloadResolver(nil, err)
+			if warn != nil {
+				r.App.GetLogger().Warnw("Error creating NodePayloadResolver", "name", name, "error", warn)
+			}
+			return npr, nil
 		}
 		return nil, err
 	}
 
-	return NewNodePayloadResolver(&node, nil), nil
+	npr, warn := NewNodePayloadResolver(&node, nil)
+	if warn != nil {
+		r.App.GetLogger().Warnw("Error creating NodePayloadResolver", "name", name, "error", warn)
+	}
+	return npr, nil
 }
 
 func (r *Resolver) P2PKeys(ctx context.Context) (*P2PKeysPayloadResolver, error) {
@@ -324,12 +332,16 @@ func (r *Resolver) Nodes(ctx context.Context, args struct {
 	offset := pageOffset(args.Offset)
 	limit := pageLimit(args.Limit)
 
-	nodes, count, err := r.App.GetChains().EVM.GetNodes(ctx, offset, limit)
+	nodes, count, err := r.App.GetChains().EVM.NodeStatuses(ctx, offset, limit)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewNodesPayload(nodes, int32(count)), nil
+	npr, warn := NewNodesPayload(nodes, int32(count))
+	if warn != nil {
+		r.App.GetLogger().Warnw("Error creating NodesPayloadResolver", "error", warn)
+	}
+	return npr, nil
 }
 
 func (r *Resolver) JobRuns(ctx context.Context, args struct {

--- a/core/web/resolver/resolver_test.go
+++ b/core/web/resolver/resolver_test.go
@@ -34,7 +34,7 @@ import (
 
 type mocks struct {
 	bridgeORM   *bridgeORMMocks.ORM
-	evmORM      *evmtest.MockORM
+	evmORM      *evmtest.TestConfigs
 	jobORM      *jobORMMocks.ORM
 	sessionsORM *sessionsMocks.ORM
 	pipelineORM *pipelineMocks.ORM
@@ -92,7 +92,7 @@ func setupFramework(t *testing.T) *gqlTestFramework {
 	// Note - If you add a new mock make sure you assert it's expectation below.
 	m := &mocks{
 		bridgeORM:   bridgeORMMocks.NewORM(t),
-		evmORM:      evmtest.NewMockORM(nil, nil),
+		evmORM:      evmtest.NewTestConfigs(),
 		jobORM:      jobORMMocks.NewORM(t),
 		feedsSvc:    feedsMocks.NewService(t),
 		sessionsORM: sessionsMocks.NewORM(t),

--- a/core/web/solana_nodes_controller.go
+++ b/core/web/solana_nodes_controller.go
@@ -1,17 +1,14 @@
 package web
 
 import (
-	"github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
-
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
 
 // ErrSolanaNotEnabled is returned when Solana.Enabled is not true.
-var ErrSolanaNotEnabled = errChainDisabled{name: "Solana", envVar: "Solana.Enabled"}
+var ErrSolanaNotEnabled = errChainDisabled{name: "Solana", tomlKey: "Solana.Enabled"}
 
 func NewSolanaNodesController(app chainlink.Application) NodesController {
-	parse := func(s string) (string, error) { return s, nil }
-	return newNodesController[string, db.Node, presenters.SolanaNodeResource](
-		app.GetChains().Solana, ErrSolanaNotEnabled, parse, presenters.NewSolanaNodeResource, app.GetAuditLogger())
+	return newNodesController[presenters.SolanaNodeResource](
+		app.GetChains().Solana, ErrSolanaNotEnabled, presenters.NewSolanaNodeResource, app.GetAuditLogger())
 }

--- a/core/web/starknet_nodes_controller.go
+++ b/core/web/starknet_nodes_controller.go
@@ -1,17 +1,14 @@
 package web
 
 import (
-	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/db"
-
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
 
 // ErrStarkNetNotEnabled is returned when Starknet.Enabled is not true.
-var ErrStarkNetNotEnabled = errChainDisabled{name: "StarkNet", envVar: "Starknet.Enabled"}
+var ErrStarkNetNotEnabled = errChainDisabled{name: "StarkNet", tomlKey: "Starknet.Enabled"}
 
 func NewStarkNetNodesController(app chainlink.Application) NodesController {
-	parse := func(s string) (string, error) { return s, nil }
-	return newNodesController[string, db.Node, presenters.StarkNetNodeResource](
-		app.GetChains().StarkNet, ErrStarkNetNotEnabled, parse, presenters.NewStarkNetNodeResource, app.GetAuditLogger())
+	return newNodesController[presenters.StarkNetNodeResource](
+		app.GetChains().StarkNet, ErrStarkNetNotEnabled, presenters.NewStarkNetNodeResource, app.GetAuditLogger())
 }


### PR DESCRIPTION
This is part legacy config cleanup (like #8830) and also working towards https://smartcontract-it.atlassian.net/browse/BCF-2114.

- TOML node config w/ general `type NodeStatus`
- less generics mess
- chain-agnostic `NodeStatuses`