### PR TITLE
Fix flakey TestLogPoller_Replay test

### DIFF
--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -408,7 +408,7 @@ func (lp *logPoller) run() {
 	logPollTick := time.After(0)
 	// stagger these somewhat, so they don't all run back-to-back
 	backupLogPollTick := time.After(100 * time.Millisecond)
-	blockPruneTick := time.After(500 * time.Millisecond)
+	blockPruneTick := time.After(3 * time.Second)
 	logPruneTick := time.After(5 * time.Second)
 	filtersLoaded := false
 

--- a/core/chains/evm/logpoller/log_poller_internal_test.go
+++ b/core/chains/evm/logpoller/log_poller_internal_test.go
@@ -349,18 +349,13 @@ func TestLogPoller_Replay(t *testing.T) {
 		lp.replayComplete <- nil
 	})
 
-	timeout := time.After(4 * time.Second)
-	select {
-	case <-utils.WaitGroupChan(&lp.wg):
-	case <-timeout:
-		require.Fail(t, "Log poller failed to shutdown gracefully")
-	}
+	lp.wg.Wait()
 
 	// Main lp.run() loop shouldn't get stuck if client aborts
 	t.Run("client abort doesnt hang run loop", func(t *testing.T) {
 		lp.backupPollerNextBlock = 0
 
-		timeout = time.After(2 * time.Second)
+		timeout := time.After(2 * time.Second)
 		lp.ctx, lp.cancel = context.WithCancel(tctx)
 		ctx, cancel := context.WithCancel(tctx)
 
@@ -395,12 +390,7 @@ func TestLogPoller_Replay(t *testing.T) {
 		<-done
 	})
 
-	timeout = time.After(4 * time.Second)
-	select {
-	case <-utils.WaitGroupChan(&lp.wg):
-	case <-timeout:
-		require.Fail(t, "Log poller failed to shutdown gracefully")
-	}
+	lp.wg.Wait()
 
 	// run() should abort if log poller shuts down while replay is in progress
 	t.Run("shutdown during replay", func(t *testing.T) {

--- a/core/chains/evm/logpoller/log_poller_internal_test.go
+++ b/core/chains/evm/logpoller/log_poller_internal_test.go
@@ -374,6 +374,8 @@ func TestLogPoller_Replay(t *testing.T) {
 			}()
 		})
 
+		ec.On("FilterLogs", mock.Anything, mock.Anything).Return([]types.Log{log1}, nil).Maybe() // in case task gets delayed by >= 100ms
+
 		lp.ctx, lp.cancel = context.WithCancel(tctx)
 		lp.wg.Add(1)
 		defer func() {
@@ -395,6 +397,9 @@ func TestLogPoller_Replay(t *testing.T) {
 		case <-utils.WaitGroupChan(&wg):
 		}
 	})
+
+	// remove Maybe expectation from prior subtest, as it will override all expected calls in future subtests
+	ec.On("FilterLogs", mock.Anything, mock.Anything).Return([]types.Log{log1}, nil).Maybe().Unset()
 
 	// run() should abort if log poller shuts down while replay is in progress
 	t.Run("shutdown during replay", func(t *testing.T) {

--- a/core/chains/evm/logpoller/log_poller_internal_test.go
+++ b/core/chains/evm/logpoller/log_poller_internal_test.go
@@ -399,7 +399,7 @@ func TestLogPoller_Replay(t *testing.T) {
 	})
 
 	// remove Maybe expectation from prior subtest, as it will override all expected calls in future subtests
-	ec.On("FilterLogs", mock.Anything, mock.Anything).Return([]types.Log{log1}, nil).Maybe().Unset()
+	ec.On("FilterLogs", mock.Anything, mock.Anything).Unset()
 
 	// run() should abort if log poller shuts down while replay is in progress
 	t.Run("shutdown during replay", func(t *testing.T) {

--- a/core/chains/evm/logpoller/log_poller_internal_test.go
+++ b/core/chains/evm/logpoller/log_poller_internal_test.go
@@ -367,9 +367,9 @@ func TestLogPoller_Replay(t *testing.T) {
 			}()
 		})
 		ec.On("FilterLogs", mock.Anything, mock.Anything).Once().Return([]types.Log{log1}, nil).Run(func(args mock.Arguments) {
+			cancel()
 			go func() {
 				defer wg.Done()
-				cancel()
 				lp.replayStart <- 4
 			}()
 		})

--- a/core/chains/evm/logpoller/log_poller_internal_test.go
+++ b/core/chains/evm/logpoller/log_poller_internal_test.go
@@ -319,7 +319,7 @@ func TestLogPoller_Replay(t *testing.T) {
 		case <-ctx.Done():
 			err = ctx.Err()
 		}
-		require.NoError(t, err, "Timed out waiting to receive replay request from lp.replayStart")
+		assert.NoError(t, err, "Timed out waiting to receive replay request from lp.replayStart")
 	}
 
 	// Replay() should return error code received from replayComplete
