### PR TITLE
[BCF-2343] Move some root fields into cfg.EVM()

### DIFF
--- a/common/txmgr/confirmer.go
+++ b/common/txmgr/confirmer.go
@@ -120,6 +120,7 @@ type Confirmer[
 	txmgrtypes.TxAttemptBuilder[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]
 	resumeCallback ResumeCallback
 	config         txmgrtypes.ConfirmerConfig
+	chainConfig    txmgrtypes.ConfirmerChainConfig
 	txConfig       txmgrtypes.ConfirmerTransactionsConfig
 	dbConfig       txmgrtypes.ConfirmerDatabaseConfig
 	chainID        CHAIN_ID
@@ -151,6 +152,7 @@ func NewConfirmer[
 	txStore txmgrtypes.TxStore[ADDR, CHAIN_ID, TX_HASH, BLOCK_HASH, R, SEQ, FEE],
 	client txmgrtypes.TxmClient[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE],
 	config txmgrtypes.ConfirmerConfig,
+	chainConfig txmgrtypes.ConfirmerChainConfig,
 	txConfig txmgrtypes.ConfirmerTransactionsConfig,
 	dbConfig txmgrtypes.ConfirmerDatabaseConfig,
 	keystore txmgrtypes.KeyStore[ADDR, CHAIN_ID, SEQ],
@@ -166,6 +168,7 @@ func NewConfirmer[
 		TxAttemptBuilder: txAttemptBuilder,
 		resumeCallback:   nil,
 		config:           config,
+		chainConfig:      chainConfig,
 		txConfig:         txConfig,
 		dbConfig:         dbConfig,
 		chainID:          client.ConfiguredChainID(),
@@ -345,7 +348,7 @@ func (ec *Confirmer[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) Che
 		return nil
 	}
 	ec.lggr.Infow(fmt.Sprintf("Found %d transactions confirmed_missing_receipt. The RPC node did not give us a receipt for these transactions even though it should have been mined. This could be due to using the wallet with an external account, or if the primary node is not synced or not propagating transactions properly", len(attempts)), "attempts", attempts)
-	txCodes, txErrs, err := ec.client.BatchSendTransactions(ctx, ec.txStore.UpdateBroadcastAts, attempts, int(ec.config.RPCDefaultBatchSize()), ec.lggr)
+	txCodes, txErrs, err := ec.client.BatchSendTransactions(ctx, ec.txStore.UpdateBroadcastAts, attempts, int(ec.chainConfig.RPCDefaultBatchSize()), ec.lggr)
 	if err != nil {
 		ec.lggr.Debugw("Batch sending transactions failed", err)
 	}
@@ -461,7 +464,7 @@ func (ec *Confirmer[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) sep
 func (ec *Confirmer[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) fetchAndSaveReceipts(ctx context.Context, attempts []txmgrtypes.TxAttempt[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE], blockNum int64) error {
 	promTxAttemptCount.WithLabelValues(ec.chainID.String()).Set(float64(len(attempts)))
 
-	batchSize := int(ec.config.RPCDefaultBatchSize())
+	batchSize := int(ec.chainConfig.RPCDefaultBatchSize())
 	if batchSize == 0 {
 		batchSize = len(attempts)
 	}

--- a/common/txmgr/resender.go
+++ b/common/txmgr/resender.go
@@ -49,7 +49,7 @@ type Resender[
 	ks                  txmgrtypes.KeyStore[ADDR, CHAIN_ID, SEQ]
 	chainID             CHAIN_ID
 	interval            time.Duration
-	config              txmgrtypes.ResenderConfig
+	config              txmgrtypes.ResenderChainConfig
 	txConfig            txmgrtypes.ResenderTransactionsConfig
 	logger              logger.Logger
 	lastAlertTimestamps map[string]time.Time
@@ -72,7 +72,7 @@ func NewResender[
 	client txmgrtypes.TransactionClient[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE],
 	ks txmgrtypes.KeyStore[ADDR, CHAIN_ID, SEQ],
 	pollInterval time.Duration,
-	config txmgrtypes.ResenderConfig,
+	config txmgrtypes.ResenderChainConfig,
 	txConfig txmgrtypes.ResenderTransactionsConfig,
 ) *Resender[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE] {
 	if txConfig.ResendAfterThreshold() == 0 {

--- a/common/txmgr/types/config.go
+++ b/common/txmgr/types/config.go
@@ -5,10 +5,7 @@ import "time"
 type TransactionManagerConfig interface {
 	BroadcasterConfig
 	ConfirmerConfig
-	ResenderConfig
 	ReaperConfig
-
-	SequenceAutoSync() bool
 }
 
 type TransactionManagerTransactionsConfig interface {
@@ -37,7 +34,6 @@ type BroadcasterListenerConfig interface {
 }
 
 type ConfirmerConfig interface {
-	RPCDefaultBatchSize() uint32
 	FeeBumpTxDepth() uint32
 	FeeLimitDefault() uint32
 
@@ -46,6 +42,10 @@ type ConfirmerConfig interface {
 	FinalityDepth() uint32
 	MaxFeePrice() string // logging value
 	FeeBumpPercent() uint16
+}
+
+type ConfirmerChainConfig interface {
+	RPCDefaultBatchSize() uint32
 }
 
 type ConfirmerDatabaseConfig interface {
@@ -58,7 +58,7 @@ type ConfirmerTransactionsConfig interface {
 	ForwardersEnabled() bool
 }
 
-type ResenderConfig interface {
+type ResenderChainConfig interface {
 	RPCDefaultBatchSize() uint32
 }
 

--- a/core/chains/evm/chain.go
+++ b/core/chains/evm/chain.go
@@ -120,7 +120,7 @@ func newChain(ctx context.Context, cfg evmconfig.ChainScopedConfig, nodes []*v2.
 		if opts.GenLogPoller != nil {
 			logPoller = opts.GenLogPoller(chainID)
 		} else {
-			logPoller = logpoller.NewObservedLogPoller(logpoller.NewORM(chainID, db, l, cfg.Database()), client, l, cfg.EvmLogPollInterval(), int64(cfg.EvmFinalityDepth()), int64(cfg.EvmLogBackfillBatchSize()), int64(cfg.EvmRPCDefaultBatchSize()), int64(cfg.EvmLogKeepBlocksDepth()))
+			logPoller = logpoller.NewObservedLogPoller(logpoller.NewORM(chainID, db, l, cfg.Database()), client, l, cfg.EVM().LogPollInterval(), int64(cfg.EvmFinalityDepth()), int64(cfg.EVM().LogBackfillBatchSize()), int64(cfg.EVM().RPCDefaultBatchSize()), int64(cfg.EVM().LogKeepBlocksDepth()))
 		}
 	}
 
@@ -149,7 +149,7 @@ func newChain(ctx context.Context, cfg evmconfig.ChainScopedConfig, nodes []*v2.
 		logBroadcaster = &log.NullBroadcaster{ErrMsg: fmt.Sprintf("Ethereum is disabled for chain %d", chainID)}
 	} else if opts.GenLogBroadcaster == nil {
 		logORM := log.NewORM(db, l, cfg.Database(), *chainID)
-		logBroadcaster = log.NewBroadcaster(logORM, client, cfg, l, highestSeenHead, opts.MailMon)
+		logBroadcaster = log.NewBroadcaster(logORM, client, cfg.EVM(), l, highestSeenHead, opts.MailMon)
 	} else {
 		logBroadcaster = opts.GenLogBroadcaster(chainID)
 	}

--- a/core/chains/evm/config/config.go
+++ b/core/chains/evm/config/config.go
@@ -15,9 +15,6 @@ import (
 type ChainScopedOnlyConfig interface {
 	evmclient.NodeConfig
 
-	AutoCreateKey() bool
-	BlockBackfillDepth() uint64
-	BlockBackfillSkip() bool
 	BlockEmissionIdleWarningThreshold() time.Duration
 	ChainID() *big.Int
 	EvmEIP1559DynamicFees() bool
@@ -40,13 +37,8 @@ type ChainScopedOnlyConfig interface {
 	EvmGasPriceDefault() *assets.Wei
 	EvmGasTipCapDefault() *assets.Wei
 	EvmGasTipCapMinimum() *assets.Wei
-	EvmLogBackfillBatchSize() uint32
-	EvmLogKeepBlocksDepth() uint32
-	EvmLogPollInterval() time.Duration
 	EvmMaxGasPriceWei() *assets.Wei
 	EvmMinGasPriceWei() *assets.Wei
-	EvmNonceAutoSync() bool
-	EvmRPCDefaultBatchSize() uint32
 	FlagsContractAddress() string
 	GasEstimatorMode() string
 	ChainType() config.ChainType
@@ -64,6 +56,16 @@ type EVM interface {
 	GasEstimator() GasEstimator
 	OCR() OCR
 	OCR2() OCR2
+
+	AutoCreateKey() bool
+	BlockBackfillDepth() uint64
+	BlockBackfillSkip() bool
+	FinalityDepth() uint32
+	LogBackfillBatchSize() uint32
+	LogPollInterval() time.Duration
+	LogKeepBlocksDepth() uint32
+	NonceAutoSync() bool
+	RPCDefaultBatchSize() uint32
 }
 
 type OCR interface {

--- a/core/chains/evm/config/mocks/chain_scoped_config.go
+++ b/core/chains/evm/config/mocks/chain_scoped_config.go
@@ -59,20 +59,6 @@ func (_m *ChainScopedConfig) AuditLogger() coreconfig.AuditLogger {
 	return r0
 }
 
-// AutoCreateKey provides a mock function with given fields:
-func (_m *ChainScopedConfig) AutoCreateKey() bool {
-	ret := _m.Called()
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
 // AutoPprof provides a mock function with given fields:
 func (_m *ChainScopedConfig) AutoPprof() coreconfig.AutoPprof {
 	ret := _m.Called()
@@ -84,34 +70,6 @@ func (_m *ChainScopedConfig) AutoPprof() coreconfig.AutoPprof {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(coreconfig.AutoPprof)
 		}
-	}
-
-	return r0
-}
-
-// BlockBackfillDepth provides a mock function with given fields:
-func (_m *ChainScopedConfig) BlockBackfillDepth() uint64 {
-	ret := _m.Called()
-
-	var r0 uint64
-	if rf, ok := ret.Get(0).(func() uint64); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint64)
-	}
-
-	return r0
-}
-
-// BlockBackfillSkip provides a mock function with given fields:
-func (_m *ChainScopedConfig) BlockBackfillSkip() bool {
-	ret := _m.Called()
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
 	}
 
 	return r0
@@ -553,48 +511,6 @@ func (_m *ChainScopedConfig) EvmGasTipCapMinimum() *assets.Wei {
 	return r0
 }
 
-// EvmLogBackfillBatchSize provides a mock function with given fields:
-func (_m *ChainScopedConfig) EvmLogBackfillBatchSize() uint32 {
-	ret := _m.Called()
-
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func() uint32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint32)
-	}
-
-	return r0
-}
-
-// EvmLogKeepBlocksDepth provides a mock function with given fields:
-func (_m *ChainScopedConfig) EvmLogKeepBlocksDepth() uint32 {
-	ret := _m.Called()
-
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func() uint32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint32)
-	}
-
-	return r0
-}
-
-// EvmLogPollInterval provides a mock function with given fields:
-func (_m *ChainScopedConfig) EvmLogPollInterval() time.Duration {
-	ret := _m.Called()
-
-	var r0 time.Duration
-	if rf, ok := ret.Get(0).(func() time.Duration); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(time.Duration)
-	}
-
-	return r0
-}
-
 // EvmMaxGasPriceWei provides a mock function with given fields:
 func (_m *ChainScopedConfig) EvmMaxGasPriceWei() *assets.Wei {
 	ret := _m.Called()
@@ -622,34 +538,6 @@ func (_m *ChainScopedConfig) EvmMinGasPriceWei() *assets.Wei {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*assets.Wei)
 		}
-	}
-
-	return r0
-}
-
-// EvmNonceAutoSync provides a mock function with given fields:
-func (_m *ChainScopedConfig) EvmNonceAutoSync() bool {
-	ret := _m.Called()
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// EvmRPCDefaultBatchSize provides a mock function with given fields:
-func (_m *ChainScopedConfig) EvmRPCDefaultBatchSize() uint32 {
-	ret := _m.Called()
-
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func() uint32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint32)
 	}
 
 	return r0

--- a/core/chains/evm/config/v2/chain_scoped.go
+++ b/core/chains/evm/config/v2/chain_scoped.go
@@ -85,20 +85,44 @@ func (e *evmConfig) GasEstimator() config.GasEstimator {
 	return &gasEstimatorConfig{c: e.c.GasEstimator, blockDelay: e.c.RPCBlockQueryDelay}
 }
 
+func (e *evmConfig) AutoCreateKey() bool {
+	return *e.c.AutoCreateKey
+}
+
+func (e *evmConfig) BlockBackfillDepth() uint64 {
+	return uint64(*e.c.BlockBackfillDepth)
+}
+
+func (e *evmConfig) BlockBackfillSkip() bool {
+	return *e.c.BlockBackfillSkip
+}
+
+func (e *evmConfig) LogBackfillBatchSize() uint32 {
+	return *e.c.LogBackfillBatchSize
+}
+
+func (e *evmConfig) LogPollInterval() time.Duration {
+	return e.c.LogPollInterval.Duration()
+}
+
+func (e *evmConfig) FinalityDepth() uint32 {
+	return *e.c.FinalityDepth
+}
+
+func (e *evmConfig) LogKeepBlocksDepth() uint32 {
+	return *e.c.LogKeepBlocksDepth
+}
+
+func (e *evmConfig) NonceAutoSync() bool {
+	return *e.c.NonceAutoSync
+}
+
+func (e *evmConfig) RPCDefaultBatchSize() uint32 {
+	return *e.c.RPCDefaultBatchSize
+}
+
 func (c *ChainScoped) EVM() config.EVM {
 	return &evmConfig{c: c.cfg}
-}
-
-func (c *ChainScoped) AutoCreateKey() bool {
-	return *c.cfg.AutoCreateKey
-}
-
-func (c *ChainScoped) BlockBackfillDepth() uint64 {
-	return uint64(*c.cfg.BlockBackfillDepth)
-}
-
-func (c *ChainScoped) BlockBackfillSkip() bool {
-	return *c.cfg.BlockBackfillSkip
 }
 
 func (c *ChainScoped) BlockEmissionIdleWarningThreshold() time.Duration {
@@ -107,10 +131,6 @@ func (c *ChainScoped) BlockEmissionIdleWarningThreshold() time.Duration {
 
 func (c *ChainScoped) EvmEIP1559DynamicFees() bool {
 	return *c.cfg.GasEstimator.EIP1559DynamicFees
-}
-
-func (t *transactionsConfig) MaxQueued() uint64 {
-	return uint64(*t.c.MaxQueued)
 }
 
 func (c *ChainScoped) EvmFinalityDepth() uint32 {
@@ -199,26 +219,6 @@ func (c *ChainScoped) EvmGasTipCapDefault() *assets.Wei {
 
 func (c *ChainScoped) EvmGasTipCapMinimum() *assets.Wei {
 	return c.cfg.GasEstimator.TipCapMin
-}
-
-func (c *ChainScoped) EvmLogBackfillBatchSize() uint32 {
-	return *c.cfg.LogBackfillBatchSize
-}
-
-func (c *ChainScoped) EvmLogPollInterval() time.Duration {
-	return c.cfg.LogPollInterval.Duration()
-}
-
-func (c *ChainScoped) EvmLogKeepBlocksDepth() uint32 {
-	return *c.cfg.LogKeepBlocksDepth
-}
-
-func (c *ChainScoped) EvmNonceAutoSync() bool {
-	return *c.cfg.NonceAutoSync
-}
-
-func (c *ChainScoped) EvmRPCDefaultBatchSize() uint32 {
-	return *c.cfg.RPCDefaultBatchSize
 }
 
 func (c *ChainScoped) FlagsContractAddress() string {
@@ -321,6 +321,10 @@ func (t *transactionsConfig) ResendAfterThreshold() time.Duration {
 
 func (t *transactionsConfig) MaxInFlight() uint32 {
 	return *t.c.MaxInFlight
+}
+
+func (t *transactionsConfig) MaxQueued() uint64 {
+	return uint64(*t.c.MaxQueued)
 }
 
 type headTrackerConfig struct {

--- a/core/chains/evm/evm_txm.go
+++ b/core/chains/evm/evm_txm.go
@@ -35,7 +35,7 @@ func newEvmTxm(
 		"gasBumpTxDepth", cfg.EvmGasBumpTxDepth(),
 		"maxInFlightTransactions", cfg.EVM().Transactions().MaxInFlight(),
 		"maxQueuedTransactions", cfg.EVM().Transactions().MaxQueued(),
-		"nonceAutoSync", cfg.EvmNonceAutoSync(),
+		"nonceAutoSync", cfg.EVM().NonceAutoSync(),
 		"gasLimitDefault", cfg.EvmGasLimitDefault(),
 	)
 
@@ -50,6 +50,7 @@ func newEvmTxm(
 		txm, err = txmgr.NewTxm(
 			db,
 			cfg,
+			cfg.EVM(),
 			cfg.EVM().Transactions(),
 			cfg.Database(),
 			cfg.Database().Listener(),

--- a/core/chains/evm/log/broadcaster.go
+++ b/core/chains/evm/log/broadcaster.go
@@ -124,8 +124,8 @@ type (
 	Config interface {
 		BlockBackfillDepth() uint64
 		BlockBackfillSkip() bool
-		EvmFinalityDepth() uint32
-		EvmLogBackfillBatchSize() uint32
+		FinalityDepth() uint32
+		LogBackfillBatchSize() uint32
 	}
 
 	ListenerOpts struct {
@@ -561,7 +561,7 @@ func (b *broadcaster) onNewHeads() {
 
 		b.lastSeenHeadNumber.Store(latestHead.Number)
 
-		keptLogsDepth := uint32(b.config.EvmFinalityDepth())
+		keptLogsDepth := uint32(b.config.FinalityDepth())
 		if b.registrations.highestNumConfirmations > keptLogsDepth {
 			keptLogsDepth = b.registrations.highestNumConfirmations
 		}

--- a/core/chains/evm/log/eth_subscriber.go
+++ b/core/chains/evm/log/eth_subscriber.go
@@ -100,7 +100,7 @@ func (sub *ethSubscriber) backfillLogs(fromBlockOverride null.Int64, addresses [
 		// request data limit.
 		// On matic its 5MB [https://github.com/maticnetwork/bor/blob/3de2110886522ab17e0b45f3c4a6722da72b7519/rpc/http.go#L35]
 		// On ethereum its 15MB [https://github.com/ethereum/go-ethereum/blob/master/rpc/websocket.go#L40]
-		batchSize := int64(sub.config.EvmLogBackfillBatchSize())
+		batchSize := int64(sub.config.LogBackfillBatchSize())
 		for from := q.FromBlock.Int64(); from <= latestHeight; from += batchSize {
 
 			to := from + batchSize - 1
@@ -122,7 +122,7 @@ func (sub *ethSubscriber) backfillLogs(fromBlockOverride null.Int64, addresses [
 			}
 			if err != nil {
 				if ctx.Err() != nil {
-					sub.logger.Errorw("LogBroadcaster: Deadline exceeded, unable to backfill a batch of logs. Consider setting EvmLogBackfillBatchSize to a lower value", "err", err, "elapsed", elapsed, "fromBlock", q.FromBlock.String(), "toBlock", q.ToBlock.String())
+					sub.logger.Errorw("LogBroadcaster: Deadline exceeded, unable to backfill a batch of logs. Consider setting EVM.LogBackfillBatchSize to a lower value", "err", err, "elapsed", elapsed, "fromBlock", q.FromBlock.String(), "toBlock", q.ToBlock.String())
 				} else {
 					sub.logger.Errorw("LogBroadcaster: Unable to backfill a batch of logs after retries", "err", err, "fromBlock", q.FromBlock.String(), "toBlock", q.ToBlock.String())
 				}
@@ -176,7 +176,7 @@ func (sub *ethSubscriber) fetchLogBatch(ctx context.Context, query ethereum.Filt
 
 		if err != nil {
 			if ctx.Err() != nil {
-				sub.logger.Errorw("LogBroadcaster: Inner deadline exceeded, unable to backfill a batch of logs. Consider setting EvmLogBackfillBatchSize to a lower value", "err", err, "elapsed", time.Since(start),
+				sub.logger.Errorw("LogBroadcaster: Inner deadline exceeded, unable to backfill a batch of logs. Consider setting EVM.LogBackfillBatchSize to a lower value", "err", err, "elapsed", time.Since(start),
 					"fromBlock", query.FromBlock.String(), "toBlock", query.ToBlock.String())
 			} else {
 				sub.logger.Errorw("LogBroadcaster: Unable to backfill a batch of logs", "err", err,

--- a/core/chains/evm/log/helpers_test.go
+++ b/core/chains/evm/log/helpers_test.go
@@ -109,7 +109,7 @@ func (c broadcasterHelperCfg) newWithEthClient(t *testing.T, ethClient evmclient
 	mailMon := srvctest.Start(t, utils.NewMailboxMonitor(t.Name()))
 
 	orm := log.NewORM(c.db, lggr, config.Database(), cltest.FixtureChainID)
-	lb := log.NewTestBroadcaster(orm, ethClient, config, lggr, c.highestSeenHead, mailMon)
+	lb := log.NewTestBroadcaster(orm, ethClient, config.EVM(), lggr, c.highestSeenHead, mailMon)
 	kst := cltest.NewKeyStore(t, c.db, globalConfig.Database())
 
 	cc := evmtest.NewChainSet(t, evmtest.TestChainOpts{

--- a/core/chains/evm/log/integration_test.go
+++ b/core/chains/evm/log/integration_test.go
@@ -85,7 +85,7 @@ func TestBroadcaster_ResubscribesOnAddOrRemoveContract(t *testing.T) {
 	helper := newBroadcasterHelperWithEthClient(t, mockEth.EthClient, cltest.Head(lastStoredBlockHeight), nil)
 	helper.mockEth = mockEth
 
-	blockBackfillDepth := helper.config.BlockBackfillDepth()
+	blockBackfillDepth := helper.config.EVM().BlockBackfillDepth()
 
 	var backfillCount atomic.Int64
 
@@ -161,7 +161,7 @@ func TestBroadcaster_BackfillOnNodeStartAndOnReplay(t *testing.T) {
 	listener2 := helper.newLogListenerWithJob("two")
 	helper.register(listener2, newMockContract(), uint32(2))
 
-	blockBackfillDepth := helper.config.BlockBackfillDepth()
+	blockBackfillDepth := helper.config.EVM().BlockBackfillDepth()
 
 	// the first backfill should use the height of last head saved to the db,
 	// minus maxNumConfirmations of subscribers and minus blockBackfillDepth
@@ -524,7 +524,7 @@ func TestBroadcaster_BackfillInBatches(t *testing.T) {
 	})
 	helper.mockEth = mockEth
 
-	blockBackfillDepth := helper.config.BlockBackfillDepth()
+	blockBackfillDepth := helper.config.EVM().BlockBackfillDepth()
 
 	var backfillCount atomic.Int64
 

--- a/core/chains/evm/txmgr/config.go
+++ b/core/chains/evm/txmgr/config.go
@@ -26,9 +26,12 @@ type Config interface {
 	EvmGasTipCapMinimum() *assets.Wei
 	EvmMaxGasPriceWei() *assets.Wei
 	EvmMinGasPriceWei() *assets.Wei
-	EvmNonceAutoSync() bool
-	EvmRPCDefaultBatchSize() uint32
 	KeySpecificMaxGasPriceWei(addr common.Address) *assets.Wei
+}
+
+type ChainConfig interface {
+	NonceAutoSync() bool
+	RPCDefaultBatchSize() uint32
 }
 
 type DatabaseConfig interface {
@@ -44,7 +47,7 @@ type (
 	EvmTxmConfig         txmgrtypes.TransactionManagerConfig
 	EvmBroadcasterConfig txmgrtypes.BroadcasterConfig
 	EvmConfirmerConfig   txmgrtypes.ConfirmerConfig
-	EvmResenderConfig    txmgrtypes.ResenderConfig
+	EvmResenderConfig    txmgrtypes.ResenderChainConfig
 	EvmReaperConfig      txmgrtypes.ReaperConfig
 )
 
@@ -58,15 +61,11 @@ func NewEvmTxmConfig(c Config) *evmTxmConfig {
 	return &evmTxmConfig{c}
 }
 
-func (c evmTxmConfig) SequenceAutoSync() bool { return c.EvmNonceAutoSync() }
-
 func (c evmTxmConfig) IsL2() bool { return c.ChainType().IsL2() }
 
 func (c evmTxmConfig) MaxFeePrice() string { return c.EvmMaxGasPriceWei().String() }
 
 func (c evmTxmConfig) FeePriceDefault() string { return c.EvmGasPriceDefault().String() }
-
-func (c evmTxmConfig) RPCDefaultBatchSize() uint32 { return c.EvmRPCDefaultBatchSize() }
 
 func (c evmTxmConfig) FeeBumpTxDepth() uint32 { return c.EvmGasBumpTxDepth() }
 

--- a/core/chains/evm/txmgr/confirmer_test.go
+++ b/core/chains/evm/txmgr/confirmer_test.go
@@ -122,7 +122,7 @@ func TestEthConfirmer_Lifecycle(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	feeEstimator := gas.NewWrappedEvmEstimator(estimator, config.EvmEIP1559DynamicFees())
 	txBuilder := txmgr.NewEvmTxAttemptBuilder(*ethClient.ConfiguredChainID(), config, ethKeyStore, feeEstimator)
-	ec := txmgr.NewEvmConfirmer(txStore, txmgr.NewEvmTxmClient(ethClient), txmgr.NewEvmTxmConfig(config), config.EVM().Transactions(), config.Database(), ethKeyStore, txBuilder, lggr)
+	ec := txmgr.NewEvmConfirmer(txStore, txmgr.NewEvmTxmClient(ethClient), txmgr.NewEvmTxmConfig(config), config.EVM(), config.EVM().Transactions(), config.Database(), ethKeyStore, txBuilder, lggr)
 	ctx := testutils.Context(t)
 
 	// Can't close unstarted instance
@@ -1648,7 +1648,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WithConnectivityCheck(t *testing
 		addresses := []gethCommon.Address{fromAddress}
 		kst.On("EnabledAddressesForChain", &cltest.FixtureChainID).Return(addresses, nil).Maybe()
 		// Create confirmer with necessary state
-		ec := txmgr.NewEvmConfirmer(txStore, txmgr.NewEvmTxmClient(ethClient), evmcfg, ccfg.EVM().Transactions(), cfg.Database(), kst, txBuilder, lggr)
+		ec := txmgr.NewEvmConfirmer(txStore, txmgr.NewEvmTxmClient(ethClient), evmcfg, ccfg.EVM(), ccfg.EVM().Transactions(), cfg.Database(), kst, txBuilder, lggr)
 		require.NoError(t, ec.Start(testutils.Context(t)))
 		currentHead := int64(30)
 		oldEnough := int64(15)
@@ -1692,7 +1692,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WithConnectivityCheck(t *testing
 		txBuilder := txmgr.NewEvmTxAttemptBuilder(*ethClient.ConfiguredChainID(), evmcfg, kst, feeEstimator)
 		addresses := []gethCommon.Address{fromAddress}
 		kst.On("EnabledAddressesForChain", &cltest.FixtureChainID).Return(addresses, nil).Maybe()
-		ec := txmgr.NewEvmConfirmer(txStore, txmgr.NewEvmTxmClient(ethClient), evmcfg, ccfg.EVM().Transactions(), cfg.Database(), kst, txBuilder, lggr)
+		ec := txmgr.NewEvmConfirmer(txStore, txmgr.NewEvmTxmClient(ethClient), evmcfg, ccfg.EVM(), ccfg.EVM().Transactions(), cfg.Database(), kst, txBuilder, lggr)
 		require.NoError(t, ec.Start(testutils.Context(t)))
 		currentHead := int64(30)
 		oldEnough := int64(15)

--- a/core/chains/evm/txmgr/mocks/config.go
+++ b/core/chains/evm/txmgr/mocks/config.go
@@ -178,34 +178,6 @@ func (_m *Config) EvmMinGasPriceWei() *assets.Wei {
 	return r0
 }
 
-// EvmNonceAutoSync provides a mock function with given fields:
-func (_m *Config) EvmNonceAutoSync() bool {
-	ret := _m.Called()
-
-	var r0 bool
-	if rf, ok := ret.Get(0).(func() bool); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(bool)
-	}
-
-	return r0
-}
-
-// EvmRPCDefaultBatchSize provides a mock function with given fields:
-func (_m *Config) EvmRPCDefaultBatchSize() uint32 {
-	ret := _m.Called()
-
-	var r0 uint32
-	if rf, ok := ret.Get(0).(func() uint32); ok {
-		r0 = rf()
-	} else {
-		r0 = ret.Get(0).(uint32)
-	}
-
-	return r0
-}
-
 // KeySpecificMaxGasPriceWei provides a mock function with given fields: addr
 func (_m *Config) KeySpecificMaxGasPriceWei(addr common.Address) *assets.Wei {
 	ret := _m.Called(addr)

--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -366,7 +366,7 @@ func (s *Shell) runNode(c *cli.Context) error {
 		}
 
 		for _, ch := range evmChainSet.Chains() {
-			if ch.Config().AutoCreateKey() {
+			if ch.Config().EVM().AutoCreateKey() {
 				lggr.Debugf("AutoCreateKey=true, will ensure EVM key for chain %s", ch.ID())
 				err2 := app.GetKeyStore().Eth().EnsureKeys(ch.ID())
 				if err2 != nil {
@@ -621,7 +621,7 @@ func (s *Shell) RebroadcastTransactions(c *cli.Context) (err error) {
 	orm := txmgr.NewTxStore(app.GetSqlxDB(), lggr, s.Config.Database())
 	txBuilder := txmgr.NewEvmTxAttemptBuilder(*ethClient.ConfiguredChainID(), chain.Config(), keyStore.Eth(), nil)
 	cfg := txmgr.NewEvmTxmConfig(chain.Config())
-	ec := txmgr.NewEvmConfirmer(orm, txmgr.NewEvmTxmClient(ethClient), cfg, chain.Config().EVM().Transactions(), chain.Config().Database(), keyStore.Eth(), txBuilder, chain.Logger())
+	ec := txmgr.NewEvmConfirmer(orm, txmgr.NewEvmTxmClient(ethClient), cfg, chain.Config().EVM(), chain.Config().EVM().Transactions(), chain.Config().Database(), keyStore.Eth(), txBuilder, chain.Logger())
 	totalNonces := endingNonce - beginningNonce + 1
 	nonces := make([]evmtypes.Nonce, totalNonces)
 	for i := int64(0); i < totalNonces; i++ {

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -219,7 +219,7 @@ func NewEthConfirmer(t testing.TB, txStore txmgr.EvmTxStore, ethClient evmclient
 	lggr := logger.TestLogger(t)
 	estimator := gas.NewWrappedEvmEstimator(gas.NewFixedPriceEstimator(config, config.EVM().GasEstimator().BlockHistory(), lggr), config.EvmEIP1559DynamicFees())
 	txBuilder := txmgr.NewEvmTxAttemptBuilder(*ethClient.ConfiguredChainID(), config, ks, estimator)
-	ec := txmgr.NewEvmConfirmer(txStore, txmgr.NewEvmTxmClient(ethClient), txmgr.NewEvmTxmConfig(config), config.EVM().Transactions(), config.Database(), ks, txBuilder, lggr)
+	ec := txmgr.NewEvmConfirmer(txStore, txmgr.NewEvmTxmClient(ethClient), txmgr.NewEvmTxmConfig(config), config.EVM(), config.EVM().Transactions(), config.Database(), ks, txBuilder, lggr)
 	ec.SetResumeCallback(fn)
 	require.NoError(t, ec.Start(testutils.Context(t)))
 	return ec, nil


### PR DESCRIPTION
Move a selection of root EVM config fields into cfg.EVM().