### PR TITLE
Handle racy edge cases in tx hash verification & handle nil latestBlock

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/registry_check_pipeline.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/registry_check_pipeline.go
@@ -252,8 +252,8 @@ func (r *EvmRegistry) checkUpkeeps(ctx context.Context, payloads []ocr2keepers.U
 	for i, req := range checkReqs {
 		index := indices[i]
 		if req.Error != nil {
-			latestBlock := r.bs.latestBlock.Load()
 			latestBlockNumber := int64(0)
+			latestBlock := r.bs.latestBlock.Load()
 			if latestBlock != nil {
 				latestBlockNumber = int64(latestBlock.Number)
 			}

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/registry_check_pipeline.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/registry_check_pipeline.go
@@ -130,7 +130,8 @@ func (r *EvmRegistry) verifyLogExists(upkeepId *big.Int, p ocr2keepers.UpkeepPay
 	checkBlockHash := common.BytesToHash(p.Trigger.BlockHash[:])
 	if checkBlockHash.String() == logBlockHash.String() {
 		// log verification would be covered by checkBlock verification as they are the same. Return early from
-		// log verificaion
+		// log verificaion. This also helps in preventing some racy conditions when rpc does not return the tx receipt
+		// for a very new log
 		return encoding.UpkeepFailureReasonNone, encoding.NoPipelineError, false
 	}
 	// if log block number is populated, check log block number and block hash


### PR DESCRIPTION
on mumbai, i saw some flaky issues when rpc did not return the tx receipt for a log it returned a few ms ago (via log poller)

i realized that we can simplify the whole log verification when logBlockHash is same as the checkBlockHash. This would help avoid any racy conditions for new logs (which are checked on logBlock itself). For any recovery runs, the log block would be older than finality anyway

Somewhat independently I also saw that there were a couple of places where we could have tried to read from a nil pointer from `r.bs.latestBlock`. Handle nil there