### PR TITLE
Foundry reverts on changePrank if no prank is active

### DIFF
--- a/contracts/.gas-snapshot
+++ b/contracts/.gas-snapshot
@@ -1,5 +1,5 @@
 FunctionsOracle_setDONPublicKey:testSetDONPublicKey_gas() (gas: 97558)
-FunctionsOracle_setRegistry:testSetRegistry_gas() (gas: 31953)
+FunctionsOracle_setRegistry:testSetRegistry_gas() (gas: 31965)
 Verifier_accessControlledVerify:testVerifyWithAccessControl_gas() (gas: 195197)
 Verifier_setConfig:testSetConfigSuccess_gas() (gas: 892255)
 Verifier_verify:testVerifyProxySuccess_gas() (gas: 185663)

--- a/contracts/test/v0.8/foundry/BaseTest.t.sol
+++ b/contracts/test/v0.8/foundry/BaseTest.t.sol
@@ -1,4 +1,4 @@
-pragma solidity ^0.8.17;
+pragma solidity ^0.8.0;
 
 import {Test} from "forge-std/Test.sol";
 

--- a/contracts/test/v0.8/foundry/BaseTest.t.sol
+++ b/contracts/test/v0.8/foundry/BaseTest.t.sol
@@ -3,10 +3,15 @@ pragma solidity ^0.8.17;
 import {Test} from "forge-std/Test.sol";
 
 contract BaseTest is Test {
+  bool private s_baseTestInitialized;
   address internal constant OWNER = 0x00007e64E1fB0C487F25dd6D3601ff6aF8d32e4e;
 
   function setUp() public virtual {
+    // BaseTest.setUp is often called multiple times from tests' setUp due to inheritance.
+    if (s_baseTestInitialized) return;
+    s_baseTestInitialized = true;
+
     // Set msg.sender to OWNER until changePrank or stopPrank is called
-    changePrank(OWNER);
+    vm.startPrank(OWNER);
   }
 }

--- a/contracts/test/v0.8/foundry/transmission/EIP_712_1014_4337.t.sol
+++ b/contracts/test/v0.8/foundry/transmission/EIP_712_1014_4337.t.sol
@@ -1,6 +1,6 @@
 pragma solidity ^0.8.15;
 
-import "forge-std/Test.sol";
+import "../BaseTest.t.sol";
 import "../../../../src/v0.8/dev/transmission/4337/SmartContractAccountFactory.sol";
 import "../../../../src/v0.8/dev/transmission/testhelpers/SmartContractAccountHelper.sol";
 import "../../../../src/v0.8/dev/transmission/4337/SCA.sol";
@@ -46,7 +46,7 @@ import "../../../../src/v0.8/vrf/testhelpers/VRFConsumer.sol";
 |                             |
 +----------------------------*/
 
-contract EIP_712_1014_4337 is Test {
+contract EIP_712_1014_4337 is BaseTest {
   event RandomnessRequest(address indexed sender, bytes32 indexed keyHash, uint256 indexed seed, uint256 fee);
 
   address internal constant LINK_WHALE = 0xD883a6A1C22fC4AbFE938a5aDF9B2Cc31b1BF18B;
@@ -60,7 +60,8 @@ contract EIP_712_1014_4337 is Test {
   uint256 END_USER_PKEY = uint256(bytes32(hex"99d518dbfea4b4ec301390f7e26d53d711fa1ca0c1a6e4cbed89617d4c578a8e"));
   address END_USER = 0xB6708257D4E1bf0b8C144793fc2Ff3193C737ed1;
 
-  function setUp() public {
+  function setUp() public override {
+    BaseTest.setUp();
     // Fund user accounts;
     vm.deal(END_USER, 10_000 ether);
     vm.deal(LINK_WHALE, 10_000 ether);

--- a/contracts/test/v0.8/foundry/verifier/BaseVerifierTest.t.sol
+++ b/contracts/test/v0.8/foundry/verifier/BaseVerifierTest.t.sol
@@ -68,9 +68,14 @@ contract BaseTest is Test {
 
   Signer[MAX_ORACLES] internal s_signers;
   bytes32[] internal s_offchaintransmitters;
+  bool private s_baseTestInitialized;
 
   function setUp() public virtual {
-    changePrank(ADMIN);
+    // BaseTest.setUp is often called multiple times from tests' setUp due to inheritance.
+    if (s_baseTestInitialized) return;
+    s_baseTestInitialized = true;
+
+    vm.startPrank(ADMIN);
     vm.mockCall(
       MOCK_VERIFIER_ADDRESS,
       abi.encodeWithSelector(IERC165.supportsInterface.selector, IVerifier.verify.selector),


### PR DESCRIPTION
Foundry recently started reverting on changePrank if no prank is active. This change will make sure all contract that inherit BaseTest will have a single startPrank call that is done in the setUp. After that, all prank calls can be changePrank calls.