### PR TITLE
OCR2 allow multiple configs per spec ID

### DIFF
--- a/core/services/ocr2/database.go
+++ b/core/services/ocr2/database.go
@@ -19,6 +19,7 @@ import (
 type db struct {
 	q            pg.Q
 	oracleSpecID int32
+	pluginID     int32
 	lggr         logger.SugaredLogger
 }
 
@@ -27,12 +28,13 @@ var (
 )
 
 // NewDB returns a new DB scoped to this oracleSpecID
-func NewDB(sqlxDB *sqlx.DB, oracleSpecID int32, lggr logger.Logger, cfg pg.QConfig) *db {
+func NewDB(sqlxDB *sqlx.DB, oracleSpecID int32, pluginID int32, lggr logger.Logger, cfg pg.QConfig) *db {
 	namedLogger := lggr.Named("OCR2.DB")
 
 	return &db{
 		q:            pg.NewQ(sqlxDB, namedLogger, cfg),
 		oracleSpecID: oracleSpecID,
+		pluginID:     pluginID,
 		lggr:         logger.Sugared(lggr),
 	}
 }
@@ -115,7 +117,7 @@ func (d *db) ReadConfig(ctx context.Context) (c *ocrtypes.ContractConfig, err er
 		offchain_config_version,
 		offchain_config
 	FROM ocr2_contract_configs
-	WHERE ocr2_oracle_spec_id = $1
+	WHERE ocr2_oracle_spec_id = $1 AND plugin_id = $2
 	LIMIT 1`
 
 	c = new(ocrtypes.ContractConfig)
@@ -124,7 +126,7 @@ func (d *db) ReadConfig(ctx context.Context) (c *ocrtypes.ContractConfig, err er
 	signers := [][]byte{}
 	transmitters := [][]byte{}
 
-	err = d.q.QueryRowx(stmt, d.oracleSpecID).Scan(
+	err = d.q.QueryRowx(stmt, d.oracleSpecID, d.pluginID).Scan(
 		&digest,
 		&c.ConfigCount,
 		(*pq.ByteaArray)(&signers),
@@ -165,6 +167,7 @@ func (d *db) WriteConfig(ctx context.Context, c ocrtypes.ContractConfig) error {
 	stmt := `
 	INSERT INTO ocr2_contract_configs (
 		ocr2_oracle_spec_id,
+		plugin_id,
 		config_digest,
 		config_count,
 		signers,
@@ -176,8 +179,8 @@ func (d *db) WriteConfig(ctx context.Context, c ocrtypes.ContractConfig) error {
 		created_at,
 		updated_at
 	)
-	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, NOW(), NOW())
-	ON CONFLICT (ocr2_oracle_spec_id) DO UPDATE SET
+	VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, NOW(), NOW())
+	ON CONFLICT (ocr2_oracle_spec_id, plugin_id) DO UPDATE SET
 		config_digest = EXCLUDED.config_digest,
 		config_count = EXCLUDED.config_count,
 		signers = EXCLUDED.signers,
@@ -190,6 +193,7 @@ func (d *db) WriteConfig(ctx context.Context, c ocrtypes.ContractConfig) error {
 	`
 	_, err := d.q.ExecContext(ctx, stmt,
 		d.oracleSpecID,
+		d.pluginID,
 		c.ConfigDigest,
 		c.ConfigCount,
 		pq.ByteaArray(signers),

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -362,7 +362,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 	spec.RelayConfig["effectiveTransmitterID"] = effectiveTransmitterID
 	lggr = logger.Sugared(lggr.With("transmitterID", transmitterID))
 
-	ocrDB := NewDB(d.db, spec.ID, lggr, d.cfg.Database())
+	ocrDB := NewDB(d.db, spec.ID, 0, lggr, d.cfg.Database())
 	peerWrapper := d.peerWrapper
 	if peerWrapper == nil {
 		return nil, errors.New("cannot setup OCR2 job service, libp2p peer was missing")

--- a/core/store/migrate/migrations/0180_ocr2_multiple_configs_per_spec.sql
+++ b/core/store/migrate/migrations/0180_ocr2_multiple_configs_per_spec.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+ALTER TABLE ocr2_contract_configs
+  ADD COLUMN plugin_id INTEGER NOT NULL DEFAULT 0,
+  DROP CONSTRAINT offchainreporting2_contract_configs_pkey,
+  ADD CONSTRAINT ocr2_contract_configs_unique_id_pair UNIQUE (ocr2_oracle_spec_id, plugin_id);
+
+-- +goose Down
+ALTER TABLE ocr2_contract_configs
+  DROP CONSTRAINT ocr2_contract_configs_unique_id_pair,
+  ADD CONSTRAINT offchainreporting2_contract_configs_pkey PRIMARY KEY (ocr2_oracle_spec_id),
+  DROP COLUMN plugin_id;


### PR DESCRIPTION
Running multiple reporting plugins inside a single job requires multiple configs to be stored in the DB.
We're adding a new column "plugin_id" to make that possible.

Other tables are already namespaced by config_digest, which must be unique inside libocr.