### PR TITLE
.github/workflows: fix Solana Smoke Tests name

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -457,7 +457,7 @@ jobs:
         with:
           basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
           hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
-          this-job-name: Solana Smoke Tests (${{ matrix.image.name }})
+          this-job-name: Solana Smoke Tests ${{ matrix.image.name }}
           test-results-file: '{"testType":"go","filePath":"/tmp/gotest.log"}'
         continue-on-error: true
       - name: Checkout the repo


### PR DESCRIPTION
The parens are already in the variable:
![image](https://user-images.githubusercontent.com/1194128/236569218-dde9a2c0-c168-4e36-a542-7ef69777634e.png)
