### PR TITLE
bump solana version: contains txm logging + race fixes

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -278,7 +278,7 @@ require (
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/smartcontractkit/chainlink-cosmos v0.1.7-0.20230407210547-2b9d8b0180ee // indirect
 	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af // indirect
-	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230328132724-705a2932e300 // indirect
+	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230418194802-3acf108c4b43 // indirect
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230328102724-20c5e1a716e9 // indirect
 	github.com/smartcontractkit/wsrpc v0.6.2-0.20230317160629-382a1ac921d8 // indirect
 	github.com/spacemonkeygo/spacelog v0.0.0-20180420211403-2296661a0572 // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1335,8 +1335,8 @@ github.com/smartcontractkit/chainlink-cosmos v0.1.7-0.20230407210547-2b9d8b0180e
 github.com/smartcontractkit/chainlink-cosmos v0.1.7-0.20230407210547-2b9d8b0180ee/go.mod h1:yvxsFQ1U+f46SsH6Sv5lZ6DDYzcc7jHS3im+A1G+6+M=
 github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af h1:m6yTktuVTeCPm+qhKbFEhaNY2SjwQ57eTL/40kngVIE=
 github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af/go.mod h1:jhYQLbmWJvlkET6zlnx961itsCZEhmG8QP19It664eQ=
-github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230328132724-705a2932e300 h1:3zjEZ8Hh1EVcu8A+7KVhD3fcWWgFKLeobgessj8OAOs=
-github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230328132724-705a2932e300/go.mod h1:iHMsx8HUSpq//xsC19+IexGtJ8GQWe7aMdsYjwr/Kug=
+github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230418194802-3acf108c4b43 h1:le6F31/sNlRTtTh1GTStAb9W80Fay3MnziUh1W8n21c=
+github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230418194802-3acf108c4b43/go.mod h1:2m0mvZK6T91y1GLqX7XYtREqzAwBNI/2CPC4W2xiSFw=
 github.com/smartcontractkit/chainlink-starknet/ops v0.0.0-20230214070706-9544d04bb4d8 h1:GRx8L71lgGIeTYIbgsXGQ/JFWKPEnAmJVO42zQ3n69A=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230328102724-20c5e1a716e9 h1:ib6EjsDRasmO2uCstsWSwWqsWeIiMBMMTR+5KcCozWo=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230328102724-20c5e1a716e9/go.mod h1:3xUS0kadHzpEM7JtoTHUJkSkByHCU+LbxnQVgCaLNJA=

--- a/go.mod
+++ b/go.mod
@@ -61,7 +61,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chainlink-cosmos v0.1.7-0.20230407210547-2b9d8b0180ee
 	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af
-	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230328132724-705a2932e300
+	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230418194802-3acf108c4b43
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230328102724-20c5e1a716e9
 	github.com/smartcontractkit/libocr v0.0.0-20230413082317-9561d14087cc
 	github.com/smartcontractkit/ocr2keepers v0.6.14

--- a/go.sum
+++ b/go.sum
@@ -1345,8 +1345,8 @@ github.com/smartcontractkit/chainlink-cosmos v0.1.7-0.20230407210547-2b9d8b0180e
 github.com/smartcontractkit/chainlink-cosmos v0.1.7-0.20230407210547-2b9d8b0180ee/go.mod h1:yvxsFQ1U+f46SsH6Sv5lZ6DDYzcc7jHS3im+A1G+6+M=
 github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af h1:m6yTktuVTeCPm+qhKbFEhaNY2SjwQ57eTL/40kngVIE=
 github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af/go.mod h1:jhYQLbmWJvlkET6zlnx961itsCZEhmG8QP19It664eQ=
-github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230328132724-705a2932e300 h1:3zjEZ8Hh1EVcu8A+7KVhD3fcWWgFKLeobgessj8OAOs=
-github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230328132724-705a2932e300/go.mod h1:iHMsx8HUSpq//xsC19+IexGtJ8GQWe7aMdsYjwr/Kug=
+github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230418194802-3acf108c4b43 h1:le6F31/sNlRTtTh1GTStAb9W80Fay3MnziUh1W8n21c=
+github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230418194802-3acf108c4b43/go.mod h1:2m0mvZK6T91y1GLqX7XYtREqzAwBNI/2CPC4W2xiSFw=
 github.com/smartcontractkit/chainlink-starknet/ops v0.0.0-20230214070706-9544d04bb4d8 h1:GRx8L71lgGIeTYIbgsXGQ/JFWKPEnAmJVO42zQ3n69A=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230328102724-20c5e1a716e9 h1:ib6EjsDRasmO2uCstsWSwWqsWeIiMBMMTR+5KcCozWo=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230328102724-20c5e1a716e9/go.mod h1:3xUS0kadHzpEM7JtoTHUJkSkByHCU+LbxnQVgCaLNJA=

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1322,7 +1322,7 @@ github.com/smartcontractkit/chainlink-env v0.3.29 h1:hcIw/BeuB0wKiiE3umAUNBZzWkH
 github.com/smartcontractkit/chainlink-env v0.3.29/go.mod h1:9c0Czq4a6wZKY20BcoAlK29DnejQIiLo/MwKYtSFnHk=
 github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af h1:m6yTktuVTeCPm+qhKbFEhaNY2SjwQ57eTL/40kngVIE=
 github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230411134126-4c780ac039af/go.mod h1:jhYQLbmWJvlkET6zlnx961itsCZEhmG8QP19It664eQ=
-github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230328132724-705a2932e300 h1:3zjEZ8Hh1EVcu8A+7KVhD3fcWWgFKLeobgessj8OAOs=
+github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230418194802-3acf108c4b43 h1:le6F31/sNlRTtTh1GTStAb9W80Fay3MnziUh1W8n21c=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230328102724-20c5e1a716e9 h1:ib6EjsDRasmO2uCstsWSwWqsWeIiMBMMTR+5KcCozWo=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230328102724-20c5e1a716e9/go.mod h1:3xUS0kadHzpEM7JtoTHUJkSkByHCU+LbxnQVgCaLNJA=
 github.com/smartcontractkit/chainlink-testing-framework v1.11.5 h1:gYSnOQhLxgE0mxwnv015nNnPgH9kcosx+AzPboEFo38=


### PR DESCRIPTION
corresponding PR in chainlink-solana: https://github.com/smartcontractkit/chainlink-solana/pull/499