### PR TITLE
Add support for vrf and ccip in link balance monitor

### DIFF
--- a/contracts/src/v0.8/dev/automation/upkeeps/LinkAvailableBalanceMonitor.sol
+++ b/contracts/src/v0.8/dev/automation/upkeeps/LinkAvailableBalanceMonitor.sol
@@ -19,8 +19,9 @@ interface ILinkAvailable {
 }
 
 /**
- * @title The ProxyBalanceMonitor contract.
+ * @title The LinkAvailableBalanceMonitor contract.
  * @notice A keeper-compatible contract that monitors proxy-gated aggregators and funds them with LINK
+ * based on balance returned from a custom function linkAvailableForPayment()
  * @dev with 30 addresses as the MAX_PERFORM, the measured max gas usage of performUpkeep is around 2M
  * therefore, we recommend an upkeep gas limit of 3M (this has a 33% margin of safety). Although, nothing
  * prevents us from using 5M gas and increasing MAX_PERFORM, 30 seems like a reasonable batch size that
@@ -35,7 +36,7 @@ interface ILinkAvailable {
      we could save a fair amount of gas and re-write this upkeep for use with Automation v2.0+,
      which has significantly different trust assumptions
  */
-contract ProxyBalanceMonitor is ConfirmedOwner, Pausable, KeeperCompatibleInterface {
+contract LinkAvailableBalanceMonitor is ConfirmedOwner, Pausable, KeeperCompatibleInterface {
   using EnumerableSet for EnumerableSet.AddressSet;
 
   event FundsWithdrawn(uint256 amountWithdrawn, address payee);

--- a/contracts/src/v0.8/dev/automation/upkeeps/ProxyBalanceMonitor.sol
+++ b/contracts/src/v0.8/dev/automation/upkeeps/ProxyBalanceMonitor.sol
@@ -120,7 +120,7 @@ contract ProxyBalanceMonitor is ConfirmedOwner, Pausable, KeeperCompatibleInterf
     uint256 numChecked = 0;
     uint256 numToCheck = MAX_CHECK;
     uint256 idx = uint256(blockhash(block.number - 1)) % numTargets; // start at random index, to distribute load
-    numToCheck = numTargets < MAX_CHECK ? numTargets : numTargets;
+    numToCheck = numTargets < MAX_CHECK ? numTargets : MAX_CHECK;
     uint256 numFound = 0;
     address[] memory proxiesToFund = new address[](MAX_PERFORM);
     for (; numChecked < numToCheck; (idx, numChecked) = ((idx + 1) % numTargets, numChecked + 1)) {

--- a/contracts/src/v0.8/dev/automation/upkeeps/ProxyBalanceMonitor.sol
+++ b/contracts/src/v0.8/dev/automation/upkeeps/ProxyBalanceMonitor.sol
@@ -12,7 +12,7 @@ interface IAggregatorProxy {
   function aggregator() external view returns (address);
 }
 
-interface IAggregator {
+interface ILinkAvailable {
   function linkAvailableForPayment() external view returns (int256 availableBalance);
 
   function transmitters() external view returns (address[] memory);
@@ -261,27 +261,27 @@ contract ProxyBalanceMonitor is ConfirmedOwner, Pausable, KeeperCompatibleInterf
    * @return address the address of the aggregator
    */
   function _needsFunding(address proxyAddress) private view returns (bool, address) {
-    IAggregator aggregator;
+    ILinkAvailable target;
     IAggregatorProxy proxy = IAggregatorProxy(proxyAddress);
     try proxy.aggregator() returns (address aggregatorAddress) {
-      aggregator = IAggregator(aggregatorAddress);
+      target = ILinkAvailable(aggregatorAddress);
     } catch {
       return (false, address(0));
     }
-    try aggregator.linkAvailableForPayment() returns (int256 balance) {
+    try target.linkAvailableForPayment() returns (int256 balance) {
       if (balance < 0 || uint256(balance) > s_minBalance) {
         return (false, address(0));
       }
     } catch {
       return (false, address(0));
     }
-    try aggregator.transmitters() returns (address[] memory transmitters) {
+    try target.transmitters() returns (address[] memory transmitters) {
       if (transmitters.length == 0) {
         return (false, address(0));
       }
     } catch {
       return (false, address(0));
     }
-    return (true, address(aggregator));
+    return (true, address(target));
   }
 }

--- a/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.7.3/contracts/utils/structs/EnumerableMap.sol
+++ b/contracts/src/v0.8/vendor/openzeppelin-solidity/v4.7.3/contracts/utils/structs/EnumerableMap.sol
@@ -1,0 +1,529 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts (last updated v4.7.0) (utils/structs/EnumerableMap.sol)
+
+pragma solidity ^0.8.0;
+
+import "./EnumerableSet.sol";
+
+/**
+ * @dev Library for managing an enumerable variant of Solidity's
+ * https://solidity.readthedocs.io/en/latest/types.html#mapping-types[`mapping`]
+ * type.
+ *
+ * Maps have the following properties:
+ *
+ * - Entries are added, removed, and checked for existence in constant time
+ * (O(1)).
+ * - Entries are enumerated in O(n). No guarantees are made on the ordering.
+ *
+ * ```
+ * contract Example {
+ *     // Add the library methods
+ *     using EnumerableMap for EnumerableMap.UintToAddressMap;
+ *
+ *     // Declare a set state variable
+ *     EnumerableMap.UintToAddressMap private myMap;
+ * }
+ * ```
+ *
+ * The following map types are supported:
+ *
+ * - `uint256 -> address` (`UintToAddressMap`) since v3.0.0
+ * - `address -> uint256` (`AddressToUintMap`) since v4.6.0
+ * - `bytes32 -> bytes32` (`Bytes32ToBytes32`) since v4.6.0
+ * - `uint256 -> uint256` (`UintToUintMap`) since v4.7.0
+ * - `bytes32 -> uint256` (`Bytes32ToUintMap`) since v4.7.0
+ *
+ * [WARNING]
+ * ====
+ *  Trying to delete such a structure from storage will likely result in data corruption, rendering the structure unusable.
+ *  See https://github.com/ethereum/solidity/pull/11843[ethereum/solidity#11843] for more info.
+ *
+ *  In order to clean an EnumerableMap, you can either remove all elements one by one or create a fresh instance using an array of EnumerableMap.
+ * ====
+ */
+library EnumerableMap {
+    using EnumerableSet for EnumerableSet.Bytes32Set;
+
+    // To implement this library for multiple types with as little code
+    // repetition as possible, we write it in terms of a generic Map type with
+    // bytes32 keys and values.
+    // The Map implementation uses private functions, and user-facing
+    // implementations (such as Uint256ToAddressMap) are just wrappers around
+    // the underlying Map.
+    // This means that we can only create new EnumerableMaps for types that fit
+    // in bytes32.
+
+    struct Bytes32ToBytes32Map {
+        // Storage of keys
+        EnumerableSet.Bytes32Set _keys;
+        mapping(bytes32 => bytes32) _values;
+    }
+
+    /**
+     * @dev Adds a key-value pair to a map, or updates the value for an existing
+     * key. O(1).
+     *
+     * Returns true if the key was added to the map, that is if it was not
+     * already present.
+     */
+    function set(
+        Bytes32ToBytes32Map storage map,
+        bytes32 key,
+        bytes32 value
+    ) internal returns (bool) {
+        map._values[key] = value;
+        return map._keys.add(key);
+    }
+
+    /**
+     * @dev Removes a key-value pair from a map. O(1).
+     *
+     * Returns true if the key was removed from the map, that is if it was present.
+     */
+    function remove(Bytes32ToBytes32Map storage map, bytes32 key) internal returns (bool) {
+        delete map._values[key];
+        return map._keys.remove(key);
+    }
+
+    /**
+     * @dev Returns true if the key is in the map. O(1).
+     */
+    function contains(Bytes32ToBytes32Map storage map, bytes32 key) internal view returns (bool) {
+        return map._keys.contains(key);
+    }
+
+    /**
+     * @dev Returns the number of key-value pairs in the map. O(1).
+     */
+    function length(Bytes32ToBytes32Map storage map) internal view returns (uint256) {
+        return map._keys.length();
+    }
+
+    /**
+     * @dev Returns the key-value pair stored at position `index` in the map. O(1).
+     *
+     * Note that there are no guarantees on the ordering of entries inside the
+     * array, and it may change when more entries are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function at(Bytes32ToBytes32Map storage map, uint256 index) internal view returns (bytes32, bytes32) {
+        bytes32 key = map._keys.at(index);
+        return (key, map._values[key]);
+    }
+
+    /**
+     * @dev Tries to returns the value associated with `key`.  O(1).
+     * Does not revert if `key` is not in the map.
+     */
+    function tryGet(Bytes32ToBytes32Map storage map, bytes32 key) internal view returns (bool, bytes32) {
+        bytes32 value = map._values[key];
+        if (value == bytes32(0)) {
+            return (contains(map, key), bytes32(0));
+        } else {
+            return (true, value);
+        }
+    }
+
+    /**
+     * @dev Returns the value associated with `key`.  O(1).
+     *
+     * Requirements:
+     *
+     * - `key` must be in the map.
+     */
+    function get(Bytes32ToBytes32Map storage map, bytes32 key) internal view returns (bytes32) {
+        bytes32 value = map._values[key];
+        require(value != 0 || contains(map, key), "EnumerableMap: nonexistent key");
+        return value;
+    }
+
+    /**
+     * @dev Same as {_get}, with a custom error message when `key` is not in the map.
+     *
+     * CAUTION: This function is deprecated because it requires allocating memory for the error
+     * message unnecessarily. For custom revert reasons use {_tryGet}.
+     */
+    function get(
+        Bytes32ToBytes32Map storage map,
+        bytes32 key,
+        string memory errorMessage
+    ) internal view returns (bytes32) {
+        bytes32 value = map._values[key];
+        require(value != 0 || contains(map, key), errorMessage);
+        return value;
+    }
+
+    // UintToUintMap
+
+    struct UintToUintMap {
+        Bytes32ToBytes32Map _inner;
+    }
+
+    /**
+     * @dev Adds a key-value pair to a map, or updates the value for an existing
+     * key. O(1).
+     *
+     * Returns true if the key was added to the map, that is if it was not
+     * already present.
+     */
+    function set(
+        UintToUintMap storage map,
+        uint256 key,
+        uint256 value
+    ) internal returns (bool) {
+        return set(map._inner, bytes32(key), bytes32(value));
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the key was removed from the map, that is if it was present.
+     */
+    function remove(UintToUintMap storage map, uint256 key) internal returns (bool) {
+        return remove(map._inner, bytes32(key));
+    }
+
+    /**
+     * @dev Returns true if the key is in the map. O(1).
+     */
+    function contains(UintToUintMap storage map, uint256 key) internal view returns (bool) {
+        return contains(map._inner, bytes32(key));
+    }
+
+    /**
+     * @dev Returns the number of elements in the map. O(1).
+     */
+    function length(UintToUintMap storage map) internal view returns (uint256) {
+        return length(map._inner);
+    }
+
+    /**
+     * @dev Returns the element stored at position `index` in the set. O(1).
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function at(UintToUintMap storage map, uint256 index) internal view returns (uint256, uint256) {
+        (bytes32 key, bytes32 value) = at(map._inner, index);
+        return (uint256(key), uint256(value));
+    }
+
+    /**
+     * @dev Tries to returns the value associated with `key`.  O(1).
+     * Does not revert if `key` is not in the map.
+     */
+    function tryGet(UintToUintMap storage map, uint256 key) internal view returns (bool, uint256) {
+        (bool success, bytes32 value) = tryGet(map._inner, bytes32(key));
+        return (success, uint256(value));
+    }
+
+    /**
+     * @dev Returns the value associated with `key`.  O(1).
+     *
+     * Requirements:
+     *
+     * - `key` must be in the map.
+     */
+    function get(UintToUintMap storage map, uint256 key) internal view returns (uint256) {
+        return uint256(get(map._inner, bytes32(key)));
+    }
+
+    /**
+     * @dev Same as {get}, with a custom error message when `key` is not in the map.
+     *
+     * CAUTION: This function is deprecated because it requires allocating memory for the error
+     * message unnecessarily. For custom revert reasons use {tryGet}.
+     */
+    function get(
+        UintToUintMap storage map,
+        uint256 key,
+        string memory errorMessage
+    ) internal view returns (uint256) {
+        return uint256(get(map._inner, bytes32(key), errorMessage));
+    }
+
+    // UintToAddressMap
+
+    struct UintToAddressMap {
+        Bytes32ToBytes32Map _inner;
+    }
+
+    /**
+     * @dev Adds a key-value pair to a map, or updates the value for an existing
+     * key. O(1).
+     *
+     * Returns true if the key was added to the map, that is if it was not
+     * already present.
+     */
+    function set(
+        UintToAddressMap storage map,
+        uint256 key,
+        address value
+    ) internal returns (bool) {
+        return set(map._inner, bytes32(key), bytes32(uint256(uint160(value))));
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the key was removed from the map, that is if it was present.
+     */
+    function remove(UintToAddressMap storage map, uint256 key) internal returns (bool) {
+        return remove(map._inner, bytes32(key));
+    }
+
+    /**
+     * @dev Returns true if the key is in the map. O(1).
+     */
+    function contains(UintToAddressMap storage map, uint256 key) internal view returns (bool) {
+        return contains(map._inner, bytes32(key));
+    }
+
+    /**
+     * @dev Returns the number of elements in the map. O(1).
+     */
+    function length(UintToAddressMap storage map) internal view returns (uint256) {
+        return length(map._inner);
+    }
+
+    /**
+     * @dev Returns the element stored at position `index` in the set. O(1).
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function at(UintToAddressMap storage map, uint256 index) internal view returns (uint256, address) {
+        (bytes32 key, bytes32 value) = at(map._inner, index);
+        return (uint256(key), address(uint160(uint256(value))));
+    }
+
+    /**
+     * @dev Tries to returns the value associated with `key`.  O(1).
+     * Does not revert if `key` is not in the map.
+     *
+     * _Available since v3.4._
+     */
+    function tryGet(UintToAddressMap storage map, uint256 key) internal view returns (bool, address) {
+        (bool success, bytes32 value) = tryGet(map._inner, bytes32(key));
+        return (success, address(uint160(uint256(value))));
+    }
+
+    /**
+     * @dev Returns the value associated with `key`.  O(1).
+     *
+     * Requirements:
+     *
+     * - `key` must be in the map.
+     */
+    function get(UintToAddressMap storage map, uint256 key) internal view returns (address) {
+        return address(uint160(uint256(get(map._inner, bytes32(key)))));
+    }
+
+    /**
+     * @dev Same as {get}, with a custom error message when `key` is not in the map.
+     *
+     * CAUTION: This function is deprecated because it requires allocating memory for the error
+     * message unnecessarily. For custom revert reasons use {tryGet}.
+     */
+    function get(
+        UintToAddressMap storage map,
+        uint256 key,
+        string memory errorMessage
+    ) internal view returns (address) {
+        return address(uint160(uint256(get(map._inner, bytes32(key), errorMessage))));
+    }
+
+    // AddressToUintMap
+
+    struct AddressToUintMap {
+        Bytes32ToBytes32Map _inner;
+    }
+
+    /**
+     * @dev Adds a key-value pair to a map, or updates the value for an existing
+     * key. O(1).
+     *
+     * Returns true if the key was added to the map, that is if it was not
+     * already present.
+     */
+    function set(
+        AddressToUintMap storage map,
+        address key,
+        uint256 value
+    ) internal returns (bool) {
+        return set(map._inner, bytes32(uint256(uint160(key))), bytes32(value));
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the key was removed from the map, that is if it was present.
+     */
+    function remove(AddressToUintMap storage map, address key) internal returns (bool) {
+        return remove(map._inner, bytes32(uint256(uint160(key))));
+    }
+
+    /**
+     * @dev Returns true if the key is in the map. O(1).
+     */
+    function contains(AddressToUintMap storage map, address key) internal view returns (bool) {
+        return contains(map._inner, bytes32(uint256(uint160(key))));
+    }
+
+    /**
+     * @dev Returns the number of elements in the map. O(1).
+     */
+    function length(AddressToUintMap storage map) internal view returns (uint256) {
+        return length(map._inner);
+    }
+
+    /**
+     * @dev Returns the element stored at position `index` in the set. O(1).
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function at(AddressToUintMap storage map, uint256 index) internal view returns (address, uint256) {
+        (bytes32 key, bytes32 value) = at(map._inner, index);
+        return (address(uint160(uint256(key))), uint256(value));
+    }
+
+    /**
+     * @dev Tries to returns the value associated with `key`.  O(1).
+     * Does not revert if `key` is not in the map.
+     */
+    function tryGet(AddressToUintMap storage map, address key) internal view returns (bool, uint256) {
+        (bool success, bytes32 value) = tryGet(map._inner, bytes32(uint256(uint160(key))));
+        return (success, uint256(value));
+    }
+
+    /**
+     * @dev Returns the value associated with `key`.  O(1).
+     *
+     * Requirements:
+     *
+     * - `key` must be in the map.
+     */
+    function get(AddressToUintMap storage map, address key) internal view returns (uint256) {
+        return uint256(get(map._inner, bytes32(uint256(uint160(key)))));
+    }
+
+    /**
+     * @dev Same as {get}, with a custom error message when `key` is not in the map.
+     *
+     * CAUTION: This function is deprecated because it requires allocating memory for the error
+     * message unnecessarily. For custom revert reasons use {tryGet}.
+     */
+    function get(
+        AddressToUintMap storage map,
+        address key,
+        string memory errorMessage
+    ) internal view returns (uint256) {
+        return uint256(get(map._inner, bytes32(uint256(uint160(key))), errorMessage));
+    }
+
+    // Bytes32ToUintMap
+
+    struct Bytes32ToUintMap {
+        Bytes32ToBytes32Map _inner;
+    }
+
+    /**
+     * @dev Adds a key-value pair to a map, or updates the value for an existing
+     * key. O(1).
+     *
+     * Returns true if the key was added to the map, that is if it was not
+     * already present.
+     */
+    function set(
+        Bytes32ToUintMap storage map,
+        bytes32 key,
+        uint256 value
+    ) internal returns (bool) {
+        return set(map._inner, key, bytes32(value));
+    }
+
+    /**
+     * @dev Removes a value from a set. O(1).
+     *
+     * Returns true if the key was removed from the map, that is if it was present.
+     */
+    function remove(Bytes32ToUintMap storage map, bytes32 key) internal returns (bool) {
+        return remove(map._inner, key);
+    }
+
+    /**
+     * @dev Returns true if the key is in the map. O(1).
+     */
+    function contains(Bytes32ToUintMap storage map, bytes32 key) internal view returns (bool) {
+        return contains(map._inner, key);
+    }
+
+    /**
+     * @dev Returns the number of elements in the map. O(1).
+     */
+    function length(Bytes32ToUintMap storage map) internal view returns (uint256) {
+        return length(map._inner);
+    }
+
+    /**
+     * @dev Returns the element stored at position `index` in the set. O(1).
+     * Note that there are no guarantees on the ordering of values inside the
+     * array, and it may change when more values are added or removed.
+     *
+     * Requirements:
+     *
+     * - `index` must be strictly less than {length}.
+     */
+    function at(Bytes32ToUintMap storage map, uint256 index) internal view returns (bytes32, uint256) {
+        (bytes32 key, bytes32 value) = at(map._inner, index);
+        return (key, uint256(value));
+    }
+
+    /**
+     * @dev Tries to returns the value associated with `key`.  O(1).
+     * Does not revert if `key` is not in the map.
+     */
+    function tryGet(Bytes32ToUintMap storage map, bytes32 key) internal view returns (bool, uint256) {
+        (bool success, bytes32 value) = tryGet(map._inner, key);
+        return (success, uint256(value));
+    }
+
+    /**
+     * @dev Returns the value associated with `key`.  O(1).
+     *
+     * Requirements:
+     *
+     * - `key` must be in the map.
+     */
+    function get(Bytes32ToUintMap storage map, bytes32 key) internal view returns (uint256) {
+        return uint256(get(map._inner, key));
+    }
+
+    /**
+     * @dev Same as {get}, with a custom error message when `key` is not in the map.
+     *
+     * CAUTION: This function is deprecated because it requires allocating memory for the error
+     * message unnecessarily. For custom revert reasons use {tryGet}.
+     */
+    function get(
+        Bytes32ToUintMap storage map,
+        bytes32 key,
+        string memory errorMessage
+    ) internal view returns (uint256) {
+        return uint256(get(map._inner, key, errorMessage));
+    }
+}

--- a/contracts/test/v0.8/automation/LinkAvailableBalanceMonitor.test.ts
+++ b/contracts/test/v0.8/automation/LinkAvailableBalanceMonitor.test.ts
@@ -5,7 +5,7 @@ import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 import * as h from '../../test-helpers/helpers'
 import { IAggregatorProxy__factory as IAggregatorProxyFactory } from '../../../typechain/factories/IAggregatorProxy__factory'
 import { ILinkAvailable__factory as ILinkAvailableFactory } from '../../../typechain/factories/ILinkAvailable__factory'
-import { ProxyBalanceMonitor, LinkToken } from '../../../typechain'
+import { LinkAvailableBalanceMonitor, LinkToken } from '../../../typechain'
 import { BigNumber } from 'ethers'
 import { mineBlock } from '../../test-helpers/helpers'
 import deepEqualInAnyOrder from 'deep-equal-in-any-order'
@@ -40,7 +40,7 @@ const oneHundredLINK = ethers.utils.parseEther('100')
 
 const randAddr = () => ethers.Wallet.createRandom().address
 
-let pm: ProxyBalanceMonitor
+let labm: LinkAvailableBalanceMonitor
 let lt: LinkToken
 let owner: SignerWithAddress
 let stranger: SignerWithAddress
@@ -104,68 +104,68 @@ const setup = async () => {
   await aggregator2.mock.transmitters.returns([randAddr()])
   await aggregator3.mock.transmitters.returns([randAddr()])
 
-  const pmFactory = await ethers.getContractFactory(
-    'ProxyBalanceMonitor',
+  const labmFactory = await ethers.getContractFactory(
+    'LinkAvailableBalanceMonitor',
     owner,
   )
   const ltFactory = await ethers.getContractFactory('LinkToken', owner)
 
   lt = await ltFactory.deploy()
-  pm = await pmFactory.deploy(lt.address, oneLINK, twoLINK)
-  await pm.deployed()
+  labm = await labmFactory.deploy(lt.address, oneLINK, twoLINK)
+  await labm.deployed()
 
   for (let i = 1; i <= 4; i++) {
     const recipient = await accounts[i].getAddress()
     await lt.connect(owner).transfer(recipient, oneHundredLINK)
   }
 
-  const setTx = await pm.connect(owner).setWatchList(proxies)
+  const setTx = await labm.connect(owner).setWatchList(proxies)
   await setTx.wait()
 }
 
-describe('ProxyBalanceMonitor', () => {
+describe('LinkAvailableBalanceMonitor', () => {
   beforeEach(async () => {
     await loadFixture(setup)
   })
 
   describe('add funds', () => {
     it('Should allow anyone to add funds', async () => {
-      await lt.transfer(pm.address, oneLINK)
-      await lt.connect(stranger).transfer(pm.address, oneLINK)
+      await lt.transfer(labm.address, oneLINK)
+      await lt.connect(stranger).transfer(labm.address, oneLINK)
     })
   })
 
   describe('setTopUpAmount()', () => {
     it('configures the top-up amount', async () => {
-      await pm.connect(owner).setTopUpAmount(100)
-      assert.equal((await pm.getTopUpAmount()).toNumber(), 100)
+      await labm.connect(owner).setTopUpAmount(100)
+      assert.equal((await labm.getTopUpAmount()).toNumber(), 100)
     })
 
     it('configuresis only callable by the owner', async () => {
-      await expect(pm.connect(stranger).setTopUpAmount(100)).to.be.reverted
+      await expect(labm.connect(stranger).setTopUpAmount(100)).to.be.reverted
     })
   })
 
   describe('setMinBalance()', () => {
     it('configures the min balance', async () => {
-      await pm.connect(owner).setMinBalance(100)
-      assert.equal((await pm.getMinBalance()).toNumber(), 100)
+      await labm.connect(owner).setMinBalance(100)
+      assert.equal((await labm.getMinBalance()).toNumber(), 100)
     })
 
     it('is only callable by the owner', async () => {
-      await expect(pm.connect(stranger).setMinBalance(100)).to.be.reverted
+      await expect(labm.connect(stranger).setMinBalance(100)).to.be.reverted
     })
   })
 
   describe('withdraw()', () => {
     beforeEach(async () => {
-      const tx = await lt.connect(owner).transfer(pm.address, oneLINK)
+      const tx = await lt.connect(owner).transfer(labm.address, oneLINK)
       await tx.wait()
     })
 
     it('Should allow the owner to withdraw', async () => {
       const beforeBalance = await lt.balanceOf(owner.address)
-      const tx = await pm.connect(owner).withdraw(oneLINK, owner.address)
+      const tx = await labm.connect(owner).withdraw(oneLINK, owner.address)
       await tx.wait()
       const afterBalance = await lt.balanceOf(owner.address)
       assert.isTrue(
@@ -175,15 +175,15 @@ describe('ProxyBalanceMonitor', () => {
     })
 
     it('Should emit an event', async () => {
-      const tx = await pm.connect(owner).withdraw(oneLINK, owner.address)
+      const tx = await labm.connect(owner).withdraw(oneLINK, owner.address)
       await expect(tx)
-        .to.emit(pm, 'FundsWithdrawn')
+        .to.emit(labm, 'FundsWithdrawn')
         .withArgs(oneLINK, owner.address)
     })
 
     it('Should allow the owner to withdraw to anyone', async () => {
       const beforeBalance = await lt.balanceOf(stranger.address)
-      const tx = await pm.connect(owner).withdraw(oneLINK, stranger.address)
+      const tx = await labm.connect(owner).withdraw(oneLINK, stranger.address)
       await tx.wait()
       const afterBalance = await lt.balanceOf(stranger.address)
       assert.isTrue(
@@ -193,25 +193,25 @@ describe('ProxyBalanceMonitor', () => {
     })
 
     it('Should not allow strangers to withdraw', async () => {
-      const tx = pm.connect(stranger).withdraw(oneLINK, owner.address)
+      const tx = labm.connect(stranger).withdraw(oneLINK, owner.address)
       await expect(tx).to.be.revertedWith(OWNABLE_ERR)
     })
   })
 
   describe('pause() / unpause()', () => {
     it('Should allow owner to pause / unpause', async () => {
-      const pauseTx = await pm.connect(owner).pause()
+      const pauseTx = await labm.connect(owner).pause()
       await pauseTx.wait()
-      const unpauseTx = await pm.connect(owner).unpause()
+      const unpauseTx = await labm.connect(owner).unpause()
       await unpauseTx.wait()
     })
 
     it('Should not allow strangers to pause / unpause', async () => {
-      const pauseTxStranger = pm.connect(stranger).pause()
+      const pauseTxStranger = labm.connect(stranger).pause()
       await expect(pauseTxStranger).to.be.revertedWith(OWNABLE_ERR)
-      const pauseTxOwner = await pm.connect(owner).pause()
+      const pauseTxOwner = await labm.connect(owner).pause()
       await pauseTxOwner.wait()
-      const unpauseTxStranger = pm.connect(stranger).unpause()
+      const unpauseTxStranger = labm.connect(stranger).unpause()
       await expect(unpauseTxStranger).to.be.revertedWith(OWNABLE_ERR)
     })
   })
@@ -223,60 +223,60 @@ describe('ProxyBalanceMonitor', () => {
 
     beforeEach(async () => {
       // reset watchlist to empty before running these tests
-      await pm.connect(owner).setWatchList([])
-      let watchList = await pm.getWatchList()
+      await labm.connect(owner).setWatchList([])
+      let watchList = await labm.getWatchList()
       assert.deepEqual(watchList, [])
     })
 
     it('Should allow owner to set the watchlist', async () => {
       // add first watchlist
-      let tx = await pm.connect(owner).setWatchList([watchAddress1])
-      let watchList = await pm.getWatchList()
+      let tx = await labm.connect(owner).setWatchList([watchAddress1])
+      let watchList = await labm.getWatchList()
       assert.deepEqual(watchList, [watchAddress1])
       // add more to watchlist
-      tx = await pm
+      tx = await labm
         .connect(owner)
         .setWatchList([watchAddress1, watchAddress2, watchAddress3])
       await tx.wait()
-      watchList = await pm.getWatchList()
+      watchList = await labm.getWatchList()
       assert.deepEqual(watchList, [watchAddress1, watchAddress2, watchAddress3])
       // remove some from watchlist
-      tx = await pm.connect(owner).setWatchList([watchAddress3, watchAddress1])
+      tx = await labm.connect(owner).setWatchList([watchAddress3, watchAddress1])
       await tx.wait()
-      watchList = await pm.getWatchList()
+      watchList = await labm.getWatchList()
       assert.deepEqual(watchList, [watchAddress3, watchAddress1])
       // add some to watchlist
-      tx = await pm.connect(owner).addToWatchList([watchAddress2])
+      tx = await labm.connect(owner).addToWatchList([watchAddress2])
       await tx.wait()
-      watchList = await pm.getWatchList()
+      watchList = await labm.getWatchList()
       assert.deepEqual(watchList, [watchAddress3, watchAddress1, watchAddress2])
     })
 
     it('Should not allow duplicates in the watchlist', async () => {
       const errMsg = `DuplicateAddress("${watchAddress1}")`
-      let tx = pm
+      let tx = labm
         .connect(owner)
         .setWatchList([watchAddress1, watchAddress2, watchAddress1])
       await expect(tx).to.be.revertedWith(errMsg)
-      tx = pm
+      tx = labm
         .connect(owner)
         .addToWatchList([watchAddress1, watchAddress2, watchAddress1])
       await expect(tx).to.be.revertedWith(errMsg)
     })
 
     it('Should not allow strangers to set the watchlist', async () => {
-      const setTxStranger = pm.connect(stranger).setWatchList([watchAddress1])
+      const setTxStranger = labm.connect(stranger).setWatchList([watchAddress1])
       await expect(setTxStranger).to.be.revertedWith(OWNABLE_ERR)
-      const addTxStranger = pm.connect(stranger).addToWatchList([watchAddress1])
+      const addTxStranger = labm.connect(stranger).addToWatchList([watchAddress1])
       await expect(addTxStranger).to.be.revertedWith(OWNABLE_ERR)
     })
 
     it('Should revert if any of the addresses are empty', async () => {
-      let tx = pm
+      let tx = labm
         .connect(owner)
         .setWatchList([watchAddress1, ethers.constants.AddressZero])
       await expect(tx).to.be.revertedWith(INVALID_WATCHLIST_ERR)
-      tx = pm
+      tx = labm
         .connect(owner)
         .addToWatchList([watchAddress1, ethers.constants.AddressZero])
       await expect(tx).to.be.revertedWith(INVALID_WATCHLIST_ERR)
@@ -286,11 +286,11 @@ describe('ProxyBalanceMonitor', () => {
   describe('checkUpkeep() / sampleUnderfundedAddresses()', () => {
     it('Should return list of address that are underfunded', async () => {
       const fundTx = await lt.connect(owner).transfer(
-        pm.address,
+        labm.address,
         sixLINK, // needs 6 total
       )
       await fundTx.wait()
-      const [should, payload] = await pm.checkUpkeep('0x')
+      const [should, payload] = await labm.checkUpkeep('0x')
       assert.isTrue(should)
       let [addresses] = ethers.utils.defaultAbiCoder.decode(
         ['address[]'],
@@ -298,17 +298,17 @@ describe('ProxyBalanceMonitor', () => {
       )
       expect(addresses).to.deep.equalInAnyOrder(proxies)
       // checkUpkeep payload should match sampleUnderfundedAddresses()
-      addresses = await pm.sampleUnderfundedAddresses()
+      addresses = await labm.sampleUnderfundedAddresses()
       expect(addresses).to.deep.equalInAnyOrder(proxies)
     })
 
     it('Should return some results even if contract cannot fund all eligible targets', async () => {
       const fundTx = await lt.connect(owner).transfer(
-        pm.address,
+        labm.address,
         fiveLINK, // needs 6 total
       )
       await fundTx.wait()
-      const [should, payload] = await pm.checkUpkeep('0x')
+      const [should, payload] = await labm.checkUpkeep('0x')
       assert.isTrue(should)
       let [addresses] = ethers.utils.defaultAbiCoder.decode(
         ['address[]'],
@@ -319,31 +319,31 @@ describe('ProxyBalanceMonitor', () => {
       assert(proxies.includes(addresses[0]))
       assert(proxies.includes(addresses[1]))
       // underfunded sample should still match list
-      addresses = await pm.sampleUnderfundedAddresses()
+      addresses = await labm.sampleUnderfundedAddresses()
       expect(addresses).to.deep.equalInAnyOrder(proxies)
     })
 
     it('Should omit aggregators that have sufficient funding', async () => {
-      let addresses = await pm.sampleUnderfundedAddresses()
+      let addresses = await labm.sampleUnderfundedAddresses()
       expect(addresses).to.deep.equalInAnyOrder(proxies)
       await aggregator2.mock.linkAvailableForPayment.returns(tenLINK)
-      addresses = await pm.sampleUnderfundedAddresses()
+      addresses = await labm.sampleUnderfundedAddresses()
       expect(addresses).to.deep.equalInAnyOrder([
         proxy1.address,
         proxy3.address,
       ])
       await aggregator1.mock.linkAvailableForPayment.returns(tenLINK)
-      addresses = await pm.sampleUnderfundedAddresses()
+      addresses = await labm.sampleUnderfundedAddresses()
       expect(addresses).to.deep.equalInAnyOrder([proxy3.address])
       await aggregator3.mock.linkAvailableForPayment.returns(tenLINK)
-      addresses = await pm.sampleUnderfundedAddresses()
+      addresses = await labm.sampleUnderfundedAddresses()
       expect(addresses).to.deep.equalInAnyOrder([])
     })
 
     it('Should revert when paused', async () => {
-      const tx = await pm.connect(owner).pause()
+      const tx = await labm.connect(owner).pause()
       await tx.wait()
-      const ethCall = pm.checkUpkeep('0x')
+      const ethCall = labm.checkUpkeep('0x')
       await expect(ethCall).to.be.revertedWith(PAUSED_ERR)
     })
 
@@ -356,8 +356,8 @@ describe('ProxyBalanceMonitor', () => {
       let aggregators: MockContract[]
 
       beforeEach(async () => {
-        MAX_PERFORM = (await pm.MAX_PERFORM()).toNumber()
-        MAX_CHECK = (await pm.MAX_CHECK()).toNumber()
+        MAX_PERFORM = (await labm.MAX_PERFORM()).toNumber()
+        MAX_CHECK = (await labm.MAX_CHECK()).toNumber()
         proxyAddresses = []
         aggregators = []
         const numAggregators = MAX_CHECK + 50
@@ -376,19 +376,19 @@ describe('ProxyBalanceMonitor', () => {
           proxyAddresses.push(proxy.address)
           aggregators.push(aggregator)
         }
-        await pm.setWatchList(proxyAddresses)
-        expect(await pm.getWatchList()).to.deep.equalInAnyOrder(proxyAddresses)
+        await labm.setWatchList(proxyAddresses)
+        expect(await labm.getWatchList()).to.deep.equalInAnyOrder(proxyAddresses)
       })
 
       it('Should not include more than MAX_PERFORM addresses', async () => {
-        const addresses = await pm.sampleUnderfundedAddresses()
+        const addresses = await labm.sampleUnderfundedAddresses()
         assert.equal(addresses.length, MAX_PERFORM)
       })
 
       it('Should sample from the list of addresses pseudorandomly', async () => {
         const firstAddress: string[] = []
         for (let idx = 0; idx < 10; idx++) {
-          const addresses = await pm.sampleUnderfundedAddresses()
+          const addresses = await labm.sampleUnderfundedAddresses()
           assert.equal(addresses.length, MAX_PERFORM)
           assert.equal(
             new Set(addresses).size,
@@ -410,7 +410,7 @@ describe('ProxyBalanceMonitor', () => {
           // traverse the whole list
           await aggregator.mock.linkAvailableForPayment.returns(tenLINK)
         }
-        await pm.checkUpkeep('0x', { gasLimit: TARGET_CHECK_GAS_LIMIT })
+        await labm.checkUpkeep('0x', { gasLimit: TARGET_CHECK_GAS_LIMIT })
       })
     })
   })
@@ -423,19 +423,19 @@ describe('ProxyBalanceMonitor', () => {
         ['address[]'],
         [proxies],
       )
-      await pm.connect(owner).setWatchList(proxies)
+      await labm.connect(owner).setWatchList(proxies)
     })
 
     it('Should revert when paused', async () => {
-      await pm.connect(owner).pause()
-      const performTx = pm.connect(keeperRegistry).performUpkeep(validPayload)
+      await labm.connect(owner).pause()
+      const performTx = labm.connect(keeperRegistry).performUpkeep(validPayload)
       await expect(performTx).to.be.revertedWith(PAUSED_ERR)
     })
 
     it('Should fund the appropriate addresses', async () => {
-      await lt.connect(owner).transfer(pm.address, tenLINK)
+      await lt.connect(owner).transfer(labm.address, tenLINK)
       await assertAggregatorBalances(zeroLINK, zeroLINK, zeroLINK)
-      const performTx = await pm
+      const performTx = await labm
         .connect(keeperRegistry)
         .performUpkeep(validPayload, { gasLimit: 2_500_000 })
       await performTx.wait()
@@ -444,7 +444,7 @@ describe('ProxyBalanceMonitor', () => {
 
     it('Can handle MAX_PERFORM proxies within gas limit', async () => {
       // add MAX_PERFORM number of proxies
-      const MAX_PERFORM = (await pm.MAX_PERFORM()).toNumber()
+      const MAX_PERFORM = (await labm.MAX_PERFORM()).toNumber()
       const proxyAddresses = []
       for (let idx = 0; idx < MAX_PERFORM; idx++) {
         const proxy = await deployMockContract(
@@ -460,18 +460,18 @@ describe('ProxyBalanceMonitor', () => {
         await aggregator.mock.transmitters.returns([randAddr()])
         proxyAddresses.push(proxy.address)
       }
-      await pm.setWatchList(proxyAddresses)
-      expect(await pm.getWatchList()).to.deep.equalInAnyOrder(proxyAddresses)
+      await labm.setWatchList(proxyAddresses)
+      expect(await labm.getWatchList()).to.deep.equalInAnyOrder(proxyAddresses)
       // add funds
-      const fundsNeeded = (await pm.getTopUpAmount()).mul(MAX_PERFORM)
-      await lt.connect(owner).transfer(pm.address, fundsNeeded)
+      const fundsNeeded = (await labm.getTopUpAmount()).mul(MAX_PERFORM)
+      await lt.connect(owner).transfer(labm.address, fundsNeeded)
       // encode payload
       const payload = ethers.utils.defaultAbiCoder.encode(
         ['address[]'],
         [proxyAddresses],
       )
       // do the thing
-      await pm
+      await labm
         .connect(keeperRegistry)
         .performUpkeep(payload, { gasLimit: TARGET_PERFORM_GAS_LIMIT })
     })
@@ -483,18 +483,18 @@ describe('ProxyBalanceMonitor', () => {
         const users = [owner, keeperRegistry, stranger]
         for (let idx = 0; idx < users.length; idx++) {
           const user = users[idx]
-          await pm.connect(user).topUp([])
+          await labm.connect(user).topUp([])
         }
       })
     })
 
     context('when paused', () => {
       it('Should be callable by no one', async () => {
-        await pm.connect(owner).pause()
+        await labm.connect(owner).pause()
         const users = [owner, keeperRegistry, stranger]
         for (let idx = 0; idx < users.length; idx++) {
           const user = users[idx]
-          const tx = pm.connect(user).topUp([])
+          const tx = labm.connect(user).topUp([])
           await expect(tx).to.be.revertedWith(PAUSED_ERR)
         }
       })
@@ -502,88 +502,88 @@ describe('ProxyBalanceMonitor', () => {
 
     context('when fully funded', () => {
       beforeEach(async () => {
-        await lt.connect(owner).transfer(pm.address, tenLINK)
+        await lt.connect(owner).transfer(labm.address, tenLINK)
         await assertAggregatorBalances(zeroLINK, zeroLINK, zeroLINK)
       })
 
       it('Should fund the appropriate addresses', async () => {
-        const tx = await pm.connect(keeperRegistry).topUp(proxies)
+        const tx = await labm.connect(keeperRegistry).topUp(proxies)
         await assertAggregatorBalances(twoLINK, twoLINK, twoLINK)
-        await expect(tx).to.emit(pm, 'TopUpSucceeded').withArgs(proxy1.address)
-        await expect(tx).to.emit(pm, 'TopUpSucceeded').withArgs(proxy2.address)
-        await expect(tx).to.emit(pm, 'TopUpSucceeded').withArgs(proxy3.address)
+        await expect(tx).to.emit(labm, 'TopUpSucceeded').withArgs(proxy1.address)
+        await expect(tx).to.emit(labm, 'TopUpSucceeded').withArgs(proxy2.address)
+        await expect(tx).to.emit(labm, 'TopUpSucceeded').withArgs(proxy3.address)
       })
 
       it('Should only fund the addresses provided', async () => {
-        await pm.connect(keeperRegistry).topUp([proxy1.address, proxy3.address])
+        await labm.connect(keeperRegistry).topUp([proxy1.address, proxy3.address])
         await assertAggregatorBalances(twoLINK, zeroLINK, twoLINK)
       })
 
       it('Should skip un-approved addresses', async () => {
-        await pm.connect(owner).setWatchList([proxy1.address, proxy2.address])
-        const tx = await pm
+        await labm.connect(owner).setWatchList([proxy1.address, proxy2.address])
+        const tx = await labm
           .connect(keeperRegistry)
           .topUp([proxy1.address, proxy2.address, proxy3.address])
         await assertAggregatorBalances(twoLINK, twoLINK, zeroLINK)
-        await expect(tx).to.emit(pm, 'TopUpSucceeded').withArgs(proxy1.address)
-        await expect(tx).to.emit(pm, 'TopUpSucceeded').withArgs(proxy2.address)
-        await expect(tx).to.emit(pm, 'TopUpBlocked').withArgs(proxy3.address)
+        await expect(tx).to.emit(labm, 'TopUpSucceeded').withArgs(proxy1.address)
+        await expect(tx).to.emit(labm, 'TopUpSucceeded').withArgs(proxy2.address)
+        await expect(tx).to.emit(labm, 'TopUpBlocked').withArgs(proxy3.address)
       })
 
       it('Should skip an address if the proxy is invalid', async () => {
-        await pm.connect(owner).setWatchList([proxy1.address, proxy4.address])
-        const tx = await pm
+        await labm.connect(owner).setWatchList([proxy1.address, proxy4.address])
+        const tx = await labm
           .connect(keeperRegistry)
           .topUp([proxy1.address, proxy4.address])
-        await expect(tx).to.emit(pm, 'TopUpSucceeded').withArgs(proxy1.address)
-        await expect(tx).to.emit(pm, 'TopUpBlocked').withArgs(proxy4.address)
+        await expect(tx).to.emit(labm, 'TopUpSucceeded').withArgs(proxy1.address)
+        await expect(tx).to.emit(labm, 'TopUpBlocked').withArgs(proxy4.address)
       })
 
       it('Should skip an address if the aggregator is invalid', async () => {
         await proxy4.mock.aggregator.returns(aggregator4.address)
-        await pm.connect(owner).setWatchList([proxy1.address, proxy4.address])
-        const tx = await pm
+        await labm.connect(owner).setWatchList([proxy1.address, proxy4.address])
+        const tx = await labm
           .connect(keeperRegistry)
           .topUp([proxy1.address, proxy4.address])
-        await expect(tx).to.emit(pm, 'TopUpSucceeded').withArgs(proxy1.address)
-        await expect(tx).to.emit(pm, 'TopUpBlocked').withArgs(proxy4.address)
+        await expect(tx).to.emit(labm, 'TopUpSucceeded').withArgs(proxy1.address)
+        await expect(tx).to.emit(labm, 'TopUpBlocked').withArgs(proxy4.address)
       })
 
       it('Should skip an address if the aggregator has no transmitters', async () => {
         await proxy4.mock.aggregator.returns(aggregator4.address)
         await aggregator4.mock.linkAvailableForPayment.returns(0)
         await aggregator4.mock.transmitters.returns([])
-        await pm.connect(owner).setWatchList([proxy1.address, proxy4.address])
-        const tx = await pm
+        await labm.connect(owner).setWatchList([proxy1.address, proxy4.address])
+        const tx = await labm
           .connect(keeperRegistry)
           .topUp([proxy1.address, proxy4.address])
-        await expect(tx).to.emit(pm, 'TopUpSucceeded').withArgs(proxy1.address)
-        await expect(tx).to.emit(pm, 'TopUpBlocked').withArgs(proxy4.address)
+        await expect(tx).to.emit(labm, 'TopUpSucceeded').withArgs(proxy1.address)
+        await expect(tx).to.emit(labm, 'TopUpBlocked').withArgs(proxy4.address)
       })
 
       it('Should skip an address if the aggregator has sufficient funding', async () => {
         await proxy4.mock.aggregator.returns(aggregator4.address)
         await aggregator4.mock.linkAvailableForPayment.returns(tenLINK)
         await aggregator4.mock.transmitters.returns([randAddr()])
-        await pm.connect(owner).setWatchList([proxy1.address, proxy4.address])
-        const tx = await pm
+        await labm.connect(owner).setWatchList([proxy1.address, proxy4.address])
+        const tx = await labm
           .connect(keeperRegistry)
           .topUp([proxy1.address, proxy4.address])
-        await expect(tx).to.emit(pm, 'TopUpSucceeded').withArgs(proxy1.address)
-        await expect(tx).to.emit(pm, 'TopUpBlocked').withArgs(proxy4.address)
+        await expect(tx).to.emit(labm, 'TopUpSucceeded').withArgs(proxy1.address)
+        await expect(tx).to.emit(labm, 'TopUpBlocked').withArgs(proxy4.address)
       })
     })
 
     context('when partially funded', () => {
       it('Should fund as many addresses as possible', async () => {
         await lt.connect(owner).transfer(
-          pm.address,
+          labm.address,
           fiveLINK, // only enough LINK to fund 2 addresses
         )
-        const tx = await pm.connect(keeperRegistry).topUp(proxies)
+        const tx = await labm.connect(keeperRegistry).topUp(proxies)
         await assertAggregatorBalances(twoLINK, twoLINK, zeroLINK)
-        await expect(tx).to.emit(pm, 'TopUpSucceeded').withArgs(proxy1.address)
-        await expect(tx).to.emit(pm, 'TopUpSucceeded').withArgs(proxy2.address)
+        await expect(tx).to.emit(labm, 'TopUpSucceeded').withArgs(proxy1.address)
+        await expect(tx).to.emit(labm, 'TopUpSucceeded').withArgs(proxy2.address)
       })
     })
   })

--- a/contracts/test/v0.8/automation/ProxyBalanceMonitor.test.ts
+++ b/contracts/test/v0.8/automation/ProxyBalanceMonitor.test.ts
@@ -360,7 +360,7 @@ describe('ProxyBalanceMonitor', () => {
         MAX_CHECK = (await pm.MAX_CHECK()).toNumber()
         proxyAddresses = []
         aggregators = []
-        const numAggregators = MAX_CHECK + 5
+        const numAggregators = MAX_CHECK + 50
         for (let idx = 0; idx < numAggregators; idx++) {
           const proxy = await deployMockContract(
             owner,

--- a/contracts/test/v0.8/automation/ProxyBalanceMonitor.test.ts
+++ b/contracts/test/v0.8/automation/ProxyBalanceMonitor.test.ts
@@ -4,7 +4,7 @@ import type { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers'
 import { loadFixture } from '@nomicfoundation/hardhat-network-helpers'
 import * as h from '../../test-helpers/helpers'
 import { IAggregatorProxy__factory as IAggregatorProxyFactory } from '../../../typechain/factories/IAggregatorProxy__factory'
-import { IAggregator__factory as IAggregatorFactory } from '../../../typechain/factories/IAggregator__factory'
+import { ILinkAvailable__factory as ILinkAvailableFactory } from '../../../typechain/factories/ILinkAvailable__factory'
 import { ProxyBalanceMonitor, LinkToken } from '../../../typechain'
 import { BigNumber } from 'ethers'
 import { mineBlock } from '../../test-helpers/helpers'
@@ -76,10 +76,10 @@ const setup = async () => {
   proxy2 = await deployMockContract(owner, IAggregatorProxyFactory.abi)
   proxy3 = await deployMockContract(owner, IAggregatorProxyFactory.abi)
   proxy4 = await deployMockContract(owner, IAggregatorProxyFactory.abi)
-  aggregator1 = await deployMockContract(owner, IAggregatorFactory.abi)
-  aggregator2 = await deployMockContract(owner, IAggregatorFactory.abi)
-  aggregator3 = await deployMockContract(owner, IAggregatorFactory.abi)
-  aggregator4 = await deployMockContract(owner, IAggregatorFactory.abi)
+  aggregator1 = await deployMockContract(owner, ILinkAvailableFactory.abi)
+  aggregator2 = await deployMockContract(owner, ILinkAvailableFactory.abi)
+  aggregator3 = await deployMockContract(owner, ILinkAvailableFactory.abi)
+  aggregator4 = await deployMockContract(owner, ILinkAvailableFactory.abi)
 
   await proxy1.deployed()
   await proxy2.deployed()
@@ -368,7 +368,7 @@ describe('ProxyBalanceMonitor', () => {
           )
           const aggregator = await deployMockContract(
             owner,
-            IAggregatorFactory.abi,
+            ILinkAvailableFactory.abi,
           )
           await proxy.mock.aggregator.returns(aggregator.address)
           await aggregator.mock.linkAvailableForPayment.returns(0)
@@ -453,7 +453,7 @@ describe('ProxyBalanceMonitor', () => {
         )
         const aggregator = await deployMockContract(
           owner,
-          IAggregatorFactory.abi,
+          ILinkAvailableFactory.abi,
         )
         await proxy.mock.aggregator.returns(aggregator.address)
         await aggregator.mock.linkAvailableForPayment.returns(0)


### PR DESCRIPTION
Changes are neatly tied in separate commits

1. Rename IAggregator to ILinkAvailable to prevent conflict with https://github.com/smartcontractkit/chainlink/blob/develop/contracts/src/v0.8/dev/vendor/entrypoint/interfaces/IAggregator.sol#L9 which was causing an issue in tests. 

2. Fix Max_check bug and corresponding test

3. Rename contract to LinkAvailableBalanceMonitor to make it more generic and not tied to proxy (as that is not needed for vrf, ccip)

4. Add support for proxy and non-proxy targets. Remove requirement for transmitters check. This makes the contract generic to support vrf and ccip
 
5. Change EnumerableSet to EnumerableMap to store per address min balance