### PR TITLE
feat: add liquidity balancer specs table

### DIFF
--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -152,6 +152,8 @@ type Job struct {
 	GatewaySpecID                 *int32
 	EALSpec                       *EALSpec
 	EALSpecID                     *int32
+	LiquidityBalancerSpec         *LiquidityBalancerSpec
+	LiquidityBalancerSpecID       *int32
 	PipelineSpecID                int32
 	PipelineSpec                  *pipeline.Spec
 	JobSpecErrors                 []SpecError
@@ -792,4 +794,10 @@ type EALSpec struct {
 
 	// UpdatedAt is the time this job was last updated.
 	UpdatedAt time.Time `toml:"-"`
+}
+
+type LiquidityBalancerSpec struct {
+	ID int32
+
+	LiquidityBalancerConfig string `toml:"liquidityBalancerConfig" db:"liquidity_balancer_config"`
 }

--- a/core/store/migrate/migrations/0213_liquidity_balancer_specs.sql
+++ b/core/store/migrate/migrations/0213_liquidity_balancer_specs.sql
@@ -1,0 +1,49 @@
+-- +goose Up
+CREATE TABLE liquidity_balancer_specs (
+    id BIGSERIAL PRIMARY KEY,
+    liquidity_balancer_config JSONB NOT NULL
+);
+
+ALTER TABLE
+    jobs
+ADD COLUMN
+    liquidity_balancer_spec_id BIGINT REFERENCES liquidity_balancer_specs(id),
+DROP CONSTRAINT chk_only_one_spec,
+ADD CONSTRAINT chk_only_one_spec CHECK (
+    num_nonnulls(
+      ocr_oracle_spec_id, ocr2_oracle_spec_id,
+      direct_request_spec_id, flux_monitor_spec_id,
+      keeper_spec_id, cron_spec_id, webhook_spec_id,
+      vrf_spec_id, blockhash_store_spec_id,
+      block_header_feeder_spec_id, bootstrap_spec_id,
+      gateway_spec_id,
+      legacy_gas_station_server_spec_id,
+      legacy_gas_station_sidecar_spec_id,
+      eal_spec_id,
+      liquidity_balancer_spec_id
+    ) = 1
+);
+
+-- +goose Down
+ALTER TABLE
+    jobs
+DROP CONSTRAINT chk_only_one_spec,
+ADD CONSTRAINT chk_only_one_spec CHECK (
+    num_nonnulls(
+      ocr_oracle_spec_id, ocr2_oracle_spec_id,
+      direct_request_spec_id, flux_monitor_spec_id,
+      keeper_spec_id, cron_spec_id, webhook_spec_id,
+      vrf_spec_id, blockhash_store_spec_id,
+      block_header_feeder_spec_id, bootstrap_spec_id,
+      gateway_spec_id,
+      legacy_gas_station_server_spec_id,
+      legacy_gas_station_sidecar_spec_id,
+      eal_spec_id
+    ) = 1
+);
+ALTER TABLE
+    jobs
+DROP COLUMN
+    liquidity_balancer_spec_id;
+DROP TABLE
+    liquidity_balancer_specs;


### PR DESCRIPTION
Add the liquidity balancer specs table. This table will be used to house the specs for the liquidity balancer job which will be implemented in ccip rather than core.

The entirety of the spec's content will be in the
`liquidity_balancer_config` field. This is done to minimize future migrations. This doesn't mean we won't be doing strict checks on the contents of the config during the validation process.