### PR TITLE
[TT-519] Test Matrix Cache Issue Fix

### DIFF
--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -4,6 +4,12 @@ inputs:
   only-modules:
     description: Set to 'true' to only cache modules
     default: 'false'
+  cache-go-modules:
+    description: |
+      Option to cache go modules
+      In matrix jobs the caching will fail in all but the first one to complete and
+      in doing so it will waste time in the pipeline
+    default: 'true'
   cache-version: 
     description: Set this to cache bust
     default: "1"
@@ -30,6 +36,7 @@ runs:
           echo "gobuildcache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
+        if: ${{ inputs.cache-go-modules }}
         name: Cache Go Modules
         with:
           path: |

--- a/.github/actions/setup-go/action.yml
+++ b/.github/actions/setup-go/action.yml
@@ -36,7 +36,7 @@ runs:
           echo "gobuildcache=$(go env GOCACHE)" >> $GITHUB_OUTPUT
 
       - uses: actions/cache@v3
-        if: ${{ inputs.cache-go-modules }}
+        if: ${{ inputs.cache-go-modules == 'true' }}
         name: Cache Go Modules
         with:
           path: |

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -153,6 +153,8 @@ jobs:
           prod: "true"
       - name: Setup Go
         uses: ./.github/actions/setup-go
+        with:
+          cache-go-modules: ${{ matrix.split.id == '1' }}
       - name: Setup Solana
         uses: ./.github/actions/setup-solana
       - name: Setup wasmd

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -154,7 +154,7 @@ jobs:
       - name: Setup Go
         uses: ./.github/actions/setup-go
         with:
-          cache-go-modules: ${{ matrix.split.id == '1' }}
+          cache-go-modules: ${{ contains(matrix.split.id, '1/') }}
       - name: Setup Solana
         uses: ./.github/actions/setup-solana
       - name: Setup wasmd

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -191,14 +191,16 @@ jobs:
             nodes: 1
             os: ubuntu-latest
             pyroscope_env: ci-smoke-vrf-evm-simulated
+            cache: 'true'
           - name: vrfv2
             nodes: 1
             os: ubuntu-latest
             pyroscope_env: ci-smoke-vrf2-evm-simulated
-          - name: ocr2vrf
-            nodes: 2
-            os: ubuntu-latest
-            pyroscope_env: ci-smoke-ocr2vrf-evm-simulated
+          # temporarily disabled
+          # - name: ocr2vrf
+          #   nodes: 2
+          #   os: ubuntu-latest
+          #   pyroscope_env: ci-smoke-ocr2vrf-evm-simulated
     runs-on: ${{ matrix.product.os }}
     name: ETH Smoke Tests ${{ matrix.product.name }}
     steps:
@@ -209,7 +211,7 @@ jobs:
       ## Run this step when changes that require tests to be run are made
       - name: Run Tests
         if: needs.changes.outputs.src == 'true'
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@v2.2.3
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@v2.2.6
         env:
           TESTCONTAINERS_RYUK_DISABLED: true
           PYROSCOPE_SERVER: ${{ matrix.product.pyroscope_env == '' && '' || !startsWith(github.ref, 'refs/tags/') && '' || secrets.QA_PYROSCOPE_INSTANCE }} # Avoid sending blank envs https://github.com/orgs/community/discussions/25725
@@ -225,6 +227,7 @@ jobs:
           publish_check_name: EVM Smoke Test Results ${{ matrix.product.name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           go_mod_path: ./integration-tests/go.mod
+          cache_go_vendors: ${{ matrix.product.cache }}
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
@@ -232,7 +235,7 @@ jobs:
       ## Run this step when changes that do not need the test to run are made
       - name: Run Setup
         if: needs.changes.outputs.src == 'false'
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@ad22fbd6f4d108b82aaf49b527bcf40f32babea8 # v2.2.1
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@v2.2.6
         with:
           test_download_vendor_packages_command: cd ./integration-tests && go mod download
           go_mod_path: ./integration-tests/go.mod


### PR DESCRIPTION
We have an issue with matrix jobs that use the cache for go modules. When a new cache is needed to be built all the jobs in the matrix attempt to do so. This limits it to only one of the jobs in the matrixes for the core-ci and integration-tests.