### PR TITLE
core/services: health Checker cleanup

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -178,7 +178,7 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 	restrictedHTTPClient := opts.RestrictedHTTPClient
 	unrestrictedHTTPClient := opts.UnrestrictedHTTPClient
 
-	// LOOPs can be be created as options, in the  case of LOOP relayers, or
+	// LOOPs can be created as options, in the  case of LOOP relayers, or
 	// as OCR2 job implementations, in the case of Median today.
 	// We will have a non-nil registry here in LOOP relayers are being used, otherwise
 	// we need to initialize in case we serve OCR2 LOOPs
@@ -216,8 +216,6 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 	} else {
 		globalLogger.Info("Nurse service (automatic pprof profiling) is disabled")
 	}
-
-	healthChecker := services.NewChecker()
 
 	telemetryIngressClient := synchronization.TelemetryIngressClient(&synchronization.NoopTelemetryIngressClient{})
 	telemetryIngressBatchClient := synchronization.TelemetryIngressBatchClient(&synchronization.NoopTelemetryIngressBatchClient{})
@@ -443,7 +441,14 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 		feedsService = &feeds.NullService{}
 	}
 
-	app := &ChainlinkApplication{
+	healthChecker := services.NewChecker()
+	for _, s := range srvcs {
+		if err := healthChecker.Register(s); err != nil {
+			return nil, err
+		}
+	}
+
+	return &ChainlinkApplication{
 		relayers:                 opts.RelayerChainInteroperators,
 		EventBroadcaster:         eventBroadcaster,
 		jobORM:                   jobORM,
@@ -472,27 +477,7 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 
 		// NOTE: Can keep things clean by putting more things in srvcs instead of manually start/closing
 		srvcs: srvcs,
-	}
-
-	for _, service := range app.srvcs {
-		checkable := service.(services.Checkable)
-		if err := app.HealthChecker.Register(service.Name(), checkable); err != nil {
-			return nil, err
-		}
-	}
-
-	// To avoid subscribing chain services twice, we only subscribe them if OCR2 is not enabled.
-	// If it's enabled, they are going to be registered with relayers by default.
-	if !cfg.OCR2().Enabled() {
-		for _, service := range app.relayers.Services() {
-			checkable := service.(services.Checkable)
-			if err := app.HealthChecker.Register(service.Name(), checkable); err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	return app, nil
+	}, nil
 }
 
 func (app *ChainlinkApplication) SetLogLevel(lvl zapcore.Level) error {

--- a/core/services/checkable.go
+++ b/core/services/checkable.go
@@ -10,4 +10,6 @@ type Checkable interface {
 	// HealthReport returns a full health report of the callee including it's dependencies.
 	// key is the dep name, value is nil if healthy, or error message otherwise.
 	HealthReport() map[string]error
+	// Name returns the fully qualified name of the component. Usually the logger name.
+	Name() string
 }

--- a/core/services/health.go
+++ b/core/services/health.go
@@ -21,7 +21,7 @@ type (
 	// Checker provides a service which can be probed for system health.
 	Checker interface {
 		// Register a service for health checks.
-		Register(name string, service Checkable) error
+		Register(service Checkable) error
 		// Unregister a service.
 		Unregister(name string) error
 		// IsReady returns the current readiness of the system.
@@ -176,8 +176,9 @@ func (c *checker) update() {
 	uptimeSeconds.Add(interval.Seconds())
 }
 
-func (c *checker) Register(name string, service Checkable) error {
-	if service == nil || name == "" {
+func (c *checker) Register(service Checkable) error {
+	name := service.Name()
+	if name == "" {
 		return errors.Errorf("misconfigured check %#v for %v", name, service)
 	}
 

--- a/core/services/health_test.go
+++ b/core/services/health_test.go
@@ -1,7 +1,6 @@
 package services_test
 
 import (
-	"fmt"
 	"net/http"
 	"testing"
 	"time"
@@ -21,6 +20,8 @@ type boolCheck struct {
 	name    string
 	healthy bool
 }
+
+func (b boolCheck) Name() string { return b.name }
 
 func (b boolCheck) Ready() error {
 	if b.healthy {
@@ -57,8 +58,8 @@ func TestCheck(t *testing.T) {
 		}},
 	} {
 		c := services.NewChecker()
-		for i, check := range test.checks {
-			require.NoError(t, c.Register(fmt.Sprint(i), check))
+		for _, check := range test.checks {
+			require.NoError(t, c.Register(check))
 		}
 
 		require.NoError(t, c.Start())

--- a/core/services/mocks/checker.go
+++ b/core/services/mocks/checker.go
@@ -78,13 +78,13 @@ func (_m *Checker) IsReady() (bool, map[string]error) {
 	return r0, r1
 }
 
-// Register provides a mock function with given fields: name, service
-func (_m *Checker) Register(name string, service services.Checkable) error {
-	ret := _m.Called(name, service)
+// Register provides a mock function with given fields: service
+func (_m *Checker) Register(service services.Checkable) error {
+	ret := _m.Called(service)
 
 	var r0 error
-	if rf, ok := ret.Get(0).(func(string, services.Checkable) error); ok {
-		r0 = rf(name, service)
+	if rf, ok := ret.Get(0).(func(services.Checkable) error); ok {
+		r0 = rf(service)
 	} else {
 		r0 = ret.Error(0)
 	}

--- a/core/services/service.go
+++ b/core/services/service.go
@@ -81,8 +81,5 @@ type ServiceCtx interface {
 	// again, you need to build a new Service to do so.
 	Close() error
 
-	// Name returns the fully qualified name of the service
-	Name() string
-
 	Checkable
 }

--- a/plugins/cmd/chainlink-median/main.go
+++ b/plugins/cmd/chainlink-median/main.go
@@ -20,7 +20,7 @@ func main() {
 	p := median.NewPlugin(s.Logger)
 	defer s.Logger.ErrorIfFn(p.Close, "Failed to close")
 
-	s.MustRegister(p.Name(), p)
+	s.MustRegister(p)
 
 	stop := make(chan struct{})
 	defer close(stop)

--- a/plugins/cmd/chainlink-solana/main.go
+++ b/plugins/cmd/chainlink-solana/main.go
@@ -27,7 +27,7 @@ func main() {
 	p := &pluginRelayer{Base: plugins.Base{Logger: s.Logger}}
 	defer s.Logger.ErrorIfFn(p.Close, "Failed to close")
 
-	s.MustRegister(p.Name(), p)
+	s.MustRegister(p)
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/plugins/cmd/chainlink-starknet/main.go
+++ b/plugins/cmd/chainlink-starknet/main.go
@@ -27,7 +27,7 @@ func main() {
 	p := &pluginRelayer{Base: plugins.Base{Logger: s.Logger}}
 	defer s.Logger.ErrorIfFn(p.Close, "Failed to close")
 
-	s.MustRegister(p.Name(), p)
+	s.MustRegister(p)
 
 	stopCh := make(chan struct{})
 	defer close(stopCh)

--- a/plugins/server.go
+++ b/plugins/server.go
@@ -54,7 +54,7 @@ type Server struct {
 
 // MustRegister registers the Checkable with services.Checker, or exits upon failure.
 func (s *Server) MustRegister(name string, c services.Checkable) {
-	err := s.Register(name, c)
+	err := s.Register(c)
 	if err != nil {
 		s.Logger.Fatalf("Failed to register %s with health checker: %v", name, err)
 	}

--- a/plugins/server.go
+++ b/plugins/server.go
@@ -53,10 +53,9 @@ type Server struct {
 }
 
 // MustRegister registers the Checkable with services.Checker, or exits upon failure.
-func (s *Server) MustRegister(name string, c services.Checkable) {
-	err := s.Register(c)
-	if err != nil {
-		s.Logger.Fatalf("Failed to register %s with health checker: %v", name, err)
+func (s *Server) MustRegister(c services.Checkable) {
+	if err := s.Register(c); err != nil {
+		s.Logger.Fatalf("Failed to register %s with health checker: %v", c.Name(), err)
 	}
 }
 


### PR DESCRIPTION
I noticed some services were added to the health checker twice, and then found some simplifications while cleaning it up.