### PR TITLE
Restored access to `ThresholdKeyShare` from OCR2 delegate.go & added env var support 

### DIFF
--- a/core/config/v2/env.go
+++ b/core/config/v2/env.go
@@ -24,6 +24,7 @@ var (
 	EnvPasswordVRF                  = EnvSecret("CL_PASSWORD_VRF")
 	EnvPyroscopeAuthToken           = EnvSecret("CL_PYROSCOPE_AUTH_TOKEN")
 	EnvPrometheusAuthToken          = EnvSecret("CL_PROMETHEUS_AUTH_TOKEN")
+	EnvThresholdKeyShare            = EnvSecret("CL_THRESHOLD_KEY_SHARE")
 )
 
 type Env string

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -421,7 +421,7 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 			relayers[relay.StarkNet] = chains.StarkNet
 		}
 		registrarConfig := plugins.NewRegistrarConfig(opts.GRPCOpts, opts.LoopRegistry.Register)
-		ocr2DelegateConfig := ocr2.NewDelegateConfig(cfg, cfg.Mercury(), cfg.Insecure(), cfg.JobPipeline(), cfg.Database(), registrarConfig)
+		ocr2DelegateConfig := ocr2.NewDelegateConfig(cfg, cfg.Mercury(), cfg.Threshold(), cfg.Insecure(), cfg.JobPipeline(), cfg.Database(), registrarConfig)
 		delegates[job.OffchainReporting2] = ocr2.NewDelegate(
 			db,
 			jobORM,

--- a/core/services/chainlink/config.go
+++ b/core/services/chainlink/config.go
@@ -197,5 +197,8 @@ func (s *Secrets) setEnv() error {
 	if prometheusAuthToken := config.EnvPrometheusAuthToken.Get(); prometheusAuthToken != "" {
 		s.Prometheus.AuthToken = &prometheusAuthToken
 	}
+	if thresholdKeyShare := config.EnvThresholdKeyShare.Get(); thresholdKeyShare != "" {
+		s.Threshold.ThresholdKeyShare = &thresholdKeyShare
+	}
 	return nil
 }

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -85,6 +85,7 @@ type DelegateConfig interface {
 	Database() pg.QConfig
 	Insecure() insecureConfig
 	Mercury() coreconfig.Mercury
+	Threshold() coreconfig.Threshold
 }
 
 // concrete implementation of DelegateConfig so it can be explicitly composed
@@ -95,6 +96,7 @@ type delegateConfig struct {
 	database    pg.QConfig
 	insecure    insecureConfig
 	mercury     mercuryConfig
+	threshold   thresholdConfig
 }
 
 func (d *delegateConfig) JobPipeline() jobPipelineConfig {
@@ -107,6 +109,10 @@ func (d *delegateConfig) Database() pg.QConfig {
 
 func (d *delegateConfig) Insecure() insecureConfig {
 	return d.insecure
+}
+
+func (d *delegateConfig) Threshold() coreconfig.Threshold {
+	return d.threshold
 }
 
 func (d *delegateConfig) Mercury() coreconfig.Mercury {
@@ -126,7 +132,11 @@ type mercuryConfig interface {
 	Credentials(credName string) *models.MercuryCredentials
 }
 
-func NewDelegateConfig(vc validate.Config, m coreconfig.Mercury, i insecureConfig, jp jobPipelineConfig, qconf pg.QConfig, pluginProcessCfg plugins.RegistrarConfig) DelegateConfig {
+type thresholdConfig interface {
+	ThresholdKeyShare() string
+}
+
+func NewDelegateConfig(vc validate.Config, m coreconfig.Mercury, t coreconfig.Threshold, i insecureConfig, jp jobPipelineConfig, qconf pg.QConfig, pluginProcessCfg plugins.RegistrarConfig) DelegateConfig {
 	return &delegateConfig{
 		Config:          vc,
 		RegistrarConfig: pluginProcessCfg,
@@ -134,6 +144,7 @@ func NewDelegateConfig(vc validate.Config, m coreconfig.Mercury, i insecureConfi
 		database:        qconf,
 		insecure:        i,
 		mercury:         m,
+		threshold:       t,
 	}
 }
 


### PR DESCRIPTION
This PR fixes the changes from PR #9541 which removed the ability to access the `ThresholdKeyShare` secrets config value in `delegate.go`.
It also adds support for setting the `ThresholdKeyShare` via an environment variable such that we can support this feature in our infra using environment variable overrides in order to assign each node in the cluster a separate key share.