### PR TITLE
[auto-2.5.1] Upgrade to latest libocr

### DIFF
--- a/core/internal/features/ocr2/features_ocr2_test.go
+++ b/core/internal/features/ocr2/features_ocr2_test.go
@@ -24,12 +24,14 @@ import (
 	"github.com/onsi/gomega"
 	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
-	testoffchainaggregator2 "github.com/smartcontractkit/libocr/gethwrappers2/testocr2aggregator"
-	confighelper2 "github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
-	ocrtypes2 "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
+
+	"github.com/smartcontractkit/libocr/bigbigendian"
+	testoffchainaggregator2 "github.com/smartcontractkit/libocr/gethwrappers2/testocr2aggregator"
+	confighelper2 "github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
+	ocrtypes2 "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	"github.com/smartcontractkit/chainlink/v2/core/assets"
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
@@ -238,12 +240,19 @@ func TestIntegration_OCR2(t *testing.T) {
 	require.NoError(t, err)
 	blockBeforeConfig, err := b.BlockByNumber(testutils.Context(t), nil)
 	require.NoError(t, err)
-	signers, transmitters, threshold, onchainConfig, encodedConfigVersion, encodedConfig, err := confighelper2.ContractSetConfigArgsForEthereumIntegrationTest(
+	signers, transmitters, threshold, _, encodedConfigVersion, encodedConfig, err := confighelper2.ContractSetConfigArgsForEthereumIntegrationTest(
 		oracles,
 		1,
 		1000000000/100, // threshold PPB
 	)
 	require.NoError(t, err)
+
+	minAnswer, maxAnswer := new(big.Int), new(big.Int)
+	minAnswer.Exp(big.NewInt(-2), big.NewInt(191), nil)
+	maxAnswer.Exp(big.NewInt(2), big.NewInt(191), nil)
+	maxAnswer.Sub(maxAnswer, big.NewInt(1))
+
+	onchainConfig := generateDefaultOCR2OnchainConfig(t, minAnswer, maxAnswer)
 	lggr.Debugw("Setting Config on Oracle Contract",
 		"signers", signers,
 		"transmitters", transmitters,
@@ -506,12 +515,19 @@ func TestIntegration_OCR2_ForwarderFlow(t *testing.T) {
 	require.NoError(t, err)
 	blockBeforeConfig, err := b.BlockByNumber(testutils.Context(t), nil)
 	require.NoError(t, err)
-	signers, effectiveTransmitters, threshold, onchainConfig, encodedConfigVersion, encodedConfig, err := confighelper2.ContractSetConfigArgsForEthereumIntegrationTest(
+	signers, effectiveTransmitters, threshold, _, encodedConfigVersion, encodedConfig, err := confighelper2.ContractSetConfigArgsForEthereumIntegrationTest(
 		oracles,
 		1,
 		1000000000/100, // threshold PPB
 	)
 	require.NoError(t, err)
+
+	minAnswer, maxAnswer := new(big.Int), new(big.Int)
+	minAnswer.Exp(big.NewInt(-2), big.NewInt(191), nil)
+	maxAnswer.Exp(big.NewInt(2), big.NewInt(191), nil)
+	maxAnswer.Sub(maxAnswer, big.NewInt(1))
+
+	onchainConfig := generateDefaultOCR2OnchainConfig(t, minAnswer, maxAnswer)
 
 	lggr.Debugw("Setting Config on Oracle Contract",
 		"signers", signers,
@@ -720,6 +736,30 @@ juelsPerFeeCoinSource = """
 	digestAndEpoch, err := ocrContract.LatestConfigDigestAndEpoch(nil)
 	require.NoError(t, err)
 	assert.Equal(t, digestAndEpoch.Epoch, epoch)
+}
+
+func generateDefaultOCR2OnchainConfig(t *testing.T, minValue *big.Int, maxValue *big.Int) []byte {
+	serializedConfig := make([]byte, 0)
+
+	s1, err := bigbigendian.SerializeSigned(1, big.NewInt(1)) //version
+	if err != nil {
+		t.Fatal(err)
+	}
+	serializedConfig = append(serializedConfig, s1...)
+
+	s2, err := bigbigendian.SerializeSigned(24, minValue) //min
+	if err != nil {
+		t.Fatal(err)
+	}
+	serializedConfig = append(serializedConfig, s2...)
+
+	s3, err := bigbigendian.SerializeSigned(24, maxValue) //max
+	if err != nil {
+		t.Fatal(err)
+	}
+	serializedConfig = append(serializedConfig, s3...)
+
+	return serializedConfig
 }
 
 func ptr[T any](v T) *T { return &v }

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/pelletier/go-toml/v2 v2.0.9
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
-	github.com/smartcontractkit/libocr v0.0.0-20230918212407-dbd4e505b3e6
-	github.com/smartcontractkit/ocr2keepers v0.7.26
+	github.com/smartcontractkit/libocr v0.0.0-20230922131214-122accb19ea6
+	github.com/smartcontractkit/ocr2keepers v0.7.27
 	github.com/smartcontractkit/ocr2vrf v0.0.0-20230804151440-2f1eb1e20687
 	github.com/smartcontractkit/sqlx v1.3.5-0.20210805004948-4be295aacbeb
 	github.com/spf13/cobra v1.6.1

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1387,10 +1387,10 @@ github.com/smartcontractkit/go-plugin v0.0.0-20230605132010-0f4d515d1472 h1:x3kN
 github.com/smartcontractkit/go-plugin v0.0.0-20230605132010-0f4d515d1472/go.mod h1:6/1TEzT0eQznvI/gV2CM29DLSkAK/e58mUWKVsPaph0=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f h1:hgJif132UCdjo8u43i7iPN1/MFnu49hv7lFGFftCHKU=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f/go.mod h1:MvMXoufZAtqExNexqi4cjrNYE9MefKddKylxjS+//n0=
-github.com/smartcontractkit/libocr v0.0.0-20230918212407-dbd4e505b3e6 h1:w+8TI2Vcm3vk8XQz40ddcwy9BNZgoakXIby35Y54iDU=
-github.com/smartcontractkit/libocr v0.0.0-20230918212407-dbd4e505b3e6/go.mod h1:2lyRkw/qLQgUWlrWWmq5nj0y90rWeO6Y+v+fCakRgb0=
-github.com/smartcontractkit/ocr2keepers v0.7.26 h1:8Usfdsa6GtliMQPThL1qb36d4J5xMyTCFJYgbGp4ecA=
-github.com/smartcontractkit/ocr2keepers v0.7.26/go.mod h1:4e1ZDRz7fpLgcRUjJpq+5mkoD0ga11BxrSp2JTWKADQ=
+github.com/smartcontractkit/libocr v0.0.0-20230922131214-122accb19ea6 h1:eSo9r53fARv2MnIO5pqYvQOXMBsTlAwhHyQ6BAVp6bY=
+github.com/smartcontractkit/libocr v0.0.0-20230922131214-122accb19ea6/go.mod h1:2lyRkw/qLQgUWlrWWmq5nj0y90rWeO6Y+v+fCakRgb0=
+github.com/smartcontractkit/ocr2keepers v0.7.27 h1:kwqMrzmEdq6gH4yqNuLQCbdlED0KaIjwZzu3FF+Gves=
+github.com/smartcontractkit/ocr2keepers v0.7.27/go.mod h1:1QGzJURnoWpysguPowOe2bshV0hNp1YX10HHlhDEsas=
 github.com/smartcontractkit/ocr2vrf v0.0.0-20230804151440-2f1eb1e20687 h1:NwC3SOc25noBTe1KUQjt45fyTIuInhoE2UfgcHAdihM=
 github.com/smartcontractkit/ocr2vrf v0.0.0-20230804151440-2f1eb1e20687/go.mod h1:YYZq52t4wcHoMQeITksYsorD+tZcOyuVU5+lvot3VFM=
 github.com/smartcontractkit/sqlx v1.3.5-0.20210805004948-4be295aacbeb h1:OMaBUb4X9IFPLbGbCHsMU+kw/BPCrewaVwWGIBc0I4A=

--- a/core/services/relay/evm/config_poller.go
+++ b/core/services/relay/evm/config_poller.go
@@ -3,23 +3,41 @@ package evm
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
+	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
+	"github.com/smartcontractkit/libocr/gethwrappers2/ocrconfigurationstoreevmsimple"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	evmRelayTypes "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm/types"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
-// ConfigSet Common to all OCR2 evm based contracts: https://github.com/smartcontractkit/libocr/blob/master/contract2/dev/OCR2Abstract.sol
-var ConfigSet common.Hash
+var (
+	failedRPCContractCalls = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "ocr2_failed_rpc_contract_calls",
+		Help: "Running count of failed RPC contract calls by chain/contract",
+	},
+		[]string{"chainID", "contractAddress"},
+	)
+)
 
-var defaultABI abi.ABI
+var (
+	// ConfigSet Common to all OCR2 evm based contracts: https://github.com/smartcontractkit/libocr/blob/master/contract2/dev/OCR2Abstract.sol
+	ConfigSet common.Hash
+
+	defaultABI abi.ABI
+)
 
 const configSetEventName = "ConfigSet"
 
@@ -50,7 +68,7 @@ func configFromLog(logData []byte) (ocrtypes.ContractConfig, error) {
 
 	var transmitAccounts []ocrtypes.Account
 	for _, addr := range unpacked.Transmitters {
-		transmitAccounts = append(transmitAccounts, ocrtypes.Account(addr.String()))
+		transmitAccounts = append(transmitAccounts, ocrtypes.Account(addr.Hex()))
 	}
 	var signers []ocrtypes.OnchainPublicKey
 	for _, addr := range unpacked.Signers {
@@ -71,36 +89,63 @@ func configFromLog(logData []byte) (ocrtypes.ContractConfig, error) {
 }
 
 type configPoller struct {
+	utils.StartStopOnce
+
 	lggr               logger.Logger
 	filterName         string
 	destChainLogPoller logpoller.LogPoller
-	addr               common.Address
+	client             client.Client
+
+	aggregatorContractAddr common.Address
+	aggregatorContract     *ocr2aggregator.OCR2Aggregator
+
+	// Some chains "manage" state bloat by deleting older logs. The ConfigStore
+	// contract allows us work around such restrictions.
+	configStoreContractAddr *common.Address
+	configStoreContract     *ocrconfigurationstoreevmsimple.OCRConfigurationStoreEVMSimple
 }
 
 func configPollerFilterName(addr common.Address) string {
 	return logpoller.FilterName("OCR2ConfigPoller", addr.String())
 }
 
-func NewConfigPoller(lggr logger.Logger, destChainPoller logpoller.LogPoller, addr common.Address) (evmRelayTypes.ConfigPoller, error) {
-	err := destChainPoller.RegisterFilter(logpoller.Filter{Name: configPollerFilterName(addr), EventSigs: []common.Hash{ConfigSet}, Addresses: []common.Address{addr}})
+func NewConfigPoller(lggr logger.Logger, client client.Client, destChainPoller logpoller.LogPoller, aggregatorContractAddr common.Address, configStoreAddr *common.Address) (evmRelayTypes.ConfigPoller, error) {
+	return newConfigPoller(lggr, client, destChainPoller, aggregatorContractAddr, configStoreAddr)
+}
+
+func newConfigPoller(lggr logger.Logger, client client.Client, destChainPoller logpoller.LogPoller, aggregatorContractAddr common.Address, configStoreAddr *common.Address) (*configPoller, error) {
+	err := destChainPoller.RegisterFilter(logpoller.Filter{Name: configPollerFilterName(aggregatorContractAddr), EventSigs: []common.Hash{ConfigSet}, Addresses: []common.Address{aggregatorContractAddr}})
+	if err != nil {
+		return nil, err
+	}
+
+	aggregatorContract, err := ocr2aggregator.NewOCR2Aggregator(aggregatorContractAddr, client)
 	if err != nil {
 		return nil, err
 	}
 
 	cp := &configPoller{
-		lggr:               lggr,
-		filterName:         configPollerFilterName(addr),
-		destChainLogPoller: destChainPoller,
-		addr:               addr,
+		lggr:                   lggr,
+		filterName:             configPollerFilterName(aggregatorContractAddr),
+		destChainLogPoller:     destChainPoller,
+		aggregatorContractAddr: aggregatorContractAddr,
+		client:                 client,
+		aggregatorContract:     aggregatorContract,
+	}
+
+	if configStoreAddr != nil {
+		cp.configStoreContractAddr = configStoreAddr
+		cp.configStoreContract, err = ocrconfigurationstoreevmsimple.NewOCRConfigurationStoreEVMSimple(*configStoreAddr, client)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return cp, nil
 }
 
-// Start noop method
 func (cp *configPoller) Start() {}
 
-// Close noop method
 func (cp *configPoller) Close() error {
 	return nil
 }
@@ -117,10 +162,14 @@ func (cp *configPoller) Replay(ctx context.Context, fromBlock int64) error {
 
 // LatestConfigDetails returns the latest config details from the logs
 func (cp *configPoller) LatestConfigDetails(ctx context.Context) (changedInBlock uint64, configDigest ocrtypes.ConfigDigest, err error) {
-	latest, err := cp.destChainLogPoller.LatestLogByEventSigWithConfs(ConfigSet, cp.addr, 1, pg.WithParentCtx(ctx))
+	latest, err := cp.destChainLogPoller.LatestLogByEventSigWithConfs(ConfigSet, cp.aggregatorContractAddr, 1, pg.WithParentCtx(ctx))
 	if err != nil {
-		// If contract is not configured, we will not have the log.
 		if errors.Is(err, sql.ErrNoRows) {
+			if cp.isConfigStoreAvailable() {
+				// Fallback to RPC call in case logs have been pruned and configStoreContract is available
+				return cp.callLatestConfigDetails(ctx)
+			}
+			// log not found means return zero config digest
 			return 0, ocrtypes.ConfigDigest{}, nil
 		}
 		return 0, ocrtypes.ConfigDigest{}, err
@@ -134,9 +183,16 @@ func (cp *configPoller) LatestConfigDetails(ctx context.Context) (changedInBlock
 
 // LatestConfig returns the latest config from the logs on a certain block
 func (cp *configPoller) LatestConfig(ctx context.Context, changedInBlock uint64) (ocrtypes.ContractConfig, error) {
-	lgs, err := cp.destChainLogPoller.Logs(int64(changedInBlock), int64(changedInBlock), ConfigSet, cp.addr, pg.WithParentCtx(ctx))
+	lgs, err := cp.destChainLogPoller.Logs(int64(changedInBlock), int64(changedInBlock), ConfigSet, cp.aggregatorContractAddr, pg.WithParentCtx(ctx))
 	if err != nil {
 		return ocrtypes.ContractConfig{}, err
+	}
+	if len(lgs) == 0 {
+		if cp.isConfigStoreAvailable() {
+			// Fallback to RPC call in case logs have been pruned
+			return cp.callReadConfigFromStore(ctx)
+		}
+		return ocrtypes.ContractConfig{}, fmt.Errorf("no logs found for config on contract %s (chain %s) at block %d", cp.aggregatorContractAddr.Hex(), cp.client.ConfiguredChainID().String(), changedInBlock)
 	}
 	latestConfigSet, err := configFromLog(lgs[len(lgs)-1].Data)
 	if err != nil {
@@ -156,4 +212,59 @@ func (cp *configPoller) LatestBlockHeight(ctx context.Context) (blockHeight uint
 		return 0, err
 	}
 	return uint64(latest), nil
+}
+
+func (cp *configPoller) isConfigStoreAvailable() bool {
+	return cp.configStoreContract != nil
+}
+
+// RPC call for latest config details
+func (cp *configPoller) callLatestConfigDetails(ctx context.Context) (changedInBlock uint64, configDigest ocrtypes.ConfigDigest, err error) {
+	details, err := cp.aggregatorContract.LatestConfigDetails(&bind.CallOpts{
+		Context: ctx,
+	})
+	if err != nil {
+		failedRPCContractCalls.WithLabelValues(cp.client.ConfiguredChainID().String(), cp.aggregatorContractAddr.Hex()).Inc()
+	}
+	return uint64(details.BlockNumber), details.ConfigDigest, err
+}
+
+// RPC call to read config from config store contract
+func (cp *configPoller) callReadConfigFromStore(ctx context.Context) (cfg ocrtypes.ContractConfig, err error) {
+	_, configDigest, err := cp.LatestConfigDetails(ctx)
+	if err != nil {
+		failedRPCContractCalls.WithLabelValues(cp.client.ConfiguredChainID().String(), cp.aggregatorContractAddr.Hex()).Inc()
+		return cfg, fmt.Errorf("failed to get latest config details: %w", err)
+	}
+	if configDigest == (ocrtypes.ConfigDigest{}) {
+		return cfg, fmt.Errorf("config details missing while trying to lookup config in store; no logs found for contract %s (chain %s)", cp.aggregatorContractAddr.Hex(), cp.client.ConfiguredChainID().String())
+	}
+
+	storedConfig, err := cp.configStoreContract.ReadConfig(&bind.CallOpts{
+		Context: ctx,
+	}, configDigest)
+	if err != nil {
+		failedRPCContractCalls.WithLabelValues(cp.client.ConfiguredChainID().String(), cp.configStoreContractAddr.Hex()).Inc()
+		return cfg, fmt.Errorf("failed to read config from config store contract: %w", err)
+	}
+
+	signers := make([]ocrtypes.OnchainPublicKey, len(storedConfig.Signers))
+	for i := range signers {
+		signers[i] = storedConfig.Signers[i].Bytes()
+	}
+	transmitters := make([]ocrtypes.Account, len(storedConfig.Transmitters))
+	for i := range transmitters {
+		transmitters[i] = ocrtypes.Account(storedConfig.Transmitters[i].Hex())
+	}
+
+	return ocrtypes.ContractConfig{
+		ConfigDigest:          configDigest,
+		ConfigCount:           uint64(storedConfig.ConfigCount),
+		Signers:               signers,
+		Transmitters:          transmitters,
+		F:                     storedConfig.F,
+		OnchainConfig:         storedConfig.OnchainConfig,
+		OffchainConfigVersion: storedConfig.OffchainConfigVersion,
+		OffchainConfig:        storedConfig.OffchainConfig,
+	}, err
 }

--- a/core/services/relay/evm/config_poller_test.go
+++ b/core/services/relay/evm/config_poller_test.go
@@ -1,27 +1,39 @@
 package evm
 
 import (
+	"database/sql"
 	"math/big"
 	"testing"
 	"time"
 
+	"github.com/ethereum/go-ethereum"
+	"github.com/smartcontractkit/libocr/bigbigendian"
+	"github.com/smartcontractkit/libocr/gethwrappers2/ocrconfigurationstoreevmsimple"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core"
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/eth/ethconfig"
 	"github.com/onsi/gomega"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/libocr/gethwrappers2/ocr2aggregator"
 	testoffchainaggregator2 "github.com/smartcontractkit/libocr/gethwrappers2/testocr2aggregator"
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
 	confighelper2 "github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
+	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	ocrtypes2 "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
+	evmClientMocks "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/link_token_interface"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
@@ -30,80 +42,284 @@ import (
 )
 
 func TestConfigPoller(t *testing.T) {
-	key, err := crypto.GenerateKey()
-	require.NoError(t, err)
-	user, err := bind.NewKeyedTransactorWithChainID(key, big.NewInt(1337))
-	require.NoError(t, err)
-	b := backends.NewSimulatedBackend(core.GenesisAlloc{
-		user.From: {Balance: big.NewInt(1000000000000000000)}},
-		5*ethconfig.Defaults.Miner.GasCeil)
-	linkTokenAddress, _, _, err := link_token_interface.DeployLinkToken(user, b)
-	require.NoError(t, err)
-	accessAddress, _, _, err := testoffchainaggregator2.DeploySimpleWriteAccessController(user, b)
-	require.NoError(t, err, "failed to deploy test access controller contract")
-	ocrAddress, _, ocrContract, err := ocr2aggregator.DeployOCR2Aggregator(
-		user,
-		b,
-		linkTokenAddress,
-		big.NewInt(0),
-		big.NewInt(10),
-		accessAddress,
-		accessAddress,
-		9,
-		"TEST",
-	)
-	require.NoError(t, err)
-	b.Commit()
-
-	db := pgtest.NewSqlxDB(t)
-	cfg := pgtest.NewQConfig(false)
-	ethClient := evmclient.NewSimulatedBackendClient(t, b, big.NewInt(1337))
 	lggr := logger.TestLogger(t)
-	ctx := testutils.Context(t)
-	lorm := logpoller.NewORM(big.NewInt(1337), db, lggr, cfg)
-	lp := logpoller.NewLogPoller(lorm, ethClient, lggr, 100*time.Millisecond, 1, 2, 2, 1000)
-	require.NoError(t, lp.Start(ctx))
-	t.Cleanup(func() { lp.Close() })
-	logPoller, err := NewConfigPoller(lggr, lp, ocrAddress)
-	require.NoError(t, err)
-	// Should have no config to begin with.
-	_, config, err := logPoller.LatestConfigDetails(testutils.Context(t))
-	require.NoError(t, err)
-	require.Equal(t, ocrtypes2.ConfigDigest{}, config)
-	// Set the config
-	contractConfig := setConfig(t, median.OffchainConfig{
-		AlphaReportInfinite: false,
-		AlphaReportPPB:      0,
-		AlphaAcceptInfinite: true,
-		AlphaAcceptPPB:      0,
-		DeltaC:              10,
-	}, ocrContract, user)
-	b.Commit()
-	latest, err := b.BlockByNumber(testutils.Context(t), nil)
-	require.NoError(t, err)
-	// Ensure we capture this config set log.
-	require.NoError(t, lp.Replay(testutils.Context(t), latest.Number().Int64()-1))
+	var ethClient *client.SimulatedBackendClient
+	var lp logpoller.LogPoller
+	var ocrAddress common.Address
+	var ocrContract *ocr2aggregator.OCR2Aggregator
+	var configStoreContractAddr common.Address
+	var configStoreContract *ocrconfigurationstoreevmsimple.OCRConfigurationStoreEVMSimple
+	var user *bind.TransactOpts
+	var b *backends.SimulatedBackend
+	var linkTokenAddress common.Address
+	var accessAddress common.Address
 
-	// Send blocks until we see the config updated.
-	var configBlock uint64
-	var digest [32]byte
-	gomega.NewGomegaWithT(t).Eventually(func() bool {
-		b.Commit()
-		configBlock, digest, err = logPoller.LatestConfigDetails(testutils.Context(t))
+	{
+		key, err := crypto.GenerateKey()
 		require.NoError(t, err)
-		return ocrtypes2.ConfigDigest{} != digest
-	}, testutils.WaitTimeout(t), 100*time.Millisecond).Should(gomega.BeTrue())
+		user, err = bind.NewKeyedTransactorWithChainID(key, big.NewInt(1337))
+		require.NoError(t, err)
+		b = backends.NewSimulatedBackend(core.GenesisAlloc{
+			user.From: {Balance: big.NewInt(1000000000000000000)}},
+			5*ethconfig.Defaults.Miner.GasCeil)
+		linkTokenAddress, _, _, err = link_token_interface.DeployLinkToken(user, b)
+		require.NoError(t, err)
+		accessAddress, _, _, err = testoffchainaggregator2.DeploySimpleWriteAccessController(user, b)
+		require.NoError(t, err, "failed to deploy test access controller contract")
+		ocrAddress, _, ocrContract, err = ocr2aggregator.DeployOCR2Aggregator(
+			user,
+			b,
+			linkTokenAddress,
+			big.NewInt(0),
+			big.NewInt(10),
+			accessAddress,
+			accessAddress,
+			9,
+			"TEST",
+		)
+		require.NoError(t, err)
+		configStoreContractAddr, _, configStoreContract, err = ocrconfigurationstoreevmsimple.DeployOCRConfigurationStoreEVMSimple(user, b)
+		require.NoError(t, err)
+		b.Commit()
 
-	// Assert the config returned is the one we configured.
-	newConfig, err := logPoller.LatestConfig(testutils.Context(t), configBlock)
-	require.NoError(t, err)
-	// Note we don't check onchainConfig, as that is populated in the contract itself.
-	assert.Equal(t, digest, [32]byte(newConfig.ConfigDigest))
-	assert.Equal(t, contractConfig.Signers, newConfig.Signers)
-	assert.Equal(t, contractConfig.Transmitters, newConfig.Transmitters)
-	assert.Equal(t, contractConfig.F, newConfig.F)
-	assert.Equal(t, contractConfig.OffchainConfigVersion, newConfig.OffchainConfigVersion)
-	assert.Equal(t, contractConfig.OffchainConfig, newConfig.OffchainConfig)
+		db := pgtest.NewSqlxDB(t)
+		cfg := pgtest.NewQConfig(false)
+		ethClient = evmclient.NewSimulatedBackendClient(t, b, testutils.SimulatedChainID)
+		ctx := testutils.Context(t)
+		lorm := logpoller.NewORM(testutils.SimulatedChainID, db, lggr, cfg)
+		lp = logpoller.NewLogPoller(lorm, ethClient, lggr, 100*time.Millisecond, 1, 2, 2, 1000)
+		require.NoError(t, lp.Start(ctx))
+		t.Cleanup(func() { lp.Close() })
+	}
+
+	t.Run("LatestConfig errors if there is no config in logs and config store is unconfigured", func(t *testing.T) {
+		cp, err := NewConfigPoller(lggr, ethClient, lp, ocrAddress, nil)
+		require.NoError(t, err)
+
+		_, err = cp.LatestConfig(testutils.Context(t), 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no logs found for config on contract")
+	})
+
+	t.Run("happy path (with config store)", func(t *testing.T) {
+		cp, err := NewConfigPoller(lggr, ethClient, lp, ocrAddress, &configStoreContractAddr)
+		require.NoError(t, err)
+		// Should have no config to begin with.
+		_, configDigest, err := cp.LatestConfigDetails(testutils.Context(t))
+		require.NoError(t, err)
+		require.Equal(t, ocrtypes2.ConfigDigest{}, configDigest)
+		// Should error because there are no logs for config at block 0
+		_, err = cp.LatestConfig(testutils.Context(t), 0)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "config details missing while trying to lookup config in store")
+
+		// Set the config
+		contractConfig := setConfig(t, median.OffchainConfig{
+			AlphaReportInfinite: false,
+			AlphaReportPPB:      0,
+			AlphaAcceptInfinite: true,
+			AlphaAcceptPPB:      0,
+			DeltaC:              10,
+		}, ocrContract, user)
+		b.Commit()
+		latest, err := b.BlockByNumber(testutils.Context(t), nil)
+		require.NoError(t, err)
+		// Ensure we capture this config set log.
+		require.NoError(t, lp.Replay(testutils.Context(t), latest.Number().Int64()-1))
+
+		// Send blocks until we see the config updated.
+		var configBlock uint64
+		var digest [32]byte
+		gomega.NewGomegaWithT(t).Eventually(func() bool {
+			b.Commit()
+			configBlock, digest, err = cp.LatestConfigDetails(testutils.Context(t))
+			require.NoError(t, err)
+			return ocrtypes2.ConfigDigest{} != digest
+		}, testutils.WaitTimeout(t), 100*time.Millisecond).Should(gomega.BeTrue())
+
+		// Assert the config returned is the one we configured.
+		newConfig, err := cp.LatestConfig(testutils.Context(t), configBlock)
+		require.NoError(t, err)
+		// Note we don't check onchainConfig, as that is populated in the contract itself.
+		assert.Equal(t, digest, [32]byte(newConfig.ConfigDigest))
+		assert.Equal(t, contractConfig.Signers, newConfig.Signers)
+		assert.Equal(t, contractConfig.Transmitters, newConfig.Transmitters)
+		assert.Equal(t, contractConfig.F, newConfig.F)
+		assert.Equal(t, contractConfig.OffchainConfigVersion, newConfig.OffchainConfigVersion)
+		assert.Equal(t, contractConfig.OffchainConfig, newConfig.OffchainConfig)
+	})
+
+	{
+		var err error
+		ocrAddress, _, ocrContract, err = ocr2aggregator.DeployOCR2Aggregator(
+			user,
+			b,
+			linkTokenAddress,
+			big.NewInt(0),
+			big.NewInt(10),
+			accessAddress,
+			accessAddress,
+			9,
+			"TEST",
+		)
+		require.NoError(t, err)
+		b.Commit()
+	}
+
+	t.Run("LatestConfigDetails, when logs have been pruned and config store contract is configured", func(t *testing.T) {
+		// Give it a log poller that will never return logs
+		mp := new(mocks.LogPoller)
+		mp.On("RegisterFilter", mock.Anything).Return(nil)
+		mp.On("LatestLogByEventSigWithConfs", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, sql.ErrNoRows)
+
+		t.Run("if callLatestConfigDetails succeeds", func(t *testing.T) {
+			cp, err := newConfigPoller(lggr, ethClient, mp, ocrAddress, &configStoreContractAddr)
+			require.NoError(t, err)
+
+			t.Run("when config has not been set, returns zero values", func(t *testing.T) {
+				changedInBlock, configDigest, err := cp.LatestConfigDetails(testutils.Context(t))
+				require.NoError(t, err)
+
+				assert.Equal(t, 0, int(changedInBlock))
+				assert.Equal(t, ocrtypes.ConfigDigest{}, configDigest)
+			})
+			t.Run("when config has been set, returns config details", func(t *testing.T) {
+				setConfig(t, median.OffchainConfig{
+					AlphaReportInfinite: false,
+					AlphaReportPPB:      0,
+					AlphaAcceptInfinite: true,
+					AlphaAcceptPPB:      0,
+					DeltaC:              10,
+				}, ocrContract, user)
+				b.Commit()
+
+				changedInBlock, configDigest, err := cp.LatestConfigDetails(testutils.Context(t))
+				require.NoError(t, err)
+
+				latest, err := b.BlockByNumber(testutils.Context(t), nil)
+				require.NoError(t, err)
+
+				onchainDetails, err := ocrContract.LatestConfigDetails(nil)
+				require.NoError(t, err)
+
+				assert.Equal(t, latest.Number().Int64(), int64(changedInBlock))
+				assert.Equal(t, onchainDetails.ConfigDigest, [32]byte(configDigest))
+			})
+		})
+		t.Run("returns error if callLatestConfigDetails fails", func(t *testing.T) {
+			failingClient := new(evmClientMocks.Client)
+			failingClient.On("ConfiguredChainID").Return(big.NewInt(42))
+			failingClient.On("CallContract", mock.Anything, mock.Anything, mock.Anything).Return(nil, errors.New("something exploded"))
+			cp, err := newConfigPoller(lggr, failingClient, mp, ocrAddress, &configStoreContractAddr)
+			require.NoError(t, err)
+
+			cp.configStoreContractAddr = &configStoreContractAddr
+			cp.configStoreContract = configStoreContract
+
+			_, _, err = cp.LatestConfigDetails(testutils.Context(t))
+			assert.EqualError(t, err, "something exploded")
+
+			failingClient.AssertExpectations(t)
+		})
+	})
+
+	{
+		var err error
+		// deploy it again to reset to empty config
+		ocrAddress, _, ocrContract, err = ocr2aggregator.DeployOCR2Aggregator(
+			user,
+			b,
+			linkTokenAddress,
+			big.NewInt(0),
+			big.NewInt(10),
+			accessAddress,
+			accessAddress,
+			9,
+			"TEST",
+		)
+		require.NoError(t, err)
+		b.Commit()
+	}
+
+	t.Run("LatestConfig, when logs have been pruned and config store contract is configured", func(t *testing.T) {
+		// Give it a log poller that will never return logs
+		mp := mocks.NewLogPoller(t)
+		mp.On("RegisterFilter", mock.Anything).Return(nil)
+		mp.On("Logs", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, nil)
+		mp.On("LatestLogByEventSigWithConfs", mock.Anything, mock.Anything, mock.Anything, mock.Anything).Return(nil, sql.ErrNoRows)
+
+		t.Run("if callReadConfig succeeds", func(t *testing.T) {
+			cp, err := newConfigPoller(lggr, ethClient, mp, ocrAddress, &configStoreContractAddr)
+			require.NoError(t, err)
+
+			t.Run("when config has not been set, returns error", func(t *testing.T) {
+				_, err := cp.LatestConfig(testutils.Context(t), 0)
+				require.Error(t, err)
+
+				assert.Contains(t, err.Error(), "config details missing while trying to lookup config in store")
+			})
+			t.Run("when config has been set, returns config", func(t *testing.T) {
+				b.Commit()
+				onchainDetails, err := ocrContract.LatestConfigDetails(nil)
+				require.NoError(t, err)
+
+				contractConfig := setConfig(t, median.OffchainConfig{
+					AlphaReportInfinite: false,
+					AlphaReportPPB:      0,
+					AlphaAcceptInfinite: true,
+					AlphaAcceptPPB:      0,
+					DeltaC:              10,
+				}, ocrContract, user)
+
+				signerAddresses, err := OnchainPublicKeyToAddress(contractConfig.Signers)
+				require.NoError(t, err)
+				transmitterAddresses, err := AccountToAddress(contractConfig.Transmitters)
+				require.NoError(t, err)
+
+				configuration := ocrconfigurationstoreevmsimple.OCRConfigurationStoreEVMSimpleConfigurationEVMSimple{
+					Signers:               signerAddresses,
+					Transmitters:          transmitterAddresses,
+					OnchainConfig:         contractConfig.OnchainConfig,
+					OffchainConfig:        contractConfig.OffchainConfig,
+					ContractAddress:       ocrAddress,
+					OffchainConfigVersion: contractConfig.OffchainConfigVersion,
+					ConfigCount:           1,
+					F:                     contractConfig.F,
+				}
+
+				addConfig(t, user, configStoreContract, configuration)
+
+				b.Commit()
+				onchainDetails, err = ocrContract.LatestConfigDetails(nil)
+				require.NoError(t, err)
+
+				newConfig, err := cp.LatestConfig(testutils.Context(t), 0)
+				require.NoError(t, err)
+
+				assert.Equal(t, onchainDetails.ConfigDigest, [32]byte(newConfig.ConfigDigest))
+				assert.Equal(t, contractConfig.Signers, newConfig.Signers)
+				assert.Equal(t, contractConfig.Transmitters, newConfig.Transmitters)
+				assert.Equal(t, contractConfig.F, newConfig.F)
+				assert.Equal(t, contractConfig.OffchainConfigVersion, newConfig.OffchainConfigVersion)
+				assert.Equal(t, contractConfig.OffchainConfig, newConfig.OffchainConfig)
+			})
+		})
+		t.Run("returns error if callReadConfig fails", func(t *testing.T) {
+			failingClient := new(evmClientMocks.Client)
+			failingClient.On("ConfiguredChainID").Return(big.NewInt(42))
+			failingClient.On("CallContract", mock.Anything, mock.MatchedBy(func(callArgs ethereum.CallMsg) bool {
+				// initial call to retrieve config store address from aggregator
+				return *callArgs.To == ocrAddress
+			}), mock.Anything).Return(nil, errors.New("something exploded")).Once()
+			cp, err := newConfigPoller(lggr, failingClient, mp, ocrAddress, &configStoreContractAddr)
+			require.NoError(t, err)
+
+			_, err = cp.LatestConfig(testutils.Context(t), 0)
+			assert.EqualError(t, err, "failed to get latest config details: something exploded")
+
+			failingClient.AssertExpectations(t)
+		})
+	})
 }
 
 func setConfig(t *testing.T, pluginConfig median.OffchainConfig, ocrContract *ocr2aggregator.OCR2Aggregator, user *bind.TransactOpts) ocrtypes2.ContractConfig {
@@ -113,7 +329,7 @@ func setConfig(t *testing.T, pluginConfig median.OffchainConfig, ocrContract *oc
 		oracles = append(oracles, confighelper2.OracleIdentityExtra{
 			OracleIdentity: confighelper2.OracleIdentity{
 				OnchainPublicKey:  utils.RandomAddress().Bytes(),
-				TransmitAccount:   ocrtypes2.Account(utils.RandomAddress().String()),
+				TransmitAccount:   ocrtypes2.Account(utils.RandomAddress().Hex()),
 				OffchainPublicKey: utils.RandomBytes32(),
 				PeerID:            utils.MustNewPeerID(),
 			},
@@ -137,7 +353,7 @@ func setConfig(t *testing.T, pluginConfig median.OffchainConfig, ocrContract *oc
 		50*time.Millisecond,
 		50*time.Millisecond,
 		1, // faults
-		nil,
+		generateDefaultOCR2OnchainConfig(t, big.NewInt(0), big.NewInt(10)),
 	)
 	require.NoError(t, err)
 	signerAddresses, err := OnchainPublicKeyToAddress(signers)
@@ -154,4 +370,34 @@ func setConfig(t *testing.T, pluginConfig median.OffchainConfig, ocrContract *oc
 		OffchainConfigVersion: offchainConfigVersion,
 		OffchainConfig:        offchainConfig,
 	}
+}
+
+func addConfig(t *testing.T, user *bind.TransactOpts, configStoreContract *ocrconfigurationstoreevmsimple.OCRConfigurationStoreEVMSimple, config ocrconfigurationstoreevmsimple.OCRConfigurationStoreEVMSimpleConfigurationEVMSimple) {
+
+	_, err := configStoreContract.AddConfig(user, config)
+	require.NoError(t, err)
+}
+
+func generateDefaultOCR2OnchainConfig(t *testing.T, minValue *big.Int, maxValue *big.Int) []byte {
+	serializedConfig := make([]byte, 0)
+
+	s1, err := bigbigendian.SerializeSigned(1, big.NewInt(1)) //version
+	if err != nil {
+		t.Fatal(err)
+	}
+	serializedConfig = append(serializedConfig, s1...)
+
+	s2, err := bigbigendian.SerializeSigned(24, minValue) //min
+	if err != nil {
+		t.Fatal(err)
+	}
+	serializedConfig = append(serializedConfig, s2...)
+
+	s3, err := bigbigendian.SerializeSigned(24, maxValue) //max
+	if err != nil {
+		t.Fatal(err)
+	}
+	serializedConfig = append(serializedConfig, s3...)
+
+	return serializedConfig
 }

--- a/core/services/relay/evm/functions/config_poller.go
+++ b/core/services/relay/evm/functions/config_poller.go
@@ -162,6 +162,9 @@ func (cp *configPoller) LatestConfig(ctx context.Context, changedInBlock uint64)
 	if err != nil {
 		return ocrtypes.ContractConfig{}, err
 	}
+	if len(lgs) == 0 {
+		return ocrtypes.ContractConfig{}, errors.New("no logs found")
+	}
 	latestConfigSet, err := configFromLog(lgs[len(lgs)-1].Data, cp.pluginType)
 	if err != nil {
 		return ocrtypes.ContractConfig{}, err

--- a/core/services/relay/evm/functions/config_poller_test.go
+++ b/core/services/relay/evm/functions/config_poller_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/smartcontractkit/libocr/bigbigendian"
+
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/core"
@@ -89,6 +91,8 @@ func runTest(t *testing.T, pluginType functions.FunctionsPluginType, expectedDig
 	_, config, err := configPoller.LatestConfigDetails(testutils.Context(t))
 	require.NoError(t, err)
 	require.Equal(t, ocrtypes2.ConfigDigest{}, config)
+	_, err = configPoller.LatestConfig(testutils.Context(t), 0)
+	require.Error(t, err)
 
 	pluginConfig := &functionsConfig.ReportingPluginConfigWrapper{
 		Config: &functionsConfig.ReportingPluginConfig{
@@ -184,7 +188,7 @@ func setFunctionsConfig(t *testing.T, pluginConfig *functionsConfig.ReportingPlu
 		50*time.Millisecond,
 		50*time.Millisecond,
 		1, // faults
-		nil,
+		generateDefaultOCR2OnchainConfig(t, big.NewInt(0), big.NewInt(10)),
 	)
 
 	require.NoError(t, err)
@@ -202,4 +206,28 @@ func setFunctionsConfig(t *testing.T, pluginConfig *functionsConfig.ReportingPlu
 		OffchainConfigVersion: offchainConfigVersion,
 		OffchainConfig:        offchainConfig,
 	}
+}
+
+func generateDefaultOCR2OnchainConfig(t *testing.T, minValue *big.Int, maxValue *big.Int) []byte {
+	var serializedConfig []byte
+
+	s1, err := bigbigendian.SerializeSigned(1, big.NewInt(1)) //version
+	if err != nil {
+		t.Fatal(err)
+	}
+	serializedConfig = append(serializedConfig, s1...)
+
+	s2, err := bigbigendian.SerializeSigned(24, minValue) //min
+	if err != nil {
+		t.Fatal(err)
+	}
+	serializedConfig = append(serializedConfig, s2...)
+
+	s3, err := bigbigendian.SerializeSigned(24, maxValue) //max
+	if err != nil {
+		t.Fatal(err)
+	}
+	serializedConfig = append(serializedConfig, s3...)
+
+	return serializedConfig
 }

--- a/core/services/relay/evm/ocr2keeper.go
+++ b/core/services/relay/evm/ocr2keeper.go
@@ -147,8 +147,11 @@ func newOCR2KeeperConfigProvider(lggr logger.Logger, chain evm.Chain, rargs rela
 
 	configPoller, err := NewConfigPoller(
 		lggr.With("contractID", rargs.ContractID),
+		chain.Client(),
 		chain.LogPoller(),
 		contractAddress,
+		// TODO: Does ocr2keeper need to support config contract? DF-19182
+		nil,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create config poller")

--- a/core/services/relay/evm/ocr2vrf.go
+++ b/core/services/relay/evm/ocr2vrf.go
@@ -135,8 +135,12 @@ func newOCR2VRFConfigProvider(lggr logger.Logger, chain evm.Chain, rargs relayty
 	}
 	configPoller, err := NewConfigPoller(
 		lggr.With("contractID", rargs.ContractID),
+		chain.Client(),
 		chain.LogPoller(),
-		contractAddress)
+		contractAddress,
+		// TODO: Does ocr2vrf need to support config contract? DF-19182
+		nil,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/relay/evm/types/types.go
+++ b/core/services/relay/evm/types/types.go
@@ -20,9 +20,10 @@ import (
 )
 
 type RelayConfig struct {
-	ChainID                *utils.Big  `json:"chainID"`
-	FromBlock              uint64      `json:"fromBlock"`
-	EffectiveTransmitterID null.String `json:"effectiveTransmitterID"`
+	ChainID                *utils.Big      `json:"chainID"`
+	FromBlock              uint64          `json:"fromBlock"`
+	EffectiveTransmitterID null.String     `json:"effectiveTransmitterID"`
+	ConfigContractAddress  *common.Address `json:"configContractAddress"`
 
 	// Contract-specific
 	SendingKeys pq.StringArray `json:"sendingKeys"`

--- a/go.mod
+++ b/go.mod
@@ -70,8 +70,8 @@ require (
 	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230908162043-e2f9fcf758d8
 	github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230831134610-680240b97aca
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.1-beta-test.0.20230901115736-bbabe542a918
-	github.com/smartcontractkit/libocr v0.0.0-20230918212407-dbd4e505b3e6
-	github.com/smartcontractkit/ocr2keepers v0.7.26
+	github.com/smartcontractkit/libocr v0.0.0-20230922131214-122accb19ea6
+	github.com/smartcontractkit/ocr2keepers v0.7.27
 	github.com/smartcontractkit/ocr2vrf v0.0.0-20230804151440-2f1eb1e20687
 	github.com/smartcontractkit/sqlx v1.3.5-0.20210805004948-4be295aacbeb
 	github.com/smartcontractkit/tdh2/go/ocr2/decryptionplugin v0.0.0-20230906073235-9e478e5e19f1

--- a/go.sum
+++ b/go.sum
@@ -1387,10 +1387,10 @@ github.com/smartcontractkit/go-plugin v0.0.0-20230605132010-0f4d515d1472 h1:x3kN
 github.com/smartcontractkit/go-plugin v0.0.0-20230605132010-0f4d515d1472/go.mod h1:6/1TEzT0eQznvI/gV2CM29DLSkAK/e58mUWKVsPaph0=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f h1:hgJif132UCdjo8u43i7iPN1/MFnu49hv7lFGFftCHKU=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f/go.mod h1:MvMXoufZAtqExNexqi4cjrNYE9MefKddKylxjS+//n0=
-github.com/smartcontractkit/libocr v0.0.0-20230918212407-dbd4e505b3e6 h1:w+8TI2Vcm3vk8XQz40ddcwy9BNZgoakXIby35Y54iDU=
-github.com/smartcontractkit/libocr v0.0.0-20230918212407-dbd4e505b3e6/go.mod h1:2lyRkw/qLQgUWlrWWmq5nj0y90rWeO6Y+v+fCakRgb0=
-github.com/smartcontractkit/ocr2keepers v0.7.26 h1:8Usfdsa6GtliMQPThL1qb36d4J5xMyTCFJYgbGp4ecA=
-github.com/smartcontractkit/ocr2keepers v0.7.26/go.mod h1:4e1ZDRz7fpLgcRUjJpq+5mkoD0ga11BxrSp2JTWKADQ=
+github.com/smartcontractkit/libocr v0.0.0-20230922131214-122accb19ea6 h1:eSo9r53fARv2MnIO5pqYvQOXMBsTlAwhHyQ6BAVp6bY=
+github.com/smartcontractkit/libocr v0.0.0-20230922131214-122accb19ea6/go.mod h1:2lyRkw/qLQgUWlrWWmq5nj0y90rWeO6Y+v+fCakRgb0=
+github.com/smartcontractkit/ocr2keepers v0.7.27 h1:kwqMrzmEdq6gH4yqNuLQCbdlED0KaIjwZzu3FF+Gves=
+github.com/smartcontractkit/ocr2keepers v0.7.27/go.mod h1:1QGzJURnoWpysguPowOe2bshV0hNp1YX10HHlhDEsas=
 github.com/smartcontractkit/ocr2vrf v0.0.0-20230804151440-2f1eb1e20687 h1:NwC3SOc25noBTe1KUQjt45fyTIuInhoE2UfgcHAdihM=
 github.com/smartcontractkit/ocr2vrf v0.0.0-20230804151440-2f1eb1e20687/go.mod h1:YYZq52t4wcHoMQeITksYsorD+tZcOyuVU5+lvot3VFM=
 github.com/smartcontractkit/sqlx v1.3.5-0.20210805004948-4be295aacbeb h1:OMaBUb4X9IFPLbGbCHsMU+kw/BPCrewaVwWGIBc0I4A=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -22,8 +22,8 @@ require (
 	github.com/smartcontractkit/chainlink-env v0.36.0
 	github.com/smartcontractkit/chainlink-testing-framework v1.16.5-0.20230908202859-e75102cf5f40
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
-	github.com/smartcontractkit/libocr v0.0.0-20230918212407-dbd4e505b3e6
-	github.com/smartcontractkit/ocr2keepers v0.7.26
+	github.com/smartcontractkit/libocr v0.0.0-20230922131214-122accb19ea6
+	github.com/smartcontractkit/ocr2keepers v0.7.27
 	github.com/smartcontractkit/ocr2vrf v0.0.0-20230804151440-2f1eb1e20687
 	github.com/smartcontractkit/tdh2/go/tdh2 v0.0.0-20230906073235-9e478e5e19f1
 	github.com/smartcontractkit/wasp v0.3.0

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -2264,10 +2264,10 @@ github.com/smartcontractkit/go-plugin v0.0.0-20230605132010-0f4d515d1472 h1:x3kN
 github.com/smartcontractkit/go-plugin v0.0.0-20230605132010-0f4d515d1472/go.mod h1:6/1TEzT0eQznvI/gV2CM29DLSkAK/e58mUWKVsPaph0=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f h1:hgJif132UCdjo8u43i7iPN1/MFnu49hv7lFGFftCHKU=
 github.com/smartcontractkit/grpc-proxy v0.0.0-20230731113816-f1be6620749f/go.mod h1:MvMXoufZAtqExNexqi4cjrNYE9MefKddKylxjS+//n0=
-github.com/smartcontractkit/libocr v0.0.0-20230918212407-dbd4e505b3e6 h1:w+8TI2Vcm3vk8XQz40ddcwy9BNZgoakXIby35Y54iDU=
-github.com/smartcontractkit/libocr v0.0.0-20230918212407-dbd4e505b3e6/go.mod h1:2lyRkw/qLQgUWlrWWmq5nj0y90rWeO6Y+v+fCakRgb0=
-github.com/smartcontractkit/ocr2keepers v0.7.26 h1:8Usfdsa6GtliMQPThL1qb36d4J5xMyTCFJYgbGp4ecA=
-github.com/smartcontractkit/ocr2keepers v0.7.26/go.mod h1:4e1ZDRz7fpLgcRUjJpq+5mkoD0ga11BxrSp2JTWKADQ=
+github.com/smartcontractkit/libocr v0.0.0-20230922131214-122accb19ea6 h1:eSo9r53fARv2MnIO5pqYvQOXMBsTlAwhHyQ6BAVp6bY=
+github.com/smartcontractkit/libocr v0.0.0-20230922131214-122accb19ea6/go.mod h1:2lyRkw/qLQgUWlrWWmq5nj0y90rWeO6Y+v+fCakRgb0=
+github.com/smartcontractkit/ocr2keepers v0.7.27 h1:kwqMrzmEdq6gH4yqNuLQCbdlED0KaIjwZzu3FF+Gves=
+github.com/smartcontractkit/ocr2keepers v0.7.27/go.mod h1:1QGzJURnoWpysguPowOe2bshV0hNp1YX10HHlhDEsas=
 github.com/smartcontractkit/ocr2vrf v0.0.0-20230804151440-2f1eb1e20687 h1:NwC3SOc25noBTe1KUQjt45fyTIuInhoE2UfgcHAdihM=
 github.com/smartcontractkit/ocr2vrf v0.0.0-20230804151440-2f1eb1e20687/go.mod h1:YYZq52t4wcHoMQeITksYsorD+tZcOyuVU5+lvot3VFM=
 github.com/smartcontractkit/sqlx v1.3.5-0.20210805004948-4be295aacbeb h1:OMaBUb4X9IFPLbGbCHsMU+kw/BPCrewaVwWGIBc0I4A=


### PR DESCRIPTION
updating libocr and ocr2keepers on automation release branch

ports https://github.com/smartcontractkit/chainlink/pull/9846/files and  https://github.com/smartcontractkit/chainlink/pull/10779 from develop which includes some fixes for tests to pass 

All file changes apart from go.mod are copy pasted from develop
