### PR TITLE
Split log buffer flow metric into two metrics

### DIFF
--- a/.changeset/spicy-horses-poke.md
+++ b/.changeset/spicy-horses-poke.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Updating prometheus metrics for Automation log triggers

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer.go
@@ -231,7 +231,8 @@ func (b *logEventBuffer) enqueue(id *big.Int, logs ...logpoller.Log) int {
 	}
 	if added > 0 {
 		lggr.Debugw("Added logs to buffer", "addedLogs", added, "dropped", dropped, "latestBlock", latestBlock)
-		prommetrics.AutomationLogsInLogBuffer.Add(float64(added - dropped))
+		prommetrics.AutomationLogBufferFlow.WithLabelValues(prommetrics.LogBufferFlowDirectionIngress).Add(float64(added))
+		prommetrics.AutomationLogBufferFlow.WithLabelValues(prommetrics.LogBufferFlowDirectionEgress).Add(float64(dropped))
 	}
 
 	return added - dropped
@@ -333,7 +334,7 @@ func (b *logEventBuffer) dequeueRange(start, end int64, upkeepLimit, totalLimit 
 
 	if len(results) > 0 {
 		b.lggr.Debugw("Dequeued logs", "results", len(results), "start", start, "end", end)
-		prommetrics.AutomationLogsInLogBuffer.Sub(float64(len(results)))
+		prommetrics.AutomationLogBufferFlow.WithLabelValues(prommetrics.LogBufferFlowDirectionEgress).Add(float64(len(results)))
 	}
 
 	return results

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer.go
@@ -232,7 +232,7 @@ func (b *logEventBuffer) enqueue(id *big.Int, logs ...logpoller.Log) int {
 	if added > 0 {
 		lggr.Debugw("Added logs to buffer", "addedLogs", added, "dropped", dropped, "latestBlock", latestBlock)
 		prommetrics.AutomationLogBufferFlow.WithLabelValues(prommetrics.LogBufferFlowDirectionIngress).Add(float64(added))
-		prommetrics.AutomationLogBufferFlow.WithLabelValues(prommetrics.LogBufferFlowDirectionEgress).Add(float64(dropped))
+		prommetrics.AutomationLogBufferFlow.WithLabelValues(prommetrics.LogBufferFlowDirectionDropped).Add(float64(dropped))
 	}
 
 	return added - dropped

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics/metrics.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics/metrics.go
@@ -12,6 +12,7 @@ const AutomationLogTriggerNamespace = "automation_log_trigger"
 const (
 	LogBufferFlowDirectionIngress = "ingress"
 	LogBufferFlowDirectionEgress  = "egress"
+	LogBufferFlowDirectionDropped = "dropped"
 )
 
 // Automation metrics

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics/metrics.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/prommetrics/metrics.go
@@ -8,12 +8,20 @@ import (
 // AutomationNamespace is the namespace for all Automation related metrics
 const AutomationLogTriggerNamespace = "automation_log_trigger"
 
+// Metric labels
+const (
+	LogBufferFlowDirectionIngress = "ingress"
+	LogBufferFlowDirectionEgress  = "egress"
+)
+
 // Automation metrics
 var (
-	AutomationLogsInLogBuffer = promauto.NewGauge(prometheus.GaugeOpts{
+	AutomationLogBufferFlow = promauto.NewCounterVec(prometheus.CounterOpts{
 		Namespace: AutomationLogTriggerNamespace,
 		Name:      "num_logs_in_log_buffer",
 		Help:      "The total number of logs currently being stored in the log buffer",
+	}, []string{
+		"direction",
 	})
 	AutomationRecovererMissedLogs = promauto.NewCounter(prometheus.CounterOpts{
 		Namespace: AutomationLogTriggerNamespace,


### PR DESCRIPTION
Change `AutomationLogsInLogBuffer` metric from a gauge to a counter and add a label that allows us to split it into ingress log count and egress log count. This allows us to have more flexibility with alerting and charting