### PR TITLE
enable EIP-1559 support for BSC mainnet & testnet

### DIFF
--- a/core/chains/evm/config/toml/defaults/BSC_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/BSC_Mainnet.toml
@@ -15,8 +15,10 @@ Transactions.ResendAfterThreshold = '1m'
 Enabled = true
 
 [GasEstimator]
-PriceDefault = '5 gwei'
-PriceMin = '1 gwei'
+# For BSC the Block Base Fee will always be 0 and only the priority fee will be used
+EIP1559DynamicFees = true
+TipCapDefault = '3 gwei'
+TipCapMin = '1 gwei'
 BumpMin = '5 gwei'
 # 15s delay since feeds update every minute in volatile situations
 BumpThreshold = 5

--- a/core/chains/evm/config/toml/defaults/BSC_Testnet.toml
+++ b/core/chains/evm/config/toml/defaults/BSC_Testnet.toml
@@ -15,8 +15,10 @@ Transactions.ResendAfterThreshold = '1m'
 Enabled = true
 
 [GasEstimator]
-PriceDefault = '5 gwei'
-PriceMin = '1 gwei'
+# For BSC the Block Base Fee will always be 0 and only the priority fee will be used
+EIP1559DynamicFees = true
+TipCapDefault = '10 gwei'
+TipCapMin = '1 gwei'
 BumpMin = '5 gwei'
 # 15s delay since feeds update every minute in volatile situations
 BumpThreshold = 5

--- a/core/config/docs/chains-evm.toml
+++ b/core/config/docs/chains-evm.toml
@@ -166,7 +166,7 @@ BumpPercent = 20 # Default
 BumpThreshold = 3 # Default
 # BumpTxDepth is the number of transactions to gas bump starting from oldest. Set to 0 for no limit (i.e. bump all). Can not be greater than EVM.Transactions.MaxInFlight. If not set, defaults to EVM.Transactions.MaxInFlight.
 BumpTxDepth = 16 # Example
-# EIP1559DynamicFees torces EIP-1559 transaction mode. Enabling EIP-1559 mode can help reduce gas costs on chains that support it. This is supported only on official Ethereum mainnet and testnets. It is not recommended to enable this setting on Polygon because the EIP-1559 fee market appears to be broken on all Polygon chains and EIP-1559 transactions are less likely to be included than legacy transactions.
+# EIP1559DynamicFees forces EIP-1559 transaction mode. Enabling EIP-1559 mode can help reduce gas costs on chains that support it. This is supported only on official Ethereum mainnet and testnets. It is not recommended to enable this setting on Polygon because the EIP-1559 fee market appears to be broken on all Polygon chains and EIP-1559 transactions are less likely to be included than legacy transactions.
 #
 # #### Technical details
 #

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -2084,7 +2084,7 @@ Enabled = true
 
 [GasEstimator]
 Mode = 'BlockHistory'
-PriceDefault = '5 gwei'
+PriceDefault = '20 gwei'
 PriceMax = '115792089237316195423570985008687907853269984665.640564039457584007913129639935 tether'
 PriceMin = '1 gwei'
 LimitDefault = 500000
@@ -2094,10 +2094,10 @@ LimitTransfer = 21000
 BumpMin = '5 gwei'
 BumpPercent = 20
 BumpThreshold = 5
-EIP1559DynamicFees = false
+EIP1559DynamicFees = true
 FeeCapDefault = '100 gwei'
-TipCapDefault = '1 wei'
-TipCapMin = '1 wei'
+TipCapDefault = '3 gwei'
+TipCapMin = '1 gwei'
 
 [GasEstimator.BlockHistory]
 BatchSize = 25
@@ -2316,7 +2316,7 @@ Enabled = true
 
 [GasEstimator]
 Mode = 'BlockHistory'
-PriceDefault = '5 gwei'
+PriceDefault = '20 gwei'
 PriceMax = '115792089237316195423570985008687907853269984665.640564039457584007913129639935 tether'
 PriceMin = '1 gwei'
 LimitDefault = 500000
@@ -2326,10 +2326,10 @@ LimitTransfer = 21000
 BumpMin = '5 gwei'
 BumpPercent = 20
 BumpThreshold = 5
-EIP1559DynamicFees = false
+EIP1559DynamicFees = true
 FeeCapDefault = '100 gwei'
-TipCapDefault = '1 wei'
-TipCapMin = '1 wei'
+TipCapDefault = '10 gwei'
+TipCapMin = '1 gwei'
 
 [GasEstimator.BlockHistory]
 BatchSize = 25
@@ -4750,7 +4750,7 @@ BumpTxDepth is the number of transactions to gas bump starting from oldest. Set 
 ```toml
 EIP1559DynamicFees = false # Default
 ```
-EIP1559DynamicFees torces EIP-1559 transaction mode. Enabling EIP-1559 mode can help reduce gas costs on chains that support it. This is supported only on official Ethereum mainnet and testnets. It is not recommended to enable this setting on Polygon because the EIP-1559 fee market appears to be broken on all Polygon chains and EIP-1559 transactions are less likely to be included than legacy transactions.
+EIP1559DynamicFees forces EIP-1559 transaction mode. Enabling EIP-1559 mode can help reduce gas costs on chains that support it. This is supported only on official Ethereum mainnet and testnets. It is not recommended to enable this setting on Polygon because the EIP-1559 fee market appears to be broken on all Polygon chains and EIP-1559 transactions are less likely to be included than legacy transactions.
 
 #### Technical details
 


### PR DESCRIPTION
The recent Hertz hard fork enabled support for [BEP-226](https://github.com/bnb-chain/BEPs/blob/master/BEPs/BEP226.md), porting EIP-1559 with a base fee of 0.

This will activate EIP-1559 support for both mainnet & testnet. The base fee will always be set to `0` and only the priority fee is used for gas payments.