### PR TITLE
Fix Hardhat cache keys

### DIFF
--- a/.github/actions/setup-hardhat/action.yaml
+++ b/.github/actions/setup-hardhat/action.yaml
@@ -14,7 +14,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: ~/.cache/hardhat-nodejs/
-        key: contracts-compilers-${{ runner.os }}-${{ inputs.cache-version }}-${{ hashFiles('contracts/pnpm.lock', 'contracts/hardhat.config.ts') }}
+        key: contracts-compilers-${{ runner.os }}-${{ inputs.cache-version }}-${{ hashFiles('contracts/pnpm-lock.yaml', 'contracts/hardhat.config.ts') }}
 
     - name: Cache contracts build outputs
       uses: actions/cache@v3
@@ -23,7 +23,7 @@ runs:
           contracts/cache/
           contracts/artifacts/
           contracts/typechain/
-        key: ${{ format('contracts-{0}-{1}-{2}', runner.os, inputs.cache-version, inputs.namespace, hashFiles('contracts/pnpm.lock', 'contracts/hardhat.config.ts', 'contracts/src/**/*.sol')) }}
+        key: ${{ format('contracts-{0}-{1}-{2}-{3}', runner.os, inputs.cache-version, inputs.namespace, hashFiles('contracts/pnpm-lock.yaml', 'contracts/hardhat.config.ts', 'contracts/src/**/*.sol')) }}
 
     - name: Compile contracts
       shell: bash

--- a/.github/actions/setup-hardhat/action.yaml
+++ b/.github/actions/setup-hardhat/action.yaml
@@ -24,8 +24,6 @@ runs:
           contracts/artifacts/
           contracts/typechain/
         key: ${{ format('contracts-{0}-{1}-{2}', runner.os, inputs.cache-version, inputs.namespace, hashFiles('contracts/pnpm.lock', 'contracts/hardhat.config.ts', 'contracts/src/**/*.sol')) }}
-        restore-keys: |
-          ${{ format('contracts-{0}-{1}-', runner.os, inputs.cache-version, inputs.namespace) }}
 
     - name: Compile contracts
       shell: bash

--- a/contracts/ci.json
+++ b/contracts/ci.json
@@ -16,7 +16,14 @@
     },
     {
       "dir": "v0.8",
-      "numOfSplits": 8
+      "numOfSplits": 8,
+      "slowTests": [
+        "Keeper",
+        "Cron.test",
+        "CronUpkeep.test",
+        "EthBalanceMonitor",
+        "CanaryUpkeep"
+      ]
     }
   ]
 }


### PR DESCRIPTION
- Revert "remove slow tests config (#9094)"
- Remove restore key for contract build output cache
- Fix invalid primary cache key generation
