### PR TITLE
core: logger name cleanup

### DIFF
--- a/common/txmgr/confirmer.go
+++ b/common/txmgr/confirmer.go
@@ -517,7 +517,7 @@ func (ec *Confirmer[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) bat
 		}
 	}
 
-	lggr := ec.lggr.Named("batchFetchReceipts").With("blockNum", blockNum)
+	lggr := ec.lggr.Named("BatchFetchReceipts").With("blockNum", blockNum)
 
 	txReceipts, txErrs, err := ec.client.BatchGetReceipts(ctx, attempts)
 	if err != nil {

--- a/common/txmgr/reaper.go
+++ b/common/txmgr/reaper.go
@@ -31,7 +31,7 @@ func NewReaper[CHAIN_ID types.ID](lggr logger.Logger, store txmgrtypes.TxHistory
 		config,
 		txConfig,
 		chainID,
-		lggr.Named("txm_reaper"),
+		lggr.Named("Reaper"),
 		atomic.Int64{},
 		make(chan struct{}, 1),
 		make(chan struct{}),
@@ -43,13 +43,13 @@ func NewReaper[CHAIN_ID types.ID](lggr logger.Logger, store txmgrtypes.TxHistory
 
 // Start the reaper. Should only be called once.
 func (r *Reaper[CHAIN_ID]) Start() {
-	r.log.Debugf("TxmReaper: started with age threshold %v and interval %v", r.txConfig.ReaperThreshold(), r.txConfig.ReaperInterval())
+	r.log.Debugf("started with age threshold %v and interval %v", r.txConfig.ReaperThreshold(), r.txConfig.ReaperInterval())
 	go r.runLoop()
 }
 
 // Stop the reaper. Should only be called once.
 func (r *Reaper[CHAIN_ID]) Stop() {
-	r.log.Debug("TxmReaper: stopping")
+	r.log.Debug("stopping")
 	close(r.chStop)
 	<-r.chDone
 }
@@ -79,7 +79,7 @@ func (r *Reaper[CHAIN_ID]) work() {
 	}
 	err := r.ReapTxes(latestBlockNum)
 	if err != nil {
-		r.log.Error("TxmReaper: unable to reap old txes: ", err)
+		r.log.Error("unable to reap old txes: ", err)
 	}
 }
 
@@ -99,20 +99,20 @@ func (r *Reaper[CHAIN_ID]) SetLatestBlockNum(latestBlockNum int64) {
 func (r *Reaper[CHAIN_ID]) ReapTxes(headNum int64) error {
 	threshold := r.txConfig.ReaperThreshold()
 	if threshold == 0 {
-		r.log.Debug("TxmReaper: Transactions.ReaperThreshold  set to 0; skipping ReapTxes")
+		r.log.Debug("Transactions.ReaperThreshold  set to 0; skipping ReapTxes")
 		return nil
 	}
 	minBlockNumberToKeep := headNum - int64(r.config.FinalityDepth())
 	mark := time.Now()
 	timeThreshold := mark.Add(-threshold)
 
-	r.log.Debugw(fmt.Sprintf("TxmReaper: reaping old txes created before %s", timeThreshold.Format(time.RFC3339)), "ageThreshold", threshold, "timeThreshold", timeThreshold, "minBlockNumberToKeep", minBlockNumberToKeep)
+	r.log.Debugw(fmt.Sprintf("reaping old txes created before %s", timeThreshold.Format(time.RFC3339)), "ageThreshold", threshold, "timeThreshold", timeThreshold, "minBlockNumberToKeep", minBlockNumberToKeep)
 
 	if err := r.store.ReapTxHistory(minBlockNumberToKeep, timeThreshold, r.chainID); err != nil {
 		return err
 	}
 
-	r.log.Debugf("TxmReaper: ReapTxes completed in %v", time.Since(mark))
+	r.log.Debugf("ReapTxes completed in %v", time.Since(mark))
 
 	return nil
 }

--- a/core/chains/cosmos/chain.go
+++ b/core/chains/cosmos/chain.go
@@ -181,7 +181,7 @@ func (c *chain) getClient(name string) (cosmosclient.ReaderWriter, error) {
 			return nil, fmt.Errorf("failed to create client for chain %s with node %s: wrong chain id %s", c.id, name, node.CosmosChainID)
 		}
 	}
-	client, err := cosmosclient.NewClient(c.id, node.TendermintURL, DefaultRequestTimeout, logger.Named(c.lggr, "Client-"+name))
+	client, err := cosmosclient.NewClient(c.id, node.TendermintURL, DefaultRequestTimeout, logger.Named(c.lggr, "Client."+name))
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create client")
 	}

--- a/core/chains/evm/chain.go
+++ b/core/chains/evm/chain.go
@@ -19,6 +19,7 @@ import (
 	"github.com/smartcontractkit/chainlink-relay/pkg/types"
 
 	relaytypes "github.com/smartcontractkit/chainlink-relay/pkg/types"
+
 	"github.com/smartcontractkit/chainlink/v2/core/chains"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
@@ -216,7 +217,7 @@ func NewTOMLChain(ctx context.Context, chain *toml.EVMConfig, opts ChainRelayExt
 
 func newChain(ctx context.Context, cfg *evmconfig.ChainScoped, nodes []*toml.Node, opts ChainRelayExtenderConfig) (*chain, error) {
 	chainID, chainType := cfg.EVM().ChainID(), cfg.EVM().ChainType()
-	l := opts.Logger.Named(chainID.String()).With("evmChainID", chainID.String())
+	l := opts.Logger
 	var client evmclient.Client
 	if !cfg.EVMRPCEnabled() {
 		client = evmclient.NewNullClient(chainID, l)

--- a/core/chains/evm/client/null_client.go
+++ b/core/chains/evm/client/null_client.go
@@ -72,7 +72,7 @@ type nullSubscription struct {
 }
 
 func newNullSubscription(lggr logger.Logger) *nullSubscription {
-	return &nullSubscription{lggr: lggr.Named("nullSubscription")}
+	return &nullSubscription{lggr: lggr.Named("NullSubscription")}
 }
 
 func (ns *nullSubscription) Unsubscribe() {

--- a/core/chains/evm/monitor/balance.go
+++ b/core/chains/evm/monitor/balance.go
@@ -116,7 +116,7 @@ func (bm *balanceMonitor) updateBalance(ethBal assets.Eth, address gethCommon.Ad
 	bm.ethBalances[address] = &ethBal
 	bm.ethBalancesMtx.Unlock()
 
-	lgr := bm.logger.Named("balance_log").With(
+	lgr := bm.logger.Named("BalanceLog").With(
 		"address", address.Hex(),
 		"ethBalance", ethBal.String(),
 		"weiBalance", ethBal.ToInt())

--- a/core/chains/solana/chain.go
+++ b/core/chains/solana/chain.go
@@ -342,7 +342,7 @@ func (c *chain) verifiedClient(node db.Node) (client.ReaderWriter, error) {
 			expectedChainID: c.id,
 		}
 		// create client
-		cl.ReaderWriter, err = client.NewClient(url, c.cfg, DefaultRequestTimeout, logger.Named(c.lggr, "Client-"+node.Name))
+		cl.ReaderWriter, err = client.NewClient(url, c.cfg, DefaultRequestTimeout, logger.Named(c.lggr, "Client."+node.Name))
 		if err != nil {
 			return nil, errors.Wrap(err, "failed to create client")
 		}

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -144,7 +144,7 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg chainlink.G
 
 	dbListener := cfg.Database().Listener()
 	eventBroadcaster := pg.NewEventBroadcaster(cfg.Database().URL(), dbListener.MinReconnectInterval(), dbListener.MaxReconnectDuration(), appLggr, cfg.AppID())
-	loopRegistry := plugins.NewLoopRegistry(appLggr.Named("LoopRegistry"))
+	loopRegistry := plugins.NewLoopRegistry(appLggr)
 
 	// create the relayer-chain interoperators from application configuration
 	relayerFactory := chainlink.RelayerFactory{

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -385,7 +385,7 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 	keyStore := keystore.New(db, utils.FastScryptParams, lggr, cfg.Database())
 
 	mailMon := utils.NewMailboxMonitor(cfg.AppID().String())
-	loopRegistry := plugins.NewLoopRegistry(lggr.Named("LoopRegistry"))
+	loopRegistry := plugins.NewLoopRegistry(lggr)
 
 	relayerFactory := chainlink.RelayerFactory{
 		Logger:       lggr,

--- a/core/logger/logger.go
+++ b/core/logger/logger.go
@@ -78,8 +78,9 @@ type Logger interface {
 	With(args ...interface{}) Logger
 	// Named creates a new Logger sub-scoped with name.
 	// Names are inherited and dot-separated.
-	//   a := l.Named("a") // logger=a
-	//   b := a.Named("b") // logger=a.b
+	//   a := l.Named("A") // logger=A
+	//   b := a.Named("A") // logger=A.B
+	// Names are generally `MixedCaps`, without spaces, like Go names.
 	Named(name string) Logger
 
 	// SetLogLevel changes the log level for this and all connected Loggers.

--- a/core/services/blockhashstore/delegate.go
+++ b/core/services/blockhashstore/delegate.go
@@ -162,7 +162,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job, qopts ...pg.QOpt) ([]job.ServiceC
 		return nil, errors.Wrap(err, "building bulletproof bhs")
 	}
 
-	log := d.logger.Named("BHS Feeder").With("jobID", jb.ID, "externalJobID", jb.ExternalJobID)
+	log := d.logger.Named("BHSFeeder").With("jobID", jb.ID, "externalJobID", jb.ExternalJobID)
 	feeder := NewFeeder(
 		log,
 		NewMultiCoordinator(coordinators...),

--- a/core/services/blockheaderfeeder/delegate.go
+++ b/core/services/blockheaderfeeder/delegate.go
@@ -156,7 +156,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job, qopts ...pg.QOpt) ([]job.ServiceC
 		return nil, errors.Wrap(err, "building batchBHS")
 	}
 
-	log := d.logger.Named("Block Header Feeder").With(
+	log := d.logger.Named("BlockHeaderFeeder").With(
 		"jobID", jb.ID,
 		"externalJobID", jb.ExternalJobID,
 		"bhsAddress", bhs.Address(),

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -185,7 +185,7 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 	// we need to initialize in case we serve OCR2 LOOPs
 	loopRegistry := opts.LoopRegistry
 	if loopRegistry == nil {
-		loopRegistry = plugins.NewLoopRegistry(globalLogger.Named("LoopRegistry"))
+		loopRegistry = plugins.NewLoopRegistry(globalLogger)
 	}
 
 	// If the audit logger is enabled

--- a/core/services/chainlink/relayer_factory.go
+++ b/core/services/chainlink/relayer_factory.go
@@ -11,6 +11,7 @@ import (
 	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
 	pkgsolana "github.com/smartcontractkit/chainlink-solana/pkg/solana"
 	pkgstarknet "github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink"
+
 	"github.com/smartcontractkit/chainlink/v2/core/chains/cosmos"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/solana"
@@ -44,7 +45,7 @@ func (r *RelayerFactory) NewEVM(ctx context.Context, config EVMFactoryConfig) (m
 
 	// override some common opts with the factory values. this seems weird... maybe other signatures should change, or this should take a different type...
 	ccOpts := evm.ChainRelayExtenderConfig{
-		Logger:        r.Logger,
+		Logger:        r.Logger.Named("EVM"),
 		DB:            r.DB,
 		KeyStore:      config.CSAETHKeystore.Eth(),
 		RelayerConfig: config.RelayerConfig,

--- a/core/services/functions/connector_handler.go
+++ b/core/services/functions/connector_handler.go
@@ -45,7 +45,7 @@ func NewFunctionsConnectorHandler(nodeAddress string, signerKey *ecdsa.PrivateKe
 		storage:     storage,
 		allowlist:   allowlist,
 		rateLimiter: rateLimiter,
-		lggr:        lggr.Named("functionsConnectorHandler"),
+		lggr:        lggr.Named("FunctionsConnectorHandler"),
 	}, nil
 }
 

--- a/core/services/gateway/gateway.go
+++ b/core/services/gateway/gateway.go
@@ -75,7 +75,7 @@ func NewGateway(codec api.Codec, httpServer gw_net.HttpServer, handlers map[stri
 		httpServer: httpServer,
 		handlers:   handlers,
 		connMgr:    connMgr,
-		lggr:       lggr.Named("gateway"),
+		lggr:       lggr.Named("Gateway"),
 	}
 	httpServer.SetHTTPRequestHandler(gw)
 	return gw

--- a/core/services/nurse.go
+++ b/core/services/nurse.go
@@ -67,7 +67,7 @@ const (
 func NewNurse(cfg Config, log logger.Logger) *Nurse {
 	return &Nurse{
 		cfg:      cfg,
-		log:      log.Named("nurse"),
+		log:      log.Named("Nurse"),
 		checks:   make(map[string]CheckFunc),
 		chGather: make(chan gatherRequest, 1),
 		chStop:   make(chan struct{}),
@@ -75,7 +75,7 @@ func NewNurse(cfg Config, log logger.Logger) *Nurse {
 }
 
 func (n *Nurse) Start() error {
-	return n.StartOnce("nurse", func() error {
+	return n.StartOnce("Nurse", func() error {
 		// This must be set *once*, and it must occur as early as possible
 		if n.cfg.MemProfileRate() != runtime.MemProfileRate {
 			runtime.MemProfileRate = n.cfg.BlockProfileRate()
@@ -137,7 +137,7 @@ func (n *Nurse) Start() error {
 }
 
 func (n *Nurse) Close() error {
-	return n.StopOnce("nurse", func() error {
+	return n.StopOnce("Nurse", func() error {
 		n.log.Debug("Nurse closing...")
 		defer n.log.Debug("Nurse closed")
 		close(n.chStop)

--- a/core/services/ocr/delegate.go
+++ b/core/services/ocr/delegate.go
@@ -297,7 +297,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job, qopts ...pg.QOpt) (services []job
 
 		enhancedTelemChan := make(chan ocrcommon.EnhancedTelemetryData, 100)
 		if ocrcommon.ShouldCollectEnhancedTelemetry(&jb) {
-			enhancedTelemService := ocrcommon.NewEnhancedTelemetryService(&jb, enhancedTelemChan, make(chan struct{}), d.monitoringEndpointGen.GenMonitoringEndpoint(concreteSpec.ContractAddress.String(), synchronization.EnhancedEA), lggr.Named("Enhanced Telemetry"))
+			enhancedTelemService := ocrcommon.NewEnhancedTelemetryService(&jb, enhancedTelemChan, make(chan struct{}), d.monitoringEndpointGen.GenMonitoringEndpoint(concreteSpec.ContractAddress.String(), synchronization.EnhancedEA), lggr.Named("EnhancedTelemetry"))
 			services = append(services, enhancedTelemService)
 		}
 

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -549,7 +549,7 @@ func (d *Delegate) newServicesMercury(
 	mercuryServices, err2 := mercury.NewServices(jb, mercuryProvider, d.pipelineRunner, runResults, lggr, oracleArgsNoPlugin, d.cfg.JobPipeline(), chEnhancedTelem, chain, d.mercuryORM, (mercuryutils.FeedID)(*spec.FeedID))
 
 	if ocrcommon.ShouldCollectEnhancedTelemetryMercury(&jb) {
-		enhancedTelemService := ocrcommon.NewEnhancedTelemetryService(&jb, chEnhancedTelem, make(chan struct{}), d.monitoringEndpointGen.GenMonitoringEndpoint(spec.FeedID.String(), synchronization.EnhancedEAMercury), lggr.Named("Enhanced Telemetry Mercury"))
+		enhancedTelemService := ocrcommon.NewEnhancedTelemetryService(&jb, chEnhancedTelem, make(chan struct{}), d.monitoringEndpointGen.GenMonitoringEndpoint(spec.FeedID.String(), synchronization.EnhancedEAMercury), lggr.Named("EnhancedTelemetryMercury"))
 		mercuryServices = append(mercuryServices, enhancedTelemService)
 	}
 
@@ -594,7 +594,7 @@ func (d *Delegate) newServicesMedian(
 	medianServices, err2 := median.NewMedianServices(ctx, jb, d.isNewlyCreatedJob, relayer, d.pipelineRunner, runResults, lggr, oracleArgsNoPlugin, mConfig, enhancedTelemChan, errorLog)
 
 	if ocrcommon.ShouldCollectEnhancedTelemetry(&jb) {
-		enhancedTelemService := ocrcommon.NewEnhancedTelemetryService(&jb, enhancedTelemChan, make(chan struct{}), d.monitoringEndpointGen.GenMonitoringEndpoint(spec.ContractID, synchronization.EnhancedEA), lggr.Named("Enhanced Telemetry"))
+		enhancedTelemService := ocrcommon.NewEnhancedTelemetryService(&jb, enhancedTelemChan, make(chan struct{}), d.monitoringEndpointGen.GenMonitoringEndpoint(spec.ContractID, synchronization.EnhancedEA), lggr.Named("EnhancedTelemetry"))
 		medianServices = append(medianServices, enhancedTelemService)
 	}
 

--- a/core/services/ocr2/plugins/threshold/decryption_queue.go
+++ b/core/services/ocr2/plugins/threshold/decryption_queue.go
@@ -56,7 +56,7 @@ func NewDecryptionQueue(maxQueueLength int, maxCiphertextBytes int, maxCiphertex
 		make(map[string]pendingRequest),
 		make(map[string]completedRequest),
 		sync.RWMutex{},
-		lggr.Named("decryptionQueue"),
+		lggr.Named("DecryptionQueue"),
 	}
 	return &dq
 }

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -61,12 +61,13 @@ type CSAETHKeystore interface {
 }
 
 func NewRelayer(db *sqlx.DB, chain evm.Chain, cfg pg.QConfig, lggr logger.Logger, ks CSAETHKeystore, eventBroadcaster pg.EventBroadcaster) *Relayer {
+	lggr = lggr.Named("Relayer")
 	return &Relayer{
 		db:               db,
 		chain:            chain,
-		lggr:             lggr.Named("Relayer"),
+		lggr:             lggr,
 		ks:               ks,
-		mercuryPool:      wsrpc.NewPool(lggr.Named("Mercury.WSRPCPool")),
+		mercuryPool:      wsrpc.NewPool(lggr),
 		eventBroadcaster: eventBroadcaster,
 		pgCfg:            cfg,
 	}

--- a/core/services/relay/evm/mercury/wsrpc/pool.go
+++ b/core/services/relay/evm/mercury/wsrpc/pool.go
@@ -127,7 +127,7 @@ type pool struct {
 }
 
 func NewPool(lggr logger.Logger) Pool {
-	p := newPool(lggr)
+	p := newPool(lggr.Named("Mercury.WSRPCPool"))
 	p.newClient = NewClient
 	return p
 }

--- a/core/services/s4/storage.go
+++ b/core/services/s4/storage.go
@@ -75,7 +75,7 @@ var _ Storage = (*storage)(nil)
 
 func NewStorage(lggr logger.Logger, contraints Constraints, orm ORM, clock utils.Clock) Storage {
 	return &storage{
-		lggr:       lggr.Named("s4_storage"),
+		lggr:       lggr.Named("S4Storage"),
 		contraints: contraints,
 		orm:        orm,
 		clock:      clock,

--- a/core/sessions/orm.go
+++ b/core/sessions/orm.go
@@ -52,11 +52,11 @@ type orm struct {
 var _ ORM = (*orm)(nil)
 
 func NewORM(db *sqlx.DB, sd time.Duration, lggr logger.Logger, cfg pg.QConfig, auditLogger audit.AuditLogger) ORM {
-	namedLogger := lggr.Named("SessionsORM")
+	lggr = lggr.Named("SessionsORM")
 	return &orm{
-		q:               pg.NewQ(db, namedLogger, cfg),
+		q:               pg.NewQ(db, lggr, cfg),
 		sessionDuration: sd,
-		lggr:            lggr.Named("SessionsORM"),
+		lggr:            lggr,
 		auditLogger:     auditLogger,
 	}
 }

--- a/plugins/loop_registry.go
+++ b/plugins/loop_registry.go
@@ -31,7 +31,7 @@ type LoopRegistry struct {
 func NewLoopRegistry(lggr logger.Logger) *LoopRegistry {
 	return &LoopRegistry{
 		registry: map[string]*RegisteredLoop{},
-		lggr:     lggr,
+		lggr:     logger.Named(lggr, "LoopRegistry"),
 	}
 }
 


### PR DESCRIPTION
While looking at the prom `health` metrics, I noticed some malformed instances `service_id`s, specifically missing `EVM` and repeated chain IDs. I also did a pass on uncapitalized names and spaces/underscores.