### PR TITLE
[Functions] Enable new features only when all config is set

### DIFF
--- a/core/services/ocr2/plugins/functions/config/config.go
+++ b/core/services/ocr2/plugins/functions/config/config.go
@@ -41,20 +41,19 @@ type DecryptionQueueConfig struct {
 }
 
 func ValidatePluginConfig(config PluginConfig) error {
-	if config.DecryptionQueueConfig == nil {
-		return errors.New("missing decryptionQueueConfig")
-	}
-	if config.DecryptionQueueConfig.MaxQueueLength <= 0 {
-		return errors.New("missing or invalid decryptionQueueConfig maxQueueLength")
-	}
-	if config.DecryptionQueueConfig.MaxCiphertextBytes <= 0 {
-		return errors.New("missing or invalid decryptionQueueConfig maxCiphertextBytes")
-	}
-	if config.DecryptionQueueConfig.MaxCiphertextIdLength <= 0 {
-		return errors.New("missing or invalid decryptionQueueConfig maxCiphertextIdLength")
-	}
-	if config.DecryptionQueueConfig.CompletedCacheTimeoutSec <= 0 {
-		return errors.New("missing or invalid decryptionQueueConfig completedCacheTimeoutSec")
+	if config.DecryptionQueueConfig != nil {
+		if config.DecryptionQueueConfig.MaxQueueLength <= 0 {
+			return errors.New("missing or invalid decryptionQueueConfig maxQueueLength")
+		}
+		if config.DecryptionQueueConfig.MaxCiphertextBytes <= 0 {
+			return errors.New("missing or invalid decryptionQueueConfig maxCiphertextBytes")
+		}
+		if config.DecryptionQueueConfig.MaxCiphertextIdLength <= 0 {
+			return errors.New("missing or invalid decryptionQueueConfig maxCiphertextIdLength")
+		}
+		if config.DecryptionQueueConfig.CompletedCacheTimeoutSec <= 0 {
+			return errors.New("missing or invalid decryptionQueueConfig completedCacheTimeoutSec")
+		}
 	}
 	return nil
 }

--- a/core/services/ocr2/plugins/functions/plugin.go
+++ b/core/services/ocr2/plugins/functions/plugin.go
@@ -74,7 +74,7 @@ func NewFunctionsServices(functionsOracleArgs, thresholdOracleArgs, s4OracleArgs
 
 	var decryptor threshold.Decryptor
 	// thresholdOracleArgs nil check will be removed once the Threshold plugin is fully integrated w/ Functions
-	if len(conf.ThresholdKeyShare) > 0 && thresholdOracleArgs != nil {
+	if len(conf.ThresholdKeyShare) > 0 && thresholdOracleArgs != nil && pluginConfig.DecryptionQueueConfig != nil {
 		decryptionQueue := threshold.NewDecryptionQueue(
 			int(pluginConfig.DecryptionQueueConfig.MaxQueueLength),
 			int(pluginConfig.DecryptionQueueConfig.MaxCiphertextBytes),
@@ -94,7 +94,7 @@ func NewFunctionsServices(functionsOracleArgs, thresholdOracleArgs, s4OracleArgs
 		}
 		allServices = append(allServices, thresholdService)
 	} else {
-		conf.Logger.Warn("ThresholdKeyShare is empty. Threshold secrets decryption plugin is disabled.")
+		conf.Logger.Warn("Threshold configuration is incomplete. Threshold secrets decryption plugin is disabled.")
 	}
 
 	listenerLogger := conf.Logger.Named("FunctionsListener")
@@ -140,7 +140,7 @@ func NewFunctionsServices(functionsOracleArgs, thresholdOracleArgs, s4OracleArgs
 		listenerLogger.Warn("No GatewayConnectorConfig, S4Constraints or OnchainAllowlist is found in the plugin config, GatewayConnector will not be enabled")
 	}
 
-	if s4OracleArgs != nil {
+	if s4OracleArgs != nil && pluginConfig.S4Constraints != nil {
 		s4OracleArgs.ReportingPluginFactory = s4_plugin.S4ReportingPluginFactory{
 			Logger:        s4OracleArgs.Logger,
 			ORM:           s4ORM,
@@ -152,7 +152,7 @@ func NewFunctionsServices(functionsOracleArgs, thresholdOracleArgs, s4OracleArgs
 		}
 		allServices = append(allServices, job.NewServiceAdapter(s4ReportingPluginOracle))
 	} else {
-		listenerLogger.Warn("s4OracleArgs is nil. S4 plugin is disabled.")
+		listenerLogger.Warn("s4OracleArgs is nil or S4Constraints are not configured. S4 plugin is disabled.")
 	}
 
 	return allServices, nil


### PR DESCRIPTION
Two modifications to ensure backward compatibility with current deployments:
1. Don't require DecryptionQueueConfig if Threshold is not ready to run.
2. Don't launch S4 plugin is pluginConfig.S4Constraints is not set.