### PR TITLE
Exit shell with non-zero if goreleaser command errors

### DIFF
--- a/tools/bin/goreleaser_wrapper
+++ b/tools/bin/goreleaser_wrapper
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 set -x
 # get machine / kernel name
 _get_platform() {


### PR DESCRIPTION
To avoid swallowing errors that should fail CI like: https://github.com/smartcontractkit/chainlink/actions/runs/4993006488/jobs/8941504684#step:4:617