### PR TITLE
Adding index required by LatestBlockByEventSigsAddrsWithConfs

### DIFF
--- a/core/store/migrate/migrations/0186_idx_for_ordering_by_block_number.sql
+++ b/core/store/migrate/migrations/0186_idx_for_ordering_by_block_number.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+-- +goose StatementBegin
+
+-- This index optimizes queries used in the following functions:
+-- * logpoller.LatestBlockByEventSigsAddrsWithConfs
+--
+-- Example query:
+-- SELECT COALESCE(MAX(block_number), 0) FROM evm_logs
+--         WHERE evm_chain_id = 420 AND
+--         event_sig = '\0xA' AND
+--         address = '\0xB' AND
+--         (block_number) <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = 420 ORDER BY block_number DESC LIMIT 1);
+CREATE INDEX idx_evm_logs_ordered_by_block_number
+    on public.evm_logs (evm_chain_id, address, event_sig, block_number DESC);
+-- +goose StatementEnd
+
+
+-- +goose Down
+
+-- +goose StatementBegin
+DROP INDEX IF EXISTS idx_evm_logs_ordered_by_block_number;
+-- +goose StatementEnd


### PR DESCRIPTION
Related to the LogPoller's query `LatestBlockByEventSigsAddrsWithConfs` added in this PR https://github.com/smartcontractkit/chainlink/pull/9748

## Context

Postgres struggles with computing the performant execution plan for this query; it probably expects a smaller number of records to be scanned. Therefore query plan is not optimal because during execution, database is forced to do a lot of sequential scanning.

In the original PR, I did perform tests with `query analyze` but on a huge dataset (around 12kk `evm_logs`). The issue with this approach is that in the real environment, we have smaller numbers of `evm_logs`, and Postgres fails to compute the proper execution plan. Therefore we end up having extremely slow queries. 
<img width="832" alt="image" src="https://github.com/smartcontractkit/chainlink/assets/18304098/6473d23f-8756-4109-ad33-e6442f86984f">

### Current state - Experiment 1 (small dataset - evm_logs ~400k rows, matching by where filter ~132953k)
```sql
 Result  (cost=7.60..7.61 rows=1 width=8) (actual time=394.100..394.101 rows=1 loops=1)
   InitPlan 1 (returns $0)
     ->  Limit  (cost=0.15..5.50 rows=1 width=16) (actual time=0.017..0.017 rows=0 loops=1)
           ->  Index Only Scan using idx_evm_log_poller_blocks_order_by_block on evm_log_poller_blocks  (cost=0.15..16.20 rows=3 width=16) (actual time=0.016..0.016 rows=0 loops=1)
                 Index Cond: (evm_chain_id = '1'::numeric)
                 Heap Fetches: 0
   InitPlan 2 (returns $1)
     ->  Limit  (cost=0.55..2.10 rows=1 width=8) (actual time=394.095..394.095 rows=0 loops=1)
           ->  Index Only Scan Backward using evm_logs_idx on evm_logs  (cost=0.55..69381.53 rows=44730 width=8) (actual time=394.094..394.094 rows=0 loops=1)
                 Index Cond: ((evm_chain_id = '1'::numeric) AND (block_number IS NOT NULL) AND (address = '\xbb0f07700587fee22c5863ed75a5e05b68fcac4763449a582987fa4e8e9a2d0f'::bytea) AND (event_sig = '\xa32c5f1d88735034143171f18fbb4d447fbbe0fbf4c98733d54092a081ba5d2a'::bytea))
                 Filter: ((block_number + 10) <= $0)
                 Rows Removed by Filter: 132953
                 Heap Fetches: 132953
 Planning Time: 1.582 ms
 Execution Time: 394.163 ms
(15 rows)
```

Index picked by Postgres
```sql
create index evm_logs_idx
    on public.evm_logs (evm_chain_id, block_number, address, event_sig);
```

### Current state - Experiment 2 (large dataset - evm_logs ~2kk rows, matching by where filter ~1kk)

```sql



```

## Solution

Don't assume that if the query works on massive datasets, it will also be blazingly fast on smaller datasets, run `explain analyze` for small, medium, and large datasets. Try assessing what is expected data size in a real environment.

