### PR TITLE
Add logs to identify when assumptions of log queuing behaviour are violated

### DIFF
--- a/.changeset/heavy-mails-rule.md
+++ b/.changeset/heavy-mails-rule.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Add logs for when the assumptions of how the log buffer will be used are violated #internal

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -119,7 +119,7 @@ func (b *logBuffer) Enqueue(uid *big.Int, logs ...logpoller.Log) (int, int) {
 
 	// clean up enqueued block counts
 	for block := range b.enqueuedBlocks {
-		if block < blockThreshold-reorgBuffer {
+		if block < blockThreshold {
 			delete(b.enqueuedBlocks, block)
 		}
 	}

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -75,7 +75,8 @@ type logBuffer struct {
 	// last block number seen by the buffer
 	lastBlockSeen *atomic.Int64
 	// map of upkeep id to its queue
-	queues         map[string]*upkeepLogQueue
+	queues map[string]*upkeepLogQueue
+	// map for then number of times we have enqueued logs for a block number
 	enqueuedBlocks map[int64]int
 	lock           sync.RWMutex
 }
@@ -109,12 +110,12 @@ func (b *logBuffer) Enqueue(uid *big.Int, logs ...logpoller.Log) (int, int) {
 		b.lggr.Debugw("enqueuing logs from a block older than latest seen block", "logBlock", latestLogBlock, "lastBlockSeen", lastBlockSeen)
 	}
 
-	for block := range uniqueBlocks {
-		if _, ok := b.enqueuedBlocks[block]; ok {
-			b.enqueuedBlocks[block] = b.enqueuedBlocks[block] + 1
-			b.lggr.Debugw("enqueuing logs again for a previously seen block", "block", block, "timesSeen", b.enqueuedBlocks[block])
+	for blockNumber := range uniqueBlocks {
+		if _, ok := b.enqueuedBlocks[blockNumber]; ok {
+			b.enqueuedBlocks[blockNumber] = b.enqueuedBlocks[blockNumber] + 1
+			b.lggr.Debugw("enqueuing logs again for a previously seen block", "blockNumber", blockNumber, "numberOfEnqueues", b.enqueuedBlocks[blockNumber])
 		} else {
-			b.enqueuedBlocks[block] = 1
+			b.enqueuedBlocks[blockNumber] = 1
 		}
 	}
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -117,6 +117,13 @@ func (b *logBuffer) Enqueue(uid *big.Int, logs ...logpoller.Log) (int, int) {
 		blockThreshold = 1
 	}
 
+	// clean up enqueued block counts
+	for block := range b.enqueuedBlocks {
+		if block < blockThreshold-reorgBuffer {
+			delete(b.enqueuedBlocks, block)
+		}
+	}
+
 	return buf.enqueue(blockThreshold, logs...)
 }
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
@@ -70,7 +70,7 @@ func (l *readableLogger) With(args ...interface{}) logger.Logger {
 	return l
 }
 
-func TestLogEventBufferV1_Enqueueviolations(t *testing.T) {
+func TestLogEventBufferV1_EnqueueViolations(t *testing.T) {
 	t.Run("enqueuing logs for a block older than latest seen logs a message", func(t *testing.T) {
 		logReceived := false
 		readableLogger := &readableLogger{

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
@@ -98,8 +98,8 @@ func TestLogEventBufferV1_Enqueueviolations(t *testing.T) {
 			logpoller.Log{BlockNumber: 1, TxHash: common.HexToHash("0x2"), LogIndex: 0},
 		)
 
-		assert.Equal(t, 1, buf.enqueuedBlocks[2])
-		assert.Equal(t, 1, buf.enqueuedBlocks[1])
+		assert.Equal(t, 1, buf.enqueuedBlocks[2]["1"])
+		assert.Equal(t, 1, buf.enqueuedBlocks[1]["2"])
 		assert.True(t, true, logReceived)
 	})
 
@@ -135,9 +135,9 @@ func TestLogEventBufferV1_Enqueueviolations(t *testing.T) {
 			logpoller.Log{BlockNumber: 3, TxHash: common.HexToHash("0x3b"), LogIndex: 0},
 		)
 
-		assert.Equal(t, 1, buf.enqueuedBlocks[2])
-		assert.Equal(t, 1, buf.enqueuedBlocks[1])
-		assert.Equal(t, 2, buf.enqueuedBlocks[3])
+		assert.Equal(t, 1, buf.enqueuedBlocks[2]["2"])
+		assert.Equal(t, 1, buf.enqueuedBlocks[1]["1"])
+		assert.Equal(t, 2, buf.enqueuedBlocks[3]["3"])
 		assert.True(t, true, logReceived)
 	})
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
@@ -1,6 +1,7 @@
 package logprovider
 
 import (
+	"github.com/stretchr/testify/assert"
 	"math/big"
 	"testing"
 
@@ -48,6 +49,96 @@ func TestLogEventBufferV1_SyncFilters(t *testing.T) {
 	require.Equal(t, 2, buf.NumOfUpkeeps())
 	require.NoError(t, buf.SyncFilters(filterStore))
 	require.Equal(t, 1, buf.NumOfUpkeeps())
+}
+
+type readableLogger struct {
+	logger.Logger
+	DebugwFn func(msg string, keysAndValues ...interface{})
+	NamedFn  func(name string) logger.Logger
+	WithFn   func(args ...interface{}) logger.Logger
+}
+
+func (l *readableLogger) Debugw(msg string, keysAndValues ...interface{}) {
+	l.DebugwFn(msg, keysAndValues...)
+}
+
+func (l *readableLogger) Named(name string) logger.Logger {
+	return l
+}
+
+func (l *readableLogger) With(args ...interface{}) logger.Logger {
+	return l
+}
+
+func TestLogEventBufferV1_Enqueueviolations(t *testing.T) {
+	t.Run("enqueuing logs for a block older than latest seen logs a message", func(t *testing.T) {
+		logReceived := false
+		readableLogger := &readableLogger{
+			DebugwFn: func(msg string, keysAndValues ...interface{}) {
+				if msg == "enqueuing logs from a block older than latest seen block" {
+					logReceived = true
+					assert.Equal(t, "logBlock", keysAndValues[0])
+					assert.Equal(t, int64(1), keysAndValues[1])
+					assert.Equal(t, "lastBlockSeen", keysAndValues[2])
+					assert.Equal(t, int64(2), keysAndValues[3])
+				}
+			},
+		}
+
+		logBufferV1 := NewLogBuffer(readableLogger, 10, 20, 1)
+
+		buf := logBufferV1.(*logBuffer)
+
+		buf.Enqueue(big.NewInt(1),
+			logpoller.Log{BlockNumber: 2, TxHash: common.HexToHash("0x1"), LogIndex: 0},
+			logpoller.Log{BlockNumber: 2, TxHash: common.HexToHash("0x1"), LogIndex: 1},
+		)
+		buf.Enqueue(big.NewInt(2),
+			logpoller.Log{BlockNumber: 1, TxHash: common.HexToHash("0x2"), LogIndex: 0},
+		)
+
+		assert.Equal(t, 1, buf.enqueuedBlocks[2])
+		assert.Equal(t, 1, buf.enqueuedBlocks[1])
+		assert.True(t, true, logReceived)
+	})
+
+	t.Run("enqueuing logs for the same block over multiple calls logs a message", func(t *testing.T) {
+		logReceived := false
+		readableLogger := &readableLogger{
+			DebugwFn: func(msg string, keysAndValues ...interface{}) {
+				if msg == "enqueuing logs again for a previously seen block" {
+					logReceived = true
+					assert.Equal(t, "blockNumber", keysAndValues[0])
+					assert.Equal(t, int64(3), keysAndValues[1])
+					assert.Equal(t, "numberOfEnqueues", keysAndValues[2])
+					assert.Equal(t, 2, keysAndValues[3])
+				}
+			},
+		}
+
+		logBufferV1 := NewLogBuffer(readableLogger, 10, 20, 1)
+
+		buf := logBufferV1.(*logBuffer)
+
+		buf.Enqueue(big.NewInt(1),
+			logpoller.Log{BlockNumber: 1, TxHash: common.HexToHash("0x1"), LogIndex: 0},
+			logpoller.Log{BlockNumber: 1, TxHash: common.HexToHash("0x1"), LogIndex: 1},
+		)
+		buf.Enqueue(big.NewInt(2),
+			logpoller.Log{BlockNumber: 2, TxHash: common.HexToHash("0x2"), LogIndex: 0},
+		)
+		buf.Enqueue(big.NewInt(3),
+			logpoller.Log{BlockNumber: 3, TxHash: common.HexToHash("0x3a"), LogIndex: 0},
+		)
+		buf.Enqueue(big.NewInt(3),
+			logpoller.Log{BlockNumber: 3, TxHash: common.HexToHash("0x3b"), LogIndex: 0},
+		)
+
+		assert.Equal(t, 1, buf.enqueuedBlocks[2])
+		assert.Equal(t, 1, buf.enqueuedBlocks[1])
+		assert.Equal(t, 2, buf.enqueuedBlocks[3])
+		assert.True(t, true, logReceived)
+	})
 }
 
 func TestLogEventBufferV1_Dequeue(t *testing.T) {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
@@ -4,9 +4,8 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/stretchr/testify/assert"
-
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
@@ -1,9 +1,10 @@
 package logprovider
 
 import (
-	"github.com/stretchr/testify/assert"
 	"math/big"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/log.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/log.go
@@ -57,8 +57,8 @@ func logID(l logpoller.Log) string {
 	return hex.EncodeToString(ext.LogIdentifier())
 }
 
-// latestBlockNumber returns the latest block number from the given logs
-func latestBlockNumber(logs ...logpoller.Log) (int64, map[int64]bool) {
+// blockStatistics returns the latest block number from the given logs, and a map of unique block numbers
+func blockStatistics(logs ...logpoller.Log) (int64, map[int64]bool) {
 	var latest int64
 	uniqueBlocks := map[int64]bool{}
 
@@ -68,5 +68,6 @@ func latestBlockNumber(logs ...logpoller.Log) (int64, map[int64]bool) {
 		}
 		uniqueBlocks[l.BlockNumber] = true
 	}
+
 	return latest, uniqueBlocks
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/log.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/log.go
@@ -8,7 +8,7 @@ import (
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 )
 
-// LogSorter sorts the logs based on block number, tx hash and log index.
+// LogSorter sorts the logs primarily by block number, then by log index, and finally by tx hash.
 // returns true if b should come before a.
 func LogSorter(a, b logpoller.Log) bool {
 	return LogComparator(a, b) > 0
@@ -58,12 +58,15 @@ func logID(l logpoller.Log) string {
 }
 
 // latestBlockNumber returns the latest block number from the given logs
-func latestBlockNumber(logs ...logpoller.Log) int64 {
+func latestBlockNumber(logs ...logpoller.Log) (int64, map[int64]bool) {
 	var latest int64
+	uniqueBlocks := map[int64]bool{}
+
 	for _, l := range logs {
 		if l.BlockNumber > latest {
 			latest = l.BlockNumber
 		}
+		uniqueBlocks[l.BlockNumber] = true
 	}
-	return latest
+	return latest, uniqueBlocks
 }


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/AUTO-10164

WIth this PR, we're updating some comments within the buffer implementation, to explicitly declare our assumptions on how the buffer will be used. 

Further to this, we're also adding logs to identify scenarios when these assumptions are violated. To achieve this, we use a map to track the number of times we enqueue upkeep logs for a particular block number. 

## Testing

Running the load test, we don't see the logs appear for enqueuing upkeep logs for the same block number more than once. 