### PR TITLE
chore: github action version bumps

### DIFF
--- a/.github/actions/build-sign-publish-chainlink/action.yml
+++ b/.github/actions/build-sign-publish-chainlink/action.yml
@@ -122,7 +122,7 @@ runs:
 
     - name: Generate docker metadata for root image
       id: meta-root
-      uses: docker/metadata-action@2c0bd771b40637d97bf205cbccdd294a32112176 # v4.5.0
+      uses: docker/metadata-action@dbef88086f6cef02e264edb7dbf63250c17cef6c # v5.5.0
       env:
         DOCKER_METADATA_PR_HEAD_SHA: "true"
       with:

--- a/.github/actions/delete-deployments/action.yml
+++ b/.github/actions/delete-deployments/action.yml
@@ -29,7 +29,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # v2.2.4
+    - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       with:
         version: ^8.0.0
 

--- a/.github/actions/setup-nodejs/action.yaml
+++ b/.github/actions/setup-nodejs/action.yaml
@@ -7,7 +7,7 @@ description: Setup pnpm for contracts
 runs:
   using: composite
   steps:
-    - uses: pnpm/action-setup@c3b53f6a16e57305370b4ae5a540c2077a1d50dd # v2.2.4
+    - uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
       with:
         version: ^7.0.0
 

--- a/.github/workflows/bash-scripts.yml
+++ b/.github/workflows/bash-scripts.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+      - uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: bash-scripts
         with:
           filters: |

--- a/.github/workflows/dependency-check.yml
+++ b/.github/workflows/dependency-check.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+      - uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           filters: |

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+      - uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           filters: |

--- a/.github/workflows/solidity-foundry.yml
+++ b/.github/workflows/solidity-foundry.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+      - uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           # Foundry is only used for Solidity v0.8 contracts, therefore we can ignore

--- a/.github/workflows/solidity-hardhat.yml
+++ b/.github/workflows/solidity-hardhat.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+      - uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           filters: |

--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - name: Checkout the repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - uses: dorny/paths-filter@4512585405083f25c027a35db413c2b3b9006d50 # v2.11.1
+      - uses: dorny/paths-filter@0bc4621a3135347011ad047f9ecf449bf72ce2bd # v3.0.0
         id: changes
         with:
           list-files: "csv"


### PR DESCRIPTION
Updating:
- `pnpm/action-setup` to v3.0.0 - https://github.com/pnpm/action-setup/releases/tag/v3.0.0
- `docker/metadata-action to v5.5.0 - https://github.com/docker/metadata-action/releases/tag/v5.5.0
- `dorny/paths-filter` to v3.0.0 - https://github.com/dorny/paths-filter/releases/tag/v3.0.0

The major version bump for all these packages is the upgrade from `node16` to `node20` runtime. 