### PR TITLE
.github/workflows: fix ci-core slack race notification url

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -232,7 +232,7 @@ jobs:
           SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
         with:
           channel-id: '#topic-data-races'
-          slack-message: "Race tests failed: ${{ job.html_url }}\n${{ github.event.pull_request.html_url || github.event.head_commit.url || format('https://github.com/smartcontractkit/chainlink/commit/{0}', github.sha) }}"
+          slack-message: "Race tests failed: ${{ job.html_url }}\n${{ format('https://github.com/smartcontractkit/chainlink/actions/runs/{0}', github.run_id) }}"
       - name: Collect Metrics
         if: always()
         id: collect-gha-metrics


### PR DESCRIPTION
Link to the particular action run that failed, rather than the PR or commit.