### PR TITLE
Thread control utility

### DIFF
--- a/core/utils/thread_control.go
+++ b/core/utils/thread_control.go
@@ -2,16 +2,11 @@ package utils
 
 import (
 	"context"
-	"errors"
 	"sync"
 	"sync/atomic"
 )
 
-var (
-	_ ThreadControl = &threadControl{}
-
-	ErrThreadLimitReached = errors.New("thread limit reached")
-)
+var _ ThreadControl = &threadControl{}
 
 // ThreadControl is a helper for managing a group of goroutines.
 type ThreadControl interface {
@@ -21,10 +16,9 @@ type ThreadControl interface {
 	Close()
 }
 
-func NewThreadControl(limit int) *threadControl {
+func NewThreadControl() *threadControl {
 	tc := &threadControl{
-		stop:  make(chan struct{}),
-		limit: int32(limit),
+		stop: make(chan struct{}),
 	}
 
 	return tc
@@ -33,7 +27,6 @@ func NewThreadControl(limit int) *threadControl {
 type threadControl struct {
 	threadsWG sync.WaitGroup
 
-	limit   int32
 	running atomic.Int32
 
 	stop StopChan

--- a/core/utils/thread_control.go
+++ b/core/utils/thread_control.go
@@ -1,0 +1,74 @@
+package utils
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+)
+
+var (
+	_ ThreadControl = &threadControl{}
+
+	ErrThreadLimitReached = errors.New("thread limit reached")
+)
+
+// ThreadControl is a helper for managing a group of goroutines.
+type ThreadControl interface {
+	// Go starts a goroutine and tracks the lifetime of the goroutine.
+	Go(fn func(context.Context)) error
+	// Close cancels the context and waits for all tracked goroutines to exit.
+	Close()
+}
+
+func NewThreadControl(pctx context.Context, limit int) *threadControl {
+	ctx, cancel := context.WithCancel(pctx)
+	tc := &threadControl{
+		ctx:    ctx,
+		cancel: cancel,
+		limit:  int32(limit),
+	}
+
+	return tc
+}
+
+type threadControl struct {
+	threadsWG sync.WaitGroup
+
+	limit   int32
+	running atomic.Int32
+
+	ctx    context.Context
+	cancel context.CancelFunc
+}
+
+func (tc *threadControl) Go(fn func(context.Context)) error {
+	if err := tc.add(); err != nil {
+		return err
+	}
+	go func(ctx context.Context) {
+		defer tc.done()
+		fn(ctx)
+	}(tc.ctx)
+
+	return nil
+}
+
+func (tc *threadControl) Close() {
+	tc.cancel()
+	tc.threadsWG.Wait()
+}
+
+func (tc *threadControl) add() error {
+	if tc.running.Add(1) > tc.limit {
+		tc.running.Add(-1)
+		return ErrThreadLimitReached
+	}
+	tc.threadsWG.Add(1)
+	return nil
+}
+
+func (tc *threadControl) done() {
+	tc.running.Add(-1)
+	tc.threadsWG.Done()
+}

--- a/core/utils/thread_control.go
+++ b/core/utils/thread_control.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"context"
 	"sync"
-	"sync/atomic"
 )
 
 var _ ThreadControl = &threadControl{}
@@ -26,10 +25,7 @@ func NewThreadControl() *threadControl {
 
 type threadControl struct {
 	threadsWG sync.WaitGroup
-
-	running atomic.Int32
-
-	stop StopChan
+	stop      StopChan
 }
 
 func (tc *threadControl) Go(fn func(context.Context)) {

--- a/core/utils/thread_control.go
+++ b/core/utils/thread_control.go
@@ -33,9 +33,9 @@ type threadControl struct {
 }
 
 func (tc *threadControl) Go(fn func(context.Context)) {
-	tc.add()
+	tc.threadsWG.Add(1)
 	go func() {
-		defer tc.done()
+		defer tc.threadsWG.Done()
 		ctx, cancel := tc.stop.NewCtx()
 		defer cancel()
 		fn(ctx)
@@ -45,14 +45,4 @@ func (tc *threadControl) Go(fn func(context.Context)) {
 func (tc *threadControl) Close() {
 	close(tc.stop)
 	tc.threadsWG.Wait()
-}
-
-func (tc *threadControl) add() {
-	tc.running.Add(1)
-	tc.threadsWG.Add(1)
-}
-
-func (tc *threadControl) done() {
-	tc.running.Add(-1)
-	tc.threadsWG.Done()
 }

--- a/core/utils/thread_control.go
+++ b/core/utils/thread_control.go
@@ -16,8 +16,8 @@ var (
 // ThreadControl is a helper for managing a group of goroutines.
 type ThreadControl interface {
 	// Go starts a goroutine and tracks the lifetime of the goroutine.
-	Go(fn func(context.Context)) error
-	// Close cancels the context and waits for all tracked goroutines to exit.
+	Go(fn func(context.Context))
+	// Close cancels the goroutines and waits for all of them to exit.
 	Close()
 }
 
@@ -39,19 +39,14 @@ type threadControl struct {
 	stop StopChan
 }
 
-func (tc *threadControl) Go(fn func(context.Context)) error {
-	if err := tc.add(); err != nil {
-		return err
-	}
-
+func (tc *threadControl) Go(fn func(context.Context)) {
+	tc.add()
 	go func() {
 		defer tc.done()
 		ctx, cancel := tc.stop.NewCtx()
 		defer cancel()
 		fn(ctx)
 	}()
-
-	return nil
 }
 
 func (tc *threadControl) Close() {
@@ -59,13 +54,9 @@ func (tc *threadControl) Close() {
 	tc.threadsWG.Wait()
 }
 
-func (tc *threadControl) add() error {
-	if tc.running.Add(1) > tc.limit {
-		tc.running.Add(-1)
-		return ErrThreadLimitReached
-	}
+func (tc *threadControl) add() {
+	tc.running.Add(1)
 	tc.threadsWG.Add(1)
-	return nil
 }
 
 func (tc *threadControl) done() {

--- a/core/utils/thread_control_test.go
+++ b/core/utils/thread_control_test.go
@@ -15,29 +15,13 @@ func TestThreadControl_Close(t *testing.T) {
 	finished := atomic.Int32{}
 
 	for i := 0; i < n; i++ {
-		require.NoError(t, tc.Go(func(ctx context.Context) {
+		tc.Go(func(ctx context.Context) {
 			<-ctx.Done()
 			finished.Add(1)
-		}))
+		})
 	}
 
 	tc.Close()
 
 	require.Equal(t, int32(n), finished.Load())
-}
-func TestThreadControl_ThreadsLimitExceeded(t *testing.T) {
-	tc := NewThreadControl(1)
-
-	finished := atomic.Int32{}
-
-	fn := func(ctx context.Context) {
-		<-ctx.Done()
-		finished.Add(1)
-	}
-	require.NoError(t, tc.Go(fn))
-	require.Error(t, tc.Go(fn))
-
-	tc.Close()
-
-	require.Equal(t, int32(1), finished.Load())
 }

--- a/core/utils/thread_control_test.go
+++ b/core/utils/thread_control_test.go
@@ -8,31 +8,9 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestThreadControl_CloseContext(t *testing.T) {
-	ctx, cancel := context.WithCancel(context.Background())
-	n := 10
-	tc := NewThreadControl(ctx, n)
-
-	sig := make(chan struct{}, n)
-	finished := atomic.Int32{}
-	for i := 0; i < n; i++ {
-		require.NoError(t, tc.Go(func(ctx context.Context) {
-			<-ctx.Done()
-			finished.Add(1)
-			sig <- struct{}{}
-		}))
-	}
-	cancel()
-
-	for i := 0; i < n; i++ {
-		<-sig
-	}
-	require.Equal(t, int32(n), finished.Load())
-}
-
 func TestThreadControl_Close(t *testing.T) {
 	n := 10
-	tc := NewThreadControl(context.Background(), n)
+	tc := NewThreadControl(n)
 
 	finished := atomic.Int32{}
 
@@ -48,7 +26,7 @@ func TestThreadControl_Close(t *testing.T) {
 	require.Equal(t, int32(n), finished.Load())
 }
 func TestThreadControl_ThreadsLimitExceeded(t *testing.T) {
-	tc := NewThreadControl(context.Background(), 1)
+	tc := NewThreadControl(1)
 
 	finished := atomic.Int32{}
 

--- a/core/utils/thread_control_test.go
+++ b/core/utils/thread_control_test.go
@@ -1,0 +1,65 @@
+package utils
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestThreadControl_CloseContext(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	n := 10
+	tc := NewThreadControl(ctx, n)
+
+	sig := make(chan struct{}, n)
+	finished := atomic.Int32{}
+	for i := 0; i < n; i++ {
+		require.NoError(t, tc.Go(func(ctx context.Context) {
+			<-ctx.Done()
+			finished.Add(1)
+			sig <- struct{}{}
+		}))
+	}
+	cancel()
+
+	for i := 0; i < n; i++ {
+		<-sig
+	}
+	require.Equal(t, int32(n), finished.Load())
+}
+
+func TestThreadControl_Close(t *testing.T) {
+	n := 10
+	tc := NewThreadControl(context.Background(), n)
+
+	finished := atomic.Int32{}
+
+	for i := 0; i < n; i++ {
+		require.NoError(t, tc.Go(func(ctx context.Context) {
+			<-ctx.Done()
+			finished.Add(1)
+		}))
+	}
+
+	tc.Close()
+
+	require.Equal(t, int32(n), finished.Load())
+}
+func TestThreadControl_ThreadsLimitExceeded(t *testing.T) {
+	tc := NewThreadControl(context.Background(), 1)
+
+	finished := atomic.Int32{}
+
+	fn := func(ctx context.Context) {
+		<-ctx.Done()
+		finished.Add(1)
+	}
+	require.NoError(t, tc.Go(fn))
+	require.Error(t, tc.Go(fn))
+
+	tc.Close()
+
+	require.Equal(t, int32(1), finished.Load())
+}

--- a/core/utils/thread_control_test.go
+++ b/core/utils/thread_control_test.go
@@ -10,7 +10,7 @@ import (
 
 func TestThreadControl_Close(t *testing.T) {
 	n := 10
-	tc := NewThreadControl(n)
+	tc := NewThreadControl()
 
 	finished := atomic.Int32{}
 


### PR DESCRIPTION
Util for managing (wait or cancel) a group of goroutines.

Under the hood it uses `sync.WaitGroup` to enable waiting for all goroutines to finish, and `StopChan` to signal the running goroutines to exit.

**NOTE** Usage examples can be found in https://github.com/smartcontractkit/chainlink/pull/10535