### PR TITLE
core/services/ocr2/validate: override OCR2 MaxDurationQuery for Solana LOOPPs

### DIFF
--- a/core/config/env/env.go
+++ b/core/config/env/env.go
@@ -25,6 +25,8 @@ var (
 	// EnvLooopHostName is the hostname used for HTTP communication between the
 	// node and LOOPps. In most cases this does not need to be set explicitly.
 	LOOPPHostName = Var("CL_LOOPP_HOSTNAME")
+	// Work around for Solana LOOPPs configured with zero values.
+	MinOCR2MaxDurationQuery = Var("CL_MIN_OCR2_MAX_DURATION_QUERY")
 
 	DatabaseAllowSimplePasswords = Var("CL_DATABASE_ALLOW_SIMPLE_PASSWORDS")
 	DatabaseURL                  = Secret("CL_DATABASE_URL")

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -361,7 +361,10 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 		lggr.ErrorIf(d.jobORM.RecordError(jb.ID, msg), "unable to record error")
 	})
 
-	lc := validate.ToLocalConfig(d.cfg.OCR2(), d.cfg.Insecure(), *spec)
+	lc, err := validate.ToLocalConfig(d.cfg.OCR2(), d.cfg.Insecure(), *spec)
+	if err != nil {
+		return nil, err
+	}
 	if err := libocr2.SanityCheckLocalConfig(lc); err != nil {
 		return nil, err
 	}

--- a/core/services/ocr2/validate/config.go
+++ b/core/services/ocr2/validate/config.go
@@ -1,11 +1,15 @@
 package validate
 
 import (
+	"fmt"
+	"sync"
 	"time"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink/v2/core/config/env"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
+	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 )
 
 // OCR2Config contains OCR2 configurations for a job.
@@ -23,7 +27,7 @@ type InsecureConfig interface {
 }
 
 // ToLocalConfig creates a OCR2 LocalConfig from the global config and the OCR2 spec.
-func ToLocalConfig(ocr2Config OCR2Config, insConf InsecureConfig, spec job.OCR2OracleSpec) types.LocalConfig {
+func ToLocalConfig(ocr2Config OCR2Config, insConf InsecureConfig, spec job.OCR2OracleSpec) (types.LocalConfig, error) {
 	var (
 		blockchainTimeout     = time.Duration(spec.BlockchainTimeout)
 		ccConfirmations       = spec.ContractConfigConfirmations
@@ -45,10 +49,36 @@ func ToLocalConfig(ocr2Config OCR2Config, insConf InsecureConfig, spec job.OCR2O
 		ContractTransmitterTransmitTimeout: ocr2Config.ContractTransmitterTransmitTimeout(),
 		DatabaseTimeout:                    ocr2Config.DatabaseTimeout(),
 	}
+	if spec.Relay == relay.Solana && env.SolanaPluginCmd.Get() != "" {
+		// Work around for Solana LOOPPs configured with zero values.
+		minOCR2MaxDurationQuery, err := getMinOCR2MaxDurationQuery()
+		if err != nil {
+			return types.LocalConfig{}, err
+		}
+		lc.MinOCR2MaxDurationQuery = minOCR2MaxDurationQuery
+	}
 	if insConf.OCRDevelopmentMode() {
 		// Skips config validation so we can use any config parameters we want.
 		// For example to lower contractConfigTrackerPollInterval to speed up tests.
 		lc.DevelopmentMode = types.EnableDangerousDevelopmentMode
 	}
-	return lc
+	return lc, nil
+}
+
+var (
+	minOCR2MaxDurationQuery     = 20 * time.Millisecond
+	minOCR2MaxDurationQueryErr  error
+	minOCR2MaxDurationQueryOnce sync.Once
+)
+
+func getMinOCR2MaxDurationQuery() (time.Duration, error) {
+	minOCR2MaxDurationQueryOnce.Do(func() {
+		if v := env.MinOCR2MaxDurationQuery.Get(); v != "" {
+			minOCR2MaxDurationQuery, minOCR2MaxDurationQueryErr = time.ParseDuration(v)
+			if minOCR2MaxDurationQueryErr != nil {
+				minOCR2MaxDurationQueryErr = fmt.Errorf("failed to parse %s: %w", env.MinOCR2MaxDurationQuery, minOCR2MaxDurationQueryErr)
+			}
+		}
+	})
+	return minOCR2MaxDurationQuery, minOCR2MaxDurationQueryErr
 }

--- a/core/services/ocr2/validate/validate.go
+++ b/core/services/ocr2/validate/validate.go
@@ -9,6 +9,7 @@ import (
 	"github.com/lib/pq"
 	"github.com/pelletier/go-toml"
 	pkgerrors "github.com/pkg/errors"
+
 	libocr2 "github.com/smartcontractkit/libocr/offchainreporting2plus"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
@@ -83,7 +84,10 @@ var (
 )
 
 func validateTimingParameters(ocr2Conf OCR2Config, insConf InsecureConfig, spec job.OCR2OracleSpec) error {
-	lc := ToLocalConfig(ocr2Conf, insConf, spec)
+	lc, err := ToLocalConfig(ocr2Conf, insConf, spec)
+	if err != nil {
+		return err
+	}
 	return libocr2.SanityCheckLocalConfig(lc)
 }
 

--- a/core/services/ocrbootstrap/delegate.go
+++ b/core/services/ocrbootstrap/delegate.go
@@ -99,7 +99,10 @@ func (d *Delegate) ServicesForSpec(jobSpec job.Job) (services []job.ServiceCtx, 
 	if err != nil {
 		return nil, errors.Wrap(err, "error calling 'relayer.NewConfigWatcher'")
 	}
-	lc := validate.ToLocalConfig(d.ocr2Cfg, d.insecureCfg, spec.AsOCR2Spec())
+	lc, err := validate.ToLocalConfig(d.ocr2Cfg, d.insecureCfg, spec.AsOCR2Spec())
+	if err != nil {
+		return nil, err
+	}
 	if err = ocr.SanityCheckLocalConfig(lc); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When running the Solana relayer in LOOP Plugin mode, set `MinOCR2MaxQueryDuration` to `CL_MIN_OCR2_MAX_DURATION_QUERY` (or default to `20ms`). 