### PR TITLE
core: move main.go to root; simplify make build/install

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -166,7 +166,7 @@ jobs:
       - name: Download Go vendor packages
         run: go mod download
       - name: Build binary
-        run: go build -o chainlink.test ./core
+        run: go build -o chainlink.test .
       - name: Setup DB
         run: ./chainlink.test local db preparetest
       - name: Increase Race Timeout

--- a/.goreleaser.develop.yaml
+++ b/.goreleaser.develop.yaml
@@ -22,7 +22,6 @@ builds:
       - linux
     goarch:
       - arm64
-    main: ./core
     hooks:
       post: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }} {{ .Os }} {{ .Arch }}
     env:
@@ -42,7 +41,6 @@ builds:
       - linux
     goarch:
       - amd64
-    main: ./core
     hooks:
       post: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }} {{ .Os }} {{ .Arch }}
     env:

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,6 @@ builds:
       - linux
     goarch:
       - arm64
-    main: ./core
     hooks:
       post: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }} {{ .Os }} {{ .Arch }}
     env:
@@ -42,7 +41,6 @@ builds:
       - linux
     goarch:
       - amd64
-    main: ./core
     hooks:
       post: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }} {{ .Os }} {{ .Arch }}
     env:
@@ -62,7 +60,6 @@ builds:
       - darwin
     goarch:
       - arm64
-    main: ./core
     hooks:
       post: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }} {{ .Os }} {{ .Arch }}
     env:
@@ -82,7 +79,6 @@ builds:
       - darwin
     goarch:
       - amd64
-    main: ./core
     hooks:
       post: ./tools/bin/goreleaser_utils build_post_hook {{ dir .Path }} {{ .Os }} {{ .Arch }}
     env:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,9 +1,7 @@
 .DEFAULT_GOAL := chainlink
 
-GOPATH ?= $(HOME)/go
 COMMIT_SHA ?= $(shell git rev-parse HEAD)
 VERSION = $(shell cat VERSION)
-GOBIN ?= $(GOPATH)/bin
 GO_LDFLAGS := $(shell tools/bin/ldflags)
 GOFLAGS = -ldflags "$(GO_LDFLAGS)"
 
@@ -37,25 +35,17 @@ gomodtidy: ## Run go mod tidy on all modules.
 	cd ./integration-tests && go mod tidy
 
 .PHONY: install-chainlink
-install-chainlink: chainlink ## Install the chainlink binary.
-	mkdir -p $(GOBIN)
-	rm -f $(GOBIN)/chainlink
-	cp $< $(GOBIN)/chainlink
+install-chainlink: operator-ui ## Install the chainlink binary.
+	go install $(GOFLAGS) .
 
 chainlink: operator-ui ## Build the chainlink binary.
-	go build $(GOFLAGS) -o $@ ./core/
+	go build $(GOFLAGS) .
 
 .PHONY: docker ## Build the chainlink docker image
 docker:
 	docker buildx build \
 	--build-arg COMMIT_SHA=$(COMMIT_SHA) \
 	-f core/chainlink.Dockerfile .
-
-.PHONY: chainlink-build
-chainlink-build: operator-ui ## Build & install the chainlink binary.
-	go build $(GOFLAGS) -o chainlink ./core/
-	rm -f $(GOBIN)/chainlink
-	cp chainlink $(GOBIN)/chainlink
 
 .PHONY: operator-ui
 operator-ui: ## Fetch the frontend
@@ -91,17 +81,17 @@ generate: abigen codecgen mockery ## Execute all go:generate commands.
 
 .PHONY: testdb
 testdb: ## Prepares the test database.
-	go run ./core/main.go local db preparetest
+	go run . local db preparetest
 
 .PHONY: testdb
 testdb-user-only: ## Prepares the test database with user only.
-	go run ./core/main.go local db preparetest --user-only
+	go run . local db preparetest --user-only
 
 # Format for CI
 .PHONY: presubmit
 presubmit: ## Format go files and imports.
