### PR TITLE
go generate a mermaid flowchart for org modules

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -147,6 +147,10 @@ goreleaser-dev-build: ## Run goreleaser snapshot build
 goreleaser-dev-release: ## run goreleaser snapshot release
 	./tools/bin/goreleaser_wrapper release --snapshot --rm-dist --config ${GORELEASER_CONFIG}
 
+.PHONY: modgraph
+modgraph:
+	./tools/bin/modgraph > go.md
+
 help:
 	@echo ""
 	@echo "         .__           .__       .__  .__        __"

--- a/go.md
+++ b/go.md
@@ -1,0 +1,65 @@
+# smartcontractkit Go modules
+```mermaid
+flowchart LR
+  subgraph chains
+    chainlink-cosmos
+    chainlink-evm
+    chainlink-solana
+    chainlink-starknet/relayer
+  end
+
+  subgraph products
+    chainlink-automation
+    chainlink-ccip
+    chainlink-data-streams
+    chainlink-feeds
+    chainlink-functions
+    chainlink-vrf
+  end
+
+  classDef outline stroke-dasharray:6,fill:none;
+  class chains,products outline
+
+  chainlink/v2 --> caigo
+  click caigo href "https://github.com/smartcontractkit/caigo"
+  chainlink/v2 --> chainlink-automation
+  click chainlink-automation href "https://github.com/smartcontractkit/chainlink-automation"
+  chainlink/v2 --> chainlink-common
+  click chainlink-common href "https://github.com/smartcontractkit/chainlink-common"
+  chainlink/v2 --> chainlink-cosmos
+  click chainlink-cosmos href "https://github.com/smartcontractkit/chainlink-cosmos"
+  chainlink/v2 --> chainlink-data-streams
+  click chainlink-data-streams href "https://github.com/smartcontractkit/chainlink-data-streams"
+  chainlink/v2 --> chainlink-feeds
+  click chainlink-feeds href "https://github.com/smartcontractkit/chainlink-feeds"
+  chainlink/v2 --> chainlink-solana
+  click chainlink-solana href "https://github.com/smartcontractkit/chainlink-solana"
+  chainlink/v2 --> chainlink-starknet/relayer
+  click chainlink-starknet/relayer href "https://github.com/smartcontractkit/chainlink-starknet"
+  chainlink/v2 --> chainlink-vrf
+  click chainlink-vrf href "https://github.com/smartcontractkit/chainlink-vrf"
+  chainlink/v2 --> libocr
+  click libocr href "https://github.com/smartcontractkit/libocr"
+  chainlink/v2 --> tdh2/go/ocr2/decryptionplugin
+  click tdh2/go/ocr2/decryptionplugin href "https://github.com/smartcontractkit/tdh2"
+  chainlink/v2 --> tdh2/go/tdh2
+  click tdh2/go/tdh2 href "https://github.com/smartcontractkit/tdh2"
+  chainlink/v2 --> wsrpc
+  click wsrpc href "https://github.com/smartcontractkit/wsrpc"
+  chainlink-automation --> libocr
+  chainlink-common --> libocr
+  chainlink-cosmos --> chainlink-common
+  chainlink-cosmos --> libocr
+  chainlink-data-streams --> chainlink-common
+  chainlink-data-streams --> libocr
+  chainlink-feeds --> chainlink-common
+  chainlink-feeds --> libocr
+  chainlink-solana --> chainlink-common
+  chainlink-solana --> libocr
+  chainlink-starknet/relayer --> caigo
+  chainlink-starknet/relayer --> chainlink-common
+  chainlink-starknet/relayer --> libocr
+  chainlink-vrf --> libocr
+  tdh2/go/ocr2/decryptionplugin --> libocr
+  tdh2/go/ocr2/decryptionplugin --> tdh2/go/tdh2
+```

--- a/main.go
+++ b/main.go
@@ -6,6 +6,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core"
 )
 
+//go:generate make modgraph
 func main() {
 	os.Exit(core.Main())
 }

--- a/tools/bin/modgraph
+++ b/tools/bin/modgraph
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+# Generates go.md
+
+set -e
+
+echo "# smartcontractkit Go modules
+\`\`\`mermaid
+flowchart LR
+  subgraph chains
+    chainlink-cosmos
+    chainlink-evm
+    chainlink-solana
+    chainlink-starknet/relayer
+  end
+
+  subgraph products
+    chainlink-automation
+    chainlink-ccip
+    chainlink-data-streams
+    chainlink-feeds
+    chainlink-functions
+    chainlink-vrf
+  end
+
+  classDef outline stroke-dasharray:6,fill:none;
+  class chains,products outline
+"
+go mod graph | \
+  # org only
+  grep smartcontractkit.*smartcontractkit | \
+  # drop prefix
+  sed s/"github\.com\/smartcontractkit\/"/""/g | \
+  # insert edges
+  sed s/" "/" --> "/ | \
+  # drop versions
+  sed s/"@[^ ]*"/""/g | \
+  # insert links
+  sed s/"\([^ ]*\)$"/"\1\nclick \1 href \"https:\/\/github.com\/smartcontractkit\/\1\""/ | \
+  # truncate links to repo
+  sed s/"\"https:\/\/github.com\/smartcontractkit\/\([^\"\/]*\)\/.*\""/"\"https:\/\/github.com\/smartcontractkit\/\1\""/ | \
+  # dedupe lines
+  awk '!x[$0]++' | \
+  # indent
+  sed 's/^/  /'
+echo "\`\`\`"


### PR DESCRIPTION
This PR adds a script for generating a go module graph of the smartcontractkit org dependencies used to build chainlink.
The script is `tools/bin/modgraph` and can be invoked via `make modgraph` to regenerate `go.md`. This is wired in to `go generate` as well, so that the existing CI checks will ensure it stays up to date.
![Screenshot from 2023-12-07 05-29-26](https://github.com/smartcontractkit/chainlink/assets/1194128/e24f1c0a-645a-41cc-b957-a1aad91497d0)
