### PR TITLE
Small cleanup in event provider for caching behaviour

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/transmit/event_provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/transmit/event_provider.go
@@ -161,14 +161,9 @@ func (c *TransmitEventProvider) GetLatestEvents(ctx context.Context) ([]ocr2keep
 // processLogs will parse the unseen logs and return the corresponding transmit events.
 func (c *TransmitEventProvider) processLogs(latestBlock int64, logs ...logpoller.Log) ([]ocr2keepers.TransmitEvent, error) {
 	vals := []ocr2keepers.TransmitEvent{}
-	visited := make(map[string]ocr2keepers.TransmitEvent)
 
 	for _, log := range logs {
 		k := c.logKey(log)
-		if _, ok := visited[k]; ok {
-			// ensure we don't have duplicates
-			continue
-		}
 
 		transmitEvent, ok := c.cache.get(ocr2keepers.BlockNumber(log.BlockNumber), k)
 		if !ok {
@@ -213,7 +208,6 @@ func (c *TransmitEventProvider) processLogs(latestBlock int64, logs ...logpoller
 		transmitEvent.Confirmations = latestBlock - int64(transmitEvent.TransmitBlock)
 
 		vals = append(vals, transmitEvent)
-		visited[k] = transmitEvent
 	}
 
 	return vals, nil

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/transmit/event_provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/transmit/event_provider.go
@@ -211,6 +211,7 @@ func (c *TransmitEventProvider) processLogs(latestBlock int64, logs ...logpoller
 		}
 
 		transmitEvent.Confirmations = latestBlock - int64(transmitEvent.TransmitBlock)
+
 		vals = append(vals, transmitEvent)
 		visited[k] = transmitEvent
 	}

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/transmit/event_provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/transmit/event_provider.go
@@ -161,8 +161,13 @@ func (c *TransmitEventProvider) GetLatestEvents(ctx context.Context) ([]ocr2keep
 // processLogs will parse the unseen logs and return the corresponding transmit events.
 func (c *TransmitEventProvider) processLogs(latestBlock int64, logs ...logpoller.Log) ([]ocr2keepers.TransmitEvent, error) {
 	vals := []ocr2keepers.TransmitEvent{}
+	visited := make(map[string]ocr2keepers.TransmitEvent)
 	for _, log := range logs {
 		k := c.logKey(log)
+		if _, ok := visited[k]; ok {
+			// ensure we don't have duplicates
+			continue
+		}
 
 		transmitEvent, ok := c.cache.get(ocr2keepers.BlockNumber(log.BlockNumber), k)
 		if !ok {
@@ -206,6 +211,7 @@ func (c *TransmitEventProvider) processLogs(latestBlock int64, logs ...logpoller
 
 		transmitEvent.Confirmations = latestBlock - int64(transmitEvent.TransmitBlock)
 		vals = append(vals, transmitEvent)
+		visited[k] = transmitEvent
 	}
 
 	return vals, nil

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/transmit/event_provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/transmit/event_provider.go
@@ -162,6 +162,7 @@ func (c *TransmitEventProvider) GetLatestEvents(ctx context.Context) ([]ocr2keep
 func (c *TransmitEventProvider) processLogs(latestBlock int64, logs ...logpoller.Log) ([]ocr2keepers.TransmitEvent, error) {
 	vals := []ocr2keepers.TransmitEvent{}
 	visited := make(map[string]ocr2keepers.TransmitEvent)
+
 	for _, log := range logs {
 		k := c.logKey(log)
 		if _, ok := visited[k]; ok {

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/transmit/event_provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/transmit/event_provider_test.go
@@ -151,7 +151,7 @@ func TestTransmitEventProvider_ProcessLogs(t *testing.T) {
 			false,
 		},
 		{
-			"same log twice",
+			"same log twice", // shouldn't happen in practice as log poller should not return same logs
 			[]transmitEventLog{
 				{
 					Log: logpoller.Log{
@@ -182,6 +182,11 @@ func TestTransmitEventProvider_ProcessLogs(t *testing.T) {
 			},
 			1,
 			[]ocr2keepers.TransmitEvent{
+				{
+					Type:       ocr2keepers.PerformEvent,
+					UpkeepID:   id,
+					CheckBlock: ocr2keepers.BlockNumber(1),
+				},
 				{
 					Type:       ocr2keepers.PerformEvent,
 					UpkeepID:   id,

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/transmit/event_provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/transmit/event_provider_test.go
@@ -151,7 +151,7 @@ func TestTransmitEventProvider_ProcessLogs(t *testing.T) {
 			false,
 		},
 		{
-			"same log twice", // shouldn't happen in practice as log poller should not return same logs
+			"same log twice", // shouldn't happen in practice as log poller should not return duplicate logs
 			[]transmitEventLog{
 				{
 					Log: logpoller.Log{


### PR DESCRIPTION
1. We don't need to add logs to cache every time even if it was present before. Since we now return previously seen logs, we don't need to wait to process all logs before adding to cache and can add them individually 
2. We don't really need the visited array as log poller should not return duplicate logs, cleaning it up