### PR TITLE
Enables Skipping More Tests

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -56,10 +56,16 @@ jobs:
 
   split-packages:
     name: Split Go Tests
+    if: ${{ !contains(join(github.event.pull_request.labels.*.name, ' '), 'skip-smoke-tests') }}
     runs-on: ubuntu-latest
     outputs:
       splits: ${{ steps.split.outputs.splits }}
     steps:
+      - name: Check for Skip Tests Label
+        if: contains(join(github.event.pull_request.labels.*.name, ' '), 'skip-smoke-tests')
+        run: |
+          echo "## \`skip-smoke-tests\` label is active, skipping E2E smoke tests" >>$GITHUB_STEP_SUMMARY
+          exit 0
       - name: Checkout the repo
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Setup Go
@@ -290,11 +296,17 @@ jobs:
 
   clean:
     name: Clean Go Tidy & Generate
+    if: ${{ !contains(join(github.event.pull_request.labels.*.name, ' '), 'skip-smoke-tests') }}
     runs-on: ubuntu-latest
     defaults:
       run:
         shell: bash
     steps:
+      - name: Check for Skip Tests Label
+        if: contains(join(github.event.pull_request.labels.*.name, ' '), 'skip-smoke-tests')
+        run: |
+          echo "## \`skip-smoke-tests\` label is active, skipping E2E smoke tests" >>$GITHUB_STEP_SUMMARY
+          exit 0
       - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           fetch-depth: 0

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -107,7 +107,7 @@ jobs:
       - name: Print Chainlink Image Built
         if: needs.changes.outputs.src == 'true'
         run: |
-          echo "### chainlink node image tag used for this test run :link:" >>$GITHUB_STEP_SUMMARY
+          echo "### Chainlink node image tag used for this test run :link:" >>$GITHUB_STEP_SUMMARY
           echo "\`${GITHUB_SHA}\`" >>$GITHUB_STEP_SUMMARY
 
   build-test-image:


### PR DESCRIPTION
The `skip-smoke-tests` tag is handy for draft PRs where you don't care about test results yet, so why waste time and resources running them? This is especially helpful when using a common workflow of building a new Chainlink image for use in soak tests. So far we've only used this tag to skip E2E smoke tests, but it can be expanded to skip the core unit and integration tests as well.

Tests are still required to complete successfully to merge, and will still run by default.