### PR TITLE
remove code that will not be executed

### DIFF
--- a/core/services/keystore/keys/ocr2key/offchain_keyring_test.go
+++ b/core/services/keystore/keys/ocr2key/offchain_keyring_test.go
@@ -61,7 +61,6 @@ func naclBoxSealAnonymous(t *testing.T, peerPublicKey [curve25519.PointSize]byte
 	ciphertext, err := box.SealAnonymous(nil, plaintext, &peerPublicKey, cryptorand.Reader)
 	if err != nil {
 		t.Fatalf("encryption failed")
-		return nil
 	}
 
 	return ciphertext


### PR DESCRIPTION
The program will exit directly after Fatal, the subsequent code will not be executed.