### PR TITLE
Avoid checking version file bump on forks in CI

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -17,7 +17,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Check for VERSION file bump on tags
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        # Avoids checking VERSION file bump on forks.
+        if: ${{ github.repository == 'smartcontractkit/chainlink' && startsWith(github.ref, 'refs/tags/v') }}
         uses: ./.github/actions/version-file-bump
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This check currently fails on forks.