### PR TITLE
Refactoring Test_Client_LatestReport to parameterized test

### DIFF
--- a/core/services/relay/evm/mercury/wsrpc/client_test.go
+++ b/core/services/relay/evm/mercury/wsrpc/client_test.go
@@ -120,97 +120,59 @@ func Test_Client_Transmit(t *testing.T) {
 func Test_Client_LatestReport(t *testing.T) {
 	lggr := logger.TestLogger(t)
 	ctx := testutils.Context(t)
+	cacheReads := 5
 
-	t.Run("with nil cache", func(t *testing.T) {
-		req := &pb.LatestReportRequest{}
-		noopCacheSet := newNoopCacheSet()
-		resp := &pb.LatestReportResponse{}
+	tests := []struct {
+		name          string
+		ttl           time.Duration
+		expectedCalls int
+	}{
+		{
+			name:          "with cache disabled",
+			ttl:           0,
+			expectedCalls: 5,
+		},
+		{
+			name:          "with cache enabled",
+			ttl:           1000 * time.Hour, //some large value that will never expire during a test
+			expectedCalls: 1,
+		},
+	}
 
-		wsrpcClient := &mocks.MockWSRPCClient{
-			LatestReportF: func(ctx context.Context, in *pb.LatestReportRequest) (*pb.LatestReportResponse, error) {
-				assert.Equal(t, req, in)
-				return resp, nil
-			},
-		}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := &pb.LatestReportRequest{}
 
-		conn := &mocks.MockConn{
-			Ready: true,
-		}
-		c := newClient(lggr, csakey.KeyV2{}, nil, "", noopCacheSet)
-		c.conn = conn
-		c.rawClient = wsrpcClient
-		require.NoError(t, c.StartOnce("Mock WSRPC Client", func() error { return nil }))
+			cacheSet := cache.NewCacheSet(lggr, cache.Config{LatestReportTTL: tt.ttl})
 
-		r, err := c.LatestReport(ctx, req)
+			resp := &pb.LatestReportResponse{}
 
-		require.NoError(t, err)
-		assert.Equal(t, resp, r)
-	})
+			var calls int
+			wsrpcClient := &mocks.MockWSRPCClient{
+				LatestReportF: func(ctx context.Context, in *pb.LatestReportRequest) (*pb.LatestReportResponse, error) {
+					calls++
+					assert.Equal(t, req, in)
+					return resp, nil
+				},
+			}
 
-	t.Run("with cache disabled", func(t *testing.T) {
-		req := &pb.LatestReportRequest{}
-		cacheSet := cache.NewCacheSet(lggr, cache.Config{LatestReportTTL: 0})
-		resp := &pb.LatestReportResponse{}
+			conn := &mocks.MockConn{
+				Ready: true,
+			}
+			c := newClient(lggr, csakey.KeyV2{}, nil, "", cacheSet)
+			c.conn = conn
+			c.rawClient = wsrpcClient
 
-		var calls int
-		wsrpcClient := &mocks.MockWSRPCClient{
-			LatestReportF: func(ctx context.Context, in *pb.LatestReportRequest) (*pb.LatestReportResponse, error) {
-				calls++
-				assert.Equal(t, req, in)
-				return resp, nil
-			},
-		}
+			servicetest.Run(t, cacheSet)
+			simulateStart(ctx, t, c)
 
-		conn := &mocks.MockConn{
-			Ready: true,
-		}
-		c := newClient(lggr, csakey.KeyV2{}, nil, "", cacheSet)
-		c.conn = conn
-		c.rawClient = wsrpcClient
+			for i := 0; i < cacheReads; i++ {
+				r, err := c.LatestReport(ctx, req)
 
-		servicetest.Run(t, cacheSet)
-		simulateStart(ctx, t, c)
-
-		for i := 0; i < 5; i++ {
-			r, err := c.LatestReport(ctx, req)
-
-			require.NoError(t, err)
-			assert.Equal(t, resp, r)
-		}
-		assert.Equal(t, 5, calls, "expected 5 calls to LatestReport but it was called %d times", calls)
-	})
-
-	t.Run("with caching", func(t *testing.T) {
-		req := &pb.LatestReportRequest{}
-		const neverExpireTTL = 1000 * time.Hour // some massive value that will never expire during a test
-		cacheSet := cache.NewCacheSet(lggr, cache.Config{LatestReportTTL: neverExpireTTL})
-		resp := &pb.LatestReportResponse{}
-
-		var calls int
-		wsrpcClient := &mocks.MockWSRPCClient{
-			LatestReportF: func(ctx context.Context, in *pb.LatestReportRequest) (*pb.LatestReportResponse, error) {
-				calls++
-				assert.Equal(t, req, in)
-				return resp, nil
-			},
-		}
-
-		conn := &mocks.MockConn{
-			Ready: true,
-		}
-		c := newClient(lggr, csakey.KeyV2{}, nil, "", cacheSet)
-		c.conn = conn
-		c.rawClient = wsrpcClient
-
-		servicetest.Run(t, cacheSet)
-		simulateStart(ctx, t, c)
-
-		for i := 0; i < 5; i++ {
-			r, err := c.LatestReport(ctx, req)
-
-			require.NoError(t, err)
-			assert.Equal(t, resp, r)
-		}
-		assert.Equal(t, 1, calls, "expected only 1 call to LatestReport but it was called %d times", calls)
-	})
+				require.NoError(t, err)
+				assert.Equal(t, resp, r)
+			}
+			assert.Equal(t, tt.expectedCalls, calls, "expected %d calls to LatestReport but it was called %d times", tt.expectedCalls, calls)
+		})
+	}
 }


### PR DESCRIPTION
Test_Client_LatestReport now: 
* is parameterized
* removes a nil cacheset test that was not adding to coverage