### PR TITLE
Nix: refactor and update flakes

### DIFF
--- a/contracts/scripts/get_solc
+++ b/contracts/scripts/get_solc
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -e
+
+# Returns solc command matching given version
+
+if [ -z "${1}" ]; then
+  echo "Usage: "
+  echo "\$ solc=\$( ${0} 0.x.y )"
+  echo "\$ \$solc <args>"
+  exit 1
+fi
+
+solc="solc-${1}"
+if [ -x "$(command -v "${solc}")" ]; then
+  echo "${solc}"
+else
+  # TODO: maybe replace solc-select with [svm-rs](https://github.com/roynalnaruto/svm-rs), to share downloaded solcs with foundry
+  if ! [ -x "$(command -v solc-select)" ]; then
+    python3 -m pip install --require-hashes -r "$(dirname ${0})/requirements.txt" >&2
+  fi
+  solc-select install "${1}" >&2
+  solc-select use "${1}" >&2
+  echo "solc"
+fi

--- a/contracts/scripts/native_solc6_compile
+++ b/contracts/scripts/native_solc6_compile
@@ -7,9 +7,9 @@
 # The resulting abi and bin files are stored in ./contracts/solc/v0.6
 
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; cd .. && pwd -P )"
+solc="$( "$(dirname $0)/get_solc" 0.6.6 )"
 
-solc-select use 0.6.6
-solc --overwrite --optimize --optimize-runs 1000000 --metadata-hash none \
+"${solc}" --overwrite --optimize --optimize-runs 1000000 --metadata-hash none \
     -o $SCRIPTPATH/solc/v0.6 \
     --abi --bin --allow-paths $SCRIPTPATH/src/v0.6,$SCRIPTPATH/src/v0.6/dev,$SCRIPTPATH/src/v0.6/interfaces,$SCRIPTPATH/src/v0.6/examples,$SCRIPTPATH/src/v0.6/tests,$SCRIPTPATH/src/v0.6/vendor \
     $SCRIPTPATH/src/v0.6/$1

--- a/contracts/scripts/native_solc7_compile
+++ b/contracts/scripts/native_solc7_compile
@@ -7,9 +7,9 @@
 # The resulting abi and bin files are stored in ./contracts/solc/v0.7
 
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; cd .. && pwd -P )"
+solc="$( "$(dirname $0)/get_solc" 0.7.6 )"
 
-solc-select use 0.7.6
-solc --overwrite --optimize --optimize-runs 1000000 --metadata-hash none \
+"${solc}" --overwrite --optimize --optimize-runs 1000000 --metadata-hash none \
     -o $SCRIPTPATH/solc/v0.7 \
     --abi --bin --allow-paths $SCRIPTPATH/src/v0.7,$SCRIPTPATH/src/v0.7/dev,$SCRIPTPATH/src/v0.7/interfaces,$SCRIPTPATH/src/v0.7/tests,$SCRIPTPATH/src/v0.7/vendor \
     $SCRIPTPATH/src/v0.7/$1

--- a/contracts/scripts/native_solc8_15_compile
+++ b/contracts/scripts/native_solc8_15_compile
@@ -10,9 +10,9 @@ ROOT="$(
     cd "$(dirname "$0")" >/dev/null 2>&1
     cd ../../ && pwd -P
 )"
+solc="$( "$(dirname $0)/get_solc" 0.8.15 )"
 
