### PR TITLE
Randomize name to avoid contention on 'idx_jobs_name'

### DIFF
--- a/core/cmd/jobs_commands_test.go
+++ b/core/cmd/jobs_commands_test.go
@@ -299,7 +299,7 @@ const directRequestSpecTemplate = `
 type                = "directrequest"
 schemaVersion       = 1
 evmChainID          = "0"
-name                = "example eth request event spec"
+name                = "%s"
 contractAddress     = "0x613a38AC1659769640aaE063C651F48E0250454C"
 externalJobID       = "%s"
 observationSource   = """
@@ -312,7 +312,7 @@ observationSource   = """
 `
 
 func getDirectRequestSpec() string {
-	return fmt.Sprintf(directRequestSpecTemplate, uuid.New())
+	return fmt.Sprintf(directRequestSpecTemplate, uuid.New(), uuid.New())
 }
 
 func TestShell_ListFindJobs(t *testing.T) {


### PR DESCRIPTION
Postgres logs show this alot:

```
2023-10-19 10:03:06.584 UTC [1981] LOG:  process 1981 still waiting for ShareLock on transaction 22607 after 31705.576 ms
cl_pg  | 2023-10-19 10:03:06.584 UTC [1981] DETAIL:  Process holding the lock: 1951. Wait queue: 1954, 1981.
cl_pg  | 2023-10-19 10:03:06.584 UTC [1981] CONTEXT:  while inserting index tuple (3,28) in relation "idx_jobs_name"
cl_pg  | 2023-10-19 10:03:06.584 UTC [1981] STATEMENT:  INSERT INTO jobs (pipeline_spec_id, name, schema_version, type, max_task_duration, ocr_oracle_spec_id, ocr2_oracle_spec_id, direct_request_spec_id, flux_monitor_spec_id,
cl_pg  | 					keeper_spec_id, cron_spec_id, vrf_spec_id, webhook_spec_id, blockhash_store_spec_id, bootstrap_spec_id, block_header_feeder_spec_id, gateway_spec_id, 
cl_pg  | 	                legacy_gas_station_server_spec_id, legacy_gas_station_sidecar_spec_id, external_job_id, gas_limit, forwarding_allowed, created_at)
cl_pg  | 			VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9,
cl_pg  | 					$10, $11, $12, $13, $14, $15, $16, $17, 
cl_pg  | 			        $18, $19, $20, $21, $22, NOW())
cl_pg  | 			RETURNING *;
```

suggesting that we aren't randomizing the `job.name` properly.