### PR TITLE
Add More E2E Test Dependencies To Cache

### DIFF
--- a/.github/workflows/automation-benchmark-tests.yml
+++ b/.github/workflows/automation-benchmark-tests.yml
@@ -107,7 +107,7 @@ jobs:
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ACCOUNT_NUMBER: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
       - name: Run Tests
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35 # v2.2.9
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         env:
           DETACH_RUNNER: true
           TEST_SUITE: benchmark

--- a/.github/workflows/automation-ondemand-tests.yml
+++ b/.github/workflows/automation-ondemand-tests.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Check if image exists
         if: inputs.chainlinkImage == ''
         id: check-image
-        uses: smartcontractkit/chainlink-github-actions/docker/image-exists@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35 #v2.2.9
+        uses: smartcontractkit/chainlink-github-actions/docker/image-exists@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
           repository: chainlink
           tag: ${{ github.sha }}${{ matrix.image.tag-suffix }}
@@ -57,7 +57,7 @@ jobs:
           AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
       - name: Build Image
         if: steps.check-image.outputs.exists == 'false' && inputs.chainlinkImage == ''
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35 # v2.2.9
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
           cl_repo: smartcontractkit/chainlink
           cl_ref: ${{ github.sha }}
@@ -160,7 +160,7 @@ jobs:
             echo "version=develop" >>$GITHUB_OUTPUT
           fi
       - name: Run Tests
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35 #v2.2.9
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         env:
           PYROSCOPE_SERVER: ${{ matrix.tests.pyroscope_env == '' && '' || !startsWith(github.ref, 'refs/tags/') && '' || secrets.QA_PYROSCOPE_INSTANCE }} # Avoid sending blank envs https://github.com/orgs/community/discussions/25725
           PYROSCOPE_ENVIRONMENT: ${{ matrix.tests.pyroscope_env }}

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -180,7 +180,7 @@ jobs:
         run: ./tools/bin/${{ matrix.cmd }} "${{ matrix.split.pkgs }}"
       - name: Print Filtered Test Results
         if: failure()
-        uses: smartcontractkit/chainlink-github-actions/go/go-test-results-parsing@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35 # v2.2.9
+        uses: smartcontractkit/chainlink-github-actions/go/go-test-results-parsing@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
           results-file: ./output.txt
           output-file: ./output-short.txt

--- a/.github/workflows/generic-test-runner.yml
+++ b/.github/workflows/generic-test-runner.yml
@@ -53,7 +53,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Check if image exists
         id: check-image
-        uses: smartcontractkit/chainlink-github-actions/docker/image-exists@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35 #v2.2.9
+        uses: smartcontractkit/chainlink-github-actions/docker/image-exists@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
           repository: chainlink
           tag: ${{ github.sha }}${{ matrix.image.tag-suffix }}
@@ -61,7 +61,7 @@ jobs:
           AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
       - name: Build Image
         if: steps.check-image.outputs.exists == 'false'
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35 # v2.2.9
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
           cl_repo: smartcontractkit/chainlink
           cl_ref: ${{ github.sha }}
@@ -126,7 +126,7 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Run Tests
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35 # v2.2.9
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
           test_command_to_run: make test_need_operator_assets && cd ./integration-tests && go test -timeout 1h -count=1 ./${{ github.event.inputs.directory }} -run ${{ github.event.inputs.test }} -v -args ${{ github.event.inputs.test-inputs }}
           test_download_vendor_packages_command: cd ./integration-tests && go mod download

--- a/.github/workflows/integration-chaos-tests.yml
+++ b/.github/workflows/integration-chaos-tests.yml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Check if image exists
         id: check-image
-        uses: smartcontractkit/chainlink-github-actions/docker/image-exists@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35 # v2.2.9
+        uses: smartcontractkit/chainlink-github-actions/docker/image-exists@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
           repository: chainlink
           tag: ${{ github.sha }}
@@ -38,7 +38,7 @@ jobs:
           AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
       - name: Build Image
         if: steps.check-image.outputs.exists == 'false'
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35 # v2.2.9
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
           cl_repo: smartcontractkit/chainlink
           cl_ref: ${{ github.sha }}
