### PR TITLE
juels per fee coin data source caching draft

### DIFF
--- a/core/services/ocr2/plugins/median/config/config.go
+++ b/core/services/ocr2/plugins/median/config/config.go
@@ -4,6 +4,8 @@
 package config
 
 import (
+	"time"
+
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/chainlink/v2/core/services/pipeline"
@@ -11,9 +13,12 @@ import (
 
 // The PluginConfig struct contains the custom arguments needed for the Median plugin.
 type PluginConfig struct {
-	JuelsPerFeeCoinPipeline string `json:"juelsPerFeeCoinSource"`
+	JuelsPerFeeCoinPipeline      string        `json:"juelsPerFeeCoinSource"`
+	JuelsPerFeeCoinCaching       bool          `json:"juelsPerFeeCoinCaching"`
+	JuelsPerFeeCoinCacheDuration time.Duration `json:"juelsPerFeeCoinCacheDuration"`
 }
 
+// TODO add validation
 // ValidatePluginConfig validates the arguments for the Median plugin.
 func ValidatePluginConfig(config PluginConfig) error {
 	if _, err := pipeline.Parse(config.JuelsPerFeeCoinPipeline); err != nil {

--- a/core/services/ocr2/plugins/median/config/config.go
+++ b/core/services/ocr2/plugins/median/config/config.go
@@ -18,11 +18,14 @@ type PluginConfig struct {
 	JuelsPerFeeCoinCacheDuration time.Duration `json:"juelsPerFeeCoinCacheDuration"`
 }
 
-// TODO add validation
 // ValidatePluginConfig validates the arguments for the Median plugin.
 func ValidatePluginConfig(config PluginConfig) error {
 	if _, err := pipeline.Parse(config.JuelsPerFeeCoinPipeline); err != nil {
 		return errors.Wrap(err, "invalid juelsPerFeeCoinSource pipeline")
+	}
+
+	if config.JuelsPerFeeCoinCacheDuration < time.Minute || config.JuelsPerFeeCoinCacheDuration > 5*time.Minute {
+		return errors.Errorf("invalid juelsPerFeeCoinSource cache duration %s", config.JuelsPerFeeCoinCacheDuration.String())
 	}
 
 	return nil


### PR DESCRIPTION
- Seems like the least invasive way of doing this. Putting this into libocr makes it hard to configure the cache.  
- Not sure about timeout length for cron cache updater

This is per job, it also makes sense to have a single instance for all jobs 