### PR TITLE
[BCF-2270] Restrict use of some OCR1 settings to OCR1; Add OCR2 equivalents

### DIFF
--- a/core/chains/evm/config/config.go
+++ b/core/chains/evm/config/config.go
@@ -42,6 +42,7 @@ type ChainScopedOnlyConfig interface {
 	EvmGasLimitMultiplier() float32
 	EvmGasLimitTransfer() uint32
 	EvmGasLimitOCRJobType() *uint32
+	EvmGasLimitOCR2JobType() *uint32
 	EvmGasLimitDRJobType() *uint32
 	EvmGasLimitVRFJobType() *uint32
 	EvmGasLimitFMJobType() *uint32

--- a/core/chains/evm/config/mocks/chain_scoped_config.go
+++ b/core/chains/evm/config/mocks/chain_scoped_config.go
@@ -1088,6 +1088,22 @@ func (_m *ChainScopedConfig) EvmGasLimitMultiplier() float32 {
 	return r0
 }
 
+// EvmGasLimitOCR2JobType provides a mock function with given fields:
+func (_m *ChainScopedConfig) EvmGasLimitOCR2JobType() *uint32 {
+	ret := _m.Called()
+
+	var r0 *uint32
+	if rf, ok := ret.Get(0).(func() *uint32); ok {
+		r0 = rf()
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*uint32)
+		}
+	}
+
+	return r0
+}
+
 // EvmGasLimitOCRJobType provides a mock function with given fields:
 func (_m *ChainScopedConfig) EvmGasLimitOCRJobType() *uint32 {
 	ret := _m.Called()
@@ -2235,6 +2251,20 @@ func (_m *ChainScopedConfig) OCR2DatabaseTimeout() time.Duration {
 	return r0
 }
 
+// OCR2DefaultTransactionQueueDepth provides a mock function with given fields:
+func (_m *ChainScopedConfig) OCR2DefaultTransactionQueueDepth() uint32 {
+	ret := _m.Called()
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func() uint32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	return r0
+}
+
 // OCR2KeyBundleID provides a mock function with given fields:
 func (_m *ChainScopedConfig) OCR2KeyBundleID() (string, error) {
 	ret := _m.Called()
@@ -2257,6 +2287,20 @@ func (_m *ChainScopedConfig) OCR2KeyBundleID() (string, error) {
 	}
 
 	return r0, r1
+}
+
+// OCR2SimulateTransactions provides a mock function with given fields:
+func (_m *ChainScopedConfig) OCR2SimulateTransactions() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
 }
 
 // OCR2TraceLogging provides a mock function with given fields:

--- a/core/chains/evm/config/v2/chain_scoped.go
+++ b/core/chains/evm/config/v2/chain_scoped.go
@@ -171,6 +171,10 @@ func (c *ChainScoped) EvmGasLimitOCRJobType() *uint32 {
 	return c.cfg.GasEstimator.LimitJobType.OCR
 }
 
+func (c *ChainScoped) EvmGasLimitOCR2JobType() *uint32 {
+	return c.cfg.GasEstimator.LimitJobType.OCR2
+}
+
 func (c *ChainScoped) EvmGasLimitDRJobType() *uint32 {
 	return c.cfg.GasEstimator.LimitJobType.DR
 }

