### PR TITLE
[Gateway] Support Websocket heartbeat messages

### DIFF
--- a/core/services/gateway/config/config.go
+++ b/core/services/gateway/config/config.go
@@ -17,6 +17,7 @@ type ConnectionManagerConfig struct {
 	AuthGatewayId             string
 	AuthTimestampToleranceSec uint32
 	AuthChallengeLen          uint32
+	HeartbeatIntervalSec      uint32
 }
 
 type DONConfig struct {


### PR DESCRIPTION
Add Ping messages sent by Gateway to all nodes. Nodes reply with Pong by default.
Tested in a local DON.