### PR TITLE
add chainlink health command; make DB available for testscript client/server tests

### DIFF
--- a/core/cmd/app.go
+++ b/core/cmd/app.go
@@ -163,6 +163,17 @@ func NewApp(s *Shell) *cli.App {
 			Subcommands: initRemoteConfigSubCmds(s),
 		},
 		{
+			Name:   "health",
+			Usage:  "Prints a health report",
+			Action: s.Health,
+			Flags: []cli.Flag{
+				cli.BoolFlag{
+					Name:  "json, j",
+					Usage: "json output",
+				},
+			},
+		},
+		{
 			Name:        "jobs",
 			Usage:       "Commands for managing Jobs",
 			Subcommands: initJobsSubCmds(s),

--- a/core/cmd/shell_local.go
+++ b/core/cmd/shell_local.go
@@ -51,6 +51,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/web"
 	webPresenters "github.com/smartcontractkit/chainlink/v2/core/web/presenters"
+	"github.com/smartcontractkit/chainlink/v2/internal/testdb"
 )
 
 var ErrProfileTooLong = errors.New("requested profile duration too large")
@@ -257,13 +258,6 @@ func initLocalSubCmds(s *Shell, safe bool) []cli.Command {
 
 // ownerPermsMask are the file permission bits reserved for owner.
 const ownerPermsMask = os.FileMode(0o700)
-
-// PristineDBName is a clean copy of test DB with migrations.
-// Used by heavyweight.FullTestDB* functions.
-const (
-	PristineDBName   = "chainlink_test_pristine"
-	TestDBNamePrefix = "chainlink_test_"
-)
 
 // RunNode starts the Chainlink core.
 func (s *Shell) RunNode(c *cli.Context) error {
@@ -815,7 +809,7 @@ func dropDanglingTestDBs(lggr logger.Logger, db *sqlx.DB) (err error) {
 		}()
 	}
 	for _, dbname := range dbs {
-		if strings.HasPrefix(dbname, TestDBNamePrefix) && !strings.HasSuffix(dbname, "_pristine") {
+		if strings.HasPrefix(dbname, testdb.TestDBNamePrefix) && !strings.HasSuffix(dbname, "_pristine") {
 			ch <- dbname
 		}
 	}
@@ -1085,11 +1079,11 @@ func dropAndCreateDB(parsed url.URL) (err error) {
 }
 
 func dropAndCreatePristineDB(db *sqlx.DB, template string) (err error) {
-	_, err = db.Exec(fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, PristineDBName))
+	_, err = db.Exec(fmt.Sprintf(`DROP DATABASE IF EXISTS "%s"`, testdb.PristineDBName))
 	if err != nil {
 		return fmt.Errorf("unable to drop postgres database: %v", err)
 	}
-	_, err = db.Exec(fmt.Sprintf(`CREATE DATABASE "%s" WITH TEMPLATE "%s"`, PristineDBName, template))
+	_, err = db.Exec(fmt.Sprintf(`CREATE DATABASE "%s" WITH TEMPLATE "%s"`, testdb.PristineDBName, template))
 	if err != nil {
 		return fmt.Errorf("unable to create postgres database: %v", err)
 	}

--- a/core/cmd/shell_remote.go
+++ b/core/cmd/shell_remote.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/gin-gonic/gin"
 	"github.com/manyminds/api2go/jsonapi"
 	"github.com/mitchellh/go-homedir"
 	"github.com/pelletier/go-toml"
@@ -508,6 +509,23 @@ func (s *Shell) checkRemoteBuildCompatibility(lggr logger.Logger, onlyWarn bool,
 		}
 		return ErrIncompatible{CLIVersion: cliVersion, CLISha: cliSha, RemoteVersion: remoteVersion, RemoteSha: remoteSha}
 	}
+	return nil
+}
+
+func (s *Shell) Health(c *cli.Context) error {
+	mime := gin.MIMEPlain
+	if c.Bool("json") {
+		mime = gin.MIMEJSON
+	}
+	resp, err := s.HTTP.Get("/health", map[string]string{"Accept": mime})
+	if err != nil {
+		return s.errorOut(err)
+	}
+	b, err := parseResponse(resp)
+	if err != nil {
+		return s.errorOut(err)
+	}
+	fmt.Println(string(b))
 	return nil
 }
 

