### PR TITLE
core/web: avoid gin context race

### DIFF
--- a/core/web/user_controller.go
+++ b/core/web/user_controller.go
@@ -33,22 +33,24 @@ type UpdatePasswordRequest struct {
 var errUnsupportedForAuth = errors.New("action is unsupported with configured authentication provider")
 
 // Index lists all API users
-func (u *UserController) Index(ctx *gin.Context) {
+func (u *UserController) Index(c *gin.Context) {
+	ctx := c.Request.Context()
 	users, err := u.App.AuthenticationProvider().ListUsers(ctx)
 	if err != nil {
 		if errors.Is(err, clsession.ErrNotSupported) {
-			jsonAPIError(ctx, http.StatusBadRequest, errUnsupportedForAuth)
+			jsonAPIError(c, http.StatusBadRequest, errUnsupportedForAuth)
 			return
 		}
 		u.App.GetLogger().Errorf("Unable to list users", "err", err)
-		jsonAPIError(ctx, http.StatusInternalServerError, err)
+		jsonAPIError(c, http.StatusInternalServerError, err)
 		return
 	}
-	jsonAPIResponse(ctx, presenters.NewUserResources(users), "users")
+	jsonAPIResponse(c, presenters.NewUserResources(users), "users")
 }
 
 // Create creates a new API user with provided context arguments.
-func (u *UserController) Create(ctx *gin.Context) {
+func (u *UserController) Create(c *gin.Context) {
+	ctx := c.Request.Context()
 	type newUserRequest struct {
 		Email    string `json:"email"`
 		Password string `json:"password"`
@@ -56,30 +58,30 @@ func (u *UserController) Create(ctx *gin.Context) {
 	}
 
 	var request newUserRequest
-	if err := ctx.ShouldBindJSON(&request); err != nil {
-		jsonAPIError(ctx, http.StatusUnprocessableEntity, err)
+	if err := c.ShouldBindJSON(&request); err != nil {
+		jsonAPIError(c, http.StatusUnprocessableEntity, err)
 		return
 	}
 
 	userRole, err := clsession.GetUserRole(request.Role)
 	if err != nil {
-		jsonAPIError(ctx, http.StatusBadRequest, err)
+		jsonAPIError(c, http.StatusBadRequest, err)
 		return
 	}
 
 	if verr := clsession.ValidateEmail(request.Email); verr != nil {
-		jsonAPIError(ctx, http.StatusBadRequest, verr)
+		jsonAPIError(c, http.StatusBadRequest, verr)
 		return
 	}
 
 	if verr := utils.VerifyPasswordComplexity(request.Password, request.Email); verr != nil {
-		jsonAPIError(ctx, http.StatusBadRequest, verr)
+		jsonAPIError(c, http.StatusBadRequest, verr)
 		return
 	}
 
 	user, err := clsession.NewUser(request.Email, request.Password, userRole)
 	if err != nil {
-		jsonAPIError(ctx, http.StatusBadRequest, errors.Errorf("error creating API user: %s", err))
+		jsonAPIError(c, http.StatusBadRequest, errors.Errorf("error creating API user: %s", err))
 		return
 	}
 	if err = u.App.AuthenticationProvider().CreateUser(ctx, &user); err != nil {
@@ -87,111 +89,113 @@ func (u *UserController) Create(ctx *gin.Context) {
 		var pgErr *pgconn.PgError
 		if ok := errors.As(err, &pgErr); ok {
 			if pgErr.Code == "23505" {
-				jsonAPIError(ctx, http.StatusBadRequest, errors.Errorf("user with email %s already exists", request.Email))
+				jsonAPIError(c, http.StatusBadRequest, errors.Errorf("user with email %s already exists", request.Email))
 				return
 			}
 		}
 		if errors.Is(err, clsession.ErrNotSupported) {
-			jsonAPIError(ctx, http.StatusBadRequest, errUnsupportedForAuth)
+			jsonAPIError(c, http.StatusBadRequest, errUnsupportedForAuth)
 			return
 		}
 		u.App.GetLogger().Errorf("Error creating new API user", "err", err)
-		jsonAPIError(ctx, http.StatusInternalServerError, errors.New("error creating API user"))
+		jsonAPIError(c, http.StatusInternalServerError, errors.New("error creating API user"))
 		return
 	}
 
-	jsonAPIResponse(ctx, presenters.NewUserResource(user), "user")
+	jsonAPIResponse(c, presenters.NewUserResource(user), "user")
 }
 
 // UpdateRole changes role field of a specified API user.
-func (u *UserController) UpdateRole(ctx *gin.Context) {
+func (u *UserController) UpdateRole(c *gin.Context) {
+	ctx := c.Request.Context()
 	type updateUserRequest struct {
 		Email   string `json:"email"`
 		NewRole string `json:"newRole"`
 	}
 
 	var request updateUserRequest
-	if err := ctx.ShouldBindJSON(&request); err != nil {
-		jsonAPIError(ctx, http.StatusUnprocessableEntity, err)
+	if err := c.ShouldBindJSON(&request); err != nil {
+		jsonAPIError(c, http.StatusUnprocessableEntity, err)
 		return
 	}
 
 	// Don't allow current admin user to edit self
-	sessionUser, ok := webauth.GetAuthenticatedUser(ctx)
+	sessionUser, ok := webauth.GetAuthenticatedUser(c)
 	if !ok {
-		jsonAPIError(ctx, http.StatusInternalServerError, errors.New("failed to obtain current user from context"))
+		jsonAPIError(c, http.StatusInternalServerError, errors.New("failed to obtain current user from context"))
 		return
 	}
 	if strings.EqualFold(sessionUser.Email, request.Email) {
-		jsonAPIError(ctx, http.StatusBadRequest, errors.New("can not change state or permissions of current admin user"))
+		jsonAPIError(c, http.StatusBadRequest, errors.New("can not change state or permissions of current admin user"))
 		return
 	}
 
 	// In case email/role is not specified try to give friendlier/actionable error messages
 	if request.Email == "" {
-		jsonAPIError(ctx, http.StatusBadRequest, errors.New("email flag is empty, must specify an email"))
+		jsonAPIError(c, http.StatusBadRequest, errors.New("email flag is empty, must specify an email"))
 		return
 	}
 	if request.NewRole == "" {
-		jsonAPIError(ctx, http.StatusBadRequest, errors.New("new-role flag is empty, must specify a new role, possible options are 'admin', 'edit', 'run', 'view'"))
+		jsonAPIError(c, http.StatusBadRequest, errors.New("new-role flag is empty, must specify a new role, possible options are 'admin', 'edit', 'run', 'view'"))
 		return
 	}
 	_, err := clsession.GetUserRole(request.NewRole)
 	if err != nil {
-		jsonAPIError(ctx, http.StatusBadRequest, errors.New("new role does not exist, possible options are 'admin', 'edit', 'run', 'view'"))
+		jsonAPIError(c, http.StatusBadRequest, errors.New("new role does not exist, possible options are 'admin', 'edit', 'run', 'view'"))
 		return
 	}
 
 	user, err := u.App.AuthenticationProvider().UpdateRole(ctx, request.Email, request.NewRole)
 	if err != nil {
 		if errors.Is(err, clsession.ErrNotSupported) {
-			jsonAPIError(ctx, http.StatusBadRequest, errUnsupportedForAuth)
+			jsonAPIError(c, http.StatusBadRequest, errUnsupportedForAuth)
 			return
 		}
-		jsonAPIError(ctx, http.StatusInternalServerError, errors.Wrap(err, "error updating API user"))
+		jsonAPIError(c, http.StatusInternalServerError, errors.Wrap(err, "error updating API user"))
 		return
 	}
 
-	jsonAPIResponse(ctx, presenters.NewUserResource(user), "user")
+	jsonAPIResponse(c, presenters.NewUserResource(user), "user")
 }
 
 // Delete deletes an API user and any sessions by email
-func (u *UserController) Delete(ctx *gin.Context) {
-	email := ctx.Param("email")
+func (u *UserController) Delete(c *gin.Context) {
+	ctx := c.Request.Context()
+	email := c.Param("email")
 
 	// Attempt find user by email
 	user, err := u.App.AuthenticationProvider().FindUser(ctx, email)
 	if err != nil {
 		if errors.Is(err, clsession.ErrNotSupported) {
-			jsonAPIError(ctx, http.StatusBadRequest, errUnsupportedForAuth)
+			jsonAPIError(c, http.StatusBadRequest, errUnsupportedForAuth)
 			return
 		}
-		jsonAPIError(ctx, http.StatusBadRequest, errors.Errorf("specified user not found: %s", email))
+		jsonAPIError(c, http.StatusBadRequest, errors.Errorf("specified user not found: %s", email))
 		return
 	}
 
 	// Don't allow current admin user to delete self
-	sessionUser, ok := webauth.GetAuthenticatedUser(ctx)
+	sessionUser, ok := webauth.GetAuthenticatedUser(c)
 	if !ok {
-		jsonAPIError(ctx, http.StatusInternalServerError, errors.New("failed to obtain current user from context"))
+		jsonAPIError(c, http.StatusInternalServerError, errors.New("failed to obtain current user from context"))
 		return
 	}
 	if strings.EqualFold(sessionUser.Email, email) {
-		jsonAPIError(ctx, http.StatusBadRequest, errors.New("can not delete currently logged in admin user"))
+		jsonAPIError(c, http.StatusBadRequest, errors.New("can not delete currently logged in admin user"))
 		return
 	}
 
 	if err = u.App.AuthenticationProvider().DeleteUser(ctx, email); err != nil {
 		if errors.Is(err, clsession.ErrNotSupported) {
-			jsonAPIError(ctx, http.StatusBadRequest, errUnsupportedForAuth)
+			jsonAPIError(c, http.StatusBadRequest, errUnsupportedForAuth)
 			return
 		}
 		u.App.GetLogger().Errorf("Error deleting API user", "err", err)
-		jsonAPIError(ctx, http.StatusInternalServerError, errors.New("error deleting API user"))
+		jsonAPIError(c, http.StatusInternalServerError, errors.New("error deleting API user"))
 		return
 	}
 
-	jsonAPIResponse(ctx, presenters.NewUserResource(user), "user")
+	jsonAPIResponse(c, presenters.NewUserResource(user), "user")
 }
 
 // UpdatePassword changes the password for the current User.


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/actions/runs/8706777077/job/23880191460
```
==================
WARNING: DATA RACE
Write at 0x00c000e[9](https://github.com/smartcontractkit/chainlink/actions/runs/8706777077/job/23880191460#step:19:10)2320 by goroutine 858:
  go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin.Middleware.func1.1()
      /home/runner/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin@v0.49.0/gintrace.go:69 +0x14e
  runtime.deferreturn()
      /opt/hostedtoolcache/go/1.21.7/x64/src/runtime/panic.go:477 +0x30
  github.com/gin-gonic/gin.(*Context).Next()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0xb89
  github.com/gin-gonic/gin.(*Engine).handleHTTPRequest()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:620 +0x774
  github.com/gin-gonic/gin.(*Engine).ServeHTTP()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:576 +0x424
  net/http.serverHandler.ServeHTTP()
      /opt/hostedtoolcache/go/1.21.7/x64/src/net/http/server.go:2938 +0x2a1
  net/http.(*conn).serve()
      /opt/hostedtoolcache/go/1.21.7/x64/src/net/http/server.go:2009 +0xc24
  net/http.(*Server).Serve.func3()
      /opt/hostedtoolcache/go/1.21.7/x64/src/net/http/server.go:3086 +0x4f

Previous read at 0x00c000e92320 by goroutine 901:
  github.com/gin-gonic/gin.(*Context).hasRequestContext()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:1186 +0xa7
  github.com/gin-gonic/gin.(*Context).Err()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:1208 +0x134
  database/sql.(*Rows).awaitDone()
      /opt/hostedtoolcache/go/1.21.7/x64/src/database/sql/sql.go:2973 +0x2a8
  database/sql.(*Rows).initContextClose.func1()
      /opt/hostedtoolcache/go/1.21.7/x64/src/database/sql/sql.go:2949 +0x8f

Goroutine 858 (running) created at:
  net/http.(*Server).Serve()
      /opt/hostedtoolcache/go/1.21.7/x64/src/net/http/server.go:3086 +0x86c
  net/http/httptest.(*Server).goServe.func1()
      /opt/hostedtoolcache/go/1.21.7/x64/src/net/http/httptest/server.go:3[10](https://github.com/smartcontractkit/chainlink/actions/runs/8706777077/job/23880191460#step:19:11) +0xcf

Goroutine 901 (finished) created at:
  database/sql.(*Rows).initContextClose()
      /opt/hostedtoolcache/go/1.21.7/x64/src/database/sql/sql.go:2949 +0x22f
  database/sql.(*DB).queryDC()
      /opt/hostedtoolcache/go/1.21.7/x64/src/database/sql/sql.go:1762 +0xa24
  database/sql.(*Tx).QueryContext()
      /opt/hostedtoolcache/go/1.21.7/x64/src/database/sql/sql.go:2497 +0x152
  github.com/jmoiron/sqlx.(*Tx).QueryRowxContext()
      /home/runner/go/pkg/mod/github.com/jmoiron/sqlx@v1.3.5/sqlx_context.go:351 +0xbb
  github.com/jmoiron/sqlx.GetContext()
      /home/runner/go/pkg/mod/github.com/jmoiron/sqlx@v1.3.5/sqlx_context.go:82 +0x9d
  github.com/jmoiron/sqlx.(*Tx).GetContext()
      /home/runner/go/pkg/mod/github.com/jmoiron/sqlx@v1.3.5/sqlx_context.go:345 +0xb7
  github.com/smartcontractkit/chainlink/v2/core/sessions/localauth.(*orm).UpdateRole.func1()
      /home/runner/work/chainlink/chainlink/core/sessions/localauth/orm.go:264 +0x162
  github.com/smartcontractkit/chainlink-common/pkg/sqlutil.Transact[go.shape.interface { BindNamed(string, interface {}) (string, []interface {}, error); DriverName() string; ExecContext(context.Context, string, ...interface {}) (database/sql.Result, error); GetContext(context.Context, interface {}, string, ...interface {}) error; NamedExecContext(context.Context, string, interface {}) (database/sql.Result, error); PrepareContext(context.Context, string) (*database/sql.Stmt, error); PrepareNamedContext(context.Context, string) (*github.com/jmoiron/sqlx.NamedStmt, error); QueryContext(context.Context, string, ...interface {}) (*database/sql.Rows, error); QueryRowxContext(context.Context, string, ...interface {}) *github.com/jmoiron/sqlx.Row; QueryxContext(context.Context, string, ...interface {}) (*github.com/jmoiron/sqlx.Rows, error); Rebind(string) string; SelectContext(context.Context, interface {}, string, ...interface {}) error }]()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.1.7-0.20240415164156-8872a8f3[11](https://github.com/smartcontractkit/chainlink/actions/runs/8706777077/job/23880191460#step:19:12)cb/pkg/sqlutil/sqlutil.go:90 +0x28e
  github.com/smartcontractkit/chainlink-common/pkg/sqlutil.TransactDataSource()
      /home/runner/go/pkg/mod/github.com/smartcontractkit/chainlink-common@v0.1.7-0.20240415164156-8872a8f311cb/pkg/sqlutil/sqlutil.go:34 +0x7b
  github.com/smartcontractkit/chainlink/v2/core/sessions/localauth.(*orm).UpdateRole()
      /home/runner/work/chainlink/chainlink/core/sessions/localauth/orm.go:262 +0x308
  github.com/smartcontractkit/chainlink/v2/core/web.(*UserController).UpdateRole()
      /home/runner/work/chainlink/chainlink/core/web/user_controller.go:145 +0x5fb
  github.com/smartcontractkit/chainlink/v2/core/web.(*UserController).UpdateRole-fm()
      <autogenerated>:1 +0x3d
  github.com/smartcontractkit/chainlink/v2/core/web.v2Routes.RequiresAdminRole.func4()
      /home/runner/work/chainlink/chainlink/core/web/auth/auth.go:253 +0x205
  github.com/gin-gonic/gin.(*Context).Next()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x92
  github.com/smartcontractkit/chainlink/v2/core/web.v2Routes.Authenticate.func1()
      /home/runner/work/chainlink/chainlink/core/web/auth/auth.go:173 +0x13d
  github.com/gin-gonic/gin.(*Context).Next()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x92
  github.com/smartcontractkit/chainlink/v2/core/web.NewRouter.Sessions.func5()
      /home/runner/go/pkg/mod/github.com/gin-contrib/sessions@v0.0.5/sessions.go:54 +0x328
  github.com/gin-gonic/gin.(*Context).Next()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x3f5
  github.com/ulule/limiter/v3/drivers/middleware/gin.(*Middleware).Handle()
      /home/runner/go/pkg/mod/github.com/ulule/limiter/v3@v3.11.2/drivers/middleware/gin/middleware.go:64 +0x2a4
  github.com/ulule/limiter/v3/drivers/middleware/gin.NewMiddleware.func1()
      /home/runner/go/pkg/mod/github.com/ulule/limiter/v3@v3.11.2/drivers/middleware/gin/middleware.go:35 +0x34
  github.com/gin-gonic/gin.(*Context).Next()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x183
  github.com/gin-gonic/gin.CustomRecoveryWithWriter.func1()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/recovery.go:102 +0xff
  github.com/gin-gonic/gin.(*Context).Next()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x92
  github.com/smartcontractkit/chainlink/v2/core/web.NewRouter.loggerFunc.func3()
      /home/runner/work/chainlink/chainlink/core/web/router.go:540 +0x2e9
  github.com/gin-gonic/gin.(*Context).Next()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0x92
  github.com/smartcontractkit/chainlink/v2/core/web.NewRouter.RequestSizeLimiter.func2()
      /home/runner/go/pkg/mod/github.com/gin-contrib/size@v0.0.0-202302[12](https://github.com/smartcontractkit/chainlink/actions/runs/8706777077/job/23880191460#step:19:13)012657-e14a14094dc4/size.go:88 +0x1b6
  github.com/gin-gonic/gin.(*Context).Next()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0xbca
  go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin.Middleware.func1()
      /home/runner/go/pkg/mod/go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin@v0.49.0/gintrace.go:95 +0xb29
  github.com/gin-gonic/gin.(*Context).Next()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/context.go:174 +0xb89
  github.com/gin-gonic/gin.(*Engine).handleHTTPRequest()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:620 +0x774
  github.com/gin-gonic/gin.(*Engine).ServeHTTP()
      /home/runner/go/pkg/mod/github.com/gin-gonic/gin@v1.9.1/gin.go:576 +0x424
  net/http.serverHandler.ServeHTTP()
      /opt/hostedtoolcache/go/1.21.7/x64/src/net/http/server.go:2938 +0x2a1
  net/http.(*conn).serve()
      /opt/hostedtoolcache/go/1.21.7/x64/src/net/http/server.go:2009 +0xc24
  net/http.(*Server).Serve.func3()
      /opt/hostedtoolcache/go/1.21.7/x64/src/net/http/server.go:3086 +0x4f
==================
```