### PR TITLE
BCF-2317 One relayer per chain id

### DIFF
--- a/core/chains/evm/chain.go
+++ b/core/chains/evm/chain.go
@@ -82,7 +82,7 @@ func newTOMLChain(ctx context.Context, chain *toml.EVMConfig, opts ChainSetOpts)
 		return nil, errChainDisabled{ChainID: chainID}
 	}
 	cfg := evmconfig.NewTOMLChainScopedConfig(opts.Config, chain, l)
-	// note: per-chain validation is not ncessary at this point since everything is checked earlier on boot.
+	// note: per-chain validation is not necessary at this point since everything is checked earlier on boot.
 	return newChain(ctx, cfg, chain.Nodes, opts)
 }
 

--- a/core/chains/solana/config.go
+++ b/core/chains/solana/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 	"github.com/smartcontractkit/chainlink/v2/core/utils/config"
 )
 
@@ -381,9 +382,13 @@ type Configs interface {
 
 var _ chains.Configs[string, soldb.Node] = (Configs)(nil)
 
-func EnsureChains(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig, ids []string) error {
+func EnsureChains(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig, ids []relay.Identifier) error {
 	q := pg.NewQ(db, lggr.Named("Ensure"), cfg)
-	return chains.EnsureChains[string](q, "solana", ids)
+	sids := make([]string, len(ids))
+	for i, id := range ids {
+		sids[i] = id.ChainID.String()
+	}
+	return chains.EnsureChains[string](q, string(relay.Solana), sids)
 }
 
 func NewConfigs(cfgs chains.ConfigsV2[string, soldb.Node]) Configs {

--- a/core/services/ocr2/plugins/ocr2keeper/util.go
+++ b/core/services/ocr2/plugins/ocr2keeper/util.go
@@ -67,11 +67,16 @@ func EVMDependencies20(spec job.Job, db *sqlx.DB, lggr logger.Logger, set evm.Ch
 	oSpec := spec.OCR2OracleSpec
 
 	// get the chain from the config
-	chainID, err2 := spec.OCR2OracleSpec.RelayConfig.EVMChainID()
+	chainID, err2 := spec.OCR2OracleSpec.GetChainID()
 	if err2 != nil {
 		return nil, nil, nil, nil, err2
 	}
-	chain, err2 = set.Get(big.NewInt(chainID))
+	evmChainID, err2 := chainID.Int64()
+	if err2 != nil {
+		return nil, nil, nil, nil, fmt.Errorf("chainID is not evm compatible: %w", err)
+	}
+
+	chain, err2 = set.Get(big.NewInt(evmChainID))
 	if err2 != nil {
 		return nil, nil, nil, nil, fmt.Errorf("%w: %s", ErrNoChainFromSpec, err2)
 	}

--- a/core/services/relay/relay.go
+++ b/core/services/relay/relay.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strconv"
 
 	"golang.org/x/exp/maps"
 
@@ -27,6 +28,24 @@ var (
 		StarkNet: {},
 	}
 )
+
+type Identifier struct {
+	Network Network
+	ChainID ChainID
+}
+
+type ChainID string
+
+func (c ChainID) String() string {
+	return string(c)
+}
+func (c ChainID) Int64() (int64, error) {
+	i, err := strconv.Atoi(c.String())
+	if err != nil {
+		return int64(0), err
+	}
+	return int64(i), nil
+}
 
 // RelayerExt is a subset of [loop.Relayer] for adapting [types.Relayer], typically with a ChainSet. See [relayerAdapter].
 type RelayerExt interface {


### PR DESCRIPTION
First sketch...

Adds plumbing for Solana only to get quick feedback

Key ideas:
- Identify relayer as (name, id) tuple eg "solana", "solana-chain-abc"
- Create one relayer per identifier and plumb a map[relay_id]relayer to delegate
- Use the existing job spec to recreate the relayer_id and do the lookup

Note: this change will spawn one relayer per chain id even if the chain id is not used by a job. We may want to implement lazy relayer initialization.