### PR TITLE
Fix zero address checks in needsFunding

### DIFF
--- a/contracts/src/v0.8/automation/upkeeps/LinkAvailableBalanceMonitor.sol
+++ b/contracts/src/v0.8/automation/upkeeps/LinkAvailableBalanceMonitor.sol
@@ -305,6 +305,13 @@ contract LinkAvailableBalanceMonitor is ConfirmedOwner, Pausable, AutomationComp
   function _needsFunding(address targetAddress, uint256 minBalance) private view returns (bool, address) {
     ILinkAvailable target;
     IAggregatorProxy proxy = IAggregatorProxy(targetAddress);
+    // Explicitly check if the targetAddress is the zero address
+    // or if it's not a contract. In both cases return with false,
+    // to prevent target.linkAvailableForPayment from running,
+    // which would revert the operation.
+    if (targetAddress == address(0) || !(targetAddress.code.length > 0)) {
+      return (false, address(0));
+    }
     try proxy.aggregator() returns (address aggregatorAddress) {
       target = ILinkAvailable(aggregatorAddress);
     } catch {


### PR DESCRIPTION
When an address in the watchlist is the ZeroAddress or is not a contract, needsFunding won't return with an error but instead will try to run target.linkAvailableForPayment(), which in turn would revert, stopping the monitor.

This fix introduces an explicit check for ZeroAddress and addresses that are not contracts, so the function returns properly.