### PR TITLE
Attempt to fix streams lookup race condition

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evm21/streams_lookup.go
@@ -151,11 +151,13 @@ func (r *EvmRegistry) streamsLookup(ctx context.Context, checkResults []ocr2keep
 	var wg sync.WaitGroup
 
 	for i, lookup := range lookups {
-		i := i
 		wg.Add(1)
-		r.threadCtrl.Go(func(ctx context.Context) {
-			r.doLookup(ctx, &wg, lookup, i, checkResults, lggr)
-		})
+		func(i int, lookup *StreamsLookup) {
+			r.threadCtrl.Go(func(ctx context.Context) {
+				r.doLookup(ctx, &wg, lookup, i, checkResults, lggr)
+			})
+		}(i, lookup)
+
 	}
 
 	wg.Wait()


### PR DESCRIPTION
It looks like we have a race condition between lines 153 and 157, so the fix here is to pass the i and lookup vars as parameters to a function before using them in thread control function