### PR TITLE
[Gateway] Return 400 HTTP code on handler errors

### DIFF
--- a/core/services/gateway/api/constants.go
+++ b/core/services/gateway/api/constants.go
@@ -6,7 +6,7 @@ const (
 	NoError ErrorCode = iota
 	UserMessageParseError
 	UnsupportedDONIdError
-	InternalHandlerError
+	HandlerError
 	RequestTimeoutError
 	NodeReponseEncodingError
 	FatalError
@@ -18,7 +18,7 @@ func ToJsonRPCErrorCode(errorCode ErrorCode) int {
 		NoError:                  0,
 		UserMessageParseError:    -32700, // Parse Error
 		UnsupportedDONIdError:    -32602, // Invalid Params
-		InternalHandlerError:     -32000, // Server Error
+		HandlerError:             -32600, // Invalid Request
 		RequestTimeoutError:      -32000, // Server Error
 		NodeReponseEncodingError: -32603, // Internal Error
 		FatalError:               -32000, // Server Error
@@ -37,7 +37,7 @@ func ToHttpErrorCode(errorCode ErrorCode) int {
 		NoError:                  200, // OK
 		UserMessageParseError:    400, // Bad Request
 		UnsupportedDONIdError:    400, // Bad Request
-		InternalHandlerError:     500, // Internal Server Error
+		HandlerError:             400, // Bad Request
 		RequestTimeoutError:      504, // Gateway Timeout
 		NodeReponseEncodingError: 500, // Internal Server Error
 		FatalError:               500, // Internal Server Error

--- a/core/services/gateway/gateway.go
+++ b/core/services/gateway/gateway.go
@@ -136,7 +136,7 @@ func (g *gateway) ProcessRequest(ctx context.Context, rawRequest []byte) (rawRes
 	responseCh := make(chan handlers.UserCallbackPayload, 1)
 	err = handler.HandleUserMessage(ctx, msg, responseCh)
 	if err != nil {
-		return newError(g.codec, msg.Body.MessageId, api.InternalHandlerError, err.Error())
+		return newError(g.codec, msg.Body.MessageId, api.HandlerError, err.Error())
 	}
 	// await response
 	var response handlers.UserCallbackPayload

--- a/core/services/gateway/gateway_test.go
+++ b/core/services/gateway/gateway_test.go
@@ -242,6 +242,6 @@ func TestGateway_ProcessRequest_HandlerError(t *testing.T) {
 
 	req := newSignedRequest(t, "abcd", "request", "testDON", []byte{})
 	response, statusCode := gw.ProcessRequest(testutils.Context(t), req)
-	requireJsonRPCError(t, response, "abcd", -32000, "failure")
-	require.Equal(t, 500, statusCode)
+	requireJsonRPCError(t, response, "abcd", -32600, "failure")
+	require.Equal(t, 400, statusCode)
 }


### PR DESCRIPTION
Handler errors are user errors (not allowlisted, rate-limited, etc) so we should return a 4XX code.