-solc-select use 0.8.15
-solc @openzeppelin/=$ROOT/contracts/node_modules/@openzeppelin/ --overwrite --optimize --optimize-runs 1000000 --metadata-hash none \
+"${solc}" @openzeppelin/=$ROOT/contracts/node_modules/@openzeppelin/ --overwrite --optimize --optimize-runs 1000000 --metadata-hash none \
     -o $ROOT/contracts/solc/v0.8.15 \
     --abi --bin \
     --allow-paths $ROOT/contracts/src/v0.8,$ROOT/contracts/src/v0.8/dev,$ROOT/contracts/src/v0.8/interfaces,$ROOT/contracts/src/v0.8/mocks,$ROOT/contracts/src/v0.8/tests,$ROOT/contracts/src/v0.8/vendor,$ROOT/contracts/node_modules/.pnpm/@openzeppelin+contracts@4.3.3/node_modules/@openzeppelin/contracts,$ROOT/contracts/node_modules/.pnpm/@openzeppelin+contracts-upgradeable@4.7.3/node_modules/@openzeppelin/contracts-upgradeable \

--- a/contracts/scripts/native_solc8_16_compile
+++ b/contracts/scripts/native_solc8_16_compile
@@ -10,9 +10,9 @@ ROOT="$(
     cd "$(dirname "$0")" >/dev/null 2>&1
     cd ../../ && pwd -P
 )"
+solc="$( "$(dirname $0)/get_solc" 0.8.16 )"
 
-solc-select use 0.8.16
-solc @openzeppelin/=$ROOT/contracts/node_modules/@openzeppelin/ --overwrite --optimize --optimize-runs 1000000 --metadata-hash none \
+"${solc}" @openzeppelin/=$ROOT/contracts/node_modules/@openzeppelin/ --overwrite --optimize --optimize-runs 1000000 --metadata-hash none \
     -o $ROOT/contracts/solc/v0.8.16 \
     --abi --bin \
     --allow-paths $ROOT/contracts/src/v0.8,$ROOT/contracts/src/v0.8/dev,$ROOT/contracts/src/v0.8/interfaces,$ROOT/contracts/src/v0.8/mocks,$ROOT/contracts/src/v0.8/tests,$ROOT/contracts/src/v0.8/vendor,$ROOT/contracts/node_modules/.pnpm/@openzeppelin+contracts@4.3.3/node_modules/@openzeppelin/contracts,$ROOT/contracts/node_modules/.pnpm/@openzeppelin+contracts-upgradeable@4.7.3/node_modules/@openzeppelin/contracts-upgradeable \

--- a/contracts/scripts/native_solc8_19_compile_ocr2vrf
+++ b/contracts/scripts/native_solc8_19_compile_ocr2vrf
@@ -10,13 +10,12 @@ ROOT="$(
     cd "$(dirname "$0")" >/dev/null 2>&1
     cd ../../ && pwd -P
 )"
+solc="$( "$(dirname $0)/get_solc" 0.8.19 )"
 
-solc-select use 0.8.19
 # Optionally set optimize runs from arguments (default = 1000)
 OPTIMIZE_RUNS="${3}"
 
-solc-select use 0.8.19
-solc @openzeppelin/=$ROOT/contracts/node_modules/@openzeppelin/ --overwrite --optimize --optimize-runs $OPTIMIZE_RUNS --metadata-hash none \
+"${solc}" @openzeppelin/=$ROOT/contracts/node_modules/@openzeppelin/ --overwrite --optimize --optimize-runs $OPTIMIZE_RUNS --metadata-hash none \
     -o $ROOT/contracts/solc/v0.8.19 \
     --abi --bin \
     --allow-paths $ROOT/contracts/src/v0.8,$ROOT/../$2/contracts,$ROOT/contracts/src/v0.8/dev,$ROOT/contracts/src/v0.8/interfaces,$ROOT/contracts/src/v0.8/mocks,$ROOT/contracts/src/v0.8/tests,$ROOT/contracts/src/v0.8/vendor,$ROOT/contracts/node_modules/.pnpm/@openzeppelin+contracts@4.3.3/node_modules/@openzeppelin/contracts,$ROOT/contracts/node_modules/.pnpm/@openzeppelin+contracts-upgradeable@4.7.3/node_modules/@openzeppelin/contracts-upgradeable \

