### PR TITLE
Update E2E tests pipeline to not fail during test coverage upload

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -380,6 +380,8 @@ jobs:
 
       - name: Upload Coverage Data
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        timeout-minutes: 2
+        continue-on-error: true
         with:
           name: cl-node-coverage-data-${{ matrix.product.name }}
           path: .covdata
@@ -497,6 +499,8 @@ jobs:
 
       - name: Upload Coverage Data
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        timeout-minutes: 2
+        continue-on-error: true
         with:
           name: cl-node-coverage-data-${{ matrix.product.name }}
           path: .covdata
@@ -723,6 +727,8 @@ jobs:
 
       - name: Upload Coverage Data
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        timeout-minutes: 2
+        continue-on-error: true
         with:
           name: cl-node-coverage-data-${{ matrix.product.name }}-${{ matrix.product.tag_suffix }}
           path: .covdata
@@ -961,6 +967,8 @@ jobs:
           should_tidy: "false"
       - name: Upload Coverage Data
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        timeout-minutes: 2
+        continue-on-error: true          
         with:
           name: cl-node-coverage-data-migration-tests
           path: .covdata
@@ -1261,6 +1269,8 @@ jobs:
 
       - name: Upload Coverage Data
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+        timeout-minutes: 2
+        continue-on-error: true
         with:
           name: cl-node-coverage-data-solana-tests
           path: .covdata


### PR DESCRIPTION
Add timeout and continue on error for `Upload Coverage Data` step in integration-tests.yml workflow