### PR TITLE
Fix client compatibility pipeline

### DIFF
--- a/.github/workflows/client-compatibility-tests.yml
+++ b/.github/workflows/client-compatibility-tests.yml
@@ -205,7 +205,7 @@ jobs:
           key_secret="$PYROSCOPE_KEY"
 
           [PrivateEthereumNetwork]
-          consensus_type="pos"
+          ethereum_version="eth2"
           consensus_layer="prysm"
           execution_layer="$execution_layer"
           wait_for_finalization=false


### PR DESCRIPTION
It should run eth2, but it is currently running eth1