### PR TITLE
LVP cache err check fix

### DIFF
--- a/core/services/pipeline/task.bridge.go
+++ b/core/services/pipeline/task.bridge.go
@@ -176,8 +176,8 @@ func (t *BridgeTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, inp
 		responseBytes, cacheErr = t.orm.GetCachedResponse(t.dotID, t.specId, cacheDuration)
 		if cacheErr != nil {
 			promBridgeCacheErrors.WithLabelValues(t.Name).Inc()
-			if !errors.Is(err, sql.ErrNoRows) {
-				lggr.Errorw("Bridge task: cache fallback failed",
+			if !errors.Is(cacheErr, sql.ErrNoRows) {
+				lggr.Warnw("Bridge task: cache fallback failed",
 					"err", cacheErr.Error(),
 					"url", url.String(),
 				)


### PR DESCRIPTION
- downgrade cache fallback fail to warn
- fix error where bridge failure error is incorrectly used in err check instead of cacheErr