### PR TITLE
Optimise log poller replay

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/integration_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/integration_test.go
@@ -61,6 +61,9 @@ func TestIntegration_LogEventProvider(t *testing.T) {
 
 	n := 10
 
+	backend.Commit()
+	lp.PollAndSaveLogs(ctx, 1) // Ensure log poller has a latest block
+
 	ids, addrs, contracts := deployUpkeepCounter(ctx, t, n, ethClient, backend, carrol, logProvider)
 	lp.PollAndSaveLogs(ctx, int64(n))
 

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/integration_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/integration_test.go
@@ -149,6 +149,8 @@ func TestIntegration_LogEventProvider_UpdateConfig(t *testing.T) {
 	provider, _ := setup(logger.TestLogger(t), lp, nil, utilsABI, nil, filterStore, opts)
 	logProvider := provider.(logprovider.LogEventProviderTest)
 
+	backend.Commit()
+	lp.PollAndSaveLogs(ctx, 1) // Ensure log poller has a latest block
 	_, addrs, contracts := deployUpkeepCounter(ctx, t, 1, ethClient, backend, carrol, logProvider)
 	lp.PollAndSaveLogs(ctx, int64(5))
 	require.Equal(t, 1, len(contracts))
@@ -222,6 +224,8 @@ func TestIntegration_LogEventProvider_Backfill(t *testing.T) {
 
 	n := 10
 
+	backend.Commit()
+	lp.PollAndSaveLogs(ctx, 1) // Ensure log poller has a latest block
 	_, _, contracts := deployUpkeepCounter(ctx, t, n, ethClient, backend, carrol, logProvider)
 
 	poll := pollFn(ctx, t, lp, ethClient)
@@ -276,6 +280,8 @@ func TestIntegration_LogEventProvider_RateLimit(t *testing.T) {
 		filterStore := logprovider.NewUpkeepFilterStore()
 		provider, _ := setup(logger.TestLogger(t), lp, nil, utilsABI, nil, filterStore, opts)
 		logProvider := provider.(logprovider.LogEventProviderTest)
+		backend.Commit()
+		lp.PollAndSaveLogs(ctx, 1) // Ensure log poller has a latest block
 
 		rounds := 5
 		numberOfUserContracts := 10
@@ -480,8 +486,10 @@ func TestIntegration_LogRecoverer_Backfill(t *testing.T) {
 	provider, recoverer := setup(logger.TestLogger(t), lp, nil, utilsABI, &mockUpkeepStateStore{}, filterStore, opts)
 	logProvider := provider.(logprovider.LogEventProviderTest)
 
-	n := 10
+	backend.Commit()
+	lp.PollAndSaveLogs(ctx, 1) // Ensure log poller has a latest block
 
+	n := 10
 	_, _, contracts := deployUpkeepCounter(ctx, t, n, ethClient, backend, carrol, logProvider)
 
 	poll := pollFn(ctx, t, lp, ethClient)

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/integration_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/integration_test.go
@@ -61,7 +61,7 @@ func TestIntegration_LogEventProvider(t *testing.T) {
 
 	n := 10
 
-	ids, addrs, contracts := deployUpkeepCounter(t, n, ethClient, backend, carrol, logProvider)
+	ids, addrs, contracts := deployUpkeepCounter(ctx, t, n, ethClient, backend, carrol, logProvider)
 	lp.PollAndSaveLogs(ctx, int64(n))
 
 	go func() {
@@ -108,7 +108,7 @@ func TestIntegration_LogEventProvider(t *testing.T) {
 
 		// re-register filters
 		for i, id := range ids {
-			err = logProvider2.RegisterFilter(logprovider.FilterOptions{
+			err = logProvider2.RegisterFilter(ctx, logprovider.FilterOptions{
 				UpkeepID:      id,
 				TriggerConfig: newPlainLogTriggerConfig(addrs[i]),
 				// using block number at which the upkeep was registered,
@@ -146,7 +146,7 @@ func TestIntegration_LogEventProvider_UpdateConfig(t *testing.T) {
 	provider, _ := setup(logger.TestLogger(t), lp, nil, utilsABI, nil, filterStore, opts)
 	logProvider := provider.(logprovider.LogEventProviderTest)
 
-	_, addrs, contracts := deployUpkeepCounter(t, 1, ethClient, backend, carrol, logProvider)
+	_, addrs, contracts := deployUpkeepCounter(ctx, t, 1, ethClient, backend, carrol, logProvider)
 	lp.PollAndSaveLogs(ctx, int64(5))
 	require.Equal(t, 1, len(contracts))
 	require.Equal(t, 1, len(addrs))
@@ -158,14 +158,14 @@ func TestIntegration_LogEventProvider_UpdateConfig(t *testing.T) {
 		b, err := ethClient.BlockByHash(ctx, backend.Commit())
 		require.NoError(t, err)
 		bn := b.Number()
-		err = logProvider.RegisterFilter(logprovider.FilterOptions{
+		err = logProvider.RegisterFilter(ctx, logprovider.FilterOptions{
 			UpkeepID:      id,
 			TriggerConfig: cfg,
 			UpdateBlock:   bn.Uint64(),
 		})
 		require.NoError(t, err)
 		// old block
-		err = logProvider.RegisterFilter(logprovider.FilterOptions{
+		err = logProvider.RegisterFilter(ctx, logprovider.FilterOptions{
 			UpkeepID:      id,
 			TriggerConfig: cfg,
 			UpdateBlock:   bn.Uint64() - 1,
@@ -175,7 +175,7 @@ func TestIntegration_LogEventProvider_UpdateConfig(t *testing.T) {
 		b, err = ethClient.BlockByHash(ctx, backend.Commit())
 		require.NoError(t, err)
 		bn = b.Number()
-		err = logProvider.RegisterFilter(logprovider.FilterOptions{
+		err = logProvider.RegisterFilter(ctx, logprovider.FilterOptions{
 			UpkeepID:      id,
 			TriggerConfig: cfg,
 			UpdateBlock:   bn.Uint64(),
@@ -190,7 +190,7 @@ func TestIntegration_LogEventProvider_UpdateConfig(t *testing.T) {
 		b, err := ethClient.BlockByHash(ctx, backend.Commit())
 		require.NoError(t, err)
 		bn := b.Number()
-		err = logProvider.RegisterFilter(logprovider.FilterOptions{
+		err = logProvider.RegisterFilter(ctx, logprovider.FilterOptions{
 			UpkeepID:      id,
 			TriggerConfig: cfg,
 			UpdateBlock:   bn.Uint64(),
@@ -219,7 +219,7 @@ func TestIntegration_LogEventProvider_Backfill(t *testing.T) {
 
 	n := 10
 
-	_, _, contracts := deployUpkeepCounter(t, n, ethClient, backend, carrol, logProvider)
+	_, _, contracts := deployUpkeepCounter(ctx, t, n, ethClient, backend, carrol, logProvider)
 
 	poll := pollFn(ctx, t, lp, ethClient)
 
@@ -280,6 +280,7 @@ func TestIntegration_LogEventProvider_RateLimit(t *testing.T) {
 
 		// deployUpkeepCounter creates 'n' blocks and 'n' contracts
 		ids, _, contracts := deployUpkeepCounter(
+			ctx,
 			t,
 			numberOfUserContracts,
 			ethClient,
@@ -478,7 +479,7 @@ func TestIntegration_LogRecoverer_Backfill(t *testing.T) {
 
 	n := 10
 
-	_, _, contracts := deployUpkeepCounter(t, n, ethClient, backend, carrol, logProvider)
+	_, _, contracts := deployUpkeepCounter(ctx, t, n, ethClient, backend, carrol, logProvider)
 
 	poll := pollFn(ctx, t, lp, ethClient)
 
@@ -603,6 +604,7 @@ func triggerEvents(
 }
 
 func deployUpkeepCounter(
+	ctx context.Context,
 	t *testing.T,
 	n int,
 	ethClient *evmclient.SimulatedBackendClient,
@@ -631,7 +633,7 @@ func deployUpkeepCounter(
 		b, err := ethClient.BlockByHash(context.Background(), backend.Commit())
 		require.NoError(t, err)
 		bn := b.Number()
-		err = logProvider.RegisterFilter(logprovider.FilterOptions{
+		err = logProvider.RegisterFilter(ctx, logprovider.FilterOptions{
 			UpkeepID:      id,
 			TriggerConfig: newPlainLogTriggerConfig(upkeepAddr),
 			UpdateBlock:   bn.Uint64(),

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider.go
@@ -51,7 +51,7 @@ type FilterOptions struct {
 
 type LogTriggersLifeCycle interface {
 	// RegisterFilter registers the filter (if valid) for the given upkeepID.
-	RegisterFilter(opts FilterOptions) error
+	RegisterFilter(ctx context.Context, opts FilterOptions) error
 	// UnregisterFilter removes the filter for the given upkeepID.
 	UnregisterFilter(upkeepID *big.Int) error
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider_life_cycle.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider_life_cycle.go
@@ -2,6 +2,7 @@ package logprovider
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"math/big"
@@ -11,11 +12,15 @@ import (
 	"golang.org/x/time/rate"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
+	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 )
 
 var (
 	// LogRetention is the amount of time to retain logs for.
 	LogRetention = 24 * time.Hour
+	// When adding a filter in log poller, backfill is done for this number of blocks
+	// from latest
+	LogBackfillBuffer = 250
 )
 
 func (p *logEventProvider) RefreshActiveUpkeeps(ids ...*big.Int) ([]*big.Int, error) {
@@ -54,7 +59,7 @@ func (p *logEventProvider) RefreshActiveUpkeeps(ids ...*big.Int) ([]*big.Int, er
 	return newIDs, merr
 }
 
-func (p *logEventProvider) RegisterFilter(opts FilterOptions) error {
+func (p *logEventProvider) RegisterFilter(ctx context.Context, opts FilterOptions) error {
 	upkeepID, cfg := opts.UpkeepID, opts.TriggerConfig
 	if err := p.validateLogTriggerConfig(cfg); err != nil {
 		return fmt.Errorf("invalid log trigger config: %w", err)
@@ -97,7 +102,7 @@ func (p *logEventProvider) RegisterFilter(opts FilterOptions) error {
 	filter.addr = cfg.ContractAddress.Bytes()
 	filter.topics = []common.Hash{cfg.Topic0, cfg.Topic1, cfg.Topic2, cfg.Topic3}
 
-	if err := p.register(lpFilter, filter); err != nil {
+	if err := p.register(ctx, lpFilter, filter); err != nil {
 		return fmt.Errorf("failed to register upkeep filter %s: %w", filter.upkeepID.String(), err)
 	}
 
@@ -105,13 +110,23 @@ func (p *logEventProvider) RegisterFilter(opts FilterOptions) error {
 }
 
 // register registers the upkeep filter with the log poller and adds it to the filter store.
-func (p *logEventProvider) register(lpFilter logpoller.Filter, ufilter upkeepFilter) error {
+func (p *logEventProvider) register(ctx context.Context, lpFilter logpoller.Filter, ufilter upkeepFilter) error {
+	latest, err := p.poller.LatestBlock(pg.WithParentCtx(ctx))
+	if err != nil {
+		return fmt.Errorf("failed to get latest block while registering filter: %w", err)
+	}
 	if err := p.poller.RegisterFilter(lpFilter); err != nil {
 		return err
 	}
 	p.filterStore.AddActiveUpkeeps(ufilter)
-	// TODO: Only do replay if this is a new filter seen in log poller
-	// p.poller.ReplayAsync(int64(ufilter.configUpdateBlock))
+	backfillBlock := latest - int64(LogBackfillBuffer)
+	if backfillBlock < 0 {
+		// New chain, backfill from start
+		backfillBlock = 0
+	}
+	// TODO: Optimise to do backfill from ufilter.configUpdateBlock only for new filters
+	// if it is not too old
+	p.poller.ReplayAsync(backfillBlock)
 
 	return nil
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider_life_cycle.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider_life_cycle.go
@@ -110,7 +110,8 @@ func (p *logEventProvider) register(lpFilter logpoller.Filter, ufilter upkeepFil
 		return err
 	}
 	p.filterStore.AddActiveUpkeeps(ufilter)
-	p.poller.ReplayAsync(int64(ufilter.configUpdateBlock))
+	// TODO: Only do replay if this is a new filter seen in log poller
+	// p.poller.ReplayAsync(int64(ufilter.configUpdateBlock))
 
 	return nil
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider_life_cycle.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider_life_cycle.go
@@ -120,9 +120,9 @@ func (p *logEventProvider) register(ctx context.Context, lpFilter logpoller.Filt
 	}
 	p.filterStore.AddActiveUpkeeps(ufilter)
 	backfillBlock := latest - int64(LogBackfillBuffer)
-	if backfillBlock < 0 {
+	if backfillBlock < 1 {
 		// New chain, backfill from start
-		backfillBlock = 0
+		backfillBlock = 1
 	}
 	// TODO: Optimise to do backfill from ufilter.configUpdateBlock only for new filters
 	// if it is not too old

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider_life_cycle_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider_life_cycle_test.go
@@ -1,6 +1,7 @@
 package logprovider
 
 import (
+	"context"
 	"fmt"
 	"math/big"
 	"testing"
@@ -93,7 +94,9 @@ func TestLogEventProvider_LifeCycle(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			err := p.RegisterFilter(FilterOptions{
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+			err := p.RegisterFilter(ctx, FilterOptions{
 				UpkeepID:      tc.upkeepID,
 				TriggerConfig: tc.upkeepCfg,
 				UpdateBlock:   tc.cfgUpdateBlock,
@@ -111,6 +114,8 @@ func TestLogEventProvider_LifeCycle(t *testing.T) {
 }
 
 func TestEventLogProvider_RefreshActiveUpkeeps(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	mp := new(mocks.LogPoller)
 	mp.On("RegisterFilter", mock.Anything).Return(nil)
 	mp.On("UnregisterFilter", mock.Anything).Return(nil)
@@ -118,7 +123,7 @@ func TestEventLogProvider_RefreshActiveUpkeeps(t *testing.T) {
 
 	p := NewLogProvider(logger.TestLogger(t), mp, &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200))
 
-	require.NoError(t, p.RegisterFilter(FilterOptions{
+	require.NoError(t, p.RegisterFilter(ctx, FilterOptions{
 		UpkeepID: core.GenUpkeepID(ocr2keepers.LogTrigger, "1111").BigInt(),
 		TriggerConfig: LogTriggerConfig{
 			ContractAddress: common.BytesToAddress(common.LeftPadBytes([]byte{1, 2, 3, 4}, 20)),
@@ -126,7 +131,7 @@ func TestEventLogProvider_RefreshActiveUpkeeps(t *testing.T) {
 		},
 		UpdateBlock: uint64(0),
 	}))
-	require.NoError(t, p.RegisterFilter(FilterOptions{
+	require.NoError(t, p.RegisterFilter(ctx, FilterOptions{
 		UpkeepID: core.GenUpkeepID(ocr2keepers.LogTrigger, "2222").BigInt(),
 		TriggerConfig: LogTriggerConfig{
 			ContractAddress: common.BytesToAddress(common.LeftPadBytes([]byte{1, 2, 3, 4}, 20)),

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider_life_cycle_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider_life_cycle_test.go
@@ -89,6 +89,7 @@ func TestLogEventProvider_LifeCycle(t *testing.T) {
 	mp := new(mocks.LogPoller)
 	mp.On("RegisterFilter", mock.Anything).Return(nil)
 	mp.On("UnregisterFilter", mock.Anything).Return(nil)
+	mp.On("LatestBlock", mock.Anything).Return(int64(0), nil)
 	mp.On("ReplayAsync", mock.Anything).Return(nil)
 	p := NewLogProvider(logger.TestLogger(t), mp, &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200))
 
@@ -119,6 +120,7 @@ func TestEventLogProvider_RefreshActiveUpkeeps(t *testing.T) {
 	mp := new(mocks.LogPoller)
 	mp.On("RegisterFilter", mock.Anything).Return(nil)
 	mp.On("UnregisterFilter", mock.Anything).Return(nil)
+	mp.On("LatestBlock", mock.Anything).Return(int64(0), nil)
 	mp.On("ReplayAsync", mock.Anything).Return(nil)
 
 	p := NewLogProvider(logger.TestLogger(t), mp, &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200))

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/provider_test.go
@@ -261,7 +261,7 @@ func TestLogEventProvider_ReadLogs(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		cfg, f := newEntry(p, i+1)
 		ids = append(ids, f.upkeepID)
-		require.NoError(t, p.RegisterFilter(FilterOptions{
+		require.NoError(t, p.RegisterFilter(ctx, FilterOptions{
 			UpkeepID:      f.upkeepID,
 			TriggerConfig: cfg,
 		}))

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/registry.go
@@ -582,7 +582,7 @@ func (r *EvmRegistry) updateTriggerConfig(id *big.Int, cfg []byte, logBlock uint
 			r.lggr.Warnw("failed to unpack log upkeep config", "upkeepID", id.String(), "err", err)
 			return nil
 		}
-		if err := r.logEventProvider.RegisterFilter(logprovider.FilterOptions{
+		if err := r.logEventProvider.RegisterFilter(r.ctx, logprovider.FilterOptions{
 			TriggerConfig: logprovider.LogTriggerConfig(parsed),
 			UpkeepID:      id,
 			UpdateBlock:   logBlock,

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/registry_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/registry_test.go
@@ -1,6 +1,7 @@
 package evm
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"math/big"
@@ -534,7 +535,7 @@ func (p *mockLogEventProvider) RefreshActiveUpkeeps(ids ...*big.Int) ([]*big.Int
 	return p.RefreshActiveUpkeepsFn(ids...)
 }
 
-func (p *mockLogEventProvider) RegisterFilter(opts logprovider.FilterOptions) error {
+func (p *mockLogEventProvider) RegisterFilter(ctx context.Context, opts logprovider.FilterOptions) error {
 	return p.RegisterFilterFn(opts)
 }
 


### PR DESCRIPTION
Doing a big async replay was causing the log poller to get stuck. Upon every restart it was done from the config start block which would become a big range as time went by.

Instead of trying to backfill from config update block, only backfill from a small history from latest block (BackfillBuffer) and do not offer better backfill protection than that. Added a todo to explore better backfill protection