### PR TITLE
[TT-707] Add chainlink image build to test image publish for workflow_dispatch

### DIFF
--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -7,9 +7,6 @@ on:
       - develop
   workflow_dispatch:
     inputs:
-      chainlink-tests-tag:
-        description: 'The tag to be pushed'
-        required: true
       ctf-base-image-tag:
         description: |
           'The tag of the CTF base image to be used,
@@ -18,7 +15,8 @@ on:
         required: true
 
 env:
-  ECR_TAG_BASE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests
+  ECR_TAG: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-tests:develop
+  CHAINLINK_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink
 
 jobs:
   publish-integration-test-image:
@@ -41,19 +39,71 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
+      - name: Setup Other Tags
+        id: tags
+        env:
+          BASE_IMAGE_TAG: ${{ inputs.ctf-base-image-tag}}
+        run: |
+          if [ -z "${BASE_IMAGE_TAG+x}" ]; then
+            echo "ctf-base-image-tag is not set, we are part of a merge and want to push the develop tag"
+            echo "other_tags=${ECR_TAG}" >> $GITHUB_OUTPUT
+          fi
       - name: Build Image
         uses: ./.github/actions/build-test-image
         with:
-          other_tags: "${{ env.ECR_TAG_BASE }}:${{ inputs.chainlink-tests-tag || 'develop' }}"
+          other_tags: ${{ steps.tags.outputs.other_tags }}
           base_image_tag: ${{ inputs.ctf-base-image-tag }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ACCOUNT_NUMBER: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
       - name: Notify Slack
-        if: failure()
+        # Only run this notification for merge to develop failures
+        if: failure() && github.event_name != 'workflow_dispatch'
         uses: slackapi/slack-github-action@e28cf165c92ffef168d23c5c9000cffc8a25e117 # v1.24.0
         env:
           SLACK_BOT_TOKEN: ${{ secrets.QA_SLACK_API_KEY }}
         with:
           channel-id: "#team-test-tooling-internal"
           slack-message: ":x: :mild-panic-intensifies: Publish Integration Test Image failed: ${{ job.html_url }}\n${{ format('https://github.com/smartcontractkit/chainlink/actions/runs/{0}', github.run_id) }}"
+  build-chainlink-image:
+    environment: integration
+    # Only run this build for workflow_dispatch
+    if: ${{ inputs.ctf-base-image-tag != '' }}
+    permissions:
+      id-token: write
+      contents: read
+    strategy:
+      matrix:
+        image:
+          - name: ""
+            dockerfile: core/chainlink.Dockerfile
+            tag-suffix: ""
+          # uncomment in the future if we end up needing to soak test the plugins image
+          # - name: (plugins)
+          #   dockerfile: plugins/chainlink.Dockerfile
+          #   tag-suffix: -plugins
+    name: Build Chainlink Image ${{ matrix.image.name }}
+    runs-on: ubuntu20.04-8cores-32GB
+    steps:
+      - name: Collect Metrics
+        id: collect-gha-metrics
+        uses: smartcontractkit/push-gha-metrics-action@d1618b772a97fd87e6505de97b872ee0b1f1729a # v2.0.2
+        with:
+          basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
+          hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          this-job-name: Build Chainlink Image ${{ matrix.image.name }}
+        continue-on-error: true
+      - name: Checkout the repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        with:
+          ref: ${{ github.sha }}
+      - name: Build Chainlink Image
+        uses: ./.github/actions/build-chainlink-image
+        with:
+          tag_suffix: ${{ matrix.image.tag-suffix }}
+          dockerfile: ${{ matrix.image.dockerfile }}
+          git_commit_sha: ${{ github.sha }}
+          GRAFANA_CLOUD_BASIC_AUTH: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
+          GRAFANA_CLOUD_HOST: ${{ secrets.GRAFANA_CLOUD_HOST }}
+          AWS_REGION: ${{ secrets.QA_AWS_REGION }}
+          AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
This allows teams to run this one dispatch and not have to make a work in progress PR before they start soak testing.
As per the requirements from the soak test runners:
- No need for the chainlink-tests-tag, just use the github.sha
- Add the chainlink node image build for workflow_dispatch so a wip PR is not needed to get the needed images for soak testing
- Don't send the slack notification on failure for workflow_dispatch