### PR TITLE
Revert "Scroll update toml config (#10243)"

### DIFF
--- a/core/chains/evm/config/toml/defaults/Scroll_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/Scroll_Mainnet.toml
@@ -1,14 +1,10 @@
 ChainID = '534352'
 FinalityDepth = 1
-# extended time setting, due to sporadic block production rate
-LogPollInterval = '30s'
+LogPollInterval = '3s'
 MinIncomingConfirmations = 1
 # Scroll only emits blocks when a new tx is received, so this method of liveness detection is not useful
 NoNewHeadsThreshold = '0'
 OCR.ContractConfirmations = 1
-
-[Transactions]
-ResendAfterThreshold = '2m'
 
 [GasEstimator]
 Mode = 'L2Suggested'

--- a/core/chains/evm/config/toml/defaults/Scroll_Sepolia.toml
+++ b/core/chains/evm/config/toml/defaults/Scroll_Sepolia.toml
@@ -1,14 +1,10 @@
 ChainID = '534351'
 FinalityDepth = 1
-# extended time setting, due to sporadic block production rate
-LogPollInterval = '30s'
+LogPollInterval = '3s'
 MinIncomingConfirmations = 1
 # Scroll only emits blocks when a new tx is received, so this method of liveness detection is not useful
 NoNewHeadsThreshold = '0'
 OCR.ContractConfirmations = 1
-
-[Transactions]
-ResendAfterThreshold = '2m'
 
 [GasEstimator]
 Mode = 'L2Suggested'

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -4018,7 +4018,7 @@ BlockBackfillSkip = false
 FinalityDepth = 1
 FinalityTagEnabled = false
 LogBackfillBatchSize = 1000
-LogPollInterval = '30s'
+LogPollInterval = '3s'
 LogKeepBlocksDepth = 100000
 MinIncomingConfirmations = 1
 MinContractPayment = '0.00001 link'
@@ -4033,7 +4033,7 @@ MaxInFlight = 16
 MaxQueued = 250
 ReaperInterval = '1h0m0s'
 ReaperThreshold = '168h0m0s'
-ResendAfterThreshold = '2m0s'
+ResendAfterThreshold = '1m0s'
 
 [BalanceMonitor]
 Enabled = true
@@ -4095,7 +4095,7 @@ BlockBackfillSkip = false
 FinalityDepth = 1
 FinalityTagEnabled = false
 LogBackfillBatchSize = 1000
-LogPollInterval = '30s'
+LogPollInterval = '3s'
 LogKeepBlocksDepth = 100000
 MinIncomingConfirmations = 1
 MinContractPayment = '0.00001 link'
@@ -4110,7 +4110,7 @@ MaxInFlight = 16
 MaxQueued = 250
 ReaperInterval = '1h0m0s'
 ReaperThreshold = '168h0m0s'
-ResendAfterThreshold = '2m0s'
+ResendAfterThreshold = '1m0s'
 
 [BalanceMonitor]
 Enabled = true


### PR DESCRIPTION
This reverts the [PR](https://github.com/smartcontractkit/chainlink/pull/10243) as it was confirmed that the testing issue was due to testnet network outage, [incident](https://status.scroll.io/incidents/kqlsqs45dz2x).