### PR TITLE
BCF-2221: explicit user cache in dockerfile

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -41,6 +41,9 @@ RUN if [ ${CHAINLINK_USER} != root ]; then \
   fi
 USER ${CHAINLINK_USER}
 WORKDIR /home/${CHAINLINK_USER}
+# explicit set the cache dir. needed so both root and non-root user has an explicit location
+ENV XDG_CACHE_HOME /home/${CHAINLINK_USER}/.cache
+RUN mkdir -p ${XDG_CACHE_HOME}
 
 EXPOSE 6688
 ENTRYPOINT ["chainlink"]

--- a/core/chainlink.goreleaser.Dockerfile
+++ b/core/chainlink.goreleaser.Dockerfile
@@ -23,6 +23,9 @@ RUN if [ ${CHAINLINK_USER} != root ]; then \
   fi
 USER ${CHAINLINK_USER}
 WORKDIR /home/${CHAINLINK_USER}
+# explicit set the cache dir. needed so both root and non-root user has an explicit location
+ENV XDG_CACHE_HOME /home/${CHAINLINK_USER}/.cache
+RUN mkdir -p ${XDG_CACHE_HOME}
 
 EXPOSE 6688
 ENTRYPOINT ["chainlink"]

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -47,6 +47,9 @@ RUN if [ ${CHAINLINK_USER} != root ]; then \
   fi
 USER ${CHAINLINK_USER}
 WORKDIR /home/${CHAINLINK_USER}
+# explicit set the cache dir. needed so both root and non-root user has an explicit location
+ENV XDG_CACHE_HOME /home/${CHAINLINK_USER}/.cache
+RUN mkdir -p ${XDG_CACHE_HOME}
 
 EXPOSE 6688
 ENTRYPOINT ["chainlink"]


### PR DESCRIPTION
manual tested by building and running the image

```
# env
HOSTNAME=055bc8ecff00
XDG_CACHE_HOME=/home/root/.cache
HOME=/root
CL_PASSWORD_KEYSTORE=this_is_a_password
CL_DEV=true
TERM=xterm
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
DEBIAN_FRONTEND=noninteractive
CL_DATABASE_URL=postgres://postgres:admin@host.docker.internal:5432/chainlink_dev_test?sslmode=disable
PWD=/home/root
# touch $XDG_CACHE_HOME/x
# ls /home/root/.cache
x
```