### PR TITLE
add coverage for registrar and registry

### DIFF
--- a/contracts/src/v0.8/automation/dev/test/AutomationRegistrar2_3.t.sol
+++ b/contracts/src/v0.8/automation/dev/test/AutomationRegistrar2_3.t.sol
@@ -50,14 +50,18 @@ contract CancelUpkeep is SetUp {
     assertEq(registry.getNumUpkeeps(), 0);
 
     uint256 startRegistrarBalance = usdToken18.balanceOf(address(registrar));
+    uint256 startUpkeepAdminBalance = usdToken18.balanceOf(UPKEEP_ADMIN);
 
-    // approve the upkeep
+    // cancel the upkeep
     vm.startPrank(OWNER);
     bytes32 hash = keccak256(abi.encode(registrationParams));
     registrar.cancel(hash);
 
     uint256 endRegistrarBalance = usdToken18.balanceOf(address(registrar));
+    uint256 endUpkeepAdminBalance = usdToken18.balanceOf(UPKEEP_ADMIN);
+
     assertEq(startRegistrarBalance - amount, endRegistrarBalance);
+    assertEq(startUpkeepAdminBalance + amount, endUpkeepAdminBalance);
   }
 }
 

--- a/contracts/src/v0.8/automation/dev/test/AutomationRegistrar2_3.t.sol
+++ b/contracts/src/v0.8/automation/dev/test/AutomationRegistrar2_3.t.sol
@@ -16,8 +16,90 @@ contract SetUp is BaseTest {
 
   function setUp() public override {
     super.setUp();
+    vm.startPrank(OWNER);
     (registry, registrar) = deployAndConfigureRegistryAndRegistrar(AutoBase.PayoutMode.ON_CHAIN);
     vm.stopPrank(); // reset identity at the start of each test
+  }
+}
+
+contract CancelUpkeep is SetUp {
+  function testUSDToken_happy() external {
+    vm.startPrank(UPKEEP_ADMIN);
+
+    uint96 amount = uint96(registrar.getMinimumRegistrationAmount(usdToken18));
+    usdToken18.approve(address(registrar), amount);
+
+    AutomationRegistrar2_3.RegistrationParams memory registrationParams = AutomationRegistrar2_3.RegistrationParams({
+      upkeepContract: address(TARGET1),
+      amount: amount,
+      adminAddress: UPKEEP_ADMIN,
+      gasLimit: 10_000,
+      triggerType: 0,
+      billingToken: usdToken18,
+      name: "foobar",
+      encryptedEmail: "",
+      checkData: bytes("check data"),
+      triggerConfig: "",
+      offchainConfig: ""
+    });
+
+    // default is auto approve off
+    registrar.registerUpkeep(registrationParams);
+
+    assertEq(usdToken18.balanceOf(address(registrar)), amount);
+    assertEq(registry.getNumUpkeeps(), 0);
+
+    uint256 startRegistrarBalance = usdToken18.balanceOf(address(registrar));
+
+    // approve the upkeep
+    vm.startPrank(OWNER);
+    bytes32 hash = keccak256(abi.encode(registrationParams));
+    registrar.cancel(hash);
+
+    uint256 endRegistrarBalance = usdToken18.balanceOf(address(registrar));
+    assertEq(startRegistrarBalance - amount, endRegistrarBalance);
+  }
+}
+
+contract ApproveUpkeep is SetUp {
+  function testUSDToken_happy() external {
+    vm.startPrank(UPKEEP_ADMIN);
+
+    uint96 amount = uint96(registrar.getMinimumRegistrationAmount(usdToken18));
+    usdToken18.approve(address(registrar), amount);
+
+    AutomationRegistrar2_3.RegistrationParams memory registrationParams = AutomationRegistrar2_3.RegistrationParams({
+      upkeepContract: address(TARGET1),
+      amount: amount,
+      adminAddress: UPKEEP_ADMIN,
+      gasLimit: 10_000,
+      triggerType: 0,
+      billingToken: usdToken18,
+      name: "foobar",
+      encryptedEmail: "",
+      checkData: bytes("check data"),
+      triggerConfig: "",
+      offchainConfig: ""
+    });
+
+    // default is auto approve off
+    registrar.registerUpkeep(registrationParams);
+
+    assertEq(usdToken18.balanceOf(address(registrar)), amount);
+    assertEq(registry.getNumUpkeeps(), 0);
+
+    uint256 startRegistrarBalance = usdToken18.balanceOf(address(registrar));
+    uint256 startRegistryBalance = usdToken18.balanceOf(address(registry));
+
+    // approve the upkeep
+    vm.startPrank(OWNER);
+    registrar.approve(registrationParams);
+
+    uint256 endRegistrarBalance = usdToken18.balanceOf(address(registrar));
+    uint256 endRegistryBalance = usdToken18.balanceOf(address(registry));
+
+    assertEq(startRegistrarBalance - amount, endRegistrarBalance);
+    assertEq(startRegistryBalance + amount, endRegistryBalance);
   }
 }
 
