### PR TITLE
CCIP-1906 Raising a flag when finality is violated

### DIFF
--- a/.changeset/silent-pets-sip.md
+++ b/.changeset/silent-pets-sip.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Exposing information about LogPoller finality violation via Healthy method. It's raised whenever LogPoller sees reorg deeper than the finality

--- a/core/chains/evm/logpoller/disabled.go
+++ b/core/chains/evm/logpoller/disabled.go
@@ -21,6 +21,10 @@ func (disabled) Start(ctx context.Context) error { return ErrDisabled }
 
 func (disabled) Close() error { return ErrDisabled }
 
+func (disabled) Healthy() error {
+	return ErrDisabled
+}
+
 func (disabled) Ready() error { return ErrDisabled }
 
 func (disabled) HealthReport() map[string]error {

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -1040,6 +1040,93 @@ func TestLogPoller_PollAndSaveLogs(t *testing.T) {
 	}
 }
 
+func TestLogPoller_ReorgDeeperThanFinality(t *testing.T) {
+	tests := []struct {
+		name          string
+		finalityDepth int64
+		finalityTag   bool
+	}{
+		{
+			name:          "fixed finality depth without finality tag",
+			finalityDepth: 1,
+			finalityTag:   false,
+		},
+		{
+			name:          "chain finality in use",
+			finalityDepth: 0,
+			finalityTag:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			th := SetupTH(t, logpoller.Opts{
+				UseFinalityTag:           tt.finalityTag,
+				FinalityDepth:            tt.finalityDepth,
+				BackfillBatchSize:        3,
+				RpcBatchSize:             2,
+				KeepFinalizedBlocksDepth: 1000,
+				BackupPollerBlockDelay:   100,
+			})
+			// Set up a log poller listening for log emitter logs.
+			err := th.LogPoller.RegisterFilter(testutils.Context(t), logpoller.Filter{
+				Name:      "Test Emitter",
+				EventSigs: []common.Hash{EmitterABI.Events["Log1"].ID},
+				Addresses: []common.Address{th.EmitterAddress1},
+			})
+			require.NoError(t, err)
+
+			// Test scenario
+			// Chain gen <- 1 <- 2 <- 3 (finalized) <- 4 (L1_1)
+			_, err = th.Emitter1.EmitLog1(th.Owner, []*big.Int{big.NewInt(1)})
+			require.NoError(t, err)
+			th.Client.Commit()
+			th.Client.Commit()
+			th.Client.Commit()
+			markBlockAsFinalized(t, th, 3)
+
+			// Polling should get us the L1 log.
+			firstPoll := th.PollAndSaveLogs(testutils.Context(t), 1)
+			assert.Equal(t, int64(5), firstPoll)
+			assert.NoError(t, th.LogPoller.Healthy())
+
+			// Fork deeper than finality depth
+			// Chain gen <- 1 <- 2 <- 3 (finalized) <- 4 (L1_1)
+			//              \  2' <- 3' <- 4' <- 5' <- 6' (finalized) <- 7' <- 8' <- 9' <- 10' (L1_2)
+			lca, err := th.Client.BlockByNumber(testutils.Context(t), big.NewInt(1))
+			require.NoError(t, err)
+			require.NoError(t, th.Client.Fork(testutils.Context(t), lca.Hash()))
+
+			// Create 2'
+			_, err = th.Emitter1.EmitLog1(th.Owner, []*big.Int{big.NewInt(2)})
+			require.NoError(t, err)
+			th.Client.Commit()
+
+			// Create 3-10
+			for i := 3; i < 10; i++ {
+				_, err = th.Emitter1.EmitLog1(th.Owner, []*big.Int{big.NewInt(int64(i))})
+				require.NoError(t, err)
+				th.Client.Commit()
+			}
+			markBlockAsFinalized(t, th, 6)
+
+			secondPoll := th.PollAndSaveLogs(testutils.Context(t), firstPoll)
+			assert.Equal(t, firstPoll, secondPoll)
+			assert.Equal(t, logpoller.ErrFinalityViolated, th.LogPoller.Healthy())
+
+			// Manually remove latest block from the log poller to bring it back to life
+			// LogPoller should be healthy again after first poll
+			// Chain gen <- 1
+			//              \  2' <- 3' <- 4' <- 5' <- 6' (finalized) <- 7' <- 8' <- 9' <- 10' (L1_2)
+			require.NoError(t, th.ORM.DeleteLogsAndBlocksAfter(testutils.Context(t), 2))
+			// Poll from latest
+			recoveryPoll := th.PollAndSaveLogs(testutils.Context(t), 1)
+			assert.Equal(t, int64(10), recoveryPoll)
+			assert.NoError(t, th.LogPoller.Healthy())
+		})
+	}
+}
+
 func TestLogPoller_PollAndSaveLogsDeepReorg(t *testing.T) {
 	t.Parallel()
 
@@ -1089,6 +1176,7 @@ func TestLogPoller_PollAndSaveLogsDeepReorg(t *testing.T) {
 
 			// Polling should get us the L1 log.
 			newStart := th.PollAndSaveLogs(testutils.Context(t), 1)
+			assert.NoError(t, th.LogPoller.Healthy())
 			assert.Equal(t, int64(3), newStart)
 			// Check that L1_1 has a proper data payload
 			lgs, err := th.ORM.SelectLogsByBlockRange(testutils.Context(t), 2, 2)
@@ -1115,6 +1203,7 @@ func TestLogPoller_PollAndSaveLogsDeepReorg(t *testing.T) {
 
 			newStart = th.PollAndSaveLogs(testutils.Context(t), newStart)
 			assert.Equal(t, int64(10), newStart)
+			assert.NoError(t, th.LogPoller.Healthy())
 
 			// Expect L1_2 to be properly updated
 			lgs, err = th.ORM.SelectLogsByBlockRange(testutils.Context(t), 2, 2)

--- a/core/chains/evm/logpoller/mocks/log_poller.go
+++ b/core/chains/evm/logpoller/mocks/log_poller.go
@@ -105,6 +105,24 @@ func (_m *LogPoller) HealthReport() map[string]error {
 	return r0
 }
 
+// Healthy provides a mock function with given fields:
+func (_m *LogPoller) Healthy() error {
+	ret := _m.Called()
+
+	if len(ret) == 0 {
+		panic("no return value specified for Healthy")
+	}
+
+	var r0 error
+	if rf, ok := ret.Get(0).(func() error); ok {
+		r0 = rf()
+	} else {
+		r0 = ret.Error(0)
+	}
+
+	return r0
+}
+
 // IndexedLogs provides a mock function with given fields: ctx, eventSig, address, topicIndex, topicValues, confs
 func (_m *LogPoller) IndexedLogs(ctx context.Context, eventSig common.Hash, address common.Address, topicIndex int, topicValues []common.Hash, confs logpoller.Confirmations) ([]logpoller.Log, error) {
 	ret := _m.Called(ctx, eventSig, address, topicIndex, topicValues, confs)


### PR DESCRIPTION
Backporting changes from CCIP repository https://github.com/smartcontractkit/ccip/pull/584

Exposing information about LogPoller's finality violation via the Healthy method. This is heavily used for CCIP to halt the protocol whenever LogPoller sees that finality is not respected by the chain.

