### PR TITLE
BCF-2665 Fix SQ regex for ci tests output

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -209,8 +209,8 @@ jobs:
         id: sonarqube_report_paths
         shell: bash
         run: |
-          echo "sonarqube_tests_report_paths=$(find go_core_tests_*_logs -name output.txt | paste -sd "," -)" >> $GITHUB_OUTPUT
-          echo "sonarqube_coverage_report_paths=$(find go_core_tests_*_logs -name coverage.txt | paste -sd "," -)" >> $GITHUB_OUTPUT
+          echo "sonarqube_tests_report_paths=$(find go_core_tests_logs -name output.txt | paste -sd "," -)" >> $GITHUB_OUTPUT
+          echo "sonarqube_coverage_report_paths=$(find go_core_tests_logs -name coverage.txt | paste -sd "," -)" >> $GITHUB_OUTPUT
       - name: SonarQube Scan
         uses: sonarsource/sonarqube-scan-action@69c1a75940dec6249b86dace6b630d3a2ae9d2a7 # v2.0.1
         with:

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -109,7 +109,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
-          name: go_core_tests_${{ matrix.cmd }}_logs
+          name: ${{ matrix.cmd }}_logs
           path: |
             ./output.txt
             ./output-short.txt

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -109,7 +109,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0
         with:
-          name: ${{ matrix.cmd }}_logs
+          name: go_core_tests_${{ matrix.cmd }}_logs
           path: |
             ./output.txt
             ./output-short.txt


### PR DESCRIPTION
Sonar Qube can no longer find test coverage, because path to artifacts got changed. This should fix the SQ regex