### PR TITLE
README.md: Link to new nixos wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,13 +272,13 @@ Go generate is used to generate mocks in this project. Mocks are generated with 
 
 ### Nix
 
-A [shell.nix](https://nixos.wiki/wiki/Development_environment_with_nix-shell) is provided for use with the [Nix package manager](https://nixos.org/), with optional [flakes](https://nixos.wiki/wiki/Flakes) support. It defines a declarative, reproducible development environment. Flakes version use deterministic, frozen (`flake.lock`) dependencies, while non-flakes shell will use your channel's packages versions.
+A [shell.nix](https://wiki.nixos.org/wiki/Development_environment_with_nix-shell) is provided for use with the [Nix package manager](https://nixos.org/), with optional [flakes](https://wiki.nixos.org/wiki/Flakes) support. It defines a declarative, reproducible development environment. Flakes version use deterministic, frozen (`flake.lock`) dependencies, while non-flakes shell will use your channel's packages versions.
 
 To use it:
 
 1. Install [nix package manager](https://nixos.org/download.html) in your system.
 
-- Optionally, enable [flakes support](https://nixos.wiki/wiki/Flakes#Enable_flakes)
+- Optionally, enable [flakes support](https://wiki.nixos.org/wiki/Flakes#Enable_flakes)
 
 2. Run `nix-shell`. You will be put in shell containing all the dependencies.
 


### PR DESCRIPTION
This commit updates the the link from the former, unofficial nixos wiki page to the new https://wiki.nixos.org

ref: NixOS/foundation#113