### PR TITLE
Adding helper for converting pub key into secp256k1 public key

### DIFF
--- a/.changeset/kind-crabs-begin.md
+++ b/.changeset/kind-crabs-begin.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Helper VRF CLI command

--- a/.changeset/shiny-forks-clap.md
+++ b/.changeset/shiny-forks-clap.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Helper VRF CLI command

--- a/core/scripts/vrfv2plus/testnet/main.go
+++ b/core/scripts/vrfv2plus/testnet/main.go
@@ -1092,7 +1092,7 @@ func main() {
 		helpers.PanicErr(err)
 		pk, err := crypto.UnmarshalPubkey(pubBytes)
 		helpers.PanicErr(err)
-		fmt.Printf("PublicKey: %s, X: %s, Y: %s\n", uncompressedPubKey, pk.X, pk.Y)
+		fmt.Printf("PublicKey: %s, X: %s, Y: %s\n", *uncompressedPubKeyCLI, pk.X, pk.Y)
 	case "coordinator-reregister-proving-key":
 		coordinatorReregisterKey := flag.NewFlagSet("coordinator-register-key", flag.ExitOnError)
 		coordinatorAddress := coordinatorReregisterKey.String("coordinator-address", "", "coordinator address")

--- a/core/scripts/vrfv2plus/testnet/main.go
+++ b/core/scripts/vrfv2plus/testnet/main.go
@@ -1079,6 +1079,20 @@ func main() {
 		helpers.PanicErr(err)
 
 		helpers.ConfirmTXMined(context.Background(), e.Ec, tx, e.ChainID, "transfer ownership to", *newOwner)
+	case "public-key-x-y":
+		publicKeyXY := flag.NewFlagSet("public-key-x-y", flag.ExitOnError)
+		uncompressedPubKeyCLI := publicKeyXY.String("pubkey", "", "uncompressed pubkey")
+		helpers.ParseArgs(publicKeyXY, os.Args[2:], "pubkey")
+		uncompressedPubKey := *uncompressedPubKeyCLI
+		// Put key in ECDSA format
+		if strings.HasPrefix(uncompressedPubKey, "0x") {
+			uncompressedPubKey = strings.Replace(uncompressedPubKey, "0x", "04", 1)
+		}
+		pubBytes, err := hex.DecodeString(uncompressedPubKey)
+		helpers.PanicErr(err)
+		pk, err := crypto.UnmarshalPubkey(pubBytes)
+		helpers.PanicErr(err)
+		fmt.Printf("PublicKey: %s, X: %s, Y: %s\n", uncompressedPubKey, pk.X, pk.Y)
 	case "coordinator-reregister-proving-key":
 		coordinatorReregisterKey := flag.NewFlagSet("coordinator-register-key", flag.ExitOnError)
 		coordinatorAddress := coordinatorReregisterKey.String("coordinator-address", "", "coordinator address")


### PR DESCRIPTION
## Updates

- Add a helper VRF CLI command to parse an uncompressed public key into secp256k1 public key with x-y coordinates

```
$ go run ./vrfv2plus/testnet public-key-x-y --pubkey 0xa5928e909223a35c40882606a99db047983f2...
Suggested Gas Price: 25000000000 wei
Modified Gas Price that will be set: 50000000000 wei
PublicKey: 0xa5928e909223a35c40882606a99db047983f2..., X: 7489056363330041778193039358879569..., Y: 467303305864939804234768982126276...
```