### PR TITLE
fix solhint issues under src/v0.8/automation

### DIFF
--- a/contracts/package.json
+++ b/contracts/package.json
@@ -18,7 +18,7 @@
     "prepublishOnly": "pnpm compile && ./scripts/prepublish_generate_abi_folder",
     "publish-beta": "pnpm publish --tag beta",
     "publish-prod": "npm dist-tag add @chainlink/contracts@0.8.0 latest",
-    "solhint": "solhint --max-warnings 377 \"./src/v0.8/**/*.sol\""
+    "solhint": "solhint --max-warnings 350 \"./src/v0.8/**/*.sol\""
   },
   "files": [
     "src/v0.8",

--- a/contracts/src/v0.8/automation/AutomationBase.sol
+++ b/contracts/src/v0.8/automation/AutomationBase.sol
@@ -8,7 +8,8 @@ contract AutomationBase {
    * @notice method that allows it to be simulated via eth_call by checking that
    * the sender is the zero address.
    */
-  function preventExecution() internal view {
+  function _preventExecution() internal view {
+    // solhint-disable-next-line avoid-tx-origin
     if (tx.origin != address(0)) {
       revert OnlySimulatedBackend();
     }
@@ -19,7 +20,7 @@ contract AutomationBase {
    * that the sender is the zero address.
    */
   modifier cannotExecute() {
-    preventExecution();
+    _preventExecution();
     _;
   }
 }

--- a/contracts/src/v0.8/automation/AutomationCompatible.sol
+++ b/contracts/src/v0.8/automation/AutomationCompatible.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import "./AutomationBase.sol";
-import "./interfaces/AutomationCompatibleInterface.sol";
+import {AutomationBase} from "./AutomationBase.sol";
+import {AutomationCompatibleInterface} from "./interfaces/AutomationCompatibleInterface.sol";
 
 abstract contract AutomationCompatible is AutomationBase, AutomationCompatibleInterface {}

--- a/contracts/src/v0.8/automation/Chainable.sol
+++ b/contracts/src/v0.8/automation/Chainable.sol
@@ -10,29 +10,31 @@ contract Chainable {
   /**
    * @dev addresses of the next contract in the chain **have to be immutable/constant** or the system won't work
    */
-  address private immutable FALLBACK_ADDRESS;
+  address private immutable i_FALLBACK_ADDRESS;
 
   /**
    * @param fallbackAddress the address of the next contract in the chain
    */
   constructor(address fallbackAddress) {
-    FALLBACK_ADDRESS = fallbackAddress;
+    i_FALLBACK_ADDRESS = fallbackAddress;
   }
 
   /**
    * @notice returns the address of the next contract in the chain
    */
   function fallbackTo() external view returns (address) {
-    return FALLBACK_ADDRESS;
+    return i_FALLBACK_ADDRESS;
   }
 
   /**
    * @notice the fallback function routes the call to the next contract in the chain
    * @dev most of the implementation is copied directly from OZ's Proxy contract
    */
+  // solhint-disable payable-fallback
+  // solhint-disable-next-line no-complex-fallback
   fallback() external {
     // copy to memory for assembly access
-    address next = FALLBACK_ADDRESS;
+    address next = i_FALLBACK_ADDRESS;
     // copied directly from OZ's Proxy contract
     assembly {
       // Copy msg.data. We take full control of memory in this inline assembly

--- a/contracts/src/v0.8/automation/ExecutionPrevention.sol
+++ b/contracts/src/v0.8/automation/ExecutionPrevention.sol
@@ -8,7 +8,8 @@ abstract contract ExecutionPrevention {
    * @notice method that allows it to be simulated via eth_call by checking that
    * the sender is the zero address.
    */
-  function preventExecution() internal view {
+  function _preventExecution() internal view {
+    // solhint-disable-next-line avoid-tx-origin
     if (tx.origin != address(0)) {
       revert OnlySimulatedBackend();
     }
@@ -19,7 +20,7 @@ abstract contract ExecutionPrevention {
    * that the sender is the zero address.
    */
   modifier cannotExecute() {
-    preventExecution();
+    _preventExecution();
     _;
   }
 }

--- a/contracts/src/v0.8/automation/HeartbeatRequester.sol
+++ b/contracts/src/v0.8/automation/HeartbeatRequester.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: MIT
+// solhint-disable-next-line one-contract-per-file
 pragma solidity 0.8.6;
 
-import "./../interfaces/TypeAndVersionInterface.sol";
-import "../shared/access/ConfirmedOwner.sol";
+import {TypeAndVersionInterface} from "./../interfaces/TypeAndVersionInterface.sol";
+import {ConfirmedOwner} from "../shared/access/ConfirmedOwner.sol";
 
 // defines some interfaces for type safety and reduces encoding/decoding
 // does not use the full interfaces intentionally because the requester only uses a fraction of them
@@ -32,6 +33,7 @@ contract HeartbeatRequester is TypeAndVersionInterface, ConfirmedOwner {
    * - HeartbeatRequester 1.0.0: The requester fetches the latest aggregator address from proxy, and request a new round
    *                             using the aggregator address.
    */
+  // solhint-disable-next-line chainlink-solidity/all-caps-constant-storage-variables
   string public constant override typeAndVersion = "HeartbeatRequester 1.0.0";
 
   constructor() ConfirmedOwner(msg.sender) {}

--- a/contracts/src/v0.8/automation/UpkeepTranscoder.sol
+++ b/contracts/src/v0.8/automation/UpkeepTranscoder.sol
@@ -2,8 +2,9 @@
 
 pragma solidity ^0.8.0;
 
-import "./interfaces/UpkeepTranscoderInterface.sol";
-import "../interfaces/TypeAndVersionInterface.sol";
+import {UpkeepTranscoderInterface} from "./interfaces/UpkeepTranscoderInterface.sol";
+import {TypeAndVersionInterface} from "../interfaces/TypeAndVersionInterface.sol";
+import {UpkeepFormat} from "./UpkeepFormat.sol";
 
 /**
  * @notice Transcoder for converting upkeep data from one keeper
@@ -16,6 +17,7 @@ contract UpkeepTranscoder is UpkeepTranscoderInterface, TypeAndVersionInterface 
    * @notice versions:
    * - UpkeepTranscoder 1.0.0: placeholder to allow new formats in the future
    */
+  // solhint-disable-next-line chainlink-solidity/all-caps-constant-storage-variables
   string public constant override typeAndVersion = "UpkeepTranscoder 1.0.0";
 
   /**


### PR DESCRIPTION
AUTO-6823

Update: this is only part 1 of the fixes, there will be more fixes to come.

With current PR, there are 3 warnings remaining in the src/v0.8/automation/ directory. they are:
```
> @chainlink/contracts@0.8.0 solhint /Users/leishi/chainlink/contracts
> solhint --fix "./src/v0.8/automation/*.sol"


./src/v0.8/automation/Chainable.sol
  33:3  warning  When fallback is not payable you will not be able to receive ether  payable-fallback
  33:3  warning  Fallback function must be simple                                    no-complex-fallback

./src/v0.8/automation/HeartbeatRequester.sol
  2:1  warning  Found more than One contract per file. 3 contracts found!  one-contract-per-file

✖ 3 problems (0 errors, 3 warnings)

```
let me know if I can suppress them or how to fix them.

