### PR TITLE
[TT-526] Allow Parallel Tests To Work

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -158,8 +158,8 @@ jobs:
         id: build-test-matrix-list
         run: |
           cd ./integration-tests
-          MATRIX_JSON_AUTOMATION=$(./scripts/buildTestMatrixList.sh ./smoke/automation_test.go automation ubuntu20.04-8cores-32GB)
-          MATRIX_JSON_KEEPER=$(./scripts/buildTestMatrixList.sh ./smoke/keeper_test.go keeper ubuntu20.04-8cores-32GB)
+          MATRIX_JSON_AUTOMATION=$(./scripts/buildTestMatrixList.sh ./smoke/automation_test.go automation ubuntu20.04-8cores-32GB 1)
+          MATRIX_JSON_KEEPER=$(./scripts/buildTestMatrixList.sh ./smoke/keeper_test.go keeper ubuntu20.04-8cores-32GB 1)
           COMBINED_ARRAY=$(jq -c -n "$MATRIX_JSON_AUTOMATION + $MATRIX_JSON_KEEPER")
           echo "MATRIX_JSON=${COMBINED_ARRAY}" >> $GITHUB_ENV
   eth-smoke-tests-matrix-automation:

--- a/integration-tests/docker/test_env/test_env_builder.go
+++ b/integration-tests/docker/test_env/test_env_builder.go
@@ -194,7 +194,7 @@ func (b *CLTestEnvBuilder) buildNewEnv(cfg *TestEnvConfig) (*CLClusterTestEnv, e
 		if b.clNodeConfig != nil {
 			cfg = b.clNodeConfig
 		} else {
-			cfg = node.NewConfig(node.BaseConf,
+			cfg = node.NewConfig(node.NewBaseConfig(),
 				node.WithOCR1(),
 				node.WithP2Pv1(),
 			)

--- a/integration-tests/scripts/buildTestMatrixList.sh
+++ b/integration-tests/scripts/buildTestMatrixList.sh
@@ -32,6 +32,8 @@ matrix_output() {
 # Read the JSON file and loop through 'tests' and 'run'
 jq -c '.tests[]' ${JSONFILE} | while read -r test; do
   testName=$(echo ${test} | jq -r '.name')
+  label=$(echo ${test} | jq -r '.label // empty')
+  effective_node_label=${label:-$NODE_LABEL}
   subTests=$(echo ${test} | jq -r '.run[]?.name // empty')
   output=""
   
@@ -41,14 +43,14 @@ jq -c '.tests[]' ${JSONFILE} | while read -r test; do
       if [ $COUNTER -ne 1 ]; then
         echo -n ","
       fi
-      matrix_output $COUNTER $MATRIX_JOB_NAME "${testName}/${subTest}" ${NODE_LABEL}
+      matrix_output $COUNTER $MATRIX_JOB_NAME "${testName}/${subTest}" ${effective_node_label}
       ((COUNTER++))
     done
   else
     if [ $COUNTER -ne 1 ]; then
       echo -n ","
     fi
-    matrix_output $COUNTER $MATRIX_JOB_NAME "${testName}" ${NODE_LABEL}
+    matrix_output $COUNTER $MATRIX_JOB_NAME "${testName}" ${effective_node_label}
     ((COUNTER++))
   fi
 

--- a/integration-tests/scripts/buildTestMatrixList.sh
+++ b/integration-tests/scripts/buildTestMatrixList.sh
@@ -14,6 +14,7 @@ cd "$SCRIPT_DIR"/../ || exit 1
 FILENAME=$1
 MATRIX_JOB_NAME=$2
 NODE_LABEL=$3
+NODE_COUNT=$4
 
 # Get list of test names from JSON file
 JSONFILE="${FILENAME}_test_list.json"
@@ -25,8 +26,9 @@ matrix_output() {
   local job_name=$2
   local test_name=$3
   local node_label=$4
+  local node_count=$5
   local counter_out=$(printf "%02d\n" $counter)
-  echo -n "{\"name\": \"${job_name}-${counter_out}\", \"file\": \"${job_name}\",\"nodes\": 1, \"os\": \"${node_label}\", \"pyroscope_env\": \"ci-smoke-${job_name}-evm-simulated\", \"run\": \"-run '^${test_name}$'\"}"
+  echo -n "{\"name\": \"${job_name}-${counter_out}\", \"file\": \"${job_name}\",\"nodes\": ${node_count}, \"os\": \"${node_label}\", \"pyroscope_env\": \"ci-smoke-${job_name}-evm-simulated\", \"run\": \"-run '^${test_name}$'\"}"
 }
 
 # Read the JSON file and loop through 'tests' and 'run'
@@ -34,6 +36,8 @@ jq -c '.tests[]' ${JSONFILE} | while read -r test; do
   testName=$(echo ${test} | jq -r '.name')
   label=$(echo ${test} | jq -r '.label // empty')
   effective_node_label=${label:-$NODE_LABEL}
+  node_count=$(echo ${test} | jq -r '.nodes // empty')
+  effective_node_count=${node_count:-$NODE_COUNT}
   subTests=$(echo ${test} | jq -r '.run[]?.name // empty')
   output=""
   
@@ -43,14 +47,14 @@ jq -c '.tests[]' ${JSONFILE} | while read -r test; do
       if [ $COUNTER -ne 1 ]; then
         echo -n ","
       fi
-      matrix_output $COUNTER $MATRIX_JOB_NAME "${testName}/${subTest}" ${effective_node_label}
+      matrix_output $COUNTER $MATRIX_JOB_NAME "${testName}/${subTest}" ${effective_node_label} ${effective_node_count}
       ((COUNTER++))
     done
   else
     if [ $COUNTER -ne 1 ]; then
       echo -n ","
     fi
-    matrix_output $COUNTER $MATRIX_JOB_NAME "${testName}" ${effective_node_label}
+    matrix_output $COUNTER $MATRIX_JOB_NAME "${testName}" ${effective_node_label} ${effective_node_count}
     ((COUNTER++))
   fi
 

--- a/integration-tests/smoke/automation_test.go
+++ b/integration-tests/smoke/automation_test.go
@@ -87,8 +87,6 @@ func TestAutomationBasic(t *testing.T) {
 
 func SetupAutomationBasic(t *testing.T, nodeUpgrade bool) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
-
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_2_0":             ethereum.RegistryVersion_2_0,
 		"registry_2_1_conditional": ethereum.RegistryVersion_2_1,
@@ -100,6 +98,7 @@ func SetupAutomationBasic(t *testing.T, nodeUpgrade bool) {
 		registryVersion := rv
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+			l := utils.GetTestLogger(t)
 
 			var (
 				upgradeImage   string
@@ -431,8 +430,6 @@ func TestAutomationAddFunds(t *testing.T) {
 
 func TestAutomationPauseUnPause(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
-
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_2_0": ethereum.RegistryVersion_2_0,
 		"registry_2_1": ethereum.RegistryVersion_2_1,
@@ -443,6 +440,7 @@ func TestAutomationPauseUnPause(t *testing.T) {
 		registryVersion := rv
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+			l := utils.GetTestLogger(t)
 			chainClient, _, contractDeployer, linkToken, registry, registrar, _ := setupAutomationTestDocker(
 				t, "pause-unpause", registryVersion, defaultOCRRegistryConfig, false,
 			)
@@ -515,8 +513,6 @@ func TestAutomationPauseUnPause(t *testing.T) {
 
 func TestAutomationRegisterUpkeep(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
-
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_2_0": ethereum.RegistryVersion_2_0,
 		"registry_2_1": ethereum.RegistryVersion_2_1,
@@ -527,6 +523,7 @@ func TestAutomationRegisterUpkeep(t *testing.T) {
 		registryVersion := rv
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+			l := utils.GetTestLogger(t)
 			chainClient, _, contractDeployer, linkToken, registry, registrar, _ := setupAutomationTestDocker(
 				t, "register-upkeep", registryVersion, defaultOCRRegistryConfig, false,
 			)
@@ -588,7 +585,6 @@ func TestAutomationRegisterUpkeep(t *testing.T) {
 
 func TestAutomationPauseRegistry(t *testing.T) {
 	t.Parallel()
-
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_2_0": ethereum.RegistryVersion_2_0,
 		"registry_2_1": ethereum.RegistryVersion_2_1,
@@ -646,8 +642,6 @@ func TestAutomationPauseRegistry(t *testing.T) {
 
 func TestAutomationKeeperNodesDown(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
-
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_2_0": ethereum.RegistryVersion_2_0,
 		"registry_2_1": ethereum.RegistryVersion_2_1,
@@ -658,6 +652,7 @@ func TestAutomationKeeperNodesDown(t *testing.T) {
 		registryVersion := rv
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+			l := utils.GetTestLogger(t)
 			chainClient, chainlinkNodes, contractDeployer, linkToken, registry, registrar, _ := setupAutomationTestDocker(
 				t, "keeper-nodes-down", registryVersion, defaultOCRRegistryConfig, false,
 			)
@@ -733,7 +728,6 @@ func TestAutomationKeeperNodesDown(t *testing.T) {
 
 func TestAutomationPerformSimulation(t *testing.T) {
 	t.Parallel()
-
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_2_0": ethereum.RegistryVersion_2_0,
 		"registry_2_1": ethereum.RegistryVersion_2_1,
@@ -797,8 +791,6 @@ func TestAutomationPerformSimulation(t *testing.T) {
 
 func TestAutomationCheckPerformGasLimit(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
-
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_2_0": ethereum.RegistryVersion_2_0,
 		"registry_2_1": ethereum.RegistryVersion_2_1,
@@ -809,6 +801,7 @@ func TestAutomationCheckPerformGasLimit(t *testing.T) {
 		registryVersion := rv
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+			l := utils.GetTestLogger(t)
 			chainClient, chainlinkNodes, contractDeployer, linkToken, registry, registrar, _ := setupAutomationTestDocker(
 				t, "gas-limit", registryVersion, defaultOCRRegistryConfig, false,
 			)
@@ -911,8 +904,6 @@ func TestAutomationCheckPerformGasLimit(t *testing.T) {
 
 func TestUpdateCheckData(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
-
 	registryVersions := map[string]ethereum.KeeperRegistryVersion{
 		"registry_2_0": ethereum.RegistryVersion_2_0,
 		"registry_2_1": ethereum.RegistryVersion_2_1,
@@ -923,6 +914,7 @@ func TestUpdateCheckData(t *testing.T) {
 		registryVersion := rv
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
+			l := utils.GetTestLogger(t)
 			chainClient, _, contractDeployer, linkToken, registry, registrar, _ := setupAutomationTestDocker(
 				t, "update-check-data", registryVersion, defaultOCRRegistryConfig, false,
 			)

--- a/integration-tests/smoke/automation_test.go
+++ b/integration-tests/smoke/automation_test.go
@@ -1003,7 +1003,7 @@ func setupAutomationTestDocker(
 	network := networks.SelectedNetwork
 
 	// build the node config
-	clNodeConfig := node.NewConfig(node.BaseConf)
+	clNodeConfig := node.NewConfig(node.NewBaseConfig())
 	syncInterval := models.MustMakeDuration(5 * time.Minute)
 	clNodeConfig.Feature.LogPoller = it_utils.Ptr[bool](true)
 	clNodeConfig.OCR2.Enabled = it_utils.Ptr[bool](true)

--- a/integration-tests/smoke/automation_test.go_test_list.json
+++ b/integration-tests/smoke/automation_test.go_test_list.json
@@ -2,31 +2,43 @@
   "tests": [
     {
       "name": "TestAutomationBasic",
-      "label": "ubuntu20.04-32cores-128GB"
+      "label": "ubuntu20.04-32cores-128GB",
+      "nodes": 3
     },
     {
-      "name": "TestAutomationAddFunds"
+      "name": "TestAutomationAddFunds",
+      "label": "ubuntu20.04-16cores-64GB",
+      "nodes": 2
     },
     {
       "name": "TestAutomationPauseUnPause",
-      "label": "ubuntu20.04-16cores-64GB"
+      "label": "ubuntu20.04-16cores-64GB",
+      "nodes": 2
     },
     {
-      "name": "TestAutomationRegisterUpkeep"
+      "name": "TestAutomationRegisterUpkeep",
+      "label": "ubuntu20.04-16cores-64GB",
+      "nodes": 2
     },
     {
-      "name": "TestAutomationPauseRegistry"
+      "name": "TestAutomationPauseRegistry",
+      "label": "ubuntu20.04-16cores-64GB",
+      "nodes": 2
     },
     {
       "name": "TestAutomationKeeperNodesDown",
-      "label": "ubuntu20.04-16cores-64GB"
+      "label": "ubuntu20.04-16cores-64GB",
+      "nodes": 2
     },
     {
-      "name": "TestAutomationPerformSimulation"
+      "name": "TestAutomationPerformSimulation",
+      "label": "ubuntu20.04-16cores-64GB",
+      "nodes": 2
     },
     {
       "name": "TestAutomationCheckPerformGasLimit",
-      "label": "ubuntu20.04-16cores-64GB"
+      "label": "ubuntu20.04-16cores-64GB",
+      "nodes": 2
     },
     {
       "name": "TestUpdateCheckData"

--- a/integration-tests/smoke/automation_test.go_test_list.json
+++ b/integration-tests/smoke/automation_test.go_test_list.json
@@ -6,8 +6,11 @@
       "nodes": 3
     },
     {
+      "name": "TestSetUpkeepTriggerConfig"
+    },
+    {
       "name": "TestAutomationAddFunds",
-      "label": "ubuntu20.04-16cores-64GB",
+      "label": "ubuntu20.04-32cores-128GB",
       "nodes": 2
     },
     {
@@ -37,14 +40,13 @@
     },
     {
       "name": "TestAutomationCheckPerformGasLimit",
-      "label": "ubuntu20.04-16cores-64GB",
+      "label": "ubuntu20.04-32cores-128GB",
       "nodes": 2
     },
     {
-      "name": "TestUpdateCheckData"
-    },
-    {
-      "name": "TestSetUpkeepTriggerConfig"
+      "name": "TestUpdateCheckData",
+      "label": "ubuntu20.04-32cores-128GB",
+      "nodes": 2
     }
   ]
 }

--- a/integration-tests/smoke/automation_test.go_test_list.json
+++ b/integration-tests/smoke/automation_test.go_test_list.json
@@ -2,105 +2,34 @@
   "tests": [
     {
       "name": "TestAutomationBasic",
-      "run": [
-        {
-          "name": "registry_2_0"
-        },
-        {
-          "name": "registry_2_1_conditional"
-        },
-        {
-          "name": "registry_2_1_logtrigger"
-        }
-      ]
+      "label": "ubuntu20.04-32cores-128GB"
     },
     {
-      "name": "TestAutomationAddFunds",
-      "run": [
-        {
-          "name": "registry_2_0"
-        },
-        {
-          "name": "registry_2_1"
-        }
-      ]
+      "name": "TestAutomationAddFunds"
     },
     {
       "name": "TestAutomationPauseUnPause",
-      "run": [
-        {
-          "name": "registry_2_0"
-        },
-        {
-          "name": "registry_2_1"
-        }
-      ]
+      "label": "ubuntu20.04-16cores-64GB"
     },
     {
-      "name": "TestAutomationRegisterUpkeep",
-      "run": [
-        {
-          "name": "registry_2_0"
-        },
-        {
-          "name": "registry_2_1"
-        }
-      ]
+      "name": "TestAutomationRegisterUpkeep"
     },
     {
-      "name": "TestAutomationPauseRegistry",
-      "run": [
-        {
-          "name": "registry_2_0"
-        },
-        {
-          "name": "registry_2_1"
-        }
-      ]
+      "name": "TestAutomationPauseRegistry"
     },
     {
       "name": "TestAutomationKeeperNodesDown",
-      "run": [
-        {
-          "name": "registry_2_0"
-        },
-        {
-          "name": "registry_2_1"
-        }
-      ]
+      "label": "ubuntu20.04-16cores-64GB"
     },
     {
-      "name": "TestAutomationPerformSimulation",
-      "run": [
-        {
-          "name": "registry_2_0"
-        },
-        {
-          "name": "registry_2_1"
-        }
-      ]
+      "name": "TestAutomationPerformSimulation"
     },
     {
       "name": "TestAutomationCheckPerformGasLimit",
-      "run": [
-        {
-          "name": "registry_2_0"
-        },
-        {
-          "name": "registry_2_1"
-        }
-      ]
+      "label": "ubuntu20.04-16cores-64GB"
     },
     {
-      "name": "TestUpdateCheckData",
-      "run": [
-        {
-          "name": "registry_2_0"
-        },
-        {
-          "name": "registry_2_1"
-        }
-      ]
+      "name": "TestUpdateCheckData"
     },
     {
       "name": "TestSetUpkeepTriggerConfig"

--- a/integration-tests/smoke/forwarders_ocr2_test.go
+++ b/integration-tests/smoke/forwarders_ocr2_test.go
@@ -24,7 +24,7 @@ func TestForwarderOCR2Basic(t *testing.T) {
 	env, err := test_env.NewCLTestEnvBuilder().
 		WithGeth().
 		WithMockServer(1).
-		WithCLNodeConfig(node.NewConfig(node.BaseConf,
+		WithCLNodeConfig(node.NewConfig(node.NewBaseConfig(),
 			node.WithOCR2(),
 			node.WithP2Pv2(),
 		)).

--- a/integration-tests/smoke/keeper_test.go
+++ b/integration-tests/smoke/keeper_test.go
@@ -75,7 +75,6 @@ var (
 
 func TestKeeperBasicSmoke(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
 	registryVersions := []ethereum.KeeperRegistryVersion{
 		ethereum.RegistryVersion_1_1,
 		ethereum.RegistryVersion_1_2,
@@ -86,6 +85,7 @@ func TestKeeperBasicSmoke(t *testing.T) {
 		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
 			t.Parallel()
+			l := utils.GetTestLogger(t)
 			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
 				t,
@@ -151,7 +151,6 @@ func TestKeeperBasicSmoke(t *testing.T) {
 
 func TestKeeperBlockCountPerTurn(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
 	registryVersions := []ethereum.KeeperRegistryVersion{
 		ethereum.RegistryVersion_1_1,
 		ethereum.RegistryVersion_1_2,
@@ -162,6 +161,7 @@ func TestKeeperBlockCountPerTurn(t *testing.T) {
 		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
 			t.Parallel()
+			l := utils.GetTestLogger(t)
 			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
 				t,
@@ -328,7 +328,6 @@ func TestKeeperSimulation(t *testing.T) {
 
 func TestKeeperCheckPerformGasLimit(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
 	registryVersions := []ethereum.KeeperRegistryVersion{
 		ethereum.RegistryVersion_1_2,
 		ethereum.RegistryVersion_1_3,
@@ -338,6 +337,7 @@ func TestKeeperCheckPerformGasLimit(t *testing.T) {
 		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
 			t.Parallel()
+			l := utils.GetTestLogger(t)
 			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, _, consumersPerformance, upkeepIDs := actions.DeployPerformanceKeeperContracts(
 				t,
@@ -440,7 +440,6 @@ func TestKeeperCheckPerformGasLimit(t *testing.T) {
 
 func TestKeeperRegisterUpkeep(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
 	registryVersions := []ethereum.KeeperRegistryVersion{
 		ethereum.RegistryVersion_1_1,
 		ethereum.RegistryVersion_1_2,
@@ -451,6 +450,7 @@ func TestKeeperRegisterUpkeep(t *testing.T) {
 		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
 			t.Parallel()
+			l := utils.GetTestLogger(t)
 			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, registrar, consumers, upkeepIDs := actions.DeployKeeperContracts(
 				t,
@@ -591,7 +591,6 @@ func TestKeeperAddFunds(t *testing.T) {
 
 func TestKeeperRemove(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
 	registryVersions := []ethereum.KeeperRegistryVersion{
 		ethereum.RegistryVersion_1_1,
 		ethereum.RegistryVersion_1_2,
@@ -602,6 +601,7 @@ func TestKeeperRemove(t *testing.T) {
 		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
 			t.Parallel()
+			l := utils.GetTestLogger(t)
 			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
 				t,
@@ -820,7 +820,6 @@ func TestKeeperMigrateRegistry(t *testing.T) {
 
 func TestKeeperNodeDown(t *testing.T) {
 	t.Parallel()
-	l := utils.GetTestLogger(t)
 	registryVersions := []ethereum.KeeperRegistryVersion{
 		ethereum.RegistryVersion_1_1,
 		ethereum.RegistryVersion_1_2,
@@ -831,6 +830,7 @@ func TestKeeperNodeDown(t *testing.T) {
 		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
 			t.Parallel()
+			l := utils.GetTestLogger(t)
 			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
 				t,

--- a/integration-tests/smoke/keeper_test.go
+++ b/integration-tests/smoke/keeper_test.go
@@ -82,10 +82,11 @@ func TestKeeperBasicSmoke(t *testing.T) {
 		ethereum.RegistryVersion_1_3,
 	}
 
-	chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
-
-	for _, registryVersion := range registryVersions {
+	for _, rv := range registryVersions {
+		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
+			t.Parallel()
+			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
 				t,
 				registryVersion,
@@ -157,10 +158,11 @@ func TestKeeperBlockCountPerTurn(t *testing.T) {
 		ethereum.RegistryVersion_1_3,
 	}
 
-	chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
-
-	for _, registryVersion := range registryVersions {
+	for _, rv := range registryVersions {
+		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
+			t.Parallel()
+			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
 				t,
 				registryVersion,
@@ -259,10 +261,11 @@ func TestKeeperSimulation(t *testing.T) {
 		ethereum.RegistryVersion_1_3,
 	}
 
-	chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
-
-	for _, registryVersion := range registryVersions {
+	for _, rv := range registryVersions {
+		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
+			t.Parallel()
+			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, _, consumersPerformance, upkeepIDs := actions.DeployPerformanceKeeperContracts(
 				t,
 				registryVersion,
@@ -331,8 +334,10 @@ func TestKeeperCheckPerformGasLimit(t *testing.T) {
 		ethereum.RegistryVersion_1_3,
 	}
 
-	for _, registryVersion := range registryVersions {
+	for _, rv := range registryVersions {
+		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
+			t.Parallel()
 			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, _, consumersPerformance, upkeepIDs := actions.DeployPerformanceKeeperContracts(
 				t,
@@ -442,10 +447,11 @@ func TestKeeperRegisterUpkeep(t *testing.T) {
 		ethereum.RegistryVersion_1_3,
 	}
 
-	chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
-
-	for _, registryVersion := range registryVersions {
+	for _, rv := range registryVersions {
+		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
+			t.Parallel()
+			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, registrar, consumers, upkeepIDs := actions.DeployKeeperContracts(
 				t,
 				registryVersion,
@@ -529,10 +535,11 @@ func TestKeeperAddFunds(t *testing.T) {
 		ethereum.RegistryVersion_1_3,
 	}
 
-	chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
-
-	for _, registryVersion := range registryVersions {
+	for _, rv := range registryVersions {
+		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
+			t.Parallel()
+			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
 				t,
 				registryVersion,
@@ -591,10 +598,11 @@ func TestKeeperRemove(t *testing.T) {
 		ethereum.RegistryVersion_1_3,
 	}
 
-	chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
-
-	for _, registryVersion := range registryVersions {
+	for _, rv := range registryVersions {
+		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
+			t.Parallel()
+			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
 				t,
 				registryVersion,
@@ -667,10 +675,11 @@ func TestKeeperPauseRegistry(t *testing.T) {
 		ethereum.RegistryVersion_1_3,
 	}
 
-	chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
-
-	for _, registryVersion := range registryVersions {
+	for _, rv := range registryVersions {
+		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
+			t.Parallel()
+			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
 				t,
 				registryVersion,
@@ -818,8 +827,10 @@ func TestKeeperNodeDown(t *testing.T) {
 		ethereum.RegistryVersion_1_3,
 	}
 
-	for _, registryVersion := range registryVersions {
+	for _, rv := range registryVersions {
+		registryVersion := rv
 		t.Run(fmt.Sprintf("registry_1_%d", registryVersion), func(t *testing.T) {
+			t.Parallel()
 			chainClient, chainlinkNodes, contractDeployer, linkToken, _ := setupKeeperTest(t)
 			registry, _, consumers, upkeepIDs := actions.DeployKeeperContracts(
 				t,
@@ -1082,7 +1093,7 @@ func setupKeeperTest(t *testing.T) (
 	contracts.LinkToken,
 	*test_env.CLClusterTestEnv,
 ) {
-	clNodeConfig := node.NewConfig(node.BaseConf)
+	clNodeConfig := node.NewConfig(node.NewBaseConfig())
 	turnLookBack := int64(0)
 	syncInterval := models.MustMakeDuration(5 * time.Second)
 	performGasOverhead := uint32(150000)

--- a/integration-tests/smoke/keeper_test.go_test_list.json
+++ b/integration-tests/smoke/keeper_test.go_test_list.json
@@ -1,35 +1,19 @@
 {
   "tests": [
     {
-      "name": "TestKeeperBasicSmoke"
+      "name": "TestKeeperBasicSmoke",
+      "label": "ubuntu20.04-32cores-128GB"
     },
     {
       "name": "TestKeeperBlockCountPerTurn",
-      "run": [
-        {
-          "name": "registry_1_1"
-        },
-        {
-          "name": "registry_1_2"
-        },
-        {
-          "name": "registry_1_3"
-        }
-      ]
+      "label": "ubuntu20.04-32cores-128GB"
     },
     {
       "name": "TestKeeperSimulation"
     },
     {
       "name": "TestKeeperCheckPerformGasLimit",
-      "run": [
-        {
-          "name": "registry_1_2"
-        },
-        {
-          "name": "registry_1_3"
-        }
-      ]
+      "label": "ubuntu20.04-16cores-64GB"
     },
     {
       "name": "TestKeeperRegisterUpkeep"
@@ -48,17 +32,7 @@
     },
     {
       "name": "TestKeeperNodeDown",
-      "run": [
-        {
-          "name": "registry_1_1"
-        },
-        {
-          "name": "registry_1_2"
-        },
-        {
-          "name": "registry_1_3"
-        }
-      ]
+      "label": "ubuntu20.04-32cores-128GB"
     },
     {
       "name": "TestKeeperPauseUnPauseUpkeep"

--- a/integration-tests/smoke/keeper_test.go_test_list.json
+++ b/integration-tests/smoke/keeper_test.go_test_list.json
@@ -2,37 +2,51 @@
   "tests": [
     {
       "name": "TestKeeperBasicSmoke",
-      "label": "ubuntu20.04-32cores-128GB"
+      "label": "ubuntu20.04-32cores-128GB",
+      "nodes": 3
     },
     {
       "name": "TestKeeperBlockCountPerTurn",
-      "label": "ubuntu20.04-32cores-128GB"
+      "label": "ubuntu20.04-32cores-128GB",
+      "nodes": 3
     },
     {
-      "name": "TestKeeperSimulation"
+      "name": "TestKeeperSimulation",
+      "label": "ubuntu20.04-16cores-64GB",
+      "nodes": 2
     },
     {
       "name": "TestKeeperCheckPerformGasLimit",
-      "label": "ubuntu20.04-16cores-64GB"
+      "label": "ubuntu20.04-16cores-64GB",
+      "nodes": 3
     },
     {
-      "name": "TestKeeperRegisterUpkeep"
+      "name": "TestKeeperRegisterUpkeep",
+      "label": "ubuntu20.04-16cores-64GB",
+      "nodes": 3
     },
     {
-      "name": "TestKeeperAddFunds"
+      "name": "TestKeeperAddFunds",
+      "label": "ubuntu20.04-16cores-64GB",
+      "nodes": 3
     },
     {
-      "name": "TestKeeperRemove"
+      "name": "TestKeeperRemove",
+      "label": "ubuntu20.04-16cores-64GB",
+      "nodes": 3
     },
     {
-      "name": "TestKeeperPauseRegistry"
+      "name": "TestKeeperPauseRegistry",
+      "label": "ubuntu20.04-16cores-64GB",
+      "nodes": 2
     },
     {
       "name": "TestKeeperMigrateRegistry"
     },
     {
       "name": "TestKeeperNodeDown",
-      "label": "ubuntu20.04-32cores-128GB"
+      "label": "ubuntu20.04-32cores-128GB",
+      "nodes": 3
     },
     {
       "name": "TestKeeperPauseUnPauseUpkeep"

--- a/integration-tests/smoke/keeper_test.go_test_list.json
+++ b/integration-tests/smoke/keeper_test.go_test_list.json
@@ -32,7 +32,7 @@
     },
     {
       "name": "TestKeeperRemove",
-      "label": "ubuntu20.04-16cores-64GB",
+      "label": "ubuntu20.04-32cores-128GB",
       "nodes": 3
     },
     {

--- a/integration-tests/smoke/ocr2_test.go
+++ b/integration-tests/smoke/ocr2_test.go
@@ -34,7 +34,7 @@ func TestOCRv2Basic(t *testing.T) {
 	env, err := test_env.NewCLTestEnvBuilder().
 		WithGeth().
 		WithMockServer(1).
-		WithCLNodeConfig(node.NewConfig(node.BaseConf,
+		WithCLNodeConfig(node.NewConfig(node.NewBaseConfig(),
 			node.WithOCR2(),
 			node.WithP2Pv2(),
 		)).

--- a/integration-tests/types/config/node/core.go
+++ b/integration-tests/types/config/node/core.go
@@ -23,8 +23,8 @@ import (
 	utils2 "github.com/smartcontractkit/chainlink/integration-tests/utils"
 )
 
-var (
-	BaseConf = &chainlink.Config{
+func NewBaseConfig() *chainlink.Config {
+	return &chainlink.Config{
 		Core: toml.Core{
 			RootDir: utils2.Ptr("/home/chainlink"),
 			Database: toml.Database{
@@ -60,7 +60,7 @@ var (
 			P2P: toml.P2P{},
 		},
 	}
-)
+}
 
 type NodeConfigOpt = func(c *chainlink.Config)
 


### PR DESCRIPTION
Use unique base config for each env, we were overwriting the BaseConfig in parallel tests.
Reduce the github runners used in keeper/automation suites by running all the sub test loops in parallel, this could be improved further but may make things harder to triage.
Add ability for the test json lists to specify github runner labels and the parallel test count to use for that test.