### PR TITLE
Revert "BCF-3116 TestShell-ListUsers test fix"

### DIFF
--- a/core/cmd/admin_commands_test.go
+++ b/core/cmd/admin_commands_test.go
@@ -150,8 +150,8 @@ func TestShell_ListUsers(t *testing.T) {
 	assert.Contains(t, output, user.Email)
 	assert.Contains(t, output, user.Role)
 	assert.Contains(t, output, user.TokenKey.String)
-	assert.Contains(t, output, user.CreatedAt.UTC().String())
-	assert.Contains(t, output, user.UpdatedAt.UTC().String())
+	assert.Contains(t, output, user.CreatedAt.String())
+	assert.Contains(t, output, user.UpdatedAt.String())
 }
 
 func TestAdminUsersPresenter_RenderTable(t *testing.T) {


### PR DESCRIPTION
Reverts smartcontractkit/chainlink#12549

This test fails on my local machine after that ^ change. I think it will only pass if the local TZ is aligned with UTC. We would have to force UTC here when writing otherwise:
https://github.com/smartcontractkit/chainlink/blob/3aa5e4681dc4475727f2167db253cc1e1f2e8c7c/core/cmd/admin_commands.go#L148-L149