### PR TITLE
core/scripts/chaincli/handler: fix CSAKeyInfo.Equals

### DIFF
--- a/core/scripts/chaincli/handler/scrape_node_config.go
+++ b/core/scripts/chaincli/handler/scrape_node_config.go
@@ -27,7 +27,7 @@ type CSAKeyInfo struct {
 }
 
 func (ci *CSAKeyInfo) Equals(ci2 *CSAKeyInfo) bool {
-	return ci.PublicKey == ci2.PublicKey && ci.NodeAddress == ci.NodeAddress
+	return ci.PublicKey == ci2.PublicKey && ci.NodeAddress == ci2.NodeAddress
 }
 
 type NodeInfo struct {


### PR DESCRIPTION
Sonar flagged this bug based on the self comparison.