### PR TITLE
chore/2215: node validate detects duplication of chain ids and nodes

### DIFF
--- a/core/chains/cosmos/config.go
+++ b/core/chains/cosmos/config.go
@@ -22,7 +22,7 @@ import (
 
 type CosmosConfigs []*CosmosConfig
 
-func (cs CosmosConfigs) ValidateConfig() (err error) {
+func (cs CosmosConfigs) validateKeys() (err error) {
 	// Unique chain IDs
 	chainIDs := v2.UniqueStrings{}
 	for i, c := range cs {
@@ -52,9 +52,17 @@ func (cs CosmosConfigs) ValidateConfig() (err error) {
 		}
 	}
 	return
+
 }
 
-func (cs *CosmosConfigs) SetFrom(fs *CosmosConfigs) {
+func (cs CosmosConfigs) ValidateConfig() (err error) {
+	return cs.validateKeys()
+}
+
+func (cs *CosmosConfigs) SetFrom(fs *CosmosConfigs) (err error) {
+	if err1 := fs.validateKeys(); err1 != nil {
+		return err1
+	}
 	for _, f := range *fs {
 		if f.ChainID == nil {
 			*cs = append(*cs, f)
@@ -66,6 +74,7 @@ func (cs *CosmosConfigs) SetFrom(fs *CosmosConfigs) {
 			(*cs)[i].SetFrom(f)
 		}
 	}
+	return
 }
 
 func (cs CosmosConfigs) Chains(ids ...string) (r []relaytypes.ChainStatus, err error) {

--- a/core/chains/evm/config/v2/config.go
+++ b/core/chains/evm/config/v2/config.go
@@ -30,6 +30,10 @@ type HasEVMConfigs interface {
 type EVMConfigs []*EVMConfig
 
 func (cs EVMConfigs) ValidateConfig() (err error) {
+	return cs.validateKeys()
+}
+
+func (cs EVMConfigs) validateKeys() (err error) {
 	// Unique chain IDs
 	chainIDs := v2.UniqueStrings{}
 	for i, c := range cs {
@@ -72,7 +76,10 @@ func (cs EVMConfigs) ValidateConfig() (err error) {
 	return
 }
 
-func (cs *EVMConfigs) SetFrom(fs *EVMConfigs) {
+func (cs *EVMConfigs) SetFrom(fs *EVMConfigs) (err error) {
+	if err1 := fs.validateKeys(); err1 != nil {
+		return err1
+	}
 	for _, f := range *fs {
 		if f.ChainID == nil {
 			*cs = append(*cs, f)
@@ -84,6 +91,7 @@ func (cs *EVMConfigs) SetFrom(fs *EVMConfigs) {
 			(*cs)[i].SetFrom(f)
 		}
 	}
+	return
 }
 
 func (cs EVMConfigs) Chains(ids ...string) (r []relaytypes.ChainStatus, err error) {

--- a/core/chains/solana/config.go
+++ b/core/chains/solana/config.go
@@ -12,6 +12,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+
 	solcfg "github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 	soldb "github.com/smartcontractkit/chainlink-solana/pkg/solana/db"
 
@@ -24,6 +25,10 @@ import (
 type SolanaConfigs []*SolanaConfig
 
 func (cs SolanaConfigs) ValidateConfig() (err error) {
+	return cs.validateKeys()
+}
+
+func (cs SolanaConfigs) validateKeys() (err error) {
 	// Unique chain IDs
 	chainIDs := v2.UniqueStrings{}
 	for i, c := range cs {
@@ -55,7 +60,10 @@ func (cs SolanaConfigs) ValidateConfig() (err error) {
 	return
 }
 
-func (cs *SolanaConfigs) SetFrom(fs *SolanaConfigs) {
+func (cs *SolanaConfigs) SetFrom(fs *SolanaConfigs) (err error) {
+	if err1 := fs.validateKeys(); err1 != nil {
+		return err1
+	}
 	for _, f := range *fs {
 		if f.ChainID == nil {
 			*cs = append(*cs, f)
@@ -67,6 +75,7 @@ func (cs *SolanaConfigs) SetFrom(fs *SolanaConfigs) {
 			(*cs)[i].SetFrom(f)
 		}
 	}
+	return
 }
 
 func (cs SolanaConfigs) Chains(ids ...string) (r []types.ChainStatus, err error) {

--- a/core/chains/starknet/config.go
+++ b/core/chains/starknet/config.go
@@ -10,6 +10,7 @@ import (
 	"golang.org/x/exp/slices"
 
 	"github.com/smartcontractkit/chainlink-relay/pkg/types"
+
 	stkcfg "github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/config"
 	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/db"
 
@@ -20,6 +21,10 @@ import (
 type StarknetConfigs []*StarknetConfig
 
 func (cs StarknetConfigs) ValidateConfig() (err error) {
+	return cs.validateKeys()
+}
+
+func (cs StarknetConfigs) validateKeys() (err error) {
 	// Unique chain IDs
 	chainIDs := v2.UniqueStrings{}
 	for i, c := range cs {
@@ -51,7 +56,10 @@ func (cs StarknetConfigs) ValidateConfig() (err error) {
 	return
 }
 
-func (cs *StarknetConfigs) SetFrom(fs *StarknetConfigs) {
+func (cs *StarknetConfigs) SetFrom(fs *StarknetConfigs) (err error) {
+	if err1 := fs.validateKeys(); err1 != nil {
+		return err1
+	}
 	for _, f := range *fs {
 		if f.ChainID == nil {
 			*cs = append(*cs, f)
@@ -63,6 +71,7 @@ func (cs *StarknetConfigs) SetFrom(fs *StarknetConfigs) {
 			(*cs)[i].SetFrom(f)
 		}
 	}
+	return
 }
 
 func (cs StarknetConfigs) Chains(ids ...string) (r []types.ChainStatus, err error) {

--- a/core/config/v2/validate.go
+++ b/core/config/v2/validate.go
@@ -72,7 +72,7 @@ func validate(v reflect.Value, checkInterface bool) (err error) {
 				if ft.Anonymous {
 					err = multierr.Append(err, fe)
 				} else {
-					err = multierr.Append(err, namedMultiErrorList(fe, ft.Name))
+					err = multierr.Append(err, NamedMultiErrorList(fe, ft.Name))
 				}
 			}
 		}
@@ -89,7 +89,7 @@ func validate(v reflect.Value, checkInterface bool) (err error) {
 				continue
 			}
 			if me := validate(mv, true); me != nil {
-				err = multierr.Append(err, namedMultiErrorList(me, fmt.Sprintf("%s", mk.Interface())))
+				err = multierr.Append(err, NamedMultiErrorList(me, fmt.Sprintf("%s", mk.Interface())))
 			}
 		}
 		return
@@ -103,7 +103,7 @@ func validate(v reflect.Value, checkInterface bool) (err error) {
 				continue
 			}
 			if me := validate(iv, true); me != nil {
-				err = multierr.Append(err, namedMultiErrorList(me, strconv.Itoa(i)))
+				err = multierr.Append(err, NamedMultiErrorList(me, strconv.Itoa(i)))
 			}
 		}
 		return
@@ -112,7 +112,7 @@ func validate(v reflect.Value, checkInterface bool) (err error) {
 	return fmt.Errorf("should be unreachable: switch missing case for kind: %s", t.Kind())
 }
 
-func namedMultiErrorList(err error, name string) error {
+func NamedMultiErrorList(err error, name string) error {
 	l, merr := utils.MultiErrorList(err)
 	if l == 0 {
 		return nil

--- a/core/services/chainlink/config.go
+++ b/core/services/chainlink/config.go
@@ -5,10 +5,13 @@ import (
 
 	"errors"
 
+	"go.uber.org/multierr"
+
 	"github.com/pelletier/go-toml/v2"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/cosmos"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/starknet"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 
 	evmcfg "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/v2"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/solana"
@@ -90,12 +93,28 @@ func (c *Config) setDefaults() {
 	}
 }
 
-func (c *Config) SetFrom(f *Config) {
+func (c *Config) SetFrom(f *Config) (err error) {
 	c.Core.SetFrom(&f.Core)
-	c.EVM.SetFrom(&f.EVM)
-	c.Cosmos.SetFrom(&f.Cosmos)
-	c.Solana.SetFrom(&f.Solana)
-	c.Starknet.SetFrom(&f.Starknet)
+
+	if err1 := c.EVM.SetFrom(&f.EVM); err1 != nil {
+		err = multierr.Append(err, config.NamedMultiErrorList(err1, "EVM"))
+	}
+
+	if err2 := c.Cosmos.SetFrom(&f.Cosmos); err2 != nil {
+		err = multierr.Append(err, config.NamedMultiErrorList(err2, "Cosmos"))
+	}
+
+	if err3 := c.Solana.SetFrom(&f.Solana); err3 != nil {
+		err = multierr.Append(err, config.NamedMultiErrorList(err3, "Solana"))
+	}
+
+	if err4 := c.Starknet.SetFrom(&f.Starknet); err4 != nil {
+		err = multierr.Append(err, config.NamedMultiErrorList(err4, "Starknet"))
+	}
+
+	_, err = utils.MultiErrorList(err)
+
+	return err
 }
 
 type Secrets struct {

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -78,7 +78,11 @@ func (o *GeneralConfigOpts) parseConfig(config string) error {
 	if err2 := v2.DecodeTOML(strings.NewReader(config), &c); err2 != nil {
 		return fmt.Errorf("failed to decode config TOML: %w", err2)
 	}
-	o.Config.SetFrom(&c)
+
+	// Overrides duplicate fields
+	if err4 := o.Config.SetFrom(&c); err4 != nil {
+		return fmt.Errorf("invalid configuration: %w", err4)
+	}
 	return nil
 }
 

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -119,8 +119,8 @@ var (
 				},
 				Nodes: []*evmcfg.Node{
 					{
-						Name:  ptr("primary"),
-						WSURL: mustURL("wss://web.socket/test"),
+						Name:  ptr("foo"),
+						WSURL: mustURL("wss://web.socket/test/foo"),
 					},
 				}},
 			{
@@ -132,8 +132,8 @@ var (
 				},
 				Nodes: []*evmcfg.Node{
 					{
-						Name:  ptr("primary"),
-						WSURL: mustURL("wss://web.socket/test"),
+						Name:  ptr("bar"),
+						WSURL: mustURL("wss://web.socket/test/bar"),
 					},
 				}},
 		},
@@ -152,7 +152,7 @@ var (
 					BlocksUntilTxTimeout: ptr[int64](20),
 				},
 				Nodes: []*coscfg.Node{
-					{Name: ptr("primary"), TendermintURL: relayutils.MustParseURL("http://bombay.cosmos.com")},
+					{Name: ptr("secondary"), TendermintURL: relayutils.MustParseURL("http://bombay.cosmos.com")},
 				}},
 		},
 		Solana: []*solana.SolanaConfig{
@@ -171,7 +171,7 @@ var (
 					OCR2CachePollPeriod: relayutils.MustNewDuration(time.Minute),
 				},
 				Nodes: []*solcfg.Node{
-					{Name: ptr("primary"), URL: relayutils.MustParseURL("http://testnet.solana.com")},
+					{Name: ptr("secondary"), URL: relayutils.MustParseURL("http://testnet.solana.com")},
 				},
 			},
 		},
@@ -534,12 +534,12 @@ func TestConfig_Marshal(t *testing.T) {
 				{
 					Name:    ptr("foo"),
 					HTTPURL: mustURL("https://foo.web"),
-					WSURL:   mustURL("wss://web.socket/test"),
+					WSURL:   mustURL("wss://web.socket/test/foo"),
 				},
 				{
 					Name:    ptr("bar"),
 					HTTPURL: mustURL("https://bar.com"),
-					WSURL:   mustURL("wss://web.socket/test"),
+					WSURL:   mustURL("wss://web.socket/test/bar"),
 				},
 				{
 					Name:     ptr("broadcast"),
@@ -917,12 +917,12 @@ GasLimit = 540
 
 [[EVM.Nodes]]
 Name = 'foo'
-WSURL = 'wss://web.socket/test'
+WSURL = 'wss://web.socket/test/foo'
 HTTPURL = 'https://foo.web'
 
 [[EVM.Nodes]]
 Name = 'bar'
-WSURL = 'wss://web.socket/test'
+WSURL = 'wss://web.socket/test/bar'
 HTTPURL = 'https://bar.com'
 
 [[EVM.Nodes]]

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -293,12 +293,12 @@ GasLimit = 540
 
 [[EVM.Nodes]]
 Name = 'foo'
-WSURL = 'wss://web.socket/test'
+WSURL = 'wss://web.socket/test/foo'
 HTTPURL = 'https://foo.web'
 
 [[EVM.Nodes]]
 Name = 'bar'
-WSURL = 'wss://web.socket/test'
+WSURL = 'wss://web.socket/test/bar'
 HTTPURL = 'https://bar.com'
 
 [[EVM.Nodes]]

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -357,8 +357,8 @@ ObservationGracePeriod = '1s'
 GasLimit = 5300000
 
 [[EVM.Nodes]]
-Name = 'primary'
-WSURL = 'wss://web.socket/test'
+Name = 'foo'
+WSURL = 'wss://web.socket/test/foo'
 
 [[EVM]]
 ChainID = '137'
@@ -434,8 +434,8 @@ ObservationGracePeriod = '1s'
 GasLimit = 5300000
 
 [[EVM.Nodes]]
-Name = 'primary'
-WSURL = 'wss://web.socket/test'
+Name = 'bar'
+WSURL = 'wss://web.socket/test/bar'
 
 [[Cosmos]]
 ChainID = 'Ibiza-808'
@@ -468,7 +468,7 @@ OCR2CacheTTL = '1m0s'
 TxMsgTimeout = '10m0s'
 
 [[Cosmos.Nodes]]
-Name = 'primary'
+Name = 'secondary'
 TendermintURL = 'http://bombay.cosmos.com'
 
 [[Solana]]
@@ -512,7 +512,7 @@ ComputeUnitPriceDefault = 0
 FeeBumpPeriod = '3s'
 
 [[Solana.Nodes]]
-Name = 'primary'
+Name = 'secondary'
 URL = 'http://testnet.solana.com'
 
 [[Starknet]]

--- a/core/services/chainlink/testdata/config-multi-chain.toml
+++ b/core/services/chainlink/testdata/config-multi-chain.toml
@@ -55,8 +55,8 @@ ChainID = '42'
 PriceDefault = '9.223372036854775807 ether'
 
 [[EVM.Nodes]]
-Name = 'primary'
-WSURL = 'wss://web.socket/test'
+Name = 'foo'
+WSURL = 'wss://web.socket/test/foo'
 
 [[EVM]]
 ChainID = '137'
@@ -65,8 +65,8 @@ ChainID = '137'
 Mode = 'FixedPrice'
 
 [[EVM.Nodes]]
-Name = 'primary'
-WSURL = 'wss://web.socket/test'
+Name = 'bar'
+WSURL = 'wss://web.socket/test/bar'
 
 [[Cosmos]]
 ChainID = 'Ibiza-808'
@@ -81,7 +81,7 @@ ChainID = 'Malaga-420'
 BlocksUntilTxTimeout = 20
 
 [[Cosmos.Nodes]]
-Name = 'primary'
+Name = 'secondary'
 TendermintURL = 'http://bombay.cosmos.com'
 
 [[Solana]]
@@ -97,7 +97,7 @@ ChainID = 'testnet'
 OCR2CachePollPeriod = '1m0s'
 
 [[Solana.Nodes]]
-Name = 'primary'
+Name = 'secondary'
 URL = 'http://testnet.solana.com'
 
 [[Starknet]]

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -293,12 +293,12 @@ GasLimit = 540
 
 [[EVM.Nodes]]
 Name = 'foo'
-WSURL = 'wss://web.socket/test'
+WSURL = 'wss://web.socket/test/foo'
 HTTPURL = 'https://foo.web'
 
 [[EVM.Nodes]]
 Name = 'bar'
-WSURL = 'wss://web.socket/test'
+WSURL = 'wss://web.socket/test/bar'
 HTTPURL = 'https://bar.com'
 
 [[EVM.Nodes]]

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -357,8 +357,8 @@ ObservationGracePeriod = '1s'
 GasLimit = 5300000
 
 [[EVM.Nodes]]
-Name = 'primary'
-WSURL = 'wss://web.socket/test'
+Name = 'foo'
+WSURL = 'wss://web.socket/test/foo'
 
 [[EVM]]
 ChainID = '137'
@@ -434,8 +434,8 @@ ObservationGracePeriod = '1s'
 GasLimit = 5300000
 
 [[EVM.Nodes]]
-Name = 'primary'
-WSURL = 'wss://web.socket/test'
+Name = 'bar'
+WSURL = 'wss://web.socket/test/bar'
 
 [[Cosmos]]
 ChainID = 'Ibiza-808'
@@ -468,7 +468,7 @@ OCR2CacheTTL = '1m0s'
 TxMsgTimeout = '10m0s'
 
 [[Cosmos.Nodes]]
-Name = 'primary'
+Name = 'secondary'
 TendermintURL = 'http://bombay.cosmos.com'
 
 [[Solana]]
@@ -512,7 +512,7 @@ ComputeUnitPriceDefault = 0
 FeeBumpPeriod = '3s'
 
 [[Solana.Nodes]]
-Name = 'primary'
+Name = 'secondary'
 URL = 'http://testnet.solana.com'
 
 [[Starknet]]

--- a/core/web/resolver/testdata/config-multi-chain.toml
+++ b/core/web/resolver/testdata/config-multi-chain.toml
@@ -55,8 +55,8 @@ ChainID = '42'
 PriceDefault = '9.223372036854775807 ether'
 
 [[EVM.Nodes]]
-Name = 'primary'
-WSURL = 'wss://web.socket/test'
+Name = 'foo'
+WSURL = 'wss://web.socket/test/foo'
 
 [[EVM]]
 ChainID = '137'
@@ -65,8 +65,8 @@ ChainID = '137'
 Mode = 'FixedPrice'
 
 [[EVM.Nodes]]
-Name = 'primary'
-WSURL = 'wss://web.socket/test'
+Name = 'bar'
+WSURL = 'wss://web.socket/test/bar'
 
 [[Cosmos]]
 ChainID = 'Ibiza-808'
@@ -81,7 +81,7 @@ ChainID = 'Malaga-420'
 BlocksUntilTxTimeout = 20
 
 [[Cosmos.Nodes]]
-Name = 'primary'
+Name = 'secondary'
 TendermintURL = 'http://bombay.cosmos.com'
 
 [[Solana]]
@@ -97,7 +97,7 @@ ChainID = 'testnet'
 OCR2CachePollPeriod = '1m0s'
 
 [[Solana.Nodes]]
-Name = 'primary'
+Name = 'secondary'
 URL = 'http://testnet.solana.com'
 
 [[Starknet]]

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -24,6 +24,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Assumption violations for MaxFeePerGas >= BaseFeePerGas and MaxFeePerGas >= MaxPriorityFeePerGas in EIP-1559 effective gas price calculation will now use a gas price if specified
+- Config validation now enforces protection against duplicate chain ids and node fields per provided TOML file. Duplicates accross multiple configuration files are still valid. If you have specified duplicate chain ids or nodes in a given configuration file, this change will error out of all `node` subcommands.
 - Set default for EVM.GasEstimator.BumpTxDepth to EVM.Transactions.MaxInFlight.
 - Bumped batch size defaults for EVM specific configuration. If you are overriding any of these fields in your local config, please consider if it is necesssary:
 	- `LogBackfillBatchSize = 1000`

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,7 +7,7 @@ sonar.exclusions=**/node_modules/**/*,**/mocks/**/*, **/testdata/**/*, **/contra
 # Coverage exclusions
 sonar.coverage.exclusions=**/*.test.ts, **/*_test.go, **/contracts/test/**/*, **/contracts/**/tests/**/*, **/core/**/testutils/**/*, **/core/**/mocks/**/*, **/core/**/cltest/**/*, **/integration-tests/**/*, **/generated/**/*, **/core/scripts**/* , **/*.pb.go, ./plugins/**/*, **/main.go
 # Duplication exclusions
-sonar.cpd.exclusions=**/contracts/**/*.sol
+sonar.cpd.exclusions=**/contracts/**/*.sol, **/config.go
 
 # Tests' root folder, inclusions (tests to check and count) and exclusions
 sonar.tests=.

--- a/testdata/scripts/node/validate/invalid-duplicates.txtar
+++ b/testdata/scripts/node/validate/invalid-duplicates.txtar
@@ -1,0 +1,94 @@
+! exec chainlink node -c config.toml -s secrets.toml validate
+cmp stderr err.txt
+cmp stdout out.txt
+
+-- config.toml --
+Log.Level = 'debug'
+
+[[EVM]]
+ChainID = '1'
+
+[[EVM]]
+ChainID = '1'
+
+[[EVM.Nodes]]
+Name = 'fake'
+WSURL = 'wss://foo.bar/ws'
+HTTPURL = 'https://foo.bar'
+
+[[EVM.Nodes]]
+Name = 'fake'
+WSURL = 'wss://foo.bar/ws'
+HTTPURL = 'https://foo.bar'
+
+[[Cosmos]]
+ChainID = 'Malaga-420'
+
+[[Cosmos]]
+ChainID = 'Malaga-420'
+
+[[Cosmos.Nodes]]
+Name = 'primary'
+TendermintURL = 'http://tender.mint'
+
+[[Cosmos.Nodes]]
+Name = 'primary'
+TendermintURL = 'http://tender.mint'
+
+[[Solana]]
+ChainID = 'mainnet'
+
+[[Solana]]
+ChainID = 'mainnet'
+
+[[Solana.Nodes]]
+Name = 'primary'
+URL = 'http://solana.web'
+
+[[Solana.Nodes]]
+Name = 'primary'
+URL = 'http://solana.web'
+
+[[Starknet]]
+ChainID = 'foobar'
+
+[[Starknet]]
+ChainID = 'foobar'
+
+[[Starknet.Nodes]]
+Name = 'primary'
+URL = 'http://stark.node'
+
+[[Starknet.Nodes]]
+Name = 'primary'
+URL = 'http://stark.node'
+
+
+-- secrets.toml --
+[Database]
+URL = 'postgresql://user:pass@localhost:5432/dbname?sslmode=disable'
+BackupURL = ''
+
+[Password]
+Keystore = ''
+
+-- out.txt --
+-- err.txt --
+Error running app: invalid configuration: 4 errors:
+	- EVM: 4 errors:
+		- 1.ChainID: invalid value (1): duplicate - must be unique
+		- 1.Nodes.1.Name: invalid value (fake): duplicate - must be unique
+		- 1.Nodes.1.WSURL: invalid value (wss://foo.bar/ws): duplicate - must be unique
+		- 1.Nodes.1.HTTPURL: invalid value (https://foo.bar): duplicate - must be unique
+	- Cosmos: 3 errors:
+		- 1.ChainID: invalid value (Malaga-420): duplicate - must be unique
+		- 1.Nodes.1.Name: invalid value (primary): duplicate - must be unique
+		- 1.Nodes.1.TendermintURL: invalid value (http://tender.mint): duplicate - must be unique
+	- Solana: 3 errors:
+		- 1.ChainID: invalid value (mainnet): duplicate - must be unique
+		- 1.Nodes.1.Name: invalid value (primary): duplicate - must be unique
+		- 1.Nodes.1.URL: invalid value (http://solana.web): duplicate - must be unique
+	- Starknet: 3 errors:
+		- 1.ChainID: invalid value (foobar): duplicate - must be unique
+		- 1.Nodes.1.Name: invalid value (primary): duplicate - must be unique
+		- 1.Nodes.1.URL: invalid value (http://stark.node): duplicate - must be unique

--- a/testdata/scripts/node/validate/invalid.txtar
+++ b/testdata/scripts/node/validate/invalid.txtar
@@ -8,14 +8,6 @@ Log.Level = 'debug'
 [[EVM]]
 ChainID = '1'
 
-[[EVM]]
-ChainID = '1'
-
-[[EVM.Nodes]]
-Name = 'fake'
-WSURL = 'wss://foo.bar/ws'
-HTTPURL = 'https://foo.bar'
-
 [[EVM.Nodes]]
 Name = 'fake'
 WSURL = 'wss://foo.bar/ws'


### PR DESCRIPTION
Detects duplication of `ChainID` and fields within `*.Nodes` for `EVM`, `Cosmos`, `Solana` and `Starknet` within configuration files.

**This is a breaking change.** We should have been enforcing uniqueness of these parameters previously for `node validate`, and had implemented functionality and testing to do so. However, current TOML file parsing for the `node` command removes all duplicates, ensuring that such validation logic could never be applied.

With this change, duplication detection validation logic is applied when the file is parsed for the command `node`. This means that this validation logic is applied before any `node` subcommand is run, such as `node start` or `node validate`. Note that other config validation occurs when the subcommands are run.
 
This approach avoids a deeper refactor of how we parse TOML config files, and is extensible to future configuration values also requiring uniqueness checks. Setting methods are used to leave out nil values of configuration, parse configuration values from multiple files, and override duplicate values. Another approach would be to prop drill all these`SetFrom` + `setFrom*` methods to accept a list of fields that should not be deduped, and drill the list of those fields into the hierarchy of setting methods that reach into chain specific config parsing logic. 