### PR TITLE
Add metric for num logs in buffer and missed logs

### DIFF
--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/active_list.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/active_list.go
@@ -9,6 +9,7 @@ import (
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics"
 )
 
 // ActiveUpkeepList is a list to manage active upkeep IDs
@@ -49,9 +50,10 @@ func (al *activeList) Reset(ids ...*big.Int) {
 	for _, id := range ids {
 		al.items[id.String()] = true
 	}
+	prommetrics.AutomationActiveUpkeeps.Set(float64(len(al.items)))
 }
 
-// Add adds new entries to the list
+// Add adds new entries to the list. Returns the number of items added
 func (al *activeList) Add(ids ...*big.Int) int {
 	al.lock.Lock()
 	defer al.lock.Unlock()
@@ -63,10 +65,11 @@ func (al *activeList) Add(ids ...*big.Int) int {
 			al.items[key] = true
 		}
 	}
+	prommetrics.AutomationActiveUpkeeps.Set(float64(len(al.items)))
 	return count
 }
 
-// Remove removes entries from the list
+// Remove removes entries from the list. Returns the number of items removed
 func (al *activeList) Remove(ids ...*big.Int) int {
 	al.lock.Lock()
 	defer al.lock.Unlock()
@@ -79,6 +82,7 @@ func (al *activeList) Remove(ids ...*big.Int) int {
 			delete(al.items, key)
 		}
 	}
