### PR TITLE
add .env example for debugging script

### DIFF
--- a/core/scripts/chaincli/.env.debugging.example
+++ b/core/scripts/chaincli/.env.debugging.example
@@ -1,0 +1,15 @@
+# [Mandatory] http url of the archival node for your network
+NODE_URL=<Https RPC Archival Node Addr>
+# [Mandatory] address of the KeeperRegistry contract for your upkeep
+KEEPER_REGISTRY_ADDRESS=<Registry Address>
+
+# [Optional] it is strongly recommended (not mandatory) to use tenderly for more debugging info
+#TENDERLY_KEY=<Tenderly Key>
+#TENDERLY_ACCOUNT_NAME=<Tenderly Account Name>
+#TENDERLY_PROJECT_NAME=<Tenderly Project Name>
+
+# [Optional] add mercury info only if your upkeep uses mercury
+#MERCURY_ID=<Mercury ID>
+#MERCURY_KEY=<Mercury Key>
+#MERCURY_LEGACY_URL=<Mercury Legacy URL>
+#MERCURY_URL=<Mercury Server URL>


### PR DESCRIPTION
The existing .env.example is for chaincli, and it is pretty complicated. 

For debugging script, we need just a few lines of configuration. Hence we created this .env for debugging script use case.