### PR TITLE
chore: remove the word chainset from variables and comments

### DIFF
--- a/core/chains/solana/chain.go
+++ b/core/chains/solana/chain.go
@@ -214,7 +214,7 @@ func (v *verifiedCachedClient) GetAccountInfoWithOpts(ctx context.Context, addr 
 }
 
 func newChain(id string, cfg *SolanaConfig, ks loop.Keystore, cfgs Configs, lggr logger.Logger) (*chain, error) {
-	lggr = logger.With(lggr, "chainID", id, "chainSet", "solana")
+	lggr = logger.With(lggr, "chainID", id, "chain", "solana")
 	var ch = chain{
 		id:          id,
 		cfg:         cfg,

--- a/core/internal/features/ocr2/features_ocr2_test.go
+++ b/core/internal/features/ocr2/features_ocr2_test.go
@@ -266,8 +266,8 @@ func TestIntegration_OCR2(t *testing.T) {
 	err = bootstrapNode.app.Start(testutils.Context(t))
 	require.NoError(t, err)
 
-	chainSet := bootstrapNode.app.GetRelayers().LegacyEVMChains()
-	require.NotNil(t, chainSet)
+	emvChains := bootstrapNode.app.GetRelayers().LegacyEVMChains()
+	require.NotNil(t, emvChains)
 	ocrJob, err := ocrbootstrap.ValidatedBootstrapSpecToml(fmt.Sprintf(`
 type				= "bootstrap"
 name				= "bootstrap"

--- a/core/services/chainlink/relayer_factory.go
+++ b/core/services/chainlink/relayer_factory.go
@@ -39,7 +39,7 @@ type EVMFactoryConfig struct {
 }
 
 func (r *RelayerFactory) NewEVM(ctx context.Context, config EVMFactoryConfig) (map[relay.ID]evmrelay.LoopRelayAdapter, error) {
-	// TODO impl EVM loop. For now always 'fallback' to an adapter and embedded chainset
+	// TODO impl EVM loop. For now always 'fallback' to an adapter and embedded chain
 
 	relayers := make(map[relay.ID]evmrelay.LoopRelayAdapter)
 
@@ -101,7 +101,8 @@ func (r *RelayerFactory) NewSolana(ks keystore.Solana, chainCfgs solana.SolanaCo
 			continue
 		}
 
-		// all the lower level APIs expect chainsets. create a single valued set per id
+		// all the lower level APIs expect a config slice. create a single valued set per id
+		// TODO BCF-2605: clean this up
 		singleChainCfg := solana.SolanaConfigs{chainCfg}
 
 		if cmdName := env.SolanaPluginCmd.Get(); cmdName != "" {
@@ -174,7 +175,8 @@ func (r *RelayerFactory) NewStarkNet(ks keystore.StarkNet, chainCfgs starknet.St
 			continue
 		}
 
-		// all the lower level APIs expect chainsets. create a single valued set per id
+		// all the lower level APIs expect a config slice. create a single valued set per id
+		// TODO BCF-2605: clean this up
 		singleChainCfg := starknet.StarknetConfigs{chainCfg}
 
 		if cmdName := env.StarknetPluginCmd.Get(); cmdName != "" {
@@ -197,7 +199,7 @@ func (r *RelayerFactory) NewStarkNet(ks keystore.StarkNet, chainCfgs starknet.St
 			// be compatible with instantiating a starknet transaction manager KeystoreAdapter within the LOOPp executable.
 			starknetRelayers[relayId] = loop.NewRelayerService(starkLggr, r.GRPCOpts, starknetCmdFn, string(cfgTOML), loopKs)
 		} else {
-			// fallback to embedded chainset
+			// fallback to embedded chain
 			opts := starknet.ChainOpts{
 				Logger:   starkLggr,
 				KeyStore: loopKs,
@@ -230,8 +232,6 @@ func (r *RelayerFactory) NewCosmos(ctx context.Context, config CosmosFactoryConf
 	// create one relayer per chain id
 	for _, chainCfg := range config.CosmosConfigs {
 		relayId := relay.ID{Network: relay.Cosmos, ChainID: relay.ChainID(*chainCfg.ChainID)}
-		// all the lower level APIs expect chainsets. create a single valued set per id
-		// TODO: Cosmos LOOPp impl. For now, use relayer adapter
 
 		opts := cosmos.ChainOpts{
 			QueryConfig:      r.QConfig,

--- a/core/services/ocr2/delegate_test.go
+++ b/core/services/ocr2/delegate_test.go
@@ -172,7 +172,7 @@ func TestGetEVMEffectiveTransmitterID(t *testing.T) {
 		})
 	}
 
-	t.Run("when forwarders are enabled and chainset retrieval fails, error should be handled", func(t *testing.T) {
+	t.Run("when forwarders are enabled and chain retrieval fails, error should be handled", func(t *testing.T) {
 		jb, err := ocr2validate.ValidatedOracleSpecToml(config.OCR2(), config.Insecure(), testspecs.OCR2EVMSpecMinimal)
 		require.NoError(t, err)
 		jb.ForwardingAllowed = true

--- a/core/services/ocr2/plugins/ocr2vrf/internal/ocr2vrf_integration_test.go
+++ b/core/services/ocr2/plugins/ocr2vrf/internal/ocr2vrf_integration_test.go
@@ -431,8 +431,8 @@ func runOCR2VRFTest(t *testing.T, useForwarders bool) {
 	err = bootstrapNode.app.Start(testutils.Context(t))
 	require.NoError(t, err)
 
-	chainSet := bootstrapNode.app.GetRelayers().LegacyEVMChains()
-	require.NotNil(t, chainSet)
+	evmChains := bootstrapNode.app.GetRelayers().LegacyEVMChains()
+	require.NotNil(t, evmChains)
 	bootstrapJobSpec := fmt.Sprintf(`
 type				= "bootstrap"
 name				= "bootstrap"

--- a/core/services/relay/evm/relayer_extender.go
+++ b/core/services/relay/evm/relayer_extender.go
@@ -128,7 +128,6 @@ func (s *ChainRelayerExt) Close() (err error) {
 }
 
 func (s *ChainRelayerExt) Name() string {
-	// we set each private chainSet logger to contain the chain id
 	return s.chain.Name()
 }
 
@@ -142,7 +141,7 @@ func (s *ChainRelayerExt) Ready() (err error) {
 
 var ErrInconsistentChainRelayerExtender = errors.New("inconsistent evm chain relayer extender")
 
-// Chainset interface remove after BFC-2441
+// Legacy interface remove after BFC-2441, BCF-2564
 
 func (s *ChainRelayerExt) SendTx(ctx context.Context, from, to string, amount *big.Int, balanceCheck bool) error {
 	return s.Transact(ctx, from, to, amount, balanceCheck)

--- a/core/services/relay/relay.go
+++ b/core/services/relay/relay.go
@@ -102,7 +102,7 @@ func (c ChainID) Int64() (int64, error) {
 	return int64(i), nil
 }
 
-// RelayerExt is a subset of [loop.Relayer] for adapting [types.Relayer], typically with a ChainSet. See [relayerAdapter].
+// RelayerExt is a subset of [loop.Relayer] for adapting [types.Relayer], typically with a Chain. See [relayerAdapter].
 type RelayerExt interface {
 	types.ChainService
 	// TODO remove after BFC-2441

--- a/core/web/resolver/eth_key_test.go
+++ b/core/web/resolver/eth_key_test.go
@@ -252,7 +252,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 		},
 
 		{
-			name:          "Empty set on #chainSet.Get()",
+			name:          "Empty set on legacy evm chains",
 			authenticated: true,
 			before: func(f *gqlTestFramework) {
 				states := []ethkey.State{


### PR DESCRIPTION
ChainSets are gone. This is cleanup to remove cruft in names and comments