+	prommetrics.AutomationActiveUpkeeps.Set(float64(len(al.items)))
 	return count
 }
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics"
 )
 
 var (
@@ -232,7 +233,7 @@ func (b *logEventBuffer) enqueue(id *big.Int, logs ...logpoller.Log) int {
 	}
 	if added > 0 {
 		lggr.Debugw("Added logs to buffer", "addedLogs", added, "dropped", dropped, "latestBlock", latestBlock)
-		atomic.AddInt64(&b.logsInBuffer, int64(added-dropped))
+		prommetrics.AutomationLogsInLogBuffer.Set(float64(atomic.AddInt64(&b.logsInBuffer, int64(added-dropped))))
 	}
 
 	return added - dropped
@@ -334,7 +335,7 @@ func (b *logEventBuffer) dequeueRange(start, end int64, upkeepLimit, totalLimit 
 
 	if len(results) > 0 {
 		b.lggr.Debugw("Dequeued logs", "results", len(results), "start", start, "end", end)
-		atomic.AddInt64(&b.logsInBuffer, -int64(len(results)))
+		prommetrics.AutomationLogsInLogBuffer.Set(float64(atomic.AddInt64(&b.logsInBuffer, -int64(len(results)))))
 	}
 
 	return results

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer.go
@@ -151,8 +151,6 @@ type logEventBuffer struct {
 	blocks []fetchedBlock
 	// latestBlock is the latest block number seen
 	latestBlock int64
-	// logsInBuffer is the number of logs currently in the buffer
-	logsInBuffer int64
 }
 
 func newLogEventBuffer(lggr logger.Logger, size, numOfLogUpkeeps, fastExecLogsHigh int) *logEventBuffer {
@@ -233,7 +231,7 @@ func (b *logEventBuffer) enqueue(id *big.Int, logs ...logpoller.Log) int {
 	}
 	if added > 0 {
 		lggr.Debugw("Added logs to buffer", "addedLogs", added, "dropped", dropped, "latestBlock", latestBlock)
-		prommetrics.AutomationLogsInLogBuffer.Set(float64(atomic.AddInt64(&b.logsInBuffer, int64(added-dropped))))
+		prommetrics.AutomationLogsInLogBuffer.Add(float64(added - dropped))
 	}
 
 	return added - dropped
@@ -335,7 +333,7 @@ func (b *logEventBuffer) dequeueRange(start, end int64, upkeepLimit, totalLimit 
 
 	if len(results) > 0 {
 		b.lggr.Debugw("Dequeued logs", "results", len(results), "start", start, "end", end)
-		prommetrics.AutomationLogsInLogBuffer.Set(float64(atomic.AddInt64(&b.logsInBuffer, -int64(len(results)))))
+		prommetrics.AutomationLogsInLogBuffer.Sub(float64(len(results)))
 	}
 
 	return results

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -24,7 +24,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/automation_utils_2_1"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
-	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
@@ -103,8 +102,6 @@ type logEventProvider struct {
 	opts LogTriggersOptions
 
 	currentPartitionIdx uint64
-
-	servedLogs int64
 }
 
 func NewLogProvider(lggr logger.Logger, poller logpoller.LogPoller, packer LogDataPacker, filterStore UpkeepFilterStore, opts LogTriggersOptions) *logEventProvider {
@@ -143,21 +140,6 @@ func (p *logEventProvider) Start(context.Context) error {
 					lggr.Warnw("readQ is full, dropping ids", "ids", ids)
 				}
 			})
-		})
-
-		p.threadCtrl.Go(func(ctx context.Context) {
-			ticker := time.NewTicker(5 * time.Second)
-			defer ticker.Stop()
-			for {
-				select {
-				case <-ticker.C:
-					p.lggr.Debugw("logs stats", "servedLogs", atomic.LoadInt64(&p.servedLogs), "logsInBuffer", atomic.LoadInt64(&p.buffer.logsInBuffer), "latestBlockSeen", p.buffer.latestBlockSeen())
-					prommetrics.AutomationLogsInLogBuffer.Set(float64(atomic.LoadInt64(&p.buffer.logsInBuffer)))
-				case <-ctx.Done():
-					return
-
-				}
-			}
 		})
 
 		return nil

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -24,6 +24,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/gethwrappers/generated/automation_utils_2_1"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
@@ -162,6 +163,7 @@ func (p *logEventProvider) GetLatestPayloads(ctx context.Context) ([]ocr2keepers
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", ErrHeadNotAvailable, err)
 	}
+	prommetrics.AutomationLogProviderLatestBlock.Set(float64(latest.BlockNumber))
 	start := latest.BlockNumber - p.opts.LookbackBlocks
 	if start <= 0 {
 		start = 1

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer.go
@@ -27,6 +27,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/core"
+	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics"
 	"github.com/smartcontractkit/chainlink/v2/core/services/pg"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 )
@@ -417,6 +418,7 @@ func (r *logRecoverer) recoverFilter(ctx context.Context, f upkeepFilter, startB
 	added, alreadyPending, ok := r.populatePending(f, filteredLogs)
 	if added > 0 {
 		r.lggr.Debugw("found missed logs", "added", added, "alreadyPending", alreadyPending, "upkeepID", f.upkeepID)
+		prommetrics.AutomationRecovererMissedLogs.Add(float64(added))
 	}
 	if !ok {
 		r.lggr.Debugw("failed to add all logs to pending", "upkeepID", f.upkeepID)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer.go
@@ -306,7 +306,7 @@ func (r *logRecoverer) GetRecoveryProposals(ctx context.Context) ([]ocr2keepers.
 	var results, pending []ocr2keepers.UpkeepPayload
 	for _, payload := range r.pending {
 		if allLogsCounter >= MaxProposals {
-			// we have enough proposals, pushed the rest are pushed back to pending
+			// we have enough proposals, the rest are pushed back to pending
 			pending = append(pending, payload)
 			continue
 		}
@@ -322,6 +322,7 @@ func (r *logRecoverer) GetRecoveryProposals(ctx context.Context) ([]ocr2keepers.
 	}
 
 	r.pending = pending
+	prommetrics.AutomationRecovererPendingPayloads.Set(float64(len(r.pending)))
 
 	r.lggr.Debugf("found %d recoverable payloads", len(results))
 
@@ -676,6 +677,7 @@ func (r *logRecoverer) addPending(payload ocr2keepers.UpkeepPayload) error {
 	if !exist {
 		r.pending = append(pending, payload)
 	}
+	prommetrics.AutomationRecovererPendingPayloads.Set(float64(len(r.pending)))
 	return nil
 }
 
@@ -689,6 +691,7 @@ func (r *logRecoverer) removePending(workID string) {
 		}
 	}
 	r.pending = updated
+	prommetrics.AutomationRecovererPendingPayloads.Set(float64(len(r.pending)))
 }
 
 // sortPending sorts the pending list by a random order based on the normalized latest block number.

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer.go
@@ -676,8 +676,8 @@ func (r *logRecoverer) addPending(payload ocr2keepers.UpkeepPayload) error {
 	}
 	if !exist {
 		r.pending = append(pending, payload)
+		prommetrics.AutomationRecovererPendingPayloads.Inc()
 	}
-	prommetrics.AutomationRecovererPendingPayloads.Set(float64(len(r.pending)))
 	return nil
 }
 
@@ -688,10 +688,11 @@ func (r *logRecoverer) removePending(workID string) {
 	for _, p := range r.pending {
 		if p.WorkID != workID {
 			updated = append(updated, p)
+		} else {
+			prommetrics.AutomationRecovererPendingPayloads.Dec()
 		}
 	}
 	r.pending = updated
-	prommetrics.AutomationRecovererPendingPayloads.Set(float64(len(r.pending)))
 }
 
 // sortPending sorts the pending list by a random order based on the normalized latest block number.

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics/metrics.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics/metrics.go
@@ -6,13 +6,18 @@ import (
 )
 
 // AutomationNamespace is the namespace for all Automation related metrics
-const AutomationNamespace = "automation"
+const AutomationLogTriggerNamespace = "automation_log_trigger"
 
 // Automation metrics
 var (
 	AutomationLogsInLogBuffer = promauto.NewGauge(prometheus.GaugeOpts{
-		Namespace: AutomationNamespace,
+		Namespace: AutomationLogTriggerNamespace,
 		Name:      "num_logs_in_log_buffer",
 		Help:      "The total number of logs currently being stored in the log buffer",
+	})
+	AutomationRecovererMissedLogs = promauto.NewCounter(prometheus.CounterOpts{
+		Namespace: AutomationLogTriggerNamespace,
+		Name:      "num_recoverer_missed_logs",
+		Help:      "How many valid log triggers were identified as being missed by the recoverer",
 	})
 )

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics/metrics.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics/metrics.go
@@ -1,0 +1,18 @@
+package prommetrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+// AutomationNamespace is the namespace for all Automation related metrics
+const AutomationNamespace = "automation"
+
+// Automation metrics
+var (
+	AutomationLogsInLogBuffer = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: AutomationNamespace,
+		Name:      "num_logs_in_log_buffer",
+		Help:      "The total number of logs currently being stored in the log buffer",
+	})
+)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics/metrics.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics/metrics.go
@@ -20,4 +20,19 @@ var (
 		Name:      "num_recoverer_missed_logs",
 		Help:      "How many valid log triggers were identified as being missed by the recoverer",
 	})
