### PR TITLE
add error for arbitrum

### DIFF
--- a/core/chains/evm/client/errors.go
+++ b/core/chains/evm/client/errors.go
@@ -140,6 +140,7 @@ var arbitrum = ClientErrors{
 	Fatal:                 arbitrumFatal,
 	L2FeeTooLow:           regexp.MustCompile(`(: |^)max fee per gas less than block base fee(:|$)`),
 	L2Full:                regexp.MustCompile(`(: |^)(queue full|sequencer pending tx pool full, please try again)(:|$)`),
+	ServiceUnavailable:    regexp.MustCompile(`(: |^)502 Bad Gateway: [\s\S]*$`),
 }
 
 var celo = ClientErrors{

--- a/core/chains/evm/client/errors_test.go
+++ b/core/chains/evm/client/errors_test.go
@@ -213,6 +213,7 @@ func Test_Eth_Errors(t *testing.T) {
 	t.Run("IsServiceUnavailable", func(t *testing.T) {
 		tests := []errorCase{
 			{"call failed: 503 Service Unavailable: <html>\r\n<head><title>503 Service Temporarily Unavailable</title></head>\r\n<body>\r\n<center><h1>503 Service Temporarily Unavailable</h1></center>\r\n</body>\r\n</html>\r\n", true, "Nethermind"},
+			{"call failed: 502 Bad Gateway: <html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>", true, "Arbitrum"},
 		}
 		for _, test := range tests {
 			err = evmclient.NewSendErrorS(test.message)


### PR DESCRIPTION
This error kept appearing

```
{"level":"error","ts":"2024-03-04T20:27:29.090Z","logger":"EVM.421614.Txm.Broadcaster","caller":"txmgr/broadcaster.go:361","msg":"Error occurred while handling tx queue in ProcessUnstartedTxs","version":"2.9.1-automation-20240220@1a44d71","err":"processUnstartedTxs failed on handleAnyInProgressTx: handleAnyInProgressTx failed: failed to fetch latest pending sequence after encountering unknown RPC error while sending transaction: primary http (https://arbitrum-testnet-cl-1.simplystaking.xyz/NJYOEWI59II1/rpc) call failed: 502 Bad Gateway: <html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx/1.18.0 (Ubuntu)</center>\r\n</body>\r\n</html>\r\n; primary http (https://arbitrum-testnet-cl-1.simplystaking.xyz/NJYOEWI59II1/rpc) call failed: 502 Bad Gateway: <html>\r\n<head><title>502 Bad Gateway</title></head>\r\n<body>\r\n<center><h1>502 Bad Gateway</h1></center>\r\n<hr><center>nginx/1.18.0 (Ubuntu)</center>\r\n</body>\r\n</html>\r\n","sentryEventID":null,"stacktrace":"github.com/smartcontractkit/chainlink/v2/common/txmgr.(*Broadcaster[...]).monitorTxs\n\t/chainlink/common/txmgr/broadcaster.go:361"}
```