### PR TITLE
core/services/relay: remove unecessary conversions of Network & ChainID

### DIFF
--- a/core/services/chainlink/relayer_chain_interoperators_test.go
+++ b/core/services/chainlink/relayer_chain_interoperators_test.go
@@ -214,8 +214,8 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 			expectedEVMChainCnt: 2,
 			expectedEVMNodeCnt:  3,
 			expectedEVMRelayerIds: []relay.ID{
-				{Network: relay.EVM, ChainID: relay.ChainID(evmChainID1.String())},
-				{Network: relay.EVM, ChainID: relay.ChainID(evmChainID2.String())},
+				{Network: relay.EVM, ChainID: evmChainID1.String()},
+				{Network: relay.EVM, ChainID: evmChainID2.String()},
 			},
 			expectedRelayerNetworks: map[relay.Network]struct{}{relay.EVM: {}},
 		},
@@ -230,8 +230,8 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 			expectedSolanaChainCnt: 2,
 			expectedSolanaNodeCnt:  2,
 			expectedSolanaRelayerIds: []relay.ID{
-				{Network: relay.Solana, ChainID: relay.ChainID(solanaChainID1)},
-				{Network: relay.Solana, ChainID: relay.ChainID(solanaChainID2)},
+				{Network: relay.Solana, ChainID: solanaChainID1},
+				{Network: relay.Solana, ChainID: solanaChainID2},
 			},
 			expectedRelayerNetworks: map[relay.Network]struct{}{relay.Solana: {}},
 		},
@@ -246,8 +246,8 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 			expectedStarknetChainCnt: 2,
 			expectedStarknetNodeCnt:  4,
 			expectedStarknetRelayerIds: []relay.ID{
-				{Network: relay.StarkNet, ChainID: relay.ChainID(starknetChainID1)},
-				{Network: relay.StarkNet, ChainID: relay.ChainID(starknetChainID2)},
+				{Network: relay.StarkNet, ChainID: starknetChainID1},
+				{Network: relay.StarkNet, ChainID: starknetChainID2},
 			},
 			expectedRelayerNetworks: map[relay.Network]struct{}{relay.StarkNet: {}},
 		},
@@ -264,8 +264,8 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 			expectedCosmosChainCnt: 2,
 			expectedCosmosNodeCnt:  2,
 			expectedCosmosRelayerIds: []relay.ID{
-				{Network: relay.Cosmos, ChainID: relay.ChainID(cosmosChainID1)},
-				{Network: relay.Cosmos, ChainID: relay.ChainID(cosmosChainID2)},
+				{Network: relay.Cosmos, ChainID: cosmosChainID1},
+				{Network: relay.Cosmos, ChainID: cosmosChainID2},
 			},
 			expectedRelayerNetworks: map[relay.Network]struct{}{relay.Cosmos: {}},
 		},
