### PR TITLE
[fix] Fix engine panic when we get a zero response

### DIFF
--- a/core/services/workflows/engine.go
+++ b/core/services/workflows/engine.go
@@ -212,7 +212,12 @@ func (e *Engine) loop(ctx context.Context) {
 		case <-ctx.Done():
 			e.logger.Debugw("shutting down loop")
 			return
-		case resp := <-e.triggerEvents:
+		case resp, isOpen := <-e.triggerEvents:
+			if !isOpen {
+				e.logger.Errorf("trigger events channel is no longer open, skipping")
+				continue
+			}
+
 			if resp.Err != nil {
 				e.logger.Errorf("trigger event was an error; not executing", resp.Err)
 				continue


### PR DESCRIPTION
* When we shut down the engine, we'll deregister all triggers associated with it.
* In our hardcoded workflow, this corresponds to the mercury engine trigger, which will close the trigger events channel.
* This causes the channel to return a zero response, which we need to handle correctly by skipping the event

Note: @ettec 's proposal to move channel ownership to capabilities rather than engine's will further bolster our resilience to these types of errors.