### PR TITLE
handle http response code according to mercury updates

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
@@ -573,9 +573,9 @@ func (r *EvmRegistry) multiFeedsRequest(ctx context.Context, ch chan<- MercuryDa
 			sent = true
 			return nil
 		},
-		// only retry when the error is 404 Not Found or 500 Internal Server Error
+		// only retry when the error is 206 Partial Content or 500 Internal Server Error
 		retry.RetryIf(func(err error) bool {
-			return err.Error() == fmt.Sprintf("%d", http.StatusNotFound) || err.Error() == fmt.Sprintf("%d", http.StatusInternalServerError) || err.Error() == fmt.Sprintf("%d", http.StatusPartialContent)
+			return err.Error() == fmt.Sprintf("%d", http.StatusInternalServerError) || err.Error() == fmt.Sprintf("%d", http.StatusPartialContent)
 		}),
 		retry.Context(ctx),
 		retry.Delay(retryDelay),

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
@@ -510,10 +510,6 @@ func (r *EvmRegistry) multiFeedsRequest(ctx context.Context, ch chan<- MercuryDa
 				retryable = true
 				state = encoding.MercuryFlakyFailure
 				return fmt.Errorf("%d", http.StatusInternalServerError)
-			} else if resp.StatusCode == http.StatusUnprocessableEntity {
-				retryable = false
-				state = encoding.InvalidMercuryRequest
-				return fmt.Errorf("at timestamp %s upkeep %s received status code %d from mercury v0.3, most likely feed ID exists, user has permissions, but the feed is not active (deactivated). This should not happen. Contact Mercury team about this", sl.Time.String(), sl.upkeepId.String(), resp.StatusCode)
 			} else if resp.StatusCode == 420 {
 				// in 0.3, this will happen when missing/malformed query args, missing or bad required headers, non-existent feeds, or no permissions for feeds
 				retryable = false


### PR DESCRIPTION
This PR targets
AUTO-5044
AUTO-6872

It handles a new HTTP response code `http.StatusPartialContent` from mercury server which indicates that the mercury request is valid but the server does not have reports for certain feeds yet. This is a retryable scenario.

This change is tested by a new unit test. A QA test can be done after this response code is sent by mercury server in a testing environment (e.g. staging). We can ask a contract to epoch number in the future to trigger this response code from mercury server and check if automation handles it properly.