@@ -297,29 +297,29 @@ func TestCoreRelayerChainInteroperators(t *testing.T) {
 			expectedEVMChainCnt: 2,
 			expectedEVMNodeCnt:  3,
 			expectedEVMRelayerIds: []relay.ID{
-				{Network: relay.EVM, ChainID: relay.ChainID(evmChainID1.String())},
-				{Network: relay.EVM, ChainID: relay.ChainID(evmChainID2.String())},
+				{Network: relay.EVM, ChainID: evmChainID1.String()},
+				{Network: relay.EVM, ChainID: evmChainID2.String()},
 			},
 
 			expectedSolanaChainCnt: 2,
 			expectedSolanaNodeCnt:  2,
 			expectedSolanaRelayerIds: []relay.ID{
-				{Network: relay.Solana, ChainID: relay.ChainID(solanaChainID1)},
-				{Network: relay.Solana, ChainID: relay.ChainID(solanaChainID2)},
+				{Network: relay.Solana, ChainID: solanaChainID1},
+				{Network: relay.Solana, ChainID: solanaChainID2},
 			},
 
 			expectedStarknetChainCnt: 2,
 			expectedStarknetNodeCnt:  4,
 			expectedStarknetRelayerIds: []relay.ID{
-				{Network: relay.StarkNet, ChainID: relay.ChainID(starknetChainID1)},
-				{Network: relay.StarkNet, ChainID: relay.ChainID(starknetChainID2)},
+				{Network: relay.StarkNet, ChainID: starknetChainID1},
+				{Network: relay.StarkNet, ChainID: starknetChainID2},
 			},
 
 			expectedCosmosChainCnt: 2,
 			expectedCosmosNodeCnt:  2,
 			expectedCosmosRelayerIds: []relay.ID{
-				{Network: relay.Cosmos, ChainID: relay.ChainID(cosmosChainID1)},
-				{Network: relay.Cosmos, ChainID: relay.ChainID(cosmosChainID2)},
+				{Network: relay.Cosmos, ChainID: cosmosChainID1},
+				{Network: relay.Cosmos, ChainID: cosmosChainID2},
 			},
 
 			expectedRelayerNetworks: map[relay.Network]struct{}{relay.EVM: {}, relay.Cosmos: {}, relay.Solana: {}, relay.StarkNet: {}},

--- a/core/services/job/models.go
+++ b/core/services/job/models.go
@@ -361,7 +361,7 @@ func (s *OCR2OracleSpec) RelayID() (relay.ID, error) {
 
 func (s *OCR2OracleSpec) getChainID() (relay.ChainID, error) {
 	if s.ChainID != "" {
-		return relay.ChainID(s.ChainID), nil
+		return s.ChainID, nil
 	}
 	// backward compatible job spec
 	return s.getChainIdFromRelayConfig()
@@ -375,13 +375,13 @@ func (s *OCR2OracleSpec) getChainIdFromRelayConfig() (relay.ChainID, error) {
 	}
 	switch t := v.(type) {
 	case string:
-		return relay.ChainID(t), nil
+		return t, nil
 	case int, int64, int32:
-		return relay.ChainID(fmt.Sprintf("%d", v)), nil
+		return fmt.Sprintf("%d", v), nil
 	case float64:
 		// backward compatibility with JSONConfig.EVMChainID
 		i := int64(t)
-		return relay.ChainID(strconv.FormatInt(i, 10)), nil
+		return strconv.FormatInt(i, 10), nil
 
 	default:
 		return "", fmt.Errorf("unable to parse chainID: unexpected type %T", t)

--- a/core/services/job/models_test.go
+++ b/core/services/job/models_test.go
@@ -30,7 +30,7 @@ func TestOCR2OracleSpec_RelayIdentifier(t *testing.T) {
 				Relay:   relay.EVM,
 				ChainID: "1",
 			},
-			want: relay.ID{Network: relay.EVM, ChainID: relay.ChainID("1")},
+			want: relay.ID{Network: relay.EVM, ChainID: "1"},
 		},
 		{
 			name: "evm implicitly configured",
@@ -38,7 +38,7 @@ func TestOCR2OracleSpec_RelayIdentifier(t *testing.T) {
 				Relay:       relay.EVM,
 				RelayConfig: map[string]any{"chainID": 1},
 			},
-			want: relay.ID{Network: relay.EVM, ChainID: relay.ChainID("1")},
+			want: relay.ID{Network: relay.EVM, ChainID: "1"},
 		},
 		{
 			name: "evm implicitly configured with bad value",

--- a/core/services/relay/relay.go
+++ b/core/services/relay/relay.go
@@ -12,18 +12,19 @@ import (
 type Network = string
 type ChainID = string
 
-var (
-	EVM             Network = "evm"
-	Cosmos          Network = "cosmos"
-	Solana          Network = "solana"
-	StarkNet        Network = "starknet"
-	SupportedRelays         = map[Network]struct{}{
-		EVM:      {},
-		Cosmos:   {},
-		Solana:   {},
-		StarkNet: {},
-	}
+const (
+	EVM      = "evm"
+	Cosmos   = "cosmos"
+	Solana   = "solana"
+	StarkNet = "starknet"
 )
+
+var SupportedRelays = map[Network]struct{}{
+	EVM:      {},
+	Cosmos:   {},
+	Solana:   {},
+	StarkNet: {},
+}
 
 // ID uniquely identifies a relayer by network and chain id
 type ID struct {
@@ -54,9 +55,9 @@ func (i *ID) UnmarshalString(s string) error {
 	// ignore the `.` in the match by dropping last rune
 	network := s[idxs[0] : idxs[1]-1]
 	chainID := s[idxs[1]:]
-	newID := &ID{ChainID: ChainID(chainID)}
+	newID := &ID{ChainID: chainID}
 	for n := range SupportedRelays {
-		if Network(network) == n {
+		if network == n {
 			newID.Network = n
 			break
 		}

--- a/core/web/chains_controller.go
+++ b/core/web/chains_controller.go
@@ -79,7 +79,7 @@ func (cc *chainsController[R]) Show(c *gin.Context) {
 		jsonAPIError(c, http.StatusBadRequest, cc.errNotEnabled)
 		return
 	}
-	relayID := relay.ID{Network: cc.network, ChainID: relay.ChainID(c.Param("ID"))}
+	relayID := relay.ID{Network: cc.network, ChainID: c.Param("ID")}
 	chain, err := cc.chainStats.ChainStatus(c, relayID)
 	if err != nil {
 		jsonAPIError(c, http.StatusBadRequest, err)

--- a/core/web/loader/chain.go
+++ b/core/web/loader/chain.go
@@ -20,7 +20,7 @@ func (b *chainBatcher) loadByIDs(_ context.Context, keys dataloader.Keys) []*dat
 	// Collect the keys to search for
 	var chainIDs []relay.ChainID
 	for ix, key := range keys {
-		chainIDs = append(chainIDs, relay.ChainID(key.String()))
+		chainIDs = append(chainIDs, key.String())
 		keyOrder[key.String()] = ix
 	}
 

--- a/core/web/loader/node.go
+++ b/core/web/loader/node.go
@@ -23,7 +23,7 @@ func (b *nodeBatcher) loadByChainIDs(ctx context.Context, keys dataloader.Keys) 
 	evmrelayIDs := make([]relay.ID, 0, len(keys))
 
 	for ix, key := range keys {
-		rid := relay.ID{Network: relay.EVM, ChainID: relay.ChainID(key.String())}
+		rid := relay.ID{Network: relay.EVM, ChainID: key.String()}
 		evmrelayIDs = append(evmrelayIDs, rid)
 		keyOrder[key.String()] = ix
 	}

--- a/core/web/solana_transfer_controller.go
+++ b/core/web/solana_transfer_controller.go
@@ -48,7 +48,7 @@ func (tc *SolanaTransfersController) Create(c *gin.Context) {
 	}
 
 	amount := new(big.Int).SetUint64(tr.Amount)
-	relayerID := relay.ID{Network: relay.Solana, ChainID: relay.ChainID(tr.SolanaChainID)}
+	relayerID := relay.ID{Network: relay.Solana, ChainID: tr.SolanaChainID}
 	relayer, err := relayers.Get(relayerID)
 	if err != nil {
 		if errors.Is(err, chainlink.ErrNoSuchRelayer) {


### PR DESCRIPTION
This PR removes some type conversions which are no longer necessary since the types are just aliased.