### PR TITLE
Mercury's Observe function should be tolerant to errors

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -277,7 +277,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.22.12 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/smartcontractkit/chainlink-cosmos v0.1.7-0.20230407210547-2b9d8b0180ee // indirect
-	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230328133051-9d3eb8328c82 // indirect
+	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af // indirect
 	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230328132724-705a2932e300 // indirect
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230328102724-20c5e1a716e9 // indirect
 	github.com/smartcontractkit/wsrpc v0.6.2-0.20230317160629-382a1ac921d8 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1333,8 +1333,8 @@ github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartcontractkit/chainlink-cosmos v0.1.7-0.20230407210547-2b9d8b0180ee h1:wHyuoacM5Sn9XNioZ/55q7ZqzByzZoj5kRZLCoXrOVU=
 github.com/smartcontractkit/chainlink-cosmos v0.1.7-0.20230407210547-2b9d8b0180ee/go.mod h1:yvxsFQ1U+f46SsH6Sv5lZ6DDYzcc7jHS3im+A1G+6+M=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230328133051-9d3eb8328c82 h1:VsNyxHnmCIpCtryMyWDv9SIseroCINOp1bme7wdXXns=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230328133051-9d3eb8328c82/go.mod h1:jhYQLbmWJvlkET6zlnx961itsCZEhmG8QP19It664eQ=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af h1:m6yTktuVTeCPm+qhKbFEhaNY2SjwQ57eTL/40kngVIE=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af/go.mod h1:jhYQLbmWJvlkET6zlnx961itsCZEhmG8QP19It664eQ=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230328132724-705a2932e300 h1:3zjEZ8Hh1EVcu8A+7KVhD3fcWWgFKLeobgessj8OAOs=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230328132724-705a2932e300/go.mod h1:iHMsx8HUSpq//xsC19+IexGtJ8GQWe7aMdsYjwr/Kug=
 github.com/smartcontractkit/chainlink-starknet/ops v0.0.0-20230214070706-9544d04bb4d8 h1:GRx8L71lgGIeTYIbgsXGQ/JFWKPEnAmJVO42zQ3n69A=

--- a/core/services/ocr2/plugins/mercury/integration_test.go
+++ b/core/services/ocr2/plugins/mercury/integration_test.go
@@ -9,11 +9,13 @@ import (
 	"io"
 	"math"
 	"math/big"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -79,6 +81,11 @@ func TestIntegration_Mercury(t *testing.T) {
 	const fromBlock = 1 // cannot use zero, start from block 1
 	const multiplier = 100000000
 	testStartTimeStamp := uint32(time.Now().Unix())
+
+	// test vars
+	// pError is the probability that an EA will return an error instead of a result, as integer percentage
+	// pError = 0 means it will never return error
+	pError := atomic.Int64{}
 
 	// feeds
 	btcFeed := Feed{"BTC/USD", randomFeedID(), big.NewInt(20_000 * multiplier), big.NewInt(19_997 * multiplier), big.NewInt(20_004 * multiplier)}
@@ -165,10 +172,18 @@ func TestIntegration_Mercury(t *testing.T) {
 			b, err := io.ReadAll(req.Body)
 			require.NoError(t, err)
 			require.Equal(t, `{"data":{"from":"ETH","to":"USD"}}`, string(b))
-			res.WriteHeader(http.StatusOK)
-			val := decimal.NewFromBigInt(p, 0).Div(decimal.NewFromInt(multiplier)).Add(decimal.NewFromInt(int64(i)).Div(decimal.NewFromInt(100))).String()
-			resp := fmt.Sprintf(`{"result": %s}`, val)
-			res.Write([]byte(resp))
+
+			r := rand.Int63n(101)
+			if r > pError.Load() {
+				res.WriteHeader(http.StatusOK)
+				val := decimal.NewFromBigInt(p, 0).Div(decimal.NewFromInt(multiplier)).Add(decimal.NewFromInt(int64(i)).Div(decimal.NewFromInt(100))).String()
+				resp := fmt.Sprintf(`{"result": %s}`, val)
+				res.Write([]byte(resp))
+			} else {
+				res.WriteHeader(http.StatusInternalServerError)
+				resp := fmt.Sprintf(`{"error": "pError test error"}`)
+				res.Write([]byte(resp))
+			}
 		}))
 		t.Cleanup(bridge.Close)
 		u, _ := url.Parse(bridge.URL)
