### PR TITLE
Change default for logs_per_block & max_logs_kept columns from NULL to 0

### DIFF
--- a/core/store/migrate/migrations/0225_log_poller_filters_add_topics_logs_per_block.sql
+++ b/core/store/migrate/migrations/0225_log_poller_filters_add_topics_logs_per_block.sql
@@ -12,8 +12,8 @@ ALTER TABLE evm.log_poller_filters
     ADD COLUMN topic2 BYTEA CHECK (octet_length(topic2) = 32),
     ADD COLUMN topic3 BYTEA CHECK (octet_length(topic3) = 32),
     ADD COLUMN topic4 BYTEA CHECK (octet_length(topic4) = 32),
-    ADD COLUMN max_logs_kept BIGINT,
-    ADD COLUMN logs_per_block BIGINT;
+    ADD COLUMN max_logs_kept BIGINT NOT NULL DEFAULT 0,
+    ADD COLUMN logs_per_block BIGINT NOT NULL DEFAULT 0;
 
 CREATE UNIQUE INDEX log_poller_filters_hash_key ON evm.log_poller_filters (evm.f_log_poller_filter_hash(name, evm_chain_id, address, event, topic2, topic3, topic4));
 


### PR DESCRIPTION
During PR review of https://github.com/smartcontractkit/chainlink/pull/11949, we decided to change the types of [ max_logs_kept / MaxLogsKept ]
and[ logs_per_block / LogsPerBlock ] from [ NUMERIC / *big.Int ] to [ BIGINT / uint64 ]. I intended the default value to be 0 now instead of NULL,
but forgot to add the corresponding NOT NULL DEFAULT 0 clause to these columns in the db schema
```
type Filter struct {
...
	MaxLogsKept  uint64             // maximum number of logs to retain ( 0 = unlimited )
	LogsPerBlock uint64             // rate limit ( maximum # of logs per block, 0 = unlimited )
}
```