### PR TITLE
Remove `configCount` check from `Verifier` contract

### DIFF
--- a/contracts/src/v0.8/Verifier.sol
+++ b/contracts/src/v0.8/Verifier.sol
@@ -442,10 +442,7 @@ contract Verifier is IVerifier, ConfirmedOwner, TypeAndVersionInterface {
       });
     }
 
-    // We need to manually set the verifier in the proxy
-    // the first time.
-    if (feedVerifierState.configCount > 1)
-      IVerifierProxy(i_verifierProxyAddr).setVerifier(feedVerifierState.latestConfigDigest, configDigest);
+    IVerifierProxy(i_verifierProxyAddr).setVerifier(feedVerifierState.latestConfigDigest, configDigest);
 
     emit ConfigSet(
       feedId,

--- a/contracts/test/v0.8/foundry/verifier/BaseVerifierTest.t.sol
+++ b/contracts/test/v0.8/foundry/verifier/BaseVerifierTest.t.sol
@@ -226,6 +226,7 @@ contract BaseTestWithConfiguredVerifier is BaseTest {
     Signer[] memory signers = _getSigners(MAX_ORACLES);
 
     // Verifier 1, Feed 1, Config 1
+    s_verifierProxy.initializeVerifier(address(s_verifier));
     s_verifier.setConfig(
       FEED_ID,
       _getSignerAddresses(signers),
@@ -235,11 +236,6 @@ contract BaseTestWithConfiguredVerifier is BaseTest {
       VERIFIER_VERSION,
       bytes("")
     );
-    (, , bytes32 configDigest) = s_verifier.latestConfigDetails(FEED_ID);
-    s_verifierProxy.initializeVerifier(address(s_verifier));
-    changePrank(address(s_verifier));
-    s_verifierProxy.setVerifier(bytes32(""), configDigest);
-    changePrank(ADMIN);
   }
 }
 
@@ -298,11 +294,9 @@ contract BaseTestWithMultipleConfiguredDigests is BaseTestWithConfiguredVerifier
       bytes("")
     );
     (, , s_configDigestFour) = s_verifier.latestConfigDetails(FEED_ID_2);
-    changePrank(address(s_verifier));
-    s_verifierProxy.setVerifier(bytes32(""), s_configDigestFour);
-    changePrank(ADMIN);
 
     // Verifier 2, Feed 3, Config 1
+    s_verifierProxy.initializeVerifier(address(s_verifier_2));
     s_verifier_2.setConfig(
       FEED_ID_3,
       _getSignerAddresses(signers),
@@ -313,9 +307,5 @@ contract BaseTestWithMultipleConfiguredDigests is BaseTestWithConfiguredVerifier
       bytes("")
     );
     (, , s_configDigestFive) = s_verifier_2.latestConfigDetails(FEED_ID_3);
-    s_verifierProxy.initializeVerifier(address(s_verifier_2));
-    changePrank(address(s_verifier_2));
-    s_verifierProxy.setVerifier(bytes32(""), s_configDigestFive);
-    changePrank(ADMIN);
   }
 }

--- a/contracts/test/v0.8/foundry/verifier/VerifierProxyInitializeVerifierTest.t.sol
+++ b/contracts/test/v0.8/foundry/verifier/VerifierProxyInitializeVerifierTest.t.sol
@@ -12,16 +12,6 @@ contract VerifierProxyInitializeVerifierTest is BaseTest {
   function setUp() public override {
     BaseTest.setUp();
     Signer[] memory signers = _getSigners(MAX_ORACLES);
-    s_verifier.setConfig(
-      FEED_ID,
-      _getSignerAddresses(signers),
-      s_offchaintransmitters,
-      FAULT_TOLERANCE,
-      bytes(""),
-      VERIFIER_VERSION,
-      bytes("")
-    );
-    (, , latestDigest) = s_verifier.latestConfigDetails(FEED_ID);
   }
 
   function test_revertsIfNotOwner() public {

--- a/contracts/test/v0.8/foundry/verifier/VerifierSetConfigTest.t.sol
+++ b/contracts/test/v0.8/foundry/verifier/VerifierSetConfigTest.t.sol
@@ -6,6 +6,10 @@ import {Verifier} from "../../../../src/v0.8/Verifier.sol";
 import {VerifierProxy} from "../../../../src/v0.8/VerifierProxy.sol";
 
 contract VerifierSetConfigTest is BaseTest {
+  function setUp() public virtual override {
+    BaseTest.setUp();
+  }
+
   function test_revertsIfCalledByNonOwner() public {
     vm.expectRevert("Only callable by owner");
     Signer[] memory signers = _getSigners(MAX_ORACLES);
@@ -103,6 +107,8 @@ contract VerifierSetConfigTest is BaseTest {
 
   function test_correctlyUpdatesTheConfig() public {
     Signer[] memory signers = _getSigners(MAX_ORACLES);
+
+    s_verifierProxy.initializeVerifier(address(s_verifier));
     s_verifier.setConfig(
       FEED_ID,
       _getSignerAddresses(signers),

--- a/contracts/test/v0.8/foundry/verifier/gas/Gas_VerifierTest.t.sol
+++ b/contracts/test/v0.8/foundry/verifier/gas/Gas_VerifierTest.t.sol
@@ -12,6 +12,7 @@ contract Verifier_setConfig is BaseTest {
     BaseTest.setUp();
     Signer[] memory signers = _getSigners(MAX_ORACLES);
     s_signerAddrs = _getSignerAddresses(signers);
+    s_verifierProxy.initializeVerifier(address(s_verifier));
   }
 
   function testSetConfigSuccess_gas() public {


### PR DESCRIPTION
Remove `configCount` check from `Verifier` contract since this is no longer needed. Previously the `VerifierProxy` had to be called the first time a new feed (configCount = 1) is started, but this has been improved. The `Verifier` contract will now be initialized on the proxy with `VerifierProxy.initializeVerifier`, and it never needs to be handled again out-of-band.