### PR TITLE
delete chain no longer removes row from evm.key_states

### DIFF
--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -1016,6 +1016,10 @@ func (s *Shell) CleanupChainTables(c *cli.Context) error {
 			if err = rows.Scan(&name, &schema); err != nil {
 				return err
 			}
+			// Skip the evm.key_states table
+			if schema == "evm" && name == "key_states" {
+				continue
+			}
 			tablesToDeleteFrom = append(tablesToDeleteFrom, schema+"."+name)
 		}
 


### PR DESCRIPTION
### Problem

The bulk command `./chainlink node db delete-chain` currently looks through all schemas and tables to find any column matching `evm_chain_id`. If it finds such a column, it deletes all rows with `evm_chain_id` matching the provided id. 

This works well, but not for evm keys. 

Today, the state of `evm.key_states` is user facing. Every eth keys command/route interacts with this table directly to create, update, list, and delete keys. Ultimately, the state of the table is what is presented to users, with minor prettier formatting changes.

At least to me, it seems like it is not intended for `./chainlink node db delete-chain` to clear out `evm.key_states` - as it was reflected on the slack thread:
https://chainlink-core.slack.com/archives/C0117GGJB6Y/p1701261268282219?thread_ts=1701255404.539909&cid=C0117GGJB6Y

> delete-chain should not delete keys, even if it is fixed, because keys can be shared between chains

This problem is a symptom of a core problem we have with our evm key routes: evm.key_states couples the existence of a key with a specific chain id. 

To state this a different way - we would not have this issue if we had a table to capture the existence of a key, a table to capture the state of the key relative to chain-ids (enabled or disabled), and a table to store the encrypted key ring material.

Until we fix this in 3.0, I recommend we follow the intent of what users of `./chainlink node db delete-chain` is, which is not to delete the key. 

### Solution
Skips the deletion of the matching row in `evm.key_states`


### Testing

Confirms that the key still exists after `delete-chain` is run. 

```
patrick.huie@smartcontract.com@MB-LXNRFW22N3 chainlink % ./chainlink keys eth list
🔑 ETH keys

-------------------------------------------------------------------------------------------------
Address:           0x46035eB4d2D49C843d96C990f4776B1846Cf3F5B
EVM Chain ID:      11155111
ETH:               0.000000000000000000
LINK:              0
Disabled:          false
Created:           2023-11-30 11:02:08.560341 -0500 EST
Updated:           2023-11-30 11:02:08.560341 -0500 EST
Max Gas Price Wei: 115792089237316195423570985008687907853269984665640564039457584007913129639935
-------------------------------------------------------------------------------------------------
patrick.huie@smartcontract.com@MB-LXNRFW22N3 chainlink % ./chainlink node db delete-chain --id 11155111 --type EVM
Rows with evm_chain_id 11155111 deleted from evm.txes.
Rows with evm_chain_id 11155111 deleted from public.log_broadcasts.
Rows with evm_chain_id 11155111 deleted from evm.heads.
Rows with evm_chain_id 11155111 deleted from public.direct_request_specs.
Rows with evm_chain_id 11155111 deleted from public.flux_monitor_specs.
Rows with evm_chain_id 11155111 deleted from public.ocr_oracle_specs.
Rows with evm_chain_id 11155111 deleted from public.keeper_specs.
Rows with evm_chain_id 11155111 deleted from public.vrf_specs.
Rows with evm_chain_id 11155111 deleted from public.log_broadcasts_pending.
Rows with evm_chain_id 11155111 deleted from public.blockhash_store_specs.
Rows with evm_chain_id 11155111 deleted from evm.forwarders.
Rows with evm_chain_id 11155111 deleted from evm.logs.
Rows with evm_chain_id 11155111 deleted from evm.log_poller_blocks.
Rows with evm_chain_id 11155111 deleted from evm.log_poller_filters.
Rows with evm_chain_id 11155111 deleted from public.block_header_feeder_specs.
Rows with evm_chain_id 11155111 deleted from public.legacy_gas_station_server_specs.
Rows with evm_chain_id 11155111 deleted from public.legacy_gas_station_sidecar_specs.
Rows with evm_chain_id 11155111 deleted from evm.upkeep_states.
Rows with evm_chain_id 11155111 deleted from public.eal_specs.
Rows with evm_chain_id 11155111 deleted from public.eal_txs.
patrick.huie@smartcontract.com@MB-LXNRFW22N3 chainlink % ./chainlink keys eth list
🔑 ETH keys

-------------------------------------------------------------------------------------------------
Address:           0x46035eB4d2D49C843d96C990f4776B1846Cf3F5B
EVM Chain ID:      11155111
ETH:               0.000000000000000000
LINK:              0
Disabled:          false
Created:           2023-11-30 11:02:08.560341 -0500 EST
Updated:           2023-11-30 11:02:08.560341 -0500 EST
Max Gas Price Wei: 115792089237316195423570985008687907853269984665640564039457584007913129639935
-------------------------------------------------------------------------------------------------
```