### PR TITLE
core/services/chainlink: skip P2P Peer Wrapper when unused

### DIFF
--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -360,7 +360,9 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 	}
 
 	var peerWrapper *ocrcommon.SingletonPeerWrapper
-	if cfg.P2P().Enabled() {
+	if !cfg.OCR().Enabled() && !cfg.OCR2().Enabled() {
+		globalLogger.Debug("P2P stack not needed")
+	} else if cfg.P2P().Enabled() {
 		if err := ocrcommon.ValidatePeerWrapperConfig(cfg.P2P()); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCF-2826

If OCR 1 & 2 are disabled, then we don't need to create a Peer Wrapper, or even validate the config.