-	goimports -w ./core
-	gofmt -w ./core
+	goimports -w .
+	gofmt -w .
 	go mod tidy
 
 .PHONY: mockery
@@ -128,7 +118,7 @@ test_need_operator_assets: ## Add blank file in web assets if operator ui has no
 
 .PHONY: config-docs
 config-docs: ## Generate core node configuration documentation
-	go run ./core/config/v2/docs/cmd/generate/main.go -o ./docs/
+	go run ./core/config/v2/docs/cmd/generate -o ./docs/
 
 .PHONY: golangci-lint
 golangci-lint: ## Run golangci-lint for all issues.

--- a/README.md
+++ b/README.md
@@ -173,7 +173,7 @@ Note: Other environment variables should not be set for all tests to pass
 6.  Drop/Create test database and run migrations:
 
 ```
-go run ./core/main.go local db preparetest
+make testdb
 ```
 
 If you do end up modifying the migrations for the database, you will need to rerun

--- a/config_docs_test.go
+++ b/config_docs_test.go
@@ -1,4 +1,4 @@
-package chainlink
+package main
 
 import (
 	_ "embed"

--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -12,12 +12,10 @@ RUN go mod download
 # Env vars needed for chainlink build
 ARG COMMIT_SHA
 
-COPY common common
-COPY core core
-COPY operator_ui operator_ui
+COPY . .
 
 # Build the golang binary
-RUN make chainlink-build
+RUN make install-chainlink
 
 # Final image: ubuntu with chainlink binary
 FROM ubuntu:20.04

--- a/core/main.go
+++ b/core/main.go
@@ -1,4 +1,4 @@
-package main
+package core
 
 import (
 	"fmt"
@@ -25,7 +25,7 @@ func init() {
 	}
 }
 
-func main() {
+func Main() {
 	recovery.ReportPanics(func() {
 		run(newProductionClient(), os.Args...)
 	})

--- a/core/main_test.go
+++ b/core/main_test.go
@@ -1,7 +1,7 @@
 //go:build !windows
 // +build !windows
 
-package main
+package core
 
 import (
 	"io"

--- a/main.go
+++ b/main.go
@@ -1,0 +1,9 @@
+package main
+
+import (
+	"github.com/smartcontractkit/chainlink/v2/core"
+)
+
+func main() {
+	core.Main()
+}

--- a/tools/bin/cldev
+++ b/tools/bin/cldev
@@ -9,9 +9,9 @@ case "$1" in
     node | core | n)
       key='0x9CA9d2D5E04012C9Ed24C0e513C9bfAa4A2dD77f'
       echo "** Running node"
-      go run -ldflags "$LDFLAGS" ./core/main.go --  node start -d -p tools/secrets/password.txt -a tools/secrets/apicredentials
+      go run -ldflags "$LDFLAGS" . --  node start -d -p tools/secrets/password.txt -a tools/secrets/apicredentials
       ;;
     *)
-      go run ./core/main.go -- $@
+      go run . -- $@
       ;;
 esac

--- a/tools/bin/lint
+++ b/tools/bin/lint
@@ -2,6 +2,6 @@
 
 set -euo pipefail
 
-cd "$(dirname "$0")"/../../core
+cd "$(dirname "$0")"/../..
 
 golangci-lint --tests=false run

--- a/tools/docker/README.md
+++ b/tools/docker/README.md
@@ -243,7 +243,7 @@ This is nothing new, just a demonstration that you should be able to run all the
 $ make install
 
 # run go tests
-$ go run ./core/main.go local db preparetest
+$ make testdb
 $ go test ./...
 
 # run evm tests


### PR DESCRIPTION
By moving `main.go` from `chainlink/core/` to `chainlink/`, we no longer have to rename the binary when we build/install, so we can use the default go commands instead of manual scripts.