### PR TITLE
update codeowners coverage

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -72,16 +72,24 @@ core/scripts/gateway @bolekk @pinebit
 
 # Contracts
 /contracts/ @se3000 @connorwstein @RensR
-/contracts/**/*Keeper* @smartcontractkit/keepers
-/contracts/**/*Upkeep* @smartcontractkit/keepers
-/contracts/**/*Functions* @smartcontractkit/functions
+
+/contracts/srv/v0.8/automation @smartcontractkit/keepers
+/contracts/**/*keeper* @smartcontractkit/keepers
+/contracts/**/*upkeep* @smartcontractkit/keepers
+/contracts/**/*automation* @smartcontractkit/keepers
+/contracts/gas-snapshots/automation.gas-snapshot @smartcontractkit/keepers
+
 /contracts/src/v0.8/functions @smartcontractkit/functions
-/contracts/test/v0.8/functions @smartcontractkit/functions
+/contracts/**/*functions* @smartcontractkit/functions
+/contracts/gas-snapshots/functions.gas-snapshot @smartcontractkit/functions
+
 /contracts/src/v0.8/llo-feeds @austinborn @Fletch153
+/contracts/gas-snapshots/llo-feeds.gas-snapshot @austinborn @Fletch153
+
 /contracts/src/v0.8/vrf @smartcontractkit/vrf-team
-/contracts/src/v0.8/dev/vrf @smartcontractkit/vrf-team
-/contracts/src/v0.8/dev/BlockhashStore.sol @smartcontractkit/vrf-team
-/contracts/src/v0.8/dev/VRFConsumerBaseV2Upgradeable.sol @smartcontractkit/vrf-team
+/contracts/**/*vrf* @smartcontractkit/vrf-team
+
+/contracts/src/v0.8/l2ep @simsonraj
 
 # Tests
 /integration-tests/ @smartcontractkit/test-tooling-team


### PR DESCRIPTION
Include the gas snapshots so the `contracts` owners don't get notified for each change to any snapshot