### PR TITLE
Speeding up LogPoller's queries by making `block_number` filtering easier for Postgres

### DIFF
--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -308,7 +308,7 @@ func (o *ORM) SelectLatestLogEventSigsAddrsWithConfs(fromBlock int64, addresses 
 				    event_sig = ANY($2) AND
 					address = ANY($3) AND
 		   			block_number > $4 AND
-					(block_number + $5) <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1)
+					block_number <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1) - $5
 			GROUP BY event_sig, address
 		)
 		ORDER BY block_number ASC
@@ -331,7 +331,7 @@ func (o *ORM) SelectLatestBlockNumberEventSigsAddrsWithConfs(eventSigs []common.
 				WHERE evm_chain_id = $1 AND
 				    event_sig = ANY($2) AND
 					address = ANY($3) AND
-					(block_number + $4) <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1)`,
+					block_number <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1) - $4`,
 		o.chainID.Int64(), sigs, addrs, confs)
 	if err != nil {
 		return 0, err
@@ -348,7 +348,7 @@ func (o *ORM) SelectDataWordRange(address common.Address, eventSig common.Hash, 
 			AND address = $2 AND event_sig = $3
 			AND substring(data from 32*$4+1 for 32) >= $5
 			AND substring(data from 32*$4+1 for 32) <= $6
-			AND (block_number + $7) <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1)
+			AND block_number <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1) - $7
 			ORDER BY (evm_logs.block_number, evm_logs.log_index)`, utils.NewBig(o.chainID), address, eventSig.Bytes(), wordIndex, wordValueMin.Bytes(), wordValueMax.Bytes(), confs)
 	if err != nil {
 		return nil, err
@@ -364,7 +364,7 @@ func (o *ORM) SelectDataWordGreaterThan(address common.Address, eventSig common.
 			WHERE evm_logs.evm_chain_id = $1
 			AND address = $2 AND event_sig = $3
 			AND substring(data from 32*$4+1 for 32) >= $5
-			AND (block_number + $6) <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1)
+			AND block_number <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1) - $6
 			ORDER BY (evm_logs.block_number, evm_logs.log_index)`, utils.NewBig(o.chainID), address, eventSig.Bytes(), wordIndex, wordValueMin.Bytes(), confs)
 	if err != nil {
 		return nil, err
@@ -384,7 +384,7 @@ func (o *ORM) SelectIndexLogsTopicGreaterThan(address common.Address, eventSig c
 			WHERE evm_logs.evm_chain_id = $1
 			AND address = $2 AND event_sig = $3
 			AND topics[$4] >= $5
-			AND (block_number + $6) <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1)
+			AND block_number <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1) - $6
 			ORDER BY (evm_logs.block_number, evm_logs.log_index)`, utils.NewBig(o.chainID), address, eventSig.Bytes(), topicIndex+1, topicValueMin.Bytes(), confs)
 	if err != nil {
 		return nil, err
@@ -405,7 +405,7 @@ func (o *ORM) SelectIndexLogsTopicRange(address common.Address, eventSig common.
 			AND address = $2 AND event_sig = $3
 			AND topics[$4] >= $5
 			AND topics[$4] <= $6
-			AND (block_number + $7) <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1)
+			AND block_number <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1) - $7
 			ORDER BY (evm_logs.block_number, evm_logs.log_index)`, utils.NewBig(o.chainID), address, eventSig.Bytes(), topicIndex+1, topicValueMin.Bytes(), topicValueMax.Bytes(), confs)
 	if err != nil {
 		return nil, err
@@ -427,7 +427,7 @@ func (o *ORM) SelectIndexedLogs(address common.Address, eventSig common.Hash, to
 			WHERE evm_logs.evm_chain_id = $1
 			AND address = $2 AND event_sig = $3
 			AND topics[$4] = ANY($5)
-			AND (block_number + $6) <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1)
+			AND block_number <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1) - $6
 			ORDER BY (evm_logs.block_number, evm_logs.log_index)`, utils.NewBig(o.chainID), address, eventSig.Bytes(), topicIndex+1, topicValuesBytes, confs)
 	if err != nil {
 		return nil, err
@@ -475,7 +475,7 @@ func (o *ORM) SelectIndexedLogsCreatedAfter(address common.Address, eventSig com
 			AND address = $2 AND event_sig = $3
 			AND topics[$4] = ANY($5)
 			AND created_at > $6
-			AND (block_number + $7) <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1)
+			AND block_number <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1) - $7
 			ORDER BY created_at ASC`, utils.NewBig(o.chainID), address, eventSig.Bytes(), topicIndex+1, topicValuesBytes, after, confs)
 	if err != nil {
 		return nil, err
@@ -499,7 +499,7 @@ func (o *ORM) SelectIndexedLogsWithSigsExcluding(sigA, sigB common.Hash, topicIn
 		AND    address = $2
 		AND    event_sig = $3
 		AND block_number BETWEEN $6 AND $7
-		AND (block_number + $8) <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1)
+		AND block_number <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1) - $8
 		
 		EXCEPT
 		
