### PR TITLE
error on zero transmitters, don't disperse fees if no transmitters

### DIFF
--- a/contracts/src/v0.8/functions/dev/1_0_0/FunctionsBilling.sol
+++ b/contracts/src/v0.8/functions/dev/1_0_0/FunctionsBilling.sol
@@ -79,6 +79,7 @@ abstract contract FunctionsBilling is Routable, IFunctionsBilling {
   error GasLimitTooBig(uint32 have, uint32 want);
   error InvalidLinkWeiPrice(int256 linkWei);
   error PaymentTooLarge();
+  error NoTransmittersSet();
 
   // ================================================================
   // |                        Balance state                         |
@@ -449,6 +450,9 @@ abstract contract FunctionsBilling is Routable, IFunctionsBilling {
     // Pay out the DON fee to all transmitters
     // Bounded by "maxNumOracles" on OCR2Abstract.sol
     address[] memory transmitters = _getTransmitters();
+    if (transmitters.length == 0) {
+      revert NoTransmittersSet();
+    }
     uint96 feePoolShare = s_feePool / uint96(transmitters.length);
     for (uint8 i = 0; i < transmitters.length; i++) {
       s_withdrawableTokens[transmitters[i]] += feePoolShare;

--- a/contracts/src/v0.8/functions/dev/1_0_0/FunctionsCoordinator.sol
+++ b/contracts/src/v0.8/functions/dev/1_0_0/FunctionsCoordinator.sol
@@ -172,7 +172,9 @@ contract FunctionsCoordinator is OCR2Base, IFunctionsCoordinator, FunctionsBilli
   }
 
   function _beforeSetConfig(uint8 /* _f */, bytes memory /* _onchainConfig */) internal override {
-    _disperseFeePool();
+    if (_getTransmitters().length > 0) {
+      _disperseFeePool();
+    }
   }
 
   function _afterSetConfig(uint8 /* _f */, bytes memory /* _onchainConfig */) internal override {}


### PR DESCRIPTION
We see this issue when trying to set the OCR configuration for the first time. There are no transmitters on the contract, but we try to disperse the fee pool. In this scenario, execution reverts due to a divide by 0.

This is a copy of a previous PR here: https://github.com/smartcontractkit/chainlink/pull/9843#event-9867741940
That one had git history messed up