### PR TITLE
Hotfix attempt for Canary : v2.8.0-rc0 upgrade fails on Polygon.

### DIFF
--- a/common/txmgr/tracker.go
+++ b/common/txmgr/tracker.go
@@ -216,7 +216,7 @@ func (tr *Tracker[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) trackAbando
 		return fmt.Errorf("tracker already started")
 	}
 
-	tr.lggr.Infow("Retrieving non fatal transactions from txStore")
+	tr.lggr.Info("Retrieving non fatal transactions from txStore")
 	nonFatalTxes, err := tr.txStore.GetNonFatalTransactions(ctx, tr.chainID)
 	if err != nil {
 		return fmt.Errorf("failed to get non fatal txes from txStore: %w", err)
@@ -245,7 +245,7 @@ func (tr *Tracker[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) HandleTxesB
 }
 
 func (tr *Tracker[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) handleTxesByState(ctx context.Context, blockHeight int64) error {
-	tr.lggr.Infow("Handling transactions by state")
+	tr.lggr.Info("Handling transactions by state")
 
 	for id, atx := range tr.txCache {
 		tx, err := tr.txStore.GetTxByID(ctx, atx.id)

--- a/common/txmgr/tracker.go
+++ b/common/txmgr/tracker.go
@@ -115,7 +115,7 @@ func (tr *Tracker[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) startIntern
 
 	tr.isStarted = true
 	if len(tr.txCache) == 0 {
-		tr.lggr.Infow("no abandoned txes found, skipping runLoop")
+		tr.lggr.Info("no abandoned txes found, skipping runLoop")
 		return nil
 	}
 
@@ -134,7 +134,7 @@ func (tr *Tracker[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) Close() err
 }
 
 func (tr *Tracker[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) closeInternal() error {
-	tr.lggr.Infow("stopping tracker")
+	tr.lggr.Info("stopping tracker")
 	if !tr.isStarted {
 		return fmt.Errorf("tracker not started")
 	}
@@ -164,7 +164,7 @@ func (tr *Tracker[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) runLoop() {
 				}
 			}
 		case <-ttlExceeded.C:
-			tr.lggr.Infow("ttl exceeded")
+			tr.lggr.Info("ttl exceeded")
 			tr.MarkAllTxesFatal(tr.ctx)
 			return
 		case <-tr.ctx.Done():

--- a/common/txmgr/txmgr.go
+++ b/common/txmgr/txmgr.go
@@ -191,6 +191,7 @@ func (b *Txm[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) Start(ctx 
 			return fmt.Errorf("Txm: Estimator failed to start: %w", err)
 		}
 
+		b.logger.Infow("Txm starting tracker")
 		if err := ms.Start(ctx, b.tracker); err != nil {
 			return fmt.Errorf("Txm: Tracker failed to start: %w", err)
 		}

--- a/common/txmgr/txmgr.go
+++ b/common/txmgr/txmgr.go
@@ -196,7 +196,7 @@ func (b *Txm[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) Start(ctx 
 			return fmt.Errorf("Txm: Tracker failed to start: %w", err)
 		}
 
-		b.logger.Infow("Txm starting runLoop")
+		b.logger.Info("Txm starting runLoop")
 		b.wg.Add(1)
 		go b.runLoop()
 		<-b.chSubbed

--- a/common/txmgr/txmgr.go
+++ b/common/txmgr/txmgr.go
@@ -195,6 +195,7 @@ func (b *Txm[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) Start(ctx 
 			return fmt.Errorf("Txm: Tracker failed to start: %w", err)
 		}
 
+		b.logger.Infow("Txm starting runLoop")
 		b.wg.Add(1)
 		go b.runLoop()
 		<-b.chSubbed

--- a/common/txmgr/txmgr.go
+++ b/common/txmgr/txmgr.go
@@ -191,7 +191,7 @@ func (b *Txm[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) Start(ctx 
 			return fmt.Errorf("Txm: Estimator failed to start: %w", err)
 		}
 
-		b.logger.Infow("Txm starting tracker")
+		b.logger.Info("Txm starting tracker")
 		if err := ms.Start(ctx, b.tracker); err != nil {
 			return fmt.Errorf("Txm: Tracker failed to start: %w", err)
 		}


### PR DESCRIPTION
Hotfix attempt for Canary : v2.8.0-rc0 upgrade fails on Polygon.

Removed start lock on tracker and added some additional logging.