### PR TITLE
bump golangci-lint to 1.55.0

### DIFF
--- a/.github/actions/golangci-lint/action.yml
+++ b/.github/actions/golangci-lint/action.yml
@@ -53,7 +53,7 @@ runs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@3a919529898de77ec3da873e3063ca4b10e7f5cc # v3.7.0
       with:
-        version: v1.54.2
+        version: v1.55.0
         # We already cache these directories in setup-go
         skip-pkg-cache: true
         skip-build-cache: true

--- a/.tool-versions
+++ b/.tool-versions
@@ -4,4 +4,4 @@ nodejs 16.16.0
 postgres 13.3
 helm 3.10.3
 zig 0.10.1
-golangci-lint 1.54.2
+golangci-lint 1.55.0

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -146,7 +146,7 @@ config-docs: ## Generate core node configuration documentation
 .PHONY: golangci-lint
 golangci-lint: ## Run golangci-lint for all issues.
 	[ -d "./golangci-lint" ] || mkdir ./golangci-lint && \
-	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.54.2 golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 > ./golangci-lint/$(shell date +%Y-%m-%d_%H:%M:%S).txt
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.55.0 golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 > ./golangci-lint/$(shell date +%Y-%m-%d_%H:%M:%S).txt
 
 
 GORELEASER_CONFIG ?= .goreleaser.yaml

--- a/common/headtracker/head_listener.go
+++ b/common/headtracker/head_listener.go
@@ -83,9 +83,8 @@ func (hl *HeadListener[HTH, S, ID, BLOCK_HASH]) ListenForNewHeads(handleNewHead 
 		} else if err != nil {
 			hl.logger.Errorw("Error in new head subscription, unsubscribed", "err", err)
 			continue
-		} else {
-			break
 		}
+		break
 	}
 }
 

--- a/core/chains/cosmos/cosmostxm/orm_test.go
+++ b/core/chains/cosmos/cosmostxm/orm_test.go
@@ -6,13 +6,12 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	cosmosdb "github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/db"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/cosmos/cosmostxm"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/cosmostest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
-
-	. "github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/db"
-
-	. "github.com/smartcontractkit/chainlink/v2/core/chains/cosmos/cosmostxm"
 )
 
 func TestORM(t *testing.T) {
@@ -20,7 +19,7 @@ func TestORM(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	logCfg := pgtest.NewQConfig(true)
 	chainID := cosmostest.RandomChainID()
-	o := NewORM(chainID, db, lggr, logCfg)
+	o := cosmostxm.NewORM(chainID, db, lggr, logCfg)
 
 	// Create
 	mid, err := o.InsertMsg("0x123", "", []byte("hello"))
@@ -28,7 +27,7 @@ func TestORM(t *testing.T) {
 	assert.NotEqual(t, 0, int(mid))
 
 	// Read
-	unstarted, err := o.GetMsgsState(Unstarted, 5)
+	unstarted, err := o.GetMsgsState(cosmosdb.Unstarted, 5)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(unstarted))
 	assert.Equal(t, "hello", string(unstarted[0].Raw))
@@ -36,21 +35,21 @@ func TestORM(t *testing.T) {
 	t.Log(unstarted[0].UpdatedAt, unstarted[0].CreatedAt)
 
 	// Limit
-	unstarted, err = o.GetMsgsState(Unstarted, 0)
+	unstarted, err = o.GetMsgsState(cosmosdb.Unstarted, 0)
 	assert.Error(t, err)
 	assert.Empty(t, unstarted)
-	unstarted, err = o.GetMsgsState(Unstarted, -1)
+	unstarted, err = o.GetMsgsState(cosmosdb.Unstarted, -1)
 	assert.Error(t, err)
 	assert.Empty(t, unstarted)
 	mid2, err := o.InsertMsg("0xabc", "", []byte("test"))
 	require.NoError(t, err)
 	assert.NotEqual(t, 0, int(mid2))
-	unstarted, err = o.GetMsgsState(Unstarted, 1)
+	unstarted, err = o.GetMsgsState(cosmosdb.Unstarted, 1)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(unstarted))
 	assert.Equal(t, "hello", string(unstarted[0].Raw))
 	assert.Equal(t, chainID, unstarted[0].ChainID)
-	unstarted, err = o.GetMsgsState(Unstarted, 2)
+	unstarted, err = o.GetMsgsState(cosmosdb.Unstarted, 2)
 	require.NoError(t, err)
 	require.Equal(t, 2, len(unstarted))
 	assert.Equal(t, "test", string(unstarted[1].Raw))
@@ -58,11 +57,11 @@ func TestORM(t *testing.T) {
 
 	// Update
 	txHash := "123"
-	err = o.UpdateMsgs([]int64{mid}, Started, &txHash)
+	err = o.UpdateMsgs([]int64{mid}, cosmosdb.Started, &txHash)
 	require.NoError(t, err)
-	err = o.UpdateMsgs([]int64{mid}, Broadcasted, &txHash)
+	err = o.UpdateMsgs([]int64{mid}, cosmosdb.Broadcasted, &txHash)
 	require.NoError(t, err)
-	broadcasted, err := o.GetMsgsState(Broadcasted, 5)
+	broadcasted, err := o.GetMsgsState(cosmosdb.Broadcasted, 5)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(broadcasted))
 	assert.Equal(t, broadcasted[0].Raw, unstarted[0].Raw)
@@ -70,9 +69,9 @@ func TestORM(t *testing.T) {
 	assert.Equal(t, *broadcasted[0].TxHash, txHash)
 	assert.Equal(t, chainID, broadcasted[0].ChainID)
 
-	err = o.UpdateMsgs([]int64{mid}, Confirmed, nil)
+	err = o.UpdateMsgs([]int64{mid}, cosmosdb.Confirmed, nil)
 	require.NoError(t, err)
-	confirmed, err := o.GetMsgsState(Confirmed, 5)
+	confirmed, err := o.GetMsgsState(cosmosdb.Confirmed, 5)
 	require.NoError(t, err)
 	require.Equal(t, 1, len(confirmed))
 }

--- a/core/chains/evm/txmgr/transmitchecker.go
+++ b/core/chains/evm/txmgr/transmitchecker.go
@@ -259,10 +259,9 @@ func (v *VRFV1Checker) Check(
 			"meta", tx.Meta,
 			"reqID", reqID)
 		return errors.New("request already fulfilled")
-	} else {
-		// Request not fulfilled
-		return nil
 	}
+	// Request not fulfilled
+	return nil
 }
 
 // VRFV2Checker is an implementation of TransmitChecker that checks whether a VRF V2 fulfillment
