### PR TITLE
Refix abandoned transactions hash conflict bug (#9340)

### DIFF
--- a/core/chains/evm/txmgr/evm_tx_store.go
+++ b/core/chains/evm/txmgr/evm_tx_store.go
@@ -1294,45 +1294,6 @@ func (o *evmTxStore) UpdateEthTxAttemptInProgressToBroadcast(etx *EvmTx, attempt
 	})
 }
 
-// recoverFromTxAttemptsHashConflict recovers from an idx_eth_tx_attempts_hash constraint violation.
-// If a replay was triggered while unconfirmed transactions were pending, they will be marked as fatal_error => abandoned.
-// In this case, we must remove the abandoned attempt from eth_tx_attempts before replacing it with a new one.  In any other
-// case, we uphold the constraint, leaving the original tx attempt as-is and returning the constraint violation error.
-//
-// Note:  the record of the original abandoned transaction will remain in eth_txes, only the attempt is replaced.  (Any receipt
-// associated with the abandoned attempt would also be lost, although this shouldn't happen since only unconfirmed transactions
-// can be abandoned.)
-func recoverFromTxAttemptsHashConflict(attempt *EvmTxAttempt, tx pg.Queryer, dupErr error, query string, args ...interface{}) (err error) {
-	var duplicateTx DbEthTx
-	defer func() {
-		if err != nil {
-			err = errors.Join(dupErr, err)
-		}
-	}()
-	err = tx.Get(&duplicateTx, `SELECT * FROM eth_txes t JOIN eth_tx_attempts a ON t.id = a.eth_tx_id WHERE a.hash = $1`, attempt.Hash)
-	if err == nil {
-		if duplicateTx.State != EthTxFatalError || !duplicateTx.Error.Valid || duplicateTx.Error.String != "abandoned" {
-			return err
-		}
-		var nrows int64
-		var res sql.Result // Remove previous attempt.
-		res, err = tx.Exec(`DELETE FROM eth_tx_attempts WHERE a.hash=$1`, attempt.Hash)
-		if err != nil {
-			return err
-		}
-		nrows, err = res.RowsAffected()
-		if err == nil {
-			if nrows == 0 {
-				err = pkgerrors.Wrap(err, "Failed to remove conflicting hash from eth_tx_attempts")
-			} else { // Try again to insert new attempt.
-				var dbAttempt DbEthTxAttempt
-				err = tx.Get(&dbAttempt, query, args...)
-			}
-		}
-	}
-	return err
-}
-
 // Updates eth tx from unstarted to in_progress and inserts in_progress eth attempt
 func (o *evmTxStore) UpdateEthTxUnstartedToInProgress(etx *EvmTx, attempt *EvmTxAttempt, qopts ...pg.QOpt) error {
 	qq := o.q.WithOpts(qopts...)
@@ -1347,20 +1308,35 @@ func (o *evmTxStore) UpdateEthTxUnstartedToInProgress(etx *EvmTx, attempt *EvmTx
 	}
 	etx.State = EthTxInProgress
 	return qq.Transaction(func(tx pg.Queryer) error {
+		// If a replay was triggered while unconfirmed transactions were pending, they will be marked as fatal_error => abandoned.
+		// In this case, we must remove the abandoned attempt from eth_tx_attempts before replacing it with a new one.  In any other
+		// case, we uphold the constraint, leaving the original tx attempt as-is and returning the constraint violation error.
+		//
+		// Note:  the record of the original abandoned transaction will remain in eth_txes, only the attempt is replaced.  (Any receipt
+		// associated with the abandoned attempt would also be lost, although this shouldn't happen since only unconfirmed transactions
+		// can be abandoned.)
+		_, err := tx.Exec(`DELETE FROM eth_tx_attempts a USING eth_txes t
+			WHERE t.id = a.eth_tx_id AND a.hash = $1 AND t.state = $2 AND t.error = 'abandoned'`,
+			attempt.Hash, EthTxFatalError,
+		)
+		if err == nil {
+			o.logger.Debugf("Replacing abandoned tx with tx hash %s with tx_id=%d with identical tx hash", attempt.Hash, attempt.TxID)
+		} else if errors.Is(err, sql.ErrNoRows) {
+			return err
+		}
+
 		dbAttempt := DbEthTxAttemptFromEthTxAttempt(attempt)
 		query, args, e := tx.BindNamed(insertIntoEthTxAttemptsQuery, &dbAttempt)
 		if e != nil {
 			return pkgerrors.Wrap(e, "failed to BindNamed")
 		}
-		err := tx.Get(&dbAttempt, query, args...)
+		err = tx.Get(&dbAttempt, query, args...)
 		if err != nil {
 			var pqErr *pgconn.PgError
 			if isPqErr := errors.As(err, &pqErr); isPqErr {
 				switch pqErr.ConstraintName {
 				case "eth_tx_attempts_eth_tx_id_fkey":
 					return errEthTxRemoved
-				case "idx_eth_tx_attempts_hash":
-					err = recoverFromTxAttemptsHashConflict(attempt, tx, err, query, args...)
 				default:
 				}
 			}

--- a/core/chains/evm/txmgr/evm_tx_store_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_test.go
@@ -1024,7 +1024,7 @@ func TestORM_MarkOldTxesMissingReceiptAsErrored(t *testing.T) {
 
 	// tx state should be confirmed missing receipt
 	// attempt should be broadcast before cutoff time
-	t.Run("succesfully mark errored transactions", func(t *testing.T) {
+	t.Run("successfully mark errored transactions", func(t *testing.T) {
 		etx := cltest.MustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(t, txStore, 1, 7, time.Now(), fromAddress)
 
 		err := txStore.MarkOldTxesMissingReceiptAsErrored(10, 2, ethClient.ConfiguredChainID())
@@ -1035,7 +1035,7 @@ func TestORM_MarkOldTxesMissingReceiptAsErrored(t *testing.T) {
 		assert.Equal(t, txmgr.EthTxFatalError, etx.State)
 	})
 
-	t.Run("succesfully mark errored transactions w/ qopt passing in sql.Tx", func(t *testing.T) {
+	t.Run("successfully mark errored transactions w/ qopt passing in sql.Tx", func(t *testing.T) {
 		q := pg.NewQ(db, logger.TestLogger(t), cfg)
 
 		etx := cltest.MustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(t, txStore, 1, 7, time.Now(), fromAddress)
@@ -1273,24 +1273,29 @@ func TestORM_UpdateEthTxUnstartedToInProgress(t *testing.T) {
 		err := txMgr.Abandon(fromAddress) // mark transaction as abandoned
 		require.NoError(t, err)
 
+		etx2 := cltest.MustInsertUnstartedEthTx(t, txStore, fromAddress)
+		etx2.Sequence = &nonce
+		attempt2 := cltest.NewLegacyEthTxAttempt(t, etx2.ID)
+		attempt2.Hash = etx.TxAttempts[0].Hash
+
 		// Even though this will initially fail due to idx_eth_tx_attempts_hash constraint, because the conflicting tx has been abandoned
 		// it should succeed after removing the abandoned attempt and retrying the insert
-		etx = cltest.MustInsertInProgressEthTxWithAttempt(t, txStore, nonce, fromAddress)
-		require.NotNil(t, etx.Sequence)
-		assert.Equal(t, nonce, *etx.Sequence)
+		err = txStore.UpdateEthTxUnstartedToInProgress(&etx2, &attempt2)
+		require.NoError(t, err)
 	})
 
 	_, fromAddress = cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
 
+	// Same flow as previous test, but without calling txMgr.Abandon()
 	t.Run("duplicate tx hash disallowed in tx_eth_attempts", func(t *testing.T) {
 		etx := cltest.MustInsertInProgressEthTxWithAttempt(t, txStore, nonce, fromAddress)
+		require.Len(t, etx.TxAttempts, 1)
 
-		etx2 := cltest.NewEthTx(t, fromAddress)
-		etx2.State = txmgr.EthTxUnstarted
-		require.NoError(t, txStore.InsertEthTx(&etx2))
+		etx.State = txmgr.EthTxUnstarted
 
-		// Should fail due to  idx_eth_tx_attempt_hash constraint
-		assert.ErrorContains(t, txStore.InsertEthTxAttempt(&etx.TxAttempts[0]), "idx_eth_tx_attempts_hash")
+		// Should fail due to idx_eth_tx_attempt_hash constraint
+		err := txStore.UpdateEthTxUnstartedToInProgress(&etx, &etx.TxAttempts[0])
+		assert.ErrorContains(t, err, "idx_eth_tx_attempts_hash")
 		txStore = cltest.NewTxStore(t, db, cfg) // current txStore is poisened now, next test will need fresh one
 	})
 }


### PR DESCRIPTION
Cherry pick of https://github.com/smartcontractkit/chainlink/commit/61f1bb683fae01343a0b13ff564e4ba96b5350dc from develop.  CHANGELOG already updated in prior commit (https://github.com/smartcontractkit/chainlink/commit/44a5fb02c613c44a7117068eb92aa0476786a1d9)