### PR TITLE
Remove unnecessary example entry from workflow DB migration

### DIFF
--- a/.changeset/ten-clouds-collect.md
+++ b/.changeset/ten-clouds-collect.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+#internal

--- a/core/store/migrate/migrations/0232_add_workflow_spec.sql
+++ b/core/store/migrate/migrations/0232_add_workflow_spec.sql
@@ -9,64 +9,9 @@ CREATE TABLE workflow_specs (
     updated_at      timestamp with time zone NOT NULL
 );
 
-INSERT INTO workflow_specs (workflow_id, workflow, workflow_owner, created_at, updated_at)
-    VALUES (
-	'15c631d295ef5e32deb99a10ee6804bc4af1385568f9b3363f6552ac6dbb2cef',
-	'triggers:
-  - type: "mercury-trigger"
-    config:
-      feedIds:
-        - "0x1111111111111111111100000000000000000000000000000000000000000000"
-        - "0x2222222222222222222200000000000000000000000000000000000000000000"
-        - "0x3333333333333333333300000000000000000000000000000000000000000000"
-
-consensus:
-  - type: "offchain_reporting"
-    ref: "evm_median"
-    inputs:
-      observations:
-        - "$(trigger.outputs)"
-    config:
-      aggregation_method: "data_feeds_2_0"
-      aggregation_config:
-        "0x1111111111111111111100000000000000000000000000000000000000000000":
-          deviation: "0.001"
-          heartbeat: 3600
-        "0x2222222222222222222200000000000000000000000000000000000000000000":
-          deviation: "0.001"
-          heartbeat: 3600
-        "0x3333333333333333333300000000000000000000000000000000000000000000":
-          deviation: "0.001"
-          heartbeat: 3600
-      encoder: "EVM"
-      encoder_config:
-        abi: "mercury_reports bytes[]"
-
-targets:
-  - type: "write_polygon-testnet-mumbai"
-    inputs:
-      report: "$(evm_median.outputs.report)"
-    config:
-      address: "0x3F3554832c636721F1fD1822Ccca0354576741Ef"
-      params: ["$(report)"]
-      abi: "receive(report bytes)"
-  - type: "write_ethereum-testnet-sepolia"
-    inputs:
-      report: "$(evm_median.outputs.report)"
-    config:
-      address: "0x54e220867af6683aE6DcBF535B4f952cB5116510"
-      params: ["$(report)"]
-      abi: "receive(report bytes)"',
-        '00000000000000000000000000000000000000aa',
-	NOW(),
-	NOW()
-    );
-
 ALTER TABLE jobs
     ADD COLUMN workflow_spec_id INT REFERENCES workflow_specs (id),
     DROP CONSTRAINT chk_specs;
-
-UPDATE jobs SET workflow_spec_id = (select id from workflow_specs limit 1) where type = 'workflow';
 
 ALTER TABLE jobs
     ADD CONSTRAINT chk_specs CHECK (


### PR DESCRIPTION
We don't want to add sample entries to all nodes everywhere.

Whichever nodes were already affected by this (e.g. staging) will have an extra entry, which could be removed together with the job spec.