### PR TITLE
Add VRF foundry profile

### DIFF
--- a/contracts/foundry.toml
+++ b/contracts/foundry.toml
@@ -21,4 +21,10 @@ solc_version = '0.8.6'
 src = 'src/v0.8/functions'
 test = 'src/v0.8/functions/tests'
 
+[profile.vrf]
+optimizer_runs = 10000
+src = 'src/v0.8/vrf'
+test = 'src/v0.8/vrf' # skips tests for no VRF foundry tests
+solc_version = '0.8.6'
+
 # See more config options https://github.com/foundry-rs/foundry/tree/master/config


### PR DESCRIPTION
This profile removes dependencies on the rest of the contracts folder in order to run foundry commands on VRF files. For example:
- `export FOUNDRY_PROFILE=vrf`
- ```forge create --rpc-url [RPC_URL] \
    --constructor-args [CONSTRUCTOR_ARGS] \
    --private-key [PRIVATE_KEY] src/v0.8/vrf/VRFCoordinatorV2.sol:VRFCoordinatorV2 \
    --etherscan-api-key [API_KEY] \
    --verify

Will now run successfully and verify a VRF coordinator contract without altering any files in the monorepo.