### PR TITLE
bumping dorny/paths-filter & pnpm/action-setup

### DIFF
--- a/.github/actions/setup-nodejs/action.yaml
+++ b/.github/actions/setup-nodejs/action.yaml
@@ -7,7 +7,7 @@ description: Setup pnpm for contracts
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@10693b3829bf86eb2572aef5f3571dcf5ca9287d #v2.2.2
+    - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd #v2.2.4
       with:
         version: ^7.0.0
 

--- a/.github/actions/split-tests/action.yaml
+++ b/.github/actions/split-tests/action.yaml
@@ -11,7 +11,7 @@ outputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@10693b3829bf86eb2572aef5f3571dcf5ca9287d #v2.2.2
+    - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd #v2.2.4
       with:
         version: ^7.0.0
 

--- a/.github/workflows/bash-cicd-scripts.yml
+++ b/.github/workflows/bash-cicd-scripts.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # v2.10.2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: bash-cicd-scripts
         with:
           filters: |

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -27,7 +27,7 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # v2.10.2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: golangci-changes
         with:
           filters: |

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # v2.10.2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changes
         with:
           filters: |

--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # v2.10.2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changes
         with:
           filters: |

--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
-      - uses: dorny/paths-filter@b2feaf19c27470162a626bd6fa8438ae5b263721 # v2.10.2
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
         id: changes
         with:
           filters: |


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/RE-1435

This reduces the `CI Core` deprecation warnings count from 113 to 36.