### PR TITLE
Add chain client wrapper for easier external use

### DIFF
--- a/core/chains/evm/client/chain_client.go
+++ b/core/chains/evm/client/chain_client.go
@@ -51,20 +51,7 @@ func NewChainClient(
 	chainID *big.Int,
 	chainType config.ChainType,
 ) Client {
-	multiNode := commonclient.NewMultiNode[
-		*big.Int,
-		evmtypes.Nonce,
-		common.Address,
-		common.Hash,
-		*types.Transaction,
-		common.Hash,
-		types.Log,
-		ethereum.FilterQuery,
-		*evmtypes.Receipt,
-		*assets.Wei,
-		*evmtypes.Head,
-		RPCClient,
-	](
+	multiNode := commonclient.NewMultiNode(
 		lggr,
 		selectionMode,
 		leaseDuration,

--- a/core/chains/evm/client/chainclient/chain_client.go
+++ b/core/chains/evm/client/chainclient/chain_client.go
@@ -1,0 +1,44 @@
+package chain_client
+
+import (
+	"math/big"
+	"net/url"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	commonclient "github.com/smartcontractkit/chainlink/v2/common/client"
+	commonconfig "github.com/smartcontractkit/chainlink/v2/common/config"
+
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
+	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
+)
+
+// Wrapper around the client package NewChainClient
+// Allows the chain client to be more accessible to external users that may not have the know how to properly initialize the different components
+// Configs should only be common go types
+func NewChainClient(lggrName string, cfg ChainClientConfig) (client.Client, error) {
+	lggr, err := logger.New()
+	if err != nil {
+		return nil, err
+	}
+	lggr = logger.Named(lggr, lggrName)
+	var empty url.URL
+	var primaries []commonclient.Node[*big.Int, *evmtypes.Head, client.RPCClient]
+	var sendonlys []commonclient.SendOnlyNode[*big.Int, client.RPCClient]
+	for i, node := range cfg.nodes {
+		if node.SendOnly != nil && *node.SendOnly {
+			rpc := client.NewRPCClient(lggr, empty, (*url.URL)(node.HTTPURL), *node.Name, int32(i), cfg.chainID,
+				commonclient.Secondary)
+			sendonly := commonclient.NewSendOnlyNode(lggr, (url.URL)(*node.HTTPURL),
+				*node.Name, cfg.chainID, rpc)
+			sendonlys = append(sendonlys, sendonly)
+		} else {
+			rpc := client.NewRPCClient(lggr, (url.URL)(*node.WSURL), (*url.URL)(node.HTTPURL), *node.Name, int32(i),
+				cfg.chainID, commonclient.Primary)
+			primaryNode := commonclient.NewNode(cfg, cfg.noNewHeadsThreshold,
+				lggr, (url.URL)(*node.WSURL), (*url.URL)(node.HTTPURL), *node.Name, int32(i), cfg.chainID, *node.Order,
+				rpc, "EVM")
+			primaries = append(primaries, primaryNode)
+		}
+	}
+	return client.NewChainClient(lggr, cfg.SelectionMode(), cfg.leaseDuration, cfg.noNewHeadsThreshold, primaries, sendonlys, cfg.chainID, commonconfig.ChainType(cfg.chainType)), nil
+}

--- a/core/chains/evm/client/chainclient/node_config.go
+++ b/core/chains/evm/client/chainclient/node_config.go
@@ -1,0 +1,141 @@
+package chain_client
+
+import (
+	"fmt"
+	"math/big"
+	"net/url"
+	"time"
+
+	"go.uber.org/multierr"
+
+	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
+	commonclient "github.com/smartcontractkit/chainlink/v2/common/client"
+	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/toml"
+)
+
+var _ commonclient.NodeConfig = ChainClientConfig{}
+
+type ChainClientConfig struct {
+	noNewHeadsThreshold time.Duration
+	chainID             *big.Int
+	chainType           string
+	nodes               []toml.Node
+
+	selectionMode        string
+	leaseDuration        time.Duration
+	pollFailureThreshold uint32
+	pollInterval         time.Duration
+	syncThreshold        uint32
+	nodeIsSyncingEnabled bool
+}
+
+type NodeConfig struct {
+	Name     *string
+	WSURL    *string
+	HTTPURL  *string
+	SendOnly *bool
+	Order    *int32
+}
+
+func NewChainClientConfig(
+	selectionMode string,
+	leaseDuration time.Duration,
+	noNewHeadsThreshold time.Duration,
+	chainID *big.Int,
+	chainType string,
+	nodeCfgs []NodeConfig,
+	pollFailureThreshold uint32,
+	pollInterval time.Duration,
+	syncThreshold uint32,
+	nodeIsSyncingEnabled bool,
+) (*ChainClientConfig, error) {
+	nodes, err := parseNodeConfigs(nodeCfgs)
+	if err != nil {
+		return nil, err
+	}
+	return &ChainClientConfig{
+		selectionMode:        selectionMode,
+		leaseDuration:        leaseDuration,
+		noNewHeadsThreshold:  noNewHeadsThreshold,
+		chainID:              chainID,
+		chainType:            chainType,
+		nodes:                nodes,
+		pollFailureThreshold: pollFailureThreshold,
+		pollInterval:         pollInterval,
+		syncThreshold:        syncThreshold,
+		nodeIsSyncingEnabled: nodeIsSyncingEnabled,
+	}, nil
+}
+
+func parseNodeConfigs(nodeCfgs []NodeConfig) ([]toml.Node, error) {
+	nodes := make([]toml.Node, len(nodeCfgs))
+	for _, nodeCfg := range nodeCfgs {
+		wsUrl, err := commonconfig.ParseURL(*nodeCfg.WSURL)
+		if err != nil {
+			return nil, err
+		}
+		var httpUrl *commonconfig.URL
+		httpUrl, err = commonconfig.ParseURL(*nodeCfg.HTTPURL)
+		if err != nil {
+			return nil, err
+		}
+		node := toml.Node{
+			Name:     nodeCfg.Name,
+			WSURL:    wsUrl,
+			HTTPURL:  httpUrl,
+			SendOnly: nodeCfg.SendOnly,
+			Order:    nodeCfg.Order,
+		}
+		nodes = append(nodes, node)
+	}
+
+	if err := validateNodeConfigs(nodes); err != nil {
+		return nil, err
+	}
+
+	return nodes, nil
+}
+
+func validateNodeConfigs(nodes []toml.Node) (err error) {
+	names := commonconfig.UniqueStrings{}
+	wsURLs := commonconfig.UniqueStrings{}
+	httpURLs := commonconfig.UniqueStrings{}
+	for i, node := range nodes {
+		if nodeErr := node.ValidateConfig(); nodeErr != nil {
+			err = multierr.Append(err, nodeErr)
+		}
+		if names.IsDupe(node.Name) {
+			err = multierr.Append(err, commonconfig.NewErrDuplicate(fmt.Sprintf("Nodes.%d.Name", i), *node.Name))
+		}
+		u := (*url.URL)(node.WSURL)
+		if wsURLs.IsDupeFmt(u) {
+			err = multierr.Append(err, commonconfig.NewErrDuplicate(fmt.Sprintf("Nodes.%d.WSURL", i), u.String()))
+		}
+		u = (*url.URL)(node.HTTPURL)
+		if httpURLs.IsDupeFmt(u) {
+			err = multierr.Append(err, commonconfig.NewErrDuplicate(fmt.Sprintf("Nodes.%d.HTTPURL", i), u.String()))
+		}
+	}
+
+	return err
+}
+
+func (c ChainClientConfig) PollFailureThreshold() uint32 {
+	return c.pollFailureThreshold
+}
+
+func (c ChainClientConfig) PollInterval() time.Duration {
+	return c.pollInterval
+}
+
+func (c ChainClientConfig) SelectionMode() string {
+	return c.selectionMode
+}
+
+func (c ChainClientConfig) SyncThreshold() uint32 {
+	return c.syncThreshold
+}
+
+func (c ChainClientConfig) NodeIsSyncingEnabled() bool {
+	return c.nodeIsSyncingEnabled
+}


### PR DESCRIPTION
Created a thin wrapper around the [EVM chain client](https://github.com/smartcontractkit/chainlink/blob/4534b59a716a41b6ef43287318e510120ed9f728/core/chains/evm/client/chain_client.go#L44) for easier external use. Currently, the parameters would require a user to properly initialize certain components such as RPC clients, Nodes, SendOnlyNodes, etc. Leaving this responsibility to the user would make it difficult for external products such as Atlas to integrate. The wrapper takes care of initializing all components and only requires configs made up of basic go types. The configs needed to initialize a chain client were consolidated into a new struct to minimize imports for the user.