### PR TITLE
core/scripts: golangci-lint cleanup

### DIFF
--- a/core/scripts/chaincli/command/keeper/upkeep.go
+++ b/core/scripts/chaincli/command/keeper/upkeep.go
@@ -82,14 +82,11 @@ var ocr2UpkeepReportHistoryCmd = &cobra.Command{
 		hdlr := handler.NewBaseHandler(cfg)
 
 		var hashes []string
-		var err error
-		var path string
-
-		path, err = cmd.Flags().GetString("csv")
+		path, err := cmd.Flags().GetString("csv")
 		if err == nil && len(path) != 0 {
-			rec, err := readCsvFile(path)
-			if err != nil {
-				log.Fatal(err)
+			rec, err2 := readCsvFile(path)
+			if err2 != nil {
+				log.Fatal(err2)
 			}
 
 			if len(rec) < 1 {
@@ -107,7 +104,7 @@ var ocr2UpkeepReportHistoryCmd = &cobra.Command{
 			}
 		}
 
-		if err := handler.OCR2AutomationReports(hdlr, hashes); err != nil {
+		if err = handler.OCR2AutomationReports(hdlr, hashes); err != nil {
 			log.Fatalf("failed to collect transaction data: %s", err)
 		}
 	},

--- a/core/scripts/chaincli/handler/handler.go
+++ b/core/scripts/chaincli/handler/handler.go
@@ -411,44 +411,44 @@ func (h *baseHandler) launchChainlinkNode(ctx context.Context, port int, contain
 
 		if writeLogs {
 			var rdr io.ReadCloser
-			rdr, err := dockerClient.ContainerLogs(ctx, nodeContainerResp.ID, types.ContainerLogsOptions{
+			rdr, err2 := dockerClient.ContainerLogs(ctx, nodeContainerResp.ID, types.ContainerLogsOptions{
 				ShowStderr: true,
 				Timestamps: true,
 			})
-			if err != nil {
+			if err2 != nil {
 				rdr.Close()
-				log.Fatal("Failed to collect logs from container: ", err)
+				log.Fatal("Failed to collect logs from container: ", err2)
 			}
 
-			stdErr, err := os.OpenFile(fmt.Sprintf("./%s-stderr.log", nodeContainerResp.ID), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
-			if err != nil {
+			stdErr, err2 := os.OpenFile(fmt.Sprintf("./%s-stderr.log", nodeContainerResp.ID), os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0755)
+			if err2 != nil {
 				rdr.Close()
 				stdErr.Close()
-				log.Fatal("Failed to open file: ", err)
+				log.Fatal("Failed to open file: ", err2)
 			}
 
-			if _, err := stdcopy.StdCopy(io.Discard, stdErr, rdr); err != nil {
+			if _, err2 := stdcopy.StdCopy(io.Discard, stdErr, rdr); err2 != nil {
 				rdr.Close()
 				stdErr.Close()
-				log.Fatal("Failed to write logs to file: ", err)
+				log.Fatal("Failed to write logs to file: ", err2)
 			}
 
 			rdr.Close()
 			stdErr.Close()
 		}
 
-		if err = dockerClient.ContainerStop(ctx, nodeContainerResp.ID, container.StopOptions{}); err != nil {
-			log.Fatal("Failed to stop node container: ", err)
+		if err2 := dockerClient.ContainerStop(ctx, nodeContainerResp.ID, container.StopOptions{}); err2 != nil {
+			log.Fatal("Failed to stop node container: ", err2)
 		}
-		if err = dockerClient.ContainerRemove(ctx, nodeContainerResp.ID, types.ContainerRemoveOptions{}); err != nil {
-			log.Fatal("Failed to remove node container: ", err)
+		if err2 := dockerClient.ContainerRemove(ctx, nodeContainerResp.ID, types.ContainerRemoveOptions{}); err2 != nil {
+			log.Fatal("Failed to remove node container: ", err2)
 		}
 
-		if err = dockerClient.ContainerStop(ctx, dbContainerResp.ID, container.StopOptions{}); err != nil {
-			log.Fatal("Failed to stop DB container: ", err)
+		if err2 := dockerClient.ContainerStop(ctx, dbContainerResp.ID, container.StopOptions{}); err2 != nil {
+			log.Fatal("Failed to stop DB container: ", err2)
 		}
-		if err = dockerClient.ContainerRemove(ctx, dbContainerResp.ID, types.ContainerRemoveOptions{}); err != nil {
-			log.Fatal("Failed to remove DB container: ", err)
+		if err2 := dockerClient.ContainerRemove(ctx, dbContainerResp.ID, types.ContainerRemoveOptions{}); err2 != nil {
+			log.Fatal("Failed to remove DB container: ", err2)
 		}
 	}, nil
 }

--- a/core/scripts/chaincli/handler/keeper_launch.go
+++ b/core/scripts/chaincli/handler/keeper_launch.go
@@ -100,14 +100,12 @@ func (k *Keeper) LaunchAndTest(ctx context.Context, withdraw, printLogs, force, 
 
 		if len(k.cfg.KeeperKeys) > 0 {
 			// import key if exists
-			var err error
 			nodeAddrHex, err = k.addKeyToKeeper(cl, k.cfg.KeeperKeys[i])
 			if err != nil {
 				log.Fatal("could not add key to keeper", err)
 			}
 		} else {
 			// get node's default wallet address
-			var err error
 			nodeAddrHex, err = getNodeAddress(cl)
 			if err != nil {
 				log.Println("Failed to get node addr: ", err)
@@ -220,35 +218,35 @@ func (k *Keeper) LaunchAndTest(ctx context.Context, withdraw, printLogs, force, 
 
 // cancelAndWithdrawActiveUpkeeps cancels all active upkeeps and withdraws funds for registry 1.2
 func (k *Keeper) cancelAndWithdrawActiveUpkeeps(ctx context.Context, activeUpkeepIds []*big.Int, canceller canceller) error {
-	var err error
 	for i := 0; i < len(activeUpkeepIds); i++ {
-		var tx *ethtypes.Transaction
 		upkeepId := activeUpkeepIds[i]
-		if tx, err = canceller.CancelUpkeep(k.buildTxOpts(ctx), upkeepId); err != nil {
+		tx, err := canceller.CancelUpkeep(k.buildTxOpts(ctx), upkeepId)
+		if err != nil {
 			return fmt.Errorf("failed to cancel upkeep %s: %s", upkeepId.String(), err)
 		}
 
-		if err := k.waitTx(ctx, tx); err != nil {
+		if err = k.waitTx(ctx, tx); err != nil {
 			log.Fatalf("failed to cancel upkeep for upkeepId: %s, error is: %s", upkeepId.String(), err.Error())
 		}
 
-		if tx, err = canceller.WithdrawFunds(k.buildTxOpts(ctx), upkeepId, k.fromAddr); err != nil {
+		tx, err = canceller.WithdrawFunds(k.buildTxOpts(ctx), upkeepId, k.fromAddr)
+		if err != nil {
 			return fmt.Errorf("failed to withdraw upkeep %s: %s", upkeepId.String(), err)
 		}
 
-		if err := k.waitTx(ctx, tx); err != nil {
+		if err = k.waitTx(ctx, tx); err != nil {
 			log.Fatalf("failed to withdraw upkeep for upkeepId: %s, error is: %s", upkeepId.String(), err.Error())
 		}
 
 		log.Printf("Upkeep %s successfully canceled and refunded: ", upkeepId.String())
 	}
 
-	var tx *ethtypes.Transaction
-	if tx, err = canceller.RecoverFunds(k.buildTxOpts(ctx)); err != nil {
+	tx, err := canceller.RecoverFunds(k.buildTxOpts(ctx))
+	if err != nil {
 		return fmt.Errorf("failed to recover funds: %s", err)
 	}
 
-	if err := k.waitTx(ctx, tx); err != nil {
+	if err = k.waitTx(ctx, tx); err != nil {
 		log.Fatalf("failed to recover funds, error is: %s", err.Error())
 	}
 
@@ -264,7 +262,7 @@ func (k *Keeper) cancelAndWithdrawUpkeeps(ctx context.Context, upkeepCount *big.
 			return fmt.Errorf("failed to cancel upkeep %d: %s", i, err)
 		}
 
-		if err := k.waitTx(ctx, tx); err != nil {
+		if err = k.waitTx(ctx, tx); err != nil {
 			log.Fatalf("failed to cancel upkeep, error is: %s", err.Error())
 		}
 
@@ -272,7 +270,7 @@ func (k *Keeper) cancelAndWithdrawUpkeeps(ctx context.Context, upkeepCount *big.
 			return fmt.Errorf("failed to withdraw upkeep %d: %s", i, err)
 		}
 
-		if err := k.waitTx(ctx, tx); err != nil {
+		if err = k.waitTx(ctx, tx); err != nil {
 			log.Fatalf("failed to withdraw upkeep, error is: %s", err.Error())
 		}
 
@@ -284,7 +282,7 @@ func (k *Keeper) cancelAndWithdrawUpkeeps(ctx context.Context, upkeepCount *big.
 		return fmt.Errorf("failed to recover funds: %s", err)
 	}
 
-	if err := k.waitTx(ctx, tx); err != nil {
+	if err = k.waitTx(ctx, tx); err != nil {
 		log.Fatalf("failed to recover funds, error is: %s", err.Error())
 	}
 

--- a/core/scripts/chaincli/handler/ocr2_config.go
+++ b/core/scripts/chaincli/handler/ocr2_config.go
@@ -54,7 +54,7 @@ func OCR2GetConfig(hdlr *baseHandler, registry_addr string) error {
 
 func configFromBlock(bl *types.Block, addr common.Address, detail keeper_registry_wrapper2_0.LatestConfigDetails) (*confighelper.PublicConfig, error) {
 	for _, tx := range bl.Transactions() {
-		if tx.To() != nil && bytes.Compare(tx.To()[:], addr[:]) == 0 {
+		if tx.To() != nil && bytes.Equal(tx.To()[:], addr[:]) {
 			// this is our transaction
 			// txRes, txErr, err := getTransactionDetailForHashes(hdlr, []string{tx})
 			ocr2Tx, err := NewBaseOCR2Tx(tx)

--- a/core/scripts/chaincli/handler/report.go
+++ b/core/scripts/chaincli/handler/report.go
@@ -85,24 +85,26 @@ func OCR2AutomationReports(hdlr *baseHandler, txs []string) error {
 	}
 
 	txRes, txErr, err = getSimulationsForTxs(hdlr, simBatch)
+	if err != nil {
+		return err
+	}
 	for i := range txRes {
 		if txErr[i] == nil {
 			continue
 		}
 
-		err, ok := txErr[i].(JsonError)
+		err2, ok := txErr[i].(JsonError) //nolint:errorlint
 		if ok {
-			decoded, err := hexutil.Decode(err.ErrorData().(string))
+			decoded, err := hexutil.Decode(err2.ErrorData().(string))
 			if err != nil {
 				elements[i].Err = err.Error()
 				continue
 			}
 
 			elements[i].Err = ocr2Txs[i].DecodeError(decoded)
-		} else if err != nil {
-			elements[i].Err = err.Error()
+		} else if err2 != nil {
+			elements[i].Err = err2.Error()
 		}
-
 	}
 
 	data := make([][]string, len(elements))
@@ -275,7 +277,7 @@ func (t *OCR2Transaction) DecodeError(b []byte) string {
 		}
 	}
 
-	return fmt.Sprintf("%s", j)
+	return j
 }
 
 func NewOCR2TransmitTx(raw map[string]interface{}) (*OCR2TransmitTx, error) {

--- a/core/scripts/common/avalanche.go
+++ b/core/scripts/common/avalanche.go
@@ -79,8 +79,8 @@ func (b *AvaBloom) UnmarshalText(input []byte) error {
 // bloomValues returns the bytes (index-value pairs) to set for the given data
 func bloomValues(data []byte, hashbuf []byte) (uint, byte, uint, byte, uint, byte) {
 	sha := crypto.NewKeccakState()
-	sha.Write(data)
-	sha.Read(hashbuf)
+	sha.Write(data)   //nolint:errcheck
+	sha.Read(hashbuf) //nolint:errcheck
 	// The actual bits to flip
 	v1 := byte(1 << (hashbuf[1] & 0x7))
 	v2 := byte(1 << (hashbuf[3] & 0x7))
@@ -259,7 +259,7 @@ func (h *AvaHeader) Hash() common.Hash {
 func rlpHash(x interface{}) (h common.Hash) {
 	sha := crypto.NewKeccakState()
 	sha.Reset()
-	rlp.Encode(sha, x)
-	sha.Read(h[:])
+	rlp.Encode(sha, x) //nolint:errcheck
+	sha.Read(h[:])     //nolint:errcheck
 	return h
 }

--- a/core/scripts/common/helpers.go
+++ b/core/scripts/common/helpers.go
@@ -395,12 +395,12 @@ func FundNode(e Environment, address string, fundingAmount *big.Int) {
 	var gasLimit uint64
 	if IsArbitrumChainID(e.ChainID) {
 		to := common.HexToAddress(address)
-		estimated, err := e.Ec.EstimateGas(context.Background(), ethereum.CallMsg{
+		estimated, err2 := e.Ec.EstimateGas(context.Background(), ethereum.CallMsg{
 			From:  e.Owner.From,
 			To:    &to,
 			Value: fundingAmount,
 		})
-		PanicErr(err)
+		PanicErr(err2)
 		gasLimit = estimated
 	} else {
 		gasLimit = uint64(21_000)
@@ -461,7 +461,7 @@ func GetRlpHeaders(env Environment, blockNumbers []*big.Int, getParentBlocks boo
 
 	hashes = make([]string, 0)
 
-	var offset *big.Int = big.NewInt(0)
+	offset := big.NewInt(0)
 	if getParentBlocks {
 		offset = big.NewInt(1)
 	}
@@ -475,15 +475,15 @@ func GetRlpHeaders(env Environment, blockNumbers []*big.Int, getParentBlocks boo
 			var h AvaHeader
 			// Get child block since it's the one that has the parent hash in its header.
 			nextBlockNum := new(big.Int).Set(blockNum).Add(blockNum, offset)
-			err := env.Jc.CallContext(context.Background(), &h, "eth_getBlockByNumber", hexutil.EncodeBig(nextBlockNum), false)
-			if err != nil {
-				return nil, hashes, fmt.Errorf("failed to get header: %+v", err)
+			err2 := env.Jc.CallContext(context.Background(), &h, "eth_getBlockByNumber", hexutil.EncodeBig(nextBlockNum), false)
+			if err2 != nil {
+				return nil, hashes, fmt.Errorf("failed to get header: %+v", err2)
 			}
 			// We can still use vanilla go-ethereum rlp.EncodeToBytes, see e.g
 			// https://github.com/ava-labs/coreth/blob/e3ca41bf5295a9a7ca1aeaf29d541fcbb94f79b1/core/types/hashing.go#L49-L57.
-			rlpHeader, err = rlp.EncodeToBytes(h)
-			if err != nil {
-				return nil, hashes, fmt.Errorf("failed to encode rlp: %+v", err)
+			rlpHeader, err2 = rlp.EncodeToBytes(h)
+			if err2 != nil {
+				return nil, hashes, fmt.Errorf("failed to encode rlp: %+v", err2)
 			}
 
 			hashes = append(hashes, h.Hash().String())
@@ -509,16 +509,16 @@ func GetRlpHeaders(env Environment, blockNumbers []*big.Int, getParentBlocks boo
 
 		} else {
 			// Get child block since it's the one that has the parent hash in its header.
-			h, err := env.Ec.HeaderByNumber(
+			h, err2 := env.Ec.HeaderByNumber(
 				context.Background(),
 				new(big.Int).Set(blockNum).Add(blockNum, offset),
 			)
-			if err != nil {
-				return nil, hashes, fmt.Errorf("failed to get header: %+v", err)
+			if err2 != nil {
+				return nil, hashes, fmt.Errorf("failed to get header: %+v", err2)
 			}
-			rlpHeader, err = rlp.EncodeToBytes(h)
-			if err != nil {
-				return nil, hashes, fmt.Errorf("failed to encode rlp: %+v", err)
+			rlpHeader, err2 = rlp.EncodeToBytes(h)
+			if err2 != nil {
+				return nil, hashes, fmt.Errorf("failed to encode rlp: %+v", err2)
 			}
 
 			hashes = append(hashes, h.Hash().String())

--- a/core/scripts/common/vrf/model/model.go
+++ b/core/scripts/common/vrf/model/model.go
@@ -21,7 +21,6 @@ type Node struct {
 	NumberOfSendingKeysToCreate int
 	SendingKeyFundingAmount     *big.Int
 	VrfKeys                     []string
-	jobSpec                     string
 }
 
 type SendingKey struct {

--- a/core/scripts/common/vrf/setup-envs/main.go
+++ b/core/scripts/common/vrf/setup-envs/main.go
@@ -50,7 +50,6 @@ func newApp(remoteNodeURL string, writer io.Writer) (*clcmd.Shell, *cli.App) {
 var (
 	checkMarkEmoji = "✅"
 	xEmoji         = "❌"
-	infoEmoji      = "ℹ️"
 )
 
 func main() {
@@ -142,7 +141,7 @@ func main() {
 
 	output := &bytes.Buffer{}
 	for key, node := range nodesMap {
-
+		node := node
 		client, app := connectToNode(&node.URL, output, node.CredsFile)
 		ethKeys := createETHKeysIfNeeded(client, app, output, numEthKeys, &node.URL, maxGasPriceGwei)
 		if key == model.VRFPrimaryNodeName {
@@ -242,6 +241,7 @@ func main() {
 		}
 
 		for key, node := range nodesMap {
+			node := node
 			client, app := connectToNode(&node.URL, output, node.CredsFile)
 
 			//GET ALL JOBS
@@ -318,7 +318,7 @@ func getVRFKeys(client *clcmd.Shell, app *cli.App, output *bytes.Buffer) []prese
 }
 
 func createJob(jobSpec string, client *clcmd.Shell, app *cli.App, output *bytes.Buffer) {
-	if err := os.WriteFile("job-spec.toml", []byte(jobSpec), 0666); err != nil {
+	if err := os.WriteFile("job-spec.toml", []byte(jobSpec), 0666); err != nil { //nolint:gosec
 		helpers.PanicErr(err)
 	}
 	job := presenters.JobResource{}
@@ -332,7 +332,7 @@ func createJob(jobSpec string, client *clcmd.Shell, app *cli.App, output *bytes.
 }
 
 func exportVRFKey(client *clcmd.Shell, app *cli.App, vrfKey presenters.VRFKeyResource, output *bytes.Buffer) {
-	if err := os.WriteFile("vrf-key-password.txt", []byte("twochains"), 0666); err != nil {
+	if err := os.WriteFile("vrf-key-password.txt", []byte("twochains"), 0666); err != nil { //nolint:gosec
 		helpers.PanicErr(err)
 	}
 	flagSet := flag.NewFlagSet("blah", flag.ExitOnError)
@@ -346,7 +346,7 @@ func exportVRFKey(client *clcmd.Shell, app *cli.App, vrfKey presenters.VRFKeyRes
 }
 
 func importVRFKey(client *clcmd.Shell, app *cli.App, output *bytes.Buffer) {
-	if err := os.WriteFile("vrf-key-password.txt", []byte("twochains"), 0666); err != nil {
+	if err := os.WriteFile("vrf-key-password.txt", []byte("twochains"), 0666); err != nil { //nolint:gosec
 		helpers.PanicErr(err)
 	}
 	flagSet := flag.NewFlagSet("blah", flag.ExitOnError)
@@ -465,12 +465,8 @@ func createVRFKeyIfNeeded(client *clcmd.Shell, app *cli.App, output *bytes.Buffe
 		}(), ", "))
 	}
 	fmt.Println()
-	for _, vrfKey := range vrfKeys {
-		allVRFKeys = append(allVRFKeys, vrfKey)
-	}
-	for _, nk := range newKeys {
-		allVRFKeys = append(allVRFKeys, nk)
-	}
+	allVRFKeys = append(allVRFKeys, vrfKeys...)
+	allVRFKeys = append(allVRFKeys, newKeys...)
 	return allVRFKeys
 }
 
@@ -526,11 +522,7 @@ func createETHKeysIfNeeded(client *clcmd.Shell, app *cli.App, output *bytes.Buff
 	}
 	output.Reset()
 	fmt.Println()
-	for _, ethKey := range ethKeys {
-		allETHKeysNode = append(allETHKeysNode, ethKey)
-	}
-	for _, nk := range newKeys {
-		allETHKeysNode = append(allETHKeysNode, nk)
-	}
+	allETHKeysNode = append(allETHKeysNode, ethKeys...)
+	allETHKeysNode = append(allETHKeysNode, newKeys...)
 	return allETHKeysNode
 }

--- a/core/scripts/functions/src/delete_jobs.go
+++ b/core/scripts/functions/src/delete_jobs.go
@@ -62,7 +62,7 @@ func (g *deleteJobs) Run(args []string) {
 		output.Reset()
 
 		fileFs := flag.NewFlagSet("test", flag.ExitOnError)
-		client.ListJobs(cli.NewContext(app, fileFs, nil))
+		err = client.ListJobs(cli.NewContext(app, fileFs, nil))
 		helpers.PanicErr(err)
 
 		var parsed []JobSpec
@@ -73,7 +73,8 @@ func (g *deleteJobs) Run(args []string) {
 			if jobSpec.BootstrapSpec.ContractID == *contractAddress || jobSpec.OffChainReporting2OracleSpec.ContractID == *contractAddress {
 				fmt.Println("Deleting job ID:", jobSpec.Id, "name:", jobSpec.Name)
 				set := flag.NewFlagSet("test", flag.ExitOnError)
-				set.Parse([]string{jobSpec.Id})
+				err = set.Parse([]string{jobSpec.Id})
+				helpers.PanicErr(err)
 				err = client.DeleteJob(cli.NewContext(app, set, nil))
 				helpers.PanicErr(err)
 			}

--- a/core/scripts/functions/src/fetching.go
+++ b/core/scripts/functions/src/fetching.go
@@ -24,11 +24,11 @@ type ocr2Bundle struct {
 }
 
 func mustFetchNodesKeys(chainID int64, nodes []*node) (nca []NodeKeys) {
-	for _, node := range nodes {
+	for _, n := range nodes {
 		output := &bytes.Buffer{}
-		client, app := newApp(node, output)
+		client, app := newApp(n, output)
 
-		fmt.Println("Logging in:", node.url)
+		fmt.Println("Logging in:", n.url)
 		loginFs := flag.NewFlagSet("test", flag.ContinueOnError)
 		loginFs.Bool("bypass-version-check", true, "")
 		loginCtx := cli.NewContext(app, loginFs, nil)
@@ -68,7 +68,7 @@ func mustFetchNodesKeys(chainID int64, nodes []*node) (nca []NodeKeys) {
 		if ocr2BundleIndex == -1 {
 			helpers.PanicErr(errors.New("node must have EVM OCR2 bundle"))
 		}
-		ocr2Bundle := ocr2Bundles[ocr2BundleIndex]
+		ocr2Bndl := ocr2Bundles[ocr2BundleIndex]
 		output.Reset()
 
 		err = client.ListCSAKeys(&cli.Context{
@@ -84,10 +84,10 @@ func mustFetchNodesKeys(chainID int64, nodes []*node) (nca []NodeKeys) {
 		nc := NodeKeys{
 			EthAddress:            ethAddress,
 			P2PPeerID:             peerID,
-			OCR2BundleID:          ocr2Bundle.ID,
-			OCR2ConfigPublicKey:   strings.TrimPrefix(ocr2Bundle.ConfigPublicKey, "ocr2cfg_evm_"),
-			OCR2OnchainPublicKey:  strings.TrimPrefix(ocr2Bundle.OnchainPublicKey, "ocr2on_evm_"),
-			OCR2OffchainPublicKey: strings.TrimPrefix(ocr2Bundle.OffchainPublicKey, "ocr2off_evm_"),
+			OCR2BundleID:          ocr2Bndl.ID,
+			OCR2ConfigPublicKey:   strings.TrimPrefix(ocr2Bndl.ConfigPublicKey, "ocr2cfg_evm_"),
+			OCR2OnchainPublicKey:  strings.TrimPrefix(ocr2Bndl.OnchainPublicKey, "ocr2on_evm_"),
+			OCR2OffchainPublicKey: strings.TrimPrefix(ocr2Bndl.OffchainPublicKey, "ocr2off_evm_"),
 			CSAPublicKey:          csaPubKey,
 		}
 

--- a/core/scripts/functions/src/generate_ocr2_config_cmd.go
+++ b/core/scripts/functions/src/generate_ocr2_config_cmd.go
@@ -134,8 +134,7 @@ func (g *generateOCR2Config) Run(args []string) {
 	keysFile := fs.String("keys", "", "a file containing nodes public keys")
 	configFile := fs.String("config", "", "a file containing JSON config")
 	chainID := fs.Int64("chainid", 80001, "chain id")
-	err := fs.Parse(args)
-	if err != nil || (*nodesFile == "" && *keysFile == "") || *configFile == "" || chainID == nil {
+	if err := fs.Parse(args); err != nil || (*nodesFile == "" && *keysFile == "") || *configFile == "" || chainID == nil {
 		fs.Usage()
 		os.Exit(1)
 	}

--- a/core/scripts/gateway/client/send_request.go
+++ b/core/scripts/gateway/client/send_request.go
@@ -52,7 +52,6 @@ func main() {
 
 	var s4SetPayload []byte
 	if *methodName == functions.MethodSecretsSet {
-		var err error
 		s4SetPayload, err = os.ReadFile(*s4SetPayloadFile)
 		if err != nil {
 			fmt.Println("error reading S4 payload file", err)
@@ -70,23 +69,21 @@ func main() {
 			Payload:    s4SetPayload,
 			Expiration: time.Now().UnixMilli() + *s4SetExpirationPeriod,
 		}
-		signature, err := envelope.Sign(key)
-		if err != nil {
-			fmt.Println("error signing S4 envelope", err)
+		signature, err2 := envelope.Sign(key)
+		if err2 != nil {
+			fmt.Println("error signing S4 envelope", err2)
 			return
 		}
 
-		s4SetPayload := functions.SecretsSetRequest{
+		payloadJSON, err2 = json.Marshal(functions.SecretsSetRequest{
 			SlotID:     envelope.SlotID,
 			Version:    envelope.Version,
 			Expiration: envelope.Expiration,
 			Payload:    s4SetPayload,
 			Signature:  signature,
-		}
-
-		payloadJSON, err = json.Marshal(s4SetPayload)
-		if err != nil {
-			fmt.Println("error marshaling S4 payload", err)
+		})
+		if err2 != nil {
+			fmt.Println("error marshaling S4 payload", err2)
 			return
 		}
 	}
@@ -122,27 +119,27 @@ func main() {
 	client := &http.Client{}
 
 	sendRequest := func() {
-		req, err := createRequest()
-		if err != nil {
-			fmt.Println("error creating a request", err)
+		req, err2 := createRequest()
+		if err2 != nil {
+			fmt.Println("error creating a request", err2)
 			return
 		}
 
-		resp, err := client.Do(req)
-		if err != nil {
-			fmt.Println("error sending a request", err)
+		resp, err2 := client.Do(req)
+		if err2 != nil {
+			fmt.Println("error sending a request", err2)
 			return
 		}
 		defer resp.Body.Close()
 
-		body, err := io.ReadAll(resp.Body)
-		if err != nil {
-			fmt.Println("error sending a request", err)
+		body, err2 := io.ReadAll(resp.Body)
+		if err2 != nil {
+			fmt.Println("error sending a request", err2)
 			return
 		}
 
 		var prettyJSON bytes.Buffer
-		if err := json.Indent(&prettyJSON, body, "", "  "); err != nil {
+		if err2 = json.Indent(&prettyJSON, body, "", "  "); err2 != nil {
 			fmt.Println(string(body))
 		} else {
 			fmt.Println(prettyJSON.String())

--- a/core/scripts/gateway/run_gateway.go
+++ b/core/scripts/gateway/run_gateway.go
@@ -56,8 +56,16 @@ func main() {
 	}
 
 	ctx, _ := signal.NotifyContext(context.Background(), os.Interrupt)
-	gw.Start(ctx)
+	err = gw.Start(ctx)
+	if err != nil {
+		fmt.Println("error staring gateway:", err)
+		return
+	}
 
 	<-ctx.Done()
-	gw.Close()
+	err = gw.Close()
+	if err != nil {
+		fmt.Println("error closing gateway:", err)
+		return
+	}
 }

--- a/core/scripts/ocr2vrf/setup_ocr2vrf.go
+++ b/core/scripts/ocr2vrf/setup_ocr2vrf.go
@@ -232,9 +232,7 @@ func setupOCR2VRFNodes(e helpers.Environment) {
 			transmitters[i+1] = f.String()
 		}
 	} else {
-		for _, t := range transmitters[1:] {
-			nodesToFund = append(nodesToFund, t)
-		}
+		nodesToFund = append(nodesToFund, transmitters[1:]...)
 	}
 
 	var payees []common.Address

--- a/core/scripts/ocr2vrf/util.go
+++ b/core/scripts/ocr2vrf/util.go
@@ -306,14 +306,6 @@ func findSubscriptionID(e helpers.Environment, vrfCoordinatorAddr string) *big.I
 	return subscriptionIterator.Event.SubId
 }
 
-func registerMigratableCoordinator(e helpers.Environment, coordinatorAddress, migratableCoordinatorAddress string) {
-	coordinator := newVRFCoordinator(common.HexToAddress(coordinatorAddress), e.Ec)
-
-	tx, err := coordinator.RegisterMigratableCoordinator(e.Owner, common.HexToAddress(migratableCoordinatorAddress))
-	helpers.PanicErr(err)
-	helpers.ConfirmTXMined(context.Background(), e.Ec, tx, e.ChainID)
-}
-
 func addConsumer(e helpers.Environment, vrfCoordinatorAddr, consumerAddr string, subId *big.Int) {
 	coordinator := newVRFCoordinator(common.HexToAddress(vrfCoordinatorAddr), e.Ec)
 
@@ -326,34 +318,6 @@ func setPayees(e helpers.Environment, vrfBeaconAddr string, transmitters, payees
 	beacon := newVRFBeacon(common.HexToAddress(vrfBeaconAddr), e.Ec)
 
 	tx, err := beacon.SetPayees(e.Owner, transmitters, payees)
-	helpers.PanicErr(err)
-	helpers.ConfirmTXMined(context.Background(), e.Ec, tx, e.ChainID)
-}
-
-func setBeaconBilling(e helpers.Environment, vrfBeaconAddr string, maximumGasPrice, reasonableGasPrice, observationPayment,
-	transmissionPayment, accountingGas uint64) {
-	beacon := newVRFBeacon(common.HexToAddress(vrfBeaconAddr), e.Ec)
-
-	tx, err := beacon.SetBilling(e.Owner, maximumGasPrice, reasonableGasPrice, observationPayment, transmissionPayment, big.NewInt(0).SetUint64(accountingGas))
-	helpers.PanicErr(err)
-	helpers.ConfirmTXMined(context.Background(), e.Ec, tx, e.ChainID)
-}
-
-func setCoordinatorBilling(e helpers.Environment, vrfCoordinatorAddr string, useReasonableGasPrice bool, unusedGasPenaltyPercent uint8,
-	stalenessSeconds, redeemableRequestGasOverhead, callbackRequestGasOverhead, premiumPercentage, reasonableGasPriceStalenessBlocks uint32,
-	fallbackWeiPerUnitLink *big.Int) {
-	coordinator := newVRFCoordinator(common.HexToAddress(vrfCoordinatorAddr), e.Ec)
-
-	tx, err := coordinator.SetCoordinatorConfig(e.Owner, vrf_coordinator.VRFBeaconTypesCoordinatorConfig{
-		UseReasonableGasPrice:             useReasonableGasPrice,
-		UnusedGasPenaltyPercent:           unusedGasPenaltyPercent,
-		StalenessSeconds:                  stalenessSeconds,
-		RedeemableRequestGasOverhead:      redeemableRequestGasOverhead,
-		CallbackRequestGasOverhead:        callbackRequestGasOverhead,
-		PremiumPercentage:                 uint8(premiumPercentage),
-		ReasonableGasPriceStalenessBlocks: reasonableGasPriceStalenessBlocks,
-		FallbackWeiPerUnitLink:            fallbackWeiPerUnitLink,
-	})
 	helpers.PanicErr(err)
 	helpers.ConfirmTXMined(context.Background(), e.Ec, tx, e.ChainID)
 }

--- a/core/scripts/vrfv2/testnet/main.go
+++ b/core/scripts/vrfv2/testnet/main.go
@@ -1088,9 +1088,8 @@ func main() {
 				return true
 			} else if strings.Contains(err.Error(), "execution reverted") {
 				return false
-			} else {
-				panic(err)
 			}
+			panic(err)
 		}
 
 		result := helpers.BinarySearch(assets.Ether(int64(*start*2)).ToInt(), big.NewInt(0), isWithdrawable)

--- a/core/scripts/vrfv2/testnet/v2scripts/super_scripts.go
+++ b/core/scripts/vrfv2/testnet/v2scripts/super_scripts.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink/core/scripts/common/vrf/util"
 
 	evmtypes "github.com/ethereum/go-ethereum/core/types"
+
 	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/link_token_interface"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/vrf_coordinator_v2"
@@ -297,7 +298,7 @@ func VRFV2DeployUniverse(
 		tx, err := vrfOwner.SetAuthorizedSenders(e.Owner, authorizedSendersSlice)
 		helpers.PanicErr(err)
 		helpers.ConfirmTXMined(context.Background(), e.Ec, tx, e.ChainID, "vrf owner set authorized senders")
-		fmt.Printf("\nTransfering ownership of coordinator: %v, VRF Owner %v\n", contractAddresses.CoordinatorAddress, vrfOwnerAddress.String())
+		fmt.Printf("\nTransferring ownership of coordinator: %v, VRF Owner %v\n", contractAddresses.CoordinatorAddress, vrfOwnerAddress.String())
 		tx, err = coordinator.TransferOwnership(e.Owner, vrfOwnerAddress)
 		helpers.PanicErr(err)
 		helpers.ConfirmTXMined(context.Background(), e.Ec, tx, e.ChainID, "transfer ownership to", vrfOwnerAddress.String())
@@ -320,9 +321,8 @@ func VRFV2DeployUniverse(
 		func() string {
 			if keys := nodesMap[model.VRFPrimaryNodeName].SendingKeys; len(keys) > 0 {
 				return keys[0].Address
-			} else {
-				return common.HexToAddress("0x0").String()
 			}
+			return common.HexToAddress("0x0").String()
 		}(),
 		contractAddresses.CoordinatorAddress,
 		contractAddresses.CoordinatorAddress,
@@ -347,9 +347,8 @@ func VRFV2DeployUniverse(
 		func() string {
 			if keys := nodesMap[model.VRFPrimaryNodeName].SendingKeys; len(keys) > 0 {
 				return keys[0].Address
-			} else {
-				return common.HexToAddress("0x0").String()
 			}
+			return common.HexToAddress("0x0").String()
 		}(),
 		contractAddresses.CoordinatorAddress,
 		contractAddresses.CoordinatorAddress,

--- a/core/scripts/vrfv2plus/testnet/main.go
+++ b/core/scripts/vrfv2plus/testnet/main.go
@@ -1046,9 +1046,8 @@ func main() {
 				return true
 			} else if strings.Contains(err.Error(), "execution reverted") {
 				return false
-			} else {
-				panic(err)
 			}
+			panic(err)
 		}
 
 		result := helpers.BinarySearch(assets.Ether(int64(*start*2)).ToInt(), big.NewInt(0), isWithdrawable)

--- a/core/scripts/vrfv2plus/testnet/proofs.go
+++ b/core/scripts/vrfv2plus/testnet/proofs.go
@@ -11,13 +11,14 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/shopspring/decimal"
+
 	helpers "github.com/smartcontractkit/chainlink/core/scripts/common"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/vrfkey"
 	"github.com/smartcontractkit/chainlink/v2/core/services/vrf/extraargs"
 	"github.com/smartcontractkit/chainlink/v2/core/services/vrf/proof"
 )
 
-var vrfProofTemplate string = `{
+var vrfProofTemplate = `{
 	pk: [
 		%s,
 		%s
@@ -42,7 +43,7 @@ var vrfProofTemplate string = `{
 }
 `
 
-var rcTemplate string = `{
+var rcTemplate = `{
 	blockNum: %d,
 	subId: %d,
 	callbackGasLimit: %d,

--- a/core/scripts/vrfv2plus/testnet/v2plusscripts/super_scripts.go
+++ b/core/scripts/vrfv2plus/testnet/v2plusscripts/super_scripts.go
@@ -202,9 +202,9 @@ func SmokeTestVRF(e helpers.Environment) {
 	var provingKeyRegisteredLog *vrf_coordinator_v2_5.VRFCoordinatorV25ProvingKeyRegistered
 	for _, log := range registerReceipt.Logs {
 		if log.Address == coordinatorAddress {
-			var err error
-			provingKeyRegisteredLog, err = coordinator.ParseProvingKeyRegistered(*log)
-			if err != nil {
+			var err2 error
+			provingKeyRegisteredLog, err2 = coordinator.ParseProvingKeyRegistered(*log)
+			if err2 != nil {
 				continue
 			}
 		}
@@ -214,9 +214,8 @@ func SmokeTestVRF(e helpers.Environment) {
 	}
 	if !bytes.Equal(provingKeyRegisteredLog.KeyHash[:], keyHash[:]) {
 		panic(fmt.Sprintf("unexpected key hash registered %s, expected %s", hexutil.Encode(provingKeyRegisteredLog.KeyHash[:]), hexutil.Encode(keyHash[:])))
-	} else {
-		fmt.Println("key hash registered:", hexutil.Encode(provingKeyRegisteredLog.KeyHash[:]))
 	}
+	fmt.Println("key hash registered:", hexutil.Encode(provingKeyRegisteredLog.KeyHash[:]))
 
 	fmt.Println("\nProving key registered, getting proving key hashes from deployed contract...")
 	_, _, provingKeyHashes, configErr := coordinator.GetRequestConfig(nil)
@@ -268,6 +267,7 @@ func SmokeTestVRF(e helpers.Environment) {
 	consumer, err := vrf_v2plus_sub_owner.NewVRFV2PlusExternalSubOwnerExample(consumerAddress, e.Ec)
 	helpers.PanicErr(err)
 	tx, err = consumer.RequestRandomWords(e.Owner, subID, 100_000, 3, 3, provingKeyRegisteredLog.KeyHash, false)
+	helpers.PanicErr(err)
 	receipt := helpers.ConfirmTXMined(context.Background(), e.Ec, tx, e.ChainID, "request random words from", consumerAddress.String())
 	fmt.Println("request blockhash:", receipt.BlockHash)
 
@@ -275,9 +275,9 @@ func SmokeTestVRF(e helpers.Environment) {
 	var rwrLog *vrf_coordinator_v2_5.VRFCoordinatorV25RandomWordsRequested
 	for _, log := range receipt.Logs {
 		if log.Address == coordinatorAddress {
-			var err error
-			rwrLog, err = coordinator.ParseRandomWordsRequested(*log)
-			if err != nil {
+			var err2 error
+			rwrLog, err2 = coordinator.ParseRandomWordsRequested(*log)
+			if err2 != nil {
 				continue
 			}
 		}
@@ -396,13 +396,13 @@ func SmokeTestBHS(e helpers.Environment) {
 	if seReceipt.Status != 1 {
 		fmt.Println("storeEarliest failed")
 		os.Exit(1)
-	} else {
-		fmt.Println("storeEarliest succeeded, checking BH is there")
-		bh, err := bhs.GetBlockhash(nil, seReceipt.BlockNumber.Sub(seReceipt.BlockNumber, big.NewInt(256)))
-		helpers.PanicErr(err)
-		fmt.Println("blockhash stored by storeEarliest:", hexutil.Encode(bh[:]))
-		anchorBlockNumber = seReceipt.BlockNumber
 	}
+	fmt.Println("storeEarliest succeeded, checking BH is there")
+	bh, err := bhs.GetBlockhash(nil, seReceipt.BlockNumber.Sub(seReceipt.BlockNumber, big.NewInt(256)))
+	helpers.PanicErr(err)
+	fmt.Println("blockhash stored by storeEarliest:", hexutil.Encode(bh[:]))
+	anchorBlockNumber = seReceipt.BlockNumber
+
 	if anchorBlockNumber == nil {
 		panic("no anchor block number")
 	}
@@ -417,12 +417,11 @@ func SmokeTestBHS(e helpers.Environment) {
 	if sReceipt.Status != 1 {
 		fmt.Println("store failed")
 		os.Exit(1)
-	} else {
-		fmt.Println("store succeeded, checking BH is there")
-		bh, err := bhs.GetBlockhash(nil, toStore)
-		helpers.PanicErr(err)
-		fmt.Println("blockhash stored by store:", hexutil.Encode(bh[:]))
 	}
+	fmt.Println("store succeeded, checking BH is there")
+	bh, err = bhs.GetBlockhash(nil, toStore)
+	helpers.PanicErr(err)
+	fmt.Println("blockhash stored by store:", hexutil.Encode(bh[:]))
 
 	fmt.Println("\nexecuting storeVerifyHeader")
 	headers, _, err := helpers.GetRlpHeaders(e, []*big.Int{anchorBlockNumber}, false)
@@ -435,12 +434,11 @@ func SmokeTestBHS(e helpers.Environment) {
 	if svhReceipt.Status != 1 {
 		fmt.Println("storeVerifyHeader failed")
 		os.Exit(1)
-	} else {
-		fmt.Println("storeVerifyHeader succeeded, checking BH is there")
-		bh, err := bhs.GetBlockhash(nil, toStore)
-		helpers.PanicErr(err)
-		fmt.Println("blockhash stored by storeVerifyHeader:", hexutil.Encode(bh[:]))
 	}
+	fmt.Println("storeVerifyHeader succeeded, checking BH is there")
+	bh, err = bhs.GetBlockhash(nil, toStore)
+	helpers.PanicErr(err)
+	fmt.Println("blockhash stored by storeVerifyHeader:", hexutil.Encode(bh[:]))
 }
 
 func sendTx(e helpers.Environment, to common.Address, data []byte) (*types.Receipt, common.Hash) {
@@ -501,7 +499,6 @@ func DeployUniverseViaCLI(e helpers.Environment) {
 	fallbackWeiPerUnitLink := decimal.RequireFromString(*fallbackWeiPerUnitLinkString).BigInt()
 	subscriptionBalanceJuels := decimal.RequireFromString(*subscriptionBalanceJuelsString).BigInt()
 	subscriptionBalanceNativeWei := decimal.RequireFromString(*subscriptionBalanceNativeWeiString).BigInt()
-	fundingAmount := decimal.RequireFromString(*nodeSendingKeyFundingAmount).BigInt()
 
 	feeConfig := vrf_coordinator_v2_5.VRFCoordinatorV25FeeConfig{
 		FulfillmentFlatFeeLinkPPM:   uint32(*flatFeeLinkPPM),
@@ -712,9 +709,8 @@ func VRFV2PlusDeployUniverse(e helpers.Environment,
 		func() string {
 			if keys := nodesMap[model.VRFPrimaryNodeName].SendingKeys; len(keys) > 0 {
 				return keys[0].Address
-			} else {
-				return common.HexToAddress("0x0").String()
 			}
+			return common.HexToAddress("0x0").String()
 		}(),
 		contractAddresses.CoordinatorAddress,
 		contractAddresses.CoordinatorAddress,
@@ -733,9 +729,8 @@ func VRFV2PlusDeployUniverse(e helpers.Environment,
 		func() string {
 			if keys := nodesMap[model.VRFPrimaryNodeName].SendingKeys; len(keys) > 0 {
 				return keys[0].Address
-			} else {
-				return common.HexToAddress("0x0").String()
 			}
+			return common.HexToAddress("0x0").String()
 		}(),
 		contractAddresses.CoordinatorAddress,
 		contractAddresses.CoordinatorAddress,

--- a/core/scripts/vrfv2plus/testnet/v2plusscripts/util.go
+++ b/core/scripts/vrfv2plus/testnet/v2plusscripts/util.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/hex"
 	"fmt"
-	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/vrf_v2plus_load_test_with_metrics"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
@@ -17,6 +16,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/blockhash_store"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/link_token_interface"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/vrf_coordinator_v2_5"
+	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/vrf_v2plus_load_test_with_metrics"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/vrf_v2plus_sub_owner"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/vrfv2plus_wrapper"
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/vrfv2plus_wrapper_consumer_example"


### PR DESCRIPTION
```
chaincli/command/keeper/upkeep.go:90:9: shadow: declaration of "err" shadows declaration at line 85 (govet)
			rec, err := readCsvFile(path)
			     ^
vrfv2/testnet/v2scripts/super_scripts.go:22: File is not `goimports`-ed with -local github.com/smartcontractkit/chainlink (goimports)
	evmtypes "github.com/ethereum/go-ethereum/core/types"
vrfv2/testnet/v2scripts/super_scripts.go:300:17: `Transfering` is a misspelling of `Transferring` (misspell)
		fmt.Printf("\nTransfering ownership of coordinator: %v, VRF Owner %v\n", contractAddresses.CoordinatorAddress, vrfOwnerAddress.String())
		              ^
vrfv2/testnet/v2scripts/super_scripts.go:323:11: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
			} else {
				return common.HexToAddress("0x0").String()
			}
vrfv2/testnet/v2scripts/super_scripts.go:350:11: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
			} else {
				return common.HexToAddress("0x0").String()
			}
common/avalanche.go:83:10: Error return value of `sha.Read` is not checked (errcheck)
	sha.Read(hashbuf)
	        ^
common/avalanche.go:262:12: Error return value of `rlp.Encode` is not checked (errcheck)
	rlp.Encode(sha, x)
	          ^
common/avalanche.go:263:10: Error return value of `sha.Read` is not checked (errcheck)
	sha.Read(h[:])
	        ^
common/helpers.go:464:13: var-declaration: should omit type *big.Int from declaration of var offset; it will be inferred from the right-hand side (revive)
	var offset *big.Int = big.NewInt(0)
	           ^
common/helpers.go:398:14: shadow: declaration of "err" shadows declaration at line 388 (govet)
		estimated, err := e.Ec.EstimateGas(context.Background(), ethereum.CallMsg{
		           ^
common/helpers.go:478:4: shadow: declaration of "err" shadows declaration at line 460 (govet)
			err := env.Jc.CallContext(context.Background(), &h, "eth_getBlockByNumber", hexutil.EncodeBig(nextBlockNum), false)
			^
vrfv2plus/testnet/v2plusscripts/util.go:7: File is not `goimports`-ed with -local github.com/smartcontractkit/chainlink (goimports)
	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/vrf_v2plus_load_test_with_metrics"
vrfv2plus/testnet/v2plusscripts/super_scripts.go:217:9: superfluous-else: if block ends with call to panic function, so drop this else and outdent its block (revive)
	} else {
		fmt.Println("key hash registered:", hexutil.Encode(provingKeyRegisteredLog.KeyHash[:]))
	}
vrfv2plus/testnet/v2plusscripts/super_scripts.go:399:9: superfluous-else: if block ends with call to os.Exit function, so drop this else and outdent its block (revive)
	} else {
		fmt.Println("storeEarliest succeeded, checking BH is there")
		bh, err := bhs.GetBlockhash(nil, seReceipt.BlockNumber.Sub(seReceipt.BlockNumber, big.NewInt(256)))
		helpers.PanicErr(err)
		fmt.Println("blockhash stored by storeEarliest:", hexutil.Encode(bh[:]))
		anchorBlockNumber = seReceipt.BlockNumber
	}
vrfv2plus/testnet/v2plusscripts/super_scripts.go:420:9: superfluous-else: if block ends with call to os.Exit function, so drop this else and outdent its block (revive)
	} else {
		fmt.Println("store succeeded, checking BH is there")
		bh, err := bhs.GetBlockhash(nil, toStore)
		helpers.PanicErr(err)
		fmt.Println("blockhash stored by store:", hexutil.Encode(bh[:]))
	}
vrfv2plus/testnet/v2plusscripts/super_scripts.go:438:9: superfluous-else: if block ends with call to os.Exit function, so drop this else and outdent its block (revive)
	} else {
		fmt.Println("storeVerifyHeader succeeded, checking BH is there")
		bh, err := bhs.GetBlockhash(nil, toStore)
		helpers.PanicErr(err)
		fmt.Println("blockhash stored by storeVerifyHeader:", hexutil.Encode(bh[:]))
	}
vrfv2plus/testnet/v2plusscripts/super_scripts.go:715:11: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
			} else {
				return common.HexToAddress("0x0").String()
			}
vrfv2plus/testnet/v2plusscripts/super_scripts.go:736:11: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary) (revive)
			} else {
				return common.HexToAddress("0x0").String()
			}
vrfv2plus/testnet/v2plusscripts/super_scripts.go:205:8: shadow: declaration of "err" shadows declaration at line 80 (govet)
			var err error
			    ^
vrfv2plus/testnet/v2plusscripts/super_scripts.go:278:8: shadow: declaration of "err" shadows declaration at line 80 (govet)
			var err error
			    ^
vrfv2plus/testnet/v2plusscripts/super_scripts.go:401:7: shadow: declaration of "err" shadows declaration at line 384 (govet)
		bh, err := bhs.GetBlockhash(nil, seReceipt.BlockNumber.Sub(seReceipt.BlockNumber, big.NewInt(256)))
		    ^
vrfv2plus/testnet/v2plusscripts/super_scripts.go:422:7: shadow: declaration of "err" shadows declaration at line 384 (govet)
		bh, err := bhs.GetBlockhash(nil, toStore)
		    ^
vrfv2plus/testnet/v2plusscripts/super_scripts.go:270:6: ineffectual assignment to err (ineffassign)
	tx, err = consumer.RequestRandomWords(e.Owner, subID, 100_000, 3, 3, provingKeyRegisteredLog.KeyHash, false)
	    ^
vrfv2plus/testnet/v2plusscripts/super_scripts.go:504:2: ineffectual assignment to fundingAmount (ineffassign)
	fundingAmount := decimal.RequireFromString(*nodeSendingKeyFundingAmount).BigInt()
	^
chaincli/handler/keeper.go:734:11: superfluous-else: if block ends with call to log.Fatalf function, so drop this else and outdent its block (revive)
			} else {
				log.Printf("upkeep privilege config is set for %s", id.String())
			}
chaincli/handler/keeper.go:781:18: func `(*Keeper).createKeeperJobOnExistingNode` is unused (unused)
func (k *Keeper) createKeeperJobOnExistingNode(urlStr, email, password, registryAddr, nodeAddr string) error {
                 ^
chaincli/handler/report.go:93:14: type assertion on error will fail on wrapped errors. Use errors.As to check for specific errors (errorlint)
		err, ok := txErr[i].(JsonError)
		           ^
chaincli/handler/report.go:278:9: S1025: the argument is already a string, there's no need to use fmt.Sprintf (gosimple)
	return fmt.Sprintf("%s", j)
	       ^
chaincli/handler/ocr2_config.go:57:24: S1004: should use bytes.Equal(tx.To()[:], addr[:]) instead (gosimple)
		if tx.To() != nil && bytes.Compare(tx.To()[:], addr[:]) == 0 {
		                     ^
chaincli/handler/handler.go:414:9: shadow: declaration of "err" shadows declaration at line 231 (govet)
			rdr, err := dockerClient.ContainerLogs(ctx, nodeContainerResp.ID, types.ContainerLogsOptions{
			     ^
chaincli/handler/keeper_launch.go:103:8: shadow: declaration of "err" shadows declaration at line 93 (govet)
			var err error
			    ^
chaincli/handler/keeper_launch.go:110:8: shadow: declaration of "err" shadows declaration at line 93 (govet)
			var err error
			    ^
chaincli/handler/keeper_launch.go:231:6: shadow: declaration of "err" shadows declaration at line 223 (govet)
		if err := k.waitTx(ctx, tx); err != nil {
		   ^
chaincli/handler/keeper_launch.go:239:6: shadow: declaration of "err" shadows declaration at line 223 (govet)
		if err := k.waitTx(ctx, tx); err != nil {
		   ^
chaincli/handler/keeper_launch.go:267:6: shadow: declaration of "err" shadows declaration at line 260 (govet)
		if err := k.waitTx(ctx, tx); err != nil {
		   ^
chaincli/handler/keeper_launch.go:275:6: shadow: declaration of "err" shadows declaration at line 260 (govet)
		if err := k.waitTx(ctx, tx); err != nil {
		   ^
chaincli/handler/keeper.go:742:9: ineffectual assignment to err (ineffassign)
			min, err := reg21.GetMinBalanceForUpkeep(nil, id)
			     ^
chaincli/handler/report.go:87:16: ineffectual assignment to err (ineffassign)
	txRes, txErr, err = getSimulationsForTxs(hdlr, simBatch)
	              ^
gateway/run_gateway.go:59:10: Error return value of `gw.Start` is not checked (errcheck)
	gw.Start(ctx)
	        ^
gateway/client/send_request.go:55:7: shadow: declaration of "err" shadows declaration at line 46 (govet)
		var err error
		    ^
gateway/client/send_request.go:73:14: shadow: declaration of "err" shadows declaration at line 46 (govet)
		signature, err := envelope.Sign(key)
		           ^
ocr2vrf/util.go:309:6: func `registerMigratableCoordinator` is unused (unused)
func registerMigratableCoordinator(e helpers.Environment, coordinatorAddress, migratableCoordinatorAddress string) {
     ^
ocr2vrf/util.go:333:6: func `setBeaconBilling` is unused (unused)
func setBeaconBilling(e helpers.Environment, vrfBeaconAddr string, maximumGasPrice, reasonableGasPrice, observationPayment,
     ^
ocr2vrf/util.go:342:6: func `setCoordinatorBilling` is unused (unused)
func setCoordinatorBilling(e helpers.Environment, vrfCoordinatorAddr string, useReasonableGasPrice bool, unusedGasPenaltyPercent uint8,
     ^
ocr2vrf/setup_ocr2vrf.go:235:3: S1011: should replace loop with `nodesToFund = append(nodesToFund, transmitters[1:]...)` (gosimple)
		for _, t := range transmitters[1:] {
		^
common/vrf/setup-envs/main.go:146:32: G601: Implicit memory aliasing in for loop. (gosec)
		client, app := connectToNode(&node.URL, output, node.CredsFile)
		                             ^
common/vrf/setup-envs/main.go:147:69: G601: Implicit memory aliasing in for loop. (gosec)
		ethKeys := createETHKeysIfNeeded(client, app, output, numEthKeys, &node.URL, maxGasPriceGwei)
		                                                                  ^
common/vrf/setup-envs/main.go:149:69: G601: Implicit memory aliasing in for loop. (gosec)
			vrfKeys := createVRFKeyIfNeeded(client, app, output, numVRFKeys, &node.URL)
			                                                                 ^
common/vrf/setup-envs/main.go:245:33: G601: Implicit memory aliasing in for loop. (gosec)
			client, app := connectToNode(&node.URL, output, node.CredsFile)
			                             ^
common/vrf/setup-envs/main.go:321:12: G306: Expect WriteFile permissions to be 0600 or less (gosec)
	if err := os.WriteFile("job-spec.toml", []byte(jobSpec), 0666); err != nil {
	          ^
common/vrf/setup-envs/main.go:335:12: G306: Expect WriteFile permissions to be 0600 or less (gosec)
	if err := os.WriteFile("vrf-key-password.txt", []byte("twochains"), 0666); err != nil {
	          ^
common/vrf/setup-envs/main.go:349:12: G306: Expect WriteFile permissions to be 0600 or less (gosec)
	if err := os.WriteFile("vrf-key-password.txt", []byte("twochains"), 0666); err != nil {
	          ^
common/vrf/setup-envs/main.go:53:2: var `infoEmoji` is unused (unused)
	infoEmoji      = "ℹ️"
	^
common/vrf/setup-envs/main.go:468:2: S1011: should replace loop with `allVRFKeys = append(allVRFKeys, vrfKeys...)` (gosimple)
	for _, vrfKey := range vrfKeys {
	^
common/vrf/setup-envs/main.go:471:2: S1011: should replace loop with `allVRFKeys = append(allVRFKeys, newKeys...)` (gosimple)
	for _, nk := range newKeys {
	^
common/vrf/setup-envs/main.go:529:2: S1011: should replace loop with `allETHKeysNode = append(allETHKeysNode, ethKeys...)` (gosimple)
	for _, ethKey := range ethKeys {
	^
common/vrf/setup-envs/main.go:532:2: S1011: should replace loop with `allETHKeysNode = append(allETHKeysNode, newKeys...)` (gosimple)
	for _, nk := range newKeys {
	^
vrfv2/testnet/main.go:1091:11: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
			} else {
				panic(err)
			}
functions/src/delete_jobs.go:65:18: Error return value of `client.ListJobs` is not checked (errcheck)
		client.ListJobs(cli.NewContext(app, fileFs, nil))
		               ^
functions/src/delete_jobs.go:76:14: Error return value of `set.Parse` is not checked (errcheck)
				set.Parse([]string{jobSpec.Id})
				         ^
functions/src/deploy_jobspecs_cmd.go:60:15: Error return value of `fileFs.Parse` is not checked (errcheck)
		fileFs.Parse([]string{tomlPath})
		            ^
functions/src/deploy_jobspecs_cmd.go:55:9: shadow: declaration of "err" shadows declaration at line 45 (govet)
		if _, err := os.Stat(tomlPath); err != nil {
		      ^
functions/src/fetching.go:71:3: shadow: declaration of "ocr2Bundle" shadows declaration at line 18 (govet)
		ocr2Bundle := ocr2Bundles[ocr2BundleIndex]
		^
functions/src/generate_ocr2_config_cmd.go:152:19: shadow: declaration of "err" shadows declaration at line 137 (govet)
		nodePublicKeys, err := json.MarshalIndent(nca, "", " ")
		                ^
functions/src/generate_ocr2_config_cmd.go:171:12: shadow: declaration of "err" shadows declaration at line 137 (govet)
		pkBytes, err := hex.DecodeString(n.OCR2OffchainPublicKey)
		         ^
functions/src/generate_ocr2_config_cmd.go:187:12: shadow: declaration of "err" shadows declaration at line 137 (govet)
		pkBytes, err := hex.DecodeString(n.OCR2ConfigPublicKey)
		         ^
common/vrf/model/model.go:24:2: field `jobSpec` is unused (unused)
	jobSpec                     string
	^
gateway/connector/run_connector.go:34:27: Error return value of `h.connector.SendToGateway` is not checked (errcheck)
	h.connector.SendToGateway(context.Background(), gatewayId, msg)
	                         ^
gateway/connector/run_connector.go:73:17: Error return value of `connector.Start` is not checked (errcheck)
	connector.Start(ctx)
	               ^
vrfv2plus/testnet/proofs.go:13: File is not `goimports`-ed with -local github.com/smartcontractkit/chainlink (goimports)
	"github.com/shopspring/decimal"
vrfv2plus/testnet/proofs.go:20:22: var-declaration: should omit type string from declaration of var vrfProofTemplate; it will be inferred from the right-hand side (revive)
var vrfProofTemplate string = `{
                     ^
vrfv2plus/testnet/proofs.go:45:16: var-declaration: should omit type string from declaration of var rcTemplate; it will be inferred from the right-hand side (revive)
var rcTemplate string = `{
               ^
vrfv2plus/testnet/main.go:1049:11: indent-error-flow: if block ends with a return statement, so drop this else and outdent its block (revive)
			} else {
				panic(err)
			}

```