### PR TITLE
Automation Load Test - set OffchainConfig to empty

### DIFF
--- a/integration-tests/load/automationv2_1/automationv2_1_test.go
+++ b/integration-tests/load/automationv2_1/automationv2_1_test.go
@@ -474,7 +474,7 @@ Load Config:
 			TriggerType:    uint8(1),
 			CheckData:      encodedCheckDataStruct,
 			TriggerConfig:  encodedLogTriggerConfig,
-			OffchainConfig: []byte("0"),
+			OffchainConfig: []byte(""),
 			FundingAmount:  automationDefaultLinkFunds,
 		}
 		l.Debug().Interface("Upkeep Config", upkeepConfig).Msg("Upkeep Config")


### PR DESCRIPTION
With the introduction of gas price control feature which uses the upkeep's offchain config, the value needs to be set to empty in the log trigger load test so as to not invoke the case of malformed offchain config.