### PR TITLE
prune vrfv2 inflight cache more frequently

### DIFF
--- a/core/services/vrf/delegate.go
+++ b/core/services/vrf/delegate.go
@@ -178,7 +178,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 					func() {},
 					// the lookback in the deduper must be >= the lookback specified for the log poller
 					// otherwise we will end up re-delivering logs that were already delivered.
-					vrfcommon.NewInflightCache(int(chain.Config().EVM().FinalityDepth())),
+					vrfcommon.NewInflightCache(int(chain.Config().EVM().FinalityDepth()), int(2*chain.Config().EVM().FinalityDepth())),
 					vrfcommon.NewLogDeduper(int(chain.Config().EVM().FinalityDepth())),
 				),
 			}, nil
@@ -232,7 +232,7 @@ func (d *Delegate) ServicesForSpec(jb job.Job) ([]job.ServiceCtx, error) {
 				func() {},
 				// the lookback in the deduper must be >= the lookback specified for the log poller
 				// otherwise we will end up re-delivering logs that were already delivered.
-				vrfcommon.NewInflightCache(int(chain.Config().EVM().FinalityDepth())),
+				vrfcommon.NewInflightCache(int(chain.Config().EVM().FinalityDepth()), int(2*chain.Config().EVM().FinalityDepth())),
 				vrfcommon.NewLogDeduper(int(chain.Config().EVM().FinalityDepth())),
 			),
 			}, nil


### PR DESCRIPTION
- reducing inflight cache for inflight cache. In case TXs revert for whatever reason, we want VRF listener to retry quickly. Otherwise, we will need to restart the node to clear the inflight cache in case of emergencies