### PR TITLE
core/services/ocr2/validate: fix Solana max duration query workaround

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -24,7 +24,8 @@
 /core/services/health @samsondav
 /core/services/job @connorwstein
 /core/services/keystore @RyanRHall
-/core/services/offchainreporting @connorwstein @samsondav
+/core/services/ocr* @connorwstein @samsondav
+/core/services/ocr2 @jmank88 @krehermann
 /core/services/periodicbackup @PiotrTrzpil @samsondav
 /core/services/pg @samsondav
 /core/services/pipeline @connorwstein @prashantkumar1982

--- a/core/services/ocr2/validate/config.go
+++ b/core/services/ocr2/validate/config.go
@@ -49,8 +49,8 @@ func ToLocalConfig(ocr2Config OCR2Config, insConf InsecureConfig, spec job.OCR2O
 		ContractTransmitterTransmitTimeout: ocr2Config.ContractTransmitterTransmitTimeout(),
 		DatabaseTimeout:                    ocr2Config.DatabaseTimeout(),
 	}
-	if spec.Relay == relay.Solana && env.SolanaPluginCmd.Get() != "" {
-		// Work around for Solana LOOPPs configured with zero values.
+	if spec.Relay == relay.Solana && env.MedianPluginCmd.Get() != "" {
+		// Work around for Solana Feeds configured with zero values to support LOOP Plugins.
 		minOCR2MaxDurationQuery, err := getMinOCR2MaxDurationQuery()
 		if err != nil {
 			return types.LocalConfig{}, err


### PR DESCRIPTION
Fixing the workaround introduced in #9893, which incorrectly checked if the _relayer_ LOOPP was active rather than the _median_ LOOPP.

Also noticed this had no code owner, and the old `/offchainreporting` reference was stale.