### PR TITLE
make legacy URL optional for v03, make block number required for conditional upkeeps using data streams

### DIFF
--- a/.changeset/tall-eagles-run.md
+++ b/.changeset/tall-eagles-run.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+tune debugging script #bugfix

--- a/core/scripts/chaincli/DEBUGGING.md
+++ b/core/scripts/chaincli/DEBUGGING.md
@@ -53,9 +53,9 @@ Execute the following command based on your upkeep type:
 - For custom logic: 
 
     ```bash
-    go run main.go keeper debug UPKEEP_ID [OPTIONAL BLOCK_NUMBER]
+    go run main.go keeper debug UPKEEP_ID [BLOCK_NUMBER]
     ```
-    If you don't specify a block number, the debugging script uses the latest block.
+    If you don't specify a block number, the debugging script uses the latest block for checkUpkeep and simulatePerformUpkeep. For conditional upkeeps using streams lookup, a BLOCK_NUMBER is required.
 
 - For log trigger upkeep:
 

--- a/core/scripts/chaincli/handler/debug.go
+++ b/core/scripts/chaincli/handler/debug.go
@@ -270,6 +270,9 @@ func (k *Keeper) Debug(ctx context.Context, args []string) {
 			message("upkeep reverted with StreamsLookup")
 			message(fmt.Sprintf("StreamsLookup data: {FeedParamKey: %s, Feeds: %v, TimeParamKey: %s, Time: %d, ExtraData: %s}", streamsLookupErr.FeedParamKey, streamsLookupErr.Feeds, streamsLookupErr.TimeParamKey, streamsLookupErr.Time.Uint64(), hexutil.Encode(streamsLookupErr.ExtraData)))
 
+			if blockNum == 0 {
+				failCheckConfig("Data streams requires a valid block number for conditional upkeeps, append a block number to your command", nil)
+			}
 			streamsLookup := &mercury.StreamsLookup{
 				StreamsLookupError: &mercury.StreamsLookupError{
 					FeedParamKey: streamsLookupErr.FeedParamKey,
@@ -293,6 +296,9 @@ func (k *Keeper) Debug(ctx context.Context, args []string) {
 				if !allowed {
 					resolveIneligible("upkeep reverted with StreamsLookup but is not allowed to access streams")
 				}
+				if k.cfg.DataStreamsLegacyURL == "" {
+					failCheckConfig("Data streams v02 requires Legacy URL, check your DATA_STREAMS settings in .env", nil)
+				}
 			} else if streamsLookup.IsMercuryV03() {
 				// handle v0.3
 				message("using data streams lookup v0.3")
@@ -300,7 +306,7 @@ func (k *Keeper) Debug(ctx context.Context, args []string) {
 				resolveIneligible("upkeep reverted with StreamsLookup but the configuration is invalid")
 			}
 
-			if k.cfg.DataStreamsLegacyURL == "" || k.cfg.DataStreamsURL == "" || k.cfg.DataStreamsID == "" || k.cfg.DataStreamsKey == "" {
+			if k.cfg.DataStreamsURL == "" || k.cfg.DataStreamsID == "" || k.cfg.DataStreamsKey == "" {
 				failCheckConfig("Data streams configs not set properly for this network, check your DATA_STREAMS settings in .env", nil)
 			}
 


### PR DESCRIPTION
AUTO-10576 
AUTO-10577

> go run main.go keeper debug 114790463727957148015442388957384598642616630118281138949379348359386357583930

time=2024-05-20T09:57:40.626-07:00 level=INFO msg="🔁 Data streams requires a valid block number for conditional upkeeps, append a block number to your command: check your config: rerun this command"


> go run main.go keeper debug 114790463727957148015442388957384598642616630118281138949379348359386357583930 45039745

All good

Run the above command without LegacyURL in .env, it proceeds forward since this one uses Mercury v03