### PR TITLE
[FUN-1138] Disable flakey functions test

### DIFF
--- a/core/services/functions/connector_handler_test.go
+++ b/core/services/functions/connector_handler_test.go
@@ -54,6 +54,7 @@ func newOffchainRequest(t *testing.T, sender []byte) (*api.Message, functions.Re
 }
 
 func TestFunctionsConnectorHandler(t *testing.T) {
+	testutils.SkipFlakey(t, "https://smartcontract-it.atlassian.net/browse/FUN-1138")
 	t.Parallel()
 
 	logger := logger.TestLogger(t)


### PR DESCRIPTION
This test is accounting for the majority of flakes at the moment, so I've disabled it and added a ticket here to track remediation: https://smartcontract-it.atlassian.net/browse/FUN-1138

cc @bolekk -- I assigned this to you since it looks like you were the last to touch the test, but happy to be redirected. Thanks!