### PR TITLE
Enable verification for Registry20 and 21

### DIFF
--- a/contracts/hardhat.config.ts
+++ b/contracts/hardhat.config.ts
@@ -32,7 +32,7 @@ subtask(TASK_COMPILE_SOLIDITY_GET_SOURCE_PATHS).setAction(
 /**
  * @type import('hardhat/config').HardhatUserConfig
  */
-export default {
+let config = {
   abiExporter: {
     path: './abi',
   },
@@ -47,6 +47,9 @@ export default {
     target: 'ethers-v5',
   },
   networks: {
+    env: {
+      url: process.env.NODE_HTTP_URL || '',
+    },
     hardhat: {
       allowUnlimitedContractSize: Boolean(
         process.env.ALLOW_UNLIMITED_CONTRACT_SIZE,
@@ -113,3 +116,16 @@ export default {
   },
   warnings: !process.env.HIDE_WARNINGS,
 }
+
+if (process.env.NETWORK_NAME && process.env.EXPLORER_API_KEY) {
+  config = {
+    ...config,
+    etherscan: {
+      apiKey: {
+        [process.env.NETWORK_NAME]: process.env.EXPLORER_API_KEY,
+      },
+    },
+  }
+}
+
+export default config

--- a/core/scripts/chaincli/.env.example
+++ b/core/scripts/chaincli/.env.example
@@ -11,6 +11,9 @@ KEEPER_REGISTRY_ADDRESS=<registry-address-from-first-step>
 BOOTSTRAP_NODE_ADDR=<bootstrap-node-addr-from-second-step>
 
 PRIVATE_KEY=<wallet-private-key>
+# EXPLORER_API_KEY and NETWORK_NAME are used for contract verification, ignore them if you don't need it
+EXPLORER_API_KEY=<explorer-api-key>
+NETWORK_NAME=<network-name>
 
 NODE_URL=<wss-rpc-node-addr>
 NODE_HTTP_URL=<https-rpc-node-addr>

--- a/core/scripts/chaincli/README.md
+++ b/core/scripts/chaincli/README.md
@@ -60,7 +60,7 @@ The second address, `KeeperRegistry2.0` is the address you need; in the `.env` f
 
 Note that this command runs contract verification by default, if you don't want to run verification, you can use the `--verify=false` flag.
 
-If you have keeper registry contract deployed already and want to run only contract verification, you can use the following command:
+If you already have keeper registry contract deployed and want to run only contract verification, you can use the following command:
 
 ```shell
 ./chaincli keeper registry verify <contract-addr> <constructor-args>

--- a/core/scripts/chaincli/command/keeper/registry.go
+++ b/core/scripts/chaincli/command/keeper/registry.go
@@ -1,6 +1,8 @@
 package keeper
 
 import (
+	"log"
+
 	"github.com/spf13/cobra"
 
 	"github.com/smartcontractkit/chainlink/core/scripts/chaincli/config"
@@ -21,7 +23,24 @@ var deployRegistryCmd = &cobra.Command{
 		cfg := config.New()
 		hdlr := handler.NewKeeper(cfg)
 
-		hdlr.DeployRegistry(cmd.Context())
+		verify, err := cmd.Flags().GetBool("verify")
+		if err != nil {
+			log.Fatal("failed to get verify flag: ", err)
+		}
+
+		hdlr.DeployRegistry(cmd.Context(), verify)
+	},
+}
+
+var verifyRegistryCmd = &cobra.Command{
+	Use:   "verify",
+	Short: "Verify keeper registry",
+	Long:  `This command verifys a keeper registry.`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cfg := config.New()
+		hdlr := handler.NewKeeper(cfg)
+
+		hdlr.VerifyContract(args...)
 	},
 }
 
@@ -51,7 +70,9 @@ var withdrawFromRegistryCmd = &cobra.Command{
 }
 
 func init() {
+	deployRegistryCmd.Flags().BoolP("verify", "v", true, "Specify if contracts should be verified on Etherscan")
 	registryCmd.AddCommand(deployRegistryCmd)
+	registryCmd.AddCommand(verifyRegistryCmd)
 	registryCmd.AddCommand(updateRegistryCmd)
 	registryCmd.AddCommand(withdrawFromRegistryCmd)
 }

--- a/core/scripts/chaincli/config/config.go
+++ b/core/scripts/chaincli/config/config.go
@@ -22,6 +22,8 @@ const (
 type Config struct {
 	NodeURL              string   `mapstructure:"NODE_URL"`
 	NodeHttpURL          string   `mapstructure:"NODE_HTTP_URL"`
+	ExplorerAPIKey       string   `mapstructure:"EXPLORER_API_KEY"`
+	NetworkName          string   `mapstructure:"NETWORK_NAME"`
 	ChainID              int64    `mapstructure:"CHAIN_ID"`
 	PrivateKey           string   `mapstructure:"PRIVATE_KEY"`
 	LinkTokenAddr        string   `mapstructure:"LINK_TOKEN_ADDR"`

--- a/core/scripts/chaincli/handler/keeper.go
+++ b/core/scripts/chaincli/handler/keeper.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"log"
 	"math/big"
+	"os"
+	"strings"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
@@ -100,16 +102,36 @@ func (k *Keeper) DeployKeepers(ctx context.Context) {
 }
 
 // DeployRegistry deploys a new keeper registry.
-func (k *Keeper) DeployRegistry(ctx context.Context) {
+func (k *Keeper) DeployRegistry(ctx context.Context, verify bool) {
+	if verify {
+		if k.cfg.RegistryVersion != keeper.RegistryVersion_2_1 && k.cfg.RegistryVersion != keeper.RegistryVersion_2_0 {
+			log.Fatal("keeper registry verification is only supported for version 2.0 and 2.1")
+		}
+		if k.cfg.ExplorerAPIKey == "" || k.cfg.ExplorerAPIKey == "<explorer-api-key>" || k.cfg.NetworkName == "" || k.cfg.NetworkName == "<network-name>" {
+			log.Fatal("please set your explore API key and network name in the .env file to verify the registry contract")
+		}
+
+		// Get the current working directory
+		currentDir, err := os.Getwd()
+		if err != nil {
+			log.Fatal("failed to get current working directory: %w", err)
+		}
+
+		// Check if it is the root directory of chaincli
+		if !strings.HasSuffix(currentDir, "core/scripts/chaincli") {
+			log.Fatal("please run the command from the root directory of chaincli to verify the registry")
+		}
+	}
+
 	switch k.cfg.RegistryVersion {
 	case keeper.RegistryVersion_1_1:
 		k.deployRegistry11(ctx)
 	case keeper.RegistryVersion_1_2:
 		k.deployRegistry12(ctx)
 	case keeper.RegistryVersion_2_0:
-		k.deployRegistry20(ctx)
+		k.deployRegistry20(ctx, verify)
 	case keeper.RegistryVersion_2_1:
-		k.deployRegistry21(ctx)
+		k.deployRegistry21(ctx, verify)
 	default:
 		panic("unsupported registry version")
 	}
@@ -176,7 +198,7 @@ func (k *Keeper) prepareRegistry(ctx context.Context) (int64, common.Address, ke
 			registryAddr, keeperRegistry12 = k.deployRegistry12(ctx)
 			deployer = &v12KeeperDeployer{keeperRegistry12}
 		case keeper.RegistryVersion_2_0:
-			registryAddr, keeperRegistry20 = k.deployRegistry20(ctx)
+			registryAddr, keeperRegistry20 = k.deployRegistry20(ctx, true)
 			deployer = &v20KeeperDeployer{KeeperRegistryInterface: keeperRegistry20, cfg: k.cfg}
 		case keeper.RegistryVersion_2_1:
 			registryAddr, keeperRegistry21 = k.deployRegistry21(ctx)
@@ -206,8 +228,33 @@ func (k *Keeper) approveFunds(ctx context.Context, registryAddr common.Address) 
 	log.Println(registryAddr.Hex(), ": KeeperRegistry approved - ", helpers.ExplorerLink(k.cfg.ChainID, approveRegistryTx.Hash()))
 }
 
+func (k *Keeper) VerifyContract(params ...string) {
+	// Change to the contracts directory where the hardhat.config.ts file is located
+	if err := k.changeToContractsDirectory(); err != nil {
+		log.Fatalf("failed to change to directory where the hardhat.config.ts file is located: %v", err)
+	}
+
+	// Append the address and params to the commandArgs slice
+	commandArgs := append([]string{}, params...)
+
+	// Format the command string with the commandArgs
+	command := fmt.Sprintf(
+		"NODE_HTTP_URL='%s' EXPLORER_API_KEY='%s' NETWORK_NAME='%s' pnpm hardhat verify --network env %s",
+		k.cfg.NodeHttpURL,
+		k.cfg.ExplorerAPIKey,
+		k.cfg.NetworkName,
+		strings.Join(commandArgs, " "),
+	)
+
+	fmt.Println("Running command to verify contract: ", command)
+	if err := k.runCommand(command); err != nil {
+		log.Println("Contract verification on Explorer failed: ", err)
+
+	}
+}
+
 // deployRegistry21 deploys a version 2.1 keeper registry
-func (k *Keeper) deployRegistry21(ctx context.Context) (common.Address, *iregistry21.IKeeperRegistryMaster) {
+func (k *Keeper) deployRegistry21(ctx context.Context, verify bool) (common.Address, *iregistry21.IKeeperRegistryMaster) {
 	registryLogicBAddr, tx, _, err := registrylogicb21.DeployKeeperRegistryLogicB(
 		k.buildTxOpts(ctx),
 		k.client,
@@ -222,6 +269,12 @@ func (k *Keeper) deployRegistry21(ctx context.Context) (common.Address, *iregist
 	k.waitDeployment(ctx, tx)
 	log.Println("KeeperRegistryLogicB 2.1 Logic deployed:", registryLogicBAddr.Hex(), "-", helpers.ExplorerLink(k.cfg.ChainID, tx.Hash()))
 
+	// verify KeeperRegistryLogicB
+	if verify {
+		k.VerifyContract(registryLogicBAddr.String(), "0", k.cfg.LinkTokenAddr, k.cfg.LinkETHFeedAddr, k.cfg.FastGasFeedAddr)
+		log.Println("KeeperRegistry LogicB 2.1 verified successfully")
+	}
+
 	registryLogicAAddr, tx, _, err := registrylogica21.DeployKeeperRegistryLogicA(
 		k.buildTxOpts(ctx),
 		k.client,
@@ -232,6 +285,12 @@ func (k *Keeper) deployRegistry21(ctx context.Context) (common.Address, *iregist
 	}
 	k.waitDeployment(ctx, tx)
 	log.Println("KeeperRegistryLogicA 2.1 Logic deployed:", registryLogicAAddr.Hex(), "-", helpers.ExplorerLink(k.cfg.ChainID, tx.Hash()))
+
+	// verify KeeperRegistryLogicA
+	if verify {
+		k.VerifyContract(registryLogicAAddr.String(), registryLogicBAddr.String())
+		log.Println("KeeperRegistry LogicA 2.1 verified successfully")
+	}
 
 	registryAddr, deployKeeperRegistryTx, _, err := registry21.DeployKeeperRegistry(
 		k.buildTxOpts(ctx),
@@ -249,11 +308,17 @@ func (k *Keeper) deployRegistry21(ctx context.Context) (common.Address, *iregist
 		log.Fatal("Failed to attach to deployed contract: ", err)
 	}
 
+	// verify KeeperRegistry
+	if verify {
+		k.VerifyContract(registryAddr.String(), registryLogicAAddr.String())
+		log.Println("KeeperRegistry 2.1 verified successfully")
+	}
+
 	return registryAddr, registryInstance
 }
 
 // deployRegistry20 deploys a version 2.0 keeper registry
-func (k *Keeper) deployRegistry20(ctx context.Context) (common.Address, *registry20.KeeperRegistry) {
+func (k *Keeper) deployRegistry20(ctx context.Context, verify bool) (common.Address, *registry20.KeeperRegistry) {
 	registryLogicAddr, deployKeeperRegistryLogicTx, _, err := registrylogic20.DeployKeeperRegistryLogic(
 		k.buildTxOpts(ctx),
 		k.client,
@@ -268,6 +333,12 @@ func (k *Keeper) deployRegistry20(ctx context.Context) (common.Address, *registr
 	k.waitDeployment(ctx, deployKeeperRegistryLogicTx)
 	log.Println("KeeperRegistry2.0 Logic deployed:", registryLogicAddr.Hex(), "-", helpers.ExplorerLink(k.cfg.ChainID, deployKeeperRegistryLogicTx.Hash()))
 
+	// verify KeeperRegistryLogic
+	if verify {
+		k.VerifyContract(registryLogicAddr.String(), "0", k.cfg.LinkTokenAddr, k.cfg.LinkETHFeedAddr, k.cfg.FastGasFeedAddr)
+		log.Println("KeeperRegistry Logic 2.0 verified successfully")
+	}
+
 	registryAddr, deployKeeperRegistryTx, registryInstance, err := registry20.DeployKeeperRegistry(
 		k.buildTxOpts(ctx),
 		k.client,
@@ -278,6 +349,13 @@ func (k *Keeper) deployRegistry20(ctx context.Context) (common.Address, *registr
 	}
 	k.waitDeployment(ctx, deployKeeperRegistryTx)
 	log.Println("KeeperRegistry2.0 deployed:", registryAddr.Hex(), "-", helpers.ExplorerLink(k.cfg.ChainID, deployKeeperRegistryTx.Hash()))
+
+	// verify KeeperRegistry
+	if verify {
+		k.VerifyContract(registryAddr.String(), registryLogicAddr.String())
+		log.Println("KeeperRegistry 2.0 verified successfully")
+	}
+
 	return registryAddr, registryInstance
 }
 

--- a/core/scripts/chaincli/handler/verify.go
+++ b/core/scripts/chaincli/handler/verify.go
@@ -1,0 +1,48 @@
+package handler
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func (k *Keeper) changeToContractsDirectory() error {
+	// Get the current working directory
+	currentDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get current working directory: %w", err)
+	}
+
+	// Check if hardhat.config.ts exists in the current directory, return if it does
+	if _, err := os.Stat(filepath.Join(currentDir, "hardhat.config.ts")); err == nil {
+		return nil
+	}
+
+	// Command should run from core/scripts/chaincli, so we need to change directory to contracts
+	// Calculate the absolute path of the target directory
+	absPath := filepath.Join(currentDir, "../../../contracts")
+
+	// Change directory
+	if err := os.Chdir(absPath); err != nil {
+		return fmt.Errorf("failed to change directory: %w", err)
+	}
+
+	// Check if hardhat.config.ts exists in the current directory
+	if _, err := os.Stat(filepath.Join(absPath, "hardhat.config.ts")); err != nil {
+		return fmt.Errorf("hardhat.config.ts not found in the current directory")
+	}
+
+	log.Printf("Successfully changed to directory %s\n", absPath)
+
+	return nil
+}
+
+func (k *Keeper) runCommand(command string) error {
+	cmd := exec.Command("bash", "-c", command)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+
+	return cmd.Run()
+}


### PR DESCRIPTION
Need to update .env to add API_KEY variable.

To use verification, 

go to chainlink/core/scripts/chaincli, 
run go build
run ./chaincli keeper registry deploy --verify

currently support only v2.1 and evm chains.