### PR TITLE
Change UseFinalityTags to FinalityTagEnabled in CHANGELOG.md to avoid confusion

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -92,7 +92,7 @@ ServerPubKey = '...'
 These will eventually replace `TelemetryIngress.URL` and `TelemetryIngress.ServerPubKey`. Setting `TelemetryIngress.URL` and `TelemetryIngress.ServerPubKey` alongside `[[TelemetryIngress.Endpoints]]` will prevent the node from booting. Only one way of configuring telemetry endpoints is supported.
 - Added bridge_name label to `pipeline_tasks_total_finished` prometheus metric. This should make it easier to see directly what bridge was failing out from the CL NODE perspective.
 
-- LogPoller will now use finality tags to dynamically determine finality on evm chains if `UseFinalityTags=true`, rather than the fixed `FinalityDepth` specified in toml config
+- LogPoller will now use finality tags to dynamically determine finality on evm chains if `EVM.FinalityTagEnabled=true`, rather than the fixed `EVM.FinalityDepth` specified in toml config
 
 ### Changed
 


### PR DESCRIPTION
The name of the param LogPoller accepts is `useFinalityTag`, but the externally-facing name of the EVM toml config param it's set based on is `FinalityTagEnabled`. There is also a toml config param named `UseFinalityTag` and associated env var, but these are only used for integration tests, there is no such thing in the main production toml config. Also adding EVM prefix for clarity.