### PR TITLE
[Functions] Interfaces for LogPollerWrapper

### DIFF
--- a/core/services/functions/listener.go
+++ b/core/services/functions/listener.go
@@ -23,6 +23,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/functions/config"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/threshold"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
+	evmrelayTypes "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/core/services/s4"
 	"github.com/smartcontractkit/chainlink/v2/core/services/synchronization/telem"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
@@ -137,6 +138,7 @@ type FunctionsListener struct {
 	mailMon           *utils.MailboxMonitor
 	urlsMonEndpoint   commontypes.MonitoringEndpoint
 	decryptor         threshold.Decryptor
+	logPollerWrapper  evmrelayTypes.LogPollerWrapper
 }
 
 func formatRequestId(requestId [32]byte) string {
@@ -155,22 +157,24 @@ func NewFunctionsListener(
 	mailMon *utils.MailboxMonitor,
 	urlsMonEndpoint commontypes.MonitoringEndpoint,
 	decryptor threshold.Decryptor,
+	logPollerWrapper evmrelayTypes.LogPollerWrapper,
 ) *FunctionsListener {
 	return &FunctionsListener{
-		oracle:          oracle,
-		oracleHexAddr:   oracle.Address().Hex(),
-		job:             job,
-		bridgeAccessor:  bridgeAccessor,
-		logBroadcaster:  logBroadcaster,
-		mbOracleEvents:  utils.NewHighCapacityMailbox[log.Broadcast](),
-		chStop:          make(chan struct{}),
-		pluginORM:       pluginORM,
-		pluginConfig:    pluginConfig,
-		s4Storage:       s4Storage,
-		logger:          lggr,
-		mailMon:         mailMon,
-		urlsMonEndpoint: urlsMonEndpoint,
-		decryptor:       decryptor,
+		oracle:           oracle,
+		oracleHexAddr:    oracle.Address().Hex(),
+		job:              job,
+		bridgeAccessor:   bridgeAccessor,
+		logBroadcaster:   logBroadcaster,
+		mbOracleEvents:   utils.NewHighCapacityMailbox[log.Broadcast](),
+		chStop:           make(chan struct{}),
+		pluginORM:        pluginORM,
+		pluginConfig:     pluginConfig,
+		s4Storage:        s4Storage,
+		logger:           lggr,
+		mailMon:          mailMon,
+		urlsMonEndpoint:  urlsMonEndpoint,
+		decryptor:        decryptor,
+		logPollerWrapper: logPollerWrapper,
 	}
 }
 

--- a/core/services/functions/listener_test.go
+++ b/core/services/functions/listener_test.go
@@ -122,7 +122,7 @@ func NewFunctionsListenerUniverse(t *testing.T, timeoutSec int, pruneFrequencySe
 	monEndpoint := ingressAgent.GenMonitoringEndpoint("0xa", synchronization.FunctionsRequests)
 
 	s4Storage := s4_mocks.NewStorage(t)
-	functionsListener := functions_service.NewFunctionsListener(oracleContract, jb, bridgeAccessor, pluginORM, pluginConfig, s4Storage, broadcaster, lggr, mailMon, monEndpoint, decryptor)
+	functionsListener := functions_service.NewFunctionsListener(oracleContract, jb, bridgeAccessor, pluginORM, pluginConfig, s4Storage, broadcaster, lggr, mailMon, monEndpoint, decryptor, nil)
 
 	return &FunctionsListenerUniverse{
 		service:        functionsListener,

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -965,7 +965,7 @@ func (d *Delegate) newServicesOCR2Functions(
 		return nil, fmt.Errorf("unsupported relay: %s", spec.Relay)
 	}
 
-	createPluginProvider := func(pluginType functionsRelay.FunctionsPluginType, relayerName string) (types.PluginProvider, error) {
+	createPluginProvider := func(pluginType functionsRelay.FunctionsPluginType, relayerName string) (evmrelaytypes.FunctionsProvider, error) {
 		return evmrelay.NewFunctionsProvider(
 			d.chainSet,
 			types.RelayArgs{
@@ -1081,6 +1081,7 @@ func (d *Delegate) newServicesOCR2Functions(
 		URLsMonEndpoint:   d.monitoringEndpointGen.GenMonitoringEndpoint(spec.ContractID, synchronization.FunctionsRequests),
 		EthKeystore:       d.ethKs,
 		ThresholdKeyShare: thresholdKeyShare,
+		LogPollerWrapper:  functionsProvider.LogPollerWrapper(),
 	}
 
 	functionsServices, err := functions.NewFunctionsServices(&functionsOracleArgs, &thresholdOracleArgs, &s4OracleArgs, &functionsServicesConfig)
@@ -1099,7 +1100,7 @@ func (d *Delegate) newServicesOCR2Functions(
 		d.cfg.JobPipeline().MaxSuccessfulRuns(),
 	)
 
-	return append([]job.ServiceCtx{runResultSaver, functionsProvider, s4Provider}, functionsServices...), nil
+	return append([]job.ServiceCtx{runResultSaver, functionsProvider, thresholdProvider, s4Provider}, functionsServices...), nil
 }
 
 // errorLog implements [loop.ErrorLog]

--- a/core/services/ocr2/plugins/functions/plugin.go
+++ b/core/services/ocr2/plugins/functions/plugin.go
@@ -28,6 +28,7 @@ import (
 	s4_plugin "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/s4"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/threshold"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
+	evmrelayTypes "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
 	"github.com/smartcontractkit/chainlink/v2/core/services/s4"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
@@ -45,6 +46,7 @@ type FunctionsServicesConfig struct {
 	URLsMonEndpoint   commontypes.MonitoringEndpoint
 	EthKeystore       keystore.Eth
 	ThresholdKeyShare []byte
+	LogPollerWrapper  evmrelayTypes.LogPollerWrapper
 }
 
 const (
@@ -117,6 +119,7 @@ func NewFunctionsServices(functionsOracleArgs, thresholdOracleArgs, s4OracleArgs
 		conf.MailMon,
 		conf.URLsMonEndpoint,
 		decryptor,
+		conf.LogPollerWrapper,
 	)
 	allServices = append(allServices, functionsListener)
 

--- a/core/services/relay/evm/functions/logpoller_wrapper.go
+++ b/core/services/relay/evm/functions/logpoller_wrapper.go
@@ -1,0 +1,49 @@
+package functions
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
+	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	evmRelayTypes "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
+)
+
+type logPollerWrapper struct {
+	logPoller logpoller.LogPoller
+	lggr      logger.Logger
+}
+
+var _ evmRelayTypes.LogPollerWrapper = &logPollerWrapper{}
+
+func NewLogPollerWrapper(logPoller logpoller.LogPoller, lggr logger.Logger) evmRelayTypes.LogPollerWrapper {
+	return &logPollerWrapper{
+		logPoller: logPoller,
+		lggr:      lggr,
+	}
+}
+
+// TODO(FUN-381): Implement LogPollerWrapper with an API suiting all users.
+func (l *logPollerWrapper) Start(context.Context) error {
+	return nil
+}
+func (l *logPollerWrapper) Close() error {
+	return nil
+}
+
+func (l *logPollerWrapper) HealthReport() map[string]error {
+	return make(map[string]error)
+}
+
+func (l *logPollerWrapper) Name() string {
+	return "LogPollerWrapper"
+}
+
+func (l *logPollerWrapper) Ready() error {
+	return nil
+}
+
+func (l *logPollerWrapper) LatestRoutes() (activeCoordinator common.Address, proposedCoordinator common.Address, err error) {
+	return common.Address{}, common.Address{}, nil
+}

--- a/core/services/relay/evm/types/types.go
+++ b/core/services/relay/evm/types/types.go
@@ -10,6 +10,8 @@ import (
 
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	relaytypes "github.com/smartcontractkit/chainlink-relay/pkg/types"
+
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
@@ -31,4 +33,16 @@ type ConfigPoller interface {
 	Start()
 	Close() error
 	Replay(ctx context.Context, fromBlock int64) error
+}
+
+// TODO(FUN-668): Move chain-agnostic types to Relayer
+type FunctionsProvider interface {
+	relaytypes.PluginProvider
+	LogPollerWrapper() LogPollerWrapper
+}
+
+// A LogPoller wrapper that understands router proxy contracts
+type LogPollerWrapper interface {
+	relaytypes.Service
+	LatestRoutes() (activeCoordinator common.Address, proposedCoordinator common.Address, err error)
 }


### PR DESCRIPTION
Introduce a chain-agnostic LogPollerWrapper that will be provided by the Relayer.
LogPollerWrapper needs to support Listener, ConfigProvider and ContractTransmitter (+ potentially more components in the future).