### PR TITLE
improve ondemand test workflow

### DIFF
--- a/.github/workflows/automation-ondemand-tests.yml
+++ b/.github/workflows/automation-ondemand-tests.yml
@@ -114,6 +114,7 @@ jobs:
         with:
           ref: ${{ github.head_ref || github.ref_name }}
       - name: Build Test Image
+        if: inputs.enableChaos || inputs.enableReorg
         uses: ./.github/actions/build-test-image
         with:
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}


### PR DESCRIPTION
Added boolean inputs to automation-ondemand-tests to enable/disable run of chaos and reorg tests, since they are not needed to be run at all times.