--- a/contracts/scripts/native_solc8_6_compile
+++ b/contracts/scripts/native_solc8_6_compile
@@ -10,12 +10,12 @@ ROOT="$(
     cd "$(dirname "$0")" >/dev/null 2>&1
     cd ../../ && pwd -P
 )"
+solc="$( "$(dirname $0)/get_solc" 0.8.6 )"
 
 # Optionally set optimize runs from arguments (default = 1000000)
-OPTIMIZE_RUNS="${2:-1000000}" 
+OPTIMIZE_RUNS="${2:-1000000}"
 
-solc-select use 0.8.6
-solc @openzeppelin/=$ROOT/contracts/node_modules/@openzeppelin/ --overwrite --optimize --optimize-runs $OPTIMIZE_RUNS --metadata-hash none \
+"${solc}" @openzeppelin/=$ROOT/contracts/node_modules/@openzeppelin/ --overwrite --optimize --optimize-runs $OPTIMIZE_RUNS --metadata-hash none \
     -o $ROOT/contracts/solc/v0.8.6 \
     --abi --bin \
     --allow-paths $ROOT/contracts/src/v0.8,$ROOT/contracts/src/v0.8/dev,$ROOT/contracts/src/v0.8/interfaces,$ROOT/contracts/src/v0.8/mocks,$ROOT/contracts/src/v0.8/tests,$ROOT/contracts/src/v0.8/vendor,$ROOT/contracts/node_modules/.pnpm/@openzeppelin+contracts@4.3.3/node_modules/@openzeppelin/contracts,$ROOT/contracts/node_modules/.pnpm/@openzeppelin+contracts-upgradeable@4.7.3/node_modules/@openzeppelin/contracts-upgradeable,$ROOT/contracts/node_modules/.pnpm/@openzeppelin+contracts-upgradeable@4.8.1/node_modules/@openzeppelin/contracts-upgradeable \

--- a/contracts/scripts/native_solc_compile_all
+++ b/contracts/scripts/native_solc_compile_all
@@ -4,12 +4,6 @@ set -e
 
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 echo $SCRIPTPATH
-python3 -m pip install --require-hashes -r $SCRIPTPATH/requirements.txt
-solc-select install 0.6.6
-solc-select install 0.7.6
-solc-select install 0.8.6
-solc-select install 0.8.15
-solc-select install 0.8.16
 
 $SCRIPTPATH/native_solc6_compile Flags.sol
 $SCRIPTPATH/native_solc6_compile Oracle.sol

--- a/contracts/scripts/native_solc_compile_all_functions
+++ b/contracts/scripts/native_solc_compile_all_functions
@@ -8,9 +8,7 @@ OPTIMIZE_RUNS="${2:-1000000}"
 
 
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-python3 -m pip install --require-hashes -r $SCRIPTPATH/requirements.txt
-solc-select install $SOLC_VERSION
-solc-select use $SOLC_VERSION
+solc="$( "$(dirname $0)/get_solc" ${SOLC_VERSION} )"
 export SOLC_VERSION=$SOLC_VERSION
 
 ROOT="$(
