### PR TITLE
Split automation-01 ci job out to multiple jobs

### DIFF
--- a/integration-tests/scripts/buildTestMatrixList.sh
+++ b/integration-tests/scripts/buildTestMatrixList.sh
@@ -40,24 +40,26 @@ jq -c '.tests[]' ${JSONFILE} | while read -r test; do
   effective_node_count=${node_count:-$NODE_COUNT}
   subTests=$(echo ${test} | jq -r '.run[]?.name // empty')
   output=""
+
+  if [ $COUNTER -ne 1 ]; then
+      echo -n ","
+  fi
   
   # Loop through subtests, if any, and print in the desired format
   if [ -n "$subTests" ]; then
+    subTestString=""
+    subTestCounter=1
     for subTest in $subTests; do
-      if [ $COUNTER -ne 1 ]; then
-        echo -n ","
+      if [ $subTestCounter -ne 1 ]; then
+        subTestString+="|"
       fi
-      matrix_output $COUNTER $MATRIX_JOB_NAME "${testName}/${subTest}" ${effective_node_label} ${effective_node_count}
-      ((COUNTER++))
+      subTestString+="${testName}\/${subTest}"
+      ((subTestCounter++))
     done
-  else
-    if [ $COUNTER -ne 1 ]; then
-      echo -n ","
-    fi
-    matrix_output $COUNTER $MATRIX_JOB_NAME "${testName}" ${effective_node_label} ${effective_node_count}
-    ((COUNTER++))
+    testName="${subTestString}"
   fi
-
+  matrix_output $COUNTER $MATRIX_JOB_NAME "${testName}" ${effective_node_label} ${effective_node_count}
+  ((COUNTER++))
 done > "./tmpout.json"
 OUTPUT=$(cat ./tmpout.json)
 echo "[${OUTPUT}]"

--- a/integration-tests/smoke/automation_test.go
+++ b/integration-tests/smoke/automation_test.go
@@ -90,9 +90,9 @@ func SetupAutomationBasic(t *testing.T, nodeUpgrade bool) {
 		"registry_2_1_with_logtrigger_and_mercury_v02": ethereum.RegistryVersion_2_1,
 	}
 
-	for n, rv := range registryVersions {
-		name := n
-		registryVersion := rv
+	for name, registryVersion := range registryVersions {
+		name := name
+		registryVersion := registryVersion
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			l := logging.GetTestLogger(t)
@@ -168,7 +168,7 @@ func SetupAutomationBasic(t *testing.T, nodeUpgrade bool) {
 					g.Expect(counter.Int64()).Should(gomega.BeNumerically(">=", int64(expect)),
 						"Expected consumer counter to be greater than %d, but got %d", expect, counter.Int64())
 				}
-			}, "5m", "1s").Should(gomega.Succeed()) // ~1m for cluster setup, ~2m for performing each upkeep 5 times, ~2m buffer
+			}, "10m", "1s").Should(gomega.Succeed()) // ~1m for cluster setup, ~2m for performing each upkeep 5 times, ~2m buffer
 
 			l.Info().Msgf("Total time taken to get 5 performs for each upkeep: %s", time.Since(startTime))
 
@@ -400,9 +400,9 @@ func TestAutomationAddFunds(t *testing.T) {
 		"registry_2_1": ethereum.RegistryVersion_2_1,
 	}
 
-	for n, rv := range registryVersions {
-		name := n
-		registryVersion := rv
+	for name, registryVersion := range registryVersions {
+		name := name
+		registryVersion := registryVersion
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			a := setupAutomationTestDocker(
@@ -557,9 +557,9 @@ func TestAutomationRegisterUpkeep(t *testing.T) {
 		"registry_2_1": ethereum.RegistryVersion_2_1,
 	}
 
-	for n, rv := range registryVersions {
-		name := n
-		registryVersion := rv
+	for name, registryVersion := range registryVersions {
+		name := name
+		registryVersion := registryVersion
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			l := logging.GetTestLogger(t)
@@ -641,9 +641,9 @@ func TestAutomationPauseRegistry(t *testing.T) {
 		"registry_2_1": ethereum.RegistryVersion_2_1,
 	}
 
-	for n, rv := range registryVersions {
-		name := n
-		registryVersion := rv
+	for name, registryVersion := range registryVersions {
+		name := name
+		registryVersion := registryVersion
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			a := setupAutomationTestDocker(
@@ -710,9 +710,9 @@ func TestAutomationKeeperNodesDown(t *testing.T) {
 		"registry_2_1": ethereum.RegistryVersion_2_1,
 	}
 
-	for n, rv := range registryVersions {
-		name := n
-		registryVersion := rv
+	for name, registryVersion := range registryVersions {
+		name := name
+		registryVersion := registryVersion
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			l := logging.GetTestLogger(t)
@@ -810,9 +810,9 @@ func TestAutomationPerformSimulation(t *testing.T) {
 		"registry_2_1": ethereum.RegistryVersion_2_1,
 	}
 
-	for n, rv := range registryVersions {
-		name := n
-		registryVersion := rv
+	for name, registryVersion := range registryVersions {
+		name := name
+		registryVersion := registryVersion
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			a := setupAutomationTestDocker(
@@ -873,9 +873,9 @@ func TestAutomationCheckPerformGasLimit(t *testing.T) {
 		"registry_2_1": ethereum.RegistryVersion_2_1,
 	}
 
-	for n, rv := range registryVersions {
-		name := n
-		registryVersion := rv
+	for name, registryVersion := range registryVersions {
+		name := name
+		registryVersion := registryVersion
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			l := logging.GetTestLogger(t)
@@ -987,9 +987,9 @@ func TestUpdateCheckData(t *testing.T) {
 		"registry_2_1": ethereum.RegistryVersion_2_1,
 	}
 
-	for n, rv := range registryVersions {
-		name := n
-		registryVersion := rv
+	for name, registryVersion := range registryVersions {
+		name := name
+		registryVersion := registryVersion
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			l := logging.GetTestLogger(t)

--- a/integration-tests/smoke/automation_test.go_test_list.json
+++ b/integration-tests/smoke/automation_test.go_test_list.json
@@ -2,8 +2,30 @@
   "tests": [
     {
       "name": "TestAutomationBasic",
-      "label": "ubuntu-latest-32cores-128GB",
-      "nodes": 6
+      "label": "ubuntu-latest",
+      "nodes": 2,
+      "run":[
+        {"name":"registry_2_0"},
+        {"name":"registry_2_1_conditional"}
+      ]
+    },
+    {
+      "name": "TestAutomationBasic",
+      "label": "ubuntu-latest",
+      "nodes": 2,
+      "run":[
+        {"name":"registry_2_1_logtrigger"},
+        {"name":"registry_2_1_with_mercury_v02"}
+      ]
+    },
+    {
+      "name": "TestAutomationBasic",
+      "label": "ubuntu-latest",
+      "nodes": 2,
+      "run":[
+        {"name":"registry_2_1_with_mercury_v03"},
+        {"name":"registry_2_1_with_logtrigger_and_mercury_v02"}
+      ]
     },
     {
       "name": "TestSetUpkeepTriggerConfig"


### PR DESCRIPTION
This was our single slowest job holding up the e2e pipeline by about 4 extra minutes. Even the bigger runner did not cut the time back as much as hoped. This breaks it out into 3 jobs that can run in the free runners and is now no longer the bottleneck.