### PR TITLE
bumg golangci-lint 1.54.2

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -80,7 +80,7 @@ jobs:
         if: needs.init.outputs.on_trigger_lint == 'true'
         uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
         with:
-          version: v1.53.3
+          version: v1.54.2
           only-new-issues: ${{ github.event.schedule == '' }} # show only new issues, unless it's a scheduled run
           args: --out-format checkstyle:golangci-lint-report.xml
       - name: Print lint report artifact

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,5 +4,5 @@ nodejs 16.16.0
 postgres 13.3
 helm 3.10.3
 zig 0.10.1
-golangci-lint 1.53.3
+golangci-lint 1.54.2
 shellspec 0.28.1

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -146,7 +146,7 @@ config-docs: ## Generate core node configuration documentation
 .PHONY: golangci-lint
 golangci-lint: ## Run golangci-lint for all issues.
 	[ -d "./golangci-lint" ] || mkdir ./golangci-lint && \
-	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.53.2 golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 > ./golangci-lint/$(shell date +%Y-%m-%d_%H:%M:%S).txt
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.54.2 golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 > ./golangci-lint/$(shell date +%Y-%m-%d_%H:%M:%S).txt
 
 
 GORELEASER_CONFIG ?= .goreleaser.yaml


### PR DESCRIPTION
~This upgrade is producing a lot of false positives from `(typecheck)` - we may have to wait for a fix.~
Resolved itself - perhaps via dependency bump.