### PR TITLE
Fixed changelog for release/2.1.0

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -13,18 +13,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## 2.1.0 - UNRELEASED
 
-### Added
-
 ### Changed
 
 - Database commands `chainlink db ...` validate TOML configuration and secrets before executing. This change of behavior will report errors
   if any Database-specific configuration is invalid.
 
-### Removed
-
 <!-- unreleasedstop -->
 
-## 2.0.0 - UNRELEASED
+## 2.0.0 - 2023-04-20
 
 ### Added
 


### PR DESCRIPTION
Removed the empty 'added' and 'removed' sections
Added release date to 2.0.0

(cherry picked from commit e8a4045590c325a957ccf9c74daf47f81f35420e)

Replaces https://github.com/smartcontractkit/chainlink/pull/9114 (privileged CI won't run on forks)