### PR TITLE
Move RegisterFilter() calls into (d *job.Delegate).CreateJob

### DIFF
--- a/core/chains/evm/forwarders/forwarder_manager.go
+++ b/core/chains/evm/forwarders/forwarder_manager.go
@@ -87,7 +87,7 @@ func (f *FwdMgr) Start(ctx context.Context) error {
 		if len(fwdrs) != 0 {
 			f.initForwardersCache(ctx, fwdrs)
 			if f.logpoller == evmlogpoller.LogPollerDisabled {
-				f.logger.Warn("Log poller is required for contract forwarder to receive AuthorizedSendersChanged logs")
+				f.logger.Warn("log poller is required for contract forwarder to receive AuthorizedSendersChanged logs")
 				return nil
 			}
 		}

--- a/core/chains/evm/forwarders/forwarder_manager.go
+++ b/core/chains/evm/forwarders/forwarder_manager.go
@@ -86,7 +86,7 @@ func (f *FwdMgr) Start(ctx context.Context) error {
 		}
 		if len(fwdrs) != 0 {
 			f.initForwardersCache(ctx, fwdrs)
-			if err := f.subscribeForwardersLogs(fwdrs, nil); err != nil {
+			if err2 := f.subscribeForwardersLogs(fwdrs, nil); err2 != nil {
 				return err
 			}
 		}

--- a/core/chains/evm/forwarders/forwarder_manager.go
+++ b/core/chains/evm/forwarders/forwarder_manager.go
@@ -86,9 +86,9 @@ func (f *FwdMgr) Start(ctx context.Context) error {
 		}
 		if len(fwdrs) != 0 {
 			f.initForwardersCache(ctx, fwdrs)
-			err = f.checkLogPollerStatus()
-			if err != nil {
-				return err
+			if f.logpoller == evmlogpoller.LogPollerDisabled {
+				f.logger.Warn("Log poller is required for contract forwarder to receive AuthorizedSendersChanged logs")
+				return nil
 			}
 		}
 
@@ -195,13 +195,6 @@ func (f *FwdMgr) initForwardersCache(ctx context.Context, fwdrs []Forwarder) {
 		f.setCachedSenders(fwdr.Address, senders)
 
 	}
-}
-
-func (f *FwdMgr) checkLogPollerStatus() error {
-	if err := f.logpoller.Ready(); err != nil {
-		return errors.Wrapf(err, "Log poller is required for contract forwarder to receive AuthorizedSendersChanged logs")
-	}
-	return nil
 }
 
 func (f *FwdMgr) setCachedSenders(addr common.Address, senders []common.Address) {

--- a/core/chains/evm/forwarders/forwarder_manager.go
+++ b/core/chains/evm/forwarders/forwarder_manager.go
@@ -86,7 +86,7 @@ func (f *FwdMgr) Start(ctx context.Context) error {
 		}
 		if len(fwdrs) != 0 {
 			f.initForwardersCache(ctx, fwdrs)
-			if err = f.subscribeForwardersLogs(fwdrs); err != nil {
+			if err := f.subscribeForwardersLogs(fwdrs, nil); err != nil {
 				return err
 			}
 		}
@@ -107,8 +107,12 @@ func (f *FwdMgr) Start(ctx context.Context) error {
 	})
 }
 
-func FilterName(addr common.Address) string {
-	return evmlogpoller.FilterName("ForwarderManager AuthorizedSendersChanged", addr.String())
+func NewLogFilter(addr common.Address) evmlogpoller.Filter {
+	return evmlogpoller.Filter{
+		Name:      evmlogpoller.FilterName("ForwarderManager AuthorizedSendersChanged", addr.String()),
+		EventSigs: []common.Hash{authChangedTopic},
+		Addresses: []common.Address{addr},
+	}
 }
 
 func (f *FwdMgr) ForwarderFor(addr common.Address) (forwarder common.Address, err error) {
@@ -164,9 +168,6 @@ func (f *FwdMgr) getContractSenders(addr common.Address) ([]common.Address, erro
 		return nil, errors.Wrapf(err, "Failed to call getAuthorizedSenders on %s", addr)
 	}
 	f.setCachedSenders(addr, senders)
-	if err = f.subscribeSendersChangedLogs(addr); err != nil {
-		return nil, err
-	}
 	return senders, nil
 }
 
@@ -195,27 +196,22 @@ func (f *FwdMgr) initForwardersCache(ctx context.Context, fwdrs []Forwarder) {
 	}
 }
 
-func (f *FwdMgr) subscribeForwardersLogs(fwdrs []Forwarder) error {
+func (f *FwdMgr) subscribeForwardersLogs(fwdrs []Forwarder, q pg.Queryer) error {
 	for _, fwdr := range fwdrs {
-		if err := f.subscribeSendersChangedLogs(fwdr.Address); err != nil {
+		if err := f.SubscribeSendersChangedLogs(fwdr.Address, q); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (f *FwdMgr) subscribeSendersChangedLogs(addr common.Address) error {
+func (f *FwdMgr) SubscribeSendersChangedLogs(addr common.Address, q pg.Queryer) error {
 	if err := f.logpoller.Ready(); err != nil {
 		f.logger.Warnw("Unable to subscribe to AuthorizedSendersChanged logs", "forwarder", addr, "err", err)
 		return nil
 	}
 
-	err := f.logpoller.RegisterFilter(
-		evmlogpoller.Filter{
-			Name:      FilterName(addr),
-			EventSigs: []common.Hash{authChangedTopic},
-			Addresses: []common.Address{addr},
-		})
+	err := f.logpoller.RegisterFilter(NewLogFilter(addr), nil)
 	return err
 }
 

--- a/core/chains/evm/forwarders/forwarder_manager_test.go
+++ b/core/chains/evm/forwarders/forwarder_manager_test.go
@@ -66,7 +66,7 @@ func TestFwdMgr_MaybeForwardTransaction(t *testing.T) {
 	require.NoError(t, err)
 	lst, err := fwdMgr.ORM.FindForwardersByChain(utils.Big(*testutils.FixtureChainID))
 	require.NoError(t, err)
-	require.Equal(t, len(lst), 1)
+	require.Equal(t, 1, len(lst))
 	require.Equal(t, lst[0].Address, forwarderAddr)
 
 	require.NoError(t, fwdMgr.Start(testutils.Context(t)))
@@ -119,7 +119,7 @@ func TestFwdMgr_AccountUnauthorizedToForward_SkipsForwarding(t *testing.T) {
 	require.NoError(t, err)
 	lst, err := fwdMgr.ORM.FindForwardersByChain(utils.Big(*testutils.FixtureChainID))
 	require.NoError(t, err)
-	require.Equal(t, len(lst), 1)
+	require.Equal(t, 1, len(lst))
 	require.Equal(t, lst[0].Address, forwarderAddr)
 
 	err = fwdMgr.Start(testutils.Context(t))

--- a/core/chains/evm/forwarders/forwarder_manager_test.go
+++ b/core/chains/evm/forwarders/forwarder_manager_test.go
@@ -34,8 +34,8 @@ var SimpleOracleCallABI = evmtypes.MustGetABI(operator_wrapper.OperatorABI).Meth
 
 func createLogPoller(t *testing.T, db *sqlx.DB, lggr logger.Logger, ec client.Client) logpoller.LogPoller {
 	lp := logpoller.NewLogPoller(logpoller.NewORM(testutils.FixtureChainID, db, lggr, pgtest.NewQConfig(true)), ec, lggr, 100*time.Millisecond, 2, 3, 2, 1000)
-	lp.StartOnce("LogPoller", func() error { return nil }) // Required because forwarder validates lp.Ready()
-	t.Cleanup(func() { lp.StopOnce("LogPoller", func() error { return nil }) })
+	require.NoError(t, lp.StartOnce("LogPoller", func() error { return nil })) // Required because forwarder validates lp.Ready())
+	t.Cleanup(func() { require.NoError(t, lp.StopOnce("LogPoller", func() error { return nil })) })
 	return lp
 }
 

--- a/core/chains/evm/forwarders/forwarder_manager_test.go
+++ b/core/chains/evm/forwarders/forwarder_manager_test.go
@@ -119,7 +119,6 @@ func TestFwdMgr_AccountUnauthorizedToForward_SkipsForwarding(t *testing.T) {
 	ec.Commit()
 
 	evmClient := client.NewSimulatedBackendClient(t, ec, testutils.FixtureChainID)
-	fwdMgr.ORM = forwarders.NewORM(db, logger.TestLogger(t), cfg.Database())
 	lp := createLogPoller(t, db, lggr, evmClient)
 	fwdMgr := forwarders.NewFwdMgr(db, evmClient, lp, lggr, evmcfg, evmcfg.Database())
 	fwdMgr.ORM = forwarders.NewORM(db, logger.TestLogger(t), cfg.Database())

--- a/core/chains/evm/forwarders/mocks/orm.go
+++ b/core/chains/evm/forwarders/mocks/orm.go
@@ -17,23 +17,30 @@ type ORM struct {
 	mock.Mock
 }
 
-// CreateForwarder provides a mock function with given fields: addr, evmChainId
-func (_m *ORM) CreateForwarder(addr common.Address, evmChainId utils.Big) (forwarders.Forwarder, error) {
-	ret := _m.Called(addr, evmChainId)
+// CreateForwarder provides a mock function with given fields: addr, evmChainId, qopts
+func (_m *ORM) CreateForwarder(addr common.Address, evmChainId utils.Big, qopts ...pg.QOpt) (forwarders.Forwarder, error) {
+	_va := make([]interface{}, len(qopts))
+	for _i := range qopts {
+		_va[_i] = qopts[_i]
+	}
+	var _ca []interface{}
+	_ca = append(_ca, addr, evmChainId)
+	_ca = append(_ca, _va...)
+	ret := _m.Called(_ca...)
 
 	var r0 forwarders.Forwarder
 	var r1 error
-	if rf, ok := ret.Get(0).(func(common.Address, utils.Big) (forwarders.Forwarder, error)); ok {
-		return rf(addr, evmChainId)
+	if rf, ok := ret.Get(0).(func(common.Address, utils.Big, ...pg.QOpt) (forwarders.Forwarder, error)); ok {
+		return rf(addr, evmChainId, qopts...)
 	}
-	if rf, ok := ret.Get(0).(func(common.Address, utils.Big) forwarders.Forwarder); ok {
-		r0 = rf(addr, evmChainId)
+	if rf, ok := ret.Get(0).(func(common.Address, utils.Big, ...pg.QOpt) forwarders.Forwarder); ok {
+		r0 = rf(addr, evmChainId, qopts...)
 	} else {
 		r0 = ret.Get(0).(forwarders.Forwarder)
 	}
 
-	if rf, ok := ret.Get(1).(func(common.Address, utils.Big) error); ok {
-		r1 = rf(addr, evmChainId)
+	if rf, ok := ret.Get(1).(func(common.Address, utils.Big, ...pg.QOpt) error); ok {
+		r1 = rf(addr, evmChainId, qopts...)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/chains/evm/forwarders/orm.go
+++ b/core/chains/evm/forwarders/orm.go
@@ -56,7 +56,7 @@ func (o *orm) DeleteForwarder(id int64, cleanup func(tx pg.Queryer, evmChainID i
 			return err2
 		}
 
-		result, err2 := o.q.Exec(`DELETE FROM evm_forwarders WHERE id = $1`, id)
+		result, err2 := tx.Exec(`DELETE FROM evm_forwarders WHERE id = $1`, id)
 		// If the forwarder wasn't found, we still want to delete the filter.
 		// In that case, the transaction must return nil, even though DeleteForwarder
 		// will return sql.ErrNoRows

--- a/core/chains/evm/logpoller/disabled.go
+++ b/core/chains/evm/logpoller/disabled.go
@@ -33,7 +33,7 @@ func (disabled) Replay(ctx context.Context, fromBlock int64) error { return ErrD
 
 func (disabled) ReplayAsync(fromBlock int64) {}
 
-func (disabled) RegisterFilter(filter Filter) error { return ErrDisabled }
+func (disabled) RegisterFilter(filter Filter, q pg.Queryer) error { return ErrDisabled }
 
 func (disabled) UnregisterFilter(name string, q pg.Queryer) error { return ErrDisabled }
 

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -230,7 +230,7 @@ func (lp *logPoller) RegisterFilter(filter Filter, q pg.Queryer) error {
 		lp.lggr.Debugw("Creating new filter", "filter", filter)
 	}
 
-	if err := lp.orm.InsertFilter(filter); err != nil {
+	if err := lp.orm.InsertFilter(filter, pg.WithQueryer(q)); err != nil {
 		return errors.Wrap(err, "RegisterFilter failed to save filter to db")
 	}
 	lp.filters[filter.Name] = filter

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -33,7 +33,7 @@ type LogPoller interface {
 	services.ServiceCtx
 	Replay(ctx context.Context, fromBlock int64) error
 	ReplayAsync(fromBlock int64)
-	RegisterFilter(filter Filter) error
+	RegisterFilter(filter Filter, q pg.Queryer) error
 	UnregisterFilter(name string, q pg.Queryer) error
 	LatestBlock(qopts ...pg.QOpt) (int64, error)
 	GetBlocksRange(ctx context.Context, numbers []uint64, qopts ...pg.QOpt) ([]LogPollerBlock, error)
@@ -198,7 +198,7 @@ func (filter *Filter) Contains(other *Filter) bool {
 // Generally speaking this is harmless. We enforce that EventSigs and Addresses are non-empty,
 // which means that anonymous events are not supported and log.Topics >= 1 always (log.Topics[0] is the event signature).
 // The filter may be unregistered later by Filter.Name
-func (lp *logPoller) RegisterFilter(filter Filter) error {
+func (lp *logPoller) RegisterFilter(filter Filter, q pg.Queryer) error {
 	if len(filter.Addresses) == 0 {
 		return errors.Errorf("at least one address must be specified")
 	}

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -113,7 +113,7 @@ func TestLogPoller_Integration(t *testing.T) {
 	th := SetupTH(t, 2, 3, 2)
 	th.Client.Commit() // Block 2. Ensure we have finality number of blocks
 
-	err := th.LogPoller.RegisterFilter(logpoller.Filter{"Integration test", []common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{th.EmitterAddress1}, 0})
+	err := th.LogPoller.RegisterFilter(logpoller.Filter{"Integration test", []common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{th.EmitterAddress1}, 0}, nil)
 	require.NoError(t, err)
 	require.Len(t, th.LogPoller.Filter(nil, nil, nil).Addresses, 1)
 	require.Len(t, th.LogPoller.Filter(nil, nil, nil).Topics, 1)
@@ -144,7 +144,7 @@ func TestLogPoller_Integration(t *testing.T) {
 	err = th.LogPoller.RegisterFilter(logpoller.Filter{
 		"Emitter - log2", []common.Hash{EmitterABI.Events["Log2"].ID},
 		[]common.Address{th.EmitterAddress1}, 0,
-	})
+	}, nil)
 	require.NoError(t, err)
 	// Replay an invalid block should error
 	assert.Error(t, th.LogPoller.Replay(testutils.Context(t), 0))
@@ -188,7 +188,7 @@ func Test_BackupLogPoller(t *testing.T) {
 		EmitterABI.Events["Log2"].ID},
 		[]common.Address{th.EmitterAddress1},
 		0}
-	err := th.LogPoller.RegisterFilter(filter1)
+	err := th.LogPoller.RegisterFilter(filter1, nil)
 	require.NoError(t, err)
 
 	filters, err := th.ORM.LoadFilters(pg.WithParentCtx(testutils.Context(t)))
@@ -199,7 +199,7 @@ func Test_BackupLogPoller(t *testing.T) {
 	err = th.LogPoller.RegisterFilter(
 		logpoller.Filter{"filter2",
 			[]common.Hash{EmitterABI.Events["Log1"].ID},
-			[]common.Address{th.EmitterAddress2}, 0})
+			[]common.Address{th.EmitterAddress2}, 0}, nil)
 	require.NoError(t, err)
 
 	defer func() {
@@ -317,7 +317,7 @@ func TestLogPoller_BlockTimestamps(t *testing.T) {
 	addresses := []common.Address{th.EmitterAddress1, th.EmitterAddress2}
 	topics := []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}
 
-	err := th.LogPoller.RegisterFilter(logpoller.Filter{"convertLogs", topics, addresses, 0})
+	err := th.LogPoller.RegisterFilter(logpoller.Filter{"convertLogs", topics, addresses, 0}, nil)
 	require.NoError(t, err)
 
 	blk, err := th.Client.BlockByNumber(ctx, nil)
@@ -491,7 +491,7 @@ func TestLogPoller_PollAndSaveLogs(t *testing.T) {
 	err := th.LogPoller.RegisterFilter(logpoller.Filter{
 		"Test Emitter 1 & 2", []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID},
 		[]common.Address{th.EmitterAddress1, th.EmitterAddress2}, 0,
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	b, err := th.Client.BlockByNumber(testutils.Context(t), nil)
@@ -715,11 +715,11 @@ func TestLogPoller_LoadFilters(t *testing.T) {
 	assert.False(t, filter2.Contains(&filter1))
 	assert.True(t, filter1.Contains(&filter3))
 
-	err := th.LogPoller.RegisterFilter(filter1)
+	err := th.LogPoller.RegisterFilter(filter1, nil)
 	require.NoError(t, err)
-	err = th.LogPoller.RegisterFilter(filter2)
+	err = th.LogPoller.RegisterFilter(filter2, nil)
 	require.NoError(t, err)
-	err = th.LogPoller.RegisterFilter(filter3)
+	err = th.LogPoller.RegisterFilter(filter3, nil)
 	require.NoError(t, err)
 
 	filters, err := th.ORM.LoadFilters()
@@ -748,8 +748,8 @@ func TestLogPoller_GetBlocks_Range(t *testing.T) {
 	th := SetupTH(t, 2, 3, 2)
 
 	err := th.LogPoller.RegisterFilter(logpoller.Filter{"GetBlocks Test", []common.Hash{
-		EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{th.EmitterAddress1, th.EmitterAddress2}, 0},
-	)
+		EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{th.EmitterAddress1, th.EmitterAddress2}, 0,
+	}, nil)
 	require.NoError(t, err)
 
 	// LP retrieves 0 blocks

--- a/core/chains/evm/logpoller/mocks/log_poller.go
+++ b/core/chains/evm/logpoller/mocks/log_poller.go
@@ -571,13 +571,13 @@ func (_m *LogPoller) Ready() error {
 	return r0
 }
 
-// RegisterFilter provides a mock function with given fields: filter
-func (_m *LogPoller) RegisterFilter(filter logpoller.Filter) error {
-	ret := _m.Called(filter)
+// RegisterFilter provides a mock function with given fields: filter, q
+func (_m *LogPoller) RegisterFilter(filter logpoller.Filter, q pg.Queryer) error {
+	ret := _m.Called(filter, q)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(logpoller.Filter) error); ok {
-		r0 = rf(filter)
+	if rf, ok := ret.Get(0).(func(logpoller.Filter, pg.Queryer) error); ok {
+		r0 = rf(filter, q)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/core/chains/evm/types/internal/blocks/internal_types_codecgen.go
+++ b/core/chains/evm/types/internal/blocks/internal_types_codecgen.go
@@ -7,12 +7,13 @@ package blocks
 
 import (
 	"errors"
-	pkg2_common "github.com/ethereum/go-ethereum/common"
-	pkg1_hexutil "github.com/ethereum/go-ethereum/common/hexutil"
-	codec1978 "github.com/ugorji/go/codec"
 	"runtime"
 	"sort"
 	"strconv"
+
+	pkg2_common "github.com/ethereum/go-ethereum/common"
+	pkg1_hexutil "github.com/ethereum/go-ethereum/common/hexutil"
+	codec1978 "github.com/ugorji/go/codec"
 )
 
 const (

--- a/core/chains/evm/types/internal/blocks/internal_types_codecgen.go
+++ b/core/chains/evm/types/internal/blocks/internal_types_codecgen.go
@@ -7,13 +7,12 @@ package blocks
 
 import (
 	"errors"
-	"runtime"
-	"sort"
-	"strconv"
-
 	pkg2_common "github.com/ethereum/go-ethereum/common"
 	pkg1_hexutil "github.com/ethereum/go-ethereum/common/hexutil"
 	codec1978 "github.com/ugorji/go/codec"
+	"runtime"
+	"sort"
+	"strconv"
 )
 
 const (

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -57,6 +57,7 @@ import (
 	evmconfig "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/gas"
 	httypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker/types"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/solana"
@@ -366,6 +367,7 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 	externalInitiatorManager = &webhook.NullExternalInitiatorManager{}
 	var useRealExternalInitiatorManager bool
 	var chainCfgs evmtypes.Configs
+	lp := logpoller.LogPollerDisabled
 	for _, flag := range flagsAndDeps {
 		switch dep := flag.(type) {
 		case evmclient.Client:
@@ -374,6 +376,8 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 			externalInitiatorManager = dep
 		case pg.EventBroadcaster:
 			eventBroadcaster = dep
+		case logpoller.LogPoller:
+			lp = dep
 		default:
 			switch flag {
 			case UseRealExternalInitiatorManager:
@@ -414,6 +418,9 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 				t.Fatalf("expected eth client ChainID %d to match configured DefaultChainID %d", chainId, cfg.DefaultChainID())
 			}
 			return ethClient
+		},
+		GenLogPoller: func(*big.Int) logpoller.LogPoller {
+			return lp
 		},
 		MailMon: mailMon,
 	})

--- a/core/internal/testutils/pgtest/pgtest.go
+++ b/core/internal/testutils/pgtest/pgtest.go
@@ -10,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	v2 "github.com/smartcontractkit/chainlink/v2/core/config/v2"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	"github.com/smartcontractkit/chainlink/v2/core/store/dialects"
@@ -33,22 +32,6 @@ func NewSqlDB(t *testing.T) *sql.DB {
 func NewSqlxDB(t testing.TB) *sqlx.DB {
 	testutils.SkipShortDB(t)
 	db, err := sqlx.Open(string(dialects.TransactionWrappedPostgres), uuid.New().String())
-	require.NoError(t, err)
-	t.Cleanup(func() { assert.NoError(t, db.Close()) })
-
-	db.MapperFunc(reflectx.CamelToSnakeASCII)
-
-	return db
-}
-
-// For tests which need transaction rollback capability, but don't want the overhead
-// of creating a separate heavyweight db
-func NewSqlxDBWithRollback(t testing.TB) *sqlx.DB {
-	testutils.SkipShortDB(t)
-	dbURL := string(v2.EnvDatabaseURL.Get())
-	require.NotEmpty(t, dbURL)
-
-	db, err := sqlx.Open(string(dialects.Postgres), dbURL)
 	require.NoError(t, err)
 	t.Cleanup(func() { assert.NoError(t, db.Close()) })
 

--- a/core/services/blockhashstore/coordinators.go
+++ b/core/services/blockhashstore/coordinators.go
@@ -68,15 +68,19 @@ type V1Coordinator struct {
 	lp logpoller.LogPoller
 }
 
-// NewV1Coordinator creates a new V1Coordinator from the given contract.
-func NewV1Coordinator(c v1.VRFCoordinatorInterface, lp logpoller.LogPoller) (*V1Coordinator, error) {
-	err := lp.RegisterFilter(logpoller.Filter{
-		Name: logpoller.FilterName("VRFv1CoordinatorFeeder", c.Address()),
+func NewV1LogFilter(addr common.Address) logpoller.Filter {
+	return logpoller.Filter{
+		Name: logpoller.FilterName("VRFv1CoordinatorFeeder", addr),
 		EventSigs: []common.Hash{
 			v1.VRFCoordinatorRandomnessRequest{}.Topic(),
 			v1.VRFCoordinatorRandomnessRequestFulfilled{}.Topic(),
-		}, Addresses: []common.Address{c.Address()},
-	})
+		}, Addresses: []common.Address{addr},
+	}
+}
+
+// NewV1Coordinator creates a new V1Coordinator from the given contract.
+func NewV1Coordinator(c v1.VRFCoordinatorInterface, lp logpoller.LogPoller) (*V1Coordinator, error) {
+	err := lp.RegisterFilter(NewV1LogFilter(c.Address()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -157,19 +161,19 @@ type V2Coordinator struct {
 	lp logpoller.LogPoller
 }
 
-// NewV2Coordinator creates a new V2Coordinator from the given contract.
-func NewV2Coordinator(c v2.VRFCoordinatorV2Interface, lp logpoller.LogPoller) (*V2Coordinator, error) {
-	err := lp.RegisterFilter(logpoller.Filter{
-		Name: logpoller.FilterName("VRFv2CoordinatorFeeder", c.Address()),
+func NewV2LogFilter(addr common.Address) logpoller.Filter {
+	return logpoller.Filter{
+		Name: logpoller.FilterName("VRFv2CoordinatorFeeder", addr),
 		EventSigs: []common.Hash{
 			v2.VRFCoordinatorV2RandomWordsRequested{}.Topic(),
 			v2.VRFCoordinatorV2RandomWordsFulfilled{}.Topic(),
-		}, Addresses: []common.Address{c.Address()},
-	})
-
-	if err != nil {
-		return nil, err
+		}, Addresses: []common.Address{addr},
 	}
+}
+
+// NewV2Coordinator creates a new V2Coordinator from the given contract.
+func NewV2Coordinator(c v2.VRFCoordinatorV2Interface, lp logpoller.LogPoller) (*V2Coordinator, error) {
+	err := lp.RegisterFilter(NewV2LogFilter(c.Address()), nil)
 
 	return &V2Coordinator{c, lp}, err
 }

--- a/core/services/blockhashstore/coordinators.go
+++ b/core/services/blockhashstore/coordinators.go
@@ -79,12 +79,8 @@ func NewV1LogFilter(addr common.Address) logpoller.Filter {
 }
 
 // NewV1Coordinator creates a new V1Coordinator from the given contract.
-func NewV1Coordinator(c v1.VRFCoordinatorInterface, lp logpoller.LogPoller) (*V1Coordinator, error) {
-	err := lp.RegisterFilter(NewV1LogFilter(c.Address()), nil)
-	if err != nil {
-		return nil, err
-	}
-	return &V1Coordinator{c, lp}, nil
+func NewV1Coordinator(c v1.VRFCoordinatorInterface, lp logpoller.LogPoller) *V1Coordinator {
+	return &V1Coordinator{c, lp}
 }
 
 // Requests satisfies the Coordinator interface.
@@ -172,10 +168,8 @@ func NewV2LogFilter(addr common.Address) logpoller.Filter {
 }
 
 // NewV2Coordinator creates a new V2Coordinator from the given contract.
-func NewV2Coordinator(c v2.VRFCoordinatorV2Interface, lp logpoller.LogPoller) (*V2Coordinator, error) {
-	err := lp.RegisterFilter(NewV2LogFilter(c.Address()), nil)
-
-	return &V2Coordinator{c, lp}, err
+func NewV2Coordinator(c v2.VRFCoordinatorV2Interface, lp logpoller.LogPoller) *V2Coordinator {
+	return &V2Coordinator{c, lp}
 }
 
 // Requests satisfies the Coordinator interface.

--- a/core/services/blockhashstore/delegate.go
+++ b/core/services/blockhashstore/delegate.go
@@ -106,12 +106,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 			return nil, errors.Wrap(err, "building V1 coordinator")
 		}
 
-		var coord *V1Coordinator
-		coord, err = NewV1Coordinator(c, lp)
-		if err != nil {
-			return nil, errors.Wrap(err, "building V1 coordinator")
-		}
-		coordinators = append(coordinators, coord)
+		coordinators = append(coordinators, NewV1Coordinator(c, lp))
 	}
 	if jb.BlockhashStoreSpec.CoordinatorV2Address != nil {
 		var c *v2.VRFCoordinatorV2
@@ -121,12 +116,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 			return nil, errors.Wrap(err, "building V2 coordinator")
 		}
 
-		var coord *V2Coordinator
-		coord, err = NewV2Coordinator(c, lp)
-		if err != nil {
-			return nil, errors.Wrap(err, "building V2 coordinator")
-		}
-		coordinators = append(coordinators, coord)
+		coordinators = append(coordinators, NewV2Coordinator(c, lp))
 	}
 
 	bpBHS, err := NewBulletproofBHS(chain.Config(), chain.Config().Database(), fromAddresses, chain.TxManager(), bhs, chain.ID(), d.ks)
@@ -171,14 +161,14 @@ func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error {
 	lp := chain.LogPoller()
 	if jb.BlockhashStoreSpec.CoordinatorV1Address == nil {
 		filter := NewV1LogFilter(jb.BlockhashStoreSpec.CoordinatorV1Address.Address())
-		lp.RegisterFilter(filter, q)
+		err = lp.RegisterFilter(filter, q)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to register filter %v", filter)
 		}
 	}
 	if jb.BlockhashStoreSpec.CoordinatorV2Address == nil {
 		filter := NewV2LogFilter(jb.BlockhashStoreSpec.CoordinatorV2Address.Address())
-		lp.RegisterFilter(filter, q)
+		err = lp.RegisterFilter(filter, q)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to register filter %v", filter)
 		}

--- a/core/services/blockhashstore/delegate.go
+++ b/core/services/blockhashstore/delegate.go
@@ -159,14 +159,14 @@ func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error {
 	}
 
 	lp := chain.LogPoller()
-	if jb.BlockhashStoreSpec.CoordinatorV1Address == nil {
+	if jb.BlockhashStoreSpec.CoordinatorV1Address != nil {
 		filter := NewV1LogFilter(jb.BlockhashStoreSpec.CoordinatorV1Address.Address())
 		err = lp.RegisterFilter(filter, q)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to register filter %v", filter)
 		}
 	}
-	if jb.BlockhashStoreSpec.CoordinatorV2Address == nil {
+	if jb.BlockhashStoreSpec.CoordinatorV2Address != nil {
 		filter := NewV2LogFilter(jb.BlockhashStoreSpec.CoordinatorV2Address.Address())
 		err = lp.RegisterFilter(filter, q)
 		if err != nil {
@@ -192,14 +192,14 @@ func (d *Delegate) OnDeleteJob(jb job.Job, q pg.Queryer) error {
 	}
 
 	lp := chain.LogPoller()
-	if jb.BlockhashStoreSpec.CoordinatorV1Address == nil {
+	if jb.BlockhashStoreSpec.CoordinatorV1Address != nil {
 		filter := NewV1LogFilter(jb.BlockhashStoreSpec.CoordinatorV1Address.Address())
 		err = lp.UnregisterFilter(filter.Name, q)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to unregister filter %s", filter.Name)
 		}
 	}
-	if jb.BlockhashStoreSpec.CoordinatorV2Address == nil {
+	if jb.BlockhashStoreSpec.CoordinatorV2Address != nil {
 		filter := NewV2LogFilter(jb.BlockhashStoreSpec.CoordinatorV2Address.Address())
 		err = lp.UnregisterFilter(filter.Name, q)
 		if err != nil {

--- a/core/services/blockhashstore/delegate_test.go
+++ b/core/services/blockhashstore/delegate_test.go
@@ -56,7 +56,7 @@ func createTestDelegate(t *testing.T) (*blockhashstore.Delegate, *testData) {
 	kst := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 	sendingKey, _ := cltest.MustAddRandomKeyToKeystore(t, kst)
 	lp := &mocklp.LogPoller{}
-	lp.On("RegisterFilter", mock.Anything).Return(nil)
+	lp.On("RegisterFilter", mock.Anything, mock.Anything).Return(nil)
 	chainSet := evmtest.NewChainSet(
 		t,
 		evmtest.TestChainOpts{

--- a/core/services/blockhashstore/feeder_test.go
+++ b/core/services/blockhashstore/feeder_test.go
@@ -255,7 +255,7 @@ func TestFeederWithLogPollerVRFv1(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// Instantiate log poller & coordinator.
 			lp := &mocklp.LogPoller{}
-			lp.On("RegisterFilter", mock.Anything).Return(nil)
+			lp.On("RegisterFilter", mock.Anything, mock.Anything).Return(nil)
 			c, err := solidity_vrf_coordinator_interface.NewVRFCoordinator(coordinatorAddress, nil)
 			require.NoError(t, err)
 			coordinator := &V1Coordinator{

--- a/core/services/blockheaderfeeder/delegate.go
+++ b/core/services/blockheaderfeeder/delegate.go
@@ -194,14 +194,14 @@ func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error {
 	}
 
 	lp := chain.LogPoller()
-	if jb.BlockHeaderFeederSpec.CoordinatorV1Address == nil {
+	if jb.BlockHeaderFeederSpec.CoordinatorV1Address != nil {
 		filter := blockhashstore.NewV1LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV1Address.Address())
 		err = lp.RegisterFilter(filter, q)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to register filter %v", filter)
 		}
 	}
-	if jb.BlockHeaderFeederSpec.CoordinatorV2Address == nil {
+	if jb.BlockHeaderFeederSpec.CoordinatorV2Address != nil {
 		filter := blockhashstore.NewV2LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV2Address.Address())
 		err = lp.RegisterFilter(filter, q)
 		if err != nil {
@@ -225,14 +225,14 @@ func (d *Delegate) OnDeleteJob(jb job.Job, q pg.Queryer) error {
 	}
 
 	lp := chain.LogPoller()
-	if jb.BlockHeaderFeederSpec.CoordinatorV1Address == nil {
+	if jb.BlockHeaderFeederSpec.CoordinatorV1Address != nil {
 		filter := blockhashstore.NewV1LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV1Address.Address())
 		err = lp.UnregisterFilter(filter.Name, q)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to unregister filter %s", filter.Name)
 		}
 	}
-	if jb.BlockHeaderFeederSpec.CoordinatorV2Address == nil {
+	if jb.BlockHeaderFeederSpec.CoordinatorV2Address != nil {
 		filter := blockhashstore.NewV2LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV2Address.Address())
 		err = lp.UnregisterFilter(filter.Name, q)
 		if err != nil {

--- a/core/services/blockheaderfeeder/delegate.go
+++ b/core/services/blockheaderfeeder/delegate.go
@@ -46,8 +46,7 @@ func (d *Delegate) JobType() job.Type {
 	return job.BlockHeaderFeeder
 }
 
-// ServicesForSpec satisfies the job.Delegate interface.
-func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
+func (d *Delegate) getChainFromSpec(jb job.Job) (evm.Chain, error) {
 	if jb.BlockHeaderFeederSpec == nil {
 		return nil, errors.Errorf("Delegate expects a BlockHeaderFeederSpec to be present, got %+v", jb)
 	}
@@ -60,6 +59,16 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 
 	if !chain.Config().Feature().LogPoller() {
 		return nil, errors.New("log poller must be enabled to run blockheaderfeeder")
+	}
+
+	return chain, nil
+}
+
+// ServicesForSpec satisfies the job.Delegate interface.
+func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
+	chain, err := d.getChainFromSpec(jb)
+	if err != nil {
+		return nil, err
 	}
 
 	if jb.BlockHeaderFeederSpec.LookbackBlocks < int32(chain.Config().EvmFinalityDepth()) {
@@ -186,13 +195,61 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 // AfterJobCreated satisfies the job.Delegate interface.
 func (d *Delegate) AfterJobCreated(spec job.Job) {}
 
+func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error {
+	chain, err := d.getChainFromSpec(jb)
+	if err != nil {
+		d.logger.Error(err)
+		return nil
+	}
+
+	lp := chain.LogPoller()
+	if jb.BlockHeaderFeederSpec.CoordinatorV1Address == nil {
+		filter := blockhashstore.NewV1LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV1Address.Address())
+		lp.RegisterFilter(filter, q)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to register filter %v", filter)
+		}
+	}
+	if jb.BlockHeaderFeederSpec.CoordinatorV2Address == nil {
+		filter := blockhashstore.NewV2LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV2Address.Address())
+		lp.RegisterFilter(filter, q)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to register filter %v", filter)
+		}
+	}
+	return nil
+}
+
 func (d *Delegate) BeforeJobCreated(spec job.Job) {}
 
 // BeforeJobDeleted satisfies the job.Delegate interface.
 func (d *Delegate) BeforeJobDeleted(spec job.Job) {}
 
 // OnDeleteJob satisfies the job.Delegate interface.
-func (d *Delegate) OnDeleteJob(spec job.Job, q pg.Queryer) error { return nil }
+func (d *Delegate) OnDeleteJob(jb job.Job, q pg.Queryer) error {
+	chain, err := d.getChainFromSpec(jb)
+	if err != nil {
+		d.logger.Error(err)
+		return nil
+	}
+
+	lp := chain.LogPoller()
+	if jb.BlockHeaderFeederSpec.CoordinatorV1Address == nil {
+		filter := blockhashstore.NewV1LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV1Address.Address())
+		err = lp.UnregisterFilter(filter.Name, q)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to unregister filter %s", filter.Name)
+		}
+	}
+	if jb.BlockHeaderFeederSpec.CoordinatorV2Address == nil {
+		filter := blockhashstore.NewV2LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV2Address.Address())
+		err = lp.UnregisterFilter(filter.Name, q)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to unregister filter %s", filter.Name)
+		}
+	}
+	return nil
+}
 
 // service is a job.Service that runs the BHS feeder every pollPeriod.
 type service struct {

--- a/core/services/cron/delegate.go
+++ b/core/services/cron/delegate.go
@@ -29,6 +29,7 @@ func (d *Delegate) JobType() job.Type {
 
 func (d *Delegate) BeforeJobCreated(spec job.Job)                {}
 func (d *Delegate) AfterJobCreated(spec job.Job)                 {}
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error { return nil }
 func (d *Delegate) BeforeJobDeleted(spec job.Job)                {}
 func (d *Delegate) OnDeleteJob(spec job.Job, q pg.Queryer) error { return nil }
 

--- a/core/services/directrequest/delegate.go
+++ b/core/services/directrequest/delegate.go
@@ -63,6 +63,7 @@ func (d *Delegate) JobType() job.Type {
 }
 
 func (d *Delegate) BeforeJobCreated(spec job.Job)                {}
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error { return nil }
 func (d *Delegate) AfterJobCreated(spec job.Job)                 {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job)                {}
 func (d *Delegate) OnDeleteJob(spec job.Job, q pg.Queryer) error { return nil }

--- a/core/services/fluxmonitorv2/delegate.go
+++ b/core/services/fluxmonitorv2/delegate.go
@@ -54,6 +54,7 @@ func (d *Delegate) JobType() job.Type {
 }
 
 func (d *Delegate) BeforeJobCreated(spec job.Job)                {}
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error { return nil }
 func (d *Delegate) AfterJobCreated(spec job.Job)                 {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job)                {}
 func (d *Delegate) OnDeleteJob(spec job.Job, q pg.Queryer) error { return nil }

--- a/core/services/gateway/delegate.go
+++ b/core/services/gateway/delegate.go
@@ -31,6 +31,7 @@ func (d *Delegate) JobType() job.Type {
 	return job.Gateway
 }
 
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error { return nil }
 func (d *Delegate) BeforeJobCreated(spec job.Job)                {}
 func (d *Delegate) AfterJobCreated(spec job.Job)                 {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job)                {}

--- a/core/services/job/spawner.go
+++ b/core/services/job/spawner.go
@@ -322,7 +322,7 @@ func (js *spawner) DeleteJob(jobID int32, qopts ...pg.QOpt) error {
 	err := q.Transaction(func(tx pg.Queryer) error {
 		err2 := js.orm.DeleteJob(jobID, pg.WithQueryer(tx))
 		if err2 != nil {
-			js.lggr.Errorw("Error deleting job", "jobID", jobID, "error", err)
+			js.lggr.Errorw("Error deleting job", "jobID", jobID, "error", err2)
 			return err2
 		}
 		// This comes after calling orm.DeleteJob(), so that any non-db side effects inside it only get executed if

--- a/core/services/keeper/delegate.go
+++ b/core/services/keeper/delegate.go
@@ -49,6 +49,7 @@ func (d *Delegate) JobType() job.Type {
 }
 
 func (d *Delegate) BeforeJobCreated(spec job.Job)                {}
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error { return nil }
 func (d *Delegate) AfterJobCreated(spec job.Job)                 {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job)                {}
 func (d *Delegate) OnDeleteJob(spec job.Job, q pg.Queryer) error { return nil }

--- a/core/services/ocr/delegate.go
+++ b/core/services/ocr/delegate.go
@@ -82,6 +82,7 @@ func (d *Delegate) JobType() job.Type {
 }
 
 func (d *Delegate) BeforeJobCreated(spec job.Job)                {}
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error { return nil }
 func (d *Delegate) AfterJobCreated(spec job.Job)                 {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job)                {}
 func (d *Delegate) OnDeleteJob(spec job.Job, q pg.Queryer) error { return nil }

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -231,8 +231,6 @@ func (d *Delegate) filtersFromSpec(spec *job.OCR2OracleSpec, extJobID uuid.UUID)
 		if err != nil {
 			d.lggr.Errorw("failed to derive ocr2keeper filter names from spec", "err", err, "spec", spec)
 		}
-	default:
-		return nil
 	}
 
 	rargs := types.RelayArgs{

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -249,7 +249,7 @@ func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error {
 		ContractID:  spec.ContractID,
 		RelayConfig: spec.RelayConfig.Bytes(),
 	}
-	r, ok := relayer.(relay.JobHooks)
+	r, ok := relayer.(evmrelay.JobHooks)
 	if !ok {
 		return nil
 	}
@@ -296,7 +296,7 @@ func (d *Delegate) OnDeleteJob(jb job.Job, q pg.Queryer) error {
 		ContractID:  spec.ContractID,
 		RelayConfig: spec.RelayConfig.Bytes(),
 	}
-	r, ok := relayer.(relay.JobHooks)
+	r, ok := relayer.(evmrelay.JobHooks)
 	if !ok {
 		return nil
 	}

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/log_provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/log_provider.go
@@ -17,7 +17,6 @@ import (
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	iregistry21 "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/i_keeper_registry_master_wrapper_2_1"
-	registry "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/keeper_registry_wrapper2_0"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
@@ -45,14 +44,14 @@ type LogProvider struct {
 
 func LogProviderFilter(addr common.Address) logpoller.Filter {
 	return logpoller.Filter{
-		Name:      logpoller.FilterName("OCR2KeeperRegistry - LogProvider", addr),
-		Addresses: []common.Address{addr},
+		Name: logpoller.FilterName("OCR2KeeperRegistry - LogProvider", addr),
 		EventSigs: []common.Hash{
-			registry.KeeperRegistryUpkeepPerformed{}.Topic(),
-			registry.KeeperRegistryReorgedUpkeepReport{}.Topic(),
-			registry.KeeperRegistryInsufficientFundsUpkeepReport{}.Topic(),
-			registry.KeeperRegistryStaleUpkeepReport{}.Topic(),
+			iregistry21.IKeeperRegistryMasterUpkeepPerformed{}.Topic(),
+			iregistry21.IKeeperRegistryMasterReorgedUpkeepReport{}.Topic(),
+			iregistry21.IKeeperRegistryMasterInsufficientFundsUpkeepReport{}.Topic(),
+			iregistry21.IKeeperRegistryMasterStaleUpkeepReport{}.Topic(),
 		},
+		Addresses: []common.Address{addr},
 	}
 }
 

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/registry.go
@@ -129,10 +129,6 @@ func NewEVMRegistryService(addr common.Address, client evm.Chain, mc *models.Mer
 		enc: EVMAutomationEncoder21{},
 	}
 
-	if err := r.registerEvents(client.ID().Uint64(), addr); err != nil {
-		return nil, fmt.Errorf("logPoller error while registering automation events: %w", err)
-	}
-
 	return r, nil
 }
 
@@ -449,18 +445,12 @@ func (r *EvmRegistry) pollLogs() error {
 	return nil
 }
 
-func UpkeepFilterName(addr common.Address) string {
-	return logpoller.FilterName("EvmRegistry - Upkeep events for", addr.String())
-}
-
-func (r *EvmRegistry) registerEvents(chainID uint64, addr common.Address) error {
-	// Add log filters for the log poller so that it can poll and find the logs that
-	// we need
-	return r.poller.RegisterFilter(logpoller.Filter{
-		Name:      UpkeepFilterName(addr),
+func UpkeepFilter(addr common.Address) (filters logpoller.Filter) {
+	return logpoller.Filter{
+		Name:      logpoller.FilterName("EvmRegistry - Upkeep events for", addr.String()),
 		EventSigs: append(upkeepStateEvents, upkeepActiveEvents...),
 		Addresses: []common.Address{addr},
-	})
+	}
 }
 
 func (r *EvmRegistry) processUpkeepStateLog(l logpoller.Log) error {

--- a/core/services/ocr2/plugins/ocr2keeper/integration_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/integration_test.go
@@ -708,22 +708,22 @@ func TestFilterNamesFromSpec20(t *testing.T) {
 		ContractID: address.String(), // valid contract addr
 	}
 
-	names, err := ocr2keeper.FilterNamesFromSpec20(spec)
+	filters, err := ocr2keeper.FiltersFromSpec20(spec)
 	require.NoError(t, err)
 
-	assert.Len(t, names, 2)
-	assert.Equal(t, logpoller.FilterName("OCR2KeeperRegistry - LogProvider", address), names[0])
-	assert.Equal(t, logpoller.FilterName("EvmRegistry - Upkeep events for", address), names[1])
+	assert.Len(t, filters, 2)
+	assert.Equal(t, logpoller.FilterName("OCR2KeeperRegistry - LogProvider", address), filters[0].Name)
+	assert.Equal(t, logpoller.FilterName("EvmRegistry - Upkeep events for", address), filters[1].Name)
 
 	spec = &job.OCR2OracleSpec{
 		PluginType: job.OCR2Keeper,
 		ContractID: "0x5431", // invalid contract addr
 	}
-	_, err = ocr2keeper.FilterNamesFromSpec20(spec)
+	_, err = ocr2keeper.FiltersFromSpec20(spec)
 	require.ErrorContains(t, err, "not a valid EIP55 formatted address")
 }
 
-func TestFilterNamesFromSpec21(t *testing.T) {
+func TestFiltersFromSpec21(t *testing.T) {
 	b := make([]byte, 20)
 	_, err := rand.Read(b)
 	require.NoError(t, err)
@@ -734,17 +734,17 @@ func TestFilterNamesFromSpec21(t *testing.T) {
 		ContractID: address.String(), // valid contract addr
 	}
 
-	names, err := ocr2keeper.FilterNamesFromSpec21(spec)
+	filters, err := ocr2keeper.FiltersFromSpec21(spec)
 	require.NoError(t, err)
 
-	assert.Len(t, names, 2)
-	assert.Equal(t, logpoller.FilterName("OCR2KeeperRegistry - LogProvider", address), names[0])
-	assert.Equal(t, logpoller.FilterName("EvmRegistry - Upkeep events for", address), names[1])
+	assert.Len(t, filters, 2)
+	assert.Equal(t, logpoller.FilterName("OCR2KeeperRegistry - LogProvider", address), filters[0].Name)
+	assert.Equal(t, logpoller.FilterName("EvmRegistry - Upkeep events for", address), filters[1].Name)
 
 	spec = &job.OCR2OracleSpec{
 		PluginType: job.OCR2Keeper,
 		ContractID: "0x5431", // invalid contract addr
 	}
-	_, err = ocr2keeper.FilterNamesFromSpec21(spec)
+	_, err = ocr2keeper.FiltersFromSpec21(spec)
 	require.ErrorContains(t, err, "not a valid EIP55 formatted address")
 }

--- a/core/services/ocr2/plugins/ocr2keeper/integration_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/integration_test.go
@@ -697,7 +697,7 @@ func TestIntegration_KeeperPluginForwarderEnabled(t *testing.T) {
 
 func ptr[T any](v T) *T { return &v }
 
-func TestFilterNamesFromSpec20(t *testing.T) {
+func TestFiltersFromSpec20(t *testing.T) {
 	b := make([]byte, 20)
 	_, err := rand.Read(b)
 	require.NoError(t, err)

--- a/core/services/ocr2/plugins/ocr2keeper/util.go
+++ b/core/services/ocr2/plugins/ocr2keeper/util.go
@@ -144,10 +144,10 @@ func EVMDependencies21(spec job.Job, db *sqlx.DB, lggr logger.Logger, set evm.Ch
 	return keeperProvider, registry, encoder, logProvider, err
 }
 
-func FilterNamesFromSpec21(spec *job.OCR2OracleSpec) (names []string, err error) {
+func FiltersFromSpec21(spec *job.OCR2OracleSpec) (names []logpoller.Filter, err error) {
 	addr, err := ethkey.NewEIP55Address(spec.ContractID)
 	if err != nil {
 		return nil, err
 	}
-	return []string{kevm21.LogProviderFilterName(addr.Address()), kevm21.UpkeepFilterName(addr.Address())}, err
+	return []logpoller.Filter{kevm21.LogProviderFilter(addr.Address()), kevm21.UpkeepFilter(addr.Address())}, err
 }

--- a/core/services/ocr2/plugins/ocr2keeper/util.go
+++ b/core/services/ocr2/plugins/ocr2keeper/util.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-relay/pkg/types"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
@@ -97,12 +98,12 @@ func EVMDependencies20(spec job.Job, db *sqlx.DB, lggr logger.Logger, set evm.Ch
 	return keeperProvider, registry, encoder, logProvider, err
 }
 
-func FilterNamesFromSpec20(spec *job.OCR2OracleSpec) (names []string, err error) {
+func FiltersFromSpec20(spec *job.OCR2OracleSpec) (filters []logpoller.Filter, err error) {
 	addr, err := ethkey.NewEIP55Address(spec.ContractID)
 	if err != nil {
 		return nil, err
 	}
-	return []string{kevm20.LogProviderFilterName(addr.Address()), kevm20.UpkeepFilterName(addr.Address())}, err
+	return []logpoller.Filter{kevm20.LogProviderFilter(addr.Address()), kevm20.UpkeepFilter(addr.Address())}, err
 }
 
 func EVMDependencies21(spec job.Job, db *sqlx.DB, lggr logger.Logger, set evm.ChainSet, pr pipeline.Runner, mc *models.MercuryCredentials) (evmrelay.OCR2KeeperProvider, *kevm21.EvmRegistry, Encoder, *kevm21.LogProvider, error) {

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
@@ -1131,6 +1131,9 @@ func FiltersFromSpec(spec *job.OCR2OracleSpec) (filters []logpoller.Filter, err 
 	if err2 != nil {
 		err = errors.Join(err, err2)
 	}
+	if err != nil {
+		return nil, err
+	}
 	return []logpoller.Filter{createLogFilter(beacon.Address(), coord.Address(), dkg.Address())}, err
 }
 

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
@@ -1115,7 +1115,7 @@ func (c *coordinator) emitReportWillBeTransmittedMetrics(
 
 func FiltersFromSpec(spec *job.OCR2OracleSpec) (filters []logpoller.Filter, err error) {
 	var cfg ocr2vrfconfig.PluginConfig
-	var beacon ethkey.EIP55Address
+	var beacon, dkg ethkey.EIP55Address
 
 	if err = json.Unmarshal(spec.PluginConfig.Bytes(), &cfg); err != nil {
 		err = pkgerrors.Wrap(err, "failed to unmarshal ocr2vrf plugin config")
@@ -1127,11 +1127,11 @@ func FiltersFromSpec(spec *job.OCR2OracleSpec) (filters []logpoller.Filter, err 
 	if err2 != nil {
 		err = errors.Join(err, err2)
 	}
-	dkg, err2 := ethkey.NewEIP55Address(cfg.DKGContractAddress)
-	if err == nil {
+	dkg, err2 = ethkey.NewEIP55Address(cfg.DKGContractAddress)
+	if err2 != nil {
 		err = errors.Join(err, err2)
 	}
-	return []logpoller.Filter{createLogFilter(beacon.Address(), coord.Address(), dkg.Address())}, nil
+	return []logpoller.Filter{createLogFilter(beacon.Address(), coord.Address(), dkg.Address())}, err
 }
 
 func createLogFilter(beaconAddress common.Address, coordinatorAddress common.Address, dkgAddress common.Address) logpoller.Filter {

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"math/big"
 	"sort"
@@ -14,7 +15,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
-	"github.com/pkg/errors"
+	pkgerrors "github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/smartcontractkit/libocr/commontypes"
@@ -173,24 +174,7 @@ func New(
 ) (ocr2vrftypes.CoordinatorInterface, error) {
 	onchainRouter, err := newRouter(lggr, beaconAddress, coordinatorAddress, client)
 	if err != nil {
-		return nil, errors.Wrap(err, "onchain router creation")
-	}
-
-	t := newTopics()
-
-	// Add log filters for the log poller so that it can poll and find the logs that
-	// we need.
-	err = logPoller.RegisterFilter(logpoller.Filter{
-		Name: filterName(beaconAddress, coordinatorAddress, dkgAddress),
-		EventSigs: []common.Hash{
-			t.randomnessRequestedTopic,
-			t.randomnessFulfillmentRequestedTopic,
-			t.randomWordsFulfilledTopic,
-			t.configSetTopic,
-			t.outputsServedTopic,
-			t.newTransmissionTopic}, Addresses: []common.Address{beaconAddress, coordinatorAddress, dkgAddress}})
-	if err != nil {
-		return nil, err
+		return nil, pkgerrors.Wrap(err, "onchain router creation")
 	}
 
 	cacheEvictionWindowSeconds := int64(60)
@@ -203,7 +187,7 @@ func New(
 		beaconAddress:            beaconAddress,
 		dkgAddress:               dkgAddress,
 		lp:                       logPoller,
-		topics:                   t,
+		topics:                   newTopics(),
 		finalityDepth:            finalityDepth,
 		evmClient:                client,
 		lggr:                     lggr.Named("OCR2VRFCoordinator"),
@@ -263,7 +247,7 @@ func (c *coordinator) ReportIsOnchain(
 		1,
 		pg.WithParentCtx(ctx))
 	if err != nil {
-		return false, errors.Wrap(err, "log poller IndexedLogs")
+		return false, pkgerrors.Wrap(err, "log poller IndexedLogs")
 	}
 
 	// Filter for valid logs that match the current config digest.
@@ -328,7 +312,7 @@ func (c *coordinator) ReportBlocks(
 	// TODO: use head broadcaster instead?
 	currentHeight, err := c.CurrentChainHeight(ctx)
 	if err != nil {
-		err = errors.Wrap(err, "header by number")
+		err = pkgerrors.Wrap(err, "header by number")
 		return
 	}
 
@@ -350,7 +334,7 @@ func (c *coordinator) ReportBlocks(
 		c.coordinatorAddress,
 		pg.WithParentCtx(ctx))
 	if err != nil {
-		err = errors.Wrapf(err, "logs with topics. address: %s", c.coordinatorAddress)
+		err = pkgerrors.Wrapf(err, "logs with topics. address: %s", c.coordinatorAddress)
 		return
 	}
 
@@ -362,7 +346,7 @@ func (c *coordinator) ReportBlocks(
 		outputsServedLogs,
 		err := c.unmarshalLogs(logs)
 	if err != nil {
-		err = errors.Wrap(err, "unmarshal logs")
+		err = pkgerrors.Wrap(err, "unmarshal logs")
 		return
 	}
 
@@ -389,7 +373,7 @@ func (c *coordinator) ReportBlocks(
 		recentBlockHashesStartHeight,
 	)
 	if err != nil {
-		err = errors.Wrap(err, "get blockhashes in ReportBlocks")
+		err = pkgerrors.Wrap(err, "get blockhashes in ReportBlocks")
 		return
 	}
 
@@ -402,7 +386,7 @@ func (c *coordinator) ReportBlocks(
 	blocksRequested := make(map[block]struct{})
 	unfulfilled, err := c.filterEligibleRandomnessRequests(randomnessRequestedLogs, confirmationDelays, currentHeight, blockhashesMapping)
 	if err != nil {
-		err = errors.Wrap(err, "filter requests in ReportBlocks")
+		err = pkgerrors.Wrap(err, "filter requests in ReportBlocks")
 		return
 	}
 	for _, uf := range unfulfilled {
@@ -413,7 +397,7 @@ func (c *coordinator) ReportBlocks(
 
 	callbacksRequested, unfulfilled, err := c.filterEligibleCallbacks(randomnessFulfillmentRequestedLogs, confirmationDelays, currentHeight, blockhashesMapping)
 	if err != nil {
-		err = errors.Wrap(err, "filter callbacks in ReportBlocks")
+		err = pkgerrors.Wrap(err, "filter callbacks in ReportBlocks")
 		return
 	}
 	for _, uf := range unfulfilled {
@@ -512,7 +496,7 @@ func (c *coordinator) getBlockhashesMappingFromRequests(
 	// Get a mapping of block numbers to block hashes.
 	blockhashesMapping, err = c.getBlockhashesMapping(ctx, append(requestedBlockNumbers, uint64(currentHeight), recentBlockHashesStartHeight))
 	if err != nil {
-		err = errors.Wrap(err, "get blockhashes for ReportBlocks")
+		err = pkgerrors.Wrap(err, "get blockhashes for ReportBlocks")
 	}
 	return
 }
@@ -542,7 +526,7 @@ func (c *coordinator) getBlockhashesMapping(
 
 	heads, err := c.lp.GetBlocksRange(ctx, blockNumbers, pg.WithParentCtx(ctx))
 	if err != nil {
-		return nil, errors.Wrap(err, "logpoller.GetBlocks")
+		return nil, pkgerrors.Wrap(err, "logpoller.GetBlocks")
 	}
 
 	blockhashesMapping = make(map[uint64]common.Hash)
@@ -757,7 +741,7 @@ func (c *coordinator) unmarshalLogs(
 			unpacked, err2 := c.onchainRouter.ParseLog(rawLog)
 			if err2 != nil {
 				// should never happen
-				err = errors.Wrap(err2, "unmarshal RandomnessRequested log")
+				err = pkgerrors.Wrap(err2, "unmarshal RandomnessRequested log")
 				return
 			}
 			rr, ok := unpacked.(*vrf_wrapper.VRFCoordinatorRandomnessRequested)
@@ -771,7 +755,7 @@ func (c *coordinator) unmarshalLogs(
 			unpacked, err2 := c.onchainRouter.ParseLog(rawLog)
 			if err2 != nil {
 				// should never happen
-				err = errors.Wrap(err2, "unmarshal RandomnessFulfillmentRequested log")
+				err = pkgerrors.Wrap(err2, "unmarshal RandomnessFulfillmentRequested log")
 				return
 			}
 			rfr, ok := unpacked.(*vrf_wrapper.VRFCoordinatorRandomnessFulfillmentRequested)
@@ -785,7 +769,7 @@ func (c *coordinator) unmarshalLogs(
 			unpacked, err2 := c.onchainRouter.ParseLog(rawLog)
 			if err2 != nil {
 				// should never happen
-				err = errors.Wrap(err2, "unmarshal RandomWordsFulfilled log")
+				err = pkgerrors.Wrap(err2, "unmarshal RandomWordsFulfilled log")
 				return
 			}
 			rwf, ok := unpacked.(*vrf_wrapper.VRFCoordinatorRandomWordsFulfilled)
@@ -799,7 +783,7 @@ func (c *coordinator) unmarshalLogs(
 			unpacked, err2 := c.onchainRouter.ParseLog(rawLog)
 			if err2 != nil {
 				// should never happen
-				err = errors.Wrap(err2, "unmarshal OutputsServed log")
+				err = pkgerrors.Wrap(err2, "unmarshal OutputsServed log")
 				return
 			}
 			nt, ok := unpacked.(*vrf_coordinator.VRFCoordinatorOutputsServed)
@@ -835,10 +819,10 @@ func (c *coordinator) ReportWillBeTransmitted(ctx context.Context, report ocr2vr
 	// Check for a re-org, and return an error if one is present.
 	blockhashesMapping, err := c.getBlockhashesMapping(ctx, []uint64{report.RecentBlockHeight})
 	if err != nil {
-		return errors.Wrap(err, "getting blockhash mapping in ReportWillBeTransmitted")
+		return pkgerrors.Wrap(err, "getting blockhash mapping in ReportWillBeTransmitted")
 	}
 	if blockhashesMapping[report.RecentBlockHeight] != report.RecentBlockHash {
-		return errors.Errorf("blockhash of report does not match most recent blockhash in ReportWillBeTransmitted")
+		return pkgerrors.Errorf("blockhash of report does not match most recent blockhash in ReportWillBeTransmitted")
 	}
 
 	blocksRequested := []blockInReport{}
@@ -910,7 +894,7 @@ func (c *coordinator) DKGVRFCommittees(ctx context.Context) (dkgCommittee, vrfCo
 		pg.WithParentCtx(ctx),
 	)
 	if err != nil {
-		err = errors.Wrap(err, "latest vrf ConfigSet by sig with confs")
+		err = pkgerrors.Wrap(err, "latest vrf ConfigSet by sig with confs")
 		return
 	}
 
@@ -921,21 +905,21 @@ func (c *coordinator) DKGVRFCommittees(ctx context.Context) (dkgCommittee, vrfCo
 		pg.WithParentCtx(ctx),
 	)
 	if err != nil {
-		err = errors.Wrap(err, "latest dkg ConfigSet by sig with confs")
+		err = pkgerrors.Wrap(err, "latest dkg ConfigSet by sig with confs")
 		return
 	}
 
 	var vrfConfigSetLog vrf_beacon.VRFBeaconConfigSet
 	err = vrfBeaconABI.UnpackIntoInterface(&vrfConfigSetLog, configSetEvent, latestVRF.Data)
 	if err != nil {
-		err = errors.Wrap(err, "unpack vrf ConfigSet into interface")
+		err = pkgerrors.Wrap(err, "unpack vrf ConfigSet into interface")
 		return
 	}
 
 	var dkgConfigSetLog dkg_wrapper.DKGConfigSet
 	err = dkgABI.UnpackIntoInterface(&dkgConfigSetLog, configSetEvent, latestDKG.Data)
 	if err != nil {
-		err = errors.Wrap(err, "unpack dkg ConfigSet into interface")
+		err = pkgerrors.Wrap(err, "unpack dkg ConfigSet into interface")
 		return
 	}
 
@@ -961,7 +945,7 @@ func (c *coordinator) ProvingKeyHash(ctx context.Context) (common.Hash, error) {
 		Context: ctx,
 	})
 	if err != nil {
-		return [32]byte{}, errors.Wrap(err, "get proving block hash")
+		return [32]byte{}, pkgerrors.Wrap(err, "get proving block hash")
 	}
 
 	return h, nil
@@ -973,7 +957,7 @@ func (c *coordinator) BeaconPeriod(ctx context.Context) (uint16, error) {
 		Context: ctx,
 	})
 	if err != nil {
-		return 0, errors.Wrap(err, "get beacon period blocks")
+		return 0, pkgerrors.Wrap(err, "get beacon period blocks")
 	}
 
 	return uint16(beaconPeriodBlocks.Int64()), nil
@@ -985,7 +969,7 @@ func (c *coordinator) ConfirmationDelays(ctx context.Context) ([]uint32, error) 
 		Context: ctx,
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "could not get confirmation delays")
+		return nil, pkgerrors.Wrap(err, "could not get confirmation delays")
 	}
 	var result []uint32
 	for _, c := range confDelays {
@@ -998,7 +982,7 @@ func (c *coordinator) ConfirmationDelays(ctx context.Context) ([]uint32, error) 
 func (c *coordinator) KeyID(ctx context.Context) (dkg.KeyID, error) {
 	keyID, err := c.onchainRouter.SKeyID(&bind.CallOpts{Context: ctx})
 	if err != nil {
-		return dkg.KeyID{}, errors.Wrap(err, "could not get key ID")
+		return dkg.KeyID{}, pkgerrors.Wrap(err, "could not get key ID")
 	}
 	return keyID, nil
 }
@@ -1082,7 +1066,7 @@ func (c *coordinator) UpdateConfiguration(
 	// Unmarshal off-chain config.
 	err := proto.Unmarshal(b, c.coordinatorConfig)
 	if err != nil {
-		return errors.Wrap(err, "error setting offchain config on coordinator")
+		return pkgerrors.Wrap(err, "error setting offchain config on coordinator")
 	}
 
 	// Update local caches with new eviction window.
@@ -1129,26 +1113,41 @@ func (c *coordinator) emitReportWillBeTransmittedMetrics(
 	promCallbacksInReport.WithLabelValues(c.labelValues()...).Observe(float64(numCallbacks))
 }
 
-func filterName(beaconAddress, coordinatorAddress, dkgAddress common.Address) string {
-	return logpoller.FilterName("VRF Coordinator", beaconAddress, coordinatorAddress, dkgAddress)
-}
-
-func FilterNamesFromSpec(spec *job.OCR2OracleSpec) (names []string, err error) {
+func FiltersFromSpec(spec *job.OCR2OracleSpec) (filters []logpoller.Filter, err error) {
 	var cfg ocr2vrfconfig.PluginConfig
-	var beaconAddress, coordinatorAddress, dkgAddress ethkey.EIP55Address
+	var beacon ethkey.EIP55Address
 
 	if err = json.Unmarshal(spec.PluginConfig.Bytes(), &cfg); err != nil {
-		err = errors.Wrap(err, "failed to unmarshal ocr2vrf plugin config")
+		err = pkgerrors.Wrap(err, "failed to unmarshal ocr2vrf plugin config")
 		return nil, err
 	}
 
-	if beaconAddress, err = ethkey.NewEIP55Address(spec.ContractID); err == nil {
-		if coordinatorAddress, err = ethkey.NewEIP55Address(cfg.VRFCoordinatorAddress); err == nil {
-			if dkgAddress, err = ethkey.NewEIP55Address(cfg.DKGContractAddress); err == nil {
-				return []string{filterName(beaconAddress.Address(), coordinatorAddress.Address(), dkgAddress.Address())}, nil
-			}
-		}
+	beacon, err = ethkey.NewEIP55Address(spec.ContractID)
+	coord, err2 := ethkey.NewEIP55Address(cfg.VRFCoordinatorAddress)
+	if err2 != nil {
+		err = errors.Join(err, err2)
 	}
+	dkg, err2 := ethkey.NewEIP55Address(cfg.DKGContractAddress)
+	if err == nil {
+		err = errors.Join(err, err2)
+	}
+	return []logpoller.Filter{createLogFilter(beacon.Address(), coord.Address(), dkg.Address())}, nil
+}
 
-	return nil, err
+func createLogFilter(beaconAddress common.Address, coordinatorAddress common.Address, dkgAddress common.Address) logpoller.Filter {
+	t := newTopics()
+	return logpoller.Filter{
+		Name: filterName(beaconAddress, coordinatorAddress, dkgAddress),
+		EventSigs: []common.Hash{
+			t.randomnessRequestedTopic,
+			t.randomnessFulfillmentRequestedTopic,
+			t.randomWordsFulfilledTopic,
+			t.configSetTopic,
+			t.outputsServedTopic,
+			t.newTransmissionTopic},
+		Addresses: []common.Address{beaconAddress, coordinatorAddress, dkgAddress}}
+}
+
+func filterName(beaconAddress, coordinatorAddress, dkgAddress common.Address) string {
+	return logpoller.FilterName("VRF Coordinator", beaconAddress, coordinatorAddress, dkgAddress)
 }

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator_test.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator_test.go
@@ -1759,17 +1759,17 @@ func TestFilterNamesFromSpec(t *testing.T) {
 		},
 	}
 
-	names, err := FilterNamesFromSpec(spec)
+	filters, err := FiltersFromSpec(spec)
 	require.NoError(t, err)
 
-	assert.Len(t, names, 1)
-	assert.Equal(t, logpoller.FilterName("VRF Coordinator", beaconAddress, coordinatorAddress, dkgAddress), names[0])
+	assert.Len(t, filters, 1)
+	assert.Equal(t, logpoller.FilterName("VRF Coordinator", beaconAddress, coordinatorAddress, dkgAddress), filters[0].Name)
 
 	spec = &job.OCR2OracleSpec{
 		PluginType:   job.OCR2VRF,
 		ContractID:   beaconAddress.String(),
 		PluginConfig: nil, // missing coordinator & dkg addresses
 	}
-	_, err = FilterNamesFromSpec(spec)
+	_, err = FiltersFromSpec(spec)
 	require.ErrorContains(t, err, "is not a valid EIP55 formatted address")
 }

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator_test.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator_test.go
@@ -1745,7 +1745,7 @@ func getLogPoller(
 	return lp
 }
 
-func TestFilterNamesFromSpec(t *testing.T) {
+func TestFiltersFromSpec(t *testing.T) {
 	beaconAddress := newAddress(t)
 	coordinatorAddress := newAddress(t)
 	dkgAddress := newAddress(t)

--- a/core/services/ocrbootstrap/delegate.go
+++ b/core/services/ocrbootstrap/delegate.go
@@ -128,6 +128,11 @@ func (d *Delegate) ServicesForSpec(jobSpec job.Job) (services []job.ServiceCtx, 
 	return []job.ServiceCtx{configProvider, job.NewServiceAdapter(bootstrapper)}, nil
 }
 
+// OnCreateJob satisfies the job.Delegate interface.
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error {
+	return nil
+}
+
 // AfterJobCreated satisfies the job.Delegate interface.
 func (d *Delegate) AfterJobCreated(spec job.Job) {
 }

--- a/core/services/ocrbootstrap/delegate.go
+++ b/core/services/ocrbootstrap/delegate.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
+	evmrelay "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 )
 
 // Delegate creates Bootstrap jobs
@@ -146,7 +147,7 @@ func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error {
 		ContractID:  spec.ContractID,
 		RelayConfig: spec.RelayConfig.Bytes(),
 	}
-	r, ok := relayer.(relay.JobHooks)
+	r, ok := relayer.(evmrelay.JobHooks)
 	if !ok {
 		return nil
 	}
@@ -177,7 +178,7 @@ func (d *Delegate) OnDeleteJob(jb job.Job, q pg.Queryer) error {
 		ContractID:  spec.ContractID,
 		RelayConfig: spec.RelayConfig.Bytes(),
 	}
-	r, ok := relayer.(relay.JobHooks)
+	r, ok := relayer.(evmrelay.JobHooks)
 	if !ok {
 		return nil
 	}

--- a/core/services/ocrbootstrap/delegate.go
+++ b/core/services/ocrbootstrap/delegate.go
@@ -65,7 +65,7 @@ func (d *Delegate) BeforeJobCreated(spec job.Job) {
 func (d *Delegate) ServicesForSpec(jobSpec job.Job) (services []job.ServiceCtx, err error) {
 	spec := jobSpec.BootstrapSpec
 	if spec == nil {
-		return nil, errors.Errorf("Bootstrap.Delegate expects an *job.BootstrapSpec to be present, got %v", jobSpec)
+		return nil, ocrcommon.ErrUnexpectedJobType{Expected: job.Bootstrap, Actual: jobSpec.Type}
 	}
 	if d.peerWrapper == nil {
 		return nil, errors.New("cannot setup OCR2 job service, libp2p peer was missing")
@@ -133,12 +133,12 @@ func (d *Delegate) ServicesForSpec(jobSpec job.Job) (services []job.ServiceCtx, 
 func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error {
 	spec := jb.BootstrapSpec
 	if spec == nil {
-		return errors.Errorf("Bootstrap.Delegate expects an *job.BootstrapSpec to be present, got %v", spec)
+		return ocrcommon.ErrUnexpectedJobType{Expected: job.Bootstrap, Actual: jb.Type}
 	}
 
 	relayer, exists := d.relayers[spec.Relay]
 	if !exists {
-		return errors.Errorf("%s relay does not exist is it enabled?", spec.Relay)
+		return ocrcommon.ErrRelayNotFound{Relay: spec.Relay}
 	}
 
 	rargs := types.RelayArgs{
@@ -164,12 +164,12 @@ func (d *Delegate) BeforeJobDeleted(spec job.Job) {}
 func (d *Delegate) OnDeleteJob(jb job.Job, q pg.Queryer) error {
 	spec := jb.BootstrapSpec
 	if spec == nil {
-		return errors.Errorf("Bootstrap.Delegate expects an *job.BootstrapSpec to be present, got %v", spec)
+		return ocrcommon.ErrUnexpectedJobType{Expected: job.Bootstrap, Actual: jb.Type}
 	}
 
 	relayer, exists := d.relayers[spec.Relay]
 	if !exists {
-		d.lggr.Errorf("%s relay does not exist is it enabled?", spec.Relay)
+		d.lggr.Error(ocrcommon.ErrRelayNotFound{Relay: spec.Relay})
 		return nil
 	}
 	rargs := types.RelayArgs{

--- a/core/services/ocrcommon/errors.go
+++ b/core/services/ocrcommon/errors.go
@@ -1,0 +1,25 @@
+package ocrcommon
+
+import (
+	"fmt"
+
+	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
+)
+
+type ErrRelayNotFound struct {
+	Relay relay.Network
+}
+
+func (e ErrRelayNotFound) Error() string {
+	return fmt.Sprintf("%v relay does not exist is it enabled?", e.Relay)
+}
+
+type ErrUnexpectedJobType struct {
+	Expected job.Type
+	Actual   job.Type
+}
+
+func (e ErrUnexpectedJobType) Error() string {
+	return fmt.Sprintf("Delegate expected an %s to be present, got %s", e.Actual, e.Expected)
+}

--- a/core/services/relay/evm/config_poller.go
+++ b/core/services/relay/evm/config_poller.go
@@ -76,20 +76,24 @@ type configPoller struct {
 	addr               common.Address
 }
 
-func configPollerFilterName(addr common.Address) string {
-	return logpoller.FilterName("OCR2ConfigPoller", addr.String())
+func NewConfigPollerFilter(addr common.Address) logpoller.Filter {
+	return logpoller.Filter{
+		Name:      logpoller.FilterName("OCR2ConfigPoller", addr.String()),
+		EventSigs: []common.Hash{ConfigSet},
+		Addresses: []common.Address{addr},
+	}
 }
 
 // NewConfigPoller creates a new ConfigPoller
-func NewConfigPoller(lggr logger.Logger, destChainPoller logpoller.LogPoller, addr common.Address) (ConfigPoller, error) {
-	err := destChainPoller.RegisterFilter(logpoller.Filter{Name: configPollerFilterName(addr), EventSigs: []common.Hash{ConfigSet}, Addresses: []common.Address{addr}})
-	if err != nil {
-		return nil, err
+func NewConfigPoller(lggr logger.Logger, destChainPoller logpoller.LogPoller, addr common.Address) (cp *configPoller, err error) {
+	filter := NewConfigPollerFilter(addr)
+	if err = destChainPoller.RegisterFilter(filter, nil); err != nil {
+		return cp, err
 	}
 
-	cp := &configPoller{
+	cp = &configPoller{
 		lggr:               lggr,
-		filterName:         configPollerFilterName(addr),
+		filterName:         filter.Name,
 		destChainLogPoller: destChainPoller,
 		addr:               addr,
 	}

--- a/core/services/relay/evm/config_poller.go
+++ b/core/services/relay/evm/config_poller.go
@@ -71,7 +71,6 @@ func configFromLog(logData []byte) (ocrtypes.ContractConfig, error) {
 
 type configPoller struct {
 	lggr               logger.Logger
-	filterName         string
 	destChainLogPoller logpoller.LogPoller
 	addr               common.Address
 }
@@ -86,14 +85,8 @@ func NewConfigPollerFilter(addr common.Address) logpoller.Filter {
 
 // NewConfigPoller creates a new ConfigPoller
 func NewConfigPoller(lggr logger.Logger, destChainPoller logpoller.LogPoller, addr common.Address) (cp *configPoller, err error) {
-	filter := NewConfigPollerFilter(addr)
-	if err = destChainPoller.RegisterFilter(filter, nil); err != nil {
-		return cp, err
-	}
-
 	cp = &configPoller{
 		lggr:               lggr,
-		filterName:         filter.Name,
 		destChainLogPoller: destChainPoller,
 		addr:               addr,
 	}

--- a/core/services/relay/evm/config_poller_test.go
+++ b/core/services/relay/evm/config_poller_test.go
@@ -79,7 +79,7 @@ func TestConfigPoller(t *testing.T) {
 		ContractID:  ocrAddress.String(),
 		RelayConfig: rc,
 	}
-	filters, err2 := FiltersFromRelayArgs(rargs)
+	filters, err2 := filtersFromRelayArgs(rargs)
 	require.NoError(t, err2)
 
 	logPoller, err := NewConfigPoller(lggr, lp, ocrAddress)

--- a/core/services/relay/evm/contract_transmitter_test.go
+++ b/core/services/relay/evm/contract_transmitter_test.go
@@ -43,7 +43,6 @@ func TestContractTransmitter(t *testing.T) {
 			"0000000000000000000000000000000000000000000000000000000000000002") // epoch
 	c.On("CallContract", mock.Anything, mock.Anything, mock.Anything).Return(digestAndEpochDontScanLogs, nil).Once()
 	contractABI, _ := abi.JSON(strings.NewReader(ocr2aggregator.OCR2AggregatorABI))
-	lp.On("RegisterFilter", mock.Anything).Return(nil)
 	ot, err := NewOCRContractTransmitter(gethcommon.Address{}, c, contractABI, mockTransmitter{}, lp, lggr, func(b []byte) (*txmgr.EvmTxMeta, error) {
 		return &txmgr.EvmTxMeta{}, nil
 	})

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -140,7 +140,7 @@ func (r *Relayer) NewConfigProvider(args relaytypes.RelayArgs) (relaytypes.Confi
 	return configProvider, err
 }
 
-func (r *Relayer) RegisterLogFilters(args relaytypes.RelayArgs, q pg.Queryer) (err error) {
+func (r *Relayer) OnCreateJob(args relaytypes.RelayArgs, q pg.Queryer) (err error) {
 	var relayConfig types.RelayConfig
 	filters, err := filtersFromRelayArgs(args)
 	if err != nil {
@@ -164,7 +164,7 @@ func (r *Relayer) RegisterLogFilters(args relaytypes.RelayArgs, q pg.Queryer) (e
 	return nil
 }
 
-func (r *Relayer) UnregisterLogFilters(args relaytypes.RelayArgs, q pg.Queryer) (err error) {
+func (r *Relayer) OnDeleteJob(args relaytypes.RelayArgs, q pg.Queryer) (err error) {
 	var relayConfig types.RelayConfig
 	filters, err := filtersFromRelayArgs(args)
 	if err != nil {

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -23,6 +23,7 @@ import (
 
 	txmgrcommon "github.com/smartcontractkit/chainlink/v2/common/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	txm "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services"
@@ -137,7 +138,7 @@ func (r *Relayer) NewConfigProvider(args relaytypes.RelayArgs) (relaytypes.Confi
 	return configProvider, err
 }
 
-func FilterNamesFromRelayArgs(args relaytypes.RelayArgs) (filterNames []string, err error) {
+func FiltersFromRelayArgs(args relaytypes.RelayArgs) (filters []logpoller.Filter, err error) {
 	var addr ethkey.EIP55Address
 	if addr, err = ethkey.NewEIP55Address(args.ContractID); err != nil {
 		return nil, err
@@ -148,11 +149,16 @@ func FilterNamesFromRelayArgs(args relaytypes.RelayArgs) (filterNames []string, 
 	}
 
 	if relayConfig.FeedID != nil {
-		filterNames = []string{mercury.FilterName(addr.Address())}
+		filters = []logpoller.Filter{mercury.NewConfigPollerFilter(addr.Address())}
 	} else {
-		filterNames = []string{configPollerFilterName(addr.Address()), transmitterFilterName(addr.Address())}
+		var transmitterFilter logpoller.Filter
+		transmitterFilter, err = newTransmitterFilter(addr.Address())
+		if err != nil {
+			return filters, err
+		}
+		filters = []logpoller.Filter{transmitterFilter}
 	}
-	return filterNames, err
+	return filters, err
 }
 
 type ConfigPoller interface {

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -142,7 +142,7 @@ func (r *Relayer) NewConfigProvider(args relaytypes.RelayArgs) (relaytypes.Confi
 
 func (r *Relayer) RegisterLogFilters(args relaytypes.RelayArgs, q pg.Queryer) (err error) {
 	var relayConfig types.RelayConfig
-	filters, err := FiltersFromRelayArgs(args)
+	filters, err := filtersFromRelayArgs(args)
 	if err != nil {
 		return err
 	}
@@ -166,7 +166,7 @@ func (r *Relayer) RegisterLogFilters(args relaytypes.RelayArgs, q pg.Queryer) (e
 
 func (r *Relayer) UnregisterLogFilters(args relaytypes.RelayArgs, q pg.Queryer) (err error) {
 	var relayConfig types.RelayConfig
-	filters, err := FiltersFromRelayArgs(args)
+	filters, err := filtersFromRelayArgs(args)
 	if err != nil {
 		return err
 	}
@@ -188,7 +188,7 @@ func (r *Relayer) UnregisterLogFilters(args relaytypes.RelayArgs, q pg.Queryer) 
 	return nil
 }
 
-func FiltersFromRelayArgs(args relaytypes.RelayArgs) (filters []logpoller.Filter, err error) {
+func filtersFromRelayArgs(args relaytypes.RelayArgs) (filters []logpoller.Filter, err error) {
 	var addr ethkey.EIP55Address
 	if addr, err = ethkey.NewEIP55Address(args.ContractID); err != nil {
 		return nil, err

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -47,6 +47,11 @@ var _ relaytypes.Relayer = &Relayer{}
 type RelayerConfig interface {
 }
 
+type JobHooks interface {
+	OnCreateJob(arg relaytypes.RelayArgs, q pg.Queryer) (err error)
+	OnDeleteJob(arg relaytypes.RelayArgs, q pg.Queryer) (err error)
+}
+
 type Relayer struct {
 	db          *sqlx.DB
 	chainSet    evm.ChainSet

--- a/core/services/relay/evm/mercury/config_poller.go
+++ b/core/services/relay/evm/mercury/config_poller.go
@@ -92,13 +92,17 @@ type ConfigPoller struct {
 	feedId             common.Hash
 }
 
-func FilterName(addr common.Address) string {
-	return logpoller.FilterName("OCR2 Mercury ConfigPoller", addr.String())
+func NewConfigPollerFilter(addr common.Address) logpoller.Filter {
+	return logpoller.Filter{
+		Name:      logpoller.FilterName("OCR2 Mercury ConfigPoller", addr.String()),
+		EventSigs: []common.Hash{FeedScopedConfigSet},
+		Addresses: []common.Address{addr},
+	}
 }
 
 // NewConfigPoller creates a new Mercury ConfigPoller
 func NewConfigPoller(lggr logger.Logger, destChainPoller logpoller.LogPoller, addr common.Address, feedId common.Hash) (*ConfigPoller, error) {
-	err := destChainPoller.RegisterFilter(logpoller.Filter{Name: FilterName(addr), EventSigs: []common.Hash{FeedScopedConfigSet}, Addresses: []common.Address{addr}})
+	err := destChainPoller.RegisterFilter(NewConfigPollerFilter(addr), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/relay/relay.go
+++ b/core/services/relay/relay.go
@@ -30,11 +30,6 @@ var (
 	}
 )
 
-type LogPollerCapable interface {
-	RegisterLogFilters(args types.RelayArgs, q pg.Queryer) (err error)
-	UnregisterLogFilters(args types.RelayArgs, q pg.Queryer) (err error)
-}
-
 type JobHooks interface {
 	OnCreateJob(arg types.RelayArgs, q pg.Queryer) (err error)
 	OnDeleteJob(arg types.RelayArgs, q pg.Queryer) (err error)
@@ -102,27 +97,19 @@ func (r *relayerAdapter) HealthReport() map[string]error {
 	return hr
 }
 
-type ErrLogFiltersNotSupported struct {
-	relayName string
-}
-
-func (e ErrLogFiltersNotSupported) Error() string {
-	return fmt.Sprintf("Log filtering is not supported by relay %s", e.relayName)
-}
-
 func (r *relayerAdapter) OnCreateJob(rargs types.RelayArgs, q pg.Queryer) (err error) {
-	relay, ok := r.Relayer.(LogPollerCapable)
+	relay, ok := r.Relayer.(JobHooks)
 	if !ok {
 		return nil
 	}
-	return relay.RegisterLogFilters(rargs, q)
+	return relay.OnCreateJob(rargs, q)
 
 }
 
 func (r *relayerAdapter) OnDeleteJob(rargs types.RelayArgs, q pg.Queryer) (err error) {
-	relay, ok := r.Relayer.(LogPollerCapable)
+	relay, ok := r.Relayer.(JobHooks)
 	if !ok {
 		return nil
 	}
-	return relay.UnregisterLogFilters(rargs, q)
+	return relay.OnDeleteJob(rargs, q)
 }

--- a/core/services/relay/relay.go
+++ b/core/services/relay/relay.go
@@ -12,7 +12,6 @@ import (
 	"github.com/smartcontractkit/chainlink-relay/pkg/types"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services"
-	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 )
 
 type Network string
@@ -29,11 +28,6 @@ var (
 		StarkNet: {},
 	}
 )
-
-type JobHooks interface {
-	OnCreateJob(arg types.RelayArgs, q pg.Queryer) (err error)
-	OnDeleteJob(arg types.RelayArgs, q pg.Queryer) (err error)
-}
 
 // RelayerExt is a subset of [loop.Relayer] for adapting [types.Relayer], typically with a ChainSet. See [relayerAdapter].
 type RelayerExt interface {
@@ -52,7 +46,6 @@ var _ loop.Relayer = (*relayerAdapter)(nil)
 // relayerAdapter adapts a [types.Relayer] and [RelayerExt] to implement [loop.Relayer].
 type relayerAdapter struct {
 	types.Relayer
-	JobHooks
 	RelayerExt
 }
 
@@ -95,21 +88,4 @@ func (r *relayerAdapter) HealthReport() map[string]error {
 	maps.Copy(r.Relayer.HealthReport(), hr)
 	maps.Copy(r.RelayerExt.HealthReport(), hr)
 	return hr
-}
-
-func (r *relayerAdapter) OnCreateJob(rargs types.RelayArgs, q pg.Queryer) (err error) {
-	relay, ok := r.Relayer.(JobHooks)
-	if !ok {
-		return nil
-	}
-	return relay.OnCreateJob(rargs, q)
-
-}
-
-func (r *relayerAdapter) OnDeleteJob(rargs types.RelayArgs, q pg.Queryer) (err error) {
-	relay, ok := r.Relayer.(JobHooks)
-	if !ok {
-		return nil
-	}
-	return relay.OnDeleteJob(rargs, q)
 }

--- a/core/services/vrf/delegate.go
+++ b/core/services/vrf/delegate.go
@@ -77,6 +77,7 @@ func (d *Delegate) JobType() job.Type {
 }
 
 func (d *Delegate) BeforeJobCreated(spec job.Job)                {}
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error { return nil }
 func (d *Delegate) AfterJobCreated(spec job.Job)                 {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job)                {}
 func (d *Delegate) OnDeleteJob(spec job.Job, q pg.Queryer) error { return nil }

--- a/core/services/webhook/delegate.go
+++ b/core/services/webhook/delegate.go
@@ -57,6 +57,8 @@ func (d *Delegate) AfterJobCreated(jb job.Job) {
 	}
 }
 
+func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error { return nil }
+
 func (d *Delegate) BeforeJobDeleted(spec job.Job) {
 	err := d.externalInitiatorManager.DeleteJob(*spec.WebhookSpecID)
 	if err != nil {

--- a/core/web/evm_forwarders_controller.go
+++ b/core/web/evm_forwarders_controller.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/forwarders"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
@@ -49,14 +50,33 @@ type TrackEVMForwarderRequest struct {
 
 // Track adds a new EVM forwarder.
 func (cc *EVMForwardersController) Track(c *gin.Context) {
+	var fwd forwarders.Forwarder
 	request := &TrackEVMForwarderRequest{}
 
-	if err := c.ShouldBindJSON(&request); err != nil {
+	err := c.ShouldBindJSON(&request)
+	if err != nil {
 		jsonAPIError(c, http.StatusUnprocessableEntity, err)
 		return
 	}
-	orm := forwarders.NewORM(cc.App.GetSqlxDB(), cc.App.GetLogger(), cc.App.GetConfig().Database())
-	fwd, err := orm.CreateForwarder(request.Address, *request.EVMChainID)
+
+	db, lggr, cfg := cc.App.GetSqlxDB(), cc.App.GetLogger(), cc.App.GetConfig().Database()
+	orm := forwarders.NewORM(db, lggr, cfg)
+	q := pg.NewQ(db, lggr, cfg)
+	err = q.Transaction(func(tx pg.Queryer) error {
+		fwd, err = orm.CreateForwarder(request.Address, *request.EVMChainID, pg.WithQueryer(tx))
+		if err != nil {
+			return err
+		}
+		chain, err2 := cc.App.GetChains().EVM.Get(request.EVMChainID.ToInt())
+		if err2 != nil {
+			return err2
+		}
+
+		if chain.LogPoller() == logpoller.LogPollerDisabled {
+			return errors.New("Log poller must be enabled to add or use forwarders")
+		}
+		return chain.LogPoller().RegisterFilter(forwarders.NewLogFilter(fwd.Address), tx)
+	})
 
 	if err != nil {
 		jsonAPIError(c, http.StatusBadRequest, err)
@@ -91,7 +111,8 @@ func (cc *EVMForwardersController) Delete(c *gin.Context) {
 			// handle same as non-existent chain id
 			return nil
 		}
-		return chain.LogPoller().UnregisterFilter(forwarders.FilterName(addr), tx)
+		filter := forwarders.NewLogFilter(addr)
+		return chain.LogPoller().UnregisterFilter(filter.Name, tx)
 	}
 
 	orm := forwarders.NewORM(cc.App.GetSqlxDB(), cc.App.GetLogger(), cc.App.GetConfig().Database())


### PR DESCRIPTION
This is accomplished by adding the OnCreateJob(filter, tx) callback, analogous to OnDeleteJob(filterName, tx) for UnregisterFilter()

In the case of forwarder manager, the RegisterFilter() call has been moved into the Track() method of the evm forwarders controller

Also in this PR:

- Adds `OnCreateJob()` and `OnDeleteJob()` implementations for the ocrbootstrap job delegate.
- Fixes a bug in OCR2 delegate, which skipped looking for ConfigPoller filters in the case of ocr2vrf and ocr2keepers job subtypes.
- Fixes a bug in blockhashstore and blockheaderfeeder jobs which caused those filters to get skipped.
- Starts log poller earlier (before tx mgr instead of after)
- Fix forwarder checks that LogPoller is "ready" (shouldn't need log poller to be ready (ie, running) yet in order to register filters, just need it to be enabled.
- Fixes bug in atomic forwarder filter deletion (remove from db should happen before remove from memory, in case the first one fails).
- Fixes test of atomic forwarder deletion (which relies on tx rollback capability) by using heavyweight db
- Moves `core/chains/evm/forwarders/orm_test.go` out of `forwarder` package to `forwarder_test` in order to use heavyweight db required for rollback functionality
- Updates many tests to work with the new model of registering filters on `CreateJob` instead of in `ServicesForSpec`
- Adds `OnCreateJob()` and `OnDeleteJob()` methods to evm relay, along with a `JobHooks` interface to access them.  We'll probably want to enforce at some point that all relays implement some version of these, but for now it's just evm since none of the others use them.  This allows `FiltersFromRelayArgs()` to be unexported, since it no longer needs to be called from outside the relay.

Note:  the bug fixes in this affect both `UnregisterFilter()` and `RegisterFilter()` calls, but the former was less important--not calling `UnregisterFilter` in some cases could create a long term problem if many jobs are removed and re-created over time, whereas not calling `RegisterFilter` for any case results in the relevant feature simply not working.