### PR TITLE
Base & Optimism hotfix

### DIFF
--- a/core/services/ocr/contract_tracker.go
+++ b/core/services/ocr/contract_tracker.go
@@ -388,7 +388,7 @@ func (t *OCRContractTracker) ConfigFromLogs(ctx context.Context, changedInBlock 
 // LatestBlockHeight queries the eth node for the most recent header
 func (t *OCRContractTracker) LatestBlockHeight(ctx context.Context) (blockheight uint64, err error) {
 	switch t.cfg.ChainType() {
-	case config.ChainMetis, config.ChainOptimismBedrock:
+	case config.ChainMetis:
 		// We skip confirmation checking anyway on these L2s so there's no need to
 		// care about the block height; we have no way of getting the L1 block
 		// height anyway

--- a/core/services/ocr/contract_tracker_test.go
+++ b/core/services/ocr/contract_tracker_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	configtest "github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest/v2"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest"
-	v2 "github.com/smartcontractkit/chainlink/v2/core/internal/testutils/evmtest/v2"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr"
@@ -106,14 +105,6 @@ func newContractTrackerUni(t *testing.T, opts ...interface{}) (uni contractTrack
 
 func Test_OCRContractTracker_LatestBlockHeight(t *testing.T) {
 	t.Parallel()
-
-	t.Run("on L2 chains, always returns 0", func(t *testing.T) {
-		uni := newContractTrackerUni(t, v2.ChainOptimismMainnet(t))
-		l, err := uni.tracker.LatestBlockHeight(testutils.Context(t))
-		require.NoError(t, err)
-
-		assert.Equal(t, uint64(0), l)
-	})
 
 	t.Run("before first head incoming, looks up on-chain", func(t *testing.T) {
 		uni := newContractTrackerUni(t)


### PR DESCRIPTION
* Base(Mainnet) + Optimism hotfix

* Revert "Base(Mainnet) + Optimism hotfix"

This reverts commit a13e848.

* Base+ optimism hotfix for non-successfull ocr rounds

* fix tests

(cherry picked from commit 38e9e4a)