### PR TITLE
Improve chain reader readability for method/event names and bindings

### DIFF
--- a/core/services/relay/evm/bindings.go
+++ b/core/services/relay/evm/bindings.go
@@ -1,50 +1,11 @@
 package evm
 
 import (
-	"fmt"
-
 	"github.com/ethereum/go-ethereum/common"
-
-	"github.com/smartcontractkit/chainlink-common/pkg/types"
 )
 
-type Bindings map[string]methodBindings
+// Bindings Key being contract name.
+type Bindings map[string]ContractBinding
 
-func (b Bindings) addEvent(contractName, typeName string, evt common.Hash) error {
-	ae, err := b.getBinding(contractName, typeName, true)
-	if err != nil {
-		return err
-	}
-
-	ae.evt = &evt
-	return nil
-}
-
-func (b Bindings) getBinding(contractName, methodName string, isConfig bool) (*addrEvtBinding, error) {
-	errType := types.ErrInvalidType
-	if isConfig {
-		errType = types.ErrInvalidConfig
-	}
-	methodNames, ok := b[contractName]
-	if !ok {
-		return nil, fmt.Errorf("%w: contract %s not found", errType, contractName)
-	}
-
-	ae, ok := methodNames[methodName]
-	if !ok {
-		return nil, fmt.Errorf("%w: method %s not found in contract %s", errType, methodName, contractName)
-	}
-
-	return ae, nil
-}
-
-type methodBindings map[string]*addrEvtBinding
-
-func NewAddrEvtFromAddress(address common.Address) *addrEvtBinding {
-	return &addrEvtBinding{addr: address}
-}
-
-type addrEvtBinding struct {
-	addr common.Address
-	evt  *common.Hash
-}
+// ContractBinding key being read name(event or method)
+type ContractBinding map[string]common.Address

--- a/core/services/relay/evm/chain_reader_test.go
+++ b/core/services/relay/evm/chain_reader_test.go
@@ -73,10 +73,10 @@ func (it *chainReaderInterfaceTester) Setup(t *testing.T) {
 	testStruct := CreateTestStruct(0, it)
 
 	it.chainConfig = types.ChainReaderConfig{
-		ChainContractReaders: map[string]types.ChainContractReader{
+		ContractReaders: map[string]types.ContractReader{
 			AnyContractName: {
 				ContractABI: testfiles.TestfilesMetaData.ABI,
-				ChainReaderDefinitions: map[string]types.ChainReaderDefinition{
+				ReadingDefinitions: map[string]types.ReadingDefinition{
 					MethodTakingLatestParamsReturningTestStruct: {
 						ChainSpecificName: "GetElementAtIndex",
 					},
@@ -112,7 +112,7 @@ func (it *chainReaderInterfaceTester) Setup(t *testing.T) {
 			},
 			AnySecondContractName: {
 				ContractABI: testfiles.TestfilesMetaData.ABI,
-				ChainReaderDefinitions: map[string]types.ChainReaderDefinition{
+				ReadingDefinitions: map[string]types.ReadingDefinition{
 					MethodReturningUint64: {
 						ChainSpecificName: "GetDifferentPrimitiveValue",
 					},
@@ -150,15 +150,15 @@ func (it *chainReaderInterfaceTester) GetChainReader(t *testing.T) clcommontypes
 	it.chain.On("LogPoller").Return(lp)
 	b := evm.Bindings{
 		AnyContractName: {
-			MethodTakingLatestParamsReturningTestStruct: evm.NewAddrEvtFromAddress(addr),
-			MethodReturningUint64:                       evm.NewAddrEvtFromAddress(addr),
-			DifferentMethodReturningUint64:              evm.NewAddrEvtFromAddress(addr2),
-			MethodReturningUint64Slice:                  evm.NewAddrEvtFromAddress(addr),
-			EventName:                                   evm.NewAddrEvtFromAddress(addr),
-			MethodReturningSeenStruct:                   evm.NewAddrEvtFromAddress(addr),
+			MethodTakingLatestParamsReturningTestStruct: addr,
+			MethodReturningUint64:                       addr,
+			DifferentMethodReturningUint64:              addr2,
+			MethodReturningUint64Slice:                  addr,
+			MethodReturningSeenStruct:                   addr,
+			EventName:                                   addr,
 		},
 		AnySecondContractName: {
-			MethodReturningUint64: evm.NewAddrEvtFromAddress(addr2),
+			MethodReturningUint64: addr2,
 		},
 	}
 	cr, err := evm.NewChainReaderService(lggr, lp, b, it.chain, it.chainConfig)

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -537,8 +537,8 @@ func (r *Relayer) NewMedianProvider(rargs commontypes.RelayArgs, pargs commontyp
 		b := Bindings{
 			// TODO BCF-2837: clean up the hard-coded values.
 			"median": {
-				"LatestTransmissionDetails": &addrEvtBinding{addr: contractID},
-				"LatestRoundReported":       &addrEvtBinding{addr: contractID},
+				"LatestTransmissionDetails": contractID,
+				"LatestRoundReported":       contractID,
 			},
 		}
 


### PR DESCRIPTION
Start and close can be a bit improved, but this is the general idea for making this a bit cleaner