### PR TITLE
add LOOPp HTTP endpoint wrappers to the integration test suite

### DIFF
--- a/integration-tests/client/chainlink.go
+++ b/integration-tests/client/chainlink.go
@@ -3,6 +3,7 @@ package client
 
 import (
 	"fmt"
+	"io"
 	"math/big"
 	"net/http"
 	"regexp"
@@ -17,6 +18,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-env/environment"
 	chainlinkChart "github.com/smartcontractkit/chainlink-env/pkg/helm/chainlink"
+
+	"github.com/prometheus/prometheus/discovery/targetgroup"
 )
 
 const (
@@ -1207,4 +1210,44 @@ func (c *Chainlink) GetForwarders() (*Forwarders, *http.Response, error) {
 		return nil, nil, err
 	}
 	return response, resp.RawResponse, err
+}
+
+// call the plugin discovery endpoint.
+// when LOOPPs are enabled, the targetGroup should be non-empty
+// otherwise it should be empty
+func (c *Chainlink) GetPluginDiscovery() (*targetgroup.Group, *http.Response, error) {
+	log.Info().Str(NodeURL, c.Config.URL).Msg("Getting plugin discovery endpoint")
+	response := &targetgroup.Group{}
+	resp, err := c.APIClient.R().
+		SetResult(response).
+		Get("/discovery")
+	if err != nil {
+		return nil, nil, err
+	}
+	err = VerifyStatusCode(resp.StatusCode(), http.StatusOK)
+	if err != nil {
+		return nil, nil, err
+	}
+	return response, resp.RawResponse, err
+}
+
+// returns the Prometheus metrics of a plugin as raw bytes.
+// prom metrics are content-type text/plain, so a byte slice is the best option.
+// returns an error when LOOPps are not running
+func (c *Chainlink) GetPluginMetrics(name string) ([]byte, error) {
+	log.Info().Str(NodeURL, c.Config.URL).Msg("Getting plugin discovery endpoint")
+
+	resp, err := c.APIClient.R().
+		SetDoNotParseResponse(true).
+		Get(fmt.Sprint("/plugins/%s/metrics", name))
+	if err != nil {
+		return nil, err
+	}
+	err = VerifyStatusCode(resp.StatusCode(), http.StatusOK)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.RawBody().Close()
+	return io.ReadAll(resp.RawResponse.Body)
+
 }


### PR DESCRIPTION
Adds calls to the new HTTP endpoints for LOOPp discovery and metrics.

I expect to use them in the chainlink-solana integration test to start, but they are more generic so this seems like the right home.