### PR TITLE
Update log trigger log provider readMaxBatchSize to 56

### DIFF
--- a/.changeset/tidy-trees-tie.md
+++ b/.changeset/tidy-trees-tie.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Updating the log trigger log provider's readMaxBatchSize to 56

--- a/.changeset/tidy-trees-tie.md
+++ b/.changeset/tidy-trees-tie.md
@@ -2,4 +2,4 @@
 "chainlink": patch
 ---
 
-Updating the log trigger log provider's readMaxBatchSize to 56
+#changed Updating the log trigger log provider's readMaxBatchSize to 56

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -42,7 +42,7 @@ var (
 	readJobQueueSize = 64
 	readLogsTimeout  = 10 * time.Second
 
-	readMaxBatchSize = 32
+	readMaxBatchSize = 56
 	// reorgBuffer is the number of blocks to add as a buffer to the block range when reading logs.
 	reorgBuffer   = int64(32)
 	readerThreads = 4


### PR DESCRIPTION
For test results and findings on how we arrived at this value, see: AUTO-8204