### PR TITLE
Update SimulatedBackendClient CallContext

### DIFF
--- a/core/chains/evm/client/simulated_backend_client.go
+++ b/core/chains/evm/client/simulated_backend_client.go
@@ -511,17 +511,21 @@ func (c *SimulatedBackendClient) ethGetTransactionReceipt(ctx context.Context, r
 	}
 
 	receipt, err := c.b.TransactionReceipt(ctx, hash)
-	if receipt != nil {
-		typed, ok := result.(*evmtypes.Receipt)
-		if !ok {
-			panic("expected a *evmtypes.Receipt")
-			// return fmt.Errorf("SimulatedBackendClient expected return type of *evmtypes.Receipt for eth_getTransactionReceipt, got type %T", result)
-		}
-
-		*typed = *evmtypes.FromGethReceipt(receipt)
+	if err != nil {
+		return err
 	}
 
-	return err
+	switch typed := result.(type) {
+	case *types.Receipt:
+		*typed = *receipt
+	case *evmtypes.Receipt:
+		*typed = *evmtypes.FromGethReceipt(receipt)
+	default:
+		panic("unexpected receipt type; use *gethtypes.Receipt or *evmtypes.Receipt")
+		// return fmt.Errorf("SimulatedBackendClient expected return type of *evmtypes.Receipt for eth_getTransactionReceipt, got type %T", result)
+	}
+
+	return nil
 }
 
 func (c *SimulatedBackendClient) ethGetBlockByNumber(ctx context.Context, result interface{}, args ...interface{}) error {

--- a/core/chains/evm/client/simulated_backend_client.go
+++ b/core/chains/evm/client/simulated_backend_client.go
@@ -515,6 +515,9 @@ func (c *SimulatedBackendClient) ethGetTransactionReceipt(ctx context.Context, r
 		return err
 	}
 
+	// strongly typing the result here has the consequence of not being flexible in
+	// custom types where a real-world RPC client would allow for custom types with
+	// custom marshalling.
 	switch typed := result.(type) {
 	case *types.Receipt:
 		*typed = *receipt

--- a/core/chains/evm/client/simulated_backend_client.go
+++ b/core/chains/evm/client/simulated_backend_client.go
@@ -443,7 +443,6 @@ func (c *SimulatedBackendClient) BatchCallContext(ctx context.Context, b []rpc.B
 		case "eth_getHeaderByNumber":
 			b[i].Error = c.ethGetHeaderByNumber(ctx, b[i].Result, b[i].Args...)
 		default:
-			// panic("not implemented")
 			return fmt.Errorf("SimulatedBackendClient got unsupported method %s", elem.Method)
 		}
 	}

--- a/core/chains/evm/client/simulated_backend_client.go
+++ b/core/chains/evm/client/simulated_backend_client.go
@@ -675,6 +675,6 @@ func interfaceToAddress(value interface{}) (common.Address, error) {
 	case *big.Int:
 		return common.BigToAddress(v), nil
 	default:
-		return common.HexToAddress("0x"), fmt.Errorf("unrecognized value type for converting value to common.Address; try string, *big.Int, or common.Address")
+		return common.Address{}, fmt.Errorf("unrecognized value type for converting value to common.Address; try string, *big.Int, or common.Address")
 	}
 }

--- a/core/chains/evm/txmgr/transmitchecker.go
+++ b/core/chains/evm/txmgr/transmitchecker.go
@@ -217,7 +217,7 @@ func (v *VRFV1Checker) Check(
 	requestTransactionReceipt := &gethtypes.Receipt{}
 	batch := []rpc.BatchElem{{
 		Method: "eth_getBlockByNumber",
-		Args:   []interface{}{nil},
+		Args:   []interface{}{"latest", false},
 		Result: mostRecentHead,
 	}, {
 		Method: "eth_getTransactionReceipt",

--- a/core/services/ocr2/plugins/ocr2keeper/evm21/core/utils.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/core/utils.go
@@ -3,7 +3,6 @@ package core
 import (
 	"context"
 	"math/big"
-	"strings"
 
 	"github.com/ethereum/go-ethereum/common"
 
@@ -14,20 +13,8 @@ import (
 // GetTxBlock calls eth_getTransactionReceipt on the eth client to obtain a tx receipt
 func GetTxBlock(ctx context.Context, client client.Client, txHash common.Hash) (*big.Int, common.Hash, error) {
 	receipt := types.Receipt{}
-	err := client.CallContext(ctx, &receipt, "eth_getTransactionReceipt", txHash)
-	if err != nil {
-		if strings.Contains(err.Error(), "not yet been implemented") {
-			// workaround for simulated chains
-			// Exploratory: fix this properly (e.g. in the simulated backend)
-			r, err1 := client.TransactionReceipt(ctx, txHash)
-			if err1 != nil {
-				return nil, common.Hash{}, err1
-			}
-			if r.Status != 1 {
-				return nil, common.Hash{}, nil
-			}
-			return r.BlockNumber, r.BlockHash, nil
-		}
+
+	if err := client.CallContext(ctx, &receipt, "eth_getTransactionReceipt", txHash); err != nil {
 		return nil, common.Hash{}, err
 	}
 


### PR DESCRIPTION
The function `CallContext` has different supported contract function calls than `BatchCallContext` even though the latter is simply a batch version of the former.

This commit makes the two functions match both in the supported calls, but also in the validation and execution of those calls.