### PR TITLE
Changes to the LDAP authentication driver

### DIFF
--- a/core/config/toml/types.go
+++ b/core/config/toml/types.go
@@ -666,7 +666,7 @@ func (w *WebServer) ValidateConfig() (err error) {
 		err = multierr.Append(err, configutils.ErrInvalid{Name: "LDAP.AdminUserGroupCN", Msg: "LDAP AdminUserGroupCN can not be empty"})
 	}
 	if *w.LDAP.EditUserGroupCN == "" {
-		err = multierr.Append(err, configutils.ErrInvalid{Name: "LDAP.RunUserGroupCN", Msg: "LDAP ReadUserGroupCN can not be empty"})
+		err = multierr.Append(err, configutils.ErrInvalid{Name: "LDAP.EditUserGroupCN", Msg: "LDAP EditUserGroupCN can not be empty"})
 	}
 	if *w.LDAP.RunUserGroupCN == "" {
 		err = multierr.Append(err, configutils.ErrInvalid{Name: "LDAP.RunUserGroupCN", Msg: "LDAP RunUserGroupCN can not be empty"})
@@ -766,9 +766,6 @@ type WebServerLDAP struct {
 func (w *WebServerLDAP) setFrom(f *WebServerLDAP) {
 	if v := f.ServerTLS; v != nil {
 		w.ServerTLS = v
-	}
-	if v := f.SessionTimeout; v != nil {
-		w.SessionTimeout = v
 	}
 	if v := f.SessionTimeout; v != nil {
 		w.SessionTimeout = v

--- a/core/config/web_config.go
+++ b/core/config/web_config.go
@@ -38,7 +38,7 @@ type LDAP interface {
 	ReadOnlyUserPass() string
 	ServerTLS() bool
 	SessionTimeout() commonconfig.Duration
-	QueryTimeout() time.Duration
+	QueryTimeout() commonconfig.Duration
 	BaseUserAttr() string
 	BaseDN() string
 	UsersDN() string

--- a/core/services/chainlink/config_test.go
+++ b/core/services/chainlink/config_test.go
@@ -1200,7 +1200,7 @@ func TestConfig_Validate(t *testing.T) {
 		- LDAP.UsersDN: invalid value (<nil>): LDAP UsersDN can not be empty
 		- LDAP.GroupsDN: invalid value (<nil>): LDAP GroupsDN can not be empty
 		- LDAP.AdminUserGroupCN: invalid value (<nil>): LDAP AdminUserGroupCN can not be empty
-		- LDAP.RunUserGroupCN: invalid value (<nil>): LDAP ReadUserGroupCN can not be empty
+		- LDAP.EditUserGroupCN: invalid value (<nil>): LDAP EditUserGroupCN can not be empty
 		- LDAP.RunUserGroupCN: invalid value (<nil>): LDAP RunUserGroupCN can not be empty
 		- LDAP.ReadUserGroupCN: invalid value (<nil>): LDAP ReadUserGroupCN can not be empty
 	- EVM: 8 errors:

--- a/core/services/chainlink/config_web_server.go
+++ b/core/services/chainlink/config_web_server.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/gin-contrib/sessions"
+	"github.com/go-ldap/ldap/v3"
 
 	commonconfig "github.com/smartcontractkit/chainlink-common/pkg/config"
 	"github.com/smartcontractkit/chainlink/v2/core/config"
@@ -215,8 +216,8 @@ func (l *ldapConfig) SessionTimeout() commonconfig.Duration {
 	return *l.c.SessionTimeout
 }
 
-func (l *ldapConfig) QueryTimeout() time.Duration {
-	return l.c.QueryTimeout.Duration()
+func (l *ldapConfig) QueryTimeout() commonconfig.Duration {
+	return *l.c.QueryTimeout
 }
 
 func (l *ldapConfig) UserAPITokenDuration() commonconfig.Duration {
@@ -255,7 +256,7 @@ func (l *ldapConfig) ActiveAttribute() string {
 	if l.c.ActiveAttribute == nil {
 		return ""
 	}
-	return *l.c.ActiveAttribute
+	return ldap.EscapeFilter(*l.c.ActiveAttribute)
 }
 
 func (l *ldapConfig) ActiveAttributeAllowedValue() string {
@@ -269,28 +270,28 @@ func (l *ldapConfig) AdminUserGroupCN() string {
 	if l.c.AdminUserGroupCN == nil {
 		return ""
 	}
-	return *l.c.AdminUserGroupCN
+	return ldap.EscapeDN(*l.c.AdminUserGroupCN)
 }
 
 func (l *ldapConfig) EditUserGroupCN() string {
 	if l.c.EditUserGroupCN == nil {
 		return ""
 	}
-	return *l.c.EditUserGroupCN
+	return ldap.EscapeDN(*l.c.EditUserGroupCN)
 }
 
 func (l *ldapConfig) RunUserGroupCN() string {
 	if l.c.RunUserGroupCN == nil {
 		return ""
 	}
-	return *l.c.RunUserGroupCN
+	return ldap.EscapeDN(*l.c.RunUserGroupCN)
 }
 
 func (l *ldapConfig) ReadUserGroupCN() string {
 	if l.c.ReadUserGroupCN == nil {
 		return ""
 	}
-	return *l.c.ReadUserGroupCN
+	return ldap.EscapeDN(*l.c.ReadUserGroupCN)
 }
 
 func (l *ldapConfig) UserApiTokenEnabled() bool {

--- a/core/sessions/ldapauth/helpers_test.go
+++ b/core/sessions/ldapauth/helpers_test.go
@@ -70,8 +70,8 @@ func (t *TestConfig) SessionTimeout() commonconfig.Duration {
 	return *commonconfig.MustNewDuration(time.Duration(0))
 }
 
-func (t *TestConfig) QueryTimeout() time.Duration {
-	return time.Duration(0)
+func (t *TestConfig) QueryTimeout() commonconfig.Duration {
+	return *commonconfig.MustNewDuration(time.Duration(0))
 }
 
 func (t *TestConfig) UserAPITokenDuration() commonconfig.Duration {

--- a/core/sessions/ldapauth/ldap_test.go
+++ b/core/sessions/ldapauth/ldap_test.go
@@ -200,6 +200,9 @@ func TestORM_FindUser_FallbackMatchLocalAdmin(t *testing.T) {
 
 	// Initilaize LDAP Authentication Provider with mock client
 	mockLdapClient := mocks.NewLDAPClient(t)
+	mockLdapConnProvider := mocks.NewLDAPConn(t)
+	mockLdapClient.On("CreateEphemeralConnection").Return(mockLdapConnProvider, nil)
+	mockLdapConnProvider.On("Close").Return(nil)
 	_, ldapAuthProvider := setupAuthenticationProvider(t, mockLdapClient)
 
 	// Not in upstream, but utilize text fixture admin user presence in test DB. Succeed

--- a/core/sessions/ldapauth/ldap_test.go
+++ b/core/sessions/ldapauth/ldap_test.go
@@ -202,7 +202,12 @@ func TestORM_FindUser_FallbackMatchLocalAdmin(t *testing.T) {
 	mockLdapClient := mocks.NewLDAPClient(t)
 	mockLdapConnProvider := mocks.NewLDAPConn(t)
 	mockLdapClient.On("CreateEphemeralConnection").Return(mockLdapConnProvider, nil)
+
+	// Expected user not in upstream for this test case
+	noResults := ldap.SearchResult{Entries: []*ldap.Entry{}}
+	mockLdapConnProvider.On("Search", mock.AnythingOfType("*ldap.SearchRequest")).Return(&noResults, nil)
 	mockLdapConnProvider.On("Close").Return(nil)
+
 	_, ldapAuthProvider := setupAuthenticationProvider(t, mockLdapClient)
 
 	// Not in upstream, but utilize text fixture admin user presence in test DB. Succeed

--- a/core/sessions/ldapauth/sync.go
+++ b/core/sessions/ldapauth/sync.go
@@ -273,7 +273,7 @@ func (ldSync *LDAPServerStateSyncer) deleteStaleAPITokens(before time.Time) erro
 func (ldSync *LDAPServerStateSyncer) ldapGroupMembersListToUser(conn LDAPConn, groupNameCN string, roleToAssign sessions.UserRole) ([]sessions.User, error) {
 	users, err := ldapGroupMembersListToUser(
 		conn, groupNameCN, roleToAssign, ldSync.config.GroupsDN(),
-		ldSync.config.BaseDN(), ldSync.config.QueryTimeout(),
+		ldSync.config.BaseDN(), ldSync.config.QueryTimeout().Duration(),
 		ldSync.lggr,
 	)
 	if err != nil {
@@ -308,7 +308,7 @@ func (ldSync *LDAPServerStateSyncer) validateUsersActive(emails []string, conn L
 	searchRequest := ldap.NewSearchRequest(
 		searchBaseDN,
 		ldap.ScopeWholeSubtree, ldap.NeverDerefAliases,
-		0, int(ldSync.config.QueryTimeout().Seconds()), false,
+		0, int(ldSync.config.QueryTimeout().Duration().Seconds()), false,
 		filterQuery,
 		[]string{ldSync.config.BaseUserAttr(), ldSync.config.ActiveAttribute()},
 		nil,


### PR DESCRIPTION
- Conform duration type for QueryTimeout in LDAP config struct
- Fix typo in config parsing error message on EditUserGroupCN required and not set
- Remove duplicate code block
- Add config validations for LDAP fields where applicable for config file parameterized values
- Fix logic for local admin authentication fallback when there is an email key clash in both the upstream ldap server and the local users table, FindUser now follows the same user source precedence
- Comment clarity for FindUser guarantees
- Added additional WHERE clause to explicitly select admin users to enforce LDAP module guarantees