### PR TITLE
BCF-2883 remove stranded, unused db func evm.notifytxinsertion

### DIFF
--- a/core/store/migrate/migrations/0219_drop_notifytxinsertion.sql
+++ b/core/store/migrate/migrations/0219_drop_notifytxinsertion.sql
@@ -1,0 +1,16 @@
+-- +goose Up
+-- +goose StatementBegin
+DROP FUNCTION IF EXISTS evm.notifytxinsertion();
+-- +goose StatementEnd
+
+-- +goose Down
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION evm.notifytxinsertion() RETURNS trigger
+    LANGUAGE plpgsql
+    AS $$
+        BEGIN
+		PERFORM pg_notify('evm.insert_on_txes'::text, encode(NEW.from_address, 'hex'));
+		RETURN NULL;
+        END
+        $$;
+-- +goose StatementEnd


### PR DESCRIPTION
This should be the last in the series of database function cleanup. This one was missed when the txm stopped using the event broadcaster in 8c96682617ad90b57b759a95f1555c51b842ee00