--- a/core/chains/evm/config/v2/config.go
+++ b/core/chains/evm/config/v2/config.go
@@ -576,6 +576,7 @@ func (e *GasEstimator) setFrom(f *GasEstimator) {
 
 type GasLimitJobType struct {
 	OCR    *uint32 `toml:",inline"`
+	OCR2   *uint32 `toml:",inline"`
 	DR     *uint32 `toml:",inline"`
 	VRF    *uint32 `toml:",inline"`
 	FM     *uint32 `toml:",inline"`
@@ -585,6 +586,9 @@ type GasLimitJobType struct {
 func (t *GasLimitJobType) setFrom(f *GasLimitJobType) {
 	if f.OCR != nil {
 		t.OCR = f.OCR
+	}
+	if f.OCR2 != nil {
+		t.OCR2 = f.OCR2
 	}
 	if f.DR != nil {
 		t.DR = f.DR

--- a/core/config/ocr2_config.go
+++ b/core/config/ocr2_config.go
@@ -17,4 +17,6 @@ type OCR2Config interface {
 	// OCR2 config, cannot override in jobs
 	OCR2TraceLogging() bool
 	OCR2CaptureEATelemetry() bool
+	OCR2DefaultTransactionQueueDepth() uint32
+	OCR2SimulateTransactions() bool
 }

--- a/core/config/v2/docs/chains-evm.toml
+++ b/core/config/v2/docs/chains-evm.toml
@@ -221,6 +221,8 @@ TipCapMin = '1 wei' # Default
 [EVM.GasEstimator.LimitJobType]
 # OCR overrides LimitDefault for OCR jobs.
 OCR = 100_000 # Example
+# OCR2 overrides LimitDefault for OCR2 jobs.
+OCR2 = 100_000 # Example
 # DR overrides LimitDefault for Direct Request jobs.
 DR = 100_000 # Example
 # VRF overrides LimitDefault for VRF jobs.

--- a/core/config/v2/docs/core.toml
+++ b/core/config/v2/docs/core.toml
@@ -295,6 +295,10 @@ DatabaseTimeout = '10s' # Default
 KeyBundleID = '7a5f66bbe6594259325bf2b4f5b1a9c900000000000000000000000000000000' # Example
 # CaptureEATelemetry toggles collecting extra information from External Adaptares
 CaptureEATelemetry = false # Default
+# DefaultTransactionQueueDepth controls the queue size for `DropOldestStrategy` in OCR2. Set to 0 to use `SendEvery` strategy instead.
+DefaultTransactionQueueDepth = 1 # Default
+# SimulateTransactions enables transaction simulation for OCR2.
+SimulateTransactions = false # Default
 
 # This section applies only if you are running off-chain reporting jobs.
 [OCR]

--- a/core/config/v2/docs/docs_test.go
+++ b/core/config/v2/docs/docs_test.go
@@ -61,6 +61,7 @@ func TestDoc(t *testing.T) {
 
 		// per-job limits are nilable
 		require.Zero(t, *docDefaults.GasEstimator.LimitJobType.OCR)
+		require.Zero(t, *docDefaults.GasEstimator.LimitJobType.OCR2)
 		require.Zero(t, *docDefaults.GasEstimator.LimitJobType.DR)
 		require.Zero(t, *docDefaults.GasEstimator.LimitJobType.Keeper)
 		require.Zero(t, *docDefaults.GasEstimator.LimitJobType.VRF)

--- a/core/config/v2/types.go
+++ b/core/config/v2/types.go
@@ -642,6 +642,8 @@ type OCR2 struct {
 	DatabaseTimeout                    *models.Duration
 	KeyBundleID                        *models.Sha256Hash
 	CaptureEATelemetry                 *bool
+	DefaultTransactionQueueDepth       *uint32
+	SimulateTransactions               *bool
 }
 
 func (o *OCR2) setFrom(f *OCR2) {
@@ -671,6 +673,12 @@ func (o *OCR2) setFrom(f *OCR2) {
 	}
 	if v := f.CaptureEATelemetry; v != nil {
 		o.CaptureEATelemetry = v
+	}
+	if v := f.DefaultTransactionQueueDepth; v != nil {
+		o.DefaultTransactionQueueDepth = v
+	}
+	if v := f.SimulateTransactions; v != nil {
+		o.SimulateTransactions = v
 	}
 }
 

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -700,6 +700,14 @@ func (g *generalConfig) OCR2CaptureEATelemetry() bool {
 	return *g.c.OCR2.CaptureEATelemetry
 }
 
+func (g *generalConfig) OCR2DefaultTransactionQueueDepth() uint32 {
+	return *g.c.OCR2.DefaultTransactionQueueDepth
+}
+
+func (g *generalConfig) OCR2SimulateTransactions() bool {
+	return *g.c.OCR2.SimulateTransactions
+}
+
 func (g *generalConfig) P2PNetworkingStack() (n ocrnetworking.NetworkingStack) {
 	return g.c.P2P.NetworkStack()
 }

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -343,6 +343,8 @@ func TestConfig_Marshal(t *testing.T) {
 		DatabaseTimeout:                    models.MustNewDuration(8 * time.Second),
 		KeyBundleID:                        ptr(models.MustSha256HashFromHex("7a5f66bbe6594259325bf2b4f5b1a9c9")),
 		CaptureEATelemetry:                 ptr(false),
+		DefaultTransactionQueueDepth:       ptr[uint32](1),
+		SimulateTransactions:               ptr(false),
 	}
 	full.OCR = config.OCR{
 		Enabled:                      ptr(true),
@@ -464,6 +466,7 @@ func TestConfig_Marshal(t *testing.T) {
 						VRF:    ptr[uint32](1003),
 						FM:     ptr[uint32](1004),
 						Keeper: ptr[uint32](1005),
+						OCR2:   ptr[uint32](1006),
 					},
 
 					BlockHistory: evmcfg.BlockHistoryEstimator{
@@ -756,6 +759,8 @@ ContractTransmitterTransmitTimeout = '1m0s'
 DatabaseTimeout = '8s'
 KeyBundleID = '7a5f66bbe6594259325bf2b4f5b1a9c900000000000000000000000000000000'
 CaptureEATelemetry = false
+DefaultTransactionQueueDepth = 1
+SimulateTransactions = false
 `},
 		{"P2P", Config{Core: config.Core{P2P: full.P2P}}, `[P2P]
 IncomingMessageBufferSize = 13
@@ -875,6 +880,7 @@ TipCapMin = '1 wei'
 
 [EVM.GasEstimator.LimitJobType]
 OCR = 1001
+OCR2 = 1006
 DR = 1002
 VRF = 1003
 FM = 1004

--- a/core/services/chainlink/mocks/general_config.go
+++ b/core/services/chainlink/mocks/general_config.go
@@ -1412,6 +1412,20 @@ func (_m *GeneralConfig) OCR2DatabaseTimeout() time.Duration {
 	return r0
 }
 
+// OCR2DefaultTransactionQueueDepth provides a mock function with given fields:
+func (_m *GeneralConfig) OCR2DefaultTransactionQueueDepth() uint32 {
+	ret := _m.Called()
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func() uint32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	return r0
+}
+
 // OCR2KeyBundleID provides a mock function with given fields:
 func (_m *GeneralConfig) OCR2KeyBundleID() (string, error) {
 	ret := _m.Called()
@@ -1434,6 +1448,20 @@ func (_m *GeneralConfig) OCR2KeyBundleID() (string, error) {
 	}
 
 	return r0, r1
+}
+
+// OCR2SimulateTransactions provides a mock function with given fields:
+func (_m *GeneralConfig) OCR2SimulateTransactions() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
 }
 
 // OCR2TraceLogging provides a mock function with given fields:

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -114,6 +114,8 @@ ContractTransmitterTransmitTimeout = '10s'
 DatabaseTimeout = '10s'
 KeyBundleID = '0000000000000000000000000000000000000000000000000000000000000000'
 CaptureEATelemetry = false
+DefaultTransactionQueueDepth = 1
+SimulateTransactions = false
 
 [OCR]
 Enabled = false

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -114,6 +114,8 @@ ContractTransmitterTransmitTimeout = '1m0s'
 DatabaseTimeout = '8s'
 KeyBundleID = '7a5f66bbe6594259325bf2b4f5b1a9c900000000000000000000000000000000'
 CaptureEATelemetry = false
+DefaultTransactionQueueDepth = 1
+SimulateTransactions = false
 
 [OCR]
 Enabled = true
@@ -251,6 +253,7 @@ TipCapMin = '1 wei'
 
 [EVM.GasEstimator.LimitJobType]
 OCR = 1001
+OCR2 = 1006
 DR = 1002
 VRF = 1003
 FM = 1004

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -114,6 +114,8 @@ ContractTransmitterTransmitTimeout = '10s'
 DatabaseTimeout = '20s'
 KeyBundleID = '0000000000000000000000000000000000000000000000000000000000000000'
 CaptureEATelemetry = false
+DefaultTransactionQueueDepth = 1
+SimulateTransactions = false
 
 [OCR]
 Enabled = true

--- a/core/services/ocr2/mocks/config.go
+++ b/core/services/ocr2/mocks/config.go
@@ -184,6 +184,20 @@ func (_m *Config) OCR2DatabaseTimeout() time.Duration {
 	return r0
 }
 
+// OCR2DefaultTransactionQueueDepth provides a mock function with given fields:
+func (_m *Config) OCR2DefaultTransactionQueueDepth() uint32 {
+	ret := _m.Called()
+
+	var r0 uint32
+	if rf, ok := ret.Get(0).(func() uint32); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(uint32)
+	}
+
+	return r0
+}
+
 // OCR2KeyBundleID provides a mock function with given fields:
 func (_m *Config) OCR2KeyBundleID() (string, error) {
 	ret := _m.Called()
@@ -206,6 +220,20 @@ func (_m *Config) OCR2KeyBundleID() (string, error) {
 	}
 
 	return r0, r1
+}
+
+// OCR2SimulateTransactions provides a mock function with given fields:
+func (_m *Config) OCR2SimulateTransactions() bool {
+	ret := _m.Called()
+
+	var r0 bool
+	if rf, ok := ret.Get(0).(func() bool); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	return r0
 }
 
 // OCR2TraceLogging provides a mock function with given fields:

--- a/core/services/pipeline/common.go
+++ b/core/services/pipeline/common.go
@@ -563,6 +563,8 @@ func SelectGasLimit(cfg config.ChainScopedConfig, jobType string, specGasLimit *
 		jobTypeGasLimit = cfg.EvmGasLimitFMJobType()
 	case OffchainReportingJobType:
 		jobTypeGasLimit = cfg.EvmGasLimitOCRJobType()
+	case OffchainReporting2JobType:
+		jobTypeGasLimit = cfg.EvmGasLimitOCR2JobType()
 	case KeeperJobType:
 		jobTypeGasLimit = cfg.EvmGasLimitKeeperJobType()
 	case VRFJobType:

--- a/core/services/pipeline/common_test.go
+++ b/core/services/pipeline/common_test.go
@@ -329,7 +329,8 @@ func TestSelectGasLimit(t *testing.T) {
 			VRF:    ptr(uint32(101)),
 			FM:     ptr(uint32(102)),
 			OCR:    ptr(uint32(103)),
-			Keeper: ptr(uint32(103)),
+			Keeper: ptr(uint32(104)),
+			OCR2:   ptr(uint32(105)),
 		}
 	})
 	cfg := evmtest.NewChainScopedConfig(t, gcfg)
@@ -350,6 +351,11 @@ func TestSelectGasLimit(t *testing.T) {
 		assert.Equal(t, uint32(103), gasLimit)
 	})
 
+	t.Run("OCR2 specific gas limit", func(t *testing.T) {
+		gasLimit := pipeline.SelectGasLimit(cfg, pipeline.OffchainReporting2JobType, nil)
+		assert.Equal(t, uint32(105), gasLimit)
+	})
+
 	t.Run("VRF specific gas limit", func(t *testing.T) {
 		gasLimit := pipeline.SelectGasLimit(cfg, pipeline.VRFJobType, nil)
 		assert.Equal(t, uint32(101), gasLimit)
@@ -362,7 +368,7 @@ func TestSelectGasLimit(t *testing.T) {
 
 	t.Run("keeper specific gas limit", func(t *testing.T) {
 		gasLimit := pipeline.SelectGasLimit(cfg, pipeline.KeeperJobType, nil)
-		assert.Equal(t, uint32(103), gasLimit)
+		assert.Equal(t, uint32(104), gasLimit)
 	})
 
 	t.Run("fallback to default gas limit", func(t *testing.T) {

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -326,16 +326,16 @@ func newContractTransmitter(lggr logger.Logger, rargs relaytypes.RelayArgs, tran
 	}
 
 	scoped := configWatcher.chain.Config()
-	strategy := txm.NewQueueingTxStrategy(rargs.ExternalJobID, scoped.OCRDefaultTransactionQueueDepth(), scoped.DatabaseDefaultQueryTimeout())
+	strategy := txm.NewQueueingTxStrategy(rargs.ExternalJobID, scoped.OCR2DefaultTransactionQueueDepth(), scoped.DatabaseDefaultQueryTimeout())
 
 	var checker txm.EvmTransmitCheckerSpec
-	if configWatcher.chain.Config().OCRSimulateTransactions() {
+	if configWatcher.chain.Config().OCR2SimulateTransactions() {
 		checker.CheckerType = txm.TransmitCheckerTypeSimulate
 	}
 
 	gasLimit := configWatcher.chain.Config().EvmGasLimitDefault()
-	if configWatcher.chain.Config().EvmGasLimitOCRJobType() != nil {
-		gasLimit = *configWatcher.chain.Config().EvmGasLimitOCRJobType()
+	if configWatcher.chain.Config().EvmGasLimitOCR2JobType() != nil {
+		gasLimit = *configWatcher.chain.Config().EvmGasLimitOCR2JobType()
 	}
 
 	transmitter, err := ocrcommon.NewTransmitter(
@@ -376,16 +376,16 @@ func newPipelineContractTransmitter(lggr logger.Logger, rargs relaytypes.RelayAr
 	effectiveTransmitterAddress := common.HexToAddress(relayConfig.EffectiveTransmitterID.String)
 	transmitterAddress := common.HexToAddress(transmitterID)
 	scoped := configWatcher.chain.Config()
-	strategy := txm.NewQueueingTxStrategy(rargs.ExternalJobID, scoped.OCRDefaultTransactionQueueDepth(), scoped.DatabaseDefaultQueryTimeout())
+	strategy := txm.NewQueueingTxStrategy(rargs.ExternalJobID, scoped.OCR2DefaultTransactionQueueDepth(), scoped.DatabaseDefaultQueryTimeout())
 
 	var checker txm.EvmTransmitCheckerSpec
-	if configWatcher.chain.Config().OCRSimulateTransactions() {
+	if configWatcher.chain.Config().OCR2SimulateTransactions() {
 		checker.CheckerType = txm.TransmitCheckerTypeSimulate
 	}
 
 	gasLimit := configWatcher.chain.Config().EvmGasLimitDefault()
-	if configWatcher.chain.Config().EvmGasLimitOCRJobType() != nil {
-		gasLimit = *configWatcher.chain.Config().EvmGasLimitOCRJobType()
+	if configWatcher.chain.Config().EvmGasLimitOCR2JobType() != nil {
+		gasLimit = *configWatcher.chain.Config().EvmGasLimitOCR2JobType()
 	}
 	if pluginGasLimit != nil {
 		gasLimit = *pluginGasLimit

--- a/core/web/resolver/testdata/config-empty-effective.toml
+++ b/core/web/resolver/testdata/config-empty-effective.toml
@@ -114,6 +114,8 @@ ContractTransmitterTransmitTimeout = '10s'
 DatabaseTimeout = '10s'
 KeyBundleID = '0000000000000000000000000000000000000000000000000000000000000000'
 CaptureEATelemetry = false
+DefaultTransactionQueueDepth = 1
+SimulateTransactions = false
 
 [OCR]
 Enabled = false

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -114,6 +114,8 @@ ContractTransmitterTransmitTimeout = '1m0s'
 DatabaseTimeout = '8s'
 KeyBundleID = '7a5f66bbe6594259325bf2b4f5b1a9c900000000000000000000000000000000'
 CaptureEATelemetry = false
+DefaultTransactionQueueDepth = 1
+SimulateTransactions = false
 
 [OCR]
 Enabled = true

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -114,6 +114,8 @@ ContractTransmitterTransmitTimeout = '10s'
 DatabaseTimeout = '20s'
 KeyBundleID = '0000000000000000000000000000000000000000000000000000000000000000'
 CaptureEATelemetry = false
+DefaultTransactionQueueDepth = 1
+SimulateTransactions = false
 
 [OCR]
 Enabled = true

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -17,6 +17,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Experimental support of runtime process isolation for Solana data feeds. Requires plugin binaries to be installed and
   configured via the env vars `CL_SOLANA_CMD` and `CL_MEDIAN_CMD`. See [plugins/README.md](../plugins/README.md).
+- New settings Evm.GasEstimator.LimitJobType.OCR2, OCR2.DefaultTransactionQueueDepth, OCR2.SimulateTransactions for OCR2
+  jobs. These replace the settings Evm.GasEstimator.LimitJobType.OCR, OCR.DefaultTransactionQueueDepth, and OCR.SimulateTransaction
+  for OCR2.
 
 ### Fixed
 
@@ -31,6 +34,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 	- `RPCDefaultBatchSize: 250`
 	- `GasEstimator.BatchSize = 25`
 - Dropped support for Development Mode configuration. `CL_DEV` is now ignored on production builds.
+- Restricted scope of the Evm.GasEstimator.LimitJobType.OCR, OCR.DefaultTransactionQueueDepth, and OCR.SimulateTransactions settings so they
+  apply only to OCR. Previously these settings would apply to OCR2 as well as OCR. You must use the OCR2 equivalents added above if you
+  want your settings to apply to OCR2.
 
 <!-- unreleasedstop -->
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -702,6 +702,8 @@ ContractTransmitterTransmitTimeout = '10s' # Default
 DatabaseTimeout = '10s' # Default
 KeyBundleID = '7a5f66bbe6594259325bf2b4f5b1a9c900000000000000000000000000000000' # Example
 CaptureEATelemetry = false # Default
+DefaultTransactionQueueDepth = 1 # Default
+SimulateTransactions = false # Default
 ```
 
 
@@ -792,6 +794,18 @@ KeyBundleID is a sha256 hexadecimal hash identifier.
 CaptureEATelemetry = false # Default
 ```
 CaptureEATelemetry toggles collecting extra information from External Adaptares
+
+### DefaultTransactionQueueDepth
+```toml
+DefaultTransactionQueueDepth = 1 # Default
+```
+DefaultTransactionQueueDepth controls the queue size for `DropOldestStrategy` in OCR2. Set to 0 to use `SendEvery` strategy instead.
+
+### SimulateTransactions
+```toml
+SimulateTransactions = false # Default
+```
+SimulateTransactions enables transaction simulation for OCR2.
 
 ## OCR
 ```toml
@@ -4412,6 +4426,7 @@ Only applies to EIP-1559 transactions)
 ```toml
 [EVM.GasEstimator.LimitJobType]
 OCR = 100_000 # Example
+OCR2 = 100_000 # Example
 DR = 100_000 # Example
 VRF = 100_000 # Example
 FM = 100_000 # Example
@@ -4424,6 +4439,12 @@ Keeper = 100_000 # Example
 OCR = 100_000 # Example
 ```
 OCR overrides LimitDefault for OCR jobs.
+
+### OCR2
+```toml
+OCR2 = 100_000 # Example
+```
+OCR2 overrides LimitDefault for OCR2 jobs.
 
 ### DR
 ```toml

--- a/testdata/scripts/node/validate/default.txtar
+++ b/testdata/scripts/node/validate/default.txtar
@@ -124,6 +124,8 @@ ContractTransmitterTransmitTimeout = '10s'
 DatabaseTimeout = '10s'
 KeyBundleID = '0000000000000000000000000000000000000000000000000000000000000000'
 CaptureEATelemetry = false
+DefaultTransactionQueueDepth = 1
+SimulateTransactions = false
 
 [OCR]
 Enabled = false

--- a/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
@@ -170,6 +170,8 @@ ContractTransmitterTransmitTimeout = '10s'
 DatabaseTimeout = '10s'
 KeyBundleID = '0000000000000000000000000000000000000000000000000000000000000000'
 CaptureEATelemetry = false
+DefaultTransactionQueueDepth = 1
+SimulateTransactions = false
 
 [OCR]
 Enabled = false

--- a/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
@@ -170,6 +170,8 @@ ContractTransmitterTransmitTimeout = '10s'
 DatabaseTimeout = '10s'
 KeyBundleID = '0000000000000000000000000000000000000000000000000000000000000000'
 CaptureEATelemetry = false
+DefaultTransactionQueueDepth = 1
+SimulateTransactions = false
 
 [OCR]
 Enabled = false

--- a/testdata/scripts/node/validate/disk-based-logging.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging.txtar
@@ -170,6 +170,8 @@ ContractTransmitterTransmitTimeout = '10s'
 DatabaseTimeout = '10s'
 KeyBundleID = '0000000000000000000000000000000000000000000000000000000000000000'
 CaptureEATelemetry = false
+DefaultTransactionQueueDepth = 1
+SimulateTransactions = false
 
 [OCR]
 Enabled = false

--- a/testdata/scripts/node/validate/invalid.txtar
+++ b/testdata/scripts/node/validate/invalid.txtar
@@ -160,6 +160,8 @@ ContractTransmitterTransmitTimeout = '10s'
 DatabaseTimeout = '10s'
 KeyBundleID = '0000000000000000000000000000000000000000000000000000000000000000'
 CaptureEATelemetry = false
+DefaultTransactionQueueDepth = 1
+SimulateTransactions = false
 
 [OCR]
 Enabled = false

--- a/testdata/scripts/node/validate/valid.txtar
+++ b/testdata/scripts/node/validate/valid.txtar
@@ -167,6 +167,8 @@ ContractTransmitterTransmitTimeout = '10s'
 DatabaseTimeout = '10s'
 KeyBundleID = '0000000000000000000000000000000000000000000000000000000000000000'
 CaptureEATelemetry = false
+DefaultTransactionQueueDepth = 1
+SimulateTransactions = false
 
 [OCR]
 Enabled = false


### PR DESCRIPTION
    - EvmGasLimitOCRJobType, OCRSimulateTransactions and
      OCRDefaultTransactionQueueDepth were all used in an OCR2 context.
      This PR removes their use from this context, and introduces OCR2
      equivalents instead.