### PR TITLE
RE-2054 chore/build tags operator ui

### DIFF
--- a/.github/actions/golangci-lint/action.yml
+++ b/.github/actions/golangci-lint/action.yml
@@ -38,9 +38,6 @@ runs:
         cache-version: ${{ inputs.cache-version }}
         go-version-file: ${{ inputs.go-version-file }}
         go-module-file: ${{ inputs.go-module-file }}
-    - name: Touching core/web/assets/index.html
-      shell: bash
-      run: mkdir -p core/web/assets && touch core/web/assets/index.html
     - name: Build binary
       if: ${{ inputs.go-directory == '.' }}
       shell: bash

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -22,7 +22,7 @@ jobs:
     name: lint
     runs-on: ubuntu20.04-8cores-32GB
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1 
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Golang Lint
         uses: ./.github/actions/golangci-lint
         with:
@@ -63,8 +63,6 @@ jobs:
         uses: ./.github/actions/setup-wasmd
       - name: Setup Postgres
         uses: ./.github/actions/setup-postgres
-      - name: Touching core/web/assets/index.html
-        run: mkdir -p core/web/assets && touch core/web/assets/index.html
       - name: Download Go vendor packages
         run: go mod download
       - name: Build binary
@@ -145,8 +143,6 @@ jobs:
         uses: ./.github/actions/setup-go
       - name: Setup Postgres
         uses: ./.github/actions/setup-postgres
-      - name: Touching core/web/assets/index.html
-        run: mkdir -p core/web/assets && touch core/web/assets/index.html
       - name: Download Go vendor packages
         run: go mod download
       - name: Build binary

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -30,10 +30,6 @@ jobs:
         with:
           go-version-file: 'go.mod'
 
-      - name: Touching core/web/assets/index.html
-        if: ${{ matrix.language == 'go' }}
-        run: mkdir -p core/web/assets && touch core/web/assets/index.html
-
       - name: Initialize CodeQL
         uses: github/codeql-action/init@cdcdbb579706841c47f7063dda365e292e5cad7a # v2.13.4
         with:

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -42,16 +42,16 @@ godoc: ## Install and run godoc
 
 .PHONY: install-chainlink
 install-chainlink: operator-ui ## Install the chainlink binary.
-	go install $(GOFLAGS) .
+	go install -tags gui $(GOFLAGS) .
 
 chainlink: operator-ui ## Build the chainlink binary.
-	go build $(GOFLAGS) .
+	go build -tags gui $(GOFLAGS) .
 
 chainlink-dev: operator-ui ## Build a dev build of chainlink binary.
-	go build -tags dev $(GOFLAGS) .
+	go build -tags gui,dev $(GOFLAGS) .
 
 chainlink-test: operator-ui ## Build a test build of chainlink binary.
-	go build $(GOFLAGS) .
+	go build -tags gui $(GOFLAGS) .
 
 .PHONY: chainlink-local-start
 chainlink-local-start:

--- a/core/web/middleware.go
+++ b/core/web/middleware.go
@@ -16,17 +16,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 )
 
-// Go's new embed feature doesn't allow us to embed things outside of the current module.
-// To get around this, we need to make sure that the assets we want to embed are available
-// inside this module. To achieve this, we direct webpack to output all of the compiled assets
-// in this module's folder under the "assets" directory.
-
-//go:embed "assets"
-var uiEmbedFs embed.FS
-
-// assetFs is the singleton file system instance that is used to serve the static
-// assets for the operator UI.
-var assetFs = NewEmbedFileSystem(uiEmbedFs, "assets")
 
 const (
 	acceptEncodingHeader  = "Accept-Encoding"

--- a/core/web/middleware_assets_dev.go
+++ b/core/web/middleware_assets_dev.go
@@ -1,0 +1,19 @@
+// +build dev
+
+package web
+
+import (
+	"embed"
+)
+
+// Go's new embed feature doesn't allow us to embed things outside of the current module.
+// To get around this, we need to make sure that the assets we want to embed are available
+// inside this module. To achieve this, we direct webpack to output all of the compiled assets
+// in this module's folder under the "assets" directory.
+
+//go:embed "mock_assets"
+var uiEmbedFs embed.FS
+
+// assetFs is the singleton file system instance that is used to serve the static
+// assets for the operator UI.
+var assetFs = NewEmbedFileSystem(uiEmbedFs, "assets")

--- a/core/web/middleware_assets_gui.go
+++ b/core/web/middleware_assets_gui.go
@@ -1,4 +1,4 @@
-// +build !dev 
+//go:build gui 
 
 package web
 

--- a/core/web/middleware_assets_no_gui.go
+++ b/core/web/middleware_assets_no_gui.go
@@ -1,4 +1,4 @@
-// +build dev
+//go:build !gui
 
 package web
 

--- a/core/web/middleware_assets_prod.go
+++ b/core/web/middleware_assets_prod.go
@@ -1,0 +1,19 @@
+// +build !dev 
+
+package web
+
+import (
+	"embed"
+)
+
+// Go's new embed feature doesn't allow us to embed things outside of the current module.
+// To get around this, we need to make sure that the assets we want to embed are available
+// inside this module. To achieve this, we direct webpack to output all of the compiled assets
+// in this module's folder under the "assets" directory.
+
+//go:embed "assets"
+var uiEmbedFs embed.FS
+
+// assetFs is the singleton file system instance that is used to serve the static
+// assets for the operator UI.
+var assetFs = NewEmbedFileSystem(uiEmbedFs, "assets")


### PR DESCRIPTION
This PR adds support for the `gui` build tag, where we can toggle the inclusion of `operator_ui` assets by supplying `-tags gui` to the `go build` command.

I initially did the inverse, where you had to supply a `nogui` tag, however that made CI much more complex, as often there are abstractions present in CI where there's different ways of passing in build tags, like with the CodeQL action. Also, more often then not, we want to use a "headless" version of chainlink for CI. 

The caveat of using `gui` over `nogui` is that we can potentially ship builds that do not include `operator_ui` assets if we forget to include the `gui` tag. I'm a little on the fence about this, but considering that we should be testing the GUI within staging -> prod test pipelines, it should be caught. The dockerfile calls out to the makefile, so i've modified all the commands in there to use the `gui` build tag.

I tried to be fancy and use something like `$(eval GOTAGS += gui)` within the `operator-ui` makefile target to avoid duplication, and to make sure that we bind the `gui` tag addition to the `operator-ui` target itself. Apparently using `eval` is bad practice though. Happy to re-add it back in if convinced otherwise, since its a much cleaner pattern, and ensures that if you depend on `operator-ui` you _will_ have its assets included properly, too.