### PR TITLE
BCF-2636: add core node metrics path to service discovery

### DIFF
--- a/core/web/loop_registry.go
+++ b/core/web/loop_registry.go
@@ -48,19 +48,12 @@ func (l *LoopRegistryServer) discoveryHandler(w http.ResponseWriter, req *http.R
 	w.Header().Set("Content-Type", "application/json")
 	var groups []*targetgroup.Group
 
-	for _, registeredPlugin := range l.registry.List() {
-		// create a metric target for each running plugin
-		target := &targetgroup.Group{
-			Targets: []model.LabelSet{
-				// target address will be called by external prometheus
-				{model.AddressLabel: model.LabelValue(fmt.Sprintf("%s:%d", l.discoveryHostName, l.exposedPromPort))},
-			},
-			Labels: map[model.LabelName]model.LabelValue{
-				model.MetricsPathLabel: model.LabelValue(pluginMetricPath(registeredPlugin.Name)),
-			},
-		}
+	// add node metrics to service discovery
+	groups = append(groups, metricTarget(l.discoveryHostName, l.exposedPromPort, "/metrics"))
 
-		groups = append(groups, target)
+	// add all the plugins
+	for _, registeredPlugin := range l.registry.List() {
+		groups = append(groups, metricTarget(l.discoveryHostName, l.exposedPromPort, pluginMetricPath(registeredPlugin.Name)))
 	}
 
 	b, err := l.jsonMarshalFn(groups)
@@ -78,6 +71,18 @@ func (l *LoopRegistryServer) discoveryHandler(w http.ResponseWriter, req *http.R
 		l.logger.Error(err)
 	}
 
+}
+
+func metricTarget(hostName string, port int, path string) *targetgroup.Group {
+	return &targetgroup.Group{
+		Targets: []model.LabelSet{
+			// target address will be called by external prometheus
+			{model.AddressLabel: model.LabelValue(fmt.Sprintf("%s:%d", hostName, port))},
+		},
+		Labels: map[model.LabelName]model.LabelValue{
+			model.MetricsPathLabel: model.LabelValue(path),
+		},
+	}
 }
 
 // pluginMetricHandlers routes from endpoints published in service discovery to the the backing LOOP endpoint

--- a/core/web/loop_registry_test.go
+++ b/core/web/loop_registry_test.go
@@ -1,6 +1,7 @@
 package web_test
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -8,6 +9,9 @@ import (
 
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/prometheus/common/model"
+	"github.com/prometheus/prometheus/discovery/targetgroup"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/cltest"
@@ -67,7 +71,13 @@ func TestLoopRegistry(t *testing.T) {
 	// shim a reference to the promserver that is running in our mock loop
 	// this ensures the client.Get calls below have a reference to mock loop impl
 
-	expectedEndPoint := "/plugins/mockLoopImpl/metrics"
+	expectedLooppEndPoint, expectedCoreEndPoint := "/plugins/mockLoopImpl/metrics", "/metrics"
+
+	// note we expect this to be an ordered result
+	expectedLabels := []model.LabelSet{
+		model.LabelSet{"__metrics_path__": model.LabelValue(expectedCoreEndPoint)},
+		model.LabelSet{"__metrics_path__": model.LabelValue(expectedLooppEndPoint)},
+	}
 
 	require.NoError(t, app.KeyStore.OCR().Add(cltest.DefaultOCRKey))
 	require.NoError(t, app.Start(testutils.Context(t)))
@@ -97,12 +107,22 @@ func TestLoopRegistry(t *testing.T) {
 		b, err := io.ReadAll(resp.Body)
 		require.NoError(t, err)
 		t.Logf("discovery response %s", b)
-		require.Contains(t, string(b), expectedEndPoint)
+		var got []*targetgroup.Group
+		require.NoError(t, json.Unmarshal(b, &got))
+
+		gotLabels := make([]model.LabelSet, 0)
+		for _, ls := range got {
+			gotLabels = append(gotLabels, ls.Labels)
+		}
+		assert.Equal(t, len(expectedLabels), len(gotLabels))
+		for i := range expectedLabels {
+			assert.EqualValues(t, expectedLabels[i], gotLabels[i])
+		}
 	})
 
 	t.Run("plugin metrics OK", func(t *testing.T) {
 		// plugin name `mockLoopImpl` matches key in PluginConfigs
-		resp, cleanup := client.Get(expectedEndPoint)
+		resp, cleanup := client.Get(expectedLooppEndPoint)
 		t.Cleanup(cleanup)
 		cltest.AssertServerResponse(t, resp, http.StatusOK)
 
@@ -115,6 +135,17 @@ func TestLoopRegistry(t *testing.T) {
 			expectedMetric = fmt.Sprintf("%s %d", testMetricName, exceptedCount)
 		)
 		require.Contains(t, string(b), expectedMetric)
+	})
+
+	t.Run("core metrics OK", func(t *testing.T) {
+		// core node metrics endpoint
+		resp, cleanup := client.Get(expectedCoreEndPoint)
+		t.Cleanup(cleanup)
+		cltest.AssertServerResponse(t, resp, http.StatusOK)
+
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		t.Logf("core metrics response %s", b)
 	})
 
 	t.Run("no existent plugin metrics ", func(t *testing.T) {


### PR DESCRIPTION
This PR adds the core node `/metrics` endpoint to the existing service discovery endpoint, enabling uniform access to both LOOPP endpoints and the core endpoint.

end-2-end test manually with local instance