### PR TITLE
LOOP plugins: Solana Relayer + Median

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -52,7 +52,16 @@ jobs:
     permissions:
       id-token: write
       contents: read
-    name: Build Chainlink Image
+    strategy:
+      matrix:
+        image:
+          - name: ""
+            dockerfile: core/chainlink.Dockerfile
+            tag-suffix: ""
+          - name: (plugins)
+            dockerfile: plugins/chainlink.Dockerfile
+            tag-suffix: -plugins
+    name: Build Chainlink Image ${{ matrix.image.name }}
     runs-on: ubuntu20.04-16cores-64GB
     needs: [changes]
     steps:
@@ -63,7 +72,7 @@ jobs:
         with:
           basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
           hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
-          this-job-name: Build Chainlink Image
+          this-job-name: Build Chainlink Image ${{ matrix.image.name }}
         continue-on-error: true
       - name: Checkout the repo
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -75,16 +84,17 @@ jobs:
         uses: smartcontractkit/chainlink-github-actions/docker/image-exists@ab595504ae9cf10c60eb8d2c5ce025284e58b210 #v2.1.5
         with:
           repository: chainlink
-          tag: ${{ github.sha }}
+          tag: ${{ github.sha }}${{ matrix.image.tag-suffix }}
           AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
       - name: Build Image
         if: steps.check-image.outputs.exists == 'false' && needs.changes.outputs.src == 'true'
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@ab595504ae9cf10c60eb8d2c5ce025284e58b210 # v2.1.5
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@2c9f401149f6c25fb632067b7e6626aebeee5d69
         with:
           cl_repo: smartcontractkit/chainlink
           cl_ref: ${{ github.sha }}
-          push_tag: ${{ env.CHAINLINK_IMAGE }}:${{ github.sha }}
+          cl_dockerfile: ${{ matrix.image.dockerfile }}
+          push_tag: ${{ env.CHAINLINK_IMAGE }}:${{ github.sha }}${{ matrix.image.tag-suffix }}
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
       - name: Print Chainlink Image Built
@@ -401,7 +411,14 @@ jobs:
       pull-requests: write
       id-token: write
       contents: read
-    name: Solana Smoke Tests
+    strategy:
+      matrix:
+        image:
+          - name: ""
+            tag-suffix: ""
+          - name: (plugins)
+            tag-suffix: -plugins
+    name: Solana Smoke Tests ${{ matrix.image.name }}
     runs-on: ubuntu-latest
     needs: [build-chainlink, solana-build-contracts, solana-test-image-exists, changes, get_solana_sha, solana-build-test-image]
     env:
@@ -417,7 +434,7 @@ jobs:
         with:
           basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
           hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
-          this-job-name: Solana Smoke Tests
+          this-job-name: Solana Smoke Tests (${{ matrix.image.name }})
           test-results-file: '{"testType":"go","filePath":"/tmp/gotest.log"}'
         continue-on-error: true
       - name: Checkout the repo
@@ -431,7 +448,7 @@ jobs:
         with:
           test_command_to_run: export ENV_JOB_IMAGE=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-solana-tests:${{ needs.get_solana_sha.outputs.sha }} && make test_smoke
           cl_repo: ${{ env.CHAINLINK_IMAGE }}
-          cl_image_tag: ${{ github.sha }}
+          cl_image_tag: ${{ github.sha }}${{ matrix.image.tag-suffix }}
           artifacts_location: /home/runner/work/chainlink-solana/chainlink-solana/integration-tests/logs
           publish_check_name: Solana Smoke Test Results
           go_mod_path: ./integration-tests/go.mod

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -47,11 +47,25 @@ install-chainlink: operator-ui ## Install the chainlink binary.
 chainlink: operator-ui ## Build the chainlink binary.
 	go build $(GOFLAGS) .
 
+.PHONY: install-solana
+install-solana: ## Build & install the chainlink-solana binary.
+	go install $(GOFLAGS) ./plugins/cmd/chainlink-solana
+
+.PHONY: install-median
+install-median: ## Build & install the chainlink-median binary.
+	go install $(GOFLAGS) ./plugins/cmd/chainlink-median
+
 .PHONY: docker ## Build the chainlink docker image
 docker:
 	docker buildx build \
 	--build-arg COMMIT_SHA=$(COMMIT_SHA) \
 	-f core/chainlink.Dockerfile .
+
+.PHONY: docker-plugins ## Build the chainlink-plugins docker image
+docker-plugins:
+	docker buildx build \
+	--build-arg COMMIT_SHA=$(COMMIT_SHA) \
+	-f plugins/chainlink.Dockerfile .
 
 .PHONY: operator-ui
 operator-ui: ## Fetch the frontend

--- a/core/chains/cosmos/chain.go
+++ b/core/chains/cosmos/chain.go
@@ -18,6 +18,8 @@ import (
 	cosmosclient "github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/client"
 	coscfg "github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/config"
 	"github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/db"
+	"github.com/smartcontractkit/chainlink/v2/core/chains"
+
 	"github.com/smartcontractkit/chainlink/v2/core/chains/cosmos/cosmostxm"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/cosmos/types"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -153,5 +155,5 @@ func (c *chain) HealthReport() map[string]error {
 }
 
 func (c *chain) SendTx(ctx context.Context, from, to string, amount *big.Int, balanceCheck bool) error {
-	return errors.New("unsupported") //TODO
+	return chains.ErrLOOPPUnsupported
 }

--- a/core/chains/errors.go
+++ b/core/chains/errors.go
@@ -1,0 +1,5 @@
+package chains
+
+import "errors"
+
+var ErrLOOPPUnsupported = errors.New("LOOPP not yet supported")

--- a/core/chains/evm/chain.go
+++ b/core/chains/evm/chain.go
@@ -263,7 +263,7 @@ func (c *chain) HealthReport() map[string]error {
 }
 
 func (c *chain) SendTx(ctx context.Context, from, to string, amount *big.Int, balanceCheck bool) error {
-	return errors.New("unsupported") //TODO
+	return chains.ErrLOOPPUnsupported
 }
 
 func (c *chain) ID() *big.Int                             { return c.id }

