### PR TITLE
Avoid shared tags for root docker images. (#9534)

### DIFF
--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -112,11 +112,13 @@ runs:
       id: meta-root
       uses: docker/metadata-action@c4ee3adeed93b1fa6a762f209fb01608c1a22f1e # v4.4.4
       with:
-        flavor: |
-          suffix=-root,onlatest=true
         # list of Docker images to use as base name for tags
         images: ${{ env.shared-images }}
-        tags: ${{ env.shared-tag-list }}
+        # XXX: DO NOT USE SHARED TAGS HERE
+        tags: |
+          type=ref,event=branch,suffix=${{ inputs.ecr-tag-suffix }}-root
+          type=semver,pattern={{version}},suffix=${{ inputs.ecr-tag-suffix }}-root
+          type=sha,format=short,suffix=${{ inputs.ecr-tag-suffix }}-root
 
     - name: Build and push root docker image
       id: buildpush-root
@@ -132,18 +134,13 @@ runs:
           CHAINLINK_USER=root
           ${{ env.shared-build-args }}
 
-    - name: Save root image name in GITHUB_ENV and GITHUB_STEP_SUMMARY
+    - name: Save root image name in GITHUB_ENV
       id: save-root-image-name-env
       shell: sh
       run: |
         IMAGES_NAME_RAW=${{ fromJSON(steps.buildpush-root.outputs.metadata)['image.name'] }}
-        IMAGE_DIGEST=${{ fromJSON(steps.buildpush-root.outputs.metadata)['containerimage.digest'] }}
         IMAGE_NAME=$(echo "$IMAGES_NAME_RAW" | cut -d"," -f1)
         echo "root_image_name=${IMAGE_NAME}" >> $GITHUB_ENV
-        echo '## Container Images' >> $GITHUB_STEP_SUMMARY
-        echo '### Root Image' >> $GITHUB_STEP_SUMMARY
-        echo "Image Name: ${IMAGE_NAME}"  >> $GITHUB_STEP_SUMMARY
-        echo "Image Digest: ${IMAGE_DIGEST}"  >> $GITHUB_STEP_SUMMARY
 
     - name: Generate docker metadata for non-root image
       id: meta-nonroot
@@ -178,7 +175,7 @@ runs:
         IMAGE_DIGEST=${{ fromJSON(steps.buildpush-nonroot.outputs.metadata)['containerimage.digest'] }}
         IMAGE_NAME=$(echo "$IMAGES_NAME_RAW" | cut -d"," -f1)
         echo "nonroot_image_name=${IMAGE_NAME}" >> $GITHUB_ENV
-        echo '### Non-root Image' >> $GITHUB_STEP_SUMMARY
+        echo '### Docker Image' >> $GITHUB_STEP_SUMMARY
         echo "Image Name: ${IMAGE_NAME}"  >> $GITHUB_STEP_SUMMARY
         echo "Image Digest: ${IMAGE_DIGEST}"  >> $GITHUB_STEP_SUMMARY
 


### PR DESCRIPTION
Set the tags explicitly as the flavor was not overriding the previous set suffixes by `ecr-tag-suffix`.

Avoids adding root image to GitHub step summary due to deprecation.

(cherry picked from commit 27099907b5b77c597635b231b0113baaf034f9c0)