### PR TITLE
core/logger: remove deprecated logger methods

### DIFF
--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"fmt"
-	"io"
 	"log"
 	"os"
 	"path/filepath"
@@ -95,14 +94,6 @@ type Logger interface {
 	Criticalw(msg string, keysAndValues ...interface{})
 	Panicw(msg string, keysAndValues ...interface{})
 	Fatalw(msg string, keysAndValues ...interface{})
-
-	// ErrorIf logs the error if present.
-	// Deprecated: use SugaredLogger.ErrorIf
-	ErrorIf(err error, msg string)
-
-	// ErrorIfClosing calls c.Close() and logs any returned error along with name.
-	// Deprecated: use SugaredLogger.ErrorIfFn with c.Close
-	ErrorIfClosing(c io.Closer, name string)
 
 	// Sync flushes any buffered log entries.
 	// Some insignificant errors are suppressed.

--- a/core/logger/logger_mock_test.go
+++ b/core/logger/logger_mock_test.go
@@ -3,8 +3,6 @@
 package logger
 
 import (
-	io "io"
-
 	mock "github.com/stretchr/testify/mock"
 	zapcore "go.uber.org/zap/zapcore"
 )
@@ -65,16 +63,6 @@ func (_m *MockLogger) Error(args ...interface{}) {
 	var _ca []interface{}
 	_ca = append(_ca, args...)
 	_m.Called(_ca...)
-}
-
-// ErrorIf provides a mock function with given fields: err, msg
-func (_m *MockLogger) ErrorIf(err error, msg string) {
-	_m.Called(err, msg)
-}
-
-// ErrorIfClosing provides a mock function with given fields: c, name
-func (_m *MockLogger) ErrorIfClosing(c io.Closer, name string) {
-	_m.Called(c, name)
 }
 
 // Errorf provides a mock function with given fields: format, values

--- a/core/logger/null_logger.go
+++ b/core/logger/null_logger.go
@@ -1,8 +1,6 @@
 package logger
 
 import (
-	"io"
-
 	"go.uber.org/zap/zapcore"
 )
 
@@ -42,10 +40,8 @@ func (l *nullLogger) Criticalw(msg string, keysAndValues ...interface{}) {}
 func (l *nullLogger) Panicw(msg string, keysAndValues ...interface{})    {}
 func (l *nullLogger) Fatalw(msg string, keysAndValues ...interface{})    {}
 
-func (l *nullLogger) ErrorIf(err error, msg string)    {}
-func (l *nullLogger) ErrorIfClosing(io.Closer, string) {}
-func (l *nullLogger) Sync() error                      { return nil }
-func (l *nullLogger) Helper(skip int) Logger           { return l }
-func (l *nullLogger) Name() string                     { return "nullLogger" }
+func (l *nullLogger) Sync() error            { return nil }
+func (l *nullLogger) Helper(skip int) Logger { return l }
+func (l *nullLogger) Name() string           { return "nullLogger" }
 
 func (l *nullLogger) Recover(panicErr interface{}) {}

--- a/core/logger/null_logger_test.go
+++ b/core/logger/null_logger_test.go
@@ -50,9 +50,7 @@ func TestNullLogger(t *testing.T) {
 		l.Criticalw("msg")
 		l.Panicw("msg")
 		l.Fatalw("msg")
-		l.ErrorIf(nil, "msg")
 		l.Recover(nil)
-		l.ErrorIfClosing(nil, "msg")
 		assert.Nil(t, l.Sync())
 	})
 }

--- a/core/logger/prometheus.go
+++ b/core/logger/prometheus.go
@@ -1,9 +1,6 @@
 package logger
 
 import (
-	"fmt"
-	"io"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"go.uber.org/zap/zapcore"
@@ -199,20 +196,6 @@ func (s *prometheusLogger) Panicw(msg string, keysAndValues ...interface{}) {
 func (s *prometheusLogger) Fatalw(msg string, keysAndValues ...interface{}) {
 	s.fatalCnt.Inc()
 	s.h.Fatalw(msg, keysAndValues...)
-}
-
-func (s *prometheusLogger) ErrorIf(err error, msg string) {
-	if err != nil {
-		s.errorCnt.Inc()
-		s.h.Errorw(msg, "err", err)
-	}
-}
-
-func (s *prometheusLogger) ErrorIfClosing(c io.Closer, name string) {
-	if err := c.Close(); err != nil {
-		s.errorCnt.Inc()
-		s.h.Errorw(fmt.Sprintf("Error closing %s", name), "err", err)
-	}
 }
 
 func (s *prometheusLogger) Sync() error {

--- a/core/logger/prometheus_test.go
+++ b/core/logger/prometheus_test.go
@@ -71,8 +71,7 @@ func TestPrometheusLogger_Counters(t *testing.T) {
 
 	l.Errorf("msg")
 	l.Errorf("msg")
-	l.ErrorIfClosing(&errorCloser{}, "foo")
-	assertCounterValue(t, errorCounter, 7)
+	assertCounterValue(t, errorCounter, 6)
 
 	l.Criticalf("msg")
 	l.Criticalw("msg")

--- a/core/logger/sentry.go
+++ b/core/logger/sentry.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"fmt"
-	"io"
 	"time"
 
 	"github.com/getsentry/sentry-go"
@@ -236,20 +235,6 @@ func (s *sentryLogger) Fatalw(msg string, keysAndValues ...interface{}) {
 	})
 	eid := hub.CaptureMessage(msg)
 	s.h.Fatalw(msg, append(keysAndValues, "sentryEventID", eid)...)
-}
-
-func (s *sentryLogger) ErrorIf(err error, msg string) {
-	if err != nil {
-		eid := sentry.CaptureException(err)
-		s.h.Errorw(msg, "err", err, "sentryEventID", eid)
-	}
-}
-
-func (s *sentryLogger) ErrorIfClosing(c io.Closer, name string) {
-	if err := c.Close(); err != nil {
-		eid := sentry.CaptureException(err)
-		s.h.Errorw(fmt.Sprintf("Error closing %s", name), "err", err, "sentryEventID", eid)
-	}
 }
 
 func (s *sentryLogger) Sync() error {

--- a/core/logger/zap.go
+++ b/core/logger/zap.go
@@ -1,8 +1,6 @@
 package logger
 
 import (
-	"fmt"
-	"io"
 	"os"
 
 	"github.com/pkg/errors"
@@ -79,18 +77,6 @@ func (l *zapLogger) Name() string {
 
 func (l *zapLogger) sugaredHelper(skip int) *zap.SugaredLogger {
 	return l.SugaredLogger.WithOptions(zap.AddCallerSkip(skip))
-}
-
-func (l *zapLogger) ErrorIf(err error, msg string) {
-	if err != nil {
-		l.Helper(1).Errorw(msg, "err", err)
-	}
-}
-
-func (l *zapLogger) ErrorIfClosing(c io.Closer, name string) {
-	if err := c.Close(); err != nil {
-		l.Helper(1).Errorw(fmt.Sprintf("Error closing %s", name), "err", err)
-	}
 }
 
 func (l *zapLogger) Sync() error {


### PR DESCRIPTION
The first-class `Logger` methods `ErrorIf` and `ErrorIfClosing` have been deprecated for a while now, in favor of the `SugaredLogger` variants. This change removes them.