--- a/core/chains/starknet/chain.go
+++ b/core/chains/starknet/chain.go
@@ -14,6 +14,8 @@ import (
 	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/db"
 	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/txm"
 	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/starknet"
+	"github.com/smartcontractkit/chainlink/v2/core/chains"
+
 	"github.com/smartcontractkit/chainlink/v2/core/chains/starknet/types"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
@@ -126,5 +128,5 @@ func (c *chain) HealthReport() map[string]error {
 }
 
 func (c *chain) SendTx(ctx context.Context, from, to string, amount *big.Int, balanceCheck bool) error {
-	return errors.New("unsupported") //TODO
+	return chains.ErrLOOPPUnsupported
 }

--- a/core/cmd/client.go
+++ b/core/cmd/client.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path"
 	"path/filepath"
 	"strconv"
@@ -22,11 +23,16 @@ import (
 	"github.com/Masterminds/semver/v3"
 	"github.com/getsentry/sentry-go"
 	"github.com/gin-gonic/gin"
+	"github.com/pelletier/go-toml/v2"
 	"github.com/pkg/errors"
 	clipkg "github.com/urfave/cli"
 	"go.uber.org/multierr"
 	"go.uber.org/zap/zapcore"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
+	pkgsolana "github.com/smartcontractkit/chainlink-solana/pkg/solana"
+	"github.com/smartcontractkit/chainlink/v2/plugins"
 
 	"github.com/smartcontractkit/sqlx"
 
@@ -35,12 +41,14 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains/solana"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/starknet"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
+	v2 "github.com/smartcontractkit/chainlink/v2/core/config/v2"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/logger/audit"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
 	"github.com/smartcontractkit/chainlink/v2/core/services/periodicbackup"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 	"github.com/smartcontractkit/chainlink/v2/core/services/versioning"
 	"github.com/smartcontractkit/chainlink/v2/core/services/webhook"
 	"github.com/smartcontractkit/chainlink/v2/core/sessions"
@@ -226,10 +234,6 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg chainlink.G
 
 	if cfg.SolanaEnabled() {
 		solLggr := appLggr.Named("Solana")
-		opts := solana.ChainSetOpts{
-			Logger:   solLggr,
-			KeyStore: &keystore.SolanaSigner{keyStore.Solana()},
-		}
 		cfgs := cfg.SolanaConfigs()
 		var ids []string
 		for _, c := range cfgs {
@@ -241,10 +245,31 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg chainlink.G
 				return nil, errors.Wrap(err, "failed to setup Solana chains")
 			}
 		}
-		opts.Configs = solana.NewConfigs(cfgs)
-		chains.Solana, err = solana.NewChainSet(opts, cfgs)
-		if err != nil {
-			return nil, errors.Wrap(err, "failed to load Solana chainset")
+
+		if cmdName := v2.EnvSolanaPluginCmd.Get(); cmdName != "" {
+			tomls, err := toml.Marshal(struct {
+				Solana solana.SolanaConfigs
+			}{Solana: cfgs})
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to marshal Solana configs")
+			}
+			chainPluginService := loop.NewRelayerService(solLggr, func() *exec.Cmd {
+				cmd := exec.Command(cmdName)
+				plugins.SetEnvConfig(cmd, cfg)
+				return cmd
+			}, string(tomls), &keystore.SolanaSigner{keyStore.Solana()})
+			chains.Solana = chainPluginService
+		} else {
+			opts := solana.ChainSetOpts{
+				Logger:   solLggr,
+				KeyStore: &keystore.SolanaSigner{keyStore.Solana()},
+				Configs:  solana.NewConfigs(cfgs),
+			}
+			chainSet, err := solana.NewChainSet(opts, cfgs)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to load Solana chainset")
+			}
+			chains.Solana = relay.NewLocalRelayerService(pkgsolana.NewRelayer(solLggr, chainSet), chainSet)
 		}
 	}
 

--- a/core/cmd/solana_node_commands_test.go
+++ b/core/cmd/solana_node_commands_test.go
@@ -27,6 +27,7 @@ func solanaStartNewApplication(t *testing.T, cfgs ...*solana.SolanaConfig) *clte
 	})
 }
 
