### PR TITLE
add test for billing overrides

### DIFF
--- a/.changeset/tiny-suns-end.md
+++ b/.changeset/tiny-suns-end.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+add test for billing override

--- a/contracts/.changeset/tasty-rings-bow.md
+++ b/contracts/.changeset/tasty-rings-bow.md
@@ -1,0 +1,5 @@
+---
+"@chainlink/contracts": patch
+---
+
+add billing override test

--- a/contracts/src/v0.8/automation/dev/test/AutomationRegistry2_3.t.sol
+++ b/contracts/src/v0.8/automation/dev/test/AutomationRegistry2_3.t.sol
@@ -948,4 +948,23 @@ contract BillingOverrides is SetUp {
     emit BillingConfigOverrideRemoved(linkUpkeepID);
     registry.removeBillingOverrides(linkUpkeepID);
   }
+
+  function test_Happy_MaxGasPayment_WithBillingOverrides() public {
+    uint96 maxPayment1 = registry.getMaxPaymentForGas(linkUpkeepID, 0, 5_000_000, address(linkToken));
+
+    // Double the two billing values
+    AutomationRegistryBase2_3.BillingOverrides memory billingOverrides = AutomationRegistryBase2_3.BillingOverrides({
+      gasFeePPB: DEFAULT_GAS_FEE_PPB * 2,
+      flatFeeMilliCents: DEFAULT_FLAT_FEE_MILLI_CENTS * 2
+    });
+
+    vm.startPrank(PRIVILEGE_MANAGER);
+    registry.setBillingOverrides(linkUpkeepID, billingOverrides);
+
+    // maxPayment2 should be greater than maxPayment1 after the overrides
+    // The 2 numbers should follow this: maxPayment2 - maxPayment1 == 2 * recepit.premium
+    // We do not apply the exact equation since we couldn't get the receipt.premium value
+    uint96 maxPayment2 = registry.getMaxPaymentForGas(linkUpkeepID, 0, 5_000_000, address(linkToken));
+    assertGt(maxPayment2, maxPayment1);
+  }
 }

--- a/contracts/src/v0.8/automation/dev/test/BaseTest.t.sol
+++ b/contracts/src/v0.8/automation/dev/test/BaseTest.t.sol
@@ -30,6 +30,8 @@ contract BaseTest is Test {
 
   // constants
   address internal constant ZERO_ADDRESS = address(0);
+  uint32 internal constant DEFAULT_GAS_FEE_PPB = 10_000_000;
+  uint24 internal constant DEFAULT_FLAT_FEE_MILLI_CENTS = 2_000;
 
   // config
   uint8 internal constant F = 1; // number of faulty nodes
@@ -153,22 +155,22 @@ contract BaseTest is Test {
     AutomationRegistryBase2_3.BillingConfig[]
       memory billingTokenConfigs = new AutomationRegistryBase2_3.BillingConfig[](billingTokens.length);
     billingTokenConfigs[0] = AutomationRegistryBase2_3.BillingConfig({
-      gasFeePPB: 10_000_000, // 15%
-      flatFeeMilliCents: 2_000, // 2 cents
+      gasFeePPB: DEFAULT_GAS_FEE_PPB, // 15%
+      flatFeeMilliCents: DEFAULT_FLAT_FEE_MILLI_CENTS, // 2 cents
       priceFeed: address(USDTOKEN_USD_FEED),
       fallbackPrice: 100_000_000, // $1
       minSpend: 100000000000000000000 // 100 USD
     });
     billingTokenConfigs[1] = AutomationRegistryBase2_3.BillingConfig({
-      gasFeePPB: 10_000_000, // 15%
-      flatFeeMilliCents: 2_000, // 2 cents
+      gasFeePPB: DEFAULT_GAS_FEE_PPB, // 15%
+      flatFeeMilliCents: DEFAULT_FLAT_FEE_MILLI_CENTS, // 2 cents
       priceFeed: address(NATIVE_USD_FEED),
       fallbackPrice: 100_000_000, // $1
       minSpend: 5000000000000000000 // 5 Native
     });
     billingTokenConfigs[2] = AutomationRegistryBase2_3.BillingConfig({
-      gasFeePPB: 10_000_000, // 10%
-      flatFeeMilliCents: 2_000, // 2 cents
+      gasFeePPB: DEFAULT_GAS_FEE_PPB, // 10%
+      flatFeeMilliCents: DEFAULT_FLAT_FEE_MILLI_CENTS, // 2 cents
       priceFeed: address(LINK_USD_FEED),
       fallbackPrice: 1_000_000_000, // $10
       minSpend: 5000000000000000000 // 5 LINK


### PR DESCRIPTION
Here is a follow up to add test coverage for billing override.

The most straightforward and intuitive way to test the override is to confirm that the outputs are different after the override. we are mostly following this.

I dug into the math a bit in `_calculatePaymentAmount ` and based on the two input BillingOverrides values, the two outputs should differ by 2 * receipt.premium. we didnt expose the receipt object in the func, and I think it is messy to copy paste the math to this test, hence I added note, but didnt check the exact numbers.

Let me know if you have better way to test this.