+	AutomationRecovererPendingPayloads = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: AutomationLogTriggerNamespace,
+		Name:      "num_recoverer_pending_payloads",
+		Help:      "How many log trigger payloads are currently pending in the recoverer",
+	})
+	AutomationActiveUpkeeps = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: AutomationLogTriggerNamespace,
+		Name:      "num_active_upkeeps",
+		Help:      "How many log trigger upkeeps are currently active",
+	})
+	AutomationLogProviderLatestBlock = promauto.NewGauge(prometheus.GaugeOpts{
+		Namespace: AutomationLogTriggerNamespace,
+		Name:      "log_provider_latest_block",
+		Help:      "The latest block number the log provider has seen",
+	})
 )


### PR DESCRIPTION
Load test run: https://github.com/smartcontractkit/chainlink/actions/runs/7795494968
Metric charts: [link](https://grafana.ops.prod.cldev.sh/explore?schemaVersion=1&panes=%7B%22X-U%22:%7B%22datasource%22:%22P5DCFC7561CCDE821%22,%22queries%22:%5B%7B%22refId%22:%22B%22,%22expr%22:%22count%28automation_log_trigger_num_logs_in_log_buffer%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P5DCFC7561CCDE821%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22,%22useBackend%22:false,%22disableTextWrap%22:false,%22fullMetaSearch%22:false,%22includeNullMetadata%22:true%7D,%7B%22refId%22:%22A%22,%22expr%22:%22rate%28automation_log_trigger_num_recoverer_missed_logs%7B%7D%5B$__rate_interval%5D%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P5DCFC7561CCDE821%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22from%22:%221707200520000%22,%22to%22:%221707202320000%22%7D%7D%7D&orgId=1)