### PR TITLE
Ignore fuzz tests in gas snapshot

### DIFF
--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Run Forge snapshot
         if: ${{ !contains(fromJson('["vrf"]'), matrix.product) }}
         run: |
-          forge snapshot --nmt "^testFuzz_.*$$" --check gas-snapshots/${{ matrix.product }}.gas-snapshot
+          forge snapshot --nmt "testFuzz_\w{1,}?" --check gas-snapshots/${{ matrix.product }}.gas-snapshot
         id: snapshot
         working-directory: contracts
         env:

--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Run Forge snapshot
         if: ${{ !contains(fromJson('["vrf"]'), matrix.product) }}
         run: |
-          forge snapshot --nmt "^testFuzz_.*$" --check gas-snapshots/${{ matrix.product }}.gas-snapshot
+          forge snapshot --nmt "^testFuzz_.*$$" --check gas-snapshots/${{ matrix.product }}.gas-snapshot
         id: snapshot
         working-directory: contracts
         env:

--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Run Forge snapshot
         if: ${{ !contains(fromJson('["vrf"]'), matrix.product) }}
         run: |
-          forge snapshot --check gas-snapshots/${{ matrix.product }}.gas-snapshot
+          forge snapshot --nmt "^testFuzz_.*$" --check gas-snapshots/${{ matrix.product }}.gas-snapshot
         id: snapshot
         working-directory: contracts
         env:

--- a/contracts/GNUmakefile
+++ b/contracts/GNUmakefile
@@ -17,7 +17,7 @@ ALL_FOUNDRY_PRODUCTS = vrf automation llo-feeds functions automation-dev shared
 # a static fuzz seed by default, flaky gas results per platform are still observed.
 .PHONY: snapshot
 snapshot: ## Make a snapshot for a specific product.
-	export FOUNDRY_PROFILE=$(FOUNDRY_PROFILE) && forge snapshot --nmt "^testFuzz_.*$" --snap gas-snapshots/$(FOUNDRY_PROFILE).gas-snapshot
+	export FOUNDRY_PROFILE=$(FOUNDRY_PROFILE) && forge snapshot --nmt "^testFuzz_.*$$" --snap gas-snapshots/$(FOUNDRY_PROFILE).gas-snapshot
 
 .PHONY: snapshot-all
 snapshot-all: ## Make a snapshot for all products.

--- a/contracts/GNUmakefile
+++ b/contracts/GNUmakefile
@@ -13,9 +13,11 @@ ALL_FOUNDRY_PRODUCTS = vrf automation llo-feeds functions automation-dev shared
 #		make snapshot
 # make call example
 # 		make FOUNDRY_PROFILE=llo-feeds snapshot
+# note make snapshot skips fuzz tests named according to best practices, although forge uses
+# a static fuzz seed by default, flaky gas results per platform are still observed.
 .PHONY: snapshot
 snapshot: ## Make a snapshot for a specific product.
-	export FOUNDRY_PROFILE=$(FOUNDRY_PROFILE) && forge snapshot --snap gas-snapshots/$(FOUNDRY_PROFILE).gas-snapshot
+	export FOUNDRY_PROFILE=$(FOUNDRY_PROFILE) && forge snapshot --nmt "^testFuzz_.*$" --snap gas-snapshots/$(FOUNDRY_PROFILE).gas-snapshot
 
 .PHONY: snapshot-all
 snapshot-all: ## Make a snapshot for all products.

--- a/contracts/GNUmakefile
+++ b/contracts/GNUmakefile
@@ -17,7 +17,7 @@ ALL_FOUNDRY_PRODUCTS = vrf automation llo-feeds functions automation-dev shared
 # a static fuzz seed by default, flaky gas results per platform are still observed.
 .PHONY: snapshot
 snapshot: ## Make a snapshot for a specific product.
-	export FOUNDRY_PROFILE=$(FOUNDRY_PROFILE) && forge snapshot --nmt "^testFuzz_.*$$" --snap gas-snapshots/$(FOUNDRY_PROFILE).gas-snapshot
+	export FOUNDRY_PROFILE=$(FOUNDRY_PROFILE) && forge snapshot --nmt "testFuzz_\w{1,}?" --snap gas-snapshots/$(FOUNDRY_PROFILE).gas-snapshot
 
 .PHONY: snapshot-all
 snapshot-all: ## Make a snapshot for all products.


### PR DESCRIPTION
`make snapshot` should skip fuzz tests named according to best practices: `testFuzz_\w{1,}?`

Although forge uses a static fuzz seed by default, flaky gas results per platform are still observed:
https://github.com/foundry-rs/foundry/issues/5689

Until they fix the issue, including fuzz tests in snapshot results will result in flaky CI.
At this moment, this repo doesn't have fuzz tests. Tested the regex pattern in other repo, and in this repo by adding a `test_MockTest()` to verify it is included in snapshot, and `testFuzz_MockTest()` to verify it is not included in snapshot.