### PR TITLE
Apply custom filter to logs in log recoverer getLogTriggerCheckData

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer.go
@@ -222,6 +222,7 @@ func (r *logRecoverer) getLogTriggerCheckData(ctx context.Context, proposal ocr2
 	if err != nil {
 		return nil, fmt.Errorf("could not read logs: %w", err)
 	}
+	logs = filter.Select(logs...)
 
 	for _, log := range logs {
 		trigger := logToTrigger(log)

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer_test.go
@@ -884,6 +884,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 			if !tc.skipFilter {
 				filterStore.AddActiveUpkeeps(upkeepFilter{
 					addr:     []byte("test"),
+					topics:   []common.Hash{common.HexToHash("0x1"), common.HexToHash("0x2"), common.HexToHash("0x3"), common.HexToHash("0x4")},
 					upkeepID: core.GenUpkeepID(ocr2keepers.LogTrigger, "123").BigInt(),
 				})
 			}


### PR DESCRIPTION
Small followup from https://github.com/smartcontractkit/chainlink/pull/10360/files

In log recoverer, there are 2 flows: node puts log recovery proposals itself, and in the other one tries to build checkData for a surfaced proposal. Adding the custom filtering in the second part too