### PR TITLE
rm old solidity versions from NPM package

### DIFF
--- a/contracts/CHANGELOG.md
+++ b/contracts/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Moved `VRFCoordinatorV2Mock.sol` to src/v0.8/vrf/mocks
 - Moved `VRFCoordinatorMock.sol` to src/v0.8/vrf/mocks
 
+### Removed
+
+- Removed all code related to versions prior to Solidity 0.8.0 (#10931)
+
 ## 0.8.0 - 2023-10-04
 
 ### Changed

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -21,8 +21,8 @@
     "solhint": "solhint --max-warnings 593 \"./src/v0.8/**/*.sol\""
   },
   "files": [
-    "src/",
-    "abi/"
+    "src/v0.8",
+    "abi/src/v0.8"
   ],
   "pnpm": {
     "_comment": "See https://github.com/ethers-io/ethers.js/discussions/2849#discussioncomment-2696454",


### PR DESCRIPTION
This PR removes old Solidity code from the next NPM package release. Only contracts that use Solidity `0.8.0` or higher will be included