### PR TITLE
chore: update runners to ubuntu22.04

### DIFF
--- a/.github/workflows/automation-benchmark-tests.yml
+++ b/.github/workflows/automation-benchmark-tests.yml
@@ -25,7 +25,7 @@ jobs:
       id-token: write
       contents: read
     name: Automation Benchmark Test
-    runs-on: ubuntu20.04-16cores-64GB
+    runs-on: ubuntu22.04-16cores-64GB
     env:
       SLACK_API_KEY: ${{ secrets.QA_SLACK_API_KEY }}
       SLACK_CHANNEL: C03KJ5S7KEK

--- a/.github/workflows/automation-load-tests.yml
+++ b/.github/workflows/automation-load-tests.yml
@@ -21,7 +21,7 @@ jobs:
       id-token: write
       contents: read
     name: Automation Load Test
-    runs-on: ubuntu20.04-16cores-64GB
+    runs-on: ubuntu22.04-16cores-64GB
     env:
       SLACK_API_KEY: ${{ secrets.QA_SLACK_API_KEY }}
       SLACK_CHANNEL: C03KJ5S7KEK

--- a/.github/workflows/automation-nightly-tests.yml
+++ b/.github/workflows/automation-nightly-tests.yml
@@ -17,7 +17,7 @@ jobs:
       id-token: write
       contents: read
     name: Build Chainlink Image
-    runs-on: ubuntu20.04-16cores-64GB
+    runs-on: ubuntu22.04-16cores-64GB
     steps:
       - name: Collect Metrics
         id: collect-gha-metrics
@@ -61,19 +61,19 @@ jobs:
           - name: Upgrade 2.0
             suite: smoke
             nodes: 1
-            os: ubuntu20.04-8cores-32GB
+            os: ubuntu22.04-8cores-32GB
             network: SIMULATED
             command: -run ^TestAutomationNodeUpgrade/registry_2_0 ./smoke
           - name: Upgrade 2.1
             suite: smoke
             nodes: 5
-            os: ubuntu20.04-8cores-32GB
+            os: ubuntu22.04-8cores-32GB
             network: SIMULATED
             command: -run ^TestAutomationNodeUpgrade/registry_2_1 ./smoke
           - name: Upgrade 2.2
             suite: smoke
             nodes: 5
-            os: ubuntu20.04-8cores-32GB
+            os: ubuntu22.04-8cores-32GB
             network: SIMULATED
             command: -run ^TestAutomationNodeUpgrade/registry_2_2 ./smoke
     runs-on: ${{ matrix.tests.os }}

--- a/.github/workflows/automation-ondemand-tests.yml
+++ b/.github/workflows/automation-ondemand-tests.yml
@@ -51,7 +51,7 @@ jobs:
             dockerfile: plugins/chainlink.Dockerfile
             tag-suffix: -plugins
     name: Build Chainlink Image ${{ matrix.image.name }}
-    runs-on: ubuntu20.04-16cores-64GB
+    runs-on: ubuntu22.04-16cores-64GB
     steps:
       - name: Collect Metrics
         if: inputs.chainlinkImage == ''
@@ -98,7 +98,7 @@ jobs:
       id-token: write
       contents: read
     name: Build Test Image
-    runs-on: ubuntu20.04-16cores-64GB
+    runs-on: ubuntu22.04-16cores-64GB
     steps:
       - name: Collect Metrics
         id: collect-gha-metrics
@@ -157,7 +157,7 @@ jobs:
             type: upgrade
             suite: smoke
             nodes: 1
-            os: ubuntu20.04-8cores-32GB
+            os: ubuntu22.04-8cores-32GB
             enabled: true
             pyroscope_env: ci-automation-on-demand-upgrade
             network: SIMULATED
@@ -166,7 +166,7 @@ jobs:
             type: upgrade
             suite: smoke
             nodes: 5
-            os: ubuntu20.04-8cores-32GB
+            os: ubuntu22.04-8cores-32GB
             enabled: true
             pyroscope_env: ci-automation-on-demand-upgrade
             network: SIMULATED
@@ -175,7 +175,7 @@ jobs:
             type: upgrade
             suite: smoke
             nodes: 5
-            os: ubuntu20.04-8cores-32GB
+            os: ubuntu22.04-8cores-32GB
             enabled: true
             pyroscope_env: ci-automation-on-demand-upgrade
             network: SIMULATED

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -41,7 +41,7 @@ jobs:
     # We don't directly merge dependabot PRs, so let's not waste the resources
     if: ${{ github.event_name == 'pull_request' ||  github.event_name == 'schedule' && github.actor != 'dependabot[bot]' }}
     name: lint
