### PR TITLE
Dequeue minimum guaranteed logs as a priority

### DIFF
--- a/.changeset/modern-ghosts-hang.md
+++ b/.changeset/modern-ghosts-hang.md
@@ -1,0 +1,4 @@
+---
+"chainlink": patch
+---
+Iterate over upkeeps using an upkeep selector #changed

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -138,7 +138,7 @@ func (b *logBuffer) trackBlockNumbersForUpkeep(uid *big.Int, uniqueBlocks map[in
 		if blockNumbers, ok := b.enqueuedBlocks[blockNumber]; ok {
 			if upkeepBlockInstances, ok := blockNumbers[uid.String()]; ok {
 				blockNumbers[uid.String()] = upkeepBlockInstances + 1
-				b.lggr.Debugw("enqueuing logs again for a previously seen block for this upkeep", "blockNumber", blockNumber, "numberOfEnqueues", b.enqueuedBlocks[blockNumber], "upkeepID", uid.String())
+				b.lggr.Debugw("enqueuing logs again for a previously seen block for this upkeep", "blockNumber", blockNumber, "upkeepID", uid.String())
 			} else {
 				blockNumbers[uid.String()] = 1
 			}

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/buffer_v1.go
@@ -432,7 +432,7 @@ func (q *upkeepLogQueue) clean(blockThreshold int64) int {
 			expired++
 			continue
 		}
-		start, _ := getBlockWindow(l.BlockNumber, blockRate)
+		start, _, _ := getBlockWindow(l.BlockNumber, blockRate)
 		if start != currentWindowStart {
 			// new window, reset capacity
 			currentWindowStart = start
@@ -478,12 +478,13 @@ func (q *upkeepLogQueue) cleanStates(blockThreshold int64) {
 }
 
 // getBlockWindow returns the start and end block of the window for the given block.
-func getBlockWindow(block int64, blockRate int) (start int64, end int64) {
+func getBlockWindow(block int64, blockRate int) (start int64, end int64, isWindowComplete bool) {
 	windowSize := int64(blockRate)
 	if windowSize == 0 {
-		return block, block
+		return
 	}
 	start = block - (block % windowSize)
 	end = start + windowSize - 1
+	isWindowComplete = block == end
 	return
 }

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -302,6 +302,9 @@ func (p *logEventProvider) getLogsFromBuffer(latestBlock int64) []ocr2keepers.Up
 			p.calculateIterations = false
 			p.currentIteration = 0
 			p.iterations = int(math.Ceil(float64(p.bufferV1.NumOfUpkeeps()*logLimitLow) / float64(maxResults)))
+			if p.iterations == 0 {
+				p.iterations = 1
+			}
 		}
 
 		upkeepSelectorFn := func(id *big.Int) bool {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -346,8 +346,10 @@ func (p *logEventProvider) getLogsFromBuffer(latestBlock int64) []ocr2keepers.Up
 			if !p.dequeuedMinimum[startWindow] && p.dequeuedLogs[startWindow] >= numberOfUpkeeps*logLimitLow {
 				p.lggr.Debugw("Dequeued minimum logs, bumping to next window", "start", start, "latestBlock", latestBlock)
 				p.dequeuedMinimum[startWindow] = true
+
 				start += int64(blockRate)
 				continue
+
 			}
 
 			if dequeuedLatestCompleteWindow {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -157,6 +157,7 @@ func (p *logEventProvider) SetConfig(cfg ocr2keepers.LogEventProviderConfig) {
 
 	switch p.opts.BufferVersion {
 	case BufferVersionV1:
+		p.lggr.With("where", "setConfig").Infow("setting buffer v1 config")
 		p.bufferV1.SetConfig(uint32(p.opts.LookbackBlocks), blockRate, logLimit)
 	default:
 	}

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"hash"
 	"io"
+	"math"
 	"math/big"
 	"runtime"
 	"sync"
@@ -114,19 +115,24 @@ type logEventProvider struct {
 	currentPartitionIdx uint64
 
 	chainID *big.Int
+
+	currentIteration    int
+	calculateIterations bool
+	iterations          int
 }
 
 func NewLogProvider(lggr logger.Logger, poller logpoller.LogPoller, chainID *big.Int, packer LogDataPacker, filterStore UpkeepFilterStore, opts LogTriggersOptions) *logEventProvider {
 	return &logEventProvider{
-		threadCtrl:  utils.NewThreadControl(),
-		lggr:        lggr.Named("KeepersRegistry.LogEventProvider"),
-		packer:      packer,
-		buffer:      newLogEventBuffer(lggr, int(opts.LookbackBlocks), defaultNumOfLogUpkeeps, defaultFastExecLogsHigh),
-		bufferV1:    NewLogBuffer(lggr, uint32(opts.LookbackBlocks), opts.BlockRate, opts.LogLimit),
-		poller:      poller,
-		opts:        opts,
-		filterStore: filterStore,
-		chainID:     chainID,
+		threadCtrl:          utils.NewThreadControl(),
+		lggr:                lggr.Named("KeepersRegistry.LogEventProvider"),
+		packer:              packer,
+		buffer:              newLogEventBuffer(lggr, int(opts.LookbackBlocks), defaultNumOfLogUpkeeps, defaultFastExecLogsHigh),
+		bufferV1:            NewLogBuffer(lggr, uint32(opts.LookbackBlocks), opts.BlockRate, opts.LogLimit),
+		poller:              poller,
+		opts:                opts,
+		filterStore:         filterStore,
+		chainID:             chainID,
+		calculateIterations: true,
 	}
 }
 
@@ -286,10 +292,26 @@ func (p *logEventProvider) getLogsFromBuffer(latestBlock int64) []ocr2keepers.Up
 
 	switch p.opts.BufferVersion {
 	case BufferVersionV1:
-		// in v1, we use a greedy approach - we keep dequeuing logs until we reach the max results or cover the entire range.
 		blockRate, logLimitLow, maxResults, _ := p.getBufferDequeueArgs()
+
+		if p.iterations == p.currentIteration {
+			p.calculateIterations = true
+		}
+
+		if p.calculateIterations {
+			p.calculateIterations = false
+			p.currentIteration = 0
+			p.iterations = int(math.Ceil(float64(p.bufferV1.NumOfUpkeeps()*logLimitLow) / float64(maxResults)))
+		}
+
+		upkeepSelectorFn := func(id *big.Int) bool {
+			return id.Int64()%int64(p.iterations) == int64(p.currentIteration)
+		}
+
 		for len(payloads) < maxResults && start <= latestBlock {
-			logs, remaining := p.bufferV1.Dequeue(start, blockRate, logLimitLow, maxResults-len(payloads), DefaultUpkeepSelector)
+			startWindow, end := getBlockWindow(start, blockRate)
+
+			logs, remaining := p.bufferV1.Dequeue(startWindow, end, logLimitLow, maxResults-len(payloads), upkeepSelectorFn)
 			if len(logs) > 0 {
 				p.lggr.Debugw("Dequeued logs", "start", start, "latestBlock", latestBlock, "logs", len(logs))
 			}
@@ -299,13 +321,16 @@ func (p *logEventProvider) getLogsFromBuffer(latestBlock int64) []ocr2keepers.Up
 					payloads = append(payloads, payload)
 				}
 			}
+
 			if remaining > 0 {
 				p.lggr.Debugw("Remaining logs", "start", start, "latestBlock", latestBlock, "remaining", remaining)
 				// TODO: handle remaining logs in a better way than consuming the entire window, e.g. do not repeat more than x times
 				continue
 			}
+
 			start += int64(blockRate)
 		}
+		p.currentIteration++
 	default:
 		logs := p.buffer.dequeueRange(start, latestBlock, AllowedLogsPerUpkeep, MaxPayloads)
 		for _, l := range logs {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -8,6 +8,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
@@ -313,6 +315,444 @@ func newEntry(p *logEventProvider, i int, args ...string) (LogTriggerConfig, upk
 		topics:   topics,
 	}
 	return cfg, f
+}
+
+func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
+	t.Run("5 upkeeps, 100 logs per upkeep per block for 100 blocks", func(t *testing.T) {
+		upkeepIDs := []*big.Int{
+			big.NewInt(1),
+			big.NewInt(2),
+			big.NewInt(3),
+			big.NewInt(4),
+			big.NewInt(5),
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start; i < end; i++ {
+				for j := 0; j < 100; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i+1)),
+						BlockNumber: i + 1,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 100, nil
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		err := provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 5, provider.bufferV1.NumOfUpkeeps())
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		// each upkeep should have 100 logs * 100 blocks = 10000 logs
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["5"].logs))
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 9980, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9980, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 9980, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 9980, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 9980, len(bufV1.queues["5"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 9960, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9960, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 9960, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 9960, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 9960, len(bufV1.queues["5"].logs))
+	})
+
+	t.Run("200 upkeeps", func(t *testing.T) {
+		var upkeepIDs []*big.Int
+
+		for i := int64(1); i <= 200; i++ {
+			upkeepIDs = append(upkeepIDs, big.NewInt(i))
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start; i < end; i++ {
+				for j := 0; j < 100; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i+1)),
+						BlockNumber: i + 1,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 100, nil
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		err := provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 200, provider.bufferV1.NumOfUpkeeps())
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		// each upkeep should have 100 logs * 100 blocks = 10000 logs
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["150"].logs))
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.iterations)
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9998, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+	})
+
+	t.Run("200 upkeeps, increasing to 300 upkeeps midway through the test", func(t *testing.T) {
+		var upkeepIDs []*big.Int
+
+		for i := int64(1); i <= 200; i++ {
+			upkeepIDs = append(upkeepIDs, big.NewInt(i))
+		}
+
+		filterStore := NewUpkeepFilterStore()
+
+		logGenerator := func(start, end int64) []logpoller.Log {
+			var res []logpoller.Log
+			for i := start; i < end; i++ {
+				for j := 0; j < 100; j++ {
+					res = append(res, logpoller.Log{
+						LogIndex:    int64(j),
+						BlockHash:   common.HexToHash(fmt.Sprintf("%d", i+1)),
+						BlockNumber: i + 1,
+					})
+				}
+			}
+			return res
+		}
+
+		// use a log poller that will create logs for the queried block range
+		logPoller := &mockLogPoller{
+			LatestBlockFn: func(ctx context.Context) (int64, error) {
+				return 100, nil
+			},
+			LogsWithSigsFn: func(ctx context.Context, start, end int64, eventSigs []common.Hash, address common.Address) ([]logpoller.Log, error) {
+				return logGenerator(start, end), nil
+			},
+		}
+
+		// prepare the filter store with upkeeps
+		for _, upkeepID := range upkeepIDs {
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		opts := NewOptions(200, big.NewInt(1))
+		opts.BufferVersion = "v1"
+
+		provider := NewLogProvider(logger.TestLogger(t), logPoller, big.NewInt(1), &mockedPacker{}, filterStore, opts)
+
+		ctx := context.Background()
+
+		err := provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 200, provider.bufferV1.NumOfUpkeeps())
+
+		bufV1 := provider.bufferV1.(*logBuffer)
+
+		// each upkeep should have 100 logs * 100 blocks = 10000 logs
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["9"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["21"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["150"].logs))
+
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.iterations)
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps; with 2 iterations this means even upkeep IDs are dequeued first
+		assert.Equal(t, 10000, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["40"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["45"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps; on the second iteration, odd upkeep IDs are dequeued
+		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["99"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["100"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps; on the third iteration, even upkeep IDs are dequeued once again
+		assert.Equal(t, 9999, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["160"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["170"].logs))
+
+		for i := int64(201); i <= 300; i++ {
+			upkeepIDs = append(upkeepIDs, big.NewInt(i))
+		}
+
+		for i := 200; i < len(upkeepIDs); i++ {
+			upkeepID := upkeepIDs[i]
+			filterStore.AddActiveUpkeeps(
+				upkeepFilter{
+					addr:     []byte(upkeepID.String()),
+					upkeepID: upkeepID,
+					topics: []common.Hash{
+						common.HexToHash(upkeepID.String()),
+					},
+				},
+			)
+		}
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 300, provider.bufferV1.NumOfUpkeeps())
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 2, provider.iterations)
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps; the new iterations
+		// have not yet been recalculated despite the new logs being added; new iterations
+		// are only calculated when current iteration maxes out at the total number of iterations
+		assert.Equal(t, 9998, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["51"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["52"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// with the newly added logs, iterations is recalculated
+		assert.Equal(t, 3, provider.iterations)
+		assert.Equal(t, 1, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9998, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["11"].logs))
+		assert.Equal(t, 9997, len(bufV1.queues["111"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9997, len(bufV1.queues["150"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 3, provider.iterations)
+		assert.Equal(t, 2, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		// the dequeue is evenly distributed across selected upkeeps
+		assert.Equal(t, 9997, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 9997, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["50"].logs))
+		assert.Equal(t, 9998, len(bufV1.queues["101"].logs))
+		assert.Equal(t, 9997, len(bufV1.queues["150"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["250"].logs))
+		assert.Equal(t, 10000, len(bufV1.queues["299"].logs))
+		assert.Equal(t, 9999, len(bufV1.queues["300"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		assert.Equal(t, 3, provider.iterations)
+		assert.Equal(t, 3, provider.currentIteration)
+
+		// we dequeue a maximum of 100 logs
+		assert.Equal(t, 100, len(payloads))
+
+		var remainingLogs int
+		// at this point, every queue should have had at least one log dequeued
+		for _, queue := range bufV1.queues {
+			assert.True(t, len(queue.logs) < 10000)
+			remainingLogs += len(queue.logs)
+		}
+
+		// check that across all 300 upkeeps, we have only dequeued 700 of the 3000000 logs (7 dequeue calls of 100 logs)
+		assert.Equal(t, 2999300, remainingLogs)
+	})
 }
 
 type mockedPacker struct {

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -373,7 +373,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		ctx := context.Background()
 
-		payloads, err := provider.GetLatestPayloads(ctx)
+		_, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
 
 		err = provider.ReadLogs(ctx, upkeepIDs...)
@@ -390,7 +390,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10000, len(bufV1.queues["4"].logs))
 		assert.Equal(t, 10000, len(bufV1.queues["5"].logs))
 
-		payloads, err = provider.GetLatestPayloads(ctx)
+		payloads, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
 
 		// we dequeue a maximum of 100 logs
@@ -470,7 +470,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		ctx := context.Background()
 
-		payloads, err := provider.GetLatestPayloads(ctx)
+		_, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
 
 		err = provider.ReadLogs(ctx, upkeepIDs...)
@@ -486,7 +486,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
 		assert.Equal(t, 10000, len(bufV1.queues["150"].logs))
 
-		payloads, err = provider.GetLatestPayloads(ctx)
+		payloads, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 2, provider.iterations)
@@ -597,7 +597,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		ctx := context.Background()
 
-		payloads, err := provider.GetLatestPayloads(ctx)
+		_, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
 
 		err = provider.ReadLogs(ctx, upkeepIDs...)
@@ -615,7 +615,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
 		assert.Equal(t, 10000, len(bufV1.queues["150"].logs))
 
-		payloads, err = provider.GetLatestPayloads(ctx)
+		payloads, err := provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 2, provider.iterations)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -850,6 +850,115 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 998, len(bufV1.queues["3"].logs))
 		assert.Equal(t, 998, len(bufV1.queues["4"].logs))
 		assert.Equal(t, 998, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts := map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the first block window
+		assert.Equal(t, 40, blockWindowCounts[1])
+		assert.Equal(t, 50, blockWindowCounts[2])
+		assert.Equal(t, 50, blockWindowCounts[3])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 996, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 996, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 996, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 996, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 996, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 40, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[2])
+		assert.Equal(t, 50, blockWindowCounts[3])
+
+		for i := 3; i < 100; i++ {
+			payloads, err = provider.GetLatestPayloads(ctx)
+			assert.NoError(t, err)
+
+			// we dequeue a maximum of 10 logs
+			assert.Equal(t, 10, len(payloads))
+		}
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 802, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 802, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 802, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 802, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 802, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 40, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[2])
+		assert.Equal(t, 40, blockWindowCounts[3])
+		assert.Equal(t, 50, blockWindowCounts[100])
+
+		// at this point, all block windows except for the latest block window will have been dequeued
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 800, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 800, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 800, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 800, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 800, len(bufV1.queues["5"].logs))
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 798, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 798, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 798, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 798, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 798, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 30, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[2])
+		assert.Equal(t, 40, blockWindowCounts[3])
+		assert.Equal(t, 40, blockWindowCounts[100])
 	})
 }
 

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -890,7 +890,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 40, blockWindowCounts[2])
 		assert.Equal(t, 50, blockWindowCounts[3])
 
-		for i := 3; i < 100; i++ {
+		for i := 2; i < 100; i++ {
 			payloads, err = provider.GetLatestPayloads(ctx)
 			assert.NoError(t, err)
 
@@ -917,6 +917,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 40, blockWindowCounts[1])
 		assert.Equal(t, 40, blockWindowCounts[2])
 		assert.Equal(t, 40, blockWindowCounts[3])
+		assert.Equal(t, 40, blockWindowCounts[99])
 		assert.Equal(t, 50, blockWindowCounts[100])
 
 		// at this point, all block windows except for the latest block window will have been dequeued

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -890,7 +890,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 40, blockWindowCounts[2])
 		assert.Equal(t, 50, blockWindowCounts[3])
 
-		for i := 2; i < 100; i++ {
+		for i := 0; i < 97; i++ {
 			payloads, err = provider.GetLatestPayloads(ctx)
 			assert.NoError(t, err)
 
@@ -958,6 +958,114 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
 		assert.Equal(t, 30, blockWindowCounts[1])
 		assert.Equal(t, 40, blockWindowCounts[2])
+		assert.Equal(t, 40, blockWindowCounts[3])
+		assert.Equal(t, 40, blockWindowCounts[100])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 796, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 796, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 796, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 796, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 796, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 20, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[2])
+		assert.Equal(t, 40, blockWindowCounts[3])
+		assert.Equal(t, 40, blockWindowCounts[100])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 794, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 794, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 794, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 794, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 794, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 10, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[2])
+		assert.Equal(t, 40, blockWindowCounts[3])
+		assert.Equal(t, 40, blockWindowCounts[100])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 792, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 792, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 792, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 792, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 792, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 0, blockWindowCounts[1])
+		assert.Equal(t, 40, blockWindowCounts[2])
+		assert.Equal(t, 40, blockWindowCounts[3])
+		assert.Equal(t, 40, blockWindowCounts[100])
+
+		payloads, err = provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		// we dequeue a maximum of 10 logs
+		assert.Equal(t, 10, len(payloads))
+
+		// the dequeue is evenly distributed across the 5 upkeeps
+		assert.Equal(t, 790, len(bufV1.queues["1"].logs))
+		assert.Equal(t, 790, len(bufV1.queues["2"].logs))
+		assert.Equal(t, 790, len(bufV1.queues["3"].logs))
+		assert.Equal(t, 790, len(bufV1.queues["4"].logs))
+		assert.Equal(t, 790, len(bufV1.queues["5"].logs))
+
+		blockWindowCounts = map[int64]int{}
+
+		for _, q := range bufV1.queues {
+			for _, l := range q.logs {
+				blockWindowCounts[l.BlockNumber]++
+			}
+		}
+
+		// all 10 logs should have been dequeued from the second block window, since the first block window has met it's minimum commitment
+		assert.Equal(t, 0, blockWindowCounts[1])
+		assert.Equal(t, 30, blockWindowCounts[2])
 		assert.Equal(t, 40, blockWindowCounts[3])
 		assert.Equal(t, 40, blockWindowCounts[100])
 	})

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/provider_test.go
@@ -373,7 +373,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		ctx := context.Background()
 