@@ -75,6 +157,7 @@ contract RegisterUpkeep is SetUp {
   }
 
   function testLink_autoApproveOn_happy() external {
+    vm.startPrank(OWNER);
     registrar.setTriggerConfig(0, AutomationRegistrar2_3.AutoApproveType.ENABLED_ALL, 1000);
 
     vm.startPrank(UPKEEP_ADMIN);
@@ -103,6 +186,7 @@ contract RegisterUpkeep is SetUp {
   }
 
   function testUSDToken_autoApproveOn_happy() external {
+    vm.startPrank(OWNER);
     registrar.setTriggerConfig(0, AutomationRegistrar2_3.AutoApproveType.ENABLED_ALL, 1000);
 
     vm.startPrank(UPKEEP_ADMIN);
@@ -131,6 +215,7 @@ contract RegisterUpkeep is SetUp {
   }
 
   function testNative_autoApproveOn_happy() external {
+    vm.startPrank(OWNER);
     registrar.setTriggerConfig(0, AutomationRegistrar2_3.AutoApproveType.ENABLED_ALL, 1000);
 
     vm.startPrank(UPKEEP_ADMIN);
@@ -239,6 +324,82 @@ contract RegisterUpkeep is SetUp {
 
     // attempt to register the same upkeep again
     vm.expectRevert(AutomationRegistrar2_3.DuplicateEntry.selector);
+    registrar.registerUpkeep(params);
+  }
+
+  function test_revertOnInsufficientPayment() external {
+    vm.startPrank(UPKEEP_ADMIN);
+
+    // slightly less than the minimum amount
+    uint96 amount = uint96(registrar.getMinimumRegistrationAmount(IERC20(address(linkToken))) - 1);
+    linkToken.approve(address(registrar), amount);
+
+    AutomationRegistrar2_3.RegistrationParams memory params = AutomationRegistrar2_3.RegistrationParams({
+      upkeepContract: address(TARGET1),
+      amount: amount,
+      adminAddress: UPKEEP_ADMIN,
+      gasLimit: 10_000,
+      triggerType: 0,
+      billingToken: IERC20(address(linkToken)),
+      name: "foobar",
+      encryptedEmail: "",
+      checkData: bytes("check data"),
+      triggerConfig: "",
+      offchainConfig: ""
+    });
+
+    // attempt to register but revert bc of insufficient payment
+    vm.expectRevert(AutomationRegistrar2_3.InsufficientPayment.selector);
+    registrar.registerUpkeep(params);
+  }
+
+  function test_revertOnInvalidAdminAddress() external {
+    vm.startPrank(UPKEEP_ADMIN);
+
+    uint96 amount = uint96(registrar.getMinimumRegistrationAmount(IERC20(address(linkToken))));
+    linkToken.approve(address(registrar), amount);
+
+    AutomationRegistrar2_3.RegistrationParams memory params = AutomationRegistrar2_3.RegistrationParams({
+      upkeepContract: address(TARGET1),
+      amount: amount,
+      adminAddress: ZERO_ADDRESS, // zero address is invalid
+      gasLimit: 10_000,
+      triggerType: 0,
+      billingToken: IERC20(address(linkToken)),
+      name: "foobar",
+      encryptedEmail: "",
+      checkData: bytes("check data"),
+      triggerConfig: "",
+      offchainConfig: ""
+    });
+
+    // attempt to register but revert bc of invalid admin address
+    vm.expectRevert(AutomationRegistrar2_3.InvalidAdminAddress.selector);
+    registrar.registerUpkeep(params);
+  }
+
+  function test_revertOnInvalidBillingToken() external {
+    vm.startPrank(UPKEEP_ADMIN);
+
+    uint96 amount = 1;
+    usdToken18_2.approve(address(registrar), amount);
+
+    AutomationRegistrar2_3.RegistrationParams memory params = AutomationRegistrar2_3.RegistrationParams({
+      upkeepContract: address(TARGET1),
+      amount: amount,
+      adminAddress: UPKEEP_ADMIN,
+      gasLimit: 10_000,
+      triggerType: 0,
+      billingToken: IERC20(address(usdToken18_2)), // unsupported billing token
+      name: "foobar",
+      encryptedEmail: "",
+      checkData: bytes("check data"),
+      triggerConfig: "",
+      offchainConfig: ""
+    });
+
+    // attempt to register but revert bc of invalid admin address
+    vm.expectRevert(AutomationRegistrar2_3.InvalidBillingToken.selector);
     registrar.registerUpkeep(params);
   }
 }

--- a/contracts/src/v0.8/automation/dev/test/BaseTest.t.sol
+++ b/contracts/src/v0.8/automation/dev/test/BaseTest.t.sol
@@ -43,6 +43,7 @@ contract BaseTest is Test {
   LinkToken internal linkToken;
   ERC20Mock6Decimals internal usdToken6;
   ERC20Mock internal usdToken18;
+  ERC20Mock internal usdToken18_2;
   WETH9 internal weth;
   MockV3Aggregator internal LINK_USD_FEED;
   MockV3Aggregator internal NATIVE_USD_FEED;
@@ -76,6 +77,7 @@ contract BaseTest is Test {
     linkToken = new LinkToken();
     linkToken.grantMintRole(OWNER);
     usdToken18 = new ERC20Mock("MOCK_ERC20_18Decimals", "MOCK_ERC20_18Decimals", OWNER, 0);
+    usdToken18_2 = new ERC20Mock("Second_MOCK_ERC20_18Decimals", "Second_MOCK_ERC20_18Decimals", OWNER, 0);
     usdToken6 = new ERC20Mock6Decimals("MOCK_ERC20_6Decimals", "MOCK_ERC20_6Decimals", OWNER, 0);
     weth = new WETH9();
 
@@ -127,6 +129,8 @@ contract BaseTest is Test {
     usdToken18.mint(UPKEEP_ADMIN, 1000e18);
     usdToken18.mint(FINANCE_ADMIN, 1000e18);
     usdToken18.mint(STRANGER, 1000e18);
+
+    usdToken18_2.mint(UPKEEP_ADMIN, 1000e18);
 
     usdToken6.mint(OWNER, 1000e6);
     usdToken6.mint(UPKEEP_ADMIN, 1000e6);


### PR DESCRIPTION
More in AUTO-10143

**registerUpkeep in registrar**

Existing:

testLink_autoApproveOff_happy
testLink_autoApproveOn_happy


testUSDToken_autoApproveOff_happy
testUSDToken_autoApproveOn_happy


testNative_autoApproveOn_happy
testNative_autoApproveOff_msgValue0
testNative_autoApproveOff_msgValueNot0


testLink_autoApproveOff_revertOnDuplicateEntry


New:
testLink_revertOnInsufficientPayment
testLink_revertOnInvalidAdminAddress
testLink_revertOnInvalidBillingToken

**approve in registrar**
New:
testUSDToken_happy

**cancel in registrar**
New:
testUSDToken_happy


**AddFunds in registry** is very well convered, just updated the name:
testNative_msgValue0: this covers **Native**
testNative_msgValueNot0: this covers **Native**
test_RevertsWhen_NativePaymentDoesntMatchBillingToken
test_RevertsWhen_UpkeepDoesNotExist
test_RevertsWhen_UpkeepIsCanceled
test_anyoneCanAddFunds
test_movesFundFromCorrectToken: this covers **LINK and USD**
test_emitsAnEvent
