### PR TITLE
Make helm chart features optional: node, db, geth

### DIFF
--- a/charts/chainlink-cluster/templates/chainlink-cm.yaml
+++ b/charts/chainlink-cluster/templates/chainlink-cm.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.chainlink.enabled }}
 {{- range $cfg := .Values.chainlink.nodes }}
 apiVersion: v1
 kind: ConfigMap
@@ -68,4 +69,5 @@ data:
   {{ else }}
   {{ end }}
 ---
+{{- end }}
 {{- end }}

--- a/charts/chainlink-cluster/templates/chainlink-db-deployment.yaml
+++ b/charts/chainlink-cluster/templates/chainlink-db-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.db.enabled }}
 {{- range $cfg := .Values.chainlink.nodes }}
 apiVersion: apps/v1
 {{ if $.Values.db.stateful }}
@@ -149,4 +150,5 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/charts/chainlink-cluster/templates/chainlink-db-networkpolicy.yaml
+++ b/charts/chainlink-cluster/templates/chainlink-db-networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicies.enabled }}
+{{- if and .Values.db.enabled .Values.networkPolicies.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/chainlink-cluster/templates/chainlink-db-service.yaml
+++ b/charts/chainlink-cluster/templates/chainlink-db-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.db.enabled }}
 {{- range $cfg := .Values.chainlink.nodes }}
 apiVersion: v1
 kind: Service
@@ -13,4 +14,5 @@ spec:
       port: 5432
       targetPort: 5432
 ---
+{{- end }}
 {{- end }}

--- a/charts/chainlink-cluster/templates/chainlink-node-deployment.yaml
+++ b/charts/chainlink-cluster/templates/chainlink-node-deployment.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.chainlink.enabled }}
 {{- range $index, $cfg := .Values.chainlink.nodes }}
 apiVersion: apps/v1
 kind: Deployment
@@ -125,4 +126,5 @@ spec:
 {{ toYaml . | indent 8 }}
 {{- end }}
 ---
+{{- end }}
 {{- end }}

--- a/charts/chainlink-cluster/templates/chainlink-node-networkpolicy.yaml
+++ b/charts/chainlink-cluster/templates/chainlink-node-networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicies.enabled }}
+{{- if and .Values.chainlink.enabled .Values.networkPolicies.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/chainlink-cluster/templates/chainlink-node-service.yaml
+++ b/charts/chainlink-cluster/templates/chainlink-node-service.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.chainlink.enabled }}
 {{- range $cfg := .Values.chainlink.nodes }}
 apiVersion: v1
 kind: Service
@@ -15,4 +16,5 @@ spec:
     instance: {{ $cfg.name }}
   type: ClusterIP
 ---
+{{- end }}
 {{- end }}

--- a/charts/chainlink-cluster/templates/chainlink-pod-monitor.yaml
+++ b/charts/chainlink-cluster/templates/chainlink-pod-monitor.yaml
@@ -1,4 +1,4 @@
-{{- if $.Values.prometheusMonitor }}
+{{- if and .Values.chainlink.enabled .Values.prometheusMonitor }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:

--- a/charts/chainlink-cluster/templates/chainlink-secret.yaml
+++ b/charts/chainlink-cluster/templates/chainlink-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.chainlink.enabled }}
 {{- range $cfg := .Values.chainlink.nodes }}
 apiVersion: v1
 kind: Secret
@@ -9,4 +10,5 @@ data:
   apicredentials: bm90cmVhbEBmYWtlZW1haWwuY2hudHdvY2hhaW5zCg==
   node-password: VC50TEhrY213ZVBUL3AsXXNZdW50andIS0FzcmhtIzRlUnM0THVLSHd2SGVqV1lBQzJKUDRNOEhpbXdnbWJhWgo=
 ---
+{{- end }}
 {{- end }}

--- a/charts/chainlink-cluster/templates/geth-config-map.yaml
+++ b/charts/chainlink-cluster/templates/geth-config-map.yaml
@@ -1,4 +1,4 @@
-{{ if (hasKey .Values "geth") }}
+{{ if and (hasKey .Values "geth") .Values.geth.enabled }}
 {{- range $cfg := .Values.geth.chains }}
 apiVersion: v1
 kind: ConfigMap
@@ -152,4 +152,4 @@ data:
     }
 ---
 {{- end }}
-{{ end }}
+{{- end }}

--- a/charts/chainlink-cluster/templates/geth-deployment.yaml
+++ b/charts/chainlink-cluster/templates/geth-deployment.yaml
@@ -1,4 +1,4 @@
-{{ if (hasKey .Values "geth") }}
+{{ if and (hasKey .Values "geth") .Values.geth.enabled }}
 {{- range $cfg := .Values.geth.chains }}
 apiVersion: apps/v1
 kind: Deployment
@@ -127,4 +127,4 @@ spec:
 {{- end }}
 ---
 {{- end }}
-{{ end }}
+{{- end }}

--- a/charts/chainlink-cluster/templates/geth-networkpolicy.yaml
+++ b/charts/chainlink-cluster/templates/geth-networkpolicy.yaml
@@ -1,3 +1,4 @@
+{{ if and (hasKey .Values "geth") .Values.geth.enabled }}
 {{- if .Values.networkPolicies.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
@@ -20,4 +21,5 @@ spec:
           port: 8544
         - protocol: TCP
           port: 8546
+{{- end }}
 {{- end }}

--- a/charts/chainlink-cluster/templates/geth-service.yaml
+++ b/charts/chainlink-cluster/templates/geth-service.yaml
@@ -1,4 +1,4 @@
-{{ if (hasKey .Values "geth") }}
+{{ if and (hasKey .Values "geth") .Values.geth.enabled }}
 {{- range $cfg := .Values.geth.chains }}
 apiVersion: v1
 kind: Service
@@ -18,4 +18,4 @@ spec:
   type: ClusterIP
 ---
 {{- end }}
-{{ end }}
+{{- end }}

--- a/charts/chainlink-cluster/templates/mockserver-networkpolicy.yaml
+++ b/charts/chainlink-cluster/templates/mockserver-networkpolicy.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicies.enabled }}
+{{- if and .Values.mockserver.enabled .Values.networkPolicies.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/chainlink-cluster/templates/networkpolicy-default.yaml
+++ b/charts/chainlink-cluster/templates/networkpolicy-default.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.networkPolicies.enabled }}
+{{- if and .Values.mockserver.enabled .Values.networkPolicies.enabled }}
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:

--- a/charts/chainlink-cluster/values.yaml
+++ b/charts/chainlink-cluster/values.yaml
@@ -10,6 +10,7 @@
 #   image: ethereum/client-go
 #   version: stable
 chainlink:
+  enabled: true
   podSecurityContext:
     fsGroup: 14933
   securityContext:
@@ -88,6 +89,7 @@ chainlink:
 #
 # if you are running long tests
 db:
+  enabled: true
   podSecurityContext:
     fsGroup: 999
   securityContext:
@@ -109,6 +111,7 @@ db:
       memory: 1024Mi
 # default cluster shipped with latest Geth ( dev mode by default )
 geth:
+  enabled: true
   podSecurityContext:
     fsGroup: 999
   securityContext:


### PR DESCRIPTION
Allows `helm template` to optionally disable certain features:
```sh
... --set chainlink.enabled=false --set db.enabled=false --set geth.enabled=false ...
```