### PR TITLE
add version to changeset release preview pr

### DIFF
--- a/.changeset/pink-sloths-lay.md
+++ b/.changeset/pink-sloths-lay.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Test changeset release preview PR with version title

--- a/.changeset/pink-sloths-lay.md
+++ b/.changeset/pink-sloths-lay.md
@@ -1,5 +1,0 @@
----
-"chainlink": patch
----
-
-Test changeset release preview PR with version title

--- a/.github/workflows/cicd-changesets.yml
+++ b/.github/workflows/cicd-changesets.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - develop
+      - re-2553/add-version-release-preview-pr # remove after testing
 
 jobs:
   cicd-changesets:
@@ -28,6 +29,29 @@ jobs:
             core-changeset:
               - added: '.changeset/**'
 
+      - name: Setup pnpm
+        uses: pnpm/action-setup@a3252b78c470c02df07e9d59298aecedc3ccdd6d # v3.0.0
+        if: steps.changeset-added.outputs.core-changeset == 'true'
+        with:
+          version: ^8.0.0
+
+      - name: Setup node
+        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+        if: steps.changeset-added.outputs.core-changeset == 'true'
+        with:
+          node-version: 20
+          cache: pnpm
+          cache-dependency-path: ./pnpm-lock.yaml
+
+      - name: Run changeset version
+        run: pnpm install && pnpm changeset version
+        if: steps.changeset-added.outputs.core-changeset == 'true'
+
+      - name: Get release version
+        if: steps.changeset-added.outputs.core-changeset == 'true'
+        id: get-release-version
+        run: VERSION=$(jq -r '.version' package.json) >> $GITHUB_OUTPUT
+
       - name: cicd-changesets
         if: steps.changeset-added.outputs.core-changeset == 'true'
         uses: smartcontractkit/.github/actions/cicd-changesets@6da79c7b9f14bec077df2c1ad40d53823b409d9c # cicd-changesets@0.3.3
@@ -37,7 +61,7 @@ jobs:
           git-email: app-token-issuer-releng[bot]@users.noreply.github.com
           pnpm-use-cache: false
           pr-draft: true
-          pr-title: "[DO NOT MERGE] Release Preview - Changeset"
+          pr-title: "[DO NOT MERGE] Changeset Release Preview - v${{ steps.get-release-version.outputs.VERSION }}"
           # aws inputs
           aws-region: ${{ secrets.AWS_REGION }}
           aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_CI_AUTO_PR_TOKEN_ISSUER_ROLE_ARN }}

--- a/.github/workflows/cicd-changesets.yml
+++ b/.github/workflows/cicd-changesets.yml
@@ -17,6 +17,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      users: read
+      statuses: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/cicd-changesets.yml
+++ b/.github/workflows/cicd-changesets.yml
@@ -18,7 +18,6 @@ jobs:
       id-token: write
       contents: read
       actions: read
-      repository-projects: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -54,7 +53,7 @@ jobs:
       - name: Get release version
         if: steps.changeset-added.outputs.core-changeset == 'true'
         id: get-release-version
-        run: VERSION=$(jq -r '.version' package.json) >> $GITHUB_OUTPUT
+        run: echo "version=$(jq -r '.version' package.json)" >> $GITHUB_OUTPUT
 
       - name: cicd-changesets
         if: steps.changeset-added.outputs.core-changeset == 'true'
@@ -65,7 +64,7 @@ jobs:
           git-email: app-token-issuer-releng[bot]@users.noreply.github.com
           pnpm-use-cache: false
           pr-draft: true
-          pr-title: "[DO NOT MERGE] Changeset Release Preview - v${{ steps.get-release-version.outputs.VERSION }}"
+          pr-title: "[DO NOT MERGE] Changeset Release Preview - v${{ steps.get-release-version.outputs.version }}"
           # aws inputs
           aws-region: ${{ secrets.AWS_REGION }}
           aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_CI_AUTO_PR_TOKEN_ISSUER_ROLE_ARN }}

--- a/.github/workflows/cicd-changesets.yml
+++ b/.github/workflows/cicd-changesets.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - develop
-      - re-2553/add-version-release-preview-pr # remove after testing
 
 jobs:
   cicd-changesets:

--- a/.github/workflows/cicd-changesets.yml
+++ b/.github/workflows/cicd-changesets.yml
@@ -17,7 +17,8 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      workflows: read
+      actions: read
+      repository-projects: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/cicd-changesets.yml
+++ b/.github/workflows/cicd-changesets.yml
@@ -17,6 +17,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+      workflow: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2

--- a/.github/workflows/cicd-changesets.yml
+++ b/.github/workflows/cicd-changesets.yml
@@ -17,8 +17,6 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      users: read
-      statuses: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
@@ -47,6 +45,8 @@ jobs:
 
       - name: Run changeset version
         run: pnpm install && pnpm changeset version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         if: steps.changeset-added.outputs.core-changeset == 'true'
 
       - name: Get release version

--- a/.github/workflows/cicd-changesets.yml
+++ b/.github/workflows/cicd-changesets.yml
@@ -17,7 +17,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
-      workflow: read
+      workflows: read
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2


### PR DESCRIPTION
This adds the version for release preview PR from cicd-changeset workflow.

Tested here:
https://github.com/smartcontractkit/chainlink/pull/13035
