### PR TITLE
fix: temporary fix for sonarqube

### DIFF
--- a/.github/workflows/ci-core.yml
+++ b/.github/workflows/ci-core.yml
@@ -302,7 +302,7 @@ jobs:
           echo "sonarqube_tests_report_paths=$(find go_core_tests_logs -name output.txt | paste -sd "," -)" >> $GITHUB_OUTPUT
           echo "sonarqube_coverage_report_paths=$(find go_core_tests_logs -name coverage.txt | paste -sd "," -)" >> $GITHUB_OUTPUT
       - name: SonarQube Scan
-        uses: sonarsource/sonarqube-scan-action@69c1a75940dec6249b86dace6b630d3a2ae9d2a7 # v2.0.1
+        uses: erikburt/sonarqube-scan-action@0e7aeb5c0fde88c2ee645c3224cdbe0f6e678a99 # Temporary Fix - v2.0.1
         with:
           args: >
             -Dsonar.go.tests.reportPaths=${{ steps.sonarqube_report_paths.outputs.sonarqube_tests_report_paths }}


### PR DESCRIPTION
We are now experiencing problems with sonarqube scan due to a faulty push to the docker image hub.

Issue explained here: https://github.com/SonarSource/sonar-scanner-cli-docker/issues/223#issuecomment-2059724480

Essentially, the github  action we rely on points to the 5.0.1 base image. However that tag was erroneously updated 9 months later (docker needs tag immutability!).

I forked the action to my personal account, and pinned the base image to the SHA from a previously successful run.
- My commit: https://github.com/erikburt/sonarqube-scan-action/commit/4a4b51f5482046f45d0fde8827a42c434f2ab94b
- Previous Run showing proper sha: https://github.com/smartcontractkit/chainlink/actions/runs/8364903954/job/22901840642#step:2:23

```
...
  #5 [internal] load build context
  #5 transferring context: 1.50kB done
  #5 DONE 0.0s
  
  #6 [1/5] FROM docker.io/sonarsource/sonar-scanner-cli:5.0.1@sha256:494ecc3b5b1ee1625bd377b3905c4284e4f0cc155cff397805a244dee1c7d575
  #6 resolve docker.io/sonarsource/sonar-scanner-cli:5.0.1@sha256:494ecc3b5b1ee1625bd377b3905c4284e4f0cc155cff397805a244dee1c7d575 done
  #6 extracting sha256:9398808236ffac29e60c04ec906d8d409af7fa19dc57d8c65ad167e9c4967006
  #6 sha256:494ecc3b5b1ee1625bd377b3905c4284e4f0cc155cff397805a244dee1c7d575 1.36kB / 1.36kB done
  #6 sha256:2f384fb1bbd5f033fa0b628efb5ef3d40b9cafaddb68b9ffdd8c3cacdc237199 5.05kB / 5.05kB done
...
```

