### PR TITLE
Include shared folder in gethwrapper generation

### DIFF
--- a/core/gethwrappers/go_generate.go
+++ b/core/gethwrappers/go_generate.go
@@ -134,6 +134,9 @@ package gethwrappers
 // Mercury
 //go:generate go generate ./llo-feeds
 
+// Shared
+//go:generate go generate ./shared
+
 // Mocks that contain only events and functions to emit them
 // These contracts are used in testing Atlas flows. The contracts contain no logic, only events, structures, and functions to emit them.
 // The flow is as follows:


### PR DESCRIPTION
`make wrappers-all` runs `go generate ../core/gethwrappers/go_generate.go`

In `go_generate.go`, the new `shared` folder was not included, causing make wrappers-all to miss it.

After adding the link, `make wrappers-all` now generates wrappers under /shared.