@@ -512,7 +512,7 @@ func (o *ORM) SelectIndexedLogsWithSigsExcluding(sigA, sigB common.Hash, topicIn
 		AND        a.event_sig = $3
 		AND        b.event_sig = $4
 	    AND 	   b.block_number BETWEEN $6 AND $7
-		AND (b.block_number + $8) <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1)
+		AND		   b.block_number <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = $1 ORDER BY block_number DESC LIMIT 1) - $8
 
 		ORDER BY block_number,log_index ASC
 			`, utils.NewBig(o.chainID), address, sigA.Bytes(), sigB.Bytes(), topicIndex+1, startBlock, endBlock, confs)


### PR DESCRIPTION
## Context

Unfortunately, Postgres sometimes is not as smart as we want it to be. It struggles with computing the optimal execution plan for queries that filter by `block_number,` and the number of confirmations is greater than 0 - `block_number + Z <= Y`

We observed this issue [after releasing  LogPoller's query](https://github.com/smartcontractkit/chainlink/pull/9748) `LatestBlockByEventSigsAddrsWithConfs`, which should be blazingly fast.

Unfortunately, I omitted the addition in the filter during perf tests because I thought it was irrelevant. I was highly mistaken.

<img width="832" alt="image" src="https://github.com/smartcontractkit/chainlink/assets/18304098/6473d23f-8756-4109-ad33-e6442f86984f">

## Solution
Replace addition on the left side
```sql
AND (block_number + X)  <= (nested SQL)
```

with subtraction on the right
```sql
AND block_number <= (nested SQL) - X
```

## Query plans and durations for different approaches

Number of rows in evm_logs: ~200k
Number of rows after applying a filter: ~66k 
Outcome: 1ms versus 50ms

Based on the query plans, you can see that the first one cannot fully utilize the index and has to perform additional filtering and heap operations (probably sequential access to data because the index is not used). The latter doesn't need this step at all.

Critical part of `explain analyze`
```
                 Filter: ((block_number + 10) <= $0)
                 Rows Removed by Filter: 66578
                 Heap Fetches: 66578
```
versus
```
                 Heap Fetches: 0
