### PR TITLE
core/services/ocr2/plugins/ocr2keeper/evmregister/v21/upkeepstate: use sqlutil instead of pg.QOpts

### DIFF
--- a/.changeset/poor-socks-travel.md
+++ b/.changeset/poor-socks-travel.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+core/services/ocr2/plugins/ocr2keeper/evmregister/v21/upkeepstate: use sqlutil instead of pg.QOpts #internal


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCF-2978