### PR TITLE
S4 uses prefixed signed Eth messages

### DIFF
--- a/core/services/s4/envelope.go
+++ b/core/services/s4/envelope.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 // Envelope represents a JSON object that is signed for address verification.
@@ -42,8 +42,7 @@ func (e Envelope) Sign(privateKey *ecdsa.PrivateKey) (signature []byte, err erro
 	if err != nil {
 		return nil, err
 	}
-	hash := crypto.Keccak256Hash(js)
-	return crypto.Sign(hash[:], privateKey)
+	return utils.GenerateEthSignature(privateKey, js)
 }
 
 // GetSignerAddress verifies the signature and returns the signing address.
@@ -55,12 +54,7 @@ func (e Envelope) GetSignerAddress(signature []byte) (address common.Address, er
 	if err != nil {
 		return common.Address{}, err
 	}
-	hash := crypto.Keccak256Hash(js)
-	sigPublicKey, err := crypto.SigToPub(hash[:], signature)
-	if err != nil {
-		return common.Address{}, err
-	}
-	return crypto.PubkeyToAddress(*sigPublicKey), nil
+	return utils.GetSignersEthAddress(js, signature)
 }
 
 func (e Envelope) ToJson() ([]byte, error) {

--- a/core/utils/eth_signatures.go
+++ b/core/utils/eth_signatures.go
@@ -1,0 +1,47 @@
+package utils
+
+import (
+	"crypto/ecdsa"
+	"fmt"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/pkg/errors"
+)
+
+const EthSignedMessagePrefix = "\x19Ethereum Signed Message:\n"
+
+func GetSignersEthAddress(msg []byte, sig []byte) (recoveredAddr common.Address, err error) {
+	if len(sig) != 65 {
+		return recoveredAddr, errors.New("invalid signature: signature length must be 65 bytes")
+	}
+
+	// Adjust the V component of the signature in case it uses 27 or 28 instead of 0 or 1
+	if sig[64] == 27 || sig[64] == 28 {
+		sig[64] -= 27
+	}
+	if sig[64] != 0 && sig[64] != 1 {
+		return recoveredAddr, errors.New("invalid signature: invalid V component")
+	}
+
+	prefixedMsg := fmt.Sprintf("%s%d%s", EthSignedMessagePrefix, len(msg), msg)
+	hash := crypto.Keccak256Hash([]byte(prefixedMsg))
+
+	sigPublicKey, err := crypto.SigToPub(hash[:], sig)
+	if err != nil {
+		return recoveredAddr, err
+	}
+
+	recoveredAddr = crypto.PubkeyToAddress(*sigPublicKey)
+	return recoveredAddr, nil
+}
+
+func GenerateEthPrefixedMsgHash(msg []byte) (hash common.Hash) {
+	prefixedMsg := fmt.Sprintf("%s%d%s", EthSignedMessagePrefix, len(msg), msg)
+	return crypto.Keccak256Hash([]byte(prefixedMsg))
+}
+
+func GenerateEthSignature(privateKey *ecdsa.PrivateKey, msg []byte) (signature []byte, err error) {
+	hash := GenerateEthPrefixedMsgHash(msg)
+	return crypto.Sign(hash[:], privateKey)
+}

--- a/core/utils/eth_signatures_test.go
+++ b/core/utils/eth_signatures_test.go
@@ -1,0 +1,53 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetSignersEthAddress_Success(t *testing.T) {
+	privateKey, err := crypto.GenerateKey()
+	require.NoError(t, err)
+	address := crypto.PubkeyToAddress(privateKey.PublicKey)
+
+	msg := []byte("test message")
+	sig, err := GenerateEthSignature(privateKey, msg)
+	assert.NoError(t, err)
+
+	recoveredAddress, err := GetSignersEthAddress(msg, sig)
+	assert.NoError(t, err)
+	assert.Equal(t, address, recoveredAddress)
+}
+
+func TestGetSignersEthAddress_InvalidSignatureLength(t *testing.T) {
+	msg := []byte("test message")
+	sig := []byte("invalid signature length")
+	_, err := GetSignersEthAddress(msg, sig)
+	assert.EqualError(t, err, "invalid signature: signature length must be 65 bytes")
+}
+
+func TestGenerateEthPrefixedMsgHash(t *testing.T) {
+	msg := []byte("test message")
+	expectedPrefix := "\x19Ethereum Signed Message:\n"
+	expectedHash := crypto.Keccak256Hash([]byte(expectedPrefix + "12" + string(msg)))
+
+	hash := GenerateEthPrefixedMsgHash(msg)
+	assert.Equal(t, expectedHash, hash)
+}
+
+func TestGenerateEthSignature(t *testing.T) {
+	privateKey, err := crypto.GenerateKey()
+	assert.NoError(t, err)
+
+	msg := []byte("test message")
+	signature, err := GenerateEthSignature(privateKey, msg)
+	assert.NoError(t, err)
+	assert.Len(t, signature, 65)
+
+	recoveredPub, err := crypto.SigToPub(GenerateEthPrefixedMsgHash(msg).Bytes(), signature)
+	assert.NoError(t, err)
+	assert.Equal(t, privateKey.PublicKey, *recoveredPub)
+}


### PR DESCRIPTION
- Added Eth prefixed signature generation and verification util functions
- Use standard Eth message prefix for signed S4 requests