### PR TITLE
Show external initiator cmds regardless of devmode vals

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -212,8 +212,7 @@ func NewApp(client *Client) *cli.App {
 		{
 			Name:        "initiators",
 			Usage:       "Commands for managing External Initiators",
-			Hidden:      !devMode,
-			Subcommands: initInitiatorsSubCmds(client, devMode),
+			Subcommands: initInitiatorsSubCmds(client),
 		},
 		{
 			Name:  "txs",

--- a/core/cmd/external_initiator_commands.go
+++ b/core/cmd/external_initiator_commands.go
@@ -7,7 +7,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
 
-func initInitiatorsSubCmds(client *Client, devMode bool) []cli.Command {
+func initInitiatorsSubCmds(client *Client) []cli.Command {
 	return []cli.Command{
 		{
 			Name:   "create",


### PR DESCRIPTION
External Initiator cmds should be available regardless of devmode values.