### PR TITLE
BCF-2657: core/services: track spawned job services via the health checker

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -404,11 +404,13 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 		globalLogger.Debug("Off-chain reporting v2 disabled")
 	}
 
+	healthChecker := services.NewChecker()
+
 	var lbs []utils.DependentAwaiter
 	for _, c := range legacyEVMChains.Slice() {
 		lbs = append(lbs, c.LogBroadcaster())
 	}
-	jobSpawner := job.NewSpawner(jobORM, cfg.Database(), delegates, db, globalLogger, lbs)
+	jobSpawner := job.NewSpawner(jobORM, cfg.Database(), healthChecker, delegates, db, globalLogger, lbs)
 	srvcs = append(srvcs, jobSpawner, pipelineRunner)
 
 	// We start the log poller after the job spawner
@@ -445,7 +447,6 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 		}
 	}
 
-	healthChecker := services.NewChecker()
 	for _, s := range srvcs {
 		if err := healthChecker.Register(s); err != nil {
 			return nil, err

--- a/core/services/directrequest/delegate.go
+++ b/core/services/directrequest/delegate.go
@@ -138,6 +138,12 @@ type listener struct {
 	utils.StartStopOnce
 }
 
+func (l *listener) HealthReport() map[string]error {
+	return map[string]error{l.Name(): l.Healthy()}
+}
+
+func (l *listener) Name() string { return l.logger.Name() }
+
 // Start complies with job.Service
 func (l *listener) Start(context.Context) error {
 	return l.StartOnce("DirectRequestListener", func() error {

--- a/core/services/functions/listener.go
+++ b/core/services/functions/listener.go
@@ -142,6 +142,12 @@ type FunctionsListener struct {
 	logPollerWrapper   evmrelayTypes.LogPollerWrapper
 }
 
+func (l *FunctionsListener) HealthReport() map[string]error {
+	return map[string]error{l.Name(): l.Healthy()}
+}
+
+func (l *FunctionsListener) Name() string { return l.logger.Name() }
+
 func formatRequestId(requestId [32]byte) string {
 	return fmt.Sprintf("0x%x", requestId)
 }

--- a/core/services/job/spawner_test.go
+++ b/core/services/job/spawner_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/smartcontractkit/chainlink/v2/core/services"
+
 	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -100,7 +102,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 		orm := NewTestORM(t, db, legacyChains, pipeline.NewORM(db, lggr, config.Database(), config.JobPipeline().MaxSuccessfulRuns()), bridges.NewORM(db, lggr, config.Database()), keyStore, config.Database())
 		a := utils.NewDependentAwaiter()
 		a.AddDependents(1)
-		spawner := job.NewSpawner(orm, config.Database(), map[job.Type]job.Delegate{}, db, lggr, []utils.DependentAwaiter{a})
+		spawner := job.NewSpawner(orm, config.Database(), noopChecker{}, map[job.Type]job.Delegate{}, db, lggr, []utils.DependentAwaiter{a})
 		// Starting the spawner should signal to the dependents
 		result := make(chan bool)
 		go func() {
@@ -139,7 +141,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 		dB := ocr.NewDelegate(nil, orm, nil, nil, nil, monitoringEndpoint, legacyChains, logger.TestLogger(t), config.Database(), mailMon)
 		delegateB := &delegate{jobB.Type, []job.ServiceCtx{serviceB1, serviceB2}, 0, make(chan struct{}), dB}
 
-		spawner := job.NewSpawner(orm, config.Database(), map[job.Type]job.Delegate{
+		spawner := job.NewSpawner(orm, config.Database(), noopChecker{}, map[job.Type]job.Delegate{
 			jobA.Type: delegateA,
 			jobB.Type: delegateB,
 		}, db, lggr, nil)
@@ -189,7 +191,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 		mailMon := srvctest.Start(t, utils.NewMailboxMonitor(t.Name()))
 		d := ocr.NewDelegate(nil, orm, nil, nil, nil, monitoringEndpoint, legacyChains, logger.TestLogger(t), config.Database(), mailMon)
 		delegateA := &delegate{jobA.Type, []job.ServiceCtx{serviceA1, serviceA2}, 0, nil, d}
-		spawner := job.NewSpawner(orm, config.Database(), map[job.Type]job.Delegate{
+		spawner := job.NewSpawner(orm, config.Database(), noopChecker{}, map[job.Type]job.Delegate{
 			jobA.Type: delegateA,
 		}, db, lggr, nil)
 
@@ -223,7 +225,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 		mailMon := srvctest.Start(t, utils.NewMailboxMonitor(t.Name()))
 		d := ocr.NewDelegate(nil, orm, nil, nil, nil, monitoringEndpoint, legacyChains, logger.TestLogger(t), config.Database(), mailMon)
 		delegateA := &delegate{jobA.Type, []job.ServiceCtx{serviceA1, serviceA2}, 0, nil, d}
-		spawner := job.NewSpawner(orm, config.Database(), map[job.Type]job.Delegate{
+		spawner := job.NewSpawner(orm, config.Database(), noopChecker{}, map[job.Type]job.Delegate{
 			jobA.Type: delegateA,
 		}, db, lggr, nil)
 
@@ -300,7 +302,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 			keyStore.OCR2(), keyStore.DKGSign(), keyStore.DKGEncrypt(), ethKeyStore, testRelayGetter, mailMon, nil)
 		delegateOCR2 := &delegate{jobOCR2VRF.Type, []job.ServiceCtx{}, 0, nil, d}
 
-		spawner := job.NewSpawner(orm, config.Database(), map[job.Type]job.Delegate{
+		spawner := job.NewSpawner(orm, config.Database(), noopChecker{}, map[job.Type]job.Delegate{
 			jobOCR2VRF.Type: delegateOCR2,
 		}, db, lggr, nil)
 
@@ -322,3 +324,17 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 		spawner.Close()
 	})
 }
+
+type noopChecker struct{}
+
+func (n noopChecker) Register(service services.Checkable) error { return nil }
+
+func (n noopChecker) Unregister(name string) error { return nil }
+
+func (n noopChecker) IsReady() (ready bool, errors map[string]error) { return true, nil }
+
+func (n noopChecker) IsHealthy() (healthy bool, errors map[string]error) { return true, nil }
+
+func (n noopChecker) Start() error { return nil }
+
+func (n noopChecker) Close() error { return nil }

--- a/core/services/ocr/contract_tracker.go
+++ b/core/services/ocr/contract_tracker.go
@@ -94,6 +94,12 @@ type (
 	}
 )
 
+func (t *OCRContractTracker) HealthReport() map[string]error {
+	return map[string]error{t.Name(): t.Healthy()}
+}
+
+func (t *OCRContractTracker) Name() string { return t.logger.Name() }
+
 // NewOCRContractTracker makes a new OCRContractTracker
 func NewOCRContractTracker(
 	contract *offchain_aggregator_wrapper.OffchainAggregator,

--- a/core/services/ocrcommon/run_saver.go
+++ b/core/services/ocrcommon/run_saver.go
@@ -18,6 +18,12 @@ type RunResultSaver struct {
 	logger            logger.Logger
 }
 
+func (r *RunResultSaver) HealthReport() map[string]error {
+	return map[string]error{r.Name(): r.Healthy()}
+}
+
+func (r *RunResultSaver) Name() string { return r.logger.Name() }
+
 func NewResultRunSaver(runResults <-chan pipeline.Run, pipelineRunner pipeline.Runner, done chan struct{},
 	logger logger.Logger, maxSuccessfulRuns uint64,
 ) *RunResultSaver {
@@ -26,7 +32,7 @@ func NewResultRunSaver(runResults <-chan pipeline.Run, pipelineRunner pipeline.R
 		runResults:        runResults,
 		pipelineRunner:    pipelineRunner,
 		done:              done,
-		logger:            logger,
+		logger:            logger.Named("RunResultSaver"),
 	}
 }
 

--- a/core/services/vrf/v2/listener_v2.go
+++ b/core/services/vrf/v2/listener_v2.go
@@ -241,6 +241,12 @@ type listenerV2 struct {
 	deduper *vrfcommon.LogDeduper
 }
 
+func (lsn *listenerV2) HealthReport() map[string]error {
+	return map[string]error{lsn.Name(): lsn.Healthy()}
+}
+
+func (lsn *listenerV2) Name() string { return lsn.l.Name() }
+
 // Start starts listenerV2.
 func (lsn *listenerV2) Start(ctx context.Context) error {
 	return lsn.StartOnce("VRFListenerV2", func() error {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `chainlink txs evm create` returns a transaction hash for the attempted transaction in the CLI. Previously only the sender, recipient and `unstarted` state were returned.
 - Fixed a bug where `evmChainId` is requested instead of `id` or `evm-chain-id` in CLI error verbatim
 - Fixed a bug that would cause the node to shut down while performing backup
+- Fixed health checker to include more services in the prometheus `health` metric and HTTP `/health` endpoint 
 
 ## 2.5.0 - UNRELEASED
 =======


### PR DESCRIPTION
I noticed that we only add services to the health checker during initial application startup, which leaves out services spawned by jobs.

https://smartcontract-it.atlassian.net/browse/BCF-2657