### PR TITLE
BCF-2652: upgrade sync.Once to sync.Func/Value(s)

### DIFF
--- a/core/services/ocr2/validate/config.go
+++ b/core/services/ocr2/validate/config.go
@@ -65,20 +65,16 @@ func ToLocalConfig(ocr2Config OCR2Config, insConf InsecureConfig, spec job.OCR2O
 	return lc, nil
 }
 
-var (
-	minOCR2MaxDurationQuery     = 100 * time.Millisecond
-	minOCR2MaxDurationQueryErr  error
-	minOCR2MaxDurationQueryOnce sync.Once
-)
+const defaultMinOCR2MaxDurationQuery = 100 * time.Millisecond
 
-func getMinOCR2MaxDurationQuery() (time.Duration, error) {
-	minOCR2MaxDurationQueryOnce.Do(func() {
-		if v := env.MinOCR2MaxDurationQuery.Get(); v != "" {
-			minOCR2MaxDurationQuery, minOCR2MaxDurationQueryErr = time.ParseDuration(v)
-			if minOCR2MaxDurationQueryErr != nil {
-				minOCR2MaxDurationQueryErr = fmt.Errorf("failed to parse %s: %w", env.MinOCR2MaxDurationQuery, minOCR2MaxDurationQueryErr)
-			}
-		}
-	})
-	return minOCR2MaxDurationQuery, minOCR2MaxDurationQueryErr
-}
+var getMinOCR2MaxDurationQuery = sync.OnceValues(func() (time.Duration, error) {
+	str := env.MinOCR2MaxDurationQuery.Get()
+	if str == "" {
+		return defaultMinOCR2MaxDurationQuery, nil
+	}
+	d, err := time.ParseDuration(str)
+	if err != nil {
+		return -1, fmt.Errorf("failed to parse %s: %w", env.MinOCR2MaxDurationQuery, err)
+	}
+	return d, nil
+})

--- a/core/services/pg/q.go
+++ b/core/services/pg/q.go
@@ -273,7 +273,9 @@ func (q Q) GetNamed(sql string, dest interface{}, arg interface{}) error {
 }
 
 func (q Q) newQueryLogger(query string, args []interface{}) *queryLogger {
-	return &queryLogger{Q: q, query: query, args: args}
+	return &queryLogger{Q: q, query: query, args: args, str: sync.OnceValue(func() string {
+		return sprintQ(query, args)
+	})}
 }
 
 // sprintQ formats the query with the given args and returns the resulting string.
@@ -315,15 +317,11 @@ type queryLogger struct {
 	query string
 	args  []interface{}
 
-	str     string
-	strOnce sync.Once
+	str func() string
 }
 
 func (q *queryLogger) String() string {
-	q.strOnce.Do(func() {
-		q.str = sprintQ(q.query, q.args)
-	})
-	return q.str
+	return q.str()
 }
 
 func (q *queryLogger) logSqlQuery() {

--- a/core/utils/lazy.go
+++ b/core/utils/lazy.go
@@ -7,8 +7,8 @@ import (
 type LazyLoad[T any] struct {
 	f     func() (T, error)
 	state T
+	ok    bool
 	lock  sync.Mutex
-	once  sync.Once
 }
 
 func NewLazyLoad[T any](f func() (T, error)) *LazyLoad[T] {
@@ -21,20 +21,16 @@ func (l *LazyLoad[T]) Get() (out T, err error) {
 	l.lock.Lock()
 	defer l.lock.Unlock()
 
-	// fetch only once (or whenever cleared)
-	l.once.Do(func() {
-		l.state, err = l.f()
-	})
-	// if err, clear so next get will retry
-	if err != nil {
-		l.once = sync.Once{}
+	if l.ok {
+		return l.state, nil
 	}
-	out = l.state
-	return
+	l.state, err = l.f()
+	l.ok = err == nil
+	return l.state, err
 }
 
 func (l *LazyLoad[T]) Reset() {
 	l.lock.Lock()
 	defer l.lock.Unlock()
-	l.once = sync.Once{}
+	l.ok = false
 }

--- a/integration-tests/reorg/reorg_confirmer.go
+++ b/integration-tests/reorg/reorg_confirmer.go
@@ -58,7 +58,7 @@ type ReorgController struct {
 	initConsensusReady    chan struct{}
 	reorgStarted          chan struct{}
 	depthReached          chan struct{}
-	once                  *sync.Once
+	once                  sync.Once
 	mutex                 sync.Mutex
 	ctx                   context.Context
 	cancel                context.CancelFunc
@@ -82,11 +82,8 @@ func NewReorgController(cfg *ReorgConfig) (*ReorgController, error) {
 		initConsensusReady: make(chan struct{}, 100),
 		reorgStarted:       make(chan struct{}, 100),
 		depthReached:       make(chan struct{}, 100),
-		once:               &sync.Once{},
-		mutex:              sync.Mutex{},
 		ctx:                ctx,
 		cancel:             ctxCancel,
-		complete:           false,
 	}
 	rc.networkStep.Store(InitConsensus)
 	for _, c := range cfg.Network.GetClients() {


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCF-2652

This PR simplifies some uses of `sync.Once` with new features available in Go 1.21:

> The new [OnceFunc](https://tip.golang.org/pkg/sync/#OnceFunc), [OnceValue](https://tip.golang.org/pkg/sync/#OnceValue), and [OnceValues](https://tip.golang.org/pkg/sync/#OnceValues) functions capture a common use of [Once](https://tip.golang.org/pkg/sync/#Once) to lazily initialize a value on first use.

https://golang.org/doc/go1.21#sync