### PR TITLE
Add reentrancy guard to VRFCoordinatorV2Mock to align its behaviour w…

### DIFF
--- a/contracts/scripts/native_solc_compile_all_vrf
+++ b/contracts/scripts/native_solc_compile_all_vrf
@@ -51,6 +51,7 @@ compileContract vrf/BatchBlockhashStore.sol
 compileContract vrf/BatchVRFCoordinatorV2.sol
 compileContract vrf/testhelpers/VRFCoordinatorV2TestHelper.sol
 compileContractAltOpts vrf/VRFCoordinatorV2.sol 10000
+compileContract mocks/VRFCoordinatorV2Mock.sol
 compileContract vrf/VRFOwner.sol
 
 # VRF V2Plus

--- a/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol
+++ b/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol
@@ -204,7 +204,7 @@ contract VRFCoordinatorV2Mock is VRFCoordinatorV2Interface, ConfirmedOwner {
     return (s_subscriptions[_subId].balance, 0, s_subscriptions[_subId].owner, s_consumers[_subId]);
   }
 
-  function cancelSubscription(uint64 _subId, address _to) external override onlySubOwner(_subId) {
+  function cancelSubscription(uint64 _subId, address _to) external override onlySubOwner(_subId) nonReentrant {
     emit SubscriptionCanceled(_subId, _to, s_subscriptions[_subId].balance);
     delete (s_subscriptions[_subId]);
   }
@@ -240,7 +240,7 @@ contract VRFCoordinatorV2Mock is VRFCoordinatorV2Interface, ConfirmedOwner {
   function removeConsumer(
     uint64 _subId,
     address _consumer
-  ) external override onlySubOwner(_subId) onlyValidConsumer(_subId, _consumer) {
+  ) external override onlySubOwner(_subId) onlyValidConsumer(_subId, _consumer) nonReentrant {
     address[] storage consumers = s_consumers[_subId];
     for (uint256 i = 0; i < consumers.length; i++) {
       if (consumers[i] == _consumer) {

--- a/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol
+++ b/contracts/src/v0.8/mocks/VRFCoordinatorV2Mock.sol
@@ -70,9 +70,7 @@ contract VRFCoordinatorV2Mock is VRFCoordinatorV2Interface, ConfirmedOwner {
    * @notice Sets the configuration of the vrfv2 mock coordinator
    */
   function setConfig() public onlyOwner {
-    s_config = Config({
-      reentrancyLock: false
-    });
+    s_config = Config({reentrancyLock: false});
     emit ConfigSet();
   }
 

--- a/contracts/test/v0.8/dev/VRFCoordinatorV2Mock.test.ts
+++ b/contracts/test/v0.8/dev/VRFCoordinatorV2Mock.test.ts
@@ -262,7 +262,7 @@ describe('VRFCoordinatorV2Mock', () => {
       expect(receipt.events[0].args['success']).to.equal(true)
       assert(
         receipt.events[0].args['payment']
-          .sub(BigNumber.from('100119017000000000'))
+          .sub(BigNumber.from('100119403000000000'))
           .lt(BigNumber.from('10000000000')),
       )
 
@@ -315,7 +315,7 @@ describe('VRFCoordinatorV2Mock', () => {
       expect(receipt.events[0].args['success']).to.equal(true)
       assert(
         receipt.events[0].args['payment']
-          .sub(BigNumber.from('100119017000000000'))
+          .sub(BigNumber.from('100120516000000000'))
           .lt(BigNumber.from('10000000000')),
       )
 


### PR DESCRIPTION
## Motivation

- Currently, VRFCoordinatorV2Mock contract does not completely mimic the behaviour of VRFCoordinatorV2 as it does not have Reentrancy Guard
-  This would lead to issues during automated and manual testing

## Solution

- Introduce Reentrancy Guard in VRFCoordinatorV2Mock to align its behaviour with VRFCoordinatorV2

## Testing

```
$ pnpm hardhat test --grep VRFCoordinatorV2Mock
...
  VRFCoordinatorV2Mock
    #createSubscription
      ✔ can create a subscription
      ✔ subscription id increments
    #addConsumer
      ✔ can add a consumer to a subscription
      ✔ cannot add a consumer to a nonexistent subscription
      ✔ cannot add more than the consumer maximum (1042ms)
    #removeConsumer
      ✔ can remove a consumer from a subscription
      ✔ cannot remove a consumer from a nonexistent subscription
      ✔ cannot remove a consumer after it is already removed
    #fundSubscription
      ✔ can fund a subscription (42ms)
      ✔ cannot fund a nonexistent subscription
    #cancelSubscription
      ✔ can cancel a subscription (41ms)
    #fulfillRandomWords
      ✔ fails to fulfill without being a valid consumer
      ✔ fails to fulfill with insufficient funds (58ms)
      ✔ can request and fulfill [ @skip-coverage ]
      ✔ Correctly allows for user override of fulfillRandomWords [ @skip-coverage ]


               ⛳ Baseline gas used   : 641560 gas

               Current gas used   : 0 gas

               🚩 Delta : -641560 gas

               ⛳ Par   : 721271 gas

               🏌️  You   : 0 gas

               🚩 Score : -721271 gas

  15 passing (15s)
```