### PR TITLE
core/chains/evm/config/toml/defaults: remove ineffectual overrides

### DIFF
--- a/core/chains/evm/config/toml/defaults/Avalanche_Fuji.toml
+++ b/core/chains/evm/config/toml/defaults/Avalanche_Fuji.toml
@@ -8,7 +8,6 @@ OCR.ContractConfirmations = 1
 RPCBlockQueryDelay = 2
 
 [GasEstimator]
-Mode = 'BlockHistory'
 PriceDefault = '25 gwei'
 PriceMax = '115792089237316195423570985008687907853269984665.640564039457584007913129639935 tether'
 PriceMin = '25 gwei'

--- a/core/chains/evm/config/toml/defaults/Avalanche_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/Avalanche_Mainnet.toml
@@ -8,7 +8,6 @@ OCR.ContractConfirmations = 1
 RPCBlockQueryDelay = 2
 
 [GasEstimator]
-Mode = 'BlockHistory'
 PriceDefault = '25 gwei'
 PriceMax = '115792089237316195423570985008687907853269984665.640564039457584007913129639935 tether'
 PriceMin = '25 gwei'

--- a/core/chains/evm/config/toml/defaults/BSC_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/BSC_Mainnet.toml
@@ -2,31 +2,18 @@
 # Clique offers finality within (N/2)+1 blocks where N is number of signers
 # There are 21 BSC validators so theoretically finality should occur after 21/2+1 = 11 blocks
 ChainID = '56'
-# Keeping this >> 11 because it's not expensive and gives us a safety margin
-FinalityDepth = 50
 LinkContractAddress = '0x404460C6A5EdE2D891e8297795264fDe62ADBB75'
 LogPollInterval = '3s'
-MinIncomingConfirmations = 3
 NoNewHeadsThreshold = '30s'
 RPCBlockQueryDelay = 2
-Transactions.ResendAfterThreshold = '1m'
-
-[BalanceMonitor]
-Enabled = true
 
 [GasEstimator]
 PriceDefault = '5 gwei'
-PriceMin = '1 gwei'
-BumpMin = '5 gwei'
 # 15s delay since feeds update every minute in volatile situations
 BumpThreshold = 5
 
 [GasEstimator.BlockHistory]
 BlockHistorySize = 24
-
-[HeadTracker]
-HistoryDepth = 100
-SamplingInterval = '1s'
 
 [OCR]
 DatabaseTimeout = '2s'

--- a/core/chains/evm/config/toml/defaults/BSC_Testnet.toml
+++ b/core/chains/evm/config/toml/defaults/BSC_Testnet.toml
@@ -2,31 +2,18 @@
 # Clique offers finality within (N/2)+1 blocks where N is number of signers
 # There are 21 BSC validators so theoretically finality should occur after 21/2+1 = 11 blocks
 ChainID = '97'
-# Keeping this >> 11 because it's not expensive and gives us a safety margin
-FinalityDepth = 50
 LinkContractAddress = '0x84b9B910527Ad5C03A9Ca831909E21e236EA7b06'
 LogPollInterval = '3s'
-MinIncomingConfirmations = 3
 NoNewHeadsThreshold = '30s'
 RPCBlockQueryDelay = 2
-Transactions.ResendAfterThreshold = '1m'
-
-[BalanceMonitor]
-Enabled = true
 
 [GasEstimator]
 PriceDefault = '5 gwei'
-PriceMin = '1 gwei'
-BumpMin = '5 gwei'
 # 15s delay since feeds update every minute in volatile situations
 BumpThreshold = 5
 
 [GasEstimator.BlockHistory]
 BlockHistorySize = 24
-
-[HeadTracker]
-HistoryDepth = 100
-SamplingInterval = '1s'
 
 [OCR]
 DatabaseTimeout = '2s'

--- a/core/chains/evm/config/toml/defaults/Ethereum_Goerli.toml
+++ b/core/chains/evm/config/toml/defaults/Ethereum_Goerli.toml
@@ -6,6 +6,5 @@ MinContractPayment = '0.1 link'
 EIP1559DynamicFees = true
 
 [GasEstimator.BlockHistory]
-BatchSize = 25
 BlockHistorySize = 4
 TransactionPercentile = 50

--- a/core/chains/evm/config/toml/defaults/Ethereum_Kovan.toml
+++ b/core/chains/evm/config/toml/defaults/Ethereum_Kovan.toml
@@ -9,6 +9,5 @@ OperatorFactoryAddress = '0x8007e24251b1D2Fc518Eb843A701d9cD21fe0aA3'
 EIP1559DynamicFees = false
 
 [GasEstimator.BlockHistory]
-BatchSize = 25
 BlockHistorySize = 4
 TransactionPercentile = 50

--- a/core/chains/evm/config/toml/defaults/Ethereum_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/Ethereum_Mainnet.toml
@@ -7,7 +7,6 @@ OperatorFactoryAddress = '0x3E64Cd889482443324F91bFA9c84fE72A511f48A'
 EIP1559DynamicFees = true
 
 [GasEstimator.BlockHistory]
