### PR TITLE
Removes 4 Core GitHub Runners

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -13,7 +13,7 @@ on:
 jobs:
   analyze:
     name: Analyze ${{ matrix.language }}
-    runs-on: ubuntu20.04-4cores-16GB
+    runs-on: ubuntu-latest
 
     strategy:
       fail-fast: false

--- a/.github/workflows/solidity-hardhat.yml
+++ b/.github/workflows/solidity-hardhat.yml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         split: ${{ fromJson(needs.split-tests.outputs.splits) }}
-    runs-on: ubuntu20.04-4cores-16GB
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
@@ -128,7 +128,7 @@ jobs:
       fail-fast: false
       matrix:
         split: ${{ fromJson(needs.split-tests.outputs.splits) }}
-    runs-on: ubuntu20.04-4cores-16GB
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1


### PR DESCRIPTION
GitHub has [made these standard now](https://github.blog/2024-01-17-github-hosted-runners-double-the-power-for-open-source/). No need to call them out and spend money on them.