@@ -337,7 +337,7 @@ func TestLogPoller_Replay(t *testing.T) {
 
 	// Replay() should return ErrReplayInProgress if caller's context is cancelled after replay has begun
 	t.Run("late abort returns ErrReplayInProgress", func(t *testing.T) {
-		ctx, cancel := context.WithTimeout(testutils.Context(t), 2*time.Second)
+		ctx, cancel := context.WithTimeout(testutils.Context(t), time.Second) // Intentionally abort replay after 1s
 		done := make(chan struct{})
 		go func() {
 			defer close(done)
@@ -347,9 +347,8 @@ func TestLogPoller_Replay(t *testing.T) {
 		assert.ErrorIs(t, lp.Replay(ctx, 4), ErrReplayInProgress)
 		<-done
 		lp.replayComplete <- nil
+		lp.wg.Wait()
 	})
-
-	lp.wg.Wait()
 
 	// Main lp.run() loop shouldn't get stuck if client aborts
 	t.Run("client abort doesnt hang run loop", func(t *testing.T) {
@@ -359,8 +358,14 @@ func TestLogPoller_Replay(t *testing.T) {
 		lp.ctx, lp.cancel = context.WithCancel(tctx)
 		ctx, cancel := context.WithCancel(tctx)
 
+		defer func() {
+			lp.cancel()
+			lp.wg.Wait()
+		}()
+
 		var wg sync.WaitGroup
 		wg.Add(2)
+
 		ec.On("FilterLogs", mock.Anything, mock.Anything).Once().Return([]types.Log{log1}, nil).Run(func(args mock.Arguments) {
 			go func() {
 				defer wg.Done()
@@ -376,27 +381,23 @@ func TestLogPoller_Replay(t *testing.T) {
 		})
 
 		lp.wg.Add(1)
-		done := make(chan struct{})
 		go func() {
-			defer close(done)
 			lp.run()
 		}()
 		select {
 		case <-timeout:
 			assert.Fail(t, "lp.run() got stuck--failed to respond to second replay event within 2s")
 		case <-utils.WaitGroupChan(&wg):
-			lp.cancel()
 		}
-		<-done
 	})
-
-	lp.wg.Wait()
 
 	// run() should abort if log poller shuts down while replay is in progress
 	t.Run("shutdown during replay", func(t *testing.T) {
 		lp.backupPollerNextBlock = 0
+
 		var wg sync.WaitGroup
 		wg.Add(2)
+
 		ec.On("FilterLogs", mock.Anything, mock.Anything).Once().Return([]types.Log{log1}, nil).Run(func(args mock.Arguments) {
 			go func() {
 				defer wg.Done()
@@ -409,27 +410,49 @@ func TestLogPoller_Replay(t *testing.T) {
 		})
 		ec.On("FilterLogs", mock.Anything, mock.Anything).Return([]types.Log{log1}, nil).Maybe() // in case task gets delayed by >= 100ms
 
+		go func() {
+			select {
+			case <-lp.replayStart: // unblock replayStart<- goroutine if it's stuck
+			default:
+			}
+			wg.Wait()
+			lp.Close()
+			lp.wg.Wait()
+		}()
+
 		timeout := time.After(2 * time.Second)
 		require.NoError(t, lp.Start(tctx))
 		select {
 		case <-timeout:
-			require.Fail(t, "lp.run() failed to respond to shutdown event during replay within 2s")
+			assert.Fail(t, "lp.run() failed to respond to shutdown event during replay within 2s")
 		case <-utils.WaitGroupChan(&wg):
-			lp.wg.Wait()
 		}
 	})
 
-	// ReplayAsync should return success as soon as replayStart is received
+	// ReplayAsync should return as soon as replayStart is received
 	t.Run("ReplayAsync success", func(t *testing.T) {
 		lp.ctx, lp.cancel = context.WithTimeout(tctx, 2*time.Second)
-		go recvStartReplay(tctx, 1, true)
-		lp.ReplayAsync(1)
-		lp.replayComplete <- nil
+		defer func() {
+			lp.replayComplete <- nil
+			lp.cancel()
+			lp.wg.Wait()
+		}()
+
+		done := make(chan struct{})
+		go func() {
+			lp.ReplayAsync(1)
+			close(done)
+		}()
+		recvStartReplay(tctx, 1, true)
+		<-done
 	})
 
 	t.Run("ReplayAsync error", func(t *testing.T) {
 		lp.ctx, lp.cancel = context.WithTimeout(tctx, 2*time.Second)
-		defer lp.cancel()
+		defer func() {
+			lp.cancel()
+			lp.wg.Wait()
+		}()
 		anyErr := errors.New("async error")
 		observedLogs.TakeAll()
 
@@ -440,7 +463,7 @@ func TestLogPoller_Replay(t *testing.T) {
 		case lp.replayComplete <- anyErr:
 			time.Sleep(2 * time.Second)
 		case <-lp.ctx.Done():
-			require.Fail(t, "failed to receive replayComplete signal")
+			assert.Fail(t, "failed to receive replayComplete signal within 2s")
 		}
 		require.Equal(t, 1, observedLogs.Len())
 		assert.Equal(t, observedLogs.All()[0].Message, anyErr.Error())


### PR DESCRIPTION
The main problem was a missing lp.replayComplete<- , but I've also
increased some timeouts, and added an extra 4s failsafe timeout around
lp.Wait

The last timeout is to avoid the whole test from waiting the full 10
mins to fail, in the event that one or more goroutines inside logpoller
get stuck (eg. waiting on <-lp.replayComplete, as happened here) and
it never proceeds past lp.Wait to the next test.  This shouldn't be able
to happen now, but it should  make it easier to debug if anything similar
comes up.

There is also a rare race condition inside testify that can happen when
lp.ctx is passed as an argument to Mock.On().  This was added to keep
the call to `ec.On("FilterLogs").Maybe()` in one subtest from interfering with
calls to `ec.On("FiltewrLogs") in the next subtest.  I've replaced the lp.ctx args
with mock.Anything, and added a call to Maybe().Unset() to solve this in a
better way.