### PR TITLE
Run a k8s rolling restart of the deployment in CRIB after develop image is built

### DIFF
--- a/.github/workflows/build-publish-develop.yml
+++ b/.github/workflows/build-publish-develop.yml
@@ -59,39 +59,44 @@ jobs:
       - name: Setup GAP
         # Don't run for plugins.
         if: matrix.image.name == ''
-        uses: smartcontractkit/.github/actions/setup-gap@main
+        uses: smartcontractkit/.github/actions/setup-gap@1bc7ce34fa81fffcb4a6eb0e4e12e59d94d0fc8f # setup-gap@0.2.0
         with:
           aws-region: ${{ secrets.AWS_REGION }}
-          aws-role-arn: ${{ secrets.AWS_OIDC_IAM_ROLE_PUBLISH_PR_ARN }}
-          api-gateway-host: ${{ secrets.AWS_API_GW_HOST_ARGO_SAND }}
-          use-argocd: "true"
-          argocd-user: ${{ secrets.ARGOCD_USER_SAND }}
-          argocd-pass: ${{ secrets.ARGOCD_PASS_SAND }}
+          aws-role-arn: ${{ secrets.AWS_OIDC_IAM_ROLE_ARN }}
+          api-gateway-host: ${{ secrets.AWS_API_GW_HOST_K8S_SAND }}
+          use-k8s: "true"
+          k8s-cluster-name: ${{ secrets.AWS_EKS_CLUSTER_NAME_SAND }}
+          use-private-ecr-registry: true
+          ecr-private-registry: ${{ secrets.AWS_ACCOUNT_ID_PROD }}
+          metrics-job-name: push-chainlink-develop ${{ matrix.image.name }}
+          gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
 
-      # Run an Argo CD sync after the image is built.
-      - name: Argo CD App Sync
+      # A mutable image tag is used for these CRIBs and it was just built/published
+      # from this workflow. The deployment has an `imagePullPolicy: Always` set, so
+      # we need to restart the deployments to pick up the new image.
+      - name: Restart K8s Deployments for CRIBs
         # Don't run for plugins.
         if: matrix.image.name == ''
         shell: bash
-        env:
-          AWS_SDLC_ECR_HOSTNAME: ${{ secrets.AWS_SDLC_ECR_HOSTNAME }}
         run: |
-          argocd app sync "crib-chainlink-develop" \
-            --plaintext \
-            --grpc-web \
-            --async \
-            --helm-set="chainlink.nodes[0].name=node1" \
-            --helm-set="chainlink.nodes[0].image=${AWS_SDLC_ECR_HOSTNAME}/chainlink:develop" \
-            --helm-set="chainlink.nodes[1].name=node2" \
-            --helm-set="chainlink.nodes[1].image=${AWS_SDLC_ECR_HOSTNAME}/chainlink:develop" \
-            --helm-set="chainlink.nodes[2].name=node3" \
-            --helm-set="chainlink.nodes[2].image=${AWS_SDLC_ECR_HOSTNAME}/chainlink:develop" \
-            --helm-set="chainlink.nodes[3].name=node4" \
-            --helm-set="chainlink.nodes[3].image=${AWS_SDLC_ECR_HOSTNAME}/chainlink:develop" \
-            --helm-set="chainlink.nodes[4].name=node5" \
-            --helm-set="chainlink.nodes[4].image=${AWS_SDLC_ECR_HOSTNAME}/chainlink:develop" \
-            --helm-set="chainlink.nodes[5].name=node6" \
-            --helm-set="chainlink.nodes[5].image=${AWS_SDLC_ECR_HOSTNAME}/chainlink:develop"
+          set -euo pipefail
+          # Removes the "smartcontractkit/" (org name) prefix.
+          REPO_NAME_ONLY="${GITHUB_REPOSITORY##*/}"
+          K8S_NAMESPACE="crib-${REPO_NAME_ONLY}-develop"
+
+          deployment_node_names=$(kubectl --namespace "${K8S_NAMESPACE}" \
+              get deployments \
+              -l "app=${K8S_NAMESPACE}" \
+              -o custom-columns=:metadata.name --no-headers)
+
+          IFS=$'\n' read -r -d '' -a deployment_names_arr <<< "$deployment_node_names" || :
+          for name in "${deployment_names_arr[@]}"; do
+              echo "Restarting deployment: $name"
+              kubectl --namespace "${K8S_NAMESPACE}" \
+                  rollout restart "deployment/${name}"
+          done
 
       - name: Collect Metrics
         if: always()

