### PR TITLE
[RE-2044] chore: bump sigstore/cosign-installer from 2.1.0 to 3.1.2

### DIFF
--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -201,7 +201,7 @@ runs:
 
     - if: inputs.sign-images == 'true'
       name: Install cosign
-      uses: sigstore/cosign-installer@581838fbedd492d2350a9ecd427a95d6de1e5d01 # v2.1.0
+      uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
       with:
         cosign-release: "v1.6.0"
 

--- a/.github/actions/goreleaser-build-sign-publish/action.yml
+++ b/.github/actions/goreleaser-build-sign-publish/action.yml
@@ -84,7 +84,7 @@ runs:
         version: ${{ inputs.zig-version }}
     - name: Setup cosign
       if: inputs.enable-cosign == 'true'
-      uses: sigstore/cosign-installer@581838fbedd492d2350a9ecd427a95d6de1e5d01 # v2.1.0
+      uses: sigstore/cosign-installer@11086d25041f77fe8fe7b9ea4e48e3b9192b8f19 # v3.1.2
       with:
         cosign-release: ${{ inputs.cosign-version }}
     - name: Login to docker registry


### PR DESCRIPTION
Cherry picking commit 0ae0b691466687ac7be2b49d9d4a1bd3136d6424 from #11192 for `2.7.0` release branch.

---

[RE-2044](https://smartcontract-it.atlassian.net/browse/RE-2044)

[RE-2044]: https://smartcontract-it.atlassian.net/browse/RE-2044?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