### PR TITLE
Drop unused queryTimeout config from TXM strategy

### DIFF
--- a/.changeset/cyan-crabs-explode.md
+++ b/.changeset/cyan-crabs-explode.md
@@ -1,5 +1,5 @@
 ---
-"chainlink": removed
+"chainlink": minor
 ---
 
 Add support for workflow jobs to Operator UI #wip #added

--- a/.changeset/cyan-crabs-explode.md
+++ b/.changeset/cyan-crabs-explode.md
@@ -1,5 +1,5 @@
 ---
-"chainlink": minor
+"chainlink": removed
 ---
 
 Add support for workflow jobs to Operator UI #wip #added

--- a/.changeset/new-forks-grab.md
+++ b/.changeset/new-forks-grab.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+Drop unused queryTimeout config from TXM strategy

--- a/.changeset/new-forks-grab.md
+++ b/.changeset/new-forks-grab.md
@@ -1,5 +1,5 @@
 ---
-"chainlink": minor
+"chainlink": removed
 ---
 
 Drop unused queryTimeout config from TXM strategy

--- a/.changeset/new-forks-grab.md
+++ b/.changeset/new-forks-grab.md
@@ -2,4 +2,4 @@
 "chainlink": removed
 ---
 
-Drop unused queryTimeout config from TXM strategy
+Drop unused queryTimeout config from TXM strategy #internal

