### PR TITLE
Fixing install and check.sh scripts

### DIFF
--- a/operator_ui/check.sh
+++ b/operator_ui/check.sh
@@ -6,7 +6,7 @@ set -e
 # jq ^1.6 https://stedolan.github.io/jq/
 
 repo=smartcontractkit/operator-ui
-gitRoot=$(git rev-parse --show-toplevel)
+gitRoot="$(dirname -- "$0")/../"
 cd "$gitRoot/operator_ui"
 
 tag_file=TAG

--- a/operator_ui/install.sh
+++ b/operator_ui/install.sh
@@ -4,7 +4,7 @@ set -e
 owner=smartcontractkit
 repo=operator-ui
 fullRepo=${owner}/${repo}
-gitRoot=$(git rev-parse --show-toplevel || pwd)
+gitRoot="$(dirname -- "$0")/../"
 cd "$gitRoot/operator_ui"
 unpack_dir="$gitRoot/core/web/assets"
 tag=$(cat TAG)


### PR DESCRIPTION
## Motivation
Needed to update these scripts to fix an issue with the build.sh script we use in ccip-localenv.

![image](https://github.com/smartcontractkit/ccip/assets/61269961/48e4b982-99ca-4e7c-ba98-f8763b7ebc97)

## Solution
Chainging `gitRoot=$(git rev-parse --show-toplevel || pwd)` to `gitRoot="$(dirname -- "$0")/../"`
[Thread](https://chainlink-core.slack.com/archives/C05CS33N08N/p1712112452125839?thread_ts=1712099333.142479&cid=C05CS33N08N) for reference


