### PR TITLE
VRF-815: run all VRF V2 tests in CI and run against PoS instead of PoW

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -407,12 +407,13 @@ jobs:
             pyroscope_env: ci-smoke-vrf-evm-simulated
           - name: vrfv2
             nodes: 1
-            run: -run TestVRFv2MultipleSendingKeys
-            file: vrfv2            
+            file: vrfv2
+            client: geth
             os: ubuntu-latest
             pyroscope_env: ci-smoke-vrf2-evm-simulated
           - name: vrfv2plus
             nodes: 1
+            client: geth
             os: ubuntu-latest
             pyroscope_env: ci-smoke-vrf2plus-evm-simulated                       
           - name: forwarder_ocr

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -407,7 +407,6 @@ jobs:
             pyroscope_env: ci-smoke-vrf-evm-simulated
           - name: vrfv2
             nodes: 1
-            file: vrfv2
             client: geth
             os: ubuntu-latest
             pyroscope_env: ci-smoke-vrf2-evm-simulated

--- a/integration-tests/smoke/vrfv2_test.go
+++ b/integration-tests/smoke/vrfv2_test.go
@@ -119,13 +119,16 @@ func TestVRFv2MultipleSendingKeys(t *testing.T) {
 	t.Parallel()
 	l := logging.GetTestLogger(t)
 
+	network, err := actions.EthereumNetworkConfigFromEnvOrDefault(l)
+	require.NoError(t, err, "Error building ethereum network config")
+
 	var vrfv2Config vrfv2_config.VRFV2Config
-	err := envconfig.Process("VRFV2", &vrfv2Config)
+	err = envconfig.Process("VRFV2", &vrfv2Config)
 	require.NoError(t, err)
 
 	env, err := test_env.NewCLTestEnvBuilder().
 		WithTestInstance(t).
-		WithGeth().
+		WithPrivateEthereumNetwork(network).
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(vrfv2Config.ChainlinkNodeFunding)).
 		WithStandardCleanup().

--- a/integration-tests/smoke/vrfv2plus_test.go
+++ b/integration-tests/smoke/vrfv2plus_test.go
@@ -611,13 +611,16 @@ func TestVRFv2PlusMultipleSendingKeys(t *testing.T) {
 	t.Parallel()
 	l := logging.GetTestLogger(t)
 
+	network, err := actions.EthereumNetworkConfigFromEnvOrDefault(l)
+	require.NoError(t, err, "Error building ethereum network config")
+
 	var vrfv2PlusConfig vrfv2plus_config.VRFV2PlusConfig
-	err := envconfig.Process("VRFV2PLUS", &vrfv2PlusConfig)
+	err = envconfig.Process("VRFV2PLUS", &vrfv2PlusConfig)
 	require.NoError(t, err)
 
 	env, err := test_env.NewCLTestEnvBuilder().
 		WithTestInstance(t).
-		WithGeth().
+		WithPrivateEthereumNetwork(network).
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(vrfv2PlusConfig.ChainlinkNodeFunding)).
 		WithStandardCleanup().
@@ -702,13 +705,17 @@ func TestVRFv2PlusMultipleSendingKeys(t *testing.T) {
 func TestVRFv2PlusMigration(t *testing.T) {
 	t.Parallel()
 	l := logging.GetTestLogger(t)
+
+	network, err := actions.EthereumNetworkConfigFromEnvOrDefault(l)
+	require.NoError(t, err, "Error building ethereum network config")
+
 	var vrfv2PlusConfig vrfv2plus_config.VRFV2PlusConfig
-	err := envconfig.Process("VRFV2PLUS", &vrfv2PlusConfig)
+	err = envconfig.Process("VRFV2PLUS", &vrfv2PlusConfig)
 	require.NoError(t, err)
 
 	env, err := test_env.NewCLTestEnvBuilder().
 		WithTestInstance(t).
-		WithGeth().
+		WithPrivateEthereumNetwork(network).
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(vrfv2PlusConfig.ChainlinkNodeFunding)).
 		WithStandardCleanup().


### PR DESCRIPTION
started Slack [discussion](https://chainlink-core.slack.com/archives/C0361N0LJ6A/p1702991657277289) on whether its reasonable to use Pos instead of Pow considering how long it takes for tests to complete with PoS


UPDATE - decided to go with PoW for now since it has much faster test execution