### PR TITLE
Rename external facing mercury to data streams

### DIFF
--- a/core/scripts/chaincli/.env.debugging.example
+++ b/core/scripts/chaincli/.env.debugging.example
@@ -8,8 +8,8 @@ KEEPER_REGISTRY_ADDRESS=<Registry Address>
 #TENDERLY_ACCOUNT_NAME=<Tenderly Account Name>
 #TENDERLY_PROJECT_NAME=<Tenderly Project Name>
 
-# [Optional] add mercury info only if your upkeep uses mercury
-#MERCURY_ID=<Mercury ID>
-#MERCURY_KEY=<Mercury Key>
-#MERCURY_LEGACY_URL=<Mercury Legacy URL>
-#MERCURY_URL=<Mercury Server URL>
+# [Optional] add data streams (https://docs.chain.link/data-streams) info only if your upkeep uses data streams
+#DATA_STREAMS_ID=<DATA STREAMS ID>
+#DATA_STREAMS_KEY=<DATA STREAMS Key>
+#DATA_STREAMS_URL=<DATA STREAMS Server URL FOR THIS NETWORK>
+#DATA_STREAMS_LEGACY_URL=<DATA STREAMS Legacy URL (v0.2 only) FOR THIS NETWORK>

--- a/core/scripts/chaincli/DEBUGGING.md
+++ b/core/scripts/chaincli/DEBUGGING.md
@@ -22,7 +22,7 @@ Ensure the following fields are provided in your `.env` file:
 
 #### Optional Fields (Streams Lookup)
 
-If your targeted upkeep involves streams lookup, include the following information:
+If your targeted upkeep involves streams lookup, please provide the following details. If you are using Data Streams v0.3 (which is likely), only provide the DATA_STREAMS_URL. The DATA_STREAMS_LEGACY_URL is specifically for Data Streams v0.2.
 
 - `DATA_STREAMS_ID`
 - `DATA_STREAMS_KEY`

