### PR TITLE
Improve check block too old detection

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/registry_check_pipeline.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/registry_check_pipeline.go
@@ -244,9 +244,9 @@ func (r *EvmRegistry) checkUpkeeps(ctx context.Context, payloads []ocr2keepers.U
 		if req.Error != nil {
 			latestBlock := r.bs.latestBlock.Load()
 			checkBlock, _, _ := r.getBlockAndUpkeepId(payloads[index].UpkeepID, payloads[index].Trigger)
-			errString := req.Error.Error()
 			// Exploratory: remove reliance on primitive way of checking errors
-			if (strings.Contains(errString, "header not found") || strings.Contains(errString, "missing trie node")) && int64(latestBlock.Number)-checkBlock.Int64() > checkBlockTooOldRange {
+			blockNotFound := (strings.Contains(req.Error.Error(), "header not found") || strings.Contains(req.Error.Error(), "missing trie node"))
+			if blockNotFound && int64(latestBlock.Number)-checkBlock.Int64() > checkBlockTooOldRange {
 				// Check block not found in RPC and it is too old, non-retryable error
 				r.lggr.Warnf("header not found error encountered in check result for upkeepId %s, check block %d, latest block %d: %s", results[index].UpkeepID.String(), checkBlock.Int64(), int64(latestBlock.Number), req.Error)
 				results[index].Retryable = false

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/registry_check_pipeline.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/registry_check_pipeline.go
@@ -245,7 +245,7 @@ func (r *EvmRegistry) checkUpkeeps(ctx context.Context, payloads []ocr2keepers.U
 			latestBlock := r.bs.latestBlock.Load()
 			checkBlock, _, _ := r.getBlockAndUpkeepId(payloads[index].UpkeepID, payloads[index].Trigger)
 			// primitive way of checking errors
-			if strings.Contains(req.Error.Error(), "header not found") && int64(latestBlock.Number)-checkBlock.Int64() > checkBlockTooOldRange {
+			if (strings.Contains(req.Error.Error(), "header not found") || strings.Contains(req.Error.Error(), "missing trie node")) && int64(latestBlock.Number)-checkBlock.Int64() > checkBlockTooOldRange {
 				// Check block not found in RPC and it is too old, non-retryable error
 				r.lggr.Warnf("header not found error encountered in check result for upkeepId %s, check block %d, latest block %d: %s", results[index].UpkeepID.String(), checkBlock.Int64(), int64(latestBlock.Number), req.Error)
 				results[index].Retryable = false

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/registry_check_pipeline.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/registry_check_pipeline.go
@@ -244,8 +244,9 @@ func (r *EvmRegistry) checkUpkeeps(ctx context.Context, payloads []ocr2keepers.U
 		if req.Error != nil {
 			latestBlock := r.bs.latestBlock.Load()
 			checkBlock, _, _ := r.getBlockAndUpkeepId(payloads[index].UpkeepID, payloads[index].Trigger)
-			// primitive way of checking errors
-			if (strings.Contains(req.Error.Error(), "header not found") || strings.Contains(req.Error.Error(), "missing trie node")) && int64(latestBlock.Number)-checkBlock.Int64() > checkBlockTooOldRange {
+			errString := req.Error.Error()
+			// Exploratory: remove reliance on primitive way of checking errors
+			if (strings.Contains(errString, "header not found") || strings.Contains(errString, "missing trie node")) && int64(latestBlock.Number)-checkBlock.Int64() > checkBlockTooOldRange {
 				// Check block not found in RPC and it is too old, non-retryable error
 				r.lggr.Warnf("header not found error encountered in check result for upkeepId %s, check block %d, latest block %d: %s", results[index].UpkeepID.String(), checkBlock.Int64(), int64(latestBlock.Number), req.Error)
 				results[index].Retryable = false

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/registry_check_pipeline.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/registry_check_pipeline.go
@@ -248,7 +248,7 @@ func (r *EvmRegistry) checkUpkeeps(ctx context.Context, payloads []ocr2keepers.U
 			blockNotFound := (strings.Contains(req.Error.Error(), "header not found") || strings.Contains(req.Error.Error(), "missing trie node"))
 			if blockNotFound && int64(latestBlock.Number)-checkBlock.Int64() > checkBlockTooOldRange {
 				// Check block not found in RPC and it is too old, non-retryable error
-				r.lggr.Warnf("header not found error encountered in check result for upkeepId %s, check block %d, latest block %d: %s", results[index].UpkeepID.String(), checkBlock.Int64(), int64(latestBlock.Number), req.Error)
+				r.lggr.Warnf("block not found error encountered in check result for upkeepId %s, check block %d, latest block %d: %s", results[index].UpkeepID.String(), checkBlock.Int64(), int64(latestBlock.Number), req.Error)
 				results[index].Retryable = false
 				results[index].PipelineExecutionState = uint8(encoding.CheckBlockTooOld)
 			} else {


### PR DESCRIPTION
saw on matic, some payloads were stuck in retry loop as they were getting missing trie node error

adding that string to error check. Don't fully like the approach of handling error strings which got us here, open to better solutions

We're not fully relying on just latest-checkBlock > checkBlockTooOldRange because the range can differ from chains, and the existing 128 range was too small for arbitrum, causing lots of payloads to error out early