### PR TITLE
[KS-136] Correctly handle numbers in YAML

### DIFF
--- a/core/services/workflows/delegate.go
+++ b/core/services/workflows/delegate.go
@@ -35,13 +35,13 @@ consensus:
       aggregation_config:
         "0x1111111111111111111100000000000000000000000000000000000000000000":
           deviation: "0.001"
-          heartbeat: "30m"
+          heartbeat: 3600
         "0x2222222222222222222200000000000000000000000000000000000000000000":
           deviation: "0.001"
-          heartbeat: "30m"
+          heartbeat: 3600
         "0x3333333333333333333300000000000000000000000000000000000000000000":
           deviation: "0.001"
-          heartbeat: "30m"
+          heartbeat: 3600
       encoder: "EVM"
       encoder_config:
         abi: "mercury_reports bytes[]"

--- a/core/services/workflows/state.go
+++ b/core/services/workflows/state.go
@@ -216,6 +216,20 @@ func deepMap(input any, transform func(el string) (any, error)) (any, error) {
 		}
 
 		return nv, nil
+	case mapping:
+		// coerce mapping to map[string]any
+		mp := map[string]any(tv)
+
+		nm := map[string]any{}
+		for k, v := range mp {
+			nv, err := deepMap(v, transform)
+			if err != nil {
+				return nil, err
+			}
+
+			nm[k] = nv
+		}
+		return nm, nil
 	case map[string]any:
 		nm := map[string]any{}
 		for k, v := range tv {

--- a/core/services/workflows/testdata/fixtures/workflows/workflow_schema.json
+++ b/core/services/workflows/testdata/fixtures/workflows/workflow_schema.json
@@ -3,6 +3,9 @@
   "$id": "https://github.com/smartcontractkit/chainlink/v2/core/services/workflows/workflow-spec-yaml",
   "$ref": "#/$defs/workflowSpecYaml",
   "$defs": {
+    "mapping": {
+      "type": "object"
+    },
     "stepDefinitionType": {
       "oneOf": [
         {
@@ -48,10 +51,10 @@
           "pattern": "^[a-z0-9_]+$"
         },
         "inputs": {
-          "type": "object"
+          "$ref": "#/$defs/mapping"
         },
         "config": {
-          "type": "object"
+          "$ref": "#/$defs/mapping"
         }
       },
       "additionalProperties": false,


### PR DESCRIPTION
* The YAML parsing library we're using will by default interpret all numbers as floats, rather than interpreting some as ints and others as floats depending on the context.
* To work around this, we implement custom unmarshalling of the config/inputs maps and parse them as json.Numbers. We'll then try to further convert that to a decimal (if the number is a float), or as an int (if it isn't).