### PR TITLE
fix/gh-actions-setup-postgres: fixing buggy Setup Postgres step

### DIFF
--- a/.github/actions/setup-postgres/wait-for-healthy-postgres.sh
+++ b/.github/actions/setup-postgres/wait-for-healthy-postgres.sh
@@ -2,10 +2,24 @@
 RETRIES=10
 
 until [ $RETRIES -eq 0 ]; do
-  if docker compose ps postgres --status running --format json | jq >/dev/null -e 'if (.[0].Health == "healthy") then true else false end'; then
+  DOCKER_OUTPUT=$(docker compose ps postgres --status running --format json)
+  JSON_TYPE=$(echo "$DOCKER_OUTPUT" | jq -r 'type')
+
+  if [ "$JSON_TYPE" == "array" ]; then
+    HEALTH_STATUS=$(echo "$DOCKER_OUTPUT" | jq -r '.[0].Health')
+  elif [ "$JSON_TYPE" == "object" ]; then
+    HEALTH_STATUS=$(echo "$DOCKER_OUTPUT" | jq -r '.Health')
+  else
+    HEALTH_STATUS="Unknown JSON type: $JSON_TYPE"
+  fi
+
+  echo "postgres health status: $HEALTH_STATUS"
+  if [ "$HEALTH_STATUS" == "healthy" ]; then
     exit 0
   fi
+
   echo "Waiting for postgres server, $((RETRIES--)) remaining attempts..."
   sleep 2
 done
+
 exit 1


### PR DESCRIPTION
`docker compose ps` is sometimes returning an array and sometimes an object. This change makes the script resilient to either state. 