### PR TITLE
add version diff check in version-file-bump action

### DIFF
--- a/.github/actions/version-file-bump/action.yml
+++ b/.github/actions/version-file-bump/action.yml
@@ -8,7 +8,7 @@ inputs:
 outputs:
   result:
     value: ${{ steps.compare.outputs.result }}
-    description: 'Result of the comparison'
+    description: "Result of the comparison"
 runs:
   using: composite
   steps:
@@ -37,6 +37,20 @@ runs:
         version1: ${{ steps.get-current-version.outputs.current_version }}
         operator: eq
         version2: ${{ steps.get-latest-version.outputs.latest_version }}
+    # The follow two steps are temp until we migrate to use version from package.json as the source of truth
+    - name: Get package version
+      id: get-package-version
+      shell: bash
+      run: |
+        package_version=$(jq -r '.version' ./package.json)
+        echo "package_version=${package_version}" | tee -a "$GITHUB_OUTPUT"
+    - name: Diff versions
+      uses: smartcontractkit/chainlink-github-actions/semver-compare@c67a09566412d153ff7640d99f96b43aa03abc04 # v2.3.6
+      id: diff
+      with:
+        version1: ${{ steps.get-current-version.outputs.current_version }}
+        operator: eq
+        version2: ${{ steps.get-package-version.outputs.package_version }}
     - name: Fail if version not bumped
       # XXX: The reason we are not checking if the current is greater than the
       # latest release is to account for hot fixes which may have been branched
@@ -44,8 +58,13 @@ runs:
       shell: bash
       env:
         VERSION_NOT_BUMPED: ${{ steps.compare.outputs.result }}
+        VERSION_SAME: ${{ steps.diff.outputs.result }}
       run: |
         if [[ "${VERSION_NOT_BUMPED:-}" = "true" ]]; then
           echo "Version file not bumped since last release. Please bump the ./VERSION file in the root of the repo and commit the change."
+          exit 1
+        fi
+        if [[ "${VERSION_SAME:-}" = "false" ]]; then
+          echo "The version in the VERSION file is not the same as the version in package.json file. Please fix by running `pnpm changeset version`."
           exit 1
         fi


### PR DESCRIPTION
This adds extra steps in `version-file-bump` composite action to check the version in `VERSION` file is the same as the version in `package.json`. The workflow will fails if they're different.

This is a temp check before migrating to use the version in `package.json` as the source of truth and remove the `VERSION` file completely.
