### PR TITLE
core: move logger fix from cmd/shell to chains/evm/types

### DIFF
--- a/core/chains/evm/types/types.go
+++ b/core/chains/evm/types/types.go
@@ -3,7 +3,9 @@ package types
 import (
 	"database/sql/driver"
 	"encoding/json"
+	"log/slog"
 	"math/big"
+	"os"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -17,6 +19,12 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils"
 	ubig "github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils/big"
 )
+
+func init() {
+	// This is a hack to undo geth's disruption of the std default logger.
+	// To be removed after upgrading geth to v1.13.10.
+	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, nil)))
+}
 
 type Configs interface {
 	Chains(ids ...string) ([]types.ChainStatus, int, error)

--- a/core/cmd/shell.go
+++ b/core/cmd/shell.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -56,12 +55,6 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/web"
 	"github.com/smartcontractkit/chainlink/v2/plugins"
 )
-
-func init() {
-	// hack to undo geth's disruption of the std default logger
-	// remove with geth v1.13.10
-	slog.SetDefault(slog.New(slog.NewTextHandler(os.Stderr, nil)))
-}
 
 var (
 	initGlobalsOnce sync.Once


### PR DESCRIPTION
Having this fix located in `cmd/shell` prevents it from being run when we invoke things like `make config-docs`. Moving to the `chains/evm/types` package will ensure it is run for more things that use geth.