+// TODO fix https://smartcontract-it.atlassian.net/browse/BCF-2114
 func TestClient_IndexSolanaNodes(t *testing.T) {
 	t.Parallel()
 

--- a/core/config/v2/env.go
+++ b/core/config/v2/env.go
@@ -8,8 +8,10 @@ import (
 )
 
 var (
-	EnvConfig = Env("CL_CONFIG")
-	EnvDev    = Env("CL_DEV")
+	EnvConfig          = Env("CL_CONFIG")
+	EnvDev             = Env("CL_DEV")
+	EnvSolanaPluginCmd = Env("CL_SOLANA_CMD")
+	EnvMedianPluginCmd = Env("CL_MEDIAN_CMD")
 
 	EnvDatabaseAllowSimplePasswords = Env("CL_DATABASE_ALLOW_SIMPLE_PASSWORDS")
 	EnvDatabaseURL                  = EnvSecret("CL_DATABASE_URL")

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -18,11 +18,9 @@ import (
 	"github.com/smartcontractkit/sqlx"
 
 	pkgcosmos "github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos"
-	"github.com/smartcontractkit/chainlink-solana/pkg/solana"
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
 	starknetrelay "github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink"
 	starkchain "github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/chain"
-
-	relaytypes "github.com/smartcontractkit/chainlink-relay/pkg/types"
 
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/cosmos"
@@ -163,9 +161,9 @@ type ApplicationOpts struct {
 // Chains holds a ChainSet for each type of chain.
 type Chains struct {
 	EVM      evm.ChainSet
-	Cosmos   cosmos.ChainSet     // nil if disabled
-	Solana   solana.ChainSet     // nil if disabled
-	StarkNet starkchain.ChainSet // nil if disabled
+	Cosmos   cosmos.ChainSet      // nil if disabled
+	Solana   relay.RelayerService // nil if disabled
+	StarkNet starkchain.ChainSet  // nil if disabled
 }
 
 func (c *Chains) services() (s []services.ServiceCtx) {
@@ -383,26 +381,27 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 	}
 	if cfg.FeatureOffchainReporting2() {
 		globalLogger.Debug("Off-chain reporting v2 enabled")
-		relayers := make(map[relay.Network]relaytypes.Relayer)
+		relayers := make(map[relay.Network]func() (loop.Relayer, error))
 		if cfg.EVMEnabled() {
-			evmRelayer := evmrelay.NewRelayer(db, chains.EVM, globalLogger.Named("EVM"), cfg, keyStore)
-			relayers[relay.EVM] = evmRelayer
-			srvcs = append(srvcs, evmRelayer)
+			lggr := globalLogger.Named("EVM")
+			evmRelayer := evmrelay.NewRelayer(db, chains.EVM, lggr, cfg, keyStore)
+			relayer := relay.RelayerAdapter{Relayer: evmRelayer, RelayerExt: chains.EVM}
+			relayers[relay.EVM] = func() (loop.Relayer, error) { return &relayer, nil }
 		}
 		if cfg.CosmosEnabled() {
-			cosmosRelayer := pkgcosmos.NewRelayer(globalLogger.Named("Cosmos.Relayer"), chains.Cosmos)
-			relayers[relay.Cosmos] = cosmosRelayer
-			srvcs = append(srvcs, cosmosRelayer)
+			lggr := globalLogger.Named("Cosmos.Relayer")
+			cosmosRelayer := pkgcosmos.NewRelayer(lggr, chains.Cosmos)
+			relayer := relay.RelayerAdapter{Relayer: cosmosRelayer, RelayerExt: chains.Cosmos}
+			relayers[relay.Cosmos] = func() (loop.Relayer, error) { return &relayer, nil }
 		}
 		if cfg.SolanaEnabled() {
-			solanaRelayer := solana.NewRelayer(globalLogger.Named("Solana.Relayer"), chains.Solana)
-			relayers[relay.Solana] = solanaRelayer
-			srvcs = append(srvcs, solanaRelayer)
+			relayers[relay.Solana] = chains.Solana.Relayer
 		}
 		if cfg.StarkNetEnabled() {
-			starknetRelayer := starknetrelay.NewRelayer(globalLogger.Named("StarkNet.Relayer"), chains.StarkNet)
-			relayers[relay.StarkNet] = starknetRelayer
-			srvcs = append(srvcs, starknetRelayer)
+			lggr := globalLogger.Named("StarkNet.Relayer")
+			starknetRelayer := starknetrelay.NewRelayer(lggr, chains.StarkNet)
+			relayer := relay.RelayerAdapter{Relayer: starknetRelayer, RelayerExt: chains.StarkNet}
+			relayers[relay.StarkNet] = func() (loop.Relayer, error) { return &relayer, nil }
 		}
 		delegates[job.OffchainReporting2] = ocr2.NewDelegate(
 			db,

--- a/core/services/job/spawner_test.go
+++ b/core/services/job/spawner_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	relaytypes "github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
 
 	"github.com/smartcontractkit/sqlx"
 
@@ -271,9 +271,10 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 		orm := NewTestORM(t, db, cc, pipeline.NewORM(db, lggr, config), bridges.NewORM(db, lggr, config), keyStore, config)
 		mailMon := srvctest.Start(t, utils.NewMailboxMonitor(t.Name()))
 
-		relayers := make(map[relay.Network]relaytypes.Relayer)
+		relayers := make(map[relay.Network]func() (loop.Relayer, error))
 		evmRelayer := evmrelay.NewRelayer(db, cc, lggr, config, keyStore)
-		relayers[relay.EVM] = evmRelayer
+		relayer := relay.RelayerAdapter{Relayer: evmRelayer, RelayerExt: cc}
+		relayers[relay.EVM] = func() (loop.Relayer, error) { return &relayer, nil }
 
 		d := ocr2.NewDelegate(nil, orm, nil, nil, monitoringEndpoint, cs, lggr, config,
 			keyStore.OCR2(), keyStore.DKGSign(), keyStore.DKGEncrypt(), ethKeyStore, relayers, mailMon)

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -1,6 +1,7 @@
 package ocr2
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
+
 	libocr2 "github.com/smartcontractkit/libocr/offchainreporting2"
 	ocr2types "github.com/smartcontractkit/libocr/offchainreporting2/types"
 	ocr2keepers "github.com/smartcontractkit/ocr2keepers/pkg"
@@ -17,7 +19,9 @@ import (
 	"github.com/smartcontractkit/ocr2vrf/ocr2vrf"
 	"github.com/smartcontractkit/sqlx"
 
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
 	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink/v2/plugins"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
@@ -54,15 +58,20 @@ type Delegate struct {
 	peerWrapper           *ocrcommon.SingletonPeerWrapper
 	monitoringEndpointGen telemetry.MonitoringEndpointGenerator
 	chainSet              evm.ChainSet
-	cfg                   validate.Config
+	cfg                   Config
 	lggr                  logger.Logger
 	ks                    keystore.OCR2
 	dkgSignKs             keystore.DKGSign
 	dkgEncryptKs          keystore.DKGEncrypt
 	ethKs                 keystore.Eth
-	relayers              map[relay.Network]types.Relayer
+	relayers              map[relay.Network]func() (loop.Relayer, error)
 	isNewlyCreatedJob     bool // Set to true if this is a new job freshly added, false if job was present already on node boot.
 	mailMon               *utils.MailboxMonitor
+}
+
+type Config interface {
+	validate.Config
+	plugins.EnvConfig
 }
 
 var _ job.Delegate = (*Delegate)(nil)
@@ -75,30 +84,30 @@ func NewDelegate(
 	monitoringEndpointGen telemetry.MonitoringEndpointGenerator,
 	chainSet evm.ChainSet,
 	lggr logger.Logger,
-	cfg validate.Config,
+	cfg Config,
 	ks keystore.OCR2,
 	dkgSignKs keystore.DKGSign,
 	dkgEncryptKs keystore.DKGEncrypt,
 	ethKs keystore.Eth,
-	relayers map[relay.Network]types.Relayer,
+	relayers map[relay.Network]func() (loop.Relayer, error),
 	mailMon *utils.MailboxMonitor,
 ) *Delegate {
 	return &Delegate{
-		db,
-		jobORM,
-		pipelineRunner,
-		peerWrapper,
-		monitoringEndpointGen,
-		chainSet,
-		cfg,
-		lggr,
-		ks,
-		dkgSignKs,
-		dkgEncryptKs,
-		ethKs,
-		relayers,
-		false,
-		mailMon,
+		db:                    db,
+		jobORM:                jobORM,
+		pipelineRunner:        pipelineRunner,
+		peerWrapper:           peerWrapper,
+		monitoringEndpointGen: monitoringEndpointGen,
+		chainSet:              chainSet,
+		cfg:                   cfg,
+		lggr:                  lggr,
+		ks:                    ks,
+		dkgSignKs:             dkgSignKs,
+		dkgEncryptKs:          dkgEncryptKs,
+		ethKs:                 ethKs,
+		relayers:              relayers,
+		isNewlyCreatedJob:     false,
+		mailMon:               mailMon,
 	}
 }
 
@@ -193,17 +202,25 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 		return nil, errors.Errorf("expected a transmitterID to be specified")
 	}
 	transmitterID := spec.TransmitterID.String
-	relayer, exists := d.relayers[spec.Relay]
+	relayerFn, exists := d.relayers[spec.Relay]
 	if !exists {
 		return nil, errors.Errorf("%s relay does not exist is it enabled?", spec.Relay)
 	}
+	relayer, err := relayerFn()
+	if err != nil {
+		//TODO defer in order to retry https://smartcontract-it.atlassian.net/browse/BCF-2112
+		return nil, fmt.Errorf("failed to get relayer: %w", err)
+	}
 	effectiveTransmitterID := transmitterID
 
-	lggr := logger.Sugared(d.lggr.Named("OCR").With(
-		"contractID", spec.ContractID,
-		"jobName", jb.Name.ValueOrZero(),
-		"jobID", jb.ID,
-	))
+	ctxVals := loop.ContextValues{
+		JobID:   jb.ID,
+		JobName: jb.Name.ValueOrZero(),
+
+		ContractID: spec.ContractID,
+		FeedID:     spec.FeedID,
+	}
+	lggr := logger.Sugared(d.lggr.Named("OCR2").With(ctxVals.Args()...))
 	feedID := spec.FeedID
 	if feedID != (common.Hash{}) {
 		lggr = logger.Sugared(lggr.With("feedID", spec.FeedID))
@@ -297,9 +314,10 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 
 	runResults := make(chan pipeline.Run, d.cfg.JobPipelineResultWriteQueueDepth())
 
+	ctx := ctxVals.ContextWithValues(context.Background())
 	switch spec.PluginType {
 	case job.Mercury:
-		mercuryProvider, err2 := relayer.NewMercuryProvider(
+		mercuryProvider, err2 := relayer.NewMercuryProvider(ctx,
 			types.RelayArgs{
 				ExternalJobID: jb.ExternalJobID,
 				JobID:         spec.ID,
@@ -332,35 +350,19 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 		}
 		return mercury.NewServices(jb, mercuryProvider, d.pipelineRunner, runResults, lggr, oracleArgsNoPlugin, d.cfg)
 	case job.Median:
-		medianProvider, err2 := relayer.NewMedianProvider(
-			types.RelayArgs{
-				ExternalJobID: jb.ExternalJobID,
-				JobID:         spec.ID,
-				ContractID:    spec.ContractID,
-				New:           d.isNewlyCreatedJob,
-				RelayConfig:   spec.RelayConfig.Bytes(),
-			}, types.PluginArgs{
-				TransmitterID: transmitterID,
-				PluginConfig:  spec.PluginConfig.Bytes(),
-			})
-		if err2 != nil {
-			return nil, err2
-		}
 		oracleArgsNoPlugin := libocr2.OracleArgs{
 			BinaryNetworkEndpointFactory: peerWrapper.Peer2,
 			V2Bootstrappers:              bootstrapPeers,
-			ContractTransmitter:          medianProvider.ContractTransmitter(),
-			ContractConfigTracker:        medianProvider.ContractConfigTracker(),
 			Database:                     ocrDB,
 			LocalConfig:                  lc,
 			Logger:                       ocrLogger,
 			MonitoringEndpoint:           d.monitoringEndpointGen.GenMonitoringEndpoint(spec.ContractID, synchronization.OCR2Median),
-			OffchainConfigDigester:       medianProvider.OffchainConfigDigester(),
 			OffchainKeyring:              kb,
 			OnchainKeyring:               kb,
 		}
 		eaMonitoringEndpoint := d.monitoringEndpointGen.GenMonitoringEndpoint(spec.ContractID, synchronization.EnhancedEA)
-		return median.NewMedianServices(jb, medianProvider, d.pipelineRunner, runResults, lggr, ocrLogger, oracleArgsNoPlugin, d.cfg, eaMonitoringEndpoint)
+		errorLog := &errorLog{jobID: jb.ID, recordError: d.jobORM.RecordError}
+		return median.NewMedianServices(ctx, jb, d.isNewlyCreatedJob, relayer, d.pipelineRunner, runResults, lggr, oracleArgsNoPlugin, d.cfg, eaMonitoringEndpoint, errorLog)
 	case job.DKG:
 		chainID, err2 := spec.RelayConfig.EVMChainID()
 		if err2 != nil {
@@ -731,4 +733,14 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 	default:
 		return nil, errors.Errorf("plugin type %s not supported", spec.PluginType)
 	}
+}
+
+// errorLog implements [loop.ErrorLog]
+type errorLog struct {
+	jobID       int32
+	recordError func(jobID int32, description string, qopts ...pg.QOpt) error
+}
+
+func (l *errorLog) SaveError(ctx context.Context, msg string) error {
+	return l.recordError(l.jobID, msg)
 }

--- a/core/services/ocr2/plugins/median/plugin.go
+++ b/core/services/ocr2/plugins/median/plugin.go
@@ -1,78 +1,243 @@
 package median
 
 import (
+	"context"
 	"encoding/json"
+	"fmt"
+	"os/exec"
 	"time"
+
+	"github.com/hashicorp/go-plugin"
 
 	"github.com/smartcontractkit/libocr/commontypes"
 	libocr2 "github.com/smartcontractkit/libocr/offchainreporting2"
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2/types"
 
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
 	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink/v2/plugins"
 
+	v2 "github.com/smartcontractkit/chainlink/v2/core/config/v2"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/median/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 type MedianConfig interface {
 	JobPipelineMaxSuccessfulRuns() uint64
+	plugins.EnvConfig
 }
 
-// NewMedian parses the arguments and returns a new Median struct.
-func NewMedianServices(jb job.Job,
-	ocr2Provider types.MedianProvider,
+func NewMedianServices(ctx context.Context,
+	jb job.Job,
+	isNewlyCreatedJob bool,
+	relayer loop.Relayer,
 	pipelineRunner pipeline.Runner,
 	runResults chan pipeline.Run,
 	lggr logger.Logger,
-	ocrLogger commontypes.Logger,
 	argsNoPlugin libocr2.OracleArgs,
 	cfg MedianConfig,
 	endpoint commontypes.MonitoringEndpoint,
-) ([]job.ServiceCtx, error) {
+	errorLog loop.ErrorLog,
+) (srvs []job.ServiceCtx, err error) {
 	var pluginConfig config.PluginConfig
-	err := json.Unmarshal(jb.OCR2OracleSpec.PluginConfig.Bytes(), &pluginConfig)
+	err = json.Unmarshal(jb.OCR2OracleSpec.PluginConfig.Bytes(), &pluginConfig)
 	if err != nil {
-		return nil, err
+		return
 	}
 	err = config.ValidatePluginConfig(pluginConfig)
 	if err != nil {
-		return nil, err
+		return
 	}
-	juelsPerFeeCoinPipelineSpec := pipeline.Spec{
+	spec := jb.OCR2OracleSpec
+	//TODO retry https://smartcontract-it.atlassian.net/browse/BCF-2112
+	provider, err := relayer.NewMedianProvider(ctx, types.RelayArgs{
+		ExternalJobID: jb.ExternalJobID,
+		JobID:         spec.ID,
+		ContractID:    spec.ContractID,
+		New:           isNewlyCreatedJob,
+		RelayConfig:   spec.RelayConfig.Bytes(),
+	}, types.PluginArgs{
+		TransmitterID: spec.TransmitterID.String,
+		PluginConfig:  spec.PluginConfig.Bytes(),
+	})
+	if err != nil {
+		return
+	}
+	srvs = append(srvs, provider)
+	argsNoPlugin.ContractTransmitter = provider.ContractTransmitter()
+	argsNoPlugin.ContractConfigTracker = provider.ContractConfigTracker()
+	argsNoPlugin.OffchainConfigDigester = provider.OffchainConfigDigester()
+
+	abort := func() {
+		var mc services.MultiClose
+		for i := range srvs {
+			mc = append(mc, srvs[i])
+		}
+		if cerr := mc.Close(); err != nil {
+			lggr.Errorw("Error closing unused services", "err", cerr)
+		}
+	}
+
+	var median loop.PluginMedian
+	if cmdName := v2.EnvMedianPluginCmd.Get(); cmdName != "" {
+		ms := NewPluginMedianService(cmdName, lggr, cfg)
+		if err = ms.Launch(); err != nil {
+			abort()
+			return
+		}
+		median = ms
+		srvs = append(srvs, ms)
+	} else {
+		median = NewPlugin(lggr, ctx.Done())
+	}
+	argsNoPlugin.ReportingPluginFactory, err = median.NewMedianPluginFactory(ctx, provider, ocrcommon.NewDataSourceV2(pipelineRunner,
+		jb,
+		*jb.PipelineSpec,
+		lggr,
+		runResults,
+		endpoint,
+	), ocrcommon.NewInMemoryDataSource(pipelineRunner, jb, pipeline.Spec{
 		ID:           jb.ID,
 		DotDagSource: pluginConfig.JuelsPerFeeCoinPipeline,
 		CreatedAt:    time.Now(),
-	}
-	argsNoPlugin.ReportingPluginFactory = median.NumericalMedianFactory{
-		ContractTransmitter: ocr2Provider.MedianContract(),
-		DataSource: ocrcommon.NewDataSourceV2(pipelineRunner,
-			jb,
-			*jb.PipelineSpec,
-			lggr,
-			runResults,
-			endpoint,
-		),
-		JuelsPerFeeCoinDataSource: ocrcommon.NewInMemoryDataSource(pipelineRunner, jb, juelsPerFeeCoinPipelineSpec, lggr),
-		OnchainConfigCodec:        ocr2Provider.OnchainConfigCodec(),
-		ReportCodec:               ocr2Provider.ReportCodec(),
-		Logger:                    ocrLogger,
-	}
-	oracle, err := libocr2.NewOracle(argsNoPlugin)
+	}, lggr), errorLog)
 	if err != nil {
-		return nil, err
+		abort()
+		return
 	}
-	if !jb.OCR2OracleSpec.CaptureEATelemetry {
-		lggr.Infof("Enhanced EA telemetry is disabled for job %s", jb.Name.ValueOrZero())
+
+	var oracle *libocr2.Oracle
+	oracle, err = libocr2.NewOracle(argsNoPlugin)
+	if err != nil {
+		abort()
+		return
 	}
-	return []job.ServiceCtx{ocr2Provider, ocrcommon.NewResultRunSaver(
+	runSaver := ocrcommon.NewResultRunSaver(
 		runResults,
 		pipelineRunner,
 		make(chan struct{}),
 		lggr,
 		cfg.JobPipelineMaxSuccessfulRuns(),
-	),
-		job.NewServiceAdapter(oracle)}, nil
+	)
+	srvs = append(srvs, runSaver, job.NewServiceAdapter(oracle))
+	if !jb.OCR2OracleSpec.CaptureEATelemetry {
+		lggr.Infof("Enhanced EA telemetry is disabled for job %s", jb.Name.ValueOrZero())
+	}
+	return
 }
+
+type Plugin struct {
+	lggr logger.Logger
+	stop utils.StopRChan
+}
+
+func NewPlugin(lggr logger.Logger, stop utils.StopRChan) *Plugin {
+	return &Plugin{lggr: lggr, stop: stop}
+}
+
+func (m *Plugin) NewMedianPluginFactory(ctx context.Context, provider types.MedianProvider, dataSource, juelsPerFeeCoin median.DataSource, errorLog loop.ErrorLog) (ocrtypes.ReportingPluginFactory, error) {
+	var ctxVals loop.ContextValues
+	ctxVals.SetValues(ctx)
+	lggr := m.lggr.With(ctxVals.Args()...)
+	factory := median.NumericalMedianFactory{
+		ContractTransmitter:       provider.MedianContract(),
+		DataSource:                dataSource,
+		JuelsPerFeeCoinDataSource: juelsPerFeeCoin,
+		Logger: logger.NewOCRWrapper(lggr, true, func(msg string) {
+			ctx, cancelFn := m.stop.NewCtx()
+			defer cancelFn()
+			if err := errorLog.SaveError(ctx, msg); err != nil {
+				lggr.Errorw("Unable to save error", "err", msg)
+			}
+		}),
+		OnchainConfigCodec: provider.OnchainConfigCodec(),
+		ReportCodec:        provider.ReportCodec(),
+	}
+	return factory, nil
+}
+
+var _ services.ServiceCtx = (*medianService)(nil)
+
+type medianService struct {
+	utils.StartStopOnce
+
+	lggr    logger.Logger
+	cfg     plugins.EnvConfig
+	cmdName string
+
+	client *plugin.Client
+	cp     plugin.ClientProtocol
+	loop.PluginMedian
+}
+
+func NewPluginMedianService(cmdName string, lggr logger.Logger, cfg plugins.EnvConfig) *medianService {
+	return &medianService{cmdName: cmdName, lggr: lggr.Named("PluginMedianService"), cfg: cfg}
+}
+
+func (m *medianService) Start(ctx context.Context) error {
+	return m.StartOnce("PluginMedianService", func() error {
+		if m.PluginMedian != nil {
+			return nil
+		}
+		return m.Launch()
+	})
+}
+
+// Launch launces the plugin, and sets the backing [loop.PluginMedian]. If this is called directly, then Start() will nop.
+func (m *medianService) Launch() error {
+	cc := loop.PluginMedianClientConfig(m.lggr)
+	cc.Cmd = exec.Command(m.cmdName) //nolint:gosec
+	plugins.SetEnvConfig(cc.Cmd, m.cfg)
+	client := plugin.NewClient(cc)
+	cp, err := client.Client()
+	if err != nil {
+		client.Kill()
+		return fmt.Errorf("failed to create plugin Client: %w", err)
+	}
+	abort := func() {
+		if cerr := cp.Close(); cerr != nil {
+			m.lggr.Errorw("Error closing ClientProtocol", "err", cerr)
+		}
+		client.Kill()
+	}
+	i, err := cp.Dispense(loop.PluginMedianName)
+	if err != nil {
+		abort()
+		return fmt.Errorf("failed to Dispense %q plugin: %w", loop.PluginMedianName, err)
+	}
+	plug, ok := i.(loop.PluginMedian)
+	if !ok {
+		abort()
+		return fmt.Errorf("expected PluginMedian but got %T", i)
+	}
+	m.client = client
+	m.cp = cp
+	m.PluginMedian = plug
+	return nil
+}
+
+func (m *medianService) Close() error {
+	return m.StopOnce("PluginMedianService", func() error {
+		err := m.cp.Close()
+		m.client.Kill()
+		return err
+	})
+}
+
+func (m *medianService) Name() string { return m.lggr.Name() }
+
+func (m *medianService) HealthReport() map[string]error {
+	return map[string]error{m.lggr.Name(): m.Healthy()}
+}
+
+func (m *medianService) ping() error { return m.cp.Ping() }
+
+func (m *medianService) Ready() error { return m.ping() }
+
+func (m *medianService) Healthy() error { return m.ping() }

--- a/core/services/relay/relay.go
+++ b/core/services/relay/relay.go
@@ -1,5 +1,18 @@
 package relay
 
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math/big"
+
+	"golang.org/x/exp/maps"
+
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
+	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink/v2/core/services"
+)
+
 type Network string
 
 var (
@@ -14,3 +27,77 @@ var (
 		StarkNet: {},
 	}
 )
+
+// RelayerExt is a subset of [loop.Relayer] for adapting [types.Relayer], typically with a ChainSet. See [RelayerAdapter].
+type RelayerExt interface {
+	services.ServiceCtx
+
+	ChainStatus(ctx context.Context, id string) (types.ChainStatus, error)
+	ChainStatuses(ctx context.Context, offset, limit int) ([]types.ChainStatus, int, error)
+
+	NodeStatuses(ctx context.Context, offset, limit int, chainIDs ...string) (nodes []types.NodeStatus, count int, err error)
+
+	SendTx(ctx context.Context, chainID, from, to string, amount *big.Int, balanceCheck bool) error
+}
+
+var _ loop.Relayer = (*RelayerAdapter)(nil)
+
+// RelayerAdapter adapts a [types.Relayer] and [RelayerExt] to imlement [loop.Relayer].
+type RelayerAdapter struct {
+	types.Relayer
+	RelayerExt
+}
+
+func (r *RelayerAdapter) NewConfigProvider(ctx context.Context, rargs types.RelayArgs) (types.ConfigProvider, error) {
+	return r.Relayer.NewConfigProvider(rargs)
+}
+
+func (r *RelayerAdapter) NewMedianProvider(ctx context.Context, rargs types.RelayArgs, pargs types.PluginArgs) (types.MedianProvider, error) {
+	return r.Relayer.NewMedianProvider(rargs, pargs)
+}
+
+func (r *RelayerAdapter) NewMercuryProvider(ctx context.Context, rargs types.RelayArgs, pargs types.PluginArgs) (types.MercuryProvider, error) {
+	return r.Relayer.NewMercuryProvider(rargs, pargs)
+}
+
+func (r *RelayerAdapter) Start(ctx context.Context) error {
+	var ms services.MultiStart
+	return ms.Start(ctx, r.RelayerExt, r.Relayer)
+}
+
+func (r *RelayerAdapter) Close() error {
+	return services.MultiClose{r.Relayer, r.RelayerExt}.Close()
+}
+
+func (r *RelayerAdapter) Name() string {
+	return fmt.Sprintf("%s-%s", r.Relayer.Name(), r.RelayerExt.Name())
+}
+
+func (r *RelayerAdapter) Ready() (err error) {
+	return errors.Join(r.Relayer.Ready(), r.RelayerExt.Ready())
+}
+
+func (r *RelayerAdapter) HealthReport() map[string]error {
+	hr := make(map[string]error)
+	maps.Copy(r.Relayer.HealthReport(), hr)
+	maps.Copy(r.RelayerExt.HealthReport(), hr)
+	return hr
+}
+
+type RelayerService interface {
+	services.ServiceCtx
+	Relayer() (loop.Relayer, error)
+}
+
+type RelayerServiceAdapter struct {
+	*RelayerAdapter
+}
+
+func (a *RelayerServiceAdapter) Relayer() (loop.Relayer, error) {
+	return a.RelayerAdapter, nil
+}
+
+// NewLocalRelayerService returns a RelayerService adapted from a [types.Relayer] and [RelayerExt].
+func NewLocalRelayerService(r types.Relayer, e RelayerExt) RelayerService {
+	return &RelayerServiceAdapter{&RelayerAdapter{Relayer: r, RelayerExt: e}}
+}

--- a/core/utils/utils.go
+++ b/core/utils/utils.go
@@ -437,17 +437,37 @@ type StopChan chan struct{}
 
 // NewCtx returns a background [context.Context] that is cancelled when StopChan is closed.
 func (s StopChan) NewCtx() (context.Context, context.CancelFunc) {
-	return s.Ctx(context.Background())
+	return StopRChan((<-chan struct{})(s)).NewCtx()
 }
 
 // Ctx cancels a [context.Context] when StopChan is closed.
 func (s StopChan) Ctx(ctx context.Context) (context.Context, context.CancelFunc) {
-	return s.CtxCancel(context.WithCancel(ctx))
+	return StopRChan((<-chan struct{})(s)).Ctx(ctx)
 }
 
 // CtxCancel cancels a [context.Context] when StopChan is closed.
 // Returns ctx and cancel unmodified, for convenience.
 func (s StopChan) CtxCancel(ctx context.Context, cancel context.CancelFunc) (context.Context, context.CancelFunc) {
+	return StopRChan((<-chan struct{})(s)).CtxCancel(ctx, cancel)
+}
+
+// A StopRChan signals when some work should stop.
+// This version is receive-only.
+type StopRChan <-chan struct{}
+
+// NewCtx returns a background [context.Context] that is cancelled when StopChan is closed.
+func (s StopRChan) NewCtx() (context.Context, context.CancelFunc) {
+	return s.Ctx(context.Background())
+}
+
+// Ctx cancels a [context.Context] when StopChan is closed.
+func (s StopRChan) Ctx(ctx context.Context) (context.Context, context.CancelFunc) {
+	return s.CtxCancel(context.WithCancel(ctx))
+}
+
+// CtxCancel cancels a [context.Context] when StopChan is closed.
+// Returns ctx and cancel unmodified, for convenience.
+func (s StopRChan) CtxCancel(ctx context.Context, cancel context.CancelFunc) (context.Context, context.CancelFunc) {
 	go func() {
 		select {
 		case <-s:

--- a/core/web/resolver/chain.go
+++ b/core/web/resolver/chain.go
@@ -2,7 +2,6 @@ package resolver
 
 import (
 	"github.com/graph-gophers/graphql-go"
-
 	"github.com/smartcontractkit/chainlink-relay/pkg/types"
 )
 

--- a/core/web/solana_chains_controller.go
+++ b/core/web/solana_chains_controller.go
@@ -1,12 +1,37 @@
 package web
 
 import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
 
 func NewSolanaChainsController(app chainlink.Application) ChainsController {
-	chainSet := app.GetChains().Solana
+	chainSet := &relayerChainSet{app.GetChains().Solana}
 	return newChainsController("solana", chainSet, ErrSolanaNotEnabled,
 		presenters.NewSolanaChainResource, app.GetLogger(), app.GetAuditLogger())
+}
+
+type relayerChainSet struct {
+	relay.RelayerService
+}
+
+func (r *relayerChainSet) ChainStatus(ctx context.Context, id string) (types.ChainStatus, error) {
+	relayer, err := r.Relayer()
+	if err != nil {
+		return types.ChainStatus{}, err
+	}
+	return relayer.ChainStatus(ctx, id)
+}
+
+func (r *relayerChainSet) ChainStatuses(ctx context.Context, offset, limit int) ([]types.ChainStatus, int, error) {
+	relayer, err := r.Relayer()
+	if err != nil {
+		return []types.ChainStatus{}, -1, err
+	}
+	return relayer.ChainStatuses(ctx, offset, limit)
 }

--- a/core/web/solana_nodes_controller.go
+++ b/core/web/solana_nodes_controller.go
@@ -1,6 +1,12 @@
 package web
 
 import (
+	"context"
+
+	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
@@ -9,7 +15,21 @@ import (
 var ErrSolanaNotEnabled = errChainDisabled{name: "Solana", tomlKey: "Solana.Enabled"}
 
 func NewSolanaNodesController(app chainlink.Application) NodesController {
-	nodeSet := app.GetChains().Solana
+	nodeSet := &relayerNodeSet{app.GetChains().Solana}
 	return newNodesController[presenters.SolanaNodeResource](
 		nodeSet, ErrSolanaNotEnabled, presenters.NewSolanaNodeResource, app.GetAuditLogger())
+}
+
+var _ chains.Nodes = (*relayerNodeSet)(nil)
+
+type relayerNodeSet struct {
+	relay.RelayerService
+}
+
+func (r *relayerNodeSet) NodeStatuses(ctx context.Context, offset, limit int, chainIDs ...string) (nodes []types.NodeStatus, count int, err error) {
+	relayer, err := r.Relayer()
+	if err != nil {
+		return nil, -1, err
+	}
+	return relayer.NodeStatuses(ctx, offset, limit, chainIDs...)
 }

--- a/core/web/solana_transfer_controller.go
+++ b/core/web/solana_transfer_controller.go
@@ -22,8 +22,8 @@ type SolanaTransfersController struct {
 
 // Create sends SOL and other native coins from the Chainlink's account to a specified address.
 func (tc *SolanaTransfersController) Create(c *gin.Context) {
-	chainSet := tc.App.GetChains().Solana
-	if chainSet == nil {
+	relayerSrv := tc.App.GetChains().Solana
+	if relayerSrv == nil {
 		jsonAPIError(c, http.StatusBadRequest, ErrSolanaNotEnabled)
 		return
 	}
@@ -46,8 +46,13 @@ func (tc *SolanaTransfersController) Create(c *gin.Context) {
 		return
 	}
 
+	relayer, err := relayerSrv.Relayer()
+	if err != nil {
+		jsonAPIError(c, http.StatusInternalServerError, errors.Errorf("chain unreachable: %v", err))
+		return
+	}
 	amount := new(big.Int).SetUint64(tr.Amount)
-	err := chainSet.SendTx(c, tr.SolanaChainID, tr.From.String(), tr.To.String(), amount, !tr.AllowHigherAmounts)
+	err = relayer.SendTx(c, tr.SolanaChainID, tr.From.String(), tr.To.String(), amount, !tr.AllowHigherAmounts)
 	if err != nil {
 		switch err {
 		case chains.ErrNotFound, chains.ErrChainIDEmpty:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## 2.1.0 - UNRELEASED
 
 ### Added
+- Experimental support of runtime process isolation for Solana data feeds. Requires plugin binaries to be installed and
+  configured via the env vars `CL_SOLANA_CMD` and `CL_MEDIAN_CMD`.
 
 ### Changed
 

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/graph-gophers/dataloader v5.0.0+incompatible
 	github.com/graph-gophers/graphql-go v1.3.0
+	github.com/hashicorp/go-plugin v1.4.8
 	github.com/hdevalence/ed25519consensus v0.0.0-20220222234857-c00d1f31bab3
 	github.com/jackc/pgconn v1.14.0
 	github.com/jackc/pgtype v1.14.0
@@ -194,7 +195,6 @@ require (
 	github.com/hashicorp/go-hclog v1.2.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
-	github.com/hashicorp/go-plugin v1.4.8 // indirect
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -141,10 +141,13 @@ require (
 	github.com/gtank/merlin v0.1.1 // indirect
 	github.com/gtank/ristretto255 v0.1.2 // indirect
 	github.com/hashicorp/errwrap v1.1.0 // indirect
+	github.com/hashicorp/go-hclog v1.2.2 // indirect
 	github.com/hashicorp/go-immutable-radix v1.3.1 // indirect
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
+	github.com/hashicorp/go-plugin v1.4.8 // indirect
 	github.com/hashicorp/golang-lru v0.5.5-0.20210104140557-80c98217689d // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce // indirect
 	github.com/hdevalence/ed25519consensus v0.0.0-20220222234857-c00d1f31bab3 // indirect
 	github.com/holiman/bloomfilter/v2 v2.0.3 // indirect
 	github.com/holiman/uint256 v1.2.0 // indirect
@@ -250,6 +253,7 @@ require (
 	github.com/multiformats/go-multistream v0.2.2 // indirect
 	github.com/multiformats/go-varint v0.0.6 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/oklog/run v1.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.5 // indirect
 	github.com/onsi/ginkgo/v2 v2.5.1 // indirect
 	github.com/opentracing/opentracing-go v1.2.0 // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -305,6 +305,7 @@ github.com/fatih/camelcase v1.0.0 h1:hxNvNX/xYBp0ovncs8WyWZrOrpBNub/JfaMvbURyft8
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/fatih/color v1.13.0/go.mod h1:kLAiJbzzSOZDVNGyDpeOxJ47H46qBXwg5ILebYFFOfk=
 github.com/fatih/color v1.15.0 h1:kOqh6YHBtK8aywxGerMG2Eq3H6Qgoqeo13Bk2Mv/nBs=
 github.com/fatih/color v1.15.0/go.mod h1:0h5ZqXfHYED7Bhv2ZJamyIOUej9KtShiJESRwBDUSsw=
 github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
@@ -565,6 +566,7 @@ github.com/hashicorp/go-bexpr v0.1.10 h1:9kuI5PFotCboP3dkDYFr/wi0gg0QVbSNz5oFRpx
 github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-hclog v1.2.2 h1:ihRI7YFwcZdiSD7SIenIhHfQH3OuDvWerAUBZbeQS3M=
+github.com/hashicorp/go-hclog v1.2.2/go.mod h1:W4Qnvbt70Wk/zYJryRzDRU/4r0kIg0PVHBcfoyhpF5M=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-immutable-radix v1.3.1 h1:DKHmCUm2hRBK510BaiZlwvpD40f8bJFeZnpfm2KLowc=
 github.com/hashicorp/go-immutable-radix v1.3.1/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
@@ -574,6 +576,7 @@ github.com/hashicorp/go-multierror v1.1.0/go.mod h1:spPvp8C1qA32ftKqdAHm4hHTbPw+
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-plugin v1.4.8 h1:CHGwpxYDOttQOY7HOWgETU9dyVjOXzniXDqJcYJE1zM=
+github.com/hashicorp/go-plugin v1.4.8/go.mod h1:viDMjcLJuDui6pXb8U4HVfb8AamCWhHGUjr2IrTF67s=
 github.com/hashicorp/go-retryablehttp v0.5.3/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
@@ -596,6 +599,7 @@ github.com/hashicorp/mdns v1.0.0/go.mod h1:tL+uN++7HEJ6SQLQ2/p+z2pH24WQKWjBPkE0m
 github.com/hashicorp/memberlist v0.1.3/go.mod h1:ajVTdAv/9Im8oMAAj5G31PhhMCZJV2pPBoIllUwCN7I=
 github.com/hashicorp/serf v0.8.2/go.mod h1:6hOLApaqBFA1NXqRQAsxw9QxuDEvNxSQRwA/JwenrHc=
 github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce h1:7UnVY3T/ZnHUrfviiAgIUjg2PXxsQfs5bphsG8F7Keo=
+github.com/hashicorp/yamux v0.0.0-20200609203250-aecfd211c9ce/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=
 github.com/hdevalence/ed25519consensus v0.0.0-20220222234857-c00d1f31bab3 h1:aSVUgRRRtOrZOC1fYmY9gV0e9z/Iu+xNVSASWjsuyGU=
 github.com/hdevalence/ed25519consensus v0.0.0-20220222234857-c00d1f31bab3/go.mod h1:5PC6ZNPde8bBqU/ewGZig35+UIZtw9Ytxez8/q5ZyFE=
 github.com/holiman/bloomfilter/v2 v2.0.3 h1:73e0e/V0tCydx14a0SCYS/EWCxgwLZ18CZcZKVu0fao=
@@ -727,6 +731,7 @@ github.com/jbenet/goprocess v0.1.3/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZl
 github.com/jbenet/goprocess v0.1.4 h1:DRGOFReOMqqDNXwW70QkacFW0YN9QnwLV0Vqk+3oU0o=
 github.com/jbenet/goprocess v0.1.4/go.mod h1:5yspPrukOVuOLORacaBi858NqyClJPQxYZlqdZVfqY4=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jhump/protoreflect v1.12.1-0.20220721211354-060cc04fc18b h1:izTof8BKh/nE1wrKOrloNA5q4odOarjf+Xpe+4qow98=
 github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af/go.mod h1:Nht3zPeWKUH0NzdCt2Blrr5ys8VGpn0CEB0cQHVjt7k=
 github.com/jmhodges/levigo v1.0.0 h1:q5EC36kV79HWeTBWsod3mG11EgStG3qArTKcvlksN1U=
 github.com/jmhodges/levigo v1.0.0/go.mod h1:Q6Qx+uH3RAqyK4rFQroq9RL7mdkABMcfhEI+nNuzMJQ=
@@ -1022,6 +1027,7 @@ github.com/mattn/go-colorable v0.1.2/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVc
 github.com/mattn/go-colorable v0.1.4/go.mod h1:U0ppj6V5qS13XJ6of8GYAs25YV2eR4EVcfRqFIhoBtE=
 github.com/mattn/go-colorable v0.1.6/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.8/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
+github.com/mattn/go-colorable v0.1.9/go.mod h1:u6P/XSegPjTcexA+o6vUJrdnUu04hMope9wVRipJSqc=
 github.com/mattn/go-colorable v0.1.11/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.12/go.mod h1:u5H1YNBxpqRaxsYJYSkiCWKzEfiAb1Gb520KVy5xxl4=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
@@ -1173,6 +1179,7 @@ github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/nxadm/tail v1.4.8/go.mod h1:+ncqLTQzXmGhMZNUePPaPqPvBxHAIsmXswZKocGu+AU=
 github.com/oklog/run v1.1.0 h1:GEenZ1cK0+q0+wsJew9qUg/DyD8k3JzYsZAi5gYi2mA=
+github.com/oklog/run v1.1.0/go.mod h1:sVPdnTZT1zYwAJeCMu2Th4T21pA3FPOQRfWjQlk7DVU=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=
 github.com/olekukonko/tablewriter v0.0.5 h1:P2Ga83D34wi1o9J6Wh1mRuqd4mF/x/lgBS7N7AbDhec=
 github.com/olekukonko/tablewriter v0.0.5/go.mod h1:hPp6KlRPjbx+hW8ykQs1w3UBbZlj6HuIJcUGPhkA7kY=
@@ -1786,6 +1793,7 @@ golang.org/x/sys v0.0.0-20211216021012-1d35b9e2eb4e/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220209214540-3681064d5158/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220405052023-b1e9470b6e64/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220412211240-33da011f77ad/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20220503163025-988cb79eb6c6/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220520151302-bc2c85ada10a/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220715151400-c0bba94af5f8/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -1,0 +1,56 @@
+# Build image: Chainlink binary
+FROM golang:1.20-buster as buildgo
+RUN go version
+WORKDIR /chainlink
+
+COPY GNUmakefile VERSION ./
+COPY tools/bin/ldflags ./tools/bin/
+
+ADD go.mod go.sum ./
+RUN go mod download
+
+# Env vars needed for chainlink build
+ARG COMMIT_SHA
+
+COPY . .
+
+# Build the golang binaries
+RUN make install-chainlink
+RUN make install-solana
+RUN make install-median
+
+# Final image: ubuntu with chainlink binary
+FROM ubuntu:20.04
+
+ARG CHAINLINK_USER=root
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update && apt-get install -y ca-certificates gnupg lsb-release curl
+
+# Install Postgres for CLI tools, needed specifically for DB backups
+RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
+  && echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" |tee /etc/apt/sources.list.d/pgdg.list \
+  && apt-get update && apt-get install -y postgresql-client-14 \
+  && apt-get clean all
+
+COPY --from=buildgo /go/bin/chainlink /usr/local/bin/
+COPY --from=buildgo /go/bin/chainlink-solana /usr/local/bin/
+ENV CL_SOLANA_CMD chainlink-solana
+COPY --from=buildgo /go/bin/chainlink-median /usr/local/bin/
+ENV CL_MEDIAN_CMD chainlink-median
+
+# Dependency of CosmWasm/wasmd
+COPY --from=buildgo /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@v*/internal/api/libwasmvm.*.so /usr/lib/
+RUN chmod 755 /usr/lib/libwasmvm.*.so
+
+RUN if [ ${CHAINLINK_USER} != root ]; then \
+  useradd --uid 14933 --create-home ${CHAINLINK_USER}; \
+  fi
+USER ${CHAINLINK_USER}
+WORKDIR /home/${CHAINLINK_USER}
+
+EXPOSE 6688
+ENTRYPOINT ["chainlink"]
+
+HEALTHCHECK CMD curl -f http://localhost:6688/health || exit 1
+
+CMD ["local", "node"]

--- a/plugins/cmd/chainlink-median/main.go
+++ b/plugins/cmd/chainlink-median/main.go
@@ -1,0 +1,34 @@
+package main
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/hashicorp/go-plugin"
+
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/median"
+	"github.com/smartcontractkit/chainlink/v2/plugins"
+)
+
+func main() {
+	envCfg, err := plugins.GetEnvConfig()
+	if err != nil {
+		fmt.Printf("Failed to get environment configuration: %s\n", err)
+		os.Exit(1)
+	}
+	lggr, closeLggr := plugins.NewLogger(envCfg)
+	defer closeLggr()
+
+	stop := make(chan struct{})
+	defer close(stop)
+
+	mp := median.NewPlugin(lggr, stop)
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: loop.PluginMedianHandshakeConfig(),
+		Plugins: map[string]plugin.Plugin{
+			loop.PluginMedianName: loop.NewGRPCPluginMedian(mp, lggr),
+		},
+		GRPCServer: plugin.DefaultGRPCServer,
+	})
+}

--- a/plugins/cmd/chainlink-solana/main.go
+++ b/plugins/cmd/chainlink-solana/main.go
@@ -1,0 +1,88 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"github.com/hashicorp/go-plugin"
+	"github.com/pelletier/go-toml/v2"
+	"go.uber.org/multierr"
+
+	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
+	pkgsol "github.com/smartcontractkit/chainlink-solana/pkg/solana"
+	"github.com/smartcontractkit/chainlink/v2/plugins"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/solana"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
+)
+
+func main() {
+	envCfg, err := plugins.GetEnvConfig()
+	if err != nil {
+		fmt.Printf("Failed to get environment configuration: %s\n", err)
+		os.Exit(1)
+	}
+	lggr, closeLggr := plugins.NewLogger(envCfg)
+	defer closeLggr()
+
+	cp := &chainPlugin{lggr: lggr}
+	defer func() {
+		logger.Sugared(lggr).ErrorIfFn(cp.Close, "chainPlugin")
+	}()
+
+	plugin.Serve(&plugin.ServeConfig{
+		HandshakeConfig: loop.PluginRelayerHandshakeConfig(),
+		Plugins: map[string]plugin.Plugin{
+			loop.PluginRelayerName: loop.NewGRPCPluginRelayer(cp, lggr),
+		},
+		GRPCServer: plugin.DefaultGRPCServer,
+	})
+}
+
+type chainPlugin struct {
+	lggr logger.Logger
+
+	mu      sync.Mutex
+	closers []io.Closer
+}
+
+func (c *chainPlugin) NewRelayer(ctx context.Context, config string, keystore loop.Keystore) (loop.Relayer, error) {
+	d := toml.NewDecoder(strings.NewReader(config))
+	d.DisallowUnknownFields()
+	var cfg struct {
+		Solana solana.SolanaConfigs
+	}
+	if err := d.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("failed to decode config toml: %w", err)
+	}
+
+	chainSet, err := solana.NewChainSet(solana.ChainSetOpts{
+		Logger:   c.lggr,
+		KeyStore: keystore,
+		Configs:  solana.NewConfigs(cfg.Solana),
+	}, cfg.Solana)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create chain: %w", err)
+	}
+	r := pkgsol.NewRelayer(c.lggr, chainSet)
+	c.mu.Lock()
+	c.closers = append(c.closers, chainSet, r)
+	c.mu.Unlock()
+	return &relay.RelayerAdapter{Relayer: r, RelayerExt: chainSet}, nil
+}
+
+func (c *chainPlugin) Close() (err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for _, cl := range c.closers {
+		if e := cl.Close(); e != nil {
+			err = multierr.Append(err, e)
+		}
+	}
+	return
+}

--- a/plugins/logger.go
+++ b/plugins/logger.go
@@ -1,0 +1,22 @@
+package plugins
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+)
+
+func NewLogger(cfg EnvConfig) (logger.Logger, func()) {
+	lcfg := logger.Config{
+		LogLevel:    cfg.LogLevel(),
+		JsonConsole: cfg.JSONConsole(),
+		UnixTS:      cfg.LogUnixTimestamps(),
+	}
+	lggr, closeLggr := lcfg.New()
+	lggr = lggr.Named("PluginSolana")
+	return lggr, func() {
+		if err := closeLggr(); err != nil {
+			fmt.Println("Failed to close logger:", err)
+		}
+	}
+}

--- a/plugins/plugins.go
+++ b/plugins/plugins.go
@@ -1,0 +1,64 @@
+package plugins
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+
+	"go.uber.org/zap/zapcore"
+)
+
+type EnvConfig interface {
+	LogLevel() zapcore.Level
+	JSONConsole() bool
+	LogUnixTimestamps() bool
+}
+
+func SetEnvConfig(cmd *exec.Cmd, cfg EnvConfig) {
+	forward := func(name string) {
+		if v, ok := os.LookupEnv(name); ok {
+			cmd.Env = append(cmd.Env, name+"="+v)
+		}
+	}
+	forward("CL_DEV")
+	forward("CL_LOG_SQL_MIGRATIONS")
+	forward("CL_LOG_COLOR")
+	cmd.Env = append(cmd.Env,
+		"CL_LOG_LEVEL="+cfg.LogLevel().String(),
+		"CL_JSON_CONSOLE="+strconv.FormatBool(cfg.JSONConsole()),
+		"CL_UNIX_TS="+strconv.FormatBool(cfg.LogUnixTimestamps()),
+	)
+}
+
+func GetEnvConfig() (EnvConfig, error) {
+	logLevelStr := os.Getenv("CL_LOG_LEVEL")
+	logLevel, err := zapcore.ParseLevel(logLevelStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse CL_LOG_LEVEL = %q: %w", logLevelStr, err)
+	}
+	return &envConfig{
+		logLevel:       logLevel,
+		jsonConsole:    strings.EqualFold("true", os.Getenv("CL_JSON_CONSOLE")),
+		unixTimestamps: strings.EqualFold("true", os.Getenv("CL_UNIX_TS")),
+	}, nil
+}
+
+type envConfig struct {
+	logLevel       zapcore.Level
+	jsonConsole    bool
+	unixTimestamps bool
+}
+
+func (e *envConfig) LogLevel() zapcore.Level {
+	return e.logLevel
+}
+
+func (e *envConfig) JSONConsole() bool {
+	return e.jsonConsole
+}
+
+func (e *envConfig) LogUnixTimestamps() bool {
+	return e.unixTimestamps
+}


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCF-2020

This PR adds experimental support for running the Solana Relayer and Median ReportingPlugin as LOOP Plugins.
This is opt-in only, and not yet supported in the standard docker image (additional binaries required: see `plugins/chainlink.Dockerfile`).