### PR TITLE
fix/release-2.4.0-re-enabling-simple-passwords-restriction

### DIFF
--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -148,6 +148,8 @@ func validateDBURL(dbURI url.URL) error {
 func (d *DatabaseSecrets) ValidateConfig() (err error) {
 	if d.URL == nil || (*url.URL)(d.URL).String() == "" {
 		err = multierr.Append(err, configutils.ErrEmpty{Name: "URL", Msg: "must be provided and non-empty"})
+	} else if *d.AllowSimplePasswords && build.IsProd() {
+		err = multierr.Append(err, configutils.ErrInvalid{Name: "AllowSimplePasswords", Value: true, Msg: "insecure configs are not allowed on secure builds"})
 	} else if !*d.AllowSimplePasswords {
 		if verr := validateDBURL((url.URL)(*d.URL)); verr != nil {
 			err = multierr.Append(err, configutils.ErrInvalid{Name: "URL", Value: "*****", Msg: dbURLPasswordComplexity(verr)})

--- a/core/config/toml/types_test.go
+++ b/core/config/toml/types_test.go
@@ -2,10 +2,13 @@ package toml
 
 import (
 	"fmt"
+	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/smartcontractkit/chainlink/v2/core/build"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
@@ -93,6 +96,80 @@ func Test_validateDBURL(t *testing.T) {
 				assert.Nil(t, err)
 			} else {
 				assert.EqualError(t, err, test.wantErr)
+			}
+		})
+	}
+}
+
+func TestValidateConfig(t *testing.T) {
+	validUrl := models.URL(url.URL{Scheme: "https", Host: "localhost"})
+	validSecretURL := *models.NewSecretURL(&validUrl)
+
+	invalidEmptyUrl := models.URL(url.URL{})
+	invalidEmptySecretURL := *models.NewSecretURL(&invalidEmptyUrl)
+
+	invalidBackupURL := models.URL(url.URL{Scheme: "http", Host: "localhost"})
+	invalidBackupSecretURL := *models.NewSecretURL(&invalidBackupURL)
+
+	tests := []struct {
+		name                string
+		input               *DatabaseSecrets
+		skip                bool
+		expectedErrContains []string
+	}{
+		{
+			name: "Nil URL",
+			input: &DatabaseSecrets{
+				URL: nil,
+			},
+			expectedErrContains: []string{"URL: empty: must be provided and non-empty"},
+		},
+		{
+			name: "Empty URL",
+			input: &DatabaseSecrets{
+				URL: &invalidEmptySecretURL,
+			},
+			expectedErrContains: []string{"URL: empty: must be provided and non-empty"},
+		},
+		{
+			name: "Insecure Password in Production",
+			input: &DatabaseSecrets{
+				URL:                  &validSecretURL,
+				AllowSimplePasswords: &[]bool{true}[0],
+			},
+			skip:                !build.IsProd(),
+			expectedErrContains: []string{"insecure configs are not allowed on secure builds"},
+		},
+		{
+			name: "Invalid Backup URL with Simple Passwords Not Allowed",
+			input: &DatabaseSecrets{
+				URL:                  &validSecretURL,
+				BackupURL:            &invalidBackupSecretURL,
+				AllowSimplePasswords: &[]bool{false}[0],
+			},
+			expectedErrContains: []string{"missing or insufficiently complex password"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// needed while -tags test is supported
+			if tt.skip {
+				t.SkipNow()
+			}
+			err := tt.input.ValidateConfig()
+			if err == nil && len(tt.expectedErrContains) > 0 {
+				t.Errorf("expected errors but got none")
+				return
+			}
+
+			if err != nil {
+				errStr := err.Error()
+				for _, expectedErrSubStr := range tt.expectedErrContains {
+					if !strings.Contains(errStr, expectedErrSubStr) {
+						t.Errorf("expected error to contain substring %q but got %v", expectedErrSubStr, errStr)
+					}
+				}
 			}
 		})
 	}

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,7 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [dev]
 
-...
+### Changed
+- Simple passwords are no longer allowed for production builds
 
 ## 2.4.0 - UNRELEASED
 ### Fixed


### PR DESCRIPTION
Cherry-picks `206df85a3d32c3a986e91638e01939d171c7259c`, which is needed for the intended functionality in `release/2.4.0`

cc @snehaagni 