### PR TITLE
Revert "core/services/chainlink: log warn instead of error if CSA key not available for feeds service (#10543)"

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -421,30 +421,26 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 		}
 	}
 
-	var feedsService feeds.Service = &feeds.NullService{}
+	var feedsService feeds.Service
 	if cfg.Feature().FeedsManager() {
-		if keys, err := opts.KeyStore.CSA().GetAll(); err != nil {
-			globalLogger.Warn("[Feeds Service] Unable to start without CSA key", "err", err)
-		} else if len(keys) == 0 {
-			globalLogger.Warn("[Feeds Service] Unable to start without CSA key")
-		} else {
-			feedsORM := feeds.NewORM(db, opts.Logger, cfg.Database())
-			feedsService = feeds.NewService(
-				feedsORM,
-				jobORM,
-				db,
-				jobSpawner,
-				keyStore,
-				cfg.Insecure(),
-				cfg.JobPipeline(),
-				cfg.OCR(),
-				cfg.OCR2(),
-				cfg.Database(),
-				legacyEVMChains,
-				globalLogger,
-				opts.Version,
-			)
-		}
+		feedsORM := feeds.NewORM(db, opts.Logger, cfg.Database())
+		feedsService = feeds.NewService(
+			feedsORM,
+			jobORM,
+			db,
+			jobSpawner,
+			keyStore,
+			cfg.Insecure(),
+			cfg.JobPipeline(),
+			cfg.OCR(),
+			cfg.OCR2(),
+			cfg.Database(),
+			legacyEVMChains,
+			globalLogger,
+			opts.Version,
+		)
+	} else {
+		feedsService = &feeds.NullService{}
 	}
 
 	for _, s := range srvcs {


### PR DESCRIPTION
This reverts commit 73966ef5dd383aca7e97747d75f6c58a20f84cce (#10543).