### PR TITLE
E2E Test Fix Chainlink Node Internal Docker Host Url When Container Startup Has To Retry

### DIFF
--- a/integration-tests/docker/test_env/cl_node.go
+++ b/integration-tests/docker/test_env/cl_node.go
@@ -339,6 +339,14 @@ func (n *ClNode) containerStartOrRestart(restartDb bool) error {
 		return fmt.Errorf("%s err: %w", ErrStartCLNodeContainer, err)
 	}
 
+	// retries can change the container name which affects urls used later
+	// so update to use the name that actually started
+	n.ContainerName, err = container.Name(context.Background())
+	if err != nil {
+		return err
+	}
+	n.ContainerName = strings.Replace(n.ContainerName, "/", "", -1)
+
 	clEndpoint, err := test_env.GetEndpoint(testcontext.Get(n.t), container, "http")
 	if err != nil {
 		return err


### PR DESCRIPTION
This is a temporary fix to make tests more stable until a proper fix can be made in chainlink-testing-framework for the retriers to not change container names on startup retry.