### PR TITLE
WIP Use MercuryCredentials in the AutomationProvider, and expose a Keyring

### DIFF
--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -175,8 +175,8 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg chainlink.G
 	}
 
 	evmFactoryCfg := chainlink.EVMFactoryConfig{
-		CSAETHKeystore: keyStore,
-		ChainOpts:      legacyevm.ChainOpts{AppConfig: cfg, EventBroadcaster: eventBroadcaster, MailMon: mailMon, DB: db},
+		CSAETHOCR2Keystore: keyStore,
+		ChainOpts:          legacyevm.ChainOpts{AppConfig: cfg, EventBroadcaster: eventBroadcaster, MailMon: mailMon, DB: db},
 	}
 	// evm always enabled for backward compatibility
 	// TODO BCF-2510 this needs to change in order to clear the path for EVM extraction

--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/pelletier/go-toml/v2 v2.1.1
 	github.com/shopspring/decimal v1.3.1
-	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231220152716-58eeae4c533e
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20231220154732-3d88f4cb29e0
+	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231221161430-4f2b2d764640
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20231221165002-a3f659f1d9c6
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20231130143053-c5102a9c0fb7

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1146,10 +1146,10 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 h1:T3lFWumvbfM1u/etVq42Afwq/jtNSBSOA8n5jntnNPo=
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
-github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231220152716-58eeae4c533e h1:WyMSJl4D/ZP4GDvEY80viW8Huuu7pgJUxRS/IjcXoxU=
-github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231220152716-58eeae4c533e/go.mod h1:hWZcq1HLea7HkXk1bN4LjeSddqQGYddpii+8jRTRxq0=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20231220154732-3d88f4cb29e0 h1:QTOnSzH+eHVvBrbu/6cfnY9OwADdFKJNwj9bFjBrXoU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20231220154732-3d88f4cb29e0/go.mod h1:IdlfCN9rUs8Q/hrOYe8McNBIwEOHEsi0jilb3Cw77xs=
+github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231221161430-4f2b2d764640 h1:5uG9w9sOGkmoU6yHnzEQ8UeSn3LIHYlmxzdgATXpzTc=
+github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231221161430-4f2b2d764640/go.mod h1:oy5rqwhu5Tpuctb1LSE4z49YOmcDqbaCSkjq4SdjUBI=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20231221165002-a3f659f1d9c6 h1:Yhd/NG3gsV9Ng0B5k+r3/aOvCXhoP3jqdJ4BflVHKME=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20231221165002-a3f659f1d9c6/go.mod h1:IdlfCN9rUs8Q/hrOYe8McNBIwEOHEsi0jilb3Cw77xs=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20231218175426-6e0427c661e5 h1:kBnmjv3fxU7krVIqZFvo1m4F6qBc4vPURQFX/mcChhI=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20231218175426-6e0427c661e5/go.mod h1:EoM7wQ81mov7wsUzG4zEnnr0EH0POEo/I0hRDg433TU=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20231204152908-a6e3fe8ff2a1 h1:xYqRgZO0nMSO8CBCMR0r3WA+LZ4kNL8a6bnbyk/oBtQ=

