### PR TITLE
golangci-lint: revive: exported, var-naming, range-val-address, early-return

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -431,7 +431,8 @@ jobs:
         run: curl https://github.com/smartcontractkit/wsrpc/raw/main/cmd/protoc-gen-go-wsrpc/protoc-gen-go-wsrpc --output $HOME/go/bin/protoc-gen-go-wsrpc && chmod +x $HOME/go/bin/protoc-gen-go-wsrpc
       - name: Setup NodeJS
         uses: ./.github/actions/setup-nodejs
-      - run: |
+      - name: make generate
+        run: |
           make rm-mocked
           make generate
       - name: Ensure clean after generate

--- a/.github/workflows/ci-scripts.yml
+++ b/.github/workflows/ci-scripts.yml
@@ -6,6 +6,8 @@ on:
 
 jobs:
   lint-scripts:
+    # We don't directly merge dependabot PRs, so let's not waste the resources
+    if: ${{ (github.event_name == 'pull_request' ||  github.event_name == 'schedule') && github.actor != 'dependabot[bot]' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,9 +71,10 @@ linters-settings:
       - name: error-return
       - name: error-strings
       - name: error-naming
+      - name: exported
       - name: if-return
       - name: increment-decrement
-      # - name: var-naming
+      - name: var-naming
       - name: var-declaration
       - name: package-comments
       - name: range
@@ -92,7 +93,7 @@ linters-settings:
       - name: struct-tag
       # - name: string-format
       - name: string-of-int
-      # - name: range-val-address
+      - name: range-val-address
       - name: range-val-in-closure
       - name: modifies-value-receiver
       - name: modifies-parameter

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -160,8 +160,7 @@ config-docs: ## Generate core node configuration documentation
 .PHONY: golangci-lint
 golangci-lint: ## Run golangci-lint for all issues.
 	[ -d "./golangci-lint" ] || mkdir ./golangci-lint && \
-	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.59.1 golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 > ./golangci-lint/$(shell date +%Y-%m-%d_%H:%M:%S).txt
-
+	docker run --rm -v $(shell pwd):/app -w /app golangci/golangci-lint:v1.59.1 golangci-lint run --max-issues-per-linter 0 --max-same-issues 0 | tee ./golangci-lint/$(shell date +%Y-%m-%d_%H:%M:%S).txt
 
 GORELEASER_CONFIG ?= .goreleaser.yaml
 


### PR DESCRIPTION
Now that `new-issues-only` is enabled again, we can turn on desired rules without having to clear out all the technical debt first. This PR enables a few revive rules.