### PR TITLE
Handle reorgs in the automation log buffer

### DIFF
--- a/.changeset/dirty-lemons-cough.md
+++ b/.changeset/dirty-lemons-cough.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+Handle reorgs in the automation log buffer #changed

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -174,18 +174,12 @@ func (b *logBuffer) Enqueue(uid *big.Int, logs ...logpoller.Log) (int, int) {
 }
 
 func (b *logBuffer) evictReorgdLogs(reorgBlocks map[int64]bool) {
-	for upkeepID, queue := range b.queues {
-		logs := queue.logs
-		for i := len(logs) - 1; i >= 0; i-- {
-			for blockNumber := range reorgBlocks {
-				if blockNumber == logs[i].BlockNumber {
-					logs = append(logs[:i], logs[i+1:]...)
-					break
-				}
+	for _, queue := range b.queues {
+		for blockNumber := range reorgBlocks {
+			if _, ok := queue.logs[blockNumber]; ok {
+				queue.logs[blockNumber] = []logpoller.Log{}
 			}
 		}
-		queue.logs = logs
-		b.queues[upkeepID] = queue
 	}
 }
 
@@ -311,7 +305,8 @@ type upkeepLogQueue struct {
 	opts *logBufferOptions
 
 	// logs is the buffer of logs for the upkeep
-	logs []logpoller.Log
+	blockNumbers []int64
+	logs         map[int64][]logpoller.Log
 	// states keeps track of the state of the logs that are known to the queue
 	// and the block number they were seen at
 	states map[string]logTriggerStateEntry
@@ -319,13 +314,14 @@ type upkeepLogQueue struct {
 }
 
 func newUpkeepLogQueue(lggr logger.Logger, id *big.Int, opts *logBufferOptions) *upkeepLogQueue {
-	maxLogs := int(opts.windowLimit.Load()) * opts.windows() // limit per window * windows
+	//maxLogs := int(opts.windowLimit.Load()) * opts.windows() // limit per window * windows
 	return &upkeepLogQueue{
-		lggr:   lggr.With("upkeepID", id.String()),
-		id:     id,
-		opts:   opts,
-		logs:   make([]logpoller.Log, 0, maxLogs),
-		states: make(map[string]logTriggerStateEntry),
+		lggr:         lggr.With("upkeepID", id.String()),
+		id:           id,
+		opts:         opts,
+		logs:         map[int64][]logpoller.Log{},
+		states:       make(map[string]logTriggerStateEntry),
+		blockNumbers: make([]int64, 0),
 	}
 }
 
@@ -335,9 +331,9 @@ func (q *upkeepLogQueue) sizeOfRange(start, end int64) int {
 	defer q.lock.RUnlock()
 
 	size := 0
-	for _, l := range q.logs {
-		if l.BlockNumber >= start && l.BlockNumber <= end {
-			size++
+	for blockNumber, logList := range q.logs {
+		if blockNumber >= start && blockNumber <= end {
+			size += len(logList)
 		}
 	}
 	return size
@@ -355,25 +351,25 @@ func (q *upkeepLogQueue) dequeue(start, end int64, limit int) ([]logpoller.Log, 
 
 	var results []logpoller.Log
 	var remaining int
-	updatedLogs := make([]logpoller.Log, 0)
-	for _, l := range q.logs {
-		if l.BlockNumber >= start && l.BlockNumber <= end {
-			if len(results) < limit {
-				results = append(results, l)
-				lid := logID(l)
-				if s, ok := q.states[lid]; ok {
-					s.state = logTriggerStateDequeued
-					q.states[lid] = s
+
+	for _, blockNumber := range q.blockNumbers {
+		if blockNumber >= start && blockNumber <= end {
+			for _, l := range q.logs[blockNumber] {
+				if len(results) < limit {
+					results = append(results, l)
+					lid := logID(l)
+					if s, ok := q.states[lid]; ok {
+						s.state = logTriggerStateDequeued
+						q.states[lid] = s
+					}
+					continue
 				}
-				continue
+				remaining++
 			}
-			remaining++
 		}
-		updatedLogs = append(updatedLogs, l)
 	}
 
 	if len(results) > 0 {
-		q.logs = updatedLogs
 		q.lggr.Debugw("Dequeued logs", "start", start, "end", end, "limit", limit, "results", len(results), "remaining", remaining)
 	}
 
@@ -389,7 +385,6 @@ func (q *upkeepLogQueue) enqueue(blockThreshold int64, logsToAdd ...logpoller.Lo
 	q.lock.Lock()
 	defer q.lock.Unlock()
 
-	logs := q.logs
 	var added int
 	for _, log := range logsToAdd {
 		if log.BlockNumber < blockThreshold {
@@ -403,9 +398,16 @@ func (q *upkeepLogQueue) enqueue(blockThreshold int64, logsToAdd ...logpoller.Lo
 		}
 		q.states[lid] = logTriggerStateEntry{state: logTriggerStateEnqueued, block: log.BlockNumber}
 		added++
-		logs = append(logs, log)
+
+		if logList, ok := q.logs[log.BlockNumber]; ok {
+			logList = append(logList, log)
+			q.logs[log.BlockNumber] = logList
+		} else {
+			q.logs[log.BlockNumber] = []logpoller.Log{log}
+			q.blockNumbers = append(q.blockNumbers, log.BlockNumber)
+		}
+
 	}
-	q.logs = logs
 
 	var dropped int
 	if added > 0 {
@@ -426,9 +428,14 @@ func (q *upkeepLogQueue) orderLogs() {
 	// sort logs by block number, tx hash and log index
 	// to keep the q sorted and to ensure that logs can be
 	// grouped by block windows for the cleanup
-	sort.SliceStable(q.logs, func(i, j int) bool {
-		return LogSorter(q.logs[i], q.logs[j])
-	})
+
+	for _, blockNumber := range q.blockNumbers {
+		toSort := q.logs[blockNumber]
+		sort.SliceStable(toSort, func(i, j int) bool {
+			return LogSorter(toSort[i], toSort[j])
+		})
+		q.logs[blockNumber] = toSort
+	}
 }
 
 // clean removes logs that are older than blockThreshold and drops logs if the limit for the
@@ -439,47 +446,58 @@ func (q *upkeepLogQueue) clean(blockThreshold int64) int {
 	blockRate := int(q.opts.blockRate.Load())
 	windowLimit := int(q.opts.windowLimit.Load())
 	updated := make([]logpoller.Log, 0)
+	blockNumbers := make([]int64, 0)
 	// helper variables to keep track of the current window capacity
 	currentWindowCapacity, currentWindowStart := 0, int64(0)
-	for _, l := range q.logs {
-		if blockThreshold > l.BlockNumber { // old log, removed
-			prommetrics.AutomationLogBufferFlow.WithLabelValues(prommetrics.LogBufferFlowDirectionExpired).Inc()
-			// q.lggr.Debugw("Expiring old log", "blockNumber", l.BlockNumber, "blockThreshold", blockThreshold, "logIndex", l.LogIndex)
-			logid := logID(l)
-			delete(q.states, logid)
-			expired++
-			continue
-		}
-		start, _ := getBlockWindow(l.BlockNumber, blockRate)
-		if start != currentWindowStart {
-			// new window, reset capacity
-			currentWindowStart = start
-			currentWindowCapacity = 0
-		}
-		currentWindowCapacity++
-		// if capacity has been reached, drop the log
-		if currentWindowCapacity > windowLimit {
-			lid := logID(l)
-			if s, ok := q.states[lid]; ok {
-				s.state = logTriggerStateDropped
-				q.states[lid] = s
+	for _, blockNumber := range q.blockNumbers {
+		logs := q.logs[blockNumber]
+
+		if blockThreshold > blockNumber { // old log, removed
+			for _, l := range logs {
+				prommetrics.AutomationLogBufferFlow.WithLabelValues(prommetrics.LogBufferFlowDirectionExpired).Inc()
+				// q.lggr.Debugw("Expiring old log", "blockNumber", l.BlockNumber, "blockThreshold", blockThreshold, "logIndex", l.LogIndex)
+				logid := logID(l)
+				delete(q.states, logid)
+				expired++
 			}
-			dropped++
-			prommetrics.AutomationLogBufferFlow.WithLabelValues(prommetrics.LogBufferFlowDirectionDropped).Inc()
-			q.lggr.Debugw("Reached log buffer limits, dropping log", "blockNumber", l.BlockNumber,
-				"blockHash", l.BlockHash, "txHash", l.TxHash, "logIndex", l.LogIndex, "len updated", len(updated),
-				"currentWindowStart", currentWindowStart, "currentWindowCapacity", currentWindowCapacity,
-				"maxLogsPerWindow", windowLimit, "blockRate", blockRate)
-			continue
+			delete(q.logs, blockNumber)
+		} else {
+			blockNumbers = append(blockNumbers, blockNumber)
+
+			start, _ := getBlockWindow(blockNumber, blockRate)
+			if start != currentWindowStart {
+				// new window, reset capacity
+				currentWindowStart = start
+				currentWindowCapacity = 0
+			}
+
+			for _, l := range logs {
+				currentWindowCapacity++
+				// if capacity has been reached, drop the log
+				if currentWindowCapacity > windowLimit {
+					lid := logID(l)
+					if s, ok := q.states[lid]; ok {
+						s.state = logTriggerStateDropped
+						q.states[lid] = s
+					}
+					dropped++
+					prommetrics.AutomationLogBufferFlow.WithLabelValues(prommetrics.LogBufferFlowDirectionDropped).Inc()
+					q.lggr.Debugw("Reached log buffer limits, dropping log", "blockNumber", l.BlockNumber,
+						"blockHash", l.BlockHash, "txHash", l.TxHash, "logIndex", l.LogIndex, "len updated", len(updated),
+						"currentWindowStart", currentWindowStart, "currentWindowCapacity", currentWindowCapacity,
+						"maxLogsPerWindow", windowLimit, "blockRate", blockRate)
+				} else {
+					updated = append(updated, l)
+				}
+			}
 		}
-		updated = append(updated, l)
+		if dropped > 0 || expired > 0 {
+			q.lggr.Debugw("Cleaned logs", "dropped", dropped, "expired", expired, "blockThreshold", blockThreshold, "len updated", len(updated), "len before", len(q.logs))
+			q.logs[blockNumber] = updated
+		}
 	}
 
-	if dropped > 0 || expired > 0 {
-		q.lggr.Debugw("Cleaned logs", "dropped", dropped, "expired", expired, "blockThreshold", blockThreshold, "len updated", len(updated), "len before", len(q.logs))
-		q.logs = updated
-	}
-
+	q.blockNumbers = blockNumbers
 	q.cleanStates(blockThreshold)
 
 	return dropped

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -2,7 +2,6 @@ package logprovider
 
 import (
 	"context"
-	"math"
 	"math/big"
 	"sort"
 	"sync"
@@ -76,10 +75,6 @@ func (o *logBufferOptions) override(lookback, blockRate, logLimit uint32) {
 	o.windowLimit.Store(logLimit * 10)
 	o.lookback.Store(lookback)
 	o.blockRate.Store(blockRate)
-}
-
-func (o *logBufferOptions) windows() int {
-	return int(math.Ceil(float64(o.lookback.Load()) / float64(o.blockRate.Load())))
 }
 
 type logBuffer struct {
@@ -406,7 +401,6 @@ func (q *upkeepLogQueue) enqueue(blockThreshold int64, logsToAdd ...logpoller.Lo
 			q.logs[log.BlockNumber] = []logpoller.Log{log}
 			q.blockNumbers = append(q.blockNumbers, log.BlockNumber)
 		}
-
 	}
 
 	var dropped int

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -2,15 +2,17 @@ package logprovider
 
 import (
 	"context"
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/smartcontractkit/chainlink-common/pkg/services"
-	"github.com/smartcontractkit/chainlink-common/pkg/types/automation"
-	"github.com/smartcontractkit/chainlink/v2/core/utils"
 	"math"
 	"math/big"
 	"sort"
 	"sync"
 	"sync/atomic"
+
+	"github.com/ethereum/go-ethereum/common"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
+	"github.com/smartcontractkit/chainlink-common/pkg/types/automation"
+	"github.com/smartcontractkit/chainlink/v2/core/utils"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	"github.com/smartcontractkit/chainlink/v2/core/logger"

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -91,6 +91,7 @@ type logBuffer struct {
 	lock            sync.RWMutex
 	blockHashes     map[int64]string
 	latestBlockHash atomic.Pointer[common.Hash]
+	history         automation.BlockHistory
 	subID           int
 	blockChan       chan automation.BlockHistory
 	threadCtrl      utils.ThreadControl
@@ -140,6 +141,7 @@ func (b *logBuffer) listen(ctx context.Context) {
 		} else {
 			hash := common.Hash(latest.Hash)
 			b.latestBlockHash.Store(&hash)
+			b.history = history
 		}
 	}
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1_test.go
@@ -2,9 +2,10 @@ package logprovider
 
 import (
 	"context"
-	"github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 	"math/big"
 	"testing"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/factory.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/factory.go
@@ -1,9 +1,10 @@
 package logprovider
 
 import (
-	"github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 	"math/big"
 	"time"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/types/automation"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/integration_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/integration_test.go
@@ -2,13 +2,15 @@ package logprovider_test
 
 import (
 	"context"
-	htmocks "github.com/smartcontractkit/chainlink/v2/common/headtracker/mocks"
-	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
-	evm "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21"
-	"github.com/stretchr/testify/mock"
 	"math/big"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/mock"
+
+	htmocks "github.com/smartcontractkit/chainlink/v2/common/headtracker/mocks"
+	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
+	evm "github.com/smartcontractkit/chainlink/v2/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21"
 
 	"github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/integration_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/integration_test.go
@@ -110,7 +110,9 @@ func TestIntegration_LogEventProvider(t *testing.T) {
 				// assuming that our service was closed and restarted,
 				// we should be able to backfill old logs and fetch new ones
 				filterStore := logprovider.NewUpkeepFilterStore()
-				logProvider2 := logprovider.NewLogProvider(logger.TestLogger(t), lp, big.NewInt(1), logprovider.NewLogEventsPacker(), filterStore, opts)
+
+				logProvider2, err := logprovider.NewLogProvider(logger.TestLogger(t), lp, big.NewInt(1), logprovider.NewLogEventsPacker(), filterStore, newMockBlockSubscriber(), opts)
+				require.NoError(t, err)
 
 				poll(backend.Commit())
 				go func() {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/log.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/log.go
@@ -80,6 +80,7 @@ func (b *logBuffer) blockStatistics(logs ...logpoller.Log) (int64, map[int64]boo
 	// if we see a reorg, update the stored hashes for the reorg blocks, and collect the reorg block numbers
 	// so that we can later evict logs for those block numbers
 	if subscriberLatest != nil && history != nil && subscriberLatest.String() != latestBlockHash.String() {
+		b.lggr.Debugw("latest block hash does not match subscriber latest, assuming reorg")
 		for _, block := range *history {
 			historyBlockNumber := int64(block.Number)
 			historyBlockHash := common.Hash(block.Hash).String()

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/log.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/log.go
@@ -2,6 +2,7 @@ package logprovider
 
 import (
 	"encoding/hex"
+
 	"github.com/ethereum/go-ethereum/common"
 
 	ocr2keepers "github.com/smartcontractkit/chainlink-common/pkg/types/automation"

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -227,9 +227,8 @@ func (p *logEventProvider) Close() error {
 
 		if p.opts.BufferVersion == BufferVersionV1 {
 			return p.bufferV1.Close()
-		} else {
-			return nil
 		}
+		return nil
 	})
 }
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -215,9 +215,9 @@ func (p *logEventProvider) Start(ctx context.Context) error {
 
 		if p.opts.BufferVersion == BufferVersionV1 {
 			return p.bufferV1.Start(ctx)
-		} else {
-			return nil
 		}
+
+		return nil
 	})
 }
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_life_cycle_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_life_cycle_test.go
@@ -100,7 +100,8 @@ func TestLogEventProvider_LifeCycle(t *testing.T) {
 		},
 	}
 
-	p := NewLogProvider(logger.TestLogger(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
+	p, err := NewLogProvider(logger.TestLogger(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), newMockBlockSubscriber(), NewOptions(200, big.NewInt(1)))
+	require.NoError(t, err)
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
@@ -152,7 +153,8 @@ func TestEventLogProvider_RefreshActiveUpkeeps(t *testing.T) {
 	mp.On("LatestBlock", mock.Anything).Return(logpoller.LogPollerBlock{}, nil)
 	mp.On("ReplayAsync", mock.Anything).Return(nil)
 
-	p := NewLogProvider(logger.TestLogger(t), mp, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
+	p, err := NewLogProvider(logger.TestLogger(t), mp, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), newMockBlockSubscriber(), NewOptions(200, big.NewInt(1)))
+	require.NoError(t, err)
 
 	require.NoError(t, p.RegisterFilter(ctx, FilterOptions{
 		UpkeepID: core.GenUpkeepID(types.LogTrigger, "1111").BigInt(),
@@ -231,7 +233,8 @@ func TestLogEventProvider_ValidateLogTriggerConfig(t *testing.T) {
 		},
 	}
 
-	p := NewLogProvider(logger.TestLogger(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
+	p, err := NewLogProvider(logger.TestLogger(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), newMockBlockSubscriber(), NewOptions(200, big.NewInt(1)))
+	require.NoError(t, err)
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			err := p.validateLogTriggerConfig(tc.cfg)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -21,7 +21,8 @@ import (
 )
 
 func TestLogEventProvider_GetFilters(t *testing.T) {
-	p := NewLogProvider(logger.TestLogger(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
+	p, err := NewLogProvider(logger.TestLogger(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), newMockBlockSubscriber(), NewOptions(200, big.NewInt(1)))
+	require.NoError(t, err)
 
 	_, f := newEntry(p, 1)
 	p.filterStore.AddActiveUpkeeps(f)
@@ -63,8 +64,8 @@ func TestLogEventProvider_GetFilters(t *testing.T) {
 }
 
 func TestLogEventProvider_UpdateEntriesLastPoll(t *testing.T) {
-	p := NewLogProvider(logger.TestLogger(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), NewOptions(200, big.NewInt(1)))
-
+	p, err := NewLogProvider(logger.TestLogger(t), nil, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), newMockBlockSubscriber(), NewOptions(200, big.NewInt(1)))
+	require.NoError(t, err)
 	n := 10
 
 	// entries := map[string]upkeepFilter{}
@@ -179,7 +180,8 @@ func TestLogEventProvider_ScheduleReadJobs(t *testing.T) {
 			opts := NewOptions(200, big.NewInt(1))
 			opts.ReadInterval = readInterval
 
-			p := NewLogProvider(logger.TestLogger(t), mp, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), opts)
+			p, err := NewLogProvider(logger.TestLogger(t), mp, big.NewInt(1), &mockedPacker{}, NewUpkeepFilterStore(), newMockBlockSubscriber(), opts)
+			require.NoError(t, err)
 
 			var ids []*big.Int
 			for i, id := range tc.ids {
@@ -254,8 +256,8 @@ func TestLogEventProvider_ReadLogs(t *testing.T) {
 	}, nil)
 
 	filterStore := NewUpkeepFilterStore()
-	p := NewLogProvider(logger.TestLogger(t), mp, big.NewInt(1), &mockedPacker{}, filterStore, NewOptions(200, big.NewInt(1)))
-
+	p, err := NewLogProvider(logger.TestLogger(t), mp, big.NewInt(1), &mockedPacker{}, filterStore, newMockBlockSubscriber(), NewOptions(200, big.NewInt(1)))
+	require.NoError(t, err)
 	var ids []*big.Int
 	for i := 0; i < 10; i++ {
 		cfg, f := newEntry(p, i+1)

--- a/core/services/relay/evm/ocr2keeper.go
+++ b/core/services/relay/evm/ocr2keeper.go
@@ -131,7 +131,7 @@ func (r *ocr2keeperRelayer) NewOCR2KeeperProvider(rargs commontypes.RelayArgs, p
 	if err != nil {
 		return nil, err
 	}
-	
+
 	services.logEventProvider = logProvider
 	services.logRecoverer = logRecoverer
 	services.blockSubscriber = blockSubscriber

--- a/core/services/relay/evm/ocr2keeper.go
+++ b/core/services/relay/evm/ocr2keeper.go
@@ -126,10 +126,14 @@ func (r *ocr2keeperRelayer) NewOCR2KeeperProvider(rargs commontypes.RelayArgs, p
 	scanner := upkeepstate.NewPerformedEventsScanner(r.lggr, client.LogPoller(), addr, finalityDepth)
 	services.upkeepStateStore = upkeepstate.NewUpkeepStateStore(orm, r.lggr, scanner)
 
-	logProvider, logRecoverer := logprovider.New(r.lggr, client.LogPoller(), client.Client(), services.upkeepStateStore, finalityDepth, client.ID())
+	blockSubscriber := evm.NewBlockSubscriber(client.HeadBroadcaster(), client.LogPoller(), finalityDepth, r.lggr)
+	logProvider, logRecoverer, err := logprovider.New(r.lggr, client.LogPoller(), client.Client(), services.upkeepStateStore, finalityDepth, client.ID(), blockSubscriber)
+	if err != nil {
+		return nil, err
+	}
+	
 	services.logEventProvider = logProvider
 	services.logRecoverer = logRecoverer
-	blockSubscriber := evm.NewBlockSubscriber(client.HeadBroadcaster(), client.LogPoller(), finalityDepth, r.lggr)
 	services.blockSubscriber = blockSubscriber
 
 	al := evm.NewActiveUpkeepList()


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/AUTO-10013

In this PR, we're:

- Restructuring the log queues so that rather than a map of upkeep ID -> log list, we store a map of upkeep ID -> blockNumber -> log list
- Passing the block subscriber to the log buffer so that the buffer can cross reference the latest block seen in an enqueue, with the latest block reported by the block subscriber
- In the event that the latest block from the subscriber and the latest block seen in an enqueue do not match, we assume a reorg has happened and evict logs for all blocks whose hashes do not match those provided in the block history provided by the block subscriber