### PR TITLE
Fix race condition in Poller tests

### DIFF
--- a/common/client/poller.go
+++ b/common/client/poller.go
@@ -27,10 +27,11 @@ type Poller[T any] struct {
 	wg     sync.WaitGroup
 }
 
-// NewPoller creates a new Poller instance
+// NewPoller creates a new Poller instance and returns a channel to receive the polled data
 func NewPoller[
 	T any,
-](pollingInterval time.Duration, pollingFunc func(ctx context.Context) (T, error), pollingTimeout time.Duration, channel chan<- T, logger logger.Logger) Poller[T] {
+](pollingInterval time.Duration, pollingFunc func(ctx context.Context) (T, error), pollingTimeout time.Duration, logger logger.Logger) (Poller[T], <-chan T) {
+	channel := make(chan T)
 	return Poller[T]{
 		pollingInterval: pollingInterval,
 		pollingFunc:     pollingFunc,
@@ -39,7 +40,7 @@ func NewPoller[
 		logger:          logger,
 		errCh:           make(chan error),
 		stopCh:          make(chan struct{}),
-	}
+	}, channel
 }
 
 var _ types.Subscription = &Poller[any]{}
@@ -58,6 +59,7 @@ func (p *Poller[T]) Unsubscribe() {
 		close(p.stopCh)
 		p.wg.Wait()
 		close(p.errCh)
+		close(p.channel)
 		return nil
 	})
 }

--- a/common/client/poller_test.go
+++ b/common/client/poller_test.go
@@ -173,4 +173,13 @@ func Test_Poller_Unsubscribe(t *testing.T) {
 		poller.Unsubscribe()
 		poller.Unsubscribe()
 	})
+
+	t.Run("Read channel after unsubscribe", func(t *testing.T) {
+		poller, channel := NewPoller[Head](time.Millisecond, pollFunc, time.Second, lggr)
+		err := poller.Start()
+		require.NoError(t, err)
+
+		poller.Unsubscribe()
+		require.Equal(t, <-channel, nil)
+	})
 }


### PR DESCRIPTION
Update the Poller to return a channel rather than accept one. This prevents a user from closing the channel and in turn a race condition from occurring if the channel is closed before sending which causes a panic.