### PR TITLE
set replace for stable satori version 1.2.0

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -361,6 +361,9 @@ replace (
 	// replicating the replace directive on cosmos SDK
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
+	// Some dependency keeps trying to update this to an unstable version
+	github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
 	// Fix CVE-2022-41717
 	golang/golang.org/x/net => golang/golang.org/x/net v0.4.0
 )

--- a/go.mod
+++ b/go.mod
@@ -364,6 +364,9 @@ replace (
 	// replicating the replace directive on cosmos SDK
 	github.com/gogo/protobuf => github.com/regen-network/protobuf v1.3.3-alpha.regen.1
 
+	// Some dependency keeps trying to update this to an unstable version
+	github.com/satori/go.uuid => github.com/satori/go.uuid v1.2.0
+
 	// Fix CVE-2022-41717
 	golang/golang.org/x/net => golang/golang.org/x/net v0.4.0
 )


### PR DESCRIPTION
Motivation:
Some of inner dependencies trying to change version to unstable 1.2.1.x where we would need to change method signatures in core code which also afects fork repos like chainlink-ccip which we want to be in sync with core repo.