### PR TITLE
fix: avoid nil pointer exception on logs if latestBlockHeight is nil

### DIFF
--- a/core/services/gateway/handlers/functions/subscriptions/subscriptions.go
+++ b/core/services/gateway/handlers/functions/subscriptions/subscriptions.go
@@ -138,7 +138,7 @@ func (s *onchainSubscriptions) queryLoop() {
 
 		latestBlockHeight, err := s.client.LatestBlockHeight(ctx)
 		if err != nil || latestBlockHeight == nil {
-			s.lggr.Errorw("Error calling LatestBlockHeight", "err", err, "latestBlockHeight", latestBlockHeight.Int64())
+			s.lggr.Errorw("Error calling LatestBlockHeight", "err", err, "latestBlockHeight", latestBlockHeight)
 			return
 		}
 


### PR DESCRIPTION
### Description

While trying to run locally some nodes I found this error:
```
2024-03-19 13:58:05 panic: runtime error: invalid memory address or nil pointer dereference
2024-03-19 13:58:05 [signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0x1e170d6]
2024-03-19 13:58:05 
2024-03-19 13:58:05 goroutine 140302 [running]:
2024-03-19 13:58:05 math/big.(*Int).Int64(...)
2024-03-19 13:58:05     /usr/local/go/src/math/big/int.go:426
2024-03-19 13:58:05 github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/functions/subscriptions.(*onchainSubscriptions).queryLoop.func1()
2024-03-19 13:58:05     /chainlink/core/services/gateway/handlers/functions/subscriptions/subscriptions.go:141 +0xd6
2024-03-19 13:58:05 github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/functions/subscriptions.(*onchainSubscriptions).queryLoop(0xc001c07680)
2024-03-19 13:58:05     /chainlink/core/services/gateway/handlers/functions/subscriptions/subscriptions.go:185 +0x129
2024-03-19 13:58:05 created by github.com/smartcontractkit/chainlink/v2/core/services/gateway/handlers/functions/subscriptions.(*onchainSubscriptions).Start.func1 in goroutine 143602
2024-03-19 13:58:05     /chainlink/core/services/gateway/handlers/functions/subscriptions/subscriptions.go:105 +0x145
```

if latestBlockHeight is nil, calling latestBlockHeight.Int64() will result in a panic