### PR TITLE
Pass docker image and version to ClNode in E2E tests

### DIFF
--- a/integration-tests/docker/test_env/cl_node.go
+++ b/integration-tests/docker/test_env/cl_node.go
@@ -49,6 +49,8 @@ type ClNode struct {
 	NodeConfig            *chainlink.Config       `json:"-"`
 	NodeSecretsConfigTOML string                  `json:"-"`
 	PostgresDb            *test_env.PostgresDb    `json:"postgresDb"`
+	UserEmail             string                  `json:"userEmail"`
+	UserPassword          string                  `json:"userPassword"`
 	t                     *testing.T
 	l                     zerolog.Logger
 	lw                    *logwatch.LogWatch
@@ -97,9 +99,11 @@ func NewClNode(networks []string, imageName, imageVersion string, nodeConfig *ch
 			ContainerVersion: imageVersion,
 			Networks:         networks,
 		},
-		NodeConfig: nodeConfig,
-		PostgresDb: pgDb,
-		l:          log.Logger,
+		UserEmail:    "local@local.com",
+		UserPassword: "localdevpassword",
+		NodeConfig:   nodeConfig,
+		PostgresDb:   pgDb,
+		l:            log.Logger,
 	}
 	for _, opt := range opts {
 		opt(n)
@@ -293,14 +297,18 @@ func (n *ClNode) StartContainer() error {
 	if err != nil {
 		return err
 	}
-	n.l.Info().Str("containerName", n.ContainerName).
+	n.l.Info().
+		Str("containerName", n.ContainerName).
+		Str("containerImage", n.ContainerImage).
+		Str("containerVersion", n.ContainerVersion).
 		Str("clEndpoint", clEndpoint).
 		Str("clInternalIP", ip).
+		Str("userEmail", n.UserEmail).
+		Str("userPassword", n.UserPassword).
 		Msg("Started Chainlink Node container")
 	clClient, err := client.NewChainlinkClient(&client.ChainlinkConfig{
 		URL:        clEndpoint,
-		Email:      "local@local.com",
-		Password:   "localdevpassword",
+		Email:      n.UserEmail,
 		InternalIP: ip,
 	},
 		n.l)

--- a/integration-tests/docker/test_env/cl_node.go
+++ b/integration-tests/docker/test_env/cl_node.go
@@ -309,6 +309,7 @@ func (n *ClNode) StartContainer() error {
 	clClient, err := client.NewChainlinkClient(&client.ChainlinkConfig{
 		URL:        clEndpoint,
 		Email:      n.UserEmail,
+		Password:   n.UserPassword,
 		InternalIP: ip,
 	},
 		n.l)

--- a/integration-tests/docker/test_env/test_env.go
+++ b/integration-tests/docker/test_env/test_env.go
@@ -142,7 +142,7 @@ func (te *CLClusterTestEnv) StartClCluster(nodeConfig *chainlink.Config, count i
 	} else {
 		te.ClCluster = &ClCluster{}
 		for i := 0; i < count; i++ {
-			ocrNode := NewClNode([]string{te.Network.Name}, os.Getenv("CHAINLINK_IMAGE"), os.Getenv("CHAINLINK_IMAGE"), nodeConfig,
+			ocrNode := NewClNode([]string{te.Network.Name}, os.Getenv("CHAINLINK_IMAGE"), os.Getenv("CHAINLINK_VERSION"), nodeConfig,
 				WithSecrets(secretsConfig),
 			)
 			te.ClCluster.Nodes = append(te.ClCluster.Nodes, ocrNode)

--- a/integration-tests/docker/test_env/test_env.go
+++ b/integration-tests/docker/test_env/test_env.go
@@ -142,7 +142,7 @@ func (te *CLClusterTestEnv) StartClCluster(nodeConfig *chainlink.Config, count i
 	} else {
 		te.ClCluster = &ClCluster{}
 		for i := 0; i < count; i++ {
-			ocrNode := NewClNode([]string{te.Network.Name}, nodeConfig,
+			ocrNode := NewClNode([]string{te.Network.Name}, os.Getenv("CHAINLINK_IMAGE"), os.Getenv("CHAINLINK_IMAGE"), nodeConfig,
 				WithSecrets(secretsConfig),
 			)
 			te.ClCluster.Nodes = append(te.ClCluster.Nodes, ocrNode)


### PR DESCRIPTION
Pass docker image and version to ClNode in E2E tests. This is required to pass image node, version from TOML config.