### PR TITLE
Refix abandoned transactions hash conflict bug

### DIFF
--- a/core/chains/evm/txmgr/evm_tx_store.go
+++ b/core/chains/evm/txmgr/evm_tx_store.go
@@ -1321,7 +1321,7 @@ func (o *evmTxStore) UpdateEthTxUnstartedToInProgress(etx *EvmTx, attempt *EvmTx
 		)
 		if err == nil {
 			o.logger.Debugf("Replacing abandoned tx with tx hash %s with tx_id=%d with identical tx hash", attempt.Hash, attempt.TxID)
-		} else if err != sql.ErrNoRows {
+		} else if errors.Is(err, sql.ErrNoRows) {
 			return err
 		}
 

--- a/core/chains/evm/txmgr/evm_tx_store_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_test.go
@@ -1024,7 +1024,7 @@ func TestORM_MarkOldTxesMissingReceiptAsErrored(t *testing.T) {
 
 	// tx state should be confirmed missing receipt
 	// attempt should be broadcast before cutoff time
-	t.Run("succesfully mark errored transactions", func(t *testing.T) {
+	t.Run("successfully mark errored transactions", func(t *testing.T) {
 		etx := cltest.MustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(t, txStore, 1, 7, time.Now(), fromAddress)
 
 		err := txStore.MarkOldTxesMissingReceiptAsErrored(10, 2, ethClient.ConfiguredChainID())
@@ -1035,7 +1035,7 @@ func TestORM_MarkOldTxesMissingReceiptAsErrored(t *testing.T) {
 		assert.Equal(t, txmgr.EthTxFatalError, etx.State)
 	})
 
-	t.Run("succesfully mark errored transactions w/ qopt passing in sql.Tx", func(t *testing.T) {
+	t.Run("successfully mark errored transactions w/ qopt passing in sql.Tx", func(t *testing.T) {
 		q := pg.NewQ(db, logger.TestLogger(t), cfg)
 
 		etx := cltest.MustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(t, txStore, 1, 7, time.Now(), fromAddress)


### PR DESCRIPTION
Removing the abandoned transaction after an error is detected doesn't work, because it poisons the whole transaction.  Even though subsequent queries would have succeeded, they fail because there's already been a sql error.

This would be an ideal case for use of nested transactions, but we can't easily add support for that so the only way is to check for and remove any conflicting abandoned transactions before the INSERT.  We can at least combine the check and DELETE into a single query.