### PR TITLE
bug/2380-keys-evm-api-status-codes: updatingv2/keys/evm routes to the correct 400 status codes

### DIFF
--- a/core/web/eth_keys_controller.go
+++ b/core/web/eth_keys_controller.go
@@ -162,14 +162,14 @@ func (ekc *ETHKeysController) Delete(c *gin.Context) {
 
 	keyID := c.Param("address")
 	if !common.IsHexAddress(keyID) {
-		jsonAPIError(c, http.StatusInternalServerError, errors.Errorf("invalid keyID: %s, must be hex address", keyID))
+		jsonAPIError(c, http.StatusBadRequest, errors.Errorf("invalid keyID: %s, must be hex address", keyID))
 		return
 	}
 
 	key, err := ethKeyStore.Get(keyID)
 	if err != nil {
 		if errors.Is(err, keystore.ErrKeyNotFound) {
-			jsonAPIError(c, http.StatusInternalServerError, err)
+			jsonAPIError(c, http.StatusNotFound, err)
 			return
 		}
 		jsonAPIError(c, http.StatusInternalServerError, err)
@@ -264,7 +264,7 @@ func (ekc *ETHKeysController) Chain(c *gin.Context) {
 	addressHex := c.Query("address")
 	addressBytes, err := hexutil.Decode(addressHex)
 	if err != nil {
-		jsonAPIError(c, http.StatusInternalServerError, errors.Wrap(err, "invalid address"))
+		jsonAPIError(c, http.StatusBadRequest, errors.Wrap(err, "invalid address"))
 		return
 	}
 	address := common.BytesToAddress(addressBytes)
@@ -279,7 +279,7 @@ func (ekc *ETHKeysController) Chain(c *gin.Context) {
 	if nonceStr := c.Query("nextNonce"); nonceStr != "" {
 		nonce, err = strconv.ParseInt(nonceStr, 10, 64)
 		if err != nil || nonce < 0 {
-			jsonAPIError(c, http.StatusInternalServerError, errors.Wrapf(err, "invalid value for nonce: expected 0 or positive int, got: %s", nonceStr))
+			jsonAPIError(c, http.StatusBadRequest, errors.Wrapf(err, "invalid value for nonce: expected 0 or positive int, got: %s", nonceStr))
 			return
 		}
 	}
@@ -287,7 +287,7 @@ func (ekc *ETHKeysController) Chain(c *gin.Context) {
 	if abandonStr := c.Query("abandon"); abandonStr != "" {
 		abandon, err = strconv.ParseBool(abandonStr)
 		if err != nil {
-			jsonAPIError(c, http.StatusInternalServerError, errors.Wrapf(err, "invalid value for abandon: expected boolean, got: %s", abandonStr))
+			jsonAPIError(c, http.StatusBadRequest, errors.Wrapf(err, "invalid value for abandon: expected boolean, got: %s", abandonStr))
 			return
 		}
 	}
@@ -303,7 +303,7 @@ func (ekc *ETHKeysController) Chain(c *gin.Context) {
 		err = multierr.Combine(err, resetErr)
 		if err != nil {
 			if strings.Contains(err.Error(), "key state not found with address") {
-				jsonAPIError(c, http.StatusInternalServerError, err)
+				jsonAPIError(c, http.StatusNotFound, err)
 			}
 			jsonAPIError(c, http.StatusInternalServerError, err)
 			return
@@ -315,7 +315,7 @@ func (ekc *ETHKeysController) Chain(c *gin.Context) {
 		var enabled bool
 		enabled, err = strconv.ParseBool(enabledStr)
 		if err != nil {
-			jsonAPIError(c, http.StatusInternalServerError, errors.Wrap(err, "enabled must be bool"))
+			jsonAPIError(c, http.StatusBadRequest, errors.Wrap(err, "enabled must be bool"))
 			return
 		}
 
@@ -333,7 +333,7 @@ func (ekc *ETHKeysController) Chain(c *gin.Context) {
 	key, err := kst.Get(address.Hex())
 	if err != nil {
 		if errors.Is(err, keystore.ErrKeyNotFound) {
-			jsonAPIError(c, http.StatusInternalServerError, err)
+			jsonAPIError(c, http.StatusNotFound, err)
 			return
 		}
 		jsonAPIError(c, http.StatusInternalServerError, err)
@@ -417,13 +417,13 @@ func (ekc *ETHKeysController) getChain(c *gin.Context, cs evm.ChainSet, chainIDs
 	chain, err := getChain(ekc.app.GetChains().EVM, chainIDstr)
 	if err != nil {
 		if errors.Is(err, ErrInvalidChainID) {
-			jsonAPIError(c, http.StatusInternalServerError, err)
+			jsonAPIError(c, http.StatusBadRequest, err)
 			return nil, false
 		} else if errors.Is(err, ErrMultipleChains) {
-			jsonAPIError(c, http.StatusInternalServerError, err)
+			jsonAPIError(c, http.StatusBadRequest, err)
 			return nil, false
 		} else if errors.Is(err, ErrMissingChainID) {
-			jsonAPIError(c, http.StatusInternalServerError, err)
+			jsonAPIError(c, http.StatusNotFound, err)
 			return nil, false
 		}
 		jsonAPIError(c, http.StatusInternalServerError, err)

--- a/core/web/eth_keys_controller_test.go
+++ b/core/web/eth_keys_controller_test.go
@@ -467,8 +467,8 @@ func TestETHKeysController_ChainFailure_InvalidAddress(t *testing.T) {
 	chainURL.RawQuery = query.Encode()
 	resp, cleanup := client.Post(chainURL.String(), nil)
 	defer cleanup()
-	// TODO once cleared, update to http.StatusBadRequest https://smartcontract-it.atlassian.net/browse/BCF-2346
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
 func TestETHKeysController_ChainFailure_MissingAddress(t *testing.T) {
@@ -497,8 +497,8 @@ func TestETHKeysController_ChainFailure_MissingAddress(t *testing.T) {
 	chainURL.RawQuery = query.Encode()
 	resp, cleanup := client.Post(chainURL.String(), nil)
 	defer cleanup()
-	// TODO once cleared, update to http.StatusNotFound https://smartcontract-it.atlassian.net/browse/BCF-2346
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
 func TestETHKeysController_ChainFailure_InvalidChainID(t *testing.T) {
@@ -527,8 +527,8 @@ func TestETHKeysController_ChainFailure_InvalidChainID(t *testing.T) {
 	chainURL.RawQuery = query.Encode()
 	resp, cleanup := client.Post(chainURL.String(), nil)
 	defer cleanup()
-	// TODO once cleared, update to http.StatusBadRequest https://smartcontract-it.atlassian.net/browse/BCF-2346
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
 func TestETHKeysController_ChainFailure_MissingChainID(t *testing.T) {
@@ -560,8 +560,8 @@ func TestETHKeysController_ChainFailure_MissingChainID(t *testing.T) {
 	chainURL.RawQuery = query.Encode()
 	resp, cleanup := client.Post(chainURL.String(), nil)
 	defer cleanup()
-	// TODO once cleared, update to http.StatusNotFound https://smartcontract-it.atlassian.net/browse/BCF-2346
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }
 
 func TestETHKeysController_ChainFailure_InvalidNonce(t *testing.T) {
@@ -592,8 +592,8 @@ func TestETHKeysController_ChainFailure_InvalidNonce(t *testing.T) {
 	chainURL.RawQuery = query.Encode()
 	resp, cleanup := client.Post(chainURL.String(), nil)
 	defer cleanup()
-	// TODO once cleared, update to http.StatusBadRequest https://smartcontract-it.atlassian.net/browse/BCF-2346
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
 func TestETHKeysController_DeleteSuccess(t *testing.T) {
@@ -664,8 +664,8 @@ func TestETHKeysController_DeleteFailure_InvalidAddress(t *testing.T) {
 
 	resp, cleanup := client.Delete(chainURL.String())
 	defer cleanup()
-	// TODO once cleared, update to http.StatusBadRequest https://smartcontract-it.atlassian.net/browse/BCF-2346
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
 func TestETHKeysController_DeleteFailure_KeyMissing(t *testing.T) {
@@ -686,6 +686,6 @@ func TestETHKeysController_DeleteFailure_KeyMissing(t *testing.T) {
 	resp, cleanup := client.Delete(chainURL.String())
 	defer cleanup()
 	t.Log(resp)
-	// TODO once cleared, update to http.StatusNotFound https://smartcontract-it.atlassian.net/browse/BCF-2346
-	assert.Equal(t, http.StatusInternalServerError, resp.StatusCode)
+
+	assert.Equal(t, http.StatusNotFound, resp.StatusCode)
 }

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [dev]
 
-...
+### Fixed
+- Updated `v2/keys/evm` and `v2/keys/eth` routes to return 400 and 404 status codes where appropriate. Previously 500s were returned when requested resources were not found or client requests could not be parsed. 
 
 ## 2.3.0 - UNRELEASED
 


### PR DESCRIPTION
We have validated with NOPs that we are all set to update the response status codes for the EVM Keys APIs to appropriate 400 status codes from the incorrectly supplied 500s