### PR TITLE
Use MultiStage Build For Test Image To Reduce Size By About Half

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -40,6 +40,7 @@ jobs:
               - '**/*go.sum'
               - '**/*go.mod'
               - '.github/workflows/integration-tests.yml'
+              - '**/*Dockerfile'
       - name: Collect Metrics
         if: always()
         id: collect-gha-metrics

--- a/integration-tests/test.Dockerfile
+++ b/integration-tests/test.Dockerfile
@@ -1,10 +1,15 @@
 ARG BASE_IMAGE
 ARG IMAGE_VERSION=latest
-FROM ${BASE_IMAGE}:${IMAGE_VERSION}
+FROM ${BASE_IMAGE}:${IMAGE_VERSION} as builder
 
 ARG SUITES=chaos migration performance reorg smoke soak benchmark
 
 COPY . testdir/
 WORKDIR /go/testdir
 RUN /go/testdir/integration-tests/scripts/buildTests "${SUITES}"
+
+# Now pull in th repo and the build run executables only
+FROM ${BASE_IMAGE}:${IMAGE_VERSION}
+COPY . testdir/
+COPY --from=builder /go/testdir/integration-tests/*.test /go/testdir/integration-tests/
 ENTRYPOINT ["/go/testdir/integration-tests/scripts/entrypoint"]


### PR DESCRIPTION
Before multistage build the image size is about 1400mb and after is is roughly 700mb