### PR TITLE
Add bash scripts CI workflow

### DIFF
--- a/.github/workflows/bash-scripts.yml
+++ b/.github/workflows/bash-scripts.yml
@@ -1,0 +1,35 @@
+name: Bash Scripts
+
+on:
+  pull_request:
+
+jobs:
+  changes:
+    name: detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      bash-scripts-src: ${{ steps.bash-scripts.outputs.src }}
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+        id: bash-scripts
+        with:
+          filters: |
+            src:
+            - 'tools/bin/**'
+            - '.github/workflows/bash-scripts.yml'
+  shellcheck:
+    name: ShellCheck Lint
+    runs-on: ubuntu-latest
+    needs: [changes]
+    steps:
+      - name: Checkout the repo
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+      - name: Run ShellCheck
+        if: needs.changes.outputs.bash-scripts-src == 'true'
+        uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0
+        with:
+          scandir: "./tools/bin"
+          # Consider changing this to check for warnings once all warnings are fixed.
+          severity: error

--- a/.github/workflows/bash-scripts.yml
+++ b/.github/workflows/bash-scripts.yml
@@ -25,7 +25,7 @@ jobs:
     needs: [changes]
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3.5.3
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
       - name: Run ShellCheck
         if: needs.changes.outputs.bash-scripts-src == 'true'
         uses: ludeeus/action-shellcheck@00cae500b08a931fb5698e11e79bfbd38e612a38 # v2.0.0

--- a/tools/bin/cldev
+++ b/tools/bin/cldev
@@ -12,6 +12,6 @@ case "$1" in
       go run -ldflags "$LDFLAGS" . --  node start -d -p tools/secrets/password.txt -a tools/secrets/apicredentials
       ;;
     *)
-      go run . -- $@
+      go run . -- "$@"
       ;;
 esac


### PR DESCRIPTION
Will scan ./tools/bin/ dir and fail if any shellcheck errors are reported. With this fix to `cldev`, no errors are currently being reported by shellcheck so this should run clean.