### PR TITLE
Remove slow tests config

### DIFF
--- a/contracts/ci.json
+++ b/contracts/ci.json
@@ -16,14 +16,7 @@
     },
     {
       "dir": "v0.8",
-      "numOfSplits": 8,
-      "slowTests": [
-        "Keeper",
-        "Cron.test",
-        "CronUpkeep.test",
-        "EthBalanceMonitor",
-        "CanaryUpkeep"
-      ]
+      "numOfSplits": 8
     }
   ]
 }


### PR DESCRIPTION
Slow test config is somehow borking CI. No idea how. I only know this fixes the issue (for now). Removing the slow test feature for now until we figure out how to fix the issue long term. _Slow CI is better than no CI_.