### PR TITLE
2232_rpc_timeouts: Setting API server read timeout to HTTPWriteTimeout

### DIFF
--- a/core/chains/evm/chain.go
+++ b/core/chains/evm/chain.go
@@ -307,5 +307,5 @@ func newPrimary(cfg evmconfig.NodePool, noNewHeadsThreshold time.Duration, lggr 
 
 func EnsureChains(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig, ids []utils.Big) error {
 	q := pg.NewQ(db, lggr.Named("Ensure"), cfg)
-	return chains.EnsureChains[utils.Big](q, "evm", ids)
+	return chains.EnsureChains(q, "evm", ids)
 }

--- a/core/chains/evm/client/client.go
+++ b/core/chains/evm/client/client.go
@@ -24,6 +24,7 @@ import (
 )
 
 const queryTimeout = 10 * time.Second
+const BALANCE_OF_ADDRESS_FUNCTION_SELECTOR = "0x70a08231"
 
 //go:generate mockery --quiet --name Client --output ./mocks/ --case=underscore
 
@@ -140,7 +141,7 @@ type CallArgs struct {
 func (client *client) TokenBalance(ctx context.Context, address common.Address, contractAddress common.Address) (*big.Int, error) {
 	result := ""
 	numLinkBigInt := new(big.Int)
-	functionSelector := evmtypes.HexToFunctionSelector("0x70a08231") // balanceOf(address)
+	functionSelector := evmtypes.HexToFunctionSelector(BALANCE_OF_ADDRESS_FUNCTION_SELECTOR) // balanceOf(address)
 	data := utils.ConcatBytes(functionSelector.Bytes(), common.LeftPadBytes(address.Bytes(), utils.EVMWordByteLen))
 	args := CallArgs{
 		To:   contractAddress,

--- a/core/chains/evm/client/client_test.go
+++ b/core/chains/evm/client/client_test.go
@@ -248,7 +248,7 @@ func TestEthClient_GetERC20Balance(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			contractAddress := testutils.NewAddress()
 			userAddress := testutils.NewAddress()
-			functionSelector := evmtypes.HexToFunctionSelector("0x70a08231") // balanceOf(address)
+			functionSelector := evmtypes.HexToFunctionSelector(evmclient.BALANCE_OF_ADDRESS_FUNCTION_SELECTOR) // balanceOf(address)
 			txData := utils.ConcatBytes(functionSelector.Bytes(), common.LeftPadBytes(userAddress.Bytes(), utils.EVMWordByteLen))
 
 			wsURL := cltest.NewWSServer(t, &cltest.FixtureChainID, func(method string, params gjson.Result) (resp testutils.JSONRPCResponse) {

--- a/core/chains/evm/client/node.go
+++ b/core/chains/evm/client/node.go
@@ -192,6 +192,7 @@ func NewNode(nodeCfg config.NodePool, noNewHeadsThreshold time.Duration, lggr lo
 		"node", n.String(),
 		"evmChainID", chainID,
 		"nodeOrder", n.order,
+		"mode", n.getNodeMode(),
 	)
 	n.lfcLog = lggr.Named("Lifecycle")
 	n.rpcLog = lggr.Named("RPC")
@@ -416,12 +417,12 @@ func (n *node) getRPCDomain() string {
 
 // CallContext implementation
 func (n *node) CallContext(ctx context.Context, result interface{}, method string, args ...interface{}) error {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With(
+	lggr := n.newRqLggr().With(
 		"method", method,
 		"args", args,
 	)
@@ -441,12 +442,12 @@ func (n *node) CallContext(ctx context.Context, result interface{}, method strin
 }
 
 func (n *node) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("nBatchElems", len(b), "batchElems", b)
+	lggr := n.newRqLggr().With("nBatchElems", len(b), "batchElems", b)
 
 	lggr.Trace("RPC call: evmclient.Client#BatchCallContext")
 	start := time.Now()
@@ -463,12 +464,12 @@ func (n *node) BatchCallContext(ctx context.Context, b []rpc.BatchElem) error {
 }
 
 func (n *node) EthSubscribe(ctx context.Context, channel chan<- *evmtypes.Head, args ...interface{}) (ethereum.Subscription, error) {
-	ctx, cancel, ws, _, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, _, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr("websocket").With("args", args)
+	lggr := n.newRqLggr().With("args", args)
 
 	lggr.Debug("RPC call: evmclient.Client#EthSubscribe")
 	start := time.Now()
@@ -486,12 +487,12 @@ func (n *node) EthSubscribe(ctx context.Context, channel chan<- *evmtypes.Head, 
 // GethClient wrappers
 
 func (n *node) TransactionReceipt(ctx context.Context, txHash common.Hash) (receipt *types.Receipt, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("txHash", txHash)
+	lggr := n.newRqLggr().With("txHash", txHash)
 
 	lggr.Debug("RPC call: evmclient.Client#TransactionReceipt")
 
@@ -513,12 +514,12 @@ func (n *node) TransactionReceipt(ctx context.Context, txHash common.Hash) (rece
 }
 
 func (n *node) TransactionByHash(ctx context.Context, txHash common.Hash) (tx *types.Transaction, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("txHash", txHash)
+	lggr := n.newRqLggr().With("txHash", txHash)
 
 	lggr.Debug("RPC call: evmclient.Client#TransactionByHash")
 
@@ -540,12 +541,12 @@ func (n *node) TransactionByHash(ctx context.Context, txHash common.Hash) (tx *t
 }
 
 func (n *node) HeaderByNumber(ctx context.Context, number *big.Int) (header *types.Header, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("number", number)
+	lggr := n.newRqLggr().With("number", number)
 
 	lggr.Debug("RPC call: evmclient.Client#HeaderByNumber")
 	start := time.Now()
@@ -564,12 +565,12 @@ func (n *node) HeaderByNumber(ctx context.Context, number *big.Int) (header *typ
 }
 
 func (n *node) HeaderByHash(ctx context.Context, hash common.Hash) (header *types.Header, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("hash", hash)
+	lggr := n.newRqLggr().With("hash", hash)
 
 	lggr.Debug("RPC call: evmclient.Client#HeaderByHash")
 	start := time.Now()
@@ -590,12 +591,12 @@ func (n *node) HeaderByHash(ctx context.Context, hash common.Hash) (header *type
 }
 
 func (n *node) SendTransaction(ctx context.Context, tx *types.Transaction) error {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("tx", tx)
+	lggr := n.newRqLggr().With("tx", tx)
 
 	lggr.Debug("RPC call: evmclient.Client#SendTransaction")
 	start := time.Now()
@@ -613,12 +614,12 @@ func (n *node) SendTransaction(ctx context.Context, tx *types.Transaction) error
 
 // PendingNonceAt returns one higher than the highest nonce from both mempool and mined transactions
 func (n *node) PendingNonceAt(ctx context.Context, account common.Address) (nonce uint64, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return 0, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("account", account)
+	lggr := n.newRqLggr().With("account", account)
 
 	lggr.Debug("RPC call: evmclient.Client#PendingNonceAt")
 	start := time.Now()
@@ -642,12 +643,12 @@ func (n *node) PendingNonceAt(ctx context.Context, account common.Address) (nonc
 // mined nonce at the given block number, but it actually returns the total
 // transaction count which is the highest mined nonce + 1
 func (n *node) NonceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (nonce uint64, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return 0, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("account", account, "blockNumber", blockNumber)
+	lggr := n.newRqLggr().With("account", account, "blockNumber", blockNumber)
 
 	lggr.Debug("RPC call: evmclient.Client#NonceAt")
 	start := time.Now()
@@ -668,12 +669,12 @@ func (n *node) NonceAt(ctx context.Context, account common.Address, blockNumber 
 }
 
 func (n *node) PendingCodeAt(ctx context.Context, account common.Address) (code []byte, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("account", account)
+	lggr := n.newRqLggr().With("account", account)
 
 	lggr.Debug("RPC call: evmclient.Client#PendingCodeAt")
 	start := time.Now()
@@ -694,12 +695,12 @@ func (n *node) PendingCodeAt(ctx context.Context, account common.Address) (code 
 }
 
 func (n *node) CodeAt(ctx context.Context, account common.Address, blockNumber *big.Int) (code []byte, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("account", account, "blockNumber", blockNumber)
+	lggr := n.newRqLggr().With("account", account, "blockNumber", blockNumber)
 
 	lggr.Debug("RPC call: evmclient.Client#CodeAt")
 	start := time.Now()
@@ -720,12 +721,12 @@ func (n *node) CodeAt(ctx context.Context, account common.Address, blockNumber *
 }
 
 func (n *node) EstimateGas(ctx context.Context, call ethereum.CallMsg) (gas uint64, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return 0, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("call", call)
+	lggr := n.newRqLggr().With("call", call)
 
 	lggr.Debug("RPC call: evmclient.Client#EstimateGas")
 	start := time.Now()
@@ -746,12 +747,12 @@ func (n *node) EstimateGas(ctx context.Context, call ethereum.CallMsg) (gas uint
 }
 
 func (n *node) SuggestGasPrice(ctx context.Context) (price *big.Int, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n))
+	lggr := n.newRqLggr()
 
 	lggr.Debug("RPC call: evmclient.Client#SuggestGasPrice")
 	start := time.Now()
@@ -772,12 +773,12 @@ func (n *node) SuggestGasPrice(ctx context.Context) (price *big.Int, err error) 
 }
 
 func (n *node) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumber *big.Int) (val []byte, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("callMsg", msg, "blockNumber", blockNumber)
+	lggr := n.newRqLggr().With("callMsg", msg, "blockNumber", blockNumber)
 
 	lggr.Debug("RPC call: evmclient.Client#CallContract")
 	start := time.Now()
@@ -799,12 +800,12 @@ func (n *node) CallContract(ctx context.Context, msg ethereum.CallMsg, blockNumb
 }
 
 func (n *node) BlockByNumber(ctx context.Context, number *big.Int) (b *types.Block, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("number", number)
+	lggr := n.newRqLggr().With("number", number)
 
 	lggr.Debug("RPC call: evmclient.Client#BlockByNumber")
 	start := time.Now()
@@ -825,12 +826,12 @@ func (n *node) BlockByNumber(ctx context.Context, number *big.Int) (b *types.Blo
 }
 
 func (n *node) BlockByHash(ctx context.Context, hash common.Hash) (b *types.Block, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("hash", hash)
+	lggr := n.newRqLggr().With("hash", hash)
 
 	lggr.Debug("RPC call: evmclient.Client#BlockByHash")
 	start := time.Now()
@@ -851,12 +852,12 @@ func (n *node) BlockByHash(ctx context.Context, hash common.Hash) (b *types.Bloc
 }
 
 func (n *node) BlockNumber(ctx context.Context) (height uint64, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return 0, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n))
+	lggr := n.newRqLggr()
 
 	lggr.Debug("RPC call: evmclient.Client#BlockNumber")
 	start := time.Now()
@@ -877,12 +878,12 @@ func (n *node) BlockNumber(ctx context.Context) (height uint64, err error) {
 }
 
 func (n *node) BalanceAt(ctx context.Context, account common.Address, blockNumber *big.Int) (balance *big.Int, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("account", account.Hex(), "blockNumber", blockNumber)
+	lggr := n.newRqLggr().With("account", account.Hex(), "blockNumber", blockNumber)
 
 	lggr.Debug("RPC call: evmclient.Client#BalanceAt")
 	start := time.Now()
@@ -903,12 +904,12 @@ func (n *node) BalanceAt(ctx context.Context, account common.Address, blockNumbe
 }
 
 func (n *node) FilterLogs(ctx context.Context, q ethereum.FilterQuery) (l []types.Log, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n)).With("q", q)
+	lggr := n.newRqLggr().With("q", q)
 
 	lggr.Debug("RPC call: evmclient.Client#FilterLogs")
 	start := time.Now()
@@ -929,12 +930,12 @@ func (n *node) FilterLogs(ctx context.Context, q ethereum.FilterQuery) (l []type
 }
 
 func (n *node) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, ch chan<- types.Log) (sub ethereum.Subscription, err error) {
-	ctx, cancel, ws, _, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, _, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr("websocket").With("q", q)
+	lggr := n.newRqLggr().With("q", q)
 
 	lggr.Debug("RPC call: evmclient.Client#SubscribeFilterLogs")
 	start := time.Now()
@@ -951,12 +952,12 @@ func (n *node) SubscribeFilterLogs(ctx context.Context, q ethereum.FilterQuery, 
 }
 
 func (n *node) SuggestGasTipCap(ctx context.Context) (tipCap *big.Int, err error) {
-	ctx, cancel, ws, http, err := n.makeLiveQueryCtx(ctx)
+	ctx, cancel, ws, http, err := n.makeLiveQueryCtxAndSafeGetClients(ctx)
 	if err != nil {
 		return nil, err
 	}
 	defer cancel()
-	lggr := n.newRqLggr(switching(n))
+	lggr := n.newRqLggr()
 
 	lggr.Debug("RPC call: evmclient.Client#SuggestGasTipCap")
 	start := time.Now()
@@ -979,10 +980,9 @@ func (n *node) SuggestGasTipCap(ctx context.Context) (tipCap *big.Int, err error
 func (n *node) ChainID() (chainID *big.Int) { return n.chainID }
 
 // newRqLggr generates a new logger with a unique request ID
-func (n *node) newRqLggr(mode string) logger.Logger {
+func (n *node) newRqLggr() logger.Logger {
 	return n.rpcLog.With(
 		"requestID", uuid.New(),
-		"mode", mode,
 	)
 }
 
@@ -1046,8 +1046,8 @@ func wrap(err error, tp string) error {
 	return errors.Wrapf(err, "%s call failed", tp)
 }
 
-// makeLiveQueryCtx wraps makeQueryCtx but returns error if node is not NodeStateAlive.
-func (n *node) makeLiveQueryCtx(parentCtx context.Context) (ctx context.Context, cancel context.CancelFunc, ws rawclient, http *rawclient, err error) {
+// makeLiveQueryCtxAndSafeGetClients wraps makeQueryCtx but returns error if node is not NodeStateAlive.
+func (n *node) makeLiveQueryCtxAndSafeGetClients(parentCtx context.Context) (ctx context.Context, cancel context.CancelFunc, ws rawclient, http *rawclient, err error) {
 	// Need to wrap in mutex because state transition can cancel and replace the
 	// context
 	n.stateMu.RLock()
@@ -1086,7 +1086,7 @@ func makeQueryCtx(ctx context.Context, ch utils.StopChan) (context.Context, cont
 	return ctx, cancel
 }
 
-func switching(n *node) string {
+func (n *node) getNodeMode() string {
 	if n.http != nil {
 		return "http"
 	}

--- a/core/cmd/eth_keys_commands.go
+++ b/core/cmd/eth_keys_commands.go
@@ -169,6 +169,7 @@ func (ps EthKeyPresenters) RenderTable(rt RendererTable) error {
 // ListETHKeys renders the active account address with its ETH & LINK balance
 func (s *Shell) ListETHKeys(_ *cli.Context) (err error) {
 	resp, err := s.HTTP.Get("/v2/keys/evm")
+	
 	if err != nil {
 		return s.errorOut(err)
 	}

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -565,20 +565,20 @@ func (s *server) run(ip net.IP, port uint16, writeTimeout time.Duration) error {
 	return errors.Wrap(err, "failed to run plaintext HTTP server")
 }
 
-func (s *server) runTLS(ip net.IP, port uint16, certFile, keyFile string, writeTimeout time.Duration) error {
+func (s *server) runTLS(ip net.IP, port uint16, certFile, keyFile string, requestTimeout time.Duration) error {
 	addr := fmt.Sprintf("%s:%d", ip.String(), port)
 	s.lggr.Infow(fmt.Sprintf("Listening and serving HTTPS on %s", addr), "ip", ip, "port", port)
-	s.tlsServer = createServer(s.handler, addr, writeTimeout)
+	s.tlsServer = createServer(s.handler, addr, requestTimeout)
 	err := s.tlsServer.ListenAndServeTLS(certFile, keyFile)
 	return errors.Wrap(err, "failed to run TLS server (NOTE: you can disable TLS server completely and silence these errors by setting WebServer.TLS.HTTPSPort=0 in your config)")
 }
 
-func createServer(handler *gin.Engine, addr string, writeTimeout time.Duration) *http.Server {
+func createServer(handler *gin.Engine, addr string, requestTimeout time.Duration) *http.Server {
 	s := &http.Server{
 		Addr:           addr,
 		Handler:        handler,
-		ReadTimeout:    5 * time.Second,
-		WriteTimeout:   writeTimeout,
+		ReadTimeout:    requestTimeout,
+		WriteTimeout:   requestTimeout,
 		IdleTimeout:    60 * time.Second,
 		MaxHeaderBytes: 1 << 20,
 	}

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -465,16 +465,16 @@ func (n ChainlinkRunner) Run(ctx context.Context, app chainlink.Application) err
 	server := server{handler: handler, lggr: app.GetLogger()}
 
 	g, gCtx := errgroup.WithContext(ctx)
-	timeoutDuration := config.WebServer().StartTimeout()
+	serverStartTimeoutDuration := config.WebServer().StartTimeout()
 	if ws.HTTPPort() != 0 {
-		go tryRunServerUntilCancelled(gCtx, app.GetLogger(), timeoutDuration, func() error {
+		go tryRunServerUntilCancelled(gCtx, app.GetLogger(), serverStartTimeoutDuration, func() error {
 			return server.run(ws.ListenIP(), ws.HTTPPort(), config.WebServer().HTTPWriteTimeout())
 		})
 	}
 
 	tls := config.WebServer().TLS()
 	if tls.HTTPSPort() != 0 {
-		go tryRunServerUntilCancelled(gCtx, app.GetLogger(), timeoutDuration, func() error {
+		go tryRunServerUntilCancelled(gCtx, app.GetLogger(), serverStartTimeoutDuration, func() error {
 			return server.runTLS(
 				tls.ListenIP(),
 				tls.HTTPSPort(),

--- a/core/internal/cltest/factories.go
+++ b/core/internal/cltest/factories.go
@@ -534,6 +534,22 @@ func MustInsertRandomKey(
 	return key, key.Address
 }
 
+func MustInsertRandomEnabledKey(
+	t testing.TB,
+	keystore keystore.Eth,
+	opts ...interface{},
+) (ethkey.KeyV2, common.Address) {
+	return MustInsertRandomKey(t, keystore, append(opts, true))
+}
+
+func MustInsertRandomDisabledKey(
+	t testing.TB,
+	keystore keystore.Eth,
+	opts ...interface{},
+) (key ethkey.KeyV2, address common.Address) {
+	return MustInsertRandomKey(t, keystore, append(opts, false))
+}
+
 func MustInsertRandomKeyReturningState(t testing.TB,
 	keystore keystore.Eth,
 	opts ...interface{},

--- a/core/web/eth_keys_controller.go
+++ b/core/web/eth_keys_controller.go
@@ -368,19 +368,15 @@ func (ekc *ETHKeysController) getEthBalance(ctx context.Context, state ethkey.St
 		return nil
 	}
 
-	if state.Disabled {
-		ethClient := chain.Client()
-		bal, err := ethClient.BalanceAt(ctx, state.Address.Address(), nil)
-		if err != nil {
-			ekc.lggr.Errorw("Failed to get ETH balance", "chainID", chainID, "address", state.Address, "err", err)
-			return nil
-		}
-
-		return bal
+	ethClient := chain.Client()
+	bal, err := ethClient.BalanceAt(ctx, state.Address.Address(), nil)
+	if err != nil {
+		ekc.lggr.Errorw("Failed to get ETH balance", "chainID", chainID, "address", state.Address, "err", err)
+		return nil
 	}
 
-	bal := chain.BalanceMonitor().GetEthBalance(state.Address.Address())
-	return bal.ToInt()
+	return bal
+
 }
 
 func (ekc *ETHKeysController) setLinkBalance(bal *assets.Link) presenters.NewETHKeyOption {

--- a/core/web/eth_keys_controller.go
+++ b/core/web/eth_keys_controller.go
@@ -41,11 +41,16 @@ func NewETHKeysController(app chainlink.Application) *ETHKeysController {
 }
 
 func createETHKeyResource(c *gin.Context, ekc *ETHKeysController, key ethkey.KeyV2, state ethkey.State) *presenters.ETHKeyResource {
+	ethBalance := ekc.getEthBalance(c.Request.Context(), state)
+	linkBalance := ekc.getLinkBalance(c.Request.Context(), state)
+	maxGasPrice := ekc.getKeyMaxGasPriceWei(state, key.Address)
+
 	r := presenters.NewETHKeyResource(key, state,
-		ekc.setEthBalance(c.Request.Context(), state),
-		ekc.setLinkBalance(c.Request.Context(), state),
-		ekc.setKeyMaxGasPriceWei(state, key.Address),
+		ekc.setEthBalance(ethBalance),
+		ekc.setLinkBalance(linkBalance),
+		ekc.setKeyMaxGasPriceWei(maxGasPrice),
 	)
+
 	return r
 }
 
@@ -99,11 +104,7 @@ func (ekc *ETHKeysController) Index(c *gin.Context) {
 			return
 		}
 
-		r := presenters.NewETHKeyResource(key, state,
-			ekc.setEthBalance(c.Request.Context(), state),
-			ekc.setLinkBalance(c.Request.Context(), state),
-			ekc.setKeyMaxGasPriceWei(state, key.Address),
-		)
+		r := createETHKeyResource(c, ekc, key, state)
 
 		resources = append(resources, *r)
 	}
@@ -113,6 +114,7 @@ func (ekc *ETHKeysController) Index(c *gin.Context) {
 	})
 
 	jsonAPIResponseWithStatus(c, resources, "keys", http.StatusOK)
+
 }
 
 // Create adds a new account
@@ -351,31 +353,42 @@ func (ekc *ETHKeysController) Chain(c *gin.Context) {
 	c.Status(http.StatusOK)
 }
 
-// setEthBalance is a custom functional option for NewEthKeyResource which
-// queries the EthClient for the ETH balance at the address and sets it on the
-// resource.
-func (ekc *ETHKeysController) setEthBalance(ctx context.Context, state ethkey.State) presenters.NewETHKeyOption {
-	var bal *big.Int
+func (ekc *ETHKeysController) setEthBalance(bal *big.Int) presenters.NewETHKeyOption {
+	return presenters.SetETHKeyEthBalance((*assets.Eth)(bal))
+}
+
+// queries the EthClient for the ETH balance at the address associated with state
+func (ekc *ETHKeysController) getEthBalance(ctx context.Context, state ethkey.State) *big.Int {
 	chainID := state.EVMChainID.ToInt()
 	chain, err := ekc.app.GetChains().EVM.Get(chainID)
 	if err != nil {
 		if !errors.Is(errors.Cause(err), evm.ErrNoChains) {
 			ekc.lggr.Errorw("Failed to get EVM Chain", "chainID", chainID, "address", state.Address, "err", err)
 		}
-	} else {
+		return nil
+	}
+
+	if state.Disabled {
 		ethClient := chain.Client()
-		bal, err = ethClient.BalanceAt(ctx, state.Address.Address(), nil)
+		bal, err := ethClient.BalanceAt(ctx, state.Address.Address(), nil)
 		if err != nil {
 			ekc.lggr.Errorw("Failed to get ETH balance", "chainID", chainID, "address", state.Address, "err", err)
+			return nil
 		}
+
+		return bal
 	}
-	return presenters.SetETHKeyEthBalance((*assets.Eth)(bal))
+
+	bal := chain.BalanceMonitor().GetEthBalance(state.Address.Address())
+	return bal.ToInt()
 }
 
-// setLinkBalance is a custom functional option for NewEthKeyResource which
-// queries the EthClient for the LINK balance at the address and sets it on the
-// resource.
-func (ekc *ETHKeysController) setLinkBalance(ctx context.Context, state ethkey.State) presenters.NewETHKeyOption {
+func (ekc *ETHKeysController) setLinkBalance(bal *assets.Link) presenters.NewETHKeyOption {
+	return presenters.SetETHKeyLinkBalance(bal)
+}
+
+// queries the EthClient for the LINK balance at the address associated with state
+func (ekc *ETHKeysController) getLinkBalance(ctx context.Context, state ethkey.State) *assets.Link {
 	var bal *assets.Link
 	chainID := state.EVMChainID.ToInt()
 	chain, err := ekc.app.GetChains().EVM.Get(chainID)
@@ -391,13 +404,17 @@ func (ekc *ETHKeysController) setLinkBalance(ctx context.Context, state ethkey.S
 			ekc.lggr.Errorw("Failed to get LINK balance", "chainID", chainID, "address", state.Address, "err", err)
 		}
 	}
-	return presenters.SetETHKeyLinkBalance(bal)
+	return bal
 }
 
 // setKeyMaxGasPriceWei is a custom functional option for NewEthKeyResource which
 // gets the key specific max gas price from the chain config and sets it on the
 // resource.
-func (ekc *ETHKeysController) setKeyMaxGasPriceWei(state ethkey.State, keyAddress common.Address) presenters.NewETHKeyOption {
+func (ekc *ETHKeysController) setKeyMaxGasPriceWei(price *assets.Wei) presenters.NewETHKeyOption {
+	return presenters.SetETHKeyMaxGasPriceWei(utils.NewBig(price.ToInt()))
+}
+
+func (ekc *ETHKeysController) getKeyMaxGasPriceWei(state ethkey.State, keyAddress common.Address) *assets.Wei {
 	var price *assets.Wei
 	chainID := state.EVMChainID.ToInt()
 	chain, err := ekc.app.GetChains().EVM.Get(chainID)
@@ -408,7 +425,7 @@ func (ekc *ETHKeysController) setKeyMaxGasPriceWei(state ethkey.State, keyAddres
 	} else {
 		price = chain.Config().EVM().GasEstimator().PriceMaxKey(keyAddress)
 	}
-	return presenters.SetETHKeyMaxGasPriceWei(utils.NewBig(price.ToInt()))
+	return price
 }
 
 // getChain is a convenience wrapper to retrieve a chain for a given request

--- a/core/web/eth_keys_controller_test.go
+++ b/core/web/eth_keys_controller_test.go
@@ -34,17 +34,17 @@ func TestETHKeysController_Index_Success(t *testing.T) {
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].NonceAutoSync = ptr(false)
-		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
+		c.EVM[0].BalanceMonitor.Enabled = ptr(true)
 	})
 	app := cltest.NewApplicationWithConfig(t, cfg, ethClient)
 
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
-	// disabled key
-	k0, addr0 := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), true)
-	// enabled keys
-	k1, addr1 := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), false)
-	k2, addr2 := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), false)
+	// enabled key
+	k0, addr0 := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
+	// disabled keys
+	k1, addr1 := cltest.MustInsertRandomDisabledKey(t, app.KeyStore.Eth())
+	k2, addr2 := cltest.MustInsertRandomDisabledKey(t, app.KeyStore.Eth())
 	expectedKeys := []ethkey.KeyV2{k0, k1, k2}
 
 	ethClient.On("BalanceAt", mock.Anything, addr0, mock.Anything).Return(big.NewInt(256), nil).Once()
@@ -57,7 +57,7 @@ func TestETHKeysController_Index_Success(t *testing.T) {
 	require.NoError(t, app.Start(testutils.Context(t)))
 
 	client := app.NewHTTPClient(cltest.APIEmailAdmin)
-	resp, cleanup := client.Get("/v2/keys/eth")
+	resp, cleanup := client.Get("/v2/keys/evm")
 	defer cleanup()
 	require.Equal(t, http.StatusOK, resp.StatusCode)
 
@@ -93,7 +93,7 @@ func TestETHKeysController_Index_Errors(t *testing.T) {
 
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
-	_, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), true)
+	_, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
 
 	ethClient.On("BalanceAt", mock.Anything, addr, mock.Anything).Return(nil, errors.New("fake error")).Once()
 	ethClient.On("LINKBalance", mock.Anything, addr, mock.Anything).Return(nil, errors.New("fake error")).Once()
@@ -130,7 +130,7 @@ func TestETHKeysController_Index_Disabled(t *testing.T) {
 
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
-	_, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), true)
+	_, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
 
 	require.NoError(t, app.Start(testutils.Context(t)))
 
@@ -254,7 +254,7 @@ func TestETHKeysController_ChainSuccess_UpdateNonce(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// enabled key
-	key, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), true)
+	key, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
 
 	ethClient.On("BalanceAt", mock.Anything, addr, mock.Anything).Return(big.NewInt(1), nil).Once()
 	ethClient.On("LINKBalance", mock.Anything, addr, mock.Anything).Return(assets.NewLinkFromJuels(1), nil).Once()
@@ -298,7 +298,7 @@ func TestETHKeysController_ChainSuccess_Disable(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// enabled key
-	key, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), true)
+	key, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
 
 	ethClient.On("BalanceAt", mock.Anything, addr, mock.Anything).Return(big.NewInt(1), nil).Once()
 	ethClient.On("LINKBalance", mock.Anything, addr, mock.Anything).Return(assets.NewLinkFromJuels(1), nil).Once()
@@ -342,7 +342,7 @@ func TestETHKeysController_ChainSuccess_Enable(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// disabled key
-	key, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), false)
+	key, addr := cltest.MustInsertRandomDisabledKey(t, app.KeyStore.Eth())
 
 	ethClient.On("BalanceAt", mock.Anything, addr, mock.Anything).Return(big.NewInt(1), nil).Once()
 	ethClient.On("LINKBalance", mock.Anything, addr, mock.Anything).Return(assets.NewLinkFromJuels(1), nil).Once()
@@ -386,7 +386,7 @@ func TestETHKeysController_ChainSuccess_ResetWithAbandon(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// enabled key
-	key, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), true)
+	key, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
 
 	ethClient.On("BalanceAt", mock.Anything, addr, mock.Anything).Return(big.NewInt(1), nil).Once()
 	ethClient.On("LINKBalance", mock.Anything, addr, mock.Anything).Return(assets.NewLinkFromJuels(1), nil).Once()
@@ -544,7 +544,7 @@ func TestETHKeysController_ChainFailure_MissingChainID(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// enabled key
-	_, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), true)
+	_, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
 
 	require.NoError(t, app.Start(testutils.Context(t)))
 
@@ -577,7 +577,7 @@ func TestETHKeysController_ChainFailure_InvalidNonce(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// enabled key
-	_, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), true)
+	_, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
 
 	require.NoError(t, app.Start(testutils.Context(t)))
 
@@ -607,8 +607,8 @@ func TestETHKeysController_DeleteSuccess(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// enabled keys
-	key0, addr0 := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), true)
-	_, addr1 := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), true)
+	key0, addr0 := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
+	_, addr1 := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
 
 	ethClient.On("BalanceAt", mock.Anything, addr0, mock.Anything).Return(big.NewInt(1), nil).Once()
 	ethClient.On("BalanceAt", mock.Anything, addr1, mock.Anything).Return(big.NewInt(1), nil).Once()

--- a/core/web/eth_keys_controller_test.go
+++ b/core/web/eth_keys_controller_test.go
@@ -34,7 +34,7 @@ func TestETHKeysController_Index_Success(t *testing.T) {
 	ethClient := cltest.NewEthMocksWithStartupAssertions(t)
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].NonceAutoSync = ptr(false)
-		c.EVM[0].BalanceMonitor.Enabled = ptr(true)
+		c.EVM[0].BalanceMonitor.Enabled = ptr(false)
 	})
 	app := cltest.NewApplicationWithConfig(t, cfg, ethClient)
 

--- a/integration-tests/client/chainlink.go
+++ b/integration-tests/client/chainlink.go
@@ -47,6 +47,11 @@ type Chainlink struct {
 // NewChainlink creates a new Chainlink model using a provided config
 func NewChainlink(c *ChainlinkConfig) (*Chainlink, error) {
 	rc := resty.New().SetBaseURL(c.URL)
+
+	if c.HTTPTimeout != nil {
+		rc.SetTimeout(*c.HTTPTimeout)
+	}
+
 	session := &Session{Email: c.Email, Password: c.Password}
 
 	// Retry the connection on boot up, sometimes pods can still be starting up and not ready to accept connections

--- a/integration-tests/client/chainlink_models.go
+++ b/integration-tests/client/chainlink_models.go
@@ -19,12 +19,13 @@ type EIServiceConfig struct {
 
 // ChainlinkConfig represents the variables needed to connect to a Chainlink node
 type ChainlinkConfig struct {
-	URL        string
-	Email      string
-	Password   string
-	InternalIP string // Can change if the node is restarted. Prefer RemoteURL if possible
-	ChartName  string
-	PodName    string
+	URL         string
+	Email       string
+	Password    string
+	InternalIP  string // Can change if the node is restarted. Prefer RemoteURL if possible
+	ChartName   string
+	PodName     string
+	HTTPTimeout *time.Duration
 }
 
 // ResponseSlice is the generic model that can be used for all Chainlink API responses that are an slice


### PR DESCRIPTION
Functional changes:
Sets the http readTimeout to WebServer.HTTPWriteTimeout configuration parameter. Previously, the readTimeout was hardcoded to 5s, while the default writeTimeout was 10s. This lead to failures in smoke tests after 5s, and more importantly, was not tunable. 

Allows HTTPTimeout in the evm RPC client to be explicitly configured. It currently uses the default timeout (never times out). 

Refactoring changes are mostly renames or separation of concern edits. 

There's a few things to consider after this unit of work:
* Deprecate collecting ETH/LINK balances in the v2/keys/evm API routes?
* Abstract http or ws geth clients in the core/chains/evm/node.go business logic behind a Transport interface
* Add LINK balances to the balance monitor class
* Hook into balance monitor for ETH account balances?
* Bumping the default for `WebServer.HTTPWriteTimeout` to a much higher value (minutes instead of seconds)