### PR TITLE
changed spammy error log to debug

### DIFF
--- a/core/services/pipeline/runner.go
+++ b/core/services/pipeline/runner.go
@@ -457,18 +457,14 @@ func (r *runner) run(ctx context.Context, pipeline *Pipeline, run *Run, vars Var
 			"run.Inputs", run.Inputs,
 		)
 	}
-	if run.HasFatalErrors() {
-		l = l.With("run.FatalErrors", run.FatalErrors)
-	}
-	if run.HasErrors() {
-		l = l.With("run.AllErrors", run.AllErrors)
-	}
 	l = l.With("run.State", run.State, "fatal", run.HasFatalErrors(), "runTime", runTime)
 	if run.HasFatalErrors() {
 		// This will also log at error level in OCR if it fails Observe so the
 		// level is appropriate
-		l.Errorw("Completed pipeline run with fatal errors")
+		l = l.With("run.FatalErrors", run.FatalErrors)
+		l.Debugw("Completed pipeline run with fatal errors")
 	} else if run.HasErrors() {
+		l = l.With("run.AllErrors", run.AllErrors)
 		l.Debugw("Completed pipeline run with errors")
 	} else {
 		l.Debugw("Completed pipeline run successfully")


### PR DESCRIPTION
https://github.com/smartcontractkit/chainlink/commit/1c576d0e34d93a6298ddcb662ee89fd04eeda53e added more logs. At https://github.com/smartcontractkit/chainlink/blame/be50a8370a0f604fbe9612e38479ccfa5ceb1ebd/core/services/pipeline/runner.go#L416 we add all errors to fatal errors by default. With the linked commit, we now log all fatal errors, so now all errors are counted as fatal and logged at the Error level. `ErrCanceled` is such an error that does not need to be logged at the Error level. Changed to debug level.