### PR TITLE
Always wait for doCheck to complete before returning

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/registry_check_pipeline.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/registry_check_pipeline.go
@@ -41,7 +41,10 @@ func (r *EvmRegistry) CheckUpkeeps(ctx context.Context, keys ...ocr2keepers.Upke
 	}
 
 	chResult := make(chan checkResult, 1)
-	go r.doCheck(ctx, keys, chResult)
+
+	r.threadCtrl.Go(func(ctx context.Context) {
+		r.doCheck(ctx, keys, chResult)
+	})
 
 	select {
 	case rs := <-chResult:

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
@@ -150,10 +150,13 @@ func (r *EvmRegistry) streamsLookup(ctx context.Context, checkResults []ocr2keep
 
 	var wg sync.WaitGroup
 
-	for i, lookup := range lookups {
-		wg.Add(1)
-		go r.doLookup(ctx, &wg, lookup, i, checkResults, lggr)
-	}
+	wg.Add(len(lookups))
+
+	r.threadCtrl.Go(func(ctx context.Context) {
+		for i, lookup := range lookups {
+			r.doLookup(ctx, &wg, lookup, i, checkResults, lggr)
+		}
+	})
 
 	wg.Wait()
 

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
@@ -151,10 +151,10 @@ func (r *EvmRegistry) streamsLookup(ctx context.Context, checkResults []ocr2keep
 	var wg sync.WaitGroup
 
 	for i, lookup := range lookups {
-		idx := i
+		i := i
 		wg.Add(1)
 		r.threadCtrl.Go(func(ctx context.Context) {
-			r.doLookup(ctx, &wg, lookup, idx, checkResults, lggr)
+			r.doLookup(ctx, &wg, lookup, i, checkResults, lggr)
 		})
 	}
 

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
@@ -152,9 +152,7 @@ func (r *EvmRegistry) streamsLookup(ctx context.Context, checkResults []ocr2keep
 
 	for i, lookup := range lookups {
 		wg.Add(1)
-		r.threadCtrl.Go(func(ctx context.Context) {
-			r.doLookup(ctx, &wg, lookup, i, checkResults, lggr)
-		})
+		go r.doLookup(ctx, &wg, lookup, i, checkResults, lggr)
 	}
 
 	wg.Wait()

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
@@ -150,13 +150,13 @@ func (r *EvmRegistry) streamsLookup(ctx context.Context, checkResults []ocr2keep
 
 	var wg sync.WaitGroup
 
-	wg.Add(len(lookups))
-
-	r.threadCtrl.Go(func(ctx context.Context) {
-		for i, lookup := range lookups {
-			r.doLookup(ctx, &wg, lookup, i, checkResults, lggr)
-		}
-	})
+	for i, lookup := range lookups {
+		idx := i
+		wg.Add(1)
+		r.threadCtrl.Go(func(ctx context.Context) {
+			r.doLookup(ctx, &wg, lookup, idx, checkResults, lggr)
+		})
+	}
 
 	wg.Wait()
 

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
@@ -149,10 +149,14 @@ func (r *EvmRegistry) streamsLookup(ctx context.Context, checkResults []ocr2keep
 	}
 
 	var wg sync.WaitGroup
+
 	for i, lookup := range lookups {
 		wg.Add(1)
-		go r.doLookup(ctx, &wg, lookup, i, checkResults, lggr)
+		r.threadCtrl.Go(func(ctx context.Context) {
+			r.doLookup(ctx, &wg, lookup, i, checkResults, lggr)
+		})
 	}
+
 	wg.Wait()
 
 	// don't surface error to plugin bc StreamsLookup process should be self-contained.
@@ -289,14 +293,19 @@ func (r *EvmRegistry) doMercuryRequest(ctx context.Context, sl *StreamsLookup, p
 	if sl.FeedParamKey == feedIdHex && sl.TimeParamKey == blockNumber {
 		// only mercury v0.2
 		for i := range sl.Feeds {
-			go r.singleFeedRequest(ctx, ch, i, sl, lggr)
+			i := i
+			r.threadCtrl.Go(func(ctx context.Context) {
+				r.singleFeedRequest(ctx, ch, i, sl, lggr)
+			})
 		}
 	} else if sl.FeedParamKey == feedIDs {
 		// only mercury v0.3
 		resultLen = 1
 		isMercuryV03 = true
 		ch = make(chan MercuryData, resultLen)
-		go r.multiFeedsRequest(ctx, ch, sl, lggr)
+		r.threadCtrl.Go(func(ctx context.Context) {
+			r.multiFeedsRequest(ctx, ch, sl, lggr)
+		})
 	} else {
 		return encoding.NoPipelineError, encoding.UpkeepFailureReasonInvalidRevertDataInput, [][]byte{}, false, 0 * time.Second, fmt.Errorf("invalid revert data input: feed param key %s, time param key %s, feeds %s", sl.FeedParamKey, sl.TimeParamKey, sl.Feeds)
 	}


### PR DESCRIPTION
AUTO-6343

We received a notification that some of our tests were flaking in CI: https://chainlink-core.slack.com/archives/C02UPK655SN/p1696419424628789

It seemed to be the case that, in our tests, we were encountering a panic because the test logger was being written to by our application code, after our test had finished.

In our application code, we run doCheck asynchronously, then wait for the result channel to receive a value, or for the parent context to be cancelled. 

I think this particular flake is caused by the cancellation of the context while `doCheck` is still executing. When the context is cancelled, we return, which subsequently allows the test to execute until completion. However, it's possible that `doCheck` is still running in the background, and writing to the test logger.

This change uses a wait group to wait for doCheck to complete, even when the parent context is cancelled. It feels like an inappropriate solution given that we seem to anticipate context cancellations in our code, but the problem is that doCheck and its child functions do not check for context cancellations, so the simpler solution is to instead wait for doCheck to finish execution before returning. 