### PR TITLE
Mercury ConfigPoller should check for the address before Notifying

### DIFF
--- a/core/services/relay/evm/mercury/config_poller.go
+++ b/core/services/relay/evm/mercury/config_poller.go
@@ -191,7 +191,10 @@ func (cp *ConfigPoller) LatestBlockHeight(ctx context.Context) (blockHeight uint
 }
 
 func (cp *ConfigPoller) startLogSubscription() {
-	feedIdPgHex := cp.feedId.Hex()[2:] // trim the leading 0x to make it comparable to pg's hex encoding.
+	// trim the leading 0x to make it comparable to pg's hex encoding.
+	addressPgHex := cp.addr.Hex()[2:]
+	feedIdPgHex := cp.feedId.Hex()[2:]
+
 	for {
 		event, ok := <-cp.subscription.Events()
 		if !ok {
@@ -203,6 +206,11 @@ func (cp *ConfigPoller) startLogSubscription() {
 		addressTopicValues := strings.Split(event.Payload, ":")
 		if len(addressTopicValues) < 2 {
 			cp.lggr.Warnf("invalid event from %s channel: %s", pg.ChannelInsertOnEVMLogs, event.Payload)
+			continue
+		}
+
+		address := addressTopicValues[0]
+		if address != addressPgHex {
 			continue
 		}
 

--- a/core/services/relay/evm/mercury/config_poller_test.go
+++ b/core/services/relay/evm/mercury/config_poller_test.go
@@ -124,34 +124,39 @@ func TestNotify(t *testing.T) {
 	th := SetupTH(t, feedID)
 	th.subscription.On("Events").Return((<-chan pg.Event)(eventCh))
 
+	addressPgHex := th.verifierAddress.Hex()[2:]
+
 	notify := th.configPoller.Notify()
 	assert.Empty(t, notify)
 
 	eventCh <- pg.Event{} // Empty event
 	assert.Empty(t, notify)
 
-	eventCh <- pg.Event{Payload: "address"} // missing topic values
+	eventCh <- pg.Event{Payload: addressPgHex} // missing topic values
 	assert.Empty(t, notify)
 
-	eventCh <- pg.Event{Payload: "address:val1"} // missing feedId topic value
+	eventCh <- pg.Event{Payload: addressPgHex + ":val1"} // missing feedId topic value
 	assert.Empty(t, notify)
 
-	eventCh <- pg.Event{Payload: "address:8257737fdf4f79639585fd0ed01bea93c248a9ad940e98dd27f41c9b6230fed1,val2"} // wrong index
+	eventCh <- pg.Event{Payload: addressPgHex + ":8257737fdf4f79639585fd0ed01bea93c248a9ad940e98dd27f41c9b6230fed1,val2"} // wrong index
 	assert.Empty(t, notify)
 
-	eventCh <- pg.Event{Payload: "address:val1,val2,8257737fdf4f79639585fd0ed01bea93c248a9ad940e98dd27f41c9b6230fed1"} // wrong index
+	eventCh <- pg.Event{Payload: addressPgHex + ":val1,val2,8257737fdf4f79639585fd0ed01bea93c248a9ad940e98dd27f41c9b6230fed1"} // wrong index
 	assert.Empty(t, notify)
 
-	eventCh <- pg.Event{Payload: "address:val1,0x8257737fdf4f79639585fd0ed01bea93c248a9ad940e98dd27f41c9b6230fed1"} // 0x prefix
+	eventCh <- pg.Event{Payload: addressPgHex + ":val1,0x8257737fdf4f79639585fd0ed01bea93c248a9ad940e98dd27f41c9b6230fed1"} // 0x prefix
 	assert.Empty(t, notify)
 
-	eventCh <- pg.Event{Payload: "address:val1,8257737fdf4f79639585fd0ed01bea93c248a9ad940e98dd27f41c9b6230fed1"}
+	eventCh <- pg.Event{Payload: "wrong_address:val1,8257737fdf4f79639585fd0ed01bea93c248a9ad940e98dd27f41c9b6230fed1"} // wrong address
+	assert.Empty(t, notify)
+
+	eventCh <- pg.Event{Payload: addressPgHex + ":val1,8257737fdf4f79639585fd0ed01bea93c248a9ad940e98dd27f41c9b6230fed1"} // expected event to notify on
 	assert.Eventually(t, func() bool { <-notify; return true }, time.Second, 10*time.Millisecond)
 
-	eventCh <- pg.Event{Payload: "address:val1,8257737fdf4f79639585fd0ed01bea93c248a9ad940e98dd27f41c9b6230fed1"} // try second time
+	eventCh <- pg.Event{Payload: addressPgHex + ":val1,8257737fdf4f79639585fd0ed01bea93c248a9ad940e98dd27f41c9b6230fed1"} // try second time
 	assert.Eventually(t, func() bool { <-notify; return true }, time.Second, 10*time.Millisecond)
 
-	eventCh <- pg.Event{Payload: "address:val1,8257737fdf4f79639585fd0ed01bea93c248a9ad940e98dd27f41c9b6230fed1:additional"}
+	eventCh <- pg.Event{Payload: addressPgHex + ":val1,8257737fdf4f79639585fd0ed01bea93c248a9ad940e98dd27f41c9b6230fed1:additional"} // additional colon separated parts
 	assert.Eventually(t, func() bool { <-notify; return true }, time.Second, 10*time.Millisecond)
 }
 

--- a/core/services/relay/evm/mercury/helper_test.go
+++ b/core/services/relay/evm/mercury/helper_test.go
@@ -27,6 +27,7 @@ type TestHarness struct {
 	configPoller     *ConfigPoller
 	user             *bind.TransactOpts
 	backend          *backends.SimulatedBackend
+	verifierAddress  common.Address
 	verifierContract *mercury_verifier.MercuryVerifier
 	logPoller        logpoller.LogPoller
 	eventBroadcaster *pgmocks.EventBroadcaster
@@ -73,6 +74,7 @@ func SetupTH(t *testing.T, feedID common.Hash) TestHarness {
 		configPoller:     configPoller,
 		user:             user,
 		backend:          b,
+		verifierAddress:  verifierAddress,
 		verifierContract: verifierContract,
 		logPoller:        lp,
 		eventBroadcaster: eventBroadcaster,


### PR DESCRIPTION
@reductionista pointed out that the ConfigPoller wasn't actually checking the address of the log events before notifying, leading to potential false positives. This PR fixes that oversight.