### PR TITLE
[DO NOT MERGE] Log provider: update scaling parameters

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer.go
@@ -17,8 +17,17 @@ import (
 var (
 	// maxLogsPerUpkeepInBlock is the maximum number of logs allowed per upkeep in a block.
 	maxLogsPerUpkeepInBlock = 32
-	// maxLogsPerBlock is the maximum number of blocks in the buffer.
-	maxLogsPerBlock = 1024
+	// maxLogsPerBlock is the maximum number of log per block for all upkeeps in the buffer.
+	//
+	// using this limit, we can calculate the maximum number of upkeeps per block
+	// that we can support in the buffer:
+	// maxLogsPerBlock / logs per upkeep = number of supported upkeeps per block
+	//
+	// 1. ideal case (a single log per upkeep):
+	// 8192 / 1 = 8192 upkeeps per block
+	// 2. worst case (32 logs per upkeep):
+	// 8192 / maxLogsPerUpkeepInBlock = 256 upkeeps per block
+	maxLogsPerBlock = 8192
 )
 
 // fetchedLog holds the log and the ID of the upkeep

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/integration_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/integration_test.go
@@ -533,7 +533,7 @@ func collectPayloads(ctx context.Context, t *testing.T, logProvider logprovider.
 	for ctx.Err() == nil && len(allPayloads) < n && rounds > 0 {
 		logs, err := logProvider.GetLatestPayloads(ctx)
 		require.NoError(t, err)
-		require.LessOrEqual(t, len(logs), logprovider.AllowedLogsPerUpkeep, "failed to get all logs")
+		require.LessOrEqual(t, len(logs), logprovider.MaxPayloadsPerUpkeep, "failed to get all logs")
 		allPayloads = append(allPayloads, logs...)
 		rounds--
 	}

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -34,10 +34,10 @@ var (
 	ErrHeadNotAvailable   = fmt.Errorf("head not available")
 	ErrBlockLimitExceeded = fmt.Errorf("block limit exceeded")
 
-	// AllowedLogsPerUpkeep is the maximum number of logs allowed per upkeep every single call.
-	AllowedLogsPerUpkeep = 5
-	// MaxPayloads is the maximum number of payloads to return per call.
-	MaxPayloads = 100
+	// MaxPayloadsPerUpkeep is the maximum number of logs allowed per upkeep every single call to the log provider.
+	MaxPayloadsPerUpkeep = 5
+	// MaxPayloads is the maximum number of payloads to return per call for all upkeeps.
+	MaxPayloads = 500
 
 	readJobQueueSize = 64
 	readLogsTimeout  = 10 * time.Second
@@ -166,7 +166,7 @@ func (p *logEventProvider) GetLatestPayloads(ctx context.Context) ([]ocr2keepers
 	if start <= 0 {
 		start = 1
 	}
-	logs := p.buffer.dequeueRange(start, latest.BlockNumber, AllowedLogsPerUpkeep, MaxPayloads)
+	logs := p.buffer.dequeueRange(start, latest.BlockNumber, MaxPayloadsPerUpkeep, MaxPayloads)
 
 	// p.lggr.Debugw("got latest logs from buffer", "latest", latest, "diff", diff, "logs", len(logs))
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -37,6 +37,13 @@ var (
 	// MaxPayloadsPerUpkeep is the maximum number of logs allowed per upkeep every single call to the log provider.
 	MaxPayloadsPerUpkeep = 5
 	// MaxPayloads is the maximum number of payloads to return per call for all upkeeps.
+	//
+	// using this limit, we can calculate the maximum number of logs to return per upkeep:
+	// MaxPayloads / logsPerUpkeep = number of upkeeps that we can process each second
+	// 1. ideal case (a single log per upkeep)
+	// MaxPayloads / 1 = 500
+	// 2. worst case (all logs are for the same upkeep)
+	// MaxPayloads / MaxPayloadsPerUpkeep = 100
 	MaxPayloads = 500
 
 	readJobQueueSize = 64

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -41,10 +41,10 @@ var (
 	// using this limit, we can calculate the maximum number of logs to return per upkeep:
 	// MaxPayloads / logsPerUpkeep = number of upkeeps that we can process each second
 	// 1. ideal case (a single log per upkeep)
-	// MaxPayloads / 1 = 500
+	// MaxPayloads / 1 = 250
 	// 2. worst case (all logs are for the same upkeep)
-	// MaxPayloads / MaxPayloadsPerUpkeep = 100
-	MaxPayloads = 500
+	// MaxPayloads / MaxPayloadsPerUpkeep = 50
+	MaxPayloads = 250
 
 	readJobQueueSize = 64
 	readLogsTimeout  = 10 * time.Second

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer.go
@@ -38,6 +38,8 @@ var (
 	RecoveryCacheTTL = 10 * time.Minute
 	// GCInterval is the interval at which the recovery cache is cleaned up
 	GCInterval = RecoveryCacheTTL - time.Second
+	// MaxProposalsPerUpkeep is the maximum number of logs allowed per upkeep every single call to log recoverer.
+	MaxProposalsPerUpkeep = 5
 	// MaxProposals is the maximum number of proposals that can be returned by GetRecoveryProposals
 	MaxProposals = 20
 	// recoveryBatchSize is the number of filters to recover in a single batch
@@ -308,7 +310,7 @@ func (r *logRecoverer) GetRecoveryProposals(ctx context.Context) ([]ocr2keepers.
 			continue
 		}
 		uid := payload.UpkeepID.String()
-		if logsCount[uid] >= AllowedLogsPerUpkeep {
+		if logsCount[uid] >= MaxProposalsPerUpkeep {
 			// we have enough proposals for this upkeep, the rest are pushed back to pending
 			pending = append(pending, payload)
 			continue


### PR DESCRIPTION
Updating scaling parameters of log provider, to increase the throughput of event logs that we are able to process:
- `MaxPayloads` was set to 500 (was 100)
- Log buffer: `maxLogsPerBlock` was set to 8192 (was 1024)

In addition, parameters for provider and recoverer are now separated to avoid coupling.