### PR TITLE
Refrains From Explicitly Requesting New OCR Rounds

### DIFF
--- a/integration-tests/actions/ocr_helpers.go
+++ b/integration-tests/actions/ocr_helpers.go
@@ -343,6 +343,25 @@ func StartNewRound(
 	return nil
 }
 
+// WatchNewRound watches for a new OCR round, similarly to StartNewRound, but it does not explicitly request a new
+// round from the contract, as this can cause some odd behavior in some cases
+func WatchNewRound(
+	roundNumber int64,
+	ocrInstances []contracts.OffchainAggregator,
+	client blockchain.EVMClient,
+	logger zerolog.Logger,
+) error {
+	for i := 0; i < len(ocrInstances); i++ {
+		ocrRound := contracts.NewOffchainAggregatorRoundConfirmer(ocrInstances[i], big.NewInt(roundNumber), client.GetNetworkConfig().Timeout.Duration, logger)
+		client.AddHeaderEventSubscription(ocrInstances[i].Address(), ocrRound)
+		err := client.WaitForEvents()
+		if err != nil {
+			return fmt.Errorf("failed to wait for event subscriptions of OCR instance %d: %w", i+1, err)
+		}
+	}
+	return nil
+}
+
 // SetAdapterResponse sets a single adapter response that correlates with an ocr contract and a chainlink node
 func SetAdapterResponse(
 	response int,

--- a/integration-tests/smoke/forwarder_ocr_test.go
+++ b/integration-tests/smoke/forwarder_ocr_test.go
@@ -68,7 +68,7 @@ func TestForwarderOCRBasic(t *testing.T) {
 
 	err = actions.CreateOCRJobsWithForwarderLocal(ocrInstances, bootstrapNode, workerNodes, 5, env.MockAdapter, env.EVMClient.GetChainID().String())
 	require.NoError(t, err, "failed to setup forwarder jobs")
-	err = actions.StartNewRound(1, ocrInstances, env.EVMClient, l)
+	err = actions.WatchNewRound(1, ocrInstances, env.EVMClient, l)
 	require.NoError(t, err)
 	err = env.EVMClient.WaitForEvents()
 	require.NoError(t, err, "Error waiting for events")
@@ -79,7 +79,7 @@ func TestForwarderOCRBasic(t *testing.T) {
 
 	err = actions.SetAllAdapterResponsesToTheSameValueLocal(10, ocrInstances, workerNodes, env.MockAdapter)
 	require.NoError(t, err)
-	err = actions.StartNewRound(2, ocrInstances, env.EVMClient, l)
+	err = actions.WatchNewRound(2, ocrInstances, env.EVMClient, l)
 	require.NoError(t, err)
 	err = env.EVMClient.WaitForEvents()
 	require.NoError(t, err, "Error waiting for events")

--- a/integration-tests/smoke/ocr_test.go
+++ b/integration-tests/smoke/ocr_test.go
@@ -47,7 +47,7 @@ func TestOCRBasic(t *testing.T) {
 	err = actions.CreateOCRJobsLocal(ocrInstances, bootstrapNode, workerNodes, 5, env.MockAdapter, env.EVMClient.GetChainID())
 	require.NoError(t, err)
 
-	err = actions.StartNewRound(1, ocrInstances, env.EVMClient, l)
+	err = actions.WatchNewRound(1, ocrInstances, env.EVMClient, l)
 	require.NoError(t, err)
 
 	answer, err := ocrInstances[0].GetLatestAnswer(testcontext.Get(t))
@@ -56,7 +56,7 @@ func TestOCRBasic(t *testing.T) {
 
 	err = actions.SetAllAdapterResponsesToTheSameValueLocal(10, ocrInstances, workerNodes, env.MockAdapter)
 	require.NoError(t, err)
-	err = actions.StartNewRound(2, ocrInstances, env.EVMClient, l)
+	err = actions.WatchNewRound(2, ocrInstances, env.EVMClient, l)
 	require.NoError(t, err)
 
 	answer, err = ocrInstances[0].GetLatestAnswer(testcontext.Get(t))
@@ -94,7 +94,7 @@ func TestOCRJobReplacement(t *testing.T) {
 	err = actions.CreateOCRJobsLocal(ocrInstances, bootstrapNode, workerNodes, 5, env.MockAdapter, env.EVMClient.GetChainID())
 	require.NoError(t, err)
 
-	err = actions.StartNewRound(1, ocrInstances, env.EVMClient, l)
+	err = actions.WatchNewRound(1, ocrInstances, env.EVMClient, l)
 	require.NoError(t, err)
 
 	answer, err := ocrInstances[0].GetLatestAnswer(testcontext.Get(t))
@@ -103,7 +103,7 @@ func TestOCRJobReplacement(t *testing.T) {
 
 	err = actions.SetAllAdapterResponsesToTheSameValueLocal(10, ocrInstances, workerNodes, env.MockAdapter)
 	require.NoError(t, err)
-	err = actions.StartNewRound(2, ocrInstances, env.EVMClient, l)
+	err = actions.WatchNewRound(2, ocrInstances, env.EVMClient, l)
 	require.NoError(t, err)
 
 	answer, err = ocrInstances[0].GetLatestAnswer(testcontext.Get(t))
@@ -120,7 +120,7 @@ func TestOCRJobReplacement(t *testing.T) {
 	err = actions.CreateOCRJobsLocal(ocrInstances, bootstrapNode, workerNodes, 5, env.MockAdapter, env.EVMClient.GetChainID())
 	require.NoError(t, err)
 
-	err = actions.StartNewRound(1, ocrInstances, env.EVMClient, l)
+	err = actions.WatchNewRound(1, ocrInstances, env.EVMClient, l)
 	require.NoError(t, err)
 
 	answer, err = ocrInstances[0].GetLatestAnswer(testcontext.Get(t))


### PR DESCRIPTION
We shouldn't change the API value **and** explicitly ask for a new round. This can cause weird behavior and flakes.