### PR TITLE
BCF-2241: Add starknet LOOPp to build and docker

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -61,6 +61,10 @@ install-solana: ## Build & install the chainlink-solana binary.
 install-median: ## Build & install the chainlink-median binary.
 	go install $(GOFLAGS) ./plugins/cmd/chainlink-median
 
+.PHONY: install-starknet
+install-starknet: ## Build & install the chainlink-solana binary.
+	go install $(GOFLAGS) ./plugins/cmd/chainlink-starknet
+
 .PHONY: docker ## Build the chainlink docker image
 docker:
 	docker buildx build \

--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -18,6 +18,7 @@ COPY . .
 RUN make install-chainlink
 RUN make install-solana
 RUN make install-median
+RUN make install-starknet
 
 # Final image: ubuntu with chainlink binary
 FROM ubuntu:20.04
@@ -37,6 +38,8 @@ COPY --from=buildgo /go/bin/chainlink-solana /usr/local/bin/
 ENV CL_SOLANA_CMD chainlink-solana
 COPY --from=buildgo /go/bin/chainlink-median /usr/local/bin/
 ENV CL_MEDIAN_CMD chainlink-median
+COPY --from=buildgo /go/bin/chainlink-starknet /usr/local/bin/
+ENV CL_STARKNET_CMD chainlink-starknet
 
 # Dependency of CosmWasm/wasmd
 COPY --from=buildgo /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@v*/internal/api/libwasmvm.*.so /usr/lib/

--- a/plugins/cmd/chainlink-median/main.go
+++ b/plugins/cmd/chainlink-median/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/plugins"
 )
 
-var (
+const (
 	loggerName = "PluginMedian"
 )
 

--- a/plugins/cmd/chainlink-median/main.go
+++ b/plugins/cmd/chainlink-median/main.go
@@ -12,13 +12,17 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/plugins"
 )
 
+var (
+	loggerName = "PluginMedian"
+)
+
 func main() {
 	envCfg, err := plugins.GetEnvConfig()
 	if err != nil {
 		fmt.Printf("Failed to get environment configuration: %s\n", err)
 		os.Exit(1)
 	}
-	lggr, closeLggr := plugins.NewLogger(envCfg)
+	lggr, closeLggr := plugins.NewLogger(loggerName, envCfg)
 	defer closeLggr()
 	slggr := logger.Sugared(lggr)
 

--- a/plugins/cmd/chainlink-solana/main.go
+++ b/plugins/cmd/chainlink-solana/main.go
@@ -21,13 +21,17 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 )
 
+var (
+	loggerName = "PluginSolana"
+)
+
 func main() {
 	envCfg, err := plugins.GetEnvConfig()
 	if err != nil {
 		fmt.Printf("Failed to get environment configuration: %s\n", err)
 		os.Exit(1)
 	}
-	lggr, closeLggr := plugins.NewLogger(envCfg)
+	lggr, closeLggr := plugins.NewLogger(loggerName, envCfg)
 	defer closeLggr()
 	slggr := logger.Sugared(lggr)
 

--- a/plugins/cmd/chainlink-solana/main.go
+++ b/plugins/cmd/chainlink-solana/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 )
 
-var (
+const (
 	loggerName = "PluginSolana"
 )
 

--- a/plugins/cmd/chainlink-starknet/main.go
+++ b/plugins/cmd/chainlink-starknet/main.go
@@ -21,13 +21,17 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 )
 
+var (
+	loggerName = "PluginStarknet"
+)
+
 func main() {
 	envCfg, err := plugins.GetEnvConfig()
 	if err != nil {
 		fmt.Printf("Failed to get environment configuration: %s\n", err)
 		os.Exit(1)
 	}
-	lggr, closeLggr := plugins.NewLogger(envCfg)
+	lggr, closeLggr := plugins.NewLogger(loggerName, envCfg)
 	defer closeLggr()
 
 	promServer := plugins.NewPromServer(envCfg.PrometheusPort(), lggr)

--- a/plugins/cmd/chainlink-starknet/main.go
+++ b/plugins/cmd/chainlink-starknet/main.go
@@ -21,7 +21,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 )
 
-var (
+const (
 	loggerName = "PluginStarknet"
 )
 

--- a/plugins/logger.go
+++ b/plugins/logger.go
@@ -6,14 +6,14 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
-func NewLogger(cfg LoggingConfig) (logger.Logger, func()) {
+func NewLogger(name string, cfg LoggingConfig) (logger.Logger, func()) {
 	lcfg := logger.Config{
 		LogLevel:    cfg.LogLevel(),
 		JsonConsole: cfg.JSONConsole(),
 		UnixTS:      cfg.LogUnixTimestamps(),
 	}
 	lggr, closeLggr := lcfg.New()
-	lggr = lggr.Named("PluginSolana")
+	lggr = lggr.Named(name)
 	return lggr, func() {
 		if err := closeLggr(); err != nil {
 			fmt.Println("Failed to close logger:", err)


### PR DESCRIPTION
Adds make install-starknet
Includes the starknet executable in the plugin docker image

Fixes a bug in the plugin logger name found in testing