### PR TITLE
Simple filter DSL PoC

### DIFF
--- a/core/chains/evm/logpoller/dsl.go
+++ b/core/chains/evm/logpoller/dsl.go
@@ -82,7 +82,7 @@ func AppendedNewFilter(root *AndFilter, other ...QFilter) *AndFilter {
 }
 
 func (f *AndFilter) accept(visitor Visitor) {
-	visitor.visitAndFilter(*f)
+	visitor.VisitAndFilter(*f)
 }
 
 type EvmChainIdFilter struct {
@@ -94,7 +94,7 @@ func NewEvmChainIdFilter(chainId *big.Int) *EvmChainIdFilter {
 }
 
 func (f *EvmChainIdFilter) accept(visitor Visitor) {
-	visitor.visitEvmChainIdFilter(*f)
+	visitor.VisitEvmChainIdFilter(*f)
 }
 
 type AddressFilter struct {
@@ -106,7 +106,7 @@ func NewAddressFilter(address ...common.Address) *AddressFilter {
 }
 
 func (f *AddressFilter) accept(visitor Visitor) {
-	visitor.visitAddressFilter(*f)
+	visitor.VisitAddressFilter(*f)
 }
 
 type EventSigFilter struct {
@@ -118,7 +118,7 @@ func NewEventSigFilter(eventSig ...common.Hash) *EventSigFilter {
 }
 
 func (f *EventSigFilter) accept(visitor Visitor) {
-	visitor.visitEventSigFilter(*f)
+	visitor.VisitEventSigFilter(*f)
 }
 
 type DataWordFilter struct {
@@ -140,7 +140,7 @@ func NewDataWordLteFilter(index int, value common.Hash) *DataWordFilter {
 }
 
 func (f *DataWordFilter) accept(visitor Visitor) {
-	visitor.visitDataWordFilter(*f)
+	visitor.VisitDataWordFilter(*f)
 }
 
 type TopicFilter struct {
@@ -161,7 +161,7 @@ func NewTopicRangeFilter(index int, topicValueMin, topicValueMax common.Hash) *A
 }
 
 func (f *TopicFilter) accept(visitor Visitor) {
-	visitor.visitTopicFilter(*f)
+	visitor.VisitTopicFilter(*f)
 }
 
 type TopicsFilter struct {
@@ -174,7 +174,7 @@ func NewTopicsFilter(index int, values ...common.Hash) *TopicsFilter {
 }
 
 func (f *TopicsFilter) accept(visitor Visitor) {
-	visitor.visitTopicsFilter(*f)
+	visitor.VisitTopicsFilter(*f)
 }
 
 type ConfirmationFilter struct {
@@ -186,11 +186,11 @@ func NewConfirmationFilter(confs Confirmations) *ConfirmationFilter {
 }
 
 func (f *ConfirmationFilter) accept(visitor Visitor) {
-	visitor.visitConfirmationFilter(*f)
+	visitor.VisitConfirmationFilter(*f)
 }
 
-func NewBlockFilter(block int64, operator ComparisonOperator) *NamedFilter {
-	return NewNamedFilter("block_number", operator, block)
+func NewBlockFilter(block int64, operator ComparisonOperator) *BlockFilter {
+	return &BlockFilter{operator, block}
 }
 
 func NewBlockRangeFilter(start, end int64) *AndFilter {
@@ -200,40 +200,54 @@ func NewBlockRangeFilter(start, end int64) *AndFilter {
 	)
 }
 
-func NewBlockTimestampAfterFilter(after time.Time) *NamedFilter {
+type BlockFilter struct {
+	operator ComparisonOperator
+	block    int64
+}
+
+func (f *BlockFilter) accept(visitor Visitor) {
+	visitor.VisitBlockFilter(*f)
+}
+
+func NewBlockTimestampAfterFilter(after time.Time) *BlockTimestampFilter {
 	return NewBlockTimeStampFilter(after, Gt)
 }
 
-func NewBlockTimeStampFilter(timestamp time.Time, operator ComparisonOperator) *NamedFilter {
-	return NewNamedFilter("block_timestamp", operator, timestamp)
+func NewBlockTimeStampFilter(timestamp time.Time, operator ComparisonOperator) *BlockTimestampFilter {
+	return &BlockTimestampFilter{operator, timestamp}
 }
 
-func NewTxHashFilter(txHash common.Hash) *NamedFilter {
-	return NewNamedFilter("tx_hash", Eq, txHash)
-}
-
-type NamedFilter struct {
-	fieldName string
+type BlockTimestampFilter struct {
 	operator  ComparisonOperator
-	value     interface{}
+	timestamp time.Time
 }
 
-func NewNamedFilter(fieldName string, operator ComparisonOperator, value interface{}) *NamedFilter {
-	return &NamedFilter{fieldName: fieldName, operator: operator, value: value}
+func (f *BlockTimestampFilter) accept(visitor Visitor) {
+	visitor.VisitBlockTimestampFilter(*f)
 }
 
-func (f *NamedFilter) accept(visitor Visitor) {
-	visitor.visitNamedFilter(*f)
+func NewTxHashFilter(txHash common.Hash) *TxHashFilter {
+	return &TxHashFilter{txHash}
+}
+
+type TxHashFilter struct {
+	txHash common.Hash
+}
+
+func (f *TxHashFilter) accept(visitor Visitor) {
+	visitor.VisitTxHashFilter(*f)
 }
 
 type Visitor interface {
-	visitAndFilter(node AndFilter)
-	visitEvmChainIdFilter(node EvmChainIdFilter)
-	visitAddressFilter(node AddressFilter)
-	visitEventSigFilter(node EventSigFilter)
-	visitDataWordFilter(node DataWordFilter)
-	visitConfirmationFilter(node ConfirmationFilter)
-	visitTopicFilter(node TopicFilter)
-	visitTopicsFilter(node TopicsFilter)
-	visitNamedFilter(node NamedFilter)
+	VisitAndFilter(node AndFilter)
+	VisitEvmChainIdFilter(node EvmChainIdFilter)
+	VisitAddressFilter(node AddressFilter)
+	VisitEventSigFilter(node EventSigFilter)
+	VisitDataWordFilter(node DataWordFilter)
+	VisitTopicFilter(node TopicFilter)
+	VisitTopicsFilter(node TopicsFilter)
+	VisitBlockFilter(node BlockFilter)
+	VisitConfirmationFilter(node ConfirmationFilter)
+	VisitBlockTimestampFilter(node BlockTimestampFilter)
+	VisitTxHashFilter(node TxHashFilter)
 }

--- a/core/chains/evm/logpoller/dsl.go
+++ b/core/chains/evm/logpoller/dsl.go
@@ -1,0 +1,239 @@
+package logpoller
+
+import (
+	"math/big"
+	"time"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	ubig "github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils/big"
+)
+
+type ComparisonOperator int
+
+const (
+	Eq ComparisonOperator = iota
+	Neq
+	Gt
+	Lt
+	Gte
+	Lte
+)
+
+type SortDirection int
+
+const (
+	Asc SortDirection = iota
+	Desc
+)
+
+var (
+	DefaultSortAndLimit = SortAndLimit{
+		sortBy: []SortBy{
+			{field: "block_number", dir: Asc},
+			{field: "log_index", dir: Asc},
+		},
+		limit: 0,
+	}
+)
+
+type SortAndLimit struct {
+	sortBy []SortBy
+	limit  int
+}
+
+type SortBy struct {
+	field string
+	dir   SortDirection
+}
+
+func NewSortAndLimit(limit int, sortBy ...SortBy) SortAndLimit {
+	return SortAndLimit{sortBy: sortBy, limit: limit}
+}
+
+func NewSortBy(field string, dir SortDirection) SortBy {
+	return SortBy{field: field, dir: dir}
+}
+
+type QFilter interface {
+	accept(visitor Visitor)
+}
+
+type AndFilter struct {
+	filters []QFilter
+}
+
+func NewAndFilter(filters ...QFilter) *AndFilter {
+	return &AndFilter{filters: filters}
+}
+
+func NewBasicAndFilter(address common.Address, eventSig common.Hash, filters ...QFilter) *AndFilter {
+	allFilters := make([]QFilter, 0, len(filters)+2)
+	allFilters = append(allFilters, NewAddressFilter(address), NewEventSigFilter(eventSig))
+	allFilters = append(allFilters, filters...)
+	return NewAndFilter(allFilters...)
+}
+
+func AppendedNewFilter(root *AndFilter, other ...QFilter) *AndFilter {
+	filters := make([]QFilter, 0, len(root.filters)+len(other))
+	filters = append(filters, root.filters...)
+	filters = append(filters, other...)
+	return NewAndFilter(filters...)
+}
+
+func (f *AndFilter) accept(visitor Visitor) {
+	visitor.visitAndFilter(*f)
+}
+
+type EvmChainIdFilter struct {
+	chainId *ubig.Big
+}
+
+func NewEvmChainIdFilter(chainId *big.Int) *EvmChainIdFilter {
+	return &EvmChainIdFilter{chainId: ubig.New(chainId)}
+}
+
+func (f *EvmChainIdFilter) accept(visitor Visitor) {
+	visitor.visitEvmChainIdFilter(*f)
+}
+
+type AddressFilter struct {
+	address []common.Address
+}
+
+func NewAddressFilter(address ...common.Address) *AddressFilter {
+	return &AddressFilter{address: address}
+}
+
+func (f *AddressFilter) accept(visitor Visitor) {
+	visitor.visitAddressFilter(*f)
+}
+
+type EventSigFilter struct {
+	eventSig []common.Hash
+}
+
+func NewEventSigFilter(eventSig ...common.Hash) *EventSigFilter {
+	return &EventSigFilter{eventSig: eventSig}
+}
+
+func (f *EventSigFilter) accept(visitor Visitor) {
+	visitor.visitEventSigFilter(*f)
+}
+
+type DataWordFilter struct {
+	index    int
+	operator ComparisonOperator
+	value    common.Hash
+}
+
+func NewDataWordFilter(index int, operator ComparisonOperator, value common.Hash) *DataWordFilter {
+	return &DataWordFilter{index: index, operator: operator, value: value}
+}
+
+func NewDataWordGteFilter(index int, value common.Hash) *DataWordFilter {
+	return NewDataWordFilter(index, Gte, value)
+}
+
+func NewDataWordLteFilter(index int, value common.Hash) *DataWordFilter {
+	return NewDataWordFilter(index, Lte, value)
+}
+
+func (f *DataWordFilter) accept(visitor Visitor) {
+	visitor.visitDataWordFilter(*f)
+}
+
+type TopicFilter struct {
+	index    int
+	operator ComparisonOperator
+	value    common.Hash
+}
+
+func NewTopicFilter(index int, operator ComparisonOperator, value common.Hash) *TopicFilter {
+	return &TopicFilter{index: index, operator: operator, value: value}
+}
+
+func NewTopicRangeFilter(index int, topicValueMin, topicValueMax common.Hash) *AndFilter {
+	return NewAndFilter(
+		NewTopicFilter(index, Gte, topicValueMin),
+		NewTopicFilter(index, Lte, topicValueMax),
+	)
+}
+
+func (f *TopicFilter) accept(visitor Visitor) {
+	visitor.visitTopicFilter(*f)
+}
+
+type TopicsFilter struct {
+	index  int
+	values []common.Hash
+}
+
+func NewTopicsFilter(index int, values ...common.Hash) *TopicsFilter {
+	return &TopicsFilter{index: index, values: values}
+}
+
+func (f *TopicsFilter) accept(visitor Visitor) {
+	visitor.visitTopicsFilter(*f)
+}
+
+type ConfirmationFilter struct {
+	confs Confirmations
+}
+
+func NewConfirmationFilter(confs Confirmations) *ConfirmationFilter {
+	return &ConfirmationFilter{confs: confs}
+}
+
+func (f *ConfirmationFilter) accept(visitor Visitor) {
+	visitor.visitConfirmationFilter(*f)
+}
+
+func NewBlockFilter(block int64, operator ComparisonOperator) *NamedFilter {
+	return NewNamedFilter("block_number", operator, block)
+}
+
+func NewBlockRangeFilter(start, end int64) *AndFilter {
+	return NewAndFilter(
+		NewBlockFilter(start, Gte),
+		NewBlockFilter(end, Lte),
+	)
+}
+
+func NewBlockTimestampAfterFilter(after time.Time) *NamedFilter {
+	return NewBlockTimeStampFilter(after, Gt)
+}
+
+func NewBlockTimeStampFilter(timestamp time.Time, operator ComparisonOperator) *NamedFilter {
+	return NewNamedFilter("block_timestamp", operator, timestamp)
+}
+
+func NewTxHashFilter(txHash common.Hash) *NamedFilter {
+	return NewNamedFilter("tx_hash", Eq, txHash)
+}
+
+type NamedFilter struct {
+	fieldName string
+	operator  ComparisonOperator
+	value     interface{}
+}
+
+func NewNamedFilter(fieldName string, operator ComparisonOperator, value interface{}) *NamedFilter {
+	return &NamedFilter{fieldName: fieldName, operator: operator, value: value}
+}
+
+func (f *NamedFilter) accept(visitor Visitor) {
+	visitor.visitNamedFilter(*f)
+}
+
+type Visitor interface {
+	visitAndFilter(node AndFilter)
+	visitEvmChainIdFilter(node EvmChainIdFilter)
+	visitAddressFilter(node AddressFilter)
+	visitEventSigFilter(node EventSigFilter)
+	visitDataWordFilter(node DataWordFilter)
+	visitConfirmationFilter(node ConfirmationFilter)
+	visitTopicFilter(node TopicFilter)
+	visitTopicsFilter(node TopicsFilter)
+	visitNamedFilter(node NamedFilter)
+}

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -1189,6 +1189,10 @@ func (lp *logPoller) IndexedLogsWithSigsExcluding(address common.Address, eventS
 	return lp.orm.SelectIndexedLogsWithSigsExcluding(eventSigA, eventSigB, topicIndex, address, fromBlock, toBlock, confs, qopts...)
 }
 
+func (lp *logPoller) SelectFilteredLogs(queryName string, filter QFilter, limit SortAndLimit, qopts ...pg.QOpt) ([]Log, error) {
+	return lp.orm.SelectFilteredLogs(filter, limit, qopts...)
+}
+
 func EvmWord(i uint64) common.Hash {
 	var b = make([]byte, 8)
 	binary.BigEndian.PutUint64(b, i)

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -324,8 +324,7 @@ func (o *DbORM) SelectLogs(start, end int64, address common.Address, eventSig co
 	filter := NewBasicAndFilter(
 		address,
 		eventSig,
-		NewBlockFilter(start, Gte),
-		NewBlockFilter(end, Lte),
+		NewBlockRangeFilter(start, end),
 	)
 	return o.SelectFilteredLogs(filter, DefaultSortAndLimit, qopts...)
 }

--- a/core/chains/evm/logpoller/orm.go
+++ b/core/chains/evm/logpoller/orm.go
@@ -12,6 +12,7 @@ import (
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+
 	ubig "github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils/big"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 )
@@ -52,6 +53,7 @@ type ORM interface {
 	SelectLogsDataWordRange(address common.Address, eventSig common.Hash, wordIndex int, wordValueMin, wordValueMax common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error)
 	SelectLogsDataWordGreaterThan(address common.Address, eventSig common.Hash, wordIndex int, wordValueMin common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error)
 	SelectLogsDataWordBetween(address common.Address, eventSig common.Hash, wordIndexMin int, wordIndexMax int, wordValue common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error)
+	SelectFilteredLogs(filter QFilter, limit SortAndLimit, qopts ...pg.QOpt) ([]Log, error)
 }
 
 type DbORM struct {
@@ -73,14 +75,12 @@ func NewORM(chainID *big.Int, db *sqlx.DB, lggr logger.Logger, cfg pg.QConfig) *
 
 // InsertBlock is idempotent to support replays.
 func (o *DbORM) InsertBlock(blockHash common.Hash, blockNumber int64, blockTimestamp time.Time, finalizedBlock int64, qopts ...pg.QOpt) error {
-	args, err := newQueryArgs(o.chainID).
-		withCustomHashArg("block_hash", blockHash).
-		withCustomArg("block_number", blockNumber).
-		withCustomArg("block_timestamp", blockTimestamp).
-		withCustomArg("finalized_block_number", finalizedBlock).
-		toArgs()
-	if err != nil {
-		return err
+	args := map[string]interface{}{
+		"evm_chain_id":           ubig.New(o.chainID),
+		"block_hash":             blockHash.Bytes(),
+		"block_number":           blockNumber,
+		"block_timestamp":        blockTimestamp,
+		"finalized_block_number": finalizedBlock,
 	}
 	return o.q.WithOpts(qopts...).ExecQNamed(`
 			INSERT INTO evm.log_poller_blocks 
@@ -94,14 +94,12 @@ func (o *DbORM) InsertBlock(blockHash common.Hash, blockNumber int64, blockTimes
 // Each address/event pair must have a unique job id, so it may be removed when the job is deleted.
 // If a second job tries to overwrite the same pair, this should fail.
 func (o *DbORM) InsertFilter(filter Filter, qopts ...pg.QOpt) (err error) {
-	args, err := newQueryArgs(o.chainID).
-		withCustomArg("name", filter.Name).
-		withCustomArg("retention", filter.Retention).
-		withAddressArray(filter.Addresses).
-		withEventSigArray(filter.EventSigs).
-		toArgs()
-	if err != nil {
-		return err
+	args := map[string]interface{}{
+		"evm_chain_id":    ubig.New(o.chainID),
+		"name":            filter.Name,
+		"retention":       filter.Retention,
+		"address_array":   concatBytes(filter.Addresses),
+		"event_sig_array": concatBytes(filter.EventSigs),
 	}
 	// '::' has to be escaped in the query string
 	// https://github.com/jmoiron/sqlx/issues/91, https://github.com/jmoiron/sqlx/issues/428
@@ -165,27 +163,6 @@ func (o *DbORM) SelectLatestBlock(qopts ...pg.QOpt) (*LogPollerBlock, error) {
 		return nil, err
 	}
 	return &b, nil
-}
-
-func (o *DbORM) SelectLatestLogByEventSigWithConfs(eventSig common.Hash, address common.Address, confs Confirmations, qopts ...pg.QOpt) (*Log, error) {
-	args, err := newQueryArgsForEvent(o.chainID, address, eventSig).
-		withConfs(confs).
-		toArgs()
-	if err != nil {
-		return nil, err
-	}
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs
-			WHERE evm_chain_id = :evm_chain_id
-			AND event_sig = :event_sig
-			AND address = :address
-			AND block_number <= %s
-			ORDER BY (block_number, log_index) DESC LIMIT 1`, nestedBlockNumberQuery(confs))
-	var l Log
-	if err := o.q.WithOpts(qopts...).GetNamed(query, &l, args); err != nil {
-		return nil, err
-	}
-	return &l, nil
 }
 
 // DeleteBlocksBefore delete all blocks before and including end.
@@ -335,77 +312,59 @@ func (o *DbORM) SelectLogsByBlockRange(start, end int64) ([]Log, error) {
 	return logs, nil
 }
 
-// SelectLogsByBlockRangeFilter finds the logs in a given block range.
+// SelectLogs finds the logs in a given block range.
 func (o *DbORM) SelectLogs(start, end int64, address common.Address, eventSig common.Hash, qopts ...pg.QOpt) ([]Log, error) {
-	args, err := newQueryArgsForEvent(o.chainID, address, eventSig).
-		withStartBlock(start).
-		withEndBlock(end).
-		toArgs()
-	if err != nil {
-		return nil, err
-	}
-	var logs []Log
-	err = o.q.WithOpts(qopts...).SelectNamed(&logs, `
-		SELECT * FROM evm.logs 
-			WHERE evm_chain_id = :evm_chain_id 
-			AND address = :address
-			AND event_sig = :event_sig  
-			AND block_number >= :start_block 
-			AND block_number <= :end_block
-			ORDER BY (block_number, log_index)`, args)
-	if err != nil {
-		return nil, err
-	}
-	return logs, nil
+	//SELECT * FROM evm.logs
+	//			WHERE evm_chain_id = :evm_chain_id
+	//			AND address = :address
+	//			AND event_sig = :event_sig
+	//			AND block_number >= :start_block
+	//			AND block_number <= :end_block
+	//			ORDER BY (block_number, log_index)
+	filter := NewBasicAndFilter(
+		address,
+		eventSig,
+		NewBlockFilter(start, Gte),
+		NewBlockFilter(end, Lte),
+	)
+	return o.SelectFilteredLogs(filter, DefaultSortAndLimit, qopts...)
 }
 
 // SelectLogsCreatedAfter finds logs created after some timestamp.
 func (o *DbORM) SelectLogsCreatedAfter(address common.Address, eventSig common.Hash, after time.Time, confs Confirmations, qopts ...pg.QOpt) ([]Log, error) {
-	args, err := newQueryArgsForEvent(o.chainID, address, eventSig).
-		withBlockTimestampAfter(after).
-		withConfs(confs).
-		toArgs()
-	if err != nil {
-		return nil, err
-	}
-
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs 
-				WHERE evm_chain_id = :evm_chain_id
-				AND address = :address
-				AND event_sig = :event_sig
-				AND block_timestamp > :block_timestamp_after
-				AND block_number <= %s
-				ORDER BY (block_number, log_index)`, nestedBlockNumberQuery(confs))
-
-	var logs []Log
-	if err = o.q.WithOpts(qopts...).SelectNamed(&logs, query, args); err != nil {
-		return nil, err
-	}
-	return logs, nil
+	//SELECT * FROM evm.logs
+	//				WHERE evm_chain_id = :evm_chain_id
+	//				AND address = :address
+	//				AND event_sig = :event_sig
+	//				AND block_timestamp > :block_timestamp_after
+	//				AND block_number <= %s
+	//				ORDER BY (block_number, log_index)
+	filter := NewBasicAndFilter(
+		address,
+		eventSig,
+		NewBlockTimestampAfterFilter(after),
+		NewConfirmationFilter(confs),
+	)
+	return o.SelectFilteredLogs(filter, DefaultSortAndLimit, qopts...)
 }
 
-// SelectLogsWithSigsByBlockRangeFilter finds the logs in the given block range with the given event signatures
+// SelectLogsWithSigs finds the logs in the given block range with the given event signatures
 // emitted from the given address.
-func (o *DbORM) SelectLogsWithSigs(start, end int64, address common.Address, eventSigs []common.Hash, qopts ...pg.QOpt) (logs []Log, err error) {
-	args, err := newQueryArgs(o.chainID).
-		withAddress(address).
-		withEventSigArray(eventSigs).
-		withStartBlock(start).
-		withEndBlock(end).
-		toArgs()
-	if err != nil {
-		return nil, err
-	}
+func (o *DbORM) SelectLogsWithSigs(start, end int64, address common.Address, eventSigs []common.Hash, qopts ...pg.QOpt) ([]Log, error) {
+	//SELECT * FROM evm.logs
+	//				WHERE evm_chain_id = :evm_chain_id
+	//				AND address = :address
+	//				AND event_sig = ANY(:event_sig_array)
+	//				AND block_number BETWEEN :start_block AND :end_block
+	//				ORDER BY (block_number, log_index)
+	filter := NewAndFilter(
+		NewAddressFilter(address),
+		NewEventSigFilter(eventSigs...),
+		NewBlockFilter(start, Gte),
+		NewBlockFilter(end, Lte),
+	)
 
-	q := o.q.WithOpts(qopts...)
-	err = q.SelectNamed(&logs, `
-			SELECT * FROM evm.logs
-				WHERE evm_chain_id = :evm_chain_id
-				AND address = :address
-				AND event_sig = ANY(:event_sig_array)
-				AND block_number BETWEEN :start_block AND :end_block
-				ORDER BY (block_number, log_index)`, args)
+	logs, err := o.SelectFilteredLogs(filter, DefaultSortAndLimit, qopts...)
 	if errors.Is(err, sql.ErrNoRows) {
 		return nil, nil
 	}
@@ -413,15 +372,14 @@ func (o *DbORM) SelectLogsWithSigs(start, end int64, address common.Address, eve
 }
 
 func (o *DbORM) GetBlocksRange(start int64, end int64, qopts ...pg.QOpt) ([]LogPollerBlock, error) {
-	args, err := newQueryArgs(o.chainID).
-		withStartBlock(start).
-		withEndBlock(end).
-		toArgs()
-	if err != nil {
-		return nil, err
+	args := map[string]interface{}{
+		"evm_chain_id": ubig.New(o.chainID),
+		"start_block":  start,
+		"end_block":    end,
 	}
+
 	var blocks []LogPollerBlock
-	err = o.q.WithOpts(qopts...).SelectNamed(&blocks, `
+	err := o.q.WithOpts(qopts...).SelectNamed(&blocks, `
         SELECT * FROM evm.log_poller_blocks 
 			WHERE block_number >= :start_block 
 			AND block_number <= :end_block
@@ -433,28 +391,66 @@ func (o *DbORM) GetBlocksRange(start int64, end int64, qopts ...pg.QOpt) ([]LogP
 	return blocks, nil
 }
 
+func (o *DbORM) SelectLatestLogByEventSigWithConfs(eventSig common.Hash, address common.Address, confs Confirmations, qopts ...pg.QOpt) (*Log, error) {
+	//SELECT * FROM evm.logs
+	//			WHERE evm_chain_id = :evm_chain_id
+	//			AND event_sig = :event_sig
+	//			AND address = :address
+	//			AND block_number <= %s
+	//			ORDER BY (block_number, log_index) DESC
+	//			LIMIT 1`
+	filter := NewBasicAndFilter(
+		address,
+		eventSig,
+		NewConfirmationFilter(confs),
+	)
+
+	sort := NewSortAndLimit(
+		1,
+		NewSortBy("block_number", Desc),
+		NewSortBy("log_index", Desc),
+	)
+
+	logs, err := o.SelectFilteredLogs(filter, sort, qopts...)
+	if err != nil {
+		return nil, err
+	}
+	if len(logs) == 0 {
+		return nil, sql.ErrNoRows
+	}
+	return &logs[0], nil
+}
+
 // SelectLatestLogEventSigsAddrsWithConfs finds the latest log by (address, event) combination that matches a list of Addresses and list of events
 func (o *DbORM) SelectLatestLogEventSigsAddrsWithConfs(fromBlock int64, addresses []common.Address, eventSigs []common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error) {
-	args, err := newQueryArgs(o.chainID).
-		withAddressArray(addresses).
-		withEventSigArray(eventSigs).
-		withStartBlock(fromBlock).
-		withConfs(confs).
-		toArgs()
+	//	SELECT * FROM evm.logs WHERE (block_number, address, event_sig) IN (
+	//			SELECT MAX(block_number), address, event_sig FROM evm.logs
+	//				WHERE evm_chain_id = :evm_chain_id
+	//				AND event_sig = ANY(:event_sig_array)
+	//				AND address = ANY(:address_array)
+	//				AND block_number > :start_block
+	//				AND block_number <= %s
+	//			GROUP BY event_sig, address
+	//		)
+	//		ORDER BY block_number ASC
+	filter := NewAndFilter(
+		NewEventSigFilter(eventSigs...),
+		NewAddressFilter(addresses...),
+		NewBlockFilter(fromBlock, Gt),
+		NewConfirmationFilter(confs),
+	)
+	sqlFilter, args, err := NewPgParser(o.chainID).Parse(filter)
 	if err != nil {
 		return nil, err
 	}
 	query := fmt.Sprintf(`
 		SELECT * FROM evm.logs WHERE (block_number, address, event_sig) IN (
 			SELECT MAX(block_number), address, event_sig FROM evm.logs 
-				WHERE evm_chain_id = :evm_chain_id 
-				AND event_sig = ANY(:event_sig_array) 
-				AND address = ANY(:address_array) 
-				AND block_number > :start_block 
-				AND block_number <= %s
+				WHERE %s
 			GROUP BY event_sig, address
 		)
-		ORDER BY block_number ASC`, nestedBlockNumberQuery(confs))
+		ORDER BY block_number ASC`, sqlFilter)
+
 	var logs []Log
 	if err := o.q.WithOpts(qopts...).SelectNamed(&logs, query, args); err != nil {
 		return nil, errors.Wrap(err, "failed to execute query")
@@ -462,24 +458,27 @@ func (o *DbORM) SelectLatestLogEventSigsAddrsWithConfs(fromBlock int64, addresse
 	return logs, nil
 }
 
-// SelectLatestBlockNumberEventSigsAddrsWithConfs finds the latest block number that matches a list of Addresses and list of events. It returns 0 if there is no matching block
+// SelectLatestBlockByEventSigsAddrsWithConfs finds the latest block number that matches a list of Addresses and list of events. It returns 0 if there is no matching block
 func (o *DbORM) SelectLatestBlockByEventSigsAddrsWithConfs(fromBlock int64, eventSigs []common.Hash, addresses []common.Address, confs Confirmations, qopts ...pg.QOpt) (int64, error) {
-	args, err := newQueryArgs(o.chainID).
-		withEventSigArray(eventSigs).
-		withAddressArray(addresses).
-		withStartBlock(fromBlock).
-		withConfs(confs).
-		toArgs()
+	//SELECT COALESCE(MAX(block_number), 0) FROM evm.logs
+	//			WHERE evm_chain_id = :evm_chain_id
+	//			AND event_sig = ANY(:event_sig_array)
+	//			AND address = ANY(:address_array)
+	//			AND block_number > :start_block
+	//			AND block_number <= %s
+	filter := NewAndFilter(
+		NewEventSigFilter(eventSigs...),
+		NewAddressFilter(addresses...),
+		NewBlockFilter(fromBlock, Gt),
+		NewConfirmationFilter(confs),
+	)
+
+	sqlFilter, args, err := NewPgParser(o.chainID).Parse(filter)
 	if err != nil {
 		return 0, err
 	}
-	query := fmt.Sprintf(`
-		SELECT COALESCE(MAX(block_number), 0) FROM evm.logs
-			WHERE evm_chain_id = :evm_chain_id 
-			AND event_sig = ANY(:event_sig_array) 
-			AND address = ANY(:address_array) 
-			AND block_number > :start_block 
-			AND block_number <= %s`, nestedBlockNumberQuery(confs))
+
+	query := fmt.Sprintf(`SELECT COALESCE(MAX(block_number), 0) FROM evm.logs WHERE %s`, sqlFilter)
 	var blockNumber int64
 	if err := o.q.WithOpts(qopts...).GetNamed(query, &blockNumber, args); err != nil {
 		return 0, err
@@ -488,230 +487,164 @@ func (o *DbORM) SelectLatestBlockByEventSigsAddrsWithConfs(fromBlock int64, even
 }
 
 func (o *DbORM) SelectLogsDataWordRange(address common.Address, eventSig common.Hash, wordIndex int, wordValueMin, wordValueMax common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error) {
-	args, err := newQueryArgsForEvent(o.chainID, address, eventSig).
-		withWordIndex(wordIndex).
-		withWordValueMin(wordValueMin).
-		withWordValueMax(wordValueMax).
-		withConfs(confs).
-		toArgs()
-	if err != nil {
-		return nil, err
-	}
-	query := fmt.Sprintf(`SELECT * FROM evm.logs 
-			WHERE evm_chain_id = :evm_chain_id
-			AND address = :address 
-			AND event_sig = :event_sig
-			AND substring(data from 32*:word_index+1 for 32) >= :word_value_min
-			AND substring(data from 32*:word_index+1 for 32) <= :word_value_max
-			AND block_number <= %s
-			ORDER BY (block_number, log_index)`, nestedBlockNumberQuery(confs))
-	var logs []Log
-	if err := o.q.WithOpts(qopts...).SelectNamed(&logs, query, args); err != nil {
-		return nil, err
-	}
-	return logs, nil
+	// SELECT * FROM evm.logs
+	//			WHERE evm_chain_id = :evm_chain_id
+	//			AND address = :address
+	//			AND event_sig = :event_sig
+	//			AND substring(data from 32*:word_index+1 for 32) >= :word_value_min
+	//			AND substring(data from 32*:word_index+1 for 32) <= :word_value_max
+	//			AND block_number <= %s
+	//			ORDER BY (block_number, log_index)
+	filter := NewBasicAndFilter(
+		address,
+		eventSig,
+		NewDataWordGteFilter(wordIndex, wordValueMin),
+		NewDataWordLteFilter(wordIndex, wordValueMax),
+		NewConfirmationFilter(confs),
+	)
+	return o.SelectFilteredLogs(filter, DefaultSortAndLimit, qopts...)
 }
 
 func (o *DbORM) SelectLogsDataWordGreaterThan(address common.Address, eventSig common.Hash, wordIndex int, wordValueMin common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error) {
-	args, err := newQueryArgsForEvent(o.chainID, address, eventSig).
-		withWordIndex(wordIndex).
-		withWordValueMin(wordValueMin).
-		withConfs(confs).
-		toArgs()
-	if err != nil {
-		return nil, err
-	}
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs 
-			WHERE evm_chain_id = :evm_chain_id
-			AND address = :address
-			AND event_sig = :event_sig
-			AND substring(data from 32*:word_index+1 for 32) >= :word_value_min
-			AND block_number <= %s
-			ORDER BY (block_number, log_index)`, nestedBlockNumberQuery(confs))
-	var logs []Log
-	if err = o.q.WithOpts(qopts...).SelectNamed(&logs, query, args); err != nil {
-		return nil, err
-	}
-	return logs, nil
+	//		SELECT * FROM evm.logs
+	//			WHERE evm_chain_id = :evm_chain_id
+	//			AND address = :address
+	//			AND event_sig = :event_sig
+	//			AND substring(data from 32*:word_index+1 for 32) >= :word_value_min
+	//			AND block_number <= %s
+	//			ORDER BY (block_number, log_index)
+	filter := NewBasicAndFilter(
+		address,
+		eventSig,
+		NewDataWordGteFilter(wordIndex, wordValueMin),
+		NewConfirmationFilter(confs),
+	)
+	return o.SelectFilteredLogs(filter, DefaultSortAndLimit, qopts...)
 }
 
 func (o *DbORM) SelectLogsDataWordBetween(address common.Address, eventSig common.Hash, wordIndexMin int, wordIndexMax int, wordValue common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error) {
-	args, err := newQueryArgsForEvent(o.chainID, address, eventSig).
-		withWordIndexMin(wordIndexMin).
-		withWordIndexMax(wordIndexMax).
-		withWordValue(wordValue).
-		withConfs(confs).
-		toArgs()
-	if err != nil {
-		return nil, err
-	}
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs 
-			WHERE evm_chain_id = :evm_chain_id
-			AND address = :address
-			AND event_sig = :event_sig
-			AND substring(data from 32*:word_index_min+1 for 32) <= :word_value
-			AND substring(data from 32*:word_index_max+1 for 32) >= :word_value
-			AND block_number <= %s
-			ORDER BY (block_number, log_index)`, nestedBlockNumberQuery(confs))
-	var logs []Log
-	if err = o.q.WithOpts(qopts...).SelectNamed(&logs, query, args); err != nil {
-		return nil, err
-	}
-	return logs, nil
+	// 	SELECT * FROM evm.logs
+	//			WHERE evm_chain_id = :evm_chain_id
+	//			AND address = :address
+	//			AND event_sig = :event_sig
+	//			AND substring(data from 32*:word_index_min+1 for 32) <= :word_value
+	//			AND substring(data from 32*:word_index_max+1 for 32) >= :word_value
+	//			AND block_number <= %s
+	//			ORDER BY (block_number, log_index)
+	filter := NewBasicAndFilter(
+		address,
+		eventSig,
+		NewDataWordLteFilter(wordIndexMin, wordValue),
+		NewDataWordGteFilter(wordIndexMax, wordValue),
+		NewConfirmationFilter(confs),
+	)
+	return o.SelectFilteredLogs(filter, DefaultSortAndLimit, qopts...)
 }
 
 func (o *DbORM) SelectIndexedLogsTopicGreaterThan(address common.Address, eventSig common.Hash, topicIndex int, topicValueMin common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error) {
-	args, err := newQueryArgsForEvent(o.chainID, address, eventSig).
-		withTopicIndex(topicIndex).
-		withTopicValueMin(topicValueMin).
-		withConfs(confs).
-		toArgs()
-	if err != nil {
-		return nil, err
-	}
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs
-			WHERE evm_chain_id = :evm_chain_id
-			AND address = :address 
-			AND event_sig = :event_sig
-			AND topics[:topic_index] >= :topic_value_min
-			AND block_number <= %s
-			ORDER BY (block_number, log_index)`, nestedBlockNumberQuery(confs))
-	var logs []Log
-	if err = o.q.WithOpts(qopts...).SelectNamed(&logs, query, args); err != nil {
-		return nil, err
-	}
-	return logs, nil
+	//SELECT * FROM evm.logs
+	//			WHERE evm_chain_id = :evm_chain_id
+	//			AND address = :address
+	//			AND event_sig = :event_sig
+	//			AND topics[:topic_index] >= :topic_value_min
+	//			AND block_number <= %s
+	//			ORDER BY (block_number, log_index)
+	filter := NewBasicAndFilter(
+		address,
+		eventSig,
+		NewTopicFilter(topicIndex, Gte, topicValueMin),
+		NewConfirmationFilter(confs),
+	)
+	return o.SelectFilteredLogs(filter, DefaultSortAndLimit, qopts...)
 }
 
 func (o *DbORM) SelectIndexedLogsTopicRange(address common.Address, eventSig common.Hash, topicIndex int, topicValueMin, topicValueMax common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error) {
-	args, err := newQueryArgsForEvent(o.chainID, address, eventSig).
-		withTopicIndex(topicIndex).
-		withTopicValueMin(topicValueMin).
-		withTopicValueMax(topicValueMax).
-		withConfs(confs).
-		toArgs()
-	if err != nil {
-		return nil, err
-	}
-	query := fmt.Sprintf(`
-			SELECT * FROM evm.logs 
-				WHERE evm_chain_id = :evm_chain_id
-				AND address = :address
-				AND event_sig = :event_sig
-				AND topics[:topic_index] >= :topic_value_min
-				AND topics[:topic_index] <= :topic_value_max
-				AND block_number <= %s
-			ORDER BY (evm.logs.block_number, evm.logs.log_index)`, nestedBlockNumberQuery(confs))
-	var logs []Log
-	if err := o.q.WithOpts(qopts...).SelectNamed(&logs, query, args); err != nil {
-		return nil, err
-	}
-	return logs, nil
+	//			SELECT * FROM evm.logs
+	//				WHERE evm_chain_id = :evm_chain_id
+	//				AND address = :address
+	//				AND event_sig = :event_sig
+	//				AND topics[:topic_index] >= :topic_value_min
+	//				AND topics[:topic_index] <= :topic_value_max
+	//				AND block_number <= %s
+	//			ORDER BY (evm.logs.block_number, evm.logs.log_index)
+	filter := NewBasicAndFilter(
+		address,
+		eventSig,
+		NewTopicRangeFilter(topicIndex, topicValueMin, topicValueMax),
+		NewConfirmationFilter(confs),
+	)
+	return o.SelectFilteredLogs(filter, DefaultSortAndLimit, qopts...)
 }
 
 func (o *DbORM) SelectIndexedLogs(address common.Address, eventSig common.Hash, topicIndex int, topicValues []common.Hash, confs Confirmations, qopts ...pg.QOpt) ([]Log, error) {
-	args, err := newQueryArgsForEvent(o.chainID, address, eventSig).
-		withTopicIndex(topicIndex).
-		withTopicValues(topicValues).
-		withConfs(confs).
-		toArgs()
-	if err != nil {
-		return nil, err
-	}
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs 
-			WHERE evm_chain_id = :evm_chain_id
-			AND address = :address
-			AND event_sig = :event_sig
-			AND topics[:topic_index] = ANY(:topic_values)
-			AND block_number <= %s
-			ORDER BY (block_number, log_index)`, nestedBlockNumberQuery(confs))
-	var logs []Log
-	if err := o.q.WithOpts(qopts...).SelectNamed(&logs, query, args); err != nil {
-		return nil, err
-	}
-	return logs, nil
+	//		SELECT * FROM evm.logs
+	//			WHERE evm_chain_id = :evm_chain_id
+	//			AND address = :address
+	//			AND event_sig = :event_sig
+	//			AND topics[:topic_index] = ANY(:topic_values)
+	//			AND block_number <= %s
+	//			ORDER BY (block_number, log_index)
+	filter := NewBasicAndFilter(
+		address,
+		eventSig,
+		NewTopicsFilter(topicIndex, topicValues...),
+		NewConfirmationFilter(confs),
+	)
+	return o.SelectFilteredLogs(filter, DefaultSortAndLimit, qopts...)
 }
 
-// SelectIndexedLogsByBlockRangeFilter finds the indexed logs in a given block range.
+// SelectIndexedLogsByBlockRange finds the indexed logs in a given block range.
 func (o *DbORM) SelectIndexedLogsByBlockRange(start, end int64, address common.Address, eventSig common.Hash, topicIndex int, topicValues []common.Hash, qopts ...pg.QOpt) ([]Log, error) {
-	args, err := newQueryArgsForEvent(o.chainID, address, eventSig).
-		withTopicIndex(topicIndex).
-		withTopicValues(topicValues).
-		withStartBlock(start).
-		withEndBlock(end).
-		toArgs()
-	if err != nil {
-		return nil, err
-	}
-	var logs []Log
-	err = o.q.WithOpts(qopts...).SelectNamed(&logs, `
-		SELECT * FROM evm.logs 
-				WHERE evm_chain_id = :evm_chain_id 
-				AND address = :address
-				AND event_sig = :event_sig
-				AND topics[:topic_index] = ANY(:topic_values)
-				AND block_number >= :start_block
-				AND block_number <= :end_block
-				ORDER BY (block_number, log_index)`, args)
-	if err != nil {
-		return nil, err
-	}
-	return logs, nil
+	//	SELECT * FROM evm.logs
+	//				WHERE evm_chain_id = :evm_chain_id
+	//				AND address = :address
+	//				AND event_sig = :event_sig
+	//				AND topics[:topic_index] = ANY(:topic_values)
+	//				AND block_number >= :start_block
+	//				AND block_number <= :end_block
+	//				ORDER BY (block_number, log_index)
+	filter := NewBasicAndFilter(
+		address,
+		eventSig,
+		NewTopicsFilter(topicIndex, topicValues...),
+		NewBlockRangeFilter(start, end),
+	)
+	return o.SelectFilteredLogs(filter, DefaultSortAndLimit, qopts...)
 }
 
 func (o *DbORM) SelectIndexedLogsCreatedAfter(address common.Address, eventSig common.Hash, topicIndex int, topicValues []common.Hash, after time.Time, confs Confirmations, qopts ...pg.QOpt) ([]Log, error) {
-	args, err := newQueryArgsForEvent(o.chainID, address, eventSig).
-		withBlockTimestampAfter(after).
-		withConfs(confs).
-		withTopicIndex(topicIndex).
-		withTopicValues(topicValues).
-		toArgs()
-	if err != nil {
-		return nil, err
-	}
-
-	query := fmt.Sprintf(`
-		SELECT * FROM evm.logs 
-			WHERE evm_chain_id = :evm_chain_id
-			AND address = :address
-			AND event_sig = :event_sig
-			AND topics[:topic_index] = ANY(:topic_values)
-			AND block_timestamp > :block_timestamp_after
-			AND block_number <= %s
-			ORDER BY (block_number, log_index)`, nestedBlockNumberQuery(confs))
-
-	var logs []Log
-	if err = o.q.WithOpts(qopts...).SelectNamed(&logs, query, args); err != nil {
-		return nil, err
-	}
-	return logs, nil
+	//SELECT * FROM evm.logs
+	//			WHERE evm_chain_id = :evm_chain_id
+	//			AND address = :address
+	//			AND event_sig = :event_sig
+	//			AND topics[:topic_index] = ANY(:topic_values)
+	//			AND block_timestamp > :block_timestamp_after
+	//			AND block_number <= %s
+	//			ORDER BY (block_number, log_index)
+	filter := NewBasicAndFilter(
+		address,
+		eventSig,
+		NewTopicsFilter(topicIndex, topicValues...),
+		NewBlockTimestampAfterFilter(after),
+		NewConfirmationFilter(confs),
+	)
+	return o.SelectFilteredLogs(filter, DefaultSortAndLimit, qopts...)
 }
 
 func (o *DbORM) SelectIndexedLogsByTxHash(address common.Address, eventSig common.Hash, txHash common.Hash, qopts ...pg.QOpt) ([]Log, error) {
-	args, err := newQueryArgs(o.chainID).
-		withTxHash(txHash).
-		withAddress(address).
-		withEventSig(eventSig).
-		toArgs()
-	if err != nil {
-		return nil, err
-	}
-	var logs []Log
-	err = o.q.WithOpts(qopts...).SelectNamed(&logs, `
-		SELECT * FROM evm.logs 
-			WHERE evm_chain_id = :evm_chain_id
-			AND address = :address
-			AND event_sig = :event_sig			  
-			AND tx_hash = :tx_hash
-			ORDER BY (block_number, log_index)`, args)
-	if err != nil {
-		return nil, err
-	}
-	return logs, nil
+	//SELECT * FROM evm.logs
+	//			WHERE evm_chain_id = :evm_chain_id
+	//			AND address = :address
+	//			AND event_sig = :event_sig
+	//			AND tx_hash = :tx_hash
+	//			ORDER BY (block_number, log_index)`
+	filter := NewAndFilter(
+		NewAddressFilter(address),
+		NewEventSigFilter(eventSig),
+		NewTxHashFilter(txHash),
+	)
+
+	return o.SelectFilteredLogs(filter, DefaultSortAndLimit, qopts...)
 }
 
 // SelectIndexedLogsWithSigsExcluding query's for logs that have signature A and exclude logs that have a corresponding signature B, matching is done based on the topic index both logs should be inside the block range and have the minimum number of confirmations
@@ -755,20 +688,22 @@ func (o *DbORM) SelectIndexedLogsWithSigsExcluding(sigA, sigB common.Hash, topic
 	return logs, nil
 }
 
-func nestedBlockNumberQuery(confs Confirmations) string {
-	if confs == Finalized {
-		return `
-				(SELECT finalized_block_number 
-				FROM evm.log_poller_blocks 
-				WHERE evm_chain_id = :evm_chain_id 
-				ORDER BY block_number DESC LIMIT 1) `
+func (o *DbORM) SelectFilteredLogs(filter QFilter, limit SortAndLimit, qopts ...pg.QOpt) ([]Log, error) {
+	sqlFilter, args, err := NewPgParser(o.chainID).Parse(filter)
+	if err != nil {
+		return nil, err
 	}
-	// Intentionally wrap with greatest() function and don't return negative block numbers when :confs > :block_number
-	// It doesn't impact logic of the outer query, because block numbers are never less or equal to 0 (guarded by log_poller_blocks_block_number_check)
-	return `
-			(SELECT greatest(block_number - :confs, 0) 
-			FROM evm.log_poller_blocks 	
-			WHERE evm_chain_id = :evm_chain_id 
-			ORDER BY block_number DESC LIMIT 1) `
 
+	query := fmt.Sprintf(
+		"select * from evm.logs where %s %s %s",
+		sqlFilter,
+		orderBy(limit.sortBy),
+		limitBy(limit.limit),
+	)
+
+	var logs []Log
+	if err := o.q.WithOpts(qopts...).SelectNamed(&logs, query, args); err != nil {
+		return nil, err
+	}
+	return logs, nil
 }

--- a/core/chains/evm/logpoller/orm_test.go
+++ b/core/chains/evm/logpoller/orm_test.go
@@ -1507,6 +1507,21 @@ func TestSelectLogsDataWordBetween(t *testing.T) {
 			assert.NoError(t, err1)
 			assert.Len(t, logs, len(tt.expectedLogs))
 
+			filter := logpoller.NewAndFilter(
+				logpoller.NewAddressFilter(address),
+				logpoller.NewEventSigFilter(eventSig),
+				logpoller.NewDataWordGteFilter(1, logpoller.EvmWord(tt.wordValue)),
+				logpoller.NewDataWordLteFilter(0, logpoller.EvmWord(tt.wordValue)),
+				logpoller.NewConfirmationFilter(logpoller.Unconfirmed),
+			)
+			sortAndLimit := logpoller.DefaultSortAndLimit
+
+			logs2, err1 := th.ORM.SelectFilteredLogs(filter, sortAndLimit)
+			assert.NoError(t, err1)
+			assert.Len(t, logs, len(tt.expectedLogs))
+
+			assert.Equal(t, logs, logs2)
+
 			for index := range logs {
 				assert.Equal(t, tt.expectedLogs[index], logs[index].BlockNumber)
 			}

--- a/core/chains/evm/logpoller/pg_parser.go
+++ b/core/chains/evm/logpoller/pg_parser.go
@@ -1,0 +1,226 @@
+package logpoller
+
+import (
+	"errors"
+	"fmt"
+	"math/big"
+	"strings"
+)
+
+func orderBy(sortBy []SortBy) string {
+	if len(sortBy) == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	sb.WriteString(" ORDER BY ")
+	for i, sort := range sortBy {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		sb.WriteString(fmt.Sprintf("%s %s", sort.field, sort.dir.pgString()))
+	}
+	return sb.String()
+}
+
+func limitBy(limit int) string {
+	if limit == 0 {
+		return ""
+	}
+	return fmt.Sprintf(" LIMIT %d", limit)
+}
+
+// PgParserVisitor is a visitor that builds a postgres query and arguments from a QFilter
+// Keep in mind it's not designed to be thread safe so should not be used concurrently.
+type PgParserVisitor struct {
+	evmChainId      *big.Int
+	query           strings.Builder
+	args            map[string]any
+	errors          []error
+	filterNameIndex int
+}
+
+func NewPgParser(evmChainID *big.Int) *PgParserVisitor {
+	return &PgParserVisitor{
+		evmChainId: evmChainID,
+		args:       map[string]any{},
+	}
+}
+
+func (v *PgParserVisitor) Parse(f QFilter) (string, map[string]any, error) {
+	f = v.addEvmChainIdFilter(f)
+	f.accept(v)
+	return v.query.String(), v.args, errors.Join(v.errors...)
+}
+
+func (v *PgParserVisitor) addEvmChainIdFilter(filter QFilter) QFilter {
+	switch casted := filter.(type) {
+	case *AndFilter:
+		return AppendedNewFilter(casted, NewEvmChainIdFilter(v.evmChainId))
+	default:
+		return NewAndFilter(casted, NewEvmChainIdFilter(v.evmChainId))
+	}
+}
+
+func (op ComparisonOperator) pgString() string {
+	switch op {
+	case Eq:
+		return "="
+	case Neq:
+		return "<>"
+	case Gt:
+		return ">"
+	case Lt:
+		return "<"
+	case Gte:
+		return ">="
+	case Lte:
+		return "<="
+	default:
+		panic("unknown comparison operator")
+	}
+}
+
+func (sd SortDirection) pgString() string {
+	switch sd {
+	case Asc:
+		return "asc"
+	case Desc:
+		return "desc"
+	default:
+		panic("unknown sort direction")
+	}
+}
+
+func (v *PgParserVisitor) visitAndFilter(node AndFilter) {
+	for i, filter := range node.filters {
+		if i > 0 {
+			v.query.WriteString(" AND ")
+		}
+		filter.accept(v)
+	}
+}
+
+func (v *PgParserVisitor) visitAddressFilter(node AddressFilter) {
+	switch len(node.address) {
+	case 0:
+		v.errors = append(v.errors, errors.New("address filter must have at least one address signature"))
+	case 1:
+		v.query.WriteString("address = :address")
+		v.args["address"] = node.address[0]
+	default:
+		v.query.WriteString("address = ANY(:address)")
+		v.args["address"] = concatBytes(node.address)
+	}
+}
+
+func (v *PgParserVisitor) visitEventSigFilter(node EventSigFilter) {
+	switch len(node.eventSig) {
+	case 0:
+		v.errors = append(v.errors, errors.New("event sig filter must have at least one event signature"))
+	case 1:
+		v.query.WriteString("event_sig = :event_sig")
+		v.args["event_sig"] = node.eventSig[0].Bytes()
+	default:
+		v.query.WriteString("event_sig = ANY(:event_sig)")
+		v.args["event_sig"] = concatBytes(node.eventSig)
+	}
+}
+
+func (v *PgParserVisitor) visitDataWordFilter(node DataWordFilter) {
+	argumentName, valueName := v.wordValueVariables()
+
+	v.query.WriteString(fmt.Sprintf(
+		"substring(data from 32*:%s+1 for 32) %s :%s",
+		argumentName,
+		node.operator.pgString(),
+		valueName,
+	))
+	v.args[argumentName] = node.index
+	v.args[valueName] = node.value.Bytes()
+}
+
+func (v *PgParserVisitor) visitConfirmationFilter(node ConfirmationFilter) {
+	v.query.WriteString("block_number <= ")
+	v.query.WriteString(nestedBlockNumberQuery(node.confs))
+	v.args["confs"] = node.confs
+}
+
+func (v *PgParserVisitor) visitEvmChainIdFilter(node EvmChainIdFilter) {
+	v.query.WriteString("evm_chain_id = :evm_chain_id")
+	v.args["evm_chain_id"] = node.chainId
+}
+
+func (v *PgParserVisitor) visitTopicFilter(node TopicFilter) {
+	topicIndex, err := sanitizeTopicIndex(node.index)
+	if err != nil {
+		v.errors = append(v.errors, err)
+		return
+	}
+
+	topicIndexName, topicValueName := v.topicVariables()
+	v.query.WriteString(fmt.Sprintf("topics[:%s] %s :%s", topicIndexName, node.operator.pgString(), topicValueName))
+	v.args[topicIndexName] = topicIndex
+	v.args[topicValueName] = node.value.Bytes()
+}
+
+func (v *PgParserVisitor) visitTopicsFilter(node TopicsFilter) {
+	topicIndex, err := sanitizeTopicIndex(node.index)
+	if err != nil {
+		v.errors = append(v.errors, err)
+		return
+	}
+
+	topicIndexName, topicValueName := v.topicVariables()
+	v.query.WriteString(fmt.Sprintf("topics[:%s] = ANY(:%s)", topicIndexName, topicValueName))
+	v.args[topicIndexName] = topicIndex
+	v.args[topicValueName] = concatBytes(node.values)
+}
+
+func (v *PgParserVisitor) visitNamedFilter(node NamedFilter) {
+	v.filterNameIndex++
+	argumentValue := fmt.Sprintf("%s_%d", node.fieldName, v.filterNameIndex)
+
+	v.query.WriteString(fmt.Sprintf("%s %s :%s", node.fieldName, node.operator.pgString(), argumentValue))
+	v.args[argumentValue] = node.value
+}
+
+func (v *PgParserVisitor) topicVariables() (string, string) {
+	v.filterNameIndex++
+	argumentName := fmt.Sprintf("topic_index_%d", v.filterNameIndex)
+	valueName := fmt.Sprintf("topic_value_%d", v.filterNameIndex)
+	return argumentName, valueName
+}
+
+func (v *PgParserVisitor) wordValueVariables() (string, string) {
+	v.filterNameIndex++
+	argumentName := fmt.Sprintf("word_index_%d", v.filterNameIndex)
+	valueName := fmt.Sprintf("word_value_%d", v.filterNameIndex)
+	return argumentName, valueName
+}
+
+func sanitizeTopicIndex(index int) (int, error) {
+	// Only topicIndex 1 through 3 is valid. 0 is the event sig and only 4 total topics are allowed
+	if index < 1 || index > 3 {
+		return 0, fmt.Errorf("invalid index for topic: %d", index)
+	}
+	return index + 1, nil
+}
+
+func nestedBlockNumberQuery(confs Confirmations) string {
+	if confs == Finalized {
+		return `
+				(SELECT finalized_block_number 
+				FROM evm.log_poller_blocks 
+				WHERE evm_chain_id = :evm_chain_id 
+				ORDER BY block_number DESC LIMIT 1) `
+	}
+	// Intentionally wrap with greatest() function and don't return negative block numbers when :confs > :block_number
+	// It doesn't impact logic of the outer query, because block numbers are never less or equal to 0 (guarded by log_poller_blocks_block_number_check)
+	return `
+			(SELECT greatest(block_number - :confs, 0) 
+			FROM evm.log_poller_blocks 	
+			WHERE evm_chain_id = :evm_chain_id 
+			ORDER BY block_number DESC LIMIT 1) `
+
+}


### PR DESCRIPTION
Simple DSL layer for filters, sort, and limit in LogPoller. This should make querying LogPoller a bit easier, especially if we need to pass custom sorting, limits or paging. Structs that describe available filters are represented as structs in the `dsl.go`. The parser is built using visitor pattern, this makes the code more loosely coupled as the DSL layer doesn't have to know any orm internals - it just represents a set of filters with values. Switching to any other storage/persistence layer will require implementing one interface - `Visitor`. It won't require any changes in LogPoller or the DSL layer at all. Additionally, DSL approach doesn't expose any database internals outside of the LogPoller - clients of the API will use building blocks for defining supported filters.

This is driven by a couple of needs:

CCIP requires more detailed queries for some cases. This approach enables us to filter by anything we want or pass limits to the queries that we need to return only a single element without any changes to LogPoller - so far we used to add new function to the interface anytime we wanted to craft a DB query
https://github.com/smartcontractkit/ccip/pull/316

We could reduce the number of read functions in the LogPoller interface. At this moment, any tiny modification in the read query requires adding a new LogPoller function. This causes an explosion in a number of methods in LogPoller. What is more, we could move all those read queries to a separate file and make LogPoller interface smaller, for instance:
```go
// logpoller.go

type LogPoller interface {
	services.Service
	Replay(ctx context.Context, fromBlock int64) error
	ReplayAsync(fromBlock int64)
	RegisterFilter(filter Filter, qopts ...pg.QOpt) error
	UnregisterFilter(name string, qopts ...pg.QOpt) error
	HasFilter(name string) bool
	LatestBlock(qopts ...pg.QOpt) (LogPollerBlock, error)
	GetBlocksRange(ctx context.Context, numbers []uint64, qopts ...pg.QOpt) ([]LogPollerBlock, error)
}
```

```go
type LogPollerQuerier struct {
    orm orm.ORM
}

func (q *LogPollerQuerier) SelectSth() {
   //build query with DSL and pass to ORM
}
```
Doesn't have to be exactly the same, just a general idea about decoupling log poller's business logic from read layer