### PR TITLE
[TT-607] Update test usage of default ocr2 onchain config

### DIFF
--- a/core/internal/features/ocr2/features_ocr2_test.go
+++ b/core/internal/features/ocr2/features_ocr2_test.go
@@ -28,7 +28,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/exp/maps"
 
-	"github.com/smartcontractkit/libocr/bigbigendian"
 	testoffchainaggregator2 "github.com/smartcontractkit/libocr/gethwrappers2/testocr2aggregator"
 	confighelper2 "github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
 	ocrtypes2 "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
@@ -45,6 +44,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ocr2key"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/p2pkey"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/testhelpers"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/validate"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocrbootstrap"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
@@ -252,7 +252,8 @@ func TestIntegration_OCR2(t *testing.T) {
 	maxAnswer.Exp(big.NewInt(2), big.NewInt(191), nil)
 	maxAnswer.Sub(maxAnswer, big.NewInt(1))
 
-	onchainConfig := generateDefaultOCR2OnchainConfig(t, minAnswer, maxAnswer)
+	onchainConfig, err := testhelpers.GenerateDefaultOCR2OnchainConfig(minAnswer, maxAnswer)
+	require.NoError(t, err)
 	lggr.Debugw("Setting Config on Oracle Contract",
 		"signers", signers,
 		"transmitters", transmitters,
@@ -527,7 +528,8 @@ func TestIntegration_OCR2_ForwarderFlow(t *testing.T) {
 	maxAnswer.Exp(big.NewInt(2), big.NewInt(191), nil)
 	maxAnswer.Sub(maxAnswer, big.NewInt(1))
 
-	onchainConfig := generateDefaultOCR2OnchainConfig(t, minAnswer, maxAnswer)
+	onchainConfig, err := testhelpers.GenerateDefaultOCR2OnchainConfig(minAnswer, maxAnswer)
+	require.NoError(t, err)
 
 	lggr.Debugw("Setting Config on Oracle Contract",
 		"signers", signers,
@@ -736,30 +738,6 @@ juelsPerFeeCoinSource = """
 	digestAndEpoch, err := ocrContract.LatestConfigDigestAndEpoch(nil)
 	require.NoError(t, err)
 	assert.Equal(t, digestAndEpoch.Epoch, epoch)
-}
-
-func generateDefaultOCR2OnchainConfig(t *testing.T, minValue *big.Int, maxValue *big.Int) []byte {
-	serializedConfig := make([]byte, 0)
-
-	s1, err := bigbigendian.SerializeSigned(1, big.NewInt(1)) //version
-	if err != nil {
-		t.Fatal(err)
-	}
-	serializedConfig = append(serializedConfig, s1...)
-
-	s2, err := bigbigendian.SerializeSigned(24, minValue) //min
-	if err != nil {
-		t.Fatal(err)
-	}
-	serializedConfig = append(serializedConfig, s2...)
-
-	s3, err := bigbigendian.SerializeSigned(24, maxValue) //max
-	if err != nil {
-		t.Fatal(err)
-	}
-	serializedConfig = append(serializedConfig, s3...)
-
-	return serializedConfig
 }
 
 func ptr[T any](v T) *T { return &v }

--- a/core/services/ocr2/testhelpers/onchain_config.go
+++ b/core/services/ocr2/testhelpers/onchain_config.go
@@ -1,0 +1,31 @@
+package testhelpers
+
+import (
+	"math/big"
+
+	"github.com/smartcontractkit/libocr/bigbigendian"
+)
+
+func GenerateDefaultOCR2OnchainConfig(minValue *big.Int, maxValue *big.Int) ([]byte, error) {
+	serializedConfig := make([]byte, 0)
+
+	s1, err := bigbigendian.SerializeSigned(1, big.NewInt(1)) //version
+	if err != nil {
+		return nil, err
+	}
+	serializedConfig = append(serializedConfig, s1...)
+
+	s2, err := bigbigendian.SerializeSigned(24, minValue) //min
+	if err != nil {
+		return nil, err
+	}
+	serializedConfig = append(serializedConfig, s2...)
+
+	s3, err := bigbigendian.SerializeSigned(24, maxValue) //max
+	if err != nil {
+		return nil, err
+	}
+	serializedConfig = append(serializedConfig, s3...)
+
+	return serializedConfig, nil
+}

--- a/core/services/relay/evm/functions/config_poller_test.go
+++ b/core/services/relay/evm/functions/config_poller_test.go
@@ -6,8 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/libocr/bigbigendian"
-
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/accounts/abi/bind/backends"
 	"github.com/ethereum/go-ethereum/core"
@@ -23,6 +21,7 @@ import (
 	ocrtypes2 "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
 	functionsConfig "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/functions/config"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/testhelpers"
 
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
@@ -172,6 +171,9 @@ func setFunctionsConfig(t *testing.T, pluginConfig *functionsConfig.ReportingPlu
 	pluginConfigBytes, err := functionsConfig.EncodeReportingPluginConfig(pluginConfig)
 	require.NoError(t, err)
 
+	onchainConfig, err := testhelpers.GenerateDefaultOCR2OnchainConfig(big.NewInt(0), big.NewInt(10))
+	require.NoError(t, err)
+
 	signers, transmitters, threshold, onchainConfig, offchainConfigVersion, offchainConfig, err := confighelper2.ContractSetConfigArgsForTests(
 		2*time.Second,        // deltaProgress
 		1*time.Second,        // deltaResend
@@ -188,7 +190,7 @@ func setFunctionsConfig(t *testing.T, pluginConfig *functionsConfig.ReportingPlu
 		50*time.Millisecond,
 		50*time.Millisecond,
 		1, // faults
-		generateDefaultOCR2OnchainConfig(t, big.NewInt(0), big.NewInt(10)),
+		onchainConfig,
 	)
 
 	require.NoError(t, err)
@@ -206,28 +208,4 @@ func setFunctionsConfig(t *testing.T, pluginConfig *functionsConfig.ReportingPlu
 		OffchainConfigVersion: offchainConfigVersion,
 		OffchainConfig:        offchainConfig,
 	}
-}
-
-func generateDefaultOCR2OnchainConfig(t *testing.T, minValue *big.Int, maxValue *big.Int) []byte {
-	var serializedConfig []byte
-
-	s1, err := bigbigendian.SerializeSigned(1, big.NewInt(1)) //version
-	if err != nil {
-		t.Fatal(err)
-	}
-	serializedConfig = append(serializedConfig, s1...)
-
-	s2, err := bigbigendian.SerializeSigned(24, minValue) //min
-	if err != nil {
-		t.Fatal(err)
-	}
-	serializedConfig = append(serializedConfig, s2...)
-
-	s3, err := bigbigendian.SerializeSigned(24, maxValue) //max
-	if err != nil {
-		t.Fatal(err)
-	}
-	serializedConfig = append(serializedConfig, s3...)
-
-	return serializedConfig
 }

--- a/integration-tests/actions/ocr2_helpers.go
+++ b/integration-tests/actions/ocr2_helpers.go
@@ -35,12 +35,13 @@ func DeployOCRv2Contracts(
 	contractDeployer contracts.ContractDeployer,
 	transmitters []string,
 	client blockchain.EVMClient,
+	ocrOptions contracts.OffchainOptions,
 ) ([]contracts.OffchainAggregatorV2, error) {
 	var ocrInstances []contracts.OffchainAggregatorV2
 	for contractCount := 0; contractCount < numberOfContracts; contractCount++ {
 		ocrInstance, err := contractDeployer.DeployOffchainAggregatorV2(
 			linkTokenContract.Address(),
-			contracts.DefaultOffChainAggregatorOptions(),
+			ocrOptions,
 		)
 		if err != nil {
 			return nil, fmt.Errorf("OCRv2 instance deployment have failed: %w", err)

--- a/integration-tests/smoke/forwarders_ocr2_test.go
+++ b/integration-tests/smoke/forwarders_ocr2_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/logging"
 
 	"github.com/smartcontractkit/chainlink/integration-tests/actions"
+	"github.com/smartcontractkit/chainlink/integration-tests/contracts"
 	"github.com/smartcontractkit/chainlink/integration-tests/docker/test_env"
 	"github.com/smartcontractkit/chainlink/integration-tests/types/config/node"
 )
@@ -73,7 +74,8 @@ func TestForwarderOCR2Basic(t *testing.T) {
 		transmitters = append(transmitters, forwarderCommonAddress.Hex())
 	}
 
-	ocrInstances, err := actions.DeployOCRv2Contracts(1, linkTokenContract, env.ContractDeployer, transmitters, env.EVMClient)
+	ocrOffchainOptions := contracts.DefaultOffChainAggregatorOptions()
+	ocrInstances, err := actions.DeployOCRv2Contracts(1, linkTokenContract, env.ContractDeployer, transmitters, env.EVMClient, ocrOffchainOptions)
 	require.NoError(t, err, "Error deploying OCRv2 contracts with forwarders")
 	err = env.EVMClient.WaitForEvents()
 	require.NoError(t, err, "Error waiting for events")
@@ -83,7 +85,7 @@ func TestForwarderOCR2Basic(t *testing.T) {
 	err = env.EVMClient.WaitForEvents()
 	require.NoError(t, err, "Error waiting for events")
 
-	ocrv2Config, err := actions.BuildMedianOCR2ConfigLocal(workerNodes)
+	ocrv2Config, err := actions.BuildMedianOCR2ConfigLocal(workerNodes, ocrOffchainOptions)
 	require.NoError(t, err, "Error building OCRv2 config")
 	ocrv2Config.Transmitters = authorizedForwarders
 

--- a/integration-tests/smoke/ocr2_test.go
+++ b/integration-tests/smoke/ocr2_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/smartcontractkit/chainlink/integration-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/client"
 	"github.com/smartcontractkit/chainlink/integration-tests/config"
+	"github.com/smartcontractkit/chainlink/integration-tests/contracts"
 	"github.com/smartcontractkit/chainlink/integration-tests/docker/test_env"
 	"github.com/smartcontractkit/chainlink/integration-tests/types/config/node"
 )
@@ -69,13 +70,14 @@ func TestOCRv2Basic(t *testing.T) {
 		transmitters = append(transmitters, addr)
 	}
 
-	aggregatorContracts, err := actions.DeployOCRv2Contracts(1, linkToken, env.ContractDeployer, transmitters, env.EVMClient)
+	ocrOffchainOptions := contracts.DefaultOffChainAggregatorOptions()
+	aggregatorContracts, err := actions.DeployOCRv2Contracts(1, linkToken, env.ContractDeployer, transmitters, env.EVMClient, ocrOffchainOptions)
 	require.NoError(t, err, "Error deploying OCRv2 aggregator contracts")
 
 	err = actions.CreateOCRv2JobsLocal(aggregatorContracts, bootstrapNode, workerNodes, env.MockServer.Client, "ocr2", 5, env.EVMClient.GetChainID().Uint64(), false)
 	require.NoError(t, err, "Error creating OCRv2 jobs")
 
-	ocrv2Config, err := actions.BuildMedianOCR2ConfigLocal(workerNodes)
+	ocrv2Config, err := actions.BuildMedianOCR2ConfigLocal(workerNodes, ocrOffchainOptions)
 	require.NoError(t, err, "Error building OCRv2 config")
 
 	err = actions.ConfigureOCRv2AggregatorContracts(env.EVMClient, ocrv2Config, aggregatorContracts)


### PR DESCRIPTION
- Removes a lot of duplicated code for creating a default config
- Reuses it now in both unit and e2e tests