### PR TITLE
core/services/job: close test peer wrappers

### DIFF
--- a/core/services/job/orm_test.go
+++ b/core/services/job/orm_test.go
@@ -23,7 +23,7 @@ import (
 
 func NewTestORM(t *testing.T, db *sqlx.DB, pipelineORM pipeline.ORM, bridgeORM bridges.ORM, keyStore keystore.Master, cfg pg.QConfig) job.ORM {
 	o := job.NewORM(db, pipelineORM, bridgeORM, keyStore, logger.TestLogger(t), cfg)
-	t.Cleanup(func() { o.Close() })
+	t.Cleanup(func() { assert.NoError(t, o.Close()) })
 	return o
 }
 

--- a/core/services/job/runner_integration_test.go
+++ b/core/services/job/runner_integration_test.go
@@ -450,6 +450,7 @@ answer1      [type=median index=0];
 		assert.NoError(t, err)
 		pw := ocrcommon.NewSingletonPeerWrapper(keyStore, config.P2P(), config.OCR(), config.Database(), db, lggr)
 		require.NoError(t, pw.Start(testutils.Context(t)))
+		t.Cleanup(func() { assert.NoError(t, pw.Close()) })
 		sd := ocr.NewDelegate(
 			db,
 			jobORM,
@@ -484,6 +485,7 @@ answer1      [type=median index=0];
 		lggr := logger.TestLogger(t)
 		pw := ocrcommon.NewSingletonPeerWrapper(keyStore, config.P2P(), config.OCR(), config.Database(), db, lggr)
 		require.NoError(t, pw.Start(testutils.Context(t)))
+		t.Cleanup(func() { assert.NoError(t, pw.Close()) })
 		sd := ocr.NewDelegate(
 			db,
 			jobORM,
@@ -512,6 +514,7 @@ answer1      [type=median index=0];
 		lggr := logger.TestLogger(t)
 		pw := ocrcommon.NewSingletonPeerWrapper(keyStore, config.P2P(), config.OCR(), config.Database(), db, lggr)
 		require.NoError(t, pw.Start(testutils.Context(t)))
+		t.Cleanup(func() { assert.NoError(t, pw.Close()) })
 		sd := ocr.NewDelegate(
 			db,
 			jobORM,
@@ -566,6 +569,7 @@ answer1      [type=median index=0];
 			lggr := logger.TestLogger(t)
 			pw := ocrcommon.NewSingletonPeerWrapper(keyStore, config.P2P(), config.OCR(), config.Database(), db, lggr)
 			require.NoError(t, pw.Start(testutils.Context(t)))
+			t.Cleanup(func() { assert.NoError(t, pw.Close()) })
 			sd := ocr.NewDelegate(
 				db,
 				jobORM,
@@ -610,7 +614,7 @@ answer1      [type=median index=0];
 		lggr := logger.TestLogger(t)
 		pw := ocrcommon.NewSingletonPeerWrapper(keyStore, config.P2P(), config.OCR(), config.Database(), db, lggr)
 		require.NoError(t, pw.Start(testutils.Context(t)))
-
+		t.Cleanup(func() { assert.NoError(t, pw.Close()) })
 		sd := ocr.NewDelegate(
 			db,
 			jobORM,


### PR DESCRIPTION
Ensure test resources are cleaned up.