-		err := provider.ReadLogs(ctx, upkeepIDs...)
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 5, provider.bufferV1.NumOfUpkeeps())
@@ -387,7 +390,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10000, len(bufV1.queues["4"].logs))
 		assert.Equal(t, 10000, len(bufV1.queues["5"].logs))
 
-		payloads, err := provider.GetLatestPayloads(ctx)
+		payloads, err = provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
 
 		// we dequeue a maximum of 100 logs
@@ -467,7 +470,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		ctx := context.Background()
 
-		err := provider.ReadLogs(ctx, upkeepIDs...)
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 200, provider.bufferV1.NumOfUpkeeps())
@@ -480,7 +486,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
 		assert.Equal(t, 10000, len(bufV1.queues["150"].logs))
 
-		payloads, err := provider.GetLatestPayloads(ctx)
+		payloads, err = provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 2, provider.iterations)
@@ -591,7 +597,10 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 
 		ctx := context.Background()
 
-		err := provider.ReadLogs(ctx, upkeepIDs...)
+		payloads, err := provider.GetLatestPayloads(ctx)
+		assert.NoError(t, err)
+
+		err = provider.ReadLogs(ctx, upkeepIDs...)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 200, provider.bufferV1.NumOfUpkeeps())
@@ -606,7 +615,7 @@ func TestLogEventProvider_GetLatestPayloads(t *testing.T) {
 		assert.Equal(t, 10000, len(bufV1.queues["101"].logs))
 		assert.Equal(t, 10000, len(bufV1.queues["150"].logs))
 
-		payloads, err := provider.GetLatestPayloads(ctx)
+		payloads, err = provider.GetLatestPayloads(ctx)
 		assert.NoError(t, err)
 
 		assert.Equal(t, 2, provider.iterations)

--- a/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer_test.go
+++ b/core/services/ocr2/plugins/ocr2keeper/evmregistry/v21/logprovider/recoverer_test.go
@@ -1187,10 +1187,15 @@ type mockFilterStore struct {
 	UpkeepFilterStore
 	HasFn               func(id *big.Int) bool
 	RangeFiltersByIDsFn func(iterator func(int, upkeepFilter), ids ...*big.Int)
+	UpdateFiltersFn     func(updater func(upkeepFilter, upkeepFilter) upkeepFilter, filters ...upkeepFilter)
 }
 
 func (s *mockFilterStore) RangeFiltersByIDs(iterator func(int, upkeepFilter), ids ...*big.Int) {
 	s.RangeFiltersByIDsFn(iterator, ids...)
+}
+
+func (s *mockFilterStore) UpdateFilters(updater func(upkeepFilter, upkeepFilter) upkeepFilter, filters ...upkeepFilter) {
+	s.UpdateFiltersFn(updater, filters...)
 }
 
 func (s *mockFilterStore) Has(id *big.Int) bool {


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/AUTO-10165

In this PR, we're modifying the log provider to dequeue the minium number of guaranteed logs across all block windows as a priority, before comitting to best effort execution.

As an example, if we have 2 upkeeps and 3 block windows, each with 10 logs to be dequeued in total (5 per upkeep), and assuming a limit of 1 log per upkeep, we would:

- Dequeue 2 logs from block window 1 # minimum commitment for block window 1 met
- Dequeue 2 logs from block window 2 # minimum commitment for block window 2 met
- Dequeue 2 logs from block window 3 # minimum commitment for block window 3 met

At this point, minimum commitment for all three block windows has been fulfilled, we can now operate on a best effort basis, going back to block window 1:

- Dequeue 2 logs from block window 1
- Dequeue 2 logs from block window 1
- Dequeue 2 logs from block window 1
- Dequeue 2 logs from block window 1 # all 10 logs have been dequeued from block window 1
- Dequeue 2 logs from block window 2
- Dequeue 2 logs from block window 2
- Dequeue 2 logs from block window 2
- Dequeue 2 logs from block window 2 # all 10 logs have been dequeued from block window 2
- Dequeue 2 logs from block window 3
- Dequeue 2 logs from block window 3
- Dequeue 2 logs from block window 3
- Dequeue 2 logs from block window 3 # all 10 logs have been dequeued from block window 3