### PR TITLE
BCF-2716: P2P.V1 default swap & deprecation warning - [v2.7.0]

### DIFF
--- a/core/chains/evm/config/mocks/chain_scoped_config.go
+++ b/core/chains/evm/config/mocks/chain_scoped_config.go
@@ -252,9 +252,9 @@ func (_m *ChainScopedConfig) Log() coreconfig.Log {
 	return r0
 }
 
-// LogConfiguration provides a mock function with given fields: log
-func (_m *ChainScopedConfig) LogConfiguration(log coreconfig.LogfFn) {
-	_m.Called(log)
+// LogConfiguration provides a mock function with given fields: log, warn
+func (_m *ChainScopedConfig) LogConfiguration(log coreconfig.LogfFn, warn coreconfig.LogfFn) {
+	_m.Called(log, warn)
 }
 
 // Mercury provides a mock function with given fields:

--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -290,7 +290,7 @@ func (s *Shell) runNode(c *cli.Context) error {
 
 	s.Config.SetPasswords(pwd, vrfpwd)
 
-	s.Config.LogConfiguration(lggr.Debugf)
+	s.Config.LogConfiguration(lggr.Debugf, lggr.Warnf)
 
 	if err := s.Config.Validate(); err != nil {
 		return errors.Wrap(err, "config validation failed")
@@ -689,7 +689,8 @@ var errDBURLMissing = errors.New("You must set CL_DATABASE_URL env variable or p
 
 // ConfigValidate validate the client configuration and pretty-prints results
 func (s *Shell) ConfigFileValidate(_ *cli.Context) error {
-	s.Config.LogConfiguration(func(f string, params ...any) { fmt.Printf(f, params...) })
+	fn := func(f string, params ...any) { fmt.Printf(f, params...) }
+	s.Config.LogConfiguration(fn, fn)
 	if err := s.configExitErr(s.Config.Validate); err != nil {
 		return err
 	}

--- a/core/config/app_config.go
+++ b/core/config/app_config.go
@@ -28,7 +28,7 @@ type AppConfig interface {
 
 	Validate() error
 	ValidateDB() error
-	LogConfiguration(log LogfFn)
+	LogConfiguration(log, warn LogfFn)
 	SetLogLevel(lvl zapcore.Level) error
 	SetLogSQL(logSQL bool)
 	SetPasswords(keystore, vrf *string)

--- a/core/config/docs/core.toml
+++ b/core/config/docs/core.toml
@@ -359,6 +359,8 @@ TraceLogging = false # Default
 # automatically fall back to V1. If V2 starts working again later, it will automatically be preferred again. This is useful
 # for migrating networks without downtime. Note that the two networking stacks _must not_ be configured to bind to the same IP/port.
 #
+# Note: P2P.V1 is deprecated will be removed in the future.
+#
 # All nodes in the OCR network should share the same networking stack.
 [P2P]
 # IncomingMessageBufferSize is the per-remote number of incoming
@@ -377,9 +379,10 @@ PeerID = '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw' # Example
 # TraceLogging enables trace level logging.
 TraceLogging = false # Default
 
+# P2P.V1 is deprecated and will be removed in a future version.
 [P2P.V1]
 # Enabled enables P2P V1.
-Enabled = true # Default
+Enabled = false # Default
 # AnnounceIP should be set as the externally reachable IP address of the Chainlink node.
 AnnounceIP = '1.2.3.4' # Example
 # AnnouncePort should be set as the externally reachable port of the Chainlink node.
@@ -423,7 +426,7 @@ PeerstoreWriteInterval = '5m' # Default
 [P2P.V2]
 # Enabled enables P2P V2.
 # Note: V1.Enabled is true by default, so it must be set false in order to run V2 only.
-Enabled = false # Default
+Enabled = true # Default
 # AnnounceAddresses is the addresses the peer will advertise on the network in `host:port` form as accepted by the TCP version of Go’s `net.Dial`. 
 # The addresses should be reachable by other nodes on the network. When attempting to connect to another node, 
 # a node will attempt to dial all of the other node’s AnnounceAddresses in round-robin fashion.

--- a/core/scripts/chaincli/handler/handler.go
+++ b/core/scripts/chaincli/handler/handler.go
@@ -64,9 +64,7 @@ HTTPSPort = 0
 LogPoller = true
 [OCR2]
 Enabled = true
-[P2P]
-[P2P.V2]
-Enabled = true
+
 [Keeper]
 TurnLookBack = 0
 [[EVM]]

--- a/core/scripts/common/vrf/docker/toml-config/base.toml
+++ b/core/scripts/common/vrf/docker/toml-config/base.toml
@@ -26,6 +26,5 @@ HTTPSPort = 0
 
 [P2P]
 [P2P.V2]
-Enabled = true
 AnnounceAddresses = ['0.0.0.0:6690']
 ListenAddresses = ['0.0.0.0:6690']

--- a/core/scripts/ocr2vrf/util.go
+++ b/core/scripts/ocr2vrf/util.go
@@ -14,16 +14,17 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	gethtypes "github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/ethclient"
+	"github.com/urfave/cli"
+	"go.dedis.ch/kyber/v3"
+	"go.dedis.ch/kyber/v3/group/edwards25519"
+	"go.dedis.ch/kyber/v3/pairing"
+
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/confighelper"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 	"github.com/smartcontractkit/ocr2vrf/altbn_128"
 	"github.com/smartcontractkit/ocr2vrf/dkg"
 	"github.com/smartcontractkit/ocr2vrf/ocr2vrf"
 	ocr2vrftypes "github.com/smartcontractkit/ocr2vrf/types"
-	"github.com/urfave/cli"
-	"go.dedis.ch/kyber/v3"
-	"go.dedis.ch/kyber/v3/group/edwards25519"
-	"go.dedis.ch/kyber/v3/pairing"
 
 	"github.com/smartcontractkit/chainlink/v2/core/cmd"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/authorized_forwarder"
@@ -43,11 +44,7 @@ var (
 	g1                               = suite.G1()
 	g2                               = suite.G2()
 	tomlConfigTemplate               = `
-	[P2P.V1]
-	Enabled = false
-
 	[P2P.V2]
-	Enabled = true
 	ListenAddresses = ["127.0.0.1:8000"]
 
 	[Feature]

--- a/core/services/chainlink/config.go
+++ b/core/services/chainlink/config.go
@@ -52,6 +52,50 @@ func (c *Config) TOMLString() (string, error) {
 	return string(b), nil
 }
 
+// deprecationWarnings returns an error if the Config contains deprecated fields.
+// This is typically used before defaults have been applied, with input from the user.
+func (c *Config) deprecationWarnings() (err error) {
+	if c.P2P.V1 != (toml.P2PV1{}) {
+		err = multierr.Append(err, config.ErrDeprecated{Name: "P2P.V1"})
+		var err2 error
+		if c.P2P.V1.AnnounceIP != nil {
+			err2 = multierr.Append(err2, config.ErrDeprecated{Name: "AnnounceIP"})
+		}
+		if c.P2P.V1.AnnouncePort != nil {
+			err2 = multierr.Append(err2, config.ErrDeprecated{Name: "AnnouncePort"})
+		}
+		if c.P2P.V1.BootstrapCheckInterval != nil {
+			err2 = multierr.Append(err2, config.ErrDeprecated{Name: "BootstrapCheckInterval"})
+		}
+		if c.P2P.V1.DefaultBootstrapPeers != nil {
+			err2 = multierr.Append(err2, config.ErrDeprecated{Name: "DefaultBootstrapPeers"})
+		}
+		if c.P2P.V1.DHTAnnouncementCounterUserPrefix != nil {
+			err2 = multierr.Append(err2, config.ErrDeprecated{Name: "DHTAnnouncementCounterUserPrefix"})
+		}
+		if c.P2P.V1.DHTLookupInterval != nil {
+			err2 = multierr.Append(err2, config.ErrDeprecated{Name: "DHTLookupInterval"})
+		}
+		if c.P2P.V1.ListenIP != nil {
+			err2 = multierr.Append(err2, config.ErrDeprecated{Name: "ListenIP"})
+		}
+		if c.P2P.V1.ListenPort != nil {
+			err2 = multierr.Append(err2, config.ErrDeprecated{Name: "ListenPort"})
+		}
+		if c.P2P.V1.NewStreamTimeout != nil {
+			err2 = multierr.Append(err2, config.ErrDeprecated{Name: "NewStreamTimeout"})
+		}
+		if c.P2P.V1.PeerstoreWriteInterval != nil {
+			err2 = multierr.Append(err2, config.ErrDeprecated{Name: "PeerstoreWriteInterval"})
+		}
+		err2 = config.NamedMultiErrorList(err2, "P2P.V1")
+		err = multierr.Append(err, err2)
+	}
+	return
+}
+
+// Validate returns an error if the Config is not valid for use, as-is.
+// This is typically used after defaults have been applied.
 func (c *Config) Validate() error {
 	if err := config.Validate(c); err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)

--- a/core/services/chainlink/config_general.go
+++ b/core/services/chainlink/config_general.go
@@ -35,10 +35,12 @@ import (
 type generalConfig struct {
 	inputTOML     string // user input, normalized via de/re-serialization
 	effectiveTOML string // with default values included
-	secretsTOML   string // with env overdies includes, redacted
+	secretsTOML   string // with env overrides includes, redacted
 
 	c       *Config // all fields non-nil (unless the legacy method signature return a pointer)
 	secrets *Secrets
+
+	warning error // warnings about inputTOML, e.g. deprecated fields
 
 	logLevelDefault zapcore.Level
 
@@ -123,7 +125,7 @@ func (o *GeneralConfigOpts) parseSecrets(secrets string) error {
 	return nil
 }
 
-// New returns a coreconfig.GeneralConfig for the given options.
+// New returns a GeneralConfig for the given options.
 func (o GeneralConfigOpts) New() (GeneralConfig, error) {
 	err := o.parse()
 	if err != nil {
@@ -134,6 +136,8 @@ func (o GeneralConfigOpts) New() (GeneralConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	_, warning := utils.MultiErrorList(o.Config.deprecationWarnings())
 
 	o.Config.setDefaults()
 	if !o.SkipEnv {
@@ -163,6 +167,7 @@ func (o GeneralConfigOpts) New() (GeneralConfig, error) {
 		secretsTOML:   secrets,
 		c:             &o.Config,
 		secrets:       &o.Secrets,
+		warning:       warning,
 	}
 	if lvl := o.Config.Log.Level; lvl != nil {
 		cfg.logLevelDefault = zapcore.Level(*lvl)
@@ -253,10 +258,13 @@ func validateEnv() (err error) {
 	return
 }
 
-func (g *generalConfig) LogConfiguration(log coreconfig.LogfFn) {
+func (g *generalConfig) LogConfiguration(log, warn coreconfig.LogfFn) {
 	log("# Secrets:\n%s\n", g.secretsTOML)
 	log("# Input Configuration:\n%s\n", g.inputTOML)
 	log("# Effective Configuration, with defaults applied:\n%s\n", g.effectiveTOML)
+	if g.warning != nil {
+		warn("# Configuration warning:\n%s\n", g.warning)
+	}
 }
 
 // ConfigTOML implements chainlink.ConfigV2

--- a/core/services/chainlink/config_p2p_test.go
+++ b/core/services/chainlink/config_p2p_test.go
@@ -4,9 +4,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/smartcontractkit/libocr/commontypes"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/libocr/commontypes"
 )
 
 func TestP2PConfig(t *testing.T) {
@@ -23,7 +24,7 @@ func TestP2PConfig(t *testing.T) {
 	assert.True(t, p2p.TraceLogging())
 
 	v1 := p2p.V1()
-	assert.False(t, v1.Enabled())
+	assert.True(t, v1.Enabled())
 	assert.Equal(t, "1.2.3.4", v1.AnnounceIP().String())
 	assert.Equal(t, uint16(1234), v1.AnnouncePort())
 	assert.Equal(t, time.Minute, v1.BootstrapCheckInterval())
@@ -38,7 +39,7 @@ func TestP2PConfig(t *testing.T) {
 	assert.Equal(t, time.Minute, v1.PeerstoreWriteInterval())
 
 	v2 := p2p.V2()
-	assert.True(t, v2.Enabled())
+	assert.False(t, v2.Enabled())
 	assert.Equal(t, []string{"a", "b", "c"}, v2.AnnounceAddresses())
 	assert.ElementsMatch(
 		t,

--- a/core/services/chainlink/mocks/general_config.go
+++ b/core/services/chainlink/mocks/general_config.go
@@ -298,9 +298,9 @@ func (_m *GeneralConfig) Log() config.Log {
 	return r0
 }
 
-// LogConfiguration provides a mock function with given fields: log
-func (_m *GeneralConfig) LogConfiguration(log config.LogfFn) {
-	_m.Called(log)
+// LogConfiguration provides a mock function with given fields: log, warn
+func (_m *GeneralConfig) LogConfiguration(log config.LogfFn, warn config.LogfFn) {
+	_m.Called(log, warn)
 }
 
 // Mercury provides a mock function with given fields:

--- a/core/services/chainlink/testdata/config-empty-effective.toml
+++ b/core/services/chainlink/testdata/config-empty-effective.toml
@@ -142,7 +142,7 @@ PeerID = ''
 TraceLogging = false
 
 [P2P.V1]
-Enabled = true
+Enabled = false
 AnnounceIP = ''
 AnnouncePort = 0
 BootstrapCheckInterval = '20s'
@@ -155,7 +155,7 @@ NewStreamTimeout = '10s'
 PeerstoreWriteInterval = '5m0s'
 
 [P2P.V2]
-Enabled = false
+Enabled = true
 AnnounceAddresses = []
 DefaultBootstrappers = []
 DeltaDial = '15s'

--- a/core/services/chainlink/testdata/config-full.toml
+++ b/core/services/chainlink/testdata/config-full.toml
@@ -148,7 +148,7 @@ PeerID = '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw'
 TraceLogging = true
 
 [P2P.V1]
-Enabled = false
+Enabled = true
 AnnounceIP = '1.2.3.4'
 AnnouncePort = 1234
 BootstrapCheckInterval = '1m0s'
@@ -161,7 +161,7 @@ NewStreamTimeout = '1s'
 PeerstoreWriteInterval = '1m0s'
 
 [P2P.V2]
-Enabled = true
+Enabled = false
 AnnounceAddresses = ['a', 'b', 'c']
 DefaultBootstrappers = ['12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10', '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99']
 DeltaDial = '1m0s'

--- a/core/services/chainlink/testdata/config-multi-chain-effective.toml
+++ b/core/services/chainlink/testdata/config-multi-chain-effective.toml
@@ -142,7 +142,7 @@ PeerID = ''
 TraceLogging = false
 
 [P2P.V1]
-Enabled = true
+Enabled = false
 AnnounceIP = ''
 AnnouncePort = 0
 BootstrapCheckInterval = '20s'
@@ -155,7 +155,7 @@ NewStreamTimeout = '10s'
 PeerstoreWriteInterval = '5m0s'
 
 [P2P.V2]
-Enabled = false
+Enabled = true
 AnnounceAddresses = []
 DefaultBootstrappers = []
 DeltaDial = '15s'

--- a/core/services/ocr2/plugins/mercury/helpers_test.go
+++ b/core/services/ocr2/plugins/mercury/helpers_test.go
@@ -190,10 +190,6 @@ func setupNode(
 		c.P2P.PeerID = ptr(p2pKey.PeerID())
 		c.P2P.TraceLogging = ptr(true)
 
-		// [P2P.V1]
-		// Enabled = false
-		c.P2P.V1.Enabled = ptr(false)
-
 		// [P2P.V2]
 		// Enabled = true
 		// AnnounceAddresses = ['$EXT_IP:17775']

--- a/core/utils/config/validate.go
+++ b/core/utils/config/validate.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/Masterminds/semver/v3"
 	"go.uber.org/multierr"
 
 	"github.com/smartcontractkit/chainlink-relay/pkg/config"
@@ -145,4 +146,17 @@ type ErrOverride struct {
 
 func (e ErrOverride) Error() string {
 	return fmt.Sprintf("%s: overrides (duplicate keys or list elements) are not allowed for multiple secrets files", e.Name)
+}
+
+type ErrDeprecated struct {
+	Name    string
+	Version semver.Version
+}
+
+func (e ErrDeprecated) Error() string {
+	when := "a future version"
+	if e.Version != (semver.Version{}) {
+		when = fmt.Sprintf("version %s", e.Version)
+	}
+	return fmt.Sprintf("%s: is deprecated and will be removed in %s", e.Name, when)
 }

--- a/core/web/resolver/testdata/config-empty-effective.toml
+++ b/core/web/resolver/testdata/config-empty-effective.toml
@@ -142,7 +142,7 @@ PeerID = ''
 TraceLogging = false
 
 [P2P.V1]
-Enabled = true
+Enabled = false
 AnnounceIP = ''
 AnnouncePort = 0
 BootstrapCheckInterval = '20s'
@@ -155,7 +155,7 @@ NewStreamTimeout = '10s'
 PeerstoreWriteInterval = '5m0s'
 
 [P2P.V2]
-Enabled = false
+Enabled = true
 AnnounceAddresses = []
 DefaultBootstrappers = []
 DeltaDial = '15s'

--- a/core/web/resolver/testdata/config-full.toml
+++ b/core/web/resolver/testdata/config-full.toml
@@ -148,7 +148,7 @@ PeerID = '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw'
 TraceLogging = true
 
 [P2P.V1]
-Enabled = false
+Enabled = true
 AnnounceIP = '1.2.3.4'
 AnnouncePort = 1234
 BootstrapCheckInterval = '1m0s'
@@ -161,7 +161,7 @@ NewStreamTimeout = '1s'
 PeerstoreWriteInterval = '1m0s'
 
 [P2P.V2]
-Enabled = true
+Enabled = false
 AnnounceAddresses = ['a', 'b', 'c']
 DefaultBootstrappers = ['12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@foo:42/bar:10', '12D3KooWMoejJznyDuEk5aX6GvbjaG12UzeornPCBNzMRqdwrFJw@test:99']
 DeltaDial = '1m0s'

--- a/core/web/resolver/testdata/config-multi-chain-effective.toml
+++ b/core/web/resolver/testdata/config-multi-chain-effective.toml
@@ -142,7 +142,7 @@ PeerID = ''
 TraceLogging = false
 
 [P2P.V1]
-Enabled = true
+Enabled = false
 AnnounceIP = ''
 AnnouncePort = 0
 BootstrapCheckInterval = '20s'
@@ -155,7 +155,7 @@ NewStreamTimeout = '10s'
 PeerstoreWriteInterval = '5m0s'
 
 [P2P.V2]
-Enabled = false
+Enabled = true
 AnnounceAddresses = []
 DefaultBootstrappers = []
 DeltaDial = '15s'

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -29,9 +29,15 @@ These will eventually replace `TelemetryIngress.URL` and `TelemetryIngress.Serve
 
 - LogPoller will now use finality tags to dynamically determine finality on evm chains if `UseFinalityTags=true`, rather than the fixed `FinalityDepth` specified in toml config
 
-### Upcoming Required Configuration Change
+### Changed
 
-- Starting in 2.9.0, chainlink nodes will no longer allow `TelemetryIngress.URL` and `TelemetryIngress.ServerPubKey`. Any TOML configuration that sets this fields will prevent the node from booting. These fields will be replaced by `[[TelemetryIngress.Endpoints]]`
+- `P2P.V1` is now disabled (`Enabled = false`) by default. It must be explicitly enabled with `true` to be used. However, it is deprecated and will be removed in the future.
+- `P2P.V2` is now enabled (`Enabled = true`) by default.
+
+### Upcoming Required Configuration Changes
+Starting in `v2.9.0`:
+- `TelemetryIngress.URL` and `TelemetryIngress.ServerPubKey` will no longer be allowed. Any TOML configuration that sets this fields will prevent the node from booting. These fields will be replaced by `[[TelemetryIngress.Endpoints]]`
+- `P2P.V1` will no longer be supported and must not be set in TOML configuration in order to boot. Use `P2P.V2` instead. If you are using both, `V1` can simply be removed.
 
 ### Removed
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -981,6 +981,8 @@ If both are configured, then for each link with another peer, V2 networking will
 automatically fall back to V1. If V2 starts working again later, it will automatically be preferred again. This is useful
 for migrating networks without downtime. Note that the two networking stacks _must not_ be configured to bind to the same IP/port.
 
+Note: P2P.V1 is deprecated will be removed in the future.
+
 All nodes in the OCR network should share the same networking stack.
 
 ### IncomingMessageBufferSize
@@ -1017,7 +1019,7 @@ TraceLogging enables trace level logging.
 ## P2P.V1
 ```toml
 [P2P.V1]
-Enabled = true # Default
+Enabled = false # Default
 AnnounceIP = '1.2.3.4' # Example
 AnnouncePort = 1337 # Example
 BootstrapCheckInterval = '20s' # Default
@@ -1029,11 +1031,11 @@ ListenPort = 1337 # Example
 NewStreamTimeout = '10s' # Default
 PeerstoreWriteInterval = '5m' # Default
 ```
-
+P2P.V1 is deprecated and will be removed in a future version.
 
 ### Enabled
 ```toml
-Enabled = true # Default
+Enabled = false # Default
 ```
 Enabled enables P2P V1.
 
@@ -1119,7 +1121,7 @@ PeerstoreWriteInterval controls how often the peerstore for the OCR V1 networkin
 ## P2P.V2
 ```toml
 [P2P.V2]
-Enabled = false # Default
+Enabled = true # Default
 AnnounceAddresses = ['1.2.3.4:9999', '[a52d:0:a88:1274::abcd]:1337'] # Example
 DefaultBootstrappers = ['12D3KooWMHMRLQkgPbFSYHwD3NBuwtS1AmxhvKVUrcfyaGDASR4U@1.2.3.4:9999', '12D3KooWM55u5Swtpw9r8aFLQHEtw7HR4t44GdNs654ej5gRs2Dh@example.com:1234'] # Example
 DeltaDial = '15s' # Default
@@ -1130,7 +1132,7 @@ ListenAddresses = ['1.2.3.4:9999', '[a52d:0:a88:1274::abcd]:1337'] # Example
 
 ### Enabled
 ```toml
-Enabled = false # Default
+Enabled = true # Default
 ```
 Enabled enables P2P V2.
 Note: V1.Enabled is true by default, so it must be set false in order to run V2 only.

--- a/integration-tests/benchmark/keeper_test.go
+++ b/integration-tests/benchmark/keeper_test.go
@@ -37,7 +37,6 @@ Enabled = true
 
 [P2P]
 [P2P.V2]
-Enabled = true
 AnnounceAddresses = ["0.0.0.0:6690"]
 ListenAddresses = ["0.0.0.0:6690"]
 [Keeper]

--- a/integration-tests/chaos/automation_chaos_test.go
+++ b/integration-tests/chaos/automation_chaos_test.go
@@ -37,7 +37,6 @@ Enabled = true
 
 [P2P]
 [P2P.V2]
-Enabled = true
 AnnounceAddresses = ["0.0.0.0:6690"]
 ListenAddresses = ["0.0.0.0:6690"]`
 

--- a/integration-tests/config/config.go
+++ b/integration-tests/config/config.go
@@ -5,6 +5,10 @@ var (
 Enabled = true
 
 [P2P]
+[P2P.V2]
+Enabled = false
+
+[P2P]
 [P2P.V1]
 Enabled = true
 ListenIP = '0.0.0.0'
@@ -18,7 +22,6 @@ Enabled = true
 
 [P2P]
 [P2P.V2]
-Enabled = true
 AnnounceAddresses = ["0.0.0.0:6690"]
 ListenAddresses = ["0.0.0.0:6690"]`
 
@@ -67,7 +70,6 @@ CaptureEATelemetry = true
 
 [P2P]
 [P2P.V2]
-Enabled = true
 ListenAddresses = ['0.0.0.0:6690']`
 
 	TelemetryIngressConfig = `[TelemetryIngress]

--- a/integration-tests/performance/ocr_test.go
+++ b/integration-tests/performance/ocr_test.go
@@ -103,6 +103,10 @@ func setupOCRTest(t *testing.T) (testEnvironment *environment.Environment, testN
 Enabled = true
 
 [P2P]
+[P2P.V2]
+Enabled = false
+
+[P2P]
 [P2P.V1]
 Enabled = true
 ListenIP = '0.0.0.0'

--- a/integration-tests/reorg/automation_reorg_test.go
+++ b/integration-tests/reorg/automation_reorg_test.go
@@ -9,6 +9,9 @@ import (
 	"time"
 
 	"github.com/onsi/gomega"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/zap/zapcore"
+
 	"github.com/smartcontractkit/chainlink-env/environment"
 	"github.com/smartcontractkit/chainlink-env/pkg/cdk8s/blockscout"
 	"github.com/smartcontractkit/chainlink-env/pkg/helm/chainlink"
@@ -17,8 +20,6 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/logging"
 	"github.com/smartcontractkit/chainlink-testing-framework/networks"
 	"github.com/smartcontractkit/chainlink-testing-framework/utils"
-	"github.com/stretchr/testify/require"
-	"go.uber.org/zap/zapcore"
 
 	"github.com/smartcontractkit/chainlink/integration-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/client"
@@ -35,7 +36,6 @@ Enabled = true
 
 [P2P]
 [P2P.V2]
-Enabled = true
 AnnounceAddresses = ["0.0.0.0:6690"]
 ListenAddresses = ["0.0.0.0:6690"]`
 	networkTOML = `Enabled = true

--- a/integration-tests/smoke/automation_test.go
+++ b/integration-tests/smoke/automation_test.go
@@ -1038,7 +1038,6 @@ func setupAutomationTestDocker(
 	clNodeConfig.Keeper.TurnLookBack = it_utils.Ptr[int64](int64(0))
 	clNodeConfig.Keeper.Registry.SyncInterval = &syncInterval
 	clNodeConfig.Keeper.Registry.PerformGasOverhead = it_utils.Ptr[uint32](uint32(150000))
-	clNodeConfig.P2P.V2.Enabled = it_utils.Ptr[bool](true)
 	clNodeConfig.P2P.V2.AnnounceAddresses = &[]string{"0.0.0.0:6690"}
 	clNodeConfig.P2P.V2.ListenAddresses = &[]string{"0.0.0.0:6690"}
 

--- a/integration-tests/smoke/keeper_test.go
+++ b/integration-tests/smoke/keeper_test.go
@@ -1098,7 +1098,7 @@ func setupKeeperTest(t *testing.T) (
 	contracts.LinkToken,
 	*test_env.CLClusterTestEnv,
 ) {
-	clNodeConfig := node.NewConfig(node.NewBaseConfig())
+	clNodeConfig := node.NewConfig(node.NewBaseConfig(), node.WithP2Pv1())
 	turnLookBack := int64(0)
 	syncInterval := models.MustMakeDuration(5 * time.Second)
 	performGasOverhead := uint32(150000)

--- a/integration-tests/types/config/node/core.go
+++ b/integration-tests/types/config/node/core.go
@@ -115,13 +115,14 @@ func WithP2Pv1() NodeConfigOpt {
 			ListenIP:   utils2.MustIP("0.0.0.0"),
 			ListenPort: utils2.Ptr[uint16](6690),
 		}
+		// disabled default
+		c.P2P.V2 = toml.P2PV2{Enabled: utils2.Ptr(false)}
 	}
 }
 
 func WithP2Pv2() NodeConfigOpt {
 	return func(c *chainlink.Config) {
 		c.P2P.V2 = toml.P2PV2{
-			Enabled:         utils2.Ptr(true),
 			ListenAddresses: &[]string{"0.0.0.0:6690"},
 		}
 	}
@@ -130,14 +131,14 @@ func WithP2Pv2() NodeConfigOpt {
 func WithTracing() NodeConfigOpt {
 	return func(c *chainlink.Config) {
 		c.Tracing = toml.Tracing{
-			Enabled: utils2.Ptr(true),
+			Enabled:         utils2.Ptr(true),
 			CollectorTarget: utils2.Ptr("otel-collector:4317"),
 			// ksortable unique id
-			NodeID: 		 utils2.Ptr(ksuid.New().String()),
-			Attributes:      map[string]string{
+			NodeID: utils2.Ptr(ksuid.New().String()),
+			Attributes: map[string]string{
 				"env": "smoke",
 			},
-			SamplingRatio:  utils2.Ptr(1.0),
+			SamplingRatio: utils2.Ptr(1.0),
 		}
 	}
 }

--- a/integration-tests/types/config/node/defaults/sample.toml
+++ b/integration-tests/types/config/node/defaults/sample.toml
@@ -15,7 +15,6 @@ DefaultTransactionQueueDepth = 0
 
 [P2P]
 [P2P.V2]
-Enabled = true
 ListenAddresses = ['0.0.0.0:6690']
 AnnounceAddresses = ['0.0.0.0:6690']
 DeltaDial = '500ms'

--- a/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-disabled.txtar
@@ -198,7 +198,7 @@ PeerID = ''
 TraceLogging = false
 
 [P2P.V1]
-Enabled = true
+Enabled = false
 AnnounceIP = ''
 AnnouncePort = 0
 BootstrapCheckInterval = '20s'
@@ -211,7 +211,7 @@ NewStreamTimeout = '10s'
 PeerstoreWriteInterval = '5m0s'
 
 [P2P.V2]
-Enabled = false
+Enabled = true
 AnnounceAddresses = []
 DefaultBootstrappers = []
 DeltaDial = '15s'

--- a/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging-no-dir.txtar
@@ -198,7 +198,7 @@ PeerID = ''
 TraceLogging = false
 
 [P2P.V1]
-Enabled = true
+Enabled = false
 AnnounceIP = ''
 AnnouncePort = 0
 BootstrapCheckInterval = '20s'
@@ -211,7 +211,7 @@ NewStreamTimeout = '10s'
 PeerstoreWriteInterval = '5m0s'
 
 [P2P.V2]
-Enabled = false
+Enabled = true
 AnnounceAddresses = []
 DefaultBootstrappers = []
 DeltaDial = '15s'

--- a/testdata/scripts/node/validate/disk-based-logging.txtar
+++ b/testdata/scripts/node/validate/disk-based-logging.txtar
@@ -198,7 +198,7 @@ PeerID = ''
 TraceLogging = false
 
 [P2P.V1]
-Enabled = true
+Enabled = false
 AnnounceIP = ''
 AnnouncePort = 0
 BootstrapCheckInterval = '20s'
@@ -211,7 +211,7 @@ NewStreamTimeout = '10s'
 PeerstoreWriteInterval = '5m0s'
 
 [P2P.V2]
-Enabled = false
+Enabled = true
 AnnounceAddresses = []
 DefaultBootstrappers = []
 DeltaDial = '15s'

--- a/testdata/scripts/node/validate/invalid.txtar
+++ b/testdata/scripts/node/validate/invalid.txtar
@@ -188,7 +188,7 @@ PeerID = ''
 TraceLogging = false
 
 [P2P.V1]
-Enabled = true
+Enabled = false
 AnnounceIP = ''
 AnnouncePort = 0
 BootstrapCheckInterval = '20s'
@@ -201,7 +201,7 @@ NewStreamTimeout = '10s'
 PeerstoreWriteInterval = '5m0s'
 
 [P2P.V2]
-Enabled = false
+Enabled = true
 AnnounceAddresses = []
 DefaultBootstrappers = []
 DeltaDial = '15s'

--- a/testdata/scripts/node/validate/valid.txtar
+++ b/testdata/scripts/node/validate/valid.txtar
@@ -195,7 +195,7 @@ PeerID = ''
 TraceLogging = false
 
 [P2P.V1]
-Enabled = true
+Enabled = false
 AnnounceIP = ''
 AnnouncePort = 0
 BootstrapCheckInterval = '20s'
@@ -208,7 +208,7 @@ NewStreamTimeout = '10s'
 PeerstoreWriteInterval = '5m0s'
 
 [P2P.V2]
-Enabled = false
+Enabled = true
 AnnounceAddresses = []
 DefaultBootstrappers = []
 DeltaDial = '15s'

--- a/testdata/scripts/node/validate/warnings.txtar
+++ b/testdata/scripts/node/validate/warnings.txtar
@@ -1,13 +1,50 @@
-! exec chainlink node validate
-stderr 'invalid configuration'
+exec chainlink node -c config.toml -s secrets.toml validate
 cmp stdout out.txt
+
+-- config.toml --
+[P2P.V1]
+Enabled = true
+AnnounceIP = ''
+AnnouncePort = 0
+BootstrapCheckInterval = '20s'
+DefaultBootstrapPeers = []
+DHTAnnouncementCounterUserPrefix = 0
+DHTLookupInterval = 10
+ListenIP = '0.0.0.0'
+ListenPort = 0
+NewStreamTimeout = '10s'
+PeerstoreWriteInterval = '5m0s'
+
+-- secrets.toml --
+[Database]
+URL = 'postgresql://user:pass1234567890abcd@localhost:5432/dbname?sslmode=disable'
+
+[Password]
+Keystore = 'keystore_pass'
 
 -- out.txt --
 # Secrets:
 [Database]
+URL = 'xxxxx'
 AllowSimplePasswords = false
 
+[Password]
+Keystore = 'xxxxx'
+
 # Input Configuration:
+[P2P]
+[P2P.V1]
+Enabled = true
+AnnounceIP = ''
+AnnouncePort = 0
+BootstrapCheckInterval = '20s'
+DefaultBootstrapPeers = []
+DHTAnnouncementCounterUserPrefix = 0
+DHTLookupInterval = 10
+ListenIP = '0.0.0.0'
+ListenPort = 0
+NewStreamTimeout = '10s'
+PeerstoreWriteInterval = '5m0s'
 
 # Effective Configuration, with defaults applied:
 InsecureFastScrypt = false
@@ -154,7 +191,7 @@ PeerID = ''
 TraceLogging = false
 
 [P2P.V1]
-Enabled = false
+Enabled = true
 AnnounceIP = ''
 AnnouncePort = 0
 BootstrapCheckInterval = '20s'
@@ -225,7 +262,18 @@ CollectorTarget = ''
 NodeID = ''
 SamplingRatio = 0.0
 
-Invalid configuration: invalid secrets: 2 errors:
-	- Database.URL: empty: must be provided and non-empty
-	- Password.Keystore: empty: must be provided and non-empty
-
+# Configuration warning:
+2 errors:
+	- P2P.V1: is deprecated and will be removed in a future version
+	- P2P.V1: 10 errors:
+		- AnnounceIP: is deprecated and will be removed in a future version
+		- AnnouncePort: is deprecated and will be removed in a future version
+		- BootstrapCheckInterval: is deprecated and will be removed in a future version
+		- DefaultBootstrapPeers: is deprecated and will be removed in a future version
+		- DHTAnnouncementCounterUserPrefix: is deprecated and will be removed in a future version
+		- DHTLookupInterval: is deprecated and will be removed in a future version
+		- ListenIP: is deprecated and will be removed in a future version
+		- ListenPort: is deprecated and will be removed in a future version
+		- NewStreamTimeout: is deprecated and will be removed in a future version
+		- PeerstoreWriteInterval: is deprecated and will be removed in a future version
+Valid configuration.


### PR DESCRIPTION
Backporting #11073

Note: this did _not_ pick up the operator ui bump from that PR for some reason, so #11104 is still necessary.

(cherry picked from commit 5808e73)