### PR TITLE
Change project name to be valid per compose regex

### DIFF
--- a/.github/actions/setup-postgres/docker-compose.yml
+++ b/.github/actions/setup-postgres/docker-compose.yml
@@ -1,4 +1,4 @@
-name: Setup Postgres for GHA
+name: gha_postgres
 version: "3.8"
 services:
   postgres:


### PR DESCRIPTION
This invalid name is causing intermittent failures rather than full
failures in CI due to different runner images being used within
the same CI pool. The newest image being run uses v2.17.2 which fails
invalid project name, whereas the older images silently coerce the
project name to be valid.

See https://github.com/docker/compose/issues/10431
