### PR TITLE
Fix helm publish workflow

### DIFF
--- a/.github/workflows/helm-chart-publish.yml
+++ b/.github/workflows/helm-chart-publish.yml
@@ -37,5 +37,6 @@ jobs:
         with:
           charts_dir: charts
           config: .github/cr.yaml
+          pages_branch: helm-releases
         env:
           CR_TOKEN: "${{ steps.get-gh-token.outputs.access-token }}"


### PR DESCRIPTION
Helm publish workflow doesn't seem to work, it always detects that there are no changes - [example run](https://github.com/smartcontractkit/chainlink/actions/runs/8721337634)

If `pages_branch` param is not passed, it would use the default which is gh_pages and that is probably disabled in this project
As a result helm chart wasn't published for a long time. The last published release is from Oct 23, see [the chart repo index here](https://raw.githubusercontent.com/smartcontractkit/chainlink/helm-release/index.yaml)
