### PR TITLE
Fix, move version 2.5.0 from unreleased in changelog

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -33,9 +33,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `chainlink txs evm create` returns a transaction hash for the attempted transaction in the CLI. Previously only the sender, recipient and `unstarted` state were returned.
 - Fixed a bug where `evmChainId` is requested instead of `id` or `evm-chain-id` in CLI error verbatim
 - Fixed a bug that would cause the node to shut down while performing backup
-- Fixed health checker to include more services in the prometheus `health` metric and HTTP `/health` endpoint 
+- Fixed health checker to include more services in the prometheus `health` metric and HTTP `/health` endpoint
 
-## 2.5.0 - UNRELEASED
+<!-- unreleasedstop -->
+
+## 2.5.0 - 2023-09-13
 
 - Unauthenticated users executing CLI commands previously generated a confusing error log, which is now removed:
   ```
@@ -50,8 +52,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - `mercury_price_feed_missing`
     - `mercury_price_feed_errors`
   Nops may wish to add alerting on these.
-
-<!-- unreleasedstop -->
 
 ### Upcoming Required Configuration Change
 


### PR DESCRIPTION
A minor fix for 2.5/6.0 releases in the changelog