### PR TITLE
fix(contracts): inline isContract() call in ERC677

### DIFF
--- a/contracts/src/v0.8/shared/token/ERC677/ERC677.sol
+++ b/contracts/src/v0.8/shared/token/ERC677/ERC677.sol
@@ -4,19 +4,16 @@ pragma solidity ^0.8.0;
 import {IERC677} from "./IERC677.sol";
 import {IERC677Receiver} from "../../interfaces/IERC677Receiver.sol";
 
-import {Address} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/utils/Address.sol";
 import {ERC20} from "../../../vendor/openzeppelin-solidity/v4.8.3/contracts/token/ERC20/ERC20.sol";
 
 contract ERC677 is IERC677, ERC20 {
-  using Address for address;
-
   constructor(string memory name, string memory symbol) ERC20(name, symbol) {}
 
   /// @inheritdoc IERC677
   function transferAndCall(address to, uint256 amount, bytes memory data) public returns (bool success) {
     super.transfer(to, amount);
     emit Transfer(msg.sender, to, amount, data);
-    if (to.isContract()) {
+    if (to.code.length > 0) {
       IERC677Receiver(to).onTokenTransfer(msg.sender, amount, data);
     }
     return true;


### PR DESCRIPTION
## Motivation

Compiling the LINK token implementation for TVM fails with the following error:

```
TypeError: Member "isContract" not unique after argument-dependent lookup in address.
--> contracts/src/v0.8/shared/token/ERC677/ERC677.sol:19:9:
|
19 | if (to.isContract()) {
| ^^^^^^^^^^^^^
```

See https://github.com/tronprotocol/tronbox/issues/136 for more details.

## Solution

This change inlines the `isContract()` call to avoid ambiguity. Open Zeppelin solves this issue similarly (see https://github.com/OpenZeppelin/openzeppelin-contracts/pull/3945/files).