@@ -19,7 +17,7 @@ ROOT="$(
 )"
 
 compileContract () {
-  solc @openzeppelin/=$ROOT/contracts/node_modules/@openzeppelin/ --overwrite --optimize --optimize-runs $OPTIMIZE_RUNS --metadata-hash none \
+  "${solc}" @openzeppelin/=$ROOT/contracts/node_modules/@openzeppelin/ --overwrite --optimize --optimize-runs $OPTIMIZE_RUNS --metadata-hash none \
       -o $ROOT/contracts/solc/v$SOLC_VERSION \
       --abi --bin \
       --allow-paths $ROOT/contracts/src/v0.8,$ROOT/contracts/src/v0.8/functions,$ROOT/contracts/node_modules/.pnpm/@openzeppelin+contracts-upgradeable@4.8.1/node_modules/@openzeppelin/contracts-upgradeable \

--- a/contracts/scripts/native_solc_compile_all_llo
+++ b/contracts/scripts/native_solc_compile_all_llo
@@ -7,15 +7,13 @@ OPTIMIZE_RUNS=15000
 
 
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
-python3 -m pip install --require-hashes -r $SCRIPTPATH/requirements.txt
-solc-select install $SOLC_VERSION
-solc-select use $SOLC_VERSION
+solc="$( "$(dirname $0)/get_solc" ${SOLC_VERSION} )"
 export SOLC_VERSION=$SOLC_VERSION
 
 ROOT="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; cd ../../ && pwd -P )"
 
 compileContract () {
-  solc --overwrite --optimize --optimize-runs $OPTIMIZE_RUNS --metadata-hash none \
+  "${solc}" --overwrite --optimize --optimize-runs $OPTIMIZE_RUNS --metadata-hash none \
       -o $ROOT/contracts/solc/v$SOLC_VERSION \
       --abi --bin --allow-paths $ROOT/contracts/src/v0.8\
       $ROOT/contracts/src/v0.8/$1

--- a/contracts/scripts/native_solc_compile_all_ocr2vrf
+++ b/contracts/scripts/native_solc_compile_all_ocr2vrf
@@ -4,8 +4,6 @@ set -e
 
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 echo $SCRIPTPATH
-python3 -m pip install --require-hashes -r $SCRIPTPATH/requirements.txt
-solc-select install 0.8.19
 
 ## Change me.
 FOLDER="ocr2vrf-origin"

--- a/contracts/scripts/native_solc_compile_events_mock
+++ b/contracts/scripts/native_solc_compile_events_mock
@@ -4,8 +4,6 @@ set -e
 
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 echo $SCRIPTPATH
-python3 -m pip install --require-hashes -r $SCRIPTPATH/requirements.txt
-solc-select install 0.8.6
 
 # Mocks
 $SCRIPTPATH/native_solc8_6_compile mocks/FunctionsOracleEventsMock.sol

--- a/contracts/scripts/transmission/native_solc_compile_all_transmission
+++ b/contracts/scripts/transmission/native_solc_compile_all_transmission
@@ -4,8 +4,6 @@ set -e
 
 SCRIPTPATH="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; cd ..; pwd -P )"
 echo $SCRIPTPATH
-python3 -m pip install --require-hashes -r $SCRIPTPATH/requirements.txt
-solc-select install 0.8.15
 
 # Contracts
 $SCRIPTPATH/native_solc8_15_compile dev/transmission/4337/SCA.sol

--- a/core/internal/gethwrappers2/compile.sh
+++ b/core/internal/gethwrappers2/compile.sh
@@ -16,10 +16,17 @@ outpath="${pkgdir}/${pkgname}.go"
 abi="${pkgdir}/${basefilename}.abi"
 bin="${pkgdir}/${basefilename}.bin"
 
-solc-select use 0.7.6
-solc --version | grep 0.7.6 || ( echo "You need solc version 0.7.6" && exit 1 )
+version="0.7.6"
+solc="solc-${version}"
+if ! [ -x "$(command -v ${solc})" ]; then
+  # TODO: reuse contract's get_solc script
+  solc-select install "${version}"
+  solc-select use "${version}"
+  solc="solc"
+fi
+"${solc}" --version | grep "${version}" || ( echo "You need solc version ${version}" && exit 1 )
 
 # FIXME: solc seems to find and compile every .sol file in this path, so invoking this once for every file produces n*3 artifacts
-solc "$solpath" ${solcoptions[@]} --abi --bin --combined-json bin,bin-runtime,srcmap-runtime --overwrite -o "$(dirname $outpath)"
+"${solc}" "$solpath" ${solcoptions[@]} --abi --bin --combined-json bin,bin-runtime,srcmap-runtime --overwrite -o "$(dirname $outpath)"
 
 go run wrap.go "$abi" "$bin" "$basefilename" "$pkgname"

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,33 @@
 {
   "nodes": {
-    "flake-utils": {
+    "dapp": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1683789895,
+        "narHash": "sha256-UKgT70OwOZO1UI912qJQ1G0GMNWuPDA3sJBoVz9LVT0=",
+        "owner": "dapphub",
+        "repo": "dapptools",
+        "rev": "d214b81ae68fb280aaf3c43f6616c299adf0c828",
+        "type": "github"
+      },
+      "original": {
+        "owner": "dapphub",
+        "repo": "dapptools",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1681202837,
+        "narHash": "sha256-H+Rh19JDwRtpVPAWp64F+rlEtxUWBAQW28eAi3SRSzg=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "cfacdce06f30d2b68473a46042957675eebb3401",
         "type": "github"
       },
       "original": {
@@ -15,26 +36,107 @@
         "type": "github"
       }
     },
+    "flake-utils_2": {
+      "locked": {
+        "lastModified": 1644229661,
+        "narHash": "sha256-1YdnJAsNy69bpcjuoKdOYQX0YxZBiCYZo4Twxerqv7k=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "3cecb5b042f7f209c56ffd8371b2711a290ec797",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "foundry": {
+      "inputs": {
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs_2"
+      },
+      "locked": {
+        "lastModified": 1684141763,
+        "narHash": "sha256-5Z0OcAT+dS0l5u27ca6ZM5pLLwk0a9zuZxEQ5cHz5yw=",
+        "owner": "shazow",
+        "repo": "foundry.nix",
+        "rev": "54ff731cbae2f3d3f63604f0a7bd5f14e3cc709c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "shazow",
+        "repo": "foundry.nix",
+        "type": "github"
+      }
+    },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1666109165,
-        "narHash": "sha256-BMLyNVkr0oONuq3lKlFCRVuYqF75CO68Z8EoCh81Zdk=",
+        "lastModified": 1622820998,
+        "narHash": "sha256-1wobInAwYtngN9M4ZqdcIOXWvoyvPt2vDI9TcOvQyKA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "aa576357673d609e618d87db43210e49d4bb1789",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "aa576357673d609e618d87db43210e49d4bb1789",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1666753130,
+        "narHash": "sha256-Wff1dGPFSneXJLI2c0kkdWTgxnQ416KE6X4KnFkgPYQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "f540aeda6f677354f1e7144ab04352f61aaa0118",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "type": "indirect"
+      }
+    },
+    "nixpkgs_3": {
+      "locked": {
+        "lastModified": 1684120848,
+        "narHash": "sha256-gIwJ5ac1FwZEkCRwjY+gLwgD4G1Bw3Xtr2jr2XihMPo=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "32096899af23d49010bd8cf6a91695888d9d9e73",
+        "rev": "0cb867999eec4085e1c9ca61c09b72261fa63bb4",
         "type": "github"
       },
       "original": {
         "owner": "nixos",
-        "ref": "nixos-unstable",
+        "ref": "nixpkgs-unstable",
         "repo": "nixpkgs",
         "type": "github"
       }
     },
     "root": {
       "inputs": {
+        "dapp": "dapp",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "foundry": "foundry",
+        "nixpkgs": "nixpkgs_3"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -2,17 +2,32 @@
   description = "Chainlink development shell";
 
   inputs = {
-    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
+    dapp.url = "github:dapphub/dapptools";
+    foundry.url = "github:shazow/foundry.nix";
   };
 
-  outputs = inputs@{ self, nixpkgs, flake-utils, ... }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        pkgs = import nixpkgs { inherit system; overlays = [ ]; };
-      in
-      rec {
-        devShell = pkgs.callPackage ./shell.nix { };
-        formatter = pkgs.nixpkgs-fmt;
-      });
+  outputs = {
+    nixpkgs,
+    flake-utils,
+    dapp,
+    foundry,
+    ...
+  }:
+    flake-utils.lib.eachDefaultSystem (system: let
+      pkgs = import nixpkgs {inherit system;};
+      inherit (pkgs) lib;
+    in {
+      devShell = pkgs.callPackage ./shell.nix {
+        foundry-bin = foundry.defaultPackage.${system};
+        dapp =
+          dapp.packages.${system}
+          // {
+            solc-static-versions = with lib; filterAttrs (n: v: hasPrefix "solc" n) dapp.packages.${system};
+          };
+      };
+
+      formatter = pkgs.alejandra;
+    });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
   };
 
   outputs = {
+    self,
     nixpkgs,
     flake-utils,
     dapp,
@@ -18,7 +19,7 @@
     flake-utils.lib.eachDefaultSystem (system: let
       pkgs = import nixpkgs {inherit system;};
       inherit (pkgs) lib;
-    in {
+    in rec {
       devShell = pkgs.callPackage ./shell.nix {
         foundry-bin = foundry.defaultPackage.${system};
         dapp =
@@ -29,5 +30,56 @@
       };
 
       formatter = pkgs.alejandra;
+
+      packages = rec {
+        chainlink = let
+          ui-tag = lib.fileContents ./operator_ui/TAG;
+          operator-ui = builtins.fetchTarball {
+            name = "smartcontractkit-operator-ui-${ui-tag}";
+            url = "https://github.com/smartcontractkit/operator-ui/releases/download/${ui-tag}/smartcontractkit-operator-ui-${builtins.substring 1 99 ui-tag}.tgz";
+            sha256 = "sha256:17qlf5s7pzvgibkzmf4cav3lb8ycqk793c1b1mwx4hsi39afnasr"; # needs update when operator-ui gets updated
+          };
+        in
+          pkgs.buildGoModule rec {
+            pname = "chainlink";
+            version = lib.fileContents ./VERSION;
+            src = ./.;
+            vendorHash = "sha256-oNOLWVvRA1bAfdGgbDtawcK37WKRf43j1QhQWhBdTJk="; # needs update when go.mod gets updated
+            subPackages = ["."];
+            doCheck = false;
+            ldflags = let
+              prefix = "github.com/smartcontractkit/chainlink/v2/core/static";
+            in [
+              "-s"
+              "-w"
+              "-X ${prefix}.Version=${version}"
+              "-X ${prefix}.Sha=${self.rev or "dirty"}"
+              "-X ${prefix}.BuildUser=nix"
+              "-X ${prefix}.BuildDate=1980-01-01T00:00:00Z"
+            ];
+
+            preBuild = ''
+              cp -r ${operator-ui}/artifacts ./core/web/assets
+            '';
+            postInstall = ''
+              mkdir -p $out/lib
+              cp --reflink=auto vendor/github.com/CosmWasm/wasmvm/internal/api/libwasmvm.* $out/lib/
+
+              patchelf --print-rpath $out/bin/chainlink \
+              | sed "s|$(pwd)/vendor/github.com/CosmWasm/wasmvm/internal/api|$out/lib|" \
+              | xargs patchelf $out/bin/chainlink --set-rpath
+            '';
+          };
+
+        default = chainlink;
+      };
+
+      apps = rec {
+        chainlink = {
+          type = "app";
+          program = "${packages.chainlink}/bin/chainlink";
+        };
+        default = chainlink;
+      };
     });
 }

--- a/shell.nix
+++ b/shell.nix
@@ -1,50 +1,66 @@
-{ pkgs ? import <nixpkgs> { } }:
-with pkgs;
-let
-  go = go_1_19;
-  postgresql = postgresql_14;
-  nodejs = nodejs-16_x;
-  nodePackages = pkgs.nodePackages.override { inherit nodejs; };
-in
-mkShell {
-  nativeBuildInputs = [
-    go
+{
+  pkgs ? import <nixpkgs> {},
+  dapp ? let
+    lock = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.dapp.locked;
+  in
+    import (fetchTarball {
+      url = "https://github.com/dapphub/dapptools/archive/${lock.rev}.tar.gz";
+      sha256 = lock.narHash;
+    }) {inherit (pkgs) system;},
+  foundry-bin ? let
+    lock = (builtins.fromJSON (builtins.readFile ./flake.lock)).nodes.foundry.locked;
+  in
+    import (fetchTarball {
+        url = "https://github.com/shazow/foundry.nix/archive/${lock.rev}.tar.gz";
+        sha256 = lock.narHash;
+      }
+      + "/foundry-bin") {inherit pkgs;},
+}: let
+  go = pkgs.go_1_20;
+  postgresql = pkgs.postgresql_14;
+  nodejs = pkgs.nodejs-16_x;
+  nodePackages = pkgs.nodePackages.override {inherit nodejs;};
 
-    postgresql
-    python3
-    python3Packages.pip
-    curl
-    nodejs
-    nodePackages.pnpm
-    # TODO: compiler / gcc for secp compilation
-    nodePackages.ganache
-    # py3: web3 slither-analyzer crytic-compile
-    # echidna
-    go-ethereum # geth
-    # parity # openethereum
-    go-mockery
-
-    # tooling
-    gotools
-    gopls
-    delve
-    golangci-lint
-    github-cli
-
-    # gofuzz
-  ] ++ lib.optionals stdenv.isLinux [
-    # some dependencies needed for node-gyp on pnpm install
-    pkg-config
-    libudev-zero
-    libusb1
+  solcs = with dapp.solc-static-versions; [
+    solc_0_6_6
+    solc_0_7_6
+    solc_0_8_6
+    solc_0_8_15
+    solc_0_8_16
   ];
-  LD_LIBRARY_PATH = "${stdenv.cc.cc.lib}/lib64:$LD_LIBRARY_PATH";
-  GOROOT = "${go}/share/go";
+in
+  pkgs.mkShell {
+    nativeBuildInputs = with pkgs;
+      [
+        go
+        postgresql
+        curl
+        cacert
+        which
+        git
 
-  PGDATA = "db";
-  CL_DATABASE_URL = "postgresql://chainlink:chainlink@localhost:5432/chainlink_test?sslmode=disable";
-  shellHook = ''
-    export GOPATH=$HOME/go
-    export PATH=$GOPATH/bin:$PATH
-  '';
-}
+        nodejs
+        nodePackages.pnpm
+        # TODO: compiler / gcc for secp compilation
+        nodePackages.ganache
+        go-ethereum # geth
+
+        # tooling
+        gotools
+        gopls
+        delve
+        golangci-lint
+        go-mockery
+
+        github-cli
+        kubernetes
+
+        # gofuzz
+        foundry-bin
+        lcov
+      ]
+      ++ solcs;
+
+    # env vars
+    CL_DATABASE_URL = "postgresql://chainlink:chainlink@localhost:5432/chainlink_test?sslmode=disable";
+  }


### PR DESCRIPTION
Flakes are long outdated and non-functional.
This PR updates its lock, and refactor flake and shell.nix, to use statically compiled solcs on development environment.

Since this allows using solc binaries fetched deterministically using Nix, made available in dev shell as versioned commands (e.g. `solc-0.8.15`), the `solc-select` logic is extracted to its own `get_solc` script, and bypassed when the needed binaries are found in PATH, so to avoid the need of a custom venv at all.
In the future, this setup can be used also in CI.

Added also a flake package output to `flake.nix`, meaning one can run chainlink now with a simple:
```
nix run github:smartcontractkit/chainlink
```

Unfortunately, `vendorHash` (and operator-ui's) needs to be hardcoded (for determinism purposes), so it'll get out of sync pretty soon.
I hope to work on tooling to have it automatically kept in sync in a follow up.