### PR TITLE
Fix flushing log stream in tests

### DIFF
--- a/integration-tests/docker/test_env/test_env_builder.go
+++ b/integration-tests/docker/test_env/test_env_builder.go
@@ -300,11 +300,7 @@ func (b *CLTestEnvBuilder) Build() (*CLClusterTestEnv, error) {
 				}
 
 				// flush logs when test failed or when we are explicitly told to collect logs
-				if b.t.Failed() || *b.testConfig.GetLoggingConfig().TestLogCollect {
-					if shutdownErr := flushLogStreamFn(); shutdownErr != nil {
-						return
-					}
-				}
+				flushLogStream := b.t.Failed() || *b.testConfig.GetLoggingConfig().TestLogCollect
 
 				// run even if test has failed, as we might be able to catch additional problems without running the test again
 				if b.chainlinkNodeLogScannerSettings != nil {
@@ -329,12 +325,18 @@ func (b *CLTestEnvBuilder) Build() (*CLClusterTestEnv, error) {
 							b.l.Error().Err(err).Msg("Error processing logs")
 							return
 						} else if err != nil && (strings.Contains(err.Error(), testreporters.MultipleLogsAtLogLevelErr) || strings.Contains(err.Error(), testreporters.OneLogAtLogLevelErr)) {
-							// err return ignored on purpose since we are already failing the test
-							_ = flushLogStreamFn()
+							flushLogStream = true
 							b.t.Fatalf("Found a concerning log in Chainklink Node logs: %v", err)
 						}
 					}
 					b.l.Info().Msg("Finished scanning Chainlink Node logs for concerning errors")
+				}
+
+				if flushLogStream {
+					err := flushLogStreamFn()
+					if err != nil {
+						b.l.Err(err).Msg("Error flushing LogStream")
+					}
 				}
 			})
 		} else {

--- a/integration-tests/docker/test_env/test_env_builder.go
+++ b/integration-tests/docker/test_env/test_env_builder.go
@@ -287,18 +287,6 @@ func (b *CLTestEnvBuilder) Build() (*CLClusterTestEnv, error) {
 					b.l.Info().Str("Absolute path", logPath).Msg("LogStream logs folder location")
 				}
 
-				var flushLogStreamFn = func() error {
-					// we can't do much if this fails, so we just log the error in LogStream
-					if flushErr := b.te.LogStream.FlushAndShutdown(); flushErr != nil {
-						b.l.Error().Err(flushErr).Msg("Error flushing and shutting down LogStream")
-						return flushErr
-					}
-					b.te.LogStream.PrintLogTargetsLocations()
-					b.te.LogStream.SaveLogLocationInTestSummary()
-
-					return nil
-				}
-
 				// flush logs when test failed or when we are explicitly told to collect logs
 				flushLogStream := b.t.Failed() || *b.testConfig.GetLoggingConfig().TestLogCollect
 
@@ -333,10 +321,12 @@ func (b *CLTestEnvBuilder) Build() (*CLClusterTestEnv, error) {
 				}
 
 				if flushLogStream {
-					err := flushLogStreamFn()
-					if err != nil {
-						b.l.Err(err).Msg("Error flushing LogStream")
+					// we can't do much if this fails, so we just log the error in LogStream
+					if err := b.te.LogStream.FlushAndShutdown(); err != nil {
+						b.l.Error().Err(err).Msg("Error flushing and shutting down LogStream")
 					}
+					b.te.LogStream.PrintLogTargetsLocations()
+					b.te.LogStream.SaveLogLocationInTestSummary()
 				}
 			})
 		} else {


### PR DESCRIPTION
This PR modifies the test cleanup code to call FlushAndShutdown() only once. It should resolve the panic issue described in [TT-1195](https://smartcontract-it.atlassian.net/browse/TT-1195?focusedCommentId=242508).

[TT-1195]: https://smartcontract-it.atlassian.net/browse/TT-1195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