@@ -351,11 +350,11 @@ func (v *VRFV2Checker) Check(
 			"meta", tx.Meta,
 			"vrfRequestId", vrfRequestID)
 		return errors.New("request already fulfilled")
-	} else {
-		l.Debugw("Request not yet fulfilled",
-			"ethTxID", tx.ID,
-			"meta", tx.Meta,
-			"vrfRequestId", vrfRequestID)
-		return nil
 	}
+	l.Debugw("Request not yet fulfilled",
+		"ethTxID", tx.ID,
+		"meta", tx.Meta,
+		"vrfRequestId", vrfRequestID)
+	return nil
+
 }

--- a/core/chains/evm/txmgr/transmitchecker_test.go
+++ b/core/chains/evm/txmgr/transmitchecker_test.go
@@ -230,11 +230,10 @@ func TestTransmitCheckers(t *testing.T) {
 				} else if reqID == r2 {
 					// Request 2 errors
 					return v1.Callbacks{}, errors.New("error getting commitment")
-				} else {
-					return v1.Callbacks{
-						SeedAndBlockNum: [32]byte{1},
-					}, nil
 				}
+				return v1.Callbacks{
+					SeedAndBlockNum: [32]byte{1},
+				}, nil
 			},
 			Client: client,
 		}
@@ -325,10 +324,9 @@ func TestTransmitCheckers(t *testing.T) {
 				} else if requestID.String() == "2" {
 					// Request 2 errors
 					return [32]byte{}, errors.New("error getting commitment")
-				} else {
-					// All other requests are unfulfilled
-					return [32]byte{1}, nil
 				}
