### PR TITLE
core/services/relay/evm: support pending for methodBinding

### DIFF
--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -608,7 +608,7 @@ func (r *Relayer) NewMedianProvider(rargs commontypes.RelayArgs, pargs commontyp
 			return nil, err
 		}
 
-		boundContracts := []commontypes.BoundContract{{Name: "median", Pending: true, Address: contractID.String()}}
+		boundContracts := []commontypes.BoundContract{{Name: "median", Address: contractID.String()}}
 		if err = chainReaderService.Bind(context.Background(), boundContracts); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
This PR adds support to `methodBinding` to recognize the `Pending` field and use the corresponding rpc block when it is set. It also disables the flag in the relayer, to match legacy behavior.

In the future this may go way or change completely, but this aligns things for now.