### PR TITLE
Remove duplicate table

### DIFF
--- a/integration-tests/config/config.go
+++ b/integration-tests/config/config.go
@@ -8,7 +8,6 @@ Enabled = true
 [P2P.V2]
 Enabled = false
 
-[P2P]
 [P2P.V1]
 Enabled = true
 ListenIP = '0.0.0.0'


### PR DESCRIPTION
Fixes the error Error running app: failed to decode config TOML: toml: table P2P already exists when running ocr soak tests.