### PR TITLE
fix: trim role-session-name to less than 64 characters

### DIFF
--- a/.github/workflows/goreleaser-build-publish-develop.yml
+++ b/.github/workflows/goreleaser-build-publish-develop.yml
@@ -26,7 +26,7 @@ jobs:
           role-duration-seconds: ${{ secrets.AWS_ROLE_DURATION_SECONDS }}
           aws-region: ${{ secrets.AWS_REGION }}
           mask-aws-account-id: true
-          role-session-name: goreleaser-build-publish-chainlink.push-chainlink-develop-goreleaser
+          role-session-name: goreleaser-build-publish-chainlink.push-develop
       - name: Build, sign, and publish image
         id: build-sign-publish
         uses: ./.github/actions/goreleaser-build-sign-publish


### PR DESCRIPTION
### Summary 

Found error after c5b055a915f6d765b194c72fc66d806f7039144f

Example: https://github.com/smartcontractkit/chainlink/actions/runs/8714475963/job/23904780143

```
Error: Could not assume role with OIDC: 1 validation error detected: Value 'goreleaser-build-publish-chainlink.push-chainlink-develop-goreleaser' at 'roleSessionName' failed to satisfy constraint: Member must have length less than or equal to 64
```