### PR TITLE
Remove trigger to run Mercury v0.2 tests on core merge to develop

### DIFF
--- a/.github/workflows/goreleaser-build-publish-develop.yml
+++ b/.github/workflows/goreleaser-build-publish-develop.yml
@@ -46,45 +46,4 @@ jobs:
           hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           this-job-name: push-chainlink-develop-goreleaser
         continue-on-error: true
-
-  mercury-e2e-tests:
-    needs: [push-chainlink-develop-goreleaser]
-    runs-on:
-      labels: ubuntu-latest
-    environment: build-develop
-    permissions:
-      id-token: write
-      contents: read
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-      - name: Configure aws credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4.0.2
-        with:
-          role-to-assume: ${{ secrets.AWS_ROLE_ARN_GATI }}
-          role-duration-seconds: ${{ secrets.AWS_ROLE_DURATION_SECONDS }}
-          aws-region: ${{ secrets.AWS_REGION }}
-      - name: Get Github Token
-        id: get-gh-token
-        uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@main
-        with:
-          url: ${{ secrets.GATI_LAMBDA_FUNCTION_URL }}
-      - name: 'Dispatch Workflow: E2E Functional Tests'
-        id: dispatch-workflow-e2e-functional-tests
-        shell: bash
-        run: |
-          image_build_metadata=$(jq -n \
-                                  --arg commit_sha "$GITHUB_SHA" \
-                                  --arg run_url "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}" \
-                                  '{
-                                    commit_sha: $commit_sha,
-                                    originating_run_url: $run_url
-                                  }')
-          gh workflow run "e2e-functional-tests.yml" \
-            --repo ${{ secrets.MERCURY_SERVER_REPO }} \
-            --ref "main" \
-            --field chainlink-ecr-repo-account="sdlc" \
-            --field chainlink-image-build-metadata="${image_build_metadata}" \
-            --field chainlink-image-tag="develop"
-        env:
-          GH_TOKEN: ${{ steps.get-gh-token.outputs.access-token }}
+        


### PR DESCRIPTION
This is to revert https://github.com/smartcontractkit/chainlink/pull/9463. We no longer need to this automatically for Mercury v0.2 repo.