### PR TITLE
golangci-lint fix issue & disable only-new-issues

### DIFF
--- a/.github/actions/golangci-lint/action.yml
+++ b/.github/actions/golangci-lint/action.yml
@@ -58,7 +58,7 @@ runs:
         skip-pkg-cache: true
         skip-build-cache: true
         # only-new-issues is only applicable to PRs, otherwise it is always set to false
-        only-new-issues: true
+        only-new-issues: false # disabled for PRs due to unreliability
         args: --out-format colored-line-number,checkstyle:golangci-lint-report.xml
         working-directory: ${{ inputs.go-directory }}
     - name: Store lint report artifact

--- a/core/services/ocr2/plugins/generic/pipeline_runner_adapter.go
+++ b/core/services/ocr2/plugins/generic/pipeline_runner_adapter.go
@@ -41,10 +41,7 @@ func (p *PipelineRunnerAdapter) ExecuteRun(ctx context.Context, spec string, var
 		},
 	}
 
-	err := merge(defaultVars, vars.Vars)
-	if err != nil {
-		return nil, err
-	}
+	merge(defaultVars, vars.Vars)
 
 	finalVars := pipeline.NewVarsFrom(defaultVars)
 	_, trrs, err := p.runner.ExecuteRun(ctx, s, finalVars, p.logger)
@@ -74,7 +71,7 @@ func NewPipelineRunnerAdapter(logger logger.Logger, job job.Job, runner pipeline
 }
 
 // merge merges mapTwo into mapOne, modifying mapOne in the process.
-func merge(mapOne, mapTwo map[string]interface{}) error {
+func merge(mapOne, mapTwo map[string]interface{}) {
 	for k, v := range mapTwo {
 		// if `mapOne` doesn't have `k`, then nothing to do, just assign v to `mapOne`.
 		if _, ok := mapOne[k]; !ok {
@@ -89,6 +86,4 @@ func merge(mapOne, mapTwo map[string]interface{}) error {
 			}
 		}
 	}
-
-	return nil
 }

--- a/core/services/ocr2/plugins/generic/pipeline_runner_adapter_test.go
+++ b/core/services/ocr2/plugins/generic/pipeline_runner_adapter_test.go
@@ -131,8 +131,7 @@ func TestMerge(t *testing.T) {
 		"val": 0,
 	}
 
-	err := merge(vars, addedVars)
-	require.NoError(t, err)
+	merge(vars, addedVars)
 
 	assert.True(t, reflect.DeepEqual(vars, map[string]interface{}{
 		"jb": map[string]interface{}{


### PR DESCRIPTION
`only-new-issues` on PRs has not been working. This PR fixes something that got through, and disables that feature for future runs.