--- a/.github/workflows/build-publish-develop.yml
+++ b/.github/workflows/build-publish-develop.yml
@@ -55,6 +55,44 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_READONLY_USERNAME }}
           dockerhub_password: ${{ secrets.DOCKERHUB_READONLY_PASSWORD }}
           git-commit-sha: ${{ steps.git-ref.outputs.checked-out || github.sha }}
+
+      - name: Setup GAP
+        # Don't run for plugins.
+        if: matrix.image.name == ''
+        uses: smartcontractkit/.github/actions/setup-gap@main
+        with:
+          aws-region: ${{ secrets.AWS_REGION }}
+          aws-role-arn: ${{ secrets.AWS_OIDC_IAM_ROLE_PUBLISH_PR_ARN }}
+          api-gateway-host: ${{ secrets.AWS_API_GW_HOST_ARGO_SAND }}
+          use-argocd: "true"
+          argocd-user: ${{ secrets.ARGOCD_USER_SAND }}
+          argocd-pass: ${{ secrets.ARGOCD_PASS_SAND }}
+
+      # Run an Argo CD sync after the image is built.
+      - name: Argo CD App Sync
+        # Don't run for plugins.
+        if: matrix.image.name == ''
+        shell: bash
+        env:
+          AWS_SDLC_ECR_HOSTNAME: ${{ secrets.AWS_SDLC_ECR_HOSTNAME }}
+        run: |
+          argocd app sync "crib-chainlink-develop" \
+            --plaintext \
+            --grpc-web \
+            --async \
+            --helm-set="chainlink.nodes[0].name=node1" \
+            --helm-set="chainlink.nodes[0].image=${AWS_SDLC_ECR_HOSTNAME}/chainlink:develop" \
+            --helm-set="chainlink.nodes[1].name=node2" \
+            --helm-set="chainlink.nodes[1].image=${AWS_SDLC_ECR_HOSTNAME}/chainlink:develop" \
+            --helm-set="chainlink.nodes[2].name=node3" \
+            --helm-set="chainlink.nodes[2].image=${AWS_SDLC_ECR_HOSTNAME}/chainlink:develop" \
+            --helm-set="chainlink.nodes[3].name=node4" \
+            --helm-set="chainlink.nodes[3].image=${AWS_SDLC_ECR_HOSTNAME}/chainlink:develop" \
+            --helm-set="chainlink.nodes[4].name=node5" \
+            --helm-set="chainlink.nodes[4].image=${AWS_SDLC_ECR_HOSTNAME}/chainlink:develop" \
+            --helm-set="chainlink.nodes[5].name=node6" \
+            --helm-set="chainlink.nodes[5].image=${AWS_SDLC_ECR_HOSTNAME}/chainlink:develop"
+
       - name: Collect Metrics
         if: always()
         id: collect-gha-metrics

--- a/.github/workflows/build-publish-pr.yml
+++ b/.github/workflows/build-publish-pr.yml
@@ -53,51 +53,6 @@ jobs:
           dockerhub_username: ${{ secrets.DOCKERHUB_READONLY_USERNAME }}
           dockerhub_password: ${{ secrets.DOCKERHUB_READONLY_PASSWORD }}
 