--- a/core/scripts/chaincli/config/config.go
+++ b/core/scripts/chaincli/config/config.go
@@ -90,12 +90,12 @@ type Config struct {
 	FeedQuoteAddr string `mapstructure:"FEED_QUOTE_ADDR"`
 	FeedDecimals  uint8  `mapstructure:"FEED_DECIMALS"`
 
-	// Mercury Config
-	MercuryURL       string `mapstructure:"MERCURY_URL"`
-	MercuryLegacyURL string `mapstructure:"MERCURY_LEGACY_URL"`
-	MercuryID        string `mapstructure:"MERCURY_ID"`
-	MercuryKey       string `mapstructure:"MERCURY_KEY"`
-	MercuryCredName  string `mapstructure:"MERCURY_CRED_NAME"`
+	// Data Streams Config
+	DataStreamsURL       string `mapstructure:"DATA_STREAMS_URL"`
+	DataStreamsLegacyURL string `mapstructure:"DATA_STREAMS_LEGACY_URL"`
+	DataStreamsID        string `mapstructure:"DATA_STREAMS_ID"`
+	DataStreamsKey       string `mapstructure:"DATA_STREAMS_KEY"`
+	DataStreamsCredName  string `mapstructure:"DATA_STREAMS_CRED_NAME"`
 
 	// Tenderly
 	TenderlyKey         string `mapstructure:"TENDERLY_KEY"`

--- a/core/scripts/chaincli/handler/debug.go
+++ b/core/scripts/chaincli/handler/debug.go
@@ -257,7 +257,7 @@ func (k *Keeper) Debug(ctx context.Context, args []string) {
 	}
 
 	if checkResult.UpkeepFailureReason == uint8(encoding.UpkeepFailureReasonTargetCheckReverted) {
-		mc := &types2.MercuryCredentials{LegacyURL: k.cfg.MercuryLegacyURL, URL: k.cfg.MercuryURL, Username: k.cfg.MercuryID, Password: k.cfg.MercuryKey}
+		mc := &types2.MercuryCredentials{LegacyURL: k.cfg.DataStreamsLegacyURL, URL: k.cfg.DataStreamsURL, Username: k.cfg.DataStreamsID, Password: k.cfg.DataStreamsKey}
 		mercuryConfig := evm21.NewMercuryConfig(mc, core.StreamsCompatibleABI)
 		lggr, _ := logger.NewLogger()
 		blockSub := &blockSubscriber{k.client}
@@ -282,25 +282,25 @@ func (k *Keeper) Debug(ctx context.Context, args []string) {
 			}
 
 			if streamsLookup.IsMercuryV02() {
-				message("using mercury lookup v0.2")
+				message("using data streams lookup v0.2")
 				// check if upkeep is allowed to use mercury v0.2
 				var allowed bool
 				_, _, _, allowed, err = streams.AllowedToUseMercury(triggerCallOpts, upkeepID)
 				if err != nil {
-					failUnknown("failed to check if upkeep is allowed to use mercury", err)
+					failUnknown("failed to check if upkeep is allowed to use data streams", err)
 				}
 				if !allowed {
 					resolveIneligible("upkeep reverted with StreamsLookup but is not allowed to access streams")
 				}
 			} else if streamsLookup.IsMercuryV03() {
 				// handle v0.3
-				message("using mercury lookup v0.3")
+				message("using data streams lookup v0.3")
 			} else {
 				resolveIneligible("upkeep reverted with StreamsLookup but the configuration is invalid")
 			}
 
-			if k.cfg.MercuryLegacyURL == "" || k.cfg.MercuryURL == "" || k.cfg.MercuryID == "" || k.cfg.MercuryKey == "" {
-				failCheckConfig("Mercury configs not set properly, check your MERCURY_LEGACY_URL, MERCURY_URL, MERCURY_ID and MERCURY_KEY", nil)
+			if k.cfg.DataStreamsLegacyURL == "" || k.cfg.DataStreamsURL == "" || k.cfg.DataStreamsID == "" || k.cfg.DataStreamsKey == "" {
+				failCheckConfig("Data streams configs not set properly, check your DATA_STREAMS_LEGACY_URL, DATA_STREAMS_URL, DATA_STREAMS_ID and DATA_STREAMS_KEY", nil)
 			}
 
 			// do mercury request
@@ -314,16 +314,16 @@ func (k *Keeper) Debug(ctx context.Context, args []string) {
 				resolveIneligible("upkeep used invalid revert data")
 			}
 			if checkResults[0].PipelineExecutionState == uint8(encoding.InvalidMercuryRequest) {
-				resolveIneligible("the mercury request data is invalid")
+				resolveIneligible("the data streams request data is invalid")
 			}
 			if err != nil {
-				failCheckConfig("failed to do mercury request ", err)
+				failCheckConfig("failed to do data streams request ", err)
 			}
 
 			// do checkCallback
 			err = streams.CheckCallback(ctx, values, streamsLookup, checkResults, 0)
 			if err != nil {
-				failUnknown("failed to execute mercury callback ", err)
+				failUnknown("failed to execute data streams callback ", err)
 			}
 			if checkResults[0].IneligibilityReason != 0 {
 				message(fmt.Sprintf("checkCallback failed with UpkeepFailureReason %d", checkResults[0].IneligibilityReason))

--- a/core/scripts/chaincli/handler/handler.go
+++ b/core/scripts/chaincli/handler/handler.go
@@ -333,7 +333,7 @@ func (h *baseHandler) launchChainlinkNode(ctx context.Context, port int, contain
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create toml file: %w", err)
 	}
-	var secretTOMLStr = fmt.Sprintf(secretTOML, h.cfg.MercuryURL, h.cfg.MercuryID, h.cfg.MercuryKey)
+	var secretTOMLStr = fmt.Sprintf(secretTOML, h.cfg.DataStreamsURL, h.cfg.DataStreamsID, h.cfg.DataStreamsKey)
 	secretFile, secretTOMLFileCleanup, err := createTomlFile(secretTOMLStr)
 	if err != nil {
 		return "", nil, fmt.Errorf("failed to create secret toml file: %w", err)

--- a/core/scripts/chaincli/handler/keeper_launch.go
+++ b/core/scripts/chaincli/handler/keeper_launch.go
@@ -19,6 +19,7 @@ import (
 	"github.com/ethereum/go-ethereum/crypto"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/hex"
+
 	"github.com/smartcontractkit/chainlink/v2/core/cmd"
 	iregistry21 "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/i_keeper_registry_master_wrapper_2_1"
 	registry12 "github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/keeper_registry_wrapper1_2"
@@ -377,13 +378,13 @@ func (k *Keeper) createOCR2KeeperJob(ctx context.Context, client cmd.HTTPClient,
 
 	request, err := json.Marshal(web.CreateJobRequest{
 		TOML: fmt.Sprintf(ocr2keeperJobTemplate,
-			contractAddr,            // contractID
-			ocr2KeyConfig.ID,        // ocrKeyBundleID
-			nodeAddr,                // transmitterID - node wallet address
-			k.cfg.BootstrapNodeAddr, // bootstrap node key and address
-			k.cfg.ChainID,           // chainID
-			contractVersion,         // contractVersion
-			k.cfg.MercuryCredName,   // mercury credential name
+			contractAddr,              // contractID
+			ocr2KeyConfig.ID,          // ocrKeyBundleID
+			nodeAddr,                  // transmitterID - node wallet address
+			k.cfg.BootstrapNodeAddr,   // bootstrap node key and address
+			k.cfg.ChainID,             // chainID
+			contractVersion,           // contractVersion
+			k.cfg.DataStreamsCredName, // mercury credential name
 		),
 	})
 	if err != nil {


### PR DESCRIPTION
AUTO-8376

As title, to avoid confusing our users, especially as we are releasing the debugging script, we want to be consistent on our naming. Here we rename all external facing mercury to data streams. 

Testing:
- I ran chaincli locally and everything runs fine.
- This change should not affect any code other than core/scripts. All the existing integration tests should pass.