```

### Addition (left side of the condition) 
```sql
explain analyze SELECT MAX(block_number) FROM evm_logs
                              WHERE evm_chain_id = 1 
                              AND event_sig = '\xa32c5f1d88735034143171f18fbb4d447fbbe0fbf4c98733d54092a081ba5d2a'
                              AND address = '\xbb0f07700587fee22c5863ed75a5e05b68fcac4763449a582987fa4e8e9a2d0f' 
                              AND (block_number + 10) <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = 1 ORDER BY block_number DESC LIMIT 1);

 Result  (cost=7.66..7.67 rows=1 width=8) (actual time=55.109..55.109 rows=1 loops=1)
   InitPlan 1 (returns $0)
     ->  Limit  (cost=0.15..5.50 rows=1 width=16) (actual time=0.013..0.013 rows=0 loops=1)
           ->  Index Only Scan using idx_evm_log_poller_blocks_order_by_block on evm_log_poller_blocks  (cost=0.15..16.20 rows=3 width=16) (actual time=0.012..0.012 rows=0 loops=1)
                 Index Cond: (evm_chain_id = '1'::numeric)
                 Heap Fetches: 0
   InitPlan 2 (returns $1)
     ->  Limit  (cost=0.55..2.16 rows=1 width=8) (actual time=55.103..55.103 rows=0 loops=1)
           ->  Index Only Scan Backward using idx_evm_logs_ordered_by_block_and_created_at on evm_logs  (cost=0.55..35795.38 rows=22144 width=8) (actual time=55.083..55.083 rows=0 loops=1)
                 Index Cond: ((evm_chain_id = '1'::numeric) AND (address = '\xbb0f07700587fee22c5863ed75a5e05b68fcac4763449a582987fa4e8e9a2d0f'::bytea) AND (event_sig = '\xa32c5f1d88735034143171f18fbb4d447fbbe0fbf4c98733d54092a081ba5d2a'::bytea) AND (block_number IS NOT NULL))
                 Filter: ((block_number + 10) <= $0)
                 Rows Removed by Filter: 66578
                 Heap Fetches: 66578
 Planning Time: 1.127 ms
 Execution Time: 55.298 ms
(15 rows)
```


### Subtraction (right side of condition)
```sql 
explain analyze SELECT MAX(block_number) FROM evm_logs
                                WHERE evm_chain_id = 1 
                                AND event_sig = '\xa32c5f1d88735034143171f18fbb4d447fbbe0fbf4c98733d54092a081ba5d2a'
                                AND address = '\xbb0f07700587fee22c5863ed75a5e05b68fcac4763449a582987fa4e8e9a2d0f' 
                                AND block_number <= (SELECT COALESCE(block_number, 0) FROM evm_log_poller_blocks WHERE evm_chain_id = 1 ORDER BY block_number DESC LIMIT 1) - 10;

 Result  (cost=7.42..7.43 rows=1 width=8) (actual time=0.132..0.132 rows=1 loops=1)
   InitPlan 1 (returns $0)
     ->  Limit  (cost=0.15..5.50 rows=1 width=16) (actual time=0.045..0.046 rows=0 loops=1)
           ->  Index Only Scan using idx_evm_log_poller_blocks_order_by_block on evm_log_poller_blocks  (cost=0.15..16.20 rows=3 width=16) (actual time=0.045..0.045 rows=0 loops=1)
                 Index Cond: (evm_chain_id = '1'::numeric)
                 Heap Fetches: 0
   InitPlan 2 (returns $1)
     ->  Limit  (cost=0.55..1.92 rows=1 width=8) (actual time=0.111..0.111 rows=0 loops=1)
           ->  Index Only Scan Backward using idx_evm_logs_ordered_by_block_and_created_at on evm_logs  (cost=0.55..30283.43 rows=22144 width=8) (actual time=0.110..0.110 rows=0 loops=1)
                 Index Cond: ((evm_chain_id = '1'::numeric) AND (address = '\xbb0f07700587fee22c5863ed75a5e05b68fcac4763449a582987fa4e8e9a2d0f'::bytea) AND (event_sig = '\xa32c5f1d88735034143171f18fbb4d447fbbe0fbf4c98733d54092a081ba5d2a'::bytea) AND (block_number IS NOT NULL) AND (block_number <= ($0 - 10)))
                 Heap Fetches: 0
 Planning Time: 2.725 ms
 Execution Time: 0.338 ms
(13 rows)

```