### PR TITLE
chore: update github-app-token-issuer to v2.3.12

### DIFF
--- a/.github/workflows/helm-chart-publish.yml
+++ b/.github/workflows/helm-chart-publish.yml
@@ -25,7 +25,7 @@ jobs:
 
       - name: Get Github Token
         id: get-gh-token
-        uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@5dd916d08c03cb5f9a97304f4f174820421bb946 # v2.3.11
+        uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@5874ff7211cf5a5a2670bb010fbff914eaaae138 # v2.3.12
         with:
           url: ${{ secrets.GATI_LAMBDA_FUNCTION_URL }}
 

--- a/.github/workflows/operator-ui-ci.yml
+++ b/.github/workflows/operator-ui-ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - name: Get Github Token
         id: get-gh-token
-        uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@5dd916d08c03cb5f9a97304f4f174820421bb946 # v2.3.11
+        uses: smartcontractkit/chainlink-github-actions/github-app-token-issuer@5874ff7211cf5a5a2670bb010fbff914eaaae138 # v2.3.12
         with:
           url: ${{ secrets.AWS_INFRA_RELENG_TOKEN_ISSUER_LAMBDA_URL }}
 


### PR DESCRIPTION
###  Summary

Updating references to the `github-app-token-issuer` action, to use the new `node20` action.

---

RE-2442