### PR TITLE
core/chains/evm/txmgr: fix race by waiting for goroutines to complete

### DIFF
--- a/core/chains/evm/txmgr/confirmer_test.go
+++ b/core/chains/evm/txmgr/confirmer_test.go
@@ -2984,13 +2984,19 @@ func TestEthConfirmer_ResumePendingRuns(t *testing.T) {
 
 		pgtest.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &tr.ID, minConfirmations, etx.ID)
 
+		done := make(chan struct{})
+		t.Cleanup(func() { <-done })
 		go func() {
+			defer close(done)
 			err2 := ec.ResumePendingTaskRuns(testutils.Context(t), &head)
-			require.NoError(t, err2)
+			if !assert.NoError(t, err2) {
+				return
+			}
 			// Retrieve Tx to check if callback completed flag was set to true
 			updateTx, err3 := txStore.FindTxWithSequence(testutils.Context(t), fromAddress, nonce)
-			require.NoError(t, err3)
-			require.Equal(t, true, updateTx.CallbackCompleted)
+			if assert.NoError(t, err3) {
+				assert.Equal(t, true, updateTx.CallbackCompleted)
+			}
 		}()
 
 		select {
@@ -3032,13 +3038,19 @@ func TestEthConfirmer_ResumePendingRuns(t *testing.T) {
 
 		pgtest.MustExec(t, db, `UPDATE evm.txes SET pipeline_task_run_id = $1, min_confirmations = $2, signal_callback = TRUE WHERE id = $3`, &tr.ID, minConfirmations, etx.ID)
 
+		done := make(chan struct{})
+		t.Cleanup(func() { <-done })
 		go func() {
+			defer close(done)
 			err2 := ec.ResumePendingTaskRuns(testutils.Context(t), &head)
-			require.NoError(t, err2)
+			if !assert.NoError(t, err2) {
+				return
+			}
 			// Retrieve Tx to check if callback completed flag was set to true
 			updateTx, err3 := txStore.FindTxWithSequence(testutils.Context(t), fromAddress, nonce)
-			require.NoError(t, err3)
-			require.Equal(t, true, updateTx.CallbackCompleted)
+			if assert.NoError(t, err3) {
+				assert.Equal(t, true, updateTx.CallbackCompleted)
+			}
 		}()
 
 		select {


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/actions/runs/7213591116/job/19653789730?pr=11555

```
==================
WARNING: DATA RACE
Read at 0x00c0016dcba3 by goroutine 76188:
  testing.(*common).logDepth()
      /opt/hostedtoolcache/go/1.21.3/x64/src/testing/testing.go:1017 +0x4af
  testing.(*common).log()
      /opt/hostedtoolcache/go/1.21.3/x64/src/testing/testing.go:1004 +0x99
  testing.(*common).Errorf()
      /opt/hostedtoolcache/go/1.21.3/x64/src/testing/testing.go:1068 +0x62
  testing.(*T).Errorf()
      <autogenerated>:1 +0x69
  github.com/stretchr/testify/assert.Fail()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.8.4/assert/assertions.go:333 +0x3eb
  github.com/stretchr/testify/assert.NoError()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.8.4/assert/assertions.go:1495 +0x126
  github.com/stretchr/testify/require.NoError()
      /home/runner/go/pkg/mod/github.com/stretchr/testify@v1.8.4/require/require.go:1357 +0x96
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr_test.TestEthConfirmer_ResumePendingRuns.func3.2()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txmgr/confirmer_test.go:2992 +0x156

Previous write at 0x00c0016dcba3 by goroutine 74773:
  testing.tRunner.func1()
      /opt/hostedtoolcache/go/1.21.3/x64/src/testing/testing.go:1582 +0x81a
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.21.3/x64/src/runtime/panic.go:477 +0x30
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.3/x64/src/testing/testing.go:1648 +0x44

Goroutine 76188 (running) created at:
  github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr_test.TestEthConfirmer_ResumePendingRuns.func3()
      /home/runner/work/chainlink/chainlink/core/chains/evm/txmgr/confirmer_test.go:2987 +0x8d9
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.3/x64/src/testing/testing.go:1595 +0x238
  testing.(*T).Run.func1()
      /opt/hostedtoolcache/go/1.21.3/x64/src/testing/testing.go:1648 +0x44

Goroutine 74773 (finished) created at:
  testing.(*T).Run()
      /opt/hostedtoolcache/go/1.21.3/x64/src/testing/testing.go:1648 +0x82a
  testing.runTests.func1()
      /opt/hostedtoolcache/go/1.21.3/x64/src/testing/testing.go:2054 +0x84
  testing.tRunner()
      /opt/hostedtoolcache/go/1.21.3/x64/src/testing/testing.go:1595 +0x238
  testing.runTests()
      /opt/hostedtoolcache/go/1.21.3/x64/src/testing/testing.go:2052 +0x896
  testing.(*M).Run()
      /opt/hostedtoolcache/go/1.21.3/x64/src/testing/testing.go:1925 +0xb57
  main.main()
      _testmain.go:261 +0x2bd
==================
```