### PR TITLE
Validate user email before asking for a password.

### DIFF
--- a/.changeset/silver-otters-play.md
+++ b/.changeset/silver-otters-play.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Validate user email before asking for a password in the chainlink CLI.

--- a/core/cmd/admin_commands.go
+++ b/core/cmd/admin_commands.go
@@ -19,6 +19,7 @@ import (
 
 	cutils "github.com/smartcontractkit/chainlink-common/pkg/utils"
 
+	"github.com/smartcontractkit/chainlink/v2/core/sessions"
 	"github.com/smartcontractkit/chainlink/v2/core/utils"
 	"github.com/smartcontractkit/chainlink/v2/core/web/presenters"
 )
@@ -195,6 +196,11 @@ func (s *Shell) ListUsers(_ *cli.Context) (err error) {
 
 // CreateUser creates a new user by prompting for email, password, and role
 func (s *Shell) CreateUser(c *cli.Context) (err error) {
+	// Check user's email validity. Note that it will also be later checked on the server side in the NewUser function.
+	if err = sessions.ValidateEmail(c.String("email")); err != nil {
+		return err
+	}
+
 	resp, err := s.HTTP.Get(s.ctx(), "/v2/users/", nil)
 	if err != nil {
 		return s.errorOut(err)

--- a/core/cmd/admin_commands_test.go
+++ b/core/cmd/admin_commands_test.go
@@ -33,8 +33,8 @@ func TestShell_CreateUser(t *testing.T) {
 		role  string
 		err   string
 	}{
-		{"Invalid request", "//", "", "parseResponse error"},
-		{"No params", "", "", "Invalid role"},
+		{"Invalid email", "//", "", "mail: missing '@' or angle-addr"},
+		{"No params", "", "", "Must enter an email"},
 		{"No email", "", "view", "Must enter an email"},
 		{"User exists", cltest.APIEmailAdmin, "admin", fmt.Sprintf(`user with email %s already exists`, cltest.APIEmailAdmin)},
 		{"Valid params", cltest.MustRandomUser(t).Email, "view", ""},


### PR DESCRIPTION
Implementing the following feature request https://smartcontract-it.atlassian.net/browse/BCF-1831.

Note that there is no need to explicitly test for the incorrect email since the verification function ParseAddress in net/mail/message.go (https://pkg.go.dev/net/mail#ParseAddress) is already thoroughly tested.