### PR TITLE
Add cascade delete to kv store table fk

### DIFF
--- a/.changeset/brave-games-drop.md
+++ b/.changeset/brave-games-drop.md
@@ -1,0 +1,5 @@
+---
+"chainlink": major
+---
+
+Fix kv_store migration fk cascade deletion

--- a/core/services/job/kv_orm_test.go
+++ b/core/services/job/kv_orm_test.go
@@ -82,4 +82,6 @@ func TestJobKVStore(t *testing.T) {
 	require.NoError(t, kvStore.Store(key, td2))
 	require.NoError(t, kvStore.Get(key, &retData))
 	require.Equal(t, td2, retData)
+
+	require.NoError(t, jobORM.DeleteJob(jobID))
 }

--- a/core/store/migrate/migrations/0229_add_kv_store_job_fk_cascade_delete.sql
+++ b/core/store/migrate/migrations/0229_add_kv_store_job_fk_cascade_delete.sql
@@ -1,0 +1,23 @@
+-- +goose Up
+
+BEGIN;
+
+ALTER TABLE job_kv_store DROP CONSTRAINT job_kv_store_job_id_fkey;
+ALTER TABLE job_kv_store
+    ADD CONSTRAINT job_kv_store_job_id_fkey
+        FOREIGN KEY (job_id)
+            REFERENCES jobs(id)
+            ON DELETE CASCADE;
+
+COMMIT;
+
+-- +goose Down
+BEGIN;
+
+ALTER TABLE job_kv_store DROP CONSTRAINT job_kv_store_job_id_fkey;
+ALTER TABLE job_kv_store
+    ADD CONSTRAINT job_kv_store_job_id_fkey
+        FOREIGN KEY (job_id)
+            REFERENCES jobs(id);
+
+COMMIT;


### PR DESCRIPTION
Adds 229 migration that adds cascade delete. This will get cherrypicked into release where 228 doesn't exist. Skip migration is supported an should work as intended, had no issues while testing it, 228 gets applied properly afterwards.