### PR TITLE
remove unused references to EventBroadcaster from evm relayer

### DIFF
--- a/core/services/chainlink/relayer_factory.go
+++ b/core/services/chainlink/relayer_factory.go
@@ -67,11 +67,10 @@ func (r *RelayerFactory) NewEVM(ctx context.Context, config EVMFactoryConfig) (m
 		}
 
 		relayerOpts := evmrelay.RelayerOpts{
-			DB:               ccOpts.DB,
-			QConfig:          ccOpts.AppConfig.Database(),
-			CSAETHKeystore:   config.CSAETHKeystore,
-			EventBroadcaster: ccOpts.EventBroadcaster,
-			MercuryPool:      r.MercuryPool,
+			DB:             ccOpts.DB,
+			QConfig:        ccOpts.AppConfig.Database(),
+			CSAETHKeystore: config.CSAETHKeystore,
+			MercuryPool:    r.MercuryPool,
 		}
 		relayer, err2 := evmrelay.NewRelayer(lggr.Named(relayID.ChainID), chain, relayerOpts)
 		if err2 != nil {

--- a/core/services/job/spawner_test.go
+++ b/core/services/job/spawner_test.go
@@ -31,7 +31,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/job/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2"
-	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 	evmrelay "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
@@ -285,10 +284,9 @@ func TestSpawner_CreateJobDeleteJob(t *testing.T) {
 		chain := evmtest.MustGetDefaultChain(t, legacyChains)
 
 		evmRelayer, err := evmrelayer.NewRelayer(lggr, chain, evmrelayer.RelayerOpts{
-			DB:               db,
-			QConfig:          testopts.GeneralConfig.Database(),
-			CSAETHKeystore:   keyStore,
-			EventBroadcaster: pg.NewNullEventBroadcaster(),
+			DB:             db,
+			QConfig:        testopts.GeneralConfig.Database(),
+			CSAETHKeystore: keyStore,
 		})
 		assert.NoError(t, err)
 

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -45,14 +45,13 @@ import (
 var _ commontypes.Relayer = &Relayer{} //nolint:staticcheck
 
 type Relayer struct {
-	db               *sqlx.DB
-	chain            legacyevm.Chain
-	lggr             logger.Logger
-	ks               CSAETHKeystore
-	mercuryPool      wsrpc.Pool
-	eventBroadcaster pg.EventBroadcaster
-	pgCfg            pg.QConfig
-	chainReader      commontypes.ChainReader
+	db          *sqlx.DB
+	chain       legacyevm.Chain
+	lggr        logger.Logger
+	ks          CSAETHKeystore
+	mercuryPool wsrpc.Pool
+	pgCfg       pg.QConfig
+	chainReader commontypes.ChainReader
 }
 
 type CSAETHKeystore interface {
@@ -64,7 +63,6 @@ type RelayerOpts struct {
 	*sqlx.DB
 	pg.QConfig
 	CSAETHKeystore
-	pg.EventBroadcaster
 	MercuryPool wsrpc.Pool
 }
 
@@ -78,9 +76,6 @@ func (c RelayerOpts) Validate() error {
 	}
 	if c.CSAETHKeystore == nil {
 		err = errors.Join(err, errors.New("nil Keystore"))
-	}
-	if c.EventBroadcaster == nil {
-		err = errors.Join(err, errors.New("nil Eventbroadcaster"))
 	}
 
 	if err != nil {
@@ -96,13 +91,12 @@ func NewRelayer(lggr logger.Logger, chain legacyevm.Chain, opts RelayerOpts) (*R
 	}
 	lggr = lggr.Named("Relayer")
 	return &Relayer{
-		db:               opts.DB,
-		chain:            chain,
-		lggr:             lggr,
-		ks:               opts.CSAETHKeystore,
-		mercuryPool:      opts.MercuryPool,
-		eventBroadcaster: opts.EventBroadcaster,
-		pgCfg:            opts.QConfig,
+		db:          opts.DB,
+		chain:       chain,
+		lggr:        lggr,
+		ks:          opts.CSAETHKeystore,
+		mercuryPool: opts.MercuryPool,
+		pgCfg:       opts.QConfig,
 	}, nil
 }
 
@@ -151,7 +145,7 @@ func (r *Relayer) NewMercuryProvider(rargs commontypes.RelayArgs, pargs commonty
 	if relayConfig.ChainID.String() != r.chain.ID().String() {
 		return nil, fmt.Errorf("internal error: chain id in spec does not match this relayer's chain: have %s expected %s", relayConfig.ChainID.String(), r.chain.ID().String())
 	}
-	cw, err := newConfigProvider(lggr, r.chain, relayOpts, r.eventBroadcaster)
+	cw, err := newConfigProvider(lggr, r.chain, relayOpts)
 	if err != nil {
 		return nil, pkgerrors.WithStack(err)
 	}
@@ -210,7 +204,7 @@ func (r *Relayer) NewConfigProvider(args commontypes.RelayArgs) (commontypes.Con
 		return nil, fmt.Errorf("internal error: chain id in spec does not match this relayer's chain: have %s expected %s", relayConfig.ChainID.String(), r.chain.ID().String())
 	}
 
-	configProvider, err := newConfigProvider(lggr, r.chain, relayOpts, r.eventBroadcaster)
+	configProvider, err := newConfigProvider(lggr, r.chain, relayOpts)
 	if err != nil {
 		// Never return (*configProvider)(nil)
 		return nil, err
@@ -320,7 +314,7 @@ func (c *configWatcher) ContractConfigTracker() ocrtypes.ContractConfigTracker {
 	return c.configPoller
 }
 
-func newConfigProvider(lggr logger.Logger, chain legacyevm.Chain, opts *types.RelayOpts, eventBroadcaster pg.EventBroadcaster) (*configWatcher, error) {
+func newConfigProvider(lggr logger.Logger, chain legacyevm.Chain, opts *types.RelayOpts) (*configWatcher, error) {
 	if !common.IsHexAddress(opts.ContractID) {
 		return nil, pkgerrors.Errorf("invalid contractID, expected hex address")
 	}
@@ -464,7 +458,7 @@ func (r *Relayer) NewMedianProvider(rargs commontypes.RelayArgs, pargs commontyp
 	}
 	contractID := common.HexToAddress(relayOpts.ContractID)
 
-	configWatcher, err := newConfigProvider(lggr, r.chain, relayOpts, r.eventBroadcaster)
+	configWatcher, err := newConfigProvider(lggr, r.chain, relayOpts)
 	if err != nil {
 		return nil, err
 	}

--- a/core/services/relay/evm/evm_test.go
+++ b/core/services/relay/evm/evm_test.go
@@ -53,10 +53,9 @@ nil Keystore`,
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			c := evm.RelayerOpts{
-				DB:               tt.fields.DB,
-				QConfig:          tt.fields.QConfig,
-				CSAETHKeystore:   tt.fields.CSAETHKeystore,
-				EventBroadcaster: tt.fields.EventBroadcaster,
+				DB:             tt.fields.DB,
+				QConfig:        tt.fields.QConfig,
+				CSAETHKeystore: tt.fields.CSAETHKeystore,
 			}
 			err := c.Validate()
 			if tt.wantErrContains != "" {

--- a/core/services/relay/evm/evm_test.go
+++ b/core/services/relay/evm/evm_test.go
@@ -15,10 +15,9 @@ import (
 func TestRelayerOpts_Validate(t *testing.T) {
 	cfg := configtest.NewTestGeneralConfig(t)
 	type fields struct {
-		DB               *sqlx.DB
-		QConfig          pg.QConfig
-		CSAETHKeystore   evm.CSAETHKeystore
-		EventBroadcaster pg.EventBroadcaster
+		DB             *sqlx.DB
+		QConfig        pg.QConfig
+		CSAETHKeystore evm.CSAETHKeystore
 	}
 	tests := []struct {
 		name            string
@@ -28,23 +27,19 @@ func TestRelayerOpts_Validate(t *testing.T) {
 		{
 			name: "all invalid",
 			fields: fields{
-				DB:               nil,
-				QConfig:          nil,
-				CSAETHKeystore:   nil,
-				EventBroadcaster: nil,
+				DB:             nil,
+				QConfig:        nil,
+				CSAETHKeystore: nil,
 			},
 			wantErrContains: `nil DB
 nil QConfig
-nil Keystore
-nil Eventbroadcaster`,
+nil Keystore`,
 		},
 		{
 			name: "missing db, keystore",
 			fields: fields{
-				DB:               nil,
-				QConfig:          cfg.Database(),
-				CSAETHKeystore:   nil,
-				EventBroadcaster: pg.NewNullEventBroadcaster(),
+				DB:      nil,
+				QConfig: cfg.Database(),
 			},
 			wantErrContains: `nil DB
 nil Keystore`,


### PR DESCRIPTION
Now that mercury is not using the EventBroadcaster (https://github.com/smartcontractkit/chainlink/commit/80bc9f23d437ac7bc0c9c8f9df40e69b5ddd8675), we can remove it from the evm relayer, too 