### PR TITLE
[TT-792] Uses Human Friendly CL Node Logs as Default

### DIFF
--- a/integration-tests/docker/test_env/test_env_builder.go
+++ b/integration-tests/docker/test_env/test_env_builder.go
@@ -265,7 +265,7 @@ func (b *CLTestEnvBuilder) Build() (*CLClusterTestEnv, error) {
 
 	if b.te.LogStream != nil {
 		b.t.Cleanup(func() {
-			b.l.Warn().Msg("Shutting down LogStream")
+			b.l.Debug().Msg("Shutting down LogStream")
 			logPath, err := osutil.GetAbsoluteFolderPath("logs")
 			if err != nil {
 				b.l.Info().Str("Absolute path", logPath).Msg("LogStream logs folder location")

--- a/integration-tests/docker/test_env/test_env_builder.go
+++ b/integration-tests/docker/test_env/test_env_builder.go
@@ -273,11 +273,13 @@ func (b *CLTestEnvBuilder) Build() (*CLClusterTestEnv, error) {
 
 			if b.t.Failed() || os.Getenv("TEST_LOG_COLLECT") == "true" {
 				// we can't do much if this fails, so we just log the error in logstream
-				_ = b.te.LogStream.FlushAndShutdown()
+				err = b.te.LogStream.FlushAndShutdown()
+				if err != nil {
+					b.l.Error().Err(err).Msg("Error flushing and shutting down LogStream")
+				}
 				b.te.LogStream.PrintLogTargetsLocations()
 				b.te.LogStream.SaveLogLocationInTestSummary()
 			}
-
 		})
 	}
 

--- a/integration-tests/smoke/automation_test.go
+++ b/integration-tests/smoke/automation_test.go
@@ -1071,6 +1071,7 @@ func setupAutomationTestDocker(
 	registryConfig.RegistryVersion = registryVersion
 	network := networks.MustGetSelectedNetworksFromEnv()[0]
 
+	// TODO: This should be updated to the new config builder model
 	// build the node config
 	clNodeConfig := node.NewConfig(node.NewBaseConfig())
 	syncInterval := models.MustMakeDuration(5 * time.Minute)
@@ -1081,6 +1082,7 @@ func setupAutomationTestDocker(
 	clNodeConfig.Keeper.Registry.PerformGasOverhead = ptr.Ptr[uint32](uint32(150000))
 	clNodeConfig.P2P.V2.AnnounceAddresses = &[]string{"0.0.0.0:6690"}
 	clNodeConfig.P2P.V2.ListenAddresses = &[]string{"0.0.0.0:6690"}
+	clNodeConfig.Log.JSONConsole = ptr.Ptr[bool](false) // Sets human-readable logs
 
 	//launch the environment
 	var env *test_env.CLClusterTestEnv

--- a/integration-tests/smoke/cron_test.go
+++ b/integration-tests/smoke/cron_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/integration-tests/client"
 	"github.com/smartcontractkit/chainlink/integration-tests/docker/test_env"
+	"github.com/smartcontractkit/chainlink/integration-tests/types/config/node"
 )
 
 func TestCronBasic(t *testing.T) {
@@ -23,6 +24,7 @@ func TestCronBasic(t *testing.T) {
 		WithTestInstance(t).
 		WithGeth().
 		WithMockAdapter().
+		WithCLNodeConfig(node.NewConfig(node.NewBaseConfig(), node.WithHumanLogs())).
 		WithCLNodes(1).
 		WithStandardCleanup().
 		WithLogStream().

--- a/integration-tests/smoke/flux_test.go
+++ b/integration-tests/smoke/flux_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/smartcontractkit/chainlink/integration-tests/client"
 	"github.com/smartcontractkit/chainlink/integration-tests/contracts"
 	"github.com/smartcontractkit/chainlink/integration-tests/docker/test_env"
+	"github.com/smartcontractkit/chainlink/integration-tests/types/config/node"
 )
 
 func TestFluxBasic(t *testing.T) {
@@ -29,6 +30,7 @@ func TestFluxBasic(t *testing.T) {
 		WithTestInstance(t).
 		WithGeth().
 		WithMockAdapter().
+		WithCLNodeConfig(node.NewConfig(node.NewBaseConfig(), node.WithHumanLogs())).
 		WithCLNodes(3).
 		WithStandardCleanup().
 		WithLogStream().

--- a/integration-tests/smoke/forwarder_ocr_test.go
+++ b/integration-tests/smoke/forwarder_ocr_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/integration-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/docker/test_env"
+	"github.com/smartcontractkit/chainlink/integration-tests/types/config/node"
 )
 
 func TestForwarderOCRBasic(t *testing.T) {
@@ -23,6 +24,7 @@ func TestForwarderOCRBasic(t *testing.T) {
 		WithGeth().
 		WithMockAdapter().
 		WithForwarders().
+		WithCLNodeConfig(node.NewConfig(node.NewBaseConfig(), node.WithHumanLogs())).
 		WithCLNodes(6).
 		WithFunding(big.NewFloat(.1)).
 		WithStandardCleanup().

--- a/integration-tests/smoke/forwarders_ocr2_test.go
+++ b/integration-tests/smoke/forwarders_ocr2_test.go
@@ -30,6 +30,7 @@ func TestForwarderOCR2Basic(t *testing.T) {
 		WithCLNodeConfig(node.NewConfig(node.NewBaseConfig(),
 			node.WithOCR2(),
 			node.WithP2Pv2(),
+			node.WithHumanLogs(),
 		)).
 		WithForwarders().
 		WithCLNodes(6).

--- a/integration-tests/smoke/ocr2_test.go
+++ b/integration-tests/smoke/ocr2_test.go
@@ -132,6 +132,7 @@ func TestOCRv2Request(t *testing.T) {
 			node.WithOCR2(),
 			node.WithP2Pv2(),
 			node.WithTracing(),
+			node.WithHumanLogs(),
 		)).
 		WithCLNodes(6).
 		WithFunding(big.NewFloat(.1)).

--- a/integration-tests/smoke/ocr2_test.go
+++ b/integration-tests/smoke/ocr2_test.go
@@ -12,11 +12,12 @@ import (
 	"github.com/smartcontractkit/chainlink-testing-framework/logging"
 	"github.com/smartcontractkit/chainlink-testing-framework/utils/testcontext"
 
+	"github.com/smartcontractkit/chainlink/v2/core/config/env"
+
 	"github.com/smartcontractkit/chainlink/integration-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/contracts"
 	"github.com/smartcontractkit/chainlink/integration-tests/docker/test_env"
 	"github.com/smartcontractkit/chainlink/integration-tests/types/config/node"
-	"github.com/smartcontractkit/chainlink/v2/core/config/env"
 )
 
 // Tests a basic OCRv2 median feed
@@ -47,6 +48,7 @@ func TestOCRv2Basic(t *testing.T) {
 					node.WithOCR2(),
 					node.WithP2Pv2(),
 					node.WithTracing(),
+					node.WithHumanLogs(),
 				)).
 				WithCLNodeOptions(test_env.WithNodeEnvVars(test.env)).
 				WithCLNodes(6).

--- a/integration-tests/smoke/ocr2_test.go
+++ b/integration-tests/smoke/ocr2_test.go
@@ -47,7 +47,7 @@ func TestOCRv2Basic(t *testing.T) {
 				WithCLNodeConfig(node.NewConfig(node.NewBaseConfig(),
 					node.WithOCR2(),
 					node.WithP2Pv2(),
-					node.WithTracing(),
+					// node.WithTracing(),
 					node.WithHumanLogs(),
 				)).
 				WithCLNodeOptions(test_env.WithNodeEnvVars(test.env)).

--- a/integration-tests/smoke/ocr2vrf_test.go
+++ b/integration-tests/smoke/ocr2vrf_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestOCR2VRFRedeemModel(t *testing.T) {
 	t.Parallel()
-	t.Skip("VRFv3 is on pause, skipping")
+	t.Skip("OCR2VRF is on pause, skipping")
 	l := logging.GetTestLogger(t)
 	testEnvironment, testNetwork := setupOCR2VRFEnvironment(t)
 	if testEnvironment.WillUseRemoteRunner() {
@@ -89,7 +89,7 @@ func TestOCR2VRFRedeemModel(t *testing.T) {
 
 func TestOCR2VRFFulfillmentModel(t *testing.T) {
 	t.Parallel()
-	t.Skip("VRFv3 is on pause, skipping")
+	t.Skip("OCR2VRF is on pause, skipping")
 	l := logging.GetTestLogger(t)
 	testEnvironment, testNetwork := setupOCR2VRFEnvironment(t)
 	if testEnvironment.WillUseRemoteRunner() {

--- a/integration-tests/smoke/ocr_test.go
+++ b/integration-tests/smoke/ocr_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/integration-tests/actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/docker/test_env"
+	"github.com/smartcontractkit/chainlink/integration-tests/types/config/node"
 )
 
 func TestOCRBasic(t *testing.T) {
@@ -73,6 +74,7 @@ func TestOCRJobReplacement(t *testing.T) {
 		WithGeth().
 		WithMockAdapter().
 		WithCLNodes(6).
+		WithCLNodeConfig(node.NewConfig(node.NewBaseConfig(), node.WithHumanLogs())).
 		WithFunding(big.NewFloat(.1)).
 		WithStandardCleanup().
 		Build()

--- a/integration-tests/smoke/ocr_test.go
+++ b/integration-tests/smoke/ocr_test.go
@@ -25,6 +25,7 @@ func TestOCRBasic(t *testing.T) {
 		WithTestInstance(t).
 		WithPrivateEthereumNetwork(network).
 		WithMockAdapter().
+		WithCLNodeConfig(node.NewConfig(node.NewBaseConfig(), node.WithHumanLogs())).
 		WithCLNodes(6).
 		WithFunding(big.NewFloat(.5)).
 		WithStandardCleanup().

--- a/integration-tests/smoke/runlog_test.go
+++ b/integration-tests/smoke/runlog_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/integration-tests/client"
 	"github.com/smartcontractkit/chainlink/integration-tests/docker/test_env"
+	"github.com/smartcontractkit/chainlink/integration-tests/types/config/node"
 )
 
 func TestRunLogBasic(t *testing.T) {
@@ -26,6 +27,7 @@ func TestRunLogBasic(t *testing.T) {
 		WithTestInstance(t).
 		WithGeth().
 		WithMockAdapter().
+		WithCLNodeConfig(node.NewConfig(node.NewBaseConfig(), node.WithHumanLogs())).
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(.1)).
 		WithStandardCleanup().

--- a/integration-tests/smoke/vrf_test.go
+++ b/integration-tests/smoke/vrf_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/smartcontractkit/chainlink/integration-tests/actions/vrfv1"
 	"github.com/smartcontractkit/chainlink/integration-tests/client"
 	"github.com/smartcontractkit/chainlink/integration-tests/docker/test_env"
+	"github.com/smartcontractkit/chainlink/integration-tests/types/config/node"
 )
 
 func TestVRFBasic(t *testing.T) {
@@ -26,6 +27,7 @@ func TestVRFBasic(t *testing.T) {
 	env, err := test_env.NewCLTestEnvBuilder().
 		WithTestInstance(t).
 		WithGeth().
+		WithCLNodeConfig(node.NewConfig(node.NewBaseConfig(), node.WithHumanLogs())).
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(.1)).
 		WithStandardCleanup().

--- a/integration-tests/smoke/vrfv2_test.go
+++ b/integration-tests/smoke/vrfv2_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/smartcontractkit/chainlink/integration-tests/actions/vrfv2_actions"
 	"github.com/smartcontractkit/chainlink/integration-tests/actions/vrfv2_actions/vrfv2_config"
 	"github.com/smartcontractkit/chainlink/integration-tests/docker/test_env"
+	"github.com/smartcontractkit/chainlink/integration-tests/types/config/node"
 )
 
 func TestVRFv2Basic(t *testing.T) {
@@ -36,6 +37,7 @@ func TestVRFv2Basic(t *testing.T) {
 	env, err := test_env.NewCLTestEnvBuilder().
 		WithTestInstance(t).
 		WithPrivateEthereumNetwork(network).
+		WithCLNodeConfig(node.NewConfig(node.NewBaseConfig(), node.WithHumanLogs())).
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(vrfv2Config.ChainlinkNodeFunding)).
 		WithStandardCleanup().

--- a/integration-tests/smoke/vrfv2plus_test.go
+++ b/integration-tests/smoke/vrfv2plus_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/smartcontractkit/chainlink/integration-tests/actions/vrfv2plus"
 	"github.com/smartcontractkit/chainlink/integration-tests/actions/vrfv2plus/vrfv2plus_config"
 	"github.com/smartcontractkit/chainlink/integration-tests/docker/test_env"
+	"github.com/smartcontractkit/chainlink/integration-tests/types/config/node"
 	it_utils "github.com/smartcontractkit/chainlink/integration-tests/utils"
 )
 
@@ -39,6 +40,7 @@ func TestVRFv2Plus(t *testing.T) {
 	env, err := test_env.NewCLTestEnvBuilder().
 		WithTestInstance(t).
 		WithPrivateEthereumNetwork(network).
+		WithCLNodeConfig(node.NewConfig(node.NewBaseConfig(), node.WithHumanLogs())).
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(vrfv2PlusConfig.ChainlinkNodeFunding)).
 		WithStandardCleanup().

--- a/integration-tests/types/config/node/core.go
+++ b/integration-tests/types/config/node/core.go
@@ -119,6 +119,13 @@ func WithP2Pv2() NodeConfigOpt {
 	}
 }
 
+// WithHumanLogs disables JSONConsole logging and uses human readable, structured logs
+func WithHumanLogs() NodeConfigOpt {
+	return func(c *chainlink.Config) {
+		c.Core.Log.JSONConsole = ptr.Ptr(false)
+	}
+}
+
 func WithTracing() NodeConfigOpt {
 	return func(c *chainlink.Config) {
 		c.Tracing = toml.Tracing{


### PR DESCRIPTION
Adds and makes use of the config option `node.WithHumanLogs()` for better debugging Chainlink node logs.