### PR TITLE
Update loading next sequence map to avoid startup failure

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -36,6 +36,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+## 2.7.1 - UNRELEASED
+
+### Fixed
+
+- Fixed a bug that causes the node to shutdown if all configured RPC's are unreachable during startup.
+
 ## 2.7.0 - UNRELEASED
 
 ### Added


### PR DESCRIPTION
- Updated loading next sequence map logic during Broadcaster startup to not return an error. This allows the Broadcaster to not fail startup due to something like an RPC call failure.
- Updated the sequence syncer to load a sequence from the tx table or on-chain if it is not found in the map. This allows the Broadcaster to populate the next sequence map for relevant addresses if it was not during startup.