### PR TITLE
Use an interface to standardize all docker container set up for various blockchain clients

### DIFF
--- a/integration-tests/docker/test_env/test_env.go
+++ b/integration-tests/docker/test_env/test_env.go
@@ -2,6 +2,7 @@ package test_env
 
 import (
 	"encoding/json"
+	"fmt"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/keystore"
@@ -34,8 +35,8 @@ type CLClusterTestEnv struct {
 
 	/* components */
 	CLNodes          []*ClNode
-	Geth             *test_env.Geth              // for tests using --dev networks
-	PrivateGethChain []test_env.PrivateGethChain // for tests using non-dev networks
+	Geth             *test_env.Geth          // for tests using --dev networks
+	PrivateChain     []test_env.PrivateChain // for tests using non-dev networks
 	MockServer       *test_env.MockServer
 	EVMClient        blockchain.EVMClient
 	ContractDeployer contracts.ContractDeployer
@@ -76,23 +77,34 @@ func (te *CLClusterTestEnv) ParallelTransactions(enabled bool) {
 	te.EVMClient.ParallelTransactions(enabled)
 }
 
-func (te *CLClusterTestEnv) WithPrivateGethChain(evmNetworks []blockchain.EVMNetwork) *CLClusterTestEnv {
-	var chains []test_env.PrivateGethChain
+func (te *CLClusterTestEnv) WithPrivateChain(evmNetworks []blockchain.EVMNetwork) *CLClusterTestEnv {
+	var chains []test_env.PrivateChain
 	for _, evmNetwork := range evmNetworks {
 		n := evmNetwork
-		chains = append(chains, test_env.NewPrivateGethChain(&n, []string{te.Network.Name}))
+		var privateChain test_env.PrivateChain
+		switch n.SimulationType {
+		case "besu":
+			privateChain = test_env.NewPrivateBesuChain(&n, []string{te.Network.Name})
+		default:
+			privateChain = test_env.NewPrivateGethChain(&n, []string{te.Network.Name})
+		}
+		chains = append(chains, privateChain)
 	}
-	te.PrivateGethChain = chains
+	te.PrivateChain = chains
 	return te
 }
 
-func (te *CLClusterTestEnv) StartPrivateGethChain() error {
-	for _, chain := range te.PrivateGethChain {
-		err := chain.PrimaryNode.Start()
+func (te *CLClusterTestEnv) StartPrivateChain() error {
+	for _, chain := range te.PrivateChain {
+		primaryNode := chain.GetPrimaryNode()
+		if primaryNode == nil {
+			return errors.WithStack(fmt.Errorf("Primary node is nil in PrivateChain interface"))
+		}
+		err := primaryNode.Start()
 		if err != nil {
 			return err
 		}
-		err = chain.PrimaryNode.ConnectToClient()
+		err = primaryNode.ConnectToClient()
 		if err != nil {
 			return err
 		}

--- a/integration-tests/docker/test_env/test_env_builder.go
+++ b/integration-tests/docker/test_env/test_env_builder.go
@@ -1,6 +1,7 @@
 package test_env
 
 import (
+	"fmt"
 	"math/big"
 	"os"
 
@@ -136,19 +137,23 @@ func (b *CLTestEnvBuilder) buildNewEnv(cfg *TestEnvConfig) (*CLClusterTestEnv, e
 		}
 	}
 	if b.nonDevGethNetworks != nil {
-		te.WithPrivateGethChain(b.nonDevGethNetworks)
-		err := te.StartPrivateGethChain()
+		te.WithPrivateChain(b.nonDevGethNetworks)
+		err := te.StartPrivateChain()
 		if err != nil {
 			return te, err
 		}
-		var nonDevGethNetworks []blockchain.EVMNetwork
-		for i, n := range te.PrivateGethChain {
-			nonDevGethNetworks = append(nonDevGethNetworks, *n.NetworkConfig)
-			nonDevGethNetworks[i].URLs = []string{n.PrimaryNode.InternalWsUrl}
-			nonDevGethNetworks[i].HTTPURLs = []string{n.PrimaryNode.InternalHttpUrl}
+		var nonDevNetworks []blockchain.EVMNetwork
+		for i, n := range te.PrivateChain {
+			primaryNode := n.GetPrimaryNode()
+			if primaryNode == nil {
+				return te, errors.WithStack(fmt.Errorf("Primary node is nil in PrivateChain interface"))
+			}
+			nonDevNetworks = append(nonDevNetworks, *n.GetNetworkConfig())
+			nonDevNetworks[i].URLs = []string{primaryNode.GetInternalWsUrl()}
+			nonDevNetworks[i].HTTPURLs = []string{primaryNode.GetInternalHttpUrl()}
 		}
-		if nonDevGethNetworks == nil {
-			return nil, errors.New("cannot create nodes with custom config without nonDevGethNetworks")
+		if nonDevNetworks == nil {
+			return nil, errors.New("cannot create nodes with custom config without nonDevNetworks")
 		}
 
 		err = te.StartClNodes(b.clNodeConfig, b.clNodesCount)

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/rs/zerolog v1.30.0
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-env v0.36.0
-	github.com/smartcontractkit/chainlink-testing-framework v1.16.8
+	github.com/smartcontractkit/chainlink-testing-framework v1.16.9-0.20230913144245-620fbcd69dfb
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20230816220705-665e93233ae5
 	github.com/smartcontractkit/ocr2keepers v0.7.23

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -2258,8 +2258,8 @@ github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230831134610-680240b97ac
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230831134610-680240b97aca/go.mod h1:RIUJXn7EVp24TL2p4FW79dYjyno23x5mjt1nKN+5WEk=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230901115736-bbabe542a918 h1:ByVauKFXphRlSNG47lNuxZ9aicu+r8AoNp933VRPpCw=
 github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230901115736-bbabe542a918/go.mod h1:/yp/sqD8Iz5GU5fcercjrw0ivJF7HDcupYg+Gjr7EPg=
-github.com/smartcontractkit/chainlink-testing-framework v1.16.8 h1:YcjSYi6Pm2vOBToxNAmuCrUyb/yymLxjmIEffHUJuhA=
-github.com/smartcontractkit/chainlink-testing-framework v1.16.8/go.mod h1:Ry6fRPr8TwrIsYVNEF1pguAgzE3QW1s54tbLWnFtfI4=
+github.com/smartcontractkit/chainlink-testing-framework v1.16.9-0.20230913144245-620fbcd69dfb h1:ZLBIvWgoB4Op24yNYJ87qGI9yd6B/6WM+uYs3Vj1Hww=
+github.com/smartcontractkit/chainlink-testing-framework v1.16.9-0.20230913144245-620fbcd69dfb/go.mod h1:Ry6fRPr8TwrIsYVNEF1pguAgzE3QW1s54tbLWnFtfI4=
 github.com/smartcontractkit/go-plugin v0.0.0-20230605132010-0f4d515d1472 h1:x3kNwgFlDmbE/n0gTSRMt9GBDfsfGrs4X9b9arPZtFI=
 github.com/smartcontractkit/go-plugin v0.0.0-20230605132010-0f4d515d1472/go.mod h1:6/1TEzT0eQznvI/gV2CM29DLSkAK/e58mUWKVsPaph0=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f h1:hgJif132UCdjo8u43i7iPN1/MFnu49hv7lFGFftCHKU=


### PR DESCRIPTION
## Motivation

- Currently setting up docker test environment for running Private chains is Geth specific.
- There is no way to run other Private chains.

## Solution

- Generalise **CLTestEnvBuilder** and **CLClusterTestEnv** to use **generic interface objects** that could be used to instantiate **Geth** or **Besu** implementations of the docker setup env based on **EVM Network Simulation Type** passed in.