### PR TITLE
fix: disable gh releases for contracts

### DIFF
--- a/.github/workflows/solidity.yml
+++ b/.github/workflows/solidity.yml
@@ -258,10 +258,7 @@ jobs:
         uses: smartcontractkit/.github/actions/ci-publish-npm@4b0ab756abcb1760cb82e1e87b94ff431905bffc # ci-publish-npm@0.4.0
         with:
           npm-token: ${{ secrets.NPM_TOKEN }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          github-release-tag-name: ${{ github.ref_name }}
-          github-release-changelog-path: "contracts/CHANGELOG.md"
-          create-github-release: true
+          create-github-release: false
           publish-command: "pnpm publish-prod --no-git-checks"
           package-json-directory: contracts
 


### PR DESCRIPTION
### Summary

It was noticed that upon a contracts release, it was tagged as `latest` which messed up the usual core release process. 

https://github.com/smartcontractkit/chainlink/actions/runs/8836102390/job/24261879602#step:3:37

The contracts release broke the expected response from this endpoint:

- `https://api.github.com/repos/${{ github.repository }}/releases/latest?draft=false&prerelease=false`

Disabling the Github release for contracts. If this is added back at a later date then we'll have to fix the compatibility of these two processes.

