### PR TITLE
[fix] Install jq when building plugins image

### DIFF
--- a/plugins/chainlink.Dockerfile
+++ b/plugins/chainlink.Dockerfile
@@ -14,6 +14,8 @@ ARG COMMIT_SHA
 
 COPY . .
 
+RUN apt-get update && apt-get install -y jq
+
 # Build the golang binaries
 RUN make install-chainlink
 


### PR DESCRIPTION
The VERSION file has been replaced with the .version key in the root package json. The version is also now sourced using jq, but jq isn't being installed by the plugins Dockerfile, and so the version is showing up as empty and the core node is panicking on boot.

This adds jq so that the version is correctly set.