### PR TITLE
BCF-2331: cleanup starknet chainopts

### DIFF
--- a/core/chains/starknet/chain_set.go
+++ b/core/chains/starknet/chain_set.go
@@ -10,12 +10,10 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/starknet/types"
-	coreconfig "github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
 type ChainSetOpts struct {
-	Config coreconfig.AppConfig
 	Logger logger.Logger
 	// the implementation used here needs to be co-ordinated with the starknet transaction manager keystore adapter
 	KeyStore loop.Keystore
@@ -29,9 +27,6 @@ func (o *ChainSetOpts) Name() string {
 func (o *ChainSetOpts) Validate() (err error) {
 	required := func(s string) error {
 		return errors.Errorf("%s is required", s)
-	}
-	if o.Config == nil {
-		err = multierr.Append(err, required("Config"))
 	}
 	if o.Logger == nil {
 		err = multierr.Append(err, required("Logger'"))

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -345,7 +345,6 @@ func (r relayerFactory) NewStarkNet(ks keystore.StarkNet) (loop.Relayer, error) 
 			Logger:   starkLggr,
 			KeyStore: loopKs,
 			Configs:  starknet.NewConfigs(cfgs),
-			Config:   r.GeneralConfig,
 		}
 		chainSet, err := starknet.NewChainSet(opts, cfgs)
 		if err != nil {

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -480,7 +480,6 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 		}
 
 		opts := starknet.ChainSetOpts{
-			Config:   cfg,
 			Logger:   starkLggr,
 			KeyStore: &keystore.StarknetLooppSigner{StarkNet: keyStore.StarkNet()},
 			Configs:  starknet.NewConfigs(cfgs),


### PR DESCRIPTION
remove redunant and broadly scoped configuration that is not used.