### PR TITLE
[TT-486] Split packages attempt 2 to only run packages that have tests

### DIFF
--- a/.github/actions/split-tests/src/handlers/golang.mts
+++ b/.github/actions/split-tests/src/handlers/golang.mts
@@ -19,11 +19,14 @@ export function getPackageList(
 ): GetGoPackagesReturn {
   const { numOfSplits } = config;
   const rawPackages = execSync(
-    "go list -json ./... | jq -s '[.[] | {ImportPath, TestGoFiles}]'",
+    "go list -json ./... | jq -s '[.[] | {ImportPath, TestGoFiles, XTestGoFiles}]'",
     { encoding: "utf8" }
   );
   const packages: GoPackageData[] = JSON.parse(rawPackages.trimEnd());
-  const packagePaths = packages.map((item) => item.ImportPath);
+  const filteredData = packages.filter(
+    (item) => (item.TestGoFiles && item.TestGoFiles.length > 0) || (item.XTestGoFiles && item.XTestGoFiles.length > 0)
+  );
+  const packagePaths = filteredData.map((item) => item.ImportPath);
   return handleSplit(packagePaths, numOfSplits);
 }
 

--- a/.github/actions/split-tests/src/types.mts
+++ b/.github/actions/split-tests/src/types.mts
@@ -103,5 +103,10 @@ export interface GoPackageData {
    * The list of go files asociated with the package
    */
   TestGoFiles: string[] | undefined;
+  /**
+   * The list of go files not associated with a specific package
+   * Things like integration tests
+   */
+  XTestGoFiles: string[] | undefined;
   // there are many other variables in the data but they are not needed yet
 }


### PR DESCRIPTION
This time includes packages that are test only packages and not associated to another package.
Verified matching 6949 tests ran before changes and after changes.