### PR TITLE
add kubeconform gha to validate k8s manifests

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ci-kubeconform
-        uses: smartcontractkit/.github/actions/ci-kubeconform@7fa39741b11e66ed59f8aad786d4b9356c389f3f # ci-kubeconform@0.1.0
+        uses: smartcontractkit/.github/actions/ci-kubeconform@1ae8a9a984814c4daf50aa96f03be2cba0ef3fec # ci-kubeconform@0.2.0
         with:
           # kubeform inputs
           charts-dir: charts/chainlink-cluster

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -30,3 +30,12 @@ jobs:
           gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
           gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
+  kubeconform:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
+      - name: Generate and validate releases
+        uses: shivjm/helm-kubeconform-action@e330da645f13bc035d5d2772838d185877f80701 # v0.3.0
+        with:
+          chartsDirectory: "charts"

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -35,7 +35,6 @@ jobs:
           gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
 
   ci-kubeconform:
-    needs: add-helm-repos
     runs-on: ubuntu-latest
     steps:
       - name: Setup yq

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -39,3 +39,4 @@ jobs:
         uses: shivjm/helm-kubeconform-action@e330da645f13bc035d5d2772838d185877f80701 # v0.3.0
         with:
           chartsDirectory: "charts"
+          regexSkipDir: "charts/chainlink-cluster/dashboard"

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -14,6 +14,8 @@ jobs:
       contents: read
       actions: read
     steps:
+      - name: Checkout the repo
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Setup yq
         uses: frenck/action-setup-yq@c4b5be8b4a215c536a41d436757d9feb92836d4f #v1.0.2
       - name: Add helm repos
@@ -37,6 +39,8 @@ jobs:
   ci-kubeconform:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout the repo
+        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
       - name: Setup yq
         uses: frenck/action-setup-yq@c4b5be8b4a215c536a41d436757d9feb92836d4f #v1.0.2
       - name: Add helm repos

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -9,13 +9,9 @@ on:
 jobs:
   ci-lint-helm-charts:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-      actions: read
     steps:
       - name: ci-lint-helm-charts
-        uses: smartcontractkit/.github/actions/ci-lint-charts@6b08487b176ef7cad086526d0b54ddff6691c044 # ci-lint-charts@0.1.2
+        uses: smartcontractkit/.github/actions/ci-lint-charts@re-2490/add-ci-kubeform # TODO pin specific version once released
         with:
           # chart testing inputs
           chart-testing-extra-args: "--lint-conf=lintconf.yaml"

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -7,12 +7,8 @@ on:
       - ".github/workflows/helm-chart.yml"
 
 jobs:
-  ci-lint-helm-charts:
+  add-helm-repos:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-      actions: read
     steps:
       - name: Add repositories
         run: |
@@ -20,6 +16,15 @@ jobs:
           helm repo add opentelemetry-collector https://open-telemetry.github.io/opentelemetry-helm-charts
           helm repo add tempo https://grafana.github.io/helm-charts
           helm repo add grafana https://grafana.github.io/helm-charts
+
+  ci-lint-helm-charts:
+    needs: add-helm-repos
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      actions: read
+    steps:
       - name: ci-lint-helm-charts
         uses: smartcontractkit/.github/actions/ci-lint-charts@6b08487b176ef7cad086526d0b54ddff6691c044 # ci-lint-charts@0.1.2
         with:
@@ -30,7 +35,9 @@ jobs:
           gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
           gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
+
   ci-kubeconform:
+    needs: add-helm-repos
     runs-on: ubuntu-latest
     steps:
       - name: ci-kubeconform

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -39,7 +39,7 @@ jobs:
           # kubeform inputs
           charts-dir: charts
           # grafana inputs
-          metrics-job-name: ci-kubeform
+          metrics-job-name: ci-kubeconform
           gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
           gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -39,4 +39,4 @@ jobs:
         uses: shivjm/helm-kubeconform-action@e330da645f13bc035d5d2772838d185877f80701 # v0.3.0
         with:
           chartsDirectory: "charts"
-          regexSkipDir: "charts/chainlink-cluster/dashboard"
+          regexSkipDir: "\\.git"

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -14,22 +14,12 @@ jobs:
       contents: read
       actions: read
     steps:
-      - name: Checkout the repo
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-      - name: Setup yq
-        uses: frenck/action-setup-yq@c4b5be8b4a215c536a41d436757d9feb92836d4f #v1.0.2
-      - name: Add helm repos
-        shell: bash
-        working-directory: charts/chainlink-cluster
-        run: |
-          if [[ -f "./Chart.lock" ]]; then
-            yq --indent 0 '.dependencies | map(["helm", "repo", "add", .name, .repository] | join(" ")) | .[]' "./Chart.lock"  | sh --;
-          fi
       - name: ci-lint-helm-charts
         uses: smartcontractkit/.github/actions/ci-lint-charts@6b08487b176ef7cad086526d0b54ddff6691c044 # ci-lint-charts@0.1.2
         with:
           # chart testing inputs
           chart-testing-extra-args: "--lint-conf=lintconf.yaml"
+          charts-dir: charts/chainlink-cluster
           # grafana inputs
           metrics-job-name: ci-lint-helm-charts
           gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
