### PR TITLE
core/services/relay/evm: restore checksummed transmitter addresses [2.0.0]

### DIFF
--- a/core/services/relay/evm/config_poller.go
+++ b/core/services/relay/evm/config_poller.go
@@ -3,7 +3,6 @@ package evm
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
@@ -50,7 +49,7 @@ func configFromLog(logData []byte) (ocrtypes.ContractConfig, error) {
 
 	var transmitAccounts []ocrtypes.Account
 	for _, addr := range unpacked.Transmitters {
-		transmitAccounts = append(transmitAccounts, ocrtypes.Account(fmt.Sprintf("0x%x", addr)))
+		transmitAccounts = append(transmitAccounts, ocrtypes.Account(addr.String()))
 	}
 	var signers []ocrtypes.OnchainPublicKey
 	for _, addr := range unpacked.Signers {

--- a/core/services/relay/evm/config_poller_test.go
+++ b/core/services/relay/evm/config_poller_test.go
@@ -2,7 +2,6 @@ package evm
 
 import (
 	"math/big"
-	"strings"
 	"testing"
 	"time"
 
@@ -94,19 +93,13 @@ func TestConfigPoller(t *testing.T) {
 		return ocrtypes2.ConfigDigest{} != digest
 	}, testutils.WaitTimeout(t), 100*time.Millisecond).Should(gomega.BeTrue())
 
-	transmitters := make([]ocrtypes2.Account, len(contractConfig.Transmitters))
-	for i, t := range contractConfig.Transmitters {
-		tt := strings.ToLower(string(t))
-		transmitters[i] = ocrtypes2.Account(tt)
-	}
-
 	// Assert the config returned is the one we configured.
 	newConfig, err := logPoller.LatestConfig(testutils.Context(t), configBlock)
 	require.NoError(t, err)
 	// Note we don't check onchainConfig, as that is populated in the contract itself.
 	assert.Equal(t, digest, [32]byte(newConfig.ConfigDigest))
 	assert.Equal(t, contractConfig.Signers, newConfig.Signers)
-	assert.Equal(t, transmitters, newConfig.Transmitters)
+	assert.Equal(t, contractConfig.Transmitters, newConfig.Transmitters)
 	assert.Equal(t, contractConfig.F, newConfig.F)
 	assert.Equal(t, contractConfig.OffchainConfigVersion, newConfig.OffchainConfigVersion)
 	assert.Equal(t, contractConfig.OffchainConfig, newConfig.OffchainConfig)

--- a/core/services/relay/evm/contract_transmitter.go
+++ b/core/services/relay/evm/contract_transmitter.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"encoding/hex"
-	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum"
@@ -170,7 +169,7 @@ func (oc *contractTransmitter) LatestConfigDigestAndEpoch(ctx context.Context) (
 
 // FromAccount returns the account from which the transmitter invokes the contract
 func (oc *contractTransmitter) FromAccount() ocrtypes.Account {
-	return ocrtypes.Account(fmt.Sprintf("0x%x", oc.transmitter.FromAddress()))
+	return ocrtypes.Account(oc.transmitter.FromAddress().String())
 }
 
 func (oc *contractTransmitter) Start(ctx context.Context) error { return nil }

--- a/core/services/relay/evm/contract_transmitter_test.go
+++ b/core/services/relay/evm/contract_transmitter_test.go
@@ -3,7 +3,6 @@ package evm
 import (
 	"context"
 	"encoding/hex"
-	"fmt"
 	"strings"
 	"testing"
 
@@ -67,5 +66,5 @@ func TestContractTransmitter(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "000130da6b9315bd59af6b0a3f5463c0d0a39e92eaa34cbcbdbace7b3bfcc777", hex.EncodeToString(digest[:]))
 	assert.Equal(t, uint32(2), epoch)
-	assert.Equal(t, fmt.Sprintf("0x%x", sampleAddress), string(ot.FromAccount()))
+	assert.Equal(t, sampleAddress.String(), string(ot.FromAccount()))
 }


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCF-2205

Reverting a regression from #8340. Mercury uses plain hex, but these EVM addresses expect the checksummed format.