### PR TITLE
core/services/ocrcommon: close started SingletonPeerWrapper

### DIFF
--- a/core/services/ocrcommon/peer_wrapper_test.go
+++ b/core/services/ocrcommon/peer_wrapper_test.go
@@ -53,6 +53,7 @@ func Test_SingletonPeerWrapper_Start(t *testing.T) {
 
 		require.NoError(t, pw.Start(testutils.Context(t)), "foo")
 		require.Equal(t, k.PeerID(), pw.PeerID)
+		require.NoError(t, pw.Close())
 	})
 
 	t.Run("with one p2p key and mismatching P2P.PeerID returns error", func(t *testing.T) {
@@ -87,6 +88,7 @@ func Test_SingletonPeerWrapper_Start(t *testing.T) {
 
 		require.NoError(t, pw.Start(testutils.Context(t)), "foo")
 		require.Equal(t, k2.PeerID(), pw.PeerID)
+		require.NoError(t, pw.Close())
 	})
 
 	t.Run("with multiple p2p keys and mismatching P2P.PeerID returns error", func(t *testing.T) {
@@ -134,14 +136,14 @@ func Test_SingletonPeerWrapper_Close(t *testing.T) {
 
 	require.NoError(t, pw.Start(testutils.Context(t)))
 	require.True(t, pw.IsStarted(), "Should have started successfully")
-	pw.Close()
+	require.NoError(t, pw.Close())
 
 	/* If peer is still stuck in listenLoop, we will get a bind error trying to start on the same port */
 	require.False(t, pw.IsStarted())
 	pw = ocrcommon.NewSingletonPeerWrapper(keyStore, cfg.P2P(), cfg.OCR(), cfg.Database(), db, logger.TestLogger(t))
 	require.NoError(t, pw.Start(testutils.Context(t)), "Should have shut down gracefully, and be able to re-use same port")
 	require.True(t, pw.IsStarted(), "Should have started successfully")
-	pw.Close()
+	require.NoError(t, pw.Close())
 }
 
 func TestSingletonPeerWrapper_PeerConfig(t *testing.T) {


### PR DESCRIPTION
```
==================
WARNING: DATA RACE
Read at 0x00c000c9b083 by goroutine 478:
  testing.(*common).logDepth()
      /opt/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1011 +0xbb
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1004 +0x99
  testing.(*common).Logf()
      /opt/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1055 +0x62
  testing.(*T).Logf()
      <autogenerated>:1 +0x69
  go.uber.org/zap/zaptest.testingWriter.Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.26.0/zaptest/logger.go:130 +0x11d
  go.uber.org/zap/zaptest.(*testingWriter).Write()
      <autogenerated>:1 +0x74
  go.uber.org/zap/zapcore.(*ioCore).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.26.0/zapcore/core.go:99 +0x192
  go.uber.org/zap/zapcore.(*CheckedEntry).Write()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.26.0/zapcore/entry.go:253 +0x2af
  go.uber.org/zap.(*SugaredLogger).log()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.26.0/sugar.go:316 +0x12f
  go.uber.org/zap.(*SugaredLogger).Debugw()
      /home/runner/go/pkg/mod/go.uber.org/zap@v1.26.0/sugar.go:218 +0xa4
  github.com/smartcontractkit/chainlink/v2/core/logger.(*zapLogger).Debugw()
      <autogenerated>:1 +0x1f
  github.com/smartcontractkit/chainlink-relay/pkg/logger.(*ocrWrapper).Debug()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-relay@v0.1.7-0.20231003135342-5e581164f8dd/pkg/logger/ocr.go:32 +0x28f
  github.com/smartcontractkit/libocr/internal/loghelper.loggerWithContextImpl.Debug()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20231005165226-b11533ed6d5e/internal/loghelper/logger_with_context.go:33 +0x138
  github.com/smartcontractkit/libocr/internal/loghelper.(*loggerWithContextImpl).Debug()
      <autogenerated>:1 +0x74
  github.com/smartcontractkit/libocr/networking/ragedisco.(*discoveryProtocol).sendLoop()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20231005165226-b11533ed6d5e/networking/ragedisco/discovery_protocol.go:575 +0x432
  github.com/smartcontractkit/libocr/networking/ragedisco.(*discoveryProtocol).sendLoop-fm()
      <autogenerated>:1 +0x33
  github.com/smartcontractkit/libocr/subprocesses.(*Subprocesses).Go.func1()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20231005165226-b11533ed6d5e/subprocesses/subprocesses.go:29 +0x72

Previous write at 0x00c000c9b083 by goroutine 433:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1582 +0x81a
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.21.1/x64/src/runtime/panic.go:477 +0x30
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1648 +0x44

Goroutine 478 (running) created at:
  github.com/smartcontractkit/libocr/subprocesses.(*Subprocesses).Go()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20231005165226-b11533ed6d5e/subprocesses/subprocesses.go:27 +0xe4
  github.com/smartcontractkit/libocr/networking/ragedisco.(*discoveryProtocol).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20231005165226-b11533ed6d5e/networking/ragedisco/discovery_protocol.go:149 +0x392
  github.com/smartcontractkit/libocr/networking/ragedisco.(*Ragep2pDiscoverer).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20231005165226-b11533ed6d5e/networking/ragedisco/ragep2p_discoverer.go:111 +0x564
  github.com/smartcontractkit/libocr/ragep2p.(*Host).Start()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20231005165226-b11533ed6d5e/ragep2p/ragep2p.go:243 +0x6dc
  github.com/smartcontractkit/libocr/networking.NewPeer()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/libocr@v0.0.0-20231005165226-b11533ed6d5e/networking/peer_v2.go:85 +0x5d5
  github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon_test.Test_SingletonPeerWrapper_Start.func2.(*SingletonPeerWrapper).Start.func3()
      /home/runner/work/chainlink/chainlink/core/services/ocrcommon/peer_wrapper.go:102 +0x224
  github.com/smartcontractkit/chainlink/v2/core/utils.(*StartStopOnce).StartOnce()
      /home/runner/work/chainlink/chainlink/core/utils/utils.go:898 +0xf6
  github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon.(*SingletonPeerWrapper).Start()
      /home/runner/work/chainlink/chainlink/core/services/ocrcommon/peer_wrapper.go:94 +0x5b4
  github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon_test.Test_SingletonPeerWrapper_Start.func2()
      /home/runner/work/chainlink/chainlink/core/services/ocrcommon/peer_wrapper_test.go:55 +0x554
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1595 +0x238
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1648 +0x44

Goroutine 433 (running) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1648 +0x82a
  github.com/smartcontractkit/chainlink/v2/core/services/ocrcommon_test.Test_SingletonPeerWrapper_Start()
      /home/runner/work/chainlink/chainlink/core/services/ocrcommon/peer_wrapper_test.go:40 +0x173
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1595 +0x238
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.1/x64/src/testing/testing.go:1648 +0x44
==================
```