### PR TITLE
Add script to setup db test user

### DIFF
--- a/.changeset/chilled-bikes-unite.md
+++ b/.changeset/chilled-bikes-unite.md
@@ -1,0 +1,5 @@
+---
+"chainlink": minor
+---
+
+#internal Add script to create test database user and update docs

--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ tools/clroot/db.sqlite3-wal
 .DS_Store
 .envrc
 .env*
+.dbenv
 !charts/chainlink-cluster/.env.example
 !.github/actions/setup-postgres/.env
 .direnv

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -104,6 +104,10 @@ testscripts: chainlink-test ## Install and run testscript against testdata/scrip
 testscripts-update: ## Update testdata/scripts/* files via testscript.
 	make testscripts TS_FLAGS="-u"
 
+.PHONY: setup-testdb
+setup-testdb: ## Setup the test database.
+	./core/scripts/setup_testdb.sh
+
 .PHONY: testdb
 testdb: ## Prepares the test database.
 	go run . local db preparetest

--- a/README.md
+++ b/README.md
@@ -167,19 +167,27 @@ go generate ./...
 
 5. Prepare your development environment:
 
-```bash
-export CL_DATABASE_URL=postgresql://127.0.0.1:5432/chainlink_test?sslmode=disable
-```
+The tests require a postgres database. In turn, the environment variable
+`CL_DATABASE_URL` must be set to value that can connect to `_test` database, and the user must be able to create and drop
+the given `_test` database.
 
 Note: Other environment variables should not be set for all tests to pass
 
-6.  Drop/Create test database and run migrations:
+There helper script for initial setup to create an appropriate test user. It requires postgres to be running on localhost at port 5432. You will be prompted for
+the `postgres` user password 
 
+```bash
+make setup-testdb
 ```
+
+This script will save the `CL_DATABASE_URL` in `.dbenv`
+
+Changes to database require migrations to be run. Similarly, `pull`'ing the repo may require migrations to run.
+After the one-time setup above:
+```
+source .dbenv
 make testdb
 ```
-
-If you do end up modifying the migrations for the database, you will need to rerun
 
 7. Run tests:
 

--- a/core/scripts/setup_testdb.sh
+++ b/core/scripts/setup_testdb.sh
@@ -1,0 +1,66 @@
+#/bin/sh
+
+# Create a new user and database for development
+# This script is intended to be run on a local development machine
+tdir=$(mktemp -d -t db-dev-user)
+
+username="chainlink_dev"
+password="insecurepassword"
+database="chainlink_development_test"
+# here document for the SQL commands
+cat << EOF > $tdir/db-dev-user.sql
+-- create a new user and database for development if they don't exist
+DO \$\$
+BEGIN
+    IF NOT EXISTS (SELECT FROM pg_roles WHERE rolname = '$username') THEN
+        CREATE ROLE $username WITH LOGIN PASSWORD '$password';
+    END IF;
+END \$\$;
+SELECT 'CREATE DATABASE $database WITH OWNER $username;' 
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = '$database')\gexec
+
+-- Grant all privileges on the database to the user
+ALTER DATABASE $database OWNER TO $username;
+GRANT ALL PRIVILEGES ON DATABASE "$database" TO "$username";
+
+-- Create a pristine database for testing
+SELECT 'CREATE DATABASE chainlink_test_pristine WITH OWNER $username;' 
+WHERE NOT EXISTS (SELECT FROM pg_database WHERE datname = 'chainlink_test_pristine')\gexec
+EOF
+
+# Print the SQL commands
+echo "SQL commands to be run: $tdir/db-dev-user.sql"
+echo "##########################################################################################################"
+echo "##########################################################################################################"
+
+cat $tdir/db-dev-user.sql
+echo "##########################################################################################################"
+echo "##########################################################################################################"
+echo ""
+# Run the SQL commands
+psql -U postgres -h localhost -f $tdir/db-dev-user.sql
+
+
+#test the connection
+PGPASSWORD=$password psql -U $username -h localhost -d $database -c "SELECT 1" && echo "Connection successful" || echo "Connection failed"
+
+db_url=$(echo "CL_DATABASE_URL=postgresql://chainlink_dev:insecurepassword@localhost:5432/chainlink_development_test")
+echo $db_url
+repo=$(git rev-parse --show-toplevel)
+pushd $repo
+export $db_url 
+make testdb || echo "Failed to create test database"
+popd
+
+# Set the database URL in the .dbenv file
+dbenv=$repo/.dbenv
+echo "\n!Success!\n"
+echo "Datbase URL: $db_url"
+
+echo "export $db_url" >> $dbenv
+echo "Has been set in the $dbenv file"
+
+echo "Either" 
+echo "    source $dbenv"
+echo "Or explicitly set environment variable in your shell"
+echo "    export $db_url"


### PR DESCRIPTION
Adds a script to create a test user. This is useful for development because it avoid overloading the root postgres user for dev work.