### PR TITLE
Print available p2p keys in case of multiple p2p error

### DIFF
--- a/core/services/keystore/p2p.go
+++ b/core/services/keystore/p2p.go
@@ -2,6 +2,7 @@ package keystore
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/pkg/errors"
 
@@ -186,9 +187,15 @@ func (ks *p2p) GetOrFirst(id p2pkey.PeerID) (p2pkey.KeyV2, error) {
 	} else if len(ks.keyRing.P2P) == 0 {
 		return p2pkey.KeyV2{}, ErrNoP2PKey
 	}
+	possibleKeys := make([]string, 0, len(ks.keyRing.P2P))
+	for _, key := range ks.keyRing.P2P {
+		possibleKeys = append(possibleKeys, key.ID())
+	}
+	//To avoid ambiguity, we require the user to specify a peer ID if there are multiple keys
 	return p2pkey.KeyV2{}, errors.New(
 		"multiple p2p keys found but peer ID was not set - you must specify a P2P.PeerID " +
-			"env var if you have more than one key, or delete the keys you aren't using",
+			"config var if you have more than one key, or delete the keys you aren't using" +
+			" (possible keys: " + strings.Join(possibleKeys, ", ") + ")",
 	)
 }
 

--- a/core/services/keystore/p2p_test.go
+++ b/core/services/keystore/p2p_test.go
@@ -134,6 +134,11 @@ func Test_P2PKeyStore_E2E(t *testing.T) {
 		require.NoError(t, err)
 		_, err = ks.GetOrFirst("")
 		require.Contains(t, err.Error(), "multiple p2p keys found")
+		//Check for possible keys in error message
+		require.Contains(t, err.Error(), k1.ID())
+		require.Contains(t, err.Error(), k2.ID())
+		require.Contains(t, err.Error(), k3.ID())
+
 		k4, err := ks.GetOrFirst(k1.PeerID())
 		require.NoError(t, err)
 		require.Equal(t, k1, k4)


### PR DESCRIPTION
If the node cannot start because of a multiple p2p keys error the user is required to configure a p2p.PeerID but the PeerID is cannot be fetched from the CLI or UI as the node does not start.

To work around this issue we print the available PeerIDs in the multiple p2p error