### PR TITLE
simplify HealthReport() implementations

### DIFF
--- a/common/headtracker/head_broadcaster.go
+++ b/common/headtracker/head_broadcaster.go
@@ -80,7 +80,7 @@ func (hb *HeadBroadcaster[H, BLOCK_HASH]) Name() string {
 }
 
 func (hb *HeadBroadcaster[H, BLOCK_HASH]) HealthReport() map[string]error {
-	return map[string]error{hb.Name(): hb.StartStopOnce.Healthy()}
+	return map[string]error{hb.Name(): hb.Healthy()}
 }
 
 func (hb *HeadBroadcaster[H, BLOCK_HASH]) BroadcastNewLongestChain(head H) {

--- a/common/headtracker/head_tracker.go
+++ b/common/headtracker/head_tracker.go
@@ -154,9 +154,7 @@ func (ht *HeadTracker[HTH, S, ID, BLOCK_HASH]) Name() string {
 }
 
 func (ht *HeadTracker[HTH, S, ID, BLOCK_HASH]) HealthReport() map[string]error {
-	report := map[string]error{
-		ht.Name(): ht.StartStopOnce.Healthy(),
-	}
+	report := map[string]error{ht.Name(): ht.Healthy()}
 	services.CopyHealth(report, ht.headListener.HealthReport())
 	return report
 }

--- a/common/txmgr/broadcaster.go
+++ b/common/txmgr/broadcaster.go
@@ -270,7 +270,7 @@ func (eb *Broadcaster[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) Name
 }
 
 func (eb *Broadcaster[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) HealthReport() map[string]error {
-	return map[string]error{eb.Name(): eb.StartStopOnce.Healthy()}
+	return map[string]error{eb.Name(): eb.Healthy()}
 }
 
 // Trigger forces the monitor for a particular address to recheck for new txes

--- a/common/txmgr/confirmer.go
+++ b/common/txmgr/confirmer.go
@@ -238,7 +238,7 @@ func (ec *Confirmer[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) Nam
 }
 
 func (ec *Confirmer[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) HealthReport() map[string]error {
-	return map[string]error{ec.Name(): ec.StartStopOnce.Healthy()}
+	return map[string]error{ec.Name(): ec.Healthy()}
 }
 
 func (ec *Confirmer[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) runLoop() {

--- a/common/txmgr/txmgr.go
+++ b/common/txmgr/txmgr.go
@@ -258,7 +258,7 @@ func (b *Txm[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) Name() str
 }
 
 func (b *Txm[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) HealthReport() map[string]error {
-	report := map[string]error{b.Name(): b.StartStopOnce.Healthy()}
+	report := map[string]error{b.Name(): b.Healthy()}
 
 	// only query if txm started properly
 	b.IfStarted(func() {

--- a/core/chains/cosmos/chain.go
+++ b/core/chains/cosmos/chain.go
@@ -18,6 +18,7 @@ import (
 	cosmosclient "github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/client"
 	coscfg "github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/config"
 	"github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/db"
+	"github.com/smartcontractkit/chainlink/v2/core/services"
 
 	"github.com/smartcontractkit/chainlink-relay/pkg/logger"
 	"github.com/smartcontractkit/chainlink-relay/pkg/loop"
@@ -204,11 +205,9 @@ func (c *chain) Ready() error {
 }
 
 func (c *chain) HealthReport() map[string]error {
-	return map[string]error{
-		c.Name(): multierr.Combine(
-			c.StartStopOnce.Healthy(),
-			c.txm.Healthy()),
-	}
+	m := map[string]error{c.Name(): c.Healthy()}
+	services.CopyHealth(m, c.txm.HealthReport())
+	return m
 }
 
 // ChainService interface

--- a/core/chains/evm/chain.go
+++ b/core/chains/evm/chain.go
@@ -376,9 +376,7 @@ func (c *chain) Name() string {
 }
 
 func (c *chain) HealthReport() map[string]error {
-	report := map[string]error{
-		c.Name(): c.StartStopOnce.Healthy(),
-	}
+	report := map[string]error{c.Name(): c.Healthy()}
 	services.CopyHealth(report, c.txm.HealthReport())
 	services.CopyHealth(report, c.headBroadcaster.HealthReport())
 	services.CopyHealth(report, c.headTracker.HealthReport())

--- a/core/chains/evm/forwarders/forwarder_manager.go
+++ b/core/chains/evm/forwarders/forwarder_manager.go
@@ -322,5 +322,5 @@ func (f *FwdMgr) Close() error {
 }
 
 func (f *FwdMgr) HealthReport() map[string]error {
-	return map[string]error{f.Name(): f.StartStopOnce.Healthy()}
+	return map[string]error{f.Name(): f.Healthy()}
 }

--- a/core/chains/evm/gas/arbitrum_estimator.go
+++ b/core/chains/evm/gas/arbitrum_estimator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/assets"
 	evmclient "github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
 
@@ -92,7 +93,9 @@ func (a *arbitrumEstimator) Close() error {
 func (a *arbitrumEstimator) Ready() error { return a.StartStopOnce.Ready() }
 
 func (a *arbitrumEstimator) HealthReport() map[string]error {
-	return map[string]error{a.Name(): a.StartStopOnce.Healthy()}
+	hp := map[string]error{a.Name(): a.Healthy()}
+	services.CopyHealth(hp, a.EvmEstimator.HealthReport())
+	return hp
 }
 
 // GetLegacyGas estimates both the gas price and the gas limit.

--- a/core/chains/evm/gas/block_history_estimator.go
+++ b/core/chains/evm/gas/block_history_estimator.go
@@ -243,7 +243,7 @@ func (b *BlockHistoryEstimator) Name() string {
 	return b.logger.Name()
 }
 func (b *BlockHistoryEstimator) HealthReport() map[string]error {
-	return map[string]error{b.Name(): b.StartStopOnce.Healthy()}
+	return map[string]error{b.Name(): b.Healthy()}
 }
 
 func (b *BlockHistoryEstimator) GetLegacyGas(_ context.Context, _ []byte, gasLimit uint32, maxGasPriceWei *assets.Wei, _ ...feetypes.Opt) (gasPrice *assets.Wei, chainSpecificGasLimit uint32, err error) {

--- a/core/chains/evm/gas/l2_suggested_estimator.go
+++ b/core/chains/evm/gas/l2_suggested_estimator.go
@@ -76,7 +76,7 @@ func (o *l2SuggestedPriceEstimator) Close() error {
 }
 
 func (o *l2SuggestedPriceEstimator) HealthReport() map[string]error {
-	return map[string]error{o.Name(): o.StartStopOnce.Healthy()}
+	return map[string]error{o.Name(): o.Healthy()}
 }
 
 func (o *l2SuggestedPriceEstimator) run() {

--- a/core/chains/evm/gas/models.go
+++ b/core/chains/evm/gas/models.go
@@ -8,6 +8,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/pkg/errors"
+
 	commonfee "github.com/smartcontractkit/chainlink/v2/common/fee"
 	feetypes "github.com/smartcontractkit/chainlink/v2/common/fee/types"
 	commontypes "github.com/smartcontractkit/chainlink/v2/common/types"
@@ -212,7 +213,7 @@ func (e *WrappedEvmEstimator) Ready() error {
 }
 
 func (e *WrappedEvmEstimator) HealthReport() map[string]error {
-	report := map[string]error{e.Name(): e.StartStopOnce.Healthy()}
+	report := map[string]error{e.Name(): e.Healthy()}
 	services.CopyHealth(report, e.EvmEstimator.HealthReport())
 	if e.l1Oracle != nil {
 		services.CopyHealth(report, e.l1Oracle.HealthReport())

--- a/core/chains/evm/gas/rollups/l1_gas_price_oracle.go
+++ b/core/chains/evm/gas/rollups/l1_gas_price_oracle.go
@@ -110,10 +110,8 @@ func (o *l1GasPriceOracle) Close() error {
 	})
 }
 
-func (o *l1GasPriceOracle) Ready() error { return o.StartStopOnce.Ready() }
-
 func (o *l1GasPriceOracle) HealthReport() map[string]error {
-	return map[string]error{o.Name(): o.StartStopOnce.Healthy()}
+	return map[string]error{o.Name(): o.Healthy()}
 }
 
 func (o *l1GasPriceOracle) run() {

--- a/core/chains/evm/log/broadcaster.go
+++ b/core/chains/evm/log/broadcaster.go
@@ -220,7 +220,7 @@ func (b *broadcaster) Name() string {
 }
 
 func (b *broadcaster) HealthReport() map[string]error {
-	return map[string]error{b.Name(): b.StartStopOnce.Healthy()}
+	return map[string]error{b.Name(): b.Healthy()}
 }
 
 func (b *broadcaster) awaitInitialSubscribers() {

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -403,7 +403,7 @@ func (lp *logPoller) Name() string {
 }
 
 func (lp *logPoller) HealthReport() map[string]error {
-	return map[string]error{lp.Name(): lp.StartStopOnce.Healthy()}
+	return map[string]error{lp.Name(): lp.Healthy()}
 }
 
 func (lp *logPoller) GetReplayFromBlock(ctx context.Context, requested int64) (int64, error) {

--- a/core/chains/evm/monitor/balance.go
+++ b/core/chains/evm/monitor/balance.go
@@ -91,7 +91,7 @@ func (bm *balanceMonitor) Name() string {
 }
 
 func (bm *balanceMonitor) HealthReport() map[string]error {
-	return map[string]error{bm.Name(): bm.StartStopOnce.Healthy()}
+	return map[string]error{bm.Name(): bm.Healthy()}
 }
 
 // OnNewLongestChain checks the balance for each key

--- a/core/chains/solana/chain.go
+++ b/core/chains/solana/chain.go
@@ -385,7 +385,7 @@ func (c *chain) Ready() error {
 }
 
 func (c *chain) HealthReport() map[string]error {
-	report := map[string]error{c.Name(): c.StartStopOnce.Healthy()}
+	report := map[string]error{c.Name(): c.Healthy()}
 	services.CopyHealth(report, c.txm.HealthReport())
 	return report
 }

--- a/core/chains/starknet/chain.go
+++ b/core/chains/starknet/chain.go
@@ -162,7 +162,7 @@ func (c *chain) Ready() error {
 }
 
 func (c *chain) HealthReport() map[string]error {
-	report := map[string]error{c.Name(): c.StartStopOnce.Healthy()}
+	report := map[string]error{c.Name(): c.Healthy()}
 	services.CopyHealth(report, c.txm.HealthReport())
 	return report
 }

--- a/core/services/job/spawner.go
+++ b/core/services/job/spawner.go
@@ -123,7 +123,7 @@ func (js *spawner) Name() string {
 }
 
 func (js *spawner) HealthReport() map[string]error {
-	return map[string]error{js.Name(): js.StartStopOnce.Healthy()}
+	return map[string]error{js.Name(): js.Healthy()}
 }
 
 func (js *spawner) startAllServices(ctx context.Context) {

--- a/core/services/relay/evm/mercury/transmitter.go
+++ b/core/services/relay/evm/mercury/transmitter.go
@@ -183,12 +183,10 @@ func (mt *mercuryTransmitter) Close() error {
 	})
 }
 
-func (mt *mercuryTransmitter) Ready() error { return mt.StartStopOnce.Ready() }
-
 func (mt *mercuryTransmitter) Name() string { return mt.lggr.Name() }
 
 func (mt *mercuryTransmitter) HealthReport() map[string]error {
-	report := map[string]error{mt.Name(): mt.StartStopOnce.Healthy()}
+	report := map[string]error{mt.Name(): mt.Healthy()}
 	services.CopyHealth(report, mt.rpcClient.HealthReport())
 	services.CopyHealth(report, mt.queue.HealthReport())
 	return report

--- a/core/services/synchronization/telemetry_ingress_batch_client.go
+++ b/core/services/synchronization/telemetry_ingress_batch_client.go
@@ -40,7 +40,6 @@ func (NoopTelemetryIngressBatchClient) Close() error { return nil }
 // Send is a no-op
 func (NoopTelemetryIngressBatchClient) Send(TelemPayload) {}
 
-// Healthy is a no-op
 func (NoopTelemetryIngressBatchClient) HealthReport() map[string]error { return map[string]error{} }
 func (NoopTelemetryIngressBatchClient) Name() string                   { return "NoopTelemetryIngressBatchClient" }
 
@@ -163,7 +162,7 @@ func (tc *telemetryIngressBatchClient) Name() string {
 }
 
 func (tc *telemetryIngressBatchClient) HealthReport() map[string]error {
-	return map[string]error{tc.Name(): tc.StartStopOnce.Healthy()}
+	return map[string]error{tc.Name(): tc.Healthy()}
 }
 
 // getCSAPrivateKey gets the client's CSA private key

--- a/core/services/synchronization/telemetry_ingress_client.go
+++ b/core/services/synchronization/telemetry_ingress_client.go
@@ -111,7 +111,7 @@ func (tc *telemetryIngressClient) Name() string {
 }
 
 func (tc *telemetryIngressClient) HealthReport() map[string]error {
-	return map[string]error{tc.Name(): tc.StartStopOnce.Healthy()}
+	return map[string]error{tc.Name(): tc.Healthy()}
 }
 
 func (tc *telemetryIngressClient) connect(ctx context.Context, clientPrivKey []byte) {

--- a/core/utils/mailbox_prom.go
+++ b/core/utils/mailbox_prom.go
@@ -58,7 +58,7 @@ func (m *MailboxMonitor) Close() error {
 }
 
 func (m *MailboxMonitor) HealthReport() map[string]error {
-	return map[string]error{m.Name(): m.StartStopOnce.Healthy()}
+	return map[string]error{m.Name(): m.Healthy()}
 }
 
 func (m *MailboxMonitor) monitorLoop(ctx context.Context, c <-chan time.Time) {


### PR DESCRIPTION
Simplify/align many implementations of `HealthReport()`, fix `cosmos/chain.chain` and `evm/gas.arbitrumEstimator`, which were not chaining properly.