### PR TITLE
Fix flaky integration test for log provider

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -79,6 +79,7 @@ require (
 	github.com/smartcontractkit/wsrpc v0.7.2
 	github.com/spf13/cast v1.5.1
 	github.com/stretchr/testify v1.8.4
+	github.com/test-go/testify v1.1.4
 	github.com/theodesp/go-heaps v0.0.0-20190520121037-88e35354fe0a
 	github.com/tidwall/gjson v1.14.4
 	github.com/ugorji/go/codec v1.2.11


### PR DESCRIPTION
The backfill integration test was relying on concurrency and timers but had inconsistent results when run on the CI environment, likely to do resource consumption. The solution was to add a new exposed function to call necessary processes directly in the test and not require running multiple processes. This reduced the test time from 12s to 7s and should be less flaky.