### PR TITLE
Add a decode extensions function

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/encoder.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/encoder.go
@@ -63,6 +63,7 @@ func (enc EVMAutomationEncoder21) Encode(results ...ocr2keepers.CheckResult) ([]
 	highestCheckBlock := big.NewInt(0)
 
 	for i, result := range results {
+		result := result
 		if err := decodeExtensions(&result); err != nil {
 			return nil, err
 		}

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/encoder.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/encoder.go
@@ -1,6 +1,7 @@
 package evm
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -58,10 +59,17 @@ func (enc EVMAutomationEncoder21) Encode(results ...ocr2keepers.CheckResult) ([]
 		PerformDatas: make([][]byte, len(results)),
 	}
 
+	encoded := 0
 	highestCheckBlock := big.NewInt(0)
+
 	for i, result := range results {
+		if err := decodeExtensions(&result); err != nil {
+			return nil, err
+		}
+
 		ext, ok := result.Extension.(EVMAutomationResultExtension21)
 		if !ok {
+			// decodeExtensions should catch this, but in the case it doesn't ...
 			return nil, fmt.Errorf("unexpected check result extension struct")
 		}
 
@@ -84,27 +92,38 @@ func (enc EVMAutomationEncoder21) Encode(results ...ocr2keepers.CheckResult) ([]
 			BlockNum:  uint32(result.Payload.Trigger.BlockNumber),
 			BlockHash: common.HexToHash(result.Payload.Trigger.BlockHash),
 		}
+
 		switch getUpkeepType(id.Bytes()) {
 		case logTrigger:
 			trExt, ok := result.Payload.Trigger.Extension.(logprovider.LogTriggerExtension)
 			if !ok {
+				// decodeExtensions should catch this, but in the case it doesn't ...
 				return nil, fmt.Errorf("unrecognized trigger extension data")
 			}
+
 			hex, err := common.ParseHexOrString(trExt.TxHash)
 			if err != nil {
 				return nil, fmt.Errorf("tx hash parse error: %w", err)
 			}
+
 			triggerW.TxHash = common.BytesToHash(hex[:])
 			triggerW.LogIndex = uint32(trExt.LogIndex)
 		default:
+			// no special handling here for conditional triggers
 		}
+
 		trigger, err := enc.packer.PackTrigger(id, triggerW)
 		if err != nil {
 			return nil, fmt.Errorf("%w: failed to pack trigger", err)
 		}
+
 		report.Triggers[i] = trigger
 		report.PerformDatas[i] = result.PerformData
+
+		encoded++
 	}
+
+	fmt.Printf("[automation-ocr3|EvmRegistry|Encoder] encoded %d out of %d results\n", encoded, len(results))
 
 	return enc.packer.PackReport(report)
 }
@@ -159,4 +178,68 @@ type UpkeepKeyHelper[T uint32 | int64] struct {
 
 func (kh UpkeepKeyHelper[T]) MakeUpkeepKey(b T, id *big.Int) ocr2keepers.UpkeepKey {
 	return ocr2keepers.UpkeepKey(fmt.Sprintf("%d%s%s", b, separator, id))
+}
+
+func decodeExtensions(result *ocr2keepers.CheckResult) error {
+	if result == nil {
+		return fmt.Errorf("non-nil value expected in decoding")
+	}
+
+	rC := *result
+
+	// decode the trigger extension data if not decoded
+	switch typedExt := rC.Payload.Trigger.Extension.(type) {
+	case logprovider.LogTriggerExtension:
+		// no decoding required
+		break
+	case []byte:
+		switch getUpkeepType(result.Payload.Upkeep.ID) {
+		case logTrigger:
+			var ext logprovider.LogTriggerExtension
+
+			// in the case of a string, the value is probably still json
+			// encoded and coming from a plugin outcome
+			if err := json.Unmarshal(typedExt, &ext); err != nil {
+				return fmt.Errorf("%w: json encoded values do not match LogTriggerExtension struct: %s", err, string(typedExt))
+			}
+
+			result.Payload.Trigger.Extension = ext
+		case conditionTrigger:
+			// no special handling for conditional triggers
+			break
+		default:
+			return fmt.Errorf("unknown upkeep type")
+		}
+	case struct{}, nil:
+		// empty fallback
+		break
+	default:
+		return fmt.Errorf("unrecognized trigger extension data")
+	}
+
+	// decode the result extension data if not decoded
+	switch typedExt := result.Extension.(type) {
+	case EVMAutomationResultExtension21:
+		// no decoding required
+		break
+	case []byte:
+		var ext EVMAutomationResultExtension21
+
+		// in the case of a string, the value is probably still json
+		// encoded and coming from a plugin outcome
+		if err := json.Unmarshal(typedExt, &ext); err != nil {
+			return fmt.Errorf("%w: json encoded values do not match EVMAutomationResultExtension21 struct", err)
+		}
+
+		result.Extension = ext
+	case struct{}, nil:
+		// empty fallback
+		break
+	default:
+		return fmt.Errorf("unrecognized CheckResult extension data")
+	}
+
+	// TODO: decode upkeep config data if not decoded
+
+	return nil
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/encoder_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/encoder_test.go
@@ -126,7 +126,7 @@ func TestEVMAutomationEncoder21_Encode_errors(t *testing.T) {
 		b, err := encoder.Encode(result)
 		assert.Nil(t, b)
 		assert.Error(t, err)
-		assert.Equal(t, err.Error(), "unexpected check result extension struct")
+		assert.Equal(t, err.Error(), "unrecognized CheckResult extension data")
 	})
 
 	t.Run("an invalid upkeep ID causes an error", func(t *testing.T) {

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/encoder_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/encoder_test.go
@@ -168,6 +168,24 @@ func TestEVMAutomationEncoder21_Encode_errors(t *testing.T) {
 		assert.Error(t, err)
 		assert.Equal(t, err.Error(), "unknown trigger type: 5: failed to pack trigger")
 	})
+
+	t.Run("an invalid result extension causes an error", func(t *testing.T) {
+		result := newResult(2, "2", ocr2keepers.UpkeepIdentifier(genUpkeepID(5, "20").String()), 1, 1)
+		result.Extension = struct{}{}
+		b, err := encoder.Encode(result)
+		assert.Nil(t, b)
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "unexpected check result extension struct")
+	})
+
+	t.Run("invalid trigger extension causes an error", func(t *testing.T) {
+		result := newResult(2, "2", ocr2keepers.UpkeepIdentifier(genUpkeepID(logTrigger, "20").String()), 1, 1)
+		result.Payload.Trigger.Extension = struct{}{}
+		b, err := encoder.Encode(result)
+		assert.Nil(t, b)
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "unrecognized trigger extension data")
+	})
 }
 
 func TestEVMAutomationEncoder21_EncodeExtract(t *testing.T) {
@@ -317,4 +335,148 @@ func decode(packer *evmRegistryPackerV2_1, raw []byte) ([]ocr2keepers.UpkeepResu
 	}
 
 	return res, nil
+}
+
+func Test_decodeExtensions(t *testing.T) {
+	t.Run("a nil result returns an error", func(t *testing.T) {
+		err := decodeExtensions(nil)
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "non-nil value expected in decoding")
+	})
+
+	t.Run("two types of extension do not require decoding", func(t *testing.T) {
+		err := decodeExtensions(&ocr2keepers.CheckResult{
+			Payload: ocr2keepers.UpkeepPayload{
+				Trigger: ocr2keepers.Trigger{
+					Extension: logprovider.LogTriggerExtension{},
+				},
+			},
+			Extension: EVMAutomationResultExtension21{},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("empty structs do not require decoding", func(t *testing.T) {
+		err := decodeExtensions(&ocr2keepers.CheckResult{
+			Payload: ocr2keepers.UpkeepPayload{
+				Trigger: ocr2keepers.Trigger{
+					Extension: struct{}{},
+				},
+			},
+			Extension: struct{}{},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("CheckResult extension as json gets decoded", func(t *testing.T) {
+		err := decodeExtensions(&ocr2keepers.CheckResult{
+			Payload: ocr2keepers.UpkeepPayload{
+				Trigger: ocr2keepers.Trigger{
+					Extension: struct{}{},
+				},
+			},
+			Extension: []byte(`{"FastGasWei":1,"LinkNative":2,"FailureReason":3}`),
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("trigger extension as json for logTrigger gets decoded", func(t *testing.T) {
+		err := decodeExtensions(&ocr2keepers.CheckResult{
+			Payload: ocr2keepers.UpkeepPayload{
+				Upkeep: ocr2keepers.ConfiguredUpkeep{
+					ID: ocr2keepers.UpkeepIdentifier(genUpkeepID(logTrigger, "111").Bytes()),
+				},
+				Trigger: ocr2keepers.Trigger{
+					Extension: []byte(`{"TxHash": "abc", "LogIndex": 123}`),
+				},
+			},
+			Extension: struct{}{},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("trigger extension as invalid json returns an error for logTrigger", func(t *testing.T) {
+		err := decodeExtensions(&ocr2keepers.CheckResult{
+			Payload: ocr2keepers.UpkeepPayload{
+				Upkeep: ocr2keepers.ConfiguredUpkeep{
+					ID: ocr2keepers.UpkeepIdentifier(genUpkeepID(logTrigger, "111").Bytes()),
+				},
+				Trigger: ocr2keepers.Trigger{
+					Extension: []byte(`invalid`),
+				},
+			},
+			Extension: struct{}{},
+		})
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "invalid character 'i' looking for beginning of value: json encoded values do not match LogTriggerExtension struct: invalid")
+	})
+
+	t.Run("trigger extension for conditionTrigger requires no decoding", func(t *testing.T) {
+		err := decodeExtensions(&ocr2keepers.CheckResult{
+			Payload: ocr2keepers.UpkeepPayload{
+				Upkeep: ocr2keepers.ConfiguredUpkeep{
+					ID: ocr2keepers.UpkeepIdentifier(genUpkeepID(conditionTrigger, "111").Bytes()),
+				},
+				Trigger: ocr2keepers.Trigger{
+					Extension: []byte(""),
+				},
+			},
+			Extension: struct{}{},
+		})
+		assert.NoError(t, err)
+	})
+
+	t.Run("trigger extension for an unknown upkeep type returns an error", func(t *testing.T) {
+		err := decodeExtensions(&ocr2keepers.CheckResult{
+			Payload: ocr2keepers.UpkeepPayload{
+				Upkeep: ocr2keepers.ConfiguredUpkeep{
+					ID: ocr2keepers.UpkeepIdentifier(genUpkeepID(99, "111").Bytes()),
+				},
+				Trigger: ocr2keepers.Trigger{
+					Extension: []byte(""),
+				},
+			},
+			Extension: struct{}{},
+		})
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "unknown upkeep type")
+	})
+
+	t.Run("CheckResult extension as invalid json returns an error", func(t *testing.T) {
+		err := decodeExtensions(&ocr2keepers.CheckResult{
+			Payload: ocr2keepers.UpkeepPayload{
+				Trigger: ocr2keepers.Trigger{
+					Extension: struct{}{},
+				},
+			},
+			Extension: []byte(`invalid`),
+		})
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "invalid character 'i' looking for beginning of value: json encoded values do not match EVMAutomationResultExtension21 struct")
+	})
+
+	t.Run("unrecognized trigger extension returns an error", func(t *testing.T) {
+		err := decodeExtensions(&ocr2keepers.CheckResult{
+			Payload: ocr2keepers.UpkeepPayload{
+				Trigger: ocr2keepers.Trigger{
+					Extension: "invalid",
+				},
+			},
+		})
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "unrecognized trigger extension data")
+	})
+
+	t.Run("unrecognized CheckResult extension returns an error", func(t *testing.T) {
+		err := decodeExtensions(&ocr2keepers.CheckResult{
+			Payload: ocr2keepers.UpkeepPayload{
+				Trigger: ocr2keepers.Trigger{
+					Extension: logprovider.LogTriggerExtension{},
+				},
+			},
+			Extension: "invalid",
+		})
+		assert.Error(t, err)
+		assert.Equal(t, err.Error(), "unrecognized CheckResult extension data")
+	})
 }


### PR DESCRIPTION
In this PR, we're adding the decodeExtensions function from the keepers 2.1 alpha branch

The idea here is to reduce the number of changes in the alpha branch, and so this discrete piece of functionality is being merged into develop on its own, reducing the impact of the keepers 2.1 alpha branch
