### PR TITLE
[Functions] Support flags in Listener

### DIFF
--- a/core/services/functions/external_adapter_client.go
+++ b/core/services/functions/external_adapter_client.go
@@ -33,6 +33,7 @@ type ExternalAdapterClient interface {
 		jobName string,
 		subscriptionOwner string,
 		subscriptionId uint64,
+		flags RequestFlags,
 		nodeProvidedSecrets string,
 		requestData *RequestData,
 	) (userResult, userError []byte, domains []string, err error)
@@ -66,6 +67,7 @@ type requestPayload struct {
 	JobName             string       `json:"jobName"`
 	SubscriptionOwner   string       `json:"subscriptionOwner"`
 	SubscriptionId      uint64       `json:"subscriptionId"`
+	Flags               RequestFlags `json:"flags"` // marshalled as an array of numbers
 	NodeProvidedSecrets string       `json:"nodeProvidedSecrets"`
 	Data                *RequestData `json:"data"`
 }
@@ -123,6 +125,7 @@ func (ea *externalAdapterClient) RunComputation(
 	jobName string,
 	subscriptionOwner string,
 	subscriptionId uint64,
+	flags RequestFlags,
 	nodeProvidedSecrets string,
 	requestData *RequestData,
 ) (userResult, userError []byte, domains []string, err error) {
@@ -133,6 +136,7 @@ func (ea *externalAdapterClient) RunComputation(
 		JobName:             jobName,
 		SubscriptionOwner:   subscriptionOwner,
 		SubscriptionId:      subscriptionId,
+		Flags:               flags,
 		NodeProvidedSecrets: nodeProvidedSecrets,
 		Data:                requestData,
 	}

--- a/core/services/functions/external_adapter_client_test.go
+++ b/core/services/functions/external_adapter_client_test.go
@@ -51,7 +51,7 @@ func runRequestTest(t *testing.T, adapterJSONResponse, expectedUserResult, expec
 	assert.NoError(t, err, "Unexpected error")
 
 	ea := functions.NewExternalAdapterClient(*adapterUrl, 100_000)
-	userResult, userError, domains, err := ea.RunComputation(testutils.Context(t), "requestID1234", "TestJob", "SubOwner", 1, "", &functions.RequestData{})
+	userResult, userError, domains, err := ea.RunComputation(testutils.Context(t), "requestID1234", "TestJob", "SubOwner", 1, functions.RequestFlags{}, "", &functions.RequestData{})
 
 	if expectedError != nil {
 		assert.Equal(t, expectedError.Error(), err.Error(), "Unexpected error")
@@ -167,7 +167,7 @@ func TestRunComputation_CorrectAdapterRequest(t *testing.T) {
 		body, err := io.ReadAll(r.Body)
 		assert.NoError(t, err)
 		expectedData := `{"source":"abcd","language":7,"codeLocation":42,"secrets":"qrvM","secretsLocation":88,"args":["arg1","arg2"]}`
-		expectedBody := fmt.Sprintf(`{"endpoint":"lambda","requestId":"requestID1234","jobName":"TestJob","subscriptionOwner":"SubOwner","subscriptionId":1,"nodeProvidedSecrets":"secRETS","data":%s}`, expectedData)
+		expectedBody := fmt.Sprintf(`{"endpoint":"lambda","requestId":"requestID1234","jobName":"TestJob","subscriptionOwner":"SubOwner","subscriptionId":1,"flags":[0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0],"nodeProvidedSecrets":"secRETS","data":%s}`, expectedData)
 		assert.Equal(t, expectedBody, string(body))
 
 		fmt.Fprintln(w, "}}invalidJSON")
@@ -186,7 +186,7 @@ func TestRunComputation_CorrectAdapterRequest(t *testing.T) {
 		SecretsLocation: 88,
 		Args:            []string{"arg1", "arg2"},
 	}
-	_, _, _, err = ea.RunComputation(testutils.Context(t), "requestID1234", "TestJob", "SubOwner", 1, "secRETS", reqData)
+	_, _, _, err = ea.RunComputation(testutils.Context(t), "requestID1234", "TestJob", "SubOwner", 1, functions.RequestFlags{}, "secRETS", reqData)
 	assert.Error(t, err)
 }
 
@@ -200,7 +200,7 @@ func TestRunComputation_HTTP500(t *testing.T) {
 	assert.NoError(t, err)
 
 	ea := functions.NewExternalAdapterClient(*adapterUrl, 100_000)
-	_, _, _, err = ea.RunComputation(testutils.Context(t), "requestID1234", "TestJob", "SubOwner", 1, "secRETS", &functions.RequestData{})
+	_, _, _, err = ea.RunComputation(testutils.Context(t), "requestID1234", "TestJob", "SubOwner", 1, functions.RequestFlags{}, "secRETS", &functions.RequestData{})
 	assert.Error(t, err)
 }
 
@@ -217,7 +217,7 @@ func TestRunComputation_ContextRespected(t *testing.T) {
 	ea := functions.NewExternalAdapterClient(*adapterUrl, 100_000)
 	ctx, cancel := context.WithTimeout(testutils.Context(t), 10*time.Millisecond)
 	defer cancel()
-	_, _, _, err = ea.RunComputation(ctx, "requestID1234", "TestJob", "SubOwner", 1, "secRETS", &functions.RequestData{})
+	_, _, _, err = ea.RunComputation(ctx, "requestID1234", "TestJob", "SubOwner", 1, functions.RequestFlags{}, "secRETS", &functions.RequestData{})
 	assert.Error(t, err)
 	close(done)
 }

--- a/core/services/functions/listener.go
+++ b/core/services/functions/listener.go
@@ -3,6 +3,7 @@ package functions
 import (
 	"context"
 	"fmt"
+	"math"
 	"reflect"
 	"sync"
 	"time"
@@ -15,6 +16,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/cbor"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/log"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/functions/generated/functions_coordinator"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/functions/generated/ocr2dr_oracle"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
@@ -111,6 +113,9 @@ const (
 	DefaultPruneMaxStoredRequests uint32 = 20_000
 	DefaultPruneCheckFrequencySec uint32 = 60 * 10
 	DefaultPruneBatchSize         uint32 = 500
+
+	FlagCBORMaxSize    uint32 = 1
+	FlagSecretsMaxSize uint32 = 2
 )
 
 type FunctionsListener struct {
@@ -274,7 +279,7 @@ func (l *FunctionsListener) processOracleEvents() {
 				case *ocr2dr_oracle.OCR2DROracleOracleRequest:
 					promOracleEvent.WithLabelValues(log.Raw.Address.Hex(), "OracleRequest").Inc()
 					l.shutdownWaitGroup.Add(1)
-					go l.handleOracleRequest(log, lb)
+					go l.handleOracleRequestV0(log, lb)
 				case *ocr2dr_oracle.OCR2DROracleOracleResponse:
 					promOracleEvent.WithLabelValues(log.Raw.Address.Hex(), "OracleResponse").Inc()
 					l.shutdownWaitGroup.Add(1)
@@ -317,13 +322,64 @@ func (l *FunctionsListener) setError(ctx context.Context, requestId RequestID, e
 	}
 }
 
-func (l *FunctionsListener) handleOracleRequest(request *ocr2dr_oracle.OCR2DROracleOracleRequest, lb log.Broadcast) {
+func (l *FunctionsListener) getMaxCBORsize(flags RequestFlags) uint32 {
+	idx := flags[FlagCBORMaxSize]
+	if int(idx) >= len(l.pluginConfig.MaxRequestSizesList) {
+		return l.pluginConfig.MaxRequestSizeBytes // deprecated
+	}
+	return l.pluginConfig.MaxRequestSizesList[idx]
+}
+
+func (l *FunctionsListener) getMaxSecretsSize(flags RequestFlags) uint32 {
+	idx := flags[FlagSecretsMaxSize]
+	if int(idx) >= len(l.pluginConfig.MaxSecretsSizesList) {
+		return math.MaxUint32 // not enforced if not configured
+	}
+	return l.pluginConfig.MaxSecretsSizesList[idx]
+}
+
+// TODO (FUN-662): call from LogPoller in a separate goroutine
+func (l *FunctionsListener) HandleOracleRequestV1(request *functions_coordinator.FunctionsCoordinatorOracleRequest, coordinatorContractAddress *common.Address, lb log.Broadcast) {
+	l.logger.Infow("oracle request v1 received", "requestID", formatRequestId(request.RequestId))
+	ctx, cancel := l.getNewHandlerContext()
+	defer cancel()
+
+	callbackGasLimit := uint32(request.CallbackGasLimit)
+	newReq := &Request{
+		RequestID:                  request.RequestId,
+		RequestTxHash:              &request.Raw.TxHash,
+		ReceivedAt:                 time.Now(),
+		Flags:                      request.Flags[:],
+		CallbackGasLimit:           &callbackGasLimit,
+		CoordinatorContractAddress: coordinatorContractAddress,
+	}
+	if err := l.pluginORM.CreateRequest(newReq, pg.WithParentCtx(ctx)); err != nil {
+		if errors.Is(err, ErrDuplicateRequestID) {
+			l.logger.Warnw("received a log with duplicate request ID", "requestID", formatRequestId(request.RequestId), "err", err)
+			l.markLogConsumed(lb, pg.WithParentCtx(ctx))
+		} else {
+			l.logger.Errorw("failed to create a DB entry for new request", "requestID", formatRequestId(request.RequestId), "err", err)
+		}
+		return
+	}
+	l.markLogConsumed(lb, pg.WithParentCtx(ctx))
+
+	promRequestDataSize.WithLabelValues(l.oracleHexAddr).Observe(float64(len(request.Data)))
+	requestData, err := l.parseCBOR(request.RequestId, request.Data, l.getMaxCBORsize(request.Flags))
+	if err != nil {
+		l.setError(ctx, request.RequestId, USER_ERROR, []byte(err.Error()))
+		return
+	}
+	l.handleRequest(ctx, request.RequestId, request.SubscriptionId, request.SubscriptionOwner, request.Flags, requestData)
+}
+
+// deprecated
+func (l *FunctionsListener) handleOracleRequestV0(request *ocr2dr_oracle.OCR2DROracleOracleRequest, lb log.Broadcast) {
 	defer l.shutdownWaitGroup.Done()
 	ctx, cancel := l.getNewHandlerContext()
 	defer cancel()
 	l.logger.Infow("oracle request received", "requestID", formatRequestId(request.RequestId))
 
-	// TODO(FUN-617) extract and set new fields (Flags, AggregationMethod, CallbackGasLimit, CoordinatorContractAddress, OnchainMetadata)
 	newReq := &Request{RequestID: request.RequestId, RequestTxHash: &request.Raw.TxHash, ReceivedAt: time.Now()}
 	if err := l.pluginORM.CreateRequest(newReq, pg.WithParentCtx(ctx)); err != nil {
 		if errors.Is(err, ErrDuplicateRequestID) {
@@ -337,24 +393,30 @@ func (l *FunctionsListener) handleOracleRequest(request *ocr2dr_oracle.OCR2DROra
 	l.markLogConsumed(lb, pg.WithParentCtx(ctx))
 
 	promRequestDataSize.WithLabelValues(l.oracleHexAddr).Observe(float64(len(request.Data)))
-
-	if l.pluginConfig.MaxRequestSizeBytes > 0 && uint32(len(request.Data)) > l.pluginConfig.MaxRequestSizeBytes {
-		l.logger.Errorw("request too big", "requestID", formatRequestId(request.RequestId), "requestSize", len(request.Data), "maxRequestSize", l.pluginConfig.MaxRequestSizeBytes)
-		l.setError(ctx, request.RequestId, USER_ERROR, []byte(fmt.Sprintf("request too big (max %d bytes)", l.pluginConfig.MaxRequestSizeBytes)))
+	requestData, err := l.parseCBOR(request.RequestId, request.Data, l.pluginConfig.MaxRequestSizeBytes)
+	if err != nil {
+		l.setError(ctx, request.RequestId, USER_ERROR, []byte(err.Error()))
 		return
+	}
+	l.handleRequest(ctx, request.RequestId, request.SubscriptionId, request.SubscriptionOwner, [32]byte{}, requestData)
+}
+
+func (l *FunctionsListener) parseCBOR(requestId RequestID, cborData []byte, maxSizeBytes uint32) (*RequestData, error) {
+	if maxSizeBytes > 0 && uint32(len(cborData)) > maxSizeBytes {
+		l.logger.Errorw("request too big", "requestID", formatRequestId(requestId), "requestSize", len(cborData), "maxRequestSize", maxSizeBytes)
+		return nil, fmt.Errorf("request too big (max %d bytes)", maxSizeBytes)
 	}
 
 	var requestData RequestData
-	if err := cbor.ParseDietCBORToStruct(request.Data, &requestData); err != nil {
-		l.logger.Errorw("failed to parse CBOR", "requestID", formatRequestId(request.RequestId), "err", err)
-		l.setError(ctx, request.RequestId, USER_ERROR, []byte("CBOR parsing error"))
-		return
+	if err := cbor.ParseDietCBORToStruct(cborData, &requestData); err != nil {
+		l.logger.Errorw("failed to parse CBOR", "requestID", formatRequestId(requestId), "err", err)
+		return nil, errors.New("CBOR parsing error")
 	}
 
-	l.handleRequest(ctx, request.RequestId, request.SubscriptionId, request.SubscriptionOwner, &requestData)
+	return &requestData, nil
 }
 
-func (l *FunctionsListener) handleRequest(ctx context.Context, requestID [32]byte, subscriptionId uint64, subscriptionOwner common.Address, requestData *RequestData) {
+func (l *FunctionsListener) handleRequest(ctx context.Context, requestID RequestID, subscriptionId uint64, subscriptionOwner common.Address, flags RequestFlags, requestData *RequestData) {
 	startTime := time.Now()
 	defer func() {
 		duration := time.Since(startTime)
@@ -383,7 +445,14 @@ func (l *FunctionsListener) handleRequest(ctx context.Context, requestID [32]byt
 		return
 	}
 
-	computationResult, computationError, domains, err := eaClient.RunComputation(ctx, requestIDStr, l.job.Name.ValueOrZero(), subscriptionOwner.Hex(), subscriptionId, nodeProvidedSecrets, requestData)
+	maxSecretsSize := l.getMaxSecretsSize(flags)
+	if uint32(len(nodeProvidedSecrets)) > maxSecretsSize {
+		l.logger.Errorw("secrets size too big", "requestID", requestIDStr, "secretsSize", len(nodeProvidedSecrets), "maxSecretsSize", maxSecretsSize)
+		l.setError(ctx, requestID, USER_ERROR, []byte("secrets size too big"))
+		return
+	}
+
+	computationResult, computationError, domains, err := eaClient.RunComputation(ctx, requestIDStr, l.job.Name.ValueOrZero(), subscriptionOwner.Hex(), subscriptionId, flags, nodeProvidedSecrets, requestData)
 
 	if err != nil {
 		l.logger.Errorw("internal adapter error", "requestID", requestIDStr, "err", err)

--- a/core/services/functions/listener_test.go
+++ b/core/services/functions/listener_test.go
@@ -17,6 +17,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	log_mocks "github.com/smartcontractkit/chainlink/v2/core/chains/evm/log/mocks"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/functions/generated/functions_coordinator"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/functions/generated/ocr2dr_oracle"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
@@ -66,7 +67,7 @@ var (
 	DecryptedSecrets     []byte                      = []byte(`{"0x0":"lhcK"}`)
 )
 
-func NewFunctionsListenerUniverse(t *testing.T, timeoutSec int, pruneFrequencySec int) *FunctionsListenerUniverse {
+func NewFunctionsListenerUniverse(t *testing.T, timeoutSec int, pruneFrequencySec int, setTiers bool) *FunctionsListenerUniverse {
 	cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.EVM[0].MinIncomingConfirmations = ptr[uint32](1)
 	})
@@ -91,6 +92,10 @@ func NewFunctionsListenerUniverse(t *testing.T, timeoutSec int, pruneFrequencySe
 		"decryptionQueueConfig": map[string]interface{}{
 			"decryptRequestTimeoutSec": 100,
 		},
+	}
+	if setTiers {
+		jsonConfig["maxRequestSizesList"] = []uint32{10, 100, 1_000}
+		jsonConfig["maxSecretsSizesList"] = []uint32{10, 100, 200}
 	}
 	jb := job.Job{
 		Type:          job.OffchainReporting2,
@@ -131,7 +136,7 @@ func NewFunctionsListenerUniverse(t *testing.T, timeoutSec int, pruneFrequencySe
 }
 
 func PrepareAndStartFunctionsListener(t *testing.T, cbor []byte) (*FunctionsListenerUniverse, *log_mocks.Broadcast, chan struct{}) {
-	uni := NewFunctionsListenerUniverse(t, 0, 1_000_000)
+	uni := NewFunctionsListenerUniverse(t, 0, 1_000_000, false)
 	uni.logBroadcaster.On("Register", mock.Anything, mock.Anything).Return(func() {})
 
 	err := uni.service.Start(testutils.Context(t))
@@ -161,7 +166,7 @@ func TestFunctionsListener_HandleOracleRequestSuccess(t *testing.T) {
 	uni.pluginORM.On("CreateRequest", mock.Anything, mock.Anything).Return(nil)
 	uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
 	uni.bridgeAccessor.On("NewExternalAdapterClient").Return(uni.eaClient, nil)
-	uni.eaClient.On("RunComputation", mock.Anything, RequestIDStr, mock.Anything, SubscriptionOwner.Hex(), SubscriptionID, mock.Anything, mock.Anything).Return(ResultBytes, nil, nil, nil)
+	uni.eaClient.On("RunComputation", mock.Anything, RequestIDStr, mock.Anything, SubscriptionOwner.Hex(), SubscriptionID, mock.Anything, mock.Anything, mock.Anything).Return(ResultBytes, nil, nil, nil)
 	uni.pluginORM.On("SetResult", RequestID, ResultBytes, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		close(doneCh)
 	}).Return(nil)
@@ -194,7 +199,7 @@ func TestFunctionsListener_ThresholdDecryptedSecrets(t *testing.T) {
 	uni.bridgeAccessor.On("NewExternalAdapterClient").Return(uni.eaClient, nil)
 	uni.eaClient.On("FetchEncryptedSecrets", mock.Anything, mock.Anything, RequestIDStr, mock.Anything, mock.Anything).Return(EncryptedSecrets, nil, nil)
 	uni.decryptor.On("Decrypt", mock.Anything, []byte(RequestIDStr), EncryptedSecrets).Return(DecryptedSecrets, nil)
-	uni.eaClient.On("RunComputation", mock.Anything, RequestIDStr, mock.Anything, SubscriptionOwner.Hex(), SubscriptionID, string(DecryptedSecrets), mock.Anything).Return(ResultBytes, nil, nil, nil)
+	uni.eaClient.On("RunComputation", mock.Anything, RequestIDStr, mock.Anything, SubscriptionOwner.Hex(), SubscriptionID, mock.Anything, string(DecryptedSecrets), mock.Anything).Return(ResultBytes, nil, nil, nil)
 	uni.pluginORM.On("SetResult", RequestID, ResultBytes, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		close(doneCh)
 	}).Return(nil)
@@ -261,7 +266,7 @@ func TestFunctionsListener_ReportSourceCodeDomains(t *testing.T) {
 	uni.pluginORM.On("CreateRequest", mock.Anything, mock.Anything).Return(nil)
 	uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
 	uni.bridgeAccessor.On("NewExternalAdapterClient").Return(uni.eaClient, nil)
-	uni.eaClient.On("RunComputation", mock.Anything, RequestIDStr, mock.Anything, SubscriptionOwner.Hex(), SubscriptionID, mock.Anything, mock.Anything).Return(ResultBytes, nil, Domains, nil)
+	uni.eaClient.On("RunComputation", mock.Anything, RequestIDStr, mock.Anything, SubscriptionOwner.Hex(), SubscriptionID, mock.Anything, mock.Anything, mock.Anything).Return(ResultBytes, nil, Domains, nil)
 	uni.pluginORM.On("SetResult", RequestID, ResultBytes, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		close(doneCh)
 	}).Return(nil)
@@ -293,7 +298,7 @@ func TestFunctionsListener_HandleOracleRequestComputationError(t *testing.T) {
 	uni.pluginORM.On("CreateRequest", mock.Anything, mock.Anything).Return(nil)
 	uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
 	uni.bridgeAccessor.On("NewExternalAdapterClient").Return(uni.eaClient, nil)
-	uni.eaClient.On("RunComputation", mock.Anything, RequestIDStr, mock.Anything, SubscriptionOwner.Hex(), SubscriptionID, mock.Anything, mock.Anything).Return(nil, ErrorBytes, nil, nil)
+	uni.eaClient.On("RunComputation", mock.Anything, RequestIDStr, mock.Anything, SubscriptionOwner.Hex(), SubscriptionID, mock.Anything, mock.Anything, mock.Anything).Return(nil, ErrorBytes, nil, nil)
 	uni.pluginORM.On("SetError", RequestID, functions_service.USER_ERROR, ErrorBytes, mock.Anything, true, mock.Anything).Run(func(args mock.Arguments) {
 		close(doneCh)
 	}).Return(nil)
@@ -376,8 +381,8 @@ func TestFunctionsListener_HandleOracleRequestCBORParsingCorrect(t *testing.T) {
 	uni.pluginORM.On("CreateRequest", mock.Anything, mock.Anything).Return(nil)
 	uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
 	uni.bridgeAccessor.On("NewExternalAdapterClient").Return(uni.eaClient, nil)
-	uni.eaClient.On("RunComputation", mock.Anything, RequestIDStr, mock.Anything, SubscriptionOwner.Hex(), SubscriptionID, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
-		reqData := args.Get(6).(*functions_service.RequestData)
+	uni.eaClient.On("RunComputation", mock.Anything, RequestIDStr, mock.Anything, SubscriptionOwner.Hex(), SubscriptionID, mock.Anything, mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
+		reqData := args.Get(7).(*functions_service.RequestData)
 		assert.Equal(t, incomingData.Source, reqData.Source)
 		assert.Equal(t, incomingData.Language, reqData.Language)
 		assert.Equal(t, incomingData.Secrets, reqData.Secrets)
@@ -398,7 +403,7 @@ func TestFunctionsListener_RequestTimeout(t *testing.T) {
 
 	reqId := newRequestID()
 	doneCh := make(chan bool)
-	uni := NewFunctionsListenerUniverse(t, 1, 1_000_000)
+	uni := NewFunctionsListenerUniverse(t, 1, 1_000_000, false)
 	uni.logBroadcaster.On("Register", mock.Anything, mock.Anything).Return(func() {})
 	uni.pluginORM.On("TimeoutExpiredResults", mock.Anything, uint32(1), mock.Anything).Return([]functions_service.RequestID{reqId}, nil).Run(func(args mock.Arguments) {
 		doneCh <- true
@@ -435,7 +440,7 @@ func TestFunctionsListener_PruneRequests(t *testing.T) {
 	t.Parallel()
 
 	doneCh := make(chan bool)
-	uni := NewFunctionsListenerUniverse(t, 0, 1)
+	uni := NewFunctionsListenerUniverse(t, 0, 1, false)
 	uni.logBroadcaster.On("Register", mock.Anything, mock.Anything).Return(func() {})
 	uni.pluginORM.On("PruneOldestRequests", functions_service.DefaultPruneMaxStoredRequests, functions_service.DefaultPruneBatchSize, mock.Anything).Return(uint32(0), uint32(0), nil).Run(func(args mock.Arguments) {
 		doneCh <- true
@@ -444,5 +449,65 @@ func TestFunctionsListener_PruneRequests(t *testing.T) {
 	err := uni.service.Start(testutils.Context(t))
 	require.NoError(t, err)
 	<-doneCh
+	uni.service.Close()
+}
+
+func TestFunctionsListener_HandleOracleRequestV1_Success(t *testing.T) {
+	testutils.SkipShortDB(t)
+	t.Parallel()
+
+	uni := NewFunctionsListenerUniverse(t, 1_000, 1_000_000, true)
+
+	flags := [32]byte{}
+	flags[1] = 1 // tier no 1 of request size
+	request := functions_coordinator.FunctionsCoordinatorOracleRequest{
+		RequestId:         RequestID,
+		SubscriptionId:    uint64(SubscriptionID),
+		SubscriptionOwner: SubscriptionOwner,
+		Flags:             flags,
+		Data:              make([]byte, 12), // tier 1 should allow for up to 100 bytes
+	}
+
+	uni.logBroadcaster.On("Register", mock.Anything, mock.Anything).Return(func() {})
+	uni.pluginORM.On("CreateRequest", mock.Anything, mock.Anything).Return(nil)
+	log := log_mocks.NewBroadcast(t)
+	uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
+	log.On("String").Return("")
+	uni.bridgeAccessor.On("NewExternalAdapterClient").Return(uni.eaClient, nil)
+	uni.eaClient.On("RunComputation", mock.Anything, RequestIDStr, mock.Anything, SubscriptionOwner.Hex(), SubscriptionID, mock.Anything, mock.Anything, mock.Anything).Return(ResultBytes, nil, nil, nil)
+	uni.pluginORM.On("SetResult", RequestID, ResultBytes, mock.Anything, mock.Anything).Return(nil)
+	err := uni.service.Start(testutils.Context(t))
+	require.NoError(t, err)
+
+	uni.service.HandleOracleRequestV1(&request, &request.RequestingContract, log)
+	uni.service.Close()
+}
+
+func TestFunctionsListener_HandleOracleRequestV1_CBORTooBig(t *testing.T) {
+	testutils.SkipShortDB(t)
+	t.Parallel()
+
+	uni := NewFunctionsListenerUniverse(t, 1_000, 1_000_000, true)
+
+	flags := [32]byte{}
+	flags[1] = 1 // tier no 1 of request size
+	request := functions_coordinator.FunctionsCoordinatorOracleRequest{
+		RequestId:         RequestID,
+		SubscriptionId:    uint64(SubscriptionID),
+		SubscriptionOwner: SubscriptionOwner,
+		Flags:             flags,
+		Data:              make([]byte, 120), // tier 1 only allows for up to 100 bytes
+	}
+
+	uni.logBroadcaster.On("Register", mock.Anything, mock.Anything).Return(func() {})
+	uni.pluginORM.On("CreateRequest", mock.Anything, mock.Anything).Return(nil)
+	log := log_mocks.NewBroadcast(t)
+	uni.logBroadcaster.On("MarkConsumed", mock.Anything, mock.Anything).Return(nil)
+	log.On("String").Return("")
+	uni.pluginORM.On("SetError", RequestID, functions_service.USER_ERROR, []byte("request too big (max 100 bytes)"), mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	err := uni.service.Start(testutils.Context(t))
+	require.NoError(t, err)
+
+	uni.service.HandleOracleRequestV1(&request, &request.RequestingContract, log)
 	uni.service.Close()
 }

--- a/core/services/functions/mocks/external_adapter_client.go
+++ b/core/services/functions/mocks/external_adapter_client.go
@@ -49,43 +49,43 @@ func (_m *ExternalAdapterClient) FetchEncryptedSecrets(ctx context.Context, encr
 	return r0, r1, r2
 }
 
-// RunComputation provides a mock function with given fields: ctx, requestId, jobName, subscriptionOwner, subscriptionId, nodeProvidedSecrets, requestData
-func (_m *ExternalAdapterClient) RunComputation(ctx context.Context, requestId string, jobName string, subscriptionOwner string, subscriptionId uint64, nodeProvidedSecrets string, requestData *functions.RequestData) ([]byte, []byte, []string, error) {
-	ret := _m.Called(ctx, requestId, jobName, subscriptionOwner, subscriptionId, nodeProvidedSecrets, requestData)
+// RunComputation provides a mock function with given fields: ctx, requestId, jobName, subscriptionOwner, subscriptionId, flags, nodeProvidedSecrets, requestData
+func (_m *ExternalAdapterClient) RunComputation(ctx context.Context, requestId string, jobName string, subscriptionOwner string, subscriptionId uint64, flags functions.RequestFlags, nodeProvidedSecrets string, requestData *functions.RequestData) ([]byte, []byte, []string, error) {
+	ret := _m.Called(ctx, requestId, jobName, subscriptionOwner, subscriptionId, flags, nodeProvidedSecrets, requestData)
 
 	var r0 []byte
 	var r1 []byte
 	var r2 []string
 	var r3 error
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, uint64, string, *functions.RequestData) ([]byte, []byte, []string, error)); ok {
-		return rf(ctx, requestId, jobName, subscriptionOwner, subscriptionId, nodeProvidedSecrets, requestData)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, uint64, functions.RequestFlags, string, *functions.RequestData) ([]byte, []byte, []string, error)); ok {
+		return rf(ctx, requestId, jobName, subscriptionOwner, subscriptionId, flags, nodeProvidedSecrets, requestData)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, uint64, string, *functions.RequestData) []byte); ok {
-		r0 = rf(ctx, requestId, jobName, subscriptionOwner, subscriptionId, nodeProvidedSecrets, requestData)
+	if rf, ok := ret.Get(0).(func(context.Context, string, string, string, uint64, functions.RequestFlags, string, *functions.RequestData) []byte); ok {
+		r0 = rf(ctx, requestId, jobName, subscriptionOwner, subscriptionId, flags, nodeProvidedSecrets, requestData)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]byte)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, uint64, string, *functions.RequestData) []byte); ok {
-		r1 = rf(ctx, requestId, jobName, subscriptionOwner, subscriptionId, nodeProvidedSecrets, requestData)
+	if rf, ok := ret.Get(1).(func(context.Context, string, string, string, uint64, functions.RequestFlags, string, *functions.RequestData) []byte); ok {
+		r1 = rf(ctx, requestId, jobName, subscriptionOwner, subscriptionId, flags, nodeProvidedSecrets, requestData)
 	} else {
 		if ret.Get(1) != nil {
 			r1 = ret.Get(1).([]byte)
 		}
 	}
 
-	if rf, ok := ret.Get(2).(func(context.Context, string, string, string, uint64, string, *functions.RequestData) []string); ok {
-		r2 = rf(ctx, requestId, jobName, subscriptionOwner, subscriptionId, nodeProvidedSecrets, requestData)
+	if rf, ok := ret.Get(2).(func(context.Context, string, string, string, uint64, functions.RequestFlags, string, *functions.RequestData) []string); ok {
+		r2 = rf(ctx, requestId, jobName, subscriptionOwner, subscriptionId, flags, nodeProvidedSecrets, requestData)
 	} else {
 		if ret.Get(2) != nil {
 			r2 = ret.Get(2).([]string)
 		}
 	}
 
-	if rf, ok := ret.Get(3).(func(context.Context, string, string, string, uint64, string, *functions.RequestData) error); ok {
-		r3 = rf(ctx, requestId, jobName, subscriptionOwner, subscriptionId, nodeProvidedSecrets, requestData)
+	if rf, ok := ret.Get(3).(func(context.Context, string, string, string, uint64, functions.RequestFlags, string, *functions.RequestData) error); ok {
+		r3 = rf(ctx, requestId, jobName, subscriptionOwner, subscriptionId, flags, nodeProvidedSecrets, requestData)
 	} else {
 		r3 = ret.Error(3)
 	}

--- a/core/services/functions/request.go
+++ b/core/services/functions/request.go
@@ -7,6 +7,8 @@ const (
 	LanguageJavaScript = 0
 )
 
+type RequestFlags [32]byte
+
 type RequestData struct {
 	Source          string   `json:"source" cbor:"source"`
 	Language        int      `json:"language" cbor:"language"`

--- a/core/services/ocr2/plugins/functions/config/config.go
+++ b/core/services/ocr2/plugins/functions/config/config.go
@@ -28,6 +28,8 @@ type PluginConfig struct {
 	PruneBatchSize                  uint32                            `json:"pruneBatchSize"`
 	ListenerEventHandlerTimeoutSec  uint32                            `json:"listenerEventHandlerTimeoutSec"`
 	MaxRequestSizeBytes             uint32                            `json:"maxRequestSizeBytes"`
+	MaxRequestSizesList             []uint32                          `json:"maxRequestSizesList"`
+	MaxSecretsSizesList             []uint32                          `json:"maxSecretsSizesList"`
 	GatewayConnectorConfig          *connector.ConnectorConfig        `json:"gatewayConnectorConfig"`
 	OnchainAllowlist                *functions.OnchainAllowlistConfig `json:"onchainAllowlist"`
 	RateLimiter                     *common.RateLimiterConfig         `json:"rateLimiter"`


### PR DESCRIPTION
1. Implement handleOracleRequestV1 to handle new OracleRequest type.
2. Parse flags and enforce relevant limits.
3. Pass flags to the EA.