### PR TITLE
Add batch size backoff in log poller insert logs

### DIFF
--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -190,7 +190,7 @@ func (o *ORM) InsertLogs(logs []Log, qopts ...pg.QOpt) error {
 (:evm_chain_id, :log_index, :block_hash, :block_number, :block_timestamp, :address, :event_sig, :topics, :tx_hash, :data, NOW()) ON CONFLICT DO NOTHING`, logs[start:end])
 
 		if err != nil {
-			if errors.Is(err, context.DeadlineExceeded) && batchInsertSize <= 500 {
+			if errors.Is(err, context.DeadlineExceeded) && batchInsertSize > 500 {
 				// In case of DB timeouts, try to insert again with a smaller batch upto a limit
 				batchInsertSize /= 2
 				i -= batchInsertSize // counteract +=batchInsertSize on next loop iteration

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -1,6 +1,7 @@
 package logpoller
 
 import (
+	"context"
 	"database/sql"
 	"math/big"
 	"time"
@@ -189,6 +190,12 @@ func (o *ORM) InsertLogs(logs []Log, qopts ...pg.QOpt) error {
 (:evm_chain_id, :log_index, :block_hash, :block_number, :block_timestamp, :address, :event_sig, :topics, :tx_hash, :data, NOW()) ON CONFLICT DO NOTHING`, logs[start:end])
 
 		if err != nil {
+			if errors.Is(err, context.DeadlineExceeded) && batchInsertSize <= 500 {
+				// In case of DB timeouts, try to insert again with a smaller batch upto a limit
+				batchInsertSize /= 2
+				i -= batchInsertSize // counteract +=batchInsertSize on next loop iteration
+				continue
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
Allow a backoff of batch size insert in case DB is loaded and times out for any reason