### PR TITLE
Pipeline Data Corruption

### DIFF
--- a/.changeset/blue-camels-begin.md
+++ b/.changeset/blue-camels-begin.md
@@ -1,0 +1,5 @@
+---
+"chainlink": patch
+---
+
+enforce proper result indexing on pipeline results #breaking_change

--- a/core/services/pipeline/graph_test.go
+++ b/core/services/pipeline/graph_test.go
@@ -171,27 +171,27 @@ func TestGraph_TasksInDependencyOrder(t *testing.T) {
 		"ds1_multiply",
 		[]pipeline.TaskDependency{{PropagateResult: true, InputTask: pipeline.Task(ds1_parse)}},
 		[]pipeline.Task{answer1},
-		0)
+		-1)
 	ds2_multiply.BaseTask = pipeline.NewBaseTask(
 		5,
 		"ds2_multiply",
 		[]pipeline.TaskDependency{{PropagateResult: true, InputTask: pipeline.Task(ds2_parse)}},
 		[]pipeline.Task{answer1},
-		0)
+		-1)
 	ds1_parse.BaseTask = pipeline.NewBaseTask(
 		1,
 		"ds1_parse",
 		[]pipeline.TaskDependency{{PropagateResult: true, InputTask: pipeline.Task(ds1)}},
 		[]pipeline.Task{ds1_multiply},
-		0)
+		-1)
 	ds2_parse.BaseTask = pipeline.NewBaseTask(
 		4,
 		"ds2_parse",
 		[]pipeline.TaskDependency{{PropagateResult: true, InputTask: pipeline.Task(ds2)}},
 		[]pipeline.Task{ds2_multiply},
-		0)
-	ds1.BaseTask = pipeline.NewBaseTask(0, "ds1", nil, []pipeline.Task{ds1_parse}, 0)
-	ds2.BaseTask = pipeline.NewBaseTask(3, "ds2", nil, []pipeline.Task{ds2_parse}, 0)
+		-1)
+	ds1.BaseTask = pipeline.NewBaseTask(0, "ds1", nil, []pipeline.Task{ds1_parse}, -1)
+	ds2.BaseTask = pipeline.NewBaseTask(3, "ds2", nil, []pipeline.Task{ds2_parse}, -1)
 
 	for i, task := range p.Tasks {
 		// Make sure inputs appear before the task, and outputs don't

--- a/core/services/pipeline/task.divide_test.go
+++ b/core/services/pipeline/task.divide_test.go
@@ -3,6 +3,7 @@ package pipeline_test
 import (
 	"fmt"
 	"math"
+	"reflect"
 	"testing"
 
 	"github.com/pkg/errors"
@@ -198,19 +199,17 @@ func TestDivideTask_Overflow(t *testing.T) {
 }
 
 func TestDivide_Example(t *testing.T) {
-	testutils.SkipFlakey(t, "BCF-3236")
 	t.Parallel()
 
 	dag := `
-ds1 [type=memo value=10000.1234]
+ds1 [type=memo value=10000.1234];
+ds2 [type=memo value=100];
 
-ds2 [type=memo value=100]
+div_by_ds2 [type=divide divisor="$(ds2)"];
+multiply [type=multiply times=10000 index=0];
 
-div_by_ds2 [type=divide divisor="$(ds2)"]
+ds1 -> div_by_ds2 -> multiply;
 
-multiply [type=multiply times=10000 index=0]
-
-ds1->div_by_ds2->multiply;
 `
 
 	db := pgtest.NewSqlxDB(t)
@@ -223,12 +222,14 @@ ds1->div_by_ds2->multiply;
 
 	lggr := logger.TestLogger(t)
 	_, trrs, err := r.ExecuteRun(testutils.Context(t), spec, vars, lggr)
-	require.NoError(t, err)
 
+	require.NoError(t, err)
 	require.Len(t, trrs, 4)
 
 	finalResult := trrs[3]
 
-	assert.Nil(t, finalResult.Result.Error)
+	require.NoError(t, finalResult.Result.Error)
+	require.Equal(t, reflect.TypeOf(decimal.Decimal{}), reflect.TypeOf(finalResult.Result.Value))
+
 	assert.Equal(t, "1000012.34", finalResult.Result.Value.(decimal.Decimal).String())
 }


### PR DESCRIPTION
The unit test `TestDivide_Example` was acting flakey in the CI pipeline which suggested a flaw in the divide and
multiply operations. When running the test, the expected result would be one of the input values or the division
result in failure cases. This implied that results were either received out of order or were being sorted incorrectly.

The pipeline runner does a final sort on the results, so that ruled out the received out of order possibility. On
inspection of the sorting index on each task, every index was the zero value. This resulted in occasional correct
and incorrect sorting, causing the test flake.

To correct the problem, the `unset` value for tasks was set to `-1` and new checks were added to enforce 0-based indexing on explicitly set indexes.