### PR TITLE
golangci-lint: enable containedctx

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - noctx
     - depguard
     - whitespace
+    - containedctx
 linters-settings:
   exhaustive:
     default-signifies-exhaustive: true

--- a/common/client/node.go
+++ b/common/client/node.go
@@ -106,10 +106,7 @@ type node[
 	stateLatestTotalDifficulty      *big.Int
 	stateLatestFinalizedBlockNumber int64
 
-	// nodeCtx is the node lifetime's context
-	nodeCtx context.Context
-	// cancelNodeCtx cancels nodeCtx when stopping the node
-	cancelNodeCtx context.CancelFunc
+	stopCh services.StopChan
 	// wg waits for subsidiary goroutines
 	wg sync.WaitGroup
 
@@ -148,7 +145,7 @@ func NewNode[
 	if httpuri != nil {
 		n.http = httpuri
 	}
-	n.nodeCtx, n.cancelNodeCtx = context.WithCancel(context.Background())
+	n.stopCh = make(services.StopChan)
 	lggr = logger.Named(lggr, "Node")
 	lggr = logger.With(lggr,
 		"nodeTier", Primary.String(),
@@ -205,7 +202,7 @@ func (n *node[CHAIN_ID, HEAD, RPC]) close() error {
 	n.stateMu.Lock()
 	defer n.stateMu.Unlock()
 
-	n.cancelNodeCtx()
+	close(n.stopCh)
 	n.state = nodeStateClosed
 	return nil
 }

--- a/common/client/node_lifecycle.go
+++ b/common/client/node_lifecycle.go
@@ -79,6 +79,8 @@ const rpcSubscriptionMethodNewHeads = "newHeads"
 // Should only be run ONCE per node, after a successful Dial
 func (n *node[CHAIN_ID, HEAD, RPC]) aliveLoop() {
 	defer n.wg.Done()
+	ctx, cancel := n.stopCh.NewCtx()
+	defer cancel()
 
 	{
 		// sanity check
@@ -100,7 +102,7 @@ func (n *node[CHAIN_ID, HEAD, RPC]) aliveLoop() {
 	lggr.Tracew("Alive loop starting", "nodeState", n.State())
 
 	headsC := make(chan HEAD)
-	sub, err := n.rpc.Subscribe(n.nodeCtx, headsC, rpcSubscriptionMethodNewHeads)
+	sub, err := n.rpc.Subscribe(ctx, headsC, rpcSubscriptionMethodNewHeads)
 	if err != nil {
 		lggr.Errorw("Initial subscribe for heads failed", "nodeState", n.State())
 		n.declareUnreachable()
@@ -151,15 +153,16 @@ func (n *node[CHAIN_ID, HEAD, RPC]) aliveLoop() {
 
 	for {
 		select {
-		case <-n.nodeCtx.Done():
+		case <-ctx.Done():
 			return
 		case <-pollCh:
-			var version string
 			promPoolRPCNodePolls.WithLabelValues(n.chainID.String(), n.name).Inc()
 			lggr.Tracew("Polling for version", "nodeState", n.State(), "pollFailures", pollFailures)
-			ctx, cancel := context.WithTimeout(n.nodeCtx, pollInterval)
-			version, err := n.RPC().ClientVersion(ctx)
-			cancel()
+			version, err := func(ctx context.Context) (string, error) {
+				ctx, cancel := context.WithTimeout(ctx, pollInterval)
+				defer cancel()
+				return n.RPC().ClientVersion(ctx)
+			}(ctx)
 			if err != nil {
 				// prevent overflow
 				if pollFailures < math.MaxUint32 {
@@ -240,9 +243,11 @@ func (n *node[CHAIN_ID, HEAD, RPC]) aliveLoop() {
 			n.declareOutOfSync(func(num int64, td *big.Int) bool { return num < highestReceivedBlockNumber })
 			return
 		case <-pollFinalizedHeadCh:
-			ctx, cancel := context.WithTimeout(n.nodeCtx, n.nodePoolCfg.FinalizedBlockPollInterval())
-			latestFinalized, err := n.RPC().LatestFinalizedBlock(ctx)
-			cancel()
+			latestFinalized, err := func(ctx context.Context) (HEAD, error) {
+				ctx, cancel := context.WithTimeout(ctx, n.nodePoolCfg.FinalizedBlockPollInterval())
+				defer cancel()
+				return n.RPC().LatestFinalizedBlock(ctx)
+			}(ctx)
 			if err != nil {
 				lggr.Warnw("Failed to fetch latest finalized block", "err", err)
 				continue
@@ -300,6 +305,8 @@ const (
 // outOfSyncLoop takes an OutOfSync node and waits until isOutOfSync returns false to go back to live status
 func (n *node[CHAIN_ID, HEAD, RPC]) outOfSyncLoop(isOutOfSync func(num int64, td *big.Int) bool) {
 	defer n.wg.Done()
+	ctx, cancel := n.stopCh.NewCtx()
+	defer cancel()
 
 	{
 		// sanity check
@@ -319,7 +326,7 @@ func (n *node[CHAIN_ID, HEAD, RPC]) outOfSyncLoop(isOutOfSync func(num int64, td
 	lggr.Debugw("Trying to revive out-of-sync RPC node", "nodeState", n.State())
 
 	// Need to redial since out-of-sync nodes are automatically disconnected
-	state := n.createVerifiedConn(n.nodeCtx, lggr)
+	state := n.createVerifiedConn(ctx, lggr)
 	if state != nodeStateAlive {
 		n.declareState(state)
 		return
@@ -328,7 +335,7 @@ func (n *node[CHAIN_ID, HEAD, RPC]) outOfSyncLoop(isOutOfSync func(num int64, td
 	lggr.Tracew("Successfully subscribed to heads feed on out-of-sync RPC node", "nodeState", n.State())
 
 	ch := make(chan HEAD)
-	sub, err := n.rpc.Subscribe(n.nodeCtx, ch, rpcSubscriptionMethodNewHeads)
+	sub, err := n.rpc.Subscribe(ctx, ch, rpcSubscriptionMethodNewHeads)
 	if err != nil {
 		lggr.Errorw("Failed to subscribe heads on out-of-sync RPC node", "nodeState", n.State(), "err", err)
 		n.declareUnreachable()
@@ -338,7 +345,7 @@ func (n *node[CHAIN_ID, HEAD, RPC]) outOfSyncLoop(isOutOfSync func(num int64, td
 
 	for {
 		select {
-		case <-n.nodeCtx.Done():
+		case <-ctx.Done():
 			return
 		case head, open := <-ch:
 			if !open {
@@ -372,6 +379,8 @@ func (n *node[CHAIN_ID, HEAD, RPC]) outOfSyncLoop(isOutOfSync func(num int64, td
 
 func (n *node[CHAIN_ID, HEAD, RPC]) unreachableLoop() {
 	defer n.wg.Done()
+	ctx, cancel := n.stopCh.NewCtx()
+	defer cancel()
 
 	{
 		// sanity check
@@ -394,12 +403,12 @@ func (n *node[CHAIN_ID, HEAD, RPC]) unreachableLoop() {
 
 	for {
 		select {
-		case <-n.nodeCtx.Done():
+		case <-ctx.Done():
 			return
 		case <-time.After(dialRetryBackoff.Duration()):
 			lggr.Tracew("Trying to re-dial RPC node", "nodeState", n.State())
 
-			err := n.rpc.Dial(n.nodeCtx)
+			err := n.rpc.Dial(ctx)
 			if err != nil {
 				lggr.Errorw(fmt.Sprintf("Failed to redial RPC node; still unreachable: %v", err), "err", err, "nodeState", n.State())
 				continue
@@ -407,7 +416,7 @@ func (n *node[CHAIN_ID, HEAD, RPC]) unreachableLoop() {
 
 			n.setState(nodeStateDialed)
 
-			state := n.verifyConn(n.nodeCtx, lggr)
+			state := n.verifyConn(ctx, lggr)
 			switch state {
 			case nodeStateUnreachable:
 				n.setState(nodeStateUnreachable)
@@ -425,6 +434,8 @@ func (n *node[CHAIN_ID, HEAD, RPC]) unreachableLoop() {
 
 func (n *node[CHAIN_ID, HEAD, RPC]) invalidChainIDLoop() {
 	defer n.wg.Done()
+	ctx, cancel := n.stopCh.NewCtx()
+	defer cancel()
 
 	{
 		// sanity check
@@ -443,7 +454,7 @@ func (n *node[CHAIN_ID, HEAD, RPC]) invalidChainIDLoop() {
 	lggr := logger.Named(n.lfcLog, "InvalidChainID")
 
 	// Need to redial since invalid chain ID nodes are automatically disconnected
-	state := n.createVerifiedConn(n.nodeCtx, lggr)
+	state := n.createVerifiedConn(ctx, lggr)
 	if state != nodeStateInvalidChainID {
 		n.declareState(state)
 		return
@@ -455,10 +466,10 @@ func (n *node[CHAIN_ID, HEAD, RPC]) invalidChainIDLoop() {
 
 	for {
 		select {
-		case <-n.nodeCtx.Done():
+		case <-ctx.Done():
 			return
 		case <-time.After(chainIDRecheckBackoff.Duration()):
-			state := n.verifyConn(n.nodeCtx, lggr)
+			state := n.verifyConn(ctx, lggr)
 			switch state {
 			case nodeStateInvalidChainID:
 				continue
@@ -475,6 +486,8 @@ func (n *node[CHAIN_ID, HEAD, RPC]) invalidChainIDLoop() {
 
 func (n *node[CHAIN_ID, HEAD, RPC]) syncingLoop() {
 	defer n.wg.Done()
+	ctx, cancel := n.stopCh.NewCtx()
+	defer cancel()
 
 	{
 		// sanity check
@@ -493,7 +506,7 @@ func (n *node[CHAIN_ID, HEAD, RPC]) syncingLoop() {
 	lggr := logger.Sugared(logger.Named(n.lfcLog, "Syncing"))
 	lggr.Debugw(fmt.Sprintf("Periodically re-checking RPC node %s with syncing status", n.String()), "nodeState", n.State())
 	// Need to redial since syncing nodes are automatically disconnected
-	state := n.createVerifiedConn(n.nodeCtx, lggr)
+	state := n.createVerifiedConn(ctx, lggr)
 	if state != nodeStateSyncing {
 		n.declareState(state)
 		return
@@ -503,11 +516,11 @@ func (n *node[CHAIN_ID, HEAD, RPC]) syncingLoop() {
 
 	for {
 		select {
-		case <-n.nodeCtx.Done():
+		case <-ctx.Done():
 			return
 		case <-time.After(recheckBackoff.Duration()):
 			lggr.Tracew("Trying to recheck if the node is still syncing", "nodeState", n.State())
-			isSyncing, err := n.rpc.IsSyncing(n.nodeCtx)
+			isSyncing, err := n.rpc.IsSyncing(ctx)
 			if err != nil {
 				lggr.Errorw("Unexpected error while verifying RPC node synchronization status", "err", err, "nodeState", n.State())
 				n.declareUnreachable()

--- a/common/txmgr/mocks/tx_manager.go
+++ b/common/txmgr/mocks/tx_manager.go
@@ -273,9 +273,9 @@ func (_m *TxManager[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) FindTx
 	return r0, r1
 }
 
-// GetForwarderForEOA provides a mock function with given fields: eoa
-func (_m *TxManager[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) GetForwarderForEOA(eoa ADDR) (ADDR, error) {
-	ret := _m.Called(eoa)
+// GetForwarderForEOA provides a mock function with given fields: ctx, eoa
+func (_m *TxManager[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) GetForwarderForEOA(ctx context.Context, eoa ADDR) (ADDR, error) {
+	ret := _m.Called(ctx, eoa)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetForwarderForEOA")
@@ -283,17 +283,17 @@ func (_m *TxManager[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) GetFor
 
 	var r0 ADDR
 	var r1 error
-	if rf, ok := ret.Get(0).(func(ADDR) (ADDR, error)); ok {
-		return rf(eoa)
+	if rf, ok := ret.Get(0).(func(context.Context, ADDR) (ADDR, error)); ok {
+		return rf(ctx, eoa)
 	}
-	if rf, ok := ret.Get(0).(func(ADDR) ADDR); ok {
-		r0 = rf(eoa)
+	if rf, ok := ret.Get(0).(func(context.Context, ADDR) ADDR); ok {
+		r0 = rf(ctx, eoa)
 	} else {
 		r0 = ret.Get(0).(ADDR)
 	}
 
-	if rf, ok := ret.Get(1).(func(ADDR) error); ok {
-		r1 = rf(eoa)
+	if rf, ok := ret.Get(1).(func(context.Context, ADDR) error); ok {
+		r1 = rf(ctx, eoa)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -301,9 +301,9 @@ func (_m *TxManager[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) GetFor
 	return r0, r1
 }
 
-// GetForwarderForEOAOCR2Feeds provides a mock function with given fields: eoa, ocr2AggregatorID
-func (_m *TxManager[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) GetForwarderForEOAOCR2Feeds(eoa ADDR, ocr2AggregatorID ADDR) (ADDR, error) {
-	ret := _m.Called(eoa, ocr2AggregatorID)
+// GetForwarderForEOAOCR2Feeds provides a mock function with given fields: ctx, eoa, ocr2AggregatorID
+func (_m *TxManager[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) GetForwarderForEOAOCR2Feeds(ctx context.Context, eoa ADDR, ocr2AggregatorID ADDR) (ADDR, error) {
+	ret := _m.Called(ctx, eoa, ocr2AggregatorID)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetForwarderForEOAOCR2Feeds")
@@ -311,17 +311,17 @@ func (_m *TxManager[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) GetFor
 
 	var r0 ADDR
 	var r1 error
-	if rf, ok := ret.Get(0).(func(ADDR, ADDR) (ADDR, error)); ok {
-		return rf(eoa, ocr2AggregatorID)
+	if rf, ok := ret.Get(0).(func(context.Context, ADDR, ADDR) (ADDR, error)); ok {
+		return rf(ctx, eoa, ocr2AggregatorID)
 	}
-	if rf, ok := ret.Get(0).(func(ADDR, ADDR) ADDR); ok {
-		r0 = rf(eoa, ocr2AggregatorID)
+	if rf, ok := ret.Get(0).(func(context.Context, ADDR, ADDR) ADDR); ok {
+		r0 = rf(ctx, eoa, ocr2AggregatorID)
 	} else {
 		r0 = ret.Get(0).(ADDR)
 	}
 
-	if rf, ok := ret.Get(1).(func(ADDR, ADDR) error); ok {
-		r1 = rf(eoa, ocr2AggregatorID)
+	if rf, ok := ret.Get(1).(func(context.Context, ADDR, ADDR) error); ok {
+		r1 = rf(ctx, eoa, ocr2AggregatorID)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/common/txmgr/test_helpers.go
+++ b/common/txmgr/test_helpers.go
@@ -35,7 +35,9 @@ func (eb *Broadcaster[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) XXXT
 }
 
 func (ec *Confirmer[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) XXXTestStartInternal() error {
-	return ec.startInternal(ec.ctx)
+	ctx, cancel := ec.stopCh.NewCtx()
+	defer cancel()
+	return ec.startInternal(ctx)
 }
 
 func (ec *Confirmer[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) XXXTestCloseInternal() error {
@@ -43,7 +45,9 @@ func (ec *Confirmer[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) XXX
 }
 
 func (er *Resender[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) XXXTestResendUnconfirmed() error {
-	return er.resendUnconfirmed(er.ctx)
+	ctx, cancel := er.stopCh.NewCtx()
+	defer cancel()
+	return er.resendUnconfirmed(ctx)
 }
 
 func (b *Txm[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) XXXTestAbandon(addr ADDR) (err error) {

--- a/common/txmgr/txmgr.go
+++ b/common/txmgr/txmgr.go
@@ -46,8 +46,8 @@ type TxManager[
 	services.Service
 	Trigger(addr ADDR)
 	CreateTransaction(ctx context.Context, txRequest txmgrtypes.TxRequest[ADDR, TX_HASH]) (etx txmgrtypes.Tx[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE], err error)
-	GetForwarderForEOA(eoa ADDR) (forwarder ADDR, err error)
-	GetForwarderForEOAOCR2Feeds(eoa, ocr2AggregatorID ADDR) (forwarder ADDR, err error)
+	GetForwarderForEOA(ctx context.Context, eoa ADDR) (forwarder ADDR, err error)
+	GetForwarderForEOAOCR2Feeds(ctx context.Context, eoa, ocr2AggregatorID ADDR) (forwarder ADDR, err error)
 	RegisterResumeCallback(fn ResumeCallback)
 	SendNativeToken(ctx context.Context, chainID CHAIN_ID, from, to ADDR, value big.Int, gasLimit uint64) (etx txmgrtypes.Tx[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE], err error)
 	Reset(addr ADDR, abandon bool) error
@@ -546,20 +546,20 @@ func (b *Txm[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) CreateTran
 }
 
 // Calls forwarderMgr to get a proper forwarder for a given EOA.
-func (b *Txm[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) GetForwarderForEOA(eoa ADDR) (forwarder ADDR, err error) {
+func (b *Txm[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) GetForwarderForEOA(ctx context.Context, eoa ADDR) (forwarder ADDR, err error) {
 	if !b.txConfig.ForwardersEnabled() {
 		return forwarder, fmt.Errorf("forwarding is not enabled, to enable set Transactions.ForwardersEnabled =true")
 	}
-	forwarder, err = b.fwdMgr.ForwarderFor(eoa)
+	forwarder, err = b.fwdMgr.ForwarderFor(ctx, eoa)
 	return
 }
 
 // GetForwarderForEOAOCR2Feeds calls forwarderMgr to get a proper forwarder for a given EOA and checks if its set as a transmitter on the OCR2Aggregator contract.
-func (b *Txm[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) GetForwarderForEOAOCR2Feeds(eoa, ocr2Aggregator ADDR) (forwarder ADDR, err error) {
+func (b *Txm[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, R, SEQ, FEE]) GetForwarderForEOAOCR2Feeds(ctx context.Context, eoa, ocr2Aggregator ADDR) (forwarder ADDR, err error) {
 	if !b.txConfig.ForwardersEnabled() {
 		return forwarder, fmt.Errorf("forwarding is not enabled, to enable set Transactions.ForwardersEnabled =true")
 	}
-	forwarder, err = b.fwdMgr.ForwarderForOCR2Feeds(eoa, ocr2Aggregator)
+	forwarder, err = b.fwdMgr.ForwarderForOCR2Feeds(ctx, eoa, ocr2Aggregator)
 	return
 }
 
@@ -656,10 +656,10 @@ func (n *NullTxManager[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) Tri
 func (n *NullTxManager[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) CreateTransaction(ctx context.Context, txRequest txmgrtypes.TxRequest[ADDR, TX_HASH]) (etx txmgrtypes.Tx[CHAIN_ID, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE], err error) {
 	return etx, errors.New(n.ErrMsg)
 }
-func (n *NullTxManager[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) GetForwarderForEOA(addr ADDR) (fwdr ADDR, err error) {
+func (n *NullTxManager[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) GetForwarderForEOA(ctx context.Context, addr ADDR) (fwdr ADDR, err error) {
 	return fwdr, err
 }
-func (n *NullTxManager[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) GetForwarderForEOAOCR2Feeds(_, _ ADDR) (fwdr ADDR, err error) {
+func (n *NullTxManager[CHAIN_ID, HEAD, ADDR, TX_HASH, BLOCK_HASH, SEQ, FEE]) GetForwarderForEOAOCR2Feeds(ctx context.Context, _, _ ADDR) (fwdr ADDR, err error) {
 	return fwdr, err
 }
 

--- a/common/txmgr/types/forwarder_manager.go
+++ b/common/txmgr/types/forwarder_manager.go
@@ -1,15 +1,18 @@
 package types
 
 import (
+	"context"
+
 	"github.com/smartcontractkit/chainlink-common/pkg/services"
+
 	"github.com/smartcontractkit/chainlink/v2/common/types"
 )
 
 //go:generate mockery --quiet --name ForwarderManager --output ./mocks/ --case=underscore
 type ForwarderManager[ADDR types.Hashable] interface {
 	services.Service
-	ForwarderFor(addr ADDR) (forwarder ADDR, err error)
-	ForwarderForOCR2Feeds(eoa, ocr2Aggregator ADDR) (forwarder ADDR, err error)
+	ForwarderFor(ctx context.Context, addr ADDR) (forwarder ADDR, err error)
+	ForwarderForOCR2Feeds(ctx context.Context, eoa, ocr2Aggregator ADDR) (forwarder ADDR, err error)
 	// Converts payload to be forwarder-friendly
 	ConvertPayload(dest ADDR, origPayload []byte) ([]byte, error)
 }

--- a/common/txmgr/types/mocks/forwarder_manager.go
+++ b/common/txmgr/types/mocks/forwarder_manager.go
@@ -63,9 +63,9 @@ func (_m *ForwarderManager[ADDR]) ConvertPayload(dest ADDR, origPayload []byte) 
 	return r0, r1
 }
 
-// ForwarderFor provides a mock function with given fields: addr
-func (_m *ForwarderManager[ADDR]) ForwarderFor(addr ADDR) (ADDR, error) {
-	ret := _m.Called(addr)
+// ForwarderFor provides a mock function with given fields: ctx, addr
+func (_m *ForwarderManager[ADDR]) ForwarderFor(ctx context.Context, addr ADDR) (ADDR, error) {
+	ret := _m.Called(ctx, addr)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ForwarderFor")
@@ -73,17 +73,17 @@ func (_m *ForwarderManager[ADDR]) ForwarderFor(addr ADDR) (ADDR, error) {
 
 	var r0 ADDR
 	var r1 error
-	if rf, ok := ret.Get(0).(func(ADDR) (ADDR, error)); ok {
-		return rf(addr)
+	if rf, ok := ret.Get(0).(func(context.Context, ADDR) (ADDR, error)); ok {
+		return rf(ctx, addr)
 	}
-	if rf, ok := ret.Get(0).(func(ADDR) ADDR); ok {
-		r0 = rf(addr)
+	if rf, ok := ret.Get(0).(func(context.Context, ADDR) ADDR); ok {
+		r0 = rf(ctx, addr)
 	} else {
 		r0 = ret.Get(0).(ADDR)
 	}
 
-	if rf, ok := ret.Get(1).(func(ADDR) error); ok {
-		r1 = rf(addr)
+	if rf, ok := ret.Get(1).(func(context.Context, ADDR) error); ok {
+		r1 = rf(ctx, addr)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -91,9 +91,9 @@ func (_m *ForwarderManager[ADDR]) ForwarderFor(addr ADDR) (ADDR, error) {
 	return r0, r1
 }
 
-// ForwarderForOCR2Feeds provides a mock function with given fields: eoa, ocr2Aggregator
-func (_m *ForwarderManager[ADDR]) ForwarderForOCR2Feeds(eoa ADDR, ocr2Aggregator ADDR) (ADDR, error) {
-	ret := _m.Called(eoa, ocr2Aggregator)
+// ForwarderForOCR2Feeds provides a mock function with given fields: ctx, eoa, ocr2Aggregator
+func (_m *ForwarderManager[ADDR]) ForwarderForOCR2Feeds(ctx context.Context, eoa ADDR, ocr2Aggregator ADDR) (ADDR, error) {
+	ret := _m.Called(ctx, eoa, ocr2Aggregator)
 
 	if len(ret) == 0 {
 		panic("no return value specified for ForwarderForOCR2Feeds")
@@ -101,17 +101,17 @@ func (_m *ForwarderManager[ADDR]) ForwarderForOCR2Feeds(eoa ADDR, ocr2Aggregator
 
 	var r0 ADDR
 	var r1 error
-	if rf, ok := ret.Get(0).(func(ADDR, ADDR) (ADDR, error)); ok {
-		return rf(eoa, ocr2Aggregator)
+	if rf, ok := ret.Get(0).(func(context.Context, ADDR, ADDR) (ADDR, error)); ok {
+		return rf(ctx, eoa, ocr2Aggregator)
 	}
-	if rf, ok := ret.Get(0).(func(ADDR, ADDR) ADDR); ok {
-		r0 = rf(eoa, ocr2Aggregator)
+	if rf, ok := ret.Get(0).(func(context.Context, ADDR, ADDR) ADDR); ok {
+		r0 = rf(ctx, eoa, ocr2Aggregator)
 	} else {
 		r0 = ret.Get(0).(ADDR)
 	}
 
-	if rf, ok := ret.Get(1).(func(ADDR, ADDR) error); ok {
-		r1 = rf(eoa, ocr2Aggregator)
+	if rf, ok := ret.Get(1).(func(context.Context, ADDR, ADDR) error); ok {
+		r1 = rf(ctx, eoa, ocr2Aggregator)
 	} else {
 		r1 = ret.Error(1)
 	}

--- a/core/chains/evm/client/node_lifecycle.go
+++ b/core/chains/evm/client/node_lifecycle.go
@@ -75,6 +75,8 @@ const (
 // Should only be run ONCE per node, after a successful Dial
 func (n *node) aliveLoop() {
 	defer n.wg.Done()
+	ctx, cancel := n.stopCh.NewCtx()
+	defer cancel()
 
 	{
 		// sanity check
@@ -96,7 +98,7 @@ func (n *node) aliveLoop() {
 	lggr.Tracew("Alive loop starting", "nodeState", n.State())
 
 	headsC := make(chan *evmtypes.Head)
-	sub, err := n.EthSubscribe(n.nodeCtx, headsC, "newHeads")
+	sub, err := n.EthSubscribe(ctx, headsC, "newHeads")
 	if err != nil {
 		lggr.Errorw("Initial subscribe for heads failed", "nodeState", n.State())
 		n.declareUnreachable()
@@ -137,18 +139,19 @@ func (n *node) aliveLoop() {
 
 	for {
 		select {
-		case <-n.nodeCtx.Done():
+		case <-ctx.Done():
 			return
 		case <-pollCh:
-			var version string
 			promEVMPoolRPCNodePolls.WithLabelValues(n.chainID.String(), n.name).Inc()
 			lggr.Tracew("Polling for version", "nodeState", n.State(), "pollFailures", pollFailures)
-			ctx, cancel := context.WithTimeout(n.nodeCtx, pollInterval)
-			ctx, cancel2 := n.makeQueryCtx(ctx)
-			err := n.CallContext(ctx, &version, "web3_clientVersion")
-			cancel2()
-			cancel()
-			if err != nil {
+			var version string
+			if err := func(ctx context.Context) error {
+				ctx, cancel := context.WithTimeout(ctx, pollInterval)
+				defer cancel()
+				ctx, cancel2 := n.makeQueryCtx(ctx)
+				defer cancel2()
+				return n.CallContext(ctx, &version, "web3_clientVersion")
+			}(ctx); err != nil {
 				// prevent overflow
 				if pollFailures < math.MaxUint32 {
 					promEVMPoolRPCNodePollsFailed.WithLabelValues(n.chainID.String(), n.name).Inc()
@@ -262,6 +265,8 @@ const (
 // outOfSyncLoop takes an OutOfSync node and waits until isOutOfSync returns false to go back to live status
 func (n *node) outOfSyncLoop(isOutOfSync func(num int64, td *big.Int) bool) {
 	defer n.wg.Done()
+	ctx, cancel := n.stopCh.NewCtx()
+	defer cancel()
 
 	{
 		// sanity check
@@ -281,14 +286,14 @@ func (n *node) outOfSyncLoop(isOutOfSync func(num int64, td *big.Int) bool) {
 	lggr.Debugw("Trying to revive out-of-sync RPC node", "nodeState", n.State())
 
 	// Need to redial since out-of-sync nodes are automatically disconnected
-	if err := n.dial(n.nodeCtx); err != nil {
+	if err := n.dial(ctx); err != nil {
 		lggr.Errorw("Failed to dial out-of-sync RPC node", "nodeState", n.State())
 		n.declareUnreachable()
 		return
 	}
 
 	// Manually re-verify since out-of-sync nodes are automatically disconnected
-	if err := n.verify(n.nodeCtx); err != nil {
+	if err := n.verify(ctx); err != nil {
 		lggr.Errorw(fmt.Sprintf("Failed to verify out-of-sync RPC node: %v", err), "err", err)
 		n.declareInvalidChainID()
 		return
@@ -297,7 +302,7 @@ func (n *node) outOfSyncLoop(isOutOfSync func(num int64, td *big.Int) bool) {
 	lggr.Tracew("Successfully subscribed to heads feed on out-of-sync RPC node", "nodeState", n.State())
 
 	ch := make(chan *evmtypes.Head)
-	subCtx, cancel := n.makeQueryCtx(n.nodeCtx)
+	subCtx, cancel := n.makeQueryCtx(ctx)
 	// raw call here to bypass node state checking
 	sub, err := n.ws.rpc.EthSubscribe(subCtx, ch, "newHeads")
 	cancel()
@@ -310,7 +315,7 @@ func (n *node) outOfSyncLoop(isOutOfSync func(num int64, td *big.Int) bool) {
 
 	for {
 		select {
-		case <-n.nodeCtx.Done():
+		case <-ctx.Done():
 			return
 		case head, open := <-ch:
 			if !open {
@@ -344,6 +349,8 @@ func (n *node) outOfSyncLoop(isOutOfSync func(num int64, td *big.Int) bool) {
 
 func (n *node) unreachableLoop() {
 	defer n.wg.Done()
+	ctx, cancel := n.stopCh.NewCtx()
+	defer cancel()
 
 	{
 		// sanity check
@@ -366,12 +373,12 @@ func (n *node) unreachableLoop() {
 
 	for {
 		select {
-		case <-n.nodeCtx.Done():
+		case <-ctx.Done():
 			return
 		case <-time.After(dialRetryBackoff.Duration()):
 			lggr.Tracew("Trying to re-dial RPC node", "nodeState", n.State())
 
-			err := n.dial(n.nodeCtx)
+			err := n.dial(ctx)
 			if err != nil {
 				lggr.Errorw(fmt.Sprintf("Failed to redial RPC node; still unreachable: %v", err), "err", err, "nodeState", n.State())
 				continue
@@ -379,7 +386,7 @@ func (n *node) unreachableLoop() {
 
 			n.setState(NodeStateDialed)
 
-			err = n.verify(n.nodeCtx)
+			err = n.verify(ctx)
 
 			if pkgerrors.Is(err, errInvalidChainID) {
 				lggr.Errorw("Failed to redial RPC node; remote endpoint returned the wrong chain ID", "err", err)
@@ -400,6 +407,8 @@ func (n *node) unreachableLoop() {
 
 func (n *node) invalidChainIDLoop() {
 	defer n.wg.Done()
+	ctx, cancel := n.stopCh.NewCtx()
+	defer cancel()
 
 	{
 		// sanity check
@@ -422,10 +431,10 @@ func (n *node) invalidChainIDLoop() {
 
 	for {
 		select {
-		case <-n.nodeCtx.Done():
+		case <-ctx.Done():
 			return
 		case <-time.After(chainIDRecheckBackoff.Duration()):
-			err := n.verify(n.nodeCtx)
+			err := n.verify(ctx)
 			if pkgerrors.Is(err, errInvalidChainID) {
 				lggr.Errorw("Failed to verify RPC node; remote endpoint returned the wrong chain ID", "err", err)
 				continue

--- a/core/chains/evm/forwarders/forwarder_manager_test.go
+++ b/core/chains/evm/forwarders/forwarder_manager_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils"
+
 	"github.com/smartcontractkit/chainlink/v2/core/services/ocr2/testhelpers"
 
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
@@ -86,7 +87,7 @@ func TestFwdMgr_MaybeForwardTransaction(t *testing.T) {
 	require.Equal(t, lst[0].Address, forwarderAddr)
 
 	require.NoError(t, fwdMgr.Start(testutils.Context(t)))
-	addr, err := fwdMgr.ForwarderFor(owner.From)
+	addr, err := fwdMgr.ForwarderFor(ctx, owner.From)
 	require.NoError(t, err)
 	require.Equal(t, addr.String(), forwarderAddr.String())
 	err = fwdMgr.Close()
@@ -148,7 +149,7 @@ func TestFwdMgr_AccountUnauthorizedToForward_SkipsForwarding(t *testing.T) {
 
 	err = fwdMgr.Start(testutils.Context(t))
 	require.NoError(t, err)
-	addr, err := fwdMgr.ForwarderFor(owner.From)
+	addr, err := fwdMgr.ForwarderFor(ctx, owner.From)
 	require.ErrorContains(t, err, "Cannot find forwarder for given EOA")
 	require.True(t, utils.IsZero(addr))
 	err = fwdMgr.Close()
@@ -214,7 +215,7 @@ func TestFwdMgr_InvalidForwarderForOCR2FeedsStates(t *testing.T) {
 	fwdMgr = forwarders.NewFwdMgr(db, evmClient, lp, lggr, evmcfg.EVM())
 	require.NoError(t, fwdMgr.Start(testutils.Context(t)))
 	// cannot find forwarder because it isn't authorized nor added as a transmitter
-	addr, err := fwdMgr.ForwarderForOCR2Feeds(owner.From, ocr2Address)
+	addr, err := fwdMgr.ForwarderForOCR2Feeds(ctx, owner.From, ocr2Address)
 	require.ErrorContains(t, err, "Cannot find forwarder for given EOA")
 	require.True(t, utils.IsZero(addr))
 
@@ -227,7 +228,7 @@ func TestFwdMgr_InvalidForwarderForOCR2FeedsStates(t *testing.T) {
 	require.Equal(t, owner.From, authorizedSenders[0])
 
 	// cannot find forwarder because it isn't added as a transmitter
-	addr, err = fwdMgr.ForwarderForOCR2Feeds(owner.From, ocr2Address)
+	addr, err = fwdMgr.ForwarderForOCR2Feeds(ctx, owner.From, ocr2Address)
 	require.ErrorContains(t, err, "Cannot find forwarder for given EOA")
 	require.True(t, utils.IsZero(addr))
 
@@ -251,7 +252,7 @@ func TestFwdMgr_InvalidForwarderForOCR2FeedsStates(t *testing.T) {
 	// create new fwd to have an empty cache that has to fetch authorized forwarders from log poller
 	fwdMgr = forwarders.NewFwdMgr(db, evmClient, lp, lggr, evmcfg.EVM())
 	require.NoError(t, fwdMgr.Start(testutils.Context(t)))
-	addr, err = fwdMgr.ForwarderForOCR2Feeds(owner.From, ocr2Address)
+	addr, err = fwdMgr.ForwarderForOCR2Feeds(ctx, owner.From, ocr2Address)
 	require.NoError(t, err, "forwarder should be valid and found because it is both authorized and set as a transmitter")
 	require.Equal(t, forwarderAddr, addr)
 	require.NoError(t, fwdMgr.Close())

--- a/core/chains/evm/gas/block_history_estimator.go
+++ b/core/chains/evm/gas/block_history_estimator.go
@@ -104,13 +104,12 @@ type BlockHistoryEstimator struct {
 	bhConfig  BlockHistoryConfig
 	// NOTE: it is assumed that blocks will be kept sorted by
 	// block number ascending
-	blocks    []evmtypes.Block
-	blocksMu  sync.RWMutex
-	size      int64
-	mb        *mailbox.Mailbox[*evmtypes.Head]
-	wg        *sync.WaitGroup
-	ctx       context.Context
-	ctxCancel context.CancelFunc
+	blocks   []evmtypes.Block
+	blocksMu sync.RWMutex
+	size     int64
+	mb       *mailbox.Mailbox[*evmtypes.Head]
+	wg       *sync.WaitGroup
+	stopCh   services.StopChan
 
 	gasPrice     *assets.Wei
 	tipCap       *assets.Wei
@@ -128,9 +127,7 @@ type BlockHistoryEstimator struct {
 // for new heads and updates the base gas price dynamically based on the
 // configured percentile of gas prices in that block
 func NewBlockHistoryEstimator(lggr logger.Logger, ethClient feeEstimatorClient, cfg chainConfig, eCfg estimatorGasEstimatorConfig, bhCfg BlockHistoryConfig, chainID *big.Int, l1Oracle rollups.L1Oracle) EvmEstimator {
-	ctx, cancel := context.WithCancel(context.Background())
-
-	b := &BlockHistoryEstimator{
+	return &BlockHistoryEstimator{
 		ethClient: ethClient,
 		chainID:   chainID,
 		config:    cfg,
@@ -138,16 +135,13 @@ func NewBlockHistoryEstimator(lggr logger.Logger, ethClient feeEstimatorClient, 
 		bhConfig:  bhCfg,
 		blocks:    make([]evmtypes.Block, 0),
 		// Must have enough blocks for both estimator and connectivity checker
-		size:      int64(mathutil.Max(bhCfg.BlockHistorySize(), bhCfg.CheckInclusionBlocks())),
-		mb:        mailbox.NewSingle[*evmtypes.Head](),
-		wg:        new(sync.WaitGroup),
-		ctx:       ctx,
-		ctxCancel: cancel,
-		logger:    logger.Sugared(logger.Named(lggr, "BlockHistoryEstimator")),
-		l1Oracle:  l1Oracle,
+		size:     int64(mathutil.Max(bhCfg.BlockHistorySize(), bhCfg.CheckInclusionBlocks())),
+		mb:       mailbox.NewSingle[*evmtypes.Head](),
+		wg:       new(sync.WaitGroup),
+		stopCh:   make(chan struct{}),
+		logger:   logger.Sugared(logger.Named(lggr, "BlockHistoryEstimator")),
+		l1Oracle: l1Oracle,
 	}
-
-	return b
 }
 
 // OnNewLongestChain recalculates and sets global gas price if a sampled new head comes
@@ -240,7 +234,7 @@ func (b *BlockHistoryEstimator) L1Oracle() rollups.L1Oracle {
 
 func (b *BlockHistoryEstimator) Close() error {
 	return b.StopOnce("BlockHistoryEstimator", func() error {
-		b.ctxCancel()
+		close(b.stopCh)
 		b.wg.Wait()
 		return nil
 	})
@@ -482,9 +476,12 @@ func (b *BlockHistoryEstimator) BumpDynamicFee(_ context.Context, originalFee Dy
 
 func (b *BlockHistoryEstimator) runLoop() {
 	defer b.wg.Done()
+	ctx, cancel := b.stopCh.NewCtx()
+	defer cancel()
+
 	for {
 		select {
-		case <-b.ctx.Done():
+		case <-ctx.Done():
 			return
 		case <-b.mb.Notify():
 			head, exists := b.mb.Retrieve()
@@ -492,7 +489,7 @@ func (b *BlockHistoryEstimator) runLoop() {
 				b.logger.Debug("No head to retrieve")
 				continue
 			}
-			b.FetchBlocksAndRecalculate(b.ctx, head)
+			b.FetchBlocksAndRecalculate(ctx, head)
 		}
 	}
 }

--- a/core/chains/evm/logpoller/log_poller.go
+++ b/core/chains/evm/logpoller/log_poller.go
@@ -119,8 +119,7 @@ type logPoller struct {
 
 	replayStart    chan int64
 	replayComplete chan error
-	ctx            context.Context
-	cancel         context.CancelFunc
+	stopCh         services.StopChan
 	wg             sync.WaitGroup
 	// This flag is raised whenever the log poller detects that the chain's finality has been violated.
 	// It can happen when reorg is deeper than the latest finalized block that LogPoller saw in a previous PollAndSave tick.
@@ -152,10 +151,8 @@ type Opts struct {
 // How fast that can be done depends largely on network speed and DB, but even for the fastest
 // support chain, polygon, which has 2s block times, we need RPCs roughly with <= 500ms latency
 func NewLogPoller(orm ORM, ec Client, lggr logger.Logger, opts Opts) *logPoller {
-	ctx, cancel := context.WithCancel(context.Background())
 	return &logPoller{
-		ctx:                      ctx,
-		cancel:                   cancel,
+		stopCh:                   make(chan struct{}),
 		ec:                       ec,
 		orm:                      orm,
 		lggr:                     logger.Sugared(logger.Named(lggr, "LogPoller")),
@@ -465,21 +462,23 @@ func (lp *logPoller) savedFinalizedBlockNumber(ctx context.Context) (int64, erro
 }
 
 func (lp *logPoller) recvReplayComplete() {
+	defer lp.wg.Done()
 	err := <-lp.replayComplete
 	if err != nil {
 		lp.lggr.Error(err)
 	}
-	lp.wg.Done()
 }
 
 // Asynchronous wrapper for Replay()
 func (lp *logPoller) ReplayAsync(fromBlock int64) {
 	lp.wg.Add(1)
 	go func() {
-		if err := lp.Replay(lp.ctx, fromBlock); err != nil {
+		defer lp.wg.Done()
+		ctx, cancel := lp.stopCh.NewCtx()
+		defer cancel()
+		if err := lp.Replay(ctx, fromBlock); err != nil {
 			lp.lggr.Error(err)
 		}
-		lp.wg.Done()
 	}()
 }
 
@@ -498,7 +497,7 @@ func (lp *logPoller) Close() error {
 		case lp.replayComplete <- ErrLogPollerShutdown:
 		default:
 		}
-		lp.cancel()
+		close(lp.stopCh)
 		lp.wg.Wait()
 		return nil
 	})
@@ -535,10 +534,10 @@ func (lp *logPoller) GetReplayFromBlock(ctx context.Context, requested int64) (i
 	return mathutil.Min(requested, lastProcessed.BlockNumber), nil
 }
 
-func (lp *logPoller) loadFilters() error {
+func (lp *logPoller) loadFilters(ctx context.Context) error {
 	lp.filterMu.Lock()
 	defer lp.filterMu.Unlock()
-	filters, err := lp.orm.LoadFilters(lp.ctx)
+	filters, err := lp.orm.LoadFilters(ctx)
 
 	if err != nil {
 		return pkgerrors.Wrapf(err, "Failed to load initial filters from db, retrying")
@@ -551,6 +550,8 @@ func (lp *logPoller) loadFilters() error {
 
 func (lp *logPoller) run() {
 	defer lp.wg.Done()
+	ctx, cancel := lp.stopCh.NewCtx()
+	defer cancel()
 	logPollTick := time.After(0)
 	// stagger these somewhat, so they don't all run back-to-back
 	backupLogPollTick := time.After(100 * time.Millisecond)
@@ -558,14 +559,14 @@ func (lp *logPoller) run() {
 
 	for {
 		select {
-		case <-lp.ctx.Done():
+		case <-ctx.Done():
 			return
 		case fromBlockReq := <-lp.replayStart:
-			lp.handleReplayRequest(fromBlockReq, filtersLoaded)
+			lp.handleReplayRequest(ctx, fromBlockReq, filtersLoaded)
 		case <-logPollTick:
 			logPollTick = time.After(utils.WithJitter(lp.pollPeriod))
 			if !filtersLoaded {
-				if err := lp.loadFilters(); err != nil {
+				if err := lp.loadFilters(ctx); err != nil {
 					lp.lggr.Errorw("Failed loading filters in main logpoller loop, retrying later", "err", err)
 					continue
 				}
@@ -574,7 +575,7 @@ func (lp *logPoller) run() {
 
 			// Always start from the latest block in the db.
 			var start int64
-			lastProcessed, err := lp.orm.SelectLatestBlock(lp.ctx)
+			lastProcessed, err := lp.orm.SelectLatestBlock(ctx)
 			if err != nil {
 				if !pkgerrors.Is(err, sql.ErrNoRows) {
 					// Assume transient db reading issue, retry forever.
@@ -583,7 +584,7 @@ func (lp *logPoller) run() {
 				}
 				// Otherwise this is the first poll _ever_ on a new chain.
 				// Only safe thing to do is to start at the first finalized block.
-				latestBlock, latestFinalizedBlockNumber, err := lp.latestBlocks(lp.ctx)
+				latestBlock, latestFinalizedBlockNumber, err := lp.latestBlocks(ctx)
 				if err != nil {
 					lp.lggr.Warnw("Unable to get latest for first poll", "err", err)
 					continue
@@ -600,7 +601,7 @@ func (lp *logPoller) run() {
 			} else {
 				start = lastProcessed.BlockNumber + 1
 			}
-			lp.PollAndSaveLogs(lp.ctx, start)
+			lp.PollAndSaveLogs(ctx, start)
 		case <-backupLogPollTick:
 			if lp.backupPollerBlockDelay == 0 {
 				continue // backup poller is disabled
@@ -618,13 +619,15 @@ func (lp *logPoller) run() {
 				lp.lggr.Warnw("Backup log poller ran before filters loaded, skipping")
 				continue
 			}
-			lp.BackupPollAndSaveLogs(lp.ctx)
+			lp.BackupPollAndSaveLogs(ctx)
 		}
 	}
 }
 
 func (lp *logPoller) backgroundWorkerRun() {
 	defer lp.wg.Done()
+	ctx, cancel := lp.stopCh.NewCtx()
+	defer cancel()
 
 	// Avoid putting too much pressure on the database by staggering the pruning of old blocks and logs.
 	// Usually, node after restart will have some work to boot the plugins and other services.
@@ -634,11 +637,11 @@ func (lp *logPoller) backgroundWorkerRun() {
 
 	for {
 		select {
-		case <-lp.ctx.Done():
+		case <-ctx.Done():
 			return
 		case <-blockPruneTick:
 			blockPruneTick = time.After(utils.WithJitter(lp.pollPeriod * 1000))
-			if allRemoved, err := lp.PruneOldBlocks(lp.ctx); err != nil {
+			if allRemoved, err := lp.PruneOldBlocks(ctx); err != nil {
 				lp.lggr.Errorw("Unable to prune old blocks", "err", err)
 			} else if !allRemoved {
 				// Tick faster when cleanup can't keep up with the pace of new blocks
@@ -646,7 +649,7 @@ func (lp *logPoller) backgroundWorkerRun() {
 			}
 		case <-logPruneTick:
 			logPruneTick = time.After(utils.WithJitter(lp.pollPeriod * 2401)) // = 7^5 avoids common factors with 1000
-			if allRemoved, err := lp.PruneExpiredLogs(lp.ctx); err != nil {
+			if allRemoved, err := lp.PruneExpiredLogs(ctx); err != nil {
 				lp.lggr.Errorw("Unable to prune expired logs", "err", err)
 			} else if !allRemoved {
 				// Tick faster when cleanup can't keep up with the pace of new logs
@@ -656,26 +659,26 @@ func (lp *logPoller) backgroundWorkerRun() {
 	}
 }
 
-func (lp *logPoller) handleReplayRequest(fromBlockReq int64, filtersLoaded bool) {
-	fromBlock, err := lp.GetReplayFromBlock(lp.ctx, fromBlockReq)
+func (lp *logPoller) handleReplayRequest(ctx context.Context, fromBlockReq int64, filtersLoaded bool) {
+	fromBlock, err := lp.GetReplayFromBlock(ctx, fromBlockReq)
 	if err == nil {
 		if !filtersLoaded {
 			lp.lggr.Warnw("Received replayReq before filters loaded", "fromBlock", fromBlock, "requested", fromBlockReq)
-			if err = lp.loadFilters(); err != nil {
+			if err = lp.loadFilters(ctx); err != nil {
 				lp.lggr.Errorw("Failed loading filters during Replay", "err", err, "fromBlock", fromBlock)
 			}
 		}
 		if err == nil {
 			// Serially process replay requests.
 			lp.lggr.Infow("Executing replay", "fromBlock", fromBlock, "requested", fromBlockReq)
-			lp.PollAndSaveLogs(lp.ctx, fromBlock)
+			lp.PollAndSaveLogs(ctx, fromBlock)
 			lp.lggr.Infow("Executing replay finished", "fromBlock", fromBlock, "requested", fromBlockReq)
 		}
 	} else {
 		lp.lggr.Errorw("Error executing replay, could not get fromBlock", "err", err)
 	}
 	select {
-	case <-lp.ctx.Done():
+	case <-ctx.Done():
 		// We're shutting down, notify client and exit
 		select {
 		case lp.replayComplete <- ErrReplayRequestAborted:

--- a/core/chains/evm/txmgr/evm_tx_store.go
+++ b/core/chains/evm/txmgr/evm_tx_store.go
@@ -19,6 +19,7 @@ import (
 	nullv4 "gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-common/pkg/services"
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/null"
 
@@ -76,10 +77,9 @@ type TestEvmTxStore interface {
 }
 
 type evmTxStore struct {
-	q         sqlutil.DataSource
-	logger    logger.SugaredLogger
-	ctx       context.Context
-	ctxCancel context.CancelFunc
+	q      sqlutil.DataSource
+	logger logger.SugaredLogger
+	stopCh services.StopChan
 }
 
 var _ EvmTxStore = (*evmTxStore)(nil)
@@ -345,12 +345,10 @@ func NewTxStore(
 	lggr logger.Logger,
 ) *evmTxStore {
 	namedLogger := logger.Named(lggr, "TxmStore")
-	ctx, cancel := context.WithCancel(context.Background())
 	return &evmTxStore{
-		q:         db,
-		logger:    logger.Sugared(namedLogger),
-		ctx:       ctx,
-		ctxCancel: cancel,
+		q:      db,
+		logger: logger.Sugared(namedLogger),
+		stopCh: make(chan struct{}),
 	}
 }
 
@@ -361,7 +359,7 @@ RETURNING *;
 `
 
 func (o *evmTxStore) Close() {
-	o.ctxCancel()
+	close(o.stopCh)
 }
 
 func (o *evmTxStore) preloadTxAttempts(ctx context.Context, txs []Tx) error {
@@ -398,7 +396,7 @@ func (o *evmTxStore) preloadTxAttempts(ctx context.Context, txs []Tx) error {
 
 func (o *evmTxStore) PreloadTxes(ctx context.Context, attempts []TxAttempt) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	return o.preloadTxesAtomic(ctx, attempts)
 }
@@ -573,7 +571,7 @@ func (o *evmTxStore) InsertReceipt(ctx context.Context, receipt *evmtypes.Receip
 
 func (o *evmTxStore) GetFatalTransactions(ctx context.Context) (txes []*Tx, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err = o.Transact(ctx, true, func(orm *evmTxStore) error {
 		stmt := `SELECT * FROM evm.txes WHERE state = 'fatal_error'`
@@ -651,7 +649,7 @@ func (o *evmTxStore) LoadTxesAttempts(ctx context.Context, etxs []*Tx) error {
 
 func (o *evmTxStore) LoadTxAttempts(ctx context.Context, etx *Tx) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	return o.loadTxAttemptsAtomic(ctx, etx)
 }
@@ -716,7 +714,7 @@ func loadConfirmedAttemptsReceipts(ctx context.Context, q sqlutil.DataSource, at
 // eth_tx that was last sent before or at the given time (up to limit)
 func (o *evmTxStore) FindTxAttemptsRequiringResend(ctx context.Context, olderThan time.Time, maxInFlightTransactions uint32, chainID *big.Int, address common.Address) (attempts []TxAttempt, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	var limit null.Uint32
 	if maxInFlightTransactions > 0 {
@@ -740,7 +738,7 @@ LIMIT $4
 
 func (o *evmTxStore) UpdateBroadcastAts(ctx context.Context, now time.Time, etxIDs []int64) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	// Deliberately do nothing on NULL broadcast_at because that indicates the
 	// tx has been moved into a state where broadcast_at is not relevant, e.g.
@@ -758,7 +756,7 @@ func (o *evmTxStore) UpdateBroadcastAts(ctx context.Context, now time.Time, etxI
 // the attempt is already broadcast it _must_ have been before this head.
 func (o *evmTxStore) SetBroadcastBeforeBlockNum(ctx context.Context, blockNum int64, chainID *big.Int) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	_, err := o.q.ExecContext(ctx,
 		`UPDATE evm.tx_attempts
@@ -773,7 +771,7 @@ AND evm.txes.id = evm.tx_attempts.eth_tx_id AND evm.txes.evm_chain_id = $2`,
 
 func (o *evmTxStore) FindTxAttemptsConfirmedMissingReceipt(ctx context.Context, chainID *big.Int) (attempts []TxAttempt, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	var dbAttempts []DbEthTxAttempt
 	err = o.q.SelectContext(ctx, &dbAttempts,
@@ -792,7 +790,7 @@ func (o *evmTxStore) FindTxAttemptsConfirmedMissingReceipt(ctx context.Context, 
 
 func (o *evmTxStore) UpdateTxsUnconfirmed(ctx context.Context, ids []int64) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	_, err := o.q.ExecContext(ctx, `UPDATE evm.txes SET state='unconfirmed' WHERE id = ANY($1)`, pq.Array(ids))
 
@@ -804,7 +802,7 @@ func (o *evmTxStore) UpdateTxsUnconfirmed(ctx context.Context, ids []int64) erro
 
 func (o *evmTxStore) FindTxAttemptsRequiringReceiptFetch(ctx context.Context, chainID *big.Int) (attempts []TxAttempt, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err = o.Transact(ctx, true, func(orm *evmTxStore) error {
 		var dbAttempts []DbEthTxAttempt
@@ -826,7 +824,7 @@ ORDER BY evm.txes.nonce ASC, evm.tx_attempts.gas_price DESC, evm.tx_attempts.gas
 
 func (o *evmTxStore) SaveFetchedReceipts(ctx context.Context, r []*evmtypes.Receipt, chainID *big.Int) (err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	receipts := toOnchainReceipt(r)
 	if len(receipts) == 0 {
@@ -930,7 +928,7 @@ func (o *evmTxStore) SaveFetchedReceipts(ctx context.Context, r []*evmtypes.Rece
 // attempts are below the finality depth from current head.
 func (o *evmTxStore) MarkAllConfirmedMissingReceipt(ctx context.Context, chainID *big.Int) (err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	res, err := o.q.ExecContext(ctx, `
 UPDATE evm.txes
@@ -961,7 +959,7 @@ WHERE state = 'unconfirmed'
 
 func (o *evmTxStore) GetInProgressTxAttempts(ctx context.Context, address common.Address, chainID *big.Int) (attempts []TxAttempt, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err = o.Transact(ctx, true, func(orm *evmTxStore) error {
 		var dbAttempts []DbEthTxAttempt
@@ -985,7 +983,7 @@ func (o *evmTxStore) FindTxesPendingCallback(ctx context.Context, blockNum int64
 	var rs []dbReceiptPlus
 
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err = o.q.SelectContext(ctx, &rs, `
 	SELECT evm.txes.pipeline_task_run_id, evm.receipts.receipt, COALESCE((evm.txes.meta->>'FailOnRevert')::boolean, false) "FailOnRevert" FROM evm.txes
@@ -1004,7 +1002,7 @@ func (o *evmTxStore) FindTxesPendingCallback(ctx context.Context, blockNum int64
 // Update tx to mark that its callback has been signaled
 func (o *evmTxStore) UpdateTxCallbackCompleted(ctx context.Context, pipelineTaskRunId uuid.UUID, chainId *big.Int) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	_, err := o.q.ExecContext(ctx, `UPDATE evm.txes SET callback_completed = TRUE WHERE pipeline_task_run_id = $1 AND evm_chain_id = $2`, pipelineTaskRunId, chainId.String())
 	if err != nil {
@@ -1015,7 +1013,7 @@ func (o *evmTxStore) UpdateTxCallbackCompleted(ctx context.Context, pipelineTask
 
 func (o *evmTxStore) FindLatestSequence(ctx context.Context, fromAddress common.Address, chainId *big.Int) (nonce evmtypes.Nonce, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	sql := `SELECT nonce FROM evm.txes WHERE from_address = $1 AND evm_chain_id = $2 AND nonce IS NOT NULL ORDER BY nonce DESC LIMIT 1`
 	err = o.q.GetContext(ctx, &nonce, sql, fromAddress, chainId.String())
@@ -1025,7 +1023,7 @@ func (o *evmTxStore) FindLatestSequence(ctx context.Context, fromAddress common.
 // FindTxWithIdempotencyKey returns any broadcast ethtx with the given idempotencyKey and chainID
 func (o *evmTxStore) FindTxWithIdempotencyKey(ctx context.Context, idempotencyKey string, chainID *big.Int) (etx *Tx, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	var dbEtx DbEthTx
 	err = o.q.GetContext(ctx, &dbEtx, `SELECT * FROM evm.txes WHERE idempotency_key = $1 and evm_chain_id = $2`, idempotencyKey, chainID.String())
@@ -1043,7 +1041,7 @@ func (o *evmTxStore) FindTxWithIdempotencyKey(ctx context.Context, idempotencyKe
 // FindTxWithSequence returns any broadcast ethtx with the given nonce
 func (o *evmTxStore) FindTxWithSequence(ctx context.Context, fromAddress common.Address, nonce evmtypes.Nonce) (etx *Tx, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	etx = new(Tx)
 	err = o.Transact(ctx, true, func(orm *evmTxStore) error {
@@ -1092,7 +1090,7 @@ AND evm.tx_attempts.eth_tx_id = $1
 
 func (o *evmTxStore) UpdateTxForRebroadcast(ctx context.Context, etx Tx, etxAttempt TxAttempt) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	return o.Transact(ctx, false, func(orm *evmTxStore) error {
 		if err := deleteEthReceipts(ctx, orm, etx.ID); err != nil {
@@ -1107,7 +1105,7 @@ func (o *evmTxStore) UpdateTxForRebroadcast(ctx context.Context, etx Tx, etxAtte
 
 func (o *evmTxStore) FindTransactionsConfirmedInBlockRange(ctx context.Context, highBlockNumber, lowBlockNumber int64, chainID *big.Int) (etxs []*Tx, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err = o.Transact(ctx, true, func(orm *evmTxStore) error {
 		var dbEtxs []DbEthTx
@@ -1134,7 +1132,7 @@ ORDER BY nonce ASC
 
 func (o *evmTxStore) FindEarliestUnconfirmedBroadcastTime(ctx context.Context, chainID *big.Int) (broadcastAt nullv4.Time, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err = o.Transact(ctx, true, func(orm *evmTxStore) error {
 		if err = orm.q.QueryRowxContext(ctx, `SELECT min(initial_broadcast_at) FROM evm.txes WHERE state = 'unconfirmed' AND evm_chain_id = $1`, chainID.String()).Scan(&broadcastAt); err != nil {
@@ -1147,7 +1145,7 @@ func (o *evmTxStore) FindEarliestUnconfirmedBroadcastTime(ctx context.Context, c
 
 func (o *evmTxStore) FindEarliestUnconfirmedTxAttemptBlock(ctx context.Context, chainID *big.Int) (earliestUnconfirmedTxBlock nullv4.Int, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err = o.Transact(ctx, true, func(orm *evmTxStore) error {
 		err = orm.q.QueryRowxContext(ctx, `
@@ -1165,7 +1163,7 @@ AND evm_chain_id = $1`, chainID.String()).Scan(&earliestUnconfirmedTxBlock)
 
 func (o *evmTxStore) IsTxFinalized(ctx context.Context, blockHeight int64, txID int64, chainID *big.Int) (finalized bool, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 
 	var count int32
@@ -1198,7 +1196,7 @@ func (o *evmTxStore) saveAttemptWithNewState(ctx context.Context, attempt TxAtte
 
 func (o *evmTxStore) SaveInsufficientFundsAttempt(ctx context.Context, timeout time.Duration, attempt *TxAttempt, broadcastAt time.Time) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	if !(attempt.State == txmgrtypes.TxAttemptInProgress || attempt.State == txmgrtypes.TxAttemptInsufficientFunds) {
 		return errors.New("expected state to be either in_progress or insufficient_eth")
@@ -1221,14 +1219,14 @@ func (o *evmTxStore) saveSentAttempt(ctx context.Context, timeout time.Duration,
 
 func (o *evmTxStore) SaveSentAttempt(ctx context.Context, timeout time.Duration, attempt *TxAttempt, broadcastAt time.Time) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	return o.saveSentAttempt(ctx, timeout, attempt, broadcastAt)
 }
 
 func (o *evmTxStore) SaveConfirmedMissingReceiptAttempt(ctx context.Context, timeout time.Duration, attempt *TxAttempt, broadcastAt time.Time) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err := o.Transact(ctx, false, func(orm *evmTxStore) error {
 		if err := orm.saveSentAttempt(ctx, timeout, attempt, broadcastAt); err != nil {
@@ -1244,7 +1242,7 @@ func (o *evmTxStore) SaveConfirmedMissingReceiptAttempt(ctx context.Context, tim
 
 func (o *evmTxStore) DeleteInProgressAttempt(ctx context.Context, attempt TxAttempt) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	if attempt.State != txmgrtypes.TxAttemptInProgress {
 		return errors.New("DeleteInProgressAttempt: expected attempt state to be in_progress")
@@ -1259,7 +1257,7 @@ func (o *evmTxStore) DeleteInProgressAttempt(ctx context.Context, attempt TxAtte
 // SaveInProgressAttempt inserts or updates an attempt
 func (o *evmTxStore) SaveInProgressAttempt(ctx context.Context, attempt *TxAttempt) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	if attempt.State != txmgrtypes.TxAttemptInProgress {
 		return errors.New("SaveInProgressAttempt failed: attempt state must be in_progress")
@@ -1293,7 +1291,7 @@ func (o *evmTxStore) SaveInProgressAttempt(ctx context.Context, attempt *TxAttem
 
 func (o *evmTxStore) GetAbandonedTransactionsByBatch(ctx context.Context, chainID *big.Int, enabledAddrs []common.Address, offset, limit uint) (txes []*Tx, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 
 	var enabledAddrsBytea [][]byte
@@ -1317,7 +1315,7 @@ func (o *evmTxStore) GetAbandonedTransactionsByBatch(ctx context.Context, chainI
 
 func (o *evmTxStore) GetTxByID(ctx context.Context, id int64) (txe *Tx, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 
 	err = o.Transact(ctx, true, func(orm *evmTxStore) error {
@@ -1352,7 +1350,7 @@ func (o *evmTxStore) FindTxsRequiringGasBump(ctx context.Context, address common
 		return
 	}
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err = o.Transact(ctx, true, func(orm *evmTxStore) error {
 		stmt := `
@@ -1379,7 +1377,7 @@ ORDER BY nonce ASC
 // block
 func (o *evmTxStore) FindTxsRequiringResubmissionDueToInsufficientFunds(ctx context.Context, address common.Address, chainID *big.Int) (etxs []*Tx, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err = o.Transact(ctx, true, func(orm *evmTxStore) error {
 		var dbEtxs []DbEthTx
@@ -1409,7 +1407,7 @@ ORDER BY nonce ASC
 // receipt and thus cannot pass on any transaction hash
 func (o *evmTxStore) MarkOldTxesMissingReceiptAsErrored(ctx context.Context, blockNum int64, finalityDepth uint32, chainID *big.Int) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	// cutoffBlockNum is a block height
 	// Any 'confirmed_missing_receipt' eth_tx with all attempts older than this block height will be marked as errored
@@ -1502,7 +1500,7 @@ GROUP BY e.id
 
 func (o *evmTxStore) SaveReplacementInProgressAttempt(ctx context.Context, oldAttempt TxAttempt, replacementAttempt *TxAttempt) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	if oldAttempt.State != txmgrtypes.TxAttemptInProgress || replacementAttempt.State != txmgrtypes.TxAttemptInProgress {
 		return errors.New("expected attempts to be in_progress")
@@ -1529,7 +1527,7 @@ func (o *evmTxStore) SaveReplacementInProgressAttempt(ctx context.Context, oldAt
 // Finds earliest saved transaction that has yet to be broadcast from the given address
 func (o *evmTxStore) FindNextUnstartedTransactionFromAddress(ctx context.Context, fromAddress common.Address, chainID *big.Int) (*Tx, error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	var dbEtx DbEthTx
 	err := o.q.GetContext(ctx, &dbEtx, `SELECT * FROM evm.txes WHERE from_address = $1 AND state = 'unstarted' AND evm_chain_id = $2 ORDER BY value ASC, created_at ASC, id ASC`, fromAddress, chainID.String())
@@ -1544,7 +1542,7 @@ func (o *evmTxStore) FindNextUnstartedTransactionFromAddress(ctx context.Context
 
 func (o *evmTxStore) UpdateTxFatalError(ctx context.Context, etx *Tx) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	if etx.State != txmgr.TxInProgress && etx.State != txmgr.TxUnstarted {
 		return pkgerrors.Errorf("can only transition to fatal_error from in_progress or unstarted, transaction is currently %s", etx.State)
@@ -1571,7 +1569,7 @@ func (o *evmTxStore) UpdateTxFatalError(ctx context.Context, etx *Tx) error {
 // Updates eth attempt from in_progress to broadcast. Also updates the eth tx to unconfirmed.
 func (o *evmTxStore) UpdateTxAttemptInProgressToBroadcast(ctx context.Context, etx *Tx, attempt TxAttempt, NewAttemptState txmgrtypes.TxAttemptState) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	if etx.BroadcastAt == nil {
 		return errors.New("unconfirmed transaction must have broadcast_at time")
@@ -1609,7 +1607,7 @@ func (o *evmTxStore) UpdateTxAttemptInProgressToBroadcast(ctx context.Context, e
 // Updates eth tx from unstarted to in_progress and inserts in_progress eth attempt
 func (o *evmTxStore) UpdateTxUnstartedToInProgress(ctx context.Context, etx *Tx, attempt *TxAttempt) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	if etx.Sequence == nil {
 		return errors.New("in_progress transaction must have nonce")
@@ -1681,7 +1679,7 @@ func (o *evmTxStore) UpdateTxUnstartedToInProgress(ctx context.Context, etx *Tx,
 // It may or may not have been broadcast to an eth node.
 func (o *evmTxStore) GetTxInProgress(ctx context.Context, fromAddress common.Address) (etx *Tx, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	etx = new(Tx)
 	if err != nil {
@@ -1712,7 +1710,7 @@ func (o *evmTxStore) GetTxInProgress(ctx context.Context, fromAddress common.Add
 
 func (o *evmTxStore) HasInProgressTransaction(ctx context.Context, account common.Address, chainID *big.Int) (exists bool, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err = o.q.GetContext(ctx, &exists, `SELECT EXISTS(SELECT 1 FROM evm.txes WHERE state = 'in_progress' AND from_address = $1 AND evm_chain_id = $2)`, account, chainID.String())
 	return exists, pkgerrors.Wrap(err, "hasInProgressTransaction failed")
@@ -1720,7 +1718,7 @@ func (o *evmTxStore) HasInProgressTransaction(ctx context.Context, account commo
 
 func (o *evmTxStore) countTransactionsWithState(ctx context.Context, fromAddress common.Address, state txmgrtypes.TxState, chainID *big.Int) (count uint32, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err = o.q.GetContext(ctx, &count, `SELECT count(*) FROM evm.txes WHERE from_address = $1 AND state = $2 AND evm_chain_id = $3`,
 		fromAddress, state, chainID.String())
@@ -1735,7 +1733,7 @@ func (o *evmTxStore) CountUnconfirmedTransactions(ctx context.Context, fromAddre
 // CountTransactionsByState returns the number of transactions with any fromAddress in the given state
 func (o *evmTxStore) CountTransactionsByState(ctx context.Context, state txmgrtypes.TxState, chainID *big.Int) (count uint32, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err = o.q.GetContext(ctx, &count, `SELECT count(*) FROM evm.txes WHERE state = $1 AND evm_chain_id = $2`,
 		state, chainID.String())
@@ -1752,7 +1750,7 @@ func (o *evmTxStore) CountUnstartedTransactions(ctx context.Context, fromAddress
 
 func (o *evmTxStore) CheckTxQueueCapacity(ctx context.Context, fromAddress common.Address, maxQueuedTransactions uint64, chainID *big.Int) (err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	if maxQueuedTransactions == 0 {
 		return nil
@@ -1772,7 +1770,7 @@ func (o *evmTxStore) CheckTxQueueCapacity(ctx context.Context, fromAddress commo
 
 func (o *evmTxStore) CreateTransaction(ctx context.Context, txRequest TxRequest, chainID *big.Int) (tx Tx, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	var dbEtx DbEthTx
 	err = o.Transact(ctx, false, func(orm *evmTxStore) error {
@@ -1806,7 +1804,7 @@ RETURNING "txes".*
 
 func (o *evmTxStore) PruneUnstartedTxQueue(ctx context.Context, queueSize uint32, subject uuid.UUID) (ids []int64, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err = o.Transact(ctx, false, func(orm *evmTxStore) error {
 		err := orm.q.SelectContext(ctx, &ids, `
@@ -1834,7 +1832,7 @@ id < (
 
 func (o *evmTxStore) ReapTxHistory(ctx context.Context, minBlockNumberToKeep int64, timeThreshold time.Time, chainID *big.Int) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 
 	// Delete old confirmed evm.txes
@@ -1893,7 +1891,7 @@ AND evm_chain_id = $2`, timeThreshold, chainID.String())
 
 func (o *evmTxStore) Abandon(ctx context.Context, chainID *big.Int, addr common.Address) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	_, err := o.q.ExecContext(ctx, `UPDATE evm.txes SET state='fatal_error', nonce = NULL, error = 'abandoned' WHERE state IN ('unconfirmed', 'in_progress', 'unstarted') AND evm_chain_id = $1 AND from_address = $2`, chainID.String(), addr)
 	return err
@@ -1902,7 +1900,7 @@ func (o *evmTxStore) Abandon(ctx context.Context, chainID *big.Int, addr common.
 // Find transactions by a field in the TxMeta blob and transaction states
 func (o *evmTxStore) FindTxesByMetaFieldAndStates(ctx context.Context, metaField string, metaValue string, states []txmgrtypes.TxState, chainID *big.Int) ([]*Tx, error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	var dbEtxs []DbEthTx
 	sql := fmt.Sprintf("SELECT * FROM evm.txes WHERE evm_chain_id = $1 AND meta->>'%s' = $2 AND state = ANY($3)", metaField)
@@ -1915,7 +1913,7 @@ func (o *evmTxStore) FindTxesByMetaFieldAndStates(ctx context.Context, metaField
 // Find transactions with a non-null TxMeta field that was provided by transaction states
 func (o *evmTxStore) FindTxesWithMetaFieldByStates(ctx context.Context, metaField string, states []txmgrtypes.TxState, chainID *big.Int) (txes []*Tx, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	var dbEtxs []DbEthTx
 	sql := fmt.Sprintf("SELECT * FROM evm.txes WHERE meta->'%s' IS NOT NULL AND state = ANY($1) AND evm_chain_id = $2", metaField)
@@ -1928,7 +1926,7 @@ func (o *evmTxStore) FindTxesWithMetaFieldByStates(ctx context.Context, metaFiel
 // Find transactions with a non-null TxMeta field that was provided and a receipt block number greater than or equal to the one provided
 func (o *evmTxStore) FindTxesWithMetaFieldByReceiptBlockNum(ctx context.Context, metaField string, blockNum int64, chainID *big.Int) (txes []*Tx, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	var dbEtxs []DbEthTx
 	sql := fmt.Sprintf("SELECT et.* FROM evm.txes et JOIN evm.tx_attempts eta on et.id = eta.eth_tx_id JOIN evm.receipts er on eta.hash = er.tx_hash WHERE et.meta->'%s' IS NOT NULL AND er.block_number >= $1 AND et.evm_chain_id = $2", metaField)
@@ -1941,7 +1939,7 @@ func (o *evmTxStore) FindTxesWithMetaFieldByReceiptBlockNum(ctx context.Context,
 // Find transactions loaded with transaction attempts and receipts by transaction IDs and states
 func (o *evmTxStore) FindTxesWithAttemptsAndReceiptsByIdsAndState(ctx context.Context, ids []int64, states []txmgrtypes.TxState, chainID *big.Int) (txes []*Tx, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	err = o.Transact(ctx, true, func(orm *evmTxStore) error {
 		var dbEtxs []DbEthTx
@@ -1964,7 +1962,7 @@ func (o *evmTxStore) FindTxesWithAttemptsAndReceiptsByIdsAndState(ctx context.Co
 // For testing only, get all txes in the DB
 func (o *evmTxStore) GetAllTxes(ctx context.Context) (txes []*Tx, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	var dbEtxs []DbEthTx
 	sql := "SELECT * FROM evm.txes"
@@ -1977,7 +1975,7 @@ func (o *evmTxStore) GetAllTxes(ctx context.Context) (txes []*Tx, err error) {
 // For testing only, get all tx attempts in the DB
 func (o *evmTxStore) GetAllTxAttempts(ctx context.Context) (attempts []TxAttempt, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	var dbAttempts []DbEthTxAttempt
 	sql := "SELECT * FROM evm.tx_attempts"
@@ -1988,7 +1986,7 @@ func (o *evmTxStore) GetAllTxAttempts(ctx context.Context) (attempts []TxAttempt
 
 func (o *evmTxStore) CountTxesByStateAndSubject(ctx context.Context, state txmgrtypes.TxState, subject uuid.UUID) (count int, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	sql := "SELECT COUNT(*) FROM evm.txes WHERE state = $1 AND subject = $2"
 	err = o.q.GetContext(ctx, &count, sql, state, subject)
@@ -1997,7 +1995,7 @@ func (o *evmTxStore) CountTxesByStateAndSubject(ctx context.Context, state txmgr
 
 func (o *evmTxStore) FindTxesByFromAddressAndState(ctx context.Context, fromAddress common.Address, state string) (txes []*Tx, err error) {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	sql := "SELECT * FROM evm.txes WHERE from_address = $1 AND state = $2"
 	var dbEtxs []DbEthTx
@@ -2009,23 +2007,9 @@ func (o *evmTxStore) FindTxesByFromAddressAndState(ctx context.Context, fromAddr
 
 func (o *evmTxStore) UpdateTxAttemptBroadcastBeforeBlockNum(ctx context.Context, id int64, blockNum uint) error {
 	var cancel context.CancelFunc
-	ctx, cancel = o.mergeContexts(ctx)
+	ctx, cancel = o.stopCh.Ctx(ctx)
 	defer cancel()
 	sql := "UPDATE evm.tx_attempts SET broadcast_before_block_num = $1 WHERE eth_tx_id = $2"
 	_, err := o.q.ExecContext(ctx, sql, blockNum, id)
 	return err
-}
-
-// Returns a context that contains the values of the provided context,
-// and which is canceled when either the provided context or TxStore parent context is canceled.
-func (o *evmTxStore) mergeContexts(ctx context.Context) (context.Context, context.CancelFunc) {
-	var cancel context.CancelCauseFunc
-	ctx, cancel = context.WithCancelCause(ctx)
-	stop := context.AfterFunc(o.ctx, func() {
-		cancel(context.Cause(o.ctx))
-	})
-	return ctx, func() {
-		stop()
-		cancel(context.Canceled)
-	}
 }

--- a/core/services/blockhashstore/delegate.go
+++ b/core/services/blockhashstore/delegate.go
@@ -215,29 +215,32 @@ type service struct {
 	pollPeriod time.Duration
 	runTimeout time.Duration
 	logger     logger.Logger
-	parentCtx  context.Context
-	cancel     context.CancelFunc
+	stopCh     services.StopChan
 }
 
 // Start the BHS feeder service, satisfying the job.Service interface.
 func (s *service) Start(context.Context) error {
 	return s.StartOnce("BHS Feeder Service", func() error {
 		s.logger.Infow("Starting BHS feeder")
-		ticker := time.NewTicker(utils.WithJitter(s.pollPeriod))
-		s.parentCtx, s.cancel = context.WithCancel(context.Background())
+		s.stopCh = make(chan struct{})
 		s.wg.Add(2)
 		go func() {
 			defer s.wg.Done()
-			s.feeder.StartHeartbeats(s.parentCtx, &realTimer{})
+			ctx, cancel := s.stopCh.NewCtx()
+			defer cancel()
+			s.feeder.StartHeartbeats(ctx, &realTimer{})
 		}()
 		go func() {
 			defer s.wg.Done()
+			ctx, cancel := s.stopCh.NewCtx()
+			defer cancel()
+			ticker := time.NewTicker(utils.WithJitter(s.pollPeriod))
 			defer ticker.Stop()
 			for {
 				select {
 				case <-ticker.C:
-					s.runFeeder()
-				case <-s.parentCtx.Done():
+					s.runFeeder(ctx)
+				case <-ctx.Done():
 					return
 				}
 			}
@@ -250,15 +253,15 @@ func (s *service) Start(context.Context) error {
 func (s *service) Close() error {
 	return s.StopOnce("BHS Feeder Service", func() error {
 		s.logger.Infow("Stopping BHS feeder")
-		s.cancel()
+		close(s.stopCh)
 		s.wg.Wait()
 		return nil
 	})
 }
 
-func (s *service) runFeeder() {
+func (s *service) runFeeder(ctx context.Context) {
 	s.logger.Debugw("Running BHS feeder")
-	ctx, cancel := context.WithTimeout(s.parentCtx, s.runTimeout)
+	ctx, cancel := context.WithTimeout(ctx, s.runTimeout)
 	defer cancel()
 	err := s.feeder.Run(ctx)
 	if err == nil {

--- a/core/services/keeper/delegate.go
+++ b/core/services/keeper/delegate.go
@@ -93,7 +93,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, spec job.Job) (services 
 	// In the case of forwarding, the keeper address is the forwarder contract deployed onchain between EOA and Registry.
 	effectiveKeeperAddress := spec.KeeperSpec.FromAddress.Address()
 	if spec.ForwardingAllowed {
-		fwdrAddress, fwderr := chain.TxManager().GetForwarderForEOA(spec.KeeperSpec.FromAddress.Address())
+		fwdrAddress, fwderr := chain.TxManager().GetForwarderForEOA(ctx, spec.KeeperSpec.FromAddress.Address())
 		if fwderr == nil {
 			effectiveKeeperAddress = fwdrAddress
 		} else {

--- a/core/services/keeper/integration_test.go
+++ b/core/services/keeper/integration_test.go
@@ -417,7 +417,7 @@ func TestKeeperForwarderEthIntegration(t *testing.T) {
 		_, err = forwarderORM.CreateForwarder(ctx, fwdrAddress, chainID)
 		require.NoError(t, err)
 
-		addr, err := app.GetRelayers().LegacyEVMChains().Slice()[0].TxManager().GetForwarderForEOA(nodeAddress)
+		addr, err := app.GetRelayers().LegacyEVMChains().Slice()[0].TxManager().GetForwarderForEOA(ctx, nodeAddress)
 		require.NoError(t, err)
 		require.Equal(t, addr, fwdrAddress)
 

--- a/core/services/ocr/config_overrider.go
+++ b/core/services/ocr/config_overrider.go
@@ -31,9 +31,8 @@ type ConfigOverriderImpl struct {
 	DeltaCFromAddress        time.Duration
 
 	// Start/Stop lifecycle
-	ctx       context.Context
-	ctxCancel context.CancelFunc
-	chDone    chan struct{}
+	chStop services.StopChan
+	chDone chan struct{}
 
 	mu sync.RWMutex
 }
@@ -63,7 +62,6 @@ func NewConfigOverriderImpl(
 	addressSeconds := addressBig.Mod(addressBig, big.NewInt(jitterSeconds)).Uint64()
 	deltaC := cfg.DeltaCOverride() + time.Duration(addressSeconds)*time.Second
 
-	ctx, cancel := context.WithCancel(context.Background())
 	co := ConfigOverriderImpl{
 		services.StateMachine{},
 		logger,
@@ -73,8 +71,7 @@ func NewConfigOverriderImpl(
 		time.Now(),
 		InitialHibernationStatus,
 		deltaC,
-		ctx,
-		cancel,
+		make(chan struct{}),
 		make(chan struct{}),
 		sync.RWMutex{},
 	}
@@ -96,7 +93,7 @@ func (c *ConfigOverriderImpl) Start(context.Context) error {
 
 func (c *ConfigOverriderImpl) Close() error {
 	return c.StopOnce("OCRContractTracker", func() error {
-		c.ctxCancel()
+		close(c.chStop)
 		<-c.chDone
 		return nil
 	})
@@ -104,11 +101,13 @@ func (c *ConfigOverriderImpl) Close() error {
 
 func (c *ConfigOverriderImpl) eventLoop() {
 	defer close(c.chDone)
+	ctx, cancel := c.chStop.NewCtx()
+	defer cancel()
 	c.pollTicker.Resume()
 	defer c.pollTicker.Destroy()
 	for {
 		select {
-		case <-c.ctx.Done():
+		case <-ctx.Done():
 			return
 		case <-c.pollTicker.Ticks():
 			if err := c.updateFlagsStatus(); err != nil {

--- a/core/services/ocr/delegate.go
+++ b/core/services/ocr/delegate.go
@@ -216,7 +216,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, jb job.Job) (services []
 		// In the case of forwarding, the transmitter address is the forwarder contract deployed onchain between EOA and OCR contract.
 		effectiveTransmitterAddress := concreteSpec.TransmitterAddress.Address()
 		if jb.ForwardingAllowed {
-			fwdrAddress, fwderr := chain.TxManager().GetForwarderForEOA(effectiveTransmitterAddress)
+			fwdrAddress, fwderr := chain.TxManager().GetForwarderForEOA(ctx, effectiveTransmitterAddress)
 			if fwderr == nil {
 				effectiveTransmitterAddress = fwdrAddress
 			} else {

--- a/core/services/ocr2/delegate.go
+++ b/core/services/ocr2/delegate.go
@@ -382,7 +382,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, jb job.Job) ([]job.Servi
 		if err2 != nil {
 			return nil, fmt.Errorf("ServicesForSpec: could not get EVM chain %s: %w", rid.ChainID, err2)
 		}
-		effectiveTransmitterID, err2 = GetEVMEffectiveTransmitterID(&jb, chain, lggr)
+		effectiveTransmitterID, err2 = GetEVMEffectiveTransmitterID(ctx, &jb, chain, lggr)
 		if err2 != nil {
 			return nil, fmt.Errorf("ServicesForSpec failed to get evm transmitterID: %w", err2)
 		}
@@ -470,7 +470,7 @@ func (d *Delegate) ServicesForSpec(ctx context.Context, jb job.Job) ([]job.Servi
 	}
 }
 
-func GetEVMEffectiveTransmitterID(jb *job.Job, chain legacyevm.Chain, lggr logger.SugaredLogger) (string, error) {
+func GetEVMEffectiveTransmitterID(ctx context.Context, jb *job.Job, chain legacyevm.Chain, lggr logger.SugaredLogger) (string, error) {
 	spec := jb.OCR2OracleSpec
 	if spec.PluginType == types.Mercury || spec.PluginType == types.LLO {
 		return spec.TransmitterID.String, nil
@@ -501,9 +501,9 @@ func GetEVMEffectiveTransmitterID(jb *job.Job, chain legacyevm.Chain, lggr logge
 		var effectiveTransmitterID common.Address
 		// Median forwarders need special handling because of OCR2Aggregator transmitters whitelist.
 		if spec.PluginType == types.Median {
-			effectiveTransmitterID, err = chain.TxManager().GetForwarderForEOAOCR2Feeds(common.HexToAddress(spec.TransmitterID.String), common.HexToAddress(spec.ContractID))
+			effectiveTransmitterID, err = chain.TxManager().GetForwarderForEOAOCR2Feeds(ctx, common.HexToAddress(spec.TransmitterID.String), common.HexToAddress(spec.ContractID))
 		} else {
-			effectiveTransmitterID, err = chain.TxManager().GetForwarderForEOA(common.HexToAddress(spec.TransmitterID.String))
+			effectiveTransmitterID, err = chain.TxManager().GetForwarderForEOA(ctx, common.HexToAddress(spec.TransmitterID.String))
 		}
 
 		if err == nil {

--- a/core/services/ocr2/delegate_test.go
+++ b/core/services/ocr2/delegate_test.go
@@ -5,10 +5,12 @@ import (
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/guregu/null.v4"
 
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+
 	evmcfg "github.com/smartcontractkit/chainlink/v2/core/chains/evm/config/toml"
 	txmmocks "github.com/smartcontractkit/chainlink/v2/core/chains/evm/txmgr/mocks"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils/big"
@@ -27,7 +29,6 @@ import (
 )
 
 func TestGetEVMEffectiveTransmitterID(t *testing.T) {
-	ctx := testutils.Context(t)
 	customChainID := big.New(testutils.NewRandomEVMChainID())
 
 	config := configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
@@ -41,7 +42,7 @@ func TestGetEVMEffectiveTransmitterID(t *testing.T) {
 	})
 	db := pgtest.NewSqlxDB(t)
 	keyStore := cltest.NewKeyStore(t, db)
-	require.NoError(t, keyStore.OCR2().Add(ctx, cltest.DefaultOCR2Key))
+	require.NoError(t, keyStore.OCR2().Add(testutils.Context(t), cltest.DefaultOCR2Key))
 	lggr := logger.TestLogger(t)
 
 	txManager := txmmocks.NewMockEvmTxManager(t)
@@ -67,7 +68,7 @@ func TestGetEVMEffectiveTransmitterID(t *testing.T) {
 		jb.OCR2OracleSpec.RelayConfig["sendingKeys"] = tc.sendingKeys
 		jb.ForwardingAllowed = tc.forwardingEnabled
 
-		args := []interface{}{tc.getForwarderForEOAArg}
+		args := []interface{}{mock.Anything, tc.getForwarderForEOAArg}
 		getForwarderMethodName := "GetForwarderForEOA"
 		if tc.pluginType == types.Median {
 			getForwarderMethodName = "GetForwarderForEOAOCR2Feeds"
@@ -144,13 +145,14 @@ func TestGetEVMEffectiveTransmitterID(t *testing.T) {
 	}
 
 	t.Run("when sending keys are not defined, the first one should be set to transmitterID", func(t *testing.T) {
+		ctx := testutils.Context(t)
 		jb, err := ocr2validate.ValidatedOracleSpecToml(testutils.Context(t), config.OCR2(), config.Insecure(), testspecs.GetOCR2EVMSpecMinimal(), nil)
 		require.NoError(t, err)
 		jb.OCR2OracleSpec.TransmitterID = null.StringFrom("some transmitterID string")
 		jb.OCR2OracleSpec.RelayConfig["sendingKeys"] = nil
 		chain, err := legacyChains.Get(customChainID.String())
 		require.NoError(t, err)
-		effectiveTransmitterID, err := ocr2.GetEVMEffectiveTransmitterID(&jb, chain, lggr)
+		effectiveTransmitterID, err := ocr2.GetEVMEffectiveTransmitterID(ctx, &jb, chain, lggr)
 		require.NoError(t, err)
 		require.Equal(t, "some transmitterID string", effectiveTransmitterID)
 		require.Equal(t, []string{"some transmitterID string"}, jb.OCR2OracleSpec.RelayConfig["sendingKeys"].([]string))
@@ -158,13 +160,14 @@ func TestGetEVMEffectiveTransmitterID(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := testutils.Context(t)
 			jb, err := ocr2validate.ValidatedOracleSpecToml(testutils.Context(t), config.OCR2(), config.Insecure(), testspecs.GetOCR2EVMSpecMinimal(), nil)
 			require.NoError(t, err)
 			setTestCase(&jb, tc, txManager)
 			chain, err := legacyChains.Get(customChainID.String())
 			require.NoError(t, err)
 
-			effectiveTransmitterID, err := ocr2.GetEVMEffectiveTransmitterID(&jb, chain, lggr)
+			effectiveTransmitterID, err := ocr2.GetEVMEffectiveTransmitterID(ctx, &jb, chain, lggr)
 			if tc.expectedError {
 				require.Error(t, err)
 			} else {
@@ -180,13 +183,14 @@ func TestGetEVMEffectiveTransmitterID(t *testing.T) {
 	}
 
 	t.Run("when forwarders are enabled and chain retrieval fails, error should be handled", func(t *testing.T) {
+		ctx := testutils.Context(t)
 		jb, err := ocr2validate.ValidatedOracleSpecToml(testutils.Context(t), config.OCR2(), config.Insecure(), testspecs.GetOCR2EVMSpecMinimal(), nil)
 		require.NoError(t, err)
 		jb.ForwardingAllowed = true
 		jb.OCR2OracleSpec.TransmitterID = null.StringFrom("0x7e57000000000000000000000000000000000001")
 		chain, err := legacyChains.Get("not an id")
 		require.Error(t, err)
-		_, err = ocr2.GetEVMEffectiveTransmitterID(&jb, chain, lggr)
+		_, err = ocr2.GetEVMEffectiveTransmitterID(ctx, &jb, chain, lggr)
 		require.Error(t, err)
 	})
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry.go
@@ -102,10 +102,12 @@ func NewEVMRegistryService(addr common.Address, client legacyevm.Chain, lggr log
 		enc:      EVMAutomationEncoder20{},
 	}
 
-	r.ctx, r.cancel = context.WithCancel(context.Background())
+	r.stopCh = make(chan struct{})
 	r.reInit = time.NewTimer(reInitializationDelay)
 
-	if err := r.registerEvents(client.ID().Uint64(), addr); err != nil {
+	ctx, cancel := r.stopCh.NewCtx()
+	defer cancel()
+	if err := r.registerEvents(ctx, client.ID().Uint64(), addr); err != nil {
 		return nil, fmt.Errorf("logPoller error while registering automation events: %w", err)
 	}
 
@@ -152,8 +154,7 @@ type EvmRegistry struct {
 	mu            sync.RWMutex
 	txHashes      map[string]bool
 	lastPollBlock int64
-	ctx           context.Context
-	cancel        context.CancelFunc
+	stopCh        services.StopChan
 	active        map[string]activeUpkeep
 	headFunc      func(ocr2keepers.BlockKey)
 	runState      int
@@ -209,8 +210,10 @@ func (r *EvmRegistry) Start(_ context.Context) error {
 		defer r.mu.Unlock()
 		// initialize the upkeep keys; if the reInit timer returns, do it again
 		{
-			go func(cx context.Context, tmr *time.Timer, lggr logger.Logger, f func() error) {
-				err := f()
+			go func(tmr *time.Timer, lggr logger.Logger, f func(context.Context) error) {
+				ctx, cancel := r.stopCh.NewCtx()
+				defer cancel()
+				err := f(ctx)
 				if err != nil {
 					lggr.Errorf("failed to initialize upkeeps", err)
 				}
@@ -218,53 +221,57 @@ func (r *EvmRegistry) Start(_ context.Context) error {
 				for {
 					select {
 					case <-tmr.C:
-						err = f()
+						err = f(ctx)
 						if err != nil {
 							lggr.Errorf("failed to re-initialize upkeeps", err)
 						}
 						tmr.Reset(reInitializationDelay)
-					case <-cx.Done():
+					case <-ctx.Done():
 						return
 					}
 				}
-			}(r.ctx, r.reInit, r.lggr, r.initialize)
+			}(r.reInit, r.lggr, r.initialize)
 		}
 
 		// start polling logs on an interval
 		{
-			go func(cx context.Context, lggr logger.Logger, f func() error) {
+			go func(lggr logger.Logger, f func(context.Context) error) {
+				ctx, cancel := r.stopCh.NewCtx()
+				defer cancel()
 				ticker := time.NewTicker(time.Second)
 
 				for {
 					select {
 					case <-ticker.C:
-						err := f()
+						err := f(ctx)
 						if err != nil {
 							lggr.Errorf("failed to poll logs for upkeeps", err)
 						}
-					case <-cx.Done():
+					case <-ctx.Done():
 						ticker.Stop()
 						return
 					}
 				}
-			}(r.ctx, r.lggr, r.pollLogs)
+			}(r.lggr, r.pollLogs)
 		}
 
 		// run process to process logs from log channel
 		{
-			go func(cx context.Context, ch chan logpoller.Log, lggr logger.Logger, f func(logpoller.Log) error) {
+			go func(ch chan logpoller.Log, lggr logger.Logger, f func(context.Context, logpoller.Log) error) {
+				ctx, cancel := r.stopCh.NewCtx()
+				defer cancel()
 				for {
 					select {
 					case l := <-ch:
-						err := f(l)
+						err := f(ctx, l)
 						if err != nil {
 							lggr.Errorf("failed to process log for upkeep", err)
 						}
-					case <-cx.Done():
+					case <-ctx.Done():
 						return
 					}
 				}
-			}(r.ctx, r.chLog, r.lggr, r.processUpkeepStateLog)
+			}(r.chLog, r.lggr, r.processUpkeepStateLog)
 		}
 
 		r.runState = 1
@@ -276,7 +283,7 @@ func (r *EvmRegistry) Close() error {
 	return r.sync.StopOnce("AutomationRegistry", func() error {
 		r.mu.Lock()
 		defer r.mu.Unlock()
-		r.cancel()
+		close(r.stopCh)
 		r.runState = 0
 		r.runError = nil
 		return nil
@@ -303,8 +310,8 @@ func (r *EvmRegistry) HealthReport() map[string]error {
 	return map[string]error{r.Name(): r.sync.Healthy()}
 }
 
-func (r *EvmRegistry) initialize() error {
-	startupCtx, cancel := context.WithTimeout(r.ctx, reInitializationDelay)
+func (r *EvmRegistry) initialize(ctx context.Context) error {
+	startupCtx, cancel := context.WithTimeout(ctx, reInitializationDelay)
 	defer cancel()
 
 	idMap := make(map[string]activeUpkeep)
@@ -345,12 +352,12 @@ func (r *EvmRegistry) initialize() error {
 	return nil
 }
 
-func (r *EvmRegistry) pollLogs() error {
+func (r *EvmRegistry) pollLogs(ctx context.Context) error {
 	var latest int64
 	var end logpoller.LogPollerBlock
 	var err error
 
-	if end, err = r.poller.LatestBlock(r.ctx); err != nil {
+	if end, err = r.poller.LatestBlock(ctx); err != nil {
 		return fmt.Errorf("%w: %s", ErrHeadNotAvailable, err)
 	}
 
@@ -367,7 +374,7 @@ func (r *EvmRegistry) pollLogs() error {
 	{
 		var logs []logpoller.Log
 		if logs, err = r.poller.LogsWithSigs(
-			r.ctx,
+			ctx,
 			end.BlockNumber-logEventLookback,
 			end.BlockNumber,
 			upkeepStateEvents,
@@ -388,17 +395,17 @@ func UpkeepFilterName(addr common.Address) string {
 	return logpoller.FilterName("EvmRegistry - Upkeep events for", addr.String())
 }
 
-func (r *EvmRegistry) registerEvents(chainID uint64, addr common.Address) error {
+func (r *EvmRegistry) registerEvents(ctx context.Context, chainID uint64, addr common.Address) error {
 	// Add log filters for the log poller so that it can poll and find the logs that
 	// we need
-	return r.poller.RegisterFilter(r.ctx, logpoller.Filter{
+	return r.poller.RegisterFilter(ctx, logpoller.Filter{
 		Name:      UpkeepFilterName(addr),
 		EventSigs: append(upkeepStateEvents, upkeepActiveEvents...),
 		Addresses: []common.Address{addr},
 	})
 }
 
-func (r *EvmRegistry) processUpkeepStateLog(l logpoller.Log) error {
+func (r *EvmRegistry) processUpkeepStateLog(ctx context.Context, l logpoller.Log) error {
 	hash := l.TxHash.String()
 	if _, ok := r.txHashes[hash]; ok {
 		return nil
@@ -414,22 +421,22 @@ func (r *EvmRegistry) processUpkeepStateLog(l logpoller.Log) error {
 	switch l := abilog.(type) {
 	case *keeper_registry_wrapper2_0.KeeperRegistryUpkeepRegistered:
 		r.lggr.Debugf("KeeperRegistryUpkeepRegistered log detected for upkeep ID %s in transaction %s", l.Id.String(), hash)
-		r.addToActive(l.Id, false)
+		r.addToActive(ctx, l.Id, false)
 	case *keeper_registry_wrapper2_0.KeeperRegistryUpkeepReceived:
 		r.lggr.Debugf("KeeperRegistryUpkeepReceived log detected for upkeep ID %s in transaction %s", l.Id.String(), hash)
-		r.addToActive(l.Id, false)
+		r.addToActive(ctx, l.Id, false)
 	case *keeper_registry_wrapper2_0.KeeperRegistryUpkeepUnpaused:
 		r.lggr.Debugf("KeeperRegistryUpkeepUnpaused log detected for upkeep ID %s in transaction %s", l.Id.String(), hash)
-		r.addToActive(l.Id, false)
+		r.addToActive(ctx, l.Id, false)
 	case *keeper_registry_wrapper2_0.KeeperRegistryUpkeepGasLimitSet:
 		r.lggr.Debugf("KeeperRegistryUpkeepGasLimitSet log detected for upkeep ID %s in transaction %s", l.Id.String(), hash)
-		r.addToActive(l.Id, true)
+		r.addToActive(ctx, l.Id, true)
 	}
 
 	return nil
 }
 
-func (r *EvmRegistry) addToActive(id *big.Int, force bool) {
+func (r *EvmRegistry) addToActive(ctx context.Context, id *big.Int, force bool) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -438,7 +445,7 @@ func (r *EvmRegistry) addToActive(id *big.Int, force bool) {
 	}
 
 	if _, ok := r.active[id.String()]; !ok || force {
-		actives, err := r.getUpkeepConfigs(r.ctx, []*big.Int{id})
+		actives, err := r.getUpkeepConfigs(ctx, []*big.Int{id})
 		if err != nil {
 			r.lggr.Errorf("failed to get upkeep configs during adding active upkeep: %w", err)
 			return

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v20/registry_test.go
@@ -186,6 +186,7 @@ func TestPollLogs(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
+			ctx := testutils.Context(t)
 			mp := new(mocks.LogPoller)
 
 			if test.LatestBlock != nil {
@@ -205,7 +206,7 @@ func TestPollLogs(t *testing.T) {
 				chLog:         make(chan logpoller.Log, 10),
 			}
 
-			err := rg.pollLogs()
+			err := rg.pollLogs(ctx)
 
 			assert.Equal(t, test.ExpectedLastPoll, rg.lastPollBlock)
 			if test.ExpectedErr != nil {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry.go
@@ -98,7 +98,7 @@ func NewEvmRegistry(
 	hc := http.DefaultClient
 
 	return &EvmRegistry{
-		ctx:              context.Background(),
+		stopCh:           make(chan struct{}),
 		threadCtrl:       utils.NewThreadControl(),
 		lggr:             lggr.Named(RegistryServiceName),
 		poller:           client.LogPoller(),
@@ -190,7 +190,7 @@ type EvmRegistry struct {
 	logProcessed     map[string]bool
 	active           ActiveUpkeepList
 	lastPollBlock    int64
-	ctx              context.Context
+	stopCh           services.StopChan
 	headFunc         func(ocr2keepers.BlockKey)
 	mercury          *MercuryConfig
 	hc               HttpClient
@@ -207,13 +207,13 @@ func (r *EvmRegistry) Name() string {
 
 func (r *EvmRegistry) Start(ctx context.Context) error {
 	return r.StartOnce(RegistryServiceName, func() error {
-		if err := r.registerEvents(r.chainID, r.addr); err != nil {
+		if err := r.registerEvents(ctx, r.chainID, r.addr); err != nil {
 			return fmt.Errorf("logPoller error while registering automation events: %w", err)
 		}
 
 		r.threadCtrl.Go(func(ctx context.Context) {
 			lggr := r.lggr.With("where", "upkeeps_referesh")
-			err := r.refreshActiveUpkeeps()
+			err := r.refreshActiveUpkeeps(ctx)
 			if err != nil {
 				lggr.Errorf("failed to initialize upkeeps", err)
 			}
@@ -224,7 +224,7 @@ func (r *EvmRegistry) Start(ctx context.Context) error {
 			for {
 				select {
 				case <-ticker.C:
-					err = r.refreshActiveUpkeeps()
+					err = r.refreshActiveUpkeeps(ctx)
 					if err != nil {
 						lggr.Errorf("failed to refresh upkeeps", err)
 					}
@@ -242,7 +242,7 @@ func (r *EvmRegistry) Start(ctx context.Context) error {
 			for {
 				select {
 				case <-ticker.C:
-					err := r.pollUpkeepStateLogs()
+					err := r.pollUpkeepStateLogs(ctx)
 					if err != nil {
 						lggr.Errorf("failed to poll logs for upkeeps", err)
 					}
@@ -259,7 +259,7 @@ func (r *EvmRegistry) Start(ctx context.Context) error {
 			for {
 				select {
 				case l := <-ch:
-					err := r.processUpkeepStateLog(l)
+					err := r.processUpkeepStateLog(ctx, l)
 					if err != nil {
 						lggr.Errorf("failed to process log for upkeep", err)
 					}
@@ -284,9 +284,9 @@ func (r *EvmRegistry) HealthReport() map[string]error {
 	return map[string]error{RegistryServiceName: r.Healthy()}
 }
 
-func (r *EvmRegistry) refreshActiveUpkeeps() error {
+func (r *EvmRegistry) refreshActiveUpkeeps(ctx context.Context) error {
 	// Allow for max timeout of refreshInterval
-	ctx, cancel := context.WithTimeout(r.ctx, refreshInterval)
+	ctx, cancel := context.WithTimeout(ctx, refreshInterval)
 	defer cancel()
 
 	r.lggr.Debugf("Refreshing active upkeeps list")
@@ -311,17 +311,17 @@ func (r *EvmRegistry) refreshActiveUpkeeps() error {
 		}
 	}
 
-	_, err = r.logEventProvider.RefreshActiveUpkeeps(r.ctx, logTriggerIDs...)
+	_, err = r.logEventProvider.RefreshActiveUpkeeps(ctx, logTriggerIDs...)
 	if err != nil {
 		return fmt.Errorf("failed to refresh active upkeep ids in log event provider: %w", err)
 	}
 
 	// Try to refersh log trigger config for all log upkeeps
-	return r.refreshLogTriggerUpkeeps(logTriggerIDs)
+	return r.refreshLogTriggerUpkeeps(ctx, logTriggerIDs)
 }
 
 // refreshLogTriggerUpkeeps refreshes the active upkeep ids for log trigger upkeeps
-func (r *EvmRegistry) refreshLogTriggerUpkeeps(ids []*big.Int) error {
+func (r *EvmRegistry) refreshLogTriggerUpkeeps(ctx context.Context, ids []*big.Int) error {
 	var err error
 	for i := 0; i < len(ids); i += logTriggerRefreshBatchSize {
 		end := i + logTriggerRefreshBatchSize
@@ -330,7 +330,7 @@ func (r *EvmRegistry) refreshLogTriggerUpkeeps(ids []*big.Int) error {
 		}
 		idBatch := ids[i:end]
 
-		if batchErr := r.refreshLogTriggerUpkeepsBatch(idBatch); batchErr != nil {
+		if batchErr := r.refreshLogTriggerUpkeepsBatch(ctx, idBatch); batchErr != nil {
 			multierr.AppendInto(&err, batchErr)
 		}
 
@@ -340,17 +340,17 @@ func (r *EvmRegistry) refreshLogTriggerUpkeeps(ids []*big.Int) error {
 	return err
 }
 
-func (r *EvmRegistry) refreshLogTriggerUpkeepsBatch(logTriggerIDs []*big.Int) error {
+func (r *EvmRegistry) refreshLogTriggerUpkeepsBatch(ctx context.Context, logTriggerIDs []*big.Int) error {
 	var logTriggerHashes []common.Hash
 	for _, id := range logTriggerIDs {
 		logTriggerHashes = append(logTriggerHashes, common.BigToHash(id))
 	}
 
-	unpausedLogs, err := r.poller.IndexedLogs(r.ctx, ac.IAutomationV21PlusCommonUpkeepUnpaused{}.Topic(), r.addr, 1, logTriggerHashes, evmtypes.Confirmations(r.finalityDepth))
+	unpausedLogs, err := r.poller.IndexedLogs(ctx, ac.IAutomationV21PlusCommonUpkeepUnpaused{}.Topic(), r.addr, 1, logTriggerHashes, evmtypes.Confirmations(r.finalityDepth))
 	if err != nil {
 		return err
 	}
-	configSetLogs, err := r.poller.IndexedLogs(r.ctx, ac.IAutomationV21PlusCommonUpkeepTriggerConfigSet{}.Topic(), r.addr, 1, logTriggerHashes, evmtypes.Confirmations(r.finalityDepth))
+	configSetLogs, err := r.poller.IndexedLogs(ctx, ac.IAutomationV21PlusCommonUpkeepTriggerConfigSet{}.Topic(), r.addr, 1, logTriggerHashes, evmtypes.Confirmations(r.finalityDepth))
 	if err != nil {
 		return err
 	}
@@ -400,7 +400,7 @@ func (r *EvmRegistry) refreshLogTriggerUpkeepsBatch(logTriggerIDs []*big.Int) er
 		if unpausedBlockNumbers[id.String()] > logBlock {
 			logBlock = unpausedBlockNumbers[id.String()]
 		}
-		if err := r.updateTriggerConfig(id, config, logBlock); err != nil {
+		if err := r.updateTriggerConfig(ctx, id, config, logBlock); err != nil {
 			merr = goerrors.Join(merr, fmt.Errorf("failed to update trigger config for upkeep id %s: %w", id.String(), err))
 		}
 	}
@@ -408,12 +408,12 @@ func (r *EvmRegistry) refreshLogTriggerUpkeepsBatch(logTriggerIDs []*big.Int) er
 	return merr
 }
 
-func (r *EvmRegistry) pollUpkeepStateLogs() error {
+func (r *EvmRegistry) pollUpkeepStateLogs(ctx context.Context) error {
 	var latest int64
 	var end logpoller.LogPollerBlock
 	var err error
 
-	if end, err = r.poller.LatestBlock(r.ctx); err != nil {
+	if end, err = r.poller.LatestBlock(ctx); err != nil {
 		return fmt.Errorf("%w: %s", ErrHeadNotAvailable, err)
 	}
 
@@ -429,7 +429,7 @@ func (r *EvmRegistry) pollUpkeepStateLogs() error {
 
 	var logs []logpoller.Log
 	if logs, err = r.poller.LogsWithSigs(
-		r.ctx,
+		ctx,
 		end.BlockNumber-logEventLookback,
 		end.BlockNumber,
 		upkeepStateEvents,
@@ -445,7 +445,7 @@ func (r *EvmRegistry) pollUpkeepStateLogs() error {
 	return nil
 }
 
-func (r *EvmRegistry) processUpkeepStateLog(l logpoller.Log) error {
+func (r *EvmRegistry) processUpkeepStateLog(ctx context.Context, l logpoller.Log) error {
 	lid := fmt.Sprintf("%s%d", l.TxHash.String(), l.LogIndex)
 	r.mu.Lock()
 	if _, ok := r.logProcessed[lid]; ok {
@@ -465,16 +465,16 @@ func (r *EvmRegistry) processUpkeepStateLog(l logpoller.Log) error {
 	switch l := abilog.(type) {
 	case *ac.IAutomationV21PlusCommonUpkeepPaused:
 		r.lggr.Debugf("KeeperRegistryUpkeepPaused log detected for upkeep ID %s in transaction %s", l.Id.String(), txHash)
-		r.removeFromActive(r.ctx, l.Id)
+		r.removeFromActive(ctx, l.Id)
 	case *ac.IAutomationV21PlusCommonUpkeepCanceled:
 		r.lggr.Debugf("KeeperRegistryUpkeepCanceled log detected for upkeep ID %s in transaction %s", l.Id.String(), txHash)
-		r.removeFromActive(r.ctx, l.Id)
+		r.removeFromActive(ctx, l.Id)
 	case *ac.IAutomationV21PlusCommonUpkeepMigrated:
 		r.lggr.Debugf("AutomationV2CommonUpkeepMigrated log detected for upkeep ID %s in transaction %s", l.Id.String(), txHash)
-		r.removeFromActive(r.ctx, l.Id)
+		r.removeFromActive(ctx, l.Id)
 	case *ac.IAutomationV21PlusCommonUpkeepTriggerConfigSet:
 		r.lggr.Debugf("KeeperRegistryUpkeepTriggerConfigSet log detected for upkeep ID %s in transaction %s", l.Id.String(), txHash)
-		if err := r.updateTriggerConfig(l.Id, l.TriggerConfig, rawLog.BlockNumber); err != nil {
+		if err := r.updateTriggerConfig(ctx, l.Id, l.TriggerConfig, rawLog.BlockNumber); err != nil {
 			r.lggr.Warnf("failed to update trigger config upon AutomationV2CommonUpkeepTriggerConfigSet for upkeep ID %s: %s", l.Id.String(), err)
 		}
 	case *ac.IAutomationV21PlusCommonUpkeepRegistered:
@@ -483,19 +483,19 @@ func (r *EvmRegistry) processUpkeepStateLog(l logpoller.Log) error {
 		trigger := core.GetUpkeepType(*uid)
 		r.lggr.Debugf("KeeperRegistryUpkeepRegistered log detected for upkeep ID %s (trigger=%d) in transaction %s", l.Id.String(), trigger, txHash)
 		r.active.Add(l.Id)
-		if err := r.updateTriggerConfig(l.Id, nil, rawLog.BlockNumber); err != nil {
+		if err := r.updateTriggerConfig(ctx, l.Id, nil, rawLog.BlockNumber); err != nil {
 			r.lggr.Warnf("failed to update trigger config upon AutomationV2CommonUpkeepRegistered for upkeep ID %s: %s", err)
 		}
 	case *ac.IAutomationV21PlusCommonUpkeepReceived:
 		r.lggr.Debugf("KeeperRegistryUpkeepReceived log detected for upkeep ID %s in transaction %s", l.Id.String(), txHash)
 		r.active.Add(l.Id)
-		if err := r.updateTriggerConfig(l.Id, nil, rawLog.BlockNumber); err != nil {
+		if err := r.updateTriggerConfig(ctx, l.Id, nil, rawLog.BlockNumber); err != nil {
 			r.lggr.Warnf("failed to update trigger config upon AutomationV2CommonUpkeepReceived for upkeep ID %s: %s", err)
 		}
 	case *ac.IAutomationV21PlusCommonUpkeepUnpaused:
 		r.lggr.Debugf("KeeperRegistryUpkeepUnpaused log detected for upkeep ID %s in transaction %s", l.Id.String(), txHash)
 		r.active.Add(l.Id)
-		if err := r.updateTriggerConfig(l.Id, nil, rawLog.BlockNumber); err != nil {
+		if err := r.updateTriggerConfig(ctx, l.Id, nil, rawLog.BlockNumber); err != nil {
 			r.lggr.Warnf("failed to update trigger config upon AutomationV2CommonUpkeepUnpaused for upkeep ID %s: %s", err)
 		}
 	default:
@@ -510,9 +510,9 @@ func RegistryUpkeepFilterName(addr common.Address) string {
 }
 
 // registerEvents registers upkeep state events from keeper registry on log poller
-func (r *EvmRegistry) registerEvents(_ uint64, addr common.Address) error {
+func (r *EvmRegistry) registerEvents(ctx context.Context, _ uint64, addr common.Address) error {
 	// Add log filters for the log poller so that it can poll and find the logs that we need
-	return r.poller.RegisterFilter(r.ctx, logpoller.Filter{
+	return r.poller.RegisterFilter(ctx, logpoller.Filter{
 		Name:      RegistryUpkeepFilterName(addr),
 		EventSigs: upkeepStateEvents,
 		Addresses: []common.Address{addr},
@@ -591,13 +591,13 @@ func (r *EvmRegistry) getLatestIDsFromContract(ctx context.Context) ([]*big.Int,
 }
 
 // updateTriggerConfig updates the trigger config for an upkeep. it will re-register a filter for this upkeep.
-func (r *EvmRegistry) updateTriggerConfig(id *big.Int, cfg []byte, logBlock uint64) error {
+func (r *EvmRegistry) updateTriggerConfig(ctx context.Context, id *big.Int, cfg []byte, logBlock uint64) error {
 	uid := &ocr2keepers.UpkeepIdentifier{}
 	uid.FromBigInt(id)
 	switch core.GetUpkeepType(*uid) {
 	case types2.LogTrigger:
 		if len(cfg) == 0 {
-			fetched, err := r.fetchTriggerConfig(id)
+			fetched, err := r.fetchTriggerConfig(ctx, id)
 			if err != nil {
 				return errors.Wrap(err, "failed to fetch log upkeep config")
 			}
@@ -609,7 +609,7 @@ func (r *EvmRegistry) updateTriggerConfig(id *big.Int, cfg []byte, logBlock uint
 			r.lggr.Warnw("failed to unpack log upkeep config", "upkeepID", id.String(), "err", err)
 			return nil
 		}
-		if err := r.logEventProvider.RegisterFilter(r.ctx, logprovider.FilterOptions{
+		if err := r.logEventProvider.RegisterFilter(ctx, logprovider.FilterOptions{
 			TriggerConfig: logprovider.LogTriggerConfig(parsed),
 			UpkeepID:      id,
 			UpdateBlock:   logBlock,
@@ -623,8 +623,8 @@ func (r *EvmRegistry) updateTriggerConfig(id *big.Int, cfg []byte, logBlock uint
 }
 
 // fetchTriggerConfig fetches trigger config in raw bytes for an upkeep.
-func (r *EvmRegistry) fetchTriggerConfig(id *big.Int) ([]byte, error) {
-	opts := r.buildCallOpts(r.ctx, nil)
+func (r *EvmRegistry) fetchTriggerConfig(ctx context.Context, id *big.Int) ([]byte, error) {
+	opts := r.buildCallOpts(ctx, nil)
 	cfg, err := r.registry.GetUpkeepTriggerConfig(opts, id)
 	if err != nil {
 		r.lggr.Warnw("failed to get trigger config", "err", err)
@@ -634,8 +634,8 @@ func (r *EvmRegistry) fetchTriggerConfig(id *big.Int) ([]byte, error) {
 }
 
 // fetchUpkeepOffchainConfig fetches upkeep offchain config in raw bytes for an upkeep.
-func (r *EvmRegistry) fetchUpkeepOffchainConfig(id *big.Int) ([]byte, error) {
-	opts := r.buildCallOpts(r.ctx, nil)
+func (r *EvmRegistry) fetchUpkeepOffchainConfig(ctx context.Context, id *big.Int) ([]byte, error) {
+	opts := r.buildCallOpts(ctx, nil)
 	ui, err := r.registry.GetUpkeep(opts, id)
 	if err != nil {
 		return []byte{}, err

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_check_pipeline.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_check_pipeline.go
@@ -96,8 +96,8 @@ func (r *EvmRegistry) getBlockAndUpkeepId(upkeepID ocr2keepers.UpkeepIdentifier,
 	return block, common.BytesToHash(trigger.BlockHash[:]), upkeepID.BigInt()
 }
 
-func (r *EvmRegistry) getBlockHash(blockNumber *big.Int) (common.Hash, error) {
-	blocks, err := r.poller.GetBlocksRange(r.ctx, []uint64{blockNumber.Uint64()})
+func (r *EvmRegistry) getBlockHash(ctx context.Context, blockNumber *big.Int) (common.Hash, error) {
+	blocks, err := r.poller.GetBlocksRange(ctx, []uint64{blockNumber.Uint64()})
 	if err != nil {
 		return [32]byte{}, err
 	}
@@ -109,7 +109,7 @@ func (r *EvmRegistry) getBlockHash(blockNumber *big.Int) (common.Hash, error) {
 }
 
 // verifyCheckBlock checks that the check block and hash are valid, returns the pipeline execution state and retryable
-func (r *EvmRegistry) verifyCheckBlock(_ context.Context, checkBlock, upkeepId *big.Int, checkHash common.Hash) (state encoding.PipelineExecutionState, retryable bool) {
+func (r *EvmRegistry) verifyCheckBlock(ctx context.Context, checkBlock, upkeepId *big.Int, checkHash common.Hash) (state encoding.PipelineExecutionState, retryable bool) {
 	// verify check block number and hash are valid
 	h, ok := r.bs.queryBlocksMap(checkBlock.Int64())
 	// if this block number/hash combo exists in block subscriber, this check block and hash still exist on chain and are valid
@@ -119,7 +119,7 @@ func (r *EvmRegistry) verifyCheckBlock(_ context.Context, checkBlock, upkeepId *
 		return encoding.NoPipelineError, false
 	}
 	r.lggr.Warnf("check block %s does not exist in block subscriber or hash does not match for upkeepId %s. this may be caused by block subscriber outdated due to re-org, querying eth client to confirm", checkBlock, upkeepId)
-	b, err := r.getBlockHash(checkBlock)
+	b, err := r.getBlockHash(ctx, checkBlock)
 	if err != nil {
 		r.lggr.Warnf("failed to query block %s: %s", checkBlock, err.Error())
 		return encoding.RpcFlakyFailure, true
@@ -132,7 +132,7 @@ func (r *EvmRegistry) verifyCheckBlock(_ context.Context, checkBlock, upkeepId *
 }
 
 // verifyLogExists checks that the log still exists on chain, returns failure reason, pipeline error, and retryable
-func (r *EvmRegistry) verifyLogExists(upkeepId *big.Int, p ocr2keepers.UpkeepPayload) (encoding.UpkeepFailureReason, encoding.PipelineExecutionState, bool) {
+func (r *EvmRegistry) verifyLogExists(ctx context.Context, upkeepId *big.Int, p ocr2keepers.UpkeepPayload) (encoding.UpkeepFailureReason, encoding.PipelineExecutionState, bool) {
 	logBlockNumber := int64(p.Trigger.LogTriggerExtension.BlockNumber)
 	logBlockHash := common.BytesToHash(p.Trigger.LogTriggerExtension.BlockHash[:])
 	checkBlockHash := common.BytesToHash(p.Trigger.BlockHash[:])
@@ -158,7 +158,7 @@ func (r *EvmRegistry) verifyLogExists(upkeepId *big.Int, p ocr2keepers.UpkeepPay
 		r.lggr.Debugf("log block not provided, querying eth client for tx hash %s for upkeepId %s", hexutil.Encode(p.Trigger.LogTriggerExtension.TxHash[:]), upkeepId)
 	}
 	// query eth client as a fallback
-	bn, bh, err := core.GetTxBlock(r.ctx, r.client, p.Trigger.LogTriggerExtension.TxHash)
+	bn, bh, err := core.GetTxBlock(ctx, r.client, p.Trigger.LogTriggerExtension.TxHash)
 	if err != nil {
 		// primitive way of checking errors
 		if strings.Contains(err.Error(), "missing required field") || strings.Contains(err.Error(), "not found") {
@@ -202,7 +202,7 @@ func (r *EvmRegistry) checkUpkeeps(ctx context.Context, payloads []ocr2keepers.U
 		uid.FromBigInt(upkeepId)
 		switch core.GetUpkeepType(*uid) {
 		case types.LogTrigger:
-			reason, state, retryable := r.verifyLogExists(upkeepId, p)
+			reason, state, retryable := r.verifyLogExists(ctx, upkeepId, p)
 			if reason != encoding.UpkeepFailureReasonNone || state != encoding.NoPipelineError {
 				results[i] = encoding.GetIneligibleCheckResultWithoutPerformData(p, reason, state, retryable)
 				continue
@@ -306,7 +306,7 @@ func (r *EvmRegistry) simulatePerformUpkeeps(ctx context.Context, checkResults [
 
 		block, _, upkeepId := r.getBlockAndUpkeepId(cr.UpkeepID, cr.Trigger)
 
-		oc, err := r.fetchUpkeepOffchainConfig(upkeepId)
+		oc, err := r.fetchUpkeepOffchainConfig(ctx, upkeepId)
 		if err != nil {
 			// this is mostly caused by RPC flakiness
 			r.lggr.Errorw("failed get offchain config, gas price check will be disabled", "err", err, "upkeepId", upkeepId, "block", block)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_check_pipeline_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_check_pipeline_test.go
@@ -346,13 +346,13 @@ func TestRegistry_VerifyLogExists(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := testutils.Context(t)
 			bs := &BlockSubscriber{
 				blocks: tc.blocks,
 			}
 			e := &EvmRegistry{
 				lggr: lggr,
 				bs:   bs,
-				ctx:  testutils.Context(t),
 			}
 
 			if tc.makeEthCall {
@@ -370,7 +370,7 @@ func TestRegistry_VerifyLogExists(t *testing.T) {
 				e.client = client
 			}
 
-			reason, state, retryable := e.verifyLogExists(tc.upkeepId, tc.payload)
+			reason, state, retryable := e.verifyLogExists(ctx, tc.upkeepId, tc.payload)
 			assert.Equal(t, tc.reason, reason)
 			assert.Equal(t, tc.state, state)
 			assert.Equal(t, tc.retryable, retryable)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/registry_test.go
@@ -16,7 +16,9 @@ import (
 
 	types2 "github.com/smartcontractkit/chainlink-automation/pkg/v3/types"
 	"github.com/smartcontractkit/chainlink-common/pkg/types"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
+	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils"
 
 	types3 "github.com/smartcontractkit/chainlink/v2/core/chains/evm/headtracker/types"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
@@ -186,6 +188,7 @@ func TestPollLogs(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.Name, func(t *testing.T) {
+			ctx := testutils.Context(t)
 			mp := new(mocks.LogPoller)
 
 			if test.LatestBlock != nil {
@@ -205,7 +208,7 @@ func TestPollLogs(t *testing.T) {
 				chLog:         make(chan logpoller.Log, 10),
 			}
 
-			err := rg.pollUpkeepStateLogs()
+			err := rg.pollUpkeepStateLogs(ctx)
 
 			assert.Equal(t, test.ExpectedLastPoll, rg.lastPollBlock)
 			if test.ExpectedErr != nil {
@@ -542,6 +545,7 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
+			ctx := tests.Context(t)
 			lggr := logger.TestLogger(t)
 			var hb types3.HeadBroadcaster
 			var lp logpoller.LogPoller
@@ -559,7 +563,7 @@ func TestRegistry_refreshLogTriggerUpkeeps(t *testing.T) {
 				lggr:             lggr,
 			}
 
-			err := registry.refreshLogTriggerUpkeeps(tc.ids)
+			err := registry.refreshLogTriggerUpkeeps(ctx, tc.ids)
 			if tc.expectsErr {
 				assert.Error(t, err)
 				assert.Equal(t, err.Error(), tc.wantErr.Error())

--- a/core/services/ocr2/plugins/ocr2keeper/integration_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/integration_test.go
@@ -427,6 +427,7 @@ func setupForwarderForNode(
 	backend *backends.SimulatedBackend,
 	recipient common.Address,
 	linkAddr common.Address) common.Address {
+	ctx := testutils.Context(t)
 	faddr, _, authorizedForwarder, err := authorized_forwarder.DeployAuthorizedForwarder(caller, backend, linkAddr, caller.From, recipient, []byte{})
 	require.NoError(t, err)
 
@@ -438,12 +439,12 @@ func setupForwarderForNode(
 	// add forwarder address to be tracked in db
 	forwarderORM := forwarders.NewORM(app.GetDB())
 	chainID := ubig.Big(*backend.Blockchain().Config().ChainID)
-	_, err = forwarderORM.CreateForwarder(testutils.Context(t), faddr, chainID)
+	_, err = forwarderORM.CreateForwarder(ctx, faddr, chainID)
 	require.NoError(t, err)
 
 	chain, err := app.GetRelayers().LegacyEVMChains().Get((*big.Int)(&chainID).String())
 	require.NoError(t, err)
-	fwdr, err := chain.TxManager().GetForwarderForEOA(recipient)
+	fwdr, err := chain.TxManager().GetForwarderForEOA(ctx, recipient)
 	require.NoError(t, err)
 	require.Equal(t, faddr, fwdr)
 

--- a/core/services/pipeline/helpers_test.go
+++ b/core/services/pipeline/helpers_test.go
@@ -1,6 +1,7 @@
 package pipeline
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -64,4 +65,4 @@ func (t *ETHTxTask) HelperSetDependencies(legacyChains legacyevm.LegacyChainCont
 	t.jobType = jobType
 }
 
-func (o *orm) Prune(pipelineSpecID int32) { o.prune(o.ds, pipelineSpecID) }
+func (o *orm) Prune(ctx context.Context, pipelineSpecID int32) { o.prune(ctx, o.ds, pipelineSpecID) }

--- a/core/services/pipeline/orm.go
+++ b/core/services/pipeline/orm.go
@@ -108,22 +108,19 @@ type orm struct {
 	lggr              logger.Logger
 	maxSuccessfulRuns uint64
 	// jobID => count
-	pm   sync.Map
-	wg   sync.WaitGroup
-	ctx  context.Context
-	cncl context.CancelFunc
+	pm     sync.Map
+	wg     sync.WaitGroup
+	stopCh services.StopChan
 }
 
 var _ ORM = (*orm)(nil)
 
 func NewORM(ds sqlutil.DataSource, lggr logger.Logger, jobPipelineMaxSuccessfulRuns uint64) *orm {
-	ctx, cancel := context.WithCancel(context.Background())
 	return &orm{
 		ds:                ds,
 		lggr:              lggr.Named("PipelineORM"),
 		maxSuccessfulRuns: jobPipelineMaxSuccessfulRuns,
-		ctx:               ctx,
-		cncl:              cancel,
+		stopCh:            make(chan struct{}),
 	}
 }
 
@@ -142,7 +139,7 @@ func (o *orm) Start(_ context.Context) error {
 
 func (o *orm) Close() error {
 	return o.StopOnce("PipelineORM", func() error {
-		o.cncl()
+		close(o.stopCh)
 		o.wg.Wait()
 		return nil
 	})
@@ -177,13 +174,11 @@ func (o *orm) DataSource() sqlutil.DataSource { return o.ds }
 func (o *orm) WithDataSource(ds sqlutil.DataSource) ORM { return o.withDataSource(ds) }
 
 func (o *orm) withDataSource(ds sqlutil.DataSource) *orm {
-	ctx, cancel := context.WithCancel(context.Background())
 	return &orm{
 		ds:                ds,
 		lggr:              o.lggr,
 		maxSuccessfulRuns: o.maxSuccessfulRuns,
-		ctx:               ctx,
-		cncl:              cancel,
+		stopCh:            make(chan struct{}),
 	}
 }
 
@@ -231,7 +226,7 @@ func (o *orm) CreateRun(ctx context.Context, run *Run) (err error) {
 // InsertRun inserts a run into the database
 func (o *orm) InsertRun(ctx context.Context, run *Run) error {
 	if run.Status() == RunStatusCompleted {
-		defer o.prune(o.ds, run.PruningKey)
+		defer o.prune(ctx, o.ds, run.PruningKey)
 	}
 	query, args, err := o.ds.BindNamed(`INSERT INTO pipeline_runs (pipeline_spec_id, pruning_key, meta, all_errors, fatal_errors, inputs, outputs, created_at, finished_at, state)
 		VALUES (:pipeline_spec_id, :pruning_key, :meta, :all_errors, :fatal_errors, :inputs, :outputs, :created_at, :finished_at, :state)
@@ -287,7 +282,7 @@ func (o *orm) StoreRun(ctx context.Context, run *Run) (restart bool, err error) 
 				return fmt.Errorf("failed to update pipeline run %d to %s: %w", run.ID, run.State, err)
 			}
 		} else {
-			defer o.prune(tx.ds, run.PruningKey)
+			defer o.prune(ctx, tx.ds, run.PruningKey)
 			// Simply finish the run, no need to do any sort of locking
 			if run.Outputs.Val == nil || len(run.FatalErrors)+len(run.AllErrors) == 0 {
 				return fmt.Errorf("run must have both Outputs and Errors, got Outputs: %#v, FatalErrors: %#v, AllErrors: %#v", run.Outputs.Val, run.FatalErrors, run.AllErrors)
@@ -401,7 +396,7 @@ RETURNING id
 
 		defer func() {
 			for pruningKey := range pruningKeysm {
-				o.prune(tx.ds, pruningKey)
+				o.prune(ctx, tx.ds, pruningKey)
 			}
 		}()
 
@@ -510,7 +505,7 @@ func (o *orm) insertFinishedRun(ctx context.Context, run *Run, saveSuccessfulTas
 		return nil
 	}
 
-	defer o.prune(o.ds, run.PruningKey)
+	defer o.prune(ctx, o.ds, run.PruningKey)
 	sql = `
 		INSERT INTO pipeline_task_runs (pipeline_run_id, id, type, index, output, error, dot_id, created_at, finished_at)
 		VALUES (:pipeline_run_id, :id, :type, :index, :output, :error, :dot_id, :created_at, :finished_at);`
@@ -709,13 +704,13 @@ const syncLimit = 1000
 //
 // Note this does not guarantee the pipeline_runs table is kept to exactly the
 // max length, rather that it doesn't excessively larger than it.
-func (o *orm) prune(tx sqlutil.DataSource, jobID int32) {
+func (o *orm) prune(ctx context.Context, tx sqlutil.DataSource, jobID int32) {
 	if jobID == 0 {
 		o.lggr.Panic("expected a non-zero job ID")
 	}
 	// For small maxSuccessfulRuns its fast enough to prune every time
 	if o.maxSuccessfulRuns < syncLimit {
-		o.withDataSource(tx).execPrune(o.ctx, jobID)
+		o.withDataSource(tx).execPrune(ctx, jobID)
 		return
 	}
 	// for large maxSuccessfulRuns we do it async on a sampled basis
@@ -725,15 +720,15 @@ func (o *orm) prune(tx sqlutil.DataSource, jobID int32) {
 	if val%every == 0 {
 		ok := o.IfStarted(func() {
 			o.wg.Add(1)
-			go func() {
+			go func(ctx context.Context) {
 				o.lggr.Debugw("Pruning runs", "jobID", jobID, "count", val, "every", every, "maxSuccessfulRuns", o.maxSuccessfulRuns)
 				defer o.wg.Done()
-				ctx, cancel := context.WithTimeout(sqlutil.WithoutDefaultTimeout(o.ctx), time.Minute)
+				ctx, cancel := o.stopCh.CtxCancel(context.WithTimeout(sqlutil.WithoutDefaultTimeout(ctx), time.Minute))
 				defer cancel()
 
 				// Must not use tx here since it could be stale by the time we execute async.
 				o.execPrune(ctx, jobID)
-			}()
+			}(context.WithoutCancel(ctx)) // don't propagate cancellation
 		})
 		if !ok {
 			o.lggr.Warnw("Cannot prune: ORM is not running", "jobID", jobID)
@@ -743,7 +738,7 @@ func (o *orm) prune(tx sqlutil.DataSource, jobID int32) {
 }
 
 func (o *orm) execPrune(ctx context.Context, jobID int32) {
-	res, err := o.ds.ExecContext(o.ctx, `DELETE FROM pipeline_runs WHERE pruning_key = $1 AND state = $2 AND id NOT IN (
+	res, err := o.ds.ExecContext(ctx, `DELETE FROM pipeline_runs WHERE pruning_key = $1 AND state = $2 AND id NOT IN (
 SELECT id FROM pipeline_runs
 WHERE pruning_key = $1 AND state = $2
 ORDER BY id DESC

--- a/core/services/pipeline/orm_test.go
+++ b/core/services/pipeline/orm_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/smartcontractkit/chainlink-common/pkg/sqlutil"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/hex"
 	"github.com/smartcontractkit/chainlink-common/pkg/utils/jsonserializable"
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 
 	"github.com/smartcontractkit/chainlink/v2/core/bridges"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/utils/big"
@@ -862,7 +863,8 @@ func Test_Prune(t *testing.T) {
 	jobID := ps1.ID
 
 	t.Run("when there are no runs to prune, does nothing", func(t *testing.T) {
-		porm.Prune(jobID)
+		ctx := tests.Context(t)
+		porm.Prune(ctx, jobID)
 
 		// no error logs; it did nothing
 		assert.Empty(t, observed.All())
@@ -898,7 +900,7 @@ func Test_Prune(t *testing.T) {
 		cltest.MustInsertPipelineRunWithStatus(t, db, ps2.ID, pipeline.RunStatusSuspended, jobID2)
 	}
 
-	porm.Prune(jobID2)
+	porm.Prune(tests.Context(t), jobID2)
 
 	cnt := pgtest.MustCount(t, db, "SELECT count(*) FROM pipeline_runs WHERE pipeline_spec_id = $1 AND state = $2", ps1.ID, pipeline.RunStatusCompleted)
 	assert.Equal(t, cnt, 20)

--- a/core/services/pipeline/task.eth_tx.go
+++ b/core/services/pipeline/task.eth_tx.go
@@ -140,7 +140,7 @@ func (t *ETHTxTask) Run(ctx context.Context, lggr logger.Logger, vars Vars, inpu
 	var forwarderAddress common.Address
 	if t.forwardingAllowed {
 		var fwderr error
-		forwarderAddress, fwderr = chain.TxManager().GetForwarderForEOA(fromAddr)
+		forwarderAddress, fwderr = chain.TxManager().GetForwarderForEOA(ctx, fromAddr)
 		if fwderr != nil {
 			lggr.Warnw("Skipping forwarding for job, will fallback to default behavior", "err", fwderr)
 		}

--- a/core/services/relay/evm/evm.go
+++ b/core/services/relay/evm/evm.go
@@ -439,8 +439,7 @@ type configWatcher struct {
 	chain            legacyevm.Chain
 	runReplay        bool
 	fromBlock        uint64
-	replayCtx        context.Context
-	replayCancel     context.CancelFunc
+	stopCh           services.StopChan
 	wg               sync.WaitGroup
 }
 
@@ -452,7 +451,6 @@ func newConfigWatcher(lggr logger.Logger,
 	fromBlock uint64,
 	runReplay bool,
 ) *configWatcher {
-	replayCtx, replayCancel := context.WithCancel(context.Background())
 	return &configWatcher{
 		lggr:             lggr.Named("ConfigWatcher").Named(contractAddress.String()),
 		contractAddress:  contractAddress,
@@ -461,8 +459,7 @@ func newConfigWatcher(lggr logger.Logger,
 		chain:            chain,
 		runReplay:        runReplay,
 		fromBlock:        fromBlock,
-		replayCtx:        replayCtx,
-		replayCancel:     replayCancel,
+		stopCh:           make(chan struct{}),
 	}
 }
 
@@ -477,8 +474,10 @@ func (c *configWatcher) Start(ctx context.Context) error {
 			c.wg.Add(1)
 			go func() {
 				defer c.wg.Done()
+				ctx, cancel := c.stopCh.NewCtx()
+				defer cancel()
 				c.lggr.Infow("starting replay for config", "fromBlock", c.fromBlock)
-				if err := c.configPoller.Replay(c.replayCtx, int64(c.fromBlock)); err != nil {
+				if err := c.configPoller.Replay(ctx, int64(c.fromBlock)); err != nil {
 					c.lggr.Errorf("error replaying for config", "err", err)
 				} else {
 					c.lggr.Infow("completed replaying for config", "fromBlock", c.fromBlock)
@@ -492,7 +491,7 @@ func (c *configWatcher) Start(ctx context.Context) error {
 
 func (c *configWatcher) Close() error {
 	return c.StopOnce(fmt.Sprintf("configWatcher %x", c.contractAddress), func() error {
-		c.replayCancel()
+		close(c.stopCh)
 		c.wg.Wait()
 		return c.configPoller.Close()
 	})

--- a/core/services/vrf/v2/listener_v2_log_listener_test.go
+++ b/core/services/vrf/v2/listener_v2_log_listener_test.go
@@ -1,7 +1,6 @@
 package v2
 
 import (
-	"context"
 	"fmt"
 	"math/big"
 	"strings"
@@ -20,6 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/smartcontractkit/chainlink-common/pkg/utils/tests"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/client"
 	"github.com/smartcontractkit/chainlink/v2/core/chains/evm/logpoller"
 	evmtypes "github.com/smartcontractkit/chainlink/v2/core/chains/evm/types"
@@ -56,7 +56,6 @@ type vrfLogPollerListenerTH struct {
 	EthDB             ethdb.Database
 	Db                *sqlx.DB
 	Listener          *listenerV2
-	Ctx               context.Context
 }
 
 func setupVRFLogPollerListenerTH(t *testing.T,
@@ -173,7 +172,6 @@ func setupVRFLogPollerListenerTH(t *testing.T,
 		EthDB:             ethDB,
 		Db:                db,
 		Listener:          listener,
-		Ctx:               ctx,
 	}
 	mockChainUpdateFn(chain, th)
 	return th
@@ -189,6 +187,7 @@ func setupVRFLogPollerListenerTH(t *testing.T,
 
 func TestInitProcessedBlock_NoVRFReqs(t *testing.T) {
 	t.Parallel()
+	ctx := tests.Context(t)
 
 	finalityDepth := int64(3)
 	th := setupVRFLogPollerListenerTH(t, false, finalityDepth, 3, 2, 1000, func(mockChain *evmmocks.Chain, th *vrfLogPollerListenerTH) {
@@ -226,7 +225,7 @@ func TestInitProcessedBlock_NoVRFReqs(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 3, len(logs))
 
-	lastProcessedBlock, err := th.Listener.initializeLastProcessedBlock(th.Ctx)
+	lastProcessedBlock, err := th.Listener.initializeLastProcessedBlock(ctx)
 	require.Nil(t, err)
 	require.Equal(t, int64(6), lastProcessedBlock)
 }
@@ -262,6 +261,7 @@ func TestLogPollerFilterRegistered(t *testing.T) {
 
 func TestInitProcessedBlock_NoUnfulfilledVRFReqs(t *testing.T) {
 	t.Parallel()
+	ctx := tests.Context(t)
 
 	finalityDepth := int64(3)
 	th := setupVRFLogPollerListenerTH(t, false, finalityDepth, 3, 2, 1000, func(mockChain *evmmocks.Chain, curTH *vrfLogPollerListenerTH) {
@@ -298,7 +298,7 @@ func TestInitProcessedBlock_NoUnfulfilledVRFReqs(t *testing.T) {
 	}
 
 	// Calling Start() after RegisterFilter() simulates a node restart after job creation, should reload Filter from db.
-	require.NoError(t, th.LogPoller.Start(th.Ctx))
+	require.NoError(t, th.LogPoller.Start(ctx))
 
 	// Blocks till now: 2 (in SetupTH) + 2 (empty blocks) + 2 (VRF req/resp block) + 5 (EmitLog blocks) = 11
 	latestBlock := int64(2 + 2 + 2 + 5)
@@ -308,17 +308,18 @@ func TestInitProcessedBlock_NoUnfulfilledVRFReqs(t *testing.T) {
 	// Then test if log poller is able to replay from finalizedBlockNumber (8 --> onwards)
 	// since there are no pending VRF requests
 	// Blocks: 1 2 3 4 [5;Request] [6;Fulfilment] 7 8 9 10 11
-	require.NoError(t, th.LogPoller.Replay(th.Ctx, latestBlock))
+	require.NoError(t, th.LogPoller.Replay(ctx, latestBlock))
 
 	// initializeLastProcessedBlock must return the finalizedBlockNumber (8) instead of
 	// VRF request block number (5), since all VRF requests are fulfilled
-	lastProcessedBlock, err := th.Listener.initializeLastProcessedBlock(th.Ctx)
+	lastProcessedBlock, err := th.Listener.initializeLastProcessedBlock(ctx)
 	require.Nil(t, err)
 	require.Equal(t, int64(8), lastProcessedBlock)
 }
 
 func TestInitProcessedBlock_OneUnfulfilledVRFReq(t *testing.T) {
 	t.Parallel()
+	ctx := tests.Context(t)
 
 	finalityDepth := int64(3)
 	th := setupVRFLogPollerListenerTH(t, false, finalityDepth, 3, 2, 1000, func(mockChain *evmmocks.Chain, curTH *vrfLogPollerListenerTH) {
@@ -353,7 +354,7 @@ func TestInitProcessedBlock_OneUnfulfilledVRFReq(t *testing.T) {
 	}
 
 	// Calling Start() after RegisterFilter() simulates a node restart after job creation, should reload Filter from db.
-	require.NoError(t, th.LogPoller.Start(th.Ctx))
+	require.NoError(t, th.LogPoller.Start(ctx))
 
 	// Blocks till now: 2 (in SetupTH) + 2 (empty blocks) + 1 (VRF req block) + 5 (EmitLog blocks) = 10
 	latestBlock := int64(2 + 2 + 1 + 5)
@@ -362,17 +363,18 @@ func TestInitProcessedBlock_OneUnfulfilledVRFReq(t *testing.T) {
 	// Replay from block 10 (latest) onwards, so that log poller has a latest block
 	// Then test if log poller is able to replay from earliestUnprocessedBlock (5 --> onwards)
 	// Blocks: 1 2 3 4 [5;Request] 6 7 8 9 10
-	require.NoError(t, th.LogPoller.Replay(th.Ctx, latestBlock))
+	require.NoError(t, th.LogPoller.Replay(ctx, latestBlock))
 
 	// initializeLastProcessedBlock must return the unfulfilled VRF
 	// request block number (5) instead of finalizedBlockNumber (8)
-	lastProcessedBlock, err := th.Listener.initializeLastProcessedBlock(th.Ctx)
+	lastProcessedBlock, err := th.Listener.initializeLastProcessedBlock(ctx)
 	require.Nil(t, err)
 	require.Equal(t, int64(5), lastProcessedBlock)
 }
 
 func TestInitProcessedBlock_SomeUnfulfilledVRFReqs(t *testing.T) {
 	t.Parallel()
+	ctx := tests.Context(t)
 
 	finalityDepth := int64(3)
 	th := setupVRFLogPollerListenerTH(t, false, finalityDepth, 3, 2, 1000, func(mockChain *evmmocks.Chain, curTH *vrfLogPollerListenerTH) {
@@ -413,7 +415,7 @@ func TestInitProcessedBlock_SomeUnfulfilledVRFReqs(t *testing.T) {
 	}
 
 	// Calling Start() after RegisterFilter() simulates a node restart after job creation, should reload Filter from db.
-	require.NoError(t, th.LogPoller.Start(th.Ctx))
+	require.NoError(t, th.LogPoller.Start(ctx))
 
 	// Blocks till now: 2 (in SetupTH) + 2 (empty blocks) + 3*5 (EmitLog + VRF req/resp blocks) = 19
 	latestBlock := int64(2 + 2 + 3*5)
@@ -424,17 +426,18 @@ func TestInitProcessedBlock_SomeUnfulfilledVRFReqs(t *testing.T) {
 	// Blocks: 1 2 3 4 5 [6;Request] [7;Request] 8 [9;Request] [10;Request]
 	// 11 [12;Request] [13;Request] 14 [15;Request] [16;Request]
 	// 17 [18;Request] [19;Request]
-	require.NoError(t, th.LogPoller.Replay(th.Ctx, latestBlock))
+	require.NoError(t, th.LogPoller.Replay(ctx, latestBlock))
 
 	// initializeLastProcessedBlock must return the earliest unfulfilled VRF request block
 	// number instead of finalizedBlockNumber
-	lastProcessedBlock, err := th.Listener.initializeLastProcessedBlock(th.Ctx)
+	lastProcessedBlock, err := th.Listener.initializeLastProcessedBlock(ctx)
 	require.Nil(t, err)
 	require.Equal(t, int64(6), lastProcessedBlock)
 }
 
 func TestInitProcessedBlock_UnfulfilledNFulfilledVRFReqs(t *testing.T) {
 	t.Parallel()
+	ctx := tests.Context(t)
 
 	finalityDepth := int64(3)
 	th := setupVRFLogPollerListenerTH(t, false, finalityDepth, 3, 2, 1000, func(mockChain *evmmocks.Chain, curTH *vrfLogPollerListenerTH) {
@@ -480,7 +483,7 @@ func TestInitProcessedBlock_UnfulfilledNFulfilledVRFReqs(t *testing.T) {
 	}
 
 	// Calling Start() after RegisterFilter() simulates a node restart after job creation, should reload Filter from db.
-	require.NoError(t, th.LogPoller.Start(th.Ctx))
+	require.NoError(t, th.LogPoller.Start(ctx))
 
 	// Blocks till now: 2 (in SetupTH) + 2 (empty blocks) + 3*5 (EmitLog + VRF req/resp blocks) = 19
 	latestBlock := int64(2 + 2 + 3*5)
@@ -490,11 +493,11 @@ func TestInitProcessedBlock_UnfulfilledNFulfilledVRFReqs(t *testing.T) {
 	// Blocks: 1 2 3 4 5 [6;Request] [7;Request;6-Fulfilment] 8 [9;Request] [10;Request;9-Fulfilment]
 	// 11 [12;Request] [13;Request;12-Fulfilment] 14 [15;Request] [16;Request;15-Fulfilment]
 	// 17 [18;Request] [19;Request;18-Fulfilment]
-	require.NoError(t, th.LogPoller.Replay(th.Ctx, latestBlock))
+	require.NoError(t, th.LogPoller.Replay(ctx, latestBlock))
 
 	// initializeLastProcessedBlock must return the earliest unfulfilled VRF request block
 	// number instead of finalizedBlockNumber
-	lastProcessedBlock, err := th.Listener.initializeLastProcessedBlock(th.Ctx)
+	lastProcessedBlock, err := th.Listener.initializeLastProcessedBlock(ctx)
 	require.Nil(t, err)
 	require.Equal(t, int64(7), lastProcessedBlock)
 }
@@ -511,6 +514,7 @@ func TestInitProcessedBlock_UnfulfilledNFulfilledVRFReqs(t *testing.T) {
 
 func TestUpdateLastProcessedBlock_NoVRFReqs(t *testing.T) {
 	t.Parallel()
+	ctx := tests.Context(t)
 
 	finalityDepth := int64(3)
 	th := setupVRFLogPollerListenerTH(t, false, finalityDepth, 3, 2, 1000, func(mockChain *evmmocks.Chain, curTH *vrfLogPollerListenerTH) {
@@ -552,22 +556,23 @@ func TestUpdateLastProcessedBlock_NoVRFReqs(t *testing.T) {
 	// Blocks till now: 2 (in SetupTH) + 2 (empty blocks) + 2 (VRF req blocks) + 5 (EmitLog blocks) = 11
 
 	// Calling Start() after RegisterFilter() simulates a node restart after job creation, should reload Filter from db.
-	require.NoError(t, th.LogPoller.Start(th.Ctx))
+	require.NoError(t, th.LogPoller.Start(ctx))
 
 	// We've to replay from before VRF request log, since updateLastProcessedBlock
 	// does not internally call LogPoller.Replay
-	require.NoError(t, th.LogPoller.Replay(th.Ctx, 4))
+	require.NoError(t, th.LogPoller.Replay(ctx, 4))
 
 	// updateLastProcessedBlock must return the finalizedBlockNumber as there are
 	// no VRF requests, after currLastProcessedBlock (block 6). The VRF requests
 	// made above are before the currLastProcessedBlock (7) passed in below
-	lastProcessedBlock, err := th.Listener.updateLastProcessedBlock(th.Ctx, 7)
+	lastProcessedBlock, err := th.Listener.updateLastProcessedBlock(ctx, 7)
 	require.Nil(t, err)
 	require.Equal(t, int64(8), lastProcessedBlock)
 }
 
 func TestUpdateLastProcessedBlock_NoUnfulfilledVRFReqs(t *testing.T) {
 	t.Parallel()
+	ctx := tests.Context(t)
 
 	finalityDepth := int64(3)
 	th := setupVRFLogPollerListenerTH(t, false, finalityDepth, 3, 2, 1000, func(mockChain *evmmocks.Chain, curTH *vrfLogPollerListenerTH) {
@@ -607,22 +612,23 @@ func TestUpdateLastProcessedBlock_NoUnfulfilledVRFReqs(t *testing.T) {
 	// Blocks till now: 2 (in SetupTH) + 2 (empty blocks) + 2 (VRF req/resp blocks) + 5 (EmitLog blocks) = 11
 
 	// Calling Start() after RegisterFilter() simulates a node restart after job creation, should reload Filter from db.
-	require.NoError(t, th.LogPoller.Start(th.Ctx))
+	require.NoError(t, th.LogPoller.Start(ctx))
 
 	// We've to replay from before VRF request log, since updateLastProcessedBlock
 	// does not internally call LogPoller.Replay
-	require.NoError(t, th.LogPoller.Replay(th.Ctx, 4))
+	require.NoError(t, th.LogPoller.Replay(ctx, 4))
 
 	// updateLastProcessedBlock must return the finalizedBlockNumber (8) though we have
 	// a VRF req at block (5) after currLastProcessedBlock (4) passed below, because
 	// the VRF request is fulfilled
-	lastProcessedBlock, err := th.Listener.updateLastProcessedBlock(th.Ctx, 4)
+	lastProcessedBlock, err := th.Listener.updateLastProcessedBlock(ctx, 4)
 	require.Nil(t, err)
 	require.Equal(t, int64(8), lastProcessedBlock)
 }
 
 func TestUpdateLastProcessedBlock_OneUnfulfilledVRFReq(t *testing.T) {
 	t.Parallel()
+	ctx := tests.Context(t)
 
 	finalityDepth := int64(3)
 	th := setupVRFLogPollerListenerTH(t, false, finalityDepth, 3, 2, 1000, func(mockChain *evmmocks.Chain, curTH *vrfLogPollerListenerTH) {
@@ -658,22 +664,23 @@ func TestUpdateLastProcessedBlock_OneUnfulfilledVRFReq(t *testing.T) {
 	// Blocks till now: 2 (in SetupTH) + 2 (empty blocks) + 1 (VRF req block) + 5 (EmitLog blocks) = 10
 
 	// Calling Start() after RegisterFilter() simulates a node restart after job creation, should reload Filter from db.
-	require.NoError(t, th.LogPoller.Start(th.Ctx))
+	require.NoError(t, th.LogPoller.Start(ctx))
 
 	// We've to replay from before VRF request log, since updateLastProcessedBlock
 	// does not internally call LogPoller.Replay
-	require.NoError(t, th.LogPoller.Replay(th.Ctx, 4))
+	require.NoError(t, th.LogPoller.Replay(ctx, 4))
 
 	// updateLastProcessedBlock must return the VRF req at block (5) instead of
 	// finalizedBlockNumber (8) after currLastProcessedBlock (4) passed below,
 	// because the VRF request is unfulfilled
-	lastProcessedBlock, err := th.Listener.updateLastProcessedBlock(th.Ctx, 4)
+	lastProcessedBlock, err := th.Listener.updateLastProcessedBlock(ctx, 4)
 	require.Nil(t, err)
 	require.Equal(t, int64(5), lastProcessedBlock)
 }
 
 func TestUpdateLastProcessedBlock_SomeUnfulfilledVRFReqs(t *testing.T) {
 	t.Parallel()
+	ctx := tests.Context(t)
 
 	finalityDepth := int64(3)
 	th := setupVRFLogPollerListenerTH(t, false, finalityDepth, 3, 2, 1000, func(mockChain *evmmocks.Chain, curTH *vrfLogPollerListenerTH) {
@@ -715,22 +722,23 @@ func TestUpdateLastProcessedBlock_SomeUnfulfilledVRFReqs(t *testing.T) {
 	// Blocks till now: 2 (in SetupTH) + 2 (empty blocks) + 3*5 (EmitLog + VRF req blocks) = 19
 
 	// Calling Start() after RegisterFilter() simulates a node restart after job creation, should reload Filter from db.
-	require.NoError(t, th.LogPoller.Start(th.Ctx))
+	require.NoError(t, th.LogPoller.Start(ctx))
 
 	// We've to replay from before VRF request log, since updateLastProcessedBlock
 	// does not internally call LogPoller.Replay
-	require.NoError(t, th.LogPoller.Replay(th.Ctx, 4))
+	require.NoError(t, th.LogPoller.Replay(ctx, 4))
 
 	// updateLastProcessedBlock must return the VRF req at block (6) instead of
 	// finalizedBlockNumber (16) after currLastProcessedBlock (4) passed below,
 	// as block 6 contains the earliest unfulfilled VRF request
-	lastProcessedBlock, err := th.Listener.updateLastProcessedBlock(th.Ctx, 4)
+	lastProcessedBlock, err := th.Listener.updateLastProcessedBlock(ctx, 4)
 	require.Nil(t, err)
 	require.Equal(t, int64(6), lastProcessedBlock)
 }
 
 func TestUpdateLastProcessedBlock_UnfulfilledNFulfilledVRFReqs(t *testing.T) {
 	t.Parallel()
+	ctx := tests.Context(t)
 
 	finalityDepth := int64(3)
 	th := setupVRFLogPollerListenerTH(t, false, finalityDepth, 3, 2, 1000, func(mockChain *evmmocks.Chain, curTH *vrfLogPollerListenerTH) {
@@ -776,17 +784,17 @@ func TestUpdateLastProcessedBlock_UnfulfilledNFulfilledVRFReqs(t *testing.T) {
 	// Blocks till now: 2 (in SetupTH) + 2 (empty blocks) + 3*5 (EmitLog + VRF req blocks) = 19
 
 	// Calling Start() after RegisterFilter() simulates a node restart after job creation, should reload Filter from db.
-	require.NoError(t, th.LogPoller.Start(th.Ctx))
+	require.NoError(t, th.LogPoller.Start(ctx))
 
 	// We've to replay from before VRF request log, since updateLastProcessedBlock
 	// does not internally call LogPoller.Replay
-	require.NoError(t, th.LogPoller.Replay(th.Ctx, 4))
+	require.NoError(t, th.LogPoller.Replay(ctx, 4))
 
 	// updateLastProcessedBlock must return the VRF req at block (7) instead of
 	// finalizedBlockNumber (16) after currLastProcessedBlock (4) passed below,
 	// as block 7 contains the earliest unfulfilled VRF request. VRF request
 	// in block 6 has been fulfilled in block 7.
-	lastProcessedBlock, err := th.Listener.updateLastProcessedBlock(th.Ctx, 4)
+	lastProcessedBlock, err := th.Listener.updateLastProcessedBlock(ctx, 4)
 	require.Nil(t, err)
 	require.Equal(t, int64(7), lastProcessedBlock)
 }

--- a/core/utils/thread_control_test.go
+++ b/core/utils/thread_control_test.go
@@ -49,7 +49,8 @@ func TestThreadControl_GoCtx(t *testing.T) {
 
 	start := time.Now()
 	wg.Wait()
-	require.True(t, time.Since(start) > timeout-1)
-	require.True(t, time.Since(start) < 2*timeout)
+	end := time.Since(start)
+	require.True(t, end > timeout-1)
+	require.True(t, end < 2*timeout)
 	require.Equal(t, int32(1), finished.Load())
 }

--- a/core/web/resolver/api_token_test.go
+++ b/core/web/resolver/api_token_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"testing"
 
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
@@ -52,8 +53,8 @@ func TestResolver_CreateAPIToken(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
-				session, ok := webauth.GetGQLAuthenticatedSession(f.Ctx)
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				session, ok := webauth.GetGQLAuthenticatedSession(ctx)
 				require.True(t, ok)
 				require.NotNil(t, session)
 
@@ -85,8 +86,8 @@ func TestResolver_CreateAPIToken(t *testing.T) {
 		{
 			name:          "input errors",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
-				session, ok := webauth.GetGQLAuthenticatedSession(f.Ctx)
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				session, ok := webauth.GetGQLAuthenticatedSession(ctx)
 				require.True(t, ok)
 				require.NotNil(t, session)
 
@@ -110,8 +111,8 @@ func TestResolver_CreateAPIToken(t *testing.T) {
 		{
 			name:          "failed to find user",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
-				session, ok := webauth.GetGQLAuthenticatedSession(f.Ctx)
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				session, ok := webauth.GetGQLAuthenticatedSession(ctx)
 				require.True(t, ok)
 				require.NotNil(t, session)
 
@@ -138,8 +139,8 @@ func TestResolver_CreateAPIToken(t *testing.T) {
 		{
 			name:          "failed to generate token",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
-				session, ok := webauth.GetGQLAuthenticatedSession(f.Ctx)
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				session, ok := webauth.GetGQLAuthenticatedSession(ctx)
 				require.True(t, ok)
 				require.NotNil(t, session)
 
@@ -208,8 +209,8 @@ func TestResolver_DeleteAPIToken(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
-				session, ok := webauth.GetGQLAuthenticatedSession(f.Ctx)
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				session, ok := webauth.GetGQLAuthenticatedSession(ctx)
 				require.True(t, ok)
 				require.NotNil(t, session)
 
@@ -239,8 +240,8 @@ func TestResolver_DeleteAPIToken(t *testing.T) {
 		{
 			name:          "input errors",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
-				session, ok := webauth.GetGQLAuthenticatedSession(f.Ctx)
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				session, ok := webauth.GetGQLAuthenticatedSession(ctx)
 				require.True(t, ok)
 				require.NotNil(t, session)
 
@@ -264,8 +265,8 @@ func TestResolver_DeleteAPIToken(t *testing.T) {
 		{
 			name:          "failed to find user",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
-				session, ok := webauth.GetGQLAuthenticatedSession(f.Ctx)
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				session, ok := webauth.GetGQLAuthenticatedSession(ctx)
 				require.True(t, ok)
 				require.NotNil(t, session)
 
@@ -292,8 +293,8 @@ func TestResolver_DeleteAPIToken(t *testing.T) {
 		{
 			name:          "failed to delete token",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
-				session, ok := webauth.GetGQLAuthenticatedSession(f.Ctx)
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				session, ok := webauth.GetGQLAuthenticatedSession(ctx)
 				require.True(t, ok)
 				require.NotNil(t, session)
 

--- a/core/web/resolver/bridge_test.go
+++ b/core/web/resolver/bridge_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"net/url"
@@ -46,7 +47,7 @@ func Test_Bridges(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("BridgeORM").Return(f.Mocks.bridgeORM)
 				f.Mocks.bridgeORM.On("BridgeTypes", mock.Anything, PageDefaultOffset, PageDefaultLimit).Return([]bridges.BridgeType{
 					{
@@ -116,7 +117,7 @@ func Test_Bridge(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("BridgeORM").Return(f.Mocks.bridgeORM)
 				f.Mocks.bridgeORM.On("FindBridge", mock.Anything, name).Return(bridges.BridgeType{
 					Name:                   name,
@@ -143,7 +144,7 @@ func Test_Bridge(t *testing.T) {
 		{
 			name:          "not found",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("BridgeORM").Return(f.Mocks.bridgeORM)
 				f.Mocks.bridgeORM.On("FindBridge", mock.Anything, name).Return(bridges.BridgeType{}, sql.ErrNoRows)
 			},
@@ -198,7 +199,7 @@ func Test_CreateBridge(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("BridgeORM").Return(f.Mocks.bridgeORM)
 				f.Mocks.bridgeORM.On("FindBridge", mock.Anything, name).Return(bridges.BridgeType{}, sql.ErrNoRows)
 				f.Mocks.bridgeORM.On("CreateBridgeType", mock.Anything, mock.IsType(&bridges.BridgeType{})).
@@ -286,7 +287,7 @@ func Test_UpdateBridge(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				// Initialize the existing bridge
 				bridge := bridges.BridgeType{
 					Name:                   name,
@@ -340,7 +341,7 @@ func Test_UpdateBridge(t *testing.T) {
 		{
 			name:          "not found",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("BridgeORM").Return(f.Mocks.bridgeORM)
 				f.Mocks.bridgeORM.On("FindBridge", mock.Anything, name).Return(bridges.BridgeType{}, sql.ErrNoRows)
 			},
@@ -407,7 +408,7 @@ func Test_DeleteBridgeMutation(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				bridge := bridges.BridgeType{
 					Name:                   name,
 					URL:                    models.WebURL(*bridgeURL),
@@ -460,7 +461,7 @@ func Test_DeleteBridgeMutation(t *testing.T) {
 			variables: map[string]interface{}{
 				"id": "bridge1",
 			},
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.bridgeORM.On("FindBridge", mock.Anything, name).Return(bridges.BridgeType{}, sql.ErrNoRows)
 				f.App.On("BridgeORM").Return(f.Mocks.bridgeORM)
 			},
@@ -479,7 +480,7 @@ func Test_DeleteBridgeMutation(t *testing.T) {
 			variables: map[string]interface{}{
 				"id": "bridge1",
 			},
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.bridgeORM.On("FindBridge", mock.Anything, name).Return(bridges.BridgeType{}, nil)
 				f.Mocks.jobORM.On("FindJobIDsWithBridge", mock.Anything, name.String()).Return([]int32{1}, nil)
 				f.App.On("BridgeORM").Return(f.Mocks.bridgeORM)

--- a/core/web/resolver/chain_test.go
+++ b/core/web/resolver/chain_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -76,7 +77,7 @@ ResendAfterThreshold = '1h0m0s'
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				chainConf := evmtoml.EVMConfig{
 					ChainID: &chainID,
 					Enabled: chain.Enabled,
@@ -113,7 +114,7 @@ ResendAfterThreshold = '1h0m0s'
 		{
 			name:          "no chains",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetRelayers").Return(&chainlinkmocks.FakeRelayerChainInteroperators{Relayers: []loop.Relayer{}})
 			},
 			query: query,
@@ -192,7 +193,7 @@ ResendAfterThreshold = '1h0m0s'
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("EVMORM").Return(f.Mocks.evmORM)
 				f.Mocks.evmORM.PutChains(evmtoml.EVMConfig{
 					ChainID: &chainID,
@@ -212,7 +213,7 @@ ResendAfterThreshold = '1h0m0s'
 		{
 			name:          "not found error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("EVMORM").Return(f.Mocks.evmORM)
 			},
 			query: query,

--- a/core/web/resolver/config_test.go
+++ b/core/web/resolver/config_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	_ "embed"
 	"encoding/json"
 	"fmt"
@@ -38,7 +39,7 @@ func TestResolver_ConfigV2(t *testing.T) {
 		{
 			name:          "empty",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				opts := chainlink.GeneralConfigOpts{}
 				cfg, err := opts.New()
 				require.NoError(t, err)
@@ -50,7 +51,7 @@ func TestResolver_ConfigV2(t *testing.T) {
 		{
 			name:          "full",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				opts := chainlink.GeneralConfigOpts{
 					ConfigStrings:  []string{configFull},
 					SecretsStrings: []string{},
@@ -65,7 +66,7 @@ func TestResolver_ConfigV2(t *testing.T) {
 		{
 			name:          "partial",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				opts := chainlink.GeneralConfigOpts{
 					ConfigStrings:  []string{configMulti},
 					SecretsStrings: []string{},

--- a/core/web/resolver/csa_keys_test.go
+++ b/core/web/resolver/csa_keys_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"testing"
@@ -58,7 +59,7 @@ func Test_CSAKeysQuery(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.csa.On("GetAll").Return(fakeKeys, nil)
 				f.Mocks.keystore.On("CSA").Return(f.Mocks.csa)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -109,7 +110,7 @@ func Test_CreateCSAKey(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.csa.On("Create", mock.Anything).Return(fakeKey, nil)
 				f.Mocks.keystore.On("CSA").Return(f.Mocks.csa)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -120,7 +121,7 @@ func Test_CreateCSAKey(t *testing.T) {
 		{
 			name:          "csa key exists error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.csa.On("Create", mock.Anything).Return(csakey.KeyV2{}, keystore.ErrCSAKeyExists)
 				f.Mocks.keystore.On("CSA").Return(f.Mocks.csa)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -178,7 +179,7 @@ func Test_DeleteCSAKey(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
 				f.Mocks.keystore.On("CSA").Return(f.Mocks.csa)
 				f.Mocks.csa.On("Delete", mock.Anything, fakeKey.ID()).Return(fakeKey, nil)
@@ -190,7 +191,7 @@ func Test_DeleteCSAKey(t *testing.T) {
 		{
 			name:          "not found error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
 				f.Mocks.keystore.On("CSA").Return(f.Mocks.csa)
 				f.Mocks.csa.

--- a/core/web/resolver/eth_key_test.go
+++ b/core/web/resolver/eth_key_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -80,7 +81,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 		{
 			name:          "success on prod",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				states := []ethkey.State{
 					{
 						Address:    evmtypes.MustEIP55Address(address.Hex()),
@@ -147,7 +148,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 		{
 			name:          "success with no chains",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				states := []ethkey.State{
 					{
 						Address:    evmtypes.MustEIP55Address(address.Hex()),
@@ -202,7 +203,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 		{
 			name:          "generic error on GetAll()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.ethKs.On("GetAll", mock.Anything).Return(nil, gError)
 				f.Mocks.keystore.On("Eth").Return(f.Mocks.ethKs)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -221,7 +222,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 		{
 			name:          "generic error on GetStatesForKeys()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.ethKs.On("GetAll", mock.Anything).Return(keys, nil)
 				f.Mocks.ethKs.On("GetStatesForKeys", mock.Anything, keys).Return(nil, gError)
 				f.Mocks.keystore.On("Eth").Return(f.Mocks.ethKs)
@@ -241,7 +242,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 		{
 			name:          "generic error on Get()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				states := []ethkey.State{
 					{
 						Address:    evmtypes.MustEIP55Address(address.Hex()),
@@ -273,7 +274,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 		{
 			name:          "Empty set on legacy evm chains",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				states := []ethkey.State{
 					{
 						Address:    evmtypes.MustEIP55Address(address.Hex()),
@@ -304,7 +305,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 		{
 			name:          "generic error on GetLINKBalance()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				states := []ethkey.State{
 					{
 						Address:    evmtypes.MustEIP55Address(address.Hex()),
@@ -366,7 +367,7 @@ func TestResolver_ETHKeys(t *testing.T) {
 		{
 			name:          "success with no eth balance",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				states := []ethkey.State{
 					{
 						Address:    evmtypes.EIP55AddressFromAddress(address),

--- a/core/web/resolver/eth_transaction_test.go
+++ b/core/web/resolver/eth_transaction_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"database/sql"
 	"errors"
 	"math/big"
@@ -68,7 +69,7 @@ func TestResolver_EthTransaction(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.txmStore.On("FindTxByHash", mock.Anything, hash).Return(&txmgr.Tx{
 					ID:             1,
 					ToAddress:      common.HexToAddress("0x5431F5F973781809D18643b87B44921b11355d81"),
@@ -130,7 +131,7 @@ func TestResolver_EthTransaction(t *testing.T) {
 		{
 			name:          "success without nil values",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				num := int64(2)
 				nonce := evmtypes.Nonce(num)
 
@@ -195,7 +196,7 @@ func TestResolver_EthTransaction(t *testing.T) {
 		{
 			name:          "not found error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.txmStore.On("FindTxByHash", mock.Anything, hash).Return(nil, sql.ErrNoRows)
 				f.App.On("TxmStorageService").Return(f.Mocks.txmStore)
 			},
@@ -212,7 +213,7 @@ func TestResolver_EthTransaction(t *testing.T) {
 		{
 			name:          "generic error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.txmStore.On("FindTxByHash", mock.Anything, hash).Return(nil, gError)
 				f.App.On("TxmStorageService").Return(f.Mocks.txmStore)
 			},
@@ -266,7 +267,7 @@ func TestResolver_EthTransactions(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				num := int64(2)
 
 				f.Mocks.txmStore.On("Transactions", mock.Anything, PageDefaultOffset, PageDefaultLimit).Return([]txmgr.Tx{
@@ -319,7 +320,7 @@ func TestResolver_EthTransactions(t *testing.T) {
 		{
 			name:          "generic error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.txmStore.On("Transactions", mock.Anything, PageDefaultOffset, PageDefaultLimit).Return(nil, 0, gError)
 				f.App.On("TxmStorageService").Return(f.Mocks.txmStore)
 			},
@@ -364,7 +365,7 @@ func TestResolver_EthTransactionsAttempts(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				num := int64(2)
 
 				f.Mocks.txmStore.On("TxAttempts", mock.Anything, PageDefaultOffset, PageDefaultLimit).Return([]txmgr.TxAttempt{
@@ -397,7 +398,7 @@ func TestResolver_EthTransactionsAttempts(t *testing.T) {
 		{
 			name:          "success with nil values",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.txmStore.On("TxAttempts", mock.Anything, PageDefaultOffset, PageDefaultLimit).Return([]txmgr.TxAttempt{
 					{
 						Hash:                    hash,
@@ -427,7 +428,7 @@ func TestResolver_EthTransactionsAttempts(t *testing.T) {
 		{
 			name:          "generic error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.txmStore.On("TxAttempts", mock.Anything, PageDefaultOffset, PageDefaultLimit).Return(nil, 0, gError)
 				f.App.On("TxmStorageService").Return(f.Mocks.txmStore)
 			},

--- a/core/web/resolver/features_test.go
+++ b/core/web/resolver/features_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"testing"
 
 	"github.com/smartcontractkit/chainlink/v2/core/internal/testutils/configtest"
@@ -23,7 +24,7 @@ func Test_ToFeatures(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetConfig").Return(configtest.NewGeneralConfig(t, func(c *chainlink.Config, s *chainlink.Secrets) {
 					t, f := true, false
 					c.Feature.UICSAKeys = &f

--- a/core/web/resolver/feeds_manager_chain_config_test.go
+++ b/core/web/resolver/feeds_manager_chain_config_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -71,7 +72,7 @@ func Test_CreateFeedsManagerChainConfig(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("CreateChainConfig", mock.Anything, feeds.ChainConfig{
 					FeedsManagerID: mgrID,
@@ -144,7 +145,7 @@ func Test_CreateFeedsManagerChainConfig(t *testing.T) {
 		{
 			name:          "create call not found",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("CreateChainConfig", mock.Anything, mock.IsType(feeds.ChainConfig{})).Return(int64(0), sql.ErrNoRows)
 			},
@@ -161,7 +162,7 @@ func Test_CreateFeedsManagerChainConfig(t *testing.T) {
 		{
 			name:          "get call not found",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("CreateChainConfig", mock.Anything, mock.IsType(feeds.ChainConfig{})).Return(cfgID, nil)
 				f.Mocks.feedsSvc.On("GetChainConfig", mock.Anything, cfgID).Return(nil, sql.ErrNoRows)
@@ -209,7 +210,7 @@ func Test_DeleteFeedsManagerChainConfig(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("GetChainConfig", mock.Anything, cfgID).Return(&feeds.ChainConfig{
 					ID: cfgID,
@@ -230,7 +231,7 @@ func Test_DeleteFeedsManagerChainConfig(t *testing.T) {
 		{
 			name:          "get call not found",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("GetChainConfig", mock.Anything, cfgID).Return(nil, sql.ErrNoRows)
 			},
@@ -247,7 +248,7 @@ func Test_DeleteFeedsManagerChainConfig(t *testing.T) {
 		{
 			name:          "delete call not found",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("GetChainConfig", mock.Anything, cfgID).Return(&feeds.ChainConfig{
 					ID: cfgID,
@@ -324,7 +325,7 @@ func Test_UpdateFeedsManagerChainConfig(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("UpdateChainConfig", mock.Anything, feeds.ChainConfig{
 					ID:             cfgID,
@@ -393,7 +394,7 @@ func Test_UpdateFeedsManagerChainConfig(t *testing.T) {
 		{
 			name:          "update call not found",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("UpdateChainConfig", mock.Anything, mock.IsType(feeds.ChainConfig{})).Return(int64(0), sql.ErrNoRows)
 			},
@@ -410,7 +411,7 @@ func Test_UpdateFeedsManagerChainConfig(t *testing.T) {
 		{
 			name:          "get call not found",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("UpdateChainConfig", mock.Anything, mock.IsType(feeds.ChainConfig{})).Return(cfgID, nil)
 				f.Mocks.feedsSvc.On("GetChainConfig", mock.Anything, cfgID).Return(nil, sql.ErrNoRows)

--- a/core/web/resolver/feeds_manager_test.go
+++ b/core/web/resolver/feeds_manager_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -40,7 +41,7 @@ func Test_FeedsManagers(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("ListJobProposalsByManagersIDs", mock.Anything, []int64{1}).Return([]feeds.JobProposal{
 					{
@@ -113,7 +114,7 @@ func Test_FeedsManager(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("GetManager", mock.Anything, mgrID).Return(&feeds.FeedsManager{
 					ID:                 mgrID,
@@ -140,7 +141,7 @@ func Test_FeedsManager(t *testing.T) {
 		{
 			name:          "not found",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("GetManager", mock.Anything, mgrID).Return(nil, sql.ErrNoRows)
 			},
@@ -212,7 +213,7 @@ func Test_CreateFeedsManager(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("RegisterManager", mock.Anything, feeds.RegisterManagerParams{
 					Name:      name,
@@ -247,7 +248,7 @@ func Test_CreateFeedsManager(t *testing.T) {
 		{
 			name:          "single feeds manager error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.
 					On("RegisterManager", mock.Anything, mock.IsType(feeds.RegisterManagerParams{})).
@@ -266,7 +267,7 @@ func Test_CreateFeedsManager(t *testing.T) {
 		{
 			name:          "not found",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("RegisterManager", mock.Anything, mock.IsType(feeds.RegisterManagerParams{})).Return(mgrID, nil)
 				f.Mocks.feedsSvc.On("GetManager", mock.Anything, mgrID).Return(nil, sql.ErrNoRows)
@@ -358,7 +359,7 @@ func Test_UpdateFeedsManager(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("UpdateManager", mock.Anything, feeds.FeedsManager{
 					ID:        mgrID,
@@ -394,7 +395,7 @@ func Test_UpdateFeedsManager(t *testing.T) {
 		{
 			name:          "not found",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("UpdateManager", mock.Anything, mock.IsType(feeds.FeedsManager{})).Return(nil)
 				f.Mocks.feedsSvc.On("GetManager", mock.Anything, mgrID).Return(nil, sql.ErrNoRows)

--- a/core/web/resolver/job_error_test.go
+++ b/core/web/resolver/job_error_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"testing"
@@ -27,7 +28,7 @@ func TestResolver_JobErrors(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					ID: int32(1),
@@ -123,7 +124,7 @@ func TestResolver_DismissJobError(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("FindSpecError", mock.Anything, id).Return(job.SpecError{
 					ID:          id,
 					Occurrences: 5,
@@ -140,7 +141,7 @@ func TestResolver_DismissJobError(t *testing.T) {
 		{
 			name:          "not found on FindSpecError()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("FindSpecError", mock.Anything, id).Return(job.SpecError{}, sql.ErrNoRows)
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 			},
@@ -158,7 +159,7 @@ func TestResolver_DismissJobError(t *testing.T) {
 		{
 			name:          "not found on DismissError()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("FindSpecError", mock.Anything, id).Return(job.SpecError{}, nil)
 				f.Mocks.jobORM.On("DismissError", mock.Anything, id).Return(sql.ErrNoRows)
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
@@ -177,7 +178,7 @@ func TestResolver_DismissJobError(t *testing.T) {
 		{
 			name:          "generic error on FindSpecError()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("FindSpecError", mock.Anything, id).Return(job.SpecError{}, gError)
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 			},
@@ -196,7 +197,7 @@ func TestResolver_DismissJobError(t *testing.T) {
 		{
 			name:          "generic error on DismissError()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("FindSpecError", mock.Anything, id).Return(job.SpecError{}, nil)
 				f.Mocks.jobORM.On("DismissError", mock.Anything, id).Return(gError)
 				f.App.On("JobORM").Return(f.Mocks.jobORM)

--- a/core/web/resolver/job_proposal_spec_test.go
+++ b/core/web/resolver/job_proposal_spec_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 	"time"
@@ -50,7 +51,7 @@ func TestResolver_ApproveJobProposalSpec(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("ApproveSpec", mock.Anything, specID, false).Return(nil)
 				f.Mocks.feedsSvc.On("GetSpec", mock.Anything, specID).Return(&feeds.JobProposalSpec{
@@ -64,7 +65,7 @@ func TestResolver_ApproveJobProposalSpec(t *testing.T) {
 		{
 			name:          "not found error on approval",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("ApproveSpec", mock.Anything, specID, false).Return(sql.ErrNoRows)
 			},
@@ -81,7 +82,7 @@ func TestResolver_ApproveJobProposalSpec(t *testing.T) {
 		{
 			name:          "not found error on fetch",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("ApproveSpec", mock.Anything, specID, false).Return(nil)
 				f.Mocks.feedsSvc.On("GetSpec", mock.Anything, specID).Return(nil, sql.ErrNoRows)
@@ -99,7 +100,7 @@ func TestResolver_ApproveJobProposalSpec(t *testing.T) {
 		{
 			name:          "unprocessable error on approval if job already exists",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("ApproveSpec", mock.Anything, specID, false).Return(feeds.ErrJobAlreadyExists)
 			},
@@ -154,7 +155,7 @@ func TestResolver_CancelJobProposalSpec(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("CancelSpec", mock.Anything, specID).Return(nil)
 				f.Mocks.feedsSvc.On("GetSpec", mock.Anything, specID).Return(&feeds.JobProposalSpec{
@@ -168,7 +169,7 @@ func TestResolver_CancelJobProposalSpec(t *testing.T) {
 		{
 			name:          "not found error on cancel",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("CancelSpec", mock.Anything, specID).Return(sql.ErrNoRows)
 			},
@@ -185,7 +186,7 @@ func TestResolver_CancelJobProposalSpec(t *testing.T) {
 		{
 			name:          "not found error on fetch",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("CancelSpec", mock.Anything, specID).Return(nil)
 				f.Mocks.feedsSvc.On("GetSpec", mock.Anything, specID).Return(nil, sql.ErrNoRows)
@@ -241,7 +242,7 @@ func TestResolver_RejectJobProposalSpec(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("RejectSpec", mock.Anything, specID).Return(nil)
 				f.Mocks.feedsSvc.On("GetSpec", mock.Anything, specID).Return(&feeds.JobProposalSpec{
@@ -255,7 +256,7 @@ func TestResolver_RejectJobProposalSpec(t *testing.T) {
 		{
 			name:          "not found error on reject",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("RejectSpec", mock.Anything, specID).Return(sql.ErrNoRows)
 			},
@@ -272,7 +273,7 @@ func TestResolver_RejectJobProposalSpec(t *testing.T) {
 		{
 			name:          "not found error on fetch",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("RejectSpec", mock.Anything, specID).Return(nil)
 				f.Mocks.feedsSvc.On("GetSpec", mock.Anything, specID).Return(nil, sql.ErrNoRows)
@@ -331,7 +332,7 @@ func TestResolver_UpdateJobProposalSpecDefinition(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("UpdateSpecDefinition", mock.Anything, specID, "").Return(nil)
 				f.Mocks.feedsSvc.On("GetSpec", mock.Anything, specID).Return(&feeds.JobProposalSpec{
@@ -345,7 +346,7 @@ func TestResolver_UpdateJobProposalSpecDefinition(t *testing.T) {
 		{
 			name:          "not found error on update",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("UpdateSpecDefinition", mock.Anything, specID, "").Return(sql.ErrNoRows)
 			},
@@ -362,7 +363,7 @@ func TestResolver_UpdateJobProposalSpecDefinition(t *testing.T) {
 		{
 			name:          "not found error on fetch",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 				f.Mocks.feedsSvc.On("UpdateSpecDefinition", mock.Anything, specID, "").Return(nil)
 				f.Mocks.feedsSvc.On("GetSpec", mock.Anything, specID).Return(nil, sql.ErrNoRows)
@@ -443,7 +444,7 @@ func TestResolver_GetJobProposal_Spec(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.feedsSvc.On("GetJobProposal", mock.Anything, jpID).Return(&feeds.JobProposal{
 					ID:             jpID,
 					Status:         feeds.JobProposalStatusApproved,

--- a/core/web/resolver/job_proposal_test.go
+++ b/core/web/resolver/job_proposal_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"testing"
@@ -64,7 +65,7 @@ func TestResolver_GetJobProposal(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.feedsSvc.On("ListManagersByIDs", mock.Anything, []int64{1}).Return([]feeds.FeedsManager{
 					{
 						ID:   1,
@@ -89,7 +90,7 @@ func TestResolver_GetJobProposal(t *testing.T) {
 		{
 			name:          "not found error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.feedsSvc.On("GetJobProposal", mock.Anything, jpID).Return(nil, sql.ErrNoRows)
 				f.App.On("GetFeedsService").Return(f.Mocks.feedsSvc)
 			},

--- a/core/web/resolver/job_run_test.go
+++ b/core/web/resolver/job_run_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"database/sql"
 	"testing"
 
@@ -39,7 +40,7 @@ func TestQuery_PaginatedJobRuns(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("PipelineRuns", mock.Anything, (*int32)(nil), PageDefaultOffset, PageDefaultLimit).Return([]pipeline.Run{
 					{
 						ID: int64(200),
@@ -63,7 +64,7 @@ func TestQuery_PaginatedJobRuns(t *testing.T) {
 		{
 			name:          "generic error on PipelineRuns()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("PipelineRuns", mock.Anything, (*int32)(nil), PageDefaultOffset, PageDefaultLimit).Return(nil, 0, gError)
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 			},
@@ -130,7 +131,7 @@ func TestResolver_JobRun(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("FindPipelineRunByID", mock.Anything, int64(2)).Return(pipeline.Run{
 					ID:             2,
 					PipelineSpecID: 5,
@@ -179,7 +180,7 @@ func TestResolver_JobRun(t *testing.T) {
 		{
 			name:          "not found error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("FindPipelineRunByID", mock.Anything, int64(2)).Return(pipeline.Run{}, sql.ErrNoRows)
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 			},
@@ -196,7 +197,7 @@ func TestResolver_JobRun(t *testing.T) {
 		{
 			name:          "generic error on FindPipelineRunByID()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("FindPipelineRunByID", mock.Anything, int64(2)).Return(pipeline.Run{}, gError)
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 			},
@@ -284,7 +285,7 @@ func TestResolver_RunJob(t *testing.T) {
 		{
 			name:          "success without body",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("RunJobV2", mock.Anything, id, (map[string]interface{})(nil)).Return(int64(25), nil)
 				f.Mocks.pipelineORM.On("FindRun", mock.Anything, int64(25)).Return(pipeline.Run{
 					ID:             2,
@@ -337,7 +338,7 @@ func TestResolver_RunJob(t *testing.T) {
 		{
 			name:          "not found job error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("RunJobV2", mock.Anything, id, (map[string]interface{})(nil)).Return(int64(25), webhook.ErrJobNotExists)
 			},
 			query: mutation,
@@ -355,7 +356,7 @@ func TestResolver_RunJob(t *testing.T) {
 		{
 			name:          "generic error on RunJobV2",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("RunJobV2", mock.Anything, id, (map[string]interface{})(nil)).Return(int64(25), gError)
 			},
 			query: mutation,
@@ -375,7 +376,7 @@ func TestResolver_RunJob(t *testing.T) {
 		{
 			name:          "generic error on FindRun",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("RunJobV2", mock.Anything, id, (map[string]interface{})(nil)).Return(int64(25), nil)
 				f.Mocks.pipelineORM.On("FindRun", mock.Anything, int64(25)).Return(pipeline.Run{}, gError)
 				f.App.On("PipelineORM").Return(f.Mocks.pipelineORM)

--- a/core/web/resolver/job_test.go
+++ b/core/web/resolver/job_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -68,7 +69,7 @@ func TestResolver_Jobs(t *testing.T) {
 		{
 			name:          "get jobs success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				plnSpecID := int32(12)
 
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
@@ -206,7 +207,7 @@ func TestResolver_Job(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					ID:              1,
@@ -238,7 +239,7 @@ func TestResolver_Job(t *testing.T) {
 		{
 			name:          "not found",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{}, sql.ErrNoRows)
 			},
@@ -255,7 +256,7 @@ func TestResolver_Job(t *testing.T) {
 		{
 			name:          "show job when chainID is disabled",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					ID:              1,
@@ -351,7 +352,7 @@ func TestResolver_CreateJob(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetConfig").Return(f.Mocks.cfg)
 				f.App.On("AddJobV2", mock.Anything, &jb).Return(nil)
 			},
@@ -378,7 +379,7 @@ func TestResolver_CreateJob(t *testing.T) {
 		{
 			name:          "generic error when adding the job",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetConfig").Return(f.Mocks.cfg)
 				f.App.On("AddJobV2", mock.Anything, &jb).Return(gError)
 			},
@@ -452,7 +453,7 @@ func TestResolver_DeleteJob(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					ID:              id,
 					Name:            null.StringFrom("test-job"),
@@ -470,7 +471,7 @@ func TestResolver_DeleteJob(t *testing.T) {
 		{
 			name:          "not found on FindJob()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{}, sql.ErrNoRows)
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 			},
@@ -488,7 +489,7 @@ func TestResolver_DeleteJob(t *testing.T) {
 		{
 			name:          "not found on DeleteJob()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{}, nil)
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.App.On("DeleteJob", mock.Anything, id).Return(sql.ErrNoRows)
@@ -507,7 +508,7 @@ func TestResolver_DeleteJob(t *testing.T) {
 		{
 			name:          "generic error on FindJob()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{}, gError)
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 			},
@@ -526,7 +527,7 @@ func TestResolver_DeleteJob(t *testing.T) {
 		{
 			name:          "generic error on DeleteJob()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{}, nil)
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.App.On("DeleteJob", mock.Anything, id).Return(gError)

--- a/core/web/resolver/log_test.go
+++ b/core/web/resolver/log_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"testing"
 
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
@@ -35,7 +36,7 @@ func TestResolver_SetSQLLogging(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.cfg.On("SetLogSQL", true).Return(nil)
 				f.App.On("GetConfig").Return(f.Mocks.cfg)
 			},
@@ -79,7 +80,7 @@ func TestResolver_SQLLogging(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.cfg.On("Database").Return(&databaseConfig{logSQL: false})
 				f.App.On("GetConfig").Return(f.Mocks.cfg)
 			},
@@ -126,7 +127,7 @@ func TestResolver_GlobalLogLevel(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.cfg.On("Log").Return(&log{level: warnLvl})
 				f.App.On("GetConfig").Return(f.Mocks.cfg)
 			},
@@ -178,7 +179,7 @@ func TestResolver_SetGlobalLogLevel(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("SetLogLevel", errorLvl).Return(nil)
 			},
 			query:     mutation,
@@ -195,7 +196,7 @@ func TestResolver_SetGlobalLogLevel(t *testing.T) {
 		{
 			name:          "generic error on SetLogLevel",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("SetLogLevel", errorLvl).Return(gError)
 			},
 			query:     mutation,

--- a/core/web/resolver/node_test.go
+++ b/core/web/resolver/node_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"testing"
 
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
@@ -39,7 +40,7 @@ func TestResolver_Nodes(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetRelayers").Return(&chainlinkmocks.FakeRelayerChainInteroperators{
 					Nodes: []types.NodeStatus{
 						{
@@ -78,7 +79,7 @@ func TestResolver_Nodes(t *testing.T) {
 		{
 			name:          "generic error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.relayerChainInterops.NodesErr = gError
 				f.App.On("GetRelayers").Return(f.Mocks.relayerChainInterops)
 			},
@@ -122,7 +123,7 @@ func Test_NodeQuery(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetRelayers").Return(&chainlinkmocks.FakeRelayerChainInteroperators{Relayers: []loop.Relayer{
 					testutils.MockRelayer{NodeStatuses: []types.NodeStatus{
 						{
@@ -146,7 +147,7 @@ func Test_NodeQuery(t *testing.T) {
 		{
 			name:          "not found error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("GetRelayers").Return(&chainlinkmocks.FakeRelayerChainInteroperators{Relayers: []loop.Relayer{}})
 			},
 			query: query,

--- a/core/web/resolver/ocr2_keys_test.go
+++ b/core/web/resolver/ocr2_keys_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -69,7 +70,7 @@ func TestResolver_GetOCR2KeyBundles(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.ocr2.On("GetAll").Return(fakeKeys, nil)
 				f.Mocks.keystore.On("OCR2").Return(f.Mocks.ocr2)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -80,7 +81,7 @@ func TestResolver_GetOCR2KeyBundles(t *testing.T) {
 		{
 			name:          "generic error on GetAll()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.ocr2.On("GetAll").Return(nil, gError)
 				f.Mocks.keystore.On("OCR2").Return(f.Mocks.ocr2)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -150,7 +151,7 @@ func TestResolver_CreateOCR2KeyBundle(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.ocr2.On("Create", mock.Anything, chaintype.ChainType("evm")).Return(fakeKey, nil)
 				f.Mocks.keystore.On("OCR2").Return(f.Mocks.ocr2)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -162,7 +163,7 @@ func TestResolver_CreateOCR2KeyBundle(t *testing.T) {
 		{
 			name:          "generic error on Create()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.ocr2.On("Create", mock.Anything, chaintype.ChainType("evm")).Return(nil, gError)
 				f.Mocks.keystore.On("OCR2").Return(f.Mocks.ocr2)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -238,7 +239,7 @@ func TestResolver_DeleteOCR2KeyBundle(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.ocr2.On("Delete", mock.Anything, fakeKey.ID()).Return(nil)
 				f.Mocks.ocr2.On("Get", fakeKey.ID()).Return(fakeKey, nil)
 				f.Mocks.keystore.On("OCR2").Return(f.Mocks.ocr2)
@@ -251,7 +252,7 @@ func TestResolver_DeleteOCR2KeyBundle(t *testing.T) {
 		{
 			name:          "not found error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.ocr2.On("Get", fakeKey.ID()).Return(fakeKey, gError)
 				f.Mocks.keystore.On("OCR2").Return(f.Mocks.ocr2)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -268,7 +269,7 @@ func TestResolver_DeleteOCR2KeyBundle(t *testing.T) {
 		{
 			name:          "generic error on Delete()",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.ocr2.On("Delete", mock.Anything, fakeKey.ID()).Return(gError)
 				f.Mocks.ocr2.On("Get", fakeKey.ID()).Return(fakeKey, nil)
 				f.Mocks.keystore.On("OCR2").Return(f.Mocks.ocr2)

--- a/core/web/resolver/ocr_test.go
+++ b/core/web/resolver/ocr_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"encoding/json"
 	"math/big"
 	"testing"
@@ -54,7 +55,7 @@ func TestResolver_GetOCRKeyBundles(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.ocr.On("GetAll").Return(fakeKeys, nil)
 				f.Mocks.keystore.On("OCR").Return(f.Mocks.ocr)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -105,7 +106,7 @@ func TestResolver_OCRCreateBundle(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.ocr.On("Create", mock.Anything).Return(fakeKey, nil)
 				f.Mocks.keystore.On("OCR").Return(f.Mocks.ocr)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -163,7 +164,7 @@ func TestResolver_OCRDeleteBundle(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.ocr.On("Delete", mock.Anything, fakeKey.ID()).Return(fakeKey, nil)
 				f.Mocks.keystore.On("OCR").Return(f.Mocks.ocr)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -175,7 +176,7 @@ func TestResolver_OCRDeleteBundle(t *testing.T) {
 		{
 			name:          "not found error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.ocr.
 					On("Delete", mock.Anything, fakeKey.ID()).
 					Return(ocrkey.KeyV2{}, keystore.KeyNotFoundError{ID: "helloWorld", KeyType: "OCR"})

--- a/core/web/resolver/p2p_test.go
+++ b/core/web/resolver/p2p_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -53,7 +54,7 @@ func TestResolver_GetP2PKeys(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.p2p.On("GetAll").Return(fakeKeys, nil)
 				f.Mocks.keystore.On("P2P").Return(f.Mocks.p2p)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -102,7 +103,7 @@ func TestResolver_CreateP2PKey(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.p2p.On("Create", mock.Anything).Return(fakeKey, nil)
 				f.Mocks.keystore.On("P2P").Return(f.Mocks.p2p)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -163,7 +164,7 @@ func TestResolver_DeleteP2PKey(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.p2p.On("Delete", mock.Anything, peerID).Return(fakeKey, nil)
 				f.Mocks.keystore.On("P2P").Return(f.Mocks.p2p)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -175,7 +176,7 @@ func TestResolver_DeleteP2PKey(t *testing.T) {
 		{
 			name:          "not found error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.p2p.
 					On("Delete", mock.Anything, peerID).
 					Return(

--- a/core/web/resolver/solana_key_test.go
+++ b/core/web/resolver/solana_key_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
@@ -40,7 +41,7 @@ func TestResolver_SolanaKeys(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.solana.On("GetAll").Return([]solkey.Key{k}, nil)
 				f.Mocks.keystore.On("Solana").Return(f.Mocks.solana)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -51,7 +52,7 @@ func TestResolver_SolanaKeys(t *testing.T) {
 		{
 			name:          "generic error on GetAll",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.solana.On("GetAll").Return([]solkey.Key{}, gError)
 				f.Mocks.keystore.On("Solana").Return(f.Mocks.solana)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)

--- a/core/web/resolver/spec_test.go
+++ b/core/web/resolver/spec_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -34,7 +35,7 @@ func TestResolver_CronSpec(t *testing.T) {
 		{
 			name:          "cron spec success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.Cron,
@@ -88,7 +89,7 @@ func TestResolver_DirectRequestSpec(t *testing.T) {
 		{
 			name:          "direct request spec success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.DirectRequest,
@@ -153,7 +154,7 @@ func TestResolver_FluxMonitorSpec(t *testing.T) {
 		{
 			name:          "flux monitor spec with standard timers",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.FluxMonitor,
@@ -220,7 +221,7 @@ func TestResolver_FluxMonitorSpec(t *testing.T) {
 		{
 			name:          "flux monitor spec with drumbeat",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.FluxMonitor,
@@ -303,7 +304,7 @@ func TestResolver_KeeperSpec(t *testing.T) {
 		{
 			name:          "keeper spec",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.Keeper,
@@ -367,7 +368,7 @@ func TestResolver_OCRSpec(t *testing.T) {
 		{
 			name:          "OCR spec",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.OffchainReporting,
@@ -472,7 +473,7 @@ func TestResolver_OCR2Spec(t *testing.T) {
 		{
 			name:          "OCR 2 spec",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.OffchainReporting2,
@@ -574,7 +575,7 @@ func TestResolver_VRFSpec(t *testing.T) {
 		{
 			name:          "vrf spec",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.VRF,
@@ -670,7 +671,7 @@ func TestResolver_WebhookSpec(t *testing.T) {
 		{
 			name:          "webhook spec",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.Webhook,
@@ -739,7 +740,7 @@ func TestResolver_BlockhashStoreSpec(t *testing.T) {
 		{
 			name:          "blockhash store spec",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.BlockhashStore,
@@ -843,7 +844,7 @@ func TestResolver_BlockHeaderFeederSpec(t *testing.T) {
 		{
 			name:          "block header feeder spec",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.BlockHeaderFeeder,
@@ -930,7 +931,7 @@ func TestResolver_BootstrapSpec(t *testing.T) {
 		{
 			name:          "Bootstrap spec",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.Bootstrap,
@@ -1002,7 +1003,7 @@ func TestResolver_WorkflowSpec(t *testing.T) {
 		{
 			name:          "Workflow spec",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.Workflow,
@@ -1060,7 +1061,7 @@ func TestResolver_GatewaySpec(t *testing.T) {
 		{
 			name:          "Gateway spec",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.App.On("JobORM").Return(f.Mocks.jobORM)
 				f.Mocks.jobORM.On("FindJobWithoutSpecErrors", mock.Anything, id).Return(job.Job{
 					Type: job.Gateway,

--- a/core/web/resolver/user_test.go
+++ b/core/web/resolver/user_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"testing"
 
 	gqlerrors "github.com/graph-gophers/graphql-go/errors"
@@ -44,8 +45,8 @@ func TestResolver_UpdateUserPassword(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
-				session, ok := auth.GetGQLAuthenticatedSession(f.Ctx)
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				session, ok := auth.GetGQLAuthenticatedSession(ctx)
 				require.True(t, ok)
 				require.NotNil(t, session)
 
@@ -73,8 +74,8 @@ func TestResolver_UpdateUserPassword(t *testing.T) {
 		{
 			name:          "update password match error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
-				session, ok := auth.GetGQLAuthenticatedSession(f.Ctx)
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				session, ok := auth.GetGQLAuthenticatedSession(ctx)
 				require.True(t, ok)
 				require.NotNil(t, session)
 
@@ -99,8 +100,8 @@ func TestResolver_UpdateUserPassword(t *testing.T) {
 		{
 			name:          "failed to clear session error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
-				session, ok := auth.GetGQLAuthenticatedSession(f.Ctx)
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				session, ok := auth.GetGQLAuthenticatedSession(ctx)
 				require.True(t, ok)
 				require.NotNil(t, session)
 
@@ -130,8 +131,8 @@ func TestResolver_UpdateUserPassword(t *testing.T) {
 		{
 			name:          "failed to update current user password error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
-				session, ok := auth.GetGQLAuthenticatedSession(f.Ctx)
+			before: func(ctx context.Context, f *gqlTestFramework) {
+				session, ok := auth.GetGQLAuthenticatedSession(ctx)
 				require.True(t, ok)
 				require.NotNil(t, session)
 

--- a/core/web/resolver/vrf_test.go
+++ b/core/web/resolver/vrf_test.go
@@ -1,6 +1,7 @@
 package resolver
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"math/big"
@@ -64,7 +65,7 @@ func TestResolver_GetVRFKey(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.vrf.On("Get", fakeKey.PublicKey.String()).Return(fakeKey, nil)
 				f.Mocks.keystore.On("VRF").Return(f.Mocks.vrf)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -76,7 +77,7 @@ func TestResolver_GetVRFKey(t *testing.T) {
 		{
 			name:          "not found error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.vrf.
 					On("Get", fakeKey.PublicKey.String()).
 					Return(vrfkey.KeyV2{}, errors.Wrapf(
@@ -146,7 +147,7 @@ func TestResolver_GetVRFKeys(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.vrf.On("GetAll").Return(fakeKeys, nil)
 				f.Mocks.keystore.On("VRF").Return(f.Mocks.vrf)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -198,7 +199,7 @@ func TestResolver_CreateVRFKey(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.vrf.On("Create", mock.Anything).Return(fakeKey, nil)
 				f.Mocks.keystore.On("VRF").Return(f.Mocks.vrf)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -261,7 +262,7 @@ func TestResolver_DeleteVRFKey(t *testing.T) {
 		{
 			name:          "success",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.vrf.On("Delete", mock.Anything, fakeKey.PublicKey.String()).Return(fakeKey, nil)
 				f.Mocks.keystore.On("VRF").Return(f.Mocks.vrf)
 				f.App.On("GetKeyStore").Return(f.Mocks.keystore)
@@ -273,7 +274,7 @@ func TestResolver_DeleteVRFKey(t *testing.T) {
 		{
 			name:          "not found error",
 			authenticated: true,
-			before: func(f *gqlTestFramework) {
+			before: func(ctx context.Context, f *gqlTestFramework) {
 				f.Mocks.vrf.
 					On("Delete", mock.Anything, fakeKey.PublicKey.String()).
 					Return(vrfkey.KeyV2{}, errors.Wrapf(


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCF-3203

This PR enabled the `containedctx` rule and cleans up all outstanding cases.
> containedctx is a linter that detects struct contained context.Context field. This is discouraged technique in favour of passing context as first argument of method or function. For rationale please read [Contexts and structs](https://go.dev/blog/context-and-structs) the Go blog post.