### PR TITLE
BCF-3116 TestShell-ListUsers test fix

### DIFF
--- a/core/cmd/admin_commands_test.go
+++ b/core/cmd/admin_commands_test.go
@@ -150,8 +150,8 @@ func TestShell_ListUsers(t *testing.T) {
 	assert.Contains(t, output, user.Email)
 	assert.Contains(t, output, user.Role)
 	assert.Contains(t, output, user.TokenKey.String)
-	assert.Contains(t, output, user.CreatedAt.String())
-	assert.Contains(t, output, user.UpdatedAt.String())
+	assert.Contains(t, output, user.CreatedAt.UTC().String())
+	assert.Contains(t, output, user.UpdatedAt.UTC().String())
 }
 
 func TestAdminUsersPresenter_RenderTable(t *testing.T) {


### PR DESCRIPTION
Test is changed to convert the users timezone to UTC before comparison.  

Question - is there any reason why the CreateUser method of the AuthenticationProvider should be returning the user's creation/update times with UTC timezone?  If not all is good.