### PR TITLE
Move RegisterFilter() calls into (d *job.Delegate).CreateJob

### DIFF
--- a/core/chains/evm/forwarders/orm.go
+++ b/core/chains/evm/forwarders/orm.go
@@ -35,7 +35,7 @@ func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) *orm {
 // CreateForwarder creates the Forwarder address associated with the current EVM chain id.
 func (o *orm) CreateForwarder(addr common.Address, evmChainId utils.Big, qopts ...pg.QOpt) (fwd Forwarder, err error) {
 	q := o.q.WithOpts(qopts...)
-	sql := `INSERT INTO evm_forwarders (address, evm_chain_id, created_at, updated_at) VALUES ($1, $2, now(), now()) RETURNING *`
+	sql := `INSERT INTO evm.forwarders (address, evm_chain_id, created_at, updated_at) VALUES ($1, $2, now(), now()) RETURNING *`
 	err = q.Get(&fwd, sql, addr, evmChainId)
 	return fwd, err
 }

--- a/core/chains/evm/forwarders/orm.go
+++ b/core/chains/evm/forwarders/orm.go
@@ -15,7 +15,7 @@ import (
 //go:generate mockery --quiet --name ORM --output ./mocks/ --case=underscore
 
 type ORM interface {
-	CreateForwarder(addr common.Address, evmChainId utils.Big) (fwd Forwarder, err error)
+	CreateForwarder(addr common.Address, evmChainId utils.Big, qopts ...pg.QOpt) (fwd Forwarder, err error)
 	FindForwarders(offset, limit int) ([]Forwarder, int, error)
 	FindForwardersByChain(evmChainId utils.Big) ([]Forwarder, error)
 	DeleteForwarder(id int64, cleanup func(tx pg.Queryer, evmChainId int64, addr common.Address) error) error
@@ -33,9 +33,10 @@ func NewORM(db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) *orm {
 }
 
 // CreateForwarder creates the Forwarder address associated with the current EVM chain id.
-func (o *orm) CreateForwarder(addr common.Address, evmChainId utils.Big) (fwd Forwarder, err error) {
-	sql := `INSERT INTO evm.forwarders (address, evm_chain_id, created_at, updated_at) VALUES ($1, $2, now(), now()) RETURNING *`
-	err = o.q.Get(&fwd, sql, addr, evmChainId)
+func (o *orm) CreateForwarder(addr common.Address, evmChainId utils.Big, qopts ...pg.QOpt) (fwd Forwarder, err error) {
+	q := o.q.WithOpts(qopts...)
+	sql := `INSERT INTO evm_forwarders (address, evm_chain_id, created_at, updated_at) VALUES ($1, $2, now(), now()) RETURNING *`
+	err = q.Get(&fwd, sql, addr, evmChainId)
 	return fwd, err
 }
 
@@ -50,13 +51,13 @@ func (o *orm) DeleteForwarder(id int64, cleanup func(tx pg.Queryer, evmChainID i
 
 	var rowsAffected int64
 	err = o.q.Transaction(func(tx pg.Queryer) error {
-		err = tx.Get(&dest, `SELECT evm_chain_id, address FROM evm.forwarders WHERE id = $1`, id)
-		if err != nil {
-			return err
+		err2 := tx.Get(&dest, `SELECT evm_chain_id, address FROM evm.forwarders WHERE id = $1`, id)
+		if err2 != nil {
+			return err2
 		}
 		if cleanup != nil {
-			if err = cleanup(tx, dest.EvmChainId, dest.Address); err != nil {
-				return err
+			if err2 = cleanup(tx, dest.EvmChainId, dest.Address); err2 != nil {
+				return err2
 			}
 		}
 
@@ -68,6 +69,14 @@ func (o *orm) DeleteForwarder(id int64, cleanup func(tx pg.Queryer, evmChainID i
 			return err2
 		}
 		rowsAffected, err2 = result.RowsAffected()
+		if err2 != nil {
+			return err2
+		}
+
+		// cleanup should be last, as it may contain non-db side effects
+		if cleanup != nil {
+			err2 = cleanup(tx, dest.EvmChainId, dest.Address)
+		}
 
 		return err2
 	})

--- a/core/chains/evm/logpoller/log_poller_internal_test.go
+++ b/core/chains/evm/logpoller/log_poller_internal_test.go
@@ -24,7 +24,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 var (
@@ -61,9 +60,6 @@ func TestLogPoller_RegisterFilter(t *testing.T) {
 	db = pgtest.NewSqlxDB(t)
 	orm = NewORM(chainID, db, lggr, pgtest.NewQConfig(true))
 
-	// disable check that chain id exists for rest of tests
-	require.NoError(t, utils.JustError(db.Exec(`SET CONSTRAINTS evm_log_poller_filters_evm_chain_id_fkey DEFERRED`)))
-
 	// Set up a test chain with a log emitting contract deployed.
 	lp := NewLogPoller(orm, nil, lggr, time.Hour, 1, 1, 2, 1000)
 
@@ -72,7 +68,7 @@ func TestLogPoller_RegisterFilter(t *testing.T) {
 	require.Equal(t, 1, len(f.Addresses))
 	assert.Equal(t, common.HexToAddress("0x0000000000000000000000000000000000000000"), f.Addresses[0])
 
-	err := lp.RegisterFilter(Filter{"Emitter Log 1", []common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{a1}, 0}, nil)
+	err := lp.RegisterFilter(Filter{"Emitter Log 1", []common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{a1}, 0})
 
 	require.NoError(t, err)
 	assert.Equal(t, []common.Address{a1}, lp.Filter(nil, nil, nil).Addresses)
@@ -80,25 +76,25 @@ func TestLogPoller_RegisterFilter(t *testing.T) {
 	validateFiltersTable(t, lp, orm)
 
 	// Should de-dupe EventSigs
-	err = lp.RegisterFilter(Filter{"Emitter Log 1 + 2", []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}, 0}, nil)
+	err = lp.RegisterFilter(Filter{"Emitter Log 1 + 2", []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}, 0})
 	require.NoError(t, err)
 	assert.Equal(t, []common.Address{a1, a2}, lp.Filter(nil, nil, nil).Addresses)
 	assert.Equal(t, [][]common.Hash{{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}}, lp.Filter(nil, nil, nil).Topics)
 	validateFiltersTable(t, lp, orm)
 
 	// Should de-dupe Addresses
-	err = lp.RegisterFilter(Filter{"Emitter Log 1 + 2 dupe", []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}, 0}, nil)
+	err = lp.RegisterFilter(Filter{"Emitter Log 1 + 2 dupe", []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}, 0})
 	require.NoError(t, err)
 	assert.Equal(t, []common.Address{a1, a2}, lp.Filter(nil, nil, nil).Addresses)
 	assert.Equal(t, [][]common.Hash{{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}}, lp.Filter(nil, nil, nil).Topics)
 	validateFiltersTable(t, lp, orm)
 
 	// Address required.
-	err = lp.RegisterFilter(Filter{"no address", []common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{}, 0}, nil)
+	err = lp.RegisterFilter(Filter{"no address", []common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{}, 0})
 	require.Error(t, err)
 
 	// Event required
-	err = lp.RegisterFilter(Filter{"No event", []common.Hash{}, []common.Address{a1}, 0}, nil)
+	err = lp.RegisterFilter(Filter{"No event", []common.Hash{}, []common.Address{a1}, 0})
 	require.Error(t, err)
 	validateFiltersTable(t, lp, orm)
 
@@ -478,7 +474,7 @@ func benchmarkFilter(b *testing.B, nFilters, nAddresses, nEvents int) {
 		for j := 0; j < nEvents; j++ {
 			events = append(events, common.BigToHash(big.NewInt(int64(j+1))))
 		}
-		err := lp.RegisterFilter(Filter{Name: "my Filter", EventSigs: events, Addresses: addresses}, nil)
+		err := lp.RegisterFilter(Filter{Name: "my Filter", EventSigs: events, Addresses: addresses})
 		require.NoError(b, err)
 	}
 	b.ResetTimer()

--- a/core/chains/evm/logpoller/log_poller_internal_test.go
+++ b/core/chains/evm/logpoller/log_poller_internal_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
 var (
@@ -56,6 +57,13 @@ func TestLogPoller_RegisterFilter(t *testing.T) {
 
 	orm := NewORM(chainID, db, lggr, pgtest.NewQConfig(true))
 
+	db.Close()
+	db = pgtest.NewSqlxDB(t)
+	orm = NewORM(chainID, db, lggr, pgtest.NewQConfig(true))
+
+	// disable check that chain id exists for rest of tests
+	require.NoError(t, utils.JustError(db.Exec(`SET CONSTRAINTS evm_log_poller_filters_evm_chain_id_fkey DEFERRED`)))
+
 	// Set up a test chain with a log emitting contract deployed.
 	lp := NewLogPoller(orm, nil, lggr, time.Hour, 1, 1, 2, 1000)
 
@@ -64,31 +72,33 @@ func TestLogPoller_RegisterFilter(t *testing.T) {
 	require.Equal(t, 1, len(f.Addresses))
 	assert.Equal(t, common.HexToAddress("0x0000000000000000000000000000000000000000"), f.Addresses[0])
 
-	err := lp.RegisterFilter(Filter{"Emitter Log 1", []common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{a1}, 0})
+	err := lp.RegisterFilter(Filter{"Emitter Log 1", []common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{a1}, 0}, nil)
+
 	require.NoError(t, err)
 	assert.Equal(t, []common.Address{a1}, lp.Filter(nil, nil, nil).Addresses)
 	assert.Equal(t, [][]common.Hash{{EmitterABI.Events["Log1"].ID}}, lp.Filter(nil, nil, nil).Topics)
 	validateFiltersTable(t, lp, orm)
 
 	// Should de-dupe EventSigs
-	err = lp.RegisterFilter(Filter{"Emitter Log 1 + 2", []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}, 0})
+	err = lp.RegisterFilter(Filter{"Emitter Log 1 + 2", []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}, 0}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []common.Address{a1, a2}, lp.Filter(nil, nil, nil).Addresses)
 	assert.Equal(t, [][]common.Hash{{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}}, lp.Filter(nil, nil, nil).Topics)
 	validateFiltersTable(t, lp, orm)
 
 	// Should de-dupe Addresses
-	err = lp.RegisterFilter(Filter{"Emitter Log 1 + 2 dupe", []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}, 0})
+	err = lp.RegisterFilter(Filter{"Emitter Log 1 + 2 dupe", []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{a2}, 0}, nil)
 	require.NoError(t, err)
 	assert.Equal(t, []common.Address{a1, a2}, lp.Filter(nil, nil, nil).Addresses)
 	assert.Equal(t, [][]common.Hash{{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}}, lp.Filter(nil, nil, nil).Topics)
 	validateFiltersTable(t, lp, orm)
 
 	// Address required.
-	err = lp.RegisterFilter(Filter{"no address", []common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{}, 0})
+	err = lp.RegisterFilter(Filter{"no address", []common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{}, 0}, nil)
 	require.Error(t, err)
+
 	// Event required
-	err = lp.RegisterFilter(Filter{"No event", []common.Hash{}, []common.Address{a1}, 0})
+	err = lp.RegisterFilter(Filter{"No event", []common.Hash{}, []common.Address{a1}, 0}, nil)
 	require.Error(t, err)
 	validateFiltersTable(t, lp, orm)
 
@@ -468,7 +478,7 @@ func benchmarkFilter(b *testing.B, nFilters, nAddresses, nEvents int) {
 		for j := 0; j < nEvents; j++ {
 			events = append(events, common.BigToHash(big.NewInt(int64(j+1))))
 		}
-		err := lp.RegisterFilter(Filter{Name: "my Filter", EventSigs: events, Addresses: addresses})
+		err := lp.RegisterFilter(Filter{Name: "my Filter", EventSigs: events, Addresses: addresses}, nil)
 		require.NoError(b, err)
 	}
 	b.ResetTimer()

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -117,7 +117,7 @@ func TestLogPoller_Integration(t *testing.T) {
 	th := SetupTH(t, 2, 3, 2)
 	th.Client.Commit() // Block 2. Ensure we have finality number of blocks
 
-	err := th.LogPoller.RegisterFilter(logpoller.Filter{"Integration test", []common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{th.EmitterAddress1}, 0}, nil)
+	err := th.LogPoller.RegisterFilter(logpoller.Filter{"Integration test", []common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{th.EmitterAddress1}, 0})
 	require.NoError(t, err)
 	require.Len(t, th.LogPoller.Filter(nil, nil, nil).Addresses, 1)
 	require.Len(t, th.LogPoller.Filter(nil, nil, nil).Topics, 1)
@@ -158,7 +158,7 @@ func TestLogPoller_Integration(t *testing.T) {
 	err = th.LogPoller.RegisterFilter(logpoller.Filter{
 		"Emitter - log2", []common.Hash{EmitterABI.Events["Log2"].ID},
 		[]common.Address{th.EmitterAddress1}, 0,
-	}, nil)
+	})
 	require.NoError(t, err)
 	// Replay an invalid block should error
 	assert.Error(t, th.LogPoller.Replay(testutils.Context(t), 0))
@@ -208,7 +208,7 @@ func Test_BackupLogPoller(t *testing.T) {
 		EmitterABI.Events["Log2"].ID},
 		[]common.Address{th.EmitterAddress1},
 		0}
-	err := th.LogPoller.RegisterFilter(filter1, nil)
+	err := th.LogPoller.RegisterFilter(filter1)
 	require.NoError(t, err)
 
 	filters, err := th.ORM.LoadFilters(pg.WithParentCtx(testutils.Context(t)))
@@ -219,7 +219,7 @@ func Test_BackupLogPoller(t *testing.T) {
 	err = th.LogPoller.RegisterFilter(
 		logpoller.Filter{"filter2",
 			[]common.Hash{EmitterABI.Events["Log1"].ID},
-			[]common.Address{th.EmitterAddress2}, 0}, nil)
+			[]common.Address{th.EmitterAddress2}, 0})
 	require.NoError(t, err)
 
 	defer func() {
@@ -337,7 +337,7 @@ func TestLogPoller_BlockTimestamps(t *testing.T) {
 	addresses := []common.Address{th.EmitterAddress1, th.EmitterAddress2}
 	topics := []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}
 
-	err := th.LogPoller.RegisterFilter(logpoller.Filter{"convertLogs", topics, addresses, 0}, nil)
+	err := th.LogPoller.RegisterFilter(logpoller.Filter{"convertLogs", topics, addresses, 0})
 	require.NoError(t, err)
 
 	blk, err := th.Client.BlockByNumber(ctx, nil)
@@ -510,7 +510,7 @@ func TestLogPoller_PollAndSaveLogs(t *testing.T) {
 	err := th.LogPoller.RegisterFilter(logpoller.Filter{
 		"Test Emitter 1 & 2", []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID},
 		[]common.Address{th.EmitterAddress1, th.EmitterAddress2}, 0,
-	}, nil)
+	})
 	require.NoError(t, err)
 
 	b, err := th.Client.BlockByNumber(testutils.Context(t), nil)
@@ -734,11 +734,11 @@ func TestLogPoller_LoadFilters(t *testing.T) {
 	assert.False(t, filter2.Contains(&filter1))
 	assert.True(t, filter1.Contains(&filter3))
 
-	err := th.LogPoller.RegisterFilter(filter1, nil)
+	err := th.LogPoller.RegisterFilter(filter1)
 	require.NoError(t, err)
-	err = th.LogPoller.RegisterFilter(filter2, nil)
+	err = th.LogPoller.RegisterFilter(filter2)
 	require.NoError(t, err)
-	err = th.LogPoller.RegisterFilter(filter3, nil)
+	err = th.LogPoller.RegisterFilter(filter3)
 	require.NoError(t, err)
 
 	filters, err := th.ORM.LoadFilters()
@@ -775,7 +775,7 @@ func TestLogPoller_GetBlocks_Range(t *testing.T) {
 
 	err := th.LogPoller.RegisterFilter(logpoller.Filter{"GetBlocks Test", []common.Hash{
 		EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{th.EmitterAddress1, th.EmitterAddress2}, 0,
-	}, nil)
+	})
 	require.NoError(t, err)
 
 	// LP retrieves 0 blocks

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -117,7 +117,7 @@ func TestLogPoller_Integration(t *testing.T) {
 	th := SetupTH(t, 2, 3, 2)
 	th.Client.Commit() // Block 2. Ensure we have finality number of blocks
 
-	err := th.LogPoller.RegisterFilter(logpoller.Filter{"Integration test", []common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{th.EmitterAddress1}, 0})
+	err := th.LogPoller.RegisterFilter(logpoller.Filter{"Integration test", []common.Hash{EmitterABI.Events["Log1"].ID}, []common.Address{th.EmitterAddress1}, 0}, nil)
 	require.NoError(t, err)
 	require.Len(t, th.LogPoller.Filter(nil, nil, nil).Addresses, 1)
 	require.Len(t, th.LogPoller.Filter(nil, nil, nil).Topics, 1)
@@ -158,7 +158,7 @@ func TestLogPoller_Integration(t *testing.T) {
 	err = th.LogPoller.RegisterFilter(logpoller.Filter{
 		"Emitter - log2", []common.Hash{EmitterABI.Events["Log2"].ID},
 		[]common.Address{th.EmitterAddress1}, 0,
-	})
+	}, nil)
 	require.NoError(t, err)
 	// Replay an invalid block should error
 	assert.Error(t, th.LogPoller.Replay(testutils.Context(t), 0))
@@ -208,7 +208,7 @@ func Test_BackupLogPoller(t *testing.T) {
 		EmitterABI.Events["Log2"].ID},
 		[]common.Address{th.EmitterAddress1},
 		0}
-	err := th.LogPoller.RegisterFilter(filter1)
+	err := th.LogPoller.RegisterFilter(filter1, nil)
 	require.NoError(t, err)
 
 	filters, err := th.ORM.LoadFilters(pg.WithParentCtx(testutils.Context(t)))
@@ -219,7 +219,7 @@ func Test_BackupLogPoller(t *testing.T) {
 	err = th.LogPoller.RegisterFilter(
 		logpoller.Filter{"filter2",
 			[]common.Hash{EmitterABI.Events["Log1"].ID},
-			[]common.Address{th.EmitterAddress2}, 0})
+			[]common.Address{th.EmitterAddress2}, 0}, nil)
 	require.NoError(t, err)
 
 	defer func() {
@@ -337,7 +337,7 @@ func TestLogPoller_BlockTimestamps(t *testing.T) {
 	addresses := []common.Address{th.EmitterAddress1, th.EmitterAddress2}
 	topics := []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}
 
-	err := th.LogPoller.RegisterFilter(logpoller.Filter{"convertLogs", topics, addresses, 0})
+	err := th.LogPoller.RegisterFilter(logpoller.Filter{"convertLogs", topics, addresses, 0}, nil)
 	require.NoError(t, err)
 
 	blk, err := th.Client.BlockByNumber(ctx, nil)
@@ -510,7 +510,7 @@ func TestLogPoller_PollAndSaveLogs(t *testing.T) {
 	err := th.LogPoller.RegisterFilter(logpoller.Filter{
 		"Test Emitter 1 & 2", []common.Hash{EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID},
 		[]common.Address{th.EmitterAddress1, th.EmitterAddress2}, 0,
-	})
+	}, nil)
 	require.NoError(t, err)
 
 	b, err := th.Client.BlockByNumber(testutils.Context(t), nil)
@@ -734,11 +734,11 @@ func TestLogPoller_LoadFilters(t *testing.T) {
 	assert.False(t, filter2.Contains(&filter1))
 	assert.True(t, filter1.Contains(&filter3))
 
-	err := th.LogPoller.RegisterFilter(filter1)
+	err := th.LogPoller.RegisterFilter(filter1, nil)
 	require.NoError(t, err)
-	err = th.LogPoller.RegisterFilter(filter2)
+	err = th.LogPoller.RegisterFilter(filter2, nil)
 	require.NoError(t, err)
-	err = th.LogPoller.RegisterFilter(filter3)
+	err = th.LogPoller.RegisterFilter(filter3, nil)
 	require.NoError(t, err)
 
 	filters, err := th.ORM.LoadFilters()
@@ -774,8 +774,8 @@ func TestLogPoller_GetBlocks_Range(t *testing.T) {
 	th := SetupTH(t, 2, 3, 2)
 
 	err := th.LogPoller.RegisterFilter(logpoller.Filter{"GetBlocks Test", []common.Hash{
-		EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{th.EmitterAddress1, th.EmitterAddress2}, 0},
-	)
+		EmitterABI.Events["Log1"].ID, EmitterABI.Events["Log2"].ID}, []common.Address{th.EmitterAddress1, th.EmitterAddress2}, 0,
+	}, nil)
 	require.NoError(t, err)
 
 	// LP retrieves 0 blocks

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -45,6 +45,7 @@ func (o *ORM) InsertBlock(h common.Hash, n int64, t time.Time, qopts ...pg.QOpt)
 // If a second job tries to overwrite the same pair, this should fail.
 func (o *ORM) InsertFilter(filter Filter, qopts ...pg.QOpt) (err error) {
 	q := o.q.WithOpts(qopts...)
+
 	addresses := make([][]byte, 0)
 	events := make([][]byte, 0)
 

--- a/core/services/blockhashstore/coordinators.go
+++ b/core/services/blockhashstore/coordinators.go
@@ -70,15 +70,19 @@ type V1Coordinator struct {
 	lp logpoller.LogPoller
 }
 
-// NewV1Coordinator creates a new V1Coordinator from the given contract.
-func NewV1Coordinator(c v1.VRFCoordinatorInterface, lp logpoller.LogPoller) (*V1Coordinator, error) {
-	err := lp.RegisterFilter(logpoller.Filter{
-		Name: logpoller.FilterName("VRFv1CoordinatorFeeder", c.Address()),
+func NewV1LogFilter(addr common.Address) logpoller.Filter {
+	return logpoller.Filter{
+		Name: logpoller.FilterName("VRFv1CoordinatorFeeder", addr),
 		EventSigs: []common.Hash{
 			v1.VRFCoordinatorRandomnessRequest{}.Topic(),
 			v1.VRFCoordinatorRandomnessRequestFulfilled{}.Topic(),
-		}, Addresses: []common.Address{c.Address()},
-	})
+		}, Addresses: []common.Address{addr},
+	}
+}
+
+// NewV1Coordinator creates a new V1Coordinator from the given contract.
+func NewV1Coordinator(c v1.VRFCoordinatorInterface, lp logpoller.LogPoller) (*V1Coordinator, error) {
+	err := lp.RegisterFilter(NewV1LogFilter(c.Address()), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -159,19 +163,19 @@ type V2Coordinator struct {
 	lp logpoller.LogPoller
 }
 
-// NewV2Coordinator creates a new V2Coordinator from the given contract.
-func NewV2Coordinator(c v2.VRFCoordinatorV2Interface, lp logpoller.LogPoller) (*V2Coordinator, error) {
-	err := lp.RegisterFilter(logpoller.Filter{
-		Name: logpoller.FilterName("VRFv2CoordinatorFeeder", c.Address()),
+func NewV2LogFilter(addr common.Address) logpoller.Filter {
+	return logpoller.Filter{
+		Name: logpoller.FilterName("VRFv2CoordinatorFeeder", addr),
 		EventSigs: []common.Hash{
 			v2.VRFCoordinatorV2RandomWordsRequested{}.Topic(),
 			v2.VRFCoordinatorV2RandomWordsFulfilled{}.Topic(),
-		}, Addresses: []common.Address{c.Address()},
-	})
-
-	if err != nil {
-		return nil, err
+		}, Addresses: []common.Address{addr},
 	}
+}
+
+// NewV2Coordinator creates a new V2Coordinator from the given contract.
+func NewV2Coordinator(c v2.VRFCoordinatorV2Interface, lp logpoller.LogPoller) (*V2Coordinator, error) {
+	err := lp.RegisterFilter(NewV2LogFilter(c.Address()), nil)
 
 	return &V2Coordinator{c, lp}, err
 }

--- a/core/services/blockhashstore/delegate.go
+++ b/core/services/blockhashstore/delegate.go
@@ -68,8 +68,8 @@ func (d *Delegate) getChainFromSpec(jb job.Job, qopts ...pg.QOpt) (evm.Chain, er
 }
 
 // ServicesForSpec satisfies the job.Delegate interface.
-func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
-	chain, err := d.getChainFromSpec(jb)
+func (d *Delegate) ServicesForSpec(jb job.Job, qopts ...pg.QOpt) ([]job.ServiceCtx, error) {
+	chain, err := d.getChainFromSpec(jb, qopts...)
 	if err != nil {
 		return nil, err
 	}
@@ -201,7 +201,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 // AfterJobCreated satisfies the job.Delegate interface.
 func (d *Delegate) AfterJobCreated(spec job.Job) {}
 
-func (d *Delegate) OnCreateJob(jb job.Job, opts pg.QOpt) error {
+func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error {
 	chain, err := d.getChainFromSpec(jb)
 	if err != nil {
 		d.logger.Error(err)
@@ -211,14 +211,14 @@ func (d *Delegate) OnCreateJob(jb job.Job, opts pg.QOpt) error {
 	lp := chain.LogPoller()
 	if jb.BlockhashStoreSpec.CoordinatorV1Address == nil {
 		filter := NewV1LogFilter(jb.BlockhashStoreSpec.CoordinatorV1Address.Address())
-		lp.RegisterFilter(filter, opts)
+		lp.RegisterFilter(filter, pg.WithQueryer(q))
 		if err != nil {
 			return errors.Wrapf(err, "Failed to register filter %v", filter)
 		}
 	}
 	if jb.BlockhashStoreSpec.CoordinatorV2Address == nil {
 		filter := NewV2LogFilter(jb.BlockhashStoreSpec.CoordinatorV2Address.Address())
-		lp.RegisterFilter(filter, opts)
+		lp.RegisterFilter(filter, pg.WithQueryer(q))
 		if err != nil {
 			return errors.Wrapf(err, "Failed to register filter %v", filter)
 		}
@@ -234,7 +234,7 @@ func (d *Delegate) BeforeJobCreated(spec job.Job) {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job) {}
 
 // OnDeleteJob satisfies the job.Delegate interface.
-func (d *Delegate) OnDeleteJob(jb job.Job, opts pg.QOpt) error {
+func (d *Delegate) OnDeleteJob(jb job.Job, q pg.Queryer) error {
 	chain, err := d.getChainFromSpec(jb)
 	if err != nil {
 		d.logger.Error(err)
@@ -244,14 +244,14 @@ func (d *Delegate) OnDeleteJob(jb job.Job, opts pg.QOpt) error {
 	lp := chain.LogPoller()
 	if jb.BlockhashStoreSpec.CoordinatorV1Address == nil {
 		filter := NewV1LogFilter(jb.BlockhashStoreSpec.CoordinatorV1Address.Address())
-		err = lp.UnregisterFilter(filter.Name, opts)
+		err = lp.UnregisterFilter(filter.Name, pg.WithQueryer(q))
 		if err != nil {
 			return errors.Wrapf(err, "Failed to unregister filter %s", filter.Name)
 		}
 	}
 	if jb.BlockhashStoreSpec.CoordinatorV2Address == nil {
 		filter := NewV2LogFilter(jb.BlockhashStoreSpec.CoordinatorV2Address.Address())
-		err = lp.UnregisterFilter(filter.Name, opts)
+		err = lp.UnregisterFilter(filter.Name, pg.WithQueryer(q))
 		if err != nil {
 			return errors.Wrapf(err, "Failed to unregister filter %s", filter.Name)
 		}

--- a/core/services/blockhashstore/delegate.go
+++ b/core/services/blockhashstore/delegate.go
@@ -201,7 +201,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 // AfterJobCreated satisfies the job.Delegate interface.
 func (d *Delegate) AfterJobCreated(spec job.Job) {}
 
-func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error {
+func (d *Delegate) OnCreateJob(jb job.Job, opts pg.QOpt) error {
 	chain, err := d.getChainFromSpec(jb)
 	if err != nil {
 		d.logger.Error(err)
@@ -211,14 +211,14 @@ func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error {
 	lp := chain.LogPoller()
 	if jb.BlockhashStoreSpec.CoordinatorV1Address == nil {
 		filter := NewV1LogFilter(jb.BlockhashStoreSpec.CoordinatorV1Address.Address())
-		lp.RegisterFilter(filter, q)
+		lp.RegisterFilter(filter, opts)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to register filter %v", filter)
 		}
 	}
 	if jb.BlockhashStoreSpec.CoordinatorV2Address == nil {
 		filter := NewV2LogFilter(jb.BlockhashStoreSpec.CoordinatorV2Address.Address())
-		lp.RegisterFilter(filter, q)
+		lp.RegisterFilter(filter, opts)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to register filter %v", filter)
 		}
@@ -234,7 +234,7 @@ func (d *Delegate) BeforeJobCreated(spec job.Job) {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job) {}
 
 // OnDeleteJob satisfies the job.Delegate interface.
-func (d *Delegate) OnDeleteJob(jb job.Job, q pg.Queryer) error {
+func (d *Delegate) OnDeleteJob(jb job.Job, opts pg.QOpt) error {
 	chain, err := d.getChainFromSpec(jb)
 	if err != nil {
 		d.logger.Error(err)
@@ -244,14 +244,14 @@ func (d *Delegate) OnDeleteJob(jb job.Job, q pg.Queryer) error {
 	lp := chain.LogPoller()
 	if jb.BlockhashStoreSpec.CoordinatorV1Address == nil {
 		filter := NewV1LogFilter(jb.BlockhashStoreSpec.CoordinatorV1Address.Address())
-		err = lp.UnregisterFilter(filter.Name, q)
+		err = lp.UnregisterFilter(filter.Name, opts)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to unregister filter %s", filter.Name)
 		}
 	}
 	if jb.BlockhashStoreSpec.CoordinatorV2Address == nil {
 		filter := NewV2LogFilter(jb.BlockhashStoreSpec.CoordinatorV2Address.Address())
-		err = lp.UnregisterFilter(filter.Name, q)
+		err = lp.UnregisterFilter(filter.Name, opts)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to unregister filter %s", filter.Name)
 		}

--- a/core/services/blockheaderfeeder/delegate.go
+++ b/core/services/blockheaderfeeder/delegate.go
@@ -210,7 +210,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 // AfterJobCreated satisfies the job.Delegate interface.
 func (d *Delegate) AfterJobCreated(spec job.Job) {}
 
-func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error {
+func (d *Delegate) OnCreateJob(jb job.Job, opts pg.QOpt) error {
 	chain, err := d.getChainFromSpec(jb)
 	if err != nil {
 		d.logger.Error(err)
@@ -220,14 +220,14 @@ func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error {
 	lp := chain.LogPoller()
 	if jb.BlockHeaderFeederSpec.CoordinatorV1Address == nil {
 		filter := blockhashstore.NewV1LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV1Address.Address())
-		lp.RegisterFilter(filter, q)
+		lp.RegisterFilter(filter, opts)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to register filter %v", filter)
 		}
 	}
 	if jb.BlockHeaderFeederSpec.CoordinatorV2Address == nil {
 		filter := blockhashstore.NewV2LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV2Address.Address())
-		lp.RegisterFilter(filter, q)
+		lp.RegisterFilter(filter, opts)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to register filter %v", filter)
 		}
@@ -241,7 +241,7 @@ func (d *Delegate) BeforeJobCreated(spec job.Job) {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job) {}
 
 // OnDeleteJob satisfies the job.Delegate interface.
-func (d *Delegate) OnDeleteJob(jb job.Job, q pg.Queryer) error {
+func (d *Delegate) OnDeleteJob(jb job.Job, opts pg.QOpt) error {
 	chain, err := d.getChainFromSpec(jb)
 	if err != nil {
 		d.logger.Error(err)
@@ -251,14 +251,14 @@ func (d *Delegate) OnDeleteJob(jb job.Job, q pg.Queryer) error {
 	lp := chain.LogPoller()
 	if jb.BlockHeaderFeederSpec.CoordinatorV1Address == nil {
 		filter := blockhashstore.NewV1LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV1Address.Address())
-		err = lp.UnregisterFilter(filter.Name, q)
+		err = lp.UnregisterFilter(filter.Name, opts)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to unregister filter %s", filter.Name)
 		}
 	}
 	if jb.BlockHeaderFeederSpec.CoordinatorV2Address == nil {
 		filter := blockhashstore.NewV2LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV2Address.Address())
-		err = lp.UnregisterFilter(filter.Name, q)
+		err = lp.UnregisterFilter(filter.Name, opts)
 		if err != nil {
 			return errors.Wrapf(err, "Failed to unregister filter %s", filter.Name)
 		}

--- a/core/services/blockheaderfeeder/delegate.go
+++ b/core/services/blockheaderfeeder/delegate.go
@@ -66,7 +66,7 @@ func (d *Delegate) getChainFromSpec(jb job.Job) (evm.Chain, error) {
 }
 
 // ServicesForSpec satisfies the job.Delegate interface.
-func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
+func (d *Delegate) ServicesForSpec(jb job.Job, opts ...pg.QOpt) ([]job.ServiceCtx, error) {
 	chain, err := d.getChainFromSpec(jb)
 	if err != nil {
 		return nil, err
@@ -210,7 +210,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 // AfterJobCreated satisfies the job.Delegate interface.
 func (d *Delegate) AfterJobCreated(spec job.Job) {}
 
-func (d *Delegate) OnCreateJob(jb job.Job, opts pg.QOpt) error {
+func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error {
 	chain, err := d.getChainFromSpec(jb)
 	if err != nil {
 		d.logger.Error(err)
@@ -220,14 +220,14 @@ func (d *Delegate) OnCreateJob(jb job.Job, opts pg.QOpt) error {
 	lp := chain.LogPoller()
 	if jb.BlockHeaderFeederSpec.CoordinatorV1Address == nil {
 		filter := blockhashstore.NewV1LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV1Address.Address())
-		lp.RegisterFilter(filter, opts)
+		lp.RegisterFilter(filter, pg.WithQueryer(q))
 		if err != nil {
 			return errors.Wrapf(err, "Failed to register filter %v", filter)
 		}
 	}
 	if jb.BlockHeaderFeederSpec.CoordinatorV2Address == nil {
 		filter := blockhashstore.NewV2LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV2Address.Address())
-		lp.RegisterFilter(filter, opts)
+		lp.RegisterFilter(filter, pg.WithQueryer(q))
 		if err != nil {
 			return errors.Wrapf(err, "Failed to register filter %v", filter)
 		}
@@ -241,7 +241,7 @@ func (d *Delegate) BeforeJobCreated(spec job.Job) {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job) {}
 
 // OnDeleteJob satisfies the job.Delegate interface.
-func (d *Delegate) OnDeleteJob(jb job.Job, opts pg.QOpt) error {
+func (d *Delegate) OnDeleteJob(jb job.Job, q pg.Queryer) error {
 	chain, err := d.getChainFromSpec(jb)
 	if err != nil {
 		d.logger.Error(err)
@@ -251,14 +251,14 @@ func (d *Delegate) OnDeleteJob(jb job.Job, opts pg.QOpt) error {
 	lp := chain.LogPoller()
 	if jb.BlockHeaderFeederSpec.CoordinatorV1Address == nil {
 		filter := blockhashstore.NewV1LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV1Address.Address())
-		err = lp.UnregisterFilter(filter.Name, opts)
+		err = lp.UnregisterFilter(filter.Name, pg.WithQueryer(q))
 		if err != nil {
 			return errors.Wrapf(err, "Failed to unregister filter %s", filter.Name)
 		}
 	}
 	if jb.BlockHeaderFeederSpec.CoordinatorV2Address == nil {
 		filter := blockhashstore.NewV2LogFilter(jb.BlockHeaderFeederSpec.CoordinatorV2Address.Address())
-		err = lp.UnregisterFilter(filter.Name, opts)
+		err = lp.UnregisterFilter(filter.Name, pg.WithQueryer(q))
 		if err != nil {
 			return errors.Wrapf(err, "Failed to unregister filter %s", filter.Name)
 		}

--- a/core/services/cron/delegate.go
+++ b/core/services/cron/delegate.go
@@ -29,6 +29,7 @@ func (d *Delegate) JobType() job.Type {
 
 func (d *Delegate) BeforeJobCreated(spec job.Job)                {}
 func (d *Delegate) AfterJobCreated(spec job.Job)                 {}
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error { return nil }
 func (d *Delegate) BeforeJobDeleted(spec job.Job)                {}
 func (d *Delegate) OnDeleteJob(spec job.Job, q pg.Queryer) error { return nil }
 

--- a/core/services/directrequest/delegate.go
+++ b/core/services/directrequest/delegate.go
@@ -63,6 +63,7 @@ func (d *Delegate) JobType() job.Type {
 }
 
 func (d *Delegate) BeforeJobCreated(spec job.Job)                {}
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error { return nil }
 func (d *Delegate) AfterJobCreated(spec job.Job)                 {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job)                {}
 func (d *Delegate) OnDeleteJob(spec job.Job, q pg.Queryer) error { return nil }

--- a/core/services/fluxmonitorv2/delegate.go
+++ b/core/services/fluxmonitorv2/delegate.go
@@ -54,6 +54,7 @@ func (d *Delegate) JobType() job.Type {
 }
 
 func (d *Delegate) BeforeJobCreated(spec job.Job)                {}
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error { return nil }
 func (d *Delegate) AfterJobCreated(spec job.Job)                 {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job)                {}
 func (d *Delegate) OnDeleteJob(spec job.Job, q pg.Queryer) error { return nil }

--- a/core/services/gateway/delegate.go
+++ b/core/services/gateway/delegate.go
@@ -33,6 +33,7 @@ func (d *Delegate) JobType() job.Type {
 
 func (d *Delegate) BeforeJobCreated(spec job.Job)                {}
 func (d *Delegate) AfterJobCreated(spec job.Job)                 {}
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error { return nil }
 func (d *Delegate) BeforeJobDeleted(spec job.Job)                {}
 func (d *Delegate) OnDeleteJob(spec job.Job, q pg.Queryer) error { return nil }
 

--- a/core/services/job/spawner.go
+++ b/core/services/job/spawner.go
@@ -58,6 +58,8 @@ type (
 		JobType() Type
 		// BeforeJobCreated is only called once on first time job create.
 		BeforeJobCreated(spec Job)
+		// OnCreateJob is called from within the CREATE db transaction.
+		OnCreateJob(spec Job, q pg.Queryer) error
 		// ServicesForSpec returns services to be started and stopped for this
 		// job. In case a given job type relies upon well-defined startup/shutdown
 		// ordering for services, they are started in the order they are given
@@ -242,10 +244,21 @@ func (js *spawner) CreateJob(jb *Job, qopts ...pg.QOpt) (err error) {
 	ctx, cancel := q.Context()
 	defer cancel()
 
-	err = js.orm.CreateJob(jb, pg.WithQueryer(q.Queryer), pg.WithParentCtx(ctx))
+	err = q.Transaction(func(tx pg.Queryer) error {
+		err = js.orm.CreateJob(jb, pg.WithQueryer(q.Queryer), pg.WithParentCtx(ctx))
+		if err != nil {
+			js.lggr.Errorw("Error creating job", "type", jb.Type, "error", err)
+			return err
+		}
+
+		js.lggr.Debugw("Callback: OnCreateJob")
+		err = delegate.OnCreateJob(*jb, tx)
+		js.lggr.Debugw("Callback: OnCreateJob done")
+		return err
+	})
 	if err != nil {
 		js.lggr.Errorw("Error creating job", "type", jb.Type, "err", err)
-		return
+		return err
 	}
 	js.lggr.Infow("Created job", "type", jb.Type, "jobID", jb.ID)
 
@@ -373,6 +386,7 @@ func (n *NullDelegate) ServicesForSpec(spec Job, qopts ...pg.QOpt) (s []ServiceC
 }
 
 func (n *NullDelegate) BeforeJobCreated(spec Job)                {}
+func (n *NullDelegate) OnCreateJob(spec Job, q pg.Queryer) error { return nil }
 func (n *NullDelegate) AfterJobCreated(spec Job)                 {}
 func (n *NullDelegate) BeforeJobDeleted(spec Job)                {}
 func (n *NullDelegate) OnDeleteJob(spec Job, q pg.Queryer) error { return nil }

--- a/core/services/keeper/delegate.go
+++ b/core/services/keeper/delegate.go
@@ -49,6 +49,7 @@ func (d *Delegate) JobType() job.Type {
 }
 
 func (d *Delegate) BeforeJobCreated(spec job.Job)                {}
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error { return nil }
 func (d *Delegate) AfterJobCreated(spec job.Job)                 {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job)                {}
 func (d *Delegate) OnDeleteJob(spec job.Job, q pg.Queryer) error { return nil }

--- a/core/services/ocr/delegate.go
+++ b/core/services/ocr/delegate.go
@@ -82,6 +82,7 @@ func (d *Delegate) JobType() job.Type {
 }
 
 func (d *Delegate) BeforeJobCreated(spec job.Job)                {}
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error { return nil }
 func (d *Delegate) AfterJobCreated(spec job.Job)                 {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job)                {}
 func (d *Delegate) OnDeleteJob(spec job.Job, q pg.Queryer) error { return nil }

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -290,7 +290,7 @@ func (d *Delegate) filtersFromSpec(spec *job.OCR2OracleSpec, extJobID uuid.UUID)
 	return filters
 }
 
-func (d *Delegate) OnCreateJob(jb job.Job, opts pg.QOpt) error {
+func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error {
 	spec := jb.OCR2OracleSpec
 	if spec == nil {
 		d.lggr.Error(ErrNonOCR2JobType{jb})
@@ -311,7 +311,7 @@ func (d *Delegate) OnCreateJob(jb job.Job, opts pg.QOpt) error {
 
 	for _, filter := range filters {
 		d.lggr.Debugf("Registering new filter %s", filter)
-		if err := lp.RegisterFilter(filter, opts); err != nil {
+		if err := lp.RegisterFilter(filter, pg.WithQueryer(q)); err != nil {
 			return errors.Wrapf(err, "Failed to register filter %s", filter)
 		}
 	}

--- a/core/services/ocr2/plugins/ocr2keeper/evm20/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm20/registry.go
@@ -381,18 +381,12 @@ func (r *EvmRegistry) pollLogs() error {
 	return nil
 }
 
-func UpkeepFilterName(addr common.Address) string {
-	return logpoller.FilterName("EvmRegistry - Upkeep events for", addr.String())
-}
-
-func (r *EvmRegistry) registerEvents(chainID uint64, addr common.Address) error {
-	// Add log filters for the log poller so that it can poll and find the logs that
-	// we need
-	return r.poller.RegisterFilter(logpoller.Filter{
-		Name:      UpkeepFilterName(addr),
+func UpkeepFilter(addr common.Address) (filters logpoller.Filter) {
+	return logpoller.Filter{
+		Name:      logpoller.FilterName("EvmRegistry - Upkeep events for", addr.String()),
 		EventSigs: append(upkeepStateEvents, upkeepActiveEvents...),
 		Addresses: []common.Address{addr},
-	})
+	}
 }
 
 func (r *EvmRegistry) processUpkeepStateLog(l logpoller.Log) error {

--- a/core/services/ocr2/plugins/ocr2keeper/evm20/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm20/registry.go
@@ -108,6 +108,12 @@ func NewEVMRegistryService(addr common.Address, client evm.Chain, lggr logger.Lo
 	return r, nil
 }
 
+func (r *EvmRegistry) registerEvents(chainID uint64, addr common.Address) error {
+	// Add log filters for the log poller so that it can poll and find the logs that
+	// we need
+	return r.poller.RegisterFilter(UpkeepFilter(addr))
+}
+
 var upkeepStateEvents = []common.Hash{
 	keeper_registry_wrapper2_0.KeeperRegistryUpkeepRegistered{}.Topic(),  // adds new upkeep id to registry
 	keeper_registry_wrapper2_0.KeeperRegistryUpkeepReceived{}.Topic(),    // adds new upkeep id to registry via migration

--- a/core/services/ocr2/plugins/ocr2keeper/util.go
+++ b/core/services/ocr2/plugins/ocr2keeper/util.go
@@ -15,6 +15,7 @@ import (
 	ocr2keepers21 "github.com/smartcontractkit/ocr2keepers/pkg/v3/types"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/job"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
@@ -99,12 +100,12 @@ func EVMDependencies20(
 	return keeperProvider, registry, encoder, logProvider, err
 }
 
-func FilterNamesFromSpec20(spec *job.OCR2OracleSpec) (names []string, err error) {
+func FiltersFromSpec20(spec *job.OCR2OracleSpec) (filters []logpoller.Filter, err error) {
 	addr, err := ethkey.NewEIP55Address(spec.ContractID)
 	if err != nil {
 		return nil, err
 	}
-	return []string{kevm20.LogProviderFilterName(addr.Address()), kevm20.UpkeepFilterName(addr.Address())}, err
+	return []logpoller.Filter{kevm20.LogProviderFilter(addr.Address()), kevm20.UpkeepFilter(addr.Address())}, err
 }
 
 func EVMDependencies21(

--- a/core/services/ocrbootstrap/delegate.go
+++ b/core/services/ocrbootstrap/delegate.go
@@ -178,6 +178,11 @@ func (d *Delegate) ServicesForSpec(jobSpec job.Job, qopts ...pg.QOpt) (services 
 	return []job.ServiceCtx{configProvider, job.NewServiceAdapter(bootstrapper)}, nil
 }
 
+// OnCreateJob satisfies the job.Delegate interface.
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error {
+	return nil
+}
+
 // AfterJobCreated satisfies the job.Delegate interface.
 func (d *Delegate) AfterJobCreated(spec job.Job) {
 }

--- a/core/services/relay/evm/config_poller.go
+++ b/core/services/relay/evm/config_poller.go
@@ -77,19 +77,24 @@ type configPoller struct {
 	addr               common.Address
 }
 
-func configPollerFilterName(addr common.Address) string {
-	return logpoller.FilterName("OCR2ConfigPoller", addr.String())
+func NewConfigPollerFilter(addr common.Address) logpoller.Filter {
+	return logpoller.Filter{
+		Name:      logpoller.FilterName("OCR2ConfigPoller", addr.String()),
+		EventSigs: []common.Hash{ConfigSet},
+		Addresses: []common.Address{addr},
+	}
 }
 
+// NewConfigPoller creates a new ConfigPoller
 func NewConfigPoller(lggr logger.Logger, destChainPoller logpoller.LogPoller, addr common.Address) (evmRelayTypes.ConfigPoller, error) {
-	err := destChainPoller.RegisterFilter(logpoller.Filter{Name: configPollerFilterName(addr), EventSigs: []common.Hash{ConfigSet}, Addresses: []common.Address{addr}})
-	if err != nil {
+	filter := NewConfigPollerFilter(addr)
+	if err := destChainPoller.RegisterFilter(filter, nil); err != nil {
 		return nil, err
 	}
 
 	cp := &configPoller{
 		lggr:               lggr,
-		filterName:         configPollerFilterName(addr),
+		filterName:         filter.Name,
 		destChainLogPoller: destChainPoller,
 		addr:               addr,
 	}

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -195,7 +195,7 @@ func FiltersFromRelayArgs(args relaytypes.RelayArgs) (filters []logpoller.Filter
 	}
 
 	if relayConfig.FeedID != nil {
-		filters = []logpoller.Filter{mercury.NewConfigPollerFilter(addr.Address())}
+		filters = []logpoller.Filter{mercury.NewConfigPollerFilter(addr.Address(), *relayConfig.FeedID)}
 	} else {
 		var transmitterFilter logpoller.Filter
 		transmitterFilter, err = newTransmitterFilter(addr.Address())

--- a/core/services/relay/evm/mercury/config_poller.go
+++ b/core/services/relay/evm/mercury/config_poller.go
@@ -95,26 +95,22 @@ type ConfigPoller struct {
 	subscription       pg.Subscription
 }
 
-func FilterName(addr common.Address, feedID common.Hash) string {
-	return logpoller.FilterName("OCR3 Mercury ConfigPoller", addr.String(), feedID.Hex())
-}
-
-func NewConfigPollerFilter(addr common.Address) logpoller.Filter {
+func NewConfigPollerFilter(addr common.Address, feedId common.Hash) logpoller.Filter {
 	return logpoller.Filter{
-		Name:      logpoller.FilterName("OCR3 Mercury ConfigPoller", addr.String(), feedID.HEX()),
+		Name:      logpoller.FilterName("OCR3 Mercury ConfigPoller", addr.String(), feedId.Hex()),
 		EventSigs: []common.Hash{FeedScopedConfigSet},
 		Addresses: []common.Address{addr},
 	}
 }
 
 // NewConfigPoller creates a new Mercury ConfigPoller
-func NewConfigPoller(lggr logger.Logger, destChainPoller logpoller.LogPoller, addr common.Address, feedId common.Hash) (*ConfigPoller, error) {
-	err := destChainPoller.RegisterFilter(NewConfigPollerFilter(addr), nil)
+func NewConfigPoller(lggr logger.Logger, destChainPoller logpoller.LogPoller, addr common.Address, feedId common.Hash, eventBroadcaster pg.EventBroadcaster) (*ConfigPoller, error) {
+	err := destChainPoller.RegisterFilter(NewConfigPollerFilter(addr, feedId), nil)
 
 	if err != nil {
 		return nil, err
 	}
-	subscription, err = eventBroadcaster.Subscribe(pg.ChannelInsertOnEVMLogs, "")
+	subscription, err := eventBroadcaster.Subscribe(pg.ChannelInsertOnEVMLogs, "")
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/relay/evm/mercury/config_poller.go
+++ b/core/services/relay/evm/mercury/config_poller.go
@@ -99,14 +99,22 @@ func FilterName(addr common.Address, feedID common.Hash) string {
 	return logpoller.FilterName("OCR3 Mercury ConfigPoller", addr.String(), feedID.Hex())
 }
 
+func NewConfigPollerFilter(addr common.Address) logpoller.Filter {
+	return logpoller.Filter{
+		Name:      logpoller.FilterName("OCR3 Mercury ConfigPoller", addr.String(), feedID.HEX()),
+		EventSigs: []common.Hash{FeedScopedConfigSet},
+		Addresses: []common.Address{addr},
+	}
+}
+
 // NewConfigPoller creates a new Mercury ConfigPoller
-func NewConfigPoller(lggr logger.Logger, destChainPoller logpoller.LogPoller, addr common.Address, feedId common.Hash, eventBroadcaster pg.EventBroadcaster) (*ConfigPoller, error) {
-	err := destChainPoller.RegisterFilter(logpoller.Filter{Name: FilterName(addr, feedId), EventSigs: []common.Hash{FeedScopedConfigSet}, Addresses: []common.Address{addr}})
+func NewConfigPoller(lggr logger.Logger, destChainPoller logpoller.LogPoller, addr common.Address, feedId common.Hash) (*ConfigPoller, error) {
+	err := destChainPoller.RegisterFilter(NewConfigPollerFilter(addr), nil)
+
 	if err != nil {
 		return nil, err
 	}
-
-	subscription, err := eventBroadcaster.Subscribe(pg.ChannelInsertOnEVMLogs, "")
+	subscription, err = eventBroadcaster.Subscribe(pg.ChannelInsertOnEVMLogs, "")
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/vrf/delegate.go
+++ b/core/services/vrf/delegate.go
@@ -68,6 +68,7 @@ func (d *Delegate) JobType() job.Type {
 }
 
 func (d *Delegate) BeforeJobCreated(spec job.Job)                {}
+func (d *Delegate) OnCreateJob(spec job.Job, q pg.Queryer) error { return nil }
 func (d *Delegate) AfterJobCreated(spec job.Job)                 {}
 func (d *Delegate) BeforeJobDeleted(spec job.Job)                {}
 func (d *Delegate) OnDeleteJob(spec job.Job, q pg.Queryer) error { return nil }

--- a/core/services/webhook/delegate.go
+++ b/core/services/webhook/delegate.go
@@ -57,6 +57,8 @@ func (d *Delegate) AfterJobCreated(jb job.Job) {
 	}
 }
 
+func (d *Delegate) OnCreateJob(jb job.Job, q pg.Queryer) error { return nil }
+
 func (d *Delegate) BeforeJobDeleted(spec job.Job) {
 	err := d.externalInitiatorManager.DeleteJob(*spec.WebhookSpecID)
 	if err != nil {

--- a/core/web/evm_forwarders_controller.go
+++ b/core/web/evm_forwarders_controller.go
@@ -67,7 +67,7 @@ func (cc *EVMForwardersController) Track(c *gin.Context) {
 		if err != nil {
 			return err
 		}
-		chain, err2 := cc.App.GetChains().EVM.Get(request.EVMChainID.ToInt())
+		chain, err2 := cc.App.GetRelayers().LegacyEVMChains().Get(request.EVMChainID.String())
 		if err2 != nil {
 			return err2
 		}
@@ -75,7 +75,7 @@ func (cc *EVMForwardersController) Track(c *gin.Context) {
 		if chain.LogPoller() == logpoller.LogPollerDisabled {
 			return errors.New("Log poller must be enabled to add or use forwarders")
 		}
-		return chain.LogPoller().RegisterFilter(forwarders.NewLogFilter(fwd.Address), tx)
+		return chain.LogPoller().RegisterFilter(forwarders.NewLogFilter(fwd.Address), pg.WithQueryer(tx))
 	})
 
 	if err != nil {


### PR DESCRIPTION
This is accomplished by adding the OnCreateJob(filter, tx) callback, analogous
to OnDeleteJob(filterName, tx) for UnregisterFilter()

In the case of forwader manager, the RegisterFilter() call has been
moved into the Track() method of the evm forwarders controller