@@ -279,6 +294,63 @@ func TestIntegration_Mercury(t *testing.T) {
 
 	// Expect at least one report per feed from each oracle
 	seen := make(map[[32]byte]map[credentials.StaticSizedPublicKey]struct{})
+	for i := range feeds {
+		// feedID will be deleted when all n oracles have reported
+		seen[feeds[i].id] = make(map[credentials.StaticSizedPublicKey]struct{}, n)
+	}
+
+	for req := range reqs {
+		v := make(map[string]interface{})
+		err := mercury.PayloadTypes.UnpackIntoMap(v, req.req.Payload)
+		require.NoError(t, err)
+		report, exists := v["report"]
+		if !exists {
+			t.Fatalf("expected payload %#v to contain 'report'", v)
+		}
+		reportElems := make(map[string]interface{})
+		err = reportcodec.ReportTypes.UnpackIntoMap(reportElems, report.([]byte))
+		require.NoError(t, err)
+
+		feedID := ([32]byte)(reportElems["feedId"].([32]uint8))
+		feed, exists := feedM[feedID]
+		require.True(t, exists)
+
+		if _, exists := seen[feedID]; !exists {
+			continue // already saw all oracles for this feed
+		}
+
+		num, err := (&reportcodec.EVMReportCodec{}).CurrentBlockNumFromReport(ocr2types.Report(report.([]byte)))
+		require.NoError(t, err)
+		currentBlock, err := backend.BlockByNumber(testutils.Context(t), nil)
+		require.NoError(t, err)
+
+		assert.GreaterOrEqual(t, currentBlock.Number().Int64(), num)
+
+		expectedBm := feed.baseBenchmarkPrice
+		expectedBid := feed.baseBid
+		expectedAsk := feed.baseAsk
+
+		assert.GreaterOrEqual(t, int(reportElems["observationsTimestamp"].(uint32)), int(testStartTimeStamp))
+		assert.InDelta(t, expectedBm.Int64(), reportElems["benchmarkPrice"].(*big.Int).Int64(), 5000000)
+		assert.InDelta(t, expectedBid.Int64(), reportElems["bid"].(*big.Int).Int64(), 5000000)
+		assert.InDelta(t, expectedAsk.Int64(), reportElems["ask"].(*big.Int).Int64(), 5000000)
+		assert.GreaterOrEqual(t, int(currentBlock.Number().Int64()), int(reportElems["currentBlockNum"].(uint64)))
+		assert.NotEqual(t, common.Hash{}, common.Hash(reportElems["currentBlockHash"].([32]uint8)))
+		assert.LessOrEqual(t, int(reportElems["validFromBlockNum"].(uint64)), int(reportElems["currentBlockNum"].(uint64)))
+
+		t.Logf("oracle %x reported for feed %s (0x%x)", req.pk, feed.name, feed.id)
+
+		seen[feedID][req.pk] = struct{}{}
+		if len(seen[feedID]) == n {
+			t.Logf("all oracles reported for feed %x (0x%x)", feed.name, feed.id)
+			delete(seen, feedID)
+			if len(seen) == 0 {
+				break // saw all oracles; success!
+			}
+		}
+	}
+
+	pError.Store(20) // 20% chance of EA error
 	for i := range feeds {
 		// feedID will be deleted when all n oracles have reported
 		seen[feeds[i].id] = make(map[credentials.StaticSizedPublicKey]struct{}, n)

--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -404,6 +404,18 @@ func (r *runner) run(ctx context.Context, pipeline *Pipeline, run *Run, vars Var
 		taskRunResults = append(taskRunResults, result)
 	}
 
+	var idxs []int32
+	for i := range taskRunResults {
+		idxs = append(idxs, taskRunResults[i].Task.OutputIndex())
+	}
+	// Ensure that task run results are ordered by their output index
+	sort.SliceStable(taskRunResults, func(i, j int) bool {
+		return taskRunResults[i].Task.OutputIndex() < taskRunResults[j].Task.OutputIndex()
+	})
+	for i := range taskRunResults {
+		idxs[i] = taskRunResults[i].Task.OutputIndex()
+	}
+
 	return taskRunResults
 }
 

--- a/core/services/relay/evm/mercury/data_source.go
+++ b/core/services/relay/evm/mercury/data_source.go
@@ -35,9 +35,9 @@ func NewDataSource(pr pipeline.Runner, jb job.Job, spec pipeline.Spec, lggr logg
 }
 
 func (ds *datasource) Observe(ctx context.Context) (relaymercury.Observation, error) {
-	run, finalResult, err := ds.executeRun(ctx)
+	run, trrs, err := ds.executeRun(ctx)
 	if err != nil {
-		return relaymercury.Observation{}, err
+		return relaymercury.Observation{}, fmt.Errorf("Observe failed while executing run: %w", err)
 	}
 	select {
 	case ds.runResults <- run:
@@ -45,7 +45,7 @@ func (ds *datasource) Observe(ctx context.Context) (relaymercury.Observation, er
 		ds.lggr.Warnf("unable to enqueue run save for job ID %d, buffer full", ds.spec.JobID)
 	}
 
-	return ds.parse(finalResult)
+	return ds.parse(trrs)
 }
 
 func toBigInt(val interface{}) (*big.Int, error) {
@@ -56,52 +56,89 @@ func toBigInt(val interface{}) (*big.Int, error) {
 	return dec.BigInt(), nil
 }
 
-// parse converts the FinalResult into a Observation and stores it in the bridge metadata
-// expects the output of observe to be five values, in the following order:
-// - benchmark price
-// - bid
-// - ask
-// - current block number
-// - current block hash
-func (ds *datasource) parse(result pipeline.FinalResult) (obs relaymercury.Observation, merr error) {
-	if result.HasErrors() {
-		return obs, result.CombinedError()
+// parse expects the output of observe to be five values, in the following order:
+// 1. benchmark price
+// 2. bid
+// 3. ask
+// 4. current block number
+// 5. current block hash
+//
+// returns error on parse errors: if something is the wrong type
+func (ds *datasource) parse(trrs pipeline.TaskRunResults) (obs relaymercury.Observation, merr error) {
+	// pipeline.TaskRunResults comes ordered asc by index, this is guaranteed
+	// by the pipeline executor
+	if len(trrs) != 5 {
+		return obs, fmt.Errorf("invalid number of results, expected: 5, got: %d", len(trrs))
 	}
-	vals := result.Values
-	if len(vals) != 5 {
-		return obs, fmt.Errorf("invalid number of results, got: %s", vals)
-	}
-	for i := 0; i < len(vals); i++ {
-		var err error
-		switch i {
-		case 0:
-			obs.BenchmarkPrice, err = toBigInt(vals[i])
-		case 1:
-			obs.Bid, err = toBigInt(vals[i])
-		case 2:
-			obs.Ask, err = toBigInt(vals[i])
-		case 3:
-			if currentblocknum, is := vals[i].(int64); is {
-				obs.CurrentBlockNum = currentblocknum
-			} else {
-				err = fmt.Errorf("expected int64, got: %v", vals[i])
-			}
-		case 4:
-			if currentblockhash, is := vals[i].(common.Hash); is {
-				obs.CurrentBlockHash = currentblockhash.Bytes()
-			} else {
-				err = fmt.Errorf("expected hash, got: %v", vals[i])
-			}
-		}
-		merr = errors.Join(merr, err)
-	}
+	merr = errors.Join(
+		setBenchmarkPrice(&obs, trrs[0].Result),
+		setBid(&obs, trrs[1].Result),
+		setAsk(&obs, trrs[2].Result),
+		setCurrentBlockNum(&obs, trrs[3].Result),
+		setCurrentBlockHash(&obs, trrs[4].Result),
+	)
 
 	return obs, merr
 }
 
+func setBenchmarkPrice(obs *relaymercury.Observation, res pipeline.Result) error {
+	if res.Error != nil {
+		obs.BenchmarkPrice.Err = res.Error
+	} else if val, err := toBigInt(res.Value); err != nil {
+		return fmt.Errorf("failed to parse BenchmarkPrice: %w", err)
+	} else {
+		obs.BenchmarkPrice.Val = val
+	}
+	return nil
+}
+
+func setBid(obs *relaymercury.Observation, res pipeline.Result) error {
+	if res.Error != nil {
+		obs.Bid.Err = res.Error
+	} else if val, err := toBigInt(res.Value); err != nil {
+		return fmt.Errorf("failed to parse Bid: %w", err)
+	} else {
+		obs.Bid.Val = val
+	}
+	return nil
+}
+
+func setAsk(obs *relaymercury.Observation, res pipeline.Result) error {
+	if res.Error != nil {
+		obs.Ask.Err = res.Error
+	} else if val, err := toBigInt(res.Value); err != nil {
+		return fmt.Errorf("failed to parse Ask: %w", err)
+	} else {
+		obs.Ask.Val = val
+	}
+	return nil
+}
+
+func setCurrentBlockNum(obs *relaymercury.Observation, res pipeline.Result) error {
+	if res.Error != nil {
+		obs.CurrentBlockNum.Err = res.Error
+	} else if val, is := res.Value.(int64); !is {
+		return fmt.Errorf("failed to parse CurrentBlockNum: expected int64, got: %T (%v)", res.Value, res.Value)
+	} else {
+		obs.CurrentBlockNum.Val = val
+	}
+	return nil
+}
+
+func setCurrentBlockHash(obs *relaymercury.Observation, res pipeline.Result) error {
+	if res.Error != nil {
+		obs.CurrentBlockHash.Err = res.Error
+	} else if val, is := res.Value.(common.Hash); !is {
+		return fmt.Errorf("failed to parse CurrentBlockHash: expected hash, got: %T (%v)", res.Value, res.Value)
+	} else {
+		obs.CurrentBlockHash.Val = val.Bytes()
+	}
+	return nil
+}
+
 // The context passed in here has a timeout of (ObservationTimeout + ObservationGracePeriod).
 // Upon context cancellation, its expected that we return any usable values within ObservationGracePeriod.
-func (ds *datasource) executeRun(ctx context.Context) (pipeline.Run, pipeline.FinalResult, error) {
+func (ds *datasource) executeRun(ctx context.Context) (pipeline.Run, pipeline.TaskRunResults, error) {
 	vars := pipeline.NewVarsFrom(map[string]interface{}{
 		"jb": map[string]interface{}{
 			"databaseID":    ds.jb.ID,
@@ -110,11 +147,19 @@ func (ds *datasource) executeRun(ctx context.Context) (pipeline.Run, pipeline.Fi
 		},
 	})
 
+	// NOTE: trrs comes back as _all_ tasks, but we only want the terminal ones
+	// They are guaranteed to be sorted by index asc so should be in the correct order
 	run, trrs, err := ds.pipelineRunner.ExecuteRun(ctx, ds.spec, vars, ds.lggr)
 	if err != nil {
-		return pipeline.Run{}, pipeline.FinalResult{}, pkgerrors.Wrapf(err, "error executing run for spec ID %v", ds.spec.ID)
+		return pipeline.Run{}, nil, pkgerrors.Wrapf(err, "error executing run for spec ID %v", ds.spec.ID)
 	}
-	finalResult := trrs.FinalResult(ds.lggr)
+	var finaltrrs []pipeline.TaskRunResult
+	for _, trr := range trrs {
+		// only return terminal trrs from executeRun
+		if trr.IsTerminal() {
+			finaltrrs = append(finaltrrs, trr)
+		}
+	}
 
-	return run, finalResult, err
+	return run, finaltrrs, err
 }

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -1034,7 +1034,7 @@ func (m *KeyedMutex) LockInt64(key int64) func() {
 	mtx := value.(*sync.Mutex)
 	mtx.Lock()
 
-	return func() { mtx.Unlock() }
+	return mtx.Unlock
 }
 
 // BoxOutput formats its arguments as fmt.Printf, and encloses them in a box of

--- a/go.mod
+++ b/go.mod
@@ -60,7 +60,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.22.12
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chainlink-cosmos v0.1.7-0.20230407210547-2b9d8b0180ee
-	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230328133051-9d3eb8328c82
+	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af
 	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230328132724-705a2932e300
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230328102724-20c5e1a716e9
 	github.com/smartcontractkit/libocr v0.0.0-20230301222433-aec519050c9a

--- a/go.sum
+++ b/go.sum
@@ -1343,8 +1343,8 @@ github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartcontractkit/chainlink-cosmos v0.1.7-0.20230407210547-2b9d8b0180ee h1:wHyuoacM5Sn9XNioZ/55q7ZqzByzZoj5kRZLCoXrOVU=
 github.com/smartcontractkit/chainlink-cosmos v0.1.7-0.20230407210547-2b9d8b0180ee/go.mod h1:yvxsFQ1U+f46SsH6Sv5lZ6DDYzcc7jHS3im+A1G+6+M=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230328133051-9d3eb8328c82 h1:VsNyxHnmCIpCtryMyWDv9SIseroCINOp1bme7wdXXns=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230328133051-9d3eb8328c82/go.mod h1:jhYQLbmWJvlkET6zlnx961itsCZEhmG8QP19It664eQ=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af h1:m6yTktuVTeCPm+qhKbFEhaNY2SjwQ57eTL/40kngVIE=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af/go.mod h1:jhYQLbmWJvlkET6zlnx961itsCZEhmG8QP19It664eQ=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230328132724-705a2932e300 h1:3zjEZ8Hh1EVcu8A+7KVhD3fcWWgFKLeobgessj8OAOs=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230328132724-705a2932e300/go.mod h1:iHMsx8HUSpq//xsC19+IexGtJ8GQWe7aMdsYjwr/Kug=
 github.com/smartcontractkit/chainlink-starknet/ops v0.0.0-20230214070706-9544d04bb4d8 h1:GRx8L71lgGIeTYIbgsXGQ/JFWKPEnAmJVO42zQ3n69A=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -289,7 +289,7 @@ require (
 	github.com/shirou/gopsutil/v3 v3.22.12 // indirect
 	github.com/shopspring/decimal v1.3.1 // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
-	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230328133051-9d3eb8328c82 // indirect
+	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af // indirect
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230328102724-20c5e1a716e9 // indirect
 	github.com/smartcontractkit/sqlx v1.3.5-0.20210805004948-4be295aacbeb // indirect
 	github.com/smartcontractkit/wsrpc v0.6.2-0.20230317160629-382a1ac921d8 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1935,8 +1935,8 @@ github.com/slack-go/slack v0.12.1/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQ
 github.com/smartcontractkit/chainlink-cosmos v0.1.7-0.20230407210547-2b9d8b0180ee h1:wHyuoacM5Sn9XNioZ/55q7ZqzByzZoj5kRZLCoXrOVU=
 github.com/smartcontractkit/chainlink-env v0.3.26 h1:PkITRsrefIEQvATQtp+macnFx9r8szzrlnsu9eFcl/o=
 github.com/smartcontractkit/chainlink-env v0.3.26/go.mod h1:9c0Czq4a6wZKY20BcoAlK29DnejQIiLo/MwKYtSFnHk=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230328133051-9d3eb8328c82 h1:VsNyxHnmCIpCtryMyWDv9SIseroCINOp1bme7wdXXns=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230328133051-9d3eb8328c82/go.mod h1:jhYQLbmWJvlkET6zlnx961itsCZEhmG8QP19It664eQ=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af h1:m6yTktuVTeCPm+qhKbFEhaNY2SjwQ57eTL/40kngVIE=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af/go.mod h1:jhYQLbmWJvlkET6zlnx961itsCZEhmG8QP19It664eQ=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230328132724-705a2932e300 h1:3zjEZ8Hh1EVcu8A+7KVhD3fcWWgFKLeobgessj8OAOs=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230328102724-20c5e1a716e9 h1:ib6EjsDRasmO2uCstsWSwWqsWeIiMBMMTR+5KcCozWo=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230328102724-20c5e1a716e9/go.mod h1:3xUS0kadHzpEM7JtoTHUJkSkByHCU+LbxnQVgCaLNJA=


### PR DESCRIPTION
- See [this](https://github.com/smartcontractkit/chainlink-relay) PR for relay component
- We now pass all observations and errors through individually instead
  of erroring if any single one observation fails
