### PR TITLE
Change the inBackupHealthReport status code to 204 (No content)

### DIFF
--- a/core/services/health.go
+++ b/core/services/health.go
@@ -252,11 +252,7 @@ func (i *InBackupHealthReport) Stop() {
 func (i *InBackupHealthReport) Start() {
 	go func() {
 		http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusServiceUnavailable)
-			_, err := w.Write([]byte("Database backup in progress..."))
-			if err != nil {
-				i.lggr.Errorf("Cannot write response to /health")
-			}
+			w.WriteHeader(http.StatusNoContent)
 		})
 		i.lggr.Info("Starting InBackupHealthReport")
 		if err := i.server.ListenAndServe(); !errors.Is(err, http.ErrServerClosed) {

--- a/core/services/health_test.go
+++ b/core/services/health_test.go
@@ -2,7 +2,6 @@ package services_test
 
 import (
 	"fmt"
-	"io"
 	"net/http"
 	"testing"
 	"time"
@@ -81,11 +80,7 @@ func TestNewInBackupHealthReport(t *testing.T) {
 
 	res, err := http.Get("http://localhost:1234/health")
 	require.NoError(t, err)
-	require.Equal(t, http.StatusServiceUnavailable, res.StatusCode)
-
-	resBody, err := io.ReadAll(res.Body)
-	require.NoError(t, err)
-	require.Equal(t, "Database backup in progress...", string(resBody))
+	require.Equal(t, http.StatusNoContent, res.StatusCode)
 
 	ibhr.Stop()
 	require.Eventually(t, func() bool { return observed.Len() >= 1 }, time.Second*5, time.Millisecond*100)

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -26,7 +26,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ```[ERROR] Error in transaction, rolling back: session missing or expired, please login again pg/transaction.go:118 ```
 - Fixed a bug that was preventing job runs to be displayed when the job `chainID` was disabled.
 - `chainlink txs evm create` returns a transaction hash for the attempted transaction in the CLI. Previously only the sender, recipient and `unstarted` state were returned.
-- Fixed a bug when when `evmChainId` is requested instead of `id` or `evm-chain-id` in CLI error verbatim
+- Fixed a bug where `evmChainId` is requested instead of `id` or `evm-chain-id` in CLI error verbatim
+- Fixed a bug that would cause the node to shut down while performing backup
 
 ## 2.5.0 - UNRELEASED
 =======


### PR DESCRIPTION
Change the `inBackupHealthReport` status code to 204 (No content). Status code 503 would cause the docker health check to fail. 

Node: `inBackupHealthReport` status code cannot be 200 as it would conflict with the `waitForNodeReady` used in CI.