### PR TITLE
[TT-757] enable log stream in test env builder by default

### DIFF
--- a/integration-tests/docker/test_env/test_env_builder.go
+++ b/integration-tests/docker/test_env/test_env_builder.go
@@ -59,7 +59,8 @@ type CLTestEnvBuilder struct {
 
 func NewCLTestEnvBuilder() *CLTestEnvBuilder {
 	return &CLTestEnvBuilder{
-		l: log.Logger,
+		l:            log.Logger,
+		hasLogStream: true,
 	}
 }
 
@@ -101,8 +102,9 @@ func (b *CLTestEnvBuilder) WithTestInstance(t *testing.T) *CLTestEnvBuilder {
 	return b
 }
 
-func (b *CLTestEnvBuilder) WithLogStream() *CLTestEnvBuilder {
-	b.hasLogStream = true
+// WithoutLogStream disables LogStream logging component
+func (b *CLTestEnvBuilder) WithoutLogStream() *CLTestEnvBuilder {
+	b.hasLogStream = false
 	return b
 }
 

--- a/integration-tests/load/vrfv2/vrfv2_test.go
+++ b/integration-tests/load/vrfv2/vrfv2_test.go
@@ -184,7 +184,6 @@ func TestVRFV2Performance(t *testing.T) {
 						l.Error().Err(err).Msg("Error cleaning up test environment")
 					}
 				}).
-			WithLogStream().
 			Build()
 
 		require.NoError(t, err, "error creating test env")

--- a/integration-tests/load/vrfv2plus/vrfv2plus_test.go
+++ b/integration-tests/load/vrfv2plus/vrfv2plus_test.go
@@ -189,7 +189,6 @@ func TestVRFV2PlusPerformance(t *testing.T) {
 						l.Error().Err(err).Msg("Error cleaning up test environment")
 					}
 				}).
-			WithLogStream().
 			Build()
 
 		require.NoError(t, err, "error creating test env")

--- a/integration-tests/smoke/automation_test.go
+++ b/integration-tests/smoke/automation_test.go
@@ -1097,7 +1097,6 @@ func setupAutomationTestDocker(
 			WithMockAdapter().
 			WithFunding(big.NewFloat(testConfig.ChainlinkNodeFunding)).
 			WithStandardCleanup().
-			WithLogStream().
 			Build()
 		require.NoError(t, err, "Error deploying test environment for Mercury")
 		env.ParallelTransactions(true)

--- a/integration-tests/smoke/cron_test.go
+++ b/integration-tests/smoke/cron_test.go
@@ -25,7 +25,6 @@ func TestCronBasic(t *testing.T) {
 		WithMockAdapter().
 		WithCLNodes(1).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err)
 
@@ -72,7 +71,6 @@ func TestCronJobReplacement(t *testing.T) {
 		WithMockAdapter().
 		WithCLNodes(1).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err)
 

--- a/integration-tests/smoke/flux_test.go
+++ b/integration-tests/smoke/flux_test.go
@@ -31,7 +31,6 @@ func TestFluxBasic(t *testing.T) {
 		WithMockAdapter().
 		WithCLNodes(3).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err)
 

--- a/integration-tests/smoke/forwarder_ocr_test.go
+++ b/integration-tests/smoke/forwarder_ocr_test.go
@@ -26,7 +26,6 @@ func TestForwarderOCRBasic(t *testing.T) {
 		WithCLNodes(6).
 		WithFunding(big.NewFloat(.1)).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err)
 

--- a/integration-tests/smoke/forwarders_ocr2_test.go
+++ b/integration-tests/smoke/forwarders_ocr2_test.go
@@ -35,7 +35,6 @@ func TestForwarderOCR2Basic(t *testing.T) {
 		WithCLNodes(6).
 		WithFunding(big.NewFloat(.1)).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err)
 

--- a/integration-tests/smoke/keeper_test.go
+++ b/integration-tests/smoke/keeper_test.go
@@ -1113,7 +1113,6 @@ func setupKeeperTest(t *testing.T) (
 		WithCLNodeConfig(clNodeConfig).
 		WithFunding(big.NewFloat(.5)).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err, "Error deploying test environment")
 

--- a/integration-tests/smoke/ocr2_test.go
+++ b/integration-tests/smoke/ocr2_test.go
@@ -52,7 +52,6 @@ func TestOCRv2Basic(t *testing.T) {
 				WithCLNodes(6).
 				WithFunding(big.NewFloat(.1)).
 				WithStandardCleanup().
-				WithLogStream().
 				Build()
 			require.NoError(t, err)
 
@@ -134,7 +133,6 @@ func TestOCRv2Request(t *testing.T) {
 		WithCLNodes(6).
 		WithFunding(big.NewFloat(.1)).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err)
 
@@ -210,7 +208,6 @@ func TestOCRv2JobReplacement(t *testing.T) {
 		WithCLNodes(6).
 		WithFunding(big.NewFloat(.1)).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err)
 

--- a/integration-tests/smoke/ocr_test.go
+++ b/integration-tests/smoke/ocr_test.go
@@ -27,7 +27,6 @@ func TestOCRBasic(t *testing.T) {
 		WithCLNodes(6).
 		WithFunding(big.NewFloat(.5)).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err)
 

--- a/integration-tests/smoke/runlog_test.go
+++ b/integration-tests/smoke/runlog_test.go
@@ -29,7 +29,6 @@ func TestRunLogBasic(t *testing.T) {
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(.1)).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err)
 

--- a/integration-tests/smoke/vrf_test.go
+++ b/integration-tests/smoke/vrf_test.go
@@ -29,7 +29,6 @@ func TestVRFBasic(t *testing.T) {
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(.1)).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err)
 	env.ParallelTransactions(true)
