### PR TITLE
Fix RequestRandomWords ABI

### DIFF
--- a/core/scripts/vrfv2plus/testnet/super_scripts.go
+++ b/core/scripts/vrfv2plus/testnet/super_scripts.go
@@ -19,7 +19,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/link_token_interface"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/vrf_coordinator_v2plus"
 	"github.com/smartcontractkit/chainlink/v2/core/services/signatures/secp256k1"
-	v2 "github.com/smartcontractkit/chainlink/v2/core/services/vrf/v2"
 )
 
 const formattedVRFJob = `
@@ -38,7 +37,7 @@ pollPeriod = "5s"
 requestTimeout = "24h"
 observationSource = """
 decode_log              [type=ethabidecodelog
-                         abi="%s"
+                         abi="RandomWordsRequested(bytes32 indexed keyHash,uint256 requestId,uint256 preSeed,uint256 indexed subId,uint16 minimumRequestConfirmations,uint32 callbackGasLimit,uint32 numWords,bytes extraArgs,address indexed sender)"
                          data="$(jobRun.logData)"
                          topics="$(jobRun.logTopics)"]
 generate_proof          [type=vrfv2plus
@@ -206,7 +205,6 @@ func deployUniverse(e helpers.Environment) {
 		compressedPkHex,
 		e.ChainID,
 		*registerKeyOracleAddress,
-		v2.RandomWordsRequestedV2PlusABI,
 		coordinatorAddress,
 		coordinatorAddress,
 		coordinatorAddress,

--- a/core/services/vrf/v2/listener_v2.go
+++ b/core/services/vrf/v2/listener_v2.go
@@ -54,9 +54,6 @@ var (
 	batchCoordinatorV2ABI                    = evmtypes.MustGetABI(batch_vrf_coordinator_v2.BatchVRFCoordinatorV2ABI)
 	batchCoordinatorV2PlusABI                = evmtypes.MustGetABI(batch_vrf_coordinator_v2plus.BatchVRFCoordinatorV2PlusABI)
 	vrfOwnerABI                              = evmtypes.MustGetABI(vrf_owner.VRFOwnerMetaData.ABI)
-	// RandomWordsRequestedV2PlusABI is the ABI of the RandomWordsRequested event
-	// for V2Plus.
-	RandomWordsRequestedV2PlusABI = coordinatorV2PlusABI.Events["RandomWordsRequested"].Sig
 )
 
 const (


### PR DESCRIPTION
## Summary

- ABI generated does not seem to be correct
- Hardcoding the ABI in the deploy-universe script to unblock V2+

## Test Plan

### Before

```
eligibleSubReqs=1 err=bad ABI specification: "RandomWordsRequested(bytes32 indexed keyHash,uint256 requestId,uint256 preSeed,uint256 indexed subId,uint16 minimumR
equestConfirmations,uint32 callbackGasLimit,uint32 numWords,address indexed sender)": bad input for task; input task errored; data: value at key 'output' is a *errors.errorString, not a map or slice: keypath not found; task inputs: too many errors errVerbose=the following errors occurred:
 -  bad ABI specification: "RandomWordsRequested(bytes32 indexed keyHash,uint256 requestId,uint256 preSeed,uint256 indexed subId,uint16 minimumRequestConfirmations,uint3
    2 callbackGasLimit,uint32 numWords,address indexed sender)": bad input for task
```

### After 

```
$ go run ./vrfv2plus/testnet deploy-universe --subscription-balance=3000000000000000000 --uncompressed-pub-key=$PUB_KEY --oracle-address=$ORACLE_ADDRESS

$ go run ./vrfv2plus/testnet eoa-request --consumer-address 0xd0A1f12572781B4C5331949DC27BD6926A2Fced4 --sub-id 88134295363900806374487112880097654129552562744770644559895018168429428983092 --key-hash 0xe2045f34bea3ebc5aca2b725327ddf20fb4e57c0b3047c27c6aad22dc3507154
TX https://testnet.snowtrace.io/tx/0x2a19caeb8b16e5275b7dd4293af636255137a5e3beb8fad68351b02d15fe73fa
Receipt blocknumber: 24904459

$ go run ./vrfv2plus/testnet eoa-read --consumer=0xd0A1f12572781B4C5331949DC27BD6926A2Fced4
request id: 51379259510216157401592618807287799180954176422224185812170000299502717377899 1st random word: 4052519613597909375510603069034478064375144075489859794594497965
0300827244195
```