### PR TITLE
[BCF-2779] Prettier storage of config for Operator UI

### DIFF
--- a/plugins/medianpoc/plugin.go
+++ b/plugins/medianpoc/plugin.go
@@ -30,8 +30,13 @@ type Plugin struct {
 	reportingplugins.MedianProviderServer
 }
 
+type pipelineSpec struct {
+	Name string `json:"name"`
+	Spec string `json:"spec"`
+}
+
 type jsonConfig struct {
-	Pipelines map[string]string `json:"pipelines"`
+	Pipelines []pipelineSpec `json:"pipelines"`
 }
 
 func (j jsonConfig) defaultPipeline() (string, error) {
@@ -39,9 +44,10 @@ func (j jsonConfig) defaultPipeline() (string, error) {
 }
 
 func (j jsonConfig) getPipeline(key string) (string, error) {
-	v, ok := j.Pipelines[key]
-	if ok {
-		return v, nil
+	for _, v := range j.Pipelines {
+		if v.Name == key {
+			return v.Spec, nil
+		}
 	}
 	return "", fmt.Errorf("no pipeline found for %s", key)
 }

--- a/plugins/medianpoc/plugin_test.go
+++ b/plugins/medianpoc/plugin_test.go
@@ -80,7 +80,7 @@ func TestNewPlugin(t *testing.T) {
 	juelsPerFeeCoinSpec := "jpfc-spec"
 	config := types.ReportingPluginServiceConfig{
 		PluginConfig: fmt.Sprintf(
-			`{"pipelines": {"__DEFAULT_PIPELINE__": "%s", "juelsPerFeeCoinPipeline": "%s"}}`,
+			`{"pipelines": [{"name": "__DEFAULT_PIPELINE__", "spec": "%s"},{"name": "juelsPerFeeCoinPipeline", "spec": "%s"}]}`,
 			defaultSpec,
 			juelsPerFeeCoinSpec,
 		),


### PR DESCRIPTION
* Don't store the pluginConfig as a string inside the job spec, instead store it as rich TOML
* Add the pipeline that comes from `observationSource` to the pipeline specs we pass to reporting plugin; this is so that we display the primary pipeline spec correctly in Operator UI.