### PR TITLE
[Functions] Don't use a static EVM Digester in Functions Digester

### DIFF
--- a/core/services/relay/evm/functions.go
+++ b/core/services/relay/evm/functions.go
@@ -9,7 +9,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
-	"github.com/smartcontractkit/libocr/offchainreporting2plus/chains/evmutil"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"go.uber.org/multierr"
@@ -128,14 +127,7 @@ func newFunctionsConfigProvider(pluginType functionsRelay.FunctionsPluginType, c
 		return nil, err
 	}
 
-	offchainConfigDigester := functionsRelay.FunctionsOffchainConfigDigester{
-		PluginType: pluginType,
-		BaseDigester: evmutil.EVMOffchainConfigDigester{
-			ChainID:         chain.ID().Uint64(),
-			ContractAddress: contractAddress,
-		},
-	}
-
+	offchainConfigDigester := functionsRelay.NewFunctionsOffchainConfigDigester(pluginType, chain.ID().Uint64(), contractAddress)
 	return newConfigWatcher(lggr, contractAddress, contractABI, offchainConfigDigester, cp, chain, fromBlock, args.New), nil
 }
 

--- a/core/services/relay/evm/functions/config_poller_test.go
+++ b/core/services/relay/evm/functions/config_poller_test.go
@@ -40,7 +40,9 @@ func TestFunctionsConfigPoller(t *testing.T) {
 	t.Run("ThresholdPlugin", func(t *testing.T) {
 		runTest(t, functions.ThresholdPlugin, functions.ThresholdDigestPrefix)
 	})
-	// TODO: Test config poller for S4Plugin (requires S4Plugin to be implemented & corresponding updates to pluginConfig)
+	t.Run("S4Plugin", func(t *testing.T) {
+		runTest(t, functions.S4Plugin, functions.S4DigestPrefix)
+	})
 }
 
 func runTest(t *testing.T, pluginType functions.FunctionsPluginType, expectedDigestPrefix ocrtypes2.ConfigDigestPrefix) {

--- a/core/services/relay/evm/functions/offchain_config_digester.go
+++ b/core/services/relay/evm/functions/offchain_config_digester.go
@@ -5,12 +5,13 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/smartcontractkit/libocr/offchainreporting2plus/chains/evmutil"
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/smartcontractkit/libocr/offchainreporting2/chains/evmutil"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 )
 
 var (
-	_                     types.OffchainConfigDigester = FunctionsOffchainConfigDigester{}
+	_                     types.OffchainConfigDigester = functionsOffchainConfigDigester{}
 	FunctionsDigestPrefix                              = types.ConfigDigestPrefixEVM
 	// In order to support multiple OCR plugins with a single jobspec & OCR2Base contract, each plugin must have a unique config digest.
 	// This is accomplished by overriding the single config digest from the contract with a unique prefix for each plugin via this custom offchain digester & config poller.
@@ -18,19 +19,33 @@ var (
 	S4DigestPrefix        = types.ConfigDigestPrefix(8)
 )
 
-type FunctionsOffchainConfigDigester struct {
-	PluginType   FunctionsPluginType
-	BaseDigester evmutil.EVMOffchainConfigDigester
+type functionsOffchainConfigDigester struct {
+	pluginType      FunctionsPluginType
+	chainID         uint64
+	contractAddress common.Address
 }
 
-func (d FunctionsOffchainConfigDigester) ConfigDigest(cc types.ContractConfig) (types.ConfigDigest, error) {
-	configDigest, err := d.BaseDigester.ConfigDigest(cc)
+func NewFunctionsOffchainConfigDigester(pluginType FunctionsPluginType, chainID uint64, contractAddress common.Address) *functionsOffchainConfigDigester {
+	return &functionsOffchainConfigDigester{
+		pluginType:      pluginType,
+		chainID:         chainID,
+		contractAddress: contractAddress,
+	}
+}
+
+func (d functionsOffchainConfigDigester) ConfigDigest(cc types.ContractConfig) (types.ConfigDigest, error) {
+	baseDigester := evmutil.EVMOffchainConfigDigester{
+		ChainID:         d.chainID,
+		ContractAddress: d.contractAddress,
+	}
+
+	configDigest, err := baseDigester.ConfigDigest(cc)
 	if err != nil {
 		return types.ConfigDigest{}, err
 	}
 
 	var prefix types.ConfigDigestPrefix
-	switch d.PluginType {
+	switch d.pluginType {
 	case FunctionsPlugin:
 		prefix = FunctionsDigestPrefix
 	case ThresholdPlugin:
@@ -46,8 +61,8 @@ func (d FunctionsOffchainConfigDigester) ConfigDigest(cc types.ContractConfig) (
 	return configDigest, nil
 }
 
-func (d FunctionsOffchainConfigDigester) ConfigDigestPrefix() (types.ConfigDigestPrefix, error) {
-	switch d.PluginType {
+func (d functionsOffchainConfigDigester) ConfigDigestPrefix() (types.ConfigDigestPrefix, error) {
+	switch d.pluginType {
 	case FunctionsPlugin:
 		return FunctionsDigestPrefix, nil
 	case ThresholdPlugin:
@@ -55,6 +70,6 @@ func (d FunctionsOffchainConfigDigester) ConfigDigestPrefix() (types.ConfigDiges
 	case S4Plugin:
 		return S4DigestPrefix, nil
 	default:
-		return 0, fmt.Errorf("unknown plugin type: %v", d.PluginType)
+		return 0, fmt.Errorf("unknown plugin type: %v", d.pluginType)
 	}
 }


### PR DESCRIPTION
Contract address will soon be dynamic so we can't use a single base digester. Let's create one on each call.