### PR TITLE
Improving chainlink.Dockerfile image size

### DIFF
--- a/core/chainlink.Dockerfile
+++ b/core/chainlink.Dockerfile
@@ -1,32 +1,25 @@
 # Build image: Chainlink binary
-FROM golang:1.21-bullseye as buildgo
-RUN go version
+FROM golang:1.21.9-alpine as buildgo
+
 WORKDIR /chainlink
-
-COPY GNUmakefile package.json ./
+COPY GNUmakefile package.json go.mod go.sum ./
 COPY tools/bin/ldflags ./tools/bin/
-
-ADD go.mod go.sum ./
 RUN go mod download
 
-# Env vars needed for chainlink build
+# Install make, jq, and clear apk cache in the same layer
 ARG COMMIT_SHA
-
 COPY . .
+RUN apk update && \
+    apk add --no-cache git curl make jq bash && \
+    rm -rf /var/cache/apk/*
 
-RUN apt-get update && apt-get install -y jq
+# Build the golang binary and plugins
+RUN make install-chainlink && \
+    go list -m -f "{{.Dir}}" github.com/smartcontractkit/chainlink-feeds | xargs -I % ln -s % /chainlink-feeds && \
+    go list -m -f "{{.Dir}}" github.com/smartcontractkit/chainlink-solana | xargs -I % ln -s % /chainlink-solana
 
-# Build the golang binary
-RUN make install-chainlink
-
-# Link LOOP Plugin source dirs with simple names
-RUN go list -m -f "{{.Dir}}" github.com/smartcontractkit/chainlink-feeds | xargs -I % ln -s % /chainlink-feeds
-RUN go list -m -f "{{.Dir}}" github.com/smartcontractkit/chainlink-solana | xargs -I % ln -s % /chainlink-solana
-
-# Build image: Plugins
-FROM golang:1.21-bullseye as buildplugins
-RUN go version
-
+# Build plugins
+FROM golang:1.21.9-alpine as buildplugins
 WORKDIR /chainlink-feeds
 COPY --from=buildgo /chainlink-feeds .
 RUN go install ./cmd/chainlink-feeds
@@ -35,42 +28,29 @@ WORKDIR /chainlink-solana
 COPY --from=buildgo /chainlink-solana .
 RUN go install ./pkg/solana/cmd/chainlink-solana
 
-# Final image: ubuntu with chainlink binary
-FROM ubuntu:20.04
+# Use a smaller, more secure final base image
+FROM alpine:latest
 
 ARG CHAINLINK_USER=root
-ENV DEBIAN_FRONTEND noninteractive
-RUN apt-get update && apt-get install -y ca-certificates gnupg lsb-release curl
 
-# Install Postgres for CLI tools, needed specifically for DB backups
-RUN curl https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add - \
-  && echo "deb http://apt.postgresql.org/pub/repos/apt/ `lsb_release -cs`-pgdg main" |tee /etc/apt/sources.list.d/pgdg.list \
-  && apt-get update && apt-get install -y postgresql-client-15 \
-  && apt-get clean all \
-  && rm -rf /var/lib/apt/lists/*
+RUN apk update && \
+    apk add --no-cache ca-certificates curl postgresql-client && \
+    rm -rf /var/cache/apk/* && \
+    if [ "${CHAINLINK_USER}" != "root" ]; then adduser -D -u 14933 ${CHAINLINK_USER}; fi
 
+# Copy binaries from build stage
 COPY --from=buildgo /go/bin/chainlink /usr/local/bin/
-
-# Install (but don't enable) LOOP Plugins
 COPY --from=buildplugins /go/bin/chainlink-feeds /usr/local/bin/
 COPY --from=buildplugins /go/bin/chainlink-solana /usr/local/bin/
-
-# Dependency of CosmWasm/wasmd
 COPY --from=buildgo /go/pkg/mod/github.com/\!cosm\!wasm/wasmvm@v*/internal/api/libwasmvm.*.so /usr/lib/
 RUN chmod 755 /usr/lib/libwasmvm.*.so
 
-RUN if [ ${CHAINLINK_USER} != root ]; then \
-  useradd --uid 14933 --create-home ${CHAINLINK_USER}; \
-  fi
 USER ${CHAINLINK_USER}
 WORKDIR /home/${CHAINLINK_USER}
-# explicit set the cache dir. needed so both root and non-root user has an explicit location
 ENV XDG_CACHE_HOME /home/${CHAINLINK_USER}/.cache
 RUN mkdir -p ${XDG_CACHE_HOME}
 
 EXPOSE 6688
 ENTRYPOINT ["chainlink"]
-
 HEALTHCHECK CMD curl -f http://localhost:6688/health || exit 1
-
 CMD ["local", "node"]


### PR DESCRIPTION
This PR updates the _chainlink.Dockerfile_ uses an alpine base image due to its significantly smaller size. Additionally, it consolidates installation commands and cleanup steps into fewer layers, minimizing the bloat caused by intermediate layers.

As demonstrated, the original Docker image size was 419MB. With these changes, the new image size is approximately 234MB, achieving a reduction of about ~180MB.

```
docker images
REPOSITORY                                    TAG           IMAGE ID       CREATED          SIZE
chainlink-develop-alpine                      latest        525dd81f8870   22 minutes ago   234MB
chainlink-develop                             latest        e33c6cd2c43d   28 minutes ago   419MB
```

Having a smaller docker image helps developers to efficient bandwidth usage as well as faster deployment. Everything seems to be working smoothly:

<img width="1508" alt="Screenshot 2024-04-15 at 13 57 34" src="https://github.com/smartcontractkit/chainlink/assets/16880741/afae7eca-7d03-4fa2-b4e6-58bd9a33a7f2">
