### PR TITLE
Fix Mercury Persistence Manager test flake

### DIFF
--- a/core/services/relay/evm/mercury/persistence_manager.go
+++ b/core/services/relay/evm/mercury/persistence_manager.go
@@ -94,11 +94,12 @@ func (pm *PersistenceManager) runFlushDeletesLoop() {
 			ticker.Stop()
 			return
 		case <-ticker.C:
-			pm.lggr.Trace("Deleting queued requests from transmit requests table")
 			queuedReqs := pm.resetDeleteQueue()
 			if err := pm.orm.DeleteTransmitRequests(queuedReqs, pg.WithParentCtx(ctx)); err != nil {
 				pm.lggr.Errorw("Failed to delete queued transmit requests", "err", err)
 				pm.addToDeleteQueue(queuedReqs...)
+			} else {
+				pm.lggr.Trace("Deleted queued transmit requests")
 			}
 		}
 	}
@@ -117,9 +118,10 @@ func (pm *PersistenceManager) runPruneLoop() {
 			ticker.Stop()
 			return
 		case <-ticker.C:
-			pm.lggr.Trace("Pruning transmit requests table")
 			if err := pm.orm.PruneTransmitRequests(pm.maxTransmitQueueSize, pg.WithParentCtx(ctx), pg.WithLongQueryTimeout()); err != nil {
 				pm.lggr.Errorw("Failed to prune transmit requests table", "err", err)
+			} else {
+				pm.lggr.Trace("Pruned transmit requests table")
 			}
 		}
 	}

--- a/core/services/relay/evm/mercury/persistence_manager.go
+++ b/core/services/relay/evm/mercury/persistence_manager.go
@@ -99,7 +99,7 @@ func (pm *PersistenceManager) runFlushDeletesLoop() {
 				pm.lggr.Errorw("Failed to delete queued transmit requests", "err", err)
 				pm.addToDeleteQueue(queuedReqs...)
 			} else {
-				pm.lggr.Trace("Deleted queued transmit requests")
+				pm.lggr.Debugw("Deleted queued transmit requests")
 			}
 		}
 	}
@@ -121,7 +121,7 @@ func (pm *PersistenceManager) runPruneLoop() {
 			if err := pm.orm.PruneTransmitRequests(pm.maxTransmitQueueSize, pg.WithParentCtx(ctx), pg.WithLongQueryTimeout()); err != nil {
 				pm.lggr.Errorw("Failed to prune transmit requests table", "err", err)
 			} else {
-				pm.lggr.Trace("Pruned transmit requests table")
+				pm.lggr.Debugw("Pruned transmit requests table")
 			}
 		}
 	}


### PR DESCRIPTION
This is an attempt at fixing the test flake observed in https://github.com/smartcontractkit/chainlink/actions/runs/6047652393/job/16411595709?pr=10404.

The issue is that the persistence manager in the test runs a flush loop on a 10ms timer and we wait a hardcoded 15ms before asserting for the effects of the loop. In a CI environment with limited resources and many concurrent tests, it is possible that the loop takes longer than 15ms to run thereby failing the test. The 'fix' in this PR is to shorten the loop interval to 5ms while also increasing the wait time to 20ms in an effort to reduce the likelihood of a slow running poll failing the test.

This isn't a great solution. Originally I went with a log observer so I could wait for a trace log line indicating a successful loop rather than trying to time it. However, I discovered that trace logs are a no-op unless the `trace` build tag is used. I didn't want to rely on this build tag largely because of the poor dev experience if you don't include this tag when running tests locally. Tests would hang for a really long time before failing with a cryptic timeout. I also didn't want to increase the log level to debug because a repeating log line every second felt spammy. I'm happy to revisit this if you feel otherwise or have other ideas!