-    runs-on: ubuntu20.04-8cores-32GB
+    runs-on: ubuntu22.04-8cores-32GB
     needs: [filter]
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1 
@@ -70,7 +70,7 @@ jobs:
     # We don't directly merge dependabot PRs, so let's not waste the resources
     if: github.actor != 'dependabot[bot]'
     needs: [filter]
-    runs-on: ubuntu20.04-64cores-256GB
+    runs-on: ubuntu22.04-64cores-256GB
     env:
       CL_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/chainlink_test?sslmode=disable
     steps:
@@ -295,7 +295,7 @@ jobs:
   clean:
     name: Clean Go Tidy & Generate
     if: ${{ !contains(join(github.event.pull_request.labels.*.name, ' '), 'skip-smoke-tests') && github.actor != 'dependabot[bot]' }}
-    runs-on: ubuntu20.04-8cores-32GB
+    runs-on: ubuntu22.04-8cores-32GB
     defaults:
       run:
         shell: bash

--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -70,7 +70,7 @@ jobs:
     # We don't directly merge dependabot PRs, so let's not waste the resources
     if: github.actor != 'dependabot[bot]'
     needs: [filter]
-    runs-on: ubuntu22.04-64cores-256GB
+    runs-on: ubuntu-latest-64cores-256GB
     env:
       CL_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/chainlink_test?sslmode=disable
     steps:

--- a/.github/workflows/goreleaser-build-publish-develop.yml
+++ b/.github/workflows/goreleaser-build-publish-develop.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   push-chainlink-develop-goreleaser:
     runs-on:
-      labels: ubuntu20.04-16cores-64GB
+      labels: ubuntu22.04-16cores-64GB
     outputs:
       goreleaser-metadata: ${{ steps.build-sign-publish.outputs.goreleaser-metadata }}
       goreleaser-artifacts: ${{ steps.build-sign-publish.outputs.goreleaser-artifacts }}

--- a/.github/workflows/integration-staging-tests.yml
+++ b/.github/workflows/integration-staging-tests.yml
@@ -35,7 +35,7 @@ concurrency:
 jobs:
   e2e-soak-test:
     environment: sdlc
-    runs-on: ubuntu20.04-8cores-32GB
+    runs-on: ubuntu22.04-8cores-32GB
     permissions:
       contents: read
       id-token: write

--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -18,7 +18,7 @@ jobs:
       id-token: write
       contents: read
     name: Publish Integration Test Image
-    runs-on: ubuntu20.04-16cores-64GB
+    runs-on: ubuntu22.04-16cores-64GB
     steps:
       - name: Collect Metrics
         id: collect-gha-metrics
@@ -72,7 +72,7 @@ jobs:
           #   dockerfile: plugins/chainlink.Dockerfile
           #   tag-suffix: -plugins
     name: Build Chainlink Image ${{ matrix.image.name }}
-    runs-on: ubuntu20.04-8cores-32GB
+    runs-on: ubuntu22.04-8cores-32GB
     steps:
       - name: Collect Metrics
         id: collect-gha-metrics

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -130,7 +130,7 @@ jobs:
 
   build-lint-integration-tests:
     name: Build and Lint integration-tests
-    runs-on: ubuntu20.04-16cores-64GB
+    runs-on: ubuntu22.04-16cores-64GB
     # We don't directly merge dependabot PRs, so let's not waste the resources
     if: github.actor != 'dependabot[bot]'
     strategy:
@@ -187,7 +187,7 @@ jobs:
             dockerfile: plugins/chainlink.Dockerfile
             tag-suffix: -plugins
     name: Build Chainlink Image ${{ matrix.image.name }}
-    runs-on: ubuntu20.04-16cores-64GB
+    runs-on: ubuntu22.04-16cores-64GB
     needs: [changes, enforce-ctf-version]
     steps:
       - name: Collect Metrics
@@ -223,7 +223,7 @@ jobs:
       id-token: write
       contents: read
     name: Build Test Image
-    runs-on: ubuntu20.04-16cores-64GB
+    runs-on: ubuntu22.04-16cores-64GB
     needs: [changes]
     steps:
       - name: Collect Metrics
@@ -512,12 +512,12 @@ jobs:
             pyroscope_env: ci-smoke-ocr-evm-simulated
           - name: ocr2
             nodes: 6
-            os: ubuntu20.04-16cores-64GB
+            os: ubuntu22.04-16cores-64GB
             file: ocr2
             pyroscope_env: ci-smoke-ocr2-evm-simulated
           - name: ocr2
             nodes: 6
-            os: ubuntu20.04-16cores-64GB
+            os: ubuntu22.04-16cores-64GB
             pyroscope_env: ci-smoke-ocr2-plugins-evm-simulated
             tag_suffix: "-plugins"
           - name: vrf