-BatchSize = 25
 # EIP-1559 does well on a smaller block history size
 BlockHistorySize = 4
 TransactionPercentile = 50

--- a/core/chains/evm/config/toml/defaults/Ethereum_Rinkeby.toml
+++ b/core/chains/evm/config/toml/defaults/Ethereum_Rinkeby.toml
@@ -8,6 +8,5 @@ MinContractPayment = '0.1 link'
 EIP1559DynamicFees = false
 
 [GasEstimator.BlockHistory]
-BatchSize = 25
 BlockHistorySize = 4
 TransactionPercentile = 50

--- a/core/chains/evm/config/toml/defaults/Ethereum_Ropsten.toml
+++ b/core/chains/evm/config/toml/defaults/Ethereum_Ropsten.toml
@@ -6,6 +6,5 @@ MinContractPayment = '0.1 link'
 EIP1559DynamicFees = true
 
 [GasEstimator.BlockHistory]
-BatchSize = 25
 BlockHistorySize = 4
 TransactionPercentile = 50

--- a/core/chains/evm/config/toml/defaults/Ethereum_Sepolia.toml
+++ b/core/chains/evm/config/toml/defaults/Ethereum_Sepolia.toml
@@ -6,7 +6,6 @@ MinContractPayment = '0.1 link'
 EIP1559DynamicFees = true
 
 [GasEstimator.BlockHistory]
-BatchSize = 25
 BlockHistorySize = 4
 TransactionPercentile = 50
 

--- a/core/chains/evm/config/toml/defaults/Fantom_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/Fantom_Mainnet.toml
@@ -1,12 +1,8 @@
 ChainID = '250'
 LinkContractAddress = '0x6F43FF82CCA38001B6699a8AC47A2d0E66939407'
 LogPollInterval = '1s'
-MinIncomingConfirmations = 3
 NoNewHeadsThreshold = '30s'
 RPCBlockQueryDelay = 2
-
-[BalanceMonitor]
-Enabled = true
 
 [GasEstimator]
 # Fantom network has been slow to include txs at times when using the BlockHistory estimator, and the recommendation is to use SuggestedPrice mode.

--- a/core/chains/evm/config/toml/defaults/Fantom_Testnet.toml
+++ b/core/chains/evm/config/toml/defaults/Fantom_Testnet.toml
@@ -1,7 +1,6 @@
 ChainID = '4002'
 LinkContractAddress = '0xfaFedb041c0DD4fA2Dc0d87a6B0979Ee6FA7af5F'
 LogPollInterval = '1s'
-MinIncomingConfirmations = 3
 # Fantom testnet only emits blocks when a new tx is received, so this method of liveness detection is not useful
 NoNewHeadsThreshold = '0'
 RPCBlockQueryDelay = 2

--- a/core/chains/evm/config/toml/defaults/Gnosis_Chiado.toml
+++ b/core/chains/evm/config/toml/defaults/Gnosis_Chiado.toml
@@ -7,5 +7,3 @@ LogPollInterval = '5s'
 [GasEstimator]
 EIP1559DynamicFees = true
 PriceMax = '500 gwei'
-# 15s delay since feeds update every minute in volatile situations
-BumpThreshold = 3

--- a/core/chains/evm/config/toml/defaults/Gnosis_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/Gnosis_Mainnet.toml
@@ -15,5 +15,3 @@ PriceDefault = '1 gwei'
 PriceMax = '500 gwei'
 # 1 Gwei is the minimum accepted by the validators (unless whitelisted)
 PriceMin = '1 gwei'
-# 15s delay since feeds update every minute in volatile situations
-BumpThreshold = 3

--- a/core/chains/evm/config/toml/defaults/Heco_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/Heco_Mainnet.toml
@@ -1,29 +1,16 @@
 # Heco uses BSC's settings.
 ChainID = '128'
-FinalityDepth = 50
 LinkContractAddress = '0x404460C6A5EdE2D891e8297795264fDe62ADBB75'
 LogPollInterval = '3s'
-MinIncomingConfirmations = 3
 NoNewHeadsThreshold = '30s'
 RPCBlockQueryDelay = 2
-Transactions.ResendAfterThreshold = '1m'
-
-
-[BalanceMonitor]
-Enabled = true
 
 [GasEstimator]
 PriceDefault = '5 gwei'
-PriceMin = '1 gwei'
-BumpMin = '5 gwei'
 BumpThreshold = 5
 
 [GasEstimator.BlockHistory]
 BlockHistorySize = 24
-
-[HeadTracker]
-HistoryDepth = 100
-SamplingInterval = '1s'
 
 [OCR]
 DatabaseTimeout = '2s'

--- a/core/chains/evm/config/toml/defaults/Metis_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/Metis_Mainnet.toml
@@ -11,10 +11,6 @@ OCR.ContractConfirmations = 1
 Mode = 'SuggestedPrice'
 # Metis uses the SuggestedPrice estimator; we don't want to place any limits on the minimum gas price
 PriceMin = '0'
