### PR TITLE
fix bug for reboot nonce skipping

### DIFF
--- a/common/txmgr/broadcaster.go
+++ b/common/txmgr/broadcaster.go
@@ -619,24 +619,12 @@ func (eb *Broadcaster[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) hand
 		// and hand off to the confirmer to get the receipt (or mark as
 		// failed).
 		observeTimeUntilBroadcast(eb.chainID, etx.CreatedAt, time.Now())
-		// Check if from_address exists in map to ensure it is valid before broadcasting
-		var sequence SEQ
-		sequence, err = eb.GetNextSequence(ctx, etx.FromAddress)
-		if err != nil {
-			return err, true
-		}
 		err = eb.txStore.UpdateTxAttemptInProgressToBroadcast(ctx, &etx, attempt, txmgrtypes.TxAttemptBroadcast)
 		if err != nil {
 			return err, true
 		}
-		// use the sequence from the transaction, not the one from
-		// the map to ensure we don't skip a sequence after a reboot
-		if etx.Sequence != nil {
-			sequence = *etx.Sequence
-		}
-
 		// Increment sequence if successfully broadcasted
-		eb.IncrementNextSequence(etx.FromAddress, sequence)
+		eb.IncrementNextSequence(etx.FromAddress, *etx.Sequence)
 		return err, true
 	case client.Underpriced:
 		return eb.tryAgainBumpingGas(ctx, lgr, err, etx, attempt, initialBroadcastAt)


### PR DESCRIPTION
There was an error where a nonce was getting skipped after a reboot

1. Tries to send nonce (124) to Chain but TXM reboots before the transaction is marked as broadcasted and the nonce incremented... so transaction still in_progress
2. The transaction with nonce 124 is accepted on chain (while the TXM is in process of recovery)
3. The TXM reboots and resets the sequencer (which the current state would be 125 as next nonce)
4. since nonce 124 was still in progress before the TXM rebooted it again is in the inprogress state and is picked up to be sent by the broadcaster
5. the broadcaster sends nonce 124 again but gets a TransactionAlreadyKnown error which then fallthroughs to success
6. success then increments the nonce in the sequencer which is 125 to 126 (Which skips nonce 125)