### PR TITLE
exclude debug.go

### DIFF
--- a/core/scripts/chaincli/handler/debug.go
+++ b/core/scripts/chaincli/handler/debug.go
@@ -75,7 +75,7 @@ func (k *Keeper) Debug(ctx context.Context, args []string) {
 	registryAddress := gethcommon.HexToAddress(k.cfg.RegistryAddress)
 	keeperRegistry21, err := iregistry21.NewIKeeperRegistryMaster(registryAddress, k.client)
 	if err != nil {
-		failUnknown("failed to connect to registry contract", err)
+		failUnknown("failed to connect to the registry contract", err)
 	}
 
 	// verify contract is correct

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.sources=.
 sonar.python.version=3.8
 
 # Full exclusions from the static analysis
-sonar.exclusions=**/node_modules/**/*,**/mocks/**/*, **/testdata/**/*, **/contracts/typechain/**/*, **/contracts/artifacts/**/*, **/contracts/cache/**/*, **/contracts/scripts/**/*, **/generated/**/*, **/fixtures/**/*, **/docs/**/*, **/tools/**/*, **/*.pb.go, **/*report.xml, **/*.config.ts, **/*.txt, **/*.abi, **/*.bin, **/*_codecgen.go, core/services/relay/evm/types/*_gen.go, core/services/relay/evm/types/gen/main.go, core/services/relay/evm/testfiles/*, **/core/web/assets**
+sonar.exclusions=**/node_modules/**/*,**/mocks/**/*, **/testdata/**/*, **/contracts/typechain/**/*, **/contracts/artifacts/**/*, **/contracts/cache/**/*, **/contracts/scripts/**/*, **/generated/**/*, **/fixtures/**/*, **/docs/**/*, **/tools/**/*, **/*.pb.go, **/*report.xml, **/*.config.ts, **/*.txt, **/*.abi, **/*.bin, **/*_codecgen.go, core/services/relay/evm/types/*_gen.go, core/services/relay/evm/types/gen/main.go, core/services/relay/evm/testfiles/*, **/core/web/assets**, core/scripts/chaincli/handler/debug.go
 # Coverage exclusions
 sonar.coverage.exclusions=**/*.test.ts, **/*_test.go, **/contracts/test/**/*, **/contracts/**/tests/**/*, **/core/**/testutils/**/*, **/core/**/mocks/**/*, **/core/**/cltest/**/*, **/integration-tests/**/*, **/generated/**/*, **/core/scripts**/* , **/*.pb.go, ./plugins/**/*, **/main.go, **/0195_add_not_null_to_evm_chain_id_in_job_specs.go
 # Duplication exclusions


### PR DESCRIPTION
Sync-ed with team, we have decided to exclude the script from sonar checks for now rather than spending time making the cosmetic surgery to make the debug function more modular. Some reasons as following:

This debug.go is a script, and we might need to completely change this within half a year so as to reflect our logic in the backend or contract.
We plan to have UI for the debugging script, so we will need to define the protocols to integrate with front end. so that will require some refactoring of the code
with the waterfall mode in the debugging script, it is relatively easy to understand the steps. Moving to smaller functions requires passing in a ton of params, making the code not as clean.
the script is "low fidelity prototype", should iterate quickly