### PR TITLE
[BCF-2374] Add flakey test re-runner and add it to the CI core workflow

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -226,6 +226,47 @@ jobs:
           this-job-name: Core Tests (${{ matrix.cmd }})
         continue-on-error: true
 
+  detect-flakey-tests:
+    needs: [core]
+    name: Flakey Test Detection
+    runs-on: ubuntu-latest
+    if: always()
+    env:
+      CL_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/chainlink_test?sslmode=disable
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Setup node
+        uses: actions/setup-node@v3
+      - name: Setup NodeJS
+        uses: ./.github/actions/setup-nodejs
+        with:
+          prod: "true"
+      - name: Setup Go
+        uses: ./.github/actions/setup-go
+      - name: Setup Postgres
+        uses: ./.github/actions/setup-postgres
+      - name: Touching core/web/assets/index.html
+        run: mkdir -p core/web/assets && touch core/web/assets/index.html
+      - name: Download Go vendor packages
+        run: go mod download
+      - name: Build binary
+        run: go build -tags test -o chainlink.test .
+      - name: Setup DB
+        run: ./chainlink.test local db preparetest
+      - name: Load test outputs
+        uses: actions/download-artifact@v3
+        with:
+          path: ./artifacts
+      - name: Build flakey test runner
+        run: go build ./tools/flakeytests/cmd/runner
+      - name: Re-run tests
+        env:
+          GRAFANA_CLOUD_BASIC_AUTH: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
+          GRAFANA_CLOUD_HOST: ${{ secrets.GRAFANA_CLOUD_HOST }}
+        run: |
+          ./runner -grafana_auth=$GRAFANA_CLOUD_BASIC_AUTH -grafana_host=$GRAFANA_CLOUD_HOST -command go_core_tests `ls -R ./artifacts/go_core_tests*/output.txt`
+
   scan:
     name: SonarQube Scan
     needs: [core]

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -266,6 +266,13 @@ jobs:
           GRAFANA_CLOUD_HOST: ${{ secrets.GRAFANA_CLOUD_HOST }}
         run: |
           ./runner -grafana_auth=$GRAFANA_CLOUD_BASIC_AUTH -grafana_host=$GRAFANA_CLOUD_HOST -command go_core_tests `ls -R ./artifacts/go_core_tests*/output.txt`
+      - name: Store logs artifacts
+        if: always()
+        uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
+        with:
+          name: flakey_test_runner_logs
+          path: |
+            ./output.txt
 
   scan:
     name: SonarQube Scan

--- a/tools/bin/go_core_tests
+++ b/tools/bin/go_core_tests
@@ -8,7 +8,7 @@ OUTPUT_FILE="./output.txt"
 echo "Failed tests and panics: ---------------------"
 echo ""
 GO_LDFLAGS=$(bash tools/bin/ldflags)
-go test -ldflags "$GO_LDFLAGS" -tags test,integration -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt  $1 | tee $OUTPUT_FILE
+go test -ldflags "$GO_LDFLAGS" -tags test,integration $TEST_FLAGS -covermode=atomic -coverpkg=./... -coverprofile=coverage.txt  $1 | tee $OUTPUT_FILE
 EXITCODE=${PIPESTATUS[0]}
 
 # Assert no known sensitive strings present in test logger output

--- a/tools/flakeytests/cmd/runner/main.go
+++ b/tools/flakeytests/cmd/runner/main.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"flag"
+	"io"
+	"log"
+	"os"
+	"strings"
+
+	"github.com/smartcontractkit/chainlink/v2/tools/flakeytests"
+)
+
+const numReruns = 2
+
+func main() {
+	grafanaHost := flag.String("grafana_host", "", "grafana host URL")
+	grafanaAuth := flag.String("grafana_auth", "", "grafana basic auth for Loki API")
+	command := flag.String("command", "", "test command being rerun; used to tag metrics")
+	flag.Parse()
+
+	if *grafanaHost == "" {
+		log.Fatal("Error re-running flakey tests: `grafana_host` is required")
+	}
+
+	if *grafanaAuth == "" {
+		log.Fatal("Error re-running flakey tests: `grafana_auth` is required")
+	}
+
+	if *command == "" {
+		log.Fatal("Error re-running flakey tests: `command` is required")
+	}
+
+	args := flag.Args()
+
+	log.Printf("Parsing output at: %v", strings.Join(args, ", "))
+	readers := []io.Reader{}
+	for _, f := range args {
+		r, err := os.Open(f)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		readers = append(readers, r)
+	}
+
+	rep := flakeytests.NewLokiReporter(*grafanaHost, *grafanaAuth, *command)
+	r := flakeytests.NewRunner(readers, rep, numReruns)
+	err := r.Run()
+	if err != nil {
+		log.Fatalf("Error re-running flakey tests: %s", err)
+	}
+}

