### PR TITLE
Add 2.1+ version in job spec and update changelog for old transmitter change

### DIFF
--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -1058,6 +1058,9 @@ func (d *Delegate) newServicesOCR2Keepers(
 	switch cfg.ContractVersion {
 	case "v2.1":
 		return d.newServicesOCR2Keepers21(ctx, lggr, jb, bootstrapPeers, kb, ocrDB, lc, ocrLogger, cfg, spec)
+	case "v2.1+":
+		// Future contracts of v2.1 (v2.x) will use the same job spec as v2.1
+		return d.newServicesOCR2Keepers21(ctx, lggr, jb, bootstrapPeers, kb, ocrDB, lc, ocrLogger, cfg, spec)
 	case "v2.0":
 		return d.newServicesOCR2Keepers20(lggr, jb, bootstrapPeers, kb, ocrDB, lc, ocrLogger, cfg, spec)
 	default:

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   URL = '...'
   ServerPubKey = '...'
 ```
+- Automation v2 jobs no longer record pipeline runs when performing upkeeps. Please check logs or on-chain txs to verify node is working as expected.
 
 <!-- unreleasedstop -->
 


### PR DESCRIPTION
This PR does two changes that we want to push in 2.9.1

- Add support of "v2.1+" in contract version of job spec to enable it to be used for 2.2 and future contracts
- update changelog for a change that was missed for pipeline transmitter change