### PR TITLE
core/services/pg: simplify API

### DIFF
--- a/core/services/pg/connection.go
+++ b/core/services/pg/connection.go
@@ -42,7 +42,7 @@ func NewConnection(uri string, dialect dialects.DialectName, config ConnectionCo
 	lockTimeout := config.DefaultLockTimeout().Milliseconds()
 	idleInTxSessionTimeout := config.DefaultIdleInTxSessionTimeout().Milliseconds()
 	stmt := fmt.Sprintf(`SET TIME ZONE 'UTC'; SET lock_timeout = %d; SET idle_in_transaction_session_timeout = %d; SET default_transaction_isolation = %q`,
-		lockTimeout, idleInTxSessionTimeout, DefaultIsolation.String())
+		lockTimeout, idleInTxSessionTimeout, defaultIsolation.String())
 	if _, err = db.Exec(stmt); err != nil {
 		return nil, err
 	}

--- a/core/services/pg/q.go
+++ b/core/services/pg/q.go
@@ -165,7 +165,7 @@ func (q Q) Context() (context.Context, context.CancelFunc) {
 	return context.WithTimeout(q.ParentCtx, q.QueryTimeout)
 }
 
-func (q Q) Transaction(fc func(q Queryer) error, txOpts ...TxOptions) error {
+func (q Q) Transaction(fc func(q Queryer) error, txOpts ...TxOption) error {
 	ctx, cancel := q.Context()
 	defer cancel()
 	return SqlxTransaction(ctx, q.Queryer, q.originalLogger(), fc, txOpts...)

--- a/core/services/pg/sqlx.go
+++ b/core/services/pg/sqlx.go
@@ -35,7 +35,7 @@ func WrapDbWithSqlx(rdb *sql.DB) *sqlx.DB {
 	return db
 }
 
-func SqlxTransaction(ctx context.Context, q Queryer, lggr logger.Logger, fc func(q Queryer) error, txOpts ...TxOptions) (err error) {
+func SqlxTransaction(ctx context.Context, q Queryer, lggr logger.Logger, fc func(q Queryer) error, txOpts ...TxOption) (err error) {
 	switch db := q.(type) {
 	case *sqlx.Tx:
 		// nested transaction: just use the outer transaction


### PR DESCRIPTION
- unexport local `const`
- swap variadic optional for functional options
- remove stale comment