@@ -955,7 +955,7 @@ jobs:
       id-token: write
       contents: read
     name: Solana Build Artifacts
-    runs-on: ubuntu20.04-16cores-64GB
+    runs-on: ubuntu22.04-16cores-64GB
     needs:
       [
         changes,
@@ -1000,7 +1000,7 @@ jobs:
       id-token: write
       contents: read
     name: Solana Build Test Image
-    runs-on: ubuntu20.04-16cores-64GB
+    runs-on: ubuntu22.04-16cores-64GB
     needs:
       [
         solana-build-contracts,
@@ -1048,7 +1048,7 @@ jobs:
       id-token: write
       contents: read
     name: Solana Smoke Tests
-    runs-on: ubuntu20.04-16cores-64GB
+    runs-on: ubuntu22.04-16cores-64GB
     needs:
       [
         build-chainlink,

--- a/.github/workflows/on-demand-log-poller.yml
+++ b/.github/workflows/on-demand-log-poller.yml
@@ -11,7 +11,7 @@ jobs:
   test:
     env:
       REF_NAME: ${{ github.head_ref || github.ref_name }}
-    runs-on: ubuntu20.04-8cores-32GB
+    runs-on: ubuntu22.04-8cores-32GB
     steps:
       - name: Add masks and export base64 config
         run: |

--- a/.github/workflows/on-demand-vrfv2-eth2-clients-test.yml
+++ b/.github/workflows/on-demand-vrfv2-eth2-clients-test.yml
@@ -11,7 +11,7 @@ jobs:
   vrfv2_smoke_test:
     name: VRFV2 Smoke Test with custom EL client client
     environment: integration
-    runs-on: ubuntu20.04-8cores-32GB
+    runs-on: ubuntu22.04-8cores-32GB
     permissions:
       checks: write
       pull-requests: write

--- a/.github/workflows/on-demand-vrfv2-performance-test.yml
+++ b/.github/workflows/on-demand-vrfv2-performance-test.yml
@@ -19,7 +19,7 @@ jobs:
   vrfv2_performance_test:
     name: VRFV2 Performance Test
     environment: integration
-    runs-on: ubuntu20.04-8cores-32GB
+    runs-on: ubuntu22.04-8cores-32GB
     permissions:
       checks: write
       pull-requests: write

--- a/.github/workflows/on-demand-vrfv2plus-eth2-clients-test.yml
+++ b/.github/workflows/on-demand-vrfv2plus-eth2-clients-test.yml
@@ -11,7 +11,7 @@ jobs:
   vrfv2plus_smoke_test:
     name: VRFV2Plus Smoke Test with custom EL client
     environment: integration
-    runs-on: ubuntu20.04-8cores-32GB
+    runs-on: ubuntu22.04-8cores-32GB
     permissions:
       checks: write
       pull-requests: write

--- a/.github/workflows/on-demand-vrfv2plus-performance-test.yml
+++ b/.github/workflows/on-demand-vrfv2plus-performance-test.yml
@@ -20,7 +20,7 @@ jobs:
   vrfv2plus_performance_test:
     name: VRFV2 Plus Performance Test
     environment: integration
-    runs-on: ubuntu20.04-8cores-32GB
+    runs-on: ubuntu22.04-8cores-32GB
     permissions:
       checks: write
       pull-requests: write


### PR DESCRIPTION
Ran into some node20 errors again during the workflows for #12454 ([example](https://github.com/smartcontractkit/chainlink/actions/runs/8302434972/job/22724782040?pr=12454#step:4:24))
> /usr/bin/docker exec  03f3f55133ccfb481575d884c132ac3ed4f204c6415d9ea0b0461ae0dc68f70e sh -c "cat /etc/*release | grep ^ID"
> /__e/node20/bin/node: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.28' not found (required by /__e/node20/bin/node)

Figured updating all the `runs-on` references from `ubuntu20` to `ubuntu22` might be worthwhile. This *might* fix the above stated workflow issues as the `ubuntu22` runners should have the proper libraries required for node20 (but so should the `ubuntu20` runners).

### Other Thoughts
- I don't know if bumping the `runs-on` is going to fix the node20 errors seen above, it seems as though other node20 actions are running on `ubuntu20` runners. So maybe this isn't the issue.
- Actions using node16 will run on node20 as of May 13th ([blog](https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/)) so we need to find a solution to the above issue if we are going to be forced to use node20

---

Edit: Saw that the core jobs with `runs-on: ubuntu22.04-64cores-256GB` were not being picked up by any runners.  It appears that the organization only runners tagged `ubuntu-latest-64cores-256GB` for this type.