### PR TITLE
golangci-lint

### DIFF
--- a/core/chains/evm/logpoller/log_poller_internal_test.go
+++ b/core/chains/evm/logpoller/log_poller_internal_test.go
@@ -56,10 +56,6 @@ func TestLogPoller_RegisterFilter(t *testing.T) {
 
 	orm := NewORM(chainID, db, lggr, pgtest.NewQConfig(true))
 
-	db.Close()
-	db = pgtest.NewSqlxDB(t)
-	orm = NewORM(chainID, db, lggr, pgtest.NewQConfig(true))
-
 	// Set up a test chain with a log emitting contract deployed.
 	lp := NewLogPoller(orm, nil, lggr, time.Hour, 1, 1, 2, 1000)
 

--- a/core/chains/evm/txmgr/txmgr_test.go
+++ b/core/chains/evm/txmgr/txmgr_test.go
@@ -401,7 +401,7 @@ func (g *gasEstimatorConfig) PriceMax() *assets.Wei                { return asse
 func (g *gasEstimatorConfig) PriceMin() *assets.Wei                { return assets.NewWeiI(42) }
 func (g *gasEstimatorConfig) Mode() string                         { return "FixedPrice" }
 func (g *gasEstimatorConfig) LimitJobType() evmconfig.LimitJobType { return &limitJobTypeConfig{} }
-func (e *gasEstimatorConfig) PriceMaxKey(addr common.Address) *assets.Wei {
+func (g *gasEstimatorConfig) PriceMaxKey(addr common.Address) *assets.Wei {
 	return assets.NewWeiI(42)
 }
 

--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -209,17 +209,15 @@ func NewApp(s *Shell) *cli.App {
 				if c.IsSet("config") {
 					if s.configFilesIsSet || s.secretsFileIsSet {
 						return errNoDuplicateFlags
-					} else {
-						s.configFiles = c.StringSlice("config")
 					}
+					s.configFiles = c.StringSlice("config")
 				}
 
 				if c.IsSet("secrets") {
 					if s.configFilesIsSet || s.secretsFileIsSet {
 						return errNoDuplicateFlags
-					} else {
-						s.secretsFiles = c.StringSlice("secrets")
 					}
+					s.secretsFiles = c.StringSlice("secrets")
 				}
 
 				// flags here, or ENV VAR only

--- a/core/cmd/cosmos_node_commands_test.go
+++ b/core/cmd/cosmos_node_commands_test.go
@@ -60,7 +60,7 @@ func TestShell_IndexCosmosNodes(t *testing.T) {
 	//Render table and check the fields order
 	b := new(bytes.Buffer)
 	rt := cmd.RendererTable{b}
-	nodes.RenderTable(rt)
+	require.NoError(t, nodes.RenderTable(rt))
 	renderLines := strings.Split(b.String(), "\n")
 	assert.Equal(t, 10, len(renderLines))
 	assert.Contains(t, renderLines[2], "Name")

--- a/core/cmd/evm_node_commands_test.go
+++ b/core/cmd/evm_node_commands_test.go
@@ -76,7 +76,7 @@ func TestShell_IndexEVMNodes(t *testing.T) {
 	//Render table and check the fields order
 	b := new(bytes.Buffer)
 	rt := cmd.RendererTable{b}
-	nodes.RenderTable(rt)
+	require.NoError(t, nodes.RenderTable(rt))
 	renderLines := strings.Split(b.String(), "\n")
 	assert.Equal(t, 23, len(renderLines))
 	assert.Contains(t, renderLines[2], "Name")

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -113,11 +113,10 @@ func (s *Shell) configExitErr(validateFn func() error) cli.ExitCoder {
 			fmt.Println("Invalid configuration:", err)
 			fmt.Println()
 			return s.errorOut(errors.New("invalid configuration"))
-		} else {
-			fmt.Printf("Notification for upcoming configuration change: %v\n", err)
-			fmt.Println("This configuration will be disallowed in future production releases.")
-			fmt.Println()
 		}
+		fmt.Printf("Notification for upcoming configuration change: %v\n", err)
+		fmt.Println("This configuration will be disallowed in future production releases.")
+		fmt.Println()
 	}
 	return nil
 }

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -136,10 +136,7 @@ func TestShell_RunNodeWithPasswords(t *testing.T) {
 				if err := cli.Before(c); err != nil {
 					return err
 				}
-				if err := client.RunNode(c); err != nil {
-					return err
-				}
-				return nil
+				return client.RunNode(c)
 			}
 
 			if test.wantUnlocked {

--- a/core/cmd/solana_node_commands_test.go
+++ b/core/cmd/solana_node_commands_test.go
@@ -71,7 +71,7 @@ func TestShell_IndexSolanaNodes(t *testing.T) {
 	//Render table and check the fields order
 	b := new(bytes.Buffer)
 	rt := cmd.RendererTable{b}
-	nodes.RenderTable(rt)
+	require.NoError(t, nodes.RenderTable(rt))
 	renderLines := strings.Split(b.String(), "\n")
 	assert.Equal(t, 17, len(renderLines))
 	assert.Contains(t, renderLines[2], "Name")

--- a/core/cmd/starknet_node_commands_test.go
+++ b/core/cmd/starknet_node_commands_test.go
@@ -71,7 +71,7 @@ func TestShell_IndexStarkNetNodes(t *testing.T) {
 	//Render table and check the fields order
 	b := new(bytes.Buffer)
 	rt := cmd.RendererTable{b}
-	nodes.RenderTable(rt)
+	require.NoError(t, nodes.RenderTable(rt))
 	renderLines := strings.Split(b.String(), "\n")
 	assert.Equal(t, 17, len(renderLines))
 	assert.Contains(t, renderLines[2], "Name")

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -1634,10 +1634,8 @@ func FlagSetApplyFromAction(action interface{}, flagSet *flag.FlagSet, parentCom
 	for _, command := range app.Commands {
 		flags := recursiveFindFlagsWithName(actionFuncName, command, parentCommand, foundName)
 
-		if flags != nil {
-			for _, flag := range flags {
-				flag.Apply(flagSet)
-			}
+		for _, flag := range flags {
+			flag.Apply(flagSet)
 		}
 	}
 

--- a/core/services/chainlink/relayer_chain_interoperators_test.go
+++ b/core/services/chainlink/relayer_chain_interoperators_test.go
@@ -320,6 +320,7 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
+		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cr, err := chainlink.NewCoreRelayerChainInteroperators(tt.initFuncs...)

--- a/core/services/keeper/integration_test.go
+++ b/core/services/keeper/integration_test.go
@@ -538,7 +538,7 @@ func TestMaxPerformDataSize(t *testing.T) {
 		backend.Commit()
 
 		// setup app
-		config, db := heavyweight.FullTestDBV2(t, fmt.Sprintf("keeper_max_perform_data_test"), func(c *chainlink.Config, s *chainlink.Secrets) {
+		config, db := heavyweight.FullTestDBV2(t, "keeper_max_perform_data_test", func(c *chainlink.Config, s *chainlink.Secrets) {
 			c.Keeper.MaxGracePeriod = ptr[int64](0)                                 // avoid waiting to re-submit for upkeeps
 			c.Keeper.Registry.SyncInterval = models.MustNewDuration(24 * time.Hour) // disable full sync ticker for test
 			c.Keeper.Registry.MaxPerformDataSize = ptr(uint32(maxPerformDataSize))  // set the max perform data size

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -23,7 +23,6 @@ import (
 	ocr2keepers20runner "github.com/smartcontractkit/ocr2keepers/pkg/v2/runner"
 	ocr2keepers21config "github.com/smartcontractkit/ocr2keepers/pkg/v3/config"
 	ocr2keepers21 "github.com/smartcontractkit/ocr2keepers/pkg/v3/plugin"
-	ocr2keepers21types "github.com/smartcontractkit/ocr2keepers/pkg/v3/types"
 	"github.com/smartcontractkit/ocr2vrf/altbn_128"
 	dkgpkg "github.com/smartcontractkit/ocr2vrf/dkg"
 	"github.com/smartcontractkit/ocr2vrf/ocr2vrf"
@@ -1311,11 +1310,4 @@ func (l *logWriter) Write(p []byte) (n int, err error) {
 	l.log.Debug(string(p), nil)
 	n = len(p)
 	return
-}
-
-type mockRecoverableProvider struct {
-}
-
-func (_m *mockRecoverableProvider) GetRecoveryProposals(ctx context.Context) ([]ocr2keepers21types.UpkeepPayload, error) {
-	return nil, nil
 }

--- a/core/services/ocr2/plugins/functions/integration_tests/v1/internal/testutils.go
+++ b/core/services/ocr2/plugins/functions/integration_tests/v1/internal/testutils.go
@@ -124,7 +124,8 @@ func CreateAndFundSubscriptions(t *testing.T, b *backends.SimulatedBackend, owne
 		var s [32]byte
 		copy(s[:], flatSignature[32:64])
 		v := flatSignature[65]
-		allowListContract.AcceptTermsOfService(owner, owner.From, owner.From, r, s, v)
+		_, err = allowListContract.AcceptTermsOfService(owner, owner.From, owner.From, r, s, v)
+		require.NoError(t, err)
 	}
 
 	_, err = routerContract.CreateSubscription(owner)

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -455,11 +455,8 @@ func (r *Relayer) NewMedianProvider(rargs relaytypes.RelayArgs, pargs relaytypes
 		return nil, err
 	}
 
-	var contractTransmitter ContractTransmitter
-	var reportCodec median.ReportCodec
-
-	reportCodec = evmreportcodec.ReportCodec{}
-	contractTransmitter, err = newContractTransmitter(r.lggr, rargs, pargs.TransmitterID, configWatcher, r.ks.Eth())
+	reportCodec := evmreportcodec.ReportCodec{}
+	contractTransmitter, err := newContractTransmitter(r.lggr, rargs, pargs.TransmitterID, configWatcher, r.ks.Eth())
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/vrf/v2/integration_v2_test.go
+++ b/core/services/vrf/v2/integration_v2_test.go
@@ -2099,19 +2099,17 @@ func TestStartingCountsV1(t *testing.T) {
 			ChainID:            chainID.ToInt(),
 		})
 	}
-	txes := append(confirmedTxes, unconfirmedTxes...)
 	sql := `INSERT INTO eth_txes (nonce, from_address, to_address, encoded_payload, value, gas_limit, state, created_at, broadcast_at, initial_broadcast_at, meta, subject, evm_chain_id, min_confirmations, pipeline_task_run_id)
 VALUES (:nonce, :from_address, :to_address, :encoded_payload, :value, :gas_limit, :state, :created_at, :broadcast_at, :initial_broadcast_at, :meta, :subject, :evm_chain_id, :min_confirmations, :pipeline_task_run_id);`
-	for _, tx := range txes {
+	for _, tx := range append(confirmedTxes, unconfirmedTxes...) {
 		dbEtx := txmgr.DbEthTxFromEthTx(&tx)
 		_, err = db.NamedExec(sql, &dbEtx)
-		txmgr.DbEthTxToEthTx(dbEtx, &tx)
 		require.NoError(t, err)
 	}
 
 	// add eth_tx_attempts for confirmed
 	broadcastBlock := int64(1)
-	txAttempts := []txmgr.TxAttempt{}
+	var txAttempts []txmgr.TxAttempt
 	for i := range confirmedTxes {
 		txAttempts = append(txAttempts, txmgr.TxAttempt{
 			TxID:                    int64(i + 1),
@@ -2142,10 +2140,10 @@ VALUES (:nonce, :from_address, :to_address, :encoded_payload, :value, :gas_limit
 	sql = `INSERT INTO eth_tx_attempts (eth_tx_id, gas_price, signed_raw_tx, hash, state, created_at, chain_specific_gas_limit)
 		VALUES (:eth_tx_id, :gas_price, :signed_raw_tx, :hash, :state, :created_at, :chain_specific_gas_limit)`
 	for _, attempt := range txAttempts {
-		dbAttempt := txmgr.DbEthTxAttemptFromEthTxAttempt(&attempt)
+		dbAttempt := txmgr.DbEthTxAttemptFromEthTxAttempt(&attempt) //nolint:gosec - just copying fields
 		_, err = db.NamedExec(sql, &dbAttempt)
-		txmgr.DbEthTxAttemptToEthTxAttempt(dbAttempt, &attempt)
 		require.NoError(t, err)
+		txmgr.DbEthTxAttemptToEthTxAttempt(dbAttempt, &attempt) //nolin:gosec - just copying fields
 	}
 
 	// add eth_receipts

--- a/core/web/solana_transfer_controller.go
+++ b/core/web/solana_transfer_controller.go
@@ -54,10 +54,9 @@ func (tc *SolanaTransfersController) Create(c *gin.Context) {
 		if errors.Is(err, chainlink.ErrNoSuchRelayer) {
 			jsonAPIError(c, http.StatusBadRequest, err)
 			return
-		} else {
-			jsonAPIError(c, http.StatusInternalServerError, err)
-			return
 		}
+		jsonAPIError(c, http.StatusInternalServerError, err)
+		return
 	}
 	// note the [loop.Relayer] API is in intermediate state. we found the relayer above; we should not need to pass
 	// the chain id here


### PR DESCRIPTION
- Error return value of * is not checked (errcheck)
- loopclosure: loop variable tt captured by func literal (govet)
- ineffectual assignment to orm (ineffassign)
- unnecessary use of fmt.Sprintf (gosimple)
- unnecessary nil check around range (gosimple)
- should merge variable declaration with assignment on next line (gosimple)
- type * is unused (unused)
- if-return: redundant if ...; err != nil check, just return error instead. (revive)
- receiver-naming: receiver name * should be consistent with previous receiver name * for * (revive)
- indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
- Implicit memory aliasing in for loop. (gosec)