### PR TITLE
Remove skip from gas benchmarking tests

### DIFF
--- a/contracts/test/v0.8/automation/KeeperRegistry2_1.test.ts
+++ b/contracts/test/v0.8/automation/KeeperRegistry2_1.test.ts
@@ -1712,134 +1712,130 @@ describe('KeeperRegistry2_1', () => {
           }
         },
       )
-    })
 
-    describe('Gas benchmarking [ @skip-coverage ]', function () {
-      const fs = [1, 10]
-      fs.forEach(function (newF) {
-        it(
-          'When f=' +
-            newF +
-            'calculates gas overhead appropriately within a margin for different scenarios',
-          async () => {
-            // Fund the upkeeps
-            await Promise.all([
-              registry.connect(admin).addFunds(upkeepId, toWei('100')),
-              registry.connect(admin).addFunds(cronUpkeepId, toWei('100')),
-              registry.connect(admin).addFunds(logUpkeepId, toWei('100')),
-            ])
-            // Perform the upkeep once to remove non-zero storage slots and have predictable gas measurement
-            let tx = await getTransmitTx(registry, keeper1, [upkeepId])
-            await tx.wait()
+      describeMaybe('Gas benchmarking [ @skip-coverage ]', function () {
+        const fs = [1, 10]
+        fs.forEach(function (newF) {
+          it(
+            'When f=' +
+              newF +
+              'calculates gas overhead appropriately within a margin for different scenarios',
+            async () => {
+              // Perform the upkeep once to remove non-zero storage slots and have predictable gas measurement
+              let tx = await getTransmitTx(registry, keeper1, [upkeepId])
+              await tx.wait()
 
-            // Different test scenarios
-            let longBytes = '0x'
-            for (let i = 0; i < maxPerformDataSize.toNumber(); i++) {
-              longBytes += '11'
-            }
-            const upkeepSuccessArray = [true, false]
-            const performGasArray = [5000, executeGas]
-            const performDataArray = ['0x', longBytes]
+              // Different test scenarios
+              let longBytes = '0x'
+              for (let i = 0; i < maxPerformDataSize.toNumber(); i++) {
+                longBytes += '11'
+              }
+              const upkeepSuccessArray = [true, false]
+              const performGasArray = [5000, executeGas]
+              const performDataArray = ['0x', longBytes]
 
-            for (const i in upkeepSuccessArray) {
-              for (const j in performGasArray) {
-                for (const k in performDataArray) {
-                  const upkeepSuccess = upkeepSuccessArray[i]
-                  const performGas = performGasArray[j]
-                  const performData = performDataArray[k]
-                  console.log(
-                    'Testing with upkeepSuccess=' +
-                      upkeepSuccess +
-                      ', performGas=' +
-                      performGas +
-                      ', performData length=' +
-                      (performData.length / 2 - 1),
-                  )
-
-                  await mock.setCanPerform(upkeepSuccess)
-                  await mock.setPerformGasToBurn(performGas)
-                  await registry
-                    .connect(owner)
-                    .setConfig(
-                      signerAddresses,
-                      keeperAddresses,
-                      newF,
-                      encodeConfig(config),
-                      offchainVersion,
-                      offchainBytes,
-                    )
-                  tx = await getTransmitTx(registry, keeper1, [upkeepId], {
-                    numSigners: newF + 1,
-                    performData,
-                  })
-                  const receipt = await tx.wait()
-                  const upkeepPerformedLogs = parseUpkeepPerformedLogs(receipt)
-                  // exactly 1 Upkeep Performed should be emitted
-                  assert.equal(upkeepPerformedLogs.length, 1)
-                  const upkeepPerformedLog = upkeepPerformedLogs[0]
-
-                  const upkeepGasUsed = upkeepPerformedLog.args.gasUsed
-                  const chargedGasOverhead = upkeepPerformedLog.args.gasOverhead
-                  const actualGasOverhead = receipt.gasUsed.sub(upkeepGasUsed)
-
-                  assert.isTrue(upkeepGasUsed.gt(BigNumber.from('0')))
-                  assert.isTrue(chargedGasOverhead.gt(BigNumber.from('0')))
-
-                  if (i == '0' && j == '0' && k == '0') {
+              for (const i in upkeepSuccessArray) {
+                for (const j in performGasArray) {
+                  for (const k in performDataArray) {
+                    const upkeepSuccess = upkeepSuccessArray[i]
+                    const performGas = performGasArray[j]
+                    const performData = performDataArray[k]
                     console.log(
-                      'Gas Benchmarking - sig verification ( f =',
-                      newF,
-                      '): calculated overhead: ',
-                      chargedGasOverhead.toString(),
-                      ' actual overhead: ',
-                      actualGasOverhead.toString(),
-                      ' margin over gasUsed: ',
-                      chargedGasOverhead.sub(actualGasOverhead).toString(),
+                      'Testing with upkeepSuccess=' +
+                        upkeepSuccess +
+                        ', performGas=' +
+                        performGas +
+                        ', performData length=' +
+                        (performData.length / 2 - 1),
                     )
-                  }
 
-                  // Overhead should not get capped
-                  const gasOverheadCap = registryGasOverhead
-                    .add(
-                      registryPerSignerGasOverhead.mul(
-                        BigNumber.from(newF + 1),
-                      ),
-                    )
-                    .add(
-                      BigNumber.from(
-                        registryPerPerformByteGasOverhead.toNumber() *
-                          performData.length,
-                      ),
-                    )
-                  const gasCapMinusOverhead =
-                    gasOverheadCap.sub(chargedGasOverhead)
-                  assert.isTrue(
-                    gasCapMinusOverhead.gt(BigNumber.from(0)),
-                    'Gas overhead got capped. Verify gas overhead variables in test match those in the registry. To not have the overheads capped increase REGISTRY_GAS_OVERHEAD by atleast ' +
-                      gasCapMinusOverhead.toString(),
-                  )
-                  // total gas charged should be greater than tx gas but within gasCalculationMargin
-                  assert.isTrue(
-                    chargedGasOverhead.gt(actualGasOverhead),
-                    'Gas overhead calculated is too low, increase account gas variables (ACCOUNTING_FIXED_GAS_OVERHEAD/ACCOUNTING_PER_SIGNER_GAS_OVERHEAD) by atleast ' +
-                      actualGasOverhead.sub(chargedGasOverhead).toString(),
-                  )
+                    await mock.setCanPerform(upkeepSuccess)
+                    await mock.setPerformGasToBurn(performGas)
+                    await registry
+                      .connect(owner)
+                      .setConfig(
+                        signerAddresses,
+                        keeperAddresses,
+                        newF,
+                        encodeConfig(config),
+                        offchainVersion,
+                        offchainBytes,
+                      )
+                    tx = await getTransmitTx(registry, keeper1, [upkeepId], {
+                      numSigners: newF + 1,
+                      performData,
+                    })
+                    const receipt = await tx.wait()
+                    const upkeepPerformedLogs =
+                      parseUpkeepPerformedLogs(receipt)
+                    // exactly 1 Upkeep Performed should be emitted
+                    assert.equal(upkeepPerformedLogs.length, 1)
+                    const upkeepPerformedLog = upkeepPerformedLogs[0]
 
-                  assert.isTrue(
-                    chargedGasOverhead
-                      .sub(actualGasOverhead)
-                      .lt(BigNumber.from(gasCalculationMargin)),
-                  ),
-                    'Gas overhead calculated is too high, decrease account gas variables (ACCOUNTING_FIXED_GAS_OVERHEAD/ACCOUNTING_PER_SIGNER_GAS_OVERHEAD)  by atleast ' +
+                    const upkeepGasUsed = upkeepPerformedLog.args.gasUsed
+                    const chargedGasOverhead =
+                      upkeepPerformedLog.args.gasOverhead
+                    const actualGasOverhead = receipt.gasUsed.sub(upkeepGasUsed)
+
+                    assert.isTrue(upkeepGasUsed.gt(BigNumber.from('0')))
+                    assert.isTrue(chargedGasOverhead.gt(BigNumber.from('0')))
+
+                    if (i == '0' && j == '0' && k == '0') {
+                      console.log(
+                        'Gas Benchmarking - sig verification ( f =',
+                        newF,
+                        '): calculated overhead: ',
+                        chargedGasOverhead.toString(),
+                        ' actual overhead: ',
+                        actualGasOverhead.toString(),
+                        ' margin over gasUsed: ',
+                        chargedGasOverhead.sub(actualGasOverhead).toString(),
+                      )
+                    }
+
+                    // Overhead should not get capped
+                    const gasOverheadCap = registryGasOverhead
+                      .add(
+                        registryPerSignerGasOverhead.mul(
+                          BigNumber.from(newF + 1),
+                        ),
+                      )
+                      .add(
+                        BigNumber.from(
+                          registryPerPerformByteGasOverhead.toNumber() *
+                            performData.length,
+                        ),
+                      )
+                    const gasCapMinusOverhead =
+                      gasOverheadCap.sub(chargedGasOverhead)
+                    assert.isTrue(
+                      gasCapMinusOverhead.gt(BigNumber.from(0)),
+                      'Gas overhead got capped. Verify gas overhead variables in test match those in the registry. To not have the overheads capped increase REGISTRY_GAS_OVERHEAD by atleast ' +
+                        gasCapMinusOverhead.toString(),
+                    )
+                    // total gas charged should be greater than tx gas but within gasCalculationMargin
+                    assert.isTrue(
+                      chargedGasOverhead.gt(actualGasOverhead),
+                      'Gas overhead calculated is too low, increase account gas variables (ACCOUNTING_FIXED_GAS_OVERHEAD/ACCOUNTING_PER_SIGNER_GAS_OVERHEAD) by atleast ' +
+                        actualGasOverhead.sub(chargedGasOverhead).toString(),
+                    )
+
+                    assert.isTrue(
                       chargedGasOverhead
-                        .sub(chargedGasOverhead)
-                        .sub(BigNumber.from(gasCalculationMargin))
-                        .toString()
+                        .sub(actualGasOverhead)
+                        .lt(BigNumber.from(gasCalculationMargin)),
+                    ),
+                      'Gas overhead calculated is too high, decrease account gas variables (ACCOUNTING_FIXED_GAS_OVERHEAD/ACCOUNTING_PER_SIGNER_GAS_OVERHEAD)  by atleast ' +
+                        chargedGasOverhead
+                          .sub(chargedGasOverhead)
+                          .sub(BigNumber.from(gasCalculationMargin))
+                          .toString()
+                  }
                 }
               }
-            }
-          },
-        )
+            },
+          )
+        })
       })
     })
 

--- a/contracts/test/v0.8/automation/KeeperRegistry2_1.test.ts
+++ b/contracts/test/v0.8/automation/KeeperRegistry2_1.test.ts
@@ -1719,7 +1719,7 @@ describe('KeeperRegistry2_1', () => {
           it(
             'When f=' +
               newF +
-              'calculates gas overhead appropriately within a margin for different scenarios',
+              ' calculates gas overhead appropriately within a margin for different scenarios',
             async () => {
               // Perform the upkeep once to remove non-zero storage slots and have predictable gas measurement
               let tx = await getTransmitTx(registry, keeper1, [upkeepId])

--- a/contracts/test/v0.8/automation/KeeperRegistry2_1.test.ts
+++ b/contracts/test/v0.8/automation/KeeperRegistry2_1.test.ts
@@ -1712,114 +1712,134 @@ describe('KeeperRegistry2_1', () => {
           }
         },
       )
+    })
 
-      // TODO - this test is timing out
-      it.skip('calculates gas overhead appropriately within a margin for different scenarios [ @skip-coverage ]', async () => {
-        // Perform the upkeep once to remove non-zero storage slots and have predictable gas measurement
+    describe('Gas benchmarking [ @skip-coverage ]', function () {
+      const fs = [1, 10]
+      fs.forEach(function (newF) {
+        it(
+          'When f=' +
+            newF +
+            'calculates gas overhead appropriately within a margin for different scenarios',
+          async () => {
+            // Fund the upkeeps
+            await Promise.all([
+              registry.connect(admin).addFunds(upkeepId, toWei('100')),
+              registry.connect(admin).addFunds(cronUpkeepId, toWei('100')),
+              registry.connect(admin).addFunds(logUpkeepId, toWei('100')),
+            ])
+            // Perform the upkeep once to remove non-zero storage slots and have predictable gas measurement
+            let tx = await getTransmitTx(registry, keeper1, [upkeepId])
+            await tx.wait()
 
-        let tx = await getTransmitTx(registry, keeper1, [upkeepId])
+            // Different test scenarios
+            let longBytes = '0x'
+            for (let i = 0; i < maxPerformDataSize.toNumber(); i++) {
+              longBytes += '11'
+            }
+            const upkeepSuccessArray = [true, false]
+            const performGasArray = [5000, executeGas]
+            const performDataArray = ['0x', longBytes]
 
-        await tx.wait()
-
-        // Different test scenarios
-        let longBytes = '0x'
-        for (let i = 0; i < maxPerformDataSize.toNumber(); i++) {
-          longBytes += '11'
-        }
-        const upkeepSuccessArray = [true, false]
-        const performGasArray = [5000, 100000, executeGas]
-        const performDataArray = ['0x', randomBytes, longBytes]
-
-        for (const i in upkeepSuccessArray) {
-          for (const j in performGasArray) {
-            for (const k in performDataArray) {
-              for (const l in fArray) {
-                const upkeepSuccess = upkeepSuccessArray[i]
-                const performGas = performGasArray[j]
-                const performData = performDataArray[k]
-                const newF = fArray[l]
-
-                await mock.setCanPerform(upkeepSuccess)
-                await mock.setPerformGasToBurn(performGas)
-                await registry
-                  .connect(owner)
-                  .setConfig(
-                    signerAddresses,
-                    keeperAddresses,
-                    newF,
-                    encodeConfig(config),
-                    offchainVersion,
-                    offchainBytes,
-                  )
-                tx = await getTransmitTx(registry, keeper1, [upkeepId], {
-                  numSigners: newF + 1,
-                  performData,
-                })
-                const receipt = await tx.wait()
-                const upkeepPerformedLogs = parseUpkeepPerformedLogs(receipt)
-                // exactly 1 Upkeep Performed should be emitted
-                assert.equal(upkeepPerformedLogs.length, 1)
-                const upkeepPerformedLog = upkeepPerformedLogs[0]
-
-                const upkeepGasUsed = upkeepPerformedLog.args.gasUsed
-                const chargedGasOverhead = upkeepPerformedLog.args.gasOverhead
-                const actualGasOverhead = receipt.gasUsed.sub(upkeepGasUsed)
-
-                assert.isTrue(upkeepGasUsed.gt(BigNumber.from('0')))
-                assert.isTrue(chargedGasOverhead.gt(BigNumber.from('0')))
-
-                if (i == '0' && j == '0' && k == '0') {
+            for (const i in upkeepSuccessArray) {
+              for (const j in performGasArray) {
+                for (const k in performDataArray) {
+                  const upkeepSuccess = upkeepSuccessArray[i]
+                  const performGas = performGasArray[j]
+                  const performData = performDataArray[k]
                   console.log(
-                    'Gas Benchmarking - sig verification ( f =',
-                    newF,
-                    '): calculated overhead: ',
-                    chargedGasOverhead.toString(),
-                    ' actual overhead: ',
-                    actualGasOverhead.toString(),
-                    ' margin over gasUsed: ',
-                    chargedGasOverhead.sub(actualGasOverhead).toString(),
+                    'Testing with upkeepSuccess=' +
+                      upkeepSuccess +
+                      ', performGas=' +
+                      performGas +
+                      ', performData length=' +
+                      (performData.length / 2 - 1),
                   )
-                }
 
-                // Overhead should not get capped
-                const gasOverheadCap = registryGasOverhead
-                  .add(
-                    registryPerSignerGasOverhead.mul(BigNumber.from(newF + 1)),
-                  )
-                  .add(
-                    BigNumber.from(
-                      registryPerPerformByteGasOverhead.toNumber() *
-                        performData.length,
-                    ),
-                  )
-                const gasCapMinusOverhead =
-                  gasOverheadCap.sub(chargedGasOverhead)
-                assert.isTrue(
-                  gasCapMinusOverhead.gt(BigNumber.from(0)),
-                  'Gas overhead got capped. Verify gas overhead variables in test match those in the registry. To not have the overheads capped increase REGISTRY_GAS_OVERHEAD by atleast ' +
-                    gasCapMinusOverhead.toString(),
-                )
-                // total gas charged should be greater than tx gas but within gasCalculationMargin
-                assert.isTrue(
-                  chargedGasOverhead.gt(actualGasOverhead),
-                  'Gas overhead calculated is too low, increase account gas variables (ACCOUNTING_FIXED_GAS_OVERHEAD/ACCOUNTING_PER_SIGNER_GAS_OVERHEAD) by atleast ' +
-                    actualGasOverhead.sub(chargedGasOverhead).toString(),
-                )
+                  await mock.setCanPerform(upkeepSuccess)
+                  await mock.setPerformGasToBurn(performGas)
+                  await registry
+                    .connect(owner)
+                    .setConfig(
+                      signerAddresses,
+                      keeperAddresses,
+                      newF,
+                      encodeConfig(config),
+                      offchainVersion,
+                      offchainBytes,
+                    )
+                  tx = await getTransmitTx(registry, keeper1, [upkeepId], {
+                    numSigners: newF + 1,
+                    performData,
+                  })
+                  const receipt = await tx.wait()
+                  const upkeepPerformedLogs = parseUpkeepPerformedLogs(receipt)
+                  // exactly 1 Upkeep Performed should be emitted
+                  assert.equal(upkeepPerformedLogs.length, 1)
+                  const upkeepPerformedLog = upkeepPerformedLogs[0]
 
-                assert.isTrue(
-                  chargedGasOverhead
-                    .sub(actualGasOverhead)
-                    .lt(BigNumber.from(gasCalculationMargin)),
-                ),
-                  'Gas overhead calculated is too high, decrease account gas variables (ACCOUNTING_FIXED_GAS_OVERHEAD/ACCOUNTING_PER_SIGNER_GAS_OVERHEAD)  by atleast ' +
+                  const upkeepGasUsed = upkeepPerformedLog.args.gasUsed
+                  const chargedGasOverhead = upkeepPerformedLog.args.gasOverhead
+                  const actualGasOverhead = receipt.gasUsed.sub(upkeepGasUsed)
+
+                  assert.isTrue(upkeepGasUsed.gt(BigNumber.from('0')))
+                  assert.isTrue(chargedGasOverhead.gt(BigNumber.from('0')))
+
+                  if (i == '0' && j == '0' && k == '0') {
+                    console.log(
+                      'Gas Benchmarking - sig verification ( f =',
+                      newF,
+                      '): calculated overhead: ',
+                      chargedGasOverhead.toString(),
+                      ' actual overhead: ',
+                      actualGasOverhead.toString(),
+                      ' margin over gasUsed: ',
+                      chargedGasOverhead.sub(actualGasOverhead).toString(),
+                    )
+                  }
+
+                  // Overhead should not get capped
+                  const gasOverheadCap = registryGasOverhead
+                    .add(
+                      registryPerSignerGasOverhead.mul(
+                        BigNumber.from(newF + 1),
+                      ),
+                    )
+                    .add(
+                      BigNumber.from(
+                        registryPerPerformByteGasOverhead.toNumber() *
+                          performData.length,
+                      ),
+                    )
+                  const gasCapMinusOverhead =
+                    gasOverheadCap.sub(chargedGasOverhead)
+                  assert.isTrue(
+                    gasCapMinusOverhead.gt(BigNumber.from(0)),
+                    'Gas overhead got capped. Verify gas overhead variables in test match those in the registry. To not have the overheads capped increase REGISTRY_GAS_OVERHEAD by atleast ' +
+                      gasCapMinusOverhead.toString(),
+                  )
+                  // total gas charged should be greater than tx gas but within gasCalculationMargin
+                  assert.isTrue(
+                    chargedGasOverhead.gt(actualGasOverhead),
+                    'Gas overhead calculated is too low, increase account gas variables (ACCOUNTING_FIXED_GAS_OVERHEAD/ACCOUNTING_PER_SIGNER_GAS_OVERHEAD) by atleast ' +
+                      actualGasOverhead.sub(chargedGasOverhead).toString(),
+                  )
+
+                  assert.isTrue(
                     chargedGasOverhead
-                      .sub(chargedGasOverhead)
-                      .sub(BigNumber.from(gasCalculationMargin))
-                      .toString()
+                      .sub(actualGasOverhead)
+                      .lt(BigNumber.from(gasCalculationMargin)),
+                  ),
+                    'Gas overhead calculated is too high, decrease account gas variables (ACCOUNTING_FIXED_GAS_OVERHEAD/ACCOUNTING_PER_SIGNER_GAS_OVERHEAD)  by atleast ' +
+                      chargedGasOverhead
+                        .sub(chargedGasOverhead)
+                        .sub(BigNumber.from(gasCalculationMargin))
+                        .toString()
+                }
               }
             }
-          }
-        }
+          },
+        )
       })
     })
 


### PR DESCRIPTION
This PR removes skip from a gas benchmarking test which had become too slow

- It reduces some test cases to only test extreme values of 'f', 'performData', 'performGas'
- It splits tests for different f into different tests