### PR TITLE
Update path filter for chaincli-lint

### DIFF
--- a/.github/workflows/ci-chaincli.yml
+++ b/.github/workflows/ci-chaincli.yml
@@ -2,7 +2,13 @@ name: chaincli CI
 
 on:
   push:
+    paths:
+      - "core/scripts/chaincli/**"
+      - ".github/workflows/ci-chaincli.yml"
   pull_request:
+    paths:
+      - "core/scripts/chaincli/**"
+      - ".github/workflows/ci-chaincli.yml"
 
 jobs:
   golangci:


### PR DESCRIPTION
It's currently failing in an unrelated change in this [CI run](https://github.com/smartcontractkit/chainlink/actions/runs/7181903970/job/19557250386?pr=11542#step:3:479).