### PR TITLE
replace deprecated set-output usages

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -25,9 +25,9 @@ runs:
       - name: Set go cache keys
         shell: bash
         id: go-cache-dir
-        run: |
-          echo "::set-output name=gomodcache::$(go env GOMODCACHE)" 
-          echo "::set-output name=gobuildcache::$(go env GOCACHE)" 
+        run: | 
+          echo "gomodcache=$(go env GOMODCACHE)" >> $GITHUB_OUTPUT 
+          echo "gobuildcache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
         name: Cache Go Modules

--- a/operator_ui/check.sh
+++ b/operator_ui/check.sh
@@ -26,12 +26,12 @@ else
   echo "$latest_tag" >"$tag_file"
   echo "Tag updated $current_tag -> $latest_tag"
   if [ "$CI" ]; then
-    echo "::set-output name=current_tag::$current_tag"
-    echo "::set-output name=latest_tag::$latest_tag"
+    echo "current_tag=$current_tag" >> $GITHUB_OUTPUT
+    echo "latest_tag=$latest_tag" >> $GITHUB_OUTPUT
     # See https://github.com/peter-evans/create-pull-request/blob/main/docs/examples.md#setting-the-pull-request-body-from-a-file
     body="${body//'%'/'%25'}"
     body="${body//$'\n'/'%0A'}"
     body="${body//$'\r'/'%0D'}"
-    echo "::set-output name=body::$body"
+    echo "body=$body" >> $GITHUB_OUTPUT
   fi
 fi


### PR DESCRIPTION
We have five uses of the deprecated `set-output`.