### PR TITLE
remove unused eventbroadcaster from legacy evm chains

### DIFF
--- a/core/chains/legacyevm/chain.go
+++ b/core/chains/legacyevm/chain.go
@@ -37,7 +37,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/config"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
-	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 )
 
 //go:generate mockery --quiet --name Chain --output ./mocks/ --case=underscore
@@ -164,9 +163,8 @@ func (c ChainRelayExtenderConfig) Validate() error {
 type ChainOpts struct {
 	AppConfig AppConfig
 
-	EventBroadcaster pg.EventBroadcaster
-	MailMon          *mailbox.Monitor
-	GasEstimator     gas.EvmFeeEstimator
+	MailMon      *mailbox.Monitor
+	GasEstimator gas.EvmFeeEstimator
 
 	*sqlx.DB
 
@@ -185,9 +183,7 @@ func (o ChainOpts) Validate() error {
 	if o.AppConfig == nil {
 		err = errors.Join(err, errors.New("nil AppConfig"))
 	}
-	if o.EventBroadcaster == nil {
-		err = errors.Join(err, errors.New("nil EventBroadcaster"))
-	}
+
 	if o.MailMon == nil {
 		err = errors.Join(err, errors.New("nil MailMon"))
 	}

--- a/core/chains/legacyevm/chain_test.go
+++ b/core/chains/legacyevm/chain_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains/legacyevm/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
-	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 )
 
 func TestLegacyChains(t *testing.T) {
@@ -34,10 +33,9 @@ func TestLegacyChains(t *testing.T) {
 
 func TestChainOpts_Validate(t *testing.T) {
 	type fields struct {
-		AppConfig        legacyevm.AppConfig
-		EventBroadcaster pg.EventBroadcaster
-		MailMon          *mailbox.Monitor
-		DB               *sqlx.DB
+		AppConfig legacyevm.AppConfig
+		MailMon   *mailbox.Monitor
+		DB        *sqlx.DB
 	}
 	tests := []struct {
 		name    string
@@ -47,19 +45,17 @@ func TestChainOpts_Validate(t *testing.T) {
 		{
 			name: "valid",
 			fields: fields{
-				AppConfig:        configtest.NewTestGeneralConfig(t),
-				EventBroadcaster: pg.NewNullEventBroadcaster(),
-				MailMon:          &mailbox.Monitor{},
-				DB:               pgtest.NewSqlxDB(t),
+				AppConfig: configtest.NewTestGeneralConfig(t),
+				MailMon:   &mailbox.Monitor{},
+				DB:        pgtest.NewSqlxDB(t),
 			},
 		},
 		{
 			name: "invalid",
 			fields: fields{
-				AppConfig:        nil,
-				EventBroadcaster: nil,
-				MailMon:          nil,
-				DB:               nil,
+				AppConfig: nil,
+				MailMon:   nil,
+				DB:        nil,
 			},
 			wantErr: true,
 		},
@@ -67,10 +63,9 @@ func TestChainOpts_Validate(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			o := legacyevm.ChainOpts{
-				AppConfig:        tt.fields.AppConfig,
-				EventBroadcaster: tt.fields.EventBroadcaster,
-				MailMon:          tt.fields.MailMon,
-				DB:               tt.fields.DB,
+				AppConfig: tt.fields.AppConfig,
+				MailMon:   tt.fields.MailMon,
+				DB:        tt.fields.DB,
 			}
 			if err := o.Validate(); (err != nil) != tt.wantErr {
 				t.Errorf("ChainOpts.Validate() error = %v, wantErr %v", err, tt.wantErr)

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -176,7 +176,7 @@ func (n ChainlinkAppFactory) NewApplication(ctx context.Context, cfg chainlink.G
 
 	evmFactoryCfg := chainlink.EVMFactoryConfig{
 		CSAETHKeystore: keyStore,
-		ChainOpts:      legacyevm.ChainOpts{AppConfig: cfg, EventBroadcaster: eventBroadcaster, MailMon: mailMon, DB: db},
+		ChainOpts:      legacyevm.ChainOpts{AppConfig: cfg, MailMon: mailMon, DB: db},
 	}
 	// evm always enabled for backward compatibility
 	// TODO BCF-2510 this needs to change in order to clear the path for EVM extraction

--- a/core/cmd/shell_local_test.go
+++ b/core/cmd/shell_local_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/logger/audit"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
 	chainlinkmocks "github.com/smartcontractkit/chainlink/v2/core/services/chainlink/mocks"
-	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	evmrelayer "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 	"github.com/smartcontractkit/chainlink/v2/core/sessions/localauth"
 	"github.com/smartcontractkit/chainlink/v2/core/store/dialects"
@@ -89,10 +88,9 @@ func TestShell_RunNodeWithPasswords(t *testing.T) {
 				Logger:   lggr,
 				KeyStore: keyStore.Eth(),
 				ChainOpts: legacyevm.ChainOpts{
-					AppConfig:        cfg,
-					EventBroadcaster: pg.NewNullEventBroadcaster(),
-					MailMon:          &mailbox.Monitor{},
-					DB:               db,
+					AppConfig: cfg,
+					MailMon:   &mailbox.Monitor{},
+					DB:        db,
 				},
 			}
 			testRelayers := genTestEVMRelayers(t, opts, keyStore)
@@ -194,10 +192,9 @@ func TestShell_RunNodeWithAPICredentialsFile(t *testing.T) {
 				Logger:   lggr,
 				KeyStore: keyStore.Eth(),
 				ChainOpts: legacyevm.ChainOpts{
-					AppConfig:        cfg,
-					EventBroadcaster: pg.NewNullEventBroadcaster(),
-					MailMon:          &mailbox.Monitor{},
-					DB:               db,
+					AppConfig: cfg,
+					MailMon:   &mailbox.Monitor{},
+					DB:        db,
 				},
 			}
 			testRelayers := genTestEVMRelayers(t, opts, keyStore)

--- a/core/internal/cltest/cltest.go
+++ b/core/internal/cltest/cltest.go
@@ -360,10 +360,9 @@ func NewApplicationWithConfig(t testing.TB, cfg chainlink.GeneralConfig, flagsAn
 
 	evmOpts := chainlink.EVMFactoryConfig{
 		ChainOpts: legacyevm.ChainOpts{
-			AppConfig:        cfg,
-			EventBroadcaster: eventBroadcaster,
-			MailMon:          mailMon,
-			DB:               db,
+			AppConfig: cfg,
+			MailMon:   mailMon,
+			DB:        db,
 		},
 		CSAETHKeystore: keyStore,
 	}

--- a/core/internal/testutils/evmtest/evmtest.go
+++ b/core/internal/testutils/evmtest/evmtest.go
@@ -37,7 +37,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore"
-	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 	evmrelay "github.com/smartcontractkit/chainlink/v2/core/services/relay/evm"
 )
@@ -87,11 +86,10 @@ func NewChainRelayExtOpts(t testing.TB, testopts TestChainOpts) legacyevm.ChainR
 		Logger:   lggr,
 		KeyStore: testopts.KeyStore,
 		ChainOpts: legacyevm.ChainOpts{
-			AppConfig:        testopts.GeneralConfig,
-			EventBroadcaster: pg.NewNullEventBroadcaster(),
-			MailMon:          testopts.MailMon,
-			GasEstimator:     testopts.GasEstimator,
-			DB:               testopts.DB,
+			AppConfig:    testopts.GeneralConfig,
+			MailMon:      testopts.MailMon,
+			GasEstimator: testopts.GasEstimator,
+			DB:           testopts.DB,
 		},
 	}
 	opts.GenEthClient = func(*big.Int) evmclient.Client {

--- a/core/services/chainlink/relayer_chain_interoperators_test.go
+++ b/core/services/chainlink/relayer_chain_interoperators_test.go
@@ -25,7 +25,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/pgtest"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/chainlink"
-	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	"github.com/smartcontractkit/chainlink/v2/core/services/relay"
 	"github.com/smartcontractkit/chainlink/v2/core/store/models"
 	"github.com/smartcontractkit/chainlink/v2/plugins"
@@ -206,10 +205,9 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 			initFuncs: []chainlink.CoreRelayerChainInitFunc{
 				chainlink.InitEVM(testctx, factory, chainlink.EVMFactoryConfig{
 					ChainOpts: legacyevm.ChainOpts{
-						AppConfig:        cfg,
-						EventBroadcaster: pg.NewNullEventBroadcaster(),
-						MailMon:          &mailbox.Monitor{},
-						DB:               db,
+						AppConfig: cfg,
+						MailMon:   &mailbox.Monitor{},
+						DB:        db,
 					},
 					CSAETHKeystore: keyStore,
 				}),
@@ -280,10 +278,10 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 				TOMLConfigs: cfg.SolanaConfigs()}),
 				chainlink.InitEVM(testctx, factory, chainlink.EVMFactoryConfig{
 					ChainOpts: legacyevm.ChainOpts{
-						AppConfig:        cfg,
-						EventBroadcaster: pg.NewNullEventBroadcaster(),
-						MailMon:          &mailbox.Monitor{},
-						DB:               db,
+						AppConfig: cfg,
+
+						MailMon: &mailbox.Monitor{},
+						DB:      db,
 					},
 					CSAETHKeystore: keyStore,
 				}),


### PR DESCRIPTION
remove dead code in the legacy evm chain abstraction. the event broadcaster is not used.