### PR TITLE
core/store/migration/migrations: rm last sqlx.NewTx use

### DIFF
--- a/core/store/migrate/migrations/0036_external_job_id.go
+++ b/core/store/migrate/migrations/0036_external_job_id.go
@@ -45,7 +45,7 @@ func Up36(ctx context.Context, tx *sql.Tx) error {
 	// Update all jobs to have an external_job_id.
 	// We do this to avoid using the uuid postgres extension.
 	var jobIDs []int32
-	txx := sqlx.NewTx(tx, "postgres")
+	txx := sqlx.Tx{Tx: tx}
 	if err := txx.SelectContext(ctx, &jobIDs, "SELECT id FROM jobs"); err != nil {
 		return err
 	}


### PR DESCRIPTION
Our fork https://github.com/smartcontractkit/sqlx exists to provide access to the internal driver name here https://github.com/smartcontractkit/sqlx/commit/202c2cd23acf0fba17c72bdbe6342b1ff1f5c77b

This PR removes the only usage `sqlx.NewTx`, which is no longer necessary to run the migrations. This should unblock using the original upustream https://github.com/jmoiron/sqlx