--- a/core/chains/evm/txmgr/evm_tx_store_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_test.go
@@ -1841,7 +1841,7 @@ func TestORM_PruneUnstartedTxQueue(t *testing.T) {
 
 	t.Run("does not prune if queue has not exceeded capacity-1", func(t *testing.T) {
 		subject1 := uuid.New()
-		strategy1 := txmgrcommon.NewDropOldestStrategy(subject1, uint32(5), cfg.Database().DefaultQueryTimeout())
+		strategy1 := txmgrcommon.NewDropOldestStrategy(subject1, uint32(5))
 		for i := 0; i < 5; i++ {
 			mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, &cltest.FixtureChainID, txRequestWithStrategy(strategy1))
 		}
@@ -1850,7 +1850,7 @@ func TestORM_PruneUnstartedTxQueue(t *testing.T) {
 
 	t.Run("prunes if queue has exceeded capacity-1", func(t *testing.T) {
 		subject2 := uuid.New()
-		strategy2 := txmgrcommon.NewDropOldestStrategy(subject2, uint32(3), cfg.Database().DefaultQueryTimeout())
+		strategy2 := txmgrcommon.NewDropOldestStrategy(subject2, uint32(3))
 		for i := 0; i < 5; i++ {
 			mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, &cltest.FixtureChainID, txRequestWithStrategy(strategy2))
 		}

--- a/core/chains/evm/txmgr/strategies_test.go
+++ b/core/chains/evm/txmgr/strategies_test.go
@@ -11,7 +11,6 @@ import (
 	txmgrcommon "github.com/smartcontractkit/chainlink/v2/common/txmgr"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
-	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
 )
 
 func Test_SendEveryStrategy(t *testing.T) {
@@ -28,10 +27,9 @@ func Test_SendEveryStrategy(t *testing.T) {
 
 func Test_DropOldestStrategy_Subject(t *testing.T) {
 	t.Parallel()
-	cfg := configtest.NewGeneralConfig(t, nil)
 
 	subject := uuid.New()
-	s := txmgrcommon.NewDropOldestStrategy(subject, 1, cfg.Database().DefaultQueryTimeout())
+	s := txmgrcommon.NewDropOldestStrategy(subject, 1)
 
 	assert.True(t, s.Subject().Valid)
 	assert.Equal(t, subject, s.Subject().UUID)
@@ -39,14 +37,12 @@ func Test_DropOldestStrategy_Subject(t *testing.T) {
 
 func Test_DropOldestStrategy_PruneQueue(t *testing.T) {
 	t.Parallel()
-	cfg := configtest.NewGeneralConfig(t, nil)
 	subject := uuid.New()
 	queueSize := uint32(2)
-	queryTimeout := cfg.Database().DefaultQueryTimeout()
 	mockTxStore := mocks.NewEvmTxStore(t)
 
 	t.Run("calls PrineUnstartedTxQueue for the given subject and queueSize, ignoring fromAddress", func(t *testing.T) {
-		strategy1 := txmgrcommon.NewDropOldestStrategy(subject, queueSize, queryTimeout)
+		strategy1 := txmgrcommon.NewDropOldestStrategy(subject, queueSize)
 		mockTxStore.On("PruneUnstartedTxQueue", mock.Anything, queueSize-1, subject, mock.Anything, mock.Anything).Once().Return([]int64{1, 2}, nil)
 		ids, err := strategy1.PruneQueue(testutils.Context(t), mockTxStore)
 		require.NoError(t, err)

--- a/core/services/blockhashstore/bhs.go
+++ b/core/services/blockhashstore/bhs.go
@@ -104,7 +104,7 @@ func (c *BulletproofBHS) Store(ctx context.Context, blockNum uint64) error {
 
 		// Set a queue size of 256. At most we store the blockhash of every block, and only the
 		// latest 256 can possibly be stored.
-		Strategy: txmgrcommon.NewQueueingTxStrategy(c.jobID, 256, c.dbConfig.DefaultQueryTimeout()),
+		Strategy: txmgrcommon.NewQueueingTxStrategy(c.jobID, 256),
 	})
 	if err != nil {
 		return errors.Wrap(err, "creating transaction")

--- a/core/services/fluxmonitorv2/delegate.go
+++ b/core/services/fluxmonitorv2/delegate.go
@@ -71,7 +71,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, jb job.Job) (services []
 		return nil, err
 	}
 	cfg := chain.Config()
-	strategy := txmgrcommon.NewQueueingTxStrategy(jb.ExternalJobID, cfg.FluxMonitor().DefaultTransactionQueueDepth(), cfg.Database().DefaultQueryTimeout())
+	strategy := txmgrcommon.NewQueueingTxStrategy(jb.ExternalJobID, cfg.FluxMonitor().DefaultTransactionQueueDepth())
 	var checker txmgr.TransmitCheckerSpec
 	if chain.Config().FluxMonitor().SimulateTransactions() {
 		checker.CheckerType = txmgr.TransmitCheckerTypeSimulate

--- a/core/services/ocr/delegate.go
+++ b/core/services/ocr/delegate.go
@@ -199,7 +199,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, jb job.Job) (services []
 		}
 
 		cfg := chain.Config()
-		strategy := txmgrcommon.NewQueueingTxStrategy(jb.ExternalJobID, cfg.OCR().DefaultTransactionQueueDepth(), cfg.Database().DefaultQueryTimeout())
+		strategy := txmgrcommon.NewQueueingTxStrategy(jb.ExternalJobID, cfg.OCR().DefaultTransactionQueueDepth())
 
 		var checker txmgr.TransmitCheckerSpec
 		if chain.Config().OCR().SimulateTransactions() {

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -521,7 +521,7 @@ func newOnChainContractTransmitter(ctx context.Context, lggr logger.Logger, rarg
 		subject = *opts.subjectID
 	}
 	scoped := configWatcher.chain.Config()
-	strategy := txmgrcommon.NewQueueingTxStrategy(subject, scoped.OCR2().DefaultTransactionQueueDepth(), scoped.Database().DefaultQueryTimeout())
+	strategy := txmgrcommon.NewQueueingTxStrategy(subject, scoped.OCR2().DefaultTransactionQueueDepth())
 
 	var checker txm.TransmitCheckerSpec
 	if configWatcher.chain.Config().OCR2().SimulateTransactions() {

--- a/core/services/relay/evm/functions.go
+++ b/core/services/relay/evm/functions.go
@@ -183,7 +183,7 @@ func newFunctionsContractTransmitter(ctx context.Context, contractVersion uint32
 	}
 
 	scoped := configWatcher.chain.Config()
-	strategy := txmgrcommon.NewQueueingTxStrategy(rargs.ExternalJobID, scoped.OCR2().DefaultTransactionQueueDepth(), scoped.Database().DefaultQueryTimeout())
+	strategy := txmgrcommon.NewQueueingTxStrategy(rargs.ExternalJobID, scoped.OCR2().DefaultTransactionQueueDepth())
 
 	var checker txm.TransmitCheckerSpec
 	if configWatcher.chain.Config().OCR2().SimulateTransactions() {


### PR DESCRIPTION
`queryTimeout` is a legacy config that was introduced because pruneService wasn't handling timeouts properly. For reference:
- https://github.com/smartcontractkit/chainlink/blob/v2.6.0/common/txmgr/strategies.go#L61

Now that the pruneService takes care of that, we can remove it.
This simplifies config extraction PR:
- https://github.com/smartcontractkit/chainlink/pull/12636