### PR TITLE
faster generate

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -212,7 +212,7 @@ jobs:
   clean:
     name: Clean Go Tidy & Generate
     if: ${{ !contains(join(github.event.pull_request.labels.*.name, ' '), 'skip-smoke-tests') }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu20.04-8cores-32GB
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
`make generate` is currently the slowest part of the CI Core workflow, usually > 10m. Trying more power.
![more-power](https://github.com/smartcontractkit/chainlink/assets/1194128/b6d5590e-2473-4a1f-843b-0539e164e8b2)
