### PR TITLE
Update to stable foundry nightly build

### DIFF
--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -55,7 +55,7 @@ jobs:
         uses: foundry-rs/foundry-toolchain@v1
         with:
           # Has to match the `make foundry` version.
-          version: nightly-e0722a10b45859892ec3b998df958a9edc77c202
+          version: nightly-5be158ba6dc7c798a6f032026fe60fc01686b33b
 
       - name: Run Forge build
         run: |

--- a/contracts/GNUmakefile
+++ b/contracts/GNUmakefile
@@ -38,7 +38,7 @@ mockery: $(mockery) ## Install mockery.
 
 .PHONY: foundry
 foundry: ## Install foundry.
-	foundryup --version nightly-e0722a10b45859892ec3b998df958a9edc77c202
+	foundryup --version nightly-5be158ba6dc7c798a6f032026fe60fc01686b33b
 
 .PHONY: foundry-refresh
 foundry-refresh: foundry


### PR DESCRIPTION
Amends hash of Foundry's Oct 2nd 2023 nightly build
![image](https://github.com/smartcontractkit/chainlink/assets/28818476/a9885ade-903c-48e0-9a53-41cbf88bb2f5)
