### PR TITLE
Use headbyhash to backfill heads on the Head Tracker

### DIFF
--- a/common/headtracker/head_tracker.go
+++ b/common/headtracker/head_tracker.go
@@ -3,7 +3,6 @@ package headtracker
 import (
 	"context"
 	"fmt"
-	"math/big"
 	"sync"
 	"time"
 
@@ -334,7 +333,7 @@ func (ht *HeadTracker[HTH, S, ID, BLOCK_HASH]) backfill(ctx context.Context, hea
 			head = existingHead
 			continue
 		}
-		head, err = ht.fetchAndSaveHead(ctx, i)
+		head, err = ht.fetchAndSaveHead(ctx, i, head.GetParentHash())
 		fetched++
 		if ctx.Err() != nil {
 			ht.log.Debugw("context canceled, aborting backfill", "err", err, "ctx.Err", ctx.Err())
@@ -346,9 +345,9 @@ func (ht *HeadTracker[HTH, S, ID, BLOCK_HASH]) backfill(ctx context.Context, hea
 	return
 }
 
-func (ht *HeadTracker[HTH, S, ID, BLOCK_HASH]) fetchAndSaveHead(ctx context.Context, n int64) (HTH, error) {
-	ht.log.Debugw("Fetching head", "blockHeight", n)
-	head, err := ht.client.HeadByNumber(ctx, big.NewInt(n))
+func (ht *HeadTracker[HTH, S, ID, BLOCK_HASH]) fetchAndSaveHead(ctx context.Context, n int64, hash BLOCK_HASH) (HTH, error) {
+	ht.log.Debugw("Fetching head", "blockHeight", n, "blockHash", hash)
+	head, err := ht.client.HeadByHash(ctx, hash)
 	if err != nil {
 		return ht.getNilHead(), err
 	} else if !head.IsValid() {

--- a/common/headtracker/types/client.go
+++ b/common/headtracker/types/client.go
@@ -9,6 +9,7 @@ import (
 
 type Client[H types.Head[BLOCK_HASH], S types.Subscription, ID types.ID, BLOCK_HASH types.Hashable] interface {
 	HeadByNumber(ctx context.Context, number *big.Int) (head H, err error)
+	HeadByHash(ctx context.Context, hash BLOCK_HASH) (head H, err error)
 	// ConfiguredChainID returns the chain ID that the node is configured to connect to
 	ConfiguredChainID() (id ID)
 	// SubscribeNewHead is the method in which the client receives new Head.

--- a/core/chains/evm/headtracker/head_broadcaster_test.go
+++ b/core/chains/evm/headtracker/head_broadcaster_test.go
@@ -59,7 +59,8 @@ func TestHeadBroadcaster_Subscribe(t *testing.T) {
 			chchHeaders <- args.Get(1).(chan<- *evmtypes.Head)
 		}).
 		Return(sub, nil)
-	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(cltest.Head(1), nil)
+	ethClient.On("HeadByNumber", mock.Anything, mock.Anything).Return(cltest.Head(1), nil).Once()
+	ethClient.On("HeadByHash", mock.Anything, mock.Anything).Return(cltest.Head(1), nil)
 
 	sub.On("Unsubscribe").Return()
 	sub.On("Err").Return(nil)

--- a/core/internal/features/features_test.go
+++ b/core/internal/features/features_test.go
@@ -1374,6 +1374,11 @@ func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 	ethClient.On("ConfiguredChainID", mock.Anything).Return(cfg.DefaultChainID(), nil)
 	ethClient.On("BalanceAt", mock.Anything, mock.Anything, mock.Anything).Maybe().Return(oneETH.ToInt(), nil)
 
+	// HeadTracker backfill
+	ethClient.On("HeadByHash", mock.Anything, h40.Hash).Return(&h40, nil).Maybe()
+	ethClient.On("HeadByHash", mock.Anything, h41.Hash).Return(&h41, nil).Maybe()
+	ethClient.On("HeadByHash", mock.Anything, h42.Hash).Return(&h42, nil).Maybe()
+
 	require.NoError(t, cc.Start(testutils.Context(t)))
 	var newHeads evmtest.RawSub[*evmtypes.Head]
 	select {
@@ -1398,12 +1403,10 @@ func TestIntegration_BlockHistoryEstimator(t *testing.T) {
 		elems[0].Result = &b43
 	})
 
-	// HeadTracker backfill
-	ethClient.On("HeadByNumber", mock.Anything, big.NewInt(42)).Return(&h42, nil)
-	ethClient.On("HeadByNumber", mock.Anything, big.NewInt(41)).Return(&h41, nil)
-
 	// Simulate one new head and check the gas price got updated
-	newHeads.TrySend(cltest.Head(43))
+	h43 := cltest.Head(43)
+	h43.ParentHash = h42.Hash
+	newHeads.TrySend(h43)
 
 	gomega.NewWithT(t).Eventually(func() string {
 		gasPrice, _, err := estimator.GetFee(testutils.Context(t), nil, 500000, maxGasPrice)


### PR DESCRIPTION
During backfill, Head Tracker uses HeadByNumber to fetch missing blocks. This doesn’t protect against a potential reorg at the time of the backfill. We need to switch to HeadByHash to ensure the block requested belongs to the latest canonical chain. In case it doesn’t, it means we backfill the wrong fork and we should exit.