### PR TITLE
update getBlockHash to not use rpc client

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/registry.go
@@ -986,12 +986,12 @@ func (r *EvmRegistry) verifyCheckBlock(ctx context.Context, checkBlock, upkeepId
 	h, ok = r.bs.queryBlocksMap(checkBlock.Int64())
 	if !ok {
 		r.lggr.Warnf("check block %s does not exist in block subscriber for upkeepId %s, querying eth client", checkBlock, upkeepId)
-		b, err := r.client.BlockByNumber(ctx, checkBlock)
+		hash, err := r.getBlockHash(checkBlock)
 		if err != nil {
 			r.lggr.Warnf("failed to query block %s: %s", checkBlock, err.Error())
 			return RpcFlakyFailure, true
 		}
-		h = b.Hash().Hex()
+		h = hash.Hex()
 	}
 	if checkHash.Hex() != h {
 		r.lggr.Warnf("check block %s hash do not match. %s from block subscriber vs %s from trigger for upkeepId %s", checkBlock, h, checkHash.Hex(), upkeepId)

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/registry.go
@@ -936,12 +936,15 @@ func (r *EvmRegistry) fetchTriggerConfig(id *big.Int) ([]byte, error) {
 }
 
 func (r *EvmRegistry) getBlockHash(blockNumber *big.Int) (common.Hash, error) {
-	block, err := r.client.BlockByNumber(r.ctx, blockNumber)
+	blocks, err := r.poller.GetBlocksRange(r.ctx, []uint64{blockNumber.Uint64()})
 	if err != nil {
 		return [32]byte{}, err
 	}
+	if len(blocks) == 0 {
+		return [32]byte{}, fmt.Errorf("could not find block %d in log poller", blockNumber.Uint64())
+	}
 
-	return block.Hash(), nil
+	return blocks[0].BlockHash, nil
 }
 
 func (r *EvmRegistry) getTxBlock(txHash common.Hash) (*big.Int, common.Hash, error) {

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/registry_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/registry_test.go
@@ -447,9 +447,9 @@ func TestRegistry_VerifyCheckBlock(t *testing.T) {
 				bs:   bs,
 			}
 			if tc.makeEthCall {
-				client := new(evmClientMocks.Client)
-				client.On("BlockByNumber", mock.Anything, tc.checkBlock).Return(nil, fmt.Errorf("error"))
-				e.client = client
+				poller := new(mocks.LogPoller)
+				poller.On("GetBlocksRange", mock.Anything, mock.Anything).Return(nil, fmt.Errorf("error"))
+				e.poller = poller
 			}
 
 			state, retryable := e.verifyCheckBlock(context.Background(), tc.checkBlock, tc.upkeepId, tc.checkHash)


### PR DESCRIPTION
This is throwing `transaction type not supported` error on arbitrum. Using log poller block instead of rpc client which is more efficient anyway