### PR TITLE
core/services: helper funcs to simplify MultiClose

### DIFF
--- a/core/chains/chain_set.go
+++ b/core/chains/chain_set.go
@@ -136,13 +136,10 @@ func (c *chainSet[N, S]) Start(ctx context.Context) error {
 }
 
 func (c *chainSet[N, S]) Close() error {
-	return c.StopOnce("ChainSet", func() (err error) {
+	return c.StopOnce("ChainSet", func() error {
 		c.lggr.Debug("Stopping")
 
-		for _, c := range c.chains {
-			err = multierr.Combine(err, c.Close())
-		}
-		return
+		return services.MultiCloser(maps.Values(c.chains)).Close()
 	})
 }
 

--- a/core/chains/evm/client/pool.go
+++ b/core/chains/evm/client/pool.go
@@ -227,14 +227,7 @@ func (p *Pool) Close() error {
 		close(p.chStop)
 		p.wg.Wait()
 
-		var mc services.MultiClose
-		for _, n := range p.nodes {
-			mc = append(mc, n)
-		}
-		for _, s := range p.sendonlys {
-			mc = append(mc, s)
-		}
-		return mc.Close()
+		return services.CloseAll(services.MultiCloser(p.nodes), services.MultiCloser(p.sendonlys))
 	})
 }
 

--- a/core/chains/evm/headtracker/head_broadcaster_test.go
+++ b/core/chains/evm/headtracker/head_broadcaster_test.go
@@ -73,7 +73,7 @@ func TestHeadBroadcaster_Subscribe(t *testing.T) {
 	ht := headtracker.NewHeadTracker(logger, ethClient, headtracker.NewWrappedConfig(evmCfg), hb, hs, mailMon)
 	var ms services.MultiStart
 	require.NoError(t, ms.Start(testutils.Context(t), mailMon, hb, ht))
-	t.Cleanup(func() { require.NoError(t, services.MultiClose{mailMon, hb, ht}.Close()) })
+	t.Cleanup(func() { require.NoError(t, services.CloseAll(mailMon, hb, ht)) })
 
 	latest1, unsubscribe1 := hb.Subscribe(checker1)
 	// "latest head" is nil here because we didn't receive any yet

--- a/core/chains/solana/chain.go
+++ b/core/chains/solana/chain.go
@@ -293,8 +293,7 @@ func (c *chain) Close() error {
 		c.lggr.Debug("Stopping")
 		c.lggr.Debug("Stopping txm")
 		c.lggr.Debug("Stopping balance monitor")
-		return multierr.Combine(c.txm.Close(),
-			c.balanceMonitor.Close())
+		return services.CloseAll(c.txm, c.balanceMonitor)
 	})
 }
 

--- a/core/services/directrequest/delegate.go
+++ b/core/services/directrequest/delegate.go
@@ -180,7 +180,7 @@ func (l *listener) Close() error {
 		close(l.chStop)
 		l.shutdownWaitGroup.Wait()
 
-		return services.MultiClose{l.mbOracleRequests, l.mbOracleCancelRequests}.Close()
+		return services.CloseAll(l.mbOracleRequests, l.mbOracleCancelRequests)
 	})
 }
 

--- a/core/services/multi_example_test.go
+++ b/core/services/multi_example_test.go
@@ -62,18 +62,19 @@ func ExampleMultiStart() {
 	// failed to start: c; failed to close: b
 }
 
-func ExampleMultiClose() {
+func ExampleMultiCloser() {
 	ctx := context.Background()
 
 	f1 := CloseFailure("f")
 	f2 := CloseFailure("f")
+	cs := []CloseFailure{f1, f2}
 
 	var ms MultiStart
 	if err := ms.Start(ctx, f1, f2); err != nil {
 		fmt.Println(err)
 		return
 	}
-	mc := MultiClose{f1, f2}
+	mc := MultiCloser(cs)
 	if err := mc.Close(); err != nil {
 		fmt.Println(err)
 	}

--- a/core/services/ocr2/plugins/median/plugin.go
+++ b/core/services/ocr2/plugins/median/plugin.go
@@ -90,11 +90,7 @@ func NewMedianServices(ctx context.Context,
 	argsNoPlugin.OffchainConfigDigester = provider.OffchainConfigDigester()
 
 	abort := func() {
-		var mc services.MultiClose
-		for i := range srvs {
-			mc = append(mc, srvs[i])
-		}
-		if cerr := mc.Close(); err != nil {
+		if cerr := services.MultiCloser(srvs).Close(); err != nil {
 			lggr.Errorw("Error closing unused services", "err", cerr)
 		}
 	}

--- a/core/services/pg/event_broadcaster.go
+++ b/core/services/pg/event_broadcaster.go
@@ -10,8 +10,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/lib/pq"
 	"github.com/pkg/errors"
-	"go.uber.org/multierr"
-
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services"
 	"github.com/smartcontractkit/chainlink/v2/core/static"
@@ -116,8 +114,7 @@ func (b *eventBroadcaster) Close() error {
 		defer b.subscriptionsMu.RUnlock()
 		b.subscriptions = nil
 
-		err = multierr.Append(err, b.db.Close())
-		err = multierr.Append(err, b.listener.Close())
+		err = services.CloseAll(b.db, b.listener)
 		close(b.chStop)
 		<-b.chDone
 		return err

--- a/core/services/relay/relay.go
+++ b/core/services/relay/relay.go
@@ -71,7 +71,7 @@ func (r *relayerAdapter) Start(ctx context.Context) error {
 }
 
 func (r *relayerAdapter) Close() error {
-	return services.MultiClose{r.Relayer, r.RelayerExt}.Close()
+	return services.CloseAll(r.Relayer, r.RelayerExt)
 }
 
 func (r *relayerAdapter) Name() string {


### PR DESCRIPTION
- s/`MultiClose`/`MultiCloser`
- unexport `type MultiCloser`
- introduce `func MultiCloser` and `func CloseAll`