-      - name: Get PR labels
-        id: pr-labels
-        env:
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          RESPONSE=$(gh pr view ${PR_NUMBER} --json labels)
-          # Check if the labels command was successful
-          if [[ $? -ne 0 ]]; then
-            echo "Error fetching labels"
-            exit 1
-          fi
-          echo "RESPONSE=${RESPONSE}"
-          LABELS=$(echo "$RESPONSE" | jq -r '.labels | map(.name) | join(", ")')
-          # Check if any labels were found
-          if [[ -z "${LABELS:-}" ]]; then
-            echo "No labels found"
-          else
-            echo "labels=${LABELS}" | tee -a "${GITHUB_OUTPUT}"
-          fi
-
-      - name: Setup GAP
-        if: contains(steps.pr-labels.outputs.labels, 'crib')
-        uses: smartcontractkit/.github/actions/setup-gap@main
-        with:
-          aws-region: ${{ secrets.AWS_REGION }}
-          aws-role-arn: ${{ secrets.AWS_OIDC_IAM_ROLE_PUBLISH_PR_ARN }}
-          api-gateway-host: ${{ secrets.AWS_API_GW_HOST_ARGO_SAND }}
-          use-argocd: "true"
-          argocd-user: ${{ secrets.ARGOCD_USER_SAND }}
-          argocd-pass: ${{ secrets.ARGOCD_PASS_SAND }}
-
-      # Run an Argo CD sync after the image is built.
-      - name: Argo CD App Sync
-        if: contains(steps.pr-labels.outputs.labels, 'crib')
-        shell: bash
-        env:
-          PR_NUMBER: ${{ github.event.number }}
-        run: |
-          argocd app sync \
-            --plaintext \
-            --grpc-web \
-            --async \
-            "crib-chainlink-${PR_NUMBER}"
-
       - name: Collect Metrics
         if: always()
         id: collect-gha-metrics

--- a/charts/chainlink-cluster/templates/chainlink-db-deployment.yaml
+++ b/charts/chainlink-cluster/templates/chainlink-db-deployment.yaml
@@ -7,6 +7,10 @@ kind: Deployment
 {{ end }}
 metadata:
   name: {{ $.Release.Name }}-{{ $cfg.name }}-db
+  labels:
+    app: {{ $.Release.Name }}-db
+    instance: {{ $cfg.name }}-db
+    release: {{ $.Release.Name }}
 spec:
   {{ if $.Values.db.stateful }}
   serviceName: {{ $.Release.Name }}-db-${{ $cfg.name }}

--- a/charts/chainlink-cluster/templates/chainlink-node-deployment.yaml
+++ b/charts/chainlink-cluster/templates/chainlink-node-deployment.yaml
@@ -3,6 +3,13 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ if eq $index 0 }}{{ $.Release.Name }}-{{ $cfg.name }}-bootstrap{{ else }}{{ $.Release.Name }}-{{ $cfg.name }}{{ end }}
+  labels:
+    app: {{ $.Release.Name }}
+    instance: {{ $cfg.name }}
+    release: {{ $.Release.Name }}
+    {{- range $key, $value := $.Values.labels }}
+    {{ $key }}: {{ $value | quote }}
+    {{- end }}
 spec:
   strategy:
     # Need to recreate the pod to deal with lease lock held by old pod.

--- a/charts/chainlink-cluster/templates/geth-deployment.yaml
+++ b/charts/chainlink-cluster/templates/geth-deployment.yaml
@@ -4,6 +4,10 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: geth-{{ $cfg.networkId }}
+  labels:
+    app: geth
+    release: {{ $.Release.Name }}
+    instance: geth-{{ $cfg.networkId }}
 spec:
   selector:
     matchLabels:


### PR DESCRIPTION
## What

1. Remove unnecessary argocd app sync after PR image is built.
2. Add necessary labels to CRIB helm chart deployments.
3. Restart node deployments after a docker image is built for 'develop' (after code is merged to trunk).