### PR TITLE
Remove 0x prefix from scanned logs

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/upkeepstate/scanner.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/upkeepstate/scanner.go
@@ -2,11 +2,11 @@ package upkeepstate
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"io"
 
 	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/common/hexutil"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	iregistry21 "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/i_keeper_registry_master_wrapper_2_1"
@@ -80,7 +80,7 @@ func (s *performedEventsScanner) logsToWorkIDs(logs []logpoller.Log) []string {
 			s.lggr.Debugw("unexpected log topics", "topics", topics)
 			continue
 		}
-		workIDs = append(workIDs, hexutil.Encode(topics[1].Bytes())[2:]) // remove 0x prefix
+		workIDs = append(workIDs, hex.EncodeToString(topics[1].Bytes()))
 	}
 	return workIDs
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/upkeepstate/scanner.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/upkeepstate/scanner.go
@@ -80,7 +80,7 @@ func (s *performedEventsScanner) logsToWorkIDs(logs []logpoller.Log) []string {
 			s.lggr.Debugw("unexpected log topics", "topics", topics)
 			continue
 		}
-		workIDs = append(workIDs, hexutil.Encode(topics[1].Bytes()))
+		workIDs = append(workIDs, hexutil.Encode(topics[1].Bytes())[2:]) // remove 0x prefix
 	}
 	return workIDs
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/upkeepstate/scanner_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/upkeepstate/scanner_test.go
@@ -49,11 +49,11 @@ func TestPerformedEventsScanner(t *testing.T) {
 					Address:     registryAddr,
 					Topics: convertTopics([]common.Hash{
 						iregistry21.IKeeperRegistryMasterDedupKeyAdded{}.Topic(),
-						common.HexToHash("0x1111"),
+						common.HexToHash("0x290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563"),
 					}),
 				},
 			},
-			[]string{common.HexToHash("0x1111").Hex()},
+			[]string{"290decd9548b62a8d60345a988386fc84ba6bc95484008f6362f93160ef3e563"},
 			nil,
 			false,
 		},


### PR DESCRIPTION
Within workID generation here https://github.com/smartcontractkit/chainlink/blob/develop/core/services/ocr2/plugins/ocr2keeper/evm21/core/payload.go#L16-L23 we use hex.EncodeToString(hash[:]) which returns without 0x prefix .

However when scanning dedup key logs we were getting 0x prefix in work IDs