+				// All other requests are unfulfilled
+				return [32]byte{1}, nil
 			},
 			HeadByNumber: func(ctx context.Context, n *big.Int) (*evmtypes.Head, error) {
 				return &evmtypes.Head{

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -1008,8 +1008,7 @@ func confirmAction(c *cli.Context) bool {
 			return true
 		} else if answer == "no" {
 			return false
-		} else {
-			fmt.Printf("%s is not valid. Please type yes or no\n", answer)
 		}
+		fmt.Printf("%s is not valid. Please type yes or no\n", answer)
 	}
 }

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -18,10 +18,10 @@ import (
 
 	coscfg "github.com/smartcontractkit/chainlink-cosmos/pkg/cosmos/config"
 	relayutils "github.com/smartcontractkit/chainlink-relay/pkg/utils"
+	"github.com/smartcontractkit/chainlink-solana/pkg/solana"
 	solcfg "github.com/smartcontractkit/chainlink-solana/pkg/solana/config"
 	stkcfg "github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/config"
 
-	"github.com/smartcontractkit/chainlink-solana/pkg/solana"
 	"github.com/smartcontractkit/chainlink/v2/core/assets"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/cosmos"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"

--- a/core/services/gateway/handlers/functions/allowlist.go
+++ b/core/services/gateway/handlers/functions/allowlist.go
@@ -152,9 +152,8 @@ func (a *onchainAllowlist) UpdateFromContract(ctx context.Context) error {
 		return a.updateFromContractV0(ctx, blockNum)
 	} else if a.config.ContractVersion == 1 {
 		return a.updateFromContractV1(ctx, blockNum)
-	} else {
-		return fmt.Errorf("unknown contract version %d", a.config.ContractVersion)
 	}
+	return fmt.Errorf("unknown contract version %d", a.config.ContractVersion)
 }
 
 func (a *onchainAllowlist) updateFromContractV0(ctx context.Context, blockNum *big.Int) error {

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/router.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/router.go
@@ -71,9 +71,8 @@ func (v *vrfRouter) ParseLog(log types.Log) (generated.AbigenLog, error) {
 		return v.beacon.ParseLog(log)
 	} else if log.Address == v.coordinator.Address() {
 		return v.coordinator.ParseLog(log)
-	} else {
-		return nil, errors.Errorf("failed to parse log. contractAddress: %x logs: %x", log.Address, log.Topics)
 	}
+	return nil, errors.Errorf("failed to parse log. contractAddress: %x logs: %x", log.Address, log.Topics)
 }
 
 // GetConfirmationDelays retrieves confirmation delays from the on-chain contract.

--- a/core/services/ocr2/plugins/threshold/decryption_queue_test.go
+++ b/core/services/ocr2/plugins/threshold/decryption_queue_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -445,28 +445,28 @@ func Test_decryptionQueue_Close(t *testing.T) {
 }
 
 func waitForPendingRequestToBeAdded(t *testing.T, dq *decryptionQueue, ciphertextId decryptionPlugin.CiphertextId) {
-	NewGomegaWithT(t).Eventually(func() bool {
+	gomega.NewGomegaWithT(t).Eventually(func() bool {
 		dq.mu.RLock()
 		_, exists := dq.pendingRequests[string(ciphertextId)]
 		dq.mu.RUnlock()
 		return exists
-	}, testutils.WaitTimeout(t), "10ms").Should(BeTrue(), "pending request should be added")
+	}, testutils.WaitTimeout(t), "10ms").Should(gomega.BeTrue(), "pending request should be added")
 }
 
 func waitForPendingRequestToBeRemoved(t *testing.T, dq *decryptionQueue, ciphertextId decryptionPlugin.CiphertextId) {
-	NewGomegaWithT(t).Eventually(func() bool {
+	gomega.NewGomegaWithT(t).Eventually(func() bool {
 		dq.mu.RLock()
 		_, exists := dq.pendingRequests[string(ciphertextId)]
 		dq.mu.RUnlock()
 		return exists
-	}, testutils.WaitTimeout(t), "10ms").Should(BeFalse(), "pending request should be removed")
+	}, testutils.WaitTimeout(t), "10ms").Should(gomega.BeFalse(), "pending request should be removed")
 }
 
 func waitForCompletedRequestToBeAdded(t *testing.T, dq *decryptionQueue, ciphertextId decryptionPlugin.CiphertextId) {
-	NewGomegaWithT(t).Eventually(func() bool {
+	gomega.NewGomegaWithT(t).Eventually(func() bool {
 		dq.mu.RLock()
 		_, exists := dq.completedRequests[string(ciphertextId)]
 		dq.mu.RUnlock()
 		return exists
-	}, testutils.WaitTimeout(t), "10ms").Should(BeFalse(), "completed request should be removed")
+	}, testutils.WaitTimeout(t), "10ms").Should(gomega.BeFalse(), "completed request should be removed")
 }

--- a/core/services/relay/evm/mercury/v2/data_source.go
+++ b/core/services/relay/evm/mercury/v2/data_source.go
@@ -208,11 +208,12 @@ func setBenchmarkPrice(o *parseOutput, res pipeline.Result) error {
 	if res.Error != nil {
 		o.benchmarkPrice.Err = res.Error
 		return res.Error
-	} else if val, err := toBigInt(res.Value); err != nil {
-		return fmt.Errorf("failed to parse BenchmarkPrice: %w", err)
-	} else {
-		o.benchmarkPrice.Val = val
 	}
+	val, err := toBigInt(res.Value)
+	if err != nil {
+		return fmt.Errorf("failed to parse BenchmarkPrice: %w", err)
+	}
+	o.benchmarkPrice.Val = val
 	return nil
 }
 

