### PR TITLE
exclude build-image gha if just changing changelog

### DIFF
--- a/.github/workflows/build-publish-pr.yml
+++ b/.github/workflows/build-publish-pr.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build-publish-untrusted:
-    if: ${{ ! startsWith(github.ref_name, 'release/') }}
+    if: ${{ ! startsWith(github.ref_name, 'release/') || (! startsWith(github.head_ref, 'release/') && ! startsWith(github.ref_name, 'chore/'))}}
     runs-on: ubuntu-20.04
     environment: sdlc
     permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
               - '!tools/**'
 
       - name: Build chainlink image
-        if: ${{ steps.change.outputs.changelog-only == 'true' }}
+        if: ${{ steps.change.outputs.changelog-only == 'false' }}
         uses: ./.github/actions/build-sign-publish-chainlink
         with:
           dockerhub_username: ${{ secrets.DOCKERHUB_READONLY_USERNAME }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,17 +6,39 @@ on:
 jobs:
   build-chainlink:
     runs-on: ubuntu-20.04
+    if: ${{ ! startsWith(github.head_ref, 'release/') && ! startsWith(github.ref_name, 'chore/') }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@9bb56186c3b09b4f86b1c65136769dd318469633 # v4.1.2
 
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: change
+        with:
+          predicate-quantifier: every
+          filters: |
+            changelog-only:
+              - 'CHANGELOG.md'
+              - '!common/**'
+              - '!contracts/**'
+              - '!core/**'
+              - '!crib/**'
+              - '!dashboard-lib/**'
+              - '!fuzz/**'
+              - '!integration-tests/**'
+              - '!internal/**'
+              - '!operator_ui/**'
+              - '!plugins/**'
+              - '!tools/**'
+
       - name: Build chainlink image
+        if: ${{ steps.change.outputs.changelog-only == 'true' }}
         uses: ./.github/actions/build-sign-publish-chainlink
         with:
           dockerhub_username: ${{ secrets.DOCKERHUB_READONLY_USERNAME }}
           dockerhub_password: ${{ secrets.DOCKERHUB_READONLY_PASSWORD }}
           publish: false
           sign-images: false
+
       - name: Collect Metrics
         if: always()
         id: collect-gha-metrics


### PR DESCRIPTION
This updates the build-image workflow to exclude building the chainlink image if we are only updating the `CHANGELOG.md` file.
