### PR TITLE
Verifiable load ferglor

### DIFF
--- a/core/scripts/chaincli/handler/keeper_verifiable_load.go
+++ b/core/scripts/chaincli/handler/keeper_verifiable_load.go
@@ -80,7 +80,7 @@ func (k *Keeper) GetVerifiableLoadStats(ctx context.Context) {
 	var wg sync.WaitGroup
 
 	// create a number of workers to process the upkeep ids in batch
-	for i := 0; i < 10; i++ {
+	for i := 0; i < 5; i++ {
 		go k.getUpkeepInfo(idChan, resultsChan, v, opts, &wg)
 	}
 
@@ -133,6 +133,7 @@ func (k *Keeper) getUpkeepInfo(idChan chan *big.Int, resultsChan chan *UpkeepInf
 		if err != nil {
 			log.Fatalf("failed to get current bucket count for %s: %v", id.String(), err)
 		}
+
 		log.Printf("upkeep ID %s has been performed %d times in %d buckets\n", id.String(), c, b+1)
 		info := &UpkeepInfo{
 			ID:                    id,

--- a/core/scripts/chaincli/handler/keeper_verifiable_load.go
+++ b/core/scripts/chaincli/handler/keeper_verifiable_load.go
@@ -79,6 +79,7 @@ func (k *Keeper) GetVerifiableLoadStats(ctx context.Context) {
 		log.Println()
 		log.Printf("================================== UPKEEP %s SUMMARY =======================================================", id.String())
 
+		// fetch how many times this upkeep has been executed
 		c, err := v.Counters(opts, id)
 		if err != nil {
 			log.Fatalf("failed to get counter for %s: %v", id.String(), err)
@@ -106,15 +107,15 @@ func (k *Keeper) GetVerifiableLoadStats(ctx context.Context) {
 		wg.Wait()
 
 		// get all the timestamp buckets of an upkeep. performs which happen every 1 hour after the first perform fall into the same bucket.
-		t, err := v.TimestampBuckets(opts, id)
-		if err != nil {
-			log.Fatalf("failed to get timestamp bucket for %s: %v", id.String(), err)
-		}
-		info.TimestampBucket = t
-		for i := uint16(0); i <= t; i++ {
-			go k.getBucketData(v, opts, true, id, i, &wg, info)
-		}
-		wg.Wait()
+		//t, err := v.TimestampBuckets(opts, id)
+		//if err != nil {
+		//	log.Fatalf("failed to get timestamp bucket for %s: %v", id.String(), err)
+		//}
+		//info.TimestampBucket = t
+		//for i := uint16(0); i <= t; i++ {
+		//	go k.getBucketData(v, opts, true, id, i, &wg, info)
+		//}
+		//wg.Wait()
 
 		for i := uint16(0); i <= b; i++ {
 			bucketDelays := info.DelayBuckets[i]
@@ -131,10 +132,11 @@ func (k *Keeper) GetVerifiableLoadStats(ctx context.Context) {
 		p90, _ := stats.Percentile(info.SortedAllDelays, 90)
 		p95, _ := stats.Percentile(info.SortedAllDelays, 95)
 		p99, _ := stats.Percentile(info.SortedAllDelays, 99)
+		// TODO sometimes SortedAllDelays is empty
 		maxDelay := info.SortedAllDelays[len(info.SortedAllDelays)-1]
 
 		log.Printf("%d performs in total. p50: %f, p90: %f, p95: %f, p99: %f, max delay: %f, total delay blocks: %d, average perform delay: %f\n", info.TotalPerforms, p50, p90, p95, p99, maxDelay, uint64(info.TotalDelayBlock), info.TotalDelayBlock/float64(info.TotalPerforms))
-		log.Printf("All delays: %v", info.SortedAllDelays)
+		//log.Printf("All delays: %v", info.SortedAllDelays)
 		upkeepStats.AllInfos = append(upkeepStats.AllInfos, info)
 		upkeepStats.TotalPerforms += info.TotalPerforms
 		upkeepStats.TotalDelayBlock += info.TotalDelayBlock


### PR DESCRIPTION
- Extract a getUpkeepInfo function
- Update getUpkeepInfo to accept a channel of uint16
- Run 10 separate instances of getUpkeepInfo that each read from the same channel
- Feed the channel with all the upkeep IDs we want to fetch info for
- When getUpkeepInfo completes, send the info result into a results channel
- When all the ids have been sent, close the id channel
- This will cause each instance of getUpkeepInfo to terminate their loops and return
- This unblocks the wait group
- Read from the results channel and use the upkeep info as needed