### PR TITLE
[Functions] Add extra validations for offchain heartbeats

### DIFF
--- a/core/services/gateway/api/message.go
+++ b/core/services/gateway/api/message.go
@@ -20,6 +20,7 @@ const (
 	MessageMethodMaxLen           = 64
 	MessageDonIdMaxLen            = 64
 	MessageReceiverLen            = 2 + 2*20
+	NullChar                      = "\x00"
 )
 
 /*
@@ -56,11 +57,20 @@ func (m *Message) Validate() error {
 	if len(m.Body.MessageId) == 0 || len(m.Body.MessageId) > MessageIdMaxLen {
 		return errors.New("invalid message ID length")
 	}
+	if strings.HasSuffix(m.Body.MessageId, NullChar) {
+		return errors.New("message ID ending with null bytes")
+	}
 	if len(m.Body.Method) == 0 || len(m.Body.Method) > MessageMethodMaxLen {
 		return errors.New("invalid method name length")
 	}
+	if strings.HasSuffix(m.Body.Method, NullChar) {
+		return errors.New("method name ending with null bytes")
+	}
 	if len(m.Body.DonId) == 0 || len(m.Body.DonId) > MessageDonIdMaxLen {
 		return errors.New("invalid DON ID length")
+	}
+	if strings.HasSuffix(m.Body.DonId, NullChar) {
+		return errors.New("DON ID ending with null bytes")
 	}
 	if len(m.Body.Receiver) != 0 && len(m.Body.Receiver) != MessageReceiverLen {
 		return errors.New("invalid Receiver length")

--- a/core/services/gateway/api/message_test.go
+++ b/core/services/gateway/api/message_test.go
@@ -31,22 +31,38 @@ func TestMessage_Validate(t *testing.T) {
 	// missing message ID
 	msg.Body.MessageId = ""
 	require.Error(t, msg.Validate())
+	// message ID ending with null bytes
+	msg.Body.MessageId = "myid\x00\x00"
+	require.Error(t, msg.Validate())
 	msg.Body.MessageId = "abcd"
+	require.NoError(t, msg.Validate())
 
 	// missing DON ID
 	msg.Body.DonId = ""
 	require.Error(t, msg.Validate())
+	// DON ID ending with null bytes
+	msg.Body.DonId = "mydon\x00\x00"
+	require.Error(t, msg.Validate())
 	msg.Body.DonId = "donA"
+	require.NoError(t, msg.Validate())
 
-	// method too long
+	// method name too long
 	msg.Body.Method = string(bytes.Repeat([]byte("a"), api.MessageMethodMaxLen+1))
 	require.Error(t, msg.Validate())
+	// empty method name
+	msg.Body.Method = ""
+	require.Error(t, msg.Validate())
+	// method name ending with null bytes
+	msg.Body.Method = "method\x00"
+	require.Error(t, msg.Validate())
 	msg.Body.Method = "request"
+	require.NoError(t, msg.Validate())
 
 	// incorrect receiver
 	msg.Body.Receiver = "blah"
 	require.Error(t, msg.Validate())
 	msg.Body.Receiver = "0x0000000000000000000000000000000000000000"
+	require.NoError(t, msg.Validate())
 
 	// invalid signature
 	msg.Signature = "0x00"

--- a/core/services/gateway/connectionmanager.go
+++ b/core/services/gateway/connectionmanager.go
@@ -287,6 +287,10 @@ func (m *donConnectionManager) readLoop(nodeAddress string, nodeState *nodeState
 				m.lggr.Errorw("message validation error when reading from node", "nodeAddress", nodeAddress, "err", err)
 				break
 			}
+			if msg.Body.Sender != nodeAddress {
+				m.lggr.Errorw("message sender mismatch when reading from node", "nodeAddress", nodeAddress, "sender", msg.Body.Sender)
+				break
+			}
 			err = m.handler.HandleNodeMessage(ctx, msg, nodeAddress)
 			if err != nil {
 				m.lggr.Error("error when calling HandleNodeMessage ", err)

--- a/core/services/ocr2/plugins/functions/config/config.go
+++ b/core/services/ocr2/plugins/functions/config/config.go
@@ -41,6 +41,7 @@ type PluginConfig struct {
 	MaxRequestSizesList                []uint32                              `json:"maxRequestSizesList"`
 	MaxSecretsSizesList                []uint32                              `json:"maxSecretsSizesList"`
 	MinimumSubscriptionBalance         assets.Link                           `json:"minimumSubscriptionBalance"`
+	AllowedHeartbeatInitiators         []string                              `json:"allowedHeartbeatInitiators"`
 	GatewayConnectorConfig             *connector.ConnectorConfig            `json:"gatewayConnectorConfig"`
 	OnchainAllowlist                   *functions.OnchainAllowlistConfig     `json:"onchainAllowlist"`
 	OnchainSubscriptions               *functions.OnchainSubscriptionsConfig `json:"onchainSubscriptions"`

--- a/core/services/ocr2/plugins/functions/plugin_test.go
+++ b/core/services/ocr2/plugins/functions/plugin_test.go
@@ -8,7 +8,6 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
-	"github.com/smartcontractkit/chainlink-common/pkg/assets"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	sfmocks "github.com/smartcontractkit/chainlink/v2/core/services/functions/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/services/gateway/connector"
@@ -17,6 +16,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/services/keystore/keys/ethkey"
 	ksmocks "github.com/smartcontractkit/chainlink/v2/core/services/keystore/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/functions"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/functions/config"
 	s4mocks "github.com/smartcontractkit/chainlink/v2/core/services/s4/mocks"
 )
 
@@ -39,7 +39,10 @@ func TestNewConnector_Success(t *testing.T) {
 	listener := sfmocks.NewFunctionsListener(t)
 	offchainTransmitter := sfmocks.NewOffchainTransmitter(t)
 	ethKeystore.On("EnabledKeysForChain", mock.Anything).Return([]ethkey.KeyV2{keyV2}, nil)
-	_, err = functions.NewConnector(gwcCfg, ethKeystore, chainID, s4Storage, allowlist, rateLimiter, subscriptions, listener, offchainTransmitter, *assets.NewLinkFromJuels(0), logger.TestLogger(t))
+	config := &config.PluginConfig{
+		GatewayConnectorConfig: gwcCfg,
+	}
+	_, err = functions.NewConnector(config, ethKeystore, chainID, s4Storage, allowlist, rateLimiter, subscriptions, listener, offchainTransmitter, logger.TestLogger(t))
 	require.NoError(t, err)
 }
 
@@ -64,6 +67,9 @@ func TestNewConnector_NoKeyForConfiguredAddress(t *testing.T) {
 	listener := sfmocks.NewFunctionsListener(t)
 	offchainTransmitter := sfmocks.NewOffchainTransmitter(t)
 	ethKeystore.On("EnabledKeysForChain", mock.Anything).Return([]ethkey.KeyV2{{Address: common.HexToAddress(addresses[1])}}, nil)
-	_, err = functions.NewConnector(gwcCfg, ethKeystore, chainID, s4Storage, allowlist, rateLimiter, subscriptions, listener, offchainTransmitter, *assets.NewLinkFromJuels(0), logger.TestLogger(t))
+	config := &config.PluginConfig{
+		GatewayConnectorConfig: gwcCfg,
+	}
+	_, err = functions.NewConnector(config, ethKeystore, chainID, s4Storage, allowlist, rateLimiter, subscriptions, listener, offchainTransmitter, logger.TestLogger(t))
 	require.Error(t, err)
 }


### PR DESCRIPTION
1. Add AllowedHeartbeatInitiators list to node's config and validate senders of incoming requests against it (same logic as in Gateway).
2. Validate Sender value in nodes' responses to make sure it matches the expected node. Extend an integration test to cover this change.
3. Validate age of incoming requests against RequestTimeoutSec from job config to avoid processing ones that already timed out.
4. Disallow null-byte suffixes in message fields to avoid any potential confusion with default padding.