### PR TITLE
.github/workflows: print *.race files

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -100,11 +100,14 @@ jobs:
           USE_TEE: false
         run: ./tools/bin/${{ matrix.cmd }} ./...
       - name: Print Filtered Test Results
-        if: failure()
+        if: ${{ failure() && matrix.cmd == 'go_core_tests' }}
         uses: smartcontractkit/chainlink-github-actions/go/go-test-results-parsing@eccde1970eca69f079d3efb3409938a72ade8497 # v2.2.13
         with:
           results-file: ./output.txt
           output-file: ./output-short.txt
+      - name: Print Races
+        if: ${{ failure() && matrix.cmd == 'go_core_race_tests' }}
+        run: find *.race | xargs cat
       - name: Store logs artifacts
         if: always()
         uses: actions/upload-artifact@3cea5372237819ed00197afe530f5a7ea3e805c8 # v3.1.0


### PR DESCRIPTION
Test artifacts are sometimes > 2.5GBs, so downloading the whole thing just to view tiny *.race results is a burden. This PR adds a step to print them, and disables normal log printing for race runs as well.