### PR TITLE
[Functions] (chore): Reduce contract sizes

### DIFF
--- a/contracts/src/v0.8/functions/dev/1_0_0/FunctionsBilling.sol
+++ b/contracts/src/v0.8/functions/dev/1_0_0/FunctionsBilling.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.6;
 
-import {Routable, ITypeAndVersion} from "./Routable.sol";
+import {Routable} from "./Routable.sol";
 import {IFunctionsRouter} from "./interfaces/IFunctionsRouter.sol";
 import {IFunctionsSubscriptions} from "./interfaces/IFunctionsSubscriptions.sol";
 import {AggregatorV3Interface} from "../../../interfaces/AggregatorV3Interface.sol";

--- a/contracts/src/v0.8/functions/dev/1_0_0/FunctionsCoordinator.sol
+++ b/contracts/src/v0.8/functions/dev/1_0_0/FunctionsCoordinator.sol
@@ -2,12 +2,10 @@
 pragma solidity ^0.8.6;
 
 import {IFunctionsCoordinator} from "./interfaces/IFunctionsCoordinator.sol";
-import {IFunctionsBilling, FunctionsBilling, Routable, ITypeAndVersion} from "./FunctionsBilling.sol";
+import {IFunctionsBilling, FunctionsBilling} from "./FunctionsBilling.sol";
 import {OCR2Base} from "./ocr/OCR2Base.sol";
-import {IOwnable} from "../../../shared/interfaces/IOwnable.sol";
-import {IFunctionsRouter} from "./interfaces/IFunctionsRouter.sol";
-import {IFunctionsSubscriptions} from "./interfaces/IFunctionsSubscriptions.sol";
 import {FulfillResult} from "./FulfillResultCodes.sol";
+import {ITypeAndVersion} from "./Routable.sol";
 
 /**
  * @title Functions Coordinator contract
@@ -78,7 +76,7 @@ contract FunctionsCoordinator is OCR2Base, IFunctionsCoordinator, FunctionsBilli
   /**
    * @inheritdoc IFunctionsCoordinator
    */
