### PR TITLE
[RE-2044] Bump sigstore/cosign-installer from 2.1.0 to 3.1.2

### DIFF
--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -223,7 +223,7 @@ runs:
 
     - if: inputs.sign-images == 'true'
       name: Install cosign
-      uses: sigstore/cosign-installer@581838fbedd492d2350a9ecd427a95d6de1e5d01 # v2.1.0
+      uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
       with:
         cosign-release: "v1.6.0"
 

--- a/.github/actions/goreleaser-build-sign-publish/action.yml
+++ b/.github/actions/goreleaser-build-sign-publish/action.yml
@@ -84,7 +84,7 @@ runs:
         version: ${{ inputs.zig-version }}
     - name: Setup cosign
       if: inputs.enable-cosign == 'true'
-      uses: sigstore/cosign-installer@581838fbedd492d2350a9ecd427a95d6de1e5d01 # v2.1.0
+      uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
       with:
         cosign-release: ${{ inputs.cosign-version }}
     - name: Login to docker registry


### PR DESCRIPTION
Bumping this version of https://github.com/sigstore/cosign-installer/ to due failing workflows.

Example: https://github.com/smartcontractkit/chainlink/actions/runs/6774773891/job/18417268502#step:3:2643

```
INFO: Downloading bootstrap version 'v1.6.0' of cosign to verify version to be installed...
      https://storage.googleapis.com/cosign-releases/v1.6.0/cosign-linux-amd64
ERROR: Unable to validate cosign version: 'v1.6.0'
Error: Process completed with exit code 1.
```

Seems like more recent version of `sigstore/cosign-installer` download directly from https://github.com/sigstore/cosign through Github rather than Google's API.

https://github.com/sigstore/cosign-installer/releases/tag/v3.0.0
> changes download URL for cosign binary to github.com instead of GCS

### Potential follow-up

See if we can bump the version of cosign we are installing?

---

[RE-2044](https://smartcontract-it.atlassian.net/browse/RE-2044)

[RE-2044]: https://smartcontract-it.atlassian.net/browse/RE-2044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