### PR TITLE
(feat): Add GasLimit to TxMgr's TxMeta

### DIFF
--- a/common/txmgr/types/tx.go
+++ b/common/txmgr/types/tx.go
@@ -150,6 +150,9 @@ type TxMeta[ADDR types.Hashable, TX_HASH types.Hashable] struct {
 	MessageIDs []string `json:"MessageIDs,omitempty"`
 	// SeqNumbers is used by CCIP for tx to committed sequence numbers correlation in logs
 	SeqNumbers []uint64 `json:"SeqNumbers,omitempty"`
+
+	// Used to set the gas limit on every transaction
+	GasLimit *uint32 `json:"GasLimit,omitempty"`
 }
 
 type TxAttempt[
@@ -299,6 +302,10 @@ func (e *Tx[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) GetLogger(lgr logger
 
 		if len(meta.SeqNumbers) > 0 {
 			lgr = lgr.With("SeqNumbers", meta.SeqNumbers)
+		}
+
+		if meta.GasLimit != nil {
+			lgr = lgr.With("GasLimit", *meta.GasLimit)
 		}
 	}
 

--- a/core/services/ocrcommon/transmitter.go
+++ b/core/services/ocrcommon/transmitter.go
@@ -71,11 +71,18 @@ func (t *transmitter) CreateEthTransaction(ctx context.Context, toAddress common
 		return errors.Wrap(err, "skipped OCR transmission, error getting round-robin address")
 	}
 
+	var gasLimit uint32
+	if txMeta != nil && txMeta.GasLimit != nil {
+		gasLimit = *txMeta.GasLimit
+	} else {
+		gasLimit = t.gasLimit
+	}
+
 	_, err = t.txm.CreateTransaction(ctx, txmgr.TxRequest{
 		FromAddress:      roundRobinFromAddress,
 		ToAddress:        toAddress,
 		EncodedPayload:   payload,
-		FeeLimit:         t.gasLimit,
+		FeeLimit:         gasLimit,
 		ForwarderAddress: t.forwarderAddress(),
 		Strategy:         t.strategy,
 		Checker:          t.checker,


### PR DESCRIPTION
# DRAFT
### Description
Extends the Transaction Manager's `TxMeta` with an optional field for gas limit to allow changing the `FeeLimit` on every request.

This feature will be used by Chainlink Functions to dynamically fill transmissions of varying gas usage into a report