### PR TITLE
Fix "make testscripts" command for BSD-style xargs

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -123,8 +123,8 @@ generate: abigen codecgen mockery ## Execute all go:generate commands.
 .PHONY: testscripts
 testscripts: chainlink-test ## Install and run testscript against testdata/scripts/* files.
 	go install github.com/rogpeppe/go-internal/cmd/testscript@latest
-	go run ./tools/txtar/cmd/lstxtardirs -recurse=true | xargs -I % \
-		sh -c 'PATH=$(CURDIR):$(PATH) testscript -e COMMIT_SHA=$(COMMIT_SHA) -e HOME="$(TMPDIR)/home" -e VERSION=$(VERSION) $(TS_FLAGS) %/*.txtar'
+	go run ./tools/txtar/cmd/lstxtardirs -recurse=true | PATH="$(CURDIR):${PATH}" xargs -I % \
+		sh -c 'testscript -e COMMIT_SHA=$(COMMIT_SHA) -e HOME="$(TMPDIR)/home" -e VERSION=$(VERSION) $(TS_FLAGS) %/*.txtar'
 
 .PHONY: testscripts-update
 testscripts-update: ## Update testdata/scripts/* files via testscript.


### PR DESCRIPTION
On MacOS (or other BSD-based environments?), xargs has a default buffer limit of 255 characters for each argument that needs replacement.  Placing the PATH= directive inside the sh -c '...' argument which also contains % means it's counted all as one giant argument that needs to be replaced.  Moving it before xargs sidesteps this requirement.  Also changing to `${PATH}` from `$(PATH)` reduces the size of the total line significantly.

(Using -S would also work here for MacOS but would probably break Linux)