@@ -109,7 +109,7 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Run Tests
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35 # v2.2.9
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
           test_command_to_run: make test_need_operator_assets && cd integration-tests && go test -timeout 1h -count=1 -json -test.parallel 11 ./chaos 2>&1 | tee /tmp/gotest.log | gotestfmt
           test_download_vendor_packages_command: cd ./integration-tests && go mod download

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -21,6 +21,7 @@ env:
   TEST_SUITE: smoke
   TEST_ARGS: -test.timeout 12m
   INTERNAL_DOCKER_REPO: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com
+  MOD_CACHE_VERSION: 2
 
 jobs:
   changes:
@@ -174,7 +175,7 @@ jobs:
       ## Run this step when changes that require tests to be run are made
       - name: Run Tests
         if: needs.changes.outputs.src == 'true'
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         env:
           TESTCONTAINERS_RYUK_DISABLED: true
           PYROSCOPE_SERVER: ${{ matrix.product.pyroscope_env == '' && '' || !startsWith(github.ref, 'refs/tags/') && '' || secrets.QA_PYROSCOPE_INSTANCE }} # Avoid sending blank envs https://github.com/orgs/community/discussions/25725
@@ -190,7 +191,7 @@ jobs:
           publish_check_name: EVM Smoke Test Results ${{ matrix.product.name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           go_mod_path: ./integration-tests/go.mod
-          cache_key_id: core-e2e
+          cache_key_id: core-e2e-${{ env.MOD_CACHE_VERSION }}
           cache_restore_only: 'true'
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -199,11 +200,11 @@ jobs:
       ## Run this step when changes that do not need the test to run are made
       - name: Run Setup
         if: needs.changes.outputs.src == 'false'
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
           test_download_vendor_packages_command: cd ./integration-tests && go mod download
           go_mod_path: ./integration-tests/go.mod
-          cache_key_id: core-e2e
+          cache_key_id: core-e2e-${{ env.MOD_CACHE_VERSION }}
           cache_restore_only: 'true'
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -392,7 +393,7 @@ jobs:
       ## Run this step when changes that require tests to be run are made
       - name: Run Tests
         if: needs.changes.outputs.src == 'true'
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         env:
           PYROSCOPE_SERVER: ${{ matrix.product.pyroscope_env == '' && '' || !startsWith(github.ref, 'refs/tags/') && '' || secrets.QA_PYROSCOPE_INSTANCE }} # Avoid sending blank envs https://github.com/orgs/community/discussions/25725
           PYROSCOPE_ENVIRONMENT: ${{ matrix.product.pyroscope_env }}
@@ -407,7 +408,7 @@ jobs:
           publish_check_name: EVM Smoke Test Results ${{ matrix.product.name }}
           token: ${{ secrets.GITHUB_TOKEN }}
           go_mod_path: ./integration-tests/go.mod
-          cache_key_id: core-e2e
+          cache_key_id: core-e2e-${{ env.MOD_CACHE_VERSION }}
           cache_restore_only: 'true'
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -415,11 +416,11 @@ jobs:
       ## Run this step when changes that do not need the test to run are made
       - name: Run Setup
         if: needs.changes.outputs.src == 'false'
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-run-tests-environment@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
           test_download_vendor_packages_command: cd ./integration-tests && go mod download
           go_mod_path: ./integration-tests/go.mod
-          cache_key_id: core-e2e
+          cache_key_id: core-e2e-${{ env.MOD_CACHE_VERSION }}
           cache_restore_only: 'true'
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -469,7 +470,7 @@ jobs:
   eth-smoke-go-mod-cache:
     environment: integration
     needs: [eth-smoke-tests]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu20.04-16cores-64GB
     name: ETH Smoke Tests Go Mod Cache
     steps:
       - name: Checkout the repo
@@ -477,11 +478,15 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
       - name: Run Setup
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/setup-go@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
-          test_download_vendor_packages_command: cd ./integration-tests && go mod download
+          test_download_vendor_packages_command: |
+            cd ./integration-tests
+            go mod download
+            # force download of test dependencies
+            go test -run=NonExistentTest ./smoke/... || echo "ignore expected test failure"
           go_mod_path: ./integration-tests/go.mod
-          cache_key_id: core-e2e
+          cache_key_id: core-e2e-${{ env.MOD_CACHE_VERSION }}
           cache_restore_only: 'false'
 
   ### Migration tests
@@ -521,7 +526,7 @@ jobs:
         run: |
           echo "Running migration tests from version '${{ steps.get_latest_version.outputs.latest_version }}' to: '${{ github.sha }}'"
       - name: Run Migration Tests
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
           test_command_to_run: make test_need_operator_assets && cd ./integration-tests && go test -timeout 30m -count=1 -json ./migration 2>&1 | tee /tmp/gotest.log | gotestfmt
           test_download_vendor_packages_command: cd ./integration-tests && go mod download
@@ -531,6 +536,8 @@ jobs:
           publish_check_name: Node Migration Test Results
           token: ${{ secrets.GITHUB_TOKEN }}
           go_mod_path: ./integration-tests/go.mod
+          cache_key_id: core-e2e-${{ env.MOD_CACHE_VERSION }}
+          cache_restore_only: 'true'
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
@@ -758,7 +765,7 @@ jobs:
           ref: ${{ needs.get_solana_sha.outputs.sha }}
       - name: Run Tests
         if: needs.changes.outputs.src == 'true'
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
           test_command_to_run: export ENV_JOB_IMAGE=${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-solana-tests:${{ needs.get_solana_sha.outputs.sha }} && make test_smoke
           cl_repo: ${{ env.CHAINLINK_IMAGE }}
@@ -766,7 +773,7 @@ jobs:
           artifacts_location: /home/runner/work/chainlink-solana/chainlink-solana/integration-tests/logs
           publish_check_name: Solana Smoke Test Results
           go_mod_path: ./integration-tests/go.mod
-          cache_key_id: core-e2e
+          cache_key_id: core-solana-e2e-${{ env.MOD_CACHE_VERSION }}
           token: ${{ secrets.GITHUB_TOKEN }}
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
@@ -821,7 +828,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
       ## Only run OCR smoke test for now
       - name: Run Tests
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         env:
           PYROSCOPE_SERVER: ${{ secrets.QA_PYROSCOPE_INSTANCE }}
           PYROSCOPE_ENVIRONMENT: ci-smoke-ocr-evm-${{ matrix.testnet }} # TODO: Only for OCR for now
@@ -836,7 +843,7 @@ jobs:
           publish_check_name: ${{ matrix.testnet }} OCR Smoke Test Results
           token: ${{ secrets.GITHUB_TOKEN }}
           go_mod_path: ./integration-tests/go.mod
-          cache_key_id: core-e2e
+          cache_key_id: core-e2e-${{ env.MOD_CACHE_VERSION }}
           cache_restore_only: 'true'
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}

--- a/.github/workflows/on-demand-ocr-soak-test.yml
+++ b/.github/workflows/on-demand-ocr-soak-test.yml
@@ -121,7 +121,7 @@ jobs:
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ACCOUNT_NUMBER: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
       - name: Run Tests
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35 # v2.2.9
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         env:
           DETACH_RUNNER: true
           TEST_SUITE: soak

--- a/.github/workflows/performance-tests.yml
+++ b/.github/workflows/performance-tests.yml
@@ -57,7 +57,7 @@ jobs:
       - name: Checkout the repo
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
       - name: Run Tests
-        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@260e9b8a4c78d8c1fa6693a0e7144b40e41c7a35 # v2.2.9
+        uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@d8d8289ebe487dc995be45d00519def022643fa7 # v2.2.11
         with:
           test_command_to_run: cd integration-tests && go test -timeout 1h -count=1 -json -test.parallel 10 ./performance 2>&1 | tee /tmp/gotest.log | gotestfmt
           test_download_vendor_packages_command: make gomod


### PR DESCRIPTION
Some test dependencies don't get downloaded when `go mod download` is ran. Adding a run of a blank test gets us those extra dependencies.