### PR TITLE
[fix] Refactor some flakey tests

### DIFF
--- a/core/cmd/shell_remote_test.go
+++ b/core/cmd/shell_remote_test.go
@@ -656,7 +656,7 @@ func TestShell_AutoLogin(t *testing.T) {
 	require.NoError(t, err)
 
 	// Expire the session and then try again
-	pgtest.MustExec(t, app.GetSqlxDB(), "TRUNCATE sessions")
+	pgtest.MustExec(t, app.GetSqlxDB(), "delete from sessions where email = $1", user.Email)
 	err = client.ListJobs(cli.NewContext(nil, fs, nil))
 	require.NoError(t, err)
 }

--- a/core/cmd/shell_remote_test.go
+++ b/core/cmd/shell_remote_test.go
@@ -257,17 +257,20 @@ func TestShell_DestroyExternalInitiator_NotFound(t *testing.T) {
 func TestShell_RemoteLogin(t *testing.T) {
 
 	app := startNewApplicationV2(t, nil)
+	orm := app.SessionORM()
+
+	u := cltest.NewUserWithSession(t, orm)
 
 	tests := []struct {
 		name, file string
 		email, pwd string
 		wantError  bool
 	}{
-		{"success prompt", "", cltest.APIEmailAdmin, cltest.Password, false},
+		{"success prompt", "", u.Email, cltest.Password, false},
 		{"success file", "../internal/fixtures/apicredentials", "", "", false},
 		{"failure prompt", "", "wrong@email.com", "wrongpwd", true},
 		{"failure file", "/tmp/doesntexist", "", "", true},
-		{"failure file w correct prompt", "/tmp/doesntexist", cltest.APIEmailAdmin, cltest.Password, true},
+		{"failure file w correct prompt", "/tmp/doesntexist", u.Email, cltest.Password, true},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -297,7 +300,8 @@ func TestShell_RemoteBuildCompatibility(t *testing.T) {
 	t.Parallel()
 
 	app := startNewApplicationV2(t, nil)
-	enteredStrings := []string{cltest.APIEmailAdmin, cltest.Password}
+	u := cltest.NewUserWithSession(t, app.SessionORM())
+	enteredStrings := []string{u.Email, cltest.Password}
 	prompter := &cltest.MockCountingPrompter{T: t, EnteredStrings: append(enteredStrings, enteredStrings...)}
 	client := app.NewAuthenticatingShell(prompter)
 
@@ -335,6 +339,7 @@ func TestShell_CheckRemoteBuildCompatibility(t *testing.T) {
 	t.Parallel()
 
 	app := startNewApplicationV2(t, nil)
+	u := cltest.NewUserWithSession(t, app.SessionORM())
 	tests := []struct {
 		name                         string
 		remoteVersion, remoteSha     string
@@ -349,7 +354,7 @@ func TestShell_CheckRemoteBuildCompatibility(t *testing.T) {
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			enteredStrings := []string{cltest.APIEmailAdmin, cltest.Password}
+			enteredStrings := []string{u.Email, cltest.Password}
 			prompter := &cltest.MockCountingPrompter{T: t, EnteredStrings: enteredStrings}
 			client := app.NewAuthenticatingShell(prompter)
 
@@ -410,8 +415,9 @@ func TestShell_ChangePassword(t *testing.T) {
 	t.Parallel()
 
 	app := startNewApplicationV2(t, nil)
+	u := cltest.NewUserWithSession(t, app.SessionORM())
 
-	enteredStrings := []string{cltest.APIEmailAdmin, cltest.Password}
+	enteredStrings := []string{u.Email, cltest.Password}
 	prompter := &cltest.MockCountingPrompter{T: t, EnteredStrings: enteredStrings}
 
 	client := app.NewAuthenticatingShell(prompter)
@@ -459,7 +465,8 @@ func TestShell_Profile_InvalidSecondsParam(t *testing.T) {
 	t.Parallel()
 
 	app := startNewApplicationV2(t, nil)
-	enteredStrings := []string{cltest.APIEmailAdmin, cltest.Password}
+	u := cltest.NewUserWithSession(t, app.SessionORM())
+	enteredStrings := []string{u.Email, cltest.Password}
 	prompter := &cltest.MockCountingPrompter{T: t, EnteredStrings: enteredStrings}
 
 	client := app.NewAuthenticatingShell(prompter)
@@ -489,7 +496,8 @@ func TestShell_Profile(t *testing.T) {
 	t.Parallel()
 
 	app := startNewApplicationV2(t, nil)
-	enteredStrings := []string{cltest.APIEmailAdmin, cltest.Password}
+	u := cltest.NewUserWithSession(t, app.SessionORM())
+	enteredStrings := []string{u.Email, cltest.Password}
 	prompter := &cltest.MockCountingPrompter{T: t, EnteredStrings: enteredStrings}
 
 	client := app.NewAuthenticatingShell(prompter)

--- a/core/cmd/shell_test.go
+++ b/core/cmd/shell_test.go
@@ -33,13 +33,16 @@ import (
 func TestTerminalCookieAuthenticator_AuthenticateWithoutSession(t *testing.T) {
 	t.Parallel()
 
+	app := cltest.NewApplicationEVMDisabled(t)
+	u := cltest.NewUserWithSession(t, app.SessionORM())
+
 	tests := []struct {
 		name, email, pwd string
 	}{
 		{"bad email", "notreal", cltest.Password},
-		{"bad pwd", cltest.APIEmailAdmin, "mostcommonwrongpwdever"},
+		{"bad pwd", u.Email, "mostcommonwrongpwdever"},
 		{"bad both", "notreal", "mostcommonwrongpwdever"},
-		{"correct", cltest.APIEmailAdmin, cltest.Password},
+		{"correct", u.Email, cltest.Password},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
@@ -63,14 +66,16 @@ func TestTerminalCookieAuthenticator_AuthenticateWithSession(t *testing.T) {
 	app := cltest.NewApplicationEVMDisabled(t)
 	require.NoError(t, app.Start(testutils.Context(t)))
 
+	u := cltest.NewUserWithSession(t, app.SessionORM())
+
 	tests := []struct {
 		name, email, pwd string
 		wantError        bool
 	}{
 		{"bad email", "notreal", cltest.Password, true},
-		{"bad pwd", cltest.APIEmailAdmin, "mostcommonwrongpwdever", true},
+		{"bad pwd", u.Email, "mostcommonwrongpwdever", true},
 		{"bad both", "notreal", "mostcommonwrongpwdever", true},
-		{"success", cltest.APIEmailAdmin, cltest.Password, false},
+		{"success", u.Email, cltest.Password, false},
 	}
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {

--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -321,37 +321,6 @@ func NewUserWithSession(t testing.TB, orm sessions.ORM) sessions.User {
 	return u
 }
 
-// CreateUserWithRole inserts a new user with specified role and associated test DB email into the test DB
-func CreateUserWithRole(t testing.TB, role sessions.UserRole) sessions.User {
-	email := ""
-	switch role {
-	case sessions.UserRoleAdmin:
-		email = APIEmailAdmin
-	case sessions.UserRoleEdit:
-		email = APIEmailEdit
-	case sessions.UserRoleRun:
-		email = APIEmailRun
-	case sessions.UserRoleView:
-		email = APIEmailViewOnly
-	default:
-		t.Fatal("Unexpected role for CreateUserWithRole")
-	}
-
-	r, err := sessions.NewUser(email, Password, role)
-	if err != nil {
-		logger.TestLogger(t).Panic(err)
-	}
-	return r
-}
-
-func MustNewUser(t *testing.T, email, password string) sessions.User {
-	r, err := sessions.NewUser(email, password, sessions.UserRoleAdmin)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return r
-}
-
 type MockAPIInitializer struct {
 	t     testing.TB
 	Count int

--- a/core/internal/cltest/mocks.go
+++ b/core/internal/cltest/mocks.go
@@ -27,6 +27,7 @@ import (
 	gethTypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/robfig/cron/v3"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // MockSubscription a mock subscription
@@ -306,6 +307,18 @@ func MustRandomUser(t testing.TB) sessions.User {
 		logger.TestLogger(t).Panic(err)
 	}
 	return r
+}
+
+func NewUserWithSession(t testing.TB, orm sessions.ORM) sessions.User {
+	u := MustRandomUser(t)
+	require.NoError(t, orm.CreateUser(&u))
+
+	_, err := orm.CreateSession(sessions.SessionRequest{
+		Email:    u.Email,
+		Password: Password,
+	})
+	require.NoError(t, err)
+	return u
 }
 
 // CreateUserWithRole inserts a new user with specified role and associated test DB email into the test DB

--- a/core/sessions/orm_test.go
+++ b/core/sessions/orm_test.go
@@ -97,13 +97,13 @@ func TestORM_DeleteUser(t *testing.T) {
 	t.Parallel()
 	_, orm := setupORM(t)
 
-	_, err := orm.FindUser(cltest.APIEmailAdmin)
+	u := cltest.MustRandomUser(t)
+	require.NoError(t, orm.CreateUser(&u))
+
+	err := orm.DeleteUser(u.Email)
 	require.NoError(t, err)
 
-	err = orm.DeleteUser(cltest.APIEmailAdmin)
-	require.NoError(t, err)
-
-	_, err = orm.FindUser(cltest.APIEmailAdmin)
+	_, err = orm.FindUser(u.Email)
 	require.Error(t, err)
 }
 
@@ -112,14 +112,17 @@ func TestORM_DeleteUserSession(t *testing.T) {
 
 	db, orm := setupORM(t)
 
+	u := cltest.MustRandomUser(t)
+	require.NoError(t, orm.CreateUser(&u))
+
 	session := sessions.NewSession()
-	_, err := db.Exec("INSERT INTO sessions (id, email, last_used, created_at) VALUES ($1, $2, now(), now())", session.ID, cltest.APIEmailAdmin)
+	_, err := db.Exec("INSERT INTO sessions (id, email, last_used, created_at) VALUES ($1, $2, now(), now())", session.ID, u.Email)
 	require.NoError(t, err)
 
 	err = orm.DeleteUserSession(session.ID)
 	require.NoError(t, err)
 
-	_, err = orm.FindUser(cltest.APIEmailAdmin)
+	_, err = orm.FindUser(u.Email)
 	require.NoError(t, err)
 
 	sessions, err := orm.Sessions(0, 10)
@@ -130,14 +133,17 @@ func TestORM_DeleteUserSession(t *testing.T) {
 func TestORM_DeleteUserCascade(t *testing.T) {
 	db, orm := setupORM(t)
 
+	u := cltest.MustRandomUser(t)
+	require.NoError(t, orm.CreateUser(&u))
+
 	session := sessions.NewSession()
-	_, err := db.Exec("INSERT INTO sessions (id, email, last_used, created_at) VALUES ($1, $2, now(), now())", session.ID, cltest.APIEmailAdmin)
+	_, err := db.Exec("INSERT INTO sessions (id, email, last_used, created_at) VALUES ($1, $2, now(), now())", session.ID, u.Email)
 	require.NoError(t, err)
 
-	err = orm.DeleteUser(cltest.APIEmailAdmin)
+	err = orm.DeleteUser(u.Email)
 	require.NoError(t, err)
 
-	_, err = orm.FindUser(cltest.APIEmailAdmin)
+	_, err = orm.FindUser(u.Email)
 	require.Error(t, err)
 
 	sessions, err := orm.Sessions(0, 10)

--- a/core/sessions/reaper_helper_test.go
+++ b/core/sessions/reaper_helper_test.go
@@ -1,0 +1,5 @@
+package sessions
+
+func (sr *sessionReaper) RunSignal() <-chan struct{} {
+	return sr.runSignal
+}

--- a/core/sessions/reaper_test.go
+++ b/core/sessions/reaper_test.go
@@ -1,7 +1,6 @@
 package sessions_test
 
 import (
-	"database/sql"
 	"testing"
 	"time"
 
@@ -11,8 +10,8 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger/audit"
 	"github.com/smartcontractkit/chainlink/v2/core/sessions"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 
-	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +34,9 @@ func TestSessionReaper_ReapSessions(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	orm := sessions.NewORM(db, config.SessionTimeout().Duration(), lggr, pgtest.NewQConfig(true), audit.NoopLogger)
 
-	r := sessions.NewSessionReaper(db.DB, config, lggr)
+	rw := sessions.NewSessionReaperWorker(db.DB, config, lggr)
+	r := utils.NewSleeperTask(rw)
+
 	t.Cleanup(func() {
 		assert.NoError(t, r.Stop())
 	})
@@ -54,34 +55,30 @@ func TestSessionReaper_ReapSessions(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			t.Cleanup(func() {
-				clearSessions(t, db.DB)
-			})
+			user := cltest.MustRandomUser(t)
+			require.NoError(t, orm.CreateUser(&user))
 
-			_, err := db.Exec("INSERT INTO sessions (last_used, email, id, created_at) VALUES ($1, $2, $3, now())", test.lastUsed, cltest.APIEmailAdmin, test.name)
+			session := sessions.NewSession()
+			session.Email = user.Email
+
+			_, err := db.Exec("INSERT INTO sessions (last_used, email, id, created_at) VALUES ($1, $2, $3, now())", test.lastUsed, user.Email, test.name)
 			require.NoError(t, err)
 
+			t.Cleanup(func() {
+				_, err2 := db.Exec("DELETE FROM sessions where email = $1", user.Email)
+				require.NoError(t, err2)
+			})
+
 			r.WakeUp()
+			<-rw.RunSignal()
+			sessions, err := orm.Sessions(0, 10)
+			assert.NoError(t, err)
 
 			if test.wantReap {
-				gomega.NewWithT(t).Eventually(func() []sessions.Session {
-					sessions, err := orm.Sessions(0, 10)
-					assert.NoError(t, err)
-					return sessions
-				}).Should(gomega.HaveLen(0))
+				assert.Len(t, sessions, 0)
 			} else {
-				gomega.NewWithT(t).Consistently(func() []sessions.Session {
-					sessions, err := orm.Sessions(0, 10)
-					assert.NoError(t, err)
-					return sessions
-				}).Should(gomega.HaveLen(1))
+				assert.Len(t, sessions, 1)
 			}
 		})
 	}
-}
-
-// clearSessions removes all sessions.
-func clearSessions(t *testing.T, db *sql.DB) {
-	_, err := db.Exec("DELETE FROM sessions")
-	require.NoError(t, err)
 }


### PR DESCRIPTION
    - Stop using Eventually() in SessionReaper tests, and use a channel to
      signal when the reaper has run instead.
    - Start using random users where we previously used APIEmailAdmin.
    - Remove a full table lock and replace it with a selective delete which
      should reduce some lock contention