--- a/core/services/chainlink/application.go
+++ b/core/services/chainlink/application.go
@@ -412,6 +412,7 @@ func NewApplication(opts ApplicationOpts) (Application, error) {
 			keyStore.DKGSign(),
 			keyStore.DKGEncrypt(),
 			keyStore.Eth(),
+			keyStore.OCR2(),
 			opts.RelayerChainInteroperators,
 			mailMon,
 			eventBroadcaster,

--- a/core/services/chainlink/relayer_factory.go
+++ b/core/services/chainlink/relayer_factory.go
@@ -37,7 +37,7 @@ type RelayerFactory struct {
 
 type EVMFactoryConfig struct {
 	legacyevm.ChainOpts
-	evmrelay.CSAETHKeystore
+	evmrelay.CSAETHOCR2Keystore
 }
 
 func (r *RelayerFactory) NewEVM(ctx context.Context, config EVMFactoryConfig) (map[relay.ID]evmrelay.LoopRelayAdapter, error) {
@@ -50,7 +50,7 @@ func (r *RelayerFactory) NewEVM(ctx context.Context, config EVMFactoryConfig) (m
 	// override some common opts with the factory values. this seems weird... maybe other signatures should change, or this should take a different type...
 	ccOpts := legacyevm.ChainRelayExtenderConfig{
 		Logger:    lggr,
-		KeyStore:  config.CSAETHKeystore.Eth(),
+		KeyStore:  config.CSAETHOCR2Keystore.Eth(),
 		ChainOpts: config.ChainOpts,
 	}
 
@@ -67,11 +67,11 @@ func (r *RelayerFactory) NewEVM(ctx context.Context, config EVMFactoryConfig) (m
 		}
 
 		relayerOpts := evmrelay.RelayerOpts{
-			DB:               ccOpts.DB,
-			QConfig:          ccOpts.AppConfig.Database(),
-			CSAETHKeystore:   config.CSAETHKeystore,
-			EventBroadcaster: ccOpts.EventBroadcaster,
-			MercuryPool:      r.MercuryPool,
+			DB:                 ccOpts.DB,
+			QConfig:            ccOpts.AppConfig.Database(),
+			CSAETHOCR2Keystore: config.CSAETHOCR2Keystore,
+			EventBroadcaster:   ccOpts.EventBroadcaster,
+			MercuryPool:        r.MercuryPool,
 		}
 		relayer, err2 := evmrelay.NewRelayer(lggr.Named(relayID.ChainID), chain, relayerOpts)
 		if err2 != nil {

--- a/core/services/job/spawner_test.go
+++ b/core/services/job/spawner_test.go
@@ -79,6 +79,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 	db := pgtest.NewSqlxDB(t)
 	keyStore := cltest.NewKeyStore(t, db, config.Database())
 	ethKeyStore := keyStore.Eth()
+	oc2KeyStore := keyStore.OCR2()
 	require.NoError(t, keyStore.OCR().Add(cltest.DefaultOCRKey))
 	require.NoError(t, keyStore.P2P().Add(cltest.DefaultP2PKey))
 	require.NoError(t, keyStore.OCR2().Add(cltest.DefaultOCR2Key))
@@ -285,10 +286,10 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 		chain := evmtest.MustGetDefaultChain(t, legacyChains)
 
 		evmRelayer, err := evmrelayer.NewRelayer(lggr, chain, evmrelayer.RelayerOpts{
-			DB:               db,
-			QConfig:          testopts.GeneralConfig.Database(),
-			CSAETHKeystore:   keyStore,
-			EventBroadcaster: pg.NewNullEventBroadcaster(),
+			DB:                 db,
+			QConfig:            testopts.GeneralConfig.Database(),
+			CSAETHOCR2Keystore: keyStore,
+			EventBroadcaster:   pg.NewNullEventBroadcaster(),
 		})
 		assert.NoError(t, err)
 
@@ -306,7 +307,7 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 		ocr2DelegateConfig := ocr2.NewDelegateConfig(config.OCR2(), config.Mercury(), config.Threshold(), config.Insecure(), config.JobPipeline(), config.Database(), processConfig)
 
 		d := ocr2.NewDelegate(nil, orm, nil, nil, nil, nil, monitoringEndpoint, legacyChains, lggr, ocr2DelegateConfig,
-			keyStore.OCR2(), keyStore.DKGSign(), keyStore.DKGEncrypt(), ethKeyStore, testRelayGetter, mailMon, nil)
+			keyStore.OCR2(), keyStore.DKGSign(), keyStore.DKGEncrypt(), ethKeyStore, oc2KeyStore, testRelayGetter, mailMon, nil)
 		delegateOCR2 := &delegate{jobOCR2VRF.Type, []job.ServiceCtx{}, 0, nil, d}
 
 		spawner := job.NewSpawner(orm, config.Database(), noopChecker{}, map[job.Type]job.Delegate{

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/keyring.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/keyring.go
@@ -1,13 +1,12 @@
 package evm
 
 import (
+	"github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 	"github.com/smartcontractkit/libocr/offchainreporting2/types"
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
-
-	"github.com/smartcontractkit/chainlink-automation/pkg/v3/plugin"
 )
 
-var _ ocr3types.OnchainKeyring[plugin.AutomationReportInfo] = &onchainKeyringV3Wrapper{}
+var _ ocr3types.OnchainKeyring[automation.AutomationReportInfo] = &onchainKeyringV3Wrapper{}
 
 type onchainKeyringV3Wrapper struct {
 	core types.OnchainKeyring
@@ -27,7 +26,7 @@ func (w *onchainKeyringV3Wrapper) MaxSignatureLength() int {
 	return w.core.MaxSignatureLength()
 }
 
-func (w *onchainKeyringV3Wrapper) Sign(digest types.ConfigDigest, seqNr uint64, r ocr3types.ReportWithInfo[plugin.AutomationReportInfo]) (signature []byte, err error) {
+func (w *onchainKeyringV3Wrapper) Sign(digest types.ConfigDigest, seqNr uint64, r ocr3types.ReportWithInfo[automation.AutomationReportInfo]) (signature []byte, err error) {
 	rCtx := types.ReportContext{
 		ReportTimestamp: types.ReportTimestamp{
 			ConfigDigest: digest,
@@ -38,7 +37,7 @@ func (w *onchainKeyringV3Wrapper) Sign(digest types.ConfigDigest, seqNr uint64, 
 	return w.core.Sign(rCtx, r.Report)
 }
 
-func (w *onchainKeyringV3Wrapper) Verify(key types.OnchainPublicKey, digest types.ConfigDigest, seqNr uint64, r ocr3types.ReportWithInfo[plugin.AutomationReportInfo], signature []byte) bool {
+func (w *onchainKeyringV3Wrapper) Verify(key types.OnchainPublicKey, digest types.ConfigDigest, seqNr uint64, r ocr3types.ReportWithInfo[automation.AutomationReportInfo], signature []byte) bool {
 	rCtx := types.ReportContext{
 		ReportTimestamp: types.ReportTimestamp{
 			ConfigDigest: digest,

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/services.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/services.go
@@ -9,7 +9,6 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2plus/ocr3types"
 	ocrtypes "github.com/smartcontractkit/libocr/offchainreporting2plus/types"
 
-	"github.com/smartcontractkit/chainlink-automation/pkg/v3/plugin"
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/legacyevm"
@@ -33,7 +32,7 @@ type AutomationServices interface {
 	LogEventProvider() logprovider.LogEventProvider
 	LogRecoverer() logprovider.LogRecoverer
 	UpkeepProvider() ocr2keepers.ConditionalUpkeepProvider
-	Keyring() ocr3types.OnchainKeyring[plugin.AutomationReportInfo]
+	Keyring() ocr3types.OnchainKeyring[ocr2keepers.AutomationReportInfo]
 }
 
 func New(addr common.Address, client legacyevm.Chain, mc *models.MercuryCredentials, keyring ocrtypes.OnchainKeyring, lggr logger.Logger, db *sqlx.DB, dbCfg pg.QConfig) (AutomationServices, error) {
@@ -131,6 +130,6 @@ func (f *automationServices) UpkeepProvider() ocr2keepers.ConditionalUpkeepProvi
 	return f.upkeepProvider
 }
 
-func (f *automationServices) Keyring() ocr3types.OnchainKeyring[plugin.AutomationReportInfo] {
+func (f *automationServices) Keyring() ocr3types.OnchainKeyring[ocr2keepers.AutomationReportInfo] {
 	return f.keyring
 }

--- a/core/services/ocr2/plugins/ocr2keeper/util.go
+++ b/core/services/ocr2/plugins/ocr2keeper/util.go
@@ -44,9 +44,9 @@ var (
 	ErrNoChainFromSpec = fmt.Errorf("could not create chain from spec")
 )
 
-func EVMProvider(db *sqlx.DB, chain legacyevm.Chain, lggr logger.Logger, spec job.Job, ethKeystore keystore.Eth, dbCfg pg.QConfig) (evmrelay.OCR2KeeperProvider, error) {
+func EVMProvider(db *sqlx.DB, chain legacyevm.Chain, lggr logger.Logger, spec job.Job, ethKeystore keystore.Eth, ocr2Keystore keystore.OCR2, dbCfg pg.QConfig) (evmrelay.OCR2KeeperProvider, error) {
 	oSpec := spec.OCR2OracleSpec
-	ocr2keeperRelayer := evmrelay.NewOCR2KeeperRelayer(db, chain, lggr.Named("OCR2KeeperRelayer"), ethKeystore, dbCfg)
+	ocr2keeperRelayer := evmrelay.NewOCR2KeeperRelayer(db, chain, lggr.Named("OCR2KeeperRelayer"), ethKeystore, ocr2Keystore, dbCfg)
 
 	keeperProvider, err := ocr2keeperRelayer.NewOCR2KeeperProvider(
 		types.RelayArgs{
@@ -73,6 +73,7 @@ func EVMDependencies20(
 	lggr logger.Logger,
 	chain legacyevm.Chain,
 	ethKeystore keystore.Eth,
+	ocr2Keystore keystore.OCR2,
 	dbCfg pg.QConfig,
 ) (evmrelay.OCR2KeeperProvider, *evmregistry20.EvmRegistry, Encoder20, *evmregistry20.LogProvider, error) {
 	var err error
@@ -81,7 +82,7 @@ func EVMDependencies20(
 	var registry *evmregistry20.EvmRegistry
 
 	// the provider will be returned as a dependency
-	if keeperProvider, err = EVMProvider(db, chain, lggr, spec, ethKeystore, dbCfg); err != nil {
+	if keeperProvider, err = EVMProvider(db, chain, lggr, spec, ethKeystore, ocr2Keystore, dbCfg); err != nil {
 		return nil, nil, nil, nil, err
 	}
 

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -49,22 +49,23 @@ type Relayer struct {
 	db               *sqlx.DB
 	chain            legacyevm.Chain
 	lggr             logger.Logger
-	ks               CSAETHKeystore
+	ks               CSAETHOCR2Keystore
 	mercuryPool      wsrpc.Pool
 	eventBroadcaster pg.EventBroadcaster
 	pgCfg            pg.QConfig
 	chainReader      commontypes.ChainReader
 }
 
-type CSAETHKeystore interface {
+type CSAETHOCR2Keystore interface {
 	CSA() keystore.CSA
 	Eth() keystore.Eth
+	OCR2() keystore.OCR2
 }
 
 type RelayerOpts struct {
 	*sqlx.DB
 	pg.QConfig
-	CSAETHKeystore
+	CSAETHOCR2Keystore
 	pg.EventBroadcaster
 	MercuryPool wsrpc.Pool
 }
@@ -77,7 +78,7 @@ func (c RelayerOpts) Validate() error {
 	if c.QConfig == nil {
 		err = errors.Join(err, errors.New("nil QConfig"))
 	}
-	if c.CSAETHKeystore == nil {
+	if c.CSAETHOCR2Keystore == nil {
 		err = errors.Join(err, errors.New("nil Keystore"))
 	}
 	if c.EventBroadcaster == nil {
@@ -100,7 +101,7 @@ func NewRelayer(lggr logger.Logger, chain legacyevm.Chain, opts RelayerOpts) (*R
 		db:               opts.DB,
 		chain:            chain,
 		lggr:             lggr,
-		ks:               opts.CSAETHKeystore,
+		ks:               opts.CSAETHOCR2Keystore,
 		mercuryPool:      opts.MercuryPool,
 		eventBroadcaster: opts.EventBroadcaster,
 		pgCfg:            opts.QConfig,
@@ -505,7 +506,7 @@ func (r *Relayer) NewMedianProvider(rargs commontypes.RelayArgs, pargs commontyp
 
 func (r *Relayer) NewAutomationProvider(rargs commontypes.RelayArgs, pargs commontypes.PluginArgs) (commontypes.AutomationProvider, error) {
 	lggr := r.lggr.Named("AutomationProvider").Named(rargs.ExternalJobID.String())
-	ocr2keeperRelayer := NewOCR2KeeperRelayer(r.db, r.chain, lggr.Named("OCR2KeeperRelayer"), r.ks.Eth(), r.pgCfg)
+	ocr2keeperRelayer := NewOCR2KeeperRelayer(r.db, r.chain, lggr.Named("OCR2KeeperRelayer"), r.ks.Eth(), r.ks.OCR2(), r.pgCfg)
 
 	return ocr2keeperRelayer.NewOCR2KeeperProvider(rargs, pargs)
 }

--- a/go.mod
+++ b/go.mod
@@ -64,8 +64,8 @@ require (
 	github.com/shirou/gopsutil/v3 v3.23.11
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704
-	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231220152716-58eeae4c533e
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20231220154732-3d88f4cb29e0
+	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231221161430-4f2b2d764640
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20231221165002-a3f659f1d9c6
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20231218175426-6e0427c661e5
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20231204152908-a6e3fe8ff2a1
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20231127231053-2232d3a6766d

--- a/go.sum
+++ b/go.sum
@@ -1132,10 +1132,10 @@ github.com/sirupsen/logrus v1.9.3 h1:dueUQJ1C2q9oE3F7wvmSGAaVtTmUizReu6fjN8uqzbQ
 github.com/sirupsen/logrus v1.9.3/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 h1:T3lFWumvbfM1u/etVq42Afwq/jtNSBSOA8n5jntnNPo=
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
-github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231220152716-58eeae4c533e h1:WyMSJl4D/ZP4GDvEY80viW8Huuu7pgJUxRS/IjcXoxU=
-github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231220152716-58eeae4c533e/go.mod h1:hWZcq1HLea7HkXk1bN4LjeSddqQGYddpii+8jRTRxq0=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20231220154732-3d88f4cb29e0 h1:QTOnSzH+eHVvBrbu/6cfnY9OwADdFKJNwj9bFjBrXoU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20231220154732-3d88f4cb29e0/go.mod h1:IdlfCN9rUs8Q/hrOYe8McNBIwEOHEsi0jilb3Cw77xs=
+github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231221161430-4f2b2d764640 h1:5uG9w9sOGkmoU6yHnzEQ8UeSn3LIHYlmxzdgATXpzTc=
+github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231221161430-4f2b2d764640/go.mod h1:oy5rqwhu5Tpuctb1LSE4z49YOmcDqbaCSkjq4SdjUBI=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20231221165002-a3f659f1d9c6 h1:Yhd/NG3gsV9Ng0B5k+r3/aOvCXhoP3jqdJ4BflVHKME=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20231221165002-a3f659f1d9c6/go.mod h1:IdlfCN9rUs8Q/hrOYe8McNBIwEOHEsi0jilb3Cw77xs=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20231218175426-6e0427c661e5 h1:kBnmjv3fxU7krVIqZFvo1m4F6qBc4vPURQFX/mcChhI=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20231218175426-6e0427c661e5/go.mod h1:EoM7wQ81mov7wsUzG4zEnnr0EH0POEo/I0hRDg433TU=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20231204152908-a6e3fe8ff2a1 h1:xYqRgZO0nMSO8CBCMR0r3WA+LZ4kNL8a6bnbyk/oBtQ=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -23,8 +23,8 @@ require (
 	github.com/scylladb/go-reflectx v1.0.1
 	github.com/segmentio/ksuid v1.0.4
 	github.com/slack-go/slack v0.12.2
-	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231220152716-58eeae4c533e
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20231220154732-3d88f4cb29e0
+	github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231221161430-4f2b2d764640
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20231221165002-a3f659f1d9c6
 	github.com/smartcontractkit/chainlink-testing-framework v1.22.1
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1463,10 +1463,10 @@ github.com/slack-go/slack v0.12.2 h1:x3OppyMyGIbbiyFhsBmpf9pwkUzMhthJMRNmNlA4LaQ
 github.com/slack-go/slack v0.12.2/go.mod h1:hlGi5oXA+Gt+yWTPP0plCdRKmjsDxecdHxYQdlMQKOw=
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704 h1:T3lFWumvbfM1u/etVq42Afwq/jtNSBSOA8n5jntnNPo=
 github.com/smartcontractkit/caigo v0.0.0-20230621050857-b29a4ca8c704/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
-github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231220152716-58eeae4c533e h1:WyMSJl4D/ZP4GDvEY80viW8Huuu7pgJUxRS/IjcXoxU=
-github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231220152716-58eeae4c533e/go.mod h1:hWZcq1HLea7HkXk1bN4LjeSddqQGYddpii+8jRTRxq0=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20231220154732-3d88f4cb29e0 h1:QTOnSzH+eHVvBrbu/6cfnY9OwADdFKJNwj9bFjBrXoU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20231220154732-3d88f4cb29e0/go.mod h1:IdlfCN9rUs8Q/hrOYe8McNBIwEOHEsi0jilb3Cw77xs=
+github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231221161430-4f2b2d764640 h1:5uG9w9sOGkmoU6yHnzEQ8UeSn3LIHYlmxzdgATXpzTc=
+github.com/smartcontractkit/chainlink-automation v1.0.2-0.20231221161430-4f2b2d764640/go.mod h1:oy5rqwhu5Tpuctb1LSE4z49YOmcDqbaCSkjq4SdjUBI=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20231221165002-a3f659f1d9c6 h1:Yhd/NG3gsV9Ng0B5k+r3/aOvCXhoP3jqdJ4BflVHKME=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20231221165002-a3f659f1d9c6/go.mod h1:IdlfCN9rUs8Q/hrOYe8McNBIwEOHEsi0jilb3Cw77xs=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20231218175426-6e0427c661e5 h1:kBnmjv3fxU7krVIqZFvo1m4F6qBc4vPURQFX/mcChhI=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20231218175426-6e0427c661e5/go.mod h1:EoM7wQ81mov7wsUzG4zEnnr0EH0POEo/I0hRDg433TU=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20231204152908-a6e3fe8ff2a1 h1:xYqRgZO0nMSO8CBCMR0r3WA+LZ4kNL8a6bnbyk/oBtQ=


### PR DESCRIPTION
Supporting PRs:

chainlink-common: https://github.com/smartcontractkit/chainlink-common/pull/301
chainlink-automation: https://github.com/smartcontractkit/chainlink-automation/pull/301

(aside: both PRs have the same number!! 🤩 )

At a high level; in common we're adding `MercuryCredentials` (a struct of 4 strings), and `KeyBundleID` (a string). We're also updating the AutomationProvider interface with a `Keyring` function, which uses the `AutomationReportInfo` type (which, in turn, has been moved out of `chainlink-automation`)

In core, we're using the `MercuryCredentials` in the registry constructor, and we're using the `KeyBundleID` to get the keyring from the OCR2 keystore. The `CSAETHKeystore` type has been updated to `CSAETHOCR2Keystore`, as it now exposes the OCR2 keystore.
