### PR TITLE
core/chains/evm/txmgr: close ethbroadcaster during test cleanup

### DIFF
--- a/core/chains/evm/txmgr/eth_broadcaster_test.go
+++ b/core/chains/evm/txmgr/eth_broadcaster_test.go
@@ -72,6 +72,7 @@ func NewTestEthBroadcaster(
 	// Mark instance as test
 	ethBroadcaster.DisableUnstartedEthTxAutoProcessing()
 	err = ethBroadcaster.Start(testutils.Context(t))
+	t.Cleanup(func() { assert.NoError(t, ethBroadcaster.Close()) })
 	return ethBroadcaster, err
 }
 


### PR DESCRIPTION
Race detector caught it logging after test was complete.
```
==================
WARNING: DATA RACE
Read at 0x00c00372fd83 by goroutine 18275:
  testing.(*common).logDepth()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:992 +0xc4
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:985 +0xa4
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1036 +0x6a
  testing.(*T).Logf()
      <autogenerated>:1 +0x75
  go.uber.org/zap/zaptest.testingWriter.Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.24.0/zaptest/logger.go:130 +0x12c
  go.uber.org/zap/zaptest.(*testingWriter).Write()
      <autogenerated>:1 +0x7e
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.24.0/zapcore/core.go:99 +0x199
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.24.0/zapcore/entry.go:255 +0x2ce
  go.uber.org/zap.(*SugaredLogger).log()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.24.0/sugar.go:295 +0x13a
  go.uber.org/zap.(*SugaredLogger).Debugw()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.24.0/sugar.go:204 +0xab
  github.com/smartcontractkit/chainlink/v2/core/logger.(*zapLogger).Debugw()
      <autogenerated>:1 +0x29
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr.(*EthBroadcaster[...]).monitorEthTxs()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txmgr/eth_broadcaster.go:325 +0x26e
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr.(*EthBroadcaster[...]).startInternal.func2()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txmgr/eth_broadcaster.go:213 +0x90

Previous write at 0x00c00372fd83 by goroutine 18252:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1563 +0x82d
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.20.3/x64/src/runtime/panic.go:476 +0x32
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1629 +0x47

Goroutine 18275 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr.(*EthBroadcaster[...]).startInternal()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txmgr/eth_broadcaster.go:213 +0x8be
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr.(*EthBroadcaster[...]).Start.func1()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txmgr/eth_broadcaster.go:180 +0x57
  github.com/smartcontractkit/chainlink/v2/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:897 +0x102
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr.(*EthBroadcaster[...]).Start()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txmgr/eth_broadcaster.go:179 +0x78
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr_test.NewTestEthBroadcaster()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txmgr/eth_broadcaster_test.go:74 +0x885
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr_test.TestEthBroadcaster_ProcessUnstartedEthTxs_KeystoreErrors()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txmgr/eth_broadcaster_test.go:1863 +0x8c4
  testing.tRunner()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1576 +0x216
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1629 +0x47

Goroutine 18252 (finished) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1629 +0x805
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:2036 +0x8d
  testing.tRunner()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1576 +0x216
  testing.runTests()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:2034 +0x87c
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.20.3/x64/src/testing/testing.go:1906 +0xb44
  main.main()
      _testmain.go:231 +0x2e9
==================
```