--- a/core/internal/cltest/heavyweight/orm.go
+++ b/core/internal/cltest/heavyweight/orm.go
@@ -1,13 +1,8 @@
+// Package heavyweight contains test helpers that are costly and you should
+// think **real carefully** before using in your tests.
 package heavyweight
 
-// The heavyweight package contains cltest items that are costly and you should
-// think **real carefully** before using in your tests.
-
 import (
-	"database/sql"
-	"errors"
-	"fmt"
-	"net/url"
 	"os"
 	"path"
 	"runtime"
@@ -20,41 +15,45 @@ import (
 
 	"github.com/jmoiron/sqlx"
 
-	"github.com/smartcontractkit/chainlink/v2/core/cmd"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	"github.com/smartcontractkit/chainlink/v2/core/store/dialects"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
+	"github.com/smartcontractkit/chainlink/v2/internal/testdb"
 )
 
 // FullTestDBV2 creates a pristine DB which runs in a separate database than the normal
 // unit tests, so you can do things like use other Postgres connection types with it.
 func FullTestDBV2(t testing.TB, overrideFn func(c *chainlink.Config, s *chainlink.Secrets)) (chainlink.GeneralConfig, *sqlx.DB) {
-	return prepareFullTestDBV2(t, false, true, overrideFn)
+	return KindFixtures.PrepareDB(t, overrideFn)
 }
 
 // FullTestDBNoFixturesV2 is the same as FullTestDB, but it does not load fixtures.
 func FullTestDBNoFixturesV2(t testing.TB, overrideFn func(c *chainlink.Config, s *chainlink.Secrets)) (chainlink.GeneralConfig, *sqlx.DB) {
-	return prepareFullTestDBV2(t, false, false, overrideFn)
+	return KindTemplate.PrepareDB(t, overrideFn)
 }
 
 // FullTestDBEmptyV2 creates an empty DB (without migrations).
 func FullTestDBEmptyV2(t testing.TB, overrideFn func(c *chainlink.Config, s *chainlink.Secrets)) (chainlink.GeneralConfig, *sqlx.DB) {
-	return prepareFullTestDBV2(t, true, false, overrideFn)
+	return KindEmpty.PrepareDB(t, overrideFn)
 }
 
 func generateName() string {
 	return strings.ReplaceAll(uuid.New().String(), "-", "")
 }
 
-func prepareFullTestDBV2(t testing.TB, empty bool, loadFixtures bool, overrideFn func(c *chainlink.Config, s *chainlink.Secrets)) (chainlink.GeneralConfig, *sqlx.DB) {
-	testutils.SkipShort(t, "FullTestDB")
+type Kind int
 
-	if empty && loadFixtures {
-		t.Fatal("could not load fixtures into an empty DB")
-	}
+const (
+	KindEmpty Kind = iota
+	KindTemplate
+	KindFixtures
+)
+
+func (c Kind) PrepareDB(t testing.TB, overrideFn func(c *chainlink.Config, s *chainlink.Secrets)) (chainlink.GeneralConfig, *sqlx.DB) {
+	testutils.SkipShort(t, "FullTestDB")
 
 	gcfg := configtest.NewGeneralConfigSimulated(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 		c.Database.Dialect = dialects.Postgres
@@ -64,7 +63,7 @@ func prepareFullTestDBV2(t testing.TB, empty bool, loadFixtures bool, overrideFn
 	})
 
 	require.NoError(t, os.MkdirAll(gcfg.RootDir(), 0700))
-	migrationTestDBURL, err := dropAndCreateThrowawayTestDB(gcfg.Database().URL(), generateName(), empty)
+	migrationTestDBURL, err := testdb.CreateOrReplace(gcfg.Database().URL(), generateName(), c != KindEmpty)
 	require.NoError(t, err)
 	db, err := pg.NewConnection(migrationTestDBURL, dialects.Postgres, gcfg.Database())
 	require.NoError(t, err)
@@ -81,7 +80,7 @@ func prepareFullTestDBV2(t testing.TB, empty bool, loadFixtures bool, overrideFn
 		}
 	})
 
-	if loadFixtures {
+	if c == KindFixtures {
 		_, filename, _, ok := runtime.Caller(1)
 		if !ok {
 			t.Fatal("could not get runtime.Caller(1)")
@@ -94,40 +93,4 @@ func prepareFullTestDBV2(t testing.TB, empty bool, loadFixtures bool, overrideFn
 	}
 
 	return gcfg, db
-}
-
-func dropAndCreateThrowawayTestDB(parsed url.URL, postfix string, empty bool) (string, error) {
-	if parsed.Path == "" {
-		return "", errors.New("path missing from database URL")
-	}
-
-	// Match the naming schema that our dangling DB cleanup methods expect
-	dbname := cmd.TestDBNamePrefix + postfix
-	if l := len(dbname); l > 63 {
-		return "", fmt.Errorf("dbname %v too long (%d), max is 63 bytes. Try a shorter postfix", dbname, l)
-	}
-	// Cannot drop test database if we are connected to it, so we must connect
-	// to a different one. 'postgres' should be present on all postgres installations
-	parsed.Path = "/postgres"
-	db, err := sql.Open(string(dialects.Postgres), parsed.String())
-	if err != nil {
-		return "", fmt.Errorf("In order to drop the test database, we need to connect to a separate database"+
-			" called 'postgres'. But we are unable to open 'postgres' database: %+v\n", err)
-	}
-	defer db.Close()
-
-	_, err = db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbname))
-	if err != nil {
-		return "", fmt.Errorf("unable to drop postgres migrations test database: %v", err)
-	}
-	if empty {
-		_, err = db.Exec(fmt.Sprintf("CREATE DATABASE %s", dbname))
-	} else {
-		_, err = db.Exec(fmt.Sprintf("CREATE DATABASE %s WITH TEMPLATE %s", dbname, cmd.PristineDBName))
-	}
-	if err != nil {
-		return "", fmt.Errorf("unable to create postgres test database with name '%s': %v", dbname, err)
-	}
-	parsed.Path = fmt.Sprintf("/%s", dbname)
-	return parsed.String(), nil
 }

--- a/core/web/health_controller.go
+++ b/core/web/health_controller.go
@@ -76,7 +76,7 @@ func (hc *HealthController) Health(c *gin.Context) {
 	healthy, errors := checker.IsHealthy()
 
 	if !healthy {
-		status = http.StatusServiceUnavailable
+		status = http.StatusMultiStatus
 	}
 
 	c.Status(status)

--- a/core/web/health_controller_test.go
+++ b/core/web/health_controller_test.go
@@ -62,7 +62,7 @@ func TestHealthController_Health_status(t *testing.T) {
 		{
 			name:   "not ready",
 			ready:  false,
-			status: http.StatusServiceUnavailable,
+			status: http.StatusMultiStatus,
 		},
 		{
 			name:   "ready",
@@ -118,7 +118,7 @@ func TestHealthController_Health_body(t *testing.T) {
 			client := app.NewHTTPClient(nil)
 			resp, cleanup := client.Get(tc.path, tc.headers)
 			t.Cleanup(cleanup)
-			assert.Equal(t, http.StatusServiceUnavailable, resp.StatusCode)
+			assert.Equal(t, http.StatusMultiStatus, resp.StatusCode)
 			body, err := io.ReadAll(resp.Body)
 			require.NoError(t, err)
 			if tc.expBody == bodyJSON {

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [dev]
 
+### Added
+
+- `chainlink health` CLI command and HTML `/health` endpoint, to provide human-readable views of the underlying JSON health data.
+
 ### Fixed
 
 - Fixed the encoding used for transactions when resending in batches

--- a/internal/testdb/testdb.go
+++ b/internal/testdb/testdb.go
@@ -1,0 +1,56 @@
+package testdb
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"net/url"
+
+	"github.com/smartcontractkit/chainlink/v2/core/store/dialects"
+)
+
+const (
+	// PristineDBName is a clean copy of test DB with migrations.
+	PristineDBName = "chainlink_test_pristine"
+	// TestDBNamePrefix is a common prefix that will be auto-removed by the dangling DB cleanup process.
+	TestDBNamePrefix = "chainlink_test_"
+)
+
+// CreateOrReplace creates a database named with a common prefix and the given suffix, and returns the URL.
+// If the database already exists, it will be dropped and re-created.
+// If withTemplate is true, the pristine DB will be used as a template.
+func CreateOrReplace(parsed url.URL, suffix string, withTemplate bool) (string, error) {
+	if parsed.Path == "" {
+		return "", errors.New("path missing from database URL")
+	}
+
+	// Match the naming schema that our dangling DB cleanup methods expect
+	dbname := TestDBNamePrefix + suffix
+	if l := len(dbname); l > 63 {
+		return "", fmt.Errorf("dbname %v too long (%d), max is 63 bytes. Try a shorter suffix", dbname, l)
+	}
+	// Cannot drop test database if we are connected to it, so we must connect
+	// to a different one. 'postgres' should be present on all postgres installations
+	parsed.Path = "/postgres"
+	db, err := sql.Open(string(dialects.Postgres), parsed.String())
+	if err != nil {
+		return "", fmt.Errorf("in order to drop the test database, we need to connect to a separate database"+
+			" called 'postgres'. But we are unable to open 'postgres' database: %+v\n", err)
+	}
+	defer db.Close()
+
+	_, err = db.Exec(fmt.Sprintf("DROP DATABASE IF EXISTS %s", dbname))
+	if err != nil {
+		return "", fmt.Errorf("unable to drop postgres migrations test database: %v", err)
+	}
+	if withTemplate {
+		_, err = db.Exec(fmt.Sprintf("CREATE DATABASE %s WITH TEMPLATE %s", dbname, PristineDBName))
+	} else {
+		_, err = db.Exec(fmt.Sprintf("CREATE DATABASE %s", dbname))
+	}
+	if err != nil {
+		return "", fmt.Errorf("unable to create postgres test database with name '%s': %v", dbname, err)
+	}
+	parsed.Path = fmt.Sprintf("/%s", dbname)
+	return parsed.String(), nil
+}

--- a/main_test.go
+++ b/main_test.go
@@ -1,15 +1,39 @@
 package main
 
 import (
+	"fmt"
+	"net/url"
 	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
 
+	"github.com/google/uuid"
+	"github.com/hashicorp/consul/sdk/freeport"
 	"github.com/rogpeppe/go-internal/testscript"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/v2/core"
+	"github.com/smartcontractkit/chainlink/v2/core/config/env"
 	"github.com/smartcontractkit/chainlink/v2/core/static"
+	"github.com/smartcontractkit/chainlink/v2/internal/testdb"
 	"github.com/smartcontractkit/chainlink/v2/tools/txtar"
+)
+
+// special files can be included to allocate additional test resources
+const (
+	// testDBName triggers initializing of a test database.
+	// The URL will be set as the value of an env var named by the file.
+	//
+	//	-- testdb.txt --
+	//	CL_DATABASE_URL
+	testDBName = "testdb.txt"
+	// testPortName triggers injection of a free port as the value of an env var named by the file.
+	//
+	//	-- testport.txt --
+	//	PORT
+	testPortName = "testport.txt"
 )
 
 func TestMain(m *testing.M) {
@@ -22,11 +46,14 @@ func TestScripts(t *testing.T) {
 	t.Parallel()
 
 	visitor := txtar.NewDirVisitor("testdata/scripts", txtar.Recurse, func(path string) error {
-		t.Run(path, func(t *testing.T) {
+		t.Run(strings.TrimPrefix(path, "testdata/scripts/"), func(t *testing.T) {
 			t.Parallel()
+
 			testscript.Run(t, testscript.Params{
-				Dir:   path,
-				Setup: commonEnv,
+				Dir:             path,
+				Setup:           commonEnv,
+				ContinueOnError: true,
+				//UpdateScripts:   true, // uncomment to update golden files
 			})
 		})
 		return nil
@@ -35,9 +62,62 @@ func TestScripts(t *testing.T) {
 	require.NoError(t, visitor.Walk())
 }
 
-func commonEnv(env *testscript.Env) error {
-	env.Setenv("HOME", "$WORK/home")
-	env.Setenv("VERSION", static.Version)
-	env.Setenv("COMMIT_SHA", static.Sha)
+func commonEnv(te *testscript.Env) error {
+	te.Setenv("HOME", "$WORK/home")
+	te.Setenv("VERSION", static.Version)
+	te.Setenv("COMMIT_SHA", static.Sha)
+
+	b, err := os.ReadFile(filepath.Join(te.WorkDir, testPortName))
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read file %s: %w", testPortName, err)
+	} else if err == nil {
+		envVarName := strings.TrimSpace(string(b))
+		te.T().Log("test port requested:", envVarName)
+
+		port, ret, err2 := takeFreePort()
+		if err2 != nil {
+			return err2
+		}
+		te.Defer(ret)
+
+		te.Setenv(envVarName, strconv.Itoa(port))
+	}
+
+	b, err = os.ReadFile(filepath.Join(te.WorkDir, testDBName))
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read file %s: %w", testDBName, err)
+	} else if err == nil {
+		envVarName := strings.TrimSpace(string(b))
+		te.T().Log("test database requested:", envVarName)
+
+		u2, err2 := initDB()
+		if err2 != nil {
+			return err2
+		}
+
+		te.Setenv(envVarName, u2)
+	}
 	return nil
+}
+
+func takeFreePort() (int, func(), error) {
+	ports, err := freeport.Take(1)
+	if err != nil {
+		return 0, nil, fmt.Errorf("failed to get free port: %w", err)
+	}
+	return ports[0], func() { freeport.Return(ports) }, nil
+}
+
+func initDB() (string, error) {
+	u, err := url.Parse(string(env.DatabaseURL.Get()))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse url: %w", err)
+	}
+
+	name := strings.ReplaceAll(uuid.NewString(), "-", "_") + "_test"
+	u2, err := testdb.CreateOrReplace(*u, name, true)
+	if err != nil {
+		return "", fmt.Errorf("failed to create DB: %w", err)
+	}
+	return u2, nil
 }

--- a/testdata/scripts/health/default.txtar
+++ b/testdata/scripts/health/default.txtar
@@ -1,0 +1,129 @@
+# start node
+exec sh -c 'eval "echo \"$(cat config.toml.tmpl)\" > config.toml"'
+exec chainlink node -c config.toml start -p password -a creds &
+
+# initialize client
+env NODEURL=http://localhost:$PORT
+exec curl --retry 10 --retry-max-time 60 --retry-connrefused $NODEURL
+exec chainlink --remote-node-url $NODEURL admin login -file creds --bypass-version-check
+
+exec chainlink --remote-node-url $NODEURL health
+cmp stdout out.txt
+
+exec chainlink --remote-node-url $NODEURL health -json
+cp stdout compact.json
+exec jq . compact.json
+cmp stdout out.json
+
+-- testdb.txt --
+CL_DATABASE_URL
+-- testport.txt --
+PORT
+
+-- password --
+T.tLHkcmwePT/p,]sYuntjwHKAsrhm#4eRs4LuKHwvHejWYAC2JP4M8HimwgmbaZ
+-- creds --
+notreal@fakeemail.ch
+fj293fbBnlQ!f9vNs
+
+-- config.toml.tmpl --
+[Webserver]
+HTTPPort = $PORT
+
+-- out.txt --
+-EventBroadcaster
+-JobSpawner
+-Mailbox.Monitor
+-Mercury.WSRPCPool
+-Mercury.WSRPCPool.CacheSet
+-PipelineORM
+-PipelineRunner
+-PromReporter
+-TelemetryManager
+
+-- out.json --
+{
+  "data": [
+    {
+      "type": "checks",
+      "id": "EventBroadcaster",
+      "attributes": {
+        "name": "EventBroadcaster",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "JobSpawner",
+      "attributes": {
+        "name": "JobSpawner",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "Mailbox.Monitor",
+      "attributes": {
+        "name": "Mailbox.Monitor",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "Mercury.WSRPCPool",
+      "attributes": {
+        "name": "Mercury.WSRPCPool",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "Mercury.WSRPCPool.CacheSet",
+      "attributes": {
+        "name": "Mercury.WSRPCPool.CacheSet",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "PipelineORM",
+      "attributes": {
+        "name": "PipelineORM",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "PipelineRunner",
+      "attributes": {
+        "name": "PipelineRunner",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "PromReporter",
+      "attributes": {
+        "name": "PromReporter",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "TelemetryManager",
+      "attributes": {
+        "name": "TelemetryManager",
+        "status": "passing",
+        "output": ""
+      }
+    }
+  ]
+}

--- a/testdata/scripts/health/help.txtar
+++ b/testdata/scripts/health/help.txtar
@@ -1,0 +1,13 @@
+exec chainlink health --help
+cmp stdout out.txt
+
+-- out.txt --
+NAME:
+   chainlink health - Prints a health report
+
+USAGE:
+   chainlink health [command options] [arguments...]
+
+OPTIONS:
+   --json, -j  json output
+   

--- a/testdata/scripts/health/multi-chain.txtar
+++ b/testdata/scripts/health/multi-chain.txtar
@@ -1,0 +1,309 @@
+# start node
+exec sh -c 'eval "echo \"$(cat config.toml.tmpl)\" > config.toml"'
+exec chainlink node -c config.toml start -p password -a creds &
+
+# initialize client
+env NODEURL=http://localhost:$PORT
+exec curl --retry 10 --retry-max-time 60 --retry-connrefused $NODEURL
+exec chainlink --remote-node-url $NODEURL admin login -file creds --bypass-version-check
+
+exec chainlink --remote-node-url $NODEURL health
+cmp stdout out.txt
+
+exec chainlink --remote-node-url $NODEURL health -json
+cp stdout compact.json
+exec jq . compact.json
+cmp stdout out.json
+
+-- testdb.txt --
+CL_DATABASE_URL
+-- testport.txt --
+PORT
+
+-- password --
+T.tLHkcmwePT/p,]sYuntjwHKAsrhm#4eRs4LuKHwvHejWYAC2JP4M8HimwgmbaZ
+-- creds --
+notreal@fakeemail.ch
+fj293fbBnlQ!f9vNs
+
+-- config.toml.tmpl --
+[Webserver]
+HTTPPort = $PORT
+
+[[Cosmos]]
+ChainID = 'Foo'
+
+[[Cosmos.Nodes]]
+Name = 'primary'
+TendermintURL = 'http://tender.mint'
+
+[[EVM]]
+ChainID = '1'
+
+[[EVM.Nodes]]
+Name = 'fake'
+WSURL = 'wss://foo.bar/ws'
+HTTPURL = 'https://foo.bar'
+
+[[Solana]]
+ChainID = 'Bar'
+
+[[Solana.Nodes]]
+Name = 'primary'
+URL = 'http://solana.web'
+
+[[Starknet]]
+ChainID = 'Baz'
+
+[[Starknet.Nodes]]
+Name = 'primary'
+URL = 'http://stark.node'
+
+-- out.txt --
+-Cosmos.Foo.Chain
+-Cosmos.Foo.Txm
+-EVM.1
+-EVM.1.BalanceMonitor
+-EVM.1.HeadBroadcaster
+-EVM.1.HeadTracker
+!EVM.1.HeadTracker.HeadListener
+	Listener is not connected
+-EVM.1.LogBroadcaster
+-EVM.1.Txm
+-EVM.1.Txm.BlockHistoryEstimator
+-EVM.1.Txm.Broadcaster
+-EVM.1.Txm.Confirmer
+-EVM.1.Txm.WrappedEvmEstimator
+-EventBroadcaster
+-JobSpawner
+-Mailbox.Monitor
+-Mercury.WSRPCPool
+-Mercury.WSRPCPool.CacheSet
+-PipelineORM
+-PipelineRunner
+-PromReporter
+-Solana.Bar
+-StarkNet.Baz
+-TelemetryManager
+
+-- out.json --
+{
+  "data": [
+    {
+      "type": "checks",
+      "id": "Cosmos.Foo.Chain",
+      "attributes": {
+        "name": "Cosmos.Foo.Chain",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "Cosmos.Foo.Txm",
+      "attributes": {
+        "name": "Cosmos.Foo.Txm",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "EVM.1",
+      "attributes": {
+        "name": "EVM.1",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "EVM.1.BalanceMonitor",
+      "attributes": {
+        "name": "EVM.1.BalanceMonitor",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "EVM.1.HeadBroadcaster",
+      "attributes": {
+        "name": "EVM.1.HeadBroadcaster",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "EVM.1.HeadTracker",
+      "attributes": {
+        "name": "EVM.1.HeadTracker",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "EVM.1.HeadTracker.HeadListener",
+      "attributes": {
+        "name": "EVM.1.HeadTracker.HeadListener",
+        "status": "failing",
+        "output": "Listener is not connected"
+      }
+    },
+    {
+      "type": "checks",
+      "id": "EVM.1.LogBroadcaster",
+      "attributes": {
+        "name": "EVM.1.LogBroadcaster",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "EVM.1.Txm",
+      "attributes": {
+        "name": "EVM.1.Txm",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "EVM.1.Txm.BlockHistoryEstimator",
+      "attributes": {
+        "name": "EVM.1.Txm.BlockHistoryEstimator",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "EVM.1.Txm.Broadcaster",
+      "attributes": {
+        "name": "EVM.1.Txm.Broadcaster",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "EVM.1.Txm.Confirmer",
+      "attributes": {
+        "name": "EVM.1.Txm.Confirmer",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "EVM.1.Txm.WrappedEvmEstimator",
+      "attributes": {
+        "name": "EVM.1.Txm.WrappedEvmEstimator",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "EventBroadcaster",
+      "attributes": {
+        "name": "EventBroadcaster",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "JobSpawner",
+      "attributes": {
+        "name": "JobSpawner",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "Mailbox.Monitor",
+      "attributes": {
+        "name": "Mailbox.Monitor",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "Mercury.WSRPCPool",
+      "attributes": {
+        "name": "Mercury.WSRPCPool",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "Mercury.WSRPCPool.CacheSet",
+      "attributes": {
+        "name": "Mercury.WSRPCPool.CacheSet",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "PipelineORM",
+      "attributes": {
+        "name": "PipelineORM",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "PipelineRunner",
+      "attributes": {
+        "name": "PipelineRunner",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "PromReporter",
+      "attributes": {
+        "name": "PromReporter",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "Solana.Bar",
+      "attributes": {
+        "name": "Solana.Bar",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "StarkNet.Baz",
+      "attributes": {
+        "name": "StarkNet.Baz",
+        "status": "passing",
+        "output": ""
+      }
+    },
+    {
+      "type": "checks",
+      "id": "TelemetryManager",
+      "attributes": {
+        "name": "TelemetryManager",
+        "status": "passing",
+        "output": ""
+      }
+    }
+  ]
+}

--- a/testdata/scripts/help.txtar
+++ b/testdata/scripts/help.txtar
@@ -17,6 +17,7 @@ COMMANDS:
    blocks          Commands for managing blocks
    bridges         Commands for Bridges communicating with External Adapters
    config          Commands for the node's configuration
+   health          Prints a health report
    jobs            Commands for managing Jobs
    keys            Commands for managing various types of keys used by the Chainlink node
    node, local     Commands for admin actions that must be run locally

--- a/testdata/scripts/node/db/migrate/db.txtar
+++ b/testdata/scripts/node/db/migrate/db.txtar
@@ -1,0 +1,6 @@
+exec chainlink node db migrate
+! stdout .
+stderr 'goose: no migrations to run. current version:'
+
+-- testdb.txt --
+CL_DATABASE_URL


### PR DESCRIPTION
Add a `chainlink health` command to print the health status in plaintext or json.

Also rigged up database usage for the testscript/txtar tests, so that we can test client/server interaction.

```
$ chainlink health
-Cosmos.Foo.Chain
-Cosmos.Foo.Txm
-EVM.1
-EVM.1.BalanceMonitor
-EVM.1.HeadBroadcaster
-EVM.1.HeadTracker
!EVM.1.HeadTracker.HeadListener
	Listener is not connected
-EVM.1.LogBroadcaster
-EVM.1.Txm
-EVM.1.Txm.BlockHistoryEstimator
-EVM.1.Txm.Broadcaster
-EVM.1.Txm.Confirmer
-EVM.1.Txm.WrappedEvmEstimator
-EventBroadcaster
-JobSpawner
-Mailbox.Monitor
-Mercury.WSRPCPool
-Mercury.WSRPCPool.CacheSet
-PipelineORM
-PipelineRunner
-PromReporter
-Solana.Bar
-StarkNet.Baz
-TelemetryManager
```