### PR TITLE
Move vrfv2plus wrapper events from interface to implementation

### DIFF
--- a/contracts/src/v0.8/vrf/dev/VRFV2PlusWrapper.sol
+++ b/contracts/src/v0.8/vrf/dev/VRFV2PlusWrapper.sol
@@ -32,6 +32,26 @@ contract VRFV2PlusWrapper is ConfirmedOwner, TypeAndVersionInterface, VRFConsume
   LinkTokenInterface internal immutable i_link;
   AggregatorV3Interface internal immutable i_link_native_feed;
 
+  event FulfillmentTxSizeSet(uint32 size);
+  event ConfigSet(
+    uint32 wrapperGasOverhead,
+    uint32 coordinatorGasOverhead,
+    uint16 coordinatorGasOverheadPerWord,
+    uint8 coordinatorNativePremiumPercentage,
+    uint8 coordinatorLinkPremiumPercentage,
+    bytes32 keyHash,
+    uint8 maxNumWords,
+    uint32 stalenessSeconds,
+    int256 fallbackWeiPerUnitLink,
+    uint32 fulfillmentFlatFeeNativePPM,
+    uint32 fulfillmentFlatFeeLinkDiscountPPM
+  );
+  event FallbackWeiPerUnitLinkUsed(uint256 requestId, int256 fallbackWeiPerUnitLink);
+  event Withdrawn(address indexed to, uint256 amount);
+  event NativeWithdrawn(address indexed to, uint256 amount);
+  event Enabled();
+  event Disabled();
+
   error LinkAlreadySet();
   error LinkDiscountTooHigh(uint32 flatFeeLinkDiscountPPM, uint32 flatFeeNativePPM);
   error InvalidPremiumPercentage(uint8 premiumPercentage, uint8 max);

--- a/contracts/src/v0.8/vrf/dev/interfaces/IVRFV2PlusWrapper.sol
+++ b/contracts/src/v0.8/vrf/dev/interfaces/IVRFV2PlusWrapper.sol
@@ -2,26 +2,6 @@
 pragma solidity ^0.8.0;
 
 interface IVRFV2PlusWrapper {
-  event FulfillmentTxSizeSet(uint32 size);
-  event ConfigSet(
-    uint32 wrapperGasOverhead,
-    uint32 coordinatorGasOverhead,
-    uint16 coordinatorGasOverheadPerWord,
-    uint8 coordinatorNativePremiumPercentage,
-    uint8 coordinatorLinkPremiumPercentage,
-    bytes32 keyHash,
-    uint8 maxNumWords,
-    uint32 stalenessSeconds,
-    int256 fallbackWeiPerUnitLink,
-    uint32 fulfillmentFlatFeeNativePPM,
-    uint32 fulfillmentFlatFeeLinkDiscountPPM
-  );
-  event FallbackWeiPerUnitLinkUsed(uint256 requestId, int256 fallbackWeiPerUnitLink);
-  event Withdrawn(address indexed to, uint256 amount);
-  event NativeWithdrawn(address indexed to, uint256 amount);
-  event Enabled();
-  event Disabled();
-
   /**
    * @return the request ID of the most recent VRF V2 request made by this wrapper. This should only
    * be relied option within the same transaction that the request was made.


### PR DESCRIPTION
Move vrfv2plus wrapper events from interface to implementation

I think it makes more sense to decouple the events from the interface as these are implementation specific details and not used by the functions declared in the interface.