### PR TITLE
fix: retries for LINKNATIVEFEED and LINKETHFEED

### DIFF
--- a/core/services/vrf/delegate.go
+++ b/core/services/vrf/delegate.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
+	"github.com/avast/retry-go/v4"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	"github.com/theodesp/go-heaps/pairing"
@@ -144,10 +146,19 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 			if vrfOwner != nil {
 				return nil, errors.New("VRF Owner is not supported for VRF V2 Plus")
 			}
-			linkNativeFeedAddress, err := coordinatorV2Plus.LINKNATIVEFEED(nil)
+
+			// Get the LINKNATIVEFEED address with retries
+			// This is needed because the RPC endpoint may be down so we need to
+			// switch over to another one.
+			var linkNativeFeedAddress common.Address
+			err = retry.Do(func() error {
+				linkNativeFeedAddress, err = coordinatorV2Plus.LINKNATIVEFEED(nil)
+				return err
+			}, retry.Attempts(10), retry.Delay(500*time.Millisecond))
 			if err != nil {
-				return nil, errors.Wrap(err, "LINKNATIVEFEED")
+				return nil, errors.Wrap(err, "can't call LINKNATIVEFEED")
 			}
+
 			aggregator, err := aggregator_v3_interface.NewAggregatorV3Interface(linkNativeFeedAddress, chain.Client())
 			if err != nil {
 				return nil, errors.Wrap(err, "NewAggregatorV3Interface")
@@ -189,7 +200,14 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 				return nil, err
 			}
 
-			linkEthFeedAddress, err := coordinatorV2.LINKETHFEED(nil)
+			// Get the LINKETHFEED address with retries
+			// This is needed because the RPC endpoint may be down so we need to
+			// switch over to another one.
+			var linkEthFeedAddress common.Address
+			err = retry.Do(func() error {
+				linkEthFeedAddress, err = coordinatorV2.LINKETHFEED(nil)
+				return err
+			}, retry.Attempts(10), retry.Delay(500*time.Millisecond))
 			if err != nil {
 				return nil, errors.Wrap(err, "LINKETHFEED")
 			}


### PR DESCRIPTION
Calls to methods that require RPC connectivity in ServicesForSpec cause issues if they fail since ServicesForSpec is not called. Add retry logic so that we take advantage of the EVM client's node rotation.