### PR TITLE
Allow burst in log recoverer when it lags

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer_test.go
@@ -353,7 +353,7 @@ func TestLogRecoverer_Recover(t *testing.T) {
 			[]int64{200, 0, 450},
 		},
 		{
-			"lastRePollBlock updated with burst",
+			"lastRePollBlock updated with burst when lagging behind",
 			100,
 			50000,
 			nil,
@@ -383,7 +383,7 @@ func TestLogRecoverer_Recover(t *testing.T) {
 			[]int64{600},
 		},
 		{
-			"lastRePollBlock starts at configUpdateBlock if higher than lastRePollBlock",
+			"recovery starts at configUpdateBlock if higher than lastRePollBlock",
 			100,
 			5000,
 			nil,

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer_test.go
@@ -328,6 +328,14 @@ func TestLogRecoverer_Recover(t *testing.T) {
 					},
 					configUpdateBlock: 450, // should be filtered out
 				},
+				{
+					upkeepID: big.NewInt(3),
+					addr:     common.HexToAddress("0x2").Bytes(),
+					topics: []common.Hash{
+						common.HexToHash("0x2"),
+					},
+					lastRePollBlock: 450, // should be filtered out, as its higher than latest-lookback
+				},
 			},
 			[]ocr2keepers.UpkeepState{ocr2keepers.UnknownState},
 			nil,
@@ -342,7 +350,67 @@ func TestLogRecoverer_Recover(t *testing.T) {
 			nil,
 			nil,
 			[]string{"84c83c79c2be2c3eabd8d35986a2a798d9187564d7f4f8f96c5a0f40f50bed3f"},
-			[]int64{200, 0},
+			[]int64{200, 0, 450},
+		},
+		{
+			"lastRePollBlock updated with burst",
+			100,
+			50000,
+			nil,
+			[]upkeepFilter{
+				{
+					upkeepID: big.NewInt(1),
+					addr:     common.HexToAddress("0x1").Bytes(),
+					topics: []common.Hash{
+						common.HexToHash("0x1"),
+					},
+					lastRePollBlock: 100, // Should be updated with burst
+				},
+			},
+			[]ocr2keepers.UpkeepState{ocr2keepers.UnknownState},
+			nil,
+			[]logpoller.Log{
+				{
+					BlockNumber: 2,
+					TxHash:      common.HexToHash("0x111"),
+					LogIndex:    1,
+					BlockHash:   common.HexToHash("0x2"),
+				},
+			},
+			nil,
+			nil,
+			[]string{"84c83c79c2be2c3eabd8d35986a2a798d9187564d7f4f8f96c5a0f40f50bed3f"},
+			[]int64{600},
+		},
+		{
+			"lastRePollBlock starts at configUpdateBlock",
+			100,
+			5000,
+			nil,
+			[]upkeepFilter{
+				{
+					upkeepID: big.NewInt(1),
+					addr:     common.HexToAddress("0x1").Bytes(),
+					topics: []common.Hash{
+						common.HexToHash("0x1"),
+					},
+					configUpdateBlock: 500,
+				},
+			},
+			[]ocr2keepers.UpkeepState{ocr2keepers.UnknownState},
+			nil,
+			[]logpoller.Log{
+				{
+					BlockNumber: 2,
+					TxHash:      common.HexToHash("0x111"),
+					LogIndex:    1,
+					BlockHash:   common.HexToHash("0x2"),
+				},
+			},
+			nil,
+			nil,
+			[]string{"84c83c79c2be2c3eabd8d35986a2a798d9187564d7f4f8f96c5a0f40f50bed3f"},
+			[]int64{700}, // should be configUpdateBlock + recoveryLogsBuffer
 		},
 	}
 

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer_test.go
@@ -383,7 +383,7 @@ func TestLogRecoverer_Recover(t *testing.T) {
 			[]int64{600},
 		},
 		{
-			"lastRePollBlock starts at configUpdateBlock",
+			"lastRePollBlock starts at configUpdateBlock if higher than lastRePollBlock",
 			100,
 			5000,
 			nil,
@@ -394,6 +394,7 @@ func TestLogRecoverer_Recover(t *testing.T) {
 					topics: []common.Hash{
 						common.HexToHash("0x1"),
 					},
+					lastRePollBlock:   100,
 					configUpdateBlock: 500,
 				},
 			},

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer_test.go
@@ -231,7 +231,7 @@ func TestLogRecoverer_Recover(t *testing.T) {
 		{
 			"no filters",
 			200,
-			200,
+			300,
 			nil,
 			[]upkeepFilter{},
 			[]ocr2keepers.UpkeepState{},


### PR DESCRIPTION
Currently we see on staging that recoverer is lagging a lot. On arbitrum, 24hr contains 345000 blocks which will take recoverer atleast ~10hrs to catch up (and then catch up again on blocks in that time)

To adjust for it in this PR i'm
1. Increasing recoveryLogsBuffer to 200 (same as lookback blocks we use in provider)
2. Allow a burst of 500 blocks when recoverer is lagging by more than 100 iterations