### PR TITLE
Make MercuryProvider extend the PluginProvider interface

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -298,7 +298,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 // indirect
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230831132059-42af68994512 // indirect
-	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230901143551-bf6bd84d6938 // indirect
+	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230904121145-c6de027ac133 // indirect
 	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230831134610-680240b97aca // indirect
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230901115736-bbabe542a918 // indirect
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20230829114801-14bf715f805e // indirect

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1372,8 +1372,8 @@ github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 h1:T3lFWumv
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230831132059-42af68994512 h1:DojChlaudA1HAxwQPKmt/EDf36OUeFJ0LJBYClauMyU=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230831132059-42af68994512/go.mod h1:xMwqRdj5vqYhCJXgKVqvyAwdcqM6ZAEhnwEQ4Khsop8=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230901143551-bf6bd84d6938 h1:LnxS4RoDcUS4+zXoY/gaV4BB6u90DgW3LtyFCoCpJzY=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230901143551-bf6bd84d6938/go.mod h1:gWclxGW7rLkbjXn7FGizYlyKhp/boekto4MEYGyiMG4=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230904121145-c6de027ac133 h1:YZQLCMKGa5sF+BV6M+yUnJ+SFuLHry8A/xFkSO++9hs=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230904121145-c6de027ac133/go.mod h1:gWclxGW7rLkbjXn7FGizYlyKhp/boekto4MEYGyiMG4=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230831134610-680240b97aca h1:x7M0m512gtXw5Z4B1WJPZ52VgshoIv+IvHqQ8hsH4AE=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230831134610-680240b97aca/go.mod h1:RIUJXn7EVp24TL2p4FW79dYjyno23x5mjt1nKN+5WEk=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230901115736-bbabe542a918 h1:ByVauKFXphRlSNG47lNuxZ9aicu+r8AoNp933VRPpCw=

--- a/core/services/ocr2/plugins/mercury/plugin.go
+++ b/core/services/ocr2/plugins/mercury/plugin.go
@@ -67,7 +67,7 @@ func NewServices(
 			runResults,
 			chEnhancedTelem,
 			chainHeadTracker,
-			ocr2Provider.ContractTransmitter(),
+			ocr2Provider.MercuryServerFetcher(),
 			pluginConfig.InitialBlockNumber.Ptr(),
 			feedID,
 		)
@@ -87,7 +87,7 @@ func NewServices(
 			lggr,
 			runResults,
 			chEnhancedTelem,
-			ocr2Provider.ContractTransmitter(),
+			ocr2Provider.MercuryServerFetcher(),
 			*pluginConfig.LinkFeedID,
 			*pluginConfig.NativeFeedID,
 		)
@@ -107,7 +107,7 @@ func NewServices(
 			lggr,
 			runResults,
 			chEnhancedTelem,
-			ocr2Provider.ContractTransmitter(),
+			ocr2Provider.MercuryServerFetcher(),
 			*pluginConfig.LinkFeedID,
 			*pluginConfig.NativeFeedID,
 		)

