### PR TITLE
common/txmgr: initialize map before goroutines race ahead

### DIFF
--- a/common/txmgr/broadcaster.go
+++ b/common/txmgr/broadcaster.go
@@ -222,15 +222,14 @@ func (eb *Broadcaster[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) star
 	eb.wg = sync.WaitGroup{}
 	eb.wg.Add(len(eb.enabledAddresses))
 	eb.triggers = make(map[ADDR]chan struct{})
+	eb.sequenceLock.Lock()
+	eb.nextSequenceMap = eb.loadNextSequenceMap(eb.enabledAddresses)
+	eb.sequenceLock.Unlock()
 	for _, addr := range eb.enabledAddresses {
 		triggerCh := make(chan struct{}, 1)
 		eb.triggers[addr] = triggerCh
 		go eb.monitorTxs(addr, triggerCh)
 	}
-
-	eb.sequenceLock.Lock()
-	defer eb.sequenceLock.Unlock()
-	eb.nextSequenceMap = eb.loadNextSequenceMap(eb.enabledAddresses)
 
 	eb.isStarted = true
 	return nil

--- a/common/txmgr/test_helpers.go
+++ b/common/txmgr/test_helpers.go
@@ -22,8 +22,8 @@ func (tr *Tracker[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) XXXDeliverB
 	tr.mb.Deliver(blockHeight)
 }
 
-func (eb *Broadcaster[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) XXXTestStartInternal() error {
-	return eb.startInternal()
+func (eb *Broadcaster[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) XXXTestStartInternal(ctx context.Context) error {
+	return eb.startInternal(ctx)
 }
 
 func (eb *Broadcaster[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) XXXTestCloseInternal() error {

--- a/core/chains/evm/txmgr/broadcaster_test.go
+++ b/core/chains/evm/txmgr/broadcaster_test.go
@@ -124,9 +124,9 @@ func TestEthBroadcaster_Lifecycle(t *testing.T) {
 	require.Error(t, eb.XXXTestCloseInternal())
 
 	// Can successfully startInternal a previously closed instance
-	require.NoError(t, eb.XXXTestStartInternal())
+	require.NoError(t, eb.XXXTestStartInternal(ctx))
 	// Can't startInternal already started instance
-	require.Error(t, eb.XXXTestStartInternal())
+	require.Error(t, eb.XXXTestStartInternal(ctx))
 	// Can successfully closeInternal again
 	require.NoError(t, eb.XXXTestCloseInternal())
 }


### PR DESCRIPTION
This PR reorders the statements in `*Broadcaster.startInternal()` so that the `nextSequenceMap` is initialized before the spawned goroutines have an opportunity to race ahead and access it.
```
$ go test ./core/chains/evm/txmgr/ -race -count 5
panic: assignment to entry in nil map

goroutine 1805 [running]:
github.com/smartcontractkit/chainlink/v2/common/txmgr.(*Broadcaster[...]).GetNextSequence(0x43dfdc0, {0x43b5538, 0xc002798410}, {0x80, 0xf7, 0x22, 0x1b, 0x6a, 0x3a, 0xce, ...})
        /home/jordan/chainlink/common/txmgr/broadcaster.go:826 +0x5ed
github.com/smartcontractkit/chainlink/v2/common/txmgr.(*Broadcaster[...]).SyncSequence(0x43dfdc0, {0x43b5538, 0xc002798410}, {0x80, 0xf7, 0x22, 0x1b, 0x6a, 0x3a, 0xce, ...})
        /home/jordan/chainlink/common/txmgr/broadcaster.go:403 +0x149
github.com/smartcontractkit/chainlink/v2/common/txmgr.(*Broadcaster[...]).monitorTxs(0x43dfdc0, {0x80, 0xf7, 0x22, 0x1b, 0x6a, 0x3a, 0xce, 0x50, 0xce, ...}, ...)
        /home/jordan/chainlink/common/txmgr/broadcaster.go:347 +0x3ee
created by github.com/smartcontractkit/chainlink/v2/common/txmgr.(*Broadcaster[...]).startInternal in goroutine 1804
        /home/jordan/chainlink/common/txmgr/broadcaster.go:228 +0x7cf
FAIL    github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr  117.452s
FAIL
```