### PR TITLE
(chore): Reduce Functions contracts solhint warnings

### DIFF
--- a/contracts/.solhintignore
+++ b/contracts/.solhintignore
@@ -1,8 +1,8 @@
 # 351 warnings
 #./src/v0.8/automation
-# 27 warnings
-#./src/v0.8/functions
 
+# Ignore Functions v1.0.0 code that was frozen after audit
+./src/v0.8/functions/v1_0_0
 
 # Ignore tests, this should not be the long term plan but is OK in the short term
 ./src/v0.8/**/*.t.sol

--- a/contracts/package.json
+++ b/contracts/package.json
@@ -18,7 +18,7 @@
     "prepublishOnly": "pnpm compile && ./scripts/prepublish_generate_abi_folder",
     "publish-beta": "pnpm publish --tag beta",
     "publish-prod": "npm dist-tag add @chainlink/contracts@0.8.0 latest",
-    "solhint": "solhint --max-warnings 442 \"./src/v0.8/**/*.sol\""
+    "solhint": "solhint --max-warnings 351 \"./src/v0.8/**/*.sol\""
   },
   "files": [
     "src/v0.8",


### PR DESCRIPTION
`contracts/src/v0.8/functions/v1_0_0` contains code that completed audited right before the solhint rules were enforced.
This PR ignores those files as we would like to maintain them frozen in the post-audit state.
The actual warnings are resolved in the `dev` version of Functions.