-BumpThreshold = 3
-
-[BalanceMonitor]
-Enabled = true
 
 [GasEstimator.BlockHistory]
 # Force an error if someone enables the estimator by accident; we never want to run the block history estimator on metisaa

--- a/core/chains/evm/config/toml/defaults/Metis_Rinkeby.toml
+++ b/core/chains/evm/config/toml/defaults/Metis_Rinkeby.toml
@@ -5,13 +5,9 @@ MinIncomingConfirmations = 1
 NoNewHeadsThreshold = '0'
 OCR.ContractConfirmations = 1
 
-[BalanceMonitor]
-Enabled = true
-
 [GasEstimator]
 Mode = 'SuggestedPrice'
 PriceMin = '0'
-BumpThreshold = 3
 
 [GasEstimator.BlockHistory]
 BlockHistorySize = 0

--- a/core/chains/evm/config/toml/defaults/Metis_Sepolia.toml
+++ b/core/chains/evm/config/toml/defaults/Metis_Sepolia.toml
@@ -5,13 +5,9 @@ MinIncomingConfirmations = 1
 NoNewHeadsThreshold = '0'
 OCR.ContractConfirmations = 1
 
-[BalanceMonitor]
-Enabled = true
-
 [GasEstimator]
 Mode = 'SuggestedPrice'
 PriceMin = '0'
-BumpThreshold = 3
 
 [GasEstimator.BlockHistory]
 BlockHistorySize = 0

--- a/core/chains/evm/config/toml/defaults/Polygon_Amoy.toml
+++ b/core/chains/evm/config/toml/defaults/Polygon_Amoy.toml
@@ -7,16 +7,11 @@ RPCBlockQueryDelay = 10
 RPCDefaultBatchSize = 100
 
 [Transactions]
-ResendAfterThreshold = '1m'
 MaxQueued = 5000
-
-[BalanceMonitor]
-Enabled = true
 
 [GasEstimator]
 EIP1559DynamicFees = true
 PriceMax = '115792089237316195423570985008687907853269984665.640564039457584007913129639935 tether'
-PriceMin = '1 gwei'
 BumpMin = '20 gwei'
 BumpThreshold = 5
 
@@ -25,7 +20,6 @@ BlockHistorySize = 24
 
 [HeadTracker]
 HistoryDepth = 2000
-SamplingInterval = '1s'
 
 [NodePool]
 SyncThreshold = 10

--- a/core/chains/evm/config/toml/defaults/Polygon_Mainnet.toml
+++ b/core/chains/evm/config/toml/defaults/Polygon_Mainnet.toml
@@ -12,12 +12,8 @@ RPCDefaultBatchSize = 100
 
 [Transactions]
 # Matic nodes under high mempool pressure are liable to drop txes, we need to ensure we keep sending them
-ResendAfterThreshold = '1m'
 # Since re-orgs on Polygon can be so large, we need a large safety buffer to allow time for the queue to clear down before we start dropping transactions
 MaxQueued = 5000
-
-[BalanceMonitor]
-Enabled = true
 
 [GasEstimator]
 # Many Polygon RPC providers set a minimum of 30 GWei on mainnet to prevent spam
@@ -35,7 +31,6 @@ BlockHistorySize = 24
 [HeadTracker]
 # Polygon suffers from a tremendous number of re-orgs, we need to set this to something very large to be conservative enough
 HistoryDepth = 2000
-SamplingInterval = '1s'
 
 [NodePool]
 SyncThreshold = 10

--- a/core/chains/evm/config/toml/defaults/Polygon_Mumbai.toml
+++ b/core/chains/evm/config/toml/defaults/Polygon_Mumbai.toml
@@ -8,16 +8,11 @@ RPCBlockQueryDelay = 10
 RPCDefaultBatchSize = 100
 
 [Transactions]
-ResendAfterThreshold = '1m'
 MaxQueued = 5000
-
-[BalanceMonitor]
-Enabled = true
 
 [GasEstimator]
 PriceDefault = '1 gwei'
 PriceMax = '115792089237316195423570985008687907853269984665.640564039457584007913129639935 tether'
-PriceMin = '1 gwei'
 BumpMin = '20 gwei'
 BumpThreshold = 5
 
@@ -26,7 +21,6 @@ BlockHistorySize = 24
 
 [HeadTracker]
 HistoryDepth = 2000
-SamplingInterval = '1s'
 
 [NodePool]
 SyncThreshold = 10

--- a/core/chains/evm/config/toml/defaults/Simulated.toml
+++ b/core/chains/evm/config/toml/defaults/Simulated.toml
@@ -8,9 +8,6 @@ NoNewHeadsThreshold = '0s'
 ReaperThreshold = '0s'
 ResendAfterThreshold = '0s'
 
-[BalanceMonitor]
-Enabled = true
-
 [GasEstimator]
 Mode = 'FixedPrice'
 PriceMin = '0'


### PR DESCRIPTION
This PR proposes removing redundant/ineffectual overrides from the evm configs. I left a few behind which had long comments about lack of support, so that we don't accidentally change them.