### PR TITLE
BCF-2880 remove unused db funcs and triggers

### DIFF
--- a/core/store/migrate/migrations/0216_drop_terra_state_transition_trigger.sql
+++ b/core/store/migrate/migrations/0216_drop_terra_state_transition_trigger.sql
@@ -1,0 +1,27 @@
+-- +goose Up
+
+-- +goose StatementBegin
+DROP FUNCTION IF EXISTS PUBLIC.check_terra_msg_state_transition;
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+
+CREATE OR REPLACE FUNCTION PUBLIC.check_terra_msg_state_transition() RETURNS TRIGGER AS $$
+DECLARE
+state_transition_map jsonb := json_build_object(
+        'unstarted', json_build_object('errored', true, 'started', true),
+        'started', json_build_object('errored', true, 'broadcasted', true),
+        'broadcasted', json_build_object('errored', true, 'confirmed', true));
+BEGIN
+    IF NOT state_transition_map ? OLD.state THEN
+        RAISE EXCEPTION 'Invalid from state %. Valid from states %', OLD.state, state_transition_map;
+END IF;
+    IF NOT state_transition_map->OLD.state ? NEW.state THEN
+        RAISE EXCEPTION 'Invalid state transition from % to %. Valid to states %', OLD.state, NEW.state, state_transition_map->OLD.state;
+END IF;
+RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+-- +goose StatementEnd

--- a/core/store/migrate/migrations/0217_drop_unused_job_triggers.sql
+++ b/core/store/migrate/migrations/0217_drop_unused_job_triggers.sql
@@ -1,0 +1,48 @@
+-- +goose Up
+-- +goose StatementBegin
+DROP TRIGGER IF EXISTS notify_job_created ON PUBLIC.jobs;
+DROP FUNCTION IF EXISTS PUBLIC.notifyjobcreated();
+
+DROP TRIGGER IF EXISTS notify_job_deleted ON PUBLIC.jobs;
+DROP FUNCTION IF EXISTS PUBLIC.notifyjobdeleted();
+
+DROP TRIGGER IF EXISTS notify_pipeline_run_started ON PUBLIC.pipeline_runs;
+DROP FUNCTION IF EXISTS PUBLIC.notifypipelinerunstarted();
+-- +goose StatementEnd
+
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE FUNCTION PUBLIC.notifyjobcreated() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+        BEGIN
+            PERFORM pg_notify('insert_on_jobs', NEW.id::text);
+            RETURN NEW;
+        END
+        $$;
+CREATE TRIGGER notify_job_created AFTER INSERT ON PUBLIC.jobs FOR EACH ROW EXECUTE PROCEDURE PUBLIC.notifyjobcreated();
+
+CREATE FUNCTION PUBLIC.notifyjobdeleted() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+	BEGIN
+		PERFORM pg_notify('delete_from_jobs', OLD.id::text);
+		RETURN OLD;
+	END
+	$$;
+CREATE TRIGGER notify_job_deleted AFTER DELETE ON PUBLIC.jobs FOR EACH ROW EXECUTE PROCEDURE PUBLIC.notifyjobdeleted();
+
+CREATE FUNCTION PUBLIC.notifypipelinerunstarted() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+	BEGIN
+		IF NEW.finished_at IS NULL THEN
+			PERFORM pg_notify('pipeline_run_started', NEW.id::text);
+		END IF;
+		RETURN NEW;
+	END
+	$$;
+CREATE TRIGGER notify_pipeline_run_started AFTER INSERT ON PUBLIC.pipeline_runs FOR EACH ROW EXECUTE PROCEDURE PUBLIC.notifypipelinerunstarted();
+
+-- +goose StatementEnd


### PR DESCRIPTION
auditing the db uncovered unused funcs and triggers that are removed in this pr.

i audited the go code by searching for the function names, trigger names, and the hard coded string in the PERFORM directive. there are no instances of any of them. presumably there listening functionality on the golang side was deleted and these db directives were forgotten about