### PR TITLE
core/internal/cltest: refactor MustInsertRandomKey* for type safety

### DIFF
--- a/core/chains/evm/log/orm_test.go
+++ b/core/chains/evm/log/orm_test.go
@@ -26,7 +26,7 @@ func TestORM_broadcasts(t *testing.T) {
 
 	orm := log.NewORM(db, lggr, cfg.Database(), cltest.FixtureChainID)
 
-	_, addr := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+	_, addr := cltest.MustInsertRandomKey(t, ethKeyStore)
 	specV2 := cltest.MustInsertV2JobSpec(t, db, addr)
 
 	const selectQuery = `SELECT consumed FROM log_broadcasts
@@ -165,10 +165,10 @@ func TestORM_MarkUnconsumed(t *testing.T) {
 
 	orm := log.NewORM(db, lggr, cfg.Database(), cltest.FixtureChainID)
 
-	_, addr1 := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+	_, addr1 := cltest.MustInsertRandomKey(t, ethKeyStore)
 	job1 := cltest.MustInsertV2JobSpec(t, db, addr1)
 
-	_, addr2 := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+	_, addr2 := cltest.MustInsertRandomKey(t, ethKeyStore)
 	job2 := cltest.MustInsertV2JobSpec(t, db, addr2)
 
 	logBefore := cltest.RandomLog(t)

--- a/core/chains/evm/monitor/balance_test.go
+++ b/core/chains/evm/monitor/balance_test.go
@@ -40,8 +40,8 @@ func TestBalanceMonitor_Start(t *testing.T) {
 		db := pgtest.NewSqlxDB(t)
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 		ethClient := newEthClientMock(t)
-		_, k0Addr := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
-		_, k1Addr := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+		_, k1Addr := cltest.MustInsertRandomKey(t, ethKeyStore)
+		_, k0Addr := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 		bm := monitor.NewBalanceMonitor(ethClient, ethKeyStore, logger.TestLogger(t))
 		defer func() { assert.NoError(t, bm.Close()) }()
@@ -69,7 +69,7 @@ func TestBalanceMonitor_Start(t *testing.T) {
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 		ethClient := newEthClientMock(t)
 
-		_, k0Addr := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+		_, k0Addr := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 		bm := monitor.NewBalanceMonitor(ethClient, ethKeyStore, logger.TestLogger(t))
 		defer func() { assert.NoError(t, bm.Close()) }()
@@ -89,7 +89,7 @@ func TestBalanceMonitor_Start(t *testing.T) {
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 		ethClient := newEthClientMock(t)
 
-		_, k0Addr := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+		_, k0Addr := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 		bm := monitor.NewBalanceMonitor(ethClient, ethKeyStore, logger.TestLogger(t))
 		defer func() { assert.NoError(t, bm.Close()) }()
@@ -119,7 +119,7 @@ func TestBalanceMonitor_Start(t *testing.T) {
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 		ethClient := newEthClientMock(t)
 
-		_, k0Addr := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+		_, k0Addr := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 		bm := monitor.NewBalanceMonitor(ethClient, ethKeyStore, logger.TestLogger(t))
 		defer func() { assert.NoError(t, bm.Close()) }()
@@ -146,8 +146,8 @@ func TestBalanceMonitor_OnNewLongestChain_UpdatesBalance(t *testing.T) {
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 		ethClient := newEthClientMock(t)
 
-		_, k0Addr := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
-		_, k1Addr := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+		_, k0Addr := cltest.MustInsertRandomKey(t, ethKeyStore)
+		_, k1Addr := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 		bm := monitor.NewBalanceMonitor(ethClient, ethKeyStore, logger.TestLogger(t))
 		k0bal := big.NewInt(42)
@@ -197,7 +197,7 @@ func TestBalanceMonitor_FewerRPCCallsWhenBehind(t *testing.T) {
 	cfg := configtest.NewGeneralConfig(t, nil)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+	cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	ethClient := newEthClientMock(t)
 

--- a/core/chains/evm/txmgr/broadcaster_test.go
+++ b/core/chains/evm/txmgr/broadcaster_test.go
@@ -89,7 +89,7 @@ func TestEthBroadcaster_Lifecycle(t *testing.T) {
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 	estimator := gasmocks.NewEvmFeeEstimator(t)
 	txBuilder := txmgr.NewEvmTxAttemptBuilder(*ethClient.ConfiguredChainID(), evmcfg.EVM().GasEstimator(), ethKeyStore, estimator)
 
@@ -145,7 +145,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Success(t *testing.T) {
 	cfg := configtest.NewTestGeneralConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
@@ -170,7 +170,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Success(t *testing.T) {
 	})
 
 	t.Run("eth_txes exist for a different from address", func(t *testing.T) {
-		_, otherAddress := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+		_, otherAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 		cltest.MustCreateUnstartedTx(t, txStore, otherAddress, toAddress, encodedPayload, gasLimit, value, &cltest.FixtureChainID)
 		retryable, err := eb.ProcessUnstartedTxs(testutils.Context(t), fromAddress)
 		assert.NoError(t, err)
@@ -493,7 +493,7 @@ func TestEthBroadcaster_TransmitChecking(t *testing.T) {
 	cfg := configtest.NewTestGeneralConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
@@ -578,7 +578,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_OptimisticLockingOnEthTx(t *testi
 	evmcfg := txmgr.NewEvmTxmConfig(ccfg.EVM())
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 	estimator := gasmocks.NewEvmFeeEstimator(t)
 	txBuilder := txmgr.NewEvmTxAttemptBuilder(*ethClient.ConfiguredChainID(), ccfg.EVM().GasEstimator(), ethKeyStore, estimator)
 
@@ -640,7 +640,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Success_WithMultiplier(t *testing
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 
@@ -687,7 +687,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 		txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, nextNonce)
+		_, fromAddress := cltest.RandomKey{Nonce: nextNonce.Int64()}.MustInsertWithState(t, ethKeyStore)
 
 		firstInProgress := txmgr.Tx{
 			FromAddress:    fromAddress,
@@ -722,7 +722,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 		txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, nextNonce)
+		_, fromAddress := cltest.RandomKey{Nonce: nextNonce.Int64()}.MustInsertWithState(t, ethKeyStore)
 
 		ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -760,7 +760,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 		txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, nextNonce)
+		_, fromAddress := cltest.RandomKey{Nonce: nextNonce.Int64()}.MustInsertWithState(t, ethKeyStore)
 
 		ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -798,7 +798,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 		txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, nextNonce)
+		_, fromAddress := cltest.RandomKey{Nonce: nextNonce.Int64()}.MustInsertWithState(t, ethKeyStore)
 
 		ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -835,7 +835,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 		txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, nextNonce)
+		_, fromAddress := cltest.RandomKey{Nonce: nextNonce.Int64()}.MustInsertWithState(t, ethKeyStore)
 
 		ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -874,7 +874,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 		txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, nextNonce)
+		_, fromAddress := cltest.RandomKey{Nonce: nextNonce.Int64()}.MustInsertWithState(t, ethKeyStore)
 
 		ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -911,7 +911,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_ResumingFromCrash(t *testing.T) {
 		txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-		_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, nextNonce)
+		_, fromAddress := cltest.RandomKey{Nonce: nextNonce.Int64()}.MustInsertWithState(t, ethKeyStore)
 
 		cfg := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 			// Configured gas price changed
@@ -982,7 +982,7 @@ func TestEthBroadcaster_ProcessUnstartedEthTxs_Errors(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
@@ -1682,7 +1682,7 @@ func TestEthBroadcaster_GetNextNonce(t *testing.T) {
 	cfg := configtest.NewGeneralConfig(t, nil)
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	keyState, _ := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	keyState, _ := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	nonce := getLocalNextNonce(t, ethKeyStore, keyState.Address.Address())
 	require.NotNil(t, nonce)
@@ -1694,7 +1694,7 @@ func TestEthBroadcaster_IncrementNextNonce(t *testing.T) {
 	cfg := configtest.NewGeneralConfig(t, nil)
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	keyState, _ := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	keyState, _ := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	// Cannot increment if supplied nonce doesn't match existing
 	require.Error(t, ethKeyStore.IncrementNextSequence(keyState.Address.Address(), &cltest.FixtureChainID, evmtypes.Nonce(42)))
@@ -1733,7 +1733,7 @@ func TestEthBroadcaster_EthTxInsertEventCausesTriggerToFire(t *testing.T) {
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 	eventBroadcaster := cltest.NewEventBroadcaster(t, evmcfg.Database().URL())
 	require.NoError(t, eventBroadcaster.Start(testutils.Context(t)))
 	t.Cleanup(func() { require.NoError(t, eventBroadcaster.Close()) })
@@ -1761,8 +1761,8 @@ func TestEthBroadcaster_SyncNonce(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 
 	kst := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, kst, true)
-	_, disabledAddress := cltest.MustInsertRandomKeyReturningState(t, kst, false)
+	_, fromAddress := cltest.RandomKey{Disabled: false}.MustInsertWithState(t, kst)
+	_, disabledAddress := cltest.RandomKey{Disabled: true}.MustInsertWithState(t, kst)
 
 	ethNodeNonce := uint64(22)
 

--- a/core/chains/evm/txmgr/confirmer_test.go
+++ b/core/chains/evm/txmgr/confirmer_test.go
@@ -117,8 +117,8 @@ func TestEthConfirmer_Lifecycle(t *testing.T) {
 	ethKeyStore := cltest.NewKeyStore(t, db, config.Database()).Eth()
 
 	// Add some fromAddresses
-	cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
-	cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+	cltest.MustInsertRandomKey(t, ethKeyStore)
+	cltest.MustInsertRandomKey(t, ethKeyStore)
 	estimator := gasmocks.NewEvmEstimator(t)
 	lggr := logger.TestLogger(t)
 	ge := config.EVM().GasEstimator()
@@ -185,7 +185,7 @@ func TestEthConfirmer_CheckForReceipts(t *testing.T) {
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	ethKeyStore := cltest.NewKeyStore(t, db, config.Database()).Eth()
 
-	_, fromAddress := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	ec := cltest.NewEthConfirmer(t, txStore, ethClient, config, ethKeyStore, nil)
 
@@ -598,7 +598,7 @@ func TestEthConfirmer_CheckForReceipts_batching(t *testing.T) {
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -663,7 +663,7 @@ func TestEthConfirmer_CheckForReceipts_HandlesNonFwdTxsWithForwardingEnabled(t *
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	evmcfg := evmtest.NewChainScopedConfig(t, cfg)
 
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 	ec := cltest.NewEthConfirmer(t, txStore, ethClient, evmcfg, ethKeyStore, nil)
 	ctx := testutils.Context(t)
 	// tx is not forwarded and doesn't have meta set. EthConfirmer should handle nil meta values
@@ -711,7 +711,7 @@ func TestEthConfirmer_CheckForReceipts_only_likely_confirmed(t *testing.T) {
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -767,7 +767,7 @@ func TestEthConfirmer_CheckForReceipts_should_not_check_for_likely_unconfirmed(t
 
 	ethKeyStore := cltest.NewKeyStore(t, db, config.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -793,11 +793,10 @@ func TestEthConfirmer_CheckForReceipts_confirmed_missing_receipt_scoped_to_key(t
 	cfg := configtest.NewTestGeneralConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	chainId1, chainId2 := 1, 2
 
-	_, fromAddress1_1 := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, chainId1)
-	_, fromAddress1_2 := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, chainId1)
-	_, fromAddress2_1 := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, chainId2)
+	_, fromAddress1_1 := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
+	_, fromAddress1_2 := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
+	_, fromAddress2_1 := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	ethClient.On("SequenceAt", mock.Anything, mock.Anything, mock.Anything).Return(evmtypes.Nonce(20), nil)
@@ -864,7 +863,7 @@ func TestEthConfirmer_CheckForReceipts_confirmed_missing_receipt(t *testing.T) {
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -1124,7 +1123,7 @@ func TestEthConfirmer_CheckConfirmedMissingReceipt(t *testing.T) {
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -1203,7 +1202,7 @@ func TestEthConfirmer_CheckConfirmedMissingReceipt_batchSendTransactions_fails(t
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -1267,7 +1266,7 @@ func TestEthConfirmer_CheckConfirmedMissingReceipt_smallEvmRPCBatchSize_middleBa
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -1338,7 +1337,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 	evmFromAddress := fromAddress
 	currentHead := int64(30)
 	gasBumpThreshold := int64(10)
@@ -1350,7 +1349,7 @@ func TestEthConfirmer_FindTxsRequiringRebroadcast(t *testing.T) {
 	mustInsertConfirmedEthTx(t, txStore, nonce, fromAddress)
 	nonce++
 
-	_, otherAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, otherAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 	evmOtherAddress := otherAddress
 
 	lggr := logger.TestLogger(t)
@@ -2490,7 +2489,7 @@ func TestEthConfirmer_RebroadcastWhereNecessary_WhenOutOfEth(t *testing.T) {
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	_, err := ethKeyStore.EnabledKeysForChain(testutils.FixtureChainID)
 	require.NoError(t, err)
@@ -2627,7 +2626,7 @@ func TestEthConfirmer_EnsureConfirmedTransactionsInLongestChain(t *testing.T) {
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
@@ -2800,7 +2799,7 @@ func TestEthConfirmer_ForceRebroadcast(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	config := newTestChainScopedConfig(t)
 	cltest.MustCreateUnstartedGeneratedTx(t, txStore, fromAddress, config.EVM().ChainID())
@@ -2902,7 +2901,7 @@ func TestEthConfirmer_ResumePendingRuns(t *testing.T) {
 
 	ethKeyStore := cltest.NewKeyStore(t, db, config.Database()).Eth()
 
-	_, fromAddress := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 

--- a/core/chains/evm/txmgr/evm_tx_store_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_test.go
@@ -37,7 +37,7 @@ func TestORM_TransactionsWithAttempts(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, from := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+	_, from := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)        // tx1
 	tx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, from) // tx2
@@ -82,7 +82,7 @@ func TestORM_Transactions(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, from := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+	_, from := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)        // tx1
 	tx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, from) // tx2
@@ -120,7 +120,7 @@ func TestORM(t *testing.T) {
 	cfg := configtest.NewGeneralConfig(t, nil)
 	keyStore := cltest.NewKeyStore(t, db, cfg.Database())
 	orm := cltest.NewTestTxStore(t, db, cfg.Database())
-	_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth(), 0)
+	_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth())
 
 	var err error
 	var etx txmgr.Tx
@@ -191,7 +191,7 @@ func TestORM_FindTxAttemptConfirmedByTxIDs(t *testing.T) {
 	orm := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, from := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+	_, from := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	tx1 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, orm, 0, 1, from) // tx1
 	tx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, orm, 1, 2, from) // tx2
@@ -328,7 +328,7 @@ func TestORM_UpdateBroadcastAts(t *testing.T) {
 	cfg := configtest.NewGeneralConfig(t, nil)
 	keyStore := cltest.NewKeyStore(t, db, cfg.Database())
 	orm := cltest.NewTestTxStore(t, db, cfg.Database())
-	_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth(), 0)
+	_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth())
 
 	t.Run("does not update when broadcast_at is NULL", func(t *testing.T) {
 		t.Parallel()
@@ -377,7 +377,7 @@ func TestORM_SetBroadcastBeforeBlockNum(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 	etx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
 	chainID := ethClient.ConfiguredChainID()
 
@@ -445,7 +445,7 @@ func TestORM_FindTxAttemptsConfirmedMissingReceipt(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	originalBroadcastAt := time.Unix(1616509100, 0)
 	etx0 := cltest.MustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(
@@ -467,7 +467,7 @@ func TestORM_UpdateTxsUnconfirmed(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	originalBroadcastAt := time.Unix(1616509100, 0)
 	etx0 := cltest.MustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(
@@ -488,7 +488,7 @@ func TestORM_FindTxAttemptsRequiringReceiptFetch(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	originalBroadcastAt := time.Unix(1616509100, 0)
 	etx0 := cltest.MustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(
@@ -509,7 +509,7 @@ func TestORM_SaveFetchedReceipts(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	originalBroadcastAt := time.Unix(1616509100, 0)
 	etx0 := cltest.MustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(
@@ -542,7 +542,7 @@ func TestORM_MarkAllConfirmedMissingReceipt(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
 	// create transaction 0 (nonce 0) that is unconfirmed (block 7)
@@ -572,7 +572,7 @@ func TestORM_PreloadTxes(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("loads eth transaction", func(t *testing.T) {
 		// insert etx with attempt
@@ -607,7 +607,7 @@ func TestORM_GetInProgressTxAttempts(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	// insert etx with attempt
 	etx := cltest.MustInsertUnconfirmedEthTxWithAttemptState(t, txStore, int64(7), fromAddress, txmgrtypes.TxAttemptInProgress)
@@ -628,7 +628,7 @@ func TestORM_FindReceiptsPendingConfirmation(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	pgtest.MustExec(t, db, `SET CONSTRAINTS pipeline_runs_pipeline_spec_id_fkey DEFERRED`)
 
@@ -671,7 +671,7 @@ func Test_FindTxWithIdempotencyKey(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("returns nil if no results", func(t *testing.T) {
 		idempotencyKey := "777"
@@ -701,7 +701,7 @@ func TestORM_FindTxWithSequence(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("returns nil if no results", func(t *testing.T) {
 		etx, err := txStore.FindTxWithSequence(testutils.Context(t), fromAddress, evmtypes.Nonce(777))
@@ -726,7 +726,7 @@ func TestORM_UpdateTxForRebroadcast(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("delete all receipts for eth transaction", func(t *testing.T) {
 		etx := cltest.MustInsertConfirmedEthTxWithReceipt(t, txStore, fromAddress, 777, 1)
@@ -767,7 +767,7 @@ func TestORM_FindTransactionsConfirmedInBlockRange(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	head := evmtypes.Head{
 		Hash:   utils.NewHash(),
@@ -802,7 +802,7 @@ func TestORM_SaveInsufficientEthAttempt(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 	defaultDuration, err := time.ParseDuration("5s")
 	require.NoError(t, err)
 
@@ -826,7 +826,7 @@ func TestORM_SaveSentAttempt(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 	defaultDuration, err := time.ParseDuration("5s")
 	require.NoError(t, err)
 
@@ -851,7 +851,7 @@ func TestORM_SaveConfirmedMissingReceiptAttempt(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 	defaultDuration, err := time.ParseDuration("5s")
 	require.NoError(t, err)
 
@@ -876,7 +876,7 @@ func TestORM_DeleteInProgressAttempt(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("deletes in_progress attempt", func(t *testing.T) {
 		etx := cltest.MustInsertInProgressEthTxWithAttempt(t, txStore, 1, fromAddress)
@@ -898,7 +898,7 @@ func TestORM_SaveInProgressAttempt(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("saves new in_progress attempt if attempt is new", func(t *testing.T) {
 		etx := cltest.MustInsertUnconfirmedEthTx(t, txStore, 1, fromAddress)
@@ -940,7 +940,7 @@ func TestORM_FindTxsRequiringGasBump(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	currentBlockNum := int64(10)
 
@@ -981,8 +981,8 @@ func TestEthConfirmer_FindTxsRequiringResubmissionDueToInsufficientEth(t *testin
 
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
-	_, otherAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
+	_, otherAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	// Insert order is mixed up to test sorting
 	etx2 := cltest.MustInsertUnconfirmedEthTxWithInsufficientEthAttempt(t, txStore, 1, fromAddress)
@@ -1041,7 +1041,7 @@ func TestORM_MarkOldTxesMissingReceiptAsErrored(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	// tx state should be confirmed missing receipt
 	// attempt should be broadcast before cutoff time
@@ -1075,7 +1075,7 @@ func TestORM_LoadEthTxesAttempts(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("load eth tx attempt", func(t *testing.T) {
 		etx := cltest.MustInsertConfirmedMissingReceiptEthTxWithLegacyAttempt(t, txStore, 1, 7, time.Now(), fromAddress)
@@ -1124,7 +1124,7 @@ func TestORM_SaveReplacementInProgressAttempt(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("replace eth tx attempt", func(t *testing.T) {
 		etx := cltest.MustInsertInProgressEthTxWithAttempt(t, txStore, 123, fromAddress)
@@ -1150,7 +1150,7 @@ func TestORM_FindNextUnstartedTransactionFromAddress(t *testing.T) {
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("cannot find unstarted tx", func(t *testing.T) {
 		cltest.MustInsertInProgressEthTxWithAttempt(t, txStore, 13, fromAddress)
@@ -1176,7 +1176,7 @@ func TestORM_UpdateTxFatalError(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("update successful", func(t *testing.T) {
 		etx := cltest.MustInsertInProgressEthTxWithAttempt(t, txStore, 13, fromAddress)
@@ -1199,7 +1199,7 @@ func TestORM_UpdateTxAttemptInProgressToBroadcast(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("update successful", func(t *testing.T) {
 		etx := cltest.MustInsertInProgressEthTxWithAttempt(t, txStore, 13, fromAddress)
@@ -1232,7 +1232,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 	q := pg.NewQ(db, logger.TestLogger(t), cfg.Database())
 	nonce := evmtypes.Nonce(123)
 
@@ -1267,7 +1267,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 	cfg = newTestChainScopedConfig(t)
 	txStore = cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore = cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress = cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress = cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 	q = pg.NewQ(db, logger.TestLogger(t), cfg.Database())
 
 	t.Run("update replaces abandoned tx with same hash", func(t *testing.T) {
@@ -1300,7 +1300,7 @@ func TestORM_UpdateTxUnstartedToInProgress(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	_, fromAddress = cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress = cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	// Same flow as previous test, but without calling txMgr.Abandon()
 	t.Run("duplicate tx hash disallowed in tx_eth_attempts", func(t *testing.T) {
@@ -1323,7 +1323,7 @@ func TestORM_GetTxInProgress(t *testing.T) {
 	cfg := newTestChainScopedConfig(t)
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("gets 0 in progress eth transaction", func(t *testing.T) {
 		etxResult, err := txStore.GetTxInProgress(testutils.Context(t), fromAddress)
@@ -1348,7 +1348,7 @@ func TestORM_HasInProgressTransaction(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("no in progress eth transaction", func(t *testing.T) {
 		exists, err := txStore.HasInProgressTransaction(testutils.Context(t), fromAddress, ethClient.ConfiguredChainID())
@@ -1373,7 +1373,7 @@ func TestORM_UpdateEthKeyNextNonce(t *testing.T) {
 	txStore := cltest.NewTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 	ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
-	ethKeyState, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	ethKeyState, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("update next nonce", func(t *testing.T) {
 		assert.Equal(t, int64(0), ethKeyState.NextNonce)
@@ -1399,8 +1399,8 @@ func TestORM_CountUnconfirmedTransactions(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
-	_, otherAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
+	_, otherAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, otherAddress)
 	cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 0, fromAddress)
@@ -1420,8 +1420,8 @@ func TestORM_CountUnstartedTransactions(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
-	_, otherAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
+	_, otherAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	cltest.MustCreateUnstartedGeneratedTx(t, txStore, fromAddress, &cltest.FixtureChainID)
 	cltest.MustCreateUnstartedGeneratedTx(t, txStore, fromAddress, &cltest.FixtureChainID)
@@ -1441,8 +1441,8 @@ func TestORM_CheckTxQueueCapacity(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
-	_, otherAddress := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
+	_, otherAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	toAddress := testutils.NewAddress()
 	encodedPayload := []byte{1, 2, 3}
@@ -1537,7 +1537,7 @@ func TestORM_CreateTransaction(t *testing.T) {
 	txStore := cltest.NewTxStore(t, db, cfg.Database())
 	kst := cltest.NewKeyStore(t, db, cfg.Database())
 
-	_, fromAddress := cltest.MustInsertRandomKey(t, kst.Eth(), 0)
+	_, fromAddress := cltest.MustInsertRandomKey(t, kst.Eth())
 	toAddress := testutils.NewAddress()
 	gasLimit := uint32(1000)
 	payload := []byte{1, 2, 3}
@@ -1610,7 +1610,7 @@ func TestORM_PruneUnstartedTxQueue(t *testing.T) {
 	txStore := cltest.NewTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 	evmtest.NewEthClientMockWithDefaultChain(t)
-	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKeyReturningState(t, ethKeyStore)
 
 	t.Run("does not prune if queue has not exceeded capacity", func(t *testing.T) {
 		subject1 := uuid.New()

--- a/core/chains/evm/txmgr/nonce_syncer_test.go
+++ b/core/chains/evm/txmgr/nonce_syncer_test.go
@@ -13,10 +13,11 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
-	"github.com/smartcontractkit/sqlx"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/sqlx"
 )
 
 func Test_NonceSyncer_Sync(t *testing.T) {
@@ -29,7 +30,7 @@ func Test_NonceSyncer_Sync(t *testing.T) {
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 		txStore := cltest.NewTxStore(t, db, cfg.Database())
 
-		_, from := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+		_, from := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 		ethClient.On("PendingNonceAt", mock.Anything, mock.MatchedBy(func(addr common.Address) bool {
 			return from == addr
@@ -55,7 +56,7 @@ func Test_NonceSyncer_Sync(t *testing.T) {
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 		txStore := cltest.NewTxStore(t, db, cfg.Database())
 
-		_, from := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+		_, from := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 		ethClient.On("PendingNonceAt", mock.Anything, mock.MatchedBy(func(addr common.Address) bool {
 			return from == addr
@@ -80,7 +81,7 @@ func Test_NonceSyncer_Sync(t *testing.T) {
 		ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-		k1, _ := cltest.MustInsertRandomKey(t, ethKeyStore, int64(32))
+		k1, _ := cltest.RandomKey{Nonce: 32}.MustInsert(t, ethKeyStore)
 
 		ethClient.On("PendingNonceAt", mock.Anything, mock.MatchedBy(func(addr common.Address) bool {
 			return k1.Address == addr
@@ -105,8 +106,8 @@ func Test_NonceSyncer_Sync(t *testing.T) {
 		ethClient := evmtest.NewEthClientMockWithDefaultChain(t)
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-		_, key1 := cltest.MustInsertRandomKey(t, ethKeyStore, int64(0))
-		_, key2 := cltest.MustInsertRandomKey(t, ethKeyStore, int64(32))
+		_, key1 := cltest.MustInsertRandomKey(t, ethKeyStore)
+		_, key2 := cltest.RandomKey{Nonce: 32}.MustInsert(t, ethKeyStore)
 
 		ethClient.On("PendingNonceAt", mock.Anything, mock.MatchedBy(func(addr common.Address) bool {
 			// Nothing to do for key2
@@ -133,7 +134,7 @@ func Test_NonceSyncer_Sync(t *testing.T) {
 		txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-		_, key1 := cltest.MustInsertRandomKey(t, ethKeyStore, int64(0))
+		_, key1 := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 		cltest.MustInsertInProgressEthTxWithAttempt(t, txStore, 1, key1)
 

--- a/core/chains/evm/txmgr/reaper_test.go
+++ b/core/chains/evm/txmgr/reaper_test.go
@@ -47,7 +47,7 @@ func TestReaper_ReapTxes(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, from := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+	_, from := cltest.MustInsertRandomKey(t, ethKeyStore)
 	var nonce int64
 	oneDayAgo := time.Now().Add(-24 * time.Hour)
 

--- a/core/chains/evm/txmgr/txmgr_test.go
+++ b/core/chains/evm/txmgr/txmgr_test.go
@@ -100,7 +100,7 @@ func TestTxm_CreateTransaction(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	kst := cltest.NewKeyStore(t, db, cfg.Database())
 
-	_, fromAddress := cltest.MustInsertRandomKey(t, kst.Eth(), 0)
+	_, fromAddress := cltest.MustInsertRandomKey(t, kst.Eth())
 	toAddress := testutils.NewAddress()
 	gasLimit := uint32(1000)
 	payload := []byte{1, 2, 3}
@@ -512,8 +512,8 @@ func TestTxm_CreateTransaction_OutOfEth(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	etKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	thisKey, _ := cltest.MustInsertRandomKey(t, etKeyStore, 1)
-	otherKey, _ := cltest.MustInsertRandomKey(t, etKeyStore, 1)
+	thisKey, _ := cltest.RandomKey{Nonce: 1}.MustInsert(t, etKeyStore)
+	otherKey, _ := cltest.RandomKey{Nonce: 1}.MustInsert(t, etKeyStore)
 
 	fromAddress := thisKey.Address
 	evmFromAddress := fromAddress
@@ -674,8 +674,8 @@ func TestTxm_Reset(t *testing.T) {
 	cfg := evmtest.NewChainScopedConfig(t, gcfg)
 	kst := cltest.NewKeyStore(t, db, cfg.Database())
 
-	_, addr := cltest.MustInsertRandomKey(t, kst.Eth(), 5)
-	_, addr2 := cltest.MustInsertRandomKey(t, kst.Eth(), 3)
+	_, addr := cltest.RandomKey{Nonce: 5}.MustInsert(t, kst.Eth())
+	_, addr2 := cltest.RandomKey{Nonce: 3}.MustInsert(t, kst.Eth())
 	txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 	// 4 confirmed tx from addr1
 	for i := int64(0); i < 4; i++ {

--- a/core/chains/evm/types/models_test.go
+++ b/core/chains/evm/types/models_test.go
@@ -94,7 +94,7 @@ func TestEthTxAttempt_GetSignedTx(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
 	cfg := configtest.NewGeneralConfig(t, nil)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 	tx := gethTypes.NewTransaction(uint64(42), testutils.NewAddress(), big.NewInt(142), 242, big.NewInt(342), []byte{1, 2, 3})
 
 	chainID := big.NewInt(3)

--- a/core/cmd/evm_transaction_commands_test.go
+++ b/core/cmd/evm_transaction_commands_test.go
@@ -29,7 +29,7 @@ func TestShell_IndexTransactions(t *testing.T) {
 	app := startNewApplicationV2(t, nil)
 	client, r := app.NewShellAndRenderer()
 
-	_, from := cltest.MustAddRandomKeyToKeystore(t, app.KeyStore.Eth())
+	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	txStore := cltest.NewTestTxStore(t, app.GetSqlxDB(), app.GetConfig().Database())
 	tx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
@@ -70,7 +70,7 @@ func TestShell_ShowTransaction(t *testing.T) {
 	client, r := app.NewShellAndRenderer()
 
 	db := app.GetSqlxDB()
-	_, from := cltest.MustAddRandomKeyToKeystore(t, app.KeyStore.Eth())
+	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	txStore := cltest.NewTestTxStore(t, db, app.GetConfig().Database())
 	tx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
@@ -94,7 +94,7 @@ func TestShell_IndexTxAttempts(t *testing.T) {
 	app := startNewApplicationV2(t, nil)
 	client, r := app.NewShellAndRenderer()
 
-	_, from := cltest.MustAddRandomKeyToKeystore(t, app.KeyStore.Eth())
+	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	txStore := cltest.NewTestTxStore(t, app.GetSqlxDB(), app.GetConfig().Database())
 	tx := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -370,7 +370,7 @@ func TestShell_RebroadcastTransactions_OutsideRange_Txm(t *testing.T) {
 
 			keyStore := cltest.NewKeyStore(t, sqlxDB, config.Database())
 
-			_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth(), 0)
+			_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth())
 
 			txStore := cltest.NewTestTxStore(t, sqlxDB, config.Database())
 			cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, int64(test.nonce), 42, fromAddress)
@@ -448,7 +448,7 @@ func TestShell_RebroadcastTransactions_AddressCheck(t *testing.T) {
 
 			keyStore := cltest.NewKeyStore(t, sqlxDB, config.Database())
 
-			_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth(), 0)
+			_, fromAddress := cltest.MustInsertRandomKey(t, keyStore.Eth())
 
 			if !test.enableAddress {
 				err := keyStore.Eth().Disable(fromAddress, testutils.FixtureChainID)

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -271,8 +271,6 @@ func NewApplicationWithKey(t *testing.T, flagsAndDeps ...interface{}) *TestAppli
 // NewApplicationWithConfigAndKey creates a new TestApplication with the given testorm
 // it will also provide an unlocked account on the keystore
 func NewApplicationWithConfigAndKey(t testing.TB, c chainlink.GeneralConfig, flagsAndDeps ...interface{}) *TestApplication {
-	t.Helper()
-
 	app := NewApplicationWithConfig(t, c, flagsAndDeps...)
 
 	chainID := *utils.NewBig(&FixtureChainID)
@@ -284,12 +282,14 @@ func NewApplicationWithConfigAndKey(t testing.TB, c chainlink.GeneralConfig, fla
 	}
 
 	if len(app.Keys) == 0 {
-		k, _ := MustInsertRandomKey(t, app.KeyStore.Eth(), 0, chainID)
+		k, _ := MustInsertRandomKey(t, app.KeyStore.Eth(), chainID)
 		app.Keys = []ethkey.KeyV2{k}
 	} else {
 		id, ks := chainID.ToInt(), app.KeyStore.Eth()
 		for _, k := range app.Keys {
-			MustAddKeyToKeystore(t, k, id, ks)
+			ks.XXXTestingOnlyAdd(k)
+			require.NoError(t, ks.Add(k.Address, id))
+			require.NoError(t, ks.Enable(k.Address, id))
 		}
 	}
 

--- a/core/services/blockhashstore/delegate_test.go
+++ b/core/services/blockhashstore/delegate_test.go
@@ -55,7 +55,7 @@ func createTestDelegate(t *testing.T) (*blockhashstore.Delegate, *testData) {
 	})
 	db := pgtest.NewSqlxDB(t)
 	kst := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	sendingKey, _ := cltest.MustAddRandomKeyToKeystore(t, kst)
+	sendingKey, _ := cltest.MustInsertRandomKey(t, kst)
 	lp := &mocklp.LogPoller{}
 	lp.On("RegisterFilter", mock.Anything).Return(nil)
 	lp.On("LatestBlock", mock.Anything, mock.Anything).Return(int64(0), nil)

--- a/core/services/fluxmonitorv2/flux_monitor_test.go
+++ b/core/services/fluxmonitorv2/flux_monitor_test.go
@@ -278,7 +278,7 @@ func withORM(orm fluxmonitorv2.ORM) func(*setupOptions) {
 func setupStoreWithKey(t *testing.T) (*sqlx.DB, common.Address) {
 	db := pgtest.NewSqlxDB(t)
 	ethKeyStore := cltest.NewKeyStore(t, db, pgtest.NewQConfig(true)).Eth()
-	_, nodeAddr := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+	_, nodeAddr := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	return db, nodeAddr
 }
@@ -287,7 +287,7 @@ func setupStoreWithKey(t *testing.T) (*sqlx.DB, common.Address) {
 func setupFullDBWithKey(t *testing.T, name string) (*sqlx.DB, common.Address) {
 	cfg, db := heavyweight.FullTestDBV2(t, name, nil)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-	_, nodeAddr := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+	_, nodeAddr := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	return db, nodeAddr
 }

--- a/core/services/fluxmonitorv2/key_store_test.go
+++ b/core/services/fluxmonitorv2/key_store_test.go
@@ -43,7 +43,7 @@ func TestKeyStore_GetRoundRobinAddress(t *testing.T) {
 	cfg := pgtest.NewQConfig(true)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg).Eth()
 
-	_, k0Address := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+	_, k0Address := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	ks := fluxmonitorv2.NewKeyStore(ethKeyStore)
 

--- a/core/services/fluxmonitorv2/orm_test.go
+++ b/core/services/fluxmonitorv2/orm_test.go
@@ -181,7 +181,7 @@ func TestORM_CreateEthTransaction(t *testing.T) {
 		txm = txmmocks.NewMockEvmTxManager(t)
 		orm = fluxmonitorv2.NewORM(db, logger.TestLogger(t), cfg, txm, strategy, txmgr.TransmitCheckerSpec{})
 
-		_, from  = cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+		_, from  = cltest.MustInsertRandomKey(t, ethKeyStore)
 		to       = testutils.NewAddress()
 		payload  = []byte{1, 0, 0}
 		gasLimit = uint32(21000)

--- a/core/services/job/runner_integration_test.go
+++ b/core/services/job/runner_integration_test.go
@@ -55,7 +55,7 @@ func TestRunner(t *testing.T) {
 	keyStore := cltest.NewKeyStore(t, db, pgtest.NewQConfig(true))
 
 	ethKeyStore := keyStore.Eth()
-	_, transmitterAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+	_, transmitterAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 	require.NoError(t, keyStore.OCR().Add(cltest.DefaultOCRKey))
 
 	config := configtest2.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {

--- a/core/services/keystore/eth_test.go
+++ b/core/services/keystore/eth_test.go
@@ -231,24 +231,24 @@ func Test_EthKeyStore_GetRoundRobinAddress(t *testing.T) {
 	//   enabled - simulated
 	// - key 4
 	//   enabled - fixture
-	k1, _ := cltest.MustInsertRandomKey(t, ethKeyStore, []utils.Big{})
+	k1, _ := cltest.MustInsertRandomKeyNoChains(t, ethKeyStore)
 	require.NoError(t, ethKeyStore.Add(k1.Address, testutils.FixtureChainID))
 	require.NoError(t, ethKeyStore.Add(k1.Address, testutils.SimulatedChainID))
 	require.NoError(t, ethKeyStore.Enable(k1.Address, testutils.FixtureChainID))
 	require.NoError(t, ethKeyStore.Enable(k1.Address, testutils.SimulatedChainID))
 
-	k2, _ := cltest.MustInsertRandomKey(t, ethKeyStore, []utils.Big{})
+	k2, _ := cltest.MustInsertRandomKeyNoChains(t, ethKeyStore)
 	require.NoError(t, ethKeyStore.Add(k2.Address, testutils.FixtureChainID))
 	require.NoError(t, ethKeyStore.Add(k2.Address, testutils.SimulatedChainID))
 	require.NoError(t, ethKeyStore.Enable(k2.Address, testutils.FixtureChainID))
 	require.NoError(t, ethKeyStore.Enable(k2.Address, testutils.SimulatedChainID))
 	require.NoError(t, ethKeyStore.Disable(k2.Address, testutils.SimulatedChainID))
 
-	k3, _ := cltest.MustInsertRandomKey(t, ethKeyStore, []utils.Big{})
+	k3, _ := cltest.MustInsertRandomKeyNoChains(t, ethKeyStore)
 	require.NoError(t, ethKeyStore.Add(k3.Address, testutils.SimulatedChainID))
 	require.NoError(t, ethKeyStore.Enable(k3.Address, testutils.SimulatedChainID))
 
-	k4, _ := cltest.MustInsertRandomKey(t, ethKeyStore, []utils.Big{})
+	k4, _ := cltest.MustInsertRandomKeyNoChains(t, ethKeyStore)
 	require.NoError(t, ethKeyStore.Add(k4.Address, testutils.FixtureChainID))
 	require.NoError(t, ethKeyStore.Enable(k4.Address, testutils.FixtureChainID))
 
@@ -335,7 +335,7 @@ func Test_EthKeyStore_SignTx(t *testing.T) {
 	keyStore := cltest.NewKeyStore(t, db, config.Database())
 	ethKeyStore := keyStore.Eth()
 
-	k, _ := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+	k, _ := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	chainID := big.NewInt(evmclient.NullClientChainID)
 	tx := types.NewTransaction(0, testutils.NewAddress(), big.NewInt(53), 21000, big.NewInt(1000000000), []byte{1, 2, 3, 4})
@@ -623,9 +623,9 @@ func Test_EthKeyStore_Reset(t *testing.T) {
 	keyStore := cltest.NewKeyStore(t, db, cfg.Database())
 	ks := keyStore.Eth()
 
-	k1, addr1 := cltest.MustInsertRandomKey(t, ks, testutils.FixtureChainID)
-	cltest.MustInsertRandomKey(t, ks, testutils.FixtureChainID)
-	cltest.MustInsertRandomKey(t, ks, testutils.SimulatedChainID)
+	k1, addr1 := cltest.MustInsertRandomKey(t, ks)
+	cltest.MustInsertRandomKey(t, ks)
+	cltest.MustInsertRandomKey(t, ks, *utils.NewBig(testutils.SimulatedChainID))
 
 	newNonce := testutils.NewRandomPositiveInt64()
 
@@ -687,8 +687,8 @@ func Test_NextSequence(t *testing.T) {
 	ks := keyStore.Eth()
 	randNonce := testutils.NewRandomPositiveInt64()
 
-	_, addr1 := cltest.MustInsertRandomKey(t, ks, testutils.FixtureChainID, randNonce)
-	cltest.MustInsertRandomKey(t, ks, testutils.FixtureChainID)
+	_, addr1 := cltest.RandomKey{Nonce: randNonce}.MustInsert(t, ks)
+	cltest.MustInsertRandomKey(t, ks)
 
 	nonce, err := ks.NextSequence(addr1, testutils.FixtureChainID)
 	require.NoError(t, err)
@@ -718,9 +718,9 @@ func Test_IncrementNextSequence(t *testing.T) {
 	ks := keyStore.Eth()
 	randNonce := testutils.NewRandomPositiveInt64()
 
-	_, addr1 := cltest.MustInsertRandomKey(t, ks, testutils.FixtureChainID, randNonce)
+	_, addr1 := cltest.RandomKey{Nonce: randNonce}.MustInsert(t, ks)
 	evmAddr1 := addr1
-	cltest.MustInsertRandomKey(t, ks, testutils.FixtureChainID)
+	cltest.MustInsertRandomKey(t, ks)
 
 	err := ks.IncrementNextSequence(evmAddr1, testutils.FixtureChainID, evmtypes.Nonce(randNonce-1))
 	assert.ErrorIs(t, err, sql.ErrNoRows)
@@ -762,9 +762,9 @@ func Test_EthKeyStore_Delete(t *testing.T) {
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Key not found")
 
-	_, addr1 := cltest.MustInsertRandomKey(t, ks, testutils.FixtureChainID)
-	_, addr2 := cltest.MustInsertRandomKey(t, ks, testutils.FixtureChainID)
-	cltest.MustInsertRandomKey(t, ks, testutils.SimulatedChainID)
+	_, addr1 := cltest.MustInsertRandomKey(t, ks)
+	_, addr2 := cltest.MustInsertRandomKey(t, ks)
+	cltest.MustInsertRandomKey(t, ks, *utils.NewBig(testutils.SimulatedChainID))
 	require.NoError(t, ks.Add(addr1, testutils.SimulatedChainID))
 	require.NoError(t, ks.Enable(addr1, testutils.SimulatedChainID))
 
@@ -814,20 +814,20 @@ func Test_EthKeyStore_CheckEnabled(t *testing.T) {
 	//   enabled - simulated
 	// - key 4
 	//   enabled - fixture
-	k1, addr1 := cltest.MustInsertRandomKey(t, ks, []utils.Big{})
+	k1, addr1 := cltest.MustInsertRandomKeyNoChains(t, ks)
 	require.NoError(t, ks.Add(k1.Address, testutils.SimulatedChainID))
 	require.NoError(t, ks.Add(k1.Address, testutils.FixtureChainID))
 	require.NoError(t, ks.Enable(k1.Address, testutils.SimulatedChainID))
 	require.NoError(t, ks.Enable(k1.Address, testutils.FixtureChainID))
 
-	k2, addr2 := cltest.MustInsertRandomKey(t, ks, []utils.Big{})
+	k2, addr2 := cltest.MustInsertRandomKeyNoChains(t, ks)
 	require.NoError(t, ks.Add(k2.Address, testutils.FixtureChainID))
 	require.NoError(t, ks.Add(k2.Address, testutils.SimulatedChainID))
 	require.NoError(t, ks.Enable(k2.Address, testutils.FixtureChainID))
 	require.NoError(t, ks.Enable(k2.Address, testutils.SimulatedChainID))
 	require.NoError(t, ks.Disable(k2.Address, testutils.SimulatedChainID))
 
-	k3, addr3 := cltest.MustInsertRandomKey(t, ks, []utils.Big{})
+	k3, addr3 := cltest.MustInsertRandomKeyNoChains(t, ks)
 	require.NoError(t, ks.Add(k3.Address, testutils.SimulatedChainID))
 	require.NoError(t, ks.Enable(k3.Address, testutils.SimulatedChainID))
 

--- a/core/services/keystore/master_test.go
+++ b/core/services/keystore/master_test.go
@@ -45,7 +45,7 @@ func TestMasterKeystore_Unlock_Save(t *testing.T) {
 	t.Run("won't load a saved keyRing if the password is incorrect", func(t *testing.T) {
 		defer reset()
 		require.NoError(t, keyStore.Unlock(cltest.Password))
-		cltest.MustAddRandomKeyToKeystore(t, keyStore.Eth()) // need at least 1 key to encrypt
+		cltest.MustInsertRandomKey(t, keyStore.Eth()) // need at least 1 key to encrypt
 		cltest.AssertCount(t, db, tableName, 1)
 		keyStore.ResetXXXTestOnly()
 		cltest.AssertCount(t, db, tableName, 1)

--- a/core/services/ocrcommon/transmitter_pipeline_test.go
+++ b/core/services/ocrcommon/transmitter_pipeline_test.go
@@ -26,7 +26,7 @@ func Test_PipelineTransmitter_CreateEthTransaction(t *testing.T) {
 	cfg := configtest.NewTestGeneralConfig(t)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	chainID := "12345"
 	gasLimit := uint32(1000)

--- a/core/services/ocrcommon/transmitter_test.go
+++ b/core/services/ocrcommon/transmitter_test.go
@@ -29,7 +29,7 @@ func Test_DefaultTransmitter_CreateEthTransaction(t *testing.T) {
 	cfg := configtest.NewTestGeneralConfig(t)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	gasLimit := uint32(1000)
 	chainID := big.NewInt(0)
@@ -70,8 +70,8 @@ func Test_DefaultTransmitter_Forwarding_Enabled_CreateEthTransaction(t *testing.
 	cfg := configtest.NewTestGeneralConfig(t)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
-	_, fromAddress2 := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
+	_, fromAddress2 := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	gasLimit := uint32(1000)
 	chainID := big.NewInt(0)
@@ -153,8 +153,8 @@ func Test_DefaultTransmitter_Forwarding_Enabled_CreateEthTransaction_No_Keystore
 	cfg := configtest.NewTestGeneralConfig(t)
 	ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
 
-	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
-	_, fromAddress2 := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+	_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
+	_, fromAddress2 := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	gasLimit := uint32(1000)
 	chainID := big.NewInt(0)

--- a/core/services/promreporter/prom_reporter_test.go
+++ b/core/services/promreporter/prom_reporter_test.go
@@ -59,7 +59,7 @@ func Test_PromReporter_OnNewLongestChain(t *testing.T) {
 		cfg := configtest.NewGeneralConfig(t, nil)
 		txStore := cltest.NewTestTxStore(t, db, cfg.Database())
 		ethKeyStore := cltest.NewKeyStore(t, db, cfg.Database()).Eth()
-		_, fromAddress := cltest.MustAddRandomKeyToKeystore(t, ethKeyStore)
+		_, fromAddress := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 		var subscribeCalls atomic.Int32
 

--- a/core/web/eth_keys_controller_test.go
+++ b/core/web/eth_keys_controller_test.go
@@ -41,10 +41,10 @@ func TestETHKeysController_Index_Success(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// enabled key
-	k0, addr0 := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
+	k0, addr0 := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 	// disabled keys
-	k1, addr1 := cltest.MustInsertRandomDisabledKey(t, app.KeyStore.Eth())
-	k2, addr2 := cltest.MustInsertRandomDisabledKey(t, app.KeyStore.Eth())
+	k1, addr1 := cltest.RandomKey{Disabled: true}.MustInsert(t, app.KeyStore.Eth())
+	k2, addr2 := cltest.RandomKey{Disabled: true}.MustInsert(t, app.KeyStore.Eth())
 	expectedKeys := []ethkey.KeyV2{k0, k1, k2}
 
 	ethClient.On("BalanceAt", mock.Anything, addr0, mock.Anything).Return(big.NewInt(256), nil).Once()
@@ -93,7 +93,7 @@ func TestETHKeysController_Index_Errors(t *testing.T) {
 
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
-	_, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
+	_, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	ethClient.On("BalanceAt", mock.Anything, addr, mock.Anything).Return(nil, errors.New("fake error")).Once()
 	ethClient.On("LINKBalance", mock.Anything, addr, mock.Anything).Return(nil, errors.New("fake error")).Once()
@@ -130,7 +130,7 @@ func TestETHKeysController_Index_Disabled(t *testing.T) {
 
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
-	_, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
+	_, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	require.NoError(t, app.Start(testutils.Context(t)))
 
@@ -259,7 +259,7 @@ func TestETHKeysController_ChainSuccess_UpdateNonce(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// enabled key
-	key, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
+	key, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	ethClient.On("BalanceAt", mock.Anything, addr, mock.Anything).Return(big.NewInt(1), nil).Once()
 	ethClient.On("LINKBalance", mock.Anything, addr, mock.Anything).Return(assets.NewLinkFromJuels(1), nil).Once()
@@ -303,7 +303,7 @@ func TestETHKeysController_ChainSuccess_Disable(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// enabled key
-	key, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
+	key, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	ethClient.On("BalanceAt", mock.Anything, addr, mock.Anything).Return(big.NewInt(1), nil).Once()
 	ethClient.On("LINKBalance", mock.Anything, addr, mock.Anything).Return(assets.NewLinkFromJuels(1), nil).Once()
@@ -347,7 +347,7 @@ func TestETHKeysController_ChainSuccess_Enable(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// disabled key
-	key, addr := cltest.MustInsertRandomDisabledKey(t, app.KeyStore.Eth())
+	key, addr := cltest.RandomKey{Disabled: true}.MustInsert(t, app.KeyStore.Eth())
 
 	ethClient.On("BalanceAt", mock.Anything, addr, mock.Anything).Return(big.NewInt(1), nil).Once()
 	ethClient.On("LINKBalance", mock.Anything, addr, mock.Anything).Return(assets.NewLinkFromJuels(1), nil).Once()
@@ -391,7 +391,7 @@ func TestETHKeysController_ChainSuccess_ResetWithAbandon(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// enabled key
-	key, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
+	key, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	ethClient.On("BalanceAt", mock.Anything, addr, mock.Anything).Return(big.NewInt(1), nil).Once()
 	ethClient.On("LINKBalance", mock.Anything, addr, mock.Anything).Return(assets.NewLinkFromJuels(1), nil).Once()
@@ -457,7 +457,7 @@ func TestETHKeysController_ChainFailure_InvalidAbandon(t *testing.T) {
 	app := cltest.NewApplicationWithConfig(t, cfg, ethClient)
 
 	// enabled key
-	_, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
+	_, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
@@ -491,7 +491,7 @@ func TestETHKeysController_ChainFailure_InvalidEnabled(t *testing.T) {
 	app := cltest.NewApplicationWithConfig(t, cfg, ethClient)
 
 	// enabled key
-	_, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
+	_, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
@@ -617,7 +617,7 @@ func TestETHKeysController_ChainFailure_MissingChainID(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// enabled key
-	_, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
+	_, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	require.NoError(t, app.Start(testutils.Context(t)))
 
@@ -650,7 +650,7 @@ func TestETHKeysController_ChainFailure_InvalidNonce(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// enabled key
-	_, addr := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
+	_, addr := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	require.NoError(t, app.Start(testutils.Context(t)))
 
@@ -680,8 +680,8 @@ func TestETHKeysController_DeleteSuccess(t *testing.T) {
 	require.NoError(t, app.KeyStore.Unlock(cltest.Password))
 
 	// enabled keys
-	key0, addr0 := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
-	_, addr1 := cltest.MustInsertRandomEnabledKey(t, app.KeyStore.Eth())
+	key0, addr0 := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
+	_, addr1 := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	ethClient.On("BalanceAt", mock.Anything, addr0, mock.Anything).Return(big.NewInt(1), nil).Once()
 	ethClient.On("BalanceAt", mock.Anything, addr1, mock.Anything).Return(big.NewInt(1), nil).Once()

--- a/core/web/evm_transactions_controller_test.go
+++ b/core/web/evm_transactions_controller_test.go
@@ -28,7 +28,7 @@ func TestTransactionsController_Index_Success(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, app.GetSqlxDB(), app.GetConfig().Database())
 	ethKeyStore := cltest.NewKeyStore(t, db, app.Config.Database()).Eth()
 	client := app.NewHTTPClient(&cltest.User{})
-	_, from := cltest.MustInsertRandomKey(t, ethKeyStore, 0)
+	_, from := cltest.MustInsertRandomKey(t, ethKeyStore)
 
 	cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)        // tx1
 	tx2 := cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 3, 2, from) // tx2
@@ -83,7 +83,7 @@ func TestTransactionsController_Show_Success(t *testing.T) {
 
 	txStore := cltest.NewTestTxStore(t, app.GetSqlxDB(), app.GetConfig().Database())
 	client := app.NewHTTPClient(&cltest.User{})
-	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), 0)
+	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	tx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, from)
 	require.Len(t, tx.TxAttempts, 1)
@@ -116,7 +116,7 @@ func TestTransactionsController_Show_NotFound(t *testing.T) {
 
 	txStore := cltest.NewTestTxStore(t, app.GetSqlxDB(), app.GetConfig().Database())
 	client := app.NewHTTPClient(&cltest.User{})
-	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), 0)
+	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 	tx := cltest.MustInsertUnconfirmedEthTxWithBroadcastLegacyAttempt(t, txStore, 1, from)
 	require.Len(t, tx.TxAttempts, 1)
 	attempt := tx.TxAttempts[0]

--- a/core/web/evm_tx_attempts_controller_test.go
+++ b/core/web/evm_tx_attempts_controller_test.go
@@ -23,7 +23,7 @@ func TestTxAttemptsController_Index_Success(t *testing.T) {
 	txStore := cltest.NewTestTxStore(t, app.GetSqlxDB(), app.GetConfig().Database())
 	client := app.NewHTTPClient(&cltest.User{})
 
-	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth(), 0)
+	_, from := cltest.MustInsertRandomKey(t, app.KeyStore.Eth())
 
 	cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 0, 1, from)
 	cltest.MustInsertConfirmedEthTxWithLegacyAttempt(t, txStore, 1, 2, from)


### PR DESCRIPTION
`MustInsertRandomKey` was accepting `opts ...interface{}` and using runtime type checks to interpret them. Some integer types were used for chains ids and others were used for the nonce. When the wrong type is passed, or a completely unrecognized one, the errors were quietly logged and did not fail the test. This PR refactors to a type safe API with fewer helper funcs and fixes some cases that were trying to pass chain IDs as unrecognized types, and others using int types for chain IDs which were applied as nonces.