@@ -39,17 +29,6 @@ jobs:
   ci-kubeconform:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout the repo
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-      - name: Setup yq
-        uses: frenck/action-setup-yq@c4b5be8b4a215c536a41d436757d9feb92836d4f #v1.0.2
-      - name: Add helm repos
-        shell: bash
-        working-directory: charts/chainlink-cluster
-        run: |
-          if [[ -f "./Chart.lock" ]]; then
-            yq --indent 0 '.dependencies | map(["helm", "repo", "add", .name, .repository] | join(" ")) | .[]' "./Chart.lock"  | sh --;
-          fi
       - name: ci-kubeconform
         uses: smartcontractkit/.github/actions/ci-kubeconform@re-2490/add-ci-kubeform # TODO pin specific version once released
         with:

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -30,13 +30,16 @@ jobs:
           gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
           gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-  kubeconform:
+  ci-kubeconform:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout repo
-        uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
-      - name: Generate and validate releases
-        uses: shivjm/helm-kubeconform-action@e330da645f13bc035d5d2772838d185877f80701 # v0.3.0
+      - name: ci-kubeconform
+        uses: smartcontractkit/.github/actions/ci-kubeconform@re-2490/add-ci-kubeform # TODO pin specific version once released
         with:
-          chartsDirectory: "charts"
-          regexSkipDir: "\\.git"
+          # kubeform inputs
+          charts-dir: charts
+          # grafana inputs
+          metrics-job-name: ci-kubeform
+          gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
+          gc-host: ${{ secrets.GRAFANA_INTERNAL_HOST }}
+          gc-org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -37,7 +37,7 @@ jobs:
         uses: smartcontractkit/.github/actions/ci-kubeconform@re-2490/add-ci-kubeform # TODO pin specific version once released
         with:
           # kubeform inputs
-          charts-dir: charts
+          charts-dir: charts/chainlink-cluster
           # grafana inputs
           metrics-job-name: ci-kubeconform
           gc-basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -7,24 +7,22 @@ on:
       - ".github/workflows/helm-chart.yml"
 
 jobs:
-  add-helm-repos:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Add repositories
-        run: |
-          helm repo add mockserver https://www.mock-server.com
-          helm repo add opentelemetry-collector https://open-telemetry.github.io/opentelemetry-helm-charts
-          helm repo add tempo https://grafana.github.io/helm-charts
-          helm repo add grafana https://grafana.github.io/helm-charts
-
   ci-lint-helm-charts:
-    needs: add-helm-repos
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: read
       actions: read
     steps:
+      - name: Setup yq
+        uses: frenck/action-setup-yq@c4b5be8b4a215c536a41d436757d9feb92836d4f #v1.0.2
+      - name: Add helm repos
+        shell: bash
+        working-directory: charts/chainlink-cluster
+        run: |
+          if [[ -f "./Chart.lock" ]]; then
+            yq --indent 0 '.dependencies | map(["helm", "repo", "add", .name, .repository] | join(" ")) | .[]' "./Chart.lock"  | sh --;
+          fi
       - name: ci-lint-helm-charts
         uses: smartcontractkit/.github/actions/ci-lint-charts@6b08487b176ef7cad086526d0b54ddff6691c044 # ci-lint-charts@0.1.2
         with:
@@ -40,6 +38,15 @@ jobs:
     needs: add-helm-repos
     runs-on: ubuntu-latest
     steps:
+      - name: Setup yq
+        uses: frenck/action-setup-yq@c4b5be8b4a215c536a41d436757d9feb92836d4f #v1.0.2
+      - name: Add helm repos
+        shell: bash
+        working-directory: charts/chainlink-cluster
+        run: |
+          if [[ -f "./Chart.lock" ]]; then
+            yq --indent 0 '.dependencies | map(["helm", "repo", "add", .name, .repository] | join(" ")) | .[]' "./Chart.lock"  | sh --;
+          fi
       - name: ci-kubeconform
         uses: smartcontractkit/.github/actions/ci-kubeconform@re-2490/add-ci-kubeform # TODO pin specific version once released
         with:

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ci-lint-helm-charts
-        uses: smartcontractkit/.github/actions/ci-lint-charts@re-2490/add-ci-kubeform # TODO pin specific version once released
+        uses: smartcontractkit/.github/actions/ci-lint-charts@7fa39741b11e66ed59f8aad786d4b9356c389f3f # ci-lint-charts@0.2.0
         with:
           # chart testing inputs
           chart-testing-extra-args: "--lint-conf=lintconf.yaml"
@@ -26,7 +26,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ci-kubeconform
-        uses: smartcontractkit/.github/actions/ci-kubeconform@re-2490/add-ci-kubeform # TODO pin specific version once released
+        uses: smartcontractkit/.github/actions/ci-kubeconform@7fa39741b11e66ed59f8aad786d4b9356c389f3f # ci-kubeconform@0.1.0
         with:
           # kubeform inputs
           charts-dir: charts/chainlink-cluster


### PR DESCRIPTION
This adds a new CI check called `ci-kubeconform` to validate k8s manifests as well as refactor the `ci-lint-helm-charts` workflow to have the `add helm repos` inside the .github action instead.