### PR TITLE
[BCF-2267] Break out Backup fields into their own interface

### DIFF
--- a/core/chains/evm/config/mocks/chain_scoped_config.go
+++ b/core/chains/evm/config/mocks/chain_scoped_config.go
@@ -622,72 +622,16 @@ func (_m *ChainScopedConfig) CosmosEnabled() bool {
 	return r0
 }
 
-// DatabaseBackupDir provides a mock function with given fields:
-func (_m *ChainScopedConfig) DatabaseBackupDir() string {
+// Database provides a mock function with given fields:
+func (_m *ChainScopedConfig) Database() coreconfig.Database {
 	ret := _m.Called()
 
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
-// DatabaseBackupFrequency provides a mock function with given fields:
-func (_m *ChainScopedConfig) DatabaseBackupFrequency() time.Duration {
-	ret := _m.Called()
-
-	var r0 time.Duration
-	if rf, ok := ret.Get(0).(func() time.Duration); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(time.Duration)
-	}
-
-	return r0
-}
-
-// DatabaseBackupMode provides a mock function with given fields:
-func (_m *ChainScopedConfig) DatabaseBackupMode() coreconfig.DatabaseBackupMode {
-	ret := _m.Called()
-
-	var r0 coreconfig.DatabaseBackupMode
-	if rf, ok := ret.Get(0).(func() coreconfig.DatabaseBackupMode); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(coreconfig.DatabaseBackupMode)
-	}
-
-	return r0
-}
-
-// DatabaseBackupOnVersionUpgrade provides a mock function with given fields:
-func (_m *ChainScopedConfig) DatabaseBackupOnVersionUpgrade() bool {
-	ret := _m.Called()
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// DatabaseBackupURL provides a mock function with given fields:
-func (_m *ChainScopedConfig) DatabaseBackupURL() *url.URL {
-	ret := _m.Called()
-
-	var r0 *url.URL
-	if rf, ok := ret.Get(0).(func() *url.URL); ok {
+	var r0 coreconfig.Database
+	if rf, ok := ret.Get(0).(func() coreconfig.Database); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*url.URL)
+			r0 = ret.Get(0).(coreconfig.Database)
 		}
 	}
 

--- a/core/cmd/client.go
+++ b/core/cmd/client.go
@@ -131,7 +131,7 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg chainlink.G
 		initPrometheus(cfg)
 	})
 
-	err = handleNodeVersioning(db, appLggr, cfg)
+	err = handleNodeVersioning(db, appLggr, cfg.RootDir(), cfg.Database())
 	if err != nil {
 		return nil, err
 	}
@@ -286,7 +286,7 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg chainlink.G
 }
 
 // handleNodeVersioning is a setup-time helper to encapsulate version changes and db migration
