### PR TITLE
Sort blocks in descending order while dequeuing

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/buffer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/buffer.go
@@ -203,6 +203,7 @@ func (b *logEventBuffer) dequeueRange(start, end int64, upkeepLimit int) []fetch
 	blocksInRange := b.getBlocksInRange(int(start), int(end))
 	fetchedBlocks := make([]fetchedBlock, 0, len(blocksInRange))
 	for _, block := range blocksInRange {
+		// Create clone of the blocks as they get processed and update underlying b.blocks
 		fetchedBlocks = append(fetchedBlocks, block.Clone())
 	}
 

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/buffer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/buffer.go
@@ -237,10 +237,6 @@ func (b *logEventBuffer) dequeueRange(start, end int64, upkeepLimit int) []fetch
 		b.blocks[b.blockNumberIndex(block.blockNumber)] = block
 	}
 
-	sort.SliceStable(results, func(i, j int) bool {
-		return results[i].log.BlockNumber < results[j].log.BlockNumber
-	})
-
 	if len(results) > 0 {
 		b.lggr.Debugw("Dequeued logs", "results", len(results), "start", start, "end", end)
 	}

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/buffer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/buffer.go
@@ -50,6 +50,18 @@ func (b fetchedBlock) Has(id *big.Int, log logpoller.Log) (bool, int) {
 	return false, upkeepLogs
 }
 
+func (b fetchedBlock) Clone() fetchedBlock {
+	logs := make([]fetchedLog, len(b.logs))
+	copy(logs, b.logs)
+	visited := make([]fetchedLog, len(b.visited))
+	copy(visited, b.visited)
+	return fetchedBlock{
+		blockNumber: b.blockNumber,
+		logs:        logs,
+		visited:     visited,
+	}
+}
+
 // logEventBuffer is a circular/ring buffer of fetched logs.
 // Each entry in the buffer represents a block,
 // and holds the logs fetched for that block.
@@ -189,10 +201,20 @@ func (b *logEventBuffer) dequeueRange(start, end int64, upkeepLimit int) []fetch
 	defer b.lock.Unlock()
 
 	blocksInRange := b.getBlocksInRange(int(start), int(end))
+	fetchedBlocks := make([]fetchedBlock, 0, len(blocksInRange))
+	for _, block := range blocksInRange {
+		fetchedBlocks = append(fetchedBlocks, block.Clone())
+	}
+
+	// Sort the blocks in reverse order of block number so that latest logs
+	// are preferred while dequeueing.
+	sort.SliceStable(fetchedBlocks, func(i, j int) bool {
+		return fetchedBlocks[i].blockNumber > fetchedBlocks[j].blockNumber
+	})
 
 	logsCount := map[string]int{}
 	var results []fetchedLog
-	for _, block := range blocksInRange {
+	for _, block := range fetchedBlocks {
 		// double checking that we don't have any gaps in the range
 		if block.blockNumber < start || block.blockNumber > end {
 			continue
@@ -209,8 +231,8 @@ func (b *logEventBuffer) dequeueRange(start, end int64, upkeepLimit int) []fetch
 		if len(blockResults) == 0 {
 			continue
 		}
-		block.visited = append(block.visited, blockResults...)
 		results = append(results, blockResults...)
+		block.visited = append(block.visited, blockResults...)
 		block.logs = remainingLogs
 		b.blocks[b.blockNumberIndex(block.blockNumber)] = block
 	}

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/buffer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/buffer_test.go
@@ -303,7 +303,7 @@ func TestLogEventBuffer_EnqueueDequeue(t *testing.T) {
 		verifyBlockNumbers(t, results, 2, 3, 4, 4)
 	})
 
-	t.Run("dequeue with limits refers latest logs", func(t *testing.T) {
+	t.Run("dequeue with limits returns latest block logs", func(t *testing.T) {
 		buf := newLogEventBuffer(logger.TestLogger(t), 3, 5, 10)
 		require.Equal(t, buf.enqueue(big.NewInt(1),
 			logpoller.Log{BlockNumber: 1, TxHash: common.HexToHash("0x1"), LogIndex: 0},

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/buffer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/buffer_test.go
@@ -303,7 +303,7 @@ func TestLogEventBuffer_EnqueueDequeue(t *testing.T) {
 		verifyBlockNumbers(t, results, 2, 3, 4, 4)
 	})
 
-	t.Run("dequeue with limits", func(t *testing.T) {
+	t.Run("dequeue with limits refers latest logs", func(t *testing.T) {
 		buf := newLogEventBuffer(logger.TestLogger(t), 3, 5, 10)
 		require.Equal(t, buf.enqueue(big.NewInt(1),
 			logpoller.Log{BlockNumber: 1, TxHash: common.HexToHash("0x1"), LogIndex: 0},
@@ -315,7 +315,10 @@ func TestLogEventBuffer_EnqueueDequeue(t *testing.T) {
 
 		logs := buf.dequeueRange(1, 5, 2)
 		require.Equal(t, 2, len(logs))
+		require.Equal(t, int64(5), logs[0].log.BlockNumber)
+		require.Equal(t, int64(4), logs[1].log.BlockNumber)
 	})
+
 	t.Run("dequeue doesn't return same logs again", func(t *testing.T) {
 		buf := newLogEventBuffer(logger.TestLogger(t), 3, 5, 10)
 		require.Equal(t, buf.enqueue(big.NewInt(1),


### PR DESCRIPTION
While dequeuing from buffer sort blocks in descending order of block number to prefer latest logs. Since buffer size can be big, and we can only process latest logs upto 128 blocks old from here, prefer to return latest logs

While i was implementing this a test revealed another issue, `blocksInRange` held references to the blocks being updated in the loop. To prevent unexpected behaviour, I'm creating a clone of the blocks first before processing them