-  function setDONPublicKey(bytes calldata donPublicKey) external override onlyRouterOwner {
+  function setDONPublicKey(bytes calldata donPublicKey) external override onlyOwner {
     if (donPublicKey.length == 0) {
       revert EmptyPublicKey();
     }
@@ -103,7 +101,7 @@ contract FunctionsCoordinator is OCR2Base, IFunctionsCoordinator, FunctionsBilli
    */
   function setNodePublicKey(address node, bytes calldata publicKey) external override {
     // Owner can set anything. Transmitters can set only their own key.
-    if (!(msg.sender == this.owner() || (_isTransmitter(msg.sender) && msg.sender == node))) {
+    if (!(msg.sender == owner() || (_isTransmitter(msg.sender) && msg.sender == node))) {
       revert UnauthorizedPublicKeyChange();
     }
     s_nodePublicKeys[node] = publicKey;
@@ -114,7 +112,7 @@ contract FunctionsCoordinator is OCR2Base, IFunctionsCoordinator, FunctionsBilli
    */
   function deleteNodePublicKey(address node) external override {
     // Owner can delete anything. Others can delete only their own key.
-    if (!(msg.sender == this.owner() || msg.sender == node)) {
+    if (!(msg.sender == owner() || msg.sender == node)) {
       revert UnauthorizedPublicKeyChange();
     }
     delete s_nodePublicKeys[node];
@@ -230,12 +228,5 @@ contract FunctionsCoordinator is OCR2Base, IFunctionsCoordinator, FunctionsBilli
         emit CostExceedsCommitment(requestIds[i]);
       }
     }
-  }
-
-  modifier onlyRouterOwner() override {
-    if (msg.sender != IOwnable(address(s_router)).owner()) {
-      revert OnlyCallableByRouterOwner();
-    }
-    _;
   }
 }

--- a/contracts/src/v0.8/functions/dev/1_0_0/FunctionsSubscriptions.sol
+++ b/contracts/src/v0.8/functions/dev/1_0_0/FunctionsSubscriptions.sol
@@ -5,7 +5,6 @@ import {IFunctionsSubscriptions} from "./interfaces/IFunctionsSubscriptions.sol"
 import {ERC677ReceiverInterface} from "../../../interfaces/ERC677ReceiverInterface.sol";
 import {LinkTokenInterface} from "../../../interfaces/LinkTokenInterface.sol";
 import {IFunctionsBilling} from "./interfaces/IFunctionsBilling.sol";
-import {IFunctionsRouter} from "./interfaces/IFunctionsRouter.sol";
 import {SafeCast} from "../../../shared/vendor/openzeppelin-solidity/v.4.8.0/contracts/utils/SafeCast.sol";
 
 /**
@@ -14,12 +13,6 @@ import {SafeCast} from "../../../shared/vendor/openzeppelin-solidity/v.4.8.0/con
  * @dev THIS CONTRACT HAS NOT GONE THROUGH ANY SECURITY REVIEW. DO NOT USE IN PROD.
  */
 abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677ReceiverInterface {
-  // Reentrancy protection.
-  bool internal s_reentrancyLock;
-  error Reentrant();
-
-  LinkTokenInterface private LINK;
-
   // ================================================================
   // |                      Subscription state                      |
   // ================================================================
@@ -40,7 +33,7 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
   // We need to maintain a list of addresses that can consume a subscription.
   // This bound ensures we are able to loop over them as needed.
   // Should a user require more consumers, they can use multiple subscriptions.
-  uint16 public constant MAX_CONSUMERS = 100;
+  uint16 private constant MAX_CONSUMERS = 100;
   mapping(address => mapping(uint64 => IFunctionsSubscriptions.Consumer)) /* consumer */ /* subscriptionId */ /* Consumer data */
     internal s_consumers;
 
@@ -91,6 +84,15 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
   }
 
   // ================================================================
+  // |                       Other state                          |
+  // ================================================================
+  // Reentrancy protection.
+  bool internal s_reentrancyLock;
+  error Reentrant();
+
+  LinkTokenInterface private LINK;
+
+  // ================================================================
   // |                       Initialization                         |
   // ================================================================
   constructor(address link) {
@@ -100,6 +102,12 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
   // ================================================================
   // |                      Getter methods                          |
   // ================================================================
+  /**
+   * @inheritdoc IFunctionsSubscriptions
+   */
+  function getMaxConsumers() external pure override returns (uint16) {
+    return MAX_CONSUMERS;
+  }
 
   /**
    * @inheritdoc IFunctionsSubscriptions
@@ -113,18 +121,6 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
    */
   function getSubscriptionCount() external view returns (uint64) {
     return s_currentsubscriptionId;
-  }
-
-  function _isValidSubscription(uint64 subscriptionId) internal view {
-    if (s_subscriptions[subscriptionId].owner == address(0)) {
-      revert InvalidSubscription();
-    }
-  }
-
-  function _isValidConsumer(address client, uint64 subscriptionId) internal view {
-    if (s_consumers[client][subscriptionId].allowed == false) {
-      revert InvalidConsumer(subscriptionId, client);
-    }
   }
 
   /**
@@ -153,11 +149,25 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
     address client,
     uint64 subscriptionId
   ) external view returns (bool allowed, uint64 initiatedRequests, uint64 completedRequests) {
-    return (
-      s_consumers[client][subscriptionId].allowed,
-      s_consumers[client][subscriptionId].initiatedRequests,
-      s_consumers[client][subscriptionId].completedRequests
-    );
+    allowed = s_consumers[client][subscriptionId].allowed;
+    initiatedRequests = s_consumers[client][subscriptionId].initiatedRequests;
+    completedRequests = s_consumers[client][subscriptionId].completedRequests;
+  }
+
+  // ================================================================
+  // |                      Internal checks                         |
+  // ================================================================
+
+  function _isValidSubscription(uint64 subscriptionId) internal view {
+    if (s_subscriptions[subscriptionId].owner == address(0)) {
+      revert InvalidSubscription();
+    }
+  }
+
+  function _isValidConsumer(address client, uint64 subscriptionId) internal view {
+    if (!s_consumers[client][subscriptionId].allowed) {
+      revert InvalidConsumer(subscriptionId, client);
+    }
   }
 
   // ================================================================
@@ -176,31 +186,6 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
 
     // Increment sent requests
     s_consumers[client][subscriptionId].initiatedRequests += 1;
-  }
-
-  /**
-   * @notice Ensure that the subscription balance can still afford fulfillment cost
-   */
-  function _checkBalance(
-    uint96 estimatedCost,
-    uint256 gasAfterPaymentCalculation,
-    uint96 adminFee,
-    uint32 callbackGasLimit,
-    uint96 juelsPerGas,
-    uint96 costWithoutFulfillment
-  ) internal view returns (uint8) {
-    // Check that the transmitter has supplied enough gas for the callback to succeed
-    if (gasleft() < callbackGasLimit + gasAfterPaymentCalculation) {
-      return 3; // IFunctionsRouter.FulfillResult.INSUFFICIENT_GAS;
-    }
-
-    // Check that the cost has not exceeded the quoted cost
-    if (adminFee + costWithoutFulfillment + (juelsPerGas * SafeCast.toUint96(callbackGasLimit)) > estimatedCost) {
-      return 4; // IFunctionsRouter.FulfillResult.COST_EXCEEDS_COMMITMENT
-    }
-
-    // If checks pass, continue as default, 0 = USER_SUCCESS;
-    return 0;
   }
 
   /**
@@ -224,10 +209,8 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
     uint96 costWithoutCallbackJuels
   ) internal returns (Receipt memory receipt) {
     uint96 callbackGasCostJuels = juelsPerGas * SafeCast.toUint96(gasUsed);
-    uint96 totalCostJuels;
-    totalCostJuels += costWithoutCallbackJuels;
-    totalCostJuels += adminFee;
-    totalCostJuels += callbackGasCostJuels;
+    uint96 totalCostJuels = costWithoutCallbackJuels + adminFee + callbackGasCostJuels;
+
     receipt = Receipt(callbackGasCostJuels, totalCostJuels);
 
     // Charge the subscription
@@ -256,7 +239,7 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
     if (owner == address(0)) {
       revert InvalidSubscription();
     }
-    cancelSubscriptionHelper(subscriptionId, owner);
+    _cancelSubscriptionHelper(subscriptionId, owner);
   }
 
   /**
@@ -276,7 +259,7 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
     // If the balances are equal, nothing to be done.
   }
 
-  /*
+  /**
    * @notice Owner withdraw LINK earned through admin fees
    * @notice If amount is 0 the full balance will be withdrawn
    * @param recipient where to send the funds
@@ -346,20 +329,18 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
   /**
    * @inheritdoc IFunctionsSubscriptions
    */
-  function createSubscription() external nonReentrant onlyAuthorizedUsers returns (uint64) {
+  function createSubscription() external nonReentrant returns (uint64 subscriptionId) {
     s_currentsubscriptionId++;
-    uint64 currentsubscriptionId = s_currentsubscriptionId;
-    address[] memory consumers = new address[](0);
-    s_subscriptions[currentsubscriptionId] = Subscription({
+    subscriptionId = s_currentsubscriptionId;
+    s_subscriptions[subscriptionId] = Subscription({
       balance: 0,
       blockedBalance: 0,
       owner: msg.sender,
       requestedOwner: address(0),
-      consumers: consumers
+      consumers: new address[](0)
     });
 
-    emit SubscriptionCreated(currentsubscriptionId, msg.sender);
-    return currentsubscriptionId;
+    emit SubscriptionCreated(subscriptionId, msg.sender);
   }
 
   /**
@@ -369,7 +350,8 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
     uint64 subscriptionId,
     address newOwner
   ) external onlySubscriptionOwner(subscriptionId) nonReentrant {
-    // Proposing to address(0) would never be claimable so don't need to check.
+    // Proposing to address(0) would never be claimable, so don't need to check.
+
     if (s_subscriptions[subscriptionId].requestedOwner != newOwner) {
       s_subscriptions[subscriptionId].requestedOwner = newOwner;
       emit SubscriptionOwnerTransferRequested(subscriptionId, msg.sender, newOwner);
@@ -379,17 +361,15 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
   /**
    * @inheritdoc IFunctionsSubscriptions
    */
-  function acceptSubscriptionOwnerTransfer(uint64 subscriptionId) external nonReentrant onlyAuthorizedUsers {
-    if (s_subscriptions[subscriptionId].owner == address(0)) {
-      revert InvalidSubscription();
+  function acceptSubscriptionOwnerTransfer(uint64 subscriptionId) external nonReentrant {
+    address previousOwner = s_subscriptions[subscriptionId].owner;
+    address nextOwner = s_subscriptions[subscriptionId].requestedOwner;
+    if (nextOwner != msg.sender) {
+      revert MustBeRequestedOwner(nextOwner);
     }
-    if (s_subscriptions[subscriptionId].requestedOwner != msg.sender) {
-      revert MustBeRequestedOwner(s_subscriptions[subscriptionId].requestedOwner);
-    }
-    address oldOwner = s_subscriptions[subscriptionId].owner;
     s_subscriptions[subscriptionId].owner = msg.sender;
     s_subscriptions[subscriptionId].requestedOwner = address(0);
-    emit SubscriptionOwnerTransferred(subscriptionId, oldOwner, msg.sender);
+    emit SubscriptionOwnerTransferred(subscriptionId, previousOwner, msg.sender);
   }
 
   /**
@@ -400,7 +380,7 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
     address consumer
   ) external onlySubscriptionOwner(subscriptionId) nonReentrant {
     Consumer memory consumerData = s_consumers[consumer][subscriptionId];
-    if (consumerData.allowed == false) {
+    if (!consumerData.allowed) {
       revert InvalidConsumer(subscriptionId, consumer);
     }
     if (consumerData.initiatedRequests != consumerData.completedRequests) {
@@ -434,7 +414,7 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
     if (s_subscriptions[subscriptionId].consumers.length == MAX_CONSUMERS) {
       revert TooManyConsumers();
     }
-    if (s_consumers[consumer][subscriptionId].allowed == true) {
+    if (s_consumers[consumer][subscriptionId].allowed) {
       // Idempotence - do nothing if already added.
       // Ensures uniqueness in s_subscriptions[subscriptionId].consumers.
       return;
@@ -452,15 +432,15 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
     uint64 subscriptionId,
     address to
   ) external onlySubscriptionOwner(subscriptionId) nonReentrant {
-    if (this.pendingRequestExists(subscriptionId)) {
+    if (_pendingRequestExists(subscriptionId)) {
       revert PendingRequestExists();
     }
-    cancelSubscriptionHelper(subscriptionId, to);
+    _cancelSubscriptionHelper(subscriptionId, to);
   }
 
-  function cancelSubscriptionHelper(uint64 subscriptionId, address to) private nonReentrant {
+  function _cancelSubscriptionHelper(uint64 subscriptionId, address to) private nonReentrant {
     Subscription memory sub = s_subscriptions[subscriptionId];
-    uint96 balance = s_subscriptions[subscriptionId].balance;
+    uint96 balance = sub.balance;
     // Note bounded by MAX_CONSUMERS;
     // If no consumers, does nothing.
     for (uint256 i = 0; i < sub.consumers.length; i++) {
@@ -478,6 +458,10 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
    * @inheritdoc IFunctionsSubscriptions
    */
   function pendingRequestExists(uint64 subscriptionId) external view returns (bool) {
+    return _pendingRequestExists(subscriptionId);
+  }
+
+  function _pendingRequestExists(uint64 subscriptionId) internal view returns (bool) {
     address[] memory consumers = s_subscriptions[subscriptionId].consumers;
     for (uint256 i = 0; i < consumers.length; i++) {
       Consumer memory consumer = s_consumers[consumers[i]][subscriptionId];
@@ -498,9 +482,11 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
     for (uint256 i = 0; i < requestIdsToTimeout.length; i++) {
       bytes32 requestId = requestIdsToTimeout[i];
       Commitment memory request = s_requestCommitments[requestId];
+      uint64 subscriptionId = request.subscriptionId;
 
       // Check that the message sender is the subscription owner
-      (, , address owner, , ) = this.getSubscription(request.subscriptionId);
+      _isValidSubscription(subscriptionId);
+      address owner = s_subscriptions[subscriptionId].owner;
       if (msg.sender != owner) {
         revert MustBeSubOwner(owner);
       }
@@ -514,8 +500,8 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
 
       if (coordinator.deleteCommitment(requestId)) {
         // Release blocked balance
-        s_subscriptions[request.subscriptionId].blockedBalance -= request.estimatedCost;
-        s_consumers[request.client][request.subscriptionId].completedRequests += 1;
+        s_subscriptions[subscriptionId].blockedBalance -= request.estimatedCost;
+        s_consumers[request.client][subscriptionId].completedRequests += 1;
         // Delete commitment
         delete s_requestCommitments[requestId];
       }
@@ -540,14 +526,6 @@ abstract contract FunctionsSubscriptions is IFunctionsSubscriptions, ERC677Recei
     if (s_reentrancyLock) {
       revert Reentrant();
     }
-    _;
-  }
-
-  /**
-   * @dev The allow list is kept on the Router contract. This modifier checks if a user is authorized from there.
-   */
-  modifier onlyAuthorizedUsers() {
-    // TODO: TOS allow list
     _;
   }
 

--- a/contracts/src/v0.8/functions/dev/1_0_0/Routable.sol
+++ b/contracts/src/v0.8/functions/dev/1_0_0/Routable.sol
@@ -62,7 +62,7 @@ abstract contract Routable is ITypeAndVersion, IConfigurable {
   /**
    * @notice Reverts if called by anyone other than the router owner.
    */
-  modifier onlyRouterOwner() virtual {
+  modifier onlyRouterOwner() {
     if (msg.sender != IOwnable(address(s_router)).owner()) {
       revert OnlyCallableByRouterOwner();
     }

--- a/contracts/src/v0.8/functions/dev/1_0_0/interfaces/IFunctionsSubscriptions.sol
+++ b/contracts/src/v0.8/functions/dev/1_0_0/interfaces/IFunctionsSubscriptions.sol
@@ -57,6 +57,12 @@ interface IFunctionsSubscriptions {
   ) external view returns (bool allowed, uint64 initiatedRequests, uint64 completedRequests);
 
   /**
+   * @notice Get the maximum number of consumers that can be added to one subscription
+   * @return maxConsumers - maximum number of consumers that can be added to one subscription
+   */
+  function getMaxConsumers() external view returns (uint16);
+
+  /**
    * @notice Get details about the total amount of LINK within the system
    * @return totalBalance - total Juels of LINK held by the contract
    */

--- a/contracts/src/v0.8/functions/dev/1_0_0/interfaces/IRouterBase.sol
+++ b/contracts/src/v0.8/functions/dev/1_0_0/interfaces/IRouterBase.sol
@@ -30,22 +30,17 @@ interface IRouterBase {
 
   /**
    * @notice Return the latest proprosal set
-   * @return proposedAtBlock The block number that the proposal was created at
+   * @return timelockEndBlock The block number that the proposal is able to be merged at
    * @return ids The identifiers of the contracts to update
-   * @return from The addresses of the contracts that will be updated from
    * @return to The addresses of the contracts that will be updated to
    */
-  function getProposedContractSet() external view returns (uint, bytes32[] memory, address[] memory, address[] memory);
+  function getProposedContractSet() external view returns (uint, bytes32[] memory, address[] memory);
 
   /**
    * @notice Proposes one or more updates to the contract routes
    * @dev Only callable by owner
    */
-  function proposeContractsUpdate(
-    bytes32[] memory proposalSetIds,
-    address[] memory proposalSetFromAddresses,
-    address[] memory proposalSetToAddresses
-  ) external;
+  function proposeContractsUpdate(bytes32[] memory proposalSetIds, address[] memory proposalSetAddresses) external;
 
   /**
    * @notice Tests a proposal for the ability to make a successful upgrade

--- a/contracts/test/v0.8/functions/v1/FunctionsSubscriptions.test.ts
+++ b/contracts/test/v0.8/functions/v1/FunctionsSubscriptions.test.ts
@@ -102,11 +102,12 @@ describe('Functions Router - Subscriptions', () => {
         )
       })
       it('subscription must exist', async function () {
+        // 0x0 is requested owner
         await expect(
           contracts.router
             .connect(roles.subOwner)
             .acceptSubscriptionOwnerTransfer(1203123123),
-        ).to.be.revertedWith(`InvalidSubscription`)
+        ).to.be.revertedWith(`MustBeRequestedOwner`)
       })
       it('must be requested owner to accept', async function () {
         await expect(

--- a/contracts/test/v0.8/functions/v1/RouterBase.test.ts
+++ b/contracts/test/v0.8/functions/v1/RouterBase.test.ts
@@ -28,15 +28,7 @@ describe('FunctionsRouter - Base', () => {
       await expect(
         contracts.router
           .connect(roles.stranger)
-          .proposeContractsUpdate(
-            [ids.donId],
-            [
-              ethers.constants.AddressZero,
-              ethers.constants.AddressZero,
-              ethers.constants.AddressZero,
-            ],
-            [contracts.coordinator.address],
-          ),
+          .proposeContractsUpdate([ids.donId], [contracts.coordinator.address]),
       ).to.be.revertedWith('Only callable by owner')
     })
 
@@ -236,11 +228,6 @@ describe('FunctionsRouter - Base', () => {
       await expect(
         contracts.router.proposeContractsUpdate(
           [ids.donId2, ids.donId3, ids.donId4],
-          [
-            ethers.constants.AddressZero,
-            ethers.constants.AddressZero,
-            ethers.constants.AddressZero,
-          ],
           [coordinator2.address, coordinator3.address, coordinator4.address],
         ),
       ).to.emit(contracts.router, `ContractProposed`)
@@ -294,11 +281,7 @@ describe('FunctionsRouter - Base', () => {
       await expect(
         contracts.router
           .connect(roles.stranger)
-          .proposeContractsUpdate(
-            [ids.donId],
-            [ethers.constants.AddressZero],
-            [contracts.coordinator.address],
-          ),
+          .proposeContractsUpdate([ids.donId], [contracts.coordinator.address]),
       ).to.be.revertedWith('Only callable by owner')
     })
 
@@ -361,7 +344,6 @@ describe('FunctionsRouter - Base', () => {
 
       await contracts.router.proposeContractsUpdate(
         [ids.donId2],
-        [ethers.constants.AddressZero],
         [coordinator2.address],
       )
 

--- a/contracts/test/v0.8/functions/v1/utils.ts
+++ b/contracts/test/v0.8/functions/v1/utils.ts
@@ -222,11 +222,7 @@ export function getSetupFactory(): () => {
       BigNumber.from('1000000000000000000'), // 1 LINK
     )
 
-    await router.proposeContractsUpdate(
-      [ids.donId],
-      [ethers.constants.AddressZero],
-      [coordinator.address],
-    )
+    await router.proposeContractsUpdate([ids.donId], [coordinator.address])
     await router.updateContracts()
 
     contracts = {


### PR DESCRIPTION
### Description
In preparation of re-adding access control, this PR reduces contract sizes, specifically focused on the Router

### Changes
Despite the many lines changed, the only logic that has changed is:
- proposal sets no longer contain "from" addresses. The updated event still contains to and from references