### PR TITLE
support customized block number for conditional

### DIFF
--- a/core/scripts/chaincli/DEBUGGING.md
+++ b/core/scripts/chaincli/DEBUGGING.md
@@ -41,10 +41,10 @@ For detailed transaction simulation logs, set up Tenderly credentials. Refer to 
 
 Execute the following command based on your upkeep type:
 
-- For conditional upkeep:
+- For conditional upkeep, if a block number is given we use that block, otherwise we use the latest block:
 
     ```bash
-    go run main.go keeper debug UPKEEP_ID
+    go run main.go keeper debug UPKEEP_ID [OPTIONAL BLOCK_NUMBER]
     ```
 
 - For log trigger upkeep:


### PR DESCRIPTION
AUTO-8793

As title, support using a block number from users. This covers both checkupkeep and perform

Test plan:

Tried the following upkeep in arbitrum sepolia:
> go run main.go keeper debug 67565883080818726407103359577750299084952920187169313465079851360269044647245 7817591

Both older block and latest block returned ineligible.

I couldn't find an upkeep which checkUpkeep returns true on older blocks but latest returns false. Hope to find some interesting test cases with Mike later.