### PR TITLE
update cicd-changeset conditional trigger

### DIFF
--- a/.github/workflows/cicd-changesets.yml
+++ b/.github/workflows/cicd-changesets.yml
@@ -17,7 +17,19 @@ jobs:
       id-token: write
       contents: read
     steps:
+      - name: Checkout repository
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: changeset-added
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          filters: |
+            core-changeset:
+              - added: '.changeset/**'
+
       - name: cicd-changesets
+        if: steps.changeset-added.outputs.core-changeset == 'true'
         uses: smartcontractkit/.github/actions/cicd-changesets@6da79c7b9f14bec077df2c1ad40d53823b409d9c # cicd-changesets@0.3.3
         with:
           # general inputs


### PR DESCRIPTION
This updates the `cicd-changesets` workflow to only run when there is a new changeset file being added and pushed to `develop` branch.

This should reduce the number of runs of this workflow.
