### PR TITLE
[BCI-2564]: Add feature to drop stale txs in the txm

### DIFF
--- a/common/txmgr/strategies.go
+++ b/common/txmgr/strategies.go
@@ -56,7 +56,7 @@ func (s DropOldestStrategy) Subject() uuid.NullUUID {
 
 func (s DropOldestStrategy) PruneQueue(ctx context.Context, pruneService txmgrtypes.UnstartedTxQueuePruner) (ids []int64, err error) {
 	// NOTE: We prune one less than the queue size to prevent the queue from exceeding the max queue size. Which could occur if a new transaction is added to the queue right after we prune.
-	ids, err = pruneService.PruneUnstartedTxQueue(ctx, s.queueSize-1, s.subject)
+	ids, err = pruneService.PruneUnstartedTxQueue(ctx, max(s.queueSize-1, 0), s.subject)
 	if err != nil {
 		return ids, fmt.Errorf("DropOldestStrategy#PruneQueue failed: %w", err)
 	}

--- a/core/chains/evm/txmgr/evm_tx_store_test.go
+++ b/core/chains/evm/txmgr/evm_tx_store_test.go
@@ -1840,6 +1840,24 @@ func TestORM_PruneUnstartedTxQueue(t *testing.T) {
 		}
 		AssertCountPerSubject(t, txStore, int64(2), subject2)
 	})
+
+	t.Run("prunes if queue with empty subject", func(t *testing.T) {
+		subject3 := uuid.Nil
+		strategy3 := txmgrcommon.NewDropOldestStrategy(subject3, uint32(3))
+		for i := 0; i < 5; i++ {
+			mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, &cltest.FixtureChainID, txRequestWithStrategy(strategy3))
+		}
+		AssertCountPerSubject(t, txStore, int64(2), subject3)
+	})
+
+	t.Run("prunes if target queue size is zero", func(t *testing.T) {
+		subject4 := uuid.New()
+		strategy4 := txmgrcommon.NewDropOldestStrategy(subject4, uint32(1))
+		for i := 0; i < 5; i++ {
+			mustCreateUnstartedGeneratedTx(t, txStore, fromAddress, &cltest.FixtureChainID, txRequestWithStrategy(strategy4))
+		}
+		AssertCountPerSubject(t, txStore, int64(0), subject4)
+	})
 }
 
 func TestORM_FindTxesWithAttemptsAndReceiptsByIdsAndState(t *testing.T) {

--- a/core/web/router.go
+++ b/core/web/router.go
@@ -288,6 +288,7 @@ func v2Routes(app chainlink.Application, r *gin.RouterGroup) {
 		authv2.GET("/transactions/evm/:TxHash", txs.Show)
 		authv2.GET("/transactions", paginatedRequest(txs.Index))
 		authv2.GET("/transactions/:TxHash", txs.Show)
+		authv2.POST("transactions/purge", txs.PurgeUnstartedQueue)
 
 		rc := ReplayController{app}
 		authv2.POST("/replay_from_block/:number", auth.RequiresRunRole(rc.ReplayFromBlock))


### PR DESCRIPTION
- **common/txmgr: Add check to prevent negative target queue sizes**
- **evm: Modify unstarted queue prune query to allow for zero length queues**
- **core/web: Add api endpoint to purge the unstarted transaction queue in the txm**

The endpoint added uses the `UnstartedTxQueuePruner` with some modifications to allow for a zero length queue.

Notes: There is a test failing and should be the last step in the feature. The issue seems to be the difference between an empty string subject `""` versus a zeroed UUID. The forced UUID parameter types in some of the methods makes this tricky. It's key to note that the `subject` column is nullable, and often seems to have an empty string inserted.
