### PR TITLE
Enhancing developer onboarding by resolving compiler compatibility issues in Chainlink node creation

### DIFF
--- a/contracts/src/v0.8/operatorforwarder/dev/AuthorizedReceiver.sol
+++ b/contracts/src/v0.8/operatorforwarder/dev/AuthorizedReceiver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity ^0.8.19;
 
 import {AuthorizedReceiverInterface} from "./interfaces/AuthorizedReceiverInterface.sol";
 

--- a/contracts/src/v0.8/operatorforwarder/dev/LinkTokenReceiver.sol
+++ b/contracts/src/v0.8/operatorforwarder/dev/LinkTokenReceiver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity ^0.8.19;
 
 // solhint-disable custom-errors
 abstract contract LinkTokenReceiver {

--- a/contracts/src/v0.8/operatorforwarder/dev/Operator.sol
+++ b/contracts/src/v0.8/operatorforwarder/dev/Operator.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.19;
+pragma solidity ^0.8.19;
 
 import {AuthorizedReceiver} from "./AuthorizedReceiver.sol";
 import {LinkTokenReceiver} from "./LinkTokenReceiver.sol";
@@ -281,12 +281,24 @@ contract Operator is AuthorizedReceiver, ConfirmedOwner, LinkTokenReceiver, Oper
     return _fundsAvailable();
   }
 
+  // @notice Checks if a given address is a contract
+  // @dev Uses EVM assembly to get the code size at the provided address, which helps determine if it is a contract
+  // @param addr The address to check
+  // @return true if the address is a contract, false otherwise
+  function isContract(address addr) internal view returns (bool) {
+      uint size;
+      assembly {
+          size := extcodesize(addr)
+      }
+      return size > 0;
+  }
+
   // @notice Forward a call to another contract
   // @dev Only callable by the owner
   // @param to address
   // @param data to forward
   function ownerForward(address to, bytes calldata data) external onlyOwner validateNotToLINK(to) {
-    require(to.isContract(), "Must forward to a contract");
+    require(isContract(to), "Must forward to a contract");
     // solhint-disable-next-line avoid-low-level-calls
     (bool status, ) = to.call(data);
     require(status, "Forwarded call failed");


### PR DESCRIPTION
The primary goal of this pull request is to streamline and simplify the process of onboarding developers for creating Chainlink, ensuring it is as smooth and pain-free as possible.

I encountered numerous errors while following the [official guide on creating a Chainlink node](https://docs.chain.link/chainlink-nodes/v1/fulfilling-requests#deploy-your-own-operator-contract).

By default, Remix is set to use the 0.8.25 compiler version, though adjustments can be made. However, considering that OpenZeppelin's contracts use version 0.8.20, as seen in their [Address.sol](https://github.com/OpenZeppelin/openzeppelin-contracts/blob/11dc5e3809ebe07d5405fe524385cbe4f890a08b/contracts/utils/Address.sol#L4), I had to modify the versions to ensure compatibility with the compiler as most of them were set to version 0.8.19.

After making these adjustments, I was able to compile the _Operator.sol_ component smoothly without encountering any errors.