@@ -119,7 +118,6 @@ func TestVRFJobReplacement(t *testing.T) {
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(.1)).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err)
 	env.ParallelTransactions(true)

--- a/integration-tests/smoke/vrfv2_test.go
+++ b/integration-tests/smoke/vrfv2_test.go
@@ -39,7 +39,6 @@ func TestVRFv2Basic(t *testing.T) {
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(vrfv2Config.ChainlinkNodeFunding)).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err, "error creating test env")
 
@@ -371,7 +370,6 @@ func TestVRFv2MultipleSendingKeys(t *testing.T) {
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(vrfv2Config.ChainlinkNodeFunding)).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err, "error creating test env")
 

--- a/integration-tests/smoke/vrfv2plus_test.go
+++ b/integration-tests/smoke/vrfv2plus_test.go
@@ -42,7 +42,6 @@ func TestVRFv2Plus(t *testing.T) {
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(vrfv2PlusConfig.ChainlinkNodeFunding)).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err, "error creating test env")
 
@@ -622,7 +621,6 @@ func TestVRFv2PlusMultipleSendingKeys(t *testing.T) {
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(vrfv2PlusConfig.ChainlinkNodeFunding)).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err, "error creating test env")
 
@@ -713,7 +711,6 @@ func TestVRFv2PlusMigration(t *testing.T) {
 		WithCLNodes(1).
 		WithFunding(big.NewFloat(vrfv2PlusConfig.ChainlinkNodeFunding)).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err, "error creating test env")
 	env.ParallelTransactions(true)

--- a/integration-tests/universal/log_poller/helpers.go
+++ b/integration-tests/universal/log_poller/helpers.go
@@ -1060,7 +1060,6 @@ func setupLogPollerTestDocker(
 		WithChainOptions(logPolllerSettingsFn).
 		EVMClientNetworkOptions(evmClientSettingsFn).
 		WithStandardCleanup().
-		WithLogStream().
 		Build()
 	require.NoError(t, err, "Error deploying test environment")
 


### PR DESCRIPTION
previously you needed to explicitly request it, but the opposite seems to have more sense as usually you want to have some logging enabled