### PR TITLE
Rename keys with dashes in helm values

### DIFF
--- a/charts/chainlink-cluster/devspace.yaml
+++ b/charts/chainlink-cluster/devspace.yaml
@@ -208,8 +208,8 @@ deployments:
             runAsUser: 999
             runAsGroup: 999
           version: v1.12.0
-          wsrpc-port: 8546
-          httprpc-port: 8544
+          wsRpcPort: 8546
+          httpRpcPort: 8544
           chains:
             - networkId: 1337
             - networkId: 2337

--- a/charts/chainlink-cluster/values.yaml
+++ b/charts/chainlink-cluster/values.yaml
@@ -120,8 +120,8 @@ geth:
     runAsUser: 999
     runAsGroup: 999
   version: v1.12.0
-  wsrpc-port: 8546
-  httprpc-port: 8544
+  wsRpcPort: 8546
+  httpRpcPort: 8544
   blocktime: 1
   chains:
     - networkId: 1337


### PR DESCRIPTION
Renaming properties with dashes as it is really hard to use them in the helm templates. 
They weren't used anywhere so it is safe to rename them.