### PR TITLE
Small improvements to log recoverer

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/factory.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/factory.go
@@ -36,6 +36,8 @@ type LogTriggersOptions struct {
 	BlockRateLimit rate.Limit
 	// blockLimitBurst is the burst upper limit on the range of blocks the we fetch logs for.
 	BlockLimitBurst int
+	// Finality depth is the number of blocks to wait before considering a block final.
+	FinalityDepth int64
 }
 
 func NewOptions(finalityDepth int64) LogTriggersOptions {
@@ -62,5 +64,8 @@ func (o *LogTriggersOptions) Defaults(finalityDepth int64) {
 	}
 	if o.BlockRateLimit == 0 {
 		o.BlockRateLimit = rate.Every(o.ReadInterval)
+	}
+	if o.FinalityDepth == 0 {
+		o.FinalityDepth = finalityDepth
 	}
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer.go
@@ -39,9 +39,9 @@ var (
 	// recoveryLogsBuffer is the number of blocks to be used as a safety buffer when reading logs
 	recoveryLogsBuffer = int64(200)
 	recoveryLogsBurst  = int64(500)
-	// performFinaliltyBuffer is the buffer subtracted from latestBlock-finalityDepth while checking
+	// performFinalityBuffer is the buffer subtracted from latestBlock-finalityDepth while checking
 	// for recoverable logs in order to give enough time for perform logs to be finalized
-	performFinaliltyBuffer = int64(200)
+	performFinalityBuffer = int64(200)
 	// blockTimeUpdateCadence is the cadence at which the chain's blocktime is re-calculated
 	blockTimeUpdateCadence = 10 * time.Minute
 )
@@ -465,7 +465,7 @@ func (r *logRecoverer) getRecoveryWindow(latest int64) (int64, int64) {
 	blockTime := r.blockTime.Load()
 	blocksInDay := int64(24*time.Hour) / blockTime
 	start := latest - blocksInDay
-	end := latest - lookbackBlocks - performFinaliltyBuffer
+	end := latest - lookbackBlocks - performFinalityBuffer
 	if start > end {
 		// In this case, allow starting from more than a day behind
 		start = end

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer.go
@@ -292,7 +292,7 @@ func (r *logRecoverer) GetRecoveryProposals(ctx context.Context) ([]ocr2keepers.
 
 	r.pending = pending
 
-	r.lggr.Debugf("found %d pending payloads", len(pending))
+	r.lggr.Debugf("found %d recoverable payloads", len(results))
 
 	return results, nil
 }
@@ -336,7 +336,7 @@ func (r *logRecoverer) recover(ctx context.Context) error {
 
 // recoverFilter recovers logs for a single upkeep filter.
 func (r *logRecoverer) recoverFilter(ctx context.Context, f upkeepFilter, startBlock, offsetBlock int64) error {
-	start := f.lastRePollBlock
+	start := f.lastRePollBlock + 1
 	// ensure we don't recover logs from before the filter was created
 	// NOTE: we expect that filter with configUpdateBlock > offsetBlock were already filtered out.
 	if configUpdateBlock := int64(f.configUpdateBlock); start < configUpdateBlock {

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer.go
@@ -353,6 +353,7 @@ func (r *logRecoverer) recoverFilter(ctx context.Context, f upkeepFilter, startB
 		// If recoverer is lagging by a lot (more than 100x recoveryLogsBuffer), allow
 		// a range of recoveryLogsBurst
 		// Exploratory: Store lastRePollBlock in DB to prevent bursts during restarts
+		// (while also taking into account exisitng pending payloads)
 		end = start + recoveryLogsBurst
 	}
 	if end > offsetBlock {

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer_test.go
@@ -352,7 +352,7 @@ func TestLogRecoverer_Recover(t *testing.T) {
 			nil,
 			nil,
 			[]string{"c207451fa897f9bb13b09d54d8655edf0644e027c53521b4a92eafbb64ba4d14"},
-			[]int64{200, 0, 450},
+			[]int64{201, 0, 450},
 		},
 		{
 			"lastRePollBlock updated with burst when lagging behind",
@@ -366,7 +366,7 @@ func TestLogRecoverer_Recover(t *testing.T) {
 					topics: []common.Hash{
 						common.HexToHash("0x1"),
 					},
-					lastRePollBlock: 100, // Should be updated with burst
+					lastRePollBlock: 99, // Should be updated with burst
 				},
 			},
 			[]ocr2keepers.UpkeepState{ocr2keepers.UnknownState},
@@ -382,7 +382,7 @@ func TestLogRecoverer_Recover(t *testing.T) {
 			nil,
 			nil,
 			[]string{"c207451fa897f9bb13b09d54d8655edf0644e027c53521b4a92eafbb64ba4d14"},
-			[]int64{601},
+			[]int64{600},
 		},
 		{
 			"recovery starts at configUpdateBlock if higher than lastRePollBlock",

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/logprovider/recoverer_test.go
@@ -382,7 +382,7 @@ func TestLogRecoverer_Recover(t *testing.T) {
 			nil,
 			nil,
 			[]string{"c207451fa897f9bb13b09d54d8655edf0644e027c53521b4a92eafbb64ba4d14"},
-			[]int64{600},
+			[]int64{601},
 		},
 		{
 			"recovery starts at configUpdateBlock if higher than lastRePollBlock",
@@ -778,7 +778,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 			},
 			logPoller: &mockLogPoller{
 				LatestBlockFn: func(qopts ...pg.QOpt) (int64, error) {
-					return 100, nil
+					return 300, nil
 				},
 			},
 			stateReader: &mockStateReader{
@@ -813,7 +813,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 			},
 			logPoller: &mockLogPoller{
 				LatestBlockFn: func(qopts ...pg.QOpt) (int64, error) {
-					return 100, nil
+					return 300, nil
 				},
 			},
 			client: &mockClient{
@@ -853,7 +853,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 			},
 			logPoller: &mockLogPoller{
 				LatestBlockFn: func(qopts ...pg.QOpt) (int64, error) {
-					return 100, nil
+					return 300, nil
 				},
 			},
 			client: &mockClient{
@@ -885,7 +885,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 			},
 			logPoller: &mockLogPoller{
 				LatestBlockFn: func(qopts ...pg.QOpt) (int64, error) {
-					return 100, nil
+					return 300, nil
 				},
 				LogsWithSigsFn: func(start, end int64, eventSigs []common.Hash, address common.Address, qopts ...pg.QOpt) ([]logpoller.Log, error) {
 					return nil, errors.New("logs with sigs boom")
@@ -920,7 +920,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 			},
 			logPoller: &mockLogPoller{
 				LatestBlockFn: func(qopts ...pg.QOpt) (int64, error) {
-					return 100, nil
+					return 300, nil
 				},
 				LogsWithSigsFn: func(start, end int64, eventSigs []common.Hash, address common.Address, qopts ...pg.QOpt) ([]logpoller.Log, error) {
 					return []logpoller.Log{
@@ -968,7 +968,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 			},
 			logPoller: &mockLogPoller{
 				LatestBlockFn: func(qopts ...pg.QOpt) (int64, error) {
-					return 100, nil
+					return 300, nil
 				},
 				LogsWithSigsFn: func(start, end int64, eventSigs []common.Hash, address common.Address, qopts ...pg.QOpt) ([]logpoller.Log, error) {
 					return []logpoller.Log{
@@ -1019,7 +1019,7 @@ func TestLogRecoverer_GetProposalData(t *testing.T) {
 			},
 			logPoller: &mockLogPoller{
 				LatestBlockFn: func(qopts ...pg.QOpt) (int64, error) {
-					return 100, nil
+					return 300, nil
 				},
 				LogsWithSigsFn: func(start, end int64, eventSigs []common.Hash, address common.Address, qopts ...pg.QOpt) ([]logpoller.Log, error) {
 					return []logpoller.Log{


### PR DESCRIPTION
- Subtract finalityDepth from buffer offset block to give enough time to get a perform log when checking for recovery
- start recovery from lastRePollBlock+1 as all logs till lastRePollBlock (inclusive) have been checked. Update filtering when finding log filters
- improve debug log in getRecoverables