### PR TITLE
End upkeep state store start() when ctx is done

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/upkeepstate/store.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/upkeepstate/store.go
@@ -120,7 +120,7 @@ func (u *upkeepStateStore) Start(pctx context.Context) error {
 
 					ticker.Reset(utils.WithJitter(u.cleanCadence))
 				case <-ctx.Done():
-
+					return
 				}
 			}
 		}(ctx)


### PR DESCRIPTION
When ctx was done, we were not ending the loop