### PR TITLE
[BCF-2674] Make BalanceMonitor test deterministic; add WorkDone to *sleeperTask for tests.

### DIFF
--- a/core/chains/evm/monitor/balance.go
+++ b/core/chains/evm/monitor/balance.go
@@ -47,8 +47,10 @@ type (
 	NullBalanceMonitor struct{}
 )
 
+var _ BalanceMonitor = (*balanceMonitor)(nil)
+
 // NewBalanceMonitor returns a new balanceMonitor
-func NewBalanceMonitor(ethClient evmclient.Client, ethKeyStore keystore.Eth, logger logger.Logger) BalanceMonitor {
+func NewBalanceMonitor(ethClient evmclient.Client, ethKeyStore keystore.Eth, logger logger.Logger) *balanceMonitor {
 	chainId := ethClient.ConfiguredChainID()
 	bm := &balanceMonitor{
 		utils.StartStopOnce{},

--- a/core/chains/evm/monitor/balance_helpers_test.go
+++ b/core/chains/evm/monitor/balance_helpers_test.go
@@ -1,0 +1,7 @@
+package monitor
+
+func (bm *balanceMonitor) WorkDone() <-chan struct{} {
+	return bm.sleeperTask.(interface {
+		WorkDone() <-chan struct{}
+	}).WorkDone()
+}

--- a/core/chains/evm/monitor/balance_test.go
+++ b/core/chains/evm/monitor/balance_test.go
@@ -169,12 +169,9 @@ func TestBalanceMonitor_OnNewLongestChain_UpdatesBalance(t *testing.T) {
 		// Do the thing
 		bm.OnNewLongestChain(testutils.Context(t), head)
 
-		gomega.NewWithT(t).Eventually(func() *big.Int {
-			return bm.GetEthBalance(k0Addr).ToInt()
-		}).Should(gomega.Equal(k0bal))
-		gomega.NewWithT(t).Eventually(func() *big.Int {
-			return bm.GetEthBalance(k1Addr).ToInt()
-		}).Should(gomega.Equal(k1bal))
+		<-bm.WorkDone()
+		assert.Equal(t, k0bal, bm.GetEthBalance(k0Addr).ToInt())
+		assert.Equal(t, k1bal, bm.GetEthBalance(k1Addr).ToInt())
 
 		// Do it again
 		k0bal2 := big.NewInt(142)
@@ -187,12 +184,9 @@ func TestBalanceMonitor_OnNewLongestChain_UpdatesBalance(t *testing.T) {
 
 		bm.OnNewLongestChain(testutils.Context(t), head)
 
-		gomega.NewWithT(t).Eventually(func() *big.Int {
-			return bm.GetEthBalance(k0Addr).ToInt()
-		}).Should(gomega.Equal(k0bal2))
-		gomega.NewWithT(t).Eventually(func() *big.Int {
-			return bm.GetEthBalance(k1Addr).ToInt()
-		}).Should(gomega.Equal(k1bal2))
+		<-bm.WorkDone()
+		assert.Equal(t, k0bal2, bm.GetEthBalance(k0Addr).ToInt())
+		assert.Equal(t, k1bal2, bm.GetEthBalance(k1Addr).ToInt())
 	})
 }
 

--- a/core/sessions/reaper.go
+++ b/core/sessions/reaper.go
@@ -13,10 +13,6 @@ type sessionReaper struct {
 	db     *sql.DB
 	config SessionReaperConfig
 	lggr   logger.Logger
-
-	// Receive from this for testing via sr.RunSignal()
-	// to be notified after each reaper run.
-	runSignal chan struct{}
 }
 
 type SessionReaperConfig interface {
@@ -26,18 +22,11 @@ type SessionReaperConfig interface {
 
 // NewSessionReaper creates a reaper that cleans stale sessions from the store.
 func NewSessionReaper(db *sql.DB, config SessionReaperConfig, lggr logger.Logger) utils.SleeperTask {
-	return utils.NewSleeperTask(NewSessionReaperWorker(db, config, lggr))
-}
-
-func NewSessionReaperWorker(db *sql.DB, config SessionReaperConfig, lggr logger.Logger) *sessionReaper {
-	return &sessionReaper{
+	return utils.NewSleeperTask(&sessionReaper{
 		db,
 		config,
 		lggr.Named("SessionReaper"),
-
-		// For testing only.
-		make(chan struct{}, 10),
-	}
+	})
 }
 
 func (sr *sessionReaper) Name() string {
@@ -50,11 +39,6 @@ func (sr *sessionReaper) Work() {
 	err := sr.deleteStaleSessions(recordCreationStaleThreshold)
 	if err != nil {
 		sr.lggr.Error("unable to reap stale sessions: ", err)
-	}
-
-	select {
-	case sr.runSignal <- struct{}{}:
-	default:
 	}
 }
 

--- a/core/sessions/reaper_helper_test.go
+++ b/core/sessions/reaper_helper_test.go
@@ -1,5 +1,0 @@
-package sessions
-
-func (sr *sessionReaper) RunSignal() <-chan struct{} {
-	return sr.runSignal
-}


### PR DESCRIPTION
* Add a test helper, WorkDone(), to the sleeper task interface so that it can be used in tests to assert that the work has been done.
* Refactor the sessions reaper test to use the same mechanism.