--- a/tools/flakeytests/reporter.go
+++ b/tools/flakeytests/reporter.go
@@ -1,0 +1,111 @@
+package flakeytests
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+)
+
+type pushRequest struct {
+	Streams []stream `json:"streams"`
+}
+
+type stream struct {
+	Stream map[string]string `json:"stream"`
+	Values [][]string        `json:"values"`
+}
+
+type flakeyTest struct {
+	Package    string `json:"package"`
+	TestName   string `json:"test_name"`
+	FQTestName string `json:"fq_test_name"`
+}
+
+type LokiReporter struct {
+	host    string
+	auth    string
+	command string
+	now     func() time.Time
+}
+
+func (l *LokiReporter) createRequest(flakeyTests map[string][]string) (pushRequest, error) {
+	vs := [][]string{}
+	now := l.now()
+	for pkg, tests := range flakeyTests {
+		for _, t := range tests {
+			d, err := json.Marshal(flakeyTest{
+				Package:    pkg,
+				TestName:   t,
+				FQTestName: fmt.Sprintf("%s:%s", pkg, t),
+			})
+			if err != nil {
+				return pushRequest{}, err
+			}
+			vs = append(vs, []string{fmt.Sprintf("%d", now.UnixNano()), string(d)})
+		}
+	}
+
+	pr := pushRequest{
+		Streams: []stream{
+			{
+				Stream: map[string]string{
+					"app":     "flakey-test-reporter",
+					"command": l.command,
+				},
+				Values: vs,
+			},
+		},
+	}
+	return pr, nil
+}
+
+func (l *LokiReporter) makeRequest(pushReq pushRequest) error {
+	body, err := json.Marshal(pushReq)
+	if err != nil {
+		return err
+	}
+
+	u := url.URL{Scheme: "https", Host: l.host, Path: "loki/api/v1/push"}
+	req, err := http.NewRequest("POST", u.String(), bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Add(
+		"Authorization",
+		fmt.Sprintf("Basic %s", base64.StdEncoding.EncodeToString([]byte(l.auth))),
+	)
+	req.Header.Add("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	} else if resp.StatusCode != http.StatusNoContent {
+		b, berr := io.ReadAll(resp.Body)
+		if berr != nil {
+			return fmt.Errorf("error decoding body for failed push request: %w", berr)
+		}
+		return fmt.Errorf("push request failed: status=%d, body=%s", resp.StatusCode, b)
+	}
+	return err
+}
+
+func (l *LokiReporter) Report(flakeyTests map[string][]string) error {
+	if len(flakeyTests) == 0 {
+		return nil
+	}
+
+	pushReq, err := l.createRequest(flakeyTests)
+	if err != nil {
+		return err
+	}
+
+	return l.makeRequest(pushReq)
+}
+
+func NewLokiReporter(host, auth, command string) *LokiReporter {
+	return &LokiReporter{host: host, auth: auth, command: command, now: time.Now}
+}

--- a/tools/flakeytests/reporter.go
+++ b/tools/flakeytests/reporter.go
@@ -109,10 +109,6 @@ func (l *LokiReporter) makeRequest(pushReq pushRequest) error {
 }
 
 func (l *LokiReporter) Report(flakeyTests map[string][]string) error {
-	if len(flakeyTests) == 0 {
-		return nil
-	}
-
 	pushReq, err := l.createRequest(flakeyTests)
 	if err != nil {
 		return err

--- a/tools/flakeytests/reporter_test.go
+++ b/tools/flakeytests/reporter_test.go
@@ -1,0 +1,43 @@
+package flakeytests
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMakeRequest_SingleTest(t *testing.T) {
+	now := time.Now()
+	ft := map[string][]string{
+		"core/assets": {"TestLink"},
+	}
+	lr := &LokiReporter{auth: "bla", host: "bla", command: "go_core_tests", now: func() time.Time { return now }}
+	pr, err := lr.createRequest(ft)
+	require.NoError(t, err)
+	assert.Len(t, pr.Streams, 1)
+	assert.Equal(t, pr.Streams[0].Stream, map[string]string{"command": "go_core_tests", "app": "flakey-test-reporter"})
+	assert.Len(t, pr.Streams[0].Values, 1)
+	assert.Equal(t, pr.Streams[0].Values[0], []string{fmt.Sprintf("%d", now.UnixNano()), "{\"package\":\"core/assets\",\"test_name\":\"TestLink\",\"fq_test_name\":\"core/assets:TestLink\"}"})
+}
+
+func TestMakeRequest_MultipleTests(t *testing.T) {
+	now := time.Now()
+	ft := map[string][]string{
+		"core/assets": {"TestLink", "TestCore"},
+	}
+	lr := &LokiReporter{auth: "bla", host: "bla", command: "go_core_tests", now: func() time.Time { return now }}
+	pr, err := lr.createRequest(ft)
+	require.NoError(t, err)
+	assert.Len(t, pr.Streams, 1)
+	assert.Equal(t, pr.Streams[0].Stream, map[string]string{"command": "go_core_tests", "app": "flakey-test-reporter"})
+	assert.Len(t, pr.Streams[0].Values, 2)
+
+	ts := fmt.Sprintf("%d", now.UnixNano())
+	assert.Equal(t, pr.Streams[0].Values, [][]string{
+		{ts, "{\"package\":\"core/assets\",\"test_name\":\"TestLink\",\"fq_test_name\":\"core/assets:TestLink\"}"},
+		{ts, "{\"package\":\"core/assets\",\"test_name\":\"TestCore\",\"fq_test_name\":\"core/assets:TestCore\"}"},
+	})
+}

--- a/tools/flakeytests/runner.go
+++ b/tools/flakeytests/runner.go
@@ -14,7 +14,9 @@ import (
 
 var (
 	failedTestRe = regexp.MustCompile(`^--- FAIL: (Test\w+)`)
-	failedPkgRe  = regexp.MustCompile(`^FAIL\s+github\.com\/smartcontractkit\/chainlink\/v2\/(\S+)`)
+	logPanicRe   = regexp.MustCompile(`^panic: Log in goroutine after (Test\w+)`)
+
+	failedPkgRe = regexp.MustCompile(`^FAIL\s+github\.com\/smartcontractkit\/chainlink\/v2\/(\S+)`)
 )
 
 type Runner struct {
@@ -62,6 +64,9 @@ func parseOutput(readers ...io.Reader) (map[string]map[string]int, error) {
 			case failedTestRe.MatchString(t):
 				m := failedTestRe.FindStringSubmatch(t)
 				testsWithoutPackage = append(testsWithoutPackage, m[1])
+			case logPanicRe.MatchString(t):
+				m := logPanicRe.FindStringSubmatch(t)
+				testsWithoutPackage = append(testsWithoutPackage, m[1])
 			case failedPkgRe.MatchString(t):
 				p := failedPkgRe.FindStringSubmatch(t)
 				for _, t := range testsWithoutPackage {
@@ -78,7 +83,6 @@ func parseOutput(readers ...io.Reader) (map[string]map[string]int, error) {
 			return nil, err
 		}
 	}
-
 	return tests, nil
 }
 

--- a/tools/flakeytests/runner.go
+++ b/tools/flakeytests/runner.go
@@ -1,0 +1,134 @@
+package flakeytests
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+)
+
+var (
+	failedTestRe = regexp.MustCompile(`^--- FAIL: (Test\w+)`)
+	failedPkgRe  = regexp.MustCompile(`^FAIL\s+github\.com\/smartcontractkit\/chainlink\/v2\/(\S+)`)
+)
+
+type Runner struct {
+	readers   []io.Reader
+	numReruns int
+	runTestFn runTestCmd
+	parse     parseFn
+	reporter  reporter
+}
+
+type reporter interface {
+	Report(map[string][]string) error
+}
+
+type runTestCmd func(pkg string, testNames []string, numReruns int, w io.Writer) error
+type parseFn func(readers ...io.Reader) (map[string]map[string]int, error)
+
+func NewRunner(readers []io.Reader, reporter reporter, numReruns int) *Runner {
+	return &Runner{
+		readers:   readers,
+		numReruns: numReruns,
+		runTestFn: runGoTest,
+		parse:     parseOutput,
+		reporter:  reporter,
+	}
+}
+
+func runGoTest(pkg string, tests []string, numReruns int, w io.Writer) error {
+	testFilter := strings.Join(tests, "|")
+	cmd := exec.Command("go", "test", "-count", fmt.Sprintf("%d", numReruns), "-run", testFilter, "-tags", "test", fmt.Sprintf("./%s/...", pkg)) //#nosec
+	cmd.Stdout = io.MultiWriter(os.Stdout, w)
+	cmd.Stderr = io.MultiWriter(os.Stderr, w)
+	return cmd.Run()
+}
+
+func parseOutput(readers ...io.Reader) (map[string]map[string]int, error) {
+	testsWithoutPackage := []string{}
+	tests := map[string]map[string]int{}
+	for _, r := range readers {
+		s := bufio.NewScanner(r)
+		for s.Scan() {
+			t := s.Text()
+			switch {
+			case failedTestRe.MatchString(t):
+				m := failedTestRe.FindStringSubmatch(t)
+				testsWithoutPackage = append(testsWithoutPackage, m[1])
+			case failedPkgRe.MatchString(t):
+				p := failedPkgRe.FindStringSubmatch(t)
+				for _, t := range testsWithoutPackage {
+					if tests[p[1]] == nil {
+						tests[p[1]] = map[string]int{}
+					}
+					tests[p[1]][t]++
+				}
+				testsWithoutPackage = []string{}
+			}
+		}
+
+		if err := s.Err(); err != nil {
+			return nil, err
+		}
+	}
+
+	return tests, nil
+}
+
+func (r *Runner) runTests(failedTests map[string]map[string]int) io.Reader {
+	var out bytes.Buffer
+	for pkg, tests := range failedTests {
+		ts := []string{}
+		for test := range tests {
+			ts = append(ts, test)
+		}
+
+		log.Printf("Executing test command with parameters: pkg=%s, tests=%+v, numReruns=%d\n", pkg, ts, r.numReruns)
+		err := r.runTestFn(pkg, ts, r.numReruns, &out)
+		if err != nil {
+			log.Printf("Test command errored: %s\n", err)
+		}
+	}
+
+	return &out
+}
+
+func (r *Runner) Run() error {
+	failedTests, err := r.parse(r.readers...)
+	if err != nil {
+		return err
+	}
+
+	output := r.runTests(failedTests)
+
+	failedReruns, err := r.parse(output)
+	if err != nil {
+		return err
+	}
+
+	suspectedFlakes := map[string][]string{}
+	// A test is flakey if it appeared in the list of original flakey tests
+	// and doesn't appear in the reruns, or if it hasn't failed each additional
+	// run, i.e. if it hasn't twice after being re-run.
+	for pkg, t := range failedTests {
+		for test := range t {
+			if failedReruns[pkg][test] != r.numReruns {
+				suspectedFlakes[pkg] = append(suspectedFlakes[pkg], test)
+			}
+		}
+	}
+
+	if len(suspectedFlakes) > 0 {
+		log.Printf("ERROR: Suspected flakes found: %+v\n", suspectedFlakes)
+	} else {
+		log.Print("SUCCESS: No suspected flakes detected")
+	}
+
+	return r.reporter.Report(suspectedFlakes)
+}

--- a/tools/flakeytests/runner_test.go
+++ b/tools/flakeytests/runner_test.go
@@ -1,0 +1,223 @@
+package flakeytests
+
+import (
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type mockReporter struct {
+	entries map[string][]string
+}
+
+func (m *mockReporter) Report(entries map[string][]string) error {
+	m.entries = entries
+	return nil
+}
+
+func newMockReporter() *mockReporter {
+	return &mockReporter{entries: map[string][]string{}}
+}
+
+func TestParser(t *testing.T) {
+	output := `
+--- FAIL: TestLink (0.00s)
+    --- FAIL: TestLink/1.1_link#01 (0.00s)
+        currencies_test.go:325:
+                Error Trace:    /Users/ccordenier/Development/chainlink/core/assets/currencies_test.go:325
+                Error:          Not equal:
+                                expected: "1.2 link"
+                                actual  : "1.1 link"
+
+                                Diff:
+                                --- Expected
+                                +++ Actual
+                                @@ -1 +1 @@
+                                -1.2 link
+                                +1.1 link
+                Test:           TestLink/1.1_link#01
+FAIL
+FAIL    github.com/smartcontractkit/chainlink/v2/core/assets    0.338s
+FAIL
+`
+
+	r := strings.NewReader(output)
+	ts, err := parseOutput(r)
+	require.NoError(t, err)
+
+	assert.Len(t, ts, 1)
+	assert.Len(t, ts["core/assets"], 1)
+	assert.Equal(t, ts["core/assets"]["TestLink"], 1)
+}
+
+func TestParser_SuccessfulOutput(t *testing.T) {
+	output := `
+?       github.com/smartcontractkit/chainlink/v2/tools/flakeytests/cmd/runner   [no test files]
+ok      github.com/smartcontractkit/chainlink/v2/tools/flakeytests      0.320s
+`
+
+	r := strings.NewReader(output)
+	ts, err := parseOutput(r)
+	require.NoError(t, err)
+	assert.Len(t, ts, 0)
+}
+
+func TestRunner_WithFlake(t *testing.T) {
+	output := `
+--- FAIL: TestLink (0.00s)
+    --- FAIL: TestLink/1.1_link#01 (0.00s)
+        currencies_test.go:325:
+                Error Trace:    /Users/ccordenier/Development/chainlink/core/assets/currencies_test.go:325
+                Error:          Not equal:
+                                expected: "1.2 link"
+                                actual  : "1.1 link"
+
+                                Diff:
+                                --- Expected
+                                +++ Actual
+                                @@ -1 +1 @@
+                                -1.2 link
+                                +1.1 link
+                Test:           TestLink/1.1_link#01
+FAIL
+FAIL    github.com/smartcontractkit/chainlink/v2/core/assets    0.338s
+FAIL
+`
+	m := newMockReporter()
+	r := &Runner{
+		numReruns: 2,
+		readers:   []io.Reader{strings.NewReader(output)},
+		runTestFn: func(pkg string, testNames []string, numReruns int, w io.Writer) error {
+			_, err := w.Write([]byte(output))
+			return err
+		},
+		parse:    parseOutput,
+		reporter: m,
+	}
+
+	// This will report a flake since we've mocked the rerun
+	// to only report one failure (not two as expected).
+	err := r.Run()
+	require.NoError(t, err)
+	assert.Len(t, m.entries, 1)
+	assert.Equal(t, m.entries["core/assets"], []string{"TestLink"})
+}
+
+func TestRunner_AllFailures(t *testing.T) {
+	output := `
+--- FAIL: TestLink (0.00s)
+    --- FAIL: TestLink/1.1_link#01 (0.00s)
+        currencies_test.go:325:
+                Error Trace:    /Users/ccordenier/Development/chainlink/core/assets/currencies_test.go:325
+                Error:          Not equal:
+                                expected: "1.2 link"
+                                actual  : "1.1 link"
+
+                                Diff:
+                                --- Expected
+                                +++ Actual
+                                @@ -1 +1 @@
+                                -1.2 link
+                                +1.1 link
+                Test:           TestLink/1.1_link#01
+FAIL
+FAIL    github.com/smartcontractkit/chainlink/v2/core/assets    0.338s
+FAIL
+`
+
+	rerunOutput := `
+--- FAIL: TestLink (0.00s)
+    --- FAIL: TestLink/1.1_link#01 (0.00s)
+        currencies_test.go:325:
+                Error Trace:    /Users/ccordenier/Development/chainlink/core/assets/currencies_test.go:325
+                Error:          Not equal:
+                                expected: "1.2 link"
+                                actual  : "1.1 link"
+
+                                Diff:
+                                --- Expected
+                                +++ Actual
+                                @@ -1 +1 @@
+                                -1.2 link
+                                +1.1 link
+                Test:           TestLink/1.1_link#01
+--- FAIL: TestLink (0.00s)
+    --- FAIL: TestLink/1.1_link#01 (0.00s)
+        currencies_test.go:325:
+                Error Trace:    /Users/ccordenier/Development/chainlink/core/assets/currencies_test.go:325
+                Error:          Not equal:
+                                expected: "1.2 link"
+                                actual  : "1.1 link"
+
+                                Diff:
+                                --- Expected
+                                +++ Actual
+                                @@ -1 +1 @@
+                                -1.2 link
+                                +1.1 link
+                Test:           TestLink/1.1_link#01
+FAIL
+FAIL    github.com/smartcontractkit/chainlink/v2/core/assets    0.315s
+FAIL
+`
+	m := newMockReporter()
+	r := &Runner{
+		numReruns: 2,
+		readers:   []io.Reader{strings.NewReader(output)},
+		runTestFn: func(pkg string, testNames []string, numReruns int, w io.Writer) error {
+			_, err := w.Write([]byte(rerunOutput))
+			return err
+		},
+		parse:    parseOutput,
+		reporter: m,
+	}
+
+	err := r.Run()
+	require.NoError(t, err)
+	assert.Len(t, m.entries, 0)
+}
+
+func TestRunner_RerunSuccessful(t *testing.T) {
+	output := `
+--- FAIL: TestLink (0.00s)
+    --- FAIL: TestLink/1.1_link#01 (0.00s)
+        currencies_test.go:325:
+                Error Trace:    /Users/ccordenier/Development/chainlink/core/assets/currencies_test.go:325
+                Error:          Not equal:
+                                expected: "1.2 link"
+                                actual  : "1.1 link"
+
+                                Diff:
+                                --- Expected
+                                +++ Actual
+                                @@ -1 +1 @@
+                                -1.2 link
+                                +1.1 link
+                Test:           TestLink/1.1_link#01
+FAIL
+FAIL    github.com/smartcontractkit/chainlink/v2/core/assets    0.338s
+FAIL
+`
+
+	rerunOutput := `
+ok      github.com/smartcontractkit/chainlink/v2/core/assets      0.320s
+`
+	m := newMockReporter()
+	r := &Runner{
+		numReruns: 2,
+		readers:   []io.Reader{strings.NewReader(output)},
+		runTestFn: func(pkg string, testNames []string, numReruns int, w io.Writer) error {
+			_, err := w.Write([]byte(rerunOutput))
+			return err
+		},
+		parse:    parseOutput,
+		reporter: m,
+	}
+
+	err := r.Run()
+	require.NoError(t, err)
+	assert.Equal(t, m.entries["core/assets"], []string{"TestLink"})
+}

--- a/tools/flakeytests/runner_test.go
+++ b/tools/flakeytests/runner_test.go
@@ -53,6 +53,76 @@ FAIL
 	assert.Equal(t, ts["core/assets"]["TestLink"], 1)
 }
 
+func TestParser_PanicInTest(t *testing.T) {
+	output := `
+?   	github.com/smartcontractkit/chainlink/v2/tools/flakeytests/cmd/runner	[no test files]
+--- FAIL: TestParser (0.00s)
+panic: foo [recovered]
+	panic: foo
+
+goroutine 21 [running]:
+testing.tRunner.func1.2({0x1009953c0, 0x1009d1e40})
+	/opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1526 +0x1c8
+testing.tRunner.func1()
+	/opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1529 +0x384
+panic({0x1009953c0, 0x1009d1e40})
+	/opt/homebrew/Cellar/go/1.20.3/libexec/src/runtime/panic.go:884 +0x204
+github.com/smartcontractkit/chainlink/v2/tools/flakeytests.TestParser(0x0?)
+	/Users/ccordenier/Development/chainlink/tools/flakeytests/runner_test.go:50 +0xa4
+testing.tRunner(0x14000083520, 0x1009d1588)
+	/opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1576 +0x10c
+created by testing.(*T).Run
+	/opt/homebrew/Cellar/go/1.20.3/libexec/src/testing/testing.go:1629 +0x368
+FAIL	github.com/smartcontractkit/chainlink/v2/tools/flakeytests	0.197s
+FAIL`
+
+	r := strings.NewReader(output)
+	ts, err := parseOutput(r)
+	require.NoError(t, err)
+
+	assert.Len(t, ts, 1)
+	assert.Len(t, ts["tools/flakeytests"], 1)
+	assert.Equal(t, ts["tools/flakeytests"]["TestParser"], 1)
+}
+
+func TestParser_PanicDueToLogging(t *testing.T) {
+	output := `
+panic: Log in goroutine after TestIntegration_LogEventProvider_Backfill has completed: 2023-07-19T10:10:45.925Z	WARN	KeepersRegistry.LogEventProvider	logprovider/provider.go:218	failed to read logs	{"version": "2.3.0@d898528", "where": "reader", "err": "fetched logs with errors: context canceled"}
+
+goroutine 4999 [running]:
+testing.(*common).logDepth(0xc0051f6000, {0xc003011960, 0xd3}, 0x3)
+	/opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1003 +0x4e7
+testing.(*common).log(...)
+	/opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:985
+testing.(*common).Logf(0xc0051f6000, {0x21ba777?, 0x41ac8a?}, {0xc00217c330?, 0x1e530c0?, 0x1?})
+	/opt/hostedtoolcache/go/1.20.5/x64/src/testing/testing.go:1036 +0x5a
+go.uber.org/zap/zaptest.testingWriter.Write({{0x7f4c5c94f018?, 0xc0051f6000?}, 0xa8?}, {0xc003017000?, 0xd4, 0xc00217c320?})
+	/home/runner/go/pkg/mod/go.uber.org/zap@v1.24.0/zaptest/logger.go:130 +0xe6
+go.uber.org/zap/zapcore.(*ioCore).Write(0xc0022f60f0, {0x1, {0xc1260b897723e1ca, 0x4bdc75e54, 0x3d56e40}, {0x22e96a1, 0x20}, {0x22c3204, 0x13}, {0x1, ...}, ...}, ...)
+	/home/runner/go/pkg/mod/go.uber.org/zap@v1.24.0/zapcore/core.go:99 +0xb5
+go.uber.org/zap/zapcore.(*CheckedEntry).Write(0xc001265ba0, {0xc0023ca100, 0x1, 0x2})
+	/home/runner/go/pkg/mod/go.uber.org/zap@v1.24.0/zapcore/entry.go:255 +0x1d9
+go.uber.org/zap.(*SugaredLogger).log(0xc00363a008, 0x1, {0x22c3204?, 0x13?}, {0x0?, 0x0?, 0x0?}, {0xc004ea3f80, 0x2, 0x2})
+	/home/runner/go/pkg/mod/go.uber.org/zap@v1.24.0/sugar.go:295 +0xee
+go.uber.org/zap.(*SugaredLogger).Warnw(...)
+	/home/runner/go/pkg/mod/go.uber.org/zap@v1.24.0/sugar.go:216
+github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider.(*logEventProvider).startReader(0xc00076d730, {0x2917018?, 0xc0043c4000?}, 0xc003b2a000)
+	/home/runner/work/chainlink/chainlink/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider.go:218 +0x29f
+created by github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider.(*logEventProvider).Start
+	/home/runner/work/chainlink/chainlink/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider.go:108 +0x133
+FAIL	github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider	20.380s
+FAIL
+`
+
+	r := strings.NewReader(output)
+	ts, err := parseOutput(r)
+	require.NoError(t, err)
+
+	assert.Len(t, ts, 1)
+	assert.Len(t, ts["core/services/ocr2/plugins/ocr2keeper/evm21/logprovider"], 1)
+	assert.Equal(t, ts["core/services/ocr2/plugins/ocr2keeper/evm21/logprovider"]["TestIntegration_LogEventProvider_Backfill"], 1)
+}
+
 func TestParser_SuccessfulOutput(t *testing.T) {
 	output := `
 ?       github.com/smartcontractkit/chainlink/v2/tools/flakeytests/cmd/runner   [no test files]


### PR DESCRIPTION
This PR adds a flakey test runner to the CI core workflow. This runner will parse the Go test output and rerun any tests that failed twice to detect flakes. A test is considered a flake if it passes during any of the reruns.

The results of this are then parsed and emitted as metrics to Grafana.

Note: we should add this to integration tests as well, but that is out of scope for this PR.