### PR TITLE
Make LogPoller more robust against local finality violations

### DIFF
--- a/.changeset/fresh-moles-explode.md
+++ b/.changeset/fresh-moles-explode.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+core/chains/evm/logpoller: Stricter finality checks in LogPoller, to be more robust during rpc failover events #updated

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -700,7 +700,7 @@ func (lp *logPoller) BackupPollAndSaveLogs(ctx context.Context) {
 			return
 		}
 		// If this is our first run, start from block min(lastProcessed.FinalizedBlockNumber-1, lastProcessed.BlockNumber-backupPollerBlockDelay)
-		backupStartBlock := mathutil.Min(lastProcessed.FinalizedBlockNumber-1, lastProcessed.BlockNumber-lp.backupPollerBlockDelay)
+		backupStartBlock := mathutil.Min(lastProcessed.FinalizedBlockNumber, lastProcessed.BlockNumber-lp.backupPollerBlockDelay)
 		// (or at block 0 if whole blockchain is too short)
 		lp.backupPollerNextBlock = mathutil.Max(backupStartBlock, 0)
 	}
@@ -820,6 +820,7 @@ func (lp *logPoller) backfill(ctx context.Context, start, end int64) error {
 		if err != nil {
 			return err
 		}
+
 		endblock := blocks[len(blocks)-1]
 		if gethLogs[len(gethLogs)-1].BlockNumber != uint64(to) {
 			// Pop endblock if there were no logs for it, so that length of blocks & gethLogs are the same to pass to convertLogs
@@ -1316,7 +1317,7 @@ func (lp *logPoller) batchFetchBlocks(ctx context.Context, blocksRequested []str
 		}
 		reqs := make([]rpc.BatchElem, 0, j-i+1)
 
-		validationBlockIndex := int(j - i)
+		validationBlockIndex := j - i
 		for k, num := range blocksRequested[i:j] {
 			if num == validationReq {
 				validationBlockIndex = k

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -1364,7 +1364,7 @@ func (lp *logPoller) fetchBlocks(ctx context.Context, blocksRequested []string, 
 		blockRequested := r.Args[0].(string)
 		if blockRequested != string(latestBlock) && block.Number > latestFinalizedBlockNumber {
 			return nil, fmt.Errorf(
-				"Received unfinalized block %d while expecting finalized block (latestFinaliezdBlockNumber = %d)",
+				"Received unfinalized block %d while expecting finalized block (latestFinalizedBlockNumber = %d)",
 				block.Number, latestFinalizedBlockNumber)
 		}
 

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -699,7 +699,7 @@ func (lp *logPoller) BackupPollAndSaveLogs(ctx context.Context) {
 			}
 			return
 		}
-		// If this is our first run, start from block min(lastProcessed.FinalizedBlockNumber-1, lastProcessed.BlockNumber-backupPollerBlockDelay)
+		// If this is our first run, start from block min(lastProcessed.FinalizedBlockNumber, lastProcessed.BlockNumber-backupPollerBlockDelay)
 		backupStartBlock := mathutil.Min(lastProcessed.FinalizedBlockNumber, lastProcessed.BlockNumber-lp.backupPollerBlockDelay)
 		// (or at block 0 if whole blockchain is too short)
 		lp.backupPollerNextBlock = mathutil.Max(backupStartBlock, 0)
@@ -1256,8 +1256,8 @@ func (lp *logPoller) GetBlocksRange(ctx context.Context, numbers []uint64) ([]Lo
 }
 
 // fillRemainingBlocksFromRPC sends a batch request for each block in blocksRequested, and converts them from
-// geth blocks into LogPollerBlock strutcs. This is only intended to be used for requesting finalized blocks,
-// if any of the blocks coming back are not finalized they will be discarded
+// geth blocks into LogPollerBlock structs. This is only intended to be used for requesting finalized blocks,
+// if any of the blocks coming back are not finalized, an error will be returned
 func (lp *logPoller) fillRemainingBlocksFromRPC(
 	ctx context.Context,
 	blocksRequested map[uint64]struct{},

--- a/core/chains/evm/logpoller/log_poller_internal_test.go
+++ b/core/chains/evm/logpoller/log_poller_internal_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/rpc"
 	pkgerrors "github.com/pkg/errors"
@@ -205,13 +206,14 @@ func TestLogPoller_BackupPollerStartup(t *testing.T) {
 	chainID := testutils.FixtureChainID
 	db := pgtest.NewSqlxDB(t)
 	orm := NewORM(chainID, db, lggr)
+	latestBlock := int64(4)
 
-	head := evmtypes.Head{Number: 3}
+	head := evmtypes.Head{Number: latestBlock}
 	events := []common.Hash{EmitterABI.Events["Log1"].ID}
 	log1 := types.Log{
 		Index:       0,
 		BlockHash:   common.Hash{},
-		BlockNumber: uint64(3),
+		BlockNumber: uint64(latestBlock),
 		Topics:      events,
 		Address:     addr,
 		TxHash:      common.HexToHash("0x1234"),
@@ -230,20 +232,44 @@ func TestLogPoller_BackupPollerStartup(t *testing.T) {
 		BackfillBatchSize:        3,
 		RpcBatchSize:             2,
 		KeepFinalizedBlocksDepth: 1000,
+		BackupPollerBlockDelay:   0,
 	}
 	lp := NewLogPoller(orm, ec, lggr, lpOpts)
 	lp.BackupPollAndSaveLogs(ctx)
 	assert.Equal(t, int64(0), lp.backupPollerNextBlock)
 	assert.Equal(t, 1, observedLogs.FilterMessageSnippet("ran before first successful log poller run").Len())
 
-	lp.PollAndSaveLogs(ctx, 3)
+	lp.PollAndSaveLogs(ctx, latestBlock)
 
 	lastProcessed, err := lp.orm.SelectLatestBlock(ctx)
 	require.NoError(t, err)
-	require.Equal(t, int64(3), lastProcessed.BlockNumber)
+	require.Equal(t, latestBlock, lastProcessed.BlockNumber)
 
 	lp.BackupPollAndSaveLogs(ctx)
-	assert.Equal(t, int64(1), lp.backupPollerNextBlock) // Ensure non-negative!
+	assert.Equal(t, int64(2), lp.backupPollerNextBlock)
+}
+
+func mockBatchCallContext(t *testing.T, ec *evmclimocks.Client) {
+	ec.On("BatchCallContext", mock.Anything, mock.Anything).Return(nil).Run(func(args mock.Arguments) {
+		elems := args.Get(1).([]rpc.BatchElem)
+		for _, e := range elems {
+			var num int64
+			block := e.Args[0].(string)
+			switch block {
+			case "latest":
+				num = 8
+			case "finalized":
+				num = 5
+			default:
+				n, err := hexutil.DecodeUint64(block)
+				require.NoError(t, err)
+				num = int64(n)
+			}
+			result := e.Result.(*evmtypes.Head)
+			*result = evmtypes.Head{Number: num, Hash: utils.NewHash()}
+
+		}
+	})
 }
 
 func TestLogPoller_Replay(t *testing.T) {
@@ -269,16 +295,20 @@ func TestLogPoller_Replay(t *testing.T) {
 	}
 
 	ec := evmclimocks.NewClient(t)
-	ec.On("HeadByNumber", mock.Anything, mock.Anything).Return(&head, nil)
-	ec.On("FilterLogs", mock.Anything, mock.Anything).Return([]types.Log{log1}, nil).Twice()
+	ec.On("HeadByNumber", mock.Anything, mock.Anything).Return(func(context.Context, *big.Int) (*evmtypes.Head, error) {
+		headCopy := head
+		return &headCopy, nil
+	})
+	ec.On("FilterLogs", mock.Anything, mock.Anything).Return([]types.Log{log1}, nil).Once()
 	ec.On("ConfiguredChainID").Return(chainID, nil)
+
 	lpOpts := Opts{
-		PollPeriod:               time.Hour,
+		PollPeriod:               time.Second,
 		FinalityDepth:            3,
 		BackfillBatchSize:        3,
 		RpcBatchSize:             3,
 		KeepFinalizedBlocksDepth: 20,
-		BackupPollerBlockDelay:   100,
+		BackupPollerBlockDelay:   0,
 	}
 	lp := NewLogPoller(orm, ec, lggr, lpOpts)
 
@@ -308,6 +338,7 @@ func TestLogPoller_Replay(t *testing.T) {
 
 	// Replay() should return error code received from replayComplete
 	t.Run("returns error code on replay complete", func(t *testing.T) {
+		mockBatchCallContext(t, ec)
 		anyErr := pkgerrors.New("any error")
 		done := make(chan struct{})
 		go func() {
@@ -345,6 +376,7 @@ func TestLogPoller_Replay(t *testing.T) {
 		var wg sync.WaitGroup
 		defer func() { wg.Wait() }()
 		ec.On("FilterLogs", mock.Anything, mock.Anything).Once().Return([]types.Log{log1}, nil).Run(func(args mock.Arguments) {
+			head = evmtypes.Head{Number: 4}
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
@@ -371,6 +403,7 @@ func TestLogPoller_Replay(t *testing.T) {
 
 		ec.On("FilterLogs", mock.Anything, mock.Anything).Return([]types.Log{log1}, nil).Maybe() // in case task gets delayed by >= 100ms
 
+		head = evmtypes.Head{Number: 5}
 		t.Cleanup(lp.reset)
 		servicetest.Run(t, lp)
 
@@ -395,6 +428,8 @@ func TestLogPoller_Replay(t *testing.T) {
 		ec.On("FilterLogs", mock.Anything, mock.Anything).Once().Return([]types.Log{log1}, nil).Run(func(args mock.Arguments) {
 			go func() {
 				defer close(done)
+
+				head = evmtypes.Head{Number: 4} // Restore latest block to 4, so this matches the fromBlock requested
 				select {
 				case lp.replayStart <- 4:
 				case <-ctx.Done():
@@ -405,9 +440,10 @@ func TestLogPoller_Replay(t *testing.T) {
 			lp.cancel()
 			close(pass)
 		})
-		ec.On("FilterLogs", mock.Anything, mock.Anything).Return([]types.Log{log1}, nil).Maybe() // in case task gets delayed by >= 100ms
+		ec.On("FilterLogs", mock.Anything, mock.Anything).Return([]types.Log{log1}, nil)
 
 		t.Cleanup(lp.reset)
+		head = evmtypes.Head{Number: 5} // Latest block must be > lastProcessed in order for SaveAndPollLogs() to call FilterLogs()
 		servicetest.Run(t, lp)
 
 		select {
@@ -420,6 +456,9 @@ func TestLogPoller_Replay(t *testing.T) {
 	// ReplayAsync should return as soon as replayStart is received
 	t.Run("ReplayAsync success", func(t *testing.T) {
 		t.Cleanup(lp.reset)
+		head = evmtypes.Head{Number: 5}
+		ec.On("FilterLogs", mock.Anything, mock.Anything).Return([]types.Log{log1}, nil)
+		mockBatchCallContext(t, ec)
 		servicetest.Run(t, lp)
 
 		lp.ReplayAsync(1)
@@ -430,6 +469,7 @@ func TestLogPoller_Replay(t *testing.T) {
 	t.Run("ReplayAsync error", func(t *testing.T) {
 		t.Cleanup(lp.reset)
 		servicetest.Run(t, lp)
+		head = evmtypes.Head{Number: 4}
 
 		anyErr := pkgerrors.New("async error")
 		observedLogs.TakeAll()
@@ -461,6 +501,9 @@ func TestLogPoller_Replay(t *testing.T) {
 
 		err = lp.orm.InsertBlock(ctx, head.Hash, head.Number, head.Timestamp, head.Number)
 		require.NoError(t, err)
+
+		ec.On("FilterLogs", mock.Anything, mock.Anything).Return([]types.Log{log1}, nil)
+		mockBatchCallContext(t, ec)
 
 		err = lp.Replay(ctx, 1)
 		require.NoError(t, err)

--- a/core/chains/evm/logpoller/log_poller_internal_test.go
+++ b/core/chains/evm/logpoller/log_poller_internal_test.go
@@ -338,6 +338,7 @@ func TestLogPoller_Replay(t *testing.T) {
 
 	// Replay() should return error code received from replayComplete
 	t.Run("returns error code on replay complete", func(t *testing.T) {
+		ec.On("FilterLogs", mock.Anything, mock.Anything).Return([]types.Log{log1}, nil).Once()
 		mockBatchCallContext(t, ec)
 		anyErr := pkgerrors.New("any error")
 		done := make(chan struct{})

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -545,8 +545,6 @@ func TestLogPoller_BackupPollAndSaveLogsSkippingLogsThatAreTooOld(t *testing.T) 
 		BackupPollerBlockDelay:   1,
 	}
 	th := SetupTH(t, lpOpts)
-	//header, err := th.Client.HeaderByNumber(ctx, nil)
-	//require.NoError(t, err)
 
 	// Emit some logs in blocks
 	for i := 1; i <= logsBatch; i++ {
@@ -559,7 +557,7 @@ func TestLogPoller_BackupPollAndSaveLogsSkippingLogsThatAreTooOld(t *testing.T) 
 	// 1 -> 2 -> ... -> firstBatchBlock
 	firstBatchBlock := th.PollAndSaveLogs(ctx, 1)
 	// Mark current tip of the chain as finalized (after emitting 10 logs)
-	markBlockAsFinalized(t, th, firstBatchBlock)
+	markBlockAsFinalized(t, th, firstBatchBlock-1)
 
 	// Emit 2nd batch of block
 	for i := 1; i <= logsBatch; i++ {
@@ -571,7 +569,7 @@ func TestLogPoller_BackupPollAndSaveLogsSkippingLogsThatAreTooOld(t *testing.T) 
 	// 1 -> 2 -> ... -> firstBatchBlock (finalized) -> .. -> firstBatchBlock + emitted logs
 	secondBatchBlock := th.PollAndSaveLogs(ctx, firstBatchBlock)
 	// Mark current tip of the block as finalized (after emitting 20 logs)
-	markBlockAsFinalized(t, th, secondBatchBlock)
+	markBlockAsFinalized(t, th, secondBatchBlock-1)
 
 	// Register filter
 	err := th.LogPoller.RegisterFilter(ctx, logpoller.Filter{
@@ -595,8 +593,8 @@ func TestLogPoller_BackupPollAndSaveLogsSkippingLogsThatAreTooOld(t *testing.T) 
 		th.EmitterAddress1,
 	)
 	require.NoError(t, err)
-	require.Len(t, logs, logsBatch+1)
-	require.Equal(t, hexutil.MustDecode(`0x0000000000000000000000000000000000000000000000000000000000000009`), logs[0].Data)
+	require.Len(t, logs, logsBatch)
+	require.Equal(t, hexutil.MustDecode(`0x000000000000000000000000000000000000000000000000000000000000000a`), logs[0].Data)
 }
 
 func TestLogPoller_BlockTimestamps(t *testing.T) {

--- a/core/chains/evm/logpoller/log_poller_test.go
+++ b/core/chains/evm/logpoller/log_poller_test.go
@@ -1344,7 +1344,7 @@ func TestLogPoller_GetBlocks_Range(t *testing.T) {
 	blockNums = []uint64{2}
 	_, err = th.LogPoller.GetBlocksRange(testutils.Context(t), blockNums)
 	require.Error(t, err)
-	assert.Equal(t, "Received unfinalized block 2 while expecting finalized block (latestFinaliezdBlockNumber = 1)", err.Error())
+	assert.Equal(t, "Received unfinalized block 2 while expecting finalized block (latestFinalizedBlockNumber = 1)", err.Error())
 
 	th.Client.Commit() // Commit block #4, so that block #2 is finalized
 


### PR DESCRIPTION
The main focus of this PR is to help LogPoller detect, prevent "local finality violations".  These are cases where the multinode layer fails over from one rpc several to another and the second one is behind on its view of the chain.  This can make it look like there is a finality violation even when there was not any global finality violation on the chain.

Primary change:

-  Checks that all results from batchFetchBlocks() are finalized aside from "latest"
    batchFetchBlocks() will now fetch the "finalized" block along with the rest of each batch, 
    and validate that all of the block numbers (aside from the special case when "latest" is requested)
    are <= the finalized block number returned.

Also in this PR are two refactors for reducing code complexity:

-   Change backfill() to always save the last block of each batch of logs requested, rather than the last block of the logs returned.
     (This only makes a difference if the last block requested has no logs matching the filter, but this change will allow us to eliminate
     lastSafeBlockNumber = latestFinalizedBlock - 1 in an upcoming PR in favor of latestFinalizedBlock which simplifies the overall LogPoller
     implementation. It also gets us a step closer to being able to use "finalized" for the upper range of the final batch request for logs, but that
     comes with some additional complexities which still need to be worked out.)

-  Start Backup LogPoller on `lastProcessed.FinalizedBlockNumber` instead of `lastProcessed.FinalizedBlockNumber` - 1.  This was a harmless "bug" where it was starting one block too early, but entirely separate from the previous change.

-   Minor refactor to remove code duplication (condensing 3 replicated code blocks calling `getCurrentBlockMaybeHandleReorg` down to 2)