### PR TITLE
WIP Fix LogUpkeep test

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/integration_21_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/integration_21_test.go
@@ -165,7 +165,7 @@ func TestIntegration_KeeperPluginConditionalUpkeep(t *testing.T) {
 }
 
 func TestIntegration_KeeperPluginLogUpkeep(t *testing.T) {
-	t.Skip() // TODO: fix test (fails in CI)
+	//t.Skip() // TODO: fix test (fails in CI)
 	g := gomega.NewWithT(t)
 
 	// setup blockchain
@@ -200,7 +200,19 @@ func TestIntegration_KeeperPluginLogUpkeep(t *testing.T) {
 	nodes := setupNodes(t, nodeKeys, registry, backend, steve)
 	// wait for nodes to start
 	// TODO: find a better way to do this
-	<-time.After(time.Second * 10)
+	gBlock := backend.Blockchain().CurrentBlock()
+
+	bump := 0
+	for {
+		cBlock := backend.Blockchain().CurrentBlock()
+		if cBlock.Number.Int64() > gBlock.Number.Int64() {
+			gBlock = cBlock
+			bump++
+		}
+		if bump == 10 {
+			break
+		}
+	}
 
 	upkeeps := 1
 
@@ -229,7 +241,7 @@ func TestIntegration_KeeperPluginLogUpkeep(t *testing.T) {
 	runs := checkPipelineRuns(t, nodes, 1*len(nodes)) // TODO: TBD
 
 	t.Run("recover logs", func(t *testing.T) {
-		t.Skip() // TODO: fix test (fails in CI)
+		//t.Skip() // TODO: fix test (fails in CI)
 		addr, contract := addrs[0], contracts[0]
 		upkeepID := registerUpkeep(t, registry, addr, carrol, steve, backend)
 		backend.Commit()

--- a/core/services/ocr2/plugins/ocr2keeper/integration_21_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/integration_21_test.go
@@ -200,19 +200,7 @@ func TestIntegration_KeeperPluginLogUpkeep(t *testing.T) {
 	nodes := setupNodes(t, nodeKeys, registry, backend, steve)
 	// wait for nodes to start
 	// TODO: find a better way to do this
-	gBlock := backend.Blockchain().CurrentBlock()
-
-	bump := 0
-	for {
-		cBlock := backend.Blockchain().CurrentBlock()
-		if cBlock.Number.Int64() > gBlock.Number.Int64() {
-			gBlock = cBlock
-			bump++
-		}
-		if bump == 10 {
-			break
-		}
-	}
+	blockWait(10, backend)
 
 	upkeeps := 1
 
@@ -266,6 +254,22 @@ func TestIntegration_KeeperPluginLogUpkeep(t *testing.T) {
 		waitPipelineRuns(t, nodes, expectedPostRecover, testutils.WaitTimeout(t), cltest.DBPollingInterval)
 
 	})
+}
+
+func blockWait(blockCount int, backend *backends.SimulatedBackend) {
+	currentBlock := backend.Blockchain().CurrentBlock()
+
+	count := 0
+	for {
+		nextBlock := backend.Blockchain().CurrentBlock()
+		if nextBlock.Number.Int64() > currentBlock.Number.Int64() {
+			currentBlock = nextBlock
+			count++
+		}
+		if count == blockCount {
+			break
+		}
+	}
 }
 
 func waitPipelineRuns(t *testing.T, nodes []Node, n int, timeout, interval time.Duration) {


### PR DESCRIPTION
This PR attempts to fix the flaky failures of the LogUpkeep test. Instead of doing a sleep for 10 seconds, the test now attempts to wait for 10 blocks before proceeding. I've tried running this locally a bunch of times, and it always passes, but I'm not convinced that it won't flake in CI again. Regarding the block wait; I'm not sure if there's a cleaner way to identify when it's safe to proceed?