### PR TITLE
[356] Bump chainlink-env

### DIFF
--- a/integration-tests/actions/automation_ocr_helpers.go
+++ b/integration-tests/actions/automation_ocr_helpers.go
@@ -10,11 +10,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/lib/pq"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 
+	"github.com/smartcontractkit/chainlink-env/logging"
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
-	"github.com/smartcontractkit/chainlink-testing-framework/utils"
 	"github.com/smartcontractkit/chainlink/integration-tests/client"
 	"github.com/smartcontractkit/chainlink/integration-tests/contracts"
 	"github.com/smartcontractkit/chainlink/integration-tests/contracts/ethereum"
@@ -44,7 +45,7 @@ func BuildAutoOCR2ConfigVarsWithKeyIndex(
 	deltaStage time.Duration,
 	keyIndex int,
 ) (contracts.OCRv2Config, error) {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	S, oracleIdentities, err := GetOracleIdentitiesWithKeyIndex(chainlinkNodes, keyIndex)
 	if err != nil {
 		return contracts.OCRv2Config{}, err
@@ -98,7 +99,7 @@ func BuildAutoOCR2ConfigVarsWithKeyIndex(
 		return contracts.OCRv2Config{}, err
 	}
 
-	l.Info().Msg("Done building OCR config")
+	log.Info().Msg("Done building OCR config")
 	return contracts.OCRv2Config{
 		Signers:               signers,
 		Transmitters:          transmitters,
@@ -117,7 +118,7 @@ func CreateOCRKeeperJobs(
 	chainID int64,
 	keyIndex int,
 ) {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	bootstrapNode := chainlinkNodes[0]
 	bootstrapNode.InternalIP()
 	bootstrapP2PIds, err := bootstrapNode.MustReadP2PKeys()
@@ -176,7 +177,7 @@ func CreateOCRKeeperJobs(
 		_, err = chainlinkNodes[nodeIndex].MustCreateJob(&autoOCR2JobSpec)
 		require.NoError(t, err, "Shouldn't fail creating OCR Task job on OCR node %d err: %+v", nodeIndex+1, err)
 	}
-	l.Info().Msg("Done creating OCR automation jobs")
+	log.Info().Msg("Done creating OCR automation jobs")
 }
 
 // DeployAutoOCRRegistryAndRegistrar registry and registrar

--- a/integration-tests/actions/keeper_helpers.go
+++ b/integration-tests/actions/keeper_helpers.go
@@ -2,17 +2,19 @@ package actions
 
 import (
 	"fmt"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 	"math"
 	"math/big"
 	"strconv"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/common/hexutil"
+	"github.com/rs/zerolog/log"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-env/logging"
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
-	"github.com/smartcontractkit/chainlink-testing-framework/utils"
 
 	"github.com/smartcontractkit/chainlink/integration-tests/client"
 	"github.com/smartcontractkit/chainlink/integration-tests/contracts"
@@ -361,7 +363,7 @@ func RegisterUpkeepContractsWithCheckData(
 	upkeepAddresses []string,
 	checkData [][]byte,
 ) []*big.Int {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	registrationTxHashes := make([]common.Hash, 0)
 	upkeepIds := make([]*big.Int, 0)
 	for contractCount, upkeepAddress := range upkeepAddresses {
@@ -379,7 +381,7 @@ func RegisterUpkeepContractsWithCheckData(
 		require.NoError(t, err, "Encoding the register request shouldn't fail")
 		tx, err := linkToken.TransferAndCall(registrar.Address(), linkFunds, req)
 		require.NoError(t, err, "Error registering the upkeep consumer to the registrar")
-		l.Debug().
+		log.Debug().
 			Str("Contract Address", upkeepAddress).
 			Int("Number", contractCount+1).
 			Int("Out Of", numberOfContracts).
@@ -408,13 +410,13 @@ func RegisterUpkeepContractsWithCheckData(
 			}
 		}
 		require.NotNil(t, upkeepId, "Upkeep ID should be found after registration")
-		l.Debug().
+		log.Debug().
 			Str("TxHash", txHash.String()).
 			Str("Upkeep ID", upkeepId.String()).
 			Msg("Found upkeepId in tx hash")
 		upkeepIds = append(upkeepIds, upkeepId)
 	}
-	l.Info().Msg("Successfully registered all Keeper Consumer Contracts")
+	log.Info().Msg("Successfully registered all Keeper Consumer Contracts")
 	return upkeepIds
 }
 
@@ -424,7 +426,7 @@ func DeployKeeperConsumers(
 	client blockchain.EVMClient,
 	numberOfContracts int,
 ) []contracts.KeeperConsumer {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	keeperConsumerContracts := make([]contracts.KeeperConsumer, 0)
 
 	for contractCount := 0; contractCount < numberOfContracts; contractCount++ {
@@ -432,7 +434,7 @@ func DeployKeeperConsumers(
 		keeperConsumerInstance, err := contractDeployer.DeployKeeperConsumer(big.NewInt(5))
 		require.NoError(t, err, "Deploying KeeperConsumer instance %d shouldn't fail", contractCount+1)
 		keeperConsumerContracts = append(keeperConsumerContracts, keeperConsumerInstance)
-		l.Debug().
+		log.Debug().
 			Str("Contract Address", keeperConsumerInstance.Address()).
 			Int("Number", contractCount+1).
 			Int("Out Of", numberOfContracts).
@@ -444,7 +446,7 @@ func DeployKeeperConsumers(
 	}
 	err := client.WaitForEvents()
 	require.NoError(t, err, "Failed waiting for to deploy all keeper consumer contracts")
-	l.Info().Msg("Successfully deployed all Keeper Consumer Contracts")
+	log.Info().Msg("Successfully deployed all Keeper Consumer Contracts")
 
 	return keeperConsumerContracts
 }
@@ -459,7 +461,7 @@ func DeployKeeperConsumersPerformance(
 	checkGasToBurn, // How much gas should be burned on checkUpkeep() calls
 	performGasToBurn int64, // How much gas should be burned on performUpkeep() calls
 ) []contracts.KeeperConsumerPerformance {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	upkeeps := make([]contracts.KeeperConsumerPerformance, 0)
 
 	for contractCount := 0; contractCount < numberOfContracts; contractCount++ {
@@ -472,7 +474,7 @@ func DeployKeeperConsumersPerformance(
 		)
 		require.NoError(t, err, "Deploying KeeperConsumerPerformance instance %d shouldn't fail", contractCount+1)
 		upkeeps = append(upkeeps, keeperConsumerInstance)
-		l.Debug().
+		log.Debug().
 			Str("Contract Address", keeperConsumerInstance.Address()).
 			Int("Number", contractCount+1).
 			Int("Out Of", numberOfContracts).
@@ -484,7 +486,7 @@ func DeployKeeperConsumersPerformance(
 	}
 	err := client.WaitForEvents()
 	require.NoError(t, err, "Failed waiting for to deploy all keeper consumer contracts")
-	l.Info().Msg("Successfully deployed all Keeper Consumer Contracts")
+	log.Info().Msg("Successfully deployed all Keeper Consumer Contracts")
 
 	return upkeeps
 }
@@ -496,14 +498,14 @@ func DeployPerformDataChecker(
 	numberOfContracts int,
 	expectedData []byte,
 ) []contracts.KeeperPerformDataChecker {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	upkeeps := make([]contracts.KeeperPerformDataChecker, 0)
 
 	for contractCount := 0; contractCount < numberOfContracts; contractCount++ {
 		performDataCheckerInstance, err := contractDeployer.DeployKeeperPerformDataChecker(expectedData)
 		require.NoError(t, err, "Deploying KeeperPerformDataChecker instance %d shouldn't fail", contractCount+1)
 		upkeeps = append(upkeeps, performDataCheckerInstance)
-		l.Debug().
+		log.Debug().
 			Str("Contract Address", performDataCheckerInstance.Address()).
 			Int("Number", contractCount+1).
 			Int("Out Of", numberOfContracts).
@@ -515,7 +517,7 @@ func DeployPerformDataChecker(
 	}
 	err := client.WaitForEvents()
 	require.NoError(t, err, "Failed waiting for to deploy all keeper perform data checker contracts")
-	l.Info().Msg("Successfully deployed all PerformDataChecker Contracts")
+	log.Info().Msg("Successfully deployed all PerformDataChecker Contracts")
 
 	return upkeeps
 }
@@ -528,7 +530,7 @@ func DeployUpkeepCounters(
 	testRange *big.Int,
 	interval *big.Int,
 ) []contracts.UpkeepCounter {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	upkeepCounters := make([]contracts.UpkeepCounter, 0)
 
 	for contractCount := 0; contractCount < numberOfContracts; contractCount++ {
@@ -536,7 +538,7 @@ func DeployUpkeepCounters(
 		upkeepCounter, err := contractDeployer.DeployUpkeepCounter(testRange, interval)
 		require.NoError(t, err, "Deploying KeeperConsumer instance %d shouldn't fail", contractCount+1)
 		upkeepCounters = append(upkeepCounters, upkeepCounter)
-		l.Debug().
+		log.Debug().
 			Str("Contract Address", upkeepCounter.Address()).
 			Int("Number", contractCount+1).
 			Int("Out Of", numberOfContracts).
@@ -548,7 +550,7 @@ func DeployUpkeepCounters(
 	}
 	err := client.WaitForEvents()
 	require.NoError(t, err, "Failed waiting for to deploy all keeper consumer contracts")
-	l.Info().Msg("Successfully deployed all Keeper Consumer Contracts")
+	log.Info().Msg("Successfully deployed all Keeper Consumer Contracts")
 
 	return upkeepCounters
 }
@@ -561,7 +563,7 @@ func DeployUpkeepPerformCounterRestrictive(
 	testRange *big.Int,
 	averageEligibilityCadence *big.Int,
 ) []contracts.UpkeepPerformCounterRestrictive {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	upkeepCounters := make([]contracts.UpkeepPerformCounterRestrictive, 0)
 
 	for contractCount := 0; contractCount < numberOfContracts; contractCount++ {
@@ -569,7 +571,7 @@ func DeployUpkeepPerformCounterRestrictive(
 		upkeepCounter, err := contractDeployer.DeployUpkeepPerformCounterRestrictive(testRange, averageEligibilityCadence)
 		require.NoError(t, err, "Deploying KeeperConsumer instance %d shouldn't fail", contractCount+1)
 		upkeepCounters = append(upkeepCounters, upkeepCounter)
-		l.Debug().
+		log.Debug().
 			Str("Contract Address", upkeepCounter.Address()).
 			Int("Number", contractCount+1).
 			Int("Out Of", numberOfContracts).
@@ -581,7 +583,7 @@ func DeployUpkeepPerformCounterRestrictive(
 	}
 	err := client.WaitForEvents()
 	require.NoError(t, err, "Failed waiting for to deploy all keeper consumer contracts")
-	l.Info().Msg("Successfully deployed all Keeper Consumer Contracts")
+	log.Info().Msg("Successfully deployed all Keeper Consumer Contracts")
 
 	return upkeepCounters
 }

--- a/integration-tests/actions/ocr2vrf_actions/ocr2vrf_config_helpers.go
+++ b/integration-tests/actions/ocr2vrf_actions/ocr2vrf_config_helpers.go
@@ -11,12 +11,13 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/lib/pq"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	"go.dedis.ch/kyber/v3"
 	"go.dedis.ch/kyber/v3/group/edwards25519"
 	"gopkg.in/guregu/null.v4"
 
-	"github.com/smartcontractkit/chainlink-testing-framework/utils"
+	"github.com/smartcontractkit/chainlink-env/logging"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/chaintype"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
@@ -39,11 +40,11 @@ func CreateOCR2VRFJobs(
 	chainID int64,
 	keyIndex int,
 ) {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	p2pV2Bootstrapper := createBootstrapJob(t, bootstrapNode, OCR2VRFPluginConfig.DKGConfig.DKGContractAddress, chainID)
 
 	createNonBootstrapJobs(t, nonBootstrapNodes, OCR2VRFPluginConfig, chainID, keyIndex, p2pV2Bootstrapper)
-	l.Info().Msg("Done creating OCR automation jobs")
+	log.Info().Msg("Done creating OCR automation jobs")
 }
 
 func createNonBootstrapJobs(
@@ -120,7 +121,7 @@ func BuildOCR2DKGConfigVars(
 	t *testing.T,
 	ocr2VRFPluginConfig *OCR2VRFPluginConfig,
 ) contracts.OCRv2Config {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	var onchainPublicKeys []common.Address
 	for _, onchainPublicKey := range ocr2VRFPluginConfig.OCR2Config.OnchainPublicKeys {
 		onchainPublicKeys = append(onchainPublicKeys, common.HexToAddress(onchainPublicKey))
@@ -192,7 +193,7 @@ func BuildOCR2DKGConfigVars(
 		)
 	require.NoError(t, err, "Shouldn't fail building OCR config")
 
-	l.Info().Msg("Done building DKG OCR config")
+	log.Info().Msg("Done building DKG OCR config")
 	return contracts.OCRv2Config{
 		Signers:               onchainPublicKeys,
 		Transmitters:          transmitters,
@@ -272,7 +273,7 @@ func BuildOCR2VRFConfigVars(
 	t *testing.T,
 	ocr2VRFPluginConfig *OCR2VRFPluginConfig,
 ) contracts.OCRv2Config {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	var onchainPublicKeys []common.Address
 	for _, onchainPublicKey := range ocr2VRFPluginConfig.OCR2Config.OnchainPublicKeys {
 		onchainPublicKeys = append(onchainPublicKeys, common.HexToAddress(onchainPublicKey))
@@ -323,7 +324,7 @@ func BuildOCR2VRFConfigVars(
 		)
 	require.NoError(t, err)
 
-	l.Info().Msg("Done building VRF OCR config")
+	log.Info().Msg("Done building VRF OCR config")
 	return contracts.OCRv2Config{
 		Signers:               onchainPublicKeys,
 		Transmitters:          transmitters,

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/rs/zerolog v1.29.1
 	github.com/slack-go/slack v0.12.2
-	github.com/smartcontractkit/chainlink-env v0.32.5
+	github.com/smartcontractkit/chainlink-env v0.32.6
 	github.com/smartcontractkit/chainlink-testing-framework v1.11.6
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20230606215712-82b910bef5c1

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1367,8 +1367,8 @@ github.com/slack-go/slack v0.12.2/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQ
 github.com/smartcontractkit/caigo v0.0.0-20230530082629-53a5a4bdb25e h1:XY8DncHICYQ1WDVpoXM7Tv3tztNHa1/DctDlSmqgU10=
 github.com/smartcontractkit/caigo v0.0.0-20230530082629-53a5a4bdb25e/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230525203711-20bed74ac906 h1:u7Lw7oqLEjADlJPJQnzlCLNSbj038QttaKY0lCa3V78=
-github.com/smartcontractkit/chainlink-env v0.32.5 h1:xwlaie96Q+BO//Wl4DHyzwktgLg/62j/JiX12hUSV0A=
-github.com/smartcontractkit/chainlink-env v0.32.5/go.mod h1:9c0Czq4a6wZKY20BcoAlK29DnejQIiLo/MwKYtSFnHk=
+github.com/smartcontractkit/chainlink-env v0.32.6 h1:3fhHMqp/uXR4ocvrW/jTYqRABUT5tmKhijtvw05QG0g=
+github.com/smartcontractkit/chainlink-env v0.32.6/go.mod h1:9c0Czq4a6wZKY20BcoAlK29DnejQIiLo/MwKYtSFnHk=
 github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230606234201-cca3103bf8a6 h1:dQG7RYxvMk9b/oJZ7sPDdm8oloFnH+YO6qLvto4Y7Nc=
 github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230606234201-cca3103bf8a6/go.mod h1:MfZBUifutkv3aK7abyw5YmTJbqt8iFwcQDFikrxC/uI=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230531071550-c058f7c3964f h1:XtumoxAyCO4JnDbhUjD+BT3H3NohfpVG3IOLKWE5m+k=

--- a/integration-tests/performance/cron_test.go
+++ b/integration-tests/performance/cron_test.go
@@ -30,7 +30,6 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	logging.Init()
 	os.Exit(m.Run())
 }
 
@@ -108,6 +107,7 @@ func TestCronPerformance(t *testing.T) {
 }
 
 func setupCronTest(t *testing.T) (testEnvironment *environment.Environment) {
+	logging.Init(t)
 	network := networks.SelectedNetwork
 	evmConfig := ethereum.New(nil)
 	if !network.Simulated {
@@ -119,6 +119,10 @@ func setupCronTest(t *testing.T) (testEnvironment *environment.Environment) {
 	}
 	baseTOML := `[WebServer]
 HTTPWriteTimout = '300s'`
+	cd, err := chainlink.NewDeployment(1, map[string]interface{}{
+		"toml": client.AddNetworksConfig(baseTOML, network),
+	})
+	require.NoError(t, err, "Error creating chainlink deployment")
 	testEnvironment = environment.New(&environment.Config{
 		NamespacePrefix: fmt.Sprintf("performance-cron-%s", strings.ReplaceAll(strings.ToLower(network.Name), " ", "-")),
 		Test:            t,
@@ -126,10 +130,8 @@ HTTPWriteTimout = '300s'`
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
 		AddHelm(evmConfig).
-		AddHelm(chainlink.New(0, map[string]interface{}{
-			"toml": client.AddNetworksConfig(baseTOML, network),
-		}))
-	err := testEnvironment.Run()
+		AddHelmCharts(cd)
+	err = testEnvironment.Run()
 	require.NoError(t, err, "Error launching test environment")
 	return testEnvironment
 }

--- a/integration-tests/performance/directrequest_test.go
+++ b/integration-tests/performance/directrequest_test.go
@@ -9,16 +9,17 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-env/environment"
+	"github.com/smartcontractkit/chainlink-env/logging"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/chainlink"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/ethereum"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/mockserver"
 	mockservercfg "github.com/smartcontractkit/chainlink-env/pkg/helm/mockserver-cfg"
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
 	ctfClient "github.com/smartcontractkit/chainlink-testing-framework/client"
-	"github.com/smartcontractkit/chainlink-testing-framework/utils"
 
 	"github.com/smartcontractkit/chainlink/integration-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/client"
@@ -30,7 +31,7 @@ import (
 )
 
 func TestDirectRequestPerformance(t *testing.T) {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	testEnvironment := setupDirectRequestTest(t)
 	if testEnvironment.WillUseRemoteRunner() {
 		return
@@ -110,7 +111,7 @@ func TestDirectRequestPerformance(t *testing.T) {
 			d, err := consumer.Data(context.Background())
 			g.Expect(err).ShouldNot(gomega.HaveOccurred(), "Getting data from consumer contract shouldn't fail")
 			g.Expect(d).ShouldNot(gomega.BeNil(), "Expected the initial on chain data to be nil")
-			l.Debug().Int64("Data", d.Int64()).Msg("Found on chain")
+			log.Debug().Int64("Data", d.Int64()).Msg("Found on chain")
 			g.Expect(d.Int64()).Should(gomega.BeNumerically("==", 5), "Expected the on-chain data to be 5, but found %d", d.Int64())
 		}, "2m", "1s").Should(gomega.Succeed())
 	}
@@ -139,6 +140,10 @@ func setupDirectRequestTest(t *testing.T) (testEnvironment *environment.Environm
 	}
 	baseTOML := `[WebServer]
 HTTPWriteTimout = '300s'`
+	cd, err := chainlink.NewDeployment(1, map[string]interface{}{
+		"toml": client.AddNetworksConfig(baseTOML, network),
+	})
+	require.NoError(t, err, "Error creating chainlink deployment")
 	testEnvironment = environment.New(&environment.Config{
 		NamespacePrefix: fmt.Sprintf("performance-cron-%s", strings.ReplaceAll(strings.ToLower(network.Name), " ", "-")),
 		Test:            t,
@@ -146,10 +151,8 @@ HTTPWriteTimout = '300s'`
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
 		AddHelm(evmConfig).
-		AddHelm(chainlink.New(0, map[string]interface{}{
-			"toml": client.AddNetworksConfig(baseTOML, network),
-		}))
-	err := testEnvironment.Run()
+		AddHelmCharts(cd)
+	err = testEnvironment.Run()
 	require.NoError(t, err, "Error launching test environment")
 	return testEnvironment
 }

--- a/integration-tests/performance/flux_test.go
+++ b/integration-tests/performance/flux_test.go
@@ -10,16 +10,17 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-env/environment"
+	"github.com/smartcontractkit/chainlink-env/logging"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/chainlink"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/ethereum"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/mockserver"
 	mockservercfg "github.com/smartcontractkit/chainlink-env/pkg/helm/mockserver-cfg"
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
 	ctfClient "github.com/smartcontractkit/chainlink-testing-framework/client"
-	"github.com/smartcontractkit/chainlink-testing-framework/utils"
 
 	"github.com/smartcontractkit/chainlink/integration-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/client"
@@ -29,7 +30,7 @@ import (
 )
 
 func TestFluxPerformance(t *testing.T) {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	testEnvironment, testNetwork := setupFluxTest(t)
 	if testEnvironment.WillUseRemoteRunner() {
 		return
@@ -85,7 +86,7 @@ func TestFluxPerformance(t *testing.T) {
 	require.NoError(t, err, "Waiting for event subscriptions in nodes shouldn't fail")
 	oracles, err := fluxInstance.GetOracles(context.Background())
 	require.NoError(t, err, "Getting oracle details from the Flux aggregator contract shouldn't fail")
-	l.Info().Str("Oracles", strings.Join(oracles, ",")).Msg("Oracles set")
+	log.Info().Str("Oracles", strings.Join(oracles, ",")).Msg("Oracles set")
 
 	adapterFullURL := fmt.Sprintf("%s%s", mockServer.Config.ClusterURL, adapterPath)
 	bta := &client.BridgeTypeAttributes{
@@ -121,7 +122,7 @@ func TestFluxPerformance(t *testing.T) {
 		require.NoError(t, err, "Waiting for event subscriptions in nodes shouldn't fail")
 		data, err := fluxInstance.GetContractData(context.Background())
 		require.NoError(t, err, "Getting contract data from flux aggregator contract shouldn't fail")
-		l.Info().Interface("Data", data).Msg("Round data")
+		log.Info().Interface("Data", data).Msg("Round data")
 		require.Equal(t, int64(1e5), data.LatestRoundData.Answer.Int64(),
 			"Expected latest round answer to be %d, but found %d", int64(1e5), data.LatestRoundData.Answer.Int64())
 		require.Equal(t, int64(1), data.LatestRoundData.RoundId.Int64(),
@@ -149,7 +150,7 @@ func TestFluxPerformance(t *testing.T) {
 			"Expected available funds to be %d, but found %d", int64(999999999999999994), data.AvailableFunds.Int64())
 		require.Equal(t, int64(6), data.AllocatedFunds.Int64(),
 			"Expected allocated funds to be %d, but found %d", int64(6), data.AllocatedFunds.Int64())
-		l.Info().Interface("data", data).Msg("Round data")
+		log.Info().Interface("data", data).Msg("Round data")
 
 		for _, oracleAddr := range nodeAddresses {
 			payment, _ := fluxInstance.WithdrawablePayment(context.Background(), oracleAddr)
@@ -186,6 +187,10 @@ HTTPWriteTimout = '300s'
 
 [OCR]
 Enabled = true`
+	cd, err := chainlink.NewDeployment(3, map[string]interface{}{
+		"toml": client.AddNetworksConfig(baseTOML, testNetwork),
+	})
+	require.NoError(t, err, "Error creating chainlink deployment")
 	testEnvironment = environment.New(&environment.Config{
 		NamespacePrefix: fmt.Sprintf("performance-flux-%s", strings.ReplaceAll(strings.ToLower(testNetwork.Name), " ", "-")),
 		Test:            t,
@@ -193,11 +198,8 @@ Enabled = true`
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
 		AddHelm(evmConf).
-		AddHelm(chainlink.New(0, map[string]interface{}{
-			"toml":     client.AddNetworksConfig(baseTOML, testNetwork),
-			"replicas": 3,
-		}))
-	err := testEnvironment.Run()
+		AddHelmCharts(cd)
+	err = testEnvironment.Run()
 	require.NoError(t, err, "Error running test environment")
 	return testEnvironment, testNetwork
 }

--- a/integration-tests/performance/ocr_test.go
+++ b/integration-tests/performance/ocr_test.go
@@ -105,6 +105,10 @@ Enabled = true
 Enabled = true
 ListenIP = '0.0.0.0'
 ListenPort = 6690`
+	cd, err := chainlink.NewDeployment(6, map[string]interface{}{
+		"toml": client.AddNetworksConfig(baseTOML, testNetwork),
+	})
+	require.NoError(t, err, "Error creating chainlink deployment")
 	testEnvironment = environment.New(&environment.Config{
 		NamespacePrefix: fmt.Sprintf("performance-ocr-%s", strings.ReplaceAll(strings.ToLower(testNetwork.Name), " ", "-")),
 		Test:            t,
@@ -112,11 +116,8 @@ ListenPort = 6690`
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
 		AddHelm(evmConfig).
-		AddHelm(chainlink.New(0, map[string]interface{}{
-			"toml":     client.AddNetworksConfig(baseTOML, testNetwork),
-			"replicas": 6,
-		}))
-	err := testEnvironment.Run()
+		AddHelmCharts(cd)
+	err = testEnvironment.Run()
 	require.NoError(t, err, "Error running test environment")
 	return testEnvironment, testNetwork
 }

--- a/integration-tests/reorg/automation_reorg_test.go
+++ b/integration-tests/reorg/automation_reorg_test.go
@@ -126,6 +126,8 @@ const (
 func TestAutomationReorg(t *testing.T) {
 	network := networks.SelectedNetwork
 
+	cd, err := chainlink.NewDeployment(numberOfNodes, defaultAutomationSettings)
+	require.NoError(t, err, "Error creating chainlink deployment")
 	testEnvironment := environment.
 		New(&environment.Config{
 			NamespacePrefix: fmt.Sprintf("automation-reorg-%d", automationReorgBlocks),
@@ -135,11 +137,9 @@ func TestAutomationReorg(t *testing.T) {
 		AddChart(blockscout.New(&blockscout.Props{
 			Name:    "geth-blockscout",
 			WsURL:   activeEVMNetwork.URL,
-			HttpURL: activeEVMNetwork.HTTPURLs[0]}))
-	for i := 0; i < numberOfNodes; i++ {
-		testEnvironment.AddHelm(chainlink.New(i, defaultAutomationSettings))
-	}
-	err := testEnvironment.Run()
+			HttpURL: activeEVMNetwork.HTTPURLs[0]})).
+		AddHelmCharts(cd)
+	err = testEnvironment.Run()
 	require.NoError(t, err, "Error setting up test environment")
 
 	if testEnvironment.WillUseRemoteRunner() {

--- a/integration-tests/reorg/reorg_test.go
+++ b/integration-tests/reorg/reorg_test.go
@@ -53,7 +53,6 @@ var (
 )
 
 func TestMain(m *testing.M) {
-	logging.Init()
 	os.Exit(m.Run())
 }
 
@@ -71,6 +70,7 @@ func CleanupReorgTest(
 }
 
 func TestDirectRequestReorg(t *testing.T) {
+	logging.Init(t)
 	testEnvironment := environment.New(&environment.Config{
 		TTL:  1 * time.Hour,
 		Test: t,
@@ -102,7 +102,7 @@ func TestDirectRequestReorg(t *testing.T) {
 	// related https://app.shortcut.com/chainlinklabs/story/38295/creating-an-evm-chain-via-cli-or-api-immediately-polling-the-nodes-and-returning-an-error
 	// node must work and reconnect even if network is not working
 	time.Sleep(90 * time.Second)
-	err = testEnvironment.AddHelm(chainlink.New(0, map[string]interface{}{
+	chainlinkDeployment, err := chainlink.NewDeployment(1, map[string]interface{}{
 		"env": map[string]interface{}{
 			"eth_url":                        "ws://geth-ethereum-geth:8546",
 			"eth_http_url":                   "http://geth-ethereum-geth:8544",
@@ -110,7 +110,9 @@ func TestDirectRequestReorg(t *testing.T) {
 			"ETH_FINALITY_DEPTH":             EVMFinalityDepth,
 			"ETH_HEAD_TRACKER_HISTORY_DEPTH": EVMTrackerHistoryDepth,
 		},
-	})).Run()
+	})
+	require.NoError(t, err, "Error building Chainlink deployment")
+	err = testEnvironment.AddHelmCharts(chainlinkDeployment).Run()
 	require.NoError(t, err, "Error adding to test environment")
 
 	chainClient, err := blockchain.NewEVMClient(networkSettings, testEnvironment)

--- a/integration-tests/smoke/cron_test.go
+++ b/integration-tests/smoke/cron_test.go
@@ -80,6 +80,10 @@ func setupCronTest(t *testing.T) (testEnvironment *environment.Environment) {
 			WsURLs:      network.URLs,
 		})
 	}
+	cd, err := chainlink.NewDeployment(1, map[string]interface{}{
+		"toml": client.AddNetworksConfig("", network),
+	})
+	require.NoError(t, err, "Error creating chainlink deployment")
 	testEnvironment = environment.New(&environment.Config{
 		NamespacePrefix: fmt.Sprintf("smoke-cron-%s", strings.ReplaceAll(strings.ToLower(network.Name), " ", "-")),
 		Test:            t,
@@ -87,10 +91,8 @@ func setupCronTest(t *testing.T) (testEnvironment *environment.Environment) {
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
 		AddHelm(evmConfig).
-		AddHelm(chainlink.New(0, map[string]interface{}{
-			"toml": client.AddNetworksConfig("", network),
-		}))
-	err := testEnvironment.Run()
+		AddHelmCharts(cd)
+	err = testEnvironment.Run()
 	require.NoError(t, err, "Error launching test environment")
 	return testEnvironment
 }

--- a/integration-tests/smoke/flux_test.go
+++ b/integration-tests/smoke/flux_test.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/google/uuid"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-env/environment"
+	"github.com/smartcontractkit/chainlink-env/logging"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/chainlink"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/ethereum"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/mockserver"
@@ -30,7 +32,7 @@ import (
 
 func TestFluxBasic(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	testEnvironment, testNetwork := setupFluxTest(t)
 	if testEnvironment.WillUseRemoteRunner() {
 		return
@@ -91,7 +93,7 @@ func TestFluxBasic(t *testing.T) {
 	require.NoError(t, err, "Waiting for event subscriptions in nodes shouldn't fail")
 	oracles, err := fluxInstance.GetOracles(context.Background())
 	require.NoError(t, err, "Getting oracle details from the Flux aggregator contract shouldn't fail")
-	l.Info().Str("Oracles", strings.Join(oracles, ",")).Msg("Oracles set")
+	log.Info().Str("Oracles", strings.Join(oracles, ",")).Msg("Oracles set")
 
 	adapterFullURL := fmt.Sprintf("%s%s", mockServer.Config.ClusterURL, adapterPath)
 	bta := &client.BridgeTypeAttributes{
@@ -123,7 +125,7 @@ func TestFluxBasic(t *testing.T) {
 	require.NoError(t, err, "Waiting for event subscriptions in nodes shouldn't fail")
 	data, err := fluxInstance.GetContractData(context.Background())
 	require.NoError(t, err, "Getting contract data from flux aggregator contract shouldn't fail")
-	l.Info().Interface("Data", data).Msg("Round data")
+	log.Info().Interface("Data", data).Msg("Round data")
 	require.Equal(t, int64(1e5), data.LatestRoundData.Answer.Int64(),
 		"Expected latest round answer to be %d, but found %d", int64(1e5), data.LatestRoundData.Answer.Int64())
 	require.Equal(t, int64(1), data.LatestRoundData.RoundId.Int64(),
@@ -151,7 +153,7 @@ func TestFluxBasic(t *testing.T) {
 		"Expected available funds to be %d, but found %d", int64(999999999999999994), data.AvailableFunds.Int64())
 	require.Equal(t, int64(6), data.AllocatedFunds.Int64(),
 		"Expected allocated funds to be %d, but found %d", int64(6), data.AllocatedFunds.Int64())
-	l.Info().Interface("data", data).Msg("Round data")
+	log.Info().Interface("data", data).Msg("Round data")
 
 	for _, oracleAddr := range nodeAddresses {
 		payment, _ := fluxInstance.WithdrawablePayment(context.Background(), oracleAddr)
@@ -172,6 +174,10 @@ func setupFluxTest(t *testing.T) (testEnvironment *environment.Environment, test
 	}
 	baseTOML := `[OCR]
 Enabled = true`
+	cd, err := chainlink.NewDeployment(3, map[string]interface{}{
+		"toml": client.AddNetworksConfig(baseTOML, testNetwork),
+	})
+	require.NoError(t, err, "Error creating chainlink deployment")
 	testEnvironment = environment.New(&environment.Config{
 		NamespacePrefix: fmt.Sprintf("smoke-flux-%s", strings.ReplaceAll(strings.ToLower(testNetwork.Name), " ", "-")),
 		Test:            t,
@@ -179,11 +185,8 @@ Enabled = true`
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
 		AddHelm(evmConf).
-		AddHelm(chainlink.New(0, map[string]interface{}{
-			"toml":     client.AddNetworksConfig(baseTOML, testNetwork),
-			"replicas": 3,
-		}))
-	err := testEnvironment.Run()
+		AddHelmCharts(cd)
+	err = testEnvironment.Run()
 	require.NoError(t, err, "Error running test environment")
 	return testEnvironment, testNetwork
 }

--- a/integration-tests/smoke/forwarder_ocr_test.go
+++ b/integration-tests/smoke/forwarder_ocr_test.go
@@ -121,6 +121,10 @@ ListenIP = '0.0.0.0'
 ListenPort = 6690`
 	networkDetailTOML := `[EVM.Transactions]
 ForwardersEnabled = true`
+	cd, err := chainlink.NewDeployment(6, map[string]interface{}{
+		"toml": client.AddNetworkDetailedConfig(baseTOML, networkDetailTOML, testNetwork),
+	})
+	require.NoError(t, err, "Error creating chainlink deployment")
 	testEnvironment = environment.New(&environment.Config{
 		NamespacePrefix: fmt.Sprintf("smoke-ocr-forwarder-%s", strings.ReplaceAll(strings.ToLower(testNetwork.Name), " ", "-")),
 		Test:            t,
@@ -128,11 +132,8 @@ ForwardersEnabled = true`
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
 		AddHelm(evmConfig).
-		AddHelm(chainlink.New(0, map[string]interface{}{
-			"toml":     client.AddNetworkDetailedConfig(baseTOML, networkDetailTOML, testNetwork),
-			"replicas": 6,
-		}))
-	err := testEnvironment.Run()
+		AddHelmCharts(cd)
+	err = testEnvironment.Run()
 	require.NoError(t, err, "Error running test environment")
 	return testEnvironment, testNetwork
 }

--- a/integration-tests/smoke/keeper_test.go
+++ b/integration-tests/smoke/keeper_test.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/onsi/gomega"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-env/environment"
+	"github.com/smartcontractkit/chainlink-env/logging"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/chainlink"
 	eth "github.com/smartcontractkit/chainlink-env/pkg/helm/ethereum"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/mockserver"
@@ -91,7 +93,7 @@ var (
 
 func TestKeeperBasicSmoke(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_1_1": ethereum.RegistryVersion_1_1,
 		"registry_1_2": ethereum.RegistryVersion_1_2,
@@ -131,7 +133,7 @@ func TestKeeperBasicSmoke(t *testing.T) {
 					g.Expect(err).ShouldNot(gomega.HaveOccurred(), "Failed to retrieve consumer counter for upkeep at index %d", i)
 					g.Expect(counter.Int64()).Should(gomega.BeNumerically(">", int64(10)),
 						"Expected consumer counter to be greater than 10, but got %d", counter.Int64())
-					l.Info().Int64("Upkeep counter", counter.Int64()).Msg("Number of upkeeps performed")
+					log.Info().Int64("Upkeep counter", counter.Int64()).Msg("Number of upkeeps performed")
 				}
 			}, "5m", "1s").Should(gomega.Succeed())
 
@@ -150,7 +152,7 @@ func TestKeeperBasicSmoke(t *testing.T) {
 				// Obtain the amount of times the upkeep has been executed so far
 				countersAfterCancellation[i], err = consumers[i].Counter(context.Background())
 				require.NoError(t, err, "Failed to retrieve consumer counter for upkeep at index %d", i)
-				l.Info().Int("Index", i).Int64("Upkeeps Performed", countersAfterCancellation[i].Int64()).Msg("Cancelled Upkeep")
+				log.Info().Int("Index", i).Int64("Upkeeps Performed", countersAfterCancellation[i].Int64()).Msg("Cancelled Upkeep")
 			}
 
 			gom.Consistently(func(g gomega.Gomega) {
@@ -169,7 +171,7 @@ func TestKeeperBasicSmoke(t *testing.T) {
 
 func TestKeeperBlockCountPerTurn(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_1_1": ethereum.RegistryVersion_1_1,
 		"registry_1_2": ethereum.RegistryVersion_1_2,
@@ -209,17 +211,17 @@ func TestKeeperBlockCountPerTurn(t *testing.T) {
 			gom.Eventually(func(g gomega.Gomega) {
 				counter, err := consumers[0].Counter(context.Background())
 				g.Expect(err).ShouldNot(gomega.HaveOccurred(), "Calling consumer's counter shouldn't fail")
-				l.Info().Int64("Upkeep counter", counter.Int64()).Msg("Number of upkeeps performed")
+				log.Info().Int64("Upkeep counter", counter.Int64()).Msg("Number of upkeeps performed")
 
 				upkeepInfo, err := registry.GetUpkeepInfo(context.Background(), upkeepID)
 				g.Expect(err).ShouldNot(gomega.HaveOccurred(), "Registry's getUpkeep shouldn't fail")
 
 				latestKeeper := upkeepInfo.LastKeeper
-				l.Info().Str("keeper", latestKeeper).Msg("last keeper to perform upkeep")
+				log.Info().Str("keeper", latestKeeper).Msg("last keeper to perform upkeep")
 				g.Expect(latestKeeper).ShouldNot(gomega.Equal(actions.ZeroAddress.String()), "Last keeper should be non zero")
 				g.Expect(latestKeeper).ShouldNot(gomega.BeElementOf(keepersPerformed), "A new keeper node should perform this upkeep")
 
-				l.Info().Str("keeper", latestKeeper).Msg("New keeper performed upkeep")
+				log.Info().Str("keeper", latestKeeper).Msg("New keeper performed upkeep")
 				keepersPerformed = append(keepersPerformed, latestKeeper)
 			}, "1m", "1s").Should(gomega.Succeed())
 
@@ -231,7 +233,7 @@ func TestKeeperBlockCountPerTurn(t *testing.T) {
 				g.Expect(latestKeeper).ShouldNot(gomega.Equal(actions.ZeroAddress.String()), "Last keeper should be non zero")
 				g.Expect(latestKeeper).ShouldNot(gomega.BeElementOf(keepersPerformed), "A new keeper node should perform this upkeep")
 
-				l.Info().Str("Keeper", latestKeeper).Msg("New keeper performed upkeep")
+				log.Info().Str("Keeper", latestKeeper).Msg("New keeper performed upkeep")
 				keepersPerformed = append(keepersPerformed, latestKeeper)
 			}, "1m", "1s").Should(gomega.Succeed())
 
@@ -255,17 +257,17 @@ func TestKeeperBlockCountPerTurn(t *testing.T) {
 			gom.Eventually(func(g gomega.Gomega) {
 				counter, err := consumers[0].Counter(context.Background())
 				g.Expect(err).ShouldNot(gomega.HaveOccurred(), "Calling consumer's counter shouldn't fail")
-				l.Info().Int64("Upkeep counter", counter.Int64()).Msg("Num upkeeps performed")
+				log.Info().Int64("Upkeep counter", counter.Int64()).Msg("Num upkeeps performed")
 
 				upkeepInfo, err := registry.GetUpkeepInfo(context.Background(), upkeepID)
 				g.Expect(err).ShouldNot(gomega.HaveOccurred(), "Registry's getUpkeep shouldn't fail")
 
 				latestKeeper := upkeepInfo.LastKeeper
-				l.Info().Str("keeper", latestKeeper).Msg("last keeper to perform upkeep")
+				log.Info().Str("keeper", latestKeeper).Msg("last keeper to perform upkeep")
 				g.Expect(latestKeeper).ShouldNot(gomega.Equal(actions.ZeroAddress.String()), "Last keeper should be non zero")
 				g.Expect(latestKeeper).ShouldNot(gomega.BeElementOf(keepersPerformed), "A new keeper node should perform this upkeep")
 
-				l.Info().Str("keeper", latestKeeper).Msg("New keeper performed upkeep")
+				log.Info().Str("keeper", latestKeeper).Msg("New keeper performed upkeep")
 				keepersPerformed = append(keepersPerformed, latestKeeper)
 			}, "1m", "1s").Should(gomega.Succeed())
 		})
@@ -348,7 +350,7 @@ func TestKeeperSimulation(t *testing.T) {
 
 func TestKeeperCheckPerformGasLimit(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_1_2": ethereum.RegistryVersion_1_2,
 		"registry_1_3": ethereum.RegistryVersion_1_3,
@@ -421,7 +423,7 @@ func TestKeeperCheckPerformGasLimit(t *testing.T) {
 			// Get existing performed count
 			existingCnt, err := consumerPerformance.GetUpkeepCount(context.Background())
 			require.NoError(t, err, "Error calling consumer's counter")
-			l.Info().Int64("Upkeep counter", existingCnt.Int64()).Msg("Check Gas Increased")
+			log.Info().Int64("Upkeep counter", existingCnt.Int64()).Msg("Check Gas Increased")
 
 			// In most cases count should remain constant, but there might be a straggling perform tx which
 			// gets committed later. Since every keeper node cannot have more than 1 straggling tx, it
@@ -438,7 +440,7 @@ func TestKeeperCheckPerformGasLimit(t *testing.T) {
 			existingCnt, err = consumerPerformance.GetUpkeepCount(context.Background())
 			require.NoError(t, err, "Error calling consumer's counter")
 			existingCntInt := existingCnt.Int64()
-			l.Info().Int64("Upkeep counter", existingCntInt).Msg("Upkeep counter when consistently block finished")
+			log.Info().Int64("Upkeep counter", existingCntInt).Msg("Upkeep counter when consistently block finished")
 
 			// Now increase checkGasLimit on registry
 			highCheckGasLimit := keeperDefaultRegistryConfig
@@ -462,7 +464,7 @@ func TestKeeperCheckPerformGasLimit(t *testing.T) {
 
 func TestKeeperRegisterUpkeep(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_1_1": ethereum.RegistryVersion_1_1,
 		"registry_1_2": ethereum.RegistryVersion_1_2,
@@ -507,7 +509,7 @@ func TestKeeperRegisterUpkeep(t *testing.T) {
 						" for upkeep at index "+strconv.Itoa(i))
 					g.Expect(counter.Int64()).Should(gomega.BeNumerically(">", int64(0)),
 						"Expected consumer counter to be greater than 0, but got %d", counter.Int64())
-					l.Info().
+					log.Info().
 						Int64("Upkeep counter", counter.Int64()).
 						Int("Upkeep ID", i).
 						Msg("Number of upkeeps performed")
@@ -526,7 +528,7 @@ func TestKeeperRegisterUpkeep(t *testing.T) {
 				g.Expect(err).ShouldNot(gomega.HaveOccurred(), "Calling newly deployed upkeep's counter shouldn't fail")
 				g.Expect(counter.Int64()).Should(gomega.BeNumerically(">", int64(0)),
 					"Expected newly registered upkeep's counter to be greater than 0, but got %d", counter.Int64())
-				l.Info().Msg("Newly registered upkeeps performed " + strconv.Itoa(int(counter.Int64())) + " times")
+				log.Info().Msg("Newly registered upkeeps performed " + strconv.Itoa(int(counter.Int64())) + " times")
 			}, "1m", "1s").Should(gomega.Succeed())
 
 			gom.Eventually(func(g gomega.Gomega) {
@@ -534,7 +536,7 @@ func TestKeeperRegisterUpkeep(t *testing.T) {
 					currentCounter, err := consumers[i].Counter(context.Background())
 					g.Expect(err).ShouldNot(gomega.HaveOccurred(), "Calling consumer's counter shouldn't fail")
 
-					l.Info().
+					log.Info().
 						Int("Upkeep ID", i).
 						Int64("Upkeep counter", currentCounter.Int64()).
 						Int64("initial counter", initialCounters[i].Int64()).
@@ -616,7 +618,7 @@ func TestKeeperAddFunds(t *testing.T) {
 
 func TestKeeperRemove(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_1_1": ethereum.RegistryVersion_1_1,
 		"registry_1_2": ethereum.RegistryVersion_1_2,
@@ -679,7 +681,7 @@ func TestKeeperRemove(t *testing.T) {
 			require.NoError(t, err, "Error setting new list of Keepers")
 			err = chainClient.WaitForEvents()
 			require.NoError(t, err, "Error waiting for events")
-			l.Info().Msg("Successfully removed keeper at address " + keepers[0] + " from the list of Keepers")
+			log.Info().Msg("Successfully removed keeper at address " + keepers[0] + " from the list of Keepers")
 
 			// The upkeeps should still perform and their counters should have increased compared to the first check
 			gom.Eventually(func(g gomega.Gomega) {
@@ -847,7 +849,7 @@ func TestKeeperMigrateRegistry(t *testing.T) {
 
 func TestKeeperNodeDown(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_1_1": ethereum.RegistryVersion_1_1,
 		"registry_1_2": ethereum.RegistryVersion_1_2,
@@ -901,7 +903,7 @@ func TestKeeperNodeDown(t *testing.T) {
 				err = chainClient.WaitForEvents()
 				require.NoError(t, err, "Error waiting for events")
 			}
-			l.Info().Msg("Successfully managed to take down the first half of the nodes")
+			log.Info().Msg("Successfully managed to take down the first half of the nodes")
 
 			// Assert that upkeeps are still performed and their counters have increased
 			gom.Eventually(func(g gomega.Gomega) {
@@ -922,14 +924,14 @@ func TestKeeperNodeDown(t *testing.T) {
 				err = chainClient.WaitForEvents()
 				require.NoError(t, err, "Error waiting for events")
 			}
-			l.Info().Msg("Successfully managed to take down the second half of the nodes")
+			log.Info().Msg("Successfully managed to take down the second half of the nodes")
 
 			// See how many times each upkeep was executed
 			var countersAfterNoMoreNodes = make([]*big.Int, len(upkeepIDs))
 			for i := 0; i < len(upkeepIDs); i++ {
 				countersAfterNoMoreNodes[i], err = consumers[i].Counter(context.Background())
 				require.NoError(t, err, "Error retrieving consumer counter %d", i)
-				l.Info().
+				log.Info().
 					Int("Index", i).
 					Int64("Upkeeps", countersAfterNoMoreNodes[i].Int64()).
 					Msg("Upkeeps Performed")
@@ -955,7 +957,7 @@ func TestKeeperNodeDown(t *testing.T) {
 
 func TestKeeperPauseUnPauseUpkeep(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	chainClient, chainlinkNodes, contractDeployer, linkToken, onlyStartRunner := setupKeeperTest(t, "pause-upkeep")
 	if onlyStartRunner {
 		return
@@ -984,7 +986,7 @@ func TestKeeperPauseUnPauseUpkeep(t *testing.T) {
 			g.Expect(err).ShouldNot(gomega.HaveOccurred(), "Failed to retrieve consumer counter for upkeep at index %d", i)
 			g.Expect(counter.Int64()).Should(gomega.BeNumerically(">", int64(5)),
 				"Expected consumer counter to be greater than 5, but got %d", counter.Int64())
-			l.Info().Int64("Upkeep counter", counter.Int64()).Msg("Number of upkeeps performed")
+			log.Info().Int64("Upkeep counter", counter.Int64()).Msg("Number of upkeeps performed")
 		}
 	}, "3m", "1s").Should(gomega.Succeed())
 
@@ -1002,7 +1004,7 @@ func TestKeeperPauseUnPauseUpkeep(t *testing.T) {
 		// Obtain the amount of times the upkeep has been executed so far
 		countersAfterPause[i], err = consumers[i].Counter(context.Background())
 		require.NoError(t, err, "Error retrieving upkeep count at index %d", i)
-		l.Info().
+		log.Info().
 			Int("Index", i).
 			Int64("Upkeeps", countersAfterPause[i].Int64()).
 			Msg("Paused Upkeep")
@@ -1038,14 +1040,14 @@ func TestKeeperPauseUnPauseUpkeep(t *testing.T) {
 				" for upkeep at index %d", i)
 			g.Expect(counter.Int64()).Should(gomega.BeNumerically(">", int64(5)+countersAfterPause[i].Int64()),
 				"Expected consumer counter to be greater than %d, but got %d", int64(5)+countersAfterPause[i].Int64(), counter.Int64())
-			l.Info().Int64("Upkeeps", counter.Int64()).Msg("Upkeeps Performed")
+			log.Info().Int64("Upkeeps", counter.Int64()).Msg("Upkeeps Performed")
 		}
 	}, "3m", "1s").Should(gomega.Succeed())
 }
 
 func TestKeeperUpdateCheckData(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	chainClient, chainlinkNodes, contractDeployer, linkToken, onlyStartRunner := setupKeeperTest(t, "pause-upkeep")
 	if onlyStartRunner {
 		return
@@ -1075,7 +1077,7 @@ func TestKeeperUpdateCheckData(t *testing.T) {
 			g.Expect(err).ShouldNot(gomega.HaveOccurred(), "Failed to retrieve perform data checker for upkeep at index %d", i)
 			g.Expect(counter.Int64()).Should(gomega.Equal(int64(0)),
 				"Expected perform data checker counter to be 0, but got %d", counter.Int64())
-			l.Info().Int64("Upkeep perform data checker", counter.Int64()).Msg("Number of upkeeps performed")
+			log.Info().Int64("Upkeep perform data checker", counter.Int64()).Msg("Number of upkeeps performed")
 		}
 	}, "2m", "1s").Should(gomega.Succeed())
 
@@ -1101,7 +1103,7 @@ func TestKeeperUpdateCheckData(t *testing.T) {
 			g.Expect(err).ShouldNot(gomega.HaveOccurred(), "Failed to retrieve perform data checker counter for upkeep at index %d", i)
 			g.Expect(counter.Int64()).Should(gomega.BeNumerically(">", int64(5)),
 				"Expected perform data checker counter to be greater than 5, but got %d", counter.Int64())
-			l.Info().Int64("Upkeep perform data checker", counter.Int64()).Msg("Number of upkeeps performed")
+			log.Info().Int64("Upkeep perform data checker", counter.Int64()).Msg("Number of upkeeps performed")
 		}
 	}, "3m", "1s").Should(gomega.Succeed())
 }
@@ -1126,10 +1128,10 @@ func setupKeeperTest(
 		})
 	}
 
-	chainlinkChart := chainlink.New(0, map[string]interface{}{
-		"replicas": "5",
-		"toml":     client.AddNetworksConfig(keeperBaseTOML, network),
+	chainlinkChart, err := chainlink.NewDeployment(5, map[string]interface{}{
+		"toml": client.AddNetworksConfig(keeperBaseTOML, network),
 	})
+	require.NoError(t, err, "Error creating chainlink deployment")
 
 	networkName := strings.ReplaceAll(strings.ToLower(network.Name), " ", "-")
 	testEnvironment := environment.New(
@@ -1140,8 +1142,8 @@ func setupKeeperTest(
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
 		AddHelm(evmConfig).
-		AddHelm(chainlinkChart)
-	err := testEnvironment.Run()
+		AddHelmCharts(chainlinkChart)
+	err = testEnvironment.Run()
 	require.NoError(t, err, "Error deploying test environment")
 	onlyStartRunner = testEnvironment.WillUseRemoteRunner()
 	if !onlyStartRunner {

--- a/integration-tests/smoke/ocr2_test.go
+++ b/integration-tests/smoke/ocr2_test.go
@@ -103,10 +103,10 @@ func setupOCR2Test(t *testing.T) (
 			WsURLs:      testNetwork.URLs,
 		})
 	}
-	chainlinkChart := chainlink.New(0, map[string]interface{}{
-		"toml":     client.AddNetworksConfig(config.BaseOCR2Config, testNetwork),
-		"replicas": 6,
+	chainlinkChart, err := chainlink.NewDeployment(6, map[string]interface{}{
+		"toml": client.AddNetworksConfig(config.BaseOCR2Config, testNetwork),
 	})
+	require.NoError(t, err, "Error creating chainlink deployment")
 
 	testEnvironment = environment.New(&environment.Config{
 		NamespacePrefix: fmt.Sprintf("smoke-ocr2-%s", strings.ReplaceAll(strings.ToLower(testNetwork.Name), " ", "-")),
@@ -115,8 +115,8 @@ func setupOCR2Test(t *testing.T) (
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
 		AddHelm(evmConfig).
-		AddHelm(chainlinkChart)
-	err := testEnvironment.Run()
+		AddHelmCharts(chainlinkChart)
+	err = testEnvironment.Run()
 	require.NoError(t, err, "Error running test environment")
 	return testEnvironment, testNetwork
 }

--- a/integration-tests/smoke/ocr_test.go
+++ b/integration-tests/smoke/ocr_test.go
@@ -93,10 +93,10 @@ func setupOCRTest(t *testing.T) (
 			WsURLs:      testNetwork.URLs,
 		})
 	}
-	chainlinkChart := chainlink.New(0, map[string]interface{}{
-		"toml":     client.AddNetworksConfig(config.BaseOCRP2PV1Config, testNetwork),
-		"replicas": 6,
+	chainlinkChart, err := chainlink.NewDeployment(6, map[string]interface{}{
+		"toml": client.AddNetworksConfig(config.BaseOCRP2PV1Config, testNetwork),
 	})
+	require.NoError(t, err, "Error creating chainlink deployment")
 
 	testEnvironment = environment.New(&environment.Config{
 		NamespacePrefix: fmt.Sprintf("smoke-ocr-%s", strings.ReplaceAll(strings.ToLower(testNetwork.Name), " ", "-")),
@@ -105,8 +105,8 @@ func setupOCRTest(t *testing.T) (
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
 		AddHelm(evmConfig).
-		AddHelm(chainlinkChart)
-	err := testEnvironment.Run()
+		AddHelmCharts(chainlinkChart)
+	err = testEnvironment.Run()
 	require.NoError(t, err, "Error running test environment")
 	return testEnvironment, testNetwork
 }

--- a/integration-tests/smoke/runlog_test.go
+++ b/integration-tests/smoke/runlog_test.go
@@ -9,10 +9,12 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/onsi/gomega"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-env/environment"
+	"github.com/smartcontractkit/chainlink-env/logging"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/chainlink"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/ethereum"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/mockserver"
@@ -29,7 +31,7 @@ import (
 
 func TestRunLogBasic(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	testEnvironment, testNetwork := setupRunLogTest(t)
 	if testEnvironment.WillUseRemoteRunner() {
 		return
@@ -108,7 +110,7 @@ func TestRunLogBasic(t *testing.T) {
 		d, err := consumer.Data(context.Background())
 		g.Expect(err).ShouldNot(gomega.HaveOccurred(), "Getting data from consumer contract shouldn't fail")
 		g.Expect(d).ShouldNot(gomega.BeNil(), "Expected the initial on chain data to be nil")
-		l.Debug().Int64("Data", d.Int64()).Msg("Found on chain")
+		log.Debug().Int64("Data", d.Int64()).Msg("Found on chain")
 		g.Expect(d.Int64()).Should(gomega.BeNumerically("==", 5), "Expected the on-chain data to be 5, but found %d", d.Int64())
 	}, "2m", "1s").Should(gomega.Succeed())
 }
@@ -123,6 +125,10 @@ func setupRunLogTest(t *testing.T) (testEnvironment *environment.Environment, te
 			WsURLs:      testNetwork.URLs,
 		})
 	}
+	cd, err := chainlink.NewDeployment(1, map[string]interface{}{
+		"toml": client.AddNetworksConfig("", testNetwork),
+	})
+	require.NoError(t, err, "Error creating chainlink deployment")
 	testEnvironment = environment.New(&environment.Config{
 		NamespacePrefix: fmt.Sprintf("smoke-runlog-%s", strings.ReplaceAll(strings.ToLower(testNetwork.Name), " ", "-")),
 		Test:            t,
@@ -130,10 +136,8 @@ func setupRunLogTest(t *testing.T) (testEnvironment *environment.Environment, te
 		AddHelm(mockservercfg.New(nil)).
 		AddHelm(mockserver.New(nil)).
 		AddHelm(evmConfig).
-		AddHelm(chainlink.New(0, map[string]interface{}{
-			"toml": client.AddNetworksConfig("", testNetwork),
-		}))
-	err := testEnvironment.Run()
+		AddHelmCharts(cd)
+	err = testEnvironment.Run()
 	require.NoError(t, err, "Error running test environment")
 	return testEnvironment, testNetwork
 }

--- a/integration-tests/smoke/vrf_test.go
+++ b/integration-tests/smoke/vrf_test.go
@@ -10,10 +10,12 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/onsi/gomega"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink-env/environment"
+	"github.com/smartcontractkit/chainlink-env/logging"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/chainlink"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/ethereum"
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
@@ -27,7 +29,7 @@ import (
 
 func TestVRFBasic(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	testEnvironment, testNetwork := setupVRFTest(t)
 	if testEnvironment.WillUseRemoteRunner() {
 		return
@@ -69,7 +71,7 @@ func TestVRFBasic(t *testing.T) {
 	for _, n := range chainlinkNodes {
 		nodeKey, err := n.MustCreateVRFKey()
 		require.NoError(t, err, "Creating VRF key shouldn't fail")
-		l.Debug().Interface("Key JSON", nodeKey).Msg("Created proving key")
+		log.Debug().Interface("Key JSON", nodeKey).Msg("Created proving key")
 		pubKeyCompressed := nodeKey.Data.ID
 		jobUUID := uuid.New()
 		os := &client.VRFTxPipelineSpec{
@@ -123,7 +125,7 @@ func TestVRFBasic(t *testing.T) {
 			// There's a better formula to ensure that VRF response is as expected, detailed under Technical Walkthrough.
 			// https://bl.chain.link/chainlink-vrf-on-chain-verifiable-randomness/
 			g.Expect(out.Uint64()).ShouldNot(gomega.BeNumerically("==", 0), "Expected the VRF job give an answer other than 0")
-			l.Debug().Uint64("Output", out.Uint64()).Msg("Randomness fulfilled")
+			log.Debug().Uint64("Output", out.Uint64()).Msg("Randomness fulfilled")
 		}, timeout, "1s").Should(gomega.Succeed())
 	}
 }
@@ -138,15 +140,17 @@ func setupVRFTest(t *testing.T) (testEnvironment *environment.Environment, testN
 			WsURLs:      testNetwork.URLs,
 		})
 	}
+	cd, err := chainlink.NewDeployment(1, map[string]interface{}{
+		"toml": client.AddNetworksConfig("", testNetwork),
+	})
+	require.NoError(t, err, "Error creating chainlink deployment")
 	testEnvironment = environment.New(&environment.Config{
 		NamespacePrefix: fmt.Sprintf("smoke-vrf-%s", strings.ReplaceAll(strings.ToLower(testNetwork.Name), " ", "-")),
 		Test:            t,
 	}).
 		AddHelm(evmConfig).
-		AddHelm(chainlink.New(0, map[string]interface{}{
-			"toml": client.AddNetworksConfig("", testNetwork),
-		}))
-	err := testEnvironment.Run()
+		AddHelmCharts(cd)
+	err = testEnvironment.Run()
 	require.NoError(t, err, "Error running test environment")
 	return testEnvironment, testNetwork
 }

--- a/integration-tests/smoke/vrfv2_test.go
+++ b/integration-tests/smoke/vrfv2_test.go
@@ -7,9 +7,11 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
+	"github.com/smartcontractkit/chainlink-env/logging"
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
 	"github.com/smartcontractkit/chainlink-testing-framework/utils"
 
@@ -25,7 +27,7 @@ import (
 func TestVRFv2Basic(t *testing.T) {
 
 	t.Parallel()
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 
 	testNetwork := networks.SelectedNetwork
 	testEnvironment := vrfv2_actions.SetupVRFV2Environment(
@@ -103,17 +105,17 @@ func TestVRFv2Basic(t *testing.T) {
 		g.Expect(err).ShouldNot(gomega.HaveOccurred())
 		g.Expect(len(jobRuns.Data)).Should(gomega.BeNumerically("==", 1))
 		lastRequestID, err = consumerContract.GetLastRequestId(context.Background())
-		l.Debug().Interface("Last Request ID", lastRequestID).Msg("Last Request ID Received")
+		log.Debug().Interface("Last Request ID", lastRequestID).Msg("Last Request ID Received")
 
 		g.Expect(err).ShouldNot(gomega.HaveOccurred())
 		status, err := consumerContract.GetRequestStatus(context.Background(), lastRequestID)
 		g.Expect(err).ShouldNot(gomega.HaveOccurred())
 		g.Expect(status.Fulfilled).Should(gomega.BeTrue())
-		l.Debug().Interface("Fulfilment Status", status.Fulfilled).Msg("Random Words Request Fulfilment Status")
+		log.Debug().Interface("Fulfilment Status", status.Fulfilled).Msg("Random Words Request Fulfilment Status")
 
 		g.Expect(err).ShouldNot(gomega.HaveOccurred())
 		for _, w := range status.RandomWords {
-			l.Debug().Uint64("Output", w.Uint64()).Msg("Randomness fulfilled")
+			log.Debug().Uint64("Output", w.Uint64()).Msg("Randomness fulfilled")
 			g.Expect(w.Uint64()).Should(gomega.BeNumerically(">", 0), "Expected the VRF job give an answer bigger than 0")
 		}
 	}, timeout, "1s").Should(gomega.Succeed())

--- a/integration-tests/soak/vrfv2_test.go
+++ b/integration-tests/soak/vrfv2_test.go
@@ -7,11 +7,11 @@ import (
 	"time"
 
 	"github.com/kelseyhightower/envconfig"
-	"github.com/rs/zerolog"
+	"github.com/rs/zerolog/log"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-env/logging"
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
-	"github.com/smartcontractkit/chainlink-testing-framework/utils"
 
 	"github.com/smartcontractkit/chainlink/integration-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/actions/vrfv2_actions"
@@ -31,7 +31,7 @@ func TestVRFV2Soak(t *testing.T) {
 	chainlinkNodeFundingAmountEth := testInputs.ChainlinkNodeFunding
 	randomnessRequestCountPerRequest := testInputs.RandomnessRequestCountPerRequest
 
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 
 	testInputs.SetForRemoteRunner()
 	testNetwork := networks.SelectedNetwork // Environment currently being used to soak test on
@@ -102,12 +102,12 @@ func TestVRFV2Soak(t *testing.T) {
 				return fmt.Errorf("error occurred Requesting Randomness, error: %w", err)
 			}
 
-			l.Info().
+			log.Info().
 				Int("Request Number", requestNumber).
 				Int("Randomness Request Count Per Request", randomnessRequestCountPerRequest).
 				Msg("Randomness requested")
 
-			printDebugData(l, vrfV2Contracts, chainlinkNodesAfterRedeployment)
+			printDebugData(vrfV2Contracts, chainlinkNodesAfterRedeployment)
 
 			return nil
 		},
@@ -116,35 +116,35 @@ func TestVRFV2Soak(t *testing.T) {
 
 	t.Cleanup(func() {
 		if err := actions.TeardownRemoteSuite(vrfV2SoakTest.TearDownVals(t)); err != nil {
-			l.Error().Err(err).Msg("Error tearing down environment")
+			log.Error().Err(err).Msg("Error tearing down environment")
 		}
 	})
 	vrfV2SoakTest.Setup(t, testEnvironment)
-	l.Info().Msg("Set up soak test")
+	log.Info().Msg("Set up soak test")
 	vrfV2SoakTest.Run(t)
 }
 
-func printDebugData(l zerolog.Logger, vrfV2Contracts vrfv2_actions.VRFV2Contracts, chainlinkNodesAfterRedeployment []*client.Chainlink) {
+func printDebugData(vrfV2Contracts vrfv2_actions.VRFV2Contracts, chainlinkNodesAfterRedeployment []*client.Chainlink) {
 	subscription, err := vrfV2Contracts.Coordinator.GetSubscription(nil, vrfv2_constants.SubID)
 	if err != nil {
-		l.Error().Err(err).
+		log.Error().Err(err).
 			Uint64("Subscription ID", vrfv2_constants.SubID).
 			Interface("Coordinator Address", vrfV2Contracts.Coordinator.Address()).
 			Msg("error occurred Getting Subscription Data from a Coordinator Contract")
 	}
-	l.Debug().Interface("Data", subscription).Uint64("Subscription ID", vrfv2_constants.SubID).Msg("Subscription Data")
+	log.Debug().Interface("Data", subscription).Uint64("Subscription ID", vrfv2_constants.SubID).Msg("Subscription Data")
 	remainingSubBalanceInLink := new(big.Float).Quo(new(big.Float).SetInt(subscription.Balance), big.NewFloat(1e18))
-	l.Debug().Interface("Balance", remainingSubBalanceInLink).Msg("Remaining Balance in Link for a subscription")
+	log.Debug().Interface("Balance", remainingSubBalanceInLink).Msg("Remaining Balance in Link for a subscription")
 	nativeTokenPrimaryKey, err := chainlinkNodesAfterRedeployment[0].ReadPrimaryETHKey()
 	if err != nil {
-		l.Error().Err(err).Msg("error occurred reading Native Token Primary Key from Chainlink Node")
+		log.Error().Err(err).Msg("error occurred reading Native Token Primary Key from Chainlink Node")
 	}
 	ethBalance, ok := new(big.Int).SetString(nativeTokenPrimaryKey.Attributes.ETHBalance, 10)
 	if !ok {
-		l.Error().Interface("Balance", nativeTokenPrimaryKey.Attributes.ETHBalance).Msg("error occurred converting Native Token Primary Key from Chainlink Node")
+		log.Error().Interface("Balance", nativeTokenPrimaryKey.Attributes.ETHBalance).Msg("error occurred converting Native Token Primary Key from Chainlink Node")
 	}
 	remainingNativeTokenPrimaryKeyBalanceInETH := new(big.Float).Quo(new(big.Float).SetInt(ethBalance), big.NewFloat(1e18))
-	l.Debug().
+	log.Debug().
 		Interface("Balance", remainingNativeTokenPrimaryKeyBalanceInETH).
 		Interface("Key Address", nativeTokenPrimaryKey.Attributes.Address).
 		Msg("Remaining Balance for a Native Token Primary Key of Chainlink Node")

--- a/integration-tests/testsetups/keeper_benchmark.go
+++ b/integration-tests/testsetups/keeper_benchmark.go
@@ -18,9 +18,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-env/environment"
+	"github.com/smartcontractkit/chainlink-env/logging"
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
 	reportModel "github.com/smartcontractkit/chainlink-testing-framework/testreporters"
-	"github.com/smartcontractkit/chainlink-testing-framework/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/keeper_registry_wrapper1_1"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/keeper_registry_wrapper1_2"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/keeper_registry_wrapper1_3"
@@ -97,7 +97,7 @@ func NewKeeperBenchmarkTest(inputs KeeperBenchmarkTestInputs) *KeeperBenchmarkTe
 
 // Setup prepares contracts for the test
 func (k *KeeperBenchmarkTest) Setup(t *testing.T, env *environment.Environment) {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	startTime := time.Now()
 	k.TestReporter.Summary.StartTime = startTime.UnixMilli()
 	k.ensureInputValues(t)
@@ -120,7 +120,7 @@ func (k *KeeperBenchmarkTest) Setup(t *testing.T, env *environment.Environment) 
 	if len(inputs.RegistryVersions) > 1 && !inputs.ForceSingleTxnKey {
 		for nodeIndex, node := range k.chainlinkNodes {
 			for registryIndex := 1; registryIndex < len(inputs.RegistryVersions); registryIndex++ {
-				l.Debug().Str("URL", node.URL()).Int("NodeIndex", nodeIndex).Int("RegistryIndex", registryIndex).Msg("Create Tx key")
+				log.Debug().Str("URL", node.URL()).Int("NodeIndex", nodeIndex).Int("RegistryIndex", registryIndex).Msg("Create Tx key")
 				_, _, err := node.CreateTxKey("evm", k.Inputs.BlockchainClient.GetChainID().String())
 				require.NoError(t, err, "Creating transaction key shouldn't fail")
 			}
@@ -165,7 +165,7 @@ func (k *KeeperBenchmarkTest) Setup(t *testing.T, env *environment.Environment) 
 	require.NoError(t, err, "Failed waiting for mock feeds to deploy")
 
 	for index := range inputs.RegistryVersions {
-		l.Info().Int("Index", index).Msg("Starting Test Setup")
+		log.Info().Int("Index", index).Msg("Starting Test Setup")
 
 		k.DeployBenchmarkKeeperContracts(
 			t,
@@ -188,16 +188,16 @@ func (k *KeeperBenchmarkTest) Setup(t *testing.T, env *environment.Environment) 
 		require.NoError(t, err, "Funding Chainlink nodes shouldn't fail")
 	}
 
-	l.Info().Str("Setup Time", time.Since(startTime).String()).Msg("Finished Keeper Benchmark Test Setup")
+	log.Info().Str("Setup Time", time.Since(startTime).String()).Msg("Finished Keeper Benchmark Test Setup")
 	err = k.SendSlackNotification(nil)
 	if err != nil {
-		l.Warn().Msg("Sending test start slack notification failed")
+		log.Warn().Msg("Sending test start slack notification failed")
 	}
 }
 
 // Run runs the keeper benchmark test
 func (k *KeeperBenchmarkTest) Run(t *testing.T) {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	u := k.Inputs.Upkeeps
 	k.TestReporter.Summary.Load.TotalCheckGasPerBlock = int64(u.NumberOfUpkeeps) * u.CheckGasToBurn
 	k.TestReporter.Summary.Load.TotalPerformGasPerBlock = int64((float64(u.NumberOfUpkeeps) /
@@ -285,19 +285,19 @@ func (k *KeeperBenchmarkTest) Run(t *testing.T) {
 	for _, chainlinkNode := range k.chainlinkNodes {
 		txData, err := chainlinkNode.MustReadTransactionAttempts()
 		if err != nil {
-			l.Error().Err(err).Msg("Error reading transaction attempts from Chainlink Node")
+			log.Error().Err(err).Msg("Error reading transaction attempts from Chainlink Node")
 		}
 		k.TestReporter.AttemptedChainlinkTransactions = append(k.TestReporter.AttemptedChainlinkTransactions, txData)
 	}
 
 	k.TestReporter.Summary.Config.Chainlink, err = k.env.ResourcesSummary("app=chainlink-0")
 	if err != nil {
-		l.Error().Err(err).Msg("Error getting resource summary of chainlink node")
+		log.Error().Err(err).Msg("Error getting resource summary of chainlink node")
 	}
 
 	k.TestReporter.Summary.Config.Geth, err = k.env.ResourcesSummary("app=geth")
 	if err != nil && k.Inputs.BlockchainClient.NetworkSimulated() {
-		l.Error().Err(err).Msg("Error getting resource summary of geth node")
+		log.Error().Err(err).Msg("Error getting resource summary of geth node")
 	}
 
 	endTime := time.Now()
@@ -310,7 +310,7 @@ func (k *KeeperBenchmarkTest) Run(t *testing.T) {
 		}
 	}
 
-	l.Info().Str("Run Time", endTime.Sub(startTime).String()).Msg("Finished Keeper Benchmark Test")
+	log.Info().Str("Run Time", endTime.Sub(startTime).String()).Msg("Finished Keeper Benchmark Test")
 }
 
 // subscribeToUpkeepPerformedEvent subscribes to the event log for UpkeepPerformed event and
@@ -321,7 +321,7 @@ func (k *KeeperBenchmarkTest) subscribeToUpkeepPerformedEvent(
 	metricsReporter *testreporters.KeeperBenchmarkTestReporter,
 	rIndex int,
 ) {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	contractABI, err := keeper_registry_wrapper1_1.KeeperRegistryMetaData.GetAbi()
 	require.NoError(t, err, "Error getting ABI")
 	switch k.Inputs.RegistryVersions[rIndex] {
@@ -349,7 +349,7 @@ func (k *KeeperBenchmarkTest) subscribeToUpkeepPerformedEvent(
 		for {
 			select {
 			case err := <-sub.Err():
-				l.Error().Err(err).Msg("Error while subscribing to Keeper Event Logs. Resubscribing...")
+				log.Error().Err(err).Msg("Error while subscribing to Keeper Event Logs. Resubscribing...")
 				sub.Unsubscribe()
 
 				sub, err = k.chainClient.SubscribeFilterLogs(context.Background(), query, eventLogs)
@@ -365,7 +365,7 @@ func (k *KeeperBenchmarkTest) subscribeToUpkeepPerformedEvent(
 				require.NoError(t, err, "Parsing upkeep performed log shouldn't fail")
 
 				if parsedLog.Success {
-					l.Info().
+					log.Info().
 						Str("Upkeep ID", parsedLog.Id.String()).
 						Bool("Success", parsedLog.Success).
 						Str("From", parsedLog.From.String()).
@@ -373,7 +373,7 @@ func (k *KeeperBenchmarkTest) subscribeToUpkeepPerformedEvent(
 						Msg("Got successful Upkeep Performed log on Registry")
 
 				} else {
-					l.Warn().
+					log.Warn().
 						Str("Upkeep ID", parsedLog.Id.String()).
 						Bool("Success", parsedLog.Success).
 						Str("From", parsedLog.From.String()).
@@ -455,7 +455,7 @@ func (k *KeeperBenchmarkTest) DeployBenchmarkKeeperContracts(
 	t *testing.T,
 	index int,
 ) {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 	registryVersion := k.Inputs.RegistryVersions[index]
 	upkeep := k.Inputs.Upkeeps
 	registry := actions.DeployKeeperRegistry(t, k.contractDeployer, k.chainClient,
@@ -525,7 +525,7 @@ func (k *KeeperBenchmarkTest) DeployBenchmarkKeeperContracts(
 			big.NewInt(int64(i)), big.NewInt(upkeep.BlockInterval), big.NewInt(upkeep.BlockRange),
 			big.NewInt(upkeep.CheckGasToBurn), big.NewInt(upkeep.PerformGasToBurn), big.NewInt(upkeep.FirstEligibleBuffer))
 		require.NoError(t, err)
-		l.Debug().Str("checkData: ", hexutil.Encode(data)).Int("id", i).Msg("checkData computed")
+		log.Debug().Str("checkData: ", hexutil.Encode(data)).Int("id", i).Msg("checkData computed")
 		checkData = append(checkData, data)
 	}
 	linkFunds := big.NewInt(0).Mul(big.NewInt(1e18), big.NewInt(upkeep.BlockRange/upkeep.BlockInterval))
@@ -555,22 +555,22 @@ func DeployKeeperConsumersBenchmark(
 	contractDeployer contracts.ContractDeployer,
 	client blockchain.EVMClient,
 ) contracts.AutomationConsumerBenchmark {
-	l := utils.GetTestLogger(t)
+	logging.Init(t)
 
 	// Deploy consumer
 	keeperConsumerInstance, err := contractDeployer.DeployKeeperConsumerBenchmark()
 	if err != nil {
-		l.Error().Err(err).Msg("Deploying AutomationConsumerBenchmark instance %d shouldn't fail")
+		log.Error().Err(err).Msg("Deploying AutomationConsumerBenchmark instance %d shouldn't fail")
 		keeperConsumerInstance, err = contractDeployer.DeployKeeperConsumerBenchmark()
 		require.NoError(t, err, "Error deploying AutomationConsumerBenchmark")
 	}
-	l.Debug().
+	log.Debug().
 		Str("Contract Address", keeperConsumerInstance.Address()).
 		Msg("Deployed Keeper Benchmark Contract")
 
 	err = client.WaitForEvents()
 	require.NoError(t, err, "Failed waiting for to deploy all keeper consumer contracts")
-	l.Info().Msg("Successfully deployed all Keeper Consumer Contracts")
+	log.Info().Msg("Successfully deployed all Keeper Consumer Contracts")
 
 	return keeperConsumerInstance
 }

--- a/integration-tests/testsetups/vrfv2.go
+++ b/integration-tests/testsetups/vrfv2.go
@@ -15,9 +15,9 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink-env/environment"
+	"github.com/smartcontractkit/chainlink-env/logging"
 	"github.com/smartcontractkit/chainlink-testing-framework/blockchain"
 	reportModel "github.com/smartcontractkit/chainlink-testing-framework/testreporters"
-	"github.com/smartcontractkit/chainlink-testing-framework/utils"
 
 	"github.com/smartcontractkit/chainlink/integration-tests/client"
 	"github.com/smartcontractkit/chainlink/integration-tests/contracts"
@@ -78,8 +78,8 @@ func (v *VRFV2SoakTest) Setup(t *testing.T, env *environment.Environment) {
 
 // Run starts the VRFV2 soak test
 func (v *VRFV2SoakTest) Run(t *testing.T) {
-	l := utils.GetTestLogger(t)
-	l.Info().
+	logging.Init(t)
+	log.Info().
 		Str("Test Duration", v.Inputs.TestDuration.Truncate(time.Second).String()).
 		Int("Max number of requests per minute wanted", v.Inputs.RequestsPerMinute).
 		Msg("Starting VRFV2 Soak Test")
@@ -131,16 +131,16 @@ func (v *VRFV2SoakTest) Run(t *testing.T) {
 
 	averageFulfillmentInBlockTime := new(big.Float).Quo(new(big.Float).SetInt(loadTestMetrics.AverageFulfillmentInMillions), big.NewFloat(1e6))
 
-	l.Info().Int("Requests", v.NumberOfRandRequests).Msg("Total Completed Requests calculated from Test")
-	l.Info().Uint64("Requests", loadTestMetrics.RequestCount.Uint64()).Msg("Total Completed Requests calculated from Contract")
-	l.Info().Uint64("Fulfilments", loadTestMetrics.FulfilmentCount.Uint64()).Msg("Total Completed Fulfilments")
-	l.Info().Uint64("Fastest Fulfilment", loadTestMetrics.FastestFulfillment.Uint64()).Msg("Fastest Fulfilment")
-	l.Info().Uint64("Slowest Fulfilment", loadTestMetrics.SlowestFulfillment.Uint64()).Msg("Slowest Fulfilment")
-	l.Info().Interface("Average Fulfillment", averageFulfillmentInBlockTime).Msg("Average Fulfillment In Block Time")
+	log.Info().Int("Requests", v.NumberOfRandRequests).Msg("Total Completed Requests calculated from Test")
+	log.Info().Uint64("Requests", loadTestMetrics.RequestCount.Uint64()).Msg("Total Completed Requests calculated from Contract")
+	log.Info().Uint64("Fulfilments", loadTestMetrics.FulfilmentCount.Uint64()).Msg("Total Completed Fulfilments")
+	log.Info().Uint64("Fastest Fulfilment", loadTestMetrics.FastestFulfillment.Uint64()).Msg("Fastest Fulfilment")
+	log.Info().Uint64("Slowest Fulfilment", loadTestMetrics.SlowestFulfillment.Uint64()).Msg("Slowest Fulfilment")
+	log.Info().Interface("Average Fulfillment", averageFulfillmentInBlockTime).Msg("Average Fulfillment In Block Time")
 
 	//todo - need to calculate 95th percentile response time in Block time and calculate how many requests breached 256 block time requirement
 
-	l.Info().Str("Run Time", time.Since(startTime).String()).Msg("Finished VRFV2 Soak Test Requests")
+	log.Info().Str("Run Time", time.Since(startTime).String()).Msg("Finished VRFV2 Soak Test Requests")
 	require.Equal(t, 0, v.ErrorCount, "Expected 0 errors")
 	require.Equal(t, loadTestMetrics.RequestCount.Uint64(), loadTestMetrics.FulfilmentCount.Uint64(), "Number of Rand Requests should be equal to Number of Fulfillments")
 }


### PR DESCRIPTION
Remove most uses of deprecated chainlink.New(...) in tests Remove use of utils.GetTestLogger in favor of just using the logging already setup in chainlink-env