-func handleNodeVersioning(db *sqlx.DB, appLggr logger.Logger, cfg chainlink.GeneralConfig) error {
+func handleNodeVersioning(db *sqlx.DB, appLggr logger.Logger, rootDir string, cfg config.Database) error {
 	var err error
 	// Set up the versioning Configs
 	verORM := versioning.NewORM(db, appLggr, cfg.DatabaseDefaultQueryTimeout())
@@ -301,8 +301,9 @@ func handleNodeVersioning(db *sqlx.DB, appLggr logger.Logger, cfg chainlink.Gene
 
 		// Take backup if app version is newer than DB version
 		// Need to do this BEFORE migration
-		if cfg.DatabaseBackupMode() != config.DatabaseBackupModeNone && cfg.DatabaseBackupOnVersionUpgrade() {
-			if err = takeBackupIfVersionUpgrade(cfg, appLggr, appv, dbv); err != nil {
+		backupCfg := cfg.Backup()
+		if backupCfg.Mode() != config.DatabaseBackupModeNone && backupCfg.OnVersionUpgrade() {
+			if err = takeBackupIfVersionUpgrade(cfg.DatabaseURL(), rootDir, cfg.Backup(), appLggr, appv, dbv); err != nil {
 				if errors.Is(err, sql.ErrNoRows) {
 					appLggr.Debugf("Failed to find any node version in the DB: %w", err)
 				} else if strings.Contains(err.Error(), "relation \"node_versions\" does not exist") {
@@ -331,7 +332,7 @@ func handleNodeVersioning(db *sqlx.DB, appLggr logger.Logger, cfg chainlink.Gene
 	return nil
 }
 
-func takeBackupIfVersionUpgrade(cfg periodicbackup.Config, lggr logger.Logger, appv, dbv *semver.Version) (err error) {
+func takeBackupIfVersionUpgrade(dbUrl url.URL, rootDir string, cfg periodicbackup.BackupConfig, lggr logger.Logger, appv, dbv *semver.Version) (err error) {
 	if appv == nil {
 		lggr.Debug("Application version is missing, skipping automatic DB backup.")
 		return nil
@@ -346,7 +347,7 @@ func takeBackupIfVersionUpgrade(cfg periodicbackup.Config, lggr logger.Logger, a
 	}
 	lggr.Infof("Upgrade detected: application version %s is newer than database version %s, taking automatic DB backup. To skip automatic database backup before version upgrades, set Database.Backup.OnVersionUpgrade=false. To disable backups entirely set Database.Backup.Mode=none.", appv.String(), dbv.String())
 
-	databaseBackup, err := periodicbackup.NewDatabaseBackup(cfg, lggr)
+	databaseBackup, err := periodicbackup.NewDatabaseBackup(dbUrl, rootDir, cfg, lggr)
 	if err != nil {
 		return errors.Wrap(err, "takeBackupIfVersionUpgrade failed")
 	}

--- a/core/config/app_config.go
+++ b/core/config/app_config.go
@@ -27,11 +27,10 @@ type AppConfig interface {
 	LogConfiguration(log LogfFn)
 	SetLogLevel(lvl zapcore.Level) error
 	SetLogSQL(logSQL bool)
-	LogSQL() bool
 	SetPasswords(keystore, vrf *string)
 
 	AutoPprof
-	Database
+	DatabaseV1
 	Ethereum
 	Explorer
 	FeatureFlags
@@ -53,6 +52,8 @@ type AppConfig interface {
 	TelemetryIngress
 	Web
 	audit.Config
+
+	Database() Database
 }
 type DatabaseBackupMode string
 

--- a/core/config/database_config.go
+++ b/core/config/database_config.go
@@ -7,12 +7,9 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/store/dialects"
 )
 
-type Database interface {
-	DatabaseBackupDir() string
-	DatabaseBackupFrequency() time.Duration
-	DatabaseBackupMode() DatabaseBackupMode
-	DatabaseBackupOnVersionUpgrade() bool
-	DatabaseBackupURL() *url.URL
+// Note: this is a legacy interface. Any new fields should be added to the database
+// interface defined below and accessed via cfg.Database().<FieldName>().
+type DatabaseV1 interface {
 	DatabaseDefaultIdleInTxSessionTimeout() time.Duration
 	DatabaseDefaultLockTimeout() time.Duration
 	DatabaseDefaultQueryTimeout() time.Duration
@@ -27,4 +24,32 @@ type Database interface {
 	ORMMaxIdleConns() int
 	ORMMaxOpenConns() int
 	TriggerFallbackDBPollInterval() time.Duration
+	LogSQL() bool
+}
+
+type Backup interface {
+	Dir() string
+	Frequency() time.Duration
+	Mode() DatabaseBackupMode
+	OnVersionUpgrade() bool
+	URL() *url.URL
+}
+
+type Database interface {
+	Backup() Backup
+	DatabaseDefaultIdleInTxSessionTimeout() time.Duration
+	DatabaseDefaultLockTimeout() time.Duration
+	DatabaseDefaultQueryTimeout() time.Duration
+	DatabaseListenerMaxReconnectDuration() time.Duration
+	DatabaseListenerMinReconnectInterval() time.Duration
+	DatabaseLockingMode() string
+	DatabaseURL() url.URL
+	GetDatabaseDialectConfiguredOrDefault() dialects.DialectName
+	LeaseLockDuration() time.Duration
+	LeaseLockRefreshInterval() time.Duration
+	MigrateDatabase() bool
+	ORMMaxIdleConns() int
+	ORMMaxOpenConns() int
+	TriggerFallbackDBPollInterval() time.Duration
+	LogSQL() bool
 }

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -276,10 +276,11 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 	}
 	srvcs = append(srvcs, explorerClient, telemetryIngressClient, telemetryIngressBatchClient)
 
-	if cfg.DatabaseBackupMode() != config.DatabaseBackupModeNone && cfg.DatabaseBackupFrequency() > 0 {
-		globalLogger.Infow("DatabaseBackup: periodic database backups are enabled", "frequency", cfg.DatabaseBackupFrequency())
+	backupCfg := cfg.Database().Backup()
+	if backupCfg.Mode() != config.DatabaseBackupModeNone && backupCfg.Frequency() > 0 {
+		globalLogger.Infow("DatabaseBackup: periodic database backups are enabled", "frequency", backupCfg.Frequency())
 
-		databaseBackup, err := periodicbackup.NewDatabaseBackup(cfg, globalLogger)
+		databaseBackup, err := periodicbackup.NewDatabaseBackup(cfg.DatabaseURL(), cfg.RootDir(), backupCfg, globalLogger)
 		if err != nil {
 			return nil, errors.Wrap(err, "NewApplication: failed to initialize database backup")
 		}

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -453,20 +453,8 @@ func (g *generalConfig) CertFile() string {
 	return s
 }
 
-func (g *generalConfig) DatabaseBackupDir() string {
-	return *g.c.Database.Backup.Dir
-}
-
-func (g *generalConfig) DatabaseBackupFrequency() time.Duration {
-	return g.c.Database.Backup.Frequency.Duration()
-}
-
-func (g *generalConfig) DatabaseBackupMode() coreconfig.DatabaseBackupMode {
-	return *g.c.Database.Backup.Mode
-}
-
-func (g *generalConfig) DatabaseBackupOnVersionUpgrade() bool {
-	return *g.c.Database.Backup.OnVersionUpgrade
+func (g *generalConfig) Database() coreconfig.Database {
+	return &databaseConfig{c: g.c.Database, s: g.secrets.Secrets.Database, logSQL: g.LogSQL}
 }
 
 func (g *generalConfig) DatabaseListenerMaxReconnectDuration() time.Duration {

--- a/core/services/chainlink/config_general_test.go
+++ b/core/services/chainlink/config_general_test.go
@@ -120,3 +120,16 @@ func TestValidateDB(t *testing.T) {
 	})
 
 }
+
+func TestConfig_LogSQL(t *testing.T) {
+	config, err := GeneralConfigOpts{}.New()
+	require.NoError(t, err)
+
+	config.SetLogSQL(true)
+	assert.Equal(t, config.LogSQL(), true)
+	assert.Equal(t, config.Database().LogSQL(), true)
+
+	config.SetLogSQL(false)
+	assert.Equal(t, config.LogSQL(), false)
+	assert.Equal(t, config.Database().LogSQL(), false)
+}

--- a/core/services/chainlink/database_config.go
+++ b/core/services/chainlink/database_config.go
@@ -1,0 +1,110 @@
+package chainlink
+
+import (
+	"net/url"
+	"time"
+
+	"github.com/smartcontractkit/chainlink/v2/core/config"
+	v2 "github.com/smartcontractkit/chainlink/v2/core/config/v2"
+	"github.com/smartcontractkit/chainlink/v2/core/store/dialects"
+)
+
+type backupConfig struct {
+	c v2.DatabaseBackup
+	s v2.DatabaseSecrets
+}
+
+func (b *backupConfig) Dir() string {
+	return *b.c.Dir
+}
+
+func (b *backupConfig) Frequency() time.Duration {
+	return b.c.Frequency.Duration()
+}
+
+func (b *backupConfig) Mode() config.DatabaseBackupMode {
+	return *b.c.Mode
+}
+
+func (b *backupConfig) OnVersionUpgrade() bool {
+	return *b.c.OnVersionUpgrade
+}
+
+func (b *backupConfig) URL() *url.URL {
+	return b.s.BackupURL.URL()
+}
+
+var _ config.Database = (*databaseConfig)(nil)
+
+type databaseConfig struct {
+	c      v2.Database
+	s      v2.DatabaseSecrets
+	logSQL func() bool
+}
+
+func (d *databaseConfig) Backup() config.Backup {
+	return &backupConfig{
+		c: d.c.Backup,
+		s: d.s,
+	}
+}
+
+func (d *databaseConfig) DatabaseDefaultIdleInTxSessionTimeout() time.Duration {
+	return d.c.DefaultIdleInTxSessionTimeout.Duration()
+}
+
+func (d *databaseConfig) DatabaseDefaultLockTimeout() time.Duration {
+	return d.c.DefaultLockTimeout.Duration()
+}
+
+func (d *databaseConfig) DatabaseDefaultQueryTimeout() time.Duration {
+	return d.c.DefaultQueryTimeout.Duration()
+}
+
+func (d *databaseConfig) DatabaseListenerMaxReconnectDuration() time.Duration {
+	return d.c.Listener.MaxReconnectDuration.Duration()
+}
+
+func (d *databaseConfig) DatabaseListenerMinReconnectInterval() time.Duration {
+	return d.c.Listener.MinReconnectInterval.Duration()
+}
+
+func (d *databaseConfig) DatabaseLockingMode() string {
+	return d.c.LockingMode()
+}
+
+func (d *databaseConfig) DatabaseURL() url.URL {
+	return *d.s.URL.URL()
+}
+
+func (d *databaseConfig) GetDatabaseDialectConfiguredOrDefault() dialects.DialectName {
+	return d.c.Dialect
+}
+
+func (d *databaseConfig) LeaseLockDuration() time.Duration {
+	return d.c.Lock.LeaseDuration.Duration()
+}
+
+func (d *databaseConfig) LeaseLockRefreshInterval() time.Duration {
+	return d.c.Lock.LeaseRefreshInterval.Duration()
+}
+
+func (d *databaseConfig) MigrateDatabase() bool {
+	return *d.c.MigrateOnStartup
+}
+
+func (d *databaseConfig) ORMMaxIdleConns() int {
+	return int(*d.c.MaxIdleConns)
+}
+
+func (d *databaseConfig) ORMMaxOpenConns() int {
+	return int(*d.c.MaxOpenConns)
+}
+
+func (d *databaseConfig) TriggerFallbackDBPollInterval() time.Duration {
+	return d.c.Listener.FallbackPollInterval.Duration()
+}
+
+func (d *databaseConfig) LogSQL() (sql bool) {
+	return d.logSQL()
+}

--- a/core/services/chainlink/database_config_test.go
+++ b/core/services/chainlink/database_config_test.go
@@ -1,0 +1,45 @@
+package chainlink
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink/v2/core/config"
+	"github.com/smartcontractkit/chainlink/v2/core/store/dialects"
+)
+
+func TestDatabaseConfig(t *testing.T) {
+	opts := GeneralConfigOpts{
+		ConfigStrings: []string{fullTOML},
+	}
+	cfg, err := opts.New()
+	require.NoError(t, err)
+
+	backup := cfg.Database().Backup()
+	assert.Equal(t, backup.Dir(), "test/backup/dir")
+	assert.Equal(t, backup.Frequency(), 1*time.Hour)
+	assert.Equal(t, backup.Mode(), config.DatabaseBackupModeFull)
+	assert.Equal(t, backup.OnVersionUpgrade(), true)
+	assert.Nil(t, backup.URL())
+
+	db := cfg.Database()
+	assert.Equal(t, db.DatabaseDefaultIdleInTxSessionTimeout(), 1*time.Minute)
+	assert.Equal(t, db.DatabaseDefaultLockTimeout(), 1*time.Hour)
+	assert.Equal(t, db.DatabaseDefaultQueryTimeout(), 1*time.Second)
+	assert.Equal(t, db.LogSQL(), true)
+	assert.Equal(t, db.ORMMaxIdleConns(), 7)
+	assert.Equal(t, db.ORMMaxOpenConns(), 13)
+	assert.Equal(t, db.MigrateDatabase(), true)
+	assert.Equal(t, db.DatabaseLockingMode(), "none")
+	assert.Equal(t, db.LeaseLockDuration(), 1*time.Minute)
+	assert.Equal(t, db.LeaseLockRefreshInterval(), 1*time.Second)
+	assert.Equal(t, db.DatabaseListenerMaxReconnectDuration(), 1*time.Minute)
+	assert.Equal(t, db.DatabaseListenerMinReconnectInterval(), 5*time.Minute)
+	assert.Equal(t, db.TriggerFallbackDBPollInterval(), 2*time.Minute)
+	assert.Equal(t, db.GetDatabaseDialectConfiguredOrDefault(), dialects.Postgres)
+	url := db.DatabaseURL()
+	assert.NotEqual(t, url.String(), "")
+}

--- a/core/services/chainlink/mocks/general_config.go
+++ b/core/services/chainlink/mocks/general_config.go
@@ -469,72 +469,16 @@ func (_m *GeneralConfig) CosmosEnabled() bool {
 	return r0
 }
 
-// DatabaseBackupDir provides a mock function with given fields:
-func (_m *GeneralConfig) DatabaseBackupDir() string {
+// Database provides a mock function with given fields:
+func (_m *GeneralConfig) Database() config.Database {
 	ret := _m.Called()
 
-	var r0 string
-	if rf, ok := ret.Get(0).(func() string); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(string)
-	}
-
-	return r0
-}
-
-// DatabaseBackupFrequency provides a mock function with given fields:
-func (_m *GeneralConfig) DatabaseBackupFrequency() time.Duration {
-	ret := _m.Called()
-
-	var r0 time.Duration
-	if rf, ok := ret.Get(0).(func() time.Duration); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(time.Duration)
-	}
-
-	return r0
-}
-
-// DatabaseBackupMode provides a mock function with given fields:
-func (_m *GeneralConfig) DatabaseBackupMode() config.DatabaseBackupMode {
-	ret := _m.Called()
-
-	var r0 config.DatabaseBackupMode
-	if rf, ok := ret.Get(0).(func() config.DatabaseBackupMode); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(config.DatabaseBackupMode)
-	}
-
-	return r0
-}
-
-// DatabaseBackupOnVersionUpgrade provides a mock function with given fields:
-func (_m *GeneralConfig) DatabaseBackupOnVersionUpgrade() bool {
-	ret := _m.Called()
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// DatabaseBackupURL provides a mock function with given fields:
-func (_m *GeneralConfig) DatabaseBackupURL() *url.URL {
-	ret := _m.Called()
-
-	var r0 *url.URL
-	if rf, ok := ret.Get(0).(func() *url.URL); ok {
+	var r0 config.Database
+	if rf, ok := ret.Get(0).(func() config.Database); ok {
 		r0 = rf()
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*url.URL)
+			r0 = ret.Get(0).(config.Database)
 		}
 	}
 

--- a/core/services/periodicbackup/backup_test.go
+++ b/core/services/periodicbackup/backup_test.go
@@ -17,9 +17,9 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/static"
 )
 
-func mustNewDatabaseBackup(t *testing.T, config Config) *databaseBackup {
+func mustNewDatabaseBackup(t *testing.T, url url.URL, rootDir string, config BackupConfig) *databaseBackup {
 	testutils.SkipShortDB(t)
-	b, err := NewDatabaseBackup(config, logger.TestLogger(t))
+	b, err := NewDatabaseBackup(url, rootDir, config, logger.TestLogger(t))
 	require.NoError(t, err)
 	return b.(*databaseBackup)
 }
@@ -31,8 +31,8 @@ func must(t testing.TB, s string) *url.URL {
 }
 
 func TestPeriodicBackup_RunBackup(t *testing.T) {
-	backupConfig := newTestConfig(time.Minute, nil, must(t, string(v2.EnvDatabaseURL.Get())), os.TempDir(), "", config.DatabaseBackupModeFull)
-	periodicBackup := mustNewDatabaseBackup(t, backupConfig)
+	backupConfig := newTestConfig(time.Minute, nil, "", config.DatabaseBackupModeFull)
+	periodicBackup := mustNewDatabaseBackup(t, *(must(t, string(v2.EnvDatabaseURL.Get()))), os.TempDir(), backupConfig)
 	assert.False(t, periodicBackup.frequencyIsTooSmall())
 
 	result, err := periodicBackup.runBackup("0.9.9")
@@ -50,8 +50,8 @@ func TestPeriodicBackup_RunBackup(t *testing.T) {
 }
 
 func TestPeriodicBackup_RunBackupInLiteMode(t *testing.T) {
-	backupConfig := newTestConfig(time.Minute, nil, must(t, string(v2.EnvDatabaseURL.Get())), os.TempDir(), "", config.DatabaseBackupModeLite)
-	periodicBackup := mustNewDatabaseBackup(t, backupConfig)
+	backupConfig := newTestConfig(time.Minute, nil, "", config.DatabaseBackupModeLite)
+	periodicBackup := mustNewDatabaseBackup(t, *(must(t, string(v2.EnvDatabaseURL.Get()))), os.TempDir(), backupConfig)
 	assert.False(t, periodicBackup.frequencyIsTooSmall())
 
 	result, err := periodicBackup.runBackup("0.9.9")
@@ -69,8 +69,8 @@ func TestPeriodicBackup_RunBackupInLiteMode(t *testing.T) {
 }
 
 func TestPeriodicBackup_RunBackupWithoutVersion(t *testing.T) {
-	backupConfig := newTestConfig(time.Minute, nil, must(t, string(v2.EnvDatabaseURL.Get())), os.TempDir(), "", config.DatabaseBackupModeFull)
-	periodicBackup := mustNewDatabaseBackup(t, backupConfig)
+	backupConfig := newTestConfig(time.Minute, nil, "", config.DatabaseBackupModeFull)
+	periodicBackup := mustNewDatabaseBackup(t, *(must(t, string(v2.EnvDatabaseURL.Get()))), os.TempDir(), backupConfig)
 	assert.False(t, periodicBackup.frequencyIsTooSmall())
 
 	result, err := periodicBackup.runBackup(static.Unset)
@@ -88,8 +88,8 @@ func TestPeriodicBackup_RunBackupWithoutVersion(t *testing.T) {
 
 func TestPeriodicBackup_RunBackupViaAltUrlAndMaskPassword(t *testing.T) {
 	altUrl, _ := url.Parse("postgresql://invalid:some-pass@invalid")
-	backupConfig := newTestConfig(time.Minute, altUrl, must(t, string(v2.EnvDatabaseURL.Get())), os.TempDir(), "", config.DatabaseBackupModeFull)
-	periodicBackup := mustNewDatabaseBackup(t, backupConfig)
+	backupConfig := newTestConfig(time.Minute, altUrl, "", config.DatabaseBackupModeFull)
+	periodicBackup := mustNewDatabaseBackup(t, *(must(t, string(v2.EnvDatabaseURL.Get()))), os.TempDir(), backupConfig)
 	assert.False(t, periodicBackup.frequencyIsTooSmall())
 
 	partialResult, err := periodicBackup.runBackup("")
@@ -98,16 +98,15 @@ func TestPeriodicBackup_RunBackupViaAltUrlAndMaskPassword(t *testing.T) {
 }
 
 func TestPeriodicBackup_FrequencyTooSmall(t *testing.T) {
-	backupConfig := newTestConfig(time.Second, nil, must(t, string(v2.EnvDatabaseURL.Get())), os.TempDir(), "", config.DatabaseBackupModeFull)
-	periodicBackup := mustNewDatabaseBackup(t, backupConfig)
+	backupConfig := newTestConfig(time.Second, nil, "", config.DatabaseBackupModeFull)
+	periodicBackup := mustNewDatabaseBackup(t, *(must(t, string(v2.EnvDatabaseURL.Get()))), os.TempDir(), backupConfig)
 	assert.True(t, periodicBackup.frequencyIsTooSmall())
 }
 
 func TestPeriodicBackup_AlternativeOutputDir(t *testing.T) {
-	backupConfig := newTestConfig(time.Second, nil, must(t, string(v2.EnvDatabaseURL.Get())), os.TempDir(),
-		filepath.Join(os.TempDir(), "alternative"), config.DatabaseBackupModeFull)
-
-	periodicBackup := mustNewDatabaseBackup(t, backupConfig)
+	backupDir := filepath.Join(os.TempDir(), "alternative")
+	backupConfig := newTestConfig(time.Second, nil, backupDir, config.DatabaseBackupModeFull)
+	periodicBackup := mustNewDatabaseBackup(t, *(must(t, string(v2.EnvDatabaseURL.Get()))), os.TempDir(), backupConfig)
 
 	result, err := periodicBackup.runBackup("0.9.9")
 	require.NoError(t, err, "error not nil for backup")
@@ -123,40 +122,33 @@ func TestPeriodicBackup_AlternativeOutputDir(t *testing.T) {
 }
 
 type testConfig struct {
-	databaseBackupFrequency time.Duration
-	databaseBackupMode      config.DatabaseBackupMode
-	databaseBackupURL       *url.URL
-	databaseBackupDir       string
-	databaseURL             url.URL
-	rootDir                 string
+	frequency time.Duration
+	mode      config.DatabaseBackupMode
+	url       *url.URL
+	dir       string
 }
 
-func (config testConfig) DatabaseBackupFrequency() time.Duration {
-	return config.databaseBackupFrequency
-}
-func (config testConfig) DatabaseBackupMode() config.DatabaseBackupMode {
-	return config.databaseBackupMode
-}
-func (config testConfig) DatabaseBackupURL() *url.URL {
-	return config.databaseBackupURL
-}
-func (config testConfig) DatabaseBackupDir() string {
-	return config.databaseBackupDir
-}
-func (config testConfig) DatabaseURL() url.URL {
-	return config.databaseURL
-}
-func (config testConfig) RootDir() string {
-	return config.rootDir
+func (t *testConfig) Frequency() time.Duration {
+	return t.frequency
 }
 
-func newTestConfig(frequency time.Duration, databaseBackupURL *url.URL, databaseURL *url.URL, rootDir string, databaseBackupDir string, mode config.DatabaseBackupMode) testConfig {
-	return testConfig{
-		databaseBackupFrequency: frequency,
-		databaseBackupMode:      mode,
-		databaseBackupURL:       databaseBackupURL,
-		databaseURL:             *databaseURL,
-		rootDir:                 rootDir,
-		databaseBackupDir:       databaseBackupDir,
+func (t *testConfig) Mode() config.DatabaseBackupMode {
+	return t.mode
+}
+
+func (t *testConfig) URL() *url.URL {
+	return t.url
+}
+
+func (t *testConfig) Dir() string {
+	return t.dir
+}
+
+func newTestConfig(frequency time.Duration, databaseBackupURL *url.URL, databaseBackupDir string, mode config.DatabaseBackupMode) *testConfig {
+	return &testConfig{
+		frequency: frequency,
+		mode:      mode,
+		url:       databaseBackupURL,
+		dir:       databaseBackupDir,
 	}
 }


### PR DESCRIPTION
- Create the scaffolding to allow us to move database config fields
   under the Database() method. This is the DatabaseV1 interface. As
   fields are moved under Database(), this interface should get thinner and
   thinner until it disappears.
- Refactor the periodic backup package so that it is decoupled from the
   Config struct by passing in smaller sub-interfaces of what it needs
   (DatabaseUrl, RootDir, Backup)