### PR TITLE
golangci-lint: revive: add early-return; fix issues

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,7 +71,7 @@ linters-settings:
       - name: identical-branches
       - name: get-return
       # - name: flag-parameter
-      # - name: early-return
+      - name: early-return
       - name: defer
       - name: constant-logical-expr
       # - name: confusing-naming

--- a/core/chains/evm/types/models.go
+++ b/core/chains/evm/types/models.go
@@ -105,11 +105,10 @@ func (h *Head) IsInChain(blockHash common.Hash) bool {
 		if h.Hash == blockHash {
 			return true
 		}
-		if h.Parent != nil {
-			h = h.Parent
-		} else {
+		if h.Parent == nil {
 			break
 		}
+		h = h.Parent
 	}
 	return false
 }
@@ -121,11 +120,10 @@ func (h *Head) HashAtHeight(blockNum int64) common.Hash {
 		if h.Number == blockNum {
 			return h.Hash
 		}
-		if h.Parent != nil {
-			h = h.Parent
-		} else {
+		if h.Parent == nil {
 			break
 		}
+		h = h.Parent
 	}
 	return common.Hash{}
 }
@@ -138,15 +136,14 @@ func (h *Head) ChainLength() uint32 {
 	l := uint32(1)
 
 	for {
-		if h.Parent != nil {
-			l++
-			if h == h.Parent {
-				panic("circular reference detected")
-			}
-			h = h.Parent
-		} else {
+		if h.Parent == nil {
 			break
 		}
+		l++
+		if h == h.Parent {
+			panic("circular reference detected")
+		}
+		h = h.Parent
 	}
 	return l
 }
@@ -157,14 +154,13 @@ func (h *Head) ChainHashes() []common.Hash {
 
 	for {
 		hashes = append(hashes, h.Hash)
-		if h.Parent != nil {
-			if h == h.Parent {
-				panic("circular reference detected")
-			}
-			h = h.Parent
-		} else {
+		if h.Parent == nil {
 			break
 		}
+		if h == h.Parent {
+			panic("circular reference detected")
+		}
+		h = h.Parent
 	}
 	return hashes
 }
@@ -186,15 +182,14 @@ func (h *Head) ChainString() string {
 
 	for {
 		sb.WriteString(h.String())
-		if h.Parent != nil {
-			if h == h.Parent {
-				panic("circular reference detected")
-			}
-			sb.WriteString("->")
-			h = h.Parent
-		} else {
+		if h.Parent == nil {
 			break
 		}
+		if h == h.Parent {
+			panic("circular reference detected")
+		}
+		sb.WriteString("->")
+		h = h.Parent
 	}
 	sb.WriteString("->nil")
 	return sb.String()

--- a/core/gethwrappers/abigen.go
+++ b/core/gethwrappers/abigen.go
@@ -147,11 +147,10 @@ func getContractName(fileNode *ast.File) string {
 				if len(n.Name) < 3 {
 					return true
 				}
-				if n.Name[len(n.Name)-3:] == "ABI" {
-					contractName = n.Name[:len(n.Name)-3]
-				} else {
+				if n.Name[len(n.Name)-3:] != "ABI" {
 					return true
 				}
+				contractName = n.Name[:len(n.Name)-3]
 			}
 		}
 		return false

--- a/core/gethwrappers/go_generate_test.go
+++ b/core/gethwrappers/go_generate_test.go
@@ -138,11 +138,10 @@ func getProjectRoot(t *testing.T) (rootPath string) {
 	root, err := os.Getwd()
 	require.NoError(t, err, "could not get current working directory")
 	for root != "/" { // Walk up path to find dir containing go.mod
-		if _, err := os.Stat(filepath.Join(root, "go.mod")); os.IsNotExist(err) {
-			root = filepath.Dir(root)
-		} else {
+		if _, err := os.Stat(filepath.Join(root, "go.mod")); !os.IsNotExist(err) {
 			return root
 		}
+		root = filepath.Dir(root)
 	}
 	t.Fatal("could not find project root")
 	return

--- a/core/gethwrappers/utils.go
+++ b/core/gethwrappers/utils.go
@@ -44,11 +44,10 @@ func GetProjectRoot() (rootPath string) {
 			err)
 	}
 	for root != "/" { // Walk up path to find dir containing go.mod
-		if _, err := os.Stat(filepath.Join(root, "go.mod")); os.IsNotExist(err) {
-			root = filepath.Dir(root)
-		} else {
+		if _, err := os.Stat(filepath.Join(root, "go.mod")); !os.IsNotExist(err) {
 			return root
 		}
+		root = filepath.Dir(root)
 	}
 	Exit("could not find project root", nil)
 	panic("can't get here")

--- a/core/scripts/chaincli/handler/keeper_verifiable_load.go
+++ b/core/scripts/chaincli/handler/keeper_verifiable_load.go
@@ -203,12 +203,11 @@ func (k *Keeper) fetchBucketData(v verifiableLoad, opts *bind.CallOpts, id *big.
 	var err error
 	for i := 0; i < retryNum; i++ {
 		bucketDelays, err = v.GetBucketedDelays(opts, id, bucketNum)
-		if err != nil {
-			log.Printf("failed to get bucketed delays for upkeep id %s bucket %d: %v, retrying...", id.String(), bucketNum, err)
-			time.Sleep(retryDelay)
-		} else {
+		if err == nil {
 			break
 		}
+		log.Printf("failed to get bucketed delays for upkeep id %s bucket %d: %v, retrying...", id.String(), bucketNum, err)
+		time.Sleep(retryDelay)
 	}
 
 	var floatBucketDelays []float64

--- a/core/scripts/common/polygonedge.go
+++ b/core/scripts/common/polygonedge.go
@@ -149,11 +149,10 @@ func GetIbftExtraClean(extra []byte) (cleanedExtra []byte, err error) {
 	hexExtra := hex.EncodeToString(extra)
 	prefix := ""
 	for _, s := range hexExtra {
-		if s == '0' {
-			prefix = prefix + "0"
-		} else {
+		if s != '0' {
 			break
 		}
+		prefix = prefix + "0"
 	}
 
 	hexExtra = strings.TrimLeft(hexExtra, "0")

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -491,12 +491,11 @@ func GetEVMEffectiveTransmitterID(jb *job.Job, chain legacyevm.Chain, lggr logge
 		effectiveTransmitterID, err := chain.TxManager().GetForwarderForEOA(common.HexToAddress(spec.TransmitterID.String))
 		if err == nil {
 			return effectiveTransmitterID.String(), nil
-		} else if spec.TransmitterID.Valid {
-			lggr.Warnw("Skipping forwarding for job, will fallback to default behavior", "job", jb.Name, "err", err)
-			// this shouldn't happen unless behaviour above was changed
-		} else {
+		} else if !spec.TransmitterID.Valid {
 			return "", errors.New("failed to get forwarder address and transmitterID is not set")
 		}
+		lggr.Warnw("Skipping forwarding for job, will fallback to default behavior", "job", jb.Name, "err", err)
+		// this shouldn't happen unless behaviour above was changed
 	}
 
 	return spec.TransmitterID.String, nil

--- a/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
+++ b/core/services/ocr2/plugins/ocr2vrf/coordinator/coordinator.go
@@ -440,18 +440,17 @@ func (c *coordinator) ReportBlocks(
 	// Fill blocks slice with valid requested blocks.
 	blocks = []ocr2vrftypes.Block{}
 	for block := range blocksRequested {
-		if c.coordinatorConfig.BatchGasLimit-currentBatchGasLimit >= c.coordinatorConfig.BlockGasOverhead {
-			_, redeemRandomnessRequested := redeemRandomnessBlocksRequested[block]
-			blocks = append(blocks, ocr2vrftypes.Block{
-				Hash:              blockhashesMapping[block.blockNumber],
-				Height:            block.blockNumber,
-				ConfirmationDelay: block.confDelay,
-				ShouldStore:       redeemRandomnessRequested,
-			})
-			currentBatchGasLimit += c.coordinatorConfig.BlockGasOverhead
-		} else {
+		if c.coordinatorConfig.BatchGasLimit-currentBatchGasLimit < c.coordinatorConfig.BlockGasOverhead {
 			break
 		}
+		_, redeemRandomnessRequested := redeemRandomnessBlocksRequested[block]
+		blocks = append(blocks, ocr2vrftypes.Block{
+			Hash:              blockhashesMapping[block.blockNumber],
+			Height:            block.blockNumber,
+			ConfirmationDelay: block.confDelay,
+			ShouldStore:       redeemRandomnessRequested,
+		})
+		currentBatchGasLimit += c.coordinatorConfig.BlockGasOverhead
 	}
 
 	c.lggr.Tracew("got elligible blocks", "blocks", blocks)

--- a/core/services/pipeline/common.go
+++ b/core/services/pipeline/common.go
@@ -673,11 +673,10 @@ func getJsonNumberValue(value json.Number) (interface{}, error) {
 		}
 	} else {
 		f, err := value.Float64()
-		if err == nil {
-			result = f
-		} else {
+		if err != nil {
 			return nil, pkgerrors.Errorf("failed to parse json.Value: %v", err)
 		}
+		result = f
 	}
 
 	return result, nil

--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -546,11 +546,10 @@ func (r *runner) Run(ctx context.Context, run *Run, l logger.Logger, saveSuccess
 	// retain old UUID values
 	for _, taskRun := range run.PipelineTaskRuns {
 		task := pipeline.ByDotID(taskRun.DotID)
-		if task != nil && task.Base() != nil {
-			task.Base().uuid = taskRun.ID
-		} else {
+		if task == nil || task.Base() == nil {
 			return false, pkgerrors.Errorf("failed to match a pipeline task for dot ID: %v", taskRun.DotID)
 		}
+		task.Base().uuid = taskRun.ID
 	}
 
 	preinsert := pipeline.RequiresPreInsert()

--- a/core/services/pipeline/task_params.go
+++ b/core/services/pipeline/task_params.go
@@ -708,11 +708,11 @@ func (p *JSONPathParam) UnmarshalPipelineParam(val interface{}) error {
 		ssp = v
 	case []interface{}:
 		for _, x := range v {
-			if as, is := x.(string); is {
-				ssp = append(ssp, as)
-			} else {
+			as, is := x.(string)
+			if !is {
 				return ErrBadInput
 			}
+			ssp = append(ssp, as)
 		}
 	case string:
 		if len(v) == 0 {

--- a/core/services/relay/evm/functions/contract_transmitter.go
+++ b/core/services/relay/evm/functions/contract_transmitter.go
@@ -125,7 +125,8 @@ func (oc *contractTransmitter) Transmit(ctx context.Context, reportCtx ocrtypes.
 	}
 
 	var destinationContract common.Address
-	if oc.contractVersion == 1 {
+	switch oc.contractVersion {
+	case 1:
 		oc.lggr.Debugw("FunctionsContractTransmitter: start", "reportLenBytes", len(report))
 		requests, err2 := oc.reportCodec.DecodeReport(report)
 		if err2 != nil {
@@ -152,7 +153,7 @@ func (oc *contractTransmitter) Transmit(ctx context.Context, reportCtx ocrtypes.
 			}
 		}
 		oc.lggr.Debugw("FunctionsContractTransmitter: ready", "nRequests", len(requests), "coordinatorContract", destinationContract.Hex())
-	} else {
+	default:
 		return fmt.Errorf("unsupported contract version: %d", oc.contractVersion)
 	}
 	payload, err := oc.contractABI.Pack("transmit", rawReportCtx, []byte(report), rs, ss, vs)

--- a/core/services/relay/evm/functions/logpoller_wrapper.go
+++ b/core/services/relay/evm/functions/logpoller_wrapper.go
@@ -304,12 +304,11 @@ func (l *logPollerWrapper) filterPreviouslyDetectedEvents(logs []logpoller.Log, 
 	expiredRequests := 0
 	for _, detectedEvent := range detectedEvents.detectedEventsOrdered {
 		expirationTime := time.Now().Add(-time.Second * time.Duration(l.logPollerCacheDurationSec))
-		if detectedEvent.timeDetected.Before(expirationTime) {
-			delete(detectedEvents.isPreviouslyDetected, detectedEvent.requestId)
-			expiredRequests++
-		} else {
+		if !detectedEvent.timeDetected.Before(expirationTime) {
 			break
 		}
+		delete(detectedEvents.isPreviouslyDetected, detectedEvent.requestId)
+		expiredRequests++
 	}
 	detectedEvents.detectedEventsOrdered = detectedEvents.detectedEventsOrdered[expiredRequests:]
 	l.lggr.Debugw("filterPreviouslyDetectedEvents: done", "filterType", filterType, "nLogs", len(logs), "nFilteredLogs", len(filteredLogs), "nExpiredRequests", expiredRequests, "previouslyDetectedCacheSize", len(detectedEvents.detectedEventsOrdered))

--- a/core/services/relay/evm/mercury/wsrpc/client.go
+++ b/core/services/relay/evm/mercury/wsrpc/client.go
@@ -193,16 +193,16 @@ func (w *client) resetTransport() {
 	b := utils.NewRedialBackoff()
 	for {
 		// Will block until successful dial, or context is canceled (i.e. on close)
-		if err := w.dial(ctx, wsrpc.WithBlock()); err != nil {
-			if ctx.Err() != nil {
-				w.logger.Debugw("ResetTransport exiting due to client Close", "err", err)
-				return
-			}
-			w.logger.Errorw("ResetTransport failed to redial", "err", err)
-			time.Sleep(b.Duration())
-		} else {
+		err := w.dial(ctx, wsrpc.WithBlock())
+		if err == nil {
 			break
 		}
+		if ctx.Err() != nil {
+			w.logger.Debugw("ResetTransport exiting due to client Close", "err", err)
+			return
+		}
+		w.logger.Errorw("ResetTransport failed to redial", "err", err)
+		time.Sleep(b.Duration())
 	}
 	w.logger.Info("ResetTransport successfully redialled")
 }

--- a/core/services/vrf/v2/listener_v2_log_processor.go
+++ b/core/services/vrf/v2/listener_v2_log_processor.go
@@ -155,22 +155,21 @@ func (lsn *listenerV2) processPendingVRFRequests(ctx context.Context, pendingReq
 			Context: ctx}, sID)
 
 		if err != nil {
-			if strings.Contains(err.Error(), "execution reverted") {
-				// "execution reverted" indicates that the subscription no longer exists.
-				// We can no longer just mark these as processed and continue,
-				// since it could be that the subscription was canceled while there
-				// were still unfulfilled requests.
-				// The simplest approach to handle this is to enter the processRequestsPerSub
-				// loop rather than create a bunch of largely duplicated code
-				// to handle this specific situation, since we need to run the pipeline to get
-				// the VRF proof, abi-encode it, etc.
-				l.Warnw("Subscription not found - setting start balance to zero", "subID", subID, "err", err)
-				startLinkBalance = big.NewInt(0)
-			} else {
+			if !strings.Contains(err.Error(), "execution reverted") {
 				// Most likely this is an RPC error, so we re-try later.
 				l.Errorw("Unable to read subscription balance", "err", err)
 				return
 			}
+			// "execution reverted" indicates that the subscription no longer exists.
+			// We can no longer just mark these as processed and continue,
+			// since it could be that the subscription was canceled while there
+			// were still unfulfilled requests.
+			// The simplest approach to handle this is to enter the processRequestsPerSub
+			// loop rather than create a bunch of largely duplicated code
+			// to handle this specific situation, since we need to run the pipeline to get
+			// the VRF proof, abi-encode it, etc.
+			l.Warnw("Subscription not found - setting start balance to zero", "subID", subID, "err", err)
+			startLinkBalance = big.NewInt(0)
 		} else {
 			// Happy path - sub is active.
 			startLinkBalance = sub.Balance()

--- a/core/sessions/ldapauth/ldap.go
+++ b/core/sessions/ldapauth/ldap.go
@@ -124,16 +124,14 @@ func (l *ldapAuthenticator) FindUser(email string) (sessions.User, error) {
 		sql := "SELECT * FROM users WHERE lower(email) = lower($1)"
 		return tx.Get(&foundLocalAdminUser, sql, email)
 	})
-	if checkErr != nil {
-		// If error is not nil, there was either an issue or no local users found
-		if !errors.Is(checkErr, sql.ErrNoRows) {
-			// If the error is not that no local user was found, log and exit
-			l.lggr.Errorf("error searching users table: %v", checkErr)
-			return sessions.User{}, errors.New("error Finding user")
-		}
-	} else {
-		// Error was nil, local user found. Return
+	if checkErr == nil {
 		return foundLocalAdminUser, nil
+	}
+	// If error is not nil, there was either an issue or no local users found
+	if !errors.Is(checkErr, sql.ErrNoRows) {
+		// If the error is not that no local user was found, log and exit
+		l.lggr.Errorf("error searching users table: %v", checkErr)
+		return sessions.User{}, errors.New("error Finding user")
 	}
 
 	// First query for user "is active" property if defined

--- a/core/web/cosmos_transfer_controller.go
+++ b/core/web/cosmos_transfer_controller.go
@@ -60,12 +60,12 @@ func (tc *CosmosTransfersController) Create(c *gin.Context) {
 	}
 	var gasToken string
 	cfgs := tc.App.GetConfig().CosmosConfigs()
-	if i := slices.IndexFunc(cfgs, func(config *coscfg.TOMLConfig) bool { return *config.ChainID == tr.CosmosChainID }); i != -1 {
-		gasToken = cfgs[i].GasToken()
-	} else {
+	i := slices.IndexFunc(cfgs, func(config *coscfg.TOMLConfig) bool { return *config.ChainID == tr.CosmosChainID })
+	if i == -1 {
 		jsonAPIError(c, http.StatusInternalServerError, fmt.Errorf("no config for chain id: %s", tr.CosmosChainID))
 		return
 	}
+	gasToken = cfgs[i].GasToken()
 
 	//TODO move this inside?
 	coin, err := denom.ConvertDecCoinToDenom(sdk.NewDecCoinFromDec(tr.Token, tr.Amount), gasToken)


### PR DESCRIPTION
Enable `early-return` in the `revive` rule set for `golangci-lint` and fix outstanding issues.