### PR TITLE
Skip multi-node.txtar test due to high flake rate

### DIFF
--- a/testdata/scripts/metrics/multi-node.txtar
+++ b/testdata/scripts/metrics/multi-node.txtar
@@ -1,3 +1,4 @@
+skip 'High Flake Rate'
 # Check that metrics specified in the expected_metrics are present in /metrics response
 # start node
 exec sh -c 'eval "echo \"$(cat config.toml.tmpl)\" > config.toml"'


### PR DESCRIPTION
Skipping for now until resolved. See https://smartcontract-it.atlassian.net/browse/BCF-3215 for context