### PR TITLE
[KS-136] Fix integration bugs

### DIFF
--- a/core/scripts/go.mod
+++ b/core/scripts/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/prometheus/client_golang v1.17.0
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chainlink-automation v1.0.2
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405173118-f5bf144ec6b3
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000
 	github.com/smartcontractkit/libocr v0.0.0-20240326191951-2bbe9382d052

--- a/core/scripts/go.sum
+++ b/core/scripts/go.sum
@@ -1187,8 +1187,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2SBz6fnSKiSW7XZ8IZQLpnI=
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25 h1:fY2wMtlr/VQxPyVVQdi1jFvQHi0VbDnGGVXzLKOZTOY=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405173118-f5bf144ec6b3 h1:LCVHf/ooB4HDkgfLUq+jK4CuCr6SsdNCQZt3/etJ8ms=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405173118-f5bf144ec6b3/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8/go.mod h1:a65NtrK4xZb01mf0dDNghPkN2wXgcqFQ55ADthVBgMc=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/core/services/relay/evm/cap_encoder.go
+++ b/core/services/relay/evm/cap_encoder.go
@@ -2,6 +2,7 @@ package evm
 
 import (
 	"context"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
@@ -75,23 +76,36 @@ func (c *capEncoder) Encode(ctx context.Context, input values.Map) ([]byte, erro
 	return append(append(workflowIDbytes, executionIDBytes...), userPayload...), nil
 }
 
+func decodeID(input map[string]any, key string) ([]byte, error) {
+	id, ok := input[key].(string)
+	if !ok {
+		return nil, fmt.Errorf("expected %s to be a string", key)
+	}
+
+	b, err := hex.DecodeString(id)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(b) < 32 {
+		return nil, fmt.Errorf("incorrect length for id %s, expected 32 bytes, got %d", id, len(b))
+	}
+
+	return b, nil
+}
+
 // extract workflowID and executionID from the input map, validate and align to 32 bytes
 // NOTE: consider requiring them to be exactly 32 bytes to avoid issues with padding
 func extractIDs(input map[string]any) ([]byte, []byte, error) {
-	workflowID, ok := input[consensustypes.WorkflowIDFieldName].(string)
-	if !ok {
-		return nil, nil, fmt.Errorf("expected %s to be a string", consensustypes.WorkflowIDFieldName)
+	workflowID, err := decodeID(input, consensustypes.WorkflowIDFieldName)
+	if err != nil {
+		return nil, nil, err
 	}
-	executionID, ok := input[consensustypes.ExecutionIDFieldName].(string)
-	if !ok {
-		return nil, nil, fmt.Errorf("expected %s to be a string", consensustypes.ExecutionIDFieldName)
+
+	executionID, err := decodeID(input, consensustypes.ExecutionIDFieldName)
+	if err != nil {
+		return nil, nil, err
 	}
-	if len(workflowID) > 32 || len(executionID) > 32 {
-		return nil, nil, fmt.Errorf("IDs too long: %d, %d", len(workflowID), len(executionID))
-	}
-	alignedWorkflowID := make([]byte, idLen)
-	copy(alignedWorkflowID, workflowID)
-	alignedExecutionID := make([]byte, idLen)
-	copy(alignedExecutionID, executionID)
-	return alignedWorkflowID, alignedExecutionID, nil
+
+	return workflowID, executionID, nil
 }

--- a/core/services/relay/evm/cap_encoder_test.go
+++ b/core/services/relay/evm/cap_encoder_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	consensustypes "github.com/smartcontractkit/chainlink-common/pkg/capabilities/consensus/ocr3/types"
@@ -13,10 +14,15 @@ import (
 )
 
 var (
-	reportA     = []byte{0x01, 0x02, 0x03}
-	reportB     = []byte{0xaa, 0xbb, 0xcc, 0xdd}
-	workflowID  = "my_id"
-	executionID = "my_execution_id"
+	reportA = []byte{0x01, 0x02, 0x03}
+	reportB = []byte{0xaa, 0xbb, 0xcc, 0xdd}
+
+	// hex encoded 32 byte strings
+	workflowID  = "15c631d295ef5e32deb99a10ee6804bc4af1385568f9b3363f6552ac6dbb2cef"
+	executionID = "8d4e66421db647dd916d3ec28d56188c8d7dae5f808e03d03339ed2562f13bb0"
+
+	invalidID   = "not_valid"
+	wrongLength = "8d4e66"
 )
 
 func TestEVMEncoder(t *testing.T) {
@@ -41,8 +47,8 @@ func TestEVMEncoder(t *testing.T) {
 
 	expected :=
 		// start of the outer tuple ((user_fields), workflow_id, workflow_execution_id)
-		"6d795f6964000000000000000000000000000000000000000000000000000000" + // workflow ID
-			"6d795f657865637574696f6e5f69640000000000000000000000000000000000" + // execution ID
+		workflowID +
+			executionID +
 			// start of the inner tuple (user_fields)
 			"0000000000000000000000000000000000000000000000000000000000000020" + // offset of mercury_reports array
 			"0000000000000000000000000000000000000000000000000000000000000002" + // length of mercury_reports array
@@ -55,4 +61,37 @@ func TestEVMEncoder(t *testing.T) {
 	// end of the inner tuple (user_fields)
 
 	require.Equal(t, expected, hex.EncodeToString(encoded))
+}
+
+func TestEVMEncoder_InvalidIDs(t *testing.T) {
+	config := map[string]any{
+		"abi": "mercury_reports bytes[]",
+	}
+	wrapped, err := values.NewMap(config)
+	require.NoError(t, err)
+	enc, err := evm.NewEVMEncoder(wrapped)
+	require.NoError(t, err)
+
+	// output of a DF2.0 aggregator + metadata fields appended by OCR
+	// using an invalid ID
+	input := map[string]any{
+		"mercury_reports":                   []any{reportA, reportB},
+		consensustypes.WorkflowIDFieldName:  invalidID,
+		consensustypes.ExecutionIDFieldName: executionID,
+	}
+	wrapped, err = values.NewMap(input)
+	require.NoError(t, err)
+	_, err = enc.Encode(testutils.Context(t), *wrapped)
+	assert.ErrorContains(t, err, "invalid byte")
+
+	// using valid hex string of wrong length
+	input = map[string]any{
+		"mercury_reports":                   []any{reportA, reportB},
+		consensustypes.WorkflowIDFieldName:  wrongLength,
+		consensustypes.ExecutionIDFieldName: executionID,
+	}
+	wrapped, err = values.NewMap(input)
+	require.NoError(t, err)
+	_, err = enc.Encode(testutils.Context(t), *wrapped)
+	assert.ErrorContains(t, err, "incorrect length for id")
 }

--- a/core/services/workflows/delegate.go
+++ b/core/services/workflows/delegate.go
@@ -3,10 +3,13 @@ package workflows
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/pelletier/go-toml"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/mercury"
+	"github.com/smartcontractkit/chainlink-common/pkg/capabilities/triggers"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
 	"github.com/smartcontractkit/chainlink/v2/core/capabilities/targets"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/legacyevm"
@@ -17,12 +20,12 @@ import (
 
 const hardcodedWorkflow = `
 triggers:
-  - type: "on_mercury_report"
+  - type: "mercury-trigger"
     config:
-      feedlist:
-        - "0x1111111111111111111100000000000000000000000000000000000000000000" # ETHUSD
-        - "0x2222222222222222222200000000000000000000000000000000000000000000" # LINKUSD
-        - "0x3333333333333333333300000000000000000000000000000000000000000000" # BTCUSD
+      feedIds:
+        - "0x1111111111111111111100000000000000000000000000000000000000000000"
+        - "0x2222222222222222222200000000000000000000000000000000000000000000"
+        - "0x3333333333333333333300000000000000000000000000000000000000000000"
         
 consensus:
   - type: "offchain_reporting"
@@ -64,8 +67,9 @@ targets:
 `
 
 type Delegate struct {
-	registry types.CapabilitiesRegistry
-	logger   logger.Logger
+	registry        types.CapabilitiesRegistry
+	logger          logger.Logger
+	legacyEVMChains legacyevm.LegacyChainContainer
 }
 
 var _ job.Delegate = (*Delegate)(nil)
@@ -84,10 +88,25 @@ func (d *Delegate) OnDeleteJob(ctx context.Context, jb job.Job, q pg.Queryer) er
 
 // ServicesForSpec satisfies the job.Delegate interface.
 func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.ServiceCtx, error) {
+	// NOTE: we temporarily do registration inside ServicesForSpec, this will be moved out of job specs in the future
+	err := targets.InitializeWrite(d.registry, d.legacyEVMChains, d.logger)
+	if err != nil {
+		d.logger.Errorw("could not initialize writes", err)
+	}
+
+	trigger := triggers.NewMercuryTriggerService()
+	err = d.registry.Add(context.Background(), trigger)
+	if err != nil {
+		d.logger.Errorw("could not add mercury trigger to registry", err)
+	} else {
+		go mercuryEventLoop(trigger, d.logger)
+	}
+
 	cfg := Config{
-		Lggr:     d.logger,
-		Spec:     hardcodedWorkflow,
-		Registry: d.registry,
+		Lggr:       d.logger,
+		Spec:       hardcodedWorkflow,
+		Registry:   d.registry,
+		WorkflowID: mockedWorkflowID,
 	}
 	engine, err := NewEngine(cfg)
 	if err != nil {
@@ -97,10 +116,53 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) ([]job.Ser
 }
 
 func NewDelegate(logger logger.Logger, registry types.CapabilitiesRegistry, legacyEVMChains legacyevm.LegacyChainContainer) *Delegate {
-	// NOTE: we temporarily do registration inside NewDelegate, this will be moved out of job specs in the future
-	_ = targets.InitializeWrite(registry, legacyEVMChains, logger)
+	return &Delegate{logger: logger, registry: registry, legacyEVMChains: legacyEVMChains}
+}
 
-	return &Delegate{logger: logger, registry: registry}
+func mercuryEventLoop(trigger *triggers.MercuryTriggerService, logger logger.Logger) {
+	sleepSec := 60 * time.Second
+	ticker := time.NewTicker(sleepSec)
+	defer ticker.Stop()
+
+	prices := []int64{300000, 2000, 5000000}
+
+	for range ticker.C {
+		for i := range prices {
+			prices[i] = prices[i] + 1
+		}
+
+		t := time.Now().Round(sleepSec).Unix()
+		reports, err := emitReports(logger, trigger, t, prices)
+		if err != nil {
+			logger.Errorw("failed to process Mercury reports", "err", err, "timestamp", time.Now().Unix(), "payload", reports)
+		}
+	}
+}
+
+func emitReports(logger logger.Logger, trigger *triggers.MercuryTriggerService, t int64, prices []int64) ([]triggers.FeedReport, error) {
+	reports := []triggers.FeedReport{
+		{
+			FeedID:               mercury.FeedID("0x1111111111111111111100000000000000000000000000000000000000000000").Bytes(),
+			FullReport:           []byte{},
+			BenchmarkPrice:       prices[0],
+			ObservationTimestamp: t,
+		},
+		{
+			FeedID:               mercury.FeedID("0x2222222222222222222200000000000000000000000000000000000000000000").Bytes(),
+			FullReport:           []byte{},
+			BenchmarkPrice:       prices[1],
+			ObservationTimestamp: t,
+		},
+		{
+			FeedID:               mercury.FeedID("0x3333333333333333333300000000000000000000000000000000000000000000").Bytes(),
+			FullReport:           []byte{},
+			BenchmarkPrice:       prices[2],
+			ObservationTimestamp: t,
+		},
+	}
+
+	logger.Infow("New set of Mercury reports", "timestamp", time.Now().Unix(), "payload", reports)
+	return reports, trigger.ProcessReport(reports)
 }
 
 func ValidatedWorkflowSpec(tomlString string) (job.Job, error) {

--- a/core/services/workflows/engine_test.go
+++ b/core/services/workflows/engine_test.go
@@ -120,7 +120,7 @@ func TestEngineWithHardcodedWorkflow(t *testing.T) {
 const (
 	simpleWorkflow = `
 triggers:
-  - type: "on_mercury_report"
+  - type: "mercury-trigger"
     config:
       feedlist:
         - "0x1111111111111111111100000000000000000000000000000000000000000000" # ETHUSD
@@ -163,7 +163,7 @@ targets:
 func mockTrigger(t *testing.T) (capabilities.TriggerCapability, capabilities.CapabilityResponse) {
 	mt := &mockTriggerCapability{
 		CapabilityInfo: capabilities.MustNewCapabilityInfo(
-			"on_mercury_report",
+			"mercury-trigger",
 			capabilities.CapabilityTypeTrigger,
 			"issues a trigger when a mercury report is received.",
 			"v1.0.0",
@@ -273,7 +273,7 @@ func TestEngine_ErrorsTheWorkflowIfAStepErrors(t *testing.T) {
 const (
 	multiStepWorkflow = `
 triggers:
-  - type: "on_mercury_report"
+  - type: "mercury-trigger"
     config:
       feedlist:
         - "0x1111111111111111111100000000000000000000000000000000000000000000" # ETHUSD

--- a/core/services/workflows/models.go
+++ b/core/services/workflows/models.go
@@ -47,6 +47,7 @@ func (w *workflowSpec) steps() []stepDefinition {
 // treated differently due to their nature of being the starting
 // point of a workflow.
 type workflow struct {
+	id string
 	graph.Graph[string, *step]
 
 	triggers []*triggerCapability

--- a/core/services/workflows/testdata/fixtures/workflows/marshalling/workflow_1.yaml
+++ b/core/services/workflows/testdata/fixtures/workflows/marshalling/workflow_1.yaml
@@ -1,5 +1,5 @@
  triggers:
-   - type: on_mercury_report@1
+   - type: mercury-trigger@1
      ref: report_data
      config:
        boolean_coercion:

--- a/go.mod
+++ b/go.mod
@@ -72,7 +72,7 @@ require (
 	github.com/shopspring/decimal v1.3.1
 	github.com/smartcontractkit/chain-selectors v1.0.10
 	github.com/smartcontractkit/chainlink-automation v1.0.2
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405173118-f5bf144ec6b3
 	github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8
 	github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540
 	github.com/smartcontractkit/chainlink-feeds v0.0.0-20240119021347-3c541a78cdb8

--- a/go.sum
+++ b/go.sum
@@ -1182,8 +1182,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2SBz6fnSKiSW7XZ8IZQLpnI=
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25 h1:fY2wMtlr/VQxPyVVQdi1jFvQHi0VbDnGGVXzLKOZTOY=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405173118-f5bf144ec6b3 h1:LCVHf/ooB4HDkgfLUq+jK4CuCr6SsdNCQZt3/etJ8ms=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405173118-f5bf144ec6b3/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8/go.mod h1:a65NtrK4xZb01mf0dDNghPkN2wXgcqFQ55ADthVBgMc=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/segmentio/ksuid v1.0.4
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.2
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405173118-f5bf144ec6b3
 	github.com/smartcontractkit/chainlink-testing-framework v1.28.1
 	github.com/smartcontractkit/chainlink-vrf v0.0.0-20231120191722-fef03814f868
 	github.com/smartcontractkit/chainlink/v2 v2.0.0-00010101000000-000000000000

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1521,8 +1521,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2SBz6fnSKiSW7XZ8IZQLpnI=
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25 h1:fY2wMtlr/VQxPyVVQdi1jFvQHi0VbDnGGVXzLKOZTOY=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405173118-f5bf144ec6b3 h1:LCVHf/ooB4HDkgfLUq+jK4CuCr6SsdNCQZt3/etJ8ms=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405173118-f5bf144ec6b3/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8/go.mod h1:a65NtrK4xZb01mf0dDNghPkN2wXgcqFQ55ADthVBgMc=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=

--- a/integration-tests/load/go.mod
+++ b/integration-tests/load/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/rs/zerolog v1.30.0
 	github.com/slack-go/slack v0.12.2
 	github.com/smartcontractkit/chainlink-automation v1.0.2
-	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25
+	github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405173118-f5bf144ec6b3
 	github.com/smartcontractkit/chainlink-testing-framework v1.28.1
 	github.com/smartcontractkit/chainlink/integration-tests v0.0.0-20240214231432-4ad5eb95178c
 	github.com/smartcontractkit/chainlink/v2 v2.9.0-beta0.0.20240216210048-da02459ddad8

--- a/integration-tests/load/go.sum
+++ b/integration-tests/load/go.sum
@@ -1504,8 +1504,8 @@ github.com/smartcontractkit/chain-selectors v1.0.10 h1:t9kJeE6B6G+hKD0GYR4kGJSCq
 github.com/smartcontractkit/chain-selectors v1.0.10/go.mod h1:d4Hi+E1zqjy9HqMkjBE5q1vcG9VGgxf5VxiRHfzi2kE=
 github.com/smartcontractkit/chainlink-automation v1.0.2 h1:xsfyuswL15q2YBGQT3qn2SBz6fnSKiSW7XZ8IZQLpnI=
 github.com/smartcontractkit/chainlink-automation v1.0.2/go.mod h1:RjboV0Qd7YP+To+OrzHGXaxUxoSONveCoAK2TQ1INLU=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25 h1:fY2wMtlr/VQxPyVVQdi1jFvQHi0VbDnGGVXzLKOZTOY=
-github.com/smartcontractkit/chainlink-common v0.1.7-0.20240404141006-77085a02ce25/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405173118-f5bf144ec6b3 h1:LCVHf/ooB4HDkgfLUq+jK4CuCr6SsdNCQZt3/etJ8ms=
+github.com/smartcontractkit/chainlink-common v0.1.7-0.20240405173118-f5bf144ec6b3/go.mod h1:kstYjAGqBswdZpl7YkSPeXBDVwaY1VaR6tUMPWl8ykA=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8 h1:I326nw5GwHQHsLKHwtu5Sb9EBLylC8CfUd7BFAS0jtg=
 github.com/smartcontractkit/chainlink-cosmos v0.4.1-0.20240213120401-01a23955f9f8/go.mod h1:a65NtrK4xZb01mf0dDNghPkN2wXgcqFQ55ADthVBgMc=
 github.com/smartcontractkit/chainlink-data-streams v0.0.0-20240220203239-09be0ea34540 h1:xFSv8561jsLtF6gYZr/zW2z5qUUAkcFkApin2mnbYTo=


### PR DESCRIPTION
* Update to latest of chainlink common; this fixes a panic due to incorrect list element handling in the values library, and moves feedIds to bytes rather than uints.
* Modify hardcoded workflow with the correct feedIds.
* Move all initialization logic of capabilities to `ServicesForSpec` so that we can merge the mercury loop into develop.
* Deterministically generate execution IDs, and move the hardcoded workflow to the delegate.
* Fix bug in cap encoder where it assumed ids where 32 characters (not bytes) long

