### PR TITLE
Update solana to take BCF-2562: Relayer dependent on chain not chainset

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -299,7 +299,7 @@ require (
 	github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 // indirect
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230824145305-c6541b2b0070 // indirect
 	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230830140037-e12ff6139b5a // indirect
-	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230824141217-c3b72b2683b9 // indirect
+	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230830203915-f177c12901f5 // indirect
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230824155404-2f61ad01a404 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20230829114801-14bf715f805e // indirect
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20230829114801-14bf715f805e // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1373,8 +1373,8 @@ github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230824145305-c6541b2b007
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230824145305-c6541b2b0070/go.mod h1:xMwqRdj5vqYhCJXgKVqvyAwdcqM6ZAEhnwEQ4Khsop8=
 github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230830140037-e12ff6139b5a h1:7uEY4bgrH1dV/Vmpn/35yOO7lq2vWJiA1pQX8YohEOM=
 github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230830140037-e12ff6139b5a/go.mod h1:gWclxGW7rLkbjXn7FGizYlyKhp/boekto4MEYGyiMG4=
-github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230824141217-c3b72b2683b9 h1:Ktcpq5xOPHe90vbiPRfZ5NQDD7xwtwiwO9uTtiHqmLg=
-github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230824141217-c3b72b2683b9/go.mod h1:RIUJXn7EVp24TL2p4FW79dYjyno23x5mjt1nKN+5WEk=
+github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230830203915-f177c12901f5 h1:AT8uK+k/1L3wF+EqKxVWu4KlSQPM70g3bYJy4iRdBbY=
+github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230830203915-f177c12901f5/go.mod h1:RIUJXn7EVp24TL2p4FW79dYjyno23x5mjt1nKN+5WEk=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230824155404-2f61ad01a404 h1:OH9nyOrp5FYtI/ClAi6kCMHHN8dA7GW7jpOE7PId938=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230824155404-2f61ad01a404/go.mod h1:/yp/sqD8Iz5GU5fcercjrw0ivJF7HDcupYg+Gjr7EPg=
 github.com/smartcontractkit/go-plugin v0.0.0-20230605132010-0f4d515d1472 h1:x3kNwgFlDmbE/n0gTSRMt9GBDfsfGrs4X9b9arPZtFI=

--- a/go.mod
+++ b/go.mod
@@ -67,7 +67,7 @@ require (
 	github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230824145305-c6541b2b0070
 	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230830140037-e12ff6139b5a
-	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230824141217-c3b72b2683b9
+	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230830203915-f177c12901f5
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230824155404-2f61ad01a404
 	github.com/smartcontractkit/libocr v0.0.0-20230816220705-665e93233ae5
 	github.com/smartcontractkit/ocr2keepers v0.7.18

--- a/go.sum
+++ b/go.sum
@@ -1373,8 +1373,8 @@ github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230824145305-c6541b2b007
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230824145305-c6541b2b0070/go.mod h1:xMwqRdj5vqYhCJXgKVqvyAwdcqM6ZAEhnwEQ4Khsop8=
 github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230830140037-e12ff6139b5a h1:7uEY4bgrH1dV/Vmpn/35yOO7lq2vWJiA1pQX8YohEOM=
 github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230830140037-e12ff6139b5a/go.mod h1:gWclxGW7rLkbjXn7FGizYlyKhp/boekto4MEYGyiMG4=
-github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230824141217-c3b72b2683b9 h1:Ktcpq5xOPHe90vbiPRfZ5NQDD7xwtwiwO9uTtiHqmLg=
-github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230824141217-c3b72b2683b9/go.mod h1:RIUJXn7EVp24TL2p4FW79dYjyno23x5mjt1nKN+5WEk=
+github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230830203915-f177c12901f5 h1:AT8uK+k/1L3wF+EqKxVWu4KlSQPM70g3bYJy4iRdBbY=
+github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230830203915-f177c12901f5/go.mod h1:RIUJXn7EVp24TL2p4FW79dYjyno23x5mjt1nKN+5WEk=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230824155404-2f61ad01a404 h1:OH9nyOrp5FYtI/ClAi6kCMHHN8dA7GW7jpOE7PId938=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230824155404-2f61ad01a404/go.mod h1:/yp/sqD8Iz5GU5fcercjrw0ivJF7HDcupYg+Gjr7EPg=
 github.com/smartcontractkit/go-plugin v0.0.0-20230605132010-0f4d515d1472 h1:x3kNwgFlDmbE/n0gTSRMt9GBDfsfGrs4X9b9arPZtFI=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -382,7 +382,7 @@ require (
 	github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 // indirect
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230824145305-c6541b2b0070 // indirect
 	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230830140037-e12ff6139b5a // indirect
-	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230824141217-c3b72b2683b9 // indirect
+	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230830203915-f177c12901f5 // indirect
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230824155404-2f61ad01a404 // indirect
 	github.com/smartcontractkit/sqlx v1.3.5-0.20210805004948-4be295aacbeb // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20230829114801-14bf715f805e // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -2243,8 +2243,8 @@ github.com/smartcontractkit/chainlink-env v0.36.0 h1:CFOjs0c0y3lrHi/fl5qseCH9EQa
 github.com/smartcontractkit/chainlink-env v0.36.0/go.mod h1:NbRExHmJGnKSYXmvNuJx5VErSx26GtE1AEN/CRzYOg8=
 github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230830140037-e12ff6139b5a h1:7uEY4bgrH1dV/Vmpn/35yOO7lq2vWJiA1pQX8YohEOM=
 github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230830140037-e12ff6139b5a/go.mod h1:gWclxGW7rLkbjXn7FGizYlyKhp/boekto4MEYGyiMG4=
-github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230824141217-c3b72b2683b9 h1:Ktcpq5xOPHe90vbiPRfZ5NQDD7xwtwiwO9uTtiHqmLg=
-github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230824141217-c3b72b2683b9/go.mod h1:RIUJXn7EVp24TL2p4FW79dYjyno23x5mjt1nKN+5WEk=
+github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230830203915-f177c12901f5 h1:AT8uK+k/1L3wF+EqKxVWu4KlSQPM70g3bYJy4iRdBbY=
+github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230830203915-f177c12901f5/go.mod h1:RIUJXn7EVp24TL2p4FW79dYjyno23x5mjt1nKN+5WEk=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230824155404-2f61ad01a404 h1:OH9nyOrp5FYtI/ClAi6kCMHHN8dA7GW7jpOE7PId938=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230824155404-2f61ad01a404/go.mod h1:/yp/sqD8Iz5GU5fcercjrw0ivJF7HDcupYg+Gjr7EPg=
 github.com/smartcontractkit/chainlink-testing-framework v1.16.1-0.20230828224428-5b8a157a94d0 h1:DvIwUQc3/yWlvuXD/t30aOyX5BPVomM7OQT8ZO9VFFo=


### PR DESCRIPTION
Previous merge used a branch of solana, which was blocked from merging because of chicken-and-egg CI

solana code has been merged and this takes that commit