### PR TITLE
Improve experience with ingresses in DevSpace

### DIFF
--- a/charts/chainlink-cluster/.helmignore
+++ b/charts/chainlink-cluster/.helmignore
@@ -22,3 +22,4 @@
 *.tmproj
 .vscode/
 .devspace/
+scripts/

--- a/charts/chainlink-cluster/devspace.yaml
+++ b/charts/chainlink-cluster/devspace.yaml
@@ -33,18 +33,11 @@ pipelines:
 
       echo
       echo "Namespace ${DEVSPACE_NAMESPACE} will be deleted in ${NS_TTL}"
-      echo "To extend the TTL for e.g. 72 hours, run: devspace run ttl ${DEVSPACE_NAMESPACE} 72h"
-      kubectl label namespace ${DEVSPACE_NAMESPACE} cleanup.kyverno.io/ttl=${NS_TTL} || true
-      kubectl label namespace/${DEVSPACE_NAMESPACE} network=crib || true
-
+      echo "To extend the TTL for e.g. 72 hours, run:"
+      echo "devspace run ttl ${DEVSPACE_NAMESPACE} 72h"
       echo
-      echo "############################################"
-      echo "Ingress Domains"
-      echo "############################################"
-      ingress_names="node1 node2 node3 node4 node5 node6 geth-1337-http geth-1337-ws geth-2337-http geth-2337-ws"
-      for ingress in ${ingress_names}; do
-        echo "https://${DEVSPACE_NAMESPACE}-${ingress}.${DEVSPACE_INGRESS_BASE_DOMAIN}"
-      done
+      kubectl label namespace ${DEVSPACE_NAMESPACE} cleanup.kyverno.io/ttl=${NS_TTL} > /dev/null 2>&1 || true
+      kubectl label namespace/${DEVSPACE_NAMESPACE} network=crib > /dev/null 2>&1 || true
 
   purge:
     run: |-
@@ -83,7 +76,12 @@ hooks:
         # vars don't work here, = releaseName
         release: "app"
     events: ["after:deploy:app"]
-    name: "wait-for-pod-hook"
+
+  # Check that the ingress was created successfully, and print ingress hostnames.
+  - name: "ingress-check-hook"
+    command: ./scripts/ingress_check.sh
+    args: ["app"] # Ingress name.
+    events: ["after:deploy:app"]
 
 # This is a list of `deployments` that DevSpace can create for this project
 deployments:

--- a/charts/chainlink-cluster/devspace.yaml
+++ b/charts/chainlink-cluster/devspace.yaml
@@ -51,6 +51,9 @@ pipelines:
       kubectl delete ns ${DEVSPACE_NAMESPACE}
 
 commands:
+  ingress-hosts: |-
+    kubectl get ingress -n ${DEVSPACE_NAMESPACE} \
+      -o=jsonpath="{range .items[*].spec.rules[*]}{.host}{'\n'}{end}"
   connect: |-
     sudo kubefwd svc -n $1
   ttl: |-
@@ -69,7 +72,7 @@ images:
 
         image=${runtime.images.app}
         MACOS_SDK_DIR=$(pwd)/tools/bin/MacOSX12.3.sdk IMAGE=$image ./tools/bin/goreleaser_wrapper release --snapshot --clean --config .goreleaser.devspace.yaml
-        docker push $image 
+        docker push $image
 hooks:
   - wait:
       running: true

--- a/charts/chainlink-cluster/scripts/ingress_check.sh
+++ b/charts/chainlink-cluster/scripts/ingress_check.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+###
+# To be invoked by `devspace` after a successful DevSpace deploy via a hook.
+###
+
+if [[ -z "${DEVSPACE_HOOK_KUBE_NAMESPACE:-}" ]]; then
+  echo "Error: DEVSPACE_HOOK_KUBE_NAMESPACE is not set. Make sure to run from devspace."
+  exit 1
+fi
+
+INGRESS_NAME="${1:-}"
+if [[ -z "${INGRESS_NAME}" ]]; then
+    echo "Usage: $0 INGRESS_NAME"
+    exit 1
+fi
+
+max_retries=10
+sleep_duration_retry=10 # 10 seconds
+sleep_duration_propagate=60 # 60 seconds
+timeout=$((60 * 2)) # 2 minutes
+elapsed=0 # Track the elapsed time
+
+# Loop until conditions are met or we reach max retries or timeout
+for ((i=1; i<=max_retries && elapsed<=timeout; i++)); do
+  ingress_hostname_aws=$(kubectl get ingress "${INGRESS_NAME}" -n "${DEVSPACE_HOOK_KUBE_NAMESPACE}" \
+    -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+  
+  # Sometimes the events on the ingress are "<none>" instead of "successfully reconciled".
+  # So we use the AWS hostname as a signal that the ingress has been created successfully.
+  if echo "${ingress_hostname_aws}" | grep -q ".elb.amazonaws.com"; then
+    echo "#############################################################"
+    echo "# Ingress hostnames:"
+    echo "#############################################################"
+    devspace run ingress-hosts
+    echo
+    echo "Sleeping for ${sleep_duration_propagate} seconds to allow DNS records to propagate... (Use CTRL+C to safely skip this step.)"
+    sleep $sleep_duration_propagate
+    echo "...done. NOTE: If you have an issue with the DNS records, try to reset your local and/or VPN DNS cache."
+    exit 0
+  else
+    echo "Attempt $i: Waiting for the ingress to be created..."
+    sleep $sleep_duration_retry
+    ((elapsed += sleep_duration_retry))
+  fi
+done
+
+# If we reached here, it means we hit the retry limit or the timeout
+echo "Error: Ingress was not successfully created within the given constraints."
+exit 1


### PR DESCRIPTION
1. Creates a new `devspace run ingress-hosts` command
2. Moves ingress output to an `after:deploy` hook and run a new `ingress_check.sh` script to check if the ingress looks to be created before displaying hostnames.
3. Prevents output on label operations