--- a/core/services/relay/evm/mercury/v3/data_source.go
+++ b/core/services/relay/evm/mercury/v3/data_source.go
@@ -222,11 +222,12 @@ func setBenchmarkPrice(o *parseOutput, res pipeline.Result) error {
 	if res.Error != nil {
 		o.benchmarkPrice.Err = res.Error
 		return res.Error
-	} else if val, err := toBigInt(res.Value); err != nil {
-		return fmt.Errorf("failed to parse BenchmarkPrice: %w", err)
-	} else {
-		o.benchmarkPrice.Val = val
 	}
+	val, err := toBigInt(res.Value)
+	if err != nil {
+		return fmt.Errorf("failed to parse BenchmarkPrice: %w", err)
+	}
+	o.benchmarkPrice.Val = val
 	return nil
 }
 
@@ -234,11 +235,12 @@ func setBid(o *parseOutput, res pipeline.Result) error {
 	if res.Error != nil {
 		o.bid.Err = res.Error
 		return res.Error
-	} else if val, err := toBigInt(res.Value); err != nil {
-		return fmt.Errorf("failed to parse Bid: %w", err)
-	} else {
-		o.bid.Val = val
 	}
+	val, err := toBigInt(res.Value)
+	if err != nil {
+		return fmt.Errorf("failed to parse Bid: %w", err)
+	}
+	o.bid.Val = val
 	return nil
 }
 
@@ -246,11 +248,12 @@ func setAsk(o *parseOutput, res pipeline.Result) error {
 	if res.Error != nil {
 		o.ask.Err = res.Error
 		return res.Error
-	} else if val, err := toBigInt(res.Value); err != nil {
-		return fmt.Errorf("failed to parse Ask: %w", err)
-	} else {
-		o.ask.Val = val
 	}
+	val, err := toBigInt(res.Value)
+	if err != nil {
+		return fmt.Errorf("failed to parse Ask: %w", err)
+	}
+	o.ask.Val = val
 	return nil
 }
 

--- a/core/services/vrf/v1/integration_test.go
+++ b/core/services/vrf/v1/integration_test.go
@@ -182,10 +182,9 @@ func TestIntegration_VRF_WithBHS(t *testing.T) {
 			return true
 		} else if strings.Contains(err2.Error(), "execution reverted") {
 			return false
-		} else {
-			t.Fatal(err2)
-			return false
 		}
+		t.Fatal(err2)
+		return false
 	}, testutils.WaitTimeout(t), time.Second).Should(gomega.BeTrue())
 
 	// Wait another 160 blocks so that the request is outside the 256 block window

--- a/core/services/vrf/v2/integration_helpers_test.go
+++ b/core/services/vrf/v2/integration_helpers_test.go
@@ -477,10 +477,9 @@ func verifyBlockhashStored(
 			return true
 		} else if strings.Contains(err.Error(), "execution reverted") {
 			return false
-		} else {
-			t.Fatal(err)
-			return false
 		}
+		t.Fatal(err)
+		return false
 	}, testutils.WaitTimeout(t), time.Second).Should(gomega.BeTrue())
 }
 
@@ -503,10 +502,9 @@ func verifyBlockhashStoredTrusted(
 			return true
 		} else if strings.Contains(err.Error(), "execution reverted") {
 			return false
-		} else {
-			t.Fatal(err)
-			return false
 		}
+		t.Fatal(err)
+		return false
 	}, time.Second*300, time.Second).Should(gomega.BeTrue())
 }
 


### PR DESCRIPTION
Bump and fix new issues:

- File is not goimports-ed with -local X (goimports)

- superfluous-else: if block ends with a continue statement, so drop this else and outdent its block (revive)

- indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)

- dot-imports: should not use dot imports (revive)

Old glitch still remains:
```go
plugins/config_test.go:90: File is not `goimports`-ed with -local github.com/smartcontractkit/chainlink (goimports)
func (m *MockEnvConfig) PrometheusPort() int { return 9090 }
func (m *MockEnvConfig) TracingEnabled() bool { return true }
plugins/loop_registry_test.go:32: File is not `goimports`-ed with -local github.com/smartcontractkit/chainlink (goimports)
func (m *MockCfgTracing) Enabled() bool { return true }
```