### PR TITLE
Dequeue upkeeps using the current dequeue iteration

### DIFF
--- a/.changeset/modern-ghosts-hang.md
+++ b/.changeset/modern-ghosts-hang.md
@@ -1,0 +1,4 @@
+---
+"chainlink": patch
+---
+Iterate over upkeeps using an upkeep selector #changed

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -196,10 +196,12 @@ func (b *logBuffer) dequeue(start, end int64, upkeepLimit, capacity int, upkeepS
 		selectedUpkeeps++
 		logsInRange := q.sizeOfRange(start, end)
 		if logsInRange == 0 {
+			b.lggr.Debugw("skipping dequeue, no logs in range", "upkeepID", q.id.String())
 			// if there are no logs in the range, skip the upkeep
 			continue
 		}
 		if capacity == 0 {
+			b.lggr.Debugw("skipping dequeue, no capacity", "upkeepID", q.id.String())
 			// if there is no more capacity for results, just count the remaining logs
 			remainingLogs += logsInRange
 			continue
@@ -262,14 +264,7 @@ func (b *logBuffer) setUpkeepQueue(uid *big.Int, buf *upkeepLogQueue) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	found := false
-	for _, id := range b.queueIDs {
-		if id == uid.String() {
-			found = true
-			break
-		}
-	}
-	if !found {
+	if _, ok := b.queues[uid.String()]; !ok {
 		b.queueIDs = append(b.queueIDs, uid.String())
 	}
 	b.queues[uid.String()] = buf

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -239,15 +239,19 @@ func (b *logBuffer) SyncFilters(filterStore UpkeepFilterStore) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	for i, upkeepID := range b.queueIDs {
+	var newQueueIDs []string
+	for _, upkeepID := range b.queueIDs {
 		uid := new(big.Int)
 		_, ok := uid.SetString(upkeepID, 10)
 		if ok && !filterStore.Has(uid) {
 			// remove upkeep that is not in the filter store
 			delete(b.queues, upkeepID)
-			b.queueIDs = append(b.queueIDs[:i], b.queueIDs[i+1:]...)
+		} else {
+			newQueueIDs = append(newQueueIDs, upkeepID)
 		}
 	}
+
+	b.queueIDs = newQueueIDs
 
 	return nil
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -26,7 +26,7 @@ type LogBuffer interface {
 	// It also accepts a function to select upkeeps.
 	// Returns logs (associated to upkeeps) and the number of remaining
 	// logs in that window for the involved upkeeps.
-	Dequeue(block int64, blockRate, upkeepLimit, maxResults int, upkeepSelector func(id *big.Int) bool) ([]BufferedLog, int)
+	Dequeue(start, end int64, upkeepLimit, maxResults int, upkeepSelector func(id *big.Int) bool) ([]BufferedLog, int)
 	// SetConfig sets the buffer size and the maximum number of logs to keep for each upkeep.
 	SetConfig(lookback, blockRate, logLimit uint32)
 	// NumOfUpkeeps returns the number of upkeeps that are being tracked by the buffer.
@@ -81,6 +81,7 @@ type logBuffer struct {
 	// map for then number of times we have enqueued logs for a block number
 	enqueuedBlocks    map[int64]map[string]int
 	enqueuedBlockLock sync.RWMutex
+	queueIDs          []string
 }
 
 func NewLogBuffer(lggr logger.Logger, lookback, blockRate, logLimit uint32) LogBuffer {
@@ -89,6 +90,7 @@ func NewLogBuffer(lggr logger.Logger, lookback, blockRate, logLimit uint32) LogB
 		opts:           newLogBufferOptions(lookback, blockRate, logLimit),
 		lastBlockSeen:  new(atomic.Int64),
 		enqueuedBlocks: map[int64]map[string]int{},
+		queueIDs:       []string{},
 		queues:         make(map[string]*upkeepLogQueue),
 	}
 }
@@ -167,11 +169,10 @@ func (b *logBuffer) trackBlockNumbersForUpkeep(uid *big.Int, uniqueBlocks map[in
 
 // Dequeue greedly pulls logs from the buffers.
 // Returns logs and the number of remaining logs in the buffer.
-func (b *logBuffer) Dequeue(block int64, blockRate, upkeepLimit, maxResults int, upkeepSelector func(id *big.Int) bool) ([]BufferedLog, int) {
+func (b *logBuffer) Dequeue(start, end int64, upkeepLimit, maxResults int, upkeepSelector func(id *big.Int) bool) ([]BufferedLog, int) {
 	b.lock.RLock()
 	defer b.lock.RUnlock()
 
-	start, end := getBlockWindow(block, blockRate)
 	return b.dequeue(start, end, upkeepLimit, maxResults, upkeepSelector)
 }
 
@@ -183,11 +184,14 @@ func (b *logBuffer) Dequeue(block int64, blockRate, upkeepLimit, maxResults int,
 func (b *logBuffer) dequeue(start, end int64, upkeepLimit, capacity int, upkeepSelector func(id *big.Int) bool) ([]BufferedLog, int) {
 	var result []BufferedLog
 	var remainingLogs int
-	for _, q := range b.queues {
+	var selectedUpkeeps int
+	numLogs := 0
+	for _, qid := range b.queueIDs {
+		q := b.queues[qid]
 		if !upkeepSelector(q.id) {
-			// if the upkeep is not selected, skip it
 			continue
 		}
+		selectedUpkeeps++
 		logsInRange := q.sizeOfRange(start, end)
 		if logsInRange == 0 {
 			// if there are no logs in the range, skip the upkeep
@@ -207,8 +211,10 @@ func (b *logBuffer) dequeue(start, end int64, upkeepLimit, capacity int, upkeepS
 			result = append(result, BufferedLog{ID: q.id, Log: l})
 			capacity--
 		}
+		numLogs += len(logs)
 		remainingLogs += remaining
 	}
+	b.lggr.Debugw("dequeued logs for upkeeps", "selectedUpkeeps", selectedUpkeeps, "numLogs", numLogs)
 	return result, remainingLogs
 }
 
@@ -230,12 +236,18 @@ func (b *logBuffer) SyncFilters(filterStore UpkeepFilterStore) error {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
-	for upkeepID := range b.queues {
+	for _, upkeepID := range b.queueIDs {
 		uid := new(big.Int)
 		_, ok := uid.SetString(upkeepID, 10)
 		if ok && !filterStore.Has(uid) {
 			// remove upkeep that is not in the filter store
 			delete(b.queues, upkeepID)
+			for i, v := range b.queueIDs {
+				if v == upkeepID {
+					b.queueIDs = append(b.queueIDs[:i], b.queueIDs[i+1:]...)
+					break
+				}
+			}
 		}
 	}
 
@@ -254,6 +266,16 @@ func (b *logBuffer) setUpkeepQueue(uid *big.Int, buf *upkeepLogQueue) {
 	b.lock.Lock()
 	defer b.lock.Unlock()
 
+	found := false
+	for _, id := range b.queueIDs {
+		if id == uid.String() {
+			found = true
+			break
+		}
+	}
+	if !found {
+		b.queueIDs = append(b.queueIDs, uid.String())
+	}
 	b.queues[uid.String()] = buf
 }
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -116,23 +116,21 @@ type logEventProvider struct {
 
 	chainID *big.Int
 
-	currentIteration    int
-	calculateIterations bool
-	iterations          int
+	currentIteration int
+	iterations       int
 }
 
 func NewLogProvider(lggr logger.Logger, poller logpoller.LogPoller, chainID *big.Int, packer LogDataPacker, filterStore UpkeepFilterStore, opts LogTriggersOptions) *logEventProvider {
 	return &logEventProvider{
-		threadCtrl:          utils.NewThreadControl(),
-		lggr:                lggr.Named("KeepersRegistry.LogEventProvider"),
-		packer:              packer,
-		buffer:              newLogEventBuffer(lggr, int(opts.LookbackBlocks), defaultNumOfLogUpkeeps, defaultFastExecLogsHigh),
-		bufferV1:            NewLogBuffer(lggr, uint32(opts.LookbackBlocks), opts.BlockRate, opts.LogLimit),
-		poller:              poller,
-		opts:                opts,
-		filterStore:         filterStore,
-		chainID:             chainID,
-		calculateIterations: true,
+		threadCtrl:  utils.NewThreadControl(),
+		lggr:        lggr.Named("KeepersRegistry.LogEventProvider"),
+		packer:      packer,
+		buffer:      newLogEventBuffer(lggr, int(opts.LookbackBlocks), defaultNumOfLogUpkeeps, defaultFastExecLogsHigh),
+		bufferV1:    NewLogBuffer(lggr, uint32(opts.LookbackBlocks), opts.BlockRate, opts.LogLimit),
+		poller:      poller,
+		opts:        opts,
+		filterStore: filterStore,
+		chainID:     chainID,
 	}
 }
 
@@ -297,11 +295,6 @@ func (p *logEventProvider) getLogsFromBuffer(latestBlock int64) []ocr2keepers.Up
 		blockRate, logLimitLow, maxResults, _ := p.getBufferDequeueArgs()
 
 		if p.iterations == p.currentIteration {
-			p.calculateIterations = true
-		}
-
-		if p.calculateIterations {
-			p.calculateIterations = false
 			p.currentIteration = 0
 			p.iterations = int(math.Ceil(float64(p.bufferV1.NumOfUpkeeps()*logLimitLow) / float64(maxResults)))
 			if p.iterations == 0 {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -313,6 +315,453 @@ func newEntry(p *logEventProvider, i int, args ...string) (LogTriggerConfig, upk
 		topics:   topics,
 	}
 	return cfg, f
+}
+
+func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
+	t.Run("5 upkeeps, 100 logs per upkeep per block for 100 blocks", func(t *testing.T) {
+		upkeepIDs := []*big.Int{
+			big.NewInt(1),
+			big.NewInt(2),
+			big.NewInt(3),
+			big.NewInt(4),
+			big.NewInt(5),
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start; i < end; i++ {
+				for j := 0; j < 100; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i+1)),
+						BlockNumber: i + 1,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 100, nil
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		_, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 5, provider.bufferV1.NumOfUpkeeps())
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		// each upkeep should have 100 logs * 100 blocks = 10000 logs
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["5"].logs))
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 9980, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9980, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 9980, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 9980, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 9980, len(bufV1.queues["5"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 9960, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9960, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 9960, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 9960, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 9960, len(bufV1.queues["5"].logs))
+	})
+
+	t.Run("200 upkeeps", func(t *testing.T) {
+		var upkeepIDs []*big.Int
+
+		for i := int64(1); i <= 200; i++ {
+			upkeepIDs = append(upkeepIDs, big.NewInt(i))
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start; i < end; i++ {
+				for j := 0; j < 100; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i+1)),
+						BlockNumber: i + 1,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 100, nil
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		_, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 200, provider.bufferV1.NumOfUpkeeps())
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		// each upkeep should have 100 logs * 100 blocks = 10000 logs
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["150"].logs))
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.iterations)
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9998, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+	})
+
+	t.Run("200 upkeeps, increasing to 300 upkeeps midway through the test", func(t *testing.T) {
+		var upkeepIDs []*big.Int
+
+		for i := int64(1); i <= 200; i++ {
+			upkeepIDs = append(upkeepIDs, big.NewInt(i))
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start; i < end; i++ {
+				for j := 0; j < 100; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i+1)),
+						BlockNumber: i + 1,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 100, nil
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		_, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 200, provider.bufferV1.NumOfUpkeeps())
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		// each upkeep should have 100 logs * 100 blocks = 10000 logs
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["9"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["21"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["150"].logs))
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.iterations)
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps; with 2 iterations this means even upkeep IDs are dequeued first
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["40"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["45"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps; on the second iteration, odd upkeep IDs are dequeued
+		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["99"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["100"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps; on the third iteration, even upkeep IDs are dequeued once again
+		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["160"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["170"].logs))
+
+		for i := int64(201); i <= 300; i++ {
+			upkeepIDs = append(upkeepIDs, big.NewInt(i))
+		}
+
+		for i := 200; i < len(upkeepIDs); i++ {
+			upkeepID := upkeepIDs[i]
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 300, provider.bufferV1.NumOfUpkeeps())
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.iterations)
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps; the new iterations
+		// have not yet been recalculated despite the new logs being added; new iterations
+		// are only calculated when current iteration maxes out at the total number of iterations
+		assert.Equal(t, 9998, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["51"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["52"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// with the newly added logs, iterations is recalculated
+		assert.Equal(t, 3, provider.iterations)
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9998, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["11"].logs))
+		assert.Equal(t, 9997, len(bufV1.queues["111"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9997, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 3, provider.iterations)
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9997, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 9997, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9997, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["250"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["299"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["300"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 3, provider.iterations)
+		assert.Equal(t, 3, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		var remainingLogs int
+		// at this point, every queue should have had at least one log dequeued
+		for _, queue := range bufV1.queues {
+			assert.True(t, len(queue.logs) < 10000)
+			remainingLogs += len(queue.logs)
+		}
+
+		// check that across all 300 upkeeps, we have only dequeued 700 of the 3000000 logs (7 dequeue calls of 100 logs)
+		assert.Equal(t, 2999300, remainingLogs)
+	})
 }
 
 type mockedPacker struct {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer_test.go
@@ -1187,10 +1187,15 @@ type mockFilterStore struct {
 	UpkeepFilterStore
 	HasFn               func(id *big.Int) bool
 	RangeFiltersByIDsFn func(iterator func(int, upkeepFilter), ids ...*big.Int)
+	UpdateFiltersFn     func(updater func(upkeepFilter, upkeepFilter) upkeepFilter, filters ...upkeepFilter)
 }
 
 func (s *mockFilterStore) RangeFiltersByIDs(iterator func(int, upkeepFilter), ids ...*big.Int) {
 	s.RangeFiltersByIDsFn(iterator, ids...)
+}
+
+func (s *mockFilterStore) UpdateFilters(updater func(upkeepFilter, upkeepFilter) upkeepFilter, filters ...upkeepFilter) {
+	s.UpdateFiltersFn(updater, filters...)
 }
 
 func (s *mockFilterStore) Has(id *big.Int) bool {


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/AUTO-9357

This PR consists of the following key change:

- Calculate the number of iterations needed to dequeue the minimum number of logs from the log buffer
  - Use a custom upkeep selector to determine which upkeeps we should dequeue logs for in the current dequeue round 

The goal here is that, in cases where the number of upkeeps exceeds the maximum number of results for a single call to log dequeue, we want to dequeue logs for subsets of upkeep IDs, in successive calls to dequeue, until at least the minimum number of logs have been dequeued for all upkeep IDs. 

For example, if `maxResults` is 100, but we store logs for 200 upkeeps; even if we choose to dequeue at most 1 log for each upkeep, we could still only dequeue logs for at most 100 upkeeps in a single dequeue call. This means that in order to dequeue 1 log for all 200 upkeeps; we would need to make 2 calls to dequeue, and for each call, ensure that we dequeue for two unique, distinct sets of upkeep IDs.

To do this determinstically, we can:
- First, calculate the total number of dequeue calls we would need to make to dequeue for all upkeep IDs. We refer to this number as `iterations`
- Add a state variable to the provider, that tracks the current iteration, in the range of (0...`iterations`), and in each dequeue round, define a custom upkeep selector such that `upkeepID % iterations == currentIteration`
- At the end of each dequeue round, increment the `currentIterations` counter, so that on the next call to dequeue, the upkeep selector will cause a different subset of upkeep IDs to be selected

## Testing

Node upgrade test is passing here: https://github.com/smartcontractkit/chainlink/actions/runs/8871312521
Load test run here: https://github.com/smartcontractkit/chainlink/actions/runs/8989012623/job/24691139888

Additionally, some unit tests have been added that demonstrate the behaviour when the buffer has logs for a small number of upkeeps, a large number of upkeeps, and a large number of upkeeps that increases midway through the dequeue rounds.