--- a/core/services/relay/evm/mercury_provider.go
+++ b/core/services/relay/evm/mercury_provider.go
@@ -4,13 +4,15 @@ import (
 	"context"
 	"errors"
 
+	"golang.org/x/exp/maps"
+
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
+
 	relaymercury "github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury"
 	relaymercuryv1 "github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury/v1"
 	relaymercuryv2 "github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury/v2"
 	relaymercuryv3 "github.com/smartcontractkit/chainlink-relay/pkg/reportingplugins/mercury/v3"
 	relaytypes "github.com/smartcontractkit/chainlink-relay/pkg/types"
-	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
-	"golang.org/x/exp/maps"
 
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services"
@@ -96,6 +98,10 @@ func (p *mercuryProvider) ReportCodecV3() relaymercuryv3.ReportCodec {
 	return p.reportCodecV3
 }
 
-func (p *mercuryProvider) ContractTransmitter() relaymercury.Transmitter {
+func (p *mercuryProvider) ContractTransmitter() ocrtypes.ContractTransmitter {
+	return p.transmitter
+}
+
+func (p *mercuryProvider) MercuryServerFetcher() relaymercury.MercuryServerFetcher {
 	return p.transmitter
 }

--- a/go.mod
+++ b/go.mod
@@ -66,7 +66,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230831132059-42af68994512
-	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230901143551-bf6bd84d6938
+	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230904121145-c6de027ac133
 	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230831134610-680240b97aca
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230901115736-bbabe542a918
 	github.com/smartcontractkit/libocr v0.0.0-20230816220705-665e93233ae5

--- a/go.sum
+++ b/go.sum
@@ -1372,8 +1372,8 @@ github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 h1:T3lFWumv
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230831132059-42af68994512 h1:DojChlaudA1HAxwQPKmt/EDf36OUeFJ0LJBYClauMyU=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230831132059-42af68994512/go.mod h1:xMwqRdj5vqYhCJXgKVqvyAwdcqM6ZAEhnwEQ4Khsop8=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230901143551-bf6bd84d6938 h1:LnxS4RoDcUS4+zXoY/gaV4BB6u90DgW3LtyFCoCpJzY=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230901143551-bf6bd84d6938/go.mod h1:gWclxGW7rLkbjXn7FGizYlyKhp/boekto4MEYGyiMG4=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230904121145-c6de027ac133 h1:YZQLCMKGa5sF+BV6M+yUnJ+SFuLHry8A/xFkSO++9hs=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230904121145-c6de027ac133/go.mod h1:gWclxGW7rLkbjXn7FGizYlyKhp/boekto4MEYGyiMG4=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230831134610-680240b97aca h1:x7M0m512gtXw5Z4B1WJPZ52VgshoIv+IvHqQ8hsH4AE=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230831134610-680240b97aca/go.mod h1:RIUJXn7EVp24TL2p4FW79dYjyno23x5mjt1nKN+5WEk=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230901115736-bbabe542a918 h1:ByVauKFXphRlSNG47lNuxZ9aicu+r8AoNp933VRPpCw=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -383,7 +383,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 // indirect
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230831132059-42af68994512 // indirect
-	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230901143551-bf6bd84d6938 // indirect
+	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230904121145-c6de027ac133 // indirect
 	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230831134610-680240b97aca // indirect
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230901115736-bbabe542a918 // indirect
 	github.com/smartcontractkit/sqlx v1.3.5-0.20210805004948-4be295aacbeb // indirect

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -2246,8 +2246,8 @@ github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230831132059-42af6899451
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20230831132059-42af68994512/go.mod h1:xMwqRdj5vqYhCJXgKVqvyAwdcqM6ZAEhnwEQ4Khsop8=
 github.com/smartcontractkit/chainlink-env v0.36.0 h1:CFOjs0c0y3lrHi/fl5qseCH9EQa5W/6CFyOvmhe2VnA=
 github.com/smartcontractkit/chainlink-env v0.36.0/go.mod h1:NbRExHmJGnKSYXmvNuJx5VErSx26GtE1AEN/CRzYOg8=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230901143551-bf6bd84d6938 h1:LnxS4RoDcUS4+zXoY/gaV4BB6u90DgW3LtyFCoCpJzY=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230901143551-bf6bd84d6938/go.mod h1:gWclxGW7rLkbjXn7FGizYlyKhp/boekto4MEYGyiMG4=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230904121145-c6de027ac133 h1:YZQLCMKGa5sF+BV6M+yUnJ+SFuLHry8A/xFkSO++9hs=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230904121145-c6de027ac133/go.mod h1:gWclxGW7rLkbjXn7FGizYlyKhp/boekto4MEYGyiMG4=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230831134610-680240b97aca h1:x7M0m512gtXw5Z4B1WJPZ52VgshoIv+IvHqQ8hsH4AE=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230831134610-680240b97aca/go.mod h1:RIUJXn7EVp24TL2p4FW79dYjyno23x5mjt1nKN+5WEk=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230901115736-bbabe542a918 h1:ByVauKFXphRlSNG47lNuxZ9aicu+r8AoNp933VRPpCw=


### PR DESCRIPTION
We want to replace the New<Product>Provider methods in the relayer interface with a single, polymorphic NewPluginProvider method which extends a common PluginProvider interface exposing the three OCR components required to set up an Oracle.

At the moment the MedianProvider and FunctionsProvider both extend this interface, but Mercury does not since it extends the OCR ContractTransmitter with a few additional methods.

This modifies Mercury's interface by splitting this transmitter into two separate components, once which implements ocrtypes.ContractTransmitter and another which encompasses the additional methods (and implements mercury.MercuryServerFetcher). This is a largely cosmetic change, since under the hood the transmitter can remain the same struct, just exposed in two different methods.